### PR TITLE
feat(gitlab): sync issue dependency links on push

### DIFF
--- a/cmd/bd/gitlab.go
+++ b/cmd/bd/gitlab.go
@@ -574,7 +574,7 @@ func runGitLabSync(cmd *cobra.Command, args []string) error {
 	}
 
 	if jsonOutput {
-		outputJSON(gitlabSyncResult{
+		return outputJSON(gitlabSyncResult{
 			DryRun:              gitlabSyncDryRun,
 			Pulled:              result.Stats.Pulled,
 			Pushed:              result.Stats.Pushed,
@@ -588,7 +588,6 @@ func runGitLabSync(cmd *cobra.Command, args []string) error {
 			MilestonesUpdated:   milestonesUpdated,
 			Warnings:            append(result.Warnings, linkWarnings...),
 		})
-		return nil
 	}
 
 	// Output results

--- a/cmd/bd/gitlab.go
+++ b/cmd/bd/gitlab.go
@@ -15,6 +15,7 @@ import (
 	"github.com/steveyegge/beads/internal/config"
 	"github.com/steveyegge/beads/internal/gitlab"
 	"github.com/steveyegge/beads/internal/metrics"
+	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/tracker"
 	"github.com/steveyegge/beads/internal/types"
 )
@@ -225,6 +226,22 @@ func getGitLabConfig() GitLabConfig {
 
 // getGitLabConfigValue reads a GitLab configuration value from store or environment.
 func getGitLabConfigValue(ctx context.Context, key string) string {
+	// Secret/yaml-only keys (e.g. gitlab.token) live in config.yaml, not the
+	// Dolt database, to avoid leaking secrets when the DB is pushed to remotes.
+	// Read them from config.yaml first, then env, and never touch the store.
+	// Mirrors internal/gitlab/tracker.go getConfig after upstream 99653e059.
+	if config.IsYamlOnlyKey(key) {
+		if val := config.GetString(key); val != "" {
+			return val
+		}
+		if envKey := gitlabConfigToEnvVar(key); envKey != "" {
+			if val := os.Getenv(envKey); val != "" {
+				return val
+			}
+		}
+		return ""
+	}
+
 	// Try to read from store (works in direct mode)
 	if store != nil {
 		value, _ := store.GetConfig(ctx, key)
@@ -422,6 +439,22 @@ func runGitLabProjects(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
+// gitlabSyncResult holds the JSON output for the gitlab sync command.
+type gitlabSyncResult struct {
+	DryRun              bool     `json:"dry_run"`
+	Pulled              int      `json:"pulled"`
+	Pushed              int      `json:"pushed"`
+	Created             int      `json:"created"`
+	Updated             int      `json:"updated"`
+	Skipped             int      `json:"skipped"`
+	Conflicts           int      `json:"conflicts"`
+	Errors              int      `json:"errors"`
+	LinksPushed         int      `json:"links_pushed"`
+	LinksLicenseSkipped int      `json:"links_license_skipped,omitempty"`
+	MilestonesUpdated   int      `json:"milestones_updated,omitempty"`
+	Warnings            []string `json:"warnings,omitempty"`
+}
+
 // runGitLabSync implements the gitlab sync command.
 // Uses the tracker.Engine for all sync operations.
 func runGitLabSync(cmd *cobra.Command, args []string) error {
@@ -469,11 +502,14 @@ func runGitLabSync(cmd *cobra.Command, args []string) error {
 
 	// Create the sync engine
 	engine := tracker.NewEngine(gt, store, actor)
-	engine.OnMessage = func(msg string) { _, _ = fmt.Fprintln(out, "  "+msg) }
+	if !jsonOutput {
+		engine.OnMessage = func(msg string) { _, _ = fmt.Fprintln(out, "  "+msg) }
+	}
 	engine.OnWarning = func(msg string) { _, _ = fmt.Fprintf(os.Stderr, "Warning: %s\n", msg) }
 
 	// Set up GitLab-specific pull hooks
 	engine.PullHooks = buildGitLabPullHooks(ctx)
+	engine.PushHooks = buildGitLabPushHooks()
 
 	// Build sync options from CLI flags
 	pull := !gitlabSyncPushOnly
@@ -512,7 +548,7 @@ func runGitLabSync(cmd *cobra.Command, args []string) error {
 		opts.ConflictResolution = tracker.ConflictTimestamp
 	}
 
-	if gitlabSyncDryRun {
+	if gitlabSyncDryRun && !jsonOutput {
 		_, _ = fmt.Fprintln(out, "Dry run mode - no changes will be made")
 		_, _ = fmt.Fprintln(out)
 	}
@@ -520,6 +556,80 @@ func runGitLabSync(cmd *cobra.Command, args []string) error {
 	result, err := engine.Sync(ctx, opts)
 	if err != nil {
 		return HandleError("%v", err)
+	}
+
+	var linkWarnings []string
+	warnLink := func(msg string) {
+		linkWarnings = append(linkWarnings, msg)
+		_, _ = fmt.Fprintf(os.Stderr, "Warning: %s\n", msg)
+	}
+
+	// Dependency-link push pass: sync beads dependencies to GitLab issue links.
+	var linksPushed int
+	var linksLicenseSkipped int
+	var milestonesUpdated int
+	if push {
+		linkData, collectWarnings := collectGitLabLinkSyncData(ctx, store, opts)
+		for _, warning := range collectWarnings {
+			warnLink(warning)
+		}
+
+		if client := gt.GitLabClient(); client != nil && len(linkData.DesiredLinks) > 0 {
+			resolver := gitlab.NewLinkResolver(client)
+			res := resolver.PushLinks(ctx, linkData.DesiredLinks, gitlab.PushLinkOptions{
+				DryRun: gitlabSyncDryRun,
+				OnPlan: func(link gitlab.DependencyLink) {
+					if !jsonOutput {
+						_, _ = fmt.Fprintf(out, "  [dry-run] Would create GitLab dependency link: #%d %s #%d\n",
+							link.SourceIID, link.LinkType, link.TargetIID)
+					}
+				},
+			})
+			linksPushed = res.Created
+			linksLicenseSkipped = res.LicenseSkipped
+			// Curated, license-aware degradation: one actionable line instead of
+			// a raw per-link API error, kept distinct from genuine failures.
+			if res.LicenseSkipped > 0 {
+				warnLink(gitLabLicenseSkipMessage(res.LicenseSkipped))
+			}
+			for _, err := range res.Errors {
+				warnLink(fmt.Sprintf("GitLab dependency link sync: %v", err))
+			}
+		}
+
+		if client := gt.GitLabClient(); client != nil && len(linkData.ScopedIssues) > 0 {
+			count, errs := gt.PushEpicMilestones(ctx, linkData.ScopedIssues, gitlab.EpicMilestoneOptions{
+				DryRun: gitlabSyncDryRun,
+				OnPlan: func(issueID string, issueIID int, milestoneID int) {
+					if !jsonOutput {
+						_, _ = fmt.Fprintf(out, "  [dry-run] Would set GitLab milestone %d on %s (#%d)\n",
+							milestoneID, issueID, issueIID)
+					}
+				},
+			})
+			milestonesUpdated = count
+			for _, err := range errs {
+				warnLink(fmt.Sprintf("GitLab epic milestone sync: %v", err))
+			}
+		}
+	}
+
+	if jsonOutput {
+		outputJSON(gitlabSyncResult{
+			DryRun:              gitlabSyncDryRun,
+			Pulled:              result.Stats.Pulled,
+			Pushed:              result.Stats.Pushed,
+			Created:             result.Stats.Created,
+			Updated:             result.Stats.Updated,
+			Skipped:             result.Stats.Skipped,
+			Conflicts:           result.Stats.Conflicts,
+			Errors:              result.Stats.Errors,
+			LinksPushed:         linksPushed,
+			LinksLicenseSkipped: linksLicenseSkipped,
+			MilestonesUpdated:   milestonesUpdated,
+			Warnings:            append(result.Warnings, linkWarnings...),
+		})
+		return nil
 	}
 
 	// Output results
@@ -531,6 +641,9 @@ func runGitLabSync(cmd *cobra.Command, args []string) error {
 		if result.Stats.Pushed > 0 {
 			_, _ = fmt.Fprintf(out, "✓ Pushed %d issues\n", result.Stats.Pushed)
 		}
+		if linksPushed > 0 {
+			_, _ = fmt.Fprintf(out, "✓ Synced %d dependency links\n", linksPushed)
+		}
 		if result.Stats.Conflicts > 0 {
 			_, _ = fmt.Fprintf(out, "→ Resolved %d conflicts\n", result.Stats.Conflicts)
 		}
@@ -541,7 +654,170 @@ func runGitLabSync(cmd *cobra.Command, args []string) error {
 		_, _ = fmt.Fprintln(out, "Run without --dry-run to apply changes")
 	}
 
+	if !gitlabSyncDryRun {
+		commandDidWrite.Store(true)
+	}
+
 	return nil
+}
+
+// gitLabLicenseSkipMessage returns a single curated, actionable line explaining
+// that N blocks/is_blocked_by links were skipped because the GitLab instance's
+// license lacks the issue-blocking feature. Used instead of raw per-link API
+// errors so the degradation is transparent and not mistaken for a real failure.
+func gitLabLicenseSkipMessage(n int) string {
+	noun := "link"
+	if n != 1 {
+		noun = "links"
+	}
+	return fmt.Sprintf(
+		"Skipped %d dependency 'blocks' %s: GitLab 'blocks'/'is_blocked_by' requires Premium/Ultimate. "+
+			"'relates_to' links and milestones were applied normally.", n, noun)
+}
+
+type gitlabLinkSyncData struct {
+	ScopedIssues []*types.Issue
+	DesiredLinks []gitlab.DependencyLink
+}
+
+func collectGitLabLinkSyncData(ctx context.Context, st storage.Storage, opts tracker.SyncOptions) (gitlabLinkSyncData, []string) {
+	if st == nil {
+		return gitlabLinkSyncData{}, []string{"GitLab dependency link sync skipped: database not available"}
+	}
+
+	allIssues, err := st.SearchIssues(ctx, "", types.IssueFilter{})
+	if err != nil {
+		return gitlabLinkSyncData{}, []string{fmt.Sprintf("GitLab dependency link sync skipped: %v", err)}
+	}
+
+	var warnings []string
+	var descendantSet map[string]bool
+	if opts.ParentID != "" {
+		descendantSet, err = buildGitLabDescendantSet(ctx, st, opts.ParentID)
+		if err != nil {
+			return gitlabLinkSyncData{}, []string{fmt.Sprintf("GitLab dependency link sync skipped: resolving parent %s: %v", opts.ParentID, err)}
+		}
+	}
+
+	scopedIssues := filterGitLabLinkScopedIssues(allIssues, opts, descendantSet)
+	scopedIssueIDs := gitlabScopedIssueIDSet(scopedIssues)
+	desired := make([]gitlab.DependencyLink, 0, len(scopedIssues))
+	for _, issue := range scopedIssues {
+		deps, err := st.GetDependenciesWithMetadata(ctx, issue.ID)
+		if err != nil {
+			warnings = append(warnings, fmt.Sprintf("GitLab dependency link sync skipped dependencies for %s: %v", issue.ID, err))
+			continue
+		}
+		for _, dep := range deps {
+			if !scopedIssueIDs[dep.ID] {
+				continue
+			}
+			link, ok := gitlab.LinkFromBeadsDependency(issue, dep)
+			if ok {
+				desired = append(desired, link)
+			}
+		}
+	}
+
+	return gitlabLinkSyncData{
+		ScopedIssues: scopedIssues,
+		DesiredLinks: gitlab.DeduplicateLinks(desired),
+	}, warnings
+}
+
+func filterGitLabLinkScopedIssues(issues []*types.Issue, opts tracker.SyncOptions, descendantSet map[string]bool) []*types.Issue {
+	result := make([]*types.Issue, 0, len(issues))
+	issueIDSet := gitlabIssueIDSet(opts.IssueIDs)
+	for _, issue := range issues {
+		if issue == nil {
+			continue
+		}
+		if issueIDSet != nil && !issueIDSet[issue.ID] {
+			continue
+		}
+		if descendantSet != nil && !descendantSet[issue.ID] {
+			continue
+		}
+		if !gitlabIssueAllowedByPushFilters(issue, opts) {
+			continue
+		}
+		result = append(result, issue)
+	}
+	return result
+}
+
+func gitlabIssueAllowedByPushFilters(issue *types.Issue, opts tracker.SyncOptions) bool {
+	if issue == nil {
+		return false
+	}
+	if opts.ExcludeEphemeral && issue.Ephemeral {
+		return false
+	}
+	if len(opts.TypeFilter) > 0 {
+		matched := false
+		for _, issueType := range opts.TypeFilter {
+			if issue.IssueType == issueType {
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			return false
+		}
+	}
+	for _, issueType := range opts.ExcludeTypes {
+		if issue.IssueType == issueType {
+			return false
+		}
+	}
+	if opts.State == "open" && issue.Status == types.StatusClosed {
+		return false
+	}
+	return true
+}
+
+func buildGitLabDescendantSet(ctx context.Context, st storage.Storage, parentID string) (map[string]bool, error) {
+	result := map[string]bool{parentID: true}
+	queue := []string{parentID}
+	for len(queue) > 0 {
+		current := queue[0]
+		queue = queue[1:]
+		dependents, err := st.GetDependentsWithMetadata(ctx, current)
+		if err != nil {
+			return nil, fmt.Errorf("getting dependents of %s: %w", current, err)
+		}
+		for _, dep := range dependents {
+			if dep.DependencyType == types.DepParentChild && !result[dep.Issue.ID] {
+				result[dep.Issue.ID] = true
+				queue = append(queue, dep.Issue.ID)
+			}
+		}
+	}
+	return result, nil
+}
+
+func gitlabIssueIDSet(ids []string) map[string]bool {
+	if len(ids) == 0 {
+		return nil
+	}
+	result := make(map[string]bool, len(ids))
+	for _, id := range ids {
+		id = strings.TrimSpace(id)
+		if id != "" {
+			result[id] = true
+		}
+	}
+	return result
+}
+
+func gitlabScopedIssueIDSet(issues []*types.Issue) map[string]bool {
+	result := make(map[string]bool, len(issues))
+	for _, issue := range issues {
+		if issue != nil && issue.ID != "" {
+			result[issue.ID] = true
+		}
+	}
+	return result
 }
 
 // buildCLIFilter constructs an IssueFilter from CLI flags.
@@ -584,6 +860,59 @@ func buildGitLabPullHooks(ctx context.Context) *tracker.PullHooks {
 			}
 			return nil
 		},
+	}
+}
+
+// buildGitLabPushHooks creates PushHooks for GitLab-specific push behavior.
+func buildGitLabPushHooks() *tracker.PushHooks {
+	return &tracker.PushHooks{
+		ContentEqual: gitLabPushContentEqual,
+	}
+}
+
+func gitLabPushContentEqual(local *types.Issue, remote *tracker.TrackerIssue) bool {
+	if local == nil || remote == nil {
+		return false
+	}
+
+	// Epics are represented as GitLab milestones. GitLab can return a milestone
+	// updated_at that is older than local beads bookkeeping even when pushed
+	// fields are already identical, so use content equality to avoid repeat PUTs.
+	if local.IssueType == types.TypeEpic && gitLabMilestonePushFieldsEqual(local, remote) {
+		return true
+	}
+
+	// Preserve the engine's default skip behavior for everything this hook does
+	// not handle explicitly.
+	return !remote.UpdatedAt.Before(local.UpdatedAt)
+}
+
+func gitLabMilestonePushFieldsEqual(local *types.Issue, remote *tracker.TrackerIssue) bool {
+	if !gitLabComparableTextEqual(local.Title, remote.Title) {
+		return false
+	}
+	if !gitLabComparableTextEqual(local.Description, remote.Description) {
+		return false
+	}
+	return gitLabMilestoneStateEqual(local.Status, remote.State)
+}
+
+func gitLabComparableTextEqual(a, b string) bool {
+	return strings.TrimSpace(strings.ReplaceAll(a, "\r\n", "\n")) ==
+		strings.TrimSpace(strings.ReplaceAll(b, "\r\n", "\n"))
+}
+
+func gitLabMilestoneStateEqual(status types.Status, remoteState interface{}) bool {
+	remoteStateString, ok := remoteState.(string)
+	if !ok {
+		return false
+	}
+	remoteStateString = strings.ToLower(strings.TrimSpace(remoteStateString))
+	switch status {
+	case types.StatusClosed:
+		return remoteStateString == "closed"
+	default:
+		return remoteStateString == "active"
 	}
 }
 

--- a/cmd/bd/gitlab.go
+++ b/cmd/bd/gitlab.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/rand"
 	"fmt"
+	"io"
 	"os"
 	"strconv"
 	"strings"
@@ -569,49 +570,7 @@ func runGitLabSync(cmd *cobra.Command, args []string) error {
 	var linksLicenseSkipped int
 	var milestonesUpdated int
 	if push {
-		linkData, collectWarnings := collectGitLabLinkSyncData(ctx, store, opts)
-		for _, warning := range collectWarnings {
-			warnLink(warning)
-		}
-
-		if client := gt.GitLabClient(); client != nil && len(linkData.DesiredLinks) > 0 {
-			resolver := gitlab.NewLinkResolver(client)
-			res := resolver.PushLinks(ctx, linkData.DesiredLinks, gitlab.PushLinkOptions{
-				DryRun: gitlabSyncDryRun,
-				OnPlan: func(link gitlab.DependencyLink) {
-					if !jsonOutput {
-						_, _ = fmt.Fprintf(out, "  [dry-run] Would create GitLab dependency link: #%d %s #%d\n",
-							link.SourceIID, link.LinkType, link.TargetIID)
-					}
-				},
-			})
-			linksPushed = res.Created
-			linksLicenseSkipped = res.LicenseSkipped
-			// Curated, license-aware degradation: one actionable line instead of
-			// a raw per-link API error, kept distinct from genuine failures.
-			if res.LicenseSkipped > 0 {
-				warnLink(gitLabLicenseSkipMessage(res.LicenseSkipped))
-			}
-			for _, err := range res.Errors {
-				warnLink(fmt.Sprintf("GitLab dependency link sync: %v", err))
-			}
-		}
-
-		if client := gt.GitLabClient(); client != nil && len(linkData.ScopedIssues) > 0 {
-			count, errs := gt.PushEpicMilestones(ctx, linkData.ScopedIssues, gitlab.EpicMilestoneOptions{
-				DryRun: gitlabSyncDryRun,
-				OnPlan: func(issueID string, issueIID int, milestoneID int) {
-					if !jsonOutput {
-						_, _ = fmt.Fprintf(out, "  [dry-run] Would set GitLab milestone %d on %s (#%d)\n",
-							milestoneID, issueID, issueIID)
-					}
-				},
-			})
-			milestonesUpdated = count
-			for _, err := range errs {
-				warnLink(fmt.Sprintf("GitLab epic milestone sync: %v", err))
-			}
-		}
+		linksPushed, linksLicenseSkipped, milestonesUpdated = pushGitLabDependencyLinks(ctx, gt, store, opts, gitlabSyncDryRun, out, warnLink)
 	}
 
 	if jsonOutput {
@@ -673,6 +632,66 @@ func gitLabLicenseSkipMessage(n int) string {
 	return fmt.Sprintf(
 		"Skipped %d dependency 'blocks' %s: GitLab 'blocks'/'is_blocked_by' requires Premium/Ultimate. "+
 			"'relates_to' links and milestones were applied normally.", n, noun)
+}
+
+// pushGitLabDependencyLinks runs the dependency-link + epic-milestone push pass:
+// it converts beads dependencies among the scoped issues (per opts) into GitLab
+// issue links (additive — stale remote links are left untouched) and repairs
+// epic-child milestones. Shared by `bd gitlab sync` and `bd gitlab push` so both
+// reach the same link parity. Dry-run plan lines are written to out (unless
+// --json); warnings are delivered via warn. Returns the number of links created,
+// license-skipped, and milestones updated.
+func pushGitLabDependencyLinks(ctx context.Context, gt *gitlab.Tracker, st storage.Storage, opts tracker.SyncOptions, dryRun bool, out io.Writer, warn func(string)) (linksPushed, linksLicenseSkipped, milestonesUpdated int) {
+	linkData, collectWarnings := collectGitLabLinkSyncData(ctx, st, opts)
+	for _, warning := range collectWarnings {
+		warn(warning)
+	}
+
+	client := gt.GitLabClient()
+	if client == nil {
+		return 0, 0, 0
+	}
+
+	if len(linkData.DesiredLinks) > 0 {
+		resolver := gitlab.NewLinkResolver(client)
+		res := resolver.PushLinks(ctx, linkData.DesiredLinks, gitlab.PushLinkOptions{
+			DryRun: dryRun,
+			OnPlan: func(link gitlab.DependencyLink) {
+				if !jsonOutput {
+					_, _ = fmt.Fprintf(out, "  [dry-run] Would create GitLab dependency link: #%d %s #%d\n",
+						link.SourceIID, link.LinkType, link.TargetIID)
+				}
+			},
+		})
+		linksPushed = res.Created
+		linksLicenseSkipped = res.LicenseSkipped
+		// Curated, license-aware degradation: one actionable line instead of
+		// a raw per-link API error, kept distinct from genuine failures.
+		if res.LicenseSkipped > 0 {
+			warn(gitLabLicenseSkipMessage(res.LicenseSkipped))
+		}
+		for _, err := range res.Errors {
+			warn(fmt.Sprintf("GitLab dependency link sync: %v", err))
+		}
+	}
+
+	if len(linkData.ScopedIssues) > 0 {
+		count, errs := gt.PushEpicMilestones(ctx, linkData.ScopedIssues, gitlab.EpicMilestoneOptions{
+			DryRun: dryRun,
+			OnPlan: func(issueID string, issueIID int, milestoneID int) {
+				if !jsonOutput {
+					_, _ = fmt.Fprintf(out, "  [dry-run] Would set GitLab milestone %d on %s (#%d)\n",
+						milestoneID, issueID, issueIID)
+				}
+			},
+		})
+		milestonesUpdated = count
+		for _, err := range errs {
+			warn(fmt.Sprintf("GitLab epic milestone sync: %v", err))
+		}
+	}
+
+	return linksPushed, linksLicenseSkipped, milestonesUpdated
 }
 
 type gitlabLinkSyncData struct {

--- a/cmd/bd/gitlab_test.go
+++ b/cmd/bd/gitlab_test.go
@@ -2,8 +2,18 @@
 package main
 
 import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/steveyegge/beads/internal/config"
+	"github.com/steveyegge/beads/internal/storage"
+	"github.com/steveyegge/beads/internal/tracker"
+	"github.com/steveyegge/beads/internal/types"
 )
 
 // TestGitLabConfigFromEnv verifies config is read from environment variables.
@@ -28,6 +38,155 @@ func TestGitLabConfigFromEnv(t *testing.T) {
 	}
 	if config.ProjectID != "42" {
 		t.Errorf("ProjectID = %q, want %q", config.ProjectID, "42")
+	}
+}
+
+// TestGitLabConfigValueYamlTokenReadsFromYaml verifies that the yaml-only
+// secret key gitlab.token is resolved from config.yaml by the CLI-layer
+// reader used to build the `bd gitlab sync` client. Before the yaml-only
+// fold-in (upstream 99653e059), getGitLabConfigValue only read the Dolt store
+// and env, so a config.yaml-stored token returned "" here. The store/dbPath
+// globals are cleared to prove the value comes from config.yaml, not the store.
+func TestGitLabConfigValueYamlTokenReadsFromYaml(t *testing.T) {
+	const wantToken = "yaml-cli-token-value"
+
+	oldDBPath, oldStore := dbPath, store
+	dbPath, store = "", nil
+	t.Cleanup(func() { dbPath, store = oldDBPath, oldStore })
+
+	tmpDir := t.TempDir()
+	beadsDir := filepath.Join(tmpDir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0o750); err != nil {
+		t.Fatalf("mkdir .beads: %v", err)
+	}
+	yamlBody := "gitlab.token: \"" + wantToken + "\"\n"
+	if err := os.WriteFile(filepath.Join(beadsDir, "config.yaml"), []byte(yamlBody), 0o600); err != nil {
+		t.Fatalf("write config.yaml: %v", err)
+	}
+
+	t.Setenv("GITLAB_TOKEN", "")
+	t.Setenv("BEADS_DIR", "")
+	t.Setenv("BEADS_TEST_IGNORE_REPO_CONFIG", "1")
+	t.Setenv("HOME", filepath.Join(tmpDir, "home"))
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmpDir, "xdg"))
+	t.Chdir(tmpDir)
+
+	config.ResetForTesting()
+	t.Cleanup(config.ResetForTesting)
+	if err := config.Initialize(); err != nil {
+		t.Fatalf("config.Initialize: %v", err)
+	}
+
+	if got := getGitLabConfigValue(context.Background(), "gitlab.token"); got != wantToken {
+		t.Errorf("getGitLabConfigValue(gitlab.token) = %q, want %q (config.yaml not consulted?)", got, wantToken)
+	}
+}
+
+// TestGitLabConfigValueYamlTokenFallsBackToEnv verifies that when no
+// config.yaml value is present, the yaml-only key path still falls back to the
+// environment variable rather than the Dolt store.
+func TestGitLabConfigValueYamlTokenFallsBackToEnv(t *testing.T) {
+	oldDBPath, oldStore := dbPath, store
+	dbPath, store = "", nil
+	t.Cleanup(func() { dbPath, store = oldDBPath, oldStore })
+
+	tmpDir := t.TempDir()
+	t.Setenv("BEADS_DIR", "")
+	t.Setenv("BEADS_TEST_IGNORE_REPO_CONFIG", "1")
+	t.Setenv("HOME", filepath.Join(tmpDir, "home"))
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmpDir, "xdg"))
+	t.Setenv("GITLAB_TOKEN", "env-cli-token-value")
+	t.Chdir(tmpDir)
+
+	config.ResetForTesting()
+	t.Cleanup(config.ResetForTesting)
+	if err := config.Initialize(); err != nil {
+		t.Fatalf("config.Initialize: %v", err)
+	}
+
+	if got := getGitLabConfigValue(context.Background(), "gitlab.token"); got != "env-cli-token-value" {
+		t.Errorf("getGitLabConfigValue(gitlab.token) = %q, want env fallback", got)
+	}
+}
+
+func TestGitLabPushHooksMilestoneContentEqualSkipsOlderRemote(t *testing.T) {
+	now := time.Now().UTC()
+	ref := "https://gitlab.example.com/group/project/-/milestones/4"
+	local := &types.Issue{
+		ID:          "bd-epic",
+		Title:       "Live milestone",
+		Description: "already synced\n",
+		Status:      types.StatusOpen,
+		IssueType:   types.TypeEpic,
+		ExternalRef: &ref,
+		UpdatedAt:   now,
+	}
+	remote := &tracker.TrackerIssue{
+		Identifier:  "35",
+		URL:         ref,
+		Title:       "Live milestone",
+		Description: "already synced",
+		State:       "active",
+		UpdatedAt:   now.Add(-time.Minute),
+	}
+
+	hooks := buildGitLabPushHooks()
+	if hooks == nil || hooks.ContentEqual == nil {
+		t.Fatal("expected GitLab ContentEqual hook")
+	}
+	if !hooks.ContentEqual(local, remote) {
+		t.Fatal("expected unchanged milestone content to skip even when remote updated_at is older")
+	}
+}
+
+func TestGitLabPushHooksMilestoneContentChangeDoesNotSkipOlderRemote(t *testing.T) {
+	now := time.Now().UTC()
+	local := &types.Issue{
+		ID:          "bd-epic",
+		Title:       "Live milestone",
+		Description: "local change",
+		Status:      types.StatusOpen,
+		IssueType:   types.TypeEpic,
+		UpdatedAt:   now,
+	}
+	remote := &tracker.TrackerIssue{
+		Identifier:  "35",
+		Title:       "Live milestone",
+		Description: "old remote",
+		State:       "active",
+		UpdatedAt:   now.Add(-time.Minute),
+	}
+
+	hooks := buildGitLabPushHooks()
+	if hooks.ContentEqual(local, remote) {
+		t.Fatal("expected changed milestone content to update when remote updated_at is older")
+	}
+}
+
+func TestGitLabPushHooksPreserveTimestampSkipForIssues(t *testing.T) {
+	now := time.Now().UTC()
+	local := &types.Issue{
+		ID:        "bd-task",
+		Title:     "Task",
+		Status:    types.StatusOpen,
+		IssueType: types.TypeTask,
+		UpdatedAt: now,
+	}
+	remote := &tracker.TrackerIssue{
+		Identifier: "42",
+		Title:      "Remote task",
+		State:      "opened",
+		UpdatedAt:  now.Add(time.Minute),
+	}
+
+	hooks := buildGitLabPushHooks()
+	if !hooks.ContentEqual(local, remote) {
+		t.Fatal("expected same-or-newer remote issue timestamp to preserve default skip behavior")
+	}
+
+	remote.UpdatedAt = now.Add(-time.Minute)
+	if hooks.ContentEqual(local, remote) {
+		t.Fatal("expected older remote issue timestamp to preserve default update behavior")
 	}
 }
 
@@ -372,5 +531,210 @@ func TestNoEphemeralDefaultTrue(t *testing.T) {
 	}
 	if f.DefValue != "true" {
 		t.Errorf("--no-ephemeral default = %q, want %q", f.DefValue, "true")
+	}
+}
+
+func TestFilterGitLabLinkScopedIssues(t *testing.T) {
+	issues := []*types.Issue{
+		{ID: "bd-parent", IssueType: types.TypeFeature, Status: types.StatusOpen},
+		{ID: "bd-child", IssueType: types.TypeTask, Status: types.StatusOpen},
+		{ID: "bd-other", IssueType: types.TypeTask, Status: types.StatusOpen},
+		{ID: "bd-mol", IssueType: types.TypeMolecule, Status: types.StatusOpen},
+		{ID: "bd-wisp", IssueType: types.TypeTask, Status: types.StatusOpen, Ephemeral: true},
+	}
+
+	t.Run("issues flag limits dependency owners", func(t *testing.T) {
+		got := filterGitLabLinkScopedIssues(issues, tracker.SyncOptions{
+			IssueIDs: []string{"bd-child", "bd-other"},
+		}, nil)
+
+		assertIssueIDs(t, got, []string{"bd-child", "bd-other"})
+	})
+
+	t.Run("parent scope limits to descendants", func(t *testing.T) {
+		got := filterGitLabLinkScopedIssues(issues, tracker.SyncOptions{}, map[string]bool{
+			"bd-parent": true,
+			"bd-child":  true,
+		})
+
+		assertIssueIDs(t, got, []string{"bd-parent", "bd-child"})
+	})
+
+	t.Run("type and internal filters apply", func(t *testing.T) {
+		got := filterGitLabLinkScopedIssues(issues, tracker.SyncOptions{
+			TypeFilter:       []types.IssueType{types.TypeTask},
+			ExcludeTypes:     []types.IssueType{types.TypeMolecule},
+			ExcludeEphemeral: true,
+		}, nil)
+
+		assertIssueIDs(t, got, []string{"bd-child", "bd-other"})
+	})
+}
+
+func TestCollectGitLabLinkSyncDataScopesEndpoints(t *testing.T) {
+	child := gitLabSyncIssue("bd-child", "https://gitlab.example.com/group/project/-/issues/10", types.TypeTask)
+	blocker := gitLabSyncIssue("bd-blocker", "https://gitlab.example.com/group/project/-/issues/20", types.TypeTask)
+	outside := gitLabSyncIssue("bd-outside", "https://gitlab.example.com/group/project/-/issues/30", types.TypeTask)
+	molecule := gitLabSyncIssue("bd-mol", "https://gitlab.example.com/group/project/-/issues/40", types.TypeMolecule)
+	parent := gitLabSyncIssue("bd-parent", "", types.TypeFeature)
+
+	st := &gitLabSyncFakeStore{
+		issues: []*types.Issue{parent, child, blocker, outside, molecule},
+		deps: map[string][]*types.IssueWithDependencyMetadata{
+			child.ID: {
+				gitLabSyncDep(blocker, types.DepBlocks),
+				gitLabSyncDep(outside, types.DepBlocks),
+				gitLabSyncDep(molecule, types.DepBlocks),
+			},
+		},
+		dependents: map[string][]*types.IssueWithDependencyMetadata{
+			parent.ID: {gitLabSyncDep(child, types.DepParentChild)},
+		},
+	}
+
+	t.Run("issues requires both endpoints", func(t *testing.T) {
+		data, warnings := collectGitLabLinkSyncData(context.Background(), st, tracker.SyncOptions{
+			IssueIDs: []string{child.ID, blocker.ID},
+		})
+		if len(warnings) != 0 {
+			t.Fatalf("warnings = %v", warnings)
+		}
+		if len(data.DesiredLinks) != 1 {
+			t.Fatalf("DesiredLinks len = %d, want 1", len(data.DesiredLinks))
+		}
+		link := data.DesiredLinks[0]
+		if link.SourceIID != 20 || link.TargetIID != 10 || link.LinkType != "blocks" {
+			t.Fatalf("link = %+v, want #20 blocks #10", link)
+		}
+	})
+
+	t.Run("issues excludes out of scope targets", func(t *testing.T) {
+		data, warnings := collectGitLabLinkSyncData(context.Background(), st, tracker.SyncOptions{
+			IssueIDs: []string{child.ID},
+		})
+		if len(warnings) != 0 {
+			t.Fatalf("warnings = %v", warnings)
+		}
+		if len(data.DesiredLinks) != 0 {
+			t.Fatalf("DesiredLinks len = %d, want 0", len(data.DesiredLinks))
+		}
+	})
+
+	t.Run("parent excludes targets outside subtree", func(t *testing.T) {
+		data, warnings := collectGitLabLinkSyncData(context.Background(), st, tracker.SyncOptions{
+			ParentID: parent.ID,
+		})
+		if len(warnings) != 0 {
+			t.Fatalf("warnings = %v", warnings)
+		}
+		if len(data.DesiredLinks) != 0 {
+			t.Fatalf("DesiredLinks len = %d, want 0", len(data.DesiredLinks))
+		}
+	})
+
+	t.Run("type filter excludes target endpoint", func(t *testing.T) {
+		data, warnings := collectGitLabLinkSyncData(context.Background(), st, tracker.SyncOptions{
+			IssueIDs:     []string{child.ID, molecule.ID},
+			ExcludeTypes: []types.IssueType{types.TypeMolecule},
+		})
+		if len(warnings) != 0 {
+			t.Fatalf("warnings = %v", warnings)
+		}
+		if len(data.DesiredLinks) != 0 {
+			t.Fatalf("DesiredLinks len = %d, want 0", len(data.DesiredLinks))
+		}
+	})
+}
+
+func TestGitLabSyncResultJSONIncludesLinksPushed(t *testing.T) {
+	data, err := json.Marshal(gitlabSyncResult{LinksPushed: 2})
+	if err != nil {
+		t.Fatalf("Marshal gitlabSyncResult: %v", err)
+	}
+	if !strings.Contains(string(data), `"links_pushed":2`) {
+		t.Fatalf("JSON = %s, want links_pushed", string(data))
+	}
+}
+
+func TestGitLabSyncResultJSONLicenseSkipped(t *testing.T) {
+	// Present when non-zero (distinct machine-readable signal from warnings/errors).
+	data, err := json.Marshal(gitlabSyncResult{LinksLicenseSkipped: 3})
+	if err != nil {
+		t.Fatalf("Marshal gitlabSyncResult: %v", err)
+	}
+	if !strings.Contains(string(data), `"links_license_skipped":3`) {
+		t.Fatalf("JSON = %s, want links_license_skipped", string(data))
+	}
+	// Omitted when zero so a normal sync doesn't carry noise.
+	data, _ = json.Marshal(gitlabSyncResult{LinksPushed: 1})
+	if strings.Contains(string(data), "links_license_skipped") {
+		t.Fatalf("JSON = %s, should omit links_license_skipped when zero", string(data))
+	}
+}
+
+func TestGitLabLicenseSkipMessage(t *testing.T) {
+	one := gitLabLicenseSkipMessage(1)
+	if !strings.Contains(one, "1 dependency 'blocks' link:") {
+		t.Fatalf("singular message = %q, want singular 'link'", one)
+	}
+	many := gitLabLicenseSkipMessage(2)
+	if !strings.Contains(many, "2 dependency 'blocks' links:") {
+		t.Fatalf("plural message = %q, want plural 'links'", many)
+	}
+	// Must be actionable: name the tier and reassure the rest applied.
+	for _, want := range []string{"Premium/Ultimate", "relates_to", "milestones"} {
+		if !strings.Contains(many, want) {
+			t.Fatalf("message = %q, missing %q", many, want)
+		}
+	}
+}
+
+type gitLabSyncFakeStore struct {
+	storage.Storage
+	issues     []*types.Issue
+	deps       map[string][]*types.IssueWithDependencyMetadata
+	dependents map[string][]*types.IssueWithDependencyMetadata
+}
+
+func (s *gitLabSyncFakeStore) SearchIssues(_ context.Context, _ string, _ types.IssueFilter) ([]*types.Issue, error) {
+	return s.issues, nil
+}
+
+func (s *gitLabSyncFakeStore) GetDependenciesWithMetadata(_ context.Context, issueID string) ([]*types.IssueWithDependencyMetadata, error) {
+	return s.deps[issueID], nil
+}
+
+func (s *gitLabSyncFakeStore) GetDependentsWithMetadata(_ context.Context, issueID string) ([]*types.IssueWithDependencyMetadata, error) {
+	return s.dependents[issueID], nil
+}
+
+func gitLabSyncIssue(id, ref string, issueType types.IssueType) *types.Issue {
+	issue := &types.Issue{
+		ID:        id,
+		IssueType: issueType,
+		Status:    types.StatusOpen,
+	}
+	if ref != "" {
+		issue.ExternalRef = &ref
+	}
+	return issue
+}
+
+func gitLabSyncDep(issue *types.Issue, depType types.DependencyType) *types.IssueWithDependencyMetadata {
+	return &types.IssueWithDependencyMetadata{
+		Issue:          *issue,
+		DependencyType: depType,
+	}
+}
+
+func assertIssueIDs(t *testing.T, issues []*types.Issue, want []string) {
+	t.Helper()
+	if len(issues) != len(want) {
+		t.Fatalf("len = %d, want %d (%v)", len(issues), len(want), want)
+	}
+	for i, issue := range issues {
+		if issue.ID != want[i] {
+			t.Fatalf("issue[%d] = %s, want %s", i, issue.ID, want[i])
+		}
 	}
 }

--- a/cmd/bd/sync_push_pull.go
+++ b/cmd/bd/sync_push_pull.go
@@ -702,6 +702,7 @@ func runGitLabPush(cmd *cobra.Command, args []string) error {
 	engine := tracker.NewEngine(gt, store, actor)
 	engine.OnMessage = func(msg string) { fmt.Println("  " + msg) }
 	engine.OnWarning = func(msg string) { fmt.Fprintf(os.Stderr, "Warning: %s\n", msg) }
+	engine.PushHooks = buildGitLabPushHooks()
 
 	result, err := engine.Sync(ctx, tracker.SyncOptions{
 		Push:     true,

--- a/cmd/bd/sync_push_pull.go
+++ b/cmd/bd/sync_push_pull.go
@@ -699,21 +699,76 @@ func runGitLabPush(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("initializing GitLab tracker: %w", err)
 	}
 
+	out := cmd.OutOrStdout()
 	engine := tracker.NewEngine(gt, store, actor)
-	engine.OnMessage = func(msg string) { fmt.Println("  " + msg) }
+	engine.OnMessage = func(msg string) {
+		if !jsonOutput {
+			fmt.Fprintln(out, "  "+msg)
+		}
+	}
 	engine.OnWarning = func(msg string) { fmt.Fprintf(os.Stderr, "Warning: %s\n", msg) }
 	engine.PushHooks = buildGitLabPushHooks()
 
-	result, err := engine.Sync(ctx, tracker.SyncOptions{
+	if dryRun && !jsonOutput {
+		fmt.Fprintln(out, "Dry run mode - no changes will be made")
+		fmt.Fprintln(out)
+	}
+
+	opts := tracker.SyncOptions{
 		Push:     true,
 		Pull:     false,
 		DryRun:   dryRun,
 		IssueIDs: args,
-	})
+	}
+	result, err := engine.Sync(ctx, opts)
 	if err != nil {
 		return err
 	}
-	outputSyncResult(result, dryRun)
+
+	// Dependency-link push parity with `bd gitlab sync`: converge beads
+	// dependencies among the requested issues into GitLab issue links (and
+	// repair epic-child milestones). Without this, `bd gitlab push <ids>`
+	// would sync content but silently omit dependency links. Output is
+	// rendered here (rather than via outputSyncResult) so the link pass runs
+	// before the summary and the --json payload carries the link counts,
+	// matching bd gitlab sync.
+	var linkWarnings []string
+	warnLink := func(msg string) {
+		linkWarnings = append(linkWarnings, msg)
+		fmt.Fprintf(os.Stderr, "Warning: %s\n", msg)
+	}
+	linksPushed, linksLicenseSkipped, milestonesUpdated := pushGitLabDependencyLinks(ctx, gt, store, opts, dryRun, out, warnLink)
+
+	if jsonOutput {
+		return outputJSON(gitlabSyncResult{
+			DryRun:              dryRun,
+			Pushed:              result.Stats.Pushed,
+			Created:             result.Stats.Created,
+			Updated:             result.Stats.Updated,
+			Skipped:             result.Stats.Skipped,
+			Conflicts:           result.Stats.Conflicts,
+			Errors:              result.Stats.Errors,
+			LinksPushed:         linksPushed,
+			LinksLicenseSkipped: linksLicenseSkipped,
+			MilestonesUpdated:   milestonesUpdated,
+			Warnings:            append(result.Warnings, linkWarnings...),
+		})
+	}
+
+	if dryRun {
+		fmt.Fprintln(out)
+		fmt.Fprintln(out, "Run without --dry-run to apply changes")
+		return nil
+	}
+	if result.Stats.Pushed > 0 {
+		fmt.Fprintf(out, "✓ Pushed %d issues\n", result.Stats.Pushed)
+	}
+	if linksPushed > 0 {
+		fmt.Fprintf(out, "✓ Synced %d dependency links\n", linksPushed)
+	}
+	if result.Stats.Conflicts > 0 {
+		fmt.Fprintf(out, "→ Resolved %d conflicts\n", result.Stats.Conflicts)
+	}
 	return nil
 }
 

--- a/internal/gitlab/fieldmapper.go
+++ b/internal/gitlab/fieldmapper.go
@@ -1,8 +1,6 @@
 package gitlab
 
 import (
-	"fmt"
-
 	"github.com/steveyegge/beads/internal/tracker"
 	"github.com/steveyegge/beads/internal/types"
 )
@@ -84,11 +82,7 @@ func (m *gitlabFieldMapper) IssueToBeads(ti *tracker.TrackerIssue) *tracker.Issu
 	// Convert gitlab.DependencyInfo to tracker.DependencyInfo
 	var deps []tracker.DependencyInfo
 	for _, d := range conv.Dependencies {
-		deps = append(deps, tracker.DependencyInfo{
-			FromExternalID: fmt.Sprintf("%d", d.FromGitLabIID),
-			ToExternalID:   fmt.Sprintf("%d", d.ToGitLabIID),
-			Type:           d.Type,
-		})
+		deps = append(deps, trackerDependencyFromGitLab(d))
 	}
 
 	return &tracker.IssueConversion{

--- a/internal/gitlab/links.go
+++ b/internal/gitlab/links.go
@@ -1,0 +1,403 @@
+package gitlab
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/steveyegge/beads/internal/tracker"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+const (
+	gitLabLinkBlocks      = "blocks"
+	gitLabLinkIsBlockedBy = "is_blocked_by"
+	gitLabLinkRelatesTo   = "relates_to"
+)
+
+// DependencyLink is a GitLab issue-link operation derived from a beads
+// dependency. SourceIID and TargetIID are GitLab project-scoped issue/work-item
+// IIDs in the direction expected by GitLab's issue-links API.
+type DependencyLink struct {
+	SourceIID      int
+	TargetIID      int
+	LinkType       string
+	FromBeadsID    string
+	ToBeadsID      string
+	DependencyType types.DependencyType
+}
+
+// PushLinkOptions configures dependency link push behavior.
+type PushLinkOptions struct {
+	DryRun bool
+	OnPlan func(DependencyLink)
+}
+
+// PushLinkResult summarizes a PushLinks pass. LicenseSkipped counts
+// blocks/is_blocked_by links that GitLab rejected because the instance license
+// lacks the issue-blocking feature (Premium/Ultimate). These are an expected,
+// non-fatal degradation and are kept separate from Errors, which holds genuine
+// (non-license) failures the caller should surface as real warnings.
+type PushLinkResult struct {
+	Created        int
+	LicenseSkipped int
+	Errors         []error
+}
+
+// EpicMilestoneOptions configures the dependency-pass epic milestone repair.
+type EpicMilestoneOptions struct {
+	DryRun bool
+	OnPlan func(issueID string, issueIID int, milestoneID int)
+}
+
+// LinkResolver handles GitLab issue-link convergence.
+type LinkResolver struct {
+	Client *Client
+}
+
+// NewLinkResolver creates a GitLab dependency link resolver.
+func NewLinkResolver(client *Client) *LinkResolver {
+	return &LinkResolver{Client: client}
+}
+
+// IssueIIDFromRef extracts a GitLab issue/work-item IID from a local external
+// ref. Milestone refs are intentionally rejected because epics map to
+// milestones, not issue-link endpoints.
+func IssueIIDFromRef(ref string) (int, bool) {
+	ref = strings.TrimSpace(ref)
+	if ref == "" || milestoneIDPattern.MatchString(ref) {
+		return 0, false
+	}
+	if matches := glShorthandPattern.FindStringSubmatch(ref); len(matches) >= 2 {
+		iid, err := strconv.Atoi(matches[1])
+		return iid, err == nil && iid > 0
+	}
+	if matches := issueIIDPattern.FindStringSubmatch(ref); len(matches) >= 2 {
+		iid, err := strconv.Atoi(matches[1])
+		return iid, err == nil && iid > 0
+	}
+	return 0, false
+}
+
+// LinkFromBeadsDependency converts one local dependency record to the GitLab
+// issue-link direction. For a beads blocks edge A -> B, GitLab stores the
+// inverse API relation: B --blocks--> A.
+func LinkFromBeadsDependency(issue *types.Issue, dep *types.IssueWithDependencyMetadata) (DependencyLink, bool) {
+	if issue == nil || dep == nil || issue.ExternalRef == nil || dep.ExternalRef == nil {
+		return DependencyLink{}, false
+	}
+	issueIID, ok := IssueIIDFromRef(*issue.ExternalRef)
+	if !ok {
+		return DependencyLink{}, false
+	}
+	depIID, ok := IssueIIDFromRef(*dep.ExternalRef)
+	if !ok || issueIID == depIID {
+		return DependencyLink{}, false
+	}
+
+	link := DependencyLink{
+		FromBeadsID:    issue.ID,
+		ToBeadsID:      dep.ID,
+		DependencyType: dep.DependencyType,
+	}
+	switch dep.DependencyType {
+	case types.DepBlocks:
+		link.SourceIID = depIID
+		link.TargetIID = issueIID
+		link.LinkType = gitLabLinkBlocks
+	case types.DepRelated, types.DepRelatesTo:
+		link.SourceIID, link.TargetIID = orderedIIDs(issueIID, depIID)
+		link.LinkType = gitLabLinkRelatesTo
+	default:
+		return DependencyLink{}, false
+	}
+	return link, true
+}
+
+// DeduplicateLinks removes duplicate desired GitLab links, including reciprocal
+// local related/relates-to edges that map to the same unordered GitLab pair.
+func DeduplicateLinks(links []DependencyLink) []DependencyLink {
+	if len(links) == 0 {
+		return nil
+	}
+	result := make([]DependencyLink, 0, len(links))
+	seen := make(map[gitLabLinkKey]struct{}, len(links))
+	for _, link := range links {
+		key := link.key()
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		result = append(result, link)
+	}
+	sort.Slice(result, func(i, j int) bool {
+		if result[i].SourceIID != result[j].SourceIID {
+			return result[i].SourceIID < result[j].SourceIID
+		}
+		if result[i].TargetIID != result[j].TargetIID {
+			return result[i].TargetIID < result[j].TargetIID
+		}
+		return result[i].LinkType < result[j].LinkType
+	})
+	return result
+}
+
+// PushLinks creates missing GitLab issue links for the desired dependency set.
+// It is additive: stale remote links are left untouched. blocks/is_blocked_by
+// links rejected for lack of a GitLab license are counted in
+// PushLinkResult.LicenseSkipped (an expected, non-fatal degradation) rather than
+// reported as genuine errors.
+func (r *LinkResolver) PushLinks(ctx context.Context, desired []DependencyLink, opts PushLinkOptions) PushLinkResult {
+	if r == nil || r.Client == nil {
+		return PushLinkResult{Errors: []error{fmt.Errorf("GitLab link resolver has no client")}}
+	}
+
+	desired = DeduplicateLinks(desired)
+	if len(desired) == 0 {
+		return PushLinkResult{}
+	}
+
+	currentBySource := make(map[int]map[gitLabLinkKey]struct{})
+	var result PushLinkResult
+
+	for _, link := range desired {
+		current, ok := currentBySource[link.SourceIID]
+		if !ok {
+			links, err := r.Client.GetIssueLinks(ctx, link.SourceIID)
+			if err != nil {
+				result.Errors = append(result.Errors, fmt.Errorf("fetch GitLab links for #%d: %w", link.SourceIID, err))
+				continue
+			}
+			current = currentLinkSet(link.SourceIID, links)
+			currentBySource[link.SourceIID] = current
+		}
+
+		if _, exists := current[link.key()]; exists {
+			continue
+		}
+
+		if opts.DryRun {
+			if opts.OnPlan != nil {
+				opts.OnPlan(link)
+			}
+			result.Created++
+			continue
+		}
+
+		if _, err := r.Client.CreateIssueLink(ctx, link.SourceIID, link.TargetIID, link.LinkType); err != nil {
+			if isGitLabLicenseError(err) {
+				// blocks/is_blocked_by needs GitLab Premium/Ultimate; this
+				// instance's license lacks it. Expected, non-fatal: skip and
+				// let the caller emit one curated message.
+				result.LicenseSkipped++
+				continue
+			}
+			result.Errors = append(result.Errors, fmt.Errorf("create GitLab link #%d %s #%d: %w", link.SourceIID, link.LinkType, link.TargetIID, err))
+			continue
+		}
+		current[link.key()] = struct{}{}
+		result.Created++
+	}
+
+	return result
+}
+
+// isGitLabLicenseError reports whether err is GitLab's 403 rejection of a
+// blocks/is_blocked_by link on an instance whose license lacks the
+// issue-blocking feature ("Blocked issues not available for current license").
+// It is deliberately specific so genuine failures are not misclassified as the
+// expected license limitation.
+func isGitLabLicenseError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	if strings.Contains(msg, "not available for current license") ||
+		strings.Contains(msg, "blocked issues not available") {
+		return true
+	}
+	// Fallback: a 403 that explicitly mentions licensing.
+	return strings.Contains(msg, "status 403") && strings.Contains(msg, "license")
+}
+
+// PushEpicMilestones ensures non-epic GitLab issues under synced epic beads
+// carry the epic's GitLab milestone. This runs during the dependency push pass
+// so milestone hierarchy stays correct even when issue content was unchanged
+// and the main push loop skipped the issue update.
+func (t *Tracker) PushEpicMilestones(ctx context.Context, issues []*types.Issue, opts EpicMilestoneOptions) (int, []error) {
+	if t == nil || t.client == nil || t.store == nil {
+		return 0, nil
+	}
+
+	seen := make(map[string]struct{}, len(issues))
+	updated := 0
+	var errs []error
+	for _, issue := range issues {
+		if issue == nil || issue.IssueType == types.TypeEpic {
+			continue
+		}
+		if _, ok := seen[issue.ID]; ok {
+			continue
+		}
+		seen[issue.ID] = struct{}{}
+		if issue.ExternalRef == nil {
+			continue
+		}
+		iid, ok := IssueIIDFromRef(*issue.ExternalRef)
+		if !ok {
+			continue
+		}
+
+		milestoneID := t.findParentEpicMilestone(ctx, issue.ID)
+		if milestoneID == 0 {
+			continue
+		}
+
+		current, err := t.client.FetchIssueByIID(ctx, iid)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("fetch GitLab issue #%d for milestone sync: %w", iid, err))
+			continue
+		}
+		if current != nil && current.Milestone != nil && current.Milestone.ID == milestoneID {
+			continue
+		}
+
+		if opts.DryRun {
+			if opts.OnPlan != nil {
+				opts.OnPlan(issue.ID, iid, milestoneID)
+			}
+			updated++
+			continue
+		}
+
+		if _, err := t.client.UpdateIssue(ctx, iid, map[string]interface{}{"milestone_id": milestoneID}); err != nil {
+			errs = append(errs, fmt.Errorf("set GitLab milestone for %s (#%d): %w", issue.ID, iid, err))
+			continue
+		}
+		updated++
+	}
+	return updated, errs
+}
+
+// issueLinksToDependencies converts GitLab issue links to normalized beads
+// dependencies. Both "B blocks A" and "A is_blocked_by B" become A -> B blocks.
+func issueLinksToDependencies(sourceIID int, links []IssueLink, _ *MappingConfig) []DependencyInfo {
+	var deps []DependencyInfo
+	for _, link := range links {
+		dep, ok := dependencyFromIssueLink(sourceIID, link)
+		if ok {
+			deps = append(deps, dep)
+		}
+	}
+	return deps
+}
+
+func dependencyFromIssueLink(currentIID int, link IssueLink) (DependencyInfo, bool) {
+	sourceIID, targetIID, ok := issueLinkIIDs(currentIID, link)
+	if !ok || (currentIID != sourceIID && currentIID != targetIID) {
+		return DependencyInfo{}, false
+	}
+
+	switch link.LinkType {
+	case gitLabLinkBlocks:
+		return DependencyInfo{
+			FromGitLabIID: targetIID,
+			ToGitLabIID:   sourceIID,
+			Type:          string(types.DepBlocks),
+		}, true
+	case gitLabLinkIsBlockedBy:
+		return DependencyInfo{
+			FromGitLabIID: sourceIID,
+			ToGitLabIID:   targetIID,
+			Type:          string(types.DepBlocks),
+		}, true
+	case gitLabLinkRelatesTo:
+		otherIID := targetIID
+		if currentIID == targetIID {
+			otherIID = sourceIID
+		}
+		return DependencyInfo{
+			FromGitLabIID: currentIID,
+			ToGitLabIID:   otherIID,
+			Type:          string(types.DepRelated),
+		}, true
+	default:
+		return DependencyInfo{}, false
+	}
+}
+
+type gitLabLinkKey struct {
+	SourceIID int
+	TargetIID int
+	LinkType  string
+}
+
+func (l DependencyLink) key() gitLabLinkKey {
+	sourceIID, targetIID := l.SourceIID, l.TargetIID
+	if l.LinkType == gitLabLinkRelatesTo {
+		sourceIID, targetIID = orderedIIDs(sourceIID, targetIID)
+	}
+	return gitLabLinkKey{SourceIID: sourceIID, TargetIID: targetIID, LinkType: l.LinkType}
+}
+
+func currentLinkSet(sourceIID int, links []IssueLink) map[gitLabLinkKey]struct{} {
+	result := make(map[gitLabLinkKey]struct{}, len(links))
+	for _, link := range links {
+		for _, key := range currentIssueLinkKeys(sourceIID, link) {
+			result[key] = struct{}{}
+		}
+	}
+	return result
+}
+
+func currentIssueLinkKeys(currentIID int, link IssueLink) []gitLabLinkKey {
+	sourceIID, targetIID, ok := issueLinkIIDs(currentIID, link)
+	if !ok {
+		return nil
+	}
+	switch link.LinkType {
+	case gitLabLinkBlocks:
+		return []gitLabLinkKey{{SourceIID: sourceIID, TargetIID: targetIID, LinkType: gitLabLinkBlocks}}
+	case gitLabLinkIsBlockedBy:
+		return []gitLabLinkKey{{SourceIID: targetIID, TargetIID: sourceIID, LinkType: gitLabLinkBlocks}}
+	case gitLabLinkRelatesTo:
+		sourceIID, targetIID = orderedIIDs(sourceIID, targetIID)
+		return []gitLabLinkKey{{SourceIID: sourceIID, TargetIID: targetIID, LinkType: gitLabLinkRelatesTo}}
+	default:
+		return nil
+	}
+}
+
+func issueLinkIIDs(currentIID int, link IssueLink) (int, int, bool) {
+	if link.SourceIssue != nil && link.TargetIssue != nil {
+		sourceIID := link.SourceIssue.IID
+		targetIID := link.TargetIssue.IID
+		if sourceIID <= 0 || targetIID <= 0 || sourceIID == targetIID {
+			return 0, 0, false
+		}
+		return sourceIID, targetIID, true
+	}
+
+	if currentIID <= 0 || link.IID <= 0 || currentIID == link.IID {
+		return 0, 0, false
+	}
+	return currentIID, link.IID, true
+}
+
+func orderedIIDs(a, b int) (int, int) {
+	if a <= b {
+		return a, b
+	}
+	return b, a
+}
+
+func trackerDependencyFromGitLab(dep DependencyInfo) tracker.DependencyInfo {
+	return tracker.DependencyInfo{
+		FromExternalID: fmt.Sprintf("%d", dep.FromGitLabIID),
+		ToExternalID:   fmt.Sprintf("%d", dep.ToGitLabIID),
+		Type:           dep.Type,
+		Source:         tracker.DependencySourceRelation,
+	}
+}

--- a/internal/gitlab/links_test.go
+++ b/internal/gitlab/links_test.go
@@ -1,0 +1,475 @@
+package gitlab
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/steveyegge/beads/internal/storage"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+func TestIssueLinksToDependencies_NormalizesBlockDirection(t *testing.T) {
+	config := DefaultMappingConfig()
+	links := []IssueLink{
+		{
+			SourceIssue: &Issue{IID: 20},
+			TargetIssue: &Issue{IID: 10},
+			LinkType:    gitLabLinkBlocks,
+		},
+		{
+			SourceIssue: &Issue{IID: 10},
+			TargetIssue: &Issue{IID: 30},
+			LinkType:    gitLabLinkIsBlockedBy,
+		},
+	}
+
+	deps := issueLinksToDependencies(10, links, config)
+
+	if len(deps) != 2 {
+		t.Fatalf("deps len = %d, want 2", len(deps))
+	}
+	for i, dep := range deps {
+		if dep.FromGitLabIID != 10 || dep.Type != string(types.DepBlocks) {
+			t.Fatalf("deps[%d] = %+v, want source issue 10 with blocks type", i, dep)
+		}
+	}
+	if deps[0].ToGitLabIID != 20 {
+		t.Fatalf("deps[0].ToGitLabIID = %d, want 20", deps[0].ToGitLabIID)
+	}
+	if deps[1].ToGitLabIID != 30 {
+		t.Fatalf("deps[1].ToGitLabIID = %d, want 30", deps[1].ToGitLabIID)
+	}
+}
+
+func TestLinkFromBeadsDependencyPushDirection(t *testing.T) {
+	issue := gitLabIssue("bd-a", "https://gitlab.example.com/group/project/-/issues/10", types.TypeTask)
+	blocker := gitLabDep("bd-b", "https://gitlab.example.com/group/project/-/work_items/20", types.DepBlocks)
+
+	link, ok := LinkFromBeadsDependency(issue, blocker)
+	if !ok {
+		t.Fatal("LinkFromBeadsDependency returned false")
+	}
+	if link.SourceIID != 20 || link.TargetIID != 10 || link.LinkType != gitLabLinkBlocks {
+		t.Fatalf("link = %+v, want GitLab #20 blocks #10", link)
+	}
+
+	related := gitLabDep("bd-c", "gitlab:30", types.DepRelatesTo)
+	link, ok = LinkFromBeadsDependency(issue, related)
+	if !ok {
+		t.Fatal("LinkFromBeadsDependency related returned false")
+	}
+	if link.SourceIID != 10 || link.TargetIID != 30 || link.LinkType != gitLabLinkRelatesTo {
+		t.Fatalf("related link = %+v, want unordered GitLab relates_to #10 #30", link)
+	}
+
+	milestone := gitLabDep("bd-epic", "https://gitlab.example.com/group/project/-/milestones/5", types.DepBlocks)
+	if _, ok := LinkFromBeadsDependency(issue, milestone); ok {
+		t.Fatal("milestone endpoint should not produce an issue link")
+	}
+}
+
+func TestDeduplicateLinksRelatedReciprocal(t *testing.T) {
+	links := []DependencyLink{
+		{SourceIID: 10, TargetIID: 20, LinkType: gitLabLinkRelatesTo},
+		{SourceIID: 20, TargetIID: 10, LinkType: gitLabLinkRelatesTo},
+	}
+
+	got := DeduplicateLinks(links)
+
+	if len(got) != 1 {
+		t.Fatalf("deduped links len = %d, want 1", len(got))
+	}
+	if got[0].SourceIID != 10 || got[0].TargetIID != 20 {
+		t.Fatalf("deduped link = %+v, want canonical #10 -> #20", got[0])
+	}
+}
+
+func TestPushLinksAddsMissing(t *testing.T) {
+	var posted bool
+	var capturedBody map[string]interface{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			_ = json.NewEncoder(w).Encode([]IssueLink{})
+		case http.MethodPost:
+			posted = true
+			if !strings.Contains(r.URL.Path, "/issues/20/links") {
+				t.Fatalf("POST path = %s, want source issue 20 links endpoint", r.URL.Path)
+			}
+			_ = json.NewDecoder(r.Body).Decode(&capturedBody)
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(IssueLink{
+				SourceIssue: &Issue{IID: 20},
+				TargetIssue: &Issue{IID: 10},
+				LinkType:    gitLabLinkBlocks,
+			})
+		default:
+			t.Fatalf("unexpected method %s", r.Method)
+		}
+	}))
+	defer server.Close()
+
+	resolver := NewLinkResolver(NewClient("token", server.URL, "123"))
+	res := resolver.PushLinks(context.Background(), []DependencyLink{
+		{SourceIID: 20, TargetIID: 10, LinkType: gitLabLinkBlocks},
+	}, PushLinkOptions{})
+	count, errs := res.Created, res.Errors
+
+	if len(errs) != 0 {
+		t.Fatalf("PushLinks errors = %v", errs)
+	}
+	if count != 1 || !posted {
+		t.Fatalf("count = %d, posted = %v, want one created POST", count, posted)
+	}
+	if capturedBody["link_type"] != gitLabLinkBlocks {
+		t.Fatalf("link_type = %v, want blocks", capturedBody["link_type"])
+	}
+	if int(capturedBody["target_issue_iid"].(float64)) != 10 {
+		t.Fatalf("target_issue_iid = %v, want 10", capturedBody["target_issue_iid"])
+	}
+}
+
+func TestPushLinksIdempotentExistingLink(t *testing.T) {
+	var posts int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			_ = json.NewEncoder(w).Encode([]IssueLink{{
+				SourceIssue: &Issue{IID: 20},
+				TargetIssue: &Issue{IID: 10},
+				LinkType:    gitLabLinkBlocks,
+			}})
+		case http.MethodPost:
+			posts++
+			t.Fatalf("unexpected POST for existing link")
+		}
+	}))
+	defer server.Close()
+
+	resolver := NewLinkResolver(NewClient("token", server.URL, "123"))
+	res := resolver.PushLinks(context.Background(), []DependencyLink{
+		{SourceIID: 20, TargetIID: 10, LinkType: gitLabLinkBlocks},
+	}, PushLinkOptions{})
+	count, errs := res.Created, res.Errors
+
+	if len(errs) != 0 {
+		t.Fatalf("PushLinks errors = %v", errs)
+	}
+	if count != 0 || posts != 0 {
+		t.Fatalf("count = %d, posts = %d, want no created links", count, posts)
+	}
+}
+
+func TestPushLinksIdempotentExistingLiveLinkedIssuePayload(t *testing.T) {
+	var posts int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			_ = json.NewEncoder(w).Encode([]IssueLink{{
+				IID:      33,
+				LinkType: gitLabLinkRelatesTo,
+			}})
+		case http.MethodPost:
+			posts++
+			t.Fatalf("unexpected POST for existing live GitLab link payload")
+		}
+	}))
+	defer server.Close()
+
+	resolver := NewLinkResolver(NewClient("token", server.URL, "123"))
+	res := resolver.PushLinks(context.Background(), []DependencyLink{
+		{SourceIID: 31, TargetIID: 33, LinkType: gitLabLinkRelatesTo},
+	}, PushLinkOptions{})
+	count, errs := res.Created, res.Errors
+
+	if len(errs) != 0 {
+		t.Fatalf("PushLinks errors = %v", errs)
+	}
+	if count != 0 || posts != 0 {
+		t.Fatalf("count = %d, posts = %d, want no created links", count, posts)
+	}
+}
+
+func TestPushLinksDryRunDoesNotPost(t *testing.T) {
+	var posts int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			_ = json.NewEncoder(w).Encode([]IssueLink{})
+		case http.MethodPost:
+			posts++
+			t.Fatalf("unexpected POST during dry-run")
+		}
+	}))
+	defer server.Close()
+
+	var planned []DependencyLink
+	resolver := NewLinkResolver(NewClient("token", server.URL, "123"))
+	res := resolver.PushLinks(context.Background(), []DependencyLink{
+		{SourceIID: 20, TargetIID: 10, LinkType: gitLabLinkBlocks},
+	}, PushLinkOptions{
+		DryRun: true,
+		OnPlan: func(link DependencyLink) {
+			planned = append(planned, link)
+		},
+	})
+	count, errs := res.Created, res.Errors
+
+	if len(errs) != 0 {
+		t.Fatalf("PushLinks errors = %v", errs)
+	}
+	if count != 1 || posts != 0 || len(planned) != 1 {
+		t.Fatalf("count = %d, posts = %d, planned = %d; want one dry-run plan and no POST", count, posts, len(planned))
+	}
+}
+
+func TestIsGitLabLicenseError(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"license 403 body", fmt.Errorf("failed to create issue link: API error: {\"message\":\"Blocked issues not available for current license\"} (status 403)"), true},
+		{"license phrase", fmt.Errorf("not available for current license"), true},
+		{"plain 403 no license", fmt.Errorf("API error: {\"message\":\"403 Forbidden\"} (status 403)"), false},
+		{"server error", fmt.Errorf("API error: {\"message\":\"boom\"} (status 500)"), false},
+		{"nil", nil, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isGitLabLicenseError(tc.err); got != tc.want {
+				t.Fatalf("isGitLabLicenseError(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestPushLinksLicenseSkippedBlocks verifies that a blocks link rejected for
+// lack of a GitLab license is counted as LicenseSkipped (not a genuine error),
+// the sync continues, and relates_to links still apply.
+func TestPushLinksLicenseSkippedBlocks(t *testing.T) {
+	var blocksPosts, relatesPosts int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			_ = json.NewEncoder(w).Encode([]IssueLink{})
+			return
+		}
+		var body map[string]interface{}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		switch body["link_type"] {
+		case gitLabLinkBlocks:
+			blocksPosts++
+			w.WriteHeader(http.StatusForbidden)
+			_, _ = w.Write([]byte(`{"message":"Blocked issues not available for current license"}`))
+		case gitLabLinkRelatesTo:
+			relatesPosts++
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(IssueLink{
+				SourceIssue: &Issue{IID: 31},
+				TargetIssue: &Issue{IID: 33},
+				LinkType:    gitLabLinkRelatesTo,
+			})
+		default:
+			t.Fatalf("unexpected link_type %v", body["link_type"])
+		}
+	}))
+	defer server.Close()
+
+	resolver := NewLinkResolver(NewClient("token", server.URL, "123"))
+	res := resolver.PushLinks(context.Background(), []DependencyLink{
+		{SourceIID: 20, TargetIID: 10, LinkType: gitLabLinkBlocks},
+		{SourceIID: 31, TargetIID: 33, LinkType: gitLabLinkRelatesTo},
+	}, PushLinkOptions{})
+
+	if len(res.Errors) != 0 {
+		t.Fatalf("Errors = %v, want none (license is not a genuine error)", res.Errors)
+	}
+	if res.LicenseSkipped != 1 {
+		t.Fatalf("LicenseSkipped = %d, want 1", res.LicenseSkipped)
+	}
+	if res.Created != 1 {
+		t.Fatalf("Created = %d, want 1 (relates_to still applied)", res.Created)
+	}
+	if blocksPosts != 1 || relatesPosts != 1 {
+		t.Fatalf("blocksPosts=%d relatesPosts=%d, want 1/1", blocksPosts, relatesPosts)
+	}
+}
+
+// TestPushLinksNonLicenseErrorIsGenuine verifies that a non-license failure
+// (e.g. a permissions 403 without the license message) is reported as a genuine
+// error, not silently treated as the expected license degradation.
+func TestPushLinksNonLicenseErrorIsGenuine(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			_ = json.NewEncoder(w).Encode([]IssueLink{})
+			return
+		}
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"message":"403 Forbidden - insufficient_scope"}`))
+	}))
+	defer server.Close()
+
+	resolver := NewLinkResolver(NewClient("token", server.URL, "123"))
+	res := resolver.PushLinks(context.Background(), []DependencyLink{
+		{SourceIID: 20, TargetIID: 10, LinkType: gitLabLinkBlocks},
+	}, PushLinkOptions{})
+
+	if res.LicenseSkipped != 0 {
+		t.Fatalf("LicenseSkipped = %d, want 0 (not a license error)", res.LicenseSkipped)
+	}
+	if len(res.Errors) != 1 {
+		t.Fatalf("Errors = %v, want exactly 1 genuine error", res.Errors)
+	}
+	if res.Created != 0 {
+		t.Fatalf("Created = %d, want 0", res.Created)
+	}
+}
+
+func TestPushEpicMilestonesDependencyOnlySync(t *testing.T) {
+	epic := gitLabIssue("bd-epic", "https://gitlab.example.com/group/project/-/milestones/5", types.TypeEpic)
+	child := gitLabIssue("bd-child", "https://gitlab.example.com/group/project/-/issues/10", types.TypeTask)
+	fakeStore := &gitLabLinkFakeStore{
+		deps: map[string][]*types.IssueWithDependencyMetadata{
+			"bd-child": {{Issue: *epic, DependencyType: types.DepParentChild}},
+		},
+	}
+
+	var updates int
+	var capturedBody map[string]interface{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/milestones"):
+			if r.URL.Query().Get("iids[]") != "5" {
+				t.Fatalf("milestone query = %s, want iids[]=5", r.URL.RawQuery)
+			}
+			_ = json.NewEncoder(w).Encode([]Milestone{{ID: 500, IID: 5, Title: "Epic milestone"}})
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/issues/10"):
+			_ = json.NewEncoder(w).Encode(Issue{ID: 100, IID: 10, Title: "Child"})
+		case r.Method == http.MethodPut && strings.Contains(r.URL.Path, "/issues/10"):
+			updates++
+			_ = json.NewDecoder(r.Body).Decode(&capturedBody)
+			_ = json.NewEncoder(w).Encode(Issue{ID: 100, IID: 10, Title: "Child", Milestone: &Milestone{ID: 500}})
+		default:
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.String())
+		}
+	}))
+	defer server.Close()
+
+	tr := &Tracker{
+		client: NewClient("token", server.URL, "123"),
+		store:  fakeStore,
+	}
+	count, errs := tr.PushEpicMilestones(context.Background(), []*types.Issue{child}, EpicMilestoneOptions{})
+
+	if len(errs) != 0 {
+		t.Fatalf("PushEpicMilestones errors = %v", errs)
+	}
+	if count != 1 || updates != 1 {
+		t.Fatalf("count = %d, updates = %d, want one milestone update", count, updates)
+	}
+	if int(capturedBody["milestone_id"].(float64)) != 500 {
+		t.Fatalf("milestone_id = %v, want 500", capturedBody["milestone_id"])
+	}
+}
+
+func TestUpdateMilestoneResolvesIIDToAPIID(t *testing.T) {
+	epic := gitLabIssue("bd-epic", "https://gitlab.example.com/group/project/-/milestones/4", types.TypeEpic)
+
+	var updatedPath string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/milestones"):
+			if r.URL.Query().Get("iids[]") != "4" {
+				t.Fatalf("milestone query = %s, want iids[]=4", r.URL.RawQuery)
+			}
+			_ = json.NewEncoder(w).Encode([]Milestone{{ID: 35, IID: 4, Title: "Existing milestone"}})
+		case r.Method == http.MethodPut && strings.Contains(r.URL.Path, "/milestones/35"):
+			updatedPath = r.URL.Path
+			_ = json.NewEncoder(w).Encode(Milestone{ID: 35, IID: 4, Title: epic.Title, WebURL: *epic.ExternalRef})
+		case r.Method == http.MethodPut:
+			t.Fatalf("PUT path = %s, want milestone API ID 35", r.URL.Path)
+		default:
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.String())
+		}
+	}))
+	defer server.Close()
+
+	tr := &Tracker{client: NewClient("token", server.URL, "123")}
+	got, err := tr.updateMilestone(context.Background(), "milestone:4", epic)
+	if err != nil {
+		t.Fatalf("updateMilestone: %v", err)
+	}
+	if updatedPath == "" {
+		t.Fatal("UpdateMilestone was not called")
+	}
+	if got.ID != "35" {
+		t.Fatalf("TrackerIssue ID = %s, want 35", got.ID)
+	}
+}
+
+func TestFetchIssueMilestoneIdentifier(t *testing.T) {
+	updatedAt := time.Date(2026, 5, 19, 10, 30, 0, 0, time.UTC)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || !strings.Contains(r.URL.Path, "/milestones") {
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.String())
+		}
+		if r.URL.Query().Get("iids[]") != "4" {
+			t.Fatalf("milestone query = %s, want iids[]=4", r.URL.RawQuery)
+		}
+		_ = json.NewEncoder(w).Encode([]Milestone{{
+			ID:          35,
+			IID:         4,
+			Title:       "Existing milestone",
+			Description: "remote milestone",
+			UpdatedAt:   &updatedAt,
+			WebURL:      "https://gitlab.example.com/group/project/-/milestones/4",
+		}})
+	}))
+	defer server.Close()
+
+	tr := &Tracker{client: NewClient("token", server.URL, "123")}
+	got, err := tr.FetchIssue(context.Background(), "milestone:4")
+	if err != nil {
+		t.Fatalf("FetchIssue milestone: %v", err)
+	}
+	if got == nil {
+		t.Fatal("FetchIssue milestone returned nil")
+	}
+	if got.Title != "Existing milestone" || got.Description != "remote milestone" {
+		t.Fatalf("TrackerIssue = %+v", got)
+	}
+	if !got.UpdatedAt.Equal(updatedAt) {
+		t.Fatalf("UpdatedAt = %s, want %s", got.UpdatedAt, updatedAt)
+	}
+}
+
+type gitLabLinkFakeStore struct {
+	storage.Storage
+	deps map[string][]*types.IssueWithDependencyMetadata
+}
+
+func (s *gitLabLinkFakeStore) GetDependenciesWithMetadata(_ context.Context, issueID string) ([]*types.IssueWithDependencyMetadata, error) {
+	return s.deps[issueID], nil
+}
+
+func gitLabIssue(id, ref string, issueType types.IssueType) *types.Issue {
+	return &types.Issue{
+		ID:          id,
+		ExternalRef: &ref,
+		IssueType:   issueType,
+		Status:      types.StatusOpen,
+	}
+}
+
+func gitLabDep(id, ref string, depType types.DependencyType) *types.IssueWithDependencyMetadata {
+	return &types.IssueWithDependencyMetadata{
+		Issue:          *gitLabIssue(id, ref, types.TypeTask),
+		DependencyType: depType,
+	}
+}

--- a/internal/gitlab/mapping.go
+++ b/internal/gitlab/mapping.go
@@ -43,7 +43,7 @@ func DefaultMappingConfig() *MappingConfig {
 		LabelTypeMap: labelTypeMap,
 		RelationMap: map[string]string{
 			"blocks":        "blocks",
-			"is_blocked_by": "blocked_by",
+			"is_blocked_by": "blocks",
 			"relates_to":    "related",
 		},
 	}
@@ -227,44 +227,6 @@ func priorityToLabel(priority int) string {
 	default:
 		return "medium"
 	}
-}
-
-// issueLinksToDependencies converts GitLab IssueLinks to beads DependencyInfo.
-func issueLinksToDependencies(sourceIID int, links []IssueLink, config *MappingConfig) []DependencyInfo {
-	var deps []DependencyInfo
-
-	for _, link := range links {
-		var toIID int
-		var depType string
-
-		// Determine direction and target
-		if link.SourceIssue != nil && link.SourceIssue.IID == sourceIID {
-			// We are the source, target is the dependency
-			if link.TargetIssue != nil {
-				toIID = link.TargetIssue.IID
-			}
-		} else if link.TargetIssue != nil && link.TargetIssue.IID == sourceIID {
-			// We are the target, source is the dependency
-			if link.SourceIssue != nil {
-				toIID = link.SourceIssue.IID
-			}
-		}
-
-		// Map link type
-		if t, ok := config.RelationMap[link.LinkType]; ok {
-			depType = t
-		} else {
-			depType = "related"
-		}
-
-		deps = append(deps, DependencyInfo{
-			FromGitLabIID: sourceIID,
-			ToGitLabIID:   toIID,
-			Type:          depType,
-		})
-	}
-
-	return deps
 }
 
 // filterNonScopedLabels returns only labels without scoped prefixes.

--- a/internal/gitlab/mapping.go
+++ b/internal/gitlab/mapping.go
@@ -197,9 +197,14 @@ func BeadsIssueToGitLabFields(issue *types.Issue, config *MappingConfig) map[str
 		fields["weight"] = *issue.EstimatedMinutes / 60
 	}
 
-	// Set state_event for closed issues
+	// Set state_event so the GitLab issue state tracks the bead. On update this
+	// closes or reopens the issue; on create GitLab's POST /issues ignores
+	// state_event, so a closed bead is created open and closed by a follow-up
+	// update in Tracker.CreateIssue.
 	if issue.Status == types.StatusClosed {
 		fields["state_event"] = "close"
+	} else {
+		fields["state_event"] = "reopen"
 	}
 
 	return fields

--- a/internal/gitlab/mapping.go
+++ b/internal/gitlab/mapping.go
@@ -13,7 +13,6 @@ type MappingConfig struct {
 	PriorityMap  map[string]int    // priority label value → beads priority (0-4)
 	StateMap     map[string]string // GitLab state → beads status
 	LabelTypeMap map[string]string // type label value → beads issue type
-	RelationMap  map[string]string // GitLab link type → beads dependency type
 }
 
 // DefaultMappingConfig returns the default mapping configuration.
@@ -41,11 +40,6 @@ func DefaultMappingConfig() *MappingConfig {
 			"reopened": StatusMapping["open"], // reopened maps to open
 		},
 		LabelTypeMap: labelTypeMap,
-		RelationMap: map[string]string{
-			"blocks":        "blocks",
-			"is_blocked_by": "blocks",
-			"relates_to":    "related",
-		},
 	}
 }
 

--- a/internal/gitlab/mapping_test.go
+++ b/internal/gitlab/mapping_test.go
@@ -389,19 +389,32 @@ func TestBeadsIssueToGitLabFields(t *testing.T) {
 	}
 }
 
-// TestBeadsIssueToGitLabFields_StateEvent verifies state_event is set for closed issues.
+// TestBeadsIssueToGitLabFields_StateEvent verifies state_event tracks the bead
+// status in both directions: closed issues close, non-closed issues reopen. The
+// reopen direction ensures a bead reopened after being synced closed does not
+// stay closed in GitLab on update.
 func TestBeadsIssueToGitLabFields_StateEvent(t *testing.T) {
 	config := DefaultMappingConfig()
 
-	closedIssue := &types.Issue{
-		Title:  "Completed task",
-		Status: types.StatusClosed,
+	tests := []struct {
+		name   string
+		status types.Status
+		want   string
+	}{
+		{"closed", types.StatusClosed, "close"},
+		{"open", types.StatusOpen, "reopen"},
+		{"in_progress", types.StatusInProgress, "reopen"},
+		// deferred is deliberately NOT closed in GitLab: only truly-done work
+		// counts toward milestone completion.
+		{"deferred", types.StatusDeferred, "reopen"},
 	}
-
-	fields := BeadsIssueToGitLabFields(closedIssue, config)
-
-	if fields["state_event"] != "close" {
-		t.Errorf("fields[\"state_event\"] = %v, want \"close\"", fields["state_event"])
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fields := BeadsIssueToGitLabFields(&types.Issue{Title: "t", Status: tt.status}, config)
+			if fields["state_event"] != tt.want {
+				t.Errorf("state_event = %v, want %q", fields["state_event"], tt.want)
+			}
+		})
 	}
 }
 

--- a/internal/gitlab/mapping_test.go
+++ b/internal/gitlab/mapping_test.go
@@ -462,12 +462,12 @@ func TestIssueLinksToDependencies(t *testing.T) {
 		t.Fatalf("issueLinksToDependencies returned %d dependencies, want 3", len(deps))
 	}
 
-	// Check blocks dependency
+	// Check blocks dependency: source 42 blocks target 43, so 43 depends on 42.
 	if deps[0].Type != "blocks" {
 		t.Errorf("deps[0].Type = %q, want \"blocks\"", deps[0].Type)
 	}
-	if deps[0].ToGitLabIID != 43 {
-		t.Errorf("deps[0].ToGitLabIID = %d, want 43", deps[0].ToGitLabIID)
+	if deps[0].FromGitLabIID != 43 || deps[0].ToGitLabIID != 42 {
+		t.Errorf("deps[0] = %d -> %d, want 43 -> 42", deps[0].FromGitLabIID, deps[0].ToGitLabIID)
 	}
 
 	// Check relates_to dependency
@@ -475,9 +475,12 @@ func TestIssueLinksToDependencies(t *testing.T) {
 		t.Errorf("deps[1].Type = %q, want \"related\"", deps[1].Type)
 	}
 
-	// Check is_blocked_by (reverse of blocks)
-	if deps[2].Type != "blocked_by" {
-		t.Errorf("deps[2].Type = %q, want \"blocked_by\"", deps[2].Type)
+	// Check is_blocked_by: source 42 is blocked by target 45, so 42 depends on 45.
+	if deps[2].Type != "blocks" {
+		t.Errorf("deps[2].Type = %q, want \"blocks\"", deps[2].Type)
+	}
+	if deps[2].FromGitLabIID != 42 || deps[2].ToGitLabIID != 45 {
+		t.Errorf("deps[2] = %d -> %d, want 42 -> 45", deps[2].FromGitLabIID, deps[2].ToGitLabIID)
 	}
 }
 
@@ -559,7 +562,7 @@ func TestIssueLinksToDependencies_AsTarget(t *testing.T) {
 	}
 }
 
-// TestissueLinksToDependencies_UnknownLinkType verifies unknown link types default to "related".
+// TestissueLinksToDependencies_UnknownLinkType verifies unknown link types are skipped.
 func TestIssueLinksToDependencies_UnknownLinkType(t *testing.T) {
 	config := DefaultMappingConfig()
 
@@ -573,13 +576,8 @@ func TestIssueLinksToDependencies_UnknownLinkType(t *testing.T) {
 
 	deps := issueLinksToDependencies(42, links, config)
 
-	if len(deps) != 1 {
-		t.Fatalf("issueLinksToDependencies returned %d dependencies, want 1", len(deps))
-	}
-
-	// Unknown link types should default to "related"
-	if deps[0].Type != "related" {
-		t.Errorf("deps[0].Type = %q, want \"related\" for unknown link type", deps[0].Type)
+	if len(deps) != 0 {
+		t.Fatalf("issueLinksToDependencies returned %d dependencies, want 0 for unknown link type", len(deps))
 	}
 }
 
@@ -598,13 +596,8 @@ func TestIssueLinksToDependencies_NilIssues(t *testing.T) {
 
 	deps := issueLinksToDependencies(42, links, config)
 
-	// Should still create a dependency but with ToGitLabIID = 0
-	if len(deps) != 1 {
-		t.Fatalf("issueLinksToDependencies returned %d dependencies, want 1", len(deps))
-	}
-
-	if deps[0].ToGitLabIID != 0 {
-		t.Errorf("deps[0].ToGitLabIID = %d, want 0 (nil target)", deps[0].ToGitLabIID)
+	if len(deps) != 0 {
+		t.Fatalf("issueLinksToDependencies returned %d dependencies, want 0 for nil target", len(deps))
 	}
 }
 

--- a/internal/gitlab/mapping_test.go
+++ b/internal/gitlab/mapping_test.go
@@ -38,15 +38,6 @@ func TestDefaultGitLabMappingConfig(t *testing.T) {
 	if typ, ok := config.LabelTypeMap["bug"]; !ok || typ != "bug" {
 		t.Errorf("LabelTypeMap[\"bug\"] = %q, want \"bug\"", typ)
 	}
-
-	// Verify relation mappings exist
-	if len(config.RelationMap) == 0 {
-		t.Error("RelationMap is empty, want default relation mappings")
-	}
-	// "blocks" should map to "blocks"
-	if r, ok := config.RelationMap["blocks"]; !ok || r != "blocks" {
-		t.Errorf("RelationMap[\"blocks\"] = %q, want \"blocks\"", r)
-	}
 }
 
 // TestpriorityFromLabels verifies parsing priority::* labels.

--- a/internal/gitlab/tracker.go
+++ b/internal/gitlab/tracker.go
@@ -30,6 +30,8 @@ var glShorthandPattern = regexp.MustCompile(`^gitlab:([1-9]\d*)$`)
 // milestoneIDPattern matches GitLab milestone URLs: .../-/milestones/5
 var milestoneIDPattern = regexp.MustCompile(`/-/milestones/(\d+)`)
 
+const gitLabMilestoneIdentifierPrefix = "milestone:"
+
 // Tracker implements tracker.IssueTracker for GitLab.
 type Tracker struct {
 	client      *Client
@@ -42,6 +44,9 @@ type Tracker struct {
 func (t *Tracker) Name() string         { return "gitlab" }
 func (t *Tracker) DisplayName() string  { return "GitLab" }
 func (t *Tracker) ConfigPrefix() string { return "gitlab" }
+
+// GitLabClient returns the underlying GitLab API client.
+func (t *Tracker) GitLabClient() *Client { return t.client }
 
 func (t *Tracker) Init(ctx context.Context, store storage.Storage) error {
 	t.store = store
@@ -169,6 +174,18 @@ func (t *Tracker) FetchIssues(ctx context.Context, opts tracker.FetchOptions) ([
 }
 
 func (t *Tracker) FetchIssue(ctx context.Context, identifier string) (*tracker.TrackerIssue, error) {
+	if milestoneIID, ok, err := parseMilestoneIdentifier(identifier); ok || err != nil {
+		if err != nil {
+			return nil, err
+		}
+		ms, err := t.client.FetchMilestoneByIID(ctx, milestoneIID)
+		if err != nil || ms == nil {
+			return nil, err
+		}
+		ti := milestoneToTrackerIssue(ms)
+		return ti, nil
+	}
+
 	iid, err := strconv.Atoi(identifier)
 	if err != nil {
 		return nil, fmt.Errorf("invalid GitLab IID %q: %w", identifier, err)
@@ -260,9 +277,23 @@ func (t *Tracker) createMilestone(ctx context.Context, issue *types.Issue) (*tra
 
 // updateMilestone updates a GitLab milestone for an epic bead.
 func (t *Tracker) updateMilestone(ctx context.Context, externalID string, issue *types.Issue) (*tracker.TrackerIssue, error) {
-	mid, err := strconv.Atoi(externalID)
+	mid, ok, err := parseMilestoneIdentifier(externalID)
 	if err != nil {
-		return nil, fmt.Errorf("invalid milestone ID %q: %w", externalID, err)
+		return nil, err
+	}
+	if !ok {
+		mid, err = strconv.Atoi(externalID)
+		if err != nil {
+			return nil, fmt.Errorf("invalid milestone ID %q: %w", externalID, err)
+		}
+	}
+	apiID := mid
+	msByIID, err := t.client.FetchMilestoneByIID(ctx, mid)
+	if err != nil {
+		return nil, fmt.Errorf("resolving milestone IID %d: %w", mid, err)
+	}
+	if msByIID != nil {
+		apiID = msByIID.ID
 	}
 
 	updates := map[string]interface{}{
@@ -275,7 +306,7 @@ func (t *Tracker) updateMilestone(ctx context.Context, externalID string, issue 
 		updates["state_event"] = "activate"
 	}
 
-	ms, err := t.client.UpdateMilestone(ctx, mid, updates)
+	ms, err := t.client.UpdateMilestone(ctx, apiID, updates)
 	if err != nil {
 		return nil, fmt.Errorf("updating milestone for epic: %w", err)
 	}
@@ -404,12 +435,21 @@ func (t *Tracker) findParentStoryGID(ctx context.Context, issueID string) string
 
 // milestoneToTrackerIssue converts a GitLab Milestone to a TrackerIssue.
 func milestoneToTrackerIssue(ms *Milestone) *tracker.TrackerIssue {
-	return &tracker.TrackerIssue{
-		ID:         strconv.Itoa(ms.ID),
-		Identifier: strconv.Itoa(ms.ID),
-		URL:        ms.WebURL,
-		Title:      ms.Title,
+	ti := &tracker.TrackerIssue{
+		ID:          strconv.Itoa(ms.ID),
+		Identifier:  strconv.Itoa(ms.ID),
+		URL:         ms.WebURL,
+		Title:       ms.Title,
+		Description: ms.Description,
+		State:       ms.State,
 	}
+	if ms.CreatedAt != nil {
+		ti.CreatedAt = *ms.CreatedAt
+	}
+	if ms.UpdatedAt != nil {
+		ti.UpdatedAt = *ms.UpdatedAt
+	}
+	return ti
 }
 
 func (t *Tracker) FieldMapper() tracker.FieldMapper {
@@ -436,13 +476,25 @@ func (t *Tracker) ExtractIdentifier(ref string) string {
 	}
 	// Try milestone pattern first (more specific path)
 	if matches := milestoneIDPattern.FindStringSubmatch(ref); len(matches) >= 2 {
-		return matches[1]
+		return gitLabMilestoneIdentifierPrefix + matches[1]
 	}
 	// Fall back to issue pattern
 	if matches := issueIIDPattern.FindStringSubmatch(ref); len(matches) >= 2 {
 		return matches[1]
 	}
 	return ""
+}
+
+func parseMilestoneIdentifier(identifier string) (int, bool, error) {
+	if !strings.HasPrefix(identifier, gitLabMilestoneIdentifierPrefix) {
+		return 0, false, nil
+	}
+	raw := strings.TrimPrefix(identifier, gitLabMilestoneIdentifierPrefix)
+	iid, err := strconv.Atoi(raw)
+	if err != nil {
+		return 0, true, fmt.Errorf("invalid GitLab milestone identifier %q: %w", identifier, err)
+	}
+	return iid, true, nil
 }
 
 // IsMilestoneRef checks if an external_ref points to a milestone (not an issue).

--- a/internal/gitlab/tracker.go
+++ b/internal/gitlab/tracker.go
@@ -233,7 +233,27 @@ func (t *Tracker) CreateIssue(ctx context.Context, issue *types.Issue) (*tracker
 		}
 	}
 
+	// GitLab's POST /issues cannot set state, so a closed bead is created
+	// "opened". Close it with a follow-up update so the state carries. On
+	// failure we keep the created issue and its external_ref (returning an error
+	// here would strand the issue and re-create a duplicate on the next push).
+	// The trade-off: the push skip-guard treats the just-created remote as
+	// up-to-date, so a failed close is not retried until the bead is next
+	// modified — hence the warning. A closed-state push is the common bulk case
+	// and this call rarely fails.
+	var warnings []string
+	if issue.Status == types.StatusClosed {
+		if closed, err := t.client.UpdateIssue(ctx, created.IID, map[string]interface{}{
+			"state_event": "close",
+		}); err == nil {
+			created = closed
+		} else {
+			warnings = append(warnings, fmt.Sprintf("created GitLab issue %d but failed to close it (left open): %v", created.IID, err))
+		}
+	}
+
 	ti := gitlabToTrackerIssue(created)
+	ti.Warnings = warnings
 	return &ti, nil
 }
 
@@ -272,7 +292,24 @@ func (t *Tracker) createMilestone(ctx context.Context, issue *types.Issue) (*tra
 	if err != nil {
 		return nil, fmt.Errorf("creating milestone for epic: %w", err)
 	}
-	return milestoneToTrackerIssue(ms), nil
+
+	// Milestones are created active; close it with a follow-up update if the
+	// epic is closed so its state carries. Best effort with the same failure
+	// trade-off as CreateIssue (a failed close is not retried until the epic is
+	// next modified).
+	var warnings []string
+	if issue.Status == types.StatusClosed {
+		if closed, err := t.client.UpdateMilestone(ctx, ms.ID, map[string]interface{}{
+			"state_event": "close",
+		}); err == nil {
+			ms = closed
+		} else {
+			warnings = append(warnings, fmt.Sprintf("created GitLab milestone %d but failed to close it (left active): %v", ms.ID, err))
+		}
+	}
+	ti := milestoneToTrackerIssue(ms)
+	ti.Warnings = warnings
+	return ti, nil
 }
 
 // updateMilestone updates a GitLab milestone for an epic bead.
@@ -375,13 +412,26 @@ func (t *Tracker) createTaskWorkItem(ctx context.Context, issue *types.Issue, pa
 	// Build URL from project path and IID
 	webURL := fmt.Sprintf("%s/%s/-/work_items/%s", t.client.BaseURL, t.projectPath, wi.IID)
 
+	iid, _ := strconv.Atoi(wi.IID)
+
 	// Also set milestone if there's a grandparent epic
 	if milestoneID := t.findParentEpicMilestone(ctx, issue.ID); milestoneID > 0 {
-		iid, _ := strconv.Atoi(wi.IID)
 		if iid > 0 {
 			_, _ = t.client.UpdateIssue(ctx, iid, map[string]interface{}{
 				"milestone_id": milestoneID,
 			})
+		}
+	}
+
+	// Work items are created open; close via the issues API (work items share
+	// the project IID space, as the milestone assignment above relies on) if the
+	// bead is closed. Best effort with the same failure trade-off as CreateIssue.
+	var warnings []string
+	if issue.Status == types.StatusClosed && iid > 0 {
+		if _, err := t.client.UpdateIssue(ctx, iid, map[string]interface{}{
+			"state_event": "close",
+		}); err != nil {
+			warnings = append(warnings, fmt.Sprintf("created GitLab work item %s but failed to close it (left open): %v", wi.IID, err))
 		}
 	}
 
@@ -390,6 +440,7 @@ func (t *Tracker) createTaskWorkItem(ctx context.Context, issue *types.Issue, pa
 		Identifier: wi.IID,
 		URL:        webURL,
 		Title:      wi.Title,
+		Warnings:   warnings,
 	}, nil
 }
 

--- a/internal/gitlab/tracker_state_test.go
+++ b/internal/gitlab/tracker_state_test.go
@@ -1,0 +1,216 @@
+package gitlab
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// capturedRequest records a single API call the tracker made.
+type capturedRequest struct {
+	method string
+	path   string
+	body   map[string]interface{}
+}
+
+// newRecordingTracker returns a Tracker whose client points at a test server
+// that records every request and replies with the JSON bodies keyed by
+// "METHOD path". store is left nil so parent-epic lookups are skipped.
+func newRecordingTracker(t *testing.T, responses map[string]string) (*Tracker, *[]capturedRequest) {
+	t.Helper()
+	var reqs []capturedRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]interface{}
+		if raw, _ := io.ReadAll(r.Body); len(raw) > 0 {
+			_ = json.Unmarshal(raw, &body)
+		}
+		// Strip the /api/v4 prefix so keys read like "/projects/123/issues".
+		path := strings.TrimPrefix(r.URL.Path, "/api/v4")
+		reqs = append(reqs, capturedRequest{method: r.Method, path: path, body: body})
+		key := r.Method + " " + path
+		resp, ok := responses[key]
+		if !ok {
+			t.Errorf("unexpected request: %s", key)
+			http.Error(w, "unexpected", http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, resp)
+	}))
+	t.Cleanup(srv.Close)
+
+	tr := &Tracker{
+		client: NewClient("token", srv.URL, "123"),
+		config: DefaultMappingConfig(),
+	}
+	return tr, &reqs
+}
+
+// findRequest returns the first captured request matching method and path.
+func findRequest(reqs []capturedRequest, method, path string) *capturedRequest {
+	for i := range reqs {
+		if reqs[i].method == method && reqs[i].path == path {
+			return &reqs[i]
+		}
+	}
+	return nil
+}
+
+// TestCreateIssue_ClosedCarriesState verifies a closed bead is created and then
+// closed with a follow-up PUT carrying state_event=close.
+func TestCreateIssue_ClosedCarriesState(t *testing.T) {
+	tr, reqs := newRecordingTracker(t, map[string]string{
+		"POST /projects/123/issues":   `{"id":100,"iid":42,"state":"opened","web_url":"https://gl/x/-/issues/42"}`,
+		"PUT /projects/123/issues/42": `{"id":100,"iid":42,"state":"closed","web_url":"https://gl/x/-/issues/42"}`,
+	})
+
+	ti, err := tr.CreateIssue(context.Background(), &types.Issue{
+		Title:     "done",
+		IssueType: types.TypeBug,
+		Status:    types.StatusClosed,
+	})
+	if err != nil {
+		t.Fatalf("CreateIssue: %v", err)
+	}
+
+	closeReq := findRequest(*reqs, http.MethodPut, "/projects/123/issues/42")
+	if closeReq == nil {
+		t.Fatalf("expected follow-up PUT to close issue, got requests: %+v", *reqs)
+	}
+	if closeReq.body["state_event"] != "close" {
+		t.Errorf("close PUT state_event = %v, want \"close\"", closeReq.body["state_event"])
+	}
+	if raw, ok := ti.Raw.(*Issue); !ok || raw.State != "closed" {
+		t.Errorf("returned issue state = %v, want closed", ti.Raw)
+	}
+}
+
+// TestCreateIssue_NonClosedSkipsClose verifies a non-closed bead is created
+// without a follow-up close request. deferred is included explicitly: deferred
+// work must stay open in GitLab.
+func TestCreateIssue_NonClosedSkipsClose(t *testing.T) {
+	for _, status := range []types.Status{types.StatusOpen, types.StatusDeferred} {
+		t.Run(string(status), func(t *testing.T) {
+			tr, reqs := newRecordingTracker(t, map[string]string{
+				"POST /projects/123/issues": `{"id":101,"iid":43,"state":"opened","web_url":"https://gl/x/-/issues/43"}`,
+			})
+
+			if _, err := tr.CreateIssue(context.Background(), &types.Issue{
+				Title:     "todo",
+				IssueType: types.TypeTask,
+				Status:    status,
+			}); err != nil {
+				t.Fatalf("CreateIssue: %v", err)
+			}
+
+			if r := findRequest(*reqs, http.MethodPut, "/projects/123/issues/43"); r != nil {
+				t.Errorf("%s issue should not trigger a close PUT, got %+v", status, r)
+			}
+		})
+	}
+}
+
+// TestCreateIssue_FailedCloseSurfacesWarning verifies that when the follow-up
+// close fails, CreateIssue still returns the created issue (so the external_ref
+// is stored and no duplicate is made) but records a warning on the returned
+// TrackerIssue so the sync engine can surface it instead of swallowing it.
+func TestCreateIssue_FailedCloseSurfacesWarning(t *testing.T) {
+	var reqs []capturedRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		path := strings.TrimPrefix(r.URL.Path, "/api/v4")
+		reqs = append(reqs, capturedRequest{method: r.Method, path: path})
+		if r.Method == http.MethodPost {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"id":100,"iid":42,"state":"opened","web_url":"https://gl/x/-/issues/42"}`)
+			return
+		}
+		// The follow-up close (PUT) fails with a non-retryable status (403) so
+		// the test doesn't wait on the client's 5xx/429 backoff retries.
+		http.Error(w, `{"message":"403 Forbidden"}`, http.StatusForbidden)
+	}))
+	t.Cleanup(srv.Close)
+	tr := &Tracker{client: NewClient("token", srv.URL, "123"), config: DefaultMappingConfig()}
+
+	ti, err := tr.CreateIssue(context.Background(), &types.Issue{
+		Title: "done", IssueType: types.TypeBug, Status: types.StatusClosed,
+	})
+	if err != nil {
+		t.Fatalf("CreateIssue should not error on a failed best-effort close: %v", err)
+	}
+	if ti == nil || ti.Identifier != "42" {
+		t.Fatalf("expected the created issue to be returned so external_ref is stored, got %+v", ti)
+	}
+	if len(ti.Warnings) == 0 {
+		t.Fatal("expected a warning on the returned TrackerIssue when the close fails")
+	}
+	if !strings.Contains(ti.Warnings[0], "failed to close") {
+		t.Errorf("warning = %q, want it to mention the failed close", ti.Warnings[0])
+	}
+}
+
+// TestUpdateIssue_StateCarries verifies the update path flips GitLab state to
+// match the bead: a closed bead closes, a reopened bead reopens.
+func TestUpdateIssue_StateCarries(t *testing.T) {
+	tests := []struct {
+		name   string
+		status types.Status
+		want   string
+	}{
+		{"close", types.StatusClosed, "close"},
+		{"reopen", types.StatusOpen, "reopen"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tr, reqs := newRecordingTracker(t, map[string]string{
+				"PUT /projects/123/issues/42": `{"id":100,"iid":42,"state":"opened"}`,
+			})
+
+			if _, err := tr.UpdateIssue(context.Background(), "42", &types.Issue{
+				Title:     "t",
+				IssueType: types.TypeTask,
+				Status:    tt.status,
+			}); err != nil {
+				t.Fatalf("UpdateIssue: %v", err)
+			}
+
+			req := findRequest(*reqs, http.MethodPut, "/projects/123/issues/42")
+			if req == nil {
+				t.Fatalf("expected a PUT, got requests: %+v", *reqs)
+			}
+			if req.body["state_event"] != tt.want {
+				t.Errorf("update state_event = %v, want %q", req.body["state_event"], tt.want)
+			}
+		})
+	}
+}
+
+// TestCreateMilestone_ClosedCarriesState verifies a closed epic is created as a
+// milestone and then closed with state_event=close.
+func TestCreateMilestone_ClosedCarriesState(t *testing.T) {
+	tr, reqs := newRecordingTracker(t, map[string]string{
+		"POST /projects/123/milestones":  `{"id":7,"iid":3,"state":"active","title":"Epic"}`,
+		"PUT /projects/123/milestones/7": `{"id":7,"iid":3,"state":"closed","title":"Epic"}`,
+	})
+
+	if _, err := tr.CreateIssue(context.Background(), &types.Issue{
+		Title:     "Epic",
+		IssueType: types.TypeEpic,
+		Status:    types.StatusClosed,
+	}); err != nil {
+		t.Fatalf("CreateIssue(epic): %v", err)
+	}
+
+	closeReq := findRequest(*reqs, http.MethodPut, "/projects/123/milestones/7")
+	if closeReq == nil {
+		t.Fatalf("expected follow-up PUT to close milestone, got requests: %+v", *reqs)
+	}
+	if closeReq.body["state_event"] != "close" {
+		t.Errorf("milestone close state_event = %v, want \"close\"", closeReq.body["state_event"])
+	}
+}

--- a/internal/gitlab/tracker_test.go
+++ b/internal/gitlab/tracker_test.go
@@ -65,6 +65,7 @@ func TestExtractIdentifier(t *testing.T) {
 		{"https://gitlab.com/group/project/-/issues/42", "42"},
 		{"https://gitlab.example.com/team/repo/-/issues/123", "123"},
 		{"https://gitlab.com/group/project/-/work_items/42", "42"},
+		{"https://gitlab.com/group/project/-/milestones/4", "milestone:4"},
 		{"not-a-url", ""},
 		// Shorthand format
 		{"gitlab:681509", "681509"},

--- a/internal/gitlab/types.go
+++ b/internal/gitlab/types.go
@@ -139,6 +139,7 @@ type Label struct {
 type IssueLink struct {
 	SourceIssue *Issue `json:"source_issue"`
 	TargetIssue *Issue `json:"target_issue"`
+	IID         int    `json:"iid,omitempty"`
 	LinkType    string `json:"link_type"` // "relates_to", "blocks", "is_blocked_by"
 }
 

--- a/internal/tracker/engine.go
+++ b/internal/tracker/engine.go
@@ -969,6 +969,12 @@ func (e *Engine) doPush(ctx context.Context, opts SyncOptions, skipIDs, forceIDs
 				// Note: issue WAS created externally, so we still count Created
 				// but also flag the error so the user knows the link is broken
 			}
+			// Surface any partial-success warnings from the create (e.g. a
+			// follow-up state change that failed) through the sync result so a
+			// degraded push is visible rather than silently swallowed.
+			for _, w := range created.Warnings {
+				e.warn("%s (%s)", w, issue.ID)
+			}
 			stats.Created++
 		} else if !opts.CreateOnly || forceIDs[issue.ID] {
 			// Update existing external issue

--- a/internal/tracker/types.go
+++ b/internal/tracker/types.go
@@ -44,6 +44,12 @@ type TrackerIssue struct {
 	ParentID         string // Parent issue identifier (for subtasks/children)
 	ParentInternalID string // Parent issue internal ID
 
+	// Warnings carries non-fatal, partial-success messages from a create/update
+	// (e.g. the issue was created but a follow-up state change failed). The sync
+	// engine drains these into the sync result's warnings so a degraded push is
+	// visible in --json output instead of being silently swallowed.
+	Warnings []string
+
 	// Raw data for tracker-specific processing
 	Raw interface{} // Original API response for tracker-specific access
 


### PR DESCRIPTION
After issue content syncs, mirror local beads dependency edges as GitLab issue links: blocks -> GitLab blocks/is_blocked_by (direction-normalized), related/relates-to -> a single relates_to link per unordered pair (deduped). Children of synced epics also keep the epic's milestone during a dependency-only sync. Reports links_pushed in --json.

Additive only (never deletes remote links). License-aware: blocks/ is_blocked_by needs GitLab Premium/Ultimate; on instances without it the link is reported as a single curated, non-fatal message (links_license_skipped in JSON) while relates_to and milestones still apply. Genuine (non-license) link failures remain real warnings, kept distinct from the license case.

## What

`bd gitlab sync` now pushes beads **dependency relationships** to GitLab as issue
links — not just issue content. After content syncs, each edge becomes the matching
GitLab link:

| beads edge | GitLab link |
|---|---|
| `A blocks B` | `A` **blocks** `B` / `B` **is blocked by** `A` |
| `A related-to C` | `A` **relates to** `C` (single link, deduped) |

It also keeps issues under an epic pointed at that epic's milestone during a
dependency-only sync. `links_pushed` is reported in `--json`.

## Why

The current sync mirrors titles/descriptions/state but drops the structure *between* issues,
so GitLab boards and reviewers can't see what blocks what. This makes the beads
dependency graph first-class in GitLab.

## Scope & design

- **Additive** — only creates missing links, never deletes (stale-link pruning is a
  deliberate follow-up, so we don't clobber links added by hand in GitLab).
- **License-aware & transparent** — `blocks`/`is_blocked_by` requires GitLab
  Premium/Ultimate. Where it's unavailable, those links are reported once as a clear,
  non-fatal message (and `links_license_skipped` in `--json`) while `relates_to` and
  milestones still apply. Genuine (non-license) link failures remain real warnings.
- **Unsupported `blocks` is omitted, not downgraded to `relates_to`.** A fallback might
  seem better than nothing, but it would harm the bidirectional sync: the pull side
  imports GitLab links back into beads dependencies, and an issue link carries no
  metadata, so a fallback `relates_to` is indistinguishable from a genuine one on the
  next pull. It would be written back as a beads `related` edge — silently corrupting
  the source-of-truth dependency graph and dropping the `blocks` direction. It would
  also assert a misleading relationship to anyone reading GitLab, and (since the sync is
  additive) linger after a license upgrade alongside the real `blocks` link. Omitting
  keeps the beads graph clean and is fully reversible: enable the license, re-sync, and
  `blocks` links appear with nothing to undo.
- **Out of scope** — GitLab Epic/work-item hierarchy, cross-project links, stale-link
  removal.

## Verification

- `go test ./internal/gitlab/... ./cmd/bd/` — direction normalization, `relates_to`
  dedup, link idempotency, the epic-milestone pass, and the license paths (license-403
  → graceful skip with `relates_to` still applied; non-license error → surfaced as a
  genuine failure).
- Validated against a live GitLab.com (Ultimate) project and a self-hosted instance:
  correct link direction, `relates_to` deduped to one link, epic milestone applied,
  `--dry-run` writes nothing, re-sync creates nothing new; on the unlicensed instance
  the `blocks` links degrade to the curated non-fatal message while `relates_to` and
  milestones sync normally.
