### PR TITLE
fix(dolt): distinguish a real dolt repo from the sql-server runtime dir

### DIFF
--- a/internal/storage/dolt/federation.go
+++ b/internal/storage/dolt/federation.go
@@ -180,6 +180,23 @@ func (s *DoltStore) syncCLIRemotesToSQL(ctx context.Context) {
 	}
 }
 
+// rootDirHasDoltRepo reports whether rootDir contains a dolt repository
+// initialized via `dolt init`. It is distinguished from a directory that
+// merely contains the sql-server's runtime files (e.g.
+// `.dolt/sql-server.info`).
+//
+// A real dolt repo always has `.dolt/repo_state.json` after `dolt init`.
+// The dolt sql-server, when its data_dir points at the server root, creates
+// only `.dolt/sql-server.info` for its own runtime state. The earlier check
+// `os.Stat(rootDir/.dolt)` could not distinguish the two and fell through
+// to a 5–7 s `dolt remote -v` walk that errored out with "not a valid
+// dolt repository" — wedging the gascity reconciler tick on every bd write
+// from the city root.
+func rootDirHasDoltRepo(rootDir string) bool {
+	_, err := os.Stat(filepath.Join(rootDir, ".dolt", "repo_state.json"))
+	return err == nil
+}
+
 // migrateServerRootRemotes checks the dolt server root directory (dbPath) for
 // remotes that should be propagated to the database CLI directory (CLIDir).
 // This handles GH#2118: users run `dolt remote add` in .beads/dolt/ (server root)
@@ -191,8 +208,7 @@ func (s *DoltStore) migrateServerRootRemotes(cliDir string) []storage.RemoteInfo
 	if rootDir == "" || rootDir == cliDir {
 		return nil
 	}
-	// Server root must have .dolt/ (from dolt init)
-	if _, err := os.Stat(filepath.Join(rootDir, ".dolt")); err != nil {
+	if !rootDirHasDoltRepo(rootDir) {
 		return nil
 	}
 	rootRemotes, err := doltutil.ListCLIRemotes(rootDir)

--- a/internal/storage/dolt/federation_repo_check_test.go
+++ b/internal/storage/dolt/federation_repo_check_test.go
@@ -1,0 +1,96 @@
+package dolt
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestRootDirHasDoltRepo verifies the discriminator that distinguishes a
+// real dolt repository (initialized via `dolt init`) from a directory that
+// merely contains the dolt sql-server's runtime files.
+//
+// Regression context: the dolt sql-server, when its `data_dir` points at
+// the bead store's server root, writes `.dolt/sql-server.info` for its
+// own runtime state. The previous check in migrateServerRootRemotes
+// stat'd only `.dolt/` and so treated this runtime directory as a real
+// repo, falling through to a 5–7 s `dolt remote -v` invocation on every
+// bd write — wedging the gascity reconciler tick.
+func TestRootDirHasDoltRepo(t *testing.T) {
+	cases := []struct {
+		name     string
+		setup    func(t *testing.T, dir string)
+		wantRepo bool
+	}{
+		{
+			name:     "no_dolt_directory",
+			setup:    func(t *testing.T, dir string) {},
+			wantRepo: false,
+		},
+		{
+			name: "sql_server_runtime_only_regression",
+			setup: func(t *testing.T, dir string) {
+				dolt := filepath.Join(dir, ".dolt")
+				if err := os.MkdirAll(dolt, 0o755); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(filepath.Join(dolt, "sql-server.info"), []byte("port=12345\n"), 0o644); err != nil {
+					t.Fatal(err)
+				}
+			},
+			wantRepo: false,
+		},
+		{
+			name: "partial_init_config_only_no_repo_state",
+			setup: func(t *testing.T, dir string) {
+				dolt := filepath.Join(dir, ".dolt")
+				if err := os.MkdirAll(dolt, 0o755); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(filepath.Join(dolt, "config.json"), []byte("{}"), 0o644); err != nil {
+					t.Fatal(err)
+				}
+			},
+			wantRepo: false,
+		},
+		{
+			name: "real_dolt_repo_with_repo_state",
+			setup: func(t *testing.T, dir string) {
+				dolt := filepath.Join(dir, ".dolt")
+				if err := os.MkdirAll(dolt, 0o755); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(filepath.Join(dolt, "repo_state.json"), []byte(`{"head":"refs/heads/main"}`), 0o644); err != nil {
+					t.Fatal(err)
+				}
+			},
+			wantRepo: true,
+		},
+		{
+			name: "real_dolt_repo_alongside_sql_server_info",
+			setup: func(t *testing.T, dir string) {
+				dolt := filepath.Join(dir, ".dolt")
+				if err := os.MkdirAll(dolt, 0o755); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(filepath.Join(dolt, "repo_state.json"), []byte(`{"head":"refs/heads/main"}`), 0o644); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(filepath.Join(dolt, "sql-server.info"), []byte("port=12345\n"), 0o644); err != nil {
+					t.Fatal(err)
+				}
+			},
+			wantRepo: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			tc.setup(t, dir)
+			got := rootDirHasDoltRepo(dir)
+			if got != tc.wantRepo {
+				t.Errorf("rootDirHasDoltRepo(%q) = %v, want %v", dir, got, tc.wantRepo)
+			}
+		})
+	}
+}


### PR DESCRIPTION


<!--
This is a starting scaffold to help reviewers (human and agent) parse intent before diff.
Replace, expand, or delete sections freely. CONTRIBUTING.md has the full hygiene rules.
-->

## What

<!-- One or two plain-language sentences: what does this change do? -->
Add rootDirHasDoltRepo(), keyed on `.dolt/repo_state.json` (written by `dolt init`, absent for a bare sql-server runtime dir), and gate the remote migration on it.

## Why

<!-- The problem this solves, the motivation, or a link to the issue: e.g. "Fixes #123" -->
migrateServerRootRemotes checked only for `.dolt/` existence to decide whether the server root holds a dolt repo. The dolt sql-server, when its data_dir points at the bead store server root, writes `.dolt/sql-server.info` for its own runtime state — so the `.dolt/` check matched a non-repo directory, fell through to a 5–7s `dolt remote -v` walk that errored "not a valid dolt repository", and wedged the gascity reconciler tick on every bd write from the city root.

## Verification

<!-- How you tested. Commands a reviewer can run to confirm. -->
Test: TestRootDirHasDoltRepo covers no-.dolt, sql-server-runtime-only, and real-repo cases — green.

