### PR TITLE
docs: publish community tools on website

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -6,6 +6,8 @@ on:
       - main
     paths:
       - 'website/**'
+      - 'docs/COMMUNITY_TOOLS.md'
+      - 'scripts/sync-website-docs.sh'
       - 'scripts/generate-llms-full.sh'
   workflow_dispatch:
 

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -6,7 +6,12 @@ on:
       - main
     paths:
       - 'website/**'
+      - 'docs/ANTIVIRUS.md'
       - 'docs/COMMUNITY_TOOLS.md'
+      - 'docs/LABELS.md'
+      - 'docs/METADATA.md'
+      - 'docs/SYNC_CONCEPTS.md'
+      - 'docs/UNINSTALLING.md'
       - 'scripts/sync-website-docs.sh'
       - 'scripts/generate-llms-full.sh'
   workflow_dispatch:

--- a/docs/METADATA.md
+++ b/docs/METADATA.md
@@ -42,28 +42,27 @@ Do not add a first-class helper such as `bd show <id> --execution` or
 issue gh-3541 determines whether schedulers or runners need these fields as a
 stable CLI surface.
 
-## Example: Verification Metadata
+## Example: Tracker Round-Trip Metadata
 
-Local verification queues are another example of metadata as an extension
-point. They may store slow-suite state in issue metadata. These keys describe
-the validation gate for a specific candidate commit:
+Tracker integrations map external issues into beads fields such as title,
+status, priority, type, labels, dependencies, and `external_ref`. When an
+integration needs to preserve tracker-specific fields that do not belong in the
+native beads schema, it can store those fields in issue metadata:
 
-| Key | Meaning |
-|-----|---------|
-| `verify_state` | Verification state: `queued`, `running`, `passed`, or `failed`. |
-| `verify_head` | Commit SHA that the verification result applies to. |
-| `verify_branch` | Branch name recorded when verification was queued. |
-| `verify_cmd` | Command run in the clean verification worktree. |
-| `verify_log` | Local path to the verifier log. |
-| `verify_result` | Compact result, such as `exit=0` or `exit=1`. |
-| `verify_enqueued_at` | UTC timestamp when the verification was queued. |
-| `verify_started_at` | UTC timestamp when the verification started. |
-| `verify_finished_at` | UTC timestamp when the verification finished. |
-| `verify_worktree` | Source or clean verification worktree path. |
-| `verify_runner` | Local verifier identity, usually `host:pid`. |
+```json
+{
+  "example_tracker": {
+    "board_id": "ENG",
+    "sprint_id": 42,
+    "remote_type": "story"
+  }
+}
+```
 
-Treat `verify_head` as the source of truth. A passing result gates that exact
-commit only; if the branch moves, enqueue verification again.
+This keeps beads' core issue model stable while allowing the integration to
+round-trip fields it understands. Prefer namespaced keys and keep
+tracker-specific policy in the integration. If a value becomes broadly useful
+to beads itself, revisit whether it deserves a native field.
 
 ## Reserved Key Prefixes
 

--- a/scripts/ci/website.sh
+++ b/scripts/ci/website.sh
@@ -25,12 +25,18 @@ generate_llms_full() {
     ./scripts/generate-llms-full.sh
 }
 
+sync_website_docs() {
+    cd "$REPO_ROOT"
+    ./scripts/sync-website-docs.sh
+}
+
 website_build() {
     cd "$WEBSITE_DIR"
     npm run build
 }
 
 ci_time "website npm ci" -- website_npm_ci
+ci_time "sync website docs" -- sync_website_docs
 ci_time "website typecheck" -- website_typecheck
 ci_time "generate llms-full" -- generate_llms_full
 ci_time "website build" -- website_build

--- a/scripts/generate-llms-full.sh
+++ b/scripts/generate-llms-full.sh
@@ -131,7 +131,29 @@ if [ -f "$DOCS_DIR/intro.md" ]; then
 fi
 
 # Process directories in logical order
-for dir in getting-started core-concepts architecture cli-reference workflows multi-agent integrations recovery reference; do
+for dir in getting-started core-concepts architecture cli-reference workflows multi-agent integrations; do
+    if [ -d "$DOCS_DIR/$dir" ]; then
+        # Process index first if exists
+        if [ -f "$DOCS_DIR/$dir/index.md" ]; then
+            process_file "$DOCS_DIR/$dir/index.md"
+        fi
+
+        # Process other files
+        for file in "$DOCS_DIR/$dir"/*.md; do
+            if [ -f "$file" ] && [ "$(basename "$file")" != "index.md" ]; then
+                process_file "$file"
+            fi
+        done
+    fi
+done
+
+for doc in community-tools; do
+    if [ -f "$DOCS_DIR/$doc.md" ]; then
+        process_file "$DOCS_DIR/$doc.md"
+    fi
+done
+
+for dir in recovery reference; do
     if [ -d "$DOCS_DIR/$dir" ]; then
         # Process index first if exists
         if [ -f "$DOCS_DIR/$dir/index.md" ]; then

--- a/scripts/sync-website-docs.sh
+++ b/scripts/sync-website-docs.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Mirror selected root documentation into the Docusaurus website tree.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+write_doc() {
+    local source="$1"
+    local target="$2"
+    local id="$3"
+    local title="$4"
+    local slug="$5"
+
+    if [[ ! -f "$source" ]]; then
+        echo "missing source doc: $source" >&2
+        exit 1
+    fi
+
+    mkdir -p "$(dirname "$target")"
+    {
+        cat <<EOF
+---
+id: $id
+title: $title
+slug: $slug
+---
+
+EOF
+        cat "$source"
+    } > "$target"
+}
+
+write_doc \
+    "$REPO_ROOT/docs/COMMUNITY_TOOLS.md" \
+    "$REPO_ROOT/website/docs/community-tools.md" \
+    "community-tools" \
+    "Community Tools" \
+    "/community-tools"
+
+latest_version="$(grep -oE '"[0-9][^"]*"' "$REPO_ROOT/website/versions.json" 2>/dev/null | head -1 | tr -d '"' || true)"
+if [[ -n "$latest_version" && -d "$REPO_ROOT/website/versioned_docs/version-$latest_version" ]]; then
+    write_doc \
+        "$REPO_ROOT/docs/COMMUNITY_TOOLS.md" \
+        "$REPO_ROOT/website/versioned_docs/version-$latest_version/community-tools.md" \
+        "community-tools" \
+        "Community Tools" \
+        "/community-tools"
+
+    sidebar="$REPO_ROOT/website/versioned_sidebars/version-$latest_version-sidebars.json"
+    if [[ -f "$sidebar" ]]; then
+        node - "$sidebar" <<'JS'
+const fs = require('fs');
+
+const sidebarPath = process.argv[2];
+const data = JSON.parse(fs.readFileSync(sidebarPath, 'utf8'));
+const items = data.docsSidebar;
+
+if (!items.includes('community-tools')) {
+  const referenceIndex = items.findIndex(
+    item => item && typeof item === 'object' && item.label === 'Reference'
+  );
+  const insertAt = referenceIndex === -1 ? items.length : referenceIndex;
+  items.splice(insertAt, 0, 'community-tools');
+  fs.writeFileSync(sidebarPath, `${JSON.stringify(data, null, 2)}\n`);
+}
+JS
+    fi
+fi

--- a/scripts/sync-website-docs.sh
+++ b/scripts/sync-website-docs.sh
@@ -28,25 +28,64 @@ slug: $slug
 ---
 
 EOF
-        cat "$source"
+        rewrite_links "$source"
     } > "$target"
 }
 
-write_doc \
-    "$REPO_ROOT/docs/COMMUNITY_TOOLS.md" \
-    "$REPO_ROOT/website/docs/community-tools.md" \
-    "community-tools" \
-    "Community Tools" \
-    "/community-tools"
+rewrite_links() {
+    local source="$1"
+
+    case "${source#$REPO_ROOT/}" in
+        docs/LABELS.md)
+            sed \
+                -e 's@](CLI_REFERENCE.md#state-labels-as-cache)@](/cli-reference/set-state)@g' \
+                -e 's#](../README.md#](https://github.com/gastownhall/beads/blob/main/README.md#g' \
+                -e 's#](../AGENTS.md#](https://github.com/gastownhall/beads/blob/main/AGENTS.md#g' \
+                -e 's#](ADVANCED.md#](/reference/advanced#g' \
+                "$source"
+            ;;
+        docs/METADATA.md)
+            sed \
+                -e 's#](PROJECT_CHARTER.md#](https://github.com/gastownhall/beads/blob/main/docs/PROJECT_CHARTER.md#g' \
+                "$source"
+            ;;
+        *)
+            cat "$source"
+            ;;
+    esac
+}
+
+doc_specs=(
+    "docs/SYNC_CONCEPTS.md|website/docs/core-concepts/sync-concepts.md|sync-concepts|Sync Concepts|/core-concepts/sync-concepts"
+    "docs/LABELS.md|website/docs/core-concepts/labels.md|labels|Labels|/core-concepts/labels"
+    "docs/METADATA.md|website/docs/core-concepts/metadata.md|metadata|Issue Metadata|/core-concepts/metadata"
+    "docs/UNINSTALLING.md|website/docs/recovery/uninstalling.md|uninstalling|Uninstalling|/recovery/uninstalling"
+    "docs/ANTIVIRUS.md|website/docs/reference/antivirus.md|antivirus|Antivirus False Positives|/reference/antivirus"
+    "docs/COMMUNITY_TOOLS.md|website/docs/community-tools.md|community-tools|Community Tools|/community-tools"
+)
+
+for spec in "${doc_specs[@]}"; do
+    IFS='|' read -r source target id title slug <<<"$spec"
+    write_doc \
+        "$REPO_ROOT/$source" \
+        "$REPO_ROOT/$target" \
+        "$id" \
+        "$title" \
+        "$slug"
+done
 
 latest_version="$(grep -oE '"[0-9][^"]*"' "$REPO_ROOT/website/versions.json" 2>/dev/null | head -1 | tr -d '"' || true)"
 if [[ -n "$latest_version" && -d "$REPO_ROOT/website/versioned_docs/version-$latest_version" ]]; then
-    write_doc \
-        "$REPO_ROOT/docs/COMMUNITY_TOOLS.md" \
-        "$REPO_ROOT/website/versioned_docs/version-$latest_version/community-tools.md" \
-        "community-tools" \
-        "Community Tools" \
-        "/community-tools"
+    for spec in "${doc_specs[@]}"; do
+        IFS='|' read -r source target id title slug <<<"$spec"
+        versioned_target="${target#website/docs/}"
+        write_doc \
+            "$REPO_ROOT/$source" \
+            "$REPO_ROOT/website/versioned_docs/version-$latest_version/$versioned_target" \
+            "$id" \
+            "$title" \
+            "$slug"
+    done
 
     sidebar="$REPO_ROOT/website/versioned_sidebars/version-$latest_version-sidebars.json"
     if [[ -f "$sidebar" ]]; then
@@ -57,14 +96,31 @@ const sidebarPath = process.argv[2];
 const data = JSON.parse(fs.readFileSync(sidebarPath, 'utf8'));
 const items = data.docsSidebar;
 
+function category(label) {
+  return items.find(item => item && typeof item === 'object' && item.label === label);
+}
+
+function insertAfter(list, after, id) {
+  if (list.includes(id)) return;
+  const index = list.indexOf(after);
+  list.splice(index === -1 ? list.length : index + 1, 0, id);
+}
+
+insertAfter(category('Core Concepts').items, 'core-concepts/hash-ids', 'core-concepts/sync-concepts');
+insertAfter(category('Core Concepts').items, 'core-concepts/sync-concepts', 'core-concepts/labels');
+insertAfter(category('Core Concepts').items, 'core-concepts/labels', 'core-concepts/metadata');
+insertAfter(category('Recovery').items, 'recovery/sync-failures', 'recovery/uninstalling');
+insertAfter(category('Reference').items, 'reference/troubleshooting', 'reference/antivirus');
+
 if (!items.includes('community-tools')) {
   const referenceIndex = items.findIndex(
     item => item && typeof item === 'object' && item.label === 'Reference'
   );
   const insertAt = referenceIndex === -1 ? items.length : referenceIndex;
   items.splice(insertAt, 0, 'community-tools');
-  fs.writeFileSync(sidebarPath, `${JSON.stringify(data, null, 2)}\n`);
 }
+
+fs.writeFileSync(sidebarPath, `${JSON.stringify(data, null, 2)}\n`);
 JS
     fi
 fi

--- a/website/docs/community-tools.md
+++ b/website/docs/community-tools.md
@@ -1,3 +1,9 @@
+---
+id: community-tools
+title: Community Tools
+slug: /community-tools
+---
+
 # Beads Community Tools
 
 A curated list of community-built UIs, extensions, and integrations for Beads. Ranked by activity and maturity.

--- a/website/docs/core-concepts/labels.md
+++ b/website/docs/core-concepts/labels.md
@@ -1,0 +1,789 @@
+---
+id: labels
+title: Labels
+slug: /core-concepts/labels
+---
+
+# Labels in Beads
+
+Labels provide flexible, multi-dimensional categorization for issues beyond the structured fields (status, priority, type). Use labels for cross-cutting concerns, technical metadata, and contextual tagging without schema changes.
+
+## Design Philosophy
+
+**When to use labels vs. structured fields:**
+
+- **Structured fields** (status, priority, type) → Core workflow state
+  - Status: Where the issue is in the workflow (`open`, `in_progress`, `blocked`, `closed`)
+  - Priority: How urgent (0-4)
+  - Type: What kind of work (`bug`, `feature`, `task`, `epic`, `chore`)
+
+- **Labels** → Everything else
+  - Technical metadata (`backend`, `frontend`, `api`, `database`)
+  - Domain/scope (`auth`, `payments`, `search`, `analytics`)
+  - Effort estimates (`small`, `medium`, `large`)
+  - Quality gates (`needs-review`, `needs-tests`, `breaking-change`)
+  - Team/ownership (`team-infra`, `team-product`)
+  - Release tracking (`v1.0`, `v2.0`, `backport-candidate`)
+
+## Quick Start
+
+```bash
+# Add labels when creating issues
+bd create "Fix auth bug" -t bug -p 1 -l auth,backend,urgent
+
+# Add labels to existing issues
+bd label add bd-42 security
+bd label add bd-42 breaking-change
+
+# List issue labels
+bd label list bd-42
+
+# Remove a label
+bd label remove bd-42 urgent
+
+# List all labels in use
+bd label list-all
+
+# Filter by labels (AND - must have ALL)
+bd list --label backend,auth
+
+# Filter by labels (OR - must have AT LEAST ONE)
+bd list --label-any frontend,backend
+
+# Combine filters
+bd list --status open --priority 1 --label security
+```
+
+## Common Label Patterns
+
+### 1. Technical Component Labels
+
+Identify which part of the system:
+```bash
+backend
+frontend
+api
+database
+infrastructure
+cli
+ui
+mobile
+```
+
+**Example:**
+```bash
+bd create "Add GraphQL endpoint" -t feature -p 2 -l backend,api
+bd create "Update login form" -t task -p 2 -l frontend,auth,ui
+```
+
+### 2. Domain/Feature Area
+
+Group by business domain:
+```bash
+auth
+payments
+search
+analytics
+billing
+notifications
+reporting
+admin
+```
+
+**Example:**
+```bash
+bd list --label payments --status open  # All open payment issues
+bd list --label-any auth,security       # Security-related work
+```
+
+### 3. Size/Effort Estimates
+
+Quick effort indicators:
+```bash
+small     # < 1 day
+medium    # 1-3 days
+large     # > 3 days
+```
+
+**Example:**
+```bash
+# Find small quick wins
+bd ready --json | jq '.[] | select(.labels[] == "small")'
+```
+
+### 4. Quality Gates
+
+Track what's needed before closing:
+```bash
+needs-review
+needs-tests
+needs-docs
+breaking-change
+```
+
+**Example:**
+```bash
+bd label add bd-42 needs-review
+bd list --label needs-review --status in_progress
+```
+
+### 5. Release Management
+
+Track release targeting:
+```bash
+v1.0
+v2.0
+backport-candidate
+release-blocker
+```
+
+**Example:**
+```bash
+bd list --label v1.0 --status open    # What's left for v1.0?
+bd label add bd-42 release-blocker
+```
+
+### 6. Team/Ownership
+
+Indicate ownership or interest:
+```bash
+team-infra
+team-product
+team-mobile
+needs-triage
+help-wanted
+```
+
+**Example:**
+```bash
+bd list --assignee alice --label team-infra
+bd create "Memory leak in cache" -t bug -p 1 -l team-infra,help-wanted
+```
+
+### 7. Special Markers
+
+Process or workflow flags:
+```bash
+auto-generated     # Created by automation
+discovered-from    # Found during other work (also a dep type)
+technical-debt
+good-first-issue
+duplicate
+wontfix
+```
+
+**Example:**
+```bash
+bd create "TODO: Refactor parser" -t chore -p 3 -l technical-debt,auto-generated
+```
+
+## Filtering by Labels
+
+### AND Filtering (--label)
+All specified labels must be present:
+
+```bash
+# Issues that are BOTH backend AND urgent
+bd list --label backend,urgent
+
+# Open bugs that need review AND tests
+bd list --status open --type bug --label needs-review,needs-tests
+```
+
+### OR Filtering (--label-any)
+At least one specified label must be present:
+
+```bash
+# Issues in frontend OR backend
+bd list --label-any frontend,backend
+
+# Security or auth related
+bd list --label-any security,auth
+```
+
+### Combining AND/OR
+Mix both filters for complex queries:
+
+```bash
+# Backend issues that are EITHER urgent OR a blocker
+bd list --label backend --label-any urgent,release-blocker
+
+# Frontend work that needs BOTH review and tests, but in any component
+bd list --label needs-review,needs-tests --label-any frontend,ui,mobile
+```
+
+## Workflow Examples
+
+### Triage Workflow
+```bash
+# Create untriaged issue
+bd create "Crash on login" -t bug -p 1 -l needs-triage
+
+# During triage, add context
+bd label add bd-42 auth
+bd label add bd-42 backend
+bd label add bd-42 urgent
+bd label remove bd-42 needs-triage
+
+# Find untriaged issues
+bd list --label needs-triage
+```
+
+### Quality Gate Workflow
+```bash
+# Start work
+bd update bd-42 --claim
+
+# Mark quality requirements
+bd label add bd-42 needs-tests
+bd label add bd-42 needs-docs
+
+# Before closing, verify
+bd label list bd-42
+# ... write tests and docs ...
+bd label remove bd-42 needs-tests
+bd label remove bd-42 needs-docs
+
+# Close when gates satisfied
+bd close bd-42
+```
+
+### Release Planning
+```bash
+# Tag issues for v1.0
+bd label add bd-42 v1.0
+bd label add bd-43 v1.0
+bd label add bd-44 v1.0
+
+# Track v1.0 progress
+bd list --label v1.0 --status closed    # Done
+bd list --label v1.0 --status open      # Remaining
+bd stats  # Overall progress
+
+# Mark critical items
+bd label add bd-45 v1.0
+bd label add bd-45 release-blocker
+```
+
+### Component-Based Work Distribution
+```bash
+# Backend team picks up work
+bd ready --json | jq '.[] | select(.labels[]? == "backend")'
+
+# Frontend team finds small tasks
+bd list --status open --label frontend,small
+
+# Find help-wanted items for new contributors
+bd list --label help-wanted,good-first-issue
+```
+
+## Label Management
+
+### Listing Labels
+```bash
+# Labels on a specific issue
+bd label list bd-42
+
+# All labels in database with usage counts
+bd label list-all
+
+# JSON output for scripting
+bd label list-all --json
+```
+
+Output:
+```json
+[
+  {"label": "auth", "count": 5},
+  {"label": "backend", "count": 12},
+  {"label": "frontend", "count": 8}
+]
+```
+
+### Bulk Operations
+
+Add labels in batch during creation:
+```bash
+bd create "Issue" -l label1,label2,label3
+```
+
+Script to add label to multiple issues:
+```bash
+# Add "needs-review" to all in_progress issues
+bd list --status in_progress --json | jq -r '.[].id' | while read id; do
+  bd label add "$id" needs-review
+done
+```
+
+Remove label from multiple issues:
+```bash
+# Remove "urgent" from closed issues
+bd list --status closed --label urgent --json | jq -r '.[].id' | while read id; do
+  bd label remove "$id" urgent
+done
+```
+
+## Integration with Git Workflow
+
+Labels are stored in the Dolt database and synced automatically with all issue data:
+
+```bash
+# Make changes
+bd create "Fix bug" -l backend,urgent
+bd label add bd-42 needs-review
+
+# Changes are committed to Dolt history automatically
+# Sync with remotes when ready:
+bd dolt push
+
+# After pulling changes:
+bd dolt pull
+bd list --label backend  # Fresh data including labels
+```
+
+## Markdown Import/Export
+
+Labels are preserved when importing from markdown:
+
+```markdown
+# Fix Authentication Bug
+
+### Type
+bug
+
+### Priority
+1
+
+### Labels
+auth, backend, urgent, needs-review
+
+### Description
+Users can't log in after recent deployment.
+```
+
+```bash
+bd create -f issue.md
+# Creates issue with all four labels
+```
+
+## Best Practices
+
+### 1. Establish Conventions Early
+Document your team's label taxonomy:
+```bash
+# Add to project README or CONTRIBUTING.md
+- Use lowercase, hyphen-separated (e.g., `good-first-issue`)
+- Prefix team labels (e.g., `team-infra`, `team-product`)
+- Use consistent size labels (`small`, `medium`, `large`)
+```
+
+### 2. Don't Overuse Labels
+Labels are flexible, but too many can cause confusion. Prefer:
+- 5-10 core technical labels (`backend`, `frontend`, `api`, etc.)
+- 3-5 domain labels per project
+- Standard process labels (`needs-review`, `needs-tests`)
+- Release labels as needed
+
+### 3. Clean Up Unused Labels
+Periodically review:
+```bash
+bd label list-all
+# Remove obsolete labels from issues
+```
+
+### 4. Use Labels for Filtering, Not Search
+Labels are for categorization, not free-text search:
+- ✅ Good: `backend`, `auth`, `urgent`
+- ❌ Bad: `fix-the-login-bug`, `john-asked-for-this`
+
+### 5. Combine with Dependencies
+Labels + dependencies = powerful organization:
+```bash
+# Epic with labeled subtasks
+bd create "Auth system rewrite" -t epic -p 1 -l auth,v2.0
+bd create "Implement JWT" -t task -p 1 -l auth,backend --deps parent-child:bd-42
+bd create "Update login UI" -t task -p 1 -l auth,frontend --deps parent-child:bd-42
+
+# Find all v2.0 auth work
+bd list --label auth,v2.0
+```
+
+## AI Agent Usage
+
+Labels are especially useful for AI agents managing complex workflows:
+
+```bash
+# Auto-label discovered work
+bd create "Found TODO in auth.go" -t task -p 2 -l auto-generated,technical-debt
+
+# Filter for agent review
+bd list --label needs-review --status in_progress --json
+
+# Track automation metadata
+bd label add bd-42 ai-generated
+bd label add bd-42 needs-human-review
+```
+
+Example agent workflow:
+```bash
+# Agent discovers issues during refactor
+bd create "Extract validateToken function" -t chore -p 2 \
+  -l technical-debt,backend,auth,small \
+  --deps discovered-from:bd-10
+
+# Agent marks work for review
+bd update bd-42 --claim
+# ... agent does work ...
+bd label add bd-42 needs-review
+bd label add bd-42 ai-generated
+
+# Human reviews and approves
+bd label remove bd-42 needs-review
+bd label add bd-42 approved
+bd close bd-42
+```
+
+## Labels as State Cache
+
+Labels can cache operational state for fast queries, enabling patterns where beads track both immutable history (events) and current state (labels).
+
+### The Pattern
+
+**Convention:** `<dimension>:<value>`
+
+Examples:
+- `patrol:muted` / `patrol:active` - patrol suppression state
+- `mode:degraded` / `mode:normal` - operational mode
+- `status:idle` / `status:working` - worker status
+- `health:healthy` / `health:failing` - component health
+
+**Implementation:**
+1. Create an event bead (full context, immutable history)
+2. Update the role bead's labels (current state cache)
+
+```bash
+# Event: Full record of what happened and why
+bd create "Muted patrol: user requested during debugging" -t event \
+  -l event-type:patrol-muted,actor:observer,reason:user-request
+
+# State: Update the role bead's label to reflect current state
+bd label remove beads/observer patrol:active
+bd label add beads/observer patrol:muted
+```
+
+**Key principle:** Events are the source of truth. Labels are a cache for fast queries.
+
+### Why This Pattern?
+
+**Fast queries without event scanning:**
+```bash
+# Without labels-as-state: scan all events to find current patrol state
+bd list --type event | grep "patrol" | tail -1  # Slow, fragile
+
+# With labels-as-state: direct query
+bd show beads/observer | grep "patrol:"  # Instant
+```
+
+**History preserved:**
+```bash
+# When was patrol muted? Why? Who did it?
+bd list --label event-type:patrol-muted --type event
+```
+
+**State recovery:**
+```bash
+# If labels get corrupted, rebuild from events
+bd list --type event --label event-type:patrol-muted | tail -1
+# Then re-apply the label
+```
+
+### Common State Dimensions
+
+| Dimension | Values | Use Case |
+|-----------|--------|----------|
+| `patrol:` | `active`, `muted` | Patrol cycle suppression |
+| `mode:` | `normal`, `degraded`, `maintenance` | Operational mode |
+| `status:` | `idle`, `working`, `blocked` | Worker activity |
+| `health:` | `healthy`, `warning`, `failing` | Component health |
+| `lock:` | `unlocked`, `locked` | Exclusive access control |
+
+### State Transitions
+
+Always create an event before changing state labels:
+
+```bash
+# Function to transition state with audit trail
+transition_state() {
+  local role="$1"
+  local dimension="$2"
+  local old_value="$3"
+  local new_value="$4"
+  local reason="$5"
+
+  # Record the transition
+  bd create "State change: $dimension $old_value → $new_value" -t event \
+    -l "event-type:state-change,dimension:$dimension,from:$old_value,to:$new_value"
+
+  # Update the cache
+  bd label remove "$role" "$dimension:$old_value"
+  bd label add "$role" "$dimension:$new_value"
+}
+
+# Usage
+transition_state beads/observer patrol active muted "User debugging session"
+```
+
+### Querying State
+
+```bash
+# Current state of a role
+bd label list beads/observer | grep ":"
+
+# All roles in a specific state
+bd list --label patrol:muted
+
+# Roles NOT in expected state
+bd list --label-any mode:degraded,health:failing
+
+# History of state changes
+bd list --type event --label event-type:state-change
+```
+
+### Best Practices
+
+1. **Use namespaced dimensions** - Prefix with role type if ambiguous
+2. **Keep value sets small** - 2-4 values per dimension
+3. **Document valid values** - List allowed values in role docs
+4. **Always create events first** - Never update labels without history
+5. **Treat labels as ephemeral** - Rebuild from events if corrupted
+
+### Future Helpers
+
+The pattern suggests helper commands (see bd-7l67):
+```bash
+# Query current state
+bd state beads/observer patrol     # → "muted"
+
+# Transition with automatic event creation
+bd set-state beads/observer patrol=active --reason "Debugging complete"
+```
+
+Until helpers exist, use the manual pattern above.
+
+## Advanced Patterns
+
+### Component Matrix
+Track issues across multiple dimensions:
+```bash
+# Backend + auth + high priority
+bd list --label backend,auth --priority 1
+
+# Any frontend work that's small
+bd list --label-any frontend,ui --label small
+
+# Critical issues across all components
+bd list --priority 0 --label-any backend,frontend,infrastructure
+```
+
+### Sprint Planning
+```bash
+# Label issues for sprint
+for id in bd-42 bd-43 bd-44 bd-45; do
+  bd label add "$id" sprint-12
+done
+
+# Track sprint progress
+bd list --label sprint-12 --status closed    # Velocity
+bd list --label sprint-12 --status open      # Remaining
+bd stats | grep "In Progress"                # Current WIP
+```
+
+### Technical Debt Tracking
+```bash
+# Mark debt
+bd create "Refactor legacy parser" -t chore -p 3 -l technical-debt,large
+
+# Find debt to tackle
+bd list --label technical-debt --label small
+bd list --label technical-debt --priority 1  # High-priority debt
+```
+
+### Breaking Change Coordination
+```bash
+# Identify breaking changes
+bd label add bd-42 breaking-change
+bd label add bd-42 v2.0
+
+# Find all breaking changes for next major release
+bd list --label breaking-change,v2.0
+
+# Ensure they're documented
+bd list --label breaking-change --label needs-docs
+```
+
+## Operational State Pattern (Labels as Cache)
+
+For orchestration systems, labels can cache the current operational state of "role beads" (issues representing agents or system components). This enables fast state queries without scanning event history.
+
+### Convention: `<dimension>:<value>`
+
+Use colon-separated labels with a dimension prefix and value suffix:
+
+```
+patrol:muted      patrol:active
+mode:degraded     mode:normal
+status:idle       status:working
+health:healthy    health:failing
+```
+
+### The Pattern
+
+1. **Create an event bead** with full context (immutable, audit trail)
+2. **Update the role bead's labels** to reflect current state (fast lookup)
+
+```bash
+# 1. Record the event (source of truth)
+bd create "Muted patrol for agent-abc" -t event \
+  --parent agent-abc \
+  -d "Reason: investigating stuck worker. Expected duration: 30m"
+
+# 2. Update the cached state label
+bd label remove agent-abc patrol:active
+bd label add agent-abc patrol:muted
+```
+
+### Why This Pattern?
+
+**Events are source of truth. Labels are cache.**
+
+| Approach | Events Only | Labels as Cache |
+|----------|-------------|-----------------|
+| Query current state | Scan all events, find latest | `bd list --label patrol:muted` |
+| Query state history | Natural (all events exist) | Query events |
+| Audit trail | Complete | Complete (events still exist) |
+| Performance | O(n) events | O(1) label lookup |
+
+The pattern gives you both: complete history via events, fast queries via labels.
+
+### Example: Agent Role States
+
+```bash
+# Create a role bead for an agent
+bd create "witness-alpha" -t role -l patrol:active,mode:normal,health:healthy
+
+# Agent enters degraded mode
+bd create "Degraded: high error rate" -t event --parent witness-alpha \
+  -d "Error rate exceeded 5%. Reducing poll frequency."
+bd label remove witness-alpha mode:normal
+bd label add witness-alpha mode:degraded
+
+# Query current state
+bd list --label mode:degraded --type role  # All degraded roles
+
+# Agent recovers
+bd create "Recovered: error rate normal" -t event --parent witness-alpha
+bd label remove witness-alpha mode:degraded
+bd label add witness-alpha mode:normal
+```
+
+### Common Dimensions
+
+| Dimension | Values | Use Case |
+|-----------|--------|----------|
+| `patrol` | `active`, `muted`, `suspended` | Agent patrol cycles |
+| `mode` | `normal`, `degraded`, `maintenance` | Operational modes |
+| `status` | `idle`, `working`, `blocked` | Work state |
+| `health` | `healthy`, `warning`, `failing` | Health checks |
+| `sync` | `current`, `stale`, `syncing` | Sync state |
+
+### Best Practices
+
+1. **Always create the event first** - Labels are cache; events are truth
+2. **Remove old value before adding new** - Prevents dimension:value1 + dimension:value2 conflicts
+3. **Use consistent dimension names** - Establish team conventions early
+4. **Keep dimensions orthogonal** - patrol and mode are independent concerns
+
+### Querying State
+
+```bash
+# Find all muted patrols
+bd list --label patrol:muted
+
+# Find healthy agents in normal mode
+bd list --label health:healthy,mode:normal
+
+# Find any non-healthy agents
+bd list --label-any health:warning,health:failing
+
+# Get state for a specific role
+bd label list witness-alpha
+# Output: patrol:active, mode:normal, health:healthy
+```
+
+### Helper Commands
+
+For convenience, use these helpers:
+
+```bash
+# Query a specific dimension
+bd state witness-alpha patrol
+# Output: active
+
+# List all state dimensions
+bd state list witness-alpha
+# Output:
+#   patrol: active
+#   mode: normal
+#   health: healthy
+
+# Set state (creates event + updates label atomically)
+bd set-state witness-alpha patrol=muted --reason "Investigating issue"
+```
+
+The `set-state` command atomically:
+1. Creates an event bead with the reason (source of truth)
+2. Removes the old dimension label if present
+3. Adds the new dimension:value label (cache)
+
+See [CLI_REFERENCE.md](/cli-reference/set-state) for full command reference.
+
+## Troubleshooting
+
+### Labels Not Showing in List
+Labels require explicit fetching. The `bd list` command shows issues but not labels in human output (only in JSON).
+
+```bash
+# See labels in JSON
+bd list --json | jq '.[] | {id, labels}'
+
+# See labels for specific issue
+bd show bd-42 --json | jq '.labels'
+bd label list bd-42
+```
+
+### Label Filtering Not Working
+Check label names for exact matches (case-sensitive):
+```bash
+# These are different labels:
+bd label add bd-42 Backend    # Capital B
+bd list --label backend       # Won't match
+
+# List all labels to see exact names
+bd label list-all
+```
+
+### Syncing Labels
+Labels are stored in the Dolt database. If labels seem out of sync:
+```bash
+# Pull from Dolt remote
+bd dolt pull
+
+# Or run doctor to diagnose
+bd doctor
+```
+
+## See Also
+
+- [README.md](https://github.com/gastownhall/beads/blob/main/README.md) - Main documentation
+- [AGENTS.md](https://github.com/gastownhall/beads/blob/main/AGENTS.md) - AI agent integration guide
+- [ADVANCED.md](/reference/advanced) - Advanced features and configuration

--- a/website/docs/core-concepts/metadata.md
+++ b/website/docs/core-concepts/metadata.md
@@ -1,3 +1,9 @@
+---
+id: metadata
+title: Issue Metadata
+slug: /core-concepts/metadata
+---
+
 # Issue Metadata
 
 The `metadata` field on issues accepts arbitrary JSON. Any valid JSON value is stored as-is.
@@ -5,7 +11,7 @@ The `metadata` field on issues accepts arbitrary JSON. Any valid JSON value is s
 Metadata is the preferred extension point for data that is specific to an
 integration, orchestrator, team workflow, or experimental automation. Before
 adding first-class fields, commands, or schema changes, check the
-[Project Charter](PROJECT_CHARTER.md#schema-boundary).
+[Project Charter](https://github.com/gastownhall/beads/blob/main/docs/PROJECT_CHARTER.md#schema-boundary).
 
 ## Example: Agent Execution Metadata
 
@@ -76,5 +82,5 @@ Avoid these prefixes in user-defined keys to prevent conflicts with future Beads
 
 ## Related
 
-- [Project Charter](PROJECT_CHARTER.md) - Product scope and schema boundary
+- [Project Charter](https://github.com/gastownhall/beads/blob/main/docs/PROJECT_CHARTER.md) - Product scope and schema boundary
 - [#1416](https://github.com/gastownhall/beads/issues/1416) - Optional schema enforcement (future)

--- a/website/docs/core-concepts/metadata.md
+++ b/website/docs/core-concepts/metadata.md
@@ -48,28 +48,27 @@ Do not add a first-class helper such as `bd show <id> --execution` or
 issue gh-3541 determines whether schedulers or runners need these fields as a
 stable CLI surface.
 
-## Example: Verification Metadata
+## Example: Tracker Round-Trip Metadata
 
-Local verification queues are another example of metadata as an extension
-point. They may store slow-suite state in issue metadata. These keys describe
-the validation gate for a specific candidate commit:
+Tracker integrations map external issues into beads fields such as title,
+status, priority, type, labels, dependencies, and `external_ref`. When an
+integration needs to preserve tracker-specific fields that do not belong in the
+native beads schema, it can store those fields in issue metadata:
 
-| Key | Meaning |
-|-----|---------|
-| `verify_state` | Verification state: `queued`, `running`, `passed`, or `failed`. |
-| `verify_head` | Commit SHA that the verification result applies to. |
-| `verify_branch` | Branch name recorded when verification was queued. |
-| `verify_cmd` | Command run in the clean verification worktree. |
-| `verify_log` | Local path to the verifier log. |
-| `verify_result` | Compact result, such as `exit=0` or `exit=1`. |
-| `verify_enqueued_at` | UTC timestamp when the verification was queued. |
-| `verify_started_at` | UTC timestamp when the verification started. |
-| `verify_finished_at` | UTC timestamp when the verification finished. |
-| `verify_worktree` | Source or clean verification worktree path. |
-| `verify_runner` | Local verifier identity, usually `host:pid`. |
+```json
+{
+  "example_tracker": {
+    "board_id": "ENG",
+    "sprint_id": 42,
+    "remote_type": "story"
+  }
+}
+```
 
-Treat `verify_head` as the source of truth. A passing result gates that exact
-commit only; if the branch moves, enqueue verification again.
+This keeps beads' core issue model stable while allowing the integration to
+round-trip fields it understands. Prefer namespaced keys and keep
+tracker-specific policy in the integration. If a value becomes broadly useful
+to beads itself, revisit whether it deserves a native field.
 
 ## Reserved Key Prefixes
 

--- a/website/docs/core-concepts/sync-concepts.md
+++ b/website/docs/core-concepts/sync-concepts.md
@@ -1,0 +1,73 @@
+---
+id: sync-concepts
+title: Sync Concepts
+slug: /core-concepts/sync-concepts
+---
+
+# Sync Concepts
+
+Beads issue data lives in Dolt. The local Dolt database is the source of truth
+for `bd list`, `bd show`, `bd ready`, and every write command.
+
+## The Wire Format
+
+Cross-machine sync uses Dolt remotes:
+
+```bash
+bd dolt push
+bd dolt pull
+```
+
+For normal git-hosted projects, the Dolt remote can be the same `origin` URL
+used for source code. Dolt stores issue history under `refs/dolt/data`, separate
+from source branches such as `refs/heads/main`.
+
+On new projects, `bd init` auto-detects `git remote get-url origin` and
+configures a Dolt remote named `origin`. The first `bd dolt push` publishes
+`refs/dolt/data`. Fresh clones should run `bd bootstrap` to clone that Dolt
+history. When bootstrap finds `refs/dolt/data` on git origin, it also wires
+that origin as the Dolt remote for future `bd dolt push` and `bd dolt pull`.
+
+## What JSONL Is For
+
+`.beads/issues.jsonl` is an export. It exists for viewers, interchange,
+migration, and backup. It is not the canonical cross-machine sync channel.
+
+Do not use routine `bd import .beads/issues.jsonl` as a replacement for
+`bd dolt pull`. JSONL import is upsert-only; it cannot infer that records absent
+from an export were deleted, pruned, or simply never exported.
+
+## Hooks
+
+The pre-commit hook refreshes `.beads/issues.jsonl` when `export.auto=true`.
+That keeps the export current for tools, but it does not push Dolt history.
+
+The post-merge and post-checkout hooks skip JSONL import when `sync.remote` is
+configured. For old projects with no Dolt remote, they may import JSONL as a
+compatibility fallback and print a warning that this is not durable sync.
+
+## Repair
+
+For projects initialized before automatic git-origin remote wiring, pick the
+machine with the authoritative local Dolt database first. Then run:
+
+```bash
+bd dolt remote list
+bd export -o .beads/issues.pre-remote.jsonl   # optional issue audit export
+bd dolt remote add origin <git-origin-url>
+bd dolt push
+```
+
+Use the Dolt-compatible git URL form when needed. For example,
+`git+ssh://git@github.com/org/repo.git` or
+`git+https://github.com/org/repo.git`. `bd dolt remote add origin ...`
+persists `sync.remote` into `.beads/config.yaml`; commit and push that config
+change so fresh clones can run `bd bootstrap`.
+
+Other machines should then run:
+
+```bash
+bd dolt pull
+# or, if the local database is stale or missing:
+bd bootstrap
+```

--- a/website/docs/recovery/uninstalling.md
+++ b/website/docs/recovery/uninstalling.md
@@ -1,3 +1,9 @@
+---
+id: uninstalling
+title: Uninstalling
+slug: /recovery/uninstalling
+---
+
 # Uninstalling Beads
 
 This guide explains how to remove beads from a repository or remove the `bd`

--- a/website/docs/reference/antivirus.md
+++ b/website/docs/reference/antivirus.md
@@ -1,0 +1,211 @@
+---
+id: antivirus
+title: Antivirus False Positives
+slug: /reference/antivirus
+---
+
+# Antivirus False Positives
+
+## Overview
+
+Some antivirus software may flag beads (`bd` or `bd.exe`) as malicious. This is a **false positive** - beads is a legitimate, open-source command-line tool for issue tracking.
+
+Beads release installers now verify downloaded archives against release `checksums.txt` before installation. For users who manually install binaries, checksum verification should be the first trust step before running `bd` or creating antivirus exclusions.
+
+## Why This Happens
+
+Go binaries (including beads) are sometimes flagged by antivirus software due to:
+
+1. **Heuristic detection**: Some malware is written in Go, causing antivirus ML models to flag Go-specific binary patterns as suspicious
+2. **Behavioral analysis**: CLI tools that modify files and interact with git may trigger behavioral detection
+3. **Unsigned binaries**: Without code signing, new executables may be treated with suspicion
+
+This is a **known industry-wide problem** affecting many legitimate Go projects. See the [Go project issues](https://github.com/golang/go/issues/16292) for examples.
+
+## Known Issues
+
+### Kaspersky Antivirus
+
+**Detection**: `PDM:Trojan.Win32.Generic`
+**Affected versions**: bd.exe v0.23.1 and potentially others
+**Component**: System Watcher (Proactive Defense Module)
+
+Kaspersky's PDM (Proactive Defense Module) uses behavioral analysis that commonly triggers false positives on Go executables.
+
+## Solutions for Users
+
+### Option 1: Verify File Integrity (Recommended First)
+
+Before running a downloaded binary or adding antivirus exclusions, verify the file is legitimate:
+
+1. Download beads from the [official GitHub releases](https://github.com/gastownhall/beads/releases)
+2. Verify the SHA256 checksum matches the `checksums.txt` file in the release
+3. If a release includes code signing, verify that signature too
+
+**Verify checksum (Windows PowerShell):**
+```powershell
+Get-FileHash bd.exe -Algorithm SHA256
+```
+
+**Verify checksum (macOS/Linux):**
+```bash
+shasum -a 256 bd
+```
+
+Compare the output with the checksum in `checksums.txt` from the release page.
+
+### Option 2: Add Exclusion (After Verification)
+
+Add beads to your antivirus exclusion list:
+
+**Kaspersky:**
+1. Open Kaspersky and go to Settings
+2. Navigate to Threats and Exclusions → Manage Exclusions
+3. Click Add → Add path to exclusion
+4. Add the directory containing `bd.exe` (e.g., `C:\Users\YourName\AppData\Local\bd\`)
+5. Select which components the exclusion applies to (scan, monitoring, etc.)
+
+**Windows Defender:**
+1. Open Windows Security
+2. Go to Virus & threat protection → Manage settings
+3. Scroll to Exclusions → Add or remove exclusions
+4. Add the beads installation directory or the specific `bd.exe` file
+
+**Other antivirus software:**
+- Look for "Exclusions", "Whitelist", or "Trusted Applications" settings
+- Add the beads installation directory or executable
+
+### Option 3: Report False Positive
+
+Help improve detection accuracy by reporting the false positive:
+
+**Kaspersky:**
+1. Visit [Kaspersky Threat Intelligence Portal](https://opentip.kaspersky.com/)
+2. Upload the `bd.exe` file for analysis
+3. Mark it as a false positive
+4. Reference: beads is open-source CLI tool (https://github.com/gastownhall/beads)
+
+**Windows Defender:**
+1. Go to [Microsoft Security Intelligence](https://www.microsoft.com/en-us/wdsi/filesubmission)
+2. Submit the file as a false positive
+3. Provide details about the legitimate software
+
+**Other vendors:**
+- Check their website for false positive submission forms
+- Most major vendors have a process for reviewing flagged files
+
+## For Developers/Distributors
+
+If you're building beads from source or distributing it:
+
+### Current Build Configuration
+
+Beads releases are built with multiple optimizations to reduce false positives:
+
+```yaml
+ldflags:
+  - -s -w  # Strip debug symbols and DWARF info
+```
+
+**Windows PE version info**: Release builds embed legitimate PE resource metadata
+(company name, product name, file description, version, copyright, and an
+application manifest) into the Windows binary using `go-winres`. This is one of the
+most effective measures against AV false positives — legitimate software almost
+always has PE metadata, and AV heuristics use its absence as a suspicion signal.
+
+These optimizations are applied automatically in official release builds.
+
+### Code Signing
+
+Windows releases are signed with an Authenticode certificate when available. Code signing:
+- Reduces false positive rates over time
+- Builds reputation with SmartScreen/antivirus vendors
+- Provides tamper verification
+
+**Verify a signed binary (Windows PowerShell):**
+```powershell
+# Check if the binary is signed
+Get-AuthenticodeSignature .\bd.exe
+
+# Expected output for signed binary:
+# SignerCertificate: [Certificate details]
+# Status: Valid
+```
+
+**Verify a signed binary (Linux/macOS with osslsigncode):**
+```bash
+# Install osslsigncode if not available
+# Ubuntu/Debian: apt-get install osslsigncode
+# macOS: brew install osslsigncode
+
+osslsigncode verify -in bd.exe
+```
+
+**Note:** Code signing requires an EV (Extended Validation) certificate, which involves a verification process. If a release is not signed, it means the certificate was not available at build time. Follow the checksum verification steps above to verify authenticity.
+
+### Alternative Build Methods
+
+Some users report success with:
+```bash
+go build -ldflags "-s -w" -o bd ./cmd/bd
+```
+
+However, results vary by antivirus vendor and version.
+
+## Frequently Asked Questions
+
+### Is beads safe to use?
+
+Yes. Beads is:
+- Open source (all code is auditable on [GitHub](https://github.com/gastownhall/beads))
+- Releases include checksums for verification
+- Used by developers worldwide
+- A simple CLI tool for issue tracking
+
+### Why don't you just fix the code to avoid detection?
+
+The issue isn't specific to beads' code - it's a characteristic of Go binaries in general. Changing code won't reliably prevent heuristic/behavioral detection. The proper solutions are:
+1. Code signing (builds trust over time)
+2. Whitelist applications with antivirus vendors
+3. User reports of false positives
+
+### Will this be fixed in future releases?
+
+We've implemented:
+- **Windows PE version info** embedded in binaries (company name, product name, version, manifest)
+- **Code signing infrastructure** for Windows releases (requires EV certificate)
+- **Build optimizations** to reduce heuristic triggers (`-s -w` ldflags)
+- **Documentation** for users to add exclusions and report false positives
+
+Still in progress:
+- Acquiring an EV code signing certificate
+- Submitting beads to antivirus vendor whitelists
+
+False positives may still occur with new releases until the certificate builds reputation with antivirus vendors. This typically takes several months of consistent signed releases.
+
+### Should I disable my antivirus?
+
+**No.** Instead:
+1. Verify release checksums before first run
+2. Keep your antivirus enabled for other threats
+3. Add beads to your antivirus exclusions only after verification if detections persist
+
+## Reporting Issues
+
+If you encounter a new antivirus false positive:
+
+1. Open an issue on [GitHub](https://github.com/gastownhall/beads/issues)
+2. Include:
+   - Antivirus software name and version
+   - Detection/threat name
+   - Beads version (`bd version`)
+   - Operating system
+
+This helps us track and address false positives across different antivirus vendors.
+
+## References
+
+- [Kaspersky False Positive Guide](https://support.kaspersky.com/1870)
+- [Go Binary False Positives Discussion](https://www.linkedin.com/pulse/go-false-positives-melle-boudewijns)
+- [Go Project Issue Tracker](https://github.com/golang/go/issues/16292)
+- [Kaspersky Community Forum](https://forum.kaspersky.com/topic/pdmtrojanwin32generic-54425/)

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -232,6 +232,10 @@ const config: Config = {
           title: 'Resources',
           items: [
             {
+              label: 'Community Tools',
+              to: '/community-tools',
+            },
+            {
               label: 'GitHub',
               href: `https://github.com/${orgName}/${projectName}`,
             },

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -21,6 +21,9 @@ const sidebars: SidebarsConfig = {
         'core-concepts/index',
         'core-concepts/issues',
         'core-concepts/hash-ids',
+        'core-concepts/sync-concepts',
+        'core-concepts/labels',
+        'core-concepts/metadata',
       ],
     },
     {
@@ -68,6 +71,7 @@ const sidebars: SidebarsConfig = {
         'recovery/merge-conflicts',
         'recovery/circular-dependencies',
         'recovery/sync-failures',
+        'recovery/uninstalling',
       ],
     },
     {
@@ -112,6 +116,7 @@ const sidebars: SidebarsConfig = {
         'reference/git-integration',
         'reference/advanced',
         'reference/troubleshooting',
+        'reference/antivirus',
         'reference/faq',
       ],
     },

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -102,6 +102,7 @@ const sidebars: SidebarsConfig = {
         'integrations/github-copilot',
       ],
     },
+    'community-tools',
     {
       type: 'category',
       label: 'Reference',

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -11528,6 +11528,130 @@ bd setup windsurf --remove
 
 </document>
 
+<document path="docs/community-tools.md">
+
+
+# Beads Community Tools
+
+A curated list of community-built UIs, extensions, and integrations for Beads. Ranked by activity and maturity.
+
+> **Note:** Beads uses a Dolt SQL database for storage. Tools should use
+> the `bd` CLI (`bd list --json`, etc.) to access data. Tools that read
+> the old `.beads/issues.jsonl` format directly are not compatible with
+> current versions.
+
+## Terminal UIs
+
+- **[Mardi Gras](https://github.com/quietpublish/mardi-gras)** - Parade-themed terminal UI with real-time updates, multi-agent orchestration, tmux integration, and Claude Code dispatch. Uses `bd list --json`. Built by [@matt-wright86](https://github.com/matt-wright86). (Go)
+
+- **[perles](https://github.com/zjrosen/perles)** - Terminal UI search, dependency and kanban viewer powered by a custom BQL (Beads Query Language). Built by [@zjrosen](https://github.com/zjrosen). (Go)
+
+## Web UIs
+
+- **[beads-ui](https://github.com/mantoni/beads-ui)** - Local web interface with live updates and kanban board. Uses the `bd` CLI for Dolt compatibility. Run with `npx beads-ui start`. Built by [@mantoni](https://github.com/mantoni). (Node.js)
+
+- **[BeadBoard](https://github.com/zenchantlive/beadboard)** - Multi-agent orchestration and communication system with a live dashboard. Agent-to-agent messaging (HANDOFF/BLOCKED/DECISION/INFO), DAG dependency graph, swarm coordination with archetypes and templates, scope-based work reservations, and an embedded execution runtime (bb-pi) built on [Pi](https://github.com/badlogic/pi-mono) that spawns typed worker agents. Cross-platform (macOS, Linux, Windows). Includes the `beadboard-driver` skill for agent integration (`npx skills add zenchantlive/beadboard --skill beadboard-driver`). Built by [@zenchantlive](https://github.com/zenchantlive). (Next.js/TypeScript)
+
+- **[beads-web](https://github.com/weselow/beads-web)** - Actively maintained fork of beads-kanban-ui. Cross-platform single-binary distribution (macOS, Linux, Windows), 7 visual themes, Dolt direct SQL integration, Windows multi-drive path support, drag-and-drop status updates. Download from [GitHub Releases](https://github.com/weselow/beads-web/releases). Built by [@weselow](https://github.com/weselow). (TypeScript/Rust)
+
+## Editor Extensions
+
+- **[vscode-beads](https://marketplace.visualstudio.com/items?itemName=planet57.vscode-beads)** - VS Code extension with issues panel and server management. Built by [@jdillon](https://github.com/jdillon). (TypeScript)
+
+- **[opencode-beads](https://github.com/joshuadavidthomas/opencode-beads)** - OpenCode plugin with automatic context injection, `/bd-*` slash commands, and autonomous task agent. Built by [@joshuadavidthomas](https://github.com/joshuadavidthomas). (Node.js)
+
+- **[Lista Beads](https://marketplace.visualstudio.com/items?itemName=ListaDev.lista-beads)** - Full-featured VS Code extension: filterable tree view, issue detail panel, dashboard with metrics, dependency graph, Dolt push/pull, CodeLens for bead references, wisps & formula support, stale issue management, and multi-tracker sync (Azure DevOps, GitHub, Jira, Linear, GitLab). Built by [@harry-miller-trimble](https://github.com/harry-miller-trimble). (TypeScript)
+
+- **[nvim-beads (fancypantalons)](https://github.com/fancypantalons/nvim-beads)** - Neovim plugin for managing Beads issues. By [@fancypantalons](https://github.com/fancypantalons). (Lua)
+
+- **[beads-manager](https://plugins.jetbrains.com/plugin/30089-beads-manager)** - Jetbrains IDE plugin to manage and view bead details. Maintained by [@developmeh](https://github.com/developmeh). (Kotlin)
+
+## Native Apps
+
+- **[Beads Task-Issue Tracker](https://github.com/w3dev33/beads-task-issue-tracker)** - Cross-platform desktop application (macOS, Windows, Linux) for browsing, creating, and managing Beads issues with a visual interface. Features multi-project support with favorites, image attachments, dashboard with statistics, advanced filtering, and dark/light theme. Built by [@w3dev33](https://github.com/w3dev33). (Tauri/Vue)
+
+- **[Beadbox](https://github.com/beadbox/beadbox)** - Native macOS dashboard with real-time sync, epic tree progress bars, multi-workspace support, and inline editing. Install with `brew tap beadbox/cask && brew install --cask beadbox`. Built by [@nmelo](https://github.com/nmelo). (Tauri/Next.js)
+
+## Data Source Middleware
+
+- **[stringer](https://github.com/davetashner/stringer)** - Codebase archaeology CLI that mines git repos for TODOs, churn hotspots, lottery-risk files, dependency health, and more. Outputs JSONL compatible with `bd init --from-jsonl`. Install with `brew install davetashner/tap/stringer`. Built by [@davetashner](https://github.com/davetashner). (Go)
+
+## Analytics & Observability
+
+* **[Thread](https://github.com/jklenk/thread)** - Read-only forensics and analytics layer for Beads. Reads local Dolt history and produces fidelity scores, rework cost metrics, session compliance scoring, and a self-contained HTML report. Add `Run 'thread prime --json' at session start` to your `AGENTS.md` to give agents project health context before they claim their first bead.
+
+Install with `uv tool install git+https://github.com/jklenk/thread`. Built by [@jklenk](https://github.com/jklenk). (Python/DuckDB)
+
+## SDKs & Libraries
+
+- **[beads-sdk](https://github.com/HerbCaudill/beads-sdk)** - Typed TypeScript SDK with zero runtime dependencies. High-level `BeadsClient` for CRUD, filtering, search, labels, dependencies, comments, epics, and sync. Install with `pnpm add @herbcaudill/beads-sdk`. Built by [@HerbCaudill](https://github.com/HerbCaudill). (TypeScript)
+
+## Claude Code Orchestration
+
+- **[Foolery](https://github.com/acartine/foolery)** - Local web UI that sits on top of Beads, giving you a visual control surface for organizing, orchestrating, and reviewing AI agent work. Features dependency-aware wave planning, a built-in terminal for live agent monitoring, a verification queue for reviewing completed beats, and keyboard-first navigation. Install with `curl -fsSL https://raw.githubusercontent.com/acartine/foolery/main/scripts/install.sh | bash`. Built by [@acartine](https://github.com/acartine). (Next.js/TypeScript)
+
+- **[beads-compound](https://github.com/roberto-mello/beads-compound-plugin)** - Claude Code plugin marketplace with persistent memory and compound-engineering workflows. Hooks auto-capture knowledge from `bd comments add` at session end and inject relevant entries at session start based on open beads. Includes 28 specialized agents, 26 commands, and 15 skills for planning, review, research, and parallel work. Also supports OpenCode and Gemini CLI. Built by [@roberto-mello](https://github.com/roberto-mello). (Bash/TypeScript)
+
+- **[claude-handoff](https://github.com/REMvisual/claude-handoff)** - Session handoff skills for Claude Code. Captures decisions, failed approaches, measurements, and next steps into structured files so the next session picks up where you left off. Uses bead IDs as chain tags for multi-session continuity, auto-detects active beads, and updates bead notes on close. Includes `/handoff`, `/handoffplan`, and a PreCompact safety-net hook. Built by [@REMvisual](https://github.com/REMvisual). (Markdown/Bash)
+- **[claude-workspace-snapshot](https://github.com/REMvisual/claude-workspace-snapshot)** - Snapshot and restore live Claude Code sessions as named, color-coded Windows Terminal tabs. Detects running sessions via process inspection and .jsonl file activity. Restores tab layout after any restart. Pairs with claude-handoff for full session continuity. Built by [@REMvisual](https://github.com/REMvisual). (PowerShell/Batch)
+- **[claude-protocol](https://github.com/weselow/claude-protocol)** - Actively maintained fork of beads-orchestration. Ground-up rewrite optimized for Claude 4.6 family models: trigger-based dev rules (TDD, logging, resilience), cross-platform Node.js hooks (replaced 19 bash scripts with 8 .cjs hooks), mandatory checklist verification, session-start dashboard, knowledge base with auto-capture. Install via `npx claude-protocol init`. Built by [@weselow](https://github.com/weselow). (Node.js/Python)
+
+## Coordination Servers
+
+- **[BeadHub](https://github.com/beadhub/beadhub)** - Open-source coordination server for AI agent teams running beads. The `bdh` CLI is a transparent wrapper over `bd` that adds work claiming, file reservation, presence awareness, and inter-agent messaging (async mail and sync chat). Includes a web dashboard. Free hosted at beadhub.ai for open-source projects. Built by [@juanre](https://github.com/juanre). (Python/TypeScript)
+
+## Historical / Stale
+
+- **[bdui](https://github.com/assimelha/bdui)** - Real-time terminal UI with tree view, dependency graph, and vim-style navigation. Built by [@assimelha](https://github.com/assimelha). (Node.js)
+
+- **[beads.el](https://codeberg.org/ctietze/beads.el)** - Emacs UI to browse, edit, and manage beads. Built by [@ctietze](https://codeberg.org/ctietze). (Elisp)
+
+- **[lazybeads](https://github.com/codegangsta/lazybeads)** - Lightweight terminal UI built with Bubble Tea for browsing and managing beads issues. Built by [@codegangsta](https://github.com/codegangsta). (Go)
+
+- **[bsv](https://github.com/bglenden/bsv)** - Simple two-panel terminal (TUI) viewer with tree navigation organized by epic/task/sub-task, markdown rendering, and mouse support. Built by [@bglenden](https://github.com/bglenden). (Rust)
+
+- **[abacus](https://github.com/ChrisEdwards/abacus)** - A powerful terminal UI for visualizing and navigating Beads issue tracking databases.
+
+- **[beads-viz-prototype](https://github.com/mattbeane/beads-viz-prototype)** - Web-based visualization generating interactive HTML from `bd export`. Built by [@mattbeane](https://github.com/mattbeane). (Python)
+
+- **[beads-dashboard](https://github.com/rhydlewis/beads-dashboard)** - A local, lean metrics dashboard for your beads data. Provides insights into lead time, throughput and other continuous improvement metrics. Includes a filterable table view of "all issues". Built by [@rhydlewis](https://github.com/rhydlewis). (Node.js/React)
+
+- **[beads-kanban-ui](https://github.com/AvivK5498/Beads-Kanban-UI)** - Visual Kanban board with git branch status tracking, epic/subtask management, design doc viewer, and activity timeline. Install via npm: `npm install -g beads-kanban-ui`. Built by [@AvivK5498](https://github.com/AvivK5498). (TypeScript/Rust)
+
+- **[beads-pm-ui](https://github.com/qosha1/beads-pm-ui)** - Gantt chart timeline view, project / team based filtering (via folder structure), quarterly goal setting and dependency chain visualization. Inline editable. Built by [@qosha1](https://github.com/qosha1). (Nextjs/Typscript)
+
+- **[Beadspace](https://github.com/cameronsjo/beadspace)** - Drop-in GitHub Pages dashboard with triage suggestions, priority/status breakdowns, and searchable issue table. Single HTML file, zero build dependencies, auto-deploys via GitHub Action. Built by [@cameronsjo](https://github.com/cameronsjo). (HTML/CSS/JS)
+
+- **[beadsmap](https://github.com/dariye/beadsmap)** - Interactive roadmap visualization with timeline (Gantt), list, and table views. Multi-source support, dependency arrows, milestone grouping, GitHub integration via OAuth device flow, and light/dark/system themes. Ships as a single `index.html`. Built by [@dariye](https://github.com/dariye). (Svelte/TypeScript)
+
+- **[Agent Native Abstraction Layer for Beads](https://marketplace.visualstudio.com/items?itemName=AgentNativeAbstractionLayer.agent-native-kanban)** (ANAL Beads) - VS Code Kanban board. Maintained by [@sebcook-ctrl](https://github.com/sebcook-ctrl). (Node.js)
+
+- **[Beads-Kanban](https://github.com/davidcforbes/Beads-Kanban)** - VS Code Kanban board for Beads issue tracking. Maintained by [@davidcforbes](https://github.com/davidcforbes). (TypeScript)
+
+- **[nvim-beads](https://github.com/joeblubaugh/nvim-beads)** - Neovim plugin for managing beads. Built by [@joeblubaugh](https://github.com/joeblubaugh). (Lua)
+
+- **[Beadster](https://github.com/beadster/beadster)** - macOS app for browsing and managing issues from `.beads/` directories in git repositories. Built by [@podviaznikov](https://github.com/podviaznikov). (Swift)
+
+-  **[Parade](https://github.com/JeremyKalmus/parade)** - Electron app for workflow orchestration with visual Kanban board, discovery wizard, and task visualization. Run with `npx parade-init`. Built by [@JeremyKalmus](https://github.com/JeremyKalmus). (Electron/React)
+
+- **[jira-beads-sync](https://github.com/conallob/jira-beads-sync)** - CLI tool & Claude Code plugin to sync tasks from Jira into beads and publish beads task states back to Jira. Built by [@conallob](https://github.com/conallob). (Go)
+
+- **[beads-orchestration](https://github.com/AvivK5498/Claude-Code-Beads-Orchestration)** - Multi-agent orchestration skill for Claude Code. Orchestrator investigates issues, manages beads tasks automatically, and delegates to tech-specific supervisors on isolated branches. Includes hooks for workflow enforcement, epic/subtask support, and optional external provider delegation (Codex/Gemini). Install via npm: `npm install -g @avivkaplan/beads-orchestration`. Built by [@AvivK5498](https://github.com/AvivK5498). (Node.js/Python)
+
+- **[beads_viewer](https://github.com/Dicklesworthstone/beads_viewer)** - Terminal interface with tree navigation and vim-style commands. Not compatible with Dolt-based beads (v0.50+); see [issue #121](https://github.com/Dicklesworthstone/beads_viewer/issues/121). Built by [@Dicklesworthstone](https://github.com/Dicklesworthstone). (Go)
+
+- **[beady](https://github.com/maphew/beady)** - Early prototype effort, now stale. Built by [@maphew](https://github.com/maphew). (Go)
+
+## Discussion
+
+See [GitHub Discussions #276](https://github.com/gastownhall/beads/discussions/276) for ongoing UI development conversations, design decisions, and community contributions.
+
+## Contributing
+
+Found or built a tool? Open a PR to add it to this list or comment on discussion #276.
+
+</document>
+
 <document path="docs/recovery/index.md">
 
 

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -2418,28 +2418,27 @@ Do not add a first-class helper such as `bd show <id> --execution` or
 issue gh-3541 determines whether schedulers or runners need these fields as a
 stable CLI surface.
 
-## Example: Verification Metadata
+## Example: Tracker Round-Trip Metadata
 
-Local verification queues are another example of metadata as an extension
-point. They may store slow-suite state in issue metadata. These keys describe
-the validation gate for a specific candidate commit:
+Tracker integrations map external issues into beads fields such as title,
+status, priority, type, labels, dependencies, and `external_ref`. When an
+integration needs to preserve tracker-specific fields that do not belong in the
+native beads schema, it can store those fields in issue metadata:
 
-| Key | Meaning |
-|-----|---------|
-| `verify_state` | Verification state: `queued`, `running`, `passed`, or `failed`. |
-| `verify_head` | Commit SHA that the verification result applies to. |
-| `verify_branch` | Branch name recorded when verification was queued. |
-| `verify_cmd` | Command run in the clean verification worktree. |
-| `verify_log` | Local path to the verifier log. |
-| `verify_result` | Compact result, such as `exit=0` or `exit=1`. |
-| `verify_enqueued_at` | UTC timestamp when the verification was queued. |
-| `verify_started_at` | UTC timestamp when the verification started. |
-| `verify_finished_at` | UTC timestamp when the verification finished. |
-| `verify_worktree` | Source or clean verification worktree path. |
-| `verify_runner` | Local verifier identity, usually `host:pid`. |
+```json
+{
+  "example_tracker": {
+    "board_id": "ENG",
+    "sprint_id": 42,
+    "remote_type": "story"
+  }
+}
+```
 
-Treat `verify_head` as the source of truth. A passing result gates that exact
-commit only; if the branch moves, enqueue verification again.
+This keeps beads' core issue model stable while allowing the integration to
+round-trip fields it understands. Prefer namespaced keys and keep
+tracker-specific policy in the integration. If a value becomes broadly useful
+to beads itself, revisit whether it deserves a native field.
 
 ## Reserved Key Prefixes
 

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -1582,6 +1582,954 @@ bd list --status open --priority 1 --type bug --json
 
 </document>
 
+<document path="docs/core-concepts/labels.md">
+
+
+# Labels in Beads
+
+Labels provide flexible, multi-dimensional categorization for issues beyond the structured fields (status, priority, type). Use labels for cross-cutting concerns, technical metadata, and contextual tagging without schema changes.
+
+## Design Philosophy
+
+**When to use labels vs. structured fields:**
+
+- **Structured fields** (status, priority, type) → Core workflow state
+  - Status: Where the issue is in the workflow (`open`, `in_progress`, `blocked`, `closed`)
+  - Priority: How urgent (0-4)
+  - Type: What kind of work (`bug`, `feature`, `task`, `epic`, `chore`)
+
+- **Labels** → Everything else
+  - Technical metadata (`backend`, `frontend`, `api`, `database`)
+  - Domain/scope (`auth`, `payments`, `search`, `analytics`)
+  - Effort estimates (`small`, `medium`, `large`)
+  - Quality gates (`needs-review`, `needs-tests`, `breaking-change`)
+  - Team/ownership (`team-infra`, `team-product`)
+  - Release tracking (`v1.0`, `v2.0`, `backport-candidate`)
+
+## Quick Start
+
+```bash
+# Add labels when creating issues
+bd create "Fix auth bug" -t bug -p 1 -l auth,backend,urgent
+
+# Add labels to existing issues
+bd label add bd-42 security
+bd label add bd-42 breaking-change
+
+# List issue labels
+bd label list bd-42
+
+# Remove a label
+bd label remove bd-42 urgent
+
+# List all labels in use
+bd label list-all
+
+# Filter by labels (AND - must have ALL)
+bd list --label backend,auth
+
+# Filter by labels (OR - must have AT LEAST ONE)
+bd list --label-any frontend,backend
+
+# Combine filters
+bd list --status open --priority 1 --label security
+```
+
+## Common Label Patterns
+
+### 1. Technical Component Labels
+
+Identify which part of the system:
+```bash
+backend
+frontend
+api
+database
+infrastructure
+cli
+ui
+mobile
+```
+
+**Example:**
+```bash
+bd create "Add GraphQL endpoint" -t feature -p 2 -l backend,api
+bd create "Update login form" -t task -p 2 -l frontend,auth,ui
+```
+
+### 2. Domain/Feature Area
+
+Group by business domain:
+```bash
+auth
+payments
+search
+analytics
+billing
+notifications
+reporting
+admin
+```
+
+**Example:**
+```bash
+bd list --label payments --status open  # All open payment issues
+bd list --label-any auth,security       # Security-related work
+```
+
+### 3. Size/Effort Estimates
+
+Quick effort indicators:
+```bash
+small     # < 1 day
+medium    # 1-3 days
+large     # > 3 days
+```
+
+**Example:**
+```bash
+# Find small quick wins
+bd ready --json | jq '.[] | select(.labels[] == "small")'
+```
+
+### 4. Quality Gates
+
+Track what's needed before closing:
+```bash
+needs-review
+needs-tests
+needs-docs
+breaking-change
+```
+
+**Example:**
+```bash
+bd label add bd-42 needs-review
+bd list --label needs-review --status in_progress
+```
+
+### 5. Release Management
+
+Track release targeting:
+```bash
+v1.0
+v2.0
+backport-candidate
+release-blocker
+```
+
+**Example:**
+```bash
+bd list --label v1.0 --status open    # What's left for v1.0?
+bd label add bd-42 release-blocker
+```
+
+### 6. Team/Ownership
+
+Indicate ownership or interest:
+```bash
+team-infra
+team-product
+team-mobile
+needs-triage
+help-wanted
+```
+
+**Example:**
+```bash
+bd list --assignee alice --label team-infra
+bd create "Memory leak in cache" -t bug -p 1 -l team-infra,help-wanted
+```
+
+### 7. Special Markers
+
+Process or workflow flags:
+```bash
+auto-generated     # Created by automation
+discovered-from    # Found during other work (also a dep type)
+technical-debt
+good-first-issue
+duplicate
+wontfix
+```
+
+**Example:**
+```bash
+bd create "TODO: Refactor parser" -t chore -p 3 -l technical-debt,auto-generated
+```
+
+## Filtering by Labels
+
+### AND Filtering (--label)
+All specified labels must be present:
+
+```bash
+# Issues that are BOTH backend AND urgent
+bd list --label backend,urgent
+
+# Open bugs that need review AND tests
+bd list --status open --type bug --label needs-review,needs-tests
+```
+
+### OR Filtering (--label-any)
+At least one specified label must be present:
+
+```bash
+# Issues in frontend OR backend
+bd list --label-any frontend,backend
+
+# Security or auth related
+bd list --label-any security,auth
+```
+
+### Combining AND/OR
+Mix both filters for complex queries:
+
+```bash
+# Backend issues that are EITHER urgent OR a blocker
+bd list --label backend --label-any urgent,release-blocker
+
+# Frontend work that needs BOTH review and tests, but in any component
+bd list --label needs-review,needs-tests --label-any frontend,ui,mobile
+```
+
+## Workflow Examples
+
+### Triage Workflow
+```bash
+# Create untriaged issue
+bd create "Crash on login" -t bug -p 1 -l needs-triage
+
+# During triage, add context
+bd label add bd-42 auth
+bd label add bd-42 backend
+bd label add bd-42 urgent
+bd label remove bd-42 needs-triage
+
+# Find untriaged issues
+bd list --label needs-triage
+```
+
+### Quality Gate Workflow
+```bash
+# Start work
+bd update bd-42 --claim
+
+# Mark quality requirements
+bd label add bd-42 needs-tests
+bd label add bd-42 needs-docs
+
+# Before closing, verify
+bd label list bd-42
+# ... write tests and docs ...
+bd label remove bd-42 needs-tests
+bd label remove bd-42 needs-docs
+
+# Close when gates satisfied
+bd close bd-42
+```
+
+### Release Planning
+```bash
+# Tag issues for v1.0
+bd label add bd-42 v1.0
+bd label add bd-43 v1.0
+bd label add bd-44 v1.0
+
+# Track v1.0 progress
+bd list --label v1.0 --status closed    # Done
+bd list --label v1.0 --status open      # Remaining
+bd stats  # Overall progress
+
+# Mark critical items
+bd label add bd-45 v1.0
+bd label add bd-45 release-blocker
+```
+
+### Component-Based Work Distribution
+```bash
+# Backend team picks up work
+bd ready --json | jq '.[] | select(.labels[]? == "backend")'
+
+# Frontend team finds small tasks
+bd list --status open --label frontend,small
+
+# Find help-wanted items for new contributors
+bd list --label help-wanted,good-first-issue
+```
+
+## Label Management
+
+### Listing Labels
+```bash
+# Labels on a specific issue
+bd label list bd-42
+
+# All labels in database with usage counts
+bd label list-all
+
+# JSON output for scripting
+bd label list-all --json
+```
+
+Output:
+```json
+[
+  {"label": "auth", "count": 5},
+  {"label": "backend", "count": 12},
+  {"label": "frontend", "count": 8}
+]
+```
+
+### Bulk Operations
+
+Add labels in batch during creation:
+```bash
+bd create "Issue" -l label1,label2,label3
+```
+
+Script to add label to multiple issues:
+```bash
+# Add "needs-review" to all in_progress issues
+bd list --status in_progress --json | jq -r '.[].id' | while read id; do
+  bd label add "$id" needs-review
+done
+```
+
+Remove label from multiple issues:
+```bash
+# Remove "urgent" from closed issues
+bd list --status closed --label urgent --json | jq -r '.[].id' | while read id; do
+  bd label remove "$id" urgent
+done
+```
+
+## Integration with Git Workflow
+
+Labels are stored in the Dolt database and synced automatically with all issue data:
+
+```bash
+# Make changes
+bd create "Fix bug" -l backend,urgent
+bd label add bd-42 needs-review
+
+# Changes are committed to Dolt history automatically
+# Sync with remotes when ready:
+bd dolt push
+
+# After pulling changes:
+bd dolt pull
+bd list --label backend  # Fresh data including labels
+```
+
+## Markdown Import/Export
+
+Labels are preserved when importing from markdown:
+
+```markdown
+# Fix Authentication Bug
+
+### Type
+bug
+
+### Priority
+1
+
+### Labels
+auth, backend, urgent, needs-review
+
+### Description
+Users can't log in after recent deployment.
+```
+
+```bash
+bd create -f issue.md
+# Creates issue with all four labels
+```
+
+## Best Practices
+
+### 1. Establish Conventions Early
+Document your team's label taxonomy:
+```bash
+# Add to project README or CONTRIBUTING.md
+- Use lowercase, hyphen-separated (e.g., `good-first-issue`)
+- Prefix team labels (e.g., `team-infra`, `team-product`)
+- Use consistent size labels (`small`, `medium`, `large`)
+```
+
+### 2. Don't Overuse Labels
+Labels are flexible, but too many can cause confusion. Prefer:
+- 5-10 core technical labels (`backend`, `frontend`, `api`, etc.)
+- 3-5 domain labels per project
+- Standard process labels (`needs-review`, `needs-tests`)
+- Release labels as needed
+
+### 3. Clean Up Unused Labels
+Periodically review:
+```bash
+bd label list-all
+# Remove obsolete labels from issues
+```
+
+### 4. Use Labels for Filtering, Not Search
+Labels are for categorization, not free-text search:
+- ✅ Good: `backend`, `auth`, `urgent`
+- ❌ Bad: `fix-the-login-bug`, `john-asked-for-this`
+
+### 5. Combine with Dependencies
+Labels + dependencies = powerful organization:
+```bash
+# Epic with labeled subtasks
+bd create "Auth system rewrite" -t epic -p 1 -l auth,v2.0
+bd create "Implement JWT" -t task -p 1 -l auth,backend --deps parent-child:bd-42
+bd create "Update login UI" -t task -p 1 -l auth,frontend --deps parent-child:bd-42
+
+# Find all v2.0 auth work
+bd list --label auth,v2.0
+```
+
+## AI Agent Usage
+
+Labels are especially useful for AI agents managing complex workflows:
+
+```bash
+# Auto-label discovered work
+bd create "Found TODO in auth.go" -t task -p 2 -l auto-generated,technical-debt
+
+# Filter for agent review
+bd list --label needs-review --status in_progress --json
+
+# Track automation metadata
+bd label add bd-42 ai-generated
+bd label add bd-42 needs-human-review
+```
+
+Example agent workflow:
+```bash
+# Agent discovers issues during refactor
+bd create "Extract validateToken function" -t chore -p 2 \
+  -l technical-debt,backend,auth,small \
+  --deps discovered-from:bd-10
+
+# Agent marks work for review
+bd update bd-42 --claim
+# ... agent does work ...
+bd label add bd-42 needs-review
+bd label add bd-42 ai-generated
+
+# Human reviews and approves
+bd label remove bd-42 needs-review
+bd label add bd-42 approved
+bd close bd-42
+```
+
+## Labels as State Cache
+
+Labels can cache operational state for fast queries, enabling patterns where beads track both immutable history (events) and current state (labels).
+
+### The Pattern
+
+**Convention:** `<dimension>:<value>`
+
+Examples:
+- `patrol:muted` / `patrol:active` - patrol suppression state
+- `mode:degraded` / `mode:normal` - operational mode
+- `status:idle` / `status:working` - worker status
+- `health:healthy` / `health:failing` - component health
+
+**Implementation:**
+1. Create an event bead (full context, immutable history)
+2. Update the role bead's labels (current state cache)
+
+```bash
+# Event: Full record of what happened and why
+bd create "Muted patrol: user requested during debugging" -t event \
+  -l event-type:patrol-muted,actor:observer,reason:user-request
+
+# State: Update the role bead's label to reflect current state
+bd label remove beads/observer patrol:active
+bd label add beads/observer patrol:muted
+```
+
+**Key principle:** Events are the source of truth. Labels are a cache for fast queries.
+
+### Why This Pattern?
+
+**Fast queries without event scanning:**
+```bash
+# Without labels-as-state: scan all events to find current patrol state
+bd list --type event | grep "patrol" | tail -1  # Slow, fragile
+
+# With labels-as-state: direct query
+bd show beads/observer | grep "patrol:"  # Instant
+```
+
+**History preserved:**
+```bash
+# When was patrol muted? Why? Who did it?
+bd list --label event-type:patrol-muted --type event
+```
+
+**State recovery:**
+```bash
+# If labels get corrupted, rebuild from events
+bd list --type event --label event-type:patrol-muted | tail -1
+# Then re-apply the label
+```
+
+### Common State Dimensions
+
+| Dimension | Values | Use Case |
+|-----------|--------|----------|
+| `patrol:` | `active`, `muted` | Patrol cycle suppression |
+| `mode:` | `normal`, `degraded`, `maintenance` | Operational mode |
+| `status:` | `idle`, `working`, `blocked` | Worker activity |
+| `health:` | `healthy`, `warning`, `failing` | Component health |
+| `lock:` | `unlocked`, `locked` | Exclusive access control |
+
+### State Transitions
+
+Always create an event before changing state labels:
+
+```bash
+# Function to transition state with audit trail
+transition_state() {
+  local role="$1"
+  local dimension="$2"
+  local old_value="$3"
+  local new_value="$4"
+  local reason="$5"
+
+  # Record the transition
+  bd create "State change: $dimension $old_value → $new_value" -t event \
+    -l "event-type:state-change,dimension:$dimension,from:$old_value,to:$new_value"
+
+  # Update the cache
+  bd label remove "$role" "$dimension:$old_value"
+  bd label add "$role" "$dimension:$new_value"
+}
+
+# Usage
+transition_state beads/observer patrol active muted "User debugging session"
+```
+
+### Querying State
+
+```bash
+# Current state of a role
+bd label list beads/observer | grep ":"
+
+# All roles in a specific state
+bd list --label patrol:muted
+
+# Roles NOT in expected state
+bd list --label-any mode:degraded,health:failing
+
+# History of state changes
+bd list --type event --label event-type:state-change
+```
+
+### Best Practices
+
+1. **Use namespaced dimensions** - Prefix with role type if ambiguous
+2. **Keep value sets small** - 2-4 values per dimension
+3. **Document valid values** - List allowed values in role docs
+4. **Always create events first** - Never update labels without history
+5. **Treat labels as ephemeral** - Rebuild from events if corrupted
+
+### Future Helpers
+
+The pattern suggests helper commands (see bd-7l67):
+```bash
+# Query current state
+bd state beads/observer patrol     # → "muted"
+
+# Transition with automatic event creation
+bd set-state beads/observer patrol=active --reason "Debugging complete"
+```
+
+Until helpers exist, use the manual pattern above.
+
+## Advanced Patterns
+
+### Component Matrix
+Track issues across multiple dimensions:
+```bash
+# Backend + auth + high priority
+bd list --label backend,auth --priority 1
+
+# Any frontend work that's small
+bd list --label-any frontend,ui --label small
+
+# Critical issues across all components
+bd list --priority 0 --label-any backend,frontend,infrastructure
+```
+
+### Sprint Planning
+```bash
+# Label issues for sprint
+for id in bd-42 bd-43 bd-44 bd-45; do
+  bd label add "$id" sprint-12
+done
+
+# Track sprint progress
+bd list --label sprint-12 --status closed    # Velocity
+bd list --label sprint-12 --status open      # Remaining
+bd stats | grep "In Progress"                # Current WIP
+```
+
+### Technical Debt Tracking
+```bash
+# Mark debt
+bd create "Refactor legacy parser" -t chore -p 3 -l technical-debt,large
+
+# Find debt to tackle
+bd list --label technical-debt --label small
+bd list --label technical-debt --priority 1  # High-priority debt
+```
+
+### Breaking Change Coordination
+```bash
+# Identify breaking changes
+bd label add bd-42 breaking-change
+bd label add bd-42 v2.0
+
+# Find all breaking changes for next major release
+bd list --label breaking-change,v2.0
+
+# Ensure they're documented
+bd list --label breaking-change --label needs-docs
+```
+
+## Operational State Pattern (Labels as Cache)
+
+For orchestration systems, labels can cache the current operational state of "role beads" (issues representing agents or system components). This enables fast state queries without scanning event history.
+
+### Convention: `<dimension>:<value>`
+
+Use colon-separated labels with a dimension prefix and value suffix:
+
+```
+patrol:muted      patrol:active
+mode:degraded     mode:normal
+status:idle       status:working
+health:healthy    health:failing
+```
+
+### The Pattern
+
+1. **Create an event bead** with full context (immutable, audit trail)
+2. **Update the role bead's labels** to reflect current state (fast lookup)
+
+```bash
+# 1. Record the event (source of truth)
+bd create "Muted patrol for agent-abc" -t event \
+  --parent agent-abc \
+  -d "Reason: investigating stuck worker. Expected duration: 30m"
+
+# 2. Update the cached state label
+bd label remove agent-abc patrol:active
+bd label add agent-abc patrol:muted
+```
+
+### Why This Pattern?
+
+**Events are source of truth. Labels are cache.**
+
+| Approach | Events Only | Labels as Cache |
+|----------|-------------|-----------------|
+| Query current state | Scan all events, find latest | `bd list --label patrol:muted` |
+| Query state history | Natural (all events exist) | Query events |
+| Audit trail | Complete | Complete (events still exist) |
+| Performance | O(n) events | O(1) label lookup |
+
+The pattern gives you both: complete history via events, fast queries via labels.
+
+### Example: Agent Role States
+
+```bash
+# Create a role bead for an agent
+bd create "witness-alpha" -t role -l patrol:active,mode:normal,health:healthy
+
+# Agent enters degraded mode
+bd create "Degraded: high error rate" -t event --parent witness-alpha \
+  -d "Error rate exceeded 5%. Reducing poll frequency."
+bd label remove witness-alpha mode:normal
+bd label add witness-alpha mode:degraded
+
+# Query current state
+bd list --label mode:degraded --type role  # All degraded roles
+
+# Agent recovers
+bd create "Recovered: error rate normal" -t event --parent witness-alpha
+bd label remove witness-alpha mode:degraded
+bd label add witness-alpha mode:normal
+```
+
+### Common Dimensions
+
+| Dimension | Values | Use Case |
+|-----------|--------|----------|
+| `patrol` | `active`, `muted`, `suspended` | Agent patrol cycles |
+| `mode` | `normal`, `degraded`, `maintenance` | Operational modes |
+| `status` | `idle`, `working`, `blocked` | Work state |
+| `health` | `healthy`, `warning`, `failing` | Health checks |
+| `sync` | `current`, `stale`, `syncing` | Sync state |
+
+### Best Practices
+
+1. **Always create the event first** - Labels are cache; events are truth
+2. **Remove old value before adding new** - Prevents dimension:value1 + dimension:value2 conflicts
+3. **Use consistent dimension names** - Establish team conventions early
+4. **Keep dimensions orthogonal** - patrol and mode are independent concerns
+
+### Querying State
+
+```bash
+# Find all muted patrols
+bd list --label patrol:muted
+
+# Find healthy agents in normal mode
+bd list --label health:healthy,mode:normal
+
+# Find any non-healthy agents
+bd list --label-any health:warning,health:failing
+
+# Get state for a specific role
+bd label list witness-alpha
+# Output: patrol:active, mode:normal, health:healthy
+```
+
+### Helper Commands
+
+For convenience, use these helpers:
+
+```bash
+# Query a specific dimension
+bd state witness-alpha patrol
+# Output: active
+
+# List all state dimensions
+bd state list witness-alpha
+# Output:
+#   patrol: active
+#   mode: normal
+#   health: healthy
+
+# Set state (creates event + updates label atomically)
+bd set-state witness-alpha patrol=muted --reason "Investigating issue"
+```
+
+The `set-state` command atomically:
+1. Creates an event bead with the reason (source of truth)
+2. Removes the old dimension label if present
+3. Adds the new dimension:value label (cache)
+
+See [CLI_REFERENCE.md](/cli-reference/set-state) for full command reference.
+
+## Troubleshooting
+
+### Labels Not Showing in List
+Labels require explicit fetching. The `bd list` command shows issues but not labels in human output (only in JSON).
+
+```bash
+# See labels in JSON
+bd list --json | jq '.[] | {id, labels}'
+
+# See labels for specific issue
+bd show bd-42 --json | jq '.labels'
+bd label list bd-42
+```
+
+### Label Filtering Not Working
+Check label names for exact matches (case-sensitive):
+```bash
+# These are different labels:
+bd label add bd-42 Backend    # Capital B
+bd list --label backend       # Won't match
+
+# List all labels to see exact names
+bd label list-all
+```
+
+### Syncing Labels
+Labels are stored in the Dolt database. If labels seem out of sync:
+```bash
+# Pull from Dolt remote
+bd dolt pull
+
+# Or run doctor to diagnose
+bd doctor
+```
+
+## See Also
+
+- [README.md](https://github.com/gastownhall/beads/blob/main/README.md) - Main documentation
+- [AGENTS.md](https://github.com/gastownhall/beads/blob/main/AGENTS.md) - AI agent integration guide
+- [ADVANCED.md](/reference/advanced) - Advanced features and configuration
+
+</document>
+
+<document path="docs/core-concepts/metadata.md">
+
+
+# Issue Metadata
+
+The `metadata` field on issues accepts arbitrary JSON. Any valid JSON value is stored as-is.
+
+Metadata is the preferred extension point for data that is specific to an
+integration, orchestrator, team workflow, or experimental automation. Before
+adding first-class fields, commands, or schema changes, check the
+[Project Charter](https://github.com/gastownhall/beads/blob/main/docs/PROJECT_CHARTER.md#schema-boundary).
+
+## Example: Agent Execution Metadata
+
+Agent execution hints are one example of using metadata to extend beads without
+adding new native database fields. Automation may store these hints so agents
+can make routing decisions without parsing prose. Agents enacting an issue
+should read metadata first, then use description and notes for scope and
+rationale:
+
+```bash
+bd show <id> --json | jq '.[0] | {id,title,metadata,description,notes}'
+```
+
+The current convention for execution hint keys is:
+
+| Key | Meaning |
+|-----|---------|
+| `execution_agent_type` | Suggested worker class, such as `explorer`, `worker`, or `mixed`. |
+| `execution_suggested_model` | Suggested model for the parent agent or spawned subagent. |
+| `execution_reasoning_effort` | Suggested reasoning effort, such as `low`, `medium`, `high`, or `xhigh`. |
+| `execution_mode` | Whether work should be local, delegated, or staged between delegated and local execution. |
+| `execution_parallel_group` | Grouping hint for work that can run alongside related tasks. |
+
+These keys are advisory metadata, not core issue fields. When a workflow uses
+them, they take precedence over free-form notes for execution routing. Notes
+remain useful for rationale, ownership, and exact prompts.
+
+Parent/orchestrator agents must consume these keys before spawning subagents.
+Model and reasoning effort are normally fixed at launch, so reading metadata
+after delegation is too late.
+
+Do not add a first-class helper such as `bd show <id> --execution` or
+`bd plan <id> --json` yet. Keep using the JSON/JQ snippet until upstream
+issue gh-3541 determines whether schedulers or runners need these fields as a
+stable CLI surface.
+
+## Example: Verification Metadata
+
+Local verification queues are another example of metadata as an extension
+point. They may store slow-suite state in issue metadata. These keys describe
+the validation gate for a specific candidate commit:
+
+| Key | Meaning |
+|-----|---------|
+| `verify_state` | Verification state: `queued`, `running`, `passed`, or `failed`. |
+| `verify_head` | Commit SHA that the verification result applies to. |
+| `verify_branch` | Branch name recorded when verification was queued. |
+| `verify_cmd` | Command run in the clean verification worktree. |
+| `verify_log` | Local path to the verifier log. |
+| `verify_result` | Compact result, such as `exit=0` or `exit=1`. |
+| `verify_enqueued_at` | UTC timestamp when the verification was queued. |
+| `verify_started_at` | UTC timestamp when the verification started. |
+| `verify_finished_at` | UTC timestamp when the verification finished. |
+| `verify_worktree` | Source or clean verification worktree path. |
+| `verify_runner` | Local verifier identity, usually `host:pid`. |
+
+Treat `verify_head` as the source of truth. A passing result gates that exact
+commit only; if the branch moves, enqueue verification again.
+
+## Reserved Key Prefixes
+
+| Prefix | Reserved For |
+|--------|------------|
+| `bd:` | Beads internal use |
+| `_` | Internal/private keys |
+
+Avoid these prefixes in user-defined keys to prevent conflicts with future Beads features.
+
+## Related
+
+- [Project Charter](https://github.com/gastownhall/beads/blob/main/docs/PROJECT_CHARTER.md) - Product scope and schema boundary
+- [#1416](https://github.com/gastownhall/beads/issues/1416) - Optional schema enforcement (future)
+
+</document>
+
+<document path="docs/core-concepts/sync-concepts.md">
+
+
+# Sync Concepts
+
+Beads issue data lives in Dolt. The local Dolt database is the source of truth
+for `bd list`, `bd show`, `bd ready`, and every write command.
+
+## The Wire Format
+
+Cross-machine sync uses Dolt remotes:
+
+```bash
+bd dolt push
+bd dolt pull
+```
+
+For normal git-hosted projects, the Dolt remote can be the same `origin` URL
+used for source code. Dolt stores issue history under `refs/dolt/data`, separate
+from source branches such as `refs/heads/main`.
+
+On new projects, `bd init` auto-detects `git remote get-url origin` and
+configures a Dolt remote named `origin`. The first `bd dolt push` publishes
+`refs/dolt/data`. Fresh clones should run `bd bootstrap` to clone that Dolt
+history. When bootstrap finds `refs/dolt/data` on git origin, it also wires
+that origin as the Dolt remote for future `bd dolt push` and `bd dolt pull`.
+
+## What JSONL Is For
+
+`.beads/issues.jsonl` is an export. It exists for viewers, interchange,
+migration, and backup. It is not the canonical cross-machine sync channel.
+
+Do not use routine `bd import .beads/issues.jsonl` as a replacement for
+`bd dolt pull`. JSONL import is upsert-only; it cannot infer that records absent
+from an export were deleted, pruned, or simply never exported.
+
+## Hooks
+
+The pre-commit hook refreshes `.beads/issues.jsonl` when `export.auto=true`.
+That keeps the export current for tools, but it does not push Dolt history.
+
+The post-merge and post-checkout hooks skip JSONL import when `sync.remote` is
+configured. For old projects with no Dolt remote, they may import JSONL as a
+compatibility fallback and print a warning that this is not durable sync.
+
+## Repair
+
+For projects initialized before automatic git-origin remote wiring, pick the
+machine with the authoritative local Dolt database first. Then run:
+
+```bash
+bd dolt remote list
+bd export -o .beads/issues.pre-remote.jsonl   # optional issue audit export
+bd dolt remote add origin <git-origin-url>
+bd dolt push
+```
+
+Use the Dolt-compatible git URL form when needed. For example,
+`git+ssh://git@github.com/org/repo.git` or
+`git+https://github.com/org/repo.git`. `bd dolt remote add origin ...`
+persists `sync.remote` into `.beads/config.yaml`; commit and push that config
+change so fresh clones can run `bd bootstrap`.
+
+Other machines should then run:
+
+```bash
+bd dolt pull
+# or, if the local database is stale or missing:
+bd bootstrap
+```
+
+</document>
+
 <document path="docs/architecture/index.md">
 
 
@@ -11959,6 +12907,138 @@ bd doctor
 
 </document>
 
+<document path="docs/recovery/uninstalling.md">
+
+
+# Uninstalling Beads
+
+This guide explains how to remove beads from a repository or remove the `bd`
+binary from a machine.
+
+## Before You Remove Data
+
+Removing `.beads/` permanently deletes the local Dolt database. If the issue
+history matters, make a Dolt-native backup first:
+
+```bash
+bd backup init /path/to/beads-backup
+bd backup sync
+```
+
+For review, migration, or interoperability, you can also write an issue-table
+export:
+
+```bash
+bd export -o ~/beads-issues-$(date +%Y%m%d).jsonl
+```
+
+`bd export` is not a complete restorable database backup. It does not preserve
+Dolt branches, commit history, working-set state, or non-issue tables.
+
+## Repository Reset
+
+Use `bd reset` from the repository root. It previews what will be removed by
+default:
+
+```bash
+bd reset
+```
+
+If the preview is correct, run:
+
+```bash
+bd reset --force
+```
+
+This removes beads-managed repository data such as:
+
+- the `.beads/` directory
+- beads-managed git hook sections
+- legacy beads sync worktrees under `.git/beads-worktrees/`
+
+## Remove Hooks Only
+
+To keep issue data but remove git hooks:
+
+```bash
+bd hooks uninstall
+```
+
+This is preferable to manually deleting hook files because beads preserves
+unrelated user hook content outside its managed hook markers.
+
+## Manual Cleanup
+
+Use manual cleanup only if `bd reset` is unavailable or cannot run in the
+repository.
+
+```bash
+# Stop a local Dolt server if one is running.
+bd dolt stop 2>/dev/null || true
+
+# Remove beads-managed hooks when bd hooks uninstall is unavailable.
+rm -f .git/hooks/pre-commit
+rm -f .git/hooks/prepare-commit-msg
+rm -f .git/hooks/post-merge
+rm -f .git/hooks/pre-push
+rm -f .git/hooks/post-checkout
+
+# Remove the local beads database and config.
+rm -rf .beads
+
+# Remove legacy sync-branch worktrees from older beads versions.
+rm -rf .git/beads-worktrees
+git worktree prune
+```
+
+If `.gitattributes` contains only beads merge-driver configuration, remove it.
+If it contains other project entries, edit out only the beads line.
+
+If beads-specific git config remains, remove it:
+
+```bash
+git config --unset beads.role 2>/dev/null || true
+git config --unset merge.beads.driver 2>/dev/null || true
+git config --unset merge.beads.name 2>/dev/null || true
+```
+
+## Remove the `bd` Binary
+
+The CLI is a standalone binary. Remove it according to how it was installed:
+
+```bash
+# Homebrew
+brew uninstall beads
+
+# Go install
+rm -f "$(which bd)"
+
+# Manual install location
+rm -f /usr/local/bin/bd
+```
+
+If you installed the MCP package separately, remove that package with the tool
+you used to install it.
+
+## Verify Removal
+
+```bash
+which bd
+test ! -e .beads
+bd hooks status 2>/dev/null || true
+git config --get merge.beads.driver
+```
+
+## Reinstall Later
+
+To initialize beads again:
+
+```bash
+bd init
+```
+
+</document>
+
 <document path="docs/reference/advanced.md">
 
 
@@ -12138,6 +13218,217 @@ In CI/CD environments, beads uses embedded mode by default (no server required):
 # Just run commands directly — no special flags needed
 bd list
 ```
+
+</document>
+
+<document path="docs/reference/antivirus.md">
+
+
+# Antivirus False Positives
+
+## Overview
+
+Some antivirus software may flag beads (`bd` or `bd.exe`) as malicious. This is a **false positive** - beads is a legitimate, open-source command-line tool for issue tracking.
+
+Beads release installers now verify downloaded archives against release `checksums.txt` before installation. For users who manually install binaries, checksum verification should be the first trust step before running `bd` or creating antivirus exclusions.
+
+## Why This Happens
+
+Go binaries (including beads) are sometimes flagged by antivirus software due to:
+
+1. **Heuristic detection**: Some malware is written in Go, causing antivirus ML models to flag Go-specific binary patterns as suspicious
+2. **Behavioral analysis**: CLI tools that modify files and interact with git may trigger behavioral detection
+3. **Unsigned binaries**: Without code signing, new executables may be treated with suspicion
+
+This is a **known industry-wide problem** affecting many legitimate Go projects. See the [Go project issues](https://github.com/golang/go/issues/16292) for examples.
+
+## Known Issues
+
+### Kaspersky Antivirus
+
+**Detection**: `PDM:Trojan.Win32.Generic`
+**Affected versions**: bd.exe v0.23.1 and potentially others
+**Component**: System Watcher (Proactive Defense Module)
+
+Kaspersky's PDM (Proactive Defense Module) uses behavioral analysis that commonly triggers false positives on Go executables.
+
+## Solutions for Users
+
+### Option 1: Verify File Integrity (Recommended First)
+
+Before running a downloaded binary or adding antivirus exclusions, verify the file is legitimate:
+
+1. Download beads from the [official GitHub releases](https://github.com/gastownhall/beads/releases)
+2. Verify the SHA256 checksum matches the `checksums.txt` file in the release
+3. If a release includes code signing, verify that signature too
+
+**Verify checksum (Windows PowerShell):**
+```powershell
+Get-FileHash bd.exe -Algorithm SHA256
+```
+
+**Verify checksum (macOS/Linux):**
+```bash
+shasum -a 256 bd
+```
+
+Compare the output with the checksum in `checksums.txt` from the release page.
+
+### Option 2: Add Exclusion (After Verification)
+
+Add beads to your antivirus exclusion list:
+
+**Kaspersky:**
+1. Open Kaspersky and go to Settings
+2. Navigate to Threats and Exclusions → Manage Exclusions
+3. Click Add → Add path to exclusion
+4. Add the directory containing `bd.exe` (e.g., `C:\Users\YourName\AppData\Local\bd\`)
+5. Select which components the exclusion applies to (scan, monitoring, etc.)
+
+**Windows Defender:**
+1. Open Windows Security
+2. Go to Virus & threat protection → Manage settings
+3. Scroll to Exclusions → Add or remove exclusions
+4. Add the beads installation directory or the specific `bd.exe` file
+
+**Other antivirus software:**
+- Look for "Exclusions", "Whitelist", or "Trusted Applications" settings
+- Add the beads installation directory or executable
+
+### Option 3: Report False Positive
+
+Help improve detection accuracy by reporting the false positive:
+
+**Kaspersky:**
+1. Visit [Kaspersky Threat Intelligence Portal](https://opentip.kaspersky.com/)
+2. Upload the `bd.exe` file for analysis
+3. Mark it as a false positive
+4. Reference: beads is open-source CLI tool (https://github.com/gastownhall/beads)
+
+**Windows Defender:**
+1. Go to [Microsoft Security Intelligence](https://www.microsoft.com/en-us/wdsi/filesubmission)
+2. Submit the file as a false positive
+3. Provide details about the legitimate software
+
+**Other vendors:**
+- Check their website for false positive submission forms
+- Most major vendors have a process for reviewing flagged files
+
+## For Developers/Distributors
+
+If you're building beads from source or distributing it:
+
+### Current Build Configuration
+
+Beads releases are built with multiple optimizations to reduce false positives:
+
+```yaml
+ldflags:
+  - -s -w  # Strip debug symbols and DWARF info
+```
+
+**Windows PE version info**: Release builds embed legitimate PE resource metadata
+(company name, product name, file description, version, copyright, and an
+application manifest) into the Windows binary using `go-winres`. This is one of the
+most effective measures against AV false positives — legitimate software almost
+always has PE metadata, and AV heuristics use its absence as a suspicion signal.
+
+These optimizations are applied automatically in official release builds.
+
+### Code Signing
+
+Windows releases are signed with an Authenticode certificate when available. Code signing:
+- Reduces false positive rates over time
+- Builds reputation with SmartScreen/antivirus vendors
+- Provides tamper verification
+
+**Verify a signed binary (Windows PowerShell):**
+```powershell
+# Check if the binary is signed
+Get-AuthenticodeSignature .\bd.exe
+
+# Expected output for signed binary:
+# SignerCertificate: [Certificate details]
+# Status: Valid
+```
+
+**Verify a signed binary (Linux/macOS with osslsigncode):**
+```bash
+# Install osslsigncode if not available
+# Ubuntu/Debian: apt-get install osslsigncode
+# macOS: brew install osslsigncode
+
+osslsigncode verify -in bd.exe
+```
+
+**Note:** Code signing requires an EV (Extended Validation) certificate, which involves a verification process. If a release is not signed, it means the certificate was not available at build time. Follow the checksum verification steps above to verify authenticity.
+
+### Alternative Build Methods
+
+Some users report success with:
+```bash
+go build -ldflags "-s -w" -o bd ./cmd/bd
+```
+
+However, results vary by antivirus vendor and version.
+
+## Frequently Asked Questions
+
+### Is beads safe to use?
+
+Yes. Beads is:
+- Open source (all code is auditable on [GitHub](https://github.com/gastownhall/beads))
+- Releases include checksums for verification
+- Used by developers worldwide
+- A simple CLI tool for issue tracking
+
+### Why don't you just fix the code to avoid detection?
+
+The issue isn't specific to beads' code - it's a characteristic of Go binaries in general. Changing code won't reliably prevent heuristic/behavioral detection. The proper solutions are:
+1. Code signing (builds trust over time)
+2. Whitelist applications with antivirus vendors
+3. User reports of false positives
+
+### Will this be fixed in future releases?
+
+We've implemented:
+- **Windows PE version info** embedded in binaries (company name, product name, version, manifest)
+- **Code signing infrastructure** for Windows releases (requires EV certificate)
+- **Build optimizations** to reduce heuristic triggers (`-s -w` ldflags)
+- **Documentation** for users to add exclusions and report false positives
+
+Still in progress:
+- Acquiring an EV code signing certificate
+- Submitting beads to antivirus vendor whitelists
+
+False positives may still occur with new releases until the certificate builds reputation with antivirus vendors. This typically takes several months of consistent signed releases.
+
+### Should I disable my antivirus?
+
+**No.** Instead:
+1. Verify release checksums before first run
+2. Keep your antivirus enabled for other threats
+3. Add beads to your antivirus exclusions only after verification if detections persist
+
+## Reporting Issues
+
+If you encounter a new antivirus false positive:
+
+1. Open an issue on [GitHub](https://github.com/gastownhall/beads/issues)
+2. Include:
+   - Antivirus software name and version
+   - Detection/threat name
+   - Beads version (`bd version`)
+   - Operating system
+
+This helps us track and address false positives across different antivirus vendors.
+
+## References
+
+- [Kaspersky False Positive Guide](https://support.kaspersky.com/1870)
+- [Go Binary False Positives Discussion](https://www.linkedin.com/pulse/go-false-positives-melle-boudewijns)
+- [Go Project Issue Tracker](https://github.com/golang/go/issues/16292)
+- [Kaspersky Community Forum](https://forum.kaspersky.com/topic/pdmtrojanwin32generic-54425/)
 
 </document>
 

--- a/website/static/llms.txt
+++ b/website/static/llms.txt
@@ -70,6 +70,7 @@ WARNING: Skipping sync or backup publication causes stale state in multi-agent w
 - Full docs: https://gastownhall.github.io/beads/
 - CLI reference: https://gastownhall.github.io/beads/cli-reference
 - Agent guide: https://gastownhall.github.io/beads/integrations/claude-code
+- Community tools: https://gastownhall.github.io/beads/community-tools
 - Complete LLM context: https://gastownhall.github.io/beads/llms-full.txt
 
 ## Links

--- a/website/static/llms.txt
+++ b/website/static/llms.txt
@@ -69,6 +69,7 @@ WARNING: Skipping sync or backup publication causes stale state in multi-agent w
 
 - Full docs: https://gastownhall.github.io/beads/
 - CLI reference: https://gastownhall.github.io/beads/cli-reference
+- Sync concepts: https://gastownhall.github.io/beads/core-concepts/sync-concepts
 - Agent guide: https://gastownhall.github.io/beads/integrations/claude-code
 - Community tools: https://gastownhall.github.io/beads/community-tools
 - Complete LLM context: https://gastownhall.github.io/beads/llms-full.txt

--- a/website/versioned_docs/version-1.0.5/community-tools.md
+++ b/website/versioned_docs/version-1.0.5/community-tools.md
@@ -1,3 +1,9 @@
+---
+id: community-tools
+title: Community Tools
+slug: /community-tools
+---
+
 # Beads Community Tools
 
 A curated list of community-built UIs, extensions, and integrations for Beads. Ranked by activity and maturity.

--- a/website/versioned_docs/version-1.0.5/core-concepts/labels.md
+++ b/website/versioned_docs/version-1.0.5/core-concepts/labels.md
@@ -1,0 +1,789 @@
+---
+id: labels
+title: Labels
+slug: /core-concepts/labels
+---
+
+# Labels in Beads
+
+Labels provide flexible, multi-dimensional categorization for issues beyond the structured fields (status, priority, type). Use labels for cross-cutting concerns, technical metadata, and contextual tagging without schema changes.
+
+## Design Philosophy
+
+**When to use labels vs. structured fields:**
+
+- **Structured fields** (status, priority, type) → Core workflow state
+  - Status: Where the issue is in the workflow (`open`, `in_progress`, `blocked`, `closed`)
+  - Priority: How urgent (0-4)
+  - Type: What kind of work (`bug`, `feature`, `task`, `epic`, `chore`)
+
+- **Labels** → Everything else
+  - Technical metadata (`backend`, `frontend`, `api`, `database`)
+  - Domain/scope (`auth`, `payments`, `search`, `analytics`)
+  - Effort estimates (`small`, `medium`, `large`)
+  - Quality gates (`needs-review`, `needs-tests`, `breaking-change`)
+  - Team/ownership (`team-infra`, `team-product`)
+  - Release tracking (`v1.0`, `v2.0`, `backport-candidate`)
+
+## Quick Start
+
+```bash
+# Add labels when creating issues
+bd create "Fix auth bug" -t bug -p 1 -l auth,backend,urgent
+
+# Add labels to existing issues
+bd label add bd-42 security
+bd label add bd-42 breaking-change
+
+# List issue labels
+bd label list bd-42
+
+# Remove a label
+bd label remove bd-42 urgent
+
+# List all labels in use
+bd label list-all
+
+# Filter by labels (AND - must have ALL)
+bd list --label backend,auth
+
+# Filter by labels (OR - must have AT LEAST ONE)
+bd list --label-any frontend,backend
+
+# Combine filters
+bd list --status open --priority 1 --label security
+```
+
+## Common Label Patterns
+
+### 1. Technical Component Labels
+
+Identify which part of the system:
+```bash
+backend
+frontend
+api
+database
+infrastructure
+cli
+ui
+mobile
+```
+
+**Example:**
+```bash
+bd create "Add GraphQL endpoint" -t feature -p 2 -l backend,api
+bd create "Update login form" -t task -p 2 -l frontend,auth,ui
+```
+
+### 2. Domain/Feature Area
+
+Group by business domain:
+```bash
+auth
+payments
+search
+analytics
+billing
+notifications
+reporting
+admin
+```
+
+**Example:**
+```bash
+bd list --label payments --status open  # All open payment issues
+bd list --label-any auth,security       # Security-related work
+```
+
+### 3. Size/Effort Estimates
+
+Quick effort indicators:
+```bash
+small     # < 1 day
+medium    # 1-3 days
+large     # > 3 days
+```
+
+**Example:**
+```bash
+# Find small quick wins
+bd ready --json | jq '.[] | select(.labels[] == "small")'
+```
+
+### 4. Quality Gates
+
+Track what's needed before closing:
+```bash
+needs-review
+needs-tests
+needs-docs
+breaking-change
+```
+
+**Example:**
+```bash
+bd label add bd-42 needs-review
+bd list --label needs-review --status in_progress
+```
+
+### 5. Release Management
+
+Track release targeting:
+```bash
+v1.0
+v2.0
+backport-candidate
+release-blocker
+```
+
+**Example:**
+```bash
+bd list --label v1.0 --status open    # What's left for v1.0?
+bd label add bd-42 release-blocker
+```
+
+### 6. Team/Ownership
+
+Indicate ownership or interest:
+```bash
+team-infra
+team-product
+team-mobile
+needs-triage
+help-wanted
+```
+
+**Example:**
+```bash
+bd list --assignee alice --label team-infra
+bd create "Memory leak in cache" -t bug -p 1 -l team-infra,help-wanted
+```
+
+### 7. Special Markers
+
+Process or workflow flags:
+```bash
+auto-generated     # Created by automation
+discovered-from    # Found during other work (also a dep type)
+technical-debt
+good-first-issue
+duplicate
+wontfix
+```
+
+**Example:**
+```bash
+bd create "TODO: Refactor parser" -t chore -p 3 -l technical-debt,auto-generated
+```
+
+## Filtering by Labels
+
+### AND Filtering (--label)
+All specified labels must be present:
+
+```bash
+# Issues that are BOTH backend AND urgent
+bd list --label backend,urgent
+
+# Open bugs that need review AND tests
+bd list --status open --type bug --label needs-review,needs-tests
+```
+
+### OR Filtering (--label-any)
+At least one specified label must be present:
+
+```bash
+# Issues in frontend OR backend
+bd list --label-any frontend,backend
+
+# Security or auth related
+bd list --label-any security,auth
+```
+
+### Combining AND/OR
+Mix both filters for complex queries:
+
+```bash
+# Backend issues that are EITHER urgent OR a blocker
+bd list --label backend --label-any urgent,release-blocker
+
+# Frontend work that needs BOTH review and tests, but in any component
+bd list --label needs-review,needs-tests --label-any frontend,ui,mobile
+```
+
+## Workflow Examples
+
+### Triage Workflow
+```bash
+# Create untriaged issue
+bd create "Crash on login" -t bug -p 1 -l needs-triage
+
+# During triage, add context
+bd label add bd-42 auth
+bd label add bd-42 backend
+bd label add bd-42 urgent
+bd label remove bd-42 needs-triage
+
+# Find untriaged issues
+bd list --label needs-triage
+```
+
+### Quality Gate Workflow
+```bash
+# Start work
+bd update bd-42 --claim
+
+# Mark quality requirements
+bd label add bd-42 needs-tests
+bd label add bd-42 needs-docs
+
+# Before closing, verify
+bd label list bd-42
+# ... write tests and docs ...
+bd label remove bd-42 needs-tests
+bd label remove bd-42 needs-docs
+
+# Close when gates satisfied
+bd close bd-42
+```
+
+### Release Planning
+```bash
+# Tag issues for v1.0
+bd label add bd-42 v1.0
+bd label add bd-43 v1.0
+bd label add bd-44 v1.0
+
+# Track v1.0 progress
+bd list --label v1.0 --status closed    # Done
+bd list --label v1.0 --status open      # Remaining
+bd stats  # Overall progress
+
+# Mark critical items
+bd label add bd-45 v1.0
+bd label add bd-45 release-blocker
+```
+
+### Component-Based Work Distribution
+```bash
+# Backend team picks up work
+bd ready --json | jq '.[] | select(.labels[]? == "backend")'
+
+# Frontend team finds small tasks
+bd list --status open --label frontend,small
+
+# Find help-wanted items for new contributors
+bd list --label help-wanted,good-first-issue
+```
+
+## Label Management
+
+### Listing Labels
+```bash
+# Labels on a specific issue
+bd label list bd-42
+
+# All labels in database with usage counts
+bd label list-all
+
+# JSON output for scripting
+bd label list-all --json
+```
+
+Output:
+```json
+[
+  {"label": "auth", "count": 5},
+  {"label": "backend", "count": 12},
+  {"label": "frontend", "count": 8}
+]
+```
+
+### Bulk Operations
+
+Add labels in batch during creation:
+```bash
+bd create "Issue" -l label1,label2,label3
+```
+
+Script to add label to multiple issues:
+```bash
+# Add "needs-review" to all in_progress issues
+bd list --status in_progress --json | jq -r '.[].id' | while read id; do
+  bd label add "$id" needs-review
+done
+```
+
+Remove label from multiple issues:
+```bash
+# Remove "urgent" from closed issues
+bd list --status closed --label urgent --json | jq -r '.[].id' | while read id; do
+  bd label remove "$id" urgent
+done
+```
+
+## Integration with Git Workflow
+
+Labels are stored in the Dolt database and synced automatically with all issue data:
+
+```bash
+# Make changes
+bd create "Fix bug" -l backend,urgent
+bd label add bd-42 needs-review
+
+# Changes are committed to Dolt history automatically
+# Sync with remotes when ready:
+bd dolt push
+
+# After pulling changes:
+bd dolt pull
+bd list --label backend  # Fresh data including labels
+```
+
+## Markdown Import/Export
+
+Labels are preserved when importing from markdown:
+
+```markdown
+# Fix Authentication Bug
+
+### Type
+bug
+
+### Priority
+1
+
+### Labels
+auth, backend, urgent, needs-review
+
+### Description
+Users can't log in after recent deployment.
+```
+
+```bash
+bd create -f issue.md
+# Creates issue with all four labels
+```
+
+## Best Practices
+
+### 1. Establish Conventions Early
+Document your team's label taxonomy:
+```bash
+# Add to project README or CONTRIBUTING.md
+- Use lowercase, hyphen-separated (e.g., `good-first-issue`)
+- Prefix team labels (e.g., `team-infra`, `team-product`)
+- Use consistent size labels (`small`, `medium`, `large`)
+```
+
+### 2. Don't Overuse Labels
+Labels are flexible, but too many can cause confusion. Prefer:
+- 5-10 core technical labels (`backend`, `frontend`, `api`, etc.)
+- 3-5 domain labels per project
+- Standard process labels (`needs-review`, `needs-tests`)
+- Release labels as needed
+
+### 3. Clean Up Unused Labels
+Periodically review:
+```bash
+bd label list-all
+# Remove obsolete labels from issues
+```
+
+### 4. Use Labels for Filtering, Not Search
+Labels are for categorization, not free-text search:
+- ✅ Good: `backend`, `auth`, `urgent`
+- ❌ Bad: `fix-the-login-bug`, `john-asked-for-this`
+
+### 5. Combine with Dependencies
+Labels + dependencies = powerful organization:
+```bash
+# Epic with labeled subtasks
+bd create "Auth system rewrite" -t epic -p 1 -l auth,v2.0
+bd create "Implement JWT" -t task -p 1 -l auth,backend --deps parent-child:bd-42
+bd create "Update login UI" -t task -p 1 -l auth,frontend --deps parent-child:bd-42
+
+# Find all v2.0 auth work
+bd list --label auth,v2.0
+```
+
+## AI Agent Usage
+
+Labels are especially useful for AI agents managing complex workflows:
+
+```bash
+# Auto-label discovered work
+bd create "Found TODO in auth.go" -t task -p 2 -l auto-generated,technical-debt
+
+# Filter for agent review
+bd list --label needs-review --status in_progress --json
+
+# Track automation metadata
+bd label add bd-42 ai-generated
+bd label add bd-42 needs-human-review
+```
+
+Example agent workflow:
+```bash
+# Agent discovers issues during refactor
+bd create "Extract validateToken function" -t chore -p 2 \
+  -l technical-debt,backend,auth,small \
+  --deps discovered-from:bd-10
+
+# Agent marks work for review
+bd update bd-42 --claim
+# ... agent does work ...
+bd label add bd-42 needs-review
+bd label add bd-42 ai-generated
+
+# Human reviews and approves
+bd label remove bd-42 needs-review
+bd label add bd-42 approved
+bd close bd-42
+```
+
+## Labels as State Cache
+
+Labels can cache operational state for fast queries, enabling patterns where beads track both immutable history (events) and current state (labels).
+
+### The Pattern
+
+**Convention:** `<dimension>:<value>`
+
+Examples:
+- `patrol:muted` / `patrol:active` - patrol suppression state
+- `mode:degraded` / `mode:normal` - operational mode
+- `status:idle` / `status:working` - worker status
+- `health:healthy` / `health:failing` - component health
+
+**Implementation:**
+1. Create an event bead (full context, immutable history)
+2. Update the role bead's labels (current state cache)
+
+```bash
+# Event: Full record of what happened and why
+bd create "Muted patrol: user requested during debugging" -t event \
+  -l event-type:patrol-muted,actor:observer,reason:user-request
+
+# State: Update the role bead's label to reflect current state
+bd label remove beads/observer patrol:active
+bd label add beads/observer patrol:muted
+```
+
+**Key principle:** Events are the source of truth. Labels are a cache for fast queries.
+
+### Why This Pattern?
+
+**Fast queries without event scanning:**
+```bash
+# Without labels-as-state: scan all events to find current patrol state
+bd list --type event | grep "patrol" | tail -1  # Slow, fragile
+
+# With labels-as-state: direct query
+bd show beads/observer | grep "patrol:"  # Instant
+```
+
+**History preserved:**
+```bash
+# When was patrol muted? Why? Who did it?
+bd list --label event-type:patrol-muted --type event
+```
+
+**State recovery:**
+```bash
+# If labels get corrupted, rebuild from events
+bd list --type event --label event-type:patrol-muted | tail -1
+# Then re-apply the label
+```
+
+### Common State Dimensions
+
+| Dimension | Values | Use Case |
+|-----------|--------|----------|
+| `patrol:` | `active`, `muted` | Patrol cycle suppression |
+| `mode:` | `normal`, `degraded`, `maintenance` | Operational mode |
+| `status:` | `idle`, `working`, `blocked` | Worker activity |
+| `health:` | `healthy`, `warning`, `failing` | Component health |
+| `lock:` | `unlocked`, `locked` | Exclusive access control |
+
+### State Transitions
+
+Always create an event before changing state labels:
+
+```bash
+# Function to transition state with audit trail
+transition_state() {
+  local role="$1"
+  local dimension="$2"
+  local old_value="$3"
+  local new_value="$4"
+  local reason="$5"
+
+  # Record the transition
+  bd create "State change: $dimension $old_value → $new_value" -t event \
+    -l "event-type:state-change,dimension:$dimension,from:$old_value,to:$new_value"
+
+  # Update the cache
+  bd label remove "$role" "$dimension:$old_value"
+  bd label add "$role" "$dimension:$new_value"
+}
+
+# Usage
+transition_state beads/observer patrol active muted "User debugging session"
+```
+
+### Querying State
+
+```bash
+# Current state of a role
+bd label list beads/observer | grep ":"
+
+# All roles in a specific state
+bd list --label patrol:muted
+
+# Roles NOT in expected state
+bd list --label-any mode:degraded,health:failing
+
+# History of state changes
+bd list --type event --label event-type:state-change
+```
+
+### Best Practices
+
+1. **Use namespaced dimensions** - Prefix with role type if ambiguous
+2. **Keep value sets small** - 2-4 values per dimension
+3. **Document valid values** - List allowed values in role docs
+4. **Always create events first** - Never update labels without history
+5. **Treat labels as ephemeral** - Rebuild from events if corrupted
+
+### Future Helpers
+
+The pattern suggests helper commands (see bd-7l67):
+```bash
+# Query current state
+bd state beads/observer patrol     # → "muted"
+
+# Transition with automatic event creation
+bd set-state beads/observer patrol=active --reason "Debugging complete"
+```
+
+Until helpers exist, use the manual pattern above.
+
+## Advanced Patterns
+
+### Component Matrix
+Track issues across multiple dimensions:
+```bash
+# Backend + auth + high priority
+bd list --label backend,auth --priority 1
+
+# Any frontend work that's small
+bd list --label-any frontend,ui --label small
+
+# Critical issues across all components
+bd list --priority 0 --label-any backend,frontend,infrastructure
+```
+
+### Sprint Planning
+```bash
+# Label issues for sprint
+for id in bd-42 bd-43 bd-44 bd-45; do
+  bd label add "$id" sprint-12
+done
+
+# Track sprint progress
+bd list --label sprint-12 --status closed    # Velocity
+bd list --label sprint-12 --status open      # Remaining
+bd stats | grep "In Progress"                # Current WIP
+```
+
+### Technical Debt Tracking
+```bash
+# Mark debt
+bd create "Refactor legacy parser" -t chore -p 3 -l technical-debt,large
+
+# Find debt to tackle
+bd list --label technical-debt --label small
+bd list --label technical-debt --priority 1  # High-priority debt
+```
+
+### Breaking Change Coordination
+```bash
+# Identify breaking changes
+bd label add bd-42 breaking-change
+bd label add bd-42 v2.0
+
+# Find all breaking changes for next major release
+bd list --label breaking-change,v2.0
+
+# Ensure they're documented
+bd list --label breaking-change --label needs-docs
+```
+
+## Operational State Pattern (Labels as Cache)
+
+For orchestration systems, labels can cache the current operational state of "role beads" (issues representing agents or system components). This enables fast state queries without scanning event history.
+
+### Convention: `<dimension>:<value>`
+
+Use colon-separated labels with a dimension prefix and value suffix:
+
+```
+patrol:muted      patrol:active
+mode:degraded     mode:normal
+status:idle       status:working
+health:healthy    health:failing
+```
+
+### The Pattern
+
+1. **Create an event bead** with full context (immutable, audit trail)
+2. **Update the role bead's labels** to reflect current state (fast lookup)
+
+```bash
+# 1. Record the event (source of truth)
+bd create "Muted patrol for agent-abc" -t event \
+  --parent agent-abc \
+  -d "Reason: investigating stuck worker. Expected duration: 30m"
+
+# 2. Update the cached state label
+bd label remove agent-abc patrol:active
+bd label add agent-abc patrol:muted
+```
+
+### Why This Pattern?
+
+**Events are source of truth. Labels are cache.**
+
+| Approach | Events Only | Labels as Cache |
+|----------|-------------|-----------------|
+| Query current state | Scan all events, find latest | `bd list --label patrol:muted` |
+| Query state history | Natural (all events exist) | Query events |
+| Audit trail | Complete | Complete (events still exist) |
+| Performance | O(n) events | O(1) label lookup |
+
+The pattern gives you both: complete history via events, fast queries via labels.
+
+### Example: Agent Role States
+
+```bash
+# Create a role bead for an agent
+bd create "witness-alpha" -t role -l patrol:active,mode:normal,health:healthy
+
+# Agent enters degraded mode
+bd create "Degraded: high error rate" -t event --parent witness-alpha \
+  -d "Error rate exceeded 5%. Reducing poll frequency."
+bd label remove witness-alpha mode:normal
+bd label add witness-alpha mode:degraded
+
+# Query current state
+bd list --label mode:degraded --type role  # All degraded roles
+
+# Agent recovers
+bd create "Recovered: error rate normal" -t event --parent witness-alpha
+bd label remove witness-alpha mode:degraded
+bd label add witness-alpha mode:normal
+```
+
+### Common Dimensions
+
+| Dimension | Values | Use Case |
+|-----------|--------|----------|
+| `patrol` | `active`, `muted`, `suspended` | Agent patrol cycles |
+| `mode` | `normal`, `degraded`, `maintenance` | Operational modes |
+| `status` | `idle`, `working`, `blocked` | Work state |
+| `health` | `healthy`, `warning`, `failing` | Health checks |
+| `sync` | `current`, `stale`, `syncing` | Sync state |
+
+### Best Practices
+
+1. **Always create the event first** - Labels are cache; events are truth
+2. **Remove old value before adding new** - Prevents dimension:value1 + dimension:value2 conflicts
+3. **Use consistent dimension names** - Establish team conventions early
+4. **Keep dimensions orthogonal** - patrol and mode are independent concerns
+
+### Querying State
+
+```bash
+# Find all muted patrols
+bd list --label patrol:muted
+
+# Find healthy agents in normal mode
+bd list --label health:healthy,mode:normal
+
+# Find any non-healthy agents
+bd list --label-any health:warning,health:failing
+
+# Get state for a specific role
+bd label list witness-alpha
+# Output: patrol:active, mode:normal, health:healthy
+```
+
+### Helper Commands
+
+For convenience, use these helpers:
+
+```bash
+# Query a specific dimension
+bd state witness-alpha patrol
+# Output: active
+
+# List all state dimensions
+bd state list witness-alpha
+# Output:
+#   patrol: active
+#   mode: normal
+#   health: healthy
+
+# Set state (creates event + updates label atomically)
+bd set-state witness-alpha patrol=muted --reason "Investigating issue"
+```
+
+The `set-state` command atomically:
+1. Creates an event bead with the reason (source of truth)
+2. Removes the old dimension label if present
+3. Adds the new dimension:value label (cache)
+
+See [CLI_REFERENCE.md](/cli-reference/set-state) for full command reference.
+
+## Troubleshooting
+
+### Labels Not Showing in List
+Labels require explicit fetching. The `bd list` command shows issues but not labels in human output (only in JSON).
+
+```bash
+# See labels in JSON
+bd list --json | jq '.[] | {id, labels}'
+
+# See labels for specific issue
+bd show bd-42 --json | jq '.labels'
+bd label list bd-42
+```
+
+### Label Filtering Not Working
+Check label names for exact matches (case-sensitive):
+```bash
+# These are different labels:
+bd label add bd-42 Backend    # Capital B
+bd list --label backend       # Won't match
+
+# List all labels to see exact names
+bd label list-all
+```
+
+### Syncing Labels
+Labels are stored in the Dolt database. If labels seem out of sync:
+```bash
+# Pull from Dolt remote
+bd dolt pull
+
+# Or run doctor to diagnose
+bd doctor
+```
+
+## See Also
+
+- [README.md](https://github.com/gastownhall/beads/blob/main/README.md) - Main documentation
+- [AGENTS.md](https://github.com/gastownhall/beads/blob/main/AGENTS.md) - AI agent integration guide
+- [ADVANCED.md](/reference/advanced) - Advanced features and configuration

--- a/website/versioned_docs/version-1.0.5/core-concepts/metadata.md
+++ b/website/versioned_docs/version-1.0.5/core-concepts/metadata.md
@@ -1,3 +1,9 @@
+---
+id: metadata
+title: Issue Metadata
+slug: /core-concepts/metadata
+---
+
 # Issue Metadata
 
 The `metadata` field on issues accepts arbitrary JSON. Any valid JSON value is stored as-is.
@@ -5,7 +11,7 @@ The `metadata` field on issues accepts arbitrary JSON. Any valid JSON value is s
 Metadata is the preferred extension point for data that is specific to an
 integration, orchestrator, team workflow, or experimental automation. Before
 adding first-class fields, commands, or schema changes, check the
-[Project Charter](PROJECT_CHARTER.md#schema-boundary).
+[Project Charter](https://github.com/gastownhall/beads/blob/main/docs/PROJECT_CHARTER.md#schema-boundary).
 
 ## Example: Agent Execution Metadata
 
@@ -76,5 +82,5 @@ Avoid these prefixes in user-defined keys to prevent conflicts with future Beads
 
 ## Related
 
-- [Project Charter](PROJECT_CHARTER.md) - Product scope and schema boundary
+- [Project Charter](https://github.com/gastownhall/beads/blob/main/docs/PROJECT_CHARTER.md) - Product scope and schema boundary
 - [#1416](https://github.com/gastownhall/beads/issues/1416) - Optional schema enforcement (future)

--- a/website/versioned_docs/version-1.0.5/core-concepts/metadata.md
+++ b/website/versioned_docs/version-1.0.5/core-concepts/metadata.md
@@ -48,28 +48,27 @@ Do not add a first-class helper such as `bd show <id> --execution` or
 issue gh-3541 determines whether schedulers or runners need these fields as a
 stable CLI surface.
 
-## Example: Verification Metadata
+## Example: Tracker Round-Trip Metadata
 
-Local verification queues are another example of metadata as an extension
-point. They may store slow-suite state in issue metadata. These keys describe
-the validation gate for a specific candidate commit:
+Tracker integrations map external issues into beads fields such as title,
+status, priority, type, labels, dependencies, and `external_ref`. When an
+integration needs to preserve tracker-specific fields that do not belong in the
+native beads schema, it can store those fields in issue metadata:
 
-| Key | Meaning |
-|-----|---------|
-| `verify_state` | Verification state: `queued`, `running`, `passed`, or `failed`. |
-| `verify_head` | Commit SHA that the verification result applies to. |
-| `verify_branch` | Branch name recorded when verification was queued. |
-| `verify_cmd` | Command run in the clean verification worktree. |
-| `verify_log` | Local path to the verifier log. |
-| `verify_result` | Compact result, such as `exit=0` or `exit=1`. |
-| `verify_enqueued_at` | UTC timestamp when the verification was queued. |
-| `verify_started_at` | UTC timestamp when the verification started. |
-| `verify_finished_at` | UTC timestamp when the verification finished. |
-| `verify_worktree` | Source or clean verification worktree path. |
-| `verify_runner` | Local verifier identity, usually `host:pid`. |
+```json
+{
+  "example_tracker": {
+    "board_id": "ENG",
+    "sprint_id": 42,
+    "remote_type": "story"
+  }
+}
+```
 
-Treat `verify_head` as the source of truth. A passing result gates that exact
-commit only; if the branch moves, enqueue verification again.
+This keeps beads' core issue model stable while allowing the integration to
+round-trip fields it understands. Prefer namespaced keys and keep
+tracker-specific policy in the integration. If a value becomes broadly useful
+to beads itself, revisit whether it deserves a native field.
 
 ## Reserved Key Prefixes
 

--- a/website/versioned_docs/version-1.0.5/core-concepts/sync-concepts.md
+++ b/website/versioned_docs/version-1.0.5/core-concepts/sync-concepts.md
@@ -1,0 +1,73 @@
+---
+id: sync-concepts
+title: Sync Concepts
+slug: /core-concepts/sync-concepts
+---
+
+# Sync Concepts
+
+Beads issue data lives in Dolt. The local Dolt database is the source of truth
+for `bd list`, `bd show`, `bd ready`, and every write command.
+
+## The Wire Format
+
+Cross-machine sync uses Dolt remotes:
+
+```bash
+bd dolt push
+bd dolt pull
+```
+
+For normal git-hosted projects, the Dolt remote can be the same `origin` URL
+used for source code. Dolt stores issue history under `refs/dolt/data`, separate
+from source branches such as `refs/heads/main`.
+
+On new projects, `bd init` auto-detects `git remote get-url origin` and
+configures a Dolt remote named `origin`. The first `bd dolt push` publishes
+`refs/dolt/data`. Fresh clones should run `bd bootstrap` to clone that Dolt
+history. When bootstrap finds `refs/dolt/data` on git origin, it also wires
+that origin as the Dolt remote for future `bd dolt push` and `bd dolt pull`.
+
+## What JSONL Is For
+
+`.beads/issues.jsonl` is an export. It exists for viewers, interchange,
+migration, and backup. It is not the canonical cross-machine sync channel.
+
+Do not use routine `bd import .beads/issues.jsonl` as a replacement for
+`bd dolt pull`. JSONL import is upsert-only; it cannot infer that records absent
+from an export were deleted, pruned, or simply never exported.
+
+## Hooks
+
+The pre-commit hook refreshes `.beads/issues.jsonl` when `export.auto=true`.
+That keeps the export current for tools, but it does not push Dolt history.
+
+The post-merge and post-checkout hooks skip JSONL import when `sync.remote` is
+configured. For old projects with no Dolt remote, they may import JSONL as a
+compatibility fallback and print a warning that this is not durable sync.
+
+## Repair
+
+For projects initialized before automatic git-origin remote wiring, pick the
+machine with the authoritative local Dolt database first. Then run:
+
+```bash
+bd dolt remote list
+bd export -o .beads/issues.pre-remote.jsonl   # optional issue audit export
+bd dolt remote add origin <git-origin-url>
+bd dolt push
+```
+
+Use the Dolt-compatible git URL form when needed. For example,
+`git+ssh://git@github.com/org/repo.git` or
+`git+https://github.com/org/repo.git`. `bd dolt remote add origin ...`
+persists `sync.remote` into `.beads/config.yaml`; commit and push that config
+change so fresh clones can run `bd bootstrap`.
+
+Other machines should then run:
+
+```bash
+bd dolt pull
+# or, if the local database is stale or missing:
+bd bootstrap
+```

--- a/website/versioned_docs/version-1.0.5/recovery/uninstalling.md
+++ b/website/versioned_docs/version-1.0.5/recovery/uninstalling.md
@@ -1,3 +1,9 @@
+---
+id: uninstalling
+title: Uninstalling
+slug: /recovery/uninstalling
+---
+
 # Uninstalling Beads
 
 This guide explains how to remove beads from a repository or remove the `bd`

--- a/website/versioned_docs/version-1.0.5/reference/antivirus.md
+++ b/website/versioned_docs/version-1.0.5/reference/antivirus.md
@@ -1,0 +1,211 @@
+---
+id: antivirus
+title: Antivirus False Positives
+slug: /reference/antivirus
+---
+
+# Antivirus False Positives
+
+## Overview
+
+Some antivirus software may flag beads (`bd` or `bd.exe`) as malicious. This is a **false positive** - beads is a legitimate, open-source command-line tool for issue tracking.
+
+Beads release installers now verify downloaded archives against release `checksums.txt` before installation. For users who manually install binaries, checksum verification should be the first trust step before running `bd` or creating antivirus exclusions.
+
+## Why This Happens
+
+Go binaries (including beads) are sometimes flagged by antivirus software due to:
+
+1. **Heuristic detection**: Some malware is written in Go, causing antivirus ML models to flag Go-specific binary patterns as suspicious
+2. **Behavioral analysis**: CLI tools that modify files and interact with git may trigger behavioral detection
+3. **Unsigned binaries**: Without code signing, new executables may be treated with suspicion
+
+This is a **known industry-wide problem** affecting many legitimate Go projects. See the [Go project issues](https://github.com/golang/go/issues/16292) for examples.
+
+## Known Issues
+
+### Kaspersky Antivirus
+
+**Detection**: `PDM:Trojan.Win32.Generic`
+**Affected versions**: bd.exe v0.23.1 and potentially others
+**Component**: System Watcher (Proactive Defense Module)
+
+Kaspersky's PDM (Proactive Defense Module) uses behavioral analysis that commonly triggers false positives on Go executables.
+
+## Solutions for Users
+
+### Option 1: Verify File Integrity (Recommended First)
+
+Before running a downloaded binary or adding antivirus exclusions, verify the file is legitimate:
+
+1. Download beads from the [official GitHub releases](https://github.com/gastownhall/beads/releases)
+2. Verify the SHA256 checksum matches the `checksums.txt` file in the release
+3. If a release includes code signing, verify that signature too
+
+**Verify checksum (Windows PowerShell):**
+```powershell
+Get-FileHash bd.exe -Algorithm SHA256
+```
+
+**Verify checksum (macOS/Linux):**
+```bash
+shasum -a 256 bd
+```
+
+Compare the output with the checksum in `checksums.txt` from the release page.
+
+### Option 2: Add Exclusion (After Verification)
+
+Add beads to your antivirus exclusion list:
+
+**Kaspersky:**
+1. Open Kaspersky and go to Settings
+2. Navigate to Threats and Exclusions → Manage Exclusions
+3. Click Add → Add path to exclusion
+4. Add the directory containing `bd.exe` (e.g., `C:\Users\YourName\AppData\Local\bd\`)
+5. Select which components the exclusion applies to (scan, monitoring, etc.)
+
+**Windows Defender:**
+1. Open Windows Security
+2. Go to Virus & threat protection → Manage settings
+3. Scroll to Exclusions → Add or remove exclusions
+4. Add the beads installation directory or the specific `bd.exe` file
+
+**Other antivirus software:**
+- Look for "Exclusions", "Whitelist", or "Trusted Applications" settings
+- Add the beads installation directory or executable
+
+### Option 3: Report False Positive
+
+Help improve detection accuracy by reporting the false positive:
+
+**Kaspersky:**
+1. Visit [Kaspersky Threat Intelligence Portal](https://opentip.kaspersky.com/)
+2. Upload the `bd.exe` file for analysis
+3. Mark it as a false positive
+4. Reference: beads is open-source CLI tool (https://github.com/gastownhall/beads)
+
+**Windows Defender:**
+1. Go to [Microsoft Security Intelligence](https://www.microsoft.com/en-us/wdsi/filesubmission)
+2. Submit the file as a false positive
+3. Provide details about the legitimate software
+
+**Other vendors:**
+- Check their website for false positive submission forms
+- Most major vendors have a process for reviewing flagged files
+
+## For Developers/Distributors
+
+If you're building beads from source or distributing it:
+
+### Current Build Configuration
+
+Beads releases are built with multiple optimizations to reduce false positives:
+
+```yaml
+ldflags:
+  - -s -w  # Strip debug symbols and DWARF info
+```
+
+**Windows PE version info**: Release builds embed legitimate PE resource metadata
+(company name, product name, file description, version, copyright, and an
+application manifest) into the Windows binary using `go-winres`. This is one of the
+most effective measures against AV false positives — legitimate software almost
+always has PE metadata, and AV heuristics use its absence as a suspicion signal.
+
+These optimizations are applied automatically in official release builds.
+
+### Code Signing
+
+Windows releases are signed with an Authenticode certificate when available. Code signing:
+- Reduces false positive rates over time
+- Builds reputation with SmartScreen/antivirus vendors
+- Provides tamper verification
+
+**Verify a signed binary (Windows PowerShell):**
+```powershell
+# Check if the binary is signed
+Get-AuthenticodeSignature .\bd.exe
+
+# Expected output for signed binary:
+# SignerCertificate: [Certificate details]
+# Status: Valid
+```
+
+**Verify a signed binary (Linux/macOS with osslsigncode):**
+```bash
+# Install osslsigncode if not available
+# Ubuntu/Debian: apt-get install osslsigncode
+# macOS: brew install osslsigncode
+
+osslsigncode verify -in bd.exe
+```
+
+**Note:** Code signing requires an EV (Extended Validation) certificate, which involves a verification process. If a release is not signed, it means the certificate was not available at build time. Follow the checksum verification steps above to verify authenticity.
+
+### Alternative Build Methods
+
+Some users report success with:
+```bash
+go build -ldflags "-s -w" -o bd ./cmd/bd
+```
+
+However, results vary by antivirus vendor and version.
+
+## Frequently Asked Questions
+
+### Is beads safe to use?
+
+Yes. Beads is:
+- Open source (all code is auditable on [GitHub](https://github.com/gastownhall/beads))
+- Releases include checksums for verification
+- Used by developers worldwide
+- A simple CLI tool for issue tracking
+
+### Why don't you just fix the code to avoid detection?
+
+The issue isn't specific to beads' code - it's a characteristic of Go binaries in general. Changing code won't reliably prevent heuristic/behavioral detection. The proper solutions are:
+1. Code signing (builds trust over time)
+2. Whitelist applications with antivirus vendors
+3. User reports of false positives
+
+### Will this be fixed in future releases?
+
+We've implemented:
+- **Windows PE version info** embedded in binaries (company name, product name, version, manifest)
+- **Code signing infrastructure** for Windows releases (requires EV certificate)
+- **Build optimizations** to reduce heuristic triggers (`-s -w` ldflags)
+- **Documentation** for users to add exclusions and report false positives
+
+Still in progress:
+- Acquiring an EV code signing certificate
+- Submitting beads to antivirus vendor whitelists
+
+False positives may still occur with new releases until the certificate builds reputation with antivirus vendors. This typically takes several months of consistent signed releases.
+
+### Should I disable my antivirus?
+
+**No.** Instead:
+1. Verify release checksums before first run
+2. Keep your antivirus enabled for other threats
+3. Add beads to your antivirus exclusions only after verification if detections persist
+
+## Reporting Issues
+
+If you encounter a new antivirus false positive:
+
+1. Open an issue on [GitHub](https://github.com/gastownhall/beads/issues)
+2. Include:
+   - Antivirus software name and version
+   - Detection/threat name
+   - Beads version (`bd version`)
+   - Operating system
+
+This helps us track and address false positives across different antivirus vendors.
+
+## References
+
+- [Kaspersky False Positive Guide](https://support.kaspersky.com/1870)
+- [Go Binary False Positives Discussion](https://www.linkedin.com/pulse/go-false-positives-melle-boudewijns)
+- [Go Project Issue Tracker](https://github.com/golang/go/issues/16292)
+- [Kaspersky Community Forum](https://forum.kaspersky.com/topic/pdmtrojanwin32generic-54425/)

--- a/website/versioned_sidebars/version-1.0.5-sidebars.json
+++ b/website/versioned_sidebars/version-1.0.5-sidebars.json
@@ -100,6 +100,7 @@
         "integrations/github-copilot"
       ]
     },
+    "community-tools",
     {
       "type": "category",
       "label": "Reference",

--- a/website/versioned_sidebars/version-1.0.5-sidebars.json
+++ b/website/versioned_sidebars/version-1.0.5-sidebars.json
@@ -18,7 +18,10 @@
       "items": [
         "core-concepts/index",
         "core-concepts/issues",
-        "core-concepts/hash-ids"
+        "core-concepts/hash-ids",
+        "core-concepts/sync-concepts",
+        "core-concepts/labels",
+        "core-concepts/metadata"
       ]
     },
     {
@@ -65,7 +68,8 @@
         "recovery/database-corruption",
         "recovery/merge-conflicts",
         "recovery/circular-dependencies",
-        "recovery/sync-failures"
+        "recovery/sync-failures",
+        "recovery/uninstalling"
       ]
     },
     {
@@ -110,6 +114,7 @@
         "reference/git-integration",
         "reference/advanced",
         "reference/troubleshooting",
+        "reference/antivirus",
         "reference/faq"
       ]
     }


### PR DESCRIPTION
## Why

Several active root docs describe public beads concepts or support workflows, but the GitHub Pages site did not publish them. The most visible gap was `docs/COMMUNITY_TOOLS.md`: the site's Integrations section covers first-party setup recipes and MCP/editor support, not third-party tools that build on top of beads.

This PR mirrors selected canonical root docs into Docusaurus automatically so Pages publishes them without relying on a maintainer or agent to remember a manual copy step.

## What Changed

- Added `scripts/sync-website-docs.sh` and ran it from the website package gate.
- Published Community Tools as a top-level docs page.
- Published Sync Concepts, Labels, and Issue Metadata under Core Concepts.
- Published Uninstalling under Recovery.
- Published Antivirus False Positives under Reference.
- Mirrored the same pages into the 1.0.5 versioned docs snapshot, which backs the default Pages route.
- Added sidebar, footer, `llms.txt`, and `llms-full.txt` coverage.
- Triggered Pages deployment when any mirrored source doc or the sync script changes.
- Clarified that agent execution and tracker round-trip metadata are examples of metadata extension conventions, not native issue fields.

## Follow-Ups Filed

- mybd-nyaa: investigate whether Observability should become an opt-in operator/advanced website page.
- mybd-bm4d: audit Worktrees and Protected Branches docs before surfacing removed sync-branch workflows.
- mybd-ptm8: audit Website Advanced Features for stale/internal public surface.

## Verification

- `bd-main/scripts/pr-preflight.sh --search "community tools docs website pages docusaurus" --repo gastownhall/beads`
- `bash -n scripts/sync-website-docs.sh scripts/generate-llms-full.sh scripts/ci/website.sh`
- `git diff --check`
- `make ci-website`
