### PR TITLE
fix: support jj secondary workspaces for .beads/ discovery and role detection

### DIFF
--- a/internal/beads/beads.go
+++ b/internal/beads/beads.go
@@ -533,6 +533,24 @@ func FindBeadsDirFrom(startDir string) string {
 	if out, err := gitOutput(startDir, "rev-parse", "--show-toplevel"); err == nil {
 		repoRoot = utils.CanonicalizePath(out)
 	}
+
+	jjSecondaryRoot := ""
+	jjPrimaryBeadsDir := ""
+	jjPrimaryHasDB := false
+	if root, ok := git.JJSecondaryWorkspaceRootFrom(startDir); ok {
+		jjSecondaryRoot = utils.CanonicalizePath(root)
+		if primaryRoot, err := git.GetJJPrimaryWorkspaceRootFrom(startDir); err == nil && primaryRoot != "" {
+			primaryBeadsDir := filepath.Join(primaryRoot, ".beads")
+			if info, err := os.Stat(primaryBeadsDir); err == nil && info.IsDir() {
+				resolved := FollowRedirect(primaryBeadsDir)
+				if hasBeadsProjectFiles(resolved) {
+					jjPrimaryBeadsDir = resolved
+					jjPrimaryHasDB = hasBeadsDatabase(resolved)
+				}
+			}
+		}
+	}
+
 	fallbackBeadsDir := ""
 	fallbackHasDB := false
 	if repoRoot != "" {
@@ -549,10 +567,15 @@ func FindBeadsDirFrom(startDir string) string {
 		if info, err := os.Stat(beadsDir); err == nil && info.IsDir() {
 			resolved := FollowRedirect(beadsDir)
 			isWorktreeRoot := repoRoot != "" && utils.PathsEqual(dir, repoRoot)
+			isJJSecondaryRoot := jjSecondaryRoot != "" && utils.PathsEqual(dir, jjSecondaryRoot)
 			if isWorktreeRoot && fallbackHasDB && !hasBeadsDatabase(resolved) {
 				// A worktree root can contain tracked .beads metadata without
 				// owning the ignored database directory. Match FindBeadsDir by
 				// preferring the shared worktree database in that case.
+			} else if isJJSecondaryRoot && jjPrimaryHasDB && !hasBeadsDatabase(resolved) {
+				// A jj secondary workspace can likewise contain inherited
+				// .beads metadata without the ignored database directory.
+				// Match FindBeadsDir by preferring the primary workspace DB.
 			} else if hasBeadsProjectFiles(resolved) {
 				return resolved
 			}
@@ -572,6 +595,10 @@ func FindBeadsDirFrom(startDir string) string {
 				return resolved
 			}
 		}
+	}
+
+	if jjPrimaryBeadsDir != "" {
+		return jjPrimaryBeadsDir
 	}
 
 	return ""

--- a/internal/beads/beads.go
+++ b/internal/beads/beads.go
@@ -691,12 +691,25 @@ func FindBeadsDir() string {
 	// Determine the walk-up boundary: worktree root for worktrees, git root otherwise.
 	// We stop BEFORE the boundary so worktree fallback logic can handle the root's .beads/.
 	isWt := git.IsWorktree()
+	// A jj secondary workspace is inside the primary's git tree but is not a git
+	// worktree. git.GetRepoRoot() returns the PRIMARY workspace root in that case,
+	// so without correction the walk would cross the secondary workspace boundary and
+	// find the secondary's git-tracked .beads/ (which has config files but no DB).
+	// Treat the jj secondary workspace root as the walk boundary, then step 3 below
+	// handles the fallback to the primary's .beads/ exactly like git worktrees do.
+	var jjSecondaryRoot string
+	var isJJSecondary bool
+	if !isWt {
+		jjSecondaryRoot, isJJSecondary = git.JJSecondaryWorkspaceRoot()
+	}
 	walkBoundary := gitRoot
 	if isWt {
 		// For worktrees, stop the walk at the worktree root.
 		// The worktree root's .beads/ may be git-tracked metadata without a real database;
 		// the worktree fallback logic (step 3) handles this correctly.
 		walkBoundary = git.GetRepoRoot()
+	} else if isJJSecondary {
+		walkBoundary = jjSecondaryRoot
 	}
 
 	// Canonicalize both walk start and walk boundary so the `dir == walkBoundary`
@@ -801,6 +814,44 @@ func FindBeadsDir() string {
 		if err != nil {
 			mainRepoRoot = ""
 		}
+	} else if isJJSecondary {
+		// 3'. JJ secondary fallback: mirror of step 3 for git worktrees
+		// (no 3'a — jj has no per-workspace redirect equivalent).
+		jjPrimaryRoot, jjPrimaryErr := git.GetJJPrimaryWorkspaceRoot()
+
+		// 3'b. Only accept the secondary's own .beads/ if it owns a real database.
+		// Otherwise it's git-tracked config inherited from the primary; fall through.
+		if jjSecondaryRoot != "" {
+			secondaryBeadsDir := filepath.Join(jjSecondaryRoot, ".beads")
+			if info, err := os.Stat(secondaryBeadsDir); err == nil && info.IsDir() {
+				if hasBeadsDatabase(secondaryBeadsDir) {
+					return secondaryBeadsDir
+				}
+				// Lenient acceptance only when the primary has no DB to fall back to.
+				primaryFallbackHasDB := false
+				if jjPrimaryErr == nil && jjPrimaryRoot != "" {
+					primaryBeadsDir := filepath.Join(jjPrimaryRoot, ".beads")
+					if pInfo, pErr := os.Stat(primaryBeadsDir); pErr == nil && pInfo.IsDir() {
+						primaryFallbackHasDB = hasBeadsDatabase(FollowRedirect(primaryBeadsDir))
+					}
+				}
+				if !primaryFallbackHasDB && hasBeadsProjectFiles(secondaryBeadsDir) {
+					return secondaryBeadsDir
+				}
+			}
+		}
+
+		// 3'c.
+		if jjPrimaryErr == nil && jjPrimaryRoot != "" {
+			primaryBeadsDir := filepath.Join(jjPrimaryRoot, ".beads")
+			if info, err := os.Stat(primaryBeadsDir); err == nil && info.IsDir() {
+				resolved := FollowRedirect(primaryBeadsDir)
+				if hasBeadsProjectFiles(resolved) {
+					return resolved
+				}
+			}
+			mainRepoRoot = jjPrimaryRoot
+		}
 	}
 
 	// 4. Extended walk: from walk boundary to git/main-repo root.
@@ -810,7 +861,7 @@ func FindBeadsDir() string {
 	// Skip if there was no walk boundary (step 2 already searched everything).
 	if walkBoundary != "" {
 		extendedRoot := gitRoot
-		if isWt && mainRepoRoot != "" {
+		if (isWt || isJJSecondary) && mainRepoRoot != "" {
 			extendedRoot = mainRepoRoot
 		}
 		// Canonicalize the extended-root so the `dir == extendedRoot` check
@@ -987,19 +1038,24 @@ func findDatabaseInTree() string {
 	// canonicalization strategy in FindBeadsDir.
 	dir = utils.CanonicalizePath(dir)
 
+	isWt := git.IsWorktree()
+	var jjSecondaryRoot string
+	var isJJSecondary bool
+	if !isWt {
+		jjSecondaryRoot, isJJSecondary = git.JJSecondaryWorkspaceRoot()
+	}
+
 	// Check cwd first — a rig subdirectory with its own .beads/ takes
 	// priority over the git root's .beads/ (same fix as FindBeadsDir step 1b).
 	//
-	// In a worktree, skip the CWD check at the worktree root. The worktree
-	// root's .beads/ may contain git-tracked metadata (metadata.json with
-	// dolt_mode=server) inherited from the parent repo checkout, but NOT the
-	// gitignored dolt/ data directory. In server mode, findDatabaseInBeadsDir
-	// returns a path regardless of whether the data dir exists, which would
-	// short-circuit the worktree-aware fallback below — causing each worktree
-	// to spawn its own dolt server against an empty data directory.
-	// The worktree-specific code (below) handles this correctly.
+	// Skip the CWD check at the worktree root (git worktree) or jj secondary
+	// workspace root: those directories may contain git-tracked metadata
+	// (metadata.json, config.yaml) without a real database. In server mode,
+	// findDatabaseInBeadsDir returns a path regardless of whether the data
+	// directory exists, so without this skip bd would open an empty DB.
 	{
-		skipCwdCheck := git.IsWorktree() && dir == utils.CanonicalizePath(git.GetRepoRoot())
+		skipCwdCheck := (isWt && dir == utils.CanonicalizePath(git.GetRepoRoot())) ||
+			(isJJSecondary && dir == utils.CanonicalizePath(jjSecondaryRoot))
 		if !skipCwdCheck {
 			cwdBeadsDir := filepath.Join(dir, ".beads")
 			if info, err := os.Stat(cwdBeadsDir); err == nil && info.IsDir() {
@@ -1011,9 +1067,9 @@ func findDatabaseInTree() string {
 		}
 	}
 
-	// Check if we're in a git worktree
+	// Check if we're in a git worktree or jj secondary workspace.
 	var mainRepoRoot string
-	if git.IsWorktree() {
+	if isWt {
 		// Per-worktree redirect override
 		if target := worktreeRedirectTarget(); target != "" {
 			if dbPath := findDatabaseInBeadsDir(target, true); dbPath != "" {
@@ -1053,12 +1109,37 @@ func findDatabaseInTree() string {
 			mainRepoRoot = ""
 		}
 		// If not found in main repo, fall back to worktree search below
+	} else if isJJSecondary {
+		jjPrimaryRoot, jjPrimaryErr := git.GetJJPrimaryWorkspaceRoot()
+
+		// Separate-DB mode: only honor secondary's .beads/ if it owns a real DB;
+		// otherwise it's inherited git-tracked config and we want the primary.
+		if jjSecondaryRoot != "" {
+			secondaryBeadsDir := filepath.Join(jjSecondaryRoot, ".beads")
+			if info, err := os.Stat(secondaryBeadsDir); err == nil && info.IsDir() {
+				if hasBeadsDatabase(secondaryBeadsDir) {
+					if dbPath := findDatabaseInBeadsDir(secondaryBeadsDir, true); dbPath != "" {
+						return dbPath
+					}
+				}
+			}
+		}
+
+		if jjPrimaryErr == nil && jjPrimaryRoot != "" {
+			primaryBeadsDir := filepath.Join(jjPrimaryRoot, ".beads")
+			if info, err := os.Stat(primaryBeadsDir); err == nil && info.IsDir() {
+				primaryBeadsDir = FollowRedirect(primaryBeadsDir)
+				if dbPath := findDatabaseInBeadsDir(primaryBeadsDir, true); dbPath != "" {
+					return dbPath
+				}
+			}
+			mainRepoRoot = jjPrimaryRoot
+		}
 	}
 
 	// Find git root to limit the search
 	gitRoot := findGitRoot()
-	if git.IsWorktree() && mainRepoRoot != "" {
-		// For worktrees, extend search boundary to include main repo
+	if (isWt || isJJSecondary) && mainRepoRoot != "" {
 		gitRoot = mainRepoRoot
 	}
 	// Canonicalize the boundary so the `dir == gitRoot` comparison is robust

--- a/internal/beads/beads_inherited_artifacts_test.go
+++ b/internal/beads/beads_inherited_artifacts_test.go
@@ -550,6 +550,208 @@ func TestFindDatabasePath_WorktreeServerModeSharesMainRepo(t *testing.T) {
 	}
 }
 
+// TestFindBeadsDir_JJSecondaryWithInheritedArtifacts covers the case where a
+// jujutsu secondary workspace (created via `jj workspace add` without
+// --colocate from a colocated jj+git primary workspace) is placed inside the
+// primary's git working tree. The secondary's .beads/ contains git-tracked
+// metadata files but no database, while the primary has the real database.
+// FindBeadsDir must return the primary's .beads/, not the secondary's.
+func TestFindBeadsDir_JJSecondaryWithInheritedArtifacts(t *testing.T) {
+	originalEnv := os.Getenv("BEADS_DIR")
+	defer func() {
+		if originalEnv != "" {
+			os.Setenv("BEADS_DIR", originalEnv)
+		} else {
+			os.Unsetenv("BEADS_DIR")
+		}
+	}()
+	os.Unsetenv("BEADS_DIR")
+
+	tmpDir, err := os.MkdirTemp("", "beads-jj-secondary-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+	tmpDir, _ = filepath.EvalSymlinks(tmpDir)
+
+	// Primary workspace: colocated jj+git, has .jj/repo as a directory and .git.
+	primaryDir := filepath.Join(tmpDir, "primary")
+	if err := os.MkdirAll(filepath.Join(primaryDir, ".jj", "repo"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Secondary workspace: inside the primary's tree (like `jj workspace add ./workspaces/secondary`).
+	// Has .jj/repo as a FILE pointing to primary's .jj/repo.
+	secondaryDir := filepath.Join(primaryDir, "workspaces", "secondary")
+	if err := os.MkdirAll(filepath.Join(secondaryDir, ".jj"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	primaryRepoPath := filepath.Join(primaryDir, ".jj", "repo")
+	if err := os.WriteFile(filepath.Join(secondaryDir, ".jj", "repo"), []byte(primaryRepoPath+"\n"), 0o640); err != nil {
+		t.Fatal(err)
+	}
+
+	// Set up git in the primary (so git rev-parse works from the secondary).
+	runGit := func(dir string, args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		out, gitErr := cmd.CombinedOutput()
+		if gitErr != nil {
+			t.Fatalf("git %v in %s: %v\n%s", args, dir, gitErr, out)
+		}
+	}
+	if err := func() error {
+		cmd := exec.Command("git", "init")
+		cmd.Dir = primaryDir
+		return cmd.Run()
+	}(); err != nil {
+		t.Skipf("git not available: %v", err)
+	}
+	runGit(primaryDir, "config", "user.email", "test@example.com")
+	runGit(primaryDir, "config", "user.name", "Test User")
+
+	mustWrite := func(path, body string) {
+		t.Helper()
+		if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Primary .beads/: real database + config.
+	primaryBeadsDir := filepath.Join(primaryDir, ".beads")
+	if err := os.MkdirAll(primaryBeadsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	mustWrite(filepath.Join(primaryBeadsDir, "metadata.json"), `{"database":"dolt"}`)
+	mustWrite(filepath.Join(primaryBeadsDir, "config.yaml"), "issue-prefix: \"proj\"\n")
+	mustWrite(filepath.Join(primaryBeadsDir, "beads.db"), "")
+	mustWrite(filepath.Join(primaryBeadsDir, ".gitignore"), "*.db\ndolt/\nembeddeddolt/\n")
+
+	// Commit the metadata so the secondary inherits it via git checkout.
+	mustWrite(filepath.Join(primaryDir, "README.md"), "# Test\n")
+	runGit(primaryDir, "add", "README.md", ".beads/metadata.json", ".beads/config.yaml", ".beads/.gitignore")
+	runGit(primaryDir, "commit", "-m", "initial")
+
+	// Simulate the secondary workspace inheriting tracked .beads/ artifacts (no DB).
+	secondaryBeadsDir := filepath.Join(secondaryDir, ".beads")
+	if err := os.MkdirAll(secondaryBeadsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	mustWrite(filepath.Join(secondaryBeadsDir, "metadata.json"), `{"database":"dolt"}`)
+	mustWrite(filepath.Join(secondaryBeadsDir, "config.yaml"), "issue-prefix: \"proj\"\n")
+	// No database in secondary — this is the inherited-artifacts scenario.
+
+	t.Chdir(secondaryDir)
+	git.ResetCaches()
+
+	result := FindBeadsDir()
+
+	resultResolved, _ := filepath.EvalSymlinks(result)
+	primaryBeadsDirResolved, _ := filepath.EvalSymlinks(primaryBeadsDir)
+	secondaryBeadsDirResolved, _ := filepath.EvalSymlinks(secondaryBeadsDir)
+
+	if resultResolved == secondaryBeadsDirResolved {
+		t.Fatalf("FindBeadsDir() returned secondary workspace's inherited .beads/ (%q); "+
+			"expected primary workspace's .beads/ (%q). "+
+			"Secondary has config files but no database; bd should use the primary's DB.",
+			result, primaryBeadsDir)
+	}
+	if resultResolved != primaryBeadsDirResolved {
+		t.Errorf("FindBeadsDir() = %q, want primary workspace .beads %q", result, primaryBeadsDir)
+	}
+}
+
+// TestFindBeadsDir_JJSecondarySeparateDBPreservesLocal verifies that when a jj
+// secondary workspace genuinely has its own database (separate-DB mode),
+// FindBeadsDir returns the secondary's .beads/ — not the primary's.
+func TestFindBeadsDir_JJSecondarySeparateDBPreservesLocal(t *testing.T) {
+	originalEnv := os.Getenv("BEADS_DIR")
+	defer func() {
+		if originalEnv != "" {
+			os.Setenv("BEADS_DIR", originalEnv)
+		} else {
+			os.Unsetenv("BEADS_DIR")
+		}
+	}()
+	os.Unsetenv("BEADS_DIR")
+
+	tmpDir, err := os.MkdirTemp("", "beads-jj-secondary-sep-db-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+	tmpDir, _ = filepath.EvalSymlinks(tmpDir)
+
+	primaryDir := filepath.Join(tmpDir, "primary")
+	if err := os.MkdirAll(filepath.Join(primaryDir, ".jj", "repo"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	secondaryDir := filepath.Join(primaryDir, "workspaces", "secondary")
+	if err := os.MkdirAll(filepath.Join(secondaryDir, ".jj"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	primaryRepoPath := filepath.Join(primaryDir, ".jj", "repo")
+	if err := os.WriteFile(filepath.Join(secondaryDir, ".jj", "repo"), []byte(primaryRepoPath+"\n"), 0o640); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := func() error {
+		cmd := exec.Command("git", "init")
+		cmd.Dir = primaryDir
+		return cmd.Run()
+	}(); err != nil {
+		t.Skipf("git not available: %v", err)
+	}
+	runGit := func(dir string, args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		out, gitErr := cmd.CombinedOutput()
+		if gitErr != nil {
+			t.Fatalf("git %v in %s: %v\n%s", args, dir, gitErr, out)
+		}
+	}
+	runGit(primaryDir, "config", "user.email", "test@example.com")
+	runGit(primaryDir, "config", "user.name", "Test User")
+
+	// Primary has a real DB.
+	primaryBeadsDir := filepath.Join(primaryDir, ".beads")
+	if err := os.MkdirAll(primaryBeadsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(primaryBeadsDir, "beads.db"), []byte{}, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(primaryDir, "README.md"), []byte("# Test\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGit(primaryDir, "add", "README.md")
+	runGit(primaryDir, "commit", "-m", "initial")
+
+	// Secondary ALSO has a real DB — separate-DB mode.
+	secondaryBeadsDir := filepath.Join(secondaryDir, ".beads")
+	if err := os.MkdirAll(secondaryBeadsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(secondaryBeadsDir, "beads.db"), []byte{}, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Chdir(secondaryDir)
+	git.ResetCaches()
+
+	result := FindBeadsDir()
+	resultResolved, _ := filepath.EvalSymlinks(result)
+	secondaryBeadsDirResolved, _ := filepath.EvalSymlinks(secondaryBeadsDir)
+
+	if resultResolved != secondaryBeadsDirResolved {
+		t.Errorf("FindBeadsDir() = %q, want secondary workspace .beads %q (separate-DB mode)",
+			result, secondaryBeadsDir)
+	}
+}
+
 // TestFindDatabasePath_WorktreeServerModeFromSubdir is the same scenario as
 // TestFindDatabasePath_WorktreeServerModeSharesMainRepo but with the CWD set
 // to a subdirectory of the worktree rather than the worktree root. This

--- a/internal/beads/beads_inherited_artifacts_test.go
+++ b/internal/beads/beads_inherited_artifacts_test.go
@@ -660,6 +660,17 @@ func TestFindBeadsDir_JJSecondaryWithInheritedArtifacts(t *testing.T) {
 	if resultResolved != primaryBeadsDirResolved {
 		t.Errorf("FindBeadsDir() = %q, want primary workspace .beads %q", result, primaryBeadsDir)
 	}
+
+	fromResult := FindBeadsDirFrom(secondaryDir)
+	fromResultResolved, _ := filepath.EvalSymlinks(fromResult)
+	if fromResultResolved == secondaryBeadsDirResolved {
+		t.Fatalf("FindBeadsDirFrom() returned secondary workspace's inherited .beads/ (%q); "+
+			"expected primary workspace's .beads/ (%q).",
+			fromResult, primaryBeadsDir)
+	}
+	if fromResultResolved != primaryBeadsDirResolved {
+		t.Errorf("FindBeadsDirFrom() = %q, want primary workspace .beads %q", fromResult, primaryBeadsDir)
+	}
 }
 
 // TestFindBeadsDir_JJSecondarySeparateDBPreservesLocal verifies that when a jj
@@ -749,6 +760,13 @@ func TestFindBeadsDir_JJSecondarySeparateDBPreservesLocal(t *testing.T) {
 	if resultResolved != secondaryBeadsDirResolved {
 		t.Errorf("FindBeadsDir() = %q, want secondary workspace .beads %q (separate-DB mode)",
 			result, secondaryBeadsDir)
+	}
+
+	fromResult := FindBeadsDirFrom(secondaryDir)
+	fromResultResolved, _ := filepath.EvalSymlinks(fromResult)
+	if fromResultResolved != secondaryBeadsDirResolved {
+		t.Errorf("FindBeadsDirFrom() = %q, want secondary workspace .beads %q (separate-DB mode)",
+			fromResult, secondaryBeadsDir)
 	}
 }
 

--- a/internal/git/gitdir.go
+++ b/internal/git/gitdir.go
@@ -313,7 +313,18 @@ func IsColocatedJJGit() bool {
 // Secondary workspaces have .jj/repo as a file (pointer to the primary's repo
 // directory) rather than a directory.
 func JJSecondaryWorkspaceRoot() (string, bool) {
-	jjRoot, err := GetJujutsuRoot()
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", false
+	}
+	return JJSecondaryWorkspaceRootFrom(cwd)
+}
+
+// JJSecondaryWorkspaceRootFrom is the path-aware variant of
+// JJSecondaryWorkspaceRoot: it resolves the jujutsu root starting from startDir
+// rather than the current working directory.
+func JJSecondaryWorkspaceRootFrom(startDir string) (string, bool) {
+	jjRoot, err := getJujutsuRootFrom(startDir)
 	if err != nil {
 		return "", false
 	}
@@ -337,7 +348,18 @@ func IsJJSecondaryWorkspace() bool {
 //
 // Returns an error if not in a jj secondary workspace or the path cannot be resolved.
 func GetJJPrimaryWorkspaceRoot() (string, error) {
-	jjRoot, err := GetJujutsuRoot()
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", fmt.Errorf("failed to get current directory: %w", err)
+	}
+	return GetJJPrimaryWorkspaceRootFrom(cwd)
+}
+
+// GetJJPrimaryWorkspaceRootFrom is the path-aware variant of
+// GetJJPrimaryWorkspaceRoot: it resolves the jujutsu root starting from startDir
+// rather than the current working directory.
+func GetJJPrimaryWorkspaceRootFrom(startDir string) (string, error) {
+	jjRoot, err := getJujutsuRootFrom(startDir)
 	if err != nil {
 		return "", err
 	}
@@ -391,8 +413,19 @@ func GetJujutsuRoot() (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("failed to get current directory: %w", err)
 	}
+	return getJujutsuRootFrom(cwd)
+}
 
-	dir := cwd
+// getJujutsuRootFrom walks up from startDir to find the jujutsu root, applying
+// the same .git-boundary rule as GetJujutsuRoot. startDir is made absolute first
+// so that a relative input (e.g. ".") walks correctly rather than stalling at
+// filepath.Dir(".") == ".".
+func getJujutsuRootFrom(startDir string) (string, error) {
+	dir, err := filepath.Abs(startDir)
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve start directory: %w", err)
+	}
+
 	for {
 		jjPath := filepath.Join(dir, ".jj")
 		if info, err := os.Stat(jjPath); err == nil && info.IsDir() {

--- a/internal/git/gitdir.go
+++ b/internal/git/gitdir.go
@@ -308,6 +308,77 @@ func IsColocatedJJGit() bool {
 	return err == nil
 }
 
+// JJSecondaryWorkspaceRoot returns the secondary workspace root and true if
+// CWD is inside a jujutsu secondary workspace; otherwise ("", false).
+// Secondary workspaces have .jj/repo as a file (pointer to the primary's repo
+// directory) rather than a directory.
+func JJSecondaryWorkspaceRoot() (string, bool) {
+	jjRoot, err := GetJujutsuRoot()
+	if err != nil {
+		return "", false
+	}
+	info, err := os.Stat(filepath.Join(jjRoot, ".jj", "repo"))
+	if err != nil || info.IsDir() {
+		return "", false
+	}
+	return jjRoot, true
+}
+
+// IsJJSecondaryWorkspace returns true if CWD is inside a jujutsu secondary workspace.
+func IsJJSecondaryWorkspace() bool {
+	_, ok := JJSecondaryWorkspaceRoot()
+	return ok
+}
+
+// GetJJPrimaryWorkspaceRoot returns the root directory of the primary jujutsu
+// workspace when called from inside a secondary workspace. The secondary's
+// .jj/repo file contains a path (relative or absolute) to the primary's
+// .jj/repo directory; the primary workspace root is two levels above that.
+//
+// Returns an error if not in a jj secondary workspace or the path cannot be resolved.
+func GetJJPrimaryWorkspaceRoot() (string, error) {
+	jjRoot, err := GetJujutsuRoot()
+	if err != nil {
+		return "", err
+	}
+
+	// #nosec G304 -- .jj/repo path is within a jujutsu workspace we located by walking from cwd
+	content, err := os.ReadFile(filepath.Join(jjRoot, ".jj", "repo"))
+	if err != nil {
+		return "", fmt.Errorf("failed to read .jj/repo: %w", err)
+	}
+
+	target := strings.TrimSpace(string(content))
+	if target == "" {
+		return "", fmt.Errorf(".jj/repo is empty")
+	}
+
+	// .jj/repo content is relative to the .jj/ directory, or absolute.
+	var primaryRepoFile string
+	if filepath.IsAbs(target) {
+		primaryRepoFile = target
+	} else {
+		primaryRepoFile = filepath.Join(jjRoot, ".jj", target)
+	}
+
+	primaryRepoFile, err = filepath.Abs(primaryRepoFile)
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve jj primary workspace path: %w", err)
+	}
+
+	// primaryRepoFile == <primary-root>/.jj/repo  →  root is Dir(Dir(that))
+	primaryRoot := filepath.Dir(filepath.Dir(primaryRepoFile))
+
+	if resolved, err := filepath.EvalSymlinks(primaryRoot); err == nil {
+		primaryRoot = resolved
+	}
+	if canonical := canonicalizeCase(primaryRoot); canonical != "" {
+		primaryRoot = canonical
+	}
+
+	return primaryRoot, nil
+}
+
 // GetJujutsuRoot returns the root directory of the jujutsu repository.
 // Returns empty string and error if not in a jujutsu repository.
 //

--- a/internal/git/jujutsu_test.go
+++ b/internal/git/jujutsu_test.go
@@ -6,6 +6,28 @@ import (
 	"testing"
 )
 
+// makeJJPrimaryWorkspace creates a minimal jj primary workspace directory.
+// The primary workspace has .jj/repo as a directory (not a file).
+func makeJJPrimaryWorkspace(t *testing.T, dir string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Join(dir, ".jj", "repo"), 0750); err != nil {
+		t.Fatalf("failed to create primary .jj/repo directory: %v", err)
+	}
+}
+
+// makeJJSecondaryWorkspace creates a minimal jj secondary workspace directory.
+// The secondary workspace has .jj/repo as a file pointing to the primary's .jj/repo.
+// repoTarget is the path to write into the .jj/repo file (relative or absolute).
+func makeJJSecondaryWorkspace(t *testing.T, dir, repoTarget string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Join(dir, ".jj"), 0750); err != nil {
+		t.Fatalf("failed to create secondary .jj directory: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".jj", "repo"), []byte(repoTarget+"\n"), 0640); err != nil {
+		t.Fatalf("failed to write .jj/repo file: %v", err)
+	}
+}
+
 func TestIsJujutsuRepo(t *testing.T) {
 	// Save original directory
 	origDir, err := os.Getwd()
@@ -235,4 +257,136 @@ func TestGetJujutsuRootStopsAtGitBoundary(t *testing.T) {
 	if err == nil {
 		t.Errorf("Expected error: .git boundary should prevent walking to parent .jj, but got root: %q", root)
 	}
+}
+
+func TestIsJJSecondaryWorkspace(t *testing.T) {
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Failed to get current directory: %v", err)
+	}
+	defer func() {
+		_ = os.Chdir(origDir)
+		ResetCaches()
+	}()
+
+	t.Run("primary workspace (repo is directory)", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		tmpDir, _ = filepath.EvalSymlinks(tmpDir)
+		makeJJPrimaryWorkspace(t, tmpDir)
+
+		if err := os.Chdir(tmpDir); err != nil {
+			t.Fatalf("Failed to chdir: %v", err)
+		}
+		ResetCaches()
+
+		if IsJJSecondaryWorkspace() {
+			t.Error("Expected IsJJSecondaryWorkspace() = false for primary workspace")
+		}
+	})
+
+	t.Run("secondary workspace (repo is file)", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		tmpDir, _ = filepath.EvalSymlinks(tmpDir)
+		primaryDir := filepath.Join(tmpDir, "primary")
+		secondaryDir := filepath.Join(tmpDir, "secondary")
+		makeJJPrimaryWorkspace(t, primaryDir)
+		makeJJSecondaryWorkspace(t, secondaryDir, filepath.Join(primaryDir, ".jj", "repo"))
+
+		if err := os.Chdir(secondaryDir); err != nil {
+			t.Fatalf("Failed to chdir: %v", err)
+		}
+		ResetCaches()
+
+		if !IsJJSecondaryWorkspace() {
+			t.Error("Expected IsJJSecondaryWorkspace() = true for secondary workspace")
+		}
+	})
+
+	t.Run("not a jj repo", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		if err := os.Chdir(tmpDir); err != nil {
+			t.Fatalf("Failed to chdir: %v", err)
+		}
+		ResetCaches()
+
+		if IsJJSecondaryWorkspace() {
+			t.Error("Expected IsJJSecondaryWorkspace() = false for non-jj directory")
+		}
+	})
+}
+
+func TestGetJJPrimaryWorkspaceRoot(t *testing.T) {
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Failed to get current directory: %v", err)
+	}
+	defer func() {
+		_ = os.Chdir(origDir)
+		ResetCaches()
+	}()
+
+	t.Run("secondary workspace with absolute path in repo file", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		tmpDir, _ = filepath.EvalSymlinks(tmpDir)
+		primaryDir := filepath.Join(tmpDir, "primary")
+		secondaryDir := filepath.Join(tmpDir, "secondary")
+		makeJJPrimaryWorkspace(t, primaryDir)
+		// Write absolute path to primary's .jj/repo
+		makeJJSecondaryWorkspace(t, secondaryDir, filepath.Join(primaryDir, ".jj", "repo"))
+
+		if err := os.Chdir(secondaryDir); err != nil {
+			t.Fatalf("Failed to chdir: %v", err)
+		}
+		ResetCaches()
+
+		got, err := GetJJPrimaryWorkspaceRoot()
+		if err != nil {
+			t.Fatalf("GetJJPrimaryWorkspaceRoot() returned error: %v", err)
+		}
+		if got != primaryDir {
+			t.Errorf("Expected primary root %q, got %q", primaryDir, got)
+		}
+	})
+
+	t.Run("secondary workspace with relative path in repo file", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		tmpDir, _ = filepath.EvalSymlinks(tmpDir)
+		primaryDir := filepath.Join(tmpDir, "primary")
+		secondaryDir := filepath.Join(tmpDir, "secondary")
+		makeJJPrimaryWorkspace(t, primaryDir)
+		// Write relative path: from secondary/.jj/ to primary/.jj/repo
+		// secondary/.jj/ -> ../../primary/.jj/repo
+		makeJJSecondaryWorkspace(t, secondaryDir, "../../primary/.jj/repo")
+
+		if err := os.Chdir(secondaryDir); err != nil {
+			t.Fatalf("Failed to chdir: %v", err)
+		}
+		ResetCaches()
+
+		got, err := GetJJPrimaryWorkspaceRoot()
+		if err != nil {
+			t.Fatalf("GetJJPrimaryWorkspaceRoot() returned error: %v", err)
+		}
+		if got != primaryDir {
+			t.Errorf("Expected primary root %q, got %q", primaryDir, got)
+		}
+	})
+
+	t.Run("primary workspace returns error", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		tmpDir, _ = filepath.EvalSymlinks(tmpDir)
+		makeJJPrimaryWorkspace(t, tmpDir)
+
+		if err := os.Chdir(tmpDir); err != nil {
+			t.Fatalf("Failed to chdir: %v", err)
+		}
+		ResetCaches()
+
+		// GetJJPrimaryWorkspaceRoot reads .jj/repo as a file; in a primary workspace
+		// .jj/repo is a directory, so ReadFile should fail.
+		_, err := GetJJPrimaryWorkspaceRoot()
+		if err == nil {
+			t.Error("Expected error from GetJJPrimaryWorkspaceRoot() in primary workspace")
+		}
+	})
 }

--- a/internal/routing/routing.go
+++ b/internal/routing/routing.go
@@ -44,13 +44,10 @@ func DetectUserRole(repoPath string) (UserRole, error) {
 	// fails even when the primary workspace has beads.role set. Resolve the
 	// primary workspace and retry there, then run the remaining fallbacks
 	// against the primary's git repo since the secondary has no usable git
-	// context. (GH#2950)
-	//
-	// NOTE: this jj resolution is based on the current working directory, not
-	// repoPath. That is correct for the current callers (both pass "."); a
-	// future caller passing a non-cwd repoPath would need this revisited.
-	if _, isSecondary := git.JJSecondaryWorkspaceRoot(); isSecondary {
-		if primaryRoot, err := git.GetJJPrimaryWorkspaceRoot(); err == nil {
+	// context. The resolution is anchored at repoPath (not cwd) so it stays
+	// consistent with the git-config lookup above. (GH#2950)
+	if _, isSecondary := git.JJSecondaryWorkspaceRootFrom(repoPath); isSecondary {
+		if primaryRoot, err := git.GetJJPrimaryWorkspaceRootFrom(repoPath); err == nil {
 			if role, ok := roleFromGitConfig(primaryRoot); ok {
 				return role, nil
 			}

--- a/internal/routing/routing.go
+++ b/internal/routing/routing.go
@@ -7,6 +7,8 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+
+	"github.com/steveyegge/beads/internal/git"
 )
 
 var gitCommandRunner = func(repoPath string, args ...string) ([]byte, error) {
@@ -34,16 +36,26 @@ const (
 // 3. Default to maintainer for local projects (no remote configured)
 func DetectUserRole(repoPath string) (UserRole, error) {
 	// First check for explicit role in git config (preferred source)
-	output, err := gitCommandRunner(repoPath, "config", "--get", "beads.role")
-	if err == nil {
-		role := strings.TrimSpace(string(output))
-		if role == string(Maintainer) {
-			return Maintainer, nil
+	if role, ok := roleFromGitConfig(repoPath); ok {
+		return role, nil
+	}
+
+	// jj secondary workspaces have no .git of their own, so the lookup above
+	// fails even when the primary workspace has beads.role set. Resolve the
+	// primary workspace and retry there, then run the remaining fallbacks
+	// against the primary's git repo since the secondary has no usable git
+	// context. (GH#2950)
+	//
+	// NOTE: this jj resolution is based on the current working directory, not
+	// repoPath. That is correct for the current callers (both pass "."); a
+	// future caller passing a non-cwd repoPath would need this revisited.
+	if _, isSecondary := git.JJSecondaryWorkspaceRoot(); isSecondary {
+		if primaryRoot, err := git.GetJJPrimaryWorkspaceRoot(); err == nil {
+			if role, ok := roleFromGitConfig(primaryRoot); ok {
+				return role, nil
+			}
+			repoPath = primaryRoot
 		}
-		if role == string(Contributor) {
-			return Contributor, nil
-		}
-		// Invalid role value - fall through with warning
 	}
 
 	// Fallback to URL heuristic (deprecated, with warning)
@@ -52,6 +64,23 @@ func DetectUserRole(repoPath string) (UserRole, error) {
 	fmt.Fprintln(os.Stderr, "  Fix: git config beads.role maintainer")
 	fmt.Fprintln(os.Stderr, "  Or:  git config beads.role contributor")
 	return detectFromURL(repoPath), nil
+}
+
+// roleFromGitConfig reads beads.role from the git config of repoPath.
+// Returns (role, true) only for a valid explicit value; (_, false) when the
+// config is unset, git is unavailable, or the value is not a recognized role.
+func roleFromGitConfig(repoPath string) (UserRole, bool) {
+	output, err := gitCommandRunner(repoPath, "config", "--get", "beads.role")
+	if err != nil {
+		return "", false
+	}
+	switch UserRole(strings.TrimSpace(string(output))) {
+	case Maintainer:
+		return Maintainer, true
+	case Contributor:
+		return Contributor, true
+	}
+	return "", false
 }
 
 // detectFromURL uses remote URL patterns to infer user role.

--- a/internal/routing/routing_test.go
+++ b/internal/routing/routing_test.go
@@ -394,3 +394,70 @@ func TestDetectUserRole_JJSecondaryWorkspace(t *testing.T) {
 		t.Errorf("expected no role-not-configured warning, got stderr:\n%s", stderr)
 	}
 }
+
+// TestDetectUserRole_JJSecondaryWorkspace_NonCwdRepoPath verifies that the jj
+// secondary resolution honors the repoPath argument rather than the current
+// working directory. Here cwd is a neutral, non-jj directory and the secondary
+// workspace is passed explicitly as repoPath — the role must still resolve from
+// the primary's git config, with no deprecation warning. (GH#2950)
+func TestDetectUserRole_JJSecondaryWorkspace_NonCwdRepoPath(t *testing.T) {
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get cwd: %v", err)
+	}
+
+	tmpDir := t.TempDir()
+	tmpDir, _ = filepath.EvalSymlinks(tmpDir) // macOS /var -> /private/var
+	primaryDir := filepath.Join(tmpDir, "primary")
+	secondaryDir := filepath.Join(tmpDir, "secondary")
+	if err := os.MkdirAll(filepath.Join(primaryDir, ".jj", "repo"), 0750); err != nil {
+		t.Fatalf("failed to create primary .jj/repo: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(secondaryDir, ".jj"), 0750); err != nil {
+		t.Fatalf("failed to create secondary .jj: %v", err)
+	}
+	repoTarget := filepath.Join(primaryDir, ".jj", "repo")
+	if err := os.WriteFile(filepath.Join(secondaryDir, ".jj", "repo"), []byte(repoTarget+"\n"), 0640); err != nil {
+		t.Fatalf("failed to write secondary .jj/repo: %v", err)
+	}
+
+	// cwd is a neutral directory that is NOT a jj workspace. This is what
+	// distinguishes this test from TestDetectUserRole_JJSecondaryWorkspace:
+	// the jj resolution must come from repoPath, not cwd.
+	neutralDir := filepath.Join(tmpDir, "neutral")
+	if err := os.MkdirAll(neutralDir, 0750); err != nil {
+		t.Fatalf("failed to create neutral dir: %v", err)
+	}
+	if err := os.Chdir(neutralDir); err != nil {
+		t.Fatalf("failed to chdir into neutral dir: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chdir(origDir)
+		git.ResetCaches()
+	})
+	git.ResetCaches()
+
+	orig := gitCommandRunner
+	gitCommandRunner = func(repo string, args ...string) ([]byte, error) {
+		if strings.HasSuffix(repo, "primary") {
+			return []byte("maintainer\n"), nil
+		}
+		return nil, errors.New("not a git repository")
+	}
+	t.Cleanup(func() { gitCommandRunner = orig })
+
+	var role UserRole
+	stderr := captureStderr(t, func() {
+		role, err = DetectUserRole(secondaryDir)
+	})
+
+	if err != nil {
+		t.Fatalf("DetectUserRole error = %v", err)
+	}
+	if role != Maintainer {
+		t.Fatalf("expected %s, got %s", Maintainer, role)
+	}
+	if strings.Contains(stderr, "not configured") {
+		t.Errorf("expected no role-not-configured warning, got stderr:\n%s", stderr)
+	}
+}

--- a/internal/routing/routing_test.go
+++ b/internal/routing/routing_test.go
@@ -2,8 +2,14 @@ package routing
 
 import (
 	"errors"
+	"io"
+	"os"
+	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
+
+	"github.com/steveyegge/beads/internal/git"
 )
 
 func TestDetermineTargetRepo(t *testing.T) {
@@ -300,5 +306,91 @@ func TestDetectUserRole_UpstreamSameRepoStillMaintainer(t *testing.T) {
 	}
 	if role != Maintainer {
 		t.Fatalf("expected %s, got %s", Maintainer, role)
+	}
+}
+
+// captureStderr runs fn with os.Stderr redirected to a pipe and returns
+// everything written to it. Used to assert the deprecation warning is (not)
+// emitted.
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+	orig := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("failed to create pipe: %v", err)
+	}
+	os.Stderr = w
+	done := make(chan string, 1)
+	go func() {
+		b, _ := io.ReadAll(r)
+		done <- string(b)
+	}()
+	fn()
+	_ = w.Close()
+	os.Stderr = orig
+	return <-done
+}
+
+// TestDetectUserRole_JJSecondaryWorkspace verifies that when bd runs from a jj
+// secondary workspace (which has no .git of its own), beads.role is resolved
+// from the primary workspace's git config rather than falling through to the
+// deprecation warning + URL heuristic. (GH#2950)
+func TestDetectUserRole_JJSecondaryWorkspace(t *testing.T) {
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get cwd: %v", err)
+	}
+
+	// Build a primary (.jj/repo is a directory) + secondary (.jj/repo is a file
+	// pointing at the primary's .jj/repo) layout, mirroring real jj.
+	tmpDir := t.TempDir()
+	tmpDir, _ = filepath.EvalSymlinks(tmpDir) // macOS /var -> /private/var
+	primaryDir := filepath.Join(tmpDir, "primary")
+	secondaryDir := filepath.Join(tmpDir, "secondary")
+	if err := os.MkdirAll(filepath.Join(primaryDir, ".jj", "repo"), 0750); err != nil {
+		t.Fatalf("failed to create primary .jj/repo: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(secondaryDir, ".jj"), 0750); err != nil {
+		t.Fatalf("failed to create secondary .jj: %v", err)
+	}
+	repoTarget := filepath.Join(primaryDir, ".jj", "repo")
+	if err := os.WriteFile(filepath.Join(secondaryDir, ".jj", "repo"), []byte(repoTarget+"\n"), 0640); err != nil {
+		t.Fatalf("failed to write secondary .jj/repo: %v", err)
+	}
+
+	if err := os.Chdir(secondaryDir); err != nil {
+		t.Fatalf("failed to chdir into secondary: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chdir(origDir)
+		git.ResetCaches()
+	})
+	git.ResetCaches()
+
+	// Path-aware mock: the secondary has no usable git config (error), but the
+	// primary returns maintainer. Match the primary loosely by suffix so we
+	// don't depend on symlink/case canonicalization of the resolved path.
+	orig := gitCommandRunner
+	gitCommandRunner = func(repo string, args ...string) ([]byte, error) {
+		if strings.HasSuffix(repo, "primary") {
+			return []byte("maintainer\n"), nil
+		}
+		return nil, errors.New("not a git repository")
+	}
+	t.Cleanup(func() { gitCommandRunner = orig })
+
+	var role UserRole
+	stderr := captureStderr(t, func() {
+		role, err = DetectUserRole(".")
+	})
+
+	if err != nil {
+		t.Fatalf("DetectUserRole error = %v", err)
+	}
+	if role != Maintainer {
+		t.Fatalf("expected %s, got %s", Maintainer, role)
+	}
+	if strings.Contains(stderr, "not configured") {
+		t.Errorf("expected no role-not-configured warning, got stderr:\n%s", stderr)
 	}
 }


### PR DESCRIPTION
## What

Fix #4305 - teach `bd` to recognize jujutsu secondary workspaces (`jj workspace add`) and route `.beads/` discovery and `beads.role` detection through the primary workspace, exactly as it already does for git worktrees.

## Why

  A jj secondary workspace has only a `.jj` directory; `.jj/repo` is a file pointing back to the primary's `.jj/repo` — there is no `.git`. This caused two bugs when running `bd` from a secondary:

  - `.beads/` discovery walked past the secondary boundary and found git-tracked metadata files (config, no database), opening the wrong or an empty database.
  - `git config --get beads.role` failed (no `.git`), so role detection fell through to the deprecated URL heuristic and printed the "beads.role not configured (GH#2950)" warning even when the primary had the role set.

  ## Verification

  New tests cover all three layers:

  go test ./internal/git/... -run TestJJ
  go test ./internal/beads/... -run TestFindBeadsDir_JJSecondary
  go test ./internal/routing/... -run TestDetectUserRole

  To verify manually: create a colocated jj+git repo, add a secondary workspace via `jj workspace add`, set `beads.role` in the primary's git config, and run `bd` from the secondary — discovery should use the primary's `.beads/` and no role warning should appear.

## Human verification
I've been running bd in multiple jj workspaces of all sorts and it's been pretty stable for me (and the agents)