### PR TITLE
db-proxy connection pooling (opt-in) + proxied-server external deploy path

### DIFF
--- a/cmd/bd/brief_flag_test.go
+++ b/cmd/bd/brief_flag_test.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// TestReadyBriefFlag verifies the --brief seam on `bd ready` (be-yvci): the flag
+// exists with a safe default (off), and setting it maps onto
+// WorkFilter.BriefBodies — the field that selects the body-stripped work-probe
+// projection. This is the seam gascity's supervisor work_query (ga-arn) uses.
+func TestReadyBriefFlag(t *testing.T) {
+	t.Parallel()
+
+	briefFlag := readyCmd.Flags().Lookup("brief")
+	if briefFlag == nil {
+		t.Fatal("--brief flag should exist on readyCmd")
+	}
+	if briefFlag.DefValue != "false" {
+		t.Errorf("--brief default should be 'false', got %q", briefFlag.DefValue)
+	}
+
+	newCmd := func() *cobra.Command {
+		c := &cobra.Command{Use: "probe", Run: func(*cobra.Command, []string) {}}
+		c.Flags().Bool("brief", false, "")
+		return c
+	}
+
+	// --brief set ⇒ WorkFilter.BriefBodies == true
+	withBrief := newCmd()
+	if err := withBrief.Flags().Parse([]string{"--brief"}); err != nil {
+		t.Fatalf("parse --brief: %v", err)
+	}
+	var f types.WorkFilter
+	applyReadyBriefFlag(withBrief, &f)
+	if !f.BriefBodies {
+		t.Error("--brief should set WorkFilter.BriefBodies=true")
+	}
+
+	// default (no --brief) ⇒ BriefBodies stays false (no behavior change)
+	def := newCmd()
+	var f2 types.WorkFilter
+	applyReadyBriefFlag(def, &f2)
+	if f2.BriefBodies {
+		t.Error("absent --brief should leave WorkFilter.BriefBodies=false")
+	}
+}

--- a/cmd/bd/compact.go
+++ b/cmd/bd/compact.go
@@ -81,6 +81,10 @@ Examples:
 	Run: func(_ *cobra.Command, _ []string) {
 		// Block mutating operations in embedded mode; allow --stats, --analyze, --dry-run read-only paths.
 		if !compactStats && !compactAnalyze && !compactDryRun {
+			// S5: compaction rewrites Dolt history and needs exclusive direct
+			// repository access — impossible through the proxy. Read-only paths
+			// (--stats/--analyze/--dry-run) remain serviceable over the routed store.
+			guardUnsupportedInProxiedMode(CapabilityCompaction)
 			if err := requireServerMode("compact"); err != nil {
 				FatalError("%v", err)
 			}

--- a/cmd/bd/db_proxy_child.go
+++ b/cmd/bd/db_proxy_child.go
@@ -71,7 +71,7 @@ not intended to be invoked directly by users.`,
 		// non-empty password; the managed loopback server uses root with no
 		// password.
 		backendPassword := ""
-		if backend == proxy.BackendExternal {
+		if backend == proxy.BackendExternal || backend == proxy.BackendLocalSharedServer {
 			backendPassword = os.Getenv(configfile.ExternalDoltPasswordEnvVar)
 		}
 
@@ -98,10 +98,12 @@ func newDatabaseServer(backend proxy.Backend, rootDir, configPath, logPath, dolt
 	switch backend {
 	case proxy.BackendLocalServer:
 		return server.NewDoltServer(doltBin, rootDir, configPath, logPath, 0)
-	case proxy.BackendExternal:
+	case proxy.BackendExternal, proxy.BackendLocalSharedServer:
+		// The shared backend fronts the managed dolt through the same external
+		// server. The N+1 → 1 collapse comes from pointing every scope at one
+		// shared rootDir (so the parent's spawn-or-reuse yields a single child),
+		// not from a distinct server type.
 		return server.NewExternalDoltServer(external)
-	case proxy.BackendLocalSharedServer:
-		return nil, fmt.Errorf("backend %q: not yet implemented", backend)
 	}
 	return nil, fmt.Errorf("unknown backend %q", backend)
 }

--- a/cmd/bd/db_proxy_child.go
+++ b/cmd/bd/db_proxy_child.go
@@ -29,6 +29,8 @@ var (
 	dbProxyChildExternalTLSCertPath string
 	dbProxyChildExternalTLSKeyPath  string
 	dbProxyChildExternalKeepAlive   time.Duration
+	dbProxyChildPoolSize            int
+	dbProxyChildBackendUser         string
 )
 
 var dbProxyChildCmd = &cobra.Command{
@@ -63,11 +65,24 @@ not intended to be invoked directly by users.`,
 			return err
 		}
 
+		// Backend credentials for pooled connections. The user arrives via
+		// flag (default root); the password is read from the environment so it
+		// never appears on the command line. Only the external backend has a
+		// non-empty password; the managed loopback server uses root with no
+		// password.
+		backendPassword := ""
+		if backend == proxy.BackendExternal {
+			backendPassword = os.Getenv(configfile.ExternalDoltPasswordEnvVar)
+		}
+
 		p := proxy.NewProxyServer(proxy.ProxyOpts{
-			RootDir:     dbProxyChildRoot,
-			Port:        dbProxyChildPort,
-			IdleTimeout: dbProxyChildIdleTimeout,
-			Server:      srv,
+			RootDir:         dbProxyChildRoot,
+			Port:            dbProxyChildPort,
+			IdleTimeout:     dbProxyChildIdleTimeout,
+			Server:          srv,
+			PoolSize:        dbProxyChildPoolSize,
+			BackendUser:     dbProxyChildBackendUser,
+			BackendPassword: backendPassword,
 		})
 		if err := p.ListenAndServe(cmd.Context()); err != nil {
 			if errors.Is(err, proxy.ErrLockHeld) {
@@ -107,6 +122,8 @@ func init() {
 	dbProxyChildCmd.Flags().StringVar(&dbProxyChildExternalTLSCertPath, "external-tls-cert-path", "", "external backend: absolute path to client TLS certificate (mTLS)")
 	dbProxyChildCmd.Flags().StringVar(&dbProxyChildExternalTLSKeyPath, "external-tls-key-path", "", "external backend: absolute path to client TLS private key (mTLS)")
 	dbProxyChildCmd.Flags().DurationVar(&dbProxyChildExternalKeepAlive, "external-keep-alive", 0, "external backend: TCP keepalive period (default 30s)")
+	dbProxyChildCmd.Flags().IntVar(&dbProxyChildPoolSize, "pool-size", 0, "if >0, pool up to N warm authenticated backend connections instead of dialing one per client")
+	dbProxyChildCmd.Flags().StringVar(&dbProxyChildBackendUser, "backend-user", "root", "user the proxy authenticates pooled backend connections as")
 	_ = dbProxyChildCmd.MarkFlagRequired("root")
 	_ = dbProxyChildCmd.MarkFlagRequired("port")
 	_ = dbProxyChildCmd.MarkFlagRequired("backend")

--- a/cmd/bd/db_proxy_child_test.go
+++ b/cmd/bd/db_proxy_child_test.go
@@ -46,14 +46,31 @@ func TestNewDatabaseServer_BackendExternal(t *testing.T) {
 	})
 }
 
-func TestNewDatabaseServer_BackendLocalSharedServerStillStubbed(t *testing.T) {
-	_, err := newDatabaseServer(
-		proxy.BackendLocalSharedServer,
-		"/tmp/root", "/tmp/cfg", "/tmp/log", "/usr/bin/dolt",
-		configfile.ExternalDoltConfig{},
-	)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "not yet implemented")
+func TestNewDatabaseServer_SharedServer(t *testing.T) {
+	t.Run("valid external target builds an ExternalDoltServer", func(t *testing.T) {
+		srv, err := newDatabaseServer(
+			proxy.BackendLocalSharedServer,
+			"", "", "", "",
+			configfile.ExternalDoltConfig{Host: "db.internal", Port: 3306},
+		)
+		require.NoError(t, err)
+		require.NotNil(t, srv)
+		// The shared backend fronts the managed dolt through the same
+		// external-server mechanism — the collapse comes from a shared rootDir,
+		// not a distinct server type.
+		_, ok := srv.(*server.ExternalDoltServer)
+		assert.True(t, ok, "expected *server.ExternalDoltServer, got %T", srv)
+	})
+
+	t.Run("invalid config bubbles validation error", func(t *testing.T) {
+		_, err := newDatabaseServer(
+			proxy.BackendLocalSharedServer,
+			"", "", "", "",
+			configfile.ExternalDoltConfig{},
+		)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "ExternalDoltConfig")
+	})
 }
 
 func TestNewDatabaseServer_UnknownBackendRejected(t *testing.T) {

--- a/cmd/bd/dolt.go
+++ b/cmd/bd/dolt.go
@@ -254,12 +254,13 @@ uncommitted changes in its working set).
 Use --remote to push to a specific named remote instead of the default.
 The remote must already exist (see 'bd dolt remote add').`,
 	Run: func(cmd *cobra.Command, args []string) {
-		// S5: raw-Dolt remote sync is impossible through the proxy (the routed
-		// DoltRemoteUseCase covers remote config CRUD only). Fail loudly with a
-		// typed, actionable error rather than appearing to succeed.
-		guardUnsupportedInProxiedMode(CapabilityDoltPush)
+		// S5: raw-Dolt remote sync is impossible *through the proxy* (the routed
+		// DoltRemoteUseCase covers remote config CRUD only). In proxied-server
+		// mode this opens a direct ServerMode store at the scope's recorded
+		// external endpoint instead, and exits with the typed unsupported error
+		// when none is recorded — never appearing to succeed.
 		ctx := context.Background()
-		st := getStore()
+		st := storeForRawDoltSync(ctx, CapabilityDoltPush)
 		if st == nil {
 			fmt.Fprintf(os.Stderr, "Error: no store available\n")
 			os.Exit(1)
@@ -327,10 +328,10 @@ variables for authentication.
 Use --remote to pull from a specific named remote instead of the default.
 The remote must already exist (see 'bd dolt remote add').`,
 	Run: func(cmd *cobra.Command, args []string) {
-		// S5: see doltPushCmd — raw-Dolt remote sync is unsupported in proxied mode.
-		guardUnsupportedInProxiedMode(CapabilityDoltPull)
+		// S5: see doltPushCmd — direct-endpoint escape hatch in proxied mode,
+		// typed unsupported error when no external endpoint is recorded.
 		ctx := context.Background()
-		st := getStore()
+		st := storeForRawDoltSync(ctx, CapabilityDoltPull)
 		if st == nil {
 			fmt.Fprintf(os.Stderr, "Error: no store available\n")
 			os.Exit(1)

--- a/cmd/bd/dolt.go
+++ b/cmd/bd/dolt.go
@@ -254,6 +254,10 @@ uncommitted changes in its working set).
 Use --remote to push to a specific named remote instead of the default.
 The remote must already exist (see 'bd dolt remote add').`,
 	Run: func(cmd *cobra.Command, args []string) {
+		// S5: raw-Dolt remote sync is impossible through the proxy (the routed
+		// DoltRemoteUseCase covers remote config CRUD only). Fail loudly with a
+		// typed, actionable error rather than appearing to succeed.
+		guardUnsupportedInProxiedMode(CapabilityDoltPush)
 		ctx := context.Background()
 		st := getStore()
 		if st == nil {
@@ -323,6 +327,8 @@ variables for authentication.
 Use --remote to pull from a specific named remote instead of the default.
 The remote must already exist (see 'bd dolt remote add').`,
 	Run: func(cmd *cobra.Command, args []string) {
+		// S5: see doltPushCmd — raw-Dolt remote sync is unsupported in proxied mode.
+		guardUnsupportedInProxiedMode(CapabilityDoltPull)
 		ctx := context.Background()
 		st := getStore()
 		if st == nil {

--- a/cmd/bd/federation.go
+++ b/cmd/bd/federation.go
@@ -137,6 +137,9 @@ func getFederatedStore() (storage.DoltStorage, error) {
 }
 
 func runFederationSync(cmd *cobra.Command, args []string) {
+	// S5: federation sync performs staging-branch surgery over raw Dolt and
+	// cannot run through the proxy. Status/list-peers reads stay serviceable.
+	guardUnsupportedInProxiedMode(CapabilityFederation)
 	ctx := rootCtx
 
 	ds, err := getFederatedStore()

--- a/cmd/bd/init.go
+++ b/cmd/bd/init.go
@@ -119,12 +119,6 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 		if os.Getenv("BEADS_DOLT_PROXIED_SERVER") == "1" {
 			initProxiedServer = true
 		}
-		if initProxiedServer {
-			// Proxied-server mode has no local Dolt init lifecycle yet. When it
-			// is implemented, that path must mark any local .dolt/ it creates or
-			// acknowledges with doltserver.MarkDoltDirCompatible.
-			FatalError("--proxied-server is not yet implemented")
-		}
 		if initProxiedServer && initServerMode {
 			FatalError("--server and --proxied-server are mutually exclusive")
 		}
@@ -196,6 +190,17 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 				FatalError("--proxied-server-external-*: %v", err)
 			}
 			externalConfig = &cfg
+		}
+		if initProxiedServer && externalConfig == nil {
+			// Managed (local dolt sql-server) proxied mode still lacks a local
+			// Dolt init lifecycle — that path must mark any local .dolt/ it
+			// creates or acknowledges with doltserver.MarkDoltDirCompatible
+			// before it can be enabled. External proxied mode fronts an
+			// already-running sql-server and creates no local Dolt, so it is
+			// supported.
+			FatalError("--proxied-server currently supports external mode only; " +
+				"specify the backend with --proxied-server-external-host and --proxied-server-external-port " +
+				"(or --proxied-server-external-socket-path)")
 		}
 
 		// Handle --backend flag: "dolt" is the only supported backend.

--- a/cmd/bd/init_proxied_external_integration_test.go
+++ b/cmd/bd/init_proxied_external_integration_test.go
@@ -1,0 +1,66 @@
+//go:build cgo
+
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/configfile"
+	"github.com/steveyegge/beads/internal/testutil"
+)
+
+// TestProxiedServerExternalStoreCommands locks in the routed-store wiring that
+// makes the legacy store-based commands (list/ready/update/close/stats) work in
+// proxied-server mode. Before that wiring these commands dereferenced a nil
+// store and panicked; only `bd create` (uow-based) worked. Gated on
+// BEADS_TEST_PROXIED_SERVER=1 + a dolt binary/container.
+func TestProxiedServerExternalStoreCommands(t *testing.T) {
+	requireProxiedServerEnv(t)
+
+	bd := buildEmbeddedBD(t)
+	port := testutil.StartIsolatedDoltContainer(t)
+
+	p := bdProxiedInit(t, bd, "pse",
+		"--proxied-server-external-host", "127.0.0.1",
+		"--proxied-server-external-port", port,
+	)
+
+	// Sanity: metadata records proxied-server external mode.
+	info, err := configfile.LoadProxiedServerClientInfo(p.beadsDir)
+	if err != nil || info == nil || info.External == nil {
+		t.Fatalf("expected external client info, err=%v info=%+v", err, info)
+	}
+
+	a := bdProxiedCreate(t, bd, p.dir, "first")
+	b := bdProxiedCreate(t, bd, p.dir, "second")
+
+	// list — exercises the routed store's GetReadyWork/GetStatistics path.
+	out, err := bdProxiedRun(t, bd, p.dir, "list")
+	if err != nil {
+		t.Fatalf("bd list failed (routed store): %v\n%s", err, out)
+	}
+	if !strings.Contains(string(out), a.ID) || !strings.Contains(string(out), b.ID) {
+		t.Fatalf("list missing created issues:\n%s", out)
+	}
+
+	// ready — both open issues with no blockers should be ready.
+	if out, err := bdProxiedRun(t, bd, p.dir, "ready"); err != nil {
+		t.Fatalf("bd ready failed (routed store): %v\n%s", err, out)
+	}
+
+	// update + close — write path through the routed store (DOLT_COMMIT via proxy).
+	if out, err := bdProxiedRun(t, bd, p.dir, "update", a.ID, "--status", "in_progress"); err != nil {
+		t.Fatalf("bd update failed: %v\n%s", err, out)
+	}
+	if out, err := bdProxiedRun(t, bd, p.dir, "close", b.ID, "--reason", "done"); err != nil {
+		t.Fatalf("bd close failed: %v\n%s", err, out)
+	}
+
+	// Confirm the writes are visible (b closed, a in progress) via a fresh
+	// invocation — proves the routed store reads committed state back.
+	got := bdProxiedShow(t, bd, p.dir, b.ID)
+	if got.Status != "closed" {
+		t.Fatalf("expected %s closed, got %q", b.ID, got.Status)
+	}
+}

--- a/cmd/bd/main.go
+++ b/cmd/bd/main.go
@@ -56,6 +56,12 @@ var (
 	storeMutex  sync.Mutex // Protects store access from background goroutine
 	storeActive = false    // Tracks if store is available
 
+	// routedStoreOpenErr records why the proxied routed store failed to open,
+	// so store-requiring commands can report the real cause (S2) instead of
+	// panicking on a nil store. Nil in direct mode and when the routed store
+	// opened successfully.
+	routedStoreOpenErr error
+
 	// Version upgrade tracking
 	versionUpgradeDetected = false // Set to true if bd version changed since last run
 	previousVersion        = ""    // The last bd version user had (empty = first run or unknown)
@@ -1057,7 +1063,34 @@ var rootCmd = &cobra.Command{
 					store = storage.NewHookFiringStore(store, hookRunner)
 				}
 			} else {
+				// Keep store nil and record the cause. bd create only needs the
+				// uow provider, so we must not fail the whole proxied path here;
+				// store-requiring commands fail loudly at the use site via
+				// requireStore() (S2) rather than dereferencing a nil store.
+				routedStoreOpenErr = serr
 				debug.Logf("proxied-server: routed store unavailable, store-based commands disabled: %v", serr)
+			}
+
+			// S2 (central guard): if the routed store failed to open, every
+			// store-requiring command reaching this block would dereference a nil
+			// store (~600 sites pass the global store into helpers like
+			// resolveAndGetFromStore that call store methods directly). Fail loudly
+			// once, here, with the captured cause + actionable hint. bd create is the
+			// only command reaching this block that runs on the uow provider alone,
+			// so it must tolerate a missing routed store; dolt push/pull/commit are
+			// unsupported and surface their own typed error in the command body.
+			if store == nil && cmdName != "create" {
+				_ = requireStore() // exits non-zero; never returns when store is nil
+			}
+
+			// S4: restore workspace-identity validation in proxied mode. The
+			// direct-path call (below, ~1142) is unreachable here because the
+			// proxied block returns early, so without this a write command could
+			// silently mutate the wrong scope through a misconfigured proxy.
+			// validateWorkspaceIdentity reads _project_id over the routed store
+			// and no-ops when the store is nil, so it is safe in best-effort mode.
+			if !useReadOnly && !globalFlag && os.Getenv("BEADS_SKIP_IDENTITY_CHECK") != "1" {
+				validateWorkspaceIdentity(rootCtx, beadsDir)
 			}
 
 			syncCommandContext()
@@ -1174,6 +1207,14 @@ var rootCmd = &cobra.Command{
 		defer restoreChangeDirSelection()
 
 		if proxiedServerMode {
+			// S1 (v2): close the routed store too. PreRun opens a proxied
+			// routed *sql.DB-backed store (newProxiedServerRoutedStore); closing
+			// only uowProvider here leaked one backend connection to the db-proxy
+			// per bd invocation, which exhausted the pool and wedged the proxy.
+			if store != nil {
+				_ = store.Close()
+				store = nil
+			}
 			if uowProvider != nil {
 				_ = uowProvider.Close(rootCtx)
 				uowProvider = nil
@@ -1364,6 +1405,30 @@ func flushBatchCommitOnShutdown() {
 	} else {
 		fmt.Fprintf(os.Stderr, "\nFlushed pending batch commit on shutdown\n")
 	}
+}
+
+// requireStore returns the active store, or exits with a clear, non-panicking
+// error when it is nil (S2). In proxied mode the routed store can be nil when
+// the db-proxy is unreachable. The proxied PreRun installs a central guard that
+// calls this for every store-requiring command (every command reaching the
+// proxied store-init block except bd create), so the ~600 raw store-deref sites
+// fail loudly here instead of panicking — the bd ready nil-store panic. It is
+// also called directly at the bd ready use sites. bd create deliberately does
+// not trigger it: it uses the uow provider and tolerates a missing routed store.
+func requireStore() storage.DoltStorage {
+	storeMutex.Lock()
+	st := store
+	storeMutex.Unlock()
+	if st != nil {
+		return st
+	}
+	const hint = "the beads store is unavailable; in proxied mode ensure the db-proxy is running and reachable, or set [beads] proxied=false to use direct ServerMode"
+	if routedStoreOpenErr != nil {
+		FatalErrorWithHintRespectJSON(
+			fmt.Sprintf("no database connection: routed store unavailable: %v", routedStoreOpenErr), hint)
+	}
+	FatalErrorWithHintRespectJSON("no database connection: store is not available", hint)
+	return nil // unreachable: FatalError* exits
 }
 
 // validateWorkspaceIdentity checks that the project identity from metadata.json

--- a/cmd/bd/main.go
+++ b/cmd/bd/main.go
@@ -1038,6 +1038,28 @@ var rootCmd = &cobra.Command{
 			}
 			uowProvider = p
 
+			// Also route a server-mode store through the proxy so the legacy
+			// store-based commands (list/ready/stats/update/close/...) work in
+			// proxied mode instead of dereferencing a nil store. Both the uow
+			// provider and this store connect through the same proxy and share
+			// its backend connection pool. Best-effort: `bd create` uses the uow
+			// provider and does not need the store, so a routing failure here
+			// must not break the proxied-create path.
+			if s, serr := newProxiedServerRoutedStore(rootCtx, beadsDir); serr == nil {
+				store = s
+				storeMutex.Lock()
+				storeActive = true
+				storeMutex.Unlock()
+				if dbPath != "" {
+					hookRunner = hooks.NewRunner(filepath.Join(filepath.Dir(dbPath), "hooks"))
+				}
+				if hookRunner != nil && !config.GetBool("no-hooks") {
+					store = storage.NewHookFiringStore(store, hookRunner)
+				}
+			} else {
+				debug.Logf("proxied-server: routed store unavailable, store-based commands disabled: %v", serr)
+			}
+
 			syncCommandContext()
 			return
 		}

--- a/cmd/bd/proxied_direct_sync.go
+++ b/cmd/bd/proxied_direct_sync.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/steveyegge/beads/internal/configfile"
+	"github.com/steveyegge/beads/internal/storage"
+	"github.com/steveyegge/beads/internal/storage/dolt"
+)
+
+// Raw-Dolt remote sync (dolt push / dolt pull) in proxied-server mode.
+//
+// The S5 guard (proxied_unsupported.go) exists because the multiplexed proxy
+// cannot service CALL DOLT_PUSH / DOLT_PULL safely, and silently dead-dropping
+// them (empty-JSON exit 0) stranded syncs. But a gc-managed proxied scope
+// records the REAL dolt endpoint — the same server the proxy itself fronts —
+// in proxied_server_client_info.json. For these capabilities we can do what
+// direct ServerMode would do: open a direct connection to that endpoint for
+// the duration of the command. The guard remains the loud fallback whenever
+// no external endpoint is recorded, preserving the dead-drop contract.
+
+// directSyncDoltConfig builds the direct ServerMode config for raw-Dolt sync
+// from a proxied scope's recorded external endpoint. Returns nil when the
+// endpoint is unusable (nil external or missing port) — callers must then
+// fall back to the unsupported-capability guard. Pure function for tests.
+func directSyncDoltConfig(beadsDir, database string, ext *configfile.ExternalDoltConfig) *dolt.Config {
+	if ext == nil || ext.Port == 0 {
+		return nil
+	}
+	host := ext.Host
+	if host == "" {
+		host = "127.0.0.1"
+	}
+	cfg := &dolt.Config{
+		Path:       beadsDir,
+		BeadsDir:   beadsDir,
+		Database:   database,
+		ServerMode: true,
+		ServerHost: host,
+		ServerPort: ext.Port,
+		ServerUser: ext.ResolvedUser(),
+		// AutoStart stays false (zero value): gc owns the managed server
+		// lifecycle; raw sync must never spawn a competing dolt.
+		//
+		// RoutedThroughProxy stays false: unlike the routed store (which
+		// listens on the proxy's ephemeral port), this endpoint IS the
+		// canonical managed server — persisting its port is identical to
+		// what gc publishes, so the portfile-clobber suppression does not
+		// apply.
+	}
+	if pw := os.Getenv("BEADS_PROXIED_SERVER_EXTERNAL_PASSWORD"); pw != "" {
+		cfg.ServerPassword = pw
+	}
+	return cfg
+}
+
+// storeForRawDoltSync returns the store a raw-Dolt remote-sync command should
+// operate on. Outside proxied-server mode it is the normal store (getStore),
+// byte-for-byte the existing behavior. In proxied-server mode it opens a
+// direct ServerMode store at the scope's recorded external endpoint; when no
+// usable endpoint is recorded it exits with the typed unsupported error,
+// exactly like the previous unconditional guard (never silent).
+func storeForRawDoltSync(ctx context.Context, c Capability) storage.DoltStorage {
+	if !proxiedServerMode {
+		return getStore()
+	}
+	dir := resolveBeadsDirForDBPath(getDBPath())
+	if dir == "" {
+		guardUnsupportedInProxiedMode(c)
+		return nil // unreachable: guard exits in proxied mode
+	}
+	info, err := configfile.LoadProxiedServerClientInfo(dir)
+	if err != nil || info == nil {
+		guardUnsupportedInProxiedMode(c)
+		return nil // unreachable: guard exits in proxied mode
+	}
+	database := configfile.DefaultDoltDatabase
+	if persisted, _ := configfile.Load(dir); persisted != nil {
+		database = persisted.GetDoltDatabase()
+	}
+	cfg := directSyncDoltConfig(dir, database, info.External)
+	if cfg == nil {
+		guardUnsupportedInProxiedMode(c)
+		return nil // unreachable: guard exits in proxied mode
+	}
+	st, err := dolt.New(ctx, cfg)
+	if err != nil {
+		FatalErrorRespectJSON("%s: opening direct dolt endpoint %s:%d: %v", c, cfg.ServerHost, cfg.ServerPort, err)
+	}
+	fmt.Fprintf(os.Stderr, "proxied scope: using direct dolt endpoint %s:%d for %s\n", cfg.ServerHost, cfg.ServerPort, c)
+	return st
+}

--- a/cmd/bd/proxied_direct_sync_test.go
+++ b/cmd/bd/proxied_direct_sync_test.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/steveyegge/beads/internal/configfile"
+)
+
+func TestDirectSyncDoltConfig(t *testing.T) {
+	t.Run("external endpoint -> direct ServerMode config", func(t *testing.T) {
+		t.Setenv("BEADS_PROXIED_SERVER_EXTERNAL_PASSWORD", "")
+		cfg := directSyncDoltConfig("/scope/.beads", "vg", &configfile.ExternalDoltConfig{
+			Host: "127.0.0.1",
+			Port: 42188,
+			User: "root",
+		})
+		if cfg == nil {
+			t.Fatal("config = nil, want direct ServerMode config")
+		}
+		if !cfg.ServerMode {
+			t.Fatal("ServerMode = false, want true")
+		}
+		if cfg.ServerHost != "127.0.0.1" || cfg.ServerPort != 42188 || cfg.ServerUser != "root" {
+			t.Fatalf("endpoint = %s:%d user=%s, want 127.0.0.1:42188 root", cfg.ServerHost, cfg.ServerPort, cfg.ServerUser)
+		}
+		if cfg.Database != "vg" {
+			t.Fatalf("Database = %q, want vg", cfg.Database)
+		}
+		if cfg.BeadsDir != "/scope/.beads" || cfg.Path != "/scope/.beads" {
+			t.Fatalf("dirs = %q/%q, want /scope/.beads", cfg.BeadsDir, cfg.Path)
+		}
+		// gc owns the managed server: raw sync must never auto-start a dolt.
+		if cfg.AutoStart {
+			t.Fatal("AutoStart = true, want false")
+		}
+		// This IS the canonical endpoint — the portfile-clobber suppression
+		// (RoutedThroughProxy) must NOT be set, unlike the routed store.
+		if cfg.RoutedThroughProxy {
+			t.Fatal("RoutedThroughProxy = true, want false (canonical endpoint)")
+		}
+	})
+
+	t.Run("empty host defaults to loopback", func(t *testing.T) {
+		cfg := directSyncDoltConfig("/scope/.beads", "db", &configfile.ExternalDoltConfig{Port: 40519})
+		if cfg == nil || cfg.ServerHost != "127.0.0.1" {
+			t.Fatalf("cfg = %+v, want host defaulted to 127.0.0.1", cfg)
+		}
+	})
+
+	t.Run("external password env is forwarded", func(t *testing.T) {
+		t.Setenv("BEADS_PROXIED_SERVER_EXTERNAL_PASSWORD", "sekrit")
+		cfg := directSyncDoltConfig("/scope/.beads", "db", &configfile.ExternalDoltConfig{Port: 42188})
+		if cfg == nil || cfg.ServerPassword != "sekrit" {
+			t.Fatal("ServerPassword not forwarded from BEADS_PROXIED_SERVER_EXTERNAL_PASSWORD")
+		}
+	})
+
+	t.Run("nil external -> nil (caller falls back to the loud guard)", func(t *testing.T) {
+		if cfg := directSyncDoltConfig("/scope/.beads", "db", nil); cfg != nil {
+			t.Fatalf("cfg = %+v, want nil", cfg)
+		}
+	})
+
+	t.Run("missing port -> nil (caller falls back to the loud guard)", func(t *testing.T) {
+		if cfg := directSyncDoltConfig("/scope/.beads", "db", &configfile.ExternalDoltConfig{Host: "127.0.0.1"}); cfg != nil {
+			t.Fatalf("cfg = %+v, want nil", cfg)
+		}
+	})
+}

--- a/cmd/bd/proxied_server.go
+++ b/cmd/bd/proxied_server.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/steveyegge/beads/internal/config"
 	"github.com/steveyegge/beads/internal/configfile"
+	"github.com/steveyegge/beads/internal/doltserver"
 	"github.com/steveyegge/beads/internal/storage/dbproxy/proxy"
 )
 
@@ -45,7 +46,29 @@ func envOrAbsJoin(envName, beadsDir string) string {
 	return filepath.Join(beadsDir, p)
 }
 
+// sharedProxyModeEnabled reports whether this scope should route through the
+// machine-wide shared db-proxy (BackendLocalSharedServer) instead of its own
+// per-scope proxieddb child. Opt-in via BEADS_SHARED_PROXY (1/true/yes/on); OFF
+// by default, so every existing proxied scope is byte-for-byte unchanged.
+func sharedProxyModeEnabled() bool {
+	switch strings.TrimSpace(strings.ToLower(os.Getenv("BEADS_SHARED_PROXY"))) {
+	case "1", "true", "yes", "on":
+		return true
+	}
+	return false
+}
+
 func resolveProxiedServerRootPath(beadsDir string) (string, error) {
+	// Opt-in: route this scope through the machine-wide shared db-proxy so all
+	// proxied scopes collapse onto one db-proxy-child (be-pen9). This is the one
+	// rootDir chokepoint every proxied provider already routes through, so the
+	// switch lands consistently for both the routed store and the uow provider.
+	// The shared backend + external wiring that completes production shared-mode
+	// is applied by the consumer (the gascity deployment, per
+	// docs/CONNECTION_POOLING_DEPLOYMENT.md).
+	if sharedProxyModeEnabled() {
+		return doltserver.SharedProxyRootDir()
+	}
 	if p := envOrAbsJoin("BEADS_PROXIED_SERVER_ROOT_PATH", beadsDir); p != "" {
 		return p, nil
 	}

--- a/cmd/bd/proxied_server_shared_test.go
+++ b/cmd/bd/proxied_server_shared_test.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestResolveProxiedServerRootPath_SharedProxyMode proves the opt-in shared
+// proxy mode: with BEADS_SHARED_PROXY set, every scope resolves to one
+// machine-wide rootDir (so they collapse onto a single db-proxy-child); without
+// it, each scope keeps its own per-scope proxieddb (live behavior, unchanged).
+func TestResolveProxiedServerRootPath_SharedProxyMode(t *testing.T) {
+	sharedHome := t.TempDir()
+	// Hermetic: neutralize any ambient proxied/shared overrides from the host.
+	t.Setenv("BEADS_SHARED_SERVER_DIR", sharedHome)
+	t.Setenv("BEADS_SHARED_PROXY_ROOT_PATH", "")
+	t.Setenv("BEADS_PROXIED_SERVER_ROOT_PATH", "")
+
+	t.Run("off by default keeps per-scope proxieddb", func(t *testing.T) {
+		t.Setenv("BEADS_SHARED_PROXY", "")
+		beadsDir := t.TempDir()
+		got, err := resolveProxiedServerRootPath(beadsDir)
+		require.NoError(t, err)
+		assert.Equal(t, filepath.Join(beadsDir, proxiedServerRootName), got)
+	})
+
+	t.Run("on resolves every scope to one shared rootDir", func(t *testing.T) {
+		t.Setenv("BEADS_SHARED_PROXY", "1")
+		want := filepath.Join(sharedHome, "proxy")
+
+		a, err := resolveProxiedServerRootPath(t.TempDir())
+		require.NoError(t, err)
+		b, err := resolveProxiedServerRootPath(t.TempDir())
+		require.NoError(t, err)
+
+		assert.Equal(t, want, a, "shared mode must resolve to SharedProxyRootDir")
+		assert.Equal(t, a, b, "shared mode must resolve all scopes to one rootDir")
+	})
+}

--- a/cmd/bd/proxied_unsupported.go
+++ b/cmd/bd/proxied_unsupported.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+)
+
+// Capability names a class of operation that cannot be serviced in
+// proxied-server mode. These are the genuinely-impossible raw-Dolt operations
+// (version-control surgery, compaction) — NOT the work surface, which the
+// routed store services normally. The const block is the single source of
+// truth that tests reference by exact value.
+type Capability string
+
+const (
+	// CapabilityDoltPush is `bd dolt push` — pushing the local Dolt history to
+	// a remote requires direct repository access, not a multiplexed proxy.
+	CapabilityDoltPush Capability = "dolt-push"
+	// CapabilityDoltPull is `bd dolt pull`.
+	CapabilityDoltPull Capability = "dolt-pull"
+	// CapabilityDoltCommit is `bd dolt commit` and other raw history writes.
+	CapabilityDoltCommit Capability = "dolt-commit"
+	// CapabilityCompaction is `bd compact` — rewriting Dolt history requires
+	// exclusive direct access to the underlying repository.
+	CapabilityCompaction Capability = "compaction"
+	// CapabilityFederation is the federation staging-branch surgery surface.
+	CapabilityFederation Capability = "federation"
+	// CapabilityRemoteSync is RemoteStore.Push/Pull/ForcePush — the
+	// DoltRemoteUseCase covers remote *config* CRUD only, not actual sync.
+	CapabilityRemoteSync Capability = "remote-sync"
+)
+
+// UnsupportedInProxiedModeError reports that a command was invoked in
+// proxied-server mode for an operation that mode cannot service. It is
+// errors.As-checkable so callers and tests can assert the exact capability,
+// and it carries an actionable message — never a silent empty-JSON exit 0,
+// which would read as success and strand the operation (the dead-drop bug).
+type UnsupportedInProxiedModeError struct {
+	Capability Capability
+}
+
+// Error implements the error interface with an operator-actionable message.
+func (e *UnsupportedInProxiedModeError) Error() string {
+	return fmt.Sprintf(
+		"%s requires direct ServerMode and is not supported in proxied-server mode; set [beads] proxied=false to use it",
+		e.Capability)
+}
+
+// ErrUnsupportedInProxiedMode constructs the typed error for a capability.
+func ErrUnsupportedInProxiedMode(c Capability) error {
+	return &UnsupportedInProxiedModeError{Capability: c}
+}
+
+// AsUnsupportedInProxiedMode reports whether err is an
+// UnsupportedInProxiedModeError, returning it for inspection.
+func AsUnsupportedInProxiedMode(err error) (*UnsupportedInProxiedModeError, bool) {
+	var target *UnsupportedInProxiedModeError
+	if errors.As(err, &target) {
+		return target, true
+	}
+	return nil, false
+}
+
+// guardUnsupportedInProxiedMode exits with the typed-error message when running
+// in proxied-server mode. Call it at the top of a command that genuinely cannot
+// be serviced through the proxy. It exits non-zero (never empty-JSON + exit 0),
+// which is the contract the dead-drop guard test enforces.
+func guardUnsupportedInProxiedMode(c Capability) {
+	if !proxiedServerMode {
+		return
+	}
+	FatalErrorRespectJSON("%s", ErrUnsupportedInProxiedMode(c).Error())
+}

--- a/cmd/bd/proxied_unsupported_test.go
+++ b/cmd/bd/proxied_unsupported_test.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// TestUnsupportedInProxiedModeErrorIsTyped verifies the error is errors.As-
+// checkable and carries the exact capability — the contract S5 commands and
+// the dead-drop guard test rely on, so an unsupported op can never be mistaken
+// for a swallowed nil error.
+func TestUnsupportedInProxiedModeErrorIsTyped(t *testing.T) {
+	err := ErrUnsupportedInProxiedMode(CapabilityDoltPush)
+
+	var typed *UnsupportedInProxiedModeError
+	if !errors.As(err, &typed) {
+		t.Fatalf("ErrUnsupportedInProxiedMode is not errors.As-checkable as *UnsupportedInProxiedModeError")
+	}
+	if typed.Capability != CapabilityDoltPush {
+		t.Fatalf("Capability = %q, want %q", typed.Capability, CapabilityDoltPush)
+	}
+
+	got, ok := AsUnsupportedInProxiedMode(fmt.Errorf("wrap: %w", err))
+	if !ok {
+		t.Fatalf("AsUnsupportedInProxiedMode failed through a wrap")
+	}
+	if got.Capability != CapabilityDoltPush {
+		t.Fatalf("wrapped Capability = %q, want %q", got.Capability, CapabilityDoltPush)
+	}
+}
+
+// TestUnsupportedInProxiedModeMessageIsActionable asserts every capability
+// renders a non-empty message that names the capability and points to the
+// proxied=false escape hatch — never an empty string that could read as success.
+func TestUnsupportedInProxiedModeMessageIsActionable(t *testing.T) {
+	for _, c := range []Capability{
+		CapabilityDoltPush,
+		CapabilityDoltPull,
+		CapabilityDoltCommit,
+		CapabilityCompaction,
+		CapabilityFederation,
+		CapabilityRemoteSync,
+	} {
+		msg := ErrUnsupportedInProxiedMode(c).Error()
+		if strings.TrimSpace(msg) == "" {
+			t.Fatalf("capability %q produced an empty message", c)
+		}
+		if !strings.Contains(msg, string(c)) {
+			t.Fatalf("message %q does not name capability %q", msg, c)
+		}
+		if !strings.Contains(msg, "proxied=false") {
+			t.Fatalf("message %q does not mention the proxied=false escape hatch", msg)
+		}
+	}
+}
+
+// TestCapabilityValuesAreStable pins the wire/string values so a rename can't
+// silently break tests or operator-facing messages.
+func TestCapabilityValuesAreStable(t *testing.T) {
+	want := map[Capability]string{
+		CapabilityDoltPush:   "dolt-push",
+		CapabilityDoltPull:   "dolt-pull",
+		CapabilityDoltCommit: "dolt-commit",
+		CapabilityCompaction: "compaction",
+		CapabilityFederation: "federation",
+		CapabilityRemoteSync: "remote-sync",
+	}
+	for c, s := range want {
+		if string(c) != s {
+			t.Fatalf("capability value = %q, want %q", string(c), s)
+		}
+	}
+}

--- a/cmd/bd/ready.go
+++ b/cmd/bd/ready.go
@@ -180,7 +180,7 @@ This is useful for agents executing molecules to see which steps can run next.`,
 		// Direct mode
 		ctx := rootCtx
 
-		activeStore := store
+		activeStore := requireStore()
 		if claimReady {
 			CheckReadonly("ready --claim")
 		} else {
@@ -472,7 +472,7 @@ func buildReadyIssueOutput(ctx context.Context, s storage.DoltStorage, issues []
 func runReadyExplain(_ *cobra.Command) {
 	ctx := rootCtx
 
-	activeStore := store
+	activeStore := requireStore()
 
 	// Get ready issues (no limit for explain mode — show everything)
 	filter := types.WorkFilter{

--- a/cmd/bd/ready.go
+++ b/cmd/bd/ready.go
@@ -132,6 +132,10 @@ This is useful for agents executing molecules to see which steps can run next.`,
 			IncludeEphemeral: includeEphemeral, // bd-i5k5x: allow ephemeral issues (e.g., merge-requests)
 			ExcludeTypes:     excludeTypes,
 		}
+		// be-yvci: --brief narrows the projection to omit heavy body columns on the
+		// high-frequency work-probe path (the seam gascity's supervisor work_query
+		// uses to realize the dolt-CPU win). Bodies remain available via bd show.
+		applyReadyBriefFlag(cmd, &filter)
 		// Use Changed() to properly handle P0 (priority=0)
 		if cmd.Flags().Changed("priority") {
 			priority, _ := cmd.Flags().GetInt("priority")
@@ -312,6 +316,16 @@ This is useful for agents executing molecules to see which steps can run next.`,
 		maybeShowTip(store)
 	},
 }
+
+// applyReadyBriefFlag maps the --brief flag onto WorkFilter.BriefBodies (be-yvci),
+// narrowing the work-probe projection to omit heavy body columns. Extracted so the
+// flag→filter wiring is unit-testable without a store.
+func applyReadyBriefFlag(cmd *cobra.Command, filter *types.WorkFilter) {
+	if brief, _ := cmd.Flags().GetBool("brief"); brief {
+		filter.BriefBodies = true
+	}
+}
+
 var blockedCmd = &cobra.Command{
 	Use:   "blocked",
 	Short: "Show blocked issues",
@@ -745,6 +759,7 @@ func init() {
 	readyCmd.Flags().StringSlice("exclude-type", nil, "Exclude issue types from results (comma-separated or repeatable, e.g., --exclude-type=convoy,epic)")
 	readyCmd.Flags().Bool("explain", false, "Show dependency-aware reasoning for why issues are ready or blocked")
 	readyCmd.Flags().Bool("claim", false, "Atomically claim the first ready issue matching the filters")
+	readyCmd.Flags().Bool("brief", false, "Omit heavy body columns (description/design/notes/...) from the projection for high-frequency machine probes (e.g. the supervisor work_query); fetch bodies via bd show (be-yvci)")
 	// Metadata filtering (GH#1406)
 	readyCmd.Flags().StringArray("metadata-field", nil, "Filter by metadata field (key=value, repeatable)")
 	readyCmd.Flags().String("has-metadata-key", "", "Filter issues that have this metadata key set")

--- a/cmd/bd/uow_factory.go
+++ b/cmd/bd/uow_factory.go
@@ -8,9 +8,57 @@ import (
 
 	"github.com/steveyegge/beads/internal/config"
 	"github.com/steveyegge/beads/internal/configfile"
+	"github.com/steveyegge/beads/internal/storage"
+	"github.com/steveyegge/beads/internal/storage/dbproxy/pidfile"
 	"github.com/steveyegge/beads/internal/storage/dbproxy/proxy"
+	"github.com/steveyegge/beads/internal/storage/dolt"
 	"github.com/steveyegge/beads/internal/storage/uow"
 )
+
+// newProxiedServerRoutedStore builds a server-mode DoltStorage that connects
+// through the already-running db-proxy (the same proxy newProxiedServerUOWProvider
+// ensured). Proxied-server mode historically only wired the uow provider, which
+// covers `bd create` but leaves the legacy store-based commands (list, ready,
+// stats, update, close, ...) hitting a nil store. Routing a normal server-mode
+// store at the proxy endpoint makes every store-based command work in proxied
+// mode, and — crucially — those connections flow through the proxy's backend
+// pool just like the uow provider's.
+//
+// The proxy terminates the client handshake with skip-auth, so the user and
+// password sent here are irrelevant; root/empty is used. The real backend
+// credentials live in the proxy child (managed) or its inherited env (external).
+func newProxiedServerRoutedStore(ctx context.Context, beadsDir string) (storage.DoltStorage, error) {
+	if beadsDir == "" {
+		return nil, fmt.Errorf("newProxiedServerRoutedStore: beadsDir must be set")
+	}
+	rootPath, err := resolveProxiedServerRootPath(beadsDir)
+	if err != nil {
+		return nil, fmt.Errorf("newProxiedServerRoutedStore: resolve root path: %w", err)
+	}
+	pf, err := pidfile.Read(rootPath, proxy.PIDFileName)
+	if err != nil || pf == nil || pf.Port == 0 {
+		return nil, fmt.Errorf("newProxiedServerRoutedStore: read proxy endpoint from %s: %w", rootPath, err)
+	}
+
+	persisted, _ := configfile.Load(beadsDir)
+	database := configfile.DefaultDoltDatabase
+	if persisted != nil {
+		database = persisted.GetDoltDatabase()
+	}
+
+	cfg := &dolt.Config{
+		Path:       beadsDir,
+		BeadsDir:   beadsDir,
+		Database:   database,
+		ServerMode: true,
+		ServerHost: "127.0.0.1",
+		ServerPort: pf.Port,
+		ServerUser: "root",
+		// AutoStart stays false: the proxy owns the backend lifecycle. We must
+		// never try to spawn a dolt server for the proxy's listener port.
+	}
+	return dolt.New(ctx, cfg)
+}
 
 func newProxiedServerUOWProvider(ctx context.Context, beadsDir string) (uow.UnitOfWorkProvider, error) {
 	if beadsDir == "" {

--- a/cmd/bd/uow_factory.go
+++ b/cmd/bd/uow_factory.go
@@ -56,6 +56,14 @@ func newProxiedServerRoutedStore(ctx context.Context, beadsDir string) (storage.
 		ServerUser: "root",
 		// AutoStart stays false: the proxy owns the backend lifecycle. We must
 		// never try to spawn a dolt server for the proxy's listener port.
+		//
+		// RoutedThroughProxy stops newServerMode from persisting pf.Port (the
+		// ephemeral proxy listener) into .beads/dolt-server.port. That file is
+		// the canonical-server discovery hint; a proxy port written there is
+		// clobbered on the next reconcile and goes stale when the proxy respawns
+		// on a new port, breaking endpoint resolution for any reader that trusts
+		// it.
+		RoutedThroughProxy: true,
 	}
 	return dolt.New(ctx, cfg)
 }

--- a/docs/CONNECTION_POOLING.md
+++ b/docs/CONNECTION_POOLING.md
@@ -1,0 +1,148 @@
+# db-proxy connection pooling
+
+## Problem
+
+Multi-agent orchestrators (e.g. gascity/gc) run beads against a persistent
+`dolt sql-server` and fork the `bd` binary for **every** agent operation. Each
+`bd` process is short-lived: it opens a fresh `*sql.DB`, dials dolt (TCP + MySQL
+auth handshake + session setup), runs its query, and tears everything down at
+exit. The in-process pool in `internal/storage/dolt/store.go` (`applyPoolLimits`)
+never survives the process, so there is **zero** cross-invocation reuse.
+
+Measured on a 1-rig city (7 active agents):
+
+- **71 new connections/sec** to dolt (lifetime `Connections` ≈ 2.33M)
+- ~560 queries/sec
+- dolt sql-server at 85–170% CPU while a `processlist` snapshot is mostly
+  `Sleep`
+
+The CPU is not query work — it is the **per-call connection setup cost** paid
+71× per second. This is gascity #1978. Hard constraint: **keep Dolt** (bead
+versioning + cross-machine sync via dolt remotes); no migration to the SQLite
+coordstore.
+
+## Approach (chosen: pooling proxy)
+
+beads already ships a `db-proxy` (`internal/storage/dbproxy/proxy`) that fronts
+the dolt sql-server for lifecycle management (auto-start, idle-stop, multi-writer
+coordination). Historically it was a **byte-transparent 1:1 forwarder**: one
+backend dial per client, `io.Copy` both ways, `Close` on disconnect — so it did
+not reduce connection churn.
+
+The fix makes the proxy a **session-pooling, MySQL-protocol-aware** forwarder:
+
+1. The proxy terminates the client handshake itself (skip-auth — clients are
+   loopback-only and already trusted by the proxy's design).
+2. It borrows an already-authenticated backend connection from a pool of warm
+   connections to dolt.
+3. The command phase is forwarded **byte-transparently** (the proven `io.Copy`
+   path), so bd's storage / uow / transaction code is unchanged.
+4. On client disconnect the proxy sends `COM_RESET_CONNECTION` to the backend
+   (purging session variables, open transactions, temp tables, prepared
+   statements) and returns it to the pool instead of closing it.
+
+`bd` continues to speak MySQL exactly as before; the only change for a consumer
+is selecting ProxiedServerMode and setting one env var.
+
+### Why not a bd daemon (rejected)
+
+A long-lived `bd serve` holding the pool, with the CLI shipping operations over
+IPC, was rejected: it requires routing the entire domain layer over an RPC
+surface (or reinventing the MySQL wire protocol over a socket), the fallback
+path is complex, and transactions still force per-invocation session pinning —
+so it yields no advantage over pooling at the proxy while costing far more code.
+
+## Correctness
+
+### Capability-flag parity
+
+Byte-transparent command-phase forwarding requires the capability flags
+negotiated **client↔proxy** to equal those negotiated **proxy↔backend** —
+result-set encoding depends on flags such as `CLIENT_DEPRECATE_EOF`,
+`CLIENT_PROTOCOL_41`, `CLIENT_QUERY_ATTRIBUTES`, `CLIENT_SESSION_TRACK`. A
+mismatch would silently corrupt the wire stream. Therefore the pool is **keyed
+by `(capabilities, database)`**: the proxy authenticates each backend with
+exactly the caps the client negotiated, and only lends a backend to a client
+with an identical key. All `bd` clients share one driver and DSN, so they
+collapse onto a single key and reuse the same warm connections. A client with an
+unexpected key simply causes a fresh dial (still correct, just not reused).
+
+### Session isolation
+
+`COM_RESET_CONNECTION` is the isolation primitive. dolt's go-mysql-server
+handler releases all locks, closes the session, creates a fresh one, and
+restores the connection's default database. Note that go-sql-driver's
+`ResetSession` does **not** send `COM_RESET_CONNECTION` (it only does a liveness
+check), which is why the proxy sends the packet itself. If the reset fails the
+connection is destroyed rather than reused.
+
+The reset reply is **sequence-checked** (a reply to a fresh command is always
+sequence 1). If the proxy instead reads an out-of-sequence packet — e.g. a
+client was killed mid-result and unread result packets are still in the stream —
+the connection is treated as misaligned and destroyed, never lent out.
+
+### COM_QUIT interception
+
+go-sql-driver sends `COM_QUIT` when it closes a connection. Forwarding that to a
+pooled backend would terminate it. The client→backend direction is therefore
+frame-aware enough to detect a standalone `COM_QUIT` and reclaim the backend
+instead of forwarding it. All other frames pass through verbatim.
+
+## Configuration / opt-in
+
+Pooling is **opt-in** and off by default (`BEADS_PROXY_POOL_SIZE` unset or `0`
+preserves the original transparent forwarding). Embedded mode and direct
+ServerMode are unaffected.
+
+| Knob | Effect |
+|------|--------|
+| `BEADS_PROXY_POOL_SIZE=N` | Enable pooling; keep up to `N` warm idle backend connections per `(caps,db)` key. Read by the uow provider when it opens the proxy endpoint. |
+
+Internals (set automatically, listed for reference):
+
+- `proxy.OpenOpts.PoolSize` / `BackendUser` → spawned child flags
+  `--pool-size` / `--backend-user`. The backend password is inherited by the
+  child via the environment, never passed on the command line.
+- `proxy.ProxyOpts.{PoolSize,BackendUser,BackendPassword,PoolConnMaxLifetime}`.
+- `PoolConnMaxLifetime` defaults to 0 (unlimited): a short lifetime would
+  re-create the churn pooling exists to eliminate.
+
+Because the proxy is spawned once and reused, the pool size is fixed by the
+**first** `bd` invocation that starts the proxy; set `BEADS_PROXY_POOL_SIZE`
+consistently across a deployment.
+
+## gascity integration
+
+gascity currently points `bd` at its managed dolt sql-server in **ServerMode**
+(`BEADS_DOLT_SERVER_HOST`/`PORT`). To benefit from pooling:
+
+1. Switch `bd` to **ProxiedServerMode** with the **external** backend so the
+   proxy fronts the existing managed sql-server (rather than starting a second
+   dolt). ProxiedServerMode is selected via the workspace's `metadata.json`
+   `dolt_mode = proxied-server` (`configfile.IsDoltProxiedServerMode`); the
+   runtime path is live at `cmd/bd/main.go` → `newProxiedServerUOWProvider` →
+   `newExternalProxiedServerUOWProvider`. The external host/port/user (and
+   `BEADS_DOLT_PASSWORD` for auth) configure the backend the proxy connects to.
+2. Export **`BEADS_PROXY_POOL_SIZE`** in the environment of every forked `bd`
+   (e.g. `2 × max concurrent agents per rig`). The proxy is shared per workspace
+   root, so all agents in a rig share one warm pool.
+
+Effect: the per-`bd` connection churn against dolt collapses to the pool size
+(steady-state ~0 new connections/sec) instead of one new authenticated
+connection per agent operation, removing the connection-setup CPU load on the
+dolt sql-server while keeping Dolt and all its versioning/sync semantics intact.
+
+## Validation
+
+`internal/storage/dbproxy/proxy`:
+
+- Unit (`pool_test.go`, `mysqlwire_test.go`): pool reuse/cap/key-isolation/
+  drain/eviction/lifetime against a fake backend; wire round-trips. No dolt.
+- Integration (`proxy_pool_integration_test.go`, `mysqlwire_spike_test.go`;
+  cgo + dolt): real proxyServer — query/transaction/`DOLT_COMMIT` round-trip,
+  rollback leaves no row, 8 concurrent clients keep private sessions, and
+  session isolation (`@var`, `autocommit`, temp table purged between borrowers
+  sharing one backend).
+- Benchmark (`BenchmarkConnectionChurn`): dolt-side `Connections` delta over 50
+  sequential sessions — **pooling off = 50** (1:1 churn), **pooling on = 0**
+  (50 pool hits, 1 dial).

--- a/docs/CONNECTION_POOLING_DEPLOYMENT.md
+++ b/docs/CONNECTION_POOLING_DEPLOYMENT.md
@@ -129,6 +129,38 @@ invocation. Add `env["BEADS_PROXY_POOL_SIZE"] = <n>` there so both agent and
 generates ~13 conns/sec even with no agents, so pooling helps the controller,
 not just agents.)
 
+### 4. `local-shared-server` — collapse N+1 proxy children into one (be-pen9)
+
+Sections 1–3 give every scope its **own** `db-proxy-child` (HQ + N rigs ⇒ N+1
+children, ~1 GB RAM measured on portharbour). The `local-shared-server` backend
+collapses them onto **one** shared child. The pool is already keyed by
+`(capabilities, database)`, so a single proxy multiplexes every scope's database;
+the collapse comes entirely from pointing every scope at **one shared proxy
+rootDir** (the parent's spawn-or-reuse is keyed by rootDir).
+
+On the beads side (landed in be-pen9):
+
+- `proxy.BackendLocalSharedServer` (`local-shared-server`) is now a dispatchable
+  backend — it fronts the managed dolt through the same external-server
+  mechanism, carries the `--external-*` args across the fork, and participates
+  in the upstream-ID guard (a shared proxy pointed at the wrong managed dolt is
+  rejected, never silently reused).
+- `doltserver.SharedProxyRootDir()` resolves the machine-wide shared rootDir
+  (`~/.beads/shared-server/proxy/`, override with `BEADS_SHARED_PROXY_ROOT_PATH`).
+- **Opt-in via `BEADS_SHARED_PROXY=1`**: when set, every proxied scope resolves
+  its proxy rootDir to `SharedProxyRootDir()` instead of its per-scope
+  `.beads/proxieddb`. **OFF by default**, so existing per-scope proxied scopes
+  are byte-for-byte unchanged.
+
+gascity wiring (the cross-rig sling that realizes the collapse in production):
+export `BEADS_SHARED_PROXY=1` in the projected env (`cmd/gc/bd_env.go`, alongside
+the section-3 pool-size injection) for every proxied scope, keeping the section-1
+`external` block pointing all scopes at the **same** managed dolt (same
+host/port ⇒ same upstream ID ⇒ they share one child). Validate on a **throwaway**
+city, never live portharbour: `pgrep -f db-proxy-child | wc -l` → 1 with each
+scope's store still queryable. (be-pen9 T-007 confirmed N+1→1 on a throwaway
+two-scope city: both scopes resolved to one rootDir and one child served both.)
+
 ### Why this matches the measured problem
 
 The managed dolt config (`/Users/cstar/portharbour/.gc/runtime/packs/dolt/

--- a/docs/CONNECTION_POOLING_DEPLOYMENT.md
+++ b/docs/CONNECTION_POOLING_DEPLOYMENT.md
@@ -1,0 +1,139 @@
+# Connection pooling — deployment, validation, gascity integration
+
+Companion to [CONNECTION_POOLING.md](CONNECTION_POOLING.md) (the design). This
+covers how to turn pooling on end-to-end, the real-CLI validation numbers, and
+the exact gascity wiring change needed to make it durable.
+
+## Deployment: `bd init --proxied-server` (external)
+
+Pooling only takes effect in **ProxiedServerMode** (the proxy must be in the
+path). Provision a workspace whose `metadata.json` records
+`dolt_mode=proxied-server` and whose `proxied_server_client_info.json` points at
+an already-running external dolt sql-server:
+
+```sh
+bd init --proxied-server \
+  --proxied-server-external-host 127.0.0.1 \
+  --proxied-server-external-port 42188 \
+  --proxied-server-external-user root \
+  --prefix pt --database pt --non-interactive
+# password (if any): export BEADS_PROXIED_SERVER_EXTERNAL_PASSWORD=...
+```
+
+Unix socket is supported too (`--proxied-server-external-socket-path`).
+Managed-local proxied mode (proxy spawns its own dolt) is intentionally still
+rejected — it needs a local `.dolt` lifecycle (`MarkDoltDirCompatible`) that is
+out of scope here; external mode fronts an existing server and creates no local
+Dolt.
+
+Then enable pooling by exporting, in the environment of every forked `bd`:
+
+```sh
+export BEADS_PROXY_POOL_SIZE=4   # 0/unset = transparent (no pooling)
+```
+
+The proxy is spawned once per workspace root and reused, so the pool size is
+frozen by the first `bd` invocation that starts the proxy. Set it consistently
+and kill any pre-existing `bd db-proxy-child` when changing it.
+
+Two `cmd/bd` changes made this usable (both on `feat/connection-pooling`):
+- `bd init --proxied-server` external was unfenced (the full
+  `runInitProxiedServer` already existed behind a blanket "not yet implemented"
+  guard).
+- A server-mode store is now routed through the proxy in proxied mode
+  (`newProxiedServerRoutedStore`), so the legacy store-based commands
+  (list/ready/stats/update/close/...) work — previously only `bd create`
+  (uow-based) did; the rest dereferenced a nil store and panicked.
+
+## Real-CLI validation
+
+Two backends were used. **Functional** correctness was checked against the live
+gascity-managed dolt on **42188** (create/list/ready/update/close/dep all work
+through the proxy; writes commit via `DOLT_COMMIT`). **Quantitative** churn was
+measured against a **dedicated quiet dolt on 42199** (no background load, so the
+global `Connections` counter is uncontaminated; the 42188 counter is global and
+gascity itself generates tens of conns/sec).
+
+Method: kill any proxy, warm once (spawns proxy with the chosen pool size), then
+50 sequential `bd list` invocations; read dolt `SHOW GLOBAL STATUS LIKE
+'Connections'` before/after.
+
+| Mode | new dolt connections / 50 invocations | per invocation |
+|------|---------------------------------------|----------------|
+| pooling OFF (`BEADS_PROXY_POOL_SIZE` unset) | 351 | **7.02** |
+| pooling ON (`BEADS_PROXY_POOL_SIZE=4`)      | 51  | **1.02** |
+
+→ **~7× fewer new dolt connections** per `bd` invocation. The proxy log confirmed
+`connection pooling enabled (maxIdle=4)` with **zero** reset/misalignment errors
+(the only logged "errors" are benign readiness probes that dial+close the proxy
+before handshaking).
+
+Notes on the numbers:
+- The pure-pool ceiling is **0** new connections (see
+  `BenchmarkConnectionChurn`: a single raw client → 0 over 50 sessions). The CLI
+  residual (~1/invocation) is not a pool defect — it is per-process overhead
+  that the pool cannot remove: each `bd` invocation in proxied mode opens both a
+  uow-provider connection set (whose `openAndInitSchema` connects twice and
+  re-checks schema) and the routed store, and the schema-init connection is the
+  remaining ~1 fresh dolt connection that isn't reused across processes.
+- OFF is ~7/invocation precisely because of that same dual-connect ×
+  schema-init; pooling collapses 6 of the 7.
+- A future optimization (out of scope) — making the uow provider lazy so
+  read-only commands skip `openAndInitSchema` — would push ON toward ~0.
+
+Container-backed integration tests (`BEADS_TEST_PROXIED_SERVER=1`, real dolt):
+`TestProxiedServerExternalCreate` (now unblocked) and
+`TestProxiedServerExternalStoreCommands` (list/ready/update/close via the routed
+store) both pass.
+
+## gascity integration (Phase 2 — the durable wiring diff)
+
+gascity currently runs `bd` in **direct ServerMode** and **re-asserts
+`dolt_mode=server` on every reconcile**, so a manual metadata flip would be
+reverted. Three coordinated changes make proxied+pooling stick. All paths are in
+`/Users/cstar/rigs/gascity`.
+
+### 1. `cmd/gc/beads_provider_lifecycle.go` — write proxied-server, not server
+
+`normalizeCanonicalBdScopeFiles` / `normalizeCanonicalBdScopeFilesForInit` (and
+the `DoltMode: "server"` literal around line 1435) re-normalize each scope's
+`metadata.json` to `dolt_mode=server` on every reconcile. Change them to emit
+`dolt_mode=proxied-server` and to write `proxied_server_client_info.json` with
+an `external` block (host/port/user) pointing at the managed dolt (42188),
+instead of (or in addition to) the server-mode host/port. This is the load-
+bearing change: without it the scope is flipped back to server mode and the
+proxy is bypassed.
+
+### 2. `examples/bd/assets/scripts/gc-beads-bd.sh` — init + env
+
+- `run_bd_init_pinned` (≈ line 2189) runs
+  `bd init --server --server-host H --server-port P`. Switch to:
+  `bd init --proxied-server --proxied-server-external-host H
+  --proxied-server-external-port P --proxied-server-external-user "$DOLT_USER"`,
+  and pass the password via `BEADS_PROXIED_SERVER_EXTERNAL_PASSWORD` (not
+  `BEADS_DOLT_PASSWORD`).
+- `run_bd_pinned` (≈ line 2179) exports `BEADS_DOLT_SERVER_HOST/PORT/USER/
+  PASSWORD` for every `bd` call, which forces direct server mode. For proxied
+  scopes, stop exporting `BEADS_DOLT_SERVER_*`/`BEADS_DOLT_SERVER_MODE` (they
+  select direct ServerMode and would shadow proxied mode) and instead export
+  `BEADS_PROXY_POOL_SIZE` (e.g. `2 × max concurrent agents per rig`) plus
+  `BEADS_PROXIED_SERVER_EXTERNAL_PASSWORD` when the server requires auth.
+
+### 3. `cmd/gc/bd_env.go` — inject the pool size into projected env
+
+The bd command runners (`bdCommandRunnerForCity/Rig`,
+`controlBdCommandRunnerFor*`) and the canonical-target env projector
+(`applyCanonicalDoltTargetEnv`, ≈ line 256) build the env map for every `bd`
+invocation. Add `env["BEADS_PROXY_POOL_SIZE"] = <n>` there so both agent and
+**controller** bd calls front the pool. (The controller + order loop alone
+generates ~13 conns/sec even with no agents, so pooling helps the controller,
+not just agents.)
+
+### Why this matches the measured problem
+
+The managed dolt config (`/Users/cstar/portharbour/.gc/runtime/packs/dolt/
+dolt-config.yaml`) already documents the symptom — short-lived per-call
+connections piling up in `Sleep`, `read_timeout` cut to 30s to reap them — and
+gascity #1978 measured 71 new conns/sec. Routing every scope through the pooled
+proxy collapses that to roughly the pool size in steady state while keeping
+Dolt, its versioning, and `dolt remote` sync untouched.

--- a/docs/decisions/be-s3ca.md
+++ b/docs/decisions/be-s3ca.md
@@ -1,0 +1,63 @@
+# Decide: Merge PR #4 in cstar/beads? (source bead be-pen9; tacit-consent 10min)
+
+| Field | Value |
+|---|---|
+| Decision bead | `be-s3ca` |
+| Source bead | `be-pen9` |
+| Rig | `beads` |
+| PM |  () |
+| Created | 2026-06-08 16:42 UTC |
+| Plan file | — |
+
+## Question
+
+Merge PR #4 in cstar/beads? (source bead be-pen9; tacit-consent 10min)
+
+## Full context
+
+**What changed:** Wire BackendLocalSharedServer: opt-in collapse of per-scope db-proxy-children into one shared proxy (OFF by default)
+
+**Tested by:** Reviewer re-ran build+vet+full suites green at head eccac031a; collapse + upstream-ID isolation guard + live-path regression all PASS (exit 0)
+
+**Ready because:** Dormant/opt-in, live fleet untouched; production cutover gated separately (ga-mozik). Base unprotected so no CI gate — manual review substituted.
+
+**PR:** https://github.com/cstar/beads/pull/4
+
+**Tacit-consent deadline:** 2026-06-08T16:52:30Z
+
+If you do nothing, gc-merge-sweep auto-merges this PR at the deadline.
+Reply `OK` to merge sooner, `NOK <why>` to hold for triage.
+
+
+## Recommended default
+
+OK (proceed with merge)
+
+## Why this is the default
+
+Reviewer agent approved. Tacit-consent timeout means no reply within 10 min = OK. Reply NOK <why> to hold.
+
+## Impact if changed
+
+On OK or 10-min timeout: gc-merge-sweep runs `gh pr merge 4 --repo cstar/beads --admin --delete-branch` and closes source bead be-pen9. On NOK: source bead stays blocked for Karel's triage.
+
+## Cascades
+
+Closing this decision bead will unblock:
+- `be-pen9` — and any beads downstream of it via `bd link`.
+
+## How to respond
+
+```bash
+cd /Users/cstar/rigs/beads && bd close be-s3ca --reason "<your answer>"
+```
+
+The PM's reason text becomes the decision record. The bd cascade
+unblocks the source bead; the pool reconciler then re-spawns the agent
+which reads this resolution from `bd show be-pen9` dependents.
+
+## Related
+
+- Plan file: `(none)`
+- Source bead: `bd show be-pen9` in `/Users/cstar/rigs/beads`
+- Other open decisions in this rig: `bd list --type decision --status open`

--- a/docs/plans/be-pen9-shared-proxy-consolidation.md
+++ b/docs/plans/be-pen9-shared-proxy-consolidation.md
@@ -1,0 +1,198 @@
+# Consolidate per-scope db-proxy-children into ONE shared proxy (`BackendLocalSharedServer`) — Plan v0.1
+
+**Status:** Draft · **Date:** 2026-06-08 · **Author:** voxist.planner · **Rig:** beads · **Bead:** be-pen9 · **Base:** `feat/connection-pooling`
+
+## Context
+
+Connection-pooling Phases 0 (be-8nd) and 1 (ga-bgub9) are merged and live. The
+proxy now pools warm backend connections per scope, but each **scope** (HQ + N
+rigs) still spawns its **own** `db-proxy-child`: portharbour measured ~17
+children at ~1 GB RAM. They all front the *same* managed dolt, so the
+fragmentation is pure overhead — N+1 listeners, N+1 pools, N+1 idle watchers
+where one would do.
+
+The decisive question (Karel): **is the warm backend pool DB-pinned?** It is
+not. The pool is keyed by `(capabilities, database)`:
+
+- `internal/storage/dbproxy/proxy/pool.go:27` — `backendKey{caps uint32; db string}`
+- `internal/storage/dbproxy/proxy/pooledconn.go:39` — `key := backendKey{caps: ch.capabilities, db: ch.database}`
+
+So a **single** `backendPool` already multiplexes many databases onto one
+listener, each `(caps, db)` getting its own warm sub-stack. This is **proven
+green today**:
+
+- `proxy/multidb_isolation_test.go::TestSpike_MultiDatabaseIsolation` — two DBs
+  (`rig_a`, `rig_b`) interleaved through one pool, each reads only its own
+  marker, heavy reuse (commit `a3dde55be`).
+- `proxy/mysqlwire_spike_test.go::TestSpike_ConnectionCounterFlat` — dolt-side
+  `Connections` stays flat across 40 sessions.
+
+What is **missing** is the process-level collapse. The proxy already
+spawn-or-reuses by **rootDir**: `GetCreateDatabaseProxyServerEndpoint(rootDir,
+opts)` (`proxy/endpoint.go:131`) does `readAndDial(rootDir)` first and only
+forks a child when no live proxy answers at that rootDir's pidfile. Today each
+scope passes a **per-scope** rootDir (`cmd/bd/proxied_server.go:24`
+`proxiedServerRoot = <beadsDir>/proxieddb`), so every scope gets its own lock,
+its own pidfile, its own child. Point every proxied scope at **one shared
+rootDir** and the `proxy.lock` race / `readAndDial` reuse collapses them to a
+single child whose `(caps, db)` pool serves them all.
+
+The backend enum already reserves the slot for this — `proxy/backend.go:18`
+`BackendLocalSharedServer = "local-shared-server"` — but it is a **constant with
+no dispatch**: `cmd/bd/db_proxy_child.go:103-104` returns
+`fmt.Errorf("backend %q: not yet implemented")`, and `endpoint.go`'s validation
+switch and `--external-*` flag plumbing have no case for it. This plan wires
+it.
+
+## Constraints
+
+- **HARD: validate on a THROWAWAY proxied city, never live portharbour.**
+  Changing the proxy topology against the running fleet risks all 18 rigs (same
+  discipline as ga-bgub9 T-004). All end-to-end assertions run on a temp city.
+- The change is **opt-in**: only scopes explicitly configured for the shared
+  backend take the new path. `external` and `local-server` scopes are
+  byte-for-byte unchanged (compose with Phase 0/1).
+- Dolt, its versioning, and `dolt remote` sync are untouched — the proxy is
+  stateless connection plumbing in front of the managed dolt.
+- Spike/integration tests are gated `//go:build cgo` and skip when `dolt` is not
+  on `PATH`. Raw `go test`/`go vet` need the icu4c CGO flags
+  (`-I/-L $(brew --prefix icu4c)`); see [gascity dev loop] memory.
+- House style: defer to the rig's existing error-wrapping / logging idioms
+  (`fmt.Errorf("...: %w")`, the `[proxy]` logger) — match `endpoint.go` /
+  `db_proxy_child.go` as written.
+
+## Proposed approach
+
+Empirical-first (Karel's STEP 1 → 2 → 3), de-risked because the pool half of
+STEP 1 is already green:
+
+1. **STEP 1 — confirm process collapse (T-001).** The pool-multiplex hypothesis
+   is pre-confirmed (tests above). The residual unknown is topological: two
+   scopes at one shared rootDir → one child. Prove it at the
+   `GetCreateDatabaseProxyServerEndpoint` reuse seam (simulate the first proxy
+   via a written pidfile + listener, exactly like `endpoint_mismatch_test.go`),
+   and prove the shared backend's upstream-ID mismatch guard rejects a proxy
+   fronting the *wrong* managed dolt. **Gate:** if collapse cannot be shown,
+   STOP and re-sling `voxist.platform-architect` (this is STEP 3 territory —
+   per-database sub-pools behind one listener — a different design).
+2. **STEP 2 — wire `BackendLocalSharedServer` (T-002…T-006).** Dispatch the
+   backend to a `server.DatabaseServer` fronting the managed dolt; add endpoint
+   validation, upstream-ID, and `--external-*` flag plumbing for it; resolve a
+   single machine-wide shared proxy rootDir and have the provider pass it.
+3. **STEP 3 — validate + document (T-007…T-008).** Throwaway-city e2e proving
+   N+1 → 1, then build/vet/test green and the deployment-doc note.
+
+The likely-lightest wiring (to be confirmed in review, see Open questions): the
+shared backend's concrete server is the **same** external-dolt server
+(`server.NewExternalDoltServer`) pointed at the managed dolt — the *collapse*
+comes entirely from the shared **rootDir**, not from a new server type. The new
+backend exists to make that rootDir policy explicit, validated, and
+discoverable.
+
+## Micro-tasks
+
+> One bead, one PR. The executor consumes the whole table in a single session.
+> First task is the failing test (TDD, architecture §10). `est` is minutes.
+
+| id | description | acceptance | est | slings |
+|---|---|---|---|---|
+| T-001 | Write failing test for shared-rootDir process collapse + upstream-ID guard, simulating the first proxy via a pidfile (per `endpoint_mismatch_test.go`). | New `proxy/endpoint_shared_test.go::TestSharedRootDir_ReusesOneChild` (second `GetCreateDatabaseProxyServerEndpoint` call, same rootDir, `BackendLocalSharedServer` → returns the same `Endpoint`, no fork) **and** `::TestSharedBackend_RejectsUpstreamMismatch` (pidfile with wrong `UpstreamID` → `ErrUpstreamMismatch`) — both RED. | 5 | — |
+| T-002 | Write failing test that `newDatabaseServer(BackendLocalSharedServer, …)` yields a usable server, not the "not yet implemented" error. | `cmd/bd/db_proxy_child_test.go::TestNewDatabaseServer_SharedServer` asserts non-nil server + nil error — RED (`db_proxy_child.go:104`). | 3 | — |
+| T-003 | Implement the `BackendLocalSharedServer` case in `newDatabaseServer` to front the managed dolt (reuse `server.NewExternalDoltServer(external)`); read backend password for the shared backend too. | T-002 passes; `db_proxy_child.go:74` password gate also covers `BackendLocalSharedServer`. | 5 | — |
+| T-004 | Add the `BackendLocalSharedServer` case to `endpoint.go`'s validation switch (require `LogFilePath` + `External.Validate()`) and make `intendedUpstreamID` return `server.ExternalDoltServerID(opts.External)` for it. | T-001's `TestSharedBackend_RejectsUpstreamMismatch` passes; a shared call missing `External` returns a validation error (assert in `endpoint_shared_test.go`). | 5 | — |
+| T-005 | Extend `forkExecChild` to append the `--external-*` args for `BackendLocalSharedServer` (currently gated `== BackendExternal`). | New `proxy/endpoint_args_test.go::TestForkArgs_SharedCarriesExternal` (extract a pure `childArgs(opts, port)` seam; assert it includes `--external-host/-port` for the shared backend) — RED then GREEN. | 5 | — |
+| T-006 | Add a machine-wide `SharedProxyRootDir()` resolver and have the proxied UOW provider pass it (not the per-scope `proxieddb`) when the shared backend is selected. | New `..._test.go::TestSharedProxyRootDir_StableAcrossScopes` (two distinct `beadsDir`s resolve to the **same** shared proxy rootDir) — RED then GREEN. | 5 | — |
+| T-007 | Validation gate (timeboxed): on a THROWAWAY proxied-shared city, init two scopes and assert exactly one child. | `pgrep -f 'db-proxy-child' \| wc -l` == 1 with both scopes' stores queryable (`bd list` succeeds against each); before/after child count pasted into the bead. NOT run against live portharbour. | 5 | — |
+| T-008 | `go build`/`go vet`/dbproxy tests green (icu4c CGO flags); add a beads-side note to `docs/CONNECTION_POOLING_DEPLOYMENT.md`; capture the cross-rig gascity sling. | `go build ./... && go vet ./... && go test ./internal/storage/dbproxy/...` green; deployment-doc Phase-2 section names the new `local-shared-server` backend. | 5 | gascity/voxist.executor (see Open questions: gascity wiring) |
+
+## GDPR data-flow impact
+
+### Data added / removed / relocated
+None. This changes **how many proxy processes** front the same managed dolt, not
+what data is stored or where. Beads issue data and the dolt store are untouched;
+no personal data is read, written, or moved.
+
+### New cross-border transfers (or "none")
+None. The shared proxy listens on loopback (`127.0.0.1`) and fronts the same
+local managed dolt; no new network egress, no new region.
+
+### Audit-log changes (or "none")
+None. Proxy/dolt logging is unchanged (a single shared `proxy.log` rather than N
+per-scope logs is fewer files, not different content).
+
+## MDR Class I traceability
+
+Not applicable — not a clinical path. This is beads/gascity orchestration
+infrastructure; no `voxmemo` clinical-documentation data crosses it and no
+chain-of-evidence metadata is involved.
+
+## Acceptance criteria
+
+- Two proxied scopes against **one shared rootDir** → exactly **ONE**
+  `db-proxy-child` serves **both** databases via the `(caps, db)` pool.
+- On a multi-scope proxied city, total `db-proxy-children` drops from **N+1 to
+  1**; total Dolt connections stay bounded (pool hits dominate).
+- Validated on a **throwaway** proxied city, not live portharbour (T-007).
+- `go build` + `go vet` + the spike/unit tests green (T-008).
+- `external` and `local-server` scopes are unaffected (no regression in
+  `endpoint_mismatch_test.go`, `proxy_pool_integration_test.go`).
+
+## Rollback plan
+
+1. **Git-level.** Revert the `gc/be-pen9` PR (single squashed commit on
+   `feat/connection-pooling`). Because the backend is opt-in (selected only when
+   a scope is configured for `local-shared-server`), reverting removes the
+   *option*; all `external`/`local-server`/embedded scopes keep working
+   untouched.
+2. **Data-level.** None — no schema change, no migration. The only live state is
+   a running shared `db-proxy-child`; on revert, kill it (`pkill -f
+   db-proxy-child`) and let scopes respawn their per-scope proxies under the
+   prior config. Dolt data and `dolt remote` sync are never touched.
+3. **Decision criteria.** Trigger rollback if, on the throwaway city, any of:
+   (a) a scope reads another scope's store (cross-store bleed — the
+   `multidb_isolation` invariant broke); (b) the dolt `Connections` counter is
+   **not** bounded (collapse/pool not effective); (c) the single shared proxy
+   crashing takes down all scopes without clean spawn-or-reuse recovery
+   (blast-radius regression vs. N independent proxies).
+
+## Open questions
+
+- **(executor/reviewer) Is a new backend type even necessary?** The collapse
+  comes from the shared **rootDir**, not the server type — `BackendExternal` +
+  a shared rootDir might suffice. Karel's design and the reserved constant say
+  model it as a backend (explicit validation + discoverability + a seam for
+  STEP 3 sub-pools). Confirm in PR; if `external`+shared-rootDir is judged
+  enough, T-003 collapses to "alias `local-shared-server` to the external
+  server" and the value is purely the rootDir policy in T-006.
+- **(executor/reviewer) Shared proxy rootDir location + override name.** Under
+  `doltserver.SharedServerDir()/proxy`? A new well-known dir? Honor a
+  `BEADS_SHARED_PROXY_ROOT_PATH` env (mirroring the existing
+  `BEADS_PROXIED_SERVER_ROOT_PATH`)? Pick the name consistent with the existing
+  envs in `cmd/bd/proxied_server.go`.
+- **(executor/reviewer) Blast radius / SPOF.** One shared proxy fronts ALL
+  scopes. Confirm the existing stale-pidfile + child-flock recovery in
+  `spawnAndHandoff` (`endpoint.go:198-258`) cleanly handles a shared-proxy
+  crash (next scope touch re-spawns one). Raise to `platform-architect` if the
+  recovery path needs hardening for the shared topology.
+- **(executor/reviewer) Idle timeout.** A shared proxy touched by many scopes
+  stays warm trivially, but if all go idle it dies and respawns on next touch.
+  The `BEADS_PROXY_IDLE_TIMEOUT` override already exists (`endpoint.go:104`);
+  confirm the default suits the shared topology or document the recommended
+  value.
+- **(cross-rig sling — NOT routed from here) gascity production wiring.**
+  Realizing N+1 → 1 *in production* needs the gascity side to select the shared
+  backend, per `docs/CONNECTION_POOLING_DEPLOYMENT.md` §1-3 (paths in
+  `/Users/cstar/rigs/gascity`): `cmd/gc/beads_provider_lifecycle.go` (emit the
+  shared-proxied mode), `examples/bd/assets/scripts/gc-beads-bd.sh` (init +
+  env), `cmd/gc/bd_env.go` (project pool size). This is a separate `ga-` bead;
+  per the planner hard rule it must route to **`gascity/voxist.executor`**, not
+  any planner. Sling-ready text:
+  > **Title:** Wire gascity to select the shared db-proxy backend (N+1 → 1)
+  > **Body:** With beads be-pen9 landed (`local-shared-server` backend +
+  > shared proxy rootDir), switch gascity's proxied-scope wiring to select it so
+  > all scopes collapse onto one shared proxy. Apply `CONNECTION_POOLING_DEPLOYMENT.md`
+  > §1 (`beads_provider_lifecycle.go` → emit shared-proxied + client info), §2
+  > (`gc-beads-bd.sh` init/env), §3 (`bd_env.go` pool-size projection). Validate
+  > on a throwaway city: `pgrep -f db-proxy-child | wc -l` → 1. Base: a beads
+  > release that includes be-pen9.
+  > **Depends on:** be-pen9 (beads side) merged + released.

--- a/docs/plans/be-pen9-shared-proxy-consolidation.md
+++ b/docs/plans/be-pen9-shared-proxy-consolidation.md
@@ -196,3 +196,22 @@ chain-of-evidence metadata is involved.
   > on a throwaway city: `pgrep -f db-proxy-child | wc -l` → 1. Base: a beads
   > release that includes be-pen9.
   > **Depends on:** be-pen9 (beads side) merged + released.
+
+## Status
+
+All micro-tasks green; one PR opens the accumulated per-task commits on `gc/be-pen9`.
+
+- [x] T-001 — failing test: shared-rootDir reuse + upstream-ID guard   ✅ green at `be89a1897`
+- [x] T-002 — failing test: `newDatabaseServer(BackendLocalSharedServer)` usable   ✅ green at `002316c49`
+- [x] T-003 — dispatch `BackendLocalSharedServer` → `NewExternalDoltServer`; password gate covers it; obsolete `…StillStubbed` test replaced   ✅ green at `002316c49`
+- [x] T-004 — `intendedUpstreamID` + endpoint validation switch cover the shared backend (`External` required)   ✅ green at `be89a1897`
+- [x] T-005 — extracted pure `childArgs(rootDir, opts, port)` seam; shared backend carries `--external-*` via `backendCarriesExternal`   ✅ green at `c2753121e`
+- [x] T-006 — `doltserver.SharedProxyRootDir()` machine-wide resolver + opt-in `BEADS_SHARED_PROXY` rootDir chokepoint in `resolveProxiedServerRootPath`   ✅ green at `587f3c9bc`
+- [x] T-007 — THROWAWAY proxied-shared city (NOT live portharbour): two external-proxied scopes → **1** db-proxy-child (before 0 → init A 1 → init B still 1; both stores queryable). N+1→1 confirmed; live fleet untouched. Evidence in the bead.
+- [x] T-008 — `go build ./...` + `go vet ./...` + `go test ./internal/storage/dbproxy/...` green; deployment-doc §4 (`local-shared-server`) added; cross-rig gascity sling captured as `ga-mozik` (gascity store, gated on be-pen9 release, unrouted by design)   ✅ green at `70a019042`
+
+### Resolved open questions
+
+- **New backend type necessary?** Kept as the plan's lightest wiring: `local-shared-server` dispatches to `NewExternalDoltServer` (same server type); the collapse is the shared rootDir. The distinct backend buys explicit validation, the upstream-ID guard, and `--external-*` fork plumbing — worth it for discoverability and a STEP-3 seam.
+- **Shared rootDir location + override.** `doltserver.SharedProxyRootDir()` → `~/.beads/shared-server/proxy/`, override `BEADS_SHARED_PROXY_ROOT_PATH` (mirrors `BEADS_SHARED_SERVER_DIR`). Scope opt-in is `BEADS_SHARED_PROXY` (truthy), OFF by default so existing proxied scopes are byte-for-byte unchanged.
+- **Blast radius / idle timeout.** Unchanged from the existing proxy: `BEADS_PROXY_IDLE_TIMEOUT` keeps a shared proxy warm; spawn-or-reuse recovery in `endpoint.go` is identical (one rootDir). No hardening needed for the opt-in beads side; production blast-radius tuning rides the gascity sling (`ga-mozik`).

--- a/docs/plans/be-yvci-narrow-poll-projection.md
+++ b/docs/plans/be-yvci-narrow-poll-projection.md
@@ -1,0 +1,197 @@
+# Plan — be-yvci: narrow the ready/work-probe projection (drop LONGTEXT bodies from the poll path)
+
+**Bead:** be-yvci (P1, bug) · **Rig:** beads · **Base branch:** `feat/connection-pooling` · **Branch:** `gc/be-yvci`
+**Author:** beads/voxist.planner-1 · **Date:** 2026-06-25
+**Slice:** A (beads-core) of the dolt-CPU re-diagnosis. Slice B (gascity work_query warm-pool + flip the flag introduced here) = ga-arn. Slice C (`gc dolt cleanup`) = ops.
+
+## Problem (one paragraph)
+
+The managed Dolt sql-server pegs CPU under the agent fleet. The architect's
+EXPLAIN-driven re-diagnosis (be-yvci comments, 2026-06-25) killed the original
+"missing index" and "recursive recompute" hypotheses: indexes exist and are
+used (`IndexedTableAccess index:[is_blocked,status]`), reads already use the
+materialized `is_blocked` column, and ANALYZE/stats is a dead end
+(memory-only, no durable gain). The remaining **beads-core** lever is the
+**wide projection on the high-frequency poll/work-probe path**: the supervisor
+probes every agent's `work_query` (`bd ready --metadata-field
+"gc.routed_to=$target" --json`) every reconcile, and that path projects all 47
+issue columns — including 5 LONGTEXT + 1 JSON + 2 TEXT "body" columns — for the
+72–82 matched rows. Measured cost: **7–12× the narrow projection for the same
+rows**. The probe never displays those bodies; it only needs routing/sort
+columns + `metadata` (which carries `gc.routed_to`).
+
+## Goal
+
+Give the ready/work-probe path a **brief projection** that omits the heavy body
+columns while keeping every column the probe actually consumes — crucially
+`metadata` (routing) and `title`. Ship it as an **opt-in `WorkFilter.BriefBodies`
+capability, default off** (zero behavior change to `bd ready`/`bd list` today,
+so no upstream contract break), wired through to a `--brief` CLI flag. The
+fleet-wide CPU win lands when Slice B (gascity ga-arn) sets that flag on the
+supervisor probe.
+
+## Crux finding that corrects the bead's design-field acceptance
+
+The bead's `design` field says the narrow projection should exclude
+`description, design, acceptance_criteria, notes, close_reason, **metadata**`.
+**Keeping `metadata` out is wrong for the ready/work-probe path.** The gascity
+work_query is `bd ready --metadata-field "gc.routed_to=$target" --json`
+(`gascity internal/config/config.go:3511`) and the consumer jq-filters on
+`.metadata["gc.routed_to"]` / `.metadata["gc.run_target"]`
+(`config.go:3527,3561`). Dropping `metadata` from the projection would silently
+break pool routing. **This plan keeps `metadata` and `title`; it drops only the
+7 free-text body columns** (`description`, `design`, `acceptance_criteria`,
+`notes`, `close_reason`, `payload`, `waiters`) — which are the measured 7–12×
+driver. `metadata` is a small JSON blob, not part of that cost.
+
+## Code map (on `feat/connection-pooling`)
+
+| Symbol | Location | Role |
+| --- | --- | --- |
+| `IssueSelectColumns` (47 cols) | `internal/storage/issueops/scan.go:14-23` | canonical wide projection |
+| `ScanIssueFrom` | `internal/storage/issueops/scan.go:34-62` | order-coupled wide scan |
+| `readyWorkIssueColumns` (`i.`-aliased wide list) | `internal/storage/issueops/ready_work_counts.go:103-111` | **work-probe projection (offender)** |
+| `GetReadyWorkWithCountsInTx` | `internal/storage/issueops/ready_work_counts.go:14-75` | the `bd ready`/work-probe entry |
+| `runSearchQueryInTx` | `internal/storage/issueops/search_counts.go:98` (uses `readyWorkIssueColumns` at `:165`) | builds the SELECT + scans |
+| `scanReadyWorkRowWithCounts` | `internal/storage/issueops/ready_work_counts.go:123` | composite scan (issue cols + dep/label/count extras) |
+| `types.WorkFilter` | `internal/types` | filter struct; add `BriefBodies bool` |
+| existing sqlmock tests | `internal/storage/issueops/search_counts_test.go`, `ready_work_test.go` | house test style (`sqlmock`, `ExpectQuery(regex)`) |
+
+The body columns to drop and the columns to keep:
+
+- **Drop (7):** `description, design, acceptance_criteria, notes, close_reason, payload, waiters`
+- **Keep (40, incl. routing):** everything else in `IssueSelectColumns`, notably
+  `id, title, status, priority, issue_type, assignee, created_at, updated_at,
+  owner, due_at, defer_until, ephemeral, pinned, is_template, **metadata**`.
+
+## Recommended mechanism
+
+`WorkFilter.BriefBodies bool` (default `false`). When `true`,
+`GetReadyWorkWithCountsInTx` → `runSearchQueryInTx` projects a new
+`briefReadyWorkIssueColumns` and scans via a brief scanner that leaves the 7
+body fields zero-valued. Default `false` keeps the existing wide behavior, so
+`bd ready --json` / `bd list --json` output is unchanged for every existing
+caller (no upstream contract break, no `gc hook` body regression). A `--brief`
+flag on `bd ready` sets the field; gascity Slice B passes `--brief` on the
+supervisor probe to realize the CPU win.
+
+`ScanIssueFrom` is strictly order-coupled to `IssueSelectColumns`, so the brief
+path needs its own column list **and** a matching brief scanner — do not try to
+reuse `ScanIssueFrom` with a shorter column list.
+
+## Micro-tasks
+
+| id | description | acceptance (a single failing test) | est_minutes | slings |
+| --- | --- | --- | --- | --- |
+| T-001 | Write the failing projection test: drive `GetReadyWorkWithCountsInTx` (or `runSearchQueryInTx`) via `sqlmock` with `WorkFilter{BriefBodies:true}` and assert the emitted SELECT **excludes** `description\|design\|acceptance_criteria\|notes\|close_reason\|payload\|waiters` and **includes** `metadata` and `title`. | `go test ./internal/storage/issueops -run TestReadyWorkBriefProjection` fails to compile/RED (field + brief columns don't exist yet). | 5 | — |
+| T-002 | Add `BriefBodies bool` to `types.WorkFilter`; add `IssueSelectColumnsBrief` (the 40-col keep-set, metadata+title retained) to `scan.go`; add the `i.`-aliased `briefReadyWorkIssueColumns` var in `ready_work_counts.go` mirroring `readyWorkIssueColumns`. | `go build ./...` passes; a unit assertion that `IssueSelectColumnsBrief` contains `metadata`,`title` and none of the 7 body names passes. | 4 | — |
+| T-003 | Add `ScanIssueBriefFrom(IssueScanner)` in `scan.go` scanning exactly the brief column set in order, leaving `Description/Design/AcceptanceCriteria/Notes/CloseReason/Payload/Waiters` zero-valued; add the brief branch to `scanReadyWorkRowWithCounts`'s composite row. | `go test ./internal/storage/issueops -run TestScanIssueBrief` passes (round-trips id/title/status/metadata; body fields empty). | 5 | — |
+| T-004 | Branch `GetReadyWorkWithCountsInTx`→`runSearchQueryInTx` to use `briefReadyWorkIssueColumns` + the brief scan when `filter.BriefBodies`; leave the default (wide) path byte-for-byte unchanged. | T-001 now GREEN; full `go test ./internal/storage/issueops/...` GREEN. | 5 | — |
+| T-005 | Guard test: with `BriefBodies:true`, returned `IssueWithCounts` still carry populated `Metadata` (routing intact), `ID`, `Status`, `Title`, and counts; with `BriefBodies:false` the bodies are still populated (no regression). | `go test ./internal/storage/issueops -run TestReadyWorkBriefKeepsMetadata` passes. | 4 | — |
+| T-006 | Add `--brief` flag to the `bd ready` command (and `bd list` if trivial) that sets `WorkFilter.BriefBodies`; document it as the seam gascity uses. | `go test ./cmd/... -run TestReadyBriefFlag` (or cmd-layer equiv) asserts `--brief` → `filter.BriefBodies==true`. | 5 | gascity/voxist.executor (ga-arn) sets `--brief` on the work_query probe |
+| T-007 | (Non-gating, best-effort) Add `BenchmarkReadyWorkBriefVsFull` and/or capture EXPLAIN via the recipe below; record the brief-vs-wide delta in the PR body. | Benchmark runs; PR body cites the measured ratio (target: brief materially cheaper, architect measured 7–12× on the wide path). | 5 | — |
+
+Run `go test ./...` (or at least `./internal/storage/...` and `./cmd/...`) green before opening the PR. `gofmt`/`go vet` clean.
+
+## Verification / evidence
+
+- **Primary (deterministic, rig-local):** T-001/T-004 projection test + T-005 metadata-retention guard.
+- **Secondary (best-effort):** EXPLAIN + timing on a populated store. EXPLAIN over the
+  dolt sql-server CLI renders empty in 2.1.8 — use a direct MySQL-protocol client.
+  Read-only recipe (from the bead's architect comment):
+  ```
+  DOLT_CLI_PASSWORD='' dolt --host 127.0.0.1 --port $(cat ~/portharbour/.beads/dolt-server.port) --user root --no-tls sql -q "USE hq; <query>"
+  ```
+  (`--no-tls` must be the last global arg.) The fleet-level `SHOW GLOBAL STATUS`
+  Com_select drop is realized only once Slice B (ga-arn) flips `--brief` on the
+  probe — that is **not** this bead's gate.
+
+## GDPR data-flow impact
+
+No-op (and mildly positive). This change only narrows a `SELECT` column list on
+an internal issue-tracker poll path; it stores nothing new, exposes nothing new,
+and removes no data-subject capability. If anything it advances data
+minimisation: the high-frequency machine probe stops pulling free-text issue
+bodies it never reads. No personal data crosses a new boundary; `bd show` (wide
+path) remains the way detail is fetched. No DSR (Art. 15–20) surface is touched.
+
+## MDR Class I traceability
+
+No-op. This bead is in the beads issue-tracker core, not the
+voxmemo → voxist-api clinical pipeline. No chain-of-evidence metadata, no
+clinical recording/transcript path, no Class I traceability surface is involved.
+Heading retained for auditor visibility per planner discipline.
+
+## Open questions
+
+- (executor/reviewer) Does the `bd list` path want the same `--brief` seam, or
+  is `bd ready` sufficient for Slice B? T-006 scopes `bd ready`; extend to
+  `bd list` only if trivial — otherwise leave to a follow-on.
+- (executor/reviewer) `scanReadyWorkRowWithCounts` builds a composite row with
+  dep/label/count extras appended after the issue columns; confirm the brief
+  scanner appends the same extras in the same order (the coupling is the main
+  implementation risk).
+- (executor/reviewer) Confirm no non-supervisor caller reads `.description` (etc.)
+  off `bd ready --json` today; if one exists it must pass no `--brief` (default
+  keeps bodies, so this is safe, but worth a grep).
+- [architect] FYI — this plan **keeps `metadata` in the brief projection**,
+  diverging from the bead's design-field acceptance which listed `metadata`
+  among the columns to exclude. Reason: the work_query routes on
+  `.metadata["gc.routed_to"]`; dropping it would break pool routing. Flagged in
+  a bead comment too.
+
+## Handoff
+
+One bead, one PR. Executor reuses worktree `worktrees/be-yvci` on `gc/be-yvci`
+(base `feat/connection-pooling`), reads this plan, executes T-001…T-007 red-green,
+opens one PR. Slice B (gascity ga-arn) consumes the `--brief` seam from T-006.
+
+## Execution status (beads/voxist.executor)
+
+All gating micro-tasks green and committed on `gc/be-yvci`.
+
+- [x] T-001 — brief work-probe SELECT omits the 7 body cols, keeps metadata+title   ✅ TestReadyWorkBriefProjection (1f6d46ae2)
+- [x] T-002 — `WorkFilter.BriefBodies` + derived `IssueSelectColumnsBrief` (drift-proof) + `briefReadyWorkIssueColumns`   ✅ TestIssueSelectColumnsBrief (1f6d46ae2/b16814ce3)
+- [x] T-003 — `ScanIssueBriefFrom` + shared composite-extras scanner   ✅ TestScanIssueBrief (1f6d46ae2/b16814ce3)
+- [x] T-004 — `runSearchQueryInTx(brief)` branch; `GetReadyWorkWithCountsInTx` threads `filter.BriefBodies`; wide path unchanged   ✅ full issueops green (1f6d46ae2)
+- [x] T-005 — brief keeps routing metadata + counts, bodies empty   ✅ TestReadyWorkBriefKeepsMetadata (b16814ce3)
+- [x] T-006 — `bd ready --brief` seam → `WorkFilter.BriefBodies` (testable helper)   ✅ TestReadyBriefFlag (6a623b24b)
+- [~] T-007 — best-effort, non-gating: documented below (no synthetic benchmark — the win is server-side projection, unmeasurable without a populated dolt store).
+
+### Implementation notes / refinements
+
+- **Drift-proofing.** `IssueSelectColumnsBrief` is **derived** from `IssueSelectColumns`
+  by removing `bodyColumnsOmittedInBrief` (not a hand-kept parallel constant), so it
+  can never drift; `TestIssueSelectColumnsBrief` locks the drop/keep sets.
+- **Coupling risk (plan-flagged) eliminated structurally.** `scanReadyWorkRowWithCounts`
+  and the new `scanReadyWorkBriefRowWithCounts` both delegate to a shared
+  `scanReadyWorkRowWithScanner(rows, scanFn)` — the 6 composite extras
+  (labels_json, dep/rdep/comment counts, parent_id, deps_json) are appended in one
+  place, so brief and wide are guaranteed identical on the extras.
+- **Scope.** `--brief` is wired on `bd ready` only (the gascity ga-arn work_query
+  command). `bd list --ready` (via `readyWorkFilterFromIssueFilter`) is left wide —
+  per the plan's open question, a trivial follow-on if a second probe needs it.
+- **Column counts.** The canonical list is 46 columns (the plan's "47" was off by
+  one); brief is 39 (drops exactly the 7 named body columns: 5 LONGTEXT
+  description/design/acceptance_criteria/notes/close_reason + 2 TEXT payload/waiters).
+
+### T-007 — measured delta (documented)
+
+The architect measured the wide projection at **7–12× the brief projection for the
+same matched rows** (be-yvci comments). The structural reduction this PR ships: the
+work-probe SELECT now projects 39/46 issue columns, dropping all 5 LONGTEXT + 2 TEXT
+free-text/blob bodies the probe never displays. A local micro-benchmark is **not**
+included: the cost is server-side (Dolt materializing LONGTEXT into the result set),
+not client scan time, so a sqlmock/in-process benchmark would misrepresent it. The
+fleet-level `SHOW GLOBAL STATUS` Com_select / CPU drop is realized when Slice B
+(gascity ga-arn) flips `--brief` on the supervisor probe — explicitly **not** this
+bead's gate.
+
+### Verification
+
+`go build -tags=gms_pure_go ./...` green; `gofmt`/`go vet` clean (issueops, types,
+cmd/bd); `go test ./internal/storage/issueops/... ./internal/types/...` green; the
+new `bd ready` command tests green; the CI pure-Go (`CGO_ENABLED=0`) cmd/bd test
+binary compiles. The Docker-backed dolt store tests and the `BEADS_DOLT_SERVER_PORT`-
+sensitive `TestApplyConfigDefaults_*` tests are unaffected (this change is confined
+to issueops/types/cmd-bd) and run clean in CI.

--- a/internal/doltserver/doltserver.go
+++ b/internal/doltserver/doltserver.go
@@ -237,6 +237,30 @@ func SharedDoltDir() (string, error) {
 	return dir, nil
 }
 
+// SharedProxyRootDir returns the machine-wide rootDir for the shared db-proxy
+// child (its proxy.lock / proxy.pid / proxy.log). Every proxied scope that
+// selects the shared backend points at this one rootDir, so the proxy parent's
+// spawn-or-reuse — keyed by rootDir — collapses their per-scope children into a
+// single shared db-proxy-child. Returns ~/.beads/shared-server/proxy/ (created
+// on first use). Override the location with BEADS_SHARED_PROXY_ROOT_PATH, which
+// mirrors how BEADS_SHARED_SERVER_DIR overrides SharedServerDir.
+func SharedProxyRootDir() (string, error) {
+	var dir string
+	if d := os.Getenv("BEADS_SHARED_PROXY_ROOT_PATH"); d != "" {
+		dir = d
+	} else {
+		serverDir, err := SharedServerDir()
+		if err != nil {
+			return "", err
+		}
+		dir = filepath.Join(serverDir, "proxy")
+	}
+	if err := os.MkdirAll(dir, config.BeadsDirPerm); err != nil {
+		return "", fmt.Errorf("cannot create shared proxy root directory %s: %w", dir, err)
+	}
+	return dir, nil
+}
+
 // resolveServerDir returns the canonical server directory for dolt state files.
 // In shared server mode, returns ~/.beads/shared-server/ instead of the
 // project's .beads/ directory.

--- a/internal/doltserver/shared_proxy_root_test.go
+++ b/internal/doltserver/shared_proxy_root_test.go
@@ -1,0 +1,58 @@
+package doltserver
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestSharedProxyRootDir_StableAcrossScopes proves the shared proxy rootDir is
+// machine-wide: it takes no scope (beadsDir) input, so every proxied scope that
+// opts into the shared backend resolves to the SAME rootDir. That identity is
+// exactly what collapses N+1 per-scope db-proxy-children into one — the proxy
+// parent's spawn-or-reuse keys on rootDir.
+func TestSharedProxyRootDir_StableAcrossScopes(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("BEADS_SHARED_SERVER_DIR", tmp)
+	t.Setenv("BEADS_SHARED_PROXY_ROOT_PATH", "") // no location override for this case
+
+	first, err := SharedProxyRootDir()
+	if err != nil {
+		t.Fatalf("SharedProxyRootDir (scope A): %v", err)
+	}
+	second, err := SharedProxyRootDir()
+	if err != nil {
+		t.Fatalf("SharedProxyRootDir (scope B): %v", err)
+	}
+	if first != second {
+		t.Errorf("shared proxy rootDir not stable across scopes: %q vs %q", first, second)
+	}
+
+	want := filepath.Join(tmp, "proxy")
+	if first != want {
+		t.Errorf("SharedProxyRootDir = %q, want %q (under SharedServerDir)", first, want)
+	}
+	if info, err := os.Stat(first); err != nil || !info.IsDir() {
+		t.Errorf("expected shared proxy rootDir to exist as a directory: %s", first)
+	}
+}
+
+// TestSharedProxyRootDir_EnvOverride proves BEADS_SHARED_PROXY_ROOT_PATH
+// overrides the location, mirroring how BEADS_SHARED_SERVER_DIR overrides
+// SharedServerDir.
+func TestSharedProxyRootDir_EnvOverride(t *testing.T) {
+	tmp := t.TempDir()
+	override := filepath.Join(tmp, "custom-proxy-root")
+	t.Setenv("BEADS_SHARED_PROXY_ROOT_PATH", override)
+
+	dir, err := SharedProxyRootDir()
+	if err != nil {
+		t.Fatalf("SharedProxyRootDir: %v", err)
+	}
+	if dir != override {
+		t.Errorf("SharedProxyRootDir = %q, want %q (from BEADS_SHARED_PROXY_ROOT_PATH)", dir, override)
+	}
+	if info, err := os.Stat(dir); err != nil || !info.IsDir() {
+		t.Errorf("expected override dir to be created: %s", dir)
+	}
+}

--- a/internal/storage/dbproxy/proxy/endpoint.go
+++ b/internal/storage/dbproxy/proxy/endpoint.go
@@ -265,19 +265,20 @@ func spawnAndHandoff(rootDir string, opts OpenOpts, deadline time.Time, lock *ut
 	}
 }
 
-func forkExecChild(rootDir string, opts OpenOpts, port int, lock *util.Lock) (*exec.Cmd, <-chan struct{}, error) {
-	released := false
-	defer func() {
-		if !released {
-			lock.Unlock()
-		}
-	}()
+// backendCarriesExternal reports whether the backend fronts an external dolt
+// target whose --external-* connection args must cross the fork boundary. Both
+// the external backend and the shared backend (which fronts the managed dolt
+// through the same external-server mechanism) carry them; the managed
+// local-server backend does not.
+func backendCarriesExternal(b Backend) bool {
+	return b == BackendExternal || b == BackendLocalSharedServer
+}
 
-	self, err := ResolveExecutable()
-	if err != nil {
-		return nil, nil, fmt.Errorf("locate bd executable: %w", err)
-	}
-
+// childArgs builds the db-proxy-child argv (the tokens after the executable)
+// for the given rootDir, open options, and listener port. It is pure — no I/O,
+// no side effects — so the fork contract can be unit-tested without spawning a
+// process. forkExecChild is the sole production caller.
+func childArgs(rootDir string, opts OpenOpts, port int) []string {
 	idleTimeout := opts.IdleTimeout
 	if idleTimeout < 0 {
 		idleTimeout = 0
@@ -305,7 +306,7 @@ func forkExecChild(rootDir string, opts OpenOpts, port int, lock *util.Lock) (*e
 			args = append(args, "--backend-user", opts.BackendUser)
 		}
 	}
-	if opts.Backend == BackendExternal {
+	if backendCarriesExternal(opts.Backend) {
 		ext := opts.External
 		if ext.Host != "" {
 			args = append(args, "--external-host", ext.Host)
@@ -329,6 +330,23 @@ func forkExecChild(rootDir string, opts OpenOpts, port int, lock *util.Lock) (*e
 			args = append(args, "--external-keep-alive", ext.KeepAlivePeriod.String())
 		}
 	}
+	return args
+}
+
+func forkExecChild(rootDir string, opts OpenOpts, port int, lock *util.Lock) (*exec.Cmd, <-chan struct{}, error) {
+	released := false
+	defer func() {
+		if !released {
+			lock.Unlock()
+		}
+	}()
+
+	self, err := ResolveExecutable()
+	if err != nil {
+		return nil, nil, fmt.Errorf("locate bd executable: %w", err)
+	}
+
+	args := childArgs(rootDir, opts, port)
 
 	logFile, err := os.OpenFile(opts.LogFilePath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600) //nolint:gosec // G304: logFilePath is caller-derived (workspace path), not user-request input
 	if err != nil {

--- a/internal/storage/dbproxy/proxy/endpoint.go
+++ b/internal/storage/dbproxy/proxy/endpoint.go
@@ -93,6 +93,31 @@ func PoolSizeFromEnv() int {
 	return n
 }
 
+// IdleTimeoutEnvVar overrides how long a pooling proxy stays alive with no
+// active client connections before it shuts down. The default (30s) is tuned
+// for a single busy workspace; an orchestrator that touches many scopes
+// sparsely (e.g. gascity probing dozens of rigs once per patrol) starves each
+// proxy below that window, so it spawns, serves one op, idle-dies, and respawns
+// on the next touch — pure churn that never reaches the warm-pool steady state
+// pooling exists to provide. Raising the timeout (e.g. "10m") keeps proxies warm
+// across sparse bursts. Accepts a Go duration string.
+const IdleTimeoutEnvVar = "BEADS_PROXY_IDLE_TIMEOUT"
+
+// IdleTimeoutFromEnv reads IdleTimeoutEnvVar, returning fallback when unset,
+// empty, or unparseable. A parsed non-positive value (e.g. "0") is returned
+// verbatim, which disables the idle timeout (proxy stays up until stopped).
+func IdleTimeoutFromEnv(fallback time.Duration) time.Duration {
+	v := strings.TrimSpace(os.Getenv(IdleTimeoutEnvVar))
+	if v == "" {
+		return fallback
+	}
+	d, err := time.ParseDuration(v)
+	if err != nil {
+		return fallback
+	}
+	return d
+}
+
 func PickFreePort() (int, error) {
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {

--- a/internal/storage/dbproxy/proxy/endpoint.go
+++ b/internal/storage/dbproxy/proxy/endpoint.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/steveyegge/beads/internal/configfile"
@@ -55,6 +56,13 @@ type OpenOpts struct {
 	LogFilePath    string
 	DoltBinPath    string
 	External       configfile.ExternalDoltConfig
+	// PoolSize, when > 0, makes the spawned proxy pool backend connections
+	// (see ProxyOpts.PoolSize). BackendUser is the user the proxy uses to
+	// authenticate those pooled connections; the password, when needed, is
+	// inherited by the child via the environment (it is never passed on the
+	// command line). 0 preserves the transparent, non-pooling proxy.
+	PoolSize    int
+	BackendUser string
 }
 
 const (
@@ -64,6 +72,26 @@ const (
 )
 
 var ResolveExecutable = os.Executable
+
+// PoolSizeEnvVar is the opt-in switch for backend connection pooling. When set
+// to a positive integer, a proxy spawned by this process pools up to that many
+// warm backend connections instead of dialing one per client. Unset or 0
+// disables pooling (transparent forwarding, the historical behavior).
+const PoolSizeEnvVar = "BEADS_PROXY_POOL_SIZE"
+
+// PoolSizeFromEnv reads PoolSizeEnvVar, returning 0 (pooling disabled) when
+// unset, empty, non-numeric, or negative.
+func PoolSizeFromEnv() int {
+	v := strings.TrimSpace(os.Getenv(PoolSizeEnvVar))
+	if v == "" {
+		return 0
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil || n < 0 {
+		return 0
+	}
+	return n
+}
 
 func PickFreePort() (int, error) {
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
@@ -237,6 +265,12 @@ func forkExecChild(rootDir string, opts OpenOpts, port int, lock *util.Lock) (*e
 	}
 	if opts.DoltBinPath != "" {
 		args = append(args, "--dolt-bin", opts.DoltBinPath)
+	}
+	if opts.PoolSize > 0 {
+		args = append(args, "--pool-size", strconv.Itoa(opts.PoolSize))
+		if opts.BackendUser != "" {
+			args = append(args, "--backend-user", opts.BackendUser)
+		}
 	}
 	if opts.Backend == BackendExternal {
 		ext := opts.External

--- a/internal/storage/dbproxy/proxy/endpoint.go
+++ b/internal/storage/dbproxy/proxy/endpoint.go
@@ -34,7 +34,12 @@ func IsUpstreamMismatch(err error) bool {
 }
 
 func intendedUpstreamID(opts OpenOpts) string {
-	if opts.Backend == BackendExternal {
+	// The shared backend fronts the managed dolt through the same external-server
+	// mechanism, so its upstream identity is the same ExternalDoltServerID. A
+	// shared proxy pointed at a different managed dolt must be rejected by the
+	// reuse guard exactly as an external one is (see ErrUpstreamMismatch).
+	switch opts.Backend {
+	case BackendExternal, BackendLocalSharedServer:
 		return server.ExternalDoltServerID(opts.External)
 	}
 	return ""
@@ -143,7 +148,10 @@ func GetCreateDatabaseProxyServerEndpoint(rootDir string, opts OpenOpts) (Endpoi
 		if opts.DoltBinPath == "" {
 			return Endpoint{}, fmt.Errorf("OpenOpts.DoltBinPath is required for backend %q", opts.Backend)
 		}
-	case BackendExternal:
+	case BackendExternal, BackendLocalSharedServer:
+		// The shared backend fronts the managed dolt via the external-server
+		// mechanism, so it carries the same requirements: a log path and a
+		// valid External target (which is also its upstream identity).
 		if opts.LogFilePath == "" {
 			return Endpoint{}, fmt.Errorf("OpenOpts.LogFilePath is required for backend %q", opts.Backend)
 		}

--- a/internal/storage/dbproxy/proxy/endpoint_args_test.go
+++ b/internal/storage/dbproxy/proxy/endpoint_args_test.go
@@ -1,0 +1,108 @@
+package proxy
+
+import (
+	"testing"
+	"time"
+
+	"github.com/steveyegge/beads/internal/configfile"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// argValue returns the value following the first occurrence of flag in args.
+// childArgs always emits flags as separate "--name" "value" tokens, so the
+// value is the next element.
+func argValue(args []string, flag string) (string, bool) {
+	for i, a := range args {
+		if a == flag {
+			if i+1 < len(args) {
+				return args[i+1], true
+			}
+			return "", true
+		}
+	}
+	return "", false
+}
+
+func hasArg(args []string, flag string) bool {
+	for _, a := range args {
+		if a == flag {
+			return true
+		}
+	}
+	return false
+}
+
+// TestForkArgs_SharedCarriesExternal proves the shared backend's child argv
+// carries the --external-* connection flags, exactly as the external backend's
+// does. Without them the spawned child would have no managed-dolt target to
+// front and would fail to dial its upstream.
+func TestForkArgs_SharedCarriesExternal(t *testing.T) {
+	opts := OpenOpts{
+		Backend:     BackendLocalSharedServer,
+		LogFilePath: "/tmp/shared/server.log",
+		External: configfile.ExternalDoltConfig{
+			Host:            "127.0.0.1",
+			Port:            3310,
+			TLSRequired:     true,
+			KeepAlivePeriod: 45 * time.Second,
+		},
+	}
+
+	args := childArgs("/tmp/shared/proxieddb", opts, 7777)
+
+	require.Equal(t, "db-proxy-child", args[0])
+	backend, ok := argValue(args, "--backend")
+	require.True(t, ok)
+	assert.Equal(t, string(BackendLocalSharedServer), backend)
+
+	host, ok := argValue(args, "--external-host")
+	require.True(t, ok, "shared backend must forward --external-host: %v", args)
+	assert.Equal(t, "127.0.0.1", host)
+
+	port, ok := argValue(args, "--external-port")
+	require.True(t, ok, "shared backend must forward --external-port")
+	assert.Equal(t, "3310", port)
+
+	assert.True(t, hasArg(args, "--external-tls"), "shared backend must forward --external-tls")
+
+	keepAlive, ok := argValue(args, "--external-keep-alive")
+	require.True(t, ok)
+	assert.Equal(t, (45 * time.Second).String(), keepAlive)
+}
+
+// TestForkArgs_ExternalUnchanged guards that extracting the childArgs seam did
+// not alter the external backend's argv — the path live portharbour rides today.
+func TestForkArgs_ExternalUnchanged(t *testing.T) {
+	opts := OpenOpts{
+		Backend:     BackendExternal,
+		LogFilePath: "/tmp/ext/server.log",
+		External:    configfile.ExternalDoltConfig{Host: "db.internal", Port: 3306},
+	}
+	args := childArgs("/tmp/ext/proxieddb", opts, 6543)
+
+	host, ok := argValue(args, "--external-host")
+	require.True(t, ok)
+	assert.Equal(t, "db.internal", host)
+	port, ok := argValue(args, "--external-port")
+	require.True(t, ok)
+	assert.Equal(t, "3306", port)
+}
+
+// TestForkArgs_LocalServerOmitsExternal guards that the managed local-server
+// backend carries NO --external-* flags (it has no external target) but does
+// carry its --config.
+func TestForkArgs_LocalServerOmitsExternal(t *testing.T) {
+	opts := OpenOpts{
+		Backend:        BackendLocalServer,
+		ConfigFilePath: "/tmp/ls/server_config.yaml",
+		LogFilePath:    "/tmp/ls/server.log",
+		DoltBinPath:    "/usr/bin/dolt",
+	}
+	args := childArgs("/tmp/ls/proxieddb", opts, 5432)
+
+	assert.False(t, hasArg(args, "--external-host"), "local-server must not forward --external-host: %v", args)
+	cfg, ok := argValue(args, "--config")
+	require.True(t, ok)
+	assert.Equal(t, "/tmp/ls/server_config.yaml", cfg)
+}

--- a/internal/storage/dbproxy/proxy/endpoint_env_test.go
+++ b/internal/storage/dbproxy/proxy/endpoint_env_test.go
@@ -1,0 +1,35 @@
+package proxy
+
+import (
+	"testing"
+	"time"
+)
+
+func TestIdleTimeoutFromEnv(t *testing.T) {
+	const fallback = 30 * time.Second
+	cases := []struct {
+		name string
+		set  bool
+		val  string
+		want time.Duration
+	}{
+		{"unset returns fallback", false, "", fallback},
+		{"blank returns fallback", true, "   ", fallback},
+		{"unparseable returns fallback", true, "soon", fallback},
+		{"valid minutes", true, "10m", 10 * time.Minute},
+		{"valid seconds", true, "90s", 90 * time.Second},
+		{"zero disables (verbatim)", true, "0", 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.set {
+				t.Setenv(IdleTimeoutEnvVar, tc.val)
+			} else {
+				t.Setenv(IdleTimeoutEnvVar, "")
+			}
+			if got := IdleTimeoutFromEnv(fallback); got != tc.want {
+				t.Fatalf("IdleTimeoutFromEnv(%q) = %v, want %v", tc.val, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/storage/dbproxy/proxy/endpoint_shared_test.go
+++ b/internal/storage/dbproxy/proxy/endpoint_shared_test.go
@@ -1,0 +1,97 @@
+package proxy_test
+
+import (
+	"errors"
+	"net"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/configfile"
+	"github.com/steveyegge/beads/internal/storage/dbproxy/pidfile"
+	"github.com/steveyegge/beads/internal/storage/dbproxy/proxy"
+	"github.com/steveyegge/beads/internal/storage/dbproxy/server"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// listenLoopback opens a throwaway loopback listener and returns its port,
+// registering cleanup. A live listener makes readAndDial's port probe succeed,
+// so GetCreateDatabaseProxyServerEndpoint takes the reuse path instead of
+// forking a child — letting these tests exercise the shared-backend reuse and
+// upstream-ID guard without a real dolt server (mirrors endpoint_mismatch_test).
+func listenLoopback(t *testing.T) int {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = ln.Close() })
+	return ln.Addr().(*net.TCPAddr).Port
+}
+
+// TestSharedRootDir_ReusesOneChild proves that a GetCreateDatabaseProxyServerEndpoint
+// call for the BackendLocalSharedServer backend at a rootDir already served by a
+// live proxy (simulated via a pidfile + listener) reuses that one child instead
+// of forking another — the process-collapse half of be-pen9. Two scopes pointed
+// at one shared rootDir therefore resolve to a single db-proxy-child.
+func TestSharedRootDir_ReusesOneChild(t *testing.T) {
+	root := t.TempDir()
+	port := listenLoopback(t)
+
+	cfg := configfile.ExternalDoltConfig{Host: "10.0.0.1", Port: 3306}
+	require.NoError(t, pidfile.Write(root, proxy.PIDFileName, pidfile.PidFile{
+		Pid:        4321,
+		Port:       port,
+		UpstreamID: server.ExternalDoltServerID(cfg),
+	}))
+
+	ep, err := proxy.GetCreateDatabaseProxyServerEndpoint(root, proxy.OpenOpts{
+		Backend:     proxy.BackendLocalSharedServer,
+		External:    cfg,
+		LogFilePath: root + "/server.log",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "127.0.0.1", ep.Host)
+	assert.Equal(t, port, ep.Port, "shared backend must reuse the already-running proxy, not fork a new one")
+}
+
+// TestSharedBackend_RejectsUpstreamMismatch proves the shared backend honors the
+// upstream-ID guard: a proxy already fronting a *different* managed dolt must be
+// rejected, never silently reused. A shared proxy pointed at the wrong upstream
+// would otherwise serve every collapsed scope the wrong store.
+func TestSharedBackend_RejectsUpstreamMismatch(t *testing.T) {
+	root := t.TempDir()
+	port := listenLoopback(t)
+
+	existing := configfile.ExternalDoltConfig{Host: "10.0.0.1", Port: 3306}
+	require.NoError(t, pidfile.Write(root, proxy.PIDFileName, pidfile.PidFile{
+		Pid:        4321,
+		Port:       port,
+		UpstreamID: server.ExternalDoltServerID(existing),
+	}))
+
+	want := configfile.ExternalDoltConfig{Host: "10.0.0.2", Port: 3306}
+	_, err := proxy.GetCreateDatabaseProxyServerEndpoint(root, proxy.OpenOpts{
+		Backend:     proxy.BackendLocalSharedServer,
+		External:    want,
+		LogFilePath: root + "/server.log",
+	})
+	require.Error(t, err)
+
+	var mismatch *proxy.ErrUpstreamMismatch
+	require.True(t, errors.As(err, &mismatch), "expected ErrUpstreamMismatch, got %T: %v", err, err)
+	assert.Equal(t, server.ExternalDoltServerID(want), mismatch.Want)
+	assert.Equal(t, server.ExternalDoltServerID(existing), mismatch.Have)
+}
+
+// TestSharedBackend_RequiresExternal proves the shared backend validates its
+// upstream config up front: without an External target there is no managed dolt
+// to front and no upstream ID to match, so the call must fail validation rather
+// than spawn a proxy pointed at nothing.
+func TestSharedBackend_RequiresExternal(t *testing.T) {
+	root := t.TempDir()
+	_, err := proxy.GetCreateDatabaseProxyServerEndpoint(root, proxy.OpenOpts{
+		Backend:     proxy.BackendLocalSharedServer,
+		LogFilePath: root + "/server.log",
+		// External omitted on purpose.
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "External")
+}

--- a/internal/storage/dbproxy/proxy/multidb_isolation_test.go
+++ b/internal/storage/dbproxy/proxy/multidb_isolation_test.go
@@ -1,0 +1,112 @@
+//go:build cgo
+
+package proxy
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+
+	_ "github.com/go-sql-driver/mysql"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSpike_MultiDatabaseIsolation is the decisive check for multi-database
+// topologies (e.g. one dolt sql-server hosting one database per rig: hq, vw,
+// va, ...). The pool is keyed by (capabilities, database); a backend
+// authenticated to database A must NEVER be lent to a client that asked for
+// database B, because COM_RESET_CONNECTION restores the session to the
+// backend's *handshake* database — silent cross-store reads otherwise.
+//
+// This only holds if go-sql-driver carries the database in the MySQL handshake
+// (CONNECT_WITH_DB), so the proxy can read it from the client's handshake
+// response and key the pool by it. If the driver instead connected with an
+// empty schema and issued COM_INIT_DB afterwards, every client would key to
+// db="" and share one pool — the corruption this test is designed to catch.
+//
+// The test forces maximal reuse pressure (pool size effectively 1 per key) and
+// interleaves clients for two databases, asserting each reads only its own.
+func TestSpike_MultiDatabaseIsolation(t *testing.T) {
+	srv, _ := spikeDolt(t)
+	pool, stats := newSpikePool(t, srv, 1) // 1 idle per key
+	addr := servePooled(t, pool, stats)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	// Provision two databases, each with a sentinel row identifying itself.
+	admin := openThroughProxy(t, addr, "")
+	for _, db := range []string{"rig_a", "rig_b"} {
+		_, err := admin.ExecContext(ctx, "CREATE DATABASE IF NOT EXISTS "+db)
+		require.NoError(t, err)
+	}
+	require.NoError(t, admin.Close())
+	for _, tc := range []struct{ db, who string }{{"rig_a", "A"}, {"rig_b", "B"}} {
+		c := openThroughProxy(t, addr, tc.db)
+		_, err := c.ExecContext(ctx, "CREATE TABLE marker (who VARCHAR(8))")
+		require.NoError(t, err)
+		_, err = c.ExecContext(ctx, "INSERT INTO marker VALUES (?)", tc.who)
+		require.NoError(t, err)
+		require.NoError(t, c.Close())
+	}
+
+	readWho := func(db string) string {
+		c := openThroughProxy(t, addr, db)
+		defer func() { _ = c.Close() }()
+		var who string
+		// Unqualified table name → resolves against the session's current
+		// database, i.e. exactly what a leaked backend would get wrong.
+		require.NoError(t, c.QueryRowContext(ctx, "SELECT who FROM marker").Scan(&who))
+		return who
+	}
+
+	// Interleave many times with single-connection clients so each open must
+	// reuse a pooled backend. A keying bug (shared db="") would surface as a
+	// client reading the other rig's marker.
+	for i := 0; i < 20; i++ {
+		require.Equal(t, "A", readWho("rig_a"), "rig_a read the wrong store on iter %d", i)
+		require.Equal(t, "B", readWho("rig_b"), "rig_b read the wrong store on iter %d", i)
+	}
+
+	// Also assert the two databases keep distinct backends (no accidental
+	// collapse): with reuse, hits should dominate and both keys stay warm.
+	snap := stats.Snapshot()
+	t.Logf("multi-db stats: %+v", snap)
+	require.GreaterOrEqual(t, snap.PoolHits, int64(30), "expected heavy reuse across both db keys")
+}
+
+// TestSpike_HandshakeCarriesDatabase nails the underlying assumption directly:
+// a client opened with a database in its DSN must surface that database to the
+// proxy via the handshake (so the pool key's db is non-empty). We observe it
+// indirectly: after a rig_a client runs, the pool holds an idle backend that,
+// when reused by another rig_a client, already resolves unqualified names to
+// rig_a without any explicit USE.
+func TestSpike_HandshakeCarriesDatabase(t *testing.T) {
+	srv, _ := spikeDolt(t)
+	pool, stats := newSpikePool(t, srv, 2)
+	addr := servePooled(t, pool, stats)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	admin := openThroughProxy(t, addr, "")
+	_, err := admin.ExecContext(ctx, "CREATE DATABASE IF NOT EXISTS rig_h")
+	require.NoError(t, err)
+	require.NoError(t, admin.Close())
+
+	c1 := openThroughProxy(t, addr, "rig_h")
+	var cur sql.NullString
+	require.NoError(t, c1.QueryRowContext(ctx, "SELECT DATABASE()").Scan(&cur))
+	require.True(t, cur.Valid && cur.String == "rig_h",
+		"session current database must be the handshake db, got %v", cur)
+	require.NoError(t, c1.Close())
+
+	require.Eventually(t, func() bool { return pool.idleCount() >= 1 }, 5*time.Second, 20*time.Millisecond)
+
+	// Reused backend must still report rig_h (reset restores the handshake db).
+	c2 := openThroughProxy(t, addr, "rig_h")
+	defer func() { _ = c2.Close() }()
+	require.NoError(t, c2.QueryRowContext(ctx, "SELECT DATABASE()").Scan(&cur))
+	require.True(t, cur.Valid && cur.String == "rig_h", "reused backend lost its db, got %v", cur)
+	require.GreaterOrEqual(t, stats.Snapshot().PoolHits, int64(1))
+}

--- a/internal/storage/dbproxy/proxy/mysqlwire.go
+++ b/internal/storage/dbproxy/proxy/mysqlwire.go
@@ -183,10 +183,10 @@ func serverGreeting(connID uint32, salt []byte) []byte {
 	p = append(p, serverCharsetUTF8MB4)
 	p = append(p, byte(statusAutocommit), byte(statusAutocommit>>8))
 	p = append(p, byte(caps>>16), byte(caps>>24))
-	p = append(p, 21)             // auth-plugin-data len (20 salt + NUL)
+	p = append(p, 21)                  // auth-plugin-data len (20 salt + NUL)
 	p = append(p, make([]byte, 10)...) // reserved
-	p = append(p, salt[8:20]...)  // auth-plugin-data-part-2 (12 bytes)
-	p = append(p, 0)              // NUL terminator for part-2
+	p = append(p, salt[8:20]...)       // auth-plugin-data-part-2 (12 bytes)
+	p = append(p, 0)                   // NUL terminator for part-2
 	p = append(p, mysqlNativePassword...)
 	p = append(p, 0)
 	return p
@@ -257,9 +257,9 @@ func indexByte(p []byte, from int, b byte) int {
 // okPacket builds a minimal OK packet for the negotiated capabilities.
 func okPacket(caps uint32) []byte {
 	p := make([]byte, 0, 16)
-	p = append(p, 0x00)             // OK header
-	p = appendLenencInt(p, 0)       // affected rows
-	p = appendLenencInt(p, 0)       // last insert id
+	p = append(p, 0x00)       // OK header
+	p = appendLenencInt(p, 0) // affected rows
+	p = appendLenencInt(p, 0) // last insert id
 	if caps&capProtocol41 != 0 {
 		p = append(p, byte(statusAutocommit), byte(statusAutocommit>>8))
 		p = append(p, 0, 0) // warnings
@@ -371,7 +371,7 @@ func parseServerGreeting(p []byte) (salt []byte, plugin string, err error) {
 		// Pre-4.1 server: only lower caps present. Not expected from dolt.
 		return salt, mysqlNativePassword, nil
 	}
-	off++ // charset
+	off++    // charset
 	off += 2 // status flags
 	capHigh := uint32(p[off]) | uint32(p[off+1])<<8
 	off += 2

--- a/internal/storage/dbproxy/proxy/mysqlwire.go
+++ b/internal/storage/dbproxy/proxy/mysqlwire.go
@@ -1,0 +1,616 @@
+package proxy
+
+// MySQL wire-protocol helpers for the session-pooling proxy.
+//
+// The proxy terminates the client handshake itself (skip-auth: clients are
+// loopback-only and already trusted by today's design), then borrows a
+// pre-authenticated backend connection from a pool. After the handshake phase
+// completes on both sides the data path is byte-transparent (io.Copy), exactly
+// as the non-pooling proxy does today — command-phase packets do not depend on
+// connection id or salt, only on the negotiated capability flags, which the
+// proxy keeps in parity between the two sides (see pool keying).
+//
+// Byte layouts are hand-rolled rather than borrowed from dolthub/vitess because
+// vitess's handshake builders are unexported and its *mysql.Conn buffers
+// internally, which is incompatible with handing the raw net.Conn to io.Copy.
+// References: MySQL Client/Server Protocol; go-sql-driver/mysql packets.go;
+// dolthub/vitess go/mysql/{server,client,conn}.go.
+
+import (
+	"context"
+	"crypto/sha1"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"time"
+)
+
+// MySQL capability flags (subset we care about). Values match the protocol
+// constants used by every MySQL-compatible client/server.
+const (
+	capLongPassword     uint32 = 1 << 0
+	capFoundRows        uint32 = 1 << 1
+	capLongFlag         uint32 = 1 << 2
+	capConnectWithDB    uint32 = 1 << 3
+	capProtocol41       uint32 = 1 << 9
+	capSSL              uint32 = 1 << 11
+	capTransactions     uint32 = 1 << 13
+	capSecureConnection uint32 = 1 << 15
+	capMultiStatements  uint32 = 1 << 16
+	capMultiResults     uint32 = 1 << 17
+	capPluginAuth       uint32 = 1 << 19
+	capConnectAttrs     uint32 = 1 << 20
+	capPluginAuthLenenc uint32 = 1 << 21
+	capDeprecateEOF     uint32 = 1 << 24
+)
+
+// MySQL command bytes (command-phase first byte).
+const (
+	comQuery           byte = 0x03
+	comInitDB          byte = 0x02
+	comPing            byte = 0x0e
+	comResetConnection byte = 0x1f
+)
+
+const (
+	mysqlNativePassword = "mysql_native_password"
+	// serverCapabilities is what the proxy advertises to clients. It is a
+	// superset; the client narrows it in its response and the proxy mirrors
+	// the client's effective set onto the backend, keeping wire parity.
+	serverCapabilities = capLongPassword | capFoundRows | capLongFlag |
+		capConnectWithDB | capProtocol41 | capTransactions |
+		capSecureConnection | capMultiStatements | capMultiResults |
+		capPluginAuth | capPluginAuthLenenc | capDeprecateEOF
+	serverCharsetUTF8MB4 = 0x2d // utf8mb4_general_ci
+	statusAutocommit     = 0x0002
+)
+
+var errProtocol = errors.New("mysqlwire: protocol error")
+
+// ---- packet framing -------------------------------------------------------
+
+// readPacket reads one MySQL packet payload from r, returning the payload and
+// the sequence id of the (last) frame. It transparently reassembles packets
+// split across 16MiB frames.
+func readPacket(r io.Reader) (payload []byte, seq byte, err error) {
+	var hdr [4]byte
+	for {
+		if _, err = io.ReadFull(r, hdr[:]); err != nil {
+			return nil, 0, err
+		}
+		n := int(hdr[0]) | int(hdr[1])<<8 | int(hdr[2])<<16
+		seq = hdr[3]
+		if n > 0 {
+			buf := make([]byte, n)
+			if _, err = io.ReadFull(r, buf); err != nil {
+				return nil, 0, err
+			}
+			payload = append(payload, buf...)
+		}
+		if n < 0xffffff { // last frame of this packet
+			return payload, seq, nil
+		}
+	}
+}
+
+// writePacket frames payload as a single MySQL packet with the given sequence
+// id and writes it. Payloads larger than 16MiB are not expected during the
+// handshake/control exchanges this helper is used for.
+func writePacket(w io.Writer, seq byte, payload []byte) error {
+	n := len(payload)
+	if n >= 0xffffff {
+		return fmt.Errorf("mysqlwire: control packet too large (%d bytes)", n)
+	}
+	hdr := []byte{byte(n), byte(n >> 8), byte(n >> 16), seq}
+	if _, err := w.Write(append(hdr, payload...)); err != nil {
+		return err
+	}
+	return nil
+}
+
+// ---- length-encoded integers ---------------------------------------------
+
+func appendLenencInt(b []byte, v uint64) []byte {
+	switch {
+	case v < 251:
+		return append(b, byte(v))
+	case v < 1<<16:
+		return append(b, 0xfc, byte(v), byte(v>>8))
+	case v < 1<<24:
+		return append(b, 0xfd, byte(v), byte(v>>8), byte(v>>16))
+	default:
+		var tmp [8]byte
+		binary.LittleEndian.PutUint64(tmp[:], v)
+		return append(append(b, 0xfe), tmp[:]...)
+	}
+}
+
+// readLenencInt reads a length-encoded integer from p starting at off,
+// returning the value and the new offset.
+func readLenencInt(p []byte, off int) (val uint64, next int, err error) {
+	if off >= len(p) {
+		return 0, off, errProtocol
+	}
+	switch first := p[off]; {
+	case first < 251:
+		return uint64(first), off + 1, nil
+	case first == 0xfc:
+		if off+3 > len(p) {
+			return 0, off, errProtocol
+		}
+		return uint64(p[off+1]) | uint64(p[off+2])<<8, off + 3, nil
+	case first == 0xfd:
+		if off+4 > len(p) {
+			return 0, off, errProtocol
+		}
+		return uint64(p[off+1]) | uint64(p[off+2])<<8 | uint64(p[off+3])<<16, off + 4, nil
+	case first == 0xfe:
+		if off+9 > len(p) {
+			return 0, off, errProtocol
+		}
+		return binary.LittleEndian.Uint64(p[off+1 : off+9]), off + 9, nil
+	default:
+		return 0, off, errProtocol
+	}
+}
+
+// ---- server-side handshake (proxy → client) ------------------------------
+
+// clientHandshake holds the parts of a client's HandshakeResponse41 the proxy
+// needs to mirror onto a backend connection.
+type clientHandshake struct {
+	capabilities uint32 // effective caps (intersection with what we advertised)
+	database     string
+	username     string
+}
+
+// serverGreeting builds a HandshakeV10 packet advertising mysql_native_password
+// with the given 20-byte salt.
+func serverGreeting(connID uint32, salt []byte) []byte {
+	caps := serverCapabilities
+	p := make([]byte, 0, 128)
+	p = append(p, 10) // protocol version
+	p = append(p, "beads-proxy"...)
+	p = append(p, 0) // server version NUL
+	var idb [4]byte
+	binary.LittleEndian.PutUint32(idb[:], connID)
+	p = append(p, idb[:]...)
+	p = append(p, salt[:8]...) // auth-plugin-data-part-1
+	p = append(p, 0)           // filler
+	p = append(p, byte(caps), byte(caps>>8))
+	p = append(p, serverCharsetUTF8MB4)
+	p = append(p, byte(statusAutocommit), byte(statusAutocommit>>8))
+	p = append(p, byte(caps>>16), byte(caps>>24))
+	p = append(p, 21)             // auth-plugin-data len (20 salt + NUL)
+	p = append(p, make([]byte, 10)...) // reserved
+	p = append(p, salt[8:20]...)  // auth-plugin-data-part-2 (12 bytes)
+	p = append(p, 0)              // NUL terminator for part-2
+	p = append(p, mysqlNativePassword...)
+	p = append(p, 0)
+	return p
+}
+
+// parseClientHandshakeResponse extracts capabilities, username and database
+// from a HandshakeResponse41 payload.
+func parseClientHandshakeResponse(p []byte) (clientHandshake, error) {
+	var h clientHandshake
+	if len(p) < 32 {
+		return h, errProtocol
+	}
+	h.capabilities = binary.LittleEndian.Uint32(p[0:4])
+	if h.capabilities&capProtocol41 == 0 {
+		return h, fmt.Errorf("%w: client did not request PROTOCOL_41", errProtocol)
+	}
+	off := 32 // 4 caps + 4 maxpkt + 1 charset + 23 reserved
+	// username (NUL-terminated)
+	end := indexByte(p, off, 0)
+	if end < 0 {
+		return h, errProtocol
+	}
+	h.username = string(p[off:end])
+	off = end + 1
+	// auth-response
+	if h.capabilities&capPluginAuthLenenc != 0 {
+		alen, next, err := readLenencInt(p, off)
+		if err != nil {
+			return h, err
+		}
+		off = next + int(alen)
+	} else if h.capabilities&capSecureConnection != 0 {
+		if off >= len(p) {
+			return h, errProtocol
+		}
+		alen := int(p[off])
+		off += 1 + alen
+	} else {
+		end = indexByte(p, off, 0)
+		if end < 0 {
+			return h, errProtocol
+		}
+		off = end + 1
+	}
+	if off > len(p) {
+		return h, errProtocol
+	}
+	// database
+	if h.capabilities&capConnectWithDB != 0 {
+		end = indexByte(p, off, 0)
+		if end < 0 {
+			return h, errProtocol
+		}
+		h.database = string(p[off:end])
+	}
+	return h, nil
+}
+
+func indexByte(p []byte, from int, b byte) int {
+	for i := from; i < len(p); i++ {
+		if p[i] == b {
+			return i
+		}
+	}
+	return -1
+}
+
+// okPacket builds a minimal OK packet for the negotiated capabilities.
+func okPacket(caps uint32) []byte {
+	p := make([]byte, 0, 16)
+	p = append(p, 0x00)             // OK header
+	p = appendLenencInt(p, 0)       // affected rows
+	p = appendLenencInt(p, 0)       // last insert id
+	if caps&capProtocol41 != 0 {
+		p = append(p, byte(statusAutocommit), byte(statusAutocommit>>8))
+		p = append(p, 0, 0) // warnings
+	} else if caps&capTransactions != 0 {
+		p = append(p, byte(statusAutocommit), byte(statusAutocommit>>8))
+	}
+	return p
+}
+
+// acceptClient performs the server side of the handshake against an incoming
+// client connection, accepting any credentials (skip-auth). It returns the
+// negotiated client parameters needed to drive a matching backend.
+func acceptClient(conn net.Conn, connID uint32, deadline time.Time) (clientHandshake, error) {
+	if !deadline.IsZero() {
+		_ = conn.SetDeadline(deadline)
+		defer func() { _ = conn.SetDeadline(time.Time{}) }()
+	}
+	salt := makeSalt(connID)
+	if err := writePacket(conn, 0, serverGreeting(connID, salt)); err != nil {
+		return clientHandshake{}, fmt.Errorf("mysqlwire: write greeting: %w", err)
+	}
+	resp, seq, err := readPacket(conn)
+	if err != nil {
+		return clientHandshake{}, fmt.Errorf("mysqlwire: read handshake response: %w", err)
+	}
+	// Reject TLS upgrade requests: the proxy is loopback-only and does not
+	// terminate TLS. A client that set CLIENT_SSL would send a short SSL
+	// request packet and expect a TLS handshake next; fail clearly instead.
+	h, err := parseClientHandshakeResponse(resp)
+	if err != nil {
+		return clientHandshake{}, err
+	}
+	if h.capabilities&capSSL != 0 {
+		return clientHandshake{}, fmt.Errorf("%w: client requested TLS, unsupported by pooling proxy", errProtocol)
+	}
+	// Mirror only the capabilities we also advertised.
+	h.capabilities &= serverCapabilities
+	if err := writePacket(conn, seq+1, okPacket(h.capabilities)); err != nil {
+		return clientHandshake{}, fmt.Errorf("mysqlwire: write auth OK: %w", err)
+	}
+	return h, nil
+}
+
+func makeSalt(connID uint32) []byte {
+	// Deterministic, non-secret salt: auth is skipped, the salt only needs to
+	// be 20 well-formed non-NUL bytes. Math/rand is intentionally avoided
+	// (unavailable / nondeterministic); the value is irrelevant to security
+	// here because the proxy accepts any auth response.
+	salt := make([]byte, 20)
+	for i := range salt {
+		salt[i] = byte(1 + (int(connID)+i*7)%250) // 1..250, never NUL
+	}
+	return salt
+}
+
+// ---- client-side handshake (proxy → dolt backend) ------------------------
+
+// backendHandshake performs the client side of the MySQL handshake against a
+// freshly dialed backend connection, negotiating exactly caps so the resulting
+// session is wire-compatible with the client the proxy will forward. user is
+// typically "root" with an empty password (loopback dolt).
+func backendHandshake(conn net.Conn, caps uint32, database, user, password string, deadline time.Time) error {
+	if !deadline.IsZero() {
+		_ = conn.SetDeadline(deadline)
+		defer func() { _ = conn.SetDeadline(time.Time{}) }()
+	}
+	greeting, _, err := readPacket(conn)
+	if err != nil {
+		return fmt.Errorf("mysqlwire: read backend greeting: %w", err)
+	}
+	salt, plugin, err := parseServerGreeting(greeting)
+	if err != nil {
+		return err
+	}
+
+	authResp := scramble(plugin, password, salt)
+	resp := buildHandshakeResponse41(caps, database, user, authResp, plugin)
+	if err := writePacket(conn, 1, resp); err != nil {
+		return fmt.Errorf("mysqlwire: write backend handshake response: %w", err)
+	}
+	return readBackendAuthResult(conn, password, salt)
+}
+
+// parseServerGreeting extracts the 20-byte salt and auth plugin name from a
+// backend HandshakeV10 packet.
+func parseServerGreeting(p []byte) (salt []byte, plugin string, err error) {
+	if len(p) < 1 || p[0] != 10 {
+		return nil, "", fmt.Errorf("%w: unexpected protocol version", errProtocol)
+	}
+	off := 1
+	end := indexByte(p, off, 0) // server version NUL
+	if end < 0 {
+		return nil, "", errProtocol
+	}
+	off = end + 1
+	off += 4 // connection id
+	if off+8 > len(p) {
+		return nil, "", errProtocol
+	}
+	salt = append(salt, p[off:off+8]...)
+	off += 8
+	off++ // filler
+	if off+2 > len(p) {
+		return nil, "", errProtocol
+	}
+	capLow := uint32(p[off]) | uint32(p[off+1])<<8
+	off += 2
+	if off >= len(p) {
+		// Pre-4.1 server: only lower caps present. Not expected from dolt.
+		return salt, mysqlNativePassword, nil
+	}
+	off++ // charset
+	off += 2 // status flags
+	capHigh := uint32(p[off]) | uint32(p[off+1])<<8
+	off += 2
+	caps := capLow | capHigh<<16
+	authDataLen := int(p[off])
+	off++
+	off += 10 // reserved
+	if caps&capSecureConnection != 0 {
+		part2 := authDataLen - 8
+		if part2 < 13 {
+			part2 = 13
+		}
+		// part2 includes a NUL terminator; copy len-1 meaningful bytes but be
+		// defensive about bounds.
+		take := part2
+		if off+take > len(p) {
+			take = len(p) - off
+		}
+		seg := p[off : off+take]
+		// strip trailing NUL
+		for len(seg) > 0 && seg[len(seg)-1] == 0 {
+			seg = seg[:len(seg)-1]
+		}
+		salt = append(salt, seg...)
+		off += take
+	}
+	plugin = mysqlNativePassword
+	if caps&capPluginAuth != 0 && off < len(p) {
+		end = indexByte(p, off, 0)
+		if end < 0 {
+			end = len(p)
+		}
+		plugin = string(p[off:end])
+	}
+	return salt, plugin, nil
+}
+
+// buildHandshakeResponse41 builds the client HandshakeResponse41 packet.
+func buildHandshakeResponse41(caps uint32, database, user string, authResp []byte, plugin string) []byte {
+	// Always set the auth-related caps we rely on; never request TLS.
+	caps |= capProtocol41 | capSecureConnection | capPluginAuth
+	caps &^= capSSL
+	if database != "" {
+		caps |= capConnectWithDB
+	} else {
+		caps &^= capConnectWithDB
+	}
+	caps &^= capConnectAttrs // we send no connection attributes
+
+	p := make([]byte, 0, 64)
+	var capb [4]byte
+	binary.LittleEndian.PutUint32(capb[:], caps)
+	p = append(p, capb[:]...)
+	var maxpkt [4]byte
+	binary.LittleEndian.PutUint32(maxpkt[:], 1<<24-1)
+	p = append(p, maxpkt[:]...)
+	p = append(p, serverCharsetUTF8MB4)
+	p = append(p, make([]byte, 23)...) // reserved
+	p = append(p, user...)
+	p = append(p, 0)
+	if caps&capPluginAuthLenenc != 0 {
+		p = appendLenencInt(p, uint64(len(authResp)))
+		p = append(p, authResp...)
+	} else {
+		p = append(p, byte(len(authResp)))
+		p = append(p, authResp...)
+	}
+	if caps&capConnectWithDB != 0 {
+		p = append(p, database...)
+		p = append(p, 0)
+	}
+	if caps&capPluginAuth != 0 {
+		p = append(p, plugin...)
+		p = append(p, 0)
+	}
+	return p
+}
+
+// readBackendAuthResult reads the backend's reply to our handshake response,
+// handling OK, ERR, AuthSwitchRequest and caching_sha2 fast-auth flows for the
+// empty-password case.
+func readBackendAuthResult(conn net.Conn, password string, salt []byte) error {
+	for {
+		pkt, seq, err := readPacket(conn)
+		if err != nil {
+			return fmt.Errorf("mysqlwire: read backend auth result: %w", err)
+		}
+		if len(pkt) == 0 {
+			return fmt.Errorf("%w: empty backend auth packet", errProtocol)
+		}
+		switch pkt[0] {
+		case 0x00: // OK
+			return nil
+		case 0xff: // ERR
+			return backendErr(pkt)
+		case 0xfe: // AuthSwitchRequest
+			plugin, switchSalt := parseAuthSwitch(pkt)
+			authResp := scramble(plugin, password, switchSalt)
+			if err := writePacket(conn, seq+1, authResp); err != nil {
+				return fmt.Errorf("mysqlwire: write auth switch response: %w", err)
+			}
+		case 0x01: // AuthMoreData (caching_sha2_password)
+			// Empty password fast path: server sends 0x01 0x03 (fast auth
+			// success) then OK, or 0x01 0x04 (full auth) which over a plaintext
+			// loopback channel expects the cleartext password + NUL. We only
+			// support empty passwords for the managed loopback dolt.
+			if len(pkt) >= 2 && pkt[1] == 0x04 {
+				if password != "" {
+					return fmt.Errorf("%w: caching_sha2 full auth with password unsupported", errProtocol)
+				}
+				if err := writePacket(conn, seq+1, []byte{0x00}); err != nil {
+					return fmt.Errorf("mysqlwire: write cleartext auth: %w", err)
+				}
+			}
+			// otherwise (0x03 fast success) loop to read the following OK.
+		default:
+			return fmt.Errorf("%w: unexpected backend auth packet 0x%02x", errProtocol, pkt[0])
+		}
+	}
+}
+
+func parseAuthSwitch(pkt []byte) (plugin string, salt []byte) {
+	off := 1
+	end := indexByte(pkt, off, 0)
+	if end < 0 {
+		return mysqlNativePassword, nil
+	}
+	plugin = string(pkt[off:end])
+	off = end + 1
+	seg := pkt[off:]
+	for len(seg) > 0 && seg[len(seg)-1] == 0 {
+		seg = seg[:len(seg)-1]
+	}
+	return plugin, seg
+}
+
+func backendErr(pkt []byte) error {
+	if len(pkt) < 3 {
+		return fmt.Errorf("%w: malformed backend error", errProtocol)
+	}
+	code := uint16(pkt[1]) | uint16(pkt[2])<<8
+	msg := pkt[3:]
+	if len(msg) > 6 && msg[0] == '#' {
+		msg = msg[6:] // skip '#' + 5-byte sqlstate
+	}
+	return fmt.Errorf("mysqlwire: backend rejected handshake (%d): %s", code, string(msg))
+}
+
+// scramble computes the auth response for the given plugin and salt. For
+// mysql_native_password with an empty password the result is empty.
+func scramble(plugin, password string, salt []byte) []byte {
+	if password == "" {
+		return nil
+	}
+	switch plugin {
+	case mysqlNativePassword, "":
+		return nativeScramble(password, salt)
+	default:
+		// caching_sha2_password and others with a real password are not used
+		// by the managed loopback dolt; empty-password path above covers it.
+		return nativeScramble(password, salt)
+	}
+}
+
+// nativeScramble implements mysql_native_password:
+// SHA1(password) XOR SHA1(salt + SHA1(SHA1(password))).
+func nativeScramble(password string, salt []byte) []byte {
+	h1 := sha1.Sum([]byte(password))
+	h2 := sha1.Sum(h1[:])
+	h := sha1.New()
+	_, _ = h.Write(salt)
+	_, _ = h.Write(h2[:])
+	mixed := h.Sum(nil)
+	out := make([]byte, len(h1))
+	for i := range h1 {
+		out[i] = h1[i] ^ mixed[i]
+	}
+	return out
+}
+
+// ---- control commands on a pooled backend --------------------------------
+
+// resetBackend sends COM_RESET_CONNECTION and waits for the OK reply. This is
+// the isolation primitive: it discards session variables, open transactions,
+// temp tables and prepared statements before the connection is reused by the
+// next client. (database/sql's ResetSession does NOT send this — it only does
+// a liveness check — which is why the proxy must send it explicitly.)
+func resetBackend(ctx context.Context, conn net.Conn) error {
+	if dl, ok := ctx.Deadline(); ok {
+		_ = conn.SetDeadline(dl)
+		defer func() { _ = conn.SetDeadline(time.Time{}) }()
+	}
+	if err := writePacket(conn, 0, []byte{comResetConnection}); err != nil {
+		return fmt.Errorf("mysqlwire: write COM_RESET_CONNECTION: %w", err)
+	}
+	pkt, seq, err := readPacket(conn)
+	if err != nil {
+		return fmt.Errorf("mysqlwire: read reset reply: %w", err)
+	}
+	// The reply to a fresh command (seq 0) is always seq 1. If we instead read
+	// a packet at some other sequence, the connection was misaligned — e.g. a
+	// client was killed mid-result and unread result packets are still in the
+	// stream. Treat that as a hard failure so the pool destroys the connection
+	// rather than lending a corrupted one to the next borrower.
+	if seq != 1 {
+		return fmt.Errorf("%w: reset reply out of sequence (seq=%d) — connection misaligned", errProtocol, seq)
+	}
+	if len(pkt) > 0 && pkt[0] == 0xff {
+		return backendErr(pkt)
+	}
+	if len(pkt) == 0 || pkt[0] != 0x00 {
+		return fmt.Errorf("%w: unexpected reset reply (first byte 0x%02x)", errProtocol, firstByte(pkt))
+	}
+	return nil
+}
+
+func firstByte(p []byte) byte {
+	if len(p) == 0 {
+		return 0
+	}
+	return p[0]
+}
+
+// pingBackend sends COM_PING and waits for OK; used as a cheap liveness check
+// before lending a pooled connection.
+func pingBackend(ctx context.Context, conn net.Conn) error {
+	if dl, ok := ctx.Deadline(); ok {
+		_ = conn.SetDeadline(dl)
+		defer func() { _ = conn.SetDeadline(time.Time{}) }()
+	}
+	if err := writePacket(conn, 0, []byte{comPing}); err != nil {
+		return err
+	}
+	pkt, _, err := readPacket(conn)
+	if err != nil {
+		return err
+	}
+	if len(pkt) > 0 && pkt[0] == 0xff {
+		return backendErr(pkt)
+	}
+	return nil
+}

--- a/internal/storage/dbproxy/proxy/mysqlwire_spike_test.go
+++ b/internal/storage/dbproxy/proxy/mysqlwire_spike_test.go
@@ -1,0 +1,283 @@
+//go:build cgo
+
+package proxy
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	_ "github.com/go-sql-driver/mysql"
+	"github.com/stretchr/testify/require"
+
+	"github.com/steveyegge/beads/internal/storage/dbproxy/server"
+)
+
+// These spike tests validate the core hypothesis of the pooling proxy against a
+// real dolt sql-server: (1) a go-sql-driver client can run queries and
+// transactions through a handshake-terminating, connection-pooling proxy;
+// (2) COM_RESET_CONNECTION isolates session state between successive borrowers;
+// (3) the dolt-side Connections counter stays flat across many sequential
+// client sessions instead of growing 1:1.
+//
+// They are gated on dolt being installed (skip otherwise) and require cgo
+// (servercfg). Run: go test ./internal/storage/dbproxy/proxy -run Spike.
+
+func freeTCPPort(t *testing.T) int {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	port := ln.Addr().(*net.TCPAddr).Port
+	require.NoError(t, ln.Close())
+	return port
+}
+
+func spikeDolt(t *testing.T) (srv *server.DoltServer, port int) {
+	t.Helper()
+	bin, err := exec.LookPath("dolt")
+	if err != nil {
+		t.Skipf("dolt not on PATH: %v", err)
+	}
+	t.Setenv("HOME", t.TempDir())
+	rootDir := t.TempDir()
+	port = freeTCPPort(t)
+	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
+	body := fmt.Sprintf("log_level: warning\nlistener:\n  host: 127.0.0.1\n  port: %d\n", port)
+	require.NoError(t, os.WriteFile(cfgPath, []byte(body), 0o600))
+	logPath := filepath.Join(t.TempDir(), "server.log")
+	srv, err = server.NewDoltServer(bin, rootDir, cfgPath, logPath, 0)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	require.NoError(t, srv.Start(ctx))
+	t.Cleanup(func() {
+		sctx, scancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer scancel()
+		_ = srv.Stop(sctx)
+	})
+	return srv, port
+}
+
+// servePooled runs a minimal pooling accept loop in the background and returns
+// the address clients should dial. It mirrors what proxyServer.handleConn will
+// do in pooling mode.
+func servePooled(t *testing.T, pool *backendPool, stats *Stats) string {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = ln.Close() })
+
+	var connID atomic.Uint32
+	go func() {
+		for {
+			c, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go func(client net.Conn) {
+				defer func() { _ = client.Close() }()
+				id := connID.Add(1)
+				res, err := runPooledSession(context.Background(), stats, pool, client, id)
+				if err != nil {
+					return
+				}
+				if res.backend == nil {
+					return
+				}
+				if res.reusable {
+					pool.put(res.backend)
+				} else {
+					_ = res.backend.conn.Close()
+				}
+			}(c)
+		}
+	}()
+	return ln.Addr().String()
+}
+
+func newSpikePool(t *testing.T, srv *server.DoltServer, maxIdle int) (*backendPool, *Stats) {
+	t.Helper()
+	stats := &Stats{}
+	pool := newBackendPool(
+		func(ctx context.Context) (net.Conn, error) { return srv.Dial(ctx) },
+		"root", "", maxIdle, 0, stats,
+	)
+	t.Cleanup(pool.drain)
+	return pool, stats
+}
+
+func openThroughProxy(t *testing.T, addr, db string) *sql.DB {
+	t.Helper()
+	dsn := fmt.Sprintf("root@tcp(%s)/%s?parseTime=true&timeout=10s&readTimeout=10s&writeTimeout=10s", addr, db)
+	dbConn, err := sql.Open("mysql", dsn)
+	require.NoError(t, err)
+	dbConn.SetMaxOpenConns(1) // one client TCP conn at a time for deterministic pooling
+	return dbConn
+}
+
+func TestSpike_PooledQueryRoundTrip(t *testing.T) {
+	srv, _ := spikeDolt(t)
+	pool, stats := newSpikePool(t, srv, 4)
+	addr := servePooled(t, pool, stats)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// Create the database via the proxy (no DB selected yet).
+	admin := openThroughProxy(t, addr, "")
+	defer func() { _ = admin.Close() }()
+	_, err := admin.ExecContext(ctx, "CREATE DATABASE IF NOT EXISTS spikedb")
+	require.NoError(t, err)
+	_ = admin.Close()
+
+	// Now connect WITH the database (exercises CONNECT_WITH_DB handshake path).
+	conn := openThroughProxy(t, addr, "spikedb")
+	defer func() { _ = conn.Close() }()
+
+	var one int
+	require.NoError(t, conn.QueryRowContext(ctx, "SELECT 1").Scan(&one))
+	require.Equal(t, 1, one)
+
+	_, err = conn.ExecContext(ctx, "CREATE TABLE t (id INT PRIMARY KEY, v VARCHAR(32))")
+	require.NoError(t, err)
+	_, err = conn.ExecContext(ctx, "INSERT INTO t VALUES (1, 'hello'), (2, 'world')")
+	require.NoError(t, err)
+
+	var v string
+	require.NoError(t, conn.QueryRowContext(ctx, "SELECT v FROM t WHERE id=2").Scan(&v))
+	require.Equal(t, "world", v)
+
+	// Transaction + DOLT_COMMIT round-trip (bd's write pattern).
+	_, err = conn.ExecContext(ctx, "INSERT INTO t VALUES (3, 'tx')")
+	require.NoError(t, err)
+	_, err = conn.ExecContext(ctx, "CALL DOLT_COMMIT('-Am', 'spike commit')")
+	require.NoError(t, err)
+
+	var cnt int
+	require.NoError(t, conn.QueryRowContext(ctx, "SELECT COUNT(*) FROM t").Scan(&cnt))
+	require.Equal(t, 3, cnt)
+
+	t.Logf("stats: %+v", stats.Snapshot())
+}
+
+func TestSpike_SessionIsolation(t *testing.T) {
+	srv, _ := spikeDolt(t)
+	pool, stats := newSpikePool(t, srv, 1) // force a single shared backend
+	addr := servePooled(t, pool, stats)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// Create a database so temp tables have somewhere to live, then drain the
+	// admin backend so the isolation check below runs against a single shared
+	// pooled connection keyed by db="isodb".
+	admin := openThroughProxy(t, addr, "")
+	_, err := admin.ExecContext(ctx, "CREATE DATABASE IF NOT EXISTS isodb")
+	require.NoError(t, err)
+	require.NoError(t, admin.Close())
+
+	// Borrower #1: set a session var and an autocommit override, then a temp
+	// table — all session-scoped state that must NOT survive to borrower #2.
+	c1 := openThroughProxy(t, addr, "isodb")
+	conn1, err := c1.Conn(ctx)
+	require.NoError(t, err)
+	_, err = conn1.ExecContext(ctx, "SET @leak = 42")
+	require.NoError(t, err)
+	_, err = conn1.ExecContext(ctx, "SET autocommit = 0")
+	require.NoError(t, err)
+	_, err = conn1.ExecContext(ctx, "CREATE TEMPORARY TABLE leaks (x INT)")
+	require.NoError(t, err)
+	var leak sql.NullInt64
+	require.NoError(t, conn1.QueryRowContext(ctx, "SELECT @leak").Scan(&leak))
+	require.True(t, leak.Valid && leak.Int64 == 42, "borrower #1 should see its own var")
+	require.NoError(t, conn1.Close())
+	require.NoError(t, c1.Close()) // returns backend to pool (reset)
+
+	// Give the pool a moment to reset+return the single backend.
+	require.Eventually(t, func() bool { return pool.idleCount() == 1 }, 5*time.Second, 20*time.Millisecond)
+
+	// Borrower #2: must reuse the SAME backend and see a clean session.
+	c2 := openThroughProxy(t, addr, "isodb")
+	defer func() { _ = c2.Close() }()
+	conn2, err := c2.Conn(ctx)
+	require.NoError(t, err)
+	defer func() { _ = conn2.Close() }()
+
+	var leak2 sql.NullInt64
+	require.NoError(t, conn2.QueryRowContext(ctx, "SELECT @leak").Scan(&leak2))
+	require.False(t, leak2.Valid, "session var @leak leaked across borrowers: %v", leak2)
+
+	var autocommit int
+	require.NoError(t, conn2.QueryRowContext(ctx, "SELECT @@autocommit").Scan(&autocommit))
+	require.Equal(t, 1, autocommit, "autocommit override leaked across borrowers")
+
+	// The temp table must be gone: querying it should error (unknown table).
+	var n int
+	err = conn2.QueryRowContext(ctx, "SELECT COUNT(*) FROM leaks").Scan(&n)
+	require.Error(t, err, "temp table 'leaks' leaked across borrowers")
+
+	snap := stats.Snapshot()
+	t.Logf("stats: %+v", snap)
+	require.GreaterOrEqual(t, snap.PoolResets, int64(1), "expected at least one COM_RESET_CONNECTION")
+	require.GreaterOrEqual(t, snap.PoolHits, int64(1), "borrower #2 should have reused the pooled backend")
+}
+
+func TestSpike_ConnectionCounterFlat(t *testing.T) {
+	srv, port := spikeDolt(t)
+	pool, stats := newSpikePool(t, srv, 2)
+	addr := servePooled(t, pool, stats)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	// A persistent direct (non-proxied) connection to read the global counter
+	// with constant overhead.
+	directDSN := fmt.Sprintf("root@tcp(127.0.0.1:%d)/?timeout=10s", port)
+	direct, err := sql.Open("mysql", directDSN)
+	require.NoError(t, err)
+	direct.SetMaxOpenConns(1)
+	defer func() { _ = direct.Close() }()
+
+	readConnections := func() int64 {
+		var name string
+		var val int64
+		require.NoError(t, direct.QueryRowContext(ctx, "SHOW STATUS LIKE 'Connections'").Scan(&name, &val))
+		return val
+	}
+
+	// Warm the pool once.
+	warm := openThroughProxy(t, addr, "")
+	require.NoError(t, warm.PingContext(ctx))
+	_, _ = warm.ExecContext(ctx, "SELECT 1")
+	_ = warm.Close()
+	require.Eventually(t, func() bool { return pool.idleCount() >= 1 }, 5*time.Second, 20*time.Millisecond)
+
+	before := readConnections()
+
+	const N = 40
+	for i := 0; i < N; i++ {
+		c := openThroughProxy(t, addr, "")
+		var one int
+		require.NoError(t, c.QueryRowContext(ctx, "SELECT 1").Scan(&one))
+		require.NoError(t, c.Close())
+		require.Eventually(t, func() bool { return pool.idleCount() >= 1 }, 5*time.Second, 10*time.Millisecond)
+	}
+
+	after := readConnections()
+	delta := after - before
+	snap := stats.Snapshot()
+	t.Logf("Connections delta over %d sequential pooled sessions: %d (pool stats: %+v)", N, delta, snap)
+
+	// With pooling, the dolt-side Connections counter must stay essentially
+	// flat (well under N). Allow a small slack for incidental reconnects.
+	require.Less(t, delta, int64(N/2), "Connections grew ~1:1 with sessions — pooling not effective")
+	require.GreaterOrEqual(t, snap.PoolHits, int64(N-2), "most sessions should be pool hits")
+}

--- a/internal/storage/dbproxy/proxy/mysqlwire_test.go
+++ b/internal/storage/dbproxy/proxy/mysqlwire_test.go
@@ -1,0 +1,86 @@
+package proxy
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLenencIntRoundTrip(t *testing.T) {
+	for _, v := range []uint64{0, 1, 250, 251, 0xfb, 0xfc, 0xffff, 0x10000, 0xffffff, 0x1000000, 1 << 40} {
+		b := appendLenencInt(nil, v)
+		got, next, err := readLenencInt(b, 0)
+		require.NoError(t, err, "v=%d", v)
+		require.Equal(t, v, got, "v=%d", v)
+		require.Equal(t, len(b), next, "v=%d consumed all bytes", v)
+	}
+}
+
+func TestPacketFramingRoundTrip(t *testing.T) {
+	var buf bytes.Buffer
+	payload := bytes.Repeat([]byte{0xab}, 100)
+	require.NoError(t, writePacket(&buf, 7, payload))
+	got, seq, err := readPacket(&buf)
+	require.NoError(t, err)
+	require.Equal(t, byte(7), seq)
+	require.Equal(t, payload, got)
+}
+
+func TestServerGreetingParsesBack(t *testing.T) {
+	// A greeting the proxy emits to clients must be parseable by our own
+	// backend-side parser (the two are symmetric on salt + plugin).
+	salt := makeSalt(42)
+	g := serverGreeting(42, salt)
+	parsedSalt, plugin, err := parseServerGreeting(g)
+	require.NoError(t, err)
+	require.Equal(t, mysqlNativePassword, plugin)
+	require.Equal(t, salt, parsedSalt, "round-tripped salt must match")
+}
+
+func TestParseClientHandshakeResponse(t *testing.T) {
+	// Build a HandshakeResponse41 the way a backend handshake would and parse
+	// it as the server side would.
+	caps := capProtocol41 | capSecureConnection | capPluginAuth | capConnectWithDB
+	resp := buildHandshakeResponse41(caps, "mydb", "root", nil, mysqlNativePassword)
+	h, err := parseClientHandshakeResponse(resp)
+	require.NoError(t, err)
+	require.Equal(t, "root", h.username)
+	require.Equal(t, "mydb", h.database)
+	require.NotZero(t, h.capabilities&capProtocol41)
+	require.NotZero(t, h.capabilities&capConnectWithDB)
+}
+
+func TestParseClientHandshakeResponse_NoDB(t *testing.T) {
+	caps := capProtocol41 | capSecureConnection | capPluginAuth
+	resp := buildHandshakeResponse41(caps, "", "someuser", []byte{1, 2, 3, 4}, mysqlNativePassword)
+	h, err := parseClientHandshakeResponse(resp)
+	require.NoError(t, err)
+	require.Equal(t, "someuser", h.username)
+	require.Equal(t, "", h.database)
+	require.Zero(t, h.capabilities&capConnectWithDB)
+}
+
+func TestNativeScrambleEmptyPassword(t *testing.T) {
+	require.Nil(t, scramble(mysqlNativePassword, "", makeSalt(1)))
+}
+
+func TestNativeScrambleDeterministic(t *testing.T) {
+	salt := makeSalt(99)
+	a := nativeScramble("hunter2", salt)
+	b := nativeScramble("hunter2", salt)
+	require.Equal(t, a, b)
+	require.Len(t, a, 20) // SHA1 digest length
+	require.NotEqual(t, nativeScramble("other", salt), a)
+}
+
+func TestOKPacketShapes(t *testing.T) {
+	// PROTOCOL_41 OK has status(2)+warnings(2) after the two lenenc ints.
+	ok41 := okPacket(capProtocol41)
+	require.Equal(t, byte(0x00), ok41[0])
+	require.Len(t, ok41, 1+1+1+2+2)
+
+	// No PROTOCOL_41, no TRANSACTIONS: just header + two lenenc ints.
+	okPlain := okPacket(0)
+	require.Len(t, okPlain, 1+1+1)
+}

--- a/internal/storage/dbproxy/proxy/pool.go
+++ b/internal/storage/dbproxy/proxy/pool.go
@@ -1,0 +1,201 @@
+package proxy
+
+// backendPool keeps a set of already-authenticated, live MySQL connections to
+// the dolt backend and lends them to clients at session granularity (one
+// backend per client TCP connection). This is the core of the connection-churn
+// fix: without it, every bd CLI invocation forks a process that opens a fresh
+// connection (TCP + auth handshake + session setup) and tears it down at exit,
+// which the dolt sql-server pays for as raw connection-setup CPU. Reusing warm
+// backends collapses that to ~zero new connections per second in steady state.
+//
+// Connections are keyed by (capabilities, database): byte-transparent
+// command-phase forwarding requires the client↔proxy and proxy↔backend
+// capability sets to match, and the initial database must be correct since the
+// proxy does not parse the command stream. All bd clients share one driver and
+// DSN, so they collapse onto a single key and reuse the same warm connections.
+
+import (
+	"context"
+	"errors"
+	"net"
+	"sync"
+	"time"
+)
+
+// backendKey identifies an interchangeable class of pooled connections. Two
+// borrowers may share a connection only if their keys are equal.
+type backendKey struct {
+	caps uint32
+	db   string
+}
+
+// pooledConn is a live, authenticated backend connection plus the metadata the
+// pool needs to decide reuse.
+type pooledConn struct {
+	conn      net.Conn
+	key       backendKey
+	createdAt time.Time
+	transient bool // dialed past the idle cap; closed (not returned) on put
+}
+
+// poolDialer establishes a raw TCP connection to the backend. It is satisfied
+// by server.DatabaseServer.Dial.
+type poolDialer func(ctx context.Context) (net.Conn, error)
+
+type backendPool struct {
+	dial     poolDialer
+	user     string
+	password string
+	maxIdle  int           // max idle connections retained per key
+	lifetime time.Duration // 0 = unlimited; retire+reopen on exceed
+	stats    *Stats
+
+	mu     sync.Mutex
+	idle   map[backendKey][]*pooledConn
+	closed bool
+}
+
+func newBackendPool(dial poolDialer, user, password string, maxIdle int, lifetime time.Duration, stats *Stats) *backendPool {
+	if maxIdle < 1 {
+		maxIdle = 1
+	}
+	return &backendPool{
+		dial:     dial,
+		user:     user,
+		password: password,
+		maxIdle:  maxIdle,
+		lifetime: lifetime,
+		stats:    stats,
+		idle:     make(map[backendKey][]*pooledConn),
+	}
+}
+
+var errPoolClosed = errors.New("proxy: backend pool closed")
+
+// get returns a connection for key, reusing a live idle one when available or
+// dialing+authenticating a fresh one otherwise. The handshake against the
+// backend is performed with exactly key.caps so the session is wire-compatible
+// with the client the caller will forward.
+func (p *backendPool) get(ctx context.Context, key backendKey) (*pooledConn, error) {
+	for {
+		p.mu.Lock()
+		if p.closed {
+			p.mu.Unlock()
+			return nil, errPoolClosed
+		}
+		stack := p.idle[key]
+		if n := len(stack); n > 0 {
+			pc := stack[n-1]
+			p.idle[key] = stack[:n-1]
+			p.mu.Unlock()
+			if p.expired(pc) {
+				_ = pc.conn.Close()
+				p.stats.IncPoolRetire()
+				continue
+			}
+			// Liveness check: a backend may have dropped the conn while idle.
+			pingCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+			err := pingBackend(pingCtx, pc.conn)
+			cancel()
+			if err != nil {
+				_ = pc.conn.Close()
+				p.stats.IncPoolDead()
+				continue
+			}
+			p.stats.IncPoolHit()
+			return pc, nil
+		}
+		p.mu.Unlock()
+		return p.dialNew(ctx, key, false)
+	}
+}
+
+// dialNew opens and authenticates a fresh backend connection for key.
+func (p *backendPool) dialNew(ctx context.Context, key backendKey, transient bool) (*pooledConn, error) {
+	conn, err := p.dial(ctx)
+	if err != nil {
+		p.stats.IncPoolDialError()
+		return nil, err
+	}
+	deadline, _ := ctx.Deadline()
+	if err := backendHandshake(conn, key.caps, key.db, p.user, p.password, deadline); err != nil {
+		_ = conn.Close()
+		p.stats.IncPoolDialError()
+		return nil, err
+	}
+	p.stats.IncPoolMiss()
+	return &pooledConn{
+		conn:      conn,
+		key:       key,
+		createdAt: time.Now(),
+		transient: transient,
+	}, nil
+}
+
+// put returns pc to the pool after resetting its session state. If the reset
+// fails, the connection is destroyed rather than risk leaking state to the
+// next borrower. Transient connections and connections returned after the pool
+// is closed are always destroyed.
+func (p *backendPool) put(pc *pooledConn) {
+	if pc == nil {
+		return
+	}
+	resetCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	err := resetBackend(resetCtx, pc.conn)
+	cancel()
+	if err != nil {
+		p.stats.IncPoolResetError()
+		_ = pc.conn.Close()
+		return
+	}
+	p.stats.IncPoolReset()
+
+	if pc.transient || p.expired(pc) {
+		_ = pc.conn.Close()
+		p.stats.IncPoolRetire()
+		return
+	}
+
+	p.mu.Lock()
+	if p.closed || len(p.idle[pc.key]) >= p.maxIdle {
+		p.mu.Unlock()
+		_ = pc.conn.Close()
+		return
+	}
+	p.idle[pc.key] = append(p.idle[pc.key], pc)
+	p.mu.Unlock()
+}
+
+func (p *backendPool) expired(pc *pooledConn) bool {
+	if p.lifetime <= 0 || pc.createdAt.IsZero() {
+		return false
+	}
+	return time.Since(pc.createdAt) >= p.lifetime
+}
+
+// drain closes every idle connection and marks the pool closed. In-flight
+// borrowed connections are closed by their handlers on put (which sees closed
+// and destroys them).
+func (p *backendPool) drain() {
+	p.mu.Lock()
+	idle := p.idle
+	p.idle = make(map[backendKey][]*pooledConn)
+	p.closed = true
+	p.mu.Unlock()
+	for _, stack := range idle {
+		for _, pc := range stack {
+			_ = pc.conn.Close()
+		}
+	}
+}
+
+// idleCount reports the total number of idle connections held (test helper).
+func (p *backendPool) idleCount() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	n := 0
+	for _, stack := range p.idle {
+		n += len(stack)
+	}
+	return n
+}

--- a/internal/storage/dbproxy/proxy/pool.go
+++ b/internal/storage/dbproxy/proxy/pool.go
@@ -22,6 +22,12 @@ import (
 	"time"
 )
 
+// poolDialTimeout bounds a backend TCP dial. It is deliberately tight and
+// distinct from handshakeTimeout (10s, see pooledconn.go): a saturated Dolt
+// should fail the dial fast, free the pool/errgroup slot, and let the caller
+// back off on "i/o timeout" rather than pinning the slot for the whole request.
+const poolDialTimeout = 2 * time.Second
+
 // backendKey identifies an interchangeable class of pooled connections. Two
 // borrowers may share a connection only if their keys are equal.
 type backendKey struct {
@@ -112,12 +118,23 @@ func (p *backendPool) get(ctx context.Context, key backendKey) (*pooledConn, err
 
 // dialNew opens and authenticates a fresh backend connection for key.
 func (p *backendPool) dialNew(ctx context.Context, key backendKey, transient bool) (*pooledConn, error) {
-	conn, err := p.dial(ctx)
+	// S3f: track concurrent dials for the peak gauge.
+	dialDone := p.stats.DialBegin()
+	// S3c: dial under a tight, dedicated deadline (or the caller's, if sooner).
+	dialCtx, cancel := context.WithTimeout(ctx, poolDialTimeout)
+	conn, err := p.dial(dialCtx)
+	cancel()
+	dialDone()
 	if err != nil {
 		p.stats.IncPoolDialError()
 		return nil, err
 	}
-	deadline, _ := ctx.Deadline()
+	// Handshake gets its own, more generous absolute deadline so a slow auth
+	// exchange is not bounded by the short dial timeout.
+	deadline := time.Now().Add(handshakeTimeout)
+	if d, ok := ctx.Deadline(); ok && d.Before(deadline) {
+		deadline = d
+	}
 	if err := backendHandshake(conn, key.caps, key.db, p.user, p.password, deadline); err != nil {
 		_ = conn.Close()
 		p.stats.IncPoolDialError()

--- a/internal/storage/dbproxy/proxy/pool_test.go
+++ b/internal/storage/dbproxy/proxy/pool_test.go
@@ -1,0 +1,202 @@
+package proxy
+
+import (
+	"context"
+	"net"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// fakeBackend is an in-memory MySQL-speaking stub: it completes the server side
+// of the handshake and answers COM_PING / COM_RESET_CONNECTION with OK. It lets
+// the pool be exercised without a real dolt sql-server. Counters are shared
+// across all connections a dialer produces.
+type fakeBackend struct {
+	dials  atomic.Int64
+	resets atomic.Int64
+	pings  atomic.Int64
+}
+
+// dialer returns a poolDialer that spins up a fresh stub connection per dial.
+func (f *fakeBackend) dialer() poolDialer {
+	return func(ctx context.Context) (net.Conn, error) {
+		f.dials.Add(1)
+		proxySide, backendSide := net.Pipe()
+		go f.serve(backendSide)
+		return proxySide, nil
+	}
+}
+
+func (f *fakeBackend) serve(c net.Conn) {
+	defer func() { _ = c.Close() }()
+	// Server greeting (seq 0).
+	if err := writePacket(c, 0, serverGreeting(1, makeSalt(1))); err != nil {
+		return
+	}
+	// Read client handshake response (seq 1); accept anything.
+	resp, _, err := readPacket(c)
+	if err != nil {
+		return
+	}
+	if _, perr := parseClientHandshakeResponse(resp); perr != nil {
+		_ = writePacket(c, 2, []byte{0xff, 0x15, 0x04}) // ERR
+		return
+	}
+	if err := writePacket(c, 2, okPacket(capProtocol41)); err != nil { // auth OK (seq 2)
+		return
+	}
+	// Command loop.
+	for {
+		pkt, seq, err := readPacket(c)
+		if err != nil {
+			return
+		}
+		if len(pkt) == 0 {
+			return
+		}
+		switch pkt[0] {
+		case comResetConnection:
+			f.resets.Add(1)
+			if err := writePacket(c, seq+1, okPacket(capProtocol41)); err != nil {
+				return
+			}
+		case comPing:
+			f.pings.Add(1)
+			if err := writePacket(c, seq+1, okPacket(capProtocol41)); err != nil {
+				return
+			}
+		case 0x01: // COM_QUIT
+			return
+		default:
+			_ = writePacket(c, seq+1, okPacket(capProtocol41))
+		}
+	}
+}
+
+func testKey() backendKey {
+	return backendKey{caps: capProtocol41 | capSecureConnection | capPluginAuth, db: "beads"}
+}
+
+func TestPool_GetDialsAndPutReturns(t *testing.T) {
+	fb := &fakeBackend{}
+	stats := &Stats{}
+	p := newBackendPool(fb.dialer(), "root", "", 4, 0, stats)
+	defer p.drain()
+
+	ctx := context.Background()
+	pc, err := p.get(ctx, testKey())
+	require.NoError(t, err)
+	require.Equal(t, int64(1), fb.dials.Load(), "first get must dial")
+	require.Equal(t, 0, p.idleCount())
+
+	p.put(pc)
+	require.Equal(t, int64(1), fb.resets.Load(), "put must COM_RESET_CONNECTION")
+	require.Equal(t, 1, p.idleCount(), "reset conn returns to pool")
+
+	// Second get reuses the idle connection (no new dial).
+	pc2, err := p.get(ctx, testKey())
+	require.NoError(t, err)
+	require.Equal(t, int64(1), fb.dials.Load(), "reuse must not dial")
+	require.GreaterOrEqual(t, fb.pings.Load(), int64(1), "reuse pings for liveness")
+	p.put(pc2)
+
+	snap := stats.Snapshot()
+	require.GreaterOrEqual(t, snap.PoolHits, int64(1))
+	require.GreaterOrEqual(t, snap.PoolMisses, int64(1))
+	require.GreaterOrEqual(t, snap.PoolResets, int64(2))
+}
+
+func TestPool_MaxIdleCap(t *testing.T) {
+	fb := &fakeBackend{}
+	p := newBackendPool(fb.dialer(), "root", "", 2, 0, &Stats{})
+	defer p.drain()
+	ctx := context.Background()
+
+	// Borrow three concurrently, then return all three. Only maxIdle=2 are kept.
+	a, err := p.get(ctx, testKey())
+	require.NoError(t, err)
+	b, err := p.get(ctx, testKey())
+	require.NoError(t, err)
+	c, err := p.get(ctx, testKey())
+	require.NoError(t, err)
+	require.Equal(t, int64(3), fb.dials.Load())
+
+	p.put(a)
+	p.put(b)
+	p.put(c)
+	require.Equal(t, 2, p.idleCount(), "idle retention capped at maxIdle")
+}
+
+func TestPool_KeyIsolation(t *testing.T) {
+	fb := &fakeBackend{}
+	p := newBackendPool(fb.dialer(), "root", "", 4, 0, &Stats{})
+	defer p.drain()
+	ctx := context.Background()
+
+	k1 := backendKey{caps: capProtocol41, db: "alpha"}
+	k2 := backendKey{caps: capProtocol41, db: "beta"}
+
+	pc1, err := p.get(ctx, k1)
+	require.NoError(t, err)
+	p.put(pc1)
+
+	// A get for a different key must NOT reuse k1's idle connection.
+	pc2, err := p.get(ctx, k2)
+	require.NoError(t, err)
+	require.Equal(t, int64(2), fb.dials.Load(), "different key dials a fresh backend")
+	p.put(pc2)
+}
+
+func TestPool_DrainClosesIdle(t *testing.T) {
+	fb := &fakeBackend{}
+	p := newBackendPool(fb.dialer(), "root", "", 4, 0, &Stats{})
+	ctx := context.Background()
+	pc, err := p.get(ctx, testKey())
+	require.NoError(t, err)
+	p.put(pc)
+	require.Equal(t, 1, p.idleCount())
+
+	p.drain()
+	require.Equal(t, 0, p.idleCount())
+
+	// get after drain fails.
+	_, err = p.get(ctx, testKey())
+	require.ErrorIs(t, err, errPoolClosed)
+}
+
+func TestPool_DeadIdleConnDiscarded(t *testing.T) {
+	fb := &fakeBackend{}
+	p := newBackendPool(fb.dialer(), "root", "", 4, 0, &Stats{})
+	defer p.drain()
+	ctx := context.Background()
+
+	pc, err := p.get(ctx, testKey())
+	require.NoError(t, err)
+	p.put(pc)
+	require.Equal(t, 1, p.idleCount())
+
+	// Kill the idle connection out from under the pool.
+	pc.conn.Close()
+
+	// Next get must detect the dead conn (ping fails) and dial a fresh one.
+	pc2, err := p.get(ctx, testKey())
+	require.NoError(t, err)
+	require.Equal(t, int64(2), fb.dials.Load(), "dead idle conn replaced by a fresh dial")
+	p.put(pc2)
+}
+
+func TestPool_LifetimeRetire(t *testing.T) {
+	fb := &fakeBackend{}
+	p := newBackendPool(fb.dialer(), "root", "", 4, 10*time.Millisecond, &Stats{})
+	defer p.drain()
+	ctx := context.Background()
+
+	pc, err := p.get(ctx, testKey())
+	require.NoError(t, err)
+	time.Sleep(20 * time.Millisecond)
+	p.put(pc) // expired → destroyed, not returned
+	require.Equal(t, 0, p.idleCount(), "expired conn not retained")
+}

--- a/internal/storage/dbproxy/proxy/pooledconn.go
+++ b/internal/storage/dbproxy/proxy/pooledconn.go
@@ -22,7 +22,7 @@ const handshakeTimeout = 10 * time.Second
 
 // sessionResult reports what the pool should do with the backend afterward.
 type sessionResult struct {
-	backend *pooledConn
+	backend  *pooledConn
 	reusable bool // false → caller must destroy (don't return to pool)
 }
 

--- a/internal/storage/dbproxy/proxy/pooledconn.go
+++ b/internal/storage/dbproxy/proxy/pooledconn.go
@@ -1,0 +1,169 @@
+package proxy
+
+// handlePooledSession drives one client connection against a pooled backend:
+// it terminates the client handshake (skip-auth), borrows a wire-compatible
+// backend connection, forwards the command phase byte-transparently in both
+// directions, and returns the backend to the pool (reset) when the client
+// disconnects. This is the pooling counterpart to the transparent
+// dial+io.Copy+Close path in proxyServer.handleConn.
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	"sync"
+	"time"
+)
+
+// handshakeTimeout bounds the client+backend handshake phase. The command
+// phase that follows is unbounded (long-lived bd sessions are normal).
+const handshakeTimeout = 10 * time.Second
+
+// sessionResult reports what the pool should do with the backend afterward.
+type sessionResult struct {
+	backend *pooledConn
+	reusable bool // false → caller must destroy (don't return to pool)
+}
+
+// runPooledSession performs the handshake handoff and bidirectional copy. It
+// returns the borrowed backend and whether it is safe to return to the pool.
+// The caller owns closing the client connection.
+func runPooledSession(ctx context.Context, stats *Stats, pool *backendPool, client net.Conn, connID uint32) (sessionResult, error) {
+	hsDeadline := time.Now().Add(handshakeTimeout)
+	ch, err := acceptClient(client, connID, hsDeadline)
+	if err != nil {
+		return sessionResult{}, err
+	}
+
+	key := backendKey{caps: ch.capabilities, db: ch.database}
+	getCtx, cancel := context.WithDeadline(ctx, hsDeadline)
+	pc, err := pool.get(getCtx, key)
+	cancel()
+	if err != nil {
+		return sessionResult{}, err
+	}
+
+	// Command phase. The backend→client direction is byte-transparent
+	// (io.Copy), exactly like handleConn. The client→backend direction is
+	// frame-aware so it can intercept COM_QUIT: go-sql-driver sends COM_QUIT
+	// when it closes a connection, and forwarding that to a pooled backend
+	// would terminate it — defeating pooling. We swallow COM_QUIT, end the
+	// session, reset the backend, and return it to the pool instead.
+	done := make(chan struct{})
+	var once sync.Once
+	finish := func() { once.Do(func() { close(done) }) }
+
+	var g sync.WaitGroup
+	var c2bErr error
+	var sawQuit bool
+
+	g.Add(1)
+	go func() {
+		defer g.Done()
+		defer finish()
+		var n int64
+		n, sawQuit, c2bErr = copyClientCommands(pc.conn, client)
+		stats.AddBytesClientToBackend(n)
+	}()
+
+	g.Add(1)
+	go func() {
+		defer g.Done()
+		n, _ := io.Copy(client, pc.conn)
+		stats.AddBytesBackendToClient(n)
+	}()
+
+	// When the client→backend direction finishes (client closed its write
+	// side / disconnected), unblock the backend→client copy by setting an
+	// immediate read deadline on the backend so io.Copy returns and we can
+	// reclaim the connection for the pool.
+	go func() {
+		select {
+		case <-ctx.Done():
+		case <-done:
+		}
+		_ = pc.conn.SetReadDeadline(time.Now())
+	}()
+
+	g.Wait()
+	_ = pc.conn.SetReadDeadline(time.Time{}) // clear for reuse
+
+	// Determine reusability. The safe case is a clean COM_QUIT from the client:
+	// the backend is then guaranteed to be at a command boundary. A plain EOF
+	// (client vanished without COM_QUIT) may have happened mid-command, so the
+	// backend stream could be misaligned — the reset's sequence-id check
+	// (resetBackend) is the backstop, but we conservatively destroy on
+	// non-quit endings and on context cancellation.
+	reusable := backendReusable(ctx, sawQuit, c2bErr)
+	return sessionResult{backend: pc, reusable: reusable}, nil
+}
+
+// copyClientCommands forwards client→backend bytes frame by frame, intercepting
+// a standalone COM_QUIT (which go-sql-driver emits on Close) so it is not
+// delivered to the pooled backend. It returns the byte count forwarded, whether
+// a COM_QUIT was seen, and any transport error.
+func copyClientCommands(backend, client net.Conn) (int64, bool, error) {
+	var total int64
+	var hdr [4]byte
+	atCommandStart := true
+	for {
+		if _, err := io.ReadFull(client, hdr[:]); err != nil {
+			if isExpectedClose(err) {
+				return total, false, nil
+			}
+			return total, false, err
+		}
+		n := int(hdr[0]) | int(hdr[1])<<8 | int(hdr[2])<<16
+		seq := hdr[3]
+		payload := make([]byte, n)
+		if n > 0 {
+			if _, err := io.ReadFull(client, payload); err != nil {
+				return total, false, err
+			}
+		}
+		// A new command begins at seq 0 when we are not mid-multiframe. A
+		// standalone COM_QUIT is exactly one byte (0x01).
+		if atCommandStart && seq == 0 && n == 1 && payload[0] == 0x01 {
+			return total, true, nil
+		}
+		if _, err := backend.Write(hdr[:]); err != nil {
+			return total, false, err
+		}
+		if n > 0 {
+			if _, err := backend.Write(payload); err != nil {
+				return total, false, err
+			}
+		}
+		total += int64(4 + n)
+		// The next frame starts a new command unless this was a max-size frame
+		// (0xffffff) that continues into another frame.
+		atCommandStart = n < 0xffffff
+	}
+}
+
+// backendReusable decides whether the backend connection can be safely reset
+// and returned to the pool after a session ends.
+func backendReusable(ctx context.Context, sawQuit bool, c2bErr error) bool {
+	if ctx.Err() != nil {
+		return false
+	}
+	if c2bErr != nil {
+		return false
+	}
+	return sawQuit
+}
+
+func isExpectedClose(err error) bool {
+	if err == nil {
+		return true
+	}
+	if errors.Is(err, io.EOF) || errors.Is(err, net.ErrClosed) {
+		return true
+	}
+	var ne net.Error
+	if errors.As(err, &ne) && ne.Timeout() {
+		return true
+	}
+	return false
+}

--- a/internal/storage/dbproxy/proxy/proxy_pool_integration_test.go
+++ b/internal/storage/dbproxy/proxy/proxy_pool_integration_test.go
@@ -1,0 +1,276 @@
+//go:build cgo
+
+package proxy
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	_ "github.com/go-sql-driver/mysql"
+	"github.com/stretchr/testify/require"
+
+	"github.com/steveyegge/beads/internal/storage/dbproxy/server"
+)
+
+// These tests drive the REAL proxyServer (ListenAndServe → handleConn →
+// handlePooledConn) in pooling mode against a real dolt sql-server that the
+// proxy itself manages, validating the production path end to end. Gated on
+// dolt + cgo.
+
+// startManagedPooledProxy creates an unstarted DoltServer and a proxyServer
+// configured to pool, runs the proxy (which starts dolt) in the background, and
+// returns the proxy address, the dolt port (for direct counter reads), and the
+// stats. The proxy is stopped on test cleanup.
+func startManagedPooledProxy(t *testing.T, poolSize int) (proxyAddr string, doltPort int, stats *Stats) {
+	t.Helper()
+	bin, err := exec.LookPath("dolt")
+	if err != nil {
+		t.Skipf("dolt not on PATH: %v", err)
+	}
+	t.Setenv("HOME", t.TempDir())
+
+	doltPort = freeTCPPort(t)
+	rootDir := t.TempDir()
+	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
+	body := fmt.Sprintf("log_level: warning\nlistener:\n  host: 127.0.0.1\n  port: %d\n", doltPort)
+	require.NoError(t, os.WriteFile(cfgPath, []byte(body), 0o600))
+	logPath := filepath.Join(t.TempDir(), "server.log")
+
+	srv, err := server.NewDoltServer(bin, rootDir, cfgPath, logPath, 0)
+	require.NoError(t, err)
+
+	proxyPort := freeTCPPort(t)
+	proxyRoot := t.TempDir()
+	stats = &Stats{}
+	p := NewProxyServer(ProxyOpts{
+		RootDir:     proxyRoot,
+		Port:        proxyPort,
+		IdleTimeout: 0,
+		Server:      srv,
+		Stats:       stats,
+		PoolSize:    poolSize,
+		BackendUser: "root",
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() { errCh <- p.ListenAndServe(ctx) }()
+	t.Cleanup(func() {
+		cancel()
+		select {
+		case <-errCh:
+		case <-time.After(30 * time.Second):
+			t.Log("proxy did not shut down within 30s")
+		}
+	})
+
+	// Wait for the proxy port to accept connections.
+	proxyAddr = fmt.Sprintf("127.0.0.1:%d", proxyPort)
+	require.Eventually(t, func() bool {
+		return probePort(Endpoint{Host: "127.0.0.1", Port: proxyPort}, 300*time.Millisecond)
+	}, 60*time.Second, 200*time.Millisecond, "proxy never became ready")
+	return proxyAddr, doltPort, stats
+}
+
+func TestIntegration_ManagedProxyPooling(t *testing.T) {
+	addr, _, stats := startManagedPooledProxy(t, 4)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	admin := openThroughProxy(t, addr, "")
+	_, err := admin.ExecContext(ctx, "CREATE DATABASE IF NOT EXISTS itdb")
+	require.NoError(t, err)
+	require.NoError(t, admin.Close())
+
+	db := openThroughProxy(t, addr, "itdb")
+	defer func() { _ = db.Close() }()
+
+	_, err = db.ExecContext(ctx, "CREATE TABLE t (id INT PRIMARY KEY)")
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx, "INSERT INTO t VALUES (1),(2),(3)")
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx, "CALL DOLT_COMMIT('-Am', 'it')")
+	require.NoError(t, err)
+
+	var n int
+	require.NoError(t, db.QueryRowContext(ctx, "SELECT COUNT(*) FROM t").Scan(&n))
+	require.Equal(t, 3, n)
+	t.Logf("stats: %+v", stats.Snapshot())
+}
+
+func TestIntegration_TransactionRollback(t *testing.T) {
+	addr, _, _ := startManagedPooledProxy(t, 2)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	admin := openThroughProxy(t, addr, "")
+	_, err := admin.ExecContext(ctx, "CREATE DATABASE IF NOT EXISTS rb")
+	require.NoError(t, err)
+	require.NoError(t, admin.Close())
+
+	db := openThroughProxy(t, addr, "rb")
+	defer func() { _ = db.Close() }()
+	_, err = db.ExecContext(ctx, "CREATE TABLE t (id INT PRIMARY KEY)")
+	require.NoError(t, err)
+
+	// Begin, insert, rollback — the row must not survive, and the backend must
+	// be reusable afterward (no leaked open transaction).
+	tx, err := db.BeginTx(ctx, nil)
+	require.NoError(t, err)
+	_, err = tx.ExecContext(ctx, "INSERT INTO t VALUES (99)")
+	require.NoError(t, err)
+	require.NoError(t, tx.Rollback())
+
+	var n int
+	require.NoError(t, db.QueryRowContext(ctx, "SELECT COUNT(*) FROM t WHERE id=99").Scan(&n))
+	require.Equal(t, 0, n, "rolled-back row must not persist")
+}
+
+func TestIntegration_ConcurrentClientsDistinctBackends(t *testing.T) {
+	addr, _, stats := startManagedPooledProxy(t, 8)
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	admin := openThroughProxy(t, addr, "")
+	_, err := admin.ExecContext(ctx, "CREATE DATABASE IF NOT EXISTS conc")
+	require.NoError(t, err)
+	require.NoError(t, admin.Close())
+
+	const workers = 8
+	var wg sync.WaitGroup
+	errs := make(chan error, workers)
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			db := openThroughProxy(t, addr, "conc")
+			defer func() { _ = db.Close() }()
+			// Hold a session var, sleep, then verify it is still ours — proves
+			// concurrent clients did NOT share one backend mid-session.
+			conn, err := db.Conn(ctx)
+			if err != nil {
+				errs <- err
+				return
+			}
+			defer func() { _ = conn.Close() }()
+			if _, err := conn.ExecContext(ctx, fmt.Sprintf("SET @who = %d", id)); err != nil {
+				errs <- err
+				return
+			}
+			time.Sleep(150 * time.Millisecond)
+			var who int
+			if err := conn.QueryRowContext(ctx, "SELECT @who").Scan(&who); err != nil {
+				errs <- err
+				return
+			}
+			if who != id {
+				errs <- fmt.Errorf("worker %d saw @who=%d — backend shared mid-session", id, who)
+			}
+		}(i)
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		require.NoError(t, err)
+	}
+	t.Logf("stats after %d concurrent workers: %+v", workers, stats.Snapshot())
+}
+
+// BenchmarkConnectionChurn measures the dolt-side Connections counter delta for
+// N sequential client sessions with pooling on vs off. Run with:
+//
+//	go test ./internal/storage/dbproxy/proxy -run NONE -bench ConnectionChurn -benchtime 1x
+func BenchmarkConnectionChurn(b *testing.B) {
+	for _, tc := range []struct {
+		name     string
+		poolSize int
+	}{
+		{"pooling_off", 0},
+		{"pooling_on", 4},
+	} {
+		b.Run(tc.name, func(b *testing.B) {
+			benchChurn(b, tc.poolSize)
+		})
+	}
+}
+
+func benchChurn(b *testing.B, poolSize int) {
+	b.Helper()
+	bin, err := exec.LookPath("dolt")
+	if err != nil {
+		b.Skipf("dolt not on PATH: %v", err)
+	}
+	b.Setenv("HOME", b.TempDir())
+	doltPort := benchFreePort(b)
+	rootDir := b.TempDir()
+	cfgPath := filepath.Join(b.TempDir(), "config.yaml")
+	body := fmt.Sprintf("log_level: warning\nlistener:\n  host: 127.0.0.1\n  port: %d\n", doltPort)
+	require.NoError(b, os.WriteFile(cfgPath, []byte(body), 0o600))
+	srv, err := server.NewDoltServer(bin, rootDir, cfgPath, filepath.Join(b.TempDir(), "s.log"), 0)
+	require.NoError(b, err)
+
+	proxyPort := benchFreePort(b)
+	stats := &Stats{}
+	p := NewProxyServer(ProxyOpts{
+		RootDir: b.TempDir(), Port: proxyPort, Server: srv, Stats: stats,
+		PoolSize: poolSize, BackendUser: "root",
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() { _ = p.ListenAndServe(ctx) }()
+	addr := fmt.Sprintf("127.0.0.1:%d", proxyPort)
+	require.Eventually(b, func() bool {
+		return probePort(Endpoint{Host: "127.0.0.1", Port: proxyPort}, 300*time.Millisecond)
+	}, 60*time.Second, 200*time.Millisecond)
+
+	bctx := context.Background()
+	direct, err := sql.Open("mysql", fmt.Sprintf("root@tcp(127.0.0.1:%d)/?timeout=10s", doltPort))
+	require.NoError(b, err)
+	direct.SetMaxOpenConns(1)
+	defer func() { _ = direct.Close() }()
+	readConns := func() int64 {
+		var name string
+		var v int64
+		require.NoError(b, direct.QueryRowContext(bctx, "SHOW STATUS LIKE 'Connections'").Scan(&name, &v))
+		return v
+	}
+
+	const N = 50
+	// warm
+	warm, _ := sql.Open("mysql", fmt.Sprintf("root@tcp(%s)/?timeout=10s", addr))
+	_ = warm.PingContext(bctx)
+	_, _ = warm.ExecContext(bctx, "SELECT 1")
+	_ = warm.Close()
+	time.Sleep(200 * time.Millisecond)
+
+	before := readConns()
+	b.ResetTimer()
+	for i := 0; i < N; i++ {
+		c, _ := sql.Open("mysql", fmt.Sprintf("root@tcp(%s)/?timeout=10s", addr))
+		var one int
+		require.NoError(b, c.QueryRowContext(bctx, "SELECT 1").Scan(&one))
+		_ = c.Close()
+		time.Sleep(10 * time.Millisecond)
+	}
+	b.StopTimer()
+	after := readConns()
+	b.ReportMetric(float64(after-before), "dolt_conns/"+fmt.Sprint(N)+"sessions")
+	b.Logf("poolSize=%d Connections delta over %d sessions: %d (stats: %+v)", poolSize, N, after-before, stats.Snapshot())
+}
+
+func benchFreePort(b *testing.B) int {
+	b.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(b, err)
+	port := ln.Addr().(*net.TCPAddr).Port
+	_ = ln.Close()
+	return port
+}

--- a/internal/storage/dbproxy/proxy/server.go
+++ b/internal/storage/dbproxy/proxy/server.go
@@ -33,17 +33,41 @@ type ProxyOpts struct {
 	// against it; tests use Snapshot() to assert. Production code should
 	// leave this nil.
 	Stats *Stats
+
+	// PoolSize enables connection pooling when > 0: instead of dialing a fresh
+	// backend per client and closing it on disconnect (the transparent path),
+	// the proxy terminates each client handshake itself and lends a backend
+	// from a pool of up to PoolSize warm, already-authenticated connections,
+	// resetting and returning them on client disconnect. This collapses the
+	// per-bd-invocation connection churn that dolt pays for as setup CPU.
+	// 0 (default) preserves the original transparent forwarding behavior.
+	PoolSize int
+	// BackendUser / BackendPassword are the credentials the proxy uses to
+	// authenticate pooled backend connections to dolt. Only consulted when
+	// PoolSize > 0. For the managed loopback server this is root / empty.
+	BackendUser     string
+	BackendPassword string
+	// PoolConnMaxLifetime optionally retires pooled connections after this
+	// duration. 0 (default) keeps them indefinitely — a short lifetime would
+	// re-create the very connection churn pooling exists to eliminate.
+	PoolConnMaxLifetime time.Duration
 }
 
 type proxyServer struct {
-	rootDir     string
-	port        int
-	idleTimeout time.Duration
-	server      server.DatabaseServer
-	stats       *Stats
+	rootDir         string
+	port            int
+	idleTimeout     time.Duration
+	server          server.DatabaseServer
+	stats           *Stats
+	poolSize        int
+	backendUser     string
+	backendPassword string
+	poolLifetime    time.Duration
 
 	logger      *log.Logger
 	listener    net.Listener
+	pool        *backendPool
+	connID      atomic.Uint32
 	activeConns atomic.Int64
 	conns       errgroup.Group
 }
@@ -79,11 +103,15 @@ var errIdleTimeout = errors.New("idle timeout reached")
 
 func NewProxyServer(opts ProxyOpts) *proxyServer {
 	return &proxyServer{
-		rootDir:     opts.RootDir,
-		port:        opts.Port,
-		idleTimeout: opts.IdleTimeout,
-		server:      opts.Server,
-		stats:       opts.Stats,
+		rootDir:         opts.RootDir,
+		port:            opts.Port,
+		idleTimeout:     opts.IdleTimeout,
+		server:          opts.Server,
+		stats:           opts.Stats,
+		poolSize:        opts.PoolSize,
+		backendUser:     opts.BackendUser,
+		backendPassword: opts.BackendPassword,
+		poolLifetime:    opts.PoolConnMaxLifetime,
 	}
 }
 
@@ -163,6 +191,19 @@ func (p *proxyServer) ListenAndServe(parentCtx context.Context) error {
 		return fmt.Errorf("write pid file: %w", err)
 	}
 	defer func() { _ = pidfile.Remove(p.rootDir, PIDFileName) }()
+
+	if p.poolSize > 0 {
+		user := p.backendUser
+		if user == "" {
+			user = "root"
+		}
+		p.pool = newBackendPool(
+			func(dctx context.Context) (net.Conn, error) { return p.server.Dial(dctx) },
+			user, p.backendPassword, p.poolSize, p.poolLifetime, p.stats,
+		)
+		p.tracef("connection pooling enabled (maxIdle=%d, user=%q, lifetime=%s)", p.poolSize, user, p.poolLifetime)
+		defer p.pool.drain()
+	}
 
 	g, gctx := errgroup.WithContext(ctx)
 	g.Go(func() error {
@@ -269,6 +310,10 @@ func (p *proxyServer) handleConn(ctx context.Context, client net.Conn) error {
 		p.tracef("handleConn(%s) end (active=%d)", addr, p.activeConns.Load())
 	}()
 
+	if p.pool != nil {
+		return p.handlePooledConn(ctx, client)
+	}
+
 	p.stats.IncBackendDialAttempt()
 	backend, err := p.server.Dial(ctx)
 	if err != nil {
@@ -315,6 +360,32 @@ func (p *proxyServer) handleConn(ctx context.Context, client net.Conn) error {
 		return err
 	})
 	return g.Wait()
+}
+
+// handlePooledConn serves one client connection in pooling mode: terminate the
+// client handshake, borrow a wire-compatible backend from the pool, forward the
+// command phase byte-transparently, and reset+return the backend on disconnect.
+func (p *proxyServer) handlePooledConn(ctx context.Context, client net.Conn) error {
+	defer func() { _ = client.Close() }()
+	p.stats.IncHandledConn()
+	res, err := runPooledSession(ctx, p.stats, p.pool, client, p.connID.Add(1))
+	if err != nil {
+		p.tracef("handlePooledConn(%s) session error: %v", client.RemoteAddr(), err)
+		if res.backend != nil {
+			_ = res.backend.conn.Close()
+		}
+		return err
+	}
+	if res.backend == nil {
+		return nil
+	}
+	if res.reusable {
+		p.pool.put(res.backend)
+	} else {
+		_ = res.backend.conn.Close()
+		p.stats.IncPoolRetire()
+	}
+	return nil
 }
 
 func waitForServerReady(ctx context.Context, s server.DatabaseServer, timeout time.Duration) error {

--- a/internal/storage/dbproxy/proxy/server.go
+++ b/internal/storage/dbproxy/proxy/server.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/cenkalti/backoff/v4"
 	"golang.org/x/sync/errgroup"
+	"golang.org/x/time/rate"
 
 	"github.com/steveyegge/beads/internal/lockfile"
 	"github.com/steveyegge/beads/internal/storage/dbproxy/pidfile"
@@ -70,6 +71,14 @@ type proxyServer struct {
 	connID      atomic.Uint32
 	activeConns atomic.Int64
 	conns       errgroup.Group
+
+	// S3d: rate-limit logging of benign client disconnects. bd clients connect,
+	// run one command, and disconnect; logging each teardown unconditionally
+	// produced the proxy.log flood (1 GB in the incident). disconnectLogLimiter
+	// caps those log lines; droppedDisconnectLogs counts suppressed lines so the
+	// next emitted line can report the gap (no silent loss).
+	disconnectLogLimiter  *rate.Limiter
+	droppedDisconnectLogs atomic.Int64
 }
 
 const (
@@ -112,7 +121,47 @@ func NewProxyServer(opts ProxyOpts) *proxyServer {
 		backendUser:     opts.BackendUser,
 		backendPassword: opts.BackendPassword,
 		poolLifetime:    opts.PoolConnMaxLifetime,
+		// At most one benign-disconnect log line per second, burst 1.
+		disconnectLogLimiter: rate.NewLimiter(rate.Every(time.Second), 1),
 	}
+}
+
+// isExpectedClientDisconnect reports whether err is a benign client teardown
+// (clean EOF — including the wrapped "read handshake response: EOF" — a closed
+// connection, a canceled context, or a read/write timeout) rather than a real
+// proxy fault. These are normal for short-lived bd clients and must not be
+// logged at full volume.
+func isExpectedClientDisconnect(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, io.EOF) || errors.Is(err, net.ErrClosed) || errors.Is(err, context.Canceled) {
+		return true
+	}
+	var ne net.Error
+	if errors.As(err, &ne) && ne.Timeout() {
+		return true
+	}
+	return false
+}
+
+// logSessionError logs a handlePooledConn error, rate-limiting benign client
+// disconnects (S3d) while always logging genuine faults. Suppressed benign
+// lines are counted and surfaced on the next emitted benign line.
+func (p *proxyServer) logSessionError(remote net.Addr, err error) {
+	if !isExpectedClientDisconnect(err) {
+		p.tracef("handlePooledConn(%s) session error: %v", remote, err)
+		return
+	}
+	if p.disconnectLogLimiter == nil || p.disconnectLogLimiter.Allow() {
+		if dropped := p.droppedDisconnectLogs.Swap(0); dropped > 0 {
+			p.tracef("handlePooledConn(%s) client disconnected: %v (+%d similar suppressed)", remote, err, dropped)
+		} else {
+			p.tracef("handlePooledConn(%s) client disconnected: %v", remote, err)
+		}
+		return
+	}
+	p.droppedDisconnectLogs.Add(1)
 }
 
 func (p *proxyServer) tracef(format string, args ...any) {
@@ -203,6 +252,16 @@ func (p *proxyServer) ListenAndServe(parentCtx context.Context) error {
 		)
 		p.tracef("connection pooling enabled (maxIdle=%d, user=%q, lifetime=%s)", p.poolSize, user, p.poolLifetime)
 		defer p.pool.drain()
+
+		// S3a (v2, primary anti-wedge): cap the number of concurrently-handled
+		// client connections to poolSize. errgroup.SetLimit makes acceptLoop's
+		// p.conns.Go block (kernel backlog absorbs the queue) rather than
+		// spawning an unbounded set of handlers, each of which would dial or
+		// borrow a backend connection. This is what bounds live backend
+		// connections per proxy; with poolSize=2 an N-scope city peaks at
+		// N×(poolSize+1) backend connections. Only set when pooling is enabled:
+		// SetLimit(0) would block every handler and wedge the non-pooled path.
+		p.conns.SetLimit(p.poolSize)
 	}
 
 	g, gctx := errgroup.WithContext(ctx)
@@ -315,7 +374,9 @@ func (p *proxyServer) handleConn(ctx context.Context, client net.Conn) error {
 	}
 
 	p.stats.IncBackendDialAttempt()
+	dialDone := p.stats.DialBegin() // S3f: concurrent-dial peak gauge
 	backend, err := p.server.Dial(ctx)
+	dialDone()
 	if err != nil {
 		p.tracef("handleConn(%s) backend dial error: %v", addr, err)
 		p.stats.IncBackendDialError()
@@ -370,7 +431,7 @@ func (p *proxyServer) handlePooledConn(ctx context.Context, client net.Conn) err
 	p.stats.IncHandledConn()
 	res, err := runPooledSession(ctx, p.stats, p.pool, client, p.connID.Add(1))
 	if err != nil {
-		p.tracef("handlePooledConn(%s) session error: %v", client.RemoteAddr(), err)
+		p.logSessionError(client.RemoteAddr(), err)
 		if res.backend != nil {
 			_ = res.backend.conn.Close()
 		}

--- a/internal/storage/dbproxy/proxy/stats.go
+++ b/internal/storage/dbproxy/proxy/stats.go
@@ -1,6 +1,9 @@
 package proxy
 
-import "sync"
+import (
+	"sync"
+	"sync/atomic"
+)
 
 type Counters struct {
 	ListenAndServeCalls  int64
@@ -30,11 +33,35 @@ type Counters struct {
 	PoolResetErrors int64
 	PoolDead        int64
 	PoolRetires     int64
+
+	// BackendDialConcurrentPeak (S3f) is the high-water mark of simultaneous
+	// in-flight backend dials. It is the direct indicator of the wedge this
+	// change set defends against: under the bound (S3a SetLimit=poolSize) it
+	// should never exceed poolSize. An operator watching this gauge climb
+	// toward @@max_connections has early warning before saturation.
+	BackendDialConcurrentPeak int64
 }
 
 type Stats struct {
-	mu       sync.Mutex
-	counters Counters
+	mu           sync.Mutex
+	counters     Counters
+	dialInFlight atomic.Int64 // current simultaneous backend dials (S3f)
+}
+
+// DialBegin records the start of a backend dial, updates the concurrent-dial
+// peak gauge, and returns a function that must be called (defer) when the dial
+// completes. Safe on a nil *Stats.
+func (s *Stats) DialBegin() func() {
+	if s == nil {
+		return func() {}
+	}
+	cur := s.dialInFlight.Add(1)
+	s.update(func(c *Counters) {
+		if cur > c.BackendDialConcurrentPeak {
+			c.BackendDialConcurrentPeak = cur
+		}
+	})
+	return func() { s.dialInFlight.Add(-1) }
 }
 
 func (s *Stats) Snapshot() Counters {

--- a/internal/storage/dbproxy/proxy/stats.go
+++ b/internal/storage/dbproxy/proxy/stats.go
@@ -16,6 +16,20 @@ type Counters struct {
 	HandledConns         int64
 	BytesClientToBackend int64
 	BytesBackendToClient int64
+
+	// Pool counters (session-pooling proxy). PoolHit: a borrow served by a
+	// warm idle connection. PoolMiss: a borrow that had to dial+authenticate
+	// a new backend. PoolDial​Errors: failed dial/handshake. PoolResets /
+	// PoolResetErrors: COM_RESET_CONNECTION outcomes on return. PoolDead:
+	// idle connection failed its liveness check and was discarded.
+	// PoolRetires: connection closed due to lifetime/idle-cap/transient.
+	PoolHits        int64
+	PoolMisses      int64
+	PoolDialErrors  int64
+	PoolResets      int64
+	PoolResetErrors int64
+	PoolDead        int64
+	PoolRetires     int64
 }
 
 type Stats struct {
@@ -58,3 +72,10 @@ func (s *Stats) AddBytesClientToBackend(n int64) {
 func (s *Stats) AddBytesBackendToClient(n int64) {
 	s.update(func(c *Counters) { c.BytesBackendToClient += n })
 }
+func (s *Stats) IncPoolHit()       { s.update(func(c *Counters) { c.PoolHits++ }) }
+func (s *Stats) IncPoolMiss()      { s.update(func(c *Counters) { c.PoolMisses++ }) }
+func (s *Stats) IncPoolDialError() { s.update(func(c *Counters) { c.PoolDialErrors++ }) }
+func (s *Stats) IncPoolReset()     { s.update(func(c *Counters) { c.PoolResets++ }) }
+func (s *Stats) IncPoolResetError() { s.update(func(c *Counters) { c.PoolResetErrors++ }) }
+func (s *Stats) IncPoolDead()      { s.update(func(c *Counters) { c.PoolDead++ }) }
+func (s *Stats) IncPoolRetire()    { s.update(func(c *Counters) { c.PoolRetires++ }) }

--- a/internal/storage/dbproxy/proxy/stats.go
+++ b/internal/storage/dbproxy/proxy/stats.go
@@ -72,10 +72,10 @@ func (s *Stats) AddBytesClientToBackend(n int64) {
 func (s *Stats) AddBytesBackendToClient(n int64) {
 	s.update(func(c *Counters) { c.BytesBackendToClient += n })
 }
-func (s *Stats) IncPoolHit()       { s.update(func(c *Counters) { c.PoolHits++ }) }
-func (s *Stats) IncPoolMiss()      { s.update(func(c *Counters) { c.PoolMisses++ }) }
-func (s *Stats) IncPoolDialError() { s.update(func(c *Counters) { c.PoolDialErrors++ }) }
-func (s *Stats) IncPoolReset()     { s.update(func(c *Counters) { c.PoolResets++ }) }
+func (s *Stats) IncPoolHit()        { s.update(func(c *Counters) { c.PoolHits++ }) }
+func (s *Stats) IncPoolMiss()       { s.update(func(c *Counters) { c.PoolMisses++ }) }
+func (s *Stats) IncPoolDialError()  { s.update(func(c *Counters) { c.PoolDialErrors++ }) }
+func (s *Stats) IncPoolReset()      { s.update(func(c *Counters) { c.PoolResets++ }) }
 func (s *Stats) IncPoolResetError() { s.update(func(c *Counters) { c.PoolResetErrors++ }) }
-func (s *Stats) IncPoolDead()      { s.update(func(c *Counters) { c.PoolDead++ }) }
-func (s *Stats) IncPoolRetire()    { s.update(func(c *Counters) { c.PoolRetires++ }) }
+func (s *Stats) IncPoolDead()       { s.update(func(c *Counters) { c.PoolDead++ }) }
+func (s *Stats) IncPoolRetire()     { s.update(func(c *Counters) { c.PoolRetires++ }) }

--- a/internal/storage/dbproxy/proxy/wedge_guards_test.go
+++ b/internal/storage/dbproxy/proxy/wedge_guards_test.go
@@ -1,0 +1,148 @@
+package proxy
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"log"
+	"net"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"golang.org/x/time/rate"
+)
+
+// TestDialBeginTracksConcurrentPeak verifies the S3f gauge records the
+// high-water mark of simultaneous in-flight dials.
+func TestDialBeginTracksConcurrentPeak(t *testing.T) {
+	s := &Stats{}
+
+	// Open three dials concurrently, then close them.
+	d1 := s.DialBegin()
+	d2 := s.DialBegin()
+	d3 := s.DialBegin()
+	if got := s.Snapshot().BackendDialConcurrentPeak; got != 3 {
+		t.Fatalf("peak = %d, want 3", got)
+	}
+	d1()
+	d2()
+	d3()
+
+	// Peak is a high-water mark: it does not decay when dials complete.
+	if got := s.Snapshot().BackendDialConcurrentPeak; got != 3 {
+		t.Fatalf("peak after close = %d, want 3 (high-water mark must not decay)", got)
+	}
+
+	// A later, smaller burst does not lower the peak.
+	d := s.DialBegin()
+	d()
+	if got := s.Snapshot().BackendDialConcurrentPeak; got != 3 {
+		t.Fatalf("peak after smaller burst = %d, want 3", got)
+	}
+}
+
+// TestDialBeginNilStatsSafe ensures the gauge is safe on a nil *Stats (the
+// proxy tolerates a nil stats sink).
+func TestDialBeginNilStatsSafe(t *testing.T) {
+	var s *Stats
+	done := s.DialBegin()
+	done() // must not panic
+}
+
+// TestIsExpectedClientDisconnect covers the S3d benign/real classification.
+func TestIsExpectedClientDisconnect(t *testing.T) {
+	deadlineErr := func() error {
+		// A timeout net.Error, as produced by a read/write deadline.
+		c1, c2 := net.Pipe()
+		defer c1.Close()
+		defer c2.Close()
+		_ = c1.SetReadDeadline(time.Now().Add(-time.Second))
+		_, err := c1.Read(make([]byte, 1))
+		return err
+	}()
+
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"eof", io.EOF, true},
+		{"wrapped handshake eof", fmt.Errorf("mysqlwire: read handshake response: %w", io.EOF), true},
+		{"closed conn", net.ErrClosed, true},
+		{"context canceled", context.Canceled, true},
+		{"deadline timeout", deadlineErr, true},
+		{"real fault", fmt.Errorf("backend refused: protocol error"), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isExpectedClientDisconnect(tc.err); got != tc.want {
+				t.Fatalf("isExpectedClientDisconnect(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
+type fakeAddr struct{ s string }
+
+func (a fakeAddr) Network() string { return "tcp" }
+func (a fakeAddr) String() string  { return a.s }
+
+// TestLogSessionErrorRateLimitsBenignDisconnects verifies that benign
+// disconnects are rate-limited (S3d) while genuine faults always log, and that
+// suppressed lines are counted and surfaced — never silently dropped.
+func TestLogSessionErrorRateLimitsBenignDisconnects(t *testing.T) {
+	var buf bytes.Buffer
+	p := &proxyServer{
+		logger: log.New(&buf, "", 0),
+		// Burst 1, but refill effectively never during the test window so only
+		// the first benign line is emitted.
+		disconnectLogLimiter: rate.NewLimiter(rate.Every(time.Hour), 1),
+	}
+	addr := fakeAddr{s: "127.0.0.1:54321"}
+
+	// 100 benign disconnects: only the first should log.
+	for i := 0; i < 100; i++ {
+		p.logSessionError(addr, io.EOF)
+	}
+	got := buf.String()
+	if n := strings.Count(got, "client disconnected"); n != 1 {
+		t.Fatalf("benign disconnect logged %d times, want 1 (rate-limited)", n)
+	}
+
+	// A genuine fault is never rate-limited.
+	buf.Reset()
+	p.logSessionError(addr, fmt.Errorf("backend protocol error"))
+	if !strings.Contains(buf.String(), "session error") {
+		t.Fatalf("genuine fault was not logged: %q", buf.String())
+	}
+
+	// The suppressed count is surfaced on the next allowed benign line.
+	buf.Reset()
+	p.disconnectLogLimiter.SetLimit(rate.Inf) // allow the next benign line
+	p.logSessionError(addr, io.EOF)
+	if !strings.Contains(buf.String(), "suppressed") {
+		t.Fatalf("suppressed-count not surfaced: %q", buf.String())
+	}
+}
+
+// TestLogSessionErrorConcurrent is a race-detector smoke test for concurrent
+// benign disconnects (the real proxy logs from many handler goroutines).
+func TestLogSessionErrorConcurrent(t *testing.T) {
+	p := &proxyServer{
+		logger:               log.New(io.Discard, "", 0),
+		disconnectLogLimiter: rate.NewLimiter(rate.Every(time.Millisecond), 1),
+	}
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			p.logSessionError(fakeAddr{s: "127.0.0.1:1"}, io.EOF)
+		}()
+	}
+	wg.Wait()
+}

--- a/internal/storage/dolt/port_file_persist_test.go
+++ b/internal/storage/dolt/port_file_persist_test.go
@@ -1,0 +1,76 @@
+package dolt
+
+import (
+	"os"
+	"testing"
+)
+
+// TestShouldPersistPortFileForConfig guards the proxied-server port-file clobber
+// fix. A proxied routed store (RoutedThroughProxy) connects to an ephemeral
+// db-proxy listener; its port must never be persisted into
+// .beads/dolt-server.port, which is the canonical-server discovery hint. Before
+// the fix, newServerMode wrote the proxy's listener port there, so the file went
+// stale the moment the proxy respawned on a new port and any reader that trusted
+// it targeted a dead endpoint.
+func TestShouldPersistPortFileForConfig(t *testing.T) {
+	// The decision keys off BEADS_DOLT_SERVER_PORT / BEADS_DOLT_PORT; clear both
+	// so the env-override branch does not mask the RoutedThroughProxy logic.
+	for _, k := range []string{"BEADS_DOLT_SERVER_PORT", "BEADS_DOLT_PORT"} {
+		if orig, ok := os.LookupEnv(k); ok {
+			t.Cleanup(func() { _ = os.Setenv(k, orig) })
+			_ = os.Unsetenv(k)
+		}
+	}
+
+	tests := []struct {
+		name string
+		cfg  *Config
+		want bool
+	}{
+		{
+			name: "canonical local server persists",
+			cfg:  &Config{ServerHost: "127.0.0.1", ServerPort: 48770},
+			want: true,
+		},
+		{
+			name: "proxied routed store does not persist",
+			cfg:  &Config{ServerHost: "127.0.0.1", ServerPort: 50534, RoutedThroughProxy: true},
+			want: false,
+		},
+		{
+			name: "remote host never persists",
+			cfg:  &Config{ServerHost: "db.example.com", ServerPort: 3306},
+			want: false,
+		},
+		{
+			name: "nil config is safe",
+			cfg:  nil,
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := shouldPersistPortFileForConfig(tt.cfg); got != tt.want {
+				t.Fatalf("shouldPersistPortFileForConfig() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestShouldPersistPortFileForConfig_EnvOverrideSuppresses confirms an explicit
+// port override still suppresses the persist even for a canonical local server,
+// preserving the pre-existing shouldPersistResolvedPortFile contract.
+func TestShouldPersistPortFileForConfig_EnvOverrideSuppresses(t *testing.T) {
+	if orig, ok := os.LookupEnv("BEADS_DOLT_PORT"); ok {
+		t.Cleanup(func() { _ = os.Setenv("BEADS_DOLT_PORT", orig) })
+	} else {
+		t.Cleanup(func() { _ = os.Unsetenv("BEADS_DOLT_PORT") })
+	}
+	_ = os.Setenv("BEADS_DOLT_PORT", "48770")
+
+	cfg := &Config{ServerHost: "127.0.0.1", ServerPort: 48770}
+	if shouldPersistPortFileForConfig(cfg) {
+		t.Fatal("expected env port override to suppress port-file persist")
+	}
+}

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -246,6 +246,14 @@ type Config struct {
 	// automatically if one isn't running. Disabled under orchestrator (GT_ROOT set).
 	AutoStart bool
 
+	// RoutedThroughProxy indicates ServerHost/ServerPort point at a db-proxy
+	// listener (the proxied-server routed store), not the canonical dolt
+	// sql-server. The proxy port is ephemeral and reassigned on every respawn,
+	// so it must never be persisted into .beads/dolt-server.port — that file is
+	// the discovery hint for the real server and gets clobbered/stale if a
+	// forwarder port lands in it. Set by newProxiedServerRoutedStore.
+	RoutedThroughProxy bool
+
 	// MaxOpenConns overrides the connection pool size (0 = default 10).
 	// Set to 1 for branch isolation in tests (DOLT_CHECKOUT is session-level).
 	MaxOpenConns int
@@ -1120,7 +1128,11 @@ func newServerMode(ctx context.Context, cfg *Config) (*DoltStore, error) {
 		}
 	}
 
-	if isLocalHost(cfg.ServerHost) && shouldPersistResolvedPortFile() {
+	// Persist the resolved port only when this store targets the canonical local
+	// dolt sql-server. A proxied routed store connects to an ephemeral db-proxy
+	// listener; persisting that port clobbers the real server's discovery hint
+	// and goes stale the moment the proxy respawns.
+	if shouldPersistPortFileForConfig(cfg) {
 		beadsDir := cfg.BeadsDir
 		if beadsDir == "" && cfg.Path != "" {
 			beadsDir = filepath.Dir(cfg.Path)
@@ -1148,6 +1160,21 @@ func newServerMode(ctx context.Context, cfg *Config) (*DoltStore, error) {
 
 func shouldPersistResolvedPortFile() bool {
 	return os.Getenv("BEADS_DOLT_SERVER_PORT") == "" && os.Getenv("BEADS_DOLT_PORT") == ""
+}
+
+// shouldPersistPortFileForConfig reports whether a freshly-opened server-mode
+// store should record its resolved port into .beads/dolt-server.port. Only the
+// canonical local dolt sql-server qualifies. A proxied routed store
+// (RoutedThroughProxy) targets an ephemeral db-proxy listener whose port must
+// never become the on-disk discovery hint: it is clobbered on the next
+// reconcile and goes stale when the proxy respawns on a new port, breaking
+// endpoint resolution for any reader that trusts the file. An explicit port
+// override (BEADS_DOLT_SERVER_PORT / BEADS_DOLT_PORT) also suppresses the write.
+func shouldPersistPortFileForConfig(cfg *Config) bool {
+	if cfg == nil {
+		return false
+	}
+	return isLocalHost(cfg.ServerHost) && shouldPersistResolvedPortFile() && !cfg.RoutedThroughProxy
 }
 
 // verifyProjectIdentity checks that the database belongs to the expected project.

--- a/internal/storage/issueops/brief_projection_test.go
+++ b/internal/storage/issueops/brief_projection_test.go
@@ -1,0 +1,213 @@
+package issueops
+
+import (
+	"context"
+	"database/sql/driver"
+	"strings"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+)
+
+// splitBriefCols returns the brief projection's column names in order, parsed
+// from the derived IssueSelectColumnsBrief so the test rows can never drift from
+// the actual projection / ScanIssueBriefFrom scan order.
+func splitBriefCols() []string {
+	parts := strings.Split(IssueSelectColumnsBrief, ",")
+	out := make([]string, len(parts))
+	for i, p := range parts {
+		out[i] = strings.TrimSpace(p)
+	}
+	return out
+}
+
+// briefIssueRowValues returns a value slice aligned to splitBriefCols(): non-null
+// values for the directly-scanned non-nullable fields (id, title, status,
+// priority, issue_type, compaction_level) + a routing metadata blob; everything
+// else nil. The 7 omitted body columns are absent by construction.
+func briefIssueRowValues(cols []string) []driver.Value {
+	set := map[string]driver.Value{
+		"id":               "brief-1",
+		"content_hash":     "hash",
+		"title":            "Brief Title",
+		"status":           "open",
+		"priority":         int64(2),
+		"issue_type":       "bug",
+		"compaction_level": int64(0),
+		"metadata":         `{"gc.routed_to":"beads/voxist.reviewer"}`,
+	}
+	vals := make([]driver.Value, len(cols))
+	for i, c := range cols {
+		if v, ok := set[c]; ok {
+			vals[i] = v
+		} else {
+			vals[i] = nil
+		}
+	}
+	return vals
+}
+
+// TestIssueSelectColumnsBrief locks the derived brief column set against drift:
+// it must drop exactly the 7 body columns and retain routing-critical columns.
+func TestIssueSelectColumnsBrief(t *testing.T) {
+	t.Parallel()
+	for _, dropped := range bodyColumnsOmittedInBrief {
+		for _, c := range splitBriefCols() {
+			if c == dropped {
+				t.Errorf("IssueSelectColumnsBrief must not contain body column %q", dropped)
+			}
+		}
+	}
+	keep := map[string]bool{"metadata": false, "title": false, "id": false, "status": false}
+	for _, c := range splitBriefCols() {
+		if _, ok := keep[c]; ok {
+			keep[c] = true
+		}
+	}
+	for c, present := range keep {
+		if !present {
+			t.Errorf("IssueSelectColumnsBrief must retain %q", c)
+		}
+	}
+}
+
+// TestScanIssueBrief round-trips a brief row through ScanIssueBriefFrom: the kept
+// fields (id/title/status/metadata) populate, and the omitted body fields stay
+// zero-valued.
+func TestScanIssueBrief(t *testing.T) {
+	t.Parallel()
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	cols := splitBriefCols()
+	mock.ExpectQuery("SELECT").WillReturnRows(sqlmock.NewRows(cols).AddRow(briefIssueRowValues(cols)...))
+
+	rows, err := db.Query("SELECT brief")
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	defer func() { _ = rows.Close() }()
+	if !rows.Next() {
+		t.Fatalf("expected one row")
+	}
+	issue, err := ScanIssueBriefFrom(rows)
+	if err != nil {
+		t.Fatalf("ScanIssueBriefFrom: %v", err)
+	}
+
+	if issue.ID != "brief-1" || issue.Title != "Brief Title" || string(issue.Status) != "open" {
+		t.Errorf("kept fields wrong: id=%q title=%q status=%q", issue.ID, issue.Title, issue.Status)
+	}
+	if len(issue.Metadata) == 0 || !strings.Contains(string(issue.Metadata), "gc.routed_to") {
+		t.Errorf("metadata (routing) must survive the brief scan, got %q", string(issue.Metadata))
+	}
+	if issue.Description != "" || issue.Design != "" || issue.AcceptanceCriteria != "" ||
+		issue.Notes != "" || issue.CloseReason != "" || issue.Payload != "" || len(issue.Waiters) != 0 {
+		t.Errorf("brief scan must leave body fields zero-valued, got desc=%q design=%q payload=%q waiters=%v",
+			issue.Description, issue.Design, issue.Payload, issue.Waiters)
+	}
+}
+
+// TestReadyWorkBriefKeepsMetadata drives the actual work-probe executor
+// (runSearchQueryInTx, brief=true) with a fully-populated brief row + the 6
+// composite count extras, and asserts the returned IssueWithCounts retains
+// routing metadata + counts while the body fields are empty.
+func TestReadyWorkBriefKeepsMetadata(t *testing.T) {
+	t.Parallel()
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	cols := splitBriefCols()
+	vals := briefIssueRowValues(cols)
+	// Append the composite extras in the order scanReadyWorkRowWithScanner expects.
+	extraCols := []string{"labels_json", "dep_count", "rdep_count", "comment_count", "parent_id", "deps_json"}
+	extraVals := []driver.Value{nil, int64(3), int64(1), int64(2), nil, nil}
+	cols = append(cols, extraCols...)
+	vals = append(vals, extraVals...)
+
+	mock.ExpectBegin()
+	tx, err := db.Begin()
+	if err != nil {
+		t.Fatalf("begin: %v", err)
+	}
+	mock.ExpectQuery("SELECT").WillReturnRows(sqlmock.NewRows(cols).AddRow(vals...))
+
+	out, err := runSearchQueryInTx(
+		context.Background(), tx, IssuesFilterTables,
+		"", "", "", nil, false, false, true, /*brief*/
+	)
+	if err != nil {
+		t.Fatalf("runSearchQueryInTx(brief): %v", err)
+	}
+	if len(out) != 1 {
+		t.Fatalf("expected 1 row, got %d", len(out))
+	}
+	iwc := out[0]
+	if iwc.Issue.ID != "brief-1" || string(iwc.Issue.Status) != "open" {
+		t.Errorf("issue identity wrong: id=%q status=%q", iwc.Issue.ID, iwc.Issue.Status)
+	}
+	if len(iwc.Issue.Metadata) == 0 || !strings.Contains(string(iwc.Issue.Metadata), "gc.routed_to") {
+		t.Errorf("routing metadata must survive the brief work-probe, got %q", string(iwc.Issue.Metadata))
+	}
+	if iwc.DependencyCount != 3 || iwc.DependentCount != 1 || iwc.CommentCount != 2 {
+		t.Errorf("composite counts wrong: dep=%d rdep=%d comment=%d", iwc.DependencyCount, iwc.DependentCount, iwc.CommentCount)
+	}
+	if iwc.Issue.Description != "" || iwc.Issue.Payload != "" || len(iwc.Issue.Waiters) != 0 {
+		t.Errorf("brief work-probe must leave bodies empty, got desc=%q payload=%q", iwc.Issue.Description, iwc.Issue.Payload)
+	}
+}
+
+// TestReadyWorkBriefProjection asserts that the work-probe projection builder,
+// driven with brief=true, emits a SELECT that omits the 7 heavy free-text/blob
+// body columns (the measured 7–12x cost driver on the high-frequency poll path)
+// while still projecting the columns the probe consumes — crucially i.metadata
+// (carries gc.routed_to for pool routing) and i.title (be-yvci).
+func TestReadyWorkBriefProjection(t *testing.T) {
+	t.Parallel()
+
+	var captured string
+	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherFunc(
+		func(_ string, actual string) error {
+			captured = actual
+			return nil // capture-and-match-all; assertions run on `captured`
+		},
+	)))
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectBegin()
+	tx, err := db.Begin()
+	if err != nil {
+		t.Fatalf("begin: %v", err)
+	}
+	// Empty result set → the scan loop never runs, so we only exercise the
+	// projection the builder emits.
+	mock.ExpectQuery("").WillReturnRows(sqlmock.NewRows([]string{"id"}))
+
+	if _, err := runSearchQueryInTx(
+		context.Background(), tx, IssuesFilterTables,
+		"", "", "", nil,
+		false /*includeWispReverseDeps*/, false /*skipLabels*/, true, /*brief*/
+	); err != nil {
+		t.Fatalf("runSearchQueryInTx(brief): %v", err)
+	}
+
+	for _, dropped := range bodyColumnsOmittedInBrief {
+		if strings.Contains(captured, "i."+dropped) {
+			t.Errorf("brief work-probe SELECT must not project i.%s\nSQL:\n%s", dropped, captured)
+		}
+	}
+	for _, kept := range []string{"i.metadata", "i.title", "i.id", "i.status"} {
+		if !strings.Contains(captured, kept) {
+			t.Errorf("brief work-probe SELECT must project %s\nSQL:\n%s", kept, captured)
+		}
+	}
+}

--- a/internal/storage/issueops/ready_work_counts.go
+++ b/internal/storage/issueops/ready_work_counts.go
@@ -21,7 +21,7 @@ func GetReadyWorkWithCountsInTx(ctx context.Context, tx *sql.Tx, filter types.Wo
 	if err != nil {
 		return nil, err
 	}
-	out, err := runSearchQueryInTx(ctx, tx, IssuesFilterTables, issuePreds.whereSQL, issuePreds.orderBySQL, issuePreds.limitSQL, issuePreds.args, wispDepsExist, false)
+	out, err := runSearchQueryInTx(ctx, tx, IssuesFilterTables, issuePreds.whereSQL, issuePreds.orderBySQL, issuePreds.limitSQL, issuePreds.args, wispDepsExist, false, filter.BriefBodies)
 	if err != nil {
 		return nil, err
 	}
@@ -41,7 +41,7 @@ func GetReadyWorkWithCountsInTx(ctx context.Context, tx *sql.Tx, filter types.Wo
 	if err != nil {
 		return nil, err
 	}
-	wisps, err := runSearchQueryInTx(ctx, tx, WispsFilterTables, wispPreds.whereSQL, wispPreds.orderBySQL, wispPreds.limitSQL, wispPreds.args, true, false)
+	wisps, err := runSearchQueryInTx(ctx, tx, WispsFilterTables, wispPreds.whereSQL, wispPreds.orderBySQL, wispPreds.limitSQL, wispPreds.args, true, false, filter.BriefBodies)
 	if err != nil {
 		if isTableNotExistError(err) {
 			return out, nil
@@ -100,15 +100,21 @@ func sortIssuesWithCountsByPolicy(items []*types.IssueWithCounts, policy types.S
 	copy(items, sorted)
 }
 
-var readyWorkIssueColumns = func() string {
-	raw := strings.ReplaceAll(IssueSelectColumns, "\n", " ")
+func aliasIssueColumns(cols string) string {
+	raw := strings.ReplaceAll(cols, "\n", " ")
 	raw = strings.ReplaceAll(raw, "\t", " ")
 	parts := strings.Split(raw, ",")
 	for i, p := range parts {
 		parts[i] = "i." + strings.TrimSpace(p)
 	}
 	return strings.Join(parts, ", ")
-}()
+}
+
+var readyWorkIssueColumns = aliasIssueColumns(IssueSelectColumns)
+
+// briefReadyWorkIssueColumns is the i.-aliased brief projection (body columns
+// dropped) used by the work-probe path when WorkFilter.BriefBodies is set (be-yvci).
+var briefReadyWorkIssueColumns = aliasIssueColumns(IssueSelectColumnsBrief)
 
 const readyWorkDepJSONObject = `JSON_OBJECT(
 	'issue_id', issue_id,
@@ -121,6 +127,19 @@ const readyWorkDepJSONObject = `JSON_OBJECT(
 )`
 
 func scanReadyWorkRowWithCounts(rows *sql.Rows) (*types.IssueWithCounts, error) {
+	return scanReadyWorkRowWithScanner(rows, ScanIssueFrom)
+}
+
+// scanReadyWorkBriefRowWithCounts scans a row from the brief work-probe projection
+// (briefReadyWorkIssueColumns): the same composite dep/label/count extras, but the
+// issue columns are the body-stripped brief set (be-yvci). Sharing
+// scanReadyWorkRowWithScanner guarantees the trailing extras are appended in the
+// identical order for both projections.
+func scanReadyWorkBriefRowWithCounts(rows *sql.Rows) (*types.IssueWithCounts, error) {
+	return scanReadyWorkRowWithScanner(rows, ScanIssueBriefFrom)
+}
+
+func scanReadyWorkRowWithScanner(rows *sql.Rows, scanIssue func(IssueScanner) (*types.Issue, error)) (*types.IssueWithCounts, error) {
 	var labelsJSON, depsJSON sql.NullString
 	var parentID sql.NullString
 	var depCount, rdepCount, commentCount sql.NullInt64
@@ -136,7 +155,7 @@ func scanReadyWorkRowWithCounts(rows *sql.Rows) (*types.IssueWithCounts, error) 
 			&depsJSON,
 		},
 	}
-	issue, err := ScanIssueFrom(composite)
+	issue, err := scanIssue(composite)
 	if err != nil {
 		return nil, fmt.Errorf("scan issue with counts: %w", err)
 	}

--- a/internal/storage/issueops/scan.go
+++ b/internal/storage/issueops/scan.go
@@ -3,6 +3,7 @@ package issueops
 import (
 	"database/sql"
 	"encoding/json"
+	"strings"
 	"time"
 
 	"github.com/steveyegge/beads/internal/types"
@@ -21,6 +22,36 @@ const IssueSelectColumns = `id, content_hash, title, description, design, accept
 	       event_kind, actor, target, payload,
 	       due_at, defer_until,
 	       work_type, source_system, metadata`
+
+// bodyColumnsOmittedInBrief are the heavy free-text/blob columns dropped from the
+// brief work-probe projection (be-yvci). They are the measured 7–12x cost driver
+// on the high-frequency poll path and are never displayed by the probe.
+// ScanIssueBriefFrom leaves the corresponding Issue fields zero-valued.
+var bodyColumnsOmittedInBrief = []string{
+	"description", "design", "acceptance_criteria", "notes", "close_reason", "payload", "waiters",
+}
+
+// IssueSelectColumnsBrief is IssueSelectColumns with the bodyColumnsOmittedInBrief
+// columns removed, preserving the original column order. It is derived (not a hand-
+// maintained parallel constant) so it can never drift from IssueSelectColumns.
+// ScanIssueBriefFrom must scan exactly these columns in this order.
+var IssueSelectColumnsBrief = func() string {
+	omit := make(map[string]struct{}, len(bodyColumnsOmittedInBrief))
+	for _, c := range bodyColumnsOmittedInBrief {
+		omit[c] = struct{}{}
+	}
+	raw := strings.ReplaceAll(IssueSelectColumns, "\n", " ")
+	raw = strings.ReplaceAll(raw, "\t", " ")
+	kept := make([]string, 0)
+	for _, p := range strings.Split(raw, ",") {
+		name := strings.TrimSpace(p)
+		if _, drop := omit[name]; drop {
+			continue
+		}
+		kept = append(kept, name)
+	}
+	return strings.Join(kept, ", ")
+}()
 
 // IssueScanner is the common interface between *sql.Row and *sql.Rows,
 // allowing a single scan function to work with both single-row and
@@ -171,6 +202,149 @@ func ScanIssueFrom(s IssueScanner) (*types.Issue, error) {
 		issue.SourceSystem = sourceSystem.String
 	}
 	// Custom metadata field (GH#1406)
+	if metadata.Valid && metadata.String != "" && metadata.String != "{}" {
+		issue.Metadata = []byte(metadata.String)
+	}
+
+	return &issue, nil
+}
+
+// ScanIssueBriefFrom scans an issue from a source that selected exactly
+// IssueSelectColumnsBrief in order — i.e. IssueSelectColumns minus the
+// bodyColumnsOmittedInBrief (description, design, acceptance_criteria, notes,
+// close_reason, payload, waiters). Those seven fields are left zero-valued.
+// Used by the brief work-probe path (be-yvci) so the high-frequency poll never
+// pulls the heavy free-text/blob columns it does not display; routing-critical
+// columns including metadata are scanned exactly as in ScanIssueFrom.
+func ScanIssueBriefFrom(s IssueScanner) (*types.Issue, error) {
+	var issue types.Issue
+	var createdAtStr, updatedAtStr sql.NullString // TEXT columns - must parse manually
+	var startedAt, closedAt, compactedAt, dueAt, deferUntil sql.NullTime
+	var estimatedMinutes, originalSize, timeoutNs sql.NullInt64
+	var createdBy sql.NullString
+	var assignee, externalRef, specID, compactedAtCommit, owner sql.NullString
+	var contentHash, sourceRepo sql.NullString
+	var workType, sourceSystem sql.NullString
+	var sender, wispType, molType, eventKind, actor, target sql.NullString
+	var awaitType, awaitID sql.NullString
+	var ephemeral, noHistory, pinned, isTemplate sql.NullInt64
+	var metadata sql.NullString
+
+	// Scan order MUST match IssueSelectColumnsBrief exactly (IssueSelectColumns
+	// with description, design, acceptance_criteria, notes, close_reason, waiters,
+	// payload removed). Those fields are intentionally not scanned and stay zero.
+	if err := s.Scan(
+		&issue.ID, &contentHash, &issue.Title, &issue.Status,
+		&issue.Priority, &issue.IssueType, &assignee, &estimatedMinutes,
+		&createdAtStr, &createdBy, &owner, &updatedAtStr, &startedAt, &closedAt, &externalRef, &specID,
+		&issue.CompactionLevel, &compactedAt, &compactedAtCommit, &originalSize, &sourceRepo,
+		&sender, &ephemeral, &noHistory, &wispType, &pinned, &isTemplate,
+		&awaitType, &awaitID, &timeoutNs,
+		&molType,
+		&eventKind, &actor, &target,
+		&dueAt, &deferUntil,
+		&workType, &sourceSystem, &metadata,
+	); err != nil {
+		return nil, err
+	}
+
+	if createdAtStr.Valid {
+		issue.CreatedAt = ParseTimeString(createdAtStr.String)
+	}
+	if updatedAtStr.Valid {
+		issue.UpdatedAt = ParseTimeString(updatedAtStr.String)
+	}
+	if contentHash.Valid {
+		issue.ContentHash = contentHash.String
+	}
+	if startedAt.Valid {
+		issue.StartedAt = &startedAt.Time
+	}
+	if closedAt.Valid {
+		issue.ClosedAt = &closedAt.Time
+	}
+	if estimatedMinutes.Valid {
+		mins := int(estimatedMinutes.Int64)
+		issue.EstimatedMinutes = &mins
+	}
+	if assignee.Valid {
+		issue.Assignee = assignee.String
+	}
+	if createdBy.Valid {
+		issue.CreatedBy = createdBy.String
+	}
+	if owner.Valid {
+		issue.Owner = owner.String
+	}
+	if externalRef.Valid {
+		issue.ExternalRef = &externalRef.String
+	}
+	if specID.Valid {
+		issue.SpecID = specID.String
+	}
+	if compactedAt.Valid {
+		issue.CompactedAt = &compactedAt.Time
+	}
+	if compactedAtCommit.Valid {
+		issue.CompactedAtCommit = &compactedAtCommit.String
+	}
+	if originalSize.Valid {
+		issue.OriginalSize = int(originalSize.Int64)
+	}
+	if sourceRepo.Valid {
+		issue.SourceRepo = sourceRepo.String
+	}
+	if sender.Valid {
+		issue.Sender = sender.String
+	}
+	if ephemeral.Valid && ephemeral.Int64 != 0 {
+		issue.Ephemeral = true
+	}
+	if noHistory.Valid && noHistory.Int64 != 0 {
+		issue.NoHistory = true
+	}
+	if wispType.Valid {
+		issue.WispType = types.WispType(wispType.String)
+	}
+	if pinned.Valid && pinned.Int64 != 0 {
+		issue.Pinned = true
+	}
+	if isTemplate.Valid && isTemplate.Int64 != 0 {
+		issue.IsTemplate = true
+	}
+	if awaitType.Valid {
+		issue.AwaitType = awaitType.String
+	}
+	if awaitID.Valid {
+		issue.AwaitID = awaitID.String
+	}
+	if timeoutNs.Valid {
+		issue.Timeout = time.Duration(timeoutNs.Int64)
+	}
+	if molType.Valid {
+		issue.MolType = types.MolType(molType.String)
+	}
+	if eventKind.Valid {
+		issue.EventKind = eventKind.String
+	}
+	if actor.Valid {
+		issue.Actor = actor.String
+	}
+	if target.Valid {
+		issue.Target = target.String
+	}
+	if dueAt.Valid {
+		issue.DueAt = &dueAt.Time
+	}
+	if deferUntil.Valid {
+		issue.DeferUntil = &deferUntil.Time
+	}
+	if workType.Valid {
+		issue.WorkType = types.WorkType(workType.String)
+	}
+	if sourceSystem.Valid {
+		issue.SourceSystem = sourceSystem.String
+	}
 	if metadata.Valid && metadata.String != "" && metadata.String != "{}" {
 		issue.Metadata = []byte(metadata.String)
 	}

--- a/internal/storage/issueops/search_counts.go
+++ b/internal/storage/issueops/search_counts.go
@@ -91,11 +91,21 @@ func runFilterSearchQueryInTx(ctx context.Context, tx *sql.Tx, query string, fil
 		limitSQL = fmt.Sprintf("LIMIT %d", filter.Limit)
 	}
 	const orderBy = "ORDER BY i.priority ASC, i.created_at DESC, i.id ASC"
-	return runSearchQueryInTx(ctx, tx, tables, whereSQL, orderBy, limitSQL, args, includeWispReverseDeps, filter.SkipLabels)
+	// Search always hydrates full bodies (callers display them); only the
+	// work-probe path opts into the brief projection (be-yvci).
+	return runSearchQueryInTx(ctx, tx, tables, whereSQL, orderBy, limitSQL, args, includeWispReverseDeps, filter.SkipLabels, false)
 }
 
 //nolint:gosec // G201: SQL fragments are caller-built from hardcoded shapes
-func runSearchQueryInTx(ctx context.Context, tx *sql.Tx, tables FilterTables, whereSQL, orderBySQL, limitSQL string, args []interface{}, includeWispReverseDeps bool, skipLabels bool) ([]*types.IssueWithCounts, error) {
+func runSearchQueryInTx(ctx context.Context, tx *sql.Tx, tables FilterTables, whereSQL, orderBySQL, limitSQL string, args []interface{}, includeWispReverseDeps bool, skipLabels bool, brief bool) ([]*types.IssueWithCounts, error) {
+	// brief (be-yvci): project the body-stripped column set on the high-frequency
+	// work-probe path; default (wide) path is byte-for-byte unchanged.
+	issueColumns := readyWorkIssueColumns
+	scanRow := scanReadyWorkRowWithCounts
+	if brief {
+		issueColumns = briefReadyWorkIssueColumns
+		scanRow = scanReadyWorkBriefRowWithCounts
+	}
 	reverseBlockerSelect := `
 				SELECT COALESCE(depends_on_issue_id, depends_on_wisp_id, depends_on_external) AS dep_id
 				FROM dependencies WHERE type = 'blocks'
@@ -162,7 +172,7 @@ func runSearchQueryInTx(ctx context.Context, tx *sql.Tx, tables FilterTables, wh
 		%s
 		%s
 	`,
-		readyWorkIssueColumns,
+		issueColumns,
 		labelsSelect,
 		tables.Main,
 		labelsJoin,
@@ -186,7 +196,7 @@ func runSearchQueryInTx(ctx context.Context, tx *sql.Tx, tables FilterTables, wh
 	var out []*types.IssueWithCounts
 	seen := make(map[string]bool)
 	for rows.Next() {
-		iwc, scanErr := scanReadyWorkRowWithCounts(rows)
+		iwc, scanErr := scanRow(rows)
 		if scanErr != nil {
 			return nil, scanErr
 		}

--- a/internal/storage/uow/dolt_sql_provider.go
+++ b/internal/storage/uow/dolt_sql_provider.go
@@ -107,6 +107,15 @@ func openDB(ctx context.Context, dsn string) (*sql.DB, error) {
 	if err != nil {
 		return nil, fmt.Errorf("uow: open db: %w", err)
 	}
+	// S3e (v2): bound the client-side *sql.DB pool. A bd invocation is a
+	// short-lived single-threaded process; without these caps the driver
+	// opens an unbounded set of backend connections to the db-proxy, which
+	// (combined with the routed-store leak) exhausted the proxy's connection
+	// budget and wedged it. One live + one idle connection, recycled every
+	// 5 minutes, is sufficient for a single command's lifetime.
+	conn.SetMaxOpenConns(1)
+	conn.SetMaxIdleConns(1)
+	conn.SetConnMaxLifetime(5 * time.Minute)
 	if err := conn.PingContext(ctx); err != nil {
 		return nil, errors.Join(fmt.Errorf("uow: ping db: %w", err), conn.Close())
 	}

--- a/internal/storage/uow/doltserver_provider.go
+++ b/internal/storage/uow/doltserver_provider.go
@@ -55,6 +55,8 @@ func NewDoltServerUOWProvider(
 		LogFilePath:    serverLogFilePath,
 		DoltBinPath:    absDoltBinExec,
 		IdleTimeout:    defaultProxyIdleTimeout,
+		PoolSize:       proxy.PoolSizeFromEnv(),
+		BackendUser:    rootUser,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("uow: get proxy endpoint: %w", err)

--- a/internal/storage/uow/doltserver_provider.go
+++ b/internal/storage/uow/doltserver_provider.go
@@ -54,7 +54,7 @@ func NewDoltServerUOWProvider(
 		ConfigFilePath: serverConfigFilePath,
 		LogFilePath:    serverLogFilePath,
 		DoltBinPath:    absDoltBinExec,
-		IdleTimeout:    defaultProxyIdleTimeout,
+		IdleTimeout:    proxy.IdleTimeoutFromEnv(defaultProxyIdleTimeout),
 		PoolSize:       proxy.PoolSizeFromEnv(),
 		BackendUser:    rootUser,
 	})

--- a/internal/storage/uow/external_doltserver_provider.go
+++ b/internal/storage/uow/external_doltserver_provider.go
@@ -46,6 +46,8 @@ func NewExternalDoltServerUOWProvider(
 		LogFilePath: serverLogFilePath,
 		External:    external,
 		IdleTimeout: defaultProxyIdleTimeout,
+		PoolSize:    proxy.PoolSizeFromEnv(),
+		BackendUser: rootUser,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("uow: get proxy endpoint: %w", err)

--- a/internal/storage/uow/external_doltserver_provider.go
+++ b/internal/storage/uow/external_doltserver_provider.go
@@ -45,7 +45,7 @@ func NewExternalDoltServerUOWProvider(
 		Backend:     proxy.BackendExternal,
 		LogFilePath: serverLogFilePath,
 		External:    external,
-		IdleTimeout: defaultProxyIdleTimeout,
+		IdleTimeout: proxy.IdleTimeoutFromEnv(defaultProxyIdleTimeout),
 		PoolSize:    proxy.PoolSizeFromEnv(),
 		BackendUser: rootUser,
 	})

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -1360,6 +1360,16 @@ type WorkFilter struct {
 	// Metadata field filtering (GH#1406)
 	MetadataFields map[string]string // Top-level key=value equality; AND semantics (all must match)
 	HasMetadataKey string            // Existence check: issue has this top-level key set (non-null)
+
+	// BriefBodies, when true, narrows the ready/work-probe projection to omit the
+	// heavy free-text/blob "body" columns (description, design, acceptance_criteria,
+	// notes, close_reason, payload, waiters) that the high-frequency supervisor probe
+	// never displays — the measured 7–12x cost driver on the poll path (be-yvci).
+	// Routing-critical columns (metadata, title, status, …) are still projected.
+	// Default false keeps the full-hydration behavior, so existing callers and
+	// `bd ready`/`bd list --json` output are unchanged. The fleet-wide CPU win lands
+	// when the supervisor work_query passes --brief (gascity slice ga-arn).
+	BriefBodies bool
 }
 
 // StaleFilter is used to filter stale issue queries


### PR DESCRIPTION
## Problem

Multi-agent orchestrators (e.g. gascity/gc, #1978) run beads against a persistent `dolt sql-server` and fork `bd` for **every** operation. Each `bd` process opens a fresh `*sql.DB` → dials dolt (TCP + MySQL auth handshake + session setup) → exits, closing the pool. The in-process pool never survives the process, so there is zero cross-invocation reuse. Measured on a 1-rig city (7 agents): **71 new connections/sec** to dolt, sql-server at 85–170% CPU while the processlist is mostly `Sleep` — pure connection-setup cost. The existing db-proxy was a byte-transparent 1:1 forwarder (dial + `io.Copy` + close per client), so it didn't help.

Hard constraint: **keep Dolt** (bead versioning + cross-machine sync via dolt remotes).

## Approach

Make the db-proxy a **session-pooling, MySQL-protocol-aware** forwarder. It terminates the client handshake itself (skip-auth: clients are loopback-only and already trusted by the proxy's design), borrows an already-authenticated backend from a pool, forwards the command phase **byte-transparently** (the proven `io.Copy` path — bd's storage/uow/transaction code is unchanged), and on client disconnect sends `COM_RESET_CONNECTION` and returns the backend to the pool instead of closing it.

Pooling is **opt-in** via `BEADS_PROXY_POOL_SIZE` (unset/0 = today's transparent behavior). Embedded and direct ServerMode are unaffected.

### Correctness
- **Capability-flag parity**: byte-transparent forwarding requires client↔proxy and proxy↔backend to negotiate the same caps (result-set encoding depends on `DEPRECATE_EOF`, `PROTOCOL_41`, `QUERY_ATTRIBUTES`, `SESSION_TRACK`, …). The pool is keyed by `(capabilities, database)`; mismatched clients fall back to a fresh dial. All `bd` clients share one driver+DSN → one key → full reuse.
- **Session isolation** via `COM_RESET_CONNECTION` (dolt releases locks, recreates the session, restores DB). go-sql-driver's `ResetSession` does *not* send it, so the proxy does. Reset failure → connection destroyed, not reused.
- **Misalignment guard**: the reset reply must be sequence 1; an out-of-sequence packet (e.g. client killed mid-result) destroys the connection rather than lending a corrupted one.
- **COM_QUIT interception**: go-sql-driver sends COM_QUIT on Close; the client→backend direction is frame-aware enough to swallow it and reclaim the backend instead of forwarding it (which would kill the pooled connection).

A `bd daemon` alternative was rejected (routing the whole domain layer over IPC, or reinventing the wire protocol over a socket; transactions still force per-invocation session pinning → no gain).

## Deployable end-to-end
- Unfenced `bd init --proxied-server` for **external** mode (the full `runInitProxiedServer` already existed behind a blanket "not yet implemented" guard; managed-local stays rejected pending its `.dolt` lifecycle).
- Routed a server-mode store through the proxy in proxied mode (`newProxiedServerRoutedStore`) so the legacy store-based commands (list/ready/stats/update/close/…) work — previously only `bd create` (uow-based) did; the rest dereferenced a nil store.

## Validation
- **Unit** (no deps): wire round-trips; pool reuse/cap/key-isolation/drain/eviction/lifetime against a fake MySQL backend.
- **Integration** (cgo + dolt): real proxyServer query/tx/`DOLT_COMMIT`, rollback, 8 concurrent clients keep private sessions, session-state isolation; container-backed `bd init --proxied-server` external + create/list/ready/update/close.
- **Benchmark** `BenchmarkConnectionChurn`: dolt `Connections` delta over 50 sequential sessions — pooling **off = 50** (1:1 churn), **on = 0** (50 hits, 1 dial).
- **Real CLI** vs a quiet dolt: **7.02 → 1.02** new dolt connections per `bd` invocation (~7×); functional correctness against a live managed dolt; zero pool reset/misalignment events. (The CLI residual ~1/invocation is per-process uow schema-init, not a pool defect; pure-pool ceiling is 0.)

See `docs/CONNECTION_POOLING.md` (design) and `docs/CONNECTION_POOLING_DEPLOYMENT.md` (deploy + validation numbers + orchestrator integration).

Refs gascity#1978.

🤖 Generated with [Claude Code](https://claude.com/claude-code)