### PR TITLE
docs(prime): note --parent for hierarchical bd create

### DIFF
--- a/cmd/bd/prime.go
+++ b/cmd/bd/prime.go
@@ -644,6 +644,7 @@ git status                  # Check changed files
 ### Creating & Updating
 - ` + "`bd create --title=\"Summary of this issue\" --description=\"Why this issue exists and what needs to be done\" --type=task|bug|feature --priority=2`" + ` - New issue
   - Priority: 0-4 or P0-P4 (0=critical, 2=medium, 4=backlog). NOT "high"/"medium"/"low"
+- ` + "`bd create ... --parent=<id>`" + ` - Hierarchical child (task under epic, subtask under task; inherits parent labels)
 - ` + "`bd update <id> --claim`" + ` - Claim work
 - ` + "`bd update <id> --assignee=username`" + ` - Assign to someone
 - ` + "`bd update <id> --title/--description/--notes/--design`" + ` - Update fields inline


### PR DESCRIPTION
## Summary

- `bd prime` lists every common `bd create` variant but never mentions `--parent`, so agents reading the brief at session start tend to flat-create issues and reach for `bd dep add` when they actually want hierarchy (epic → task, task → subtask). The flag has existed in `bd create` for a while (cmd/bd/create.go:907) — it just wasn't discoverable from the prime output.
- This adds a single-line bullet in the "Creating & Updating" section. Net change to `bd prime` output: +1 line.

```
- `bd create ... --parent=<id>` - Hierarchical child (task under epic, subtask under task; inherits parent labels)
```

Kept deliberately lean — `bd prime` is read on every session start and shouldn't bloat. No workflow-block changes, no MCP-context changes.

## Test plan

- [x] `bd prime` from a beads workspace — confirm the new bullet renders cleanly and the surrounding section is untouched
- [x] `make test` (or `go test -tags gms_pure_go ./cmd/bd/...`) — `cmd/bd/prime_test.go` has no assertions on the changed lines, so existing tests should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)