### PR TITLE
fix: create .beads/.gitignore after remote bootstrap

### DIFF
--- a/cmd/bd/bootstrap.go
+++ b/cmd/bd/bootstrap.go
@@ -690,7 +690,7 @@ func finalizeSyncedBootstrap(beadsDir, syncRemote string, cfg *configfile.Config
 		return fmt.Errorf("create config.yaml: %w", err)
 	}
 	if err := doctor.EnsureGitignoreForBeadsDir(beadsDir); err != nil {
-		return fmt.Errorf("create .beads/.gitignore: %w", err)
+		return fmt.Errorf("ensure .beads/.gitignore: %w", err)
 	}
 
 	// Persist sync.remote so subsequent fresh clones (and bd bootstrap

--- a/cmd/bd/bootstrap.go
+++ b/cmd/bd/bootstrap.go
@@ -13,6 +13,7 @@ import (
 
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/spf13/cobra"
+	"github.com/steveyegge/beads/cmd/bd/doctor"
 	"github.com/steveyegge/beads/cmd/bd/doctor/fix"
 	"github.com/steveyegge/beads/internal/beads"
 	"github.com/steveyegge/beads/internal/config"
@@ -687,6 +688,9 @@ func finalizeSyncedBootstrap(beadsDir, syncRemote string, cfg *configfile.Config
 
 	if err := createConfigYaml(beadsDir, false, ""); err != nil {
 		return fmt.Errorf("create config.yaml: %w", err)
+	}
+	if err := doctor.EnsureGitignoreForBeadsDir(beadsDir); err != nil {
+		return fmt.Errorf("create .beads/.gitignore: %w", err)
 	}
 
 	// Persist sync.remote so subsequent fresh clones (and bd bootstrap

--- a/cmd/bd/bootstrap_test.go
+++ b/cmd/bd/bootstrap_test.go
@@ -1214,6 +1214,17 @@ func TestFinalizeSyncedBootstrapWritesConfigFiles(t *testing.T) {
 	if !strings.Contains(yaml, syncRemote) {
 		t.Errorf("config.yaml does not contain sync remote URL %q:\n%s", syncRemote, yaml)
 	}
+
+	gitignoreBytes, err := os.ReadFile(filepath.Join(beadsDir, ".gitignore"))
+	if err != nil {
+		t.Fatalf(".beads/.gitignore missing after finalize: %v", err)
+	}
+	gitignore := string(gitignoreBytes)
+	for _, pattern := range []string{".local_version", "backup/", "export-state.json", "last-touched"} {
+		if !strings.Contains(gitignore, pattern) {
+			t.Errorf(".beads/.gitignore missing runtime pattern %q:\n%s", pattern, gitignore)
+		}
+	}
 }
 
 func TestFinalizeSyncedBootstrap_WorktreeStubDoesNotShadowTargetConfig(t *testing.T) {

--- a/cmd/bd/doctor/gitignore.go
+++ b/cmd/bd/doctor/gitignore.go
@@ -123,6 +123,8 @@ var requiredPatterns = []string{
 	"*.corrupt.backup/",
 	".beads-credential-key",
 	"proxied_server_client_info.json",
+	".local_version",
+	"backup/",
 }
 
 // CheckGitignore checks if .beads/.gitignore is up to date.
@@ -218,7 +220,7 @@ func FixGitignore(repoPath string) error {
 func missingGitignorePatterns(content string) []string {
 	var missing []string
 	for _, pattern := range requiredPatterns {
-		if !strings.Contains(content, pattern) {
+		if !containsGitignorePattern(content, pattern) {
 			missing = append(missing, pattern)
 		}
 	}

--- a/cmd/bd/doctor/gitignore.go
+++ b/cmd/bd/doctor/gitignore.go
@@ -143,13 +143,7 @@ func CheckGitignore(repoPath string) DoctorCheck {
 
 	// Check for required patterns
 	contentStr := string(content)
-	var missing []string
-	for _, pattern := range requiredPatterns {
-		if !strings.Contains(contentStr, pattern) {
-			missing = append(missing, pattern)
-		}
-	}
-
+	missing := missingGitignorePatterns(contentStr)
 	if len(missing) > 0 {
 		return DoctorCheck{
 			Name:    "Gitignore",
@@ -167,12 +161,37 @@ func CheckGitignore(repoPath string) DoctorCheck {
 	}
 }
 
+// EnsureGitignoreForBeadsDir writes the canonical .beads/.gitignore when it is
+// missing or outdated. It leaves an existing up-to-date file untouched so local
+// additions are preserved.
+func EnsureGitignoreForBeadsDir(beadsDir string) error {
+	gitignorePath := filepath.Join(beadsDir, ".gitignore")
+	content, err := os.ReadFile(gitignorePath) // #nosec G304 -- caller supplies the active .beads dir
+	if err == nil && len(missingGitignorePatterns(string(content))) == 0 {
+		return nil
+	}
+	return writeGitignoreTemplate(gitignorePath)
+}
+
 // FixGitignore updates .beads/.gitignore to the current template.
 // If a redirect exists, it writes to the redirect target's .gitignore instead.
 // repoPath is the project root directory.
 func FixGitignore(repoPath string) error {
 	gitignorePath := filepath.Join(ResolveBeadsDirForRepo(repoPath), ".gitignore")
+	return writeGitignoreTemplate(gitignorePath)
+}
 
+func missingGitignorePatterns(content string) []string {
+	var missing []string
+	for _, pattern := range requiredPatterns {
+		if !strings.Contains(content, pattern) {
+			missing = append(missing, pattern)
+		}
+	}
+	return missing
+}
+
+func writeGitignoreTemplate(gitignorePath string) error {
 	// If file exists and is read-only, fix permissions first
 	if info, err := os.Stat(gitignorePath); err == nil {
 		if info.Mode().Perm()&0200 == 0 { // No write permission for owner

--- a/cmd/bd/doctor/gitignore.go
+++ b/cmd/bd/doctor/gitignore.go
@@ -162,15 +162,49 @@ func CheckGitignore(repoPath string) DoctorCheck {
 }
 
 // EnsureGitignoreForBeadsDir writes the canonical .beads/.gitignore when it is
-// missing or outdated. It leaves an existing up-to-date file untouched so local
-// additions are preserved.
+// missing or outdated. If the file does not exist, it writes the full template.
+// If it exists but is outdated, it safely appends missing required patterns so
+// local additions are preserved.
 func EnsureGitignoreForBeadsDir(beadsDir string) error {
 	gitignorePath := filepath.Join(beadsDir, ".gitignore")
+
 	content, err := os.ReadFile(gitignorePath) // #nosec G304 -- caller supplies the active .beads dir
-	if err == nil && len(missingGitignorePatterns(string(content))) == 0 {
+	if os.IsNotExist(err) {
+		return writeGitignoreTemplate(gitignorePath)
+	}
+	if err != nil {
+		return fmt.Errorf("read .beads/.gitignore: %w", err)
+	}
+
+	missing := missingGitignorePatterns(string(content))
+	if len(missing) == 0 {
 		return nil
 	}
-	return writeGitignoreTemplate(gitignorePath)
+
+	if info, err := os.Stat(gitignorePath); err == nil {
+		if info.Mode().Perm()&0200 == 0 {
+			if err := os.Chmod(gitignorePath, 0600); err != nil {
+				return fmt.Errorf("chmod .beads/.gitignore: %w", err)
+			}
+		}
+	}
+
+	existingContent := string(content)
+	newContent := existingContent
+	if len(newContent) > 0 && !strings.HasSuffix(newContent, "\n") {
+		newContent += "\n"
+	}
+
+	newContent += "\n# Added by bd (missing required patterns)\n"
+	for _, pattern := range missing {
+		newContent += pattern + "\n"
+	}
+
+	if err := os.WriteFile(gitignorePath, []byte(newContent), 0600); err != nil {
+		return fmt.Errorf("ensure .beads/.gitignore: %w", err)
+	}
+
+	return nil
 }
 
 // FixGitignore updates .beads/.gitignore to the current template.

--- a/cmd/bd/doctor/gitignore_test.go
+++ b/cmd/bd/doctor/gitignore_test.go
@@ -357,6 +357,48 @@ daemon.log
 	}
 }
 
+func TestEnsureGitignoreForBeadsDir_AppendsMissingRuntimePatterns(t *testing.T) {
+	tmpDir := t.TempDir()
+	beadsDir := filepath.Join(tmpDir, ".beads")
+	if err := os.Mkdir(beadsDir, 0750); err != nil {
+		t.Fatal(err)
+	}
+
+	var stalePatterns []string
+	for _, pattern := range requiredPatterns {
+		if pattern == ".local_version" || pattern == "backup/" {
+			continue
+		}
+		stalePatterns = append(stalePatterns, pattern)
+	}
+	initialContent := "# Local additions\ncustom-local/\n" + strings.Join(stalePatterns, "\n") + "\n"
+	gitignorePath := filepath.Join(beadsDir, ".gitignore")
+	if err := os.WriteFile(gitignorePath, []byte(initialContent), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := EnsureGitignoreForBeadsDir(beadsDir); err != nil {
+		t.Fatalf("EnsureGitignoreForBeadsDir failed: %v", err)
+	}
+
+	content, err := os.ReadFile(gitignorePath)
+	if err != nil {
+		t.Fatalf("read .beads/.gitignore: %v", err)
+	}
+	contentStr := string(content)
+	if !strings.HasPrefix(contentStr, initialContent) {
+		t.Fatalf("existing .gitignore content was not preserved:\n%s", contentStr)
+	}
+	for _, pattern := range []string{".local_version", "backup/"} {
+		if !containsGitignorePattern(contentStr, pattern) {
+			t.Errorf("expected appended pattern %q in .beads/.gitignore:\n%s", pattern, contentStr)
+		}
+	}
+	if missing := missingGitignorePatterns(contentStr); len(missing) > 0 {
+		t.Fatalf("expected .beads/.gitignore to be complete after ensure, missing: %s", strings.Join(missing, ", "))
+	}
+}
+
 func TestFixGitignore_PartialPatterns(t *testing.T) {
 	tests := []struct {
 		name              string
@@ -2371,7 +2413,8 @@ func TestContainsGitignorePattern(t *testing.T) {
 		{"# .dolt/ is ignored\n", ".dolt/", false}, // comment, not pattern
 		{"  .dolt/  \n", ".dolt/", true},           // whitespace trimmed
 		{"", ".dolt/", false},
-		{".dolt/foo\n", ".dolt/", false}, // not exact match
+		{".dolt/foo\n", ".dolt/", false},    // not exact match
+		{"embeddeddolt/\n", "dolt/", false}, // substring must not satisfy exact pattern
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

Remote sync bootstrap now writes the standard `.beads/.gitignore` during finalization, alongside `metadata.json` and `config.yaml`.

## Why

Fresh clones that recover beads data with `bd bootstrap` should land in the same git hygiene state as `bd init`. Before this change, the sync-bootstrap path finalized enough config to reopen the cloned Dolt database, but it did not create `.beads/.gitignore`. That left normal local runtime files such as `.local_version`, `backup/`, `export-state.json`, and `last-touched` visible as untracked files after normal `bd` use.

This belongs in bootstrap because bootstrap is the recovery/fresh-clone entry point for existing beads data. Users should not need to know that `bd doctor --fix` is a second cleanup step after a successful clone.

## Changes

- Added `doctor.EnsureGitignoreForBeadsDir`, which writes the canonical `.beads/.gitignore` when it is missing or outdated.
- Kept existing up-to-date `.beads/.gitignore` files untouched, preserving local additions.
- Called that helper from `finalizeSyncedBootstrap`.
- Extended the sync-bootstrap finalization regression test to assert runtime ignore patterns are present.

Fixes #4308.

## Validation

- `go test -tags gms_pure_go ./cmd/bd -run 'TestFinalizeSyncedBootstrapWritesConfigFiles|TestFinalizeSyncedBootstrapIsIdempotent' -count=1`
- `go test -tags gms_pure_go ./cmd/bd/doctor -run 'TestCheckGitignore|TestGitignoreTemplate' -count=1`
- `go test -tags gms_pure_go ./cmd/bd -run '^$' -count=1`
- `go test -tags gms_pure_go ./cmd/bd/doctor -count=1`
- Queued local slow validation for `mybd-qagg`: `make test` at `004e4e28cce5494d4d12afc1642dacd0d9d4016a`
