### PR TITLE
fix(cli): render markdown with terminal capability gates (#3881)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,8 @@ BUILD_DIR := .
 GIT_BUILD := $(shell git rev-parse --short HEAD)
 ifeq ($(OS),Windows_NT)
 INSTALL_DIR := $(USERPROFILE)/.local/bin
+WINDOWS_MINGW_BIN ?= /c/ProgramData/mingw64/mingw64/bin
+WINDOWS_MINGW_GCC := $(WINDOWS_MINGW_BIN)/gcc.exe
 else
 INSTALL_DIR := $(HOME)/.local/bin
 endif
@@ -29,7 +31,8 @@ endif
 # Windows notes:
 #   - ICU is NOT required. go-icu-regex has a pure-Go fallback (regex_windows.go)
 #     and gms_pure_go tag tells go-mysql-server to use pure-Go regex too.
-#   - CGO_ENABLED=1 needs a C compiler (MinGW/MSYS2) but does NOT need ICU.
+#   - CGO_ENABLED=1 needs MinGW-w64/MSYS2 gcc but does NOT need ICU.
+#     MSVC link.exe is not a supported alternative for Go's Windows cgo path.
 export CGO_ENABLED := 1
 
 # When go.mod requires a newer Go version than the locally installed one,
@@ -53,7 +56,17 @@ REGRESSION_TIMEOUT ?= 20m
 build:
 	@echo "Building bd..."
 ifeq ($(OS),Windows_NT)
-	go build -tags "$(BUILD_TAGS)" -ldflags="-X main.Build=$(GIT_BUILD)" -o $(BUILD_DIR)/bd.exe ./cmd/bd
+	@if command -v gcc >/dev/null 2>&1; then \
+		CC=$${CC:-gcc} go build -tags "$(BUILD_TAGS)" -ldflags="-X main.Build=$(GIT_BUILD)" -o $(BUILD_DIR)/bd.exe ./cmd/bd; \
+	elif [ -x "$(WINDOWS_MINGW_GCC)" ]; then \
+		echo "Using MinGW-w64 from $(WINDOWS_MINGW_BIN)"; \
+		PATH="$(WINDOWS_MINGW_BIN):$$PATH" CC=gcc go build -tags "$(BUILD_TAGS)" -ldflags="-X main.Build=$(GIT_BUILD)" -o $(BUILD_DIR)/bd.exe ./cmd/bd; \
+	else \
+		echo "ERROR: Windows CGO builds require MinGW-w64 gcc." >&2; \
+		echo "       Visual Studio clang/MSVC link.exe is not supported by Go cgo for this build." >&2; \
+		echo "       Install MinGW-w64 and ensure gcc.exe is on PATH, or set WINDOWS_MINGW_BIN=/path/to/mingw/bin." >&2; \
+		exit 1; \
+	fi
 else
 	go build -tags "$(BUILD_TAGS)" -ldflags="-X main.Build=$(GIT_BUILD)" -o $(BUILD_DIR)/bd ./cmd/bd
 ifeq ($(shell uname),Darwin)

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ ifeq ($(OS),Windows_NT)
 INSTALL_DIR := $(USERPROFILE)/.local/bin
 WINDOWS_MINGW_BIN ?= /c/ProgramData/mingw64/mingw64/bin
 WINDOWS_MINGW_GCC := $(WINDOWS_MINGW_BIN)/gcc.exe
+WINDOWS_CGO_BINS ?= $(WINDOWS_MINGW_BIN) /c/msys64/clangarm64/bin /c/msys64/ucrt64/bin /c/msys64/mingw64/bin /c/msys64/clang64/bin
 else
 INSTALL_DIR := $(HOME)/.local/bin
 endif
@@ -31,8 +32,9 @@ endif
 # Windows notes:
 #   - ICU is NOT required. go-icu-regex has a pure-Go fallback (regex_windows.go)
 #     and gms_pure_go tag tells go-mysql-server to use pure-Go regex too.
-#   - CGO_ENABLED=1 needs MinGW-w64/MSYS2 gcc but does NOT need ICU.
-#     MSVC link.exe is not a supported alternative for Go's Windows cgo path.
+#   - CGO_ENABLED=1 needs a GCC-compatible Windows CGO compiler but does NOT
+#     need ICU. Supported local toolchains include MinGW-w64/MSYS2 gcc and
+#     MSYS2 clang/LLVM targeting windows-gnu.
 export CGO_ENABLED := 1
 
 # When go.mod requires a newer Go version than the locally installed one,
@@ -56,15 +58,29 @@ REGRESSION_TIMEOUT ?= 20m
 build:
 	@echo "Building bd..."
 ifeq ($(OS),Windows_NT)
-	@if command -v gcc >/dev/null 2>&1; then \
-		CC=$${CC:-gcc} go build -tags "$(BUILD_TAGS)" -ldflags="-X main.Build=$(GIT_BUILD)" -o $(BUILD_DIR)/bd.exe ./cmd/bd; \
-	elif [ -x "$(WINDOWS_MINGW_GCC)" ]; then \
-		echo "Using MinGW-w64 from $(WINDOWS_MINGW_BIN)"; \
-		PATH="$(WINDOWS_MINGW_BIN):$$PATH" CC=gcc go build -tags "$(BUILD_TAGS)" -ldflags="-X main.Build=$(GIT_BUILD)" -o $(BUILD_DIR)/bd.exe ./cmd/bd; \
+	@if [ -n "$$CC" ]; then \
+		echo "Using CC=$$CC"; \
+		go build -tags "$(BUILD_TAGS)" -ldflags="-X main.Build=$(GIT_BUILD)" -o $(BUILD_DIR)/bd.exe ./cmd/bd; \
+	elif command -v gcc >/dev/null 2>&1; then \
+		CC=gcc go build -tags "$(BUILD_TAGS)" -ldflags="-X main.Build=$(GIT_BUILD)" -o $(BUILD_DIR)/bd.exe ./cmd/bd; \
+	elif command -v clang >/dev/null 2>&1 && clang -dumpmachine 2>/dev/null | grep -qi 'windows.*gnu'; then \
+		CC=clang go build -tags "$(BUILD_TAGS)" -ldflags="-X main.Build=$(GIT_BUILD)" -o $(BUILD_DIR)/bd.exe ./cmd/bd; \
 	else \
-		echo "ERROR: Windows CGO builds require MinGW-w64 gcc." >&2; \
-		echo "       Visual Studio clang/MSVC link.exe is not supported by Go cgo for this build." >&2; \
-		echo "       Install MinGW-w64 and ensure gcc.exe is on PATH, or set WINDOWS_MINGW_BIN=/path/to/mingw/bin." >&2; \
+		for bin in $(WINDOWS_CGO_BINS); do \
+			if [ -x "$$bin/gcc.exe" ]; then \
+				echo "Using Windows CGO gcc from $$bin"; \
+				PATH="$$bin:$$PATH" CC=gcc go build -tags "$(BUILD_TAGS)" -ldflags="-X main.Build=$(GIT_BUILD)" -o $(BUILD_DIR)/bd.exe ./cmd/bd; \
+				exit $$?; \
+			fi; \
+			if [ -x "$$bin/clang.exe" ] && "$$bin/clang.exe" -dumpmachine 2>/dev/null | grep -qi 'windows.*gnu'; then \
+				echo "Using Windows CGO clang from $$bin"; \
+				PATH="$$bin:$$PATH" CC=clang go build -tags "$(BUILD_TAGS)" -ldflags="-X main.Build=$(GIT_BUILD)" -o $(BUILD_DIR)/bd.exe ./cmd/bd; \
+				exit $$?; \
+			fi; \
+		done; \
+		echo "ERROR: Windows CGO builds require a GCC-compatible compiler." >&2; \
+		echo "       Install MinGW-w64/MSYS2 gcc or MSYS2 clang/LLVM targeting windows-gnu." >&2; \
+		echo "       Put it on PATH, set CC, or set WINDOWS_CGO_BINS=/path/to/toolchain/bin." >&2; \
 		exit 1; \
 	fi
 else

--- a/docs/INSTALLING.md
+++ b/docs/INSTALLING.md
@@ -208,15 +208,17 @@ $env:CGO_ENABLED="0"; go install github.com/steveyegge/beads/cmd/bd@latest
 
 This produces a server-mode-only binary with no C compiler requirement — the fastest path to a working `bd` on Windows.
 
-**Via go install** (embedded-capable, needs MinGW):
+**Via go install** (embedded-capable, needs a Windows CGO toolchain):
 ```pwsh
 $env:CGO_ENABLED="1"; $env:GOFLAGS="-tags=gms_pure_go"; go install github.com/steveyegge/beads/cmd/bd@latest
 ```
 
-Requires MinGW-w64 gcc on your PATH. ICU is **not** required — `gms_pure_go` selects Go's stdlib `regexp`.
-Visual Studio clang/MSVC `link.exe` is not a supported substitute for this
-Windows CGO build; Go's Windows CGO path expects a MinGW-w64 style GCC
-toolchain.
+Requires a GCC-compatible Windows CGO compiler on your PATH, such as
+MinGW-w64/MSYS2 `gcc` or MSYS2 LLVM `clang` targeting `windows-gnu`
+(`clang64`/`clangarm64`). ICU is **not** required — `gms_pure_go` selects
+Go's stdlib `regexp`. Visual Studio `cl.exe` by itself is not enough because
+Go passes GCC-style CGO flags; use a MinGW/MSYS2 toolchain, set `CC`, or set
+`WINDOWS_CGO_BINS` when building from source.
 
 **From source**:
 ```pwsh

--- a/docs/INSTALLING.md
+++ b/docs/INSTALLING.md
@@ -214,6 +214,9 @@ $env:CGO_ENABLED="1"; $env:GOFLAGS="-tags=gms_pure_go"; go install github.com/st
 ```
 
 Requires MinGW-w64 gcc on your PATH. ICU is **not** required — `gms_pure_go` selects Go's stdlib `regexp`.
+Visual Studio clang/MSVC `link.exe` is not a supported substitute for this
+Windows CGO build; Go's Windows CGO path expects a MinGW-w64 style GCC
+toolchain.
 
 **From source**:
 ```pwsh

--- a/internal/ui/terminal.go
+++ b/internal/ui/terminal.go
@@ -3,6 +3,8 @@ package ui
 
 import (
 	"os"
+	"strconv"
+	"strings"
 
 	"golang.org/x/term"
 )
@@ -25,6 +27,7 @@ func IsStderrTerminal() bool {
 //   - NO_COLOR: https://no-color.org/ - disables color if set
 //   - CLICOLOR=0: disables color
 //   - CLICOLOR_FORCE: forces color even in non-TTY
+//   - TERM=dumb: disables color unless explicitly forced
 //   - Falls back to TTY detection
 func ShouldUseColor() bool {
 	// Git hook context - disable color to prevent termenv OSC 11 terminal
@@ -49,8 +52,80 @@ func ShouldUseColor() bool {
 		return true
 	}
 
+	// TERM is a terminfo terminal type string (for example "xterm-256color",
+	// "xterm-kitty", "screen-256color", "tmux-256color", or "vt100").
+	// "dumb" explicitly means ANSI controls are unsupported.
+	if strings.EqualFold(os.Getenv("TERM"), "dumb") {
+		return false
+	}
+
 	// Default: use color only if stdout is a TTY
 	return IsTerminal()
+}
+
+// ShouldUseHyperlinks determines if OSC 8 terminal hyperlinks should be emitted.
+// OSC 8 support is not implied by ANSI color support, so this intentionally uses
+// a narrower allowlist plus FORCE_HYPERLINK for users who know their terminal.
+func ShouldUseHyperlinks() bool {
+	return shouldUseHyperlinks(IsTerminal())
+}
+
+// shouldUseHyperlinks is the testable implementation behind ShouldUseHyperlinks.
+// It takes the stdout TTY result as a parameter so tests can cover known terminal
+// capability markers (for example Windows Terminal's WT_SESSION) without needing
+// to run inside those terminals.
+func shouldUseHyperlinks(stdoutIsTerminal bool) bool {
+	if os.Getenv("BD_GIT_HOOK") == "1" {
+		return false
+	}
+	if os.Getenv("NO_COLOR") != "" {
+		return false
+	}
+	if os.Getenv("CLICOLOR") == "0" {
+		return false
+	}
+	// TERM is a terminfo terminal type string (for example "xterm-256color",
+	// "xterm-kitty", "screen-256color", "tmux-256color", or "vt100"), not a
+	// boolean toggle. "dumb" explicitly means OSC 8 hyperlinks are unsupported.
+	if strings.EqualFold(os.Getenv("TERM"), "dumb") {
+		return false
+	}
+	if force := os.Getenv("FORCE_HYPERLINK"); force != "" && force != "0" {
+		return true
+	}
+	if !stdoutIsTerminal {
+		return false
+	}
+
+	if os.Getenv("WT_SESSION") != "" ||
+		os.Getenv("KITTY_WINDOW_ID") != "" ||
+		os.Getenv("WEZTERM_EXECUTABLE") != "" ||
+		os.Getenv("KONSOLE_VERSION") != "" ||
+		os.Getenv("DOMTERM") != "" ||
+		os.Getenv("GHOSTTY_RESOURCES_DIR") != "" {
+		return true
+	}
+
+	switch strings.ToLower(os.Getenv("TERM_PROGRAM")) {
+	case "iterm.app", "wezterm", "vscode", "apple_terminal", "tabby", "hyper", "ghostty":
+		return true
+	}
+
+	termName := strings.ToLower(os.Getenv("TERM"))
+	if strings.Contains(termName, "xterm-kitty") ||
+		strings.Contains(termName, "wezterm") ||
+		strings.Contains(termName, "foot") ||
+		strings.Contains(termName, "contour") ||
+		strings.Contains(termName, "ghostty") {
+		return true
+	}
+
+	if vte := os.Getenv("VTE_VERSION"); vte != "" {
+		version, err := strconv.Atoi(vte)
+		return err == nil && version >= 5000
+	}
+
+	return false
 }
 
 // ShouldUseEmoji determines if emoji decorations should be used.

--- a/internal/ui/terminal_test.go
+++ b/internal/ui/terminal_test.go
@@ -10,10 +10,12 @@ func TestShouldUseColor(t *testing.T) {
 	origNoColor := os.Getenv("NO_COLOR")
 	origCliColor := os.Getenv("CLICOLOR")
 	origCliColorForce := os.Getenv("CLICOLOR_FORCE")
+	origTerm := os.Getenv("TERM")
 	defer func() {
 		setEnv("NO_COLOR", origNoColor)
 		setEnv("CLICOLOR", origCliColor)
 		setEnv("CLICOLOR_FORCE", origCliColorForce)
+		setEnv("TERM", origTerm)
 	}()
 
 	tests := []struct {
@@ -21,6 +23,7 @@ func TestShouldUseColor(t *testing.T) {
 		noColor         string
 		cliColor        string
 		cliColorForce   string
+		term            string
 		wantColor       bool
 		skipTTYDepCheck bool // Some tests don't depend on TTY state
 	}{
@@ -51,6 +54,19 @@ func TestShouldUseColor(t *testing.T) {
 			skipTTYDepCheck: true,
 		},
 		{
+			name:            "TERM dumb disables color",
+			term:            "dumb",
+			wantColor:       false,
+			skipTTYDepCheck: true,
+		},
+		{
+			name:            "CLICOLOR_FORCE overrides TERM dumb",
+			cliColorForce:   "1",
+			term:            "dumb",
+			wantColor:       true,
+			skipTTYDepCheck: true,
+		},
+		{
 			name:            "NO_COLOR takes precedence over CLICOLOR_FORCE",
 			noColor:         "1",
 			cliColorForce:   "1",
@@ -65,6 +81,7 @@ func TestShouldUseColor(t *testing.T) {
 			os.Unsetenv("NO_COLOR")
 			os.Unsetenv("CLICOLOR")
 			os.Unsetenv("CLICOLOR_FORCE")
+			os.Unsetenv("TERM")
 
 			// Set test-specific vars
 			if tt.noColor != "" {
@@ -76,12 +93,83 @@ func TestShouldUseColor(t *testing.T) {
 			if tt.cliColorForce != "" {
 				os.Setenv("CLICOLOR_FORCE", tt.cliColorForce)
 			}
+			if tt.term != "" {
+				os.Setenv("TERM", tt.term)
+			}
 
 			got := ShouldUseColor()
 			if tt.skipTTYDepCheck && got != tt.wantColor {
 				t.Errorf("ShouldUseColor() = %v, want %v", got, tt.wantColor)
 			}
 		})
+	}
+}
+
+func TestShouldUseHyperlinks(t *testing.T) {
+	envKeys := []string{
+		"BD_GIT_HOOK",
+		"NO_COLOR",
+		"CLICOLOR",
+		"FORCE_HYPERLINK",
+		"TERM",
+		"TERM_PROGRAM",
+		"WT_SESSION",
+	}
+	orig := map[string]string{}
+	for _, key := range envKeys {
+		orig[key] = os.Getenv(key)
+		os.Unsetenv(key)
+	}
+	defer func() {
+		for _, key := range envKeys {
+			setEnv(key, orig[key])
+		}
+	}()
+
+	if ShouldUseHyperlinks() {
+		t.Fatal("hyperlinks should be disabled for non-TTY output by default")
+	}
+
+	os.Setenv("FORCE_HYPERLINK", "1")
+	if !ShouldUseHyperlinks() {
+		t.Fatal("FORCE_HYPERLINK should enable hyperlinks")
+	}
+
+	os.Setenv("NO_COLOR", "1")
+	if ShouldUseHyperlinks() {
+		t.Fatal("NO_COLOR should disable hyperlinks even when forced")
+	}
+
+	os.Unsetenv("NO_COLOR")
+	os.Setenv("TERM", "dumb")
+	if ShouldUseHyperlinks() {
+		t.Fatal("TERM=dumb should disable hyperlinks even when forced")
+	}
+
+	os.Setenv("TERM", "xterm-256color")
+	os.Setenv("BD_GIT_HOOK", "1")
+	if ShouldUseHyperlinks() {
+		t.Fatal("BD_GIT_HOOK should disable hyperlinks")
+	}
+
+	os.Unsetenv("BD_GIT_HOOK")
+	os.Unsetenv("FORCE_HYPERLINK")
+	os.Setenv("TERM", "xterm-256color")
+	os.Setenv("WT_SESSION", "windows-terminal-session")
+	if !shouldUseHyperlinks(true) {
+		t.Fatal("WT_SESSION should enable hyperlinks for Windows Terminal when stdout is a TTY")
+	}
+
+	os.Unsetenv("WT_SESSION")
+	os.Setenv("TERM_PROGRAM", "vscode")
+	if !shouldUseHyperlinks(true) {
+		t.Fatal("TERM_PROGRAM=vscode should enable hyperlinks when stdout is a TTY")
+	}
+
+	os.Unsetenv("TERM_PROGRAM")
+	os.Setenv("TERM", "xterm-kitty")
+	if !shouldUseHyperlinks(true) {
+		t.Fatal("xterm-kitty should enable hyperlinks when stdout is a TTY")
 	}
 }
 

--- a/internal/uimd/markdown.go
+++ b/internal/uimd/markdown.go
@@ -7,20 +7,20 @@ package uimd
 
 import (
 	"os"
+	"strings"
 
 	"charm.land/glamour/v2"
+	"charm.land/glamour/v2/styles"
+	xansi "github.com/charmbracelet/x/ansi"
 	"github.com/steveyegge/beads/internal/ui"
 	"golang.org/x/term"
 )
 
-// RenderMarkdown renders markdown text using glamour's auto-detected terminal style.
+// RenderMarkdown renders markdown text using glamour's terminal style.
 // Returns the rendered markdown or the original text if rendering fails.
 // Word wraps at terminal width (or 80 columns if width can't be detected).
 func RenderMarkdown(markdown string) string {
 	if ui.IsAgentMode() {
-		return markdown
-	}
-	if !ui.ShouldUseColor() {
 		return markdown
 	}
 
@@ -34,10 +34,27 @@ func RenderMarkdown(markdown string) string {
 		wrapWidth = maxReadableWidth
 	}
 
-	renderer, err := glamour.NewTermRenderer(
-		// No style is specified so glamour can auto-detect light/dark terminals.
+	// Markdown rendering and terminal escape emission are separate concerns.
+	// Even when ANSI color is unavailable, Glamour's notty style still improves
+	// structure for tables, lists, wrapping, and links. ANSI SGR and OSC 8 are
+	// stripped below unless their specific terminal capability checks pass.
+	useANSI := ui.ShouldUseColor()
+	useHyperlinks := ui.ShouldUseHyperlinks()
+	options := []glamour.TermRendererOption{
 		glamour.WithWordWrap(wrapWidth),
-	)
+		glamour.WithPreservedNewLines(),
+		glamour.WithTableWrap(false),
+	}
+	if useANSI {
+		options = append(options,
+			glamour.WithEnvironmentConfig(),
+			glamour.WithChromaFormatter("terminal256"),
+		)
+	} else {
+		options = append(options, glamour.WithStandardStyle(styles.NoTTYStyle))
+	}
+
+	renderer, err := glamour.NewTermRenderer(options...)
 	if err != nil {
 		return markdown
 	}
@@ -47,5 +64,56 @@ func RenderMarkdown(markdown string) string {
 		return markdown
 	}
 
+	if !useHyperlinks {
+		rendered = stripOSC8Hyperlinks(rendered)
+	}
+	if !useANSI && !useHyperlinks {
+		rendered = xansi.Strip(rendered)
+	}
+
 	return rendered
+}
+
+// stripOSC8Hyperlinks removes only OSC 8 hyperlink open/close sequences.
+// Glamour emits OSC 8 whenever it renders links, but OSC 8 support is separate
+// from ANSI SGR color support. We keep regular ANSI styling intact when color is
+// supported and only remove hyperlinks when ShouldUseHyperlinks says they are
+// unsafe for the current terminal.
+func stripOSC8Hyperlinks(s string) string {
+	const osc8 = "\x1b]8;"
+	if !strings.Contains(s, osc8) {
+		return s
+	}
+
+	var out strings.Builder
+	out.Grow(len(s))
+	for i := 0; i < len(s); {
+		if strings.HasPrefix(s[i:], osc8) {
+			if end := oscSequenceEnd(s, i+len(osc8)); end > i {
+				i = end
+				continue
+			}
+		}
+		out.WriteByte(s[i])
+		i++
+	}
+	return out.String()
+}
+
+// oscSequenceEnd returns the byte index after an OSC control sequence.
+// OSC strings can end with BEL or ST (ESC \); this helper keeps the stripping
+// logic local to OSC 8 handling instead of using a broad ANSI stripper that would
+// also remove color/style escapes we may still want to preserve.
+func oscSequenceEnd(s string, start int) int {
+	for i := start; i < len(s); i++ {
+		switch s[i] {
+		case '\a':
+			return i + 1
+		case '\x1b':
+			if i+1 < len(s) && s[i+1] == '\\' {
+				return i + 2
+			}
+		}
+	}
+	return -1
 }

--- a/internal/uimd/markdown_test.go
+++ b/internal/uimd/markdown_test.go
@@ -1,0 +1,141 @@
+package uimd
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestRenderMarkdownStripsEscapesWhenANSIUnsupported(t *testing.T) {
+	withMarkdownEnv(t, map[string]string{
+		"NO_COLOR":        "1",
+		"TERM":            "dumb",
+		"CLICOLOR_FORCE":  "",
+		"FORCE_HYPERLINK": "",
+		"BD_AGENT_MODE":   "",
+		"CLAUDE_CODE":     "",
+	})
+
+	out := RenderMarkdown("# Title\n\n[link](https://example.com)\n\n| A | B |\n| - | - |\n| 1 | 2 |\n")
+	if strings.Contains(out, "\x1b[") || strings.Contains(out, "\x1b]8;") {
+		t.Fatalf("expected no terminal escapes when ANSI is unsupported, got %q", out)
+	}
+	if !strings.Contains(out, "Title") || !strings.Contains(out, "example.com") {
+		t.Fatalf("expected rendered markdown content, got %q", out)
+	}
+}
+
+func TestRenderMarkdownStripsOSC8WhenHyperlinksUnsupported(t *testing.T) {
+	withMarkdownEnv(t, map[string]string{
+		"NO_COLOR":        "",
+		"TERM":            "xterm-256color",
+		"CLICOLOR_FORCE":  "1",
+		"FORCE_HYPERLINK": "",
+		"BD_AGENT_MODE":   "",
+		"CLAUDE_CODE":     "",
+	})
+
+	out := RenderMarkdown("[link](https://example.com)")
+	if strings.Contains(out, "\x1b]8;") {
+		t.Fatalf("expected OSC 8 hyperlinks to be stripped, got %q", out)
+	}
+	if !strings.Contains(out, "\x1b[") {
+		t.Fatalf("expected ANSI styling when color is forced, got %q", out)
+	}
+}
+
+func TestRenderMarkdownKeepsOSC8WhenHyperlinksSupported(t *testing.T) {
+	withMarkdownEnv(t, map[string]string{
+		"NO_COLOR":        "",
+		"TERM":            "xterm-256color",
+		"CLICOLOR_FORCE":  "1",
+		"FORCE_HYPERLINK": "1",
+		"BD_AGENT_MODE":   "",
+		"CLAUDE_CODE":     "",
+	})
+
+	out := RenderMarkdown("[link](https://example.com)")
+	if !strings.Contains(out, "\x1b]8;") {
+		t.Fatalf("expected OSC 8 hyperlink escapes, got %q", out)
+	}
+}
+
+func TestRenderMarkdownCanKeepOSC8WithoutANSIColor(t *testing.T) {
+	withMarkdownEnv(t, map[string]string{
+		"NO_COLOR":        "",
+		"TERM":            "xterm-256color",
+		"CLICOLOR_FORCE":  "",
+		"FORCE_HYPERLINK": "1",
+		"BD_AGENT_MODE":   "",
+		"CLAUDE_CODE":     "",
+	})
+
+	out := RenderMarkdown("[link](https://example.com)")
+	if !strings.Contains(out, "\x1b]8;") {
+		t.Fatalf("expected OSC 8 hyperlink escapes, got %q", out)
+	}
+	if strings.Contains(out, "\x1b[") {
+		t.Fatalf("expected no ANSI SGR styling, got %q", out)
+	}
+}
+
+func TestRenderMarkdownReturnsRawMarkdownInAgentMode(t *testing.T) {
+	withMarkdownEnv(t, map[string]string{
+		"NO_COLOR":        "",
+		"TERM":            "xterm-256color",
+		"CLICOLOR_FORCE":  "1",
+		"FORCE_HYPERLINK": "1",
+		"BD_AGENT_MODE":   "1",
+		"CLAUDE_CODE":     "",
+	})
+
+	input := "# Title\n\n[link](https://example.com)"
+	if out := RenderMarkdown(input); out != input {
+		t.Fatalf("agent mode should return raw markdown, got %q", out)
+	}
+}
+
+func withMarkdownEnv(t *testing.T, values map[string]string) {
+	t.Helper()
+
+	keys := []string{
+		"BD_GIT_HOOK",
+		"NO_COLOR",
+		"CLICOLOR",
+		"CLICOLOR_FORCE",
+		"FORCE_HYPERLINK",
+		"TERM",
+		"TERM_PROGRAM",
+		"WT_SESSION",
+		"KITTY_WINDOW_ID",
+		"WEZTERM_EXECUTABLE",
+		"KONSOLE_VERSION",
+		"DOMTERM",
+		"GHOSTTY_RESOURCES_DIR",
+		"VTE_VERSION",
+		"BD_AGENT_MODE",
+		"CLAUDE_CODE",
+	}
+	orig := make(map[string]string, len(keys))
+	for _, key := range keys {
+		orig[key] = os.Getenv(key)
+		os.Unsetenv(key)
+	}
+	t.Cleanup(func() {
+		for _, key := range keys {
+			if orig[key] == "" {
+				os.Unsetenv(key)
+			} else {
+				os.Setenv(key, orig[key])
+			}
+		}
+	})
+
+	for key, value := range values {
+		if value == "" {
+			os.Unsetenv(key)
+		} else {
+			os.Setenv(key, value)
+		}
+	}
+}


### PR DESCRIPTION
Fixes the existing Glamour formatting for ANSI-Capable terminals.

## What

- checks the terminal if ANSI / OSC8 is supported
- if supported, renders the output using the ANSI / OSC8 formatting using Glamour

## Why

Fixes #3881 

## Verification

- Unit tests where implemented
