### PR TITLE
fix(storage): set updated_at explicitly in is_blocked recompute (GH#4298)

### DIFF
--- a/internal/storage/dolt/is_blocked_test.go
+++ b/internal/storage/dolt/is_blocked_test.go
@@ -2,7 +2,9 @@ package dolt
 
 import (
 	"context"
+	"database/sql"
 	"testing"
+	"time"
 
 	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/types"
@@ -17,6 +19,69 @@ func getIsBlocked(t *testing.T, ctx context.Context, store *DoltStore, table, id
 		t.Fatalf("read is_blocked from %s for %s: %v", table, id, err)
 	}
 	return b != 0
+}
+
+// updatedMinusCreatedSeconds returns the stored updated_at minus created_at, in
+// seconds, computed in SQL so the comparison is on the raw DATETIME numerals and
+// independent of any Go-side timezone handling.
+func updatedMinusCreatedSeconds(t *testing.T, ctx context.Context, store *DoltStore, table, id string) int64 {
+	t.Helper()
+	var diff sql.NullInt64
+	//nolint:gosec // G201: table is a hardcoded "issues" or "wisps" from callers.
+	err := store.db.QueryRowContext(ctx,
+		"SELECT TIMESTAMPDIFF(SECOND, created_at, updated_at) FROM "+table+" WHERE id = ?", id).Scan(&diff)
+	if err != nil {
+		t.Fatalf("read created_at/updated_at skew from %s for %s: %v", table, id, err)
+	}
+	if !diff.Valid {
+		t.Fatalf("created_at/updated_at skew for %s is NULL", id)
+	}
+	return diff.Int64
+}
+
+// TestIsBlocked_RecomputeWritesUTCUpdatedAt guards GH#4298: the is_blocked
+// recompute must write updated_at as true UTC, consistent with created_at.
+// Before the fix the recompute UPDATE omitted updated_at and relied on the
+// schema's ON UPDATE CURRENT_TIMESTAMP, which the embedded Dolt driver fills
+// with local wall-clock time mislabeled as UTC — so updated_at landed off by
+// the machine's UTC offset. A non-UTC local zone is forced here so the
+// regression is deterministic regardless of host/CI timezone.
+func TestIsBlocked_RecomputeWritesUTCUpdatedAt(t *testing.T) {
+	origLocal := time.Local
+	time.Local = time.FixedZone("TEST-0700", -7*60*60)
+	defer func() { time.Local = origLocal }()
+
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	createPerm(t, ctx, store, "isb-utc-blocker")
+	createPerm(t, ctx, store, "isb-utc-blocked")
+
+	// Adding a blocks dependency runs the is_blocked recompute over the depender.
+	if err := store.AddDependency(ctx, &types.Dependency{
+		IssueID: "isb-utc-blocked", DependsOnID: "isb-utc-blocker", Type: types.DepBlocks,
+	}, "tester"); err != nil {
+		t.Fatalf("AddDependency: %v", err)
+	}
+	if !getIsBlocked(t, ctx, store, "issues", "isb-utc-blocked") {
+		t.Fatal("expected is_blocked = 1 after adding blocks dep")
+	}
+
+	// created_at is written as explicit UTC; a correctly-UTC updated_at from the
+	// recompute (which fires in the same wall-clock moment) must be within a
+	// small window of it. A timezone-mislabeled updated_at would be off by the
+	// forced -7h offset (~25200s).
+	skew := updatedMinusCreatedSeconds(t, ctx, store, "issues", "isb-utc-blocked")
+	if skew < 0 {
+		skew = -skew
+	}
+	if skew > 60 {
+		t.Fatalf("updated_at and created_at differ by %ds after is_blocked recompute; "+
+			"expected both true UTC (skew <= 60s). updated_at was written in local time "+
+			"mislabeled as UTC (GH#4298)", skew)
+	}
 }
 
 func TestIsBlocked_FreshIssueIsNotBlocked(t *testing.T) {

--- a/internal/storage/issueops/blocked_state.go
+++ b/internal/storage/issueops/blocked_state.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"time"
 
 	"github.com/steveyegge/beads/internal/types"
 )
@@ -122,7 +123,7 @@ func markIsBlockedPassForIssuesInTx(ctx context.Context, tx *sql.Tx, ids []strin
 
 func markBlockedTemplateForIssues() string {
 	return fmt.Sprintf(`
-		UPDATE issues i SET i.is_blocked = 1
+		UPDATE issues i SET i.is_blocked = 1, i.updated_at = ?
 		WHERE i.id IN (%%s)
 		  AND i.is_blocked = 0
 		  AND i.status <> 'closed' AND i.status <> 'pinned'
@@ -166,7 +167,7 @@ func markBlockedTemplateForIssues() string {
 
 func unmarkBlockedTemplateForIssues() string {
 	return fmt.Sprintf(`
-		UPDATE issues i SET i.is_blocked = 0
+		UPDATE issues i SET i.is_blocked = 0, i.updated_at = ?
 		WHERE i.id IN (%%s)
 		  AND i.is_blocked = 1
 		  AND (
@@ -228,7 +229,7 @@ func markIsBlockedPassForWispsInTx(ctx context.Context, tx *sql.Tx, ids []string
 
 func markBlockedTemplateForWisps() string {
 	return fmt.Sprintf(`
-		UPDATE wisps w SET w.is_blocked = 1
+		UPDATE wisps w SET w.is_blocked = 1, w.updated_at = ?
 		WHERE w.id IN (%%s)
 		  AND w.is_blocked = 0
 		  AND w.status <> 'closed' AND w.status <> 'pinned'
@@ -272,7 +273,7 @@ func markBlockedTemplateForWisps() string {
 
 func unmarkBlockedTemplateForWisps() string {
 	return fmt.Sprintf(`
-		UPDATE wisps w SET w.is_blocked = 0
+		UPDATE wisps w SET w.is_blocked = 0, w.updated_at = ?
 		WHERE w.id IN (%%s)
 		  AND w.is_blocked = 1
 		  AND (
@@ -318,6 +319,12 @@ func unmarkBlockedTemplateForWisps() string {
 
 //nolint:gosec // G201: callers pass constant templates; only IN-clause placeholders are formatted in.
 func runMarkUnmarkBatchedInTx(ctx context.Context, tx *sql.Tx, markTmpl, unmarkTmpl string, ids []string) (int64, error) {
+	// Bind updated_at explicitly as true UTC. The is_blocked recompute is the one
+	// issueops UPDATE that otherwise relies on the schema's ON UPDATE
+	// CURRENT_TIMESTAMP; under the embedded Dolt driver that records local
+	// wall-clock time mislabeled as UTC (GH#4298). Every other UPDATE sets
+	// updated_at = ? with a Go-side UTC value, so do the same here.
+	now := time.Now().UTC()
 	var changed int64
 	for start := 0; start < len(ids); start += queryBatchSize {
 		end := start + queryBatchSize
@@ -325,15 +332,16 @@ func runMarkUnmarkBatchedInTx(ctx context.Context, tx *sql.Tx, markTmpl, unmarkT
 			end = len(ids)
 		}
 		placeholders, args := buildSQLInClause(ids[start:end])
+		execArgs := append([]interface{}{now}, args...)
 
-		res, err := tx.ExecContext(ctx, fmt.Sprintf(markTmpl, placeholders), args...)
+		res, err := tx.ExecContext(ctx, fmt.Sprintf(markTmpl, placeholders), execArgs...)
 		if err != nil {
 			return changed, fmt.Errorf("recompute is_blocked (mark): %w", err)
 		}
 		n, _ := res.RowsAffected()
 		changed += n
 
-		res, err = tx.ExecContext(ctx, fmt.Sprintf(unmarkTmpl, placeholders), args...)
+		res, err = tx.ExecContext(ctx, fmt.Sprintf(unmarkTmpl, placeholders), execArgs...)
 		if err != nil {
 			return changed, fmt.Errorf("recompute is_blocked (unmark): %w", err)
 		}
@@ -345,6 +353,8 @@ func runMarkUnmarkBatchedInTx(ctx context.Context, tx *sql.Tx, markTmpl, unmarkT
 
 //nolint:gosec // G201: callers pass constant templates; only IN-clause placeholders are formatted in.
 func runMarkBatchedInTx(ctx context.Context, tx *sql.Tx, markTmpl string, ids []string) (int64, error) {
+	// See runMarkUnmarkBatchedInTx: bind updated_at as explicit UTC (GH#4298).
+	now := time.Now().UTC()
 	var changed int64
 	for start := 0; start < len(ids); start += queryBatchSize {
 		end := start + queryBatchSize
@@ -352,8 +362,9 @@ func runMarkBatchedInTx(ctx context.Context, tx *sql.Tx, markTmpl string, ids []
 			end = len(ids)
 		}
 		placeholders, args := buildSQLInClause(ids[start:end])
+		execArgs := append([]interface{}{now}, args...)
 
-		res, err := tx.ExecContext(ctx, fmt.Sprintf(markTmpl, placeholders), args...)
+		res, err := tx.ExecContext(ctx, fmt.Sprintf(markTmpl, placeholders), execArgs...)
 		if err != nil {
 			return changed, fmt.Errorf("mark is_blocked: %w", err)
 		}


### PR DESCRIPTION
## Summary

Fixes GH#4298: `bd export` emits `updated_at` with local wall-clock numerals suffixed `Z`, off by the machine's UTC offset, for any issue/wisp touched by the blocked-state recompute. `created_at` on the same row stays correct because it is written explicitly.

Root cause: `RecomputeIsBlockedInTx` (`internal/storage/issueops/blocked_state.go`) was the **only** issueops UPDATE that omitted `updated_at` and relied on the schema's `updated_at DATETIME ... ON UPDATE CURRENT_TIMESTAMP`. Under the embedded Dolt path the session query time is set from local `time.Now()` (`dolthub/driver` `conn.go` → `SetQueryTime(time.Now())`, still present in v2.1.4), so the auto-filled `updated_at` carries local numerals tagged UTC. This breaks UTC-based downstream tooling (sync, "recently changed" queries, conflict resolution).

## Change

- Bind `updated_at = time.Now().UTC()` explicitly in the mark/unmark batched recompute UPDATEs (issues + wisps), matching the existing pattern in `claim.go`, `close.go`, `update.go`, `bulk_ops.go`, and `compaction.go`. This removes the recompute's reliance on `ON UPDATE CURRENT_TIMESTAMP` and the driver's local query time.
- Add `TestIsBlocked_RecomputeWritesUTCUpdatedAt`, which forces a non-UTC local zone and asserts (in SQL via `TIMESTAMPDIFF`) that `updated_at` stays within seconds of `created_at` after the recompute, so a timezone-mislabeled value is caught regardless of host/CI timezone.

## Test plan

```
CGO_ENABLED=1 go test -tags gms_pure_go -run '^TestIsBlocked_' ./internal/storage/dolt/
```

All `TestIsBlocked_*` pass. The change is behavior-preserving for the affected row set (the same rows the recompute already touched via `ON UPDATE`); it only makes the written timestamp an explicit UTC value instead of the driver's local query time.

Made with [Cursor](https://cursor.com)