### PR TITLE
feat(claim): make claimable statuses configurable via claim.from-statuses (#4164)

### DIFF
--- a/cmd/bd/claim_custom_status_embedded_test.go
+++ b/cmd/bd/claim_custom_status_embedded_test.go
@@ -1,0 +1,78 @@
+//go:build cgo
+
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// TestEmbeddedClaimFromCustomStatus is the regression test for
+// gastownhall/beads#4164: claim hardcoded "status = 'open'", so issues parked
+// in a project's custom claimable status (e.g. "ready") could never be claimed.
+// claim.from-statuses makes the claimable set configurable while keeping "open"
+// always claimable (default behavior unchanged).
+func TestEmbeddedClaimFromCustomStatus(t *testing.T) {
+	if os.Getenv("BEADS_TEST_EMBEDDED_DOLT") != "1" {
+		t.Skip("set BEADS_TEST_EMBEDDED_DOLT=1 to run embedded dolt integration tests")
+	}
+	t.Parallel()
+
+	bd := buildEmbeddedBD(t)
+	dir, _, _ := bdInit(t, bd, "--prefix", "claim")
+
+	// Register a custom "ready" status so issues can be parked there.
+	if out, err := bdRunWithFlockRetry(t, bd, dir, "config", "set", "status.custom", "ready:active"); err != nil {
+		t.Fatalf("config set status.custom failed: %v\n%s", err, out)
+	}
+
+	t.Run("default_open_only_claimable", func(t *testing.T) {
+		issue := bdCreate(t, bd, dir, "Default claimable", "--type", "task")
+
+		// Park it in the custom "ready" status.
+		bdUpdate(t, bd, dir, issue.ID, "--status", "ready")
+		if got := bdShow(t, bd, dir, issue.ID); got.Status != types.Status("ready") {
+			t.Fatalf("expected status ready after update, got %s", got.Status)
+		}
+
+		// With claim.from-statuses unset, only "open" is claimable, so claiming
+		// a "ready" issue must fail — this pins the backward-compatible default.
+		out := bdUpdateFail(t, bd, dir, issue.ID, "--claim")
+		if !strings.Contains(out, "claimable") {
+			t.Errorf("expected not-claimable error, got: %s", out)
+		}
+	})
+
+	t.Run("custom_status_claimable_when_configured", func(t *testing.T) {
+		if out, err := bdRunWithFlockRetry(t, bd, dir, "config", "set", "claim.from-statuses", "ready"); err != nil {
+			t.Fatalf("config set claim.from-statuses failed: %v\n%s", err, out)
+		}
+
+		issue := bdCreate(t, bd, dir, "Configured claimable", "--type", "task")
+		bdUpdate(t, bd, dir, issue.ID, "--status", "ready")
+
+		// Now "ready" is claimable: claim should succeed and transition to in_progress.
+		bdUpdate(t, bd, dir, issue.ID, "--claim")
+		got := bdShow(t, bd, dir, issue.ID)
+		if got.Assignee == "" {
+			t.Error("expected assignee to be set after claiming a configured custom status")
+		}
+		if got.Status != types.StatusInProgress {
+			t.Errorf("expected status in_progress after claim, got %s", got.Status)
+		}
+	})
+
+	t.Run("open_still_claimable_with_config", func(t *testing.T) {
+		// "open" must remain claimable even when claim.from-statuses lists only
+		// custom statuses (open is always implicitly included).
+		issue := bdCreate(t, bd, dir, "Open still claimable", "--type", "task")
+		bdUpdate(t, bd, dir, issue.ID, "--claim")
+		got := bdShow(t, bd, dir, issue.ID)
+		if got.Status != types.StatusInProgress {
+			t.Errorf("expected open issue to remain claimable, got status %s", got.Status)
+		}
+	})
+}

--- a/cmd/bd/config.go
+++ b/cmd/bd/config.go
@@ -782,7 +782,7 @@ var recognizedConfigPrefixes = []string{
 	"export.", "import.", "dolt.", "jira.", "linear.", "github.", "custom.",
 	"status.", "doctor.suppress.", "routing.", "sync.", "git.",
 	"directory.", "repos.", "external_projects.", "validation.",
-	"hierarchy.", "ai.", "backup.", "federation.",
+	"hierarchy.", "ai.", "backup.", "federation.", "claim.",
 }
 
 // recognizedConfigKeys lists valid non-namespaced config keys.

--- a/internal/storage/issueops/claim.go
+++ b/internal/storage/issueops/claim.go
@@ -6,11 +6,18 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/types"
 )
+
+// ClaimFromStatusesKey is the config key listing additional statuses (beyond
+// the built-in "open") from which an issue may be claimed. Projects that model
+// their lifecycle with custom statuses (e.g. "ready") set this so that claim
+// works for those statuses too. See gastownhall/beads#4164.
+const ClaimFromStatusesKey = "claim.from-statuses"
 
 // ClaimResult holds the result of a ClaimIssueInTx call.
 type ClaimResult struct {
@@ -18,9 +25,35 @@ type ClaimResult struct {
 	IsWisp   bool
 }
 
+// resolveClaimableStatusesInTx returns the set of statuses from which an issue
+// may be claimed. The built-in "open" status is always claimable; projects can
+// add others (typically custom statuses such as "ready") via the
+// claim.from-statuses config key. The returned slice is de-duplicated and
+// always contains "open" first so default behavior is unchanged when the key is
+// unset (gastownhall/beads#4164).
+func resolveClaimableStatusesInTx(ctx context.Context, tx *sql.Tx) []string {
+	statuses := []string{string(types.StatusOpen)}
+	seen := map[string]struct{}{string(types.StatusOpen): {}}
+
+	value, err := GetConfigInTx(ctx, tx, ClaimFromStatusesKey)
+	if err != nil || value == "" {
+		return statuses
+	}
+	for _, s := range ParseCommaSeparatedList(value) {
+		if _, ok := seen[s]; ok {
+			continue
+		}
+		seen[s] = struct{}{}
+		statuses = append(statuses, s)
+	}
+	return statuses
+}
+
 // ClaimIssueInTx atomically claims an issue using compare-and-swap semantics.
 // It sets the assignee to actor and status to "in_progress" only if the issue
-// is currently open and unassigned or already assigned to the same actor.
+// is currently in a claimable status (always "open", plus any statuses listed
+// in the claim.from-statuses config key — see GH#4164) and is unassigned or
+// already assigned to the same actor.
 // Returns storage.ErrAlreadyClaimed if already claimed by a different user.
 // Idempotent: re-claiming an in_progress issue by the same actor is a no-op
 // success (supports agent retry workflows).
@@ -40,6 +73,15 @@ func ClaimIssueInTx(ctx context.Context, tx *sql.Tx, id string, actor string) (*
 
 	now := time.Now().UTC()
 
+	// Build the claimable-status CAS predicate. "open" is always claimable;
+	// projects may add custom statuses via claim.from-statuses (GH#4164).
+	claimable := resolveClaimableStatusesInTx(ctx, tx)
+	statusPlaceholders := strings.TrimSuffix(strings.Repeat("?, ", len(claimable)), ", ")
+	statusArgs := make([]interface{}, len(claimable))
+	for i, s := range claimable {
+		statusArgs[i] = s
+	}
+
 	// Conditional UPDATE: only succeeds while the issue is still claimable.
 	// Also set started_at on first transition to in_progress (GH#2796); preserve
 	// any existing value so re-claims don't overwrite the original start time.
@@ -47,17 +89,25 @@ func ClaimIssueInTx(ctx context.Context, tx *sql.Tx, id string, actor string) (*
 		result sql.Result
 	)
 	if oldIssue.StartedAt == nil {
+		args := make([]interface{}, 0, 4+len(statusArgs))
+		args = append(args, actor, now, now, id)
+		args = append(args, statusArgs...)
+		args = append(args, actor)
 		result, err = tx.ExecContext(ctx, fmt.Sprintf(`
 			UPDATE %s
 			SET assignee = ?, status = 'in_progress', updated_at = ?, started_at = ?
-			WHERE id = ? AND status = 'open' AND (assignee = '' OR assignee IS NULL OR assignee = ?)
-		`, issueTable), actor, now, now, id, actor)
+			WHERE id = ? AND status IN (%s) AND (assignee = '' OR assignee IS NULL OR assignee = ?)
+		`, issueTable, statusPlaceholders), args...)
 	} else {
+		args := make([]interface{}, 0, 3+len(statusArgs))
+		args = append(args, actor, now, id)
+		args = append(args, statusArgs...)
+		args = append(args, actor)
 		result, err = tx.ExecContext(ctx, fmt.Sprintf(`
 			UPDATE %s
 			SET assignee = ?, status = 'in_progress', updated_at = ?
-			WHERE id = ? AND status = 'open' AND (assignee = '' OR assignee IS NULL OR assignee = ?)
-		`, issueTable), actor, now, id, actor)
+			WHERE id = ? AND status IN (%s) AND (assignee = '' OR assignee IS NULL OR assignee = ?)
+		`, issueTable, statusPlaceholders), args...)
 	}
 	if err != nil {
 		return nil, fmt.Errorf("failed to claim issue: %w", err)


### PR DESCRIPTION
## Summary

`ClaimIssueInTx` hardcoded `WHERE status = 'open'`, so an issue parked in a project's custom claimable status (e.g. `ready`) could never be claimed — `bd update <id> --claim` (and `--status in_progress --claim`) failed for any custom-status lifecycle. Reported in #4164.

This makes the claimable-status set configurable while keeping the default behavior identical:

- New `claim.from-statuses` config key lists **additional** statuses an issue may be claimed from.
- `open` is **always** claimable; it's prepended and de-duplicated, so behavior is unchanged when the key is unset.
- The CAS `UPDATE` now uses `status IN (...)` built from that set (parameterized; no SQL injection surface).
- Registered the `claim.` config prefix so `bd config set claim.from-statuses ...` isn't flagged as an unrecognized key.

### Usage

```sh
# default: only "open" is claimable (unchanged)
bd config set status.custom "ready:active"
bd config set claim.from-statuses "ready"
bd update <id> --claim   # now works when the issue is in "ready"
```

## Test plan

Added `cmd/bd/claim_custom_status_embedded_test.go` (embedded-dolt, gated on `BEADS_TEST_EMBEDDED_DOLT=1`):

- [x] `default_open_only_claimable` — claiming a `ready` issue fails when `claim.from-statuses` is unset (pins backward-compatible default)
- [x] `custom_status_claimable_when_configured` — with `claim.from-statuses=ready`, claim succeeds and transitions to `in_progress`
- [x] `open_still_claimable_with_config` — `open` remains claimable even when the key lists only custom statuses

Existing claim coverage still passes:

```
go test -tags gms_pure_go -run 'TestEmbeddedUpdate/update_claim' ./cmd/bd/   # update_claim, update_claim_already_claimed PASS
go test -tags gms_pure_go -run '^TestEmbeddedClaimFromCustomStatus$' ./cmd/bd/  # PASS
```

Fixes #4164

Made with [Cursor](https://cursor.com)