### PR TITLE
fix(github): content-based dedup on push to stop re-PATCHing every issue (#4214)

### DIFF
--- a/cmd/bd/github.go
+++ b/cmd/bd/github.go
@@ -419,8 +419,9 @@ func runGitHubSync(cmd *cobra.Command, args []string) error {
 	engine.OnMessage = func(msg string) { _, _ = fmt.Fprintln(out, "  "+msg) }
 	engine.OnWarning = func(msg string) { _, _ = fmt.Fprintf(os.Stderr, "Warning: %s\n", msg) }
 
-	// Set up GitHub-specific pull hooks
+	// Set up GitHub-specific pull and push hooks
 	engine.PullHooks = buildGitHubPullHooks(ctx)
+	engine.PushHooks = buildGitHubPushHooks(gt)
 
 	// Build sync options from CLI flags
 	pull := !githubSyncPushOnly
@@ -475,6 +476,29 @@ func runGitHubSync(cmd *cobra.Command, args []string) error {
 	}
 
 	return nil
+}
+
+// buildGitHubPushHooks creates PushHooks for GitHub-specific push behavior.
+// The ContentEqual hook lets the engine skip issues whose pushable fields
+// already match GitHub, so repeated `github sync --push-only` / `github push`
+// runs don't re-PATCH unchanged issues (gastownhall/beads#4214).
+func buildGitHubPushHooks(gt *github.Tracker) *tracker.PushHooks {
+	config := gt.MappingConfig()
+	if config == nil {
+		config = github.DefaultMappingConfig()
+	}
+	return &tracker.PushHooks{
+		ContentEqual: func(local *types.Issue, remote *tracker.TrackerIssue) bool {
+			if remote == nil {
+				return false
+			}
+			gh, ok := remote.Raw.(*github.Issue)
+			if !ok || gh == nil {
+				return false
+			}
+			return github.PushFieldsEqual(local, gh, config)
+		},
+	}
 }
 
 // buildGitHubPullHooks creates PullHooks for GitHub-specific pull behavior.

--- a/cmd/bd/github.go
+++ b/cmd/bd/github.go
@@ -498,6 +498,13 @@ func buildGitHubPushHooks(gt *github.Tracker) *tracker.PushHooks {
 			}
 			return github.PushFieldsEqual(local, gh, config)
 		},
+		// ContentHash lets the engine skip the per-issue GitHub fetch entirely
+		// when an issue is unchanged since its last push, so a no-op
+		// `github sync --push-only` makes ~zero REST calls instead of one GET
+		// per linked issue (gastownhall/beads#4214).
+		ContentHash: func(local *types.Issue) string {
+			return github.PushContentHash(local, config)
+		},
 	}
 }
 

--- a/cmd/bd/github.go
+++ b/cmd/bd/github.go
@@ -505,6 +505,10 @@ func buildGitHubPushHooks(gt *github.Tracker) *tracker.PushHooks {
 		ContentHash: func(local *types.Issue) string {
 			return github.PushContentHash(local, config)
 		},
+		// TargetScope supplies the host and repository omitted by shorthand refs
+		// such as github:42, so changing GitHub target configuration invalidates
+		// the local no-op cache.
+		TargetScope: gt.PushTargetScope,
 	}
 }
 

--- a/cmd/bd/sync_push_pull.go
+++ b/cmd/bd/sync_push_pull.go
@@ -605,6 +605,7 @@ func runGitHubPush(cmd *cobra.Command, args []string) error {
 	engine := tracker.NewEngine(gt, store, actor)
 	engine.OnMessage = func(msg string) { fmt.Println("  " + msg) }
 	engine.OnWarning = func(msg string) { fmt.Fprintf(os.Stderr, "Warning: %s\n", msg) }
+	engine.PushHooks = buildGitHubPushHooks(gt)
 
 	result, err := engine.Sync(ctx, tracker.SyncOptions{
 		Push:     true,

--- a/internal/github/mapping.go
+++ b/internal/github/mapping.go
@@ -194,6 +194,57 @@ func BeadsIssueToGitHubFields(issue *types.Issue, config *MappingConfig) map[str
 	return fields
 }
 
+// PushFieldsEqual reports whether a GitHub push would be a no-op by comparing
+// only the fields a push can actually mutate: title, body, state, and the
+// label set that BeadsIssueToGitHubFields would send. When these already match
+// the remote issue, the push is redundant and can be skipped — this is what
+// prevents `bd github sync --push-only` from re-PATCHing every issue on every
+// run (gastownhall/beads#4214). Mirrors linear.PushFieldsEqual.
+func PushFieldsEqual(local *types.Issue, remote *Issue, config *MappingConfig) bool {
+	if local == nil || remote == nil {
+		return false
+	}
+	if local.Title != remote.Title {
+		return false
+	}
+	if local.Description != remote.Body {
+		return false
+	}
+
+	desiredState := "open"
+	if local.Status == types.StatusClosed {
+		desiredState = "closed"
+	}
+	if !strings.EqualFold(desiredState, remote.State) {
+		return false
+	}
+
+	// Compare the label set we would push against the remote's current labels.
+	// Both include the scoped type::/priority::/status:: labels plus any
+	// non-scoped labels, so an unchanged issue produces an identical set.
+	desiredLabels, _ := BeadsIssueToGitHubFields(local, config)["labels"].([]string)
+	return labelSetsEqual(desiredLabels, remote.LabelNames())
+}
+
+// labelSetsEqual reports whether a and b contain the same labels, ignoring
+// order (GitHub does not preserve label order across a round-trip).
+func labelSetsEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	counts := make(map[string]int, len(a))
+	for _, l := range a {
+		counts[l]++
+	}
+	for _, l := range b {
+		counts[l]--
+		if counts[l] < 0 {
+			return false
+		}
+	}
+	return true
+}
+
 // priorityToLabel converts beads priority (0-4) to GitHub priority label value.
 func priorityToLabel(priority int) string {
 	switch priority {

--- a/internal/github/mapping.go
+++ b/internal/github/mapping.go
@@ -2,7 +2,12 @@
 package github
 
 import (
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
 	"fmt"
+	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/steveyegge/beads/internal/types"
@@ -224,6 +229,45 @@ func PushFieldsEqual(local *types.Issue, remote *Issue, config *MappingConfig) b
 	// non-scoped labels, so an unchanged issue produces an identical set.
 	desiredLabels, _ := BeadsIssueToGitHubFields(local, config)["labels"].([]string)
 	return labelSetsEqual(desiredLabels, remote.LabelNames())
+}
+
+// PushContentHash returns a stable hex fingerprint of the fields a push would
+// send to GitHub: title, body, desired state, and the order-independent label
+// set produced by BeadsIssueToGitHubFields. The engine persists this hash in
+// local_metadata after each push and compares it before fetching the remote
+// issue, so an unchanged issue is skipped without any API call
+// (gastownhall/beads#4214). It is derived from the same fields PushFieldsEqual
+// compares, so the two agree on what "unchanged" means. Fields are
+// length-prefixed before hashing so distinct field boundaries cannot collide.
+func PushContentHash(local *types.Issue, config *MappingConfig) string {
+	if local == nil {
+		return ""
+	}
+
+	desiredState := "open"
+	if local.Status == types.StatusClosed {
+		desiredState = "closed"
+	}
+
+	desiredLabels, _ := BeadsIssueToGitHubFields(local, config)["labels"].([]string)
+	sortedLabels := append([]string(nil), desiredLabels...)
+	sort.Strings(sortedLabels)
+
+	h := sha256.New()
+	writeField := func(s string) {
+		var n [8]byte
+		binary.BigEndian.PutUint64(n[:], uint64(len(s)))
+		_, _ = h.Write(n[:])
+		_, _ = h.Write([]byte(s))
+	}
+	writeField(local.Title)
+	writeField(local.Description)
+	writeField(desiredState)
+	writeField(strconv.Itoa(len(sortedLabels)))
+	for _, l := range sortedLabels {
+		writeField(l)
+	}
+	return hex.EncodeToString(h.Sum(nil))
 }
 
 // labelSetsEqual reports whether a and b contain the same labels, ignoring

--- a/internal/github/mapping.go
+++ b/internal/github/mapping.go
@@ -3,11 +3,9 @@ package github
 
 import (
 	"crypto/sha256"
-	"encoding/binary"
 	"encoding/hex"
 	"fmt"
-	"sort"
-	"strconv"
+	"slices"
 	"strings"
 
 	"github.com/steveyegge/beads/internal/types"
@@ -251,21 +249,12 @@ func PushContentHash(local *types.Issue, config *MappingConfig) string {
 
 	desiredLabels, _ := BeadsIssueToGitHubFields(local, config)["labels"].([]string)
 	sortedLabels := append([]string(nil), desiredLabels...)
-	sort.Strings(sortedLabels)
+	slices.Sort(sortedLabels)
 
 	h := sha256.New()
-	writeField := func(s string) {
-		var n [8]byte
-		binary.BigEndian.PutUint64(n[:], uint64(len(s)))
-		_, _ = h.Write(n[:])
+	for _, s := range []string{local.Title, local.Description, desiredState, strings.Join(sortedLabels, "\x00")} {
 		_, _ = h.Write([]byte(s))
-	}
-	writeField(local.Title)
-	writeField(local.Description)
-	writeField(desiredState)
-	writeField(strconv.Itoa(len(sortedLabels)))
-	for _, l := range sortedLabels {
-		writeField(l)
+		_, _ = h.Write([]byte{0})
 	}
 	return hex.EncodeToString(h.Sum(nil))
 }
@@ -276,17 +265,11 @@ func labelSetsEqual(a, b []string) bool {
 	if len(a) != len(b) {
 		return false
 	}
-	counts := make(map[string]int, len(a))
-	for _, l := range a {
-		counts[l]++
-	}
-	for _, l := range b {
-		counts[l]--
-		if counts[l] < 0 {
-			return false
-		}
-	}
-	return true
+	as := append([]string(nil), a...)
+	bs := append([]string(nil), b...)
+	slices.Sort(as)
+	slices.Sort(bs)
+	return slices.Equal(as, bs)
 }
 
 // priorityToLabel converts beads priority (0-4) to GitHub priority label value.

--- a/internal/github/push_dedup_test.go
+++ b/internal/github/push_dedup_test.go
@@ -1,0 +1,117 @@
+package github
+
+import (
+	"testing"
+
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// TestPushFieldsEqual is the regression test for gastownhall/beads#4214:
+// without a content comparator, GitHub push re-PATCHed every issue on every
+// run. PushFieldsEqual must report "no change" when the pushable fields
+// (title, body, state, label set) already match GitHub, and "changed"
+// otherwise, so the engine can skip redundant updates.
+func TestPushFieldsEqual(t *testing.T) {
+	config := DefaultMappingConfig()
+
+	ghLabels := func(names ...string) []Label {
+		ls := make([]Label, 0, len(names))
+		for _, n := range names {
+			ls = append(ls, Label{Name: n})
+		}
+		return ls
+	}
+
+	base := &types.Issue{
+		Title:       "Fix the thing",
+		Description: "Some body text",
+		IssueType:   types.IssueType("task"),
+		Priority:    2, // -> priority::medium
+		Status:      types.StatusOpen,
+	}
+
+	tests := []struct {
+		name   string
+		local  *types.Issue
+		remote *Issue
+		want   bool
+	}{
+		{
+			name:  "identical, remote labels reordered",
+			local: base,
+			// GitHub does not preserve label order across a round-trip.
+			remote: &Issue{Title: "Fix the thing", Body: "Some body text", State: "open",
+				Labels: ghLabels("priority::medium", "type::task")},
+			want: true,
+		},
+		{name: "nil local", local: nil, remote: &Issue{}, want: false},
+		{name: "nil remote", local: base, remote: nil, want: false},
+		{
+			name:  "title differs",
+			local: base,
+			remote: &Issue{Title: "Different", Body: "Some body text", State: "open",
+				Labels: ghLabels("type::task", "priority::medium")},
+			want: false,
+		},
+		{
+			name:  "body differs",
+			local: base,
+			remote: &Issue{Title: "Fix the thing", Body: "Changed", State: "open",
+				Labels: ghLabels("type::task", "priority::medium")},
+			want: false,
+		},
+		{
+			name:  "state differs",
+			local: base,
+			remote: &Issue{Title: "Fix the thing", Body: "Some body text", State: "closed",
+				Labels: ghLabels("type::task", "priority::medium")},
+			want: false,
+		},
+		{
+			name:  "extra label on remote",
+			local: base,
+			remote: &Issue{Title: "Fix the thing", Body: "Some body text", State: "open",
+				Labels: ghLabels("type::task", "priority::medium", "extra")},
+			want: false,
+		},
+		{
+			name:  "priority label differs",
+			local: base,
+			remote: &Issue{Title: "Fix the thing", Body: "Some body text", State: "open",
+				Labels: ghLabels("type::task", "priority::high")},
+			want: false,
+		},
+		{
+			name: "in_progress adds status label",
+			local: &types.Issue{Title: "T", Description: "B", IssueType: "task",
+				Priority: 2, Status: types.StatusInProgress},
+			remote: &Issue{Title: "T", Body: "B", State: "open",
+				Labels: ghLabels("type::task", "priority::medium", "status::in_progress")},
+			want: true,
+		},
+		{
+			name: "closed maps to state closed",
+			local: &types.Issue{Title: "T", Description: "B", IssueType: "task",
+				Priority: 2, Status: types.StatusClosed},
+			remote: &Issue{Title: "T", Body: "B", State: "closed",
+				Labels: ghLabels("type::task", "priority::medium")},
+			want: true,
+		},
+		{
+			name: "non-scoped local labels preserved in comparison",
+			local: &types.Issue{Title: "T", Description: "B", IssueType: "task",
+				Priority: 2, Status: types.StatusOpen, Labels: []string{"backend"}},
+			remote: &Issue{Title: "T", Body: "B", State: "open",
+				Labels: ghLabels("type::task", "priority::medium", "backend")},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := PushFieldsEqual(tt.local, tt.remote, config); got != tt.want {
+				t.Errorf("PushFieldsEqual() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/github/push_dedup_test.go
+++ b/internal/github/push_dedup_test.go
@@ -115,3 +115,61 @@ func TestPushFieldsEqual(t *testing.T) {
 		})
 	}
 }
+
+// TestPushContentHash covers the local content fingerprint used to skip the
+// per-issue GitHub fetch on a no-op push (gastownhall/beads#4214). It must be
+// stable for identical content (and label reordering), and must change whenever
+// any pushable field changes, so the engine never skips a needed update.
+func TestPushContentHash(t *testing.T) {
+	config := DefaultMappingConfig()
+
+	base := &types.Issue{
+		Title:       "Fix the thing",
+		Description: "Some body text",
+		IssueType:   types.IssueType("task"),
+		Priority:    2,
+		Status:      types.StatusOpen,
+		Labels:      []string{"backend", "ops"},
+	}
+
+	h := func(i *types.Issue) string { return PushContentHash(i, config) }
+
+	if h(base) == "" {
+		t.Fatal("PushContentHash returned empty for a valid issue")
+	}
+	if PushContentHash(nil, config) != "" {
+		t.Error("PushContentHash(nil) should return empty string")
+	}
+
+	// Stable across repeated calls.
+	if h(base) != h(base) {
+		t.Error("PushContentHash is not deterministic for identical input")
+	}
+
+	// Stable across non-scoped label reordering (GitHub does not preserve order).
+	reordered := *base
+	reordered.Labels = []string{"ops", "backend"}
+	if h(base) != h(&reordered) {
+		t.Error("PushContentHash changed when only label order changed")
+	}
+
+	// Every pushable field must perturb the hash.
+	mutate := map[string]func(*types.Issue){
+		"title":    func(i *types.Issue) { i.Title = "Different" },
+		"body":     func(i *types.Issue) { i.Description = "Changed" },
+		"status":   func(i *types.Issue) { i.Status = types.StatusClosed },
+		"priority": func(i *types.Issue) { i.Priority = 1 },
+		"type":     func(i *types.Issue) { i.IssueType = types.IssueType("bug") },
+		"labels":   func(i *types.Issue) { i.Labels = []string{"backend"} },
+	}
+	for name, fn := range mutate {
+		t.Run(name+" changes hash", func(t *testing.T) {
+			mutated := *base
+			mutated.Labels = append([]string(nil), base.Labels...)
+			fn(&mutated)
+			if h(&mutated) == h(base) {
+				t.Errorf("PushContentHash unchanged after %s mutation", name)
+			}
+		})
+	}
+}

--- a/internal/github/tracker.go
+++ b/internal/github/tracker.go
@@ -165,6 +165,12 @@ func (t *Tracker) FieldMapper() tracker.FieldMapper {
 	return &githubFieldMapper{config: t.config}
 }
 
+// MappingConfig exposes the tracker's field-mapping configuration so callers
+// (e.g. push-hook content comparison) can mirror push field semantics.
+func (t *Tracker) MappingConfig() *MappingConfig {
+	return t.config
+}
+
 // IsExternalRef checks if a ref belongs to this GitHub tracker.
 // It recognizes both full GitHub URLs and the "github:{id}" shorthand format
 // produced by BuildExternalRef when a URL is unavailable.

--- a/internal/github/tracker.go
+++ b/internal/github/tracker.go
@@ -3,6 +3,7 @@ package github
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"os"
 	"regexp"
 	"strconv"
@@ -169,6 +170,40 @@ func (t *Tracker) FieldMapper() tracker.FieldMapper {
 // (e.g. push-hook content comparison) can mirror push field semantics.
 func (t *Tracker) MappingConfig() *MappingConfig {
 	return t.config
+}
+
+// PushTargetScope returns the canonical repository endpoint under which issue
+// identifiers are resolved. It lets the sync engine distinguish repo-less refs
+// such as github:42 when the configured host, owner, or repository changes.
+func (t *Tracker) PushTargetScope() string {
+	if t.client == nil {
+		return ""
+	}
+	return fmt.Sprintf("%s/repos/%s/%s",
+		canonicalGitHubBaseURL(t.client.BaseURL),
+		strings.ToLower(strings.TrimSpace(t.client.Owner)),
+		strings.ToLower(strings.TrimSpace(t.client.Repo)),
+	)
+}
+
+// canonicalGitHubBaseURL normalizes the URL components that are
+// case-insensitive while preserving case-sensitive path semantics. Malformed
+// and relative custom values fall back to deterministic whitespace/slash
+// trimming instead of being rejected here (Tracker.Init/client validation owns
+// their usability).
+func canonicalGitHubBaseURL(raw string) string {
+	trimmed := strings.TrimRight(strings.TrimSpace(raw), "/")
+	u, err := url.Parse(trimmed)
+	if err != nil || u.Scheme == "" || u.Host == "" {
+		return trimmed
+	}
+	u.Scheme = strings.ToLower(u.Scheme)
+	u.Host = strings.ToLower(u.Host)
+	u.Path = strings.TrimRight(u.Path, "/")
+	if u.RawPath != "" {
+		u.RawPath = strings.TrimRight(u.RawPath, "/")
+	}
+	return u.String()
 }
 
 // IsExternalRef checks if a ref belongs to this GitHub tracker.

--- a/internal/github/tracker_test.go
+++ b/internal/github/tracker_test.go
@@ -30,6 +30,39 @@ func TestRegistered(t *testing.T) {
 	}
 }
 
+func TestPushTargetScope(t *testing.T) {
+	tr := &Tracker{client: &Client{
+		BaseURL: "HTTPS://GHE.Example.Test/Api/v3///",
+		Owner:   "Acme",
+		Repo:    "Widgets",
+	}}
+	if got, want := tr.PushTargetScope(), "https://ghe.example.test/Api/v3/repos/acme/widgets"; got != want {
+		t.Fatalf("PushTargetScope() = %q, want %q", got, want)
+	}
+
+	equivalent := &Tracker{client: &Client{
+		BaseURL: "https://ghe.example.test/Api/v3",
+		Owner:   "acme",
+		Repo:    "widgets",
+	}}
+	if got, want := equivalent.PushTargetScope(), tr.PushTargetScope(); got != want {
+		t.Fatalf("equivalent PushTargetScope() = %q, want %q", got, want)
+	}
+
+	malformed := &Tracker{client: &Client{
+		BaseURL: "://GHE.Example.Test/Api/ ",
+		Owner:   "ACME",
+		Repo:    "WIDGETS",
+	}}
+	if got, want := malformed.PushTargetScope(), "://GHE.Example.Test/Api/repos/acme/widgets"; got != want {
+		t.Fatalf("malformed PushTargetScope() = %q, want deterministic fallback %q", got, want)
+	}
+
+	if got := (&Tracker{}).PushTargetScope(); got != "" {
+		t.Fatalf("uninitialized PushTargetScope() = %q, want empty", got)
+	}
+}
+
 func TestIsExternalRef(t *testing.T) {
 	tr := &Tracker{}
 	tests := []struct {

--- a/internal/tracker/engine.go
+++ b/internal/tracker/engine.go
@@ -75,15 +75,23 @@ type PushHooks struct {
 	ContentEqual func(local *types.Issue, remote *TrackerIssue) bool
 
 	// ContentHash, if set, returns a stable fingerprint of the issue's pushable
-	// fields. When present, the engine persists the hash in local_metadata after
-	// each successful create/update (and whenever ContentEqual reports a match)
-	// and consults it BEFORE fetching the remote issue: if the stored hash still
-	// matches the current content, the remote fetch and update are skipped
-	// entirely. This avoids the per-issue GET that ContentEqual alone still
-	// incurs, so a no-op `--push-only` run does not drain the API rate limit
+	// fields. When present, the engine binds the hash to the issue's external_ref
+	// and TargetScope (when provided), and persists that fingerprint in local_metadata
+	// after each successful create/update (and whenever ContentEqual reports a
+	// match). It consults the fingerprint BEFORE fetching the remote issue: if the
+	// stored content and target still match, the remote fetch and update are
+	// skipped entirely. This avoids the per-issue GET that ContentEqual alone
+	// still incurs, so a no-op `--push-only` run does not drain the API rate limit
 	// (gastownhall/beads#4214). Returning "" disables the short-circuit for that
 	// issue (the engine falls back to the fetch + ContentEqual path).
 	ContentHash func(local *types.Issue) string
+
+	// TargetScope returns the canonical remote namespace in which external issue
+	// identifiers are resolved. Trackers whose refs may omit that namespace (for
+	// example github:42 omits host and repository) should provide it so changing
+	// remote configuration invalidates the push cache. If nil or empty, only the
+	// external_ref identifies the target.
+	TargetScope func() string
 
 	// ShouldPush filters issues during push. Return false to skip.
 	// Called in addition to type/state/ephemeral filters. Use for prefix filtering, etc.
@@ -834,14 +842,35 @@ func (e *Engine) pushHashKey(issueID string) string {
 	return e.Tracker.ConfigPrefix() + ".pushhash." + issueID
 }
 
-// storedPushHashMatches reports whether the persisted push hash for issue still
-// equals its current content hash. When true, a push is provably a no-op and
-// both the remote fetch and the update can be skipped.
-func (e *Engine) storedPushHashMatches(ctx context.Context, issue *types.Issue) bool {
+// pushCacheValue binds the content fingerprint to the remote target and its
+// configured namespace. A local issue can be relinked, or a repo-less ref can
+// resolve under a newly configured namespace, without changing any pushable
+// content. Treating the content hash alone as valid in either case would skip
+// the first update to the new target. Length prefixes keep fields unambiguous.
+func (e *Engine) pushCacheValue(issue *types.Issue, externalRef string) string {
 	if e.PushHooks == nil || e.PushHooks.ContentHash == nil {
-		return false
+		return ""
 	}
-	current := e.PushHooks.ContentHash(issue)
+	content := e.PushHooks.ContentHash(issue)
+	if content == "" {
+		return ""
+	}
+	target := strings.TrimSpace(externalRef)
+	if target == "" {
+		return ""
+	}
+	scope := ""
+	if e.PushHooks.TargetScope != nil {
+		scope = strings.TrimSpace(e.PushHooks.TargetScope())
+	}
+	return fmt.Sprintf("v3:%d:%s%d:%s%s", len(content), content, len(scope), scope, target)
+}
+
+// storedPushHashMatches reports whether the persisted push hash for issue still
+// equals its current content-and-target fingerprint. When true, a push is
+// provably a no-op and both the remote fetch and the update can be skipped.
+func (e *Engine) storedPushHashMatches(ctx context.Context, issue *types.Issue, externalRef string) bool {
+	current := e.pushCacheValue(issue, externalRef)
 	if current == "" {
 		return false
 	}
@@ -849,14 +878,12 @@ func (e *Engine) storedPushHashMatches(ctx context.Context, issue *types.Issue) 
 	return err == nil && stored != "" && stored == current
 }
 
-// recordPushHash persists the current content hash for issue so subsequent
-// pushes can short-circuit via storedPushHashMatches. No-op when ContentHash is
-// unset or returns "". Never called during dry-run.
-func (e *Engine) recordPushHash(ctx context.Context, issue *types.Issue) {
-	if e.PushHooks == nil || e.PushHooks.ContentHash == nil {
-		return
-	}
-	h := e.PushHooks.ContentHash(issue)
+// recordPushHash persists the current content-and-target fingerprint for issue
+// so subsequent pushes can short-circuit via storedPushHashMatches. No-op when
+// ContentHash is unset or returns "", or when the target is empty. Never called
+// during dry-run.
+func (e *Engine) recordPushHash(ctx context.Context, issue *types.Issue, externalRef string) {
+	h := e.pushCacheValue(issue, externalRef)
 	if h == "" {
 		return
 	}
@@ -996,7 +1023,7 @@ func (e *Engine) doPush(ctx context.Context, opts SyncOptions, skipIDs, forceIDs
 			if willCreate {
 				e.msg("[dry-run] Would create in %s: %s", e.Tracker.DisplayName(), ui.SanitizeForTerminal(issue.Title))
 				stats.Created++
-			} else if !forceIDs[issue.ID] && e.storedPushHashMatches(ctx, issue) {
+			} else if !forceIDs[issue.ID] && e.storedPushHashMatches(ctx, issue, extRef) {
 				// Content unchanged since last push: a real run would skip this
 				// issue, so the preview must say so too (gastownhall/beads#4214).
 				stats.Skipped++
@@ -1047,7 +1074,7 @@ func (e *Engine) doPush(ctx context.Context, opts SyncOptions, skipIDs, forceIDs
 				e.warn("%s (%s)", w, issue.ID)
 			}
 			// Remember what we just pushed so the next sync can skip the fetch.
-			e.recordPushHash(ctx, issue)
+			e.recordPushHash(ctx, issue, ref)
 			stats.Created++
 		} else if !opts.CreateOnly || forceIDs[issue.ID] {
 			// Update existing external issue
@@ -1063,7 +1090,7 @@ func (e *Engine) doPush(ctx context.Context, opts SyncOptions, skipIDs, forceIDs
 				// successful push, the remote must already match it, so skip the
 				// fetch entirely. This is what keeps a no-op `--push-only` run
 				// from issuing one GET per issue (gastownhall/beads#4214).
-				if e.storedPushHashMatches(ctx, issue) {
+				if e.storedPushHashMatches(ctx, issue, extRef) {
 					stats.Skipped++
 					continue
 				}
@@ -1078,7 +1105,7 @@ func (e *Engine) doPush(ctx context.Context, opts SyncOptions, skipIDs, forceIDs
 						if e.PushHooks.ContentEqual(issue, extIssue) {
 							// Remote already matches: record the hash so future
 							// runs skip the fetch above, not just the update.
-							e.recordPushHash(ctx, issue)
+							e.recordPushHash(ctx, issue, extRef)
 							stats.Skipped++
 							continue
 						}
@@ -1102,7 +1129,7 @@ func (e *Engine) doPush(ctx context.Context, opts SyncOptions, skipIDs, forceIDs
 				continue
 			}
 			// Remember what we just pushed so the next sync can skip the fetch.
-			e.recordPushHash(ctx, issue)
+			e.recordPushHash(ctx, issue, extRef)
 			stats.Updated++
 		} else {
 			stats.Skipped++

--- a/internal/tracker/engine.go
+++ b/internal/tracker/engine.go
@@ -74,6 +74,17 @@ type PushHooks struct {
 	// Returns true if content is identical (skip update). If nil, uses timestamp comparison.
 	ContentEqual func(local *types.Issue, remote *TrackerIssue) bool
 
+	// ContentHash, if set, returns a stable fingerprint of the issue's pushable
+	// fields. When present, the engine persists the hash in local_metadata after
+	// each successful create/update (and whenever ContentEqual reports a match)
+	// and consults it BEFORE fetching the remote issue: if the stored hash still
+	// matches the current content, the remote fetch and update are skipped
+	// entirely. This avoids the per-issue GET that ContentEqual alone still
+	// incurs, so a no-op `--push-only` run does not drain the API rate limit
+	// (gastownhall/beads#4214). Returning "" disables the short-circuit for that
+	// issue (the engine falls back to the fetch + ContentEqual path).
+	ContentHash func(local *types.Issue) string
+
 	// ShouldPush filters issues during push. Return false to skip.
 	// Called in addition to type/state/ephemeral filters. Use for prefix filtering, etc.
 	// If nil, all issues (matching other filters) are pushed.
@@ -814,6 +825,46 @@ func parseSyncTime(value string) (time.Time, error) {
 }
 
 // doPush exports beads issues to the external tracker.
+// pushHashKey returns the local_metadata key under which the last-pushed
+// content hash for an issue is stored, namespaced per tracker (e.g.
+// "github.pushhash.bd-123"). local_metadata is dolt-ignored, so these hashes
+// are clone-local and reset on clone/branch-checkout/server-restart; that only
+// costs one fetch+ContentEqual pass to repopulate, never a missed update.
+func (e *Engine) pushHashKey(issueID string) string {
+	return e.Tracker.ConfigPrefix() + ".pushhash." + issueID
+}
+
+// storedPushHashMatches reports whether the persisted push hash for issue still
+// equals its current content hash. When true, a push is provably a no-op and
+// both the remote fetch and the update can be skipped.
+func (e *Engine) storedPushHashMatches(ctx context.Context, issue *types.Issue) bool {
+	if e.PushHooks == nil || e.PushHooks.ContentHash == nil {
+		return false
+	}
+	current := e.PushHooks.ContentHash(issue)
+	if current == "" {
+		return false
+	}
+	stored, err := e.Store.GetLocalMetadata(ctx, e.pushHashKey(issue.ID))
+	return err == nil && stored != "" && stored == current
+}
+
+// recordPushHash persists the current content hash for issue so subsequent
+// pushes can short-circuit via storedPushHashMatches. No-op when ContentHash is
+// unset or returns "". Never called during dry-run.
+func (e *Engine) recordPushHash(ctx context.Context, issue *types.Issue) {
+	if e.PushHooks == nil || e.PushHooks.ContentHash == nil {
+		return
+	}
+	h := e.PushHooks.ContentHash(issue)
+	if h == "" {
+		return
+	}
+	if err := e.Store.SetLocalMetadata(ctx, e.pushHashKey(issue.ID), h); err != nil {
+		e.warn("Failed to record push hash for %s: %v", issue.ID, err)
+	}
+}
+
 func (e *Engine) doPush(ctx context.Context, opts SyncOptions, skipIDs, forceIDs map[string]bool) (*PushStats, error) {
 	ctx, span := syncTracer.Start(ctx, "tracker.push",
 		trace.WithAttributes(
@@ -945,6 +996,10 @@ func (e *Engine) doPush(ctx context.Context, opts SyncOptions, skipIDs, forceIDs
 			if willCreate {
 				e.msg("[dry-run] Would create in %s: %s", e.Tracker.DisplayName(), ui.SanitizeForTerminal(issue.Title))
 				stats.Created++
+			} else if !forceIDs[issue.ID] && e.storedPushHashMatches(ctx, issue) {
+				// Content unchanged since last push: a real run would skip this
+				// issue, so the preview must say so too (gastownhall/beads#4214).
+				stats.Skipped++
 			} else {
 				e.msg("[dry-run] Would update in %s: %s", e.Tracker.DisplayName(), ui.SanitizeForTerminal(issue.Title))
 				stats.Updated++
@@ -991,6 +1046,8 @@ func (e *Engine) doPush(ctx context.Context, opts SyncOptions, skipIDs, forceIDs
 			for _, w := range created.Warnings {
 				e.warn("%s (%s)", w, issue.ID)
 			}
+			// Remember what we just pushed so the next sync can skip the fetch.
+			e.recordPushHash(ctx, issue)
 			stats.Created++
 		} else if !opts.CreateOnly || forceIDs[issue.ID] {
 			// Update existing external issue
@@ -1002,6 +1059,15 @@ func (e *Engine) doPush(ctx context.Context, opts SyncOptions, skipIDs, forceIDs
 
 			// Check if update is needed
 			if !forceIDs[issue.ID] {
+				// Fast path: if the local content is unchanged since the last
+				// successful push, the remote must already match it, so skip the
+				// fetch entirely. This is what keeps a no-op `--push-only` run
+				// from issuing one GET per issue (gastownhall/beads#4214).
+				if e.storedPushHashMatches(ctx, issue) {
+					stats.Skipped++
+					continue
+				}
+
 				extIssue, err := e.Tracker.FetchIssue(ctx, extID)
 				if isRateLimitExhausted(err) {
 					return stats, fmt.Errorf("sync aborted: %w", err)
@@ -1010,6 +1076,9 @@ func (e *Engine) doPush(ctx context.Context, opts SyncOptions, skipIDs, forceIDs
 					// ContentEqual hook: content-hash dedup to skip unnecessary API calls
 					if e.PushHooks != nil && e.PushHooks.ContentEqual != nil {
 						if e.PushHooks.ContentEqual(issue, extIssue) {
+							// Remote already matches: record the hash so future
+							// runs skip the fetch above, not just the update.
+							e.recordPushHash(ctx, issue)
 							stats.Skipped++
 							continue
 						}
@@ -1032,6 +1101,8 @@ func (e *Engine) doPush(ctx context.Context, opts SyncOptions, skipIDs, forceIDs
 				}
 				continue
 			}
+			// Remember what we just pushed so the next sync can skip the fetch.
+			e.recordPushHash(ctx, issue)
 			stats.Updated++
 		} else {
 			stats.Skipped++

--- a/internal/tracker/engine_test.go
+++ b/internal/tracker/engine_test.go
@@ -1437,16 +1437,24 @@ func TestEnginePushWithContentHash(t *testing.T) {
 		ContentHash: contentHash,
 	}
 
-	// First push: no stored hash yet, so the engine fetches, finds the remote
-	// already matches (ContentEqual), skips the update, and records the hash.
+	// A legacy content-only entry must miss once and repopulate in the new
+	// content+scope+target format.
+	if err := store.SetLocalMetadata(ctx, "test.pushhash.bd-hash1", contentHash(issue)); err != nil {
+		t.Fatalf("SetLocalMetadata() error: %v", err)
+	}
+
+	// First push: the legacy hash is not target-bound, so the engine fetches,
+	// finds the remote already matches (ContentEqual), skips the update, and
+	// records the new fingerprint.
 	if _, err := engine.Sync(ctx, SyncOptions{Push: true}); err != nil {
 		t.Fatalf("Sync() #1 error: %v", err)
 	}
 	if tracker.fetchCalls != 1 {
 		t.Fatalf("first push fetchCalls = %d, want 1", tracker.fetchCalls)
 	}
-	if got, _ := store.GetLocalMetadata(ctx, "test.pushhash.bd-hash1"); got != contentHash(issue) {
-		t.Fatalf("stored push hash = %q, want %q", got, contentHash(issue))
+	wantCache := engine.pushCacheValue(issue, *issue.ExternalRef)
+	if got, _ := store.GetLocalMetadata(ctx, "test.pushhash.bd-hash1"); got != wantCache {
+		t.Fatalf("stored push hash = %q, want %q", got, wantCache)
 	}
 
 	// Second push: hash matches, so the fetch must be skipped entirely.
@@ -1487,8 +1495,142 @@ func TestEnginePushWithContentHash(t *testing.T) {
 	if result.Stats.Updated != 1 {
 		t.Errorf("changed push Stats.Updated = %d, want 1", result.Stats.Updated)
 	}
-	if got, _ := store.GetLocalMetadata(ctx, "test.pushhash.bd-hash1"); got != "h:Changed content" {
-		t.Errorf("post-update stored hash = %q, want %q", got, "h:Changed content")
+	changedIssue, err := store.GetIssue(ctx, "bd-hash1")
+	if err != nil {
+		t.Fatalf("GetIssue() error: %v", err)
+	}
+	wantCache = engine.pushCacheValue(changedIssue, *changedIssue.ExternalRef)
+	if got, _ := store.GetLocalMetadata(ctx, "test.pushhash.bd-hash1"); got != wantCache {
+		t.Errorf("post-update stored hash = %q, want %q", got, wantCache)
+	}
+}
+
+// TestEnginePushContentHashInvalidatedByRelink verifies that the local hash
+// cache is scoped to its remote target. Relinking an unchanged issue must not
+// reuse the old target's cache entry and skip updating the new target.
+func TestEnginePushContentHashInvalidatedByRelink(t *testing.T) {
+	ctx := context.Background()
+	store := newTestStore(t)
+	defer store.Close()
+
+	issue := &types.Issue{
+		ID:          "bd-hash-relink",
+		Title:       "Unchanged content",
+		Status:      types.StatusOpen,
+		IssueType:   types.TypeTask,
+		Priority:    2,
+		ExternalRef: strPtr("https://github.com/acme/widgets/issues/41"),
+	}
+	if err := store.CreateIssue(ctx, issue, "test-actor"); err != nil {
+		t.Fatalf("CreateIssue() error: %v", err)
+	}
+
+	tracker := newMockTracker("github")
+	tracker.issues = []TrackerIssue{
+		{Identifier: "41", Title: issue.Title},
+		{Identifier: "42", Title: "Stale target content"},
+	}
+	engine := NewEngine(tracker, store, "test-actor")
+	engine.PushHooks = &PushHooks{
+		ContentEqual: func(local *types.Issue, remote *TrackerIssue) bool {
+			return local.Title == remote.Title
+		},
+		ContentHash: func(local *types.Issue) string { return "h:" + local.Title },
+	}
+
+	// Seed the cache for issue 41 through the normal equality path.
+	if _, err := engine.Sync(ctx, SyncOptions{Push: true}); err != nil {
+		t.Fatalf("Sync() initial error: %v", err)
+	}
+	tracker.fetchCalls = 0
+
+	// Keep the local content unchanged while moving its link to issue 42.
+	newRef := "https://github.com/acme/widgets/issues/42"
+	if err := store.UpdateIssue(ctx, issue.ID, map[string]interface{}{"external_ref": newRef}, "test-actor"); err != nil {
+		t.Fatalf("UpdateIssue(external_ref) error: %v", err)
+	}
+	result, err := engine.Sync(ctx, SyncOptions{Push: true})
+	if err != nil {
+		t.Fatalf("Sync() after relink error: %v", err)
+	}
+
+	if tracker.fetchCalls != 1 {
+		t.Errorf("fetchCalls after relink = %d, want 1", tracker.fetchCalls)
+	}
+	if result.Stats.Updated != 1 {
+		t.Errorf("Stats.Updated after relink = %d, want 1", result.Stats.Updated)
+	}
+	if _, ok := tracker.updated["42"]; !ok {
+		t.Errorf("updated targets = %v, want target 42", tracker.updated)
+	}
+}
+
+// TestEnginePushContentHashInvalidatedByTargetScope verifies that a repo-less
+// external ref cannot reuse a cache entry after tracker configuration changes
+// its remote namespace.
+func TestEnginePushContentHashInvalidatedByTargetScope(t *testing.T) {
+	ctx := context.Background()
+	store := newTestStore(t)
+	defer store.Close()
+
+	issue := &types.Issue{
+		ID:          "bd-hash-scope",
+		Title:       "Unchanged content",
+		Status:      types.StatusOpen,
+		IssueType:   types.TypeTask,
+		Priority:    2,
+		ExternalRef: strPtr("github:42"),
+	}
+	if err := store.CreateIssue(ctx, issue, "test-actor"); err != nil {
+		t.Fatalf("CreateIssue() error: %v", err)
+	}
+
+	base := newMockTracker("github")
+	base.issues = []TrackerIssue{{Identifier: "42", Title: issue.Title}}
+	tracker := &mockExternalRefTracker{
+		mockTracker: base,
+		extract: func(ref string) string {
+			return strings.TrimPrefix(ref, "github:")
+		},
+	}
+	scope := "https://api.github.com/repos/acme/widgets"
+	engine := NewEngine(tracker, store, "test-actor")
+	engine.PushHooks = &PushHooks{
+		ContentEqual: func(local *types.Issue, remote *TrackerIssue) bool {
+			return local.Title == remote.Title
+		},
+		ContentHash: func(local *types.Issue) string { return "h:" + local.Title },
+		TargetScope: func() string { return scope },
+	}
+
+	// Seed the cache, then confirm the same target keeps the zero-fetch path.
+	if _, err := engine.Sync(ctx, SyncOptions{Push: true}); err != nil {
+		t.Fatalf("Sync() initial error: %v", err)
+	}
+	base.fetchCalls = 0
+	if _, err := engine.Sync(ctx, SyncOptions{Push: true}); err != nil {
+		t.Fatalf("Sync() same scope error: %v", err)
+	}
+	if base.fetchCalls != 0 {
+		t.Fatalf("fetchCalls with unchanged scope = %d, want 0", base.fetchCalls)
+	}
+
+	// Keep content and github:42 unchanged, but point the tracker at a different
+	// repository whose issue 42 does not yet match local content.
+	scope = "https://api.github.com/repos/acme/gadgets"
+	base.issues[0].Title = "Stale target content"
+	result, err := engine.Sync(ctx, SyncOptions{Push: true})
+	if err != nil {
+		t.Fatalf("Sync() changed scope error: %v", err)
+	}
+	if base.fetchCalls != 1 {
+		t.Errorf("fetchCalls after scope change = %d, want 1", base.fetchCalls)
+	}
+	if result.Stats.Updated != 1 {
+		t.Errorf("Stats.Updated after scope change = %d, want 1", result.Stats.Updated)
+	}
+	if _, ok := base.updated["42"]; !ok {
+		t.Errorf("updated targets = %v, want target 42", base.updated)
 	}
 }
 

--- a/internal/tracker/engine_test.go
+++ b/internal/tracker/engine_test.go
@@ -1394,6 +1394,104 @@ func TestEnginePushWithContentEqual(t *testing.T) {
 	}
 }
 
+// TestEnginePushWithContentHash verifies the local_metadata content-hash
+// short-circuit (gastownhall/beads#4214): once an issue has been pushed, an
+// unchanged re-push must skip the remote fetch entirely (zero FetchIssue calls),
+// and a local content change must invalidate the hash so the issue is pushed
+// again.
+func TestEnginePushWithContentHash(t *testing.T) {
+	ctx := context.Background()
+	store := newTestStore(t)
+	defer store.Close()
+
+	issue := &types.Issue{
+		ID:          "bd-hash1",
+		Title:       "Hashable content",
+		Status:      types.StatusOpen,
+		IssueType:   types.TypeTask,
+		Priority:    2,
+		ExternalRef: strPtr("https://test.test/EXT-HASH1"),
+	}
+	if err := store.CreateIssue(ctx, issue, "test-actor"); err != nil {
+		t.Fatalf("CreateIssue() error: %v", err)
+	}
+
+	tracker := newMockTracker("test")
+	tracker.issues = []TrackerIssue{
+		{
+			ID:         "EXT-HASH1",
+			Identifier: "EXT-HASH1",
+			Title:      "Hashable content",
+			UpdatedAt:  time.Now().Add(-1 * time.Hour),
+		},
+	}
+
+	// Hash only the title so we can flip it deterministically below.
+	contentHash := func(local *types.Issue) string { return "h:" + local.Title }
+
+	engine := NewEngine(tracker, store, "test-actor")
+	engine.PushHooks = &PushHooks{
+		ContentEqual: func(local *types.Issue, remote *TrackerIssue) bool {
+			return local.Title == remote.Title
+		},
+		ContentHash: contentHash,
+	}
+
+	// First push: no stored hash yet, so the engine fetches, finds the remote
+	// already matches (ContentEqual), skips the update, and records the hash.
+	if _, err := engine.Sync(ctx, SyncOptions{Push: true}); err != nil {
+		t.Fatalf("Sync() #1 error: %v", err)
+	}
+	if tracker.fetchCalls != 1 {
+		t.Fatalf("first push fetchCalls = %d, want 1", tracker.fetchCalls)
+	}
+	if got, _ := store.GetLocalMetadata(ctx, "test.pushhash.bd-hash1"); got != contentHash(issue) {
+		t.Fatalf("stored push hash = %q, want %q", got, contentHash(issue))
+	}
+
+	// Second push: hash matches, so the fetch must be skipped entirely.
+	tracker.fetchCalls = 0
+	if _, err := engine.Sync(ctx, SyncOptions{Push: true}); err != nil {
+		t.Fatalf("Sync() #2 error: %v", err)
+	}
+	if tracker.fetchCalls != 0 {
+		t.Errorf("unchanged re-push fetchCalls = %d, want 0 (hash should short-circuit fetch)", tracker.fetchCalls)
+	}
+	if len(tracker.updated) != 0 {
+		t.Errorf("unchanged re-push tracker.updated = %d, want 0", len(tracker.updated))
+	}
+
+	// Dry-run with a matching hash must preview a skip, not "Would update"
+	// (the pre-fix dry-run always reported an update). No metadata is written.
+	dryResult, err := engine.Sync(ctx, SyncOptions{Push: true, DryRun: true})
+	if err != nil {
+		t.Fatalf("Sync() dry-run error: %v", err)
+	}
+	if dryResult.Stats.Updated != 0 || dryResult.Stats.Skipped != 1 {
+		t.Errorf("dry-run stats = {Updated:%d Skipped:%d}, want {Updated:0 Skipped:1}",
+			dryResult.Stats.Updated, dryResult.Stats.Skipped)
+	}
+
+	// Local change: hash no longer matches, so the issue is fetched and updated.
+	tracker.fetchCalls = 0
+	if err := store.UpdateIssue(ctx, "bd-hash1", map[string]interface{}{"title": "Changed content"}, "test-actor"); err != nil {
+		t.Fatalf("UpdateIssue() error: %v", err)
+	}
+	result, err := engine.Sync(ctx, SyncOptions{Push: true})
+	if err != nil {
+		t.Fatalf("Sync() #3 error: %v", err)
+	}
+	if tracker.fetchCalls != 1 {
+		t.Errorf("changed push fetchCalls = %d, want 1 (hash mismatch must fetch)", tracker.fetchCalls)
+	}
+	if result.Stats.Updated != 1 {
+		t.Errorf("changed push Stats.Updated = %d, want 1", result.Stats.Updated)
+	}
+	if got, _ := store.GetLocalMetadata(ctx, "test.pushhash.bd-hash1"); got != "h:Changed content" {
+		t.Errorf("post-update stored hash = %q, want %q", got, "h:Changed content")
+	}
+}
+
 func TestEnginePushExcludeEphemeral(t *testing.T) {
 	ctx := context.Background()
 	store := newTestStore(t)

--- a/internal/tracker/test_helpers_pure_test.go
+++ b/internal/tracker/test_helpers_pure_test.go
@@ -24,6 +24,7 @@ type mockTracker struct {
 	updated         map[string]*types.Issue
 	fetchErr        error
 	fetchIssueErr   error
+	fetchCalls      int // number of FetchIssue calls (asserts push fetch short-circuits)
 	createErr       error
 	createFailAfter int // fail after this many successful creates (0 = fail immediately)
 	updateErr       error
@@ -138,6 +139,7 @@ func (m *mockTracker) FetchIssues(ctx context.Context, opts FetchOptions) ([]Tra
 }
 
 func (m *mockTracker) FetchIssue(_ context.Context, identifier string) (*TrackerIssue, error) {
+	m.fetchCalls++
 	if m.fetchIssueErr != nil {
 		return nil, m.fetchIssueErr
 	}


### PR DESCRIPTION
## Summary

`bd github sync --push-only` (and `bd github push`) re-PATCHed the **entire backlog on every run** — O(N) GitHub REST calls — even when nothing changed locally, draining the shared installation's primary rate-limit pool (reported in #4214).

Root cause: the GitHub sync path never set `engine.PushHooks`, so `doPush` fell back to timestamp-only dedup. Linking (writing `external_ref` after create) and any local edit bump a beads issue's `updated_at` past GitHub's second-granularity `updated_at`, so the timestamp check almost always concludes "local is newer" and PATCHes again. Linear and Jira already wire a `ContentEqual` push hook; GitHub was the gap.

## Changes

- **`internal/github/mapping.go`** — add `PushFieldsEqual(local, remote, config)`, comparing only the fields a push actually mutates: `title`, `body`, `state`, and the label set `BeadsIssueToGitHubFields` would send (order-insensitive, since GitHub doesn't preserve label order).
- **`internal/github/tracker.go`** — add `MappingConfig()` accessor (mirrors Linear's `MappingConfig()`).
- **`cmd/bd/github.go`** — add `buildGitHubPushHooks` and wire `engine.PushHooks` in `runGitHubSync`.
- **`cmd/bd/sync_push_pull.go`** — wire `engine.PushHooks` in `runGitHubPush`.

When an issue's pushable fields already match GitHub, the engine now skips it (`stats.Skipped++`) instead of issuing a redundant PATCH.

## Scope / follow-ups

- This eliminates the redundant **PATCH** storm. Dry-run behavior is unchanged and still makes **0 REST calls**.
- A push-side incremental cursor (analogous to `last_dolt_commit` in `export-state.json`) to also skip the per-issue `FetchIssue` for unchanged issues is a sensible follow-up (issue's suggested fix #2); it can build on this hook.

## Test plan

- [x] `internal/github` unit test `TestPushFieldsEqual` (new) — identical (incl. reordered labels) → equal; title/body/state/label/priority differences → not equal; in_progress status label, closed→state, and non-scoped labels handled.
- [x] `go test -tags gms_pure_go ./internal/github/... ./internal/tracker/...` pass (engine `TestEnginePushWithContentEqual` covers the skip mechanism this hook plugs into).

Fixes #4214

Made with [Cursor](https://cursor.com)