### PR TITLE
docs(llms): drop removed `bd backup fetch-git` from recovery tips

### DIFF
--- a/website/static/llms.txt
+++ b/website/static/llms.txt
@@ -49,7 +49,7 @@ bd backup sync                            # Push a Dolt-native backup
 
 Quick fixes for common issues:
 
-- Database Recovery: `bd backup restore` or `bd backup fetch-git`
+- Database Recovery: `bd backup restore`
 - Merge Conflicts: Use Dolt merge/recovery tools, then `bd dolt pull`
 - Circular Dependencies: `bd doctor` (diagnose only, NEVER --fix)
 - Sync Failures: `bd dolt pull`


### PR DESCRIPTION
## Summary

`backup export-git` / `backup fetch-git` were removed in PR #2842 (backup is now Dolt-native only), but `website/static/llms.txt` still listed `bd backup fetch-git` as a database-recovery option. This points database recovery at the still-valid `bd backup restore`.

Note: `llms.txt` (the short discoverability file) is hand-maintained; only `llms-full.txt` is generated by `scripts/generate-llms-full.sh`, so this edit won't be clobbered.

Refs #4126

## Test plan

- [x] Docs-only one-line change; no stale `fetch-git`/`export-git` references remain outside `CHANGELOG.md` (historical).

Made with [Cursor](https://cursor.com)