### PR TITLE
feat(init): add --init-if-missing for idempotent init (#3490)

### DIFF
--- a/cmd/bd/init.go
+++ b/cmd/bd/init.go
@@ -372,6 +372,17 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 				// --init-if-missing makes init idempotent: when the workspace
 				// is already initialized, skip and exit 0 instead of aborting.
 				if initIfMissing {
+					// Guard against masking a genuine mismatch: if the caller
+					// explicitly requested a --prefix that does not match the
+					// existing workspace, silently skipping would ignore the
+					// request. Abort as usual in that case. (Skipped when
+					// --database is set, since that overrides prefix-based
+					// naming and is the authoritative database selector.)
+					if cmd.Flags().Changed("prefix") && !cmd.Flags().Changed("database") {
+						if existing := existingWorkspaceDBName(); initIfMissingPrefixMismatch(existing, prefix) {
+							FatalError("workspace already initialized as database %q, but --prefix %q was requested.\nRemove --prefix (or pass a matching value) to reuse the existing workspace.", existing, prefix)
+						}
+					}
 					if !quiet {
 						fmt.Fprintln(os.Stderr, "Skipping init: workspace already initialized.")
 					}
@@ -460,19 +471,12 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 
 		// Normalize prefix before storing it in config or deriving the Dolt
 		// database name. Dots are not valid in issue prefixes and must match the
-		// underscore form used for DoltDatabase/metadata.json.
-		// Leading dots produce invalid names (e.g. ".claude" -> "claude"), and
-		// the trailing hyphen is added automatically during ID generation.
-		prefix = strings.TrimLeft(prefix, ".")
-		prefix = strings.TrimRight(prefix, "-")
-		prefix = strings.ReplaceAll(prefix, ".", "_")
-
-		// Sanitize prefix for use as a MySQL database name.
-		// Directory names like "001" (common in temp dirs) are invalid because
-		// MySQL identifiers must start with a letter or underscore.
-		if len(prefix) > 0 && !((prefix[0] >= 'a' && prefix[0] <= 'z') || (prefix[0] >= 'A' && prefix[0] <= 'Z') || prefix[0] == '_') {
-			prefix = "bd_" + prefix
-		}
+		// underscore form used for DoltDatabase/metadata.json. Leading dots
+		// produce invalid names (e.g. ".claude" -> "claude"), the trailing
+		// hyphen is added automatically during ID generation, and a leading
+		// non-letter is prefixed with "bd_" so the derived MySQL identifier is
+		// valid (directory names like "001" are common in temp dirs).
+		prefix = normalizeIssuePrefix(prefix)
 
 		// Cross-boundary safety (bd-q83 / ADR 0002): check remote state
 		// BEFORE any filesystem side-effects so a refusal exits cleanly.
@@ -713,7 +717,7 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 			// Must match the sanitization applied to metadata.json DoltDatabase
 			// field (line below), otherwise init creates a database with one name
 			// but metadata.json records a different name, causing reopens to fail.
-			dbName = strings.ReplaceAll(prefix, "-", "_")
+			dbName = dbNameFromPrefix(prefix)
 		} else {
 			dbName = "beads"
 		}
@@ -1969,33 +1973,82 @@ func countExistingIssues(_ string) (int, error) {
 //
 // For redirects, checks the redirect target and errors if it already has a database.
 // This prevents accidentally overwriting an existing canonical database (GH#bd-0qel).
-func checkExistingBeadsData(prefix string) error {
-	// Check BEADS_DIR environment variable first (matches FindBeadsDir pattern)
-	// When BEADS_DIR is set, it takes precedence over CWD and worktree checks
-	if envBeadsDir := os.Getenv("BEADS_DIR"); envBeadsDir != "" {
-		absBeadsDir := utils.CanonicalizePath(envBeadsDir)
-		return checkExistingBeadsDataAt(absBeadsDir, prefix)
+// normalizeIssuePrefix applies the prefix normalization rules shared by the
+// init path and the --init-if-missing mismatch guard: strip leading dots, drop
+// the trailing hyphen, convert dots to underscores, and prepend "bd_" when the
+// result would not start with a SQL-identifier-safe character. Keeping this in
+// one place ensures the mismatch check derives exactly the same name init does.
+func normalizeIssuePrefix(prefix string) string {
+	prefix = strings.TrimLeft(prefix, ".")
+	prefix = strings.TrimRight(prefix, "-")
+	prefix = strings.ReplaceAll(prefix, ".", "_")
+	if len(prefix) > 0 && !((prefix[0] >= 'a' && prefix[0] <= 'z') || (prefix[0] >= 'A' && prefix[0] <= 'Z') || prefix[0] == '_') {
+		prefix = "bd_" + prefix
 	}
+	return prefix
+}
 
+// dbNameFromPrefix derives the Dolt database name from a normalized issue
+// prefix (hyphens become underscores), matching how init records DoltDatabase.
+func dbNameFromPrefix(prefix string) string {
+	return strings.ReplaceAll(prefix, "-", "_")
+}
+
+// initIfMissingPrefixMismatch reports whether an explicit --prefix request
+// conflicts with the existing workspace, in which case --init-if-missing must
+// abort rather than silently skip (otherwise the requested prefix is ignored).
+// existingDBName is the existing workspace's recorded Dolt database name;
+// requestedPrefix is the raw, un-normalized --prefix value. Returns false when
+// the existing name is unknown so an undeterminable state falls through to the
+// benign skip.
+func initIfMissingPrefixMismatch(existingDBName, requestedPrefix string) bool {
+	if existingDBName == "" {
+		return false
+	}
+	requested := dbNameFromPrefix(normalizeIssuePrefix(requestedPrefix))
+	return requested != "" && !strings.EqualFold(existingDBName, requested)
+}
+
+// resolveInitBeadsDir resolves the .beads directory that init would target,
+// using the same precedence as checkExistingBeadsData (BEADS_DIR > worktree
+// fallback > CWD). Returns "" when it cannot be determined.
+func resolveInitBeadsDir() string {
+	if envBeadsDir := os.Getenv("BEADS_DIR"); envBeadsDir != "" {
+		return utils.CanonicalizePath(envBeadsDir)
+	}
 	cwd, err := os.Getwd()
 	if err != nil {
-		return nil // Can't determine CWD, allow init to proceed
+		return ""
 	}
-
-	// Determine where to check for .beads directory
-	// Guard with isGitRepo() check first - on Windows, git commands may hang
-	// when run outside a git repository (GH#727)
-	var beadsDir string
 	if isGitRepo() && git.IsWorktree() {
-		beadsDir = beads.GetWorktreeFallbackBeadsDir()
-		if beadsDir == "" {
-			return nil // Can't determine shared fallback, allow init to proceed
-		}
-	} else {
-		// For regular repos (or non-git directories), check current directory
-		beadsDir = filepath.Join(cwd, ".beads")
+		return beads.GetWorktreeFallbackBeadsDir()
 	}
+	return filepath.Join(cwd, ".beads")
+}
 
+// existingWorkspaceDBName returns the Dolt database name explicitly recorded
+// for the already-initialized workspace at the init target, or "" if it cannot
+// be determined. It reads the raw DoltDatabase field rather than
+// GetDoltDatabase() on purpose: the getter falls back to a default name (and an
+// env override), which would manufacture a phantom value and trigger false
+// mismatches. An unset value safely falls through to the benign skip.
+func existingWorkspaceDBName() string {
+	beadsDir := resolveInitBeadsDir()
+	if beadsDir == "" {
+		return ""
+	}
+	cfg, err := configfile.Load(beadsDir)
+	if err != nil || cfg == nil {
+		return ""
+	}
+	return cfg.DoltDatabase
+}
+
+func checkExistingBeadsData(prefix string) error {
+	beadsDir := resolveInitBeadsDir()
+	if beadsDir == "" {
+		return nil // Can't determine target, allow init to proceed
+	}
 	return checkExistingBeadsDataAt(beadsDir, prefix)
 }
 

--- a/cmd/bd/init.go
+++ b/cmd/bd/init.go
@@ -75,6 +75,7 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 		skipAgents, _ := cmd.Flags().GetBool("skip-agents")
 		force, _ := cmd.Flags().GetBool("force")
 		reinitLocal, _ := cmd.Flags().GetBool("reinit-local")
+		initIfMissing, _ := cmd.Flags().GetBool("init-if-missing")
 		discardRemote, _ := cmd.Flags().GetBool("discard-remote")
 		nonInteractiveFlag, _ := cmd.Flags().GetBool("non-interactive")
 		roleFlag, _ := cmd.Flags().GetString("role")
@@ -368,6 +369,14 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 		// docs/adr/0002-init-safety-invariants.md).
 		if !reinitLocal {
 			if err := checkExistingBeadsData(prefix); err != nil {
+				// --init-if-missing makes init idempotent: when the workspace
+				// is already initialized, skip and exit 0 instead of aborting.
+				if initIfMissing {
+					if !quiet {
+						fmt.Fprintln(os.Stderr, "Skipping init: workspace already initialized.")
+					}
+					return
+				}
 				FatalError("%v", err)
 			}
 		}
@@ -1641,6 +1650,7 @@ func init() {
 	initCmd.Flags().Bool("reinit-local", false, "Re-initialize local .beads/ over existing local data. Does NOT authorize remote divergence; see --discard-remote.")
 	initCmd.Flags().Bool("discard-remote", false, "Authorize discarding the configured remote's Dolt history when re-initializing. Requires --destroy-token in non-interactive mode; see 'bd help init-safety'.")
 	initCmd.Flags().Bool("from-jsonl", false, "Import issues from configured import.path instead of git history")
+	initCmd.Flags().Bool("init-if-missing", false, "If the workspace is already initialized, skip init and exit 0 instead of failing (idempotent init for scaffolds)")
 	initCmd.Flags().String("destroy-token", "", "Explicit confirmation token for destructive re-init in non-interactive mode (format: 'DESTROY-<prefix>')")
 	initCmd.Flags().String("agents-template", "", "Path to custom AGENTS.md template (overrides embedded default)")
 	initCmd.Flags().String("agents-profile", "", "AGENTS.md profile: 'minimal' (default, pointer to bd prime) or 'full' (complete command reference)")

--- a/cmd/bd/init.go
+++ b/cmd/bd/init.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bufio"
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -369,17 +370,25 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 		// docs/adr/0002-init-safety-invariants.md).
 		if !reinitLocal {
 			if err := checkExistingBeadsData(prefix); err != nil {
-				// --init-if-missing makes init idempotent: when the workspace
-				// is already initialized, skip and exit 0 instead of aborting.
-				if initIfMissing {
-					// Guard against masking a genuine mismatch: if the caller
-					// explicitly requested a --prefix that does not match the
-					// existing workspace, silently skipping would ignore the
-					// request. Abort as usual in that case. (Skipped when
-					// --database is set, since that overrides prefix-based
-					// naming and is the authoritative database selector.)
-					if cmd.Flags().Changed("prefix") && !cmd.Flags().Changed("database") {
-						if existing := existingWorkspaceDBName(); initIfMissingPrefixMismatch(existing, prefix) {
+				// --init-if-missing makes init idempotent, but ONLY for the
+				// benign "workspace already initialized" case. An operational
+				// error from the check (e.g. an unreadable .beads/embeddeddolt
+				// directory) must still abort rather than be masked as a
+				// successful skip.
+				if initIfMissing && errors.Is(err, errWorkspaceAlreadyInitialized) {
+					// Guard against masking a genuine mismatch: an explicit
+					// --prefix or --database that does not match the existing
+					// workspace must abort, since silently skipping would ignore
+					// the request and reuse a different database. --database is
+					// the authoritative selector, so it is checked even when
+					// --prefix is also set.
+					existing := existingWorkspaceDBName()
+					if cmd.Flags().Changed("database") {
+						if initIfMissingDatabaseMismatch(existing, database) {
+							FatalError("workspace already initialized as database %q, but --database %q was requested.\nRemove --database (or pass a matching value) to reuse the existing workspace.", existing, database)
+						}
+					} else if cmd.Flags().Changed("prefix") {
+						if initIfMissingPrefixMismatch(existing, prefix) {
 							FatalError("workspace already initialized as database %q, but --prefix %q was requested.\nRemove --prefix (or pass a matching value) to reuse the existing workspace.", existing, prefix)
 						}
 					}
@@ -1754,8 +1763,34 @@ func migrateOldDatabases(targetPath string, quiet bool) error {
 	return nil
 }
 
+// errWorkspaceAlreadyInitialized marks the benign "this workspace already has a
+// database" outcome from checkExistingBeadsData. --init-if-missing treats only
+// this case as an idempotent skip; any other error from the check is operational
+// (e.g. an unreadable .beads/embeddeddolt directory) and must still abort rather
+// than be silently masked as success.
+var errWorkspaceAlreadyInitialized = errors.New("workspace already initialized")
+
+// workspaceExistsError carries a user-facing "already initialized" message while
+// still matching errWorkspaceAlreadyInitialized via errors.Is, so callers can
+// distinguish the benign case without the sentinel text leaking into the message.
+type workspaceExistsError struct{ msg string }
+
+func (e *workspaceExistsError) Error() string { return e.msg }
+func (e *workspaceExistsError) Is(target error) bool {
+	return target == errWorkspaceAlreadyInitialized
+}
+
+// alreadyInitialized builds a workspaceExistsError from a formatted message.
+func alreadyInitialized(format string, args ...any) error {
+	return &workspaceExistsError{msg: fmt.Sprintf(format, args...)}
+}
+
 // checkExistingBeadsDataAt checks for existing database at a specific beadsDir path.
 // This is extracted to support both BEADS_DIR and CWD-based resolution.
+//
+// A returned error that matches errWorkspaceAlreadyInitialized means a database
+// already exists (the benign, idempotent-skip case); any other error is
+// operational and must not be treated as success.
 func checkExistingBeadsDataAt(beadsDir string, prefix string) error {
 	// Check if .beads directory exists
 	if _, err := os.Stat(beadsDir); os.IsNotExist(err) {
@@ -1769,7 +1804,7 @@ func checkExistingBeadsDataAt(beadsDir string, prefix string) error {
 				return fmt.Errorf("resolve proxied server root: %w", rootErr)
 			}
 			if info, statErr := os.Stat(proxiedRoot); statErr == nil && info.IsDir() {
-				return fmt.Errorf(`
+				return alreadyInitialized(`
 %s Found existing Dolt database: %s
 
 This workspace is already initialized.
@@ -1801,7 +1836,7 @@ Aborting.`, ui.RenderWarn("⚠"), proxiedRoot, ui.RenderAccent("bd list"))
 				}
 				if info, statErr := os.Stat(filepath.Join(embeddedRoot, entry.Name(), ".dolt")); statErr == nil && info.IsDir() {
 					location := filepath.Join(embeddedRoot, entry.Name())
-					return fmt.Errorf(`
+					return alreadyInitialized(`
 %s Found existing Dolt database: %s
 
 This workspace is already initialized.
@@ -1862,7 +1897,7 @@ Aborting.`, ui.RenderWarn("⚠"), location, ui.RenderAccent("bd list"), prefix)
 				port := doltserver.DefaultConfig(beadsDir).Port
 				location = fmt.Sprintf("dolt server at %s:%d", host, port)
 			}
-			return fmt.Errorf(`
+			return alreadyInitialized(`
 %s Found existing Dolt database: %s
 
 This workspace is already initialized.
@@ -1887,7 +1922,7 @@ Aborting.`, ui.RenderWarn("⚠"), location, ui.RenderAccent("bd list"), prefix)
 	if redirectTarget != beadsDir {
 		targetDBPath := filepath.Join(redirectTarget, beads.CanonicalDatabaseName)
 		if _, err := os.Stat(targetDBPath); err == nil {
-			return fmt.Errorf(`
+			return alreadyInitialized(`
 %s Cannot init: redirect target already has database
 
 Local .beads redirects to: %s
@@ -1911,7 +1946,7 @@ Aborting.`, ui.RenderWarn("⚠"), redirectTarget, targetDBPath, ui.RenderAccent(
 	// Check for existing database file (no redirect case)
 	dbPath := filepath.Join(beadsDir, beads.CanonicalDatabaseName)
 	if _, err := os.Stat(dbPath); err == nil {
-		return fmt.Errorf(`
+		return alreadyInitialized(`
 %s Found existing database: %s
 
 This workspace is already initialized.
@@ -2007,6 +2042,20 @@ func initIfMissingPrefixMismatch(existingDBName, requestedPrefix string) bool {
 	}
 	requested := dbNameFromPrefix(normalizeIssuePrefix(requestedPrefix))
 	return requested != "" && !strings.EqualFold(existingDBName, requested)
+}
+
+// initIfMissingDatabaseMismatch reports whether an explicit --database request
+// conflicts with the existing workspace. --database is the authoritative database
+// selector (it overrides prefix-based naming later in init), so an explicit
+// mismatch must abort --init-if-missing rather than silently reuse a different
+// database. existingDBName is the existing workspace's recorded Dolt database
+// name; requestedDatabase is the raw --database value. Returns false when either
+// is unknown so an undeterminable state falls through to the benign skip.
+func initIfMissingDatabaseMismatch(existingDBName, requestedDatabase string) bool {
+	if existingDBName == "" || requestedDatabase == "" {
+		return false
+	}
+	return !strings.EqualFold(existingDBName, requestedDatabase)
 }
 
 // resolveInitBeadsDir resolves the .beads directory that init would target,

--- a/cmd/bd/init_test.go
+++ b/cmd/bd/init_test.go
@@ -5,6 +5,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -381,6 +382,81 @@ func TestInitIfMissingMatchingPrefixSkips(t *testing.T) {
 	if !strings.Contains(stderr, "Skipping init: workspace already initialized") {
 		t.Errorf("expected benign skip message, got:\n%s", stderr)
 	}
+}
+
+func TestInitIfMissingDatabaseMismatch(t *testing.T) {
+	tests := []struct {
+		name      string
+		existing  string
+		requested string
+		want      bool
+	}{
+		{name: "exact match", existing: "foo", requested: "foo", want: false},
+		{name: "case-insensitive match", existing: "Foo", requested: "foo", want: false},
+		{name: "genuine mismatch aborts", existing: "foo", requested: "bar", want: true},
+		{name: "unknown existing falls through", existing: "", requested: "bar", want: false},
+		{name: "empty requested falls through", existing: "foo", requested: "", want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := initIfMissingDatabaseMismatch(tt.existing, tt.requested); got != tt.want {
+				t.Errorf("initIfMissingDatabaseMismatch(%q, %q) = %v, want %v",
+					tt.existing, tt.requested, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestCheckExistingBeadsDataOperationalErrorNotMasked verifies the core of the
+// --init-if-missing idempotency fix: only the benign "already initialized"
+// outcome matches errWorkspaceAlreadyInitialized (and may be skipped), while an
+// operational failure must NOT match it — otherwise --init-if-missing would mask
+// a real error (e.g. an unreadable .beads/embeddeddolt) as a successful skip.
+func TestCheckExistingBeadsDataOperationalErrorNotMasked(t *testing.T) {
+	saveEmbeddedConfig := func(t *testing.T, beadsDir string) {
+		t.Helper()
+		cfg := &configfile.Config{
+			Database: "dolt",
+			Backend:  configfile.BackendDolt,
+			DoltMode: configfile.DoltModeEmbedded,
+		}
+		if err := cfg.Save(beadsDir); err != nil {
+			t.Fatalf("save config: %v", err)
+		}
+	}
+
+	t.Run("existing database matches sentinel", func(t *testing.T) {
+		beadsDir := t.TempDir()
+		saveEmbeddedConfig(t, beadsDir)
+		// A real embedded database lives at embeddeddolt/<db>/.dolt.
+		if err := os.MkdirAll(filepath.Join(beadsDir, "embeddeddolt", "mydb", ".dolt"), 0o750); err != nil {
+			t.Fatal(err)
+		}
+		err := checkExistingBeadsDataAt(beadsDir, "mydb")
+		if err == nil {
+			t.Fatal("expected already-initialized error, got nil")
+		}
+		if !errors.Is(err, errWorkspaceAlreadyInitialized) {
+			t.Errorf("existing-database error must match errWorkspaceAlreadyInitialized, got: %v", err)
+		}
+	})
+
+	t.Run("operational error not masked", func(t *testing.T) {
+		beadsDir := t.TempDir()
+		saveEmbeddedConfig(t, beadsDir)
+		// Make embeddeddolt a regular file so os.ReadDir fails with a
+		// non-IsNotExist (operational) error rather than "already initialized".
+		if err := os.WriteFile(filepath.Join(beadsDir, "embeddeddolt"), []byte("not a dir"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		err := checkExistingBeadsDataAt(beadsDir, "mydb")
+		if err == nil {
+			t.Fatal("expected operational error, got nil")
+		}
+		if errors.Is(err, errWorkspaceAlreadyInitialized) {
+			t.Errorf("operational error must NOT match errWorkspaceAlreadyInitialized (would be masked by --init-if-missing): %v", err)
+		}
+	})
 }
 
 func TestInitWithCustomDBPath(t *testing.T) {

--- a/cmd/bd/init_test.go
+++ b/cmd/bd/init_test.go
@@ -301,6 +301,88 @@ func TestInitIfMissing(t *testing.T) {
 	}
 }
 
+// TestInitIfMissingPrefixMismatch covers the guard that keeps --init-if-missing
+// from masking a genuine prefix mismatch (review follow-up on #4332/#3490): a
+// re-init that explicitly requests a different prefix than the existing
+// workspace must abort, while a matching prefix (after normalization) or an
+// undeterminable existing name must fall through to the benign skip.
+func TestInitIfMissingPrefixMismatch(t *testing.T) {
+	tests := []struct {
+		name      string
+		existing  string
+		requested string
+		want      bool
+	}{
+		{name: "exact match", existing: "foo", requested: "foo", want: false},
+		{name: "case-insensitive match", existing: "Foo", requested: "foo", want: false},
+		{name: "hyphen normalizes to underscore", existing: "my_proj", requested: "my-proj", want: false},
+		{name: "trailing hyphen trimmed", existing: "foo", requested: "foo-", want: false},
+		{name: "leading-digit gets bd_ prefix", existing: "bd_001", requested: "001", want: false},
+		{name: "genuine mismatch aborts", existing: "foo", requested: "bar", want: true},
+		{name: "unknown existing falls through", existing: "", requested: "bar", want: false},
+		{name: "empty requested falls through", existing: "foo", requested: "", want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := initIfMissingPrefixMismatch(tt.existing, tt.requested); got != tt.want {
+				t.Errorf("initIfMissingPrefixMismatch(%q, %q) = %v, want %v",
+					tt.existing, tt.requested, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestInitIfMissingMatchingPrefixSkips verifies the mismatch guard does not
+// regress the happy path: re-running with the SAME explicit --prefix as the
+// existing workspace still skips cleanly (exit 0) rather than aborting.
+func TestInitIfMissingMatchingPrefixSkips(t *testing.T) {
+	skipIfNoDolt(t)
+	origDBPath := dbPath
+	resetInitFlags := func() {
+		_ = initCmd.Flags().Set("force", "false")
+		_ = initCmd.Flags().Set("reinit-local", "false")
+		_ = initCmd.Flags().Set("init-if-missing", "false")
+		_ = initCmd.Flags().Set("quiet", "false")
+		_ = initCmd.Flags().Set("prefix", "")
+	}
+	defer func() {
+		dbPath = origDBPath
+		resetInitFlags()
+	}()
+	dbPath = ""
+	resetInitFlags()
+
+	tmpDir := t.TempDir()
+	t.Chdir(tmpDir)
+
+	rootCmd.SetArgs([]string{"init", "--prefix", "test", "--quiet"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("First init failed: %v", err)
+	}
+
+	resetInitFlags()
+	oldStderr := os.Stderr
+	r, w, _ := os.Pipe()
+	os.Stderr = w
+
+	// Same prefix as the existing workspace: must skip, not abort.
+	rootCmd.SetArgs([]string{"init", "--prefix", "test", "--init-if-missing"})
+	execErr := rootCmd.Execute()
+
+	w.Close()
+	os.Stderr = oldStderr
+	var buf bytes.Buffer
+	buf.ReadFrom(r)
+	stderr := buf.String()
+
+	if execErr != nil {
+		t.Fatalf("init --init-if-missing with matching prefix should succeed, got: %v", execErr)
+	}
+	if !strings.Contains(stderr, "Skipping init: workspace already initialized") {
+		t.Errorf("expected benign skip message, got:\n%s", stderr)
+	}
+}
+
 func TestInitWithCustomDBPath(t *testing.T) {
 	t.Skip("BEADS_DB env var does not control Dolt store location; Dolt always uses .beads/dolt/")
 	// Save original state

--- a/cmd/bd/init_test.go
+++ b/cmd/bd/init_test.go
@@ -227,6 +227,80 @@ func TestInitAlreadyInitialized(t *testing.T) {
 	}
 }
 
+// GH#3490: `bd init --init-if-missing` makes init idempotent for scaffold
+// scripts. When the workspace is already initialized, init must skip and
+// return without error (exit 0), emitting a benign "Skipping init" message,
+// instead of aborting via os.Exit(1). The default (no-flag) abort path calls
+// os.Exit(1) and therefore cannot be exercised in-process (see the note above
+// TestInitAlreadyInitialized); this test covers the new success path.
+func TestInitIfMissing(t *testing.T) {
+	skipIfNoDolt(t)
+	// Reset global state
+	origDBPath := dbPath
+
+	// Cobra flag values persist across Execute() calls on the shared command
+	// tree (a sibling test may have left --force set, and our own first init
+	// sets --quiet). Normalize the flags this test depends on before each run,
+	// and restore defaults afterward so we neither inherit nor leak state.
+	resetInitFlags := func() {
+		_ = initCmd.Flags().Set("force", "false")
+		_ = initCmd.Flags().Set("reinit-local", "false")
+		_ = initCmd.Flags().Set("init-if-missing", "false")
+		_ = initCmd.Flags().Set("quiet", "false")
+		_ = initCmd.Flags().Set("prefix", "")
+	}
+	defer func() {
+		dbPath = origDBPath
+		resetInitFlags()
+	}()
+	dbPath = ""
+	resetInitFlags()
+
+	tmpDir := t.TempDir()
+	t.Chdir(tmpDir)
+
+	// First init creates the workspace.
+	rootCmd.SetArgs([]string{"init", "--prefix", "test", "--quiet"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("First init failed: %v", err)
+	}
+
+	// Re-running with --init-if-missing must be a benign no-op that exits 0:
+	// Execute() returns nil rather than the process aborting via os.Exit(1).
+	// Clear --quiet (set by the first run) so the skip message is emitted, and
+	// ensure no stale --force bypasses the already-initialized guard.
+	resetInitFlags()
+
+	oldStderr := os.Stderr
+	r, w, _ := os.Pipe()
+	os.Stderr = w
+
+	rootCmd.SetArgs([]string{"init", "--prefix", "test", "--init-if-missing"})
+	execErr := rootCmd.Execute()
+
+	w.Close()
+	os.Stderr = oldStderr
+	var buf bytes.Buffer
+	buf.ReadFrom(r)
+	stderr := buf.String()
+
+	if execErr != nil {
+		t.Fatalf("init --init-if-missing on an initialized workspace should succeed, got: %v", execErr)
+	}
+	if !strings.Contains(stderr, "Skipping init: workspace already initialized") {
+		t.Errorf("expected a 'Skipping init: workspace already initialized' message on stderr, got:\n%s", stderr)
+	}
+
+	// The skip is a no-op: the existing workspace must remain in place (init
+	// returned before touching any data). We assert on the .beads directory
+	// rather than a specific backend layout so the test holds for both the
+	// embedded and server test modes.
+	beadsDir := filepath.Join(tmpDir, ".beads")
+	if info, err := os.Stat(beadsDir); err != nil || !info.IsDir() {
+		t.Fatalf("expected existing .beads workspace to remain at %s, stat err: %v", beadsDir, err)
+	}
+}
+
 func TestInitWithCustomDBPath(t *testing.T) {
 	t.Skip("BEADS_DB env var does not control Dolt store location; Dolt always uses .beads/dolt/")
 	// Save original state

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -3395,6 +3395,7 @@ bd init [flags]
       --external                                       Server is externally managed (skip server startup); use with --shared-server or --server
       --force                                          Deprecated alias for --reinit-local. Bypasses only the LOCAL data-safety guard; does NOT authorize remote divergence (see 'bd help init-safety').
       --from-jsonl                                     Import issues from configured import.path instead of git history
+      --init-if-missing                                If the workspace is already initialized, skip init and exit 0 instead of failing (idempotent init for scaffolds)
       --non-interactive                                Skip all interactive prompts (auto-detected in CI or non-TTY environments)
   -p, --prefix string                                  Issue prefix (default: current directory name)
       --proxied-server                                 [EXPERIMENTAL] Use a per-workspace proxied dolt sql-server (proxy + child dolt) rooted at .beads/proxieddb

--- a/website/docs/cli-reference/init.md
+++ b/website/docs/cli-reference/init.md
@@ -63,6 +63,7 @@ bd init [flags]
       --external                                       Server is externally managed (skip server startup); use with --shared-server or --server
       --force                                          Deprecated alias for --reinit-local. Bypasses only the LOCAL data-safety guard; does NOT authorize remote divergence (see 'bd help init-safety').
       --from-jsonl                                     Import issues from configured import.path instead of git history
+      --init-if-missing                                If the workspace is already initialized, skip init and exit 0 instead of failing (idempotent init for scaffolds)
       --non-interactive                                Skip all interactive prompts (auto-detected in CI or non-TTY environments)
   -p, --prefix string                                  Issue prefix (default: current directory name)
       --proxied-server                                 [EXPERIMENTAL] Use a per-workspace proxied dolt sql-server (proxy + child dolt) rooted at .beads/proxieddb

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -6506,6 +6506,7 @@ bd init [flags]
       --external                                       Server is externally managed (skip server startup); use with --shared-server or --server
       --force                                          Deprecated alias for --reinit-local. Bypasses only the LOCAL data-safety guard; does NOT authorize remote divergence (see 'bd help init-safety').
       --from-jsonl                                     Import issues from configured import.path instead of git history
+      --init-if-missing                                If the workspace is already initialized, skip init and exit 0 instead of failing (idempotent init for scaffolds)
       --non-interactive                                Skip all interactive prompts (auto-detected in CI or non-TTY environments)
   -p, --prefix string                                  Issue prefix (default: current directory name)
       --proxied-server                                 [EXPERIMENTAL] Use a per-workspace proxied dolt sql-server (proxy + child dolt) rooted at .beads/proxieddb

--- a/website/versioned_docs/version-1.0.0/cli-reference/init.md
+++ b/website/versioned_docs/version-1.0.0/cli-reference/init.md
@@ -63,6 +63,7 @@ bd init [flags]
       --external                                       Server is externally managed (skip server startup); use with --shared-server or --server
       --force                                          Deprecated alias for --reinit-local. Bypasses only the LOCAL data-safety guard; does NOT authorize remote divergence (see 'bd help init-safety').
       --from-jsonl                                     Import issues from configured import.path instead of git history
+      --init-if-missing                                If the workspace is already initialized, skip init and exit 0 instead of failing (idempotent init for scaffolds)
       --non-interactive                                Skip all interactive prompts (auto-detected in CI or non-TTY environments)
   -p, --prefix string                                  Issue prefix (default: current directory name)
       --proxied-server                                 [EXPERIMENTAL] Use a per-workspace proxied dolt sql-server (proxy + child dolt) rooted at .beads/proxieddb

--- a/website/versioned_docs/version-1.0.4/cli-reference/init.md
+++ b/website/versioned_docs/version-1.0.4/cli-reference/init.md
@@ -63,6 +63,7 @@ bd init [flags]
       --external                                       Server is externally managed (skip server startup); use with --shared-server or --server
       --force                                          Deprecated alias for --reinit-local. Bypasses only the LOCAL data-safety guard; does NOT authorize remote divergence (see 'bd help init-safety').
       --from-jsonl                                     Import issues from configured import.path instead of git history
+      --init-if-missing                                If the workspace is already initialized, skip init and exit 0 instead of failing (idempotent init for scaffolds)
       --non-interactive                                Skip all interactive prompts (auto-detected in CI or non-TTY environments)
   -p, --prefix string                                  Issue prefix (default: current directory name)
       --proxied-server                                 [EXPERIMENTAL] Use a per-workspace proxied dolt sql-server (proxy + child dolt) rooted at .beads/proxieddb

--- a/website/versioned_docs/version-1.0.5/cli-reference/init.md
+++ b/website/versioned_docs/version-1.0.5/cli-reference/init.md
@@ -63,6 +63,7 @@ bd init [flags]
       --external                                       Server is externally managed (skip server startup); use with --shared-server or --server
       --force                                          Deprecated alias for --reinit-local. Bypasses only the LOCAL data-safety guard; does NOT authorize remote divergence (see 'bd help init-safety').
       --from-jsonl                                     Import issues from configured import.path instead of git history
+      --init-if-missing                                If the workspace is already initialized, skip init and exit 0 instead of failing (idempotent init for scaffolds)
       --non-interactive                                Skip all interactive prompts (auto-detected in CI or non-TTY environments)
   -p, --prefix string                                  Issue prefix (default: current directory name)
       --proxied-server                                 [EXPERIMENTAL] Use a per-workspace proxied dolt sql-server (proxy + child dolt) rooted at .beads/proxieddb


### PR DESCRIPTION
## Summary

Closes #3490.

`bd init` aborts with exit 1 when the workspace is already initialized. Scaffold/bootstrap scripts that just want "ensure a workspace exists" must therefore pre-`stat` `.beads/embeddeddolt/<prefix>` to distinguish the benign "already initialized" case from a real error — a footgun.

This adds an opt-in **`--init-if-missing`** flag for idempotent init:

- When the workspace is already initialized, init prints `Skipping init: workspace already initialized.` to stderr (suppressed under `--quiet`) and exits **0** instead of aborting.
- Default behavior (flag absent) is **unchanged**: exit 1 with the existing "already initialized … Aborting" message.

This is framed as CLI ergonomics (generic idempotency), not orchestration policy, so it stays within the project charter's core scope.

## Implementation

- The flag is intercepted **only** at the existing `checkExistingBeadsData(prefix)` guard call site in `cmd/bd/init.go`. The detection logic (`checkExistingBeadsDataAt`) is untouched.
- `--force` / `--reinit-local` paths are unaffected (they bypass the guard as before).

## Non-goals

- Not changing the default abort behavior.
- Not auto-repairing/migrating an existing workspace.
- Not touching reinit-local paths.

## Tests

- `TestInitIfMissing` in `cmd/bd/init_test.go` (mirrors `TestInitAlreadyInitialized`): inits a workspace, then re-runs with `--init-if-missing` and asserts `Execute()` returns nil (exit 0) and emits the benign skip message. The default abort path calls `os.Exit(1)` and cannot be exercised in-process (documented limitation already noted in this file).
- Verified passing against a real Dolt container: `--- PASS: TestInitIfMissing`.

## Docs

- `docs/CLI_REFERENCE.md`, website CLI reference pages, and `website/static/llms-full.txt` regenerated via `scripts/generate-cli-docs.sh` + `scripts/generate-llms-full.sh`; `./scripts/generate-cli-docs.sh --check` passes.

## Test plan

- [ ] `bd init --prefix foo` then `bd init --prefix foo --init-if-missing` exits 0 with the skip message
- [ ] `bd init --prefix foo` (no flag) on an initialized workspace still exits 1
- [ ] `--init-if-missing` appears in `bd init --help` and `docs/CLI_REFERENCE.md`

Made with [Cursor](https://cursor.com)