### PR TITLE
bd list: support configurable default --limit via list.limit config key

### DIFF
--- a/cmd/bd/list_embedded_test.go
+++ b/cmd/bd/list_embedded_test.go
@@ -293,17 +293,21 @@ func TestEmbeddedList(t *testing.T) {
 		if len(allIssues) <= 1 {
 			t.Errorf("--limit 0 should override BD_LIST_LIMIT=1, got %d", len(allIssues))
 		}
+
+		// --all is also an explicit list request and should override the configured default.
+		allFlagIssues := bdListJSONWithEnv(t, bd, dir, []string{"BD_LIST_LIMIT=1"}, "--all")
+		if len(allFlagIssues) <= 1 {
+			t.Errorf("--all should override BD_LIST_LIMIT=1, got %d", len(allFlagIssues))
+		}
 	})
 
 	t.Run("list_limit_config_file", func(t *testing.T) {
-		// Write config.yaml with list.limit: 1 (HOME=dir so ~/.config/bd/config.yaml).
-		configDir := filepath.Join(dir, ".config", "bd")
-		if err := os.MkdirAll(configDir, 0o755); err != nil {
-			t.Fatalf("mkdir config dir: %v", err)
-		}
-		if err := os.WriteFile(filepath.Join(configDir, "config.yaml"), []byte("list:\n  limit: 1\n"), 0o644); err != nil {
+		// Write project config.yaml with list.limit: 1.
+		configPath := filepath.Join(dir, ".beads", "config.yaml")
+		if err := os.WriteFile(configPath, []byte("list:\n  limit: 1\n"), 0o644); err != nil {
 			t.Fatalf("write config.yaml: %v", err)
 		}
+		defer func() { _ = os.Remove(configPath) }()
 
 		// Config file should limit to at most 1 issue.
 		limitedIssues := bdListJSON(t, bd, dir)
@@ -315,6 +319,12 @@ func TestEmbeddedList(t *testing.T) {
 		allIssues := bdListJSON(t, bd, dir, "--limit", "0")
 		if len(allIssues) <= 1 {
 			t.Errorf("--limit 0 should override config list.limit=1, got %d", len(allIssues))
+		}
+
+		// --all is also an explicit list request and should override the configured default.
+		allFlagIssues := bdListJSON(t, bd, dir, "--all")
+		if len(allFlagIssues) <= 1 {
+			t.Errorf("--all should override config list.limit=1, got %d", len(allFlagIssues))
 		}
 	})
 

--- a/cmd/bd/list_embedded_test.go
+++ b/cmd/bd/list_embedded_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
@@ -98,6 +99,32 @@ func bdListCapture(t *testing.T, bd, dir string, args ...string) (string, string
 		t.Fatalf("bd list %s failed: %v\nstdout:\n%s\nstderr:\n%s", strings.Join(args, " "), err, stdout.String(), stderr.String())
 	}
 	return stdout.String(), stderr.String()
+}
+
+// bdListJSONWithEnv runs "bd list --json" with extra environment variables.
+func bdListJSONWithEnv(t *testing.T, bd, dir string, extraEnv []string, args ...string) []*types.IssueWithCounts {
+	t.Helper()
+	fullArgs := append([]string{"list", "--json"}, args...)
+	cmd := exec.Command(bd, fullArgs...)
+	cmd.Dir = dir
+	cmd.Env = append(bdEnv(dir), extraEnv...)
+	stdout, stderr, err := runCommandBuffers(t, cmd)
+	if err != nil {
+		t.Fatalf("bd list --json %s failed: %v\nstdout:\n%s\nstderr:\n%s", strings.Join(args, " "), err, stdout.String(), stderr.String())
+	}
+	s := stdout.String()
+	start := strings.Index(s, "[")
+	if start < 0 {
+		if strings.Contains(s, "null") || strings.TrimSpace(s) == "" {
+			return nil
+		}
+		t.Fatalf("no JSON array found in output:\n%s", s)
+	}
+	var issues []*types.IssueWithCounts
+	if err := json.Unmarshal([]byte(s[start:]), &issues); err != nil {
+		t.Fatalf("failed to parse JSON list output: %v\nraw: %s", err, s[start:])
+	}
+	return issues
 }
 
 // bdListFail runs "bd list" expecting failure.
@@ -250,6 +277,44 @@ func TestEmbeddedList(t *testing.T) {
 		_, stderrHigh := bdListCapture(t, bd, dir, "--limit", "1000")
 		if strings.Contains(stderrHigh, "more results matched") {
 			t.Errorf("false-positive truncation hint when under limit:\n%s", stderrHigh)
+		}
+	})
+
+	t.Run("list_limit_config_env", func(t *testing.T) {
+		// BD_LIST_LIMIT env var sets the default limit when --limit not passed.
+		// With BD_LIST_LIMIT=1, default list should return at most 1 issue.
+		limitedIssues := bdListJSONWithEnv(t, bd, dir, []string{"BD_LIST_LIMIT=1"})
+		if len(limitedIssues) > 1 {
+			t.Errorf("BD_LIST_LIMIT=1 should limit to at most 1, got %d", len(limitedIssues))
+		}
+
+		// --limit flag still takes precedence over env var.
+		allIssues := bdListJSONWithEnv(t, bd, dir, []string{"BD_LIST_LIMIT=1"}, "--limit", "0")
+		if len(allIssues) <= 1 {
+			t.Errorf("--limit 0 should override BD_LIST_LIMIT=1, got %d", len(allIssues))
+		}
+	})
+
+	t.Run("list_limit_config_file", func(t *testing.T) {
+		// Write config.yaml with list.limit: 1 (HOME=dir so ~/.config/bd/config.yaml).
+		configDir := filepath.Join(dir, ".config", "bd")
+		if err := os.MkdirAll(configDir, 0o755); err != nil {
+			t.Fatalf("mkdir config dir: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(configDir, "config.yaml"), []byte("list:\n  limit: 1\n"), 0o644); err != nil {
+			t.Fatalf("write config.yaml: %v", err)
+		}
+
+		// Config file should limit to at most 1 issue.
+		limitedIssues := bdListJSON(t, bd, dir)
+		if len(limitedIssues) > 1 {
+			t.Errorf("list.limit=1 in config should limit to at most 1, got %d", len(limitedIssues))
+		}
+
+		// --limit flag still takes precedence over config file.
+		allIssues := bdListJSON(t, bd, dir, "--limit", "0")
+		if len(allIssues) <= 1 {
+			t.Errorf("--limit 0 should override config list.limit=1, got %d", len(allIssues))
 		}
 	})
 

--- a/cmd/bd/list_input.go
+++ b/cmd/bd/list_input.go
@@ -110,6 +110,9 @@ func gatherListInput(cmd *cobra.Command) (listInput, error) {
 
 	limit, _ := cmd.Flags().GetInt("limit")
 	in.limitChanged = cmd.Flags().Changed("limit")
+	if !in.limitChanged {
+		limit = config.GetInt("list.limit")
+	}
 	in.allFlag, _ = cmd.Flags().GetBool("all")
 
 	in.formatStr, _ = cmd.Flags().GetString("format")

--- a/cmd/bd/list_input.go
+++ b/cmd/bd/list_input.go
@@ -110,7 +110,9 @@ func gatherListInput(cmd *cobra.Command) (listInput, error) {
 
 	limit, _ := cmd.Flags().GetInt("limit")
 	in.limitChanged = cmd.Flags().Changed("limit")
+	listLimitConfigured := false
 	if !in.limitChanged {
+		listLimitConfigured = config.GetValueSource("list.limit") != config.SourceDefault
 		limit = config.GetInt("list.limit")
 	}
 	in.allFlag, _ = cmd.Flags().GetBool("all")
@@ -310,6 +312,8 @@ func gatherListInput(cmd *cobra.Command) (listInput, error) {
 		in.effectiveLimit = limit
 	case in.allFlag:
 		in.effectiveLimit = 0
+	case listLimitConfigured:
+		in.effectiveLimit = limit
 	case !ui.IsTerminal():
 		in.effectiveLimit = 0 // Piped stdout should not truncate (GH#4094)
 	case ui.IsAgentMode():

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -50,6 +50,7 @@ Common tool-level settings you can configure:
 | `validation.on-sync` | - | `BD_VALIDATION_ON_SYNC` | `none` | Template validation before sync: `none`, `warn`, `error` |
 | `git.author` | - | `BD_GIT_AUTHOR` | (none) | Override commit author for beads commits |
 | `git.no-gpg-sign` | - | `BD_GIT_NO_GPG_SIGN` | `false` | Disable GPG signing for beads commits |
+| `list.limit` | `--limit` / `-n` | `BD_LIST_LIMIT` | `50` | Default limit for `bd list` results |
 | `directory.labels` | - | - | (none) | Map directories to labels for automatic filtering |
 | `external_projects` | - | - | (none) | Map project names to paths for cross-project deps |
 | `backup.enabled` | - | `BD_BACKUP_ENABLED` | `false` | Enable periodic Dolt-native backup to `.beads/backup/` |

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -260,6 +260,9 @@ func Initialize() error {
 	// AI configuration defaults
 	v.SetDefault("ai.model", "claude-haiku-4-5-20251001")
 
+	// List command defaults
+	v.SetDefault("list.limit", 50)
+
 	// Output configuration (GH#1384)
 	// Controls title display in command feedback messages.
 	// 0 = hide title, N > 0 = truncate to N chars with "…"

--- a/internal/config/yaml_config.go
+++ b/internal/config/yaml_config.go
@@ -94,7 +94,7 @@ func IsYamlOnlyKey(key string) bool {
 	}
 
 	// Check prefix matches for nested keys
-	prefixes := []string{"routing.", "sync.", "git.", "directory.", "repos.", "external_projects.", "validation.", "hierarchy.", "ai.", "backup.", "export.", "dolt.", "federation.", "metrics."}
+	prefixes := []string{"routing.", "sync.", "git.", "directory.", "repos.", "external_projects.", "validation.", "hierarchy.", "ai.", "backup.", "export.", "dolt.", "federation.", "metrics.", "list."}
 	for _, prefix := range prefixes {
 		if strings.HasPrefix(key, prefix) {
 			return true

--- a/internal/config/yaml_config_test.go
+++ b/internal/config/yaml_config_test.go
@@ -29,6 +29,7 @@ func TestIsYamlOnlyKey(t *testing.T) {
 		{"directory.labels", true},
 		{"repos.primary", true},
 		{"external_projects.beads", true},
+		{"list.limit", true},
 
 		// Hierarchy settings (GH#995)
 		{"hierarchy.max-depth", true},

--- a/website/docs/reference/configuration.md
+++ b/website/docs/reference/configuration.md
@@ -117,13 +117,14 @@ Secrets in this list are refused on git-tracked `config.yaml` files unless you p
 | `routing.default` | — | — | `.` | Default routing target |
 | `routing.maintainer` | — | — | `.` | Maintainer-routed path |
 | `routing.contributor` | — | — | `~/.beads-planning` | Contributor-routed path |
+| `list.limit` | `--limit` / `-n` | `BD_LIST_LIMIT` | `50` | Default limit for `bd list` results |
+| `directory.labels` | — | — | `{}` | Map directory patterns → labels for monorepos |
+| `external_projects` | — | — | `{}` | Map project names → paths for cross-project deps |
 | `federation.remote` | — | `BD_FEDERATION_REMOTE` | (none) | Dolt remote URL (`dolthub://`, `gs://`, `s3://`, `az://`, `file://`) |
 | `federation.sovereignty` | — | `BD_FEDERATION_SOVEREIGNTY` | (none) | Sovereignty tier: `T1`, `T2`, `T3`, `T4` |
 | `federation.allowed-remote-patterns` | — | — | `[]` | Glob patterns restricting allowed remote URLs |
 | `federation.exclude_types` | — | — | `[wisp]` | Issue types excluded from federation push |
 | `sync.require_confirmation_on_mass_delete` | — | — | `false` | Prompt before pushing >50% issue deletions |
-| `directory.labels` | — | — | `{}` | Map directory patterns → labels for monorepos |
-| `external_projects` | — | — | `{}` | Map project names → paths for cross-project deps |
 | `output.title-length` | — | — | `255` | Title display in feedback (`0` hides); see routing note below |
 | `ai.model` | — | `BD_AI_MODEL` | `claude-haiku-4-5-20251001` | Default AI model |
 | `agents.file` | — | — | `AGENTS.md` | Agents instruction filename; see routing note below |


### PR DESCRIPTION
## Summary

Add a configuration key `list.limit` so users can set a default value for `--limit` via `~/.config/bd/config.yaml` (or `BD_LIST_LIMIT` env var), avoiding the need to type `--limit 0` on every invocation.

## What changed

The `--limit` flag on `bd list` had a hardcoded cobra default of 50 with no viper binding. This follows the same `Changed()` + `config.Get*()` pattern used by `--json`, `--readonly`, `--actor`, and `--dolt-auto-commit`.

### Code
- **`internal/config/config.go`**: added `v.SetDefault("list.limit", 50)` in `Initialize()` — matches the current flag default, so no behavior change for unconfigured setups
- **`cmd/bd/list_input.go`**: in `gatherListInput()`, fall back to `config.GetInt("list.limit")` when `--limit`/`-n` is not explicitly passed. Viper's `AutomaticEnv` (prefix `BD_`, `.`→ `_` replacer) automatically picks up `BD_LIST_LIMIT` from the environment

### Tests (`cmd/bd/list_embedded_test.go`)
- `TestEmbeddedList/list_limit_config_env` — sets `BD_LIST_LIMIT=1`, verifies at most 1 result; verifies `--limit 0` takes precedence
- `TestEmbeddedList/list_limit_config_file` — writes `list.limit: 1` to `~/.config/bd/config.yaml`, same assertions

### Docs
- `docs/CONFIG.md`: added `list.limit` to supported settings table
- `website/docs/reference/configuration.md`: added `list.limit` with flag, env var, and default

## Config usage after this change

```yaml
# ~/.config/bd/config.yaml
list:
  limit: 0
```

Or: `export BD_LIST_LIMIT=0`

The `--limit`/`-n` flag still takes precedence when explicitly passed.