### PR TITLE
fix(context): tolerate non-git scopes in GetRepoContext

### DIFF
--- a/internal/beads/context.go
+++ b/internal/beads/context.go
@@ -128,11 +128,16 @@ func buildRepoContext() (*RepoContext, error) {
 		// Beads dir is in a different repo - use that repo's root
 		repoRoot = repoRootForBeadsDir(beadsDir)
 	} else {
-		// Normal case - find repo root via git
+		// Normal case - find repo root via git.
 		var err error
 		repoRoot, err = git.GetMainRepoRoot()
 		if err != nil {
-			return nil, fmt.Errorf("cannot determine repository root: %w", err)
+			// No enclosing git repository (e.g. a non-git city/HQ scope that
+			// holds a .beads store but is not itself version-controlled). bd
+			// operates on the .beads store directly in dolt-server mode and
+			// does not need a git root here, so fall back to the directory
+			// that contains .beads rather than failing context resolution.
+			repoRoot = filepath.Dir(beadsDir)
 		}
 	}
 

--- a/internal/beads/context_test.go
+++ b/internal/beads/context_test.go
@@ -675,6 +675,61 @@ func TestGetRepoContext_BEADS_DIR_ExternalRepo(t *testing.T) {
 	}
 }
 
+// TestGetRepoContext_NonGitScope verifies that GetRepoContext tolerates a .beads
+// store living in a directory that is not itself a git repository — e.g. a Gas
+// City / HQ scope in dolt-server mode, which holds a .beads store but is not
+// version-controlled. Rather than failing with "cannot determine repository
+// root", it must fall back to the directory that contains .beads.
+func TestGetRepoContext_NonGitScope(t *testing.T) {
+	originalBeadsDir := os.Getenv("BEADS_DIR")
+	originalWd, _ := os.Getwd()
+	t.Cleanup(func() {
+		if originalBeadsDir != "" {
+			os.Setenv("BEADS_DIR", originalBeadsDir)
+		} else {
+			os.Unsetenv("BEADS_DIR")
+		}
+		os.Chdir(originalWd)
+		ResetCaches()
+		git.ResetCaches()
+	})
+
+	// A plain, NON-git directory that holds a .beads store (no git init).
+	nonGitScope := t.TempDir()
+	beadsDir := filepath.Join(nonGitScope, ".beads")
+	if err := os.MkdirAll(beadsDir, 0750); err != nil {
+		t.Fatalf("failed to create .beads dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(beadsDir, "beads.db"), []byte{}, 0644); err != nil {
+		t.Fatalf("failed to create beads.db: %v", err)
+	}
+
+	// Resolve via cwd with no BEADS_DIR redirect, so we exercise the
+	// non-external branch where git.GetMainRepoRoot() fails.
+	os.Unsetenv("BEADS_DIR")
+	if err := os.Chdir(nonGitScope); err != nil {
+		t.Fatalf("failed to chdir into non-git scope: %v", err)
+	}
+	ResetCaches()
+	git.ResetCaches()
+
+	rc, err := GetRepoContext()
+	if err != nil {
+		t.Fatalf("GetRepoContext should tolerate a non-git scope, got error: %v", err)
+	}
+
+	// RepoRoot must fall back to the directory that contains .beads.
+	if want := resolveSymlinks(nonGitScope); rc.RepoRoot != want {
+		t.Errorf("RepoRoot = %q, want fallback to .beads parent %q", rc.RepoRoot, want)
+	}
+	if want := resolveSymlinks(beadsDir); rc.BeadsDir != want {
+		t.Errorf("BeadsDir = %q, want %q", rc.BeadsDir, want)
+	}
+	if rc.IsRedirected {
+		t.Error("IsRedirected should be false for a local non-git scope")
+	}
+}
+
 // TestRole_BEADS_DIR_ImpliesContributor tests that BEADS_DIR redirect
 // implicitly returns Contributor role without requiring git config.
 func TestRole_BEADS_DIR_ImpliesContributor(t *testing.T) {


### PR DESCRIPTION
## What

`GetRepoContext()` (and therefore `bd context` and every other caller) now falls back to the directory that contains `.beads` when there is no enclosing git repository, instead of failing with `cannot determine repository root`.

## Why

In dolt-server mode bd does not need a git root — it operates on the `.beads` store directly. But a `.beads` store can legitimately live in a directory that is **not itself version-controlled**, e.g. a Gas City / HQ scope that holds a store but is not a git repo. In that scope, `git.GetMainRepoRoot()` fails and `buildRepoContext()` returned a hard error, so `bd context --json` (and anything that resolves repo context) blew up there.

Concretely this blocks orchestrators that shell out to `bd context --json` per scope — the gascity supervisor's `bd_context_agreement` preflight fails at the non-git city scope, taking the native store offline. The redirect/external-`BEADS_DIR` paths are unchanged; only the "no git root at all" case now degrades gracefully to the `.beads` parent.

## Verification

- New test `TestGetRepoContext_NonGitScope` (exercises a `.beads` store in a plain non-git dir; asserts `RepoRoot` falls back to the `.beads` parent, no error, `IsRedirected == false`).
- `CGO_ENABLED=1 go test -tags gms_pure_go ./internal/beads/` — passes.
- `CGO_ENABLED=1 go build -tags gms_pure_go ./cmd/bd/` — builds.
- `gofmt -l` clean.

Verified live: with this fix, `bd context --json` at a non-git city scope returns `backend=dolt, database=hq` instead of erroring, and the gascity supervisor's per-scope `bd context` handshake passes.
