### PR TITLE
fix(sec): use os/user.Current().HomeDir in isPathInSafeBoundary (SEC-003)

### DIFF
--- a/internal/beads/context.go
+++ b/internal/beads/context.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"os/user"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -332,7 +333,11 @@ func isPathInSafeBoundary(path string) bool {
 		}
 	}
 	// Also reject other users' home directories
-	homeDir, _ := os.UserHomeDir()
+	u, err := user.Current()
+	homeDir := ""
+	if err == nil {
+		homeDir = u.HomeDir
+	}
 	if strings.HasPrefix(absPath, "/Users/") || strings.HasPrefix(absPath, "/home/") || strings.HasPrefix(absPath, "/var/home/") {
 		if homeDir != "" && !strings.HasPrefix(absPath, homeDir) {
 			return false


### PR DESCRIPTION
## Summary

`isPathInSafeBoundary` in `internal/beads/context.go` uses `os.UserHomeDir()` to obtain the current user's home directory when rejecting paths under other users' home directories.

`os.UserHomeDir()` resolves via the `HOME` environment variable on Unix, which can be overridden or empty in restricted/container environments. `os/user.Current().HomeDir` reads from the password database directly and is not affected by environment variable manipulation.

## Change

- Replace `os.UserHomeDir()` with `os/user.Current().HomeDir` in `isPathInSafeBoundary`
- Handle the `user.Current()` error gracefully: if lookup fails, `homeDir` stays empty and the home-directory boundary check is skipped (same behavior as before — `os.UserHomeDir()` also ignores errors via `_, _`)

## Testing

- `TestIsPathInSafeBoundary`: all 13 cases pass
- `go vet ./...`: clean
- `go build ./...`: clean

## Security

This change is part of SEC-003 (safe-boundary robustness). The motivation: in multi-user or container setups where `HOME` is set to a different user's directory (or is unset), `os.UserHomeDir()` could return a wrong value, causing the boundary check to accept paths it should reject.