### PR TITLE
fix(storage): stop guaranteed-empty DOLT_COMMITs flooding the Dolt log on busy coordination DBs

### DIFF
--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -1690,7 +1690,23 @@ func (s *DoltStore) Commit(ctx context.Context, message string) (retErr error) {
 	// GH#2455: Stage all dirty tables EXCEPT config. Query dolt_status for
 	// dirty tables and stage each one individually, skipping config to avoid
 	// sweeping up stale issue_prefix changes from concurrent operations.
-	rows, err := conn.QueryContext(ctx, "SELECT table_name FROM dolt_status")
+	//
+	// Exclude dolt_ignore'd tables in the scan itself (same predicate as
+	// issueops.HasPendingChanges). Ignored tables (wisp_%, local_metadata, …)
+	// can sit PERMANENTLY dirty in dolt_status under wisp churn but can never
+	// be staged — DOLT_ADD on them fails and is skipped below. Without this
+	// exclusion the table list is non-empty whenever only ignored tables are
+	// dirty, so every write command issues a guaranteed-empty DOLT_COMMIT that
+	// the server rejects with "nothing to commit" — flooding the Dolt log and
+	// burning server CPU at orchestrator reconcile cadence (observed ~99% of
+	// all Dolt log lines on a busy coordination DB).
+	rows, err := conn.QueryContext(ctx, `
+		SELECT s.table_name FROM dolt_status s
+		WHERE NOT EXISTS (
+			SELECT 1 FROM dolt_ignore di
+			WHERE di.ignored = 1
+			AND s.table_name LIKE di.pattern
+		)`)
 	if err != nil {
 		// If dolt_status fails, fall back to nothing (rare edge case).
 		return fmt.Errorf("failed to query dolt_status: %w", err)

--- a/internal/storage/uow/doltserver_tx.go
+++ b/internal/storage/uow/doltserver_tx.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 
 	"github.com/steveyegge/beads/internal/storage/domain/db"
+	"github.com/steveyegge/beads/internal/storage/issueops"
 )
 
 type doltServerTx struct {
@@ -25,8 +26,43 @@ func (t *doltServerTx) Commit(ctx context.Context, message string) error {
 	}
 	t.done = true
 	defer t.releaseConn()
-	_, err := t.conn.ExecContext(ctx, "CALL DOLT_COMMIT('-Am', ?);", message)
-	return err
+
+	// Skip the no-op COMMIT that floods the Dolt log and burns server CPU when
+	// an idempotent write staged nothing — e.g. a same-value REPLACE INTO
+	// metadata, or a same-actor re-claim whose CAS UPDATE matched 0 rows. The
+	// gascity supervisor's desired-state reconciler re-applies unchanged
+	// session-bead state on every tick, so without this guard each such tick
+	// issues START TRANSACTION + an empty DOLT_COMMIT('-Am') that Dolt rejects
+	// server-side with "nothing to commit" (the work still succeeds; the COMMIT
+	// round-trip is pure wasted churn).
+	//
+	// DOLT_COMMIT('-Am') stages-and-commits the whole working set atomically, so
+	// nothing is pre-staged at this point. The correct gate is therefore the
+	// global working-set check (HasPendingChanges, which mirrors what '-Am' will
+	// sweep up and excludes dolt_ignore'd tables), NOT a staged-set count —
+	// that would always read 0 here and wrongly skip every real write. This
+	// connection is pinned to a single Dolt session (BeginTx pins t.conn and
+	// runs START TRANSACTION), so dolt_status reflects only this UOW's changes;
+	// the check is race-free with concurrent sessions.
+	pending, err := issueops.HasPendingChanges(ctx, t.conn)
+	if err != nil {
+		return err
+	}
+	if !pending {
+		return nil
+	}
+
+	if _, err := t.conn.ExecContext(ctx, "CALL DOLT_COMMIT('-Am', ?);", message); err != nil {
+		// Belt-and-suspenders: Dolt can still report "nothing to commit" for a
+		// working set that dolt_status counted as dirty (e.g. a row rewritten to
+		// its existing value). That is benign — swallow it rather than surface a
+		// non-error as an error.
+		if issueops.IsNothingToCommitError(err) {
+			return nil
+		}
+		return err
+	}
+	return nil
 }
 
 func (t *doltServerTx) Rollback(ctx context.Context) error {

--- a/internal/storage/uow/doltserver_tx_test.go
+++ b/internal/storage/uow/doltserver_tx_test.go
@@ -1,0 +1,155 @@
+package uow
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+)
+
+// matchHasPending matches the dolt_status working-set check issued by
+// issueops.HasPendingChanges. The guard in (*doltServerTx).Commit runs this
+// BEFORE deciding whether to issue DOLT_COMMIT('-Am', …).
+const matchHasPending = `SELECT COUNT\(\*\) FROM dolt_status`
+
+// matchDoltCommit matches the empty-commit-prone CALL DOLT_COMMIT('-Am', …).
+const matchDoltCommit = `CALL DOLT_COMMIT\('-Am'`
+
+// newMockConn returns a real *sql.Conn backed by sqlmock, plus the mock. The
+// guard calls issueops.HasPendingChanges(ctx, t.conn) and then t.conn.ExecContext
+// directly on this connection, so a sqlmock-backed *sql.Conn exercises the exact
+// production code path.
+func newMockConn(t *testing.T) (*sql.Conn, sqlmock.Sqlmock) {
+	t.Helper()
+	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherRegexp))
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	conn, err := db.Conn(context.Background())
+	if err != nil {
+		t.Fatalf("db.Conn: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = conn.Close()
+		_ = db.Close()
+	})
+	return conn, mock
+}
+
+// TestDoltServerTxCommitSkipsEmptyCommit is the discriminating regression test
+// for the high-frequency "nothing to commit" Dolt warning + CPU churn driven by
+// the proxied-server UnitOfWork commit path (internal/storage/uow/doltserver_tx.go).
+//
+// The bug: (*doltServerTx).Commit issued CALL DOLT_COMMIT('-Am', ?) UNCONDITIONALLY.
+// When an idempotent write (same-value REPLACE INTO metadata, same-actor 0-row
+// CAS re-claim) staged nothing, the '-Am' commit was rejected server-side with
+// "nothing to commit", logged as a warning and burning Dolt CPU evaluating the
+// empty commit — at the gascity reconciler's per-tick cadence this floods dolt.log.
+//
+// The fix gates the COMMIT on issueops.HasPendingChanges (the global working-set
+// check, which mirrors what '-Am' commits). This test asserts:
+//   - no-op (HasPendingChanges -> 0 rows): DOLT_COMMIT is NOT issued, Commit -> nil.
+//   - real write (HasPendingChanges -> >0): DOLT_COMMIT IS issued, Commit -> nil.
+//
+// It FAILS if the guard is reverted: an unconditional Commit would issue
+// DOLT_COMMIT in the no-op case, which has no matching sqlmock expectation, so
+// ExecContext returns an "unexpected" error -> Commit returns non-nil -> test fails.
+func TestDoltServerTxCommitSkipsEmptyCommit(t *testing.T) {
+	t.Run("no pending changes -> skips DOLT_COMMIT", func(t *testing.T) {
+		conn, mock := newMockConn(t)
+
+		// HasPendingChanges returns 0: the working set is clean (idempotent no-op).
+		mock.ExpectQuery(matchHasPending).
+			WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
+		// Deliberately NO ExpectExec for DOLT_COMMIT: if the code issues it anyway
+		// (guard reverted), sqlmock returns an "unexpected Exec" error and Commit
+		// returns non-nil, failing this test.
+
+		tx := &doltServerTx{conn: conn}
+		if err := tx.Commit(context.Background(), "bd: noop"); err != nil {
+			t.Fatalf("Commit on a clean working set should be a no-op nil, got: %v", err)
+		}
+		if !tx.done {
+			t.Error("Commit must mark the tx done even when it skips the empty commit")
+		}
+		if err := mock.ExpectationsWereMet(); err != nil {
+			t.Errorf("unmet/unexpected sqlmock expectations: %v", err)
+		}
+	})
+
+	t.Run("pending changes -> issues DOLT_COMMIT", func(t *testing.T) {
+		conn, mock := newMockConn(t)
+
+		// HasPendingChanges returns >0: a real change is staged-and-committed by -Am.
+		mock.ExpectQuery(matchHasPending).
+			WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(3))
+		mock.ExpectExec(matchDoltCommit).
+			WithArgs("bd: real write").
+			WillReturnResult(sqlmock.NewResult(0, 1))
+
+		tx := &doltServerTx{conn: conn}
+		if err := tx.Commit(context.Background(), "bd: real write"); err != nil {
+			t.Fatalf("Commit with pending changes should succeed, got: %v", err)
+		}
+		if err := mock.ExpectationsWereMet(); err != nil {
+			t.Errorf("expected DOLT_COMMIT to be issued for a real change: %v", err)
+		}
+	})
+
+	t.Run("benign nothing-to-commit from DOLT_COMMIT is swallowed", func(t *testing.T) {
+		conn, mock := newMockConn(t)
+
+		// dolt_status counted the working set as dirty (e.g. a row rewritten to its
+		// existing value), so the guard lets the commit through, but Dolt still
+		// reports "nothing to commit". That must be swallowed, not surfaced.
+		mock.ExpectQuery(matchHasPending).
+			WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
+		mock.ExpectExec(matchDoltCommit).
+			WithArgs("bd: rewrite same value").
+			WillReturnError(errors.New("nothing to commit"))
+
+		tx := &doltServerTx{conn: conn}
+		if err := tx.Commit(context.Background(), "bd: rewrite same value"); err != nil {
+			t.Fatalf("benign nothing-to-commit should be swallowed, got: %v", err)
+		}
+		if err := mock.ExpectationsWereMet(); err != nil {
+			t.Errorf("unmet/unexpected sqlmock expectations: %v", err)
+		}
+	})
+
+	t.Run("real DOLT_COMMIT error is propagated", func(t *testing.T) {
+		conn, mock := newMockConn(t)
+
+		mock.ExpectQuery(matchHasPending).
+			WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
+		mock.ExpectExec(matchDoltCommit).
+			WithArgs("bd: boom").
+			WillReturnError(errors.New("dolt: disk full"))
+
+		tx := &doltServerTx{conn: conn}
+		err := tx.Commit(context.Background(), "bd: boom")
+		if err == nil {
+			t.Fatal("a genuine DOLT_COMMIT error must be propagated, got nil")
+		}
+		if err := mock.ExpectationsWereMet(); err != nil {
+			t.Errorf("unmet/unexpected sqlmock expectations: %v", err)
+		}
+	})
+}
+
+// TestDoltServerTxCommitAlreadyDone verifies the existing double-commit guard is
+// preserved by the change (no new query/exec is issued on a second Commit).
+func TestDoltServerTxCommitAlreadyDone(t *testing.T) {
+	conn, mock := newMockConn(t)
+	// No expectations at all: a done tx must touch the connection zero times.
+	tx := &doltServerTx{conn: conn, done: true}
+	err := tx.Commit(context.Background(), "bd: late")
+	if err == nil {
+		t.Fatal("Commit on an already-done tx must error")
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("a done-tx Commit must not query/exec anything: %v", err)
+	}
+}


### PR DESCRIPTION
## Problem

On a busy multi-database coordination deployment (gascity-managed, 5 DBs, perpetual wisp churn), **~99% of all Dolt server log lines** were `error="nothing to commit"` warnings (~0.7–2/sec sustained, peaks 17/sec), with the Dolt sql-server burning 1–3 CPU cores evaluating empty commits. Every single `bd` **write** command emitted one guaranteed-empty `DOLT_COMMIT`.

## Root cause (traced via dolt debug query log on the live system)

Two independent unconditional-commit sites:

1. **`DoltStore.Commit`** (`internal/storage/dolt/store.go`) builds its staging list from `dolt_status` excluding only `config`. **`dolt_ignore`'d tables (`wisp_%`, `local_metadata`) sit permanently dirty in `dolt_status` under wisp churn but can never be staged** — `DOLT_ADD` on them fails and is skipped. So whenever only ignored tables are dirty (i.e. *constantly* on a coordination DB), the list is non-empty, the `len(tables)==0` early-return never fires, and the function issues an empty `DOLT_COMMIT('-m')` that the server rejects. The post-write auto-commit takes this path on **every write command**. The captured query trail of one `bd update`:
   ```
   UPDATE issues … ; INSERT INTO events …
   DOLT_ADD ×2 ; DOLT_COMMIT('-m', …)   -- real commit, succeeds
   COMMIT
   DOLT_ADD ×6 ; DOLT_COMMIT('-m', …)   -- 6 = the perpetually-dirty ignored tables; always empty → server error
   ```

2. **`doltServerTx.Commit`** (`internal/storage/uow/doltserver_tx.go`) issued `CALL DOLT_COMMIT('-Am', ?)` unconditionally with no working-set check and returned the raw error.

## Fix

- `DoltStore.Commit`: filter the `dolt_status` scan with the same `dolt_ignore` predicate as `issueops.HasPendingChanges`, so the existing `len(tables)==0` early-return fires as intended (its comment already said “or dolt_ignore'd” — the implementation just never excluded them).
- `doltServerTx.Commit`: gate on `issueops.HasPendingChanges` (correct for `-Am`, which sweeps the whole working set and respects `dolt_ignore`), and swallow a residual benign nothing-to-commit instead of returning it. + discriminating sqlmock regression test.

Uses only helpers already on `main` (`HasPendingChanges`, `IsNothingToCommitError`) — independent of, and complementary to, #4288 (which guards the selective-staging `-m` helpers).

## Live validation (production coordination DB)

| Metric | Before | After |
|---|---|---|
| Background `nothing to commit` per 15s | 11 | **0** |
| Burst of 20 idempotent no-op writes | 27 errors | **0** |
| Sustained 60s, normal orchestrator load | ~40–50 | **0** |

`go build ./...`, `go vet`, `gofmt` clean; `internal/storage/uow` package tests pass including the real-Dolt integration path.