### PR TITLE
fix(mol bond): route operands to the target's database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   every remote-ahead case, as before
   ([#4259](https://github.com/gastownhall/beads/issues/4259)).
 
+### Fixed
+
+- **`bd mol bond <A> <B>` ignored prefix routing** — operand resolution now uses
+  the same routing fallback as `bd show`/`bd update`/`bd close`, so a bead that
+  lives in a routed store (a prefix-routed rig via `routes.jsonl`, or the
+  contributor planning store) resolves instead of failing with `'<id>' not found
+  (not an issue ID or formula name)`. Previously `bd mol bond` resolved operands
+  against the local store only, so `gt sling <bead> <rig>` — which cooks the
+  default formula and bonds it to a rig-routed bead — died at `bd mol bond` even
+  though `bd show <bead>` resolved the same ID. Resolution is write-intent: a
+  prefix-routed target opens writable and the bond commits where the bead lives.
+  A bond whose two operands resolve to different stores is rejected rather than
+  written to the wrong database. Same routing-parity fix as
+  [#3608](https://github.com/gastownhall/beads/issues/3608) for `bd close`.
+  Fixes [#4714](https://github.com/gastownhall/beads/issues/4714).
+
 ## [1.1.0] - 2026-07-04
 
 First stable release of the 1.1.0 line. It consolidates everything from

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,7 +104,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   A bond whose two operands resolve to different stores is rejected rather than
   written to the wrong database. Same routing-parity fix as
   [#3608](https://github.com/gastownhall/beads/issues/3608) for `bd close`.
-  Fixes [#4714](https://github.com/gastownhall/beads/issues/4714).
+  Consolidates the complementary work in
+  [#4350](https://github.com/gastownhall/beads/pull/4350) and
+  [#4720](https://github.com/gastownhall/beads/pull/4720), following the live
+  Gas Town reproduction in
+  [gastown#4220](https://github.com/gastownhall/gastown/issues/4220). Fixes
+  [#4714](https://github.com/gastownhall/beads/issues/4714).
 
 ## [1.1.0] - 2026-07-04
 

--- a/cmd/bd/dep.go
+++ b/cmd/bd/dep.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -623,7 +622,7 @@ func validateBulkDepEdges(ctx context.Context, edges []bulkDepEdge) ([]bulkDepEd
 		current.Cleanups = append(current.Cleanups, fromCleanup)
 		current.IssueID = fromID
 		current.Store = fromStore
-		current.StoreKey = dependencyStoreKey(fromStore)
+		current.StoreKey = storeIdentityKey(fromStore)
 
 		if strings.HasPrefix(edge.DependsOnID, "external:") {
 			if err := validateExternalRef(edge.DependsOnID); err != nil {
@@ -672,18 +671,6 @@ func validateBulkDepEdges(ctx context.Context, edges []bulkDepEdge) ([]bulkDepEd
 
 func bulkDepValidationError(errs []string) error {
 	return fmt.Errorf("bulk dependency validation failed:\n  %s", strings.Join(errs, "\n  "))
-}
-
-func dependencyStoreKey(s storage.DoltStorage) string {
-	if locator, ok := storage.UnwrapStore(s).(storage.StoreLocator); ok {
-		if cliDir := strings.TrimSpace(locator.CLIDir()); cliDir != "" {
-			return "cli:" + filepath.Clean(cliDir)
-		}
-		if path := strings.TrimSpace(locator.Path()); path != "" {
-			return "path:" + filepath.Clean(path)
-		}
-	}
-	return fmt.Sprintf("instance:%p", s)
 }
 
 var depListCmd = &cobra.Command{

--- a/cmd/bd/mol_bond.go
+++ b/cmd/bd/mol_bond.go
@@ -216,9 +216,9 @@ func runMolBond(cmd *cobra.Command, args []string) error {
 		if routeErr != nil {
 			return HandleErrorRespectJSON("%v", routeErr)
 		}
-		if rr.MutationForbidden {
+		if routeErr := verifyMolBondWritableHome(rr, targetStoreKey); routeErr != nil {
 			rr.Close()
-			return HandleErrorRespectJSON("cannot bond issue %s: contributor auto-routing forbids mutation; run the bond from the project that owns the issue", targetID)
+			return HandleErrorRespectJSON("%v", routeErr)
 		}
 		activeStore = rr.Store
 		closeActiveStore = rr.Close
@@ -667,6 +667,22 @@ func validateMolBondHomes(localStore storage.DoltStorage, discoveries ...*molBon
 		return "", storeIdentityKey(localStore), nil
 	}
 	return targetID, targetKey, nil
+}
+
+// verifyMolBondWritableHome closes the TOCTOU gap between read-only discovery
+// and writable reopen. Routing or local contents may change between phases; a
+// bond must never mutate a logical store that was not the validated home.
+func verifyMolBondWritableHome(rr *RoutedResult, expectedStoreKey string) error {
+	if rr == nil || rr.Store == nil {
+		return fmt.Errorf("routed bond target reopened without a store")
+	}
+	if rr.MutationForbidden {
+		return fmt.Errorf("cannot bond issue %s: contributor auto-routing forbids mutation; run the bond from the project that owns the issue", rr.ResolvedID)
+	}
+	if actual := storeIdentityKey(rr.Store); actual != expectedStoreKey {
+		return fmt.Errorf("routed bond target changed between discovery and writable reopen (expected %s, got %s); retry the command", expectedStoreKey, actual)
+	}
+	return nil
 }
 
 // materializeMolBondOperand is the second phase: after one store home has been

--- a/cmd/bd/mol_bond.go
+++ b/cmd/bd/mol_bond.go
@@ -123,16 +123,27 @@ func runMolBond(cmd *cobra.Command, args []string) error {
 		vars[parts[0]] = parts[1]
 	}
 
-	// For dry-run, just check if operands can be resolved (don't cook)
+	discA, err := discoverMolBondOperand(ctx, store, args[0])
+	if err != nil {
+		return HandleErrorRespectJSON("%v", err)
+	}
+	defer discA.Close()
+	discB, err := discoverMolBondOperand(ctx, store, args[1])
+	if err != nil {
+		return HandleErrorRespectJSON("%v", err)
+	}
+	defer discB.Close()
+
+	targetID, targetStoreKey, err := validateMolBondHomes(store, discA, discB)
+	if err != nil {
+		return HandleErrorRespectJSON("%v", err)
+	}
+
+	// Dry-run shares the same read-only discovery and store-policy validation
+	// as execution, but never reopens the accepted target writable or cooks.
 	if dryRun {
-		issueA, formulaA, err := resolveOrDescribe(ctx, store, args[0])
-		if err != nil {
-			return HandleErrorRespectJSON("%v", err)
-		}
-		issueB, formulaB, err := resolveOrDescribe(ctx, store, args[1])
-		if err != nil {
-			return HandleErrorRespectJSON("%v", err)
-		}
+		issueA, formulaA := discA.issue, discA.formula
+		issueB, formulaB := discB.issue, discB.formula
 
 		idA := args[0]
 		idB := args[1]
@@ -193,22 +204,32 @@ func runMolBond(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	opA, err := resolveMolBondOperand(ctx, store, args[0], vars)
-	if err != nil {
-		return HandleErrorRespectJSON("%v", err)
+	// Close read-only discovery handles before opening the single accepted home
+	// writable. Unsupported cross-store operations return above without any
+	// writable foreign-store open or its migration/open-time side effects.
+	discA.Close()
+	discB.Close()
+	activeStore := store
+	closeActiveStore := func() {}
+	if targetID != "" && targetStoreKey != storeIdentityKey(store) {
+		rr, routeErr := resolveAndGetIssueForMutation(ctx, store, targetID)
+		if routeErr != nil {
+			return HandleErrorRespectJSON("%v", routeErr)
+		}
+		if rr.MutationForbidden {
+			rr.Close()
+			return HandleErrorRespectJSON("cannot bond issue %s: contributor auto-routing forbids mutation; run the bond from the project that owns the issue", targetID)
+		}
+		activeStore = rr.Store
+		closeActiveStore = rr.Close
 	}
-	defer opA.Close()
-	opB, err := resolveMolBondOperandWithPreferredStore(ctx, store, opA, args[1], vars)
-	if err != nil {
-		return HandleErrorRespectJSON("%v", err)
-	}
-	defer opB.Close()
+	defer closeActiveStore()
 
-	// The bond mutation runs against the store that owns the operands. When an
-	// operand was resolved via routing (e.g. a prefix-routed rig bead), that is
-	// the routed store, not the local one — otherwise the bond would write to
-	// the wrong database or fail on a cross-store reference (mirrors #3609).
-	activeStore, err := pickBondStore(store, opA, opB)
+	opA, err := materializeMolBondOperand(ctx, activeStore, discA, vars)
+	if err != nil {
+		return HandleErrorRespectJSON("%v", err)
+	}
+	opB, err := materializeMolBondOperand(ctx, activeStore, discB, vars)
 	if err != nil {
 		return HandleErrorRespectJSON("%v", err)
 	}
@@ -571,40 +592,108 @@ func minPriority(a, b int) int {
 	return b
 }
 
-// molBondOperand is a resolved mol-bond operand together with the store that
-// owns it. For an existing issue, store is whichever store resolution found the
-// issue in (local or routed) and cooked is false. For a formula cooked inline,
-// store is nil (the cooked protos are in-memory until the bond writes them) and
-// cooked is true.
 type molBondOperand struct {
 	subgraph *TemplateSubgraph
-	cooked   bool                // cooked inline from a formula (no owning store yet)
-	store    storage.DoltStorage // store that owns the issue; nil for cooked formulas
-	routed   bool                // issue was found via routing, not the local store
-	readOnly bool                // routing policy forbids mutation of this store
-	closeFn  func()              // releases any routed store handle
+	cooked   bool
 }
 
-// Close releases any routed store handle held by the operand. Safe on nil.
-func (o *molBondOperand) Close() {
-	if o != nil && o.closeFn != nil {
-		o.closeFn()
+// molBondDiscovery is the read-only first phase of operand resolution. Existing
+// issues carry their logical store identity; formulas remain storeless.
+type molBondDiscovery struct {
+	operand           string
+	issue             *types.Issue
+	formula           string
+	storeKey          string
+	mutationForbidden bool
+	closeFn           func()
+}
+
+func (d *molBondDiscovery) Close() {
+	if d != nil && d.closeFn != nil {
+		d.closeFn()
+		d.closeFn = nil
 	}
 }
 
-// operandFromIssue wraps a resolved issue as a molBondOperand, loading the full
-// proto subgraph when the issue is a proto and wrapping a plain molecule as a
-// single-issue subgraph otherwise.
-func operandFromIssue(ctx context.Context, s storage.DoltStorage, issue *types.Issue, routed, readOnly bool, closeFn func()) (*molBondOperand, error) {
-	if isProto(issue) {
-		subgraph, err := loadTemplateSubgraph(ctx, s, issue.ID)
+// discoverMolBondOperand resolves through read-only routing so unsupported
+// cross-store operations can be rejected before any writable foreign-store
+// open. Formula lookup remains issue-first.
+func discoverMolBondOperand(ctx context.Context, localStore storage.DoltStorage, operand string) (*molBondDiscovery, error) {
+	rr, err := resolveAndGetIssueWithRouting(ctx, localStore, operand)
+	if err == nil {
+		return &molBondDiscovery{
+			operand:           operand,
+			issue:             rr.Issue,
+			storeKey:          storeIdentityKey(rr.Store),
+			mutationForbidden: rr.MutationForbidden,
+			closeFn:           rr.Close,
+		}, nil
+	}
+	if !isNotFoundErr(err) {
+		return nil, err
+	}
+	if !looksLikeFormulaName(operand) {
+		return nil, fmt.Errorf("'%s' not found (not an issue ID or formula name)", operand)
+	}
+	parser := formula.NewParser()
+	f, loadErr := parser.LoadByName(operand)
+	if loadErr != nil {
+		return nil, fmt.Errorf("'%s' not found as issue or formula: %w", operand, loadErr)
+	}
+	return &molBondDiscovery{operand: operand, formula: f.Formula}, nil
+}
+
+// validateMolBondHomes returns the issue ID and logical store key that pin the
+// mutation. Formula-only bonds stay local. All checks happen on read-only
+// discovery handles.
+func validateMolBondHomes(localStore storage.DoltStorage, discoveries ...*molBondDiscovery) (string, string, error) {
+	var targetID, targetKey string
+	for _, d := range discoveries {
+		if d == nil || d.issue == nil {
+			continue
+		}
+		if d.mutationForbidden {
+			return "", "", fmt.Errorf("cannot bond issue %s: contributor auto-routing forbids mutation; run the bond from the project that owns the issue", d.issue.ID)
+		}
+		if targetKey == "" {
+			targetID, targetKey = d.issue.ID, d.storeKey
+			continue
+		}
+		if d.storeKey != targetKey {
+			return "", "", fmt.Errorf("cannot bond operands that live in different stores/rigs; run the bond from the rig that owns them")
+		}
+	}
+	if targetKey == "" {
+		return "", storeIdentityKey(localStore), nil
+	}
+	return targetID, targetKey, nil
+}
+
+// materializeMolBondOperand is the second phase: after one store home has been
+// accepted and opened writable, load an issue/proto there or cook a formula in
+// memory for the bond operation.
+func materializeMolBondOperand(ctx context.Context, activeStore storage.DoltStorage, d *molBondDiscovery, vars map[string]string) (*molBondOperand, error) {
+	if d == nil {
+		return nil, fmt.Errorf("missing mol bond operand")
+	}
+	if d.issue == nil {
+		subgraph, err := resolveAndCookFormulaWithVars(d.operand, nil, vars)
 		if err != nil {
-			if closeFn != nil {
-				closeFn()
-			}
+			return nil, fmt.Errorf("'%s' not found as issue or formula: %w", d.operand, err)
+		}
+		return &molBondOperand{subgraph: subgraph, cooked: true}, nil
+	}
+	rr, err := resolveAndGetFromStore(ctx, activeStore, d.issue.ID, false)
+	if err != nil {
+		return nil, err
+	}
+	issue := rr.Issue
+	if isProto(issue) {
+		subgraph, err := loadTemplateSubgraph(ctx, activeStore, issue.ID)
+		if err != nil {
 			return nil, fmt.Errorf("loading proto subgraph '%s': %w", issue.ID, err)
 		}
-		return &molBondOperand{subgraph: subgraph, store: s, routed: routed, readOnly: readOnly, closeFn: closeFn}, nil
+		return &molBondOperand{subgraph: subgraph}, nil
 	}
 	return &molBondOperand{
 		subgraph: &TemplateSubgraph{
@@ -612,123 +701,7 @@ func operandFromIssue(ctx context.Context, s storage.DoltStorage, issue *types.I
 			Issues:   []*types.Issue{issue},
 			IssueMap: map[string]*types.Issue{issue.ID: issue},
 		},
-		store:    s,
-		routed:   routed,
-		readOnly: readOnly,
-		closeFn:  closeFn,
 	}, nil
-}
-
-// resolveMolBondOperand resolves a single mol-bond operand as an existing issue
-// or, failing that, an inline formula.
-//
-// Issue resolution uses the same routing fallback as bd show/update/close
-// (local store, then prefix-routed rig via routes.jsonl, then contributor
-// auto-routing) so an operand that lives only in a routed store resolves
-// instead of failing with "not found". Resolution is write-intent: a
-// prefix-routed target opens writable so the bond commits where the issue
-// lives, mirroring the bd close fix in #3608/#3609. The returned operand
-// carries the owning store; the caller runs the bond mutation against it and
-// must call Close() to release any routed handle.
-func resolveMolBondOperand(ctx context.Context, localStore storage.DoltStorage, operand string, vars map[string]string) (*molBondOperand, error) {
-	rr, err := resolveAndGetIssueForMutation(ctx, localStore, operand)
-	if err == nil {
-		return operandFromIssue(ctx, rr.Store, rr.Issue, rr.Routed, rr.ReadOnly, rr.Close)
-	}
-	if !isNotFoundErr(err) {
-		return nil, err
-	}
-
-	// Not an issue in any store — try to cook it as a formula.
-	if !looksLikeFormulaName(operand) {
-		return nil, fmt.Errorf("'%s' not found (not an issue ID or formula name)", operand)
-	}
-	subgraph, cookErr := resolveAndCookFormulaWithVars(operand, nil, vars)
-	if cookErr != nil {
-		return nil, fmt.Errorf("'%s' not found as issue or formula: %w", operand, cookErr)
-	}
-	return &molBondOperand{subgraph: subgraph, cooked: true}, nil
-}
-
-// resolveMolBondOperandWithPreferredStore preserves the single-work-store
-// behavior introduced by #4350. Once the first issue operand pins a store, try
-// the second operand there before opening another routed handle. This lets two
-// issues in the same routed database share one handle while still falling back
-// to normal routing so a genuinely cross-store pair can be rejected explicitly.
-func resolveMolBondOperandWithPreferredStore(ctx context.Context, localStore storage.DoltStorage, preferred *molBondOperand, operand string, vars map[string]string) (*molBondOperand, error) {
-	if preferred != nil && preferred.store != nil {
-		rr, err := resolveAndGetFromStore(ctx, preferred.store, operand, preferred.routed)
-		if err == nil {
-			return operandFromIssue(ctx, preferred.store, rr.Issue, preferred.routed, preferred.readOnly, nil)
-		}
-		if !isNotFoundErr(err) {
-			return nil, err
-		}
-	}
-	return resolveMolBondOperand(ctx, localStore, operand, vars)
-}
-
-// pickBondStore returns the store the bond mutation must run against.
-//
-// Cooked-formula operands are in-memory and store-agnostic, so they impose no
-// constraint. Each existing-issue operand pins the bond to the store that owns
-// it. When both operands are existing issues owned by different stores the bond
-// is a cross-store operation with no well-defined home, so it is rejected rather
-// than silently written to the wrong database. When nothing pins a store (both
-// operands are cooked formulas) the bond stays on the local store.
-func pickBondStore(localStore storage.DoltStorage, a, b *molBondOperand) (storage.DoltStorage, error) {
-	active := localStore
-	pinned := false
-	for _, op := range []*molBondOperand{a, b} {
-		if op.cooked || op.store == nil {
-			continue
-		}
-		if op.readOnly {
-			return nil, fmt.Errorf("cannot bond issue %s: contributor auto-routing opened its store read-only; run the bond from the project that owns the issue", op.subgraph.Root.ID)
-		}
-		if !pinned {
-			active = op.store
-			pinned = true
-			continue
-		}
-		if storeIdentityKey(op.store) != storeIdentityKey(active) {
-			return nil, fmt.Errorf("cannot bond operands that live in different stores/rigs; run the bond from the rig that owns them")
-		}
-	}
-	return active, nil
-}
-
-// resolveOrDescribe checks if an operand is an issue or formula without cooking.
-// Used for dry-run mode. Returns (issue, formulaName, error).
-// If it's an issue, issue is set. If it's a formula, formulaName is set.
-//
-// Issue resolution uses the read-only routing fallback (local, then prefix-routed
-// rig, then contributor auto-routing) so a dry run previews routed operands the
-// same way the real bond resolves them.
-func resolveOrDescribe(ctx context.Context, localStore storage.DoltStorage, operand string) (*types.Issue, string, error) {
-	rr, err := resolveAndGetIssueWithRouting(ctx, localStore, operand)
-	if err == nil {
-		issue := rr.Issue
-		rr.Close()
-		return issue, "", nil
-	}
-	if !isNotFoundErr(err) {
-		return nil, "", err
-	}
-
-	// Not found as issue - check if it looks like a formula name
-	if !looksLikeFormulaName(operand) {
-		return nil, "", fmt.Errorf("'%s' not found (not an issue ID or formula name)", operand)
-	}
-
-	// Try to load the formula (but don't cook it)
-	parser := formula.NewParser()
-	f, err := parser.LoadByName(operand)
-	if err != nil {
-		return nil, "", fmt.Errorf("'%s' not found as issue or formula: %w", operand, err)
-	}
-
-	return nil, f.Formula, nil
 }
 
 // looksLikeFormulaName checks if an operand looks like a formula name.

--- a/cmd/bd/mol_bond.go
+++ b/cmd/bd/mol_bond.go
@@ -198,7 +198,7 @@ func runMolBond(cmd *cobra.Command, args []string) error {
 		return HandleErrorRespectJSON("%v", err)
 	}
 	defer opA.Close()
-	opB, err := resolveMolBondOperand(ctx, store, args[1], vars)
+	opB, err := resolveMolBondOperandWithPreferredStore(ctx, store, opA, args[1], vars)
 	if err != nil {
 		return HandleErrorRespectJSON("%v", err)
 	}
@@ -581,6 +581,7 @@ type molBondOperand struct {
 	cooked   bool                // cooked inline from a formula (no owning store yet)
 	store    storage.DoltStorage // store that owns the issue; nil for cooked formulas
 	routed   bool                // issue was found via routing, not the local store
+	readOnly bool                // routing policy forbids mutation of this store
 	closeFn  func()              // releases any routed store handle
 }
 
@@ -594,7 +595,7 @@ func (o *molBondOperand) Close() {
 // operandFromIssue wraps a resolved issue as a molBondOperand, loading the full
 // proto subgraph when the issue is a proto and wrapping a plain molecule as a
 // single-issue subgraph otherwise.
-func operandFromIssue(ctx context.Context, s storage.DoltStorage, issue *types.Issue, routed bool, closeFn func()) (*molBondOperand, error) {
+func operandFromIssue(ctx context.Context, s storage.DoltStorage, issue *types.Issue, routed, readOnly bool, closeFn func()) (*molBondOperand, error) {
 	if isProto(issue) {
 		subgraph, err := loadTemplateSubgraph(ctx, s, issue.ID)
 		if err != nil {
@@ -603,7 +604,7 @@ func operandFromIssue(ctx context.Context, s storage.DoltStorage, issue *types.I
 			}
 			return nil, fmt.Errorf("loading proto subgraph '%s': %w", issue.ID, err)
 		}
-		return &molBondOperand{subgraph: subgraph, store: s, routed: routed, closeFn: closeFn}, nil
+		return &molBondOperand{subgraph: subgraph, store: s, routed: routed, readOnly: readOnly, closeFn: closeFn}, nil
 	}
 	return &molBondOperand{
 		subgraph: &TemplateSubgraph{
@@ -611,9 +612,10 @@ func operandFromIssue(ctx context.Context, s storage.DoltStorage, issue *types.I
 			Issues:   []*types.Issue{issue},
 			IssueMap: map[string]*types.Issue{issue.ID: issue},
 		},
-		store:   s,
-		routed:  routed,
-		closeFn: closeFn,
+		store:    s,
+		routed:   routed,
+		readOnly: readOnly,
+		closeFn:  closeFn,
 	}, nil
 }
 
@@ -631,7 +633,7 @@ func operandFromIssue(ctx context.Context, s storage.DoltStorage, issue *types.I
 func resolveMolBondOperand(ctx context.Context, localStore storage.DoltStorage, operand string, vars map[string]string) (*molBondOperand, error) {
 	rr, err := resolveAndGetIssueForMutation(ctx, localStore, operand)
 	if err == nil {
-		return operandFromIssue(ctx, rr.Store, rr.Issue, rr.Routed, rr.Close)
+		return operandFromIssue(ctx, rr.Store, rr.Issue, rr.Routed, rr.ReadOnly, rr.Close)
 	}
 	if !isNotFoundErr(err) {
 		return nil, err
@@ -646,6 +648,24 @@ func resolveMolBondOperand(ctx context.Context, localStore storage.DoltStorage, 
 		return nil, fmt.Errorf("'%s' not found as issue or formula: %w", operand, cookErr)
 	}
 	return &molBondOperand{subgraph: subgraph, cooked: true}, nil
+}
+
+// resolveMolBondOperandWithPreferredStore preserves the single-work-store
+// behavior introduced by #4350. Once the first issue operand pins a store, try
+// the second operand there before opening another routed handle. This lets two
+// issues in the same routed database share one handle while still falling back
+// to normal routing so a genuinely cross-store pair can be rejected explicitly.
+func resolveMolBondOperandWithPreferredStore(ctx context.Context, localStore storage.DoltStorage, preferred *molBondOperand, operand string, vars map[string]string) (*molBondOperand, error) {
+	if preferred != nil && preferred.store != nil {
+		rr, err := resolveAndGetFromStore(ctx, preferred.store, operand, preferred.routed)
+		if err == nil {
+			return operandFromIssue(ctx, preferred.store, rr.Issue, preferred.routed, preferred.readOnly, nil)
+		}
+		if !isNotFoundErr(err) {
+			return nil, err
+		}
+	}
+	return resolveMolBondOperand(ctx, localStore, operand, vars)
 }
 
 // pickBondStore returns the store the bond mutation must run against.
@@ -663,12 +683,15 @@ func pickBondStore(localStore storage.DoltStorage, a, b *molBondOperand) (storag
 		if op.cooked || op.store == nil {
 			continue
 		}
+		if op.readOnly {
+			return nil, fmt.Errorf("cannot bond issue %s: contributor auto-routing opened its store read-only; run the bond from the project that owns the issue", op.subgraph.Root.ID)
+		}
 		if !pinned {
 			active = op.store
 			pinned = true
 			continue
 		}
-		if op.store != active {
+		if storeIdentityKey(op.store) != storeIdentityKey(active) {
 			return nil, fmt.Errorf("cannot bond operands that live in different stores/rigs; run the bond from the rig that owns them")
 		}
 	}

--- a/cmd/bd/mol_bond.go
+++ b/cmd/bd/mol_bond.go
@@ -124,12 +124,19 @@ func runMolBond(cmd *cobra.Command, args []string) error {
 		vars[parts[0]] = parts[1]
 	}
 
+	// mol bond writes the spawned wisps into the same database as the target issue,
+	// so operate on the target's (possibly routed) database rather than the active
+	// store. See resolveBondStore. (GH#4220)
+	workStore, closeWorkStore := resolveBondStore(ctx, store, args[:2])
+	defer closeWorkStore()
+
+	// For dry-run, just check if operands can be resolved (don't cook)
 	if dryRun {
-		issueA, formulaA, err := resolveOrDescribe(ctx, store, args[0])
+		issueA, formulaA, err := resolveOrDescribe(ctx, workStore, args[0])
 		if err != nil {
 			return HandleErrorRespectJSON("%v", err)
 		}
-		issueB, formulaB, err := resolveOrDescribe(ctx, store, args[1])
+		issueB, formulaB, err := resolveOrDescribe(ctx, workStore, args[1])
 		if err != nil {
 			return HandleErrorRespectJSON("%v", err)
 		}
@@ -193,11 +200,14 @@ func runMolBond(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	subgraphA, cookedA, err := resolveOrCookToSubgraph(ctx, store, args[0], vars)
+	// Resolve both operands - can be issue IDs or formula names
+	// Formula names are cooked inline to in-memory subgraphs
+	// Pass vars for step condition filtering (bd-7zka.1)
+	subgraphA, cookedA, err := resolveOrCookToSubgraph(ctx, workStore, args[0], vars)
 	if err != nil {
 		return HandleErrorRespectJSON("%v", err)
 	}
-	subgraphB, cookedB, err := resolveOrCookToSubgraph(ctx, store, args[1], vars)
+	subgraphB, cookedB, err := resolveOrCookToSubgraph(ctx, workStore, args[1], vars)
 	if err != nil {
 		return HandleErrorRespectJSON("%v", err)
 	}
@@ -219,23 +229,23 @@ func runMolBond(cmd *cobra.Command, args []string) error {
 	case aIsProto && bIsProto:
 		// Compound protos are templates - always persistent
 		// Note: Proto+proto bonding from formulas is a DB operation, not in-memory
-		result, err = bondProtoProto(ctx, store, issueA, issueB, bondType, customTitle, actor)
+		result, err = bondProtoProto(ctx, workStore, issueA, issueB, bondType, customTitle, actor)
 	case aIsProto && !bIsProto:
 		// Pass subgraph directly if cooked from formula
 		if cookedA {
-			result, err = bondProtoMolWithSubgraph(ctx, store, subgraphA, issueA, issueB, bondType, vars, childRef, actor, ephemeral, pour)
+			result, err = bondProtoMolWithSubgraph(ctx, workStore, subgraphA, issueA, issueB, bondType, vars, childRef, actor, ephemeral, pour)
 		} else {
-			result, err = bondProtoMol(ctx, store, issueA, issueB, bondType, vars, childRef, actor, ephemeral, pour)
+			result, err = bondProtoMol(ctx, workStore, issueA, issueB, bondType, vars, childRef, actor, ephemeral, pour)
 		}
 	case !aIsProto && bIsProto:
 		// Pass subgraph directly if cooked from formula
 		if cookedB {
-			result, err = bondProtoMolWithSubgraph(ctx, store, subgraphB, issueB, issueA, bondType, vars, childRef, actor, ephemeral, pour)
+			result, err = bondProtoMolWithSubgraph(ctx, workStore, subgraphB, issueB, issueA, bondType, vars, childRef, actor, ephemeral, pour)
 		} else {
-			result, err = bondMolProto(ctx, store, issueA, issueB, bondType, vars, childRef, actor, ephemeral, pour)
+			result, err = bondMolProto(ctx, workStore, issueA, issueB, bondType, vars, childRef, actor, ephemeral, pour)
 		}
 	default:
-		result, err = bondMolMol(ctx, store, issueA, issueB, bondType, actor)
+		result, err = bondMolMol(ctx, workStore, issueA, issueB, bondType, actor)
 	}
 
 	if err != nil {
@@ -628,6 +638,37 @@ func resolveOrCookToSubgraph(ctx context.Context, s storage.DoltStorage, operand
 	}
 
 	return subgraph, true, nil
+}
+
+// resolveBondStore picks the database a bond should operate on.
+//
+// `bd mol bond` spawns wisps into the same database as the target issue. When an
+// operand is an existing issue that lives in a different rig's database — e.g. when
+// invoked from the town root (or with BEADS_DOLT_DATA_DIR set) where the active store
+// is the town DB (hq) but the target lives in a rig DB — the operand resolves
+// "not found" against the active store and the bond fails. This mirrors the
+// cross-database prefix routing already used by `bd show`, `bd update`, `bd close`,
+// etc. (GH#4220)
+//
+// It returns the routed store (and its close function) for the first operand that
+// routes elsewhere, or the local store (with a no-op close) when nothing routes.
+// Formula-name operands are skipped: they are cooked into the working store, not
+// looked up across databases.
+func resolveBondStore(ctx context.Context, localStore storage.DoltStorage, operands []string) (storage.DoltStorage, func()) {
+	for _, arg := range operands {
+		if looksLikeFormulaName(arg) {
+			continue
+		}
+		res, err := resolveAndGetIssueWithRouting(ctx, localStore, arg)
+		if err != nil {
+			continue // not resolvable here; resolveOrCook will surface the real error
+		}
+		if res.Routed {
+			return res.Store, res.Close
+		}
+		res.Close()
+	}
+	return localStore, func() {}
 }
 
 // looksLikeFormulaName checks if an operand looks like a formula name.

--- a/cmd/bd/mol_bond.go
+++ b/cmd/bd/mol_bond.go
@@ -11,7 +11,6 @@ import (
 	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/types"
 	"github.com/steveyegge/beads/internal/ui"
-	"github.com/steveyegge/beads/internal/utils"
 )
 
 var molBondCmd = &cobra.Command{
@@ -124,19 +123,13 @@ func runMolBond(cmd *cobra.Command, args []string) error {
 		vars[parts[0]] = parts[1]
 	}
 
-	// mol bond writes the spawned wisps into the same database as the target issue,
-	// so operate on the target's (possibly routed) database rather than the active
-	// store. See resolveBondStore. (GH#4220)
-	workStore, closeWorkStore := resolveBondStore(ctx, store, args[:2])
-	defer closeWorkStore()
-
 	// For dry-run, just check if operands can be resolved (don't cook)
 	if dryRun {
-		issueA, formulaA, err := resolveOrDescribe(ctx, workStore, args[0])
+		issueA, formulaA, err := resolveOrDescribe(ctx, store, args[0])
 		if err != nil {
 			return HandleErrorRespectJSON("%v", err)
 		}
-		issueB, formulaB, err := resolveOrDescribe(ctx, workStore, args[1])
+		issueB, formulaB, err := resolveOrDescribe(ctx, store, args[1])
 		if err != nil {
 			return HandleErrorRespectJSON("%v", err)
 		}
@@ -200,19 +193,29 @@ func runMolBond(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	// Resolve both operands - can be issue IDs or formula names
-	// Formula names are cooked inline to in-memory subgraphs
-	// Pass vars for step condition filtering (bd-7zka.1)
-	subgraphA, cookedA, err := resolveOrCookToSubgraph(ctx, workStore, args[0], vars)
+	opA, err := resolveMolBondOperand(ctx, store, args[0], vars)
 	if err != nil {
 		return HandleErrorRespectJSON("%v", err)
 	}
-	subgraphB, cookedB, err := resolveOrCookToSubgraph(ctx, workStore, args[1], vars)
+	defer opA.Close()
+	opB, err := resolveMolBondOperand(ctx, store, args[1], vars)
+	if err != nil {
+		return HandleErrorRespectJSON("%v", err)
+	}
+	defer opB.Close()
+
+	// The bond mutation runs against the store that owns the operands. When an
+	// operand was resolved via routing (e.g. a prefix-routed rig bead), that is
+	// the routed store, not the local one — otherwise the bond would write to
+	// the wrong database or fail on a cross-store reference (mirrors #3609).
+	activeStore, err := pickBondStore(store, opA, opB)
 	if err != nil {
 		return HandleErrorRespectJSON("%v", err)
 	}
 
 	// No cleanup needed - in-memory subgraphs don't pollute the DB
+	subgraphA, cookedA := opA.subgraph, opA.cooked
+	subgraphB, cookedB := opB.subgraph, opB.cooked
 	issueA := subgraphA.Root
 	issueB := subgraphB.Root
 	idA := issueA.ID
@@ -223,29 +226,29 @@ func runMolBond(cmd *cobra.Command, args []string) error {
 	bIsProto := issueB.IsTemplate || cookedB
 
 	// Dispatch based on operand types
-	// All operations use the main store; wisp flag determines ephemeral vs persistent
+	// All operations use activeStore; wisp flag determines ephemeral vs persistent
 	var result *BondResult
 	switch {
 	case aIsProto && bIsProto:
 		// Compound protos are templates - always persistent
 		// Note: Proto+proto bonding from formulas is a DB operation, not in-memory
-		result, err = bondProtoProto(ctx, workStore, issueA, issueB, bondType, customTitle, actor)
+		result, err = bondProtoProto(ctx, activeStore, issueA, issueB, bondType, customTitle, actor)
 	case aIsProto && !bIsProto:
 		// Pass subgraph directly if cooked from formula
 		if cookedA {
-			result, err = bondProtoMolWithSubgraph(ctx, workStore, subgraphA, issueA, issueB, bondType, vars, childRef, actor, ephemeral, pour)
+			result, err = bondProtoMolWithSubgraph(ctx, activeStore, subgraphA, issueA, issueB, bondType, vars, childRef, actor, ephemeral, pour)
 		} else {
-			result, err = bondProtoMol(ctx, workStore, issueA, issueB, bondType, vars, childRef, actor, ephemeral, pour)
+			result, err = bondProtoMol(ctx, activeStore, issueA, issueB, bondType, vars, childRef, actor, ephemeral, pour)
 		}
 	case !aIsProto && bIsProto:
 		// Pass subgraph directly if cooked from formula
 		if cookedB {
-			result, err = bondProtoMolWithSubgraph(ctx, workStore, subgraphB, issueB, issueA, bondType, vars, childRef, actor, ephemeral, pour)
+			result, err = bondProtoMolWithSubgraph(ctx, activeStore, subgraphB, issueB, issueA, bondType, vars, childRef, actor, ephemeral, pour)
 		} else {
-			result, err = bondMolProto(ctx, workStore, issueA, issueB, bondType, vars, childRef, actor, ephemeral, pour)
+			result, err = bondMolProto(ctx, activeStore, issueA, issueB, bondType, vars, childRef, actor, ephemeral, pour)
 		}
 	default:
-		result, err = bondMolMol(ctx, workStore, issueA, issueB, bondType, actor)
+		result, err = bondMolMol(ctx, activeStore, issueA, issueB, bondType, actor)
 	}
 
 	if err != nil {
@@ -568,17 +571,126 @@ func minPriority(a, b int) int {
 	return b
 }
 
+// molBondOperand is a resolved mol-bond operand together with the store that
+// owns it. For an existing issue, store is whichever store resolution found the
+// issue in (local or routed) and cooked is false. For a formula cooked inline,
+// store is nil (the cooked protos are in-memory until the bond writes them) and
+// cooked is true.
+type molBondOperand struct {
+	subgraph *TemplateSubgraph
+	cooked   bool                // cooked inline from a formula (no owning store yet)
+	store    storage.DoltStorage // store that owns the issue; nil for cooked formulas
+	routed   bool                // issue was found via routing, not the local store
+	closeFn  func()              // releases any routed store handle
+}
+
+// Close releases any routed store handle held by the operand. Safe on nil.
+func (o *molBondOperand) Close() {
+	if o != nil && o.closeFn != nil {
+		o.closeFn()
+	}
+}
+
+// operandFromIssue wraps a resolved issue as a molBondOperand, loading the full
+// proto subgraph when the issue is a proto and wrapping a plain molecule as a
+// single-issue subgraph otherwise.
+func operandFromIssue(ctx context.Context, s storage.DoltStorage, issue *types.Issue, routed bool, closeFn func()) (*molBondOperand, error) {
+	if isProto(issue) {
+		subgraph, err := loadTemplateSubgraph(ctx, s, issue.ID)
+		if err != nil {
+			if closeFn != nil {
+				closeFn()
+			}
+			return nil, fmt.Errorf("loading proto subgraph '%s': %w", issue.ID, err)
+		}
+		return &molBondOperand{subgraph: subgraph, store: s, routed: routed, closeFn: closeFn}, nil
+	}
+	return &molBondOperand{
+		subgraph: &TemplateSubgraph{
+			Root:     issue,
+			Issues:   []*types.Issue{issue},
+			IssueMap: map[string]*types.Issue{issue.ID: issue},
+		},
+		store:   s,
+		routed:  routed,
+		closeFn: closeFn,
+	}, nil
+}
+
+// resolveMolBondOperand resolves a single mol-bond operand as an existing issue
+// or, failing that, an inline formula.
+//
+// Issue resolution uses the same routing fallback as bd show/update/close
+// (local store, then prefix-routed rig via routes.jsonl, then contributor
+// auto-routing) so an operand that lives only in a routed store resolves
+// instead of failing with "not found". Resolution is write-intent: a
+// prefix-routed target opens writable so the bond commits where the issue
+// lives, mirroring the bd close fix in #3608/#3609. The returned operand
+// carries the owning store; the caller runs the bond mutation against it and
+// must call Close() to release any routed handle.
+func resolveMolBondOperand(ctx context.Context, localStore storage.DoltStorage, operand string, vars map[string]string) (*molBondOperand, error) {
+	rr, err := resolveAndGetIssueForMutation(ctx, localStore, operand)
+	if err == nil {
+		return operandFromIssue(ctx, rr.Store, rr.Issue, rr.Routed, rr.Close)
+	}
+	if !isNotFoundErr(err) {
+		return nil, err
+	}
+
+	// Not an issue in any store — try to cook it as a formula.
+	if !looksLikeFormulaName(operand) {
+		return nil, fmt.Errorf("'%s' not found (not an issue ID or formula name)", operand)
+	}
+	subgraph, cookErr := resolveAndCookFormulaWithVars(operand, nil, vars)
+	if cookErr != nil {
+		return nil, fmt.Errorf("'%s' not found as issue or formula: %w", operand, cookErr)
+	}
+	return &molBondOperand{subgraph: subgraph, cooked: true}, nil
+}
+
+// pickBondStore returns the store the bond mutation must run against.
+//
+// Cooked-formula operands are in-memory and store-agnostic, so they impose no
+// constraint. Each existing-issue operand pins the bond to the store that owns
+// it. When both operands are existing issues owned by different stores the bond
+// is a cross-store operation with no well-defined home, so it is rejected rather
+// than silently written to the wrong database. When nothing pins a store (both
+// operands are cooked formulas) the bond stays on the local store.
+func pickBondStore(localStore storage.DoltStorage, a, b *molBondOperand) (storage.DoltStorage, error) {
+	active := localStore
+	pinned := false
+	for _, op := range []*molBondOperand{a, b} {
+		if op.cooked || op.store == nil {
+			continue
+		}
+		if !pinned {
+			active = op.store
+			pinned = true
+			continue
+		}
+		if op.store != active {
+			return nil, fmt.Errorf("cannot bond operands that live in different stores/rigs; run the bond from the rig that owns them")
+		}
+	}
+	return active, nil
+}
+
 // resolveOrDescribe checks if an operand is an issue or formula without cooking.
 // Used for dry-run mode. Returns (issue, formulaName, error).
 // If it's an issue, issue is set. If it's a formula, formulaName is set.
-func resolveOrDescribe(ctx context.Context, s storage.DoltStorage, operand string) (*types.Issue, string, error) {
-	// First, try to resolve as an existing issue
-	id, err := utils.ResolvePartialID(ctx, s, operand)
+//
+// Issue resolution uses the read-only routing fallback (local, then prefix-routed
+// rig, then contributor auto-routing) so a dry run previews routed operands the
+// same way the real bond resolves them.
+func resolveOrDescribe(ctx context.Context, localStore storage.DoltStorage, operand string) (*types.Issue, string, error) {
+	rr, err := resolveAndGetIssueWithRouting(ctx, localStore, operand)
 	if err == nil {
-		issue, err := s.GetIssue(ctx, id)
-		if err == nil {
-			return issue, "", nil
-		}
+		issue := rr.Issue
+		rr.Close()
+		return issue, "", nil
+	}
+	if !isNotFoundErr(err) {
+		return nil, "", err
 	}
 
 	// Not found as issue - check if it looks like a formula name
@@ -594,81 +706,6 @@ func resolveOrDescribe(ctx context.Context, s storage.DoltStorage, operand strin
 	}
 
 	return nil, f.Formula, nil
-}
-
-// resolveOrCookToSubgraph tries to resolve an operand as an issue ID or formula.
-// If it's an issue, loads the subgraph from DB. If it's a formula, cooks inline to subgraph.
-// Returns the subgraph, whether it was cooked from formula, and any error.
-//
-// The vars parameter is used for step condition filtering (bd-7zka.1).
-// This implements gt-4v1eo: formulas are cooked to in-memory subgraphs (no DB storage).
-func resolveOrCookToSubgraph(ctx context.Context, s storage.DoltStorage, operand string, vars map[string]string) (*TemplateSubgraph, bool, error) {
-	// First, try to resolve as an existing issue
-	id, err := utils.ResolvePartialID(ctx, s, operand)
-	if err == nil {
-		issue, err := s.GetIssue(ctx, id)
-		if err == nil {
-			// Check if it's a proto (template)
-			if isProto(issue) {
-				subgraph, err := loadTemplateSubgraph(ctx, s, id)
-				if err != nil {
-					return nil, false, fmt.Errorf("loading proto subgraph '%s': %w", id, err)
-				}
-				return subgraph, false, nil
-			}
-			// It's a molecule, not a proto - wrap it as a single-issue subgraph
-			return &TemplateSubgraph{
-				Root:     issue,
-				Issues:   []*types.Issue{issue},
-				IssueMap: map[string]*types.Issue{issue.ID: issue},
-			}, false, nil
-		}
-	}
-
-	// Not found as issue - check if it looks like a formula name
-	if !looksLikeFormulaName(operand) {
-		return nil, false, fmt.Errorf("'%s' not found (not an issue ID or formula name)", operand)
-	}
-
-	// Try to cook formula inline to in-memory subgraph
-	// Pass vars for step condition filtering (bd-7zka.1)
-	subgraph, err := resolveAndCookFormulaWithVars(operand, nil, vars)
-	if err != nil {
-		return nil, false, fmt.Errorf("'%s' not found as issue or formula: %w", operand, err)
-	}
-
-	return subgraph, true, nil
-}
-
-// resolveBondStore picks the database a bond should operate on.
-//
-// `bd mol bond` spawns wisps into the same database as the target issue. When an
-// operand is an existing issue that lives in a different rig's database — e.g. when
-// invoked from the town root (or with BEADS_DOLT_DATA_DIR set) where the active store
-// is the town DB (hq) but the target lives in a rig DB — the operand resolves
-// "not found" against the active store and the bond fails. This mirrors the
-// cross-database prefix routing already used by `bd show`, `bd update`, `bd close`,
-// etc. (GH#4220)
-//
-// It returns the routed store (and its close function) for the first operand that
-// routes elsewhere, or the local store (with a no-op close) when nothing routes.
-// Formula-name operands are skipped: they are cooked into the working store, not
-// looked up across databases.
-func resolveBondStore(ctx context.Context, localStore storage.DoltStorage, operands []string) (storage.DoltStorage, func()) {
-	for _, arg := range operands {
-		if looksLikeFormulaName(arg) {
-			continue
-		}
-		res, err := resolveAndGetIssueWithRouting(ctx, localStore, arg)
-		if err != nil {
-			continue // not resolvable here; resolveOrCook will surface the real error
-		}
-		if res.Routed {
-			return res.Store, res.Close
-		}
-		res.Close()
-	}
-	return localStore, func() {}
 }
 
 // looksLikeFormulaName checks if an operand looks like a formula name.

--- a/cmd/bd/mol_bond_routing_test.go
+++ b/cmd/bd/mol_bond_routing_test.go
@@ -1,0 +1,129 @@
+//go:build cgo
+
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestResolveBondStore is the regression test for GH#4220: `bd mol bond` resolved
+// its operands only against the active store, so when the target issue lived in a
+// different (routed) database — e.g. invoked from the town root where the active store
+// is the town DB but the target lives in a rig DB — the bond failed with
+// "'<id>' not found", even though `bd show`/`bd update`/`bd close` routed the same ID
+// fine. resolveBondStore performs the same routing fallback and returns the database
+// the bond must operate on, so spawned wisps land in the target's database.
+//
+// Cases:
+//   - local target (no routing) → returns the local primary store
+//   - routed target → returns the routed store, not the local one
+//   - formula operand + routed target → formula is skipped, routed target wins
+//   - nothing resolvable (formula only) → falls back to the local store
+func TestResolveBondStore(t *testing.T) {
+	cases := []struct {
+		name          string
+		role          string
+		enableRouting bool
+		localSeed     []string
+		planningSeed  []string
+		operands      []string
+		wantRouted    bool // true: expect a store != local; false: expect the local store
+	}{
+		{
+			name:       "local_target_uses_local_store",
+			role:       "maintainer",
+			localSeed:  []string{"shared-here"},
+			operands:   []string{"mol-some-formula", "shared-here"},
+			wantRouted: false,
+		},
+		{
+			name:          "routed_target_uses_routed_store",
+			role:          "contributor",
+			enableRouting: true,
+			planningSeed:  []string{"shared-there"},
+			operands:      []string{"mol-some-formula", "shared-there"},
+			wantRouted:    true,
+		},
+		{
+			name:          "formula_operand_skipped_routed_target_wins",
+			role:          "contributor",
+			enableRouting: true,
+			planningSeed:  []string{"shared-target"},
+			operands:      []string{"shared-target", "mol-polecat-work"},
+			wantRouted:    true,
+		},
+		{
+			name:       "no_resolvable_operand_falls_back_to_local",
+			role:       "maintainer",
+			operands:   []string{"mol-a", "mol-b"},
+			wantRouted: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			initConfigForTest(t)
+
+			tmpDir := t.TempDir()
+			repoDir := filepath.Join(tmpDir, "repo")
+			planningDir := filepath.Join(tmpDir, "planning")
+
+			runCmd(t, tmpDir, "git", "init", repoDir)
+			runCmd(t, repoDir, "git", "config", "beads.role", tc.role)
+
+			primaryStore := newTestStoreIsolatedDB(t, filepath.Join(repoDir, ".beads", "beads.db"), "shared")
+			ctx := context.Background()
+
+			if tc.enableRouting {
+				if err := primaryStore.SetConfig(ctx, "routing.mode", "auto"); err != nil {
+					t.Fatalf("set routing.mode: %v", err)
+				}
+				if err := primaryStore.SetConfig(ctx, "routing.contributor", planningDir); err != nil {
+					t.Fatalf("set routing.contributor: %v", err)
+				}
+			}
+
+			for _, id := range tc.localSeed {
+				seedIssue(t, ctx, primaryStore, id)
+			}
+
+			if len(tc.planningSeed) > 0 {
+				planningStore := newTestStoreIsolatedDB(t, filepath.Join(planningDir, ".beads", "beads.db"), "shared")
+				for _, id := range tc.planningSeed {
+					seedIssue(t, ctx, planningStore, id)
+				}
+				if err := planningStore.Close(); err != nil {
+					t.Fatalf("close planning store: %v", err)
+				}
+			}
+
+			oldWD, err := os.Getwd()
+			if err != nil {
+				t.Fatalf("getwd: %v", err)
+			}
+			t.Cleanup(func() { _ = os.Chdir(oldWD) })
+			if err := os.Chdir(repoDir); err != nil {
+				t.Fatalf("chdir repoDir: %v", err)
+			}
+
+			workStore, closeWorkStore := resolveBondStore(ctx, primaryStore, tc.operands)
+			defer closeWorkStore()
+
+			if workStore == nil {
+				t.Fatal("resolveBondStore returned a nil store")
+			}
+			if tc.wantRouted {
+				if workStore == primaryStore {
+					t.Errorf("expected a routed store, got the local primary store")
+				}
+			} else {
+				if workStore != primaryStore {
+					t.Errorf("expected the local primary store, got a routed store")
+				}
+			}
+		})
+	}
+}

--- a/cmd/bd/mol_bond_routing_test.go
+++ b/cmd/bd/mol_bond_routing_test.go
@@ -22,10 +22,8 @@ import (
 // utils.ResolvePartialID against the local store only and never fell through to
 // the routing fallback that show/update/close use.
 //
-// resolveMolBondOperand now routes operand resolution through
-// resolveAndGetIssueForMutation, so an operand that exists only in a routed
-// store resolves and reports the routed store as its owner. The bond mutation
-// then runs against that store instead of the local one.
+// discoverMolBondOperand resolves both operands read-only and records their
+// logical store homes before the accepted target is reopened writable.
 //
 // The cases mirror TestResolveCloseTargets:
 //   - maintainer-mode local resolution (no routing involved)
@@ -33,22 +31,20 @@ import (
 func TestResolveMolBondOperandRouting(t *testing.T) {
 	cases := []struct {
 		name          string
-		role          string // git config beads.role value
-		enableRouting bool   // set routing.mode=auto + routing.contributor=<planningDir>
-		localSeed     string // issue ID to create in the primary (local) store, if non-empty
-		planningSeed  string // issue ID to create in the routed planning store, if non-empty
-		operand       string // argument to resolveMolBondOperand
-		wantRouted    bool   // expected molBondOperand.routed
-		wantReadOnly  bool   // expected mutation policy for the resolved store
-		wantStore     string // "local" (== primaryStore) or "planning" (routed handle)
+		role          string
+		enableRouting bool
+		localSeed     string
+		planningSeed  string
+		operand       string
+		wantForbidden bool
+		wantStore     string
 	}{
 		{
-			name:       "maintainer_local_issue",
-			role:       "maintainer",
-			localSeed:  "shared-local",
-			operand:    "shared-local",
-			wantRouted: false,
-			wantStore:  "local",
+			name:      "maintainer_local_issue",
+			role:      "maintainer",
+			localSeed: "shared-local",
+			operand:   "shared-local",
+			wantStore: "local",
 		},
 		{
 			name:          "contributor_routed_issue",
@@ -56,8 +52,7 @@ func TestResolveMolBondOperandRouting(t *testing.T) {
 			enableRouting: true,
 			planningSeed:  "shared-routed",
 			operand:       "shared-routed",
-			wantRouted:    true,
-			wantReadOnly:  true,
+			wantForbidden: true,
 			wantStore:     "planning",
 		},
 	}
@@ -91,7 +86,7 @@ func TestResolveMolBondOperandRouting(t *testing.T) {
 			if tc.planningSeed != "" {
 				planningStore := newTestStoreIsolatedDB(t, filepath.Join(planningDir, ".beads", "beads.db"), "shared")
 				seedIssue(t, ctx, planningStore, tc.planningSeed)
-				// Release the planning store so resolveMolBondOperand can open the
+				// Release the planning store so discovery can open the
 				// routed store through the normal command path.
 				if err := planningStore.Close(); err != nil {
 					t.Fatalf("close planning store: %v", err)
@@ -107,35 +102,30 @@ func TestResolveMolBondOperandRouting(t *testing.T) {
 				t.Fatalf("chdir repoDir: %v", err)
 			}
 
-			op, err := resolveMolBondOperand(ctx, primaryStore, tc.operand, nil)
+			disc, err := discoverMolBondOperand(ctx, primaryStore, tc.operand)
 			if err != nil {
-				t.Fatalf("resolveMolBondOperand(%q): %v", tc.operand, err)
+				t.Fatalf("discoverMolBondOperand(%q): %v", tc.operand, err)
 			}
-			defer op.Close()
-
-			if op.subgraph == nil || op.subgraph.Root == nil {
-				t.Fatalf("operand %q: missing resolved subgraph", tc.operand)
+			defer disc.Close()
+			if disc.issue == nil || disc.issue.ID != tc.operand || disc.formula != "" {
+				t.Fatalf("operand %q discovery = %#v", tc.operand, disc)
 			}
-			if op.subgraph.Root.ID != tc.operand {
-				t.Errorf("operand %q: Root.ID = %q, want %q", tc.operand, op.subgraph.Root.ID, tc.operand)
+			if disc.mutationForbidden != tc.wantForbidden {
+				t.Errorf("operand %q: mutationForbidden = %v, want %v", tc.operand, disc.mutationForbidden, tc.wantForbidden)
 			}
-			if op.cooked {
-				t.Errorf("operand %q: cooked = true, want false (it is an existing issue)", tc.operand)
-			}
-			if op.routed != tc.wantRouted {
-				t.Errorf("operand %q: routed = %v, want %v", tc.operand, op.routed, tc.wantRouted)
-			}
-			if op.readOnly != tc.wantReadOnly {
-				t.Errorf("operand %q: readOnly = %v, want %v", tc.operand, op.readOnly, tc.wantReadOnly)
-			}
-			if op.readOnly {
-				formula := &molBondOperand{cooked: true}
-				if _, err := pickBondStore(primaryStore, formula, op); err == nil || !strings.Contains(err.Error(), "auto-routing") {
-					t.Errorf("read-only auto-routed operand error = %v, want clear refusal", err)
+			if disc.mutationForbidden {
+				formula := &molBondDiscovery{operand: "mol-test", formula: "mol-test"}
+				if _, _, err := validateMolBondHomes(primaryStore, formula, disc); err == nil || !strings.Contains(err.Error(), "auto-routing") {
+					t.Errorf("forbidden auto-routed operand error = %v, want clear refusal", err)
 				}
 			}
-
-			assertStoreOrigin(t, tc.operand, tc.wantStore, op.store, primaryStore)
+			localKey := storeIdentityKey(primaryStore)
+			if tc.wantStore == "local" && disc.storeKey != localKey {
+				t.Errorf("operand %q storeKey = %q, want local %q", tc.operand, disc.storeKey, localKey)
+			}
+			if tc.wantStore == "planning" && disc.storeKey == localKey {
+				t.Errorf("operand %q unexpectedly resolved to local store", tc.operand)
+			}
 		})
 	}
 }
@@ -152,23 +142,36 @@ func TestMolBondPrefixRouting(t *testing.T) {
 		"mol": {"mol-polecat-work"},
 	})
 
-	opA, err := resolveMolBondOperand(ctx, townStore, "gt-first", nil)
+	discA, err := discoverMolBondOperand(ctx, townStore, "gt-first")
 	if err != nil {
-		t.Fatalf("resolve first routed operand: %v", err)
+		t.Fatalf("discover first routed operand: %v", err)
 	}
-	defer opA.Close()
-	opB, err := resolveMolBondOperandWithPreferredStore(ctx, townStore, opA, "gt-second", nil)
+	defer discA.Close()
+	discB, err := discoverMolBondOperand(ctx, townStore, "gt-second")
 	if err != nil {
-		t.Fatalf("resolve second routed operand: %v", err)
+		t.Fatalf("discover second routed operand: %v", err)
 	}
-	defer opB.Close()
-	if opA.store != opB.store {
-		t.Fatal("same-rig operands did not reuse one routed store handle")
-	}
-	active, err := pickBondStore(townStore, opA, opB)
+	defer discB.Close()
+	targetID, _, err := validateMolBondHomes(townStore, discA, discB)
 	if err != nil {
 		t.Fatalf("same-rig operands rejected as cross-store: %v", err)
 	}
+	discA.Close()
+	discB.Close()
+	routed, err := resolveAndGetIssueForMutation(ctx, townStore, targetID)
+	if err != nil {
+		t.Fatalf("open accepted target writable: %v", err)
+	}
+	defer routed.Close()
+	opA, err := materializeMolBondOperand(ctx, routed.Store, discA, nil)
+	if err != nil {
+		t.Fatalf("materialize first operand: %v", err)
+	}
+	opB, err := materializeMolBondOperand(ctx, routed.Store, discB, nil)
+	if err != nil {
+		t.Fatalf("materialize second operand: %v", err)
+	}
+	active := routed.Store
 	if _, err := bondMolMol(ctx, active, opA.subgraph.Root, opB.subgraph.Root, types.BondTypeSequential, "test"); err != nil {
 		t.Fatalf("bond same-rig operands: %v", err)
 	}
@@ -180,27 +183,40 @@ func TestMolBondPrefixRouting(t *testing.T) {
 		t.Fatalf("routed mutation landed incorrectly: dependencies=%v", deps)
 	}
 
-	crossA, err := resolveMolBondOperand(ctx, townStore, "gt-first", nil)
+	crossA, err := discoverMolBondOperand(ctx, townStore, "gt-first")
 	if err != nil {
-		t.Fatalf("resolve cross-store operand A: %v", err)
+		t.Fatalf("discover cross-store operand A: %v", err)
 	}
 	defer crossA.Close()
-	crossB, err := resolveMolBondOperandWithPreferredStore(ctx, townStore, crossA, "zz-other", nil)
+	crossB, err := discoverMolBondOperand(ctx, townStore, "zz-other")
 	if err != nil {
-		t.Fatalf("resolve cross-store operand B: %v", err)
+		t.Fatalf("discover cross-store operand B: %v", err)
 	}
 	defer crossB.Close()
-	if _, err := pickBondStore(townStore, crossA, crossB); err == nil || !strings.Contains(err.Error(), "different stores/rigs") {
+	if _, _, err := validateMolBondHomes(townStore, crossA, crossB); err == nil || !strings.Contains(err.Error(), "different stores/rigs") {
 		t.Fatalf("cross-store pair error = %v, want explicit rejection", err)
 	}
 
-	formulaLike, err := resolveMolBondOperand(ctx, townStore, "mol-polecat-work", nil)
+	formulaLike, err := discoverMolBondOperand(ctx, townStore, "mol-polecat-work")
 	if err != nil {
-		t.Fatalf("resolve formula-like routed issue: %v", err)
+		t.Fatalf("discover formula-like routed issue: %v", err)
 	}
 	defer formulaLike.Close()
-	if formulaLike.cooked || formulaLike.subgraph.Root.ID != "mol-polecat-work" {
-		t.Fatalf("formula-like issue did not retain issue-first semantics: cooked=%v root=%q", formulaLike.cooked, formulaLike.subgraph.Root.ID)
+	if formulaLike.issue == nil || formulaLike.issue.ID != "mol-polecat-work" || formulaLike.formula != "" {
+		t.Fatalf("formula-like issue did not retain issue-first semantics: %#v", formulaLike)
+	}
+
+	routesPath := filepath.Join(filepath.Dir(dbPath), "routes.jsonl")
+	routes, err := os.ReadFile(routesPath)
+	if err != nil {
+		t.Fatalf("read routes for failure case: %v", err)
+	}
+	routes = append(routes, []byte("{\"prefix\":\"bad-\",\"path\":\"missing-rig\"}\n")...)
+	if err := os.WriteFile(routesPath, routes, 0644); err != nil {
+		t.Fatalf("write failure route: %v", err)
+	}
+	if _, err := discoverMolBondOperand(ctx, townStore, "bad-target"); err == nil || !strings.Contains(err.Error(), "no dolt_database") {
+		t.Fatalf("matched-route failure = %v, want actionable target metadata error", err)
 	}
 }
 
@@ -245,23 +261,4 @@ func setupMolBondPrefixRouting(t *testing.T, rigs map[string][]string) (context.
 	}
 	t.Cleanup(func() { _ = os.Chdir(oldWD) })
 	return ctx, townStore
-}
-
-func assertStoreOrigin(t *testing.T, operand, want string, got, local storage.DoltStorage) {
-	t.Helper()
-	switch want {
-	case "local":
-		if got != local {
-			t.Errorf("operand %q: store should be the local primary store", operand)
-		}
-	case "planning":
-		if got == nil {
-			t.Errorf("operand %q: store is nil", operand)
-		}
-		if got == local {
-			t.Errorf("operand %q: store should be the routed planning store, not the local one", operand)
-		}
-	default:
-		t.Fatalf("operand %q: unknown wantStore %q", operand, want)
-	}
 }

--- a/cmd/bd/mol_bond_routing_test.go
+++ b/cmd/bd/mol_bond_routing_test.go
@@ -4,11 +4,14 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/steveyegge/beads/internal/storage"
+	"github.com/steveyegge/beads/internal/types"
 )
 
 // TestResolveMolBondOperandRouting is the regression test for the mol-bond
@@ -36,6 +39,7 @@ func TestResolveMolBondOperandRouting(t *testing.T) {
 		planningSeed  string // issue ID to create in the routed planning store, if non-empty
 		operand       string // argument to resolveMolBondOperand
 		wantRouted    bool   // expected molBondOperand.routed
+		wantReadOnly  bool   // expected mutation policy for the resolved store
 		wantStore     string // "local" (== primaryStore) or "planning" (routed handle)
 	}{
 		{
@@ -53,6 +57,7 @@ func TestResolveMolBondOperandRouting(t *testing.T) {
 			planningSeed:  "shared-routed",
 			operand:       "shared-routed",
 			wantRouted:    true,
+			wantReadOnly:  true,
 			wantStore:     "planning",
 		},
 	}
@@ -120,10 +125,126 @@ func TestResolveMolBondOperandRouting(t *testing.T) {
 			if op.routed != tc.wantRouted {
 				t.Errorf("operand %q: routed = %v, want %v", tc.operand, op.routed, tc.wantRouted)
 			}
+			if op.readOnly != tc.wantReadOnly {
+				t.Errorf("operand %q: readOnly = %v, want %v", tc.operand, op.readOnly, tc.wantReadOnly)
+			}
+			if op.readOnly {
+				formula := &molBondOperand{cooked: true}
+				if _, err := pickBondStore(primaryStore, formula, op); err == nil || !strings.Contains(err.Error(), "auto-routing") {
+					t.Errorf("read-only auto-routed operand error = %v, want clear refusal", err)
+				}
+			}
 
 			assertStoreOrigin(t, tc.operand, tc.wantStore, op.store, primaryStore)
 		})
 	}
+}
+
+// TestMolBondPrefixRouting exercises the explicit routes.jsonl path reported in
+// #4714 and gastownhall/gastown#4220. It proves that a same-rig pair shares one
+// writable handle and can mutate that rig, while a genuinely cross-rig pair is
+// rejected before mutation. It also guards issue-first resolution for IDs that
+// look like formula names.
+func TestMolBondPrefixRouting(t *testing.T) {
+	ctx, townStore := setupMolBondPrefixRouting(t, map[string][]string{
+		"gt":  {"gt-first", "gt-second"},
+		"zz":  {"zz-other"},
+		"mol": {"mol-polecat-work"},
+	})
+
+	opA, err := resolveMolBondOperand(ctx, townStore, "gt-first", nil)
+	if err != nil {
+		t.Fatalf("resolve first routed operand: %v", err)
+	}
+	defer opA.Close()
+	opB, err := resolveMolBondOperandWithPreferredStore(ctx, townStore, opA, "gt-second", nil)
+	if err != nil {
+		t.Fatalf("resolve second routed operand: %v", err)
+	}
+	defer opB.Close()
+	if opA.store != opB.store {
+		t.Fatal("same-rig operands did not reuse one routed store handle")
+	}
+	active, err := pickBondStore(townStore, opA, opB)
+	if err != nil {
+		t.Fatalf("same-rig operands rejected as cross-store: %v", err)
+	}
+	if _, err := bondMolMol(ctx, active, opA.subgraph.Root, opB.subgraph.Root, types.BondTypeSequential, "test"); err != nil {
+		t.Fatalf("bond same-rig operands: %v", err)
+	}
+	deps, err := active.GetDependenciesWithMetadata(ctx, "gt-second")
+	if err != nil {
+		t.Fatalf("read routed dependencies after bond: %v", err)
+	}
+	if len(deps) != 1 || deps[0].ID != "gt-first" {
+		t.Fatalf("routed mutation landed incorrectly: dependencies=%v", deps)
+	}
+
+	crossA, err := resolveMolBondOperand(ctx, townStore, "gt-first", nil)
+	if err != nil {
+		t.Fatalf("resolve cross-store operand A: %v", err)
+	}
+	defer crossA.Close()
+	crossB, err := resolveMolBondOperandWithPreferredStore(ctx, townStore, crossA, "zz-other", nil)
+	if err != nil {
+		t.Fatalf("resolve cross-store operand B: %v", err)
+	}
+	defer crossB.Close()
+	if _, err := pickBondStore(townStore, crossA, crossB); err == nil || !strings.Contains(err.Error(), "different stores/rigs") {
+		t.Fatalf("cross-store pair error = %v, want explicit rejection", err)
+	}
+
+	formulaLike, err := resolveMolBondOperand(ctx, townStore, "mol-polecat-work", nil)
+	if err != nil {
+		t.Fatalf("resolve formula-like routed issue: %v", err)
+	}
+	defer formulaLike.Close()
+	if formulaLike.cooked || formulaLike.subgraph.Root.ID != "mol-polecat-work" {
+		t.Fatalf("formula-like issue did not retain issue-first semantics: cooked=%v root=%q", formulaLike.cooked, formulaLike.subgraph.Root.ID)
+	}
+}
+
+func setupMolBondPrefixRouting(t *testing.T, rigs map[string][]string) (context.Context, storage.DoltStorage) {
+	t.Helper()
+	initConfigForTest(t)
+	ctx := context.Background()
+	townDir := t.TempDir()
+	townBeadsDir := filepath.Join(townDir, ".beads")
+	if err := os.MkdirAll(townBeadsDir, 0755); err != nil {
+		t.Fatalf("create town beads dir: %v", err)
+	}
+	townDBPath := filepath.Join(townBeadsDir, "dolt")
+	townStore := newTestStoreIsolatedDB(t, townDBPath, "hq")
+
+	var routes strings.Builder
+	for prefix, ids := range rigs {
+		rigPath := "rig-" + prefix
+		rigDBPath := filepath.Join(townDir, rigPath, ".beads", "dolt")
+		rigStore := newTestStoreIsolatedDB(t, rigDBPath, prefix)
+		for _, id := range ids {
+			seedIssue(t, ctx, rigStore, id)
+		}
+		if err := rigStore.Close(); err != nil {
+			t.Fatalf("close %s routed store: %v", prefix, err)
+		}
+		fmt.Fprintf(&routes, "{\"prefix\":%q,\"path\":%q}\n", prefix+"-", rigPath)
+	}
+	if err := os.WriteFile(filepath.Join(townBeadsDir, "routes.jsonl"), []byte(routes.String()), 0644); err != nil {
+		t.Fatalf("write routes.jsonl: %v", err)
+	}
+
+	oldDBPath := dbPath
+	dbPath = townDBPath
+	t.Cleanup(func() { dbPath = oldDBPath })
+	oldWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(townDir); err != nil {
+		t.Fatalf("chdir town: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(oldWD) })
+	return ctx, townStore
 }
 
 func assertStoreOrigin(t *testing.T, operand, want string, got, local storage.DoltStorage) {

--- a/cmd/bd/mol_bond_routing_test.go
+++ b/cmd/bd/mol_bond_routing_test.go
@@ -218,6 +218,25 @@ func TestMolBondPrefixRouting(t *testing.T) {
 	if _, err := discoverMolBondOperand(ctx, townStore, "bad-target"); err == nil || !strings.Contains(err.Error(), "no dolt_database") {
 		t.Fatalf("matched-route failure = %v, want actionable target metadata error", err)
 	}
+
+	drift, err := discoverMolBondOperand(ctx, townStore, "zz-other")
+	if err != nil {
+		t.Fatalf("discover drift fixture: %v", err)
+	}
+	_, driftKey, err := validateMolBondHomes(townStore, drift)
+	if err != nil {
+		t.Fatalf("validate drift fixture: %v", err)
+	}
+	drift.Close()
+	seedIssue(t, ctx, townStore, "zz-other") // local-first resolution now points elsewhere
+	reopened, err := resolveAndGetIssueForMutation(ctx, townStore, "zz-other")
+	if err != nil {
+		t.Fatalf("reopen drift fixture: %v", err)
+	}
+	defer reopened.Close()
+	if err := verifyMolBondWritableHome(reopened, driftKey); err == nil || !strings.Contains(err.Error(), "changed between discovery") {
+		t.Fatalf("reopen identity mismatch = %v, want retryable safety error", err)
+	}
 }
 
 func setupMolBondPrefixRouting(t *testing.T, rigs map[string][]string) (context.Context, storage.DoltStorage) {

--- a/cmd/bd/mol_bond_routing_test.go
+++ b/cmd/bd/mol_bond_routing_test.go
@@ -7,59 +7,53 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/steveyegge/beads/internal/storage"
 )
 
-// TestResolveBondStore is the regression test for GH#4220: `bd mol bond` resolved
-// its operands only against the active store, so when the target issue lived in a
-// different (routed) database — e.g. invoked from the town root where the active store
-// is the town DB but the target lives in a rig DB — the bond failed with
-// "'<id>' not found", even though `bd show`/`bd update`/`bd close` routed the same ID
-// fine. resolveBondStore performs the same routing fallback and returns the database
-// the bond must operate on, so spawned wisps land in the target's database.
+// TestResolveMolBondOperandRouting is the regression test for the mol-bond
+// routing bug: `bd mol bond <formula> <bead>` failed with
+// "'<bead>' not found (not an issue ID or formula name)" whenever <bead> lived
+// in a routed store (a prefix-routed rig, or the contributor planning store),
+// even though `bd show <bead>` resolved it. mol bond resolved operands with
+// utils.ResolvePartialID against the local store only and never fell through to
+// the routing fallback that show/update/close use.
 //
-// Cases:
-//   - local target (no routing) → returns the local primary store
-//   - routed target → returns the routed store, not the local one
-//   - formula operand + routed target → formula is skipped, routed target wins
-//   - nothing resolvable (formula only) → falls back to the local store
-func TestResolveBondStore(t *testing.T) {
+// resolveMolBondOperand now routes operand resolution through
+// resolveAndGetIssueForMutation, so an operand that exists only in a routed
+// store resolves and reports the routed store as its owner. The bond mutation
+// then runs against that store instead of the local one.
+//
+// The cases mirror TestResolveCloseTargets:
+//   - maintainer-mode local resolution (no routing involved)
+//   - contributor-mode operand that lives only in the routed planning store
+func TestResolveMolBondOperandRouting(t *testing.T) {
 	cases := []struct {
 		name          string
-		role          string
-		enableRouting bool
-		localSeed     []string
-		planningSeed  []string
-		operands      []string
-		wantRouted    bool // true: expect a store != local; false: expect the local store
+		role          string // git config beads.role value
+		enableRouting bool   // set routing.mode=auto + routing.contributor=<planningDir>
+		localSeed     string // issue ID to create in the primary (local) store, if non-empty
+		planningSeed  string // issue ID to create in the routed planning store, if non-empty
+		operand       string // argument to resolveMolBondOperand
+		wantRouted    bool   // expected molBondOperand.routed
+		wantStore     string // "local" (== primaryStore) or "planning" (routed handle)
 	}{
 		{
-			name:       "local_target_uses_local_store",
+			name:       "maintainer_local_issue",
 			role:       "maintainer",
-			localSeed:  []string{"shared-here"},
-			operands:   []string{"mol-some-formula", "shared-here"},
+			localSeed:  "shared-local",
+			operand:    "shared-local",
 			wantRouted: false,
+			wantStore:  "local",
 		},
 		{
-			name:          "routed_target_uses_routed_store",
+			name:          "contributor_routed_issue",
 			role:          "contributor",
 			enableRouting: true,
-			planningSeed:  []string{"shared-there"},
-			operands:      []string{"mol-some-formula", "shared-there"},
+			planningSeed:  "shared-routed",
+			operand:       "shared-routed",
 			wantRouted:    true,
-		},
-		{
-			name:          "formula_operand_skipped_routed_target_wins",
-			role:          "contributor",
-			enableRouting: true,
-			planningSeed:  []string{"shared-target"},
-			operands:      []string{"shared-target", "mol-polecat-work"},
-			wantRouted:    true,
-		},
-		{
-			name:       "no_resolvable_operand_falls_back_to_local",
-			role:       "maintainer",
-			operands:   []string{"mol-a", "mol-b"},
-			wantRouted: false,
+			wantStore:     "planning",
 		},
 	}
 
@@ -86,15 +80,14 @@ func TestResolveBondStore(t *testing.T) {
 				}
 			}
 
-			for _, id := range tc.localSeed {
-				seedIssue(t, ctx, primaryStore, id)
+			if tc.localSeed != "" {
+				seedIssue(t, ctx, primaryStore, tc.localSeed)
 			}
-
-			if len(tc.planningSeed) > 0 {
+			if tc.planningSeed != "" {
 				planningStore := newTestStoreIsolatedDB(t, filepath.Join(planningDir, ".beads", "beads.db"), "shared")
-				for _, id := range tc.planningSeed {
-					seedIssue(t, ctx, planningStore, id)
-				}
+				seedIssue(t, ctx, planningStore, tc.planningSeed)
+				// Release the planning store so resolveMolBondOperand can open the
+				// routed store through the normal command path.
 				if err := planningStore.Close(); err != nil {
 					t.Fatalf("close planning store: %v", err)
 				}
@@ -109,21 +102,45 @@ func TestResolveBondStore(t *testing.T) {
 				t.Fatalf("chdir repoDir: %v", err)
 			}
 
-			workStore, closeWorkStore := resolveBondStore(ctx, primaryStore, tc.operands)
-			defer closeWorkStore()
+			op, err := resolveMolBondOperand(ctx, primaryStore, tc.operand, nil)
+			if err != nil {
+				t.Fatalf("resolveMolBondOperand(%q): %v", tc.operand, err)
+			}
+			defer op.Close()
 
-			if workStore == nil {
-				t.Fatal("resolveBondStore returned a nil store")
+			if op.subgraph == nil || op.subgraph.Root == nil {
+				t.Fatalf("operand %q: missing resolved subgraph", tc.operand)
 			}
-			if tc.wantRouted {
-				if workStore == primaryStore {
-					t.Errorf("expected a routed store, got the local primary store")
-				}
-			} else {
-				if workStore != primaryStore {
-					t.Errorf("expected the local primary store, got a routed store")
-				}
+			if op.subgraph.Root.ID != tc.operand {
+				t.Errorf("operand %q: Root.ID = %q, want %q", tc.operand, op.subgraph.Root.ID, tc.operand)
 			}
+			if op.cooked {
+				t.Errorf("operand %q: cooked = true, want false (it is an existing issue)", tc.operand)
+			}
+			if op.routed != tc.wantRouted {
+				t.Errorf("operand %q: routed = %v, want %v", tc.operand, op.routed, tc.wantRouted)
+			}
+
+			assertStoreOrigin(t, tc.operand, tc.wantStore, op.store, primaryStore)
 		})
+	}
+}
+
+func assertStoreOrigin(t *testing.T, operand, want string, got, local storage.DoltStorage) {
+	t.Helper()
+	switch want {
+	case "local":
+		if got != local {
+			t.Errorf("operand %q: store should be the local primary store", operand)
+		}
+	case "planning":
+		if got == nil {
+			t.Errorf("operand %q: store is nil", operand)
+		}
+		if got == local {
+			t.Errorf("operand %q: store should be the routed planning store, not the local one", operand)
+		}
+	default:
+		t.Fatalf("operand %q: unknown wantStore %q", operand, want)
 	}
 }

--- a/cmd/bd/mol_embedded_test.go
+++ b/cmd/bd/mol_embedded_test.go
@@ -3,13 +3,87 @@
 package main
 
 import (
+	"encoding/json"
 	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/steveyegge/beads/internal/formula"
 	"github.com/steveyegge/beads/internal/storage/embeddeddolt"
 	"github.com/steveyegge/beads/internal/types"
 )
+
+// TestEmbeddedMolBondRoutesFormulaMutationToTarget is the end-to-end
+// regression for #4350/#4714. A formula found in the town is bonded to an issue
+// that exists only in a prefix-routed rig; every spawned issue and dependency
+// must land in the rig database without advancing the town database.
+func TestEmbeddedMolBondRoutesFormulaMutationToTarget(t *testing.T) {
+	if os.Getenv("BEADS_TEST_EMBEDDED_DOLT") != "1" {
+		t.Skip("set BEADS_TEST_EMBEDDED_DOLT=1 to run embedded dolt integration tests")
+	}
+
+	bd := buildEmbeddedBD(t)
+	sourceDir, targetDir, targetBeadsDir := setupRoutedEmbeddedRepo(t, bd, "src", "tgt")
+	target := bdCreate(t, bd, targetDir, "Routed bond target", "--type", "epic")
+
+	formulasDir := filepath.Join(sourceDir, ".beads", "formulas")
+	if err := os.MkdirAll(formulasDir, 0755); err != nil {
+		t.Fatalf("create formulas dir: %v", err)
+	}
+	formulaBody := `formula = "mol-route"
+description = "Routed bond regression"
+version = 1
+type = "workflow"
+
+[[steps]]
+id = "work"
+title = "Routed work"
+`
+	if err := os.WriteFile(filepath.Join(formulasDir, "mol-route.formula.toml"), []byte(formulaBody), 0644); err != nil {
+		t.Fatalf("write formula: %v", err)
+	}
+
+	sourceBeadsDir := filepath.Join(sourceDir, ".beads")
+	sourceBefore := embeddedCurrentCommit(t, sourceBeadsDir, "src")
+	targetBefore := embeddedCurrentCommit(t, targetBeadsDir, "tgt")
+	dryRunOut := bdCommand(t, bd, sourceDir, "mol", "bond", "mol-route", target.ID, "--type", "parallel", "--dry-run")
+	if !strings.Contains(dryRunOut, target.ID) {
+		t.Fatalf("dry-run did not resolve routed target %s:\n%s", target.ID, dryRunOut)
+	}
+	assertEmbeddedHeadUnchanged(t, sourceBeadsDir, "src", sourceBefore, "routed mol bond dry-run source")
+	assertEmbeddedHeadUnchanged(t, targetBeadsDir, "tgt", targetBefore, "routed mol bond dry-run target")
+
+	out := bdCommand(t, bd, sourceDir, "--json", "mol", "bond", "mol-route", target.ID, "--type", "parallel")
+
+	var result BondResult
+	jsonStart := strings.Index(out, "{")
+	if jsonStart < 0 {
+		t.Fatalf("bond output has no JSON object: %s", out)
+	}
+	if err := json.NewDecoder(strings.NewReader(out[jsonStart:])).Decode(&result); err != nil {
+		t.Fatalf("decode bond result: %v\n%s", err, out)
+	}
+	if result.ResultID != target.ID || result.Spawned == 0 || len(result.IDMapping) == 0 {
+		t.Fatalf("unexpected bond result: %+v", result)
+	}
+
+	assertEmbeddedHeadUnchanged(t, sourceBeadsDir, "src", sourceBefore, "routed mol bond source")
+	assertEmbeddedHeadAdvanced(t, targetBeadsDir, "tgt", targetBefore, "routed mol bond target")
+
+	targetStore := openStore(t, targetBeadsDir, "tgt")
+	for oldID, newID := range result.IDMapping {
+		if _, err := targetStore.GetIssue(t.Context(), newID); err != nil {
+			t.Errorf("spawned %s -> %s missing from target store: %v", oldID, newID, err)
+		}
+	}
+	sourceStore := openStore(t, sourceBeadsDir, "src")
+	for _, newID := range result.IDMapping {
+		if _, err := sourceStore.GetIssue(t.Context(), newID); err == nil {
+			t.Errorf("spawned issue %s leaked into source store", newID)
+		}
+	}
+}
 
 // TestSpawnMolecule_PreservesStepLabels verifies that a cooked formula with
 // per-step labels results in spawned issues whose labels are persisted to the

--- a/cmd/bd/mol_embedded_test.go
+++ b/cmd/bd/mol_embedded_test.go
@@ -43,10 +43,32 @@ title = "Routed work"
 	if err := os.WriteFile(filepath.Join(formulasDir, "mol-route.formula.toml"), []byte(formulaBody), 0644); err != nil {
 		t.Fatalf("write formula: %v", err)
 	}
+	otherDir := filepath.Join(sourceDir, "other-repo")
+	if err := os.MkdirAll(otherDir, 0750); err != nil {
+		t.Fatalf("create other rig: %v", err)
+	}
+	initGitRepoAt(t, otherDir)
+	runBDInit(t, bd, otherDir, "--prefix", "oth")
+	other := bdCreate(t, bd, otherDir, "Other routed target")
+	routes := "{\"prefix\":\"tgt-\",\"path\":\"target-repo\"}\n" +
+		"{\"prefix\":\"oth-\",\"path\":\"other-repo\"}\n"
+	if err := os.WriteFile(filepath.Join(sourceDir, ".beads", "routes.jsonl"), []byte(routes), 0644); err != nil {
+		t.Fatalf("write two-rig routes: %v", err)
+	}
 
 	sourceBeadsDir := filepath.Join(sourceDir, ".beads")
+	otherBeadsDir := filepath.Join(otherDir, ".beads")
 	sourceBefore := embeddedCurrentCommit(t, sourceBeadsDir, "src")
 	targetBefore := embeddedCurrentCommit(t, targetBeadsDir, "tgt")
+	otherBefore := embeddedCurrentCommit(t, otherBeadsDir, "oth")
+	crossOut, crossErr := bdRunWithFlockRetry(t, bd, sourceDir, "mol", "bond", target.ID, other.ID, "--dry-run")
+	if crossErr == nil || !strings.Contains(string(crossOut), "different stores/rigs") {
+		t.Fatalf("cross-rig dry-run error = %v, output:\n%s", crossErr, crossOut)
+	}
+	assertEmbeddedHeadUnchanged(t, sourceBeadsDir, "src", sourceBefore, "cross-rig dry-run source")
+	assertEmbeddedHeadUnchanged(t, targetBeadsDir, "tgt", targetBefore, "cross-rig dry-run target")
+	assertEmbeddedHeadUnchanged(t, otherBeadsDir, "oth", otherBefore, "cross-rig dry-run other")
+
 	dryRunOut := bdCommand(t, bd, sourceDir, "mol", "bond", "mol-route", target.ID, "--type", "parallel", "--dry-run")
 	if !strings.Contains(dryRunOut, target.ID) {
 		t.Fatalf("dry-run did not resolve routed target %s:\n%s", target.ID, dryRunOut)

--- a/cmd/bd/routed.go
+++ b/cmd/bd/routed.go
@@ -35,8 +35,24 @@ type RoutedResult struct {
 	Issue      *types.Issue
 	Store      storage.DoltStorage // The store that contains this issue (may be routed)
 	Routed     bool                // true if the issue was found via routing
+	ReadOnly   bool                // true when routing policy forbids mutation of this store
 	ResolvedID string              // The resolved (full) issue ID
 	closeFn    func()              // Function to close routed storage (if any)
+}
+
+// storeIdentityKey returns a stable logical identity for a store. Routed
+// commands may open the same database more than once, so interface/pointer
+// equality is not sufficient for deciding whether two operands share a home.
+func storeIdentityKey(s storage.DoltStorage) string {
+	if locator, ok := storage.UnwrapStore(s).(storage.StoreLocator); ok {
+		if cliDir := strings.TrimSpace(locator.CLIDir()); cliDir != "" {
+			return "cli:" + filepath.Clean(cliDir)
+		}
+		if path := strings.TrimSpace(locator.Path()); path != "" {
+			return "path:" + filepath.Clean(path)
+		}
+	}
+	return fmt.Sprintf("instance:%p", s)
 }
 
 // Close closes any routed storage. Safe to call if Routed is false.
@@ -131,6 +147,7 @@ func resolveViaAutoRouting(ctx context.Context, localStore storage.DoltStorage, 
 		_ = routedStore.Close()
 		return nil, err
 	}
+	result.ReadOnly = true
 	result.closeFn = func() { _ = routedStore.Close() }
 	return result, nil
 }
@@ -237,6 +254,7 @@ func resolveViaPrefixRoutingWithAccess(ctx context.Context, id string, writable 
 		_ = targetStore.Close()
 		return nil, err
 	}
+	result.ReadOnly = !writable
 	result.closeFn = func() { _ = targetStore.Close() }
 
 	if os.Getenv("BD_DEBUG_ROUTING") != "" {

--- a/cmd/bd/routed.go
+++ b/cmd/bd/routed.go
@@ -17,6 +17,8 @@ import (
 	"github.com/steveyegge/beads/internal/utils"
 )
 
+var errRoutingUnavailable = errors.New("routing unavailable")
+
 // isNotFoundErr returns true if the error indicates the issue was not found.
 // This covers both storage.ErrNotFound (from GetIssue) and the plain error
 // from ResolvePartialID which doesn't wrap the sentinel.
@@ -32,12 +34,12 @@ func isNotFoundErr(err error) bool {
 
 // RoutedResult contains the result of a routed issue lookup
 type RoutedResult struct {
-	Issue      *types.Issue
-	Store      storage.DoltStorage // The store that contains this issue (may be routed)
-	Routed     bool                // true if the issue was found via routing
-	ReadOnly   bool                // true when routing policy forbids mutation of this store
-	ResolvedID string              // The resolved (full) issue ID
-	closeFn    func()              // Function to close routed storage (if any)
+	Issue             *types.Issue
+	Store             storage.DoltStorage // The store that contains this issue (may be routed)
+	Routed            bool                // true if the issue was found via routing
+	MutationForbidden bool                // true when routing policy forbids mutation of this store
+	ResolvedID        string              // The resolved (full) issue ID
+	closeFn           func()              // Function to close routed storage (if any)
 }
 
 // storeIdentityKey returns a stable logical identity for a store. Routed
@@ -96,6 +98,8 @@ func resolveAndGetIssueWithRoutingAccess(ctx context.Context, localStore storage
 	if isNotFoundErr(err) {
 		if prefixResult, prefixErr := resolveViaPrefixRoutingWithAccess(ctx, id, writablePrefixRoute); prefixErr == nil {
 			return prefixResult, nil
+		} else if !errors.Is(prefixErr, errRoutingUnavailable) && !isNotFoundErr(prefixErr) {
+			return nil, prefixErr
 		}
 	}
 
@@ -105,6 +109,8 @@ func resolveAndGetIssueWithRoutingAccess(ctx context.Context, localStore storage
 	if isNotFoundErr(err) {
 		if autoResult, autoErr := resolveViaAutoRouting(ctx, localStore, id); autoErr == nil {
 			return autoResult, nil
+		} else if !errors.Is(autoErr, errRoutingUnavailable) && !isNotFoundErr(autoErr) {
+			return nil, autoErr
 		}
 	}
 
@@ -138,8 +144,11 @@ func resolveAndGetFromStore(ctx context.Context, s storage.DoltStorage, id strin
 // Returns a RoutedResult if the issue is found in the auto-routed store.
 func resolveViaAutoRouting(ctx context.Context, localStore storage.DoltStorage, id string) (*RoutedResult, error) {
 	routedStore, routed, err := openRoutedReadStore(ctx, localStore)
-	if err != nil || !routed {
-		return nil, fmt.Errorf("no auto-routed store available")
+	if err != nil {
+		return nil, err
+	}
+	if !routed {
+		return nil, fmt.Errorf("%w: no auto-routed store available", errRoutingUnavailable)
 	}
 
 	result, err := resolveAndGetFromStore(ctx, routedStore, id, true)
@@ -147,7 +156,7 @@ func resolveViaAutoRouting(ctx context.Context, localStore storage.DoltStorage, 
 		_ = routedStore.Close()
 		return nil, err
 	}
-	result.ReadOnly = true
+	result.MutationForbidden = true
 	result.closeFn = func() { _ = routedStore.Close() }
 	return result, nil
 }
@@ -180,19 +189,25 @@ func resolveViaPrefixRoutingWithAccess(ctx context.Context, id string, writable 
 	// Extract prefix from the bead ID (e.g., "hr-" from "hr-8wn.1")
 	prefix := extractBeadPrefix(id)
 	if prefix == "" {
-		return nil, fmt.Errorf("no prefix in ID %q", id)
+		return nil, fmt.Errorf("%w: no prefix in ID %q", errRoutingUnavailable, id)
 	}
 
 	// Find the resolved beads directory (where routes.jsonl lives)
 	currentBeadsDir := resolveCommandBeadsDir(dbPath)
 	if currentBeadsDir == "" {
-		return nil, fmt.Errorf("no beads directory available")
+		return nil, fmt.Errorf("%w: no beads directory available", errRoutingUnavailable)
 	}
 
 	// Load routes from routes.jsonl
 	routes, err := loadPrefixRoutes(currentBeadsDir)
-	if err != nil || len(routes) == 0 {
-		return nil, fmt.Errorf("no routes available")
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, fmt.Errorf("%w: no routes available", errRoutingUnavailable)
+		}
+		return nil, fmt.Errorf("loading routes: %w", err)
+	}
+	if len(routes) == 0 {
+		return nil, fmt.Errorf("%w: no routes available", errRoutingUnavailable)
 	}
 
 	// Find matching route for this prefix
@@ -204,12 +219,12 @@ func resolveViaPrefixRoutingWithAccess(ctx context.Context, id string, writable 
 		}
 	}
 	if matchedRoute == nil {
-		return nil, fmt.Errorf("no route for prefix %q", prefix)
+		return nil, fmt.Errorf("%w: no route for prefix %q", errRoutingUnavailable, prefix)
 	}
 
 	// Skip if the route points to current directory (town-level, already checked)
 	if matchedRoute.Path == "." {
-		return nil, fmt.Errorf("route points to current database")
+		return nil, fmt.Errorf("%w: route points to current database", errRoutingUnavailable)
 	}
 
 	// Derive the town root from the current beads dir.
@@ -254,7 +269,6 @@ func resolveViaPrefixRoutingWithAccess(ctx context.Context, id string, writable 
 		_ = targetStore.Close()
 		return nil, err
 	}
-	result.ReadOnly = !writable
 	result.closeFn = func() { _ = targetStore.Close() }
 
 	if os.Getenv("BD_DEBUG_ROUTING") != "" {


### PR DESCRIPTION
## Why

`bd mol bond` resolved operands only in the active database. In a centralized-Dolt Gas Town workspace, `bd show <rig-bead>` followed `routes.jsonl`, but `bd mol bond mol-polecat-work <rig-bead>` failed with `not found`, causing `gt sling` to roll back the polecat.

This is a real, independently reproduced routing-parity bug. It was first diagnosed and validated end-to-end by Johan Snyman in this PR and gastownhall/gastown#4220, then independently reproduced and modernized by Rody Vilchez in #4714 and #4720.

Closes #4714. Addresses Bug 1 in gastownhall/gastown#4220.

## What changed

This branch consolidates both contributions:

- preserves Johan's original diagnosis, live Gas Town validation, one-work-store design, and original authored commit;
- preserves Rody's current-main write-intent routing, issue-first formula ambiguity handling, routed dry-run behavior, cross-store policy, changelog, tests, and original authored commit;
- rebases the combined work onto current `main` and adds maintainer fixes for store identity and safe store opening.

The final flow has two phases:

1. Discover both operands through read-only routing, record their logical database homes, reject contributor auto-routes and cross-store pairs, and use the same validation for `--dry-run`.
2. Close discovery handles, reopen only the single accepted home writable, verify it is still the same logical database, reload both issue operands there, then perform the bond.

This prevents unsupported cross-rig commands from triggering writable-open migrations in either foreign project. Matched-route configuration, migration-gate, permission, and lock failures are also propagated instead of being mislabeled as `not found`.

## Attribution

- Johan Snyman (`j-s-au`): original commit `86be4d7f6`, production diagnosis, gastownhall/gastown#4220 reproduction, live end-to-end verification, and work-store/test design.
- Rody Vilchez (`R0SEWT`): carried commit `2ef514122`, #4714 reproduction, current routing primitives, write-intent/dry-run split, issue-first behavior, cross-store policy, changelog, and regression coverage.

Both original authored commits remain in the branch history.

## Verification

Passed locally:

```text
go vet -tags gms_pure_go ./cmd/bd/...
go test -tags gms_pure_go ./cmd/bd -run 'TestMolBondPrefixRouting|TestResolveMolBondOperandRouting' -count=1
BEADS_TEST_EMBEDDED_DOLT=1 go test -tags gms_pure_go ./cmd/bd -run TestEmbeddedMolBondRoutesFormulaMutationToTarget -count=1
```

Coverage includes:

- formula + explicit-prefix-routed issue mutating only the target database;
- same-rig issue pairs succeeding through one writable home;
- true cross-rig pairs rejected during read-only discovery;
- cross-rig dry-run rejection without advancing either database;
- contributor auto-route mutation refusal;
- issue IDs that resemble formula names retaining issue-first semantics;
- matched-route failures remaining actionable;
- writable-reopen identity drift aborting before mutation.

The full `make test` suite passed locally for exact head `bcafe5bdd889eaaf97d231275a3fed85f10f615c`. Two independent agent reviews report no remaining blockers. This nontrivial PR still requires substantive human review before merge.

_codex-gpt-5.6-sol-high on behalf of maphew_
