### PR TITLE
fix(storage): retry writes on MySQL 1213 and 'invalid connection' in Dolt server mode

### DIFF
--- a/cmd/bd/create_proxied_server.go
+++ b/cmd/bd/create_proxied_server.go
@@ -104,8 +104,9 @@ func runCreateProxiedSingle(_ *cobra.Command, ctx context.Context, in createInpu
 		return
 	}
 
-	uw, cctx := proxiedOpenUOW(ctx)
-	defer uw.Close(ctx)
+	// Load create context (read-only) to validate input before the write tx.
+	configUW, cctx := proxiedOpenUOW(ctx)
+	configUW.Close(ctx)
 
 	customTypes := resolveProxiedCustomTypes(cctx.CustomTypes)
 	if in.issueType != "" {
@@ -135,17 +136,19 @@ func runCreateProxiedSingle(_ *cobra.Command, ctx context.Context, in createInpu
 	}
 
 	var result domain.CreateIssueResult
-	if issue.Ephemeral {
-		result, err = uw.IssueUseCase().CreateWisp(ctx, params, in.createdBy)
-	} else {
-		result, err = uw.IssueUseCase().CreateIssue(ctx, params, in.createdBy)
-	}
-	if err != nil {
+	if err := uow.RunInTxMsg(ctx, uowProvider, func(uw uow.UnitOfWork) (string, error) {
+		var e error
+		if issue.Ephemeral {
+			result, e = uw.IssueUseCase().CreateWisp(ctx, params, in.createdBy)
+		} else {
+			result, e = uw.IssueUseCase().CreateIssue(ctx, params, in.createdBy)
+		}
+		if e != nil {
+			return "", e
+		}
+		return fmt.Sprintf("bd: create %s", result.Issue.ID), nil
+	}); err != nil {
 		FatalError("%v", err)
-	}
-
-	if err := uw.Commit(ctx, fmt.Sprintf("bd: create %s", result.Issue.ID)); err != nil && !isDoltNothingToCommit(err) {
-		FatalError("commit: %v", err)
 	}
 
 	switch {
@@ -246,8 +249,8 @@ func runCreateProxiedMarkdown(_ *cobra.Command, ctx context.Context, in createIn
 		builds = append(builds, templateBuild{template: t, deps: deps})
 	}
 
-	uw, cctx := proxiedOpenUOW(ctx)
-	defer uw.Close(ctx)
+	configUW, cctx := proxiedOpenUOW(ctx)
+	configUW.Close(ctx)
 
 	customTypes := resolveProxiedCustomTypes(cctx.CustomTypes)
 	for _, b := range builds {
@@ -284,18 +287,19 @@ func runCreateProxiedMarkdown(_ *cobra.Command, ctx context.Context, in createIn
 	}
 
 	var result domain.CreateIssuesResult
-	if in.ephemeral {
-		result, err = uw.IssueUseCase().CreateWisps(ctx, paramsList, in.createdBy)
-	} else {
-		result, err = uw.IssueUseCase().CreateIssues(ctx, paramsList, in.createdBy)
-	}
-	if err != nil {
+	if err := uow.RunInTxMsg(ctx, uowProvider, func(uw uow.UnitOfWork) (string, error) {
+		var e error
+		if in.ephemeral {
+			result, e = uw.IssueUseCase().CreateWisps(ctx, paramsList, in.createdBy)
+		} else {
+			result, e = uw.IssueUseCase().CreateIssues(ctx, paramsList, in.createdBy)
+		}
+		if e != nil {
+			return "", e
+		}
+		return fmt.Sprintf("bd: create %d issue(s) from %s", len(result.Issues), in.markdownFile), nil
+	}); err != nil {
 		FatalError("creating issues from markdown: %v", err)
-	}
-
-	commitMsg := fmt.Sprintf("bd: create %d issue(s) from %s", len(result.Issues), in.markdownFile)
-	if err := uw.Commit(ctx, commitMsg); err != nil && !isDoltNothingToCommit(err) {
-		FatalError("commit: %v", err)
 	}
 
 	if in.jsonOutput {

--- a/cmd/bd/init_proxied_server.go
+++ b/cmd/bd/init_proxied_server.go
@@ -17,6 +17,7 @@ import (
 	"github.com/steveyegge/beads/internal/storage/domain"
 	"github.com/steveyegge/beads/internal/storage/fs"
 	"github.com/steveyegge/beads/internal/storage/git"
+	"github.com/steveyegge/beads/internal/storage/uow"
 	"github.com/steveyegge/beads/internal/ui"
 )
 
@@ -152,12 +153,6 @@ func runInitProxiedServer(cmd *cobra.Command, ctx context.Context, in initProxie
 	}
 	defer func() { _ = provider.Close(ctx) }()
 
-	uw, err := provider.NewUOW(ctx)
-	if err != nil {
-		FatalError("failed to open unit of work: %v", err)
-	}
-	defer uw.Close(ctx)
-
 	bootstrapParams := domain.BootstrapProjectParams{
 		Prefix:         prefix,
 		ProjectID:      projectID,
@@ -180,12 +175,11 @@ func runInitProxiedServer(cmd *cobra.Command, ctx context.Context, in initProxie
 		bootstrapParams.RemoteURL = remoteURL
 	}
 
-	if _, err := uw.BootstrapUseCase().BootstrapProject(ctx, bootstrapParams); err != nil {
-		FatalError("bootstrap project: %v", err)
-	}
-
-	if err := uw.Commit(ctx, "bd init"); err != nil {
-		FatalError("commit init: %v", err)
+	if err := uow.RunInTx(ctx, provider, "bd init", func(uw uow.UnitOfWork) error {
+		_, err := uw.BootstrapUseCase().BootstrapProject(ctx, bootstrapParams)
+		return err
+	}); err != nil {
+		FatalError("init: %v", err)
 	}
 
 	runInitProxiedServerTail(cmd, ctx, in, runInitTailContext{

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -487,6 +487,7 @@ var doltMetrics struct {
 	circuitTrips        metric.Int64Counter
 	circuitRejected     metric.Int64Counter
 	serializationErrors metric.Int64Counter
+	writeRetries        metric.Int64Counter
 	connAcquireMs       metric.Float64Histogram
 	poolWaitCount       metric.Int64Counter
 	poolWaitMs          metric.Float64Histogram
@@ -513,6 +514,10 @@ func init() {
 	doltMetrics.serializationErrors, _ = m.Int64Counter("bd.db.serialization_errors",
 		metric.WithDescription("Serialization failures (MySQL 1213/1205) before retry"),
 		metric.WithUnit("{error}"),
+	)
+	doltMetrics.writeRetries, _ = m.Int64Counter("bd.write_retries_total",
+		metric.WithDescription("Write-tx retries in withRetryTx (label: type=serialization|connection)"),
+		metric.WithUnit("{retry}"),
 	)
 	doltMetrics.connAcquireMs, _ = m.Float64Histogram("bd.db.conn_acquire_ms",
 		metric.WithDescription("Time to acquire a pooled connection for a Dolt transaction"),
@@ -633,6 +638,11 @@ func (s *DoltStore) withRetryTx(ctx context.Context, fn func(tx *sql.Tx) error) 
 		err := s.withWriteTx(ctx, fn)
 		if err != nil && isSerializationError(err) {
 			doltMetrics.serializationErrors.Add(ctx, 1)
+			doltMetrics.writeRetries.Add(ctx, 1, metric.WithAttributes(attribute.String("type", "serialization")))
+			return err // retryable
+		}
+		if err != nil && isRetryableError(err) {
+			doltMetrics.writeRetries.Add(ctx, 1, metric.WithAttributes(attribute.String("type", "connection")))
 			return err // retryable
 		}
 		if err != nil {

--- a/internal/storage/uow/dolt_sql_provider.go
+++ b/internal/storage/uow/dolt_sql_provider.go
@@ -45,12 +45,25 @@ func (p *doltSQLProvider) Close(ctx context.Context) error {
 }
 
 func (p *doltSQLProvider) BeginTx(ctx context.Context) (Tx, error) {
-	conn, err := p.db.Conn(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("uow: pin connection: %w", err)
+	var conn *sql.Conn
+	bo := backoff.NewExponentialBackOff()
+	bo.InitialInterval = 50 * time.Millisecond
+	bo.MaxElapsedTime = 3 * time.Second
+	if err := backoff.Retry(func() error {
+		var connErr error
+		conn, connErr = p.db.Conn(ctx)
+		if connErr != nil {
+			if isSerializationError(connErr) || isInvalidConnectionError(connErr) {
+				return fmt.Errorf("uow: pin connection: %w", connErr)
+			}
+			return backoff.Permanent(fmt.Errorf("uow: pin connection: %w", connErr))
+		}
+		return nil
+	}, backoff.WithContext(bo, ctx)); err != nil {
+		return nil, err
 	}
 
-	_, err = conn.ExecContext(ctx, "START TRANSACTION;")
+	_, err := conn.ExecContext(ctx, "START TRANSACTION;")
 	if err != nil {
 		_ = conn.Close()
 		return nil, fmt.Errorf("uow: failed to start transaction: %w", err)

--- a/internal/storage/uow/errors.go
+++ b/internal/storage/uow/errors.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"io"
 	"net"
+	"strings"
 	"syscall"
 
 	mysql "github.com/go-sql-driver/mysql"
@@ -45,4 +46,18 @@ func isRetryableWarmupError(err error) bool {
 		errors.Is(err, io.EOF) ||
 		errors.Is(err, syscall.ECONNREFUSED) ||
 		errors.Is(err, syscall.ECONNRESET)
+}
+
+// isInvalidConnectionError returns true if the error is a transient MySQL
+// driver connection failure. The transaction was either rolled back or never
+// started, so the entire sequence is safe to replay.
+func isInvalidConnectionError(err error) bool {
+	if err == nil {
+		return false
+	}
+	s := strings.ToLower(err.Error())
+	return strings.Contains(s, "invalid connection") ||
+		strings.Contains(s, "driver: bad connection") ||
+		strings.Contains(s, "lost connection") ||
+		strings.Contains(s, "broken pipe")
 }

--- a/internal/storage/uow/errors_test.go
+++ b/internal/storage/uow/errors_test.go
@@ -43,3 +43,29 @@ func TestIsRetryableWarmupError(t *testing.T) {
 		assert.False(t, isRetryableWarmupError(err), "%s must be permanent: %v", name, err)
 	}
 }
+
+func TestIsInvalidConnectionError(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{name: "nil", err: nil, expected: false},
+		{name: "invalid connection", err: errors.New("invalid connection"), expected: true},
+		{name: "driver: bad connection", err: errors.New("driver: bad connection"), expected: true},
+		{name: "lost connection", err: errors.New("Error 2013: Lost connection to MySQL server"), expected: true},
+		{name: "broken pipe", err: errors.New("write: broken pipe"), expected: true},
+		{name: "case insensitive", err: errors.New("Invalid Connection"), expected: true},
+		{name: "syntax error - not retryable", err: errors.New("Error 1064: syntax error"), expected: false},
+		{name: "table not found - not retryable", err: errors.New("Error 1146: Table not found"), expected: false},
+		{name: "deadlock - not covered here", err: errors.New("Error 1213: Deadlock found"), expected: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isInvalidConnectionError(tt.err)
+			if got != tt.expected {
+				t.Errorf("isInvalidConnectionError(%v) = %v, want %v", tt.err, got, tt.expected)
+			}
+		})
+	}
+}

--- a/internal/storage/uow/run_in_tx.go
+++ b/internal/storage/uow/run_in_tx.go
@@ -1,0 +1,95 @@
+package uow
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/cenkalti/backoff/v4"
+)
+
+const defaultRunInTxMaxElapsed = 15 * time.Second
+
+// RunInTx opens a UnitOfWork, calls fn, and commits. The entire sequence is
+// retried on transient serialization (1213/1205) and connection errors up to
+// MaxElapsedTime. fn must be idempotent within a single transaction; the commit
+// step is safe to replay because DOLT_COMMIT returns "nothing to commit" if a
+// prior attempt already committed.
+func RunInTx(ctx context.Context, p UnitOfWorkProvider, commitMsg string, fn func(uw UnitOfWork) error) error {
+	bo := backoff.NewExponentialBackOff()
+	bo.InitialInterval = 25 * time.Millisecond
+	bo.MaxElapsedTime = defaultRunInTxMaxElapsed
+
+	return backoff.Retry(func() error {
+		uw, err := p.NewUOW(ctx)
+		if err != nil {
+			if isSerializationError(err) || isInvalidConnectionError(err) {
+				return err // retry
+			}
+			return backoff.Permanent(err)
+		}
+		defer uw.Close(ctx)
+
+		if err := fn(uw); err != nil {
+			return backoff.Permanent(err) // domain errors are not retryable
+		}
+
+		err = uw.Commit(ctx, commitMsg)
+		if isSerializationError(err) || isInvalidConnectionError(err) {
+			return err // retry the whole tx
+		}
+		if isNothingToCommit(err) {
+			return nil // idempotent success
+		}
+		if err != nil {
+			return backoff.Permanent(err)
+		}
+		return nil
+	}, backoff.WithContext(bo, ctx))
+}
+
+// RunInTxMsg is like RunInTx but fn returns the commit message together with
+// any error, allowing callers whose message depends on the domain result to
+// compute it inside the same retry-safe closure.
+func RunInTxMsg(ctx context.Context, p UnitOfWorkProvider, fn func(uw UnitOfWork) (string, error)) error {
+	bo := backoff.NewExponentialBackOff()
+	bo.InitialInterval = 25 * time.Millisecond
+	bo.MaxElapsedTime = defaultRunInTxMaxElapsed
+
+	return backoff.Retry(func() error {
+		uw, err := p.NewUOW(ctx)
+		if err != nil {
+			if isSerializationError(err) || isInvalidConnectionError(err) {
+				return err
+			}
+			return backoff.Permanent(err)
+		}
+		defer uw.Close(ctx)
+
+		msg, err := fn(uw)
+		if err != nil {
+			return backoff.Permanent(err)
+		}
+
+		err = uw.Commit(ctx, msg)
+		if isSerializationError(err) || isInvalidConnectionError(err) {
+			return err
+		}
+		if isNothingToCommit(err) {
+			return nil
+		}
+		if err != nil {
+			return backoff.Permanent(err)
+		}
+		return nil
+	}, backoff.WithContext(bo, ctx))
+}
+
+func isNothingToCommit(err error) bool {
+	if err == nil {
+		return false
+	}
+	s := strings.ToLower(err.Error())
+	return strings.Contains(s, "nothing to commit") ||
+		(strings.Contains(s, "no changes") && strings.Contains(s, "commit"))
+}

--- a/internal/storage/uow/run_in_tx_test.go
+++ b/internal/storage/uow/run_in_tx_test.go
@@ -1,0 +1,146 @@
+package uow
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	mysql "github.com/go-sql-driver/mysql"
+	"github.com/steveyegge/beads/internal/storage/domain"
+)
+
+// stubUOW implements UnitOfWork for testing. Only Commit and Close are used;
+// all use-case accessors panic if called (they shouldn't be in these tests).
+type stubUOW struct {
+	commitErr error
+	closed    bool
+}
+
+func (u *stubUOW) Close(_ context.Context)                               { u.closed = true }
+func (u *stubUOW) Commit(_ context.Context, _ string) error              { return u.commitErr }
+func (u *stubUOW) ConfigUseCase() domain.ConfigUseCase                   { panic("not implemented") }
+func (u *stubUOW) DoltRemoteUseCase() domain.DoltRemoteUseCase           { panic("not implemented") }
+func (u *stubUOW) BootstrapUseCase() domain.BootstrapUseCase             { panic("not implemented") }
+func (u *stubUOW) IssueUseCase() domain.IssueUseCase                    { panic("not implemented") }
+func (u *stubUOW) DependencyUseCase() domain.DependencyUseCase           { panic("not implemented") }
+func (u *stubUOW) LabelUseCase() domain.LabelUseCase                    { panic("not implemented") }
+func (u *stubUOW) CommentUseCase() domain.CommentUseCase                 { panic("not implemented") }
+
+// controlledProvider lets tests inject errors per-attempt.
+type controlledProvider struct {
+	attempts   int
+	newUOWErrs []error // per-attempt NewUOW error (nil = success)
+	commitErrs []error // per-attempt Commit error (nil = success)
+}
+
+func (p *controlledProvider) Close(_ context.Context) error { return nil }
+
+func (p *controlledProvider) NewUOW(_ context.Context) (UnitOfWork, error) {
+	i := p.attempts
+	p.attempts++
+	var newErr error
+	if i < len(p.newUOWErrs) {
+		newErr = p.newUOWErrs[i]
+	}
+	if newErr != nil {
+		return nil, newErr
+	}
+	var commitErr error
+	if i < len(p.commitErrs) {
+		commitErr = p.commitErrs[i]
+	}
+	return &stubUOW{commitErr: commitErr}, nil
+}
+
+func TestRunInTx_Success(t *testing.T) {
+	p := &controlledProvider{}
+	err := RunInTx(context.Background(), p, "test", func(_ UnitOfWork) error {
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if p.attempts != 1 {
+		t.Errorf("expected 1 attempt, got %d", p.attempts)
+	}
+}
+
+func TestRunInTx_RetryOnSerializationError(t *testing.T) {
+	deadlock := &mysql.MySQLError{Number: 1213, Message: "Deadlock found when trying to get lock"}
+	p := &controlledProvider{commitErrs: []error{deadlock, nil}}
+	err := RunInTx(context.Background(), p, "test", func(_ UnitOfWork) error {
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if p.attempts != 2 {
+		t.Errorf("expected 2 attempts (1 retry), got %d", p.attempts)
+	}
+}
+
+func TestRunInTx_RetryOnConnectionError(t *testing.T) {
+	p := &controlledProvider{commitErrs: []error{errors.New("invalid connection"), nil}}
+	err := RunInTx(context.Background(), p, "test", func(_ UnitOfWork) error {
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if p.attempts != 2 {
+		t.Errorf("expected 2 attempts (1 retry), got %d", p.attempts)
+	}
+}
+
+func TestRunInTx_RetryOnNewUOWConnectionError(t *testing.T) {
+	p := &controlledProvider{newUOWErrs: []error{errors.New("driver: bad connection"), nil}}
+	err := RunInTx(context.Background(), p, "test", func(_ UnitOfWork) error {
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if p.attempts != 2 {
+		t.Errorf("expected 2 attempts (1 retry), got %d", p.attempts)
+	}
+}
+
+func TestRunInTx_NoDomainErrorRetry(t *testing.T) {
+	domainErr := errors.New("ErrAlreadyClaimed")
+	fnCalls := 0
+	p := &controlledProvider{}
+	err := RunInTx(context.Background(), p, "test", func(_ UnitOfWork) error {
+		fnCalls++
+		return domainErr
+	})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if fnCalls != 1 {
+		t.Errorf("domain error must not be retried: fn called %d times", fnCalls)
+	}
+}
+
+func TestRunInTx_NothingToCommitIsSuccess(t *testing.T) {
+	p := &controlledProvider{commitErrs: []error{errors.New("nothing to commit")}}
+	err := RunInTx(context.Background(), p, "test", func(_ UnitOfWork) error {
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("nothing-to-commit should be treated as success, got: %v", err)
+	}
+}
+
+func TestRunInTxMsg_RetryOnConnectionError(t *testing.T) {
+	p := &controlledProvider{commitErrs: []error{errors.New("invalid connection"), nil}}
+	err := RunInTxMsg(context.Background(), p, func(_ UnitOfWork) (string, error) {
+		return "test commit", nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if p.attempts != 2 {
+		t.Errorf("expected 2 attempts, got %d", p.attempts)
+	}
+}
+


### PR DESCRIPTION
Closes #4354

## What changes

Fixes ~50% silent write loss under 20+ concurrent writers to a shared-server Dolt store (`proxied=false`). Two error classes — MySQL 1213 (`ER_LOCK_DEADLOCK`) and `"invalid connection"` — were swallowed without retry, leaving beads in stale state.

### Changes

**`internal/storage/uow/errors.go`**
- `isInvalidConnectionError` helper (invalid connection, bad connection, lost connection, broken pipe)

**`internal/storage/uow/run_in_tx.go`** (new)
- `RunInTx` / `RunInTxMsg` — replay the full `NewUOW → fn → Commit` cycle on transient errors
- Domain errors are `backoff.Permanent`; `"nothing to commit"` is idempotent success
- Package-level function (not interface method) — no breaking change to mocks

**`internal/storage/dolt/store.go`**
- `withRetryTx`: extend retry predicate from `isSerializationError`-only to `isSerializationError || isRetryableError` (one line; consistent with `withRetry`)
- `bd.write_retries_total` counter with `type=serialization|connection` label

**`internal/storage/uow/dolt_sql_provider.go`**
- `BeginTx`: wrap `db.Conn` acquisition in 3-attempt backoff (mirrors `initSchema`)

**`cmd/bd/create_proxied_server.go`** + **`cmd/bd/init_proxied_server.go`**
- Migrate UoW write paths to `RunInTx` / `RunInTxMsg`

## Tests

- `uow/errors_test.go` — `isInvalidConnectionError` table test
- `uow/run_in_tx_test.go` — `RunInTx` retries on 1213 and `"invalid connection"`, does NOT retry on domain errors, treats `"nothing to commit"` as success

## No breaking changes

- No schema changes
- No new external dependencies (`cenkalti/backoff/v4` already imported)
- `UnitOfWorkProvider` interface unchanged
- Config-key tuning (`dolt.write-retry-max-elapsed`) deferred to follow-up

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/storage/uow/...` — all pass
- [ ] Load test: 20 concurrent `bd update --claim` → 0 silent failures (requires dolt-server env)