### PR TITLE
docs(metadata): document portability of execution model/effort hints

### DIFF
--- a/docs/METADATA.md
+++ b/docs/METADATA.md
@@ -33,14 +33,22 @@ These keys are advisory metadata, not core issue fields. When a workflow uses
 them, they take precedence over free-form notes for execution routing. Notes
 remain useful for rationale, ownership, and exact prompts.
 
+Model and effort values are portable hints, not runtime bindings. The
+`execution_reasoning_effort` values above are a canonical advisory scale:
+writers should store canonical values rather than runtime-local ones, and a
+consumer whose runtime uses a different scale should map the stored value to
+its nearest native level instead of dropping the hint. Likewise,
+`execution_suggested_model` is a capability-tier suggestion: a consumer on a
+different provider should substitute a model of the same tier rather than
+ignore the hint.
+
 Parent/orchestrator agents must consume these keys before spawning subagents.
 Model and reasoning effort are normally fixed at launch, so reading metadata
 after delegation is too late.
 
 Do not add a first-class helper such as `bd show <id> --execution` or
-`bd plan <id> --json` yet. Keep using the JSON/JQ snippet until upstream
-issue gh-3541 determines whether schedulers or runners need these fields as a
-stable CLI surface.
+`bd plan <id> --json`. Issue gh-3541 resolved to keep execution hints as
+metadata only; the JSON/JQ snippet remains the supported access path.
 
 ## Example: Tracker Round-Trip Metadata
 


### PR DESCRIPTION
## What

Two small wording changes to `docs/METADATA.md`, in the agent execution metadata section:

- Document the portability rule for `execution_reasoning_effort` and `execution_suggested_model`: stored effort values are a canonical advisory scale that consumers map to their runtime's nearest native level, and suggested models are capability-tier hints that consumers on a different provider substitute with a same-tier model rather than drop.
- Update the gh-3541 reference from "open question" phrasing to its resolution: execution hints stay metadata-only, with the JSON/JQ snippet as the supported access path.

## Why

Agent runtimes disagree on effort vocabularies and model names. The doc currently exemplifies one runtime's effort scale (`low`/`medium`/`high`/`xhigh`) without saying what a consumer on a runtime with a different scale should do, and `execution_suggested_model` does not say whether a model value binds a consumer on another provider. In cross-runtime use (one agent writes the hint, a different runtime's agent consumes it), that ambiguity makes the hints either silently dropped or wrongly treated as hard pins.

The fix is deliberately a rule, not a table: no model names and no per-vendor scale mappings are added, because those age with every model release. The rule (canonical scale, consumer maps; tier suggestion, consumer substitutes) stays correct as runtimes evolve.

This follows the project charter's metadata-before-schema boundary - it only clarifies semantics of the existing advisory keys, no schema or CLI changes.

## Collision check

`scripts/pr-preflight.sh --search "execution metadata reasoning effort model"` found no open PRs on this topic. This PR shares no files with #4237 (agent maintainer conventions) and is independent of it. #3541 is the issue that originated these keys; it closed 2026-06-03 with the metadata-only resolution this PR now reflects.

_claude-fable-5-high on behalf of matt wilkie_
