### PR TITLE
fix(lint): exclude fmt.Fprint from errcheck like its Fprintf/Fprintln siblings

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -30,8 +30,10 @@ linters:
         - (os).Chdir
         - (os).MkdirAll
         - (fmt).Sscanf
+        - (fmt).Fprint
         - (fmt).Fprintf
         - (fmt).Fprintln
+        - fmt.Fprint
         - fmt.Fprintf
         - fmt.Fprintln
     misspell:


### PR DESCRIPTION
## Why

`main` CI has been red for the last three pushes, and every open PR inherits the failure (we hit it live on #4359): golangci-lint fails with

```
cmd/bd/bootstrap.go:694:12: Error return value of `fmt.Fprint` is not checked (errcheck)
```

That line landed in f483ac2b4 (the bd-6dnrw.31 bootstrap guidance change) and is the repo's first bare `fmt.Fprint` call. `.golangci.yml` already excludes `fmt.Fprintf` and `fmt.Fprintln` from errcheck because CLI print errors are noise; `fmt.Fprint` is the same family and its omission from the list was accidental, not a policy choice.

## What

Add `(fmt).Fprint` and `fmt.Fprint` to the errcheck `exclude-functions` list, matching the spelling pairs of the existing entries. Config-level fix rather than a call-site `_, _ =` so the next bare `Fprint` doesn't re-break CI.

## Verification

Ran the exact CI toolchain locally: `golangci-lint v2.12.2` with `--build-tags=gms_pure_go` on `./cmd/bd/` reports `0 issues` after the change (it reproduces the failure before it, same as the [failing main runs](https://github.com/gastownhall/beads/actions/runs/27291801983/job/80614031391)).

This unblocks the Lint, Build Artifacts, PR Lint wrapper, and CI Gate checks on all open PRs.

_claude-unknown-model-high on behalf of matt wilkie_
