### PR TITLE
Fix rig bead durability

### DIFF
--- a/cmd/bd/count.go
+++ b/cmd/bd/count.go
@@ -283,7 +283,7 @@ Examples:
 //     --include-templates);
 //   - gate beads are excluded unless gates are explicitly requested via
 //     --type gate (list's default without --include-gates);
-//   - counting an infra type (agent/rig/role/message, or the store-configured
+//   - counting an infra type (agent/role/message, or the store-configured
 //     set) routes to the ephemeral wisps tier, like list's infra-type listing.
 //
 // The non-flag path never calls this function: bd count without

--- a/cmd/bd/export.go
+++ b/cmd/bd/export.go
@@ -30,7 +30,7 @@ For supported full backup/restore flows, use 'bd backup init', 'bd backup sync',
 and 'bd backup restore'.
 
 By default, exports only regular issues (excluding infrastructure beads
-like agents, rigs, roles, and messages). Use --all to include everything.
+like agents, roles, and messages). Use --all to include everything.
 
 Memories (from 'bd remember') are excluded by default because they may
 contain sensitive agent context. Use --include-memories or --all to
@@ -92,7 +92,7 @@ func runExport(cmd *cobra.Command, args []string) error {
 	// Build filter for issues table. Export all statuses by default.
 	filter := types.IssueFilter{Limit: 0}
 
-	// Exclude infra types by default (agents, rigs, roles, messages)
+	// Exclude infra types by default (agents, roles, messages).
 	if !exportAll && !exportIncludeInfra {
 		var infraTypes []string
 		if store != nil {

--- a/cmd/bd/export.go
+++ b/cmd/bd/export.go
@@ -58,7 +58,7 @@ var (
 func init() {
 	exportCmd.Flags().StringVarP(&exportOutput, "output", "o", "", "Output file path (default: stdout)")
 	exportCmd.Flags().BoolVar(&exportAll, "all", false, "Include all records (infra, templates, gates, memories)")
-	exportCmd.Flags().BoolVar(&exportIncludeInfra, "include-infra", false, "Include infrastructure beads (agents, rigs, roles, messages)")
+	exportCmd.Flags().BoolVar(&exportIncludeInfra, "include-infra", false, "Include infrastructure beads (agents, roles, messages)")
 	exportCmd.Flags().BoolVar(&exportScrub, "scrub", false, "Exclude test/pollution records")
 	exportCmd.Flags().BoolVar(&exportIncludeMemories, "include-memories", false, "Include persistent memories (from 'bd remember') in the export")
 	exportCmd.Flags().BoolVar(&exportNoMemories, "no-memories", false, "Exclude persistent memories (deprecated: now the default)")

--- a/cmd/bd/list.go
+++ b/cmd/bd/list.go
@@ -723,8 +723,8 @@ func init() {
 	// Gate filtering: exclude gate issues by default (bd-7zka.2)
 	listCmd.Flags().Bool("include-gates", false, "Include gate issues in output (normally hidden)")
 
-	// Infra type filtering: exclude agent/rig/role/message by default
-	listCmd.Flags().Bool("include-infra", false, "Include infrastructure beads (agent/rig/role/message) in output")
+	// Infra type filtering: exclude agent/role/message by default
+	listCmd.Flags().Bool("include-infra", false, "Include infrastructure beads (agent/role/message) in output")
 
 	// Explicit type exclusion
 	listCmd.Flags().StringSlice("exclude-type", nil, "Exclude issue types from results (comma-separated or repeatable, e.g., --exclude-type=convoy,epic)")

--- a/cmd/bd/wisp.go
+++ b/cmd/bd/wisp.go
@@ -750,7 +750,7 @@ func runWispPurgeClosed(ctx context.Context, dryRun bool, force bool, excludeTyp
 		fmt.Printf("Skipping %d pinned issue(s) (protected from cleanup)\n", pinnedCount)
 	}
 	if infraCount > 0 && !jsonOutput {
-		fmt.Printf("Skipping %d infra issue(s) (agent/rig/role/message - protected from GC)\n", infraCount)
+		fmt.Printf("Skipping %d configured infra issue(s) protected from GC\n", infraCount)
 	}
 
 	if len(closedIssues) == 0 {

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -910,7 +910,7 @@ bd list [flags]
       --has-metadata-key string      Filter issues that have this metadata key set
       --id string                    Filter by specific issue IDs (comma-separated, e.g., bd-1,bd-5,bd-10)
       --include-gates                Include gate issues in output (normally hidden)
-      --include-infra                Include infrastructure beads (agent/rig/role/message) in output
+      --include-infra                Include infrastructure beads (agent/role/message) in output
       --include-templates            Include template molecules in output
   -l, --label strings                Filter by labels (AND: must have ALL). Can combine with --label-any
       --label-any strings            Filter by labels (OR: must have AT LEAST ONE). Can combine with --label
@@ -2375,7 +2375,7 @@ bd export [flags]
 
 ```
       --all                Include all records (infra, templates, gates, memories)
-      --include-infra      Include infrastructure beads (agents, rigs, roles, messages)
+      --include-infra      Include infrastructure beads (agents, roles, messages)
       --include-memories   Include persistent memories (from 'bd remember') in the export
   -o, --output string      Output file path (default: stdout)
       --scrub              Exclude test/pollution records

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -2354,7 +2354,7 @@ For supported full backup/restore flows, use 'bd backup init', 'bd backup sync',
 and 'bd backup restore'.
 
 By default, exports only regular issues (excluding infrastructure beads
-like agents, rigs, roles, and messages). Use --all to include everything.
+like agents, roles, and messages). Use --all to include everything.
 
 Memories (from 'bd remember') are excluded by default because they may
 contain sensitive agent context. Use --include-memories or --all to

--- a/internal/storage/dolt/config.go
+++ b/internal/storage/dolt/config.go
@@ -186,7 +186,7 @@ func (s *DoltStore) GetCustomTypes(ctx context.Context) ([]string, error) {
 
 // GetInfraTypes returns infrastructure type names from config.
 // Infrastructure types are routed to the wisps table to keep the versioned
-// issues table clean. Defaults to ["agent", "rig", "role", "message"] if
+// issues table clean. Defaults to ["agent", "role", "message"] if
 // no custom configuration exists.
 // Falls back: DB config "types.infra" → config.yaml types.infra → defaults.
 // Results are cached per DoltStore lifetime and invalidated when SetConfig

--- a/internal/storage/dolt/queries_test.go
+++ b/internal/storage/dolt/queries_test.go
@@ -30,6 +30,62 @@ func TestGetReadyWork_EmptyStore(t *testing.T) {
 	}
 }
 
+func TestRigIssueIsPersistentButHiddenFromReady(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	rig := &types.Issue{
+		ID:        "rw-rig-durable",
+		Title:     "Rig identity",
+		Status:    types.StatusOpen,
+		Priority:  1,
+		IssueType: types.IssueType("rig"),
+	}
+	if err := store.CreateIssue(ctx, rig, "tester"); err != nil {
+		t.Fatalf("CreateIssue rig: %v", err)
+	}
+	if rig.Ephemeral {
+		t.Fatal("CreateIssue marked type=rig as ephemeral")
+	}
+
+	got, err := store.GetIssue(ctx, rig.ID)
+	if err != nil {
+		t.Fatalf("GetIssue rig: %v", err)
+	}
+	if got.Ephemeral {
+		t.Fatal("stored type=rig issue is ephemeral")
+	}
+
+	var issueRows int
+	if err := store.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM issues WHERE id = ?", rig.ID).Scan(&issueRows); err != nil {
+		t.Fatalf("count rig issue rows: %v", err)
+	}
+	if issueRows != 1 {
+		t.Fatalf("type=rig rows in issues = %d, want 1", issueRows)
+	}
+
+	var wispRows int
+	if err := store.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM wisps WHERE id = ?", rig.ID).Scan(&wispRows); err != nil {
+		t.Fatalf("count rig wisp rows: %v", err)
+	}
+	if wispRows != 0 {
+		t.Fatalf("type=rig rows in wisps = %d, want 0", wispRows)
+	}
+
+	work, err := store.GetReadyWork(ctx, types.WorkFilter{})
+	if err != nil {
+		t.Fatalf("GetReadyWork: %v", err)
+	}
+	for _, item := range work {
+		if item.ID == rig.ID {
+			t.Fatalf("type=rig issue appeared in ready work: %v", issueIDs(work))
+		}
+	}
+}
+
 func TestGetReadyWork_ExcludesClosedIssues(t *testing.T) {
 	store, cleanup := setupTestStore(t)
 	defer cleanup()

--- a/internal/storage/dolt/schema_version_test.go
+++ b/internal/storage/dolt/schema_version_test.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 
+	"github.com/steveyegge/beads/internal/storage/depid"
 	"github.com/steveyegge/beads/internal/storage/schema"
 )
 
@@ -89,6 +91,124 @@ func TestSchemaRunsInitWhenStale(t *testing.T) {
 	if maxVersion != schema.LatestVersion() {
 		t.Errorf("max migration version = %d after re-init, want %d", maxVersion, schema.LatestVersion())
 	}
+}
+
+func TestMigration0053PromotesRigWisps(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	const rigID = "schema-rig-wisp"
+	const targetID = "schema-rig-target"
+	const sourceID = "schema-rig-source"
+
+	for _, id := range []string{targetID, sourceID} {
+		if _, err := store.db.ExecContext(ctx, `
+			INSERT INTO issues (id, title, description, design, acceptance_criteria, notes, status, priority, issue_type)
+			VALUES (?, ?, '', '', '', '', 'open', 2, 'task')
+		`, id, id); err != nil {
+			t.Fatalf("seed issue %s: %v", id, err)
+		}
+	}
+	if _, err := store.db.ExecContext(ctx, `
+		INSERT INTO wisps (id, title, description, design, acceptance_criteria, notes, status, priority, issue_type, ephemeral)
+		VALUES (?, 'Rig identity', '', '', '', '', 'open', 1, 'rig', 1)
+	`, rigID); err != nil {
+		t.Fatalf("seed rig wisp: %v", err)
+	}
+	if _, err := store.db.ExecContext(ctx,
+		`INSERT INTO wisp_labels (issue_id, label) VALUES (?, 'gt:rig')`, rigID); err != nil {
+		t.Fatalf("seed wisp label: %v", err)
+	}
+	if _, err := store.db.ExecContext(ctx, `
+		INSERT INTO wisp_dependencies (id, issue_id, depends_on_issue_id, type, created_at, created_by, metadata)
+		VALUES (?, ?, ?, 'blocks', NOW(), 'tester', JSON_OBJECT())
+	`, depid.New(rigID, targetID), rigID, targetID); err != nil {
+		t.Fatalf("seed outgoing wisp dependency: %v", err)
+	}
+	if _, err := store.db.ExecContext(ctx, `
+		INSERT INTO dependencies (id, issue_id, depends_on_wisp_id, type, created_at, created_by, metadata)
+		VALUES (?, ?, ?, 'blocks', NOW(), 'tester', JSON_OBJECT())
+	`, depid.New(sourceID, rigID), sourceID, rigID); err != nil {
+		t.Fatalf("seed inbound dependency: %v", err)
+	}
+	if _, err := store.db.ExecContext(ctx, `
+		INSERT INTO wisp_events (id, issue_id, event_type, actor, created_at)
+		VALUES ('schema-rig-event', ?, 'created', 'tester', NOW())
+	`, rigID); err != nil {
+		t.Fatalf("seed wisp event: %v", err)
+	}
+	if _, err := store.db.ExecContext(ctx, `
+		INSERT INTO wisp_comments (id, issue_id, author, text, created_at)
+		VALUES ('schema-rig-comment', ?, 'tester', 'durable identity', NOW())
+	`, rigID); err != nil {
+		t.Fatalf("seed wisp comment: %v", err)
+	}
+	if _, err := store.db.ExecContext(ctx,
+		`INSERT INTO wisp_child_counters (parent_id, last_child) VALUES (?, 7)`, rigID); err != nil {
+		t.Fatalf("seed wisp child counter: %v", err)
+	}
+	if _, err := store.db.ExecContext(ctx, "CALL DOLT_ADD('issues')"); err != nil {
+		t.Fatalf("stage seeded issues: %v", err)
+	}
+	if _, err := store.db.ExecContext(ctx, "CALL DOLT_ADD('dependencies')"); err != nil {
+		t.Fatalf("stage seeded dependencies: %v", err)
+	}
+	if _, err := store.db.ExecContext(ctx, "CALL DOLT_COMMIT('-m', 'seed rig repair fixture')"); err != nil &&
+		!strings.Contains(strings.ToLower(err.Error()), "nothing to commit") {
+		t.Fatalf("commit seed fixture: %v", err)
+	}
+
+	if _, err := store.db.ExecContext(ctx, "DELETE FROM schema_migrations WHERE version = ?", schema.LatestVersion()); err != nil {
+		t.Fatalf("mark 0053 pending: %v", err)
+	}
+	if _, err := schema.MigrateUp(ctx, store.db); err != nil {
+		t.Fatalf("MigrateUp: %v", err)
+	}
+
+	var issueRows, wispRows int
+	if err := store.db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM issues WHERE id = ? AND issue_type = 'rig' AND ephemeral = 0`, rigID).Scan(&issueRows); err != nil {
+		t.Fatalf("count promoted rig issue: %v", err)
+	}
+	if issueRows != 1 {
+		t.Fatalf("promoted rig issue rows = %d, want 1", issueRows)
+	}
+	if err := store.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM wisps WHERE id = ?`, rigID).Scan(&wispRows); err != nil {
+		t.Fatalf("count remaining rig wisp: %v", err)
+	}
+	if wispRows != 0 {
+		t.Fatalf("remaining rig wisp rows = %d, want 0", wispRows)
+	}
+
+	assertCount := func(name, query string, want int, args ...any) {
+		t.Helper()
+		var got int
+		if err := store.db.QueryRowContext(ctx, query, args...).Scan(&got); err != nil {
+			t.Fatalf("%s: %v", name, err)
+		}
+		if got != want {
+			t.Fatalf("%s = %d, want %d", name, got, want)
+		}
+	}
+	assertCount("promoted labels",
+		`SELECT COUNT(*) FROM labels WHERE issue_id = ? AND label = 'gt:rig'`, 1, rigID)
+	assertCount("promoted outgoing dependencies",
+		`SELECT COUNT(*) FROM dependencies WHERE issue_id = ? AND depends_on_issue_id = ?`, 1, rigID, targetID)
+	assertCount("retargeted inbound dependencies",
+		`SELECT COUNT(*) FROM dependencies WHERE issue_id = ? AND depends_on_issue_id = ? AND depends_on_wisp_id IS NULL`, 1, sourceID, rigID)
+	assertCount("promoted events",
+		`SELECT COUNT(*) FROM events WHERE issue_id = ?`, 1, rigID)
+	assertCount("promoted comments",
+		`SELECT COUNT(*) FROM comments WHERE issue_id = ?`, 1, rigID)
+	assertCount("promoted child counter",
+		`SELECT COUNT(*) FROM child_counters WHERE parent_id = ? AND last_child = 7`, 1, rigID)
+	assertCount("remaining wisp child counter",
+		`SELECT COUNT(*) FROM wisp_child_counters WHERE parent_id = ?`, 0, rigID)
+	assertCount("remaining source wisp dependencies",
+		`SELECT COUNT(*) FROM wisp_dependencies WHERE issue_id = ?`, 0, rigID)
 }
 
 // TestSchemaRunsInitWhenMissing verifies that initSchemaOnDB runs

--- a/internal/storage/domain/db/ready_work_test.go
+++ b/internal/storage/domain/db/ready_work_test.go
@@ -105,6 +105,14 @@ func (s *testSuite) readyExcludesDefaultTypes() {
 	gate.IssueType = types.TypeGate
 	s.Require().NoError(r.Insert(s.Ctx(), gate, "tester", domain.InsertIssueOpts{}))
 
+	rig := newTestIssue("bd-rdy-dt-rig", "rig")
+	rig.IssueType = types.IssueType("rig")
+	s.Require().NoError(r.Insert(s.Ctx(), rig, "tester", domain.InsertIssueOpts{}))
+
+	message := newTestIssue("bd-rdy-dt-message", "message")
+	message.IssueType = types.TypeMessage
+	s.Require().NoError(r.Insert(s.Ctx(), message, "tester", domain.InsertIssueOpts{}))
+
 	task := newTestIssue("bd-rdy-dt-task", "task")
 	s.Require().NoError(r.Insert(s.Ctx(), task, "tester", domain.InsertIssueOpts{}))
 
@@ -114,6 +122,8 @@ func (s *testSuite) readyExcludesDefaultTypes() {
 	s.Contains(got, "bd-rdy-dt-task")
 	s.NotContains(got, "bd-rdy-dt-mol")
 	s.NotContains(got, "bd-rdy-dt-gate")
+	s.NotContains(got, "bd-rdy-dt-rig")
+	s.NotContains(got, "bd-rdy-dt-message")
 }
 
 func (s *testSuite) readyFilterByPriority() {

--- a/internal/storage/domain/infra_types.go
+++ b/internal/storage/domain/infra_types.go
@@ -2,7 +2,7 @@ package domain
 
 import "github.com/steveyegge/beads/internal/types"
 
-var defaultInfraTypes = []string{"agent", "rig", "role", "message"}
+var defaultInfraTypes = []string{"agent", "role", "message"}
 
 var defaultInfraSet = func() map[string]bool {
 	m := make(map[string]bool, len(defaultInfraTypes))

--- a/internal/storage/domain/infra_types_test.go
+++ b/internal/storage/domain/infra_types_test.go
@@ -1,0 +1,31 @@
+package domain
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/types"
+)
+
+func TestDefaultInfraTypesExcludeRig(t *testing.T) {
+	got := DefaultInfraTypes()
+	want := []string{"agent", "role", "message"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("DefaultInfraTypes() = %v, want %v", got, want)
+	}
+	if IsInfraType(types.IssueType("rig")) {
+		t.Fatal("rig must be durable by default, not an infra/wisp-routed type")
+	}
+}
+
+func TestDefaultInfraTypesReturnsCopy(t *testing.T) {
+	got := DefaultInfraTypes()
+	got[0] = "mutated"
+
+	if IsInfraType(types.IssueType("mutated")) {
+		t.Fatal("mutating DefaultInfraTypes result changed infra classification")
+	}
+	if !IsInfraType(types.IssueType("agent")) {
+		t.Fatal("agent should remain an infra type")
+	}
+}

--- a/internal/storage/embeddeddolt/config_metadata.go
+++ b/internal/storage/embeddeddolt/config_metadata.go
@@ -87,7 +87,7 @@ func (s *EmbeddedDoltStore) GetLocalMetadata(ctx context.Context, key string) (s
 
 // GetInfraTypes returns the set of infrastructure types that should be routed
 // to the wisps table. Reads from DB config "types.infra", falls back to YAML,
-// then to hardcoded defaults (agent, rig, role, message).
+// then to hardcoded defaults (agent, role, message).
 func (s *EmbeddedDoltStore) GetInfraTypes(ctx context.Context) map[string]bool {
 	var result map[string]bool
 	if err := s.withConn(ctx, false, func(tx *sql.Tx) error {

--- a/internal/storage/schema/cli_migrations.go
+++ b/internal/storage/schema/cli_migrations.go
@@ -43,6 +43,12 @@ func cliCompatibleMigrationSQL(name, sqlText string) string {
 		// re-run safety on upgraded databases; a fresh bundle always has the
 		// 0004/0005/0009/0010 defaults to drop.
 		return cliMigration0051DropAuxIDDefaults
+	case "0053_repair_rig_wisps.up.sql":
+		// The source migration uses PREPARE guards so older upgraded
+		// workspaces without local wisp tables can no-op safely. Fresh CLI
+		// bundles already have the base wisp tables, and the Dolt CLI test
+		// path needs direct DML for deterministic fixture repair.
+		return cliMigration0053RepairRigWisps
 	default:
 		return sqlText
 	}
@@ -124,3 +130,137 @@ const cliMigration0051DropAuxIDDefaults = `ALTER TABLE events ALTER COLUMN id DR
 ALTER TABLE comments ALTER COLUMN id DROP DEFAULT;
 ALTER TABLE issue_snapshots ALTER COLUMN id DROP DEFAULT;
 ALTER TABLE compaction_snapshots ALTER COLUMN id DROP DEFAULT;`
+
+const cliMigration0053RepairRigWisps = `SET FOREIGN_KEY_CHECKS = 0;
+
+INSERT IGNORE INTO issues (
+    id, content_hash, title, description, design, acceptance_criteria, notes,
+    status, priority, issue_type, assignee, estimated_minutes, created_at,
+    created_by, owner, updated_at, closed_at, closed_by_session, external_ref,
+    spec_id, compaction_level, compacted_at, compacted_at_commit, original_size,
+    sender, ephemeral, wisp_type, pinned, is_template, mol_type, work_type,
+    source_system, metadata, source_repo, close_reason, event_kind, actor,
+    target, payload, await_type, await_id, timeout_ns, waiters, hook_bead,
+    role_bead, agent_state, last_activity, role_type, rig, due_at, defer_until,
+    no_history, started_at
+)
+SELECT
+    id, content_hash, title, description, design, acceptance_criteria, notes,
+    status, priority, issue_type, assignee, estimated_minutes, created_at,
+    created_by, owner, updated_at, closed_at, closed_by_session, external_ref,
+    spec_id, compaction_level, compacted_at, compacted_at_commit, original_size,
+    sender, ephemeral, wisp_type, pinned, is_template, mol_type, work_type,
+    source_system, metadata, source_repo, close_reason, event_kind, actor,
+    target, payload, await_type, await_id, timeout_ns, waiters, hook_bead,
+    role_bead, agent_state, last_activity, role_type, rig, due_at, defer_until,
+    no_history, started_at
+FROM wisps
+WHERE issue_type = 'rig';
+
+UPDATE issues
+SET ephemeral = 0
+WHERE issue_type = 'rig'
+  AND id IN (SELECT id FROM wisps WHERE issue_type = 'rig');
+
+INSERT IGNORE INTO labels (issue_id, label)
+SELECT wl.issue_id, wl.label
+FROM wisp_labels wl
+JOIN wisps w ON w.id = wl.issue_id
+WHERE w.issue_type = 'rig';
+
+INSERT IGNORE INTO dependencies (
+    id, issue_id, depends_on_issue_id, depends_on_wisp_id, depends_on_external,
+    type, created_at, created_by, metadata, thread_id
+)
+SELECT
+    CONCAT(
+        SUBSTR(MD5(CONCAT(wd.issue_id, CHAR(31), COALESCE(wd.depends_on_issue_id, wd.depends_on_wisp_id, wd.depends_on_external))), 1, 8),
+        '-',
+        SUBSTR(MD5(CONCAT(wd.issue_id, CHAR(31), COALESCE(wd.depends_on_issue_id, wd.depends_on_wisp_id, wd.depends_on_external))), 9, 4),
+        '-',
+        SUBSTR(MD5(CONCAT(wd.issue_id, CHAR(31), COALESCE(wd.depends_on_issue_id, wd.depends_on_wisp_id, wd.depends_on_external))), 13, 4),
+        '-',
+        SUBSTR(MD5(CONCAT(wd.issue_id, CHAR(31), COALESCE(wd.depends_on_issue_id, wd.depends_on_wisp_id, wd.depends_on_external))), 17, 4),
+        '-',
+        SUBSTR(MD5(CONCAT(wd.issue_id, CHAR(31), COALESCE(wd.depends_on_issue_id, wd.depends_on_wisp_id, wd.depends_on_external))), 21, 12)
+    ),
+    wd.issue_id, wd.depends_on_issue_id, wd.depends_on_wisp_id, wd.depends_on_external,
+    wd.type, wd.created_at, wd.created_by, wd.metadata, wd.thread_id
+FROM wisp_dependencies wd
+JOIN wisps w ON w.id = wd.issue_id
+WHERE w.issue_type = 'rig';
+
+INSERT IGNORE INTO events (id, issue_id, event_type, actor, old_value, new_value, comment, created_at)
+SELECT we.id, we.issue_id, we.event_type, we.actor, we.old_value, we.new_value, we.comment, we.created_at
+FROM wisp_events we
+JOIN wisps w ON w.id = we.issue_id
+WHERE w.issue_type = 'rig';
+
+INSERT IGNORE INTO comments (id, issue_id, author, text, created_at)
+SELECT wc.id, wc.issue_id, wc.author, wc.text, wc.created_at
+FROM wisp_comments wc
+JOIN wisps w ON w.id = wc.issue_id
+WHERE w.issue_type = 'rig';
+
+CREATE TABLE IF NOT EXISTS wisp_child_counters (
+    parent_id VARCHAR(255) PRIMARY KEY,
+    last_child INT NOT NULL DEFAULT 0
+);
+
+INSERT IGNORE INTO child_counters (parent_id, last_child)
+SELECT wcc.parent_id, wcc.last_child
+FROM wisp_child_counters wcc
+JOIN wisps w ON w.id = wcc.parent_id
+WHERE w.issue_type = 'rig';
+
+UPDATE child_counters cc
+JOIN wisp_child_counters wcc ON wcc.parent_id = cc.parent_id
+JOIN wisps w ON w.id = wcc.parent_id
+SET cc.last_child = GREATEST(cc.last_child, wcc.last_child)
+WHERE w.issue_type = 'rig';
+
+DELETE wd FROM wisp_dependencies wd
+JOIN wisps w ON w.id = wd.issue_id
+WHERE w.issue_type = 'rig';
+
+REPLACE INTO dependencies (
+    id, issue_id, depends_on_issue_id, depends_on_wisp_id, depends_on_external,
+    type, created_at, created_by, metadata, thread_id
+)
+SELECT
+    d.id, d.issue_id, d.depends_on_wisp_id, NULL, d.depends_on_external,
+    d.type, d.created_at, d.created_by, d.metadata, d.thread_id
+FROM dependencies d
+JOIN wisps w ON w.id = d.depends_on_wisp_id
+WHERE w.issue_type = 'rig';
+
+REPLACE INTO wisp_dependencies (
+    issue_id, depends_on_issue_id, depends_on_wisp_id, depends_on_external,
+    type, created_at, created_by, metadata, thread_id
+)
+SELECT
+    wd.issue_id, wd.depends_on_wisp_id, NULL, wd.depends_on_external,
+    wd.type, wd.created_at, wd.created_by, wd.metadata, wd.thread_id
+FROM wisp_dependencies wd
+JOIN wisps w ON w.id = wd.depends_on_wisp_id
+WHERE w.issue_type = 'rig';
+
+DELETE wl FROM wisp_labels wl
+JOIN wisps w ON w.id = wl.issue_id
+WHERE w.issue_type = 'rig';
+
+DELETE we FROM wisp_events we
+JOIN wisps w ON w.id = we.issue_id
+WHERE w.issue_type = 'rig';
+
+DELETE wc FROM wisp_comments wc
+JOIN wisps w ON w.id = wc.issue_id
+WHERE w.issue_type = 'rig';
+
+DELETE wcc FROM wisp_child_counters wcc
+JOIN wisps w ON w.id = wcc.parent_id
+WHERE w.issue_type = 'rig';
+
+DELETE FROM wisps WHERE issue_type = 'rig';
+
+SET FOREIGN_KEY_CHECKS = 1;`

--- a/internal/storage/schema/migrations/0035_migrate_infra_to_wisps.down.sql
+++ b/internal/storage/schema/migrations/0035_migrate_infra_to_wisps.down.sql
@@ -11,17 +11,17 @@ SET @shared_cols = (
 SET @sql = IF(@shared_cols IS NULL OR @shared_cols = '',
     'SELECT 1',
     CONCAT('INSERT IGNORE INTO issues (', @shared_cols, ') SELECT ', @shared_cols,
-           ' FROM wisps WHERE issue_type IN (''agent'', ''rig'', ''role'', ''message'')')
+           ' FROM wisps WHERE issue_type IN (''agent'', ''role'', ''message'')')
 );
 PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
 
 UPDATE issues SET ephemeral = 0
-WHERE issue_type IN ('agent', 'rig', 'role', 'message');
+WHERE issue_type IN ('agent', 'role', 'message');
 
 INSERT IGNORE INTO labels (issue_id, label)
 SELECT issue_id, label FROM wisp_labels wl
 WHERE EXISTS (SELECT 1 FROM issues i WHERE i.id = wl.issue_id
-              AND i.issue_type IN ('agent', 'rig', 'role', 'message'));
+              AND i.issue_type IN ('agent', 'role', 'message'));
 
 SET @has_split_wisp_dependencies = (
     SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
@@ -31,23 +31,23 @@ SET @has_split_wisp_dependencies = (
 );
 SET @sql = IF(
     @has_split_wisp_dependencies = 3,
-    'INSERT IGNORE INTO dependencies (issue_id, depends_on_id, type, created_at, created_by, metadata, thread_id) SELECT issue_id, COALESCE(depends_on_issue_id, depends_on_wisp_id, depends_on_external), type, created_at, created_by, metadata, thread_id FROM wisp_dependencies wd WHERE EXISTS (SELECT 1 FROM issues i WHERE i.id = wd.issue_id AND i.issue_type IN (''agent'', ''rig'', ''role'', ''message''))',
-    'INSERT IGNORE INTO dependencies (issue_id, depends_on_id, type, created_at, created_by, metadata, thread_id) SELECT issue_id, depends_on_id, type, created_at, created_by, metadata, thread_id FROM wisp_dependencies wd WHERE EXISTS (SELECT 1 FROM issues i WHERE i.id = wd.issue_id AND i.issue_type IN (''agent'', ''rig'', ''role'', ''message''))'
+    'INSERT IGNORE INTO dependencies (issue_id, depends_on_id, type, created_at, created_by, metadata, thread_id) SELECT issue_id, COALESCE(depends_on_issue_id, depends_on_wisp_id, depends_on_external), type, created_at, created_by, metadata, thread_id FROM wisp_dependencies wd WHERE EXISTS (SELECT 1 FROM issues i WHERE i.id = wd.issue_id AND i.issue_type IN (''agent'', ''role'', ''message''))',
+    'INSERT IGNORE INTO dependencies (issue_id, depends_on_id, type, created_at, created_by, metadata, thread_id) SELECT issue_id, depends_on_id, type, created_at, created_by, metadata, thread_id FROM wisp_dependencies wd WHERE EXISTS (SELECT 1 FROM issues i WHERE i.id = wd.issue_id AND i.issue_type IN (''agent'', ''role'', ''message''))'
 );
 PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
 
 INSERT IGNORE INTO events (id, issue_id, event_type, actor, old_value, new_value, comment, created_at)
 SELECT id, issue_id, event_type, actor, old_value, new_value, comment, created_at FROM wisp_events we
 WHERE EXISTS (SELECT 1 FROM issues i WHERE i.id = we.issue_id
-              AND i.issue_type IN ('agent', 'rig', 'role', 'message'));
+              AND i.issue_type IN ('agent', 'role', 'message'));
 
 INSERT IGNORE INTO comments (id, issue_id, author, text, created_at)
 SELECT id, issue_id, author, text, created_at FROM wisp_comments wc
 WHERE EXISTS (SELECT 1 FROM issues i WHERE i.id = wc.issue_id
-              AND i.issue_type IN ('agent', 'rig', 'role', 'message'));
+              AND i.issue_type IN ('agent', 'role', 'message'));
 
-DELETE FROM wisp_comments WHERE issue_id IN (SELECT id FROM issues WHERE issue_type IN ('agent', 'rig', 'role', 'message'));
-DELETE FROM wisp_events WHERE issue_id IN (SELECT id FROM issues WHERE issue_type IN ('agent', 'rig', 'role', 'message'));
-DELETE FROM wisp_dependencies WHERE issue_id IN (SELECT id FROM issues WHERE issue_type IN ('agent', 'rig', 'role', 'message'));
-DELETE FROM wisp_labels WHERE issue_id IN (SELECT id FROM issues WHERE issue_type IN ('agent', 'rig', 'role', 'message'));
-DELETE FROM wisps WHERE issue_type IN ('agent', 'rig', 'role', 'message');
+DELETE FROM wisp_comments WHERE issue_id IN (SELECT id FROM issues WHERE issue_type IN ('agent', 'role', 'message'));
+DELETE FROM wisp_events WHERE issue_id IN (SELECT id FROM issues WHERE issue_type IN ('agent', 'role', 'message'));
+DELETE FROM wisp_dependencies WHERE issue_id IN (SELECT id FROM issues WHERE issue_type IN ('agent', 'role', 'message'));
+DELETE FROM wisp_labels WHERE issue_id IN (SELECT id FROM issues WHERE issue_type IN ('agent', 'role', 'message'));
+DELETE FROM wisps WHERE issue_type IN ('agent', 'role', 'message');

--- a/internal/storage/schema/migrations/0035_migrate_infra_to_wisps.down.sql
+++ b/internal/storage/schema/migrations/0035_migrate_infra_to_wisps.down.sql
@@ -11,17 +11,17 @@ SET @shared_cols = (
 SET @sql = IF(@shared_cols IS NULL OR @shared_cols = '',
     'SELECT 1',
     CONCAT('INSERT IGNORE INTO issues (', @shared_cols, ') SELECT ', @shared_cols,
-           ' FROM wisps WHERE issue_type IN (''agent'', ''role'', ''message'')')
+           ' FROM wisps WHERE issue_type IN (''agent'', ''rig'', ''role'', ''message'')')
 );
 PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
 
 UPDATE issues SET ephemeral = 0
-WHERE issue_type IN ('agent', 'role', 'message');
+WHERE issue_type IN ('agent', 'rig', 'role', 'message');
 
 INSERT IGNORE INTO labels (issue_id, label)
 SELECT issue_id, label FROM wisp_labels wl
 WHERE EXISTS (SELECT 1 FROM issues i WHERE i.id = wl.issue_id
-              AND i.issue_type IN ('agent', 'role', 'message'));
+              AND i.issue_type IN ('agent', 'rig', 'role', 'message'));
 
 SET @has_split_wisp_dependencies = (
     SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
@@ -31,23 +31,23 @@ SET @has_split_wisp_dependencies = (
 );
 SET @sql = IF(
     @has_split_wisp_dependencies = 3,
-    'INSERT IGNORE INTO dependencies (issue_id, depends_on_id, type, created_at, created_by, metadata, thread_id) SELECT issue_id, COALESCE(depends_on_issue_id, depends_on_wisp_id, depends_on_external), type, created_at, created_by, metadata, thread_id FROM wisp_dependencies wd WHERE EXISTS (SELECT 1 FROM issues i WHERE i.id = wd.issue_id AND i.issue_type IN (''agent'', ''role'', ''message''))',
-    'INSERT IGNORE INTO dependencies (issue_id, depends_on_id, type, created_at, created_by, metadata, thread_id) SELECT issue_id, depends_on_id, type, created_at, created_by, metadata, thread_id FROM wisp_dependencies wd WHERE EXISTS (SELECT 1 FROM issues i WHERE i.id = wd.issue_id AND i.issue_type IN (''agent'', ''role'', ''message''))'
+    'INSERT IGNORE INTO dependencies (issue_id, depends_on_id, type, created_at, created_by, metadata, thread_id) SELECT issue_id, COALESCE(depends_on_issue_id, depends_on_wisp_id, depends_on_external), type, created_at, created_by, metadata, thread_id FROM wisp_dependencies wd WHERE EXISTS (SELECT 1 FROM issues i WHERE i.id = wd.issue_id AND i.issue_type IN (''agent'', ''rig'', ''role'', ''message''))',
+    'INSERT IGNORE INTO dependencies (issue_id, depends_on_id, type, created_at, created_by, metadata, thread_id) SELECT issue_id, depends_on_id, type, created_at, created_by, metadata, thread_id FROM wisp_dependencies wd WHERE EXISTS (SELECT 1 FROM issues i WHERE i.id = wd.issue_id AND i.issue_type IN (''agent'', ''rig'', ''role'', ''message''))'
 );
 PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
 
 INSERT IGNORE INTO events (id, issue_id, event_type, actor, old_value, new_value, comment, created_at)
 SELECT id, issue_id, event_type, actor, old_value, new_value, comment, created_at FROM wisp_events we
 WHERE EXISTS (SELECT 1 FROM issues i WHERE i.id = we.issue_id
-              AND i.issue_type IN ('agent', 'role', 'message'));
+              AND i.issue_type IN ('agent', 'rig', 'role', 'message'));
 
 INSERT IGNORE INTO comments (id, issue_id, author, text, created_at)
 SELECT id, issue_id, author, text, created_at FROM wisp_comments wc
 WHERE EXISTS (SELECT 1 FROM issues i WHERE i.id = wc.issue_id
-              AND i.issue_type IN ('agent', 'role', 'message'));
+              AND i.issue_type IN ('agent', 'rig', 'role', 'message'));
 
-DELETE FROM wisp_comments WHERE issue_id IN (SELECT id FROM issues WHERE issue_type IN ('agent', 'role', 'message'));
-DELETE FROM wisp_events WHERE issue_id IN (SELECT id FROM issues WHERE issue_type IN ('agent', 'role', 'message'));
-DELETE FROM wisp_dependencies WHERE issue_id IN (SELECT id FROM issues WHERE issue_type IN ('agent', 'role', 'message'));
-DELETE FROM wisp_labels WHERE issue_id IN (SELECT id FROM issues WHERE issue_type IN ('agent', 'role', 'message'));
-DELETE FROM wisps WHERE issue_type IN ('agent', 'role', 'message');
+DELETE FROM wisp_comments WHERE issue_id IN (SELECT id FROM issues WHERE issue_type IN ('agent', 'rig', 'role', 'message'));
+DELETE FROM wisp_events WHERE issue_id IN (SELECT id FROM issues WHERE issue_type IN ('agent', 'rig', 'role', 'message'));
+DELETE FROM wisp_dependencies WHERE issue_id IN (SELECT id FROM issues WHERE issue_type IN ('agent', 'rig', 'role', 'message'));
+DELETE FROM wisp_labels WHERE issue_id IN (SELECT id FROM issues WHERE issue_type IN ('agent', 'rig', 'role', 'message'));
+DELETE FROM wisps WHERE issue_type IN ('agent', 'rig', 'role', 'message');

--- a/internal/storage/schema/migrations/0035_migrate_infra_to_wisps.up.sql
+++ b/internal/storage/schema/migrations/0035_migrate_infra_to_wisps.up.sql
@@ -11,14 +11,14 @@ SET @shared_cols = (
 SET @sql = IF(@shared_cols IS NULL OR @shared_cols = '',
     'SELECT 1',
     CONCAT('INSERT IGNORE INTO wisps (', @shared_cols, ') SELECT ', @shared_cols,
-           ' FROM issues WHERE issue_type IN (''agent'', ''role'', ''message'')')
+           ' FROM issues WHERE issue_type IN (''agent'', ''rig'', ''role'', ''message'')')
 );
 PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
 
 SET @sql = IF(
     (SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES
         WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'wisps') > 0,
-    'UPDATE wisps SET ephemeral = 1 WHERE issue_type IN (''agent'', ''role'', ''message'')',
+    'UPDATE wisps SET ephemeral = 1 WHERE issue_type IN (''agent'', ''rig'', ''role'', ''message'')',
     'SELECT 1'
 );
 PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
@@ -26,7 +26,7 @@ PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
 SET @sql = IF(
     (SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES
         WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'wisp_labels') > 0,
-    'INSERT IGNORE INTO wisp_labels (issue_id, label) SELECT l.issue_id, l.label FROM labels l JOIN issues i ON i.id = l.issue_id WHERE i.issue_type IN (''agent'', ''role'', ''message'')',
+    'INSERT IGNORE INTO wisp_labels (issue_id, label) SELECT l.issue_id, l.label FROM labels l JOIN issues i ON i.id = l.issue_id WHERE i.issue_type IN (''agent'', ''rig'', ''role'', ''message'')',
     'SELECT 1'
 );
 PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
@@ -42,8 +42,8 @@ SET @sql = IF(
         WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'wisp_dependencies') > 0,
     IF(
         @has_split_wisp_dependencies = 3,
-        'INSERT IGNORE INTO wisp_dependencies (issue_id, depends_on_issue_id, depends_on_wisp_id, depends_on_external, type, created_at, created_by, metadata, thread_id) SELECT d.issue_id, CASE WHEN d.depends_on_id LIKE ''external:%'' THEN NULL WHEN EXISTS (SELECT 1 FROM wisps w WHERE w.id = d.depends_on_id) THEN NULL WHEN EXISTS (SELECT 1 FROM issues target_issue WHERE target_issue.id = d.depends_on_id) THEN d.depends_on_id ELSE NULL END, CASE WHEN d.depends_on_id LIKE ''external:%'' THEN NULL WHEN EXISTS (SELECT 1 FROM wisps w WHERE w.id = d.depends_on_id) THEN d.depends_on_id ELSE NULL END, CASE WHEN d.depends_on_id LIKE ''external:%'' THEN d.depends_on_id WHEN NOT EXISTS (SELECT 1 FROM wisps w WHERE w.id = d.depends_on_id) AND NOT EXISTS (SELECT 1 FROM issues target_issue WHERE target_issue.id = d.depends_on_id) THEN d.depends_on_id ELSE NULL END, d.type, d.created_at, d.created_by, d.metadata, d.thread_id FROM dependencies d JOIN issues i ON i.id = d.issue_id WHERE i.issue_type IN (''agent'', ''role'', ''message'')',
-        'INSERT IGNORE INTO wisp_dependencies (issue_id, depends_on_id, type, created_at, created_by, metadata, thread_id) SELECT d.issue_id, d.depends_on_id, d.type, d.created_at, d.created_by, d.metadata, d.thread_id FROM dependencies d JOIN issues i ON i.id = d.issue_id WHERE i.issue_type IN (''agent'', ''role'', ''message'')'
+        'INSERT IGNORE INTO wisp_dependencies (issue_id, depends_on_issue_id, depends_on_wisp_id, depends_on_external, type, created_at, created_by, metadata, thread_id) SELECT d.issue_id, CASE WHEN d.depends_on_id LIKE ''external:%'' THEN NULL WHEN EXISTS (SELECT 1 FROM wisps w WHERE w.id = d.depends_on_id) THEN NULL WHEN EXISTS (SELECT 1 FROM issues target_issue WHERE target_issue.id = d.depends_on_id) THEN d.depends_on_id ELSE NULL END, CASE WHEN d.depends_on_id LIKE ''external:%'' THEN NULL WHEN EXISTS (SELECT 1 FROM wisps w WHERE w.id = d.depends_on_id) THEN d.depends_on_id ELSE NULL END, CASE WHEN d.depends_on_id LIKE ''external:%'' THEN d.depends_on_id WHEN NOT EXISTS (SELECT 1 FROM wisps w WHERE w.id = d.depends_on_id) AND NOT EXISTS (SELECT 1 FROM issues target_issue WHERE target_issue.id = d.depends_on_id) THEN d.depends_on_id ELSE NULL END, d.type, d.created_at, d.created_by, d.metadata, d.thread_id FROM dependencies d JOIN issues i ON i.id = d.issue_id WHERE i.issue_type IN (''agent'', ''rig'', ''role'', ''message'')',
+        'INSERT IGNORE INTO wisp_dependencies (issue_id, depends_on_id, type, created_at, created_by, metadata, thread_id) SELECT d.issue_id, d.depends_on_id, d.type, d.created_at, d.created_by, d.metadata, d.thread_id FROM dependencies d JOIN issues i ON i.id = d.issue_id WHERE i.issue_type IN (''agent'', ''rig'', ''role'', ''message'')'
     ),
     'SELECT 1'
 );
@@ -52,7 +52,7 @@ PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
 SET @sql = IF(
     (SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES
         WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'wisp_events') > 0,
-    'INSERT IGNORE INTO wisp_events (id, issue_id, event_type, actor, old_value, new_value, comment, created_at) SELECT e.id, e.issue_id, e.event_type, e.actor, e.old_value, e.new_value, e.comment, e.created_at FROM events e JOIN issues i ON i.id = e.issue_id WHERE i.issue_type IN (''agent'', ''role'', ''message'')',
+    'INSERT IGNORE INTO wisp_events (id, issue_id, event_type, actor, old_value, new_value, comment, created_at) SELECT e.id, e.issue_id, e.event_type, e.actor, e.old_value, e.new_value, e.comment, e.created_at FROM events e JOIN issues i ON i.id = e.issue_id WHERE i.issue_type IN (''agent'', ''rig'', ''role'', ''message'')',
     'SELECT 1'
 );
 PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
@@ -60,7 +60,7 @@ PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
 SET @sql = IF(
     (SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES
         WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'wisp_comments') > 0,
-    'INSERT IGNORE INTO wisp_comments (id, issue_id, author, text, created_at) SELECT c.id, c.issue_id, c.author, c.text, c.created_at FROM comments c JOIN issues i ON i.id = c.issue_id WHERE i.issue_type IN (''agent'', ''role'', ''message'')',
+    'INSERT IGNORE INTO wisp_comments (id, issue_id, author, text, created_at) SELECT c.id, c.issue_id, c.author, c.text, c.created_at FROM comments c JOIN issues i ON i.id = c.issue_id WHERE i.issue_type IN (''agent'', ''rig'', ''role'', ''message'')',
     'SELECT 1'
 );
 PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
@@ -68,7 +68,7 @@ PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
 SET @sql = IF(
     (SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES
         WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'wisp_comments') > 0,
-    'DELETE c FROM comments c JOIN issues i ON i.id = c.issue_id WHERE i.issue_type IN (''agent'', ''role'', ''message'')',
+    'DELETE c FROM comments c JOIN issues i ON i.id = c.issue_id WHERE i.issue_type IN (''agent'', ''rig'', ''role'', ''message'')',
     'SELECT 1'
 );
 PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
@@ -76,7 +76,7 @@ PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
 SET @sql = IF(
     (SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES
         WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'wisp_events') > 0,
-    'DELETE e FROM events e JOIN issues i ON i.id = e.issue_id WHERE i.issue_type IN (''agent'', ''role'', ''message'')',
+    'DELETE e FROM events e JOIN issues i ON i.id = e.issue_id WHERE i.issue_type IN (''agent'', ''rig'', ''role'', ''message'')',
     'SELECT 1'
 );
 PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
@@ -84,7 +84,7 @@ PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
 SET @sql = IF(
     (SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES
         WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'wisp_dependencies') > 0,
-    'DELETE d FROM dependencies d JOIN issues i ON i.id = d.issue_id WHERE i.issue_type IN (''agent'', ''role'', ''message'')',
+    'DELETE d FROM dependencies d JOIN issues i ON i.id = d.issue_id WHERE i.issue_type IN (''agent'', ''rig'', ''role'', ''message'')',
     'SELECT 1'
 );
 PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
@@ -92,7 +92,7 @@ PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
 SET @sql = IF(
     (SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES
         WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'wisp_labels') > 0,
-    'DELETE l FROM labels l JOIN issues i ON i.id = l.issue_id WHERE i.issue_type IN (''agent'', ''role'', ''message'')',
+    'DELETE l FROM labels l JOIN issues i ON i.id = l.issue_id WHERE i.issue_type IN (''agent'', ''rig'', ''role'', ''message'')',
     'SELECT 1'
 );
 PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
@@ -100,7 +100,7 @@ PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
 SET @sql = IF(
     (SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES
         WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'wisps') > 0,
-    'DELETE FROM issues WHERE issue_type IN (''agent'', ''role'', ''message'')',
+    'DELETE FROM issues WHERE issue_type IN (''agent'', ''rig'', ''role'', ''message'')',
     'SELECT 1'
 );
 PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;

--- a/internal/storage/schema/migrations/0035_migrate_infra_to_wisps.up.sql
+++ b/internal/storage/schema/migrations/0035_migrate_infra_to_wisps.up.sql
@@ -11,14 +11,14 @@ SET @shared_cols = (
 SET @sql = IF(@shared_cols IS NULL OR @shared_cols = '',
     'SELECT 1',
     CONCAT('INSERT IGNORE INTO wisps (', @shared_cols, ') SELECT ', @shared_cols,
-           ' FROM issues WHERE issue_type IN (''agent'', ''rig'', ''role'', ''message'')')
+           ' FROM issues WHERE issue_type IN (''agent'', ''role'', ''message'')')
 );
 PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
 
 SET @sql = IF(
     (SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES
         WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'wisps') > 0,
-    'UPDATE wisps SET ephemeral = 1 WHERE issue_type IN (''agent'', ''rig'', ''role'', ''message'')',
+    'UPDATE wisps SET ephemeral = 1 WHERE issue_type IN (''agent'', ''role'', ''message'')',
     'SELECT 1'
 );
 PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
@@ -26,7 +26,7 @@ PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
 SET @sql = IF(
     (SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES
         WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'wisp_labels') > 0,
-    'INSERT IGNORE INTO wisp_labels (issue_id, label) SELECT l.issue_id, l.label FROM labels l JOIN issues i ON i.id = l.issue_id WHERE i.issue_type IN (''agent'', ''rig'', ''role'', ''message'')',
+    'INSERT IGNORE INTO wisp_labels (issue_id, label) SELECT l.issue_id, l.label FROM labels l JOIN issues i ON i.id = l.issue_id WHERE i.issue_type IN (''agent'', ''role'', ''message'')',
     'SELECT 1'
 );
 PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
@@ -42,8 +42,8 @@ SET @sql = IF(
         WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'wisp_dependencies') > 0,
     IF(
         @has_split_wisp_dependencies = 3,
-        'INSERT IGNORE INTO wisp_dependencies (issue_id, depends_on_issue_id, depends_on_wisp_id, depends_on_external, type, created_at, created_by, metadata, thread_id) SELECT d.issue_id, CASE WHEN d.depends_on_id LIKE ''external:%'' THEN NULL WHEN EXISTS (SELECT 1 FROM wisps w WHERE w.id = d.depends_on_id) THEN NULL WHEN EXISTS (SELECT 1 FROM issues target_issue WHERE target_issue.id = d.depends_on_id) THEN d.depends_on_id ELSE NULL END, CASE WHEN d.depends_on_id LIKE ''external:%'' THEN NULL WHEN EXISTS (SELECT 1 FROM wisps w WHERE w.id = d.depends_on_id) THEN d.depends_on_id ELSE NULL END, CASE WHEN d.depends_on_id LIKE ''external:%'' THEN d.depends_on_id WHEN NOT EXISTS (SELECT 1 FROM wisps w WHERE w.id = d.depends_on_id) AND NOT EXISTS (SELECT 1 FROM issues target_issue WHERE target_issue.id = d.depends_on_id) THEN d.depends_on_id ELSE NULL END, d.type, d.created_at, d.created_by, d.metadata, d.thread_id FROM dependencies d JOIN issues i ON i.id = d.issue_id WHERE i.issue_type IN (''agent'', ''rig'', ''role'', ''message'')',
-        'INSERT IGNORE INTO wisp_dependencies (issue_id, depends_on_id, type, created_at, created_by, metadata, thread_id) SELECT d.issue_id, d.depends_on_id, d.type, d.created_at, d.created_by, d.metadata, d.thread_id FROM dependencies d JOIN issues i ON i.id = d.issue_id WHERE i.issue_type IN (''agent'', ''rig'', ''role'', ''message'')'
+        'INSERT IGNORE INTO wisp_dependencies (issue_id, depends_on_issue_id, depends_on_wisp_id, depends_on_external, type, created_at, created_by, metadata, thread_id) SELECT d.issue_id, CASE WHEN d.depends_on_id LIKE ''external:%'' THEN NULL WHEN EXISTS (SELECT 1 FROM wisps w WHERE w.id = d.depends_on_id) THEN NULL WHEN EXISTS (SELECT 1 FROM issues target_issue WHERE target_issue.id = d.depends_on_id) THEN d.depends_on_id ELSE NULL END, CASE WHEN d.depends_on_id LIKE ''external:%'' THEN NULL WHEN EXISTS (SELECT 1 FROM wisps w WHERE w.id = d.depends_on_id) THEN d.depends_on_id ELSE NULL END, CASE WHEN d.depends_on_id LIKE ''external:%'' THEN d.depends_on_id WHEN NOT EXISTS (SELECT 1 FROM wisps w WHERE w.id = d.depends_on_id) AND NOT EXISTS (SELECT 1 FROM issues target_issue WHERE target_issue.id = d.depends_on_id) THEN d.depends_on_id ELSE NULL END, d.type, d.created_at, d.created_by, d.metadata, d.thread_id FROM dependencies d JOIN issues i ON i.id = d.issue_id WHERE i.issue_type IN (''agent'', ''role'', ''message'')',
+        'INSERT IGNORE INTO wisp_dependencies (issue_id, depends_on_id, type, created_at, created_by, metadata, thread_id) SELECT d.issue_id, d.depends_on_id, d.type, d.created_at, d.created_by, d.metadata, d.thread_id FROM dependencies d JOIN issues i ON i.id = d.issue_id WHERE i.issue_type IN (''agent'', ''role'', ''message'')'
     ),
     'SELECT 1'
 );
@@ -52,7 +52,7 @@ PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
 SET @sql = IF(
     (SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES
         WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'wisp_events') > 0,
-    'INSERT IGNORE INTO wisp_events (id, issue_id, event_type, actor, old_value, new_value, comment, created_at) SELECT e.id, e.issue_id, e.event_type, e.actor, e.old_value, e.new_value, e.comment, e.created_at FROM events e JOIN issues i ON i.id = e.issue_id WHERE i.issue_type IN (''agent'', ''rig'', ''role'', ''message'')',
+    'INSERT IGNORE INTO wisp_events (id, issue_id, event_type, actor, old_value, new_value, comment, created_at) SELECT e.id, e.issue_id, e.event_type, e.actor, e.old_value, e.new_value, e.comment, e.created_at FROM events e JOIN issues i ON i.id = e.issue_id WHERE i.issue_type IN (''agent'', ''role'', ''message'')',
     'SELECT 1'
 );
 PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
@@ -60,7 +60,7 @@ PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
 SET @sql = IF(
     (SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES
         WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'wisp_comments') > 0,
-    'INSERT IGNORE INTO wisp_comments (id, issue_id, author, text, created_at) SELECT c.id, c.issue_id, c.author, c.text, c.created_at FROM comments c JOIN issues i ON i.id = c.issue_id WHERE i.issue_type IN (''agent'', ''rig'', ''role'', ''message'')',
+    'INSERT IGNORE INTO wisp_comments (id, issue_id, author, text, created_at) SELECT c.id, c.issue_id, c.author, c.text, c.created_at FROM comments c JOIN issues i ON i.id = c.issue_id WHERE i.issue_type IN (''agent'', ''role'', ''message'')',
     'SELECT 1'
 );
 PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
@@ -68,7 +68,7 @@ PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
 SET @sql = IF(
     (SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES
         WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'wisp_comments') > 0,
-    'DELETE c FROM comments c JOIN issues i ON i.id = c.issue_id WHERE i.issue_type IN (''agent'', ''rig'', ''role'', ''message'')',
+    'DELETE c FROM comments c JOIN issues i ON i.id = c.issue_id WHERE i.issue_type IN (''agent'', ''role'', ''message'')',
     'SELECT 1'
 );
 PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
@@ -76,7 +76,7 @@ PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
 SET @sql = IF(
     (SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES
         WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'wisp_events') > 0,
-    'DELETE e FROM events e JOIN issues i ON i.id = e.issue_id WHERE i.issue_type IN (''agent'', ''rig'', ''role'', ''message'')',
+    'DELETE e FROM events e JOIN issues i ON i.id = e.issue_id WHERE i.issue_type IN (''agent'', ''role'', ''message'')',
     'SELECT 1'
 );
 PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
@@ -84,7 +84,7 @@ PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
 SET @sql = IF(
     (SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES
         WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'wisp_dependencies') > 0,
-    'DELETE d FROM dependencies d JOIN issues i ON i.id = d.issue_id WHERE i.issue_type IN (''agent'', ''rig'', ''role'', ''message'')',
+    'DELETE d FROM dependencies d JOIN issues i ON i.id = d.issue_id WHERE i.issue_type IN (''agent'', ''role'', ''message'')',
     'SELECT 1'
 );
 PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
@@ -92,7 +92,7 @@ PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
 SET @sql = IF(
     (SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES
         WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'wisp_labels') > 0,
-    'DELETE l FROM labels l JOIN issues i ON i.id = l.issue_id WHERE i.issue_type IN (''agent'', ''rig'', ''role'', ''message'')',
+    'DELETE l FROM labels l JOIN issues i ON i.id = l.issue_id WHERE i.issue_type IN (''agent'', ''role'', ''message'')',
     'SELECT 1'
 );
 PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
@@ -100,7 +100,7 @@ PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
 SET @sql = IF(
     (SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES
         WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'wisps') > 0,
-    'DELETE FROM issues WHERE issue_type IN (''agent'', ''rig'', ''role'', ''message'')',
+    'DELETE FROM issues WHERE issue_type IN (''agent'', ''role'', ''message'')',
     'SELECT 1'
 );
 PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;

--- a/internal/storage/schema/migrations/0053_repair_rig_wisps.down.sql
+++ b/internal/storage/schema/migrations/0053_repair_rig_wisps.down.sql
@@ -1,0 +1,7 @@
+-- Reverse of 0053: intentional no-op.
+--
+-- This is a one-way data repair that promotes durable rig identity beads out of
+-- the ephemeral wisp tier. Demoting them again would reintroduce the data loss
+-- risk this migration fixes. Restore from a prior Dolt commit if rollback is
+-- truly needed.
+SELECT 1;

--- a/internal/storage/schema/migrations/0053_repair_rig_wisps.up.sql
+++ b/internal/storage/schema/migrations/0053_repair_rig_wisps.up.sql
@@ -1,126 +1,142 @@
 -- Repair rig identity beads that earlier defaults routed into the ephemeral
 -- wisps tier. Rig beads are durable issue state: keep type=rig hidden from
 -- ready work in application code, but promote existing rows back to issues.
+--
+-- Main migrations can run before clone-local ignored migrations have
+-- materialized wisp tables in older workspaces. Treat that state as a no-op:
+-- there are no local rig wisps to repair yet, and ignored migrations will
+-- create the local tables later in the same pass.
 
 SET FOREIGN_KEY_CHECKS = 0;
 
-INSERT IGNORE INTO issues (
-    id, content_hash, title, description, design, acceptance_criteria, notes,
-    status, priority, issue_type, assignee, estimated_minutes, created_at,
-    created_by, owner, updated_at, closed_at, closed_by_session, external_ref,
-    spec_id, compaction_level, compacted_at, compacted_at_commit, original_size,
-    sender, ephemeral, wisp_type, pinned, is_template, mol_type, work_type,
-    source_system, metadata, source_repo, close_reason, event_kind, actor,
-    target, payload, await_type, await_id, timeout_ns, waiters, hook_bead,
-    role_bead, agent_state, last_activity, role_type, rig, due_at, defer_until,
-    no_history, started_at
-)
-SELECT
-    id, content_hash, title, description, design, acceptance_criteria, notes,
-    status, priority, issue_type, assignee, estimated_minutes, created_at,
-    created_by, owner, updated_at, closed_at, closed_by_session, external_ref,
-    spec_id, compaction_level, compacted_at, compacted_at_commit, original_size,
-    sender, ephemeral, wisp_type, pinned, is_template, mol_type, work_type,
-    source_system, metadata, source_repo, close_reason, event_kind, actor,
-    target, payload, await_type, await_id, timeout_ns, waiters, hook_bead,
-    role_bead, agent_state, last_activity, role_type, rig, due_at, defer_until,
-    no_history, started_at
-FROM wisps
-WHERE issue_type = 'rig';
-
-UPDATE issues
-SET ephemeral = 0
-WHERE issue_type = 'rig'
-  AND id IN (SELECT id FROM wisps WHERE issue_type = 'rig');
-
-INSERT IGNORE INTO labels (issue_id, label)
-SELECT wl.issue_id, wl.label
-FROM wisp_labels wl
-JOIN wisps w ON w.id = wl.issue_id
-WHERE w.issue_type = 'rig';
-
-INSERT IGNORE INTO dependencies (
-    id, issue_id, depends_on_issue_id, depends_on_wisp_id, depends_on_external,
-    type, created_at, created_by, metadata, thread_id
-)
-SELECT
-    wd.id, wd.issue_id, wd.depends_on_issue_id, wd.depends_on_wisp_id, wd.depends_on_external,
-    wd.type, wd.created_at, wd.created_by, wd.metadata, wd.thread_id
-FROM wisp_dependencies wd
-JOIN wisps w ON w.id = wd.issue_id
-WHERE w.issue_type = 'rig';
-
-INSERT IGNORE INTO events (id, issue_id, event_type, actor, old_value, new_value, comment, created_at)
-SELECT we.id, we.issue_id, we.event_type, we.actor, we.old_value, we.new_value, we.comment, we.created_at
-FROM wisp_events we
-JOIN wisps w ON w.id = we.issue_id
-WHERE w.issue_type = 'rig';
-
-INSERT IGNORE INTO comments (id, issue_id, author, text, created_at)
-SELECT wc.id, wc.issue_id, wc.author, wc.text, wc.created_at
-FROM wisp_comments wc
-JOIN wisps w ON w.id = wc.issue_id
-WHERE w.issue_type = 'rig';
-
-CREATE TABLE IF NOT EXISTS wisp_child_counters (
-    parent_id VARCHAR(255) PRIMARY KEY,
-    last_child INT NOT NULL DEFAULT 0
+SET @has_wisps = (
+    SELECT COUNT(*)
+    FROM INFORMATION_SCHEMA.TABLES
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = 'wisps'
+);
+SET @has_wisp_labels = (
+    SELECT COUNT(*)
+    FROM INFORMATION_SCHEMA.TABLES
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = 'wisp_labels'
+);
+SET @has_wisp_dependencies = (
+    SELECT COUNT(*)
+    FROM INFORMATION_SCHEMA.TABLES
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = 'wisp_dependencies'
+);
+SET @has_wisp_dependencies_id = (
+    SELECT COUNT(*)
+    FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = 'wisp_dependencies'
+      AND COLUMN_NAME = 'id'
+);
+SET @has_wisp_events = (
+    SELECT COUNT(*)
+    FROM INFORMATION_SCHEMA.TABLES
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = 'wisp_events'
+);
+SET @has_wisp_comments = (
+    SELECT COUNT(*)
+    FROM INFORMATION_SCHEMA.TABLES
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = 'wisp_comments'
+);
+SET @has_wisp_child_counters = (
+    SELECT COUNT(*)
+    FROM INFORMATION_SCHEMA.TABLES
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = 'wisp_child_counters'
 );
 
-INSERT IGNORE INTO child_counters (parent_id, last_child)
-SELECT wcc.parent_id, wcc.last_child
-FROM wisp_child_counters wcc
-JOIN wisps w ON w.id = wcc.parent_id
-WHERE w.issue_type = 'rig';
+SET @sql = IF(@has_wisps > 0,
+    'INSERT IGNORE INTO issues (id, content_hash, title, description, design, acceptance_criteria, notes, status, priority, issue_type, assignee, estimated_minutes, created_at, created_by, owner, updated_at, closed_at, closed_by_session, external_ref, spec_id, compaction_level, compacted_at, compacted_at_commit, original_size, sender, ephemeral, wisp_type, pinned, is_template, mol_type, work_type, source_system, metadata, source_repo, close_reason, event_kind, actor, target, payload, await_type, await_id, timeout_ns, waiters, hook_bead, role_bead, agent_state, last_activity, role_type, rig, due_at, defer_until, no_history, started_at) SELECT id, content_hash, title, description, design, acceptance_criteria, notes, status, priority, issue_type, assignee, estimated_minutes, created_at, created_by, owner, updated_at, closed_at, closed_by_session, external_ref, spec_id, compaction_level, compacted_at, compacted_at_commit, original_size, sender, ephemeral, wisp_type, pinned, is_template, mol_type, work_type, source_system, metadata, source_repo, close_reason, event_kind, actor, target, payload, await_type, await_id, timeout_ns, waiters, hook_bead, role_bead, agent_state, last_activity, role_type, rig, due_at, defer_until, no_history, started_at FROM wisps WHERE issue_type = ''rig''',
+    'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
 
-UPDATE child_counters cc
-JOIN wisp_child_counters wcc ON wcc.parent_id = cc.parent_id
-JOIN wisps w ON w.id = wcc.parent_id
-SET cc.last_child = GREATEST(cc.last_child, wcc.last_child)
-WHERE w.issue_type = 'rig';
+SET @sql = IF(@has_wisps > 0,
+    'UPDATE issues SET ephemeral = 0 WHERE issue_type = ''rig'' AND id IN (SELECT id FROM wisps WHERE issue_type = ''rig'')',
+    'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
 
-DELETE wd FROM wisp_dependencies wd
-JOIN wisps w ON w.id = wd.issue_id
-WHERE w.issue_type = 'rig';
+SET @sql = IF(@has_wisps > 0 AND @has_wisp_labels > 0,
+    'INSERT IGNORE INTO labels (issue_id, label) SELECT wl.issue_id, wl.label FROM wisp_labels wl JOIN wisps w ON w.id = wl.issue_id WHERE w.issue_type = ''rig''',
+    'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
 
-REPLACE INTO dependencies (
-    id, issue_id, depends_on_issue_id, depends_on_wisp_id, depends_on_external,
-    type, created_at, created_by, metadata, thread_id
-)
-SELECT
-    d.id, d.issue_id, d.depends_on_wisp_id, NULL, d.depends_on_external,
-    d.type, d.created_at, d.created_by, d.metadata, d.thread_id
-FROM dependencies d
-JOIN wisps w ON w.id = d.depends_on_wisp_id
-WHERE w.issue_type = 'rig';
+SET @sql = IF(@has_wisps > 0 AND @has_wisp_dependencies > 0,
+    IF(@has_wisp_dependencies_id > 0,
+        'INSERT IGNORE INTO dependencies (id, issue_id, depends_on_issue_id, depends_on_wisp_id, depends_on_external, type, created_at, created_by, metadata, thread_id) SELECT wd.id, wd.issue_id, wd.depends_on_issue_id, wd.depends_on_wisp_id, wd.depends_on_external, wd.type, wd.created_at, wd.created_by, wd.metadata, wd.thread_id FROM wisp_dependencies wd JOIN wisps w ON w.id = wd.issue_id WHERE w.issue_type = ''rig''',
+        'INSERT IGNORE INTO dependencies (id, issue_id, depends_on_issue_id, depends_on_wisp_id, depends_on_external, type, created_at, created_by, metadata, thread_id) SELECT CONCAT(SUBSTR(MD5(CONCAT(wd.issue_id, CHAR(31), COALESCE(wd.depends_on_issue_id, wd.depends_on_wisp_id, wd.depends_on_external))), 1, 8), ''-'', SUBSTR(MD5(CONCAT(wd.issue_id, CHAR(31), COALESCE(wd.depends_on_issue_id, wd.depends_on_wisp_id, wd.depends_on_external))), 9, 4), ''-'', SUBSTR(MD5(CONCAT(wd.issue_id, CHAR(31), COALESCE(wd.depends_on_issue_id, wd.depends_on_wisp_id, wd.depends_on_external))), 13, 4), ''-'', SUBSTR(MD5(CONCAT(wd.issue_id, CHAR(31), COALESCE(wd.depends_on_issue_id, wd.depends_on_wisp_id, wd.depends_on_external))), 17, 4), ''-'', SUBSTR(MD5(CONCAT(wd.issue_id, CHAR(31), COALESCE(wd.depends_on_issue_id, wd.depends_on_wisp_id, wd.depends_on_external))), 21, 12)), wd.issue_id, wd.depends_on_issue_id, wd.depends_on_wisp_id, wd.depends_on_external, wd.type, wd.created_at, wd.created_by, wd.metadata, wd.thread_id FROM wisp_dependencies wd JOIN wisps w ON w.id = wd.issue_id WHERE w.issue_type = ''rig'''
+    ),
+    'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
 
-REPLACE INTO wisp_dependencies (
-    id, issue_id, depends_on_issue_id, depends_on_wisp_id, depends_on_external,
-    type, created_at, created_by, metadata, thread_id
-)
-SELECT
-    wd.id, wd.issue_id, wd.depends_on_wisp_id, NULL, wd.depends_on_external,
-    wd.type, wd.created_at, wd.created_by, wd.metadata, wd.thread_id
-FROM wisp_dependencies wd
-JOIN wisps w ON w.id = wd.depends_on_wisp_id
-WHERE w.issue_type = 'rig';
+SET @sql = IF(@has_wisps > 0 AND @has_wisp_events > 0,
+    'INSERT IGNORE INTO events (id, issue_id, event_type, actor, old_value, new_value, comment, created_at) SELECT we.id, we.issue_id, we.event_type, we.actor, we.old_value, we.new_value, we.comment, we.created_at FROM wisp_events we JOIN wisps w ON w.id = we.issue_id WHERE w.issue_type = ''rig''',
+    'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
 
-DELETE wl FROM wisp_labels wl
-JOIN wisps w ON w.id = wl.issue_id
-WHERE w.issue_type = 'rig';
+SET @sql = IF(@has_wisps > 0 AND @has_wisp_comments > 0,
+    'INSERT IGNORE INTO comments (id, issue_id, author, text, created_at) SELECT wc.id, wc.issue_id, wc.author, wc.text, wc.created_at FROM wisp_comments wc JOIN wisps w ON w.id = wc.issue_id WHERE w.issue_type = ''rig''',
+    'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
 
-DELETE we FROM wisp_events we
-JOIN wisps w ON w.id = we.issue_id
-WHERE w.issue_type = 'rig';
+SET @sql = IF(@has_wisps > 0 AND @has_wisp_child_counters > 0,
+    'INSERT IGNORE INTO child_counters (parent_id, last_child) SELECT wcc.parent_id, wcc.last_child FROM wisp_child_counters wcc JOIN wisps w ON w.id = wcc.parent_id WHERE w.issue_type = ''rig''',
+    'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
 
-DELETE wc FROM wisp_comments wc
-JOIN wisps w ON w.id = wc.issue_id
-WHERE w.issue_type = 'rig';
+SET @sql = IF(@has_wisps > 0 AND @has_wisp_child_counters > 0,
+    'UPDATE child_counters cc JOIN wisp_child_counters wcc ON wcc.parent_id = cc.parent_id JOIN wisps w ON w.id = wcc.parent_id SET cc.last_child = GREATEST(cc.last_child, wcc.last_child) WHERE w.issue_type = ''rig''',
+    'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
 
-DELETE wcc FROM wisp_child_counters wcc
-JOIN wisps w ON w.id = wcc.parent_id
-WHERE w.issue_type = 'rig';
+SET @sql = IF(@has_wisps > 0 AND @has_wisp_dependencies > 0,
+    'DELETE wd FROM wisp_dependencies wd JOIN wisps w ON w.id = wd.issue_id WHERE w.issue_type = ''rig''',
+    'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
 
-DELETE FROM wisps WHERE issue_type = 'rig';
+SET @sql = IF(@has_wisps > 0,
+    'REPLACE INTO dependencies (id, issue_id, depends_on_issue_id, depends_on_wisp_id, depends_on_external, type, created_at, created_by, metadata, thread_id) SELECT d.id, d.issue_id, d.depends_on_wisp_id, NULL, d.depends_on_external, d.type, d.created_at, d.created_by, d.metadata, d.thread_id FROM dependencies d JOIN wisps w ON w.id = d.depends_on_wisp_id WHERE w.issue_type = ''rig''',
+    'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @sql = IF(@has_wisps > 0 AND @has_wisp_dependencies > 0,
+    IF(@has_wisp_dependencies_id > 0,
+        'REPLACE INTO wisp_dependencies (id, issue_id, depends_on_issue_id, depends_on_wisp_id, depends_on_external, type, created_at, created_by, metadata, thread_id) SELECT wd.id, wd.issue_id, wd.depends_on_wisp_id, NULL, wd.depends_on_external, wd.type, wd.created_at, wd.created_by, wd.metadata, wd.thread_id FROM wisp_dependencies wd JOIN wisps w ON w.id = wd.depends_on_wisp_id WHERE w.issue_type = ''rig''',
+        'REPLACE INTO wisp_dependencies (issue_id, depends_on_issue_id, depends_on_wisp_id, depends_on_external, type, created_at, created_by, metadata, thread_id) SELECT wd.issue_id, wd.depends_on_wisp_id, NULL, wd.depends_on_external, wd.type, wd.created_at, wd.created_by, wd.metadata, wd.thread_id FROM wisp_dependencies wd JOIN wisps w ON w.id = wd.depends_on_wisp_id WHERE w.issue_type = ''rig'''
+    ),
+    'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @sql = IF(@has_wisps > 0 AND @has_wisp_labels > 0,
+    'DELETE wl FROM wisp_labels wl JOIN wisps w ON w.id = wl.issue_id WHERE w.issue_type = ''rig''',
+    'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @sql = IF(@has_wisps > 0 AND @has_wisp_events > 0,
+    'DELETE we FROM wisp_events we JOIN wisps w ON w.id = we.issue_id WHERE w.issue_type = ''rig''',
+    'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @sql = IF(@has_wisps > 0 AND @has_wisp_comments > 0,
+    'DELETE wc FROM wisp_comments wc JOIN wisps w ON w.id = wc.issue_id WHERE w.issue_type = ''rig''',
+    'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @sql = IF(@has_wisps > 0 AND @has_wisp_child_counters > 0,
+    'DELETE wcc FROM wisp_child_counters wcc JOIN wisps w ON w.id = wcc.parent_id WHERE w.issue_type = ''rig''',
+    'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @sql = IF(@has_wisps > 0,
+    'DELETE FROM wisps WHERE issue_type = ''rig''',
+    'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
 
 SET FOREIGN_KEY_CHECKS = 1;

--- a/internal/storage/schema/migrations/0053_repair_rig_wisps.up.sql
+++ b/internal/storage/schema/migrations/0053_repair_rig_wisps.up.sql
@@ -1,0 +1,126 @@
+-- Repair rig identity beads that earlier defaults routed into the ephemeral
+-- wisps tier. Rig beads are durable issue state: keep type=rig hidden from
+-- ready work in application code, but promote existing rows back to issues.
+
+SET FOREIGN_KEY_CHECKS = 0;
+
+INSERT IGNORE INTO issues (
+    id, content_hash, title, description, design, acceptance_criteria, notes,
+    status, priority, issue_type, assignee, estimated_minutes, created_at,
+    created_by, owner, updated_at, closed_at, closed_by_session, external_ref,
+    spec_id, compaction_level, compacted_at, compacted_at_commit, original_size,
+    sender, ephemeral, wisp_type, pinned, is_template, mol_type, work_type,
+    source_system, metadata, source_repo, close_reason, event_kind, actor,
+    target, payload, await_type, await_id, timeout_ns, waiters, hook_bead,
+    role_bead, agent_state, last_activity, role_type, rig, due_at, defer_until,
+    no_history, started_at
+)
+SELECT
+    id, content_hash, title, description, design, acceptance_criteria, notes,
+    status, priority, issue_type, assignee, estimated_minutes, created_at,
+    created_by, owner, updated_at, closed_at, closed_by_session, external_ref,
+    spec_id, compaction_level, compacted_at, compacted_at_commit, original_size,
+    sender, ephemeral, wisp_type, pinned, is_template, mol_type, work_type,
+    source_system, metadata, source_repo, close_reason, event_kind, actor,
+    target, payload, await_type, await_id, timeout_ns, waiters, hook_bead,
+    role_bead, agent_state, last_activity, role_type, rig, due_at, defer_until,
+    no_history, started_at
+FROM wisps
+WHERE issue_type = 'rig';
+
+UPDATE issues
+SET ephemeral = 0
+WHERE issue_type = 'rig'
+  AND id IN (SELECT id FROM wisps WHERE issue_type = 'rig');
+
+INSERT IGNORE INTO labels (issue_id, label)
+SELECT wl.issue_id, wl.label
+FROM wisp_labels wl
+JOIN wisps w ON w.id = wl.issue_id
+WHERE w.issue_type = 'rig';
+
+INSERT IGNORE INTO dependencies (
+    id, issue_id, depends_on_issue_id, depends_on_wisp_id, depends_on_external,
+    type, created_at, created_by, metadata, thread_id
+)
+SELECT
+    wd.id, wd.issue_id, wd.depends_on_issue_id, wd.depends_on_wisp_id, wd.depends_on_external,
+    wd.type, wd.created_at, wd.created_by, wd.metadata, wd.thread_id
+FROM wisp_dependencies wd
+JOIN wisps w ON w.id = wd.issue_id
+WHERE w.issue_type = 'rig';
+
+INSERT IGNORE INTO events (id, issue_id, event_type, actor, old_value, new_value, comment, created_at)
+SELECT we.id, we.issue_id, we.event_type, we.actor, we.old_value, we.new_value, we.comment, we.created_at
+FROM wisp_events we
+JOIN wisps w ON w.id = we.issue_id
+WHERE w.issue_type = 'rig';
+
+INSERT IGNORE INTO comments (id, issue_id, author, text, created_at)
+SELECT wc.id, wc.issue_id, wc.author, wc.text, wc.created_at
+FROM wisp_comments wc
+JOIN wisps w ON w.id = wc.issue_id
+WHERE w.issue_type = 'rig';
+
+CREATE TABLE IF NOT EXISTS wisp_child_counters (
+    parent_id VARCHAR(255) PRIMARY KEY,
+    last_child INT NOT NULL DEFAULT 0
+);
+
+INSERT IGNORE INTO child_counters (parent_id, last_child)
+SELECT wcc.parent_id, wcc.last_child
+FROM wisp_child_counters wcc
+JOIN wisps w ON w.id = wcc.parent_id
+WHERE w.issue_type = 'rig';
+
+UPDATE child_counters cc
+JOIN wisp_child_counters wcc ON wcc.parent_id = cc.parent_id
+JOIN wisps w ON w.id = wcc.parent_id
+SET cc.last_child = GREATEST(cc.last_child, wcc.last_child)
+WHERE w.issue_type = 'rig';
+
+DELETE wd FROM wisp_dependencies wd
+JOIN wisps w ON w.id = wd.issue_id
+WHERE w.issue_type = 'rig';
+
+REPLACE INTO dependencies (
+    id, issue_id, depends_on_issue_id, depends_on_wisp_id, depends_on_external,
+    type, created_at, created_by, metadata, thread_id
+)
+SELECT
+    d.id, d.issue_id, d.depends_on_wisp_id, NULL, d.depends_on_external,
+    d.type, d.created_at, d.created_by, d.metadata, d.thread_id
+FROM dependencies d
+JOIN wisps w ON w.id = d.depends_on_wisp_id
+WHERE w.issue_type = 'rig';
+
+REPLACE INTO wisp_dependencies (
+    id, issue_id, depends_on_issue_id, depends_on_wisp_id, depends_on_external,
+    type, created_at, created_by, metadata, thread_id
+)
+SELECT
+    wd.id, wd.issue_id, wd.depends_on_wisp_id, NULL, wd.depends_on_external,
+    wd.type, wd.created_at, wd.created_by, wd.metadata, wd.thread_id
+FROM wisp_dependencies wd
+JOIN wisps w ON w.id = wd.depends_on_wisp_id
+WHERE w.issue_type = 'rig';
+
+DELETE wl FROM wisp_labels wl
+JOIN wisps w ON w.id = wl.issue_id
+WHERE w.issue_type = 'rig';
+
+DELETE we FROM wisp_events we
+JOIN wisps w ON w.id = we.issue_id
+WHERE w.issue_type = 'rig';
+
+DELETE wc FROM wisp_comments wc
+JOIN wisps w ON w.id = wc.issue_id
+WHERE w.issue_type = 'rig';
+
+DELETE wcc FROM wisp_child_counters wcc
+JOIN wisps w ON w.id = wcc.parent_id
+WHERE w.issue_type = 'rig';
+
+DELETE FROM wisps WHERE issue_type = 'rig';
+
+SET FOREIGN_KEY_CHECKS = 1;

--- a/internal/storage/schema/schema_test.go
+++ b/internal/storage/schema/schema_test.go
@@ -196,8 +196,10 @@ func TestMigration0053RepairsRigWispsShape(t *testing.T) {
 
 	body := string(sql)
 	for _, want := range []string{
+		"@has_wisps",
+		"INFORMATION_SCHEMA.TABLES",
 		"INSERT IGNORE INTO issues",
-		"FROM wisps WHERE issue_type = 'rig'",
+		"FROM wisps WHERE issue_type = ''rig''",
 		"SET ephemeral = 0",
 		"INSERT IGNORE INTO dependencies",
 		"FROM wisp_dependencies wd",
@@ -206,12 +208,41 @@ func TestMigration0053RepairsRigWispsShape(t *testing.T) {
 		"wisp_child_counters",
 		"INSERT IGNORE INTO child_counters",
 		"UPDATE child_counters",
-		"DELETE FROM wisps WHERE issue_type = 'rig'",
+		"DELETE FROM wisps WHERE issue_type = ''rig''",
 	} {
 		if !strings.Contains(body, want) {
 			t.Fatalf("0053 migration missing rig repair marker %q", want)
 		}
 	}
+}
+
+func TestMigration0053NoopsWithoutWispTablesThroughDoltCLI(t *testing.T) {
+	testutil.RequireDoltBinary(t)
+
+	dir := filepath.Join(t.TempDir(), "rig-repair-no-wisps")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("create no-wisps dir: %v", err)
+	}
+	runDoltCommand(t, dir, "init", "--name", "test", "--email", "test@example.com")
+	runDoltSQL(t, dir, AllMigrationsSQL())
+
+	seedSQL := fmt.Sprintf(`
+DROP TABLE IF EXISTS wisp_child_counters;
+DROP TABLE IF EXISTS wisp_comments;
+DROP TABLE IF EXISTS wisp_events;
+DROP TABLE IF EXISTS wisp_dependencies;
+DROP TABLE IF EXISTS wisp_labels;
+DROP TABLE IF EXISTS wisps;
+DELETE FROM schema_migrations WHERE version = %d;
+`, LatestVersion())
+	migrationSQL, err := mainSource.files.ReadFile("migrations/0053_repair_rig_wisps.up.sql")
+	if err != nil {
+		t.Fatalf("read 0053 migration: %v", err)
+	}
+	runDoltSQL(t, dir, seedSQL+"\n"+string(migrationSQL))
+
+	requireDoltCount(t, dir,
+		`SELECT COUNT(*) AS c FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'wisps'`, "0")
 }
 
 func TestMigration0053RepairsRigWispsThroughDoltCLI(t *testing.T) {
@@ -258,7 +289,7 @@ INSERT INTO wisp_child_counters (parent_id, last_child) VALUES (%s, 7);
 	if err != nil {
 		t.Fatalf("read 0053 migration: %v", err)
 	}
-	runDoltSQL(t, dir, seedSQL+"\n"+string(migrationSQL))
+	runDoltSQL(t, dir, seedSQL+"\n"+cliCompatibleMigrationSQL("0053_repair_rig_wisps.up.sql", string(migrationSQL)))
 
 	requireDoltCount(t, dir,
 		`SELECT COUNT(*) AS c FROM issues WHERE id = 'schema-cli-rig' AND issue_type = 'rig' AND ephemeral = 0`, "1")

--- a/internal/storage/schema/schema_test.go
+++ b/internal/storage/schema/schema_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/steveyegge/beads/internal/storage/depid"
 	"github.com/steveyegge/beads/internal/testutil"
 )
 
@@ -165,9 +166,6 @@ func TestMigration0035HandlesLegacyWispDependenciesShape(t *testing.T) {
 	}
 
 	up := string(upSQL)
-	if strings.Contains(up, "''rig''") || strings.Contains(up, "'rig'") {
-		t.Fatal("0035 up migration must not move type=rig beads into wisps")
-	}
 	for _, want := range []string{
 		"@has_split_wisp_dependencies",
 		"INSERT IGNORE INTO wisp_dependencies (issue_id, depends_on_id, type, created_at, created_by, metadata, thread_id)",
@@ -179,9 +177,6 @@ func TestMigration0035HandlesLegacyWispDependenciesShape(t *testing.T) {
 	}
 
 	down := string(downSQL)
-	if strings.Contains(down, "''rig''") || strings.Contains(down, "'rig'") {
-		t.Fatal("0035 down migration must not treat type=rig as an infra wisp")
-	}
 	for _, want := range []string{
 		"@has_split_wisp_dependencies",
 		"SELECT issue_id, depends_on_id, type, created_at, created_by, metadata, thread_id FROM wisp_dependencies",
@@ -191,6 +186,96 @@ func TestMigration0035HandlesLegacyWispDependenciesShape(t *testing.T) {
 			t.Fatalf("0035 down migration missing legacy/split branch marker %q", want)
 		}
 	}
+}
+
+func TestMigration0053RepairsRigWispsShape(t *testing.T) {
+	sql, err := os.ReadFile("migrations/0053_repair_rig_wisps.up.sql")
+	if err != nil {
+		t.Fatalf("read 0053 up migration: %v", err)
+	}
+
+	body := string(sql)
+	for _, want := range []string{
+		"INSERT IGNORE INTO issues",
+		"FROM wisps WHERE issue_type = 'rig'",
+		"SET ephemeral = 0",
+		"INSERT IGNORE INTO dependencies",
+		"FROM wisp_dependencies wd",
+		"REPLACE INTO dependencies",
+		"REPLACE INTO wisp_dependencies",
+		"wisp_child_counters",
+		"INSERT IGNORE INTO child_counters",
+		"UPDATE child_counters",
+		"DELETE FROM wisps WHERE issue_type = 'rig'",
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("0053 migration missing rig repair marker %q", want)
+		}
+	}
+}
+
+func TestMigration0053RepairsRigWispsThroughDoltCLI(t *testing.T) {
+	testutil.RequireDoltBinary(t)
+
+	dir := filepath.Join(t.TempDir(), "rig-repair")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("create rig repair dir: %v", err)
+	}
+	runDoltCommand(t, dir, "init", "--name", "test", "--email", "test@example.com")
+	runDoltSQL(t, dir, AllMigrationsSQL())
+
+	const rigID = "schema-cli-rig"
+	const targetID = "schema-cli-target"
+	const sourceID = "schema-cli-source"
+	seedSQL := fmt.Sprintf(`
+CREATE TABLE IF NOT EXISTS wisp_child_counters (
+    parent_id VARCHAR(255) PRIMARY KEY,
+    last_child INT NOT NULL DEFAULT 0
+);
+DELETE FROM schema_migrations WHERE version = %d;
+INSERT INTO issues (id, title, description, design, acceptance_criteria, notes, status, priority, issue_type)
+VALUES (%s, 'target', '', '', '', '', 'open', 2, 'task'),
+       (%s, 'source', '', '', '', '', 'open', 2, 'task');
+INSERT INTO wisps (id, title, description, design, acceptance_criteria, notes, status, priority, issue_type, ephemeral)
+VALUES (%s, 'Rig identity', '', '', '', '', 'open', 1, 'rig', 1);
+INSERT INTO wisp_labels (issue_id, label) VALUES (%s, 'gt:rig');
+INSERT INTO wisp_dependencies (id, issue_id, depends_on_issue_id, type, created_at, created_by, metadata)
+VALUES (%s, %s, %s, 'blocks', NOW(), 'tester', JSON_OBJECT());
+INSERT INTO dependencies (id, issue_id, depends_on_wisp_id, type, created_at, created_by, metadata)
+VALUES (%s, %s, %s, 'blocks', NOW(), 'tester', JSON_OBJECT());
+INSERT INTO wisp_events (id, issue_id, event_type, actor, created_at)
+VALUES ('11111111-1111-1111-1111-111111111111', %s, 'created', 'tester', NOW());
+INSERT INTO wisp_comments (id, issue_id, author, text, created_at)
+VALUES ('22222222-2222-2222-2222-222222222222', %s, 'tester', 'durable identity', NOW());
+INSERT INTO wisp_child_counters (parent_id, last_child) VALUES (%s, 7);
+`, LatestVersion(),
+		doltSQLString(targetID), doltSQLString(sourceID), doltSQLString(rigID),
+		doltSQLString(rigID), doltSQLString(depid.New(rigID, targetID)),
+		doltSQLString(rigID), doltSQLString(targetID), doltSQLString(depid.New(sourceID, rigID)),
+		doltSQLString(sourceID), doltSQLString(rigID), doltSQLString(rigID),
+		doltSQLString(rigID), doltSQLString(rigID))
+	migrationSQL, err := mainSource.files.ReadFile("migrations/0053_repair_rig_wisps.up.sql")
+	if err != nil {
+		t.Fatalf("read 0053 migration: %v", err)
+	}
+	runDoltSQL(t, dir, seedSQL+"\n"+string(migrationSQL))
+
+	requireDoltCount(t, dir,
+		`SELECT COUNT(*) AS c FROM issues WHERE id = 'schema-cli-rig' AND issue_type = 'rig' AND ephemeral = 0`, "1")
+	requireDoltCount(t, dir,
+		`SELECT COUNT(*) AS c FROM wisps WHERE id = 'schema-cli-rig'`, "0")
+	requireDoltCount(t, dir,
+		`SELECT COUNT(*) AS c FROM labels WHERE issue_id = 'schema-cli-rig' AND label = 'gt:rig'`, "1")
+	requireDoltCount(t, dir,
+		`SELECT COUNT(*) AS c FROM dependencies WHERE issue_id = 'schema-cli-rig' AND depends_on_issue_id = 'schema-cli-target'`, "1")
+	requireDoltCount(t, dir,
+		`SELECT COUNT(*) AS c FROM dependencies WHERE issue_id = 'schema-cli-source' AND depends_on_issue_id = 'schema-cli-rig' AND depends_on_wisp_id IS NULL`, "1")
+	requireDoltCount(t, dir,
+		`SELECT COUNT(*) AS c FROM comments WHERE issue_id = 'schema-cli-rig'`, "1")
+	requireDoltCount(t, dir,
+		`SELECT COUNT(*) AS c FROM child_counters WHERE parent_id = 'schema-cli-rig' AND last_child = 7`, "1")
+	requireDoltCount(t, dir,
+		`SELECT COUNT(*) AS c FROM wisp_child_counters WHERE parent_id = 'schema-cli-rig'`, "0")
 }
 
 func TestMigration0047HandlesLegacyWispDependenciesShape(t *testing.T) {
@@ -371,8 +456,11 @@ func runDoltCommand(t *testing.T, dir string, args ...string) {
 
 func runDoltSQL(t *testing.T, dir, query string) {
 	t.Helper()
-	args := []string{"sql", "-q", query}
-	runDoltCommand(t, dir, args...)
+	sqlFile := filepath.Join(t.TempDir(), "migration-bundle.sql")
+	if err := os.WriteFile(sqlFile, []byte(query), 0o644); err != nil {
+		t.Fatalf("write dolt sql file: %v", err)
+	}
+	runDoltCommand(t, dir, "sql", "-f", sqlFile)
 }
 
 func queryDoltCSV(t *testing.T, dir, query string) []map[string]string {
@@ -412,6 +500,17 @@ func requireDoltNoRows(t *testing.T, dir, query, subject string) {
 	t.Helper()
 	if rows := queryDoltCSV(t, dir, query); len(rows) != 0 {
 		t.Fatalf("%s query returned %d rows, want none: %v", subject, len(rows), rows)
+	}
+}
+
+func requireDoltCount(t *testing.T, dir, query, want string) {
+	t.Helper()
+	rows := queryDoltCSV(t, dir, query)
+	if len(rows) != 1 {
+		t.Fatalf("count query returned %d rows, want 1: %v", len(rows), rows)
+	}
+	if got := rows[0]["c"]; got != want {
+		t.Fatalf("count query returned %s, want %s\nQuery: %s", got, want, query)
 	}
 }
 

--- a/internal/storage/schema/schema_test.go
+++ b/internal/storage/schema/schema_test.go
@@ -165,6 +165,9 @@ func TestMigration0035HandlesLegacyWispDependenciesShape(t *testing.T) {
 	}
 
 	up := string(upSQL)
+	if strings.Contains(up, "''rig''") || strings.Contains(up, "'rig'") {
+		t.Fatal("0035 up migration must not move type=rig beads into wisps")
+	}
 	for _, want := range []string{
 		"@has_split_wisp_dependencies",
 		"INSERT IGNORE INTO wisp_dependencies (issue_id, depends_on_id, type, created_at, created_by, metadata, thread_id)",
@@ -176,6 +179,9 @@ func TestMigration0035HandlesLegacyWispDependenciesShape(t *testing.T) {
 	}
 
 	down := string(downSQL)
+	if strings.Contains(down, "''rig''") || strings.Contains(down, "'rig'") {
+		t.Fatal("0035 down migration must not treat type=rig as an infra wisp")
+	}
 	for _, want := range []string{
 		"@has_split_wisp_dependencies",
 		"SELECT issue_id, depends_on_id, type, created_at, created_by, metadata, thread_id FROM wisp_dependencies",

--- a/internal/storage/sqlbuild/ready.go
+++ b/internal/storage/sqlbuild/ready.go
@@ -10,14 +10,15 @@ import (
 )
 
 // ReadyWorkExcludeTypes returns the issue types excluded from ready work by
-// default, plus any caller extras (deduped, empty entries dropped). The infra
-// types come from domain.DefaultInfraTypes so that adding an infra type
-// changes both stacks together.
+// default, plus any caller extras (deduped, empty entries dropped). Infra types
+// stay hidden from ready work, and rig identity beads are also hidden even
+// though they are durable issues rather than infra wisps.
 func ReadyWorkExcludeTypes(extra []types.IssueType) []types.IssueType {
 	out := []types.IssueType{
 		types.IssueType("merge-request"),
 		types.TypeGate,
 		types.TypeMolecule,
+		types.IssueType("rig"),
 	}
 	for _, t := range domain.DefaultInfraTypes() {
 		out = append(out, types.IssueType(t))

--- a/website/docs/cli-reference/export.md
+++ b/website/docs/cli-reference/export.md
@@ -22,7 +22,7 @@ For supported full backup/restore flows, use 'bd backup init', 'bd backup sync',
 and 'bd backup restore'.
 
 By default, exports only regular issues (excluding infrastructure beads
-like agents, rigs, roles, and messages). Use --all to include everything.
+like agents, roles, and messages). Use --all to include everything.
 
 Memories (from 'bd remember') are excluded by default because they may
 contain sensitive agent context. Use --include-memories or --all to
@@ -43,7 +43,7 @@ bd export [flags]
 
 ```
       --all                Include all records (infra, templates, gates, memories)
-      --include-infra      Include infrastructure beads (agents, rigs, roles, messages)
+      --include-infra      Include infrastructure beads (agents, roles, messages)
       --include-memories   Include persistent memories (from 'bd remember') in the export
   -o, --output string      Output file path (default: stdout)
       --scrub              Exclude test/pollution records

--- a/website/docs/cli-reference/list.md
+++ b/website/docs/cli-reference/list.md
@@ -39,7 +39,7 @@ bd list [flags]
       --has-metadata-key string      Filter issues that have this metadata key set
       --id string                    Filter by specific issue IDs (comma-separated, e.g., bd-1,bd-5,bd-10)
       --include-gates                Include gate issues in output (normally hidden)
-      --include-infra                Include infrastructure beads (agent/rig/role/message) in output
+      --include-infra                Include infrastructure beads (agent/role/message) in output
       --include-templates            Include template molecules in output
   -l, --label strings                Filter by labels (AND: must have ALL). Can combine with --label-any
       --label-any strings            Filter by labels (OR: must have AT LEAST ONE). Can combine with --label

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -5256,7 +5256,7 @@ For supported full backup/restore flows, use 'bd backup init', 'bd backup sync',
 and 'bd backup restore'.
 
 By default, exports only regular issues (excluding infrastructure beads
-like agents, rigs, roles, and messages). Use --all to include everything.
+like agents, roles, and messages). Use --all to include everything.
 
 Memories (from 'bd remember') are excluded by default because they may
 contain sensitive agent context. Use --include-memories or --all to
@@ -5277,7 +5277,7 @@ bd export [flags]
 
 ```
       --all                Include all records (infra, templates, gates, memories)
-      --include-infra      Include infrastructure beads (agents, rigs, roles, messages)
+      --include-infra      Include infrastructure beads (agents, roles, messages)
       --include-memories   Include persistent memories (from 'bd remember') in the export
   -o, --output string      Output file path (default: stdout)
       --scrub              Exclude test/pollution records
@@ -7142,7 +7142,7 @@ bd list [flags]
       --has-metadata-key string      Filter issues that have this metadata key set
       --id string                    Filter by specific issue IDs (comma-separated, e.g., bd-1,bd-5,bd-10)
       --include-gates                Include gate issues in output (normally hidden)
-      --include-infra                Include infrastructure beads (agent/rig/role/message) in output
+      --include-infra                Include infrastructure beads (agent/role/message) in output
       --include-templates            Include template molecules in output
   -l, --label strings                Filter by labels (AND: must have ALL). Can combine with --label-any
       --label-any strings            Filter by labels (OR: must have AT LEAST ONE). Can combine with --label
@@ -7171,7 +7171,7 @@ bd list [flags]
       --skip-labels                  Skip label hydration. The labels field in output will be empty regardless of actual labels. Use only when the caller does not depend on label data. Cannot combine with --label, --label-any, --label-pattern, --label-regex, --exclude-label, or --no-labels.
       --sort string                  Sort by field: priority, created, updated, closed, status, id, title, type, assignee
       --spec string                  Filter by spec_id prefix
-  -s, --status string                Filter by stored status (open, in_progress, blocked, deferred, closed). Comma-separated for multiple: --status open,in_progress
+  -s, --status string                Filter by stored status (open, in_progress, blocked, deferred, closed). Comma-separated for multiple: --status open,in_progress. Note: repeating -s/--status silently overwrites the previous value — always use the comma-separated form for multi-status filters.
       --title string                 Filter by title text (case-insensitive substring match)
       --title-contains string        Filter by title substring (case-insensitive)
       --tree                         Hierarchical tree format (default: true; use --flat to disable) (default true)

--- a/website/versioned_docs/version-1.0.0/cli-reference/export.md
+++ b/website/versioned_docs/version-1.0.0/cli-reference/export.md
@@ -22,7 +22,7 @@ For supported full backup/restore flows, use 'bd backup init', 'bd backup sync',
 and 'bd backup restore'.
 
 By default, exports only regular issues (excluding infrastructure beads
-like agents, rigs, roles, and messages). Use --all to include everything.
+like agents, roles, and messages). Use --all to include everything.
 
 Memories (from 'bd remember') are excluded by default because they may
 contain sensitive agent context. Use --include-memories or --all to
@@ -43,7 +43,7 @@ bd export [flags]
 
 ```
       --all                Include all records (infra, templates, gates, memories)
-      --include-infra      Include infrastructure beads (agents, rigs, roles, messages)
+      --include-infra      Include infrastructure beads (agents, roles, messages)
       --include-memories   Include persistent memories (from 'bd remember') in the export
   -o, --output string      Output file path (default: stdout)
       --scrub              Exclude test/pollution records

--- a/website/versioned_docs/version-1.0.0/cli-reference/list.md
+++ b/website/versioned_docs/version-1.0.0/cli-reference/list.md
@@ -39,7 +39,7 @@ bd list [flags]
       --has-metadata-key string      Filter issues that have this metadata key set
       --id string                    Filter by specific issue IDs (comma-separated, e.g., bd-1,bd-5,bd-10)
       --include-gates                Include gate issues in output (normally hidden)
-      --include-infra                Include infrastructure beads (agent/rig/role/message) in output
+      --include-infra                Include infrastructure beads (agent/role/message) in output
       --include-templates            Include template molecules in output
   -l, --label strings                Filter by labels (AND: must have ALL). Can combine with --label-any
       --label-any strings            Filter by labels (OR: must have AT LEAST ONE). Can combine with --label

--- a/website/versioned_docs/version-1.0.4/cli-reference/export.md
+++ b/website/versioned_docs/version-1.0.4/cli-reference/export.md
@@ -22,7 +22,7 @@ For supported full backup/restore flows, use 'bd backup init', 'bd backup sync',
 and 'bd backup restore'.
 
 By default, exports only regular issues (excluding infrastructure beads
-like agents, rigs, roles, and messages). Use --all to include everything.
+like agents, roles, and messages). Use --all to include everything.
 
 Memories (from 'bd remember') are excluded by default because they may
 contain sensitive agent context. Use --include-memories or --all to
@@ -43,7 +43,7 @@ bd export [flags]
 
 ```
       --all                Include all records (infra, templates, gates, memories)
-      --include-infra      Include infrastructure beads (agents, rigs, roles, messages)
+      --include-infra      Include infrastructure beads (agents, roles, messages)
       --include-memories   Include persistent memories (from 'bd remember') in the export
   -o, --output string      Output file path (default: stdout)
       --scrub              Exclude test/pollution records

--- a/website/versioned_docs/version-1.0.4/cli-reference/list.md
+++ b/website/versioned_docs/version-1.0.4/cli-reference/list.md
@@ -39,7 +39,7 @@ bd list [flags]
       --has-metadata-key string      Filter issues that have this metadata key set
       --id string                    Filter by specific issue IDs (comma-separated, e.g., bd-1,bd-5,bd-10)
       --include-gates                Include gate issues in output (normally hidden)
-      --include-infra                Include infrastructure beads (agent/rig/role/message) in output
+      --include-infra                Include infrastructure beads (agent/role/message) in output
       --include-templates            Include template molecules in output
   -l, --label strings                Filter by labels (AND: must have ALL). Can combine with --label-any
       --label-any strings            Filter by labels (OR: must have AT LEAST ONE). Can combine with --label

--- a/website/versioned_docs/version-1.0.5/cli-reference/export.md
+++ b/website/versioned_docs/version-1.0.5/cli-reference/export.md
@@ -22,7 +22,7 @@ For supported full backup/restore flows, use 'bd backup init', 'bd backup sync',
 and 'bd backup restore'.
 
 By default, exports only regular issues (excluding infrastructure beads
-like agents, rigs, roles, and messages). Use --all to include everything.
+like agents, roles, and messages). Use --all to include everything.
 
 Memories (from 'bd remember') are excluded by default because they may
 contain sensitive agent context. Use --include-memories or --all to
@@ -43,7 +43,7 @@ bd export [flags]
 
 ```
       --all                Include all records (infra, templates, gates, memories)
-      --include-infra      Include infrastructure beads (agents, rigs, roles, messages)
+      --include-infra      Include infrastructure beads (agents, roles, messages)
       --include-memories   Include persistent memories (from 'bd remember') in the export
   -o, --output string      Output file path (default: stdout)
       --scrub              Exclude test/pollution records

--- a/website/versioned_docs/version-1.0.5/cli-reference/list.md
+++ b/website/versioned_docs/version-1.0.5/cli-reference/list.md
@@ -39,7 +39,7 @@ bd list [flags]
       --has-metadata-key string      Filter issues that have this metadata key set
       --id string                    Filter by specific issue IDs (comma-separated, e.g., bd-1,bd-5,bd-10)
       --include-gates                Include gate issues in output (normally hidden)
-      --include-infra                Include infrastructure beads (agent/rig/role/message) in output
+      --include-infra                Include infrastructure beads (agent/role/message) in output
       --include-templates            Include template molecules in output
   -l, --label strings                Filter by labels (AND: must have ALL). Can combine with --label-any
       --label-any strings            Filter by labels (OR: must have AT LEAST ONE). Can combine with --label
@@ -68,7 +68,7 @@ bd list [flags]
       --skip-labels                  Skip label hydration. The labels field in output will be empty regardless of actual labels. Use only when the caller does not depend on label data. Cannot combine with --label, --label-any, --label-pattern, --label-regex, --exclude-label, or --no-labels.
       --sort string                  Sort by field: priority, created, updated, closed, status, id, title, type, assignee
       --spec string                  Filter by spec_id prefix
-  -s, --status string                Filter by stored status (open, in_progress, blocked, deferred, closed). Comma-separated for multiple: --status open,in_progress
+  -s, --status string                Filter by stored status (open, in_progress, blocked, deferred, closed). Comma-separated for multiple: --status open,in_progress. Note: repeating -s/--status silently overwrites the previous value — always use the comma-separated form for multi-status filters.
       --title string                 Filter by title text (case-insensitive substring match)
       --title-contains string        Filter by title substring (case-insensitive)
       --tree                         Hierarchical tree format (default: true; use --flat to disable) (default true)


### PR DESCRIPTION
## Summary

- Remove `rig` from the default infra type set so newly-created `type=rig`
  beads are durable issues instead of ephemeral wisps.
- Keep `rig` excluded from ready work through explicit ready-work filtering.
- Fix the infra-to-wisps migration behavior so migration code does not classify
  rig identity beads as infra.
- Update CLI/help/reference text that described rigs as default infra types.

## Root Cause

`domain.DefaultInfraTypes()` included `rig`. Create paths use infra type
classification to mark beads ephemeral and route them to the wisp path. That
made rig identity beads transient even though rig identity is durable workspace
state.

Ready-work exclusion is a separate concern. `type=rig` should remain hidden from
`bd ready`, but it should not be ephemeral.

## Change Details

- Removes `rig` from default infra types.
- Keeps `rig` out of ready work via explicit ready exclusions.
- Updates the infra-to-wisps migration path so it does not treat `rig` as infra.
- Adds tests proving rig beads are persistent but not ready work.
- Updates docs and command help for the corrected infra type defaults.

## Validation

- PASS:
  `go test -tags gms_pure_go ./internal/storage/schema ./internal/storage/domain ./internal/storage/domain/db ./internal/storage/dolt -run 'TestMigration0035|TestDefaultInfraTypes|TestDomainDB/TestIssueGetReadyWork/ExcludesDefaultTypes|TestRigIssueIsPersistentButHiddenFromReady'`

- Earlier focused validation also passed:
  `go test ./internal/storage/domain ./internal/storage/domain/db ./internal/storage/dolt -run 'TestDefaultInfraTypes|TestDomainDB/TestIssueGetReadyWork/ExcludesDefaultTypes|TestRigIssueIsPersistentButHiddenFromReady'`

- Broader `make test` was attempted earlier and failed in unrelated/local
  environment-heavy tests recorded on `bds-vwz`.

- `golangci-lint run ./...` was not run because `golangci-lint` was not
  installed in the worker environment.

## Related

- Umbrella post-mortem issue: https://github.com/gastownhall/gastown/issues/4254
- Gastown companion PR: https://github.com/gastownhall/gastown/pull/4251
