### PR TITLE
fix: consolidate 8 critical-bug-sweep branches (5 fixes, 4 duplicate)

### DIFF
--- a/cmd/bd/doctor/fix/metadata.go
+++ b/cmd/bd/doctor/fix/metadata.go
@@ -344,6 +344,7 @@ func reconcileAuthoritativeServerMetadata(cfg *configfile.Config, databases []se
 			schemaCandidates = append(schemaCandidates, db)
 		}
 	}
+	current, hasCurrent := byName[cfg.GetDoltDatabase()]
 
 	if cfg.ProjectID != "" {
 		var matches []serverDatabaseMetadata
@@ -365,14 +366,26 @@ func reconcileAuthoritativeServerMetadata(cfg *configfile.Config, databases []se
 			)
 		}
 		if len(matches) == 1 && cfg.DoltDatabase != matches[0].Name {
+			// Safety guard: when the configured database has its own project_id that
+			// disagrees with metadata.json, and a different database matches the local
+			// project_id, we have conflicting identity signals. Auto-switching databases
+			// here can silently attach this workspace to another project.
+			if hasCurrent && current.HasSchema && current.ProjectID != "" && current.ProjectID != cfg.ProjectID {
+				return false, "", fmt.Errorf(
+					"conflicting project identity: metadata.json project_id %s matches database %q, but configured database %q reports project_id %s",
+					cfg.ProjectID,
+					matches[0].Name,
+					current.Name,
+					current.ProjectID,
+				)
+			}
 			from := cfg.GetDoltDatabase()
 			cfg.DoltDatabase = matches[0].Name
 			return true, fmt.Sprintf("repaired dolt_database: %q -> %q using project_id %s", from, matches[0].Name, cfg.ProjectID), nil
 		}
 	}
 
-	current, ok := byName[cfg.GetDoltDatabase()]
-	if ok && current.HasSchema && current.ProjectID != "" && cfg.ProjectID != current.ProjectID {
+	if hasCurrent && current.HasSchema && current.ProjectID != "" && cfg.ProjectID != current.ProjectID {
 		from := cfg.ProjectID
 		cfg.ProjectID = current.ProjectID
 		if from == "" {

--- a/cmd/bd/doctor/fix/metadata.go
+++ b/cmd/bd/doctor/fix/metadata.go
@@ -394,7 +394,10 @@ func reconcileAuthoritativeServerMetadata(cfg *configfile.Config, databases []se
 		return true, fmt.Sprintf("repaired project_id: %s -> %s from database %q", from, current.ProjectID, current.Name), nil
 	}
 
-	if cfg.ProjectID == "" && len(schemaCandidates) == 1 {
+	// In shared-server mode, a sole schema candidate can belong to a different
+	// workspace. Without a local project_id anchor, auto-adopting that database
+	// can redirect this workspace to another project's data.
+	if cfg.ProjectID == "" && len(schemaCandidates) == 1 && !doltserver.IsSharedServerMode() {
 		candidate := schemaCandidates[0]
 		var repairs []string
 		if cfg.DoltDatabase != candidate.Name {

--- a/cmd/bd/doctor/fix/metadata_test.go
+++ b/cmd/bd/doctor/fix/metadata_test.go
@@ -228,7 +228,7 @@ func TestReconcileAuthoritativeServerMetadata_UsesProjectIDToRepairDatabaseName(
 	}
 
 	changed, msg, err := reconcileAuthoritativeServerMetadata(cfg, []serverDatabaseMetadata{
-		{Name: "wrong_db", HasSchema: true, ProjectID: "other-proj"},
+		{Name: "wrong_db", HasSchema: true, ProjectID: ""},
 		{Name: "canonical_db", HasSchema: true, ProjectID: "proj-123"},
 	})
 	if err != nil {
@@ -242,6 +242,37 @@ func TestReconcileAuthoritativeServerMetadata_UsesProjectIDToRepairDatabaseName(
 	}
 	if !strings.Contains(msg, "canonical_db") || !strings.Contains(msg, "proj-123") {
 		t.Fatalf("unexpected repair message: %q", msg)
+	}
+}
+
+func TestReconcileAuthoritativeServerMetadata_ErrorsOnConflictingIdentitySignals(t *testing.T) {
+	cfg := &configfile.Config{
+		DoltMode:     configfile.DoltModeServer,
+		DoltDatabase: "current_db",
+		ProjectID:    "stale-local-id",
+	}
+
+	changed, msg, err := reconcileAuthoritativeServerMetadata(cfg, []serverDatabaseMetadata{
+		{Name: "current_db", HasSchema: true, ProjectID: "server-authoritative-id"},
+		{Name: "other_db", HasSchema: true, ProjectID: "stale-local-id"},
+	})
+	if err == nil {
+		t.Fatal("expected conflict error when project_id and configured database disagree")
+	}
+	if changed {
+		t.Fatal("changed = true, want false on conflict")
+	}
+	if msg != "" {
+		t.Fatalf("msg = %q, want empty on conflict", msg)
+	}
+	if !strings.Contains(err.Error(), "conflicting project identity") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.DoltDatabase != "current_db" {
+		t.Fatalf("DoltDatabase mutated to %q, want %q", cfg.DoltDatabase, "current_db")
+	}
+	if cfg.ProjectID != "stale-local-id" {
+		t.Fatalf("ProjectID mutated to %q, want %q", cfg.ProjectID, "stale-local-id")
 	}
 }
 

--- a/cmd/bd/doctor/fix/metadata_test.go
+++ b/cmd/bd/doctor/fix/metadata_test.go
@@ -349,6 +349,35 @@ func TestReconcileAuthoritativeServerMetadata_SoleCandidateFallback(t *testing.T
 	}
 }
 
+func TestReconcileAuthoritativeServerMetadata_DoesNotAdoptSoleCandidateInSharedServerMode(t *testing.T) {
+	t.Setenv("BEADS_DOLT_SHARED_SERVER", "1")
+
+	cfg := &configfile.Config{
+		DoltMode:     configfile.DoltModeServer,
+		DoltDatabase: "wrong_db",
+		// No ProjectID; in shared-server mode this must not trigger candidate adoption.
+	}
+
+	changed, msg, err := reconcileAuthoritativeServerMetadata(cfg, []serverDatabaseMetadata{
+		{Name: "only_db", HasSchema: true, ProjectID: "other-project"},
+	})
+	if err != nil {
+		t.Fatalf("reconcileAuthoritativeServerMetadata error: %v", err)
+	}
+	if changed {
+		t.Fatalf("expected no change in shared-server mode, got msg: %q", msg)
+	}
+	if msg != "" {
+		t.Fatalf("expected empty msg when no change, got %q", msg)
+	}
+	if cfg.DoltDatabase != "wrong_db" {
+		t.Fatalf("DoltDatabase = %q, want unchanged %q", cfg.DoltDatabase, "wrong_db")
+	}
+	if cfg.ProjectID != "" {
+		t.Fatalf("ProjectID = %q, want empty", cfg.ProjectID)
+	}
+}
+
 func TestReconcileAuthoritativeServerMetadata_NoChangeWhenAlreadyCorrect(t *testing.T) {
 	cfg := &configfile.Config{
 		DoltMode:     configfile.DoltModeServer,

--- a/internal/linear/client.go
+++ b/internal/linear/client.go
@@ -829,7 +829,11 @@ func (c *Client) createIssueSingleAttempt(ctx context.Context, title, descriptio
 	}
 
 	httpReq.Header.Set("Content-Type", "application/json")
-	httpReq.Header.Set("Authorization", c.APIKey)
+	authValue, err := c.authHeader()
+	if err != nil {
+		return nil, err
+	}
+	httpReq.Header.Set("Authorization", authValue)
 
 	resp, err := c.HTTPClient.Do(httpReq)
 	if err != nil {

--- a/internal/linear/client.go
+++ b/internal/linear/client.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/steveyegge/beads/internal/debug"
@@ -112,6 +113,16 @@ const issuesQuery = `
 	}
 `
 
+type rateLimitState struct {
+	mu        sync.RWMutex
+	remaining int
+	resetsAt  time.Time
+}
+
+func newRateLimitState() *rateLimitState {
+	return &rateLimitState{remaining: -1}
+}
+
 // NewClient creates a new Linear client with the given API key and team ID.
 func NewClient(apiKey, teamID string) *Client {
 	return &Client{
@@ -122,6 +133,7 @@ func NewClient(apiKey, teamID string) *Client {
 		HTTPClient: &http.Client{
 			Timeout: DefaultTimeout,
 		},
+		rateLimitState: newRateLimitState(),
 	}
 }
 
@@ -136,6 +148,7 @@ func NewOAuthClient(oauthConfig OAuthConfig, teamID string) *Client {
 		HTTPClient: &http.Client{
 			Timeout: DefaultTimeout,
 		},
+		rateLimitState: newRateLimitState(),
 	}
 }
 
@@ -151,6 +164,7 @@ func (c *Client) WithEndpoint(endpoint string) *Client {
 		AuthMode:       c.AuthMode,
 		TokenManager:   c.TokenManager,
 		RateLimitFloor: c.RateLimitFloor,
+		rateLimitState: c.rateLimitState,
 	}
 }
 
@@ -166,6 +180,7 @@ func (c *Client) WithHTTPClient(httpClient *http.Client) *Client {
 		AuthMode:       c.AuthMode,
 		TokenManager:   c.TokenManager,
 		RateLimitFloor: c.RateLimitFloor,
+		rateLimitState: c.rateLimitState,
 	}
 }
 
@@ -181,6 +196,7 @@ func (c *Client) WithProjectID(projectID string) *Client {
 		AuthMode:       c.AuthMode,
 		TokenManager:   c.TokenManager,
 		RateLimitFloor: c.RateLimitFloor,
+		rateLimitState: c.rateLimitState,
 	}
 }
 
@@ -210,7 +226,34 @@ func (c *Client) WithRateLimitFloor(floor int) *Client {
 		AuthMode:       c.AuthMode,
 		TokenManager:   c.TokenManager,
 		RateLimitFloor: floor,
+		rateLimitState: c.rateLimitState,
 	}
+}
+
+func (c *Client) circuitBreakerError() *ErrRateLimitExhausted {
+	if c.rateLimitState == nil {
+		return nil
+	}
+	c.rateLimitState.mu.RLock()
+	defer c.rateLimitState.mu.RUnlock()
+	if c.rateLimitState.remaining < 0 || c.rateLimitState.remaining >= c.rateLimitFloor() {
+		return nil
+	}
+	return &ErrRateLimitExhausted{
+		Remaining: c.rateLimitState.remaining,
+		Floor:     c.rateLimitFloor(),
+		ResetsAt:  c.rateLimitState.resetsAt,
+	}
+}
+
+func (c *Client) recordRateLimitHeaders(info RateLimitInfo) {
+	if c.rateLimitState == nil || info.RequestsRemaining < 0 {
+		return
+	}
+	c.rateLimitState.mu.Lock()
+	c.rateLimitState.remaining = info.RequestsRemaining
+	c.rateLimitState.resetsAt = info.RequestsReset
+	c.rateLimitState.mu.Unlock()
 }
 
 // rateLimitFloor returns the effective circuit-breaker floor, using the
@@ -298,6 +341,10 @@ func (c *Client) executeOnce(ctx context.Context, req *GraphQLRequest) (json.Raw
 	var lastErr error
 	var lastStatus int
 	for attempt := 0; attempt <= MaxRetries; attempt++ {
+		if rlErr := c.circuitBreakerError(); rlErr != nil {
+			return nil, lastStatus, rlErr
+		}
+
 		httpReq, err := http.NewRequestWithContext(ctx, "POST", c.Endpoint, bytes.NewReader(body))
 		if err != nil {
 			return nil, 0, fmt.Errorf("failed to create request: %w", err)
@@ -325,15 +372,7 @@ func (c *Client) executeOnce(ctx context.Context, req *GraphQLRequest) (json.Raw
 
 		lastStatus = resp.StatusCode
 		rl := parseRateLimitHeaders(resp.Header)
-
-		// Circuit breaker: stop early when remaining quota is critically low.
-		if rl.RequestsRemaining >= 0 && rl.RequestsRemaining < c.rateLimitFloor() {
-			return nil, lastStatus, &ErrRateLimitExhausted{
-				Remaining: rl.RequestsRemaining,
-				Floor:     c.rateLimitFloor(),
-				ResetsAt:  rl.RequestsReset,
-			}
-		}
+		c.recordRateLimitHeaders(rl)
 
 		if resp.StatusCode == http.StatusTooManyRequests {
 			delay := rl.RetryAfter

--- a/internal/linear/client_test.go
+++ b/internal/linear/client_test.go
@@ -636,8 +636,10 @@ func TestExecute_NoRetryAfterFallsBackToExponential(t *testing.T) {
 	}
 }
 
-func TestExecute_CircuitBreakerTrips(t *testing.T) {
+func TestExecute_CircuitBreakerTripsOnSubsequentRequest(t *testing.T) {
+	requestCount := 0
 	srv := mockServer(t, func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
 		w.Header().Set("X-RateLimit-Requests-Remaining", "50")
 		w.Header().Set("X-RateLimit-Requests-Reset", "2026-06-01T00:00:00Z")
 		w.WriteHeader(http.StatusOK)
@@ -647,7 +649,15 @@ func TestExecute_CircuitBreakerTrips(t *testing.T) {
 	client := NewClient("key", "team").WithEndpoint(srv.Server.URL)
 	ctx := context.Background()
 
-	_, err := client.Execute(ctx, &GraphQLRequest{Query: "{ viewer { id } }"})
+	data, err := client.Execute(ctx, &GraphQLRequest{Query: "{ viewer { id } }"})
+	if err != nil {
+		t.Fatalf("first Execute returned error: %v", err)
+	}
+	if data == nil {
+		t.Fatal("first Execute returned nil data")
+	}
+
+	_, err = client.Execute(ctx, &GraphQLRequest{Query: "{ viewer { id } }"})
 	if err == nil {
 		t.Fatal("expected ErrRateLimitExhausted, got nil")
 	}
@@ -661,6 +671,9 @@ func TestExecute_CircuitBreakerTrips(t *testing.T) {
 	}
 	if rlErr.Floor != DefaultRateLimitFloor {
 		t.Errorf("Floor = %d, want %d", rlErr.Floor, DefaultRateLimitFloor)
+	}
+	if requestCount != 1 {
+		t.Errorf("requestCount = %d, want 1 (second call should trip locally)", requestCount)
 	}
 }
 

--- a/internal/linear/idempotency_test.go
+++ b/internal/linear/idempotency_test.go
@@ -288,6 +288,115 @@ func TestCreateIssueIdempotentEmptyDescription(t *testing.T) {
 	}
 }
 
+func TestCreateIssueIdempotentOAuthAuthHeader(t *testing.T) {
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(oauthTokenResponse{
+			AccessToken: "lin_oauth_test_token",
+			TokenType:   "Bearer",
+			ExpiresIn:   3600,
+			Scope:       "read write",
+		})
+	}))
+	defer tokenServer.Close()
+
+	searchCalls := 0
+	createCalls := 0
+	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer lin_oauth_test_token" {
+			w.WriteHeader(http.StatusUnauthorized)
+			w.Write([]byte(`{"error":"unauthorized"}`))
+			return
+		}
+
+		var req GraphQLRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("failed to decode request: %v", err)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		if strings.Contains(req.Query, "FindByDescription") {
+			searchCalls++
+			resp := map[string]interface{}{
+				"data": map[string]interface{}{
+					"issues": map[string]interface{}{
+						"nodes":    []Issue{},
+						"pageInfo": map[string]interface{}{"hasNextPage": false, "endCursor": ""},
+					},
+				},
+			}
+			json.NewEncoder(w).Encode(resp)
+			return
+		}
+
+		if strings.Contains(req.Query, "issueCreate") {
+			createCalls++
+			input, _ := req.Variables["input"].(map[string]interface{})
+			description, _ := input["description"].(string)
+			resp := map[string]interface{}{
+				"data": map[string]interface{}{
+					"issueCreate": map[string]interface{}{
+						"success": true,
+						"issue": map[string]interface{}{
+							"id":          "oauth-new-uuid",
+							"identifier":  "TEAM-100",
+							"title":       input["title"],
+							"description": description,
+							"url":         "https://linear.app/team/issue/TEAM-100",
+							"priority":    input["priority"],
+							"state": map[string]interface{}{
+								"id":   "state-1",
+								"name": "Todo",
+								"type": "unstarted",
+							},
+							"createdAt": "2026-05-01T10:00:00Z",
+							"updatedAt": "2026-05-01T10:00:00Z",
+						},
+					},
+				},
+			}
+			json.NewEncoder(w).Encode(resp)
+			return
+		}
+
+		t.Fatalf("unexpected query: %s", req.Query)
+	}))
+	defer apiServer.Close()
+
+	client := NewOAuthClient(OAuthConfig{
+		ClientID:     "test-client-id",
+		ClientSecret: "test-secret",
+		TokenURL:     tokenServer.URL,
+	}, "team-1").WithEndpoint(apiServer.URL)
+
+	marker := GenerateIdempotencyMarker("bead-oauth", "dev@test.com", 300)
+	issue, deduped, err := client.CreateIssueIdempotent(
+		context.Background(),
+		"OAuth Issue",
+		"oauth description",
+		1, "", nil,
+		marker,
+	)
+	if err != nil {
+		t.Fatalf("CreateIssueIdempotent failed for OAuth client: %v", err)
+	}
+	if deduped {
+		t.Error("expected deduped=false for fresh OAuth create")
+	}
+	if issue == nil || issue.Identifier != "TEAM-100" {
+		t.Fatalf("expected TEAM-100 issue, got %#v", issue)
+	}
+	if searchCalls != 1 {
+		t.Errorf("search calls = %d, want 1", searchCalls)
+	}
+	if createCalls != 1 {
+		t.Errorf("create calls = %d, want 1", createCalls)
+	}
+	if !strings.Contains(issue.Description, marker) {
+		t.Errorf("issue description should contain marker, got %q", issue.Description)
+	}
+}
+
 // recoveryHandler simulates an ambiguous create failure followed by a
 // successful dedup search. It models the scenario where issueCreate reaches
 // Linear (the issue is created) but the HTTP response is lost, so the next

--- a/internal/linear/tracker.go
+++ b/internal/linear/tracker.go
@@ -503,7 +503,14 @@ func (t *Tracker) BatchPush(ctx context.Context, issues []*types.Issue, forceIDs
 			fetched, lookupErr := routeClient.FetchIssueByIdentifier(ctx, externalID)
 			if lookupErr == nil && fetched != nil {
 				remoteIssue = fetched
-				if PushFieldsEqual(issue, remoteIssue, t.config, teamLabelCache) {
+				// BatchPush receives pre-formatted descriptions from the sync
+				// engine (FormatDescription hook). Clear structured fields before
+				// comparison so PushFieldsEqual does not re-append them.
+				comparableIssue := *issue
+				comparableIssue.AcceptanceCriteria = ""
+				comparableIssue.Design = ""
+				comparableIssue.Notes = ""
+				if PushFieldsEqual(&comparableIssue, remoteIssue, t.config, teamLabelCache) {
 					result.Skipped = append(result.Skipped, issue.ID)
 					continue
 				}

--- a/internal/linear/tracker_test.go
+++ b/internal/linear/tracker_test.go
@@ -157,6 +157,79 @@ func TestBatchPush_SkipsUnchangedIssue(t *testing.T) {
 	}
 }
 
+// TestBatchPush_SkipsUnchangedIssueWithPreformattedDescription verifies that
+// BatchPush skip semantics still work when descriptions were pre-formatted by
+// the engine's FormatDescription hook (BuildLinearDescription). This guards
+// against double-formatting during skip comparison.
+func TestBatchPush_SkipsUnchangedIssueWithPreformattedDescription(t *testing.T) {
+	var updateCalled bool
+	formattedDescription := "Base body\n\n## Acceptance Criteria\nMust pass"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var req GraphQLRequest
+		_ = json.Unmarshal(body, &req)
+		w.Header().Set("Content-Type", "application/json")
+
+		switch {
+		case strings.Contains(req.Query, "TeamStates"):
+			json.NewEncoder(w).Encode(teamStatesResp("team-1", "state-open", "Backlog", "backlog"))
+		case strings.Contains(req.Query, "IssueByIdentifier"):
+			json.NewEncoder(w).Encode(issueByIdentifierResp(
+				"remote-uuid", "TEAM-1", "My Issue", formattedDescription, 0,
+				"state-open", "Backlog", "backlog",
+			))
+		case strings.Contains(req.Query, "issueUpdate"):
+			updateCalled = true
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"data": map[string]interface{}{
+					"issueUpdate": map[string]interface{}{
+						"success": true,
+						"issue":   map[string]interface{}{"id": "remote-uuid", "url": "https://linear.app/team/issue/TEAM-1", "updatedAt": "2026-01-01T00:00:00Z"},
+					},
+				},
+			})
+		}
+	}))
+	defer server.Close()
+
+	cfg := DefaultMappingConfig()
+	cfg.ExplicitStateMap = map[string]string{"backlog": "open"}
+
+	extRef := "https://linear.app/team/issue/TEAM-1"
+	local := &types.Issue{
+		ID:                 "local-1",
+		Title:              "My Issue",
+		Description:        formattedDescription,
+		AcceptanceCriteria: "Must pass",
+		Status:             types.StatusOpen,
+		Priority:           4,
+		ExternalRef:        &extRef,
+	}
+
+	tr := &Tracker{
+		teamIDs: []string{"team-1"},
+		clients: map[string]*Client{
+			"team-1": NewClient("key", "team-1").WithEndpoint(server.URL),
+		},
+		config: cfg,
+	}
+
+	result, err := tr.BatchPush(context.Background(), []*types.Issue{local}, nil)
+	if err != nil {
+		t.Fatalf("BatchPush: %v", err)
+	}
+	if updateCalled {
+		t.Error("UpdateIssue was called for an unchanged pre-formatted issue; expected it to be skipped")
+	}
+	if len(result.Skipped) != 1 || result.Skipped[0] != "local-1" {
+		t.Errorf("Skipped = %v, want [local-1]", result.Skipped)
+	}
+	if len(result.Updated) != 0 {
+		t.Errorf("Updated = %v, want []", result.Updated)
+	}
+}
+
 // TestBatchPush_ForceBypassesSkip verifies that an issue in forceIDs is
 // updated even when PushFieldsEqual would normally skip it.
 func TestBatchPush_ForceBypassesSkip(t *testing.T) {

--- a/internal/linear/tracker_test.go
+++ b/internal/linear/tracker_test.go
@@ -174,6 +174,8 @@ func TestBatchPush_SkipsUnchangedIssueWithPreformattedDescription(t *testing.T) 
 		switch {
 		case strings.Contains(req.Query, "TeamStates"):
 			json.NewEncoder(w).Encode(teamStatesResp("team-1", "state-open", "Backlog", "backlog"))
+		case strings.Contains(req.Query, "TeamLabels"):
+			json.NewEncoder(w).Encode(teamLabelsEmptyResp("team-1"))
 		case strings.Contains(req.Query, "IssueByIdentifier"):
 			json.NewEncoder(w).Encode(issueByIdentifierResp(
 				"remote-uuid", "TEAM-1", "My Issue", formattedDescription, 0,

--- a/internal/linear/types.go
+++ b/internal/linear/types.go
@@ -63,6 +63,7 @@ type Client struct {
 	AuthMode       AuthMode
 	TokenManager   *OAuthTokenManager
 	RateLimitFloor int // Minimum remaining quota before circuit breaker trips (0 = use DefaultRateLimitFloor)
+	rateLimitState *rateLimitState
 }
 
 // RateLimitInfo captures rate-limit state from Linear API response headers.


### PR DESCRIPTION
## Summary

The daily "critical bug sweep" automation repeatedly discovered and fixed the same bugs across 8 separate `cursor/critical-bug-investigation-*` branches without landing any of them, spawning duplicates each run.

This PR consolidates all 8 branches:

### Duplicate fixes (4 branches → 1 cherry-pick)
- **Linear OAuth authHeader()** — `createIssueSingleAttempt` used `c.APIKey` directly instead of `c.authHeader()`, so OAuth client-credentials setups sent an empty Authorization header. Picked branch `672f` (most comprehensive regression test using `NewOAuthClient` with a real token server). Deleted branches `30a4`, `92ee`, `df0e`.

### Distinct fixes (4 branches → 4 cherry-picks)
- **Rate-limit circuit-breaker false-positive** (`5e8b`) — The breaker tripped on the current request that revealed low remaining quota, discarding a successful response. Now records state and trips on the *next* call instead. Adds persistent `rateLimitState` struct with mutex.
- **BatchPush double-format skip mismatch** (`7e25`) — Pre-formatted descriptions from `FormatDescription` hook caused `PushFieldsEqual` to see a mismatch (structured fields still populated on local issue). Clears `AcceptanceCriteria`/`Design`/`Notes` before comparison.
- **bd doctor conflicting project_id repoint** (`1a3d`) — When the configured database has its own `project_id` that disagrees with `metadata.json`, and a different database matches the local `project_id`, doctor now errors instead of silently switching databases.
- **Shared-server sole-candidate auto-adopt** (`cef0`) — Gates sole-candidate database adoption on `!doltserver.IsSharedServerMode()` to prevent cross-project data attachment when no `project_id` anchor exists.

All 8 branches have been deleted from the fork remote.

## Test plan

- [x] `go test ./internal/linear/... -count=1` — all pass (OAuth, rate-limit breaker, BatchPush)
- [x] `go test ./cmd/bd/doctor/fix/... -count=1 -run TestReconcile` — all 8 reconciliation tests pass
- [x] Each fix includes its own regression test
- [x] No conflicts between cherry-picks


Made with [Cursor](https://cursor.com)