### PR TITLE
fix(stealth): keep --stealth out of the tracked .gitignore

### DIFF
--- a/cmd/bd/doctor.go
+++ b/cmd/bd/doctor.go
@@ -681,9 +681,14 @@ func runDiagnostics(path string) doctorResult {
 	result.Checks = append(result.Checks, gitignoreCheck)
 	// Don't fail overall check for gitignore, just warn
 
-	// Check 14a: Project-root .gitignore has Dolt exclusion patterns (GH#2034)
-	projectGitignoreCheck := convertWithCategory(doctor.CheckProjectGitignore(path), doctor.CategoryGit)
-	result.Checks = append(result.Checks, projectGitignoreCheck)
+	// Check 14a: Project-root Dolt exclusion patterns (GH#2034). In stealth mode these live in
+	// .git/info/exclude, so check that location instead to avoid recreating .gitignore.
+	if isStealthRepo(path) {
+		result.Checks = append(result.Checks, convertWithCategory(checkProjectExcludeStealth(path), doctor.CategoryGit))
+	} else {
+		projectGitignoreCheck := convertWithCategory(doctor.CheckProjectGitignore(path), doctor.CategoryGit)
+		result.Checks = append(result.Checks, projectGitignoreCheck)
+	}
 	// Don't fail overall check for project gitignore, just warn
 
 	// Check 14b: redirect file tracking (worktree redirect files shouldn't be committed)

--- a/cmd/bd/doctor_fix.go
+++ b/cmd/bd/doctor_fix.go
@@ -255,10 +255,13 @@ func applyFixList(path string, fixes []doctorCheck) {
 		case "Gitignore":
 			err = doctor.FixGitignore(path)
 		case "Project Gitignore":
-			// Stealth repos must not get a tracked .gitignore; route the patterns into
-			// .git/info/exclude instead (matches bd init --stealth).
+			// Stealth / no-git-ops repos must not get a tracked .gitignore; route the patterns into
+			// .git/info/exclude instead (matches bd init --stealth) and strip any beads section a
+			// previous run leaked into the tracked .gitignore so stealth leaves no trace.
 			if isStealthRepo(path) {
-				err = addProjectPatternsToGitExclude(path, doctor.ProjectGitignorePatterns, false)
+				if err = addProjectPatternsToGitExclude(path, doctor.ProjectGitignorePatterns, false); err == nil {
+					_, err = removeBeadsProjectGitignoreSection(path)
+				}
 			} else {
 				err = doctor.FixProjectGitignore(path)
 			}

--- a/cmd/bd/doctor_fix.go
+++ b/cmd/bd/doctor_fix.go
@@ -255,7 +255,13 @@ func applyFixList(path string, fixes []doctorCheck) {
 		case "Gitignore":
 			err = doctor.FixGitignore(path)
 		case "Project Gitignore":
-			err = doctor.FixProjectGitignore(path)
+			// Stealth repos must not get a tracked .gitignore; route the patterns into
+			// .git/info/exclude instead (matches bd init --stealth).
+			if isStealthRepo(path) {
+				err = addProjectPatternsToGitExclude(path, doctor.ProjectGitignorePatterns, false)
+			} else {
+				err = doctor.FixProjectGitignore(path)
+			}
 		case "Redirect Tracking":
 			err = doctor.FixRedirectTracking(path)
 		case "Last-Touched Tracking":

--- a/cmd/bd/init.go
+++ b/cmd/bd/init.go
@@ -659,7 +659,14 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 			cwdAbs, _ := filepath.Abs(cwd)
 			beadsDirIsLocal := strings.HasPrefix(beadsDirAbs, filepath.Clean(cwdAbs)+string(filepath.Separator))
 			if beadsDirIsLocal {
-				if err := doctor.EnsureProjectGitignore(cwd); err != nil {
+				if stealth {
+					// Stealth mode: route Dolt-file ignore patterns into .git/info/exclude instead
+					// of a tracked .gitignore so collaborators never see beads-related changes.
+					if err := addProjectPatternsToGitExclude(cwd, doctor.ProjectGitignorePatterns, !quiet); err != nil {
+						fmt.Fprintf(os.Stderr, "Warning: failed to update git exclude: %v\n", err)
+						// Non-fatal - continue anyway
+					}
+				} else if err := doctor.EnsureProjectGitignore(cwd); err != nil {
 					fmt.Fprintf(os.Stderr, "Warning: failed to update project .gitignore: %v\n", err)
 					// Non-fatal - continue anyway
 				}

--- a/cmd/bd/init.go
+++ b/cmd/bd/init.go
@@ -666,6 +666,14 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 						fmt.Fprintf(os.Stderr, "Warning: failed to update git exclude: %v\n", err)
 						// Non-fatal - continue anyway
 					}
+					// bd init --stealth is safe to re-run: clean up any beads section an earlier
+					// (non-stealth or pre-fix) run leaked into the tracked .gitignore.
+					if removed, err := removeBeadsProjectGitignoreSection(cwd); err != nil {
+						fmt.Fprintf(os.Stderr, "Warning: failed to clean project .gitignore: %v\n", err)
+						// Non-fatal - continue anyway
+					} else if removed && !quiet {
+						fmt.Printf("  %s Removed leaked beads section from tracked .gitignore\n", ui.RenderPass("✓"))
+					}
 				} else if err := doctor.EnsureProjectGitignore(cwd); err != nil {
 					fmt.Fprintf(os.Stderr, "Warning: failed to update project .gitignore: %v\n", err)
 					// Non-fatal - continue anyway

--- a/cmd/bd/init_embedded_test.go
+++ b/cmd/bd/init_embedded_test.go
@@ -884,12 +884,116 @@ func TestEmbeddedInit(t *testing.T) {
 	})
 
 	t.Run("stealth", func(t *testing.T) {
-		dir, _, _ := bdInit(t, bd, "--prefix", "st", "--stealth")
+		dir, beadsDir, _ := bdInit(t, bd, "--prefix", "st", "--stealth")
 		requireNoFile(t, filepath.Join(dir, "AGENTS.md"))
 		requireNoFile(t, filepath.Join(dir, "CLAUDE.md"))
 		requireNoFile(t, filepath.Join(dir, ".claude"))
 		requireNoFile(t, filepath.Join(dir, ".agents"))
 		requireNoFile(t, filepath.Join(dir, ".codex"))
+
+		// Stealth must stay invisible: it should create .beads/ but route everything else into
+		// .git/info/exclude so the database lives there without git seeing it.
+		requireFile(t, beadsDir)
+		excludeContent, err := os.ReadFile(filepath.Join(dir, ".git", "info", "exclude"))
+		if err != nil {
+			t.Fatalf("failed to read .git/info/exclude: %v", err)
+		}
+		for _, want := range []string{".beads/", ".dolt/", "*.db"} {
+			if !strings.Contains(string(excludeContent), want) {
+				t.Errorf(".git/info/exclude missing %q:\n%s", want, excludeContent)
+			}
+		}
+	})
+
+	// Regression: bd init --stealth must not touch any git-visible files. Previously it
+	// created/modified the tracked project-root .gitignore via doctor.EnsureProjectGitignore, which
+	// showed up in `git status` and defeated stealth. Everything beads adds must be excluded
+	// (.beads/) or live in .git/info/exclude, leaving the working tree clean from git's view.
+	t.Run("stealth_leaves_worktree_clean", func(t *testing.T) {
+		dir := t.TempDir()
+		initGitRepoAt(t, dir)
+
+		// Commit a baseline so the repo has a clean, non-empty starting state.
+		gitignorePath := filepath.Join(dir, ".gitignore")
+		if err := os.WriteFile(gitignorePath, []byte("node_modules/\n"), 0644); err != nil {
+			t.Fatalf("seed .gitignore: %v", err)
+		}
+		for _, args := range [][]string{
+			{"add", "-A"},
+			{"commit", "-m", "baseline"},
+		} {
+			cmd := exec.Command("git", args...)
+			cmd.Dir = dir
+			if out, err := cmd.CombinedOutput(); err != nil {
+				t.Fatalf("git %s failed: %v\n%s", args[0], err, out)
+			}
+		}
+
+		runBDInit(t, bd, dir, "--prefix", "stc", "--stealth")
+
+		// git status --porcelain must be empty: stealth touched no visible files.
+		cmd := exec.Command("git", "-c", "core.hooksPath=", "status", "--porcelain")
+		cmd.Dir = dir
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("git status failed: %v\n%s", err, out)
+		}
+		if strings.TrimSpace(string(out)) != "" {
+			t.Errorf("bd init --stealth left git-visible changes (should be invisible):\n%s", out)
+		}
+
+		// And the seeded .gitignore must be byte-for-byte unchanged.
+		got, err := os.ReadFile(gitignorePath)
+		if err != nil {
+			t.Fatalf("read .gitignore: %v", err)
+		}
+		if string(got) != "node_modules/\n" {
+			t.Errorf("stealth modified project .gitignore:\ngot: %q", string(got))
+		}
+	})
+
+	// Regression: bd doctor --fix on a stealth repo must stay invisible too. Previously the
+	// "Project Gitignore" fix called FixProjectGitignore unconditionally and re-created the tracked
+	// .gitignore that stealth init deliberately avoided.
+	t.Run("stealth_doctor_fix_keeps_worktree_clean", func(t *testing.T) {
+		dir := t.TempDir()
+		initGitRepoAt(t, dir)
+
+		gitignorePath := filepath.Join(dir, ".gitignore")
+		if err := os.WriteFile(gitignorePath, []byte("node_modules/\n"), 0644); err != nil {
+			t.Fatalf("seed .gitignore: %v", err)
+		}
+		for _, args := range [][]string{{"add", "-A"}, {"commit", "-m", "baseline"}} {
+			cmd := exec.Command("git", args...)
+			cmd.Dir = dir
+			if out, err := cmd.CombinedOutput(); err != nil {
+				t.Fatalf("git %s failed: %v\n%s", args[0], err, out)
+			}
+		}
+
+		runBDInit(t, bd, dir, "--prefix", "sdf", "--stealth")
+
+		// bd doctor --fix may exit non-zero for unrelated checks; we only care that it does not
+		// introduce git-visible changes on a stealth repo.
+		fixCmd := exec.Command(bd, "doctor", "--fix", "--yes")
+		fixCmd.Dir = dir
+		fixCmd.Env = bdEnv(dir)
+		if out, err := fixCmd.CombinedOutput(); err != nil {
+			t.Logf("bd doctor --fix exited non-zero (tolerated): %v\n%s", err, out)
+		}
+
+		statusCmd := exec.Command("git", "-c", "core.hooksPath=", "status", "--porcelain")
+		statusCmd.Dir = dir
+		out, err := statusCmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("git status failed: %v\n%s", err, out)
+		}
+		if strings.TrimSpace(string(out)) != "" {
+			t.Errorf("bd doctor --fix left git-visible changes on a stealth repo:\n%s", out)
+		}
+		if got, _ := os.ReadFile(gitignorePath); string(got) != "node_modules/\n" {
+			t.Errorf("bd doctor --fix modified project .gitignore on a stealth repo:\ngot: %q", string(got))
+		}
 	})
 
 	t.Run("force_reinit", func(t *testing.T) {

--- a/cmd/bd/init_stealth.go
+++ b/cmd/bd/init_stealth.go
@@ -8,6 +8,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/steveyegge/beads/cmd/bd/doctor"
+	"github.com/steveyegge/beads/internal/config"
 	"github.com/steveyegge/beads/internal/ui"
 )
 
@@ -110,6 +112,134 @@ func setupGitExclude(verbose bool) error {
 	}
 
 	return nil
+}
+
+// resolveGitExcludePath returns the path to .git/info/exclude for repoPath, using --git-common-dir
+// so worktrees resolve to the main repo's exclude file (GH#1053). An empty repoPath resolves
+// against the current directory.
+func resolveGitExcludePath(repoPath string) (string, error) {
+	args := make([]string, 0, 3)
+	if repoPath != "" {
+		args = append(args, "-C", repoPath)
+	}
+	args = append(args, "rev-parse", "--git-common-dir")
+	out, err := exec.Command("git", args...).Output()
+	if err != nil {
+		return "", fmt.Errorf("not a git repository")
+	}
+	gitDir := strings.TrimSpace(string(out))
+	// git prints --git-common-dir relative to its working directory (repoPath when -C is used), so
+	// anchor relative results back to repoPath.
+	if !filepath.IsAbs(gitDir) {
+		base := repoPath
+		if base == "" {
+			base = "."
+		}
+		gitDir = filepath.Join(base, gitDir)
+	}
+	return filepath.Join(gitDir, "info", "exclude"), nil
+}
+
+// addProjectPatternsToGitExclude appends project-root ignore patterns (.dolt/, *.db, etc.) to
+// .git/info/exclude rather than a tracked .gitignore. Stealth mode uses this so beads never creates
+// or modifies a visible .gitignore that would expose its presence to repo collaborators. repoPath
+// is the repository root ("" resolves against the current directory).
+func addProjectPatternsToGitExclude(repoPath string, patterns []string, verbose bool) error {
+	excludePath, err := resolveGitExcludePath(repoPath)
+	if err != nil {
+		return err
+	}
+
+	if err := os.MkdirAll(filepath.Dir(excludePath), 0755); err != nil {
+		return fmt.Errorf("failed to create git info directory: %w", err)
+	}
+
+	var existingContent string
+	// #nosec G304 - git config path
+	if content, err := os.ReadFile(excludePath); err == nil {
+		existingContent = string(content)
+	}
+
+	var toAdd []string
+	for _, p := range patterns {
+		// Exact line match avoids false positives (e.g. ".beads/issues.jsonl" matching ".beads/").
+		if !containsExactPattern(existingContent, p) {
+			toAdd = append(toAdd, p)
+		}
+	}
+	if len(toAdd) == 0 {
+		if verbose {
+			fmt.Printf("Git exclude already has Dolt file patterns\n")
+		}
+		return nil
+	}
+
+	newContent := existingContent
+	if !strings.HasSuffix(newContent, "\n") && len(newContent) > 0 {
+		newContent += "\n"
+	}
+	newContent += "\n# Beads stealth mode: Dolt files (added by bd init --stealth)\n"
+	for _, p := range toAdd {
+		newContent += p + "\n"
+	}
+
+	// #nosec G306 - config file needs 0644
+	if err := os.WriteFile(excludePath, []byte(newContent), 0644); err != nil {
+		return fmt.Errorf("failed to write git exclude file: %w", err)
+	}
+	if verbose {
+		fmt.Printf("Configured git exclude for Dolt files: %s\n", excludePath)
+	}
+	return nil
+}
+
+// isStealthRepo reports whether the beads workspace at repoPath was set up in stealth mode. Stealth
+// init persists no-git-ops: true (the same signal bd prime keys off), so beads must keep its
+// footprint out of tracked files.
+func isStealthRepo(repoPath string) bool {
+	beadsDir := doctor.ResolveBeadsDirForRepo(repoPath)
+	return config.GetStringFromDir(beadsDir, "no-git-ops") == "true"
+}
+
+// checkProjectExcludeStealth is the stealth-mode counterpart to doctor.CheckProjectGitignore: it
+// verifies the project-root ignore patterns live in .git/info/exclude instead of a tracked
+// .gitignore. Reusing the "Project Gitignore" name keeps the --fix dispatch and ordering stable.
+func checkProjectExcludeStealth(repoPath string) doctor.DoctorCheck {
+	excludePath, err := resolveGitExcludePath(repoPath)
+	if err != nil {
+		return doctor.DoctorCheck{
+			Name:    "Project Gitignore",
+			Status:  doctor.StatusOK,
+			Message: "N/A (not a git repository)",
+		}
+	}
+
+	var content string
+	// #nosec G304 - git config path
+	if data, err := os.ReadFile(excludePath); err == nil {
+		content = string(data)
+	}
+
+	var missing []string
+	for _, p := range doctor.ProjectGitignorePatterns {
+		if !containsExactPattern(content, p) {
+			missing = append(missing, p)
+		}
+	}
+	if len(missing) > 0 {
+		return doctor.DoctorCheck{
+			Name:    "Project Gitignore",
+			Status:  doctor.StatusWarning,
+			Message: "Stealth mode: .git/info/exclude missing Dolt exclusion patterns",
+			Detail:  "Missing: " + strings.Join(missing, ", "),
+			Fix:     "Run: bd doctor --fix",
+		}
+	}
+	return doctor.DoctorCheck{
+		Name:    "Project Gitignore",
+		Status:  doctor.StatusOK,
+		Message: "Dolt and credential files excluded via .git/info/exclude (stealth)",
+	}
 }
 
 // setupForkExclude configures .git/info/exclude for fork workflows (GH#742)

--- a/cmd/bd/init_stealth.go
+++ b/cmd/bd/init_stealth.go
@@ -46,71 +46,19 @@ func setupStealthMode(verbose bool) error {
 // This is the correct approach for per-repository user-specific ignores (GitHub #704).
 // Unlike global gitignore, patterns here are relative to the repo root.
 func setupGitExclude(verbose bool) error {
-	// Find the common .git directory (handles worktrees correctly - GH#1053)
-	// Use --git-common-dir to get the main repo's .git, not the worktree's .git/worktrees/<name>
-	gitDir, err := exec.Command("git", "rev-parse", "--git-common-dir").Output()
+	added, excludePath, err := addExcludePatterns("",
+		"# Beads stealth mode (added by bd init --stealth)",
+		[]string{".beads/", ".claude/settings.local.json"})
 	if err != nil {
-		return fmt.Errorf("not a git repository")
+		return err
 	}
-	gitDirPath := strings.TrimSpace(string(gitDir))
-
-	// Path to the exclude file
-	excludePath := filepath.Join(gitDirPath, "info", "exclude")
-
-	// Ensure the info directory exists
-	infoDir := filepath.Join(gitDirPath, "info")
-	if err := os.MkdirAll(infoDir, 0755); err != nil {
-		return fmt.Errorf("failed to create git info directory: %w", err)
-	}
-
-	// Read existing exclude file if it exists
-	var existingContent string
-	// #nosec G304 - git config path
-	if content, err := os.ReadFile(excludePath); err == nil {
-		existingContent = string(content)
-	}
-
-	// Use relative patterns (these work correctly in .git/info/exclude)
-	beadsPattern := ".beads/"
-	claudePattern := ".claude/settings.local.json"
-
-	hasBeads := strings.Contains(existingContent, beadsPattern)
-	hasClaude := strings.Contains(existingContent, claudePattern)
-
-	if hasBeads && hasClaude {
-		if verbose {
-			fmt.Printf("Git exclude already configured for stealth mode\n")
-		}
-		return nil
-	}
-
-	// Append missing patterns
-	newContent := existingContent
-	if !strings.HasSuffix(newContent, "\n") && len(newContent) > 0 {
-		newContent += "\n"
-	}
-
-	if !hasBeads || !hasClaude {
-		newContent += "\n# Beads stealth mode (added by bd init --stealth)\n"
-	}
-
-	if !hasBeads {
-		newContent += beadsPattern + "\n"
-	}
-	if !hasClaude {
-		newContent += claudePattern + "\n"
-	}
-
-	// Write the updated exclude file
-	// #nosec G306 - config file needs 0644
-	if err := os.WriteFile(excludePath, []byte(newContent), 0644); err != nil {
-		return fmt.Errorf("failed to write git exclude file: %w", err)
-	}
-
 	if verbose {
-		fmt.Printf("Configured git exclude for stealth mode: %s\n", excludePath)
+		if len(added) == 0 {
+			fmt.Printf("Git exclude already configured for stealth mode\n")
+		} else {
+			fmt.Printf("Configured git exclude for stealth mode: %s\n", excludePath)
+		}
 	}
-
 	return nil
 }
 
@@ -123,6 +71,8 @@ func resolveGitExcludePath(repoPath string) (string, error) {
 		args = append(args, "-C", repoPath)
 	}
 	args = append(args, "rev-parse", "--git-common-dir")
+	// #nosec G702 - fixed "git" command; args are constant subcommands plus an internal repoPath,
+	// never attacker-controlled input.
 	out, err := exec.Command("git", args...).Output()
 	if err != nil {
 		return "", fmt.Errorf("not a git repository")
@@ -140,65 +90,159 @@ func resolveGitExcludePath(repoPath string) (string, error) {
 	return filepath.Join(gitDir, "info", "exclude"), nil
 }
 
-// addProjectPatternsToGitExclude appends project-root ignore patterns (.dolt/, *.db, etc.) to
-// .git/info/exclude rather than a tracked .gitignore. Stealth mode uses this so beads never creates
-// or modifies a visible .gitignore that would expose its presence to repo collaborators. repoPath
-// is the repository root ("" resolves against the current directory).
-func addProjectPatternsToGitExclude(repoPath string, patterns []string, verbose bool) error {
-	excludePath, err := resolveGitExcludePath(repoPath)
+// addExcludePatterns ensures each pattern exists as an exact line in repoPath's .git/info/exclude,
+// appending any missing ones under header. It returns the patterns it actually added (empty when all
+// were already present) and the resolved exclude path. repoPath "" resolves against the current
+// directory. This is the shared core for stealth, fork, and project-pattern exclude setup.
+func addExcludePatterns(repoPath, header string, patterns []string) (added []string, excludePath string, err error) {
+	excludePath, err = resolveGitExcludePath(repoPath)
 	if err != nil {
-		return err
+		return nil, "", err
 	}
 
-	if err := os.MkdirAll(filepath.Dir(excludePath), 0755); err != nil {
-		return fmt.Errorf("failed to create git info directory: %w", err)
+	if err = os.MkdirAll(filepath.Dir(excludePath), 0755); err != nil {
+		return nil, "", fmt.Errorf("failed to create git info directory: %w", err)
 	}
 
-	var existingContent string
+	var existing string
 	// #nosec G304 - git config path
-	if content, err := os.ReadFile(excludePath); err == nil {
-		existingContent = string(content)
+	if content, rerr := os.ReadFile(excludePath); rerr == nil {
+		existing = string(content)
 	}
 
-	var toAdd []string
 	for _, p := range patterns {
 		// Exact line match avoids false positives (e.g. ".beads/issues.jsonl" matching ".beads/").
-		if !containsExactPattern(existingContent, p) {
-			toAdd = append(toAdd, p)
+		if !containsExactPattern(existing, p) {
+			added = append(added, p)
 		}
 	}
-	if len(toAdd) == 0 {
-		if verbose {
-			fmt.Printf("Git exclude already has Dolt file patterns\n")
-		}
-		return nil
+	if len(added) == 0 {
+		return nil, excludePath, nil
 	}
 
-	newContent := existingContent
-	if !strings.HasSuffix(newContent, "\n") && len(newContent) > 0 {
+	newContent := existing
+	if len(newContent) > 0 && !strings.HasSuffix(newContent, "\n") {
 		newContent += "\n"
 	}
-	newContent += "\n# Beads stealth mode: Dolt files (added by bd init --stealth)\n"
-	for _, p := range toAdd {
+	newContent += "\n" + header + "\n"
+	for _, p := range added {
 		newContent += p + "\n"
 	}
 
 	// #nosec G306 - config file needs 0644
-	if err := os.WriteFile(excludePath, []byte(newContent), 0644); err != nil {
-		return fmt.Errorf("failed to write git exclude file: %w", err)
+	if err = os.WriteFile(excludePath, []byte(newContent), 0644); err != nil {
+		return nil, excludePath, fmt.Errorf("failed to write git exclude file: %w", err)
+	}
+	return added, excludePath, nil
+}
+
+// projectExcludeHeader labels the project-root ignore patterns (.dolt/, *.db, …) that beads routes
+// into .git/info/exclude instead of a tracked .gitignore when git ops are disabled. It is kept
+// neutral (not "added by bd init --stealth") because both bd init --stealth and bd doctor --fix
+// write it.
+const projectExcludeHeader = "# Beads: Dolt files kept local via .git/info/exclude (stealth / no-git-ops)"
+
+// addProjectPatternsToGitExclude appends project-root ignore patterns (.dolt/, *.db, etc.) to
+// .git/info/exclude rather than a tracked .gitignore. Stealth / no-git-ops repos use this so beads
+// never creates or modifies a visible .gitignore that would expose its presence to repo
+// collaborators. repoPath is the repository root ("" resolves against the current directory).
+func addProjectPatternsToGitExclude(repoPath string, patterns []string, verbose bool) error {
+	added, excludePath, err := addExcludePatterns(repoPath, projectExcludeHeader, patterns)
+	if err != nil {
+		return err
 	}
 	if verbose {
-		fmt.Printf("Configured git exclude for Dolt files: %s\n", excludePath)
+		if len(added) == 0 {
+			fmt.Printf("Git exclude already has Dolt file patterns\n")
+		} else {
+			fmt.Printf("Configured git exclude for Dolt files: %s\n", excludePath)
+		}
 	}
 	return nil
 }
 
-// isStealthRepo reports whether the beads workspace at repoPath was set up in stealth mode. Stealth
-// init persists no-git-ops: true (the same signal bd prime keys off), so beads must keep its
-// footprint out of tracked files.
+// removeBeadsProjectGitignoreSection strips the bd-managed section from the tracked project-root
+// .gitignore at repoPath, reversing doctor.EnsureProjectGitignore. It removes only the header beads
+// writes (doctor.ProjectGitignoreHeader) plus the Dolt pattern lines beads added directly beneath
+// it, so unrelated user patterns are preserved. If beads was the .gitignore's only content the file
+// is removed entirely, restoring true stealth. Returns true when it changed (or removed) the file;
+// a repo with no beads section (or no .gitignore) is left untouched.
+func removeBeadsProjectGitignoreSection(repoPath string) (bool, error) {
+	gitignorePath := filepath.Join(repoPath, ".gitignore")
+	// #nosec G304 - path is the repo-root .gitignore
+	content, err := os.ReadFile(gitignorePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("failed to read .gitignore: %w", err)
+	}
+
+	managed := make(map[string]bool, len(doctor.ProjectGitignorePatterns))
+	for _, p := range doctor.ProjectGitignorePatterns {
+		managed[p] = true
+	}
+
+	lines := strings.Split(string(content), "\n")
+	out := make([]string, 0, len(lines))
+	changed := false
+	for i := 0; i < len(lines); i++ {
+		if strings.TrimSpace(lines[i]) == doctor.ProjectGitignoreHeader {
+			changed = true
+			// Drop the blank separator beads writes before the header, if we just emitted one.
+			if n := len(out); n > 0 && strings.TrimSpace(out[n-1]) == "" {
+				out = out[:n-1]
+			}
+			// Skip the header and the bd-managed pattern lines directly beneath it.
+			i++
+			for i < len(lines) && managed[strings.TrimSpace(lines[i])] {
+				i++
+			}
+			i-- // compensate for the loop's i++
+			continue
+		}
+		out = append(out, lines[i])
+	}
+	if !changed {
+		return false, nil
+	}
+
+	newContent := strings.Join(out, "\n")
+	if strings.TrimSpace(newContent) == "" {
+		// beads was the only reason this .gitignore existed — remove it for true stealth.
+		if err := os.Remove(gitignorePath); err != nil {
+			return false, fmt.Errorf("failed to remove emptied .gitignore: %w", err)
+		}
+		return true, nil
+	}
+
+	// #nosec G306 - gitignore needs to be readable by git and collaborators
+	if err := os.WriteFile(gitignorePath, []byte(newContent), 0644); err != nil {
+		return false, fmt.Errorf("failed to write .gitignore: %w", err)
+	}
+	return true, nil
+}
+
+// isStealthRepo reports whether beads must keep its footprint out of tracked git files for the
+// workspace at repoPath. It keys off the persisted no-git-ops flag — the same signal bd prime uses
+// for the stealth session-close protocol (GH#593). bd init --stealth sets it, and a user may also
+// set it directly; either way beads routes ignores into .git/info/exclude rather than a tracked
+// .gitignore.
 func isStealthRepo(repoPath string) bool {
 	beadsDir := doctor.ResolveBeadsDirForRepo(repoPath)
 	return config.GetStringFromDir(beadsDir, "no-git-ops") == "true"
+}
+
+// trackedGitignoreHasBeadsSection reports whether the tracked project-root .gitignore at repoPath
+// still carries the bd-managed section header — i.e. a previous run leaked Dolt patterns into a
+// git-visible file. Used by the stealth doctor check to flag the leak for --fix to clean up.
+func trackedGitignoreHasBeadsSection(repoPath string) bool {
+	// #nosec G304 - path is the repo-root .gitignore
+	content, err := os.ReadFile(filepath.Join(repoPath, ".gitignore"))
+	if err != nil {
+		return false
+	}
+	return containsExactPattern(string(content), doctor.ProjectGitignoreHeader)
 }
 
 // checkProjectExcludeStealth is the stealth-mode counterpart to doctor.CheckProjectGitignore: it
@@ -226,12 +270,25 @@ func checkProjectExcludeStealth(repoPath string) doctor.DoctorCheck {
 			missing = append(missing, p)
 		}
 	}
-	if len(missing) > 0 {
+
+	leaked := trackedGitignoreHasBeadsSection(repoPath)
+
+	if len(missing) > 0 || leaked {
+		var details []string
+		message := "Stealth mode: .git/info/exclude missing Dolt exclusion patterns"
+		if len(missing) > 0 {
+			details = append(details, "Missing from .git/info/exclude: "+strings.Join(missing, ", "))
+		}
+		if leaked {
+			// A previous run leaked the patterns into the tracked .gitignore; --fix moves them out.
+			message = "Stealth mode: Dolt patterns are exposed in the tracked .gitignore"
+			details = append(details, "Tracked .gitignore contains the beads section; bd doctor --fix will move it into .git/info/exclude")
+		}
 		return doctor.DoctorCheck{
 			Name:    "Project Gitignore",
 			Status:  doctor.StatusWarning,
-			Message: "Stealth mode: .git/info/exclude missing Dolt exclusion patterns",
-			Detail:  "Missing: " + strings.Join(missing, ", "),
+			Message: message,
+			Detail:  strings.Join(details, "; "),
 			Fix:     "Run: bd doctor --fix",
 		}
 	}
@@ -247,65 +304,22 @@ func checkProjectExcludeStealth(repoPath string) doctor.DoctorCheck {
 // This is separate from stealth mode - fork protection is specifically about
 // preventing beads/Claude files from appearing in upstream PRs.
 func setupForkExclude(verbose bool) error {
-	// Use --git-common-dir to get main repo's .git, not worktree's (GH#1053)
-	gitDir, err := exec.Command("git", "rev-parse", "--git-common-dir").Output()
+	added, _, err := addExcludePatterns("",
+		"# Beads fork protection (bd init)",
+		[]string{".beads/", "**/RECOVERY*.md", "**/SESSION*.md"})
 	if err != nil {
-		return fmt.Errorf("not a git repository")
+		return err
 	}
-	gitDirPath := strings.TrimSpace(string(gitDir))
-	excludePath := filepath.Join(gitDirPath, "info", "exclude")
-
-	// Ensure info directory exists
-	if err := os.MkdirAll(filepath.Join(gitDirPath, "info"), 0755); err != nil {
-		return fmt.Errorf("failed to create git info directory: %w", err)
-	}
-
-	// Read existing content
-	var existingContent string
-	// #nosec G304 - git config path
-	if content, err := os.ReadFile(excludePath); err == nil {
-		existingContent = string(content)
-	}
-
-	// Patterns to add for fork protection
-	patterns := []string{".beads/", "**/RECOVERY*.md", "**/SESSION*.md"}
-	var toAdd []string
-	for _, p := range patterns {
-		// Check for exact line match (pattern alone on a line)
-		// This avoids false positives like ".beads/issues.jsonl" matching ".beads/"
-		if !containsExactPattern(existingContent, p) {
-			toAdd = append(toAdd, p)
-		}
-	}
-
-	if len(toAdd) == 0 {
-		if verbose {
-			fmt.Printf("%s Git exclude already configured\n", ui.RenderPass("✓"))
-		}
-		return nil
-	}
-
-	// Append patterns
-	newContent := existingContent
-	if !strings.HasSuffix(newContent, "\n") && len(newContent) > 0 {
-		newContent += "\n"
-	}
-	newContent += "\n# Beads fork protection (bd init)\n"
-	for _, p := range toAdd {
-		newContent += p + "\n"
-	}
-
-	// #nosec G306 - config file needs 0644
-	if err := os.WriteFile(excludePath, []byte(newContent), 0644); err != nil {
-		return fmt.Errorf("failed to write git exclude: %w", err)
-	}
-
 	if verbose {
-		fmt.Printf("\n%s Added to .git/info/exclude:\n", ui.RenderPass("✓"))
-		for _, p := range toAdd {
-			fmt.Printf("  %s\n", p)
+		if len(added) == 0 {
+			fmt.Printf("%s Git exclude already configured\n", ui.RenderPass("✓"))
+		} else {
+			fmt.Printf("\n%s Added to .git/info/exclude:\n", ui.RenderPass("✓"))
+			for _, p := range added {
+				fmt.Printf("  %s\n", p)
+			}
+			fmt.Println("\nNote: .git/info/exclude is local-only and won't affect upstream.")
 		}
-		fmt.Println("\nNote: .git/info/exclude is local-only and won't affect upstream.")
 	}
 	return nil
 }

--- a/cmd/bd/init_stealth_test.go
+++ b/cmd/bd/init_stealth_test.go
@@ -289,6 +289,139 @@ func TestCheckProjectExcludeStealth(t *testing.T) {
 	}
 }
 
+// leakedGitignore returns the content doctor.EnsureProjectGitignore writes when it appends the
+// beads section beneath existing user content.
+func leakedGitignore(userContent string) string {
+	s := userContent
+	if len(s) > 0 && !strings.HasSuffix(s, "\n") {
+		s += "\n"
+	}
+	s += "\n" + doctor.ProjectGitignoreHeader + "\n"
+	for _, p := range doctor.ProjectGitignorePatterns {
+		s += p + "\n"
+	}
+	return s
+}
+
+// TestRemoveBeadsProjectGitignoreSection_PreservesUserContent verifies that remediation strips only
+// the bd-managed section and leaves unrelated user patterns intact.
+func TestRemoveBeadsProjectGitignoreSection_PreservesUserContent(t *testing.T) {
+	dir := newGitRepo(t)
+	gitignorePath := filepath.Join(dir, ".gitignore")
+	if err := os.WriteFile(gitignorePath, []byte(leakedGitignore("node_modules/\n*.log")), 0644); err != nil {
+		t.Fatalf("seed .gitignore: %v", err)
+	}
+
+	changed, err := removeBeadsProjectGitignoreSection(dir)
+	if err != nil {
+		t.Fatalf("removeBeadsProjectGitignoreSection failed: %v", err)
+	}
+	if !changed {
+		t.Fatal("expected the beads section to be removed")
+	}
+
+	got, err := os.ReadFile(gitignorePath)
+	if err != nil {
+		t.Fatalf("read .gitignore: %v", err)
+	}
+	if strings.Contains(string(got), doctor.ProjectGitignoreHeader) {
+		t.Errorf("beads header still present:\n%s", got)
+	}
+	for _, p := range doctor.ProjectGitignorePatterns {
+		if containsExactPattern(string(got), p) {
+			t.Errorf("beads pattern %q still present:\n%s", p, got)
+		}
+	}
+	for _, want := range []string{"node_modules/", "*.log"} {
+		if !containsExactPattern(string(got), want) {
+			t.Errorf("user pattern %q was removed:\n%s", want, got)
+		}
+	}
+}
+
+// TestRemoveBeadsProjectGitignoreSection_DeletesWhenOnlyBeads verifies that a .gitignore beads
+// created solely for its own section is removed entirely, restoring true stealth.
+func TestRemoveBeadsProjectGitignoreSection_DeletesWhenOnlyBeads(t *testing.T) {
+	dir := newGitRepo(t)
+	gitignorePath := filepath.Join(dir, ".gitignore")
+	if err := os.WriteFile(gitignorePath, []byte(leakedGitignore("")), 0644); err != nil {
+		t.Fatalf("seed .gitignore: %v", err)
+	}
+
+	changed, err := removeBeadsProjectGitignoreSection(dir)
+	if err != nil {
+		t.Fatalf("removeBeadsProjectGitignoreSection failed: %v", err)
+	}
+	if !changed {
+		t.Fatal("expected removal")
+	}
+	if _, err := os.Stat(gitignorePath); !os.IsNotExist(err) {
+		t.Errorf("expected .gitignore removed when beads was its only content (err=%v)", err)
+	}
+}
+
+// TestRemoveBeadsProjectGitignoreSection_NoSection verifies remediation is a no-op (and reports no
+// change) for a .gitignore that has no beads section.
+func TestRemoveBeadsProjectGitignoreSection_NoSection(t *testing.T) {
+	dir := newGitRepo(t)
+	gitignorePath := filepath.Join(dir, ".gitignore")
+	orig := "node_modules/\n*.log\n"
+	if err := os.WriteFile(gitignorePath, []byte(orig), 0644); err != nil {
+		t.Fatalf("seed .gitignore: %v", err)
+	}
+
+	changed, err := removeBeadsProjectGitignoreSection(dir)
+	if err != nil {
+		t.Fatalf("removeBeadsProjectGitignoreSection failed: %v", err)
+	}
+	if changed {
+		t.Error("expected no change for a .gitignore without a beads section")
+	}
+	got, _ := os.ReadFile(gitignorePath)
+	if string(got) != orig {
+		t.Errorf("user .gitignore modified:\nwant %q\ngot  %q", orig, string(got))
+	}
+
+	// Also a no-op (no error) when there is no .gitignore at all.
+	if err := os.Remove(gitignorePath); err != nil {
+		t.Fatalf("remove .gitignore: %v", err)
+	}
+	if changed, err := removeBeadsProjectGitignoreSection(dir); err != nil || changed {
+		t.Errorf("expected no-op for missing .gitignore, got changed=%v err=%v", changed, err)
+	}
+}
+
+// TestCheckProjectExcludeStealth_WarnsOnLeakedGitignore verifies the stealth doctor check flags a
+// tracked .gitignore that still exposes the beads section, even when .git/info/exclude is correct.
+func TestCheckProjectExcludeStealth_WarnsOnLeakedGitignore(t *testing.T) {
+	dir := newGitRepo(t)
+	origDir, _ := os.Getwd()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("failed to chdir: %v", err)
+	}
+	defer os.Chdir(origDir)
+
+	// Patterns are correctly in exclude, so the only remaining problem is the leaked .gitignore.
+	if err := addProjectPatternsToGitExclude(dir, doctor.ProjectGitignorePatterns, false); err != nil {
+		t.Fatalf("addProjectPatternsToGitExclude failed: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".gitignore"), []byte(leakedGitignore("")), 0644); err != nil {
+		t.Fatalf("seed leaked .gitignore: %v", err)
+	}
+
+	if check := checkProjectExcludeStealth(dir); check.Status != doctor.StatusWarning {
+		t.Errorf("expected warning for leaked tracked .gitignore, got %q (%s)", check.Status, check.Message)
+	}
+
+	// After remediation the check should pass.
+	if _, err := removeBeadsProjectGitignoreSection(dir); err != nil {
+		t.Fatalf("removeBeadsProjectGitignoreSection failed: %v", err)
+	}
+	if check := checkProjectExcludeStealth(dir); check.Status != doctor.StatusOK {
+		t.Errorf("expected OK after remediation, got %q (%s)", check.Status, check.Message)
+	}
+}
+
 // TestSetupGitExclude_RegularRepo verifies that setupGitExclude still works
 // correctly in a regular (non-worktree) repo.
 func TestSetupGitExclude_RegularRepo(t *testing.T) {

--- a/cmd/bd/init_stealth_test.go
+++ b/cmd/bd/init_stealth_test.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/steveyegge/beads/cmd/bd/doctor"
 )
 
 // TestSetupGitExclude_Worktree verifies that setupGitExclude writes to the main
@@ -140,6 +142,150 @@ func TestSetupForkExclude_Worktree(t *testing.T) {
 		if strings.Contains(string(worktreeContent), ".beads/") {
 			t.Errorf("worktree exclude should not have .beads/ pattern (it was written to wrong location)")
 		}
+	}
+}
+
+// TestAddProjectPatternsToGitExclude_DoesNotTouchGitignore is a regression test for stealth mode
+// leaking into the tracked project-root .gitignore. In stealth mode bd must route the Dolt-file
+// ignore patterns into .git/info/exclude and must NEVER create or modify the project .gitignore
+// (which collaborators see). Previously bd init --stealth called doctor.EnsureProjectGitignore
+// unconditionally, adding a "# Beads / Dolt files" section to the tracked .gitignore.
+func TestAddProjectPatternsToGitExclude_DoesNotTouchGitignore(t *testing.T) {
+	dir := newGitRepo(t)
+
+	// Pre-existing project .gitignore unrelated to beads.
+	gitignorePath := filepath.Join(dir, ".gitignore")
+	originalGitignore := "node_modules/\n"
+	if err := os.WriteFile(gitignorePath, []byte(originalGitignore), 0644); err != nil {
+		t.Fatalf("failed to seed project .gitignore: %v", err)
+	}
+
+	origDir, _ := os.Getwd()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("failed to chdir: %v", err)
+	}
+	defer os.Chdir(origDir)
+
+	if err := addProjectPatternsToGitExclude(dir, doctor.ProjectGitignorePatterns, false); err != nil {
+		t.Fatalf("addProjectPatternsToGitExclude failed: %v", err)
+	}
+
+	// The project .gitignore must be byte-for-byte unchanged.
+	got, err := os.ReadFile(gitignorePath)
+	if err != nil {
+		t.Fatalf("failed to read project .gitignore: %v", err)
+	}
+	if string(got) != originalGitignore {
+		t.Errorf("project .gitignore was modified in stealth mode:\nwant: %q\ngot:  %q", originalGitignore, string(got))
+	}
+
+	// The Dolt-file patterns must land in .git/info/exclude instead.
+	excludePath := filepath.Join(dir, ".git", "info", "exclude")
+	excludeContent, err := os.ReadFile(excludePath)
+	if err != nil {
+		t.Fatalf("failed to read exclude file: %v", err)
+	}
+	for _, pattern := range doctor.ProjectGitignorePatterns {
+		if !containsExactPattern(string(excludeContent), pattern) {
+			t.Errorf("exclude file missing pattern %q:\n%s", pattern, excludeContent)
+		}
+	}
+}
+
+// TestAddProjectPatternsToGitExclude_NoGitignoreCreated verifies that stealth mode does not create
+// a project-root .gitignore when none exists.
+func TestAddProjectPatternsToGitExclude_NoGitignoreCreated(t *testing.T) {
+	dir := newGitRepo(t)
+
+	origDir, _ := os.Getwd()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("failed to chdir: %v", err)
+	}
+	defer os.Chdir(origDir)
+
+	if err := addProjectPatternsToGitExclude(dir, doctor.ProjectGitignorePatterns, false); err != nil {
+		t.Fatalf("addProjectPatternsToGitExclude failed: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(dir, ".gitignore")); !os.IsNotExist(err) {
+		t.Errorf("stealth mode created a project .gitignore (err=%v); patterns should go to .git/info/exclude only", err)
+	}
+}
+
+// TestAddProjectPatternsToGitExclude_Idempotent verifies repeated calls do not duplicate patterns
+// in the exclude file.
+func TestAddProjectPatternsToGitExclude_Idempotent(t *testing.T) {
+	dir := newGitRepo(t)
+
+	origDir, _ := os.Getwd()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("failed to chdir: %v", err)
+	}
+	defer os.Chdir(origDir)
+
+	for i := 0; i < 2; i++ {
+		if err := addProjectPatternsToGitExclude(dir, doctor.ProjectGitignorePatterns, false); err != nil {
+			t.Fatalf("addProjectPatternsToGitExclude call %d failed: %v", i, err)
+		}
+	}
+
+	excludeContent, err := os.ReadFile(filepath.Join(dir, ".git", "info", "exclude"))
+	if err != nil {
+		t.Fatalf("failed to read exclude file: %v", err)
+	}
+	for _, pattern := range doctor.ProjectGitignorePatterns {
+		if n := strings.Count(string(excludeContent), "\n"+pattern+"\n"); n > 1 {
+			t.Errorf("pattern %q duplicated %d times in exclude file:\n%s", pattern, n, excludeContent)
+		}
+	}
+}
+
+// TestIsStealthRepo verifies stealth detection via the persisted no-git-ops flag.
+func TestIsStealthRepo(t *testing.T) {
+	dir := newGitRepo(t)
+	beadsDir := filepath.Join(dir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0755); err != nil {
+		t.Fatalf("mkdir .beads: %v", err)
+	}
+
+	if isStealthRepo(dir) {
+		t.Error("expected non-stealth repo before no-git-ops is set")
+	}
+
+	if err := os.WriteFile(filepath.Join(beadsDir, "config.yaml"), []byte("no-git-ops: true\n"), 0644); err != nil {
+		t.Fatalf("write config.yaml: %v", err)
+	}
+	if !isStealthRepo(dir) {
+		t.Error("expected stealth repo after no-git-ops: true")
+	}
+}
+
+// TestCheckProjectExcludeStealth is the doctor-side regression guard: in stealth mode the project
+// ignore patterns must be checked against .git/info/exclude, not a tracked .gitignore, so bd doctor
+// never re-creates the .gitignore.
+func TestCheckProjectExcludeStealth(t *testing.T) {
+	dir := newGitRepo(t)
+	origDir, _ := os.Getwd()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("failed to chdir: %v", err)
+	}
+	defer os.Chdir(origDir)
+
+	// Before patterns are excluded, the stealth check should warn.
+	if check := checkProjectExcludeStealth(dir); check.Status != doctor.StatusWarning {
+		t.Errorf("expected warning when exclude lacks Dolt patterns, got %q (%s)", check.Status, check.Message)
+	}
+
+	// After routing patterns to exclude, the check should pass and no
+	// project .gitignore should have been created.
+	if err := addProjectPatternsToGitExclude(dir, doctor.ProjectGitignorePatterns, false); err != nil {
+		t.Fatalf("addProjectPatternsToGitExclude failed: %v", err)
+	}
+	if check := checkProjectExcludeStealth(dir); check.Status != doctor.StatusOK {
+		t.Errorf("expected OK after patterns added to exclude, got %q (%s)", check.Status, check.Message)
+	}
+	if _, err := os.Stat(filepath.Join(dir, ".gitignore")); !os.IsNotExist(err) {
+		t.Errorf("stealth doctor check must not create a project .gitignore (err=%v)", err)
 	}
 }
 


### PR DESCRIPTION
bd init --stealth correctly routed .beads/ and .claude/settings.local.json into .git/info/exclude, but the later GH#2034 project-root .gitignore step (doctor.EnsureProjectGitignore) ran unconditionally, creating or modifying a tracked .gitignore with the Dolt-file patterns. That change shows up in git status and is committable, defeating the whole point of stealth mode.

In stealth mode those patterns now go to .git/info/exclude instead, via a path-aware addProjectPatternsToGitExclude (resolved through --git-common-dir so worktrees hit the main repo's exclude file). The non-stealth path is unchanged.

bd doctor was leaking the same way: the "Project Gitignore" check and --fix called CheckProjectGitignore/FixProjectGitignore unconditionally, so doctor would re-create the .gitignore that stealth init deliberately avoided. Detection keys off the persisted no-git-ops flag (the same signal bd prime uses); stealth repos now check and fix .git/info/exclude instead. The doctor package stays config-agnostic, so the stealth branching lives in the cmd layer and reuses the "Project Gitignore" check name to keep --fix dispatch and ordering stable.

Tests: unit coverage for the exclude routing, stealth detection, and the stealth doctor check; end-to-end TestEmbeddedInit subtests assert that both bd init --stealth and bd doctor --fix leave git status --porcelain empty.