### PR TITLE
fix(codex): correct hook path to resolve from plugin root

### DIFF
--- a/cmd/bd/setup/plugin_layout_test.go
+++ b/cmd/bd/setup/plugin_layout_test.go
@@ -47,8 +47,8 @@ func TestPluginLayoutUsesSharedBeadsRoot(t *testing.T) {
 	if codexManifest.Skills != "./skills/" {
 		t.Fatalf("Codex manifest skills path = %q, want ./skills/", codexManifest.Skills)
 	}
-	if codexManifest.Hooks != "./hooks/hooks.json" {
-		t.Fatalf("Codex manifest hooks path = %q, want ./hooks/hooks.json", codexManifest.Hooks)
+	if codexManifest.Hooks != "./.codex-plugin/hooks/hooks.json" {
+		t.Fatalf("Codex manifest hooks path = %q, want ./.codex-plugin/hooks/hooks.json", codexManifest.Hooks)
 	}
 
 	requireRepoFile(t, root, "plugins", "beads", "skills", "beads", "SKILL.md")

--- a/plugins/beads/.codex-plugin/plugin.json
+++ b/plugins/beads/.codex-plugin/plugin.json
@@ -16,7 +16,7 @@
     "agent-memory"
   ],
   "skills": "./skills/",
-  "hooks": "./hooks/hooks.json",
+  "hooks": "./.codex-plugin/hooks/hooks.json",
   "interface": {
     "displayName": "Beads",
     "shortDescription": "Project task tracking with bd",


### PR DESCRIPTION
## What

Fixes the Codex hooks path in `plugins/beads/.codex-plugin/plugin.json`. PR #4188 moved hook files from `plugins/beads/hooks/hooks.json` to `plugins/beads/.codex-plugin/hooks/hooks.json` to isolate Codex-only hooks from Claude. However, the manifest path was left as `"./hooks/hooks.json"`, which Codex resolves relative to the **plugin root** (`plugins/beads/`), not relative to `.codex-plugin/`.

This causes a runtime warning:

```
failed to read /home/<user>/.codex/plugins/cache/beads-marketplace/beads/1.0.5/hooks/hooks.json: No such file or directory
```

The actual file is at `.codex-plugin/hooks/hooks.json`. Correcting the path to `"./.codex-plugin/hooks/hooks.json"` lets Codex resolve it correctly, and preserves the harness-specific isolation introduced by #4188 (Claude's loader does not scan inside `.codex-plugin/`).

## Changes

- `plugins/beads/.codex-plugin/plugin.json`: `"hooks"` path `./hooks/hooks.json` -> `./.codex-plugin/hooks/hooks.json`
- `cmd/bd/setup/plugin_layout_test.go`: update `TestPluginLayoutUsesSharedBeadsRoot` assertion to match the corrected path

## Verification

- `jq empty plugins/beads/.codex-plugin/plugin.json plugins/beads/.codex-plugin/hooks/hooks.json` - both files parse cleanly
- `go test ./cmd/bd/setup -run TestPluginLayoutUsesSharedBeadsRoot -count=1` - **PASS**
- File still exists at `plugins/beads/.codex-plugin/hooks/hooks.json` (unchanged)
- No file at `plugins/beads/hooks/hooks.json` (unchanged, Claude protection intact)

Note: CI checks are pending maintainer approval to run (standard GitHub Actions behavior for first-time external contributors).

Closes #4210. Follow-up to #4188.
