### PR TITLE
Preflight graph apply blocking cycles

### DIFF
--- a/cmd/bd/assign.go
+++ b/cmd/bd/assign.go
@@ -27,9 +27,7 @@ Examples:
 
 		ctx := rootCtx
 
-		// Write-intent routing: a prefix-routed target must open writable so the
-		// assignee update commits on the target head (#4141).
-		result, err := resolveAndGetIssueWithRoutingForWrite(ctx, store, id)
+		result, err := resolveAndGetIssueForMutation(ctx, store, id)
 		if err != nil {
 			if result != nil {
 				result.Close()

--- a/cmd/bd/close.go
+++ b/cmd/bd/close.go
@@ -621,7 +621,7 @@ func resolveCloseTargets(ctx context.Context, localStore storage.DoltStorage, id
 		// Write-intent: a prefix-routed target opens writable so the close
 		// commits on the target head (#4141). Contributor auto-routing below
 		// stays read-only: it hydrates foreign projects that must not be mutated.
-		if r, err := resolveViaPrefixRoutingMode(ctx, id, true); err == nil {
+		if r, err := resolveViaPrefixRoutingWithAccess(ctx, id, true); err == nil {
 			results = append(results, r)
 			continue
 		}

--- a/cmd/bd/comment.go
+++ b/cmd/bd/comment.go
@@ -62,7 +62,7 @@ Examples:
 
 		ctx := rootCtx
 
-		result, err := resolveAndGetIssueWithRoutingForWrite(ctx, store, id)
+		result, err := resolveAndGetIssueForMutation(ctx, store, id)
 		if err != nil {
 			if result != nil {
 				result.Close()

--- a/cmd/bd/comments.go
+++ b/cmd/bd/comments.go
@@ -156,9 +156,7 @@ Examples:
 		}
 		ctx := rootCtx
 
-		// Write-intent: comments add writes through the routed target store,
-		// matching the `bd comment` shorthand (#4141).
-		result, err := resolveAndGetIssueWithRoutingForWrite(ctx, store, issueID)
+		result, err := resolveAndGetIssueForMutation(ctx, store, issueID)
 		if err != nil {
 			if result != nil {
 				result.Close()

--- a/cmd/bd/delete.go
+++ b/cmd/bd/delete.go
@@ -94,10 +94,8 @@ Force: Delete and orphan dependents
 		// Single issue deletion (legacy behavior)
 		issueID := issueIDs[0]
 		ctx := rootCtx
-		// Get the issue to be deleted, using prefix-based routing. Write-intent:
-		// a prefix-routed target opens writable so the delete commits on the
-		// target head (#4141).
-		routedResult, err := resolveAndGetIssueWithRoutingForWrite(ctx, store, issueID)
+		// Get the issue to be deleted, using prefix-based routing
+		routedResult, err := resolveAndGetIssueForMutation(ctx, store, issueID)
 		if err != nil {
 			if isNotFoundErr(err) {
 				FatalError("issue %s not found", issueID)
@@ -260,9 +258,7 @@ func deleteBatch(_ *cobra.Command, issueIDs []string, force bool, dryRun bool, c
 	notFound := []string{}
 	var routedStore storage.DoltStorage
 	for _, id := range issueIDs {
-		// Write-intent: the batch delete mutates this routed store below, so it
-		// must open writable to commit on the target head (#4141).
-		result, err := resolveAndGetIssueWithRoutingForWrite(ctx, store, id)
+		result, err := resolveAndGetIssueForMutation(ctx, store, id)
 		if err != nil {
 			if isNotFoundErr(err) {
 				notFound = append(notFound, id)

--- a/cmd/bd/dep.go
+++ b/cmd/bd/dep.go
@@ -25,27 +25,28 @@ import (
 //
 // The routed store is opened read-only; callers that mutate the returned store
 // (e.g. dep add/remove/link writing through the source issue's store) must use
-// resolveIDWithRoutingForWrite instead.
+// resolveIDForMutation instead (GH#3231, #4141).
 func resolveIDWithRouting(ctx context.Context, localStore storage.DoltStorage, id string) (resolvedID string, targetStore storage.DoltStorage, cleanup func(), err error) {
-	return resolveIDWithRoutingMode(ctx, localStore, id, false)
-}
-
-// resolveIDWithRoutingForWrite is the write-intent variant of
-// resolveIDWithRouting: a prefix-routed target store is opened writable so a
-// dependency write through it commits on the target head (#4141). Read-only
-// resolution (e.g. resolving the depends-on target ID, or dep tree) must keep
-// resolveIDWithRouting so a routed read never mutates a foreign project's
-// history (bd-6dnrw.32, GH#3231).
-func resolveIDWithRoutingForWrite(ctx context.Context, localStore storage.DoltStorage, id string) (resolvedID string, targetStore storage.DoltStorage, cleanup func(), err error) {
-	return resolveIDWithRoutingMode(ctx, localStore, id, true)
-}
-
-func resolveIDWithRoutingMode(ctx context.Context, localStore storage.DoltStorage, id string, forWrite bool) (resolvedID string, targetStore storage.DoltStorage, cleanup func(), err error) {
-	resolve := resolveAndGetIssueWithRouting
-	if forWrite {
-		resolve = resolveAndGetIssueWithRoutingForWrite
+	result, err := resolveAndGetIssueWithRouting(ctx, localStore, id)
+	if err != nil {
+		return "", nil, func() {}, fmt.Errorf("resolving issue ID %s: %w", id, err)
 	}
-	result, err := resolve(ctx, localStore, id)
+	if result == nil || result.Issue == nil {
+		return "", nil, func() {}, fmt.Errorf("no issue found matching %q", id)
+	}
+	s := result.Store
+	if s == nil {
+		s = localStore
+	}
+	return result.ResolvedID, s, func() { result.Close() }, nil
+}
+
+// resolveIDForMutation mirrors resolveIDWithRouting but opens prefix-routed
+// target stores writable (resolveAndGetIssueForMutation) so mutation commands
+// can commit to the routed repository. Its result validation, local-store
+// fallback, and cleanup tail must stay aligned with resolveIDWithRouting.
+func resolveIDForMutation(ctx context.Context, localStore storage.DoltStorage, id string) (resolvedID string, targetStore storage.DoltStorage, cleanup func(), err error) {
+	result, err := resolveAndGetIssueForMutation(ctx, localStore, id)
 	if err != nil {
 		return "", nil, func() {}, fmt.Errorf("resolving issue ID %s: %w", id, err)
 	}
@@ -151,8 +152,10 @@ Examples:
 
 			// Resolve partial IDs with routing support. The source issue's store
 			// is mutated below, so resolve it write-intent (#4141); the blocker
-			// target is only resolved by ID and stays read-only.
-			fromID, fromStore, fromCleanup, err := resolveIDWithRoutingForWrite(ctx, store, blocksID)
+			// target is only resolved by ID and stays read-only, so a routed read
+			// never opens a foreign project writable or runs open-time migrations
+			// against its history (bd-6dnrw.32, GH#3231).
+			fromID, fromStore, fromCleanup, err := resolveIDForMutation(ctx, store, blocksID)
 			if err != nil {
 				FatalErrorRespectJSON("%v", err)
 			}
@@ -313,8 +316,10 @@ Examples:
 		isExternalRef := strings.HasPrefix(dependsOnArg, "external:")
 
 		// Write-intent: the source issue's store is mutated by AddDependency
-		// below, so the routed target must open writable (#4141).
-		fromID, fromStore, fromCleanup, err := resolveIDWithRoutingForWrite(ctx, store, args[0])
+		// below, so the routed source must open writable (#4141). The depends-on
+		// target is only resolved by ID and stays read-only, so resolving it can
+		// never open a foreign project writable (bd-6dnrw.32, GH#3231).
+		fromID, fromStore, fromCleanup, err := resolveIDForMutation(ctx, store, args[0])
 		if err != nil {
 			FatalErrorRespectJSON("%v", err)
 		}
@@ -606,8 +611,9 @@ func validateBulkDepEdges(ctx context.Context, edges []bulkDepEdge) ([]bulkDepEd
 	for _, edge := range edges {
 		current := edge
 		// Write-intent: addBulkDependencies writes through current.Store (the
-		// source issue's store), so a routed target must open writable (#4141).
-		fromID, fromStore, fromCleanup, err := resolveIDWithRoutingForWrite(ctx, store, edge.IssueID)
+		// source issue's store), so a routed source must open writable (#4141);
+		// the depends-on target below stays read-only (bd-6dnrw.32, GH#3231).
+		fromID, fromStore, fromCleanup, err := resolveIDForMutation(ctx, store, edge.IssueID)
 		if err != nil {
 			errs = append(errs, fmt.Sprintf("line %d: resolving issue ID %s: %v", edge.Line, edge.IssueID, err))
 			continue
@@ -905,9 +911,10 @@ var depRemoveCmd = &cobra.Command{
 
 		// Resolve partial IDs with routing support. The source issue's store is
 		// mutated by RemoveDependency below, so resolve it write-intent (#4141);
-		// the depends-on target is only resolved by ID and stays read-only.
+		// the depends-on target is only resolved by ID and stays read-only
+		// (bd-6dnrw.32, GH#3231).
 		var fromID, toID string
-		fromID, fromStore, fromCleanup, err := resolveIDWithRoutingForWrite(ctx, store, args[0])
+		fromID, fromStore, fromCleanup, err := resolveIDForMutation(ctx, store, args[0])
 		if err != nil {
 			FatalErrorRespectJSON("%v", err)
 		}

--- a/cmd/bd/dep_test.go
+++ b/cmd/bd/dep_test.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/steveyegge/beads/internal/storage"
+	"github.com/steveyegge/beads/internal/storage/dolt"
 	"github.com/steveyegge/beads/internal/types"
 )
 
@@ -1450,6 +1451,101 @@ func TestIsChildOf(t *testing.T) {
 				t.Errorf("isChildOf(%q, %q) = %v, want %v", tt.childID, tt.parentID, got, tt.want)
 			}
 		})
+	}
+}
+
+// TestDepRoutedTargetOpensReadOnly is the regression guard for the dep/link
+// target-resolution invariant: a cross-rig dependency target is resolved by ID
+// only, so resolveIDWithRouting must open the routed foreign store read-only,
+// while resolveIDForMutation (used for the mutated source issue) opens it
+// writable. Opening a dep/link target writable re-exposes GH#3231 open-time
+// mutations against a foreign project.
+//
+// NOTE: This test uses os.Chdir and cannot run in parallel with other tests.
+func TestDepRoutedTargetOpensReadOnly(t *testing.T) {
+	ctx := context.Background()
+
+	tmpDir := t.TempDir()
+	townBeadsDir := filepath.Join(tmpDir, ".beads")
+	if err := os.MkdirAll(townBeadsDir, 0755); err != nil {
+		t.Fatalf("create town beads dir: %v", err)
+	}
+	rigBeadsDir := filepath.Join(tmpDir, "rig", ".beads")
+	if err := os.MkdirAll(rigBeadsDir, 0755); err != nil {
+		t.Fatalf("create rig beads dir: %v", err)
+	}
+
+	townDBPath := filepath.Join(townBeadsDir, "dolt")
+	townStore := newTestStoreIsolatedDB(t, townDBPath, "hq")
+
+	rigDBPath := filepath.Join(rigBeadsDir, "dolt")
+	rigStore := newTestStoreIsolatedDB(t, rigDBPath, "gt")
+	if err := rigStore.CreateIssue(ctx, &types.Issue{
+		ID:        "gt-target1",
+		Title:     "Routed dep target",
+		Status:    types.StatusOpen,
+		Priority:  2,
+		IssueType: types.TypeTask,
+	}, "test"); err != nil {
+		t.Fatalf("create rig issue: %v", err)
+	}
+	// Release the rig store before routing reopens it.
+	rigStore.Close()
+
+	routesPath := filepath.Join(townBeadsDir, "routes.jsonl")
+	if err := os.WriteFile(routesPath, []byte(`{"prefix":"gt-","path":"rig"}`), 0644); err != nil {
+		t.Fatalf("write routes.jsonl: %v", err)
+	}
+
+	oldDbPath := dbPath
+	dbPath = townDBPath
+	t.Cleanup(func() { dbPath = oldDbPath })
+
+	oldWd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(oldWd) })
+
+	// Target-only resolution (the dep/link target) must open the routed store
+	// read-only.
+	roID, roStore, roCleanup, err := resolveIDWithRouting(ctx, townStore, "gt-target1")
+	if err != nil {
+		t.Fatalf("resolveIDWithRouting (target) failed: %v", err)
+	}
+	if roID != "gt-target1" {
+		t.Errorf("resolved target ID = %q, want gt-target1", roID)
+	}
+	roDolt, ok := roStore.(*dolt.DoltStore)
+	if !ok {
+		roCleanup()
+		t.Fatalf("routed target store is %T, want *dolt.DoltStore", roStore)
+	}
+	if !roDolt.IsReadOnly() {
+		roCleanup()
+		t.Fatal("dep/link target must be resolved read-only, but routed store is writable (GH#3231)")
+	}
+	roCleanup()
+
+	// Source resolution (the mutated issue's store) must open the routed store
+	// writable so the dependency write commits on the target head (#4141).
+	rwID, rwStore, rwCleanup, err := resolveIDForMutation(ctx, townStore, "gt-target1")
+	if err != nil {
+		t.Fatalf("resolveIDForMutation (source) failed: %v", err)
+	}
+	defer rwCleanup()
+	if rwID != "gt-target1" {
+		t.Errorf("resolved source ID = %q, want gt-target1", rwID)
+	}
+	rwDolt, ok := rwStore.(*dolt.DoltStore)
+	if !ok {
+		t.Fatalf("routed source store is %T, want *dolt.DoltStore", rwStore)
+	}
+	if rwDolt.IsReadOnly() {
+		t.Fatal("source resolution must open the routed store writable, but it is read-only")
 	}
 }
 

--- a/cmd/bd/edit.go
+++ b/cmd/bd/edit.go
@@ -31,10 +31,8 @@ Examples:
 		id := args[0]
 		ctx := rootCtx
 
-		// Resolve ID with prefix routing (supports cross-rig edits like `bd edit xe-5ls`).
-		// Write-intent: the routed target opens writable so the field update
-		// commits on the target head (#4141).
-		result, err := resolveAndGetIssueWithRoutingForWrite(ctx, store, id)
+		// Resolve ID with prefix routing (supports cross-rig edits like `bd edit xe-5ls`)
+		result, err := resolveAndGetIssueForMutation(ctx, store, id)
 		if err != nil {
 			FatalErrorRespectJSON("resolving %s: %v", id, err)
 		}

--- a/cmd/bd/graph_apply.go
+++ b/cmd/bd/graph_apply.go
@@ -586,7 +586,9 @@ func executeGraphApply(ctx context.Context, plan *GraphApplyPlan, opts GraphAppl
 		if err := validateGraphApplyPlannedParentBlockingPaths(ctx, tx, plan, keyToID, parentDepPairs); err != nil {
 			return err
 		}
-		canSkipLocalCycleChecks := graphApplyPlanCanSkipSQLCycleChecks(plan)
+		if err := validateGraphApplyPlannedBlockingCycles(ctx, tx, plan, keyToID); err != nil {
+			return err
+		}
 
 		// Add dependencies from edges.
 		for i, edge := range plan.Edges {
@@ -608,7 +610,7 @@ func executeGraphApply(ctx context.Context, plan *GraphApplyPlan, opts GraphAppl
 				Type:        depType,
 			}
 			addOpts := storage.DependencyAddOptions{}
-			if canSkipLocalCycleChecks && graphApplyEdgeCanSkipSQLCycleCheck(edge, depType) {
+			if graphApplyCycleRelevantDependencyType(depType) {
 				addOpts.SkipCycleCheck = true
 			}
 			if err := tx.AddDependencyWithOptions(ctx, dep, actor, addOpts); err != nil {
@@ -650,6 +652,45 @@ func executeGraphApply(ctx context.Context, plan *GraphApplyPlan, opts GraphAppl
 	}
 
 	return &GraphApplyResult{IDs: keyToID}, nil
+}
+
+func validateGraphApplyPlannedBlockingCycles(ctx context.Context, tx storage.Transaction, plan *GraphApplyPlan, keyToID map[string]string) error {
+	type plannedEdge struct {
+		index  int
+		fromID string
+		toID   string
+	}
+
+	adj := make(map[string][]string)
+	checks := make([]plannedEdge, 0, len(plan.Edges))
+	for i, edge := range plan.Edges {
+		depType := graphApplyDependencyType(edge.Type)
+		if !graphApplyCycleRelevantDependencyType(depType) {
+			continue
+		}
+		fromID := resolveEdgeRef(edge.FromKey, edge.FromID, keyToID)
+		toID := resolveEdgeRef(edge.ToKey, edge.ToID, keyToID)
+		if fromID == "" || toID == "" {
+			continue
+		}
+		if fromID == toID {
+			return fmt.Errorf("edge %d %s->%s creates a blocking dependency cycle", i, fromID, toID)
+		}
+		adj[fromID] = append(adj[fromID], toID)
+		checks = append(checks, plannedEdge{index: i, fromID: fromID, toID: toID})
+	}
+
+	depCache := make(map[string][]*types.Dependency)
+	for _, edge := range checks {
+		hasPath, err := graphApplyHasPath(ctx, tx, adj, depCache, edge.toID, edge.fromID)
+		if err != nil {
+			return fmt.Errorf("edge %d %s->%s: checking planned blocking cycle: %w", edge.index, edge.fromID, edge.toID, err)
+		}
+		if hasPath {
+			return fmt.Errorf("edge %d %s->%s creates a blocking dependency cycle", edge.index, edge.fromID, edge.toID)
+		}
+	}
+	return nil
 }
 
 func validateGraphApplyPlannedParentBlockingPaths(ctx context.Context, tx storage.Transaction, plan *GraphApplyPlan, keyToID map[string]string, parentDepPairs map[string]bool) error {

--- a/cmd/bd/graph_apply.go
+++ b/cmd/bd/graph_apply.go
@@ -450,7 +450,7 @@ func validateGraphApplyLocalCycles(plan *GraphApplyPlan, knownKeys map[string]bo
 	}
 	for _, edge := range plan.Edges {
 		depType := graphApplyDependencyType(edge.Type)
-		if !graphApplyEdgeCanSkipSQLCycleCheck(edge, depType) {
+		if !graphApplyEdgeIsLocalCycleRelevant(edge, depType) {
 			continue
 		}
 		if !knownKeys[edge.FromKey] || !knownKeys[edge.ToKey] {
@@ -654,6 +654,17 @@ func executeGraphApply(ctx context.Context, plan *GraphApplyPlan, opts GraphAppl
 	return &GraphApplyResult{IDs: keyToID}, nil
 }
 
+// validateGraphApplyPlannedBlockingCycles rejects planned blocking edges that
+// would close a blocking-dependency cycle, evaluated whole-graph before any
+// insert. It mirrors the storage per-edge SQL cycle check
+// (issueops.CheckDependencyCycleInTx), which only traverses blocks and
+// conditional-blocks edges: both the planned adjacency and the existing-dep
+// walk are restricted to cycle-relevant types via
+// graphApplyCycleRelevantDependencyType. This is deliberately narrower than
+// the ready-work traversal used by validateGraphApplyPlannedParentBlockingPaths
+// — graph-apply must not reject a blocking edge whose only return path runs
+// through an existing parent-child or waits-for dep when plain `bd dep add`
+// would allow it.
 func validateGraphApplyPlannedBlockingCycles(ctx context.Context, tx storage.Transaction, plan *GraphApplyPlan, keyToID map[string]string) error {
 	type plannedEdge struct {
 		index  int
@@ -682,7 +693,7 @@ func validateGraphApplyPlannedBlockingCycles(ctx context.Context, tx storage.Tra
 
 	depCache := make(map[string][]*types.Dependency)
 	for _, edge := range checks {
-		hasPath, err := graphApplyHasPath(ctx, tx, adj, depCache, edge.toID, edge.fromID)
+		hasPath, err := graphApplyHasPath(ctx, tx, adj, depCache, edge.toID, edge.fromID, graphApplyCycleRelevantDependencyType)
 		if err != nil {
 			return fmt.Errorf("edge %d %s->%s: checking planned blocking cycle: %w", edge.index, edge.fromID, edge.toID, err)
 		}
@@ -693,6 +704,14 @@ func validateGraphApplyPlannedBlockingCycles(ctx context.Context, tx storage.Tra
 	return nil
 }
 
+// validateGraphApplyPlannedParentBlockingPaths rejects plans where a planned
+// blocking edge would create a path from a parent to its child. Unlike
+// validateGraphApplyPlannedBlockingCycles, its existing-dep walk follows the
+// full AffectsReadyWork set (blocks, conditional-blocks, parent-child,
+// waits-for) because a parent→child path closed through any ready-affecting
+// dependency is a real ready-work deadlock. The two predicates must stay
+// distinct: narrowing this one would miss real deadlocks; broadening the
+// blocking-cycle walk would reject edges plain `bd dep add` accepts.
 func validateGraphApplyPlannedParentBlockingPaths(ctx context.Context, tx storage.Transaction, plan *GraphApplyPlan, keyToID map[string]string, parentDepPairs map[string]bool) error {
 	adj := make(map[string][]string)
 	for pair := range parentDepPairs {
@@ -729,7 +748,7 @@ func validateGraphApplyPlannedParentBlockingPaths(ctx context.Context, tx storag
 		if childID == "" || parentID == "" {
 			continue
 		}
-		hasPath, err := graphApplyHasPath(ctx, tx, adj, depCache, parentID, childID)
+		hasPath, err := graphApplyHasPath(ctx, tx, adj, depCache, parentID, childID, graphApplyReadyPathDependencyType)
 		if err != nil {
 			return err
 		}
@@ -740,7 +759,11 @@ func validateGraphApplyPlannedParentBlockingPaths(ctx context.Context, tx storag
 	return nil
 }
 
-func graphApplyHasPath(ctx context.Context, tx storage.Transaction, adj map[string][]string, depCache map[string][]*types.Dependency, fromID, toID string) (bool, error) {
+// graphApplyHasPath reports whether fromID can reach toID by following the
+// in-memory planned adjacency plus existing store dependencies. followExistingDep
+// selects which existing dep types the walk traverses, letting callers mirror
+// either the blocking-only SQL cycle check or the broader ready-work graph.
+func graphApplyHasPath(ctx context.Context, tx storage.Transaction, adj map[string][]string, depCache map[string][]*types.Dependency, fromID, toID string, followExistingDep func(types.DependencyType) bool) (bool, error) {
 	seen := make(map[string]bool)
 	var visit func(string) (bool, error)
 	visit = func(id string) (bool, error) {
@@ -767,7 +790,7 @@ func graphApplyHasPath(ctx context.Context, tx storage.Transaction, adj map[stri
 			depCache[id] = deps
 		}
 		for _, dep := range deps {
-			if !graphApplyReadyPathDependencyType(dep.Type) {
+			if !followExistingDep(dep.Type) {
 				continue
 			}
 			found, err := visit(dep.DependsOnID)
@@ -780,20 +803,12 @@ func graphApplyHasPath(ctx context.Context, tx storage.Transaction, adj map[stri
 	return visit(fromID)
 }
 
-func graphApplyPlanCanSkipSQLCycleChecks(plan *GraphApplyPlan) bool {
-	for _, edge := range plan.Edges {
-		depType := graphApplyDependencyType(edge.Type)
-		if !graphApplyCycleRelevantDependencyType(depType) {
-			continue
-		}
-		if !graphApplyEdgeCanSkipSQLCycleCheck(edge, depType) {
-			return false
-		}
-	}
-	return true
-}
-
-func graphApplyEdgeCanSkipSQLCycleCheck(edge GraphApplyEdge, depType types.DependencyType) bool {
+// graphApplyEdgeIsLocalCycleRelevant reports whether an edge participates in the
+// in-memory local cycle check run by validateGraphApplyLocalCycles: it must be a
+// fully-local edge (both endpoints addressed by key, neither by an existing ID)
+// of a cycle-relevant dependency type. The whole-graph preflight now always skips
+// the storage SQL cycle probe, so this no longer gates that skip.
+func graphApplyEdgeIsLocalCycleRelevant(edge GraphApplyEdge, depType types.DependencyType) bool {
 	if edge.FromKey == "" || edge.ToKey == "" || edge.FromID != "" || edge.ToID != "" {
 		return false
 	}

--- a/cmd/bd/graph_apply_execution_unit_test.go
+++ b/cmd/bd/graph_apply_execution_unit_test.go
@@ -281,6 +281,80 @@ func TestExecuteGraphApplyUnitSkipsSQLCycleChecksAfterGraphPreflight(t *testing.
 	}
 }
 
+// TestExecuteGraphApplyUnitAllowsBlockingThroughExistingParentChild pins the
+// rule that the whole-graph blocking-cycle preflight mirrors the storage SQL
+// cycle check: a planned blocking edge whose only return path runs through an
+// existing parent-child dep must be allowed (plain `bd dep add` allows it), so
+// the preflight's existing-edge walk is restricted to blocking dep types.
+func TestExecuteGraphApplyUnitAllowsBlockingThroughExistingParentChild(t *testing.T) {
+	ctx, fakeStore := withGraphApplyFakeStore(t)
+	for _, id := range []string{"ga-parent", "ga-child"} {
+		if err := fakeStore.CreateIssue(ctx, &types.Issue{
+			ID:        id,
+			Title:     id,
+			Status:    types.StatusOpen,
+			Priority:  2,
+			IssueType: types.TypeTask,
+		}, actor); err != nil {
+			t.Fatalf("CreateIssue(%s): %v", id, err)
+		}
+	}
+	// Existing parent-child dep: ga-child is a child of ga-parent.
+	fakeStore.deps = append(fakeStore.deps, &types.Dependency{
+		IssueID:     "ga-child",
+		DependsOnID: "ga-parent",
+		Type:        types.DepParentChild,
+	})
+
+	plan := &GraphApplyPlan{
+		Edges: []GraphApplyEdge{
+			{FromID: "ga-parent", ToID: "ga-child", Type: "blocks"},
+		},
+	}
+
+	if _, err := executeGraphApply(ctx, plan, GraphApplyOptions{}); err != nil {
+		t.Fatalf("blocking edge closing a cycle only through an existing parent-child dep must be allowed, got: %v", err)
+	}
+}
+
+// TestExecuteGraphApplyUnitRejectsBlockingThroughExistingBlocking is the
+// companion guard: a planned blocking edge that closes a cycle through an
+// existing blocking dep must still be rejected by the preflight.
+func TestExecuteGraphApplyUnitRejectsBlockingThroughExistingBlocking(t *testing.T) {
+	ctx, fakeStore := withGraphApplyFakeStore(t)
+	for _, id := range []string{"ga-x", "ga-y"} {
+		if err := fakeStore.CreateIssue(ctx, &types.Issue{
+			ID:        id,
+			Title:     id,
+			Status:    types.StatusOpen,
+			Priority:  2,
+			IssueType: types.TypeTask,
+		}, actor); err != nil {
+			t.Fatalf("CreateIssue(%s): %v", id, err)
+		}
+	}
+	// Existing blocking dep: ga-y blocks ga-x.
+	fakeStore.deps = append(fakeStore.deps, &types.Dependency{
+		IssueID:     "ga-y",
+		DependsOnID: "ga-x",
+		Type:        types.DepBlocks,
+	})
+
+	plan := &GraphApplyPlan{
+		Edges: []GraphApplyEdge{
+			{FromID: "ga-x", ToID: "ga-y", Type: "blocks"},
+		},
+	}
+
+	_, err := executeGraphApply(ctx, plan, GraphApplyOptions{})
+	if err == nil {
+		t.Fatal("expected blocking cycle through existing blocking dep to be rejected")
+	}
+	if !strings.Contains(err.Error(), "cycle") {
+		t.Fatalf("error = %q, want cycle rejection", err.Error())
+	}
+}
+
 func TestExecuteGraphApplyUnitRejectsBlockingChildToParentDuplicate(t *testing.T) {
 	ctx, _ := withGraphApplyFakeStore(t)
 

--- a/cmd/bd/graph_apply_execution_unit_test.go
+++ b/cmd/bd/graph_apply_execution_unit_test.go
@@ -12,9 +12,10 @@ import (
 
 type graphApplyFakeStore struct {
 	storage.DoltStorage
-	issues map[string]*types.Issue
-	deps   []*types.Dependency
-	nextID int
+	issues  map[string]*types.Issue
+	deps    []*types.Dependency
+	addOpts []storage.DependencyAddOptions
+	nextID  int
 }
 
 func newGraphApplyFakeStore() *graphApplyFakeStore {
@@ -81,15 +82,17 @@ func (s *graphApplyFakeStore) RunInTransaction(ctx context.Context, _ string, fn
 	}
 	s.issues = txStore.issues
 	s.deps = txStore.deps
+	s.addOpts = txStore.addOpts
 	s.nextID = txStore.nextID
 	return nil
 }
 
 func (s *graphApplyFakeStore) clone() *graphApplyFakeStore {
 	cp := &graphApplyFakeStore{
-		issues: make(map[string]*types.Issue, len(s.issues)),
-		deps:   make([]*types.Dependency, 0, len(s.deps)),
-		nextID: s.nextID,
+		issues:  make(map[string]*types.Issue, len(s.issues)),
+		deps:    make([]*types.Dependency, 0, len(s.deps)),
+		addOpts: append([]storage.DependencyAddOptions(nil), s.addOpts...),
+		nextID:  s.nextID,
 	}
 	for id, issue := range s.issues {
 		issueCopy := *issue
@@ -129,6 +132,7 @@ func (tx *graphApplyFakeTx) AddDependency(ctx context.Context, dep *types.Depend
 }
 
 func (tx *graphApplyFakeTx) AddDependencyWithOptions(_ context.Context, dep *types.Dependency, _ string, opts storage.DependencyAddOptions) error {
+	tx.store.addOpts = append(tx.store.addOpts, opts)
 	for _, existing := range tx.store.deps {
 		if existing.IssueID == dep.IssueID && existing.DependsOnID == dep.DependsOnID {
 			if existing.Type == dep.Type {
@@ -237,6 +241,43 @@ func TestExecuteGraphApplyUnitRejectsMixedLocalExternalBlockingCycle(t *testing.
 	}
 	if !strings.Contains(err.Error(), "cycle") {
 		t.Fatalf("error = %q, want cycle rejection", err.Error())
+	}
+}
+
+func TestExecuteGraphApplyUnitSkipsSQLCycleChecksAfterGraphPreflight(t *testing.T) {
+	ctx, fakeStore := withGraphApplyFakeStore(t)
+	if err := fakeStore.CreateIssue(ctx, &types.Issue{
+		ID:        "ga-existing",
+		Title:     "Existing",
+		Status:    types.StatusOpen,
+		Priority:  2,
+		IssueType: types.TypeTask,
+	}, actor); err != nil {
+		t.Fatalf("CreateIssue(existing): %v", err)
+	}
+
+	plan := &GraphApplyPlan{
+		Nodes: []GraphApplyNode{
+			{Key: "a", Title: "A", Type: "task"},
+			{Key: "b", Title: "B", Type: "task"},
+		},
+		Edges: []GraphApplyEdge{
+			{FromID: "ga-existing", ToKey: "a", Type: "blocks"},
+			{FromKey: "a", ToKey: "b", Type: "blocks"},
+			{FromKey: "b", ToID: "external:other:shipped", Type: "blocks"},
+		},
+	}
+
+	if _, err := executeGraphApply(ctx, plan, GraphApplyOptions{}); err != nil {
+		t.Fatalf("executeGraphApply: %v", err)
+	}
+	if len(fakeStore.addOpts) != len(plan.Edges) {
+		t.Fatalf("AddDependencyWithOptions calls = %d, want %d", len(fakeStore.addOpts), len(plan.Edges))
+	}
+	for i, opts := range fakeStore.addOpts {
+		if !opts.SkipCycleCheck {
+			t.Fatalf("edge %d SkipCycleCheck = false, want true", i)
+		}
 	}
 }
 

--- a/cmd/bd/graph_apply_test.go
+++ b/cmd/bd/graph_apply_test.go
@@ -361,7 +361,7 @@ func TestValidateGraphApplyPlanIgnoresIDOverridesForLocalCycleValidation(t *test
 	}
 }
 
-func TestGraphApplyEdgeCanSkipSQLCycleCheckOnlyForLocalBlockingEdges(t *testing.T) {
+func TestGraphApplyEdgeIsLocalCycleRelevantOnlyForLocalBlockingEdges(t *testing.T) {
 	tests := []struct {
 		name string
 		edge GraphApplyEdge
@@ -377,9 +377,9 @@ func TestGraphApplyEdgeCanSkipSQLCycleCheckOnlyForLocalBlockingEdges(t *testing.
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := graphApplyEdgeCanSkipSQLCycleCheck(tt.edge, graphApplyDependencyType(tt.typ))
+			got := graphApplyEdgeIsLocalCycleRelevant(tt.edge, graphApplyDependencyType(tt.typ))
 			if got != tt.want {
-				t.Fatalf("skip = %v, want %v", got, tt.want)
+				t.Fatalf("localCycleRelevant = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/cmd/bd/human.go
+++ b/cmd/bd/human.go
@@ -191,9 +191,8 @@ Examples:
 		ctx := rootCtx
 		issueID := args[0]
 
-		// Resolve partial ID and get issue. Write-intent: a prefix-routed target
-		// opens writable so the comment/close commits on the target head (#4141).
-		result, err := resolveAndGetIssueWithRoutingForWrite(ctx, store, issueID)
+		// Resolve partial ID and get issue
+		result, err := resolveAndGetIssueForMutation(ctx, store, issueID)
 		if err != nil {
 			FatalErrorRespectJSON("resolving issue ID %s: %v", issueID, err)
 		}
@@ -264,9 +263,8 @@ Examples:
 		ctx := rootCtx
 		issueID := args[0]
 
-		// Resolve partial ID and get issue. Write-intent: a prefix-routed target
-		// opens writable so the comment/close commits on the target head (#4141).
-		result, err := resolveAndGetIssueWithRoutingForWrite(ctx, store, issueID)
+		// Resolve partial ID and get issue
+		result, err := resolveAndGetIssueForMutation(ctx, store, issueID)
 		if err != nil {
 			FatalErrorRespectJSON("resolving issue ID %s: %v", issueID, err)
 		}

--- a/cmd/bd/link.go
+++ b/cmd/bd/link.go
@@ -31,10 +31,11 @@ Examples:
 
 		ctx := rootCtx
 
-		// Resolve partial IDs with routing support. The source issue's store is
-		// mutated by AddDependency below, so resolve it write-intent (#4141); the
-		// dependency target is only resolved by ID and stays read-only.
-		fromID, fromStore, fromCleanup, err := resolveIDWithRoutingForWrite(ctx, store, id1)
+		// Resolve partial IDs with routing support. The source issue's store
+		// is mutated by AddDependency below, so resolve it write-intent
+		// (#4141); the dependency target is only resolved by ID and stays
+		// read-only (bd-6dnrw.32, GH#3231).
+		fromID, fromStore, fromCleanup, err := resolveIDForMutation(ctx, store, id1)
 		if err != nil {
 			FatalErrorRespectJSON("%v", err)
 		}

--- a/cmd/bd/note.go
+++ b/cmd/bd/note.go
@@ -60,7 +60,7 @@ Examples:
 
 		ctx := rootCtx
 
-		result, err := resolveAndGetIssueWithRoutingForWrite(ctx, store, id)
+		result, err := resolveAndGetIssueForMutation(ctx, store, id)
 		if err != nil {
 			if result != nil {
 				result.Close()

--- a/cmd/bd/priority.go
+++ b/cmd/bd/priority.go
@@ -40,9 +40,7 @@ Examples:
 
 		ctx := rootCtx
 
-		// Write-intent routing: a prefix-routed target must open writable so the
-		// priority update commits on the target head (#4141).
-		result, err := resolveAndGetIssueWithRoutingForWrite(ctx, store, id)
+		result, err := resolveAndGetIssueForMutation(ctx, store, id)
 		if err != nil {
 			if result != nil {
 				result.Close()

--- a/cmd/bd/reopen.go
+++ b/cmd/bd/reopen.go
@@ -37,9 +37,8 @@ This is more explicit than 'bd update --status open' and emits a Reopened event.
 				diagHint())
 		}
 		for _, id := range args {
-			// Resolve with prefix routing (supports cross-rig reopens like `bd reopen xe-5ls`).
-			// Write-intent: reopen commits through the routed target store (#4141).
-			result, err := resolveAndGetIssueWithRoutingForWrite(ctx, store, id)
+			// Resolve with prefix routing (supports cross-rig reopens like `bd reopen xe-5ls`)
+			result, err := resolveAndGetIssueForMutation(ctx, store, id)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "Error resolving %s: %v\n", id, err)
 				hasError = true

--- a/cmd/bd/routed.go
+++ b/cmd/bd/routed.go
@@ -50,26 +50,24 @@ func (r *RoutedResult) Close() {
 // Tries the local store first, then prefix-based routing via routes.jsonl,
 // then falls back to contributor auto-routing.
 //
-// Routed stores are opened read-only; mutating commands must use
-// resolveAndGetIssueWithRoutingForWrite instead.
-//
 // Returns a RoutedResult containing the issue, resolved ID, and the store to use.
 // The caller MUST call result.Close() when done to release any routed storage.
+//
+// Prefix-routed target stores are opened read-only; mutating commands must use
+// resolveAndGetIssueForMutation instead so a routed read can never write
+// migrations or other open-time mutations into a foreign project (GH#3231, #4141).
 func resolveAndGetIssueWithRouting(ctx context.Context, localStore storage.DoltStorage, id string) (*RoutedResult, error) {
-	return resolveAndGetIssueWithRoutingMode(ctx, localStore, id, false)
+	return resolveAndGetIssueWithRoutingAccess(ctx, localStore, id, false)
 }
 
-// resolveAndGetIssueWithRoutingForWrite is the write-intent variant of
-// resolveAndGetIssueWithRouting: a prefix-routed target store is opened
-// writable so mutating commands can write through it and commit on the
-// target store's head (#4141). Read paths must keep the read-only variant so
-// a routed read can never write migrations or other open-time mutations into
-// a foreign project's history (bd-6dnrw.32, GH#3231).
-func resolveAndGetIssueWithRoutingForWrite(ctx context.Context, localStore storage.DoltStorage, id string) (*RoutedResult, error) {
-	return resolveAndGetIssueWithRoutingMode(ctx, localStore, id, true)
+// resolveAndGetIssueForMutation resolves an issue like
+// resolveAndGetIssueWithRouting, but opens prefix-routed target stores in
+// writable mode so mutation commands can commit to the routed repository.
+func resolveAndGetIssueForMutation(ctx context.Context, localStore storage.DoltStorage, id string) (*RoutedResult, error) {
+	return resolveAndGetIssueWithRoutingAccess(ctx, localStore, id, true)
 }
 
-func resolveAndGetIssueWithRoutingMode(ctx context.Context, localStore storage.DoltStorage, id string, forWrite bool) (*RoutedResult, error) {
+func resolveAndGetIssueWithRoutingAccess(ctx context.Context, localStore storage.DoltStorage, id string, writablePrefixRoute bool) (*RoutedResult, error) {
 	// Try local store first.
 	result, err := resolveAndGetFromStore(ctx, localStore, id, false)
 	if err == nil {
@@ -80,14 +78,14 @@ func resolveAndGetIssueWithRoutingMode(ctx context.Context, localStore storage.D
 	// This handles cross-rig lookups where the ID's prefix maps to a different
 	// database (e.g., hr-8wn.1 routes to the herald rig's database).
 	if isNotFoundErr(err) {
-		if prefixResult, prefixErr := resolveViaPrefixRoutingMode(ctx, id, forWrite); prefixErr == nil {
+		if prefixResult, prefixErr := resolveViaPrefixRoutingWithAccess(ctx, id, writablePrefixRoute); prefixErr == nil {
 			return prefixResult, nil
 		}
 	}
 
 	// If not found via prefix routing, try contributor auto-routing as fallback (GH#2345).
-	// Auto-routed stores stay read-only even for write-intent callers: this
-	// path hydrates foreign contributor projects, which must never be mutated.
+	// Auto-routed stores stay read-only even for write-intent callers (writablePrefixRoute):
+	// this path hydrates foreign contributor projects, which must never be mutated.
 	if isNotFoundErr(err) {
 		if autoResult, autoErr := resolveViaAutoRouting(ctx, localStore, id); autoErr == nil {
 			return autoResult, nil
@@ -150,15 +148,18 @@ type prefixRoute struct {
 // (e.g., crew/beercan → town/.beads with database "hq"), a bead ID like "hr-8wn.1"
 // can be resolved by following the "hr-" route to the herald rig's .beads directory,
 // which declares dolt_database="herald".
+//
+// The read-only open guarantees a routed read cannot mutate the target; mutation
+// commands must route through resolveViaPrefixRoutingWithAccess with writable=true.
 func resolveViaPrefixRouting(ctx context.Context, id string) (*RoutedResult, error) {
-	return resolveViaPrefixRoutingMode(ctx, id, false)
+	return resolveViaPrefixRoutingWithAccess(ctx, id, false)
 }
 
-// resolveViaPrefixRoutingMode is resolveViaPrefixRouting with an explicit
-// store-open mode. forWrite opens the routed target writable, behaving like
-// running the command inside that rig; false keeps the read-only open that
-// guarantees a routed read cannot mutate the target (bd-6dnrw.32).
-func resolveViaPrefixRoutingMode(ctx context.Context, id string, forWrite bool) (*RoutedResult, error) {
+// resolveViaPrefixRoutingWithAccess is the shared implementation that selects the
+// store-open mode. writable opens the routed target writable, behaving like running
+// the command inside that rig; false keeps the read-only open that guarantees a
+// routed read cannot mutate the target (bd-6dnrw.32).
+func resolveViaPrefixRoutingWithAccess(ctx context.Context, id string, writable bool) (*RoutedResult, error) {
 	// Extract prefix from the bead ID (e.g., "hr-" from "hr-8wn.1")
 	prefix := extractBeadPrefix(id)
 	if prefix == "" {
@@ -210,26 +211,25 @@ func resolveViaPrefixRoutingMode(ctx context.Context, id string, forWrite bool) 
 
 	debug.Logf("[routing] Prefix %q matched route to %s (database: %s)\n", prefix, matchedRoute.Path, targetDB)
 
-	// Open a store for the target database — read-only unless the caller
-	// declared write intent (routed writes must commit on the target head,
-	// which a read-only open refuses).
-	// We need to temporarily override BEADS_DOLT_SERVER_DATABASE so the store
-	// connects to the correct database on the shared Dolt server.
-	openStore := newReadOnlyStoreFromConfig
-	if forWrite {
-		openStore = newDoltStoreFromConfig
-	}
+	// We need to temporarily override BEADS_DOLT_SERVER_DATABASE so server-mode
+	// stores connect to the correct database on the shared Dolt server.
 	origDB := os.Getenv("BEADS_DOLT_SERVER_DATABASE")
 	_ = os.Setenv("BEADS_DOLT_SERVER_DATABASE", targetDB)
-	targetStore, err := openStore(ctx, targetBeadsDir)
+	var targetStore storage.DoltStorage
+	var openErr error
+	if writable {
+		targetStore, openErr = newDoltStoreFromConfig(ctx, targetBeadsDir)
+	} else {
+		targetStore, openErr = newReadOnlyStoreFromConfig(ctx, targetBeadsDir)
+	}
 	// Restore the original env var
 	if origDB != "" {
 		_ = os.Setenv("BEADS_DOLT_SERVER_DATABASE", origDB)
 	} else {
 		_ = os.Unsetenv("BEADS_DOLT_SERVER_DATABASE")
 	}
-	if err != nil {
-		return nil, fmt.Errorf("opening routed store for %s: %w", matchedRoute.Path, err)
+	if openErr != nil {
+		return nil, fmt.Errorf("opening routed store for %s: %w", matchedRoute.Path, openErr)
 	}
 
 	result, err := resolveAndGetFromStore(ctx, targetStore, id, true)

--- a/cmd/bd/tag.go
+++ b/cmd/bd/tag.go
@@ -27,9 +27,7 @@ Examples:
 
 		ctx := rootCtx
 
-		// Write-intent routing: a prefix-routed target must open writable so the
-		// label add commits on the target head (#4141).
-		result, err := resolveAndGetIssueWithRoutingForWrite(ctx, store, id)
+		result, err := resolveAndGetIssueForMutation(ctx, store, id)
 		if err != nil {
 			if result != nil {
 				result.Close()

--- a/cmd/bd/update.go
+++ b/cmd/bd/update.go
@@ -327,9 +327,8 @@ create, update, show, or close operation).`,
 			pendingCloseResults = nil
 		}
 		for _, id := range args {
-			// Resolve and get issue with routing (e.g., gt-xyz routes to another rig).
-			// Write-intent: update commits through the routed target store (#4141).
-			result, err := resolveAndGetIssueWithRoutingForWrite(ctx, store, id)
+			// Resolve and get issue with routing (e.g., gt-xyz routes to another rig)
+			result, err := resolveAndGetIssueForMutation(ctx, store, id)
 			if err != nil {
 				if result != nil {
 					result.Close()

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -1640,6 +1640,18 @@ func (s *DoltStore) Path() string {
 	return s.dbPath
 }
 
+// IsReadOnly reports whether the store was opened in read-only mode. It is a
+// test-facing accessor: production read-only enforcement comes from the
+// read-only open mode itself (the readOnly field guards every write path), not
+// from callers consulting this method. Tests such as
+// TestDepRoutedTargetOpensReadOnly use it to assert that routed
+// dependency/link target resolution opens a by-ID target read-only, so
+// resolving it never opens a foreign project writable or runs open-time
+// migrations into its history (bd-6dnrw.32, GH#3231).
+func (s *DoltStore) IsReadOnly() bool {
+	return s.readOnly
+}
+
 // CLIDir returns the directory for dolt CLI operations (push/pull/remote/fetch).
 // The actual database lives in a subdirectory of Path() named after the database.
 // Use this instead of Path() when running dolt CLI commands that target the

--- a/internal/storage/domain/db/issue_usecase_test.go
+++ b/internal/storage/domain/db/issue_usecase_test.go
@@ -158,6 +158,10 @@ func (s *testSuite) TestIssueUseCase_ApplyGraph() {
 	s.Run("DifferentTypeOverParentChildPairErrors", s.applyGraphDifferentTypeOverPair)
 	s.Run("ReverseBlockingOverParentChildPairErrors", s.applyGraphReverseBlocking)
 	s.Run("LiveCycleThroughExistingDepsErrors", s.applyGraphLiveCycle)
+	s.Run("ExternalIDIntraBatchBlockingCycleErrors", s.applyGraphExternalIDBlockingCycle)
+	s.Run("RegularGraphCycleThroughExistingWispDepErrors", s.applyGraphRegularCycleThroughWispDep)
+	s.Run("WispGraphCycleThroughExistingRegularDepErrors", s.applyGraphWispCycleThroughRegularDep)
+	s.Run("AllowsBlockingThroughExistingParentChild", s.applyGraphAllowsBlockingThroughParentChild)
 	s.Run("HealthyPlanRoundTrips", s.applyGraphHealthy)
 	s.Run("WispGraphRoutesToWispTables", s.applyGraphWispRouting)
 }
@@ -437,6 +441,132 @@ func (s *testSuite) applyGraphLiveCycle() {
 	for _, d := range deps {
 		s.NotEqual(string(types.DepParentChild), d.depType, "parent-child dep must not be written when live cycle detected: %+v", d)
 	}
+}
+
+// applyGraphExternalIDBlockingCycle proves the ported whole-graph preflight
+// (validatePlannedBlockingCycles) rejects an intra-batch blocking cycle formed
+// entirely by external-ID edges, before any edge is inserted.
+func (s *testSuite) applyGraphExternalIDBlockingCycle() {
+	s.resetMintConfig("gH", "")
+	uc := s.issueUseCase()
+
+	issueRepo := NewIssueSQLRepository(s.Runner())
+	p := newTestIssue("gH-existing-p", "existing P")
+	q := newTestIssue("gH-existing-q", "existing Q")
+	s.Require().NoError(issueRepo.Insert(s.Ctx(), p, "seeder", domain.InsertIssueOpts{}))
+	s.Require().NoError(issueRepo.Insert(s.Ctx(), q, "seeder", domain.InsertIssueOpts{}))
+
+	// Two planned blocking edges between existing issues, referenced by ID,
+	// close a 2-cycle within a single graph-apply batch.
+	_, err := uc.ApplyIssueGraph(s.Ctx(), domain.GraphPlan{
+		Edges: []domain.GraphEdge{
+			{FromID: "gH-existing-p", ToID: "gH-existing-q", Type: types.DepBlocks},
+			{FromID: "gH-existing-q", ToID: "gH-existing-p", Type: types.DepBlocks},
+		},
+	}, "tester")
+	s.Require().Error(err)
+	s.Contains(err.Error(), "creates a blocking dependency cycle")
+
+	deps := s.loadDepRows("dependencies", "gH-%")
+	s.Empty(deps, "no blocking edge may be written when an intra-batch external-ID cycle is detected")
+}
+
+// applyGraphRegularCycleThroughWispDep proves a regular graph-apply rejects a
+// planned blocking edge that closes a cycle through an existing blocking edge
+// living in wisp_dependencies. The per-edge depRepo.HasCycle probe this
+// preflight replaced walked both dependency tables, so the whole-graph walk
+// must too — otherwise a mixed regular/wisp blocking cycle commits undetected.
+func (s *testSuite) applyGraphRegularCycleThroughWispDep() {
+	s.resetMintConfig("gI", "")
+	uc := s.issueUseCase()
+
+	s.seedWispRow("gI-w")
+	s.seedIssueRow("gI-r")
+
+	// Existing blocking edge gI-w -> gI-r lives in wisp_dependencies.
+	s.Require().NoError(s.depRepo().Insert(s.Ctx(),
+		newDep("gI-w", "gI-r", types.DepBlocks), "seeder",
+		domain.DepInsertOpts{UseWispsTable: true}))
+
+	// Regular graph-apply adds gI-r -> gI-w (blocks) into dependencies, closing
+	// a blocking cycle that crosses the regular and wisp dependency tables.
+	_, err := uc.ApplyIssueGraph(s.Ctx(), domain.GraphPlan{
+		Edges: []domain.GraphEdge{
+			{FromID: "gI-r", ToID: "gI-w", Type: types.DepBlocks},
+		},
+	}, "tester")
+	s.Require().Error(err)
+	s.Contains(err.Error(), "creates a blocking dependency cycle")
+
+	s.Empty(s.loadDepRows("dependencies", "gI-%"),
+		"no regular blocking edge may be written when the cycle closes through an existing wisp dep")
+}
+
+// applyGraphWispCycleThroughRegularDep is the mirror of the case above: a wisp
+// graph-apply must reject a planned blocking edge that closes a cycle through
+// an existing blocking edge living in the regular dependencies table.
+func (s *testSuite) applyGraphWispCycleThroughRegularDep() {
+	s.resetMintConfig("gJ", "")
+	uc := s.issueUseCase()
+
+	s.seedIssueRow("gJ-r")
+	s.seedWispRow("gJ-w")
+
+	// Existing blocking edge gJ-r -> gJ-w lives in the regular dependencies
+	// table (with a wisp target column).
+	s.Require().NoError(s.depRepo().Insert(s.Ctx(),
+		newDep("gJ-r", "gJ-w", types.DepBlocks), "seeder",
+		domain.DepInsertOpts{}))
+
+	// Wisp graph-apply adds gJ-w -> gJ-r (blocks) into wisp_dependencies,
+	// closing a cross-table blocking cycle.
+	_, err := uc.ApplyWispGraph(s.Ctx(), domain.GraphPlan{
+		Edges: []domain.GraphEdge{
+			{FromID: "gJ-w", ToID: "gJ-r", Type: types.DepBlocks},
+		},
+	}, "tester")
+	s.Require().Error(err)
+	s.Contains(err.Error(), "creates a blocking dependency cycle")
+
+	s.Empty(s.loadDepRows("wisp_dependencies", "gJ-%"),
+		"no wisp blocking edge may be written when the cycle closes through an existing regular dep")
+}
+
+// applyGraphAllowsBlockingThroughParentChild mirrors the embedded
+// TestExecuteGraphApplyUnitAllowsBlockingThroughExistingParentChild on the
+// domain path: a planned blocking edge whose only return path is an existing
+// parent-child dep is allowed, because the blocking-cycle walk never follows
+// non-blocking dep types. This pins that the cycleRelevantDepType filter is not
+// silently widened on the server path.
+func (s *testSuite) applyGraphAllowsBlockingThroughParentChild() {
+	s.resetMintConfig("gK", "")
+	uc := s.issueUseCase()
+
+	s.seedIssueRow("gK-parent")
+	s.seedIssueRow("gK-child")
+
+	// Existing parent-child dep gK-child -> gK-parent: the only return path.
+	s.Require().NoError(s.depRepo().Insert(s.Ctx(),
+		newDep("gK-child", "gK-parent", types.DepParentChild), "seeder",
+		domain.DepInsertOpts{}))
+
+	// A planned blocking edge gK-parent -> gK-child. Its only "return path"
+	// gK-child -> gK-parent is parent-child, which the cycle walk must not
+	// follow, so this is allowed (matching bd dep add and embedded graph-apply).
+	_, err := uc.ApplyIssueGraph(s.Ctx(), domain.GraphPlan{
+		Edges: []domain.GraphEdge{
+			{FromID: "gK-parent", ToID: "gK-child", Type: types.DepBlocks},
+		},
+	}, "tester")
+	s.Require().NoError(err)
+
+	var blockingSeen bool
+	for _, d := range s.loadDepRows("dependencies", "gK-%") {
+		if d.depType == string(types.DepBlocks) && d.issueID == "gK-parent" && d.dependsOnID == "gK-child" {
+			blockingSeen = true
+		}
+	}
+	s.True(blockingSeen, "planned blocking edge gK-parent -> gK-child must be written when the only return path is a parent-child dep")
 }
 
 func (s *testSuite) applyGraphHealthy() {

--- a/internal/storage/domain/issue.go
+++ b/internal/storage/domain/issue.go
@@ -794,7 +794,10 @@ func (u *issueUseCaseImpl) applyGraph(ctx context.Context, plan GraphPlan, actor
 	// already-existing dependencies in the store. This must run before any
 	// dep inserts to catch the violation before we've written anything.
 	parentDepPairs := graphParentDepPairs(plan.Nodes, keyToID)
-	if err := u.validatePlannedBlockingPaths(ctx, plan, keyToID, parentDepPairs, useWisp); err != nil {
+	if err := u.validatePlannedBlockingPaths(ctx, plan, keyToID, parentDepPairs); err != nil {
+		return GraphApplyResult{}, err
+	}
+	if err := u.validatePlannedBlockingCycles(ctx, plan, keyToID); err != nil {
 		return GraphApplyResult{}, err
 	}
 
@@ -803,14 +806,10 @@ func (u *issueUseCaseImpl) applyGraph(ctx context.Context, plan GraphPlan, actor
 	//   - Same pair, different type   → error (conflicting edge over a parent-child link).
 	//   - Reverse pair, blocking type → error (creates a parent → child blocking cycle).
 	//
-	// Cycle-check skip optimization (matches embedded executeGraphApply):
-	// when every cycle-relevant edge in the plan is fully local (both
-	// endpoints by key, neither by ID), the CLI-side local cycle validator
-	// has already proven the planned subgraph is acyclic and
-	// validatePlannedBlockingPaths has covered parent-child paths against
-	// live deps. In that case the per-edge HasCycle SQL probe is skipped.
-	// Edges that reference external IDs always pay for HasCycle.
-	planCanSkipCycleCheck := applyGraphPlanCanSkipSQLCycleChecks(plan)
+	// Blocking cycles are already proven absent by validatePlannedBlockingCycles
+	// above (whole-graph preflight over planned + existing blocking edges, the
+	// same strategy as embedded executeGraphApply), so the edge insert loop no
+	// longer runs a per-edge HasCycle SQL probe.
 	for i, edge := range plan.Edges {
 		fromID := resolveEdgeRef(edge.FromKey, edge.FromID, keyToID)
 		if fromID == "" {
@@ -833,16 +832,6 @@ func (u *issueUseCaseImpl) applyGraph(ctx context.Context, plan GraphPlan, actor
 		}
 		if parentDepPairs[depPairKey(toID, fromID)] && cycleRelevantDepType(depType) {
 			return GraphApplyResult{}, fmt.Errorf("applyGraph: edge %d %s->%s creates a blocking reverse of a parent-child relationship", i, fromID, toID)
-		}
-
-		if cycleRelevantDepType(depType) && !(planCanSkipCycleCheck && applyGraphEdgeCanSkipSQLCycleCheck(edge, depType)) {
-			cycle, err := u.depRepo.HasCycle(ctx, fromID, toID)
-			if err != nil {
-				return GraphApplyResult{}, fmt.Errorf("applyGraph: edge %d cycle check: %w", i, err)
-			}
-			if cycle {
-				return GraphApplyResult{}, fmt.Errorf("applyGraph: edge %d (%s -> %s): would create a cycle", i, fromID, toID)
-			}
 		}
 
 		dep := &types.Dependency{
@@ -932,37 +921,15 @@ func cycleRelevantDepType(t types.DependencyType) bool {
 	return t == types.DepBlocks || t == types.DepConditionalBlocks
 }
 
-// applyGraphPlanCanSkipSQLCycleChecks returns true when every cycle-relevant
-// edge in the plan is purely local (both endpoints by key, neither by ID).
-// In that case the CLI-side local cycle validator has already proven the
-// planned subgraph is acyclic, and no per-edge SQL HasCycle probe is needed
-// in applyGraph's edge pass. Non-cycle-relevant edges (e.g. "related") do
-// not gate the skip. Mirrors embedded graphApplyPlanCanSkipSQLCycleChecks.
-func applyGraphPlanCanSkipSQLCycleChecks(plan GraphPlan) bool {
-	for _, edge := range plan.Edges {
-		depType := edge.Type
-		if depType == "" {
-			depType = types.DepBlocks
-		}
-		if !cycleRelevantDepType(depType) {
-			continue
-		}
-		if !applyGraphEdgeCanSkipSQLCycleCheck(edge, depType) {
-			return false
-		}
-	}
-	return true
-}
-
-// applyGraphEdgeCanSkipSQLCycleCheck returns true when the edge is fully
-// local (both endpoints by key, neither by ID) and the dep type is
-// cycle-relevant. An edge that references an external ID always pays for
-// HasCycle because the local validator never saw the external graph.
-func applyGraphEdgeCanSkipSQLCycleCheck(edge GraphEdge, depType types.DependencyType) bool {
-	if edge.FromKey == "" || edge.ToKey == "" || edge.FromID != "" || edge.ToID != "" {
-		return false
-	}
-	return cycleRelevantDepType(depType)
+// readyPathDepType reports whether a dependency type affects ready-work. It is
+// the broad predicate used when walking existing deps for parent→child
+// blocking-path validation, in contrast to the blocking-only
+// cycleRelevantDepType used for pure blocking-cycle detection. The two must
+// stay distinct: narrowing the parent-path walk would miss real ready-work
+// deadlocks, while broadening the blocking-cycle walk would reject edges that
+// plain `bd dep add` accepts.
+func readyPathDepType(t types.DependencyType) bool {
+	return t.AffectsReadyWork()
 }
 
 // resolveEdgeRef returns the ID for an edge endpoint: the keyToID lookup
@@ -987,7 +954,6 @@ func (u *issueUseCaseImpl) validatePlannedBlockingPaths(
 	plan GraphPlan,
 	keyToID map[string]string,
 	parentDepPairs map[string]bool,
-	useWisp bool,
 ) error {
 	adj := make(map[string][]string)
 	for pair := range parentDepPairs {
@@ -1001,7 +967,7 @@ func (u *issueUseCaseImpl) validatePlannedBlockingPaths(
 		if depType == "" {
 			depType = types.DepBlocks
 		}
-		if !depType.AffectsReadyWork() {
+		if !readyPathDepType(depType) {
 			continue
 		}
 		fromID := resolveEdgeRef(edge.FromKey, edge.FromID, keyToID)
@@ -1029,7 +995,7 @@ func (u *issueUseCaseImpl) validatePlannedBlockingPaths(
 		if childID == "" || parentID == "" {
 			continue
 		}
-		hasPath, err := u.graphHasPath(ctx, adj, depCache, parentID, childID, useWisp)
+		hasPath, err := u.graphHasPath(ctx, adj, depCache, parentID, childID, readyPathDepType)
 		if err != nil {
 			return err
 		}
@@ -1040,16 +1006,79 @@ func (u *issueUseCaseImpl) validatePlannedBlockingPaths(
 	return nil
 }
 
+// validatePlannedBlockingCycles rejects planned blocking edges that would close
+// a blocking-dependency cycle, evaluated whole-graph before any insert. It
+// mirrors embedded validateGraphApplyPlannedBlockingCycles and the storage
+// per-edge SQL cycle check (depRepo.HasCycle): both the planned adjacency and
+// the existing-dep walk are restricted to blocks/conditional-blocks via
+// cycleRelevantDepType, so graph-apply stays consistent with `bd dep add` and
+// does not reject a blocking edge whose return path runs through an existing
+// parent-child or waits-for dep.
+func (u *issueUseCaseImpl) validatePlannedBlockingCycles(
+	ctx context.Context,
+	plan GraphPlan,
+	keyToID map[string]string,
+) error {
+	type plannedEdge struct {
+		index  int
+		fromID string
+		toID   string
+	}
+
+	adj := make(map[string][]string)
+	checks := make([]plannedEdge, 0, len(plan.Edges))
+	for i, edge := range plan.Edges {
+		depType := edge.Type
+		if depType == "" {
+			depType = types.DepBlocks
+		}
+		if !cycleRelevantDepType(depType) {
+			continue
+		}
+		fromID := resolveEdgeRef(edge.FromKey, edge.FromID, keyToID)
+		toID := resolveEdgeRef(edge.ToKey, edge.ToID, keyToID)
+		if fromID == "" || toID == "" {
+			continue
+		}
+		if fromID == toID {
+			return fmt.Errorf("applyGraph: edge %d %s->%s creates a blocking dependency cycle", i, fromID, toID)
+		}
+		adj[fromID] = append(adj[fromID], toID)
+		checks = append(checks, plannedEdge{index: i, fromID: fromID, toID: toID})
+	}
+
+	depCache := make(map[string][]*types.Dependency)
+	for _, edge := range checks {
+		hasPath, err := u.graphHasPath(ctx, adj, depCache, edge.toID, edge.fromID, cycleRelevantDepType)
+		if err != nil {
+			return fmt.Errorf("applyGraph: edge %d %s->%s: checking planned blocking cycle: %w", edge.index, edge.fromID, edge.toID, err)
+		}
+		if hasPath {
+			return fmt.Errorf("applyGraph: edge %d %s->%s creates a blocking dependency cycle", edge.index, edge.fromID, edge.toID)
+		}
+	}
+	return nil
+}
+
 // graphHasPath returns true if fromID can reach toID by following the
 // in-memory adjacency (planned parent-child + planned blocking edges) and
-// existing AffectsReadyWork deps loaded lazily from the store. Per-node
-// dep fetches are cached so each visited node hits the DB at most once.
+// existing deps loaded lazily from the store. followExistingDep selects which
+// existing dep types the walk traverses, so callers can mirror either the
+// blocking-only SQL cycle check or the broader ready-work graph. Per-node dep
+// fetches are cached so each visited node hits the DB at most once.
+//
+// Existing deps are loaded from BOTH dependency tables. The per-edge
+// depRepo.HasCycle probe this walk replaced traversed dependencies ∪
+// wisp_dependencies (and the embedded path's GetDependencyRecords selects the
+// table per node), so a blocking cycle that closes through the other table —
+// e.g. an existing wisp edge reached during a regular graph-apply — must still
+// be detected regardless of which table this graph-apply primarily writes.
 func (u *issueUseCaseImpl) graphHasPath(
 	ctx context.Context,
 	adj map[string][]string,
 	depCache map[string][]*types.Dependency,
 	fromID, toID string,
-	useWisp bool,
+	followExistingDep func(types.DependencyType) bool,
 ) (bool, error) {
 	seen := make(map[string]bool)
 	var visit func(string) (bool, error)
@@ -1069,18 +1098,25 @@ func (u *issueUseCaseImpl) graphHasPath(
 		}
 		deps, ok := depCache[id]
 		if !ok {
-			res, err := u.depRepo.ListByIssueIDs(ctx, []string{id}, DepListOpts{
+			regular, err := u.depRepo.ListByIssueIDs(ctx, []string{id}, DepListOpts{
 				Direction:     DepDirectionOut,
-				UseWispsTable: useWisp,
+				UseWispsTable: false,
 			})
 			if err != nil {
 				return false, fmt.Errorf("applyGraph: read existing deps for %s: %w", id, err)
 			}
-			deps = res.Outgoing[id]
+			wisp, err := u.depRepo.ListByIssueIDs(ctx, []string{id}, DepListOpts{
+				Direction:     DepDirectionOut,
+				UseWispsTable: true,
+			})
+			if err != nil {
+				return false, fmt.Errorf("applyGraph: read existing wisp deps for %s: %w", id, err)
+			}
+			deps = append(regular.Outgoing[id], wisp.Outgoing[id]...)
 			depCache[id] = deps
 		}
 		for _, dep := range deps {
-			if !dep.Type.AffectsReadyWork() {
+			if !followExistingDep(dep.Type) {
 				continue
 			}
 			found, err := visit(dep.DependsOnID)


### PR DESCRIPTION
## Summary
- preflight the planned graph for blocking dependency cycles before inserting edges
- skip per-edge SQL cycle checks for cycle-relevant graph apply dependencies after the graph-level preflight passes
- cover mixed local/external fanout edges with focused tests

## Verification
- go test ./cmd/bd -run 'TestExecuteGraphApplyUnit(SkipsSQLCycleChecksAfterGraphPreflight|RejectsMixedLocalExternalBlockingCycle|RejectsBlockingChildToParentDuplicate|RejectsReverseParentToChildBlockingEdge)' -count=1
- go test ./cmd/bd -run 'TestExecuteGraphApplyRejectsMixedLocalExternalBlockingCycle|TestExecuteGraphApplyRejectsStoredPrefixParentBlockingPath|TestExecuteGraphApplyAllowsExplicitParentChildDuplicate' -count=1