### PR TITLE
feat(count): add --include-infra for exact bd list cardinality parity

### DIFF
--- a/cmd/bd/assign.go
+++ b/cmd/bd/assign.go
@@ -27,7 +27,9 @@ Examples:
 
 		ctx := rootCtx
 
-		result, err := resolveAndGetIssueWithRouting(ctx, store, id)
+		// Write-intent routing: a prefix-routed target must open writable so the
+		// assignee update commits on the target head (#4141).
+		result, err := resolveAndGetIssueWithRoutingForWrite(ctx, store, id)
 		if err != nil {
 			if result != nil {
 				result.Close()

--- a/cmd/bd/autocommit_embedded_test.go
+++ b/cmd/bd/autocommit_embedded_test.go
@@ -245,3 +245,114 @@ func TestEmbeddedRoutedSiblingWritesCommitTargetHead(t *testing.T) {
 		}
 	})
 }
+
+// TestEmbeddedRoutedMutatingSiblingWritesCommitTargetHead pins the rest of the
+// prefix-routed mutating command surface to the same write-through contract as
+// comment/note/reopen above. These commands (the assign/tag shorthands plus
+// dep/delete/close) resolve a prefix-routed target through the write-intent
+// router and must commit on the target head, not fail "store is read-only"
+// (#4141). Each subtest creates the bead in the target rig, runs the command
+// from the source rig so resolution must route, and asserts both that the
+// target HEAD advanced and that the mutation persisted in the target store.
+func TestEmbeddedRoutedMutatingSiblingWritesCommitTargetHead(t *testing.T) {
+	if os.Getenv("BEADS_TEST_EMBEDDED_DOLT") != "1" {
+		t.Skip("set BEADS_TEST_EMBEDDED_DOLT=1 to run embedded dolt auto-commit tests")
+	}
+	t.Parallel()
+
+	bd := buildEmbeddedBD(t)
+
+	t.Run("assign", func(t *testing.T) {
+		sourceDir, targetDir, targetBeadsDir := setupRoutedEmbeddedRepo(t, bd, "sas", "tas")
+		issue := bdCreate(t, bd, targetDir, "Routed assign target")
+		before := embeddedCurrentCommit(t, targetBeadsDir, "tas")
+
+		bdCommand(t, bd, sourceDir, "assign", issue.ID, "alice")
+
+		assertEmbeddedHeadAdvanced(t, targetBeadsDir, "tas", before, "routed assign")
+		targetStore := openStore(t, targetBeadsDir, "tas")
+		got, err := targetStore.GetIssue(t.Context(), issue.ID)
+		if err != nil {
+			t.Fatalf("GetIssue: %v", err)
+		}
+		if got.Assignee != "alice" {
+			t.Fatalf("target assignee = %q, want alice", got.Assignee)
+		}
+	})
+
+	t.Run("tag", func(t *testing.T) {
+		sourceDir, targetDir, targetBeadsDir := setupRoutedEmbeddedRepo(t, bd, "stg", "ttg")
+		issue := bdCreate(t, bd, targetDir, "Routed tag target")
+		before := embeddedCurrentCommit(t, targetBeadsDir, "ttg")
+
+		bdCommand(t, bd, sourceDir, "tag", issue.ID, "routed-label")
+
+		assertEmbeddedHeadAdvanced(t, targetBeadsDir, "ttg", before, "routed tag")
+		targetStore := openStore(t, targetBeadsDir, "ttg")
+		labels, err := targetStore.GetLabelsForIssues(t.Context(), []string{issue.ID})
+		if err != nil {
+			t.Fatalf("GetLabelsForIssues: %v", err)
+		}
+		if !slices.Contains(labels[issue.ID], "routed-label") {
+			t.Fatalf("target labels = %v, want routed-label", labels[issue.ID])
+		}
+	})
+
+	t.Run("dep_add", func(t *testing.T) {
+		sourceDir, targetDir, targetBeadsDir := setupRoutedEmbeddedRepo(t, bd, "sdp", "tdp")
+		from := bdCreate(t, bd, targetDir, "Routed dep source")
+		to := bdCreate(t, bd, targetDir, "Routed dep target")
+		before := embeddedCurrentCommit(t, targetBeadsDir, "tdp")
+
+		bdCommand(t, bd, sourceDir, "dep", "add", from.ID, to.ID)
+
+		assertEmbeddedHeadAdvanced(t, targetBeadsDir, "tdp", before, "routed dep add")
+		targetStore := openStore(t, targetBeadsDir, "tdp")
+		deps, err := targetStore.GetDependencies(t.Context(), from.ID)
+		if err != nil {
+			t.Fatalf("GetDependencies: %v", err)
+		}
+		found := false
+		for _, d := range deps {
+			if d.ID == to.ID {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("routed dep add did not persist %s -> %s in target store (deps=%v)", from.ID, to.ID, deps)
+		}
+	})
+
+	t.Run("delete", func(t *testing.T) {
+		sourceDir, targetDir, targetBeadsDir := setupRoutedEmbeddedRepo(t, bd, "sdl", "tdl")
+		issue := bdCreate(t, bd, targetDir, "Routed delete target")
+		before := embeddedCurrentCommit(t, targetBeadsDir, "tdl")
+
+		bdCommand(t, bd, sourceDir, "delete", issue.ID, "--force")
+
+		assertEmbeddedHeadAdvanced(t, targetBeadsDir, "tdl", before, "routed delete")
+		targetStore := openStore(t, targetBeadsDir, "tdl")
+		if _, err := targetStore.GetIssue(t.Context(), issue.ID); err == nil {
+			t.Fatalf("routed delete did not remove %s from target store", issue.ID)
+		}
+	})
+
+	t.Run("close", func(t *testing.T) {
+		sourceDir, targetDir, targetBeadsDir := setupRoutedEmbeddedRepo(t, bd, "scl", "tcl")
+		issue := bdCreate(t, bd, targetDir, "Routed close target")
+		before := embeddedCurrentCommit(t, targetBeadsDir, "tcl")
+
+		bdCommand(t, bd, sourceDir, "close", issue.ID, "--reason", "routed close")
+
+		assertEmbeddedHeadAdvanced(t, targetBeadsDir, "tcl", before, "routed close")
+		targetStore := openStore(t, targetBeadsDir, "tcl")
+		got, err := targetStore.GetIssue(t.Context(), issue.ID)
+		if err != nil {
+			t.Fatalf("GetIssue: %v", err)
+		}
+		if got.Status != types.StatusClosed {
+			t.Fatalf("target status = %s, want %s", got.Status, types.StatusClosed)
+		}
+	})
+}

--- a/cmd/bd/close.go
+++ b/cmd/bd/close.go
@@ -613,7 +613,10 @@ func resolveCloseTargets(ctx context.Context, localStore storage.DoltStorage, id
 			cleanup()
 			return nil, func() {}, fmt.Errorf("resolving ID %s: %w", id, err)
 		}
-		if r, err := resolveViaPrefixRouting(ctx, id); err == nil {
+		// Write-intent: a prefix-routed target opens writable so the close
+		// commits on the target head (#4141). Contributor auto-routing below
+		// stays read-only: it hydrates foreign projects that must not be mutated.
+		if r, err := resolveViaPrefixRoutingMode(ctx, id, true); err == nil {
 			results = append(results, r)
 			continue
 		}

--- a/cmd/bd/comment.go
+++ b/cmd/bd/comment.go
@@ -62,7 +62,7 @@ Examples:
 
 		ctx := rootCtx
 
-		result, err := resolveAndGetIssueWithRouting(ctx, store, id)
+		result, err := resolveAndGetIssueWithRoutingForWrite(ctx, store, id)
 		if err != nil {
 			if result != nil {
 				result.Close()

--- a/cmd/bd/comments.go
+++ b/cmd/bd/comments.go
@@ -156,7 +156,9 @@ Examples:
 		}
 		ctx := rootCtx
 
-		result, err := resolveAndGetIssueWithRouting(ctx, store, issueID)
+		// Write-intent: comments add writes through the routed target store,
+		// matching the `bd comment` shorthand (#4141).
+		result, err := resolveAndGetIssueWithRoutingForWrite(ctx, store, issueID)
 		if err != nil {
 			if result != nil {
 				result.Close()

--- a/cmd/bd/count.go
+++ b/cmd/bd/count.go
@@ -29,6 +29,7 @@ Examples:
   bd count --by-assignee            # Group count by assignee
   bd count --by-label               # Group count by label
   bd count --assignee alice --by-status  # Count alice's issues by status
+  bd count --include-infra          # Count issues + wisps tier (matches 'bd list --include-infra --all' cardinality)
 `,
 	Run: func(cmd *cobra.Command, args []string) {
 		status, _ := cmd.Flags().GetString("status")
@@ -197,7 +198,15 @@ Examples:
 			filter.PriorityMax = &priorityMax
 		}
 
-		filter.SkipWisps = true // bd count never needs ephemeral wisp results
+		if includeInfra, _ := cmd.Flags().GetBool("include-infra"); includeInfra {
+			cfg, err := loadDirectListFilterConfig(ctx, store)
+			if err != nil {
+				FatalError("%v", err)
+			}
+			applyCountIncludeInfra(&filter, issueType, cfg)
+		} else {
+			filter.SkipWisps = true // durable tier only; bd count's historical default
+		}
 
 		// Q1: SQL COUNT(*) aggregate — avoids materializing all rows.
 		if groupBy == "" {
@@ -261,6 +270,40 @@ Examples:
 	},
 }
 
+// applyCountIncludeInfra switches the count filter to the wisps-inclusive
+// mode of `bd list --include-infra` (GH#4387). It mirrors the buildListFilter
+// defaults that determine list's cardinality so that, for any filter set,
+// `bd count --include-infra <filters>` returns exactly the number of rows
+// `bd list --include-infra <filters> --all` materializes:
+//
+//   - the wisps table is merged into the count (SkipWisps=false), picking up
+//     no_history beads (durable work stored in the wisps tier) and ephemeral
+//     wisps, exactly like list's merge path;
+//   - template molecules are excluded (list's default without
+//     --include-templates);
+//   - gate beads are excluded unless gates are explicitly requested via
+//     --type gate (list's default without --include-gates);
+//   - counting an infra type (agent/rig/role/message, or the store-configured
+//     set) routes to the ephemeral wisps tier, like list's infra-type listing.
+//
+// The non-flag path never calls this function: bd count without
+// --include-infra keeps its historical durable-only semantics.
+func applyCountIncludeInfra(filter *types.IssueFilter, issueType string, cfg listFilterConfig) {
+	filter.SkipWisps = false
+
+	isTemplate := false
+	filter.IsTemplate = &isTemplate
+
+	if issueType != "gate" {
+		filter.ExcludeTypes = append(filter.ExcludeTypes, "gate")
+	}
+
+	if issueType != "" && cfg.isInfra(issueType) {
+		ephemeral := true
+		filter.Ephemeral = &ephemeral
+	}
+}
+
 func init() {
 	// Filter flags (same as list command)
 	countCmd.Flags().StringP("status", "s", "", "Filter by stored status (open, in_progress, blocked, deferred, closed). Note: dependency-blocked issues use 'bd blocked'")
@@ -293,6 +336,11 @@ func init() {
 	// Priority ranges
 	countCmd.Flags().Int("priority-min", 0, "Filter by minimum priority (inclusive)")
 	countCmd.Flags().Int("priority-max", 0, "Filter by maximum priority (inclusive)")
+
+	// Wisps tier (GH#4387): mirrors bd list's flag of the same name so
+	// `bd count --include-infra <filters>` returns exactly the cardinality of
+	// `bd list --include-infra <filters> --all`.
+	countCmd.Flags().Bool("include-infra", false, "Include infrastructure beads and the wisps tier (matches 'bd list --include-infra --all' cardinality)")
 
 	// Grouping flags
 	countCmd.Flags().Bool("by-status", false, "Group count by status")

--- a/cmd/bd/count_embedded_test.go
+++ b/cmd/bd/count_embedded_test.go
@@ -465,6 +465,113 @@ func TestEmbeddedCount(t *testing.T) {
 	})
 }
 
+// TestEmbeddedCountIncludeInfra is the CLI-level guard for GH#4387:
+// `bd count --include-infra <filters>` must return exactly the cardinality of
+// `bd list --include-infra <filters> --all` (modulo list's --limit), including
+// the wisps tier (no_history + ephemeral beads) and honoring list's default
+// template exclusion. Without the flag, bd count keeps today's durable-only
+// semantics.
+func TestEmbeddedCountIncludeInfra(t *testing.T) {
+	if os.Getenv("BEADS_TEST_EMBEDDED_DOLT") != "1" {
+		t.Skip("set BEADS_TEST_EMBEDDED_DOLT=1 to run embedded dolt integration tests")
+	}
+	t.Parallel()
+
+	bd := buildEmbeddedBD(t)
+	dir, _, _ := bdInit(t, bd, "--prefix", "ci")
+
+	// Durable issues tier.
+	bdCreate(t, bd, dir, "Infra durable task one", "--type", "task")
+	bdCreate(t, bd, dir, "Infra durable task two", "--type", "task")
+	bdCreate(t, bd, dir, "Infra durable bug", "--type", "bug")
+	closedIssue := bdCreate(t, bd, dir, "Infra durable task closed", "--type", "task")
+	bdClose(t, bd, dir, closedIssue.ID)
+	// Wisps tier: no_history beads are durable work that bd list --include-infra
+	// returns; ephemeral beads are GC-eligible wisps.
+	bdCreate(t, bd, dir, "Infra nohistory task one", "--type", "task", "--no-history")
+	bdCreate(t, bd, dir, "Infra nohistory task two", "--type", "task", "--no-history")
+	bdCreate(t, bd, dir, "Infra ephemeral task", "--type", "task", "--ephemeral")
+
+	countOf := func(args ...string) int {
+		t.Helper()
+		m := bdCountJSON(t, bd, dir, args...)
+		return int(m["count"].(float64))
+	}
+	listCardinality := func(args ...string) int {
+		t.Helper()
+		fullArgs := append([]string{"--include-infra", "--all", "--limit", "0"}, args...)
+		return len(bdListJSON(t, bd, dir, fullArgs...))
+	}
+
+	t.Run("default_stays_durable_only", func(t *testing.T) {
+		if got := countOf("--type", "task"); got != 3 {
+			t.Errorf("bd count --type task = %d, want 3 (durable tasks only; default must stay byte-identical)", got)
+		}
+	})
+
+	t.Run("include_infra_counts_wisps_tier", func(t *testing.T) {
+		// 3 durable tasks + 2 no_history tasks + 1 ephemeral task.
+		if got := countOf("--include-infra", "--type", "task"); got != 6 {
+			t.Errorf("bd count --include-infra --type task = %d, want 6", got)
+		}
+	})
+
+	t.Run("include_infra_matches_list_cardinality", func(t *testing.T) {
+		for _, filters := range [][]string{
+			nil,
+			{"--type", "task"},
+			{"--type", "bug"},
+			{"--status", "open"},
+			{"--status", "closed"},
+		} {
+			want := listCardinality(filters...)
+			got := countOf(append([]string{"--include-infra"}, filters...)...)
+			if got != want {
+				t.Errorf("bd count --include-infra %v = %d, but bd list --include-infra --all %v returned %d rows", filters, got, filters, want)
+			}
+		}
+	})
+
+	t.Run("include_infra_grouped_by_type", func(t *testing.T) {
+		m := bdCountJSON(t, bd, dir, "--include-infra", "--by-type")
+		total := int(m["total"].(float64))
+		if want := listCardinality(); total != want {
+			t.Errorf("bd count --include-infra --by-type total = %d, want list cardinality %d", total, want)
+		}
+		groups, ok := m["groups"].([]interface{})
+		if !ok {
+			t.Fatal("expected groups array")
+		}
+		byType := make(map[string]int)
+		for _, g := range groups {
+			gm := g.(map[string]interface{})
+			byType[gm["group"].(string)] = int(gm["count"].(float64))
+		}
+		if byType["task"] != 6 {
+			t.Errorf("grouped task count = %d, want 6 (wisps tier missing from --by-type)", byType["task"])
+		}
+		if byType["bug"] != 1 {
+			t.Errorf("grouped bug count = %d, want 1", byType["bug"])
+		}
+	})
+
+	t.Run("grouped_without_flag_stays_durable_only", func(t *testing.T) {
+		m := bdCountJSON(t, bd, dir, "--by-type")
+		groups, ok := m["groups"].([]interface{})
+		if !ok {
+			t.Fatal("expected groups array")
+		}
+		for _, g := range groups {
+			gm := g.(map[string]interface{})
+			if gm["group"] == "task" {
+				if got := int(gm["count"].(float64)); got != 3 {
+					t.Errorf("bd count --by-type task = %d, want 3 (durable only)", got)
+				}
+			}
+		}
+	})
+}
+
 // TestEmbeddedCountConcurrent exercises count operations concurrently.
 func TestEmbeddedCountConcurrent(t *testing.T) {
 	if os.Getenv("BEADS_TEST_EMBEDDED_DOLT") != "1" {

--- a/cmd/bd/count_filter_test.go
+++ b/cmd/bd/count_filter_test.go
@@ -1,0 +1,114 @@
+//go:build cgo
+
+package main
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// TestApplyCountIncludeInfraMirrorsListFilter pins `bd count --include-infra`
+// to the exact cardinality semantics of `bd list --include-infra --all`
+// (GH#4387): for any filter set, the count must equal the number of rows the
+// equivalent list invocation returns. The trap dimensions are the wisps merge
+// (SkipWisps), template exclusion (IsTemplate), the default gate exclusion
+// (ExcludeTypes), and infra-type routing to the ephemeral tier (Ephemeral).
+func TestApplyCountIncludeInfraMirrorsListFilter(t *testing.T) {
+	cfg := listFilterConfig{}
+	for _, issueType := range []string{"", "task", "gate", "message"} {
+		name := issueType
+		if name == "" {
+			name = "none"
+		}
+		t.Run("type_"+name, func(t *testing.T) {
+			in := listInput{allFlag: true, includeInfra: true, issueType: issueType}
+			want, err := buildListFilter(in, cfg)
+			if err != nil {
+				t.Fatalf("buildListFilter(%q): %v", issueType, err)
+			}
+
+			got := types.IssueFilter{}
+			if issueType != "" {
+				it := types.IssueType(issueType)
+				got.IssueType = &it
+			}
+			applyCountIncludeInfra(&got, issueType, cfg)
+
+			if got.SkipWisps != want.SkipWisps {
+				t.Errorf("SkipWisps = %v, list --include-infra --all uses %v", got.SkipWisps, want.SkipWisps)
+			}
+			if !reflect.DeepEqual(got.IsTemplate, want.IsTemplate) {
+				t.Errorf("IsTemplate = %v, list --include-infra --all uses %v", ptrStr(got.IsTemplate), ptrStr(want.IsTemplate))
+			}
+			if !reflect.DeepEqual(got.ExcludeTypes, want.ExcludeTypes) {
+				t.Errorf("ExcludeTypes = %v, list --include-infra --all uses %v", got.ExcludeTypes, want.ExcludeTypes)
+			}
+			if !reflect.DeepEqual(got.Ephemeral, want.Ephemeral) {
+				t.Errorf("Ephemeral = %v, list --include-infra --all uses %v", ptrStr(got.Ephemeral), ptrStr(want.Ephemeral))
+			}
+			if !reflect.DeepEqual(got.IssueType, want.IssueType) {
+				t.Errorf("IssueType = %v, list --include-infra --all uses %v", got.IssueType, want.IssueType)
+			}
+			// bd count defaults to all statuses and all pinned states, which is
+			// exactly what list's --all flag selects: none of these dimensions
+			// may carry a filter on either side.
+			if !reflect.DeepEqual(got.Status, want.Status) {
+				t.Errorf("Status = %v, list --include-infra --all uses %v", got.Status, want.Status)
+			}
+			if !reflect.DeepEqual(got.Statuses, want.Statuses) {
+				t.Errorf("Statuses = %v, list --include-infra --all uses %v", got.Statuses, want.Statuses)
+			}
+			if !reflect.DeepEqual(got.ExcludeStatus, want.ExcludeStatus) {
+				t.Errorf("ExcludeStatus = %v, list --include-infra --all uses %v", got.ExcludeStatus, want.ExcludeStatus)
+			}
+			if !reflect.DeepEqual(got.Pinned, want.Pinned) {
+				t.Errorf("Pinned = %v, list --include-infra --all uses %v", ptrStr(got.Pinned), ptrStr(want.Pinned))
+			}
+		})
+	}
+}
+
+// TestApplyCountIncludeInfraCustomInfraTypes verifies that the infra-type
+// routing honors a store-configured infra set, exactly like bd list does.
+func TestApplyCountIncludeInfraCustomInfraTypes(t *testing.T) {
+	cfg := listFilterConfig{infraSet: map[string]bool{"robot": true}}
+
+	var robot types.IssueFilter
+	applyCountIncludeInfra(&robot, "robot", cfg)
+	if robot.Ephemeral == nil || !*robot.Ephemeral {
+		t.Errorf("custom infra type %q must route to the ephemeral tier (Ephemeral=true), got %v", "robot", ptrStr(robot.Ephemeral))
+	}
+
+	// "message" is a default infra type but NOT part of the custom set, so it
+	// must not route to the ephemeral tier (mirrors listFilterConfig.isInfra).
+	var msg types.IssueFilter
+	applyCountIncludeInfra(&msg, "message", cfg)
+	if msg.Ephemeral != nil {
+		t.Errorf("non-infra type under custom set must keep Ephemeral=nil, got %v", ptrStr(msg.Ephemeral))
+	}
+}
+
+// TestApplyCountIncludeInfraDefaultUntouched documents that the helper is only
+// invoked under --include-infra: the no-flag path must keep today's
+// durable-only semantics (SkipWisps=true, no template/gate exclusion).
+func TestApplyCountIncludeInfraDefaultUntouched(t *testing.T) {
+	// The default path in count.go does not call applyCountIncludeInfra; it
+	// sets SkipWisps=true and nothing else. Pin the flag's existence and
+	// default value so scripted callers keep byte-identical behavior.
+	flag := countCmd.Flags().Lookup("include-infra")
+	if flag == nil {
+		t.Fatal("bd count must expose an --include-infra flag (GH#4387)")
+	}
+	if flag.DefValue != "false" {
+		t.Fatalf("--include-infra must default to false, got %q", flag.DefValue)
+	}
+}
+
+func ptrStr[T any](p *T) string {
+	if p == nil {
+		return "<nil>"
+	}
+	return "&" + reflect.ValueOf(*p).String()
+}

--- a/cmd/bd/delete.go
+++ b/cmd/bd/delete.go
@@ -88,8 +88,10 @@ Force: Delete and orphan dependents
 		// Single issue deletion (legacy behavior)
 		issueID := issueIDs[0]
 		ctx := rootCtx
-		// Get the issue to be deleted, using prefix-based routing
-		routedResult, err := resolveAndGetIssueWithRouting(ctx, store, issueID)
+		// Get the issue to be deleted, using prefix-based routing. Write-intent:
+		// a prefix-routed target opens writable so the delete commits on the
+		// target head (#4141).
+		routedResult, err := resolveAndGetIssueWithRoutingForWrite(ctx, store, issueID)
 		if err != nil {
 			if isNotFoundErr(err) {
 				FatalError("issue %s not found", issueID)
@@ -252,7 +254,9 @@ func deleteBatch(_ *cobra.Command, issueIDs []string, force bool, dryRun bool, c
 	notFound := []string{}
 	var routedStore storage.DoltStorage
 	for _, id := range issueIDs {
-		result, err := resolveAndGetIssueWithRouting(ctx, store, id)
+		// Write-intent: the batch delete mutates this routed store below, so it
+		// must open writable to commit on the target head (#4141).
+		result, err := resolveAndGetIssueWithRoutingForWrite(ctx, store, id)
 		if err != nil {
 			if isNotFoundErr(err) {
 				notFound = append(notFound, id)

--- a/cmd/bd/dep.go
+++ b/cmd/bd/dep.go
@@ -22,8 +22,30 @@ import (
 // If the issue routes to a different database, a routed store is returned
 // and must be closed by the caller via the returned cleanup function.
 // If the issue is in the local store, cleanup is a no-op.
+//
+// The routed store is opened read-only; callers that mutate the returned store
+// (e.g. dep add/remove/link writing through the source issue's store) must use
+// resolveIDWithRoutingForWrite instead.
 func resolveIDWithRouting(ctx context.Context, localStore storage.DoltStorage, id string) (resolvedID string, targetStore storage.DoltStorage, cleanup func(), err error) {
-	result, err := resolveAndGetIssueWithRouting(ctx, localStore, id)
+	return resolveIDWithRoutingMode(ctx, localStore, id, false)
+}
+
+// resolveIDWithRoutingForWrite is the write-intent variant of
+// resolveIDWithRouting: a prefix-routed target store is opened writable so a
+// dependency write through it commits on the target head (#4141). Read-only
+// resolution (e.g. resolving the depends-on target ID, or dep tree) must keep
+// resolveIDWithRouting so a routed read never mutates a foreign project's
+// history (bd-6dnrw.32, GH#3231).
+func resolveIDWithRoutingForWrite(ctx context.Context, localStore storage.DoltStorage, id string) (resolvedID string, targetStore storage.DoltStorage, cleanup func(), err error) {
+	return resolveIDWithRoutingMode(ctx, localStore, id, true)
+}
+
+func resolveIDWithRoutingMode(ctx context.Context, localStore storage.DoltStorage, id string, forWrite bool) (resolvedID string, targetStore storage.DoltStorage, cleanup func(), err error) {
+	resolve := resolveAndGetIssueWithRouting
+	if forWrite {
+		resolve = resolveAndGetIssueWithRoutingForWrite
+	}
+	result, err := resolve(ctx, localStore, id)
 	if err != nil {
 		return "", nil, func() {}, fmt.Errorf("resolving issue ID %s: %w", id, err)
 	}
@@ -123,8 +145,10 @@ Examples:
 			ctx := rootCtx
 			depType := "blocks"
 
-			// Resolve partial IDs with routing support
-			fromID, fromStore, fromCleanup, err := resolveIDWithRouting(ctx, store, blocksID)
+			// Resolve partial IDs with routing support. The source issue's store
+			// is mutated below, so resolve it write-intent (#4141); the blocker
+			// target is only resolved by ID and stays read-only.
+			fromID, fromStore, fromCleanup, err := resolveIDWithRoutingForWrite(ctx, store, blocksID)
 			if err != nil {
 				FatalErrorRespectJSON("%v", err)
 			}
@@ -280,7 +304,9 @@ Examples:
 		// Check if toID is an external reference (don't resolve it)
 		isExternalRef := strings.HasPrefix(dependsOnArg, "external:")
 
-		fromID, fromStore, fromCleanup, err := resolveIDWithRouting(ctx, store, args[0])
+		// Write-intent: the source issue's store is mutated by AddDependency
+		// below, so the routed target must open writable (#4141).
+		fromID, fromStore, fromCleanup, err := resolveIDWithRoutingForWrite(ctx, store, args[0])
 		if err != nil {
 			FatalErrorRespectJSON("%v", err)
 		}
@@ -571,7 +597,9 @@ func validateBulkDepEdges(ctx context.Context, edges []bulkDepEdge) ([]bulkDepEd
 
 	for _, edge := range edges {
 		current := edge
-		fromID, fromStore, fromCleanup, err := resolveIDWithRouting(ctx, store, edge.IssueID)
+		// Write-intent: addBulkDependencies writes through current.Store (the
+		// source issue's store), so a routed target must open writable (#4141).
+		fromID, fromStore, fromCleanup, err := resolveIDWithRoutingForWrite(ctx, store, edge.IssueID)
 		if err != nil {
 			errs = append(errs, fmt.Sprintf("line %d: resolving issue ID %s: %v", edge.Line, edge.IssueID, err))
 			continue
@@ -859,9 +887,11 @@ var depRemoveCmd = &cobra.Command{
 		CheckReadonly("dep remove")
 		ctx := rootCtx
 
-		// Resolve partial IDs with routing support
+		// Resolve partial IDs with routing support. The source issue's store is
+		// mutated by RemoveDependency below, so resolve it write-intent (#4141);
+		// the depends-on target is only resolved by ID and stays read-only.
 		var fromID, toID string
-		fromID, fromStore, fromCleanup, err := resolveIDWithRouting(ctx, store, args[0])
+		fromID, fromStore, fromCleanup, err := resolveIDWithRoutingForWrite(ctx, store, args[0])
 		if err != nil {
 			FatalErrorRespectJSON("%v", err)
 		}

--- a/cmd/bd/dep_embedded_test.go
+++ b/cmd/bd/dep_embedded_test.go
@@ -79,6 +79,21 @@ func bdDepWithInput(t *testing.T, bd, dir, input string, args ...string) string 
 	return stdout.String()
 }
 
+// bdDepWithInputFail runs "bd dep" with stdin input expecting failure.
+func bdDepWithInputFail(t *testing.T, bd, dir, input string, args ...string) string {
+	t.Helper()
+	fullArgs := append([]string{"dep"}, args...)
+	cmd := exec.Command(bd, fullArgs...)
+	cmd.Dir = dir
+	cmd.Env = bdEnv(dir)
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected bd dep %s to fail, but succeeded:\n%s", strings.Join(args, " "), out)
+	}
+	return string(out)
+}
+
 func TestEmbeddedDep(t *testing.T) {
 	if os.Getenv("BEADS_TEST_EMBEDDED_DOLT") != "1" {
 		t.Skip("set BEADS_TEST_EMBEDDED_DOLT=1 to run embedded dolt integration tests")
@@ -523,7 +538,12 @@ func TestEmbeddedDepNoCycleCheck(t *testing.T) {
 	bdDep(t, bd, dir, extra.ID, "--blocks", ids[n-1], "--no-cycle-check")
 }
 
-func TestEmbeddedDepBulkNoCycleCheckSkipsPerEdgeCycleValidation(t *testing.T) {
+// TestEmbeddedDepBulkNoCycleCheckKeepsWholeGraphGate pins the bd-6dnrw.8
+// contract: bulk --no-cycle-check skips the per-edge recursive check for
+// speed, but one whole-graph cycle check still gates the commit, so a bulk
+// add that would introduce a cycle rolls back atomically instead of landing
+// and poisoning ready-work.
+func TestEmbeddedDepBulkNoCycleCheckKeepsWholeGraphGate(t *testing.T) {
 	if os.Getenv("BEADS_TEST_EMBEDDED_DOLT") != "1" {
 		t.Skip("set BEADS_TEST_EMBEDDED_DOLT=1 to run embedded dolt integration tests")
 	}
@@ -534,15 +554,25 @@ func TestEmbeddedDepBulkNoCycleCheckSkipsPerEdgeCycleValidation(t *testing.T) {
 
 	a := bdCreate(t, bd, dir, "Bulk cycle A", "--type", "task")
 	b := bdCreate(t, bd, dir, "Bulk cycle B", "--type", "task")
-	input := fmt.Sprintf("{\"from\":%q,\"to\":%q}\n{\"from\":%q,\"to\":%q}\n", a.ID, b.ID, b.ID, a.ID)
+	c := bdCreate(t, bd, dir, "Bulk cycle C", "--type", "task")
 
-	out := bdDepWithInput(t, bd, dir, input, "add", "--file", "-", "--no-cycle-check")
+	// Cycle-free bulk wiring succeeds with the per-edge check skipped.
+	okInput := fmt.Sprintf("{\"from\":%q,\"to\":%q}\n{\"from\":%q,\"to\":%q}\n", a.ID, b.ID, b.ID, c.ID)
+	out := bdDepWithInput(t, bd, dir, okInput, "add", "--file", "-", "--no-cycle-check")
 	if !strings.Contains(out, "Added 2 dependencies") {
 		t.Fatalf("expected bulk add summary, got: %s", out)
 	}
 
+	// Closing the chain into a cycle is refused by the final whole-graph
+	// check, and the refused batch commits nothing.
+	cycleInput := fmt.Sprintf("{\"from\":%q,\"to\":%q}\n", c.ID, a.ID)
+	failOut := bdDepWithInputFail(t, bd, dir, cycleInput, "add", "--file", "-", "--no-cycle-check")
+	if !strings.Contains(failOut, "dependency cycle would be created") || !strings.Contains(failOut, "no edges added") {
+		t.Fatalf("expected whole-graph cycle rejection, got: %s", failOut)
+	}
+
 	cycles := bdDep(t, bd, dir, "cycles")
-	if !strings.Contains(cycles, "Found") {
-		t.Fatalf("expected skipped cycle validation to leave detectable cycle, got: %s", cycles)
+	if !strings.Contains(cycles, "No dependency cycles detected") {
+		t.Fatalf("expected rolled-back bulk add to leave the graph acyclic, got: %s", cycles)
 	}
 }

--- a/cmd/bd/edit.go
+++ b/cmd/bd/edit.go
@@ -31,8 +31,10 @@ Examples:
 		id := args[0]
 		ctx := rootCtx
 
-		// Resolve ID with prefix routing (supports cross-rig edits like `bd edit xe-5ls`)
-		result, err := resolveAndGetIssueWithRouting(ctx, store, id)
+		// Resolve ID with prefix routing (supports cross-rig edits like `bd edit xe-5ls`).
+		// Write-intent: the routed target opens writable so the field update
+		// commits on the target head (#4141).
+		result, err := resolveAndGetIssueWithRoutingForWrite(ctx, store, id)
 		if err != nil {
 			FatalErrorRespectJSON("resolving %s: %v", id, err)
 		}

--- a/cmd/bd/human.go
+++ b/cmd/bd/human.go
@@ -191,8 +191,9 @@ Examples:
 		ctx := rootCtx
 		issueID := args[0]
 
-		// Resolve partial ID and get issue
-		result, err := resolveAndGetIssueWithRouting(ctx, store, issueID)
+		// Resolve partial ID and get issue. Write-intent: a prefix-routed target
+		// opens writable so the comment/close commits on the target head (#4141).
+		result, err := resolveAndGetIssueWithRoutingForWrite(ctx, store, issueID)
 		if err != nil {
 			FatalErrorRespectJSON("resolving issue ID %s: %v", issueID, err)
 		}
@@ -263,8 +264,9 @@ Examples:
 		ctx := rootCtx
 		issueID := args[0]
 
-		// Resolve partial ID and get issue
-		result, err := resolveAndGetIssueWithRouting(ctx, store, issueID)
+		// Resolve partial ID and get issue. Write-intent: a prefix-routed target
+		// opens writable so the comment/close commits on the target head (#4141).
+		result, err := resolveAndGetIssueWithRoutingForWrite(ctx, store, issueID)
 		if err != nil {
 			FatalErrorRespectJSON("resolving issue ID %s: %v", issueID, err)
 		}

--- a/cmd/bd/link.go
+++ b/cmd/bd/link.go
@@ -31,8 +31,10 @@ Examples:
 
 		ctx := rootCtx
 
-		// Resolve partial IDs with routing support
-		fromID, fromStore, fromCleanup, err := resolveIDWithRouting(ctx, store, id1)
+		// Resolve partial IDs with routing support. The source issue's store is
+		// mutated by AddDependency below, so resolve it write-intent (#4141); the
+		// dependency target is only resolved by ID and stays read-only.
+		fromID, fromStore, fromCleanup, err := resolveIDWithRoutingForWrite(ctx, store, id1)
 		if err != nil {
 			FatalErrorRespectJSON("%v", err)
 		}

--- a/cmd/bd/note.go
+++ b/cmd/bd/note.go
@@ -60,7 +60,7 @@ Examples:
 
 		ctx := rootCtx
 
-		result, err := resolveAndGetIssueWithRouting(ctx, store, id)
+		result, err := resolveAndGetIssueWithRoutingForWrite(ctx, store, id)
 		if err != nil {
 			if result != nil {
 				result.Close()

--- a/cmd/bd/priority.go
+++ b/cmd/bd/priority.go
@@ -40,7 +40,9 @@ Examples:
 
 		ctx := rootCtx
 
-		result, err := resolveAndGetIssueWithRouting(ctx, store, id)
+		// Write-intent routing: a prefix-routed target must open writable so the
+		// priority update commits on the target head (#4141).
+		result, err := resolveAndGetIssueWithRoutingForWrite(ctx, store, id)
 		if err != nil {
 			if result != nil {
 				result.Close()

--- a/cmd/bd/reopen.go
+++ b/cmd/bd/reopen.go
@@ -31,8 +31,9 @@ This is more explicit than 'bd update --status open' and emits a Reopened event.
 				diagHint())
 		}
 		for _, id := range args {
-			// Resolve with prefix routing (supports cross-rig reopens like `bd reopen xe-5ls`)
-			result, err := resolveAndGetIssueWithRouting(ctx, store, id)
+			// Resolve with prefix routing (supports cross-rig reopens like `bd reopen xe-5ls`).
+			// Write-intent: reopen commits through the routed target store (#4141).
+			result, err := resolveAndGetIssueWithRoutingForWrite(ctx, store, id)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "Error resolving %s: %v\n", id, err)
 				hasError = true

--- a/cmd/bd/routed.go
+++ b/cmd/bd/routed.go
@@ -50,9 +50,26 @@ func (r *RoutedResult) Close() {
 // Tries the local store first, then prefix-based routing via routes.jsonl,
 // then falls back to contributor auto-routing.
 //
+// Routed stores are opened read-only; mutating commands must use
+// resolveAndGetIssueWithRoutingForWrite instead.
+//
 // Returns a RoutedResult containing the issue, resolved ID, and the store to use.
 // The caller MUST call result.Close() when done to release any routed storage.
 func resolveAndGetIssueWithRouting(ctx context.Context, localStore storage.DoltStorage, id string) (*RoutedResult, error) {
+	return resolveAndGetIssueWithRoutingMode(ctx, localStore, id, false)
+}
+
+// resolveAndGetIssueWithRoutingForWrite is the write-intent variant of
+// resolveAndGetIssueWithRouting: a prefix-routed target store is opened
+// writable so mutating commands can write through it and commit on the
+// target store's head (#4141). Read paths must keep the read-only variant so
+// a routed read can never write migrations or other open-time mutations into
+// a foreign project's history (bd-6dnrw.32, GH#3231).
+func resolveAndGetIssueWithRoutingForWrite(ctx context.Context, localStore storage.DoltStorage, id string) (*RoutedResult, error) {
+	return resolveAndGetIssueWithRoutingMode(ctx, localStore, id, true)
+}
+
+func resolveAndGetIssueWithRoutingMode(ctx context.Context, localStore storage.DoltStorage, id string, forWrite bool) (*RoutedResult, error) {
 	// Try local store first.
 	result, err := resolveAndGetFromStore(ctx, localStore, id, false)
 	if err == nil {
@@ -63,12 +80,14 @@ func resolveAndGetIssueWithRouting(ctx context.Context, localStore storage.DoltS
 	// This handles cross-rig lookups where the ID's prefix maps to a different
 	// database (e.g., hr-8wn.1 routes to the herald rig's database).
 	if isNotFoundErr(err) {
-		if prefixResult, prefixErr := resolveViaPrefixRouting(ctx, id); prefixErr == nil {
+		if prefixResult, prefixErr := resolveViaPrefixRoutingMode(ctx, id, forWrite); prefixErr == nil {
 			return prefixResult, nil
 		}
 	}
 
 	// If not found via prefix routing, try contributor auto-routing as fallback (GH#2345).
+	// Auto-routed stores stay read-only even for write-intent callers: this
+	// path hydrates foreign contributor projects, which must never be mutated.
 	if isNotFoundErr(err) {
 		if autoResult, autoErr := resolveViaAutoRouting(ctx, localStore, id); autoErr == nil {
 			return autoResult, nil
@@ -125,13 +144,21 @@ type prefixRoute struct {
 }
 
 // resolveViaPrefixRouting attempts to find an issue by looking up its prefix
-// in routes.jsonl and opening the target rig's database.
+// in routes.jsonl and opening the target rig's database read-only.
 //
 // This enables cross-rig lookups: when running from a redirected .beads directory
 // (e.g., crew/beercan → town/.beads with database "hq"), a bead ID like "hr-8wn.1"
 // can be resolved by following the "hr-" route to the herald rig's .beads directory,
 // which declares dolt_database="herald".
 func resolveViaPrefixRouting(ctx context.Context, id string) (*RoutedResult, error) {
+	return resolveViaPrefixRoutingMode(ctx, id, false)
+}
+
+// resolveViaPrefixRoutingMode is resolveViaPrefixRouting with an explicit
+// store-open mode. forWrite opens the routed target writable, behaving like
+// running the command inside that rig; false keeps the read-only open that
+// guarantees a routed read cannot mutate the target (bd-6dnrw.32).
+func resolveViaPrefixRoutingMode(ctx context.Context, id string, forWrite bool) (*RoutedResult, error) {
 	// Extract prefix from the bead ID (e.g., "hr-" from "hr-8wn.1")
 	prefix := extractBeadPrefix(id)
 	if prefix == "" {
@@ -183,12 +210,18 @@ func resolveViaPrefixRouting(ctx context.Context, id string) (*RoutedResult, err
 
 	debug.Logf("[routing] Prefix %q matched route to %s (database: %s)\n", prefix, matchedRoute.Path, targetDB)
 
-	// Open a read-only store for the target database.
+	// Open a store for the target database — read-only unless the caller
+	// declared write intent (routed writes must commit on the target head,
+	// which a read-only open refuses).
 	// We need to temporarily override BEADS_DOLT_SERVER_DATABASE so the store
 	// connects to the correct database on the shared Dolt server.
+	openStore := newReadOnlyStoreFromConfig
+	if forWrite {
+		openStore = newDoltStoreFromConfig
+	}
 	origDB := os.Getenv("BEADS_DOLT_SERVER_DATABASE")
 	_ = os.Setenv("BEADS_DOLT_SERVER_DATABASE", targetDB)
-	targetStore, err := newReadOnlyStoreFromConfig(ctx, targetBeadsDir)
+	targetStore, err := openStore(ctx, targetBeadsDir)
 	// Restore the original env var
 	if origDB != "" {
 		_ = os.Setenv("BEADS_DOLT_SERVER_DATABASE", origDB)

--- a/cmd/bd/tag.go
+++ b/cmd/bd/tag.go
@@ -27,7 +27,9 @@ Examples:
 
 		ctx := rootCtx
 
-		result, err := resolveAndGetIssueWithRouting(ctx, store, id)
+		// Write-intent routing: a prefix-routed target must open writable so the
+		// label add commits on the target head (#4141).
+		result, err := resolveAndGetIssueWithRoutingForWrite(ctx, store, id)
 		if err != nil {
 			if result != nil {
 				result.Close()

--- a/cmd/bd/update.go
+++ b/cmd/bd/update.go
@@ -322,8 +322,9 @@ create, update, show, or close operation).`,
 			pendingCloseResults = nil
 		}
 		for _, id := range args {
-			// Resolve and get issue with routing (e.g., gt-xyz routes to another rig)
-			result, err := resolveAndGetIssueWithRouting(ctx, store, id)
+			// Resolve and get issue with routing (e.g., gt-xyz routes to another rig).
+			// Write-intent: update commits through the routed target store (#4141).
+			result, err := resolveAndGetIssueWithRoutingForWrite(ctx, store, id)
 			if err != nil {
 				if result != nil {
 					result.Close()

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -1505,6 +1505,7 @@ Examples:
   bd count --by-assignee            # Group count by assignee
   bd count --by-label               # Group count by label
   bd count --assignee alice --by-status  # Count alice's issues by status
+  bd count --include-infra          # Count issues + wisps tier (matches 'bd list --include-infra --all' cardinality)
 
 
 ```
@@ -1527,6 +1528,7 @@ bd count [flags]
       --desc-contains string    Filter by description substring
       --empty-description       Filter issues with empty description
       --id string               Filter by specific issue IDs (comma-separated)
+      --include-infra           Include infrastructure beads and the wisps tier (matches 'bd list --include-infra --all' cardinality)
   -l, --label strings           Filter by labels (AND: must have ALL)
       --label-any strings       Filter by labels (OR: must have AT LEAST ONE)
       --no-assignee             Filter issues with no assignee
@@ -1780,7 +1782,7 @@ bd dep [issue-id] [flags]
 
 ```
   -b, --blocks string    Issue ID that this issue blocks (shorthand for: bd dep add <blocked> <blocker>)
-      --no-cycle-check   Skip cycle detection after adding (use for bulk wiring — run 'bd dep cycles' to verify afterwards)
+      --no-cycle-check   Skip per-edge cycle checks for speed (bulk wiring); bulk --file adds still run one final whole-graph check before commit
 ```
 
 #### bd dep add
@@ -1825,7 +1827,7 @@ bd dep add [issue-id] [depends-on-id] [flags]
       --blocked-by string   Issue ID that blocks the first issue (alternative to positional arg)
       --depends-on string   Issue ID that the first issue depends on (alias for --blocked-by)
       --file string         Read dependency edges from JSONL file, or '-' for stdin
-      --no-cycle-check      Skip cycle detection after adding (use for bulk wiring — run 'bd dep cycles' to verify afterwards)
+      --no-cycle-check      Skip per-edge cycle checks for speed (bulk wiring); bulk --file adds still run one final whole-graph check before commit
   -t, --type string         Dependency type (blocks|tracks|related|parent-child|discovered-from|until|caused-by|validates|relates-to|supersedes) (default "blocks")
 ```
 
@@ -2427,6 +2429,20 @@ Timestamps (created_at, updated_at, started_at, closed_at) are preserved
 when present in the JSONL and otherwise filled in by the importer. The
 legacy "wisp" boolean is accepted as an alias for "ephemeral".
 
+By default a row only rewrites an existing local issue when its
+updated_at is strictly newer. Older rows are skipped (reported as
+stale_skipped_ids) and rows with the same updated_at keep every local
+column — updated_at has second granularity, so a timestamp tie can be
+two distinct same-second updates, and the local row wins the tie
+(reported as tie_kept_local_ids; the row's labels/comments/dependencies
+still merge). The guard is also enforced inside the upsert itself, so a
+local update that lands while the import is running is preserved rather
+than overwritten. Existing issues that the import did rewrite are listed
+with a field-level summary (updated_issues), so local state changed by
+an import is visible. To deliberately restore an older snapshot, pass
+--allow-stale, which imports every row even when it overwrites newer
+local state.
+
 EXAMPLES:
   bd import                        # Import from configured import.path
   bd import backup.jsonl           # Import from a specific file
@@ -2435,6 +2451,7 @@ EXAMPLES:
   cat issues.jsonl | bd import -   # Pipe JSONL from another tool
   bd import --dry-run              # Show what would be imported
   bd import --dedup                # Skip issues with duplicate titles
+  bd import --allow-stale old.jsonl # Restore an older snapshot (overwrites newer local rows)
   bd import --json                 # Structured output with created and skipped IDs
 
 ```
@@ -2444,6 +2461,7 @@ bd import [file|-] [flags]
 **Flags:**
 
 ```
+      --allow-stale    Import rows even when older than the local issue (required to restore an older snapshot)
       --dedup          Skip lines whose title matches an existing open issue
       --dry-run        Show what would be imported without importing
   -i, --input string   Read JSONL from a specific file

--- a/internal/storage/dolt/count_include_wisps_test.go
+++ b/internal/storage/dolt/count_include_wisps_test.go
@@ -111,6 +111,62 @@ func TestCountIssuesMergedMatchesSearch(t *testing.T) {
 	}
 }
 
+// TestCountIssuesEphemeralFallsThroughToDurable pins the GH#4387 count/list
+// parity fix for the ephemeral (infra-type) branch. SearchIssuesInTx, when an
+// Ephemeral=true filter matches no wisps, falls through and searches the
+// durable issues table (search.go "Fall through: wisps table doesn't exist or
+// returned no results"). Before the fix CountIssuesInTx returned the wisps-only
+// count and so reported 0 where list returned the durable row, breaking the
+// "count == len(list) for any filter" contract. This reproduces the exact
+// empty-wisps-but-durable-match state: a durable issues row carrying
+// ephemeral=1 (what an infra bead that landed durable looks like), which normal
+// creation never produces because it routes ephemeral/infra beads to the wisps
+// table, so the row is inserted directly.
+func TestCountIssuesEphemeralFallsThroughToDurable(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	// A durable, non-ephemeral task that the Ephemeral=true filter must exclude,
+	// so the test proves the filter is applied rather than counting everything.
+	if err := store.CreateIssue(ctx, &types.Issue{
+		ID:        "ed-task-1",
+		Title:     "durable task",
+		Status:    types.StatusOpen,
+		Priority:  2,
+		IssueType: types.TypeTask,
+	}, "tester"); err != nil {
+		t.Fatalf("create durable task: %v", err)
+	}
+
+	// A durable issues-table row flagged ephemeral=1 with no matching wisp.
+	if _, err := store.db.ExecContext(ctx,
+		"INSERT INTO issues (id, title, description, design, acceptance_criteria, notes, status, priority, issue_type, ephemeral) "+
+			"VALUES ('ed-infra-1', 'durable ephemeral', '', '', '', '', 'open', 2, 'agent', 1)"); err != nil {
+		t.Fatalf("seed durable ephemeral issue: %v", err)
+	}
+
+	ephemeral := true
+	filter := types.IssueFilter{Ephemeral: &ephemeral}
+
+	results, err := store.SearchIssues(ctx, "", filter)
+	if err != nil {
+		t.Fatalf("SearchIssues: %v", err)
+	}
+	count, err := store.CountIssues(ctx, "", filter)
+	if err != nil {
+		t.Fatalf("CountIssues: %v", err)
+	}
+	if count != int64(len(results)) {
+		t.Errorf("CountIssues = %d but SearchIssues returned %d rows; ephemeral fall-through parity broken (GH#4387)", count, len(results))
+	}
+	if count != 1 {
+		t.Errorf("CountIssues = %d, want 1 (durable ephemeral row must be counted via fall-through to the issues table)", count)
+	}
+}
+
 // TestCountIssuesByGroupIncludesWisps verifies the grouped-count paths honor
 // SkipWisps the same way CountIssues does, so `bd count --include-infra
 // --by-*` reports the merged issues+wisps numbers instead of silently-wrong
@@ -199,4 +255,114 @@ func TestCountIssuesByGroupIncludesWisps(t *testing.T) {
 			t.Errorf("ephemeral bug count = %d, want 0", counts["bug"])
 		}
 	})
+}
+
+// seedDurableEphemeralRow inserts the exact GH#4387 fall-through trap: a durable
+// issues-table row carrying ephemeral=1 with no matching wisp. Normal creation
+// never produces this because ephemeral/infra beads route to the wisps table on
+// insert, so the row is written directly. Returns the durable ephemeral row id.
+func seedDurableEphemeralRow(t *testing.T, ctx context.Context, store *DoltStore, p string) string {
+	t.Helper()
+	// A durable, non-ephemeral task that the Ephemeral=true filter must exclude,
+	// so the test proves the filter is applied rather than counting everything.
+	if err := store.CreateIssue(ctx, &types.Issue{
+		ID:        p + "-task-1",
+		Title:     "durable task",
+		Status:    types.StatusOpen,
+		Priority:  2,
+		IssueType: types.TypeTask,
+	}, "tester"); err != nil {
+		t.Fatalf("create durable task: %v", err)
+	}
+	infraID := p + "-infra-1"
+	if _, err := store.db.ExecContext(ctx,
+		"INSERT INTO issues (id, title, description, design, acceptance_criteria, notes, status, priority, issue_type, ephemeral) "+
+			"VALUES ('"+infraID+"', 'durable ephemeral', '', '', '', '', 'open', 2, 'agent', 1)"); err != nil {
+		t.Fatalf("seed durable ephemeral issue: %v", err)
+	}
+	return infraID
+}
+
+// TestCountIssuesByGroupEphemeralFallsThroughToDurable is the grouped-count
+// sibling of TestCountIssuesEphemeralFallsThroughToDurable. Before the fix,
+// CountIssuesByGroupInTx returned the wisps-only grouped counts for an
+// Ephemeral=true filter, so `bd count --include-infra --by-type` reported empty
+// buckets (sum 0) while the scalar Total fell through to the durable issues
+// table and reported 1 — sum(groups) != Total, breaking GH#4387 cardinality
+// parity. This pins that the grouped path falls through to the durable issues
+// table the same way the scalar path does.
+func TestCountIssuesByGroupEphemeralFallsThroughToDurable(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	infraID := seedDurableEphemeralRow(t, ctx, store, "eg")
+
+	ephemeral := true
+	filter := types.IssueFilter{Ephemeral: &ephemeral}
+
+	groups, err := store.CountIssuesByGroup(ctx, filter, "type")
+	if err != nil {
+		t.Fatalf("CountIssuesByGroup: %v", err)
+	}
+	count, err := store.CountIssues(ctx, "", filter)
+	if err != nil {
+		t.Fatalf("CountIssues: %v", err)
+	}
+
+	sum := 0
+	for _, v := range groups {
+		sum += v
+	}
+	if int64(sum) != count {
+		t.Errorf("sum(CountIssuesByGroup)=%d but CountIssues=%d; grouped ephemeral fall-through parity broken (GH#4387)", sum, count)
+	}
+	// The durable ephemeral row has issue_type='agent'; the non-ephemeral
+	// durable task must be excluded by the Ephemeral=true filter.
+	if groups["agent"] != 1 {
+		t.Errorf("grouped agent count = %d, want 1 (durable ephemeral row %q must fall through to the issues table)", groups["agent"], infraID)
+	}
+	if len(groups) != 1 {
+		t.Errorf("grouped counts had %d buckets, want 1 (only the durable ephemeral agent row); groups=%v", len(groups), groups)
+	}
+}
+
+// TestSearchIssuesWithCountsEphemeralFallsThroughToDurable is the
+// counts-projection sibling of the same GH#4387 fix. Before the fix,
+// SearchIssuesWithCountsInTx returned nil for an Ephemeral=true filter whenever
+// no matching wisp existed, so `bd search --counts --include-infra` dropped a
+// durable issues-table row flagged ephemeral=1 that plain SearchIssues (and
+// CountIssues) still surface. This pins parity between the counts-projection
+// search and the plain search for that durable-ephemeral state.
+func TestSearchIssuesWithCountsEphemeralFallsThroughToDurable(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	infraID := seedDurableEphemeralRow(t, ctx, store, "es")
+
+	ephemeral := true
+	filter := types.IssueFilter{Ephemeral: &ephemeral}
+
+	withCounts, err := store.SearchIssuesWithCounts(ctx, "", filter)
+	if err != nil {
+		t.Fatalf("SearchIssuesWithCounts: %v", err)
+	}
+	plain, err := store.SearchIssues(ctx, "", filter)
+	if err != nil {
+		t.Fatalf("SearchIssues: %v", err)
+	}
+	if len(withCounts) != len(plain) {
+		t.Errorf("SearchIssuesWithCounts returned %d rows but SearchIssues returned %d; counts-projection ephemeral fall-through parity broken (GH#4387)", len(withCounts), len(plain))
+	}
+	if len(withCounts) != 1 {
+		t.Fatalf("SearchIssuesWithCounts returned %d rows, want 1 (durable ephemeral row must fall through to the issues table)", len(withCounts))
+	}
+	if withCounts[0] == nil || withCounts[0].Issue == nil || withCounts[0].Issue.ID != infraID {
+		t.Errorf("SearchIssuesWithCounts returned unexpected row %+v, want %q", withCounts[0], infraID)
+	}
 }

--- a/internal/storage/dolt/count_include_wisps_test.go
+++ b/internal/storage/dolt/count_include_wisps_test.go
@@ -1,0 +1,202 @@
+package dolt
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// seedCountWispCorpus creates a mixed corpus spanning every cardinality trap
+// from GH#4387: durable issues, a template, no_history wisps (durable work in
+// the wisps table), and a true ephemeral wisp.
+//
+// Layout (prefix distinguishes per-test corpora on the shared branch store):
+//
+//	<p>-perm-task-1   issues  task  open
+//	<p>-perm-task-2   issues  task  closed
+//	<p>-perm-bug      issues  bug   open
+//	<p>-perm-tpl      issues  task  open  is_template=1
+//	<p>-nohist-task   wisps   task  open  no_history=1
+//	<p>-nohist-bug    wisps   bug   open  no_history=1
+//	<p>-eph-task      wisps   task  open  ephemeral=1
+func seedCountWispCorpus(t *testing.T, ctx context.Context, store *DoltStore, p string) {
+	t.Helper()
+	now := time.Now()
+	mk := func(id string, mut func(*types.Issue)) {
+		t.Helper()
+		issue := &types.Issue{
+			ID:        p + "-" + id,
+			Title:     id,
+			Status:    types.StatusOpen,
+			Priority:  2,
+			IssueType: types.TypeTask,
+		}
+		if mut != nil {
+			mut(issue)
+		}
+		if err := store.CreateIssue(ctx, issue, "tester"); err != nil {
+			t.Fatalf("create %s: %v", issue.ID, err)
+		}
+	}
+	mk("perm-task-1", nil)
+	mk("perm-task-2", func(i *types.Issue) {
+		i.Status = types.StatusClosed
+		i.ClosedAt = &now
+	})
+	mk("perm-bug", func(i *types.Issue) { i.IssueType = types.TypeBug })
+	mk("perm-tpl", func(i *types.Issue) { i.IsTemplate = true })
+	mk("nohist-task", func(i *types.Issue) { i.NoHistory = true })
+	mk("nohist-bug", func(i *types.Issue) {
+		i.NoHistory = true
+		i.IssueType = types.TypeBug
+	})
+	mk("eph-task", func(i *types.Issue) { i.Ephemeral = true })
+}
+
+// TestCountIssuesMergedMatchesSearch is the storage-side parity guard for
+// GH#4387: for any filter, CountIssues with SkipWisps=false must return
+// exactly len(SearchIssues) for the same filter — the merged issues+wisps
+// cardinality that `bd list --include-infra` materializes.
+func TestCountIssuesMergedMatchesSearch(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	seedCountWispCorpus(t, ctx, store, "cm")
+
+	task := types.TypeTask
+	noTemplate := false
+	ephemeral := true
+
+	cases := []struct {
+		name   string
+		filter types.IssueFilter
+		want   int64
+	}{
+		// 4 issues + 2 no_history wisps + 1 ephemeral wisp.
+		{"merged_all", types.IssueFilter{}, 7},
+		// Durable tier only (today's bd count default).
+		{"durable_only", types.IssueFilter{SkipWisps: true}, 4},
+		// Type filter applies identically to both tables.
+		{"merged_type_task", types.IssueFilter{IssueType: &task}, 5},
+		// Template exclusion (bd list default) drops cm-perm-tpl.
+		{"merged_no_templates", types.IssueFilter{IsTemplate: &noTemplate}, 6},
+		{"merged_no_templates_task", types.IssueFilter{IsTemplate: &noTemplate, IssueType: &task}, 4},
+		// Ephemeral-only routes to the wisps tier (bd list --type <infra>).
+		{"ephemeral_only", types.IssueFilter{Ephemeral: &ephemeral}, 1},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			count, err := store.CountIssues(ctx, "", tc.filter)
+			if err != nil {
+				t.Fatalf("CountIssues: %v", err)
+			}
+			if count != tc.want {
+				t.Errorf("CountIssues = %d, want %d", count, tc.want)
+			}
+
+			results, err := store.SearchIssues(ctx, "", tc.filter)
+			if err != nil {
+				t.Fatalf("SearchIssues: %v", err)
+			}
+			if count != int64(len(results)) {
+				t.Errorf("CountIssues = %d but SearchIssues returned %d rows; count/list parity broken (GH#4387)", count, len(results))
+			}
+		})
+	}
+}
+
+// TestCountIssuesByGroupIncludesWisps verifies the grouped-count paths honor
+// SkipWisps the same way CountIssues does, so `bd count --include-infra
+// --by-*` reports the merged issues+wisps numbers instead of silently-wrong
+// durable-only buckets (GH#4387).
+func TestCountIssuesByGroupIncludesWisps(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	seedCountWispCorpus(t, ctx, store, "cg")
+	if err := store.AddLabel(ctx, "cg-perm-task-1", "shared", "tester"); err != nil {
+		t.Fatalf("label cg-perm-task-1: %v", err)
+	}
+	if err := store.AddLabel(ctx, "cg-nohist-task", "shared", "tester"); err != nil {
+		t.Fatalf("label cg-nohist-task: %v", err)
+	}
+
+	t.Run("by_type_merged", func(t *testing.T) {
+		counts, err := store.CountIssuesByGroup(ctx, types.IssueFilter{}, "type")
+		if err != nil {
+			t.Fatalf("CountIssuesByGroup: %v", err)
+		}
+		// task: perm-task-1, perm-task-2, perm-tpl, nohist-task, eph-task.
+		if counts["task"] != 5 {
+			t.Errorf("merged task count = %d, want 5 (wisps tier dropped from grouped count)", counts["task"])
+		}
+		// bug: perm-bug, nohist-bug.
+		if counts["bug"] != 2 {
+			t.Errorf("merged bug count = %d, want 2", counts["bug"])
+		}
+	})
+
+	t.Run("by_type_durable_only", func(t *testing.T) {
+		counts, err := store.CountIssuesByGroup(ctx, types.IssueFilter{SkipWisps: true}, "type")
+		if err != nil {
+			t.Fatalf("CountIssuesByGroup: %v", err)
+		}
+		if counts["task"] != 3 {
+			t.Errorf("durable task count = %d, want 3 (SkipWisps must keep today's semantics)", counts["task"])
+		}
+		if counts["bug"] != 1 {
+			t.Errorf("durable bug count = %d, want 1", counts["bug"])
+		}
+	})
+
+	t.Run("by_status_merged", func(t *testing.T) {
+		counts, err := store.CountIssuesByGroup(ctx, types.IssueFilter{}, "status")
+		if err != nil {
+			t.Fatalf("CountIssuesByGroup: %v", err)
+		}
+		if counts["open"] != 6 {
+			t.Errorf("merged open count = %d, want 6", counts["open"])
+		}
+		if counts["closed"] != 1 {
+			t.Errorf("merged closed count = %d, want 1", counts["closed"])
+		}
+	})
+
+	t.Run("by_label_merged", func(t *testing.T) {
+		counts, err := store.CountIssuesByGroup(ctx, types.IssueFilter{}, "label")
+		if err != nil {
+			t.Fatalf("CountIssuesByGroup: %v", err)
+		}
+		// "shared" sits on one durable issue and one no_history wisp.
+		if counts["shared"] != 2 {
+			t.Errorf("merged label count = %d, want 2 (wisp labels dropped)", counts["shared"])
+		}
+		// 5 remaining beads carry no label.
+		if counts["(no labels)"] != 5 {
+			t.Errorf("merged (no labels) count = %d, want 5", counts["(no labels)"])
+		}
+	})
+
+	t.Run("by_type_ephemeral_only", func(t *testing.T) {
+		ephemeral := true
+		counts, err := store.CountIssuesByGroup(ctx, types.IssueFilter{Ephemeral: &ephemeral}, "type")
+		if err != nil {
+			t.Fatalf("CountIssuesByGroup: %v", err)
+		}
+		if counts["task"] != 1 {
+			t.Errorf("ephemeral task count = %d, want 1", counts["task"])
+		}
+		if counts["bug"] != 0 {
+			t.Errorf("ephemeral bug count = %d, want 0", counts["bug"])
+		}
+	})
+}

--- a/internal/storage/dolt/counts.go
+++ b/internal/storage/dolt/counts.go
@@ -3,8 +3,6 @@ package dolt
 import (
 	"context"
 	"database/sql"
-	"fmt"
-	"strings"
 
 	"github.com/steveyegge/beads/internal/storage/issueops"
 	"github.com/steveyegge/beads/internal/types"
@@ -24,20 +22,17 @@ const depTargetExpr = "COALESCE(depends_on_issue_id, depends_on_wisp_id, depends
 
 // CountIssues returns the number of issues matching query and filter.
 // Filter.Limit and Filter.Offset are ignored; all other fields apply.
+// Wisps-merge semantics follow SearchIssues: SkipWisps=true counts the
+// durable issues table only, otherwise the wisps tier is merged in (GH#4387).
 func (s *DoltStore) CountIssues(ctx context.Context, query string, filter types.IssueFilter) (int64, error) {
 	var n int64
 	err := s.withReadTx(ctx, func(tx *sql.Tx) error {
-		whereClauses, args, err := issueops.BuildIssueFilterClauses(query, filter, issueops.IssuesFilterTables)
+		count, err := issueops.CountIssuesInTx(ctx, tx, query, filter)
 		if err != nil {
 			return err
 		}
-		where := ""
-		if len(whereClauses) > 0 {
-			where = " WHERE " + strings.Join(whereClauses, " AND ")
-		}
-		//nolint:gosec // table name is a static constant; placeholders are bound
-		q := fmt.Sprintf(`SELECT count(*) FROM issues%s`, where)
-		return tx.QueryRowContext(ctx, q, args...).Scan(&n)
+		n = int64(count)
+		return nil
 	})
 	return n, err
 }

--- a/internal/storage/embeddeddolt/counts.go
+++ b/internal/storage/embeddeddolt/counts.go
@@ -5,8 +5,6 @@ package embeddeddolt
 import (
 	"context"
 	"database/sql"
-	"fmt"
-	"strings"
 
 	"github.com/steveyegge/beads/internal/storage/issueops"
 	"github.com/steveyegge/beads/internal/types"
@@ -24,20 +22,19 @@ import (
 // matches issueops.DepTargetExpr on main.
 const depTargetExpr = "COALESCE(depends_on_issue_id, depends_on_wisp_id, depends_on_external)"
 
+// CountIssues returns the number of issues matching query and filter.
+// Filter.Limit and Filter.Offset are ignored; all other fields apply.
+// Wisps-merge semantics follow SearchIssues: SkipWisps=true counts the
+// durable issues table only, otherwise the wisps tier is merged in (GH#4387).
 func (s *EmbeddedDoltStore) CountIssues(ctx context.Context, query string, filter types.IssueFilter) (int64, error) {
 	var n int64
 	err := s.withConn(ctx, false, func(tx *sql.Tx) error {
-		whereClauses, args, err := issueops.BuildIssueFilterClauses(query, filter, issueops.IssuesFilterTables)
+		count, err := issueops.CountIssuesInTx(ctx, tx, query, filter)
 		if err != nil {
 			return err
 		}
-		where := ""
-		if len(whereClauses) > 0 {
-			where = " WHERE " + strings.Join(whereClauses, " AND ")
-		}
-		//nolint:gosec // table name is a static constant; placeholders are bound
-		q := fmt.Sprintf(`SELECT count(*) FROM issues%s`, where)
-		return tx.QueryRowContext(ctx, q, args...).Scan(&n)
+		n = int64(count)
+		return nil
 	})
 	return n, err
 }

--- a/internal/storage/issueops/count.go
+++ b/internal/storage/issueops/count.go
@@ -16,9 +16,25 @@ import (
 // wisps count is merged in (GH#4387).
 func CountIssuesInTx(ctx context.Context, tx *sql.Tx, query string, filter types.IssueFilter) (int, error) {
 	if filter.Ephemeral != nil && *filter.Ephemeral {
-		count, err := countTableInTx(ctx, tx, query, filter, WispsFilterTables)
+		wispCount, err := countTableInTx(ctx, tx, query, filter, WispsFilterTables)
 		if err != nil && !isTableNotExistError(err) {
 			return 0, fmt.Errorf("count wisps (ephemeral filter): %w", err)
+		}
+		if wispCount > 0 {
+			return wispCount, nil
+		}
+		// Fall through: the wisps table is missing or has no matching rows.
+		// SearchIssuesInTx does the same — it searches the durable issues table
+		// in this case (search.go "Fall through: wisps table doesn't exist or
+		// returned no results"). Mirroring it keeps the GH#4387 count/list parity
+		// contract for an infra-type filter that matches only a durable
+		// issues-table row flagged ephemeral=1 — a defensive parity state that
+		// normal creation never produces (ephemeral/infra beads route to the
+		// wisps table on insert), but which would otherwise be reported as 0 by
+		// count while list returns it.
+		count, err := countTableInTx(ctx, tx, query, filter, IssuesFilterTables)
+		if err != nil {
+			return 0, fmt.Errorf("count issues (ephemeral fall-through): %w", err)
 		}
 		return count, nil
 	}
@@ -34,7 +50,9 @@ func CountIssuesInTx(ctx context.Context, tx *sql.Tx, query string, filter types
 
 	// Merge wisps count when caller hasn't opted out (same semantics as SearchIssuesInTx).
 	// Issues and wisps are always in separate tables (PromoteFromEphemeral deletes the
-	// wisps row), so the two counts don't double-count.
+	// wisps row), so the two counts don't double-count. count trusts that disjoint-table
+	// invariant; SearchIssuesInTx is the corruption detector — it errors loudly if an ID
+	// appears in both tables ("id %q exists in both issues and wisps").
 	wispCount, wispErr := countTableInTx(ctx, tx, query, filter, WispsFilterTables)
 	if wispErr != nil && !isTableNotExistError(wispErr) {
 		return 0, fmt.Errorf("count wisps (merge): %w", wispErr)
@@ -51,12 +69,27 @@ func CountIssuesInTx(ctx context.Context, tx *sql.Tx, query string, filter types
 // only, and otherwise the wisps tier is merged into each group (GH#4387).
 func CountIssuesByGroupInTx(ctx context.Context, tx *sql.Tx, filter types.IssueFilter, groupBy string) (map[string]int, error) {
 	if filter.Ephemeral != nil && *filter.Ephemeral {
-		counts, err := countGroupForTablesInTx(ctx, tx, filter, groupBy, WispsFilterTables)
+		wispCounts, err := countGroupForTablesInTx(ctx, tx, filter, groupBy, WispsFilterTables)
 		if err != nil && !isTableNotExistError(err) {
 			return nil, fmt.Errorf("count wisps by %s (ephemeral filter): %w", groupBy, err)
 		}
-		if counts == nil {
-			counts = make(map[string]int)
+		total := 0
+		for _, v := range wispCounts {
+			total += v
+		}
+		if total > 0 {
+			return wispCounts, nil
+		}
+		// Fall through: the wisps table is missing or matched no rows. Mirror
+		// CountIssuesInTx's scalar ephemeral fall-through (and SearchIssuesInTx)
+		// so grouped counts also report a durable issues-table row flagged
+		// ephemeral=1. Without this the scalar Total (which falls through) would
+		// disagree with the sum of the grouped buckets (wisps-only), breaking
+		// the GH#4387 count/list cardinality parity for `bd count
+		// --include-infra --by-*`.
+		counts, err := countGroupForTablesInTx(ctx, tx, filter, groupBy, IssuesFilterTables)
+		if err != nil {
+			return nil, fmt.Errorf("count issues by %s (ephemeral fall-through): %w", groupBy, err)
 		}
 		return counts, nil
 	}

--- a/internal/storage/issueops/count.go
+++ b/internal/storage/issueops/count.go
@@ -9,18 +9,21 @@ import (
 	"github.com/steveyegge/beads/internal/types"
 )
 
-// CountIssuesInTx counts issues matching the filter within a transaction.
-// Mirrors SearchIssuesInTx's wisps-merge semantics but returns only the count.
-func CountIssuesInTx(ctx context.Context, tx *sql.Tx, filter types.IssueFilter) (int, error) {
+// CountIssuesInTx counts issues matching the query and filter within a
+// transaction. Mirrors SearchIssuesInTx's wisps-merge semantics but returns
+// only the count: ephemeral-only filters route to the wisps table,
+// SkipWisps=true counts the durable issues table only, and otherwise the
+// wisps count is merged in (GH#4387).
+func CountIssuesInTx(ctx context.Context, tx *sql.Tx, query string, filter types.IssueFilter) (int, error) {
 	if filter.Ephemeral != nil && *filter.Ephemeral {
-		count, err := countTableInTx(ctx, tx, filter, WispsFilterTables)
+		count, err := countTableInTx(ctx, tx, query, filter, WispsFilterTables)
 		if err != nil && !isTableNotExistError(err) {
 			return 0, fmt.Errorf("count wisps (ephemeral filter): %w", err)
 		}
 		return count, nil
 	}
 
-	count, err := countTableInTx(ctx, tx, filter, IssuesFilterTables)
+	count, err := countTableInTx(ctx, tx, query, filter, IssuesFilterTables)
 	if err != nil {
 		return 0, fmt.Errorf("count issues: %w", err)
 	}
@@ -32,7 +35,7 @@ func CountIssuesInTx(ctx context.Context, tx *sql.Tx, filter types.IssueFilter) 
 	// Merge wisps count when caller hasn't opted out (same semantics as SearchIssuesInTx).
 	// Issues and wisps are always in separate tables (PromoteFromEphemeral deletes the
 	// wisps row), so the two counts don't double-count.
-	wispCount, wispErr := countTableInTx(ctx, tx, filter, WispsFilterTables)
+	wispCount, wispErr := countTableInTx(ctx, tx, query, filter, WispsFilterTables)
 	if wispErr != nil && !isTableNotExistError(wispErr) {
 		return 0, fmt.Errorf("count wisps (merge): %w", wispErr)
 	}
@@ -42,12 +45,46 @@ func CountIssuesInTx(ctx context.Context, tx *sql.Tx, filter types.IssueFilter) 
 // CountIssuesByGroupInTx counts issues grouped by a field within a transaction.
 // groupBy must be one of: status, priority, type, assignee, label.
 // Returns a map of group value → count, using the same display format as bd count.
+//
+// Mirrors CountIssuesInTx's wisps-merge semantics: ephemeral-only filters
+// route to the wisps table, SkipWisps=true counts the durable issues table
+// only, and otherwise the wisps tier is merged into each group (GH#4387).
 func CountIssuesByGroupInTx(ctx context.Context, tx *sql.Tx, filter types.IssueFilter, groupBy string) (map[string]int, error) {
-	tables := IssuesFilterTables
 	if filter.Ephemeral != nil && *filter.Ephemeral {
-		tables = WispsFilterTables
+		counts, err := countGroupForTablesInTx(ctx, tx, filter, groupBy, WispsFilterTables)
+		if err != nil && !isTableNotExistError(err) {
+			return nil, fmt.Errorf("count wisps by %s (ephemeral filter): %w", groupBy, err)
+		}
+		if counts == nil {
+			counts = make(map[string]int)
+		}
+		return counts, nil
 	}
 
+	counts, err := countGroupForTablesInTx(ctx, tx, filter, groupBy, IssuesFilterTables)
+	if err != nil {
+		return nil, err
+	}
+
+	if filter.SkipWisps {
+		return counts, nil
+	}
+
+	// Merge wisps counts when the caller hasn't opted out (same semantics as
+	// CountIssuesInTx / SearchIssuesInTx; the two tables never share an ID).
+	wispCounts, wispErr := countGroupForTablesInTx(ctx, tx, filter, groupBy, WispsFilterTables)
+	if wispErr != nil && !isTableNotExistError(wispErr) {
+		return nil, fmt.Errorf("count wisps by %s (merge): %w", groupBy, wispErr)
+	}
+	for k, v := range wispCounts {
+		counts[k] += v
+	}
+	return counts, nil
+}
+
+// countGroupForTablesInTx runs a grouped count against one table set
+// (issues or wisps) and normalizes keys to bd count's display format.
+func countGroupForTablesInTx(ctx context.Context, tx *sql.Tx, filter types.IssueFilter, groupBy string, tables FilterTables) (map[string]int, error) {
 	if groupBy == "label" {
 		return countByLabelInTx(ctx, tx, filter, tables)
 	}
@@ -85,9 +122,9 @@ func CountIssuesByGroupInTx(ctx context.Context, tx *sql.Tx, filter types.IssueF
 	return counts, nil
 }
 
-// countTableInTx runs SELECT COUNT(*) FROM <table> WHERE <filter>.
-func countTableInTx(ctx context.Context, tx *sql.Tx, filter types.IssueFilter, tables FilterTables) (int, error) {
-	clauses, args, err := BuildIssueFilterClauses("", filter, tables)
+// countTableInTx runs SELECT COUNT(*) FROM <table> WHERE <query+filter>.
+func countTableInTx(ctx context.Context, tx *sql.Tx, query string, filter types.IssueFilter, tables FilterTables) (int, error) {
+	clauses, args, err := BuildIssueFilterClauses(query, filter, tables)
 	if err != nil {
 		return 0, err
 	}
@@ -96,9 +133,9 @@ func countTableInTx(ctx context.Context, tx *sql.Tx, filter types.IssueFilter, t
 		whereSQL = " WHERE " + strings.Join(clauses, " AND ")
 	}
 	//nolint:gosec // G201: tables.Main is hardcoded to "issues" or "wisps"
-	query := fmt.Sprintf("SELECT COUNT(*) FROM %s%s", tables.Main, whereSQL)
+	countSQL := fmt.Sprintf("SELECT COUNT(*) FROM %s%s", tables.Main, whereSQL)
 	var count int
-	if err := tx.QueryRowContext(ctx, query, args...).Scan(&count); err != nil {
+	if err := tx.QueryRowContext(ctx, countSQL, args...).Scan(&count); err != nil {
 		return 0, err
 	}
 	return count, nil

--- a/internal/storage/issueops/search.go
+++ b/internal/storage/issueops/search.go
@@ -266,4 +266,3 @@ func hydrateIssues(ctx context.Context, tx *sql.Tx, issues []*types.Issue, table
 
 	return nil
 }
-

--- a/internal/storage/issueops/search_counts.go
+++ b/internal/storage/issueops/search_counts.go
@@ -21,14 +21,26 @@ func SearchIssuesWithCountsInTx(ctx context.Context, tx *sql.Tx, query string, f
 		if probeErr != nil {
 			return nil, fmt.Errorf("search issues with counts: ephemeral wisp probe: %w", probeErr)
 		}
-		if empty || !wispDepsExist {
-			return nil, nil
+		if !empty && wispDepsExist {
+			wisps, err := runFilterSearchQueryInTx(ctx, tx, query, filter, WispsFilterTables, true)
+			if err != nil && !isTableNotExistError(err) {
+				return nil, err
+			}
+			if len(wisps) > 0 {
+				return finishSearchIssuesWithCounts(wisps, filter), nil
+			}
 		}
-		wisps, err := runFilterSearchQueryInTx(ctx, tx, query, filter, WispsFilterTables, true)
+		// Fall through: the wisps tier is missing/empty or matched no rows.
+		// Mirror SearchIssuesInTx / CountIssuesInTx so count-projection searches
+		// also surface a durable issues-table row flagged ephemeral=1 instead of
+		// dropping it. Use the same IssuesFilterTables query the non-ephemeral
+		// path uses, keeping the GH#4387 count/list cardinality parity for
+		// searches that project counts (e.g. `bd search --counts --include-infra`).
+		out, err := runFilterSearchQueryInTx(ctx, tx, query, filter, IssuesFilterTables, wispDepsExist)
 		if err != nil {
 			return nil, err
 		}
-		return finishSearchIssuesWithCounts(wisps, filter), nil
+		return finishSearchIssuesWithCounts(out, filter), nil
 	}
 
 	out, err := runFilterSearchQueryInTx(ctx, tx, query, filter, IssuesFilterTables, wispDepsExist)

--- a/website/docs/cli-reference/count.md
+++ b/website/docs/cli-reference/count.md
@@ -24,6 +24,7 @@ Examples:
   bd count --by-assignee            # Group count by assignee
   bd count --by-label               # Group count by label
   bd count --assignee alice --by-status  # Count alice's issues by status
+  bd count --include-infra          # Count issues + wisps tier (matches 'bd list --include-infra --all' cardinality)
 
 
 ```
@@ -46,6 +47,7 @@ bd count [flags]
       --desc-contains string    Filter by description substring
       --empty-description       Filter issues with empty description
       --id string               Filter by specific issue IDs (comma-separated)
+      --include-infra           Include infrastructure beads and the wisps tier (matches 'bd list --include-infra --all' cardinality)
   -l, --label strings           Filter by labels (AND: must have ALL)
       --label-any strings       Filter by labels (OR: must have AT LEAST ONE)
       --no-assignee             Filter issues with no assignee

--- a/website/docs/cli-reference/dep.md
+++ b/website/docs/cli-reference/dep.md
@@ -30,7 +30,7 @@ bd dep [issue-id] [flags]
 
 ```
   -b, --blocks string    Issue ID that this issue blocks (shorthand for: bd dep add <blocked> <blocker>)
-      --no-cycle-check   Skip cycle detection after adding (use for bulk wiring — run 'bd dep cycles' to verify afterwards)
+      --no-cycle-check   Skip per-edge cycle checks for speed (bulk wiring); bulk --file adds still run one final whole-graph check before commit
 ```
 
 ### bd dep add
@@ -75,7 +75,7 @@ bd dep add [issue-id] [depends-on-id] [flags]
       --blocked-by string   Issue ID that blocks the first issue (alternative to positional arg)
       --depends-on string   Issue ID that the first issue depends on (alias for --blocked-by)
       --file string         Read dependency edges from JSONL file, or '-' for stdin
-      --no-cycle-check      Skip cycle detection after adding (use for bulk wiring — run 'bd dep cycles' to verify afterwards)
+      --no-cycle-check      Skip per-edge cycle checks for speed (bulk wiring); bulk --file adds still run one final whole-graph check before commit
   -t, --type string         Dependency type (blocks|tracks|related|parent-child|discovered-from|until|caused-by|validates|relates-to|supersedes) (default "blocks")
 ```
 

--- a/website/docs/cli-reference/import.md
+++ b/website/docs/cli-reference/import.md
@@ -48,6 +48,20 @@ Timestamps (created_at, updated_at, started_at, closed_at) are preserved
 when present in the JSONL and otherwise filled in by the importer. The
 legacy "wisp" boolean is accepted as an alias for "ephemeral".
 
+By default a row only rewrites an existing local issue when its
+updated_at is strictly newer. Older rows are skipped (reported as
+stale_skipped_ids) and rows with the same updated_at keep every local
+column — updated_at has second granularity, so a timestamp tie can be
+two distinct same-second updates, and the local row wins the tie
+(reported as tie_kept_local_ids; the row's labels/comments/dependencies
+still merge). The guard is also enforced inside the upsert itself, so a
+local update that lands while the import is running is preserved rather
+than overwritten. Existing issues that the import did rewrite are listed
+with a field-level summary (updated_issues), so local state changed by
+an import is visible. To deliberately restore an older snapshot, pass
+--allow-stale, which imports every row even when it overwrites newer
+local state.
+
 EXAMPLES:
   bd import                        # Import from configured import.path
   bd import backup.jsonl           # Import from a specific file
@@ -56,6 +70,7 @@ EXAMPLES:
   cat issues.jsonl | bd import -   # Pipe JSONL from another tool
   bd import --dry-run              # Show what would be imported
   bd import --dedup                # Skip issues with duplicate titles
+  bd import --allow-stale old.jsonl # Restore an older snapshot (overwrites newer local rows)
   bd import --json                 # Structured output with created and skipped IDs
 
 ```
@@ -65,6 +80,7 @@ bd import [file|-] [flags]
 **Flags:**
 
 ```
+      --allow-stale    Import rows even when older than the local issue (required to restore an older snapshot)
       --dedup          Skip lines whose title matches an existing open issue
       --dry-run        Show what would be imported without importing
   -i, --input string   Read JSONL from a specific file

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -4202,6 +4202,7 @@ Examples:
   bd count --by-assignee            # Group count by assignee
   bd count --by-label               # Group count by label
   bd count --assignee alice --by-status  # Count alice's issues by status
+  bd count --include-infra          # Count issues + wisps tier (matches 'bd list --include-infra --all' cardinality)
 
 
 ```
@@ -4224,6 +4225,7 @@ bd count [flags]
       --desc-contains string    Filter by description substring
       --empty-description       Filter issues with empty description
       --id string               Filter by specific issue IDs (comma-separated)
+      --include-infra           Include infrastructure beads and the wisps tier (matches 'bd list --include-infra --all' cardinality)
   -l, --label strings           Filter by labels (AND: must have ALL)
       --label-any strings       Filter by labels (OR: must have AT LEAST ONE)
       --no-assignee             Filter issues with no assignee
@@ -4454,7 +4456,7 @@ bd dep [issue-id] [flags]
 
 ```
   -b, --blocks string    Issue ID that this issue blocks (shorthand for: bd dep add <blocked> <blocker>)
-      --no-cycle-check   Skip cycle detection after adding (use for bulk wiring — run 'bd dep cycles' to verify afterwards)
+      --no-cycle-check   Skip per-edge cycle checks for speed (bulk wiring); bulk --file adds still run one final whole-graph check before commit
 ```
 
 ### bd dep add
@@ -4499,7 +4501,7 @@ bd dep add [issue-id] [depends-on-id] [flags]
       --blocked-by string   Issue ID that blocks the first issue (alternative to positional arg)
       --depends-on string   Issue ID that the first issue depends on (alias for --blocked-by)
       --file string         Read dependency edges from JSONL file, or '-' for stdin
-      --no-cycle-check      Skip cycle detection after adding (use for bulk wiring — run 'bd dep cycles' to verify afterwards)
+      --no-cycle-check      Skip per-edge cycle checks for speed (bulk wiring); bulk --file adds still run one final whole-graph check before commit
   -t, --type string         Dependency type (blocks|tracks|related|parent-child|discovered-from|until|caused-by|validates|relates-to|supersedes) (default "blocks")
 ```
 
@@ -6305,6 +6307,20 @@ Timestamps (created_at, updated_at, started_at, closed_at) are preserved
 when present in the JSONL and otherwise filled in by the importer. The
 legacy "wisp" boolean is accepted as an alias for "ephemeral".
 
+By default a row only rewrites an existing local issue when its
+updated_at is strictly newer. Older rows are skipped (reported as
+stale_skipped_ids) and rows with the same updated_at keep every local
+column — updated_at has second granularity, so a timestamp tie can be
+two distinct same-second updates, and the local row wins the tie
+(reported as tie_kept_local_ids; the row's labels/comments/dependencies
+still merge). The guard is also enforced inside the upsert itself, so a
+local update that lands while the import is running is preserved rather
+than overwritten. Existing issues that the import did rewrite are listed
+with a field-level summary (updated_issues), so local state changed by
+an import is visible. To deliberately restore an older snapshot, pass
+--allow-stale, which imports every row even when it overwrites newer
+local state.
+
 EXAMPLES:
   bd import                        # Import from configured import.path
   bd import backup.jsonl           # Import from a specific file
@@ -6313,6 +6329,7 @@ EXAMPLES:
   cat issues.jsonl | bd import -   # Pipe JSONL from another tool
   bd import --dry-run              # Show what would be imported
   bd import --dedup                # Skip issues with duplicate titles
+  bd import --allow-stale old.jsonl # Restore an older snapshot (overwrites newer local rows)
   bd import --json                 # Structured output with created and skipped IDs
 
 ```
@@ -6322,6 +6339,7 @@ bd import [file|-] [flags]
 **Flags:**
 
 ```
+      --allow-stale    Import rows even when older than the local issue (required to restore an older snapshot)
       --dedup          Skip lines whose title matches an existing open issue
       --dry-run        Show what would be imported without importing
   -i, --input string   Read JSONL from a specific file

--- a/website/versioned_docs/version-1.0.0/cli-reference/count.md
+++ b/website/versioned_docs/version-1.0.0/cli-reference/count.md
@@ -24,6 +24,7 @@ Examples:
   bd count --by-assignee            # Group count by assignee
   bd count --by-label               # Group count by label
   bd count --assignee alice --by-status  # Count alice's issues by status
+  bd count --include-infra          # Count issues + wisps tier (matches 'bd list --include-infra --all' cardinality)
 
 
 ```
@@ -46,6 +47,7 @@ bd count [flags]
       --desc-contains string    Filter by description substring
       --empty-description       Filter issues with empty description
       --id string               Filter by specific issue IDs (comma-separated)
+      --include-infra           Include infrastructure beads and the wisps tier (matches 'bd list --include-infra --all' cardinality)
   -l, --label strings           Filter by labels (AND: must have ALL)
       --label-any strings       Filter by labels (OR: must have AT LEAST ONE)
       --no-assignee             Filter issues with no assignee

--- a/website/versioned_docs/version-1.0.0/cli-reference/dep.md
+++ b/website/versioned_docs/version-1.0.0/cli-reference/dep.md
@@ -30,7 +30,7 @@ bd dep [issue-id] [flags]
 
 ```
   -b, --blocks string    Issue ID that this issue blocks (shorthand for: bd dep add <blocked> <blocker>)
-      --no-cycle-check   Skip cycle detection after adding (use for bulk wiring — run 'bd dep cycles' to verify afterwards)
+      --no-cycle-check   Skip per-edge cycle checks for speed (bulk wiring); bulk --file adds still run one final whole-graph check before commit
 ```
 
 ### bd dep add
@@ -75,7 +75,7 @@ bd dep add [issue-id] [depends-on-id] [flags]
       --blocked-by string   Issue ID that blocks the first issue (alternative to positional arg)
       --depends-on string   Issue ID that the first issue depends on (alias for --blocked-by)
       --file string         Read dependency edges from JSONL file, or '-' for stdin
-      --no-cycle-check      Skip cycle detection after adding (use for bulk wiring — run 'bd dep cycles' to verify afterwards)
+      --no-cycle-check      Skip per-edge cycle checks for speed (bulk wiring); bulk --file adds still run one final whole-graph check before commit
   -t, --type string         Dependency type (blocks|tracks|related|parent-child|discovered-from|until|caused-by|validates|relates-to|supersedes) (default "blocks")
 ```
 

--- a/website/versioned_docs/version-1.0.0/cli-reference/import.md
+++ b/website/versioned_docs/version-1.0.0/cli-reference/import.md
@@ -48,6 +48,20 @@ Timestamps (created_at, updated_at, started_at, closed_at) are preserved
 when present in the JSONL and otherwise filled in by the importer. The
 legacy "wisp" boolean is accepted as an alias for "ephemeral".
 
+By default a row only rewrites an existing local issue when its
+updated_at is strictly newer. Older rows are skipped (reported as
+stale_skipped_ids) and rows with the same updated_at keep every local
+column — updated_at has second granularity, so a timestamp tie can be
+two distinct same-second updates, and the local row wins the tie
+(reported as tie_kept_local_ids; the row's labels/comments/dependencies
+still merge). The guard is also enforced inside the upsert itself, so a
+local update that lands while the import is running is preserved rather
+than overwritten. Existing issues that the import did rewrite are listed
+with a field-level summary (updated_issues), so local state changed by
+an import is visible. To deliberately restore an older snapshot, pass
+--allow-stale, which imports every row even when it overwrites newer
+local state.
+
 EXAMPLES:
   bd import                        # Import from configured import.path
   bd import backup.jsonl           # Import from a specific file
@@ -56,6 +70,7 @@ EXAMPLES:
   cat issues.jsonl | bd import -   # Pipe JSONL from another tool
   bd import --dry-run              # Show what would be imported
   bd import --dedup                # Skip issues with duplicate titles
+  bd import --allow-stale old.jsonl # Restore an older snapshot (overwrites newer local rows)
   bd import --json                 # Structured output with created and skipped IDs
 
 ```
@@ -65,6 +80,7 @@ bd import [file|-] [flags]
 **Flags:**
 
 ```
+      --allow-stale    Import rows even when older than the local issue (required to restore an older snapshot)
       --dedup          Skip lines whose title matches an existing open issue
       --dry-run        Show what would be imported without importing
   -i, --input string   Read JSONL from a specific file

--- a/website/versioned_docs/version-1.0.4/cli-reference/count.md
+++ b/website/versioned_docs/version-1.0.4/cli-reference/count.md
@@ -24,6 +24,7 @@ Examples:
   bd count --by-assignee            # Group count by assignee
   bd count --by-label               # Group count by label
   bd count --assignee alice --by-status  # Count alice's issues by status
+  bd count --include-infra          # Count issues + wisps tier (matches 'bd list --include-infra --all' cardinality)
 
 
 ```
@@ -46,6 +47,7 @@ bd count [flags]
       --desc-contains string    Filter by description substring
       --empty-description       Filter issues with empty description
       --id string               Filter by specific issue IDs (comma-separated)
+      --include-infra           Include infrastructure beads and the wisps tier (matches 'bd list --include-infra --all' cardinality)
   -l, --label strings           Filter by labels (AND: must have ALL)
       --label-any strings       Filter by labels (OR: must have AT LEAST ONE)
       --no-assignee             Filter issues with no assignee

--- a/website/versioned_docs/version-1.0.4/cli-reference/dep.md
+++ b/website/versioned_docs/version-1.0.4/cli-reference/dep.md
@@ -30,7 +30,7 @@ bd dep [issue-id] [flags]
 
 ```
   -b, --blocks string    Issue ID that this issue blocks (shorthand for: bd dep add <blocked> <blocker>)
-      --no-cycle-check   Skip cycle detection after adding (use for bulk wiring — run 'bd dep cycles' to verify afterwards)
+      --no-cycle-check   Skip per-edge cycle checks for speed (bulk wiring); bulk --file adds still run one final whole-graph check before commit
 ```
 
 ### bd dep add
@@ -75,7 +75,7 @@ bd dep add [issue-id] [depends-on-id] [flags]
       --blocked-by string   Issue ID that blocks the first issue (alternative to positional arg)
       --depends-on string   Issue ID that the first issue depends on (alias for --blocked-by)
       --file string         Read dependency edges from JSONL file, or '-' for stdin
-      --no-cycle-check      Skip cycle detection after adding (use for bulk wiring — run 'bd dep cycles' to verify afterwards)
+      --no-cycle-check      Skip per-edge cycle checks for speed (bulk wiring); bulk --file adds still run one final whole-graph check before commit
   -t, --type string         Dependency type (blocks|tracks|related|parent-child|discovered-from|until|caused-by|validates|relates-to|supersedes) (default "blocks")
 ```
 

--- a/website/versioned_docs/version-1.0.4/cli-reference/import.md
+++ b/website/versioned_docs/version-1.0.4/cli-reference/import.md
@@ -48,6 +48,20 @@ Timestamps (created_at, updated_at, started_at, closed_at) are preserved
 when present in the JSONL and otherwise filled in by the importer. The
 legacy "wisp" boolean is accepted as an alias for "ephemeral".
 
+By default a row only rewrites an existing local issue when its
+updated_at is strictly newer. Older rows are skipped (reported as
+stale_skipped_ids) and rows with the same updated_at keep every local
+column — updated_at has second granularity, so a timestamp tie can be
+two distinct same-second updates, and the local row wins the tie
+(reported as tie_kept_local_ids; the row's labels/comments/dependencies
+still merge). The guard is also enforced inside the upsert itself, so a
+local update that lands while the import is running is preserved rather
+than overwritten. Existing issues that the import did rewrite are listed
+with a field-level summary (updated_issues), so local state changed by
+an import is visible. To deliberately restore an older snapshot, pass
+--allow-stale, which imports every row even when it overwrites newer
+local state.
+
 EXAMPLES:
   bd import                        # Import from configured import.path
   bd import backup.jsonl           # Import from a specific file
@@ -56,6 +70,7 @@ EXAMPLES:
   cat issues.jsonl | bd import -   # Pipe JSONL from another tool
   bd import --dry-run              # Show what would be imported
   bd import --dedup                # Skip issues with duplicate titles
+  bd import --allow-stale old.jsonl # Restore an older snapshot (overwrites newer local rows)
   bd import --json                 # Structured output with created and skipped IDs
 
 ```
@@ -65,6 +80,7 @@ bd import [file|-] [flags]
 **Flags:**
 
 ```
+      --allow-stale    Import rows even when older than the local issue (required to restore an older snapshot)
       --dedup          Skip lines whose title matches an existing open issue
       --dry-run        Show what would be imported without importing
   -i, --input string   Read JSONL from a specific file

--- a/website/versioned_docs/version-1.0.5/cli-reference/count.md
+++ b/website/versioned_docs/version-1.0.5/cli-reference/count.md
@@ -24,6 +24,7 @@ Examples:
   bd count --by-assignee            # Group count by assignee
   bd count --by-label               # Group count by label
   bd count --assignee alice --by-status  # Count alice's issues by status
+  bd count --include-infra          # Count issues + wisps tier (matches 'bd list --include-infra --all' cardinality)
 
 
 ```
@@ -46,6 +47,7 @@ bd count [flags]
       --desc-contains string    Filter by description substring
       --empty-description       Filter issues with empty description
       --id string               Filter by specific issue IDs (comma-separated)
+      --include-infra           Include infrastructure beads and the wisps tier (matches 'bd list --include-infra --all' cardinality)
   -l, --label strings           Filter by labels (AND: must have ALL)
       --label-any strings       Filter by labels (OR: must have AT LEAST ONE)
       --no-assignee             Filter issues with no assignee

--- a/website/versioned_docs/version-1.0.5/cli-reference/dep.md
+++ b/website/versioned_docs/version-1.0.5/cli-reference/dep.md
@@ -30,7 +30,7 @@ bd dep [issue-id] [flags]
 
 ```
   -b, --blocks string    Issue ID that this issue blocks (shorthand for: bd dep add <blocked> <blocker>)
-      --no-cycle-check   Skip cycle detection after adding (use for bulk wiring — run 'bd dep cycles' to verify afterwards)
+      --no-cycle-check   Skip per-edge cycle checks for speed (bulk wiring); bulk --file adds still run one final whole-graph check before commit
 ```
 
 ### bd dep add
@@ -75,7 +75,7 @@ bd dep add [issue-id] [depends-on-id] [flags]
       --blocked-by string   Issue ID that blocks the first issue (alternative to positional arg)
       --depends-on string   Issue ID that the first issue depends on (alias for --blocked-by)
       --file string         Read dependency edges from JSONL file, or '-' for stdin
-      --no-cycle-check      Skip cycle detection after adding (use for bulk wiring — run 'bd dep cycles' to verify afterwards)
+      --no-cycle-check      Skip per-edge cycle checks for speed (bulk wiring); bulk --file adds still run one final whole-graph check before commit
   -t, --type string         Dependency type (blocks|tracks|related|parent-child|discovered-from|until|caused-by|validates|relates-to|supersedes) (default "blocks")
 ```
 

--- a/website/versioned_docs/version-1.0.5/cli-reference/import.md
+++ b/website/versioned_docs/version-1.0.5/cli-reference/import.md
@@ -48,6 +48,20 @@ Timestamps (created_at, updated_at, started_at, closed_at) are preserved
 when present in the JSONL and otherwise filled in by the importer. The
 legacy "wisp" boolean is accepted as an alias for "ephemeral".
 
+By default a row only rewrites an existing local issue when its
+updated_at is strictly newer. Older rows are skipped (reported as
+stale_skipped_ids) and rows with the same updated_at keep every local
+column — updated_at has second granularity, so a timestamp tie can be
+two distinct same-second updates, and the local row wins the tie
+(reported as tie_kept_local_ids; the row's labels/comments/dependencies
+still merge). The guard is also enforced inside the upsert itself, so a
+local update that lands while the import is running is preserved rather
+than overwritten. Existing issues that the import did rewrite are listed
+with a field-level summary (updated_issues), so local state changed by
+an import is visible. To deliberately restore an older snapshot, pass
+--allow-stale, which imports every row even when it overwrites newer
+local state.
+
 EXAMPLES:
   bd import                        # Import from configured import.path
   bd import backup.jsonl           # Import from a specific file
@@ -56,6 +70,7 @@ EXAMPLES:
   cat issues.jsonl | bd import -   # Pipe JSONL from another tool
   bd import --dry-run              # Show what would be imported
   bd import --dedup                # Skip issues with duplicate titles
+  bd import --allow-stale old.jsonl # Restore an older snapshot (overwrites newer local rows)
   bd import --json                 # Structured output with created and skipped IDs
 
 ```
@@ -65,6 +80,7 @@ bd import [file|-] [flags]
 **Flags:**
 
 ```
+      --allow-stale    Import rows even when older than the local issue (required to restore an older snapshot)
       --dedup          Skip lines whose title matches an existing open issue
       --dry-run        Show what would be imported without importing
   -i, --input string   Read JSONL from a specific file


### PR DESCRIPTION
## Problem

`bd count` (cmd/bd/count.go) hardcodes `filter.SkipWisps = true` (introduced in 9a29a158f, the Q2-perf SQL-COUNT rewrite), so it only counts the durable `issues` table. But `bd list --include-infra` merges the `wisps` table — whose `no_history` rows are durable work — so no `bd count` invocation can reproduce a list cardinality. Measured on the production gascity rig store: `bd count --type task` = 23,777 vs the equivalent `bd list --include-infra` cardinality of 33,601, a **29% undercount**. This blocks Gas City's bd-CLI-backed store from implementing an exact `Counter`, which its bounded-read pagination optimization requires (every `all=true` API read currently materializes the full closed history — ~11s and ~100MB JSON per request on that store).

## Fix

Add `--include-infra` to `bd count`, mirroring `bd list`'s flag of the same name, with the contract: **for any filter set, `bd count --include-infra <filters>` returns exactly the number of rows `bd list --include-infra <filters> --all` returns** (modulo list's `--limit`).

- **cmd/bd/count.go** — new flag; `applyCountIncludeInfra` reproduces the `buildListFilter` defaults that determine list's cardinality under `--include-infra`: wisps merge (`SkipWisps=false`), template exclusion (`IsTemplate=false`, the cardinality trap the issue calls out), default gate exclusion unless `--type gate`, and infra-type routing to the ephemeral tier using the store-configured infra set. Without the flag the filter construction is unchanged — the widely-scripted default stays byte-identical.
- **internal/storage/{dolt,embeddeddolt}/counts.go** — `CountIssues` now delegates to `issueops.CountIssuesInTx` (extended with the `query` param) instead of a hardcoded `SELECT COUNT(*) FROM issues`. `CountIssuesInTx` already implemented the merged issues+wisps count but had no production callers; this wires it in so count and search share one WHERE-clause builder per table, making parity structural rather than coincidental.
- **internal/storage/issueops/count.go** — `CountIssuesByGroupInTx` now honors `SkipWisps`/`Ephemeral` with the same merge semantics, so `--by-*` grouped counts under `--include-infra` report merged buckets (and the grouped total still equals the flat count) instead of silently-wrong durable-only numbers.

## Tests (TDD)

- `cmd/bd/count_filter_test.go` — pins the count filter against `buildListFilter` field-by-field for `--type` ∈ {none, task, gate, message} plus custom infra-set routing, and pins the flag's existence/default.
- `internal/storage/dolt/count_include_wisps_test.go` — asserts `CountIssues == len(SearchIssues)` across the trap filters (templates, `no_history`, ephemeral, type filters) and merged/durable/ephemeral grouped counts including `--by-label` across `labels`/`wisp_labels`.
- `cmd/bd/count_embedded_test.go` — CLI-level `TestEmbeddedCountIncludeInfra`: count==list parity over several filter sets, wisps-tier inclusion, grouped totals, and byte-identical no-flag defaults.

## Parity evidence (production gascity rig store, read-only, bd built from this branch)

| invocation | patched count | `bd list --include-infra ... --all --json --limit 0` cardinality |
|---|---|---|
| `--include-infra --type task` | **33,601** | **33,601** |
| `--include-infra` | 42,631 | 42,631 |
| `--include-infra --status open` | 1,969 | 1,969 |
| `--include-infra --by-type` | total 42,631 (task bucket 33,601, Σgroups = total) | 42,631 |
| `--type task` (no flag) | 23,777 | stock bd 1.0.5 on same store: 23,777 (byte-identical default) |

(The issue's measurements were 23,717 / 33,538; the store has grown since it was filed.)

## Gates

- `make ci-pr-core` (`go test -race -short -skip '^TestEmbedded' ./...`) — pass
- `make ci-pr-policy` — pass (CLI docs regenerated via `scripts/generate-cli-docs.sh` + `generate-llms-full.sh`; this also picks up pre-existing dep/import help-text drift on main that was failing `check-doc-flags.sh`)
- `make ci-pr-lint` — pass (includes a pre-existing gofmt fix in `issueops/search.go` that was failing `fmt-check` on main)
- `go vet ./...` — clean
- `BEADS_TEST_EMBEDDED_DOLT=1` embedded count suites and full `internal/storage/{dolt,embeddeddolt}` packages — pass

Fixes #4387

🤖 Generated with [Claude Code](https://claude.com/claude-code)