### PR TITLE
docs: add beads.nvim to community tools

### DIFF
--- a/docs/COMMUNITY_TOOLS.md
+++ b/docs/COMMUNITY_TOOLS.md
@@ -30,6 +30,7 @@ A curated list of community-built UIs, extensions, and integrations for Beads. R
 - **[Lista Beads](https://marketplace.visualstudio.com/items?itemName=ListaDev.lista-beads)** - Full-featured VS Code extension: filterable tree view, issue detail panel, dashboard with metrics, dependency graph, Dolt push/pull, CodeLens for bead references, wisps & formula support, stale issue management, and multi-tracker sync (Azure DevOps, GitHub, Jira, Linear, GitLab). Built by [@harry-miller-trimble](https://github.com/harry-miller-trimble). (TypeScript)
 
 - **[nvim-beads (fancypantalons)](https://github.com/fancypantalons/nvim-beads)** - Neovim plugin for managing Beads issues. By [@fancypantalons](https://github.com/fancypantalons). (Lua)
+- **[beads.nvim](https://github.com/tomfordweb/beads.nvim)** - Neovim UI for managing Beads issues — ready queue, editable floating detail view, create/quick-capture, Telescope pickers, memories, and dependency graph. Uses the `bd` CLI for Dolt compatibility. By [@tomfordweb](https://github.com/tomfordweb). (Lua)
 
 - **[beads-manager](https://plugins.jetbrains.com/plugin/30089-beads-manager)** - Jetbrains IDE plugin to manage and view bead details. Maintained by [@developmeh](https://github.com/developmeh). (Kotlin)
 


### PR DESCRIPTION
Hey there - first off thank you all for your hard work for this amazing program. 

## What

Adds **beads.nvim** to the Editor Extensions list — a Neovim UI for managing Beads issues, placed alongside the other Neovim entries.

## Why

beads.nvim gives Neovim users a front end for `beads`: a queue kanban board, and a variety of telescope pickers to search issues and memories. An editable floating detail view with sidebar to view linked issues. Create / quick-capture, Telescope pickers, memory management, and the dependency graph. 

It's just a UI over the `bd` CLI, so `bd` stays the single source of truth and it stays Dolt-compatible. It does not read the legacy `.beads/issues.jsonl` format.

## Verification

- Plugin drives the `bd` CLI directly (no `.beads/issues.jsonl` parsing) — compatible with current Dolt-backed Beads.
- Repo is public and maintained: https://github.com/tomfordweb/beads.nvim (README, `:help beads`, CI for lint/test/docs).
- Diff is a single-line addition to `docs/COMMUNITY_TOOLS.md`; no `.beads/` data or generated files included.
