### PR TITLE
fix: Dolt /tmp/mysql.sock down → TCP fallback (gt-28itz)

### DIFF
--- a/internal/storage/dolt/socket_fallback_test.go
+++ b/internal/storage/dolt/socket_fallback_test.go
@@ -1,0 +1,78 @@
+package dolt
+
+import (
+	"errors"
+	"net"
+	"testing"
+	"time"
+)
+
+// resolveSocketTransport implements a socket-first / TCP-fallback policy for
+// Dolt server connections (gt-28itz). These tests stub dialProbe so they run
+// without a live Dolt server.
+
+func withStubbedDialProbe(t *testing.T, reachable map[string]bool) {
+	t.Helper()
+	orig := dialProbe
+	t.Cleanup(func() { dialProbe = orig })
+	dialProbe = func(network, addr string, _ time.Duration) error {
+		if reachable[network+"|"+addr] {
+			return nil
+		}
+		return errors.New("stub: unreachable " + network + " " + addr)
+	}
+}
+
+// No socket configured → pure TCP, no probing, returns "".
+func TestResolveSocketTransport_NoSocket(t *testing.T) {
+	withStubbedDialProbe(t, map[string]bool{})
+	got := resolveSocketTransport("", "127.0.0.1", 52756, 100*time.Millisecond)
+	if got != "" {
+		t.Errorf("expected empty socket (TCP), got %q", got)
+	}
+}
+
+// Socket is live → keep using the socket.
+func TestResolveSocketTransport_SocketUp(t *testing.T) {
+	withStubbedDialProbe(t, map[string]bool{
+		"unix|/tmp/mysql.sock": true,
+	})
+	got := resolveSocketTransport("/tmp/mysql.sock", "127.0.0.1", 52756, 100*time.Millisecond)
+	if got != "/tmp/mysql.sock" {
+		t.Errorf("expected socket kept, got %q", got)
+	}
+}
+
+// Socket down but TCP up → fall back to TCP (return ""). This is the gt-28itz
+// regression: /tmp/mysql.sock absent while the server is reachable on :52756.
+func TestResolveSocketTransport_SocketDownTCPUp_FallsBack(t *testing.T) {
+	withStubbedDialProbe(t, map[string]bool{
+		"tcp|" + net.JoinHostPort("127.0.0.1", "52756"): true,
+		// unix socket intentionally absent from the reachable set
+	})
+	got := resolveSocketTransport("/tmp/mysql.sock", "127.0.0.1", 52756, 100*time.Millisecond)
+	if got != "" {
+		t.Errorf("expected TCP fallback (empty socket), got %q", got)
+	}
+}
+
+// Socket down AND TCP down → keep the socket so the normal error path reports
+// the outage with its socket-specific hint (no silent transport swap).
+func TestResolveSocketTransport_BothDown_KeepsSocket(t *testing.T) {
+	withStubbedDialProbe(t, map[string]bool{})
+	got := resolveSocketTransport("/tmp/mysql.sock", "127.0.0.1", 52756, 100*time.Millisecond)
+	if got != "/tmp/mysql.sock" {
+		t.Errorf("expected socket kept (both down), got %q", got)
+	}
+}
+
+// Socket down and no usable TCP port → keep socket (cannot fall back).
+func TestResolveSocketTransport_SocketDownNoPort_KeepsSocket(t *testing.T) {
+	withStubbedDialProbe(t, map[string]bool{
+		"tcp|" + net.JoinHostPort("127.0.0.1", "0"): true, // should never be probed
+	})
+	got := resolveSocketTransport("/tmp/mysql.sock", "127.0.0.1", 0, 100*time.Millisecond)
+	if got != "/tmp/mysql.sock" {
+		t.Errorf("expected socket kept (no TCP port), got %q", got)
+	}
+}

--- a/internal/storage/dolt/socket_fallback_test.go
+++ b/internal/storage/dolt/socket_fallback_test.go
@@ -1,8 +1,10 @@
 package dolt
 
 import (
+	"context"
 	"errors"
 	"net"
+	"reflect"
 	"testing"
 	"time"
 )
@@ -11,24 +13,35 @@ import (
 // Dolt server connections (gt-28itz). These tests stub dialProbe so they run
 // without a live Dolt server.
 
-func withStubbedDialProbe(t *testing.T, reachable map[string]bool) {
+type probeCall struct {
+	network string
+	addr    string
+}
+
+func withStubbedDialProbe(t *testing.T, reachable map[string]bool) *[]probeCall {
 	t.Helper()
 	orig := dialProbe
 	t.Cleanup(func() { dialProbe = orig })
+	var calls []probeCall
 	dialProbe = func(network, addr string, _ time.Duration) error {
+		calls = append(calls, probeCall{network: network, addr: addr})
 		if reachable[network+"|"+addr] {
 			return nil
 		}
 		return errors.New("stub: unreachable " + network + " " + addr)
 	}
+	return &calls
 }
 
 // No socket configured → pure TCP, no probing, returns "".
 func TestResolveSocketTransport_NoSocket(t *testing.T) {
-	withStubbedDialProbe(t, map[string]bool{})
+	calls := withStubbedDialProbe(t, map[string]bool{})
 	got := resolveSocketTransport("", "127.0.0.1", 52756, 100*time.Millisecond)
 	if got != "" {
 		t.Errorf("expected empty socket (TCP), got %q", got)
+	}
+	if len(*calls) != 0 {
+		t.Errorf("expected no probes without a configured socket, got %v", *calls)
 	}
 }
 
@@ -74,5 +87,60 @@ func TestResolveSocketTransport_SocketDownNoPort_KeepsSocket(t *testing.T) {
 	got := resolveSocketTransport("/tmp/mysql.sock", "127.0.0.1", 0, 100*time.Millisecond)
 	if got != "/tmp/mysql.sock" {
 		t.Errorf("expected socket kept (no TCP port), got %q", got)
+	}
+}
+
+// Socket fallback is wired in newServerMode before its fail-fast connection
+// dial. Keep this test on the connection-error path so it needs no live Dolt
+// server while still proving that server-mode configuration is normalized.
+func TestNewServerMode_SocketDownTCPUpFallsBack(t *testing.T) {
+	t.Setenv("BEADS_TEST_MODE", "1")
+	const socket = "/tmp/beads-test-mysql.sock"
+	const host = "127.0.0.1"
+	const port = 1 // expected to be unreachable for the eventual real connection dial
+	tcpAddr := net.JoinHostPort(host, "1")
+	calls := withStubbedDialProbe(t, map[string]bool{
+		"tcp|" + tcpAddr: true,
+	})
+	cfg := &Config{
+		Database:     "test_socket_fallback_wiring",
+		ServerHost:   host,
+		ServerPort:   port,
+		ServerSocket: socket,
+		AutoStart:    false,
+	}
+
+	_, err := newServerMode(context.Background(), cfg)
+	if err == nil {
+		t.Fatal("expected connection error from unreachable TCP endpoint")
+	}
+	if cfg.ServerSocket != "" {
+		t.Fatalf("expected server mode to select TCP fallback, socket = %q", cfg.ServerSocket)
+	}
+	wantCalls := []probeCall{
+		{network: "unix", addr: socket},
+		{network: "tcp", addr: tcpAddr},
+	}
+	if !reflect.DeepEqual(*calls, wantCalls) {
+		t.Errorf("probe calls = %v, want %v", *calls, wantCalls)
+	}
+}
+
+func TestNewServerMode_NoSocketDoesNotProbe(t *testing.T) {
+	t.Setenv("BEADS_TEST_MODE", "1")
+	calls := withStubbedDialProbe(t, map[string]bool{})
+	cfg := &Config{
+		Database:   "test_socket_fallback_no_socket",
+		ServerHost: "127.0.0.1",
+		ServerPort: 1, // expected to be unreachable for the eventual real connection dial
+		AutoStart:  false,
+	}
+
+	_, err := newServerMode(context.Background(), cfg)
+	if err == nil {
+		t.Fatal("expected connection error from unreachable TCP endpoint")
+	}
+	if len(*calls) != 0 {
+		t.Errorf("expected no probes without a configured socket, got %v", *calls)
 	}
 }

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -1250,6 +1250,46 @@ func buildTestModeProductionPortPanic(cfg *Config) string {
 	)
 }
 
+// dialProbe reports whether an address accepts a connection within timeout.
+// Declared as a var (not a plain call) so unit tests can stub connectivity
+// without a live Dolt server. Returns nil when the endpoint is reachable.
+var dialProbe = func(network, addr string, timeout time.Duration) error {
+	conn, err := net.DialTimeout(network, addr, timeout)
+	if err != nil {
+		return err
+	}
+	_ = conn.Close()
+	return nil
+}
+
+// resolveSocketTransport applies a socket-first / TCP-fallback policy and
+// returns the effective unix socket path to use ("" means use TCP).
+//
+// A configured unix socket is a preference, not a hard requirement. Dolt's
+// /tmp/mysql.sock is created only on some server start paths and is frequently
+// absent while the server is fully reachable on its TCP port — when that
+// happens, every socket-mode bd operation (and `gt mq submit`, cross-rig bead
+// reads that route through bd) fails hard with no fallback (gt-28itz). This
+// mirrors the conservative socket-first/TCP-fallback semantics already used on
+// the gt-CLI side (internal/cmd/dolt_dsn.go localDoltSocketPath/buildDoltDSN).
+//
+// Returns the socket unchanged when: no socket is configured, the socket is
+// connectable, or neither the socket nor TCP is reachable (the latter is left
+// to the normal error path so its socket-specific hint still surfaces a true
+// outage rather than masking it behind a TCP error).
+func resolveSocketTransport(socket, host string, port int, timeout time.Duration) string {
+	if socket == "" {
+		return ""
+	}
+	if dialProbe("unix", socket, timeout) == nil {
+		return socket // socket is live — keep using it
+	}
+	if port > 0 && dialProbe("tcp", net.JoinHostPort(host, strconv.Itoa(port)), timeout) == nil {
+		return "" // socket down but TCP up — transparently fall back to TCP
+	}
+	return socket // both down (or no TCP port) — keep socket for the error path
+}
+
 // newServerMode creates a DoltStore connected to a running dolt sql-server.
 // This path is pure Go and does not require CGO.
 func newServerMode(ctx context.Context, cfg *Config) (*DoltStore, error) {
@@ -1273,6 +1313,12 @@ func newServerMode(ctx context.Context, cfg *Config) (*DoltStore, error) {
 		resolvedBeadsDir = filepath.Dir(cfg.Path) // fallback: cfg.Path is .beads/dolt → parent is .beads/
 	}
 	serverDir := doltserver.ResolveServerDir(resolvedBeadsDir)
+
+	// Socket-first / TCP-fallback (gt-28itz): a configured unix socket that
+	// isn't currently connectable must not block operations when the server is
+	// reachable over TCP. Normalizing here means the fail-fast dial below and
+	// the DSN built in openServerConnection agree on the transport.
+	cfg.ServerSocket = resolveSocketTransport(cfg.ServerSocket, cfg.ServerHost, cfg.ServerPort, 500*time.Millisecond)
 
 	// Fail-fast connectivity check before MySQL protocol initialization.
 	// This gives an immediate, clear error if the Dolt server isn't running,

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -39,6 +39,7 @@ import (
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/steveyegge/beads/internal/configfile"
+	"github.com/steveyegge/beads/internal/debug"
 	"github.com/steveyegge/beads/internal/doltserver"
 	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/storage/doltutil"
@@ -1285,6 +1286,7 @@ func resolveSocketTransport(socket, host string, port int, timeout time.Duration
 		return socket // socket is live — keep using it
 	}
 	if port > 0 && dialProbe("tcp", net.JoinHostPort(host, strconv.Itoa(port)), timeout) == nil {
+		debug.Logf("dolt: socket %s unreachable, falling back to TCP %s\n", socket, net.JoinHostPort(host, strconv.Itoa(port)))
 		return "" // socket down but TCP up — transparently fall back to TCP
 	}
 	return socket // both down (or no TCP port) — keep socket for the error path


### PR DESCRIPTION
## Problem (gt-28itz)
Dolt's `/tmp/mysql.sock` is intermittently down. When it is, `gt mq submit` and cross-rig `bd` reads fail with `connection refused` on the socket path, even though the Dolt server is reachable via TCP (port still works). This blocked merge flows + cross-rig bead reads in Gas City (2026-06-13).

## Fix
`fix/gt-28itz-dolt-socket-tcp-fallback` @8d55d7fc5 — when the Unix socket connection fails, fall back to TCP automatically. Built + tested + pushed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)