### PR TITLE
fix(query): lex digit-led identifier-shaped tokens as identifiers

### DIFF
--- a/internal/query/lexer.go
+++ b/internal/query/lexer.go
@@ -229,12 +229,19 @@ func (l *Lexer) readString(quote rune, startPos int) (Token, error) {
 }
 
 // readNumberOrDuration reads a number or duration (e.g., 7d, 24h).
+//
+// Unsigned digit-led tokens that continue into identifier characters
+// (e.g. "1-alpha", "42day-sla", "9.3.1") are re-lexed as identifiers so
+// they can stand in unquoted on the value side of comparisons like
+// "label=1-alpha". Signed forms ("-3-foo") still error — the user has
+// to quote them.
 func (l *Lexer) readNumberOrDuration(startPos int) (Token, error) {
 	var sb strings.Builder
 
 	// Handle optional sign
 	r := l.next()
-	if r == '-' || r == '+' {
+	hadSign := r == '-' || r == '+'
+	if hadSign {
 		sb.WriteRune(r)
 		r = l.next()
 	}
@@ -256,13 +263,26 @@ func (l *Lexer) readNumberOrDuration(startPos int) (Token, error) {
 		sb.WriteRune(r)
 	}
 
-	// Check for duration suffix
-	if r != 0 && isDurationSuffix(r) {
+	// Check for duration suffix. Only commit to a duration when the suffix
+	// stands alone — if more identifier characters follow (e.g. "7day"),
+	// fall through to the identifier-fallback below.
+	if r != 0 && isDurationSuffix(r) && !isIdentChar(l.peek()) {
 		sb.WriteRune(r)
 		return Token{Type: TokenDuration, Value: sb.String(), Pos: startPos}, nil
 	}
 
-	// Not a duration suffix, back up
+	// Identifier-continuation fallback: an unsigned digit-led run that
+	// butts against more identifier characters is an identifier, not a
+	// number. Restart the lex at the original position and read it as an
+	// identifier so "1-alpha", "2bravo", "42d-sla" all tokenize as one
+	// TokenIdent.
+	if !hadSign && r != 0 && isIdentChar(r) {
+		l.pos = startPos
+		return l.readIdent(startPos)
+	}
+
+	// Not a duration suffix and not an identifier — back up the lookahead
+	// rune.
 	if r != 0 {
 		l.backup()
 	}

--- a/internal/query/query_test.go
+++ b/internal/query/query_test.go
@@ -115,6 +115,36 @@ func TestLexer(t *testing.T) {
 			expected: []TokenType{TokenIdent, TokenEquals, TokenIdent, TokenEOF},
 			values:   []string{"label", "=", "gt:merge-request", ""},
 		},
+		{
+			name:     "digit-led identifier on the value side",
+			input:    "assignee=1-alpha",
+			expected: []TokenType{TokenIdent, TokenEquals, TokenIdent, TokenEOF},
+			values:   []string{"assignee", "=", "1-alpha", ""},
+		},
+		{
+			name:     "digit-led identifier in a compound expression",
+			input:    "assignee=2-bravo AND status=open",
+			expected: []TokenType{TokenIdent, TokenEquals, TokenIdent, TokenAnd, TokenIdent, TokenEquals, TokenIdent, TokenEOF},
+			values:   []string{"assignee", "=", "2-bravo", "AND", "status", "=", "open", ""},
+		},
+		{
+			name:     "digit-led identifier with duration-suffix prefix",
+			input:    "label=7day-window",
+			expected: []TokenType{TokenIdent, TokenEquals, TokenIdent, TokenEOF},
+			values:   []string{"label", "=", "7day-window", ""},
+		},
+		{
+			name:     "duration still wins when the suffix stands alone",
+			input:    "updated>30d",
+			expected: []TokenType{TokenIdent, TokenGreater, TokenDuration, TokenEOF},
+			values:   []string{"updated", ">", "30d", ""},
+		},
+		{
+			name:     "duration with trailing space stays a duration",
+			input:    "updated>30d AND status=open",
+			expected: []TokenType{TokenIdent, TokenGreater, TokenDuration, TokenAnd, TokenIdent, TokenEquals, TokenIdent, TokenEOF},
+			values:   []string{"updated", ">", "30d", "AND", "status", "=", "open", ""},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

The query lexer's \`readNumberOrDuration\` unconditionally claimed any digit-led token, then erred at the first non-digit / non-duration-suffix byte. Identifier-shaped values like \`1-alpha\` or \`42d-sla\` therefore couldn't appear unquoted on the value side of a comparison:

\`\`\`
$ bd query 'assignee=1-alpha'
Error: parsing query: expected digit at position 11

$ bd query 'label=42d-sla'
Error: parsing query: expected digit at position 12
\`\`\`

Every caller that wanted to filter on such a value had to quote the string or fall back to a client-side filter. The DSL already treats identifiers and values uniformly (the existing \"identifier with hyphen\" / \"unquoted identifier with colon\" cases under \`TestLexer\` exercise that for letter-led tokens) — digit-led was the only outlier.

## Changes

Two lookahead adjustments in \`readNumberOrDuration\`:

- **Duration suffix is terminal-only.** \`isDurationSuffix\` only fires when the suffix character isn't followed by another identifier-continuation character. \`updated>7d\` still tokenises as \`updated\` / \`>\` / \`7d\` (duration); \`label=7day-sla\` falls through to the identifier path.
- **Unsigned digit-led identifier fallback.** If, after reading the digit run, the next character is an identifier-continuation char, the lexer rewinds to the token start and re-reads via \`readIdent\`. Signed forms (\`-3-foo\`) still error so arithmetic-shaped input doesn't silently morph into an identifier — quote them if you need them.

## Testing

- \`go test ./internal/query/\` — full package passes (existing cases unchanged).
- Five new \`TestLexer\` cases:
  - \`digit-led identifier on the value side\` (\`assignee=1-alpha\`)
  - \`digit-led identifier in a compound expression\` (\`assignee=2-bravo AND status=open\`)
  - \`digit-led identifier with duration-suffix prefix\` (\`label=7day-window\`)
  - \`duration still wins when the suffix stands alone\` (\`updated>30d\`)
  - \`duration with trailing space stays a duration\` (\`updated>30d AND status=open\`)
- \`go test ./internal/storage/issueops/\` passes.
- End-to-end: built \`cmd/bd\` against this branch, ran \`bd query 'assignee=1-alpha'\` against a real store — returns cleanly instead of the parser error. \`bd query 'priority=2'\` and \`bd query 'updated>30d'\` continue to work as before.

## Notes for reviewers

- No external API or schema change; this is strictly a lexer-fallback widening.
- The pre-commit hook needed \`GOTOOLCHAIN=go1.26.2\` and a bumped golangci-lint timeout to run on this machine; lint result was clean (\`0 issues\`). Happy to file a separate PR bumping the pinned \`golangci-lint@v2.10.1\` to a release that supports the project's Go target if maintainers want one.