### PR TITLE
fix(cli): render markdown with terminal capability gates (#3881)

### DIFF
--- a/internal/ui/terminal.go
+++ b/internal/ui/terminal.go
@@ -3,6 +3,8 @@ package ui
 
 import (
 	"os"
+	"strconv"
+	"strings"
 
 	"golang.org/x/term"
 )
@@ -25,6 +27,7 @@ func IsStderrTerminal() bool {
 //   - NO_COLOR: https://no-color.org/ - disables color if set
 //   - CLICOLOR=0: disables color
 //   - CLICOLOR_FORCE: forces color even in non-TTY
+//   - TERM=dumb: disables color unless explicitly forced
 //   - Falls back to TTY detection
 func ShouldUseColor() bool {
 	// Git hook context - disable color to prevent termenv OSC 11 terminal
@@ -49,8 +52,80 @@ func ShouldUseColor() bool {
 		return true
 	}
 
+	// TERM is a terminfo terminal type string (for example "xterm-256color",
+	// "xterm-kitty", "screen-256color", "tmux-256color", or "vt100").
+	// "dumb" explicitly means ANSI controls are unsupported.
+	if strings.EqualFold(os.Getenv("TERM"), "dumb") {
+		return false
+	}
+
 	// Default: use color only if stdout is a TTY
 	return IsTerminal()
+}
+
+// ShouldUseHyperlinks determines if OSC 8 terminal hyperlinks should be emitted.
+// OSC 8 support is not implied by ANSI color support, so this intentionally uses
+// a narrower allowlist plus FORCE_HYPERLINK for users who know their terminal.
+func ShouldUseHyperlinks() bool {
+	return shouldUseHyperlinks(IsTerminal())
+}
+
+// shouldUseHyperlinks is the testable implementation behind ShouldUseHyperlinks.
+// It takes the stdout TTY result as a parameter so tests can cover known terminal
+// capability markers (for example Windows Terminal's WT_SESSION) without needing
+// to run inside those terminals.
+func shouldUseHyperlinks(stdoutIsTerminal bool) bool {
+	if os.Getenv("BD_GIT_HOOK") == "1" {
+		return false
+	}
+	if os.Getenv("NO_COLOR") != "" {
+		return false
+	}
+	if os.Getenv("CLICOLOR") == "0" {
+		return false
+	}
+	// TERM is a terminfo terminal type string (for example "xterm-256color",
+	// "xterm-kitty", "screen-256color", "tmux-256color", or "vt100"), not a
+	// boolean toggle. "dumb" explicitly means OSC 8 hyperlinks are unsupported.
+	if strings.EqualFold(os.Getenv("TERM"), "dumb") {
+		return false
+	}
+	if force := os.Getenv("FORCE_HYPERLINK"); force != "" && force != "0" {
+		return true
+	}
+	if !stdoutIsTerminal {
+		return false
+	}
+
+	if os.Getenv("WT_SESSION") != "" ||
+		os.Getenv("KITTY_WINDOW_ID") != "" ||
+		os.Getenv("WEZTERM_EXECUTABLE") != "" ||
+		os.Getenv("KONSOLE_VERSION") != "" ||
+		os.Getenv("DOMTERM") != "" ||
+		os.Getenv("GHOSTTY_RESOURCES_DIR") != "" {
+		return true
+	}
+
+	switch strings.ToLower(os.Getenv("TERM_PROGRAM")) {
+	case "iterm.app", "wezterm", "vscode", "apple_terminal", "tabby", "hyper", "ghostty":
+		return true
+	}
+
+	termName := strings.ToLower(os.Getenv("TERM"))
+	if strings.Contains(termName, "xterm-kitty") ||
+		strings.Contains(termName, "wezterm") ||
+		strings.Contains(termName, "foot") ||
+		strings.Contains(termName, "contour") ||
+		strings.Contains(termName, "ghostty") {
+		return true
+	}
+
+	if vte := os.Getenv("VTE_VERSION"); vte != "" {
+		version, err := strconv.Atoi(vte)
+		return err == nil && version >= 5000
+	}
+
+	return false
 }
 
 // ShouldUseEmoji determines if emoji decorations should be used.

--- a/internal/ui/terminal_test.go
+++ b/internal/ui/terminal_test.go
@@ -10,10 +10,12 @@ func TestShouldUseColor(t *testing.T) {
 	origNoColor := os.Getenv("NO_COLOR")
 	origCliColor := os.Getenv("CLICOLOR")
 	origCliColorForce := os.Getenv("CLICOLOR_FORCE")
+	origTerm := os.Getenv("TERM")
 	defer func() {
 		setEnv("NO_COLOR", origNoColor)
 		setEnv("CLICOLOR", origCliColor)
 		setEnv("CLICOLOR_FORCE", origCliColorForce)
+		setEnv("TERM", origTerm)
 	}()
 
 	tests := []struct {
@@ -21,6 +23,7 @@ func TestShouldUseColor(t *testing.T) {
 		noColor         string
 		cliColor        string
 		cliColorForce   string
+		term            string
 		wantColor       bool
 		skipTTYDepCheck bool // Some tests don't depend on TTY state
 	}{
@@ -51,6 +54,19 @@ func TestShouldUseColor(t *testing.T) {
 			skipTTYDepCheck: true,
 		},
 		{
+			name:            "TERM dumb disables color",
+			term:            "dumb",
+			wantColor:       false,
+			skipTTYDepCheck: true,
+		},
+		{
+			name:            "CLICOLOR_FORCE overrides TERM dumb",
+			cliColorForce:   "1",
+			term:            "dumb",
+			wantColor:       true,
+			skipTTYDepCheck: true,
+		},
+		{
 			name:            "NO_COLOR takes precedence over CLICOLOR_FORCE",
 			noColor:         "1",
 			cliColorForce:   "1",
@@ -65,6 +81,7 @@ func TestShouldUseColor(t *testing.T) {
 			os.Unsetenv("NO_COLOR")
 			os.Unsetenv("CLICOLOR")
 			os.Unsetenv("CLICOLOR_FORCE")
+			os.Unsetenv("TERM")
 
 			// Set test-specific vars
 			if tt.noColor != "" {
@@ -76,12 +93,83 @@ func TestShouldUseColor(t *testing.T) {
 			if tt.cliColorForce != "" {
 				os.Setenv("CLICOLOR_FORCE", tt.cliColorForce)
 			}
+			if tt.term != "" {
+				os.Setenv("TERM", tt.term)
+			}
 
 			got := ShouldUseColor()
 			if tt.skipTTYDepCheck && got != tt.wantColor {
 				t.Errorf("ShouldUseColor() = %v, want %v", got, tt.wantColor)
 			}
 		})
+	}
+}
+
+func TestShouldUseHyperlinks(t *testing.T) {
+	envKeys := []string{
+		"BD_GIT_HOOK",
+		"NO_COLOR",
+		"CLICOLOR",
+		"FORCE_HYPERLINK",
+		"TERM",
+		"TERM_PROGRAM",
+		"WT_SESSION",
+	}
+	orig := map[string]string{}
+	for _, key := range envKeys {
+		orig[key] = os.Getenv(key)
+		os.Unsetenv(key)
+	}
+	defer func() {
+		for _, key := range envKeys {
+			setEnv(key, orig[key])
+		}
+	}()
+
+	if ShouldUseHyperlinks() {
+		t.Fatal("hyperlinks should be disabled for non-TTY output by default")
+	}
+
+	os.Setenv("FORCE_HYPERLINK", "1")
+	if !ShouldUseHyperlinks() {
+		t.Fatal("FORCE_HYPERLINK should enable hyperlinks")
+	}
+
+	os.Setenv("NO_COLOR", "1")
+	if ShouldUseHyperlinks() {
+		t.Fatal("NO_COLOR should disable hyperlinks even when forced")
+	}
+
+	os.Unsetenv("NO_COLOR")
+	os.Setenv("TERM", "dumb")
+	if ShouldUseHyperlinks() {
+		t.Fatal("TERM=dumb should disable hyperlinks even when forced")
+	}
+
+	os.Setenv("TERM", "xterm-256color")
+	os.Setenv("BD_GIT_HOOK", "1")
+	if ShouldUseHyperlinks() {
+		t.Fatal("BD_GIT_HOOK should disable hyperlinks")
+	}
+
+	os.Unsetenv("BD_GIT_HOOK")
+	os.Unsetenv("FORCE_HYPERLINK")
+	os.Setenv("TERM", "xterm-256color")
+	os.Setenv("WT_SESSION", "windows-terminal-session")
+	if !shouldUseHyperlinks(true) {
+		t.Fatal("WT_SESSION should enable hyperlinks for Windows Terminal when stdout is a TTY")
+	}
+
+	os.Unsetenv("WT_SESSION")
+	os.Setenv("TERM_PROGRAM", "vscode")
+	if !shouldUseHyperlinks(true) {
+		t.Fatal("TERM_PROGRAM=vscode should enable hyperlinks when stdout is a TTY")
+	}
+
+	os.Unsetenv("TERM_PROGRAM")
+	os.Setenv("TERM", "xterm-kitty")
+	if !shouldUseHyperlinks(true) {
+		t.Fatal("xterm-kitty should enable hyperlinks when stdout is a TTY")
 	}
 }
 

--- a/internal/uimd/markdown.go
+++ b/internal/uimd/markdown.go
@@ -7,20 +7,20 @@ package uimd
 
 import (
 	"os"
+	"strings"
 
 	"charm.land/glamour/v2"
+	"charm.land/glamour/v2/styles"
+	xansi "github.com/charmbracelet/x/ansi"
 	"github.com/steveyegge/beads/internal/ui"
 	"golang.org/x/term"
 )
 
-// RenderMarkdown renders markdown text using glamour's auto-detected terminal style.
+// RenderMarkdown renders markdown text using glamour's terminal style.
 // Returns the rendered markdown or the original text if rendering fails.
 // Word wraps at terminal width (or 80 columns if width can't be detected).
 func RenderMarkdown(markdown string) string {
 	if ui.IsAgentMode() {
-		return markdown
-	}
-	if !ui.ShouldUseColor() {
 		return markdown
 	}
 
@@ -34,10 +34,27 @@ func RenderMarkdown(markdown string) string {
 		wrapWidth = maxReadableWidth
 	}
 
-	renderer, err := glamour.NewTermRenderer(
-		// No style is specified so glamour can auto-detect light/dark terminals.
+	// Markdown rendering and terminal escape emission are separate concerns.
+	// Even when ANSI color is unavailable, Glamour's notty style still improves
+	// structure for tables, lists, wrapping, and links. ANSI SGR and OSC 8 are
+	// stripped below unless their specific terminal capability checks pass.
+	useANSI := ui.ShouldUseColor()
+	useHyperlinks := ui.ShouldUseHyperlinks()
+	options := []glamour.TermRendererOption{
 		glamour.WithWordWrap(wrapWidth),
-	)
+		glamour.WithPreservedNewLines(),
+		glamour.WithTableWrap(false),
+	}
+	if useANSI {
+		options = append(options,
+			glamour.WithEnvironmentConfig(),
+			glamour.WithChromaFormatter("terminal256"),
+		)
+	} else {
+		options = append(options, glamour.WithStandardStyle(styles.NoTTYStyle))
+	}
+
+	renderer, err := glamour.NewTermRenderer(options...)
 	if err != nil {
 		return markdown
 	}
@@ -47,5 +64,56 @@ func RenderMarkdown(markdown string) string {
 		return markdown
 	}
 
+	if !useHyperlinks {
+		rendered = stripOSC8Hyperlinks(rendered)
+	}
+	if !useANSI && !useHyperlinks {
+		rendered = xansi.Strip(rendered)
+	}
+
 	return rendered
+}
+
+// stripOSC8Hyperlinks removes only OSC 8 hyperlink open/close sequences.
+// Glamour emits OSC 8 whenever it renders links, but OSC 8 support is separate
+// from ANSI SGR color support. We keep regular ANSI styling intact when color is
+// supported and only remove hyperlinks when ShouldUseHyperlinks says they are
+// unsafe for the current terminal.
+func stripOSC8Hyperlinks(s string) string {
+	const osc8 = "\x1b]8;"
+	if !strings.Contains(s, osc8) {
+		return s
+	}
+
+	var out strings.Builder
+	out.Grow(len(s))
+	for i := 0; i < len(s); {
+		if strings.HasPrefix(s[i:], osc8) {
+			if end := oscSequenceEnd(s, i+len(osc8)); end > i {
+				i = end
+				continue
+			}
+		}
+		out.WriteByte(s[i])
+		i++
+	}
+	return out.String()
+}
+
+// oscSequenceEnd returns the byte index after an OSC control sequence.
+// OSC strings can end with BEL or ST (ESC \); this helper keeps the stripping
+// logic local to OSC 8 handling instead of using a broad ANSI stripper that would
+// also remove color/style escapes we may still want to preserve.
+func oscSequenceEnd(s string, start int) int {
+	for i := start; i < len(s); i++ {
+		switch s[i] {
+		case '\a':
+			return i + 1
+		case '\x1b':
+			if i+1 < len(s) && s[i+1] == '\\' {
+				return i + 2
+			}
+		}
+	}
+	return -1
 }

--- a/internal/uimd/markdown_test.go
+++ b/internal/uimd/markdown_test.go
@@ -1,0 +1,141 @@
+package uimd
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestRenderMarkdownStripsEscapesWhenANSIUnsupported(t *testing.T) {
+	withMarkdownEnv(t, map[string]string{
+		"NO_COLOR":        "1",
+		"TERM":            "dumb",
+		"CLICOLOR_FORCE":  "",
+		"FORCE_HYPERLINK": "",
+		"BD_AGENT_MODE":   "",
+		"CLAUDE_CODE":     "",
+	})
+
+	out := RenderMarkdown("# Title\n\n[link](https://example.com)\n\n| A | B |\n| - | - |\n| 1 | 2 |\n")
+	if strings.Contains(out, "\x1b[") || strings.Contains(out, "\x1b]8;") {
+		t.Fatalf("expected no terminal escapes when ANSI is unsupported, got %q", out)
+	}
+	if !strings.Contains(out, "Title") || !strings.Contains(out, "example.com") {
+		t.Fatalf("expected rendered markdown content, got %q", out)
+	}
+}
+
+func TestRenderMarkdownStripsOSC8WhenHyperlinksUnsupported(t *testing.T) {
+	withMarkdownEnv(t, map[string]string{
+		"NO_COLOR":        "",
+		"TERM":            "xterm-256color",
+		"CLICOLOR_FORCE":  "1",
+		"FORCE_HYPERLINK": "",
+		"BD_AGENT_MODE":   "",
+		"CLAUDE_CODE":     "",
+	})
+
+	out := RenderMarkdown("[link](https://example.com)")
+	if strings.Contains(out, "\x1b]8;") {
+		t.Fatalf("expected OSC 8 hyperlinks to be stripped, got %q", out)
+	}
+	if !strings.Contains(out, "\x1b[") {
+		t.Fatalf("expected ANSI styling when color is forced, got %q", out)
+	}
+}
+
+func TestRenderMarkdownKeepsOSC8WhenHyperlinksSupported(t *testing.T) {
+	withMarkdownEnv(t, map[string]string{
+		"NO_COLOR":        "",
+		"TERM":            "xterm-256color",
+		"CLICOLOR_FORCE":  "1",
+		"FORCE_HYPERLINK": "1",
+		"BD_AGENT_MODE":   "",
+		"CLAUDE_CODE":     "",
+	})
+
+	out := RenderMarkdown("[link](https://example.com)")
+	if !strings.Contains(out, "\x1b]8;") {
+		t.Fatalf("expected OSC 8 hyperlink escapes, got %q", out)
+	}
+}
+
+func TestRenderMarkdownCanKeepOSC8WithoutANSIColor(t *testing.T) {
+	withMarkdownEnv(t, map[string]string{
+		"NO_COLOR":        "",
+		"TERM":            "xterm-256color",
+		"CLICOLOR_FORCE":  "",
+		"FORCE_HYPERLINK": "1",
+		"BD_AGENT_MODE":   "",
+		"CLAUDE_CODE":     "",
+	})
+
+	out := RenderMarkdown("[link](https://example.com)")
+	if !strings.Contains(out, "\x1b]8;") {
+		t.Fatalf("expected OSC 8 hyperlink escapes, got %q", out)
+	}
+	if strings.Contains(out, "\x1b[") {
+		t.Fatalf("expected no ANSI SGR styling, got %q", out)
+	}
+}
+
+func TestRenderMarkdownReturnsRawMarkdownInAgentMode(t *testing.T) {
+	withMarkdownEnv(t, map[string]string{
+		"NO_COLOR":        "",
+		"TERM":            "xterm-256color",
+		"CLICOLOR_FORCE":  "1",
+		"FORCE_HYPERLINK": "1",
+		"BD_AGENT_MODE":   "1",
+		"CLAUDE_CODE":     "",
+	})
+
+	input := "# Title\n\n[link](https://example.com)"
+	if out := RenderMarkdown(input); out != input {
+		t.Fatalf("agent mode should return raw markdown, got %q", out)
+	}
+}
+
+func withMarkdownEnv(t *testing.T, values map[string]string) {
+	t.Helper()
+
+	keys := []string{
+		"BD_GIT_HOOK",
+		"NO_COLOR",
+		"CLICOLOR",
+		"CLICOLOR_FORCE",
+		"FORCE_HYPERLINK",
+		"TERM",
+		"TERM_PROGRAM",
+		"WT_SESSION",
+		"KITTY_WINDOW_ID",
+		"WEZTERM_EXECUTABLE",
+		"KONSOLE_VERSION",
+		"DOMTERM",
+		"GHOSTTY_RESOURCES_DIR",
+		"VTE_VERSION",
+		"BD_AGENT_MODE",
+		"CLAUDE_CODE",
+	}
+	orig := make(map[string]string, len(keys))
+	for _, key := range keys {
+		orig[key] = os.Getenv(key)
+		os.Unsetenv(key)
+	}
+	t.Cleanup(func() {
+		for _, key := range keys {
+			if orig[key] == "" {
+				os.Unsetenv(key)
+			} else {
+				os.Setenv(key, orig[key])
+			}
+		}
+	})
+
+	for key, value := range values {
+		if value == "" {
+			os.Unsetenv(key)
+		} else {
+			os.Setenv(key, value)
+		}
+	}
+}

--- a/internal/uimd/markdown_test.go
+++ b/internal/uimd/markdown_test.go
@@ -6,6 +6,38 @@ import (
 	"testing"
 )
 
+// TestRenderMarkdownStylesBodyContentRegression3881 is the focused guard for
+// gastownhall/beads#3881: when color is supported, body markdown (headings,
+// bold, inline code) must be rendered with ANSI styling, not passed through as
+// plaintext. The glamour v1->v2 migration silently broke this by dropping the
+// style option, leaving an empty StyleConfig that emitted unstyled text. This
+// asserts both that ANSI SGR is present and that markdown syntax markers are
+// consumed, so it cannot be satisfied by raw passthrough.
+func TestRenderMarkdownStylesBodyContentRegression3881(t *testing.T) {
+	withMarkdownEnv(t, map[string]string{
+		"NO_COLOR":        "",
+		"TERM":            "xterm-256color",
+		"CLICOLOR_FORCE":  "1",
+		"FORCE_HYPERLINK": "",
+		"BD_AGENT_MODE":   "",
+		"CLAUDE_CODE":     "",
+	})
+
+	out := RenderMarkdown("# Heading\n\nSome **bold** text and `code`.\n")
+
+	if !strings.Contains(out, "\x1b[") {
+		t.Fatalf("expected ANSI SGR styling for rendered body, got %q", out)
+	}
+	if !strings.Contains(out, "Heading") {
+		t.Fatalf("expected heading text in output, got %q", out)
+	}
+	for _, marker := range []string{"# ", "**", "`"} {
+		if strings.Contains(out, marker) {
+			t.Fatalf("expected markdown marker %q to be rendered away, got %q", marker, out)
+		}
+	}
+}
+
 func TestRenderMarkdownStripsEscapesWhenANSIUnsupported(t *testing.T) {
 	withMarkdownEnv(t, map[string]string{
 		"NO_COLOR":        "1",


### PR DESCRIPTION
Fixes the existing Glamour formatting for ANSI-Capable terminals.

## What

- checks the terminal if ANSI / OSC8 is supported
- if supported, renders the output using the ANSI / OSC8 formatting using Glamour

## Why

Fixes #3881 

## Verification

- Unit tests where implemented