### PR TITLE
fix(dolt): retry on transient Dolt merge-conflict (Error 1105)

### DIFF
--- a/internal/storage/dolt/retry_test.go
+++ b/internal/storage/dolt/retry_test.go
@@ -88,6 +88,11 @@ func TestIsRetryableError(t *testing.T) {
 			expected: true,
 		},
 		{
+			name:     "dolt merge conflict 1105 — retryable",
+			err:      errors.New("dolt commit: Error 1105 (HY000): Merge conflict detected, @autocommit transaction rolled back"),
+			expected: true,
+		},
+		{
 			name:     "syntax error - not retryable",
 			err:      errors.New("Error 1064: You have an error in your SQL syntax"),
 			expected: false,

--- a/internal/storage/dolt/retry_test.go
+++ b/internal/storage/dolt/retry_test.go
@@ -188,3 +188,23 @@ func TestWithRetry_NonRetryableError(t *testing.T) {
 		t.Errorf("expected 1 call for non-retryable error, got %d", callCount)
 	}
 }
+
+func TestWithRetry_RetryOnMergeConflict(t *testing.T) {
+	store := &DoltStore{}
+
+	callCount := 0
+	err := store.withRetry(context.Background(), func() error {
+		callCount++
+		if callCount < 3 {
+			return errors.New("dolt commit: Error 1105 (HY000): Merge conflict detected, @autocommit transaction rolled back")
+		}
+		return nil
+	})
+
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if callCount != 3 {
+		t.Errorf("expected 3 calls (2 retries + success), got %d", callCount)
+	}
+}

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -364,6 +364,14 @@ func isRetryableError(err error) bool {
 	if strings.Contains(errStr, "no root value found") {
 		return true
 	}
+	// Dolt concurrent-write race: when two goroutines call DOLT_COMMIT on the
+	// same row, Dolt's 3-way merge rolls back with Error 1105 "Merge conflict
+	// detected, @autocommit transaction rolled back". Dolt cleans up completely
+	// (no data loss, no corruption) — retrying the full transaction is safe.
+	// Observed 2026-06-14 under concurrent bd writes (vp-5xx5).
+	if strings.Contains(errStr, "merge conflict detected") {
+		return true
+	}
 	return false
 }
 


### PR DESCRIPTION
## Summary

- Adds `"merge conflict detected"` to `isRetryableError()` in `store.go`, matching the existing `"no root value found"` pattern (also Error 1105, different message)
- Concurrent `DOLT_COMMIT` calls occasionally fail with `Error 1105 (HY000): Merge conflict detected, @autocommit transaction rolled back`; Dolt rolls back cleanly (no data loss) but the error was surfacing to callers instead of being retried
- Adds two new tests: `TestIsRetryableError/dolt_merge_conflict_1105_—_retryable` and `TestWithRetry_RetryOnMergeConflict`

Note: `gh issue create` was denied by the available token. A GitHub issue should be filed on gastownhall/beads to complete the `Fixes:` link before merge.

## Why retrying is safe

After Error 1105, Dolt cleanly rolls back the working set to the prior committed state. `runDoltTransaction()` acquires a fresh connection each attempt (starting from a clean Dolt head), so a retry re-runs the transaction on a clean working set.

## Test plan

- [x] `go test ./internal/storage/dolt/... -run TestIsRetryableError -v` — 20 passed (was 18 before T-001/T-002)
- [x] `go test ./internal/storage/dolt/... -run TestWithRetry_RetryOnMergeConflict -v` — 1 passed (T-003)
- [x] `go test -short ./internal/storage/dolt/...` — 359 passed, 0 new failures (5 pre-existing `TestApplyConfigDefaults_*` failures on `main` unchanged)