### PR TITLE
fix(is_blocked): cross-mode full recompute repair for stale is_blocked (bd-6dnrw.37)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   schema-reshaping merges fall back to a full recompute; conflicted pulls skip
   it until the operator resolves. (bd-6dnrw.3, PR 4107 follow-up)
 
+- **Stale `is_blocked` is now repairable — `bd recompute-blocked`.** The
+  post-pull recompute above is scoped to the merge diff and is skipped when a
+  re-pull merges nothing (`HEAD` unchanged), so a recompute that failed *after*
+  its merge committed — or a conflicted pull resolved by hand (which skips the
+  recompute) — could leave `is_blocked` stale with no way to repair it: rerunning
+  `bd dolt pull` merged nothing and recomputed nothing. The new
+  `bd recompute-blocked` command runs a full, unconditional recompute over every
+  issue and wisp and commits the result; it is idempotent and works in **both**
+  embedded and server mode (unlike `bd doctor`, which is server-mode only).
+  Server-mode `bd doctor` also gains a read-only **Blocked State** check that
+  reports stale rows and a `bd doctor --fix` that runs the same repair.
+  (bd-6dnrw.37)
+
 - **Deterministic history-table primary keys (cross-clone merge-safety).**
   Migration `0037` converted the legacy BIGINT primary keys of `events`,
   `comments`, `issue_snapshots` and `compaction_snapshots` by backfilling

--- a/cmd/bd/doctor.go
+++ b/cmd/bd/doctor.go
@@ -624,6 +624,16 @@ func runDiagnostics(path string) doctorResult {
 		result.OverallOK = false
 	}
 
+	// Check 10c: is_blocked consistency — derived flags a skipped post-pull
+	// recompute can leave stale (bd-6dnrw.37). `bd ready` trusts is_blocked, so
+	// staleness silently hides ready work; the full recompute repairs it.
+	// Warn-only (does not fail OverallOK): this is a new check shipping in a
+	// patch, and is_blocked is self-healing via 'bd doctor --fix' / the next
+	// pull's recompute — surface it as actionable without turning doctor red
+	// across the fleet if an unforeseen dependency shape trips the predicate.
+	blockedConsistencyCheck := convertWithCategory(doctor.CheckBlockedConsistencyWithStore(sharedStore), doctor.CategoryData)
+	result.Checks = append(result.Checks, blockedConsistencyCheck)
+
 	// Check 11: Claude integration
 	claudeCheck := convertWithCategory(doctor.CheckClaude(path), doctor.CategoryIntegration)
 	result.Checks = append(result.Checks, claudeCheck)

--- a/cmd/bd/doctor/blocked.go
+++ b/cmd/bd/doctor/blocked.go
@@ -1,0 +1,59 @@
+package doctor
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/steveyegge/beads/internal/storage/dolt"
+	"github.com/steveyegge/beads/internal/storage/issueops"
+)
+
+// BlockedConsistencyCheckName is the doctor check name; applyFixList dispatches
+// the repair (fix.RecomputeBlocked) on this exact string.
+const BlockedConsistencyCheckName = "Blocked State"
+
+// CheckBlockedConsistencyWithStore reports issues and wisps whose denormalized
+// is_blocked flag disagrees with the dependency graph (bd-6dnrw.37). is_blocked
+// is derived state maintained by the local write paths and by a post-pull
+// recompute scoped to the merge diff; a recompute that failed after its merge
+// committed, or a conflicted pull resolved by hand, can leave it stale, and a
+// re-pull that merges nothing will not refresh it. `bd ready` trusts the
+// column, so stale values silently hide ready work or surface blocked work. The
+// repair is 'bd doctor --fix', which runs a full recompute.
+func CheckBlockedConsistencyWithStore(ss *SharedStore) DoctorCheck {
+	store := ss.Store()
+	if store == nil {
+		return DoctorCheck{
+			Name:    BlockedConsistencyCheckName,
+			Status:  StatusOK,
+			Message: "No database yet",
+		}
+	}
+	return checkBlockedConsistencyWithStore(context.Background(), store)
+}
+
+func checkBlockedConsistencyWithStore(ctx context.Context, store *dolt.DoltStore) DoctorCheck {
+	stale, err := issueops.CountIsBlockedInconsistenciesInTx(ctx, store.UnderlyingDB())
+	if err != nil {
+		return DoctorCheck{
+			Name:    BlockedConsistencyCheckName,
+			Status:  StatusWarning,
+			Message: "Unable to check is_blocked consistency",
+			Detail:  err.Error(),
+		}
+	}
+	if stale == 0 {
+		return DoctorCheck{
+			Name:    BlockedConsistencyCheckName,
+			Status:  StatusOK,
+			Message: "is_blocked flags consistent with dependency graph",
+		}
+	}
+	return DoctorCheck{
+		Name:    BlockedConsistencyCheckName,
+		Status:  StatusWarning,
+		Message: fmt.Sprintf("%d issue/wisp row(s) have a stale is_blocked flag — 'bd ready' may hide ready work or show blocked work", stale),
+		Detail:  "is_blocked is derived from the dependency graph; a skipped post-pull recompute can leave it stale",
+		Fix:     "Run: bd doctor --fix (or 'bd recompute-blocked', which also works in embedded mode)",
+	}
+}

--- a/cmd/bd/doctor/fix/blocked.go
+++ b/cmd/bd/doctor/fix/blocked.go
@@ -1,0 +1,66 @@
+package fix
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	"github.com/steveyegge/beads/internal/storage/issueops"
+)
+
+// RecomputeBlocked repairs stale is_blocked flags (bd-6dnrw.37) by running a
+// full is_blocked recompute over every issue and wisp, then committing the
+// issues table so the corrected flags sync. is_blocked is derived state that a
+// skipped post-pull recompute can leave stale; a re-pull that merges nothing
+// will not refresh it, so this full pass is the repair.
+//
+// Mirrors DependencyKeys: opens its own writable store, repairs in a
+// transaction, and stages only the table it touched so an unrelated dirty
+// working set is not swept under this commit.
+func RecomputeBlocked(path string) error {
+	beadsDir, err := resolvedWorkspaceBeadsDir(path)
+	if err != nil {
+		return err
+	}
+
+	db, err := openDoltDB(beadsDir)
+	if err != nil {
+		fmt.Printf("  Blocked-state fix skipped (%v)\n", err)
+		return nil
+	}
+	defer db.Close()
+
+	return repairBlockedState(context.Background(), db)
+}
+
+// repairBlockedState recomputes is_blocked on an open connection. Split from
+// RecomputeBlocked so the repair is testable against an existing store handle.
+func repairBlockedState(ctx context.Context, db *sql.DB) error {
+	// Explicit transaction so writes persist when @@autocommit is OFF (e.g. a
+	// Dolt server started with --no-auto-commit).
+	tx, err := db.Begin()
+	if err != nil {
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	changed, err := issueops.RecomputeAllIsBlockedInTx(ctx, tx)
+	if err != nil {
+		_ = tx.Rollback()
+		return fmt.Errorf("failed to recompute is_blocked: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("failed to commit is_blocked repairs: %w", err)
+	}
+
+	if changed == 0 {
+		fmt.Println("  is_blocked already consistent — nothing to fix")
+		return nil
+	}
+
+	// Commit in Dolt, staging only issues — the synced table is_blocked lives
+	// on (wisps are dolt_ignore'd). Best effort: the repair is already applied.
+	_, _ = db.Exec("CALL DOLT_ADD(?)", "issues")
+	_, _ = db.Exec("CALL DOLT_COMMIT('-m', 'doctor: recompute is_blocked for all issues')")
+
+	fmt.Printf("  Recomputed is_blocked: %d row(s) corrected\n", changed)
+	return nil
+}

--- a/cmd/bd/doctor/fix/blocked.go
+++ b/cmd/bd/doctor/fix/blocked.go
@@ -42,6 +42,16 @@ func repairBlockedState(ctx context.Context, db *sql.DB) error {
 	if err != nil {
 		return fmt.Errorf("failed to begin transaction: %w", err)
 	}
+	// Refuse to derive and commit is_blocked from a dirty graph: like the store
+	// paths, the recompute reads the working set and stages only `issues`, so a
+	// dirty issues/dependencies tree would taint the repair commit (bd-6dnrw.37).
+	// In a `bd doctor --fix` run the dependency-graph fixes commit ahead of this
+	// one, so the tree is normally clean here; when it is not, surface it as an
+	// actionable error rather than committing tainted state.
+	if err := issueops.GuardBlockedRecomputeWorkingSet(ctx, tx); err != nil {
+		_ = tx.Rollback()
+		return err
+	}
 	changed, err := issueops.RecomputeAllIsBlockedInTx(ctx, tx)
 	if err != nil {
 		_ = tx.Rollback()
@@ -56,10 +66,18 @@ func repairBlockedState(ctx context.Context, db *sql.DB) error {
 		return nil
 	}
 
-	// Commit in Dolt, staging only issues — the synced table is_blocked lives
-	// on (wisps are dolt_ignore'd). Best effort: the repair is already applied.
-	_, _ = db.Exec("CALL DOLT_ADD(?)", "issues")
-	_, _ = db.Exec("CALL DOLT_COMMIT('-m', 'doctor: recompute is_blocked for all issues')")
+	// Persist the corrected flags as a Dolt commit, staging only issues — the
+	// synced table is_blocked lives on (wisps are dolt_ignore'd). This path keeps
+	// its own fresh-DB lifecycle rather than the shared store helper, but it must
+	// not report success on a failed commit: a swallowed DOLT_COMMIT error would
+	// leave the repair in the working set only, silently undone by the next pull.
+	// bd doctor is server-mode only, so the server supplies the commit identity.
+	if _, err := db.ExecContext(ctx, "CALL DOLT_ADD(?)", "issues"); err != nil {
+		return fmt.Errorf("failed to stage is_blocked repairs: %w", err)
+	}
+	if _, err := db.ExecContext(ctx, "CALL DOLT_COMMIT('-m', 'doctor: recompute is_blocked for all issues')"); err != nil && !issueops.IsNothingToCommitError(err) {
+		return fmt.Errorf("failed to commit is_blocked repairs to Dolt: %w", err)
+	}
 
 	fmt.Printf("  Recomputed is_blocked: %d row(s) corrected\n", changed)
 	return nil

--- a/cmd/bd/doctor_fix.go
+++ b/cmd/bd/doctor_fix.go
@@ -309,6 +309,11 @@ func applyFixList(path string, fixes []doctorCheck) {
 			err = fix.OrphanedDependencies(path, doctorVerbose)
 		case "Dependency Keys":
 			err = fix.DependencyKeys(path, doctorVerbose)
+		case "Blocked State":
+			// bd-6dnrw.37: full is_blocked recompute. Unlisted in the order
+			// slice (priority 1000) so it runs after the dependency-graph fixes
+			// above, recomputing from the corrected graph.
+			err = fix.RecomputeBlocked(path)
 		case "Child-Parent Dependencies":
 			// Requires explicit opt-in flag (destructive, may remove intentional deps)
 			if !doctorFixChildParent {

--- a/cmd/bd/doctor_fix.go
+++ b/cmd/bd/doctor_fix.go
@@ -200,8 +200,12 @@ func applyFixesInteractive(path string, issues []doctorCheck) {
 	}
 }
 
-// applyFixList applies a list of fixes and reports results
-func applyFixList(path string, fixes []doctorCheck) {
+// orderDoctorFixes sorts doctor fixes in place into a dependency-aware apply
+// order. Extracted from applyFixList so the ordering invariants are unit
+// testable without a live database — notably that "Blocked State" (the full
+// is_blocked recompute) runs after every graph-mutating fix, so it recomputes
+// from the corrected graph rather than a pre-repair one (bd-6dnrw.37).
+func orderDoctorFixes(fixes []doctorCheck) {
 	// Apply fixes in a dependency-aware order.
 	// Rough dependency chain:
 	// gitignore (fast, security-critical) → permissions/lock cleanup → config sanity → DB integrity/migrations.
@@ -220,18 +224,26 @@ func applyFixList(path string, fixes []doctorCheck) {
 		"Schema Compatibility",
 		"Project Identity",
 	}
-	priority := make(map[string]int, len(order))
+	priority := make(map[string]int, len(order)+1)
 	for i, name := range order {
 		priority[name] = i
 	}
+	// "Blocked State" recomputes is_blocked from the dependency graph, so it must
+	// run after every graph-mutating fix (Dependency Keys, Orphaned/Child-Parent
+	// Dependencies, Cross-Table Duplicates). Those are all unlisted and share the
+	// default priority below, and their relative order would otherwise be decided
+	// by check-append order alone. Pin Blocked State to an explicit terminal
+	// priority so it is provably last regardless of append order (bd-6dnrw.37).
+	const defaultPriority = 1000
+	priority["Blocked State"] = defaultPriority + 1
 	slices.SortStableFunc(fixes, func(a, b doctorCheck) int {
 		pa, oka := priority[a.Name]
 		if !oka {
-			pa = 1000
+			pa = defaultPriority
 		}
 		pb, okb := priority[b.Name]
 		if !okb {
-			pb = 1000
+			pb = defaultPriority
 		}
 		if pa < pb {
 			return -1
@@ -241,6 +253,11 @@ func applyFixList(path string, fixes []doctorCheck) {
 		}
 		return 0
 	})
+}
+
+// applyFixList applies a list of fixes and reports results
+func applyFixList(path string, fixes []doctorCheck) {
+	orderDoctorFixes(fixes)
 
 	fixedCount := 0
 	errorCount := 0
@@ -310,9 +327,9 @@ func applyFixList(path string, fixes []doctorCheck) {
 		case "Dependency Keys":
 			err = fix.DependencyKeys(path, doctorVerbose)
 		case "Blocked State":
-			// bd-6dnrw.37: full is_blocked recompute. Unlisted in the order
-			// slice (priority 1000) so it runs after the dependency-graph fixes
-			// above, recomputing from the corrected graph.
+			// bd-6dnrw.37: full is_blocked recompute. Pinned to a terminal
+			// priority in the sort above so it runs after every graph-mutating
+			// fix, recomputing from the corrected graph.
 			err = fix.RecomputeBlocked(path)
 		case "Child-Parent Dependencies":
 			// Requires explicit opt-in flag (destructive, may remove intentional deps)

--- a/cmd/bd/doctor_fix_order_test.go
+++ b/cmd/bd/doctor_fix_order_test.go
@@ -1,0 +1,81 @@
+package main
+
+import "testing"
+
+func fixNames(fixes []doctorCheck) []string {
+	out := make([]string, len(fixes))
+	for i, f := range fixes {
+		out[i] = f.Name
+	}
+	return out
+}
+
+// TestOrderDoctorFixes_BlockedStateRunsAfterGraphFixes guards bd-6dnrw.37: the
+// full is_blocked recompute ("Blocked State") must be applied after every
+// graph-mutating doctor fix so it recomputes from the corrected graph. The
+// regression it pins: removing a child→parent dependency under
+// `bd doctor --fix --fix-child-parent` unblocks the child, so a Blocked State
+// recompute ordered before that cleanup would leave is_blocked stale.
+func TestOrderDoctorFixes_BlockedStateRunsAfterGraphFixes(t *testing.T) {
+	// Append order that previously mis-ordered the recompute: Blocked State is
+	// appended before the dependency-graph fixes that can unblock issues.
+	fixes := []doctorCheck{
+		{Name: "Dependency Keys"},
+		{Name: "Blocked State"},
+		{Name: "Orphaned Dependencies"},
+		{Name: "Child-Parent Dependencies"},
+		{Name: "Cross-Table Duplicates"},
+	}
+	orderDoctorFixes(fixes)
+
+	pos := make(map[string]int, len(fixes))
+	for i, f := range fixes {
+		pos[f.Name] = i
+	}
+	for _, name := range []string{
+		"Dependency Keys",
+		"Orphaned Dependencies",
+		"Child-Parent Dependencies",
+		"Cross-Table Duplicates",
+	} {
+		if pos["Blocked State"] < pos[name] {
+			t.Errorf("Blocked State (pos %d) must run after %s (pos %d); order=%v",
+				pos["Blocked State"], name, pos[name], fixNames(fixes))
+		}
+	}
+	if got := fixes[len(fixes)-1].Name; got != "Blocked State" {
+		t.Errorf("Blocked State must be last among graph fixes, got last=%q order=%v",
+			got, fixNames(fixes))
+	}
+}
+
+// TestOrderDoctorFixes_BlockedStateStaysLastWhenGraphFixAppendedAfter pins the
+// robustness that terminal-priority ordering buys over relying on check-append
+// order: a graph-mutating fix appended *after* Blocked State (the original
+// latent bug) must still run before the recompute.
+func TestOrderDoctorFixes_BlockedStateStaysLastWhenGraphFixAppendedAfter(t *testing.T) {
+	fixes := []doctorCheck{
+		{Name: "Blocked State"},
+		{Name: "Future Graph Fix"}, // unlisted, shares the default priority
+		{Name: "Child-Parent Dependencies"},
+	}
+	orderDoctorFixes(fixes)
+	if got := fixes[len(fixes)-1].Name; got != "Blocked State" {
+		t.Errorf("Blocked State must remain last even when a graph fix is appended after it; got last=%q order=%v",
+			got, fixNames(fixes))
+	}
+}
+
+// TestOrderDoctorFixes_EarlyFixesStillSortFirst is a guardrail that pinning
+// Blocked State terminal did not disturb the explicitly-ordered early fixes.
+func TestOrderDoctorFixes_EarlyFixesStillSortFirst(t *testing.T) {
+	fixes := []doctorCheck{
+		{Name: "Blocked State"},
+		{Name: "Permissions"},
+		{Name: "Gitignore"},
+	}
+	orderDoctorFixes(fixes)
+	if fixes[0].Name != "Gitignore" || fixes[1].Name != "Permissions" {
+		t.Errorf("early ordered fixes must sort ahead of Blocked State; order=%v", fixNames(fixes))
+	}
+}

--- a/cmd/bd/recompute_blocked.go
+++ b/cmd/bd/recompute_blocked.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/steveyegge/beads/internal/storage"
+)
+
+var recomputeBlockedCmd = &cobra.Command{
+	Use:     "recompute-blocked",
+	GroupID: "maint",
+	Short:   "Recompute is_blocked for all issues (repairs stale flags after a pull)",
+	Long: `Recompute the denormalized is_blocked flag for every issue and wisp.
+
+is_blocked is derived from the dependency graph and maintained automatically by
+local writes and by a post-pull recompute scoped to what the merge changed. If
+that scoped recompute is skipped — a recompute that failed after its merge
+committed, or a conflicted pull resolved by hand — the flag can go stale, and a
+later pull that merges nothing will not refresh it (bd-6dnrw.37). 'bd ready'
+trusts the flag, so stale values silently hide ready work or surface blocked
+work.
+
+This command runs the full recompute unconditionally and commits the result.
+It is idempotent: on a consistent database it changes nothing. Works in both
+embedded and server mode (unlike 'bd doctor', which is server-mode only).
+
+Examples:
+  bd recompute-blocked          # Repair stale is_blocked flags
+  bd recompute-blocked --json   # Machine-parseable {"rows_corrected": N}`,
+	Run: func(_ *cobra.Command, _ []string) {
+		CheckReadonly("recompute-blocked")
+		ctx := rootCtx
+
+		recomputer, ok := storage.UnwrapStore(store).(storage.BlockedRecomputer)
+		if !ok {
+			FatalError("storage backend does not support is_blocked recompute")
+		}
+		changed, err := recomputer.RecomputeAllBlocked(ctx)
+		if err != nil {
+			FatalError("recompute is_blocked: %v", err)
+		}
+
+		if jsonOutput {
+			outputJSON(map[string]interface{}{"rows_corrected": changed})
+			return
+		}
+		if changed == 0 {
+			fmt.Println("is_blocked already consistent — nothing to recompute.")
+			return
+		}
+		fmt.Printf("Recomputed is_blocked: %d row(s) corrected.\n", changed)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(recomputeBlockedCmd)
+}

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -180,6 +180,7 @@ Reference for bd Latest. Generated from `bd help --all`.
 - [bd preflight](#bd-preflight) — Show PR readiness checklist
 - [bd prune](#bd-prune) — Delete old closed beads to reclaim space and shrink exports
 - [bd purge](#bd-purge) — Delete closed ephemeral beads to reclaim space
+- [bd recompute-blocked](#bd-recompute-blocked) — Recompute is_blocked for all issues (repairs stale flags after a pull)
 - [bd rename-prefix](#bd-rename-prefix) — Rename the issue prefix for all issues in the database
 - [bd rules](#bd-rules) — Audit and compact Claude rules
   - [bd rules audit](#bd-rules-audit) — Scan rules for contradictions and merge opportunities
@@ -4265,6 +4266,30 @@ bd purge [flags]
   -f, --force               Actually purge (without this, shows preview)
       --older-than string   Only purge beads closed more than N ago (e.g., 7d, 2w, 30)
       --pattern string      Only purge beads matching ID glob pattern (e.g., *-wisp-*)
+```
+
+### bd recompute-blocked
+
+Recompute the denormalized is_blocked flag for every issue and wisp.
+
+is_blocked is derived from the dependency graph and maintained automatically by
+local writes and by a post-pull recompute scoped to what the merge changed. If
+that scoped recompute is skipped — a recompute that failed after its merge
+committed, or a conflicted pull resolved by hand — the flag can go stale, and a
+later pull that merges nothing will not refresh it (bd-6dnrw.37). 'bd ready'
+trusts the flag, so stale values silently hide ready work or surface blocked
+work.
+
+This command runs the full recompute unconditionally and commits the result.
+It is idempotent: on a consistent database it changes nothing. Works in both
+embedded and server mode (unlike 'bd doctor', which is server-mode only).
+
+Examples:
+  bd recompute-blocked          # Repair stale is_blocked flags
+  bd recompute-blocked --json   # Machine-parseable &#123;"rows_corrected": N&#125;
+
+```
+bd recompute-blocked
 ```
 
 ### bd rename-prefix

--- a/internal/storage/dolt/blocked_consistency_test.go
+++ b/internal/storage/dolt/blocked_consistency_test.go
@@ -1,0 +1,179 @@
+package dolt
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/storage/issueops"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// countInconsistencies wraps the read-only detection used by the bd doctor
+// Blocked State check.
+func countInconsistencies(ctx context.Context, t *testing.T, db *sql.DB) int64 {
+	t.Helper()
+	n, err := issueops.CountIsBlockedInconsistenciesInTx(ctx, db)
+	if err != nil {
+		t.Fatalf("CountIsBlockedInconsistenciesInTx: %v", err)
+	}
+	return n
+}
+
+// recomputeAll wraps the full repair used by 'bd doctor --fix' and returns the
+// number of rows it corrected.
+func recomputeAll(ctx context.Context, t *testing.T, db *sql.DB) int64 {
+	t.Helper()
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatalf("begin recompute-all tx: %v", err)
+	}
+	changed, err := issueops.RecomputeAllIsBlockedInTx(ctx, tx)
+	if err != nil {
+		_ = tx.Rollback()
+		t.Fatalf("RecomputeAllIsBlockedInTx: %v", err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("commit recompute-all tx: %v", err)
+	}
+	return changed
+}
+
+// TestRecomputeAllIsBlocked_RepairsStaleClearedFlag is the bd-6dnrw.37 repair
+// path: a row that SHOULD be blocked but whose is_blocked was left at 0 (the
+// shape a skipped post-pull recompute leaves behind). Detection must see it,
+// the full recompute must fix it, and detection and repair must then agree the
+// database is consistent — the lockstep that keeps the COUNT predicate from
+// drifting from the recompute SQL.
+func TestRecomputeAllIsBlocked_RepairsStaleClearedFlag(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	// Correct graph via the normal write path: bm-w blocked on open bm-x.
+	seedBlockedPair(ctx, t, store, true)
+	if !isBlocked(ctx, t, store.db, "bm-w") {
+		t.Fatal("precondition: bm-w should be blocked by open bm-x")
+	}
+	// A correctly-maintained graph has zero inconsistencies.
+	if n := countInconsistencies(ctx, t, store.db); n != 0 {
+		t.Fatalf("consistent graph: want 0 inconsistencies, got %d", n)
+	}
+
+	// Corrupt: clear bm-w's flag directly, with no recompute — exactly what a
+	// merge that bypassed the recompute hook leaves behind.
+	if _, err := store.db.ExecContext(ctx, "UPDATE issues SET is_blocked = 0 WHERE id = 'bm-w'"); err != nil {
+		t.Fatalf("corrupt is_blocked: %v", err)
+	}
+	if n := countInconsistencies(ctx, t, store.db); n != 1 {
+		t.Fatalf("after corruption: want 1 inconsistency, got %d", n)
+	}
+
+	// Repair via the full recompute (the always-available path that does not
+	// need a pull to advance HEAD).
+	if changed := recomputeAll(ctx, t, store.db); changed != 1 {
+		t.Fatalf("repair: want 1 row corrected, got %d", changed)
+	}
+	if !isBlocked(ctx, t, store.db, "bm-w") {
+		t.Fatal("after repair: bm-w must read blocked again")
+	}
+	// Detection and repair now agree, and the repair is idempotent.
+	if n := countInconsistencies(ctx, t, store.db); n != 0 {
+		t.Fatalf("after repair: want 0 inconsistencies, got %d", n)
+	}
+	if again := recomputeAll(ctx, t, store.db); again != 0 {
+		t.Fatalf("repair must be idempotent: want 0 on second run, got %d", again)
+	}
+}
+
+// TestRecomputeAllIsBlocked_ClearsStuckBlockedFlag is the mirror case: a row
+// left is_blocked = 1 after its only blocker was closed remotely (a merge that
+// bypassed the recompute hook). `bd ready` would keep hiding it; the full
+// recompute must clear the flag.
+func TestRecomputeAllIsBlocked_ClearsStuckBlockedFlag(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	seedBlockedPair(ctx, t, store, true)
+	if !isBlocked(ctx, t, store.db, "bm-w") {
+		t.Fatal("precondition: bm-w should be blocked by open bm-x")
+	}
+
+	// "Merge": the remote closed the blocker; no local recompute ran, so bm-w
+	// is stuck is_blocked = 1 with a closed blocker.
+	if _, err := store.db.ExecContext(ctx, "UPDATE issues SET status = 'closed' WHERE id = 'bm-x'"); err != nil {
+		t.Fatalf("simulate merged close: %v", err)
+	}
+	if !isBlocked(ctx, t, store.db, "bm-w") {
+		t.Fatal("setup: bm-w must still read blocked before the recompute (the stale flag is the bug)")
+	}
+	if n := countInconsistencies(ctx, t, store.db); n != 1 {
+		t.Fatalf("after merged close: want 1 inconsistency, got %d", n)
+	}
+
+	if changed := recomputeAll(ctx, t, store.db); changed != 1 {
+		t.Fatalf("repair: want 1 row corrected, got %d", changed)
+	}
+	if isBlocked(ctx, t, store.db, "bm-w") {
+		t.Fatal("after repair: bm-w must be unblocked (its only blocker is closed)")
+	}
+	if n := countInconsistencies(ctx, t, store.db); n != 0 {
+		t.Fatalf("after repair: want 0 inconsistencies, got %d", n)
+	}
+}
+
+// TestRecomputeAllIsBlocked_CascadesThroughParentChild verifies the fixpoint:
+// is_blocked propagates from a blocked parent to its child across passes. The
+// single-pass detection COUNT is a documented lower bound here — it sees only
+// the parent on the first pass — but the recompute corrects the whole chain and
+// detection reaches 0 once it converges.
+func TestRecomputeAllIsBlocked_CascadesThroughParentChild(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	// bm-w blocked on open bm-x; bm-y is a child of bm-w, so bm-y inherits
+	// blocked. All maintained by the normal write path.
+	seedBlockedPair(ctx, t, store, true)
+	child := &types.Issue{ID: "bm-y", Title: "bm-y", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask}
+	if err := store.CreateIssue(ctx, child, "tester"); err != nil {
+		t.Fatalf("create child: %v", err)
+	}
+	if err := store.AddDependency(ctx, &types.Dependency{IssueID: "bm-y", DependsOnID: "bm-w", Type: types.DepParentChild}, "tester"); err != nil {
+		t.Fatalf("add parent-child: %v", err)
+	}
+	if _, err := store.db.ExecContext(ctx, "CALL DOLT_COMMIT('-Am', 'seed parent-child chain')"); err != nil && !isDoltNothingToCommit(err) {
+		t.Fatalf("commit chain: %v", err)
+	}
+	if !isBlocked(ctx, t, store.db, "bm-y") {
+		t.Fatal("precondition: child bm-y should inherit blocked from parent bm-w")
+	}
+	if n := countInconsistencies(ctx, t, store.db); n != 0 {
+		t.Fatalf("consistent chain: want 0 inconsistencies, got %d", n)
+	}
+
+	// Corrupt both the parent and the child to is_blocked = 0.
+	if _, err := store.db.ExecContext(ctx, "UPDATE issues SET is_blocked = 0 WHERE id IN ('bm-w', 'bm-y')"); err != nil {
+		t.Fatalf("corrupt chain: %v", err)
+	}
+	// Single-pass detection sees only the parent (the child's parent-child
+	// reason depends on the parent's still-corrupted flag) — a lower bound.
+	if n := countInconsistencies(ctx, t, store.db); n != 1 {
+		t.Fatalf("after corruption: want 1 (single-pass lower bound), got %d", n)
+	}
+
+	// The fixpoint corrects the whole chain across passes.
+	if changed := recomputeAll(ctx, t, store.db); changed != 2 {
+		t.Fatalf("repair: want 2 rows corrected across passes, got %d", changed)
+	}
+	if !isBlocked(ctx, t, store.db, "bm-w") || !isBlocked(ctx, t, store.db, "bm-y") {
+		t.Fatal("after repair: both bm-w and bm-y must read blocked")
+	}
+	if n := countInconsistencies(ctx, t, store.db); n != 0 {
+		t.Fatalf("after repair: want 0 inconsistencies, got %d", n)
+	}
+}

--- a/internal/storage/dolt/blocked_recompute_guard_test.go
+++ b/internal/storage/dolt/blocked_recompute_guard_test.go
@@ -1,0 +1,174 @@
+package dolt
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/storage/issueops"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// workingSetGraphDirty returns the committable graph tables (issues,
+// dependencies) the guard reports as dirty.
+func workingSetGraphDirty(ctx context.Context, t *testing.T, store *DoltStore) []string {
+	t.Helper()
+	rows, err := store.db.QueryContext(ctx,
+		"SELECT DISTINCT table_name FROM dolt_status WHERE table_name IN ('issues','dependencies') ORDER BY table_name")
+	if err != nil {
+		t.Fatalf("query dolt_status: %v", err)
+	}
+	defer rows.Close()
+	var dirty []string
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			t.Fatalf("scan dolt_status: %v", err)
+		}
+		dirty = append(dirty, name)
+	}
+	return dirty
+}
+
+// TestRecomputeAllBlocked_RefusesDirtyIssues is the bd-6dnrw.37 release-safety
+// guard: a full recompute stages the whole `issues` table and derives flags
+// from the current graph, so it must refuse to run while `issues` has unrelated
+// uncommitted edits rather than sweep them into the repair commit.
+func TestRecomputeAllBlocked_RefusesDirtyIssues(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	seedBlockedPair(ctx, t, store, true) // clean, consistent committed tree
+
+	// Unrelated dirty edit the operator has not committed.
+	if _, err := store.db.ExecContext(ctx, "UPDATE issues SET title = 'uncommitted edit' WHERE id = 'bm-x'"); err != nil {
+		t.Fatalf("dirty issues: %v", err)
+	}
+
+	changed, err := store.RecomputeAllBlocked(ctx)
+	if !errors.Is(err, issueops.ErrBlockedRecomputeDirtyGraph) {
+		t.Fatalf("want ErrBlockedRecomputeDirtyGraph, got changed=%d err=%v", changed, err)
+	}
+	if changed != 0 {
+		t.Fatalf("refused recompute must report 0 rows, got %d", changed)
+	}
+	// The edit must remain uncommitted in the working set, not swept into a commit.
+	if dirty := workingSetGraphDirty(ctx, t, store); len(dirty) != 1 || dirty[0] != "issues" {
+		t.Fatalf("issues edit must still be dirty (unswept), got dirty=%v", dirty)
+	}
+}
+
+// TestRecomputeAllBlocked_RefusesDirtyDependencies guards the other half of the
+// finding: is_blocked is derived from `dependencies`, so committing flags while
+// dependency edits are uncommitted would publish state derived from a graph that
+// is not part of the same commit.
+func TestRecomputeAllBlocked_RefusesDirtyDependencies(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	seedBlockedPair(ctx, t, store, true)
+
+	// Uncommitted dependency-graph edit.
+	if _, err := store.db.ExecContext(ctx, "DELETE FROM dependencies WHERE issue_id = 'bm-w'"); err != nil {
+		t.Fatalf("dirty dependencies: %v", err)
+	}
+
+	changed, err := store.RecomputeAllBlocked(ctx)
+	if !errors.Is(err, issueops.ErrBlockedRecomputeDirtyGraph) {
+		t.Fatalf("want ErrBlockedRecomputeDirtyGraph, got changed=%d err=%v", changed, err)
+	}
+	if changed != 0 {
+		t.Fatalf("refused recompute must report 0 rows, got %d", changed)
+	}
+}
+
+// TestRecomputeAllBlocked_AllowsDirtyWisps pins the deliberate exclusion of the
+// dolt-ignored wisp tables from the guard. Dolt reports every ignored table as
+// perpetually modified, so guarding on wisps would refuse the recompute in any
+// workspace that uses them. A stale committed flag must still be repaired even
+// while the wisp tables are dirty.
+func TestRecomputeAllBlocked_AllowsDirtyWisps(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	seedBlockedPair(ctx, t, store, true)
+
+	// A throwaway wisp leaves the dolt-ignored wisp tables perpetually dirty.
+	scratch := &types.Issue{ID: "bm-wisp", Title: "scratch", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask}
+	if err := store.CreateIssue(ctx, scratch, "tester"); err != nil {
+		t.Fatalf("create scratch issue: %v", err)
+	}
+	if err := store.UpdateIssue(ctx, "bm-wisp", map[string]interface{}{"no_history": true}, "tester"); err != nil {
+		t.Fatalf("demote scratch to wisp: %v", err)
+	}
+
+	// Commit a stale is_blocked (the shape a skipped post-pull recompute leaves),
+	// so the only remaining working-set dirt is the ignored wisp tables.
+	if _, err := store.db.ExecContext(ctx, "UPDATE issues SET is_blocked = 0 WHERE id = 'bm-w'"); err != nil {
+		t.Fatalf("corrupt is_blocked: %v", err)
+	}
+	if _, err := store.db.ExecContext(ctx, "CALL DOLT_COMMIT('-Am', 'commit stale flag + scratch demotion')"); err != nil && !isDoltNothingToCommit(err) {
+		t.Fatalf("commit stale flag: %v", err)
+	}
+	if dirty := workingSetGraphDirty(ctx, t, store); len(dirty) != 0 {
+		t.Fatalf("precondition: committable graph must be clean, got dirty=%v", dirty)
+	}
+
+	// The recompute must run (not refuse) despite perpetually-dirty wisps.
+	changed, err := store.RecomputeAllBlocked(ctx)
+	if err != nil {
+		t.Fatalf("recompute must run with only wisps dirty: %v", err)
+	}
+	if changed != 1 {
+		t.Fatalf("want 1 row repaired, got %d", changed)
+	}
+	if !isBlocked(ctx, t, store.db, "bm-w") {
+		t.Fatal("bm-w must read blocked again after repair")
+	}
+}
+
+// TestRecomputeAllBlocked_RepairsAndCommitsWhenClean covers the changed>0 commit
+// branch of the store method: on a clean tree a stale flag is repaired and the
+// correction is committed (the working set returns to clean), and the repair is
+// idempotent.
+func TestRecomputeAllBlocked_RepairsAndCommitsWhenClean(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	seedBlockedPair(ctx, t, store, true)
+
+	// Commit a stale flag so the tree is clean going into the recompute.
+	if _, err := store.db.ExecContext(ctx, "UPDATE issues SET is_blocked = 0 WHERE id = 'bm-w'"); err != nil {
+		t.Fatalf("corrupt is_blocked: %v", err)
+	}
+	if _, err := store.db.ExecContext(ctx, "CALL DOLT_COMMIT('-Am', 'commit stale flag')"); err != nil && !isDoltNothingToCommit(err) {
+		t.Fatalf("commit stale flag: %v", err)
+	}
+
+	changed, err := store.RecomputeAllBlocked(ctx)
+	if err != nil {
+		t.Fatalf("recompute on clean tree: %v", err)
+	}
+	if changed != 1 {
+		t.Fatalf("want 1 row repaired, got %d", changed)
+	}
+	if !isBlocked(ctx, t, store.db, "bm-w") {
+		t.Fatal("bm-w must read blocked again after repair")
+	}
+	// The repair was committed: the committable graph is clean again.
+	if dirty := workingSetGraphDirty(ctx, t, store); len(dirty) != 0 {
+		t.Fatalf("repair must be committed, leaving a clean tree, got dirty=%v", dirty)
+	}
+	// Idempotent: a second pass corrects nothing and stays clean.
+	if again, err := store.RecomputeAllBlocked(ctx); err != nil || again != 0 {
+		t.Fatalf("recompute must be idempotent: got changed=%d err=%v", again, err)
+	}
+}

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -2731,6 +2731,15 @@ func (s *DoltStore) RecomputeAllBlocked(ctx context.Context) (int, error) {
 	if err != nil {
 		return 0, fmt.Errorf("begin is_blocked recompute: %w", err)
 	}
+	// Refuse to derive and commit is_blocked from a dirty graph: the recompute
+	// reads the current working set and stages only `issues`, so pre-existing
+	// dirty issue/dependency edits would otherwise be swept into — or silently
+	// inform — the repair commit (bd-6dnrw.37). Checked inside this tx so it
+	// sees the same working set the recompute will read.
+	if err := issueops.GuardBlockedRecomputeWorkingSet(ctx, tx); err != nil {
+		_ = tx.Rollback()
+		return 0, err
+	}
 	changed, err := issueops.RecomputeAllIsBlockedInTx(ctx, tx)
 	if err != nil {
 		_ = tx.Rollback()

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -2719,6 +2719,36 @@ func (s *DoltStore) recomputeBlockedAfterPull(ctx context.Context, fromCommit st
 	return nil
 }
 
+// RecomputeAllBlocked recomputes is_blocked for every issue and wisp in one full
+// pass and returns the number of rows it corrected. It is the mode-independent
+// repair behind 'bd recompute-blocked' and 'bd doctor --fix' (bd-6dnrw.37): the
+// scoped post-pull recompute is skipped when a re-pull merges nothing, so a
+// recompute that failed after its merge committed — or a conflicted pull the
+// operator resolved by hand — leaves is_blocked stale until this full pass runs.
+// Idempotent: a consistent database corrects nothing.
+func (s *DoltStore) RecomputeAllBlocked(ctx context.Context) (int, error) {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return 0, fmt.Errorf("begin is_blocked recompute: %w", err)
+	}
+	changed, err := issueops.RecomputeAllIsBlockedInTx(ctx, tx)
+	if err != nil {
+		_ = tx.Rollback()
+		return 0, err
+	}
+	if err := tx.Commit(); err != nil {
+		return 0, fmt.Errorf("commit is_blocked recompute: %w", err)
+	}
+	if changed > 0 {
+		// Stage only issues — the synced table is_blocked lives on (wisps are
+		// dolt_ignore'd) — so an unrelated dirty working set is not swept in.
+		if err := s.doltAddAndCommit(ctx, []string{"issues"}, "bd: recompute is_blocked (full)"); err != nil {
+			return int(changed), err
+		}
+	}
+	return int(changed), nil
+}
+
 // recomputeBlockedTx runs the post-merge is_blocked recompute in its own
 // transaction.
 func (s *DoltStore) recomputeBlockedTx(ctx context.Context, fromCommit string) error {

--- a/internal/storage/embeddeddolt/blocked_recompute_test.go
+++ b/internal/storage/embeddeddolt/blocked_recompute_test.go
@@ -34,6 +34,14 @@ func TestEmbeddedRecomputeAllBlockedWiring(t *testing.T) {
 	if err := te.store.AddDependency(ctx, &types.Dependency{IssueID: "rcb-w", DependsOnID: "rcb-x", Type: types.DepBlocks}, "tester"); err != nil {
 		t.Fatalf("add dependency: %v", err)
 	}
+	// Embedded writes land in the working set; production flushes them to Dolt
+	// history on session shutdown, so `bd recompute-blocked` (a fresh process)
+	// sees a clean tree. Commit here to match that precondition — the recompute's
+	// dirty-graph guard refuses an uncommitted issues/dependencies tree
+	// (bd-6dnrw.37).
+	if err := te.store.Commit(ctx, "seed consistent graph"); err != nil {
+		t.Fatalf("commit seed: %v", err)
+	}
 
 	rc, ok := storage.UnwrapStore(te.store).(storage.BlockedRecomputer)
 	if !ok {

--- a/internal/storage/embeddeddolt/blocked_recompute_test.go
+++ b/internal/storage/embeddeddolt/blocked_recompute_test.go
@@ -1,0 +1,55 @@
+//go:build cgo
+
+package embeddeddolt_test
+
+import (
+	"testing"
+
+	"github.com/steveyegge/beads/internal/storage"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// TestEmbeddedRecomputeAllBlockedWiring confirms the embedded store satisfies
+// the cross-mode BlockedRecomputer capability (bd-6dnrw.37) and that a full
+// recompute over a correctly-maintained graph is a clean no-op — the path that
+// runs whenever 'bd recompute-blocked' is invoked in embedded mode.
+//
+// The is_blocked SQL semantics (stale-flag detection, repair, cascade,
+// idempotence) are exercised against a real engine by the dolt package's
+// RecomputeAllIsBlocked lockstep tests, which share the exact issueops core;
+// the embedded commit path (StageAndCommit of "issues") is the same one the
+// already-tested recomputeBlockedAfterPull uses.
+func TestEmbeddedRecomputeAllBlockedWiring(t *testing.T) {
+	skipUnlessEmbeddedDolt(t)
+	te := newTestEnv(t, "rcb")
+	ctx := t.Context()
+
+	// Correct graph via the normal write path: rcb-w blocked on open rcb-x.
+	for _, id := range []string{"rcb-w", "rcb-x"} {
+		iss := &types.Issue{ID: id, Title: id, Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask}
+		if err := te.store.CreateIssue(ctx, iss, "tester"); err != nil {
+			t.Fatalf("create %s: %v", id, err)
+		}
+	}
+	if err := te.store.AddDependency(ctx, &types.Dependency{IssueID: "rcb-w", DependsOnID: "rcb-x", Type: types.DepBlocks}, "tester"); err != nil {
+		t.Fatalf("add dependency: %v", err)
+	}
+
+	rc, ok := storage.UnwrapStore(te.store).(storage.BlockedRecomputer)
+	if !ok {
+		t.Fatal("embedded store must implement storage.BlockedRecomputer")
+	}
+
+	// A correctly-maintained graph needs no corrections, and the recompute must
+	// be idempotent.
+	changed, err := rc.RecomputeAllBlocked(ctx)
+	if err != nil {
+		t.Fatalf("RecomputeAllBlocked: %v", err)
+	}
+	if changed != 0 {
+		t.Fatalf("consistent graph: want 0 rows corrected, got %d", changed)
+	}
+	if again, err := rc.RecomputeAllBlocked(ctx); err != nil || again != 0 {
+		t.Fatalf("recompute must stay a no-op: got changed=%d err=%v", again, err)
+	}
+}

--- a/internal/storage/embeddeddolt/version_control.go
+++ b/internal/storage/embeddeddolt/version_control.go
@@ -254,6 +254,31 @@ func (s *EmbeddedDoltStore) RecomputeBlockedAfterMerge(ctx context.Context, from
 	return s.recomputeBlockedAfterPull(ctx, fromCommit)
 }
 
+// RecomputeAllBlocked recomputes is_blocked for every issue and wisp in one full
+// pass and returns the number of rows it corrected. This is the embedded path
+// of the mode-independent repair (bd-6dnrw.37); see DoltStore.RecomputeAllBlocked.
+func (s *EmbeddedDoltStore) RecomputeAllBlocked(ctx context.Context) (int, error) {
+	var changed int64
+	if err := s.withConn(ctx, true, func(tx *sql.Tx) error {
+		var e error
+		changed, e = issueops.RecomputeAllIsBlockedInTx(ctx, tx)
+		return e
+	}); err != nil {
+		return 0, err
+	}
+	if changed > 0 {
+		// Stage only issues (wisps are dolt_ignore'd), matching the post-pull
+		// recompute, so an unrelated dirty working set is not swept in.
+		if err := s.withMutatingDBConn(ctx, func(db versioncontrolops.DBConn) error {
+			return versioncontrolops.StageAndCommit(ctx, db,
+				map[string]bool{"issues": true}, "bd: recompute is_blocked (full)", commitAuthor)
+		}); err != nil {
+			return int(changed), err
+		}
+	}
+	return int(changed), nil
+}
+
 func (s *EmbeddedDoltStore) GetConflicts(ctx context.Context) ([]storage.Conflict, error) {
 	var conflicts []storage.Conflict
 	err := s.withDBConn(ctx, func(db versioncontrolops.DBConn) error {

--- a/internal/storage/embeddeddolt/version_control.go
+++ b/internal/storage/embeddeddolt/version_control.go
@@ -260,6 +260,12 @@ func (s *EmbeddedDoltStore) RecomputeBlockedAfterMerge(ctx context.Context, from
 func (s *EmbeddedDoltStore) RecomputeAllBlocked(ctx context.Context) (int, error) {
 	var changed int64
 	if err := s.withConn(ctx, true, func(tx *sql.Tx) error {
+		// Refuse to derive and commit is_blocked from a dirty graph (see
+		// DoltStore.RecomputeAllBlocked); checked inside the recompute tx so it
+		// sees the same working set the recompute will read (bd-6dnrw.37).
+		if e := issueops.GuardBlockedRecomputeWorkingSet(ctx, tx); e != nil {
+			return e
+		}
 		var e error
 		changed, e = issueops.RecomputeAllIsBlockedInTx(ctx, tx)
 		return e

--- a/internal/storage/issueops/blocked_consistency.go
+++ b/internal/storage/issueops/blocked_consistency.go
@@ -1,0 +1,183 @@
+package issueops
+
+import (
+	"context"
+	"fmt"
+)
+
+// RecomputeAllIsBlockedInTx recomputes the denormalized is_blocked column for
+// every issue and wisp in one batched mark/unmark fixpoint and returns the
+// number of rows it corrected.
+//
+// Unlike RecomputeIsBlockedAfterMergeInTx, which is scoped to a pull's diff and
+// is skipped when a re-pull merges nothing (head == fromCommit), this is the
+// always-available full repair: it does not depend on a merge advancing HEAD,
+// so it can recover an is_blocked column left stale by a post-merge recompute
+// that failed after its merge committed, or by a conflicted pull the operator
+// resolved by hand (bd-6dnrw.37). It is idempotent — on a consistent database
+// it changes nothing and returns 0.
+func RecomputeAllIsBlockedInTx(ctx context.Context, tx DBTX) (int64, error) {
+	issueIDs, err := allIDs(ctx, tx, "issues")
+	if err != nil {
+		return 0, fmt.Errorf("recompute all is_blocked: list issues: %w", err)
+	}
+	wispIDs, err := allIDs(ctx, tx, "wisps")
+	if err != nil {
+		if isTableNotExistError(err) {
+			wispIDs = nil
+		} else {
+			return 0, fmt.Errorf("recompute all is_blocked: list wisps: %w", err)
+		}
+	}
+	return recomputeIsBlockedCounting(ctx, tx, issueIDs, wispIDs)
+}
+
+// recomputeIsBlockedCounting is RecomputeIsBlockedInTx with a corrected-row
+// count: it sums the rows flipped across every fixpoint pass. A parent flip in
+// one pass can cascade to its children in the next, and each correction counts.
+func recomputeIsBlockedCounting(ctx context.Context, tx DBTX, issueIDs, wispIDs []string) (int64, error) {
+	if len(issueIDs) == 0 && len(wispIDs) == 0 {
+		return 0, nil
+	}
+	var total int64
+	for {
+		var changed int64
+		n, err := recomputeIsBlockedPassForIssuesInTx(ctx, tx, issueIDs)
+		if err != nil {
+			return total, err
+		}
+		changed += n
+		n, err = recomputeIsBlockedPassForWispsInTx(ctx, tx, wispIDs)
+		if err != nil {
+			return total, err
+		}
+		changed += n
+		total += changed
+		if changed == 0 {
+			return total, nil
+		}
+	}
+}
+
+// CountIsBlockedInconsistenciesInTx reports how many issue and wisp rows carry a
+// stale is_blocked flag — rows a full recompute would flip. It is the read-only
+// detection behind the bd doctor "Blocked State" check (bd-6dnrw.37); the
+// repair is RecomputeAllIsBlockedInTx.
+//
+// The two share no SQL but are pinned together by the blocked-consistency
+// lockstep test: a converged database counts 0, and any row this counts is one
+// a recompute pass changes. The count is a single-pass lower bound — a
+// corrupted parent's children are only counted on the pass after the parent is
+// fixed — which is exactly what a "needs repair?" check wants: nonzero means run
+// --fix, zero means consistent.
+func CountIsBlockedInconsistenciesInTx(ctx context.Context, tx DBTX) (int64, error) {
+	var total int64
+
+	n, err := countRows(ctx, tx, countStaleIsBlockedSQL("issues", "i", "dependencies"))
+	if err != nil {
+		return 0, fmt.Errorf("count stale is_blocked issues: %w", err)
+	}
+	total += n
+
+	n, err = countRows(ctx, tx, countStaleIsBlockedSQL("wisps", "w", "wisp_dependencies"))
+	if err != nil {
+		if isTableNotExistError(err) {
+			return total, nil
+		}
+		return 0, fmt.Errorf("count stale is_blocked wisps: %w", err)
+	}
+	total += n
+
+	return total, nil
+}
+
+// countStaleIsBlockedSQL builds a COUNT(*) of rows whose stored is_blocked
+// disagrees with the dependency graph for one table (issues or wisps). The two
+// OR branches mirror the mark and unmark UPDATE templates in blocked_state.go
+// exactly:
+//
+//   - mark-eligible:   is_blocked = 0 on an open row that should be blocked.
+//   - unmark-eligible: is_blocked = 1 on a row that should not be blocked
+//     (closed/pinned, or no remaining reason — De Morgan of NOT EXISTS ... is
+//     NOT (the shouldBeBlocked disjunction)).
+//
+// is_blocked is 0 or 1, so the branches are mutually exclusive and the count is
+// their sum. table/alias/depTable are hardcoded constants supplied by the only
+// two callers.
+//
+//nolint:gosec // G201: table, alias, and depTable are constant; only the constant gate SQL is interpolated.
+func countStaleIsBlockedSQL(table, alias, depTable string) string {
+	disjunction := shouldBeBlockedDisjunction(alias, depTable)
+	return fmt.Sprintf(`
+		SELECT COUNT(*) FROM %[1]s %[2]s
+		WHERE
+		  ( %[2]s.is_blocked = 0
+		    AND %[2]s.status <> 'closed' AND %[2]s.status <> 'pinned'
+		    AND ( %[3]s ) )
+		  OR
+		  ( %[2]s.is_blocked = 1
+		    AND ( %[2]s.status = 'closed' OR %[2]s.status = 'pinned'
+		          OR NOT ( %[3]s ) ) )
+	`, table, alias, disjunction)
+}
+
+// shouldBeBlockedDisjunction is the OR of every reason a row should have
+// is_blocked = 1: an open hard blocker (issue or wisp), a blocked parent (issue
+// or wisp), or an ungated waits-for spawner. It mirrors the disjunction inside
+// the mark/unmark templates in blocked_state.go; the lockstep test keeps the
+// two from drifting. alias is the row's table alias, depTable its dependency
+// table; the joined target tables (issues/wisps) are the same for both.
+func shouldBeBlockedDisjunction(alias, depTable string) string {
+	//nolint:gosec // G201: alias and depTable are constant; waitsForGateBlockedSQL is a constant template.
+	return fmt.Sprintf(`
+		    EXISTS (
+		      SELECT 1 FROM %[2]s d
+		      JOIN issues t ON t.id = d.depends_on_issue_id
+		      WHERE d.issue_id = %[1]s.id
+		        AND (d.type = 'blocks' OR d.type = 'conditional-blocks')
+		        AND t.status <> 'closed' AND t.status <> 'pinned'
+		    )
+		    OR EXISTS (
+		      SELECT 1 FROM %[2]s d
+		      JOIN wisps t ON t.id = d.depends_on_wisp_id
+		      WHERE d.issue_id = %[1]s.id
+		        AND (d.type = 'blocks' OR d.type = 'conditional-blocks')
+		        AND t.status <> 'closed' AND t.status <> 'pinned'
+		    )
+		    OR EXISTS (
+		      SELECT 1 FROM %[2]s d
+		      JOIN issues p ON p.id = d.depends_on_issue_id
+		      WHERE d.issue_id = %[1]s.id
+		        AND d.type = 'parent-child'
+		        AND p.is_blocked = 1
+		    )
+		    OR EXISTS (
+		      SELECT 1 FROM %[2]s d
+		      JOIN wisps p ON p.id = d.depends_on_wisp_id
+		      WHERE d.issue_id = %[1]s.id
+		        AND d.type = 'parent-child'
+		        AND p.is_blocked = 1
+		    )
+		    OR EXISTS (
+		      SELECT 1 FROM %[2]s d
+		      WHERE d.issue_id = %[1]s.id AND d.type = 'waits-for'
+		        AND (%[3]s)
+		    )
+	`, alias, depTable, waitsForGateBlockedSQL)
+}
+
+// countRows runs a single COUNT(*) query and returns the scalar.
+func countRows(ctx context.Context, tx DBTX, query string) (int64, error) {
+	rows, err := tx.QueryContext(ctx, query)
+	if err != nil {
+		return 0, err
+	}
+	defer rows.Close()
+	var n int64
+	if rows.Next() {
+		if err := rows.Scan(&n); err != nil {
+			return 0, err
+		}
+	}
+	return n, rows.Err()
+}

--- a/internal/storage/issueops/blocked_consistency.go
+++ b/internal/storage/issueops/blocked_consistency.go
@@ -2,8 +2,69 @@ package issueops
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"sort"
+	"strings"
 )
+
+// blockedRecomputeGraphTables are the version-controlled tables a full
+// is_blocked recompute reads and folds into its issues-only repair commit.
+//
+// The dolt-ignored wisp tables (wisps, wisp_dependencies) are deliberately
+// excluded. They are never staged or committed, so dirty wisp state cannot leak
+// into the repair commit; and because Dolt reports every ignored table as
+// perpetually "modified" in dolt_status, guarding on them would refuse the
+// recompute in any workspace that has ever created a wisp. is_blocked derived
+// from wisp state is the same working-set-derived value every local write path
+// already produces.
+var blockedRecomputeGraphTables = []string{"issues", "dependencies"}
+
+// ErrBlockedRecomputeDirtyGraph reports that a full is_blocked recompute was
+// asked to run while its committable graph tables had uncommitted changes.
+// Callers wrap it with the offending table names.
+var ErrBlockedRecomputeDirtyGraph = errors.New("is_blocked recompute needs a clean working set")
+
+// GuardBlockedRecomputeWorkingSet refuses a full is_blocked recompute when the
+// committable graph tables (issues, dependencies) have uncommitted working-set
+// changes (bd-6dnrw.37). The recompute derives is_blocked from the current graph
+// and stages only `issues`, so running it dirty would either sweep unrelated
+// issue edits into the repair commit or commit flags derived from uncommitted
+// dependency edits that are not part of the same commit. Run it as the first
+// statement inside the recompute's own transaction so it sees exactly the
+// working set the recompute will read. Returns a wrapped
+// ErrBlockedRecomputeDirtyGraph naming the dirty tables, or nil when clean.
+func GuardBlockedRecomputeWorkingSet(ctx context.Context, tx DBTX) error {
+	placeholders := strings.TrimSuffix(strings.Repeat("?,", len(blockedRecomputeGraphTables)), ",")
+	args := make([]any, len(blockedRecomputeGraphTables))
+	for i, t := range blockedRecomputeGraphTables {
+		args[i] = t
+	}
+	rows, err := tx.QueryContext(ctx,
+		"SELECT DISTINCT table_name FROM dolt_status WHERE table_name IN ("+placeholders+")", args...)
+	if err != nil {
+		return fmt.Errorf("check working set before is_blocked recompute: %w", err)
+	}
+	defer rows.Close()
+
+	var dirty []string
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return fmt.Errorf("check working set before is_blocked recompute: %w", err)
+		}
+		dirty = append(dirty, name)
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("check working set before is_blocked recompute: %w", err)
+	}
+	if len(dirty) == 0 {
+		return nil
+	}
+	sort.Strings(dirty)
+	return fmt.Errorf("%w: commit or discard pending changes to %s first",
+		ErrBlockedRecomputeDirtyGraph, strings.Join(dirty, ", "))
+}
 
 // RecomputeAllIsBlockedInTx recomputes the denormalized is_blocked column for
 // every issue and wisp in one batched mark/unmark fixpoint and returns the

--- a/internal/storage/issueops/blocked_merge.go
+++ b/internal/storage/issueops/blocked_merge.go
@@ -295,7 +295,7 @@ func recomputeIsBlockedForAll(ctx context.Context, tx *sql.Tx) error {
 }
 
 // allIDs lists every id in table. table must be a hardcoded constant.
-func allIDs(ctx context.Context, tx *sql.Tx, table string) ([]string, error) {
+func allIDs(ctx context.Context, tx DBTX, table string) ([]string, error) {
 	//nolint:gosec // G201: table is a hardcoded constant, never user input.
 	rows, err := tx.QueryContext(ctx, fmt.Sprintf("SELECT id FROM %s", table))
 	if err != nil {

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -248,6 +248,18 @@ type Compactor interface {
 	Compact(ctx context.Context, initialHash, boundaryHash string, oldCommits int, recentHashes []string) error
 }
 
+// BlockedRecomputer recomputes the denormalized is_blocked column for every
+// issue and wisp in one full pass and reports how many rows it corrected.
+// Callers should type-assert to this interface for the is_blocked repair
+// (bd-6dnrw.37): unlike the scoped post-pull recompute, it does not depend on a
+// merge advancing HEAD, so it can recover a column a skipped recompute (a
+// recompute that failed after its merge committed, or a hand-resolved
+// conflicted pull) left stale. It is idempotent — a consistent database
+// corrects nothing.
+type BlockedRecomputer interface {
+	RecomputeAllBlocked(ctx context.Context) (int, error)
+}
+
 // LifecycleManager provides lifecycle inspection beyond Close().
 type LifecycleManager interface {
 	IsClosed() bool

--- a/website/docs/cli-reference/index.md
+++ b/website/docs/cli-reference/index.md
@@ -9,7 +9,7 @@ sidebar_position: 0
 <!-- AUTO-GENERATED: do not edit manually -->
 Reference for bd Latest. Generated from `bd help --list` and `bd help --doc <command>`.
 
-This reference covers all 106 live top-level `bd` commands. Regenerate it with:
+This reference covers all 107 live top-level `bd` commands. Regenerate it with:
 
 ```bash
 ./scripts/generate-cli-docs.sh
@@ -94,6 +94,7 @@ This reference covers all 106 live top-level `bd` commands. Regenerate it with:
 - [`bd quickstart`](./quickstart.md)
 - [`bd ready`](./ready.md)
 - [`bd recall`](./recall.md)
+- [`bd recompute-blocked`](./recompute-blocked.md)
 - [`bd remember`](./remember.md)
 - [`bd rename`](./rename.md)
 - [`bd rename-prefix`](./rename-prefix.md)

--- a/website/docs/cli-reference/recompute-blocked.md
+++ b/website/docs/cli-reference/recompute-blocked.md
@@ -1,0 +1,33 @@
+---
+id: recompute-blocked
+title: bd recompute-blocked
+slug: /cli-reference/recompute-blocked
+sidebar_position: 999
+---
+
+<!-- AUTO-GENERATED: do not edit manually -->
+Generated from `bd help --doc recompute-blocked`
+
+## bd recompute-blocked
+
+Recompute the denormalized is_blocked flag for every issue and wisp.
+
+is_blocked is derived from the dependency graph and maintained automatically by
+local writes and by a post-pull recompute scoped to what the merge changed. If
+that scoped recompute is skipped — a recompute that failed after its merge
+committed, or a conflicted pull resolved by hand — the flag can go stale, and a
+later pull that merges nothing will not refresh it (bd-6dnrw.37). 'bd ready'
+trusts the flag, so stale values silently hide ready work or surface blocked
+work.
+
+This command runs the full recompute unconditionally and commits the result.
+It is idempotent: on a consistent database it changes nothing. Works in both
+embedded and server mode (unlike 'bd doctor', which is server-mode only).
+
+Examples:
+  bd recompute-blocked          # Repair stale is_blocked flags
+  bd recompute-blocked --json   # Machine-parseable &#123;"rows_corrected": N&#125;
+
+```
+bd recompute-blocked
+```

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -2750,7 +2750,7 @@ For these use cases, consider GitHub Issues, Linear, or Jira.
 <!-- AUTO-GENERATED: do not edit manually -->
 Reference for bd Latest. Generated from `bd help --list` and `bd help --doc <command>`.
 
-This reference covers all 106 live top-level `bd` commands. Regenerate it with:
+This reference covers all 107 live top-level `bd` commands. Regenerate it with:
 
 ```bash
 ./scripts/generate-cli-docs.sh
@@ -2835,6 +2835,7 @@ This reference covers all 106 live top-level `bd` commands. Regenerate it with:
 - [`bd quickstart`](./quickstart.md)
 - [`bd ready`](./ready.md)
 - [`bd recall`](./recall.md)
+- [`bd recompute-blocked`](./recompute-blocked.md)
 - [`bd remember`](./remember.md)
 - [`bd rename`](./rename.md)
 - [`bd rename-prefix`](./rename-prefix.md)
@@ -8776,6 +8777,38 @@ Examples:
 
 ```
 bd recall <key>
+```
+
+</document>
+
+<document path="docs/cli-reference/recompute-blocked.md">
+
+
+<!-- AUTO-GENERATED: do not edit manually -->
+Generated from `bd help --doc recompute-blocked`
+
+## bd recompute-blocked
+
+Recompute the denormalized is_blocked flag for every issue and wisp.
+
+is_blocked is derived from the dependency graph and maintained automatically by
+local writes and by a post-pull recompute scoped to what the merge changed. If
+that scoped recompute is skipped — a recompute that failed after its merge
+committed, or a conflicted pull resolved by hand — the flag can go stale, and a
+later pull that merges nothing will not refresh it (bd-6dnrw.37). 'bd ready'
+trusts the flag, so stale values silently hide ready work or surface blocked
+work.
+
+This command runs the full recompute unconditionally and commits the result.
+It is idempotent: on a consistent database it changes nothing. Works in both
+embedded and server mode (unlike 'bd doctor', which is server-mode only).
+
+Examples:
+  bd recompute-blocked          # Repair stale is_blocked flags
+  bd recompute-blocked --json   # Machine-parseable &#123;"rows_corrected": N&#125;
+
+```
+bd recompute-blocked
 ```
 
 </document>

--- a/website/versioned_docs/version-1.0.0/cli-reference/index.md
+++ b/website/versioned_docs/version-1.0.0/cli-reference/index.md
@@ -9,7 +9,7 @@ sidebar_position: 0
 <!-- AUTO-GENERATED: do not edit manually -->
 Reference for bd v1.0.0. Generated from `bd help --list` and `bd help --doc <command>`.
 
-This reference covers all 106 live top-level `bd` commands. Regenerate it with:
+This reference covers all 107 live top-level `bd` commands. Regenerate it with:
 
 ```bash
 ./scripts/generate-cli-docs.sh
@@ -94,6 +94,7 @@ This reference covers all 106 live top-level `bd` commands. Regenerate it with:
 - [`bd quickstart`](./quickstart.md)
 - [`bd ready`](./ready.md)
 - [`bd recall`](./recall.md)
+- [`bd recompute-blocked`](./recompute-blocked.md)
 - [`bd remember`](./remember.md)
 - [`bd rename`](./rename.md)
 - [`bd rename-prefix`](./rename-prefix.md)

--- a/website/versioned_docs/version-1.0.0/cli-reference/recompute-blocked.md
+++ b/website/versioned_docs/version-1.0.0/cli-reference/recompute-blocked.md
@@ -1,0 +1,33 @@
+---
+id: recompute-blocked
+title: bd recompute-blocked
+slug: /cli-reference/recompute-blocked
+sidebar_position: 999
+---
+
+<!-- AUTO-GENERATED: do not edit manually -->
+Generated from `bd help --doc recompute-blocked`
+
+## bd recompute-blocked
+
+Recompute the denormalized is_blocked flag for every issue and wisp.
+
+is_blocked is derived from the dependency graph and maintained automatically by
+local writes and by a post-pull recompute scoped to what the merge changed. If
+that scoped recompute is skipped — a recompute that failed after its merge
+committed, or a conflicted pull resolved by hand — the flag can go stale, and a
+later pull that merges nothing will not refresh it (bd-6dnrw.37). 'bd ready'
+trusts the flag, so stale values silently hide ready work or surface blocked
+work.
+
+This command runs the full recompute unconditionally and commits the result.
+It is idempotent: on a consistent database it changes nothing. Works in both
+embedded and server mode (unlike 'bd doctor', which is server-mode only).
+
+Examples:
+  bd recompute-blocked          # Repair stale is_blocked flags
+  bd recompute-blocked --json   # Machine-parseable &#123;"rows_corrected": N&#125;
+
+```
+bd recompute-blocked
+```

--- a/website/versioned_docs/version-1.0.4/cli-reference/index.md
+++ b/website/versioned_docs/version-1.0.4/cli-reference/index.md
@@ -9,7 +9,7 @@ sidebar_position: 0
 <!-- AUTO-GENERATED: do not edit manually -->
 Reference for bd v1.0.4. Generated from `bd help --list` and `bd help --doc <command>`.
 
-This reference covers all 106 live top-level `bd` commands. Regenerate it with:
+This reference covers all 107 live top-level `bd` commands. Regenerate it with:
 
 ```bash
 ./scripts/generate-cli-docs.sh
@@ -94,6 +94,7 @@ This reference covers all 106 live top-level `bd` commands. Regenerate it with:
 - [`bd quickstart`](./quickstart.md)
 - [`bd ready`](./ready.md)
 - [`bd recall`](./recall.md)
+- [`bd recompute-blocked`](./recompute-blocked.md)
 - [`bd remember`](./remember.md)
 - [`bd rename`](./rename.md)
 - [`bd rename-prefix`](./rename-prefix.md)

--- a/website/versioned_docs/version-1.0.4/cli-reference/recompute-blocked.md
+++ b/website/versioned_docs/version-1.0.4/cli-reference/recompute-blocked.md
@@ -1,0 +1,33 @@
+---
+id: recompute-blocked
+title: bd recompute-blocked
+slug: /cli-reference/recompute-blocked
+sidebar_position: 999
+---
+
+<!-- AUTO-GENERATED: do not edit manually -->
+Generated from `bd help --doc recompute-blocked`
+
+## bd recompute-blocked
+
+Recompute the denormalized is_blocked flag for every issue and wisp.
+
+is_blocked is derived from the dependency graph and maintained automatically by
+local writes and by a post-pull recompute scoped to what the merge changed. If
+that scoped recompute is skipped — a recompute that failed after its merge
+committed, or a conflicted pull resolved by hand — the flag can go stale, and a
+later pull that merges nothing will not refresh it (bd-6dnrw.37). 'bd ready'
+trusts the flag, so stale values silently hide ready work or surface blocked
+work.
+
+This command runs the full recompute unconditionally and commits the result.
+It is idempotent: on a consistent database it changes nothing. Works in both
+embedded and server mode (unlike 'bd doctor', which is server-mode only).
+
+Examples:
+  bd recompute-blocked          # Repair stale is_blocked flags
+  bd recompute-blocked --json   # Machine-parseable &#123;"rows_corrected": N&#125;
+
+```
+bd recompute-blocked
+```

--- a/website/versioned_docs/version-1.0.5/cli-reference/index.md
+++ b/website/versioned_docs/version-1.0.5/cli-reference/index.md
@@ -9,7 +9,7 @@ sidebar_position: 0
 <!-- AUTO-GENERATED: do not edit manually -->
 Reference for bd v1.0.5. Generated from `bd help --list` and `bd help --doc <command>`.
 
-This reference covers all 106 live top-level `bd` commands. Regenerate it with:
+This reference covers all 107 live top-level `bd` commands. Regenerate it with:
 
 ```bash
 ./scripts/generate-cli-docs.sh
@@ -94,6 +94,7 @@ This reference covers all 106 live top-level `bd` commands. Regenerate it with:
 - [`bd quickstart`](./quickstart.md)
 - [`bd ready`](./ready.md)
 - [`bd recall`](./recall.md)
+- [`bd recompute-blocked`](./recompute-blocked.md)
 - [`bd remember`](./remember.md)
 - [`bd rename`](./rename.md)
 - [`bd rename-prefix`](./rename-prefix.md)

--- a/website/versioned_docs/version-1.0.5/cli-reference/recompute-blocked.md
+++ b/website/versioned_docs/version-1.0.5/cli-reference/recompute-blocked.md
@@ -1,0 +1,33 @@
+---
+id: recompute-blocked
+title: bd recompute-blocked
+slug: /cli-reference/recompute-blocked
+sidebar_position: 999
+---
+
+<!-- AUTO-GENERATED: do not edit manually -->
+Generated from `bd help --doc recompute-blocked`
+
+## bd recompute-blocked
+
+Recompute the denormalized is_blocked flag for every issue and wisp.
+
+is_blocked is derived from the dependency graph and maintained automatically by
+local writes and by a post-pull recompute scoped to what the merge changed. If
+that scoped recompute is skipped — a recompute that failed after its merge
+committed, or a conflicted pull resolved by hand — the flag can go stale, and a
+later pull that merges nothing will not refresh it (bd-6dnrw.37). 'bd ready'
+trusts the flag, so stale values silently hide ready work or surface blocked
+work.
+
+This command runs the full recompute unconditionally and commits the result.
+It is idempotent: on a consistent database it changes nothing. Works in both
+embedded and server mode (unlike 'bd doctor', which is server-mode only).
+
+Examples:
+  bd recompute-blocked          # Repair stale is_blocked flags
+  bd recompute-blocked --json   # Machine-parseable &#123;"rows_corrected": N&#125;
+
+```
+bd recompute-blocked
+```


### PR DESCRIPTION
## Problem (bd-6dnrw.37)

The post-pull `is_blocked` recompute (bd-6dnrw.3) is scoped to the merge diff and **skips when a re-pull merges nothing** (`HEAD` unchanged). So a recompute that failed *after* its merge committed — or a conflicted pull resolved by hand (which skips the recompute) — left `is_blocked` stale with **no way to repair it**: rerunning `bd dolt pull` merged nothing and recomputed nothing. `bd ready` trusts `is_blocked`, so stale values silently hide ready work or surface blocked work.

## Fix

**Shared core** (`internal/storage/issueops/blocked_consistency.go`):
- `RecomputeAllIsBlockedInTx` — full mark/unmark fixpoint over every issue + wisp; returns rows corrected; idempotent; reuses the existing pass functions.
- `CountIsBlockedInconsistenciesInTx` — read-only `COUNT` of stale rows for detection. Its predicate mirrors the mark/unmark templates and is **pinned to the repair** by the lockstep tests (a converged DB counts 0; any counted row is one a recompute pass flips), so detection cannot silently drift from repair.

**Cross-mode repair:**
- `storage.BlockedRecomputer` capability; `DoltStore` + `EmbeddedDoltStore` `RecomputeAllBlocked` (stages `issues`-only, matching the post-pull recompute).
- **`bd recompute-blocked`** — works in **both** embedded and server mode. (`bd doctor` is server-mode only, so embedded users need a non-doctor entry point.)
- `bd doctor` (server mode) gains a read-only **Blocked State** check and a `bd doctor --fix` dispatch running the same repair. Warn-only (does not fail `OverallOK`) — a new check shipping in a patch, and `is_blocked` self-heals via the fix.

## Deferred follow-up

The secondary item from bd-6dnrw.37 — server-mode `recomputeBlockedAfterPull` commits via `s.Commit` (all dirty tables) and could sweep a concurrent writer's changes — is split to **bd-6y5hx** (P3). It is subtle: after an auto-resolved merge the working set holds the *whole* merge result, so a naive `issues`-only narrowing would drop merge results. The embedded path already stages `issues`-only; the new repair path stages `issues`-only too.

## Testing

- 3 dolt-package lockstep tests: detect==repair, stuck-blocked flag, parent-child cascade.
- Embedded wiring test (capability + no-op + idempotence).
- Smoke-tested on a real ~2000-issue embedded DB: **0 false positives**.
- `go build` / `go vet` / `gofmt` / `golangci-lint` all clean.

Based on `main`; independent of #4412.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
