### PR TITLE
fix(remember): reject subcommand-like bare word instead of storing it

### DIFF
--- a/cmd/bd/memory.go
+++ b/cmd/bd/memory.go
@@ -44,6 +44,29 @@ func slugify(s string) string {
 	return slug
 }
 
+// matchesKnownCommand reports whether insight is a single bare word that
+// matches the name or an alias of a top-level bd command. It is used to catch
+// `bd remember <subcommand>` mistakes before they become accidental memories.
+// Multi-word insights (the normal case) always pass, since they contain
+// whitespace and so cannot be a single command token.
+func matchesKnownCommand(cmd *cobra.Command, insight string) (string, bool) {
+	word := strings.TrimSpace(insight)
+	if word == "" || strings.ContainsAny(word, " \t\r\n") {
+		return "", false
+	}
+	for _, c := range cmd.Root().Commands() {
+		if strings.EqualFold(c.Name(), word) {
+			return c.Name(), true
+		}
+		for _, alias := range c.Aliases {
+			if strings.EqualFold(alias, word) {
+				return c.Name(), true
+			}
+		}
+	}
+	return "", false
+}
+
 // rememberCmd stores a memory.
 var rememberCmd = &cobra.Command{
 	Use:   `remember "<insight>"`,
@@ -86,6 +109,23 @@ Examples:
 			return HandleErrorRespectJSON("memory content cannot be empty")
 		}
 
+		// Guard against a subcommand-like first argument being silently stored
+		// as memory content. `bd remember` is a leaf command, so a mistaken
+		// `bd remember recall` (or any bare bd command name) would otherwise
+		// store the word "recall" as a memory instead of doing what the user
+		// intended (GH#4401). A genuine insight is a phrase, so only a single
+		// bare word that matches a known command is treated as suspect, and an
+		// explicit --key signals deliberate intent and bypasses the guard.
+		if memoryKeyFlag == "" {
+			if name, ok := matchesKnownCommand(cmd, insight); ok {
+				return HandleErrorWithHintRespectJSON(
+					fmt.Sprintf("%q looks like a command, not something to remember", insight),
+					fmt.Sprintf("Did you mean 'bd %s'? To store %q as a memory anyway, give it an explicit key: bd remember %q --key <key>", name, insight, insight),
+				)
+			}
+		}
+
+		// Generate or use provided key
 		key := memoryKeyFlag
 		if key == "" {
 			key = slugify(insight)

--- a/cmd/bd/memory_pure_test.go
+++ b/cmd/bd/memory_pure_test.go
@@ -1,0 +1,41 @@
+// Pure-Go tests for memory command helpers. No cgo / Dolt dependency, so this
+// file carries no build tag and compiles under CGO_ENABLED=0 with gms_pure_go.
+
+package main
+
+import "testing"
+
+// TestMatchesKnownCommand guards the `bd remember <subcommand>` misfire fix
+// (GH#4401): a bare word that names a real top-level command must be flagged so
+// it is not silently stored as memory content, while genuine multi-word
+// insights (and arbitrary single words) must pass through untouched.
+func TestMatchesKnownCommand(t *testing.T) {
+	cases := []struct {
+		name     string
+		insight  string
+		wantName string
+		wantHit  bool
+	}{
+		{"sibling command recall", "recall", "recall", true},
+		{"sibling command forget", "forget", "forget", true},
+		{"sibling command memories", "memories", "memories", true},
+		{"remember itself", "remember", "remember", true},
+		{"case insensitive", "ReCall", "recall", true},
+		{"multi-word insight", "always run tests with the -race flag", "", false},
+		{"leading command word in a phrase", "recall the auth design", "", false},
+		{"non-command single word", "zorblax", "", false},
+		{"empty", "", "", false},
+		{"whitespace only", "   ", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotName, gotHit := matchesKnownCommand(rememberCmd, tc.insight)
+			if gotHit != tc.wantHit {
+				t.Fatalf("matchesKnownCommand(%q) hit = %v, want %v", tc.insight, gotHit, tc.wantHit)
+			}
+			if gotHit && gotName != tc.wantName {
+				t.Errorf("matchesKnownCommand(%q) name = %q, want %q", tc.insight, gotName, tc.wantName)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

`bd remember` is a leaf command (`cobra.ExactArgs(1)`), so a mistaken `bd remember recall` — or any bare bd command name like `status`, `forget`, `memories` — silently stored that word as a memory instead of doing what the user intended. No subcommand dispatch, no confirmation.

This guards the content argument: if it is a **single bare word** that matches the name or alias of a top-level bd command, `remember` refuses with an actionable hint instead of writing a memory.

- Genuine insights are phrases (they contain whitespace), so they pass through untouched — zero impact on normal use.
- An explicit `--key` signals deliberate intent and bypasses the guard, so storing the literal word is still possible.

## Behavior

```
$ bd remember recall
Error: "recall" looks like a command, not something to remember
Hint: Did you mean 'bd recall'? To store "recall" as a memory anyway, give it an explicit key: bd remember "recall" --key <key>

$ bd remember "always run tests with the -race flag"
Remembered [always-run-tests-with-the-race-flag]: always run tests with the -race flag

$ bd remember recall --key my-recall-note
Remembered [my-recall-note]: recall
```

`--json` mode emits a structured `{"error":..., "hint":...}` object (via `FatalErrorWithHintRespectJSON`).

## Testing

- New pure-Go regression test `TestMatchesKnownCommand` (no cgo/Dolt dependency) covering sibling commands, case-insensitivity, multi-word insights, a leading-command-word phrase, non-command words, and empty/whitespace.
- `go build -tags gms_pure_go ./cmd/bd/` clean; `gofmt`/`go vet` clean.
- Verified end-to-end against an embedded workspace (refuse / store / escape-hatch / JSON cases above).

Fixes #4401

🤖 Generated with [Claude Code](https://claude.com/claude-code)