### PR TITLE
fix(preflight): make the readiness checklist project-aware

### DIFF
--- a/cmd/bd/preflight.go
+++ b/cmd/bd/preflight.go
@@ -177,7 +177,7 @@ func buildPreflightChecklist(dir string) []string {
 // isBeadsRepo reports whether dir is the beads source repo, detected by the
 // module path in go.mod. Used to keep preflight's repo-specific checklist.
 func isBeadsRepo(dir string) bool {
-	data, err := os.ReadFile(filepath.Join(dir, "go.mod"))
+	data, err := os.ReadFile(filepath.Join(dir, "go.mod")) //nolint:gosec // path is constructed internally (repo root + fixed filename)
 	if err != nil {
 		return false
 	}

--- a/cmd/bd/preflight.go
+++ b/cmd/bd/preflight.go
@@ -90,19 +90,107 @@ func runPreflight(cmd *cobra.Command, args []string) error {
 		return runChecks(jsonOutput, skipLint)
 	}
 
+	// Static checklist mode — tailor the checklist to the detected project
+	// stack so non-Go projects don't get a misleading Go/Nix checklist (GH#4364).
+	root := git.GetRepoRoot()
+	if root == "" {
+		if wd, err := os.Getwd(); err == nil {
+			root = wd
+		}
+	}
+
 	fmt.Println("PR Readiness Checklist:")
 	fmt.Println()
-	fmt.Println("[ ] Tests pass: go test -tags gms_pure_go -short ./...")
-	fmt.Println("[ ] Lint passes: golangci-lint run --build-tags=gms_pure_go ./...")
-	fmt.Println("[ ] Formatting: gofmt -l .")
-	fmt.Println("[ ] No beads pollution: check .beads/issues.jsonl diff")
-	fmt.Println("[ ] Nix hash current: go.sum unchanged or vendorHash updated")
-	fmt.Println("[ ] Version sync: version.go matches default.nix")
+	for _, item := range buildPreflightChecklist(root) {
+		fmt.Printf("[ ] %s\n", item)
+	}
 	fmt.Println()
 	fmt.Println("Run 'bd preflight --check' to validate automatically.")
 	return nil
 }
 
+// fileExists reports whether name exists directly under dir.
+func fileExists(dir, name string) bool {
+	if dir == "" {
+		return false
+	}
+	_, err := os.Stat(filepath.Join(dir, name))
+	return err == nil
+}
+
+// buildPreflightChecklist returns PR-readiness checklist items tailored to the
+// project's language stack, detected from standard marker files in dir. A
+// project with no recognized stack gets a generic reminder rather than a
+// misleading Go checklist, and the repo's own Go+Nix specific items
+// (gms_pure_go build tags, nix vendorHash, version.go vs default.nix) only
+// appear where they apply (GH#4364).
+func buildPreflightChecklist(dir string) []string {
+	// Preserve the exact rich checklist when run inside the beads repo itself
+	// (its primary audience), so the gms_pure_go build tags and nix/version
+	// reminders beads contributors rely on are not lost.
+	if isBeadsRepo(dir) {
+		return []string{
+			"Tests pass: go test -tags gms_pure_go -short ./...",
+			"Lint passes: golangci-lint run --build-tags=gms_pure_go ./...",
+			"Formatting: gofmt -l .",
+			"No beads pollution: check .beads/issues.jsonl diff",
+			"Nix hash current: go.sum unchanged or vendorHash updated",
+			"Version sync: version.go matches default.nix",
+		}
+	}
+
+	var items []string
+	switch {
+	case fileExists(dir, "go.mod"):
+		items = append(items,
+			"Tests pass: go test ./...",
+			"Lint passes: golangci-lint run ./...",
+			"Formatting: gofmt -l .",
+		)
+	case fileExists(dir, "package.json"):
+		items = append(items,
+			"Tests pass: npm test",
+			"Types check: tsc --noEmit",
+		)
+	case fileExists(dir, "pyproject.toml"), fileExists(dir, "setup.py"):
+		items = append(items,
+			"Tests pass: pytest",
+			"Lint passes: ruff check",
+		)
+	case fileExists(dir, "Cargo.toml"):
+		items = append(items,
+			"Tests pass: cargo test",
+			"Lint passes: cargo clippy",
+		)
+	default:
+		items = append(items, "Tests pass: run your project's test suite, linter, and formatter")
+	}
+
+	// Relevant to any beads workspace, regardless of language.
+	if fileExists(dir, ".beads") {
+		items = append(items, "No beads pollution: check .beads/issues.jsonl diff")
+	}
+
+	return items
+}
+
+// isBeadsRepo reports whether dir is the beads source repo, detected by the
+// module path in go.mod. Used to keep preflight's repo-specific checklist.
+func isBeadsRepo(dir string) bool {
+	data, err := os.ReadFile(filepath.Join(dir, "go.mod"))
+	if err != nil {
+		return false
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "module ") {
+			return strings.TrimSpace(strings.TrimPrefix(line, "module ")) == "github.com/steveyegge/beads"
+		}
+	}
+	return false
+}
+
+// runChecks executes all preflight checks and reports results.
 func runChecks(jsonOutput, skipLint bool) error {
 	var results []CheckResult
 

--- a/cmd/bd/preflight_test.go
+++ b/cmd/bd/preflight_test.go
@@ -303,3 +303,101 @@ func TestRunVersionSyncCheck_ScriptFallback(t *testing.T) {
 		t.Fatal("expected fallback logic, not script invocation")
 	}
 }
+
+// writeMarkerDir creates a temp dir containing the given marker files (each
+// with trivial content) and returns its path. Used to exercise project-type
+// detection in the preflight checklist (GH#4364).
+func writeMarkerDir(t *testing.T, files map[string]string) string {
+	t.Helper()
+	dir := t.TempDir()
+	for name, content := range files {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+	return dir
+}
+
+func TestBuildPreflightChecklist(t *testing.T) {
+	beadsGoMod := "module github.com/steveyegge/beads\n\ngo 1.22\n"
+	otherGoMod := "module example.com/foo\n\ngo 1.22\n"
+
+	cases := []struct {
+		name        string
+		files       map[string]string
+		wantContain []string // substring present in at least one item
+		wantAbsent  []string // substring present in no item
+	}{
+		{
+			name:        "beads repo keeps rich Go+Nix checklist",
+			files:       map[string]string{"go.mod": beadsGoMod, "default.nix": "{}", ".beads": ""},
+			wantContain: []string{"gms_pure_go", "Version sync", "Nix hash", "No beads pollution"},
+		},
+		{
+			name:        "generic Go project gets plain go commands",
+			files:       map[string]string{"go.mod": otherGoMod},
+			wantContain: []string{"go test ./...", "golangci-lint run ./...", "gofmt -l ."},
+			wantAbsent:  []string{"gms_pure_go", "Version sync", "Nix hash"},
+		},
+		{
+			name:        "node project",
+			files:       map[string]string{"package.json": "{}"},
+			wantContain: []string{"npm test", "tsc --noEmit"},
+			wantAbsent:  []string{"go test", "gofmt"},
+		},
+		{
+			name:        "rust project",
+			files:       map[string]string{"Cargo.toml": "[package]\n"},
+			wantContain: []string{"cargo test", "cargo clippy"},
+			wantAbsent:  []string{"go test ./...", "npm test"},
+		},
+		{
+			name:        "python pyproject",
+			files:       map[string]string{"pyproject.toml": "[project]\n"},
+			wantContain: []string{"pytest", "ruff check"},
+		},
+		{
+			name:        "python setup.py",
+			files:       map[string]string{"setup.py": "", ".beads": ""},
+			wantContain: []string{"pytest", "No beads pollution"},
+		},
+		{
+			name:        "unknown stack gets generic reminder",
+			files:       map[string]string{"README.md": "hi"},
+			wantContain: []string{"run your project's test suite"},
+			wantAbsent:  []string{"go test", "npm test", "cargo test", "pytest"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := writeMarkerDir(t, tc.files)
+			joined := strings.Join(buildPreflightChecklist(dir), "\n")
+			for _, want := range tc.wantContain {
+				if !strings.Contains(joined, want) {
+					t.Errorf("checklist missing %q\ngot:\n%s", want, joined)
+				}
+			}
+			for _, absent := range tc.wantAbsent {
+				if strings.Contains(joined, absent) {
+					t.Errorf("checklist unexpectedly contains %q\ngot:\n%s", absent, joined)
+				}
+			}
+		})
+	}
+}
+
+func TestIsBeadsRepo(t *testing.T) {
+	beads := writeMarkerDir(t, map[string]string{"go.mod": "module github.com/steveyegge/beads\n"})
+	if !isBeadsRepo(beads) {
+		t.Error("expected beads module to be detected as the beads repo")
+	}
+	other := writeMarkerDir(t, map[string]string{"go.mod": "module example.com/foo\n"})
+	if isBeadsRepo(other) {
+		t.Error("non-beads module should not be detected as the beads repo")
+	}
+	empty := t.TempDir()
+	if isBeadsRepo(empty) {
+		t.Error("dir without go.mod should not be detected as the beads repo")
+	}
+}


### PR DESCRIPTION
## Summary

`bd preflight` always printed a Go/Nix-specific checklist regardless of the project's language stack:

```
[ ] Tests pass: go test -tags gms_pure_go -short ./...
[ ] Lint passes: golangci-lint run --build-tags=gms_pure_go ./...
[ ] Formatting: gofmt -l .
[ ] No beads pollution: check .beads/issues.jsonl diff
[ ] Nix hash current: go.sum unchanged or vendorHash updated
[ ] Version sync: version.go matches default.nix
```

In a non-Go repo (bash project, Node app, etc.) this is misleading — those commands don't apply.

## Fix

Detect the stack from standard marker files and emit a tailored checklist:

| Marker | Checklist |
|---|---|
| `go.mod` | `go test ./...`, `golangci-lint run ./...`, `gofmt -l .` |
| `package.json` | `npm test`, `tsc --noEmit` |
| `pyproject.toml` / `setup.py` | `pytest`, `ruff check` |
| `Cargo.toml` | `cargo test`, `cargo clippy` |
| none | generic "run your project's test suite, linter, and formatter" |

The beads-pollution item is added for any beads workspace (`.beads` present).

**No regression for beads contributors:** when preflight runs inside the beads repo itself (detected via the `go.mod` module path), the original rich Go+Nix checklist — including the `gms_pure_go` build tags, nix vendorHash, and version-sync reminders — is preserved exactly.

This is scoped to the static `bd preflight` checklist. The `--check` mode (which actually runs `go test`/`golangci-lint`/nix/version checks) remains Go-focused and is out of scope here.

## Verified

Built and ran against initialized scratch workspaces for each stack:

```
node    -> npm test / tsc --noEmit
rust    -> cargo test / cargo clippy
python  -> pytest / ruff check
go(gen) -> go test ./... / golangci-lint run ./... / gofmt -l .   (no gms_pure_go, no nix)
none    -> run your project's test suite, linter, and formatter
```

All include the beads-pollution line in a beads workspace.

## Testing

- New pure-Go tests `TestBuildPreflightChecklist` (table-driven across all stacks, asserting presence/absence) and `TestIsBeadsRepo`.
- `go build -tags gms_pure_go ./cmd/bd/` clean; `gofmt`/`go vet` clean; preflight test suite green.

Fixes #4364

🤖 Generated with [Claude Code](https://claude.com/claude-code)