### PR TITLE
docs(skill): fix decision skill referencing nonexistent `bd decision record`

### DIFF
--- a/plugins/beads/skills/beads/commands/decision.md
+++ b/plugins/beads/skills/beads/commands/decision.md
@@ -9,7 +9,7 @@ Decisions use `--type decision`. The description field holds the structured deci
 
 ## Record a Decision
 
-When the user wants to record a decision (or you invoke `bd decision record`):
+When the user wants to record a decision (i.e. the `record` action of this command):
 
 1. Gather the following (ask if not provided):
    - **Title**: Short summary of what was decided (required)


### PR DESCRIPTION
## Summary

The decision skill (`plugins/beads/skills/beads/commands/decision.md`) had its "Record a Decision" section read:

> When the user wants to record a decision (or you invoke `bd decision record`):

There is no `bd decision` subcommand. An agent skimming the skill sees a backtick-wrapped `bd decision record` presented as an action and runs it literally → `unknown command "decision"`. The intended meaning was the `record` action of this slash-command (frontmatter: `argument-hint: record|list|show|supersede`), not a CLI verb.

## Fix

Reword the parenthetical to name the slash-command action instead of a fake CLI command:

```diff
-When the user wants to record a decision (or you invoke `bd decision record`):
+When the user wants to record a decision (i.e. the `record` action of this command):
```

This is the only `bd decision` reference in the file (and the repo); every other command block already uses the correct `bd create --type decision` / `bd list --type decision` forms.

Fixes #4291

🤖 Generated with [Claude Code](https://claude.com/claude-code)