### PR TITLE
fix(config): derive tracker config namespaces from the registry

### DIFF
--- a/cmd/bd/config.go
+++ b/cmd/bd/config.go
@@ -16,6 +16,7 @@ import (
 	"github.com/steveyegge/beads/internal/git"
 	"github.com/steveyegge/beads/internal/metrics"
 	"github.com/steveyegge/beads/internal/remotecache"
+	"github.com/steveyegge/beads/internal/tracker"
 	"github.com/steveyegge/beads/internal/types"
 )
 
@@ -33,6 +34,9 @@ Common namespaces:
   - jira.*            Jira integration settings
   - linear.*          Linear integration settings
   - github.*          GitHub integration settings
+  - gitlab.*          GitLab integration settings
+  - ado.*             Azure DevOps integration settings
+  - notion.*          Notion integration settings
   - custom.*          Custom integration settings
   - status.*          Issue status configuration
   - doctor.suppress.* Suppress specific bd doctor warnings (GH#1095)
@@ -862,11 +866,30 @@ Examples:
 
 // recognizedConfigPrefixes lists valid top-level config namespaces.
 // Keys under custom.* are always accepted (user-extensible).
+//
+// Tracker namespaces (jira., linear., github., ado., ...) are NOT listed here:
+// they are derived from the tracker registry at runtime via
+// allRecognizedConfigPrefixes, so the recognizer cannot drift out of sync when
+// a new tracker is added (GH#4427).
 var recognizedConfigPrefixes = []string{
-	"export.", "import.", "dolt.", "jira.", "linear.", "github.", "custom.",
+	"export.", "import.", "dolt.", "custom.",
 	"status.", "types.", "doctor.suppress.", "routing.", "sync.", "git.",
 	"directory.", "repos.", "external_projects.", "validation.",
 	"hierarchy.", "ai.", "backup.", "federation.", "metrics.", "agent.",
+}
+
+// allRecognizedConfigPrefixes returns the static namespaces plus the prefix of
+// every registered tracker ("ado.", "jira.", ...). Deriving tracker prefixes
+// from the registry keeps config-key recognition in sync with the set of
+// trackers compiled into bd instead of a hand-maintained allowlist (GH#4427).
+func allRecognizedConfigPrefixes() []string {
+	names := tracker.List()
+	prefixes := make([]string, 0, len(recognizedConfigPrefixes)+len(names))
+	prefixes = append(prefixes, recognizedConfigPrefixes...)
+	for _, name := range names {
+		prefixes = append(prefixes, name+".")
+	}
+	return prefixes
 }
 
 // recognizedConfigKeys lists valid non-namespaced config keys.
@@ -883,7 +906,7 @@ func isRecognizedConfigKey(key string) bool {
 	if recognizedConfigKeys[key] {
 		return true
 	}
-	for _, prefix := range recognizedConfigPrefixes {
+	for _, prefix := range allRecognizedConfigPrefixes() {
 		if strings.HasPrefix(key, prefix) {
 			return true
 		}
@@ -922,7 +945,7 @@ func suggestConfigKey(key string) string {
 
 	bestMatch := ""
 	bestDist := 3 // max edit distance to suggest
-	for _, known := range recognizedConfigPrefixes {
+	for _, known := range allRecognizedConfigPrefixes() {
 		knownPrefix := strings.TrimSuffix(known, ".")
 		d := levenshteinDistance(parts[0], knownPrefix)
 		if d > 0 && d < bestDist {

--- a/cmd/bd/config_validate_key_test.go
+++ b/cmd/bd/config_validate_key_test.go
@@ -3,6 +3,8 @@ package main
 import (
 	"strings"
 	"testing"
+
+	"github.com/steveyegge/beads/internal/tracker"
 )
 
 func TestIsRecognizedConfigKey(t *testing.T) {
@@ -11,6 +13,10 @@ func TestIsRecognizedConfigKey(t *testing.T) {
 		"doctor.suppress.git-hooks", "no-git-ops", "beads.role",
 		"status.custom", "types.custom", "types.infra", "ai.model",
 		"backup.enabled", "import.path", "dolt.local-only", "agent.profile",
+		// Tracker namespaces are derived from the registry (GH#4427); cover
+		// ado (the original bug) plus the others removed from the static list.
+		"ado.org", "ado.project", "github.token", "linear.api-key",
+		"gitlab.url", "notion.token",
 	}
 	for _, key := range recognized {
 		if !isRecognizedConfigKey(key) {
@@ -24,6 +30,22 @@ func TestIsRecognizedConfigKey(t *testing.T) {
 	for _, key := range unrecognized {
 		if isRecognizedConfigKey(key) {
 			t.Errorf("isRecognizedConfigKey(%q) = true, want false", key)
+		}
+	}
+}
+
+// TestTrackerConfigPrefixesRecognized guards against the recognizer drifting
+// out of sync with the tracker registry (GH#4427): every registered tracker's
+// config namespace must be recognized, without being hand-listed.
+func TestTrackerConfigPrefixesRecognized(t *testing.T) {
+	names := tracker.List()
+	if len(names) == 0 {
+		t.Fatal("no trackers registered; tracker adapters not linked into the test binary")
+	}
+	for _, name := range names {
+		key := name + ".some-setting"
+		if !isRecognizedConfigKey(key) {
+			t.Errorf("config key %q for registered tracker %q not recognized", key, name)
 		}
 	}
 }
@@ -42,6 +64,9 @@ func TestSuggestConfigKey(t *testing.T) {
 		{"exprot.auto", "export.auto"},
 		{"exoprt.path", "export.path"},
 		{"totally.bogus", ""},
+		// Tracker prefixes participate in suggestions too (GH#4427): a near-miss
+		// of "ado" should suggest the registry-derived "ado." namespace.
+		{"add.org", "ado.org"},
 	}
 	for _, tt := range tests {
 		got := suggestConfigKey(tt.input)

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -2723,6 +2723,9 @@ Common namespaces:
   - jira.*            Jira integration settings
   - linear.*          Linear integration settings
   - github.*          GitHub integration settings
+  - gitlab.*          GitLab integration settings
+  - ado.*             Azure DevOps integration settings
+  - notion.*          Notion integration settings
   - custom.*          Custom integration settings
   - status.*          Issue status configuration
   - doctor.suppress.* Suppress specific bd doctor warnings (GH#1095)

--- a/website/docs/cli-reference/config.md
+++ b/website/docs/cli-reference/config.md
@@ -20,6 +20,9 @@ Common namespaces:
   - jira.*            Jira integration settings
   - linear.*          Linear integration settings
   - github.*          GitHub integration settings
+  - gitlab.*          GitLab integration settings
+  - ado.*             Azure DevOps integration settings
+  - notion.*          Notion integration settings
   - custom.*          Custom integration settings
   - status.*          Issue status configuration
   - doctor.suppress.* Suppress specific bd doctor warnings (GH#1095)

--- a/website/versioned_docs/version-1.0.0/cli-reference/config.md
+++ b/website/versioned_docs/version-1.0.0/cli-reference/config.md
@@ -20,6 +20,9 @@ Common namespaces:
   - jira.*            Jira integration settings
   - linear.*          Linear integration settings
   - github.*          GitHub integration settings
+  - gitlab.*          GitLab integration settings
+  - ado.*             Azure DevOps integration settings
+  - notion.*          Notion integration settings
   - custom.*          Custom integration settings
   - status.*          Issue status configuration
   - doctor.suppress.* Suppress specific bd doctor warnings (GH#1095)

--- a/website/versioned_docs/version-1.0.4/cli-reference/config.md
+++ b/website/versioned_docs/version-1.0.4/cli-reference/config.md
@@ -20,6 +20,9 @@ Common namespaces:
   - jira.*            Jira integration settings
   - linear.*          Linear integration settings
   - github.*          GitHub integration settings
+  - gitlab.*          GitLab integration settings
+  - ado.*             Azure DevOps integration settings
+  - notion.*          Notion integration settings
   - custom.*          Custom integration settings
   - status.*          Issue status configuration
   - doctor.suppress.* Suppress specific bd doctor warnings (GH#1095)

--- a/website/versioned_docs/version-1.0.5/cli-reference/config.md
+++ b/website/versioned_docs/version-1.0.5/cli-reference/config.md
@@ -20,6 +20,9 @@ Common namespaces:
   - jira.*            Jira integration settings
   - linear.*          Linear integration settings
   - github.*          GitHub integration settings
+  - gitlab.*          GitLab integration settings
+  - ado.*             Azure DevOps integration settings
+  - notion.*          Notion integration settings
   - custom.*          Custom integration settings
   - status.*          Issue status configuration
   - doctor.suppress.* Suppress specific bd doctor warnings (GH#1095)


### PR DESCRIPTION
## Summary

`bd config set ado.org <org>` emitted a spurious warning even though ADO is a fully registered tracker and the value writes/reads correctly:

```
$ bd config set ado.org MyOrg
Warning: "ado.org" is not a recognized config key. Did you mean "ai.org"?
Run 'bd config --help' for valid namespaces.
Set ado.org = MyOrg
```

## Root cause

`recognizedConfigPrefixes` in `cmd/bd/config.go` hardcoded `jira.`/`linear.`/`github.` but never gained `ado.` (or `gitlab.`/`notion.`). The allowlist had drifted from the tracker registry — a recurring class of bug that bites every new tracker.

## Fix

Make the tracker registry the single source of truth instead of just patching in `ado.`:

- Drop the hardcoded tracker prefixes from `recognizedConfigPrefixes`.
- Derive them at runtime from `tracker.List()` via a new `allRecognizedConfigPrefixes()` helper, used by both `isRecognizedConfigKey` and `suggestConfigKey`.

This eliminates the drift class — the next registered tracker is covered automatically. **Bonus:** a genuine near-miss like `add.org` now suggests `ado.org` instead of the unhelpful `ai.org`.

Also adds the missing tracker namespaces (`gitlab`, `ado`, `notion`) to the `Common namespaces` help text.

## Behavior

```
$ bd config set ado.org MyOrg
Set ado.org = MyOrg                                    # no warning

$ bd config set add.org Oops
Warning: "add.org" is not a recognized config key. Did you mean "ado.org"?   # still catches typos, better suggestion
Set add.org = Oops
```

## Testing

- `TestIsRecognizedConfigKey` extended with `ado.org`/`ado.project` plus `github`/`linear`/`gitlab`/`notion` keys (guards the prefixes removed from the static list).
- New `TestTrackerConfigPrefixesRecognized` asserts **every** registered tracker's namespace is recognized — directly guards the drift class.
- `TestSuggestConfigKey` gains the `add.org -> ado.org` case.
- Verified end-to-end against an embedded workspace; `go build`/`gofmt`/`go vet` clean; `go test -run Config ./cmd/bd/` green.

Fixes #4427

🤖 Generated with [Claude Code](https://claude.com/claude-code)