### PR TITLE
fix(migrate): compute repo fingerprint from -C target, not process cwd

### DIFF
--- a/cmd/bd/migrate.go
+++ b/cmd/bd/migrate.go
@@ -92,11 +92,15 @@ BD_ALLOW_REMOTE_MIGRATE=1 remains supported for scripted/CI use.
 			return HandleError("failed to load config: %v", err)
 		}
 
-		return handleDoltMetadataUpdate(cfg, dryRun)
+		return handleDoltMetadataUpdate(cfg, beadsDir, dryRun)
 	},
 }
 
-func handleDoltMetadataUpdate(cfg *configfile.Config, dryRun bool) error {
+// handleDoltMetadataUpdate handles version metadata updates for Dolt backends.
+// beadsDir is the resolved .beads directory (honoring -C); repo-derived metadata
+// is computed from it rather than the process cwd so `bd -C <dir> migrate`
+// fingerprints the target repo, not the caller's (GH#4361).
+func handleDoltMetadataUpdate(cfg *configfile.Config, beadsDir string, dryRun bool) error {
 	ctx := rootCtx
 	store := getStore()
 	if store == nil {
@@ -207,7 +211,7 @@ func handleDoltMetadataUpdate(cfg *configfile.Config, dryRun bool) error {
 
 	// Set repo_id if missing (non-fatal — may fail in non-git environments)
 	if needsRepoID {
-		computed, err := beads.ComputeRepoID()
+		computed, err := beads.ComputeRepoIDForPath(beadsDir)
 		if err != nil {
 			if !jsonOutput {
 				fmt.Fprintf(os.Stderr, "Warning: could not compute repo_id: %v\n", err)
@@ -228,7 +232,7 @@ func handleDoltMetadataUpdate(cfg *configfile.Config, dryRun bool) error {
 
 	// Set clone_id if missing (non-fatal — may fail in non-git environments)
 	if needsCloneID {
-		computed, err := beads.GetCloneID()
+		computed, err := beads.GetCloneIDForPath(beadsDir)
 		if err != nil {
 			if !jsonOutput {
 				fmt.Fprintf(os.Stderr, "Warning: could not compute clone_id: %v\n", err)
@@ -304,7 +308,11 @@ func handleUpdateRepoID(dryRun bool, autoYes bool) error {
 		return HandleErrorWithHint("no beads database found", diagHint())
 	}
 
-	newRepoID, err := beads.ComputeRepoID()
+	// Compute new repo ID from the resolved .beads directory (honoring -C),
+	// not the process cwd. Otherwise `bd -C <dir> migrate --update-repo-id`
+	// stamps the target DB with the caller repo's fingerprint and the bad
+	// value propagates to every clone on the next sync (GH#4361).
+	newRepoID, err := beads.ComputeRepoIDForPath(beadsDir)
 	if err != nil {
 		if jsonOutput {
 			if jerr := outputJSON(map[string]interface{}{

--- a/cmd/bd/migrate_embedded_test.go
+++ b/cmd/bd/migrate_embedded_test.go
@@ -26,6 +26,20 @@ func bdMigrate(t *testing.T, bd, dir string, args ...string) string {
 	return stdout.String()
 }
 
+// extractNewRepoID pulls the fingerprint from the "  New: <hash>" line of
+// `bd migrate --update-repo-id --dry-run` output.
+func extractNewRepoID(t *testing.T, out string) string {
+	t.Helper()
+	for _, line := range strings.Split(out, "\n") {
+		if strings.Contains(line, "New:") {
+			fields := strings.Fields(line)
+			return fields[len(fields)-1]
+		}
+	}
+	t.Fatalf("no 'New:' fingerprint line in migrate output:\n%s", out)
+	return ""
+}
+
 // bdMigrateFail runs "bd migrate" expecting failure.
 func bdMigrateFail(t *testing.T, bd, dir string, args ...string) string {
 	t.Helper()
@@ -110,6 +124,43 @@ func TestEmbeddedMigrate(t *testing.T) {
 		out := bdMigrate(t, bd, dir, "--update-repo-id", "--yes")
 		if !strings.Contains(out, "Repository ID") && !strings.Contains(out, "repo_id") {
 			t.Errorf("expected repo ID update message: %s", out)
+		}
+	})
+
+	// Regression for GH#4361: `bd -C <dir> migrate --update-repo-id` must
+	// derive the new fingerprint from the -C target, not the process cwd.
+	// Otherwise it stamps the target DB with the caller repo's fingerprint,
+	// which then propagates to every clone via the synced metadata table.
+	t.Run("migrate_update_repo_id_honors_C", func(t *testing.T) {
+		dirA, _, _ := bdInit(t, bd, "--prefix", "ca")
+		dirB, _, _ := bdInit(t, bd, "--prefix", "cb")
+
+		runDryRun := func(cwd, target, home string) string {
+			cmd := exec.Command(bd, "-C", target, "migrate", "--update-repo-id", "--dry-run")
+			cmd.Dir = cwd
+			cmd.Env = bdEnv(home)
+			stdout, stderr, err := runCommandBuffers(t, cmd)
+			if err != nil {
+				t.Fatalf("bd -C %s migrate --update-repo-id --dry-run (cwd=%s) failed: %v\nstdout:\n%s\nstderr:\n%s",
+					target, cwd, err, stdout.String(), stderr.String())
+			}
+			return extractNewRepoID(t, stdout.String())
+		}
+
+		// Each repo's fingerprint computed from its own directory.
+		wantA := runDryRun(dirA, dirA, dirA)
+		wantB := runDryRun(dirB, dirB, dirB)
+		if wantA == wantB {
+			t.Fatalf("test setup invalid: repos A and B produced the same fingerprint %q", wantA)
+		}
+
+		// Run from inside A but target B via -C. Must report B's fingerprint.
+		got := runDryRun(dirA, dirB, dirB)
+		if got == wantA {
+			t.Fatalf("bd -C <B> reported A's fingerprint %q — computed from cwd, not -C target (GH#4361)", wantA)
+		}
+		if got != wantB {
+			t.Errorf("bd -C <B> migrate --update-repo-id from cwd A reported %q, want B's fingerprint %q", got, wantB)
 		}
 	})
 


### PR DESCRIPTION
## Problem

`bd -C <dir> migrate --update-repo-id` derives the **new** repository fingerprint from the process working directory, not the `-C` target. `-C` doesn't `chdir` (it resolves `BEADS_DIR`), but `beads.ComputeRepoID()` shells out to git in the caller's cwd. So:

- Run from a **different repo**, it stamps the target DB with the *caller's* fingerprint.
- Run from a **non-git cwd**, it fails outright with `not a git repository` despite a valid `-C` target.

Because `repo_id` lives in the **synced metadata table**, the bad value propagates to every clone on the next push and their `bd doctor` goes red with a misleading "database belongs to different repository". `bd doctor` already computes this correctly (`ComputeRepoIDForPath(beadsDir)`); migrate disagreed, which is how the reporter caught it.

Fixes #4361.

## Repro (before)

Two repos A and B, each with its own beads DB. From **inside A**:

```
$ bd -C /tmp/repoB migrate --update-repo-id --dry-run   # New: 1814c071  (A's!)
$ bd -C /tmp/repoA migrate --update-repo-id --dry-run   # New: 1814c071  (A's)
$ cd /tmp && bd -C /tmp/repoA migrate --update-repo-id --dry-run
Error: failed to compute repository ID: not a git repository
```

Both `-C` targets report the **same** fingerprint (the cwd's).

## Fix

Compute repo-derived metadata from the resolved `.beads` directory (which already honors `-C`) instead of the process cwd, mirroring `bd doctor`:

- `handleUpdateRepoID` → `ComputeRepoIDForPath(beadsDir)`
- `handleDoltMetadataUpdate` repo_id/clone_id backfill → `ComputeRepoIDForPath(beadsDir)` / `GetCloneIDForPath(beadsDir)` (same defect on the plain `bd migrate` path; threaded `beadsDir` in)

## After

```
# from inside A:
bd -C /tmp/repoB ... --dry-run   # New: 09b30495  (B's)
bd -C /tmp/repoA ... --dry-run   # New: 1814c071  (A's)
# from /tmp (no git repo): both targets report their own fingerprint, no error
```

The `-C` values now match the per-repo control values (`cd` in, no `-C`) exactly.

## Test

Adds `TestEmbeddedMigrate/migrate_update_repo_id_honors_C`: two repos, asserts `bd -C <B>` from cwd A reports B's fingerprint, not A's. Verified it **fails** on the pre-fix code (`reported A's fingerprint … computed from cwd, not -C target`) and passes with the fix. `gofmt`/`go vet` clean; pure-Go (`CGO_ENABLED=0`) compile gate passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)