### PR TITLE
fix(import): honor imported dependency created_by

### DIFF
--- a/cmd/bd/import_from_jsonl_test.go
+++ b/cmd/bd/import_from_jsonl_test.go
@@ -442,6 +442,40 @@ func TestImportFromLocalJSONL(t *testing.T) {
 		}
 	})
 
+	t.Run("preserves dependency created_by from JSONL import", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		dbPath := filepath.Join(tmpDir, "dolt")
+		store := newTestStore(t, dbPath)
+
+		jsonlContent := `{"id":"test-dep-target","title":"Dependency target","status":"open","priority":2,"issue_type":"task","created_at":"2025-01-01T00:00:00Z","updated_at":"2025-01-01T00:00:00Z"}
+{"id":"test-dep-source","title":"Dependency source","status":"open","priority":2,"issue_type":"task","dependencies":[{"depends_on_id":"test-dep-target","type":"blocks","created_by":"someone.else","created_at":"2025-01-01T00:00:00Z"}],"created_at":"2025-01-01T00:00:00Z","updated_at":"2025-01-01T00:00:00Z"}
+`
+		jsonlPath := filepath.Join(tmpDir, "issues.jsonl")
+		if err := os.WriteFile(jsonlPath, []byte(jsonlContent), 0644); err != nil {
+			t.Fatalf("Failed to write JSONL file: %v", err)
+		}
+
+		ctx := context.Background()
+		count, err := importFromLocalJSONL(ctx, store, jsonlPath)
+		if err != nil {
+			t.Fatalf("importFromLocalJSONL failed: %v", err)
+		}
+		if count != 2 {
+			t.Fatalf("imported count = %d, want 2", count)
+		}
+
+		deps, err := store.GetDependencyRecords(ctx, "test-dep-source")
+		if err != nil {
+			t.Fatalf("GetDependencyRecords(test-dep-source): %v", err)
+		}
+		if len(deps) != 1 {
+			t.Fatalf("deps = %#v, want one dependency", deps)
+		}
+		if deps[0].CreatedBy != "someone.else" {
+			t.Fatalf("dependency created_by = %q, want someone.else", deps[0].CreatedBy)
+		}
+	})
+
 	t.Run("skips tombstone entries during import", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		dbPath := filepath.Join(tmpDir, "dolt")

--- a/internal/storage/issueops/create.go
+++ b/internal/storage/issueops/create.go
@@ -715,12 +715,13 @@ func PersistDependenciesWithOptionsResult(ctx context.Context, tx *sql.Tx, issue
 			// Deterministic id from (issue_id, target) keeps bulk-imported edges
 			// merge-safe across clones — two clones importing the same JSONL get the
 			// same primary key, not two random UUIDs that collide on uk_dep_* (#4259).
+			createdBy := dependencyCreatedBy(dep, actor)
 			//nolint:gosec // G201: depTable is one of two hardcoded constants; target column from DepTargetKind.Column()
 			sqlResult, err := tx.ExecContext(ctx, fmt.Sprintf(`
 					INSERT INTO %s (id, issue_id, %s, type, created_by, created_at)
 					VALUES (?, ?, ?, ?, ?, ?)
 					ON DUPLICATE KEY UPDATE type = type
-				`, depTable, kind.Column()), depid.New(dep.IssueID, dep.DependsOnID), dep.IssueID, dep.DependsOnID, dep.Type, actor, createdAt)
+				`, depTable, kind.Column()), depid.New(dep.IssueID, dep.DependsOnID), dep.IssueID, dep.DependsOnID, dep.Type, createdBy, createdAt)
 			if err != nil {
 				return result, fmt.Errorf("failed to insert dependency %s -> %s: %w", dep.IssueID, dep.DependsOnID, err)
 			}
@@ -734,6 +735,16 @@ func PersistDependenciesWithOptionsResult(ctx context.Context, tx *sql.Tx, issue
 		}
 	}
 	return result, nil
+}
+
+// dependencyCreatedBy returns the author stamped on a dependency edge.
+// Import/restore paths populate dep.CreatedBy from JSONL; interactive
+// creation leaves it empty and falls back to the current actor.
+func dependencyCreatedBy(dep *types.Dependency, actor string) string {
+	if dep != nil && dep.CreatedBy != "" {
+		return dep.CreatedBy
+	}
+	return actor
 }
 
 func recordSkippedDependency(opts storage.BatchCreateOptions, dep *types.Dependency, reason string) {

--- a/internal/storage/issueops/create_test.go
+++ b/internal/storage/issueops/create_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/steveyegge/beads/internal/storage"
+	"github.com/steveyegge/beads/internal/storage/depid"
 	"github.com/steveyegge/beads/internal/types"
 )
 
@@ -147,6 +148,88 @@ func TestFilterCreateIssuesMixedBucketDependenciesSkipsWhenConfigured(t *testing
 	if len(skipped) != 1 || !strings.Contains(skipped[0], "test-regular-source -> test-wisp-target") ||
 		!strings.Contains(skipped[0], "cross-bucket dependency") {
 		t.Fatalf("skipped = %#v, want cross-bucket dependency detail", skipped)
+	}
+}
+
+func TestPersistDependenciesHonorsImportedCreatedBy(t *testing.T) {
+	ctx := context.Background()
+	db, mock, tx := beginMockTx(t)
+	defer db.Close()
+
+	target := &types.Issue{ID: "target", IssueType: types.TypeTask}
+	source := &types.Issue{
+		ID:        "source",
+		IssueType: types.TypeTask,
+		Dependencies: []*types.Dependency{{
+			DependsOnID: "target",
+			Type:        types.DepRelated,
+			CreatedBy:   "someone.else",
+		}},
+	}
+
+	mock.ExpectQuery("SELECT 1 FROM wisps WHERE id = \\? LIMIT 1").
+		WithArgs("target").
+		WillReturnError(sql.ErrNoRows)
+	mock.ExpectQuery("SELECT 1 FROM issues WHERE id = \\?").
+		WithArgs("target").
+		WillReturnRows(sqlmock.NewRows([]string{"1"}).AddRow(1))
+	mock.ExpectExec("INSERT INTO dependencies").
+		WithArgs(depid.New("source", "target"), "source", "target", types.DepRelated, "someone.else", sqlmock.AnyArg()).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	result, err := PersistDependenciesWithOptionsResult(ctx, tx, []*types.Issue{target, source}, "current.user", storage.BatchCreateOptions{})
+	if err != nil {
+		t.Fatalf("PersistDependenciesWithOptionsResult error = %v, want nil", err)
+	}
+	if !result.ChangedTables["dependencies"] {
+		t.Fatalf("ChangedTables = %#v, want dependencies changed", result.ChangedTables)
+	}
+
+	mock.ExpectRollback()
+	if err := tx.Rollback(); err != nil {
+		t.Fatalf("rollback: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestPersistDependenciesDefaultsCreatedByToActor(t *testing.T) {
+	ctx := context.Background()
+	db, mock, tx := beginMockTx(t)
+	defer db.Close()
+
+	target := &types.Issue{ID: "target", IssueType: types.TypeTask}
+	source := &types.Issue{
+		ID:        "source",
+		IssueType: types.TypeTask,
+		Dependencies: []*types.Dependency{{
+			DependsOnID: "target",
+			Type:        types.DepRelated,
+		}},
+	}
+
+	mock.ExpectQuery("SELECT 1 FROM wisps WHERE id = \\? LIMIT 1").
+		WithArgs("target").
+		WillReturnError(sql.ErrNoRows)
+	mock.ExpectQuery("SELECT 1 FROM issues WHERE id = \\?").
+		WithArgs("target").
+		WillReturnRows(sqlmock.NewRows([]string{"1"}).AddRow(1))
+	mock.ExpectExec("INSERT INTO dependencies").
+		WithArgs(depid.New("source", "target"), "source", "target", types.DepRelated, "current.user", sqlmock.AnyArg()).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	_, err := PersistDependenciesWithOptionsResult(ctx, tx, []*types.Issue{target, source}, "current.user", storage.BatchCreateOptions{})
+	if err != nil {
+		t.Fatalf("PersistDependenciesWithOptionsResult error = %v, want nil", err)
+	}
+
+	mock.ExpectRollback()
+	if err := tx.Rollback(); err != nil {
+		t.Fatalf("rollback: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
 	}
 }
 


### PR DESCRIPTION
## What

JSONL import now honors `created_by` on imported dependency edges when the dependency object includes it.

## Why

JSONL import already parsed dependency `created_by`, but `PersistDependencies` stamped new dependency rows with the current actor. This caused imported dependency attribution to be lost. Dependencies without imported `created_by` still fall back to the current actor, preserving interactive creation behavior.

## Verification

- `go test ./internal/storage/issueops -run 'TestPersistDependencies(HonorsImportedCreatedBy|DefaultsCreatedByToActor)'`
- `CGO_ENABLED=1 go test -tags gms_pure_go ./cmd/bd -run 'TestImportFromLocalJSONL/preserves_dependency_created_by_from_JSONL_import'`