### PR TITLE
feat(cmd/bd): support bd update proxied-server mode

### DIFF
--- a/cmd/bd/init.go
+++ b/cmd/bd/init.go
@@ -120,12 +120,12 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 		if os.Getenv("BEADS_DOLT_PROXIED_SERVER") == "1" {
 			initProxiedServer = true
 		}
-		if initProxiedServer {
-			// Proxied-server mode has no local Dolt init lifecycle yet. When it
-			// is implemented, that path must mark any local .dolt/ it creates or
-			// acknowledges with doltserver.MarkDoltDirCompatible.
-			FatalError("--proxied-server is not yet implemented")
-		}
+		// if initProxiedServer {
+		// 	// Proxied-server mode has no local Dolt init lifecycle yet. When it
+		// 	// is implemented, that path must mark any local .dolt/ it creates or
+		// 	// acknowledges with doltserver.MarkDoltDirCompatible.
+		// 	FatalError("--proxied-server is not yet implemented")
+		// }
 		if initProxiedServer && initServerMode {
 			FatalError("--server and --proxied-server are mutually exclusive")
 		}

--- a/cmd/bd/init.go
+++ b/cmd/bd/init.go
@@ -120,12 +120,12 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 		if os.Getenv("BEADS_DOLT_PROXIED_SERVER") == "1" {
 			initProxiedServer = true
 		}
-		// if initProxiedServer {
-		// 	// Proxied-server mode has no local Dolt init lifecycle yet. When it
-		// 	// is implemented, that path must mark any local .dolt/ it creates or
-		// 	// acknowledges with doltserver.MarkDoltDirCompatible.
-		// 	FatalError("--proxied-server is not yet implemented")
-		// }
+		if initProxiedServer {
+			// Proxied-server mode has no local Dolt init lifecycle yet. When it
+			// is implemented, that path must mark any local .dolt/ it creates or
+			// acknowledges with doltserver.MarkDoltDirCompatible.
+			FatalError("--proxied-server is not yet implemented")
+		}
 		if initProxiedServer && initServerMode {
 			FatalError("--server and --proxied-server are mutually exclusive")
 		}

--- a/cmd/bd/proxied_integration_helpers_test.go
+++ b/cmd/bd/proxied_integration_helpers_test.go
@@ -152,6 +152,53 @@ func bdProxiedRunBuffers(t *testing.T, bd, dir string, args ...string) (string, 
 	return stdout.String(), stderr.String(), err
 }
 
+func bdProxiedUpdate(t *testing.T, bd, dir string, args ...string) []*types.Issue {
+	t.Helper()
+	fullArgs := append([]string{"update", "--json"}, args...)
+	out, err := bdProxiedRun(t, bd, dir, fullArgs...)
+	if err != nil {
+		t.Fatalf("bd update %s failed: %v\n%s", strings.Join(args, " "), err, out)
+	}
+	s := string(out)
+	start := strings.Index(s, "[")
+	if start < 0 {
+		t.Fatalf("no JSON array found in update output:\n%s", s)
+	}
+	var issues []*types.Issue
+	if err := json.Unmarshal([]byte(s[start:]), &issues); err != nil {
+		t.Fatalf("failed to parse update JSON: %v\nraw: %s", err, s[start:])
+	}
+	if len(issues) == 0 {
+		t.Fatalf("update returned empty JSON array:\n%s", s)
+	}
+	return issues
+}
+
+func bdProxiedUpdateOne(t *testing.T, bd, dir string, args ...string) *types.Issue {
+	t.Helper()
+	issues := bdProxiedUpdate(t, bd, dir, args...)
+	if len(issues) != 1 {
+		t.Fatalf("expected 1 issue in update output, got %d", len(issues))
+	}
+	return issues[0]
+}
+
+func bdProxiedUpdateRaw(t *testing.T, bd, dir string, args ...string) (string, string, error) {
+	t.Helper()
+	fullArgs := append([]string{"update"}, args...)
+	return bdProxiedRunBuffers(t, bd, dir, fullArgs...)
+}
+
+func bdProxiedUpdateFail(t *testing.T, bd, dir string, args ...string) string {
+	t.Helper()
+	stdout, stderr, err := bdProxiedUpdateRaw(t, bd, dir, args...)
+	if err == nil {
+		t.Fatalf("bd update %s should have failed; got:\nstdout:\n%s\nstderr:\n%s",
+			strings.Join(args, " "), stdout, stderr)
+	}
+	return stdout + stderr
+}
+
 func bdProxiedShow(t *testing.T, bd, dir, id string) *types.Issue {
 	t.Helper()
 	out, err := bdProxiedRun(t, bd, dir, "show", id, "--json")
@@ -169,7 +216,28 @@ type proxiedProject struct {
 	prefix    string
 }
 
+func bdProxiedInitWithHooks(t *testing.T, bd, prefix string, hooks map[string]string, extraInitArgs ...string) proxiedProject {
+	t.Helper()
+	p := bdProxiedInitInternal(t, bd, prefix, false, extraInitArgs...)
+	hooksDir := filepath.Join(p.beadsDir, "hooks")
+	if err := os.MkdirAll(hooksDir, 0o755); err != nil {
+		t.Fatalf("mkdir hooks dir: %v", err)
+	}
+	for name, body := range hooks {
+		hookPath := filepath.Join(hooksDir, name)
+		if err := os.WriteFile(hookPath, []byte(body), 0o755); err != nil {
+			t.Fatalf("write hook %s: %v", name, err)
+		}
+	}
+	return p
+}
+
 func bdProxiedInit(t *testing.T, bd, prefix string, extraInitArgs ...string) proxiedProject {
+	t.Helper()
+	return bdProxiedInitInternal(t, bd, prefix, true, extraInitArgs...)
+}
+
+func bdProxiedInitInternal(t *testing.T, bd, prefix string, skipHooks bool, extraInitArgs ...string) proxiedProject {
 	t.Helper()
 
 	dir := t.TempDir()
@@ -183,15 +251,18 @@ func bdProxiedInit(t *testing.T, bd, prefix string, extraInitArgs ...string) pro
 	})
 	shutdownProxyOnInterrupt(t, proxyRoot)
 
-	args := append([]string{
+	baseArgs := []string{
 		"init",
 		"--proxied-server",
 		"--quiet",
 		"--prefix", prefix,
 		"--non-interactive",
-		"--skip-hooks",
 		"--skip-agents",
-	}, extraInitArgs...)
+	}
+	if skipHooks {
+		baseArgs = append(baseArgs, "--skip-hooks")
+	}
+	args := append(baseArgs, extraInitArgs...)
 
 	cmd := exec.Command(bd, args...)
 	cmd.Dir = dir

--- a/cmd/bd/update.go
+++ b/cmd/bd/update.go
@@ -29,6 +29,11 @@ create, update, show, or close operation).`,
 	Run: func(cmd *cobra.Command, args []string) {
 		CheckReadonly("update")
 
+		if usesProxiedServer() {
+			runUpdateProxiedServer(cmd, rootCtx, args)
+			return
+		}
+
 		// If no IDs provided, use last touched issue
 		if len(args) == 0 {
 			lastTouched := GetLastTouchedID()

--- a/cmd/bd/update_input.go
+++ b/cmd/bd/update_input.go
@@ -1,0 +1,269 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/steveyegge/beads/internal/timeparsing"
+	"github.com/steveyegge/beads/internal/types"
+	"github.com/steveyegge/beads/internal/ui"
+	"github.com/steveyegge/beads/internal/utils"
+	"github.com/steveyegge/beads/internal/validation"
+)
+
+type updateInput struct {
+	fields           map[string]any
+	addLabels        []string
+	removeLabels     []string
+	setLabels        *[]string
+	reparent         *string
+	claim            bool
+	appendNotes      string
+	hasAppendNotes   bool
+	setMetadata      []string
+	unsetMetadata    []string
+	mergeMetadataIn  json.RawMessage
+	clearDeferStatus bool
+}
+
+func gatherUpdateInput(ctx context.Context, cmd *cobra.Command) *updateInput {
+	in := &updateInput{fields: map[string]any{}}
+
+	if cmd.Flags().Changed("status") {
+		status, _ := cmd.Flags().GetString("status")
+		validateUpdateStatus(ctx, status)
+		in.fields["status"] = status
+		if status == "closed" {
+			session, _ := cmd.Flags().GetString("session")
+			if session == "" {
+				session = os.Getenv("CLAUDE_SESSION_ID")
+			}
+			if session != "" {
+				in.fields["closed_by_session"] = session
+			}
+		}
+	}
+	if cmd.Flags().Changed("priority") {
+		priorityStr, _ := cmd.Flags().GetString("priority")
+		priority, err := validation.ValidatePriority(priorityStr)
+		if err != nil {
+			FatalErrorRespectJSON("%v", err)
+		}
+		in.fields["priority"] = priority
+	}
+	if cmd.Flags().Changed("title") {
+		title, _ := cmd.Flags().GetString("title")
+		title = strings.TrimSpace(title)
+		if title == "" {
+			FatalErrorRespectJSON("title cannot be empty")
+		}
+		in.fields["title"] = title
+	}
+	if cmd.Flags().Changed("assignee") {
+		assignee, _ := cmd.Flags().GetString("assignee")
+		in.fields["assignee"] = assignee
+	}
+	if description, changed := getDescriptionFlag(cmd); changed {
+		if err := validateDescriptionUpdate(cmd, description, changed); err != nil {
+			FatalErrorRespectJSON("%v", err)
+		}
+		in.fields["description"] = description
+	}
+	if design, changed := getDesignFlag(cmd); changed {
+		in.fields["design"] = design
+	}
+	if cmd.Flags().Changed("notes") && cmd.Flags().Changed("append-notes") {
+		FatalErrorRespectJSON("cannot specify both --notes and --append-notes")
+	}
+	if cmd.Flags().Changed("notes") {
+		notes, _ := cmd.Flags().GetString("notes")
+		in.fields["notes"] = notes
+	}
+	if cmd.Flags().Changed("append-notes") {
+		in.appendNotes, _ = cmd.Flags().GetString("append-notes")
+		in.hasAppendNotes = true
+	}
+	if cmd.Flags().Changed("acceptance") || cmd.Flags().Changed("acceptance-criteria") {
+		var ac string
+		if cmd.Flags().Changed("acceptance") {
+			ac, _ = cmd.Flags().GetString("acceptance")
+		} else {
+			ac, _ = cmd.Flags().GetString("acceptance-criteria")
+		}
+		in.fields["acceptance_criteria"] = ac
+	}
+	if cmd.Flags().Changed("external-ref") {
+		externalRef, _ := cmd.Flags().GetString("external-ref")
+		if externalRef == "" {
+			in.fields["external_ref"] = nil
+		} else {
+			in.fields["external_ref"] = externalRef
+		}
+	}
+	if cmd.Flags().Changed("spec-id") {
+		specID, _ := cmd.Flags().GetString("spec-id")
+		in.fields["spec_id"] = specID
+	}
+	if cmd.Flags().Changed("estimate") {
+		estimate, _ := cmd.Flags().GetInt("estimate")
+		if estimate < 0 {
+			FatalErrorRespectJSON("estimate must be a non-negative number of minutes")
+		}
+		in.fields["estimated_minutes"] = estimate
+	}
+	if cmd.Flags().Changed("type") {
+		issueType, _ := cmd.Flags().GetString("type")
+		in.fields["issue_type"] = utils.NormalizeIssueType(issueType)
+	}
+	if cmd.Flags().Changed("add-label") {
+		in.addLabels, _ = cmd.Flags().GetStringSlice("add-label")
+	}
+	if cmd.Flags().Changed("remove-label") {
+		in.removeLabels, _ = cmd.Flags().GetStringSlice("remove-label")
+	}
+	if cmd.Flags().Changed("set-labels") {
+		labels, _ := cmd.Flags().GetStringSlice("set-labels")
+		in.setLabels = &labels
+	}
+	if cmd.Flags().Changed("parent") {
+		parent, _ := cmd.Flags().GetString("parent")
+		in.reparent = &parent
+	}
+	if cmd.Flags().Changed("await-id") {
+		awaitID, _ := cmd.Flags().GetString("await-id")
+		in.fields["await_id"] = awaitID
+	}
+	if cmd.Flags().Changed("due") {
+		dueStr, _ := cmd.Flags().GetString("due")
+		if dueStr == "" {
+			in.fields["due_at"] = nil
+		} else {
+			t, err := timeparsing.ParseRelativeTime(dueStr, time.Now())
+			if err != nil {
+				FatalErrorRespectJSON("invalid --due format %q. Examples: +6h, tomorrow, next monday, 2025-01-15", dueStr)
+			}
+			in.fields["due_at"] = t
+		}
+	}
+	if cmd.Flags().Changed("defer") {
+		deferStr, _ := cmd.Flags().GetString("defer")
+		jsonOut, _ := cmd.Flags().GetBool("json")
+		if deferStr == "" {
+			in.fields["defer_until"] = nil
+			if _, ok := in.fields["status"]; !ok {
+				in.clearDeferStatus = true
+			}
+		} else {
+			t, err := timeparsing.ParseRelativeTime(deferStr, time.Now())
+			if err != nil {
+				FatalErrorRespectJSON("invalid --defer format %q. Examples: +1h, tomorrow, next monday, 2025-01-15", deferStr)
+			}
+			inPast := t.Before(time.Now())
+			if inPast && !jsonOut {
+				fmt.Fprintf(os.Stderr, "%s Defer date %q is in the past. Issue will appear in bd ready immediately.\n",
+					ui.RenderWarn("!"), t.Format("2006-01-02 15:04"))
+				fmt.Fprintf(os.Stderr, "  Did you mean a future date? Use --defer=+1h or --defer=tomorrow\n")
+			}
+			in.fields["defer_until"] = t
+			if _, ok := in.fields["status"]; !ok && !inPast {
+				in.fields["status"] = string(types.StatusDeferred)
+			}
+		}
+	}
+	ephemeralChanged := cmd.Flags().Changed("ephemeral")
+	persistentChanged := cmd.Flags().Changed("persistent")
+	noHistoryChanged := cmd.Flags().Changed("no-history")
+	historyChanged := cmd.Flags().Changed("history")
+	if ephemeralChanged && persistentChanged {
+		FatalErrorRespectJSON("cannot specify both --ephemeral and --persistent flags")
+	}
+	if noHistoryChanged && ephemeralChanged {
+		FatalErrorRespectJSON("cannot specify both --no-history and --ephemeral flags")
+	}
+	if noHistoryChanged && historyChanged {
+		FatalErrorRespectJSON("cannot specify both --no-history and --history flags")
+	}
+	if ephemeralChanged {
+		in.fields["wisp"] = true
+	}
+	if persistentChanged {
+		in.fields["wisp"] = false
+	}
+	if noHistoryChanged {
+		in.fields["no_history"] = true
+	}
+	if historyChanged {
+		in.fields["no_history"] = false
+	}
+	if cmd.Flags().Changed("metadata") {
+		metadataValue, _ := cmd.Flags().GetString("metadata")
+		var metadataJSON string
+		if strings.HasPrefix(metadataValue, "@") {
+			filePath := metadataValue[1:]
+			data, err := os.ReadFile(filePath) //#nosec G304 -- user-supplied path via @file syntax
+			if err != nil {
+				FatalErrorRespectJSON("failed to read metadata file %s: %v", filePath, err)
+			}
+			metadataJSON = string(data)
+		} else {
+			metadataJSON = metadataValue
+		}
+		if !json.Valid([]byte(metadataJSON)) {
+			FatalErrorRespectJSON("invalid JSON in --metadata: must be valid JSON")
+		}
+		in.mergeMetadataIn = json.RawMessage(metadataJSON)
+	}
+	setMetadataFlags, _ := cmd.Flags().GetStringArray("set-metadata")
+	unsetMetadataFlags, _ := cmd.Flags().GetStringArray("unset-metadata")
+	if (len(setMetadataFlags) > 0 || len(unsetMetadataFlags) > 0) && cmd.Flags().Changed("metadata") {
+		FatalErrorRespectJSON("cannot combine --metadata with --set-metadata or --unset-metadata")
+	}
+	in.setMetadata = setMetadataFlags
+	in.unsetMetadata = unsetMetadataFlags
+
+	in.claim, _ = cmd.Flags().GetBool("claim")
+	return in
+}
+
+func validateUpdateStatus(ctx context.Context, status string) {
+	if uowProvider == nil {
+		FatalError("proxied-server UOW provider not initialized")
+	}
+	uw, err := uowProvider.NewUOW(ctx)
+	if err != nil {
+		FatalError("open unit of work: %v", err)
+	}
+	names, err := uw.ConfigUseCase().ListAllStatusNames(ctx)
+	uw.Close(ctx)
+	if err != nil {
+		FatalErrorRespectJSON("read status set: %v", err)
+	}
+	for _, name := range names {
+		if name == status {
+			return
+		}
+	}
+	FatalErrorRespectJSON("invalid status %q (allowed: %s)", status, strings.Join(names, ", "))
+}
+
+func isUpdateInputNoop(in *updateInput) bool {
+	if in.claim {
+		return false
+	}
+	if len(in.fields) > 0 || in.hasAppendNotes || in.setLabels != nil || in.reparent != nil {
+		return false
+	}
+	if len(in.addLabels) > 0 || len(in.removeLabels) > 0 {
+		return false
+	}
+	if len(in.mergeMetadataIn) > 0 || len(in.setMetadata) > 0 || len(in.unsetMetadata) > 0 {
+		return false
+	}
+	return true
+}

--- a/cmd/bd/update_proxied_integration_test.go
+++ b/cmd/bd/update_proxied_integration_test.go
@@ -1,0 +1,960 @@
+//go:build cgo
+
+package main
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/steveyegge/beads/internal/types"
+)
+
+func TestProxiedServerUpdate(t *testing.T) {
+	requireProxiedServerEnv(t)
+	bd := buildEmbeddedBD(t)
+
+	t.Run("no_ids_errors", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "un1")
+		out := bdProxiedUpdateFail(t, bd, p.dir)
+		if !strings.Contains(out, "no issue ID provided") {
+			t.Errorf("expected no-id error, got: %s", out)
+		}
+	})
+
+	t.Run("no_flags_is_noop_message", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "un2")
+		issue := bdProxiedCreate(t, bd, p.dir, "Seed")
+		out, err := bdProxiedRun(t, bd, p.dir, "update", issue.ID)
+		if err != nil {
+			t.Fatalf("update with no flags should succeed, got: %v\n%s", err, out)
+		}
+		if !strings.Contains(string(out), "No updates specified") {
+			t.Errorf("expected 'No updates specified', got: %s", out)
+		}
+	})
+
+	t.Run("field_updates_round_trip", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "uf")
+		issue := bdProxiedCreate(t, bd, p.dir, "Original")
+		updated := bdProxiedUpdateOne(t, bd, p.dir, issue.ID,
+			"--title", "Renamed",
+			"-p", "0",
+			"--assignee", "alice",
+			"--description", "new body")
+		if updated.Title != "Renamed" {
+			t.Errorf("title: got %q, want %q", updated.Title, "Renamed")
+		}
+		if updated.Priority != 0 {
+			t.Errorf("priority: got %d, want 0", updated.Priority)
+		}
+		if updated.Assignee != "alice" {
+			t.Errorf("assignee: got %q, want %q", updated.Assignee, "alice")
+		}
+		if updated.Description != "new body" {
+			t.Errorf("description: got %q, want %q", updated.Description, "new body")
+		}
+	})
+
+	t.Run("claim_sets_assignee_and_in_progress", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "uc")
+		issue := bdProxiedCreate(t, bd, p.dir, "To claim")
+		updated := bdProxiedUpdateOne(t, bd, p.dir, issue.ID, "--claim")
+		if updated.Status != types.StatusInProgress {
+			t.Errorf("status: got %q, want in_progress", updated.Status)
+		}
+		if updated.Assignee == "" {
+			t.Errorf("assignee should be set after --claim, got empty")
+		}
+	})
+
+	t.Run("claim_then_other_user_conflicts", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "ucc")
+		issue := bdProxiedCreate(t, bd, p.dir, "Contested")
+		bdProxiedUpdateOne(t, bd, p.dir, issue.ID, "--claim", "--assignee", "alice")
+
+		out := bdProxiedUpdateFail(t, bd, p.dir, issue.ID, "--claim", "--assignee", "bob")
+		if !strings.Contains(out, "already claimed") {
+			t.Errorf("expected 'already claimed' error, got: %s", out)
+		}
+	})
+
+	t.Run("add_remove_labels", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "ul")
+		issue := bdProxiedCreate(t, bd, p.dir, "Labeled")
+		bdProxiedUpdateOne(t, bd, p.dir, issue.ID, "--add-label", "perf,tech-debt")
+		bdProxiedUpdateOne(t, bd, p.dir, issue.ID, "--remove-label", "perf")
+
+		db := openProxiedDB(t, p)
+		labels := getProxiedLabels(t, db, issue.ID)
+		if len(labels) != 1 || labels[0] != "tech-debt" {
+			t.Errorf("labels after add+remove: got %v, want [tech-debt]", labels)
+		}
+	})
+
+	t.Run("set_labels_diffs", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "usl")
+		issue := bdProxiedCreate(t, bd, p.dir, "Set labels")
+		bdProxiedUpdateOne(t, bd, p.dir, issue.ID, "--add-label", "a,b,c")
+		bdProxiedUpdateOne(t, bd, p.dir, issue.ID, "--set-labels", "b,d")
+
+		db := openProxiedDB(t, p)
+		labels := getProxiedLabels(t, db, issue.ID)
+		got := strings.Join(labels, ",")
+		if got != "b,d" && got != "d,b" {
+			t.Errorf("labels after --set-labels: got %v, want [b d] (any order)", labels)
+		}
+	})
+
+	t.Run("reparent_replaces_existing_parent", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "urp")
+		oldParent := bdProxiedCreate(t, bd, p.dir, "Old parent", "-t", "epic")
+		newParent := bdProxiedCreate(t, bd, p.dir, "New parent", "-t", "epic")
+		child := bdProxiedCreate(t, bd, p.dir, "Child", "--parent", oldParent.ID)
+
+		bdProxiedUpdateOne(t, bd, p.dir, child.ID, "--parent", newParent.ID)
+
+		db := openProxiedDB(t, p)
+		assertProxiedDepExistsWithType(t, db, child.ID, newParent.ID, string(types.DepParentChild))
+		var oldRowCount int
+		if err := db.QueryRowContext(context.Background(),
+			"SELECT COUNT(*) FROM dependencies WHERE issue_id = ? AND depends_on_issue_id = ?",
+			child.ID, oldParent.ID).Scan(&oldRowCount); err != nil {
+			t.Fatalf("count old parent dep: %v", err)
+		}
+		if oldRowCount != 0 {
+			t.Errorf("old parent dep should be gone, got %d rows", oldRowCount)
+		}
+	})
+
+	t.Run("reparent_empty_unparents", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "uup")
+		parent := bdProxiedCreate(t, bd, p.dir, "Parent", "-t", "epic")
+		child := bdProxiedCreate(t, bd, p.dir, "Child", "--parent", parent.ID)
+
+		bdProxiedUpdateOne(t, bd, p.dir, child.ID, "--parent", "")
+
+		db := openProxiedDB(t, p)
+		var count int
+		if err := db.QueryRowContext(context.Background(),
+			"SELECT COUNT(*) FROM dependencies WHERE issue_id = ? AND type = 'parent-child'",
+			child.ID).Scan(&count); err != nil {
+			t.Fatalf("count parent dep: %v", err)
+		}
+		if count != 0 {
+			t.Errorf("expected no parent-child dep after unparent, got %d", count)
+		}
+	})
+
+	t.Run("close_unblocks_dependents", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "ucb")
+		blocker := bdProxiedCreate(t, bd, p.dir, "Blocker")
+		blocked := bdProxiedCreate(t, bd, p.dir, "Dependent", "--deps", "depends-on:"+blocker.ID)
+
+		db := openProxiedDB(t, p)
+		if !readIsBlocked(t, db, blocked.ID) {
+			t.Fatalf("dependent should be blocked before blocker closes")
+		}
+
+		bdProxiedUpdateOne(t, bd, p.dir, blocker.ID, "-s", "closed")
+
+		if readIsBlocked(t, db, blocked.ID) {
+			t.Errorf("dependent should be unblocked after blocker closes")
+		}
+	})
+
+	t.Run("invalid_status_rejected", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "uis")
+		issue := bdProxiedCreate(t, bd, p.dir, "Status test")
+		out := bdProxiedUpdateFail(t, bd, p.dir, issue.ID, "-s", "not-a-real-status")
+		if !strings.Contains(out, "invalid status") {
+			t.Errorf("expected 'invalid status' error, got: %s", out)
+		}
+	})
+
+	t.Run("multiple_ids_update_all", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "umu")
+		a := bdProxiedCreate(t, bd, p.dir, "A")
+		b := bdProxiedCreate(t, bd, p.dir, "B")
+		issues := bdProxiedUpdate(t, bd, p.dir, a.ID, b.ID, "--assignee", "team")
+		if len(issues) != 2 {
+			t.Fatalf("expected 2 updated issues, got %d", len(issues))
+		}
+		for _, iss := range issues {
+			if iss.Assignee != "team" {
+				t.Errorf("%s assignee: got %q, want team", iss.ID, iss.Assignee)
+			}
+		}
+	})
+
+	t.Run("defer_clear_restores_open", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "udf")
+		issue := bdProxiedCreate(t, bd, p.dir, "Deferred")
+
+		deferred := bdProxiedUpdateOne(t, bd, p.dir, issue.ID, "--defer", "+1d")
+		if deferred.Status != types.StatusDeferred {
+			t.Fatalf("expected deferred status, got %q", deferred.Status)
+		}
+
+		restored := bdProxiedUpdateOne(t, bd, p.dir, issue.ID, "--defer", "")
+		if restored.Status != types.StatusOpen {
+			t.Errorf("--defer='' should restore open, got %q", restored.Status)
+		}
+	})
+
+	t.Run("update_type", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "ut")
+		issue := bdProxiedCreate(t, bd, p.dir, "Type test")
+		updated := bdProxiedUpdateOne(t, bd, p.dir, issue.ID, "--type", "bug")
+		if updated.IssueType != types.TypeBug {
+			t.Errorf("type: got %q, want %q", updated.IssueType, types.TypeBug)
+		}
+	})
+
+	t.Run("update_type_invalid_rejected", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "uti")
+		issue := bdProxiedCreate(t, bd, p.dir, "Bad type test")
+		out := bdProxiedUpdateFail(t, bd, p.dir, issue.ID, "--type", "not-a-real-type")
+		if !strings.Contains(strings.ToLower(out), "invalid") &&
+			!strings.Contains(strings.ToLower(out), "unknown") {
+			t.Errorf("expected invalid/unknown type error, got: %s", out)
+		}
+	})
+
+	t.Run("update_type_custom", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "utc")
+		issue := bdProxiedCreate(t, bd, p.dir, "Custom type test")
+
+		db := openProxiedDB(t, p)
+		if _, err := db.ExecContext(context.Background(),
+			"INSERT INTO config (`key`, value) VALUES ('types.custom', ?) "+
+				"ON DUPLICATE KEY UPDATE value = VALUES(value)",
+			"molecule"); err != nil {
+			t.Fatalf("seed types.custom: %v", err)
+		}
+
+		updated := bdProxiedUpdateOne(t, bd, p.dir, issue.ID, "--type", "molecule")
+		if string(updated.IssueType) != "molecule" {
+			t.Errorf("type: got %q, want %q", updated.IssueType, "molecule")
+		}
+	})
+
+	t.Run("description_from_file", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "ubf")
+		issue := bdProxiedCreate(t, bd, p.dir, "Body file test")
+
+		bodyPath := filepath.Join(p.dir, "body.txt")
+		if err := os.WriteFile(bodyPath, []byte("from file"), 0o600); err != nil {
+			t.Fatalf("write body file: %v", err)
+		}
+
+		updated := bdProxiedUpdateOne(t, bd, p.dir, issue.ID, "--body-file", bodyPath)
+		if updated.Description != "from file" {
+			t.Errorf("description: got %q, want %q", updated.Description, "from file")
+		}
+	})
+
+	t.Run("description_body_alias", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "uba")
+		issue := bdProxiedCreate(t, bd, p.dir, "Body alias test")
+		updated := bdProxiedUpdateOne(t, bd, p.dir, issue.ID, "--body", "via body flag")
+		if updated.Description != "via body flag" {
+			t.Errorf("description: got %q, want %q", updated.Description, "via body flag")
+		}
+	})
+
+	t.Run("update_creates_dolt_commit", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "udc")
+		issue := bdProxiedCreate(t, bd, p.dir, "Dolt commit test")
+
+		db := openProxiedDB(t, p)
+		var before string
+		if err := db.QueryRowContext(context.Background(),
+			"SELECT HASHOF('HEAD')").Scan(&before); err != nil {
+			t.Fatalf("read HEAD before: %v", err)
+		}
+
+		bdProxiedUpdateOne(t, bd, p.dir, issue.ID, "--title", "Renamed for commit")
+
+		var after string
+		if err := db.QueryRowContext(context.Background(),
+			"SELECT HASHOF('HEAD')").Scan(&after); err != nil {
+			t.Fatalf("read HEAD after: %v", err)
+		}
+		if after == before {
+			t.Errorf("HEAD did not advance: before=%s after=%s (uw.Commit should produce a Dolt commit)",
+				before, after)
+		}
+	})
+
+	t.Run("reparent_from_orphan", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "urpo")
+		parent := bdProxiedCreate(t, bd, p.dir, "New parent", "-t", "epic")
+		orphan := bdProxiedCreate(t, bd, p.dir, "Orphan child")
+
+		bdProxiedUpdateOne(t, bd, p.dir, orphan.ID, "--parent", parent.ID)
+
+		db := openProxiedDB(t, p)
+		assertProxiedDepExistsWithType(t, db, orphan.ID, parent.ID, string(types.DepParentChild))
+	})
+
+	t.Run("close_with_session_flag", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "ucws")
+		issue := bdProxiedCreate(t, bd, p.dir, "Close-with-session flag test")
+
+		bdProxiedUpdateOne(t, bd, p.dir, issue.ID, "-s", "closed", "--session", "sess-flag")
+
+		db := openProxiedDB(t, p)
+		var got sql.NullString
+		if err := db.QueryRowContext(context.Background(),
+			"SELECT closed_by_session FROM issues WHERE id = ?", issue.ID).Scan(&got); err != nil {
+			t.Fatalf("read closed_by_session: %v", err)
+		}
+		if !got.Valid || got.String != "sess-flag" {
+			t.Errorf("closed_by_session: got %q (valid=%v), want %q", got.String, got.Valid, "sess-flag")
+		}
+	})
+
+	t.Run("close_with_session_env", func(t *testing.T) {
+		t.Setenv("CLAUDE_SESSION_ID", "sess-env")
+		p := bdProxiedInit(t, bd, "ucwe")
+		issue := bdProxiedCreate(t, bd, p.dir, "Close-with-session env test")
+
+		bdProxiedUpdateOne(t, bd, p.dir, issue.ID, "-s", "closed")
+
+		db := openProxiedDB(t, p)
+		var got sql.NullString
+		if err := db.QueryRowContext(context.Background(),
+			"SELECT closed_by_session FROM issues WHERE id = ?", issue.ID).Scan(&got); err != nil {
+			t.Fatalf("read closed_by_session: %v", err)
+		}
+		if !got.Valid || got.String != "sess-env" {
+			t.Errorf("closed_by_session: got %q (valid=%v), want %q (from CLAUDE_SESSION_ID)",
+				got.String, got.Valid, "sess-env")
+		}
+	})
+
+	t.Run("ephemeral_persistent_conflict", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "uepc")
+		issue := bdProxiedCreate(t, bd, p.dir, "Ephemeral/persistent conflict test")
+		out := bdProxiedUpdateFail(t, bd, p.dir, issue.ID, "--ephemeral", "--persistent")
+		if !strings.Contains(out, "cannot specify both --ephemeral and --persistent") {
+			t.Errorf("expected conflict error, got: %s", out)
+		}
+	})
+
+	t.Run("update_history", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "uh")
+		issue := bdProxiedCreate(t, bd, p.dir, "History test")
+
+		db := openProxiedDB(t, p)
+		bdProxiedUpdateOne(t, bd, p.dir, issue.ID, "--no-history")
+		bdProxiedUpdateOne(t, bd, p.dir, issue.ID, "--history")
+
+		var noHistory int
+		if err := db.QueryRowContext(context.Background(),
+			"SELECT no_history FROM issues WHERE id = ?", issue.ID).Scan(&noHistory); err != nil {
+			t.Fatalf("read no_history: %v", err)
+		}
+		if noHistory != 0 {
+			t.Errorf("no_history: got %d, want 0 after --history", noHistory)
+		}
+	})
+
+	t.Run("update_no_history", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "unh")
+		issue := bdProxiedCreate(t, bd, p.dir, "No history test")
+
+		db := openProxiedDB(t, p)
+		bdProxiedUpdateOne(t, bd, p.dir, issue.ID, "--no-history")
+
+		var noHistory int
+		if err := db.QueryRowContext(context.Background(),
+			"SELECT no_history FROM issues WHERE id = ?", issue.ID).Scan(&noHistory); err != nil {
+			t.Fatalf("read no_history: %v", err)
+		}
+		if noHistory != 1 {
+			t.Errorf("no_history: got %d, want 1 after --no-history", noHistory)
+		}
+	})
+
+	t.Run("update_persistent", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "ups")
+		issue := bdProxiedCreate(t, bd, p.dir, "Persistent test")
+
+		db := openProxiedDB(t, p)
+		bdProxiedUpdateOne(t, bd, p.dir, issue.ID, "--ephemeral")
+		bdProxiedUpdateOne(t, bd, p.dir, issue.ID, "--persistent")
+
+		var ephemeral int
+		if err := db.QueryRowContext(context.Background(),
+			"SELECT ephemeral FROM issues WHERE id = ?", issue.ID).Scan(&ephemeral); err != nil {
+			t.Fatalf("read ephemeral: %v", err)
+		}
+		if ephemeral != 0 {
+			t.Errorf("ephemeral: got %d, want 0 after --persistent", ephemeral)
+		}
+	})
+
+	t.Run("update_ephemeral", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "uep")
+		issue := bdProxiedCreate(t, bd, p.dir, "Ephemeral test")
+
+		db := openProxiedDB(t, p)
+		bdProxiedUpdateOne(t, bd, p.dir, issue.ID, "--ephemeral")
+
+		var ephemeral int
+		if err := db.QueryRowContext(context.Background(),
+			"SELECT ephemeral FROM issues WHERE id = ?", issue.ID).Scan(&ephemeral); err != nil {
+			t.Fatalf("read ephemeral: %v", err)
+		}
+		if ephemeral != 1 {
+			t.Errorf("ephemeral: got %d, want 1 after --ephemeral", ephemeral)
+		}
+	})
+
+	t.Run("reopen_reblocks_dependents", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "urb")
+		blocker := bdProxiedCreate(t, bd, p.dir, "Reopen blocker")
+		blocked := bdProxiedCreate(t, bd, p.dir, "Reopen dependent", "--deps", "depends-on:"+blocker.ID)
+
+		db := openProxiedDB(t, p)
+		if !readIsBlocked(t, db, blocked.ID) {
+			t.Fatalf("dependent should be blocked before close")
+		}
+
+		bdProxiedUpdateOne(t, bd, p.dir, blocker.ID, "-s", "closed")
+		if readIsBlocked(t, db, blocked.ID) {
+			t.Fatalf("dependent should be unblocked after blocker closes")
+		}
+
+		bdProxiedUpdateOne(t, bd, p.dir, blocker.ID, "-s", "open")
+		if !readIsBlocked(t, db, blocked.ID) {
+			t.Errorf("dependent should be re-blocked after blocker reopens")
+		}
+	})
+
+	t.Run("update_nonexistent_id", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "unx")
+		out := bdProxiedUpdateFail(t, bd, p.dir, "unx-doesnotexist", "--title", "x")
+		if !strings.Contains(strings.ToLower(out), "not found") &&
+			!strings.Contains(strings.ToLower(out), "no rows") &&
+			!strings.Contains(strings.ToLower(out), "error") {
+			t.Errorf("expected a not-found / error message, got: %s", out)
+		}
+	})
+
+	t.Run("update_invalid_priority", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "uip")
+		issue := bdProxiedCreate(t, bd, p.dir, "Invalid priority test")
+		out := bdProxiedUpdateFail(t, bd, p.dir, issue.ID, "-p", "99")
+		if !strings.Contains(out, "invalid priority") {
+			t.Errorf("expected 'invalid priority' error, got: %s", out)
+		}
+	})
+
+	t.Run("update_metadata_invalid_json", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "umij")
+		issue := bdProxiedCreate(t, bd, p.dir, "Metadata invalid JSON test")
+		out := bdProxiedUpdateFail(t, bd, p.dir, issue.ID, "--metadata", "not json at all")
+		if !strings.Contains(out, "invalid JSON") {
+			t.Errorf("expected 'invalid JSON' error, got: %s", out)
+		}
+	})
+
+	t.Run("update_metadata_at_file", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "umaf")
+		issue := bdProxiedCreate(t, bd, p.dir, "Metadata @file test")
+
+		metaPath := filepath.Join(p.dir, "meta.json")
+		if err := os.WriteFile(metaPath, []byte(`{"src":"file","n":7}`), 0o600); err != nil {
+			t.Fatalf("write metadata file: %v", err)
+		}
+
+		updated := bdProxiedUpdateOne(t, bd, p.dir, issue.ID, "--metadata", "@"+metaPath)
+		var got map[string]any
+		if err := json.Unmarshal(updated.Metadata, &got); err != nil {
+			t.Fatalf("parse metadata %q: %v", updated.Metadata, err)
+		}
+		if got["src"] != "file" {
+			t.Errorf("metadata[src]: got %v, want %q", got["src"], "file")
+		}
+		if got["n"] != float64(7) {
+			t.Errorf("metadata[n]: got %v, want 7", got["n"])
+		}
+	})
+
+	t.Run("metadata_and_set_conflict", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "umsc")
+		issue := bdProxiedCreate(t, bd, p.dir, "Metadata conflict test")
+		out := bdProxiedUpdateFail(t, bd, p.dir, issue.ID,
+			"--metadata", `{"a":1}`,
+			"--set-metadata", "x=y")
+		if !strings.Contains(out, "cannot combine --metadata with --set-metadata") {
+			t.Errorf("expected conflict error, got: %s", out)
+		}
+	})
+
+	t.Run("update_unset_metadata", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "uum")
+		issue := bdProxiedCreate(t, bd, p.dir, "Unset metadata test")
+		bdProxiedUpdateOne(t, bd, p.dir, issue.ID, "--metadata", `{"keep":"yes","drop":"yes"}`)
+
+		updated := bdProxiedUpdateOne(t, bd, p.dir, issue.ID, "--unset-metadata", "drop")
+
+		var got map[string]any
+		if err := json.Unmarshal(updated.Metadata, &got); err != nil {
+			t.Fatalf("parse metadata %q: %v", updated.Metadata, err)
+		}
+		if _, present := got["drop"]; present {
+			t.Errorf("metadata[drop]: still present after --unset-metadata, got %v", got)
+		}
+		if got["keep"] != "yes" {
+			t.Errorf("metadata[keep]: got %v, want %q", got["keep"], "yes")
+		}
+	})
+
+	t.Run("update_set_metadata", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "usm")
+		issue := bdProxiedCreate(t, bd, p.dir, "Set metadata test")
+		updated := bdProxiedUpdateOne(t, bd, p.dir, issue.ID,
+			"--set-metadata", "tier=gold",
+			"--set-metadata", "score=99")
+
+		var got map[string]any
+		if err := json.Unmarshal(updated.Metadata, &got); err != nil {
+			t.Fatalf("parse metadata %q: %v", updated.Metadata, err)
+		}
+		if got["tier"] != "gold" {
+			t.Errorf("metadata[tier]: got %v, want %q", got["tier"], "gold")
+		}
+		if got["score"] != float64(99) {
+			t.Errorf("metadata[score]: got %v, want 99 (number-typed via toJSONValue)", got["score"])
+		}
+	})
+
+	t.Run("update_metadata_merge", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "umm")
+		issue := bdProxiedCreate(t, bd, p.dir, "Metadata merge test")
+		bdProxiedUpdateOne(t, bd, p.dir, issue.ID, "--metadata", `{"a":1,"b":2}`)
+		merged := bdProxiedUpdateOne(t, bd, p.dir, issue.ID, "--metadata", `{"b":3,"c":4}`)
+
+		var got map[string]any
+		if err := json.Unmarshal(merged.Metadata, &got); err != nil {
+			t.Fatalf("parse metadata %q: %v", merged.Metadata, err)
+		}
+		want := map[string]float64{"a": 1, "b": 3, "c": 4}
+		for k, v := range want {
+			gv, ok := got[k].(float64)
+			if !ok {
+				t.Errorf("metadata[%s]: got %v (%T), want %v", k, got[k], got[k], v)
+				continue
+			}
+			if gv != v {
+				t.Errorf("metadata[%s]: got %v, want %v", k, gv, v)
+			}
+		}
+		if len(got) != 3 {
+			t.Errorf("metadata: got %d keys (%v), want 3 (a,b,c)", len(got), got)
+		}
+	})
+
+	t.Run("update_metadata_json", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "umd")
+		issue := bdProxiedCreate(t, bd, p.dir, "Metadata json test")
+		updated := bdProxiedUpdateOne(t, bd, p.dir, issue.ID, "--metadata", `{"k":"v","n":42}`)
+		var got map[string]any
+		if err := json.Unmarshal(updated.Metadata, &got); err != nil {
+			t.Fatalf("parse metadata %q: %v", updated.Metadata, err)
+		}
+		if got["k"] != "v" {
+			t.Errorf("metadata[k]: got %v, want %q", got["k"], "v")
+		}
+		if got["n"] != float64(42) {
+			t.Errorf("metadata[n]: got %v, want 42", got["n"])
+		}
+	})
+
+	t.Run("update_await_id", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "uaw")
+		issue := bdProxiedCreate(t, bd, p.dir, "Await id test")
+		updated := bdProxiedUpdateOne(t, bd, p.dir, issue.ID, "--await-id", "gate-1")
+		if updated.AwaitID != "gate-1" {
+			t.Errorf("await_id: got %q, want %q", updated.AwaitID, "gate-1")
+		}
+	})
+
+	t.Run("update_defer_clear_preserves_non_deferred_status", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "udfp2")
+		issue := bdProxiedCreate(t, bd, p.dir, "Defer clear preserve test")
+
+		seeded := bdProxiedUpdateOne(t, bd, p.dir, issue.ID, "--defer", "+1d", "-s", "blocked")
+		if seeded.Status != types.StatusBlocked {
+			t.Fatalf("seed: expected blocked, got %q", seeded.Status)
+		}
+
+		cleared := bdProxiedUpdateOne(t, bd, p.dir, issue.ID, "--defer", "")
+		if cleared.Status != types.StatusBlocked {
+			t.Errorf("status: got %q, want %q (defer='' should not flip non-deferred status to open)",
+				cleared.Status, types.StatusBlocked)
+		}
+		if cleared.DeferUntil != nil {
+			t.Errorf("defer_until: expected nil after clear, got %s", cleared.DeferUntil)
+		}
+	})
+
+	t.Run("update_defer_past_date_keeps_status_open", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "udfp")
+		issue := bdProxiedCreate(t, bd, p.dir, "Defer past test")
+
+		updated := bdProxiedUpdateOne(t, bd, p.dir, issue.ID, "--defer", "2020-01-01")
+		if updated.Status != types.StatusOpen {
+			t.Errorf("status: got %q, want %q (past defer date must not flip to deferred)",
+				updated.Status, types.StatusOpen)
+		}
+		if updated.DeferUntil == nil {
+			t.Errorf("defer_until: got nil, want past timestamp set")
+		}
+	})
+
+	t.Run("update_defer_respects_explicit_status", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "udfe")
+		issue := bdProxiedCreate(t, bd, p.dir, "Defer explicit status test")
+
+		updated := bdProxiedUpdateOne(t, bd, p.dir, issue.ID, "--defer", "+1d", "-s", "blocked")
+		if updated.Status != types.StatusBlocked {
+			t.Errorf("status: got %q, want %q (explicit --status must win over defer auto-set)",
+				updated.Status, types.StatusBlocked)
+		}
+		if updated.DeferUntil == nil {
+			t.Errorf("defer_until: got nil, want non-nil (defer still applied)")
+		}
+	})
+
+	t.Run("update_defer_set", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "udfs")
+		issue := bdProxiedCreate(t, bd, p.dir, "Defer set test")
+
+		now := time.Now()
+		set := bdProxiedUpdateOne(t, bd, p.dir, issue.ID, "--defer", "+1d")
+		if set.Status != types.StatusDeferred {
+			t.Errorf("status: got %q, want %q", set.Status, types.StatusDeferred)
+		}
+		if set.DeferUntil == nil {
+			t.Fatalf("defer_until: got nil, want a future time")
+		}
+		if !set.DeferUntil.After(now) {
+			t.Errorf("defer_until: got %s, expected after %s", set.DeferUntil, now)
+		}
+	})
+
+	t.Run("update_due", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "udu")
+		issue := bdProxiedCreate(t, bd, p.dir, "Due test")
+
+		now := time.Now()
+		set := bdProxiedUpdateOne(t, bd, p.dir, issue.ID, "--due", "+6h")
+		if set.DueAt == nil {
+			t.Fatalf("due_at: got nil, want a future time")
+		}
+		if !set.DueAt.After(now) {
+			t.Errorf("due_at: got %s, expected after %s", set.DueAt, now)
+		}
+
+		cleared := bdProxiedUpdateOne(t, bd, p.dir, issue.ID, "--due", "")
+		if cleared.DueAt != nil {
+			t.Errorf("due_at: expected nil after clear, got %s", cleared.DueAt)
+		}
+	})
+
+	t.Run("update_estimate", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "ues")
+		issue := bdProxiedCreate(t, bd, p.dir, "Estimate test")
+
+		updated := bdProxiedUpdateOne(t, bd, p.dir, issue.ID, "--estimate", "60")
+		if updated.EstimatedMinutes == nil {
+			t.Fatalf("estimate: got nil, want 60")
+		}
+		if *updated.EstimatedMinutes != 60 {
+			t.Errorf("estimate: got %d, want 60", *updated.EstimatedMinutes)
+		}
+
+		out := bdProxiedUpdateFail(t, bd, p.dir, issue.ID, "--estimate", "-1")
+		if !strings.Contains(out, "non-negative") {
+			t.Errorf("expected 'non-negative' error, got: %s", out)
+		}
+	})
+
+	t.Run("update_spec_id", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "usp")
+		issue := bdProxiedCreate(t, bd, p.dir, "Spec id test")
+		updated := bdProxiedUpdateOne(t, bd, p.dir, issue.ID, "--spec-id", "spec-42")
+		if updated.SpecID != "spec-42" {
+			t.Errorf("spec_id: got %q, want %q", updated.SpecID, "spec-42")
+		}
+	})
+
+	t.Run("update_external_ref_clear", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "uerc")
+		issue := bdProxiedCreate(t, bd, p.dir, "External ref clear test", "--external-ref", "gh-9")
+		if issue.ExternalRef == nil || *issue.ExternalRef != "gh-9" {
+			t.Fatalf("seed: external_ref not set as expected, got %v", issue.ExternalRef)
+		}
+
+		cleared := bdProxiedUpdateOne(t, bd, p.dir, issue.ID, "--external-ref", "")
+		if cleared.ExternalRef != nil && *cleared.ExternalRef != "" {
+			t.Errorf("external_ref: expected nil or empty after clear, got %q", *cleared.ExternalRef)
+		}
+	})
+
+	t.Run("update_external_ref", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "uer")
+		issue := bdProxiedCreate(t, bd, p.dir, "External ref test")
+		updated := bdProxiedUpdateOne(t, bd, p.dir, issue.ID, "--external-ref", "gh-9")
+		if updated.ExternalRef == nil {
+			t.Fatalf("external_ref: got nil, want pointer to %q", "gh-9")
+		}
+		if *updated.ExternalRef != "gh-9" {
+			t.Errorf("external_ref: got %q, want %q", *updated.ExternalRef, "gh-9")
+		}
+	})
+
+	t.Run("update_acceptance", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "uac")
+		issue := bdProxiedCreate(t, bd, p.dir, "Acceptance test")
+
+		shortFlag := bdProxiedUpdateOne(t, bd, p.dir, issue.ID, "--acceptance", "via short")
+		if shortFlag.AcceptanceCriteria != "via short" {
+			t.Errorf("--acceptance: got %q, want %q", shortFlag.AcceptanceCriteria, "via short")
+		}
+
+		longFlag := bdProxiedUpdateOne(t, bd, p.dir, issue.ID, "--acceptance-criteria", "via long")
+		if longFlag.AcceptanceCriteria != "via long" {
+			t.Errorf("--acceptance-criteria: got %q, want %q", longFlag.AcceptanceCriteria, "via long")
+		}
+	})
+
+	t.Run("notes_and_append_conflict", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "una")
+		issue := bdProxiedCreate(t, bd, p.dir, "Notes conflict test")
+		out := bdProxiedUpdateFail(t, bd, p.dir, issue.ID, "--notes", "a", "--append-notes", "b")
+		if !strings.Contains(out, "cannot specify both --notes and --append-notes") {
+			t.Errorf("expected conflict error, got: %s", out)
+		}
+	})
+
+	t.Run("update_notes", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "un")
+		issue := bdProxiedCreate(t, bd, p.dir, "Notes test", "--notes", "first")
+		updated := bdProxiedUpdateOne(t, bd, p.dir, issue.ID, "--notes", "replacement")
+		if updated.Notes != "replacement" {
+			t.Errorf("notes: got %q, want %q", updated.Notes, "replacement")
+		}
+	})
+
+	t.Run("update_design", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "ud")
+		issue := bdProxiedCreate(t, bd, p.dir, "Design test")
+
+		flagUpdated := bdProxiedUpdateOne(t, bd, p.dir, issue.ID, "--design", "via flag")
+		if flagUpdated.Design != "via flag" {
+			t.Errorf("--design: got %q, want %q", flagUpdated.Design, "via flag")
+		}
+
+		designFile := filepath.Join(p.dir, "design.txt")
+		if err := os.WriteFile(designFile, []byte("via file"), 0o600); err != nil {
+			t.Fatalf("write design file: %v", err)
+		}
+		fileUpdated := bdProxiedUpdateOne(t, bd, p.dir, issue.ID, "--design-file", designFile)
+		if fileUpdated.Design != "via file" {
+			t.Errorf("--design-file: got %q, want %q", fileUpdated.Design, "via file")
+		}
+	})
+
+	t.Run("update_type_custom_table", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "utt")
+		issue := bdProxiedCreate(t, bd, p.dir, "Custom type table test")
+
+		db := openProxiedDB(t, p)
+		if _, err := db.ExecContext(context.Background(),
+			"INSERT INTO custom_types (name) VALUES (?)", "swarm"); err != nil {
+			t.Fatalf("seed custom_types row: %v", err)
+		}
+
+		updated := bdProxiedUpdateOne(t, bd, p.dir, issue.ID, "--type", "swarm")
+		if string(updated.IssueType) != "swarm" {
+			t.Errorf("type: got %q, want %q", updated.IssueType, "swarm")
+		}
+	})
+
+	t.Run("append_notes_concatenates", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "uan")
+		issue := bdProxiedCreate(t, bd, p.dir, "Notes", "--notes", "first")
+		updated := bdProxiedUpdateOne(t, bd, p.dir, issue.ID, "--append-notes", "second")
+		want := "first\nsecond"
+		if updated.Notes != want {
+			t.Errorf("notes: got %q, want %q", updated.Notes, want)
+		}
+	})
+}
+
+func TestProxiedServerUpdateHooks(t *testing.T) {
+	requireProxiedServerEnv(t)
+	bd := buildEmbeddedBD(t)
+
+	t.Run("on_update_fires_on_field_change", func(t *testing.T) {
+		dir := t.TempDir()
+		markerPath := filepath.Join(dir, "on_update_marker")
+		hookBody := "#!/bin/sh\necho \"$1\" > " + markerPath + "\n"
+
+		p := bdProxiedInitWithHooks(t, bd, "uph", map[string]string{
+			"on_update": hookBody,
+		})
+		issue := bdProxiedCreate(t, bd, p.dir, "Hook test")
+
+		_ = os.Remove(markerPath)
+		stdout, stderr, runErr := bdProxiedUpdateRaw(t, bd, p.dir, issue.ID, "--title", "After update")
+		if runErr != nil {
+			t.Fatalf("bd update failed: %v\nstdout:\n%s\nstderr:\n%s", runErr, stdout, stderr)
+		}
+
+		gotID, err := waitForMarker(markerPath, 5*time.Second)
+		if err != nil {
+			t.Fatalf("on_update hook did not fire within timeout: %v\nstdout:\n%s\nstderr:\n%s",
+				err, stdout, stderr)
+		}
+		if strings.TrimSpace(gotID) != issue.ID {
+			t.Errorf("on_update marker: got %q, want issue ID %q", strings.TrimSpace(gotID), issue.ID)
+		}
+	})
+
+	t.Run("on_close_fires_when_status_transitions_to_closed", func(t *testing.T) {
+		dir := t.TempDir()
+		markerPath := filepath.Join(dir, "on_close_marker")
+		hookBody := "#!/bin/sh\necho \"$1\" > " + markerPath + "\n"
+
+		p := bdProxiedInitWithHooks(t, bd, "uphc", map[string]string{
+			"on_close": hookBody,
+		})
+		issue := bdProxiedCreate(t, bd, p.dir, "Hook close test")
+
+		_ = os.Remove(markerPath)
+		bdProxiedUpdateOne(t, bd, p.dir, issue.ID, "-s", "closed")
+
+		gotID, err := waitForMarker(markerPath, 5*time.Second)
+		if err != nil {
+			t.Fatalf("on_close hook did not fire within timeout: %v", err)
+		}
+		if strings.TrimSpace(gotID) != issue.ID {
+			t.Errorf("on_close marker: got %q, want issue ID %q", strings.TrimSpace(gotID), issue.ID)
+		}
+	})
+}
+
+func waitForMarker(path string, timeout time.Duration) (string, error) {
+	deadline := time.Now().Add(timeout)
+	for {
+		data, err := os.ReadFile(path)
+		if err == nil {
+			return string(data), nil
+		}
+		if !os.IsNotExist(err) {
+			return "", err
+		}
+		if time.Now().After(deadline) {
+			return "", fmt.Errorf("marker %s not found after %s", path, timeout)
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+}
+
+func TestProxiedServerUpdateConcurrentClaim(t *testing.T) {
+	requireProxiedServerEnv(t)
+	bd := buildEmbeddedBD(t)
+
+	p := bdProxiedInit(t, bd, "ucc")
+	issue := bdProxiedCreate(t, bd, p.dir, "Concurrent claim contest")
+
+	const n = 5
+	type result struct {
+		actor    string
+		exitErr  error
+		stderr   string
+		combined string
+	}
+	results := make([]result, n)
+
+	var wg sync.WaitGroup
+	for i := 0; i < n; i++ {
+		i := i
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			actorName := fmt.Sprintf("alice-%d", i)
+			stdout, stderr, err := bdProxiedUpdateRaw(t, bd, p.dir,
+				issue.ID, "--claim", "--actor", actorName)
+			results[i] = result{
+				actor:    actorName,
+				exitErr:  err,
+				stderr:   stderr,
+				combined: stdout + stderr,
+			}
+		}()
+	}
+	wg.Wait()
+
+	var winners []string
+	var conflicts int
+	for _, r := range results {
+		if r.exitErr == nil {
+			winners = append(winners, r.actor)
+			continue
+		}
+		isClaimedConflict := strings.Contains(r.combined, "already claimed")
+		isSerializationFailure := strings.Contains(r.combined, "serialization failure") ||
+			strings.Contains(r.combined, "Error 1213")
+		if isClaimedConflict || isSerializationFailure {
+			conflicts++
+			continue
+		}
+		t.Errorf("unexpected failure for %s: err=%v combined=%s", r.actor, r.exitErr, r.combined)
+	}
+
+	if len(winners) != 1 {
+		t.Errorf("expected exactly one winner, got %d: %v", len(winners), winners)
+	}
+	if conflicts != n-1 {
+		t.Errorf("expected %d conflicts (claim or serialization), got %d", n-1, conflicts)
+	}
+
+	db := openProxiedDB(t, p)
+	var assignee string
+	var status string
+	if err := db.QueryRowContext(context.Background(),
+		"SELECT assignee, status FROM issues WHERE id = ?", issue.ID).Scan(&assignee, &status); err != nil {
+		t.Fatalf("read final issue state: %v", err)
+	}
+	if status != "in_progress" {
+		t.Errorf("final status: got %q, want in_progress", status)
+	}
+	if len(winners) == 1 && assignee != winners[0] {
+		t.Errorf("final assignee: got %q, want %q (the actor that won the CAS)", assignee, winners[0])
+	}
+}
+
+func readIsBlocked(t *testing.T, db *sql.DB, id string) bool {
+	t.Helper()
+	var v int
+	if err := db.QueryRowContext(context.Background(),
+		"SELECT is_blocked FROM issues WHERE id = ?", id).Scan(&v); err != nil {
+		t.Fatalf("read is_blocked for %s: %v", id, err)
+	}
+	return v != 0
+}

--- a/cmd/bd/update_proxied_integration_test.go
+++ b/cmd/bd/update_proxied_integration_test.go
@@ -875,6 +875,205 @@ func waitForMarker(path string, timeout time.Duration) (string, error) {
 	}
 }
 
+func TestProxiedServerUpdateWisp(t *testing.T) {
+	requireProxiedServerEnv(t)
+	bd := buildEmbeddedBD(t)
+
+	t.Run("wisp_field_update_routes_to_wisps_table", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "uwf")
+		wisp := bdProxiedCreate(t, bd, p.dir, "Wisp field test", "--ephemeral")
+		db := openProxiedDB(t, p)
+		assertRowExists(t, db, "wisps", wisp.ID)
+		assertRowAbsent(t, db, "issues", wisp.ID)
+
+		updated := bdProxiedUpdateOne(t, bd, p.dir, wisp.ID, "--title", "wisp renamed", "-p", "0")
+		if updated.Title != "wisp renamed" {
+			t.Errorf("title: got %q, want %q", updated.Title, "wisp renamed")
+		}
+		if updated.Priority != 0 {
+			t.Errorf("priority: got %d, want 0", updated.Priority)
+		}
+
+		var wispTitle string
+		var wispPriority int
+		s := db.QueryRowContext(context.Background(),
+			"SELECT title, priority FROM wisps WHERE id = ?", wisp.ID).Scan(&wispTitle, &wispPriority)
+		if s != nil {
+			t.Fatalf("read wisp row: %v", s)
+		}
+		if wispTitle != "wisp renamed" || wispPriority != 0 {
+			t.Errorf("wisps row: title=%q priority=%d, want (wisp renamed, 0)", wispTitle, wispPriority)
+		}
+	})
+
+	t.Run("wisp_status_close_routes_to_wisps_table", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "uws")
+		wisp := bdProxiedCreate(t, bd, p.dir, "Wisp close test", "--ephemeral")
+
+		bdProxiedUpdateOne(t, bd, p.dir, wisp.ID, "-s", "closed")
+
+		db := openProxiedDB(t, p)
+		var status string
+		if err := db.QueryRowContext(context.Background(),
+			"SELECT status FROM wisps WHERE id = ?", wisp.ID).Scan(&status); err != nil {
+			t.Fatalf("read wisp status: %v", err)
+		}
+		if status != "closed" {
+			t.Errorf("wisp status: got %q, want closed", status)
+		}
+	})
+
+	t.Run("wisp_labels_route_to_wisp_labels", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "uwl")
+		wisp := bdProxiedCreate(t, bd, p.dir, "Wisp labels test", "--ephemeral")
+
+		bdProxiedUpdateOne(t, bd, p.dir, wisp.ID, "--add-label", "alpha,beta")
+
+		db := openProxiedDB(t, p)
+		wispLabels := readLabels(t, db, "wisp_labels", wisp.ID)
+		if got := strings.Join(wispLabels, ","); got != "alpha,beta" && got != "beta,alpha" {
+			t.Errorf("wisp_labels: got %v, want [alpha beta] (any order)", wispLabels)
+		}
+		issueLabels := readLabels(t, db, "labels", wisp.ID)
+		if len(issueLabels) != 0 {
+			t.Errorf("labels table must be empty for wisp ids, got %v", issueLabels)
+		}
+	})
+
+	t.Run("wisp_set_labels_diffs_against_wisp_labels", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "uwsl")
+		wisp := bdProxiedCreate(t, bd, p.dir, "Wisp set-labels test", "--ephemeral")
+
+		bdProxiedUpdateOne(t, bd, p.dir, wisp.ID, "--add-label", "keep,drop")
+		bdProxiedUpdateOne(t, bd, p.dir, wisp.ID, "--set-labels", "keep,add")
+
+		db := openProxiedDB(t, p)
+		got := strings.Join(readLabels(t, db, "wisp_labels", wisp.ID), ",")
+		if got != "add,keep" && got != "keep,add" {
+			t.Errorf("wisp_labels after set-labels: got %s, want [add keep] (any order)", got)
+		}
+	})
+
+	t.Run("wisp_claim_routes_to_wisps_table", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "uwc")
+		wisp := bdProxiedCreate(t, bd, p.dir, "Wisp claim test", "--ephemeral")
+
+		updated := bdProxiedUpdateOne(t, bd, p.dir, wisp.ID, "--claim", "--actor", "alice")
+		if updated.Assignee != "alice" {
+			t.Errorf("assignee: got %q, want alice", updated.Assignee)
+		}
+		if updated.Status != types.StatusInProgress {
+			t.Errorf("status: got %q, want in_progress", updated.Status)
+		}
+
+		db := openProxiedDB(t, p)
+		var assignee, status string
+		if err := db.QueryRowContext(context.Background(),
+			"SELECT assignee, status FROM wisps WHERE id = ?", wisp.ID).Scan(&assignee, &status); err != nil {
+			t.Fatalf("read wisps row: %v", err)
+		}
+		if assignee != "alice" || status != "in_progress" {
+			t.Errorf("wisps row: assignee=%q status=%q, want (alice, in_progress)", assignee, status)
+		}
+	})
+
+	t.Run("wisp_reparent_routes_to_wisp_dependencies", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "uwr")
+		parent := bdProxiedCreate(t, bd, p.dir, "Wisp parent", "--ephemeral")
+		child := bdProxiedCreate(t, bd, p.dir, "Wisp child", "--ephemeral")
+
+		bdProxiedUpdateOne(t, bd, p.dir, child.ID, "--parent", parent.ID)
+
+		db := openProxiedDB(t, p)
+		var wispCount, permCount int
+		if err := db.QueryRowContext(context.Background(),
+			"SELECT COUNT(*) FROM wisp_dependencies WHERE issue_id = ? AND depends_on_wisp_id = ? AND type = 'parent-child'",
+			child.ID, parent.ID).Scan(&wispCount); err != nil {
+			t.Fatalf("read wisp_dependencies: %v", err)
+		}
+		if wispCount != 1 {
+			t.Errorf("wisp_dependencies: got %d parent-child rows, want 1", wispCount)
+		}
+		if err := db.QueryRowContext(context.Background(),
+			"SELECT COUNT(*) FROM dependencies WHERE issue_id = ?", child.ID).Scan(&permCount); err != nil {
+			t.Fatalf("read dependencies: %v", err)
+		}
+		if permCount != 0 {
+			t.Errorf("dependencies (issues table) must be empty for wisp reparent, got %d", permCount)
+		}
+	})
+
+	t.Run("wisp_metadata_routes_to_wisps_table", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "uwm")
+		wisp := bdProxiedCreate(t, bd, p.dir, "Wisp metadata test", "--ephemeral")
+
+		bdProxiedUpdateOne(t, bd, p.dir, wisp.ID, "--metadata", `{"src":"wisp"}`)
+
+		db := openProxiedDB(t, p)
+		var raw sql.NullString
+		if err := db.QueryRowContext(context.Background(),
+			"SELECT metadata FROM wisps WHERE id = ?", wisp.ID).Scan(&raw); err != nil {
+			t.Fatalf("read wisp metadata: %v", err)
+		}
+		if !raw.Valid {
+			t.Fatalf("wisp metadata: NULL, want JSON")
+		}
+		var got map[string]any
+		if err := json.Unmarshal([]byte(raw.String), &got); err != nil {
+			t.Fatalf("parse wisp metadata %q: %v", raw.String, err)
+		}
+		if got["src"] != "wisp" {
+			t.Errorf("metadata[src]: got %v, want %q", got["src"], "wisp")
+		}
+	})
+}
+
+func assertRowExists(t *testing.T, db *sql.DB, table, id string) {
+	t.Helper()
+	var count int
+	q := "SELECT COUNT(*) FROM " + table + " WHERE id = ?"
+	if err := db.QueryRowContext(context.Background(), q, id).Scan(&count); err != nil {
+		t.Fatalf("read %s for %s: %v", table, id, err)
+	}
+	if count != 1 {
+		t.Fatalf("%s row %s: count=%d, want 1", table, id, count)
+	}
+}
+
+func assertRowAbsent(t *testing.T, db *sql.DB, table, id string) {
+	t.Helper()
+	var count int
+	q := "SELECT COUNT(*) FROM " + table + " WHERE id = ?"
+	if err := db.QueryRowContext(context.Background(), q, id).Scan(&count); err != nil {
+		t.Fatalf("read %s for %s: %v", table, id, err)
+	}
+	if count != 0 {
+		t.Fatalf("%s row %s: count=%d, want 0", table, id, count)
+	}
+}
+
+func readLabels(t *testing.T, db *sql.DB, table, id string) []string {
+	t.Helper()
+	q := "SELECT label FROM " + table + " WHERE issue_id = ? ORDER BY label"
+	rows, err := db.QueryContext(context.Background(), q, id)
+	if err != nil {
+		t.Fatalf("query %s for %s: %v", table, id, err)
+	}
+	defer rows.Close()
+	var out []string
+	for rows.Next() {
+		var l string
+		if err := rows.Scan(&l); err != nil {
+			t.Fatalf("scan %s: %v", table, err)
+		}
+		out = append(out, l)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iter %s: %v", table, err)
+	}
+	return out
+}
+
 func TestProxiedServerUpdateConcurrentClaim(t *testing.T) {
 	requireProxiedServerEnv(t)
 	bd := buildEmbeddedBD(t)

--- a/cmd/bd/update_proxied_server.go
+++ b/cmd/bd/update_proxied_server.go
@@ -1,0 +1,189 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+
+	"github.com/steveyegge/beads/internal/hooks"
+	"github.com/steveyegge/beads/internal/storage"
+	"github.com/steveyegge/beads/internal/storage/domain"
+	"github.com/steveyegge/beads/internal/storage/fs"
+	"github.com/steveyegge/beads/internal/types"
+	"github.com/steveyegge/beads/internal/ui"
+)
+
+func runUpdateProxiedServer(cmd *cobra.Command, ctx context.Context, args []string) {
+	if len(args) == 0 {
+		FatalErrorRespectJSON("no issue ID provided")
+	}
+
+	in := gatherUpdateInput(ctx, cmd)
+	if isUpdateInputNoop(in) {
+		fmt.Println("No updates specified")
+		return
+	}
+
+	jsonOut, _ := cmd.Flags().GetBool("json")
+	var updated []*types.Issue
+	var anyUpdated bool
+
+	for _, id := range args {
+		issue, ok := applyUpdateProxiedOne(ctx, id, in)
+		if !ok {
+			continue
+		}
+		anyUpdated = true
+		if jsonOut {
+			updated = append(updated, issue)
+		} else {
+			fmt.Printf("%s Updated issue: %s\n", ui.RenderPass("✓"), formatFeedbackID(issue.ID, issue.Title))
+		}
+	}
+
+	if jsonOut && len(updated) > 0 {
+		outputJSON(updated)
+	}
+	if !anyUpdated {
+		os.Exit(1)
+	}
+}
+
+func applyUpdateProxiedOne(ctx context.Context, id string, in *updateInput) (*types.Issue, bool) {
+	if uowProvider == nil {
+		FatalError("proxied-server UOW provider not initialized")
+	}
+	uw, err := uowProvider.NewUOW(ctx)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error opening unit of work for %s: %v\n", id, err)
+		return nil, false
+	}
+	defer uw.Close(ctx)
+
+	issueUC := uw.IssueUseCase()
+	current, err := issueUC.GetIssue(ctx, id)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error resolving %s: %v\n", id, err)
+		return nil, false
+	}
+	if current == nil {
+		fmt.Fprintf(os.Stderr, "Issue %s not found\n", id)
+		return nil, false
+	}
+	if err := validateIssueUpdatable(id, current); err != nil {
+		fmt.Fprintf(os.Stderr, "%s\n", err)
+		return nil, false
+	}
+
+	spec, err := buildUpdateSpecForIssue(current, in)
+	if err != nil {
+		FatalErrorRespectJSON("%v", err)
+	}
+
+	updated, err := issueUC.ApplyUpdate(ctx, id, spec, actor)
+	if err != nil {
+		if errors.Is(err, storage.ErrAlreadyClaimed) || errors.Is(err, storage.ErrNotClaimable) {
+			fmt.Fprintf(os.Stderr, "Error claiming %s: %v\n", id, err)
+		} else {
+			fmt.Fprintf(os.Stderr, "Error updating %s: %v\n", id, err)
+		}
+		return nil, false
+	}
+
+	if err := uw.Commit(ctx, fmt.Sprintf("bd: update %s", id)); err != nil && !isDoltNothingToCommit(err) {
+		fmt.Fprintf(os.Stderr, "Error committing %s: %v\n", id, err)
+		return nil, false
+	}
+
+	if err := fireProxiedUpdateHooks(ctx, current, updated); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: %s: %v\n", id, err)
+	}
+	return updated, true
+}
+
+func fireProxiedUpdateHooks(ctx context.Context, before, after *types.Issue) error {
+	if after == nil {
+		return nil
+	}
+	runner, err := proxiedHookRunner(ctx)
+	if err != nil {
+		return fmt.Errorf("hook runner: %w", err)
+	}
+	if runner == nil {
+		return nil
+	}
+	if err := runner.RunSync(hooks.EventUpdate, after); err != nil {
+		return fmt.Errorf("on_update hook: %w", err)
+	}
+	if before != nil &&
+		before.Status != types.StatusClosed &&
+		after.Status == types.StatusClosed {
+		if err := runner.RunSync(hooks.EventClose, after); err != nil {
+			return fmt.Errorf("on_close hook: %w", err)
+		}
+	}
+	return nil
+}
+
+func proxiedHookRunner(ctx context.Context) (*hooks.Runner, error) {
+	if hookRunner != nil {
+		return hookRunner, nil
+	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		return nil, fmt.Errorf("getwd: %w", err)
+	}
+	fsProvider := fs.NewFileSystemProvider(cwd, newBeadsDirTemplates(), newFileSystemAdapters())
+	resolution := fsProvider.BeadsDirFSUseCase().ResolveBeadsDir(ctx)
+	if resolution.BeadsDir == "" {
+		return nil, nil
+	}
+	return hooks.NewRunner(filepath.Join(resolution.BeadsDir, "hooks")), nil
+}
+
+func buildUpdateSpecForIssue(current *types.Issue, in *updateInput) (domain.UpdateSpec, error) {
+	fields := make(map[string]any, len(in.fields))
+	for k, v := range in.fields {
+		fields[k] = v
+	}
+
+	if in.clearDeferStatus && current.Status == types.StatusDeferred {
+		fields["status"] = string(types.StatusOpen)
+	}
+	if in.hasAppendNotes {
+		combined := current.Notes
+		if combined != "" {
+			combined += "\n"
+		}
+		combined += in.appendNotes
+		fields["notes"] = combined
+	}
+	if len(in.mergeMetadataIn) > 0 {
+		merged, err := mergeMetadata(current.Metadata, in.mergeMetadataIn)
+		if err != nil {
+			return domain.UpdateSpec{}, fmt.Errorf("metadata merge failed for %s: %w", current.ID, err)
+		}
+		fields["metadata"] = merged
+	}
+	if len(in.setMetadata) > 0 || len(in.unsetMetadata) > 0 {
+		merged, err := applyMetadataEdits(current.Metadata, in.setMetadata, in.unsetMetadata)
+		if err != nil {
+			return domain.UpdateSpec{}, fmt.Errorf("metadata edit failed for %s: %w", current.ID, err)
+		}
+		fields["metadata"] = merged
+	}
+
+	spec := domain.UpdateSpec{
+		Fields:       fields,
+		Claim:        in.claim,
+		AddLabels:    in.addLabels,
+		RemoveLabels: in.removeLabels,
+		SetLabels:    in.setLabels,
+		Reparent:     in.reparent,
+	}
+	return spec, nil
+}

--- a/cmd/bd/update_proxied_server.go
+++ b/cmd/bd/update_proxied_server.go
@@ -66,13 +66,17 @@ func applyUpdateProxiedOne(ctx context.Context, id string, in *updateInput) (*ty
 
 	issueUC := uw.IssueUseCase()
 	current, err := issueUC.GetIssue(ctx, id)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error resolving %s: %v\n", id, err)
-		return nil, false
-	}
-	if current == nil {
-		fmt.Fprintf(os.Stderr, "Issue %s not found\n", id)
-		return nil, false
+	if err != nil || current == nil {
+		wispCurrent, wispErr := issueUC.GetWisp(ctx, id)
+		if wispErr == nil && wispCurrent != nil {
+			current = wispCurrent
+		} else if err != nil {
+			fmt.Fprintf(os.Stderr, "Error resolving %s: %v\n", id, err)
+			return nil, false
+		} else {
+			fmt.Fprintf(os.Stderr, "Issue %s not found\n", id)
+			return nil, false
+		}
 	}
 	if err := validateIssueUpdatable(id, current); err != nil {
 		fmt.Fprintf(os.Stderr, "%s\n", err)

--- a/internal/storage/domain/config.go
+++ b/internal/storage/domain/config.go
@@ -19,6 +19,7 @@ type ConfigSQLRepository interface {
 	GetAdaptiveIDConfig(ctx context.Context) (AdaptiveIDConfig, error)
 
 	GetCustomStatuses(ctx context.Context) ([]types.CustomStatus, error)
+	ListAllStatusNames(ctx context.Context) ([]string, error)
 	GetInfraTypes(ctx context.Context) (map[string]bool, error)
 }
 
@@ -28,6 +29,7 @@ type ConfigUseCase interface {
 	LoadCreateContext(ctx context.Context) (CreateContext, error)
 
 	GetCustomStatuses(ctx context.Context) ([]types.CustomStatus, error)
+	ListAllStatusNames(ctx context.Context) ([]string, error)
 	GetInfraTypes(ctx context.Context) (map[string]bool, error)
 	IsInfraTypeCtx(ctx context.Context, t types.IssueType) (bool, error)
 }
@@ -102,6 +104,14 @@ func (u *configUseCaseImpl) GetCustomStatuses(ctx context.Context) ([]types.Cust
 	out, err := u.cfgRepo.GetCustomStatuses(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("GetCustomStatuses: %w", err)
+	}
+	return out, nil
+}
+
+func (u *configUseCaseImpl) ListAllStatusNames(ctx context.Context) ([]string, error) {
+	out, err := u.cfgRepo.ListAllStatusNames(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("ListAllStatusNames: %w", err)
 	}
 	return out, nil
 }

--- a/internal/storage/domain/db/config.go
+++ b/internal/storage/domain/db/config.go
@@ -9,6 +9,8 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/steveyegge/beads/internal/config"
+	"github.com/steveyegge/beads/internal/storage/dberrors"
 	"github.com/steveyegge/beads/internal/storage/domain"
 	"github.com/steveyegge/beads/internal/types"
 )
@@ -72,6 +74,49 @@ func (r *configSQLRepositoryImpl) SetConfig(ctx context.Context, key, value stri
 }
 
 func (r *configSQLRepositoryImpl) GetCustomTypes(ctx context.Context) ([]string, error) {
+	fromTable, err := r.readCustomTypesTable(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	fromDB := fromTable
+	if len(fromDB) == 0 {
+		fromConfig, err := r.readCustomTypesConfig(ctx)
+		if err != nil {
+			return nil, err
+		}
+		fromDB = fromConfig
+	}
+
+	return unionWithYAMLCustomTypes(fromDB, config.GetCustomTypesFromYAML()), nil
+}
+
+func (r *configSQLRepositoryImpl) readCustomTypesTable(ctx context.Context) ([]string, error) {
+	rows, err := r.runner.QueryContext(ctx, "SELECT name FROM custom_types ORDER BY name")
+	if err != nil {
+		if dberrors.IsTableNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("db: GetCustomTypes: query custom_types: %w", err)
+	}
+	defer rows.Close()
+	var out []string
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return nil, fmt.Errorf("db: GetCustomTypes: scan custom_types: %w", err)
+		}
+		if name = strings.TrimSpace(name); name != "" {
+			out = append(out, name)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("db: GetCustomTypes: read custom_types: %w", err)
+	}
+	return out, nil
+}
+
+func (r *configSQLRepositoryImpl) readCustomTypesConfig(ctx context.Context) ([]string, error) {
 	value, err := r.GetConfig(ctx, "types.custom")
 	if err != nil {
 		return nil, fmt.Errorf("db: GetCustomTypes: %w", err)
@@ -85,6 +130,31 @@ func (r *configSQLRepositoryImpl) GetCustomTypes(ctx context.Context) ([]string,
 		return parseCustomTypesList(jsonTypes), nil
 	}
 	return parseCustomTypesList(strings.Split(value, ",")), nil
+}
+
+func unionWithYAMLCustomTypes(dbTypes, yamlTypes []string) []string {
+	if len(dbTypes) == 0 && len(yamlTypes) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(dbTypes)+len(yamlTypes))
+	out := make([]string, 0, len(dbTypes)+len(yamlTypes))
+	for _, src := range [][]string{dbTypes, yamlTypes} {
+		for _, t := range src {
+			t = strings.TrimSpace(t)
+			if t == "" {
+				continue
+			}
+			if _, ok := seen[t]; ok {
+				continue
+			}
+			seen[t] = struct{}{}
+			out = append(out, t)
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
 }
 
 func parseCustomTypesList(in []string) []string {
@@ -160,6 +230,25 @@ func (r *configSQLRepositoryImpl) GetCustomStatuses(ctx context.Context) ([]type
 		return nil, fmt.Errorf("db: GetCustomStatuses: read custom_statuses: %w", err)
 	}
 	return result, nil
+}
+
+func (r *configSQLRepositoryImpl) ListAllStatusNames(ctx context.Context) ([]string, error) {
+	builtins := []types.Status{
+		types.StatusOpen, types.StatusInProgress, types.StatusBlocked,
+		types.StatusDeferred, types.StatusClosed, types.StatusPinned, types.StatusHooked,
+	}
+	custom, err := r.GetCustomStatuses(ctx)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]string, 0, len(builtins)+len(custom))
+	for _, s := range builtins {
+		out = append(out, string(s))
+	}
+	for _, c := range custom {
+		out = append(out, c.Name)
+	}
+	return out, nil
 }
 
 func (r *configSQLRepositoryImpl) GetInfraTypes(ctx context.Context) (map[string]bool, error) {

--- a/internal/storage/domain/db/config_test.go
+++ b/internal/storage/domain/db/config_test.go
@@ -31,6 +31,8 @@ func (s *testSuite) TestConfigSQLRepository() {
 		s.Run("CommaSeparated", s.configGetCustomTypesCommaSeparated)
 		s.Run("JSONArray", s.configGetCustomTypesJSONArray)
 		s.Run("TrimsWhitespaceAndSkipsEmpty", s.configGetCustomTypesTrimsAndSkipsEmpty)
+		s.Run("CustomTypesTableTakesPrecedenceOverConfigString", s.configGetCustomTypesTablePrecedence)
+		s.Run("ConfigStringFallbackWhenTableEmpty", s.configGetCustomTypesConfigFallback)
 	})
 	s.Run("GetAllowedPrefixes", func() {
 		s.Run("MissingKeyReturnsEmpty", s.configGetAllowedPrefixesMissing)
@@ -44,6 +46,11 @@ func (s *testSuite) TestConfigSQLRepository() {
 	s.Run("GetCustomStatuses", func() {
 		s.Run("EmptyTableReturnsNil", s.configGetCustomStatusesEmpty)
 		s.Run("ReturnsRowsOrderedByName", s.configGetCustomStatusesRows)
+	})
+	s.Run("ListAllStatusNames", func() {
+		s.Run("BuiltinsOnlyWhenNoCustom", s.configListAllStatusNamesBuiltinsOnly)
+		s.Run("BuiltinsFirstThenCustomAppended", s.configListAllStatusNamesAppendsCustom)
+		s.Run("UseCaseSurfacesRepoResults", s.configUseCaseListAllStatusNames)
 	})
 	s.Run("GetInfraTypes", func() {
 		s.Run("MissingKeyReturnsEmpty", s.configGetInfraTypesMissing)
@@ -267,4 +274,75 @@ func (s *testSuite) configGetAdaptiveIDConfigMalformed() {
 	// All three should fall back to defaults: malformed values are silently
 	// ignored to match the embedded GetAdaptiveConfigTx behavior.
 	s.Equal(domain.DefaultAdaptiveConfig(), got)
+}
+
+func (s *testSuite) configListAllStatusNamesBuiltinsOnly() {
+	_, err := s.Runner().ExecContext(s.Ctx(), "DELETE FROM custom_statuses")
+	s.Require().NoError(err)
+
+	got, err := s.configRepo().ListAllStatusNames(s.Ctx())
+	s.Require().NoError(err)
+	s.Equal([]string{"open", "in_progress", "blocked", "deferred", "closed", "pinned", "hooked"}, got)
+}
+
+func (s *testSuite) configListAllStatusNamesAppendsCustom() {
+	_, err := s.Runner().ExecContext(s.Ctx(), "DELETE FROM custom_statuses")
+	s.Require().NoError(err)
+	_, err = s.Runner().ExecContext(s.Ctx(),
+		"INSERT INTO custom_statuses (name, category) VALUES (?, ?), (?, ?)",
+		"review", string(types.CategoryWIP),
+		"archived", string(types.CategoryDone),
+	)
+	s.Require().NoError(err)
+
+	got, err := s.configRepo().ListAllStatusNames(s.Ctx())
+	s.Require().NoError(err)
+	s.Equal([]string{
+		"open", "in_progress", "blocked", "deferred", "closed", "pinned", "hooked",
+		"archived", "review",
+	}, got)
+}
+
+func (s *testSuite) configUseCaseListAllStatusNames() {
+	_, err := s.Runner().ExecContext(s.Ctx(), "DELETE FROM custom_statuses")
+	s.Require().NoError(err)
+	_, err = s.Runner().ExecContext(s.Ctx(),
+		"INSERT INTO custom_statuses (name, category) VALUES (?, ?)",
+		"audit", string(types.CategoryWIP),
+	)
+	s.Require().NoError(err)
+
+	uc := domain.NewConfigUseCase(NewConfigSQLRepository(s.Runner()))
+	got, err := uc.ListAllStatusNames(s.Ctx())
+	s.Require().NoError(err)
+	s.Equal([]string{
+		"open", "in_progress", "blocked", "deferred", "closed", "pinned", "hooked",
+		"audit",
+	}, got)
+}
+
+func (s *testSuite) configGetCustomTypesTablePrecedence() {
+	_, err := s.Runner().ExecContext(s.Ctx(), "DELETE FROM custom_types")
+	s.Require().NoError(err)
+	r := s.configRepo()
+	s.Require().NoError(r.SetConfig(s.Ctx(), "types.custom", "from-config"))
+	_, err = s.Runner().ExecContext(s.Ctx(),
+		"INSERT INTO custom_types (name) VALUES (?), (?)",
+		"from-table-a", "from-table-b")
+	s.Require().NoError(err)
+
+	got, err := r.GetCustomTypes(s.Ctx())
+	s.Require().NoError(err)
+	s.Equal([]string{"from-table-a", "from-table-b"}, got)
+}
+
+func (s *testSuite) configGetCustomTypesConfigFallback() {
+	_, err := s.Runner().ExecContext(s.Ctx(), "DELETE FROM custom_types")
+	s.Require().NoError(err)
+	r := s.configRepo()
+	s.Require().NoError(r.SetConfig(s.Ctx(), "types.custom", "fallback-only"))
+
+	got, err := r.GetCustomTypes(s.Ctx())
+	s.Require().NoError(err)
+	s.Equal([]string{"fallback-only"}, got)
 }

--- a/internal/storage/domain/db/dependency.go
+++ b/internal/storage/domain/db/dependency.go
@@ -193,6 +193,51 @@ func (r *dependencySQLRepositoryImpl) markDirectBlockedSource(ctx context.Contex
 	return err
 }
 
+func (r *dependencySQLRepositoryImpl) Delete(ctx context.Context, issueID, dependsOnID, actor string, opts domain.DepInsertOpts) (domain.DepDeleteResult, error) {
+	if issueID == "" || dependsOnID == "" {
+		return domain.DepDeleteResult{}, errors.New("db: DependencySQLRepository.Delete: issueID and dependsOnID must not be empty")
+	}
+	table := pickDepTable(opts.UseWispsTable)
+
+	var depType string
+	//nolint:gosec // G201: table and depTargetExpr are hardcoded constants
+	err := r.runner.QueryRowContext(ctx,
+		fmt.Sprintf("SELECT type FROM %s WHERE issue_id = ? AND %s = ?", table, depTargetExpr),
+		issueID, dependsOnID,
+	).Scan(&depType)
+	switch {
+	case errors.Is(err, sql.ErrNoRows):
+		return domain.DepDeleteResult{Found: false}, nil
+	case err != nil:
+		return domain.DepDeleteResult{}, fmt.Errorf("db: DependencySQLRepository.Delete: lookup type %s -> %s: %w", issueID, dependsOnID, err)
+	}
+
+	//nolint:gosec // G201: table and depTargetExpr are hardcoded constants
+	if _, err := r.runner.ExecContext(ctx,
+		fmt.Sprintf("DELETE FROM %s WHERE issue_id = ? AND %s = ?", table, depTargetExpr),
+		issueID, dependsOnID,
+	); err != nil {
+		return domain.DepDeleteResult{}, fmt.Errorf("db: DependencySQLRepository.Delete: %s -> %s: %w", issueID, dependsOnID, err)
+	}
+
+	dt := types.DependencyType(depType)
+	var affectedIssues, affectedWisps []string
+	var aerr error
+	if opts.UseWispsTable {
+		affectedIssues, affectedWisps, aerr = issueops.AffectedByDepChangeForWispInTx(ctx, r.runner, issueID, dependsOnID, dt)
+	} else {
+		affectedIssues, affectedWisps, aerr = issueops.AffectedByDepChangeInTx(ctx, r.runner, issueID, dependsOnID, dt)
+	}
+	if aerr != nil {
+		return domain.DepDeleteResult{}, fmt.Errorf("db: DependencySQLRepository.Delete: affected set: %w", aerr)
+	}
+	if err := issueops.RecomputeIsBlockedInTx(ctx, r.runner, affectedIssues, affectedWisps); err != nil {
+		return domain.DepDeleteResult{}, fmt.Errorf("db: DependencySQLRepository.Delete: recompute is_blocked: %w", err)
+	}
+
+	return domain.DepDeleteResult{Found: true, Type: dt, DependsOnID: dependsOnID}, nil
+}
+
 func (r *dependencySQLRepositoryImpl) HasCycle(ctx context.Context, issueID, dependsOnID string) (bool, error) {
 	if issueID == "" || dependsOnID == "" {
 		return false, errors.New("db: DependencySQLRepository.HasCycle: issueID and dependsOnID must not be empty")

--- a/internal/storage/domain/db/dependency_test.go
+++ b/internal/storage/domain/db/dependency_test.go
@@ -17,6 +17,13 @@ func (s *testSuite) TestDependencySQLRepository() {
 		s.Run("MissingTargetIssueFailsFK", s.depInsertFKViolation)
 		s.Run("ThreadIDPersists", s.depInsertThreadID)
 	})
+	s.Run("Delete", func() {
+		s.Run("ReturnsFoundFalseOnMissingEdge", s.depDeleteMissingEdge)
+		s.Run("ReturnsTypeAndDependsOnID", s.depDeleteReturnsMetadata)
+		s.Run("RemovesRow", s.depDeleteRemovesRow)
+		s.Run("RejectsEmptyIDs", s.depDeleteEmptyIDs)
+		s.Run("WispRoutesToWispDependencies", s.depDeleteWispRouting)
+	})
 	s.Run("HasCycle", func() {
 		s.Run("StraightLineIsAcyclic", s.depCycleAcyclic)
 		s.Run("DirectBackEdgeDetected", s.depCycleDirectBackEdge)
@@ -502,4 +509,75 @@ func (s *testSuite) depWispDirectBackEdge() {
 	cycle, err := r.HasCycle(s.Ctx(), "bd-dep-wd-t", "bd-dep-wd-s")
 	s.Require().NoError(err)
 	s.True(cycle, "fast path must probe wisp_dependencies too")
+}
+
+func (s *testSuite) depDeleteMissingEdge() {
+	s.seedIssueRow("bd-dep-del-miss-a")
+	s.seedIssueRow("bd-dep-del-miss-b")
+	r := s.depRepo()
+
+	res, err := r.Delete(s.Ctx(), "bd-dep-del-miss-a", "bd-dep-del-miss-b", "tester", domain.DepInsertOpts{})
+	s.Require().NoError(err, "Delete on a non-existent edge must succeed (mirrors RemoveDependencyInTx)")
+	s.False(res.Found, "Found must be false so callers like Reparent can distinguish no-op from removal")
+}
+
+func (s *testSuite) depDeleteReturnsMetadata() {
+	s.seedIssueRow("bd-dep-del-meta-a")
+	s.seedIssueRow("bd-dep-del-meta-b")
+	r := s.depRepo()
+	s.Require().NoError(r.Insert(s.Ctx(),
+		newDep("bd-dep-del-meta-a", "bd-dep-del-meta-b", types.DepParentChild), "tester", domain.DepInsertOpts{}))
+
+	res, err := r.Delete(s.Ctx(), "bd-dep-del-meta-a", "bd-dep-del-meta-b", "tester", domain.DepInsertOpts{})
+	s.Require().NoError(err)
+	s.True(res.Found)
+	s.Equal(types.DepParentChild, res.Type)
+	s.Equal("bd-dep-del-meta-b", res.DependsOnID)
+}
+
+func (s *testSuite) depDeleteRemovesRow() {
+	s.seedIssueRow("bd-dep-del-row-a")
+	s.seedIssueRow("bd-dep-del-row-b")
+	r := s.depRepo()
+	s.Require().NoError(r.Insert(s.Ctx(),
+		newDep("bd-dep-del-row-a", "bd-dep-del-row-b", types.DepBlocks), "tester", domain.DepInsertOpts{}))
+
+	_, err := r.Delete(s.Ctx(), "bd-dep-del-row-a", "bd-dep-del-row-b", "tester", domain.DepInsertOpts{})
+	s.Require().NoError(err)
+
+	out, err := r.ListByIssueIDs(s.Ctx(), []string{"bd-dep-del-row-a"}, domain.DepListOpts{Direction: domain.DepDirectionOut})
+	s.Require().NoError(err)
+	s.Empty(out.Outgoing["bd-dep-del-row-a"], "deleted dep must disappear from outgoing list")
+}
+
+func (s *testSuite) depDeleteEmptyIDs() {
+	r := s.depRepo()
+	_, err := r.Delete(s.Ctx(), "", "bd-x", "tester", domain.DepInsertOpts{})
+	s.Require().Error(err)
+	_, err = r.Delete(s.Ctx(), "bd-x", "", "tester", domain.DepInsertOpts{})
+	s.Require().Error(err)
+}
+
+func (s *testSuite) depDeleteWispRouting() {
+	s.seedIssueRow("bd-dep-del-wisp-issuesrc")
+	s.seedIssueRow("bd-dep-del-wisp-issuetgt")
+	s.seedWispRow("bd-dep-del-wisp-wispsrc")
+	s.seedWispRow("bd-dep-del-wisp-wisptgt")
+	r := s.depRepo()
+	s.Require().NoError(r.Insert(s.Ctx(),
+		newDep("bd-dep-del-wisp-issuesrc", "bd-dep-del-wisp-issuetgt", types.DepBlocks), "tester", domain.DepInsertOpts{}))
+	s.Require().NoError(r.Insert(s.Ctx(),
+		newDep("bd-dep-del-wisp-wispsrc", "bd-dep-del-wisp-wisptgt", types.DepBlocks), "tester", domain.DepInsertOpts{UseWispsTable: true}))
+
+	res, err := r.Delete(s.Ctx(), "bd-dep-del-wisp-wispsrc", "bd-dep-del-wisp-wisptgt", "tester", domain.DepInsertOpts{UseWispsTable: true})
+	s.Require().NoError(err)
+	s.True(res.Found)
+
+	var permCount, wispCount int
+	s.Require().NoError(s.Runner().QueryRowContext(s.Ctx(),
+		"SELECT COUNT(*) FROM dependencies WHERE issue_id = ?", "bd-dep-del-wisp-issuesrc").Scan(&permCount))
+	s.Equal(1, permCount, "wisp-routed Delete must not touch the dependencies table")
+	s.Require().NoError(s.Runner().QueryRowContext(s.Ctx(),
+		"SELECT COUNT(*) FROM wisp_dependencies WHERE issue_id = ?", "bd-dep-del-wisp-wispsrc").Scan(&wispCount))
+	s.Equal(0, wispCount, "wisp-routed Delete must remove from wisp_dependencies")
 }

--- a/internal/storage/domain/db/dependency_usecase_test.go
+++ b/internal/storage/domain/db/dependency_usecase_test.go
@@ -19,6 +19,10 @@ func (s *testSuite) TestDependencyUseCase() {
 		s.Run("EmptyNewParentUnparents", s.ducReparentUnparent)
 		s.Run("SameParentIsNoop", s.ducReparentSameParent)
 	})
+	s.Run("Wisp", func() {
+		s.Run("RemoveWispDependencyRoutesToWispDeps", s.ducRemoveWispDependencyRoutes)
+		s.Run("ReparentWispRoutesToWispDeps", s.ducReparentWispRoutes)
+	})
 }
 
 func (s *testSuite) depUseCase() domain.DependencyUseCase {
@@ -123,4 +127,51 @@ func (s *testSuite) ducReparentSameParent() {
 		"SELECT COUNT(*) FROM dependencies WHERE issue_id = ? AND depends_on_issue_id = ? AND type = 'parent-child'",
 		"bd-duc-rp-same-c", "bd-duc-rp-same-p").Scan(&count))
 	s.Equal(1, count)
+}
+
+func (s *testSuite) currentWispParent(childID string) string {
+	res, err := s.depUseCase().ListByWispIDs(s.Ctx(), []string{childID}, domain.DepListFilter{
+		Types:     []types.DependencyType{types.DepParentChild},
+		Direction: domain.DepDirectionOut,
+	})
+	s.Require().NoError(err)
+	for _, dep := range res.Outgoing[childID] {
+		if dep.Type == types.DepParentChild {
+			return dep.DependsOnID
+		}
+	}
+	return ""
+}
+
+func (s *testSuite) ducRemoveWispDependencyRoutes() {
+	s.seedWispRow("bd-duc-rwd-a")
+	s.seedWispRow("bd-duc-rwd-b")
+	wispDepRepo := NewDependencySQLRepository(s.Runner())
+	s.Require().NoError(wispDepRepo.Insert(s.Ctx(),
+		newDep("bd-duc-rwd-a", "bd-duc-rwd-b", types.DepBlocks), "tester", domain.DepInsertOpts{UseWispsTable: true}))
+
+	s.Require().NoError(s.depUseCase().RemoveWispDependency(s.Ctx(), "bd-duc-rwd-a", "bd-duc-rwd-b", "tester"))
+
+	wispRes, err := s.depUseCase().ListByWispIDs(s.Ctx(), []string{"bd-duc-rwd-a"},
+		domain.DepListFilter{Direction: domain.DepDirectionOut})
+	s.Require().NoError(err)
+	s.Empty(wispRes.Outgoing["bd-duc-rwd-a"])
+}
+
+func (s *testSuite) ducReparentWispRoutes() {
+	s.seedWispRow("bd-duc-rpw-c")
+	s.seedWispRow("bd-duc-rpw-old")
+	s.seedWispRow("bd-duc-rpw-new")
+	depRepo := NewDependencySQLRepository(s.Runner())
+	s.Require().NoError(depRepo.Insert(s.Ctx(),
+		newDep("bd-duc-rpw-c", "bd-duc-rpw-old", types.DepParentChild), "seeder", domain.DepInsertOpts{UseWispsTable: true}))
+
+	s.Require().NoError(s.depUseCase().ReparentWisp(s.Ctx(), "bd-duc-rpw-c", "bd-duc-rpw-new", "tester"))
+
+	s.Equal("bd-duc-rpw-new", s.currentWispParent("bd-duc-rpw-c"))
+
+	var issuesCount int
+	s.Require().NoError(s.Runner().QueryRowContext(s.Ctx(),
+		"SELECT COUNT(*) FROM dependencies WHERE issue_id = ?", "bd-duc-rpw-c").Scan(&issuesCount))
+	s.Equal(0, issuesCount, "wisp-routed Reparent must not touch the issues dep table")
 }

--- a/internal/storage/domain/db/dependency_usecase_test.go
+++ b/internal/storage/domain/db/dependency_usecase_test.go
@@ -1,0 +1,126 @@
+package db
+
+import (
+	"github.com/steveyegge/beads/internal/storage/domain"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+func (s *testSuite) TestDependencyUseCase() {
+	s.Run("RemoveDependency", func() {
+		s.Run("EmptyIDsReturnError", s.ducRemoveDependencyEmptyIDs)
+		s.Run("DelegatesToRepoDelete", s.ducRemoveDependencyDelegates)
+		s.Run("MissingEdgeIsNoop", s.ducRemoveDependencyMissingNoop)
+	})
+	s.Run("Reparent", func() {
+		s.Run("EmptyChildReturnsError", s.ducReparentEmptyChild)
+		s.Run("SelfParentReturnsError", s.ducReparentSelf)
+		s.Run("AddsParentWhenNoneExists", s.ducReparentFromNone)
+		s.Run("ReplacesExistingParent", s.ducReparentReplaces)
+		s.Run("EmptyNewParentUnparents", s.ducReparentUnparent)
+		s.Run("SameParentIsNoop", s.ducReparentSameParent)
+	})
+}
+
+func (s *testSuite) depUseCase() domain.DependencyUseCase {
+	return domain.NewDependencyUseCase(NewDependencySQLRepository(s.Runner()))
+}
+
+func (s *testSuite) currentParent(childID string) string {
+	res, err := s.depUseCase().ListByIssueIDs(s.Ctx(), []string{childID}, domain.DepListFilter{
+		Types:     []types.DependencyType{types.DepParentChild},
+		Direction: domain.DepDirectionOut,
+	})
+	s.Require().NoError(err)
+	for _, dep := range res.Outgoing[childID] {
+		if dep.Type == types.DepParentChild {
+			return dep.DependsOnID
+		}
+	}
+	return ""
+}
+
+func (s *testSuite) ducRemoveDependencyEmptyIDs() {
+	uc := s.depUseCase()
+	s.Require().Error(uc.RemoveDependency(s.Ctx(), "", "bd-x", "tester"))
+	s.Require().Error(uc.RemoveDependency(s.Ctx(), "bd-x", "", "tester"))
+}
+
+func (s *testSuite) ducRemoveDependencyDelegates() {
+	s.seedIssueRow("bd-duc-rd-1")
+	s.seedIssueRow("bd-duc-rd-2")
+	depRepo := NewDependencySQLRepository(s.Runner())
+	s.Require().NoError(depRepo.Insert(s.Ctx(),
+		newDep("bd-duc-rd-1", "bd-duc-rd-2", types.DepBlocks), "tester", domain.DepInsertOpts{}))
+
+	s.Require().NoError(s.depUseCase().RemoveDependency(s.Ctx(), "bd-duc-rd-1", "bd-duc-rd-2", "tester"))
+
+	res, err := s.depUseCase().ListByIssueIDs(s.Ctx(), []string{"bd-duc-rd-1"},
+		domain.DepListFilter{Direction: domain.DepDirectionOut})
+	s.Require().NoError(err)
+	s.Empty(res.Outgoing["bd-duc-rd-1"])
+}
+
+func (s *testSuite) ducRemoveDependencyMissingNoop() {
+	s.seedIssueRow("bd-duc-rd-miss-a")
+	s.seedIssueRow("bd-duc-rd-miss-b")
+	s.Require().NoError(s.depUseCase().RemoveDependency(s.Ctx(), "bd-duc-rd-miss-a", "bd-duc-rd-miss-b", "tester"))
+}
+
+func (s *testSuite) ducReparentEmptyChild() {
+	s.Require().Error(s.depUseCase().Reparent(s.Ctx(), "", "bd-x", "tester"))
+}
+
+func (s *testSuite) ducReparentSelf() {
+	s.Require().Error(s.depUseCase().Reparent(s.Ctx(), "bd-x", "bd-x", "tester"))
+}
+
+func (s *testSuite) ducReparentFromNone() {
+	s.seedIssueRow("bd-duc-rp-none-c")
+	s.seedIssueRow("bd-duc-rp-none-p")
+
+	s.Require().NoError(s.depUseCase().Reparent(s.Ctx(), "bd-duc-rp-none-c", "bd-duc-rp-none-p", "tester"))
+
+	s.Equal("bd-duc-rp-none-p", s.currentParent("bd-duc-rp-none-c"))
+}
+
+func (s *testSuite) ducReparentReplaces() {
+	s.seedIssueRow("bd-duc-rp-c")
+	s.seedIssueRow("bd-duc-rp-old")
+	s.seedIssueRow("bd-duc-rp-new")
+	depRepo := NewDependencySQLRepository(s.Runner())
+	s.Require().NoError(depRepo.Insert(s.Ctx(),
+		newDep("bd-duc-rp-c", "bd-duc-rp-old", types.DepParentChild), "tester", domain.DepInsertOpts{}))
+
+	s.Require().NoError(s.depUseCase().Reparent(s.Ctx(), "bd-duc-rp-c", "bd-duc-rp-new", "tester"))
+
+	s.Equal("bd-duc-rp-new", s.currentParent("bd-duc-rp-c"))
+}
+
+func (s *testSuite) ducReparentUnparent() {
+	s.seedIssueRow("bd-duc-rp-up-c")
+	s.seedIssueRow("bd-duc-rp-up-p")
+	depRepo := NewDependencySQLRepository(s.Runner())
+	s.Require().NoError(depRepo.Insert(s.Ctx(),
+		newDep("bd-duc-rp-up-c", "bd-duc-rp-up-p", types.DepParentChild), "tester", domain.DepInsertOpts{}))
+
+	s.Require().NoError(s.depUseCase().Reparent(s.Ctx(), "bd-duc-rp-up-c", "", "tester"))
+
+	s.Equal("", s.currentParent("bd-duc-rp-up-c"))
+}
+
+func (s *testSuite) ducReparentSameParent() {
+	s.seedIssueRow("bd-duc-rp-same-c")
+	s.seedIssueRow("bd-duc-rp-same-p")
+	depRepo := NewDependencySQLRepository(s.Runner())
+	s.Require().NoError(depRepo.Insert(s.Ctx(),
+		newDep("bd-duc-rp-same-c", "bd-duc-rp-same-p", types.DepParentChild), "tester", domain.DepInsertOpts{}))
+
+	s.Require().NoError(s.depUseCase().Reparent(s.Ctx(), "bd-duc-rp-same-c", "bd-duc-rp-same-p", "tester"))
+
+	s.Equal("bd-duc-rp-same-p", s.currentParent("bd-duc-rp-same-c"))
+	var count int
+	s.Require().NoError(s.Runner().QueryRowContext(s.Ctx(),
+		"SELECT COUNT(*) FROM dependencies WHERE issue_id = ? AND depends_on_issue_id = ? AND type = 'parent-child'",
+		"bd-duc-rp-same-c", "bd-duc-rp-same-p").Scan(&count))
+	s.Equal(1, count)
+}

--- a/internal/storage/domain/db/is_blocked_test.go
+++ b/internal/storage/domain/db/is_blocked_test.go
@@ -1,0 +1,125 @@
+package db
+
+import (
+	"github.com/steveyegge/beads/internal/storage/domain"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+func (s *testSuite) TestIsBlockedParity() {
+	s.Run("DeleteBlocksEdgeUnblocksSource", s.ibDeleteBlocksUnblocks)
+	s.Run("DeleteParentChildEdgeUnblocksChild", s.ibDeleteParentChildUnblocks)
+	s.Run("UpdateStatusClosedUnblocksDependents", s.ibUpdateCloseUnblocks)
+	s.Run("UpdateStatusReopenReblocksDependents", s.ibUpdateReopenReblocks)
+	s.Run("ReparentAwayFromBlockedParentUnblocksChild", s.ibReparentUnblocks)
+	s.Run("ClaimDoesNotChangeIsBlocked", s.ibClaimDoesNotChange)
+}
+
+func (s *testSuite) isBlocked(id string) bool {
+	var v int
+	s.Require().NoError(s.Runner().QueryRowContext(s.Ctx(),
+		"SELECT is_blocked FROM issues WHERE id = ?", id).Scan(&v))
+	return v != 0
+}
+
+func (s *testSuite) ibDeleteBlocksUnblocks() {
+	s.seedIssueRow("bd-ib-a")
+	s.seedIssueRow("bd-ib-b")
+	r := s.depRepo()
+
+	s.Require().NoError(r.Insert(s.Ctx(), newDep("bd-ib-a", "bd-ib-b", types.DepBlocks), "tester", domain.DepInsertOpts{}))
+	s.Require().True(s.isBlocked("bd-ib-a"), "source must be blocked after blocks-edge insert")
+
+	res, err := r.Delete(s.Ctx(), "bd-ib-a", "bd-ib-b", "tester", domain.DepInsertOpts{})
+	s.Require().NoError(err)
+	s.Require().True(res.Found)
+	s.Equal(types.DepBlocks, res.Type)
+	s.False(s.isBlocked("bd-ib-a"), "source must be unblocked once last blocks-edge is removed")
+}
+
+func (s *testSuite) ibDeleteParentChildUnblocks() {
+	s.seedIssueRow("bd-ib-pc-parent")
+	s.seedIssueRow("bd-ib-pc-child")
+	s.seedIssueRow("bd-ib-pc-blocker")
+	r := s.depRepo()
+
+	s.Require().NoError(r.Insert(s.Ctx(), newDep("bd-ib-pc-parent", "bd-ib-pc-blocker", types.DepBlocks), "tester", domain.DepInsertOpts{}))
+	s.Require().NoError(r.Insert(s.Ctx(), newDep("bd-ib-pc-child", "bd-ib-pc-parent", types.DepParentChild), "tester", domain.DepInsertOpts{}))
+	s.Require().True(s.isBlocked("bd-ib-pc-parent"))
+	s.Require().True(s.isBlocked("bd-ib-pc-child"), "child must inherit parent's blocked state")
+
+	res, err := r.Delete(s.Ctx(), "bd-ib-pc-child", "bd-ib-pc-parent", "tester", domain.DepInsertOpts{})
+	s.Require().NoError(err)
+	s.Require().True(res.Found)
+	s.False(s.isBlocked("bd-ib-pc-child"), "child must be unblocked once severed from blocked parent")
+	s.True(s.isBlocked("bd-ib-pc-parent"), "parent still has its own blocker")
+}
+
+func (s *testSuite) ibUpdateCloseUnblocks() {
+	s.seedIssueRow("bd-ib-up-src")
+	s.seedIssueRow("bd-ib-up-tgt")
+	s.Require().NoError(s.depRepo().Insert(s.Ctx(),
+		newDep("bd-ib-up-src", "bd-ib-up-tgt", types.DepBlocks), "tester", domain.DepInsertOpts{}))
+	s.Require().True(s.isBlocked("bd-ib-up-src"))
+
+	issueRepo := NewIssueSQLRepository(s.Runner())
+	s.Require().NoError(issueRepo.Update(s.Ctx(), "bd-ib-up-tgt",
+		map[string]any{"status": string(types.StatusClosed)}, "tester", domain.IssueTableOpts{}))
+
+	s.False(s.isBlocked("bd-ib-up-src"), "closing the blocker must unblock its dependent")
+}
+
+func (s *testSuite) ibUpdateReopenReblocks() {
+	s.seedIssueRow("bd-ib-re-src")
+	s.seedIssueRow("bd-ib-re-tgt")
+	s.Require().NoError(s.depRepo().Insert(s.Ctx(),
+		newDep("bd-ib-re-src", "bd-ib-re-tgt", types.DepBlocks), "tester", domain.DepInsertOpts{}))
+
+	issueRepo := NewIssueSQLRepository(s.Runner())
+	s.Require().NoError(issueRepo.Update(s.Ctx(), "bd-ib-re-tgt",
+		map[string]any{"status": string(types.StatusClosed)}, "tester", domain.IssueTableOpts{}))
+	s.Require().False(s.isBlocked("bd-ib-re-src"))
+
+	s.Require().NoError(issueRepo.Update(s.Ctx(), "bd-ib-re-tgt",
+		map[string]any{"status": string(types.StatusOpen)}, "tester", domain.IssueTableOpts{}))
+	s.True(s.isBlocked("bd-ib-re-src"), "reopening the blocker must re-block its dependent")
+}
+
+func (s *testSuite) ibReparentUnblocks() {
+	s.seedIssueRow("bd-ib-rp-blockedparent")
+	s.seedIssueRow("bd-ib-rp-cleanparent")
+	s.seedIssueRow("bd-ib-rp-child")
+	s.seedIssueRow("bd-ib-rp-blocker")
+	r := s.depRepo()
+
+	s.Require().NoError(r.Insert(s.Ctx(),
+		newDep("bd-ib-rp-blockedparent", "bd-ib-rp-blocker", types.DepBlocks), "tester", domain.DepInsertOpts{}))
+	s.Require().NoError(r.Insert(s.Ctx(),
+		newDep("bd-ib-rp-child", "bd-ib-rp-blockedparent", types.DepParentChild), "tester", domain.DepInsertOpts{}))
+	s.Require().True(s.isBlocked("bd-ib-rp-child"))
+
+	depUC := domain.NewDependencyUseCase(r)
+	s.Require().NoError(depUC.Reparent(s.Ctx(), "bd-ib-rp-child", "bd-ib-rp-cleanparent", "tester"))
+
+	s.False(s.isBlocked("bd-ib-rp-child"), "child must be unblocked after reparenting onto a clean parent")
+}
+
+func (s *testSuite) ibClaimDoesNotChange() {
+	s.seedIssueRow("bd-ib-cl-src")
+	s.seedIssueRow("bd-ib-cl-blocker")
+	s.seedIssueRow("bd-ib-cl-free")
+	r := s.depRepo()
+
+	s.Require().NoError(r.Insert(s.Ctx(),
+		newDep("bd-ib-cl-src", "bd-ib-cl-blocker", types.DepBlocks), "tester", domain.DepInsertOpts{}))
+	s.Require().True(s.isBlocked("bd-ib-cl-src"))
+	s.Require().False(s.isBlocked("bd-ib-cl-free"))
+
+	issueRepo := NewIssueSQLRepository(s.Runner())
+	res, err := issueRepo.Claim(s.Ctx(), "bd-ib-cl-free", "tester", domain.IssueTableOpts{})
+	s.Require().NoError(err)
+	s.Require().True(res.Updated)
+
+	s.True(s.isBlocked("bd-ib-cl-src"), "blocked dependent must remain blocked across an unrelated claim")
+	s.False(s.isBlocked("bd-ib-cl-free"), "claimed issue (open->in_progress) must not become blocked")
+	s.False(s.isBlocked("bd-ib-cl-blocker"), "untouched issue must stay unblocked")
+}

--- a/internal/storage/domain/db/issue.go
+++ b/internal/storage/domain/db/issue.go
@@ -39,10 +39,14 @@ var allowedUpdateFields = map[string]struct{}{
 	"description": {}, "design": {}, "acceptance_criteria": {}, "notes": {},
 	"issue_type": {}, "estimated_minutes": {}, "external_ref": {}, "spec_id": {},
 	"started_at": {}, "closed_at": {}, "close_reason": {}, "closed_by_session": {},
-	"source_repo": {}, "sender": {}, "wisp_type": {}, "no_history": {}, "pinned": {},
+	"source_repo": {}, "sender": {}, "wisp": {}, "wisp_type": {}, "no_history": {}, "pinned": {},
 	"mol_type": {}, "event_kind": {}, "actor": {}, "target": {}, "payload": {},
 	"due_at": {}, "defer_until": {}, "await_id": {}, "waiters": {},
 	"metadata": {},
+}
+
+var updateFieldColumnRename = map[string]string{
+	"wisp": "ephemeral",
 }
 
 func (r *issueSQLRepositoryImpl) Insert(ctx context.Context, issue *types.Issue, actor string, opts domain.InsertIssueOpts) error {
@@ -93,7 +97,11 @@ func (r *issueSQLRepositoryImpl) Update(ctx context.Context, id string, updates 
 		if _, ok := allowedUpdateFields[key]; !ok {
 			return fmt.Errorf("db: Update: field %q is not allowed", key)
 		}
-		setClauses = append(setClauses, fmt.Sprintf("`%s` = ?", key))
+		column := key
+		if renamed, ok := updateFieldColumnRename[key]; ok {
+			column = renamed
+		}
+		setClauses = append(setClauses, fmt.Sprintf("`%s` = ?", column))
 		args = append(args, normalizeUpdateValue(key, value))
 	}
 	setClauses = append(setClauses, "updated_at = ?")
@@ -101,6 +109,21 @@ func (r *issueSQLRepositoryImpl) Update(ctx context.Context, id string, updates 
 	args = append(args, id)
 
 	table := pickIssueTable(opts.UseWispsTable)
+
+	var oldStatus types.Status
+	_, statusChanging := updates["status"]
+	if statusChanging {
+		//nolint:gosec // G201: table is one of two hardcoded constants
+		if err := r.runner.QueryRowContext(ctx,
+			fmt.Sprintf("SELECT status FROM %s WHERE id = ?", table), id,
+		).Scan(&oldStatus); err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return fmt.Errorf("db: Update %s: %w", id, sql.ErrNoRows)
+			}
+			return fmt.Errorf("db: Update %s: read old status: %w", id, err)
+		}
+	}
+
 	//nolint:gosec // G201: table is one of two hardcoded constants
 	q := fmt.Sprintf("UPDATE %s SET %s WHERE id = ?", table, strings.Join(setClauses, ", "))
 	res, err := r.runner.ExecContext(ctx, q, args...)
@@ -115,11 +138,129 @@ func (r *issueSQLRepositoryImpl) Update(ctx context.Context, id string, updates 
 		return fmt.Errorf("db: Update %s: %w", id, sql.ErrNoRows)
 	}
 
-	return r.events.Record(ctx, domain.Event{
+	if err := r.events.Record(ctx, domain.Event{
 		IssueID: id,
 		Type:    types.EventUpdated,
 		Actor:   actor,
-	}, domain.RecordEventOpts{UseWispsTable: opts.UseWispsTable})
+	}, domain.RecordEventOpts{UseWispsTable: opts.UseWispsTable}); err != nil {
+		return err
+	}
+
+	if statusChanging {
+		newStatus := coerceStatus(updates["status"])
+		oldActive := oldStatus != types.StatusClosed && oldStatus != types.StatusPinned
+		newActive := newStatus != types.StatusClosed && newStatus != types.StatusPinned
+		if oldActive != newActive {
+			var (
+				affectedIssues, affectedWisps []string
+				aerr                          error
+			)
+			if opts.UseWispsTable {
+				affectedIssues, affectedWisps, aerr = issueops.AffectedByStatusChangeForWispInTx(ctx, r.runner, id)
+			} else {
+				affectedIssues, affectedWisps, aerr = issueops.AffectedByStatusChangeInTx(ctx, r.runner, id)
+			}
+			if aerr != nil {
+				return fmt.Errorf("db: Update %s: affected by status change: %w", id, aerr)
+			}
+			if err := issueops.RecomputeIsBlockedInTx(ctx, r.runner, affectedIssues, affectedWisps); err != nil {
+				return fmt.Errorf("db: Update %s: recompute is_blocked: %w", id, err)
+			}
+		}
+	}
+	return nil
+}
+
+func coerceStatus(v any) types.Status {
+	switch s := v.(type) {
+	case string:
+		return types.Status(s)
+	case types.Status:
+		return s
+	default:
+		return ""
+	}
+}
+
+func (r *issueSQLRepositoryImpl) Claim(ctx context.Context, id, actor string, opts domain.IssueTableOpts) (domain.ClaimRowResult, error) {
+	if id == "" {
+		return domain.ClaimRowResult{}, errors.New("db: Claim: id must not be empty")
+	}
+
+	oldIssue, err := r.Get(ctx, id, opts)
+	if err != nil {
+		return domain.ClaimRowResult{}, fmt.Errorf("db: Claim %s: read old issue: %w", id, err)
+	}
+
+	table := pickIssueTable(opts.UseWispsTable)
+	now := time.Now().UTC()
+	startedWasZero := oldIssue.StartedAt == nil
+
+	var res sql.Result
+	if startedWasZero {
+		//nolint:gosec // G201: table is one of two hardcoded constants
+		res, err = r.runner.ExecContext(ctx, fmt.Sprintf(`
+			UPDATE %s
+			SET assignee = ?, status = 'in_progress', updated_at = ?, started_at = ?
+			WHERE id = ? AND status = 'open' AND (assignee = '' OR assignee IS NULL OR assignee = ?)
+		`, table), actor, now, now, id, actor)
+	} else {
+		//nolint:gosec // G201: table is one of two hardcoded constants
+		res, err = r.runner.ExecContext(ctx, fmt.Sprintf(`
+			UPDATE %s
+			SET assignee = ?, status = 'in_progress', updated_at = ?
+			WHERE id = ? AND status = 'open' AND (assignee = '' OR assignee IS NULL OR assignee = ?)
+		`, table), actor, now, id, actor)
+	}
+	if err != nil {
+		return domain.ClaimRowResult{}, fmt.Errorf("db: Claim %s: %w", id, err)
+	}
+	rows, err := res.RowsAffected()
+	if err != nil {
+		return domain.ClaimRowResult{}, fmt.Errorf("db: Claim %s: rows affected: %w", id, err)
+	}
+
+	if rows == 0 {
+		var currentAssignee sql.NullString
+		var currentStatus types.Status
+		//nolint:gosec // G201: table is one of two hardcoded constants
+		if err := r.runner.QueryRowContext(ctx,
+			fmt.Sprintf("SELECT assignee, status FROM %s WHERE id = ?", table), id,
+		).Scan(&currentAssignee, &currentStatus); err != nil {
+			return domain.ClaimRowResult{}, fmt.Errorf("db: Claim %s: read current state: %w", id, err)
+		}
+		assignee := ""
+		if currentAssignee.Valid {
+			assignee = currentAssignee.String
+		}
+		return domain.ClaimRowResult{
+			Updated:          false,
+			CurrentAssignee:  assignee,
+			CurrentStatus:    currentStatus,
+			StartedAtWasZero: startedWasZero,
+			OldIssue:         oldIssue,
+		}, nil
+	}
+
+	oldData, _ := json.Marshal(oldIssue)
+	newData, _ := json.Marshal(map[string]any{"assignee": actor, "status": "in_progress"})
+	if err := r.events.Record(ctx, domain.Event{
+		IssueID:  id,
+		Type:     types.EventType("claimed"),
+		Actor:    actor,
+		OldValue: string(oldData),
+		NewValue: string(newData),
+	}, domain.RecordEventOpts{UseWispsTable: opts.UseWispsTable}); err != nil {
+		return domain.ClaimRowResult{}, fmt.Errorf("db: Claim %s: record event: %w", id, err)
+	}
+
+	return domain.ClaimRowResult{
+		Updated:          true,
+		CurrentAssignee:  actor,
+		CurrentStatus:    types.StatusInProgress,
+		StartedAtWasZero: startedWasZero,
+		OldIssue:         oldIssue,
+	}, nil
 }
 
 func (r *issueSQLRepositoryImpl) Get(ctx context.Context, id string, opts domain.IssueTableOpts) (*types.Issue, error) {

--- a/internal/storage/domain/db/issue_test.go
+++ b/internal/storage/domain/db/issue_test.go
@@ -29,6 +29,16 @@ func (s *testSuite) TestIssueSQLRepository() {
 		s.Run("EmptyUpdatesIsNoop", s.issueUpdateEmpty)
 		s.Run("NormalizesStatusType", s.issueUpdateStatusType)
 		s.Run("NormalizesTimestampToUTC", s.issueUpdateNormalizesTimestamp)
+		s.Run("MissingIDWithStatusChangeReturnsErrNoRows", s.issueUpdateMissingIDWithStatus)
+	})
+	s.Run("Claim", func() {
+		s.Run("FreshOpenSetsAssigneeAndStartedAt", s.issueClaimFresh)
+		s.Run("IdempotentReclaimBySameActor", s.issueClaimIdempotent)
+		s.Run("PreservesStartedAtOnReclaim", s.issueClaimPreservesStartedAt)
+		s.Run("ConflictReturnsForeignAssignee", s.issueClaimConflict)
+		s.Run("NotClaimableWhenClosed", s.issueClaimClosed)
+		s.Run("EmptyIDReturnsError", s.issueClaimEmptyID)
+		s.Run("RecordsClaimedEvent", s.issueClaimRecordsEvent)
 	})
 	s.Run("Get", func() {
 		s.Run("MissingIDReturnsErrNoRows", s.issueGetMissing)
@@ -526,4 +536,119 @@ func (s *testSuite) issueNextCounterIDEmptyPrefix() {
 	_, err := r.NextCounterID(s.Ctx(), "")
 	s.Require().Error(err)
 	s.Contains(err.Error(), "prefix must not be empty")
+}
+
+func (s *testSuite) issueUpdateMissingIDWithStatus() {
+	r := s.issueRepo()
+	err := r.Update(s.Ctx(), "bd-status-missing",
+		map[string]any{"status": string(types.StatusClosed)}, "tester", domain.IssueTableOpts{})
+	s.Require().Error(err)
+	s.True(errors.Is(err, sql.ErrNoRows), "expected sql.ErrNoRows, got %v", err)
+}
+
+func (s *testSuite) issueClaimFresh() {
+	r := s.issueRepo()
+	s.Require().NoError(r.Insert(s.Ctx(), newTestIssue("bd-claim-fresh", "x"), "tester", domain.InsertIssueOpts{}))
+
+	res, err := r.Claim(s.Ctx(), "bd-claim-fresh", "alice", domain.IssueTableOpts{})
+	s.Require().NoError(err)
+	s.True(res.Updated, "fresh open+unassigned must claim")
+	s.True(res.StartedAtWasZero, "fresh row has no prior started_at")
+	s.Equal("alice", res.CurrentAssignee)
+	s.Equal(types.StatusInProgress, res.CurrentStatus)
+	s.Require().NotNil(res.OldIssue)
+	s.Equal(types.StatusOpen, res.OldIssue.Status)
+
+	out, err := r.Get(s.Ctx(), "bd-claim-fresh", domain.IssueTableOpts{})
+	s.Require().NoError(err)
+	s.Equal("alice", out.Assignee)
+	s.Equal(types.StatusInProgress, out.Status)
+	s.Require().NotNil(out.StartedAt, "first claim must set started_at")
+}
+
+func (s *testSuite) issueClaimIdempotent() {
+	r := s.issueRepo()
+	s.Require().NoError(r.Insert(s.Ctx(), newTestIssue("bd-claim-idem", "x"), "tester", domain.InsertIssueOpts{}))
+	_, err := r.Claim(s.Ctx(), "bd-claim-idem", "alice", domain.IssueTableOpts{})
+	s.Require().NoError(err)
+
+	res, err := r.Claim(s.Ctx(), "bd-claim-idem", "alice", domain.IssueTableOpts{})
+	s.Require().NoError(err)
+	s.False(res.Updated, "re-claim by same actor must not flip rows")
+	s.Equal("alice", res.CurrentAssignee)
+	s.Equal(types.StatusInProgress, res.CurrentStatus)
+}
+
+func (s *testSuite) issueClaimPreservesStartedAt() {
+	r := s.issueRepo()
+	s.Require().NoError(r.Insert(s.Ctx(), newTestIssue("bd-claim-sa", "x"), "tester", domain.InsertIssueOpts{}))
+
+	res1, err := r.Claim(s.Ctx(), "bd-claim-sa", "alice", domain.IssueTableOpts{})
+	s.Require().NoError(err)
+	s.Require().True(res1.Updated)
+
+	first, err := r.Get(s.Ctx(), "bd-claim-sa", domain.IssueTableOpts{})
+	s.Require().NoError(err)
+	s.Require().NotNil(first.StartedAt)
+	originalStart := *first.StartedAt
+
+	s.Require().NoError(r.Update(s.Ctx(), "bd-claim-sa",
+		map[string]any{"status": string(types.StatusOpen)}, "tester", domain.IssueTableOpts{}))
+
+	res2, err := r.Claim(s.Ctx(), "bd-claim-sa", "alice", domain.IssueTableOpts{})
+	s.Require().NoError(err)
+	s.True(res2.Updated)
+	s.False(res2.StartedAtWasZero, "second claim must see prior started_at")
+
+	second, err := r.Get(s.Ctx(), "bd-claim-sa", domain.IssueTableOpts{})
+	s.Require().NoError(err)
+	s.Require().NotNil(second.StartedAt)
+	s.Equal(originalStart.Unix(), second.StartedAt.Unix(), "started_at must not be overwritten")
+}
+
+func (s *testSuite) issueClaimConflict() {
+	r := s.issueRepo()
+	s.Require().NoError(r.Insert(s.Ctx(), newTestIssue("bd-claim-conflict", "x"), "tester", domain.InsertIssueOpts{}))
+	_, err := r.Claim(s.Ctx(), "bd-claim-conflict", "alice", domain.IssueTableOpts{})
+	s.Require().NoError(err)
+
+	res, err := r.Claim(s.Ctx(), "bd-claim-conflict", "bob", domain.IssueTableOpts{})
+	s.Require().NoError(err, "conflict surfaces via Updated=false, not as a SQL error")
+	s.False(res.Updated)
+	s.Equal("alice", res.CurrentAssignee, "must surface the existing assignee for use-case error wrapping")
+	s.Equal(types.StatusInProgress, res.CurrentStatus)
+}
+
+func (s *testSuite) issueClaimClosed() {
+	r := s.issueRepo()
+	s.Require().NoError(r.Insert(s.Ctx(), newTestIssue("bd-claim-closed", "x"), "tester", domain.InsertIssueOpts{}))
+	s.Require().NoError(r.Update(s.Ctx(), "bd-claim-closed",
+		map[string]any{"status": string(types.StatusClosed)}, "tester", domain.IssueTableOpts{}))
+
+	res, err := r.Claim(s.Ctx(), "bd-claim-closed", "alice", domain.IssueTableOpts{})
+	s.Require().NoError(err)
+	s.False(res.Updated)
+	s.Equal(types.StatusClosed, res.CurrentStatus, "closed issues are not claimable; CurrentStatus drives ErrNotClaimable in the use case")
+	s.Equal("", res.CurrentAssignee)
+}
+
+func (s *testSuite) issueClaimEmptyID() {
+	_, err := s.issueRepo().Claim(s.Ctx(), "", "alice", domain.IssueTableOpts{})
+	s.Require().Error(err)
+	s.Contains(err.Error(), "id must not be empty")
+}
+
+func (s *testSuite) issueClaimRecordsEvent() {
+	r := s.issueRepo()
+	s.Require().NoError(r.Insert(s.Ctx(), newTestIssue("bd-claim-evt", "x"), "tester", domain.InsertIssueOpts{}))
+
+	res, err := r.Claim(s.Ctx(), "bd-claim-evt", "alice", domain.IssueTableOpts{})
+	s.Require().NoError(err)
+	s.Require().True(res.Updated)
+
+	var count int
+	s.Require().NoError(s.Runner().QueryRowContext(s.Ctx(),
+		"SELECT COUNT(*) FROM events WHERE issue_id = ? AND event_type = ?",
+		"bd-claim-evt", "claimed").Scan(&count))
+	s.Equal(1, count, "successful claim must record exactly one 'claimed' event")
 }

--- a/internal/storage/domain/db/issue_usecase_apply_update_test.go
+++ b/internal/storage/domain/db/issue_usecase_apply_update_test.go
@@ -1,0 +1,210 @@
+package db
+
+import (
+	"errors"
+
+	"github.com/steveyegge/beads/internal/storage"
+	"github.com/steveyegge/beads/internal/storage/domain"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+func (s *testSuite) TestIssueUseCase_Claim() {
+	s.Run("SuccessReturnsEmptyResult", s.iucClaimSuccess)
+	s.Run("IdempotentReclaimMarksAlreadyClaimed", s.iucClaimIdempotent)
+	s.Run("ConflictWrapsErrAlreadyClaimed", s.iucClaimConflict)
+	s.Run("ClosedWrapsErrNotClaimable", s.iucClaimClosed)
+	s.Run("EmptyIDReturnsError", s.iucClaimEmptyID)
+	s.Run("EmptyActorReturnsError", s.iucClaimEmptyActor)
+}
+
+func (s *testSuite) TestIssueUseCase_ApplyUpdate() {
+	s.Run("EmptyIDReturnsError", s.iucApplyUpdateEmptyID)
+	s.Run("FieldsOnlyAppliesAndReFetches", s.iucApplyUpdateFieldsOnly)
+	s.Run("ClaimAndFieldsRunTogether", s.iucApplyUpdateClaimPlusFields)
+	s.Run("AddRemoveLabelPaths", s.iucApplyUpdateAddRemoveLabels)
+	s.Run("SetLabelsDiffsAgainstCurrent", s.iucApplyUpdateSetLabels)
+	s.Run("SetLabelsTakesPrecedenceOverAddRemove", s.iucApplyUpdateSetLabelsBeatsAddRemove)
+	s.Run("ReparentReplacesParent", s.iucApplyUpdateReparent)
+	s.Run("ReparentEmptyUnparents", s.iucApplyUpdateUnparent)
+	s.Run("NoSpecBitsIsHarmless", s.iucApplyUpdateEmptySpec)
+}
+
+func (s *testSuite) seedOpenIssue(id string) {
+	r := s.issueRepo()
+	s.Require().NoError(r.Insert(s.Ctx(), newTestIssue(id, "seed"), "seeder", domain.InsertIssueOpts{}))
+}
+
+func (s *testSuite) iucClaimSuccess() {
+	s.seedOpenIssue("bd-iuc-cl-ok")
+	res, err := s.issueUseCase().ClaimIssue(s.Ctx(), "bd-iuc-cl-ok", "alice")
+	s.Require().NoError(err)
+	s.False(res.AlreadyClaimed)
+	s.Equal("", res.PriorAssignee)
+}
+
+func (s *testSuite) iucClaimIdempotent() {
+	s.seedOpenIssue("bd-iuc-cl-idem")
+	uc := s.issueUseCase()
+	_, err := uc.ClaimIssue(s.Ctx(), "bd-iuc-cl-idem", "alice")
+	s.Require().NoError(err)
+
+	res, err := uc.ClaimIssue(s.Ctx(), "bd-iuc-cl-idem", "alice")
+	s.Require().NoError(err)
+	s.True(res.AlreadyClaimed)
+	s.Equal("alice", res.PriorAssignee)
+}
+
+func (s *testSuite) iucClaimConflict() {
+	s.seedOpenIssue("bd-iuc-cl-conf")
+	uc := s.issueUseCase()
+	_, err := uc.ClaimIssue(s.Ctx(), "bd-iuc-cl-conf", "alice")
+	s.Require().NoError(err)
+
+	_, err = uc.ClaimIssue(s.Ctx(), "bd-iuc-cl-conf", "bob")
+	s.Require().Error(err)
+	s.True(errors.Is(err, storage.ErrAlreadyClaimed), "expected ErrAlreadyClaimed, got %v", err)
+	s.Contains(err.Error(), "alice")
+}
+
+func (s *testSuite) iucClaimClosed() {
+	s.seedOpenIssue("bd-iuc-cl-closed")
+	r := s.issueRepo()
+	s.Require().NoError(r.Update(s.Ctx(), "bd-iuc-cl-closed",
+		map[string]any{"status": string(types.StatusClosed)}, "seeder", domain.IssueTableOpts{}))
+
+	_, err := s.issueUseCase().ClaimIssue(s.Ctx(), "bd-iuc-cl-closed", "alice")
+	s.Require().Error(err)
+	s.True(errors.Is(err, storage.ErrNotClaimable), "expected ErrNotClaimable, got %v", err)
+}
+
+func (s *testSuite) iucClaimEmptyID() {
+	_, err := s.issueUseCase().ClaimIssue(s.Ctx(), "", "alice")
+	s.Require().Error(err)
+}
+
+func (s *testSuite) iucClaimEmptyActor() {
+	_, err := s.issueUseCase().ClaimIssue(s.Ctx(), "bd-x", "")
+	s.Require().Error(err)
+}
+
+func (s *testSuite) iucApplyUpdateEmptyID() {
+	_, err := s.issueUseCase().ApplyUpdate(s.Ctx(), "", domain.UpdateSpec{}, "tester")
+	s.Require().Error(err)
+}
+
+func (s *testSuite) iucApplyUpdateFieldsOnly() {
+	s.seedOpenIssue("bd-iuc-au-f")
+	updated, err := s.issueUseCase().ApplyUpdate(s.Ctx(), "bd-iuc-au-f", domain.UpdateSpec{
+		Fields: map[string]any{"title": "renamed", "priority": 0},
+	}, "tester")
+	s.Require().NoError(err)
+	s.Equal("renamed", updated.Title)
+	s.Equal(0, updated.Priority)
+}
+
+func (s *testSuite) iucApplyUpdateClaimPlusFields() {
+	s.seedOpenIssue("bd-iuc-au-cf")
+	updated, err := s.issueUseCase().ApplyUpdate(s.Ctx(), "bd-iuc-au-cf", domain.UpdateSpec{
+		Claim:  true,
+		Fields: map[string]any{"priority": 1},
+	}, "alice")
+	s.Require().NoError(err)
+	s.Equal("alice", updated.Assignee)
+	s.Equal(types.StatusInProgress, updated.Status)
+	s.Equal(1, updated.Priority)
+}
+
+func (s *testSuite) iucApplyUpdateAddRemoveLabels() {
+	s.seedOpenIssue("bd-iuc-au-arl")
+	uc := s.issueUseCase()
+	_, err := uc.ApplyUpdate(s.Ctx(), "bd-iuc-au-arl", domain.UpdateSpec{
+		AddLabels: []string{"keep", "drop"},
+	}, "tester")
+	s.Require().NoError(err)
+
+	_, err = uc.ApplyUpdate(s.Ctx(), "bd-iuc-au-arl", domain.UpdateSpec{
+		AddLabels:    []string{"new"},
+		RemoveLabels: []string{"drop"},
+	}, "tester")
+	s.Require().NoError(err)
+
+	labels, err := s.labelUseCase().GetLabels(s.Ctx(), "bd-iuc-au-arl")
+	s.Require().NoError(err)
+	s.Equal([]string{"keep", "new"}, labels)
+}
+
+func (s *testSuite) iucApplyUpdateSetLabels() {
+	s.seedOpenIssue("bd-iuc-au-sl")
+	uc := s.issueUseCase()
+	_, err := uc.ApplyUpdate(s.Ctx(), "bd-iuc-au-sl", domain.UpdateSpec{
+		AddLabels: []string{"x", "y"},
+	}, "tester")
+	s.Require().NoError(err)
+
+	desired := []string{"y", "z"}
+	_, err = uc.ApplyUpdate(s.Ctx(), "bd-iuc-au-sl", domain.UpdateSpec{
+		SetLabels: &desired,
+	}, "tester")
+	s.Require().NoError(err)
+
+	labels, err := s.labelUseCase().GetLabels(s.Ctx(), "bd-iuc-au-sl")
+	s.Require().NoError(err)
+	s.Equal([]string{"y", "z"}, labels)
+}
+
+func (s *testSuite) iucApplyUpdateSetLabelsBeatsAddRemove() {
+	s.seedOpenIssue("bd-iuc-au-sl-prec")
+	uc := s.issueUseCase()
+
+	desired := []string{"only-this"}
+	_, err := uc.ApplyUpdate(s.Ctx(), "bd-iuc-au-sl-prec", domain.UpdateSpec{
+		AddLabels:    []string{"add-me"},
+		RemoveLabels: []string{"remove-me"},
+		SetLabels:    &desired,
+	}, "tester")
+	s.Require().NoError(err)
+
+	labels, err := s.labelUseCase().GetLabels(s.Ctx(), "bd-iuc-au-sl-prec")
+	s.Require().NoError(err)
+	s.Equal([]string{"only-this"}, labels)
+}
+
+func (s *testSuite) iucApplyUpdateReparent() {
+	s.seedOpenIssue("bd-iuc-au-rp-c")
+	s.seedOpenIssue("bd-iuc-au-rp-old")
+	s.seedOpenIssue("bd-iuc-au-rp-new")
+	depRepo := NewDependencySQLRepository(s.Runner())
+	s.Require().NoError(depRepo.Insert(s.Ctx(),
+		newDep("bd-iuc-au-rp-c", "bd-iuc-au-rp-old", types.DepParentChild), "seeder", domain.DepInsertOpts{}))
+
+	newParent := "bd-iuc-au-rp-new"
+	_, err := s.issueUseCase().ApplyUpdate(s.Ctx(), "bd-iuc-au-rp-c", domain.UpdateSpec{
+		Reparent: &newParent,
+	}, "tester")
+	s.Require().NoError(err)
+
+	s.Equal("bd-iuc-au-rp-new", s.currentParent("bd-iuc-au-rp-c"))
+}
+
+func (s *testSuite) iucApplyUpdateUnparent() {
+	s.seedOpenIssue("bd-iuc-au-up-c")
+	s.seedOpenIssue("bd-iuc-au-up-p")
+	depRepo := NewDependencySQLRepository(s.Runner())
+	s.Require().NoError(depRepo.Insert(s.Ctx(),
+		newDep("bd-iuc-au-up-c", "bd-iuc-au-up-p", types.DepParentChild), "seeder", domain.DepInsertOpts{}))
+
+	empty := ""
+	_, err := s.issueUseCase().ApplyUpdate(s.Ctx(), "bd-iuc-au-up-c", domain.UpdateSpec{
+		Reparent: &empty,
+	}, "tester")
+	s.Require().NoError(err)
+
+	s.Equal("", s.currentParent("bd-iuc-au-up-c"))
+}
+
+func (s *testSuite) iucApplyUpdateEmptySpec() {
+	s.seedOpenIssue("bd-iuc-au-empty")
+	updated, err := s.issueUseCase().ApplyUpdate(s.Ctx(), "bd-iuc-au-empty", domain.UpdateSpec{}, "tester")
+	s.Require().NoError(err)
+	s.Equal("bd-iuc-au-empty", updated.ID)
+}

--- a/internal/storage/domain/db/issue_usecase_apply_update_test.go
+++ b/internal/storage/domain/db/issue_usecase_apply_update_test.go
@@ -15,6 +15,7 @@ func (s *testSuite) TestIssueUseCase_Claim() {
 	s.Run("ClosedWrapsErrNotClaimable", s.iucClaimClosed)
 	s.Run("EmptyIDReturnsError", s.iucClaimEmptyID)
 	s.Run("EmptyActorReturnsError", s.iucClaimEmptyActor)
+	s.Run("ClaimWispWritesToWispsTable", s.iucClaimWispWritesToWispsTable)
 }
 
 func (s *testSuite) TestIssueUseCase_ApplyUpdate() {
@@ -27,6 +28,8 @@ func (s *testSuite) TestIssueUseCase_ApplyUpdate() {
 	s.Run("ReparentReplacesParent", s.iucApplyUpdateReparent)
 	s.Run("ReparentEmptyUnparents", s.iucApplyUpdateUnparent)
 	s.Run("NoSpecBitsIsHarmless", s.iucApplyUpdateEmptySpec)
+	s.Run("WispIDDispatchesToWispTables", s.iucApplyUpdateDispatchesToWisp)
+	s.Run("ClaimAgainstWispDispatches", s.iucClaimDispatchesToWisp)
 }
 
 func (s *testSuite) seedOpenIssue(id string) {
@@ -207,4 +210,71 @@ func (s *testSuite) iucApplyUpdateEmptySpec() {
 	updated, err := s.issueUseCase().ApplyUpdate(s.Ctx(), "bd-iuc-au-empty", domain.UpdateSpec{}, "tester")
 	s.Require().NoError(err)
 	s.Equal("bd-iuc-au-empty", updated.ID)
+}
+
+func (s *testSuite) seedOpenWisp(id string) {
+	r := s.issueRepo()
+	w := newTestIssue(id, "seed wisp")
+	w.Ephemeral = true
+	s.Require().NoError(r.Insert(s.Ctx(), w, "seeder", domain.InsertIssueOpts{UseWispsTable: true}))
+}
+
+func (s *testSuite) iucApplyUpdateDispatchesToWisp() {
+	s.seedOpenWisp("bd-iuc-au-wisp-c")
+	s.seedOpenWisp("bd-iuc-au-wisp-newp")
+	depRepo := NewDependencySQLRepository(s.Runner())
+	s.Require().NoError(depRepo.Insert(s.Ctx(),
+		&types.Dependency{IssueID: "bd-iuc-au-wisp-c", DependsOnID: "bd-iuc-au-wisp-newp", Type: types.DepParentChild},
+		"seeder", domain.DepInsertOpts{UseWispsTable: true}))
+
+	setLabels := []string{"alpha", "beta"}
+	reparent := "bd-iuc-au-wisp-newp"
+	updated, err := s.issueUseCase().ApplyUpdate(s.Ctx(), "bd-iuc-au-wisp-c", domain.UpdateSpec{
+		Fields:    map[string]any{"title": "wisp renamed"},
+		SetLabels: &setLabels,
+		Reparent:  &reparent,
+	}, "tester")
+	s.Require().NoError(err)
+	s.Equal("wisp renamed", updated.Title)
+
+	wispRow, err := s.issueRepo().Get(s.Ctx(), "bd-iuc-au-wisp-c", domain.IssueTableOpts{UseWispsTable: true})
+	s.Require().NoError(err)
+	s.Equal("wisp renamed", wispRow.Title, "update must land in wisps table")
+
+	wispLabels, err := s.labelUseCase().GetWispLabels(s.Ctx(), "bd-iuc-au-wisp-c")
+	s.Require().NoError(err)
+	s.Equal([]string{"alpha", "beta"}, wispLabels)
+
+	var issueLabelCount int
+	s.Require().NoError(s.Runner().QueryRowContext(s.Ctx(),
+		"SELECT COUNT(*) FROM labels WHERE issue_id = ?", "bd-iuc-au-wisp-c").Scan(&issueLabelCount))
+	s.Equal(0, issueLabelCount, "wisp-dispatched ApplyUpdate must not write to issues label table")
+}
+
+func (s *testSuite) iucClaimWispWritesToWispsTable() {
+	s.seedOpenWisp("bd-iuc-clw-wisp")
+
+	res, err := s.issueUseCase().ClaimWisp(s.Ctx(), "bd-iuc-clw-wisp", "alice")
+	s.Require().NoError(err)
+	s.False(res.AlreadyClaimed)
+
+	wispRow, err := s.issueRepo().Get(s.Ctx(), "bd-iuc-clw-wisp", domain.IssueTableOpts{UseWispsTable: true})
+	s.Require().NoError(err)
+	s.Equal("alice", wispRow.Assignee)
+	s.Equal(types.StatusInProgress, wispRow.Status)
+}
+
+func (s *testSuite) iucClaimDispatchesToWisp() {
+	s.seedOpenWisp("bd-iuc-au-clw-wisp")
+
+	updated, err := s.issueUseCase().ApplyUpdate(s.Ctx(), "bd-iuc-au-clw-wisp", domain.UpdateSpec{
+		Claim: true,
+	}, "alice")
+	s.Require().NoError(err)
+	s.Equal("alice", updated.Assignee)
+	s.Equal(types.StatusInProgress, updated.Status)
+
+	wispRow, err := s.issueRepo().Get(s.Ctx(), "bd-iuc-au-clw-wisp", domain.IssueTableOpts{UseWispsTable: true})
+	s.Require().NoError(err)
+	s.Equal("alice", wispRow.Assignee, "ApplyUpdate's Claim branch must route to ClaimWisp for a wisp id")
 }

--- a/internal/storage/domain/db/issue_usecase_test.go
+++ b/internal/storage/domain/db/issue_usecase_test.go
@@ -20,6 +20,8 @@ func (s *testSuite) TestIssueUseCase_MintTopLevelID() {
 
 func (s *testSuite) issueUseCase() domain.IssueUseCase {
 	runner := s.Runner()
+	labelUC := domain.NewLabelUseCase(NewLabelSQLRepository(runner))
+	depUC := domain.NewDependencyUseCase(NewDependencySQLRepository(runner))
 	return domain.NewIssueUseCase(
 		NewIssueSQLRepository(runner),
 		NewDependencySQLRepository(runner),
@@ -27,6 +29,8 @@ func (s *testSuite) issueUseCase() domain.IssueUseCase {
 		NewChildCounterSQLRepository(runner),
 		NewCommentSQLRepository(runner),
 		NewConfigSQLRepository(runner),
+		labelUC,
+		depUC,
 	)
 }
 

--- a/internal/storage/domain/db/label.go
+++ b/internal/storage/domain/db/label.go
@@ -53,6 +53,29 @@ func (r *labelSQLRepositoryImpl) Insert(ctx context.Context, issueID, label, act
 	}, domain.RecordEventOpts{UseWispsTable: opts.UseWispsTable})
 }
 
+func (r *labelSQLRepositoryImpl) Delete(ctx context.Context, issueID, label, actor string, opts domain.LabelOpts) error {
+	if issueID == "" {
+		return fmt.Errorf("db: LabelSQLRepository.Delete: issueID must not be empty")
+	}
+	if label == "" {
+		return fmt.Errorf("db: LabelSQLRepository.Delete: label must not be empty")
+	}
+	table := pickLabelTable(opts.UseWispsTable)
+	//nolint:gosec // G201: table is one of two hardcoded constants
+	if _, err := r.runner.ExecContext(ctx,
+		fmt.Sprintf("DELETE FROM %s WHERE issue_id = ? AND label = ?", table),
+		issueID, label,
+	); err != nil {
+		return fmt.Errorf("db: LabelSQLRepository.Delete %s/%s: %w", issueID, label, err)
+	}
+	return r.events.Record(ctx, domain.Event{
+		IssueID:  issueID,
+		Type:     types.EventLabelRemoved,
+		Actor:    actor,
+		OldValue: label,
+	}, domain.RecordEventOpts{UseWispsTable: opts.UseWispsTable})
+}
+
 func (r *labelSQLRepositoryImpl) List(ctx context.Context, issueID string, opts domain.LabelOpts) ([]string, error) {
 	if issueID == "" {
 		return nil, fmt.Errorf("db: LabelSQLRepository.List: issueID must not be empty")

--- a/internal/storage/domain/db/label_test.go
+++ b/internal/storage/domain/db/label_test.go
@@ -14,6 +14,15 @@ func (s *testSuite) TestLabelSQLRepository() {
 		s.Run("RejectsEmptyLabel", s.labelInsertEmptyLabel)
 		s.Run("MissingIssueIDFailsFK", s.labelInsertFKViolation)
 	})
+	s.Run("Delete", func() {
+		s.Run("RemovesLabelRow", s.labelDeleteRemoves)
+		s.Run("RecordsLabelRemovedEvent", s.labelDeleteRecordsEvent)
+		s.Run("MissingLabelIsNoop", s.labelDeleteMissingNoop)
+		s.Run("OnlyTargetLabelRemoved", s.labelDeleteSpecificLabel)
+		s.Run("RejectsEmptyIssueID", s.labelDeleteEmptyIssueID)
+		s.Run("RejectsEmptyLabel", s.labelDeleteEmptyLabel)
+		s.Run("WispRoutesToWispLabels", s.labelDeleteWispRouting)
+	})
 	s.Run("List", func() {
 		s.Run("OrdersByLabelAlpha", s.labelListAlphaOrder)
 		s.Run("UnknownIssueReturnsEmpty", s.labelListUnknown)
@@ -213,4 +222,95 @@ func (s *testSuite) labelWispBulkIsolated() {
 	s.Require().NoError(err)
 	s.Equal([]string{"a", "b"}, out["bd-lbl-wbulk-1"])
 	s.Equal([]string{"c"}, out["bd-lbl-wbulk-2"])
+}
+
+func (s *testSuite) labelDeleteRemoves() {
+	s.seedIssueRow("bd-lbl-del-1")
+	r := s.labelRepo()
+	s.Require().NoError(r.Insert(s.Ctx(), "bd-lbl-del-1", "tech-debt", "tester", domain.LabelOpts{}))
+
+	s.Require().NoError(r.Delete(s.Ctx(), "bd-lbl-del-1", "tech-debt", "tester", domain.LabelOpts{}))
+
+	out, err := r.List(s.Ctx(), "bd-lbl-del-1", domain.LabelOpts{})
+	s.Require().NoError(err)
+	s.Empty(out, "deleted label should no longer appear in List")
+}
+
+func (s *testSuite) labelDeleteRecordsEvent() {
+	s.seedIssueRow("bd-lbl-del-evt")
+	r := s.labelRepo()
+	s.Require().NoError(r.Insert(s.Ctx(), "bd-lbl-del-evt", "perf", "alice", domain.LabelOpts{}))
+	s.Require().NoError(r.Delete(s.Ctx(), "bd-lbl-del-evt", "perf", "bob", domain.LabelOpts{}))
+
+	var actor, oldValue string
+	s.Require().NoError(s.Runner().QueryRowContext(s.Ctx(),
+		"SELECT actor, old_value FROM events WHERE issue_id = ? AND event_type = ?",
+		"bd-lbl-del-evt", string(types.EventLabelRemoved),
+	).Scan(&actor, &oldValue))
+	s.Equal("bob", actor)
+	s.Equal("perf", oldValue, "event old_value should carry the removed label name (symmetric with Insert's new_value)")
+}
+
+func (s *testSuite) labelDeleteMissingNoop() {
+	s.seedIssueRow("bd-lbl-del-miss")
+	r := s.labelRepo()
+	s.Require().NoError(r.Delete(s.Ctx(), "bd-lbl-del-miss", "never-there", "tester", domain.LabelOpts{}))
+
+	out, err := r.List(s.Ctx(), "bd-lbl-del-miss", domain.LabelOpts{})
+	s.Require().NoError(err)
+	s.Empty(out)
+}
+
+func (s *testSuite) labelDeleteSpecificLabel() {
+	s.seedIssueRow("bd-lbl-del-specific")
+	r := s.labelRepo()
+	s.Require().NoError(r.Insert(s.Ctx(), "bd-lbl-del-specific", "keep", "tester", domain.LabelOpts{}))
+	s.Require().NoError(r.Insert(s.Ctx(), "bd-lbl-del-specific", "drop", "tester", domain.LabelOpts{}))
+	s.Require().NoError(r.Insert(s.Ctx(), "bd-lbl-del-specific", "stay", "tester", domain.LabelOpts{}))
+
+	s.Require().NoError(r.Delete(s.Ctx(), "bd-lbl-del-specific", "drop", "tester", domain.LabelOpts{}))
+
+	out, err := r.List(s.Ctx(), "bd-lbl-del-specific", domain.LabelOpts{})
+	s.Require().NoError(err)
+	s.Equal([]string{"keep", "stay"}, out, "Delete must target only the named label, not siblings on the same issue")
+}
+
+func (s *testSuite) labelDeleteEmptyIssueID() {
+	err := s.labelRepo().Delete(s.Ctx(), "", "x", "tester", domain.LabelOpts{})
+	s.Require().Error(err)
+}
+
+func (s *testSuite) labelDeleteEmptyLabel() {
+	err := s.labelRepo().Delete(s.Ctx(), "bd-lbl-del-x", "", "tester", domain.LabelOpts{})
+	s.Require().Error(err)
+}
+
+func (s *testSuite) labelDeleteWispRouting() {
+	s.seedIssueRow("bd-lbl-del-cross-perm")
+	s.seedWispRow("bd-lbl-del-cross-wisp")
+	r := s.labelRepo()
+	s.Require().NoError(r.Insert(s.Ctx(), "bd-lbl-del-cross-perm", "shared", "tester", domain.LabelOpts{}))
+	s.Require().NoError(r.Insert(s.Ctx(), "bd-lbl-del-cross-wisp", "shared", "tester", domain.LabelOpts{UseWispsTable: true}))
+
+	s.Require().NoError(r.Delete(s.Ctx(), "bd-lbl-del-cross-wisp", "shared", "tester", domain.LabelOpts{UseWispsTable: true}))
+
+	var wispCount, permCount int
+	s.Require().NoError(s.Runner().QueryRowContext(s.Ctx(),
+		"SELECT COUNT(*) FROM wisp_labels WHERE issue_id = ?", "bd-lbl-del-cross-wisp").Scan(&wispCount))
+	s.Equal(0, wispCount, "wisp-routed Delete must remove the wisp_labels row")
+	s.Require().NoError(s.Runner().QueryRowContext(s.Ctx(),
+		"SELECT COUNT(*) FROM labels WHERE issue_id = ?", "bd-lbl-del-cross-perm").Scan(&permCount))
+	s.Equal(1, permCount, "wisp-routed Delete must not touch the labels table")
+
+	var wispEvt, permEvt int
+	s.Require().NoError(s.Runner().QueryRowContext(s.Ctx(),
+		"SELECT COUNT(*) FROM wisp_events WHERE issue_id = ? AND event_type = ?",
+		"bd-lbl-del-cross-wisp", string(types.EventLabelRemoved),
+	).Scan(&wispEvt))
+	s.Equal(1, wispEvt)
+	s.Require().NoError(s.Runner().QueryRowContext(s.Ctx(),
+		"SELECT COUNT(*) FROM events WHERE issue_id = ? AND event_type = ?",
+		"bd-lbl-del-cross-wisp", string(types.EventLabelRemoved),
+	).Scan(&permEvt))
+	s.Equal(0, permEvt, "wisp-routed Delete must record the event in wisp_events, not events")
 }

--- a/internal/storage/domain/db/label_usecase_test.go
+++ b/internal/storage/domain/db/label_usecase_test.go
@@ -26,6 +26,12 @@ func (s *testSuite) TestLabelUseCase() {
 		s.Run("SameSetIsNoop", s.lucSetLabelsSameSet)
 		s.Run("EmptyDesiredRemovesAll", s.lucSetLabelsEmptyClears)
 	})
+	s.Run("Wisp", func() {
+		s.Run("RemoveWispLabelRoutesToWispLabels", s.lucRemoveWispLabelRoutes)
+		s.Run("AddWispLabelsRoutesToWispLabels", s.lucAddWispLabelsRoutes)
+		s.Run("RemoveWispLabelsRoutesToWispLabels", s.lucRemoveWispLabelsRoutes)
+		s.Run("SetWispLabelsDiffsWispsTable", s.lucSetWispLabelsDiffs)
+	})
 }
 
 func (s *testSuite) labelUseCase() domain.LabelUseCase {
@@ -153,4 +159,54 @@ func (s *testSuite) lucSetLabelsEmptyClears() {
 	out, err := uc.GetLabels(s.Ctx(), "bd-luc-sl-clear")
 	s.Require().NoError(err)
 	s.Empty(out)
+}
+
+func (s *testSuite) lucRemoveWispLabelRoutes() {
+	s.seedWispRow("bd-lwc-rwl")
+	uc := s.labelUseCase()
+	s.Require().NoError(uc.AddWispLabel(s.Ctx(), "bd-lwc-rwl", "drop", "tester"))
+
+	s.Require().NoError(uc.RemoveWispLabel(s.Ctx(), "bd-lwc-rwl", "drop", "tester"))
+
+	wispLabels, err := uc.GetWispLabels(s.Ctx(), "bd-lwc-rwl")
+	s.Require().NoError(err)
+	s.Empty(wispLabels)
+}
+
+func (s *testSuite) lucAddWispLabelsRoutes() {
+	s.seedWispRow("bd-lwc-awl")
+	uc := s.labelUseCase()
+	s.Require().NoError(uc.AddWispLabels(s.Ctx(), "bd-lwc-awl", []string{"a", "", "b"}, "tester"))
+
+	wispLabels, err := uc.GetWispLabels(s.Ctx(), "bd-lwc-awl")
+	s.Require().NoError(err)
+	s.Equal([]string{"a", "b"}, wispLabels)
+
+	issueLabels, err := uc.GetLabels(s.Ctx(), "bd-lwc-awl")
+	s.Require().NoError(err)
+	s.Empty(issueLabels, "wisp-routed Add must not touch the issues label table")
+}
+
+func (s *testSuite) lucRemoveWispLabelsRoutes() {
+	s.seedWispRow("bd-lwc-rwls")
+	uc := s.labelUseCase()
+	s.Require().NoError(uc.AddWispLabels(s.Ctx(), "bd-lwc-rwls", []string{"keep", "drop1", "drop2"}, "tester"))
+
+	s.Require().NoError(uc.RemoveWispLabels(s.Ctx(), "bd-lwc-rwls", []string{"drop1", "drop2"}, "tester"))
+
+	wispLabels, err := uc.GetWispLabels(s.Ctx(), "bd-lwc-rwls")
+	s.Require().NoError(err)
+	s.Equal([]string{"keep"}, wispLabels)
+}
+
+func (s *testSuite) lucSetWispLabelsDiffs() {
+	s.seedWispRow("bd-lwc-swl")
+	uc := s.labelUseCase()
+	s.Require().NoError(uc.AddWispLabels(s.Ctx(), "bd-lwc-swl", []string{"keep", "drop"}, "tester"))
+
+	s.Require().NoError(uc.SetWispLabels(s.Ctx(), "bd-lwc-swl", []string{"keep", "add"}, "tester"))
+
+	wispLabels, err := uc.GetWispLabels(s.Ctx(), "bd-lwc-swl")
+	s.Require().NoError(err)
+	s.Equal([]string{"add", "keep"}, wispLabels)
 }

--- a/internal/storage/domain/db/label_usecase_test.go
+++ b/internal/storage/domain/db/label_usecase_test.go
@@ -1,0 +1,156 @@
+package db
+
+import (
+	"github.com/steveyegge/beads/internal/storage/domain"
+)
+
+func (s *testSuite) TestLabelUseCase() {
+	s.Run("RemoveLabel", func() {
+		s.Run("EmptyIDReturnsError", s.lucRemoveLabelEmptyID)
+		s.Run("EmptyLabelReturnsError", s.lucRemoveLabelEmptyLabel)
+		s.Run("DelegatesToRepoDelete", s.lucRemoveLabelDelegates)
+	})
+	s.Run("AddLabels", func() {
+		s.Run("EmptyIDReturnsError", s.lucAddLabelsEmptyID)
+		s.Run("SkipsEmptyEntries", s.lucAddLabelsSkipsEmpty)
+		s.Run("AddsAllProvided", s.lucAddLabelsAll)
+	})
+	s.Run("RemoveLabels", func() {
+		s.Run("EmptyIDReturnsError", s.lucRemoveLabelsEmptyID)
+		s.Run("SkipsEmptyEntries", s.lucRemoveLabelsSkipsEmpty)
+		s.Run("RemovesAllProvided", s.lucRemoveLabelsAll)
+	})
+	s.Run("SetLabels", func() {
+		s.Run("EmptyIDReturnsError", s.lucSetLabelsEmptyID)
+		s.Run("DiffAddsAndRemoves", s.lucSetLabelsDiffs)
+		s.Run("SameSetIsNoop", s.lucSetLabelsSameSet)
+		s.Run("EmptyDesiredRemovesAll", s.lucSetLabelsEmptyClears)
+	})
+}
+
+func (s *testSuite) labelUseCase() domain.LabelUseCase {
+	return domain.NewLabelUseCase(NewLabelSQLRepository(s.Runner()))
+}
+
+func (s *testSuite) lucRemoveLabelEmptyID() {
+	err := s.labelUseCase().RemoveLabel(s.Ctx(), "", "x", "tester")
+	s.Require().Error(err)
+}
+
+func (s *testSuite) lucRemoveLabelEmptyLabel() {
+	err := s.labelUseCase().RemoveLabel(s.Ctx(), "bd-luc-rl", "", "tester")
+	s.Require().Error(err)
+}
+
+func (s *testSuite) lucRemoveLabelDelegates() {
+	s.seedIssueRow("bd-luc-rl-1")
+	uc := s.labelUseCase()
+	s.Require().NoError(uc.AddLabel(s.Ctx(), "bd-luc-rl-1", "drop-me", "tester"))
+
+	s.Require().NoError(uc.RemoveLabel(s.Ctx(), "bd-luc-rl-1", "drop-me", "tester"))
+
+	out, err := uc.GetLabels(s.Ctx(), "bd-luc-rl-1")
+	s.Require().NoError(err)
+	s.Empty(out)
+}
+
+func (s *testSuite) lucAddLabelsEmptyID() {
+	err := s.labelUseCase().AddLabels(s.Ctx(), "", []string{"x"}, "tester")
+	s.Require().Error(err)
+}
+
+func (s *testSuite) lucAddLabelsSkipsEmpty() {
+	s.seedIssueRow("bd-luc-al-skip")
+	uc := s.labelUseCase()
+	s.Require().NoError(uc.AddLabels(s.Ctx(), "bd-luc-al-skip", []string{"a", "", "b", ""}, "tester"))
+
+	out, err := uc.GetLabels(s.Ctx(), "bd-luc-al-skip")
+	s.Require().NoError(err)
+	s.Equal([]string{"a", "b"}, out)
+}
+
+func (s *testSuite) lucAddLabelsAll() {
+	s.seedIssueRow("bd-luc-al-1")
+	uc := s.labelUseCase()
+	s.Require().NoError(uc.AddLabels(s.Ctx(), "bd-luc-al-1", []string{"one", "two", "three"}, "tester"))
+
+	out, err := uc.GetLabels(s.Ctx(), "bd-luc-al-1")
+	s.Require().NoError(err)
+	s.Equal([]string{"one", "three", "two"}, out)
+}
+
+func (s *testSuite) lucRemoveLabelsEmptyID() {
+	err := s.labelUseCase().RemoveLabels(s.Ctx(), "", []string{"x"}, "tester")
+	s.Require().Error(err)
+}
+
+func (s *testSuite) lucRemoveLabelsSkipsEmpty() {
+	s.seedIssueRow("bd-luc-rml-skip")
+	uc := s.labelUseCase()
+	s.Require().NoError(uc.AddLabels(s.Ctx(), "bd-luc-rml-skip", []string{"a", "b", "c"}, "tester"))
+
+	s.Require().NoError(uc.RemoveLabels(s.Ctx(), "bd-luc-rml-skip", []string{"a", "", "c"}, "tester"))
+
+	out, err := uc.GetLabels(s.Ctx(), "bd-luc-rml-skip")
+	s.Require().NoError(err)
+	s.Equal([]string{"b"}, out)
+}
+
+func (s *testSuite) lucRemoveLabelsAll() {
+	s.seedIssueRow("bd-luc-rml-1")
+	uc := s.labelUseCase()
+	s.Require().NoError(uc.AddLabels(s.Ctx(), "bd-luc-rml-1", []string{"a", "b"}, "tester"))
+
+	s.Require().NoError(uc.RemoveLabels(s.Ctx(), "bd-luc-rml-1", []string{"a", "b"}, "tester"))
+
+	out, err := uc.GetLabels(s.Ctx(), "bd-luc-rml-1")
+	s.Require().NoError(err)
+	s.Empty(out)
+}
+
+func (s *testSuite) lucSetLabelsEmptyID() {
+	err := s.labelUseCase().SetLabels(s.Ctx(), "", []string{"x"}, "tester")
+	s.Require().Error(err)
+}
+
+func (s *testSuite) lucSetLabelsDiffs() {
+	s.seedIssueRow("bd-luc-sl-diff")
+	uc := s.labelUseCase()
+	s.Require().NoError(uc.AddLabels(s.Ctx(), "bd-luc-sl-diff", []string{"keep", "drop"}, "tester"))
+
+	s.Require().NoError(uc.SetLabels(s.Ctx(), "bd-luc-sl-diff", []string{"keep", "add"}, "tester"))
+
+	out, err := uc.GetLabels(s.Ctx(), "bd-luc-sl-diff")
+	s.Require().NoError(err)
+	s.Equal([]string{"add", "keep"}, out)
+}
+
+func (s *testSuite) lucSetLabelsSameSet() {
+	s.seedIssueRow("bd-luc-sl-same")
+	uc := s.labelUseCase()
+	s.Require().NoError(uc.AddLabels(s.Ctx(), "bd-luc-sl-same", []string{"x", "y"}, "tester"))
+
+	s.Require().NoError(uc.SetLabels(s.Ctx(), "bd-luc-sl-same", []string{"x", "y"}, "tester"))
+
+	out, err := uc.GetLabels(s.Ctx(), "bd-luc-sl-same")
+	s.Require().NoError(err)
+	s.Equal([]string{"x", "y"}, out)
+
+	var removedEvents int
+	s.Require().NoError(s.Runner().QueryRowContext(s.Ctx(),
+		"SELECT COUNT(*) FROM events WHERE issue_id = ? AND event_type = 'label_removed'",
+		"bd-luc-sl-same").Scan(&removedEvents))
+	s.Equal(0, removedEvents)
+}
+
+func (s *testSuite) lucSetLabelsEmptyClears() {
+	s.seedIssueRow("bd-luc-sl-clear")
+	uc := s.labelUseCase()
+	s.Require().NoError(uc.AddLabels(s.Ctx(), "bd-luc-sl-clear", []string{"a", "b"}, "tester"))
+
+	s.Require().NoError(uc.SetLabels(s.Ctx(), "bd-luc-sl-clear", nil, "tester"))
+
+	out, err := uc.GetLabels(s.Ctx(), "bd-luc-sl-clear")
+	s.Require().NoError(err)
+	s.Empty(out)
+}

--- a/internal/storage/domain/dependency.go
+++ b/internal/storage/domain/dependency.go
@@ -46,8 +46,15 @@ type BlockingInfo struct {
 	Parent    map[string]string
 }
 
+type DepDeleteResult struct {
+	Found       bool
+	Type        types.DependencyType
+	DependsOnID string
+}
+
 type DependencySQLRepository interface {
 	Insert(ctx context.Context, dep *types.Dependency, actor string, opts DepInsertOpts) error
+	Delete(ctx context.Context, issueID, dependsOnID, actor string, opts DepInsertOpts) (DepDeleteResult, error)
 	HasCycle(ctx context.Context, issueID, dependsOnID string) (bool, error)
 	ListByIssueIDs(ctx context.Context, issueIDs []string, opts DepListOpts) (DepBulkResult, error)
 	CountsByIssueIDs(ctx context.Context, issueIDs []string, opts DepCountsOpts) (map[string]*types.DependencyCounts, error)
@@ -58,6 +65,8 @@ type DependencySQLRepository interface {
 
 type DependencyUseCase interface {
 	AddDependency(ctx context.Context, dep *types.Dependency, actor string) error
+	RemoveDependency(ctx context.Context, issueID, dependsOnID, actor string) error
+	Reparent(ctx context.Context, childID, newParentID, actor string) error
 	ListByIssueIDs(ctx context.Context, issueIDs []string, filter DepListFilter) (DepBulkResult, error)
 	CountsByIssueIDs(ctx context.Context, issueIDs []string) (map[string]*types.DependencyCounts, error)
 	GetBlockingInfo(ctx context.Context, issueIDs []string) (BlockingInfo, error)
@@ -106,6 +115,63 @@ func (u *dependencyUseCaseImpl) add(ctx context.Context, dep *types.Dependency, 
 
 	if err := u.depRepo.Insert(ctx, dep, actor, DepInsertOpts{UseWispsTable: useWisp}); err != nil {
 		return fmt.Errorf("add dep: insert: %w", err)
+	}
+	return nil
+}
+
+func (u *dependencyUseCaseImpl) RemoveDependency(ctx context.Context, issueID, dependsOnID, actor string) error {
+	if issueID == "" || dependsOnID == "" {
+		return fmt.Errorf("remove dep: issueID and dependsOnID must not be empty")
+	}
+	if _, err := u.depRepo.Delete(ctx, issueID, dependsOnID, actor, DepInsertOpts{}); err != nil {
+		return fmt.Errorf("remove dep %s -> %s: %w", issueID, dependsOnID, err)
+	}
+	return nil
+}
+
+func (u *dependencyUseCaseImpl) Reparent(ctx context.Context, childID, newParentID, actor string) error {
+	if childID == "" {
+		return fmt.Errorf("reparent: childID must not be empty")
+	}
+	if childID == newParentID {
+		return fmt.Errorf("reparent: %s cannot be its own parent", childID)
+	}
+
+	res, err := u.depRepo.ListByIssueIDs(ctx, []string{childID}, DepListOpts{
+		Types:     []types.DependencyType{types.DepParentChild},
+		Direction: DepDirectionOut,
+	})
+	if err != nil {
+		return fmt.Errorf("reparent: list current parent: %w", err)
+	}
+
+	var oldParentID string
+	for _, dep := range res.Outgoing[childID] {
+		if dep.Type == types.DepParentChild {
+			oldParentID = dep.DependsOnID
+			break
+		}
+	}
+
+	if oldParentID == newParentID {
+		return nil
+	}
+
+	if oldParentID != "" {
+		if _, err := u.depRepo.Delete(ctx, childID, oldParentID, actor, DepInsertOpts{}); err != nil {
+			return fmt.Errorf("reparent: remove old parent %s: %w", oldParentID, err)
+		}
+	}
+
+	if newParentID != "" {
+		dep := &types.Dependency{
+			IssueID:     childID,
+			DependsOnID: newParentID,
+			Type:        types.DepParentChild,
+		}
+		if err := u.depRepo.Insert(ctx, dep, actor, DepInsertOpts{}); err != nil {
+			return fmt.Errorf("reparent: add new parent %s: %w", newParentID, err)
+		}
 	}
 	return nil
 }

--- a/internal/storage/domain/dependency.go
+++ b/internal/storage/domain/dependency.go
@@ -73,6 +73,8 @@ type DependencyUseCase interface {
 	GetForIssueIDs(ctx context.Context, ids []string) (map[string][]*types.Dependency, error)
 
 	AddWispDependency(ctx context.Context, dep *types.Dependency, actor string) error
+	RemoveWispDependency(ctx context.Context, wispID, dependsOnID, actor string) error
+	ReparentWisp(ctx context.Context, childWispID, newParentID, actor string) error
 	ListByWispIDs(ctx context.Context, wispIDs []string, filter DepListFilter) (DepBulkResult, error)
 	CountsByWispIDs(ctx context.Context, wispIDs []string) (map[string]*types.DependencyCounts, error)
 }
@@ -120,16 +122,32 @@ func (u *dependencyUseCaseImpl) add(ctx context.Context, dep *types.Dependency, 
 }
 
 func (u *dependencyUseCaseImpl) RemoveDependency(ctx context.Context, issueID, dependsOnID, actor string) error {
-	if issueID == "" || dependsOnID == "" {
-		return fmt.Errorf("remove dep: issueID and dependsOnID must not be empty")
+	return u.removeDep(ctx, issueID, dependsOnID, actor, false)
+}
+
+func (u *dependencyUseCaseImpl) RemoveWispDependency(ctx context.Context, wispID, dependsOnID, actor string) error {
+	return u.removeDep(ctx, wispID, dependsOnID, actor, true)
+}
+
+func (u *dependencyUseCaseImpl) removeDep(ctx context.Context, sourceID, dependsOnID, actor string, useWisp bool) error {
+	if sourceID == "" || dependsOnID == "" {
+		return fmt.Errorf("remove dep: sourceID and dependsOnID must not be empty")
 	}
-	if _, err := u.depRepo.Delete(ctx, issueID, dependsOnID, actor, DepInsertOpts{}); err != nil {
-		return fmt.Errorf("remove dep %s -> %s: %w", issueID, dependsOnID, err)
+	if _, err := u.depRepo.Delete(ctx, sourceID, dependsOnID, actor, DepInsertOpts{UseWispsTable: useWisp}); err != nil {
+		return fmt.Errorf("remove dep %s -> %s: %w", sourceID, dependsOnID, err)
 	}
 	return nil
 }
 
 func (u *dependencyUseCaseImpl) Reparent(ctx context.Context, childID, newParentID, actor string) error {
+	return u.reparent(ctx, childID, newParentID, actor, false)
+}
+
+func (u *dependencyUseCaseImpl) ReparentWisp(ctx context.Context, childWispID, newParentID, actor string) error {
+	return u.reparent(ctx, childWispID, newParentID, actor, true)
+}
+
+func (u *dependencyUseCaseImpl) reparent(ctx context.Context, childID, newParentID, actor string, useWisp bool) error {
 	if childID == "" {
 		return fmt.Errorf("reparent: childID must not be empty")
 	}
@@ -137,9 +155,11 @@ func (u *dependencyUseCaseImpl) Reparent(ctx context.Context, childID, newParent
 		return fmt.Errorf("reparent: %s cannot be its own parent", childID)
 	}
 
+	opts := DepInsertOpts{UseWispsTable: useWisp}
 	res, err := u.depRepo.ListByIssueIDs(ctx, []string{childID}, DepListOpts{
-		Types:     []types.DependencyType{types.DepParentChild},
-		Direction: DepDirectionOut,
+		Types:         []types.DependencyType{types.DepParentChild},
+		Direction:     DepDirectionOut,
+		UseWispsTable: useWisp,
 	})
 	if err != nil {
 		return fmt.Errorf("reparent: list current parent: %w", err)
@@ -158,7 +178,7 @@ func (u *dependencyUseCaseImpl) Reparent(ctx context.Context, childID, newParent
 	}
 
 	if oldParentID != "" {
-		if _, err := u.depRepo.Delete(ctx, childID, oldParentID, actor, DepInsertOpts{}); err != nil {
+		if _, err := u.depRepo.Delete(ctx, childID, oldParentID, actor, opts); err != nil {
 			return fmt.Errorf("reparent: remove old parent %s: %w", oldParentID, err)
 		}
 	}
@@ -169,7 +189,7 @@ func (u *dependencyUseCaseImpl) Reparent(ctx context.Context, childID, newParent
 			DependsOnID: newParentID,
 			Type:        types.DepParentChild,
 		}
-		if err := u.depRepo.Insert(ctx, dep, actor, DepInsertOpts{}); err != nil {
+		if err := u.depRepo.Insert(ctx, dep, actor, opts); err != nil {
 			return fmt.Errorf("reparent: add new parent %s: %w", newParentID, err)
 		}
 	}

--- a/internal/storage/domain/issue.go
+++ b/internal/storage/domain/issue.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/steveyegge/beads/internal/idgen"
+	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/storage/dberrors"
 	"github.com/steveyegge/beads/internal/types"
 )
@@ -20,10 +21,19 @@ type IssueTableOpts struct {
 	UseWispsTable bool
 }
 
+type ClaimRowResult struct {
+	Updated          bool
+	CurrentAssignee  string
+	CurrentStatus    types.Status
+	StartedAtWasZero bool
+	OldIssue         *types.Issue
+}
+
 type IssueSQLRepository interface {
 	Insert(ctx context.Context, issue *types.Issue, actor string, opts InsertIssueOpts) error
 	InsertBatch(ctx context.Context, issues []*types.Issue, actor string, opts InsertIssueOpts) error
 	Update(ctx context.Context, id string, updates map[string]any, actor string, opts IssueTableOpts) error
+	Claim(ctx context.Context, id, actor string, opts IssueTableOpts) (ClaimRowResult, error)
 	Get(ctx context.Context, id string, opts IssueTableOpts) (*types.Issue, error)
 	GetByIDs(ctx context.Context, ids []string, opts IssueTableOpts) ([]*types.Issue, error)
 	Exists(ctx context.Context, id string, opts IssueTableOpts) (bool, error)
@@ -108,6 +118,20 @@ type GraphApplyResult struct {
 	IDs map[string]string
 }
 
+type ClaimResult struct {
+	AlreadyClaimed bool
+	PriorAssignee  string
+}
+
+type UpdateSpec struct {
+	Fields       map[string]any
+	Claim        bool
+	AddLabels    []string
+	RemoveLabels []string
+	SetLabels    *[]string
+	Reparent     *string
+}
+
 type IssueUseCase interface {
 	GetIssue(ctx context.Context, id string) (*types.Issue, error)
 	GetIssuesByIDs(ctx context.Context, ids []string) ([]*types.Issue, error)
@@ -120,6 +144,8 @@ type IssueUseCase interface {
 	CreateIssue(ctx context.Context, params CreateIssueParams, actor string) (CreateIssueResult, error)
 	CreateIssues(ctx context.Context, params []CreateIssueParams, actor string) (CreateIssuesResult, error)
 	UpdateIssue(ctx context.Context, id string, updates map[string]any, actor string) error
+	ClaimIssue(ctx context.Context, id, actor string) (ClaimResult, error)
+	ApplyUpdate(ctx context.Context, id string, spec UpdateSpec, actor string) (*types.Issue, error)
 	ApplyIssueGraph(ctx context.Context, plan GraphPlan, actor string) (GraphApplyResult, error)
 
 	GetWisp(ctx context.Context, id string) (*types.Issue, error)
@@ -137,6 +163,8 @@ func NewIssueUseCase(
 	counterRepo ChildCounterSQLRepository,
 	commentRepo CommentSQLRepository,
 	cfgRepo ConfigSQLRepository,
+	labelUC LabelUseCase,
+	depUC DependencyUseCase,
 ) IssueUseCase {
 	return &issueUseCaseImpl{
 		issueRepo:   issueRepo,
@@ -145,6 +173,8 @@ func NewIssueUseCase(
 		counterRepo: counterRepo,
 		commentRepo: commentRepo,
 		cfgRepo:     cfgRepo,
+		labelUC:     labelUC,
+		depUC:       depUC,
 	}
 }
 
@@ -155,6 +185,8 @@ type issueUseCaseImpl struct {
 	counterRepo ChildCounterSQLRepository
 	commentRepo CommentSQLRepository
 	cfgRepo     ConfigSQLRepository
+	labelUC     LabelUseCase
+	depUC       DependencyUseCase
 }
 
 var _ IssueUseCase = (*issueUseCaseImpl)(nil)
@@ -212,7 +244,88 @@ func (u *issueUseCaseImpl) update(ctx context.Context, id string, updates map[st
 	if len(updates) == 0 {
 		return nil
 	}
+	if rawType, ok := updates["issue_type"]; ok {
+		if issueType, ok := rawType.(string); ok && issueType != "" {
+			customTypes, err := u.cfgRepo.GetCustomTypes(ctx)
+			if err != nil {
+				return fmt.Errorf("update: read custom types: %w", err)
+			}
+			if !types.IssueType(issueType).IsValidWithCustom(customTypes) {
+				return fmt.Errorf("invalid issue type: %s", issueType)
+			}
+		}
+	}
 	return u.issueRepo.Update(ctx, id, updates, actor, IssueTableOpts{UseWispsTable: useWisp})
+}
+
+func (u *issueUseCaseImpl) ClaimIssue(ctx context.Context, id, actor string) (ClaimResult, error) {
+	if id == "" {
+		return ClaimResult{}, fmt.Errorf("claim: id must not be empty")
+	}
+	if actor == "" {
+		return ClaimResult{}, fmt.Errorf("claim: actor must not be empty")
+	}
+	row, err := u.issueRepo.Claim(ctx, id, actor, IssueTableOpts{})
+	if err != nil {
+		return ClaimResult{}, fmt.Errorf("claim %s: %w", id, err)
+	}
+	if row.Updated {
+		return ClaimResult{}, nil
+	}
+	if row.CurrentAssignee == actor && row.CurrentStatus == types.StatusInProgress {
+		return ClaimResult{AlreadyClaimed: true, PriorAssignee: actor}, nil
+	}
+	if row.CurrentAssignee != "" && row.CurrentAssignee != actor {
+		return ClaimResult{}, fmt.Errorf("%w by %s", storage.ErrAlreadyClaimed, row.CurrentAssignee)
+	}
+	return ClaimResult{}, fmt.Errorf("%w: status %s", storage.ErrNotClaimable, row.CurrentStatus)
+}
+
+func (u *issueUseCaseImpl) ApplyUpdate(ctx context.Context, id string, spec UpdateSpec, actor string) (*types.Issue, error) {
+	if id == "" {
+		return nil, fmt.Errorf("ApplyUpdate: id must not be empty")
+	}
+
+	if spec.Claim {
+		if _, err := u.ClaimIssue(ctx, id, actor); err != nil {
+			return nil, err
+		}
+	}
+
+	if len(spec.Fields) > 0 {
+		if err := u.UpdateIssue(ctx, id, spec.Fields, actor); err != nil {
+			return nil, err
+		}
+	}
+
+	if spec.SetLabels != nil {
+		if err := u.labelUC.SetLabels(ctx, id, *spec.SetLabels, actor); err != nil {
+			return nil, err
+		}
+	} else {
+		if len(spec.AddLabels) > 0 {
+			if err := u.labelUC.AddLabels(ctx, id, spec.AddLabels, actor); err != nil {
+				return nil, err
+			}
+		}
+		if len(spec.RemoveLabels) > 0 {
+			if err := u.labelUC.RemoveLabels(ctx, id, spec.RemoveLabels, actor); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	if spec.Reparent != nil {
+		if err := u.depUC.Reparent(ctx, id, *spec.Reparent, actor); err != nil {
+			return nil, err
+		}
+	}
+
+	issue, err := u.GetIssue(ctx, id)
+	if err != nil {
+		return nil, fmt.Errorf("ApplyUpdate: re-fetch %s: %w", id, err)
+	}
+	return issue, nil
 }
 
 func (u *issueUseCaseImpl) SearchIssues(ctx context.Context, query string, filter types.IssueFilter) (SearchPage, error) {

--- a/internal/storage/domain/issue.go
+++ b/internal/storage/domain/issue.go
@@ -153,6 +153,7 @@ type IssueUseCase interface {
 	CreateWisp(ctx context.Context, params CreateIssueParams, actor string) (CreateIssueResult, error)
 	CreateWisps(ctx context.Context, params []CreateIssueParams, actor string) (CreateIssuesResult, error)
 	UpdateWisp(ctx context.Context, id string, updates map[string]any, actor string) error
+	ClaimWisp(ctx context.Context, id, actor string) (ClaimResult, error)
 	ApplyWispGraph(ctx context.Context, plan GraphPlan, actor string) (GraphApplyResult, error)
 }
 
@@ -259,13 +260,21 @@ func (u *issueUseCaseImpl) update(ctx context.Context, id string, updates map[st
 }
 
 func (u *issueUseCaseImpl) ClaimIssue(ctx context.Context, id, actor string) (ClaimResult, error) {
+	return u.claim(ctx, id, actor, false)
+}
+
+func (u *issueUseCaseImpl) ClaimWisp(ctx context.Context, id, actor string) (ClaimResult, error) {
+	return u.claim(ctx, id, actor, true)
+}
+
+func (u *issueUseCaseImpl) claim(ctx context.Context, id, actor string, useWisp bool) (ClaimResult, error) {
 	if id == "" {
 		return ClaimResult{}, fmt.Errorf("claim: id must not be empty")
 	}
 	if actor == "" {
 		return ClaimResult{}, fmt.Errorf("claim: actor must not be empty")
 	}
-	row, err := u.issueRepo.Claim(ctx, id, actor, IssueTableOpts{})
+	row, err := u.issueRepo.Claim(ctx, id, actor, IssueTableOpts{UseWispsTable: useWisp})
 	if err != nil {
 		return ClaimResult{}, fmt.Errorf("claim %s: %w", id, err)
 	}
@@ -286,46 +295,103 @@ func (u *issueUseCaseImpl) ApplyUpdate(ctx context.Context, id string, spec Upda
 		return nil, fmt.Errorf("ApplyUpdate: id must not be empty")
 	}
 
+	useWisp, err := u.isWispID(ctx, id)
+	if err != nil {
+		return nil, fmt.Errorf("ApplyUpdate %s: %w", id, err)
+	}
+
 	if spec.Claim {
-		if _, err := u.ClaimIssue(ctx, id, actor); err != nil {
-			return nil, err
+		if useWisp {
+			if _, err := u.ClaimWisp(ctx, id, actor); err != nil {
+				return nil, err
+			}
+		} else {
+			if _, err := u.ClaimIssue(ctx, id, actor); err != nil {
+				return nil, err
+			}
 		}
 	}
 
 	if len(spec.Fields) > 0 {
-		if err := u.UpdateIssue(ctx, id, spec.Fields, actor); err != nil {
-			return nil, err
+		if useWisp {
+			if err := u.UpdateWisp(ctx, id, spec.Fields, actor); err != nil {
+				return nil, err
+			}
+		} else {
+			if err := u.UpdateIssue(ctx, id, spec.Fields, actor); err != nil {
+				return nil, err
+			}
 		}
 	}
 
 	if spec.SetLabels != nil {
-		if err := u.labelUC.SetLabels(ctx, id, *spec.SetLabels, actor); err != nil {
-			return nil, err
-		}
-	} else {
-		if len(spec.AddLabels) > 0 {
-			if err := u.labelUC.AddLabels(ctx, id, spec.AddLabels, actor); err != nil {
+		if useWisp {
+			if err := u.labelUC.SetWispLabels(ctx, id, *spec.SetLabels, actor); err != nil {
+				return nil, err
+			}
+		} else {
+			if err := u.labelUC.SetLabels(ctx, id, *spec.SetLabels, actor); err != nil {
 				return nil, err
 			}
 		}
+	} else {
+		if len(spec.AddLabels) > 0 {
+			if useWisp {
+				if err := u.labelUC.AddWispLabels(ctx, id, spec.AddLabels, actor); err != nil {
+					return nil, err
+				}
+			} else {
+				if err := u.labelUC.AddLabels(ctx, id, spec.AddLabels, actor); err != nil {
+					return nil, err
+				}
+			}
+		}
 		if len(spec.RemoveLabels) > 0 {
-			if err := u.labelUC.RemoveLabels(ctx, id, spec.RemoveLabels, actor); err != nil {
-				return nil, err
+			if useWisp {
+				if err := u.labelUC.RemoveWispLabels(ctx, id, spec.RemoveLabels, actor); err != nil {
+					return nil, err
+				}
+			} else {
+				if err := u.labelUC.RemoveLabels(ctx, id, spec.RemoveLabels, actor); err != nil {
+					return nil, err
+				}
 			}
 		}
 	}
 
 	if spec.Reparent != nil {
-		if err := u.depUC.Reparent(ctx, id, *spec.Reparent, actor); err != nil {
-			return nil, err
+		if useWisp {
+			if err := u.depUC.ReparentWisp(ctx, id, *spec.Reparent, actor); err != nil {
+				return nil, err
+			}
+		} else {
+			if err := u.depUC.Reparent(ctx, id, *spec.Reparent, actor); err != nil {
+				return nil, err
+			}
 		}
 	}
 
-	issue, err := u.GetIssue(ctx, id)
+	var issue *types.Issue
+	if useWisp {
+		issue, err = u.GetWisp(ctx, id)
+	} else {
+		issue, err = u.GetIssue(ctx, id)
+	}
 	if err != nil {
 		return nil, fmt.Errorf("ApplyUpdate: re-fetch %s: %w", id, err)
 	}
 	return issue, nil
+}
+
+func (u *issueUseCaseImpl) isWispID(ctx context.Context, id string) (bool, error) {
+	found, err := u.issueRepo.Exists(ctx, id, IssueTableOpts{UseWispsTable: true})
+	if err != nil {
+		if dberrors.IsTableNotExist(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("probe wisps table: %w", err)
+	}
+	return found, nil
 }
 
 func (u *issueUseCaseImpl) SearchIssues(ctx context.Context, query string, filter types.IssueFilter) (SearchPage, error) {

--- a/internal/storage/domain/label.go
+++ b/internal/storage/domain/label.go
@@ -27,6 +27,10 @@ type LabelUseCase interface {
 	InheritFromParent(ctx context.Context, childID, parentID, actor string, skipExisting []string) ([]string, error)
 
 	AddWispLabel(ctx context.Context, wispID, label, actor string) error
+	RemoveWispLabel(ctx context.Context, wispID, label, actor string) error
+	AddWispLabels(ctx context.Context, wispID string, labels []string, actor string) error
+	RemoveWispLabels(ctx context.Context, wispID string, labels []string, actor string) error
+	SetWispLabels(ctx context.Context, wispID string, labels []string, actor string) error
 	GetWispLabels(ctx context.Context, wispID string) ([]string, error)
 	GetLabelsForWisps(ctx context.Context, wispIDs []string) (map[string][]string, error)
 	InheritFromWispParent(ctx context.Context, childWispID, parentWispID, actor string, skipExisting []string) ([]string, error)
@@ -64,27 +68,44 @@ func (u *labelUseCaseImpl) add(ctx context.Context, id, label, actor string, use
 }
 
 func (u *labelUseCaseImpl) RemoveLabel(ctx context.Context, issueID, label, actor string) error {
-	if issueID == "" {
+	return u.remove(ctx, issueID, label, actor, false)
+}
+
+func (u *labelUseCaseImpl) RemoveWispLabel(ctx context.Context, wispID, label, actor string) error {
+	return u.remove(ctx, wispID, label, actor, true)
+}
+
+func (u *labelUseCaseImpl) remove(ctx context.Context, id, label, actor string, useWisp bool) error {
+	if id == "" {
 		return fmt.Errorf("remove label: id must not be empty")
 	}
 	if label == "" {
 		return fmt.Errorf("remove label: label must not be empty")
 	}
-	if err := u.labelRepo.Delete(ctx, issueID, label, actor, LabelOpts{}); err != nil {
-		return fmt.Errorf("remove label %s/%s: %w", issueID, label, err)
+	if err := u.labelRepo.Delete(ctx, id, label, actor, LabelOpts{UseWispsTable: useWisp}); err != nil {
+		return fmt.Errorf("remove label %s/%s: %w", id, label, err)
 	}
 	return nil
 }
 
 func (u *labelUseCaseImpl) AddLabels(ctx context.Context, issueID string, labels []string, actor string) error {
-	if issueID == "" {
+	return u.addMany(ctx, issueID, labels, actor, false)
+}
+
+func (u *labelUseCaseImpl) AddWispLabels(ctx context.Context, wispID string, labels []string, actor string) error {
+	return u.addMany(ctx, wispID, labels, actor, true)
+}
+
+func (u *labelUseCaseImpl) addMany(ctx context.Context, id string, labels []string, actor string, useWisp bool) error {
+	if id == "" {
 		return fmt.Errorf("add labels: id must not be empty")
 	}
+	opts := LabelOpts{UseWispsTable: useWisp}
 	for _, label := range labels {
 		if label == "" {
 			continue
 		}
-		if err := u.labelRepo.Insert(ctx, issueID, label, actor, LabelOpts{}); err != nil {
+		if err := u.labelRepo.Insert(ctx, id, label, actor, opts); err != nil {
 			return fmt.Errorf("add labels: %s: %w", label, err)
 		}
 	}
@@ -92,14 +113,23 @@ func (u *labelUseCaseImpl) AddLabels(ctx context.Context, issueID string, labels
 }
 
 func (u *labelUseCaseImpl) RemoveLabels(ctx context.Context, issueID string, labels []string, actor string) error {
-	if issueID == "" {
+	return u.removeMany(ctx, issueID, labels, actor, false)
+}
+
+func (u *labelUseCaseImpl) RemoveWispLabels(ctx context.Context, wispID string, labels []string, actor string) error {
+	return u.removeMany(ctx, wispID, labels, actor, true)
+}
+
+func (u *labelUseCaseImpl) removeMany(ctx context.Context, id string, labels []string, actor string, useWisp bool) error {
+	if id == "" {
 		return fmt.Errorf("remove labels: id must not be empty")
 	}
+	opts := LabelOpts{UseWispsTable: useWisp}
 	for _, label := range labels {
 		if label == "" {
 			continue
 		}
-		if err := u.labelRepo.Delete(ctx, issueID, label, actor, LabelOpts{}); err != nil {
+		if err := u.labelRepo.Delete(ctx, id, label, actor, opts); err != nil {
 			return fmt.Errorf("remove labels: %s: %w", label, err)
 		}
 	}
@@ -107,10 +137,19 @@ func (u *labelUseCaseImpl) RemoveLabels(ctx context.Context, issueID string, lab
 }
 
 func (u *labelUseCaseImpl) SetLabels(ctx context.Context, issueID string, labels []string, actor string) error {
-	if issueID == "" {
+	return u.setMany(ctx, issueID, labels, actor, false)
+}
+
+func (u *labelUseCaseImpl) SetWispLabels(ctx context.Context, wispID string, labels []string, actor string) error {
+	return u.setMany(ctx, wispID, labels, actor, true)
+}
+
+func (u *labelUseCaseImpl) setMany(ctx context.Context, id string, labels []string, actor string, useWisp bool) error {
+	if id == "" {
 		return fmt.Errorf("set labels: id must not be empty")
 	}
-	current, err := u.labelRepo.List(ctx, issueID, LabelOpts{})
+	opts := LabelOpts{UseWispsTable: useWisp}
+	current, err := u.labelRepo.List(ctx, id, opts)
 	if err != nil {
 		return fmt.Errorf("set labels: list current: %w", err)
 	}
@@ -124,14 +163,14 @@ func (u *labelUseCaseImpl) SetLabels(ctx context.Context, issueID string, labels
 	for _, l := range current {
 		existing[l] = true
 		if !desired[l] {
-			if err := u.labelRepo.Delete(ctx, issueID, l, actor, LabelOpts{}); err != nil {
+			if err := u.labelRepo.Delete(ctx, id, l, actor, opts); err != nil {
 				return fmt.Errorf("set labels: remove %s: %w", l, err)
 			}
 		}
 	}
 	for l := range desired {
 		if !existing[l] {
-			if err := u.labelRepo.Insert(ctx, issueID, l, actor, LabelOpts{}); err != nil {
+			if err := u.labelRepo.Insert(ctx, id, l, actor, opts); err != nil {
 				return fmt.Errorf("set labels: add %s: %w", l, err)
 			}
 		}

--- a/internal/storage/domain/label.go
+++ b/internal/storage/domain/label.go
@@ -11,12 +11,17 @@ type LabelOpts struct {
 
 type LabelSQLRepository interface {
 	Insert(ctx context.Context, issueID, label, actor string, opts LabelOpts) error
+	Delete(ctx context.Context, issueID, label, actor string, opts LabelOpts) error
 	List(ctx context.Context, issueID string, opts LabelOpts) ([]string, error)
 	ListByIssueIDs(ctx context.Context, issueIDs []string, opts LabelOpts) (map[string][]string, error)
 }
 
 type LabelUseCase interface {
 	AddLabel(ctx context.Context, issueID, label, actor string) error
+	RemoveLabel(ctx context.Context, issueID, label, actor string) error
+	AddLabels(ctx context.Context, issueID string, labels []string, actor string) error
+	RemoveLabels(ctx context.Context, issueID string, labels []string, actor string) error
+	SetLabels(ctx context.Context, issueID string, labels []string, actor string) error
 	GetLabels(ctx context.Context, issueID string) ([]string, error)
 	GetLabelsForIssues(ctx context.Context, issueIDs []string) (map[string][]string, error)
 	InheritFromParent(ctx context.Context, childID, parentID, actor string, skipExisting []string) ([]string, error)
@@ -54,6 +59,82 @@ func (u *labelUseCaseImpl) add(ctx context.Context, id, label, actor string, use
 	}
 	if err := u.labelRepo.Insert(ctx, id, label, actor, LabelOpts{UseWispsTable: useWisp}); err != nil {
 		return fmt.Errorf("add label %s/%s: %w", id, label, err)
+	}
+	return nil
+}
+
+func (u *labelUseCaseImpl) RemoveLabel(ctx context.Context, issueID, label, actor string) error {
+	if issueID == "" {
+		return fmt.Errorf("remove label: id must not be empty")
+	}
+	if label == "" {
+		return fmt.Errorf("remove label: label must not be empty")
+	}
+	if err := u.labelRepo.Delete(ctx, issueID, label, actor, LabelOpts{}); err != nil {
+		return fmt.Errorf("remove label %s/%s: %w", issueID, label, err)
+	}
+	return nil
+}
+
+func (u *labelUseCaseImpl) AddLabels(ctx context.Context, issueID string, labels []string, actor string) error {
+	if issueID == "" {
+		return fmt.Errorf("add labels: id must not be empty")
+	}
+	for _, label := range labels {
+		if label == "" {
+			continue
+		}
+		if err := u.labelRepo.Insert(ctx, issueID, label, actor, LabelOpts{}); err != nil {
+			return fmt.Errorf("add labels: %s: %w", label, err)
+		}
+	}
+	return nil
+}
+
+func (u *labelUseCaseImpl) RemoveLabels(ctx context.Context, issueID string, labels []string, actor string) error {
+	if issueID == "" {
+		return fmt.Errorf("remove labels: id must not be empty")
+	}
+	for _, label := range labels {
+		if label == "" {
+			continue
+		}
+		if err := u.labelRepo.Delete(ctx, issueID, label, actor, LabelOpts{}); err != nil {
+			return fmt.Errorf("remove labels: %s: %w", label, err)
+		}
+	}
+	return nil
+}
+
+func (u *labelUseCaseImpl) SetLabels(ctx context.Context, issueID string, labels []string, actor string) error {
+	if issueID == "" {
+		return fmt.Errorf("set labels: id must not be empty")
+	}
+	current, err := u.labelRepo.List(ctx, issueID, LabelOpts{})
+	if err != nil {
+		return fmt.Errorf("set labels: list current: %w", err)
+	}
+	desired := make(map[string]bool, len(labels))
+	for _, l := range labels {
+		if l != "" {
+			desired[l] = true
+		}
+	}
+	existing := make(map[string]bool, len(current))
+	for _, l := range current {
+		existing[l] = true
+		if !desired[l] {
+			if err := u.labelRepo.Delete(ctx, issueID, l, actor, LabelOpts{}); err != nil {
+				return fmt.Errorf("set labels: remove %s: %w", l, err)
+			}
+		}
+	}
+	for l := range desired {
+		if !existing[l] {
+			if err := u.labelRepo.Insert(ctx, issueID, l, actor, LabelOpts{}); err != nil {
+				return fmt.Errorf("set labels: add %s: %w", l, err)
+			}
+		}
 	}
 	return nil
 }

--- a/internal/storage/uow/uow.go
+++ b/internal/storage/uow/uow.go
@@ -89,6 +89,8 @@ func (u *baseUOW) IssueUseCase() domain.IssueUseCase {
 			db.NewChildCounterSQLRepository(runner),
 			db.NewCommentSQLRepository(runner),
 			db.NewConfigSQLRepository(runner),
+			u.LabelUseCase(),
+			u.DependencyUseCase(),
 		)
 	}
 	return u.issueUseCase


### PR DESCRIPTION
## Summary

Wires `bd update` through the domain use-case layer so it works under
`--proxied-server` (the embedded path is preserved unchanged — dispatch
is a single early-return at the top of `updateCmd.Run`).

The shape mirrors `bd create`: a thin CLI dispatch, a `cmd/bd/update_input.go`
that gathers flags into an `updateInput` struct (matching the existing
`createInput` pattern), and `cmd/bd/update_proxied_server.go` for
orchestration (UOW, per-issue field resolution, commit, hooks).

To make this work, the following pieces were added to the domain layer:

- `IssueUseCase`: `ClaimIssue`, `ApplyUpdate` (orchestrator that bundles
  Claim + Fields + Labels + Reparent in one transaction).
- `LabelUseCase`: `RemoveLabel`, `AddLabels`, `RemoveLabels`, `SetLabels`
  (with diff against current set).
- `DependencyUseCase`: `RemoveDependency`, `Reparent` (no-op when parent
  unchanged, unparent when empty).
- `ConfigUseCase`: `ListAllStatusNames` (built-ins + custom merged, drives
  CLI status validation).
- Matching repo methods on `IssueSQLRepository` (`Claim`),
  `DependencySQLRepository` (`Delete`), `LabelSQLRepository` (`Delete`),
  `ConfigSQLRepository` (`ListAllStatusNames`, three-layer custom-types
  resolution: `custom_types` table → `types.custom` config string → YAML
  overlay).

🤖 Generated with [Claude Code](https://claude.com/claude-code)