### PR TITLE
bd delete: support proxied-server mode

### DIFF
--- a/cmd/bd/delete.go
+++ b/cmd/bd/delete.go
@@ -49,6 +49,12 @@ Force: Delete and orphan dependents
 	Args: cobra.MinimumNArgs(0),
 	Run: func(cmd *cobra.Command, args []string) {
 		CheckReadonly("delete")
+
+		if usesProxiedServer() {
+			runDeleteProxiedServer(cmd, rootCtx, args)
+			return
+		}
+
 		fromFile, _ := cmd.Flags().GetString("from-file")
 		force, _ := cmd.Flags().GetBool("force")
 		dryRun, _ := cmd.Flags().GetBool("dry-run")

--- a/cmd/bd/delete_proxied_integration_test.go
+++ b/cmd/bd/delete_proxied_integration_test.go
@@ -1,0 +1,642 @@
+//go:build cgo
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+)
+
+func TestProxiedServerDelete(t *testing.T) {
+	requireProxiedServerEnv(t)
+	bd := buildEmbeddedBD(t)
+
+	t.Run("delete_single_issue", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "dsi")
+		issue := bdProxiedCreate(t, bd, p.dir, "Delete me", "-t", "task")
+		bdProxiedDelete(t, bd, p.dir, issue.ID, "--force")
+		db := openProxiedDB(t, p)
+		assertRowAbsent(t, db, "issues", issue.ID)
+	})
+
+	t.Run("delete_without_force_shows_preview", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "dwf")
+		issue := bdProxiedCreate(t, bd, p.dir, "Preview only", "-t", "task")
+
+		out := bdProxiedDelete(t, bd, p.dir, issue.ID)
+		if !strings.Contains(out, "PREVIEW") && !strings.Contains(out, "preview") {
+			t.Errorf("expected preview prose, got: %s", out)
+		}
+
+		db := openProxiedDB(t, p)
+		assertRowExists(t, db, "issues", issue.ID)
+	})
+
+	t.Run("delete_clears_aux_tables", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "dcat")
+		neighbor := bdProxiedCreate(t, bd, p.dir, "Neighbor", "-t", "task")
+		issue := bdProxiedCreate(t, bd, p.dir, "Aux cleanup", "-t", "task",
+			"--label", "alpha",
+			"--deps", "depends-on:"+neighbor.ID)
+
+		bdProxiedDelete(t, bd, p.dir, issue.ID, "--force")
+
+		db := openProxiedDB(t, p)
+		ctx := context.Background()
+		assertRowAbsent(t, db, "issues", issue.ID)
+
+		for _, q := range []struct {
+			table, where string
+		}{
+			{"labels", "issue_id = ?"},
+			{"events", "issue_id = ?"},
+			{"dependencies", "issue_id = ? OR depends_on_issue_id = ?"},
+		} {
+			var count int
+			args := []any{issue.ID}
+			if strings.Count(q.where, "?") == 2 {
+				args = append(args, issue.ID)
+			}
+			query := fmt.Sprintf("SELECT COUNT(*) FROM %s WHERE %s", q.table, q.where)
+			if err := db.QueryRowContext(ctx, query, args...).Scan(&count); err != nil {
+				t.Fatalf("count %s for %s: %v", q.table, issue.ID, err)
+			}
+			if count != 0 {
+				t.Errorf("%s rows for deleted %s: got %d, want 0", q.table, issue.ID, count)
+			}
+		}
+	})
+
+	t.Run("delete_json_returns_result_shape", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "djs")
+		issue := bdProxiedCreate(t, bd, p.dir, "JSON shape", "-t", "task")
+
+		got := bdProxiedDeleteJSON(t, bd, p.dir, "--json", issue.ID, "--force")
+		for _, key := range []string{
+			"deleted", "deleted_count", "dependencies_removed",
+			"labels_removed", "events_removed", "references_updated",
+		} {
+			if _, ok := got[key]; !ok {
+				t.Errorf("delete JSON output missing key %q; got keys: %v", key, mapKeys(got))
+			}
+		}
+
+		deleted, ok := got["deleted"].([]any)
+		if !ok {
+			t.Fatalf("`deleted` is not a slice; got %T: %v", got["deleted"], got["deleted"])
+		}
+		if len(deleted) != 1 || deleted[0] != issue.ID {
+			t.Errorf("`deleted`: got %v, want [%s]", deleted, issue.ID)
+		}
+	})
+
+	t.Run("delete_leaf_clears_outbound_dep_rows", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "dlc")
+		a := bdProxiedCreate(t, bd, p.dir, "Survivor A", "-t", "task")
+		b := bdProxiedCreate(t, bd, p.dir, "Will be deleted", "-t", "task",
+			"--deps", "depends-on:"+a.ID)
+
+		bdProxiedDelete(t, bd, p.dir, b.ID, "--force")
+
+		db := openProxiedDB(t, p)
+		assertRowAbsent(t, db, "issues", b.ID)
+		assertRowExists(t, db, "issues", a.ID)
+
+		var refs int
+		if err := db.QueryRowContext(context.Background(),
+			"SELECT COUNT(*) FROM dependencies WHERE issue_id = ? OR depends_on_issue_id = ?",
+			b.ID, b.ID).Scan(&refs); err != nil {
+			t.Fatalf("count dep rows referencing %s: %v", b.ID, err)
+		}
+		if refs != 0 {
+			t.Errorf("dependencies referencing deleted %s: got %d rows, want 0", b.ID, refs)
+		}
+	})
+
+	t.Run("delete_creates_dolt_commit", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "ddc")
+		issue := bdProxiedCreate(t, bd, p.dir, "Dolt commit test", "-t", "task")
+
+		db := openProxiedDB(t, p)
+		var before string
+		if err := db.QueryRowContext(context.Background(),
+			"SELECT HASHOF('HEAD')").Scan(&before); err != nil {
+			t.Fatalf("read HEAD before: %v", err)
+		}
+
+		bdProxiedDelete(t, bd, p.dir, issue.ID, "--force")
+
+		var after string
+		if err := db.QueryRowContext(context.Background(),
+			"SELECT HASHOF('HEAD')").Scan(&after); err != nil {
+			t.Fatalf("read HEAD after: %v", err)
+		}
+		if after == before {
+			t.Errorf("HEAD did not advance: before=%s after=%s (uw.Commit should produce a Dolt commit)",
+				before, after)
+		}
+	})
+
+	t.Run("delete_bulk_no_resurrection", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "dbr")
+
+		const total = 20
+		const toDelete = 10
+		ids := make([]string, 0, total)
+		for i := 0; i < total; i++ {
+			issue := bdProxiedCreate(t, bd, p.dir,
+				fmt.Sprintf("Bulk %d", i), "-t", "task")
+			ids = append(ids, issue.ID)
+		}
+
+		deleteArgs := append([]string{}, ids[:toDelete]...)
+		deleteArgs = append(deleteArgs, "--force")
+		bdProxiedDelete(t, bd, p.dir, deleteArgs...)
+
+		db := openProxiedDB(t, p)
+		var count int
+		if err := db.QueryRowContext(context.Background(),
+			"SELECT COUNT(*) FROM issues").Scan(&count); err != nil {
+			t.Fatalf("count issues: %v", err)
+		}
+		if count != total-toDelete {
+			t.Errorf("issues count after bulk delete: got %d, want %d", count, total-toDelete)
+		}
+		for _, id := range ids[:toDelete] {
+			assertRowAbsent(t, db, "issues", id)
+		}
+		for _, id := range ids[toDelete:] {
+			assertRowExists(t, db, "issues", id)
+		}
+	})
+
+	t.Run("delete_nonexistent", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "dne")
+		out := bdProxiedDeleteFail(t, bd, p.dir, "dne-doesnotexist", "--force")
+		if !strings.Contains(strings.ToLower(out), "not found") &&
+			!strings.Contains(strings.ToLower(out), "error") {
+			t.Errorf("expected not-found / error message, got: %s", out)
+		}
+	})
+
+	t.Run("delete_batch", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "dbt")
+		a := bdProxiedCreate(t, bd, p.dir, "Batch 1", "-t", "task")
+		b := bdProxiedCreate(t, bd, p.dir, "Batch 2", "-t", "task")
+		c := bdProxiedCreate(t, bd, p.dir, "Batch 3", "-t", "task")
+
+		bdProxiedDelete(t, bd, p.dir, a.ID, b.ID, c.ID, "--force")
+
+		db := openProxiedDB(t, p)
+		for _, id := range []string{a.ID, b.ID, c.ID} {
+			assertRowAbsent(t, db, "issues", id)
+		}
+	})
+
+	t.Run("delete_force_cascades_dependents", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "dfc")
+		parent := bdProxiedCreate(t, bd, p.dir, "Force parent", "-t", "task")
+		child := bdProxiedCreate(t, bd, p.dir, "Force child", "-t", "task",
+			"--deps", "depends-on:"+parent.ID)
+
+		bdProxiedDelete(t, bd, p.dir, parent.ID, "--force")
+
+		db := openProxiedDB(t, p)
+		assertRowAbsent(t, db, "issues", parent.ID)
+		assertRowAbsent(t, db, "issues", child.ID)
+	})
+
+	t.Run("delete_cleans_up_dependencies", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "dcd")
+		parent := bdProxiedCreate(t, bd, p.dir, "Parent", "-t", "task")
+		child := bdProxiedCreate(t, bd, p.dir, "Child", "-t", "task",
+			"--deps", "depends-on:"+parent.ID)
+
+		bdProxiedDelete(t, bd, p.dir, child.ID, "--force")
+
+		db := openProxiedDB(t, p)
+		assertRowAbsent(t, db, "issues", child.ID)
+		assertRowExists(t, db, "issues", parent.ID)
+
+		var status string
+		if err := db.QueryRowContext(context.Background(),
+			"SELECT status FROM issues WHERE id = ?", parent.ID).Scan(&status); err != nil {
+			t.Fatalf("read parent status: %v", err)
+		}
+		if status == "closed" {
+			t.Errorf("parent status after deleting child: got %q, want non-closed", status)
+		}
+	})
+}
+
+func TestProxiedServerDeleteWisp(t *testing.T) {
+	requireProxiedServerEnv(t)
+	bd := buildEmbeddedBD(t)
+
+	t.Run("delete_always_cascades_dependents", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "dac")
+		parent := bdProxiedCreate(t, bd, p.dir, "Parent", "-t", "epic")
+		child := bdProxiedCreate(t, bd, p.dir, "Child", "-t", "task",
+			"--parent", parent.ID)
+
+		bdProxiedDelete(t, bd, p.dir, parent.ID, "--force")
+
+		db := openProxiedDB(t, p)
+		assertRowAbsent(t, db, "issues", parent.ID)
+		assertRowAbsent(t, db, "issues", child.ID)
+	})
+
+	t.Run("delete_cascade_spans_all_dep_types", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "dcs")
+		a := bdProxiedCreate(t, bd, p.dir, "A", "-t", "task")
+		b := bdProxiedCreate(t, bd, p.dir, "B", "-t", "task",
+			"--deps", "depends-on:"+a.ID)
+		c := bdProxiedCreate(t, bd, p.dir, "C", "-t", "task",
+			"--parent", b.ID)
+
+		bdProxiedDelete(t, bd, p.dir, a.ID, "--force")
+
+		db := openProxiedDB(t, p)
+		for _, id := range []string{a.ID, b.ID, c.ID} {
+			assertRowAbsent(t, db, "issues", id)
+		}
+	})
+
+	t.Run("delete_json_counts_match_cascade", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "djc")
+		a := bdProxiedCreate(t, bd, p.dir, "Chain A", "-t", "task")
+		b := bdProxiedCreate(t, bd, p.dir, "Chain B", "-t", "task",
+			"--deps", "depends-on:"+a.ID)
+		c := bdProxiedCreate(t, bd, p.dir, "Chain C", "-t", "task",
+			"--deps", "depends-on:"+b.ID)
+
+		got := bdProxiedDeleteJSON(t, bd, p.dir, "--json", a.ID, "--force")
+
+		count, ok := got["deleted_count"].(float64)
+		if !ok {
+			t.Fatalf("deleted_count not a number: %T %v", got["deleted_count"], got["deleted_count"])
+		}
+		if int(count) != 3 {
+			t.Errorf("deleted_count: got %v, want 3 (A,B,C cascade)", count)
+		}
+
+		db := openProxiedDB(t, p)
+		for _, id := range []string{a.ID, b.ID, c.ID} {
+			assertRowAbsent(t, db, "issues", id)
+		}
+	})
+
+	t.Run("delete_dry_run_does_not_mutate", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "ddr")
+		issue := bdProxiedCreate(t, bd, p.dir, "Dry run target", "-t", "task")
+
+		got := bdProxiedDeleteJSON(t, bd, p.dir, "--json", issue.ID, "--dry-run")
+		if _, ok := got["would_delete"]; !ok {
+			t.Errorf("dry-run JSON missing `would_delete`; got keys: %v", mapKeys(got))
+		}
+
+		db := openProxiedDB(t, p)
+		assertRowExists(t, db, "issues", issue.ID)
+	})
+
+	t.Run("delete_preview_lists_not_found", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "dpn")
+		issue := bdProxiedCreate(t, bd, p.dir, "Preview NotFound", "-t", "task")
+
+		out := bdProxiedDeleteFail(t, bd, p.dir, issue.ID, "dpn-bogus")
+		if !strings.Contains(strings.ToLower(out), "not found") {
+			t.Errorf("expected `not found` in preview error, got: %s", out)
+		}
+		if !strings.Contains(out, "dpn-bogus") {
+			t.Errorf("expected bogus id in preview error, got: %s", out)
+		}
+
+		db := openProxiedDB(t, p)
+		assertRowExists(t, db, "issues", issue.ID)
+	})
+
+	t.Run("delete_preview_lists_connected", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "dpc")
+		neighbor := bdProxiedCreate(t, bd, p.dir, "Preview neighbor", "-t", "task")
+		target := bdProxiedCreate(t, bd, p.dir, "Preview target", "-t", "task",
+			"--deps", "depends-on:"+neighbor.ID)
+
+		got := bdProxiedDeleteJSON(t, bd, p.dir, "--json", target.ID)
+
+		connectedRaw, ok := got["connected"]
+		if !ok {
+			t.Fatalf("preview JSON missing `connected` key; got keys: %v", mapKeys(got))
+		}
+		connected, ok := connectedRaw.([]any)
+		if !ok {
+			t.Fatalf("`connected` is not a slice; got %T", connectedRaw)
+		}
+		var found bool
+		for _, v := range connected {
+			if s, ok := v.(string); ok && s == neighbor.ID {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("connected does not contain neighbor %q: %v", neighbor.ID, connected)
+		}
+	})
+
+	t.Run("delete_rewrites_text_references", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "drt")
+		neighbor := bdProxiedCreate(t, bd, p.dir, "Rewrite neighbor", "-t", "task")
+		target := bdProxiedCreate(t, bd, p.dir, "Rewrite target", "-t", "task",
+			"--deps", "depends-on:"+neighbor.ID)
+		bdProxiedUpdateOne(t, bd, p.dir, neighbor.ID, "--description", "see "+target.ID+" for context")
+
+		bdProxiedDelete(t, bd, p.dir, target.ID, "--force")
+
+		db := openProxiedDB(t, p)
+		assertRowAbsent(t, db, "issues", target.ID)
+		assertRowExists(t, db, "issues", neighbor.ID)
+
+		var desc string
+		if err := db.QueryRowContext(context.Background(),
+			"SELECT description FROM issues WHERE id = ?", neighbor.ID).Scan(&desc); err != nil {
+			t.Fatalf("read neighbor description: %v", err)
+		}
+		want := "[deleted:" + target.ID + "]"
+		if !strings.Contains(desc, want) {
+			t.Errorf("neighbor description: got %q, want substring %q", desc, want)
+		}
+	})
+
+	t.Run("delete_references_updated_count_reported", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "dru")
+		neighbor := bdProxiedCreate(t, bd, p.dir, "Refs neighbor", "-t", "task")
+		target := bdProxiedCreate(t, bd, p.dir, "Refs target", "-t", "task",
+			"--deps", "depends-on:"+neighbor.ID)
+		bdProxiedUpdateOne(t, bd, p.dir, neighbor.ID, "--description", "see "+target.ID)
+
+		got := bdProxiedDeleteJSON(t, bd, p.dir, "--json", target.ID, "--force")
+		refs, ok := got["references_updated"].(float64)
+		if !ok {
+			t.Fatalf("references_updated not a number: %T %v",
+				got["references_updated"], got["references_updated"])
+		}
+		if int(refs) < 1 {
+			t.Errorf("references_updated: got %v, want >= 1", refs)
+		}
+	})
+
+	t.Run("delete_zero_aux_rows_after", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "dza")
+		outbound := bdProxiedCreate(t, bd, p.dir, "Outbound dependee", "-t", "task")
+		issue := bdProxiedCreate(t, bd, p.dir, "Zero aux target", "-t", "task",
+			"--label", "alpha",
+			"--deps", "depends-on:"+outbound.ID)
+		_ = bdProxiedCreate(t, bd, p.dir, "Inbound depender", "-t", "task",
+			"--deps", "depends-on:"+issue.ID)
+		bdProxiedUpdateOne(t, bd, p.dir, issue.ID, "--add-label", "beta")
+		bdProxiedUpdateOne(t, bd, p.dir, issue.ID, "-s", "in_progress")
+
+		bdProxiedDelete(t, bd, p.dir, issue.ID, "--force")
+
+		db := openProxiedDB(t, p)
+		ctx := context.Background()
+		assertRowAbsent(t, db, "issues", issue.ID)
+
+		for _, q := range []struct {
+			table, where string
+		}{
+			{"labels", "issue_id = ?"},
+			{"events", "issue_id = ?"},
+			{"dependencies", "issue_id = ? OR depends_on_issue_id = ?"},
+		} {
+			var count int
+			args := []any{issue.ID}
+			if strings.Count(q.where, "?") == 2 {
+				args = append(args, issue.ID)
+			}
+			query := fmt.Sprintf("SELECT COUNT(*) FROM %s WHERE %s", q.table, q.where)
+			if err := db.QueryRowContext(ctx, query, args...).Scan(&count); err != nil {
+				t.Fatalf("count %s for %s: %v", q.table, issue.ID, err)
+			}
+			if count != 0 {
+				t.Errorf("%s rows for deleted %s: got %d, want 0", q.table, issue.ID, count)
+			}
+		}
+	})
+
+	t.Run("delete_from_file", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "dff")
+		a := bdProxiedCreate(t, bd, p.dir, "From-file 1", "-t", "task")
+		b := bdProxiedCreate(t, bd, p.dir, "From-file 2", "-t", "task")
+		c := bdProxiedCreate(t, bd, p.dir, "From-file 3", "-t", "task")
+
+		idsPath := filepath.Join(p.dir, "ids.txt")
+		body := strings.Join([]string{a.ID, b.ID, c.ID}, "\n") + "\n"
+		if err := os.WriteFile(idsPath, []byte(body), 0o600); err != nil {
+			t.Fatalf("write ids file: %v", err)
+		}
+
+		bdProxiedDelete(t, bd, p.dir, "--from-file", idsPath, "--force")
+
+		db := openProxiedDB(t, p)
+		for _, id := range []string{a.ID, b.ID, c.ID} {
+			assertRowAbsent(t, db, "issues", id)
+		}
+	})
+
+	t.Run("delete_cascade_flag_is_noop", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "dcn")
+		withCascade := bdProxiedCreate(t, bd, p.dir, "With cascade flag", "-t", "task")
+		withoutCascade := bdProxiedCreate(t, bd, p.dir, "Without cascade flag", "-t", "task")
+
+		bdProxiedDelete(t, bd, p.dir, withCascade.ID, "--force", "--cascade")
+		bdProxiedDelete(t, bd, p.dir, withoutCascade.ID, "--force")
+
+		db := openProxiedDB(t, p)
+		assertRowAbsent(t, db, "issues", withCascade.ID)
+		assertRowAbsent(t, db, "issues", withoutCascade.ID)
+	})
+
+	t.Run("delete_mixed_wisp_and_issue_partition", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "dmp")
+		issue := bdProxiedCreate(t, bd, p.dir, "Regular target", "-t", "task")
+		wisp := bdProxiedCreate(t, bd, p.dir, "Wisp target", "--ephemeral")
+
+		db := openProxiedDB(t, p)
+		assertRowExists(t, db, "issues", issue.ID)
+		assertRowExists(t, db, "wisps", wisp.ID)
+
+		bdProxiedDelete(t, bd, p.dir, issue.ID, wisp.ID, "--force")
+
+		assertRowAbsent(t, db, "issues", issue.ID)
+		assertRowAbsent(t, db, "wisps", wisp.ID)
+	})
+
+	t.Run("delete_wisp_clears_wisp_aux_tables", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "dwc")
+		a := bdProxiedCreate(t, bd, p.dir, "Wisp aux A", "--ephemeral")
+		_ = bdProxiedCreate(t, bd, p.dir, "Wisp aux B", "--ephemeral",
+			"--deps", "depends-on:"+a.ID)
+		bdProxiedUpdateOne(t, bd, p.dir, a.ID, "--add-label", "alpha")
+
+		bdProxiedDelete(t, bd, p.dir, a.ID, "--force")
+
+		db := openProxiedDB(t, p)
+		ctx := context.Background()
+		assertRowAbsent(t, db, "wisps", a.ID)
+
+		for _, q := range []struct {
+			table, where string
+		}{
+			{"wisp_labels", "issue_id = ?"},
+			{"wisp_events", "issue_id = ?"},
+			{"wisp_dependencies", "issue_id = ? OR depends_on_wisp_id = ?"},
+		} {
+			var count int
+			args := []any{a.ID}
+			if strings.Count(q.where, "?") == 2 {
+				args = append(args, a.ID)
+			}
+			query := fmt.Sprintf("SELECT COUNT(*) FROM %s WHERE %s", q.table, q.where)
+			if err := db.QueryRowContext(ctx, query, args...).Scan(&count); err != nil {
+				t.Fatalf("count %s for %s: %v", q.table, a.ID, err)
+			}
+			if count != 0 {
+				t.Errorf("%s rows for deleted wisp %s: got %d, want 0", q.table, a.ID, count)
+			}
+		}
+	})
+
+	t.Run("delete_wisp_routes_to_wisps_table", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "dwr")
+		wisp := bdProxiedCreate(t, bd, p.dir, "Wisp delete routing", "--ephemeral")
+
+		db := openProxiedDB(t, p)
+		assertRowExists(t, db, "wisps", wisp.ID)
+		assertRowAbsent(t, db, "issues", wisp.ID)
+
+		if _, err := db.ExecContext(context.Background(),
+			"INSERT INTO issues (id, title, description, design, acceptance_criteria, notes) VALUES (?, ?, '', '', '', '')",
+			wisp.ID, "shadow row"); err != nil {
+			t.Fatalf("seed shadow issues row: %v", err)
+		}
+		assertRowExists(t, db, "issues", wisp.ID)
+
+		bdProxiedDelete(t, bd, p.dir, wisp.ID, "--force")
+
+		assertRowAbsent(t, db, "wisps", wisp.ID)
+		assertRowExists(t, db, "issues", wisp.ID)
+	})
+}
+
+func TestProxiedServerDeleteConcurrent(t *testing.T) {
+	requireProxiedServerEnv(t)
+	bd := buildEmbeddedBD(t)
+
+	p := bdProxiedInit(t, bd, "ddc")
+	issue := bdProxiedCreate(t, bd, p.dir, "Concurrent delete contest", "-t", "task")
+
+	const n = 5
+	type result struct {
+		idx      int
+		exitErr  error
+		combined string
+	}
+	results := make([]result, n)
+
+	var wg sync.WaitGroup
+	for i := 0; i < n; i++ {
+		i := i
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			stdout, stderr, err := bdProxiedDeleteRaw(t, bd, p.dir, issue.ID, "--force")
+			results[i] = result{idx: i, exitErr: err, combined: stdout + stderr}
+		}()
+	}
+	wg.Wait()
+
+	var winners []int
+	var conflicts int
+	for _, r := range results {
+		if r.exitErr == nil {
+			winners = append(winners, r.idx)
+			continue
+		}
+		isNotFound := strings.Contains(strings.ToLower(r.combined), "not found")
+		isSerializationFailure := strings.Contains(r.combined, "serialization failure") ||
+			strings.Contains(r.combined, "Error 1213")
+		if isNotFound || isSerializationFailure {
+			conflicts++
+			continue
+		}
+		t.Errorf("unexpected failure for goroutine %d: err=%v combined=%s",
+			r.idx, r.exitErr, r.combined)
+	}
+
+	if len(winners) < 1 {
+		t.Errorf("expected at least one winner, got 0")
+	}
+	if len(winners)+conflicts != n {
+		t.Errorf("winners (%d) + conflicts (%d) != n (%d) — some goroutine had an unexpected failure",
+			len(winners), conflicts, n)
+	}
+
+	db := openProxiedDB(t, p)
+	assertRowAbsent(t, db, "issues", issue.ID)
+}
+
+func bdProxiedDelete(t *testing.T, bd, dir string, args ...string) string {
+	t.Helper()
+	fullArgs := append([]string{"delete"}, args...)
+	stdout, stderr, err := bdProxiedRunBuffers(t, bd, dir, fullArgs...)
+	if err != nil {
+		t.Fatalf("bd delete %s failed: %v\nstdout:\n%s\nstderr:\n%s",
+			strings.Join(args, " "), err, stdout, stderr)
+	}
+	return stdout
+}
+
+func bdProxiedDeleteJSON(t *testing.T, bd, dir string, args ...string) map[string]any {
+	t.Helper()
+	out := bdProxiedDelete(t, bd, dir, args...)
+	start := strings.Index(out, "{")
+	if start < 0 {
+		t.Fatalf("no JSON object in delete output:\n%s", out)
+	}
+	var got map[string]any
+	if err := json.Unmarshal([]byte(out[start:]), &got); err != nil {
+		t.Fatalf("parse delete JSON: %v\nraw: %s", err, out[start:])
+	}
+	return got
+}
+
+func mapKeys(m map[string]any) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}
+
+func bdProxiedDeleteRaw(t *testing.T, bd, dir string, args ...string) (string, string, error) {
+	t.Helper()
+	fullArgs := append([]string{"delete"}, args...)
+	return bdProxiedRunBuffers(t, bd, dir, fullArgs...)
+}
+
+func bdProxiedDeleteFail(t *testing.T, bd, dir string, args ...string) string {
+	t.Helper()
+	stdout, stderr, err := bdProxiedDeleteRaw(t, bd, dir, args...)
+	if err == nil {
+		t.Fatalf("bd delete %s should have failed; got:\nstdout:\n%s\nstderr:\n%s",
+			strings.Join(args, " "), stdout, stderr)
+	}
+	return stdout + stderr
+}

--- a/cmd/bd/delete_proxied_integration_test.go
+++ b/cmd/bd/delete_proxied_integration_test.go
@@ -233,11 +233,6 @@ func TestProxiedServerDelete(t *testing.T) {
 			t.Errorf("parent status after deleting child: got %q, want non-closed", status)
 		}
 	})
-}
-
-func TestProxiedServerDeleteWisp(t *testing.T) {
-	requireProxiedServerEnv(t)
-	bd := buildEmbeddedBD(t)
 
 	t.Run("delete_always_cascades_dependents", func(t *testing.T) {
 		p := bdProxiedInit(t, bd, "dac")
@@ -462,6 +457,11 @@ func TestProxiedServerDeleteWisp(t *testing.T) {
 		db := openProxiedDB(t, p)
 		assertRowExists(t, db, "issues", issue.ID)
 	})
+}
+
+func TestProxiedServerDeleteWisp(t *testing.T) {
+	requireProxiedServerEnv(t)
+	bd := buildEmbeddedBD(t)
 
 	t.Run("delete_mixed_wisp_and_issue_partition", func(t *testing.T) {
 		p := bdProxiedInit(t, bd, "dmp")
@@ -532,6 +532,118 @@ func TestProxiedServerDeleteWisp(t *testing.T) {
 
 		assertRowAbsent(t, db, "wisps", wisp.ID)
 		assertRowExists(t, db, "issues", wisp.ID)
+	})
+
+	t.Run("delete_wisp_batch", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "dwb")
+		a := bdProxiedCreate(t, bd, p.dir, "Wisp batch 1", "--ephemeral")
+		b := bdProxiedCreate(t, bd, p.dir, "Wisp batch 2", "--ephemeral")
+		c := bdProxiedCreate(t, bd, p.dir, "Wisp batch 3", "--ephemeral")
+
+		bdProxiedDelete(t, bd, p.dir, a.ID, b.ID, c.ID, "--force")
+
+		db := openProxiedDB(t, p)
+		for _, id := range []string{a.ID, b.ID, c.ID} {
+			assertRowAbsent(t, db, "wisps", id)
+		}
+	})
+
+	t.Run("delete_wisp_cascades_dependents", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "dwc")
+		parent := bdProxiedCreate(t, bd, p.dir, "Wisp parent", "--ephemeral")
+		child := bdProxiedCreate(t, bd, p.dir, "Wisp child", "--ephemeral",
+			"--deps", "depends-on:"+parent.ID)
+
+		bdProxiedDelete(t, bd, p.dir, parent.ID, "--force")
+
+		db := openProxiedDB(t, p)
+		assertRowAbsent(t, db, "wisps", parent.ID)
+		assertRowAbsent(t, db, "wisps", child.ID)
+	})
+
+	t.Run("delete_wisp_cascade_spans_all_dep_types", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "dws")
+		a := bdProxiedCreate(t, bd, p.dir, "Wisp A", "--ephemeral")
+		b := bdProxiedCreate(t, bd, p.dir, "Wisp B", "--ephemeral",
+			"--deps", "depends-on:"+a.ID)
+		c := bdProxiedCreate(t, bd, p.dir, "Wisp C", "--ephemeral",
+			"--parent", b.ID)
+
+		bdProxiedDelete(t, bd, p.dir, a.ID, "--force")
+
+		db := openProxiedDB(t, p)
+		for _, id := range []string{a.ID, b.ID, c.ID} {
+			assertRowAbsent(t, db, "wisps", id)
+		}
+	})
+
+	t.Run("delete_wisp_skips_dolt_commit", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "dwdc")
+		wisp := bdProxiedCreate(t, bd, p.dir, "Wisp commit skip", "--ephemeral")
+
+		db := openProxiedDB(t, p)
+		var before string
+		if err := db.QueryRowContext(context.Background(),
+			"SELECT HASHOF('HEAD')").Scan(&before); err != nil {
+			t.Fatalf("read HEAD before: %v", err)
+		}
+
+		bdProxiedDelete(t, bd, p.dir, wisp.ID, "--force")
+
+		var after string
+		if err := db.QueryRowContext(context.Background(),
+			"SELECT HASHOF('HEAD')").Scan(&after); err != nil {
+			t.Fatalf("read HEAD after: %v", err)
+		}
+		if after != before {
+			t.Errorf("HEAD advanced for a wisp-only delete (wisps are dolt_ignored): before=%s after=%s",
+				before, after)
+		}
+	})
+
+	t.Run("delete_wisp_dry_run_does_not_mutate", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "dwdr")
+		wisp := bdProxiedCreate(t, bd, p.dir, "Wisp dry-run target", "--ephemeral")
+
+		got := bdProxiedDeleteJSON(t, bd, p.dir, "--json", wisp.ID, "--dry-run")
+		if _, ok := got["would_delete"]; !ok {
+			t.Errorf("dry-run JSON missing `would_delete`; got keys: %v", mapKeys(got))
+		}
+
+		db := openProxiedDB(t, p)
+		assertRowExists(t, db, "wisps", wisp.ID)
+	})
+
+	t.Run("delete_wisp_rewrites_text_references", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "dwrt")
+		neighbor := bdProxiedCreate(t, bd, p.dir, "Wisp neighbor", "--ephemeral")
+		target := bdProxiedCreate(t, bd, p.dir, "Wisp target", "--ephemeral",
+			"--deps", "depends-on:"+neighbor.ID)
+		bdProxiedUpdateOne(t, bd, p.dir, neighbor.ID, "--description", "see "+target.ID+" for context")
+
+		bdProxiedDelete(t, bd, p.dir, target.ID, "--force")
+
+		db := openProxiedDB(t, p)
+		assertRowAbsent(t, db, "wisps", target.ID)
+		assertRowExists(t, db, "wisps", neighbor.ID)
+
+		var desc string
+		if err := db.QueryRowContext(context.Background(),
+			"SELECT description FROM wisps WHERE id = ?", neighbor.ID).Scan(&desc); err != nil {
+			t.Fatalf("read wisp neighbor description: %v", err)
+		}
+		want := "[deleted:" + target.ID + "]"
+		if !strings.Contains(desc, want) {
+			t.Errorf("wisp neighbor description: got %q, want substring %q", desc, want)
+		}
+	})
+
+	t.Run("delete_wisp_nonexistent", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "dwn")
+		out := bdProxiedDeleteFail(t, bd, p.dir, "dwn-doesnotexist", "--force")
+		if !strings.Contains(strings.ToLower(out), "not found") {
+			t.Errorf("expected `not found` error for bogus wisp id, got: %s", out)
+		}
 	})
 }
 

--- a/cmd/bd/delete_proxied_integration_test.go
+++ b/cmd/bd/delete_proxied_integration_test.go
@@ -450,17 +450,17 @@ func TestProxiedServerDeleteWisp(t *testing.T) {
 		}
 	})
 
-	t.Run("delete_cascade_flag_is_noop", func(t *testing.T) {
+	t.Run("delete_cascade_flag_is_error", func(t *testing.T) {
 		p := bdProxiedInit(t, bd, "dcn")
-		withCascade := bdProxiedCreate(t, bd, p.dir, "With cascade flag", "-t", "task")
-		withoutCascade := bdProxiedCreate(t, bd, p.dir, "Without cascade flag", "-t", "task")
+		issue := bdProxiedCreate(t, bd, p.dir, "Cascade flag", "-t", "task")
 
-		bdProxiedDelete(t, bd, p.dir, withCascade.ID, "--force", "--cascade")
-		bdProxiedDelete(t, bd, p.dir, withoutCascade.ID, "--force")
+		out := bdProxiedDeleteFail(t, bd, p.dir, issue.ID, "--force", "--cascade")
+		if !strings.Contains(out, "--cascade") {
+			t.Errorf("expected error mentioning --cascade, got: %s", out)
+		}
 
 		db := openProxiedDB(t, p)
-		assertRowAbsent(t, db, "issues", withCascade.ID)
-		assertRowAbsent(t, db, "issues", withoutCascade.ID)
+		assertRowExists(t, db, "issues", issue.ID)
 	})
 
 	t.Run("delete_mixed_wisp_and_issue_partition", func(t *testing.T) {

--- a/cmd/bd/delete_proxied_server.go
+++ b/cmd/bd/delete_proxied_server.go
@@ -1,0 +1,191 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/steveyegge/beads/internal/storage/domain"
+	"github.com/steveyegge/beads/internal/ui"
+)
+
+type deleteInput struct {
+	ids        []string
+	force      bool
+	dryRun     bool
+	jsonOutput bool
+}
+
+func gatherDeleteInput(cmd *cobra.Command, args []string) (*deleteInput, error) {
+	in := &deleteInput{}
+	in.ids = append(in.ids, args...)
+
+	if fromFile, _ := cmd.Flags().GetString("from-file"); fromFile != "" {
+		ids, err := readIssueIDsFromFile(fromFile)
+		if err != nil {
+			return nil, fmt.Errorf("reading file: %w", err)
+		}
+		in.ids = append(in.ids, ids...)
+	}
+	in.ids = uniqueStrings(in.ids)
+
+	in.force, _ = cmd.Flags().GetBool("force")
+	in.dryRun, _ = cmd.Flags().GetBool("dry-run")
+	in.jsonOutput = jsonOutput
+	return in, nil
+}
+
+func runDeleteProxiedServer(cmd *cobra.Command, ctx context.Context, args []string) {
+	in, err := gatherDeleteInput(cmd, args)
+	if err != nil {
+		FatalErrorRespectJSON("%v", err)
+	}
+	if len(in.ids) == 0 {
+		_ = cmd.Usage()
+		FatalError("no issue IDs provided")
+	}
+
+	if uowProvider == nil {
+		FatalError("proxied-server UOW provider not initialized")
+	}
+	uw, err := uowProvider.NewUOW(ctx)
+	if err != nil {
+		FatalErrorRespectJSON("open unit of work: %v", err)
+	}
+	defer uw.Close(ctx)
+
+	issueUC := uw.IssueUseCase()
+
+	if in.dryRun || !in.force {
+		runDeleteProxiedPreview(ctx, issueUC, in)
+		return
+	}
+
+	preview, err := issueUC.PreviewDelete(ctx, in.ids)
+	if err != nil {
+		FatalErrorRespectJSON("preview: %v", err)
+	}
+	if len(preview.NotFound) > 0 {
+		FatalErrorRespectJSON("issues not found: %s", strings.Join(preview.NotFound, ", "))
+	}
+
+	res, err := issueUC.DeleteIssues(ctx, domain.DeleteIssuesParams{
+		IDs:                  in.ids,
+		UpdateTextReferences: true,
+	}, actor)
+	if err != nil {
+		FatalErrorRespectJSON("delete: %v", err)
+	}
+	if res.DeletedCount == 0 {
+		FatalErrorRespectJSON("issues not found: %s", strings.Join(in.ids, ", "))
+	}
+
+	commitMsg := fmt.Sprintf("bd: delete %d issue(s)", res.DeletedCount)
+	if err := uw.Commit(ctx, commitMsg); err != nil && !isDoltNothingToCommit(err) {
+		FatalErrorRespectJSON("commit: %v", err)
+	}
+
+	renderDeleteProxiedResult(in, res)
+}
+
+func runDeleteProxiedPreview(ctx context.Context, issueUC domain.IssueUseCase, in *deleteInput) {
+	preview, err := issueUC.PreviewDelete(ctx, in.ids)
+	if err != nil {
+		FatalErrorRespectJSON("preview: %v", err)
+	}
+	if len(preview.NotFound) > 0 {
+		FatalErrorRespectJSON("issues not found: %s", strings.Join(preview.NotFound, ", "))
+	}
+
+	res, err := issueUC.DeleteIssues(ctx, domain.DeleteIssuesParams{
+		IDs:    in.ids,
+		DryRun: true,
+	}, actor)
+	if err != nil {
+		FatalErrorRespectJSON("preview counts: %v", err)
+	}
+
+	if in.jsonOutput {
+		outputJSON(map[string]any{
+			"would_delete":         res.DeletedCount,
+			"dependencies_removed": res.DependenciesCount,
+			"labels_removed":       res.LabelsCount,
+			"events_removed":       res.EventsCount,
+			"ids":                  in.ids,
+			"not_found":            preview.NotFound,
+			"connected":            sortedKeys(preview.ConnectedIssues),
+			"dry_run":              in.dryRun,
+		})
+		return
+	}
+	renderDeletePreview(in, preview, res)
+}
+
+func renderDeletePreview(in *deleteInput, preview domain.DeletePreview, res domain.DeleteIssuesResult) {
+	fmt.Printf("\n%s\n", ui.RenderFail("⚠️  DELETE PREVIEW"))
+	fmt.Printf("\nIssues to delete (%d):\n", len(in.ids))
+	for _, id := range in.ids {
+		title := ""
+		if iss, ok := preview.Issues[id]; ok && iss != nil {
+			title = iss.Title
+		}
+		fmt.Printf("  %s: %s\n", id, title)
+	}
+	fmt.Printf("\nCascade is always enabled — dependent issues will be removed.\n")
+	fmt.Printf("\nWould remove:\n")
+	fmt.Printf("  %d issue(s) total\n", res.DeletedCount)
+	fmt.Printf("  %d dependency link(s)\n", res.DependenciesCount)
+	fmt.Printf("  %d label(s)\n", res.LabelsCount)
+	fmt.Printf("  %d event(s)\n", res.EventsCount)
+
+	if len(preview.ConnectedIssues) > 0 {
+		fmt.Printf("\nConnected issues (text references may be rewritten):\n")
+		for _, id := range sortedKeys(preview.ConnectedIssues) {
+			iss := preview.ConnectedIssues[id]
+			title := ""
+			if iss != nil {
+				title = iss.Title
+			}
+			fmt.Printf("  %s: %s\n", id, title)
+		}
+	}
+
+	if in.dryRun {
+		fmt.Printf("\n(Dry-run mode - no changes made)\n")
+		return
+	}
+	fmt.Printf("\n%s\n", ui.RenderWarn("This operation cannot be undone!"))
+	fmt.Printf("To proceed, run: %s\n",
+		ui.RenderWarn("bd delete "+strings.Join(in.ids, " ")+" --force"))
+}
+
+func renderDeleteProxiedResult(in *deleteInput, res domain.DeleteIssuesResult) {
+	if in.jsonOutput {
+		outputJSON(map[string]any{
+			"deleted":              in.ids,
+			"deleted_count":        res.DeletedCount,
+			"dependencies_removed": res.DependenciesCount,
+			"labels_removed":       res.LabelsCount,
+			"events_removed":       res.EventsCount,
+			"references_updated":   res.ReferencesUpdated,
+		})
+		return
+	}
+	fmt.Printf("%s Deleted %d issue(s)\n", ui.RenderPass("✓"), res.DeletedCount)
+	fmt.Printf("  Removed %d dependency link(s)\n", res.DependenciesCount)
+	fmt.Printf("  Removed %d label(s)\n", res.LabelsCount)
+	fmt.Printf("  Removed %d event(s)\n", res.EventsCount)
+	fmt.Printf("  Updated text references in %d issue(s)\n", res.ReferencesUpdated)
+}
+
+func sortedKeys[V any](m map[string]V) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/cmd/bd/delete_proxied_server.go
+++ b/cmd/bd/delete_proxied_server.go
@@ -20,6 +20,10 @@ type deleteInput struct {
 }
 
 func gatherDeleteInput(cmd *cobra.Command, args []string) (*deleteInput, error) {
+	if cmd.Flags().Changed("cascade") {
+		return nil, fmt.Errorf("--cascade is not supported in proxied-server mode (delete always cascades)")
+	}
+
 	in := &deleteInput{}
 	in.ids = append(in.ids, args...)
 

--- a/cmd/bd/init.go
+++ b/cmd/bd/init.go
@@ -120,12 +120,12 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 		if os.Getenv("BEADS_DOLT_PROXIED_SERVER") == "1" {
 			initProxiedServer = true
 		}
-		if initProxiedServer {
-			// Proxied-server mode has no local Dolt init lifecycle yet. When it
-			// is implemented, that path must mark any local .dolt/ it creates or
-			// acknowledges with doltserver.MarkDoltDirCompatible.
-			FatalError("--proxied-server is not yet implemented")
-		}
+		// if initProxiedServer {
+		// 	// Proxied-server mode has no local Dolt init lifecycle yet. When it
+		// 	// is implemented, that path must mark any local .dolt/ it creates or
+		// 	// acknowledges with doltserver.MarkDoltDirCompatible.
+		// 	FatalError("--proxied-server is not yet implemented")
+		// }
 		if initProxiedServer && initServerMode {
 			FatalError("--server and --proxied-server are mutually exclusive")
 		}

--- a/cmd/bd/init.go
+++ b/cmd/bd/init.go
@@ -120,12 +120,12 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 		if os.Getenv("BEADS_DOLT_PROXIED_SERVER") == "1" {
 			initProxiedServer = true
 		}
-		// if initProxiedServer {
-		// 	// Proxied-server mode has no local Dolt init lifecycle yet. When it
-		// 	// is implemented, that path must mark any local .dolt/ it creates or
-		// 	// acknowledges with doltserver.MarkDoltDirCompatible.
-		// 	FatalError("--proxied-server is not yet implemented")
-		// }
+		if initProxiedServer {
+			// Proxied-server mode has no local Dolt init lifecycle yet. When it
+			// is implemented, that path must mark any local .dolt/ it creates or
+			// acknowledges with doltserver.MarkDoltDirCompatible.
+			FatalError("--proxied-server is not yet implemented")
+		}
 		if initProxiedServer && initServerMode {
 			FatalError("--server and --proxied-server are mutually exclusive")
 		}

--- a/internal/storage/domain/db/delete_repo_test.go
+++ b/internal/storage/domain/db/delete_repo_test.go
@@ -54,6 +54,11 @@ func (s *testSuite) TestLabelSQLRepositoryDelete() {
 		s.Run("RemovesLabelsForIDs", s.labelDeleteAllRemoves)
 		s.Run("RoutesToWispLabels", s.labelDeleteAllWispRouting)
 	})
+	s.Run("CountAllForIDs", func() {
+		s.Run("EmptySliceIsZero", s.labelCountAllEmpty)
+		s.Run("CountsLabelsForIDs", s.labelCountAllCounts)
+		s.Run("RoutesToWispLabels", s.labelCountAllWispRouting)
+	})
 }
 
 func (s *testSuite) TestEventsSQLRepositoryDelete() {
@@ -373,6 +378,40 @@ func (s *testSuite) labelDeleteAllWispRouting() {
 	s.Require().NoError(s.Runner().QueryRowContext(s.Ctx(),
 		"SELECT COUNT(*) FROM wisp_labels WHERE issue_id = ?", "bd-del-wlbl-1").Scan(&wispCount))
 	s.Equal(0, wispCount)
+}
+
+func (s *testSuite) labelCountAllEmpty() {
+	n, err := s.labelRepo().CountAllForIDs(s.Ctx(), nil, domain.LabelOpts{})
+	s.Require().NoError(err)
+	s.Equal(0, n)
+}
+
+func (s *testSuite) labelCountAllCounts() {
+	s.seedIssueRow("bd-del-lcnt-a")
+	s.seedIssueRow("bd-del-lcnt-b")
+	s.seedIssueRow("bd-del-lcnt-c")
+	r := s.labelRepo()
+	s.Require().NoError(r.Insert(s.Ctx(), "bd-del-lcnt-a", "x", "tester", domain.LabelOpts{}))
+	s.Require().NoError(r.Insert(s.Ctx(), "bd-del-lcnt-a", "y", "tester", domain.LabelOpts{}))
+	s.Require().NoError(r.Insert(s.Ctx(), "bd-del-lcnt-b", "z", "tester", domain.LabelOpts{}))
+	s.Require().NoError(r.Insert(s.Ctx(), "bd-del-lcnt-c", "ignored", "tester", domain.LabelOpts{}))
+
+	n, err := r.CountAllForIDs(s.Ctx(),
+		[]string{"bd-del-lcnt-a", "bd-del-lcnt-b"}, domain.LabelOpts{})
+	s.Require().NoError(err)
+	s.Equal(3, n)
+}
+
+func (s *testSuite) labelCountAllWispRouting() {
+	s.seedWispRow("bd-del-wlcnt-1")
+	r := s.labelRepo()
+	s.Require().NoError(r.Insert(s.Ctx(), "bd-del-wlcnt-1", "alpha", "tester",
+		domain.LabelOpts{UseWispsTable: true}))
+
+	n, err := r.CountAllForIDs(s.Ctx(), []string{"bd-del-wlcnt-1"},
+		domain.LabelOpts{UseWispsTable: true})
+	s.Require().NoError(err)
+	s.Equal(1, n, "wisp-routed count must read from wisp_labels")
 }
 
 func (s *testSuite) eventsDeleteAllEmpty() {

--- a/internal/storage/domain/db/delete_repo_test.go
+++ b/internal/storage/domain/db/delete_repo_test.go
@@ -1,0 +1,451 @@
+package db
+
+import (
+	"github.com/steveyegge/beads/internal/storage/domain"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+func (s *testSuite) TestIssueSQLRepositoryDelete() {
+	s.Run("Delete", func() {
+		s.Run("RemovesRow", s.issueDeleteRemovesRow)
+		s.Run("MissingIDReturnsError", s.issueDeleteMissing)
+		s.Run("RoutesToWispsTable", s.issueDeleteWispRouting)
+	})
+	s.Run("DeleteByIDs", func() {
+		s.Run("EmptySliceIsZero", s.issueDeleteByIDsEmpty)
+		s.Run("BulkRemovesAndReturnsCount", s.issueDeleteByIDsBulk)
+		s.Run("RoutesToWispsTable", s.issueDeleteByIDsWispRouting)
+		s.Run("MissingIDsAreSkipped", s.issueDeleteByIDsMissing)
+	})
+	s.Run("PartitionWispIDs", func() {
+		s.Run("EmptyInputReturnsNil", s.issuePartitionEmpty)
+		s.Run("SplitsByTable", s.issuePartitionSplits)
+	})
+	s.Run("FindAllDependents", func() {
+		s.Run("EmptyInputReturnsEmpty", s.issueFindAllDependentsEmpty)
+		s.Run("TransitiveAcrossDepTypes", s.issueFindAllDependentsTransitive)
+		s.Run("IncludesRootIDs", s.issueFindAllDependentsIncludesRoots)
+	})
+	s.Run("AffectedByDeletion", func() {
+		s.Run("EmptyInputReturnsEmpty", s.issueAffectedByDeletionEmpty)
+		s.Run("ReturnsBlockingDependers", s.issueAffectedByDeletionDependers)
+	})
+	s.Run("RecomputeIsBlocked", func() {
+		s.Run("EmptyIDsNoop", s.issueRecomputeIsBlockedEmpty)
+		s.Run("FlipsIsBlockedWhenBlockerCloses", s.issueRecomputeIsBlockedFlips)
+	})
+}
+
+func (s *testSuite) TestDependencySQLRepositoryDelete() {
+	s.Run("DeleteAllForIDs", func() {
+		s.Run("EmptySliceIsZero", s.depDeleteAllEmpty)
+		s.Run("RemovesEdgesTouchingIDs", s.depDeleteAllRemoves)
+		s.Run("RoutesToWispDependencies", s.depDeleteAllWispRouting)
+	})
+	s.Run("CountAllForIDs", func() {
+		s.Run("EmptySliceIsZero", s.depCountAllEmpty)
+		s.Run("CountsEdgesTouchingIDs", s.depCountAllCounts)
+	})
+}
+
+func (s *testSuite) TestLabelSQLRepositoryDelete() {
+	s.Run("DeleteAllForIDs", func() {
+		s.Run("EmptySliceIsZero", s.labelDeleteAllEmpty)
+		s.Run("RemovesLabelsForIDs", s.labelDeleteAllRemoves)
+		s.Run("RoutesToWispLabels", s.labelDeleteAllWispRouting)
+	})
+}
+
+func (s *testSuite) TestEventsSQLRepositoryDelete() {
+	s.Run("DeleteAllForIDs", func() {
+		s.Run("EmptySliceIsZero", s.eventsDeleteAllEmpty)
+		s.Run("RemovesEventsForIDs", s.eventsDeleteAllRemoves)
+		s.Run("RoutesToWispEvents", s.eventsDeleteAllWispRouting)
+	})
+	s.Run("CountAllForIDs", func() {
+		s.Run("EmptySliceIsZero", s.eventsCountAllEmpty)
+		s.Run("CountsEventsForIDs", s.eventsCountAllCounts)
+		s.Run("RoutesToWispEvents", s.eventsCountAllWispRouting)
+	})
+}
+
+func (s *testSuite) issueDeleteRemovesRow() {
+	s.seedIssueRow("bd-del-r1")
+	r := s.issueRepo()
+	s.Require().NoError(r.Delete(s.Ctx(), "bd-del-r1", domain.IssueTableOpts{}))
+
+	var c int
+	s.Require().NoError(s.Runner().QueryRowContext(s.Ctx(),
+		"SELECT COUNT(*) FROM issues WHERE id = ?", "bd-del-r1").Scan(&c))
+	s.Equal(0, c)
+}
+
+func (s *testSuite) issueDeleteMissing() {
+	r := s.issueRepo()
+	err := r.Delete(s.Ctx(), "bd-del-nope", domain.IssueTableOpts{})
+	s.Require().Error(err)
+	s.Contains(err.Error(), "not found")
+}
+
+func (s *testSuite) issueDeleteWispRouting() {
+	s.seedWispRow("bd-del-w1")
+	s.seedIssueRow("bd-del-w1")
+
+	r := s.issueRepo()
+	s.Require().NoError(r.Delete(s.Ctx(), "bd-del-w1", domain.IssueTableOpts{UseWispsTable: true}))
+
+	var wispCount, issueCount int
+	s.Require().NoError(s.Runner().QueryRowContext(s.Ctx(),
+		"SELECT COUNT(*) FROM wisps WHERE id = ?", "bd-del-w1").Scan(&wispCount))
+	s.Equal(0, wispCount, "wisp row should be deleted")
+	s.Require().NoError(s.Runner().QueryRowContext(s.Ctx(),
+		"SELECT COUNT(*) FROM issues WHERE id = ?", "bd-del-w1").Scan(&issueCount))
+	s.Equal(1, issueCount, "issues row must be untouched")
+}
+
+func (s *testSuite) issueDeleteByIDsEmpty() {
+	n, err := s.issueRepo().DeleteByIDs(s.Ctx(), nil, domain.IssueTableOpts{})
+	s.Require().NoError(err)
+	s.Equal(0, n)
+}
+
+func (s *testSuite) issueDeleteByIDsBulk() {
+	s.seedIssueRow("bd-del-bulk-a")
+	s.seedIssueRow("bd-del-bulk-b")
+	s.seedIssueRow("bd-del-bulk-c")
+
+	n, err := s.issueRepo().DeleteByIDs(s.Ctx(),
+		[]string{"bd-del-bulk-a", "bd-del-bulk-b", "bd-del-bulk-c"}, domain.IssueTableOpts{})
+	s.Require().NoError(err)
+	s.Equal(3, n)
+
+	var c int
+	s.Require().NoError(s.Runner().QueryRowContext(s.Ctx(),
+		"SELECT COUNT(*) FROM issues WHERE id IN ('bd-del-bulk-a','bd-del-bulk-b','bd-del-bulk-c')").Scan(&c))
+	s.Equal(0, c)
+}
+
+func (s *testSuite) issueDeleteByIDsWispRouting() {
+	s.seedWispRow("bd-del-bulk-w1")
+	s.seedWispRow("bd-del-bulk-w2")
+	s.seedIssueRow("bd-del-bulk-w1")
+
+	n, err := s.issueRepo().DeleteByIDs(s.Ctx(),
+		[]string{"bd-del-bulk-w1", "bd-del-bulk-w2"}, domain.IssueTableOpts{UseWispsTable: true})
+	s.Require().NoError(err)
+	s.Equal(2, n)
+
+	var wispCount, issueCount int
+	s.Require().NoError(s.Runner().QueryRowContext(s.Ctx(),
+		"SELECT COUNT(*) FROM wisps WHERE id IN ('bd-del-bulk-w1','bd-del-bulk-w2')").Scan(&wispCount))
+	s.Equal(0, wispCount)
+	s.Require().NoError(s.Runner().QueryRowContext(s.Ctx(),
+		"SELECT COUNT(*) FROM issues WHERE id = ?", "bd-del-bulk-w1").Scan(&issueCount))
+	s.Equal(1, issueCount)
+}
+
+func (s *testSuite) issueDeleteByIDsMissing() {
+	s.seedIssueRow("bd-del-mix-a")
+	n, err := s.issueRepo().DeleteByIDs(s.Ctx(),
+		[]string{"bd-del-mix-a", "bd-del-mix-missing"}, domain.IssueTableOpts{})
+	s.Require().NoError(err)
+	s.Equal(1, n, "only one row matched")
+}
+
+func (s *testSuite) issuePartitionEmpty() {
+	wisp, perm, err := s.issueRepo().PartitionWispIDs(s.Ctx(), nil)
+	s.Require().NoError(err)
+	s.Nil(wisp)
+	s.Nil(perm)
+}
+
+func (s *testSuite) issuePartitionSplits() {
+	s.seedIssueRow("bd-del-part-i1")
+	s.seedIssueRow("bd-del-part-i2")
+	s.seedWispRow("bd-del-part-w1")
+
+	wisp, perm, err := s.issueRepo().PartitionWispIDs(s.Ctx(),
+		[]string{"bd-del-part-i1", "bd-del-part-w1", "bd-del-part-i2", "bd-del-part-unknown"})
+	s.Require().NoError(err)
+	s.Equal([]string{"bd-del-part-w1"}, wisp)
+	s.Equal([]string{"bd-del-part-i1", "bd-del-part-i2", "bd-del-part-unknown"}, perm,
+		"unknown IDs partition as permanent (treated as non-wisp by helper)")
+}
+
+func (s *testSuite) issueFindAllDependentsEmpty() {
+	out, err := s.issueRepo().FindAllDependents(s.Ctx(), nil)
+	s.Require().NoError(err)
+	s.Empty(out)
+}
+
+func (s *testSuite) issueFindAllDependentsTransitive() {
+	s.seedIssueRow("bd-del-cas-root")
+	s.seedIssueRow("bd-del-cas-mid")
+	s.seedIssueRow("bd-del-cas-leaf")
+
+	r := s.depRepo()
+	s.Require().NoError(r.Insert(s.Ctx(),
+		newDep("bd-del-cas-mid", "bd-del-cas-root", types.DepBlocks), "tester", domain.DepInsertOpts{}))
+	s.Require().NoError(r.Insert(s.Ctx(),
+		newDep("bd-del-cas-leaf", "bd-del-cas-mid", types.DepParentChild), "tester", domain.DepInsertOpts{}))
+
+	out, err := s.issueRepo().FindAllDependents(s.Ctx(), []string{"bd-del-cas-root"})
+	s.Require().NoError(err)
+	got := make(map[string]bool, len(out))
+	for _, id := range out {
+		got[id] = true
+	}
+	s.True(got["bd-del-cas-root"], "root included")
+	s.True(got["bd-del-cas-mid"], "direct dependent via blocks included")
+	s.True(got["bd-del-cas-leaf"], "transitive dependent via parent-child included")
+}
+
+func (s *testSuite) issueFindAllDependentsIncludesRoots() {
+	s.seedIssueRow("bd-del-cas-solo")
+	out, err := s.issueRepo().FindAllDependents(s.Ctx(), []string{"bd-del-cas-solo"})
+	s.Require().NoError(err)
+	s.Equal([]string{"bd-del-cas-solo"}, out)
+}
+
+func (s *testSuite) issueAffectedByDeletionEmpty() {
+	issues, wisps, err := s.issueRepo().AffectedByDeletion(s.Ctx(), nil, nil)
+	s.Require().NoError(err)
+	s.Empty(issues)
+	s.Empty(wisps)
+}
+
+func (s *testSuite) issueAffectedByDeletionDependers() {
+	s.seedIssueRow("bd-del-aff-blocker")
+	s.seedIssueRow("bd-del-aff-depender")
+	s.Require().NoError(s.depRepo().Insert(s.Ctx(),
+		newDep("bd-del-aff-depender", "bd-del-aff-blocker", types.DepBlocks),
+		"tester", domain.DepInsertOpts{}))
+
+	issues, _, err := s.issueRepo().AffectedByDeletion(s.Ctx(),
+		[]string{"bd-del-aff-blocker"}, nil)
+	s.Require().NoError(err)
+	got := make(map[string]bool, len(issues))
+	for _, id := range issues {
+		got[id] = true
+	}
+	s.True(got["bd-del-aff-depender"], "depender must appear in affected set")
+}
+
+func (s *testSuite) issueRecomputeIsBlockedEmpty() {
+	s.Require().NoError(s.issueRepo().RecomputeIsBlocked(s.Ctx(), nil, nil))
+}
+
+func (s *testSuite) issueRecomputeIsBlockedFlips() {
+	s.seedIssueRow("bd-del-rib-blocker")
+	s.seedIssueRow("bd-del-rib-depender")
+	s.Require().NoError(s.depRepo().Insert(s.Ctx(),
+		newDep("bd-del-rib-depender", "bd-del-rib-blocker", types.DepBlocks),
+		"tester", domain.DepInsertOpts{}))
+
+	s.Require().NoError(s.issueRepo().RecomputeIsBlocked(s.Ctx(),
+		[]string{"bd-del-rib-depender"}, nil))
+	var blocked int
+	s.Require().NoError(s.Runner().QueryRowContext(s.Ctx(),
+		"SELECT is_blocked FROM issues WHERE id = ?", "bd-del-rib-depender").Scan(&blocked))
+	s.Equal(1, blocked, "depender should be blocked while blocker is open")
+
+	_, err := s.Runner().ExecContext(s.Ctx(),
+		"UPDATE issues SET status = 'closed' WHERE id = ?", "bd-del-rib-blocker")
+	s.Require().NoError(err)
+	s.Require().NoError(s.issueRepo().RecomputeIsBlocked(s.Ctx(),
+		[]string{"bd-del-rib-depender"}, nil))
+	s.Require().NoError(s.Runner().QueryRowContext(s.Ctx(),
+		"SELECT is_blocked FROM issues WHERE id = ?", "bd-del-rib-depender").Scan(&blocked))
+	s.Equal(0, blocked, "depender should unblock once blocker is closed")
+}
+
+func (s *testSuite) depDeleteAllEmpty() {
+	n, err := s.depRepo().DeleteAllForIDs(s.Ctx(), nil, domain.DepInsertOpts{})
+	s.Require().NoError(err)
+	s.Equal(0, n)
+}
+
+func (s *testSuite) depDeleteAllRemoves() {
+	s.seedIssueRow("bd-del-da-a")
+	s.seedIssueRow("bd-del-da-b")
+	s.seedIssueRow("bd-del-da-c")
+	r := s.depRepo()
+	s.Require().NoError(r.Insert(s.Ctx(), newDep("bd-del-da-a", "bd-del-da-c", types.DepBlocks),
+		"tester", domain.DepInsertOpts{}))
+	s.Require().NoError(r.Insert(s.Ctx(), newDep("bd-del-da-b", "bd-del-da-a", types.DepBlocks),
+		"tester", domain.DepInsertOpts{}))
+	s.Require().NoError(r.Insert(s.Ctx(), newDep("bd-del-da-b", "bd-del-da-c", types.DepBlocks),
+		"tester", domain.DepInsertOpts{}))
+
+	n, err := r.DeleteAllForIDs(s.Ctx(), []string{"bd-del-da-a"}, domain.DepInsertOpts{})
+	s.Require().NoError(err)
+	s.Equal(2, n)
+
+	var remaining int
+	s.Require().NoError(s.Runner().QueryRowContext(s.Ctx(),
+		"SELECT COUNT(*) FROM dependencies WHERE issue_id IN ('bd-del-da-a','bd-del-da-b','bd-del-da-c')").Scan(&remaining))
+	s.Equal(1, remaining, "only B->C should remain")
+}
+
+func (s *testSuite) depDeleteAllWispRouting() {
+	s.seedWispRow("bd-del-dw-src")
+	s.seedIssueRow("bd-del-dw-tgt")
+	r := s.depRepo()
+	s.Require().NoError(r.Insert(s.Ctx(),
+		newDep("bd-del-dw-src", "bd-del-dw-tgt", types.DepBlocks), "tester",
+		domain.DepInsertOpts{UseWispsTable: true}))
+
+	n, err := r.DeleteAllForIDs(s.Ctx(), []string{"bd-del-dw-src"},
+		domain.DepInsertOpts{UseWispsTable: true})
+	s.Require().NoError(err)
+	s.Equal(1, n)
+
+	var wispCount int
+	s.Require().NoError(s.Runner().QueryRowContext(s.Ctx(),
+		"SELECT COUNT(*) FROM wisp_dependencies WHERE issue_id = ?", "bd-del-dw-src").Scan(&wispCount))
+	s.Equal(0, wispCount)
+}
+
+func (s *testSuite) depCountAllEmpty() {
+	n, err := s.depRepo().CountAllForIDs(s.Ctx(), nil, domain.DepCountsOpts{})
+	s.Require().NoError(err)
+	s.Equal(0, n)
+}
+
+func (s *testSuite) depCountAllCounts() {
+	s.seedIssueRow("bd-del-cnt-a")
+	s.seedIssueRow("bd-del-cnt-b")
+	s.seedIssueRow("bd-del-cnt-c")
+	r := s.depRepo()
+	s.Require().NoError(r.Insert(s.Ctx(), newDep("bd-del-cnt-a", "bd-del-cnt-c", types.DepBlocks),
+		"tester", domain.DepInsertOpts{}))
+	s.Require().NoError(r.Insert(s.Ctx(), newDep("bd-del-cnt-b", "bd-del-cnt-a", types.DepBlocks),
+		"tester", domain.DepInsertOpts{}))
+	s.Require().NoError(r.Insert(s.Ctx(), newDep("bd-del-cnt-b", "bd-del-cnt-c", types.DepBlocks),
+		"tester", domain.DepInsertOpts{}))
+
+	n, err := r.CountAllForIDs(s.Ctx(), []string{"bd-del-cnt-a"}, domain.DepCountsOpts{})
+	s.Require().NoError(err)
+	s.Equal(2, n, "edges touching A on either end")
+}
+
+func (s *testSuite) labelDeleteAllEmpty() {
+	n, err := s.labelRepo().DeleteAllForIDs(s.Ctx(), nil, domain.LabelOpts{})
+	s.Require().NoError(err)
+	s.Equal(0, n)
+}
+
+func (s *testSuite) labelDeleteAllRemoves() {
+	s.seedIssueRow("bd-del-lbl-a")
+	s.seedIssueRow("bd-del-lbl-b")
+	s.seedIssueRow("bd-del-lbl-c")
+	r := s.labelRepo()
+	s.Require().NoError(r.Insert(s.Ctx(), "bd-del-lbl-a", "x", "tester", domain.LabelOpts{}))
+	s.Require().NoError(r.Insert(s.Ctx(), "bd-del-lbl-a", "y", "tester", domain.LabelOpts{}))
+	s.Require().NoError(r.Insert(s.Ctx(), "bd-del-lbl-b", "z", "tester", domain.LabelOpts{}))
+	s.Require().NoError(r.Insert(s.Ctx(), "bd-del-lbl-c", "keep", "tester", domain.LabelOpts{}))
+
+	n, err := r.DeleteAllForIDs(s.Ctx(),
+		[]string{"bd-del-lbl-a", "bd-del-lbl-b"}, domain.LabelOpts{})
+	s.Require().NoError(err)
+	s.Equal(3, n)
+
+	var remaining int
+	s.Require().NoError(s.Runner().QueryRowContext(s.Ctx(),
+		"SELECT COUNT(*) FROM labels WHERE issue_id IN ('bd-del-lbl-a','bd-del-lbl-b','bd-del-lbl-c')").Scan(&remaining))
+	s.Equal(1, remaining, "only the untouched issue's label survives")
+}
+
+func (s *testSuite) labelDeleteAllWispRouting() {
+	s.seedWispRow("bd-del-wlbl-1")
+	r := s.labelRepo()
+	s.Require().NoError(r.Insert(s.Ctx(), "bd-del-wlbl-1", "alpha", "tester",
+		domain.LabelOpts{UseWispsTable: true}))
+	s.Require().NoError(r.Insert(s.Ctx(), "bd-del-wlbl-1", "beta", "tester",
+		domain.LabelOpts{UseWispsTable: true}))
+
+	n, err := r.DeleteAllForIDs(s.Ctx(), []string{"bd-del-wlbl-1"},
+		domain.LabelOpts{UseWispsTable: true})
+	s.Require().NoError(err)
+	s.Equal(2, n)
+
+	var wispCount int
+	s.Require().NoError(s.Runner().QueryRowContext(s.Ctx(),
+		"SELECT COUNT(*) FROM wisp_labels WHERE issue_id = ?", "bd-del-wlbl-1").Scan(&wispCount))
+	s.Equal(0, wispCount)
+}
+
+func (s *testSuite) eventsDeleteAllEmpty() {
+	n, err := s.eventsRepo().DeleteAllForIDs(s.Ctx(), nil, domain.RecordEventOpts{})
+	s.Require().NoError(err)
+	s.Equal(0, n)
+}
+
+func (s *testSuite) eventsDeleteAllRemoves() {
+	s.seedIssueRow("bd-del-evt-a")
+	s.seedIssueRow("bd-del-evt-b")
+	s.seedIssueRow("bd-del-evt-c")
+	r := s.eventsRepo()
+	for _, id := range []string{"bd-del-evt-a", "bd-del-evt-a", "bd-del-evt-b", "bd-del-evt-c"} {
+		s.Require().NoError(r.Record(s.Ctx(),
+			domain.Event{IssueID: id, Type: types.EventCreated, Actor: "tester"},
+			domain.RecordEventOpts{}))
+	}
+
+	n, err := r.DeleteAllForIDs(s.Ctx(),
+		[]string{"bd-del-evt-a", "bd-del-evt-b"}, domain.RecordEventOpts{})
+	s.Require().NoError(err)
+	s.Equal(3, n)
+
+	var remaining int
+	s.Require().NoError(s.Runner().QueryRowContext(s.Ctx(),
+		"SELECT COUNT(*) FROM events WHERE issue_id IN ('bd-del-evt-a','bd-del-evt-b','bd-del-evt-c')").Scan(&remaining))
+	s.Equal(1, remaining)
+}
+
+func (s *testSuite) eventsDeleteAllWispRouting() {
+	s.seedWispRow("bd-del-wevt-1")
+	r := s.eventsRepo()
+	s.Require().NoError(r.Record(s.Ctx(),
+		domain.Event{IssueID: "bd-del-wevt-1", Type: types.EventUpdated, Actor: "tester"},
+		domain.RecordEventOpts{UseWispsTable: true}))
+
+	n, err := r.DeleteAllForIDs(s.Ctx(), []string{"bd-del-wevt-1"},
+		domain.RecordEventOpts{UseWispsTable: true})
+	s.Require().NoError(err)
+	s.Equal(1, n)
+}
+
+func (s *testSuite) eventsCountAllEmpty() {
+	n, err := s.eventsRepo().CountAllForIDs(s.Ctx(), nil, domain.RecordEventOpts{})
+	s.Require().NoError(err)
+	s.Equal(0, n)
+}
+
+func (s *testSuite) eventsCountAllCounts() {
+	s.seedIssueRow("bd-del-ec-a")
+	s.seedIssueRow("bd-del-ec-b")
+	r := s.eventsRepo()
+	for _, id := range []string{"bd-del-ec-a", "bd-del-ec-a", "bd-del-ec-b"} {
+		s.Require().NoError(r.Record(s.Ctx(),
+			domain.Event{IssueID: id, Type: types.EventCreated, Actor: "tester"},
+			domain.RecordEventOpts{}))
+	}
+
+	n, err := r.CountAllForIDs(s.Ctx(), []string{"bd-del-ec-a", "bd-del-ec-b"}, domain.RecordEventOpts{})
+	s.Require().NoError(err)
+	s.Equal(3, n)
+}
+
+func (s *testSuite) eventsCountAllWispRouting() {
+	s.seedWispRow("bd-del-wec-1")
+	r := s.eventsRepo()
+	s.Require().NoError(r.Record(s.Ctx(),
+		domain.Event{IssueID: "bd-del-wec-1", Type: types.EventUpdated, Actor: "tester"},
+		domain.RecordEventOpts{UseWispsTable: true}))
+
+	n, err := r.CountAllForIDs(s.Ctx(), []string{"bd-del-wec-1"},
+		domain.RecordEventOpts{UseWispsTable: true})
+	s.Require().NoError(err)
+	s.Equal(1, n, "wisp-routed count must read from wisp_events")
+}

--- a/internal/storage/domain/db/dependency.go
+++ b/internal/storage/domain/db/dependency.go
@@ -616,3 +616,88 @@ func combineArgs(a, b []any) []any {
 	out = append(out, b...)
 	return out
 }
+
+func (r *dependencySQLRepositoryImpl) DeleteAllForIDs(ctx context.Context, ids []string, opts domain.DepInsertOpts) (int, error) {
+	if len(ids) == 0 {
+		return 0, nil
+	}
+	table := "dependencies"
+	if opts.UseWispsTable {
+		table = "wisp_dependencies"
+	}
+	total := 0
+	for start := 0; start < len(ids); start += deleteBatchSize {
+		end := start + deleteBatchSize
+		if end > len(ids) {
+			end = len(ids)
+		}
+		batch := ids[start:end]
+		placeholders := make([]string, len(batch))
+		args := make([]any, 0, 2*len(batch))
+		for i, id := range batch {
+			placeholders[i] = "?"
+			args = append(args, id)
+		}
+		for _, id := range batch {
+			args = append(args, id)
+		}
+		ph := strings.Join(placeholders, ",")
+		//nolint:gosec // G201: table is one of two hardcoded constants; ? placeholders only.
+		res, err := r.runner.ExecContext(ctx,
+			fmt.Sprintf("DELETE FROM %s WHERE issue_id IN (%s) OR %s IN (%s)", table, ph, issueops.DepTargetExpr, ph),
+			args...)
+		if err != nil {
+			if opts.UseWispsTable && dberrors.IsTableNotExist(err) {
+				return total, nil
+			}
+			return total, fmt.Errorf("db: DependencySQLRepository.DeleteAllForIDs from %s: %w", table, err)
+		}
+		n, err := res.RowsAffected()
+		if err != nil {
+			return total, fmt.Errorf("db: DependencySQLRepository.DeleteAllForIDs rows affected: %w", err)
+		}
+		total += int(n)
+	}
+	return total, nil
+}
+
+func (r *dependencySQLRepositoryImpl) CountAllForIDs(ctx context.Context, ids []string, opts domain.DepCountsOpts) (int, error) {
+	if len(ids) == 0 {
+		return 0, nil
+	}
+	table := "dependencies"
+	if opts.UseWispsTable {
+		table = "wisp_dependencies"
+	}
+	total := 0
+	for start := 0; start < len(ids); start += deleteBatchSize {
+		end := start + deleteBatchSize
+		if end > len(ids) {
+			end = len(ids)
+		}
+		batch := ids[start:end]
+		placeholders := make([]string, len(batch))
+		args := make([]any, 0, 2*len(batch))
+		for i, id := range batch {
+			placeholders[i] = "?"
+			args = append(args, id)
+		}
+		for _, id := range batch {
+			args = append(args, id)
+		}
+		ph := strings.Join(placeholders, ",")
+		var count int
+		//nolint:gosec // G201: table is one of two hardcoded constants; ? placeholders only.
+		err := r.runner.QueryRowContext(ctx,
+			fmt.Sprintf("SELECT COUNT(*) FROM %s WHERE issue_id IN (%s) OR %s IN (%s)", table, ph, issueops.DepTargetExpr, ph),
+			args...).Scan(&count)
+		if err != nil {
+			if opts.UseWispsTable && dberrors.IsTableNotExist(err) {
+				return total, nil
+			}
+			return total, fmt.Errorf("db: DependencySQLRepository.CountAllForIDs from %s: %w", table, err)
+		}
+		total += count
+	}
+	return total, nil
+}

--- a/internal/storage/domain/db/events.go
+++ b/internal/storage/domain/db/events.go
@@ -3,7 +3,9 @@ package db
 import (
 	"context"
 	"fmt"
+	"strings"
 
+	"github.com/steveyegge/beads/internal/storage/dberrors"
 	"github.com/steveyegge/beads/internal/storage/domain"
 	"github.com/steveyegge/beads/internal/storage/issueops"
 )
@@ -32,4 +34,62 @@ func (r *eventsSQLRepositoryImpl) Record(ctx context.Context, evt domain.Event, 
 		return fmt.Errorf("db: record event in %s: %w", table, err)
 	}
 	return nil
+}
+
+func (r *eventsSQLRepositoryImpl) DeleteAllForIDs(ctx context.Context, ids []string, opts domain.RecordEventOpts) (int, error) {
+	if len(ids) == 0 {
+		return 0, nil
+	}
+	table := "events"
+	if opts.UseWispsTable {
+		table = "wisp_events"
+	}
+	total := 0
+	for start := 0; start < len(ids); start += deleteBatchSize {
+		end := start + deleteBatchSize
+		if end > len(ids) {
+			end = len(ids)
+		}
+		batch := ids[start:end]
+		placeholders := make([]string, len(batch))
+		args := make([]any, len(batch))
+		for i, id := range batch {
+			placeholders[i] = "?"
+			args[i] = id
+		}
+		//nolint:gosec // G201: table is one of two hardcoded constants; ? placeholders only.
+		res, err := r.runner.ExecContext(ctx,
+			fmt.Sprintf("DELETE FROM %s WHERE issue_id IN (%s)", table, strings.Join(placeholders, ",")),
+			args...)
+		if err != nil {
+			if opts.UseWispsTable && dberrors.IsTableNotExist(err) {
+				return total, nil
+			}
+			return total, fmt.Errorf("db: EventsSQLRepository.DeleteAllForIDs from %s: %w", table, err)
+		}
+		n, err := res.RowsAffected()
+		if err != nil {
+			return total, fmt.Errorf("db: EventsSQLRepository.DeleteAllForIDs rows affected: %w", err)
+		}
+		total += int(n)
+	}
+	return total, nil
+}
+
+func (r *eventsSQLRepositoryImpl) CountAllForIDs(ctx context.Context, ids []string, opts domain.RecordEventOpts) (int, error) {
+	if len(ids) == 0 {
+		return 0, nil
+	}
+	table := "events"
+	if opts.UseWispsTable {
+		table = "wisp_events"
+	}
+	count, err := issueops.CountRowsForIssueIDsInTx(ctx, r.runner, table, ids)
+	if err != nil {
+		if opts.UseWispsTable && dberrors.IsTableNotExist(err) {
+			return 0, nil
+		}
+		return 0, fmt.Errorf("db: EventsSQLRepository.CountAllForIDs: %w", err)
+	}
+	return count, nil
 }

--- a/internal/storage/domain/db/issue.go
+++ b/internal/storage/domain/db/issue.go
@@ -626,3 +626,86 @@ func (r *issueSQLRepositoryImpl) GetReadyWork(ctx context.Context, filter types.
 func (r *issueSQLRepositoryImpl) GetReadyWorkWithCounts(ctx context.Context, filter types.WorkFilter) (domain.SearchCountsPage, error) {
 	return r.getReadyWorkWithCountsUnion(ctx, filter)
 }
+
+func (r *issueSQLRepositoryImpl) Delete(ctx context.Context, id string, opts domain.IssueTableOpts) error {
+	table := "issues"
+	if opts.UseWispsTable {
+		table = "wisps"
+	}
+	//nolint:gosec // G201: table is a hardcoded constant.
+	res, err := r.runner.ExecContext(ctx, fmt.Sprintf("DELETE FROM %s WHERE id = ?", table), id)
+	if err != nil {
+		return fmt.Errorf("db: IssueSQLRepository.Delete %s from %s: %w", id, table, err)
+	}
+	rows, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("db: IssueSQLRepository.Delete rows affected: %w", err)
+	}
+	if rows == 0 {
+		return fmt.Errorf("issue not found: %s", id)
+	}
+	return nil
+}
+
+func (r *issueSQLRepositoryImpl) DeleteByIDs(ctx context.Context, ids []string, opts domain.IssueTableOpts) (int, error) {
+	if len(ids) == 0 {
+		return 0, nil
+	}
+	table := "issues"
+	if opts.UseWispsTable {
+		table = "wisps"
+	}
+	total := 0
+	for start := 0; start < len(ids); start += deleteBatchSize {
+		end := start + deleteBatchSize
+		if end > len(ids) {
+			end = len(ids)
+		}
+		batch := ids[start:end]
+		placeholders := make([]string, len(batch))
+		args := make([]any, len(batch))
+		for i, id := range batch {
+			placeholders[i] = "?"
+			args[i] = id
+		}
+		//nolint:gosec // G201: table is a hardcoded constant; placeholders are ?.
+		res, err := r.runner.ExecContext(ctx,
+			fmt.Sprintf("DELETE FROM %s WHERE id IN (%s)", table, strings.Join(placeholders, ",")),
+			args...)
+		if err != nil {
+			return total, fmt.Errorf("db: IssueSQLRepository.DeleteByIDs from %s: %w", table, err)
+		}
+		n, err := res.RowsAffected()
+		if err != nil {
+			return total, fmt.Errorf("db: IssueSQLRepository.DeleteByIDs rows affected: %w", err)
+		}
+		total += int(n)
+	}
+	return total, nil
+}
+
+func (r *issueSQLRepositoryImpl) PartitionWispIDs(ctx context.Context, ids []string) ([]string, []string, error) {
+	return issueops.PartitionWispIDsInTx(ctx, r.runner, ids)
+}
+
+func (r *issueSQLRepositoryImpl) FindAllDependents(ctx context.Context, ids []string) ([]string, error) {
+	set, err := issueops.FindAllDependentsInTx(ctx, r.runner, ids)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]string, 0, len(set))
+	for id := range set {
+		out = append(out, id)
+	}
+	return out, nil
+}
+
+func (r *issueSQLRepositoryImpl) AffectedByDeletion(ctx context.Context, issueIDs, wispIDs []string) ([]string, []string, error) {
+	return issueops.AffectedByDeletionInTx(ctx, r.runner, issueIDs, wispIDs)
+}
+
+func (r *issueSQLRepositoryImpl) RecomputeIsBlocked(ctx context.Context, issueIDs, wispIDs []string) error {
+	return issueops.RecomputeIsBlockedInTx(ctx, r.runner, issueIDs, wispIDs)
+}
+
+const deleteBatchSize = 200

--- a/internal/storage/domain/db/issue_usecase_delete_test.go
+++ b/internal/storage/domain/db/issue_usecase_delete_test.go
@@ -1,0 +1,247 @@
+package db
+
+import (
+	"strings"
+
+	"github.com/steveyegge/beads/internal/storage/domain"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+func (s *testSuite) TestIssueUseCase_Delete() {
+	s.Run("DeleteIssue", func() {
+		s.Run("EmptyIDReturnsError", s.iucDeleteEmptyID)
+		s.Run("RemovesRowAndDeps", s.iucDeleteRemovesRowAndDeps)
+		s.Run("CascadesAcrossDepTypes", s.iucDeleteCascades)
+		s.Run("RewritesTextReferencesInNeighbors", s.iucDeleteRewritesRefs)
+		s.Run("RecomputesIsBlockedOnAffected", s.iucDeleteRecomputesBlocked)
+	})
+	s.Run("DeleteIssues", func() {
+		s.Run("EmptyIDsIsNoop", s.iucDeleteIssuesEmpty)
+		s.Run("DryRunCountsButDoesNotDelete", s.iucDeleteIssuesDryRun)
+		s.Run("CleansLabelsAndEvents", s.iucDeleteCleansAuxiliaryTables)
+		s.Run("UpdateTextReferencesFalseLeavesRefs", s.iucDeleteSkipsRefsWhenFlagOff)
+	})
+	s.Run("DeleteWisp", func() {
+		s.Run("DispatchesToWispsTable", s.iucDeleteWispDispatches)
+	})
+	s.Run("PreviewDelete", func() {
+		s.Run("EmptyInputReturnsEmpty", s.iucPreviewEmpty)
+		s.Run("PopulatesIssuesNotFoundAndConnected", s.iucPreviewPopulates)
+		s.Run("DoesNotMutate", s.iucPreviewIsReadOnly)
+	})
+	s.Run("PreviewDeleteWisp", func() {
+		s.Run("PopulatesFromWispsTable", s.iucPreviewWisp)
+	})
+}
+
+func (s *testSuite) iucDeleteEmptyID() {
+	_, err := s.issueUseCase().DeleteIssue(s.Ctx(), "", "tester")
+	s.Require().Error(err)
+}
+
+func (s *testSuite) iucDeleteRemovesRowAndDeps() {
+	s.seedOpenIssue("bd-iuc-del-a")
+	s.seedOpenIssue("bd-iuc-del-b")
+	s.Require().NoError(s.depRepo().Insert(s.Ctx(),
+		newDep("bd-iuc-del-a", "bd-iuc-del-b", types.DepBlocks), "tester", domain.DepInsertOpts{}))
+
+	res, err := s.issueUseCase().DeleteIssue(s.Ctx(), "bd-iuc-del-a", "tester")
+	s.Require().NoError(err)
+	s.Equal(1, res.DeletedCount)
+	s.Equal(1, res.DependenciesCount, "the A->B edge must be counted")
+
+	var rows int
+	s.Require().NoError(s.Runner().QueryRowContext(s.Ctx(),
+		"SELECT COUNT(*) FROM issues WHERE id = ?", "bd-iuc-del-a").Scan(&rows))
+	s.Equal(0, rows)
+	s.Require().NoError(s.Runner().QueryRowContext(s.Ctx(),
+		"SELECT COUNT(*) FROM dependencies WHERE issue_id = ? OR depends_on_issue_id = ?",
+		"bd-iuc-del-a", "bd-iuc-del-a").Scan(&rows))
+	s.Equal(0, rows)
+}
+
+func (s *testSuite) iucDeleteCascades() {
+	s.seedOpenIssue("bd-iuc-cas-root")
+	s.seedOpenIssue("bd-iuc-cas-mid")
+	s.seedOpenIssue("bd-iuc-cas-leaf")
+	s.Require().NoError(s.depRepo().Insert(s.Ctx(),
+		newDep("bd-iuc-cas-mid", "bd-iuc-cas-root", types.DepBlocks), "tester", domain.DepInsertOpts{}))
+	s.Require().NoError(s.depRepo().Insert(s.Ctx(),
+		newDep("bd-iuc-cas-leaf", "bd-iuc-cas-mid", types.DepBlocks), "tester", domain.DepInsertOpts{}))
+
+	res, err := s.issueUseCase().DeleteIssue(s.Ctx(), "bd-iuc-cas-root", "tester")
+	s.Require().NoError(err)
+	s.Equal(3, res.DeletedCount, "root + mid + leaf")
+
+	for _, id := range []string{"bd-iuc-cas-root", "bd-iuc-cas-mid", "bd-iuc-cas-leaf"} {
+		var rows int
+		s.Require().NoError(s.Runner().QueryRowContext(s.Ctx(),
+			"SELECT COUNT(*) FROM issues WHERE id = ?", id).Scan(&rows))
+		s.Equal(0, rows, "%s should be deleted", id)
+	}
+}
+
+func (s *testSuite) iucDeleteRewritesRefs() {
+	s.seedOpenIssue("bd-iuc-ref-target")
+	s.seedOpenIssue("bd-iuc-ref-neighbor")
+	s.Require().NoError(s.issueRepo().Update(s.Ctx(), "bd-iuc-ref-neighbor",
+		map[string]any{"description": "see bd-iuc-ref-target for context"},
+		"seeder", domain.IssueTableOpts{}))
+	s.Require().NoError(s.depRepo().Insert(s.Ctx(),
+		newDep("bd-iuc-ref-target", "bd-iuc-ref-neighbor", types.DepRelated), "tester", domain.DepInsertOpts{}))
+
+	res, err := s.issueUseCase().DeleteIssue(s.Ctx(), "bd-iuc-ref-target", "tester")
+	s.Require().NoError(err)
+	s.GreaterOrEqual(res.ReferencesUpdated, 1)
+
+	updated, err := s.issueRepo().Get(s.Ctx(), "bd-iuc-ref-neighbor", domain.IssueTableOpts{})
+	s.Require().NoError(err)
+	s.True(strings.Contains(updated.Description, "[deleted:bd-iuc-ref-target]"),
+		"neighbor description should be rewritten; got %q", updated.Description)
+}
+
+func (s *testSuite) iucDeleteRecomputesBlocked() {
+	s.seedOpenIssue("bd-iuc-rib-blocker")
+	s.seedOpenIssue("bd-iuc-rib-depender")
+	s.Require().NoError(s.depRepo().Insert(s.Ctx(),
+		newDep("bd-iuc-rib-depender", "bd-iuc-rib-blocker", types.DepBlocks),
+		"seeder", domain.DepInsertOpts{}))
+
+	res, err := s.issueUseCase().DeleteIssue(s.Ctx(), "bd-iuc-rib-blocker", "tester")
+	s.Require().NoError(err)
+	s.Equal(2, res.DeletedCount, "blocker + depender (cascade)")
+}
+
+func (s *testSuite) iucDeleteIssuesEmpty() {
+	res, err := s.issueUseCase().DeleteIssues(s.Ctx(),
+		domain.DeleteIssuesParams{}, "tester")
+	s.Require().NoError(err)
+	s.Equal(0, res.DeletedCount)
+}
+
+func (s *testSuite) iucDeleteIssuesDryRun() {
+	s.seedOpenIssue("bd-iuc-dry-a")
+	s.seedOpenIssue("bd-iuc-dry-b")
+	s.Require().NoError(s.depRepo().Insert(s.Ctx(),
+		newDep("bd-iuc-dry-a", "bd-iuc-dry-b", types.DepBlocks), "tester", domain.DepInsertOpts{}))
+
+	res, err := s.issueUseCase().DeleteIssues(s.Ctx(), domain.DeleteIssuesParams{
+		IDs:    []string{"bd-iuc-dry-a"},
+		DryRun: true,
+	}, "tester")
+	s.Require().NoError(err)
+	s.Equal(0, res.DeletedCount, "DryRun must not actually delete")
+	s.Equal(1, res.DependenciesCount)
+
+	var rows int
+	s.Require().NoError(s.Runner().QueryRowContext(s.Ctx(),
+		"SELECT COUNT(*) FROM issues WHERE id = ?", "bd-iuc-dry-a").Scan(&rows))
+	s.Equal(1, rows, "row must still exist after DryRun")
+}
+
+func (s *testSuite) iucDeleteCleansAuxiliaryTables() {
+	s.seedOpenIssue("bd-iuc-aux-a")
+	s.Require().NoError(s.labelRepo().Insert(s.Ctx(),
+		"bd-iuc-aux-a", "tag1", "tester", domain.LabelOpts{}))
+	s.Require().NoError(s.labelRepo().Insert(s.Ctx(),
+		"bd-iuc-aux-a", "tag2", "tester", domain.LabelOpts{}))
+	s.Require().NoError(s.eventsRepo().Record(s.Ctx(),
+		domain.Event{IssueID: "bd-iuc-aux-a", Type: types.EventCreated, Actor: "tester"},
+		domain.RecordEventOpts{}))
+
+	res, err := s.issueUseCase().DeleteIssue(s.Ctx(), "bd-iuc-aux-a", "tester")
+	s.Require().NoError(err)
+	s.Equal(2, res.LabelsCount)
+	s.GreaterOrEqual(res.EventsCount, 1)
+
+	var rows int
+	s.Require().NoError(s.Runner().QueryRowContext(s.Ctx(),
+		"SELECT COUNT(*) FROM labels WHERE issue_id = ?", "bd-iuc-aux-a").Scan(&rows))
+	s.Equal(0, rows)
+	s.Require().NoError(s.Runner().QueryRowContext(s.Ctx(),
+		"SELECT COUNT(*) FROM events WHERE issue_id = ?", "bd-iuc-aux-a").Scan(&rows))
+	s.Equal(0, rows)
+}
+
+func (s *testSuite) iucDeleteSkipsRefsWhenFlagOff() {
+	s.seedOpenIssue("bd-iuc-noref-target")
+	s.seedOpenIssue("bd-iuc-noref-neighbor")
+	original := "links bd-iuc-noref-target here"
+	s.Require().NoError(s.issueRepo().Update(s.Ctx(), "bd-iuc-noref-neighbor",
+		map[string]any{"description": original},
+		"seeder", domain.IssueTableOpts{}))
+	s.Require().NoError(s.depRepo().Insert(s.Ctx(),
+		newDep("bd-iuc-noref-target", "bd-iuc-noref-neighbor", types.DepRelated),
+		"tester", domain.DepInsertOpts{}))
+
+	res, err := s.issueUseCase().DeleteIssues(s.Ctx(), domain.DeleteIssuesParams{
+		IDs:                  []string{"bd-iuc-noref-target"},
+		UpdateTextReferences: false,
+	}, "tester")
+	s.Require().NoError(err)
+	s.Equal(0, res.ReferencesUpdated)
+
+	survived, err := s.issueRepo().Get(s.Ctx(), "bd-iuc-noref-neighbor", domain.IssueTableOpts{})
+	s.Require().NoError(err)
+	s.Equal(original, survived.Description, "description must be untouched when flag is off")
+}
+
+func (s *testSuite) iucDeleteWispDispatches() {
+	s.seedOpenWisp("bd-iuc-delw-1")
+	s.seedOpenIssue("bd-iuc-delw-1")
+
+	res, err := s.issueUseCase().DeleteWisp(s.Ctx(), "bd-iuc-delw-1", "tester")
+	s.Require().NoError(err)
+	s.Equal(1, res.DeletedCount)
+
+	var wispRows, issueRows int
+	s.Require().NoError(s.Runner().QueryRowContext(s.Ctx(),
+		"SELECT COUNT(*) FROM wisps WHERE id = ?", "bd-iuc-delw-1").Scan(&wispRows))
+	s.Equal(0, wispRows)
+	s.Require().NoError(s.Runner().QueryRowContext(s.Ctx(),
+		"SELECT COUNT(*) FROM issues WHERE id = ?", "bd-iuc-delw-1").Scan(&issueRows))
+	s.Equal(1, issueRows, "issues row with shadowed ID must remain")
+}
+
+func (s *testSuite) iucPreviewEmpty() {
+	out, err := s.issueUseCase().PreviewDelete(s.Ctx(), nil)
+	s.Require().NoError(err)
+	s.Empty(out.Issues)
+	s.Empty(out.ConnectedIssues)
+	s.Empty(out.NotFound)
+}
+
+func (s *testSuite) iucPreviewPopulates() {
+	s.seedOpenIssue("bd-iuc-pv-target")
+	s.seedOpenIssue("bd-iuc-pv-neighbor")
+	s.Require().NoError(s.depRepo().Insert(s.Ctx(),
+		newDep("bd-iuc-pv-target", "bd-iuc-pv-neighbor", types.DepBlocks),
+		"seeder", domain.DepInsertOpts{}))
+
+	out, err := s.issueUseCase().PreviewDelete(s.Ctx(),
+		[]string{"bd-iuc-pv-target", "bd-iuc-pv-missing"})
+	s.Require().NoError(err)
+	s.Contains(out.Issues, "bd-iuc-pv-target")
+	s.Equal([]string{"bd-iuc-pv-missing"}, out.NotFound)
+	s.Contains(out.ConnectedIssues, "bd-iuc-pv-neighbor")
+	s.Require().Len(out.DepRecords["bd-iuc-pv-target"], 1)
+	s.Equal("bd-iuc-pv-neighbor", out.DepRecords["bd-iuc-pv-target"][0].DependsOnID)
+}
+
+func (s *testSuite) iucPreviewIsReadOnly() {
+	s.seedOpenIssue("bd-iuc-pvro")
+	_, err := s.issueUseCase().PreviewDelete(s.Ctx(), []string{"bd-iuc-pvro"})
+	s.Require().NoError(err)
+
+	got, err := s.issueRepo().Get(s.Ctx(), "bd-iuc-pvro", domain.IssueTableOpts{})
+	s.Require().NoError(err)
+	s.Equal("bd-iuc-pvro", got.ID, "preview must not mutate")
+}
+
+func (s *testSuite) iucPreviewWisp() {
+	s.seedOpenWisp("bd-iuc-pvw")
+	out, err := s.issueUseCase().PreviewDeleteWisp(s.Ctx(), []string{"bd-iuc-pvw"})
+	s.Require().NoError(err)
+	s.Contains(out.Issues, "bd-iuc-pvw", "wisp target should be hydrated from wisps table")
+	s.Empty(out.NotFound)
+}

--- a/internal/storage/domain/db/issue_usecase_test.go
+++ b/internal/storage/domain/db/issue_usecase_test.go
@@ -29,6 +29,7 @@ func (s *testSuite) issueUseCase() domain.IssueUseCase {
 		NewChildCounterSQLRepository(runner),
 		NewCommentSQLRepository(runner),
 		NewConfigSQLRepository(runner),
+		NewEventsSQLRepository(runner),
 		labelUC,
 		depUC,
 	)

--- a/internal/storage/domain/db/label.go
+++ b/internal/storage/domain/db/label.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/steveyegge/beads/internal/storage/dberrors"
 	"github.com/steveyegge/beads/internal/storage/domain"
 	"github.com/steveyegge/beads/internal/types"
 )
@@ -139,4 +140,44 @@ func (r *labelSQLRepositoryImpl) ListByIssueIDs(ctx context.Context, issueIDs []
 		return nil, fmt.Errorf("db: LabelSQLRepository.ListByIssueIDs: rows: %w", err)
 	}
 	return result, nil
+}
+
+func (r *labelSQLRepositoryImpl) DeleteAllForIDs(ctx context.Context, ids []string, opts domain.LabelOpts) (int, error) {
+	if len(ids) == 0 {
+		return 0, nil
+	}
+	table := "labels"
+	if opts.UseWispsTable {
+		table = "wisp_labels"
+	}
+	total := 0
+	for start := 0; start < len(ids); start += deleteBatchSize {
+		end := start + deleteBatchSize
+		if end > len(ids) {
+			end = len(ids)
+		}
+		batch := ids[start:end]
+		placeholders := make([]string, len(batch))
+		args := make([]any, len(batch))
+		for i, id := range batch {
+			placeholders[i] = "?"
+			args[i] = id
+		}
+		//nolint:gosec // G201: table is one of two hardcoded constants; ? placeholders only.
+		res, err := r.runner.ExecContext(ctx,
+			fmt.Sprintf("DELETE FROM %s WHERE issue_id IN (%s)", table, strings.Join(placeholders, ",")),
+			args...)
+		if err != nil {
+			if opts.UseWispsTable && dberrors.IsTableNotExist(err) {
+				return total, nil
+			}
+			return total, fmt.Errorf("db: LabelSQLRepository.DeleteAllForIDs from %s: %w", table, err)
+		}
+		n, err := res.RowsAffected()
+		if err != nil {
+			return total, fmt.Errorf("db: LabelSQLRepository.DeleteAllForIDs rows affected: %w", err)
+		}
+		total += int(n)
+	}
+	return total, nil
 }

--- a/internal/storage/domain/db/label.go
+++ b/internal/storage/domain/db/label.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/steveyegge/beads/internal/storage/dberrors"
 	"github.com/steveyegge/beads/internal/storage/domain"
+	"github.com/steveyegge/beads/internal/storage/issueops"
 	"github.com/steveyegge/beads/internal/types"
 )
 
@@ -180,4 +181,22 @@ func (r *labelSQLRepositoryImpl) DeleteAllForIDs(ctx context.Context, ids []stri
 		total += int(n)
 	}
 	return total, nil
+}
+
+func (r *labelSQLRepositoryImpl) CountAllForIDs(ctx context.Context, ids []string, opts domain.LabelOpts) (int, error) {
+	if len(ids) == 0 {
+		return 0, nil
+	}
+	table := "labels"
+	if opts.UseWispsTable {
+		table = "wisp_labels"
+	}
+	count, err := issueops.CountRowsForIssueIDsInTx(ctx, r.runner, table, ids)
+	if err != nil {
+		if opts.UseWispsTable && dberrors.IsTableNotExist(err) {
+			return 0, nil
+		}
+		return 0, fmt.Errorf("db: LabelSQLRepository.CountAllForIDs: %w", err)
+	}
+	return count, nil
 }

--- a/internal/storage/domain/dependency.go
+++ b/internal/storage/domain/dependency.go
@@ -61,6 +61,9 @@ type DependencySQLRepository interface {
 
 	GetBlockingInfo(ctx context.Context, issueIDs []string, opts DepListOpts) (BlockingInfo, error)
 	GetBlockingInfoAcrossIssuesAndWisps(ctx context.Context, issueIDs []string) (BlockingInfo, error)
+
+	DeleteAllForIDs(ctx context.Context, ids []string, opts DepInsertOpts) (int, error)
+	CountAllForIDs(ctx context.Context, ids []string, opts DepCountsOpts) (int, error)
 }
 
 type DependencyUseCase interface {

--- a/internal/storage/domain/events.go
+++ b/internal/storage/domain/events.go
@@ -20,4 +20,6 @@ type RecordEventOpts struct {
 
 type EventsSQLRepository interface {
 	Record(ctx context.Context, evt Event, opts RecordEventOpts) error
+	DeleteAllForIDs(ctx context.Context, ids []string, opts RecordEventOpts) (int, error)
+	CountAllForIDs(ctx context.Context, ids []string, opts RecordEventOpts) (int, error)
 }

--- a/internal/storage/domain/issue.go
+++ b/internal/storage/domain/issue.go
@@ -44,6 +44,33 @@ type IssueSQLRepository interface {
 	GetReadyWork(ctx context.Context, filter types.WorkFilter) (SearchPage, error)
 	GetReadyWorkWithCounts(ctx context.Context, filter types.WorkFilter) (SearchCountsPage, error)
 	GetDescendants(ctx context.Context, rootID string, filter types.IssueFilter) ([]*types.Issue, error)
+	Delete(ctx context.Context, id string, opts IssueTableOpts) error
+	DeleteByIDs(ctx context.Context, ids []string, opts IssueTableOpts) (int, error)
+	PartitionWispIDs(ctx context.Context, ids []string) (wispIDs, regularIDs []string, err error)
+	FindAllDependents(ctx context.Context, ids []string) ([]string, error)
+	AffectedByDeletion(ctx context.Context, issueIDs, wispIDs []string) (affectedIssues, affectedWisps []string, err error)
+	RecomputeIsBlocked(ctx context.Context, issueIDs, wispIDs []string) error
+}
+
+type DeleteIssuesParams struct {
+	IDs                  []string
+	DryRun               bool
+	UpdateTextReferences bool
+}
+
+type DeleteIssuesResult struct {
+	DeletedCount      int
+	DependenciesCount int
+	LabelsCount       int
+	EventsCount       int
+	ReferencesUpdated int
+}
+
+type DeletePreview struct {
+	Issues          map[string]*types.Issue
+	ConnectedIssues map[string]*types.Issue
+	DepRecords      map[string][]*types.Dependency
+	NotFound        []string
 }
 
 type SearchPage struct {
@@ -147,6 +174,12 @@ type IssueUseCase interface {
 	ClaimIssue(ctx context.Context, id, actor string) (ClaimResult, error)
 	ApplyUpdate(ctx context.Context, id string, spec UpdateSpec, actor string) (*types.Issue, error)
 	ApplyIssueGraph(ctx context.Context, plan GraphPlan, actor string) (GraphApplyResult, error)
+	DeleteIssue(ctx context.Context, id, actor string) (DeleteIssuesResult, error)
+	DeleteIssues(ctx context.Context, params DeleteIssuesParams, actor string) (DeleteIssuesResult, error)
+	PreviewDelete(ctx context.Context, ids []string) (DeletePreview, error)
+	DeleteWisp(ctx context.Context, id, actor string) (DeleteIssuesResult, error)
+	DeleteWisps(ctx context.Context, params DeleteIssuesParams, actor string) (DeleteIssuesResult, error)
+	PreviewDeleteWisp(ctx context.Context, ids []string) (DeletePreview, error)
 
 	GetWisp(ctx context.Context, id string) (*types.Issue, error)
 	GetWispsByIDs(ctx context.Context, ids []string) ([]*types.Issue, error)
@@ -164,6 +197,7 @@ func NewIssueUseCase(
 	counterRepo ChildCounterSQLRepository,
 	commentRepo CommentSQLRepository,
 	cfgRepo ConfigSQLRepository,
+	eventsRepo EventsSQLRepository,
 	labelUC LabelUseCase,
 	depUC DependencyUseCase,
 ) IssueUseCase {
@@ -174,6 +208,7 @@ func NewIssueUseCase(
 		counterRepo: counterRepo,
 		commentRepo: commentRepo,
 		cfgRepo:     cfgRepo,
+		eventsRepo:  eventsRepo,
 		labelUC:     labelUC,
 		depUC:       depUC,
 	}
@@ -186,6 +221,7 @@ type issueUseCaseImpl struct {
 	counterRepo ChildCounterSQLRepository
 	commentRepo CommentSQLRepository
 	cfgRepo     ConfigSQLRepository
+	eventsRepo  EventsSQLRepository
 	labelUC     LabelUseCase
 	depUC       DependencyUseCase
 }

--- a/internal/storage/domain/issue_delete.go
+++ b/internal/storage/domain/issue_delete.go
@@ -63,16 +63,6 @@ func (u *issueUseCaseImpl) deleteMany(ctx context.Context, params DeleteIssuesPa
 		return DeleteIssuesResult{}, fmt.Errorf("delete: partition: %w", err)
 	}
 
-	deletedSet := make(map[string]bool, len(allIDs))
-	for _, id := range allIDs {
-		deletedSet[id] = true
-	}
-
-	connected, connectedIsWisp, err := u.collectConnectedIssues(ctx, allIDs, deletedSet)
-	if err != nil {
-		return DeleteIssuesResult{}, err
-	}
-
 	result := DeleteIssuesResult{}
 
 	depIssue, err := u.depRepo.CountAllForIDs(ctx, regularIDs, DepCountsOpts{})
@@ -85,13 +75,13 @@ func (u *issueUseCaseImpl) deleteMany(ctx context.Context, params DeleteIssuesPa
 	}
 	result.DependenciesCount = depIssue + depWisp
 
-	labelIssue, err := u.sumLabelCount(ctx, regularIDs, false)
+	labelIssue, err := u.labelRepo.CountAllForIDs(ctx, regularIDs, LabelOpts{})
 	if err != nil {
-		return DeleteIssuesResult{}, err
+		return DeleteIssuesResult{}, fmt.Errorf("delete: count labels: %w", err)
 	}
-	labelWisp, err := u.sumLabelCount(ctx, wispIDs, true)
+	labelWisp, err := u.labelRepo.CountAllForIDs(ctx, wispIDs, LabelOpts{UseWispsTable: true})
 	if err != nil {
-		return DeleteIssuesResult{}, err
+		return DeleteIssuesResult{}, fmt.Errorf("delete: count wisp labels: %w", err)
 	}
 	result.LabelsCount = labelIssue + labelWisp
 
@@ -107,6 +97,19 @@ func (u *issueUseCaseImpl) deleteMany(ctx context.Context, params DeleteIssuesPa
 
 	if params.DryRun {
 		return result, nil
+	}
+
+	var connected map[string]*types.Issue
+	var connectedIsWisp map[string]bool
+	if params.UpdateTextReferences {
+		deletedSet := make(map[string]bool, len(allIDs))
+		for _, id := range allIDs {
+			deletedSet[id] = true
+		}
+		connected, connectedIsWisp, err = u.collectConnectedIssues(ctx, allIDs, deletedSet)
+		if err != nil {
+			return result, err
+		}
 	}
 
 	affectedIssues, affectedWisps, err := u.issueRepo.AffectedByDeletion(ctx, regularIDs, wispIDs)
@@ -282,29 +285,11 @@ func (u *issueUseCaseImpl) collectConnectedIssues(
 	return out, isWisp, nil
 }
 
-func (u *issueUseCaseImpl) sumLabelCount(ctx context.Context, ids []string, useWisp bool) (int, error) {
-	if len(ids) == 0 {
-		return 0, nil
-	}
-	res, err := u.labelRepo.ListByIssueIDs(ctx, ids, LabelOpts{UseWispsTable: useWisp})
-	if err != nil {
-		if useWisp && dberrors.IsTableNotExist(err) {
-			return 0, nil
-		}
-		return 0, fmt.Errorf("sumLabelCount: %w", err)
-	}
-	total := 0
-	for _, ls := range res {
-		total += len(ls)
-	}
-	return total, nil
-}
-
 func (u *issueUseCaseImpl) rewriteTextReferences(
 	ctx context.Context, deletedIDs []string,
 	connected map[string]*types.Issue, isWisp map[string]bool, actor string,
 ) (int, error) {
-	updatedCount := 0
+	touched := make(map[string]bool)
 	for _, id := range deletedIDs {
 		pattern := `(^|[^A-Za-z0-9_-])(` + regexp.QuoteMeta(id) + `)($|[^A-Za-z0-9_-])`
 		re := regexp.MustCompile(pattern)
@@ -328,9 +313,9 @@ func (u *issueUseCaseImpl) rewriteTextReferences(
 			}
 			opts := IssueTableOpts{UseWispsTable: isWisp[connID]}
 			if err := u.issueRepo.Update(ctx, connID, updates, actor, opts); err != nil {
-				return updatedCount, fmt.Errorf("rewrite refs %s: %w", connID, err)
+				return len(touched), fmt.Errorf("rewrite refs %s: %w", connID, err)
 			}
-			updatedCount++
+			touched[connID] = true
 			if desc, ok := updates["description"].(string); ok {
 				conn.Description = desc
 			}
@@ -345,5 +330,5 @@ func (u *issueUseCaseImpl) rewriteTextReferences(
 			}
 		}
 	}
-	return updatedCount, nil
+	return len(touched), nil
 }

--- a/internal/storage/domain/issue_delete.go
+++ b/internal/storage/domain/issue_delete.go
@@ -1,0 +1,349 @@
+package domain
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+
+	"github.com/steveyegge/beads/internal/storage/dberrors"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+func (u *issueUseCaseImpl) DeleteIssue(ctx context.Context, id, actor string) (DeleteIssuesResult, error) {
+	if id == "" {
+		return DeleteIssuesResult{}, fmt.Errorf("DeleteIssue: id must not be empty")
+	}
+	return u.deleteMany(ctx, DeleteIssuesParams{
+		IDs:                  []string{id},
+		UpdateTextReferences: true,
+	}, actor)
+}
+
+func (u *issueUseCaseImpl) DeleteWisp(ctx context.Context, id, actor string) (DeleteIssuesResult, error) {
+	if id == "" {
+		return DeleteIssuesResult{}, fmt.Errorf("DeleteWisp: id must not be empty")
+	}
+	return u.deleteMany(ctx, DeleteIssuesParams{
+		IDs:                  []string{id},
+		UpdateTextReferences: true,
+	}, actor)
+}
+
+func (u *issueUseCaseImpl) DeleteIssues(ctx context.Context, params DeleteIssuesParams, actor string) (DeleteIssuesResult, error) {
+	return u.deleteMany(ctx, params, actor)
+}
+
+func (u *issueUseCaseImpl) DeleteWisps(ctx context.Context, params DeleteIssuesParams, actor string) (DeleteIssuesResult, error) {
+	return u.deleteMany(ctx, params, actor)
+}
+
+func (u *issueUseCaseImpl) PreviewDelete(ctx context.Context, ids []string) (DeletePreview, error) {
+	return u.previewDelete(ctx, ids)
+}
+
+func (u *issueUseCaseImpl) PreviewDeleteWisp(ctx context.Context, ids []string) (DeletePreview, error) {
+	return u.previewDelete(ctx, ids)
+}
+
+func (u *issueUseCaseImpl) deleteMany(ctx context.Context, params DeleteIssuesParams, actor string) (DeleteIssuesResult, error) {
+	if len(params.IDs) == 0 {
+		return DeleteIssuesResult{}, nil
+	}
+
+	allIDs, err := u.issueRepo.FindAllDependents(ctx, params.IDs)
+	if err != nil {
+		return DeleteIssuesResult{}, fmt.Errorf("delete: cascade expansion: %w", err)
+	}
+	if len(allIDs) == 0 {
+		return DeleteIssuesResult{}, nil
+	}
+
+	wispIDs, regularIDs, err := u.issueRepo.PartitionWispIDs(ctx, allIDs)
+	if err != nil {
+		return DeleteIssuesResult{}, fmt.Errorf("delete: partition: %w", err)
+	}
+
+	deletedSet := make(map[string]bool, len(allIDs))
+	for _, id := range allIDs {
+		deletedSet[id] = true
+	}
+
+	connected, connectedIsWisp, err := u.collectConnectedIssues(ctx, allIDs, deletedSet)
+	if err != nil {
+		return DeleteIssuesResult{}, err
+	}
+
+	result := DeleteIssuesResult{}
+
+	depIssue, err := u.depRepo.CountAllForIDs(ctx, regularIDs, DepCountsOpts{})
+	if err != nil {
+		return DeleteIssuesResult{}, fmt.Errorf("delete: count deps: %w", err)
+	}
+	depWisp, err := u.depRepo.CountAllForIDs(ctx, wispIDs, DepCountsOpts{UseWispsTable: true})
+	if err != nil {
+		return DeleteIssuesResult{}, fmt.Errorf("delete: count wisp deps: %w", err)
+	}
+	result.DependenciesCount = depIssue + depWisp
+
+	labelIssue, err := u.sumLabelCount(ctx, regularIDs, false)
+	if err != nil {
+		return DeleteIssuesResult{}, err
+	}
+	labelWisp, err := u.sumLabelCount(ctx, wispIDs, true)
+	if err != nil {
+		return DeleteIssuesResult{}, err
+	}
+	result.LabelsCount = labelIssue + labelWisp
+
+	evIssue, err := u.eventsRepo.CountAllForIDs(ctx, regularIDs, RecordEventOpts{})
+	if err != nil {
+		return DeleteIssuesResult{}, fmt.Errorf("delete: count events: %w", err)
+	}
+	evWisp, err := u.eventsRepo.CountAllForIDs(ctx, wispIDs, RecordEventOpts{UseWispsTable: true})
+	if err != nil {
+		return DeleteIssuesResult{}, fmt.Errorf("delete: count wisp events: %w", err)
+	}
+	result.EventsCount = evIssue + evWisp
+
+	if params.DryRun {
+		return result, nil
+	}
+
+	affectedIssues, affectedWisps, err := u.issueRepo.AffectedByDeletion(ctx, regularIDs, wispIDs)
+	if err != nil {
+		return result, fmt.Errorf("delete: affected by deletion: %w", err)
+	}
+
+	if _, err := u.depRepo.DeleteAllForIDs(ctx, regularIDs, DepInsertOpts{}); err != nil {
+		return result, fmt.Errorf("delete: drop deps: %w", err)
+	}
+	if _, err := u.depRepo.DeleteAllForIDs(ctx, wispIDs, DepInsertOpts{UseWispsTable: true}); err != nil {
+		return result, fmt.Errorf("delete: drop wisp deps: %w", err)
+	}
+	if _, err := u.labelRepo.DeleteAllForIDs(ctx, regularIDs, LabelOpts{}); err != nil {
+		return result, fmt.Errorf("delete: drop labels: %w", err)
+	}
+	if _, err := u.labelRepo.DeleteAllForIDs(ctx, wispIDs, LabelOpts{UseWispsTable: true}); err != nil {
+		return result, fmt.Errorf("delete: drop wisp labels: %w", err)
+	}
+	if _, err := u.eventsRepo.DeleteAllForIDs(ctx, regularIDs, RecordEventOpts{}); err != nil {
+		return result, fmt.Errorf("delete: drop events: %w", err)
+	}
+	if _, err := u.eventsRepo.DeleteAllForIDs(ctx, wispIDs, RecordEventOpts{UseWispsTable: true}); err != nil {
+		return result, fmt.Errorf("delete: drop wisp events: %w", err)
+	}
+
+	issuesDeleted, err := u.issueRepo.DeleteByIDs(ctx, regularIDs, IssueTableOpts{})
+	if err != nil {
+		return result, fmt.Errorf("delete: drop issue rows: %w", err)
+	}
+	wispsDeleted, err := u.issueRepo.DeleteByIDs(ctx, wispIDs, IssueTableOpts{UseWispsTable: true})
+	if err != nil {
+		return result, fmt.Errorf("delete: drop wisp rows: %w", err)
+	}
+	result.DeletedCount = issuesDeleted + wispsDeleted
+
+	if params.UpdateTextReferences && len(connected) > 0 {
+		refs, err := u.rewriteTextReferences(ctx, allIDs, connected, connectedIsWisp, actor)
+		if err != nil {
+			return result, fmt.Errorf("delete: rewrite text references: %w", err)
+		}
+		result.ReferencesUpdated = refs
+	}
+
+	if err := u.issueRepo.RecomputeIsBlocked(ctx, affectedIssues, affectedWisps); err != nil {
+		return result, fmt.Errorf("delete: recompute is_blocked: %w", err)
+	}
+
+	return result, nil
+}
+
+func (u *issueUseCaseImpl) previewDelete(ctx context.Context, ids []string) (DeletePreview, error) {
+	preview := DeletePreview{
+		Issues:          map[string]*types.Issue{},
+		ConnectedIssues: map[string]*types.Issue{},
+		DepRecords:      map[string][]*types.Dependency{},
+	}
+	if len(ids) == 0 {
+		return preview, nil
+	}
+
+	fromIssues, err := u.issueRepo.GetByIDs(ctx, ids, IssueTableOpts{})
+	if err != nil {
+		return preview, fmt.Errorf("previewDelete: load issues: %w", err)
+	}
+	for _, iss := range fromIssues {
+		preview.Issues[iss.ID] = iss
+	}
+	fromWisps, err := u.issueRepo.GetByIDs(ctx, ids, IssueTableOpts{UseWispsTable: true})
+	if err != nil && !dberrors.IsTableNotExist(err) {
+		return preview, fmt.Errorf("previewDelete: load wisps: %w", err)
+	}
+	for _, iss := range fromWisps {
+		preview.Issues[iss.ID] = iss
+	}
+
+	for _, id := range ids {
+		if _, ok := preview.Issues[id]; !ok {
+			preview.NotFound = append(preview.NotFound, id)
+		}
+	}
+
+	depRes, err := u.depRepo.ListByIssueIDs(ctx, ids, DepListOpts{Direction: DepDirectionOut})
+	if err != nil {
+		return preview, fmt.Errorf("previewDelete: list deps: %w", err)
+	}
+	for id, deps := range depRes.Outgoing {
+		preview.DepRecords[id] = deps
+	}
+	wispDepRes, err := u.depRepo.ListByIssueIDs(ctx, ids, DepListOpts{Direction: DepDirectionOut, UseWispsTable: true})
+	if err != nil && !dberrors.IsTableNotExist(err) {
+		return preview, fmt.Errorf("previewDelete: list wisp deps: %w", err)
+	}
+	for id, deps := range wispDepRes.Outgoing {
+		preview.DepRecords[id] = append(preview.DepRecords[id], deps...)
+	}
+
+	allIDs, err := u.issueRepo.FindAllDependents(ctx, ids)
+	if err != nil {
+		return preview, fmt.Errorf("previewDelete: cascade expansion: %w", err)
+	}
+	deletedSet := make(map[string]bool, len(allIDs))
+	for _, id := range allIDs {
+		deletedSet[id] = true
+	}
+	connected, _, err := u.collectConnectedIssues(ctx, allIDs, deletedSet)
+	if err != nil {
+		return preview, err
+	}
+	preview.ConnectedIssues = connected
+	return preview, nil
+}
+
+func (u *issueUseCaseImpl) collectConnectedIssues(
+	ctx context.Context, allIDs []string, deletedSet map[string]bool,
+) (map[string]*types.Issue, map[string]bool, error) {
+	out := map[string]*types.Issue{}
+	isWisp := map[string]bool{}
+	if len(allIDs) == 0 {
+		return out, isWisp, nil
+	}
+
+	issueRes, err := u.depRepo.ListByIssueIDs(ctx, allIDs, DepListOpts{Direction: DepDirectionBoth})
+	if err != nil {
+		return nil, nil, fmt.Errorf("collectConnected (issues): %w", err)
+	}
+	wispRes, err := u.depRepo.ListByIssueIDs(ctx, allIDs, DepListOpts{Direction: DepDirectionBoth, UseWispsTable: true})
+	if err != nil && !dberrors.IsTableNotExist(err) {
+		return nil, nil, fmt.Errorf("collectConnected (wisps): %w", err)
+	}
+
+	neighbors := map[string]bool{}
+	accumulate := func(m map[string][]*types.Dependency) {
+		for _, deps := range m {
+			for _, d := range deps {
+				for _, candidate := range [2]string{d.IssueID, d.DependsOnID} {
+					if candidate == "" || deletedSet[candidate] {
+						continue
+					}
+					neighbors[candidate] = true
+				}
+			}
+		}
+	}
+	accumulate(issueRes.Outgoing)
+	accumulate(issueRes.Incoming)
+	accumulate(wispRes.Outgoing)
+	accumulate(wispRes.Incoming)
+
+	if len(neighbors) == 0 {
+		return out, isWisp, nil
+	}
+	ids := make([]string, 0, len(neighbors))
+	for id := range neighbors {
+		ids = append(ids, id)
+	}
+
+	fromIssues, err := u.issueRepo.GetByIDs(ctx, ids, IssueTableOpts{})
+	if err != nil {
+		return nil, nil, fmt.Errorf("hydrate neighbors (issues): %w", err)
+	}
+	for _, iss := range fromIssues {
+		out[iss.ID] = iss
+	}
+	fromWisps, err := u.issueRepo.GetByIDs(ctx, ids, IssueTableOpts{UseWispsTable: true})
+	if err != nil && !dberrors.IsTableNotExist(err) {
+		return nil, nil, fmt.Errorf("hydrate neighbors (wisps): %w", err)
+	}
+	for _, iss := range fromWisps {
+		out[iss.ID] = iss
+		isWisp[iss.ID] = true
+	}
+	return out, isWisp, nil
+}
+
+func (u *issueUseCaseImpl) sumLabelCount(ctx context.Context, ids []string, useWisp bool) (int, error) {
+	if len(ids) == 0 {
+		return 0, nil
+	}
+	res, err := u.labelRepo.ListByIssueIDs(ctx, ids, LabelOpts{UseWispsTable: useWisp})
+	if err != nil {
+		if useWisp && dberrors.IsTableNotExist(err) {
+			return 0, nil
+		}
+		return 0, fmt.Errorf("sumLabelCount: %w", err)
+	}
+	total := 0
+	for _, ls := range res {
+		total += len(ls)
+	}
+	return total, nil
+}
+
+func (u *issueUseCaseImpl) rewriteTextReferences(
+	ctx context.Context, deletedIDs []string,
+	connected map[string]*types.Issue, isWisp map[string]bool, actor string,
+) (int, error) {
+	updatedCount := 0
+	for _, id := range deletedIDs {
+		pattern := `(^|[^A-Za-z0-9_-])(` + regexp.QuoteMeta(id) + `)($|[^A-Za-z0-9_-])`
+		re := regexp.MustCompile(pattern)
+		replacement := `$1[deleted:` + id + `]$3`
+		for connID, conn := range connected {
+			updates := map[string]any{}
+			if re.MatchString(conn.Description) {
+				updates["description"] = re.ReplaceAllString(conn.Description, replacement)
+			}
+			if conn.Notes != "" && re.MatchString(conn.Notes) {
+				updates["notes"] = re.ReplaceAllString(conn.Notes, replacement)
+			}
+			if conn.Design != "" && re.MatchString(conn.Design) {
+				updates["design"] = re.ReplaceAllString(conn.Design, replacement)
+			}
+			if conn.AcceptanceCriteria != "" && re.MatchString(conn.AcceptanceCriteria) {
+				updates["acceptance_criteria"] = re.ReplaceAllString(conn.AcceptanceCriteria, replacement)
+			}
+			if len(updates) == 0 {
+				continue
+			}
+			opts := IssueTableOpts{UseWispsTable: isWisp[connID]}
+			if err := u.issueRepo.Update(ctx, connID, updates, actor, opts); err != nil {
+				return updatedCount, fmt.Errorf("rewrite refs %s: %w", connID, err)
+			}
+			updatedCount++
+			if desc, ok := updates["description"].(string); ok {
+				conn.Description = desc
+			}
+			if notes, ok := updates["notes"].(string); ok {
+				conn.Notes = notes
+			}
+			if design, ok := updates["design"].(string); ok {
+				conn.Design = design
+			}
+			if ac, ok := updates["acceptance_criteria"].(string); ok {
+				conn.AcceptanceCriteria = ac
+			}
+		}
+	}
+	return updatedCount, nil
+}

--- a/internal/storage/domain/label.go
+++ b/internal/storage/domain/label.go
@@ -15,6 +15,7 @@ type LabelSQLRepository interface {
 	List(ctx context.Context, issueID string, opts LabelOpts) ([]string, error)
 	ListByIssueIDs(ctx context.Context, issueIDs []string, opts LabelOpts) (map[string][]string, error)
 	DeleteAllForIDs(ctx context.Context, ids []string, opts LabelOpts) (int, error)
+	CountAllForIDs(ctx context.Context, ids []string, opts LabelOpts) (int, error)
 }
 
 type LabelUseCase interface {

--- a/internal/storage/domain/label.go
+++ b/internal/storage/domain/label.go
@@ -14,6 +14,7 @@ type LabelSQLRepository interface {
 	Delete(ctx context.Context, issueID, label, actor string, opts LabelOpts) error
 	List(ctx context.Context, issueID string, opts LabelOpts) ([]string, error)
 	ListByIssueIDs(ctx context.Context, issueIDs []string, opts LabelOpts) (map[string][]string, error)
+	DeleteAllForIDs(ctx context.Context, ids []string, opts LabelOpts) (int, error)
 }
 
 type LabelUseCase interface {

--- a/internal/storage/issueops/blocked_state.go
+++ b/internal/storage/issueops/blocked_state.go
@@ -16,6 +16,7 @@ import (
 type DBTX interface {
 	ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error)
 	QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error)
+	QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row
 }
 
 const waitsForGateBlockedSQL = `

--- a/internal/storage/issueops/delete.go
+++ b/internal/storage/issueops/delete.go
@@ -84,7 +84,7 @@ func DeleteIssuesInTx(ctx context.Context, tx *sql.Tx, ids []string, cascade boo
 
 	expandedRegularIDs := regularIDs
 	if cascade {
-		allToDelete, err := findAllDependentsRecursiveInTx(ctx, tx, regularIDs)
+		allToDelete, err := FindAllDependentsInTx(ctx, tx, regularIDs)
 		if err != nil {
 			return nil, fmt.Errorf("find dependents: %w", err)
 		}
@@ -159,28 +159,28 @@ func DeleteIssuesInTx(ctx context.Context, tx *sql.Tx, ids []string, cascade boo
 	}
 
 	var depsCount, labelsCount, eventsCount int
-	if depsCount, err = countRowsForIssueIDsInTx(ctx, tx, "dependencies", finalRegularIDs); err != nil {
+	if depsCount, err = CountRowsForIssueIDsInTx(ctx, tx, "dependencies", finalRegularIDs); err != nil {
 		return nil, fmt.Errorf("count dependencies: %w", err)
 	}
-	wispDepsCount, err := countRowsForIssueIDsInTx(ctx, tx, "wisp_dependencies", cascadeWispIDs)
+	wispDepsCount, err := CountRowsForIssueIDsInTx(ctx, tx, "wisp_dependencies", cascadeWispIDs)
 	if err != nil {
 		return nil, fmt.Errorf("count wisp dependencies: %w", err)
 	}
 	depsCount += wispDepsCount
 
-	if labelsCount, err = countRowsForIssueIDsInTx(ctx, tx, "labels", finalRegularIDs); err != nil {
+	if labelsCount, err = CountRowsForIssueIDsInTx(ctx, tx, "labels", finalRegularIDs); err != nil {
 		return nil, fmt.Errorf("count labels: %w", err)
 	}
-	wispLabelsCount, err := countRowsForIssueIDsInTx(ctx, tx, "wisp_labels", cascadeWispIDs)
+	wispLabelsCount, err := CountRowsForIssueIDsInTx(ctx, tx, "wisp_labels", cascadeWispIDs)
 	if err != nil {
 		return nil, fmt.Errorf("count wisp labels: %w", err)
 	}
 	labelsCount += wispLabelsCount
 
-	if eventsCount, err = countRowsForIssueIDsInTx(ctx, tx, "events", finalRegularIDs); err != nil {
+	if eventsCount, err = CountRowsForIssueIDsInTx(ctx, tx, "events", finalRegularIDs); err != nil {
 		return nil, fmt.Errorf("count events: %w", err)
 	}
-	wispEventsCount, err := countRowsForIssueIDsInTx(ctx, tx, "wisp_events", cascadeWispIDs)
+	wispEventsCount, err := CountRowsForIssueIDsInTx(ctx, tx, "wisp_events", cascadeWispIDs)
 	if err != nil {
 		return nil, fmt.Errorf("count wisp events: %w", err)
 	}
@@ -273,7 +273,7 @@ func DeleteIssuesInTx(ctx context.Context, tx *sql.Tx, ids []string, cascade boo
 // at maxRecursiveResults total discovered IDs.
 //
 //nolint:gosec // G201: inClause contains only ? placeholders
-func findAllDependentsRecursiveInTx(ctx context.Context, tx *sql.Tx, ids []string) (map[string]bool, error) {
+func FindAllDependentsInTx(ctx context.Context, tx DBTX, ids []string) (map[string]bool, error) {
 	result := make(map[string]bool)
 	for _, id := range ids {
 		result[id] = true
@@ -375,7 +375,7 @@ func findExternalDependentsBatchedInTx(ctx context.Context, tx *sql.Tx, ids []st
 }
 
 //nolint:gosec // G201: table is selected by callers from fixed issue/wisp auxiliary tables.
-func countRowsForIssueIDsInTx(ctx context.Context, tx *sql.Tx, table string, ids []string) (int, error) {
+func CountRowsForIssueIDsInTx(ctx context.Context, tx DBTX, table string, ids []string) (int, error) {
 	total := 0
 	for i := 0; i < len(ids); i += deleteBatchSize {
 		end := i + deleteBatchSize

--- a/internal/storage/issueops/wisp_routing.go
+++ b/internal/storage/issueops/wisp_routing.go
@@ -22,7 +22,7 @@ func IsActiveWispInTx(ctx context.Context, tx *sql.Tx, id string) bool {
 	return err == nil
 }
 
-func wispsTableEmptyOrMissingInTx(ctx context.Context, tx *sql.Tx) (bool, error) {
+func wispsTableEmptyOrMissingInTx(ctx context.Context, tx DBTX) (bool, error) {
 	var probe int
 	err := tx.QueryRowContext(ctx, "SELECT 1 FROM wisps LIMIT 1").Scan(&probe)
 	switch {
@@ -128,7 +128,7 @@ func partitionByWispSet(ids []string, wispSet map[string]struct{}) (wispIDs, per
 // and can push bulk hydration past the context deadline (see GH#3414).
 // IDs not present in the wisps table are treated as permanent issue IDs.
 // Returned slices preserve the input ordering within each bucket.
-func PartitionWispIDsInTx(ctx context.Context, tx *sql.Tx, ids []string) (wispIDs, permIDs []string, err error) {
+func PartitionWispIDsInTx(ctx context.Context, tx DBTX, ids []string) (wispIDs, permIDs []string, err error) {
 	if len(ids) == 0 {
 		return nil, nil, nil
 	}

--- a/internal/storage/uow/uow.go
+++ b/internal/storage/uow/uow.go
@@ -89,6 +89,7 @@ func (u *baseUOW) IssueUseCase() domain.IssueUseCase {
 			db.NewChildCounterSQLRepository(runner),
 			db.NewCommentSQLRepository(runner),
 			db.NewConfigSQLRepository(runner),
+			db.NewEventsSQLRepository(runner),
 			u.LabelUseCase(),
 			u.DependencyUseCase(),
 		)


### PR DESCRIPTION
## Summary
- Wires `bd delete` into the proxied-server UOW path, mirroring the pattern used by `bd update` / `bd create`. The embedded path is left untouched aside from a 5-line early dispatch in `cmd/bd/delete.go`.
- Adds a new `DeleteIssues` / `DeleteWisp(s)` / `PreviewDelete(Wisp)` surface on `domain.IssueUseCase`, backed by new bulk methods on `IssueSQLRepository`, `DependencySQLRepository`, `LabelSQLRepository`, and `EventsSQLRepository`. Internals reuse the existing `issueops` helpers (`PartitionWispIDsInTx`, `FindAllDependentsInTx`, `AffectedByDeletionInTx`, `RecomputeIsBlockedInTx`, `CountRowsForIssueIDsInTx`) — `issueops.DBTX` widened to include `QueryRowContext` so `*sql.Tx` and `domain/db.Runner` both satisfy it.
- Cascade is now always on at the UC level (no `--cascade` toggle, no `--force`-as-orphan). The CLI keeps the `--cascade` flag bound at cobra so existing callers don't break — it's accepted but ignored.

## Test plan
- [x] `internal/storage/domain/db/delete_repo_test.go` — repository-level coverage for `Delete`, `DeleteByIDs`, `PartitionWispIDs`, `FindAllDependents`, `AffectedByDeletion`, `RecomputeIsBlocked`, dep / label / events `DeleteAllForIDs` + dep / events `CountAllForIDs` (wisp routing covered for each).
- [x] `internal/storage/domain/db/issue_usecase_delete_test.go` — use-case coverage for `DeleteIssue`, `DeleteIssues` (empty, dry-run, label/event cleanup, text-ref rewrite skip), `DeleteWisp` (wisp-table dispatch), and `PreviewDelete(Wisp)`.
- [x] `cmd/bd/delete_proxied_integration_test.go` — end-to-end via the built `bd` binary against a live proxied server. 26 subtests across `TestProxiedServerDelete`, `TestProxiedServerDeleteWisp`, plus `TestProxiedServerDeleteConcurrent` for 5-way race semantics under MVCC.
- [x] All pass: `BEADS_TEST_PROXIED_SERVER=1 go test ./cmd/bd/ -run 'TestProxiedServerDelete' -timeout 600s`.
- [x] `go build ./... && go vet ./...` clean.