### PR TITLE
/{cmd,internal}: bd show proxied-server support

### DIFF
--- a/cmd/bd/proxied_integration_helpers_test.go
+++ b/cmd/bd/proxied_integration_helpers_test.go
@@ -208,6 +208,63 @@ func bdProxiedShow(t *testing.T, bd, dir, id string) *types.Issue {
 	return parseIssueJSON(t, out)
 }
 
+func bdProxiedShowRaw(t *testing.T, bd, dir string, args ...string) string {
+	t.Helper()
+	fullArgs := append([]string{"show"}, args...)
+	out, err := bdProxiedRun(t, bd, dir, fullArgs...)
+	if err != nil {
+		t.Fatalf("bd show %s failed: %v\n%s", strings.Join(args, " "), err, out)
+	}
+	return string(out)
+}
+
+func bdProxiedShowFail(t *testing.T, bd, dir string, args ...string) (string, string) {
+	t.Helper()
+	fullArgs := append([]string{"show"}, args...)
+	stdout, stderr, err := bdProxiedRunBuffers(t, bd, dir, fullArgs...)
+	if err == nil {
+		t.Fatalf("bd show %s should have failed; got stdout:\n%s\nstderr:\n%s",
+			strings.Join(args, " "), stdout, stderr)
+	}
+	return stdout, stderr
+}
+
+func bdProxiedShowDetailsAll(t *testing.T, bd, dir string, args ...string) []map[string]interface{} {
+	t.Helper()
+	fullArgs := append([]string{"show", "--json"}, args...)
+	out, err := bdProxiedRun(t, bd, dir, fullArgs...)
+	if err != nil {
+		t.Fatalf("bd show --json %s failed: %v\n%s", strings.Join(args, " "), err, out)
+	}
+	s := strings.TrimSpace(string(out))
+	start := strings.IndexAny(s, "[{")
+	if start < 0 {
+		t.Fatalf("no JSON in show output: %s", s)
+	}
+	s = s[start:]
+	if strings.HasPrefix(s, "[") {
+		var arr []map[string]interface{}
+		if err := json.Unmarshal([]byte(s), &arr); err != nil {
+			t.Fatalf("parse show JSON array: %v\n%s", err, s)
+		}
+		return arr
+	}
+	var m map[string]interface{}
+	if err := json.Unmarshal([]byte(s), &m); err != nil {
+		t.Fatalf("parse show JSON: %v\n%s", err, s)
+	}
+	return []map[string]interface{}{m}
+}
+
+func bdProxiedShowDetailsFirst(t *testing.T, bd, dir string, args ...string) map[string]interface{} {
+	t.Helper()
+	arr := bdProxiedShowDetailsAll(t, bd, dir, args...)
+	if len(arr) == 0 {
+		t.Fatalf("bd show --json %s returned empty array", strings.Join(args, " "))
+	}
+	return arr[0]
+}
+
 type proxiedProject struct {
 	dir       string
 	beadsDir  string

--- a/cmd/bd/show.go
+++ b/cmd/bd/show.go
@@ -20,6 +20,10 @@ var showCmd = &cobra.Command{
 	Short:   "Show issue details",
 	Args:    cobra.ArbitraryArgs, // Allow zero positional args when --id is used
 	Run: func(cmd *cobra.Command, args []string) {
+		if usesProxiedServer() {
+			runShowProxiedServer(cmd, rootCtx, args)
+			return
+		}
 		showThread, _ := cmd.Flags().GetBool("thread")
 		shortMode, _ := cmd.Flags().GetBool("short")
 		longMode, _ := cmd.Flags().GetBool("long")

--- a/cmd/bd/show_proxied_integration_test.go
+++ b/cmd/bd/show_proxied_integration_test.go
@@ -1,0 +1,811 @@
+//go:build cgo
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestProxiedServerShow(t *testing.T) {
+	requireProxiedServerEnv(t)
+	bd := buildEmbeddedBD(t)
+
+	t.Run("show_single_issue", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "ssi")
+		issue := bdProxiedCreate(t, bd, p.dir, "Show me", "--type", "task")
+
+		out := bdProxiedShowRaw(t, bd, p.dir, issue.ID)
+		if !strings.Contains(out, "Show me") {
+			t.Errorf("expected title in output: %s", out)
+		}
+		if !strings.Contains(out, issue.ID) {
+			t.Errorf("expected ID in output: %s", out)
+		}
+	})
+
+	t.Run("show_multiple_issues", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "smi")
+		issue1 := bdProxiedCreate(t, bd, p.dir, "Multi 1", "--type", "task")
+		issue2 := bdProxiedCreate(t, bd, p.dir, "Multi 2", "--type", "task")
+
+		out := bdProxiedShowRaw(t, bd, p.dir, issue1.ID, issue2.ID)
+		if !strings.Contains(out, "Multi 1") || !strings.Contains(out, "Multi 2") {
+			t.Errorf("expected both titles: %s", out)
+		}
+		if !strings.Contains(out, issue1.ID) || !strings.Contains(out, issue2.ID) {
+			t.Errorf("expected both IDs: %s", out)
+		}
+	})
+
+	t.Run("show_nonexistent_id_exits_nonzero", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "sne")
+		stdout, stderr := bdProxiedShowFail(t, bd, p.dir, "sne-nonexistent999")
+		_ = stdout
+		_ = stderr
+	})
+
+	t.Run("show_no_args_errors", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "sna")
+		stdout, stderr := bdProxiedShowFail(t, bd, p.dir)
+		combined := stdout + stderr
+		if !strings.Contains(combined, "at least one issue ID") {
+			t.Errorf("expected 'at least one issue ID' error, got: %s", combined)
+		}
+	})
+
+	t.Run("show_json_fields_round_trip", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "sjf")
+		issue := bdProxiedCreate(t, bd, p.dir, "JSON show", "--type", "task",
+			"--description", "A description", "-p", "1")
+
+		m := bdProxiedShowDetailsFirst(t, bd, p.dir, issue.ID)
+		if m["id"] != issue.ID {
+			t.Errorf("id: got %v, want %v", m["id"], issue.ID)
+		}
+		if m["title"] != "JSON show" {
+			t.Errorf("title: got %v", m["title"])
+		}
+		if m["description"] != "A description" {
+			t.Errorf("description: got %v", m["description"])
+		}
+		if m["issue_type"] != "task" {
+			t.Errorf("issue_type: got %v, want task", m["issue_type"])
+		}
+		if m["priority"] != float64(1) {
+			t.Errorf("priority: got %v, want 1", m["priority"])
+		}
+		if _, ok := m["created_at"]; !ok {
+			t.Errorf("missing created_at")
+		}
+	})
+
+	t.Run("show_json_includes_labels", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "sjl")
+		issue := bdProxiedCreate(t, bd, p.dir, "Labeled show", "--type", "task", "-l", "bug")
+
+		m := bdProxiedShowDetailsFirst(t, bd, p.dir, issue.ID)
+		labels, ok := m["labels"].([]interface{})
+		if !ok {
+			t.Fatalf("expected labels array, got %T (%v)", m["labels"], m["labels"])
+		}
+		found := false
+		for _, l := range labels {
+			if l == "bug" {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("expected 'bug' in labels: %v", labels)
+		}
+	})
+
+	t.Run("show_json_includes_dependencies", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "sjd")
+		blocker := bdProxiedCreate(t, bd, p.dir, "Blocker", "--type", "task")
+		blocked := bdProxiedCreate(t, bd, p.dir, "Blocked",
+			"--type", "task", "--deps", "blocked-by:"+blocker.ID)
+
+		m := bdProxiedShowDetailsFirst(t, bd, p.dir, blocked.ID)
+		deps, _ := m["dependencies"].([]interface{})
+		if len(deps) == 0 {
+			t.Fatalf("expected dependencies in JSON output: %v", m)
+		}
+		first, _ := deps[0].(map[string]interface{})
+		if first["id"] != blocker.ID {
+			t.Errorf("dep target id: got %v, want %v", first["id"], blocker.ID)
+		}
+		if first["dependency_type"] != "blocks" {
+			t.Errorf("dep type: got %v, want blocks", first["dependency_type"])
+		}
+	})
+
+	t.Run("show_json_count_fields_default", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "sjc")
+		blocker := bdProxiedCreate(t, bd, p.dir, "Blocker", "--type", "task")
+		blocked := bdProxiedCreate(t, bd, p.dir, "Blocked",
+			"--type", "task", "--deps", "blocked-by:"+blocker.ID)
+
+		m := bdProxiedShowDetailsFirst(t, bd, p.dir, blocked.ID)
+		if _, ok := m["dependency_count"]; !ok {
+			t.Errorf("expected dependency_count present in default JSON")
+		}
+		if _, ok := m["dependent_count"]; !ok {
+			t.Errorf("expected dependent_count present in default JSON")
+		}
+		if _, ok := m["comment_count"]; !ok {
+			t.Errorf("expected comment_count present in default JSON")
+		}
+		if _, ok := m["dependents"]; ok {
+			t.Errorf("dependents slice should be absent by default (count-only)")
+		}
+		if _, ok := m["comments"]; ok {
+			t.Errorf("comments slice should be absent by default (count-only)")
+		}
+		if m["dependency_count"] != float64(1) {
+			t.Errorf("dependency_count: got %v, want 1", m["dependency_count"])
+		}
+	})
+
+	t.Run("show_json_includes_comments_under_flag", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "sjic")
+		issue := bdProxiedCreate(t, bd, p.dir, "Commented", "--type", "task")
+
+		db := openProxiedDB(t, p)
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if _, err := db.ExecContext(ctx,
+			"INSERT INTO comments (id, issue_id, author, text, created_at) VALUES (?, ?, ?, ?, NOW())",
+			fmt.Sprintf("cmt-%d", time.Now().UnixNano()), issue.ID, "tester", "Hello"); err != nil {
+			t.Fatalf("insert comment: %v", err)
+		}
+
+		m := bdProxiedShowDetailsFirst(t, bd, p.dir, issue.ID, "--include-comments")
+		comments, _ := m["comments"].([]interface{})
+		if len(comments) == 0 {
+			t.Errorf("expected comments with --include-comments: %v", m)
+		}
+	})
+
+	t.Run("show_json_includes_dependents_under_flag", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "sjidep")
+		hub := bdProxiedCreate(t, bd, p.dir, "Hub", "--type", "task")
+		bdProxiedCreate(t, bd, p.dir, "Spoke 1", "--type", "task", "--deps", "blocked-by:"+hub.ID)
+		bdProxiedCreate(t, bd, p.dir, "Spoke 2", "--type", "task", "--deps", "blocked-by:"+hub.ID)
+
+		m := bdProxiedShowDetailsFirst(t, bd, p.dir, hub.ID, "--include-dependents")
+		deps, _ := m["dependents"].([]interface{})
+		if len(deps) != 2 {
+			t.Errorf("expected 2 dependents, got %d: %v", len(deps), m["dependents"])
+		}
+		if first, ok := deps[0].(map[string]interface{}); ok {
+			if first["id"] == nil || first["title"] == nil {
+				t.Errorf("dependent shallow row missing id/title: %v", first)
+			}
+		}
+	})
+
+	t.Run("show_json_epic_progress", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "sjep")
+		epic := bdProxiedCreate(t, bd, p.dir, "Epic progress", "--type", "epic")
+		child1 := bdProxiedCreate(t, bd, p.dir, "Epic child 1", "--type", "task", "--parent", epic.ID)
+		bdProxiedCreate(t, bd, p.dir, "Epic child 2", "--type", "task", "--parent", epic.ID)
+		bdProxiedUpdateOne(t, bd, p.dir, child1.ID, "--status", "closed")
+
+		m := bdProxiedShowDetailsFirst(t, bd, p.dir, epic.ID, "--include-dependents")
+		if total, ok := m["epic_total_children"]; ok {
+			if total != float64(2) {
+				t.Errorf("epic_total_children: got %v, want 2", total)
+			}
+		} else {
+			t.Errorf("missing epic_total_children: %v", m)
+		}
+		if closed, ok := m["epic_closed_children"]; ok {
+			if closed != float64(1) {
+				t.Errorf("epic_closed_children: got %v, want 1", closed)
+			}
+		} else {
+			t.Errorf("missing epic_closed_children: %v", m)
+		}
+	})
+
+	t.Run("show_json_parent_derived", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "sjp")
+		parent := bdProxiedCreate(t, bd, p.dir, "Parent", "--type", "epic")
+		child := bdProxiedCreate(t, bd, p.dir, "Child", "--type", "task", "--parent", parent.ID)
+
+		m := bdProxiedShowDetailsFirst(t, bd, p.dir, child.ID)
+		if got, _ := m["parent"].(string); got != parent.ID {
+			t.Errorf("parent field: got %v, want %v", m["parent"], parent.ID)
+		}
+	})
+
+	t.Run("show_short", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "ssh")
+		issue := bdProxiedCreate(t, bd, p.dir, "Short show", "--type", "task")
+		out := bdProxiedShowRaw(t, bd, p.dir, issue.ID, "--short")
+		lines := strings.Split(strings.TrimSpace(out), "\n")
+		if len(lines) > 3 {
+			t.Errorf("expected compact output, got %d lines:\n%s", len(lines), out)
+		}
+		if !strings.Contains(out, issue.ID) {
+			t.Errorf("expected ID in short output: %s", out)
+		}
+	})
+
+	t.Run("show_long", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "slong")
+		issue := bdProxiedCreate(t, bd, p.dir, "Long show", "--type", "task",
+			"--description", "Desc", "--assignee", "alice")
+		out := bdProxiedShowRaw(t, bd, p.dir, issue.ID, "--long")
+		if !strings.Contains(out, "Long show") {
+			t.Errorf("expected title in long output: %s", out)
+		}
+	})
+
+	t.Run("show_id_flag", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "sid")
+		issue := bdProxiedCreate(t, bd, p.dir, "ID flag test", "--type", "task")
+
+		out := bdProxiedShowRaw(t, bd, p.dir, "--id", issue.ID, "--short")
+		if !strings.Contains(out, issue.ID) {
+			t.Errorf("expected ID via --id flag: %s", out)
+		}
+
+		out2 := bdProxiedShowRaw(t, bd, p.dir, "--id="+issue.ID, "--id="+issue.ID, "--short")
+		if strings.Count(out2, issue.ID) < 2 {
+			t.Errorf("expected ID twice via duplicate --id: %s", out2)
+		}
+
+		out3 := bdProxiedShowRaw(t, bd, p.dir, issue.ID, "--id="+issue.ID, "--short")
+		if strings.Count(out3, issue.ID) < 2 {
+			t.Errorf("expected ID twice via mixed positional+--id: %s", out3)
+		}
+	})
+
+	t.Run("show_local_time_no_error", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "slt")
+		issue := bdProxiedCreate(t, bd, p.dir, "Local time", "--type", "task")
+		out := bdProxiedShowRaw(t, bd, p.dir, issue.ID, "--local-time")
+		if !strings.Contains(out, "Local time") {
+			t.Errorf("expected title in output: %s", out)
+		}
+	})
+
+	t.Run("show_external_ref_rendered", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "sxr")
+		issue := bdProxiedCreate(t, bd, p.dir, "External ref test",
+			"--type", "task", "--external-ref", "https://example.com/spec.md")
+		out := bdProxiedShowRaw(t, bd, p.dir, issue.ID)
+		if !strings.Contains(out, "External:") {
+			t.Errorf("expected 'External:' line in output, got: %s", out)
+		}
+		if !strings.Contains(out, "https://example.com/spec.md") {
+			t.Errorf("expected external ref URL, got: %s", out)
+		}
+	})
+
+	t.Run("show_no_external_ref_omits_line", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "snx")
+		issue := bdProxiedCreate(t, bd, p.dir, "No ref test", "--type", "task")
+		out := bdProxiedShowRaw(t, bd, p.dir, issue.ID)
+		if strings.Contains(out, "External:") {
+			t.Errorf("expected no 'External:' line, got: %s", out)
+		}
+	})
+
+	t.Run("show_not_found_json_envelope", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "snj")
+		stdout, _ := bdProxiedShowFail(t, bd, p.dir, "snj-bogus", "--json")
+		if stdout == "" {
+			t.Fatal("expected JSON error on stdout, got empty")
+		}
+		var envelope map[string]interface{}
+		if err := json.Unmarshal([]byte(stdout), &envelope); err != nil {
+			t.Fatalf("expected valid JSON envelope on stdout, got: %v\n%s", err, stdout)
+		}
+		if errField, _ := envelope["error"].(string); errField == "" {
+			t.Errorf("expected non-empty 'error' field, got: %s", stdout)
+		}
+	})
+
+	t.Run("view_alias_dispatches_to_proxied", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "sva")
+		issue := bdProxiedCreate(t, bd, p.dir, "View alias", "--type", "task")
+		out, err := bdProxiedRun(t, bd, p.dir, "view", issue.ID, "--short")
+		if err != nil {
+			t.Fatalf("bd view failed: %v\n%s", err, out)
+		}
+		if !strings.Contains(string(out), issue.ID) {
+			t.Errorf("expected ID via view alias: %s", out)
+		}
+	})
+
+	t.Run("show_concurrent_json_and_short", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "scn")
+		const (
+			numWorkers      = 8
+			issuesPerWorker = 3
+		)
+		ids := make([]string, 0, numWorkers*issuesPerWorker)
+		for i := 0; i < numWorkers*issuesPerWorker; i++ {
+			issue := bdProxiedCreate(t, bd, p.dir,
+				fmt.Sprintf("concurrent-show-%d", i), "--type", "task")
+			ids = append(ids, issue.ID)
+		}
+
+		type result struct {
+			worker int
+			err    error
+		}
+		results := make([]result, numWorkers)
+		var wg sync.WaitGroup
+		wg.Add(numWorkers)
+		for w := 0; w < numWorkers; w++ {
+			go func(worker int) {
+				defer wg.Done()
+				r := result{worker: worker}
+				for i := 0; i < issuesPerWorker; i++ {
+					id := ids[worker*issuesPerWorker+i]
+					if _, err := bdProxiedRun(t, bd, p.dir, "show", id, "--json"); err != nil {
+						r.err = fmt.Errorf("show --json %s: %w", id, err)
+						results[worker] = r
+						return
+					}
+					if _, err := bdProxiedRun(t, bd, p.dir, "show", id, "--short"); err != nil {
+						r.err = fmt.Errorf("show --short %s: %w", id, err)
+						results[worker] = r
+						return
+					}
+				}
+				results[worker] = r
+			}(w)
+		}
+		wg.Wait()
+		for _, r := range results {
+			if r.err != nil {
+				t.Errorf("worker %d failed: %v", r.worker, r.err)
+			}
+		}
+	})
+
+	t.Run("show_wisp_id_routes_to_wisp_uc", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "swr")
+		wisp := bdProxiedCreate(t, bd, p.dir, "Wisp default", "--type", "task", "--ephemeral")
+
+		out := bdProxiedShowRaw(t, bd, p.dir, wisp.ID)
+		if !strings.Contains(out, "Wisp default") {
+			t.Errorf("expected wisp title in output: %s", out)
+		}
+
+		m := bdProxiedShowDetailsFirst(t, bd, p.dir, wisp.ID)
+		if _, ok := m["comment_count"]; !ok {
+			t.Errorf("expected comment_count for wisp")
+		}
+		if _, ok := m["dependent_count"]; !ok {
+			t.Errorf("expected dependent_count for wisp")
+		}
+	})
+
+	t.Run("show_refs_lists_referrers", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "srl")
+		parent := bdProxiedCreate(t, bd, p.dir, "Refs parent", "--type", "task")
+		child := bdProxiedCreate(t, bd, p.dir, "Refs child",
+			"--type", "task", "--deps", "blocked-by:"+parent.ID)
+
+		out := bdProxiedShowRaw(t, bd, p.dir, parent.ID, "--refs")
+		if !strings.Contains(out, child.ID) {
+			t.Errorf("expected --refs output to contain referrer %s: %s", child.ID, out)
+		}
+	})
+
+	t.Run("show_refs_groups_by_type", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "srg")
+		hub := bdProxiedCreate(t, bd, p.dir, "Refs hub", "--type", "task")
+		bdProxiedCreate(t, bd, p.dir, "Blocker A",
+			"--type", "task", "--deps", "blocked-by:"+hub.ID)
+		bdProxiedCreate(t, bd, p.dir, "Related A",
+			"--type", "task", "--deps", "related:"+hub.ID)
+
+		out := bdProxiedShowRaw(t, bd, p.dir, hub.ID, "--refs")
+		if !strings.Contains(out, "blocks") {
+			t.Errorf("expected 'blocks' group in --refs output: %s", out)
+		}
+		if !strings.Contains(out, "related") {
+			t.Errorf("expected 'related' group in --refs output: %s", out)
+		}
+	})
+
+	t.Run("show_refs_empty", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "sre")
+		issue := bdProxiedCreate(t, bd, p.dir, "No refs", "--type", "task")
+		out := bdProxiedShowRaw(t, bd, p.dir, issue.ID, "--refs")
+		if !strings.Contains(out, "No references found") {
+			t.Errorf("expected 'No references found' in --refs output: %s", out)
+		}
+	})
+
+	t.Run("show_refs_json_map_shape", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "srj")
+		parent := bdProxiedCreate(t, bd, p.dir, "Refs parent J", "--type", "task")
+		child := bdProxiedCreate(t, bd, p.dir, "Refs child J",
+			"--type", "task", "--deps", "blocked-by:"+parent.ID)
+
+		out, err := bdProxiedRun(t, bd, p.dir, "show", parent.ID, "--refs", "--json")
+		if err != nil {
+			t.Fatalf("bd show --refs --json failed: %v\n%s", err, out)
+		}
+		s := strings.TrimSpace(string(out))
+		start := strings.Index(s, "{")
+		if start < 0 {
+			t.Fatalf("no JSON object found: %s", s)
+		}
+		var envelope map[string]interface{}
+		if err := json.Unmarshal([]byte(s[start:]), &envelope); err != nil {
+			t.Fatalf("parse refs JSON: %v\n%s", err, s[start:])
+		}
+		entry, ok := envelope[parent.ID]
+		if !ok {
+			t.Fatalf("expected entry for %s in refs JSON: %v", parent.ID, envelope)
+		}
+		refs, _ := entry.([]interface{})
+		if len(refs) == 0 {
+			t.Fatalf("expected non-empty refs slice for %s: %v", parent.ID, entry)
+		}
+		first, _ := refs[0].(map[string]interface{})
+		if first["id"] != child.ID {
+			t.Errorf("expected child %s in refs JSON, got: %v", child.ID, first)
+		}
+	})
+
+	t.Run("show_wisp_refs", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "swrefs")
+		wisp := bdProxiedCreate(t, bd, p.dir, "Wisp ref target", "--type", "task", "--ephemeral")
+		referrer := bdProxiedCreate(t, bd, p.dir, "Wisp referrer",
+			"--type", "task", "--ephemeral", "--deps", "blocked-by:"+wisp.ID)
+
+		out := bdProxiedShowRaw(t, bd, p.dir, wisp.ID, "--refs")
+		if !strings.Contains(out, referrer.ID) {
+			t.Errorf("expected wisp referrer %s in --refs output: %s", referrer.ID, out)
+		}
+	})
+
+	t.Run("show_children", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "sc")
+		parent := bdProxiedCreate(t, bd, p.dir, "Children parent", "--type", "epic")
+		child := bdProxiedCreate(t, bd, p.dir, "Children child",
+			"--type", "task", "--parent", parent.ID)
+
+		out := bdProxiedShowRaw(t, bd, p.dir, parent.ID, "--children")
+		if !strings.Contains(out, child.ID) {
+			t.Errorf("expected child %s in --children output: %s", child.ID, out)
+		}
+	})
+
+	t.Run("show_children_empty", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "sce")
+		issue := bdProxiedCreate(t, bd, p.dir, "No children", "--type", "task")
+		out := bdProxiedShowRaw(t, bd, p.dir, issue.ID, "--children")
+		if !strings.Contains(out, "No children found") {
+			t.Errorf("expected 'No children found' in output: %s", out)
+		}
+	})
+
+	t.Run("show_children_short", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "scs")
+		parent := bdProxiedCreate(t, bd, p.dir, "Parent S", "--type", "epic")
+		child := bdProxiedCreate(t, bd, p.dir, "Child S",
+			"--type", "task", "--parent", parent.ID)
+
+		out := bdProxiedShowRaw(t, bd, p.dir, parent.ID, "--children", "--short")
+		if !strings.Contains(out, child.ID) {
+			t.Errorf("expected child %s in --children --short output: %s", child.ID, out)
+		}
+	})
+
+	t.Run("show_children_json_map_shape", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "scj")
+		parent := bdProxiedCreate(t, bd, p.dir, "Parent J", "--type", "epic")
+		child := bdProxiedCreate(t, bd, p.dir, "Child J",
+			"--type", "task", "--parent", parent.ID)
+
+		out, err := bdProxiedRun(t, bd, p.dir, "show", parent.ID, "--children", "--json")
+		if err != nil {
+			t.Fatalf("show --children --json: %v\n%s", err, out)
+		}
+		s := strings.TrimSpace(string(out))
+		start := strings.Index(s, "{")
+		if start < 0 {
+			t.Fatalf("no JSON object: %s", s)
+		}
+		var envelope map[string]interface{}
+		if err := json.Unmarshal([]byte(s[start:]), &envelope); err != nil {
+			t.Fatalf("parse children JSON: %v\n%s", err, s[start:])
+		}
+		entry, ok := envelope[parent.ID]
+		if !ok {
+			t.Fatalf("expected entry for %s in children JSON: %v", parent.ID, envelope)
+		}
+		kids, _ := entry.([]interface{})
+		if len(kids) == 0 {
+			t.Fatalf("expected children slice for %s: %v", parent.ID, entry)
+		}
+		first, _ := kids[0].(map[string]interface{})
+		if first["id"] != child.ID {
+			t.Errorf("expected child %s in children JSON: %v", child.ID, first)
+		}
+		if first["dependency_type"] != "parent-child" {
+			t.Errorf("expected dependency_type=parent-child, got %v", first["dependency_type"])
+		}
+	})
+
+	t.Run("show_wisp_children", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "swc")
+		epicW := bdProxiedCreate(t, bd, p.dir, "Wisp epic", "--type", "epic", "--ephemeral")
+		childW := bdProxiedCreate(t, bd, p.dir, "Wisp child",
+			"--type", "task", "--ephemeral", "--parent", epicW.ID)
+
+		out := bdProxiedShowRaw(t, bd, p.dir, epicW.ID, "--children")
+		if !strings.Contains(out, childW.ID) {
+			t.Errorf("expected wisp child %s in --children: %s", childW.ID, out)
+		}
+	})
+
+	t.Run("show_as_of_historical_title", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "sao")
+		issue := bdProxiedCreate(t, bd, p.dir, "AsOf original", "--type", "task")
+
+		hash := proxiedCurrentCommit(t, p)
+
+		bdProxiedUpdateOne(t, bd, p.dir, issue.ID, "--title", "AsOf updated")
+
+		out := bdProxiedShowRaw(t, bd, p.dir, issue.ID, "--as-of", hash)
+		if !strings.Contains(out, "AsOf original") {
+			t.Errorf("expected original title at old commit: %s", out)
+		}
+		if strings.Contains(out, "AsOf updated") {
+			t.Errorf("should not see updated title at old commit: %s", out)
+		}
+	})
+
+	t.Run("show_as_of_invalid_ref_errors", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "saoi")
+		issue := bdProxiedCreate(t, bd, p.dir, "AsOf invalid", "--type", "task")
+
+		_, stderr, _ := bdProxiedRunBuffers(t, bd, p.dir, "show", issue.ID, "--as-of", "'; DROP TABLE issues; --")
+		if !strings.Contains(stderr, "invalid ref") {
+			t.Errorf("expected 'invalid ref' in stderr, got: %s", stderr)
+		}
+	})
+
+	t.Run("show_as_of_short_mode", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "saos")
+		issue := bdProxiedCreate(t, bd, p.dir, "AsOf short", "--type", "task")
+		hash := proxiedCurrentCommit(t, p)
+		bdProxiedUpdateOne(t, bd, p.dir, issue.ID, "--title", "AsOf short updated")
+
+		out := bdProxiedShowRaw(t, bd, p.dir, issue.ID, "--as-of", hash, "--short")
+		if !strings.Contains(out, issue.ID) {
+			t.Errorf("expected ID in --as-of --short output: %s", out)
+		}
+		if !strings.Contains(out, "AsOf short") {
+			t.Errorf("expected historical title in short output: %s", out)
+		}
+	})
+
+	t.Run("show_as_of_json_array", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "saoj")
+		issue := bdProxiedCreate(t, bd, p.dir, "AsOf JSON", "--type", "task")
+		hash := proxiedCurrentCommit(t, p)
+		bdProxiedUpdateOne(t, bd, p.dir, issue.ID, "--title", "AsOf JSON updated")
+
+		arr := bdProxiedShowDetailsAll(t, bd, p.dir, issue.ID, "--as-of", hash)
+		if len(arr) == 0 {
+			t.Fatalf("expected non-empty array from --as-of --json")
+		}
+		if arr[0]["title"] != "AsOf JSON" {
+			t.Errorf("expected historical title in JSON, got %v", arr[0]["title"])
+		}
+	})
+
+	t.Run("show_thread_walks_to_root", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "sthr")
+		root := bdProxiedCreate(t, bd, p.dir, "Root msg", "--type", "task")
+		mid := bdProxiedCreate(t, bd, p.dir, "Mid reply",
+			"--type", "task", "--deps", "replies-to:"+root.ID)
+		leaf := bdProxiedCreate(t, bd, p.dir, "Leaf reply",
+			"--type", "task", "--deps", "replies-to:"+mid.ID)
+
+		out := bdProxiedShowRaw(t, bd, p.dir, leaf.ID, "--thread")
+		for _, want := range []string{root.ID, mid.ID, leaf.ID, "Total: 3"} {
+			if !strings.Contains(out, want) {
+				t.Errorf("expected %q in --thread output:\n%s", want, out)
+			}
+		}
+	})
+
+	t.Run("show_thread_collects_replies", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "stbr")
+		root := bdProxiedCreate(t, bd, p.dir, "Branch root", "--type", "task")
+		a := bdProxiedCreate(t, bd, p.dir, "Reply A",
+			"--type", "task", "--deps", "replies-to:"+root.ID)
+		b := bdProxiedCreate(t, bd, p.dir, "Reply B",
+			"--type", "task", "--deps", "replies-to:"+root.ID)
+		aReply := bdProxiedCreate(t, bd, p.dir, "Reply A1",
+			"--type", "task", "--deps", "replies-to:"+a.ID)
+
+		out := bdProxiedShowRaw(t, bd, p.dir, root.ID, "--thread")
+		for _, want := range []string{root.ID, a.ID, b.ID, aReply.ID, "Total: 4"} {
+			if !strings.Contains(out, want) {
+				t.Errorf("expected %q in thread output:\n%s", want, out)
+			}
+		}
+	})
+
+	t.Run("show_thread_json_emits_array", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "stj")
+		root := bdProxiedCreate(t, bd, p.dir, "Thread JSON root", "--type", "task")
+		reply := bdProxiedCreate(t, bd, p.dir, "Thread JSON reply",
+			"--type", "task", "--deps", "replies-to:"+root.ID)
+
+		out, err := bdProxiedRun(t, bd, p.dir, "show", root.ID, "--thread", "--json")
+		if err != nil {
+			t.Fatalf("--thread --json failed: %v\n%s", err, out)
+		}
+		s := strings.TrimSpace(string(out))
+		start := strings.Index(s, "[")
+		if start < 0 {
+			t.Fatalf("no JSON array: %s", s)
+		}
+		var arr []map[string]interface{}
+		if err := json.Unmarshal([]byte(s[start:]), &arr); err != nil {
+			t.Fatalf("parse thread JSON: %v\n%s", err, s[start:])
+		}
+		if len(arr) != 2 {
+			t.Errorf("expected 2 entries in thread JSON, got %d: %v", len(arr), arr)
+		}
+		if arr[0]["id"] != root.ID || arr[1]["id"] != reply.ID {
+			t.Errorf("thread order: got [%v, %v], want [%v, %v]",
+				arr[0]["id"], arr[1]["id"], root.ID, reply.ID)
+		}
+	})
+
+	t.Run("show_thread_orphan_message_renders_alone", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "sto")
+		orphan := bdProxiedCreate(t, bd, p.dir, "Orphan msg", "--type", "task")
+		out := bdProxiedShowRaw(t, bd, p.dir, orphan.ID, "--thread")
+		if !strings.Contains(out, orphan.ID) {
+			t.Errorf("expected orphan ID in thread output: %s", out)
+		}
+		if !strings.Contains(out, "Total: 1") {
+			t.Errorf("expected 'Total: 1' for orphan thread: %s", out)
+		}
+	})
+
+	t.Run("show_current_with_in_progress", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "scur")
+		issue := bdProxiedCreate(t, bd, p.dir, "In progress", "--type", "task")
+		bdProxiedUpdateOne(t, bd, p.dir, issue.ID,
+			"--status", "in_progress", "--assignee", "alice", "--actor", "alice")
+
+		out, err := bdProxiedRun(t, bd, p.dir, "--actor", "alice", "show", "--current")
+		if err != nil {
+			t.Fatalf("--current failed: %v\n%s", err, out)
+		}
+		if !strings.Contains(string(out), issue.ID) {
+			t.Errorf("expected --current to resolve to %s: %s", issue.ID, out)
+		}
+	})
+
+	t.Run("show_current_prefers_in_progress_over_hooked", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "scp")
+		hooked := bdProxiedCreate(t, bd, p.dir, "Hooked one", "--type", "task")
+		inProg := bdProxiedCreate(t, bd, p.dir, "InProg one", "--type", "task")
+		bdProxiedUpdateOne(t, bd, p.dir, hooked.ID,
+			"--status", "hooked", "--assignee", "alice", "--actor", "alice")
+		bdProxiedUpdateOne(t, bd, p.dir, inProg.ID,
+			"--status", "in_progress", "--assignee", "alice", "--actor", "alice")
+
+		out, err := bdProxiedRun(t, bd, p.dir, "--actor", "alice", "show", "--current")
+		if err != nil {
+			t.Fatalf("--current failed: %v\n%s", err, out)
+		}
+		if !strings.Contains(string(out), inProg.ID) {
+			t.Errorf("expected in-progress %s to win over hooked: %s", inProg.ID, out)
+		}
+		if strings.Contains(string(out), hooked.ID) {
+			t.Errorf("hooked should not appear when in-progress exists: %s", out)
+		}
+	})
+
+	t.Run("show_current_with_id_fails", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "scid")
+		issue := bdProxiedCreate(t, bd, p.dir, "Conflict", "--type", "task")
+		stdout, stderr := bdProxiedShowFail(t, bd, p.dir, "--current", issue.ID)
+		combined := stdout + stderr
+		if !strings.Contains(combined, "--current cannot be combined") {
+			t.Errorf("expected conflict error, got: %s", combined)
+		}
+	})
+
+	t.Run("show_current_no_match_errors", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "scnm")
+		stdout, stderr := bdProxiedShowFail(t, bd, p.dir, "--current")
+		combined := stdout + stderr
+		if !strings.Contains(combined, "no current issue found") {
+			t.Errorf("expected 'no current issue found' error, got: %s", combined)
+		}
+	})
+
+	t.Run("show_watch_rejected_in_proxied_mode", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "swt")
+		issue := bdProxiedCreate(t, bd, p.dir, "Watch test", "--type", "task")
+		stdout, stderr := bdProxiedShowFail(t, bd, p.dir, issue.ID, "--watch")
+		combined := stdout + stderr
+		if !strings.Contains(combined, "watch mode not supported in proxied-server mode") {
+			t.Errorf("expected proxied watch-rejection error, got: %s", combined)
+		}
+	})
+
+	t.Run("show_wisp_comments_default_count_only", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "swcc")
+		wisp := bdProxiedCreate(t, bd, p.dir, "Wisp w/comments", "--type", "task", "--ephemeral")
+
+		db := openProxiedDB(t, p)
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		for i := 0; i < 3; i++ {
+			if _, err := db.ExecContext(ctx,
+				"INSERT INTO wisp_comments (id, issue_id, author, text, created_at) VALUES (?, ?, ?, ?, NOW())",
+				fmt.Sprintf("wcmt-%d-%d", time.Now().UnixNano(), i), wisp.ID, "tester",
+				fmt.Sprintf("wisp comment %d", i)); err != nil {
+				t.Fatalf("insert wisp_comment: %v", err)
+			}
+		}
+
+		m := bdProxiedShowDetailsFirst(t, bd, p.dir, wisp.ID)
+		if got, _ := m["comment_count"].(float64); got != 3 {
+			t.Errorf("comment_count: got %v, want 3", m["comment_count"])
+		}
+		if _, ok := m["comments"]; ok {
+			t.Errorf("comments slice should be absent by default")
+		}
+	})
+
+	t.Run("show_wisp_comments_include_streams", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "swci")
+		wisp := bdProxiedCreate(t, bd, p.dir, "Wisp stream", "--type", "task", "--ephemeral")
+
+		db := openProxiedDB(t, p)
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if _, err := db.ExecContext(ctx,
+			"INSERT INTO wisp_comments (id, issue_id, author, text, created_at) VALUES (?, ?, ?, ?, NOW())",
+			fmt.Sprintf("wcmt-stream-%d", time.Now().UnixNano()), wisp.ID, "tester", "stream me"); err != nil {
+			t.Fatalf("insert wisp_comment: %v", err)
+		}
+
+		m := bdProxiedShowDetailsFirst(t, bd, p.dir, wisp.ID, "--include-comments")
+		comments, _ := m["comments"].([]interface{})
+		if len(comments) == 0 {
+			t.Fatalf("expected wisp comments with --include-comments: %v", m)
+		}
+	})
+}
+
+func proxiedCurrentCommit(t *testing.T, p proxiedProject) string {
+	t.Helper()
+	db := openProxiedDB(t, p)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	var hash string
+	if err := db.QueryRowContext(ctx, "SELECT HASHOF('HEAD')").Scan(&hash); err != nil {
+		t.Fatalf("read HASHOF('HEAD'): %v", err)
+	}
+	return hash
+}

--- a/cmd/bd/show_proxied_server.go
+++ b/cmd/bd/show_proxied_server.go
@@ -1,0 +1,716 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"slices"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/steveyegge/beads/internal/storage/domain"
+	"github.com/steveyegge/beads/internal/storage/uow"
+	"github.com/steveyegge/beads/internal/types"
+	"github.com/steveyegge/beads/internal/ui"
+	"github.com/steveyegge/beads/internal/uimd"
+)
+
+type showProxiedInput struct {
+	ids             []string
+	thread          bool
+	shortMode       bool
+	longMode        bool
+	refs            bool
+	children        bool
+	asOfRef         string
+	localTime       bool
+	watchMode       bool
+	currentMode     bool
+	includeDepends  bool
+	includeComments bool
+}
+
+func gatherShowProxiedInput(cmd *cobra.Command, args []string) *showProxiedInput {
+	in := &showProxiedInput{}
+	in.thread, _ = cmd.Flags().GetBool("thread")
+	in.shortMode, _ = cmd.Flags().GetBool("short")
+	in.longMode, _ = cmd.Flags().GetBool("long")
+	in.refs, _ = cmd.Flags().GetBool("refs")
+	in.children, _ = cmd.Flags().GetBool("children")
+	in.asOfRef, _ = cmd.Flags().GetString("as-of")
+	in.localTime, _ = cmd.Flags().GetBool("local-time")
+	in.watchMode, _ = cmd.Flags().GetBool("watch")
+	in.currentMode, _ = cmd.Flags().GetBool("current")
+	in.includeDepends, _ = cmd.Flags().GetBool("include-dependents")
+	in.includeComments, _ = cmd.Flags().GetBool("include-comments")
+
+	idFlags, _ := cmd.Flags().GetStringArray("id")
+	in.ids = append(in.ids, args...)
+	in.ids = append(in.ids, idFlags...)
+	return in
+}
+
+func proxiedOpenReadUOW(ctx context.Context) uow.UnitOfWork {
+	if uowProvider == nil {
+		FatalError("proxied-server UOW provider not initialized")
+	}
+	uw, err := uowProvider.NewUOW(ctx)
+	if err != nil {
+		FatalErrorRespectJSON("open unit of work: %v", err)
+	}
+	return uw
+}
+
+func runShowProxiedServer(cmd *cobra.Command, ctx context.Context, args []string) {
+	in := gatherShowProxiedInput(cmd, args)
+
+	if in.watchMode {
+		FatalErrorRespectJSON("watch mode not supported in proxied-server mode")
+	}
+
+	uw := proxiedOpenReadUOW(ctx)
+	defer uw.Close(ctx)
+
+	if in.currentMode {
+		if len(in.ids) > 0 {
+			FatalErrorRespectJSON("--current cannot be combined with explicit issue IDs")
+		}
+		currentID := resolveCurrentIssueIDProxied(ctx, uw)
+		if currentID == "" {
+			FatalErrorRespectJSON("no current issue found (no in-progress, hooked, or recently touched issues)")
+		}
+		in.ids = []string{currentID}
+	}
+
+	if len(in.ids) == 0 {
+		FatalErrorRespectJSON("at least one issue ID is required (use positional args, --id flag, or --current)")
+	}
+
+	switch {
+	case in.asOfRef != "":
+		runShowProxiedAsOf(ctx, uw, in)
+	case in.thread:
+		runShowProxiedThread(ctx, uw, in)
+	case in.refs:
+		runShowProxiedRefs(ctx, uw, in)
+	case in.children:
+		runShowProxiedChildren(ctx, uw, in)
+	default:
+		runShowProxiedDefault(ctx, uw, in)
+	}
+}
+
+func resolveCurrentIssueIDProxied(ctx context.Context, uw uow.UnitOfWork) string {
+	currentActor := getActorWithGit()
+	if currentActor == "" {
+		return ""
+	}
+	for _, status := range []types.Status{types.StatusInProgress, types.StatusHooked} {
+		st := status
+		filter := types.IssueFilter{Status: &st, Assignee: &currentActor}
+		page, err := uw.IssueUseCase().SearchIssues(ctx, "", filter)
+		if err == nil && len(page.Items) > 0 {
+			return page.Items[0].ID
+		}
+	}
+	return ""
+}
+
+func proxiedGetIssueOrWisp(ctx context.Context, uw uow.UnitOfWork, id string) (issue *types.Issue, isWisp bool, err error) {
+	issue, err = uw.IssueUseCase().GetIssue(ctx, id)
+	if err == nil && issue != nil {
+		return issue, false, nil
+	}
+	wispIssue, wispErr := uw.IssueUseCase().GetWisp(ctx, id)
+	if wispErr == nil && wispIssue != nil {
+		return wispIssue, true, nil
+	}
+	if err != nil {
+		return nil, false, err
+	}
+	return nil, false, nil
+}
+
+func proxiedListDeps(ctx context.Context, uw uow.UnitOfWork, id string, isWisp bool, filter domain.DepListFilter) ([]*types.IssueWithDependencyMetadata, error) {
+	if isWisp {
+		return uw.DependencyUseCase().ListWispWithIssueMetadata(ctx, id, filter)
+	}
+	return uw.DependencyUseCase().ListWithIssueMetadata(ctx, id, filter)
+}
+
+func proxiedCountDeps(ctx context.Context, uw uow.UnitOfWork, id string, isWisp bool, filter domain.DepListFilter) (int64, error) {
+	if isWisp {
+		return uw.DependencyUseCase().CountByWispID(ctx, id, filter)
+	}
+	return uw.DependencyUseCase().CountByIssueID(ctx, id, filter)
+}
+
+func proxiedGetComments(ctx context.Context, uw uow.UnitOfWork, id string, isWisp bool) ([]*types.Comment, error) {
+	if isWisp {
+		return uw.CommentUseCase().GetCommentsForWisp(ctx, id)
+	}
+	return uw.CommentUseCase().GetCommentsForIssue(ctx, id)
+}
+
+func proxiedCountComments(ctx context.Context, uw uow.UnitOfWork, id string, isWisp bool) (int64, error) {
+	if isWisp {
+		return uw.CommentUseCase().CountCommentsForWisp(ctx, id)
+	}
+	return uw.CommentUseCase().CountCommentsForIssue(ctx, id)
+}
+
+func runShowProxiedAsOf(ctx context.Context, uw uow.UnitOfWork, in *showProxiedInput) {
+	var jsonIssues []*types.Issue
+	for idx, id := range in.ids {
+		issue, err := uw.IssueUseCase().AsOf(ctx, id, in.asOfRef)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error fetching %s as of %s: %v\n", id, in.asOfRef, err)
+			continue
+		}
+		if issue == nil {
+			fmt.Fprintf(os.Stderr, "Issue %s did not exist at %s\n", id, in.asOfRef)
+			continue
+		}
+
+		if in.shortMode {
+			fmt.Println(formatShortIssue(issue))
+			continue
+		}
+		if jsonOutput {
+			jsonIssues = append(jsonIssues, issue)
+			continue
+		}
+
+		if idx > 0 {
+			fmt.Println("\n" + ui.RenderMuted(strings.Repeat("-", 60)))
+		}
+		fmt.Printf("\n%s (as of %s)\n", formatIssueHeader(issue), ui.RenderMuted(in.asOfRef))
+		fmt.Println(formatIssueMetadata(issue))
+		if issue.Description != "" {
+			fmt.Printf("\n%s\n%s\n", ui.RenderBold("DESCRIPTION"), uimd.RenderMarkdown(issue.Description))
+		}
+		fmt.Println()
+	}
+	if jsonOutput && len(jsonIssues) > 0 {
+		outputJSON(jsonIssues)
+	}
+}
+
+func runShowProxiedRefs(ctx context.Context, uw uow.UnitOfWork, in *showProxiedInput) {
+	allRefs := make(map[string][]*types.IssueWithDependencyMetadata, len(in.ids))
+	for _, id := range in.ids {
+		issue, isWisp, err := proxiedGetIssueOrWisp(ctx, uw, id)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error resolving %s: %v\n", id, err)
+			continue
+		}
+		if issue == nil {
+			fmt.Fprintf(os.Stderr, "Issue %s not found\n", id)
+			continue
+		}
+		refs, err := proxiedListDeps(ctx, uw, id, isWisp, domain.DepListFilter{Direction: domain.DepDirectionIn})
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error getting refs for %s: %v\n", id, err)
+			continue
+		}
+		allRefs[id] = refs
+	}
+
+	if jsonOutput {
+		outputJSON(allRefs)
+		return
+	}
+	for id, refs := range allRefs {
+		if len(refs) == 0 {
+			fmt.Printf("\n%s: No references found\n", ui.RenderAccent(id))
+			continue
+		}
+		fmt.Printf("\n%s References to %s:\n", ui.RenderAccent("📎"), id)
+		refsByType := make(map[types.DependencyType][]*types.IssueWithDependencyMetadata)
+		for _, ref := range refs {
+			refsByType[ref.DependencyType] = append(refsByType[ref.DependencyType], ref)
+		}
+		typeOrder := []types.DependencyType{
+			types.DepUntil, types.DepCausedBy, types.DepValidates,
+			types.DepBlocks, types.DepParentChild, types.DepRelatesTo,
+			types.DepTracks, types.DepDiscoveredFrom, types.DepRelated,
+			types.DepSupersedes, types.DepDuplicates, types.DepRepliesTo,
+			types.DepApprovedBy, types.DepAuthoredBy, types.DepAssignedTo,
+		}
+		shown := make(map[types.DependencyType]bool)
+		for _, depType := range typeOrder {
+			if grp, ok := refsByType[depType]; ok {
+				displayRefGroup(depType, grp)
+				shown[depType] = true
+			}
+		}
+		for depType, grp := range refsByType {
+			if !shown[depType] {
+				displayRefGroup(depType, grp)
+			}
+		}
+		fmt.Println()
+	}
+}
+
+func runShowProxiedChildren(ctx context.Context, uw uow.UnitOfWork, in *showProxiedInput) {
+	allChildren := make(map[string][]*types.IssueWithDependencyMetadata, len(in.ids))
+	for _, id := range in.ids {
+		issue, isWisp, err := proxiedGetIssueOrWisp(ctx, uw, id)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error resolving %s: %v\n", id, err)
+			continue
+		}
+		if issue == nil {
+			fmt.Fprintf(os.Stderr, "Issue %s not found\n", id)
+			continue
+		}
+		kids, err := proxiedListDeps(ctx, uw, id, isWisp, domain.DepListFilter{
+			Types:     []types.DependencyType{types.DepParentChild},
+			Direction: domain.DepDirectionIn,
+		})
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error getting children for %s: %v\n", id, err)
+			continue
+		}
+		if kids == nil {
+			kids = []*types.IssueWithDependencyMetadata{}
+		}
+		allChildren[id] = kids
+	}
+
+	if jsonOutput {
+		outputJSON(allChildren)
+		return
+	}
+	for id, kids := range allChildren {
+		if len(kids) == 0 {
+			fmt.Printf("%s: No children found\n", ui.RenderAccent(id))
+			continue
+		}
+		fmt.Printf("%s Children of %s (%d):\n", ui.RenderAccent("↳"), id, len(kids))
+		for _, c := range kids {
+			if in.shortMode {
+				fmt.Printf("  %s\n", formatShortIssue(&c.Issue))
+			} else {
+				fmt.Println(formatDependencyLine("↳", c))
+			}
+		}
+		fmt.Println()
+	}
+}
+
+func runShowProxiedThread(ctx context.Context, uw uow.UnitOfWork, in *showProxiedInput) {
+	if len(in.ids) == 0 {
+		return
+	}
+	startMsg, _, err := proxiedGetIssueOrWisp(ctx, uw, in.ids[0])
+	if err != nil {
+		FatalErrorRespectJSON("fetching message %s: %v", in.ids[0], err)
+	}
+	if startMsg == nil {
+		FatalErrorRespectJSON("message %s not found", in.ids[0])
+	}
+
+	rootMsg := startMsg
+	seen := map[string]bool{rootMsg.ID: true}
+	for {
+		parentID := proxiedFindRepliesTo(ctx, uw, rootMsg.ID)
+		if parentID == "" || seen[parentID] {
+			break
+		}
+		seen[parentID] = true
+		parentMsg, _ := uw.IssueUseCase().GetIssue(ctx, parentID)
+		if parentMsg == nil {
+			parentMsg, _ = uw.IssueUseCase().GetWisp(ctx, parentID)
+		}
+		if parentMsg == nil {
+			break
+		}
+		rootMsg = parentMsg
+	}
+
+	threadMessages := []*types.Issue{rootMsg}
+	threadIDs := map[string]bool{rootMsg.ID: true}
+	repliesTo := map[string]string{}
+	queue := []string{rootMsg.ID}
+	for len(queue) > 0 {
+		current := queue[0]
+		queue = queue[1:]
+		replies := proxiedFindReplies(ctx, uw, current)
+		for _, reply := range replies {
+			if threadIDs[reply.ID] {
+				continue
+			}
+			r := reply
+			threadMessages = append(threadMessages, &r)
+			threadIDs[reply.ID] = true
+			repliesTo[reply.ID] = current
+			queue = append(queue, reply.ID)
+		}
+	}
+
+	slices.SortFunc(threadMessages, func(a, b *types.Issue) int {
+		return a.CreatedAt.Compare(b.CreatedAt)
+	})
+
+	if jsonOutput {
+		encoder := json.NewEncoder(os.Stdout)
+		encoder.SetIndent("", "  ")
+		_ = encoder.Encode(threadMessages)
+		return
+	}
+
+	fmt.Printf("\n%s Thread: %s\n", ui.RenderAccent("📬"), rootMsg.Title)
+	fmt.Println(strings.Repeat("─", 66))
+	for _, msg := range threadMessages {
+		depth := 0
+		parent := repliesTo[msg.ID]
+		for parent != "" && depth < 5 {
+			depth++
+			parent = repliesTo[parent]
+		}
+		indent := strings.Repeat("  ", depth)
+		timeStr := msg.CreatedAt.Format("2006-01-02 15:04")
+		statusIcon := "📧"
+		if msg.Status == types.StatusClosed {
+			statusIcon = "✓"
+		}
+		fmt.Printf("%s%s %s %s\n", indent, statusIcon, ui.RenderAccent(msg.ID), ui.RenderMuted(timeStr))
+		fmt.Printf("%s  From: %s  To: %s\n", indent, msg.Sender, msg.Assignee)
+		if parentID := repliesTo[msg.ID]; parentID != "" {
+			fmt.Printf("%s  Re: %s\n", indent, parentID)
+		}
+		fmt.Printf("%s  %s: %s\n", indent, ui.RenderMuted("Subject"), msg.Title)
+		if msg.Description != "" {
+			for _, line := range strings.Split(msg.Description, "\n") {
+				fmt.Printf("%s  %s\n", indent, line)
+			}
+		}
+		fmt.Println()
+	}
+	fmt.Printf("Total: %d messages in thread\n\n", len(threadMessages))
+}
+
+func proxiedFindRepliesTo(ctx context.Context, uw uow.UnitOfWork, id string) string {
+	deps, err := uw.DependencyUseCase().ListWithIssueMetadata(ctx, id, domain.DepListFilter{
+		Types:     []types.DependencyType{types.DepRepliesTo},
+		Direction: domain.DepDirectionOut,
+	})
+	if err != nil || len(deps) == 0 {
+		return ""
+	}
+	return deps[0].ID
+}
+
+func proxiedFindReplies(ctx context.Context, uw uow.UnitOfWork, id string) []types.Issue {
+	deps, err := uw.DependencyUseCase().ListWithIssueMetadata(ctx, id, domain.DepListFilter{
+		Types:     []types.DependencyType{types.DepRepliesTo},
+		Direction: domain.DepDirectionIn,
+	})
+	if err != nil {
+		return nil
+	}
+	out := make([]types.Issue, 0, len(deps))
+	for _, d := range deps {
+		out = append(out, d.Issue)
+	}
+	return out
+}
+
+func runShowProxiedDefault(ctx context.Context, uw uow.UnitOfWork, in *showProxiedInput) {
+	formatTime := func(t time.Time) string {
+		if in.localTime {
+			t = t.Local()
+		}
+		return t.Format("2006-01-02 15:04")
+	}
+
+	var allDetails []interface{}
+	foundCount := 0
+	for idx, id := range in.ids {
+		issue, isWisp, err := proxiedGetIssueOrWisp(ctx, uw, id)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error fetching %s: %v\n", id, err)
+			continue
+		}
+		if issue == nil {
+			fmt.Fprintf(os.Stderr, "Issue %s not found\n", id)
+			continue
+		}
+		foundCount++
+
+		if in.shortMode {
+			fmt.Println(formatShortIssue(issue))
+			continue
+		}
+
+		if jsonOutput {
+			details := proxiedBuildDetails(ctx, uw, issue, isWisp, in)
+			allDetails = append(allDetails, details)
+			continue
+		}
+
+		proxiedRenderIssue(ctx, uw, issue, isWisp, in, idx, formatTime)
+	}
+
+	if jsonOutput {
+		if len(allDetails) > 0 {
+			outputJSON(allDetails)
+		} else {
+			FatalErrorRespectJSON("no issues found matching the provided IDs")
+		}
+	} else if foundCount == 0 {
+		os.Exit(1)
+	}
+}
+
+func proxiedBuildDetails(ctx context.Context, uw uow.UnitOfWork, issue *types.Issue, isWisp bool, in *showProxiedInput) *types.IssueDetails {
+	details := &types.IssueDetails{Issue: *issue}
+
+	if isWisp {
+		details.Labels, _ = uw.LabelUseCase().GetWispLabels(ctx, issue.ID)
+	} else {
+		details.Labels, _ = uw.LabelUseCase().GetLabels(ctx, issue.ID)
+	}
+
+	deps, _ := proxiedListDeps(ctx, uw, issue.ID, isWisp, domain.DepListFilter{Direction: domain.DepDirectionOut})
+	details.Dependencies = deps
+
+	depCount, _ := proxiedCountDeps(ctx, uw, issue.ID, isWisp, domain.DepListFilter{Direction: domain.DepDirectionIn})
+	details.DependentCount = &depCount
+	depnCount, _ := proxiedCountDeps(ctx, uw, issue.ID, isWisp, domain.DepListFilter{Direction: domain.DepDirectionOut})
+	details.DependencyCount = &depnCount
+	cmtCount, _ := proxiedCountComments(ctx, uw, issue.ID, isWisp)
+	details.CommentCount = &cmtCount
+
+	if in.includeDepends {
+		dependents, err := proxiedListDeps(ctx, uw, issue.ID, isWisp, domain.DepListFilter{Direction: domain.DepDirectionIn})
+		if err == nil {
+			shallow := make([]*types.IssueWithDependencyMetadata, 0, len(dependents))
+			for _, item := range dependents {
+				shallow = append(shallow, &types.IssueWithDependencyMetadata{
+					Issue: types.Issue{
+						ID:        item.ID,
+						Status:    item.Status,
+						IssueType: item.IssueType,
+						Priority:  item.Priority,
+						Title:     item.Title,
+					},
+					DependencyType: item.DependencyType,
+				})
+			}
+			details.Dependents = shallow
+
+			if issue.IssueType == types.TypeEpic && len(shallow) > 0 {
+				total, closed := 0, 0
+				for _, dep := range shallow {
+					if dep.DependencyType == types.DepParentChild {
+						total++
+						if dep.Status == types.StatusClosed {
+							closed++
+						}
+					}
+				}
+				if total > 0 {
+					details.EpicTotalChildren = &total
+					details.EpicClosedChildren = &closed
+					closeable := total == closed
+					details.EpicCloseable = &closeable
+				}
+			}
+		}
+	}
+
+	if in.includeComments {
+		comments, err := proxiedGetComments(ctx, uw, issue.ID, isWisp)
+		if err == nil {
+			details.Comments = comments
+		}
+	}
+
+	for _, dep := range details.Dependencies {
+		if dep.DependencyType == types.DepParentChild {
+			parentID := dep.ID
+			details.Parent = &parentID
+			break
+		}
+	}
+	return details
+}
+
+func proxiedRenderIssue(ctx context.Context, uw uow.UnitOfWork, issue *types.Issue, isWisp bool, in *showProxiedInput, idx int, formatTime func(time.Time) string) {
+	if idx > 0 {
+		fmt.Println("\n" + ui.RenderMuted(strings.Repeat("─", 60)))
+		fmt.Printf("\n%s\n", formatIssueHeader(issue))
+	} else {
+		fmt.Printf("%s\n", formatIssueHeader(issue))
+	}
+	fmt.Println(formatIssueMetadata(issue))
+
+	if issue.CompactionLevel > 0 && issue.OriginalSize > 0 {
+		currentSize := len(issue.Description) + len(issue.Design) + len(issue.Notes) + len(issue.AcceptanceCriteria)
+		saved := issue.OriginalSize - currentSize
+		if saved > 0 {
+			reduction := float64(saved) / float64(issue.OriginalSize) * 100
+			fmt.Println()
+			fmt.Printf("📊 %d → %d bytes (%.0f%% reduction)\n", issue.OriginalSize, currentSize, reduction)
+		}
+	}
+
+	if issue.Description != "" {
+		fmt.Printf("\n%s\n%s\n", ui.RenderBold("DESCRIPTION"), uimd.RenderMarkdown(issue.Description))
+	} else {
+		fmt.Printf("\n%s\n  %s\n", ui.RenderBold("DESCRIPTION"), ui.RenderMuted("(none)"))
+	}
+	if issue.Design != "" {
+		fmt.Printf("\n%s\n%s\n", ui.RenderBold("DESIGN"), uimd.RenderMarkdown(issue.Design))
+	}
+	if issue.Notes != "" {
+		fmt.Printf("\n%s\n%s\n", ui.RenderBold("NOTES"), uimd.RenderMarkdown(issue.Notes))
+	}
+	if issue.AcceptanceCriteria != "" {
+		fmt.Printf("\n%s\n%s\n", ui.RenderBold("ACCEPTANCE CRITERIA"), uimd.RenderMarkdown(issue.AcceptanceCriteria))
+	}
+
+	var labels []string
+	if isWisp {
+		labels, _ = uw.LabelUseCase().GetWispLabels(ctx, issue.ID)
+	} else {
+		labels, _ = uw.LabelUseCase().GetLabels(ctx, issue.ID)
+	}
+	if len(labels) > 0 {
+		fmt.Printf("\n%s %s\n", ui.RenderBold("LABELS:"), strings.Join(labels, ", "))
+	}
+
+	if metaStr := formatIssueCustomMetadata(issue); metaStr != "" {
+		fmt.Printf("\n%s\n", metaStr)
+	}
+
+	relatedSeen := make(map[string]*types.IssueWithDependencyMetadata)
+
+	depsWithMeta, _ := proxiedListDeps(ctx, uw, issue.ID, isWisp, domain.DepListFilter{Direction: domain.DepDirectionOut})
+	if len(depsWithMeta) > 0 {
+		var blocks, parent, discovered []*types.IssueWithDependencyMetadata
+		for _, dep := range depsWithMeta {
+			switch dep.DependencyType {
+			case types.DepBlocks:
+				blocks = append(blocks, dep)
+			case types.DepParentChild:
+				parent = append(parent, dep)
+			case types.DepRelated, types.DepRelatesTo:
+				relatedSeen[dep.ID] = dep
+			case types.DepDiscoveredFrom:
+				discovered = append(discovered, dep)
+			default:
+				blocks = append(blocks, dep)
+			}
+		}
+		if len(parent) > 0 {
+			fmt.Printf("\n%s\n", ui.RenderBold("PARENT"))
+			for _, dep := range parent {
+				fmt.Println(formatDependencyLine("↑", dep))
+			}
+		}
+		if len(blocks) > 0 {
+			fmt.Printf("\n%s\n", ui.RenderBold("DEPENDS ON"))
+			for _, dep := range blocks {
+				fmt.Println(formatDependencyLine("→", dep))
+			}
+		}
+		if len(discovered) > 0 {
+			fmt.Printf("\n%s\n", ui.RenderBold("DISCOVERED FROM"))
+			for _, dep := range discovered {
+				fmt.Println(formatDependencyLine("◊", dep))
+			}
+		}
+	}
+
+	dependentsWithMeta, _ := proxiedListDeps(ctx, uw, issue.ID, isWisp, domain.DepListFilter{Direction: domain.DepDirectionIn})
+	if len(dependentsWithMeta) > 0 {
+		var blocks, children, discovered []*types.IssueWithDependencyMetadata
+		for _, dep := range dependentsWithMeta {
+			switch dep.DependencyType {
+			case types.DepBlocks:
+				blocks = append(blocks, dep)
+			case types.DepParentChild:
+				children = append(children, dep)
+			case types.DepRelated, types.DepRelatesTo:
+				relatedSeen[dep.ID] = dep
+			case types.DepDiscoveredFrom:
+				discovered = append(discovered, dep)
+			default:
+				blocks = append(blocks, dep)
+			}
+		}
+		if len(children) > 0 {
+			fmt.Printf("\n%s\n", ui.RenderBold("CHILDREN"))
+			for _, dep := range children {
+				fmt.Println(formatDependencyLine("↳", dep))
+			}
+			if issue.IssueType == types.TypeEpic {
+				closedCount := 0
+				for _, dep := range children {
+					if dep.Status == types.StatusClosed {
+						closedCount++
+					}
+				}
+				pct := 0
+				if len(children) > 0 {
+					pct = (closedCount * 100) / len(children)
+				}
+				if closedCount == len(children) {
+					fmt.Printf("  %s %d/%d complete (%d%%) — eligible for close\n", ui.RenderPass("✓"), closedCount, len(children), pct)
+				} else {
+					fmt.Printf("  %s %d/%d complete (%d%%)\n", ui.RenderMuted("◐"), closedCount, len(children), pct)
+				}
+			}
+		}
+		if len(blocks) > 0 {
+			fmt.Printf("\n%s\n", ui.RenderBold("BLOCKS"))
+			for _, dep := range blocks {
+				fmt.Println(formatDependencyLine("←", dep))
+			}
+		}
+		if len(discovered) > 0 {
+			fmt.Printf("\n%s\n", ui.RenderBold("DISCOVERED"))
+			for _, dep := range discovered {
+				fmt.Println(formatDependencyLine("◊", dep))
+			}
+		}
+	}
+
+	if len(relatedSeen) > 0 {
+		fmt.Printf("\n%s\n", ui.RenderBold("RELATED"))
+		ids := make([]string, 0, len(relatedSeen))
+		for k := range relatedSeen {
+			ids = append(ids, k)
+		}
+		sort.Strings(ids)
+		for _, k := range ids {
+			fmt.Println(formatDependencyLine("↔", relatedSeen[k]))
+		}
+	}
+
+	comments, _ := proxiedGetComments(ctx, uw, issue.ID, isWisp)
+	if len(comments) > 0 {
+		fmt.Printf("\n%s\n", ui.RenderBold("COMMENTS"))
+		for _, c := range comments {
+			fmt.Printf("  %s %s\n", ui.RenderMuted(formatTime(c.CreatedAt)), c.Author)
+			rendered := uimd.RenderMarkdown(c.Text)
+			for _, line := range strings.Split(strings.TrimRight(rendered, "\n"), "\n") {
+				fmt.Printf("    %s\n", line)
+			}
+		}
+	}
+
+	if in.longMode {
+		fmt.Print(formatIssueLongExtras(issue, formatTime))
+	}
+
+	fmt.Println()
+}

--- a/internal/storage/domain/comment.go
+++ b/internal/storage/domain/comment.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/types"
 )
 
@@ -14,14 +15,21 @@ type CommentOpts struct {
 type CommentSQLRepository interface {
 	CountsByIssueIDs(ctx context.Context, issueIDs []string, opts CommentOpts) (map[string]int, error)
 	ListByIssueIDs(ctx context.Context, issueIDs []string, opts CommentOpts) (map[string][]*types.Comment, error)
+	IterByIssueID(ctx context.Context, issueID string, opts CommentOpts) (storage.Iter[types.Comment], error)
 }
 
 type CommentUseCase interface {
 	GetCommentCounts(ctx context.Context, issueIDs []string) (map[string]int, error)
 	GetCommentsForIssues(ctx context.Context, issueIDs []string) (map[string][]*types.Comment, error)
+	GetCommentsForIssue(ctx context.Context, issueID string) ([]*types.Comment, error)
+	CountCommentsForIssue(ctx context.Context, issueID string) (int64, error)
+	IterCommentsForIssue(ctx context.Context, issueID string) (storage.Iter[types.Comment], error)
 
 	GetWispCommentCounts(ctx context.Context, wispIDs []string) (map[string]int, error)
 	GetCommentsForWisps(ctx context.Context, wispIDs []string) (map[string][]*types.Comment, error)
+	GetCommentsForWisp(ctx context.Context, wispID string) ([]*types.Comment, error)
+	CountCommentsForWisp(ctx context.Context, wispID string) (int64, error)
+	IterCommentsForWisp(ctx context.Context, wispID string) (storage.Iter[types.Comment], error)
 }
 
 func NewCommentUseCase(commentRepo CommentSQLRepository) CommentUseCase {
@@ -57,8 +65,65 @@ func (u *commentUseCaseImpl) GetCommentsForIssues(ctx context.Context, issueIDs 
 	return u.list(ctx, issueIDs, false)
 }
 
+func (u *commentUseCaseImpl) GetCommentsForIssue(ctx context.Context, issueID string) ([]*types.Comment, error) {
+	return u.listOne(ctx, issueID, false)
+}
+
+func (u *commentUseCaseImpl) CountCommentsForIssue(ctx context.Context, issueID string) (int64, error) {
+	return u.countOne(ctx, issueID, false)
+}
+
+func (u *commentUseCaseImpl) IterCommentsForIssue(ctx context.Context, issueID string) (storage.Iter[types.Comment], error) {
+	return u.iterOne(ctx, issueID, false)
+}
+
 func (u *commentUseCaseImpl) GetCommentsForWisps(ctx context.Context, wispIDs []string) (map[string][]*types.Comment, error) {
 	return u.list(ctx, wispIDs, true)
+}
+
+func (u *commentUseCaseImpl) GetCommentsForWisp(ctx context.Context, wispID string) ([]*types.Comment, error) {
+	return u.listOne(ctx, wispID, true)
+}
+
+func (u *commentUseCaseImpl) CountCommentsForWisp(ctx context.Context, wispID string) (int64, error) {
+	return u.countOne(ctx, wispID, true)
+}
+
+func (u *commentUseCaseImpl) IterCommentsForWisp(ctx context.Context, wispID string) (storage.Iter[types.Comment], error) {
+	return u.iterOne(ctx, wispID, true)
+}
+
+func (u *commentUseCaseImpl) listOne(ctx context.Context, id string, useWisp bool) ([]*types.Comment, error) {
+	if id == "" {
+		return nil, fmt.Errorf("comment list: id must not be empty")
+	}
+	out, err := u.commentRepo.ListByIssueIDs(ctx, []string{id}, CommentOpts{UseWispsTable: useWisp})
+	if err != nil {
+		return nil, fmt.Errorf("comment list: %w", err)
+	}
+	return out[id], nil
+}
+
+func (u *commentUseCaseImpl) countOne(ctx context.Context, id string, useWisp bool) (int64, error) {
+	if id == "" {
+		return 0, fmt.Errorf("comment count: id must not be empty")
+	}
+	out, err := u.commentRepo.CountsByIssueIDs(ctx, []string{id}, CommentOpts{UseWispsTable: useWisp})
+	if err != nil {
+		return 0, fmt.Errorf("comment count: %w", err)
+	}
+	return int64(out[id]), nil
+}
+
+func (u *commentUseCaseImpl) iterOne(ctx context.Context, id string, useWisp bool) (storage.Iter[types.Comment], error) {
+	if id == "" {
+		return nil, fmt.Errorf("comment iter: id must not be empty")
+	}
+	it, err := u.commentRepo.IterByIssueID(ctx, id, CommentOpts{UseWispsTable: useWisp})
+	if err != nil {
+		return nil, fmt.Errorf("comment iter: %w", err)
+	}
+	return it, nil
 }
 
 func (u *commentUseCaseImpl) list(ctx context.Context, ids []string, useWisp bool) (map[string][]*types.Comment, error) {

--- a/internal/storage/domain/db/comment.go
+++ b/internal/storage/domain/db/comment.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/storage/domain"
 	"github.com/steveyegge/beads/internal/types"
 )
@@ -100,4 +101,12 @@ func (r *commentSQLRepositoryImpl) ListByIssueIDs(ctx context.Context, issueIDs 
 		return nil, fmt.Errorf("db: CommentSQLRepository.ListByIssueIDs: rows: %w", err)
 	}
 	return result, nil
+}
+
+func (r *commentSQLRepositoryImpl) IterByIssueID(ctx context.Context, issueID string, opts domain.CommentOpts) (storage.Iter[types.Comment], error) {
+	bulk, err := r.ListByIssueIDs(ctx, []string{issueID}, opts)
+	if err != nil {
+		return nil, err
+	}
+	return storage.NewSliceIter(bulk[issueID]), nil
 }

--- a/internal/storage/domain/db/comment_iter_test.go
+++ b/internal/storage/domain/db/comment_iter_test.go
@@ -1,0 +1,85 @@
+package db
+
+import (
+	"context"
+	"time"
+
+	"github.com/steveyegge/beads/internal/storage/domain"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+func (s *testSuite) TestCommentSQLRepositoryIter() {
+	s.Run("IterByIssueID", func() {
+		s.Run("StreamsInCreationOrder", s.commentIterOrdered)
+		s.Run("EmptyIssueProducesEmptyIter", s.commentIterEmpty)
+		s.Run("WispRouting", s.commentIterWispRouting)
+		s.Run("WispOptDoesNotPickUpPerm", s.commentIterCrossRoutingIsolated)
+	})
+}
+
+func (s *testSuite) commentIterOrdered() {
+	s.seedIssueRow("bd-cmt-it-1")
+	base := time.Now().UTC().Truncate(time.Second)
+	s.seedComment("bd-cmt-it-1", "a", "second", base.Add(time.Second))
+	s.seedComment("bd-cmt-it-1", "a", "first", base)
+	s.seedComment("bd-cmt-it-1", "a", "third", base.Add(2*time.Second))
+
+	it, err := s.commentRepo().IterByIssueID(s.Ctx(), "bd-cmt-it-1", domain.CommentOpts{})
+	s.Require().NoError(err)
+	defer it.Close() //nolint:errcheck
+
+	var texts []string
+	for it.Next(context.Background()) {
+		c := it.Value()
+		texts = append(texts, c.Text)
+	}
+	s.Require().NoError(it.Err())
+	s.Equal([]string{"first", "second", "third"}, texts)
+}
+
+func (s *testSuite) commentIterEmpty() {
+	s.seedIssueRow("bd-cmt-it-empty")
+	it, err := s.commentRepo().IterByIssueID(s.Ctx(), "bd-cmt-it-empty", domain.CommentOpts{})
+	s.Require().NoError(err)
+	defer it.Close() //nolint:errcheck
+	s.False(it.Next(context.Background()))
+	s.NoError(it.Err())
+}
+
+func (s *testSuite) commentIterWispRouting() {
+	s.seedWispRow("bd-cmt-it-wisp")
+	base := time.Now().UTC().Truncate(time.Second)
+	s.seedWispComment("bd-cmt-it-wisp", "a", "wisp first", base)
+	s.seedWispComment("bd-cmt-it-wisp", "a", "wisp second", base.Add(time.Second))
+
+	it, err := s.commentRepo().IterByIssueID(s.Ctx(), "bd-cmt-it-wisp", domain.CommentOpts{UseWispsTable: true})
+	s.Require().NoError(err)
+	defer it.Close() //nolint:errcheck
+
+	var items []*types.Comment
+	for it.Next(context.Background()) {
+		items = append(items, it.Value())
+	}
+	s.Require().NoError(it.Err())
+	s.Require().Len(items, 2)
+	s.Equal("wisp first", items[0].Text)
+	s.Equal("wisp second", items[1].Text)
+}
+
+func (s *testSuite) commentIterCrossRoutingIsolated() {
+	s.seedIssueRow("bd-cmt-it-perm")
+	s.seedWispRow("bd-cmt-it-w2")
+	now := time.Now().UTC()
+	s.seedComment("bd-cmt-it-perm", "a", "perm", now)
+	s.seedWispComment("bd-cmt-it-w2", "a", "wisp", now)
+
+	itPerm, err := s.commentRepo().IterByIssueID(s.Ctx(), "bd-cmt-it-w2", domain.CommentOpts{})
+	s.Require().NoError(err)
+	s.False(itPerm.Next(context.Background()), "perm-table iter for wisp ID must yield nothing")
+	_ = itPerm.Close()
+
+	itWisp, err := s.commentRepo().IterByIssueID(s.Ctx(), "bd-cmt-it-perm", domain.CommentOpts{UseWispsTable: true})
+	s.Require().NoError(err)
+	s.False(itWisp.Next(context.Background()), "wisp-table iter for perm ID must yield nothing")
+	_ = itWisp.Close()
+}

--- a/internal/storage/domain/db/comment_usecase_test.go
+++ b/internal/storage/domain/db/comment_usecase_test.go
@@ -1,0 +1,142 @@
+package db
+
+import (
+	"context"
+	"time"
+
+	"github.com/steveyegge/beads/internal/storage/domain"
+)
+
+func (s *testSuite) TestCommentUseCase() {
+	s.Run("Issue", func() {
+		s.Run("GetCommentsForIssueReturnsSlice", s.commentUCGetSlice)
+		s.Run("CountCommentsForIssueReturnsCount", s.commentUCCount)
+		s.Run("IterCommentsForIssueStreamsSameRows", s.commentUCIterMatches)
+		s.Run("MissingIssueReturnsEmptySlice", s.commentUCGetMissingEmpty)
+		s.Run("MissingIssueReturnsZeroCount", s.commentUCCountMissingZero)
+		s.Run("EmptyIDRejected", s.commentUCEmptyIDs)
+	})
+	s.Run("Wisp", func() {
+		s.Run("GetCommentsForWispRoutes", s.commentUCWispGet)
+		s.Run("CountCommentsForWispRoutes", s.commentUCWispCount)
+		s.Run("PermLookupOfWispCommentsReturnsEmpty", s.commentUCWispIsolated)
+	})
+}
+
+func (s *testSuite) commentUseCase() domain.CommentUseCase {
+	return domain.NewCommentUseCase(NewCommentSQLRepository(s.Runner()))
+}
+
+func (s *testSuite) commentUCGetSlice() {
+	s.seedIssueRow("bd-cuc-get")
+	base := time.Now().UTC().Truncate(time.Second)
+	s.seedComment("bd-cuc-get", "a", "first", base)
+	s.seedComment("bd-cuc-get", "a", "second", base.Add(time.Second))
+
+	out, err := s.commentUseCase().GetCommentsForIssue(s.Ctx(), "bd-cuc-get")
+	s.Require().NoError(err)
+	s.Require().Len(out, 2)
+	s.Equal("first", out[0].Text)
+	s.Equal("second", out[1].Text)
+}
+
+func (s *testSuite) commentUCCount() {
+	s.seedIssueRow("bd-cuc-cnt")
+	now := time.Now().UTC()
+	s.seedComment("bd-cuc-cnt", "a", "x", now)
+	s.seedComment("bd-cuc-cnt", "a", "y", now)
+	s.seedComment("bd-cuc-cnt", "a", "z", now)
+
+	n, err := s.commentUseCase().CountCommentsForIssue(s.Ctx(), "bd-cuc-cnt")
+	s.Require().NoError(err)
+	s.Equal(int64(3), n)
+}
+
+func (s *testSuite) commentUCIterMatches() {
+	s.seedIssueRow("bd-cuc-iter")
+	base := time.Now().UTC().Truncate(time.Second)
+	s.seedComment("bd-cuc-iter", "a", "alpha", base)
+	s.seedComment("bd-cuc-iter", "a", "beta", base.Add(time.Second))
+
+	list, err := s.commentUseCase().GetCommentsForIssue(s.Ctx(), "bd-cuc-iter")
+	s.Require().NoError(err)
+
+	it, err := s.commentUseCase().IterCommentsForIssue(s.Ctx(), "bd-cuc-iter")
+	s.Require().NoError(err)
+	defer it.Close() //nolint:errcheck
+
+	streamed := []string{}
+	for it.Next(context.Background()) {
+		streamed = append(streamed, it.Value().Text)
+	}
+	s.Require().NoError(it.Err())
+	s.Require().Len(streamed, len(list))
+	s.Equal("alpha", streamed[0])
+	s.Equal("beta", streamed[1])
+}
+
+func (s *testSuite) commentUCGetMissingEmpty() {
+	out, err := s.commentUseCase().GetCommentsForIssue(s.Ctx(), "bd-cuc-ghost")
+	s.Require().NoError(err)
+	s.Empty(out, "missing issue yields empty slice, not error")
+}
+
+func (s *testSuite) commentUCCountMissingZero() {
+	n, err := s.commentUseCase().CountCommentsForIssue(s.Ctx(), "bd-cuc-ghost-cnt")
+	s.Require().NoError(err)
+	s.Equal(int64(0), n)
+}
+
+func (s *testSuite) commentUCEmptyIDs() {
+	uc := s.commentUseCase()
+
+	_, err := uc.GetCommentsForIssue(s.Ctx(), "")
+	s.Require().Error(err)
+	s.Contains(err.Error(), "id must not be empty")
+
+	_, err = uc.CountCommentsForIssue(s.Ctx(), "")
+	s.Require().Error(err)
+
+	_, err = uc.IterCommentsForIssue(s.Ctx(), "")
+	s.Require().Error(err)
+
+	_, err = uc.GetCommentsForWisp(s.Ctx(), "")
+	s.Require().Error(err)
+
+	_, err = uc.CountCommentsForWisp(s.Ctx(), "")
+	s.Require().Error(err)
+
+	_, err = uc.IterCommentsForWisp(s.Ctx(), "")
+	s.Require().Error(err)
+}
+
+func (s *testSuite) commentUCWispGet() {
+	s.seedWispRow("bd-cuc-wisp-get")
+	now := time.Now().UTC()
+	s.seedWispComment("bd-cuc-wisp-get", "a", "wisp comment", now)
+
+	out, err := s.commentUseCase().GetCommentsForWisp(s.Ctx(), "bd-cuc-wisp-get")
+	s.Require().NoError(err)
+	s.Require().Len(out, 1)
+	s.Equal("wisp comment", out[0].Text)
+}
+
+func (s *testSuite) commentUCWispCount() {
+	s.seedWispRow("bd-cuc-wisp-cnt")
+	now := time.Now().UTC()
+	s.seedWispComment("bd-cuc-wisp-cnt", "a", "x", now)
+	s.seedWispComment("bd-cuc-wisp-cnt", "a", "y", now)
+
+	n, err := s.commentUseCase().CountCommentsForWisp(s.Ctx(), "bd-cuc-wisp-cnt")
+	s.Require().NoError(err)
+	s.Equal(int64(2), n)
+}
+
+func (s *testSuite) commentUCWispIsolated() {
+	s.seedWispRow("bd-cuc-wisp-iso")
+	s.seedWispComment("bd-cuc-wisp-iso", "a", "wisp only", time.Now().UTC())
+
+	out, err := s.commentUseCase().GetCommentsForIssue(s.Ctx(), "bd-cuc-wisp-iso")
+	s.Require().NoError(err)
+	s.Empty(out, "perm-table lookup must not pick up wisp comments")
+}

--- a/internal/storage/domain/db/dependency.go
+++ b/internal/storage/domain/db/dependency.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/storage/dberrors"
 	"github.com/steveyegge/beads/internal/storage/depid"
 	"github.com/steveyegge/beads/internal/storage/domain"
@@ -700,4 +701,52 @@ func (r *dependencySQLRepositoryImpl) CountAllForIDs(ctx context.Context, ids []
 		total += count
 	}
 	return total, nil
+}
+
+func (r *dependencySQLRepositoryImpl) ListWithIssueMetadata(ctx context.Context, sourceID string, opts domain.DepListOpts) ([]*types.IssueWithDependencyMetadata, error) {
+	var out []*types.IssueWithDependencyMetadata
+	if opts.Direction == domain.DepDirectionOut || opts.Direction == domain.DepDirectionBoth {
+		deps, err := issueops.GetDependenciesWithMetadataInTx(ctx, r.runner, sourceID)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, filterDepsByType(deps, opts.Types)...)
+	}
+	if opts.Direction == domain.DepDirectionIn || opts.Direction == domain.DepDirectionBoth {
+		deps, err := issueops.GetDependentsWithMetadataInTx(ctx, r.runner, sourceID)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, filterDepsByType(deps, opts.Types)...)
+	}
+	return out, nil
+}
+
+func (r *dependencySQLRepositoryImpl) IterWithIssueMetadata(ctx context.Context, sourceID string, opts domain.DepListOpts) (storage.Iter[types.IssueWithDependencyMetadata], error) {
+	items, err := r.ListWithIssueMetadata(ctx, sourceID, opts)
+	if err != nil {
+		return nil, err
+	}
+	return storage.NewSliceIter(items), nil
+}
+
+func (r *dependencySQLRepositoryImpl) CountByID(ctx context.Context, sourceID string, opts domain.DepListOpts) (int64, error) {
+	return issueops.CountDependencyEdgesInTx(ctx, r.runner, sourceID, opts.Direction, opts.Types)
+}
+
+func filterDepsByType(deps []*types.IssueWithDependencyMetadata, filter []types.DependencyType) []*types.IssueWithDependencyMetadata {
+	if len(filter) == 0 {
+		return deps
+	}
+	allowed := make(map[types.DependencyType]struct{}, len(filter))
+	for _, t := range filter {
+		allowed[t] = struct{}{}
+	}
+	out := make([]*types.IssueWithDependencyMetadata, 0, len(deps))
+	for _, d := range deps {
+		if _, ok := allowed[d.DependencyType]; ok {
+			out = append(out, d)
+		}
+	}
+	return out
 }

--- a/internal/storage/domain/db/dependency_metadata_test.go
+++ b/internal/storage/domain/db/dependency_metadata_test.go
@@ -1,0 +1,246 @@
+package db
+
+import (
+	"context"
+
+	"github.com/steveyegge/beads/internal/storage/domain"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+func (s *testSuite) TestDependencySQLRepositoryWithIssueMetadata() {
+	s.Run("ListWithIssueMetadata", func() {
+		s.Run("OutgoingHydratesTargetFields", s.depMetaListOutgoing)
+		s.Run("IncomingHydratesSourceFields", s.depMetaListIncoming)
+		s.Run("BothConcatenatesBoth", s.depMetaListBoth)
+		s.Run("TypeFilterApplied", s.depMetaListTypeFilter)
+		s.Run("EmptyWhenNoEdges", s.depMetaListEmpty)
+		s.Run("CrossesPermAndWispEdgeTables", s.depMetaListCrossTables)
+	})
+	s.Run("IterWithIssueMetadata", func() {
+		s.Run("StreamsSameRowsAsList", s.depMetaIterMatchesList)
+		s.Run("EmptyIteratorIsValid", s.depMetaIterEmpty)
+	})
+	s.Run("CountByID", func() {
+		s.Run("OutgoingSumsBothEdgeTables", s.depCountByIDOutgoing)
+		s.Run("IncomingSumsBothEdgeTables", s.depCountByIDIncoming)
+		s.Run("BothSumsAllEdges", s.depCountByIDBoth)
+		s.Run("TypeFilterApplied", s.depCountByIDTypeFilter)
+		s.Run("ReturnsZeroOnNoEdges", s.depCountByIDZero)
+	})
+}
+
+func (s *testSuite) seedBlocksEdge(issueID, dependsOnID string) {
+	s.Require().NoError(s.depRepo().Insert(s.Ctx(),
+		newDep(issueID, dependsOnID, types.DepBlocks), "tester", domain.DepInsertOpts{}))
+}
+
+func (s *testSuite) depMetaListOutgoing() {
+	s.seedIssueRow("bd-meta-out-src")
+	s.seedIssueRow("bd-meta-out-t1")
+	s.seedIssueRow("bd-meta-out-t2")
+	_, err := s.Runner().ExecContext(s.Ctx(),
+		"UPDATE issues SET title = ?, priority = ?, status = ? WHERE id = ?",
+		"target one", 1, string(types.StatusInProgress), "bd-meta-out-t1")
+	s.Require().NoError(err)
+	s.seedBlocksEdge("bd-meta-out-src", "bd-meta-out-t1")
+	s.seedBlocksEdge("bd-meta-out-src", "bd-meta-out-t2")
+
+	out, err := s.depRepo().ListWithIssueMetadata(s.Ctx(), "bd-meta-out-src",
+		domain.DepListOpts{Direction: domain.DepDirectionOut})
+	s.Require().NoError(err)
+	s.Require().Len(out, 2)
+	got := make(map[string]*types.IssueWithDependencyMetadata, len(out))
+	for _, d := range out {
+		got[d.ID] = d
+	}
+	s.Require().NotNil(got["bd-meta-out-t1"])
+	s.Equal(types.DepBlocks, got["bd-meta-out-t1"].DependencyType)
+	s.NotEmpty(got["bd-meta-out-t1"].Title, "joined issue row title must be hydrated")
+}
+
+func (s *testSuite) depMetaListIncoming() {
+	s.seedIssueRow("bd-meta-in-tgt")
+	s.seedIssueRow("bd-meta-in-s1")
+	s.seedIssueRow("bd-meta-in-s2")
+	s.seedBlocksEdge("bd-meta-in-s1", "bd-meta-in-tgt")
+	s.seedBlocksEdge("bd-meta-in-s2", "bd-meta-in-tgt")
+
+	out, err := s.depRepo().ListWithIssueMetadata(s.Ctx(), "bd-meta-in-tgt",
+		domain.DepListOpts{Direction: domain.DepDirectionIn})
+	s.Require().NoError(err)
+	s.Require().Len(out, 2)
+	for _, d := range out {
+		s.Equal(types.DepBlocks, d.DependencyType)
+		s.NotEmpty(d.ID)
+	}
+}
+
+func (s *testSuite) depMetaListBoth() {
+	s.seedIssueRow("bd-meta-both-x")
+	s.seedIssueRow("bd-meta-both-up")
+	s.seedIssueRow("bd-meta-both-down")
+	s.seedBlocksEdge("bd-meta-both-x", "bd-meta-both-up")
+	s.seedBlocksEdge("bd-meta-both-down", "bd-meta-both-x")
+
+	out, err := s.depRepo().ListWithIssueMetadata(s.Ctx(), "bd-meta-both-x",
+		domain.DepListOpts{Direction: domain.DepDirectionBoth})
+	s.Require().NoError(err)
+	s.Require().Len(out, 2, "Both returns outgoing + incoming concatenated")
+	seen := map[string]bool{}
+	for _, d := range out {
+		seen[d.ID] = true
+	}
+	s.True(seen["bd-meta-both-up"])
+	s.True(seen["bd-meta-both-down"])
+}
+
+func (s *testSuite) depMetaListTypeFilter() {
+	s.seedIssueRow("bd-meta-tf-src")
+	s.seedIssueRow("bd-meta-tf-bl")
+	s.seedIssueRow("bd-meta-tf-rel")
+	s.Require().NoError(s.depRepo().Insert(s.Ctx(),
+		newDep("bd-meta-tf-src", "bd-meta-tf-bl", types.DepBlocks), "tester", domain.DepInsertOpts{}))
+	s.Require().NoError(s.depRepo().Insert(s.Ctx(),
+		newDep("bd-meta-tf-src", "bd-meta-tf-rel", types.DepRelated), "tester", domain.DepInsertOpts{}))
+
+	out, err := s.depRepo().ListWithIssueMetadata(s.Ctx(), "bd-meta-tf-src",
+		domain.DepListOpts{
+			Direction: domain.DepDirectionOut,
+			Types:     []types.DependencyType{types.DepBlocks},
+		})
+	s.Require().NoError(err)
+	s.Require().Len(out, 1)
+	s.Equal("bd-meta-tf-bl", out[0].ID)
+	s.Equal(types.DepBlocks, out[0].DependencyType)
+}
+
+func (s *testSuite) depMetaListEmpty() {
+	s.seedIssueRow("bd-meta-empty")
+	out, err := s.depRepo().ListWithIssueMetadata(s.Ctx(), "bd-meta-empty",
+		domain.DepListOpts{Direction: domain.DepDirectionBoth})
+	s.Require().NoError(err)
+	s.Empty(out)
+}
+
+func (s *testSuite) depMetaListCrossTables() {
+	s.seedIssueRow("bd-meta-x-tgt")
+	s.seedIssueRow("bd-meta-x-perm-src")
+	s.seedWispRow("bd-meta-x-wisp-src")
+
+	s.Require().NoError(s.depRepo().Insert(s.Ctx(),
+		newDep("bd-meta-x-perm-src", "bd-meta-x-tgt", types.DepBlocks), "tester", domain.DepInsertOpts{}))
+	s.Require().NoError(s.depRepo().Insert(s.Ctx(),
+		newDep("bd-meta-x-wisp-src", "bd-meta-x-tgt", types.DepBlocks), "tester", domain.DepInsertOpts{UseWispsTable: true}))
+
+	out, err := s.depRepo().ListWithIssueMetadata(s.Ctx(), "bd-meta-x-tgt",
+		domain.DepListOpts{Direction: domain.DepDirectionIn})
+	s.Require().NoError(err)
+	s.Require().Len(out, 2, "Incoming must union dependencies + wisp_dependencies")
+
+	n, err := s.depRepo().CountByID(s.Ctx(), "bd-meta-x-tgt",
+		domain.DepListOpts{Direction: domain.DepDirectionIn})
+	s.Require().NoError(err)
+	s.Equal(int64(2), n, "CountByID Incoming must sum both edge tables")
+}
+
+func (s *testSuite) depMetaIterMatchesList() {
+	s.seedIssueRow("bd-meta-iter-src")
+	s.seedIssueRow("bd-meta-iter-a")
+	s.seedIssueRow("bd-meta-iter-b")
+	s.seedBlocksEdge("bd-meta-iter-src", "bd-meta-iter-a")
+	s.seedBlocksEdge("bd-meta-iter-src", "bd-meta-iter-b")
+
+	opts := domain.DepListOpts{Direction: domain.DepDirectionOut}
+	list, err := s.depRepo().ListWithIssueMetadata(s.Ctx(), "bd-meta-iter-src", opts)
+	s.Require().NoError(err)
+
+	it, err := s.depRepo().IterWithIssueMetadata(s.Ctx(), "bd-meta-iter-src", opts)
+	s.Require().NoError(err)
+	defer it.Close() //nolint:errcheck
+
+	var streamed []*types.IssueWithDependencyMetadata
+	for it.Next(context.Background()) {
+		streamed = append(streamed, it.Value())
+	}
+	s.Require().NoError(it.Err())
+	s.Equal(len(list), len(streamed))
+}
+
+func (s *testSuite) depMetaIterEmpty() {
+	s.seedIssueRow("bd-meta-iter-empty")
+	it, err := s.depRepo().IterWithIssueMetadata(s.Ctx(), "bd-meta-iter-empty",
+		domain.DepListOpts{Direction: domain.DepDirectionBoth})
+	s.Require().NoError(err)
+	defer it.Close() //nolint:errcheck
+	s.False(it.Next(context.Background()))
+	s.NoError(it.Err())
+}
+
+func (s *testSuite) depCountByIDOutgoing() {
+	s.seedIssueRow("bd-cbi-out-src")
+	s.seedIssueRow("bd-cbi-out-a")
+	s.seedIssueRow("bd-cbi-out-b")
+	s.seedBlocksEdge("bd-cbi-out-src", "bd-cbi-out-a")
+	s.seedBlocksEdge("bd-cbi-out-src", "bd-cbi-out-b")
+
+	n, err := s.depRepo().CountByID(s.Ctx(), "bd-cbi-out-src",
+		domain.DepListOpts{Direction: domain.DepDirectionOut})
+	s.Require().NoError(err)
+	s.Equal(int64(2), n)
+}
+
+func (s *testSuite) depCountByIDIncoming() {
+	s.seedIssueRow("bd-cbi-in-tgt")
+	s.seedIssueRow("bd-cbi-in-s1")
+	s.seedIssueRow("bd-cbi-in-s2")
+	s.seedIssueRow("bd-cbi-in-s3")
+	s.seedBlocksEdge("bd-cbi-in-s1", "bd-cbi-in-tgt")
+	s.seedBlocksEdge("bd-cbi-in-s2", "bd-cbi-in-tgt")
+	s.seedBlocksEdge("bd-cbi-in-s3", "bd-cbi-in-tgt")
+
+	n, err := s.depRepo().CountByID(s.Ctx(), "bd-cbi-in-tgt",
+		domain.DepListOpts{Direction: domain.DepDirectionIn})
+	s.Require().NoError(err)
+	s.Equal(int64(3), n)
+}
+
+func (s *testSuite) depCountByIDBoth() {
+	s.seedIssueRow("bd-cbi-both-x")
+	s.seedIssueRow("bd-cbi-both-up")
+	s.seedIssueRow("bd-cbi-both-down-a")
+	s.seedIssueRow("bd-cbi-both-down-b")
+	s.seedBlocksEdge("bd-cbi-both-x", "bd-cbi-both-up")
+	s.seedBlocksEdge("bd-cbi-both-down-a", "bd-cbi-both-x")
+	s.seedBlocksEdge("bd-cbi-both-down-b", "bd-cbi-both-x")
+
+	n, err := s.depRepo().CountByID(s.Ctx(), "bd-cbi-both-x",
+		domain.DepListOpts{Direction: domain.DepDirectionBoth})
+	s.Require().NoError(err)
+	s.Equal(int64(3), n, "Both must sum outgoing (1) and incoming (2)")
+}
+
+func (s *testSuite) depCountByIDTypeFilter() {
+	s.seedIssueRow("bd-cbi-tf-src")
+	s.seedIssueRow("bd-cbi-tf-bl")
+	s.seedIssueRow("bd-cbi-tf-rel")
+	s.Require().NoError(s.depRepo().Insert(s.Ctx(),
+		newDep("bd-cbi-tf-src", "bd-cbi-tf-bl", types.DepBlocks), "tester", domain.DepInsertOpts{}))
+	s.Require().NoError(s.depRepo().Insert(s.Ctx(),
+		newDep("bd-cbi-tf-src", "bd-cbi-tf-rel", types.DepRelated), "tester", domain.DepInsertOpts{}))
+
+	n, err := s.depRepo().CountByID(s.Ctx(), "bd-cbi-tf-src",
+		domain.DepListOpts{
+			Direction: domain.DepDirectionOut,
+			Types:     []types.DependencyType{types.DepBlocks},
+		})
+	s.Require().NoError(err)
+	s.Equal(int64(1), n)
+}
+
+func (s *testSuite) depCountByIDZero() {
+	s.seedIssueRow("bd-cbi-zero")
+	n, err := s.depRepo().CountByID(s.Ctx(), "bd-cbi-zero",
+		domain.DepListOpts{Direction: domain.DepDirectionBoth})
+	s.Require().NoError(err)
+	s.Equal(int64(0), n)
+}

--- a/internal/storage/domain/db/dependency_usecase_metadata_test.go
+++ b/internal/storage/domain/db/dependency_usecase_metadata_test.go
@@ -1,0 +1,144 @@
+package db
+
+import (
+	"context"
+
+	"github.com/steveyegge/beads/internal/storage/domain"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+func (s *testSuite) TestDependencyUseCaseWithIssueMetadata() {
+	s.Run("ListWithIssueMetadata", func() {
+		s.Run("OutgoingDelegates", s.depUCListMetaOutgoing)
+		s.Run("TypeFilterDelegates", s.depUCListMetaTypeFilter)
+		s.Run("EmptyIDRejected", s.depUCListMetaEmptyID)
+	})
+	s.Run("IterWithIssueMetadata", func() {
+		s.Run("StreamsSameRowsAsList", s.depUCIterMetaMatchesList)
+		s.Run("EmptyIDRejected", s.depUCIterMetaEmptyID)
+	})
+	s.Run("CountByIssueID", func() {
+		s.Run("BothSumsIncomingAndOutgoing", s.depUCCountByIDBoth)
+		s.Run("EmptyIDRejected", s.depUCCountByIDEmptyID)
+	})
+	s.Run("Wisp", func() {
+		s.Run("ListRoutesToWispOnSourceEdge", s.depUCWispListRouting)
+		s.Run("CountRoutesToWispOnSourceEdge", s.depUCWispCountRouting)
+	})
+}
+
+func (s *testSuite) depUCListMetaOutgoing() {
+	s.seedIssueRow("bd-duc-meta-src")
+	s.seedIssueRow("bd-duc-meta-a")
+	s.seedIssueRow("bd-duc-meta-b")
+	s.seedBlocksEdge("bd-duc-meta-src", "bd-duc-meta-a")
+	s.seedBlocksEdge("bd-duc-meta-src", "bd-duc-meta-b")
+
+	out, err := s.depUseCase().ListWithIssueMetadata(s.Ctx(), "bd-duc-meta-src",
+		domain.DepListFilter{Direction: domain.DepDirectionOut})
+	s.Require().NoError(err)
+	s.Require().Len(out, 2)
+	for _, d := range out {
+		s.Equal(types.DepBlocks, d.DependencyType)
+		s.NotEmpty(d.ID)
+	}
+}
+
+func (s *testSuite) depUCListMetaTypeFilter() {
+	s.seedIssueRow("bd-duc-meta-tf-src")
+	s.seedIssueRow("bd-duc-meta-tf-bl")
+	s.seedIssueRow("bd-duc-meta-tf-rel")
+	s.Require().NoError(s.depRepo().Insert(s.Ctx(),
+		newDep("bd-duc-meta-tf-src", "bd-duc-meta-tf-bl", types.DepBlocks), "tester", domain.DepInsertOpts{}))
+	s.Require().NoError(s.depRepo().Insert(s.Ctx(),
+		newDep("bd-duc-meta-tf-src", "bd-duc-meta-tf-rel", types.DepRelated), "tester", domain.DepInsertOpts{}))
+
+	out, err := s.depUseCase().ListWithIssueMetadata(s.Ctx(), "bd-duc-meta-tf-src",
+		domain.DepListFilter{
+			Direction: domain.DepDirectionOut,
+			Types:     []types.DependencyType{types.DepRelated},
+		})
+	s.Require().NoError(err)
+	s.Require().Len(out, 1)
+	s.Equal("bd-duc-meta-tf-rel", out[0].ID)
+}
+
+func (s *testSuite) depUCListMetaEmptyID() {
+	_, err := s.depUseCase().ListWithIssueMetadata(s.Ctx(), "",
+		domain.DepListFilter{Direction: domain.DepDirectionOut})
+	s.Require().Error(err)
+	s.Contains(err.Error(), "sourceID must not be empty")
+}
+
+func (s *testSuite) depUCIterMetaMatchesList() {
+	s.seedIssueRow("bd-duc-iter-src")
+	s.seedIssueRow("bd-duc-iter-a")
+	s.seedBlocksEdge("bd-duc-iter-src", "bd-duc-iter-a")
+
+	filter := domain.DepListFilter{Direction: domain.DepDirectionOut}
+	list, err := s.depUseCase().ListWithIssueMetadata(s.Ctx(), "bd-duc-iter-src", filter)
+	s.Require().NoError(err)
+
+	it, err := s.depUseCase().IterWithIssueMetadata(s.Ctx(), "bd-duc-iter-src", filter)
+	s.Require().NoError(err)
+	defer it.Close() //nolint:errcheck
+
+	var streamed []*types.IssueWithDependencyMetadata
+	for it.Next(context.Background()) {
+		streamed = append(streamed, it.Value())
+	}
+	s.Require().NoError(it.Err())
+	s.Equal(len(list), len(streamed))
+}
+
+func (s *testSuite) depUCIterMetaEmptyID() {
+	_, err := s.depUseCase().IterWithIssueMetadata(s.Ctx(), "",
+		domain.DepListFilter{Direction: domain.DepDirectionOut})
+	s.Require().Error(err)
+}
+
+func (s *testSuite) depUCCountByIDBoth() {
+	s.seedIssueRow("bd-duc-cnt-x")
+	s.seedIssueRow("bd-duc-cnt-up")
+	s.seedIssueRow("bd-duc-cnt-down")
+	s.seedBlocksEdge("bd-duc-cnt-x", "bd-duc-cnt-up")
+	s.seedBlocksEdge("bd-duc-cnt-down", "bd-duc-cnt-x")
+
+	n, err := s.depUseCase().CountByIssueID(s.Ctx(), "bd-duc-cnt-x",
+		domain.DepListFilter{Direction: domain.DepDirectionBoth})
+	s.Require().NoError(err)
+	s.Equal(int64(2), n)
+}
+
+func (s *testSuite) depUCCountByIDEmptyID() {
+	_, err := s.depUseCase().CountByIssueID(s.Ctx(), "",
+		domain.DepListFilter{Direction: domain.DepDirectionBoth})
+	s.Require().Error(err)
+}
+
+func (s *testSuite) depUCWispListRouting() {
+	s.seedIssueRow("bd-duc-wisp-tgt")
+	s.seedWispRow("bd-duc-wisp-src")
+	s.Require().NoError(s.depRepo().Insert(s.Ctx(),
+		newDep("bd-duc-wisp-src", "bd-duc-wisp-tgt", types.DepBlocks), "tester",
+		domain.DepInsertOpts{UseWispsTable: true}))
+
+	out, err := s.depUseCase().ListWispWithIssueMetadata(s.Ctx(), "bd-duc-wisp-src",
+		domain.DepListFilter{Direction: domain.DepDirectionOut})
+	s.Require().NoError(err)
+	s.Require().Len(out, 1)
+	s.Equal("bd-duc-wisp-tgt", out[0].ID)
+}
+
+func (s *testSuite) depUCWispCountRouting() {
+	s.seedIssueRow("bd-duc-wisp-cnt-tgt")
+	s.seedWispRow("bd-duc-wisp-cnt-src")
+	s.Require().NoError(s.depRepo().Insert(s.Ctx(),
+		newDep("bd-duc-wisp-cnt-src", "bd-duc-wisp-cnt-tgt", types.DepBlocks), "tester",
+		domain.DepInsertOpts{UseWispsTable: true}))
+
+	n, err := s.depUseCase().CountByWispID(s.Ctx(), "bd-duc-wisp-cnt-src",
+		domain.DepListFilter{Direction: domain.DepDirectionOut})
+	s.Require().NoError(err)
+	s.Equal(int64(1), n)
+}

--- a/internal/storage/domain/db/issue.go
+++ b/internal/storage/domain/db/issue.go
@@ -708,4 +708,8 @@ func (r *issueSQLRepositoryImpl) RecomputeIsBlocked(ctx context.Context, issueID
 	return issueops.RecomputeIsBlockedInTx(ctx, r.runner, issueIDs, wispIDs)
 }
 
+func (r *issueSQLRepositoryImpl) AsOf(ctx context.Context, id, ref string) (*types.Issue, error) {
+	return issueops.AsOfInTx(ctx, r.runner, id, ref)
+}
+
 const deleteBatchSize = 200

--- a/internal/storage/domain/db/issue_as_of_test.go
+++ b/internal/storage/domain/db/issue_as_of_test.go
@@ -1,0 +1,83 @@
+package db
+
+import (
+	"errors"
+
+	"github.com/steveyegge/beads/internal/storage"
+	"github.com/steveyegge/beads/internal/storage/domain"
+)
+
+func (s *testSuite) TestIssueSQLRepositoryAsOf() {
+	s.Run("ReturnsRowAsOfCommit", s.asOfReturnsHistoricalRow)
+	s.Run("CurrentReadStillReflectsLatest", s.asOfCurrentStillLatest)
+	s.Run("MissingIssueReturnsErrNotFound", s.asOfMissingIssue)
+	s.Run("InvalidRefRejected", s.asOfInvalidRef)
+	s.Run("EmptyRefRejected", s.asOfEmptyRef)
+}
+
+func (s *testSuite) doltCommit(msg string) string {
+	_, err := s.Runner().ExecContext(s.Ctx(), "CALL DOLT_ADD('-A')")
+	s.Require().NoError(err)
+	_, err = s.Runner().ExecContext(s.Ctx(), "CALL DOLT_COMMIT('-m', ?, '--allow-empty')", msg)
+	s.Require().NoError(err)
+	var hash string
+	s.Require().NoError(s.Runner().QueryRowContext(s.Ctx(), "SELECT HASHOF('HEAD')").Scan(&hash))
+	return hash
+}
+
+func (s *testSuite) asOfReturnsHistoricalRow() {
+	r := s.issueRepo()
+	in := newTestIssue("bd-asof-1", "original")
+	s.Require().NoError(r.Insert(s.Ctx(), in, "tester", domain.InsertIssueOpts{}))
+
+	initialHash := s.doltCommit("seed bd-asof-1")
+
+	s.Require().NoError(r.Update(s.Ctx(), "bd-asof-1",
+		map[string]any{"title": "modified"}, "tester", domain.IssueTableOpts{}))
+	_ = s.doltCommit("modify bd-asof-1")
+
+	old, err := r.AsOf(s.Ctx(), "bd-asof-1", initialHash)
+	s.Require().NoError(err)
+	s.Require().NotNil(old)
+	s.Equal("original", old.Title)
+}
+
+func (s *testSuite) asOfCurrentStillLatest() {
+	r := s.issueRepo()
+	in := newTestIssue("bd-asof-cur", "v1")
+	s.Require().NoError(r.Insert(s.Ctx(), in, "tester", domain.InsertIssueOpts{}))
+	hash := s.doltCommit("seed bd-asof-cur")
+
+	s.Require().NoError(r.Update(s.Ctx(), "bd-asof-cur",
+		map[string]any{"title": "v2"}, "tester", domain.IssueTableOpts{}))
+	_ = s.doltCommit("modify bd-asof-cur")
+
+	current, err := r.Get(s.Ctx(), "bd-asof-cur", domain.IssueTableOpts{})
+	s.Require().NoError(err)
+	s.Require().NotNil(current)
+	s.Equal("v2", current.Title)
+
+	historical, err := r.AsOf(s.Ctx(), "bd-asof-cur", hash)
+	s.Require().NoError(err)
+	s.Require().NotNil(historical)
+	s.Equal("v1", historical.Title)
+}
+
+func (s *testSuite) asOfMissingIssue() {
+	hash := s.doltCommit("asof-missing baseline")
+	_, err := s.issueRepo().AsOf(s.Ctx(), "bd-asof-nope", hash)
+	s.Require().Error(err)
+	s.True(errors.Is(err, storage.ErrNotFound), "missing row at ref must surface storage.ErrNotFound")
+}
+
+func (s *testSuite) asOfInvalidRef() {
+	_, err := s.issueRepo().AsOf(s.Ctx(), "bd-anything", "'; DROP TABLE issues; --")
+	s.Require().Error(err)
+	s.Contains(err.Error(), "invalid ref")
+}
+
+func (s *testSuite) asOfEmptyRef() {
+	_, err := s.issueRepo().AsOf(s.Ctx(), "bd-anything", "")
+	s.Require().Error(err)
+	s.Contains(err.Error(), "ref cannot be empty")
+}

--- a/internal/storage/domain/db/issue_usecase_as_of_test.go
+++ b/internal/storage/domain/db/issue_usecase_as_of_test.go
@@ -1,0 +1,34 @@
+package db
+
+func (s *testSuite) TestIssueUseCaseAsOf() {
+	s.Run("DelegatesToRepoAtRef", s.issueUCAsOfHistorical)
+	s.Run("EmptyIDRejected", s.issueUCAsOfEmptyID)
+	s.Run("PropagatesRepoError", s.issueUCAsOfBadRef)
+}
+
+func (s *testSuite) issueUCAsOfHistorical() {
+	s.seedIssueRow("bd-iuc-asof")
+	hash := s.doltCommit("seed bd-iuc-asof")
+
+	_, err := s.Runner().ExecContext(s.Ctx(),
+		"UPDATE issues SET title = ? WHERE id = ?", "after", "bd-iuc-asof")
+	s.Require().NoError(err)
+	_ = s.doltCommit("modify bd-iuc-asof")
+
+	out, err := s.issueUseCase().AsOf(s.Ctx(), "bd-iuc-asof", hash)
+	s.Require().NoError(err)
+	s.Require().NotNil(out)
+	s.Equal("seed", out.Title)
+}
+
+func (s *testSuite) issueUCAsOfEmptyID() {
+	_, err := s.issueUseCase().AsOf(s.Ctx(), "", "HEAD")
+	s.Require().Error(err)
+	s.Contains(err.Error(), "id must not be empty")
+}
+
+func (s *testSuite) issueUCAsOfBadRef() {
+	_, err := s.issueUseCase().AsOf(s.Ctx(), "bd-iuc-asof-x", "'; DROP TABLE issues; --")
+	s.Require().Error(err)
+	s.Contains(err.Error(), "invalid ref")
+}

--- a/internal/storage/domain/dependency.go
+++ b/internal/storage/domain/dependency.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/storage/dberrors"
 	"github.com/steveyegge/beads/internal/types"
 )
@@ -57,6 +58,9 @@ type DependencySQLRepository interface {
 	Delete(ctx context.Context, issueID, dependsOnID, actor string, opts DepInsertOpts) (DepDeleteResult, error)
 	HasCycle(ctx context.Context, issueID, dependsOnID string) (bool, error)
 	ListByIssueIDs(ctx context.Context, issueIDs []string, opts DepListOpts) (DepBulkResult, error)
+	ListWithIssueMetadata(ctx context.Context, sourceID string, opts DepListOpts) ([]*types.IssueWithDependencyMetadata, error)
+	IterWithIssueMetadata(ctx context.Context, sourceID string, opts DepListOpts) (storage.Iter[types.IssueWithDependencyMetadata], error)
+	CountByID(ctx context.Context, sourceID string, opts DepListOpts) (int64, error)
 	CountsByIssueIDs(ctx context.Context, issueIDs []string, opts DepCountsOpts) (map[string]*types.DependencyCounts, error)
 
 	GetBlockingInfo(ctx context.Context, issueIDs []string, opts DepListOpts) (BlockingInfo, error)
@@ -71,6 +75,9 @@ type DependencyUseCase interface {
 	RemoveDependency(ctx context.Context, issueID, dependsOnID, actor string) error
 	Reparent(ctx context.Context, childID, newParentID, actor string) error
 	ListByIssueIDs(ctx context.Context, issueIDs []string, filter DepListFilter) (DepBulkResult, error)
+	ListWithIssueMetadata(ctx context.Context, issueID string, filter DepListFilter) ([]*types.IssueWithDependencyMetadata, error)
+	IterWithIssueMetadata(ctx context.Context, issueID string, filter DepListFilter) (storage.Iter[types.IssueWithDependencyMetadata], error)
+	CountByIssueID(ctx context.Context, issueID string, filter DepListFilter) (int64, error)
 	CountsByIssueIDs(ctx context.Context, issueIDs []string) (map[string]*types.DependencyCounts, error)
 	GetBlockingInfo(ctx context.Context, issueIDs []string) (BlockingInfo, error)
 	GetForIssueIDs(ctx context.Context, ids []string) (map[string][]*types.Dependency, error)
@@ -79,6 +86,9 @@ type DependencyUseCase interface {
 	RemoveWispDependency(ctx context.Context, wispID, dependsOnID, actor string) error
 	ReparentWisp(ctx context.Context, childWispID, newParentID, actor string) error
 	ListByWispIDs(ctx context.Context, wispIDs []string, filter DepListFilter) (DepBulkResult, error)
+	ListWispWithIssueMetadata(ctx context.Context, wispID string, filter DepListFilter) ([]*types.IssueWithDependencyMetadata, error)
+	IterWispWithIssueMetadata(ctx context.Context, wispID string, filter DepListFilter) (storage.Iter[types.IssueWithDependencyMetadata], error)
+	CountByWispID(ctx context.Context, wispID string, filter DepListFilter) (int64, error)
 	CountsByWispIDs(ctx context.Context, wispIDs []string) (map[string]*types.DependencyCounts, error)
 }
 
@@ -203,6 +213,18 @@ func (u *dependencyUseCaseImpl) ListByIssueIDs(ctx context.Context, issueIDs []s
 	return u.list(ctx, issueIDs, filter, false)
 }
 
+func (u *dependencyUseCaseImpl) ListWithIssueMetadata(ctx context.Context, issueID string, filter DepListFilter) ([]*types.IssueWithDependencyMetadata, error) {
+	return u.listWithMetadata(ctx, issueID, filter, false)
+}
+
+func (u *dependencyUseCaseImpl) IterWithIssueMetadata(ctx context.Context, issueID string, filter DepListFilter) (storage.Iter[types.IssueWithDependencyMetadata], error) {
+	return u.iterWithMetadata(ctx, issueID, filter, false)
+}
+
+func (u *dependencyUseCaseImpl) CountByIssueID(ctx context.Context, issueID string, filter DepListFilter) (int64, error) {
+	return u.countByID(ctx, issueID, filter, false)
+}
+
 func (u *dependencyUseCaseImpl) GetForIssueIDs(ctx context.Context, ids []string) (map[string][]*types.Dependency, error) {
 	if len(ids) == 0 {
 		return map[string][]*types.Dependency{}, nil
@@ -227,6 +249,63 @@ func (u *dependencyUseCaseImpl) GetForIssueIDs(ctx context.Context, ids []string
 
 func (u *dependencyUseCaseImpl) ListByWispIDs(ctx context.Context, wispIDs []string, filter DepListFilter) (DepBulkResult, error) {
 	return u.list(ctx, wispIDs, filter, true)
+}
+
+func (u *dependencyUseCaseImpl) ListWispWithIssueMetadata(ctx context.Context, wispID string, filter DepListFilter) ([]*types.IssueWithDependencyMetadata, error) {
+	return u.listWithMetadata(ctx, wispID, filter, true)
+}
+
+func (u *dependencyUseCaseImpl) IterWispWithIssueMetadata(ctx context.Context, wispID string, filter DepListFilter) (storage.Iter[types.IssueWithDependencyMetadata], error) {
+	return u.iterWithMetadata(ctx, wispID, filter, true)
+}
+
+func (u *dependencyUseCaseImpl) CountByWispID(ctx context.Context, wispID string, filter DepListFilter) (int64, error) {
+	return u.countByID(ctx, wispID, filter, true)
+}
+
+func (u *dependencyUseCaseImpl) listWithMetadata(ctx context.Context, sourceID string, filter DepListFilter, useWisp bool) ([]*types.IssueWithDependencyMetadata, error) {
+	if sourceID == "" {
+		return nil, fmt.Errorf("list dep metadata: sourceID must not be empty")
+	}
+	out, err := u.depRepo.ListWithIssueMetadata(ctx, sourceID, DepListOpts{
+		Types:         filter.Types,
+		Direction:     filter.Direction,
+		UseWispsTable: useWisp,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("list dep metadata: %w", err)
+	}
+	return out, nil
+}
+
+func (u *dependencyUseCaseImpl) iterWithMetadata(ctx context.Context, sourceID string, filter DepListFilter, useWisp bool) (storage.Iter[types.IssueWithDependencyMetadata], error) {
+	if sourceID == "" {
+		return nil, fmt.Errorf("iter dep metadata: sourceID must not be empty")
+	}
+	it, err := u.depRepo.IterWithIssueMetadata(ctx, sourceID, DepListOpts{
+		Types:         filter.Types,
+		Direction:     filter.Direction,
+		UseWispsTable: useWisp,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("iter dep metadata: %w", err)
+	}
+	return it, nil
+}
+
+func (u *dependencyUseCaseImpl) countByID(ctx context.Context, sourceID string, filter DepListFilter, useWisp bool) (int64, error) {
+	if sourceID == "" {
+		return 0, fmt.Errorf("count by id: sourceID must not be empty")
+	}
+	n, err := u.depRepo.CountByID(ctx, sourceID, DepListOpts{
+		Types:         filter.Types,
+		Direction:     filter.Direction,
+		UseWispsTable: useWisp,
+	})
+	if err != nil {
+		return 0, fmt.Errorf("count by id: %w", err)
+	}
+	return n, nil
 }
 
 func (u *dependencyUseCaseImpl) list(ctx context.Context, ids []string, filter DepListFilter, useWisp bool) (DepBulkResult, error) {

--- a/internal/storage/domain/issue.go
+++ b/internal/storage/domain/issue.go
@@ -35,6 +35,7 @@ type IssueSQLRepository interface {
 	Update(ctx context.Context, id string, updates map[string]any, actor string, opts IssueTableOpts) error
 	Claim(ctx context.Context, id, actor string, opts IssueTableOpts) (ClaimRowResult, error)
 	Get(ctx context.Context, id string, opts IssueTableOpts) (*types.Issue, error)
+	AsOf(ctx context.Context, id, ref string) (*types.Issue, error)
 	GetByIDs(ctx context.Context, ids []string, opts IssueTableOpts) ([]*types.Issue, error)
 	Exists(ctx context.Context, id string, opts IssueTableOpts) (bool, error)
 	CountForPrefix(ctx context.Context, prefix string, opts IssueTableOpts) (int, error)
@@ -174,6 +175,7 @@ type IssueUseCase interface {
 	ClaimIssue(ctx context.Context, id, actor string) (ClaimResult, error)
 	ApplyUpdate(ctx context.Context, id string, spec UpdateSpec, actor string) (*types.Issue, error)
 	ApplyIssueGraph(ctx context.Context, plan GraphPlan, actor string) (GraphApplyResult, error)
+	AsOf(ctx context.Context, id, ref string) (*types.Issue, error)
 	DeleteIssue(ctx context.Context, id, actor string) (DeleteIssuesResult, error)
 	DeleteIssues(ctx context.Context, params DeleteIssuesParams, actor string) (DeleteIssuesResult, error)
 	PreviewDelete(ctx context.Context, ids []string) (DeletePreview, error)
@@ -230,6 +232,17 @@ var _ IssueUseCase = (*issueUseCaseImpl)(nil)
 
 func (u *issueUseCaseImpl) GetIssue(ctx context.Context, id string) (*types.Issue, error) {
 	return u.get(ctx, id, false)
+}
+
+func (u *issueUseCaseImpl) AsOf(ctx context.Context, id, ref string) (*types.Issue, error) {
+	if id == "" {
+		return nil, fmt.Errorf("as of: id must not be empty")
+	}
+	issue, err := u.issueRepo.AsOf(ctx, id, ref)
+	if err != nil {
+		return nil, fmt.Errorf("as of %s @ %s: %w", id, ref, err)
+	}
+	return issue, nil
 }
 
 func (u *issueUseCaseImpl) GetWisp(ctx context.Context, id string) (*types.Issue, error) {

--- a/internal/storage/issueops/as_of.go
+++ b/internal/storage/issueops/as_of.go
@@ -33,7 +33,7 @@ func ValidateRef(ref string) error {
 // Uses Dolt's AS OF syntax which works in both server and embedded modes.
 //
 // nolint:gosec // G201: ref is validated by ValidateRef() above - AS OF requires literal
-func AsOfInTx(ctx context.Context, tx *sql.Tx, issueID string, ref string) (*types.Issue, error) {
+func AsOfInTx(ctx context.Context, tx DBTX, issueID string, ref string) (*types.Issue, error) {
 	if err := ValidateRef(ref); err != nil {
 		return nil, fmt.Errorf("invalid ref: %w", err)
 	}

--- a/internal/storage/issueops/dep_counts.go
+++ b/internal/storage/issueops/dep_counts.go
@@ -1,0 +1,59 @@
+package issueops
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/steveyegge/beads/internal/storage/domain"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+func CountDependencyEdgesInTx(ctx context.Context, tx DBTX, sourceID string, dir domain.DepDirection, typeFilter []types.DependencyType) (int64, error) {
+	typeClause, typeArgs := buildDepTypeClause(typeFilter)
+
+	var total int64
+	for _, table := range []string{"dependencies", "wisp_dependencies"} {
+		if dir == domain.DepDirectionOut || dir == domain.DepDirectionBoth {
+			n, err := countDepWhere(ctx, tx, table, "issue_id = ?", typeClause, sourceID, typeArgs)
+			if err != nil {
+				return 0, err
+			}
+			total += n
+		}
+		if dir == domain.DepDirectionIn || dir == domain.DepDirectionBoth {
+			n, err := countDepWhere(ctx, tx, table, DepTargetExpr+" = ?", typeClause, sourceID, typeArgs)
+			if err != nil {
+				return 0, err
+			}
+			total += n
+		}
+	}
+	return total, nil
+}
+
+func countDepWhere(ctx context.Context, tx DBTX, table, whereExpr, typeClause string, sourceID string, typeArgs []any) (int64, error) {
+	q := fmt.Sprintf("SELECT count(*) FROM %s WHERE %s", table, whereExpr) //nolint:gosec
+	if typeClause != "" {
+		q += " AND " + typeClause
+	}
+	args := append([]any{sourceID}, typeArgs...)
+	var n int64
+	if err := tx.QueryRowContext(ctx, q, args...).Scan(&n); err != nil {
+		return 0, fmt.Errorf("count %s: %w", table, err)
+	}
+	return n, nil
+}
+
+func buildDepTypeClause(filter []types.DependencyType) (string, []any) {
+	if len(filter) == 0 {
+		return "", nil
+	}
+	placeholders := make([]string, len(filter))
+	args := make([]any, len(filter))
+	for i, t := range filter {
+		placeholders[i] = "?"
+		args[i] = string(t)
+	}
+	return "type IN (" + strings.Join(placeholders, ",") + ")", args
+}

--- a/internal/storage/issueops/dependencies.go
+++ b/internal/storage/issueops/dependencies.go
@@ -752,7 +752,7 @@ func RemoveDependencyInTx(ctx context.Context, tx *sql.Tx, issueID, dependsOnID 
 // reuse it across calls.
 //
 //nolint:gosec // G201: table names come from WispTableRouting (hardcoded constants)
-func GetIssuesByIDsInTx(ctx context.Context, tx *sql.Tx, ids []string, wispSet map[string]struct{}) ([]*types.Issue, error) {
+func GetIssuesByIDsInTx(ctx context.Context, tx DBTX, ids []string, wispSet map[string]struct{}) ([]*types.Issue, error) {
 	if len(ids) == 0 {
 		return nil, nil
 	}
@@ -850,7 +850,7 @@ func GetIssuesByIDsInTx(ctx context.Context, tx *sql.Tx, ids []string, wispSet m
 // Queries both dependency tables to handle cross-table dependencies.
 //
 //nolint:gosec // G201: table names come from hardcoded constants
-func GetDependenciesWithMetadataInTx(ctx context.Context, tx *sql.Tx, issueID string) ([]*types.IssueWithDependencyMetadata, error) {
+func GetDependenciesWithMetadataInTx(ctx context.Context, tx DBTX, issueID string) ([]*types.IssueWithDependencyMetadata, error) {
 	type depMeta struct {
 		depID, depType string
 	}
@@ -913,7 +913,7 @@ func GetDependenciesWithMetadataInTx(ctx context.Context, tx *sql.Tx, issueID st
 // along with the dependency type. Works within an existing transaction.
 //
 //nolint:gosec // G201: table names come from WispTableRouting (hardcoded constants)
-func GetDependentsWithMetadataInTx(ctx context.Context, tx *sql.Tx, issueID string) ([]*types.IssueWithDependencyMetadata, error) {
+func GetDependentsWithMetadataInTx(ctx context.Context, tx DBTX, issueID string) ([]*types.IssueWithDependencyMetadata, error) {
 	type depMeta struct {
 		depID, depType string
 	}

--- a/internal/storage/issueops/wisp_routing.go
+++ b/internal/storage/issueops/wisp_routing.go
@@ -64,7 +64,7 @@ func optionalTableExistsInTx(ctx context.Context, tx *sql.Tx, table string) (boo
 // Returns an empty set when ids is empty; never issues a query.
 //
 //nolint:gosec // G201: query uses placeholder-only interpolation
-func WispIDSetInTx(ctx context.Context, tx *sql.Tx, ids []string) (map[string]struct{}, error) {
+func WispIDSetInTx(ctx context.Context, tx DBTX, ids []string) (map[string]struct{}, error) {
 	set := make(map[string]struct{})
 	if len(ids) == 0 {
 		return set, nil


### PR DESCRIPTION
## Summary

- Adds proxied-server support for `bd show`, mirroring the pattern used by `bd update` / `bd create` / `bd delete`.
- Wires the cobra `Run` to dispatch to `runShowProxiedServer` (`cmd/bd/show.go`) when `usesProxiedServer()`; the direct-mode body is untouched.
- New `cmd/bd/show_proxied_server.go` opens a single UOW once per invocation and threads it through every branch (`--as-of`, `--thread`, `--refs`, `--children`, `--current`, and the default pretty/JSON path). `--watch` is rejected in proxied mode; `--current` resolves via `IssueUseCase.SearchIssues` without falling back to last-touched (not supported here).
- New domain UC + SQL repo methods to back the show paths: `IssueUseCase.AsOf`; `DependencyUseCase.{List,Iter}WithIssueMetadata` + `CountByIssueID` (with wisp variants); `CommentUseCase.{Get,Count,Iter}CommentsFor{Issue,Wisp}`. All delegate to issueops helpers (`AsOfInTx`, `Get{Dependencies,Dependents}WithMetadataInTx`, new `CountDependencyEdgesInTx` summing both edge tables) — no changes under `internal/storage/dolt/*`.
- Repo + UC unit tests for every new method (db package suite).
- New `cmd/bd/show_proxied_integration_test.go` provides 47 subtests covering every direct-mode behavior plus proxied-specific cases (wisp routing through `ListWispWithIssueMetadata` / `CountByWispID` / `GetCommentsForWisp`, `--watch` rejection, `--current` no-match error, gascity's `bd show --json <id>` JSON contract).

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/storage/domain/...` (repo + UC suites, including the new AsOf / ListWithIssueMetadata / IterWithIssueMetadata / CountByID / IterByIssueID coverage)
- [x] `BEADS_TEST_PROXIED_SERVER=1 go test -tags cgo ./cmd/bd/ -run TestProxiedServerShow` (47 subtests, 73s)
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)