### PR TITLE
/{cmd,internal}: bd close proxied-server support

### DIFF
--- a/cmd/bd/close.go
+++ b/cmd/bd/close.go
@@ -34,6 +34,11 @@ the flags appear in the command line.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		CheckReadonly("close")
 
+		if usesProxiedServer() {
+			runCloseProxiedServer(cmd, rootCtx, args)
+			return
+		}
+
 		// If no IDs provided, use last touched issue
 		if len(args) == 0 {
 			lastTouched := GetLastTouchedID()

--- a/cmd/bd/close_proxied_integration_test.go
+++ b/cmd/bd/close_proxied_integration_test.go
@@ -1,0 +1,791 @@
+//go:build cgo
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/types"
+)
+
+func bdProxiedClose(t *testing.T, bd, dir string, args ...string) string {
+	t.Helper()
+	fullArgs := append([]string{"close"}, args...)
+	stdout, stderr, err := bdProxiedRunBuffers(t, bd, dir, fullArgs...)
+	if err != nil {
+		t.Fatalf("bd close %s failed: %v\nstdout:\n%s\nstderr:\n%s",
+			strings.Join(args, " "), err, stdout, stderr)
+	}
+	return stdout
+}
+
+func bdProxiedCloseFail(t *testing.T, bd, dir string, args ...string) string {
+	t.Helper()
+	fullArgs := append([]string{"close"}, args...)
+	stdout, stderr, err := bdProxiedRunBuffers(t, bd, dir, fullArgs...)
+	if err == nil {
+		t.Fatalf("expected bd close %s to fail, got:\nstdout:\n%s\nstderr:\n%s",
+			strings.Join(args, " "), stdout, stderr)
+	}
+	return stdout + stderr
+}
+
+func bdProxiedCloseJSON(t *testing.T, bd, dir string, args ...string) []*types.Issue {
+	t.Helper()
+	fullArgs := append([]string{"close", "--json"}, args...)
+	stdout, stderr, err := bdProxiedRunBuffers(t, bd, dir, fullArgs...)
+	if err != nil {
+		t.Fatalf("bd close --json %s failed: %v\nstdout:\n%s\nstderr:\n%s",
+			strings.Join(args, " "), err, stdout, stderr)
+	}
+	start := strings.Index(stdout, "[")
+	if start < 0 {
+		t.Fatalf("no JSON array in close output:\n%s", stdout)
+	}
+	var issues []*types.Issue
+	if err := json.Unmarshal([]byte(stdout[start:]), &issues); err != nil {
+		t.Fatalf("parse close JSON: %v\nraw: %s", err, stdout[start:])
+	}
+	return issues
+}
+
+func bdProxiedCloseJSONEnvelope(t *testing.T, bd, dir string, args ...string) map[string]json.RawMessage {
+	t.Helper()
+	fullArgs := append([]string{"close", "--json"}, args...)
+	stdout, stderr, err := bdProxiedRunBuffers(t, bd, dir, fullArgs...)
+	if err != nil {
+		t.Fatalf("bd close --json %s failed: %v\nstdout:\n%s\nstderr:\n%s",
+			strings.Join(args, " "), err, stdout, stderr)
+	}
+	start := strings.Index(stdout, "{")
+	if start < 0 {
+		t.Fatalf("no JSON object in close output:\n%s", stdout)
+	}
+	var env map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(stdout[start:]), &env); err != nil {
+		t.Fatalf("parse close JSON envelope: %v\nraw: %s", err, stdout[start:])
+	}
+	return env
+}
+
+func readClosedBySession(t *testing.T, db *sql.DB, id string) string {
+	t.Helper()
+	var got sql.NullString
+	err := db.QueryRowContext(context.Background(),
+		"SELECT closed_by_session FROM issues WHERE id = ?", id).Scan(&got)
+	if err == sql.ErrNoRows {
+		if err := db.QueryRowContext(context.Background(),
+			"SELECT closed_by_session FROM wisps WHERE id = ?", id).Scan(&got); err != nil {
+			t.Fatalf("read closed_by_session for %s: %v", id, err)
+		}
+	} else if err != nil {
+		t.Fatalf("read closed_by_session for %s: %v", id, err)
+	}
+	if !got.Valid {
+		return ""
+	}
+	return got.String
+}
+
+func readCloseReason(t *testing.T, db *sql.DB, id string) string {
+	t.Helper()
+	var got sql.NullString
+	err := db.QueryRowContext(context.Background(),
+		"SELECT close_reason FROM issues WHERE id = ?", id).Scan(&got)
+	if err == sql.ErrNoRows {
+		if err := db.QueryRowContext(context.Background(),
+			"SELECT close_reason FROM wisps WHERE id = ?", id).Scan(&got); err != nil {
+			t.Fatalf("read close_reason for %s: %v", id, err)
+		}
+	} else if err != nil {
+		t.Fatalf("read close_reason for %s: %v", id, err)
+	}
+	if !got.Valid {
+		return ""
+	}
+	return got.String
+}
+
+func readStatus(t *testing.T, db *sql.DB, id string) types.Status {
+	t.Helper()
+	var got string
+	err := db.QueryRowContext(context.Background(),
+		"SELECT status FROM issues WHERE id = ?", id).Scan(&got)
+	if err == sql.ErrNoRows {
+		if err := db.QueryRowContext(context.Background(),
+			"SELECT status FROM wisps WHERE id = ?", id).Scan(&got); err != nil {
+			t.Fatalf("read status for %s: %v", id, err)
+		}
+	} else if err != nil {
+		t.Fatalf("read status for %s: %v", id, err)
+	}
+	return types.Status(got)
+}
+
+func readAssignee(t *testing.T, db *sql.DB, id string) string {
+	t.Helper()
+	var got sql.NullString
+	err := db.QueryRowContext(context.Background(),
+		"SELECT assignee FROM issues WHERE id = ?", id).Scan(&got)
+	if err == sql.ErrNoRows {
+		if err := db.QueryRowContext(context.Background(),
+			"SELECT assignee FROM wisps WHERE id = ?", id).Scan(&got); err != nil {
+			t.Fatalf("read assignee for %s: %v", id, err)
+		}
+	} else if err != nil {
+		t.Fatalf("read assignee for %s: %v", id, err)
+	}
+	if !got.Valid {
+		return ""
+	}
+	return got.String
+}
+
+func readDoltHead(t *testing.T, db *sql.DB) string {
+	t.Helper()
+	var h string
+	if err := db.QueryRowContext(context.Background(), "SELECT HASHOF('HEAD')").Scan(&h); err != nil {
+		t.Fatalf("read HEAD: %v", err)
+	}
+	return h
+}
+
+func readDoltLogTopMessage(t *testing.T, db *sql.DB) string {
+	t.Helper()
+	var msg string
+	if err := db.QueryRowContext(context.Background(),
+		"SELECT message FROM dolt_log ORDER BY date DESC LIMIT 1").Scan(&msg); err != nil {
+		t.Fatalf("read latest dolt_log message: %v", err)
+	}
+	return msg
+}
+
+func readDoltLogCountSince(t *testing.T, db *sql.DB, sinceHash string) int {
+	t.Helper()
+	rows, err := db.QueryContext(context.Background(),
+		"SELECT commit_hash FROM dolt_log ORDER BY date DESC")
+	if err != nil {
+		t.Fatalf("read dolt_log: %v", err)
+	}
+	defer rows.Close()
+	n := 0
+	for rows.Next() {
+		var h string
+		if err := rows.Scan(&h); err != nil {
+			t.Fatalf("scan dolt_log: %v", err)
+		}
+		if h == sinceHash {
+			return n
+		}
+		n++
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iter dolt_log: %v", err)
+	}
+	return n
+}
+
+func TestProxiedServerClose(t *testing.T) {
+	requireProxiedServerEnv(t)
+	bd := buildEmbeddedBD(t)
+
+	t.Run("basic_close", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "cb")
+		issue := bdProxiedCreate(t, bd, p.dir, "Close me")
+		bdProxiedClose(t, bd, p.dir, issue.ID)
+		got := bdProxiedShow(t, bd, p.dir, issue.ID)
+		if got.Status != types.StatusClosed {
+			t.Errorf("status: got %q, want closed", got.Status)
+		}
+		if got.ClosedAt == nil {
+			t.Error("closed_at should be set")
+		}
+	})
+
+	t.Run("close_default_reason", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "cdr")
+		issue := bdProxiedCreate(t, bd, p.dir, "Default reason")
+		bdProxiedClose(t, bd, p.dir, issue.ID)
+		db := openProxiedDB(t, p)
+		if got := readCloseReason(t, db, issue.ID); got != "Closed" {
+			t.Errorf("close_reason: got %q, want %q", got, "Closed")
+		}
+	})
+
+	t.Run("close_with_reason", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "cwr")
+		issue := bdProxiedCreate(t, bd, p.dir, "Reason test")
+		bdProxiedClose(t, bd, p.dir, issue.ID, "--reason", "done")
+		db := openProxiedDB(t, p)
+		if got := readCloseReason(t, db, issue.ID); got != "done" {
+			t.Errorf("close_reason: got %q, want %q", got, "done")
+		}
+	})
+
+	t.Run("close_with_reason_short", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "cwrs")
+		issue := bdProxiedCreate(t, bd, p.dir, "Short reason")
+		bdProxiedClose(t, bd, p.dir, issue.ID, "-r", "fixed")
+		db := openProxiedDB(t, p)
+		if got := readCloseReason(t, db, issue.ID); got != "fixed" {
+			t.Errorf("close_reason: got %q, want %q", got, "fixed")
+		}
+	})
+
+	t.Run("close_with_message_alias", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "cwma")
+		issue := bdProxiedCreate(t, bd, p.dir, "Message alias")
+		bdProxiedClose(t, bd, p.dir, issue.ID, "-m", "via message")
+		db := openProxiedDB(t, p)
+		if got := readCloseReason(t, db, issue.ID); got != "via message" {
+			t.Errorf("close_reason: got %q, want %q", got, "via message")
+		}
+	})
+
+	t.Run("close_with_resolution_alias", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "cwra")
+		issue := bdProxiedCreate(t, bd, p.dir, "Resolution alias")
+		bdProxiedClose(t, bd, p.dir, issue.ID, "--resolution", "wontfix")
+		db := openProxiedDB(t, p)
+		if got := readCloseReason(t, db, issue.ID); got != "wontfix" {
+			t.Errorf("close_reason: got %q, want %q", got, "wontfix")
+		}
+	})
+
+	t.Run("close_with_comment_alias", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "cwca")
+		issue := bdProxiedCreate(t, bd, p.dir, "Comment alias")
+		bdProxiedClose(t, bd, p.dir, issue.ID, "--comment", "duplicate")
+		db := openProxiedDB(t, p)
+		if got := readCloseReason(t, db, issue.ID); got != "duplicate" {
+			t.Errorf("close_reason: got %q, want %q", got, "duplicate")
+		}
+	})
+
+	t.Run("close_multiple_ids", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "cmi")
+		a := bdProxiedCreate(t, bd, p.dir, "Multi A")
+		b := bdProxiedCreate(t, bd, p.dir, "Multi B")
+		bdProxiedClose(t, bd, p.dir, a.ID, b.ID)
+		db := openProxiedDB(t, p)
+		if got := readStatus(t, db, a.ID); got != types.StatusClosed {
+			t.Errorf("a status: got %q, want closed", got)
+		}
+		if got := readStatus(t, db, b.ID); got != types.StatusClosed {
+			t.Errorf("b status: got %q, want closed", got)
+		}
+	})
+
+	t.Run("close_multiple_ids_with_per_id_reasons", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "cmpr")
+		a := bdProxiedCreate(t, bd, p.dir, "Multi reason A")
+		b := bdProxiedCreate(t, bd, p.dir, "Multi reason B")
+		bdProxiedClose(t, bd, p.dir, a.ID, "--reason", "fixed A", b.ID, "--reason", "fixed B")
+		db := openProxiedDB(t, p)
+		if got := readCloseReason(t, db, a.ID); got != "fixed A" {
+			t.Errorf("a reason: got %q, want %q", got, "fixed A")
+		}
+		if got := readCloseReason(t, db, b.ID); got != "fixed B" {
+			t.Errorf("b reason: got %q, want %q", got, "fixed B")
+		}
+	})
+
+	t.Run("close_already_closed", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "cac")
+		issue := bdProxiedCreate(t, bd, p.dir, "Double close")
+		bdProxiedClose(t, bd, p.dir, issue.ID, "--reason", "first")
+		stdout, stderr, err := bdProxiedRunBuffers(t, bd, p.dir, "close", issue.ID, "--reason", "second")
+		_ = stdout
+		_ = stderr
+		_ = err
+		db := openProxiedDB(t, p)
+		if got := readCloseReason(t, db, issue.ID); got != "first" {
+			t.Errorf("re-close must not overwrite reason: got %q, want %q", got, "first")
+		}
+	})
+
+	t.Run("close_nonexistent_id", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "cni")
+		out := bdProxiedCloseFail(t, bd, p.dir, "cni-does-not-exist")
+		if !strings.Contains(out, "not found") {
+			t.Errorf("expected 'not found' error, got: %s", out)
+		}
+	})
+
+	t.Run("close_blocked_refuses_without_force", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "cbr")
+		blocker := bdProxiedCreate(t, bd, p.dir, "Blocker")
+		blocked := bdProxiedCreate(t, bd, p.dir, "Blocked", "--deps", "depends-on:"+blocker.ID)
+		out := bdProxiedCloseFail(t, bd, p.dir, blocked.ID)
+		if !strings.Contains(out, "blocked by") {
+			t.Errorf("expected blocker error, got: %s", out)
+		}
+		db := openProxiedDB(t, p)
+		if got := readStatus(t, db, blocked.ID); got == types.StatusClosed {
+			t.Error("blocked issue should remain open without --force")
+		}
+	})
+
+	t.Run("close_blocked_with_force", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "cbf")
+		blocker := bdProxiedCreate(t, bd, p.dir, "Blocker force")
+		blocked := bdProxiedCreate(t, bd, p.dir, "Blocked force", "--deps", "depends-on:"+blocker.ID)
+		bdProxiedClose(t, bd, p.dir, blocked.ID, "--force")
+		db := openProxiedDB(t, p)
+		if got := readStatus(t, db, blocked.ID); got != types.StatusClosed {
+			t.Errorf("status with --force: got %q, want closed", got)
+		}
+	})
+
+	t.Run("close_pinned_refuses_without_force", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "cpr")
+		issue := bdProxiedCreate(t, bd, p.dir, "Pinned")
+		bdProxiedUpdateOne(t, bd, p.dir, issue.ID, "-s", "pinned")
+		bdProxiedCloseFail(t, bd, p.dir, issue.ID)
+		db := openProxiedDB(t, p)
+		if got := readStatus(t, db, issue.ID); got == types.StatusClosed {
+			t.Error("pinned issue should remain pinned without --force")
+		}
+	})
+
+	t.Run("close_pinned_with_force", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "cpf")
+		issue := bdProxiedCreate(t, bd, p.dir, "Pinned force")
+		bdProxiedUpdateOne(t, bd, p.dir, issue.ID, "-s", "pinned")
+		bdProxiedClose(t, bd, p.dir, issue.ID, "--force")
+		db := openProxiedDB(t, p)
+		if got := readStatus(t, db, issue.ID); got != types.StatusClosed {
+			t.Errorf("status: got %q, want closed", got)
+		}
+	})
+
+	t.Run("close_epic_open_children_refuses", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "ceor")
+		epic := bdProxiedCreate(t, bd, p.dir, "Epic", "-t", "epic")
+		_ = bdProxiedCreate(t, bd, p.dir, "Child", "--parent", epic.ID)
+		out := bdProxiedCloseFail(t, bd, p.dir, epic.ID)
+		if !strings.Contains(out, "open child") {
+			t.Errorf("expected 'open child' error, got: %s", out)
+		}
+	})
+
+	t.Run("close_epic_open_children_force", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "ceof")
+		epic := bdProxiedCreate(t, bd, p.dir, "Epic force", "-t", "epic")
+		_ = bdProxiedCreate(t, bd, p.dir, "Child force", "--parent", epic.ID)
+		bdProxiedClose(t, bd, p.dir, epic.ID, "--force")
+		db := openProxiedDB(t, p)
+		if got := readStatus(t, db, epic.ID); got != types.StatusClosed {
+			t.Errorf("status: got %q, want closed", got)
+		}
+	})
+
+	t.Run("close_last_child_keeps_regular_epic_open", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "clce")
+		epic := bdProxiedCreate(t, bd, p.dir, "Regular epic", "-t", "epic")
+		child := bdProxiedCreate(t, bd, p.dir, "Last child", "--parent", epic.ID)
+		bdProxiedClose(t, bd, p.dir, child.ID)
+		db := openProxiedDB(t, p)
+		if got := readStatus(t, db, epic.ID); got != types.StatusOpen {
+			t.Errorf("regular epic should stay open after last child closes, got %q", got)
+		}
+	})
+
+	t.Run("close_unblocks_dependent", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "cud")
+		blocker := bdProxiedCreate(t, bd, p.dir, "Unblock blocker")
+		blocked := bdProxiedCreate(t, bd, p.dir, "Unblock blocked", "--deps", "depends-on:"+blocker.ID)
+		db := openProxiedDB(t, p)
+		if !readIsBlocked(t, db, blocked.ID) {
+			t.Fatal("dependent should be blocked before blocker closes")
+		}
+		bdProxiedClose(t, bd, p.dir, blocker.ID)
+		if readIsBlocked(t, db, blocked.ID) {
+			t.Error("dependent should be unblocked after blocker closes")
+		}
+	})
+
+	t.Run("close_suggest_next", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "csn")
+		blocker := bdProxiedCreate(t, bd, p.dir, "Suggest blocker")
+		blocked := bdProxiedCreate(t, bd, p.dir, "Suggest blocked", "--deps", "depends-on:"+blocker.ID)
+		out := bdProxiedClose(t, bd, p.dir, blocker.ID, "--suggest-next")
+		if !strings.Contains(out, blocked.ID) {
+			t.Errorf("suggest-next output missing unblocked id %s:\n%s", blocked.ID, out)
+		}
+	})
+
+	t.Run("close_suggest_next_json", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "csnj")
+		blocker := bdProxiedCreate(t, bd, p.dir, "Suggest JSON blocker")
+		blocked := bdProxiedCreate(t, bd, p.dir, "Suggest JSON blocked", "--deps", "depends-on:"+blocker.ID)
+		env := bdProxiedCloseJSONEnvelope(t, bd, p.dir, blocker.ID, "--suggest-next")
+		raw, ok := env["unblocked"]
+		if !ok {
+			t.Fatalf("envelope missing 'unblocked' key: %v", env)
+		}
+		var unblocked []*types.Issue
+		if err := json.Unmarshal(raw, &unblocked); err != nil {
+			t.Fatalf("parse unblocked: %v\n%s", err, string(raw))
+		}
+		if len(unblocked) != 1 || unblocked[0].ID != blocked.ID {
+			t.Errorf("unblocked: got %+v, want [%s]", unblocked, blocked.ID)
+		}
+	})
+
+	t.Run("close_claim_next", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "ccn")
+		toClose := bdProxiedCreate(t, bd, p.dir, "Claim next close")
+		nextIssue := bdProxiedCreate(t, bd, p.dir, "Claim next target")
+		bdProxiedClose(t, bd, p.dir, toClose.ID, "--claim-next")
+		db := openProxiedDB(t, p)
+		if got := readStatus(t, db, nextIssue.ID); got != types.StatusInProgress {
+			t.Errorf("next issue status: got %q, want in_progress", got)
+		}
+		if got := readAssignee(t, db, nextIssue.ID); got == "" {
+			t.Error("next issue assignee should be set after --claim-next")
+		}
+	})
+
+	t.Run("close_claim_next_no_ready", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "ccnr")
+		issue := bdProxiedCreate(t, bd, p.dir, "Only issue")
+		out := bdProxiedClose(t, bd, p.dir, issue.ID, "--claim-next")
+		if !strings.Contains(out, "No ready issues") {
+			t.Errorf("expected 'No ready issues', got: %s", out)
+		}
+	})
+
+	t.Run("close_claim_next_json", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "ccnj")
+		toClose := bdProxiedCreate(t, bd, p.dir, "Claim JSON close")
+		_ = bdProxiedCreate(t, bd, p.dir, "Claim JSON target")
+		env := bdProxiedCloseJSONEnvelope(t, bd, p.dir, toClose.ID, "--claim-next")
+		if _, ok := env["closed"]; !ok {
+			t.Errorf("envelope missing 'closed' key: %v", env)
+		}
+		if _, ok := env["claimed"]; !ok {
+			t.Errorf("envelope missing 'claimed' key: %v", env)
+		}
+	})
+
+	t.Run("close_with_session", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "cws")
+		issue := bdProxiedCreate(t, bd, p.dir, "Session flag")
+		bdProxiedClose(t, bd, p.dir, issue.ID, "--session", "sess-456")
+		db := openProxiedDB(t, p)
+		if got := readClosedBySession(t, db, issue.ID); got != "sess-456" {
+			t.Errorf("closed_by_session: got %q, want %q", got, "sess-456")
+		}
+	})
+
+	t.Run("close_session_from_env", func(t *testing.T) {
+		t.Setenv("CLAUDE_SESSION_ID", "sess-env")
+		p := bdProxiedInit(t, bd, "cse")
+		issue := bdProxiedCreate(t, bd, p.dir, "Session env")
+		bdProxiedClose(t, bd, p.dir, issue.ID)
+		db := openProxiedDB(t, p)
+		if got := readClosedBySession(t, db, issue.ID); got != "sess-env" {
+			t.Errorf("closed_by_session: got %q, want %q", got, "sess-env")
+		}
+	})
+
+	t.Run("close_json_output", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "cjo")
+		issue := bdProxiedCreate(t, bd, p.dir, "JSON close")
+		issues := bdProxiedCloseJSON(t, bd, p.dir, issue.ID)
+		if len(issues) != 1 || issues[0].ID != issue.ID {
+			t.Errorf("close JSON: got %+v, want [%s]", issues, issue.ID)
+		}
+		if issues[0].Status != types.StatusClosed {
+			t.Errorf("returned issue status: got %q, want closed", issues[0].Status)
+		}
+	})
+
+	t.Run("done_alias", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "da")
+		issue := bdProxiedCreate(t, bd, p.dir, "Done alias")
+		stdout, stderr, err := bdProxiedRunBuffers(t, bd, p.dir, "done", issue.ID)
+		if err != nil {
+			t.Fatalf("bd done failed: %v\nstdout:\n%s\nstderr:\n%s", err, stdout, stderr)
+		}
+		db := openProxiedDB(t, p)
+		if got := readStatus(t, db, issue.ID); got != types.StatusClosed {
+			t.Errorf("status via done alias: got %q, want closed", got)
+		}
+	})
+
+	t.Run("done_positional_reason", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "dpr")
+		issue := bdProxiedCreate(t, bd, p.dir, "Done reason")
+		stdout, stderr, err := bdProxiedRunBuffers(t, bd, p.dir, "done", issue.ID, "the reason")
+		if err != nil {
+			t.Fatalf("bd done with reason failed: %v\nstdout:\n%s\nstderr:\n%s", err, stdout, stderr)
+		}
+		db := openProxiedDB(t, p)
+		if got := readCloseReason(t, db, issue.ID); got != "the reason" {
+			t.Errorf("close_reason: got %q, want %q", got, "the reason")
+		}
+	})
+
+	t.Run("close_continue_multiple_ids_fails", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "ccmi")
+		a := bdProxiedCreate(t, bd, p.dir, "Continue multi A")
+		b := bdProxiedCreate(t, bd, p.dir, "Continue multi B")
+		out := bdProxiedCloseFail(t, bd, p.dir, a.ID, b.ID, "--continue")
+		if !strings.Contains(out, "single issue") {
+			t.Errorf("expected single-issue error, got: %s", out)
+		}
+	})
+
+	t.Run("close_suggest_next_multiple_ids_fails", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "csmi")
+		a := bdProxiedCreate(t, bd, p.dir, "Suggest multi A")
+		b := bdProxiedCreate(t, bd, p.dir, "Suggest multi B")
+		out := bdProxiedCloseFail(t, bd, p.dir, a.ID, b.ID, "--suggest-next")
+		if !strings.Contains(out, "single issue") {
+			t.Errorf("expected single-issue error, got: %s", out)
+		}
+	})
+
+	t.Run("single_transaction_dolt_commit", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "stdc")
+		a := bdProxiedCreate(t, bd, p.dir, "Tx A")
+		b := bdProxiedCreate(t, bd, p.dir, "Tx B")
+		c := bdProxiedCreate(t, bd, p.dir, "Tx C")
+		db := openProxiedDB(t, p)
+		before := readDoltHead(t, db)
+		bdProxiedClose(t, bd, p.dir, a.ID, b.ID, c.ID)
+		count := readDoltLogCountSince(t, db, before)
+		if count != 1 {
+			t.Errorf("expected exactly 1 new dolt commit for batch close, got %d", count)
+		}
+		msg := readDoltLogTopMessage(t, db)
+		for _, id := range []string{a.ID, b.ID, c.ID} {
+			if !strings.Contains(msg, id) {
+				t.Errorf("dolt commit message %q should contain id %s", msg, id)
+			}
+		}
+		if !strings.HasPrefix(msg, "bd: close ") {
+			t.Errorf("dolt commit message should begin with 'bd: close ', got: %q", msg)
+		}
+	})
+
+	t.Run("no_ids_errors", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "nie")
+		out := bdProxiedCloseFail(t, bd, p.dir)
+		if !strings.Contains(out, "no issue ID provided") {
+			t.Errorf("expected 'no issue ID provided', got: %s", out)
+		}
+	})
+
+	t.Run("last_touched_not_supported", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "ltns")
+		_ = bdProxiedCreate(t, bd, p.dir, "Recent create")
+		out := bdProxiedCloseFail(t, bd, p.dir)
+		if !strings.Contains(out, "no issue ID provided") {
+			t.Errorf("proxied mode must not fall back to last-touched; got: %s", out)
+		}
+	})
+
+	t.Run("close_wisp_issue", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "cwi")
+		wisp := bdProxiedCreate(t, bd, p.dir, "Wisp close", "--ephemeral")
+		bdProxiedClose(t, bd, p.dir, wisp.ID)
+		db := openProxiedDB(t, p)
+		var status string
+		if err := db.QueryRowContext(context.Background(),
+			"SELECT status FROM wisps WHERE id = ?", wisp.ID).Scan(&status); err != nil {
+			t.Fatalf("read wisp status: %v", err)
+		}
+		if types.Status(status) != types.StatusClosed {
+			t.Errorf("wisp status: got %q, want closed", status)
+		}
+	})
+
+	t.Run("close_wisp_epic_open_children", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "cweoc")
+		wispEpic := bdProxiedCreate(t, bd, p.dir, "Wisp epic", "-t", "epic", "--ephemeral")
+		_ = bdProxiedCreate(t, bd, p.dir, "Wisp child", "--ephemeral", "--parent", wispEpic.ID)
+		out := bdProxiedCloseFail(t, bd, p.dir, wispEpic.ID)
+		if !strings.Contains(out, "open child") {
+			t.Errorf("expected 'open child' error for wisp epic, got: %s", out)
+		}
+	})
+
+	t.Run("close_wisp_blocked_refuses", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "cwbr")
+		blocker := bdProxiedCreate(t, bd, p.dir, "Blocker for wisp")
+		wisp := bdProxiedCreate(t, bd, p.dir, "Blocked wisp", "--ephemeral", "--deps", "depends-on:"+blocker.ID)
+		out := bdProxiedCloseFail(t, bd, p.dir, wisp.ID)
+		if !strings.Contains(out, "blocked by") {
+			t.Errorf("expected wisp blocker error, got: %s", out)
+		}
+	})
+
+	t.Run("continue_advances_to_next_ready_step", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "cantrs")
+		root := bdProxiedCreate(t, bd, p.dir, "Molecule root", "-t", "epic", "--labels", "template")
+		step1 := bdProxiedCreate(t, bd, p.dir, "Step 1", "--parent", root.ID)
+		step2 := bdProxiedCreate(t, bd, p.dir, "Step 2", "--parent", root.ID, "--deps", "depends-on:"+step1.ID)
+		_ = bdProxiedCreate(t, bd, p.dir, "Step 3", "--parent", root.ID, "--deps", "depends-on:"+step2.ID)
+		bdProxiedClose(t, bd, p.dir, step1.ID, "--continue")
+		db := openProxiedDB(t, p)
+		if got := readStatus(t, db, step2.ID); got != types.StatusInProgress {
+			t.Errorf("step2 status after --continue: got %q, want in_progress", got)
+		}
+		if readAssignee(t, db, step2.ID) == "" {
+			t.Error("step2 assignee should be set after --continue auto-claim")
+		}
+	})
+
+	t.Run("continue_no_auto_does_not_claim", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "cnac")
+		root := bdProxiedCreate(t, bd, p.dir, "Molecule root", "-t", "epic", "--labels", "template")
+		step1 := bdProxiedCreate(t, bd, p.dir, "Step 1", "--parent", root.ID)
+		step2 := bdProxiedCreate(t, bd, p.dir, "Step 2", "--parent", root.ID, "--deps", "depends-on:"+step1.ID)
+		bdProxiedClose(t, bd, p.dir, step1.ID, "--continue", "--no-auto")
+		db := openProxiedDB(t, p)
+		if got := readStatus(t, db, step2.ID); got != types.StatusOpen {
+			t.Errorf("step2 status with --no-auto: got %q, want open", got)
+		}
+		if readAssignee(t, db, step2.ID) != "" {
+			t.Error("step2 assignee should NOT be set with --no-auto")
+		}
+	})
+
+	t.Run("auto_close_completed_molecule", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "accm")
+		root := bdProxiedCreate(t, bd, p.dir, "Molecule root", "-t", "epic", "--labels", "template")
+		s1 := bdProxiedCreate(t, bd, p.dir, "Step 1", "--parent", root.ID)
+		s2 := bdProxiedCreate(t, bd, p.dir, "Step 2", "--parent", root.ID)
+		bdProxiedClose(t, bd, p.dir, s1.ID, s2.ID)
+		db := openProxiedDB(t, p)
+		if got := readStatus(t, db, root.ID); got != types.StatusClosed {
+			t.Errorf("template-labeled molecule root should auto-close after all steps complete, got %q", got)
+		}
+		if got := readCloseReason(t, db, root.ID); got != "all steps complete" {
+			t.Errorf("auto-close reason: got %q, want %q", got, "all steps complete")
+		}
+	})
+
+	t.Run("hooks_fire_on_close", func(t *testing.T) {
+		marker := filepath.Join(t.TempDir(), "on_close_marker")
+		script := "#!/bin/sh\nprintf '%s\\n' \"$1\" > " + shellQuote(marker) + "\n"
+		if runtime.GOOS == "windows" {
+			t.Skip("hook script form is POSIX shell")
+		}
+		p := bdProxiedInitWithHooks(t, bd, "hfc", map[string]string{"on_close": script})
+		issue := bdProxiedCreate(t, bd, p.dir, "Hook fire")
+		bdProxiedClose(t, bd, p.dir, issue.ID)
+		data, err := os.ReadFile(marker)
+		if err != nil {
+			t.Fatalf("hook marker not written: %v", err)
+		}
+		if !strings.Contains(string(data), issue.ID) {
+			t.Errorf("hook marker missing issue ID; got: %q", string(data))
+		}
+	})
+}
+
+func shellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", "'\\''") + "'"
+}
+
+func TestProxiedServerCloseConcurrent(t *testing.T) {
+	requireProxiedServerEnv(t)
+	bd := buildEmbeddedBD(t)
+
+	p := bdProxiedInit(t, bd, "cxc")
+
+	const (
+		numWorkers      = 10
+		issuesPerWorker = 5
+	)
+
+	type ws struct {
+		closed int
+		errs   []string
+	}
+	results := make([]ws, numWorkers)
+	var wg sync.WaitGroup
+	wg.Add(numWorkers)
+
+	for w := 0; w < numWorkers; w++ {
+		w := w
+		go func() {
+			defer wg.Done()
+			r := &results[w]
+			for i := 0; i < issuesPerWorker; i++ {
+				title := fmt.Sprintf("worker-%d-issue-%d", w, i)
+				cmd := exec.Command(bd, "create", "--json", title)
+				cmd.Dir = p.dir
+				cmd.Env = bdProxiedEnv(p.dir)
+				var stdout, stderr bytes.Buffer
+				cmd.Stdout = &stdout
+				cmd.Stderr = &stderr
+				if err := cmd.Run(); err != nil {
+					r.errs = append(r.errs, fmt.Sprintf("create %s: %v\n%s", title, err, stderr.String()))
+					continue
+				}
+				out := stdout.Bytes()
+				start := bytes.Index(out, []byte("{"))
+				if start < 0 {
+					r.errs = append(r.errs, "no JSON in create output")
+					continue
+				}
+				var issue types.Issue
+				if err := json.Unmarshal(out[start:], &issue); err != nil {
+					r.errs = append(r.errs, fmt.Sprintf("parse create JSON: %v", err))
+					continue
+				}
+
+				closeCmd := exec.Command(bd, "close", issue.ID)
+				closeCmd.Dir = p.dir
+				closeCmd.Env = bdProxiedEnv(p.dir)
+				var cstdout, cstderr bytes.Buffer
+				closeCmd.Stdout = &cstdout
+				closeCmd.Stderr = &cstderr
+				if err := closeCmd.Run(); err != nil {
+					r.errs = append(r.errs, fmt.Sprintf("close %s: %v\n%s", issue.ID, err, cstderr.String()))
+					continue
+				}
+				r.closed++
+			}
+		}()
+	}
+	wg.Wait()
+
+	totalClosed := 0
+	for w, r := range results {
+		totalClosed += r.closed
+		for _, e := range r.errs {
+			t.Errorf("worker %d: %s", w, e)
+		}
+	}
+	want := numWorkers * issuesPerWorker
+	if totalClosed != want {
+		t.Errorf("closed count: got %d, want %d", totalClosed, want)
+	}
+
+	db := openProxiedDB(t, p)
+	var openCount int
+	if err := db.QueryRowContext(context.Background(),
+		"SELECT COUNT(*) FROM issues WHERE status != 'closed'").Scan(&openCount); err != nil {
+		t.Fatalf("query open count: %v", err)
+	}
+	if openCount != 0 {
+		t.Errorf("open issues remain after concurrent close: %d", openCount)
+	}
+}

--- a/cmd/bd/close_proxied_server.go
+++ b/cmd/bd/close_proxied_server.go
@@ -1,0 +1,575 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/steveyegge/beads/internal/audit"
+	"github.com/steveyegge/beads/internal/hooks"
+	"github.com/steveyegge/beads/internal/storage"
+	"github.com/steveyegge/beads/internal/storage/domain"
+	"github.com/steveyegge/beads/internal/storage/uow"
+	"github.com/steveyegge/beads/internal/types"
+	"github.com/steveyegge/beads/internal/ui"
+)
+
+type closeProxiedInput struct {
+	force       bool
+	continueOn  bool
+	noAuto      bool
+	suggestNext bool
+	claimNext   bool
+	session     string
+	jsonOut     bool
+}
+
+type closeProxiedOutcome struct {
+	id     string
+	before *types.Issue
+	after  *types.Issue
+}
+
+func runCloseProxiedServer(cmd *cobra.Command, ctx context.Context, args []string) {
+	if len(args) == 0 {
+		FatalErrorRespectJSON("no issue ID provided")
+	}
+
+	reasons, updatedArgs, err := resolveCloseReasons(cmd, args)
+	if err != nil {
+		FatalErrorRespectJSON("%v", err)
+	}
+	args = updatedArgs
+	if err := validateCloseReasons(reasons); err != nil {
+		FatalErrorRespectJSON("%v", err)
+	}
+
+	in := gatherCloseProxiedInput(cmd)
+
+	if in.continueOn && len(args) > 1 {
+		FatalErrorRespectJSON("--continue only works when closing a single issue")
+	}
+	if in.suggestNext && len(args) > 1 {
+		FatalErrorRespectJSON("--suggest-next only works when closing a single issue")
+	}
+
+	if uowProvider == nil {
+		FatalError("proxied-server UOW provider not initialized")
+	}
+	uw, err := uowProvider.NewUOW(ctx)
+	if err != nil {
+		FatalErrorRespectJSON("open unit of work: %v", err)
+	}
+	defer uw.Close(ctx)
+
+	outcomes := make([]closeProxiedOutcome, 0, len(args))
+	closedIssues := []*types.Issue{}
+	for i, id := range args {
+		reason := reasonForCloseIndex(reasons, i)
+		outcome, ok := closeProxiedOne(ctx, uw, id, reason, in)
+		if !ok {
+			continue
+		}
+		outcomes = append(outcomes, outcome)
+		if in.jsonOut {
+			closedIssues = append(closedIssues, outcome.after)
+		} else {
+			fmt.Printf("%s Closed %s: %s\n", ui.RenderPass("✓"), formatFeedbackID(outcome.after.ID, outcome.after.Title), reason)
+		}
+	}
+
+	var unblocked []*types.Issue
+	if in.suggestNext && len(args) == 1 && len(outcomes) > 0 {
+		unblocked = closeProxiedSuggestNext(ctx, uw, args[0])
+	}
+
+	var continueResult *ContinueResult
+	if in.continueOn && len(args) == 1 && len(outcomes) > 0 {
+		continueResult = closeProxiedContinue(ctx, uw, args[0], !in.noAuto)
+	}
+
+	var claimedNextIssue *types.Issue
+	if in.claimNext && len(outcomes) > 0 && !in.continueOn {
+		claimedNextIssue = closeProxiedClaimNext(ctx, uw, in.jsonOut)
+	}
+
+	if len(outcomes) > 0 {
+		msg := closeProxiedCommitMessage(outcomes, claimedNextIssue, continueResult)
+		if err := uw.Commit(ctx, msg); err != nil && !isDoltNothingToCommit(err) {
+			FatalErrorRespectJSON("commit close: %v", err)
+		}
+		for _, o := range outcomes {
+			if err := fireProxiedCloseHooks(ctx, o.before, o.after); err != nil {
+				fmt.Fprintf(os.Stderr, "warning: %s: %v\n", o.id, err)
+			}
+		}
+	}
+
+	if !in.jsonOut {
+		if len(unblocked) > 0 {
+			fmt.Printf("\nNewly unblocked:\n")
+			for _, issue := range unblocked {
+				fmt.Printf("  • %s (P%d)\n", formatFeedbackID(issue.ID, issue.Title), issue.Priority)
+			}
+		}
+		if continueResult != nil {
+			PrintContinueResult(continueResult)
+		}
+		if claimedNextIssue != nil {
+			fmt.Printf("%s Auto-claimed next ready issue: %s (P%d)\n", ui.RenderPass("✓"), formatFeedbackID(claimedNextIssue.ID, claimedNextIssue.Title), claimedNextIssue.Priority)
+		}
+	}
+
+	if in.jsonOut && len(closedIssues) > 0 {
+		switch {
+		case len(unblocked) > 0:
+			outputJSON(map[string]interface{}{"closed": closedIssues, "unblocked": unblocked})
+		case continueResult != nil:
+			outputJSON(map[string]interface{}{"closed": closedIssues, "continue": continueResult})
+		case claimedNextIssue != nil:
+			outputJSON(map[string]interface{}{"closed": closedIssues, "claimed": claimedNextIssue})
+		default:
+			outputJSON(closedIssues)
+		}
+	}
+
+	if len(args) > 0 && len(outcomes) == 0 {
+		os.Exit(1)
+	}
+}
+
+func gatherCloseProxiedInput(cmd *cobra.Command) closeProxiedInput {
+	in := closeProxiedInput{}
+	in.force, _ = cmd.Flags().GetBool("force")
+	in.continueOn, _ = cmd.Flags().GetBool("continue")
+	in.noAuto, _ = cmd.Flags().GetBool("no-auto")
+	in.suggestNext, _ = cmd.Flags().GetBool("suggest-next")
+	in.claimNext, _ = cmd.Flags().GetBool("claim-next")
+	in.session, _ = cmd.Flags().GetString("session")
+	if in.session == "" {
+		in.session = os.Getenv("CLAUDE_SESSION_ID")
+	}
+	in.jsonOut, _ = cmd.Flags().GetBool("json")
+	return in
+}
+
+func closeProxiedOne(ctx context.Context, uw uow.UnitOfWork, id, reason string, in closeProxiedInput) (closeProxiedOutcome, bool) {
+	current, isWisp := proxiedResolveIssueOrWisp(ctx, uw, id)
+	if current == nil {
+		fmt.Fprintf(os.Stderr, "Issue %s not found\n", id)
+		return closeProxiedOutcome{}, false
+	}
+
+	if err := validateIssueClosable(id, current, in.force); err != nil {
+		fmt.Fprintf(os.Stderr, "%s\n", err)
+		return closeProxiedOutcome{}, false
+	}
+
+	if !in.force && current.IssueType == types.TypeEpic {
+		var openChildren int
+		var err error
+		if isWisp {
+			openChildren, err = uw.IssueUseCase().CountOpenWispChildren(ctx, id)
+		} else {
+			openChildren, err = uw.IssueUseCase().CountOpenChildren(ctx, id)
+		}
+		if err == nil && openChildren > 0 {
+			fmt.Fprintf(os.Stderr, "cannot close epic %s: %d open child issue(s); close children first or use --force to override\n", id, openChildren)
+			return closeProxiedOutcome{}, false
+		}
+	}
+
+	if !in.force {
+		if err := checkGateSatisfaction(current); err != nil {
+			fmt.Fprintf(os.Stderr, "cannot close %s: %s\n", id, err)
+			return closeProxiedOutcome{}, false
+		}
+	}
+
+	if !in.force {
+		var blocked bool
+		var blockers []string
+		var err error
+		if isWisp {
+			blocked, blockers, err = uw.DependencyUseCase().IsWispBlocked(ctx, id)
+		} else {
+			blocked, blockers, err = uw.DependencyUseCase().IsBlocked(ctx, id)
+		}
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error checking blockers for %s: %v\n", id, err)
+			return closeProxiedOutcome{}, false
+		}
+		if blocked && len(blockers) > 0 {
+			fmt.Fprintf(os.Stderr, "cannot close %s: blocked by open issues %v (use --force to override)\n", id, blockers)
+			return closeProxiedOutcome{}, false
+		}
+	}
+
+	params := domain.CloseIssueParams{Reason: reason, Session: in.session}
+	var (
+		res domain.CloseIssueResult
+		err error
+	)
+	if isWisp {
+		res, err = uw.IssueUseCase().CloseWisp(ctx, id, params, actor)
+	} else {
+		res, err = uw.IssueUseCase().CloseIssue(ctx, id, params, actor)
+	}
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error closing %s: %v\n", id, err)
+		return closeProxiedOutcome{}, false
+	}
+
+	oldStatus := string(current.Status)
+	if oldStatus == "" {
+		oldStatus = "open"
+	}
+	audit.LogFieldChange(id, "status", oldStatus, "closed", actor, reason)
+
+	autoCloseProxiedCompletedMolecule(ctx, uw, id, actor, in.session, in.jsonOut)
+
+	return closeProxiedOutcome{id: id, before: current, after: res.Issue}, true
+}
+
+func closeProxiedCommitMessage(outcomes []closeProxiedOutcome, claimed *types.Issue, cont *ContinueResult) string {
+	ids := make([]string, 0, len(outcomes))
+	for _, o := range outcomes {
+		ids = append(ids, o.id)
+	}
+	msg := "bd: close " + strings.Join(ids, ", ")
+	if cont != nil && cont.AutoAdvanced && cont.NextStep != nil {
+		msg += "; advance to " + cont.NextStep.ID
+	}
+	if claimed != nil {
+		msg += "; claim " + claimed.ID
+	}
+	return msg
+}
+
+func proxiedResolveIssueOrWisp(ctx context.Context, uw uow.UnitOfWork, id string) (*types.Issue, bool) {
+	issue, err := uw.IssueUseCase().GetIssue(ctx, id)
+	if err == nil && issue != nil {
+		return issue, false
+	}
+	wisp, err := uw.IssueUseCase().GetWisp(ctx, id)
+	if err == nil && wisp != nil {
+		return wisp, true
+	}
+	return nil, false
+}
+
+func fireProxiedCloseHooks(ctx context.Context, before, after *types.Issue) error {
+	if after == nil {
+		return nil
+	}
+	runner, err := proxiedHookRunner(ctx)
+	if err != nil {
+		return fmt.Errorf("hook runner: %w", err)
+	}
+	if runner == nil {
+		return nil
+	}
+	if err := runner.RunSync(hooks.EventUpdate, after); err != nil {
+		return fmt.Errorf("on_update hook: %w", err)
+	}
+	if before != nil && before.Status != types.StatusClosed && after.Status == types.StatusClosed {
+		if err := runner.RunSync(hooks.EventClose, after); err != nil {
+			return fmt.Errorf("on_close hook: %w", err)
+		}
+	}
+	return nil
+}
+
+func closeProxiedSuggestNext(ctx context.Context, uw uow.UnitOfWork, closedID string) []*types.Issue {
+	unblocked, err := uw.IssueUseCase().GetNewlyUnblockedByClose(ctx, closedID)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: could not compute newly unblocked: %v\n", err)
+		return nil
+	}
+	return unblocked
+}
+
+func closeProxiedClaimNext(ctx context.Context, uw uow.UnitOfWork, jsonOut bool) *types.Issue {
+	page, err := uw.IssueUseCase().GetReadyWork(ctx, types.WorkFilter{
+		Status:     "open",
+		Limit:      1,
+		SortPolicy: types.SortPolicy("priority"),
+	})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: could not get ready issues: %v\n", err)
+		return nil
+	}
+	if len(page.Items) == 0 {
+		if !jsonOut {
+			fmt.Printf("\n%s No ready issues available to claim.\n", ui.RenderWarn("✨"))
+		}
+		return nil
+	}
+
+	nextIssue := page.Items[0]
+	if _, err := uw.IssueUseCase().ClaimIssue(ctx, nextIssue.ID, actor); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: could not claim next issue %s: %v\n", nextIssue.ID, err)
+		return nil
+	}
+	return nextIssue
+}
+
+func closeProxiedContinue(ctx context.Context, uw uow.UnitOfWork, closedID string, autoClaim bool) *ContinueResult {
+	result, err := proxiedAdvanceToNextStep(ctx, uw, closedID, autoClaim, actor)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: could not advance to next step: %v\n", err)
+		return nil
+	}
+	return result
+}
+
+func autoCloseProxiedCompletedMolecule(ctx context.Context, uw uow.UnitOfWork, closedStepID string, actorName, session string, jsonOut bool) {
+	moleculeID := proxiedFindParentMolecule(ctx, uw, closedStepID)
+	if moleculeID == "" {
+		return
+	}
+
+	root, err := uw.IssueUseCase().GetIssue(ctx, moleculeID)
+	if err != nil || root == nil || root.Status == types.StatusClosed {
+		return
+	}
+	if labels, err := uw.LabelUseCase().GetLabels(ctx, moleculeID); err == nil {
+		root.Labels = labels
+	}
+	if !shouldAutoCloseCompletedRoot(root) {
+		return
+	}
+
+	progress, err := proxiedGetMoleculeProgress(ctx, uw, moleculeID)
+	if err != nil {
+		return
+	}
+	if progress.Completed < progress.Total {
+		return
+	}
+
+	params := domain.CloseIssueParams{Reason: "all steps complete", Session: session}
+	if _, err := uw.IssueUseCase().CloseIssue(ctx, moleculeID, params, actorName); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: could not auto-close completed molecule %s: %v\n", moleculeID, err)
+		return
+	}
+	if !jsonOut {
+		fmt.Printf("%s Auto-closed completed molecule %s\n", ui.RenderPass("✓"), formatFeedbackID(moleculeID, root.Title))
+	}
+}
+
+func proxiedFindParentMolecule(ctx context.Context, uw uow.UnitOfWork, issueID string) string {
+	current := issueID
+	for depth := 0; depth < 50; depth++ {
+		deps, err := uw.DependencyUseCase().GetForIssueIDs(ctx, []string{current})
+		if err != nil {
+			return ""
+		}
+		var parent string
+		for _, dep := range deps[current] {
+			if dep.Type == types.DepParentChild {
+				parent = dep.DependsOnID
+				break
+			}
+		}
+		if parent == "" {
+			if current == issueID {
+				return ""
+			}
+			return current
+		}
+		current = parent
+	}
+	return current
+}
+
+func proxiedLoadTemplateSubgraph(ctx context.Context, uw uow.UnitOfWork, templateID string) (*TemplateSubgraph, error) {
+	root, err := uw.IssueUseCase().GetIssue(ctx, templateID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get template: %w", err)
+	}
+	if root == nil {
+		return nil, fmt.Errorf("template %s not found", templateID)
+	}
+
+	subgraph := &TemplateSubgraph{
+		Root:     root,
+		Issues:   []*types.Issue{root},
+		IssueMap: map[string]*types.Issue{root.ID: root},
+	}
+
+	visited := map[string]bool{root.ID: true}
+	if err := proxiedLoadDescendants(ctx, uw, subgraph, root.ID, visited); err != nil {
+		return nil, err
+	}
+
+	for _, issue := range subgraph.Issues {
+		deps, err := uw.DependencyUseCase().GetForIssueIDs(ctx, []string{issue.ID})
+		if err != nil {
+			return nil, fmt.Errorf("failed to get dependencies for %s: %w", issue.ID, err)
+		}
+		for _, dep := range deps[issue.ID] {
+			if _, ok := subgraph.IssueMap[dep.DependsOnID]; ok {
+				subgraph.Dependencies = append(subgraph.Dependencies, dep)
+			}
+		}
+	}
+
+	return subgraph, nil
+}
+
+func proxiedLoadDescendants(ctx context.Context, uw uow.UnitOfWork, subgraph *TemplateSubgraph, parentID string, visited map[string]bool) error {
+	dependents, err := uw.DependencyUseCase().ListWithIssueMetadata(ctx, parentID, domain.DepListFilter{
+		Direction: domain.DepDirectionIn,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to get dependents of %s: %w", parentID, err)
+	}
+
+	for _, dependent := range dependents {
+		if dependent.DependencyType != types.DepParentChild {
+			continue
+		}
+		if _, exists := subgraph.IssueMap[dependent.ID]; exists {
+			continue
+		}
+		if visited[dependent.ID] {
+			continue
+		}
+		child := dependent.Issue
+		subgraph.Issues = append(subgraph.Issues, &child)
+		subgraph.IssueMap[child.ID] = &child
+		visited[child.ID] = true
+		if err := proxiedLoadDescendants(ctx, uw, subgraph, child.ID, visited); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func proxiedGetMoleculeProgress(ctx context.Context, uw uow.UnitOfWork, moleculeID string) (*MoleculeProgress, error) {
+	subgraph, err := proxiedLoadTemplateSubgraph(ctx, uw, moleculeID)
+	if err != nil {
+		return nil, err
+	}
+
+	progress := &MoleculeProgress{
+		MoleculeID:    subgraph.Root.ID,
+		MoleculeTitle: subgraph.Root.Title,
+		Assignee:      subgraph.Root.Assignee,
+		Total:         len(subgraph.Issues) - 1,
+	}
+
+	analysis := analyzeMoleculeParallel(subgraph)
+	readyIDs := make(map[string]bool)
+	for id, info := range analysis.Steps {
+		if info.IsReady {
+			readyIDs[id] = true
+		}
+	}
+
+	var steps []*StepStatus
+	for _, issue := range subgraph.Issues {
+		if issue.ID == subgraph.Root.ID {
+			continue
+		}
+		step := &StepStatus{Issue: issue}
+		switch issue.Status {
+		case types.StatusClosed:
+			step.Status = "done"
+			progress.Completed++
+		case types.StatusInProgress:
+			step.Status = "current"
+			step.IsCurrent = true
+			progress.CurrentStep = issue
+		case types.StatusBlocked:
+			step.Status = "blocked"
+		default:
+			if readyIDs[issue.ID] {
+				step.Status = "ready"
+				if progress.NextStep == nil {
+					progress.NextStep = issue
+				}
+			} else {
+				step.Status = "pending"
+			}
+		}
+		steps = append(steps, step)
+	}
+
+	sortStepsByDependencyOrder(steps, subgraph)
+	progress.Steps = steps
+
+	if progress.CurrentStep == nil && progress.NextStep == nil {
+		for _, step := range steps {
+			if step.Status == "ready" {
+				progress.NextStep = step.Issue
+				break
+			}
+		}
+	}
+
+	return progress, nil
+}
+
+func proxiedAdvanceToNextStep(ctx context.Context, uw uow.UnitOfWork, closedStepID string, autoClaim bool, actorName string) (*ContinueResult, error) {
+	closedStep, err := uw.IssueUseCase().GetIssue(ctx, closedStepID)
+	if err != nil || closedStep == nil {
+		wisp, wErr := uw.IssueUseCase().GetWisp(ctx, closedStepID)
+		if wErr != nil || wisp == nil {
+			return nil, fmt.Errorf("could not get closed step: %w", err)
+		}
+		closedStep = wisp
+	}
+
+	result := &ContinueResult{ClosedStep: closedStep}
+
+	moleculeID := proxiedFindParentMolecule(ctx, uw, closedStepID)
+	if moleculeID == "" {
+		return nil, nil
+	}
+	result.MoleculeID = moleculeID
+
+	progress, err := proxiedGetMoleculeProgress(ctx, uw, moleculeID)
+	if err != nil {
+		return nil, fmt.Errorf("could not load molecule: %w", err)
+	}
+
+	if progress.Completed >= progress.Total {
+		result.MolComplete = true
+		return result, nil
+	}
+
+	var readySteps []*types.Issue
+	for _, step := range progress.Steps {
+		if step.Status == "ready" {
+			readySteps = append(readySteps, step.Issue)
+		}
+	}
+	if len(readySteps) == 0 {
+		return result, nil
+	}
+	result.NextStep = readySteps[0]
+
+	if !autoClaim {
+		return result, nil
+	}
+
+	for _, candidate := range readySteps {
+		_, claimErr := uw.IssueUseCase().ClaimIssueIfOpen(ctx, candidate.ID, actorName)
+		if claimErr == nil {
+			result.NextStep = candidate
+			result.AutoAdvanced = true
+			return result, nil
+		}
+		if errors.Is(claimErr, storage.ErrAlreadyClaimed) || errors.Is(claimErr, storage.ErrNotClaimable) {
+			continue
+		}
+		return result, nil
+	}
+	return result, nil
+}

--- a/cmd/bd/close_proxied_server.go
+++ b/cmd/bd/close_proxied_server.go
@@ -32,6 +32,7 @@ type closeProxiedOutcome struct {
 	id     string
 	before *types.Issue
 	after  *types.Issue
+	closed bool
 }
 
 func runCloseProxiedServer(cmd *cobra.Command, ctx context.Context, args []string) {
@@ -103,6 +104,9 @@ func runCloseProxiedServer(cmd *cobra.Command, ctx context.Context, args []strin
 			FatalErrorRespectJSON("commit close: %v", err)
 		}
 		for _, o := range outcomes {
+			if !o.closed {
+				continue
+			}
 			if err := fireProxiedCloseHooks(ctx, o.before, o.after); err != nil {
 				fmt.Fprintf(os.Stderr, "warning: %s: %v\n", o.id, err)
 			}
@@ -232,7 +236,7 @@ func closeProxiedOne(ctx context.Context, uw uow.UnitOfWork, id, reason string, 
 
 	autoCloseProxiedCompletedMolecule(ctx, uw, id, actor, in.session, in.jsonOut)
 
-	return closeProxiedOutcome{id: id, before: current, after: res.Issue}, true
+	return closeProxiedOutcome{id: id, before: current, after: res.Issue, closed: res.Closed}, true
 }
 
 func closeProxiedCommitMessage(outcomes []closeProxiedOutcome, claimed *types.Issue, cont *ContinueResult) string {

--- a/cmd/bd/init.go
+++ b/cmd/bd/init.go
@@ -120,12 +120,12 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 		if os.Getenv("BEADS_DOLT_PROXIED_SERVER") == "1" {
 			initProxiedServer = true
 		}
-		if initProxiedServer {
-			// Proxied-server mode has no local Dolt init lifecycle yet. When it
-			// is implemented, that path must mark any local .dolt/ it creates or
-			// acknowledges with doltserver.MarkDoltDirCompatible.
-			FatalError("--proxied-server is not yet implemented")
-		}
+		// if initProxiedServer {
+		// 	// Proxied-server mode has no local Dolt init lifecycle yet. When it
+		// 	// is implemented, that path must mark any local .dolt/ it creates or
+		// 	// acknowledges with doltserver.MarkDoltDirCompatible.
+		// 	FatalError("--proxied-server is not yet implemented")
+		// }
 		if initProxiedServer && initServerMode {
 			FatalError("--server and --proxied-server are mutually exclusive")
 		}

--- a/cmd/bd/init.go
+++ b/cmd/bd/init.go
@@ -120,12 +120,12 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 		if os.Getenv("BEADS_DOLT_PROXIED_SERVER") == "1" {
 			initProxiedServer = true
 		}
-		// if initProxiedServer {
-		// 	// Proxied-server mode has no local Dolt init lifecycle yet. When it
-		// 	// is implemented, that path must mark any local .dolt/ it creates or
-		// 	// acknowledges with doltserver.MarkDoltDirCompatible.
-		// 	FatalError("--proxied-server is not yet implemented")
-		// }
+		if initProxiedServer {
+			// Proxied-server mode has no local Dolt init lifecycle yet. When it
+			// is implemented, that path must mark any local .dolt/ it creates or
+			// acknowledges with doltserver.MarkDoltDirCompatible.
+			FatalError("--proxied-server is not yet implemented")
+		}
 		if initProxiedServer && initServerMode {
 			FatalError("--server and --proxied-server are mutually exclusive")
 		}

--- a/internal/storage/domain/db/close_test.go
+++ b/internal/storage/domain/db/close_test.go
@@ -1,0 +1,252 @@
+package db
+
+import (
+	"github.com/steveyegge/beads/internal/storage/domain"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+func (s *testSuite) TestIssueSQLRepositoryClose() {
+	s.Run("ClosesOpenIssue", s.closeMutatesRow)
+	s.Run("IdempotentOnAlreadyClosed", s.closeIdempotent)
+	s.Run("RecomputesIsBlockedOnDependents", s.closeRecomputesIsBlocked)
+	s.Run("MissingIDErrors", s.closeMissingID)
+	s.Run("RoutesWisp", s.closeRoutesWisp)
+}
+
+func (s *testSuite) TestIssueSQLRepositoryGetNewlyUnblockedByClose() {
+	s.Run("ReturnsDependentNowUnblocked", s.unblockedReturnsDependent)
+	s.Run("OmitsDependentWithOtherOpenBlocker", s.unblockedOmitsWithOther)
+	s.Run("OmitsAlreadyClosedDependent", s.unblockedOmitsClosed)
+	s.Run("EmptyWhenNoDependents", s.unblockedEmpty)
+}
+
+func (s *testSuite) TestDependencySQLRepositoryIsBlocked() {
+	s.Run("FalseWhenNoBlockers", s.isBlockedFalseWhenNoBlockers)
+	s.Run("TrueWhenOpenBlocksEdge", s.isBlockedTrueOnBlocks)
+	s.Run("FalseAfterBlockerClosed", s.isBlockedFalseAfterBlockerClosed)
+	s.Run("TrueOnWaitsForEdge", s.isBlockedTrueOnWaitsFor)
+	s.Run("TrueOnConditionalBlocksEdge", s.isBlockedTrueOnConditionalBlocks)
+}
+
+func (s *testSuite) closeMutatesRow() {
+	s.seedIssueRow("bd-cl-row")
+	r := NewIssueSQLRepository(s.Runner())
+
+	res, err := r.Close(s.Ctx(), "bd-cl-row",
+		domain.CloseRowParams{Reason: "done", Session: "sess-1"}, "tester", domain.IssueTableOpts{})
+	s.Require().NoError(err)
+	s.True(res.Updated)
+	s.False(res.AlreadyClosed)
+	s.False(res.IsWisp)
+
+	var status, reason, session string
+	s.Require().NoError(s.Runner().QueryRowContext(s.Ctx(),
+		"SELECT status, close_reason, closed_by_session FROM issues WHERE id = ?", "bd-cl-row").
+		Scan(&status, &reason, &session))
+	s.Equal(string(types.StatusClosed), status)
+	s.Equal("done", reason)
+	s.Equal("sess-1", session)
+
+	var evtCount int
+	s.Require().NoError(s.Runner().QueryRowContext(s.Ctx(),
+		"SELECT COUNT(*) FROM events WHERE issue_id = ? AND event_type = ?",
+		"bd-cl-row", string(types.EventClosed)).Scan(&evtCount))
+	s.Equal(1, evtCount)
+}
+
+func (s *testSuite) closeIdempotent() {
+	s.seedIssueRow("bd-cl-idem")
+	r := NewIssueSQLRepository(s.Runner())
+
+	_, err := r.Close(s.Ctx(), "bd-cl-idem",
+		domain.CloseRowParams{Reason: "first"}, "tester", domain.IssueTableOpts{})
+	s.Require().NoError(err)
+
+	res, err := r.Close(s.Ctx(), "bd-cl-idem",
+		domain.CloseRowParams{Reason: "second"}, "tester", domain.IssueTableOpts{})
+	s.Require().NoError(err)
+	s.False(res.Updated)
+	s.True(res.AlreadyClosed)
+
+	var reason string
+	s.Require().NoError(s.Runner().QueryRowContext(s.Ctx(),
+		"SELECT close_reason FROM issues WHERE id = ?", "bd-cl-idem").Scan(&reason))
+	s.Equal("first", reason)
+
+	var evtCount int
+	s.Require().NoError(s.Runner().QueryRowContext(s.Ctx(),
+		"SELECT COUNT(*) FROM events WHERE issue_id = ? AND event_type = ?",
+		"bd-cl-idem", string(types.EventClosed)).Scan(&evtCount))
+	s.Equal(1, evtCount)
+}
+
+func (s *testSuite) closeRecomputesIsBlocked() {
+	s.seedIssueRow("bd-cl-src")
+	s.seedIssueRow("bd-cl-tgt")
+	s.Require().NoError(s.depRepo().Insert(s.Ctx(),
+		newDep("bd-cl-src", "bd-cl-tgt", types.DepBlocks), "tester", domain.DepInsertOpts{}))
+	s.Require().True(s.isBlocked("bd-cl-src"))
+
+	r := NewIssueSQLRepository(s.Runner())
+	_, err := r.Close(s.Ctx(), "bd-cl-tgt",
+		domain.CloseRowParams{Reason: "done"}, "tester", domain.IssueTableOpts{})
+	s.Require().NoError(err)
+
+	s.False(s.isBlocked("bd-cl-src"), "closing the blocker must clear cached is_blocked on dependent")
+}
+
+func (s *testSuite) closeMissingID() {
+	r := NewIssueSQLRepository(s.Runner())
+	_, err := r.Close(s.Ctx(), "bd-cl-missing",
+		domain.CloseRowParams{Reason: "noop"}, "tester", domain.IssueTableOpts{})
+	s.Require().Error(err)
+}
+
+func (s *testSuite) closeRoutesWisp() {
+	s.seedWispRow("bd-cl-wisp")
+	r := NewIssueSQLRepository(s.Runner())
+
+	res, err := r.Close(s.Ctx(), "bd-cl-wisp",
+		domain.CloseRowParams{Reason: "done"}, "tester", domain.IssueTableOpts{UseWispsTable: true})
+	s.Require().NoError(err)
+	s.True(res.Updated)
+	s.True(res.IsWisp)
+
+	var status string
+	s.Require().NoError(s.Runner().QueryRowContext(s.Ctx(),
+		"SELECT status FROM wisps WHERE id = ?", "bd-cl-wisp").Scan(&status))
+	s.Equal(string(types.StatusClosed), status)
+}
+
+func (s *testSuite) unblockedReturnsDependent() {
+	s.seedIssueRow("bd-un-dep")
+	s.seedIssueRow("bd-un-blocker")
+	s.Require().NoError(s.depRepo().Insert(s.Ctx(),
+		newDep("bd-un-dep", "bd-un-blocker", types.DepBlocks), "tester", domain.DepInsertOpts{}))
+
+	r := NewIssueSQLRepository(s.Runner())
+	_, err := r.Close(s.Ctx(), "bd-un-blocker",
+		domain.CloseRowParams{Reason: "done"}, "tester", domain.IssueTableOpts{})
+	s.Require().NoError(err)
+
+	unblocked, err := r.GetNewlyUnblockedByClose(s.Ctx(), "bd-un-blocker")
+	s.Require().NoError(err)
+	s.Require().Len(unblocked, 1)
+	s.Equal("bd-un-dep", unblocked[0].ID)
+}
+
+func (s *testSuite) unblockedOmitsWithOther() {
+	s.seedIssueRow("bd-un2-dep")
+	s.seedIssueRow("bd-un2-b1")
+	s.seedIssueRow("bd-un2-b2")
+	dep := s.depRepo()
+	s.Require().NoError(dep.Insert(s.Ctx(),
+		newDep("bd-un2-dep", "bd-un2-b1", types.DepBlocks), "tester", domain.DepInsertOpts{}))
+	s.Require().NoError(dep.Insert(s.Ctx(),
+		newDep("bd-un2-dep", "bd-un2-b2", types.DepBlocks), "tester", domain.DepInsertOpts{}))
+
+	r := NewIssueSQLRepository(s.Runner())
+	_, err := r.Close(s.Ctx(), "bd-un2-b1",
+		domain.CloseRowParams{Reason: "done"}, "tester", domain.IssueTableOpts{})
+	s.Require().NoError(err)
+
+	unblocked, err := r.GetNewlyUnblockedByClose(s.Ctx(), "bd-un2-b1")
+	s.Require().NoError(err)
+	s.Empty(unblocked, "dependent still has bd-un2-b2 open as blocker")
+}
+
+func (s *testSuite) unblockedOmitsClosed() {
+	s.seedIssueRow("bd-un3-dep")
+	s.seedIssueRow("bd-un3-blocker")
+	s.Require().NoError(s.depRepo().Insert(s.Ctx(),
+		newDep("bd-un3-dep", "bd-un3-blocker", types.DepBlocks), "tester", domain.DepInsertOpts{}))
+
+	r := NewIssueSQLRepository(s.Runner())
+	_, err := r.Close(s.Ctx(), "bd-un3-dep",
+		domain.CloseRowParams{Reason: "done"}, "tester", domain.IssueTableOpts{})
+	s.Require().NoError(err)
+	_, err = r.Close(s.Ctx(), "bd-un3-blocker",
+		domain.CloseRowParams{Reason: "done"}, "tester", domain.IssueTableOpts{})
+	s.Require().NoError(err)
+
+	unblocked, err := r.GetNewlyUnblockedByClose(s.Ctx(), "bd-un3-blocker")
+	s.Require().NoError(err)
+	s.Empty(unblocked, "already-closed dependents must not be returned")
+}
+
+func (s *testSuite) unblockedEmpty() {
+	s.seedIssueRow("bd-un4-lonely")
+	r := NewIssueSQLRepository(s.Runner())
+	_, err := r.Close(s.Ctx(), "bd-un4-lonely",
+		domain.CloseRowParams{Reason: "done"}, "tester", domain.IssueTableOpts{})
+	s.Require().NoError(err)
+
+	unblocked, err := r.GetNewlyUnblockedByClose(s.Ctx(), "bd-un4-lonely")
+	s.Require().NoError(err)
+	s.Empty(unblocked)
+}
+
+func (s *testSuite) isBlockedFalseWhenNoBlockers() {
+	s.seedIssueRow("bd-isb-free")
+	blocked, blockers, err := s.depRepo().IsBlocked(s.Ctx(), "bd-isb-free", domain.DepListOpts{})
+	s.Require().NoError(err)
+	s.False(blocked)
+	s.Empty(blockers)
+}
+
+func (s *testSuite) isBlockedTrueOnBlocks() {
+	s.seedIssueRow("bd-isb-src")
+	s.seedIssueRow("bd-isb-tgt")
+	s.Require().NoError(s.depRepo().Insert(s.Ctx(),
+		newDep("bd-isb-src", "bd-isb-tgt", types.DepBlocks), "tester", domain.DepInsertOpts{}))
+
+	blocked, blockers, err := s.depRepo().IsBlocked(s.Ctx(), "bd-isb-src", domain.DepListOpts{})
+	s.Require().NoError(err)
+	s.True(blocked)
+	s.Contains(blockers, "bd-isb-tgt")
+}
+
+func (s *testSuite) isBlockedFalseAfterBlockerClosed() {
+	s.seedIssueRow("bd-isb-c-src")
+	s.seedIssueRow("bd-isb-c-tgt")
+	s.Require().NoError(s.depRepo().Insert(s.Ctx(),
+		newDep("bd-isb-c-src", "bd-isb-c-tgt", types.DepBlocks), "tester", domain.DepInsertOpts{}))
+
+	r := NewIssueSQLRepository(s.Runner())
+	_, err := r.Close(s.Ctx(), "bd-isb-c-tgt",
+		domain.CloseRowParams{Reason: "done"}, "tester", domain.IssueTableOpts{})
+	s.Require().NoError(err)
+
+	blocked, _, err := s.depRepo().IsBlocked(s.Ctx(), "bd-isb-c-src", domain.DepListOpts{})
+	s.Require().NoError(err)
+	s.False(blocked)
+}
+
+func (s *testSuite) isBlockedTrueOnWaitsFor() {
+	s.seedIssueRow("bd-isb-wf-src")
+	s.seedIssueRow("bd-isb-wf-hard")
+	s.seedIssueRow("bd-isb-wf-tgt")
+	dep := s.depRepo()
+	s.Require().NoError(dep.Insert(s.Ctx(),
+		newDep("bd-isb-wf-src", "bd-isb-wf-hard", types.DepBlocks), "tester", domain.DepInsertOpts{}))
+	s.Require().NoError(dep.Insert(s.Ctx(),
+		newDep("bd-isb-wf-src", "bd-isb-wf-tgt", types.DepWaitsFor), "tester", domain.DepInsertOpts{}))
+
+	blocked, blockers, err := dep.IsBlocked(s.Ctx(), "bd-isb-wf-src", domain.DepListOpts{})
+	s.Require().NoError(err)
+	s.True(blocked)
+	s.Contains(blockers, "bd-isb-wf-hard")
+	s.Contains(blockers, "bd-isb-wf-tgt (waits-for)")
+}
+
+func (s *testSuite) isBlockedTrueOnConditionalBlocks() {
+	s.seedIssueRow("bd-isb-cb-src")
+	s.seedIssueRow("bd-isb-cb-tgt")
+	s.Require().NoError(s.depRepo().Insert(s.Ctx(),
+		newDep("bd-isb-cb-src", "bd-isb-cb-tgt", types.DepConditionalBlocks), "tester", domain.DepInsertOpts{}))
+
+	blocked, blockers, err := s.depRepo().IsBlocked(s.Ctx(), "bd-isb-cb-src", domain.DepListOpts{})
+	s.Require().NoError(err)
+	s.True(blocked)
+	s.Contains(blockers, "bd-isb-cb-tgt (conditional-blocks)")
+}

--- a/internal/storage/domain/db/close_usecase_test.go
+++ b/internal/storage/domain/db/close_usecase_test.go
@@ -1,0 +1,242 @@
+package db
+
+import (
+	"errors"
+
+	"github.com/steveyegge/beads/internal/storage"
+	"github.com/steveyegge/beads/internal/storage/domain"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+func (s *testSuite) TestIssueUseCase_CloseIssue() {
+	s.Run("ReturnsUpdatedIssue", s.uccCloseReturnsIssue)
+	s.Run("AlreadyClosedReportsNotClosed", s.uccCloseAlreadyClosed)
+	s.Run("EmptyIDErrors", s.uccCloseEmptyID)
+	s.Run("EmptyActorErrors", s.uccCloseEmptyActor)
+	s.Run("WispVariantRoutesToWispsTable", s.uccCloseWispRoutes)
+}
+
+func (s *testSuite) TestIssueUseCase_ClaimIfOpen() {
+	s.Run("OpenIssueClaimedSuccessfully", s.uccClaimIfOpenOpen)
+	s.Run("AlreadyClosedReturnsNotClaimable", s.uccClaimIfOpenClosed)
+	s.Run("AlreadyClaimedByOtherReturnsAlreadyClaimed", s.uccClaimIfOpenContested)
+	s.Run("AlreadyClaimedBySameActorIsIdempotent", s.uccClaimIfOpenIdempotent)
+}
+
+func (s *testSuite) TestIssueUseCase_CountOpenChildren() {
+	s.Run("CountsNonClosedChildrenOnly", s.uccCountOpenChildrenMixed)
+	s.Run("ZeroWhenNoChildren", s.uccCountOpenChildrenNone)
+	s.Run("IgnoresNonParentChildEdges", s.uccCountOpenChildrenIgnoresOtherTypes)
+	s.Run("EmptyIDErrors", s.uccCountOpenChildrenEmptyID)
+}
+
+func (s *testSuite) TestIssueUseCase_GetNewlyUnblockedByClose() {
+	s.Run("ReturnsDependent", s.uccUnblockedReturnsDependent)
+	s.Run("EmptyIDErrors", s.uccUnblockedEmptyID)
+}
+
+func (s *testSuite) TestDependencyUseCase_IsBlocked() {
+	s.Run("TrueOnBlocksEdge", s.uccIsBlockedTrue)
+	s.Run("FalseWhenNoBlockers", s.uccIsBlockedFalse)
+	s.Run("EmptyIDErrors", s.uccIsBlockedEmptyID)
+}
+
+func (s *testSuite) uccCloseReturnsIssue() {
+	s.seedIssueRow("bd-ucc-cl-1")
+	uc := s.issueUseCase()
+
+	res, err := uc.CloseIssue(s.Ctx(), "bd-ucc-cl-1",
+		domain.CloseIssueParams{Reason: "done", Session: "sess-1"}, "tester")
+	s.Require().NoError(err)
+	s.True(res.Closed)
+	s.Require().NotNil(res.Issue)
+	s.Equal("bd-ucc-cl-1", res.Issue.ID)
+	s.Equal(types.StatusClosed, res.Issue.Status)
+}
+
+func (s *testSuite) uccCloseAlreadyClosed() {
+	s.seedIssueRow("bd-ucc-cl-2")
+	uc := s.issueUseCase()
+
+	_, err := uc.CloseIssue(s.Ctx(), "bd-ucc-cl-2",
+		domain.CloseIssueParams{Reason: "first"}, "tester")
+	s.Require().NoError(err)
+
+	res, err := uc.CloseIssue(s.Ctx(), "bd-ucc-cl-2",
+		domain.CloseIssueParams{Reason: "second"}, "tester")
+	s.Require().NoError(err)
+	s.False(res.Closed)
+	s.Require().NotNil(res.Issue)
+	s.Equal(types.StatusClosed, res.Issue.Status)
+}
+
+func (s *testSuite) uccCloseEmptyID() {
+	_, err := s.issueUseCase().CloseIssue(s.Ctx(), "",
+		domain.CloseIssueParams{Reason: "x"}, "tester")
+	s.Require().Error(err)
+}
+
+func (s *testSuite) uccCloseEmptyActor() {
+	s.seedIssueRow("bd-ucc-cl-noactor")
+	_, err := s.issueUseCase().CloseIssue(s.Ctx(), "bd-ucc-cl-noactor",
+		domain.CloseIssueParams{Reason: "x"}, "")
+	s.Require().Error(err)
+}
+
+func (s *testSuite) uccCloseWispRoutes() {
+	s.seedWispRow("bd-ucc-cl-wisp")
+	uc := s.issueUseCase()
+
+	res, err := uc.CloseWisp(s.Ctx(), "bd-ucc-cl-wisp",
+		domain.CloseIssueParams{Reason: "done"}, "tester")
+	s.Require().NoError(err)
+	s.True(res.Closed)
+	s.Require().NotNil(res.Issue)
+	s.Equal(types.StatusClosed, res.Issue.Status)
+
+	var status string
+	s.Require().NoError(s.Runner().QueryRowContext(s.Ctx(),
+		"SELECT status FROM wisps WHERE id = ?", "bd-ucc-cl-wisp").Scan(&status))
+	s.Equal(string(types.StatusClosed), status)
+}
+
+func (s *testSuite) uccClaimIfOpenOpen() {
+	s.seedIssueRow("bd-ucc-cif-1")
+	res, err := s.issueUseCase().ClaimIssueIfOpen(s.Ctx(), "bd-ucc-cif-1", "tester")
+	s.Require().NoError(err)
+	s.False(res.AlreadyClaimed)
+
+	var status, assignee string
+	s.Require().NoError(s.Runner().QueryRowContext(s.Ctx(),
+		"SELECT status, assignee FROM issues WHERE id = ?", "bd-ucc-cif-1").Scan(&status, &assignee))
+	s.Equal(string(types.StatusInProgress), status)
+	s.Equal("tester", assignee)
+}
+
+func (s *testSuite) uccClaimIfOpenClosed() {
+	s.seedIssueRow("bd-ucc-cif-2")
+	uc := s.issueUseCase()
+	_, err := uc.CloseIssue(s.Ctx(), "bd-ucc-cif-2",
+		domain.CloseIssueParams{Reason: "done"}, "tester")
+	s.Require().NoError(err)
+
+	_, err = uc.ClaimIssueIfOpen(s.Ctx(), "bd-ucc-cif-2", "tester")
+	s.Require().Error(err)
+	s.True(errors.Is(err, storage.ErrNotClaimable))
+}
+
+func (s *testSuite) uccClaimIfOpenContested() {
+	s.seedIssueRow("bd-ucc-cif-3")
+	uc := s.issueUseCase()
+	_, err := uc.ClaimIssueIfOpen(s.Ctx(), "bd-ucc-cif-3", "alice")
+	s.Require().NoError(err)
+
+	_, err = uc.ClaimIssueIfOpen(s.Ctx(), "bd-ucc-cif-3", "bob")
+	s.Require().Error(err)
+	s.True(errors.Is(err, storage.ErrAlreadyClaimed))
+}
+
+func (s *testSuite) uccClaimIfOpenIdempotent() {
+	s.seedIssueRow("bd-ucc-cif-4")
+	uc := s.issueUseCase()
+	_, err := uc.ClaimIssueIfOpen(s.Ctx(), "bd-ucc-cif-4", "alice")
+	s.Require().NoError(err)
+
+	res, err := uc.ClaimIssueIfOpen(s.Ctx(), "bd-ucc-cif-4", "alice")
+	s.Require().NoError(err)
+	s.True(res.AlreadyClaimed)
+	s.Equal("alice", res.PriorAssignee)
+}
+
+func (s *testSuite) uccCountOpenChildrenMixed() {
+	s.seedIssueRow("bd-ucc-coc-parent")
+	s.seedIssueRow("bd-ucc-coc-c1")
+	s.seedIssueRow("bd-ucc-coc-c2")
+	s.seedIssueRow("bd-ucc-coc-c3")
+	dep := s.depRepo()
+	for _, child := range []string{"bd-ucc-coc-c1", "bd-ucc-coc-c2", "bd-ucc-coc-c3"} {
+		s.Require().NoError(dep.Insert(s.Ctx(),
+			newDep(child, "bd-ucc-coc-parent", types.DepParentChild), "tester", domain.DepInsertOpts{}))
+	}
+	_, err := s.issueUseCase().CloseIssue(s.Ctx(), "bd-ucc-coc-c2",
+		domain.CloseIssueParams{Reason: "done"}, "tester")
+	s.Require().NoError(err)
+
+	got, err := s.issueUseCase().CountOpenChildren(s.Ctx(), "bd-ucc-coc-parent")
+	s.Require().NoError(err)
+	s.Equal(2, got, "two children remain open after one is closed")
+}
+
+func (s *testSuite) uccCountOpenChildrenNone() {
+	s.seedIssueRow("bd-ucc-coc-lonely")
+	got, err := s.issueUseCase().CountOpenChildren(s.Ctx(), "bd-ucc-coc-lonely")
+	s.Require().NoError(err)
+	s.Equal(0, got)
+}
+
+func (s *testSuite) uccCountOpenChildrenIgnoresOtherTypes() {
+	s.seedIssueRow("bd-ucc-coc-mixed-p")
+	s.seedIssueRow("bd-ucc-coc-mixed-c")
+	s.seedIssueRow("bd-ucc-coc-mixed-r")
+	dep := s.depRepo()
+	s.Require().NoError(dep.Insert(s.Ctx(),
+		newDep("bd-ucc-coc-mixed-c", "bd-ucc-coc-mixed-p", types.DepParentChild), "tester", domain.DepInsertOpts{}))
+	s.Require().NoError(dep.Insert(s.Ctx(),
+		newDep("bd-ucc-coc-mixed-r", "bd-ucc-coc-mixed-p", types.DepRelated), "tester", domain.DepInsertOpts{}))
+
+	got, err := s.issueUseCase().CountOpenChildren(s.Ctx(), "bd-ucc-coc-mixed-p")
+	s.Require().NoError(err)
+	s.Equal(1, got, "related edges must not be counted as children")
+}
+
+func (s *testSuite) uccCountOpenChildrenEmptyID() {
+	_, err := s.issueUseCase().CountOpenChildren(s.Ctx(), "")
+	s.Require().Error(err)
+}
+
+func (s *testSuite) uccUnblockedReturnsDependent() {
+	s.seedIssueRow("bd-ucc-un-dep")
+	s.seedIssueRow("bd-ucc-un-blocker")
+	s.Require().NoError(s.depRepo().Insert(s.Ctx(),
+		newDep("bd-ucc-un-dep", "bd-ucc-un-blocker", types.DepBlocks), "tester", domain.DepInsertOpts{}))
+
+	uc := s.issueUseCase()
+	_, err := uc.CloseIssue(s.Ctx(), "bd-ucc-un-blocker",
+		domain.CloseIssueParams{Reason: "done"}, "tester")
+	s.Require().NoError(err)
+
+	unblocked, err := uc.GetNewlyUnblockedByClose(s.Ctx(), "bd-ucc-un-blocker")
+	s.Require().NoError(err)
+	s.Require().Len(unblocked, 1)
+	s.Equal("bd-ucc-un-dep", unblocked[0].ID)
+}
+
+func (s *testSuite) uccUnblockedEmptyID() {
+	_, err := s.issueUseCase().GetNewlyUnblockedByClose(s.Ctx(), "")
+	s.Require().Error(err)
+}
+
+func (s *testSuite) uccIsBlockedTrue() {
+	s.seedIssueRow("bd-ucc-isb-src")
+	s.seedIssueRow("bd-ucc-isb-tgt")
+	s.Require().NoError(s.depRepo().Insert(s.Ctx(),
+		newDep("bd-ucc-isb-src", "bd-ucc-isb-tgt", types.DepBlocks), "tester", domain.DepInsertOpts{}))
+
+	blocked, blockers, err := s.depUseCase().IsBlocked(s.Ctx(), "bd-ucc-isb-src")
+	s.Require().NoError(err)
+	s.True(blocked)
+	s.Contains(blockers, "bd-ucc-isb-tgt")
+}
+
+func (s *testSuite) uccIsBlockedFalse() {
+	s.seedIssueRow("bd-ucc-isb-free")
+	blocked, blockers, err := s.depUseCase().IsBlocked(s.Ctx(), "bd-ucc-isb-free")
+	s.Require().NoError(err)
+	s.False(blocked)
+	s.Empty(blockers)
+}
+
+func (s *testSuite) uccIsBlockedEmptyID() {
+	_, _, err := s.depUseCase().IsBlocked(s.Ctx(), "")
+	s.Require().Error(err)
+}

--- a/internal/storage/domain/db/dependency.go
+++ b/internal/storage/domain/db/dependency.go
@@ -750,3 +750,11 @@ func filterDepsByType(deps []*types.IssueWithDependencyMetadata, filter []types.
 	}
 	return out
 }
+
+func (r *dependencySQLRepositoryImpl) IsBlocked(ctx context.Context, issueID string, opts domain.DepListOpts) (bool, []string, error) {
+	blocked, blockers, err := issueops.IsBlockedInTx(ctx, r.runner, issueID)
+	if err != nil {
+		return false, nil, fmt.Errorf("db: DependencySQLRepository.IsBlocked %s: %w", issueID, err)
+	}
+	return blocked, blockers, nil
+}

--- a/internal/storage/domain/db/issue.go
+++ b/internal/storage/domain/db/issue.go
@@ -712,4 +712,24 @@ func (r *issueSQLRepositoryImpl) AsOf(ctx context.Context, id, ref string) (*typ
 	return issueops.AsOfInTx(ctx, r.runner, id, ref)
 }
 
+func (r *issueSQLRepositoryImpl) Close(ctx context.Context, id string, params domain.CloseRowParams, actor string, opts domain.IssueTableOpts) (domain.CloseRowResult, error) {
+	res, err := issueops.CloseIssueInTx(ctx, r.runner, id, params.Reason, actor, params.Session)
+	if err != nil {
+		return domain.CloseRowResult{}, fmt.Errorf("db: IssueSQLRepository.Close %s: %w", id, err)
+	}
+	return domain.CloseRowResult{
+		Updated:       !res.AlreadyClosed,
+		AlreadyClosed: res.AlreadyClosed,
+		IsWisp:        res.IsWisp,
+	}, nil
+}
+
+func (r *issueSQLRepositoryImpl) GetNewlyUnblockedByClose(ctx context.Context, closedID string) ([]*types.Issue, error) {
+	out, err := issueops.GetNewlyUnblockedByCloseInTx(ctx, r.runner, closedID)
+	if err != nil {
+		return nil, fmt.Errorf("db: IssueSQLRepository.GetNewlyUnblockedByClose %s: %w", closedID, err)
+	}
+	return out, nil
+}
+
 const deleteBatchSize = 200

--- a/internal/storage/domain/dependency.go
+++ b/internal/storage/domain/dependency.go
@@ -65,6 +65,7 @@ type DependencySQLRepository interface {
 
 	GetBlockingInfo(ctx context.Context, issueIDs []string, opts DepListOpts) (BlockingInfo, error)
 	GetBlockingInfoAcrossIssuesAndWisps(ctx context.Context, issueIDs []string) (BlockingInfo, error)
+	IsBlocked(ctx context.Context, issueID string, opts DepListOpts) (bool, []string, error)
 
 	DeleteAllForIDs(ctx context.Context, ids []string, opts DepInsertOpts) (int, error)
 	CountAllForIDs(ctx context.Context, ids []string, opts DepCountsOpts) (int, error)
@@ -80,6 +81,7 @@ type DependencyUseCase interface {
 	CountByIssueID(ctx context.Context, issueID string, filter DepListFilter) (int64, error)
 	CountsByIssueIDs(ctx context.Context, issueIDs []string) (map[string]*types.DependencyCounts, error)
 	GetBlockingInfo(ctx context.Context, issueIDs []string) (BlockingInfo, error)
+	IsBlocked(ctx context.Context, issueID string) (bool, []string, error)
 	GetForIssueIDs(ctx context.Context, ids []string) (map[string][]*types.Dependency, error)
 
 	AddWispDependency(ctx context.Context, dep *types.Dependency, actor string) error
@@ -90,6 +92,7 @@ type DependencyUseCase interface {
 	IterWispWithIssueMetadata(ctx context.Context, wispID string, filter DepListFilter) (storage.Iter[types.IssueWithDependencyMetadata], error)
 	CountByWispID(ctx context.Context, wispID string, filter DepListFilter) (int64, error)
 	CountsByWispIDs(ctx context.Context, wispIDs []string) (map[string]*types.DependencyCounts, error)
+	IsWispBlocked(ctx context.Context, wispID string) (bool, []string, error)
 }
 
 func NewDependencyUseCase(depRepo DependencySQLRepository) DependencyUseCase {
@@ -362,4 +365,23 @@ func (u *dependencyUseCaseImpl) GetBlockingInfo(ctx context.Context, issueIDs []
 
 func isBlockingDep(t types.DependencyType) bool {
 	return t == types.DepBlocks || t == types.DepConditionalBlocks
+}
+
+func (u *dependencyUseCaseImpl) IsBlocked(ctx context.Context, issueID string) (bool, []string, error) {
+	return u.isBlocked(ctx, issueID, false)
+}
+
+func (u *dependencyUseCaseImpl) IsWispBlocked(ctx context.Context, wispID string) (bool, []string, error) {
+	return u.isBlocked(ctx, wispID, true)
+}
+
+func (u *dependencyUseCaseImpl) isBlocked(ctx context.Context, id string, useWisp bool) (bool, []string, error) {
+	if id == "" {
+		return false, nil, fmt.Errorf("IsBlocked: id must not be empty")
+	}
+	blocked, blockers, err := u.depRepo.IsBlocked(ctx, id, DepListOpts{UseWispsTable: useWisp})
+	if err != nil {
+		return false, nil, fmt.Errorf("IsBlocked %s: %w", id, err)
+	}
+	return blocked, blockers, nil
 }

--- a/internal/storage/domain/issue.go
+++ b/internal/storage/domain/issue.go
@@ -51,6 +51,19 @@ type IssueSQLRepository interface {
 	FindAllDependents(ctx context.Context, ids []string) ([]string, error)
 	AffectedByDeletion(ctx context.Context, issueIDs, wispIDs []string) (affectedIssues, affectedWisps []string, err error)
 	RecomputeIsBlocked(ctx context.Context, issueIDs, wispIDs []string) error
+	Close(ctx context.Context, id string, params CloseRowParams, actor string, opts IssueTableOpts) (CloseRowResult, error)
+	GetNewlyUnblockedByClose(ctx context.Context, closedID string) ([]*types.Issue, error)
+}
+
+type CloseRowParams struct {
+	Reason  string
+	Session string
+}
+
+type CloseRowResult struct {
+	Updated       bool
+	AlreadyClosed bool
+	IsWisp        bool
 }
 
 type DeleteIssuesParams struct {
@@ -173,6 +186,10 @@ type IssueUseCase interface {
 	CreateIssues(ctx context.Context, params []CreateIssueParams, actor string) (CreateIssuesResult, error)
 	UpdateIssue(ctx context.Context, id string, updates map[string]any, actor string) error
 	ClaimIssue(ctx context.Context, id, actor string) (ClaimResult, error)
+	ClaimIssueIfOpen(ctx context.Context, id, actor string) (ClaimResult, error)
+	CloseIssue(ctx context.Context, id string, params CloseIssueParams, actor string) (CloseIssueResult, error)
+	CountOpenChildren(ctx context.Context, id string) (int, error)
+	GetNewlyUnblockedByClose(ctx context.Context, closedID string) ([]*types.Issue, error)
 	ApplyUpdate(ctx context.Context, id string, spec UpdateSpec, actor string) (*types.Issue, error)
 	ApplyIssueGraph(ctx context.Context, plan GraphPlan, actor string) (GraphApplyResult, error)
 	AsOf(ctx context.Context, id, ref string) (*types.Issue, error)
@@ -189,7 +206,21 @@ type IssueUseCase interface {
 	CreateWisps(ctx context.Context, params []CreateIssueParams, actor string) (CreateIssuesResult, error)
 	UpdateWisp(ctx context.Context, id string, updates map[string]any, actor string) error
 	ClaimWisp(ctx context.Context, id, actor string) (ClaimResult, error)
+	ClaimWispIfOpen(ctx context.Context, id, actor string) (ClaimResult, error)
+	CloseWisp(ctx context.Context, id string, params CloseIssueParams, actor string) (CloseIssueResult, error)
+	CountOpenWispChildren(ctx context.Context, id string) (int, error)
+	GetNewlyUnblockedByCloseWisp(ctx context.Context, closedID string) ([]*types.Issue, error)
 	ApplyWispGraph(ctx context.Context, plan GraphPlan, actor string) (GraphApplyResult, error)
+}
+
+type CloseIssueParams struct {
+	Reason  string
+	Session string
+}
+
+type CloseIssueResult struct {
+	Issue  *types.Issue
+	Closed bool
 }
 
 func NewIssueUseCase(
@@ -1111,4 +1142,89 @@ func (u *issueUseCaseImpl) mintTopLevelID(ctx context.Context, issue *types.Issu
 		}
 	}
 	return "", fmt.Errorf("failed to generate unique ID for prefix %q after lengths %d..%d with 10 nonces each", prefix, baseLength, cfg.MaxLength)
+}
+
+func (u *issueUseCaseImpl) CloseIssue(ctx context.Context, id string, params CloseIssueParams, actor string) (CloseIssueResult, error) {
+	return u.close(ctx, id, params, actor, false)
+}
+
+func (u *issueUseCaseImpl) CloseWisp(ctx context.Context, id string, params CloseIssueParams, actor string) (CloseIssueResult, error) {
+	return u.close(ctx, id, params, actor, true)
+}
+
+func (u *issueUseCaseImpl) close(ctx context.Context, id string, params CloseIssueParams, actor string, useWisp bool) (CloseIssueResult, error) {
+	if id == "" {
+		return CloseIssueResult{}, fmt.Errorf("close: id must not be empty")
+	}
+	if actor == "" {
+		return CloseIssueResult{}, fmt.Errorf("close: actor must not be empty")
+	}
+	row, err := u.issueRepo.Close(ctx, id, CloseRowParams{Reason: params.Reason, Session: params.Session}, actor, IssueTableOpts{UseWispsTable: useWisp})
+	if err != nil {
+		return CloseIssueResult{}, fmt.Errorf("close %s: %w", id, err)
+	}
+	issue, err := u.issueRepo.Get(ctx, id, IssueTableOpts{UseWispsTable: row.IsWisp})
+	if err != nil {
+		return CloseIssueResult{}, fmt.Errorf("close %s: reload: %w", id, err)
+	}
+	return CloseIssueResult{
+		Issue:  issue,
+		Closed: !row.AlreadyClosed,
+	}, nil
+}
+
+func (u *issueUseCaseImpl) ClaimIssueIfOpen(ctx context.Context, id, actor string) (ClaimResult, error) {
+	return u.claim(ctx, id, actor, false)
+}
+
+func (u *issueUseCaseImpl) ClaimWispIfOpen(ctx context.Context, id, actor string) (ClaimResult, error) {
+	return u.claim(ctx, id, actor, true)
+}
+
+func (u *issueUseCaseImpl) CountOpenChildren(ctx context.Context, id string) (int, error) {
+	return u.countOpenChildren(ctx, id, false)
+}
+
+func (u *issueUseCaseImpl) CountOpenWispChildren(ctx context.Context, id string) (int, error) {
+	return u.countOpenChildren(ctx, id, true)
+}
+
+func (u *issueUseCaseImpl) countOpenChildren(ctx context.Context, id string, useWisp bool) (int, error) {
+	if id == "" {
+		return 0, fmt.Errorf("CountOpenChildren: id must not be empty")
+	}
+	children, err := u.depRepo.ListWithIssueMetadata(ctx, id, DepListOpts{
+		Types:         []types.DependencyType{types.DepParentChild},
+		Direction:     DepDirectionIn,
+		UseWispsTable: useWisp,
+	})
+	if err != nil {
+		return 0, fmt.Errorf("CountOpenChildren %s: %w", id, err)
+	}
+	open := 0
+	for _, child := range children {
+		if child.Status != types.StatusClosed {
+			open++
+		}
+	}
+	return open, nil
+}
+
+func (u *issueUseCaseImpl) GetNewlyUnblockedByClose(ctx context.Context, closedID string) ([]*types.Issue, error) {
+	return u.getNewlyUnblockedByClose(ctx, closedID)
+}
+
+func (u *issueUseCaseImpl) GetNewlyUnblockedByCloseWisp(ctx context.Context, closedID string) ([]*types.Issue, error) {
+	return u.getNewlyUnblockedByClose(ctx, closedID)
+}
+
+func (u *issueUseCaseImpl) getNewlyUnblockedByClose(ctx context.Context, closedID string) ([]*types.Issue, error) {
+	if closedID == "" {
+		return nil, fmt.Errorf("GetNewlyUnblockedByClose: closedID must not be empty")
+	}
+	out, err := u.issueRepo.GetNewlyUnblockedByClose(ctx, closedID)
+	if err != nil {
+		return nil, fmt.Errorf("GetNewlyUnblockedByClose %s: %w", closedID, err)
+	}
+	return out, nil
 }

--- a/internal/storage/issueops/close.go
+++ b/internal/storage/issueops/close.go
@@ -11,22 +11,23 @@ import (
 
 // CloseResult holds the result of a CloseIssueInTx call.
 type CloseResult struct {
-	IsWisp bool
+	IsWisp        bool
+	AlreadyClosed bool
 }
 
 // CloseIssueInTx closes an issue within a transaction, setting status to closed
 // and recording the close event. Routes to the correct table (issues/wisps)
 // automatically. The caller is responsible for Dolt versioning if needed.
-func CloseIssueInTx(ctx context.Context, tx *sql.Tx, id string, reason, actor, session string) (*CloseResult, error) {
+func CloseIssueInTx(ctx context.Context, tx DBTX, id string, reason, actor, session string) (*CloseResult, error) {
 	return closeIssueInTx(ctx, tx, id, reason, actor, session, true)
 }
 
-func CloseIssueWithoutEventInTx(ctx context.Context, tx *sql.Tx, id string, reason, actor, session string) (*CloseResult, error) {
+func CloseIssueWithoutEventInTx(ctx context.Context, tx DBTX, id string, reason, actor, session string) (*CloseResult, error) {
 	return closeIssueInTx(ctx, tx, id, reason, actor, session, false)
 }
 
 //nolint:gosec // G201: table names come from WispTableRouting (hardcoded constants)
-func closeIssueInTx(ctx context.Context, tx *sql.Tx, id string, reason, actor, session string, recordEvent bool) (*CloseResult, error) {
+func closeIssueInTx(ctx context.Context, tx DBTX, id string, reason, actor, session string, recordEvent bool) (*CloseResult, error) {
 	isWisp := IsActiveWispInTx(ctx, tx, id)
 	issueTable, _, eventTable, _ := WispTableRouting(isWisp)
 
@@ -45,8 +46,8 @@ func closeIssueInTx(ctx context.Context, tx *sql.Tx, id string, reason, actor, s
 
 	result, err := tx.ExecContext(ctx, fmt.Sprintf(`
 		UPDATE %s SET status = ?, closed_at = ?, updated_at = ?, close_reason = ?, closed_by_session = ?
-		WHERE id = ?
-	`, issueTable), types.StatusClosed, now, now, reason, session, id)
+		WHERE id = ? AND status != ?
+	`, issueTable), types.StatusClosed, now, now, reason, session, id, types.StatusClosed)
 	if err != nil {
 		return nil, fmt.Errorf("failed to close issue: %w", err)
 	}
@@ -67,7 +68,7 @@ func closeIssueInTx(ctx context.Context, tx *sql.Tx, id string, reason, actor, s
 			return nil, fmt.Errorf("failed to check issue existence: %w", qerr)
 		}
 		if types.Status(status) == types.StatusClosed {
-			return &CloseResult{IsWisp: isWisp}, nil
+			return &CloseResult{IsWisp: isWisp, AlreadyClosed: true}, nil
 		}
 		return nil, fmt.Errorf("failed to close issue: %s", id)
 	}

--- a/internal/storage/issueops/dependency_queries.go
+++ b/internal/storage/issueops/dependency_queries.go
@@ -423,7 +423,7 @@ func queryBlocksInfo(
 	return nil
 }
 
-func loadStatusByIDInTx(ctx context.Context, tx *sql.Tx, ids []string) (map[string]types.Status, error) {
+func loadStatusByIDInTx(ctx context.Context, tx DBTX, ids []string) (map[string]types.Status, error) {
 	statusByID := make(map[string]types.Status)
 	if len(ids) == 0 {
 		return statusByID, nil
@@ -474,7 +474,7 @@ func loadStatusByIDInTx(ctx context.Context, tx *sql.Tx, ids []string) (map[stri
 // Returns full issue objects for the newly-unblocked issues.
 //
 //nolint:gosec // G201: table names come from hardcoded constants
-func GetNewlyUnblockedByCloseInTx(ctx context.Context, tx *sql.Tx, closedIssueID string) ([]*types.Issue, error) {
+func GetNewlyUnblockedByCloseInTx(ctx context.Context, tx DBTX, closedIssueID string) ([]*types.Issue, error) {
 	candidateSet := make(map[string]bool)
 	for _, depTable := range []string{"dependencies", "wisp_dependencies"} {
 		rows, err := tx.QueryContext(ctx, fmt.Sprintf(`
@@ -604,7 +604,7 @@ func GetNewlyUnblockedByCloseInTx(ctx context.Context, tx *sql.Tx, closedIssueID
 // a list of blocker descriptions for display.
 //
 //nolint:gosec // G201: table names are hardcoded constants.
-func IsBlockedInTx(ctx context.Context, tx *sql.Tx, issueID string) (bool, []string, error) {
+func IsBlockedInTx(ctx context.Context, tx DBTX, issueID string) (bool, []string, error) {
 	var blocked bool
 	found := false
 	for _, table := range []string{"issues", "wisps"} {

--- a/internal/storage/issueops/get_issue.go
+++ b/internal/storage/issueops/get_issue.go
@@ -14,7 +14,7 @@ import (
 // including its labels. Automatically routes to the wisps/wisp_labels tables
 // if the ID is an active wisp. Returns storage.ErrNotFound (wrapped) if the
 // issue does not exist in either table.
-func GetIssueInTx(ctx context.Context, tx *sql.Tx, id string) (*types.Issue, error) {
+func GetIssueInTx(ctx context.Context, tx DBTX, id string) (*types.Issue, error) {
 	issue, err := getIssueFromTableInTx(ctx, tx, "issues", "labels", id)
 	if err == nil {
 		return issue, nil
@@ -33,7 +33,7 @@ func GetIssueInTx(ctx context.Context, tx *sql.Tx, id string) (*types.Issue, err
 	return nil, err
 }
 
-func getIssueFromTableInTx(ctx context.Context, tx *sql.Tx, issueTable, labelTable, id string) (*types.Issue, error) {
+func getIssueFromTableInTx(ctx context.Context, tx DBTX, issueTable, labelTable, id string) (*types.Issue, error) {
 	//nolint:gosec // G201: issueTable is a hardcoded literal supplied by GetIssueInTx ("issues" or "wisps")
 	row := tx.QueryRowContext(ctx, fmt.Sprintf(`SELECT %s FROM %s WHERE id = ?`, IssueSelectColumns, issueTable), id)
 	issue, err := ScanIssueFrom(row)

--- a/internal/storage/issueops/helpers.go
+++ b/internal/storage/issueops/helpers.go
@@ -142,7 +142,7 @@ func insertIssueIntoTable(ctx context.Context, tx *sql.Tx, table string, issue *
 // RecordEventInTable records an event in the specified events table.
 //
 //nolint:gosec // G201: table is a hardcoded constant ("events" or "wisp_events")
-func RecordEventInTable(ctx context.Context, tx *sql.Tx, table, issueID string, eventType types.EventType, actor, newValue string) error {
+func RecordEventInTable(ctx context.Context, tx DBTX, table, issueID string, eventType types.EventType, actor, newValue string) error {
 	_, err := tx.ExecContext(ctx, fmt.Sprintf(`
 		INSERT INTO %s (id, issue_id, event_type, actor, old_value, new_value)
 		VALUES (?, ?, ?, ?, ?, ?)

--- a/internal/storage/issueops/labels.go
+++ b/internal/storage/issueops/labels.go
@@ -12,7 +12,7 @@ import (
 // GetLabelsInTx retrieves all labels for an issue within an existing transaction.
 // Automatically routes to wisp_labels if the ID is an active wisp.
 // Returns labels sorted alphabetically.
-func GetLabelsInTx(ctx context.Context, tx *sql.Tx, table, issueID string) ([]string, error) {
+func GetLabelsInTx(ctx context.Context, tx DBTX, table, issueID string) ([]string, error) {
 	if table == "" {
 		isWisp := IsActiveWispInTx(ctx, tx, issueID)
 		_, table, _, _ = WispTableRouting(isWisp)

--- a/internal/storage/issueops/wisp_routing.go
+++ b/internal/storage/issueops/wisp_routing.go
@@ -16,7 +16,7 @@ import (
 // For hot-path callers that partition a batch of IDs by wisp status,
 // prefer WispIDSetInTx + partitionByWispSet to amortize the per-ID
 // query cost into a single scoped query over the batch.
-func IsActiveWispInTx(ctx context.Context, tx *sql.Tx, id string) bool {
+func IsActiveWispInTx(ctx context.Context, tx DBTX, id string) bool {
 	var exists int
 	err := tx.QueryRowContext(ctx, "SELECT 1 FROM wisps WHERE id = ? LIMIT 1", id).Scan(&exists)
 	return err == nil


### PR DESCRIPTION
## Summary

- Adds proxied-server support for `bd close`, mirroring the pattern used by `bd update` / `bd create` / `bd delete` / `bd show`.
- Wires the cobra `Run` to dispatch to `runCloseProxiedServer` (`cmd/bd/close.go`, 4-line patch) when `usesProxiedServer()`; the direct-mode body is untouched.
- New `cmd/bd/close_proxied_server.go` opens a **single UOW** for the whole invocation and threads it through every per-id close plus the post-loop `--suggest-next` / `--continue` / `--claim-next` paths. One `uw.Commit("bd: close <ids>[; advance to <id>][; claim <id>]")` covers the entire batch, so multi-id closes (used heavily by gascity's `CloseAllWithReason`) become atomic — one dolt commit instead of N.
- Reuses the direct-mode reason / done-alias / gate helpers as-is (`resolveCloseReasons`, `validateCloseReasons`, `checkGateSatisfaction`, `shouldAutoCloseCompletedRoot`, `analyzeMoleculeParallel`, `sortStepsByDependencyOrder`). Molecule logic (`--continue`, auto-close-completed-molecule) is ported in-file using only use-case calls — no new direct-mode helpers required.
- Last-touched fallback is intentionally **not** supported in proxied mode (matches the explicit error from `bd update` / `bd delete`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)