### PR TITLE
test(cmd/bd): pin BEADS_DIR so TestCommitBeadsConfigSkipsGitHooks resolves the temp repo when nested

### DIFF
--- a/cmd/bd/sync_remote_test.go
+++ b/cmd/bd/sync_remote_test.go
@@ -50,7 +50,26 @@ func TestNormalizeRemoteURL(t *testing.T) {
 
 func TestCommitBeadsConfigSkipsGitHooks(t *testing.T) {
 	repo := t.TempDir()
-	runGitForCommitConfigTest(t, repo, "init")
+
+	// Pin bd's repo resolution to this temp repo. commitBeadsConfig resolves the
+	// target repo via GetRepoContext -> FindBeadsDir, which walks UP the
+	// directory tree. When the test runs from a checkout nested inside another
+	// beads repo (e.g. a verification worktree under the coordination repo),
+	// FindBeadsDir escapes the temp repo and resolves to the OUTER repo's
+	// .beads; commitBeadsConfig then commits against the wrong repository and
+	// fails (observed as `git commit` exit 128 and "branch has no commits yet").
+	// os.Chdir below is not enough because resolution is not purely CWD-based.
+	// BEADS_DIR pins it deterministically regardless of where the test runs.
+	t.Setenv("BEADS_DIR", filepath.Join(repo, ".beads"))
+
+	// Isolate git config and pin the initial branch so the commit never depends
+	// on the developer's ~/.gitconfig or the ambient init.defaultBranch.
+	gitHome := t.TempDir()
+	t.Setenv("HOME", gitHome)
+	t.Setenv("GIT_CONFIG_GLOBAL", filepath.Join(gitHome, ".gitconfig"))
+	t.Setenv("GIT_CONFIG_NOSYSTEM", "1")
+
+	runGitForCommitConfigTest(t, repo, "init", "--initial-branch=main")
 	runGitForCommitConfigTest(t, repo, "config", "user.email", "test@example.com")
 	runGitForCommitConfigTest(t, repo, "config", "user.name", "Test User")
 


### PR DESCRIPTION
## Why

`TestCommitBeadsConfigSkipsGitHooks` could fail when the test suite runs from a checkout that is **nested inside another beads repo** (for example, a CI/verification worktree created under a repo that itself has a `.beads/`). `commitBeadsConfig` resolves its target repo via `GetRepoContext` → `FindBeadsDir`, which walks **up** the directory tree. When nested, `FindBeadsDir` escapes the test's temp repo and resolves to the **outer** repo's `.beads`, so the internal `git commit` runs against the wrong repository and fails:

```
Warning: failed to commit config change: exit status 128
git log -1 --format=%s failed: exit status 128
fatal: your current branch '...' does not have any commits yet
```

The test's `os.Chdir` into its temp repo isn't sufficient, because resolution isn't purely CWD-based. (This reproduced reliably under a full `go test ./...` run from a nested worktree; it passes from a standalone checkout, which is why CI is green.)

## What

Make the test hermetic with respect to repo resolution and git config:

- **`t.Setenv("BEADS_DIR", repo/.beads)`** — pins `FindBeadsDir` to the test's temp repo so resolution can't escape upward. This is the fix.
- Isolate `HOME` / `GIT_CONFIG_GLOBAL` (+ `GIT_CONFIG_NOSYSTEM=1`) and create the branch explicitly with `git init --initial-branch=main`, so the commit never depends on the developer's `~/.gitconfig` or the ambient `init.defaultBranch`.

Test-only change; no production code touched.

## Verification

- Passes in isolation and under a full `make test` (`go test ./...`) run from a worktree nested inside another beads repo — the exact configuration that previously failed deterministically.
- `gofmt` / `go vet` clean.
