### PR TITLE
bootstrap: guard git code-repo sync.remote + transient-not-found retry

### DIFF
--- a/cmd/bd/bootstrap.go
+++ b/cmd/bd/bootstrap.go
@@ -46,6 +46,10 @@ type bootstrapServerDBCheck struct {
 	Err       error
 }
 
+// bootstrapRetryDelay is the sleep function used between server-DB-not-found
+// retries. Injectable for testing.
+var bootstrapRetryDelay = func(d time.Duration) { time.Sleep(d) }
+
 var checkBootstrapServerDB = func(probeCfg bootstrapServerProbeConfig) bootstrapServerDBCheck {
 	host := probeCfg.host
 	port := probeCfg.port
@@ -284,6 +288,15 @@ func detectBootstrapAction(beadsDir string, cfg *configfile.Config) BootstrapPla
 	// Check sync.remote (primary) or sync.git-remote (deprecated fallback)
 	syncRemote := resolveSyncRemote()
 	if syncRemote != "" {
+		if isGitCodeRepoURL(syncRemote) {
+			// Cloning from a git code-repo URL via DOLT_CLONE spins dolt to
+			// 1000% CPU and requires manual SIGKILL (vc-8djyca). Reject and
+			// surface the misconfiguration rather than attempting the clone.
+			fmt.Fprintf(os.Stderr, "error: sync.remote %q looks like a git code-repository URL, not a Dolt remote — skipping clone\n", syncRemote)
+			plan.Action = "none"
+			plan.Reason = fmt.Sprintf("sync.remote %q rejected: git code-repository URL (not a Dolt remote)", syncRemote)
+			return plan
+		}
 		// User-provided sync.remote — trust the URL format as-is.
 		// normalizeRemoteURL would convert http:// to git+http://,
 		// breaking Dolt remotesapi endpoints (GH#3339).
@@ -380,7 +393,24 @@ func existingBootstrapDBPlan(beadsDir string, cfg *configfile.Config, isServer, 
 			database: cfg.GetDoltDatabase(),
 			tls:      cfg.GetDoltServerTLS(),
 		}
-		result := checkBootstrapServerDB(probeCfg)
+		// When the server is reachable but the DB appears absent, retry with
+		// exponential backoff before concluding the DB is genuinely missing.
+		// A managed Dolt restart completes in <30 s; three retries over 70 s
+		// cover all observed restart windows (vc-8djyca).
+		retryDelays := []time.Duration{10 * time.Second, 20 * time.Second, 40 * time.Second}
+		var result bootstrapServerDBCheck
+		for attempt := 0; ; attempt++ {
+			result = checkBootstrapServerDB(probeCfg)
+			if result.Err != nil || result.Exists || !result.Reachable {
+				break
+			}
+			if attempt >= len(retryDelays) {
+				break
+			}
+			fmt.Fprintf(os.Stderr, "Database %s not found on reachable server (attempt %d/%d), retrying in %v (possible transient restart)\n",
+				cfg.GetDoltDatabase(), attempt+1, len(retryDelays), retryDelays[attempt])
+			bootstrapRetryDelay(retryDelays[attempt])
+		}
 		if result.Err != nil {
 			plan.Action = "none"
 			plan.Reason = fmt.Sprintf("Could not verify existing server database %s: %v", cfg.GetDoltDatabase(), result.Err)
@@ -975,4 +1005,59 @@ func init() {
 	bootstrapCmd.Flags().BoolP("yes", "y", false, "Skip confirmation prompts (for CI/automation)")
 	bootstrapCmd.Flags().Bool("non-interactive", false, "Alias for --yes")
 	rootCmd.AddCommand(bootstrapCmd)
+}
+
+// isGitCodeRepoURL reports whether rawURL looks like a git code-repository
+// remote rather than a Dolt data remote. Used to block accidental DOLT_CLONE
+// against forges like github.com (vc-8djyca).
+//
+// Rules (in priority order):
+//   - Dolt-native schemes (dolthub, s3, gs, az, file) → always false
+//   - .git suffix → always true (Dolt DBs never carry a .git suffix)
+//   - Well-known code forges / their subdomains → true
+//   - Everything else → false (git+ssh:// to self-hosted Dolt remotes is valid)
+func isGitCodeRepoURL(rawURL string) bool {
+	// Dolt-native schemes are never code repos.
+	for _, prefix := range []string{"dolthub://", "s3://", "gs://", "az://", "file://"} {
+		if strings.HasPrefix(rawURL, prefix) {
+			return false
+		}
+	}
+	// .git suffix is a universal code-repo signal; Dolt DBs never use it.
+	if strings.HasSuffix(strings.ToLower(rawURL), ".git") {
+		return true
+	}
+	// Well-known code-hosting forges.
+	host := urlHostname(rawURL)
+	switch host {
+	case "github.com", "gitlab.com", "bitbucket.org", "codeberg.org":
+		return true
+	}
+	return strings.HasSuffix(host, ".github.com") || strings.HasSuffix(host, ".gitlab.com")
+}
+
+// urlHostname extracts the lowercase hostname from a URL without importing
+// net/url. Handles scheme://[user@]host[:port]/path and SCP git@host:path.
+func urlHostname(rawURL string) string {
+	if sep := strings.Index(rawURL, "://"); sep >= 0 {
+		rest := rawURL[sep+3:]
+		if at := strings.Index(rest, "@"); at >= 0 {
+			rest = rest[at+1:]
+		}
+		if slash := strings.Index(rest, "/"); slash >= 0 {
+			rest = rest[:slash]
+		}
+		if colon := strings.Index(rest, ":"); colon >= 0 {
+			rest = rest[:colon]
+		}
+		return strings.ToLower(rest)
+	}
+	// SCP-style: git@github.com:org/repo
+	if at := strings.Index(rawURL, "@"); at >= 0 {
+		rest := rawURL[at+1:]
+		if colon := strings.Index(rest, ":"); colon >= 0 {
+			return strings.ToLower(rest[:colon])
+		}
+	}
+	return ""
 }

--- a/cmd/bd/bootstrap_guard_test.go
+++ b/cmd/bd/bootstrap_guard_test.go
@@ -1,0 +1,288 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/steveyegge/beads/internal/config"
+	"github.com/steveyegge/beads/internal/configfile"
+)
+
+// TestIsGitCodeRepoURL verifies the URL classifier that guards sync.remote
+// against accidental git code-repository URLs (vc-8djyca).
+func TestIsGitCodeRepoURL(t *testing.T) {
+	tests := []struct {
+		url  string
+		want bool
+	}{
+		// .git suffix — always a code-repo signal regardless of host
+		{"git+ssh://github.com/org/repo.git", true},
+		{"https://github.com/org/repo.git", true},
+		{"ssh://git@github.com/org/repo.git", true},
+		{"git@github.com:org/repo.git", true},
+		{"https://gitlab.com/org/repo.git", true},
+		{"git+https://bitbucket.org/org/repo.git", true},
+		{"https://codeberg.org/org/repo.git", true},
+		// .git on unknown host: still blocked (Dolt DBs never use .git suffix)
+		{"git+ssh://my-dolt.example.com/org/repo.git", true},
+
+		// Well-known forges without .git suffix
+		{"https://github.com/org/repo", true},
+		{"git+ssh://github.com/org/db", true},
+		{"https://gitlab.com/org/group/repo", true},
+		{"https://bitbucket.org/org/repo", true},
+		{"https://codeberg.org/org/repo", true},
+
+		// github.com / gitlab.com subdomains
+		{"https://raw.github.com/org/repo", true},
+		{"https://api.github.com/repos/org/repo", true},
+		{"https://example.gitlab.com/org/repo", true},
+
+		// Valid Dolt-native schemes — never blocked
+		{"dolthub://myorg/mydb", false},
+		{"s3://bucket/path", false},
+		{"gs://bucket/path", false},
+		{"az://container/path", false},
+		{"file:///tmp/doltdb", false},
+
+		// git+ssh to a self-hosted Dolt remote — NOT a code repo
+		{"git+ssh://my-self-hosted-dolt.example.com/org/db", false},
+		{"https://doltremoteapi.dolthub.com/org/db", false},
+		{"https://doltremoteapi.example.com/mydb", false},
+
+		// SCP-style to non-forge — allowed
+		{"git@my-dolt.example.com:org/db", false},
+
+		// Edge: empty string
+		{"", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.url, func(t *testing.T) {
+			got := isGitCodeRepoURL(tt.url)
+			if got != tt.want {
+				t.Errorf("isGitCodeRepoURL(%q) = %v, want %v", tt.url, got, tt.want)
+			}
+		})
+	}
+}
+
+// setupSyncRemoteConfig writes sync.remote to .beads/config.yaml and
+// initializes the config subsystem so resolveSyncRemote() can read it.
+// Returns a cleanup function that resets config state.
+func setupSyncRemoteConfig(t *testing.T, beadsDir, remote string) func() {
+	t.Helper()
+	if err := os.WriteFile(
+		filepath.Join(beadsDir, "config.yaml"),
+		[]byte("sync.remote: "+remote+"\n"),
+		0o644,
+	); err != nil {
+		t.Fatalf("write config.yaml: %v", err)
+	}
+	config.ResetForTesting()
+	t.Setenv("BEADS_DIR", beadsDir)
+	t.Setenv("BEADS_TEST_IGNORE_REPO_CONFIG", "1")
+	if err := config.Initialize(); err != nil {
+		t.Fatalf("config.Initialize: %v", err)
+	}
+	return func() { config.ResetForTesting() }
+}
+
+// TestDetectBootstrapAction_GitCodeRepoSyncRemoteBlocked verifies that a
+// sync.remote pointing at a git code-repository host is rejected (action=none)
+// instead of triggering DOLT_CLONE (vc-8djyca Layer 1).
+func TestDetectBootstrapAction_GitCodeRepoSyncRemoteBlocked(t *testing.T) {
+	for _, remote := range []string{
+		"git+ssh://github.com/org/repo.git",
+		"https://github.com/org/repo.git",
+		"git@github.com:org/repo.git",
+		"https://gitlab.com/group/repo.git",
+	} {
+		t.Run(remote, func(t *testing.T) {
+			restore := snapshotBootstrapEnv(t)
+			defer restore()
+
+			tmpDir := t.TempDir()
+			beadsDir := filepath.Join(tmpDir, ".beads")
+			if err := os.MkdirAll(beadsDir, 0o750); err != nil {
+				t.Fatal(err)
+			}
+			cleanup := setupSyncRemoteConfig(t, beadsDir, remote)
+			defer cleanup()
+
+			oldWd, _ := os.Getwd()
+			defer func() { _ = os.Chdir(oldWd) }()
+			if err := os.Chdir(tmpDir); err != nil {
+				t.Fatal(err)
+			}
+
+			cfg := configfile.DefaultConfig()
+			plan := detectBootstrapAction(beadsDir, cfg)
+
+			if plan.Action != "none" {
+				t.Errorf("remote=%q: action=%q, want %q (git code-repo URL must be blocked)", remote, plan.Action, "none")
+			}
+			if plan.SyncRemote != "" {
+				t.Errorf("remote=%q: SyncRemote=%q, want empty (blocked URL must not propagate)", remote, plan.SyncRemote)
+			}
+		})
+	}
+}
+
+// TestDetectBootstrapAction_ValidDoltSyncRemoteUnchanged verifies that a valid
+// Dolt remote URL is still accepted as-is (no regression from Layer 1 guard).
+func TestDetectBootstrapAction_ValidDoltSyncRemoteUnchanged(t *testing.T) {
+	for _, remote := range []string{
+		"https://doltremoteapi.dolthub.com/org/db",
+		"dolthub://myorg/mydb",
+		"git+ssh://my-self-hosted-dolt.example.com/org/db",
+	} {
+		t.Run(remote, func(t *testing.T) {
+			restore := snapshotBootstrapEnv(t)
+			defer restore()
+
+			tmpDir := t.TempDir()
+			beadsDir := filepath.Join(tmpDir, ".beads")
+			if err := os.MkdirAll(beadsDir, 0o750); err != nil {
+				t.Fatal(err)
+			}
+			cleanup := setupSyncRemoteConfig(t, beadsDir, remote)
+			defer cleanup()
+
+			oldWd, _ := os.Getwd()
+			defer func() { _ = os.Chdir(oldWd) }()
+			if err := os.Chdir(tmpDir); err != nil {
+				t.Fatal(err)
+			}
+
+			cfg := configfile.DefaultConfig()
+			plan := detectBootstrapAction(beadsDir, cfg)
+
+			if plan.Action != "sync" {
+				t.Errorf("remote=%q: action=%q, want %q (valid Dolt remote must not be blocked)", remote, plan.Action, "sync")
+			}
+			if plan.SyncRemote != remote {
+				t.Errorf("remote=%q: SyncRemote=%q, want same URL", remote, plan.SyncRemote)
+			}
+		})
+	}
+}
+
+// TestDetectBootstrapAction_ServerTransientRestart_DBFoundAfterRetry verifies
+// that when the server is reachable but the DB appears absent on the first probe
+// (e.g. during a managed Dolt restart), the retry loop waits and eventually finds
+// the DB — returning action=none instead of falling through to sync/init
+// (vc-8djyca Layer 2).
+func TestDetectBootstrapAction_ServerTransientRestart_DBFoundAfterRetry(t *testing.T) {
+	t.Setenv("BEADS_DOLT_DATA_DIR", "")
+	t.Setenv("BEADS_DOLT_SHARED_SERVER", "")
+	t.Setenv("BEADS_DOLT_SERVER_DATABASE", "")
+	t.Setenv("BEADS_DOLT_SERVER_HOST", "")
+	t.Setenv("BEADS_DOLT_SERVER_PORT", "")
+
+	tmpDir := t.TempDir()
+	beadsDir := filepath.Join(tmpDir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	doltDataDir := filepath.Join(tmpDir, "dolt-data")
+	if err := os.MkdirAll(filepath.Join(doltDataDir, "mydb"), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("BEADS_DOLT_DATA_DIR", doltDataDir)
+
+	oldWd, _ := os.Getwd()
+	defer func() { _ = os.Chdir(oldWd) }()
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := configfile.DefaultConfig()
+	cfg.DoltMode = configfile.DoltModeServer
+	cfg.DoltDatabase = "mydb"
+	cfg.DoltDataDir = doltDataDir
+
+	// Simulate a restart: DB absent for first 2 probes, then found.
+	callCount := 0
+	origCheck := checkBootstrapServerDB
+	checkBootstrapServerDB = func(_ bootstrapServerProbeConfig) bootstrapServerDBCheck {
+		callCount++
+		if callCount <= 2 {
+			return bootstrapServerDBCheck{Exists: false, Reachable: true}
+		}
+		return bootstrapServerDBCheck{Exists: true, Reachable: true}
+	}
+	defer func() { checkBootstrapServerDB = origCheck }()
+
+	origDelay := bootstrapRetryDelay
+	bootstrapRetryDelay = func(time.Duration) {}
+	defer func() { bootstrapRetryDelay = origDelay }()
+
+	plan := detectBootstrapAction(beadsDir, cfg)
+
+	if plan.Action != "none" {
+		t.Errorf("action=%q, want %q — DB found after retry must suppress clone", plan.Action, "none")
+	}
+	if !plan.HasExisting {
+		t.Error("HasExisting=false, want true — DB was found on the retry probe")
+	}
+	if callCount < 3 {
+		t.Errorf("checkBootstrapServerDB called %d times, want >=3 (retry must fire)", callCount)
+	}
+}
+
+// TestDetectBootstrapAction_ServerGenuinelyAbsent_FallsThrough verifies that
+// when the server is reachable but the DB is genuinely absent after all retries,
+// detection falls through to init (no change from pre-retry behavior).
+func TestDetectBootstrapAction_ServerGenuinelyAbsent_FallsThrough(t *testing.T) {
+	t.Setenv("BEADS_DOLT_DATA_DIR", "")
+	t.Setenv("BEADS_DOLT_SHARED_SERVER", "")
+	t.Setenv("BEADS_DOLT_SERVER_DATABASE", "")
+	t.Setenv("BEADS_DOLT_SERVER_HOST", "")
+	t.Setenv("BEADS_DOLT_SERVER_PORT", "")
+
+	tmpDir := t.TempDir()
+	beadsDir := filepath.Join(tmpDir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	doltDataDir := filepath.Join(tmpDir, "dolt-data")
+	if err := os.MkdirAll(filepath.Join(doltDataDir, "mydb"), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("BEADS_DOLT_DATA_DIR", doltDataDir)
+
+	oldWd, _ := os.Getwd()
+	defer func() { _ = os.Chdir(oldWd) }()
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := configfile.DefaultConfig()
+	cfg.DoltMode = configfile.DoltModeServer
+	cfg.DoltDatabase = "mydb"
+	cfg.DoltDataDir = doltDataDir
+
+	// DB is always absent — simulates a genuinely missing database.
+	origCheck := checkBootstrapServerDB
+	checkBootstrapServerDB = func(_ bootstrapServerProbeConfig) bootstrapServerDBCheck {
+		return bootstrapServerDBCheck{Exists: false, Reachable: true}
+	}
+	defer func() { checkBootstrapServerDB = origCheck }()
+
+	origDelay := bootstrapRetryDelay
+	bootstrapRetryDelay = func(time.Duration) {}
+	defer func() { bootstrapRetryDelay = origDelay }()
+
+	plan := detectBootstrapAction(beadsDir, cfg)
+
+	if plan.Action == "none" {
+		t.Errorf("action=none, want non-none — genuinely absent DB must not block recovery")
+	}
+	// No backup or JSONL → should fall through to init.
+	if plan.Action != "init" {
+		t.Errorf("action=%q, want %q — no backup/jsonl available, fresh init expected", plan.Action, "init")
+	}
+}

--- a/cmd/bd/bootstrap_test.go
+++ b/cmd/bd/bootstrap_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/steveyegge/beads/internal/config"
 	"github.com/steveyegge/beads/internal/configfile"
@@ -202,6 +203,9 @@ func TestDetectBootstrapAction_ServerModeMissingConfiguredDBDoesNotReturnNone(t 
 		return bootstrapServerDBCheck{Exists: false, Reachable: true}
 	}
 	defer func() { checkBootstrapServerDB = origCheck }()
+	origDelay := bootstrapRetryDelay
+	bootstrapRetryDelay = func(time.Duration) {}
+	defer func() { bootstrapRetryDelay = origDelay }()
 
 	plan := detectBootstrapAction(beadsDir, cfg)
 	if plan.Action == "none" {
@@ -630,6 +634,9 @@ func TestDetectBootstrapAction_ServerModePlanUsesConfiguredDatabaseName(t *testi
 		return bootstrapServerDBCheck{Exists: false, Reachable: true}
 	}
 	defer func() { checkBootstrapServerDB = origCheck }()
+	origDelay := bootstrapRetryDelay
+	bootstrapRetryDelay = func(time.Duration) {}
+	defer func() { bootstrapRetryDelay = origDelay }()
 
 	plan := detectBootstrapAction(beadsDir, cfg)
 


### PR DESCRIPTION
## Problem

Two failure modes when `sync.remote` is misconfigured or a managed Dolt server restarts:

1. **Wrong URL type**: If `sync.remote` is set to a git code-repository URL (e.g. `git+ssh://github.com/org/repo.git`), `bd bootstrap` fires `DOLT_CLONE` against it. Dolt spins to ~1000% CPU and requires manual SIGKILL.

2. **Transient restart**: When a managed Dolt server restarts it briefly reports "database not found" for up to ~30 s. Without retry logic, `bd bootstrap` immediately falls through to sync/init, potentially triggering an unnecessary `DOLT_CLONE`.

## Changes

### Layer 1 — `isGitCodeRepoURL()` guard in `detectBootstrapAction()`

Added `isGitCodeRepoURL(rawURL string) bool` (priority order):
- Dolt-native schemes (`dolthub://`, `s3://`, `gs://`, `az://`, `file://`) → **false** (always safe)
- `.git` suffix → **true** (Dolt DBs never use a `.git` suffix)
- Known code forges (`github.com`, `gitlab.com`, `bitbucket.org`, `codeberg.org`) or their subdomains → **true**
- Everything else → **false** (self-hosted `git+ssh://` Dolt remotes are valid)

When `isGitCodeRepoURL` returns true, `detectBootstrapAction` logs a structured error and returns `action=none`.

### Layer 2 — transient-not-found retry

When the server is reachable but the DB appears absent, retry 3× with exponential back-off (10 s, 20 s, 40 s) before falling through to sync/init. Spans 70 s total, covering all observed managed-Dolt restart windows (~30 s).

The delay is injected via `bootstrapRetryDelay` (`var` holding `func(time.Duration)`) so tests run at zero-sleep speed.

## Tests

New file `cmd/bd/bootstrap_guard_test.go`:
- `TestIsGitCodeRepoURL` — 21 cases: `.git` suffix, forge hosts, subdomains, Dolt-native schemes, self-hosted remotes, SCP-style, empty string
- `TestDetectBootstrapAction_GitCodeRepoSyncRemoteBlocked` — `action=none` for 4 git forge URLs
- `TestDetectBootstrapAction_ValidDoltSyncRemoteUnchanged` — no regression for 3 valid Dolt remotes
- `TestDetectBootstrapAction_ServerTransientRestart_DBFoundAfterRetry` — `action=none` + `HasExisting=true` when DB appears on 3rd probe
- `TestDetectBootstrapAction_ServerGenuinelyAbsent_FallsThrough` — falls through to `init` when DB is absent after all retries

Two existing server-mode tests stub `bootstrapRetryDelay` to avoid 70 s of real sleep.

## Test results

863 tests pass. 2 pre-existing failures in `TestIsBackupAutoEnabled` (unrelated, also fails on `main`).