### PR TITLE
/{cmd,internal}: wire bd dep to proxied-server use cases

### DIFF
--- a/cmd/bd/dep.go
+++ b/cmd/bd/dep.go
@@ -143,6 +143,10 @@ Examples:
 			CheckReadonly("dep --blocks")
 
 			ctx := rootCtx
+			if usesProxiedServer() {
+				runDepBlocksProxiedServer(cmd, ctx, blockerID, blocksID)
+				return
+			}
 			depType := "blocks"
 
 			// Resolve partial IDs with routing support. The source issue's store
@@ -275,6 +279,10 @@ Examples:
 	},
 	Run: func(cmd *cobra.Command, args []string) {
 		CheckReadonly("dep add")
+		if usesProxiedServer() {
+			runDepAddProxiedServer(cmd, rootCtx, args)
+			return
+		}
 		depType, _ := cmd.Flags().GetString("type")
 		file, _ := cmd.Flags().GetString("file")
 
@@ -691,6 +699,10 @@ Examples:
   bd dep list gt-abc --direction=up -t tracks  # Show what tracks gt-abc (convoy tracking)`,
 	Args: cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
+		if usesProxiedServer() {
+			runDepListProxiedServer(cmd, rootCtx, args)
+			return
+		}
 		ctx := rootCtx
 		direction, _ := cmd.Flags().GetString("direction")
 		typeFilter, _ := cmd.Flags().GetString("type")
@@ -885,6 +897,10 @@ var depRemoveCmd = &cobra.Command{
 	Args:    cobra.ExactArgs(2),
 	Run: func(cmd *cobra.Command, args []string) {
 		CheckReadonly("dep remove")
+		if usesProxiedServer() {
+			runDepRemoveProxiedServer(cmd, rootCtx, args)
+			return
+		}
 		ctx := rootCtx
 
 		// Resolve partial IDs with routing support. The source issue's store is
@@ -969,6 +985,10 @@ Examples:
   bd dep tree gt-0iqq --depth=3          # Limit to 3 levels deep`,
 	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
+		if usesProxiedServer() {
+			runDepTreeProxiedServer(cmd, rootCtx, args)
+			return
+		}
 		ctx := rootCtx
 
 		// Resolve partial ID with routing support
@@ -1086,6 +1106,10 @@ var depCyclesCmd = &cobra.Command{
 	Use:   "cycles",
 	Short: "Detect dependency cycles",
 	Run: func(cmd *cobra.Command, args []string) {
+		if usesProxiedServer() {
+			runDepCyclesProxiedServer(cmd, rootCtx)
+			return
+		}
 
 		ctx := rootCtx
 		cycles, err := store.DetectCycles(ctx)

--- a/cmd/bd/dep_proxied_integration_test.go
+++ b/cmd/bd/dep_proxied_integration_test.go
@@ -1,0 +1,718 @@
+//go:build cgo
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+)
+
+func bdProxiedDep(t *testing.T, bd, dir string, args ...string) string {
+	t.Helper()
+	fullArgs := append([]string{"dep"}, args...)
+	cmd := exec.Command(bd, fullArgs...)
+	cmd.Dir = dir
+	cmd.Env = bdProxiedEnv(dir)
+	stdout, stderr, err := runCommandBuffers(t, cmd)
+	if err != nil {
+		t.Fatalf("bd dep %s failed: %v\nstdout:\n%s\nstderr:\n%s",
+			strings.Join(args, " "), err, stdout.String(), stderr.String())
+	}
+	return stdout.String()
+}
+
+func bdProxiedDepFail(t *testing.T, bd, dir string, args ...string) string {
+	t.Helper()
+	fullArgs := append([]string{"dep"}, args...)
+	cmd := exec.Command(bd, fullArgs...)
+	cmd.Dir = dir
+	cmd.Env = bdProxiedEnv(dir)
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected bd dep %s to fail, but succeeded:\n%s",
+			strings.Join(args, " "), out)
+	}
+	return string(out)
+}
+
+func bdProxiedDepJSON(t *testing.T, bd, dir string, args ...string) map[string]interface{} {
+	t.Helper()
+	fullArgs := append([]string{"dep"}, args...)
+	fullArgs = append(fullArgs, "--json")
+	cmd := exec.Command(bd, fullArgs...)
+	cmd.Dir = dir
+	cmd.Env = bdProxiedEnv(dir)
+	stdout, stderr, err := runCommandBuffers(t, cmd)
+	if err != nil {
+		t.Fatalf("bd dep --json %s failed: %v\nstdout:\n%s\nstderr:\n%s",
+			strings.Join(args, " "), err, stdout.String(), stderr.String())
+	}
+	s := strings.TrimSpace(stdout.String())
+	start := strings.IndexAny(s, "{[")
+	if start < 0 {
+		t.Fatalf("no JSON in dep output: %s", s)
+	}
+	var m map[string]interface{}
+	if err := json.Unmarshal([]byte(s[start:]), &m); err != nil {
+		t.Fatalf("parse dep JSON: %v\n%s", err, s)
+	}
+	return m
+}
+
+func bdProxiedDepJSONArray(t *testing.T, bd, dir string, args ...string) []interface{} {
+	t.Helper()
+	fullArgs := append([]string{"dep"}, args...)
+	fullArgs = append(fullArgs, "--json")
+	cmd := exec.Command(bd, fullArgs...)
+	cmd.Dir = dir
+	cmd.Env = bdProxiedEnv(dir)
+	stdout, stderr, err := runCommandBuffers(t, cmd)
+	if err != nil {
+		t.Fatalf("bd dep --json %s failed: %v\nstdout:\n%s\nstderr:\n%s",
+			strings.Join(args, " "), err, stdout.String(), stderr.String())
+	}
+	s := strings.TrimSpace(stdout.String())
+	start := strings.Index(s, "[")
+	if start < 0 {
+		t.Fatalf("no JSON array in dep output: %s", s)
+	}
+	var arr []interface{}
+	if err := json.Unmarshal([]byte(s[start:]), &arr); err != nil {
+		t.Fatalf("parse dep JSON array: %v\n%s", err, s)
+	}
+	return arr
+}
+
+func bdProxiedDepWithInput(t *testing.T, bd, dir, input string, args ...string) string {
+	t.Helper()
+	fullArgs := append([]string{"dep"}, args...)
+	cmd := exec.Command(bd, fullArgs...)
+	cmd.Dir = dir
+	cmd.Env = bdProxiedEnv(dir)
+	cmd.Stdin = strings.NewReader(input)
+	stdout, stderr, err := runCommandBuffers(t, cmd)
+	if err != nil {
+		t.Fatalf("bd dep %s failed: %v\nstdout:\n%s\nstderr:\n%s",
+			strings.Join(args, " "), err, stdout.String(), stderr.String())
+	}
+	return stdout.String()
+}
+
+func bdProxiedDepWithInputFail(t *testing.T, bd, dir, input string, args ...string) string {
+	t.Helper()
+	fullArgs := append([]string{"dep"}, args...)
+	cmd := exec.Command(bd, fullArgs...)
+	cmd.Dir = dir
+	cmd.Env = bdProxiedEnv(dir)
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected bd dep %s to fail, but succeeded:\n%s",
+			strings.Join(args, " "), out)
+	}
+	return string(out)
+}
+
+func TestProxiedServerDep(t *testing.T) {
+	requireProxiedServerEnv(t)
+	bd := buildEmbeddedBD(t)
+
+	t.Run("Blocks", func(t *testing.T) {
+		t.Run("happy_path", func(t *testing.T) {
+			p := bdProxiedInit(t, bd, "dpb1")
+			a := bdProxiedCreate(t, bd, p.dir, "Block A", "--type", "task")
+			b := bdProxiedCreate(t, bd, p.dir, "Block B", "--type", "task")
+			out := bdProxiedDep(t, bd, p.dir, a.ID, "--blocks", b.ID)
+			if !strings.Contains(out, "Added") || !strings.Contains(out, "blocks") {
+				t.Errorf("expected 'Added ... blocks' output: %s", out)
+			}
+		})
+	})
+
+	t.Run("Add", func(t *testing.T) {
+		t.Run("positional_args", func(t *testing.T) {
+			p := bdProxiedInit(t, bd, "dpa1")
+			a := bdProxiedCreate(t, bd, p.dir, "Pos A", "--type", "task")
+			b := bdProxiedCreate(t, bd, p.dir, "Pos B", "--type", "task")
+			out := bdProxiedDep(t, bd, p.dir, "add", a.ID, b.ID)
+			if !strings.Contains(out, "Added dependency") {
+				t.Errorf("expected 'Added dependency': %s", out)
+			}
+		})
+
+		t.Run("type_parent_child", func(t *testing.T) {
+			p := bdProxiedInit(t, bd, "dpa2")
+			epic := bdProxiedCreate(t, bd, p.dir, "Epic", "--type", "epic")
+			c1 := bdProxiedCreate(t, bd, p.dir, "Child 1", "--type", "task")
+			c2 := bdProxiedCreate(t, bd, p.dir, "Child 2", "--type", "task")
+			bdProxiedDep(t, bd, p.dir, "add", c1.ID, epic.ID, "--type", "parent-child")
+			bdProxiedDep(t, bd, p.dir, "add", c2.ID, epic.ID, "--type", "parent-child")
+			out := bdProxiedDep(t, bd, p.dir, "list", epic.ID, "--direction", "up")
+			if !strings.Contains(out, c1.ID) || !strings.Contains(out, c2.ID) {
+				t.Errorf("expected both children in dependents: %s", out)
+			}
+		})
+
+		t.Run("type_tracks", func(t *testing.T) {
+			p := bdProxiedInit(t, bd, "dpa3")
+			tracker := bdProxiedCreate(t, bd, p.dir, "Tracker", "--type", "task")
+			tracked := bdProxiedCreate(t, bd, p.dir, "Tracked", "--type", "task")
+			bdProxiedDep(t, bd, p.dir, "add", tracker.ID, tracked.ID, "--type", "tracks")
+			out := bdProxiedDep(t, bd, p.dir, "list", tracker.ID)
+			if !strings.Contains(out, tracked.ID) {
+				t.Errorf("expected tracked issue in deps: %s", out)
+			}
+		})
+
+		t.Run("type_related", func(t *testing.T) {
+			p := bdProxiedInit(t, bd, "dpa4")
+			r1 := bdProxiedCreate(t, bd, p.dir, "Related 1", "--type", "task")
+			r2 := bdProxiedCreate(t, bd, p.dir, "Related 2", "--type", "task")
+			out := bdProxiedDep(t, bd, p.dir, "add", r1.ID, r2.ID, "--type", "related")
+			if !strings.Contains(out, "Added dependency") {
+				t.Errorf("expected related edge accepted: %s", out)
+			}
+		})
+
+		t.Run("blocked_by_flag", func(t *testing.T) {
+			p := bdProxiedInit(t, bd, "dpa5")
+			x := bdProxiedCreate(t, bd, p.dir, "Blocked", "--type", "task")
+			y := bdProxiedCreate(t, bd, p.dir, "Blocker", "--type", "task")
+			bdProxiedDep(t, bd, p.dir, "add", x.ID, "--blocked-by", y.ID)
+			out := bdProxiedDep(t, bd, p.dir, "list", x.ID)
+			if !strings.Contains(out, y.ID) {
+				t.Errorf("expected blocker in deps: %s", out)
+			}
+		})
+
+		t.Run("depends_on_flag", func(t *testing.T) {
+			p := bdProxiedInit(t, bd, "dpa6")
+			x := bdProxiedCreate(t, bd, p.dir, "Dependent", "--type", "task")
+			y := bdProxiedCreate(t, bd, p.dir, "Dependency", "--type", "task")
+			bdProxiedDep(t, bd, p.dir, "add", x.ID, "--depends-on", y.ID)
+			out := bdProxiedDep(t, bd, p.dir, "list", x.ID)
+			if !strings.Contains(out, y.ID) {
+				t.Errorf("expected dependency in deps: %s", out)
+			}
+		})
+
+		t.Run("cycle_rejected", func(t *testing.T) {
+			p := bdProxiedInit(t, bd, "dpa7")
+			a := bdProxiedCreate(t, bd, p.dir, "Cyc A", "--type", "task")
+			b := bdProxiedCreate(t, bd, p.dir, "Cyc B", "--type", "task")
+			bdProxiedDep(t, bd, p.dir, "add", a.ID, b.ID)
+			out := bdProxiedDepFail(t, bd, p.dir, "add", b.ID, a.ID)
+			if !strings.Contains(strings.ToLower(out), "cycle") {
+				t.Errorf("expected 'cycle' error: %s", out)
+			}
+		})
+
+		t.Run("child_parent_antipattern", func(t *testing.T) {
+			p := bdProxiedInit(t, bd, "dpa8")
+			parent := bdProxiedCreate(t, bd, p.dir, "AP Parent", "--type", "epic")
+			child := bdProxiedCreate(t, bd, p.dir, "AP Child", "--type", "task", "--parent", parent.ID)
+			out := bdProxiedDepFail(t, bd, p.dir, "add", child.ID, parent.ID)
+			if !strings.Contains(out, "child") && !strings.Contains(out, "deadlock") {
+				t.Errorf("expected child→parent rejection: %s", out)
+			}
+		})
+
+		t.Run("json_output", func(t *testing.T) {
+			p := bdProxiedInit(t, bd, "dpa9")
+			j1 := bdProxiedCreate(t, bd, p.dir, "JSON A", "--type", "task")
+			j2 := bdProxiedCreate(t, bd, p.dir, "JSON B", "--type", "task")
+			m := bdProxiedDepJSON(t, bd, p.dir, "add", j1.ID, j2.ID)
+			if m["status"] != "added" {
+				t.Errorf("expected status=added, got %v", m["status"])
+			}
+			if m["issue_id"] != j1.ID || m["depends_on_id"] != j2.ID {
+				t.Errorf("unexpected envelope: %v", m)
+			}
+		})
+
+		t.Run("bulk_file_jsonl", func(t *testing.T) {
+			p := bdProxiedInit(t, bd, "dpa10")
+			b1 := bdProxiedCreate(t, bd, p.dir, "Bulk A", "--type", "task")
+			b2 := bdProxiedCreate(t, bd, p.dir, "Bulk B", "--type", "task")
+			b3 := bdProxiedCreate(t, bd, p.dir, "Bulk C", "--type", "task")
+			path := filepath.Join(t.TempDir(), "deps.jsonl")
+			body := fmt.Sprintf("{\"from\":%q,\"to\":%q}\n{\"issue_id\":%q,\"depends_on_id\":%q,\"type\":\"tracks\"}\n",
+				b1.ID, b2.ID, b3.ID, b2.ID)
+			if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+				t.Fatalf("write deps file: %v", err)
+			}
+			out := bdProxiedDep(t, bd, p.dir, "add", "--file", path)
+			if !strings.Contains(out, "Added 2 dependencies") {
+				t.Fatalf("expected bulk add summary: %s", out)
+			}
+			list1 := bdProxiedDep(t, bd, p.dir, "list", b1.ID)
+			if !strings.Contains(list1, b2.ID) {
+				t.Fatalf("expected first bulk dep in list: %s", list1)
+			}
+			list3 := bdProxiedDep(t, bd, p.dir, "list", b3.ID)
+			if !strings.Contains(list3, b2.ID) || !strings.Contains(list3, "tracks") {
+				t.Fatalf("expected typed bulk dep in list: %s", list3)
+			}
+		})
+
+		t.Run("bulk_file_validation_atomic", func(t *testing.T) {
+			p := bdProxiedInit(t, bd, "dpa11")
+			v1 := bdProxiedCreate(t, bd, p.dir, "Valid A", "--type", "task")
+			v2 := bdProxiedCreate(t, bd, p.dir, "Valid B", "--type", "task")
+			path := filepath.Join(t.TempDir(), "bad-deps.jsonl")
+			body := fmt.Sprintf("{\"from\":%q,\"to\":%q}\n{\"from\":\"\",\"to\":%q}\n{\"from\":%q,\"to\":\"\"}\n",
+				v1.ID, v2.ID, v2.ID, v1.ID)
+			if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+				t.Fatalf("write bad deps file: %v", err)
+			}
+			out := bdProxiedDepFail(t, bd, p.dir, "add", "--file", path)
+			if !strings.Contains(out, "line 2: missing from") || !strings.Contains(out, "line 3: missing to") {
+				t.Fatalf("expected all validation errors: %s", out)
+			}
+			list := bdProxiedDep(t, bd, p.dir, "list", v1.ID)
+			if strings.Contains(list, v2.ID) {
+				t.Fatalf("bulk validation failure should not partial-commit: %s", list)
+			}
+		})
+
+		t.Run("no_cycle_check_chain", func(t *testing.T) {
+			p := bdProxiedInit(t, bd, "dpa12")
+			const n = 10
+			ids := make([]string, n)
+			for i := 0; i < n; i++ {
+				issue := bdProxiedCreate(t, bd, p.dir, fmt.Sprintf("chain-%d", i), "--type", "task")
+				ids[i] = issue.ID
+			}
+			for i := 1; i < n; i++ {
+				out := bdProxiedDep(t, bd, p.dir, "add", ids[i], ids[i-1], "--no-cycle-check")
+				if strings.Contains(out, "cycle") {
+					t.Errorf("unexpected cycle output with --no-cycle-check: %s", out)
+				}
+			}
+			cyclesOut := bdProxiedDep(t, bd, p.dir, "cycles")
+			if strings.Contains(cyclesOut, "Found") {
+				t.Errorf("unexpected cycles after acyclic chain wiring: %s", cyclesOut)
+			}
+			extra := bdProxiedCreate(t, bd, p.dir, "chain-extra", "--type", "task")
+			bdProxiedDep(t, bd, p.dir, extra.ID, "--blocks", ids[n-1], "--no-cycle-check")
+		})
+
+		t.Run("bulk_no_cycle_check_whole_graph_gate", func(t *testing.T) {
+			p := bdProxiedInit(t, bd, "dpa13")
+			a := bdProxiedCreate(t, bd, p.dir, "Gate A", "--type", "task")
+			b := bdProxiedCreate(t, bd, p.dir, "Gate B", "--type", "task")
+			c := bdProxiedCreate(t, bd, p.dir, "Gate C", "--type", "task")
+
+			okInput := fmt.Sprintf("{\"from\":%q,\"to\":%q}\n{\"from\":%q,\"to\":%q}\n",
+				a.ID, b.ID, b.ID, c.ID)
+			out := bdProxiedDepWithInput(t, bd, p.dir, okInput, "add", "--file", "-", "--no-cycle-check")
+			if !strings.Contains(out, "Added 2 dependencies") {
+				t.Fatalf("expected acyclic bulk add summary: %s", out)
+			}
+
+			cycleInput := fmt.Sprintf("{\"from\":%q,\"to\":%q}\n", c.ID, a.ID)
+			failOut := bdProxiedDepWithInputFail(t, bd, p.dir, cycleInput, "add", "--file", "-", "--no-cycle-check")
+			if !strings.Contains(strings.ToLower(failOut), "cycle") {
+				t.Fatalf("expected whole-graph cycle rejection: %s", failOut)
+			}
+
+			cycles := bdProxiedDep(t, bd, p.dir, "cycles")
+			if !strings.Contains(cycles, "No dependency cycles detected") {
+				t.Fatalf("expected rolled-back bulk add to leave graph acyclic: %s", cycles)
+			}
+		})
+
+		t.Run("commit_visible_to_subsequent_invocation", func(t *testing.T) {
+			p := bdProxiedInit(t, bd, "dpa14")
+			a := bdProxiedCreate(t, bd, p.dir, "Commit A", "--type", "task")
+			b := bdProxiedCreate(t, bd, p.dir, "Commit B", "--type", "task")
+			bdProxiedDep(t, bd, p.dir, "add", a.ID, b.ID)
+			out := bdProxiedDep(t, bd, p.dir, "list", a.ID)
+			if !strings.Contains(out, b.ID) {
+				t.Fatalf("dep not visible in fresh CLI invocation after add: %s", out)
+			}
+		})
+
+		t.Run("bulk_external_ref_passthrough", func(t *testing.T) {
+			p := bdProxiedInit(t, bd, "dpa15")
+			src := bdProxiedCreate(t, bd, p.dir, "Ext src", "--type", "task")
+			input := fmt.Sprintf("{\"from\":%q,\"to\":\"external:other:capability\"}\n", src.ID)
+			cmd := exec.Command(bd, "dep", "add", "--file", "-")
+			cmd.Dir = p.dir
+			cmd.Env = bdProxiedEnv(p.dir)
+			cmd.Stdin = strings.NewReader(input)
+			out, err := cmd.CombinedOutput()
+			if err != nil {
+				if !strings.Contains(string(out), "external") {
+					t.Fatalf("external-ref bulk add failed without a clear external-ref error: %v\n%s", err, out)
+				}
+				return
+			}
+			if !strings.Contains(string(out), "Added 1 dependencies") {
+				t.Fatalf("expected 1-edge bulk add summary or clear external-ref error: %s", out)
+			}
+		})
+	})
+
+	t.Run("Remove", func(t *testing.T) {
+		t.Run("basic", func(t *testing.T) {
+			p := bdProxiedInit(t, bd, "dpr1")
+			a := bdProxiedCreate(t, bd, p.dir, "Rm A", "--type", "task")
+			b := bdProxiedCreate(t, bd, p.dir, "Rm B", "--type", "task")
+			bdProxiedDep(t, bd, p.dir, "add", a.ID, b.ID)
+			out := bdProxiedDep(t, bd, p.dir, "remove", a.ID, b.ID)
+			if !strings.Contains(out, "Removed") {
+				t.Errorf("expected 'Removed': %s", out)
+			}
+		})
+
+		t.Run("rm_alias", func(t *testing.T) {
+			p := bdProxiedInit(t, bd, "dpr2")
+			a := bdProxiedCreate(t, bd, p.dir, "Rm A", "--type", "task")
+			b := bdProxiedCreate(t, bd, p.dir, "Rm B", "--type", "task")
+			bdProxiedDep(t, bd, p.dir, "add", a.ID, b.ID)
+			out := bdProxiedDep(t, bd, p.dir, "rm", a.ID, b.ID)
+			if !strings.Contains(out, "Removed") {
+				t.Errorf("expected 'Removed' via rm alias: %s", out)
+			}
+		})
+
+		t.Run("json_output", func(t *testing.T) {
+			p := bdProxiedInit(t, bd, "dpr3")
+			a := bdProxiedCreate(t, bd, p.dir, "Rm JSON A", "--type", "task")
+			b := bdProxiedCreate(t, bd, p.dir, "Rm JSON B", "--type", "task")
+			bdProxiedDep(t, bd, p.dir, "add", a.ID, b.ID)
+			m := bdProxiedDepJSON(t, bd, p.dir, "remove", a.ID, b.ID)
+			if m["status"] != "removed" {
+				t.Errorf("expected status=removed, got %v", m["status"])
+			}
+		})
+	})
+
+	t.Run("List", func(t *testing.T) {
+		t.Run("default_direction_down", func(t *testing.T) {
+			p := bdProxiedInit(t, bd, "dpl1")
+			a := bdProxiedCreate(t, bd, p.dir, "L A", "--type", "task")
+			b := bdProxiedCreate(t, bd, p.dir, "L B", "--type", "task")
+			bdProxiedDep(t, bd, p.dir, "add", a.ID, b.ID)
+			out := bdProxiedDep(t, bd, p.dir, "list", a.ID)
+			if !strings.Contains(out, b.ID) {
+				t.Errorf("expected dependency in list output: %s", out)
+			}
+		})
+
+		t.Run("direction_up", func(t *testing.T) {
+			p := bdProxiedInit(t, bd, "dpl2")
+			a := bdProxiedCreate(t, bd, p.dir, "Up A", "--type", "task")
+			b := bdProxiedCreate(t, bd, p.dir, "Up B", "--type", "task")
+			bdProxiedDep(t, bd, p.dir, "add", a.ID, b.ID)
+			out := bdProxiedDep(t, bd, p.dir, "list", b.ID, "--direction", "up")
+			if !strings.Contains(out, a.ID) {
+				t.Errorf("expected dependent in --direction up: %s", out)
+			}
+		})
+
+		t.Run("type_filter", func(t *testing.T) {
+			p := bdProxiedInit(t, bd, "dpl3")
+			epic := bdProxiedCreate(t, bd, p.dir, "TF epic", "--type", "epic")
+			c1 := bdProxiedCreate(t, bd, p.dir, "TF c1", "--type", "task")
+			c2 := bdProxiedCreate(t, bd, p.dir, "TF c2", "--type", "task")
+			bdProxiedDep(t, bd, p.dir, "add", c1.ID, epic.ID, "--type", "parent-child")
+			bdProxiedDep(t, bd, p.dir, "add", c2.ID, epic.ID, "--type", "parent-child")
+			out := bdProxiedDep(t, bd, p.dir, "list", epic.ID, "--direction", "up", "--type", "parent-child")
+			if !strings.Contains(out, c1.ID) || !strings.Contains(out, c2.ID) {
+				t.Errorf("expected children in type-filtered list: %s", out)
+			}
+		})
+
+		t.Run("json_output", func(t *testing.T) {
+			p := bdProxiedInit(t, bd, "dpl4")
+			a := bdProxiedCreate(t, bd, p.dir, "LJ A", "--type", "task")
+			b := bdProxiedCreate(t, bd, p.dir, "LJ B", "--type", "task")
+			bdProxiedDep(t, bd, p.dir, "add", a.ID, b.ID)
+			arr := bdProxiedDepJSONArray(t, bd, p.dir, "list", a.ID)
+			if len(arr) == 0 {
+				t.Fatalf("expected non-empty JSON list array")
+			}
+			raw, _ := json.Marshal(arr)
+			if !strings.Contains(string(raw), b.ID) {
+				t.Errorf("expected dependency target in JSON: %s", string(raw))
+			}
+		})
+
+		t.Run("batch_multi_arg", func(t *testing.T) {
+			p := bdProxiedInit(t, bd, "dpl5")
+			a := bdProxiedCreate(t, bd, p.dir, "B A", "--type", "task")
+			b := bdProxiedCreate(t, bd, p.dir, "B B", "--type", "task")
+			c := bdProxiedCreate(t, bd, p.dir, "B C", "--type", "task")
+			d := bdProxiedCreate(t, bd, p.dir, "B D", "--type", "task")
+			bdProxiedDep(t, bd, p.dir, "add", a.ID, b.ID)
+			bdProxiedDep(t, bd, p.dir, "add", c.ID, d.ID)
+			out := bdProxiedDep(t, bd, p.dir, "list", a.ID, c.ID)
+			if !strings.Contains(out, b.ID) || !strings.Contains(out, d.ID) {
+				t.Errorf("expected both deps in batch list: %s", out)
+			}
+			arr := bdProxiedDepJSONArray(t, bd, p.dir, "list", a.ID, c.ID)
+			if len(arr) != 2 {
+				t.Errorf("expected 2 deps in batch JSON, got %d: %v", len(arr), arr)
+			}
+		})
+
+		t.Run("batch_partitions_wisp_and_issue_ids", func(t *testing.T) {
+			p := bdProxiedInit(t, bd, "dpl6")
+			issueSrc := bdProxiedCreate(t, bd, p.dir, "WP issue src", "--type", "task")
+			issueTgt := bdProxiedCreate(t, bd, p.dir, "WP issue tgt", "--type", "task")
+			bdProxiedDep(t, bd, p.dir, "add", issueSrc.ID, issueTgt.ID)
+
+			db := openProxiedDB(t, p)
+			wispSrc := fmt.Sprintf("%s-wisp-src", p.prefix)
+			wispTgt := fmt.Sprintf("%s-wisp-tgt", p.prefix)
+			if _, err := db.ExecContext(context.Background(),
+				"INSERT INTO wisps (id, title) VALUES (?, ?), (?, ?)",
+				wispSrc, "wisp src", wispTgt, "wisp tgt"); err != nil {
+				t.Fatalf("seed wisps: %v", err)
+			}
+			if _, err := db.ExecContext(context.Background(),
+				"INSERT INTO wisp_dependencies (id, issue_id, depends_on_wisp_id, type, created_at, created_by, metadata) VALUES (UUID(), ?, ?, 'blocks', NOW(), 'tester', '{}')",
+				wispSrc, wispTgt); err != nil {
+				t.Fatalf("seed wisp dep: %v", err)
+			}
+
+			arr := bdProxiedDepJSONArray(t, bd, p.dir, "list", issueSrc.ID, wispSrc)
+			raw, _ := json.Marshal(arr)
+			if !strings.Contains(string(raw), issueTgt.ID) {
+				t.Errorf("expected issue target %s in batch list: %s", issueTgt.ID, string(raw))
+			}
+			if !strings.Contains(string(raw), wispTgt) {
+				t.Errorf("expected wisp target %s in batch list (partitioning path): %s", wispTgt, string(raw))
+			}
+		})
+	})
+
+	t.Run("Tree", func(t *testing.T) {
+		t.Run("basic", func(t *testing.T) {
+			p := bdProxiedInit(t, bd, "dpt1")
+			root := bdProxiedCreate(t, bd, p.dir, "Tree root", "--type", "task")
+			child := bdProxiedCreate(t, bd, p.dir, "Tree child", "--type", "task")
+			bdProxiedDep(t, bd, p.dir, "add", root.ID, child.ID)
+			out := bdProxiedDep(t, bd, p.dir, "tree", root.ID)
+			if !strings.Contains(out, root.ID) {
+				t.Errorf("expected root ID in tree: %s", out)
+			}
+		})
+
+		t.Run("direction_up", func(t *testing.T) {
+			p := bdProxiedInit(t, bd, "dpt2")
+			root := bdProxiedCreate(t, bd, p.dir, "Up tree root", "--type", "task")
+			dep := bdProxiedCreate(t, bd, p.dir, "Up tree dep", "--type", "task")
+			bdProxiedDep(t, bd, p.dir, "add", root.ID, dep.ID)
+			out := bdProxiedDep(t, bd, p.dir, "tree", dep.ID, "--direction", "up")
+			if len(strings.TrimSpace(out)) == 0 {
+				t.Error("expected non-empty tree output for --direction up")
+			}
+		})
+
+		t.Run("direction_both", func(t *testing.T) {
+			p := bdProxiedInit(t, bd, "dpt3")
+			root := bdProxiedCreate(t, bd, p.dir, "Both root", "--type", "task")
+			dep := bdProxiedCreate(t, bd, p.dir, "Both dep", "--type", "task")
+			bdProxiedDep(t, bd, p.dir, "add", root.ID, dep.ID)
+			out := bdProxiedDep(t, bd, p.dir, "tree", root.ID, "--direction", "both")
+			if len(strings.TrimSpace(out)) == 0 {
+				t.Error("expected non-empty tree output for --direction both")
+			}
+		})
+
+		t.Run("both_does_not_duplicate_root", func(t *testing.T) {
+			p := bdProxiedInit(t, bd, "dpt4")
+			root := bdProxiedCreate(t, bd, p.dir, "Dedup root", "--type", "task")
+			depDown := bdProxiedCreate(t, bd, p.dir, "Dedup down", "--type", "task")
+			depUp := bdProxiedCreate(t, bd, p.dir, "Dedup up", "--type", "task")
+			bdProxiedDep(t, bd, p.dir, "add", root.ID, depDown.ID)
+			bdProxiedDep(t, bd, p.dir, "add", depUp.ID, root.ID)
+			arr := bdProxiedDepJSONArray(t, bd, p.dir, "tree", root.ID, "--direction", "both")
+			count := 0
+			for _, node := range arr {
+				m, ok := node.(map[string]interface{})
+				if !ok {
+					continue
+				}
+				if id, _ := m["id"].(string); id == root.ID {
+					count++
+				}
+			}
+			if count != 1 {
+				t.Errorf("expected root %s to appear exactly once in both tree, got %d: %v", root.ID, count, arr)
+			}
+		})
+
+		t.Run("max_depth", func(t *testing.T) {
+			p := bdProxiedInit(t, bd, "dpt5")
+			a := bdProxiedCreate(t, bd, p.dir, "MD A", "--type", "task")
+			b := bdProxiedCreate(t, bd, p.dir, "MD B", "--type", "task")
+			c := bdProxiedCreate(t, bd, p.dir, "MD C", "--type", "task")
+			bdProxiedDep(t, bd, p.dir, "add", a.ID, b.ID)
+			bdProxiedDep(t, bd, p.dir, "add", b.ID, c.ID)
+			out := bdProxiedDep(t, bd, p.dir, "tree", a.ID, "--max-depth", "1")
+			if !strings.Contains(out, a.ID) {
+				t.Errorf("expected root in shallow tree: %s", out)
+			}
+		})
+
+		t.Run("status_filter", func(t *testing.T) {
+			p := bdProxiedInit(t, bd, "dpt6")
+			root := bdProxiedCreate(t, bd, p.dir, "SF root", "--type", "task")
+			dep := bdProxiedCreate(t, bd, p.dir, "SF dep", "--type", "task")
+			bdProxiedDep(t, bd, p.dir, "add", root.ID, dep.ID)
+			_ = bdProxiedDep(t, bd, p.dir, "tree", root.ID, "--status", "open")
+		})
+
+		t.Run("format_mermaid", func(t *testing.T) {
+			p := bdProxiedInit(t, bd, "dpt7")
+			root := bdProxiedCreate(t, bd, p.dir, "Mer root", "--type", "task")
+			dep := bdProxiedCreate(t, bd, p.dir, "Mer dep", "--type", "task")
+			bdProxiedDep(t, bd, p.dir, "add", root.ID, dep.ID)
+			out := bdProxiedDep(t, bd, p.dir, "tree", root.ID, "--format", "mermaid")
+			if !strings.Contains(out, "flowchart") && !strings.Contains(out, "graph") {
+				t.Errorf("expected mermaid flowchart/graph syntax: %s", out)
+			}
+		})
+
+		t.Run("json_output", func(t *testing.T) {
+			p := bdProxiedInit(t, bd, "dpt8")
+			root := bdProxiedCreate(t, bd, p.dir, "JT root", "--type", "task")
+			dep := bdProxiedCreate(t, bd, p.dir, "JT dep", "--type", "task")
+			bdProxiedDep(t, bd, p.dir, "add", root.ID, dep.ID)
+			arr := bdProxiedDepJSONArray(t, bd, p.dir, "tree", root.ID)
+			raw, _ := json.Marshal(arr)
+			if !strings.Contains(string(raw), root.ID) {
+				t.Errorf("expected root ID in JSON tree: %s", string(raw))
+			}
+		})
+
+		t.Run("ignores_relates_to", func(t *testing.T) {
+			p := bdProxiedInit(t, bd, "dpt9")
+			root := bdProxiedCreate(t, bd, p.dir, "Rel root", "--type", "task")
+			blocker := bdProxiedCreate(t, bd, p.dir, "Real blocker", "--type", "task")
+			related := bdProxiedCreate(t, bd, p.dir, "Loose relation", "--type", "task")
+			bdProxiedDep(t, bd, p.dir, "add", root.ID, blocker.ID, "--type", "blocks")
+			bdProxiedDep(t, bd, p.dir, "add", root.ID, related.ID, "--type", "relates-to")
+			bdProxiedDep(t, bd, p.dir, "add", related.ID, root.ID, "--type", "relates-to")
+
+			listOut := bdProxiedDep(t, bd, p.dir, "list", root.ID)
+			if !strings.Contains(listOut, related.ID) || !strings.Contains(listOut, "relates-to") {
+				t.Fatalf("expected relates-to in dep list: %s", listOut)
+			}
+
+			treeOut := bdProxiedDep(t, bd, p.dir, "tree", root.ID)
+			if !strings.Contains(treeOut, root.ID) || !strings.Contains(treeOut, blocker.ID) {
+				t.Fatalf("expected root + real blocker in tree: %s", treeOut)
+			}
+			if strings.Contains(treeOut, related.ID) {
+				t.Fatalf("relates-to should not render in tree: %s", treeOut)
+			}
+
+			upOut := bdProxiedDep(t, bd, p.dir, "tree", related.ID, "--direction", "up")
+			if strings.Contains(upOut, root.ID) {
+				t.Fatalf("reverse relates-to should not render in dependent tree: %s", upOut)
+			}
+		})
+	})
+
+	t.Run("Cycles", func(t *testing.T) {
+		t.Run("detect", func(t *testing.T) {
+			p := bdProxiedInit(t, bd, "dpc1")
+			a := bdProxiedCreate(t, bd, p.dir, "C A", "--type", "task")
+			b := bdProxiedCreate(t, bd, p.dir, "C B", "--type", "task")
+			bdProxiedDep(t, bd, p.dir, "add", a.ID, b.ID)
+
+			db := openProxiedDB(t, p)
+			if _, err := db.ExecContext(context.Background(),
+				"INSERT INTO dependencies (id, issue_id, depends_on_issue_id, type, created_at, created_by, metadata) VALUES (UUID(), ?, ?, 'blocks', NOW(), 'tester', '{}')",
+				b.ID, a.ID); err != nil {
+				t.Fatalf("seed cycle: %v", err)
+			}
+
+			out := bdProxiedDep(t, bd, p.dir, "cycles")
+			if !strings.Contains(out, a.ID) || !strings.Contains(out, b.ID) {
+				t.Errorf("expected cycle members in output: %s", out)
+			}
+		})
+
+		t.Run("none", func(t *testing.T) {
+			p := bdProxiedInit(t, bd, "dpc2")
+			a := bdProxiedCreate(t, bd, p.dir, "NC A", "--type", "task")
+			b := bdProxiedCreate(t, bd, p.dir, "NC B", "--type", "task")
+			bdProxiedDep(t, bd, p.dir, "add", a.ID, b.ID)
+			out := bdProxiedDep(t, bd, p.dir, "cycles")
+			if !strings.Contains(out, "No dependency cycles detected") {
+				t.Errorf("expected no-cycle message: %s", out)
+			}
+		})
+	})
+}
+
+func TestProxiedServerDepConcurrent(t *testing.T) {
+	requireProxiedServerEnv(t)
+	bd := buildEmbeddedBD(t)
+	p := bdProxiedInit(t, bd, "dpcon")
+
+	var ids []string
+	for i := 0; i < 16; i++ {
+		issue := bdProxiedCreate(t, bd, p.dir, fmt.Sprintf("concurrent-%d", i), "--type", "task")
+		ids = append(ids, issue.ID)
+	}
+	for i := 0; i < 8; i++ {
+		bdProxiedDep(t, bd, p.dir, "add", ids[i*2], ids[i*2+1])
+	}
+
+	const numWorkers = 8
+	type workerResult struct {
+		worker int
+		err    error
+	}
+	results := make([]workerResult, numWorkers)
+	var wg sync.WaitGroup
+	wg.Add(numWorkers)
+
+	for w := 0; w < numWorkers; w++ {
+		go func(worker int) {
+			defer wg.Done()
+			r := workerResult{worker: worker}
+			id := ids[worker*2]
+
+			cmd := exec.Command(bd, "dep", "list", id, "--json")
+			cmd.Dir = p.dir
+			cmd.Env = bdProxiedEnv(p.dir)
+			if out, err := cmd.CombinedOutput(); err != nil {
+				r.err = fmt.Errorf("worker %d dep list: %v\n%s", worker, err, out)
+				results[worker] = r
+				return
+			}
+
+			cmd = exec.Command(bd, "dep", "tree", id)
+			cmd.Dir = p.dir
+			cmd.Env = bdProxiedEnv(p.dir)
+			if out, err := cmd.CombinedOutput(); err != nil {
+				r.err = fmt.Errorf("worker %d dep tree: %v\n%s", worker, err, out)
+				results[worker] = r
+				return
+			}
+			results[worker] = r
+		}(w)
+	}
+	wg.Wait()
+
+	for _, r := range results {
+		if r.err != nil && !strings.Contains(r.err.Error(), "one writer at a time") {
+			t.Errorf("worker %d failed: %v", r.worker, r.err)
+		}
+	}
+}

--- a/cmd/bd/dep_proxied_server.go
+++ b/cmd/bd/dep_proxied_server.go
@@ -1,0 +1,546 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/steveyegge/beads/internal/storage/domain"
+	"github.com/steveyegge/beads/internal/storage/uow"
+	"github.com/steveyegge/beads/internal/types"
+	"github.com/steveyegge/beads/internal/ui"
+)
+
+func openDepProxiedUOW(ctx context.Context) uow.UnitOfWork {
+	if uowProvider == nil {
+		FatalErrorRespectJSON("proxied-server UOW provider not initialized")
+	}
+	uw, err := uowProvider.NewUOW(ctx)
+	if err != nil {
+		FatalErrorRespectJSON("open unit of work: %v", err)
+	}
+	return uw
+}
+
+func proxiedLookupTitle(ctx context.Context, uw uow.UnitOfWork, id string) string {
+	if IsExternalRef(id) {
+		return ""
+	}
+	issue, err := uw.IssueUseCase().GetIssue(ctx, id)
+	if err == nil && issue != nil {
+		return issue.Title
+	}
+	wisp, err := uw.IssueUseCase().GetWisp(ctx, id)
+	if err == nil && wisp != nil {
+		return wisp.Title
+	}
+	return ""
+}
+
+func proxiedWarnCycles(ctx context.Context, uw uow.UnitOfWork) {
+	cycles, err := uw.DependencyUseCase().DetectCycles(ctx)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: Failed to check for cycles: %v\n", err)
+		return
+	}
+	if len(cycles) == 0 {
+		return
+	}
+	fmt.Fprintf(os.Stderr, "\n%s Warning: Dependency cycle detected!\n", ui.RenderWarn("⚠"))
+	fmt.Fprintf(os.Stderr, "This can hide issues from the ready work list and cause confusion.\n\n")
+	fmt.Fprintf(os.Stderr, "Cycle path:\n")
+	for _, cycle := range cycles {
+		for j, issue := range cycle {
+			if j == 0 {
+				fmt.Fprintf(os.Stderr, "  %s", issue.ID)
+			} else {
+				fmt.Fprintf(os.Stderr, " → %s", issue.ID)
+			}
+		}
+		if len(cycle) > 0 {
+			fmt.Fprintf(os.Stderr, " → %s", cycle[0].ID)
+		}
+		fmt.Fprintf(os.Stderr, "\n")
+	}
+	fmt.Fprintf(os.Stderr, "\nRun 'bd dep cycles' for detailed analysis.\n\n")
+}
+
+func runDepBlocksProxiedServer(cmd *cobra.Command, ctx context.Context, blockerID, blockedID string) {
+	if isChildOf(blockedID, blockerID) {
+		FatalErrorRespectJSON("cannot add dependency: %s is already a child of %s. Children inherit dependency on parent completion via hierarchy. Adding an explicit dependency would create a deadlock", blockedID, blockerID)
+	}
+
+	uw := openDepProxiedUOW(ctx)
+	defer uw.Close(ctx)
+
+	dep := &types.Dependency{
+		IssueID:     blockedID,
+		DependsOnID: blockerID,
+		Type:        types.DepBlocks,
+	}
+	if _, err := uw.DependencyUseCase().AddDependencies(ctx, []*types.Dependency{dep}, actor, domain.BulkAddDepsOpts{}); err != nil {
+		FatalErrorRespectJSON("%v", err)
+	}
+
+	noCycleCheck, _ := cmd.Flags().GetBool("no-cycle-check")
+	if !noCycleCheck {
+		proxiedWarnCycles(ctx, uw)
+	}
+
+	blockerTitle := proxiedLookupTitle(ctx, uw, blockerID)
+	blockedTitle := proxiedLookupTitle(ctx, uw, blockedID)
+
+	if err := uw.Commit(ctx, fmt.Sprintf("bd: dep add %s %s", blockedID, blockerID)); err != nil && !isDoltNothingToCommit(err) {
+		FatalErrorRespectJSON("failed to commit: %v", err)
+	}
+
+	if jsonOutput {
+		outputJSON(map[string]interface{}{
+			"status":     "added",
+			"blocker_id": blockerID,
+			"blocked_id": blockedID,
+			"type":       string(types.DepBlocks),
+		})
+		return
+	}
+
+	fmt.Printf("%s Added dependency: %s blocks %s\n",
+		ui.RenderPass("✓"),
+		formatFeedbackIDParen(blockerID, blockerTitle),
+		formatFeedbackIDParen(blockedID, blockedTitle))
+}
+
+func runDepAddProxiedServer(cmd *cobra.Command, ctx context.Context, args []string) {
+	depType, _ := cmd.Flags().GetString("type")
+	file, _ := cmd.Flags().GetString("file")
+
+	if file != "" {
+		runDepAddBulkProxied(cmd, ctx, file, depType)
+		return
+	}
+
+	blockedBy, _ := cmd.Flags().GetString("blocked-by")
+	dependsOn, _ := cmd.Flags().GetString("depends-on")
+
+	var dependsOnArg string
+	switch {
+	case blockedBy != "":
+		dependsOnArg = blockedBy
+	case dependsOn != "":
+		dependsOnArg = dependsOn
+	default:
+		dependsOnArg = args[1]
+	}
+
+	fromID := args[0]
+	var toID string
+	if strings.HasPrefix(dependsOnArg, "external:") {
+		if err := validateExternalRef(dependsOnArg); err != nil {
+			FatalErrorRespectJSON("%v", err)
+		}
+		toID = dependsOnArg
+	} else {
+		toID = dependsOnArg
+	}
+
+	if isChildOf(fromID, toID) {
+		FatalErrorRespectJSON("cannot add dependency: %s is already a child of %s. Children inherit dependency on parent completion via hierarchy. Adding an explicit dependency would create a deadlock", fromID, toID)
+	}
+
+	dt := types.DependencyType(depType)
+	if !dt.IsValid() {
+		FatalErrorRespectJSON("invalid dependency type %q: must be non-empty and at most 50 characters", depType)
+	}
+
+	uw := openDepProxiedUOW(ctx)
+	defer uw.Close(ctx)
+
+	dep := &types.Dependency{IssueID: fromID, DependsOnID: toID, Type: dt}
+	if _, err := uw.DependencyUseCase().AddDependencies(ctx, []*types.Dependency{dep}, actor, domain.BulkAddDepsOpts{}); err != nil {
+		FatalErrorRespectJSON("%v", err)
+	}
+
+	noCycleCheck, _ := cmd.Flags().GetBool("no-cycle-check")
+	if !noCycleCheck {
+		proxiedWarnCycles(ctx, uw)
+	}
+
+	fromTitle := proxiedLookupTitle(ctx, uw, fromID)
+	toTitle := proxiedLookupTitle(ctx, uw, toID)
+
+	if err := uw.Commit(ctx, fmt.Sprintf("bd: dep add %s %s", fromID, toID)); err != nil && !isDoltNothingToCommit(err) {
+		FatalErrorRespectJSON("failed to commit: %v", err)
+	}
+
+	if jsonOutput {
+		outputJSON(map[string]interface{}{
+			"status":        "added",
+			"issue_id":      fromID,
+			"depends_on_id": toID,
+			"type":          depType,
+		})
+		return
+	}
+
+	fmt.Printf("%s Added dependency: %s depends on %s (%s)\n",
+		ui.RenderPass("✓"),
+		formatFeedbackIDParen(fromID, fromTitle),
+		formatFeedbackIDParen(toID, toTitle),
+		depType)
+}
+
+func runDepAddBulkProxied(cmd *cobra.Command, ctx context.Context, file, defaultType string) {
+	edges, err := readBulkDepEdges(file, defaultType)
+	if err != nil {
+		FatalErrorRespectJSON("%v", err)
+	}
+	if len(edges) == 0 {
+		FatalErrorRespectJSON("no dependency edges found")
+	}
+
+	deps := make([]*types.Dependency, 0, len(edges))
+	for _, edge := range edges {
+		if isChildOf(edge.IssueID, edge.DependsOnID) {
+			FatalErrorRespectJSON("line %d: cannot add dependency: %s is already a child of %s", edge.Line, edge.IssueID, edge.DependsOnID)
+		}
+		if strings.HasPrefix(edge.DependsOnID, "external:") {
+			if err := validateExternalRef(edge.DependsOnID); err != nil {
+				FatalErrorRespectJSON("line %d: %v", edge.Line, err)
+			}
+		}
+		deps = append(deps, &types.Dependency{
+			IssueID:     edge.IssueID,
+			DependsOnID: edge.DependsOnID,
+			Type:        edge.Type,
+		})
+	}
+
+	uw := openDepProxiedUOW(ctx)
+	defer uw.Close(ctx)
+
+	noCycleCheck, _ := cmd.Flags().GetBool("no-cycle-check")
+	if _, err := uw.DependencyUseCase().AddDependencies(ctx, deps, actor, domain.BulkAddDepsOpts{
+		SkipPerEdgeCycleCheck: noCycleCheck,
+	}); err != nil {
+		FatalErrorRespectJSON("%v", err)
+	}
+
+	if !noCycleCheck {
+		proxiedWarnCycles(ctx, uw)
+	}
+
+	if err := uw.Commit(ctx, fmt.Sprintf("dependency: add %d edges", len(deps))); err != nil && !isDoltNothingToCommit(err) {
+		FatalErrorRespectJSON("failed to commit: %v", err)
+	}
+
+	if jsonOutput {
+		out := make([]map[string]interface{}, 0, len(deps))
+		for _, dep := range deps {
+			out = append(out, map[string]interface{}{
+				"issue_id":      dep.IssueID,
+				"depends_on_id": dep.DependsOnID,
+				"type":          string(dep.Type),
+			})
+		}
+		outputJSON(map[string]interface{}{
+			"status":       "added",
+			"count":        len(deps),
+			"dependencies": out,
+		})
+		return
+	}
+
+	fmt.Printf("%s Added %d dependencies\n", ui.RenderPass("✓"), len(deps))
+}
+
+func runDepRemoveProxiedServer(cmd *cobra.Command, ctx context.Context, args []string) {
+	fromID := args[0]
+	toID := args[1]
+	if strings.HasPrefix(toID, "external:") {
+		if err := validateExternalRef(toID); err != nil {
+			FatalErrorRespectJSON("%v", err)
+		}
+	}
+
+	uw := openDepProxiedUOW(ctx)
+	defer uw.Close(ctx)
+
+	if err := uw.DependencyUseCase().RemoveDependency(ctx, fromID, toID, actor); err != nil {
+		FatalErrorRespectJSON("%v", err)
+	}
+
+	fromTitle := proxiedLookupTitle(ctx, uw, fromID)
+	toTitle := proxiedLookupTitle(ctx, uw, toID)
+
+	if err := uw.Commit(ctx, fmt.Sprintf("bd: dep remove %s %s", fromID, toID)); err != nil && !isDoltNothingToCommit(err) {
+		FatalErrorRespectJSON("failed to commit: %v", err)
+	}
+
+	if jsonOutput {
+		outputJSON(map[string]interface{}{
+			"status":        "removed",
+			"issue_id":      fromID,
+			"depends_on_id": toID,
+		})
+		return
+	}
+
+	fmt.Printf("%s Removed dependency: %s no longer depends on %s\n",
+		ui.RenderPass("✓"),
+		formatFeedbackIDParen(fromID, fromTitle),
+		formatFeedbackIDParen(toID, toTitle))
+}
+
+func runDepListProxiedServer(cmd *cobra.Command, ctx context.Context, args []string) {
+	direction, _ := cmd.Flags().GetString("direction")
+	typeFilter, _ := cmd.Flags().GetString("type")
+	if direction == "" {
+		direction = "down"
+	}
+
+	uw := openDepProxiedUOW(ctx)
+	defer uw.Close(ctx)
+
+	depUC := uw.DependencyUseCase()
+
+	if len(args) > 1 && direction == "down" {
+		depMap, err := depUC.GetIssueDependencyRecords(ctx, args)
+		if err != nil {
+			FatalErrorRespectJSON("%v", err)
+		}
+		var allDeps []*types.Dependency
+		for _, id := range args {
+			for _, dep := range depMap[id] {
+				if typeFilter == "" || string(dep.Type) == typeFilter {
+					allDeps = append(allDeps, dep)
+				}
+			}
+		}
+		if jsonOutput {
+			if allDeps == nil {
+				allDeps = []*types.Dependency{}
+			}
+			outputJSON(allDeps)
+			return
+		}
+		for _, id := range args {
+			deps := depMap[id]
+			if len(deps) == 0 {
+				fmt.Printf("\n%s has no dependencies\n", id)
+				continue
+			}
+			fmt.Printf("\n%s %s depends on:\n\n", ui.RenderAccent("📋"), id)
+			for _, dep := range deps {
+				if typeFilter != "" && string(dep.Type) != typeFilter {
+					continue
+				}
+				fmt.Printf("  %s via %s\n", dep.DependsOnID, dep.Type)
+			}
+		}
+		fmt.Println()
+		return
+	}
+
+	var allIssues []*types.IssueWithDependencyMetadata
+	listDirection := domain.DepDirectionOut
+	if direction == "up" {
+		listDirection = domain.DepDirectionIn
+	}
+	for _, id := range args {
+		issues, err := depUC.ListWithIssueMetadata(ctx, id, domain.DepListFilter{Direction: listDirection})
+		if err != nil {
+			FatalErrorRespectJSON("%v", err)
+		}
+		if typeFilter != "" {
+			filtered := issues[:0]
+			for _, iss := range issues {
+				if string(iss.DependencyType) == typeFilter {
+					filtered = append(filtered, iss)
+				}
+			}
+			issues = filtered
+		}
+		allIssues = append(allIssues, issues...)
+	}
+
+	if jsonOutput {
+		if allIssues == nil {
+			allIssues = []*types.IssueWithDependencyMetadata{}
+		}
+		outputJSON(allIssues)
+		return
+	}
+
+	if len(allIssues) == 0 {
+		if len(args) == 1 {
+			if direction == "up" {
+				fmt.Printf("\nNo issues depend on %s\n", args[0])
+			} else {
+				fmt.Printf("\n%s has no dependencies\n", args[0])
+			}
+		} else {
+			fmt.Println("\nNo dependencies found")
+		}
+		return
+	}
+
+	for _, iss := range allIssues {
+		var idStr string
+		switch iss.Status {
+		case types.StatusOpen:
+			idStr = ui.StatusOpenStyle.Render(iss.ID)
+		case types.StatusInProgress:
+			idStr = ui.StatusInProgressStyle.Render(iss.ID)
+		case types.StatusBlocked:
+			idStr = ui.StatusBlockedStyle.Render(iss.ID)
+		case types.StatusClosed:
+			idStr = ui.StatusClosedStyle.Render(iss.ID)
+		default:
+			idStr = iss.ID
+		}
+		fmt.Printf("  %s: %s [P%d] (%s) via %s\n",
+			idStr, iss.Title, iss.Priority, iss.Status, iss.DependencyType)
+	}
+	fmt.Println()
+}
+
+func runDepTreeProxiedServer(cmd *cobra.Command, ctx context.Context, args []string) {
+	fullID := args[0]
+	showAllPaths, _ := cmd.Flags().GetBool("show-all-paths")
+	maxDepth, _ := cmd.Flags().GetInt("max-depth")
+	reverse, _ := cmd.Flags().GetBool("reverse")
+	direction, _ := cmd.Flags().GetString("direction")
+	statusFilter, _ := cmd.Flags().GetString("status")
+	formatStr, _ := cmd.Flags().GetString("format")
+	if strings.EqualFold(formatStr, "json") {
+		jsonOutput = true
+		formatStr = ""
+	}
+	if direction == "" && reverse {
+		direction = "up"
+	} else if direction == "" {
+		direction = "down"
+	}
+	if direction != "down" && direction != "up" && direction != "both" {
+		FatalErrorRespectJSON("--direction must be 'down', 'up', or 'both'")
+	}
+	if maxDepth < 1 {
+		FatalErrorRespectJSON("--max-depth must be >= 1")
+	}
+
+	uw := openDepProxiedUOW(ctx)
+	defer uw.Close(ctx)
+
+	depUC := uw.DependencyUseCase()
+	var tree []*types.TreeNode
+
+	if direction == "both" {
+		downTree, err := depUC.GetDependencyTree(ctx, fullID, domain.DepTreeOpts{
+			MaxDepth:     maxDepth,
+			ShowAllPaths: showAllPaths,
+			Direction:    domain.DepDirectionOut,
+		})
+		if err != nil {
+			FatalErrorRespectJSON("%v", err)
+		}
+		upTree, err := depUC.GetDependencyTree(ctx, fullID, domain.DepTreeOpts{
+			MaxDepth:     maxDepth,
+			ShowAllPaths: showAllPaths,
+			Direction:    domain.DepDirectionIn,
+		})
+		if err != nil {
+			FatalErrorRespectJSON("%v", err)
+		}
+		tree = mergeBidirectionalTrees(downTree, upTree, fullID)
+	} else {
+		treeDir := domain.DepDirectionOut
+		if direction == "up" {
+			treeDir = domain.DepDirectionIn
+		}
+		var err error
+		tree, err = depUC.GetDependencyTree(ctx, fullID, domain.DepTreeOpts{
+			MaxDepth:     maxDepth,
+			ShowAllPaths: showAllPaths,
+			Direction:    treeDir,
+		})
+		if err != nil {
+			FatalErrorRespectJSON("%v", err)
+		}
+	}
+
+	if statusFilter != "" {
+		tree = filterTreeByStatus(tree, types.Status(statusFilter))
+	}
+
+	if formatStr == "mermaid" {
+		outputMermaidTree(tree, args[0])
+		return
+	}
+
+	if jsonOutput {
+		if tree == nil {
+			tree = []*types.TreeNode{}
+		}
+		outputJSON(tree)
+		return
+	}
+
+	if len(tree) == 0 {
+		switch direction {
+		case "up":
+			fmt.Printf("\n%s has no dependents\n", fullID)
+		case "both":
+			fmt.Printf("\n%s has no dependencies or dependents\n", fullID)
+		default:
+			fmt.Printf("\n%s has no dependencies\n", fullID)
+		}
+		return
+	}
+
+	switch direction {
+	case "up":
+		fmt.Printf("\n%s Dependent tree for %s:\n\n", ui.RenderAccent("🌲"), fullID)
+	case "both":
+		fmt.Printf("\n%s Full dependency graph for %s:\n\n", ui.RenderAccent("🌲"), fullID)
+	default:
+		fmt.Printf("\n%s Dependency tree for %s:\n\n", ui.RenderAccent("🌲"), fullID)
+	}
+
+	renderTree(tree, maxDepth, direction)
+	fmt.Println()
+}
+
+func runDepCyclesProxiedServer(_ *cobra.Command, ctx context.Context) {
+	uw := openDepProxiedUOW(ctx)
+	defer uw.Close(ctx)
+
+	cycles, err := uw.DependencyUseCase().DetectCycles(ctx)
+	if err != nil {
+		FatalErrorRespectJSON("%v", err)
+	}
+
+	if jsonOutput {
+		if cycles == nil {
+			cycles = [][]*types.Issue{}
+		}
+		outputJSON(cycles)
+		return
+	}
+
+	if len(cycles) == 0 {
+		fmt.Printf("\n%s No dependency cycles detected\n\n", ui.RenderPass("✓"))
+		return
+	}
+
+	fmt.Printf("\n%s Found %d dependency cycles:\n\n", ui.RenderFail("⚠"), len(cycles))
+	for i, cycle := range cycles {
+		fmt.Printf("%d. Cycle involving:\n", i+1)
+		for _, issue := range cycle {
+			fmt.Printf("   - %s: %s\n", issue.ID, issue.Title)
+		}
+		fmt.Println()
+	}
+}

--- a/cmd/bd/dep_proxied_server.go
+++ b/cmd/bd/dep_proxied_server.go
@@ -256,7 +256,7 @@ func runDepAddBulkProxied(cmd *cobra.Command, ctx context.Context, file, default
 	fmt.Printf("%s Added %d dependencies\n", ui.RenderPass("✓"), len(deps))
 }
 
-func runDepRemoveProxiedServer(cmd *cobra.Command, ctx context.Context, args []string) {
+func runDepRemoveProxiedServer(_ *cobra.Command, ctx context.Context, args []string) {
 	fromID := args[0]
 	toID := args[1]
 	if strings.HasPrefix(toID, "external:") {

--- a/internal/storage/domain/db/dependency.go
+++ b/internal/storage/domain/db/dependency.go
@@ -766,3 +766,61 @@ func (r *dependencySQLRepositoryImpl) DetectCycles(ctx context.Context) ([][]*ty
 	}
 	return out, nil
 }
+
+func (r *dependencySQLRepositoryImpl) GetTree(ctx context.Context, rootID string, opts domain.DepTreeOpts) ([]*types.TreeNode, error) {
+	if rootID == "" {
+		return nil, errors.New("db: DependencySQLRepository.GetTree: rootID must not be empty")
+	}
+	if opts.Direction == domain.DepDirectionBoth {
+		return nil, errors.New("db: DependencySQLRepository.GetTree: DepDirectionBoth not supported; callers must invoke once per direction and merge")
+	}
+	maxDepth := opts.MaxDepth
+	if maxDepth <= 0 {
+		maxDepth = 50
+	}
+	reverse := opts.Direction == domain.DepDirectionIn
+	out, err := issueops.GetDependencyTreeInTx(ctx, r.runner, rootID, maxDepth, opts.ShowAllPaths, reverse)
+	if err != nil {
+		return nil, fmt.Errorf("db: DependencySQLRepository.GetTree: %w", err)
+	}
+	return out, nil
+}
+
+func (r *dependencySQLRepositoryImpl) CycleThroughEdges(ctx context.Context, edges [][2]string) (string, error) {
+	if len(edges) == 0 {
+		return "", nil
+	}
+	graph := make(map[string][]string)
+	if err := issueops.AppendBlockingGraphInTx(ctx, r.runner, []string{"dependencies"}, graph); err != nil {
+		return "", fmt.Errorf("db: DependencySQLRepository.CycleThroughEdges: %w", err)
+	}
+	if err := issueops.AppendBlockingGraphInTx(ctx, r.runner, []string{"wisp_dependencies"}, graph); err != nil && !dberrors.IsTableNotExist(err) {
+		return "", fmt.Errorf("db: DependencySQLRepository.CycleThroughEdges (wisps): %w", err)
+	}
+	return issueops.CycleThroughEdgesInGraph(graph, edges), nil
+}
+
+func (r *dependencySQLRepositoryImpl) GetDependencyRecordsForIssues(ctx context.Context, issueIDs []string) (map[string][]*types.Dependency, error) {
+	if len(issueIDs) == 0 {
+		return map[string][]*types.Dependency{}, nil
+	}
+	out, err := issueops.GetDependencyRecordsForIssuesInTx(ctx, r.runner, issueIDs)
+	if err != nil {
+		return nil, fmt.Errorf("db: DependencySQLRepository.GetDependencyRecordsForIssues: %w", err)
+	}
+	return out, nil
+}
+
+func (r *dependencySQLRepositoryImpl) GetWispDependencyRecordsForIDs(ctx context.Context, wispIDs []string) (map[string][]*types.Dependency, error) {
+	if len(wispIDs) == 0 {
+		return map[string][]*types.Dependency{}, nil
+	}
+	out, err := issueops.GetDependencyRecordsForIssuesFromTableInTx(ctx, r.runner, "wisp_dependencies", wispIDs)
+	if err != nil {
+		if dberrors.IsTableNotExist(err) {
+			return map[string][]*types.Dependency{}, nil
+		}
+		return nil, fmt.Errorf("db: DependencySQLRepository.GetWispDependencyRecordsForIDs: %w", err)
+	}
+	return out, nil
+}

--- a/internal/storage/domain/db/dependency_extras_test.go
+++ b/internal/storage/domain/db/dependency_extras_test.go
@@ -1,0 +1,376 @@
+package db
+
+import (
+	"github.com/steveyegge/beads/internal/storage/domain"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+func (s *testSuite) TestDependencySQLRepository_Extras() {
+	s.Run("GetTree", func() {
+		s.Run("EmptyRootIDReturnsError", s.depTreeEmptyRoot)
+		s.Run("BothDirectionRejected", s.depTreeBothRejected)
+		s.Run("SingleNodeNoDeps", s.depTreeSingleNode)
+		s.Run("DirectionOutTraversesDependencies", s.depTreeDirectionOut)
+		s.Run("DirectionInTraversesDependents", s.depTreeDirectionIn)
+		s.Run("MaxDepthRespected", s.depTreeMaxDepth)
+		s.Run("ZeroMaxDepthFallsBackToDefault", s.depTreeMaxDepthDefault)
+		s.Run("CycleVisitedOnce", s.depTreeCycleVisitedOnce)
+	})
+	s.Run("CycleThroughEdges", func() {
+		s.Run("EmptyEdgesReturnsEmpty", s.depCTEEmpty)
+		s.Run("NoCycleReturnsEmpty", s.depCTENoCycle)
+		s.Run("CycleThroughNewEdgeDetected", s.depCTEDetected)
+		s.Run("NonBlockingTypesIgnored", s.depCTENonBlockingIgnored)
+		s.Run("CycleAcrossWispTable", s.depCTEAcrossWisp)
+		s.Run("UnrelatedExistingCycleIgnored", s.depCTEUnrelatedCycleIgnored)
+	})
+	s.Run("GetDependencyRecordsForIssues", func() {
+		s.Run("EmptyReturnsEmptyMap", s.depRecsEmpty)
+		s.Run("ReturnsRecordsForIssues", s.depRecsBasic)
+		s.Run("WispIDsRoutedToWispTable", s.depRecsWispRouted)
+		s.Run("MissingIDAbsentFromMap", s.depRecsMissingID)
+	})
+	s.Run("GetWispDependencyRecordsForIDs", func() {
+		s.Run("EmptyReturnsEmptyMap", s.depWispRecsEmpty)
+		s.Run("ReturnsOnlyFromWispTable", s.depWispRecsForcedTable)
+		s.Run("PermSourceWithSameIDIgnored", s.depWispRecsIgnoresPerm)
+	})
+}
+
+// ---- GetTree ----
+
+func (s *testSuite) depTreeEmptyRoot() {
+	_, err := s.depRepo().GetTree(s.Ctx(), "", domain.DepTreeOpts{MaxDepth: 5})
+	s.Require().Error(err)
+}
+
+func (s *testSuite) depTreeBothRejected() {
+	s.seedIssueRow("bd-tree-both")
+	_, err := s.depRepo().GetTree(s.Ctx(), "bd-tree-both", domain.DepTreeOpts{
+		MaxDepth:  5,
+		Direction: domain.DepDirectionBoth,
+	})
+	s.Require().Error(err, "Both direction must be rejected; callers merge two calls")
+}
+
+func (s *testSuite) depTreeSingleNode() {
+	s.seedIssueRow("bd-tree-solo")
+	out, err := s.depRepo().GetTree(s.Ctx(), "bd-tree-solo", domain.DepTreeOpts{
+		MaxDepth:  5,
+		Direction: domain.DepDirectionOut,
+	})
+	s.Require().NoError(err)
+	s.Require().Len(out, 1, "no edges → just the root")
+	s.Equal("bd-tree-solo", out[0].ID)
+	s.Equal(0, out[0].Depth)
+	s.Empty(out[0].ParentID)
+}
+
+func (s *testSuite) depTreeDirectionOut() {
+	// Chain: a -> b -> c (a depends on b depends on c)
+	s.seedIssueRow("bd-tree-out-a")
+	s.seedIssueRow("bd-tree-out-b")
+	s.seedIssueRow("bd-tree-out-c")
+	r := s.depRepo()
+	s.Require().NoError(r.Insert(s.Ctx(), newDep("bd-tree-out-a", "bd-tree-out-b", types.DepBlocks), "tester", domain.DepInsertOpts{}))
+	s.Require().NoError(r.Insert(s.Ctx(), newDep("bd-tree-out-b", "bd-tree-out-c", types.DepBlocks), "tester", domain.DepInsertOpts{}))
+
+	out, err := r.GetTree(s.Ctx(), "bd-tree-out-a", domain.DepTreeOpts{
+		MaxDepth:  5,
+		Direction: domain.DepDirectionOut,
+	})
+	s.Require().NoError(err)
+
+	byID := map[string]*types.TreeNode{}
+	for _, n := range out {
+		byID[n.ID] = n
+	}
+	s.Require().Contains(byID, "bd-tree-out-a")
+	s.Require().Contains(byID, "bd-tree-out-b")
+	s.Require().Contains(byID, "bd-tree-out-c")
+	s.Equal(0, byID["bd-tree-out-a"].Depth)
+	s.Equal(1, byID["bd-tree-out-b"].Depth)
+	s.Equal(2, byID["bd-tree-out-c"].Depth)
+	s.Equal("bd-tree-out-a", byID["bd-tree-out-b"].ParentID)
+	s.Equal("bd-tree-out-b", byID["bd-tree-out-c"].ParentID)
+}
+
+func (s *testSuite) depTreeDirectionIn() {
+	// a -> root, b -> root: root's dependents are a and b.
+	s.seedIssueRow("bd-tree-in-root")
+	s.seedIssueRow("bd-tree-in-a")
+	s.seedIssueRow("bd-tree-in-b")
+	r := s.depRepo()
+	s.Require().NoError(r.Insert(s.Ctx(), newDep("bd-tree-in-a", "bd-tree-in-root", types.DepBlocks), "tester", domain.DepInsertOpts{}))
+	s.Require().NoError(r.Insert(s.Ctx(), newDep("bd-tree-in-b", "bd-tree-in-root", types.DepBlocks), "tester", domain.DepInsertOpts{}))
+
+	out, err := r.GetTree(s.Ctx(), "bd-tree-in-root", domain.DepTreeOpts{
+		MaxDepth:  5,
+		Direction: domain.DepDirectionIn,
+	})
+	s.Require().NoError(err)
+	ids := map[string]bool{}
+	for _, n := range out {
+		ids[n.ID] = true
+	}
+	s.Contains(ids, "bd-tree-in-root")
+	s.Contains(ids, "bd-tree-in-a")
+	s.Contains(ids, "bd-tree-in-b")
+}
+
+func (s *testSuite) depTreeMaxDepth() {
+	// a -> b -> c. MaxDepth=1 must stop at depth 0; c (depth 2) absent.
+	// (Per buildDependencyTreeInTx, depth >= maxDepth halts traversal.)
+	s.seedIssueRow("bd-tree-md-a")
+	s.seedIssueRow("bd-tree-md-b")
+	s.seedIssueRow("bd-tree-md-c")
+	r := s.depRepo()
+	s.Require().NoError(r.Insert(s.Ctx(), newDep("bd-tree-md-a", "bd-tree-md-b", types.DepBlocks), "tester", domain.DepInsertOpts{}))
+	s.Require().NoError(r.Insert(s.Ctx(), newDep("bd-tree-md-b", "bd-tree-md-c", types.DepBlocks), "tester", domain.DepInsertOpts{}))
+
+	out, err := r.GetTree(s.Ctx(), "bd-tree-md-a", domain.DepTreeOpts{
+		MaxDepth:  1,
+		Direction: domain.DepDirectionOut,
+	})
+	s.Require().NoError(err)
+	ids := map[string]bool{}
+	for _, n := range out {
+		ids[n.ID] = true
+	}
+	s.True(ids["bd-tree-md-a"])
+	s.False(ids["bd-tree-md-c"], "depth-2 node must be pruned by MaxDepth=1")
+}
+
+func (s *testSuite) depTreeMaxDepthDefault() {
+	// MaxDepth=0 should fall back to the repo's default and traverse normally.
+	s.seedIssueRow("bd-tree-mdd-a")
+	s.seedIssueRow("bd-tree-mdd-b")
+	r := s.depRepo()
+	s.Require().NoError(r.Insert(s.Ctx(), newDep("bd-tree-mdd-a", "bd-tree-mdd-b", types.DepBlocks), "tester", domain.DepInsertOpts{}))
+	out, err := r.GetTree(s.Ctx(), "bd-tree-mdd-a", domain.DepTreeOpts{Direction: domain.DepDirectionOut})
+	s.Require().NoError(err)
+	ids := map[string]bool{}
+	for _, n := range out {
+		ids[n.ID] = true
+	}
+	s.True(ids["bd-tree-mdd-b"], "MaxDepth=0 must default, not prune everything below the root")
+}
+
+func (s *testSuite) depTreeCycleVisitedOnce() {
+	// a -> b, b -> a. Traversal must terminate; both nodes appear at most twice
+	// (root + revisit hint), and the traversal must not infinite-loop.
+	s.seedIssueRow("bd-tree-cyc-a")
+	s.seedIssueRow("bd-tree-cyc-b")
+	r := s.depRepo()
+	s.Require().NoError(r.Insert(s.Ctx(), newDep("bd-tree-cyc-a", "bd-tree-cyc-b", types.DepBlocks), "tester", domain.DepInsertOpts{}))
+	s.Require().NoError(r.Insert(s.Ctx(), newDep("bd-tree-cyc-b", "bd-tree-cyc-a", types.DepBlocks), "tester", domain.DepInsertOpts{}))
+
+	out, err := r.GetTree(s.Ctx(), "bd-tree-cyc-a", domain.DepTreeOpts{
+		MaxDepth:  10,
+		Direction: domain.DepDirectionOut,
+	})
+	s.Require().NoError(err)
+	s.NotEmpty(out)
+}
+
+// ---- CycleThroughEdges ----
+
+func (s *testSuite) depCTEEmpty() {
+	out, err := s.depRepo().CycleThroughEdges(s.Ctx(), nil)
+	s.Require().NoError(err)
+	s.Empty(out)
+}
+
+func (s *testSuite) depCTENoCycle() {
+	s.seedIssueRow("bd-cte-nc-a")
+	s.seedIssueRow("bd-cte-nc-b")
+	r := s.depRepo()
+	s.Require().NoError(r.Insert(s.Ctx(), newDep("bd-cte-nc-a", "bd-cte-nc-b", types.DepBlocks), "tester", domain.DepInsertOpts{}))
+
+	out, err := r.CycleThroughEdges(s.Ctx(), [][2]string{{"bd-cte-nc-a", "bd-cte-nc-b"}})
+	s.Require().NoError(err)
+	s.Empty(out, "non-cyclic edge must return empty cycle path")
+}
+
+func (s *testSuite) depCTEDetected() {
+	// Setup: a -> b already in graph. Caller is about to add b -> a.
+	// The graph already contains the new edge (callers insert before checking),
+	// so cycle search starting at a (the source) finds it.
+	s.seedIssueRow("bd-cte-det-a")
+	s.seedIssueRow("bd-cte-det-b")
+	r := s.depRepo()
+	s.Require().NoError(r.Insert(s.Ctx(), newDep("bd-cte-det-a", "bd-cte-det-b", types.DepBlocks), "tester", domain.DepInsertOpts{}))
+	s.Require().NoError(r.Insert(s.Ctx(), newDep("bd-cte-det-b", "bd-cte-det-a", types.DepBlocks), "tester", domain.DepInsertOpts{}))
+
+	out, err := r.CycleThroughEdges(s.Ctx(), [][2]string{{"bd-cte-det-b", "bd-cte-det-a"}})
+	s.Require().NoError(err)
+	s.NotEmpty(out, "cycle through the new edge must be reported")
+	s.Contains(out, "bd-cte-det-a")
+	s.Contains(out, "bd-cte-det-b")
+}
+
+func (s *testSuite) depCTENonBlockingIgnored() {
+	// related-only edges must not form a cycle even when the topology would
+	// close one under blocking semantics.
+	s.seedIssueRow("bd-cte-nb-a")
+	s.seedIssueRow("bd-cte-nb-b")
+	r := s.depRepo()
+	s.Require().NoError(r.Insert(s.Ctx(), newDep("bd-cte-nb-a", "bd-cte-nb-b", types.DepRelated), "tester", domain.DepInsertOpts{}))
+	s.Require().NoError(r.Insert(s.Ctx(), newDep("bd-cte-nb-b", "bd-cte-nb-a", types.DepRelated), "tester", domain.DepInsertOpts{}))
+
+	out, err := r.CycleThroughEdges(s.Ctx(), [][2]string{{"bd-cte-nb-b", "bd-cte-nb-a"}})
+	s.Require().NoError(err)
+	s.Empty(out, "related-only edges form no blocking cycle")
+}
+
+func (s *testSuite) depCTEAcrossWisp() {
+	// Wisp source w blocks issue a (in wisp_dependencies); issue a blocks wisp
+	// w via raw insert into wisp_dependencies as source=w-source-of-truth?
+	// To keep this simple, exercise the table union: a -> b in perm and
+	// b -> a in wisp_dependencies. The graph union must close the cycle.
+	s.seedIssueRow("bd-cte-w-a")
+	s.seedWispRow("bd-cte-w-b")
+	r := s.depRepo()
+	// Perm edge: bd-cte-w-a -> bd-cte-w-b. Target is a wisp, so use raw SQL
+	// (Insert writes depends_on_issue_id only).
+	_, err := s.Runner().ExecContext(s.Ctx(), `
+		INSERT INTO dependencies (id, issue_id, depends_on_wisp_id, type, created_at, created_by, metadata)
+		VALUES (UUID(), ?, ?, 'blocks', NOW(), 'tester', '{}')
+	`, "bd-cte-w-a", "bd-cte-w-b")
+	s.Require().NoError(err)
+	// Wisp edge: bd-cte-w-b (wisp) -> bd-cte-w-a (perm) in wisp_dependencies.
+	s.Require().NoError(r.Insert(s.Ctx(),
+		newDep("bd-cte-w-b", "bd-cte-w-a", types.DepBlocks), "tester",
+		domain.DepInsertOpts{UseWispsTable: true}))
+
+	out, err := r.CycleThroughEdges(s.Ctx(), [][2]string{{"bd-cte-w-b", "bd-cte-w-a"}})
+	s.Require().NoError(err)
+	s.NotEmpty(out, "cycle spanning dependencies + wisp_dependencies must be detected")
+}
+
+func (s *testSuite) depCTEUnrelatedCycleIgnored() {
+	// Pre-existing cycle x -> y -> x exists. A separate, acyclic new edge
+	// p -> q must not be flagged just because *some* cycle exists (bd-578h9.9).
+	s.seedIssueRow("bd-cte-uc-x")
+	s.seedIssueRow("bd-cte-uc-y")
+	s.seedIssueRow("bd-cte-uc-p")
+	s.seedIssueRow("bd-cte-uc-q")
+	r := s.depRepo()
+	s.Require().NoError(r.Insert(s.Ctx(), newDep("bd-cte-uc-x", "bd-cte-uc-y", types.DepBlocks), "tester", domain.DepInsertOpts{}))
+	// Insert y -> x via raw SQL to bypass cycle check; we want the graph in a
+	// cyclic state without going through the use case validator.
+	_, err := s.Runner().ExecContext(s.Ctx(), `
+		INSERT INTO dependencies (id, issue_id, depends_on_issue_id, type, created_at, created_by, metadata)
+		VALUES (UUID(), ?, ?, 'blocks', NOW(), 'tester', '{}')
+	`, "bd-cte-uc-y", "bd-cte-uc-x")
+	s.Require().NoError(err)
+	// p -> q: acyclic new edge.
+	s.Require().NoError(r.Insert(s.Ctx(), newDep("bd-cte-uc-p", "bd-cte-uc-q", types.DepBlocks), "tester", domain.DepInsertOpts{}))
+
+	out, err := r.CycleThroughEdges(s.Ctx(), [][2]string{{"bd-cte-uc-p", "bd-cte-uc-q"}})
+	s.Require().NoError(err)
+	s.Empty(out, "pre-existing cycle not touching the new edge must not block it")
+}
+
+// ---- GetDependencyRecordsForIssues ----
+
+func (s *testSuite) depRecsEmpty() {
+	out, err := s.depRepo().GetDependencyRecordsForIssues(s.Ctx(), nil)
+	s.Require().NoError(err)
+	s.NotNil(out)
+	s.Empty(out)
+}
+
+func (s *testSuite) depRecsBasic() {
+	s.seedIssueRow("bd-recs-src")
+	s.seedIssueRow("bd-recs-a")
+	s.seedIssueRow("bd-recs-b")
+	r := s.depRepo()
+	s.Require().NoError(r.Insert(s.Ctx(), newDep("bd-recs-src", "bd-recs-a", types.DepBlocks), "tester", domain.DepInsertOpts{}))
+	s.Require().NoError(r.Insert(s.Ctx(), newDep("bd-recs-src", "bd-recs-b", types.DepRelated), "tester", domain.DepInsertOpts{}))
+
+	out, err := r.GetDependencyRecordsForIssues(s.Ctx(), []string{"bd-recs-src"})
+	s.Require().NoError(err)
+	s.Require().Len(out["bd-recs-src"], 2)
+	targets := map[string]types.DependencyType{}
+	for _, dep := range out["bd-recs-src"] {
+		targets[dep.DependsOnID] = dep.Type
+	}
+	s.Equal(types.DepBlocks, targets["bd-recs-a"])
+	s.Equal(types.DepRelated, targets["bd-recs-b"])
+}
+
+func (s *testSuite) depRecsWispRouted() {
+	// Wisp source: its deps live in wisp_dependencies and must still come back
+	// when queried via the partitioning method.
+	s.seedWispRow("bd-recs-wsrc")
+	s.seedIssueRow("bd-recs-wtgt")
+	r := s.depRepo()
+	s.Require().NoError(r.Insert(s.Ctx(),
+		newDep("bd-recs-wsrc", "bd-recs-wtgt", types.DepBlocks), "tester",
+		domain.DepInsertOpts{UseWispsTable: true}))
+
+	out, err := r.GetDependencyRecordsForIssues(s.Ctx(), []string{"bd-recs-wsrc"})
+	s.Require().NoError(err)
+	s.Require().Len(out["bd-recs-wsrc"], 1, "wisp ID must route to wisp_dependencies and be returned")
+	s.Equal("bd-recs-wtgt", out["bd-recs-wsrc"][0].DependsOnID)
+}
+
+func (s *testSuite) depRecsMissingID() {
+	s.seedIssueRow("bd-recs-mi-real")
+	s.seedIssueRow("bd-recs-mi-target")
+	r := s.depRepo()
+	s.Require().NoError(r.Insert(s.Ctx(),
+		newDep("bd-recs-mi-real", "bd-recs-mi-target", types.DepBlocks), "tester",
+		domain.DepInsertOpts{}))
+
+	out, err := r.GetDependencyRecordsForIssues(s.Ctx(), []string{"bd-recs-mi-real", "bd-recs-mi-missing"})
+	s.Require().NoError(err)
+	s.NotEmpty(out["bd-recs-mi-real"])
+	_, present := out["bd-recs-mi-missing"]
+	s.False(present, "non-existent IDs must not appear in the result map")
+}
+
+// ---- GetWispDependencyRecordsForIDs ----
+
+func (s *testSuite) depWispRecsEmpty() {
+	out, err := s.depRepo().GetWispDependencyRecordsForIDs(s.Ctx(), nil)
+	s.Require().NoError(err)
+	s.NotNil(out)
+	s.Empty(out)
+}
+
+func (s *testSuite) depWispRecsForcedTable() {
+	s.seedWispRow("bd-wrecs-src")
+	s.seedIssueRow("bd-wrecs-a")
+	s.seedIssueRow("bd-wrecs-b")
+	r := s.depRepo()
+	s.Require().NoError(r.Insert(s.Ctx(),
+		newDep("bd-wrecs-src", "bd-wrecs-a", types.DepBlocks), "tester",
+		domain.DepInsertOpts{UseWispsTable: true}))
+	s.Require().NoError(r.Insert(s.Ctx(),
+		newDep("bd-wrecs-src", "bd-wrecs-b", types.DepRelated), "tester",
+		domain.DepInsertOpts{UseWispsTable: true}))
+
+	out, err := r.GetWispDependencyRecordsForIDs(s.Ctx(), []string{"bd-wrecs-src"})
+	s.Require().NoError(err)
+	s.Require().Len(out["bd-wrecs-src"], 2)
+}
+
+func (s *testSuite) depWispRecsIgnoresPerm() {
+	// Same ID has a row in dependencies (perm) — the wisp-only fetch must
+	// ignore it. Use raw SQL because Insert(UseWispsTable=false) on a wisp ID
+	// would FK-fail.
+	s.seedIssueRow("bd-wrecs-ig-perm-src")
+	s.seedIssueRow("bd-wrecs-ig-tgt")
+	r := s.depRepo()
+	s.Require().NoError(r.Insert(s.Ctx(),
+		newDep("bd-wrecs-ig-perm-src", "bd-wrecs-ig-tgt", types.DepBlocks), "tester",
+		domain.DepInsertOpts{}))
+
+	// Forced wisp-only fetch using the perm ID must return nothing — there's
+	// no wisp_dependencies row for it even though dependencies has one.
+	out, err := r.GetWispDependencyRecordsForIDs(s.Ctx(), []string{"bd-wrecs-ig-perm-src"})
+	s.Require().NoError(err)
+	s.Empty(out["bd-wrecs-ig-perm-src"], "forced wisp-table fetch must ignore perm rows")
+}

--- a/internal/storage/domain/db/dependency_usecase_extras_test.go
+++ b/internal/storage/domain/db/dependency_usecase_extras_test.go
@@ -1,0 +1,255 @@
+package db
+
+import (
+	"github.com/steveyegge/beads/internal/storage/domain"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+func (s *testSuite) TestDependencyUseCase_Extras() {
+	s.Run("GetDependencyTree", func() {
+		s.Run("EmptyRootIDReturnsError", s.ducTreeEmptyRoot)
+		s.Run("DelegatesToRepo", s.ducTreeDelegates)
+	})
+	s.Run("GetIssueDependencyRecords", func() {
+		s.Run("EmptyReturnsEmptyMapNoRepoCall", s.ducGetIssueRecsEmpty)
+		s.Run("DelegatesToRepo", s.ducGetIssueRecsDelegates)
+	})
+	s.Run("GetWispDependencyRecords", func() {
+		s.Run("EmptyReturnsEmptyMap", s.ducGetWispRecsEmpty)
+		s.Run("DelegatesToRepoWispTable", s.ducGetWispRecsDelegates)
+	})
+	s.Run("AddDependencies", func() {
+		s.Run("EmptySliceReturnsEmptyResult", s.ducAddBulkEmpty)
+		s.Run("NilDepReturnsError", s.ducAddBulkNilDep)
+		s.Run("EmptyIDsReturnError", s.ducAddBulkEmptyIDs)
+		s.Run("InsertsEdgesAndReturnsAdded", s.ducAddBulkInserts)
+		s.Run("PerEdgeCycleCheckBlocksCycleCreation", s.ducAddBulkPerEdgeCycle)
+		s.Run("SkipPerEdgeStillRunsFinalCheck", s.ducAddBulkFinalCycleCheck)
+		s.Run("SkipPerEdgeAcceptsAcyclicBulk", s.ducAddBulkSkipPerEdgeAcyclic)
+		s.Run("NonBlockingEdgesSkipCycleChecks", s.ducAddBulkNonBlockingNoCheck)
+	})
+	s.Run("AddWispDependencies", func() {
+		s.Run("RoutesToWispDepsTable", s.ducAddBulkWispRoutes)
+	})
+}
+
+// ---- GetDependencyTree ----
+
+func (s *testSuite) ducTreeEmptyRoot() {
+	_, err := s.depUseCase().GetDependencyTree(s.Ctx(), "", domain.DepTreeOpts{
+		MaxDepth:  5,
+		Direction: domain.DepDirectionOut,
+	})
+	s.Require().Error(err)
+}
+
+func (s *testSuite) ducTreeDelegates() {
+	// Verify the UC passes opts through and returns repo output: build a chain
+	// a -> b and assert both nodes come back at the correct depths.
+	s.seedIssueRow("bd-duc-tree-a")
+	s.seedIssueRow("bd-duc-tree-b")
+	depRepo := NewDependencySQLRepository(s.Runner())
+	s.Require().NoError(depRepo.Insert(s.Ctx(),
+		newDep("bd-duc-tree-a", "bd-duc-tree-b", types.DepBlocks), "tester", domain.DepInsertOpts{}))
+
+	out, err := s.depUseCase().GetDependencyTree(s.Ctx(), "bd-duc-tree-a", domain.DepTreeOpts{
+		MaxDepth:  5,
+		Direction: domain.DepDirectionOut,
+	})
+	s.Require().NoError(err)
+	byID := map[string]*types.TreeNode{}
+	for _, n := range out {
+		byID[n.ID] = n
+	}
+	s.Require().Contains(byID, "bd-duc-tree-a")
+	s.Require().Contains(byID, "bd-duc-tree-b")
+	s.Equal(0, byID["bd-duc-tree-a"].Depth)
+	s.Equal(1, byID["bd-duc-tree-b"].Depth)
+}
+
+// ---- GetIssueDependencyRecords ----
+
+func (s *testSuite) ducGetIssueRecsEmpty() {
+	out, err := s.depUseCase().GetIssueDependencyRecords(s.Ctx(), nil)
+	s.Require().NoError(err)
+	s.NotNil(out)
+	s.Empty(out)
+}
+
+func (s *testSuite) ducGetIssueRecsDelegates() {
+	s.seedIssueRow("bd-duc-girecs-src")
+	s.seedIssueRow("bd-duc-girecs-tgt")
+	depRepo := NewDependencySQLRepository(s.Runner())
+	s.Require().NoError(depRepo.Insert(s.Ctx(),
+		newDep("bd-duc-girecs-src", "bd-duc-girecs-tgt", types.DepBlocks), "tester", domain.DepInsertOpts{}))
+
+	out, err := s.depUseCase().GetIssueDependencyRecords(s.Ctx(), []string{"bd-duc-girecs-src"})
+	s.Require().NoError(err)
+	s.Require().Len(out["bd-duc-girecs-src"], 1)
+	s.Equal("bd-duc-girecs-tgt", out["bd-duc-girecs-src"][0].DependsOnID)
+}
+
+// ---- GetWispDependencyRecords ----
+
+func (s *testSuite) ducGetWispRecsEmpty() {
+	out, err := s.depUseCase().GetWispDependencyRecords(s.Ctx(), nil)
+	s.Require().NoError(err)
+	s.NotNil(out)
+	s.Empty(out)
+}
+
+func (s *testSuite) ducGetWispRecsDelegates() {
+	s.seedWispRow("bd-duc-gwrecs-src")
+	s.seedIssueRow("bd-duc-gwrecs-tgt")
+	depRepo := NewDependencySQLRepository(s.Runner())
+	s.Require().NoError(depRepo.Insert(s.Ctx(),
+		newDep("bd-duc-gwrecs-src", "bd-duc-gwrecs-tgt", types.DepBlocks), "tester",
+		domain.DepInsertOpts{UseWispsTable: true}))
+
+	out, err := s.depUseCase().GetWispDependencyRecords(s.Ctx(), []string{"bd-duc-gwrecs-src"})
+	s.Require().NoError(err)
+	s.Require().Len(out["bd-duc-gwrecs-src"], 1)
+	s.Equal("bd-duc-gwrecs-tgt", out["bd-duc-gwrecs-src"][0].DependsOnID)
+}
+
+// ---- AddDependencies ----
+
+func (s *testSuite) ducAddBulkEmpty() {
+	res, err := s.depUseCase().AddDependencies(s.Ctx(), nil, "tester", domain.BulkAddDepsOpts{})
+	s.Require().NoError(err)
+	s.NotNil(res.Added)
+	s.Empty(res.Added)
+}
+
+func (s *testSuite) ducAddBulkNilDep() {
+	deps := []*types.Dependency{nil}
+	_, err := s.depUseCase().AddDependencies(s.Ctx(), deps, "tester", domain.BulkAddDepsOpts{})
+	s.Require().Error(err)
+}
+
+func (s *testSuite) ducAddBulkEmptyIDs() {
+	uc := s.depUseCase()
+	_, err := uc.AddDependencies(s.Ctx(),
+		[]*types.Dependency{newDep("", "bd-x", types.DepBlocks)}, "tester", domain.BulkAddDepsOpts{})
+	s.Require().Error(err)
+	_, err = uc.AddDependencies(s.Ctx(),
+		[]*types.Dependency{newDep("bd-x", "", types.DepBlocks)}, "tester", domain.BulkAddDepsOpts{})
+	s.Require().Error(err)
+}
+
+func (s *testSuite) ducAddBulkInserts() {
+	s.seedIssueRow("bd-duc-bulk-a")
+	s.seedIssueRow("bd-duc-bulk-b")
+	s.seedIssueRow("bd-duc-bulk-c")
+
+	deps := []*types.Dependency{
+		newDep("bd-duc-bulk-a", "bd-duc-bulk-b", types.DepBlocks),
+		newDep("bd-duc-bulk-a", "bd-duc-bulk-c", types.DepBlocks),
+	}
+	res, err := s.depUseCase().AddDependencies(s.Ctx(), deps, "tester", domain.BulkAddDepsOpts{})
+	s.Require().NoError(err)
+	s.Require().Len(res.Added, 2)
+
+	// Verify both rows landed.
+	out, err := s.depUseCase().GetIssueDependencyRecords(s.Ctx(), []string{"bd-duc-bulk-a"})
+	s.Require().NoError(err)
+	s.Require().Len(out["bd-duc-bulk-a"], 2)
+}
+
+func (s *testSuite) ducAddBulkPerEdgeCycle() {
+	// Existing a -> b. Trying to add b -> a must fail the per-edge cycle check
+	// and NOT insert the new edge.
+	s.seedIssueRow("bd-duc-pec-a")
+	s.seedIssueRow("bd-duc-pec-b")
+	depRepo := NewDependencySQLRepository(s.Runner())
+	s.Require().NoError(depRepo.Insert(s.Ctx(),
+		newDep("bd-duc-pec-a", "bd-duc-pec-b", types.DepBlocks), "tester", domain.DepInsertOpts{}))
+
+	_, err := s.depUseCase().AddDependencies(s.Ctx(),
+		[]*types.Dependency{newDep("bd-duc-pec-b", "bd-duc-pec-a", types.DepBlocks)},
+		"tester", domain.BulkAddDepsOpts{})
+	s.Require().Error(err, "per-edge cycle check must block the new edge")
+
+	var count int
+	s.Require().NoError(s.Runner().QueryRowContext(s.Ctx(),
+		"SELECT COUNT(*) FROM dependencies WHERE issue_id = ? AND depends_on_issue_id = ?",
+		"bd-duc-pec-b", "bd-duc-pec-a").Scan(&count))
+	s.Equal(0, count, "cycle-rejected edge must not have been inserted")
+}
+
+func (s *testSuite) ducAddBulkFinalCycleCheck() {
+	// With SkipPerEdgeCycleCheck, the per-edge guard is bypassed but the final
+	// whole-graph CycleThroughEdges call still fails the operation. The CLI
+	// runs this inside a UOW so rollback happens at the transaction boundary;
+	// here we just assert that the error is returned. (Inserted rows from the
+	// pre-failure loop iterations are NOT rolled back at the UC level — the
+	// UC's contract is "return error so the surrounding UOW rolls back".)
+	s.seedIssueRow("bd-duc-fcc-a")
+	s.seedIssueRow("bd-duc-fcc-b")
+	depRepo := NewDependencySQLRepository(s.Runner())
+	s.Require().NoError(depRepo.Insert(s.Ctx(),
+		newDep("bd-duc-fcc-a", "bd-duc-fcc-b", types.DepBlocks), "tester", domain.DepInsertOpts{}))
+
+	_, err := s.depUseCase().AddDependencies(s.Ctx(),
+		[]*types.Dependency{newDep("bd-duc-fcc-b", "bd-duc-fcc-a", types.DepBlocks)},
+		"tester", domain.BulkAddDepsOpts{SkipPerEdgeCycleCheck: true})
+	s.Require().Error(err, "final whole-graph cycle check must fail the bulk add")
+	s.Contains(err.Error(), "cycle")
+}
+
+func (s *testSuite) ducAddBulkSkipPerEdgeAcyclic() {
+	// SkipPerEdgeCycleCheck + acyclic edges → success.
+	s.seedIssueRow("bd-duc-spa-a")
+	s.seedIssueRow("bd-duc-spa-b")
+	s.seedIssueRow("bd-duc-spa-c")
+
+	deps := []*types.Dependency{
+		newDep("bd-duc-spa-a", "bd-duc-spa-b", types.DepBlocks),
+		newDep("bd-duc-spa-b", "bd-duc-spa-c", types.DepBlocks),
+	}
+	res, err := s.depUseCase().AddDependencies(s.Ctx(), deps, "tester",
+		domain.BulkAddDepsOpts{SkipPerEdgeCycleCheck: true})
+	s.Require().NoError(err)
+	s.Require().Len(res.Added, 2)
+}
+
+func (s *testSuite) ducAddBulkNonBlockingNoCheck() {
+	// Non-blocking types (related) skip the cycle check entirely — adding a
+	// "related" edge between two issues that already cycle on blocking must
+	// succeed without complaint.
+	s.seedIssueRow("bd-duc-nbnc-a")
+	s.seedIssueRow("bd-duc-nbnc-b")
+	depRepo := NewDependencySQLRepository(s.Runner())
+	s.Require().NoError(depRepo.Insert(s.Ctx(),
+		newDep("bd-duc-nbnc-a", "bd-duc-nbnc-b", types.DepBlocks), "tester", domain.DepInsertOpts{}))
+
+	// related edge b -> a: cycle check is per-edge for blocking types only, so
+	// this should always be accepted.
+	res, err := s.depUseCase().AddDependencies(s.Ctx(),
+		[]*types.Dependency{newDep("bd-duc-nbnc-b", "bd-duc-nbnc-a", types.DepRelated)},
+		"tester", domain.BulkAddDepsOpts{})
+	s.Require().NoError(err)
+	s.Require().Len(res.Added, 1)
+}
+
+// ---- AddWispDependencies ----
+
+func (s *testSuite) ducAddBulkWispRoutes() {
+	s.seedWispRow("bd-duc-bw-src")
+	s.seedIssueRow("bd-duc-bw-tgt")
+
+	deps := []*types.Dependency{
+		newDep("bd-duc-bw-src", "bd-duc-bw-tgt", types.DepBlocks),
+	}
+	res, err := s.depUseCase().AddWispDependencies(s.Ctx(), deps, "tester", domain.BulkAddDepsOpts{})
+	s.Require().NoError(err)
+	s.Require().Len(res.Added, 1)
+
+	var wispCount, permCount int
+	s.Require().NoError(s.Runner().QueryRowContext(s.Ctx(),
+		"SELECT COUNT(*) FROM wisp_dependencies WHERE issue_id = ?", "bd-duc-bw-src").Scan(&wispCount))
+	s.Equal(1, wispCount)
+	s.Require().NoError(s.Runner().QueryRowContext(s.Ctx(),
+		"SELECT COUNT(*) FROM dependencies WHERE issue_id = ?", "bd-duc-bw-src").Scan(&permCount))
+	s.Equal(0, permCount, "wisp-routed bulk add must not touch the issues dep table")
+}

--- a/internal/storage/domain/dependency.go
+++ b/internal/storage/domain/dependency.go
@@ -53,6 +53,20 @@ type DepDeleteResult struct {
 	DependsOnID string
 }
 
+type DepTreeOpts struct {
+	MaxDepth     int
+	ShowAllPaths bool
+	Direction    DepDirection
+}
+
+type BulkAddDepsOpts struct {
+	SkipPerEdgeCycleCheck bool
+}
+
+type BulkAddDepsResult struct {
+	Added []*types.Dependency
+}
+
 type DependencySQLRepository interface {
 	Insert(ctx context.Context, dep *types.Dependency, actor string, opts DepInsertOpts) error
 	Delete(ctx context.Context, issueID, dependsOnID, actor string, opts DepInsertOpts) (DepDeleteResult, error)
@@ -70,6 +84,11 @@ type DependencySQLRepository interface {
 	DeleteAllForIDs(ctx context.Context, ids []string, opts DepInsertOpts) (int, error)
 	CountAllForIDs(ctx context.Context, ids []string, opts DepCountsOpts) (int, error)
 	DetectCycles(ctx context.Context) ([][]*types.Issue, error)
+
+	GetTree(ctx context.Context, rootID string, opts DepTreeOpts) ([]*types.TreeNode, error)
+	CycleThroughEdges(ctx context.Context, edges [][2]string) (string, error)
+	GetDependencyRecordsForIssues(ctx context.Context, issueIDs []string) (map[string][]*types.Dependency, error)
+	GetWispDependencyRecordsForIDs(ctx context.Context, wispIDs []string) (map[string][]*types.Dependency, error)
 }
 
 type DependencyUseCase interface {
@@ -85,6 +104,13 @@ type DependencyUseCase interface {
 	IsBlocked(ctx context.Context, issueID string) (bool, []string, error)
 	GetForIssueIDs(ctx context.Context, ids []string) (map[string][]*types.Dependency, error)
 	DetectCycles(ctx context.Context) ([][]*types.Issue, error)
+
+	GetDependencyTree(ctx context.Context, rootID string, opts DepTreeOpts) ([]*types.TreeNode, error)
+	AddDependencies(ctx context.Context, deps []*types.Dependency, actor string, opts BulkAddDepsOpts) (BulkAddDepsResult, error)
+	GetIssueDependencyRecords(ctx context.Context, issueIDs []string) (map[string][]*types.Dependency, error)
+
+	AddWispDependencies(ctx context.Context, deps []*types.Dependency, actor string, opts BulkAddDepsOpts) (BulkAddDepsResult, error)
+	GetWispDependencyRecords(ctx context.Context, wispIDs []string) (map[string][]*types.Dependency, error)
 
 	AddWispDependency(ctx context.Context, dep *types.Dependency, actor string) error
 	RemoveWispDependency(ctx context.Context, wispID, dependsOnID, actor string) error
@@ -392,6 +418,93 @@ func (u *dependencyUseCaseImpl) DetectCycles(ctx context.Context) ([][]*types.Is
 	out, err := u.depRepo.DetectCycles(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("DetectCycles: %w", err)
+	}
+	return out, nil
+}
+
+func (u *dependencyUseCaseImpl) GetDependencyTree(ctx context.Context, rootID string, opts DepTreeOpts) ([]*types.TreeNode, error) {
+	if rootID == "" {
+		return nil, fmt.Errorf("GetDependencyTree: rootID must not be empty")
+	}
+	out, err := u.depRepo.GetTree(ctx, rootID, opts)
+	if err != nil {
+		return nil, fmt.Errorf("GetDependencyTree: %w", err)
+	}
+	return out, nil
+}
+
+func (u *dependencyUseCaseImpl) AddDependencies(ctx context.Context, deps []*types.Dependency, actor string, opts BulkAddDepsOpts) (BulkAddDepsResult, error) {
+	return u.addBulk(ctx, deps, actor, opts, false)
+}
+
+func (u *dependencyUseCaseImpl) AddWispDependencies(ctx context.Context, deps []*types.Dependency, actor string, opts BulkAddDepsOpts) (BulkAddDepsResult, error) {
+	return u.addBulk(ctx, deps, actor, opts, true)
+}
+
+func (u *dependencyUseCaseImpl) addBulk(ctx context.Context, deps []*types.Dependency, actor string, opts BulkAddDepsOpts, useWisp bool) (BulkAddDepsResult, error) {
+	if len(deps) == 0 {
+		return BulkAddDepsResult{Added: []*types.Dependency{}}, nil
+	}
+	insertOpts := DepInsertOpts{UseWispsTable: useWisp}
+	for i, dep := range deps {
+		if dep == nil {
+			return BulkAddDepsResult{}, fmt.Errorf("add deps[%d]: dep must not be nil", i)
+		}
+		if dep.IssueID == "" || dep.DependsOnID == "" {
+			return BulkAddDepsResult{}, fmt.Errorf("add deps[%d]: IssueID and DependsOnID must be non-empty", i)
+		}
+		if !opts.SkipPerEdgeCycleCheck && isBlockingDep(dep.Type) {
+			cycle, err := u.depRepo.HasCycle(ctx, dep.IssueID, dep.DependsOnID)
+			if err != nil {
+				return BulkAddDepsResult{}, fmt.Errorf("add deps[%d]: cycle check: %w", i, err)
+			}
+			if cycle {
+				return BulkAddDepsResult{}, fmt.Errorf("add deps[%d]: adding %s -> %s would create a cycle", i, dep.IssueID, dep.DependsOnID)
+			}
+		}
+		if err := u.depRepo.Insert(ctx, dep, actor, insertOpts); err != nil {
+			return BulkAddDepsResult{}, fmt.Errorf("add deps[%d]: insert: %w", i, err)
+		}
+	}
+	if opts.SkipPerEdgeCycleCheck {
+		var pairs [][2]string
+		for _, dep := range deps {
+			if !isBlockingDep(dep.Type) {
+				continue
+			}
+			pairs = append(pairs, [2]string{dep.IssueID, dep.DependsOnID})
+		}
+		if len(pairs) > 0 {
+			cyclePath, err := u.depRepo.CycleThroughEdges(ctx, pairs)
+			if err != nil {
+				return BulkAddDepsResult{}, fmt.Errorf("add deps: final cycle check: %w", err)
+			}
+			if cyclePath != "" {
+				return BulkAddDepsResult{}, fmt.Errorf("add deps: dependency cycle would be created: %s", cyclePath)
+			}
+		}
+	}
+	return BulkAddDepsResult{Added: deps}, nil
+}
+
+func (u *dependencyUseCaseImpl) GetIssueDependencyRecords(ctx context.Context, issueIDs []string) (map[string][]*types.Dependency, error) {
+	if len(issueIDs) == 0 {
+		return map[string][]*types.Dependency{}, nil
+	}
+	out, err := u.depRepo.GetDependencyRecordsForIssues(ctx, issueIDs)
+	if err != nil {
+		return nil, fmt.Errorf("GetIssueDependencyRecords: %w", err)
+	}
+	return out, nil
+}
+
+func (u *dependencyUseCaseImpl) GetWispDependencyRecords(ctx context.Context, wispIDs []string) (map[string][]*types.Dependency, error) {
+	if len(wispIDs) == 0 {
+		return map[string][]*types.Dependency{}, nil
+	}
+	out, err := u.depRepo.GetWispDependencyRecordsForIDs(ctx, wispIDs)
+	if err != nil {
+		return nil, fmt.Errorf("GetWispDependencyRecords: %w", err)
 	}
 	return out, nil
 }

--- a/internal/storage/issueops/dependency_tree.go
+++ b/internal/storage/issueops/dependency_tree.go
@@ -2,7 +2,6 @@ package issueops
 
 import (
 	"context"
-	"database/sql"
 
 	"github.com/steveyegge/beads/internal/types"
 )
@@ -10,12 +9,12 @@ import (
 // GetDependencyTreeInTx returns a flattened dependency tree for visualization.
 // It performs a recursive BFS traversal up to maxDepth, using GetIssueInTx and
 // GetDependenciesInTx/GetDependentsInTx which handle wisp routing.
-func GetDependencyTreeInTx(ctx context.Context, tx *sql.Tx, issueID string, maxDepth int, showAllPaths bool, reverse bool) ([]*types.TreeNode, error) {
+func GetDependencyTreeInTx(ctx context.Context, tx DBTX, issueID string, maxDepth int, showAllPaths bool, reverse bool) ([]*types.TreeNode, error) {
 	visited := make(map[string]bool)
 	return buildDependencyTreeInTx(ctx, tx, issueID, 0, maxDepth, reverse, visited, "", "")
 }
 
-func buildDependencyTreeInTx(ctx context.Context, tx *sql.Tx, issueID string, depth, maxDepth int, reverse bool, visited map[string]bool, parentID string, edgeFromParent types.DependencyType) ([]*types.TreeNode, error) {
+func buildDependencyTreeInTx(ctx context.Context, tx DBTX, issueID string, depth, maxDepth int, reverse bool, visited map[string]bool, parentID string, edgeFromParent types.DependencyType) ([]*types.TreeNode, error) {
 	if depth >= maxDepth || visited[issueID] {
 		return nil, nil
 	}


### PR DESCRIPTION
Wires every `bd dep` subcommand (`--blocks` shorthand, `add`, `remove`, `list`, `tree`, `cycles`) through the domain `DependencyUseCase` when running in proxied-server mode, matching the existing pattern used by `bd update`, `bd list`, `bd create`, etc.

- New `DependencyUseCase` methods: `GetDependencyTree`, `AddDependencies` (bulk + per-edge / whole-graph cycle gating), `GetIssueDependencyRecords`, plus wisp variants `AddWispDependencies` and `GetWispDependencyRecords`.
- New `DependencySQLRepository` methods: `GetTree`, `CycleThroughEdges`, `GetDependencyRecordsForIssues`, `GetWispDependencyRecordsForIDs`. All wrap existing `issueops` helpers — `GetDependencyTreeInTx`, `AppendBlockingGraphInTx` + `CycleThroughEdgesInGraph`, `GetDependencyRecordsForIssuesInTx`, `GetDependencyRecordsForIssuesFromTableInTx` — no new SQL.
- Widened `issueops.GetDependencyTreeInTx` first param from `*sql.Tx` to `DBTX` so the repo can pass its `Runner` directly. Callees already accepted `DBTX`.
- New `cmd/bd/dep_proxied_server.go` with one entry point per subcommand. `cmd/bd/dep.go` gets five three-line `if usesProxiedServer()` dispatch blocks; the legacy `storage.Store` path is otherwise untouched.
- Bulk `dep add --file` flows through `AddDependencies` with `BulkAddDepsOpts{SkipPerEdgeCycleCheck: noCycleCheck}`; the UC runs per-edge `HasCycle` by default, or one final `CycleThroughEdges` whole-graph gate when skipping (preserves bd-6dnrw.8 semantics).
- `dep tree --direction both` makes two `GetDependencyTree` calls and reuses the existing `mergeBidirectionalTrees`.