### PR TITLE
bd config proxied-server

### DIFF
--- a/cmd/bd/config.go
+++ b/cmd/bd/config.go
@@ -187,6 +187,11 @@ var configSetCmd = &cobra.Command{
 			return
 		}
 
+		if usesProxiedServer() {
+			runConfigSetProxiedServer(rootCtx, key, value)
+			return
+		}
+
 		// Database-stored config requires direct mode
 		if err := ensureDirectMode("config set requires direct database access"); err != nil {
 			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
@@ -273,6 +278,11 @@ var configGetCmd = &cobra.Command{
 			return
 		}
 
+		if usesProxiedServer() {
+			runConfigGetProxiedServer(rootCtx, key)
+			return
+		}
+
 		// Database-stored config requires direct mode
 		if err := ensureDirectMode("config get requires direct database access"); err != nil {
 			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
@@ -309,6 +319,11 @@ var configListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List all configuration",
 	Run: func(cmd *cobra.Command, args []string) {
+		if usesProxiedServer() {
+			runConfigListProxiedServer(rootCtx)
+			return
+		}
+
 		// Config operations work in direct mode only
 		if err := ensureDirectMode("config list requires direct database access"); err != nil {
 			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
@@ -464,6 +479,11 @@ var configUnsetCmd = &cobra.Command{
 			} else {
 				fmt.Printf("Unset %s (in git config)\n", key)
 			}
+			return
+		}
+
+		if usesProxiedServer() {
+			runConfigUnsetProxiedServer(rootCtx, key)
 			return
 		}
 
@@ -730,19 +750,29 @@ Examples:
 
 		// Phase 6: Write DB keys in batch
 		if len(dbPairs) > 0 {
-			if err := ensureDirectMode("config set-many requires direct database access"); err != nil {
-				fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-				os.Exit(1)
-			}
-
-			ctx := rootCtx
-			for _, p := range dbPairs {
-				if err := store.SetConfig(ctx, p.key, p.value); err != nil {
-					fmt.Fprintf(os.Stderr, "Error setting config %s: %v\n", p.key, err)
+			if usesProxiedServer() {
+				keys := make([]string, len(dbPairs))
+				values := make([]string, len(dbPairs))
+				for i, p := range dbPairs {
+					keys[i] = p.key
+					values[i] = p.value
+				}
+				runConfigSetManyProxiedServer(rootCtx, keys, values)
+			} else {
+				if err := ensureDirectMode("config set-many requires direct database access"); err != nil {
+					fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 					os.Exit(1)
 				}
+
+				ctx := rootCtx
+				for _, p := range dbPairs {
+					if err := store.SetConfig(ctx, p.key, p.value); err != nil {
+						fmt.Fprintf(os.Stderr, "Error setting config %s: %v\n", p.key, err)
+						os.Exit(1)
+					}
+				}
+				commandDidWrite.Store(true)
 			}
-			commandDidWrite.Store(true)
 		}
 
 		// Phase 7: Output results

--- a/cmd/bd/config_proxied_integration_test.go
+++ b/cmd/bd/config_proxied_integration_test.go
@@ -1,0 +1,407 @@
+//go:build cgo
+
+package main
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+)
+
+func bdProxiedConfig(t *testing.T, bd, dir string, args ...string) string {
+	t.Helper()
+	fullArgs := append([]string{"config"}, args...)
+	stdout, stderr, err := bdProxiedRunBuffers(t, bd, dir, fullArgs...)
+	if err != nil {
+		t.Fatalf("bd config %s failed: %v\nstdout:\n%s\nstderr:\n%s",
+			strings.Join(args, " "), err, stdout, stderr)
+	}
+	return stdout
+}
+
+func bdProxiedConfigFail(t *testing.T, bd, dir string, args ...string) string {
+	t.Helper()
+	fullArgs := append([]string{"config"}, args...)
+	stdout, stderr, err := bdProxiedRunBuffers(t, bd, dir, fullArgs...)
+	if err == nil {
+		t.Fatalf("expected bd config %s to fail; got stdout:\n%s\nstderr:\n%s",
+			strings.Join(args, " "), stdout, stderr)
+	}
+	return stdout + stderr
+}
+
+func bdProxiedConfigListJSON(t *testing.T, bd, dir string) map[string]string {
+	t.Helper()
+	out := bdProxiedConfig(t, bd, dir, "list", "--json")
+	s := strings.TrimSpace(out)
+	start := strings.Index(s, "{")
+	if start < 0 {
+		t.Fatalf("no JSON object in config list output: %s", s)
+	}
+	var raw map[string]interface{}
+	if err := json.Unmarshal([]byte(s[start:]), &raw); err != nil {
+		t.Fatalf("parse config list JSON: %v\n%s", err, s)
+	}
+	m := make(map[string]string, len(raw))
+	for k, v := range raw {
+		if k == "schema_version" {
+			continue
+		}
+		if sv, ok := v.(string); ok {
+			m[k] = sv
+		}
+	}
+	return m
+}
+
+func proxiedDoltHead(t *testing.T, db *sql.DB) string {
+	t.Helper()
+	var h string
+	if err := db.QueryRowContext(context.Background(), "SELECT HASHOF('HEAD')").Scan(&h); err != nil {
+		t.Fatalf("read HEAD: %v", err)
+	}
+	return h
+}
+
+func proxiedDoltCommitCountSince(t *testing.T, db *sql.DB, sinceHash string) int {
+	t.Helper()
+	var n int
+	if err := db.QueryRowContext(context.Background(),
+		"SELECT COUNT(*) FROM DOLT_LOG('HEAD', '--not', ?)", sinceHash).Scan(&n); err != nil {
+		t.Fatalf("count commits since %s: %v", sinceHash, err)
+	}
+	return n
+}
+
+func TestProxiedServerConfig(t *testing.T) {
+	requireProxiedServerEnv(t)
+	bd := buildEmbeddedBD(t)
+
+	t.Run("config_set_and_get", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "pcs")
+		bdProxiedConfig(t, bd, p.dir, "set", "test.key1", "hello")
+		out := bdProxiedConfig(t, bd, p.dir, "get", "test.key1")
+		if !strings.Contains(out, "hello") {
+			t.Errorf("expected 'hello' in get output: %s", out)
+		}
+	})
+
+	t.Run("config_set_overwrite", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "pco")
+		bdProxiedConfig(t, bd, p.dir, "set", "test.overwrite", "first")
+		bdProxiedConfig(t, bd, p.dir, "set", "test.overwrite", "second")
+		out := bdProxiedConfig(t, bd, p.dir, "get", "test.overwrite")
+		if !strings.Contains(out, "second") {
+			t.Errorf("expected 'second' after overwrite: %s", out)
+		}
+	})
+
+	t.Run("config_set_namespaced", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "pcn")
+		bdProxiedConfig(t, bd, p.dir, "set", "jira.url", "https://example.atlassian.net")
+		out := bdProxiedConfig(t, bd, p.dir, "get", "jira.url")
+		if !strings.Contains(out, "https://example.atlassian.net") {
+			t.Errorf("expected jira URL in output: %s", out)
+		}
+	})
+
+	t.Run("config_set_and_get_linear_state_map_dotted_key", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "pcd")
+		bdProxiedConfig(t, bd, p.dir, "set", "linear.state_map.closed", "Done")
+		out := bdProxiedConfig(t, bd, p.dir, "get", "linear.state_map.closed")
+		if strings.TrimSpace(out) != "Done" {
+			t.Errorf("expected exact state_map value, got: %s", out)
+		}
+	})
+
+	t.Run("config_list", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "pcl")
+		out := bdProxiedConfig(t, bd, p.dir, "list")
+		if !strings.Contains(out, "issue_prefix") {
+			t.Errorf("expected issue_prefix in list output: %s", out)
+		}
+	})
+
+	t.Run("config_list_json", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "pcj")
+		bdProxiedConfig(t, bd, p.dir, "set", "test.key1", "hello")
+		m := bdProxiedConfigListJSON(t, bd, p.dir)
+		if _, ok := m["issue_prefix"]; !ok {
+			t.Error("expected issue_prefix in JSON config list")
+		}
+		if v, ok := m["test.key1"]; !ok || v != "hello" {
+			t.Errorf("expected test.key1=hello, got %q", v)
+		}
+	})
+
+	t.Run("config_unset", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "pcu")
+		bdProxiedConfig(t, bd, p.dir, "set", "test.removeme", "temp")
+		out := bdProxiedConfig(t, bd, p.dir, "get", "test.removeme")
+		if !strings.Contains(out, "temp") {
+			t.Fatalf("expected 'temp' before unset: %s", out)
+		}
+		bdProxiedConfig(t, bd, p.dir, "unset", "test.removeme")
+		out = bdProxiedConfig(t, bd, p.dir, "get", "test.removeme")
+		if !strings.Contains(out, "not set") {
+			t.Errorf("expected 'not set' after unset: %s", out)
+		}
+		m := bdProxiedConfigListJSON(t, bd, p.dir)
+		if _, ok := m["test.removeme"]; ok {
+			t.Error("expected test.removeme to be absent from config list after unset")
+		}
+	})
+
+	t.Run("config_get_missing_key", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "pcm")
+		out := bdProxiedConfig(t, bd, p.dir, "get", "nonexistent.key.xyz")
+		if !strings.Contains(out, "not set") {
+			t.Errorf("expected 'not set' for missing key: %s", out)
+		}
+	})
+
+	t.Run("config_set_no_args", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "pcsna")
+		bdProxiedConfigFail(t, bd, p.dir, "set")
+	})
+
+	t.Run("config_unset_no_args", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "pcuna")
+		bdProxiedConfigFail(t, bd, p.dir, "unset")
+	})
+
+	t.Run("config_set_creates_dolt_commit", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "pcsc")
+		db := openProxiedDB(t, p)
+		before := proxiedDoltHead(t, db)
+
+		bdProxiedConfig(t, bd, p.dir, "set", "test.commit", "v1")
+
+		after := proxiedDoltHead(t, db)
+		if after == before {
+			t.Errorf("HEAD did not advance: before=%s after=%s", before, after)
+		}
+	})
+
+	t.Run("config_unset_creates_dolt_commit", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "pcuc")
+		bdProxiedConfig(t, bd, p.dir, "set", "test.commit", "v1")
+
+		db := openProxiedDB(t, p)
+		before := proxiedDoltHead(t, db)
+
+		bdProxiedConfig(t, bd, p.dir, "unset", "test.commit")
+
+		after := proxiedDoltHead(t, db)
+		if after == before {
+			t.Errorf("HEAD did not advance on unset: before=%s after=%s", before, after)
+		}
+	})
+
+	t.Run("config_yaml_only_key_skips_dolt_commit", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "pcy")
+		db := openProxiedDB(t, p)
+		before := proxiedDoltHead(t, db)
+
+		bdProxiedConfig(t, bd, p.dir, "set", "export.auto", "true")
+
+		after := proxiedDoltHead(t, db)
+		if after != before {
+			t.Errorf("yaml-only set should not advance HEAD: before=%s after=%s", before, after)
+		}
+
+		out := bdProxiedConfig(t, bd, p.dir, "get", "export.auto")
+		if !strings.Contains(out, "true") {
+			t.Errorf("expected export.auto=true via get: %s", out)
+		}
+
+		yamlPath := filepath.Join(p.beadsDir, "config.yaml")
+		body, err := os.ReadFile(yamlPath)
+		if err != nil {
+			t.Fatalf("read %s: %v", yamlPath, err)
+		}
+		if !strings.Contains(string(body), "auto") {
+			t.Errorf("expected export.auto written to config.yaml, got:\n%s", body)
+		}
+
+		before = proxiedDoltHead(t, db)
+		bdProxiedConfig(t, bd, p.dir, "unset", "export.auto")
+		after = proxiedDoltHead(t, db)
+		if after != before {
+			t.Errorf("yaml-only unset should not advance HEAD: before=%s after=%s", before, after)
+		}
+	})
+
+	t.Run("config_beads_role_skips_dolt_commit", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "pcr")
+		db := openProxiedDB(t, p)
+		before := proxiedDoltHead(t, db)
+
+		bdProxiedConfig(t, bd, p.dir, "set", "beads.role", "contributor")
+
+		after := proxiedDoltHead(t, db)
+		if after != before {
+			t.Errorf("beads.role set should not advance HEAD: before=%s after=%s", before, after)
+		}
+
+		gitCmd := exec.Command("git", "config", "--get", "beads.role")
+		gitCmd.Dir = p.dir
+		out, err := gitCmd.Output()
+		if err != nil {
+			t.Fatalf("git config --get beads.role: %v", err)
+		}
+		if strings.TrimSpace(string(out)) != "contributor" {
+			t.Errorf("expected beads.role=contributor in git config, got %q", out)
+		}
+
+		before = proxiedDoltHead(t, db)
+		bdProxiedConfig(t, bd, p.dir, "unset", "beads.role")
+		after = proxiedDoltHead(t, db)
+		if after != before {
+			t.Errorf("beads.role unset should not advance HEAD: before=%s after=%s", before, after)
+		}
+	})
+}
+
+func TestProxiedServerConfigSetMany(t *testing.T) {
+	requireProxiedServerEnv(t)
+	bd := buildEmbeddedBD(t)
+
+	t.Run("set_many_single_dolt_commit", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "pcsm")
+		db := openProxiedDB(t, p)
+		before := proxiedDoltHead(t, db)
+
+		bdProxiedConfig(t, bd, p.dir, "set-many",
+			"ado.state_map.open=New",
+			"ado.state_map.in_progress=Active",
+			"ado.state_map.closed=Closed",
+		)
+
+		after := proxiedDoltHead(t, db)
+		if after == before {
+			t.Fatalf("HEAD did not advance for set-many: before=%s after=%s", before, after)
+		}
+		n := proxiedDoltCommitCountSince(t, db, before)
+		if n != 1 {
+			t.Errorf("expected exactly 1 Dolt commit for set-many with 3 keys, got %d", n)
+		}
+	})
+
+	t.Run("set_many_cli_round_trip", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "pcsmr")
+		bdProxiedConfig(t, bd, p.dir, "set-many",
+			"jira.url=https://example.atlassian.net",
+			"jira.project=PROJ",
+			"linear.state_map.closed=Done",
+		)
+
+		want := map[string]string{
+			"jira.url":                "https://example.atlassian.net",
+			"jira.project":            "PROJ",
+			"linear.state_map.closed": "Done",
+		}
+		for k, v := range want {
+			out := bdProxiedConfig(t, bd, p.dir, "get", k)
+			if strings.TrimSpace(out) != v {
+				t.Errorf("get %s: expected %q, got %q", k, v, out)
+			}
+		}
+
+		m := bdProxiedConfigListJSON(t, bd, p.dir)
+		for k, v := range want {
+			if got, ok := m[k]; !ok || got != v {
+				t.Errorf("list --json: %s expected %q, got %q (exists=%v)", k, v, got, ok)
+			}
+		}
+	})
+}
+
+func TestProxiedServerConfigConcurrent(t *testing.T) {
+	requireProxiedServerEnv(t)
+	bd := buildEmbeddedBD(t)
+
+	p := bdProxiedInit(t, bd, "pcc")
+
+	const numWorkers = 8
+
+	type workerResult struct {
+		worker int
+		err    error
+	}
+
+	results := make([]workerResult, numWorkers)
+	var wg sync.WaitGroup
+	wg.Add(numWorkers)
+
+	for w := 0; w < numWorkers; w++ {
+		go func(worker int) {
+			defer wg.Done()
+			r := workerResult{worker: worker}
+
+			for i := 0; i < 5; i++ {
+				key := fmt.Sprintf("worker%d.key%d", worker, i)
+				value := fmt.Sprintf("value-%d-%d", worker, i)
+				if _, err := bdProxiedRun(t, bd, p.dir, "config", "set", key, value); err != nil {
+					r.err = fmt.Errorf("set %s: %v", key, err)
+					results[worker] = r
+					return
+				}
+			}
+
+			for i := 0; i < 5; i++ {
+				key := fmt.Sprintf("worker%d.key%d", worker, i)
+				expected := fmt.Sprintf("value-%d-%d", worker, i)
+				out, err := bdProxiedRun(t, bd, p.dir, "config", "get", key)
+				if err != nil {
+					r.err = fmt.Errorf("get %s: %v\n%s", key, err, out)
+					results[worker] = r
+					return
+				}
+				if !strings.Contains(string(out), expected) {
+					r.err = fmt.Errorf("worker %d: key %s expected %q, got %q", worker, key, expected, string(out))
+					results[worker] = r
+					return
+				}
+			}
+
+			results[worker] = r
+		}(w)
+	}
+	wg.Wait()
+
+	for _, r := range results {
+		if r.err != nil &&
+			!strings.Contains(r.err.Error(), "serialization failure") &&
+			!strings.Contains(r.err.Error(), "Error 1213") {
+			t.Errorf("worker %d failed: %v", r.worker, r.err)
+		}
+	}
+
+	m := bdProxiedConfigListJSON(t, bd, p.dir)
+	var successCount int
+	for _, r := range results {
+		if r.err != nil {
+			continue
+		}
+		successCount++
+		w := r.worker
+		for i := 0; i < 5; i++ {
+			key := fmt.Sprintf("worker%d.key%d", w, i)
+			expected := fmt.Sprintf("value-%d-%d", w, i)
+			if v, ok := m[key]; !ok || v != expected {
+				t.Errorf("after concurrent writes: key %s expected %q, got %q (exists=%v)", key, expected, v, ok)
+			}
+		}
+	}
+	if successCount == 0 {
+		t.Fatal("expected at least 1 worker to succeed")
+	}
+}

--- a/cmd/bd/config_proxied_server.go
+++ b/cmd/bd/config_proxied_server.go
@@ -1,0 +1,147 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	"github.com/steveyegge/beads/internal/storage/uow"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+func openConfigProxiedUOW(ctx context.Context) uow.UnitOfWork {
+	if uowProvider == nil {
+		FatalErrorRespectJSON("proxied-server UOW provider not initialized")
+	}
+	uw, err := uowProvider.NewUOW(ctx)
+	if err != nil {
+		FatalErrorRespectJSON("open unit of work: %v", err)
+	}
+	return uw
+}
+
+func runConfigSetProxiedServer(ctx context.Context, key, value string) {
+	if key == "status.custom" && value != "" {
+		if _, err := types.ParseCustomStatusConfig(value); err != nil {
+			FatalErrorRespectJSON("invalid status.custom value: %v", err)
+		}
+	}
+
+	uw := openConfigProxiedUOW(ctx)
+	defer uw.Close(ctx)
+
+	if err := uw.ConfigUseCase().SetConfig(ctx, key, value); err != nil {
+		FatalErrorRespectJSON("Error setting config: %v", err)
+	}
+
+	if err := uw.Commit(ctx, fmt.Sprintf("bd: config set %s", key)); err != nil && !isDoltNothingToCommit(err) {
+		FatalErrorRespectJSON("failed to commit: %v", err)
+	}
+
+	if jsonOutput {
+		outputJSON(map[string]string{
+			"key":   key,
+			"value": value,
+		})
+	} else {
+		fmt.Printf("Set %s = %s\n", key, value)
+	}
+	printConfigSideEffects(checkConfigSetSideEffects(key, value))
+}
+
+func runConfigGetProxiedServer(ctx context.Context, key string) {
+	uw := openConfigProxiedUOW(ctx)
+	defer uw.Close(ctx)
+
+	value, err := uw.ConfigUseCase().GetConfig(ctx, key)
+	if err != nil {
+		FatalErrorRespectJSON("Error getting config: %v", err)
+	}
+
+	if jsonOutput {
+		outputJSON(map[string]string{
+			"key":   key,
+			"value": value,
+		})
+		return
+	}
+	if value == "" {
+		fmt.Printf("%s (not set)\n", key)
+	} else {
+		fmt.Printf("%s\n", value)
+	}
+}
+
+func runConfigListProxiedServer(ctx context.Context) {
+	uw := openConfigProxiedUOW(ctx)
+	defer uw.Close(ctx)
+
+	cfg, err := uw.ConfigUseCase().GetAllConfig(ctx)
+	if err != nil {
+		FatalErrorRespectJSON("Error listing config: %v", err)
+	}
+
+	if jsonOutput {
+		outputJSON(cfg)
+		return
+	}
+
+	if len(cfg) == 0 {
+		fmt.Println("No configuration set")
+		return
+	}
+
+	keys := make([]string, 0, len(cfg))
+	for k := range cfg {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	fmt.Println("\nConfiguration:")
+	for _, k := range keys {
+		fmt.Printf("  %s = %s\n", k, cfg[k])
+	}
+
+	showConfigYAMLOverrides(cfg)
+}
+
+func runConfigUnsetProxiedServer(ctx context.Context, key string) {
+	uw := openConfigProxiedUOW(ctx)
+	defer uw.Close(ctx)
+
+	if err := uw.ConfigUseCase().DeleteConfig(ctx, key); err != nil {
+		FatalErrorRespectJSON("Error deleting config: %v", err)
+	}
+
+	if err := uw.Commit(ctx, fmt.Sprintf("bd: config unset %s", key)); err != nil && !isDoltNothingToCommit(err) {
+		FatalErrorRespectJSON("failed to commit: %v", err)
+	}
+
+	if jsonOutput {
+		outputJSON(map[string]string{
+			"key": key,
+		})
+	} else {
+		fmt.Printf("Unset %s\n", key)
+	}
+	printConfigSideEffects(checkConfigUnsetSideEffects(key))
+}
+
+func runConfigSetManyProxiedServer(ctx context.Context, keys, values []string) {
+	if len(keys) == 0 {
+		return
+	}
+	uw := openConfigProxiedUOW(ctx)
+	defer uw.Close(ctx)
+
+	cfgUC := uw.ConfigUseCase()
+	for i, k := range keys {
+		if err := cfgUC.SetConfig(ctx, k, values[i]); err != nil {
+			FatalErrorRespectJSON("Error setting config %s: %v", k, err)
+		}
+	}
+
+	if err := uw.Commit(ctx, fmt.Sprintf("bd: config set-many (%d keys)", len(keys))); err != nil && !isDoltNothingToCommit(err) {
+		FatalErrorRespectJSON("failed to commit: %v", err)
+	}
+}

--- a/internal/storage/domain/config.go
+++ b/internal/storage/domain/config.go
@@ -13,6 +13,8 @@ type ConfigSQLRepository interface {
 	SetLocalMetadata(ctx context.Context, key, value string) error
 	GetConfig(ctx context.Context, key string) (string, error)
 	SetConfig(ctx context.Context, key, value string) error
+	DeleteConfig(ctx context.Context, key string) error
+	GetAllConfig(ctx context.Context) (map[string]string, error)
 
 	GetCustomTypes(ctx context.Context) ([]string, error)
 	GetAllowedPrefixes(ctx context.Context) (string, error)
@@ -32,6 +34,11 @@ type ConfigUseCase interface {
 	ListAllStatusNames(ctx context.Context) ([]string, error)
 	GetInfraTypes(ctx context.Context) (map[string]bool, error)
 	IsInfraTypeCtx(ctx context.Context, t types.IssueType) (bool, error)
+
+	GetConfig(ctx context.Context, key string) (string, error)
+	SetConfig(ctx context.Context, key, value string) error
+	DeleteConfig(ctx context.Context, key string) error
+	GetAllConfig(ctx context.Context) (map[string]string, error)
 }
 
 // CreateContext bundles the read-only config inputs that bd create needs
@@ -130,6 +137,36 @@ func (u *configUseCaseImpl) IsInfraTypeCtx(ctx context.Context, t types.IssueTyp
 		return false, err
 	}
 	return infra[string(t)], nil
+}
+
+func (u *configUseCaseImpl) GetConfig(ctx context.Context, key string) (string, error) {
+	out, err := u.cfgRepo.GetConfig(ctx, key)
+	if err != nil {
+		return "", fmt.Errorf("GetConfig: %w", err)
+	}
+	return out, nil
+}
+
+func (u *configUseCaseImpl) SetConfig(ctx context.Context, key, value string) error {
+	if err := u.cfgRepo.SetConfig(ctx, key, value); err != nil {
+		return fmt.Errorf("SetConfig: %w", err)
+	}
+	return nil
+}
+
+func (u *configUseCaseImpl) DeleteConfig(ctx context.Context, key string) error {
+	if err := u.cfgRepo.DeleteConfig(ctx, key); err != nil {
+		return fmt.Errorf("DeleteConfig: %w", err)
+	}
+	return nil
+}
+
+func (u *configUseCaseImpl) GetAllConfig(ctx context.Context) (map[string]string, error) {
+	out, err := u.cfgRepo.GetAllConfig(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("GetAllConfig: %w", err)
+	}
+	return out, nil
 }
 
 func (u *configUseCaseImpl) LoadCreateContext(ctx context.Context) (CreateContext, error) {

--- a/internal/storage/domain/db/config.go
+++ b/internal/storage/domain/db/config.go
@@ -73,6 +73,33 @@ func (r *configSQLRepositoryImpl) SetConfig(ctx context.Context, key, value stri
 	return nil
 }
 
+func (r *configSQLRepositoryImpl) DeleteConfig(ctx context.Context, key string) error {
+	if _, err := r.runner.ExecContext(ctx, "DELETE FROM config WHERE `key` = ?", key); err != nil {
+		return fmt.Errorf("db: DeleteConfig %s: %w", key, err)
+	}
+	return nil
+}
+
+func (r *configSQLRepositoryImpl) GetAllConfig(ctx context.Context) (map[string]string, error) {
+	rows, err := r.runner.QueryContext(ctx, "SELECT `key`, value FROM config")
+	if err != nil {
+		return nil, fmt.Errorf("db: GetAllConfig: %w", err)
+	}
+	defer rows.Close()
+	out := make(map[string]string)
+	for rows.Next() {
+		var k, v string
+		if err := rows.Scan(&k, &v); err != nil {
+			return nil, fmt.Errorf("db: GetAllConfig: scan: %w", err)
+		}
+		out[k] = v
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("db: GetAllConfig: read: %w", err)
+	}
+	return out, nil
+}
+
 func (r *configSQLRepositoryImpl) GetCustomTypes(ctx context.Context) ([]string, error) {
 	fromTable, err := r.readCustomTypesTable(ctx)
 	if err != nil {

--- a/internal/storage/domain/db/config_test.go
+++ b/internal/storage/domain/db/config_test.go
@@ -25,6 +25,24 @@ func (s *testSuite) TestConfigSQLRepository() {
 		s.Run("IssuePrefixTrimsTrailingHyphen", s.configSetConfigIssuePrefixTrim)
 		s.Run("IssuePrefixWithoutHyphenUnchanged", s.configSetConfigIssuePrefixUnchanged)
 	})
+	s.Run("DeleteConfig", func() {
+		s.Run("RemovesExistingKey", s.configDeleteConfigRemovesExisting)
+		s.Run("MissingKeyIsNoop", s.configDeleteConfigMissingKey)
+	})
+	s.Run("GetAllConfig", func() {
+		s.Run("EmptyReturnsEmptyMap", s.configGetAllConfigEmpty)
+		s.Run("ReturnsAllRows", s.configGetAllConfigAllRows)
+	})
+	s.Run("UseCase", func() {
+		s.Run("GetConfigMissingKey", s.configUseCaseGetConfigMissing)
+		s.Run("GetConfigRoundTrip", s.configUseCaseGetConfigRoundTrip)
+		s.Run("SetConfigOverwrite", s.configUseCaseSetConfigOverwrite)
+		s.Run("SetConfigIssuePrefixTrim", s.configUseCaseSetConfigIssuePrefixTrim)
+		s.Run("DeleteConfigRemovesExisting", s.configUseCaseDeleteConfigRemoves)
+		s.Run("DeleteConfigMissingKeyIsNoop", s.configUseCaseDeleteConfigMissing)
+		s.Run("GetAllConfigEmpty", s.configUseCaseGetAllConfigEmpty)
+		s.Run("GetAllConfigReturnsAllRows", s.configUseCaseGetAllConfigAllRows)
+	})
 	s.Run("GetCustomTypes", func() {
 		s.Run("MissingKeyReturnsNil", s.configGetCustomTypesMissing)
 		s.Run("EmptyValueReturnsNil", s.configGetCustomTypesEmpty)
@@ -128,6 +146,45 @@ func (s *testSuite) configSetConfigIssuePrefixTrim() {
 	v, err := r.GetConfig(s.Ctx(), "issue_prefix")
 	s.Require().NoError(err)
 	s.Equal("bd", v)
+}
+
+func (s *testSuite) configDeleteConfigRemovesExisting() {
+	r := s.configRepo()
+	s.Require().NoError(r.SetConfig(s.Ctx(), "jira.url", "https://example.atlassian.net"))
+	s.Require().NoError(r.DeleteConfig(s.Ctx(), "jira.url"))
+	v, err := r.GetConfig(s.Ctx(), "jira.url")
+	s.Require().NoError(err)
+	s.Equal("", v)
+}
+
+func (s *testSuite) configDeleteConfigMissingKey() {
+	r := s.configRepo()
+	s.Require().NoError(r.DeleteConfig(s.Ctx(), "no_such_key"))
+}
+
+func (s *testSuite) configGetAllConfigEmpty() {
+	_, err := s.Runner().ExecContext(s.Ctx(), "DELETE FROM config")
+	s.Require().NoError(err)
+	got, err := s.configRepo().GetAllConfig(s.Ctx())
+	s.Require().NoError(err)
+	s.Equal(map[string]string{}, got)
+}
+
+func (s *testSuite) configGetAllConfigAllRows() {
+	_, err := s.Runner().ExecContext(s.Ctx(), "DELETE FROM config")
+	s.Require().NoError(err)
+	r := s.configRepo()
+	s.Require().NoError(r.SetConfig(s.Ctx(), "jira.url", "https://example.atlassian.net"))
+	s.Require().NoError(r.SetConfig(s.Ctx(), "jira.project", "PROJ"))
+	s.Require().NoError(r.SetConfig(s.Ctx(), "export.auto", "true"))
+
+	got, err := r.GetAllConfig(s.Ctx())
+	s.Require().NoError(err)
+	s.Equal(map[string]string{
+		"jira.url":     "https://example.atlassian.net",
+		"jira.project": "PROJ",
+		"export.auto":  "true",
+	}, got)
 }
 
 func (s *testSuite) configSetConfigIssuePrefixUnchanged() {
@@ -318,6 +375,77 @@ func (s *testSuite) configUseCaseListAllStatusNames() {
 	s.Equal([]string{
 		"open", "in_progress", "blocked", "deferred", "closed", "pinned", "hooked",
 		"audit",
+	}, got)
+}
+
+func (s *testSuite) configUC() domain.ConfigUseCase {
+	return domain.NewConfigUseCase(NewConfigSQLRepository(s.Runner()))
+}
+
+func (s *testSuite) configUseCaseGetConfigMissing() {
+	v, err := s.configUC().GetConfig(s.Ctx(), "no_such_key")
+	s.Require().NoError(err)
+	s.Equal("", v)
+}
+
+func (s *testSuite) configUseCaseGetConfigRoundTrip() {
+	uc := s.configUC()
+	s.Require().NoError(uc.SetConfig(s.Ctx(), "team.sync_branch", "main"))
+	v, err := uc.GetConfig(s.Ctx(), "team.sync_branch")
+	s.Require().NoError(err)
+	s.Equal("main", v)
+}
+
+func (s *testSuite) configUseCaseSetConfigOverwrite() {
+	uc := s.configUC()
+	s.Require().NoError(uc.SetConfig(s.Ctx(), "k", "v1"))
+	s.Require().NoError(uc.SetConfig(s.Ctx(), "k", "v2"))
+	v, err := uc.GetConfig(s.Ctx(), "k")
+	s.Require().NoError(err)
+	s.Equal("v2", v)
+}
+
+func (s *testSuite) configUseCaseSetConfigIssuePrefixTrim() {
+	uc := s.configUC()
+	s.Require().NoError(uc.SetConfig(s.Ctx(), "issue_prefix", "bd-"))
+	v, err := uc.GetConfig(s.Ctx(), "issue_prefix")
+	s.Require().NoError(err)
+	s.Equal("bd", v)
+}
+
+func (s *testSuite) configUseCaseDeleteConfigRemoves() {
+	uc := s.configUC()
+	s.Require().NoError(uc.SetConfig(s.Ctx(), "jira.url", "https://example.atlassian.net"))
+	s.Require().NoError(uc.DeleteConfig(s.Ctx(), "jira.url"))
+	v, err := uc.GetConfig(s.Ctx(), "jira.url")
+	s.Require().NoError(err)
+	s.Equal("", v)
+}
+
+func (s *testSuite) configUseCaseDeleteConfigMissing() {
+	s.Require().NoError(s.configUC().DeleteConfig(s.Ctx(), "no_such_key"))
+}
+
+func (s *testSuite) configUseCaseGetAllConfigEmpty() {
+	_, err := s.Runner().ExecContext(s.Ctx(), "DELETE FROM config")
+	s.Require().NoError(err)
+	got, err := s.configUC().GetAllConfig(s.Ctx())
+	s.Require().NoError(err)
+	s.Equal(map[string]string{}, got)
+}
+
+func (s *testSuite) configUseCaseGetAllConfigAllRows() {
+	_, err := s.Runner().ExecContext(s.Ctx(), "DELETE FROM config")
+	s.Require().NoError(err)
+	uc := s.configUC()
+	s.Require().NoError(uc.SetConfig(s.Ctx(), "jira.url", "https://example.atlassian.net"))
+	s.Require().NoError(uc.SetConfig(s.Ctx(), "jira.project", "PROJ"))
+
+	got, err := uc.GetAllConfig(s.Ctx())
+	s.Require().NoError(err)
+	s.Equal(map[string]string{
+		"jira.url":     "https://example.atlassian.net",
+		"jira.project": "PROJ",
 	}, got)
 }
 


### PR DESCRIPTION
## Summary

- Adds proxied-server mode support to `bd config` (`set`, `get`, `list`, `unset`, `set-many`) via domain use case methods, following the same pattern as `bd dep`, `bd close`, `bd reopen`, `bd ready`, etc.
- Extends `domain.ConfigUseCase` with `GetConfig`, `SetConfig`, `DeleteConfig`, `GetAllConfig`. Extends `domain.ConfigSQLRepository` with `DeleteConfig` and `GetAllConfig` (`GetConfig`/`SetConfig` already existed).
- Routes `cmd/bd/config.go` through `usesProxiedServer()` early-return branches placed after the yaml-only and `beads.role` short-circuits so those non-DB paths stay unchanged. `set-many` batches all DB writes into one `uw.Commit` for a single Dolt commit.

## Test plan

- [x] `go build ./...` and `go vet ./...` pass.
- [x] New repository-level unit tests for `DeleteConfig` and `GetAllConfig` plus use-case-level tests for all four new use case methods (`internal/storage/domain/db/config_test.go`).
- [x] New integration tests in `cmd/bd/config_proxied_integration_test.go` (build tag `cgo`, gated on `BEADS_TEST_PROXIED_SERVER=1`):
  - 10 subtests mirroring `TestEmbeddedConfig` (set/get, overwrite, namespaced, dotted key, list, list_json, unset, missing key, no-args failures).
  - Dolt-commit assertions for proxied `set` and `unset` (`HASHOF('HEAD')` before/after).
  - `set-many` single-commit assertion via `DOLT_LOG('HEAD', '--not', <before>)`.
  - `set-many` end-to-end CLI round trip across multiple keys.
  - Yaml-only key (`export.auto`) and `beads.role` short-circuits must NOT advance Dolt HEAD in proxied mode.
  - Concurrent test (8 goroutines × 5 keys each) tolerating Dolt serialization-failure escapes.
- [x] Full proxied integration suite ran green locally (`BEADS_TEST_PROXIED_SERVER=1 go test -tags=cgo -run TestProxiedServerConfig ./cmd/bd/`).