### PR TITLE
fix(config): recognize ado.* as valid config namespace

### DIFF
--- a/cmd/bd/config.go
+++ b/cmd/bd/config.go
@@ -812,7 +812,7 @@ var recognizedConfigPrefixes = []string{
 	"export.", "import.", "dolt.", "jira.", "linear.", "github.", "custom.",
 	"status.", "doctor.suppress.", "routing.", "sync.", "git.",
 	"directory.", "repos.", "external_projects.", "validation.",
-	"hierarchy.", "ai.", "backup.", "federation.",
+	"hierarchy.", "ai.", "backup.", "federation.", "ado.",
 }
 
 // recognizedConfigKeys lists valid non-namespaced config keys.

--- a/cmd/bd/config_validate_key_test.go
+++ b/cmd/bd/config_validate_key_test.go
@@ -10,7 +10,7 @@ func TestIsRecognizedConfigKey(t *testing.T) {
 		"export.auto", "dolt.auto-push", "jira.url", "custom.anything",
 		"doctor.suppress.git-hooks", "no-git-ops", "beads.role",
 		"status.custom", "ai.model", "backup.enabled", "import.path",
-		"dolt.local-only",
+		"dolt.local-only", "ado.org", "ado.project", "ado.projects",
 	}
 	for _, key := range recognized {
 		if !isRecognizedConfigKey(key) {


### PR DESCRIPTION
## Summary

`bd config set ado.org <value>` (and `ado.project`, `ado.projects`, etc.) emits a spurious warning:

```
$ bd config set ado.org MyOrg
Warning: "ado.org" is not a recognized config key. Did you mean "ai.org"?
```

The value is actually written and read correctly by the ADO integration (cmd/bd/ado.go), but the config-key allowlist in config.go was never updated when ADO support was added.

## Fix

Add `"ado."` to `recognizedConfigPrefixes` in cmd/bd/config.go. This is a one-line change that mirrors how `jira.`, `linear.`, and `github.` are already handled.

## Test

Added `ado.org`, `ado.project`, `ado.projects` to the recognized-key list in `TestIsRecognizedConfigKey`.

Fixes #4427