### PR TITLE
fix(compact): pass --allow-empty to DOLT_CHERRY_PICK (#3815)

### DIFF
--- a/internal/storage/versioncontrolops/compact.go
+++ b/internal/storage/versioncontrolops/compact.go
@@ -55,8 +55,14 @@ func Compact(ctx context.Context, conn DBConn, initialHash, boundaryHash string,
 		return err
 	}
 
+	// --allow-empty: the preserved window can contain empty commits (a Dolt
+	// auto-commit with no table change, or a bd create double-commit whose
+	// leading member has 0 changed tables). Without this flag DOLT_CHERRY_PICK
+	// aborts the entire replay at the first empty commit with Error 1105
+	// ("The previous cherry-pick commit is empty. Use --allow-empty ..."),
+	// leaving compaction permanently blocked on active databases. See #3815.
 	for _, hash := range recentHashes {
-		if err := execSQL(fmt.Sprintf("cherry-pick %s", hash[:min(8, len(hash))]), "CALL DOLT_CHERRY_PICK(?)", hash); err != nil {
+		if err := execSQL(fmt.Sprintf("cherry-pick %s", hash[:min(8, len(hash))]), "CALL DOLT_CHERRY_PICK('--allow-empty', ?)", hash); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
## What

`bd compact` replays the recent-window commits onto the squashed base via `DOLT_CHERRY_PICK`. This passes `--allow-empty` to that call so the replay no longer aborts on empty commits.

```go
CALL DOLT_CHERRY_PICK('--allow-empty', ?)   // was: CALL DOLT_CHERRY_PICK(?)
```

Fixes #3815.

## Why

Without `--allow-empty`, the first empty commit in the preserved window aborts the entire cherry-pick replay:

```
Error 1105 (HY000): The previous cherry-pick commit is empty.
                    Use --allow-empty to cherry-pick empty commits.
```

Empty commits occur in two ways on active databases: a Dolt auto-commit with no table change, and a `bd create` double-commit whose leading member carries 0 changed tables (the data lands in the identically-messaged commit that immediately follows). Even a single empty commit anywhere in the window blocks compaction permanently, so the Dolt store never shrinks. `--allow-empty` is the flag Dolt's own error message instructs using, and empty vs. non-empty is a Dolt implementation detail with no bd-level UI distinction, so preserving empties on replay is the least-surprising behavior. The flag follows the variadic-flag convention already used throughout this package (`CALL DOLT_RESET('--soft', ?)`, `CALL DOLT_COMMIT('-Am', ?, '--author', ?)`).

## Provenance

This supersedes #4145 by @root-mechanicum, whose fork branch is ~2,381 commits behind `main` and cannot be updated in place. The original fix commit is preserved here with @root-mechanicum as author; this branch is the same one-line change cherry-picked cleanly onto current `main` so CI runs green (the failures on #4145 were stale-base artifacts — `Differential Regression` and `Embedded Dolt Cmd 16/20` both pass on current main). Please close #4145 as superseded once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
