### PR TITLE
fix(storage): phase-aware retries for Dolt server-mode write tx

### DIFF
--- a/cmd/bd/create_proxied_server.go
+++ b/cmd/bd/create_proxied_server.go
@@ -104,8 +104,9 @@ func runCreateProxiedSingle(_ *cobra.Command, ctx context.Context, in createInpu
 		return
 	}
 
-	uw, cctx := proxiedOpenUOW(ctx)
-	defer uw.Close(ctx)
+	// Load create context (read-only) to validate input before the write tx.
+	configUW, cctx := proxiedOpenUOW(ctx)
+	configUW.Close(ctx)
 
 	customTypes := resolveProxiedCustomTypes(cctx.CustomTypes)
 	if in.issueType != "" {
@@ -135,17 +136,19 @@ func runCreateProxiedSingle(_ *cobra.Command, ctx context.Context, in createInpu
 	}
 
 	var result domain.CreateIssueResult
-	if issue.Ephemeral {
-		result, err = uw.IssueUseCase().CreateWisp(ctx, params, in.createdBy)
-	} else {
-		result, err = uw.IssueUseCase().CreateIssue(ctx, params, in.createdBy)
-	}
-	if err != nil {
+	if err := uow.RunInTxMsg(ctx, uowProvider, func(uw uow.UnitOfWork) (string, error) {
+		var e error
+		if issue.Ephemeral {
+			result, e = uw.IssueUseCase().CreateWisp(ctx, params, in.createdBy)
+		} else {
+			result, e = uw.IssueUseCase().CreateIssue(ctx, params, in.createdBy)
+		}
+		if e != nil {
+			return "", e
+		}
+		return fmt.Sprintf("bd: create %s", result.Issue.ID), nil
+	}); err != nil {
 		FatalError("%v", err)
-	}
-
-	if err := uw.Commit(ctx, fmt.Sprintf("bd: create %s", result.Issue.ID)); err != nil && !isDoltNothingToCommit(err) {
-		FatalError("commit: %v", err)
 	}
 
 	switch {
@@ -246,8 +249,8 @@ func runCreateProxiedMarkdown(_ *cobra.Command, ctx context.Context, in createIn
 		builds = append(builds, templateBuild{template: t, deps: deps})
 	}
 
-	uw, cctx := proxiedOpenUOW(ctx)
-	defer uw.Close(ctx)
+	configUW, cctx := proxiedOpenUOW(ctx)
+	configUW.Close(ctx)
 
 	customTypes := resolveProxiedCustomTypes(cctx.CustomTypes)
 	for _, b := range builds {
@@ -284,18 +287,19 @@ func runCreateProxiedMarkdown(_ *cobra.Command, ctx context.Context, in createIn
 	}
 
 	var result domain.CreateIssuesResult
-	if in.ephemeral {
-		result, err = uw.IssueUseCase().CreateWisps(ctx, paramsList, in.createdBy)
-	} else {
-		result, err = uw.IssueUseCase().CreateIssues(ctx, paramsList, in.createdBy)
-	}
-	if err != nil {
+	if err := uow.RunInTxMsg(ctx, uowProvider, func(uw uow.UnitOfWork) (string, error) {
+		var e error
+		if in.ephemeral {
+			result, e = uw.IssueUseCase().CreateWisps(ctx, paramsList, in.createdBy)
+		} else {
+			result, e = uw.IssueUseCase().CreateIssues(ctx, paramsList, in.createdBy)
+		}
+		if e != nil {
+			return "", e
+		}
+		return fmt.Sprintf("bd: create %d issue(s) from %s", len(result.Issues), in.markdownFile), nil
+	}); err != nil {
 		FatalError("creating issues from markdown: %v", err)
-	}
-
-	commitMsg := fmt.Sprintf("bd: create %d issue(s) from %s", len(result.Issues), in.markdownFile)
-	if err := uw.Commit(ctx, commitMsg); err != nil && !isDoltNothingToCommit(err) {
-		FatalError("commit: %v", err)
 	}
 
 	if in.jsonOutput {

--- a/cmd/bd/init_proxied_server.go
+++ b/cmd/bd/init_proxied_server.go
@@ -17,6 +17,7 @@ import (
 	"github.com/steveyegge/beads/internal/storage/domain"
 	"github.com/steveyegge/beads/internal/storage/fs"
 	"github.com/steveyegge/beads/internal/storage/git"
+	"github.com/steveyegge/beads/internal/storage/uow"
 	"github.com/steveyegge/beads/internal/ui"
 )
 
@@ -149,12 +150,6 @@ func runInitProxiedServer(cmd *cobra.Command, ctx context.Context, in initProxie
 		FatalError("failed to open uow provider: %v", err)
 	}
 
-	uw, err := uowProvider.NewUOW(ctx)
-	if err != nil {
-		FatalError("failed to open unit of work: %v", err)
-	}
-	defer uw.Close(ctx)
-
 	bootstrapParams := domain.BootstrapProjectParams{
 		Prefix:         prefix,
 		ProjectID:      projectID,
@@ -177,12 +172,11 @@ func runInitProxiedServer(cmd *cobra.Command, ctx context.Context, in initProxie
 		bootstrapParams.RemoteURL = remoteURL
 	}
 
-	if _, err := uw.BootstrapUseCase().BootstrapProject(ctx, bootstrapParams); err != nil {
-		FatalError("bootstrap project: %v", err)
-	}
-
-	if err := uw.Commit(ctx, "bd init"); err != nil {
-		FatalError("commit init: %v", err)
+	if err := uow.RunInTx(ctx, uowProvider, "bd init", func(uw uow.UnitOfWork) error {
+		_, err := uw.BootstrapUseCase().BootstrapProject(ctx, bootstrapParams)
+		return err
+	}); err != nil {
+		FatalError("init: %v", err)
 	}
 
 	runInitProxiedServerTail(cmd, ctx, in, runInitTailContext{

--- a/internal/storage/dolt/errors.go
+++ b/internal/storage/dolt/errors.go
@@ -35,6 +35,13 @@ var (
 	// prevent propagating the corruption to the remote. Run bd dolt verify
 	// to diagnose and recover.
 	ErrDanglingReference = errors.New("dangling chunk reference")
+
+	// errCommitPhase marks an error as having occurred during tx.Commit (as
+	// opposed to BeginTx or the transaction body). A connection failure during
+	// commit is ambiguous — the commit may have landed on the server before the
+	// connection dropped — so withRetryTx must NOT blindly replay it, or it
+	// could double-apply the write. Pre-commit failures carry no such risk.
+	errCommitPhase = errors.New("write commit phase")
 )
 
 // isTableNotExistError returns true if the error indicates a MySQL/Dolt

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -488,6 +488,7 @@ var doltMetrics struct {
 	circuitTrips        metric.Int64Counter
 	circuitRejected     metric.Int64Counter
 	serializationErrors metric.Int64Counter
+	writeRetries        metric.Int64Counter
 	connAcquireMs       metric.Float64Histogram
 	poolWaitCount       metric.Int64Counter
 	poolWaitMs          metric.Float64Histogram
@@ -514,6 +515,10 @@ func init() {
 	doltMetrics.serializationErrors, _ = m.Int64Counter("bd.db.serialization_errors",
 		metric.WithDescription("Serialization failures (MySQL 1213/1205) before retry"),
 		metric.WithUnit("{error}"),
+	)
+	doltMetrics.writeRetries, _ = m.Int64Counter("bd.write_retries_total",
+		metric.WithDescription("Write-tx retries in withRetryTx (label: type=serialization|connection)"),
+		metric.WithUnit("{retry}"),
 	)
 	doltMetrics.connAcquireMs, _ = m.Float64Histogram("bd.db.conn_acquire_ms",
 		metric.WithDescription("Time to acquire a pooled connection for a Dolt transaction"),
@@ -632,14 +637,28 @@ func (s *DoltStore) withRetryTx(ctx context.Context, fn func(tx *sql.Tx) error) 
 	}
 	return backoff.Retry(func() error {
 		err := s.withWriteTx(ctx, fn)
-		if err != nil && isSerializationError(err) {
+		if err == nil {
+			return nil
+		}
+		// Serialization failures (1213/1205) guarantee a server-side rollback,
+		// so the write never landed — safe to replay at any phase.
+		if isSerializationError(err) {
 			doltMetrics.serializationErrors.Add(ctx, 1)
+			doltMetrics.writeRetries.Add(ctx, 1, metric.WithAttributes(attribute.String("type", "serialization")))
 			return err // retryable
 		}
-		if err != nil {
-			return backoff.Permanent(err)
+		// Connection failures are only safe to replay BEFORE commit (BeginTx or
+		// the body): nothing was committed. A failure tagged errCommitPhase is
+		// ambiguous — the commit may have landed before the connection dropped —
+		// so replaying could double-apply the write. Surface it instead.
+		if isRetryableError(err) {
+			if errors.Is(err, errCommitPhase) {
+				return backoff.Permanent(fmt.Errorf("write commit result indeterminate after connection loss (not retried to avoid double-apply): %w", err))
+			}
+			doltMetrics.writeRetries.Add(ctx, 1, metric.WithAttributes(attribute.String("type", "connection")))
+			return err // pre-commit transient: retryable
 		}
-		return nil
+		return backoff.Permanent(err)
 	}, backoff.WithContext(bo, ctx))
 }
 
@@ -655,7 +674,9 @@ func (s *DoltStore) withWriteTx(ctx context.Context, fn func(tx *sql.Tx) error) 
 		return errors.Join(err, tx.Rollback())
 	}
 	if err := tx.Commit(); err != nil {
-		return fmt.Errorf("commit write tx: %w", err)
+		// Tag commit-phase failures so withRetryTx can tell an ambiguous commit
+		// loss apart from a safe-to-replay pre-commit failure.
+		return fmt.Errorf("commit write tx: %w (%w)", err, errCommitPhase)
 	}
 	return nil
 }

--- a/internal/storage/uow/dolt_sql_provider.go
+++ b/internal/storage/uow/dolt_sql_provider.go
@@ -45,12 +45,25 @@ func (p *doltSQLProvider) Close(ctx context.Context) error {
 }
 
 func (p *doltSQLProvider) BeginTx(ctx context.Context) (Tx, error) {
-	conn, err := p.db.Conn(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("uow: pin connection: %w", err)
+	var conn *sql.Conn
+	bo := backoff.NewExponentialBackOff()
+	bo.InitialInterval = 50 * time.Millisecond
+	bo.MaxElapsedTime = 3 * time.Second
+	if err := backoff.Retry(func() error {
+		var connErr error
+		conn, connErr = p.db.Conn(ctx)
+		if connErr != nil {
+			if isSerializationError(connErr) || isInvalidConnectionError(connErr) {
+				return fmt.Errorf("uow: pin connection: %w", connErr)
+			}
+			return backoff.Permanent(fmt.Errorf("uow: pin connection: %w", connErr))
+		}
+		return nil
+	}, backoff.WithContext(bo, ctx)); err != nil {
+		return nil, err
 	}
 
-	_, err = conn.ExecContext(ctx, "START TRANSACTION;")
+	_, err := conn.ExecContext(ctx, "START TRANSACTION;")
 	if err != nil {
 		return nil, fmt.Errorf("uow: failed to start transaction: %w", err)
 	}

--- a/internal/storage/uow/errors.go
+++ b/internal/storage/uow/errors.go
@@ -2,6 +2,7 @@ package uow
 
 import (
 	"errors"
+	"strings"
 
 	mysql "github.com/go-sql-driver/mysql"
 )
@@ -16,4 +17,37 @@ func isSerializationError(err error) bool {
 		return false
 	}
 	return mysqlErr.Number == 1213 || mysqlErr.Number == 1205
+}
+
+// isInvalidConnectionError returns true if the error is a transient MySQL
+// driver connection failure (the dolt sql-server reaped an idle pooled
+// connection, the server restarted, the pipe broke, a brief network blip, etc.).
+//
+// This deliberately mirrors the connection-failure substrings recognised by the
+// DoltStore-layer classifier (internal/storage/dolt isRetryableError). The two
+// retry layers run over independent *sql.DB handles on parallel write paths —
+// uow.RunInTx backs the proxied-server create/init writes, withRetryTx backs the
+// DoltStore API writes — so they must agree on what "transient connection
+// failure" means, or the same server restart would retry on one path and surface
+// on the other. Storage-state transients that are NOT connection failures
+// (e.g. "database is read only", migration-lock) stay a DoltStore-layer concern
+// and are intentionally out of scope here.
+//
+// Whether retrying is SAFE depends on WHEN this fires, not just that it did:
+//   - Before commit (pinning a connection, starting the tx, or a write inside
+//     fn): nothing was committed, so replaying the whole sequence is safe.
+//   - At/after commit: the result is AMBIGUOUS — the commit may have landed on
+//     the server before the connection dropped. Callers must NOT blindly replay
+//     a commit-phase failure; see RunInTx for the phase-aware handling.
+func isInvalidConnectionError(err error) bool {
+	if err == nil {
+		return false
+	}
+	s := strings.ToLower(err.Error())
+	return strings.Contains(s, "invalid connection") ||
+		strings.Contains(s, "driver: bad connection") ||
+		strings.Contains(s, "lost connection") ||
+		strings.Contains(s, "broken pipe") ||
+		strings.Contains(s, "connection reset") ||
+		strings.Contains(s, "connection refused")
 }

--- a/internal/storage/uow/errors.go
+++ b/internal/storage/uow/errors.go
@@ -23,7 +23,7 @@ func isSerializationError(err error) bool {
 // driver connection failure (the dolt sql-server reaped an idle pooled
 // connection, the server restarted, the pipe broke, a brief network blip, etc.).
 //
-// This deliberately mirrors the connection-failure substrings recognised by the
+// This deliberately mirrors the connection-failure substrings recognized by the
 // DoltStore-layer classifier (internal/storage/dolt isRetryableError). The two
 // retry layers run over independent *sql.DB handles on parallel write paths —
 // uow.RunInTx backs the proxied-server create/init writes, withRetryTx backs the

--- a/internal/storage/uow/errors_test.go
+++ b/internal/storage/uow/errors_test.go
@@ -1,0 +1,39 @@
+package uow
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+func TestIsInvalidConnectionError(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{name: "nil", err: nil, expected: false},
+		{name: "invalid connection", err: errors.New("invalid connection"), expected: true},
+		{name: "driver: bad connection", err: errors.New("driver: bad connection"), expected: true},
+		{name: "lost connection", err: errors.New("Error 2013: Lost connection to MySQL server"), expected: true},
+		{name: "broken pipe", err: errors.New("write: broken pipe"), expected: true},
+		// Server restart / network blip — must match the DoltStore-layer
+		// classifier so the same failure retries on both parallel write paths.
+		{name: "connection reset", err: errors.New("read: connection reset by peer"), expected: true},
+		{name: "connection refused", err: errors.New("dial tcp 127.0.0.1:3306: connect: connection refused"), expected: true},
+		// Real driver errors arrive wrapped; the substring match must see through it.
+		{name: "wrapped connection refused", err: fmt.Errorf("uow: pin connection: %w", errors.New("connection refused")), expected: true},
+		{name: "case insensitive", err: errors.New("Invalid Connection"), expected: true},
+		{name: "syntax error - not retryable", err: errors.New("Error 1064: syntax error"), expected: false},
+		{name: "table not found - not retryable", err: errors.New("Error 1146: Table not found"), expected: false},
+		{name: "deadlock - not covered here", err: errors.New("Error 1213: Deadlock found"), expected: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isInvalidConnectionError(tt.err)
+			if got != tt.expected {
+				t.Errorf("isInvalidConnectionError(%v) = %v, want %v", tt.err, got, tt.expected)
+			}
+		})
+	}
+}

--- a/internal/storage/uow/run_in_tx.go
+++ b/internal/storage/uow/run_in_tx.go
@@ -1,0 +1,100 @@
+package uow
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/cenkalti/backoff/v4"
+)
+
+const defaultRunInTxMaxElapsed = 15 * time.Second
+
+// ErrCommitIndeterminate indicates that a transaction's commit could not be
+// confirmed because the connection failed at or after COMMIT. The write may or
+// may not have landed on the server, so the sequence is deliberately NOT
+// retried — replaying fn could double-apply (e.g. create a second issue). The
+// caller should re-read state to determine what happened.
+var ErrCommitIndeterminate = errors.New("commit result indeterminate after connection loss")
+
+// RunInTx opens a UnitOfWork, calls fn, and commits, retrying the whole
+// sequence on transient failures with phase-aware safety:
+//
+//   - Pre-commit failures (NewUOW, a connection pin, or a transient error
+//     raised by fn before COMMIT) leave nothing committed, so the sequence is
+//     replayed.
+//   - Serialization failures (1213/1205) guarantee a server-side rollback, so
+//     they are replayed at any phase.
+//   - A connection failure at/after COMMIT is AMBIGUOUS — the commit may have
+//     succeeded before the connection dropped. It is NOT retried; RunInTx
+//     returns ErrCommitIndeterminate so the caller can reconcile rather than
+//     risk a double-apply.
+//
+// Domain errors returned by fn are never retried.
+func RunInTx(ctx context.Context, p UnitOfWorkProvider, commitMsg string, fn func(uw UnitOfWork) error) error {
+	return RunInTxMsg(ctx, p, func(uw UnitOfWork) (string, error) {
+		return commitMsg, fn(uw)
+	})
+}
+
+// RunInTxMsg is like RunInTx but fn returns the commit message together with
+// any error, allowing callers whose message depends on the domain result to
+// compute it inside the same retry-safe closure.
+func RunInTxMsg(ctx context.Context, p UnitOfWorkProvider, fn func(uw UnitOfWork) (string, error)) error {
+	bo := backoff.NewExponentialBackOff()
+	bo.InitialInterval = 25 * time.Millisecond
+	bo.MaxElapsedTime = defaultRunInTxMaxElapsed
+
+	return backoff.Retry(func() error {
+		// Pre-commit: opening the unit of work pins a connection and starts the
+		// transaction. Nothing is committed yet, so transient failures replay.
+		uw, err := p.NewUOW(ctx)
+		if err != nil {
+			if isSerializationError(err) || isInvalidConnectionError(err) {
+				return err // retry
+			}
+			return backoff.Permanent(err)
+		}
+		defer uw.Close(ctx)
+
+		// Pre-commit: fn runs entirely inside the open transaction. A transient
+		// error here (e.g. the server reaped the connection mid-write) rolled
+		// the transaction back, so replaying the whole sequence is safe. A
+		// domain error (validation, not-found, already-claimed, ...) is final.
+		msg, err := fn(uw)
+		if err != nil {
+			if isSerializationError(err) || isInvalidConnectionError(err) {
+				return err // pre-commit transient: retry
+			}
+			return backoff.Permanent(err) // domain error: do not retry
+		}
+
+		// Commit phase: this is where retry safety gets subtle.
+		err = uw.Commit(ctx, msg)
+		switch {
+		case err == nil:
+			return nil
+		case isNothingToCommit(err):
+			return nil // no data changes to persist — idempotent success
+		case isSerializationError(err):
+			return err // server rolled the tx back — safe to replay
+		case isInvalidConnectionError(err):
+			// Ambiguous: the commit may have landed before the connection died.
+			// Retrying would re-run fn and could double-apply. Surface instead.
+			return backoff.Permanent(fmt.Errorf("%w: %w", ErrCommitIndeterminate, err))
+		default:
+			return backoff.Permanent(err)
+		}
+	}, backoff.WithContext(bo, ctx))
+}
+
+func isNothingToCommit(err error) bool {
+	if err == nil {
+		return false
+	}
+	s := strings.ToLower(err.Error())
+	return strings.Contains(s, "nothing to commit") ||
+		(strings.Contains(s, "no changes") && strings.Contains(s, "commit"))
+}

--- a/internal/storage/uow/run_in_tx_test.go
+++ b/internal/storage/uow/run_in_tx_test.go
@@ -1,0 +1,170 @@
+package uow
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	mysql "github.com/go-sql-driver/mysql"
+	"github.com/steveyegge/beads/internal/storage/domain"
+)
+
+// stubUOW implements UnitOfWork for testing. Only Commit and Close are used;
+// all use-case accessors panic if called (they shouldn't be in these tests).
+type stubUOW struct {
+	commitErr error
+	closed    bool
+}
+
+func (u *stubUOW) Close(_ context.Context)                     { u.closed = true }
+func (u *stubUOW) Commit(_ context.Context, _ string) error    { return u.commitErr }
+func (u *stubUOW) ConfigUseCase() domain.ConfigUseCase         { panic("not implemented") }
+func (u *stubUOW) DoltRemoteUseCase() domain.DoltRemoteUseCase { panic("not implemented") }
+func (u *stubUOW) BootstrapUseCase() domain.BootstrapUseCase   { panic("not implemented") }
+func (u *stubUOW) IssueUseCase() domain.IssueUseCase           { panic("not implemented") }
+func (u *stubUOW) DependencyUseCase() domain.DependencyUseCase { panic("not implemented") }
+func (u *stubUOW) LabelUseCase() domain.LabelUseCase           { panic("not implemented") }
+func (u *stubUOW) CommentUseCase() domain.CommentUseCase       { panic("not implemented") }
+
+// controlledProvider lets tests inject errors per-attempt.
+type controlledProvider struct {
+	attempts   int
+	newUOWErrs []error // per-attempt NewUOW error (nil = success)
+	commitErrs []error // per-attempt Commit error (nil = success)
+}
+
+func (p *controlledProvider) Close(_ context.Context) error { return nil }
+
+func (p *controlledProvider) NewUOW(_ context.Context) (UnitOfWork, error) {
+	i := p.attempts
+	p.attempts++
+	var newErr error
+	if i < len(p.newUOWErrs) {
+		newErr = p.newUOWErrs[i]
+	}
+	if newErr != nil {
+		return nil, newErr
+	}
+	var commitErr error
+	if i < len(p.commitErrs) {
+		commitErr = p.commitErrs[i]
+	}
+	return &stubUOW{commitErr: commitErr}, nil
+}
+
+func TestRunInTx_Success(t *testing.T) {
+	p := &controlledProvider{}
+	err := RunInTx(context.Background(), p, "test", func(_ UnitOfWork) error {
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if p.attempts != 1 {
+		t.Errorf("expected 1 attempt, got %d", p.attempts)
+	}
+}
+
+func TestRunInTx_RetryOnSerializationError(t *testing.T) {
+	deadlock := &mysql.MySQLError{Number: 1213, Message: "Deadlock found when trying to get lock"}
+	p := &controlledProvider{commitErrs: []error{deadlock, nil}}
+	err := RunInTx(context.Background(), p, "test", func(_ UnitOfWork) error {
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if p.attempts != 2 {
+		t.Errorf("expected 2 attempts (1 retry), got %d", p.attempts)
+	}
+}
+
+// A connection loss AT COMMIT is ambiguous (the commit may have landed before
+// the connection dropped), so it must NOT be retried — retrying could create a
+// duplicate. RunInTx returns ErrCommitIndeterminate after a single attempt.
+func TestRunInTx_CommitConnectionLossIsIndeterminate(t *testing.T) {
+	p := &controlledProvider{commitErrs: []error{errors.New("invalid connection"), nil}}
+	err := RunInTx(context.Background(), p, "test", func(_ UnitOfWork) error {
+		return nil
+	})
+	if !errors.Is(err, ErrCommitIndeterminate) {
+		t.Fatalf("expected ErrCommitIndeterminate, got: %v", err)
+	}
+	if p.attempts != 1 {
+		t.Errorf("commit-phase connection loss must not be retried: got %d attempts", p.attempts)
+	}
+}
+
+// A transient connection error raised INSIDE fn (before commit) leaves nothing
+// committed, so the whole sequence is safe to replay.
+func TestRunInTx_RetryOnTransientErrorInFn(t *testing.T) {
+	p := &controlledProvider{}
+	fnCalls := 0
+	err := RunInTx(context.Background(), p, "test", func(_ UnitOfWork) error {
+		fnCalls++
+		if fnCalls == 1 {
+			return errors.New("invalid connection")
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if fnCalls != 2 {
+		t.Errorf("pre-commit transient in fn must be retried: fn called %d times", fnCalls)
+	}
+}
+
+func TestRunInTx_RetryOnNewUOWConnectionError(t *testing.T) {
+	p := &controlledProvider{newUOWErrs: []error{errors.New("driver: bad connection"), nil}}
+	err := RunInTx(context.Background(), p, "test", func(_ UnitOfWork) error {
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if p.attempts != 2 {
+		t.Errorf("expected 2 attempts (1 retry), got %d", p.attempts)
+	}
+}
+
+func TestRunInTx_NoDomainErrorRetry(t *testing.T) {
+	domainErr := errors.New("ErrAlreadyClaimed")
+	fnCalls := 0
+	p := &controlledProvider{}
+	err := RunInTx(context.Background(), p, "test", func(_ UnitOfWork) error {
+		fnCalls++
+		return domainErr
+	})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if fnCalls != 1 {
+		t.Errorf("domain error must not be retried: fn called %d times", fnCalls)
+	}
+}
+
+func TestRunInTx_NothingToCommitIsSuccess(t *testing.T) {
+	p := &controlledProvider{commitErrs: []error{errors.New("nothing to commit")}}
+	err := RunInTx(context.Background(), p, "test", func(_ UnitOfWork) error {
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("nothing-to-commit should be treated as success, got: %v", err)
+	}
+}
+
+// RunInTxMsg shares the phase-aware commit handling: a commit-phase connection
+// loss is indeterminate and not retried.
+func TestRunInTxMsg_CommitConnectionLossIsIndeterminate(t *testing.T) {
+	p := &controlledProvider{commitErrs: []error{errors.New("invalid connection"), nil}}
+	err := RunInTxMsg(context.Background(), p, func(_ UnitOfWork) (string, error) {
+		return "test commit", nil
+	})
+	if !errors.Is(err, ErrCommitIndeterminate) {
+		t.Fatalf("expected ErrCommitIndeterminate, got: %v", err)
+	}
+	if p.attempts != 1 {
+		t.Errorf("commit-phase connection loss must not be retried: got %d attempts", p.attempts)
+	}
+}


### PR DESCRIPTION
## Why

Dolt server-mode write transactions need to retry transient failures (`1213`/`1205` serialization, `invalid connection`), but the existing approach retried **any** transient failure around the whole write — including a connection loss at `COMMIT`. That case is ambiguous: the commit can land on the server *before* the connection drops, so replaying re-runs `fn` (e.g. minting a second issue id) and **double-applies the write**. This makes the retry a data-integrity hazard rather than a fix.

## What

Phase-aware retries that separate pre-commit failures from ambiguous commit-result failures:

- **Pre-commit** (`NewUOW` / connection pin / a transient error raised by `fn` before `COMMIT`): nothing committed, so the whole sequence is safely replayed. Also fixes a gap where transient errors raised *inside* `fn` were previously dropped as permanent.
- **Serialization** (`1213`/`1205`): a guaranteed server-side rollback — replayed at any phase.
- **Connection loss at/after `COMMIT`**: ambiguous — **not** retried. Surfaced as `ErrCommitIndeterminate` (uow) / an indeterminate-commit error (dolt store) so the caller can reconcile instead of risking a duplicate.

`DoltStore.withRetryTx` gets the same treatment via an `errCommitPhase` tag on commit-phase failures. The uow and DoltStore connection classifiers are aligned (they run over independent `*sql.DB` handles on parallel write paths), so the same server restart retries consistently on both. The re-introduced `isRetryableWarmupError` (removed upstream) is dropped.

The read path is intentionally out of scope; idle-connection reaping on reads is handled separately by the `ConnMaxIdleTime` + `withReadTx` change.

## Relationship to #4355

This **builds on and supersedes #4355** by @bourgois, whose diagnosis and `internal/storage/uow` test scaffolding this is based on. Authorship is preserved — the commit is authored by @bourgois with `Co-authored-by` for both contributors. A new PR was opened (rather than updating #4355 in place) only because that PR's branch lives on an **org-owned fork**, which GitHub's "allow edits from maintainers" does not let maintainers push to. Once this lands, #4355 can be closed in its favor.

## Validation

- Rebased onto current `main`.
- Per-phase unit tests added, including the indeterminate-commit case (`TestRunInTx_CommitConnectionLossIsIndeterminate`, `…RetryOnTransientErrorInFn`, `…RetryOnSerializationError`, `…NoDomainErrorRetry`).
- Full `make test` green.

Closes #4354 (the issue #4355 was opened to fix).

_claude-opus-4-8-high on behalf of maphew_
