### PR TITLE
fix(compact): stop advertising the unimplemented Tier 2 compaction (#4463)

### DIFF
--- a/cmd/bd/compact.go
+++ b/cmd/bd/compact.go
@@ -51,7 +51,7 @@ Modes:
 
 Tiers:
   - Tier 1: Semantic compression (30 days closed, 70% reduction)
-  - Tier 2: Ultra compression (90 days closed, 95% reduction)
+  - Tier 2: Ultra compression (90 days closed) - planned, not yet implemented
 
 Dolt Garbage Collection:
   With auto-commit per mutation, Dolt commit history grows over time. Use
@@ -122,6 +122,13 @@ Examples:
 		}
 		if activeModes > 1 {
 			fmt.Fprintf(os.Stderr, "Error: cannot use multiple modes together (--analyze, --apply, --auto are mutually exclusive)\n")
+			os.Exit(1)
+		}
+
+		// Only Tier 1 compaction is implemented. Reject other tiers up front with
+		// a clear message rather than failing deep inside a mode.
+		if compactTier != 1 {
+			fmt.Fprintf(os.Stderr, "Error: Tier %d compaction is not yet implemented; only --tier 1 is available\n", compactTier)
 			os.Exit(1)
 		}
 
@@ -496,8 +503,9 @@ func runCompactStats(ctx context.Context, store storage.DoltStorage) {
 				"total_size": tier1Size,
 			},
 			"tier2": map[string]interface{}{
-				"candidates": len(tier2),
-				"total_size": tier2Size,
+				"candidates":  len(tier2),
+				"total_size":  tier2Size,
+				"implemented": false,
 			},
 		}
 		outputJSON(output)
@@ -512,12 +520,9 @@ func runCompactStats(ctx context.Context, store storage.DoltStorage) {
 		fmt.Printf("  Estimated savings: %d bytes (70%%)\n\n", tier1Size*7/10)
 	}
 
-	fmt.Printf("Tier 2 (90+ days closed, Tier 1 compacted):\n")
+	fmt.Printf("Tier 2 (90+ days closed, Tier 1 compacted): not yet implemented\n")
 	fmt.Printf("  Candidates: %d\n", len(tier2))
 	fmt.Printf("  Total size: %d bytes\n", tier2Size)
-	if tier2Size > 0 {
-		fmt.Printf("  Estimated savings: %d bytes (95%%)\n", tier2Size*95/100)
-	}
 }
 
 func runCompactAnalyze(ctx context.Context, store storage.DoltStorage) {
@@ -911,7 +916,7 @@ func progressBar(current, total int) string {
 
 func init() {
 	compactCmd.Flags().BoolVar(&compactDryRun, "dry-run", false, "Preview without compacting")
-	compactCmd.Flags().IntVar(&compactTier, "tier", 1, "Compaction tier (1 or 2)")
+	compactCmd.Flags().IntVar(&compactTier, "tier", 1, "Compaction tier (only tier 1 is implemented)")
 	compactCmd.Flags().BoolVar(&compactAll, "all", false, "Process all candidates")
 	compactCmd.Flags().StringVar(&compactID, "id", "", "Compact specific issue")
 	compactCmd.Flags().BoolVar(&compactForce, "force", false, "Force compact (bypass checks, requires --id)")

--- a/cmd/bd/compact_tier2_embedded_test.go
+++ b/cmd/bd/compact_tier2_embedded_test.go
@@ -1,0 +1,54 @@
+//go:build cgo
+
+package main
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// TestEmbeddedAdminCompactTier2Honesty verifies that the unimplemented Tier 2
+// is not advertised as a working capability: invoking it errors with a clear
+// "not yet implemented" message, and --stats does not promise Tier 2 savings.
+func TestEmbeddedAdminCompactTier2Honesty(t *testing.T) {
+	if os.Getenv("BEADS_TEST_EMBEDDED_DOLT") != "1" {
+		t.Skip("set BEADS_TEST_EMBEDDED_DOLT=1 to run embedded dolt integration tests")
+	}
+	t.Parallel()
+
+	bd := buildEmbeddedBD(t)
+	dir, _, _ := bdInit(t, bd, "--prefix", "t2")
+
+	t.Run("tier2_rejected", func(t *testing.T) {
+		// --analyze reaches the tier guard (read-only, direct-mode path).
+		cmd := exec.Command(bd, "admin", "compact", "--analyze", "--tier", "2")
+		cmd.Dir = dir
+		cmd.Env = bdEnv(dir)
+		out, err := cmd.CombinedOutput()
+		if err == nil {
+			t.Fatalf("expected --tier 2 to fail, but succeeded:\n%s", out)
+		}
+		if !strings.Contains(string(out), "not yet implemented") {
+			t.Errorf("expected 'not yet implemented' message, got:\n%s", out)
+		}
+	})
+
+	t.Run("stats_does_not_advertise_tier2", func(t *testing.T) {
+		cmd := exec.Command(bd, "admin", "compact", "--stats")
+		cmd.Dir = dir
+		cmd.Env = bdEnv(dir)
+		stdout, stderr, err := runCommandBuffers(t, cmd)
+		if err != nil {
+			t.Fatalf("bd admin compact --stats failed: %v\nstdout:\n%s\nstderr:\n%s", err, stdout.String(), stderr.String())
+		}
+		out := stdout.String()
+		if !strings.Contains(out, "not yet implemented") {
+			t.Errorf("expected Tier 2 to be marked 'not yet implemented' in --stats, got:\n%s", out)
+		}
+		if strings.Contains(out, "95%") {
+			t.Errorf("--stats still advertises a Tier 2 savings estimate (95%%):\n%s", out)
+		}
+	})
+}

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -4658,7 +4658,7 @@ Modes:
 
 Tiers:
   - Tier 1: Semantic compression (30 days closed, 70% reduction)
-  - Tier 2: Ultra compression (90 days closed, 95% reduction)
+  - Tier 2: Ultra compression (90 days closed) - planned, not yet implemented
 
 Dolt Garbage Collection:
   With auto-commit per mutation, Dolt commit history grows over time. Use
@@ -4707,7 +4707,7 @@ bd admin compact [flags]
       --limit int        Limit number of candidates (0 = no limit)
       --stats            Show compaction statistics
       --summary string   Path to summary file (use '-' for stdin)
-      --tier int         Compaction tier (1 or 2) (default 1)
+      --tier int         Compaction tier (only tier 1 is implemented) (default 1)
       --workers int      Parallel workers (default 5)
 ```
 

--- a/examples/compaction/README.md
+++ b/examples/compaction/README.md
@@ -65,17 +65,17 @@ chmod +x auto-compact.sh
 # Custom threshold
 ./auto-compact.sh --threshold 50
 
-# Tier 2 ultra-compression
-./auto-compact.sh --tier 2 --threshold 20
-
 # Preview without compacting
 ./auto-compact.sh --dry-run
 ```
 
+(Tier 2 ultra-compression is planned but not yet implemented; only `--tier 1`
+works today.)
+
 **Features:**
 - Configurable eligibility threshold
 - Skips compaction if below threshold
-- Supports both tiers
+- Tier 1 semantic compression (Tier 2 planned)
 - Dry-run mode for testing
 
 **When to use:** 

--- a/plugins/beads/skills/beads/commands/compact.md
+++ b/plugins/beads/skills/beads/commands/compact.md
@@ -8,7 +8,7 @@ Reduce database size by summarizing closed issues no longer actively referenced.
 ## Compaction Tiers
 
 - **Tier 1**: Semantic compression (30+ days closed, ~70% size reduction)
-- **Tier 2**: Ultra compression (90+ days closed, ~95% size reduction)
+- **Tier 2**: Ultra compression (90+ days closed) — planned, not yet implemented
 
 ## Usage
 

--- a/website/docs/cli-reference/admin.md
+++ b/website/docs/cli-reference/admin.md
@@ -81,7 +81,7 @@ Modes:
 
 Tiers:
   - Tier 1: Semantic compression (30 days closed, 70% reduction)
-  - Tier 2: Ultra compression (90 days closed, 95% reduction)
+  - Tier 2: Ultra compression (90 days closed) - planned, not yet implemented
 
 Dolt Garbage Collection:
   With auto-commit per mutation, Dolt commit history grows over time. Use
@@ -130,7 +130,7 @@ bd admin compact [flags]
       --limit int        Limit number of candidates (0 = no limit)
       --stats            Show compaction statistics
       --summary string   Path to summary file (use '-' for stdin)
-      --tier int         Compaction tier (1 or 2) (default 1)
+      --tier int         Compaction tier (only tier 1 is implemented) (default 1)
       --workers int      Parallel workers (default 5)
 ```
 

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -2947,7 +2947,7 @@ Modes:
 
 Tiers:
   - Tier 1: Semantic compression (30 days closed, 70% reduction)
-  - Tier 2: Ultra compression (90 days closed, 95% reduction)
+  - Tier 2: Ultra compression (90 days closed) - planned, not yet implemented
 
 Dolt Garbage Collection:
   With auto-commit per mutation, Dolt commit history grows over time. Use
@@ -2996,7 +2996,7 @@ bd admin compact [flags]
       --limit int        Limit number of candidates (0 = no limit)
       --stats            Show compaction statistics
       --summary string   Path to summary file (use '-' for stdin)
-      --tier int         Compaction tier (1 or 2) (default 1)
+      --tier int         Compaction tier (only tier 1 is implemented) (default 1)
       --workers int      Parallel workers (default 5)
 ```
 

--- a/website/versioned_docs/version-1.0.0/cli-reference/admin.md
+++ b/website/versioned_docs/version-1.0.0/cli-reference/admin.md
@@ -81,7 +81,7 @@ Modes:
 
 Tiers:
   - Tier 1: Semantic compression (30 days closed, 70% reduction)
-  - Tier 2: Ultra compression (90 days closed, 95% reduction)
+  - Tier 2: Ultra compression (90 days closed) - planned, not yet implemented
 
 Dolt Garbage Collection:
   With auto-commit per mutation, Dolt commit history grows over time. Use
@@ -130,7 +130,7 @@ bd admin compact [flags]
       --limit int        Limit number of candidates (0 = no limit)
       --stats            Show compaction statistics
       --summary string   Path to summary file (use '-' for stdin)
-      --tier int         Compaction tier (1 or 2) (default 1)
+      --tier int         Compaction tier (only tier 1 is implemented) (default 1)
       --workers int      Parallel workers (default 5)
 ```
 

--- a/website/versioned_docs/version-1.0.4/cli-reference/admin.md
+++ b/website/versioned_docs/version-1.0.4/cli-reference/admin.md
@@ -81,7 +81,7 @@ Modes:
 
 Tiers:
   - Tier 1: Semantic compression (30 days closed, 70% reduction)
-  - Tier 2: Ultra compression (90 days closed, 95% reduction)
+  - Tier 2: Ultra compression (90 days closed) - planned, not yet implemented
 
 Dolt Garbage Collection:
   With auto-commit per mutation, Dolt commit history grows over time. Use
@@ -130,7 +130,7 @@ bd admin compact [flags]
       --limit int        Limit number of candidates (0 = no limit)
       --stats            Show compaction statistics
       --summary string   Path to summary file (use '-' for stdin)
-      --tier int         Compaction tier (1 or 2) (default 1)
+      --tier int         Compaction tier (only tier 1 is implemented) (default 1)
       --workers int      Parallel workers (default 5)
 ```
 

--- a/website/versioned_docs/version-1.0.5/cli-reference/admin.md
+++ b/website/versioned_docs/version-1.0.5/cli-reference/admin.md
@@ -81,7 +81,7 @@ Modes:
 
 Tiers:
   - Tier 1: Semantic compression (30 days closed, 70% reduction)
-  - Tier 2: Ultra compression (90 days closed, 95% reduction)
+  - Tier 2: Ultra compression (90 days closed) - planned, not yet implemented
 
 Dolt Garbage Collection:
   With auto-commit per mutation, Dolt commit history grows over time. Use
@@ -130,7 +130,7 @@ bd admin compact [flags]
       --limit int        Limit number of candidates (0 = no limit)
       --stats            Show compaction statistics
       --summary string   Path to summary file (use '-' for stdin)
-      --tier int         Compaction tier (1 or 2) (default 1)
+      --tier int         Compaction tier (only tier 1 is implemented) (default 1)
       --workers int      Parallel workers (default 5)
 ```
 


### PR DESCRIPTION
## Why

`bd admin compact --tier 2` hard-errors "Tier 2 compaction not yet implemented",
yet the surface advertised it as a working capability:

- command help: "Tier 2: Ultra compression (90 days closed, 95% reduction)"
- `--stats`: printed a "Tier 2 … Estimated savings 95%" line
- the plugin skill doc, the examples README, and the generated CLI reference
  repeated the 95% claim

That is a false promise — users (and agents reading `--stats --json`) can't tell
the feature is a stub. This is defect No.2 of #4463.

## What

Make the surface honest. No attempt is made to *implement* Tier 2 — its
semantics are undefined and inventing them is out of scope; this only removes
the false advertising.

- Reject `--tier != 1` early with `Tier N compaction is not yet implemented;
  only --tier 1 is available`, instead of failing deep inside a mode.
- `--stats` labels Tier 2 "not yet implemented" and drops the 95% estimate;
  the JSON `tier2` block gains `"implemented": false`.
- Update the command help, the `--tier` flag help, the plugin skill doc, and the
  examples README; regenerate the generated CLI reference.

## Tests

- New embedded e2e (`TestEmbeddedAdminCompactTier2Honesty`): `--tier 2` errors
  with "not yet implemented"; `--stats` says "not yet implemented" and no longer
  contains "95%".
- `go build` / `go vet` / `gofmt` clean; doc-flags freshness passes locally;
  full `make test` enqueued.

## Scope of #4463

With this, the issue's defects are dispositioned:

- **No.1 (data-safety / dead tables)** — fixed in #4464 (merged).
- **No.2 (Tier 2 advertised)** — this PR.
- **No.3 (no automation)** — by design: per the Project Charter's Orchestration
  Boundary, scheduling/threshold triggers belong to the orchestration layer, not
  core beads. Not building auto-compaction into core.
- **No.4 (bd compact vs bd admin compact naming)** — the *hazard* (history-squash
  erasing the rows restore relied on) is gone now that restore reads the
  snapshot table (#4464), and the two commands already cross-reference in help.
  What remains is cosmetic; tracked as optional polish.

---
_claude-opus-4-8-high on behalf of maphew_
