### PR TITLE
fix(create): reject cross-table ID collisions between issues and wisps (#4455)

### DIFF
--- a/internal/storage/embeddeddolt/cross_table_id_collision_test.go
+++ b/internal/storage/embeddeddolt/cross_table_id_collision_test.go
@@ -1,0 +1,114 @@
+//go:build cgo
+
+package embeddeddolt_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// TestCreateRejectsCrossTableIDCollision is the regression test for GH#4455:
+// `bd create` must never put the same ID in both the issues and wisps tables.
+// Issues and wisps share one ID space but live in separate tables, so a dual
+// presence row makes merge-based lookups (bd ready/search) hard-error for the
+// whole store. The fix rejects a create whose ID already exists in the sibling
+// table; #4163 only made the lookups tolerant of an already-corrupted store.
+func TestCreateRejectsCrossTableIDCollision(t *testing.T) {
+	skipUnlessEmbeddedDolt(t)
+
+	ctx := t.Context()
+
+	// Direction 1: permanent issue first, then a wisp with the same ID.
+	t.Run("issue then wisp", func(t *testing.T) {
+		te := newTestEnv(t, "ct")
+		if err := te.store.CreateIssue(ctx, &types.Issue{
+			ID: "ct-aaa", Title: "perm", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask,
+		}, "tester"); err != nil {
+			t.Fatalf("create permanent issue: %v", err)
+		}
+		err := te.store.CreateIssue(ctx, &types.Issue{
+			ID: "ct-aaa", Title: "wisp", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask, Ephemeral: true,
+		}, "tester")
+		if err == nil {
+			t.Fatal("expected cross-table collision to be rejected, got nil error")
+		}
+		if !strings.Contains(err.Error(), "already exists in the issues table") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		// The wisp must not have been written.
+		var wispCount int
+		te.queryScalar(t, ctx, "SELECT COUNT(*) FROM wisps WHERE id = ?", []any{"ct-aaa"}, &wispCount)
+		if wispCount != 0 {
+			t.Fatalf("colliding wisp was written: wisps rows = %d, want 0", wispCount)
+		}
+	})
+
+	// Direction 2: wisp first, then a permanent issue with the same ID.
+	t.Run("wisp then issue", func(t *testing.T) {
+		te := newTestEnv(t, "ct")
+		if err := te.store.CreateIssue(ctx, &types.Issue{
+			ID: "ct-bbb", Title: "wisp", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask, Ephemeral: true,
+		}, "tester"); err != nil {
+			t.Fatalf("create wisp: %v", err)
+		}
+		err := te.store.CreateIssue(ctx, &types.Issue{
+			ID: "ct-bbb", Title: "perm", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask,
+		}, "tester")
+		if err == nil {
+			t.Fatal("expected cross-table collision to be rejected, got nil error")
+		}
+		if !strings.Contains(err.Error(), "already exists in the wisps table") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		var issueCount int
+		te.queryScalar(t, ctx, "SELECT COUNT(*) FROM issues WHERE id = ?", []any{"ct-bbb"}, &issueCount)
+		if issueCount != 0 {
+			t.Fatalf("colliding issue was written: issues rows = %d, want 0", issueCount)
+		}
+	})
+
+	// Non-regression: re-creating an ID in its own table still upserts.
+	t.Run("same table recreate still allowed", func(t *testing.T) {
+		te := newTestEnv(t, "ct")
+		mk := func(title string) error {
+			return te.store.CreateIssue(ctx, &types.Issue{
+				ID: "ct-ccc", Title: title, Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask,
+			}, "tester")
+		}
+		if err := mk("first"); err != nil {
+			t.Fatalf("first create: %v", err)
+		}
+		if err := mk("second"); err != nil {
+			t.Fatalf("same-table recreate must still succeed, got: %v", err)
+		}
+	})
+}
+
+// TestPromoteStillWorksWithCollisionGuard locks in the carve-out: promotion
+// inserts into issues while the wisp row still exists (PromoteFromEphemeralInTx),
+// then deletes the wisp. It calls InsertIssueIfNew directly and bypasses the
+// create-path collision guard, so promotion must remain unaffected.
+func TestPromoteStillWorksWithCollisionGuard(t *testing.T) {
+	skipUnlessEmbeddedDolt(t)
+
+	ctx := t.Context()
+	te := newTestEnv(t, "ct")
+
+	if err := te.store.CreateIssue(ctx, &types.Issue{
+		ID: "ct-eph", Title: "ephemeral", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask, Ephemeral: true,
+	}, "tester"); err != nil {
+		t.Fatalf("create ephemeral wisp: %v", err)
+	}
+	if err := te.store.PromoteFromEphemeral(ctx, "ct-eph", "tester"); err != nil {
+		t.Fatalf("promote must succeed despite collision guard: %v", err)
+	}
+
+	var issueCount, wispCount int
+	te.queryScalar(t, ctx, "SELECT COUNT(*) FROM issues WHERE id = ?", []any{"ct-eph"}, &issueCount)
+	te.queryScalar(t, ctx, "SELECT COUNT(*) FROM wisps WHERE id = ?", []any{"ct-eph"}, &wispCount)
+	if issueCount != 1 || wispCount != 0 {
+		t.Fatalf("after promote: issues=%d wisps=%d, want issues=1 wisps=0", issueCount, wispCount)
+	}
+}

--- a/internal/storage/issueops/create.go
+++ b/internal/storage/issueops/create.go
@@ -110,6 +110,12 @@ func CreateIssueInTxWithResult(ctx context.Context, tx *sql.Tx, bc *BatchContext
 		}
 	}
 
+	if skip, err := checkCrossTableIDCollision(ctx, tx, issue.ID, issueTable, bc.Opts); err != nil {
+		return result, err
+	} else if skip {
+		return result, nil
+	}
+
 	if skip, err := CheckOrphan(ctx, tx, issue, issueTable, bc.Opts.OrphanHandling); err != nil {
 		return result, err
 	} else if skip {
@@ -512,6 +518,44 @@ func CheckOrphan(ctx context.Context, tx *sql.Tx, issue *types.Issue, issueTable
 	default: // OrphanAllow, OrphanResurrect
 		return false, nil
 	}
+}
+
+// checkCrossTableIDCollision rejects a create whose ID already lives in the
+// sibling table (GH#4455). Issues and wisps share one ID space but live in
+// separate tables; an ID present in both makes the merge-based lookups
+// (bd ready/search) hard-error for the whole store. The target-table
+// existence check in InsertIssueIfNew only sees one table, so nothing else in
+// the create path closes this hole.
+//
+// Promotion (PromoteFromEphemeralInTx) deliberately inserts into issues while
+// the wisp row still exists, then deletes the wisp — but it calls
+// InsertIssueIfNew directly and never routes through here, so its transient
+// dual-presence window is unaffected.
+//
+// ConflictSkip is the auto-import upgrade-recovery path (GH#3955), which must
+// never hard-fail; there we skip the colliding row instead (lookups stay
+// tolerant via GH#4163).
+//
+//nolint:gosec // G201: siblingTable is one of two hardcoded constants
+func checkCrossTableIDCollision(ctx context.Context, tx *sql.Tx, id, issueTable string, opts storage.BatchCreateOptions) (skip bool, err error) {
+	if id == "" {
+		return false, nil
+	}
+	siblingTable := "wisps"
+	if issueTable == "wisps" {
+		siblingTable = "issues"
+	}
+	var siblingCount int
+	if err := tx.QueryRowContext(ctx, fmt.Sprintf(`SELECT COUNT(*) FROM %s WHERE id = ?`, siblingTable), id).Scan(&siblingCount); err != nil {
+		return false, fmt.Errorf("failed to check cross-table ID collision for %s: %w", id, err)
+	}
+	if siblingCount == 0 {
+		return false, nil
+	}
+	if opts.ConflictSkip {
+		return true, nil
+	}
+	return false, fmt.Errorf("cannot create %q: ID already exists in the %s table (issues and wisps share one ID space)", id, siblingTable)
 }
 
 // InsertIssueIfNew inserts the issue and returns whether it was genuinely new,


### PR DESCRIPTION
Fixes #4455.

## Problem

`bd create` would put the **same ID in both the `issues` and `wisps` tables**. A normal issue and a `--no-history`/`--ephemeral` wisp created with the same explicit `--id` both succeed silently:

```
$ bd create "perm copy" --id prev-aaa --type task                 # ✓ rc=0
$ bd create "wisp copy" --id prev-aaa --no-history --type task     # ✓ rc=0  <-- no guard
```

The resulting dual-presence row makes the merge-based lookups (`bd ready`, `bd search`) hard-error for the entire store. #4163 made those lookups *tolerant* of an already-corrupted store (and added a `bd doctor` repair) but did **not** prevent the dup from being created. This PR closes the prevention gap.

## Root cause

The existence check in `InsertIssueIfNew` only ever queries the **target** table (`issues` OR `wisps`, never both), and nothing else in the create path enforces cross-table ID uniqueness.

## Fix

Add `checkCrossTableIDCollision` to the create path (`CreateIssueInTxWithResult`): a create whose ID already lives in the sibling table is refused with a clear error.

```
$ bd create "wisp copy" --id prev-aaa --no-history --type task
Error: cannot create "prev-aaa": ID already exists in the issues table (issues and wisps share one ID space)
```

Two paths are deliberately carved out:

- **Promotion** (`PromoteFromEphemeralInTx`) inserts into `issues` while the wisp row still exists, then deletes the wisp. It calls `InsertIssueIfNew` directly and bypasses `CreateIssueInTxWithResult`, so its transient dual-presence window is unaffected.
- **Auto-import upgrade-recovery** (`ConflictSkip`, GH#3955) must never hard-fail on startup, so it *skips* the colliding row instead of erroring (lookups stay tolerant via #4163).

Guard runs in both collision directions and reuses the existing single-transaction create path, so it works in embedded mode and for sequential `bd create` invocations in server mode.

## Testing

Added `internal/storage/embeddeddolt/cross_table_id_collision_test.go` covering:
- issue-then-wisp and wisp-then-issue collisions are both rejected and write nothing;
- same-table re-create still upserts (no regression);
- promotion of an ephemeral wisp still succeeds with the guard in place.

Verified the test **fails without the fix** and passes with it. Full `internal/storage/issueops` and `internal/storage/embeddeddolt` suites pass (`BEADS_TEST_EMBEDDED_DOLT=1`, `-tags gms_pure_go`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)