### PR TITLE
feat(dolt): query-level connection pooler to collapse Dolt connection churn

### DIFF
--- a/cmd/bd/db_proxy_child.go
+++ b/cmd/bd/db_proxy_child.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -29,6 +30,8 @@ var (
 	dbProxyChildExternalTLSCertPath string
 	dbProxyChildExternalTLSKeyPath  string
 	dbProxyChildExternalKeepAlive   time.Duration
+	dbProxyChildPoolSocket          string
+	dbProxyChildPoolSize            int
 )
 
 var dbProxyChildCmd = &cobra.Command{
@@ -58,6 +61,13 @@ not intended to be invoked directly by users.`,
 			KeepAlivePeriod: dbProxyChildExternalKeepAlive,
 		}
 
+		// Pooled mode: serve the QUERY-LEVEL connection pooler on a unix socket
+		// instead of the TCP byte-passthrough proxy, reusing the same lifecycle
+		// scaffolding (lock, pidfile, log, signal handling, idle shutdown).
+		if backend == proxy.BackendExternalPooled {
+			return runPooledProxyChild(cmd.Context(), external)
+		}
+
 		srv, err := newDatabaseServer(backend, dbProxyChildRoot, dbProxyChildConfig, dbProxyChildLogPath, dbProxyChildDoltBin, external)
 		if err != nil {
 			return err
@@ -77,6 +87,35 @@ not intended to be invoked directly by users.`,
 		}
 		return nil
 	},
+}
+
+// runPooledProxyChild runs the pooled (query-level) serving mode. The upstream
+// Dolt address comes from the external config; clients are served on the
+// pool socket recorded in the pidfile.
+func runPooledProxyChild(ctx context.Context, external configfile.ExternalDoltConfig) error {
+	if dbProxyChildPoolSocket == "" {
+		return fmt.Errorf("backend %q requires --pool-socket", proxy.BackendExternalPooled)
+	}
+	doltAddr := ""
+	if external.Host != "" {
+		doltAddr = fmt.Sprintf("%s:%d", external.Host, external.Port)
+	}
+	p := proxy.NewPooledServer(proxy.PooledOpts{
+		RootDir:     dbProxyChildRoot,
+		Socket:      dbProxyChildPoolSocket,
+		DoltAddr:    doltAddr,
+		DoltSocket:  external.Socket,
+		DoltUser:    external.User,
+		PoolSize:    dbProxyChildPoolSize,
+		IdleTimeout: dbProxyChildIdleTimeout,
+	})
+	if err := p.ListenAndServe(ctx); err != nil {
+		if errors.Is(err, proxy.ErrLockHeld) {
+			os.Exit(proxy.LockHeldExitCode)
+		}
+		return err
+	}
+	return nil
 }
 
 func newDatabaseServer(backend proxy.Backend, rootDir, configPath, logPath, doltBin string, external configfile.ExternalDoltConfig) (server.DatabaseServer, error) {
@@ -107,6 +146,8 @@ func init() {
 	dbProxyChildCmd.Flags().StringVar(&dbProxyChildExternalTLSCertPath, "external-tls-cert-path", "", "external backend: absolute path to client TLS certificate (mTLS)")
 	dbProxyChildCmd.Flags().StringVar(&dbProxyChildExternalTLSKeyPath, "external-tls-key-path", "", "external backend: absolute path to client TLS private key (mTLS)")
 	dbProxyChildCmd.Flags().DurationVar(&dbProxyChildExternalKeepAlive, "external-keep-alive", 0, "external backend: TCP keepalive period (default 30s)")
+	dbProxyChildCmd.Flags().StringVar(&dbProxyChildPoolSocket, "pool-socket", "", "pooled backend: unix socket path the pooler listens on for clients")
+	dbProxyChildCmd.Flags().IntVar(&dbProxyChildPoolSize, "pool-size", 0, "pooled backend: number of persistent backend connections (default 16, min 4)")
 	_ = dbProxyChildCmd.MarkFlagRequired("root")
 	_ = dbProxyChildCmd.MarkFlagRequired("port")
 	_ = dbProxyChildCmd.MarkFlagRequired("backend")

--- a/go.mod
+++ b/go.mod
@@ -140,7 +140,7 @@ require (
 	github.com/dolthub/gozstd v0.0.0-20240423170813-23a2903bca63 // indirect
 	github.com/dolthub/ishell v0.0.0-20260414231531-5f031e3e9037 // indirect
 	github.com/dolthub/jsonpath v0.0.2-0.20240227200619-19675ab05c71 // indirect
-	github.com/dolthub/vitess v0.0.0-20260604210335-0893abc80542 // indirect
+	github.com/dolthub/vitess v0.0.0-20260604210335-0893abc80542
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/ebitengine/purego v0.10.0 // indirect
 	github.com/edsrzf/mmap-go v1.2.0 // indirect

--- a/internal/storage/dbproxy/pidfile/pidfile.go
+++ b/internal/storage/dbproxy/pidfile/pidfile.go
@@ -14,6 +14,10 @@ type PidFile struct {
 	Pid        int    `json:"pid"`
 	Port       int    `json:"port"`
 	UpstreamID string `json:"upstream_id,omitempty"`
+	// Socket is the unix-domain socket path a server listens on, used by the
+	// pooled (query-level) proxy mode instead of a TCP port. Empty for the TCP
+	// byte-passthrough proxy.
+	Socket string `json:"socket,omitempty"`
 }
 
 func Path(rootDir, name string) string {

--- a/internal/storage/dbproxy/pool/backend.go
+++ b/internal/storage/dbproxy/pool/backend.go
@@ -1,0 +1,155 @@
+package pool
+
+import (
+	"fmt"
+	"io"
+	"net"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/dolthub/vitess/go/mysql"
+	"github.com/dolthub/vitess/go/sqltypes"
+)
+
+// backend is one persistent connection to Dolt, held across many client
+// sessions. The win of the pooler is that Dolt sees a fixed set of these
+// regardless of how many short-lived clients connect and disconnect.
+//
+// A backend may be borrowed (pinned to a client connection) or idle (in the
+// pool). The keepalive loop must be able to ping EITHER without racing the
+// client's queries, so all wire I/O on a backend is serialized by mu. The
+// client handler and the keepalive both take mu for the duration of one
+// command/ping, which keeps a long-idle BORROWED backend alive (a client conn
+// that go-sql-driver holds open but isn't actively querying) without ever
+// dropping its session state.
+type backend struct {
+	id int
+
+	mu    sync.Mutex
+	conn  *mysql.Conn // vitess client conn; full handshake done once at warmup
+	curDB string      // currently-USEd database, so we only switch when needed
+}
+
+const resetIOTimeout = 5 * time.Second
+
+// connParams builds vitess ConnParams for dialing Dolt with NO default
+// database. Connecting with no DB means COM_RESET_CONNECTION restores the
+// backend to a clean "no DB" state; the pooler applies each client's database
+// per checkout via ComInitDB.
+func connParams(cfg Config) (*mysql.ConnParams, error) {
+	cp := &mysql.ConnParams{Uname: cfg.User}
+	if cfg.Socket != "" {
+		cp.UnixSocket = cfg.Socket
+		return cp, nil
+	}
+	host, port, err := splitHostPort(cfg.Addr)
+	if err != nil {
+		return nil, err
+	}
+	cp.Host = host
+	cp.Port = port
+	return cp, nil
+}
+
+func splitHostPort(addr string) (string, int, error) {
+	host, portStr, err := net.SplitHostPort(addr)
+	if err != nil {
+		return "", 0, fmt.Errorf("pool: parse addr %q: %w", addr, err)
+	}
+	port, err := strconv.Atoi(portStr)
+	if err != nil {
+		return "", 0, fmt.Errorf("pool: parse port in %q: %w", addr, err)
+	}
+	return host, port, nil
+}
+
+func (b *backend) close() {
+	if b != nil && b.conn != nil {
+		b.conn.Close()
+	}
+}
+
+// exec runs a text query on the backend, serialized against keepalive pings.
+func (b *backend) exec(query string, maxrows int) (*sqltypes.Result, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.conn.ExecuteFetch(query, maxrows, true)
+}
+
+// ping checks backend liveness, serialized against client queries. Used by the
+// keepalive loop and the borrow-time liveness check.
+func (b *backend) ping() error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.conn.Ping()
+}
+
+// useDB ensures the backend's default database matches the client's request.
+// It is a no-op when the database is already current, which keeps the common
+// case (all clients on the same DB) free of redundant USE round-trips.
+func (b *backend) useDB(db string) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if db == "" || db == b.curDB {
+		return nil
+	}
+	if _, err := b.conn.ExecuteFetch("USE `"+escapeIdent(db)+"`", 1, false); err != nil {
+		return err
+	}
+	b.curDB = db
+	return nil
+}
+
+func escapeIdent(s string) string {
+	return strings.ReplaceAll(s, "`", "``")
+}
+
+// reset clears all session state so the backend is safe for the next client.
+//
+// It sends a raw COM_RESET_CONNECTION (0x1f) packet directly on the underlying
+// net.Conn. The vitess client Conn does not expose a method to send this, but
+// its `.Conn` (net.Conn) field is exported. Empirically Dolt's
+// COM_RESET_CONNECTION clears: default DB (-> connect-time DB, i.e. none here),
+// user vars, session vars (autocommit), AND the Dolt active branch — fully
+// restoring a clean session.
+//
+// Only safe to call at a session boundary with no ExecuteFetch in flight, i.e.
+// when vitess's read buffer for this conn is fully drained.
+func (b *backend) reset() error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	nc := b.conn.Conn
+	// COM_RESET_CONNECTION: 4-byte header (len=1, seq=0) + 1-byte payload 0x1f.
+	pkt := []byte{0x01, 0x00, 0x00, 0x00, 0x1f}
+	if err := nc.SetWriteDeadline(time.Now().Add(resetIOTimeout)); err != nil {
+		return err
+	}
+	if _, err := nc.Write(pkt); err != nil {
+		return err
+	}
+	if err := nc.SetReadDeadline(time.Now().Add(resetIOTimeout)); err != nil {
+		return err
+	}
+	hdr := make([]byte, 4)
+	if _, err := io.ReadFull(nc, hdr); err != nil {
+		return fmt.Errorf("read reset reply header: %w", err)
+	}
+	n := int(hdr[0]) | int(hdr[1])<<8 | int(hdr[2])<<16
+	body := make([]byte, n)
+	if _, err := io.ReadFull(nc, body); err != nil {
+		return fmt.Errorf("read reset reply body: %w", err)
+	}
+	_ = nc.SetReadDeadline(time.Time{})
+	_ = nc.SetWriteDeadline(time.Time{})
+	if len(body) > 0 && body[0] == 0xff {
+		msg := ""
+		if len(body) > 3 {
+			msg = string(body[3:])
+		}
+		return fmt.Errorf("COM_RESET_CONNECTION error: %s", msg)
+	}
+	b.curDB = "" // reset restored to connect-time DB (none)
+	return nil
+}

--- a/internal/storage/dbproxy/pool/config_env.go
+++ b/internal/storage/dbproxy/pool/config_env.go
@@ -1,0 +1,64 @@
+package pool
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+)
+
+// Environment variables that gate and tune the connection pooler. The pooler is
+// OFF unless EnvEnabled is truthy, so nothing about bd's behavior changes by
+// default.
+const (
+	// EnvEnabled, when set to a truthy value (1/true/yes/on), routes bd's
+	// external-Dolt traffic through the query-level connection pooler instead
+	// of the TCP byte-passthrough proxy.
+	EnvEnabled = "BEADS_DOLT_POOL"
+	// EnvSize overrides the number of persistent backend connections the pooler
+	// holds open to Dolt (default DefaultSize, clamped to >= MinSize).
+	EnvSize = "BEADS_DOLT_POOL_SIZE"
+	// EnvSocket overrides the unix socket path the pooler listens on. When
+	// unset, a path under the proxy root dir is used.
+	EnvSocket = "BEADS_DOLT_POOL_SOCKET"
+)
+
+// PoolSocketName is the default pooler socket filename placed under the proxy
+// root dir when EnvSocket is unset.
+const PoolSocketName = "pool.sock"
+
+// EnabledFromEnv reports whether the pooler is opted in via EnvEnabled.
+func EnabledFromEnv() bool {
+	return truthy(os.Getenv(EnvEnabled))
+}
+
+// SizeFromEnv returns the configured pool size, or 0 when unset/invalid (the
+// caller then falls back to DefaultSize).
+func SizeFromEnv() int {
+	v := os.Getenv(EnvSize)
+	if v == "" {
+		return 0
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil || n <= 0 {
+		return 0
+	}
+	return n
+}
+
+// SocketFromEnv returns the operator-configured pooler socket path, or a
+// default under rootDir when unset.
+func SocketFromEnv(rootDir string) string {
+	if v := os.Getenv(EnvSocket); v != "" {
+		return v
+	}
+	return filepath.Join(rootDir, PoolSocketName)
+}
+
+func truthy(s string) bool {
+	switch s {
+	case "1", "t", "T", "true", "TRUE", "True", "yes", "YES", "on", "ON":
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/storage/dbproxy/pool/config_env_test.go
+++ b/internal/storage/dbproxy/pool/config_env_test.go
@@ -1,0 +1,51 @@
+package pool
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestEnabledFromEnv(t *testing.T) {
+	cases := map[string]bool{
+		"1": true, "true": true, "TRUE": true, "yes": true, "on": true, "T": true,
+		"":      false,
+		"0":     false,
+		"false": false,
+		"off":   false,
+		"2":     false, // only explicit truthy tokens enable it
+	}
+	for v, want := range cases {
+		t.Setenv(EnvEnabled, v)
+		if got := EnabledFromEnv(); got != want {
+			t.Errorf("EnabledFromEnv(%q) = %v, want %v", v, got, want)
+		}
+	}
+}
+
+func TestSizeFromEnv(t *testing.T) {
+	cases := map[string]int{
+		"":    0,
+		"0":   0,
+		"-3":  0,
+		"abc": 0,
+		"8":   8,
+		"32":  32,
+	}
+	for v, want := range cases {
+		t.Setenv(EnvSize, v)
+		if got := SizeFromEnv(); got != want {
+			t.Errorf("SizeFromEnv(%q) = %d, want %d", v, got, want)
+		}
+	}
+}
+
+func TestSocketFromEnv(t *testing.T) {
+	t.Setenv(EnvSocket, "")
+	if got, want := SocketFromEnv("/root/dir"), filepath.Join("/root/dir", PoolSocketName); got != want {
+		t.Errorf("SocketFromEnv default = %q, want %q", got, want)
+	}
+	t.Setenv(EnvSocket, "/custom/p.sock")
+	if got := SocketFromEnv("/root/dir"); got != "/custom/p.sock" {
+		t.Errorf("SocketFromEnv override = %q, want /custom/p.sock", got)
+	}
+}

--- a/internal/storage/dbproxy/pool/doc.go
+++ b/internal/storage/dbproxy/pool/doc.go
@@ -10,13 +10,24 @@
 //	BEADS_DOLT_POOL_SIZE=16      # optional: persistent backends (default 16, min 4)
 //	BEADS_DOLT_POOL_SOCKET=/path # optional: client socket (default <rootDir>/pool.sock)
 //
-// When BEADS_DOLT_POOL is truthy, uow.NewExternalDoltServerUOWProvider resolves
-// a BackendExternalPooled endpoint instead of the TCP byte-passthrough proxy:
-// bd spawns a db-proxy-child in pooled mode (reusing the same lock/pidfile/log/
-// idle-shutdown lifecycle), the child listens on the pooler unix socket, and bd
-// connects to that socket. The socket path is recorded in proxy.pid and bd's
-// DSN is built as a unix-socket DSN (the store layer also honors
-// BEADS_DOLT_SERVER_SOCKET for direct connections).
+// Two activation paths consult BEADS_DOLT_POOL, both spawning a db-proxy-child
+// in pooled mode (reusing the same lock/pidfile/log/idle-shutdown lifecycle)
+// that listens on a pooler unix socket recorded in proxy.pid:
+//
+//   - SERVER-MODE store path (the town's actual path): the direct dolt store
+//     (internal/storage/dolt, newServerMode -> openServerConnection over TCP to
+//     BEADS_DOLT_SERVER_HOST/PORT). maybeActivatePooler ensures a SHARED,
+//     long-lived pooler keyed to the resolved host:port under
+//     ~/.beads/pool/<host>_<port>/ — one pooler per Dolt endpoint, reused by
+//     every bd process via the proxy lock/pidfile — and rewrites
+//     cfg.ServerSocket to the pooler socket.
+//   - uow external-doltserver provider: NewExternalDoltServerUOWProvider
+//     resolves a BackendExternalPooled endpoint under the workspace server root.
+//
+// In both cases bd's DSN is built as a unix-socket DSN (the store layer also
+// honors BEADS_DOLT_SERVER_SOCKET for direct connections). Activation is a strict
+// no-op unless BEADS_DOLT_POOL is truthy, BEADS_TEST_MODE is unset, and the path
+// is plain TCP server mode (no operator socket, not a proxied-server config).
 //
 // # Routing summary
 //

--- a/internal/storage/dbproxy/pool/doc.go
+++ b/internal/storage/dbproxy/pool/doc.go
@@ -1,0 +1,36 @@
+// Package pool fronts a Dolt sql-server with a query-level MySQL connection
+// pooler. See the package overview in pool.go for the design.
+//
+// # Enabling the pooler
+//
+// The pooler is OFF by default; bd connects to Dolt exactly as before unless it
+// is opted in. To enable it, set in bd's environment:
+//
+//	BEADS_DOLT_POOL=1            # turn the pooler on (truthy: 1/true/yes/on)
+//	BEADS_DOLT_POOL_SIZE=16      # optional: persistent backends (default 16, min 4)
+//	BEADS_DOLT_POOL_SOCKET=/path # optional: client socket (default <rootDir>/pool.sock)
+//
+// When BEADS_DOLT_POOL is truthy, uow.NewExternalDoltServerUOWProvider resolves
+// a BackendExternalPooled endpoint instead of the TCP byte-passthrough proxy:
+// bd spawns a db-proxy-child in pooled mode (reusing the same lock/pidfile/log/
+// idle-shutdown lifecycle), the child listens on the pooler unix socket, and bd
+// connects to that socket. The socket path is recorded in proxy.pid and bd's
+// DSN is built as a unix-socket DSN (the store layer also honors
+// BEADS_DOLT_SERVER_SOCKET for direct connections).
+//
+// # Routing summary
+//
+//	bd client  --unix socket-->  pooler (this package)  --K persistent conns-->  Dolt
+//
+// Regardless of how many short-lived bd processes connect, Dolt sees ~K
+// connections (collapsing connection churn; see gt-ye21 / #4292).
+//
+// # Prepared statements
+//
+// bd's server-mode DSN does not set interpolateParams, so go-sql-driver sends
+// server-side COM_STMT_PREPARE/EXECUTE for parameterized queries. The pooler
+// implements these by interpolating the bound parameter values back into the
+// SQL text (via vitess GenerateQuery, which SQL-encodes and escapes values) and
+// running the result as a plain text query — so prepared statements work
+// through the pooler without a server-side prepare on the backend.
+package pool

--- a/internal/storage/dbproxy/pool/handler.go
+++ b/internal/storage/dbproxy/pool/handler.go
@@ -1,0 +1,214 @@
+package pool
+
+import (
+	"context"
+	"sync/atomic"
+
+	"github.com/dolthub/vitess/go/mysql"
+	"github.com/dolthub/vitess/go/sqltypes"
+	querypb "github.com/dolthub/vitess/go/vt/proto/query"
+	"github.com/dolthub/vitess/go/vt/sqlparser"
+)
+
+// maxRows bounds how many rows a single ExecuteFetch buffers. bd result sets
+// are small relative to this ceiling; it exists only to cap pathological reads.
+const maxRows = 10_000_000
+
+// Handler is a vitess mysql.Handler that pins one pooled backend per client
+// connection and forwards every command to it. It is the QUERY-LEVEL serving
+// core of the pooler (as opposed to the byte-passthrough proxy).
+//
+// Prepared statements: bd's server-mode DSN does NOT set interpolateParams, so
+// go-sql-driver sends server-side COM_STMT_PREPARE/EXECUTE for every
+// parameterized query. The vitess layer parses the prepare and binds the
+// parameter values; this handler interpolates those bound values back into the
+// SQL text (via vitess's own GenerateQuery, which SQL-encodes/escapes values)
+// and runs the result as a plain text query on the backend. This makes
+// prepared statements work without needing a server-side prepare on the
+// backend (the vitess CLIENT conn exposes no prepared-statement API).
+type Handler struct {
+	pool   *Pool
+	active atomic.Int64 // in-flight client connections, for graceful drain
+}
+
+// NewHandler returns a Handler backed by pool.
+func NewHandler(pool *Pool) *Handler { return &Handler{pool: pool} }
+
+// ActiveConns reports the number of client connections currently being served.
+func (h *Handler) ActiveConns() int64 { return h.active.Load() }
+
+// Ensure Handler satisfies the vitess interface at compile time.
+var _ mysql.Handler = (*Handler)(nil)
+
+// clientState is pinned to a client connection via c.ClientData for its
+// lifetime. It tracks the borrowed backend and whether the session is still
+// clean (so ConnectionClosed knows whether to Release or Discard).
+type clientState struct {
+	be      *backend
+	tainted bool // an error occurred; backend must be discarded, not reused
+}
+
+func (h *Handler) stateFor(c *mysql.Conn) *clientState {
+	st, _ := c.ClientData.(*clientState)
+	return st
+}
+
+// NewConnection borrows a backend and pins it for this client's lifetime.
+// If borrowing fails (pool exhausted/closed), the connection is left without a
+// backend; the first command will fail cleanly via stateFor returning nil.
+func (h *Handler) NewConnection(c *mysql.Conn) {
+	h.active.Add(1)
+	h.pool.cfg.Stats.IncClientConn()
+	b, err := h.pool.Borrow(context.Background())
+	if err != nil {
+		h.pool.logf("client %d: borrow failed: %v", c.ConnectionID, err)
+		c.ClientData = (*clientState)(nil)
+		return
+	}
+	c.ClientData = &clientState{be: b}
+}
+
+// ConnectionClosed returns the backend to the pool: Release on a clean session
+// (reset-and-reuse), Discard if any error tainted the session.
+func (h *Handler) ConnectionClosed(c *mysql.Conn) {
+	defer h.active.Add(-1)
+	st := h.stateFor(c)
+	if st == nil || st.be == nil {
+		return
+	}
+	if st.tainted {
+		h.pool.Discard(st.be)
+	} else {
+		h.pool.Release(st.be)
+	}
+	st.be = nil
+}
+
+func (h *Handler) ConnectionAuthenticated(c *mysql.Conn) error { return nil }
+
+func (h *Handler) ConnectionAborted(c *mysql.Conn, reason string) error { return nil }
+
+// ComInitDB handles USE <db> (and the implicit USE vitess issues after auth
+// when the client handshake carried a default database).
+func (h *Handler) ComInitDB(c *mysql.Conn, schemaName string) error {
+	st := h.stateFor(c)
+	if st == nil || st.be == nil {
+		return errNoBackend()
+	}
+	if err := st.be.useDB(schemaName); err != nil {
+		st.tainted = true
+		return err
+	}
+	return nil
+}
+
+// ComQuery forwards a text query to the pinned backend and streams the result.
+func (h *Handler) ComQuery(ctx context.Context, c *mysql.Conn, query string, callback mysql.ResultSpoolFn) error {
+	st := h.stateFor(c)
+	if st == nil || st.be == nil {
+		return errNoBackend()
+	}
+	res, err := st.be.exec(query, maxRows)
+	if err != nil {
+		st.tainted = true
+		return err
+	}
+	return callback(res, false)
+}
+
+// ComMultiQuery handles a single statement and returns the remainder. bd uses
+// multiStatements=true in its DSN, so this path is exercised; vitess splits
+// statements and calls us once per statement.
+func (h *Handler) ComMultiQuery(ctx context.Context, c *mysql.Conn, query string, callback mysql.ResultSpoolFn) (string, error) {
+	st := h.stateFor(c)
+	if st == nil || st.be == nil {
+		return "", errNoBackend()
+	}
+	statement, remainder, err := sqlparser.SplitStatement(query)
+	if err != nil {
+		// Could not split; run the whole blob as one statement.
+		statement, remainder = query, ""
+	}
+	res, qerr := st.be.exec(statement, maxRows)
+	if qerr != nil {
+		st.tainted = true
+		return "", qerr
+	}
+	return remainder, callback(res, remainder != "")
+}
+
+// ComPrepare is invoked when a client sends COM_STMT_PREPARE. vitess has
+// already parsed the query and counted its parameters; we return the result
+// column fields. We cannot run the parameterized query yet (no values), and the
+// vitess CLIENT conn has no prepared-statement API, so we return nil fields:
+// go-sql-driver reads the authoritative column metadata from the binary
+// COM_STMT_EXECUTE response instead, which we produce in ComStmtExecute.
+func (h *Handler) ComPrepare(ctx context.Context, c *mysql.Conn, query string, prepare *mysql.PrepareData) ([]*querypb.Field, error) {
+	st := h.stateFor(c)
+	if st == nil || st.be == nil {
+		return nil, errNoBackend()
+	}
+	return nil, nil
+}
+
+// ComStmtExecute runs a previously prepared statement. vitess supplies the
+// bound parameter values in prepare.BindVars (keyed v1, v2, ...). We parse the
+// prepared SQL (its `?` placeholders become :v1, :v2 ...), interpolate the
+// bound values via vitess's GenerateQuery (which SQL-encodes and escapes each
+// value), and run the resulting plain text query on the backend.
+func (h *Handler) ComStmtExecute(ctx context.Context, c *mysql.Conn, prepare *mysql.PrepareData, callback func(*sqltypes.Result) error) error {
+	st := h.stateFor(c)
+	if st == nil || st.be == nil {
+		return errNoBackend()
+	}
+	query, err := interpolate(prepare.PrepareStmt, prepare.BindVars)
+	if err != nil {
+		// Parse/interpolation failure does not desync the backend (nothing was
+		// sent to it), so the session is NOT tainted.
+		return mysql.NewSQLError(mysql.ERNotSupportedYet, mysql.SSUnknownSQLState,
+			"pooler: cannot execute prepared statement: %v", err)
+	}
+	res, qerr := st.be.exec(query, maxRows)
+	if qerr != nil {
+		st.tainted = true
+		return qerr
+	}
+	return callback(res)
+}
+
+// interpolate substitutes the bound parameter values into a parameterized
+// statement, yielding an executable plain-text query.
+func interpolate(stmt string, bindVars map[string]*querypb.BindVariable) (string, error) {
+	parsed, err := sqlparser.Parse(stmt)
+	if err != nil {
+		return "", err
+	}
+	pq := sqlparser.NewParsedQuery(parsed)
+	return pq.GenerateQuery(bindVars, nil)
+}
+
+// ComResetConnection forwards a client COM_RESET_CONNECTION to the backend so
+// the backend's session state is cleared mid-connection too (go-sql-driver's
+// pool sends this when recycling a conn).
+func (h *Handler) ComResetConnection(c *mysql.Conn) error {
+	st := h.stateFor(c)
+	if st == nil || st.be == nil {
+		return errNoBackend()
+	}
+	if err := st.be.reset(); err != nil {
+		st.tainted = true
+		return err
+	}
+	return nil
+}
+
+func (h *Handler) WarningCount(c *mysql.Conn) uint16 { return 0 }
+
+func (h *Handler) ParserOptionsForConnection(c *mysql.Conn) (sqlparser.ParserOptions, error) {
+	return sqlparser.ParserOptions{}, nil
+}
+
+func errNoBackend() error {
+	return mysql.NewSQLError(mysql.ERUnknownError, mysql.SSUnknownSQLState,
+		"pooler: no backend available for connection")
+}

--- a/internal/storage/dbproxy/pool/idle_integration_test.go
+++ b/internal/storage/dbproxy/pool/idle_integration_test.go
@@ -1,0 +1,40 @@
+package pool_test
+
+import (
+	"testing"
+	"time"
+)
+
+// TestPool_KeepaliveSurvivesIdleReaping verifies that a backend left idle past
+// Dolt's ~40s loopback idle-reaping window is still usable, because the
+// keepalive pinger (and the borrow-time liveness ping with lazy reconnect)
+// keeps it alive / heals it. This test takes ~45s, so it is gated behind
+// BEADS_POOL_TEST_DOLT_ADDR like the others and skipped in -short mode.
+func TestPool_KeepaliveSurvivesIdleReaping(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long idle-reaping test in -short mode")
+	}
+	addr := doltAddr(t)
+	dbName := makeTestDB(t, addr)
+	srv, stats := startServer(t, addr, 2)
+	db := pooledDB(t, srv.Socket(), dbName, 2)
+
+	var one int
+	if err := db.QueryRow("SELECT 1").Scan(&one); err != nil {
+		t.Fatalf("initial query: %v", err)
+	}
+	// Idle well past the ~40s reaping window. Keepalive (1s in tests) must keep
+	// backends alive across this gap.
+	time.Sleep(45 * time.Second)
+
+	if err := db.QueryRow("SELECT 1").Scan(&one); err != nil {
+		t.Fatalf("query after idle: %v", err)
+	}
+	if one != 1 {
+		t.Fatalf("got %d want 1", one)
+	}
+	if rc := stats.Snapshot().Reconnects; rc > 1 {
+		t.Fatalf("too many reconnects (%d); keepalive should have prevented reaping", rc)
+	}
+	t.Logf("idle survival OK; reconnects=%d", stats.Snapshot().Reconnects)
+}

--- a/internal/storage/dbproxy/pool/pool.go
+++ b/internal/storage/dbproxy/pool/pool.go
@@ -1,0 +1,453 @@
+// Package pool implements a MySQL connection pooler that fronts a Dolt
+// sql-server. Many short-lived clients (bd processes) connect to the pooler;
+// the pooler multiplexes them onto a SMALL fixed set of persistent backend
+// connections to Dolt, so Dolt sees ~constant connections regardless of client
+// churn (gt-ye21 / #4292).
+//
+// Design notes (proven by the de-risking spike):
+//   - Client-facing handshake is terminated by the vitess go/mysql Listener +
+//     AuthServerNone (Dolt is passwordless). vitess negotiates capability flags
+//     and frames result sets, so CLIENT_DEPRECATE_EOF etc. stay consistent and
+//     the handler never has to match flags manually.
+//   - Each client CONNECTION pins one backend for its lifetime (no mid-conn
+//     multiplexing). The win is REUSE across successive clients: 300 churning
+//     clients collapse to ~K backend connections on Dolt.
+//   - On clean client disconnect the backend is reset (COM_RESET_CONNECTION)
+//     and returned to the pool. On ANY backend error the backend is discarded
+//     and reconnected, never reset-reused, so a desynced backend can never be
+//     handed to the next client.
+//   - Idle Dolt backends are reaped after ~40s (loopback idle reaping, NOT
+//     wait_timeout). A background keepalive Ping every ~10s plus a
+//     liveness-Ping-with-reconnect on borrow keeps reconnects at zero.
+package pool
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/dolthub/vitess/go/mysql"
+)
+
+// Defaults for pool sizing and timing. Operators tune size via
+// BEADS_DOLT_POOL_SIZE; the rest are conservative constants.
+const (
+	// DefaultSize is the number of persistent backend connections held open
+	// against Dolt when no explicit size is configured.
+	DefaultSize = 16
+	// MinSize is the floor for the pool size; smaller values are clamped up.
+	MinSize = 4
+
+	defaultKeepalive   = 10 * time.Second
+	defaultBorrowWait  = 10 * time.Second
+	defaultDialTimeout = 10 * time.Second
+)
+
+// ErrBorrowTimeout is returned by borrow when no backend becomes available
+// within the configured wait timeout (all K backends are checked out and the
+// client gave up waiting).
+var ErrBorrowTimeout = errors.New("pool: timed out waiting for an available backend")
+
+// ErrClosed is returned by borrow once the pool has been closed.
+var ErrClosed = errors.New("pool: closed")
+
+// Config configures a Pool.
+type Config struct {
+	// Addr is the Dolt sql-server TCP address (host:port) the backends dial.
+	Addr string
+	// Socket, when non-empty, is a unix-domain socket path for the Dolt
+	// sql-server; it takes precedence over Addr.
+	Socket string
+	// User is the MySQL user backends authenticate as (Dolt is passwordless,
+	// so only the user name matters). Defaults to "root".
+	User string
+	// Size is the number of persistent backends. Clamped to >= MinSize.
+	Size int
+	// KeepaliveInterval is how often idle backends are pinged. 0 -> default.
+	KeepaliveInterval time.Duration
+	// BorrowWait bounds how long borrow blocks before returning
+	// ErrBorrowTimeout. 0 -> default.
+	BorrowWait time.Duration
+	// Stats, when non-nil, receives counters for reconnects and borrow waits.
+	Stats *Stats
+}
+
+func (c Config) withDefaults() Config {
+	if c.User == "" {
+		c.User = "root"
+	}
+	if c.Size < MinSize {
+		c.Size = MinSize
+	}
+	if c.KeepaliveInterval <= 0 {
+		c.KeepaliveInterval = defaultKeepalive
+	}
+	if c.BorrowWait <= 0 {
+		c.BorrowWait = defaultBorrowWait
+	}
+	return c
+}
+
+// Pool is a fixed-size set of persistent backends fronting one Dolt server.
+type Pool struct {
+	cfg  Config
+	cp   *mysql.ConnParams
+	logf func(string, ...any)
+
+	mu     sync.Mutex
+	cond   *sync.Cond
+	idle   []*backend
+	all    []*backend
+	closed bool
+
+	keepaliveStop chan struct{}
+	keepaliveDone chan struct{}
+}
+
+// New creates and warms a Pool: it dials Size persistent backends up front so
+// the first client never pays a connect cost, and starts the keepalive loop.
+// On any warmup failure it tears down already-dialed backends and returns the
+// error.
+func New(ctx context.Context, cfg Config) (*Pool, error) {
+	cfg = cfg.withDefaults()
+	cp, err := connParams(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	p := &Pool{
+		cfg:           cfg,
+		cp:            cp,
+		logf:          func(string, ...any) {},
+		keepaliveStop: make(chan struct{}),
+		keepaliveDone: make(chan struct{}),
+	}
+	p.cond = sync.NewCond(&p.mu)
+
+	for i := 0; i < cfg.Size; i++ {
+		b, err := p.dial(ctx, i)
+		if err != nil {
+			for _, done := range p.all {
+				done.close()
+			}
+			return nil, fmt.Errorf("pool: warmup backend %d: %w", i, err)
+		}
+		p.idle = append(p.idle, b)
+		p.all = append(p.all, b)
+	}
+
+	go p.keepalive()
+	return p, nil
+}
+
+// SetLogger installs a logging function (e.g. (*log.Logger).Printf). Optional;
+// the pool is silent by default.
+func (p *Pool) SetLogger(logf func(string, ...any)) {
+	if logf != nil {
+		p.logf = logf
+	}
+}
+
+// Size returns the configured number of backends.
+func (p *Pool) Size() int { return p.cfg.Size }
+
+func (p *Pool) dial(ctx context.Context, id int) (*backend, error) {
+	dctx, cancel := context.WithTimeout(ctx, defaultDialTimeout)
+	defer cancel()
+	c, err := mysql.Connect(dctx, p.cp)
+	if err != nil {
+		return nil, err
+	}
+	return &backend{id: id, conn: c}, nil
+}
+
+// Borrow blocks until a live backend is available or the wait timeout elapses.
+// The returned backend is guaranteed live (it is Pinged, and lazily
+// reconnected if the ping fails). Callers MUST return it via Release (clean
+// session end) or Discard (after any error).
+func (p *Pool) Borrow(ctx context.Context) (*backend, error) {
+	deadline := time.Now().Add(p.cfg.BorrowWait)
+
+	p.mu.Lock()
+	if len(p.idle) == 0 && !p.closed {
+		p.cfg.Stats.IncBorrowWait()
+	}
+	for len(p.idle) == 0 && !p.closed {
+		if !p.waitUntil(deadline) {
+			p.mu.Unlock()
+			if p.isClosed() {
+				return nil, ErrClosed
+			}
+			p.cfg.Stats.IncBorrowTimeout()
+			return nil, ErrBorrowTimeout
+		}
+	}
+	if p.closed {
+		p.mu.Unlock()
+		return nil, ErrClosed
+	}
+	b := p.idle[len(p.idle)-1]
+	p.idle = p.idle[:len(p.idle)-1]
+	p.mu.Unlock()
+
+	// Liveness check with lazy reconnect: an idle backend may have been reaped
+	// by Dolt. Pinging here keeps a possibly-dead conn off the hot path.
+	if err := b.ping(); err != nil {
+		p.logf("backend %d dead on borrow (%v); reconnecting", b.id, err)
+		p.cfg.Stats.IncReconnect()
+		nb, derr := p.dial(ctx, b.id)
+		if derr != nil {
+			// Reconnect failed: put a placeholder back so pool size is
+			// preserved and signal waiters, then surface the error.
+			b.close()
+			p.returnDead(b.id)
+			return nil, fmt.Errorf("pool: reconnect backend %d on borrow: %w", b.id, derr)
+		}
+		b.close()
+		b = nb
+		p.swapInAll(b)
+	}
+	return b, nil
+}
+
+// waitUntil blocks on the cond until either it is signalled or the deadline
+// passes. It returns true if it may have been signalled (caller should
+// re-check the predicate) and false if the deadline elapsed. p.mu must be held.
+func (p *Pool) waitUntil(deadline time.Time) bool {
+	remaining := time.Until(deadline)
+	if remaining <= 0 {
+		return false
+	}
+	// sync.Cond has no timed wait; use a timer that broadcasts on expiry.
+	timer := time.AfterFunc(remaining, func() {
+		p.mu.Lock()
+		p.cond.Broadcast()
+		p.mu.Unlock()
+	})
+	p.cond.Wait()
+	timer.Stop()
+	return time.Now().Before(deadline)
+}
+
+// Release resets the backend's session state (COM_RESET_CONNECTION) and returns
+// it to the idle set. This is the ONLY path that reuses a backend, and it is
+// only safe at a clean session boundary with no query in flight. If the reset
+// fails, the backend is discarded and replaced so a desynced backend never
+// re-enters the pool.
+func (p *Pool) Release(b *backend) {
+	if b == nil {
+		return
+	}
+	if err := b.reset(); err != nil {
+		p.logf("backend %d reset failed (%v); discarding", b.id, err)
+		p.Discard(b)
+		return
+	}
+	p.mu.Lock()
+	if p.closed {
+		p.mu.Unlock()
+		b.close()
+		return
+	}
+	p.idle = append(p.idle, b)
+	p.cond.Signal()
+	p.mu.Unlock()
+}
+
+// Discard throws away a (possibly desynced) backend and asynchronously
+// reconnects a replacement so the pool keeps its size. Use after ANY backend
+// error: a backend that errored mid-query may have unread bytes or partial
+// state and must never be reset-reused.
+func (p *Pool) Discard(b *backend) {
+	if b == nil {
+		return
+	}
+	id := b.id
+	b.close()
+	p.cfg.Stats.IncDiscard()
+
+	// Reconnect in the background so the erroring client path isn't blocked.
+	go func() {
+		nb, err := p.dial(context.Background(), id)
+		if err != nil {
+			p.logf("backend %d reconnect after discard failed: %v", id, err)
+			p.returnDead(id)
+			return
+		}
+		p.mu.Lock()
+		if p.closed {
+			p.mu.Unlock()
+			nb.close()
+			return
+		}
+		p.swapInAllLocked(nb)
+		p.idle = append(p.idle, nb)
+		p.cond.Signal()
+		p.mu.Unlock()
+	}()
+}
+
+// returnDead handles a failed reconnect: it removes the slot's contribution so
+// borrowers don't block forever waiting on a backend that will never return,
+// then signals waiters (who will see the reduced idle set / timeout).
+func (p *Pool) returnDead(id int) {
+	p.mu.Lock()
+	// Drop the dead backend from `all` so close() doesn't double-free; a future
+	// keepalive or borrow on a surviving backend keeps the pool serving.
+	p.removeFromAllLocked(id)
+	p.cond.Broadcast()
+	p.mu.Unlock()
+}
+
+func (p *Pool) swapInAll(nb *backend) {
+	p.mu.Lock()
+	p.swapInAllLocked(nb)
+	p.mu.Unlock()
+}
+
+func (p *Pool) swapInAllLocked(nb *backend) {
+	for i, b := range p.all {
+		if b.id == nb.id {
+			p.all[i] = nb
+			return
+		}
+	}
+	p.all = append(p.all, nb)
+}
+
+func (p *Pool) removeFromAllLocked(id int) {
+	for i, b := range p.all {
+		if b.id == id {
+			p.all = append(p.all[:i], p.all[i+1:]...)
+			return
+		}
+	}
+}
+
+func (p *Pool) isClosed() bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.closed
+}
+
+// keepalive pings idle backends so Dolt does not reap them. To avoid racing a
+// concurrent Borrow on the same conn, it pops each backend out of idle, pings
+// it without the lock, then returns it.
+func (p *Pool) keepalive() {
+	defer close(p.keepaliveDone)
+	t := time.NewTicker(p.cfg.KeepaliveInterval)
+	defer t.Stop()
+	for {
+		select {
+		case <-p.keepaliveStop:
+			return
+		case <-t.C:
+			p.pingAll()
+		}
+	}
+}
+
+// pingAll pings EVERY backend — idle and borrowed alike. A borrowed backend is
+// pinned to a long-lived client connection that may sit idle (go-sql-driver
+// keeps conns open in its own pool); without pinging it too, Dolt's ~40s idle
+// reaper would kill it and the next client query would EOF. The per-backend
+// mutex serializes the ping against any in-flight client query, so pinging a
+// borrowed backend is race-free and never disturbs its session state.
+//
+// For an IDLE backend whose ping fails, we reconnect and swap in a replacement.
+// For a BORROWED backend whose ping fails, we must not swap it (a client holds
+// the pointer); we leave it, and the failure surfaces on that client's next
+// query, after which ConnectionClosed will Discard+replace it.
+func (p *Pool) pingAll() {
+	p.mu.Lock()
+	if p.closed {
+		p.mu.Unlock()
+		return
+	}
+	// Snapshot the backend set and the idle membership so we can ping without
+	// holding the pool lock (pings do wire I/O).
+	snapshot := make([]*backend, len(p.all))
+	copy(snapshot, p.all)
+	idleSet := make(map[int]bool, len(p.idle))
+	for _, b := range p.idle {
+		idleSet[b.id] = true
+	}
+	p.mu.Unlock()
+
+	for _, b := range snapshot {
+		if err := b.ping(); err != nil {
+			p.logf("backend %d failed keepalive ping: %v", b.id, err)
+			if idleSet[b.id] {
+				p.reconnectIdle(b)
+			}
+			// Borrowed backend: leave it; the client query path / Discard heals it.
+		}
+	}
+}
+
+// reconnectIdle replaces a dead idle backend with a fresh connection, but only
+// if it is still in the idle set (it may have been borrowed since the snapshot,
+// in which case we leave it for the borrow/query path to heal).
+func (p *Pool) reconnectIdle(dead *backend) {
+	p.mu.Lock()
+	idx := -1
+	for i, b := range p.idle {
+		if b == dead {
+			idx = i
+			break
+		}
+	}
+	if idx < 0 || p.closed {
+		p.mu.Unlock()
+		return // borrowed since snapshot, or pool closing
+	}
+	// Remove it from idle while we reconnect (without the lock).
+	p.idle = append(p.idle[:idx], p.idle[idx+1:]...)
+	p.mu.Unlock()
+
+	p.cfg.Stats.IncReconnect()
+	nb, derr := p.dial(context.Background(), dead.id)
+	if derr != nil {
+		p.logf("backend %d keepalive reconnect failed: %v", dead.id, derr)
+		dead.close()
+		p.returnDead(dead.id)
+		return
+	}
+	dead.close()
+
+	p.mu.Lock()
+	if p.closed {
+		p.mu.Unlock()
+		nb.close()
+		return
+	}
+	p.swapInAllLocked(nb)
+	p.idle = append(p.idle, nb)
+	p.cond.Signal()
+	p.mu.Unlock()
+}
+
+// Close stops the keepalive loop and closes every backend. In-flight Borrow
+// callers are woken and receive ErrClosed. Idempotent.
+func (p *Pool) Close() {
+	p.mu.Lock()
+	if p.closed {
+		p.mu.Unlock()
+		return
+	}
+	p.closed = true
+	all := p.all
+	p.all = nil
+	p.idle = nil
+	p.cond.Broadcast()
+	p.mu.Unlock()
+
+	close(p.keepaliveStop)
+	<-p.keepaliveDone
+
+	for _, b := range all {
+		b.close()
+	}
+}

--- a/internal/storage/dbproxy/pool/pool.go
+++ b/internal/storage/dbproxy/pool/pool.go
@@ -212,8 +212,8 @@ func (p *Pool) Borrow(ctx context.Context) (*backend, error) {
 	return b, nil
 }
 
-// waitUntil blocks on the cond until either it is signalled or the deadline
-// passes. It returns true if it may have been signalled (caller should
+// waitUntil blocks on the cond until either it is signaled or the deadline
+// passes. It returns true if it may have been signaled (caller should
 // re-check the predicate) and false if the deadline elapsed. p.mu must be held.
 func (p *Pool) waitUntil(deadline time.Time) bool {
 	remaining := time.Until(deadline)

--- a/internal/storage/dbproxy/pool/pool_integration_test.go
+++ b/internal/storage/dbproxy/pool/pool_integration_test.go
@@ -1,0 +1,369 @@
+package pool_test
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	gomysql "github.com/go-sql-driver/mysql"
+
+	"github.com/steveyegge/beads/internal/storage/dbproxy/pool"
+)
+
+// These tests exercise the pooler against a LIVE Dolt sql-server. They are
+// gated on BEADS_POOL_TEST_DOLT_ADDR (e.g. "127.0.0.1:3307"); when it is unset
+// the tests skip, so CI without a Dolt server stays green. Each test creates
+// and drops its own throwaway database (poolspike_test*) and never touches real
+// data.
+
+const testDBPrefix = "poolspike_test"
+
+func doltAddr(t *testing.T) string {
+	t.Helper()
+	addr := os.Getenv("BEADS_POOL_TEST_DOLT_ADDR")
+	if addr == "" {
+		t.Skip("BEADS_POOL_TEST_DOLT_ADDR not set; skipping live-Dolt pooler test")
+	}
+	return addr
+}
+
+// adminDB opens a direct (non-pooled) connection to Dolt for test setup/teardown
+// and assertions that must bypass the pooler.
+func adminDB(t *testing.T, addr, dbName string) *sql.DB {
+	t.Helper()
+	cfg := gomysql.Config{
+		User: "root", Net: "tcp", Addr: addr, DBName: dbName,
+		AllowNativePasswords: true,
+	}
+	cfg.TLSConfig = "false"
+	db, err := sql.Open("mysql", cfg.FormatDSN())
+	if err != nil {
+		t.Fatalf("open admin db: %v", err)
+	}
+	db.SetMaxOpenConns(2)
+	return db
+}
+
+func makeTestDB(t *testing.T, addr string) string {
+	t.Helper()
+	name := fmt.Sprintf("%s_%d", testDBPrefix, time.Now().UnixNano())
+	admin := adminDB(t, addr, "")
+	defer admin.Close()
+	if _, err := admin.Exec("CREATE DATABASE `" + name + "`"); err != nil {
+		t.Fatalf("create test db %s: %v", name, err)
+	}
+	t.Cleanup(func() {
+		a := adminDB(t, addr, "")
+		defer a.Close()
+		_, _ = a.Exec("DROP DATABASE IF EXISTS `" + name + "`")
+	})
+	// Dolt can lag between CREATE DATABASE and visibility; poll until usable.
+	deadline := time.Now().Add(10 * time.Second)
+	for {
+		a := adminDB(t, addr, name)
+		err := a.Ping()
+		a.Close()
+		if err == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("test db %s never became usable: %v", name, err)
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	return name
+}
+
+// poolSocket returns a short unix socket path under the test's temp dir.
+func poolSocket(t *testing.T) string {
+	t.Helper()
+	// Unix socket paths are length-limited (~104 bytes on macOS); keep short.
+	dir, err := os.MkdirTemp("", "poolsock")
+	if err != nil {
+		t.Fatalf("mkdtemp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	return filepath.Join(dir, "p.sock")
+}
+
+func startServer(t *testing.T, addr string, size int) (*pool.Server, *pool.Stats) {
+	t.Helper()
+	sock := poolSocket(t)
+	stats := &pool.Stats{}
+	srv, err := pool.NewServer(context.Background(), pool.ServerConfig{
+		Socket: sock,
+		Pool:   pool.Config{Addr: addr, Size: size, Stats: stats, KeepaliveInterval: time.Second},
+		Logf:   func(string, ...any) {},
+	})
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	go srv.Serve()
+	t.Cleanup(srv.Shutdown)
+	// Wait for the socket to be accepting.
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		if _, err := os.Stat(sock); err == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("pooler socket %s never appeared", sock)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	return srv, stats
+}
+
+// pooledDB opens a go-sql-driver connection THROUGH the pooler socket, mirroring
+// bd's server-mode DSN (notably: interpolateParams is NOT set, so go-sql-driver
+// uses server-side prepared statements for parameterized queries).
+func pooledDB(t *testing.T, socket, dbName string, maxConns int) *sql.DB {
+	t.Helper()
+	cfg := gomysql.Config{
+		User: "root", Net: "unix", Addr: socket, DBName: dbName,
+		ParseTime: true, MultiStatements: true, AllowNativePasswords: true,
+	}
+	cfg.TLSConfig = "false"
+	db, err := sql.Open("mysql", cfg.FormatDSN())
+	if err != nil {
+		t.Fatalf("open pooled db: %v", err)
+	}
+	db.SetMaxOpenConns(maxConns)
+	t.Cleanup(func() { _ = db.Close() })
+	return db
+}
+
+func TestPool_PreparedStatementRoundTrip(t *testing.T) {
+	addr := doltAddr(t)
+	dbName := makeTestDB(t, addr)
+	srv, _ := startServer(t, addr, 4)
+	db := pooledDB(t, srv.Socket(), dbName, 4)
+
+	if _, err := db.Exec("CREATE TABLE t (id int primary key, name varchar(64))"); err != nil {
+		t.Fatalf("create table: %v", err)
+	}
+	// Parameterized INSERT -> COM_STMT_PREPARE/EXECUTE through the pooler.
+	if _, err := db.Exec("INSERT INTO t (id, name) VALUES (?, ?)", 1, "alice"); err != nil {
+		t.Fatalf("param insert: %v", err)
+	}
+	// Parameterized SELECT.
+	var name string
+	if err := db.QueryRow("SELECT name FROM t WHERE id = ?", 1).Scan(&name); err != nil {
+		t.Fatalf("param select: %v", err)
+	}
+	if name != "alice" {
+		t.Fatalf("got name %q, want alice", name)
+	}
+	// Multi-row parameterized query.
+	if _, err := db.Exec("INSERT INTO t (id, name) VALUES (?, ?)", 2, "bob"); err != nil {
+		t.Fatalf("param insert 2: %v", err)
+	}
+	rows, err := db.Query("SELECT id, name FROM t WHERE id >= ? ORDER BY id", 1)
+	if err != nil {
+		t.Fatalf("param multi-row query: %v", err)
+	}
+	defer rows.Close()
+	got := map[int]string{}
+	for rows.Next() {
+		var id int
+		var nm string
+		if err := rows.Scan(&id, &nm); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		got[id] = nm
+	}
+	if got[1] != "alice" || got[2] != "bob" {
+		t.Fatalf("unexpected rows: %v", got)
+	}
+}
+
+func TestPool_ClientIsolation_NoBleed(t *testing.T) {
+	addr := doltAddr(t)
+	dbName := makeTestDB(t, addr)
+	// K=1: every client is forced onto the SAME backend, so any session bleed
+	// (user vars, session vars, default branch) would be observable across
+	// distinct clients. Each client below is a SEPARATE *sql.DB that we fully
+	// Close, which drops the client TCP/unix connection and triggers the
+	// pooler's ConnectionClosed -> reset-on-release path. (Using db.Conn().Close
+	// would instead return the conn to go-sql-driver's own pool, which sends its
+	// own COM_RESET and would not exercise the pooler's boundary reset.)
+	srv, _ := startServer(t, addr, 1)
+
+	// Client A: dirty the session, then drop the connection entirely.
+	{
+		a := pooledDBNoCleanup(t, srv.Socket(), dbName)
+		if _, err := a.Exec("SET @leak = 'boom'"); err != nil {
+			t.Fatalf("set user var: %v", err)
+		}
+		if _, err := a.Exec("SET autocommit = 0"); err != nil {
+			t.Fatalf("set autocommit: %v", err)
+		}
+		// Also switch the active Dolt branch to prove branch state is reset.
+		if _, err := a.Exec("CALL DOLT_CHECKOUT('-b', 'pooltest_branch')"); err != nil {
+			// Branch may already exist from a prior run; ignore creation errors
+			// but try a plain checkout so the session branch is non-main.
+			_, _ = a.Exec("CALL DOLT_CHECKOUT('pooltest_branch')")
+		}
+		_ = a.Close() // drop client conn -> pooler resets the backend
+	}
+
+	// Wait for the backend to be released+reset back into the pool (Release
+	// happens in the pooler's ConnectionClosed handler, asynchronously w.r.t.
+	// the client Close()).
+	time.Sleep(200 * time.Millisecond)
+
+	// Client B on the same (only) backend must see clean state.
+	b := pooledDBNoCleanup(t, srv.Socket(), dbName)
+	defer b.Close()
+
+	var leak sql.NullString
+	if err := b.QueryRow("SELECT @leak").Scan(&leak); err != nil {
+		t.Fatalf("select user var: %v", err)
+	}
+	if leak.Valid {
+		t.Fatalf("user var leaked across clients: %q", leak.String)
+	}
+	var autocommit string
+	if err := b.QueryRow("SELECT @@autocommit").Scan(&autocommit); err != nil {
+		t.Fatalf("select autocommit: %v", err)
+	}
+	if autocommit != "1" {
+		t.Fatalf("autocommit leaked: got %q want 1", autocommit)
+	}
+	var branch string
+	if err := b.QueryRow("SELECT active_branch()").Scan(&branch); err != nil {
+		t.Fatalf("select active_branch: %v", err)
+	}
+	if branch != "main" {
+		t.Fatalf("active branch leaked: got %q want main", branch)
+	}
+}
+
+// pooledDBNoCleanup opens a pooled connection that the caller is responsible
+// for Closing (used to deterministically drop client connections mid-test).
+func pooledDBNoCleanup(t *testing.T, socket, dbName string) *sql.DB {
+	t.Helper()
+	cfg := gomysql.Config{
+		User: "root", Net: "unix", Addr: socket, DBName: dbName,
+		ParseTime: true, MultiStatements: true, AllowNativePasswords: true,
+	}
+	cfg.TLSConfig = "false"
+	db, err := sql.Open("mysql", cfg.FormatDSN())
+	if err != nil {
+		t.Fatalf("open pooled db: %v", err)
+	}
+	db.SetMaxOpenConns(1)
+	return db
+}
+
+func TestPool_CommitVisibleAcrossClients(t *testing.T) {
+	addr := doltAddr(t)
+	dbName := makeTestDB(t, addr)
+	srv, _ := startServer(t, addr, 4)
+	db := pooledDB(t, srv.Socket(), dbName, 4)
+
+	if _, err := db.Exec("CREATE TABLE c (id int primary key, v int)"); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	// Writer client inserts and DOLT_COMMITs through the pool.
+	writer, err := db.Conn(context.Background())
+	if err != nil {
+		t.Fatalf("writer conn: %v", err)
+	}
+	if _, err := writer.ExecContext(context.Background(), "INSERT INTO c (id, v) VALUES (1, 42)"); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	if _, err := writer.ExecContext(context.Background(), "CALL DOLT_COMMIT('-A', '-m', 'pool test commit')"); err != nil {
+		t.Fatalf("dolt_commit: %v", err)
+	}
+	_ = writer.Close()
+
+	// A separate pooled reader must see the committed row.
+	var v int
+	if err := db.QueryRow("SELECT v FROM c WHERE id = 1").Scan(&v); err != nil {
+		t.Fatalf("read after commit: %v", err)
+	}
+	if v != 42 {
+		t.Fatalf("got v=%d want 42", v)
+	}
+}
+
+func TestPool_ChurnCollapsesConnections(t *testing.T) {
+	addr := doltAddr(t)
+	dbName := makeTestDB(t, addr)
+	const k = 4
+	srv, _ := startServer(t, addr, k)
+
+	admin := adminDB(t, addr, "")
+	defer admin.Close()
+	baseline := doltConnectionsCounter(t, admin)
+
+	// Many short-lived clients, each opening its own connection, running one
+	// query, and closing. Through a direct connection this would create ~N new
+	// Dolt connections; through the pooler it should stay ~k.
+	const n = 60
+	var wg sync.WaitGroup
+	errCh := make(chan error, n)
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			cfg := gomysql.Config{
+				User: "root", Net: "unix", Addr: srv.Socket(), DBName: dbName,
+				AllowNativePasswords: true,
+			}
+			cfg.TLSConfig = "false"
+			c, err := sql.Open("mysql", cfg.FormatDSN())
+			if err != nil {
+				errCh <- err
+				return
+			}
+			defer c.Close()
+			c.SetMaxOpenConns(1)
+			var one int
+			if err := c.QueryRow("SELECT 1").Scan(&one); err != nil {
+				errCh <- err
+			}
+		}()
+	}
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		if err != nil {
+			t.Fatalf("churn client error: %v", err)
+		}
+	}
+
+	after := doltConnectionsCounter(t, admin)
+	delta := after - baseline
+	// The pooler holds k persistent backends; churn should add at most a small
+	// constant (warmup already happened, so ideally ~0). Allow generous slack
+	// for the admin connection and Dolt internals, but assert it is FAR below n.
+	if delta > int64(k)+8 {
+		t.Fatalf("churn did not collapse: Dolt Connections rose by %d over %d clients (want <= %d)", delta, n, int64(k)+8)
+	}
+	t.Logf("churn: %d clients -> Dolt Connections delta %d (pool size %d)", n, delta, k)
+}
+
+// doltConnectionsCounter reads the global Connections status counter (total
+// connections accepted since server start). The delta across a churn workload
+// reveals how many NEW backend connections Dolt saw.
+func doltConnectionsCounter(t *testing.T, admin *sql.DB) int64 {
+	t.Helper()
+	var name string
+	var val string
+	if err := admin.QueryRow("SHOW GLOBAL STATUS LIKE 'Connections'").Scan(&name, &val); err != nil {
+		t.Fatalf("show status Connections: %v", err)
+	}
+	n, err := strconv.ParseInt(val, 10, 64)
+	if err != nil {
+		t.Fatalf("parse Connections %q: %v", val, err)
+	}
+	return n
+}

--- a/internal/storage/dbproxy/pool/pool_internal_test.go
+++ b/internal/storage/dbproxy/pool/pool_internal_test.go
@@ -1,0 +1,118 @@
+package pool
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+)
+
+func internalDoltAddr(t *testing.T) string {
+	t.Helper()
+	addr := os.Getenv("BEADS_POOL_TEST_DOLT_ADDR")
+	if addr == "" {
+		t.Skip("BEADS_POOL_TEST_DOLT_ADDR not set; skipping live-Dolt pooler test")
+	}
+	return addr
+}
+
+// TestBorrowTimeout verifies that when all backends are checked out, an
+// additional Borrow blocks for ~BorrowWait and then returns ErrBorrowTimeout
+// rather than hanging forever; and that releasing a backend unblocks a waiter.
+func TestBorrowTimeout(t *testing.T) {
+	addr := internalDoltAddr(t)
+	p, err := New(context.Background(), Config{
+		Addr:       addr,
+		Size:       MinSize, // 4
+		BorrowWait: 300 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer p.Close()
+
+	borrowed := make([]*backend, 0, MinSize)
+	for i := 0; i < MinSize; i++ {
+		b, err := p.Borrow(context.Background())
+		if err != nil {
+			t.Fatalf("borrow %d: %v", i, err)
+		}
+		borrowed = append(borrowed, b)
+	}
+
+	start := time.Now()
+	_, err = p.Borrow(context.Background())
+	elapsed := time.Since(start)
+	if err != ErrBorrowTimeout {
+		t.Fatalf("expected ErrBorrowTimeout, got %v", err)
+	}
+	if elapsed < 250*time.Millisecond {
+		t.Fatalf("borrow returned too fast (%s); should have waited ~300ms", elapsed)
+	}
+
+	// Release one and confirm a subsequent borrow now succeeds quickly.
+	p.Release(borrowed[0])
+	got := make(chan error, 1)
+	go func() {
+		b, err := p.Borrow(context.Background())
+		if err == nil {
+			p.Release(b)
+		}
+		got <- err
+	}()
+	select {
+	case err := <-got:
+		if err != nil {
+			t.Fatalf("borrow after release: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("borrow after release did not unblock")
+	}
+
+	for _, b := range borrowed[1:] {
+		p.Release(b)
+	}
+}
+
+// TestDiscardKeepsPoolSize verifies that discarding a backend (simulating an
+// error path) asynchronously reconnects a replacement so the pool's borrowable
+// count returns to its configured size.
+func TestDiscardKeepsPoolSize(t *testing.T) {
+	addr := internalDoltAddr(t)
+	p, err := New(context.Background(), Config{Addr: addr, Size: MinSize})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer p.Close()
+
+	b, err := p.Borrow(context.Background())
+	if err != nil {
+		t.Fatalf("borrow: %v", err)
+	}
+	p.Discard(b) // throws away + async reconnect
+
+	// Eventually all MinSize backends should be borrowable again.
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		held := make([]*backend, 0, MinSize)
+		ok := true
+		for i := 0; i < MinSize; i++ {
+			bb, err := p.Borrow(context.Background())
+			if err != nil {
+				ok = false
+				break
+			}
+			held = append(held, bb)
+		}
+		for _, hb := range held {
+			p.Release(hb)
+		}
+		if ok {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("pool did not recover to size %d after discard", MinSize)
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+}

--- a/internal/storage/dbproxy/pool/serve.go
+++ b/internal/storage/dbproxy/pool/serve.go
@@ -1,0 +1,114 @@
+package pool
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/dolthub/vitess/go/mysql"
+)
+
+// drainTimeout bounds how long Shutdown waits for in-flight client connections
+// to finish before closing backends out from under them.
+const drainTimeout = 5 * time.Second
+
+// Server warms a Pool and serves the pooler's MySQL protocol on a unix socket
+// via a vitess Listener. It owns the pool lifecycle; callers drive readiness
+// and shutdown via Serve/Shutdown.
+type Server struct {
+	cfg      Config
+	socket   string
+	logf     func(string, ...any)
+	pool     *Pool
+	handler  *Handler
+	listener *mysql.Listener
+}
+
+// ServerConfig configures a pooler Server.
+type ServerConfig struct {
+	// Socket is the unix-domain socket path the pooler listens on. Clients
+	// (bd) connect here; it is what BEADS_DOLT_SERVER_SOCKET should point at.
+	Socket string
+	// Pool is the backend pool configuration.
+	Pool Config
+	// Logf, when non-nil, receives diagnostic log lines.
+	Logf func(string, ...any)
+}
+
+// NewServer warms the backend pool and creates (but does not yet Accept) the
+// listener. The socket is removed first if it already exists (stale from a dead
+// pooler). On any failure the pool is torn down.
+func NewServer(ctx context.Context, sc ServerConfig) (*Server, error) {
+	if sc.Socket == "" {
+		return nil, fmt.Errorf("pool: server socket path is required")
+	}
+	logf := sc.Logf
+	if logf == nil {
+		logf = func(string, ...any) {}
+	}
+
+	p, err := New(ctx, sc.Pool)
+	if err != nil {
+		return nil, err
+	}
+	p.SetLogger(logf)
+
+	if err := os.Remove(sc.Socket); err != nil && !os.IsNotExist(err) {
+		p.Close()
+		return nil, fmt.Errorf("pool: remove stale socket %q: %w", sc.Socket, err)
+	}
+
+	h := NewHandler(p)
+	l, err := mysql.NewListener("unix", sc.Socket, mysql.NewAuthServerNone(), h, 0, 0)
+	if err != nil {
+		p.Close()
+		return nil, fmt.Errorf("pool: listen on unix://%s: %w", sc.Socket, err)
+	}
+
+	return &Server{
+		cfg:      sc.Pool,
+		socket:   sc.Socket,
+		logf:     logf,
+		pool:     p,
+		handler:  h,
+		listener: l,
+	}, nil
+}
+
+// Pool returns the underlying pool (for stats/inspection).
+func (s *Server) Pool() *Pool { return s.pool }
+
+// Socket returns the listening socket path.
+func (s *Server) Socket() string { return s.socket }
+
+// Serve blocks accepting and handling client connections until Shutdown (or a
+// listener error) stops it. vitess's Listener.Accept owns per-connection
+// goroutines and graceful close.
+func (s *Server) Serve() {
+	s.logf("pooler serving on unix://%s (pool size %d)", s.socket, s.pool.Size())
+	s.listener.Accept()
+}
+
+// Shutdown gracefully stops the pooler:
+//  1. Close the listener so Accept returns and no new clients are admitted.
+//  2. Wait (bounded) for in-flight client connections to finish their current
+//     work and return their backends.
+//  3. Close all backends and remove the socket file.
+//
+// vitess's Listener.Close stops accepting but does not itself wait for handler
+// goroutines, so step 2 polls the handler's active-connection count.
+func (s *Server) Shutdown() {
+	s.listener.Close()
+
+	deadline := time.Now().Add(drainTimeout)
+	for s.handler.ActiveConns() > 0 && time.Now().Before(deadline) {
+		time.Sleep(20 * time.Millisecond)
+	}
+	if n := s.handler.ActiveConns(); n > 0 {
+		s.logf("pooler shutdown: %d client conn(s) still active after %s; closing backends", n, drainTimeout)
+	}
+
+	s.pool.Close()
+	_ = os.Remove(s.socket)
+}

--- a/internal/storage/dbproxy/pool/serve.go
+++ b/internal/storage/dbproxy/pool/serve.go
@@ -79,6 +79,10 @@ func NewServer(ctx context.Context, sc ServerConfig) (*Server, error) {
 // Pool returns the underlying pool (for stats/inspection).
 func (s *Server) Pool() *Pool { return s.pool }
 
+// ActiveConns reports the number of client connections currently being served,
+// used by callers to drive idle-shutdown.
+func (s *Server) ActiveConns() int64 { return s.handler.ActiveConns() }
+
 // Socket returns the listening socket path.
 func (s *Server) Socket() string { return s.socket }
 

--- a/internal/storage/dbproxy/pool/stats.go
+++ b/internal/storage/dbproxy/pool/stats.go
@@ -1,0 +1,57 @@
+package pool
+
+import "sync"
+
+// Counters is an immutable snapshot of pool metrics. All fields are cumulative
+// since pool creation.
+type Counters struct {
+	// Reconnects counts backends re-dialed due to a failed liveness/keepalive
+	// ping (idle reaping recovery).
+	Reconnects int64
+	// Discards counts backends thrown away after an error and replaced (never
+	// reset-reused).
+	Discards int64
+	// BorrowWaits counts borrows that had to block because all backends were
+	// checked out (a sign the pool may be undersized for the load).
+	BorrowWaits int64
+	// BorrowTimeouts counts borrows that gave up after BorrowWait elapsed.
+	BorrowTimeouts int64
+	// ClientConns counts client connections accepted by the handler.
+	ClientConns int64
+	// PreparesRejected counts COM_STMT_PREPARE requests that could not be
+	// served (should be 0 in normal operation).
+	PreparesRejected int64
+}
+
+// Stats is a concurrency-safe counter bag for a Pool. A nil *Stats is valid and
+// makes every Inc a no-op, so production callers may leave it nil.
+type Stats struct {
+	mu sync.Mutex
+	c  Counters
+}
+
+// Snapshot returns a copy of the current counters. Safe on a nil receiver.
+func (s *Stats) Snapshot() Counters {
+	if s == nil {
+		return Counters{}
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.c
+}
+
+func (s *Stats) update(fn func(*Counters)) {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	fn(&s.c)
+	s.mu.Unlock()
+}
+
+func (s *Stats) IncReconnect()       { s.update(func(c *Counters) { c.Reconnects++ }) }
+func (s *Stats) IncDiscard()         { s.update(func(c *Counters) { c.Discards++ }) }
+func (s *Stats) IncBorrowWait()      { s.update(func(c *Counters) { c.BorrowWaits++ }) }
+func (s *Stats) IncBorrowTimeout()   { s.update(func(c *Counters) { c.BorrowTimeouts++ }) }
+func (s *Stats) IncClientConn()      { s.update(func(c *Counters) { c.ClientConns++ }) }
+func (s *Stats) IncPrepareRejected() { s.update(func(c *Counters) { c.PreparesRejected++ }) }

--- a/internal/storage/dbproxy/proxy/backend.go
+++ b/internal/storage/dbproxy/proxy/backend.go
@@ -16,6 +16,10 @@ const (
 	BackendExternal          Backend = "external"
 	BackendLocalServer       Backend = "local-server"
 	BackendLocalSharedServer Backend = "local-shared-server"
+	// BackendExternalPooled fronts an already-running external Dolt sql-server
+	// with the QUERY-LEVEL connection pooler (vitess Listener on a unix socket)
+	// instead of the TCP byte-passthrough proxy. Opt-in via BEADS_DOLT_POOL=1.
+	BackendExternalPooled Backend = "external-pooled"
 )
 
 // knownBackends is the dispatchable set, ordered for stable error messages
@@ -24,6 +28,7 @@ var knownBackends = []Backend{
 	BackendExternal,
 	BackendLocalServer,
 	BackendLocalSharedServer,
+	BackendExternalPooled,
 }
 
 func (b Backend) String() string { return string(b) }

--- a/internal/storage/dbproxy/proxy/endpoint.go
+++ b/internal/storage/dbproxy/proxy/endpoint.go
@@ -33,7 +33,7 @@ func IsUpstreamMismatch(err error) bool {
 }
 
 func intendedUpstreamID(opts OpenOpts) string {
-	if opts.Backend == BackendExternal {
+	if opts.Backend == BackendExternal || opts.Backend == BackendExternalPooled {
 		return server.ExternalDoltServerID(opts.External)
 	}
 	return ""
@@ -42,11 +42,21 @@ func intendedUpstreamID(opts OpenOpts) string {
 type Endpoint struct {
 	Host string
 	Port int
+	// Socket, when non-empty, is the unix-domain socket the pooled proxy
+	// listens on. Callers route clients here (Host/Port are unset in this case).
+	Socket string
 }
 
 func (e Endpoint) Address() string {
+	if e.Socket != "" {
+		return e.Socket
+	}
 	return net.JoinHostPort(e.Host, strconv.Itoa(e.Port))
 }
+
+// IsSocket reports whether the endpoint is a unix socket (pooled mode) rather
+// than a TCP host:port (passthrough mode).
+func (e Endpoint) IsSocket() bool { return e.Socket != "" }
 
 type OpenOpts struct {
 	IdleTimeout    time.Duration
@@ -55,6 +65,10 @@ type OpenOpts struct {
 	LogFilePath    string
 	DoltBinPath    string
 	External       configfile.ExternalDoltConfig
+	// PoolSocket is the unix socket the pooled proxy listens on (required for
+	// BackendExternalPooled). PoolSize overrides the default backend count.
+	PoolSocket string
+	PoolSize   int
 }
 
 const (
@@ -93,6 +107,16 @@ func GetCreateDatabaseProxyServerEndpoint(rootDir string, opts OpenOpts) (Endpoi
 	case BackendExternal:
 		if opts.LogFilePath == "" {
 			return Endpoint{}, fmt.Errorf("OpenOpts.LogFilePath is required for backend %q", opts.Backend)
+		}
+		if err := opts.External.Validate(); err != nil {
+			return Endpoint{}, fmt.Errorf("OpenOpts.External: %w", err)
+		}
+	case BackendExternalPooled:
+		if opts.LogFilePath == "" {
+			return Endpoint{}, fmt.Errorf("OpenOpts.LogFilePath is required for backend %q", opts.Backend)
+		}
+		if opts.PoolSocket == "" {
+			return Endpoint{}, fmt.Errorf("OpenOpts.PoolSocket is required for backend %q", opts.Backend)
 		}
 		if err := opts.External.Validate(); err != nil {
 			return Endpoint{}, fmt.Errorf("OpenOpts.External: %w", err)
@@ -238,7 +262,9 @@ func forkExecChild(rootDir string, opts OpenOpts, port int, lock *util.Lock) (*e
 	if opts.DoltBinPath != "" {
 		args = append(args, "--dolt-bin", opts.DoltBinPath)
 	}
-	if opts.Backend == BackendExternal {
+	// Both external (passthrough) and external-pooled fronts need the upstream
+	// Dolt connection details.
+	if opts.Backend == BackendExternal || opts.Backend == BackendExternalPooled {
 		ext := opts.External
 		if ext.Host != "" {
 			args = append(args, "--external-host", ext.Host)
@@ -260,6 +286,12 @@ func forkExecChild(rootDir string, opts OpenOpts, port int, lock *util.Lock) (*e
 		}
 		if ext.KeepAlivePeriod != 0 {
 			args = append(args, "--external-keep-alive", ext.KeepAlivePeriod.String())
+		}
+	}
+	if opts.Backend == BackendExternalPooled {
+		args = append(args, "--pool-socket", opts.PoolSocket)
+		if opts.PoolSize > 0 {
+			args = append(args, "--pool-size", strconv.Itoa(opts.PoolSize))
 		}
 	}
 
@@ -297,15 +329,26 @@ func readAndDial(rootDir string) (Endpoint, *pidfile.PidFile, bool) {
 	if err != nil || pf == nil {
 		return Endpoint{}, nil, false
 	}
-	ep := Endpoint{Host: "127.0.0.1", Port: pf.Port}
-	if !probePort(ep, 500*time.Millisecond) {
+	var ep Endpoint
+	if pf.Socket != "" {
+		ep = Endpoint{Socket: pf.Socket}
+	} else {
+		ep = Endpoint{Host: "127.0.0.1", Port: pf.Port}
+	}
+	if !probe(ep, 500*time.Millisecond) {
 		return Endpoint{}, nil, false
 	}
 	return ep, pf, true
 }
 
-func probePort(ep Endpoint, timeout time.Duration) bool {
-	conn, err := net.DialTimeout("tcp", ep.Address(), timeout)
+// probe dials the endpoint (TCP or unix socket) to confirm a server is
+// listening.
+func probe(ep Endpoint, timeout time.Duration) bool {
+	network := "tcp"
+	if ep.IsSocket() {
+		network = "unix"
+	}
+	conn, err := net.DialTimeout(network, ep.Address(), timeout)
 	if err != nil {
 		return false
 	}

--- a/internal/storage/dbproxy/proxy/pooled_server.go
+++ b/internal/storage/dbproxy/proxy/pooled_server.go
@@ -1,0 +1,173 @@
+package proxy
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"sync/atomic"
+	"syscall"
+	"time"
+
+	"github.com/steveyegge/beads/internal/lockfile"
+	"github.com/steveyegge/beads/internal/storage/dbproxy/pidfile"
+	"github.com/steveyegge/beads/internal/storage/dbproxy/pool"
+	"github.com/steveyegge/beads/internal/storage/dbproxy/util"
+)
+
+// PooledOpts configures a pooledServer.
+type PooledOpts struct {
+	// RootDir holds proxy.lock / proxy.pid / proxy.log (shared with the
+	// passthrough proxy so only one server per rootDir runs at a time).
+	RootDir string
+	// Socket is the unix-domain socket the pooler listens on for clients (bd).
+	Socket string
+	// DoltAddr is the external Dolt sql-server TCP address (host:port). Ignored
+	// if DoltSocket is set.
+	DoltAddr string
+	// DoltSocket is an optional unix socket path for the external Dolt server.
+	DoltSocket string
+	// DoltUser is the MySQL user backends authenticate as (default "root").
+	DoltUser string
+	// PoolSize is the number of persistent backends. Clamped to >= pool.MinSize.
+	PoolSize int
+	// IdleTimeout shuts the pooler down after this long with no client
+	// connections (0 disables, matching the passthrough proxy).
+	IdleTimeout time.Duration
+}
+
+// pooledServer is the QUERY-LEVEL serving mode of the dbproxy. It reuses the
+// passthrough proxy's lifecycle scaffolding — the proxy.lock flock, proxy.pid
+// pidfile, proxy.log, SIGTERM/SIGINT handling, the LockHeldExitCode contract,
+// and the idle-shutdown watcher — but swaps the serve core for a pool.Server
+// (vitess Listener + connection pool) listening on a unix socket.
+type pooledServer struct {
+	opts   PooledOpts
+	logger *log.Logger
+}
+
+// NewPooledServer constructs a pooledServer.
+func NewPooledServer(opts PooledOpts) *pooledServer {
+	return &pooledServer{opts: opts}
+}
+
+// ListenAndServe acquires the rootDir lock, warms the pool, writes the pidfile
+// (recording the socket path), serves clients, and shuts down on idle timeout
+// or signal. It returns ErrLockHeld if another server already owns the rootDir,
+// so a spawned child can map it to LockHeldExitCode exactly like the
+// passthrough proxy.
+func (s *pooledServer) ListenAndServe(parentCtx context.Context) error {
+	lock, err := util.TryLock(filepath.Join(s.opts.RootDir, LockFileName))
+	if err != nil {
+		if lockfile.IsLocked(err) {
+			return ErrLockHeld
+		}
+		return fmt.Errorf("acquire %s: %w", LockFileName, err)
+	}
+	defer lock.Unlock()
+
+	logPath := filepath.Join(s.opts.RootDir, LogFileName)
+	f, err := os.OpenFile(logPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600) // #nosec G304 -- logPath derived from operator config, not request input
+	if err != nil {
+		return fmt.Errorf("open proxy log %q: %w", logPath, err)
+	}
+	s.logger = log.New(f, "[pool-proxy] ", log.LstdFlags|log.Lmicroseconds)
+	defer func() { _ = f.Close() }()
+
+	ctx, cancel := context.WithCancel(parentCtx)
+	defer cancel()
+
+	// Install signal handlers BEFORE warmup so SIGTERM during startup still
+	// runs deferred cleanup (pidfile + socket removal).
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGTERM, syscall.SIGINT)
+	defer signal.Stop(sigCh)
+
+	var sigReceived atomic.Bool
+	go func() {
+		select {
+		case <-ctx.Done():
+		case <-sigCh:
+			sigReceived.Store(true)
+			cancel()
+		}
+	}()
+
+	srv, err := pool.NewServer(ctx, pool.ServerConfig{
+		Socket: s.opts.Socket,
+		Pool: pool.Config{
+			Addr:   s.opts.DoltAddr,
+			Socket: s.opts.DoltSocket,
+			User:   s.opts.DoltUser,
+			Size:   s.opts.PoolSize,
+		},
+		Logf: s.logger.Printf,
+	})
+	if err != nil {
+		return fmt.Errorf("warm pooler: %w", err)
+	}
+
+	if err := pidfile.Write(s.opts.RootDir, PIDFileName, pidfile.PidFile{
+		Pid:    os.Getpid(),
+		Socket: s.opts.Socket,
+	}); err != nil {
+		srv.Shutdown()
+		return fmt.Errorf("write pid file: %w", err)
+	}
+	defer func() { _ = pidfile.Remove(s.opts.RootDir, PIDFileName) }()
+
+	serveDone := make(chan struct{})
+	go func() {
+		defer close(serveDone)
+		srv.Serve() // blocks until srv.Shutdown closes the listener
+	}()
+
+	idleErr := s.idleWatch(ctx, srv)
+
+	srv.Shutdown()
+	<-serveDone
+
+	if errors.Is(idleErr, errIdleTimeout) || sigReceived.Load() {
+		return nil
+	}
+	return idleErr
+}
+
+// idleWatch shuts the pooler down after IdleTimeout with no active client
+// connections. It mirrors proxyServer.idleWatcher but reads the live
+// connection count from the pool handler. Returns errIdleTimeout on expiry, or
+// nil when the context is canceled.
+func (s *pooledServer) idleWatch(ctx context.Context, srv *pool.Server) error {
+	if s.opts.IdleTimeout <= 0 {
+		<-ctx.Done()
+		return nil
+	}
+	interval := s.opts.IdleTimeout / 4
+	if interval < idleWatcherMinInterval {
+		interval = idleWatcherMinInterval
+	}
+	tick := time.NewTicker(interval)
+	defer tick.Stop()
+	var idleSince time.Time
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-tick.C:
+			if srv.ActiveConns() > 0 {
+				idleSince = time.Time{}
+				continue
+			}
+			if idleSince.IsZero() {
+				idleSince = time.Now()
+				continue
+			}
+			if time.Since(idleSince) >= s.opts.IdleTimeout {
+				return errIdleTimeout
+			}
+		}
+	}
+}

--- a/internal/storage/dbproxy/proxy/pooled_server_test.go
+++ b/internal/storage/dbproxy/proxy/pooled_server_test.go
@@ -1,0 +1,60 @@
+package proxy
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/steveyegge/beads/internal/storage/dbproxy/util"
+)
+
+// TestPooledServer_ErrLockHeld verifies the pooled server reuses the same
+// rootDir flock contract as the passthrough proxy: if the lock is already held,
+// ListenAndServe returns ErrLockHeld (which the child maps to LockHeldExitCode)
+// without ever touching Dolt.
+func TestPooledServer_ErrLockHeld(t *testing.T) {
+	rootDir := t.TempDir()
+
+	// Hold the proxy lock from "another" process.
+	lock, err := util.TryLock(filepath.Join(rootDir, LockFileName))
+	if err != nil {
+		t.Fatalf("acquire lock: %v", err)
+	}
+	defer lock.Unlock()
+
+	s := NewPooledServer(PooledOpts{
+		RootDir:  rootDir,
+		Socket:   filepath.Join(rootDir, "pool.sock"),
+		DoltAddr: "127.0.0.1:3307",
+		PoolSize: 4,
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	err = s.ListenAndServe(ctx)
+	if !errors.Is(err, ErrLockHeld) {
+		t.Fatalf("expected ErrLockHeld, got %v", err)
+	}
+}
+
+// TestPooledServer_RequiresSocket verifies that the pooled child surfaces a
+// clear error when no client socket is configured.
+func TestPooledServer_RequiresSocket(t *testing.T) {
+	rootDir := t.TempDir()
+	s := NewPooledServer(PooledOpts{
+		RootDir:  rootDir,
+		DoltAddr: "127.0.0.1:3307",
+		PoolSize: 4,
+	})
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	err := s.ListenAndServe(ctx)
+	if err == nil {
+		t.Fatal("expected error for missing socket, got nil")
+	}
+	if errors.Is(err, ErrLockHeld) {
+		t.Fatalf("unexpected ErrLockHeld; want socket-required error: %v", err)
+	}
+}

--- a/internal/storage/dolt/pool_activation.go
+++ b/internal/storage/dolt/pool_activation.go
@@ -1,0 +1,135 @@
+package dolt
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/steveyegge/beads/internal/config"
+	"github.com/steveyegge/beads/internal/configfile"
+	"github.com/steveyegge/beads/internal/storage/dbproxy/pool"
+	"github.com/steveyegge/beads/internal/storage/dbproxy/proxy"
+)
+
+// maybeActivatePooler routes the server-mode store connection through the shared
+// connection pooler when BEADS_DOLT_POOL is opted in.
+//
+// The town's bd processes connect via the DIRECT server-mode path
+// (newServerMode -> openServerConnection over TCP to BEADS_DOLT_SERVER_HOST/PORT),
+// NOT through the uow external-doltserver provider. So activation must hook in
+// here, at the common server-mode connection setup, before the connectivity
+// check and DSN building.
+//
+// When activated, it ensures a SHARED, long-lived pooler child is running for
+// the resolved Dolt endpoint (one per host:port, reused across every bd process
+// via the proxy lock/pidfile in a stable rootDir) and rewrites cfg.ServerSocket
+// to the pooler socket. Everything downstream (the fail-fast dial in
+// newServerMode and buildServerDSN) already honors ServerSocket, so the whole
+// store transparently flows through the pooler.
+//
+// It is a no-op (returns nil, store unchanged) unless ALL of the following hold,
+// keeping the feature strictly opt-in with zero default behavior change:
+//   - BEADS_DOLT_POOL is truthy.
+//   - Not test mode (BEADS_TEST_MODE != 1): test traffic must never be pooled
+//     onto the production pooler.
+//   - The store is plain server mode over TCP: no socket already configured
+//     (operator socket is respected), not a proxied-server config, and a real
+//     host/port resolved.
+//
+// On any failure to bring up the pooler it logs a warning and leaves
+// cfg.ServerSocket untouched, so bd falls back to the direct connection rather
+// than failing the command.
+func maybeActivatePooler(cfg *Config) {
+	if !pool.EnabledFromEnv() {
+		return
+	}
+	// Safety: never pool test traffic onto the production pooler.
+	if os.Getenv("BEADS_TEST_MODE") == "1" {
+		return
+	}
+	// Respect an explicitly configured socket / proxied-server path; only the
+	// plain TCP server-mode path is hijacked.
+	if cfg.ServerSocket != "" || cfg.ProxiedServer {
+		return
+	}
+	if cfg.ServerHost == "" || cfg.ServerPort <= 0 {
+		return
+	}
+	// Never front the production endpoint while in test mode is covered above;
+	// here we additionally refuse to pool when the resolved port looks like a
+	// throwaway test server is not a concern — only real endpoints reach here.
+
+	socket, err := ensureSharedPooler(cfg.ServerHost, cfg.ServerPort, cfg.ServerUser)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "warning: BEADS_DOLT_POOL set but pooler unavailable (%v); using direct connection\n", err)
+		return
+	}
+	cfg.ServerSocket = socket
+}
+
+// ensureSharedPooler spawns-or-reuses the shared pooler child for the given Dolt
+// endpoint and returns the unix socket clients should connect to. The pooler is
+// keyed by host:port so every rig fronting the same Dolt server shares ONE
+// pooler process; the proxy lock/pidfile machinery makes concurrent bd
+// processes cooperate (first one spawns, the rest reuse).
+func ensureSharedPooler(host string, port int, user string) (string, error) {
+	rootDir, err := poolerRootDir(host, port)
+	if err != nil {
+		return "", err
+	}
+	if err := os.MkdirAll(rootDir, config.BeadsDirPerm); err != nil {
+		return "", fmt.Errorf("create pooler root %q: %w", rootDir, err)
+	}
+
+	socket := pool.SocketFromEnv(rootDir)
+	logPath := filepath.Join(rootDir, proxy.LogFileName)
+	if user == "" {
+		user = "root"
+	}
+
+	ep, err := proxy.GetCreateDatabaseProxyServerEndpoint(rootDir, proxy.OpenOpts{
+		Backend:     proxy.BackendExternalPooled,
+		LogFilePath: logPath,
+		PoolSocket:  socket,
+		PoolSize:    pool.SizeFromEnv(),
+		IdleTimeout: 0, // long-lived: shared across many short bd invocations
+		External: configfile.ExternalDoltConfig{
+			Host: host,
+			Port: port,
+			User: user,
+		},
+	})
+	if err != nil {
+		return "", fmt.Errorf("start shared pooler for %s:%d: %w", host, port, err)
+	}
+	if !ep.IsSocket() {
+		return "", fmt.Errorf("pooler endpoint is not a socket: %q", ep.Address())
+	}
+	return ep.Socket, nil
+}
+
+// poolerRootDir returns a stable per-endpoint directory under the user's beads
+// home, so all bd processes fronting the same Dolt host:port converge on the
+// same pooler (lock/pidfile/socket). Keyed by host_port.
+func poolerRootDir(host string, port int) (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve home dir: %w", err)
+	}
+	key := fmt.Sprintf("%s_%d", sanitizeKey(host), port)
+	return filepath.Join(home, ".beads", "pool", key), nil
+}
+
+// sanitizeKey makes a host string safe for a path segment.
+func sanitizeKey(host string) string {
+	out := make([]rune, 0, len(host))
+	for _, r := range host {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == '-', r == '.':
+			out = append(out, r)
+		default:
+			out = append(out, '_')
+		}
+	}
+	return string(out)
+}

--- a/internal/storage/dolt/pool_activation_test.go
+++ b/internal/storage/dolt/pool_activation_test.go
@@ -1,0 +1,94 @@
+package dolt
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestMaybeActivatePooler_NoOpWhenDisabled verifies the pooler stays OFF (and
+// never rewrites ServerSocket) unless every opt-in condition holds.
+func TestMaybeActivatePooler_NoOpWhenDisabled(t *testing.T) {
+	cases := []struct {
+		name string
+		env  map[string]string
+		cfg  Config
+	}{
+		{
+			name: "env unset",
+			env:  map[string]string{"BEADS_DOLT_POOL": ""},
+			cfg:  Config{ServerHost: "127.0.0.1", ServerPort: 3307},
+		},
+		{
+			name: "env false",
+			env:  map[string]string{"BEADS_DOLT_POOL": "0"},
+			cfg:  Config{ServerHost: "127.0.0.1", ServerPort: 3307},
+		},
+		{
+			name: "test mode blocks activation",
+			env:  map[string]string{"BEADS_DOLT_POOL": "1", "BEADS_TEST_MODE": "1"},
+			cfg:  Config{ServerHost: "127.0.0.1", ServerPort: 3307},
+		},
+		{
+			name: "explicit socket respected",
+			env:  map[string]string{"BEADS_DOLT_POOL": "1"},
+			cfg:  Config{ServerSocket: "/tmp/operator.sock", ServerHost: "127.0.0.1", ServerPort: 3307},
+		},
+		{
+			name: "proxied server not hijacked",
+			env:  map[string]string{"BEADS_DOLT_POOL": "1"},
+			cfg:  Config{ProxiedServer: true, ServerHost: "127.0.0.1", ServerPort: 3307},
+		},
+		{
+			name: "no port resolved",
+			env:  map[string]string{"BEADS_DOLT_POOL": "1"},
+			cfg:  Config{ServerHost: "127.0.0.1", ServerPort: 0},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			for k, v := range tc.env {
+				t.Setenv(k, v)
+			}
+			before := tc.cfg.ServerSocket
+			cfg := tc.cfg
+			maybeActivatePooler(&cfg)
+			if cfg.ServerSocket != before {
+				t.Fatalf("ServerSocket changed from %q to %q; expected no-op", before, cfg.ServerSocket)
+			}
+		})
+	}
+}
+
+// TestPoolerRootDir verifies the per-endpoint shared root dir is stable and
+// keyed by host:port so all rigs fronting the same Dolt server converge.
+func TestPoolerRootDir(t *testing.T) {
+	a, err := poolerRootDir("127.0.0.1", 3307)
+	if err != nil {
+		t.Fatalf("poolerRootDir: %v", err)
+	}
+	b, err := poolerRootDir("127.0.0.1", 3307)
+	if err != nil {
+		t.Fatalf("poolerRootDir: %v", err)
+	}
+	if a != b {
+		t.Fatalf("root dir not stable: %q vs %q", a, b)
+	}
+	if !strings.HasSuffix(a, filepath.Join("pool", "127.0.0.1_3307")) {
+		t.Fatalf("unexpected root dir %q", a)
+	}
+	// Different port -> different dir (so two Dolt endpoints get two poolers).
+	c, _ := poolerRootDir("127.0.0.1", 3308)
+	if c == a {
+		t.Fatalf("different ports collided: %q", c)
+	}
+}
+
+func TestSanitizeKey(t *testing.T) {
+	if got := sanitizeKey("127.0.0.1"); got != "127.0.0.1" {
+		t.Errorf("sanitizeKey(127.0.0.1) = %q", got)
+	}
+	if got := sanitizeKey("my/evil:host"); got != "my_evil_host" {
+		t.Errorf("sanitizeKey path-injection = %q, want my_evil_host", got)
+	}
+}

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -1004,6 +1004,13 @@ func New(ctx context.Context, cfg *Config) (*DoltStore, error) {
 // newServerMode creates a DoltStore connected to a running dolt sql-server.
 // This path is pure Go and does not require CGO.
 func newServerMode(ctx context.Context, cfg *Config) (*DoltStore, error) {
+	// Opt-in: when BEADS_DOLT_POOL is set, front the resolved Dolt endpoint with
+	// the shared connection pooler and redirect this store's connection to the
+	// pooler socket. No-op unless opted in; see maybeActivatePooler. This runs
+	// BEFORE the connectivity check / DSN building so cfg.ServerSocket takes
+	// effect for the rest of newServerMode.
+	maybeActivatePooler(cfg)
+
 	// Clean stale circuit breaker files before checking — prevents leftover
 	// state from previous sessions poisoning fresh inits (GH#2598).
 	CleanStaleCircuitBreakerFiles()

--- a/internal/storage/uow/dolt_sql_provider.go
+++ b/internal/storage/uow/dolt_sql_provider.go
@@ -107,6 +107,7 @@ func (p *doltSQLProvider) initSchema(ctx context.Context, database string) error
 
 func buildDSN(ep proxy.Endpoint, database, user, password string) string {
 	return util.DoltServerDSN{
+		Socket:   ep.Socket, // set in pooled mode; empty for TCP passthrough
 		Host:     ep.Host,
 		Port:     ep.Port,
 		User:     user,

--- a/internal/storage/uow/external_doltserver_provider.go
+++ b/internal/storage/uow/external_doltserver_provider.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/steveyegge/beads/internal/config"
 	"github.com/steveyegge/beads/internal/configfile"
+	"github.com/steveyegge/beads/internal/storage/dbproxy/pool"
 	"github.com/steveyegge/beads/internal/storage/dbproxy/proxy"
 )
 
@@ -41,12 +42,22 @@ func NewExternalDoltServerUOWProvider(
 		return nil, fmt.Errorf("uow: creating server root directory: %w", err)
 	}
 
-	ep, err := proxy.GetCreateDatabaseProxyServerEndpoint(absServerRootDir, proxy.OpenOpts{
+	opts := proxy.OpenOpts{
 		Backend:     proxy.BackendExternal,
 		LogFilePath: serverLogFilePath,
 		External:    external,
 		IdleTimeout: defaultProxyIdleTimeout,
-	})
+	}
+	// Opt-in: front the external Dolt server with the query-level connection
+	// pooler (a unix socket) instead of the TCP byte-passthrough proxy. Gated
+	// by BEADS_DOLT_POOL so default behavior is unchanged.
+	if pool.EnabledFromEnv() {
+		opts.Backend = proxy.BackendExternalPooled
+		opts.PoolSocket = pool.SocketFromEnv(absServerRootDir)
+		opts.PoolSize = pool.SizeFromEnv()
+	}
+
+	ep, err := proxy.GetCreateDatabaseProxyServerEndpoint(absServerRootDir, opts)
 	if err != nil {
 		return nil, fmt.Errorf("uow: get proxy endpoint: %w", err)
 	}

--- a/scripts/bd-pool
+++ b/scripts/bd-pool
@@ -1,0 +1,37 @@
+#!/bin/sh
+# bd-pool — town-wide wrapper that routes EVERY bd process through the SHARED
+# Dolt connection pooler (gt-ye21 / #4292).
+#
+# It sets BEADS_DOLT_POOL=1 and execs the real bd. On first use per Dolt
+# endpoint, bd spawns ONE shared, long-lived pooler child under
+# ~/.beads/pool/<host>_<port>/ (lock + pidfile + pool.sock); all subsequent bd
+# processes — gastown-daemon-spawned and interactive agent sessions alike —
+# reuse it, so Dolt sees ~K persistent connections instead of ~3 per bd
+# invocation.
+#
+# DEPLOYMENT (town-wide, zero per-caller config):
+#   1. Install the pooler-enabled bd binary somewhere stable, e.g.:
+#        cp /path/to/bd /Users/bbriski/.local/bin/bd-pooler
+#   2. Install this wrapper next to it and point it at that binary:
+#        cp scripts/bd-pool /Users/bbriski/.local/bin/bd-pool
+#        # edit REAL_BD below if your install path differs
+#   3. Repoint the bd symlink at the wrapper:
+#        ln -sf /Users/bbriski/.local/bin/bd-pool /opt/homebrew/bin/bd
+#
+# REVERT (instant, no rebuild):
+#   - Repoint the symlink back at the previous bd binary:
+#        ln -sf <previous-bd> /opt/homebrew/bin/bd
+#   - OR force-disable the pooler for a single call / globally:
+#        BEADS_DOLT_POOL=0 bd ...        # this call only
+#        export BEADS_DOLT_POOL=0        # whole shell
+#     With BEADS_DOLT_POOL unset/0 the same binary behaves exactly as before.
+#
+# TUNABLES (optional env, all have safe defaults):
+#   BEADS_DOLT_POOL_SIZE=16        # persistent backends (default 16, min 4)
+#   BEADS_DOLT_POOL_SOCKET=/path   # override the client socket path
+#
+# Point this at your pooler-enabled bd binary.
+REAL_BD="${BD_POOL_REAL_BD:-/Users/bbriski/.local/bin/bd-pooler}"
+
+# Default ON, but honor an explicit override (BEADS_DOLT_POOL=0 disables).
+BEADS_DOLT_POOL="${BEADS_DOLT_POOL:-1}" exec "$REAL_BD" "$@"


### PR DESCRIPTION
Core is built, tested, and proven end-to-end on a live town. An extended soak is running on a live workspace; see the testing comment below for full results.

## Problem
`bd`/`gt` use a connection-per-invocation model: every short-lived `bd` process opens its own Dolt sql-server connection. Under multi-process patrol/agent load this storms the listener's accept loop until it wedges ("alive but unresponsive"). Measured churn on a live town: hundreds of new Dolt connections/min, while concurrent connections stay tiny (sub-second open/close).

## Fix
A query-level MySQL connection **pooler** that fronts Dolt: it holds K persistent backend connections and multiplexes the many short-lived `bd` clients onto them, so **Dolt sees ~K connections regardless of client rate.**

- **`internal/storage/dbproxy/pool/`** — the pooler core: vitess `go/mysql` `Listener` + `Handler`, a persistent backend pool with keepalive + reconnect-on-borrow (Dolt idle-reaps loopback conns ~40s), bounded borrow-wait, and `COM_RESET_CONNECTION` between clients (proven to fully reset Dolt session state — branch/vars/autocommit/DB — so backends are safely reused with zero bleed).
- **`proxy/pooled_server.go`** — reuses the existing `dbproxy` lifecycle (lock/pidfile/log/idle-shutdown, signal handling) for a new pooled serving mode; the byte-passthrough proxy is untouched.
- **`internal/storage/dolt/pool_activation.go`** — `maybeActivatePooler`, hooked at the top of `newServerMode`, spawns one **shared, long-lived pooler per Dolt endpoint** and routes the server-mode store connection through its socket. **OFF by default** (opt-in via `BEADS_DOLT_POOL`), strict no-op otherwise, falls back to a direct connection on spawn failure.

### Prepared statements
`bd`'s server-mode DSN does not set `interpolateParams`, so go-sql-driver sends server-side `COM_STMT_PREPARE/EXECUTE`. The pooler implements these by interpolating bound params back into SQL via vitess `GenerateQuery` (SQL-encoded/escaped) and running plain text — so prepared statements work through the pool without a server-side prepare.

## Enabling
`BEADS_DOLT_POOL=1` (`BEADS_DOLT_POOL_SIZE=16`, `BEADS_DOLT_POOL_SOCKET=...` optional). See `internal/storage/dbproxy/pool/doc.go`.

## Evidence (live town Dolt)
- **Churn A/B, normal `bd` invocations:** plain ×60 → ~120–183 new Dolt connections; pooled ×60 → **~1–5.** ~30–180× collapse.
- **Shared + long-lived:** `bd` from multiple rigs uses the same pooler PID; one child process; per-rig DB isolation intact (correct `ComInitDB` per session).
- **Isolation/commit:** K=1 forced-reuse shows no session/branch/var bleed; a `DOLT_COMMIT` written through the pool is visible to a separate pooled reader.
- Tests + `golangci-lint`: green (incl. `-race`). Live-Dolt integration tests gated on `BEADS_POOL_TEST_DOLT_ADDR` (skipped in CI).

## Status / soak
Running on a live town now; churn collapse + stability confirmed across multiple steady-state windows (full results in the testing comment). Extended soak ongoing.
