### PR TITLE
revert: back out v1.1.0-rc.1 release prep (re-land after maintainer review)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "beads",
       "source": "./plugins/beads",
       "description": "AI-supervised issue tracker for coding workflows",
-      "version": "1.1.0-rc.1"
+      "version": "1.0.5"
     }
   ]
 }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,14 +46,7 @@ jobs:
           echo "OK: tag and version.go agree on $code_version"
 
       - name: Check version + docs consistency
-        run: |
-          tag_version="${GITHUB_REF_NAME#v}"
-          if [[ "$tag_version" == *-* ]]; then
-            echo "Prerelease tag detected; stable docs snapshot may remain on latest stable release."
-            ./scripts/check-versions.sh
-          else
-            BEADS_REQUIRE_RELEASE_DOCS=1 ./scripts/check-versions.sh
-          fi
+        run: BEADS_REQUIRE_RELEASE_DOCS=1 ./scripts/check-versions.sh
 
   release-package-mcp:
     name: Release Package Gate (MCP)
@@ -345,7 +338,7 @@ jobs:
   publish-pypi:
     runs-on: ubuntu-latest
     needs: [release-package-mcp, goreleaser]
-    if: ${{ github.repository == 'gastownhall/beads' && startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-') }}
+    if: ${{ github.repository == 'gastownhall/beads' && startsWith(github.ref, 'refs/tags/v') }}
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
@@ -380,7 +373,7 @@ jobs:
   publish-npm:
     runs-on: ubuntu-latest
     needs: [release-package-npm, goreleaser, goreleaser-macos]
-    if: ${{ github.repository == 'gastownhall/beads' && startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-') }}
+    if: ${{ github.repository == 'gastownhall/beads' && startsWith(github.ref, 'refs/tags/v') }}
     permissions:
       contents: read
       id-token: write  # Required for npm provenance/trusted publishing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.1.0-rc.1] - 2026-06-23
-
 ### Upgrade Notes
 
 - **Mixed bd versions sharing one Dolt remote.** Pre-1.0.6 binaries record

--- a/cmd/bd/info.go
+++ b/cmd/bd/info.go
@@ -214,18 +214,6 @@ type VersionChange struct {
 // versionChanges contains agent-actionable changes for recent versions
 var versionChanges = []VersionChange{
 	{
-		Version: "1.1.0-rc.1",
-		Date:    "2026-06-23",
-		Changes: []string{
-			"RC: v1.0.5 was pulled from the default release path after #4259; this candidate carries the cross-clone data-safety fixes for validation before stable promotion.",
-			"UPGRADE: For multiple clones sharing one Dolt remote, sync every clone before upgrading, designate one machine to migrate and push, then upgrade/pull the remaining clones before doing tracked work.",
-			"NEW: bd refuses silent in-place schema migrations on existing remote-backed databases unless BD_ALLOW_REMOTE_MIGRATE=1 is set by the designated migrator.",
-			"NEW: schema_migrations records per-migration content hashes, and bd doctor reports migration-content skew against the cached remote-tracking ref.",
-			"FIX: dependencies and wisp_dependencies now use deterministic natural-key-derived IDs, with migration 0050 rekeying existing rows and same-edge pull conflicts auto-resolved when only audit columns differ.",
-			"FIX: Dolt primary-key merge refusals are classified with recovery guidance instead of surfacing only a raw Error 1105.",
-		},
-	},
-	{
 		Version: "1.0.5",
 		Date:    "2026-05-28",
 		Changes: []string{

--- a/cmd/bd/version.go
+++ b/cmd/bd/version.go
@@ -16,7 +16,7 @@ import (
 
 var (
 	// Version is the current version of bd (overridden by ldflags at build time)
-	Version = "1.1.0-rc.1"
+	Version = "1.0.5"
 	// Build can be set via ldflags at compile time
 	Build = "dev"
 	// Commit and branch the git revision the binary was built from (optional ldflag)

--- a/cmd/bd/winres/manifest.xml
+++ b/cmd/bd/winres/manifest.xml
@@ -3,7 +3,7 @@
   <assemblyIdentity
     type="win32"
     name="beads.bd"
-    version="1.1.0.0"
+    version="1.0.5.0"
     processorArchitecture="*"/>
   <description>beads - AI-supervised issue tracker</description>
   <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">

--- a/cmd/bd/winres/winres.json
+++ b/cmd/bd/winres/winres.json
@@ -9,8 +9,8 @@
     "#1": {
       "0000": {
         "fixed": {
-          "file_version": "1.1.0",
-          "product_version": "1.1.0",
+          "file_version": "1.0.5",
+          "product_version": "1.0.5",
           "type": "App"
         },
         "info": {
@@ -18,12 +18,12 @@
             "Comments": "AI-supervised issue tracker for coding workflows",
             "CompanyName": "Steve Yegge",
             "FileDescription": "beads - AI-supervised issue tracker",
-            "FileVersion": "1.1.0-rc.1",
+            "FileVersion": "1.0.5",
             "InternalName": "bd",
             "LegalCopyright": "Copyright (c) 2024-2026 Steve Yegge. MIT License.",
             "OriginalFilename": "bd.exe",
             "ProductName": "beads",
-            "ProductVersion": "1.1.0-rc.1"
+            "ProductVersion": "1.0.5"
           }
         }
       }

--- a/default.nix
+++ b/default.nix
@@ -7,7 +7,7 @@
 }:
 buildGoModule {
   pname = "beads";
-  version = "1.1.0-rc.1";
+  version = "1.0.5";
 
   src = self;
 

--- a/integrations/beads-mcp/pyproject.toml
+++ b/integrations/beads-mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "beads-mcp"
-version = "1.1.0-rc.1"
+version = "1.0.5"
 description = "MCP server for beads issue tracker."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/integrations/beads-mcp/src/beads_mcp/__init__.py
+++ b/integrations/beads-mcp/src/beads_mcp/__init__.py
@@ -4,4 +4,4 @@ This package provides an MCP (Model Context Protocol) server that exposes
 beads (bd) issue tracker functionality to MCP Clients.
 """
 
-__version__ = "1.1.0-rc.1"
+__version__ = "1.0.5"

--- a/integrations/beads-mcp/uv.lock
+++ b/integrations/beads-mcp/uv.lock
@@ -80,7 +80,7 @@ wheels = [
 
 [[package]]
 name = "beads-mcp"
-version = "1.1.0rc1"
+version = "1.0.5"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },

--- a/npm-package/package.json
+++ b/npm-package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@beads/bd",
-  "version": "1.1.0-rc.1",
+  "version": "1.0.5",
   "description": "Beads issue tracker - lightweight memory system for coding agents with native binary support",
   "main": "bin/bd.js",
   "bin": {

--- a/plugins/beads/.claude-plugin/plugin.json
+++ b/plugins/beads/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "beads",
   "description": "AI-supervised issue tracker for coding workflows. Manage tasks, discover work, and maintain context with simple CLI commands.",
-  "version": "1.1.0-rc.1",
+  "version": "1.0.5",
   "author": {
     "name": "Steve Yegge",
     "url": "https://github.com/steveyegge"

--- a/plugins/beads/.codex-plugin/plugin.json
+++ b/plugins/beads/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "beads",
-  "version": "1.1.0-rc.1",
+  "version": "1.0.5",
   "description": "AI-supervised issue tracking for coding workflows with agent skills.",
   "author": {
     "name": "Steve Yegge",

--- a/plugins/beads/.copilot-plugin/plugin.json
+++ b/plugins/beads/.copilot-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "beads",
   "description": "AI-supervised issue tracker for coding workflows. Manage tasks, discover work, and maintain context with simple CLI commands.",
-  "version": "1.1.0-rc.1",
+  "version": "1.0.5",
   "author": {
     "name": "Steve Yegge",
     "url": "https://github.com/steveyegge"

--- a/scripts/check-docs-version.sh
+++ b/scripts/check-docs-version.sh
@@ -4,8 +4,8 @@
 # Between a version bump and the actual release, cmd/bd/version.go can be ahead
 # of the latest released docs snapshot. In normal PR/main CI, keep validating
 # the latest released docs without forcing it to match the unreleased binary
-# version. Set BEADS_REQUIRE_RELEASE_DOCS=1, or run from a stable v* tag, to
-# require the released docs snapshot to match the current binary version.
+# version. Set BEADS_REQUIRE_RELEASE_DOCS=1, or run from a v* tag, to require
+# the released docs snapshot to match the current binary version.
 
 set -euo pipefail
 
@@ -63,14 +63,10 @@ if [ -n "$LATEST_DOCS_VERSION" ]; then
 fi
 
 REQUIRE_RELEASE_DOCS="${BEADS_REQUIRE_RELEASE_DOCS:-}"
-IS_PRERELEASE=0
-if [[ "$CANONICAL" == *-* ]]; then
-    IS_PRERELEASE=1
-fi
-if [ -z "$REQUIRE_RELEASE_DOCS" ] && [ "$IS_PRERELEASE" -eq 0 ] && [[ "${GITHUB_REF:-}" == refs/tags/v* ]]; then
+if [ -z "$REQUIRE_RELEASE_DOCS" ] && [[ "${GITHUB_REF:-}" == refs/tags/v* ]]; then
     REQUIRE_RELEASE_DOCS=1
 fi
-if [ -z "$REQUIRE_RELEASE_DOCS" ] && [ "$IS_PRERELEASE" -eq 0 ] && [ "${GITHUB_REF_TYPE:-}" = "tag" ]; then
+if [ -z "$REQUIRE_RELEASE_DOCS" ] && [ "${GITHUB_REF_TYPE:-}" = "tag" ]; then
     REQUIRE_RELEASE_DOCS=1
 fi
 

--- a/scripts/gen-winres.sh
+++ b/scripts/gen-winres.sh
@@ -26,7 +26,6 @@ else
 fi
 
 echo "[winres] Generating Windows PE resources for bd v${VERSION}"
-PE_VERSION="${VERSION%%-*}"
 
 # Check for go-winres
 if ! command -v go-winres &> /dev/null; then
@@ -38,8 +37,8 @@ fi
 go-winres make \
     --in "$WINRES_DIR/winres.json" \
     --out "$OUT_PREFIX" \
-    --product-version "$PE_VERSION" \
-    --file-version "$PE_VERSION"
+    --product-version "$VERSION" \
+    --file-version "$VERSION"
 
 echo "[winres] Generated:"
 ls -la "$REPO_ROOT"/cmd/bd/rsrc_windows_*.syso 2>/dev/null || echo "[winres] (no .syso files found - check go-winres output)"

--- a/scripts/update-versions.sh
+++ b/scripts/update-versions.sh
@@ -24,16 +24,13 @@ usage() {
     echo ""
     echo "Updates version numbers across all components (no git operations),"
     echo "and snapshots the Docusaurus release docs so version.go and the docs"
-    echo "snapshot cannot drift apart for stable releases."
+    echo "snapshot cannot drift apart."
     echo ""
     echo "  --skip-docs   Skip the Docusaurus snapshot (e.g. on a host without"
     echo "                Node.js). You must then run scripts/snapshot-release-docs.sh"
-    echo "                <version> elsewhere before tagging a stable release, or CI"
-    echo "                will fail. Prereleases skip docs snapshots by default."
+    echo "                <version> elsewhere before tagging, or CI will fail."
     echo ""
-    echo "Examples:"
-    echo "  $0 0.47.1"
-    echo "  $0 1.1.0-rc.1"
+    echo "Example: $0 0.47.1"
     echo ""
     echo "For full releases, use: bd mol wisp beads-release --var version=X.Y.Z"
 }
@@ -59,18 +56,11 @@ if [ -z "$NEW_VERSION" ]; then
     exit 1
 fi
 
-# Validate semantic versioning. Accept prerelease identifiers so release
-# candidates can be cut without pretending to be stable package releases.
-if ! [[ $NEW_VERSION =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z][0-9A-Za-z.-]*)?$ ]]; then
+# Validate semantic versioning
+if ! [[ $NEW_VERSION =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
     echo -e "${RED}Error: Invalid version format '$NEW_VERSION'${NC}"
-    echo "Expected: MAJOR.MINOR.PATCH or MAJOR.MINOR.PATCH-prerelease (e.g., 0.47.1 or 1.1.0-rc.1)"
+    echo "Expected: MAJOR.MINOR.PATCH (e.g., 0.47.1)"
     exit 1
-fi
-
-BASE_VERSION="${NEW_VERSION%%-*}"
-IS_PRERELEASE=0
-if [ "$BASE_VERSION" != "$NEW_VERSION" ]; then
-    IS_PRERELEASE=1
 fi
 
 # Check we're in repo root
@@ -132,12 +122,12 @@ update_file "default.nix" "version = \"$CURRENT_VERSION\";" "version = \"$NEW_VE
 
 # 8. Windows PE resource metadata
 echo "  • cmd/bd/winres/winres.json"
-update_file "cmd/bd/winres/winres.json" "\"file_version\": \"$CURRENT_VERSION\"" "\"file_version\": \"$BASE_VERSION\""
-update_file "cmd/bd/winres/winres.json" "\"product_version\": \"$CURRENT_VERSION\"" "\"product_version\": \"$BASE_VERSION\""
+update_file "cmd/bd/winres/winres.json" "\"file_version\": \"$CURRENT_VERSION\"" "\"file_version\": \"$NEW_VERSION\""
+update_file "cmd/bd/winres/winres.json" "\"product_version\": \"$CURRENT_VERSION\"" "\"product_version\": \"$NEW_VERSION\""
 update_file "cmd/bd/winres/winres.json" "\"FileVersion\": \"$CURRENT_VERSION\"" "\"FileVersion\": \"$NEW_VERSION\""
 update_file "cmd/bd/winres/winres.json" "\"ProductVersion\": \"$CURRENT_VERSION\"" "\"ProductVersion\": \"$NEW_VERSION\""
 echo "  • cmd/bd/winres/manifest.xml"
-update_file "cmd/bd/winres/manifest.xml" "version=\"$CURRENT_VERSION.0\"" "version=\"$BASE_VERSION.0\""
+update_file "cmd/bd/winres/manifest.xml" "version=\"$CURRENT_VERSION.0\"" "version=\"$NEW_VERSION.0\""
 
 echo ""
 echo -e "${GREEN}✓ Version constants updated to $NEW_VERSION${NC}"
@@ -148,15 +138,8 @@ echo ""
 # main red after the 1.0.5 release (version bumped, docs snapshot missing).
 if [ "$SKIP_DOCS" -eq 1 ]; then
     echo -e "${YELLOW}Skipping docs snapshot (--skip-docs).${NC}"
-    if [ "$IS_PRERELEASE" -eq 1 ]; then
-        echo "  Prerelease CI does not require a stable docs snapshot for $NEW_VERSION."
-    else
-        echo "  Run scripts/snapshot-release-docs.sh $NEW_VERSION before tagging,"
-        echo "  or CI (check-version-consistency) will fail."
-    fi
-elif [ "$IS_PRERELEASE" -eq 1 ]; then
-    echo -e "${YELLOW}Skipping docs snapshot for prerelease $NEW_VERSION.${NC}"
-    echo "  Stable docs stay on the latest stable release until $BASE_VERSION ships."
+    echo "  Run scripts/snapshot-release-docs.sh $NEW_VERSION before tagging,"
+    echo "  or CI (check-version-consistency) will fail."
 else
     echo "Snapshotting release docs..."
     ./scripts/snapshot-release-docs.sh "$NEW_VERSION"


### PR DESCRIPTION
## High-level overview

This PR backs #4476 out so maintainers can review the v1.1.0-rc.1 release-prep change before it lands again. The release candidate being prepared is a post-v1.0.5 recovery candidate; the user-facing highlights since v1.0.5 are:

- **Data-safety recovery for #4259.** Dependency and history-table row IDs now converge deterministically across clones, `schema_migrations` records per-migration content hashes, and `bd doctor` can surface migration-content skew instead of leaving operators with cryptic Dolt merge failures.
- **Safer upgrades for shared remotes.** Remote-backed databases no longer silently apply pending schema migrations in place unless a designated migrator opts in with `BD_ALLOW_REMOTE_MIGRATE=1`; recovery guidance now recognizes Dolt primary-key merge refusals and points to the canonical-clone bootstrap path.
- **More reliable sync/merge behavior.** `bd dolt pull` can repair supported foreign-key cascade conflicts, handles mixed-version migration rows where safe, recomputes `is_blocked` after merges, and adds `bd recompute-blocked` plus doctor repair coverage for stale blocker state.
- **Broader server/proxied mode coverage.** More core commands now have server-mode implementations and parity coverage, including list/update/show/delete/close/dep/reopen/config/ready paths, with connection lifecycle and retry fixes around embedded Dolt/server mode.
- **CLI and workflow polish.** Notable user-facing additions include `bd init --init-if-missing`, `bd count --include-infra`, `children --pretty`, `defer --reason`, non-truncated piped `bd list`, safer worktree/where/no-db routing, and Jira custom-field support.
- **Recovery, docs, and release safety.** Compaction now archives content before destructive cleanup and restore works; docs/community tooling/recovery guidance were refreshed; CI/release gates catch version/docs/migration drift; RC release automation is intended to build GitHub prerelease artifacts without updating stable Homebrew/npm/PyPI channels.

After this revert merges, `main` returns to the post-#4411, pre-RC-prep state. No RC tag is created by this PR.

## Why

#4476 auto-merged before maintainers had a chance to review the RC release-prep changes. This backs it out in a normal PR so the release-prep patch can be reviewed and re-landed intentionally.

## What

- Reverts merge commit 427fdd0c852b1d3745dbfdce33b55f77892ec669 from #4476.
- Restores package/version metadata and release workflow scripts to the pre-RC-prep state.
- Preserves #4411 and subsequent `main` commits by reverting only the #4476 merge commit.

## Validation

- `git diff --check upstream/main..HEAD`
- `scripts/check-versions.sh`
