### PR TITLE
perf(schema): replace per-connection content_hash IS.COLUMNS probe with SHOW COLUMNS

### DIFF
--- a/internal/storage/dolt/dolt_benchmark_test.go
+++ b/internal/storage/dolt/dolt_benchmark_test.go
@@ -1902,3 +1902,46 @@ func BenchmarkGetIssuesByIDs_SmallNLargeW_10_10K(b *testing.B) {
 func BenchmarkGetIssuesByIDs_SmallNLargeW_100_5K(b *testing.B) {
 	benchmarkGetIssuesByIDsSmallN(b, 5000, 100)
 }
+
+// =============================================================================
+// Schema Probe Benchmarks
+// =============================================================================
+
+// BenchmarkContentHashColumnProbe compares the retired INFORMATION_SCHEMA.COLUMNS
+// existence probe against the SHOW COLUMNS probe that replaced it.
+// schema.MigrateUp's migrationWorkNeeded runs this probe twice on every
+// connection. INFORMATION_SCHEMA.COLUMNS forces Dolt to materialize the full
+// column catalog because the predicate is not pushed down; SHOW COLUMNS reads a
+// single table's schema directly. The gap measured here understates production:
+// on a multi-database deployment the old probe was measured at 19-60 ms/conn
+// versus ~0 ms on the new one.
+func BenchmarkContentHashColumnProbe(b *testing.B) {
+	store, cleanup := setupBenchStore(b)
+	defer cleanup()
+	ctx := context.Background()
+
+	b.Run("InformationSchema", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			var count int
+			if err := store.db.QueryRowContext(ctx,
+				`SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ? AND COLUMN_NAME = 'content_hash'`,
+				"schema_migrations").Scan(&count); err != nil {
+				b.Fatalf("information_schema probe: %v", err)
+			}
+		}
+	})
+
+	b.Run("ShowColumns", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			rows, err := store.db.QueryContext(ctx, "SHOW COLUMNS FROM schema_migrations LIKE 'content_hash'")
+			if err != nil {
+				b.Fatalf("show columns probe: %v", err)
+			}
+			for rows.Next() { //nolint:revive // draining the result set is the point
+			}
+			_ = rows.Close()
+		}
+	})
+}

--- a/internal/storage/schema/content_hash_test.go
+++ b/internal/storage/schema/content_hash_test.go
@@ -22,8 +22,8 @@ func TestEnsureContentHashColumnAddsWhenMissing(t *testing.T) {
 	}
 	defer db.Close()
 
-	mock.ExpectQuery(`SELECT COUNT\(\*\) FROM INFORMATION_SCHEMA\.COLUMNS`).
-		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
+	mock.ExpectQuery(`SHOW COLUMNS FROM schema_migrations LIKE 'content_hash'`).
+		WillReturnRows(showColumnsRows())
 	mock.ExpectExec(`ALTER TABLE schema_migrations ADD COLUMN content_hash CHAR\(64\)`).
 		WillReturnResult(sqlmock.NewResult(0, 0))
 
@@ -48,8 +48,8 @@ func TestEnsureContentHashColumnNoOpWhenPresent(t *testing.T) {
 	}
 	defer db.Close()
 
-	mock.ExpectQuery(`SELECT COUNT\(\*\) FROM INFORMATION_SCHEMA\.COLUMNS`).
-		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
+	mock.ExpectQuery(`SHOW COLUMNS FROM schema_migrations LIKE 'content_hash'`).
+		WillReturnRows(showColumnsRows("content_hash"))
 	// No ExpectExec: an ALTER here would be an unexpected call.
 
 	added, err := mainSource.ensureContentHashColumn(context.Background(), db)
@@ -112,8 +112,8 @@ func TestMigrationWorkNeededAddsContentHashColumnOnUpToDateDB(t *testing.T) {
 	expectScalar(mock, "SELECT COALESCE(MAX(version), 0) FROM schema_migrations", "version", LatestVersion())
 	expectScalar(mock, "SELECT COALESCE(MAX(version), 0) FROM ignored_schema_migrations", "version", LatestIgnoredVersion())
 	// ...but schema_migrations predates the content_hash column.
-	mock.ExpectQuery(`SELECT COUNT\(\*\) FROM INFORMATION_SCHEMA\.COLUMNS`).
-		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
+	mock.ExpectQuery(`SHOW COLUMNS FROM schema_migrations LIKE 'content_hash'`).
+		WillReturnRows(showColumnsRows())
 
 	needed, err := migrationWorkNeeded(context.Background(), db)
 	if err != nil {
@@ -140,10 +140,10 @@ func TestMigrationWorkNotNeededWhenContentHashColumnsPresent(t *testing.T) {
 
 	expectScalar(mock, "SELECT COALESCE(MAX(version), 0) FROM schema_migrations", "version", LatestVersion())
 	expectScalar(mock, "SELECT COALESCE(MAX(version), 0) FROM ignored_schema_migrations", "version", LatestIgnoredVersion())
-	mock.ExpectQuery(`SELECT COUNT\(\*\) FROM INFORMATION_SCHEMA\.COLUMNS`).
-		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
-	mock.ExpectQuery(`SELECT COUNT\(\*\) FROM INFORMATION_SCHEMA\.COLUMNS`).
-		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
+	mock.ExpectQuery(`SHOW COLUMNS FROM schema_migrations LIKE 'content_hash'`).
+		WillReturnRows(showColumnsRows("content_hash"))
+	mock.ExpectQuery(`SHOW COLUMNS FROM ignored_schema_migrations LIKE 'content_hash'`).
+		WillReturnRows(showColumnsRows("content_hash"))
 	// No backfill pending (custom tables already populated).
 	expectScalar(mock, "SELECT COUNT(*) FROM custom_types", "count", 1)
 	expectScalar(mock, "SELECT COUNT(*) FROM custom_statuses", "count", 1)

--- a/internal/storage/schema/lock_test.go
+++ b/internal/storage/schema/lock_test.go
@@ -156,6 +156,8 @@ func expectOnePendingMigration(t *testing.T, mock sqlmock.Sqlmock) {
 		WillReturnResult(sqlmock.NewResult(0, 0))
 }
 
+// expectColumnExists mocks the INFORMATION_SCHEMA.COLUMNS probe still used by
+// the dependency/aux id-column re-key paths (dep_id_backfill.go).
 func expectColumnExists(mock sqlmock.Sqlmock, present bool) {
 	n := 0
 	if present {
@@ -166,9 +168,12 @@ func expectColumnExists(mock sqlmock.Sqlmock, present bool) {
 }
 
 // expectContentHashColumnExists mocks the idempotent ensureContentHashColumn
-// probe, reporting that the content_hash column already exists (so no ALTER runs).
+// probe, reporting that the content_hash column already exists (so no ALTER
+// runs). The probe is a single-table SHOW COLUMNS, not an
+// INFORMATION_SCHEMA scan.
 func expectContentHashColumnExists(mock sqlmock.Sqlmock) {
-	expectColumnExists(mock, true)
+	mock.ExpectQuery(`SHOW COLUMNS FROM \w+ LIKE 'content_hash'`).
+		WillReturnRows(showColumnsRows("content_hash"))
 }
 
 func expectScalar(mock sqlmock.Sqlmock, query, column string, value any) {

--- a/internal/storage/schema/schema.go
+++ b/internal/storage/schema/schema.go
@@ -737,16 +737,50 @@ func (m migrationSource) bootstrapSQL() string {
 }
 
 // hasContentHashColumn reports whether the cursor table already carries the
-// content_hash column. It probes INFORMATION_SCHEMA, so a not-yet-created table
-// simply reports false.
+// content_hash column. A not-yet-created table simply reports false.
+//
+// It probes a single table with SHOW COLUMNS rather than INFORMATION_SCHEMA.COLUMNS,
+// whose predicate Dolt does not push down. The LIKE narrows the result set, but
+// we still compare the Field name exactly because '_' is a LIKE single-character
+// wildcard.
 func (m migrationSource) hasContentHashColumn(ctx context.Context, db DBConn) (bool, error) {
-	var count int
-	if err := db.QueryRowContext(ctx,
-		`SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ? AND COLUMN_NAME = 'content_hash'`,
-		m.cursorTable).Scan(&count); err != nil {
+	//nolint:gosec // G201: m.cursorTable is a hardcoded constant; the LIKE literal is fixed.
+	rows, err := db.QueryContext(ctx, "SHOW COLUMNS FROM "+m.cursorTable+" LIKE 'content_hash'")
+	if err != nil {
+		// SHOW COLUMNS errors on a missing table; the old INFORMATION_SCHEMA
+		// probe returned count 0 instead. Preserve that: an absent cursor table
+		// has no content_hash column.
+		if dberrors.IsTableNotExist(err) {
+			return false, nil
+		}
 		return false, fmt.Errorf("checking %s.content_hash: %w", m.cursorTable, err)
 	}
-	return count > 0, nil
+	defer func() { _ = rows.Close() }()
+
+	cols, err := rows.Columns()
+	if err != nil {
+		return false, fmt.Errorf("checking %s.content_hash: %w", m.cursorTable, err)
+	}
+	// SHOW COLUMNS returns Field, Type, Null, Key, Default, Extra (and possibly
+	// more on some servers); scan every column into RawBytes and read the first
+	// ("Field"), which is the column name.
+	cells := make([]sql.RawBytes, len(cols))
+	dest := make([]any, len(cols))
+	for i := range cells {
+		dest[i] = &cells[i]
+	}
+	for rows.Next() {
+		if err := rows.Scan(dest...); err != nil {
+			return false, fmt.Errorf("checking %s.content_hash: %w", m.cursorTable, err)
+		}
+		if len(cells) > 0 && string(cells[0]) == "content_hash" {
+			return true, nil
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return false, fmt.Errorf("checking %s.content_hash: %w", m.cursorTable, err)
+	}
+	return false, nil
 }
 
 // ensureContentHashColumn adds the content_hash column to an existing cursor

--- a/internal/storage/schema/schema_test.go
+++ b/internal/storage/schema/schema_test.go
@@ -3,6 +3,7 @@ package schema
 import (
 	"context"
 	"encoding/csv"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -706,5 +707,155 @@ func TestUnstageIgnoredTablesResetsExistingIgnoredTables(t *testing.T) {
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
+// showColumnsRows builds a SHOW COLUMNS result with one row per supplied field
+// name, mirroring the Field/Type/Null/Key/Default/Extra shape Dolt returns.
+func showColumnsRows(fields ...string) *sqlmock.Rows {
+	rows := sqlmock.NewRows([]string{"Field", "Type", "Null", "Key", "Default", "Extra"})
+	for _, f := range fields {
+		rows.AddRow(f, "char(64)", "YES", "", nil, "")
+	}
+	return rows
+}
+
+func TestHasContentHashColumnUsesShowColumns(t *testing.T) {
+	t.Run("column present", func(t *testing.T) {
+		db, mock, err := sqlmock.New()
+		if err != nil {
+			t.Fatalf("sqlmock.New: %v", err)
+		}
+		defer db.Close()
+
+		mock.ExpectQuery(`SHOW COLUMNS FROM schema_migrations LIKE 'content_hash'`).
+			WillReturnRows(showColumnsRows("content_hash"))
+
+		has, err := mainSource.hasContentHashColumn(context.Background(), db)
+		if err != nil {
+			t.Fatalf("hasContentHashColumn: %v", err)
+		}
+		if !has {
+			t.Fatal("has = false, want true when SHOW COLUMNS returns the column")
+		}
+		if err := mock.ExpectationsWereMet(); err != nil {
+			t.Fatalf("unmet sql expectations: %v", err)
+		}
+	})
+
+	t.Run("column absent", func(t *testing.T) {
+		db, mock, _ := sqlmock.New()
+		defer db.Close()
+		mock.ExpectQuery(`SHOW COLUMNS FROM schema_migrations`).
+			WillReturnRows(showColumnsRows())
+
+		has, err := mainSource.hasContentHashColumn(context.Background(), db)
+		if err != nil {
+			t.Fatalf("hasContentHashColumn: %v", err)
+		}
+		if has {
+			t.Fatal("has = true, want false when SHOW COLUMNS returns no rows")
+		}
+	})
+
+	t.Run("missing table reports false without error", func(t *testing.T) {
+		// The old INFORMATION_SCHEMA probe returned count 0 for an absent table;
+		// SHOW COLUMNS errors with 1146 instead. That error must be swallowed so a
+		// not-yet-created cursor table still reports "no content_hash column".
+		db, mock, _ := sqlmock.New()
+		defer db.Close()
+		mock.ExpectQuery(`SHOW COLUMNS FROM schema_migrations`).
+			WillReturnError(errors.New("Error 1146: Table 'beads.schema_migrations' doesn't exist"))
+
+		has, err := mainSource.hasContentHashColumn(context.Background(), db)
+		if err != nil {
+			t.Fatalf("hasContentHashColumn returned error for missing table, want nil: %v", err)
+		}
+		if has {
+			t.Fatal("has = true, want false for a missing cursor table")
+		}
+	})
+
+	t.Run("non-matching field is rejected", func(t *testing.T) {
+		// '_' is a LIKE single-char wildcard, so 'contentXhash' could slip past
+		// the server-side filter; the exact Field comparison must reject it.
+		db, mock, _ := sqlmock.New()
+		defer db.Close()
+		mock.ExpectQuery(`SHOW COLUMNS FROM schema_migrations`).
+			WillReturnRows(showColumnsRows("contentXhash"))
+
+		has, err := mainSource.hasContentHashColumn(context.Background(), db)
+		if err != nil {
+			t.Fatalf("hasContentHashColumn: %v", err)
+		}
+		if has {
+			t.Fatal("has = true, want false for a column that only matches the LIKE wildcard")
+		}
+	})
+
+	t.Run("propagates unexpected errors", func(t *testing.T) {
+		db, mock, _ := sqlmock.New()
+		defer db.Close()
+		mock.ExpectQuery(`SHOW COLUMNS FROM schema_migrations`).
+			WillReturnError(errors.New("connection refused"))
+
+		if _, err := mainSource.hasContentHashColumn(context.Background(), db); err == nil {
+			t.Fatal("expected unexpected error to propagate, got nil")
+		}
+	})
+}
+
+// TestHasContentHashColumnMatchesInformationSchemaOnDolt proves on a real Dolt
+// database that the SHOW COLUMNS probe returns the same answer as the retired
+// INFORMATION_SCHEMA.COLUMNS probe, in both the present and absent states.
+func TestHasContentHashColumnMatchesInformationSchemaOnDolt(t *testing.T) {
+	testutil.RequireDoltBinary(t)
+
+	dir := filepath.Join(t.TempDir(), "content-hash-probe")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("create probe dir: %v", err)
+	}
+	runDoltCommand(t, dir, "init", "--name", "test", "--email", "test@example.com")
+
+	const table = "schema_migrations"
+
+	// The retired probe: COUNT(*) over INFORMATION_SCHEMA.COLUMNS.
+	infoSchemaHas := func() bool {
+		rows := queryDoltCSV(t, dir, fmt.Sprintf(`
+SELECT COUNT(*) AS cnt
+FROM INFORMATION_SCHEMA.COLUMNS
+WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = '%s' AND COLUMN_NAME = 'content_hash'`, table))
+		return len(rows) == 1 && rows[0]["cnt"] == "1"
+	}
+	// The new probe: SHOW COLUMNS ... LIKE, matching the Field name exactly.
+	showColumnsHas := func() bool {
+		rows := queryDoltCSV(t, dir, fmt.Sprintf("SHOW COLUMNS FROM %s LIKE 'content_hash'", table))
+		for _, r := range rows {
+			for _, v := range r {
+				if v == "content_hash" {
+					return true
+				}
+			}
+		}
+		return false
+	}
+
+	// State 1: cursor table carries content_hash (matches bootstrapSQL).
+	runDoltSQL(t, dir, fmt.Sprintf(
+		"CREATE TABLE %s (version INT PRIMARY KEY, applied_at DATETIME, content_hash CHAR(64))", table))
+	if !showColumnsHas() {
+		t.Fatal("SHOW COLUMNS reported no content_hash on a table that has it")
+	}
+	if got, want := showColumnsHas(), infoSchemaHas(); got != want {
+		t.Fatalf("with content_hash: SHOW COLUMNS=%v, INFORMATION_SCHEMA=%v", got, want)
+	}
+
+	// State 2: same table without content_hash.
+	runDoltSQL(t, dir, fmt.Sprintf("ALTER TABLE %s DROP COLUMN content_hash", table))
+	if showColumnsHas() {
+		t.Fatal("SHOW COLUMNS reported content_hash on a table that lacks it")
+	}
+	if got, want := showColumnsHas(), infoSchemaHas(); got != want {
+		t.Fatalf("without content_hash: SHOW COLUMNS=%v, INFORMATION_SCHEMA=%v", got, want)
 	}
 }


### PR DESCRIPTION
## Human Commentary

During heavy load in Gas City this showed up as a major consumer of CPU cycles. All indications are that it is safe and performant. We are requesting the necessary data instead of grabbing significantly more from Dolt/database and narrowing down the desired data. I have not been able to find a reason not to make the change. No signs that there are any configurations where the change would not still function.

## What

Replace the per-connection `content_hash` existence probe in schema migration: `migrationSource.hasContentHashColumn` now uses `SHOW COLUMNS FROM <cursorTable> LIKE 'content_hash'` instead of `SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS`.

## Why

Dolt does not push the `INFORMATION_SCHEMA.COLUMNS` predicate down, so the old probe materialized **every column of every table across all databases** on each call. `migrationWorkNeeded` runs the probe **twice on every connection**, so on a multi-database deployment (5 DBs / ~1,843 columns) it cost ~19–60 ms/conn and was a measured ~34% of Dolt CPU — a recurring connection-storm driver. `SHOW COLUMNS` answers from a single table's schema without scanning `INFORMATION_SCHEMA`.

Correctness is preserved:

- The `Field` name is compared **exactly**, because `_` is a LIKE single-character wildcard.
- A missing cursor table makes `SHOW COLUMNS` error with 1146 where the old probe returned count 0; that error is swallowed (via `dberrors.IsTableNotExist`) so a not-yet-created table still reports *no content_hash column*.
- The separate id-column re-key probe in `dep_id_backfill.go` still uses `INFORMATION_SCHEMA.COLUMNS` and is intentionally unchanged (it runs only during a migration pass, not per-connection).

## Verification

```
go build ./...
go test ./internal/storage/schema/...
go test ./internal/storage/dolt/ -run='^$' -bench=BenchmarkContentHashColumnProbe -benchmem
```

- `BenchmarkContentHashColumnProbe` (before/after A/B): `INFORMATION_SCHEMA.COLUMNS` ~9.49 ms/op vs `SHOW COLUMNS … LIKE` ~0.22 ms/op (~43× faster). Reproduced locally on Dolt 2.1.8 at ~18 ms → ~0.43 ms.
- `TestHasContentHashColumnUsesShowColumns` (sqlmock): present, absent, missing-table-reports-false, LIKE-wildcard-rejected, error-propagation.
- `TestHasContentHashColumnMatchesInformationSchemaOnDolt` (real Dolt, gated by `RequireDoltBinary`): the new probe agrees with the retired `INFORMATION_SCHEMA` probe in both the present and absent states.

---
_Claude Code-claude-opus-4-8-high on behalf of John Zook