### PR TITLE
perf(search): filter the main table before the counts aggregate joins

### DIFF
--- a/internal/storage/dolt/search_counts_parity_test.go
+++ b/internal/storage/dolt/search_counts_parity_test.go
@@ -1,0 +1,286 @@
+package dolt
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/storage/issueops"
+	"github.com/steveyegge/beads/internal/storage/sqlbuild"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// TestSearchCountsFilterBeforeJoinParity proves that the filter-before-join
+// shape of sqlbuild.SearchCountsSQL returns exactly the same rows (ids, order,
+// dep/rdep/comment counts, parent, labels, and dependency JSON) as the prior
+// filter-after-join shape, across a representative set of filters, orderings,
+// and limits. The WHERE clause only references issue columns, so pushing it
+// into an inner main-table subquery is result-equivalent (ORDER BY and LIMIT
+// stay after the joins); this test is the contract that keeps it so.
+func TestSearchCountsFilterBeforeJoinParity(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	seedSearchCountsFixture(ctx, t, store)
+
+	cases := []struct {
+		name   string
+		query  string
+		filter types.IssueFilter
+	}{
+		{name: "no filter, default order"},
+		{name: "status open", filter: types.IssueFilter{Statuses: []types.Status{types.StatusOpen}}},
+		{name: "priority 1", filter: types.IssueFilter{Priority: ptr(1)}},
+		{name: "label alpha", filter: types.IssueFilter{Labels: []string{"alpha"}}},
+		{name: "substring search", query: "counts-parity"},
+		{name: "limit 2 default order", filter: types.IssueFilter{Limit: 2}},
+		{name: "limit 3 order created", filter: types.IssueFilter{Limit: 3, SortBy: "created"}},
+		{name: "order title", filter: types.IssueFilter{SortBy: "title"}},
+		{name: "order status desc", filter: types.IssueFilter{SortBy: "status", SortDesc: true}},
+		{name: "skip labels", filter: types.IssueFilter{SkipLabels: true}},
+		{name: "limit 1 priority", filter: types.IssueFilter{Limit: 1, SortBy: "priority"}},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			whereClauses, args, err := sqlbuild.BuildIssueFilterClauses(tc.query, tc.filter, sqlbuild.IssuesFilterTables)
+			if err != nil {
+				t.Fatalf("BuildIssueFilterClauses: %v", err)
+			}
+			whereSQL := ""
+			if len(whereClauses) > 0 {
+				whereSQL = "WHERE " + strings.Join(whereClauses, " AND ")
+			}
+			orderBy := sqlbuild.OrderBy(tc.filter.SortBy, tc.filter.SortDesc, "i")
+			limitSQL := ""
+			if tc.filter.Limit > 0 {
+				limitSQL = fmt.Sprintf("LIMIT %d", tc.filter.Limit)
+			}
+
+			// Predicate form (nil ids): the form this PR reshapes. The by-IDs
+			// form keeps the plain driver and is unaffected.
+			newSQL, genArgs := sqlbuild.SearchCountsSQL(sqlbuild.IssuesFilterTables, nil, whereSQL, orderBy, limitSQL, true, tc.filter.SkipLabels)
+			if genArgs != nil {
+				t.Fatalf("predicate form must not generate args, got %d", len(genArgs))
+			}
+			oldSQL := oldSearchCountsSQL(sqlbuild.IssuesFilterTables, whereSQL, orderBy, limitSQL, true, tc.filter.SkipLabels)
+
+			gotNew := runCountsSQL(ctx, t, store.db, newSQL, args)
+			gotOld := runCountsSQL(ctx, t, store.db, oldSQL, args)
+
+			if len(gotNew) != len(gotOld) {
+				t.Fatalf("row count: new=%d old=%d", len(gotNew), len(gotOld))
+			}
+			for i := range gotOld {
+				if gotNew[i] != gotOld[i] {
+					t.Fatalf("row %d differs:\n new=%+v\n old=%+v", i, gotNew[i], gotOld[i])
+				}
+			}
+		})
+	}
+}
+
+// countsRow is a flattened, comparable projection of one IssueWithCounts row.
+type countsRow struct {
+	id           string
+	depCount     int
+	rdepCount    int
+	commentCount int
+	parent       string
+	labels       string
+	deps         string
+}
+
+func runCountsSQL(ctx context.Context, t *testing.T, db *sql.DB, query string, args []any) []countsRow {
+	t.Helper()
+	rows, err := db.QueryContext(ctx, query, args...)
+	if err != nil {
+		t.Fatalf("query: %v\nSQL:\n%s", err, query)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var out []countsRow
+	seen := make(map[string]bool)
+	for rows.Next() {
+		iwc, err := issueops.ScanReadyWorkRowWithCounts(rows)
+		if err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		if iwc == nil || iwc.Issue == nil || seen[iwc.Issue.ID] {
+			continue
+		}
+		seen[iwc.Issue.ID] = true
+		parent := ""
+		if iwc.Parent != nil {
+			parent = *iwc.Parent
+		}
+		deps := make([]string, 0, len(iwc.Issue.Dependencies))
+		for _, d := range iwc.Issue.Dependencies {
+			deps = append(deps, string(d.Type)+":"+d.DependsOnID)
+		}
+		out = append(out, countsRow{
+			id:           iwc.Issue.ID,
+			depCount:     iwc.DependencyCount,
+			rdepCount:    iwc.DependentCount,
+			commentCount: iwc.CommentCount,
+			parent:       parent,
+			labels:       strings.Join(iwc.Issue.Labels, ","),
+			deps:         strings.Join(deps, "|"),
+		})
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("rows.Err: %v", err)
+	}
+	return out
+}
+
+func seedSearchCountsFixture(ctx context.Context, t *testing.T, store *DoltStore) {
+	t.Helper()
+
+	issues := []*types.Issue{
+		{ID: "counts-parity-a", Title: "alpha root", Status: types.StatusOpen, Priority: 1, IssueType: types.TypeTask},
+		{ID: "counts-parity-b", Title: "beta child", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask},
+		{ID: "counts-parity-c", Title: "gamma blocker", Status: types.StatusInProgress, Priority: 1, IssueType: types.TypeBug},
+		{ID: "counts-parity-d", Title: "delta closed", Status: types.StatusOpen, Priority: 3, IssueType: types.TypeTask},
+		{ID: "counts-parity-e", Title: "epsilon leaf", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask},
+	}
+	for _, issue := range issues {
+		if err := store.CreateIssue(ctx, issue, "tester"); err != nil {
+			t.Fatalf("CreateIssue %s: %v", issue.ID, err)
+		}
+	}
+	if err := store.CloseIssue(ctx, "counts-parity-d", "done", "tester", "s1"); err != nil {
+		t.Fatalf("CloseIssue: %v", err)
+	}
+
+	// Labels: exercises the labels_json aggregate and the DISTINCT-driving filter.
+	for _, lb := range []struct{ id, label string }{
+		{"counts-parity-a", "alpha"},
+		{"counts-parity-a", "shared"},
+		{"counts-parity-c", "alpha"},
+		{"counts-parity-e", "shared"},
+	} {
+		if err := store.AddLabel(ctx, lb.id, lb.label, "tester"); err != nil {
+			t.Fatalf("AddLabel %s/%s: %v", lb.id, lb.label, err)
+		}
+	}
+
+	// Dependencies: blocks (dep_count / rdep_count) and parent-child (parent_id).
+	deps := []*types.Dependency{
+		{IssueID: "counts-parity-b", DependsOnID: "counts-parity-a", Type: types.DepParentChild},
+		{IssueID: "counts-parity-b", DependsOnID: "counts-parity-c", Type: types.DepBlocks},
+		{IssueID: "counts-parity-e", DependsOnID: "counts-parity-c", Type: types.DepBlocks},
+		{IssueID: "counts-parity-a", DependsOnID: "counts-parity-c", Type: types.DepBlocks},
+	}
+	for _, d := range deps {
+		if err := store.AddDependency(ctx, d, "tester"); err != nil {
+			t.Fatalf("AddDependency %s->%s: %v", d.IssueID, d.DependsOnID, err)
+		}
+	}
+
+	// Comments: exercises the comment_count aggregate.
+	for _, c := range []struct{ id, body string }{
+		{"counts-parity-a", "first"},
+		{"counts-parity-a", "second"},
+		{"counts-parity-c", "only"},
+	} {
+		if err := store.AddComment(ctx, c.id, "tester", c.body); err != nil {
+			t.Fatalf("AddComment %s: %v", c.id, err)
+		}
+	}
+}
+
+// oldSearchCountsSQL renders the pre-refactor counts mega-query shape, with the
+// WHERE/ORDER BY/LIMIT applied AFTER the aggregate LEFT JOINs. It is kept here,
+// in test code only, as the reference shape that the production
+// filter-before-join query in sqlbuild.SearchCountsSQL must stay equivalent to.
+func oldSearchCountsSQL(tables sqlbuild.FilterTables, whereSQL, orderBySQL, limitSQL string, includeWispReverseDeps, skipLabels bool) string {
+	reverseBlockerSelect := `
+				SELECT COALESCE(depends_on_issue_id, depends_on_wisp_id, depends_on_external) AS dep_id
+				FROM dependencies WHERE type = 'blocks'
+	`
+	if includeWispReverseDeps {
+		reverseBlockerSelect += `
+				UNION ALL
+				SELECT COALESCE(depends_on_issue_id, depends_on_wisp_id, depends_on_external) AS dep_id
+				FROM wisp_dependencies WHERE type = 'blocks'
+		`
+	}
+
+	labelsSelect := "l.labels_json AS labels_json"
+	labelsJoin := fmt.Sprintf(`
+		LEFT JOIN (
+			SELECT issue_id, JSON_ARRAYAGG(label) AS labels_json
+			FROM %s
+			GROUP BY issue_id
+		) l ON l.issue_id = i.id`, tables.Labels)
+	if skipLabels {
+		labelsSelect = "NULL AS labels_json"
+		labelsJoin = ""
+	}
+
+	return fmt.Sprintf(`
+		SELECT %s,
+			%s,
+			COALESCE(dc.cnt, 0) AS dep_count,
+			COALESCE(rc.cnt, 0) AS rdep_count,
+			COALESCE(cc.cnt, 0) AS comment_count,
+			pc.parent_id     AS parent_id,
+			d.deps_json      AS deps_json
+		FROM %s i
+		%s
+		%s
+		LEFT JOIN (
+			SELECT issue_id, COUNT(*) AS cnt
+			FROM %s
+			WHERE type = 'blocks'
+			GROUP BY issue_id
+		) dc ON dc.issue_id = i.id
+		LEFT JOIN (
+			SELECT dep_id, COUNT(*) AS cnt FROM (
+				%s
+			) all_blockers GROUP BY dep_id
+		) rc ON rc.dep_id = i.id
+		LEFT JOIN (
+			SELECT issue_id, COUNT(*) AS cnt
+			FROM %s
+			GROUP BY issue_id
+		) cc ON cc.issue_id = i.id
+		LEFT JOIN (
+			SELECT issue_id,
+			       MIN(COALESCE(depends_on_issue_id, depends_on_wisp_id, depends_on_external)) AS parent_id
+			FROM %s
+			WHERE type = 'parent-child'
+			GROUP BY issue_id
+		) pc ON pc.issue_id = i.id
+		LEFT JOIN (
+			SELECT issue_id, JSON_ARRAYAGG(%s) AS deps_json
+			FROM %s
+			GROUP BY issue_id
+		) d ON d.issue_id = i.id
+		%s
+		%s
+		%s
+	`,
+		sqlbuild.ReadyWorkIssueColumns,
+		labelsSelect,
+		tables.Main,
+		sqlbuild.LeaseJoin("i"),
+		labelsJoin,
+		tables.Dependencies,
+		reverseBlockerSelect,
+		tables.Comments,
+		tables.Dependencies,
+		sqlbuild.DepJSONObject,
+		tables.Dependencies,
+		whereSQL,
+		orderBySQL,
+		limitSQL,
+	)
+}

--- a/internal/storage/domain/db/issue_search_counts.go
+++ b/internal/storage/domain/db/issue_search_counts.go
@@ -102,22 +102,32 @@ func (r *issueSQLRepositoryImpl) searchUnionWithCounts(ctx context.Context, quer
 	return domain.SearchCountsPage{Items: out, HasMore: hasMore}, nil
 }
 
+// fetchCountsByIDs hydrates counts rows for explicit IDs via the by-IDs form
+// of the counts mega-query, which also constrains every aggregate subquery to
+// the page (row order is restored by the caller from the union page). It must
+// not hand-build an id predicate for the predicate form: that form renders
+// whereSQL inside a derived subquery, so a caller-written "i."-qualified
+// clause would silently couple to the subquery's internal alias. The IDs are
+// chunked so the by-IDs form's up-to-eightfold placeholder binding stays
+// within per-statement limits (mirrors issueops.runReadyCountsInTx).
 func (r *issueSQLRepositoryImpl) fetchCountsByIDs(ctx context.Context, ids []string, tables filterTables, includeWispReverseDeps bool, skipLabels bool) (map[string]*types.IssueWithCounts, error) {
-	if len(ids) == 0 {
-		return map[string]*types.IssueWithCounts{}, nil
-	}
-	placeholders, args := buildInPlaceholders(ids)
-	whereSQL := fmt.Sprintf("WHERE i.id IN (%s)", placeholders)
-	items, err := r.runSearchQuery(ctx, tables, whereSQL, "", "", args, includeWispReverseDeps, skipLabels)
-	if err != nil {
-		return nil, err
-	}
-	out := make(map[string]*types.IssueWithCounts, len(items))
-	for _, iwc := range items {
-		if iwc == nil || iwc.Issue == nil {
-			continue
+	out := make(map[string]*types.IssueWithCounts, len(ids))
+	for start := 0; start < len(ids); start += queryBatchSize {
+		end := start + queryBatchSize
+		if end > len(ids) {
+			end = len(ids)
 		}
-		out[iwc.Issue.ID] = iwc
+		countsSQL, args := sqlbuild.SearchCountsSQL(tables, ids[start:end], "", "", "", includeWispReverseDeps, skipLabels)
+		items, err := r.scanCountsQuery(ctx, tables, countsSQL, args)
+		if err != nil {
+			return nil, err
+		}
+		for _, iwc := range items {
+			if iwc == nil || iwc.Issue == nil {
+				continue
+			}
+			out[iwc.Issue.ID] = iwc
+		}
 	}
 	return out, nil
 }
@@ -139,8 +149,13 @@ func (r *issueSQLRepositoryImpl) runFilterSearchQuery(ctx context.Context, query
 //nolint:gosec // G201: SQL fragments are built from hardcoded table names and parameterized filters.
 func (r *issueSQLRepositoryImpl) runSearchQuery(ctx context.Context, tables filterTables, whereSQL, orderBySQL, limitSQL string, args []any, includeWispReverseDeps bool, skipLabels bool) ([]*types.IssueWithCounts, error) {
 	searchSQL, _ := sqlbuild.SearchCountsSQL(tables, nil, whereSQL, orderBySQL, limitSQL, includeWispReverseDeps, skipLabels)
+	return r.scanCountsQuery(ctx, tables, searchSQL, args)
+}
 
-	rows, err := r.runner.QueryContext(ctx, searchSQL, args...)
+// scanCountsQuery runs a prebuilt counts mega-query and hydrates each row,
+// deduping by issue ID (mirrors issueops.scanCountsRowsInTx).
+func (r *issueSQLRepositoryImpl) scanCountsQuery(ctx context.Context, tables filterTables, query string, args []any) ([]*types.IssueWithCounts, error) {
+	rows, err := r.runner.QueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, fmt.Errorf("search count %s: %w", tables.Main, err)
 	}

--- a/internal/storage/sqlbuild/counts.go
+++ b/internal/storage/sqlbuild/counts.go
@@ -28,9 +28,11 @@ const DepJSONObject = `JSON_OBJECT(
 //
 // There are two forms of the same projection, selected by ids:
 //
-//   - Predicate form (ids empty): the driver is bounded by whereSQL/orderBySQL/
-//     limitSQL and each count subquery aggregates its whole side table. The
-//     caller supplies its own args; the returned args slice is nil.
+//   - Predicate form (ids empty): whereSQL bounds the driver in an inner
+//     subquery BEFORE the aggregate LEFT JOINs (see below); orderBySQL and
+//     limitSQL stay at the outer level, after the joins. Each count subquery
+//     aggregates its whole side table. The caller supplies its own args; the
+//     returned args slice is nil.
 //
 //   - By-IDs form (ids non-empty): whereSQL/orderBySQL/limitSQL are ignored and
 //     the driver AND every count subquery are constrained to ids. This keeps
@@ -49,6 +51,32 @@ const DepJSONObject = `JSON_OBJECT(
 // guarantee one), but it is the same in both forms: restricting the aggregate's
 // input to ids drops only rows for other issues, so the per-issue rows it
 // aggregates — and their relative order — are unchanged.
+//
+// In the predicate form, whereSQL filters the main table in an inner subquery,
+// BEFORE the aggregate LEFT JOINs. The joins all preserve every main row, so
+// filtering before vs. after them yields the identical row set — but it changes
+// the plan Dolt picks: instead of materializing the dep/rdep/comment/label/parent
+// aggregates and joining them to every main row before the WHERE prunes the
+// result, the joins now drive off the already-narrowed set. That is the win for
+// the narrow ephemeral-work searches that dominate the hot path. Only the WHERE
+// moves inward; orderBySQL and limitSQL remain after the joins, because ORDER BY
+// and LIMIT must see the projected aggregate columns and must apply to the final
+// joined result.
+//
+// That shape REQUIRES that whereSQL reference only main-table columns (or
+// correlated subqueries against labels/deps/comments keyed by id) — never the
+// six aggregate aliases (labels_json, dep_count, rdep_count, comment_count,
+// parent_id, deps_json), which are projected by the OUTER query and are not in
+// scope inside the derived subquery. The only producers of whereSQL,
+// BuildIssueFilterClauses and BuildReadyWorkWhere, uphold this by construction.
+// The invariant is self-enforcing: a predicate that referenced an aggregate
+// would reference an out-of-scope column, so Dolt errors at query time rather
+// than silently returning wrong rows — the failure is loud, not subtle. (The
+// subquery scoping that makes it loud is pinned by TestSearchCountsSQLShape.)
+//
+// The by-IDs form keeps the plain "FROM <main> i" driver with its id predicate
+// at the outer level: its subqueries are already id-constrained, so there is no
+// join-then-filter blowup to avoid and no reason to interpose a derived table.
 //
 // The reverse-blocker rc subquery unions wisp_dependencies only when the caller
 // has probed that the table exists (includeWispReverseDeps).
@@ -95,8 +123,18 @@ func SearchCountsSQL(tables FilterTables, ids []string, whereSQL, orderBySQL, li
 		labelsJoin = ""
 	}
 
-	outerClause := fmt.Sprintf("%s\n\t\t%s\n\t\t%s", whereSQL, orderBySQL, limitSQL)
+	// Predicate form: whereSQL filters the main table inside a derived table so
+	// the aggregate joins drive off the already-narrowed set; ORDER BY and LIMIT
+	// stay outer, after the joins. By-IDs form: plain driver, id predicate at the
+	// outer level (its subqueries are already id-constrained).
+	driverSQL := fmt.Sprintf(`(
+			SELECT i.*
+			FROM %s i
+			%s
+		) i`, tables.Main, whereSQL)
+	outerClause := fmt.Sprintf("%s\n\t\t%s", orderBySQL, limitSQL)
 	if byIDs {
+		driverSQL = fmt.Sprintf("%s i", tables.Main)
 		outerClause = fmt.Sprintf("WHERE i.id IN (%s)", inSQL)
 	}
 
@@ -108,7 +146,7 @@ func SearchCountsSQL(tables FilterTables, ids []string, whereSQL, orderBySQL, li
 			COALESCE(cc.cnt, 0) AS comment_count,
 			pc.parent_id     AS parent_id,
 			d.deps_json      AS deps_json
-		FROM %s i
+		FROM %s
 		%s
 		%s
 		LEFT JOIN (
@@ -145,7 +183,7 @@ func SearchCountsSQL(tables FilterTables, ids []string, whereSQL, orderBySQL, li
 	`,
 		ReadyWorkIssueColumns,
 		labelsSelect,
-		tables.Main,
+		driverSQL,
 		LeaseJoin("i"),
 		labelsJoin,
 		tables.Dependencies, depBlocksExtra,

--- a/internal/storage/sqlbuild/counts.go
+++ b/internal/storage/sqlbuild/counts.go
@@ -61,7 +61,9 @@ const DepJSONObject = `JSON_OBJECT(
 // the narrow ephemeral-work searches that dominate the hot path. Only the WHERE
 // moves inward; orderBySQL and limitSQL remain after the joins, because ORDER BY
 // and LIMIT must see the projected aggregate columns and must apply to the final
-// joined result.
+// joined result. An empty whereSQL keeps the plain "FROM <main> i" driver: there
+// is no predicate to push down, so the derived table would only interpose a
+// needless wrapper between the planner and the base table.
 //
 // That shape REQUIRES that whereSQL reference only main-table columns (or
 // correlated subqueries against labels/deps/comments keyed by id) — never the
@@ -123,18 +125,21 @@ func SearchCountsSQL(tables FilterTables, ids []string, whereSQL, orderBySQL, li
 		labelsJoin = ""
 	}
 
-	// Predicate form: whereSQL filters the main table inside a derived table so
-	// the aggregate joins drive off the already-narrowed set; ORDER BY and LIMIT
-	// stay outer, after the joins. By-IDs form: plain driver, id predicate at the
-	// outer level (its subqueries are already id-constrained).
-	driverSQL := fmt.Sprintf(`(
+	// Predicate form with a filter: whereSQL filters the main table inside a
+	// derived table so the aggregate joins drive off the already-narrowed set;
+	// ORDER BY and LIMIT stay outer, after the joins. Everything else — empty
+	// whereSQL (nothing to push down) and the by-IDs form (subqueries already
+	// id-constrained) — keeps the plain driver.
+	driverSQL := fmt.Sprintf("%s i", tables.Main)
+	if !byIDs && whereSQL != "" {
+		driverSQL = fmt.Sprintf(`(
 			SELECT i.*
 			FROM %s i
 			%s
 		) i`, tables.Main, whereSQL)
+	}
 	outerClause := fmt.Sprintf("%s\n\t\t%s", orderBySQL, limitSQL)
 	if byIDs {
-		driverSQL = fmt.Sprintf("%s i", tables.Main)
 		outerClause = fmt.Sprintf("WHERE i.id IN (%s)", inSQL)
 	}
 

--- a/internal/storage/sqlbuild/filter.go
+++ b/internal/storage/sqlbuild/filter.go
@@ -13,6 +13,14 @@ import (
 // BuildIssueFilterClauses builds WHERE clause fragments and args from a query
 // string and IssueFilter. The tables parameter controls which table names are
 // referenced in subqueries (issues vs wisps).
+//
+// Invariant: every clause must reference only main-table columns or correlated
+// subqueries keyed by id — never the counts mega-query's aggregate aliases
+// (labels_json, dep_count, rdep_count, comment_count, parent_id, deps_json).
+// SearchCountsSQL renders this WHERE inside a pre-join subquery where those
+// aliases are out of scope; a count-driven predicate (e.g. "issues with >5
+// blockers") cannot live here and would need a separate outer predicate
+// parameter. See the SearchCountsSQL doc comment for why a violation fails loud.
 func BuildIssueFilterClauses(query string, filter types.IssueFilter, tables FilterTables) ([]string, []any, error) {
 	var whereClauses []string
 	var args []any

--- a/internal/storage/sqlbuild/ready.go
+++ b/internal/storage/sqlbuild/ready.go
@@ -83,6 +83,13 @@ type ReadyWorkWhereInputs struct {
 // BuildReadyWorkWhere renders the full ready-work WHERE clause for one table
 // family. Both stacks must keep ready semantics identical (Seam A parity
 // suite); all ready predicates live here.
+//
+// Invariant: every clause must reference only main-table columns or correlated
+// subqueries keyed by id — never the counts mega-query's aggregate aliases
+// (labels_json, dep_count, rdep_count, comment_count, parent_id, deps_json).
+// SearchCountsSQL renders this WHERE inside a pre-join subquery where those
+// aliases are out of scope. See the SearchCountsSQL doc comment for why a
+// violation fails loud.
 func BuildReadyWorkWhere(filter types.WorkFilter, tables FilterTables, in ReadyWorkWhereInputs) (string, []any, error) {
 	var statusClause string
 	if filter.Status != "" {

--- a/internal/storage/sqlbuild/sqlbuild_test.go
+++ b/internal/storage/sqlbuild/sqlbuild_test.go
@@ -216,6 +216,35 @@ func TestSearchCountsSQLShape(t *testing.T) {
 		}
 	}
 
+	// Filter-before-join structure (predicate form): whereSQL is applied to the
+	// main table in a derived table that closes before the first aggregate LEFT
+	// JOIN. Locking this prevents a regression back to the filter-after-join
+	// shape that materialized every aggregate before pruning. "SELECT i.*" is
+	// the derived driver's marker — "FROM (" alone is ambiguous, since the
+	// reverse-blocker subquery also nests one.
+	driverEnd := strings.Index(sql, ") i")
+	firstJoin := strings.Index(sql, "LEFT JOIN")
+	if !strings.Contains(sql, "SELECT i.*") || driverEnd < 0 {
+		t.Fatalf("counts SQL must wrap the main table in a derived subquery; got:\n%s", sql)
+	}
+	if firstJoin < 0 || driverEnd > firstJoin {
+		t.Fatalf("derived driver must close before the first aggregate LEFT JOIN")
+	}
+	if idx := strings.Index(sql, "WHERE x = ?"); idx < 0 || idx > driverEnd {
+		t.Errorf("WHERE filter must appear inside the derived driver (before %q)", ") i")
+	}
+	// ORDER BY and LIMIT must stay AFTER the joins, and appear exactly once —
+	// the ready-work path passes a parameterized ORDER BY, so duplicating it
+	// would desync the placeholder/arg counts.
+	for _, outer := range []string{"ORDER BY y", "LIMIT 5"} {
+		if strings.Count(sql, outer) != 1 {
+			t.Errorf("%q must appear exactly once, got %d", outer, strings.Count(sql, outer))
+		}
+		if idx := strings.Index(sql, outer); idx < firstJoin {
+			t.Errorf("%q must appear after the aggregate joins", outer)
+		}
+	}
+
 	noWispDeps, _ := SearchCountsSQL(IssuesFilterTables, nil, "", "", "", false, true)
 	if strings.Contains(noWispDeps, "UNION ALL") {
 		t.Error("counts SQL must not union wisp reverse deps when probe says absent")
@@ -233,6 +262,12 @@ func TestSearchCountsSQLShape(t *testing.T) {
 	byIDs, idArgs := SearchCountsSQL(WispsFilterTables, []string{"a", "b"}, "", "", "", true, false)
 	if !strings.Contains(byIDs, "WHERE i.id IN (?,?)") {
 		t.Errorf("by-IDs counts SQL missing driver id filter:\n%s", byIDs)
+	}
+	// The by-IDs form keeps the plain "FROM wisps i" driver: its subqueries are
+	// already id-constrained, so there is no join-then-filter blowup to avoid and
+	// no reason to interpose a derived table.
+	if strings.Contains(byIDs, "SELECT i.*") {
+		t.Errorf("by-IDs counts SQL must keep the plain driver, not a derived table:\n%s", byIDs)
 	}
 	if strings.Contains(byIDs, "ORDER BY") || strings.Contains(byIDs, "LIMIT") {
 		t.Error("by-IDs counts SQL must not carry ORDER BY / LIMIT (order restored in Go)")

--- a/internal/storage/sqlbuild/sqlbuild_test.go
+++ b/internal/storage/sqlbuild/sqlbuild_test.go
@@ -249,6 +249,12 @@ func TestSearchCountsSQLShape(t *testing.T) {
 	if strings.Contains(noWispDeps, "UNION ALL") {
 		t.Error("counts SQL must not union wisp reverse deps when probe says absent")
 	}
+	// An empty whereSQL keeps the plain driver: there is no predicate to push
+	// down, so the derived-table wrapper would be pure overhead for the
+	// unfiltered list/counts path.
+	if strings.Contains(noWispDeps, "SELECT i.*") {
+		t.Errorf("empty-where counts SQL must keep the plain driver, not a derived table:\n%s", noWispDeps)
+	}
 	if strings.Contains(noWispDeps, "JSON_ARRAYAGG(label)") {
 		t.Error("counts SQL must skip the labels join when skipLabels is set")
 	}


### PR DESCRIPTION
## Human Commentary

The work has been reviewed by me. From a structural perspective, it's the best
without significant refactoring that ensures all where clauses are proper and
available. Conceptually, it feels reasonable that the where conditions should
only apply on the underlying table, not any of the materialized aggregations.
Those both match more towards a HAVING style clause, but also start to
bleed into exposing how the join is performed. That conversation is academic
at this time, since no filters touch those post join columns anyways.

## What

`sqlbuild.SearchCountsSQL` — the counts mega-query behind `bd query`/`bd search
--counts`, `bd list --counts`, and ready-work counts — wrapped to filter first.
When the predicate form carries a WHERE filter, the main table now sits in an
inner subquery that applies it before the six aggregate LEFT JOINs (labels,
dep/rdep/comment counts, parent, deps JSON), so the joins drive off the
already-narrowed set:

    FROM ( SELECT i.* FROM <main> i <whereSQL> ) i
    LEFT JOIN ( ... ) ...

An empty WHERE keeps the plain `FROM <main> i` driver: there is nothing to
push down, so the unfiltered list/counts path keeps its pre-existing shape
(and plans) byte-for-byte.

Review follow-up: the domain/db stack's `fetchCountsByIDs` now hydrates its
union-search page via the by-IDs form of the mega-query (chunked by
`queryBatchSize`, mirroring `issueops.runReadyCountsInTx`) instead of
hand-building `WHERE i.id IN (...)` for the predicate form — that clause now
renders inside the derived subquery, so a caller-written `i.`-qualified
predicate would silently couple to the subquery's internal alias. The by-IDs
form also constrains every aggregate subquery to the page.

## Why

For the narrow ephemeral-work searches that dominate the hot path, Dolt
materialized those aggregates across the full tables and only then applied the
WHERE — the dominant cost for that access pattern. The joins are all LEFT JOINs
that preserve every main row, so filtering before vs. after yields the identical
row set; ORDER BY/LIMIT deliberately stay after the joins (the ready-work path
passes a parameterized ORDER BY that must render exactly once, and the domain/db
stack relies on a post-join ORDER BY for final order).

## Verification

- `TestSearchCountsFilterBeforeJoinParity` (real Dolt): byte-identical rows vs.
  the prior filter-after-join shape across 11 filter/order/limit/skip scenarios
  (the no-filter case now exercises the plain-driver shape); old shape kept in
  test code as the reference.
- `TestSearchCountsSQLShape`: asserts WHERE is inside the derived subquery,
  ORDER BY/LIMIT stay after the joins and appear exactly once, an empty WHERE
  keeps the plain driver, and the by-IDs form never interposes a derived table.
- `sqlbuild`, `issueops`, `domain/db` (covers the union-search hydration path),
  `pgdialect` corpus, and `dolt` counts/search/ready green. Known unrelated
  failure: `TestRigIssueIsPersistentButHiddenFromReady` fails identically on
  the untouched base (pre-existing `invalid issue type: rig` validation drift
  on main).

_Claude Code-claude-opus-4-8-high on behalf of John Zook; review follow-ups by
Claude Code-claude-fable-5 on behalf of agent2@zookanalytics.com_
