### PR TITLE
fix(dolt): close db pool on any failure path in newServerMode/openServerConnection

### DIFF
--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -1125,9 +1125,16 @@ func newServerMode(ctx context.Context, cfg *Config) (*DoltStore, error) {
 		return nil, err
 	}
 
+	// Close the pool on any failure path below; cleared once ownership passes to the caller.
+	storeReady := false
+	defer func() {
+		if !storeReady {
+			_ = db.Close()
+		}
+	}()
+
 	// Test connection
 	if err := db.PingContext(ctx); err != nil {
-		_ = db.Close()
 		return nil, fmt.Errorf("failed to ping Dolt database: %w", err)
 	}
 
@@ -1161,7 +1168,6 @@ func newServerMode(ctx context.Context, cfg *Config) (*DoltStore, error) {
 	// would fail with cryptic unknown-column errors instead of a clear
 	// "upgrade bd" message (the stale-binary incident behind #4135/#4137).
 	if err := schema.CheckForwardDrift(ctx, db); err != nil {
-		_ = db.Close()
 		return nil, err
 	}
 	if !cfg.ReadOnly {
@@ -1178,7 +1184,6 @@ func newServerMode(ctx context.Context, cfg *Config) (*DoltStore, error) {
 			verifyErr = store.verifyProjectIdentity(ctx, cfg.BeadsDir)
 		}
 		if verifyErr != nil {
-			_ = db.Close()
 			return nil, verifyErr
 		}
 	}
@@ -1199,6 +1204,9 @@ func newServerMode(ctx context.Context, cfg *Config) (*DoltStore, error) {
 	// These report sql.DB.Stats() on each OTel scrape — no-op when telemetry is off.
 	store.registerPoolGauges()
 
+	// Ownership of db transfers to the returned store; suppress the deferred
+	// close above. Must be the last thing before the success return.
+	storeReady = true
 	return store, nil
 }
 
@@ -1413,19 +1421,25 @@ func openServerConnection(ctx context.Context, cfg *Config) (*sql.DB, string, er
 	// pairs in dolt-server.log).
 	applyPoolLimits(db, cfg)
 
+	// Close the pool on any failure path below; cleared at the success return.
+	connReady := false
+	defer func() {
+		if !connReady {
+			_ = db.Close()
+		}
+	}()
+
 	// Ensure database exists (may need to create it)
 	// First connect without database to create it
 	initConnStr := buildServerDSN(cfg, "")
 	initDB, err := sql.Open("mysql", initConnStr)
 	if err != nil {
-		_ = db.Close()
 		return nil, "", fmt.Errorf("failed to open init connection: %w", err)
 	}
 	defer func() { _ = initDB.Close() }()
 
 	// Validate database name to prevent SQL injection via backtick escaping
 	if err := ValidateDatabaseName(cfg.Database); err != nil {
-		_ = db.Close()
 		return nil, "", fmt.Errorf("invalid database name %q: %w", cfg.Database, err)
 	}
 
@@ -1433,7 +1447,6 @@ func openServerConnection(ctx context.Context, cfg *Config) (*sql.DB, string, er
 	// This is the last line of defense against test pollution (Clown Shows #12-#18).
 	// Pattern-based, not env-var-based — env vars can be misconfigured or missing.
 	if isTestDatabaseName(cfg.Database) && cfg.ServerPort == DefaultSQLPort {
-		_ = db.Close()
 		return nil, "", fmt.Errorf(
 			"REFUSED: will not CREATE DATABASE %q on production port %d — "+
 				"this is a test database name on the production server (see DOLT-WAR-ROOM.md)",
@@ -1450,14 +1463,12 @@ func openServerConnection(ctx context.Context, cfg *Config) (*sql.DB, string, er
 	// match unrelated databases with LIKE.
 	dbExists, checkErr := databaseExistsOnServer(ctx, initDB, cfg.Database)
 	if checkErr != nil {
-		_ = db.Close()
 		return nil, "", fmt.Errorf("failed to check if database %q exists on server %s:%d: %w",
 			cfg.Database, cfg.ServerHost, cfg.ServerPort, checkErr)
 	}
 
 	if !dbExists {
 		if !cfg.CreateIfMissing {
-			_ = db.Close()
 			return nil, "", databaseNotFoundError(cfg)
 		}
 
@@ -1466,7 +1477,6 @@ func openServerConnection(ctx context.Context, cfg *Config) (*sql.DB, string, er
 			// Dolt may return error 1007 even with IF NOT EXISTS - ignore if database already exists
 			errLower := strings.ToLower(err.Error())
 			if !strings.Contains(errLower, "database exists") && !strings.Contains(errLower, "1007") {
-				_ = db.Close()
 				// Check for connection refused - server likely not running
 				if strings.Contains(errLower, "connection refused") || strings.Contains(errLower, "connect: connection refused") {
 					return nil, "", fmt.Errorf("failed to connect to Dolt server at %s:%d: %w\n\nThe Dolt server may not be running. Try:\n  bd dolt start    # Start a local server\n  gt dolt start    # If using an orchestrator",
@@ -1496,10 +1506,10 @@ func openServerConnection(ctx context.Context, cfg *Config) (*sql.DB, string, er
 		}
 		return nil
 	}, backoff.WithContext(bo, ctx)); err != nil {
-		_ = db.Close()
 		return nil, "", fmt.Errorf("database %q not available after CREATE DATABASE: %w", cfg.Database, err)
 	}
 
+	connReady = true
 	return db, connStr, nil
 }
 


### PR DESCRIPTION
## Human Commentary

Original fix was adding the db.Close() that's missing in the following block, which leads to a connection leak (the underlying bug being fixed):
```
		if err := store.initSchema(ctx); err != nil {
			return nil, fmt.Errorf("failed to initialize schema: %w", err)
		}
```
but that just patches what is a structural problem that allows this class of errors to exist. So rewrote to protect all early returns in both functions. Claude's audit of other similar places in the code to apply this structural fix came up with nothing else.

## What

Installs a single deferred close guard at the point of pool acquisition in
both `newServerMode` and `openServerConnection` (`internal/storage/dolt/store.go`),
so the Dolt connection pool is closed on every early-return failure path and
released only once ownership transfers to the caller.

## Why

`newServerMode`'s `initSchema` branch returned without closing the pool, leaking
it. In a long-lived process these leaks accumulate toward `max_connections`
(`ConnMaxLifetime=1h` does not promptly reap idle leaked conns) — the suspected
driver of the multi-day connection creep. `openServerConnection` had the same
shape: six separate error returns each repeating `_ = db.Close()`, one bad merge
away from the same leak.

Rather than patch the one missing close, the guard makes the path forget-proof:

```go
ready := false
defer func() {
    if !ready {
        _ = db.Close()
    }
}()
```

`ready` is set true only at the success return, where ownership passes to the
caller (`newServerMode` -> `store.Close()`; `openServerConnection` -> the returned
`*sql.DB`). All the call-site `_ = db.Close()` closes are removed in favor of the
guard, so a future failure path cannot reintroduce the leak.

## Verification

- `go build ./internal/storage/dolt/`
- `go test ./internal/storage/dolt/`

_Claude Code-claude-opus-4-8-high on behalf of John Zook_