### PR TITLE
fix(cli): handle unchecked output-helper errors + regen metrics CLI docs (unbreak main)

### DIFF
--- a/cmd/bd/compact.go
+++ b/cmd/bd/compact.go
@@ -259,7 +259,9 @@ func runCompactSingle(ctx context.Context, compactor *compact.Compactor, store s
 					"total_content_bytes": originalSize,
 				},
 			}
-			outputJSON(output)
+			if err := outputJSON(output); err != nil {
+				fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			}
 			return
 		}
 
@@ -308,7 +310,9 @@ func runCompactSingle(ctx context.Context, compactor *compact.Compactor, store s
 			"reduction_pct":  float64(savingBytes) / float64(originalSize) * 100,
 			"elapsed_ms":     elapsed.Milliseconds(),
 		}
-		outputJSON(output)
+		if err := outputJSON(output); err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		}
 		return
 	}
 
@@ -345,11 +349,13 @@ func runCompactAll(ctx context.Context, compactor *compact.Compactor, store stor
 
 	if len(candidates) == 0 {
 		if jsonOutput {
-			outputJSON(map[string]interface{}{
+			if err := outputJSON(map[string]interface{}{
 				"success": true,
 				"count":   0,
 				"message": "No eligible candidates",
-			})
+			}); err != nil {
+				fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			}
 			return
 		}
 		fmt.Println("No eligible candidates for compaction")
@@ -401,7 +407,9 @@ func runCompactAll(ctx context.Context, compactor *compact.Compactor, store stor
 					"total_content_bytes": totalSize,
 				},
 			}
-			outputJSON(output)
+			if err := outputJSON(output); err != nil {
+				fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			}
 			return
 		}
 
@@ -460,7 +468,9 @@ func runCompactAll(ctx context.Context, compactor *compact.Compactor, store stor
 			"original_size": totalOriginal,
 			"elapsed_ms":    elapsed.Milliseconds(),
 		}
-		outputJSON(output)
+		if err := outputJSON(output); err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		}
 		return
 	}
 
@@ -508,7 +518,9 @@ func runCompactStats(ctx context.Context, store storage.DoltStorage) {
 				"implemented": false,
 			},
 		}
-		outputJSON(output)
+		if err := outputJSON(output); err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		}
 		return
 	}
 
@@ -622,7 +634,9 @@ func runCompactAnalyze(ctx context.Context, store storage.DoltStorage) {
 				"total_content_bytes": totalSize,
 			},
 		}
-		outputJSON(output)
+		if err := outputJSON(output); err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		}
 		return
 	}
 
@@ -745,7 +759,9 @@ func runCompactApply(ctx context.Context, store storage.DoltStorage) {
 			"reduction_pct":  reductionPct,
 			"elapsed_ms":     elapsed.Milliseconds(),
 		}
-		outputJSON(output)
+		if err := outputJSON(output); err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		}
 		return
 	}
 
@@ -774,7 +790,9 @@ func runCompactDolt() {
 					"dolt_path": doltPath,
 					"available": false,
 				}
-				outputJSON(output)
+				if err := outputJSON(output); err != nil {
+					fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+				}
 				return
 			}
 			fmt.Printf("DRY RUN - Dolt garbage collection\n\n")
@@ -802,7 +820,9 @@ func runCompactDolt() {
 				"size_before":  sizeBefore,
 				"size_display": formatBytes(sizeBefore),
 			}
-			outputJSON(output)
+			if err := outputJSON(output); err != nil {
+				fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			}
 			return
 		}
 		fmt.Printf("DRY RUN - Dolt garbage collection\n\n")
@@ -858,7 +878,9 @@ func runCompactDolt() {
 			"freed_display": formatBytes(freed),
 			"elapsed_ms":    elapsed.Milliseconds(),
 		}
-		outputJSON(result)
+		if err := outputJSON(result); err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		}
 		return
 	}
 

--- a/cmd/bd/create_proxied_server.go
+++ b/cmd/bd/create_proxied_server.go
@@ -97,7 +97,9 @@ func runCreateProxiedSingle(_ *cobra.Command, ctx context.Context, in createInpu
 		}
 		previewIssue := buildCreateIssueFromInput(in)
 		if in.jsonOutput {
-			outputJSON(previewIssue)
+			if err := outputJSON(previewIssue); err != nil {
+				fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			}
 		} else {
 			renderCreateDryRunPreview(previewIssue, previewLabels, in.deps)
 		}
@@ -153,7 +155,9 @@ func runCreateProxiedSingle(_ *cobra.Command, ctx context.Context, in createInpu
 
 	switch {
 	case in.jsonOutput:
-		outputJSON(result.Issue)
+		if err := outputJSON(result.Issue); err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		}
 	case in.silent:
 		fmt.Println(result.Issue.ID)
 	default:
@@ -303,7 +307,9 @@ func runCreateProxiedMarkdown(_ *cobra.Command, ctx context.Context, in createIn
 	}
 
 	if in.jsonOutput {
-		outputJSON(result.Issues)
+		if err := outputJSON(result.Issues); err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		}
 		return
 	}
 
@@ -376,7 +382,9 @@ func runCreateProxiedGraph(_ *cobra.Command, ctx context.Context, in createInput
 		if err := validateGraphApplyPlan(&plan, resolveProxiedCustomTypes(cctx.CustomTypes)); err != nil {
 			FatalError("invalid graph plan: %v", err)
 		}
-		emitGraphApplyDryRun(&plan)
+		if err := emitGraphApplyDryRun(&plan); err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		}
 		return
 	}
 
@@ -409,7 +417,9 @@ func runCreateProxiedGraph(_ *cobra.Command, ctx context.Context, in createInput
 	}
 
 	if in.jsonOutput {
-		outputJSON(GraphApplyResult{IDs: result.IDs})
+		if err := outputJSON(GraphApplyResult{IDs: result.IDs}); err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		}
 		return
 	}
 

--- a/cmd/bd/dolt.go
+++ b/cmd/bd/dolt.go
@@ -631,7 +631,9 @@ reachability, server version, and database.`,
 // is exercised by TestRunExternalDoltStatus_Unreachable).
 func renderLocalDoltStatus(state *doltserver.State, serverDir string) {
 	if jsonOutput {
-		outputJSON(state)
+		if err := outputJSON(state); err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		}
 		return
 	}
 	if state == nil || !state.Running {
@@ -753,7 +755,9 @@ func runExternalDoltStatus(beadsDir string, cfg *configfile.Config) {
 	}
 
 	if jsonOutput {
-		outputJSON(result)
+		if err := outputJSON(result); err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		}
 		return
 	}
 
@@ -786,7 +790,7 @@ func showEmbeddedDoltStatus(beadsDir string) {
 	}
 
 	if jsonOutput {
-		outputJSON(map[string]interface{}{
+		if err := outputJSON(map[string]interface{}{
 			"mode": "embedded",
 			// Embedded mode has an active in-process engine, but no
 			// separate server process. Use a server-specific field so
@@ -794,7 +798,9 @@ func showEmbeddedDoltStatus(beadsDir string) {
 			"server_running":  false,
 			"data_dir":        dataDir,
 			"data_dir_exists": dataDirExists,
-		})
+		}); err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		}
 		return
 	}
 
@@ -1068,7 +1074,7 @@ var doltRemoteAddCmd = &cobra.Command{
 		result, err := ensureDoltRemote(ctx, st, name, url, confirmDoltRemoteOverwrite)
 		if err != nil {
 			if jsonOutput {
-				outputJSONError(err, "remote_add_failed")
+				_ = outputJSONError(err, "remote_add_failed")
 			} else {
 				fmt.Fprintf(os.Stderr, "Error adding remote: %v\n", err)
 			}
@@ -1089,10 +1095,12 @@ var doltRemoteAddCmd = &cobra.Command{
 		}
 
 		if jsonOutput {
-			outputJSON(map[string]interface{}{
+			if err := outputJSON(map[string]interface{}{
 				"name": name,
 				"url":  url,
-			})
+			}); err != nil {
+				fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			}
 		} else {
 			fmt.Printf("Added remote %q → %s\n", name, url)
 		}
@@ -1113,7 +1121,7 @@ var doltRemoteListCmd = &cobra.Command{
 		remotes, err := st.ListRemotes(ctx)
 		if err != nil {
 			if jsonOutput {
-				outputJSONError(err, "remote_list_failed")
+				_ = outputJSONError(err, "remote_list_failed")
 			} else {
 				fmt.Fprintf(os.Stderr, "Error listing remotes: %v\n", err)
 			}
@@ -1121,7 +1129,9 @@ var doltRemoteListCmd = &cobra.Command{
 		}
 
 		if jsonOutput {
-			outputJSON(formatDoltRemoteListJSON(remotes))
+			if err := outputJSON(formatDoltRemoteListJSON(remotes)); err != nil {
+				fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			}
 			return
 		}
 
@@ -1172,7 +1182,7 @@ var doltRemoteRemoveCmd = &cobra.Command{
 
 		if err := st.RemoveRemote(ctx, name); err != nil {
 			if jsonOutput {
-				outputJSONError(err, "remote_remove_failed")
+				_ = outputJSONError(err, "remote_remove_failed")
 			} else {
 				fmt.Fprintf(os.Stderr, "Error removing remote: %v\n", err)
 			}
@@ -1191,10 +1201,12 @@ var doltRemoteRemoveCmd = &cobra.Command{
 		}
 
 		if jsonOutput {
-			outputJSON(map[string]interface{}{
+			if err := outputJSON(map[string]interface{}{
 				"name":    name,
 				"removed": true,
-			})
+			}); err != nil {
+				fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			}
 		} else {
 			fmt.Printf("Removed remote %q\n", name)
 		}
@@ -1302,7 +1314,9 @@ func showDoltConfig(testConnection bool) {
 				}
 			}
 		}
-		outputJSON(result)
+		if err := outputJSON(result); err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		}
 		return
 	}
 
@@ -1473,11 +1487,13 @@ func setDoltConfig(key, value string, updateConfig bool) {
 			os.Exit(1)
 		}
 		if jsonOutput {
-			outputJSON(map[string]interface{}{
+			if err := outputJSON(map[string]interface{}{
 				"key":      "shared-server",
 				"value":    lower,
 				"location": "config.yaml",
-			})
+			}); err != nil {
+				fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			}
 			return
 		}
 		if lower == "true" {
@@ -1513,7 +1529,9 @@ func setDoltConfig(key, value string, updateConfig bool) {
 		if updateConfig {
 			result["config_yaml_updated"] = true
 		}
-		outputJSON(result)
+		if err := outputJSON(result); err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		}
 		return
 	}
 
@@ -1555,11 +1573,13 @@ func testDoltConnection() {
 
 	if jsonOutput {
 		ok := testServerConnection(host, port)
-		outputJSON(map[string]interface{}{
+		if err := outputJSON(map[string]interface{}{
 			"host":          host,
 			"port":          port,
 			"connection_ok": ok,
-		})
+		}); err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		}
 		if !ok {
 			os.Exit(1)
 		}

--- a/cmd/bd/restore.go
+++ b/cmd/bd/restore.go
@@ -85,7 +85,9 @@ from Dolt version history, which can only be displayed, not applied.`,
 				os.Exit(1)
 			}
 			if jsonOutput {
-				outputJSON(restored)
+				if err := outputJSON(restored); err != nil {
+					fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+				}
 				return
 			}
 			fmt.Printf("%s Restored %s from archived snapshot (compaction level %d → %d)\n",
@@ -98,7 +100,9 @@ from Dolt version history, which can only be displayed, not applied.`,
 		if snap != nil {
 			view := snapshotView(issue, snap)
 			if jsonOutput {
-				outputJSON(view)
+				if err := outputJSON(view); err != nil {
+					fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+				}
 			} else {
 				displayRestoredIssue(view, "archived snapshot")
 				fmt.Printf("%s\n", ui.RenderMuted("Run 'bd restore "+issueID+" --apply' to write this content back."))
@@ -138,7 +142,9 @@ from Dolt version history, which can only be displayed, not applied.`,
 		}
 
 		if jsonOutput {
-			outputJSON(best.Issue)
+			if err := outputJSON(best.Issue); err != nil {
+				fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			}
 		} else {
 			hashDisplay := best.CommitHash
 			if len(hashDisplay) > 8 {

--- a/website/docs/cli-reference/metrics.md
+++ b/website/docs/cli-reference/metrics.md
@@ -24,7 +24,7 @@ any user-supplied text.
   bd metrics example    show real examples of the events bd sends
 
 ```
-bd metrics
+bd metrics [flags]
 ```
 
 ### bd metrics example
@@ -32,7 +32,7 @@ bd metrics
 Show real examples of the anonymous metrics bd sends
 
 ```
-bd metrics example
+bd metrics example [flags]
 ```
 
 ### bd metrics off
@@ -40,7 +40,7 @@ bd metrics example
 Turn anonymous usage metrics off
 
 ```
-bd metrics off
+bd metrics off [flags]
 ```
 
 ### bd metrics on
@@ -48,5 +48,5 @@ bd metrics off
 Turn anonymous usage metrics on
 
 ```
-bd metrics on
+bd metrics on [flags]
 ```


### PR DESCRIPTION
## Why
PR #4419's RunE refactor turned `main` CI red on two checks: **Lint** (golangci-lint `errcheck`) and **Check doc flags freshness**. `go build`/tests were green, so it slipped in; this restores main to green.

## What
- **errcheck**: wrap the previously-unchecked error returns from output helpers (`outputJSON`, `emitGraphApplyDryRun`) in the four files #4419 touched, surfacing a genuine encode failure to stderr instead of dropping it silently.
- **`outputJSONError` (3 sites in `bd dolt remote add/list/remove`)**: discard the return explicitly (`_ =`). `outputJSONError` *always* returns the `&exitError{Code:1}` sentinel after writing the JSON envelope, and the following `os.Exit(1)` drives the exit code — wrapping+logging it would emit a spurious `Error: exit code 1` after the JSON envelope, corrupting the stderr `--json` error contract. **(Caught by adversarial red-team review of this diff.)**
- **docs**: regenerate `website/docs/cli-reference/metrics.md` (the only stale generated doc; `CLI_REFERENCE.md` + `llms-full.txt` verified already in sync).

## Verification
`go build ./...`, `go vet ./...`, `gofmt -l`, `golangci-lint run` (0 errcheck), `./scripts/check-doc-flags.sh` all pass. Diff reviewed by a 4-lens adversarial red-team workflow (behavioral correctness / mis-wrap audit / error-handling appropriateness / doc completeness) with each finding independently verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)