### PR TITLE
docs: add Bead Me Up, Scotty to community tools

### DIFF
--- a/docs/COMMUNITY_TOOLS.md
+++ b/docs/COMMUNITY_TOOLS.md
@@ -23,6 +23,8 @@ A curated list of community-built UIs, extensions, and integrations for Beads. R
 
 - **[beads-web](https://github.com/weselow/beads-web)** - Actively maintained fork of beads-kanban-ui. Cross-platform single-binary distribution (macOS, Linux, Windows), 7 visual themes, Dolt direct SQL integration, Windows multi-drive path support, drag-and-drop status updates. Download from [GitHub Releases](https://github.com/weselow/beads-web/releases). Built by [@weselow](https://github.com/weselow). (TypeScript/Rust)
 
+- **[Bead Me Up, Scotty](https://github.com/brendan-appstart/bead-me-up-scotty)** - Polished multi-project web UI for creating, updating, and prioritizing beads across all your repos from one place. Kanban board with drag-and-drop status changes and reordering, plus list, epics (with progress bars), and dependency-graph views; faceted filtering and full-text search; live updates via SSE that react the moment `.beads/` changes; and human-vs-agent attribution throughout. Uses the `bd` CLI for full Dolt compatibility. Global install (`scotty`) opens the current directory's project in your browser, and a built-in Publish view generates a shareable static showcase site from your beads. Live demo at [beadmeupscotty.com](https://beadmeupscotty.com). Built by [@brendan-appstart](https://github.com/brendan-appstart). (Next.js/TypeScript)
+
 ## Editor Extensions
 
 - **[vscode-beads](https://marketplace.visualstudio.com/items?itemName=planet57.vscode-beads)** - VS Code extension with issues panel and server management. Built by [@jdillon](https://github.com/jdillon). (TypeScript)


### PR DESCRIPTION
Adds **[Bead Me Up, Scotty](https://github.com/brendan-appstart/bead-me-up-scotty)** to the Web UIs section of the community tools list.

It's a multi-project web UI for creating, updating, and prioritizing beads across all your repos from one place:

- Kanban board with drag-and-drop status changes and reordering, plus list, epics (with progress bars), and dependency-graph views
- Faceted filtering and full-text search
- Live updates via SSE that react the moment `.beads/` changes
- Human-vs-agent attribution throughout
- Uses the `bd` CLI for full Dolt compatibility
- Global install (`scotty`) opens the current directory's project in your browser, and a built-in Publish view generates a shareable static showcase site

Live demo: [beadmeupscotty.com](https://beadmeupscotty.com)

🤖 Generated with [Claude Code](https://claude.com/claude-code)