### PR TITLE
chore: re-land v1.1.0-rc.1 release prep

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "beads",
       "source": "./plugins/beads",
       "description": "AI-supervised issue tracker for coding workflows",
-      "version": "1.0.5"
+      "version": "1.1.0-rc.1"
     }
   ]
 }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,14 @@ jobs:
           echo "OK: tag and version.go agree on $code_version"
 
       - name: Check version + docs consistency
-        run: BEADS_REQUIRE_RELEASE_DOCS=1 ./scripts/check-versions.sh
+        run: |
+          tag_version="${GITHUB_REF_NAME#v}"
+          if [[ "$tag_version" == *-* ]]; then
+            echo "Prerelease tag detected; stable docs snapshot may remain on latest stable release."
+            ./scripts/check-versions.sh
+          else
+            BEADS_REQUIRE_RELEASE_DOCS=1 ./scripts/check-versions.sh
+          fi
 
   release-package-mcp:
     name: Release Package Gate (MCP)
@@ -338,7 +345,7 @@ jobs:
   publish-pypi:
     runs-on: ubuntu-latest
     needs: [release-package-mcp, goreleaser]
-    if: ${{ github.repository == 'gastownhall/beads' && startsWith(github.ref, 'refs/tags/v') }}
+    if: ${{ github.repository == 'gastownhall/beads' && startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-') }}
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
@@ -373,7 +380,7 @@ jobs:
   publish-npm:
     runs-on: ubuntu-latest
     needs: [release-package-npm, goreleaser, goreleaser-macos]
-    if: ${{ github.repository == 'gastownhall/beads' && startsWith(github.ref, 'refs/tags/v') }}
+    if: ${{ github.repository == 'gastownhall/beads' && startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-') }}
     permissions:
       contents: read
       id-token: write  # Required for npm provenance/trusted publishing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0-rc.1] - 2026-06-23
+
 ### Upgrade Notes
 
 - **Mixed bd versions sharing one Dolt remote.** Pre-1.0.6 binaries record

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -13,6 +13,7 @@ This document describes the complete release process for beads, including GitHub
 - [4. PyPI Release (MCP Server)](#4-pypi-release-mcp-server)
 - [5. npm Package Release](#5-npm-package-release)
 - [6. Verify Release](#6-verify-release)
+- [Prerelease / Release Candidate (RC) Workflow](#prerelease--release-candidate-rc-workflow)
 - [Hotfix Releases](#hotfix-releases)
 - [Rollback Procedure](#rollback-procedure)
 
@@ -513,6 +514,74 @@ curl -fsSL https://raw.githubusercontent.com/gastownhall/beads/main/scripts/inst
 bd version
 ```
 
+## Prerelease / Release Candidate (RC) Workflow
+
+Release candidates let a build be validated through the full release pipeline
+without promoting it to the stable channels. An RC carries a SemVer prerelease
+identifier (e.g. `1.1.0-rc.1`); Python tooling normalizes this to PEP 440 form
+(`1.1.0rc1`).
+
+**How a prerelease tag differs from a stable release:**
+
+- **GitHub release** is published and **marked as a prerelease** (goreleaser
+  `release.prerelease: auto`), with binaries for all platforms.
+- **Homebrew** is not updated (goreleaser `brews.skip_upload: true`; the core
+  formula only tracks stable releases).
+- **PyPI** and **npm** publish jobs are **skipped**. The `publish-pypi` and
+  `publish-npm` jobs are gated with `!contains(github.ref_name, '-')`, so a tag
+  containing a `-` never reaches the stable package channels.
+- **The stable docs snapshot is not required.** `verify-version-consistency`
+  runs `scripts/check-versions.sh` without `BEADS_REQUIRE_RELEASE_DOCS=1` for
+  prerelease tags, and `scripts/check-docs-version.sh` treats a prerelease
+  canonical version as non-strict. The versioned docs stay on the latest stable
+  release until the base `X.Y.Z` ships.
+
+### Cut an RC
+
+```bash
+# 1. Update CHANGELOG.md and cmd/bd/info.go with the RC notes (manual step),
+#    same as a stable release. Date the CHANGELOG section.
+
+# 2. Bump versions. update-versions.sh accepts a prerelease identifier and,
+#    for prereleases, skips the Docusaurus docs snapshot automatically.
+./scripts/update-versions.sh 1.1.0-rc.1
+#    Windows PE numeric fields (winres file_version/product_version and the
+#    manifest <assemblyIdentity> version) are set to the base version 1.1.0,
+#    because PE versions must be purely numeric; gen-winres.sh strips the
+#    prerelease suffix the same way at build time.
+
+# 3. Keep the MCP lockfile in sync (PEP 440 normalizes to 1.1.0rc1), or the
+#    Package Gate (MCP) check goes red:
+(cd integrations/beads-mcp && uv lock)
+
+# 4. Validate locally.
+./scripts/check-versions.sh
+
+# 5. Open a PR for the RC prep and have it reviewed. RC prep should land
+#    through normal review, not auto-merge.
+```
+
+After the RC prep is merged to `main`, cut the tag from the merge commit:
+
+```bash
+git checkout main && git pull
+git tag -a v1.1.0-rc.1 -m "Release candidate v1.1.0-rc.1"
+git push origin v1.1.0-rc.1
+```
+
+Pushing the `v*` tag triggers the release workflow with the prerelease behavior
+above. Tag creation is restricted to release maintainers; see
+[Prerequisites](#prerequisites).
+
+### Validate and promote
+
+- Install the RC from the GitHub prerelease assets and exercise the changes it
+  is gating before promoting.
+- To promote to stable, bump to the base version with no suffix
+  (`./scripts/update-versions.sh 1.1.0`). The stable bump **does** require the
+  docs snapshot and **does** publish to Homebrew/PyPI/npm, so follow the
+  standard [Prepare Release](#1-prepare-release) steps from there.
+
 ## Hotfix Releases
 
 For urgent bug fixes:
@@ -715,6 +784,11 @@ Examples:
 - `0.21.5` → `0.22.0`: New features (minor bump)
 - `0.22.0` → `0.22.1`: Bug fix (patch bump)
 - `0.22.1` → `1.0.0`: Stable release (major bump)
+
+**Prereleases:** append a SemVer prerelease identifier for release candidates,
+e.g. `1.1.0-rc.1`. Prerelease tags publish a GitHub prerelease only and stay
+off the stable Homebrew/PyPI/npm channels — see
+[Prerelease / Release Candidate (RC) Workflow](#prerelease--release-candidate-rc-workflow).
 
 ## Release Cadence
 

--- a/cmd/bd/info.go
+++ b/cmd/bd/info.go
@@ -214,6 +214,18 @@ type VersionChange struct {
 // versionChanges contains agent-actionable changes for recent versions
 var versionChanges = []VersionChange{
 	{
+		Version: "1.1.0-rc.1",
+		Date:    "2026-06-23",
+		Changes: []string{
+			"RC: v1.0.5 was pulled from the default release path after #4259; this candidate carries the cross-clone data-safety fixes for validation before stable promotion.",
+			"UPGRADE: For multiple clones sharing one Dolt remote, sync every clone before upgrading, designate one machine to migrate and push, then upgrade/pull the remaining clones before doing tracked work.",
+			"NEW: bd refuses silent in-place schema migrations on existing remote-backed databases unless BD_ALLOW_REMOTE_MIGRATE=1 is set by the designated migrator.",
+			"NEW: schema_migrations records per-migration content hashes, and bd doctor reports migration-content skew against the cached remote-tracking ref.",
+			"FIX: dependencies and wisp_dependencies now use deterministic natural-key-derived IDs, with migration 0050 rekeying existing rows and same-edge pull conflicts auto-resolved when only audit columns differ.",
+			"FIX: Dolt primary-key merge refusals are classified with recovery guidance instead of surfacing only a raw Error 1105.",
+		},
+	},
+	{
 		Version: "1.0.5",
 		Date:    "2026-05-28",
 		Changes: []string{

--- a/cmd/bd/version.go
+++ b/cmd/bd/version.go
@@ -16,7 +16,7 @@ import (
 
 var (
 	// Version is the current version of bd (overridden by ldflags at build time)
-	Version = "1.0.5"
+	Version = "1.1.0-rc.1"
 	// Build can be set via ldflags at compile time
 	Build = "dev"
 	// Commit and branch the git revision the binary was built from (optional ldflag)

--- a/cmd/bd/winres/manifest.xml
+++ b/cmd/bd/winres/manifest.xml
@@ -3,7 +3,7 @@
   <assemblyIdentity
     type="win32"
     name="beads.bd"
-    version="1.0.5.0"
+    version="1.1.0.0"
     processorArchitecture="*"/>
   <description>beads - AI-supervised issue tracker</description>
   <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">

--- a/cmd/bd/winres/winres.json
+++ b/cmd/bd/winres/winres.json
@@ -9,8 +9,8 @@
     "#1": {
       "0000": {
         "fixed": {
-          "file_version": "1.0.5",
-          "product_version": "1.0.5",
+          "file_version": "1.1.0",
+          "product_version": "1.1.0",
           "type": "App"
         },
         "info": {
@@ -18,12 +18,12 @@
             "Comments": "AI-supervised issue tracker for coding workflows",
             "CompanyName": "Steve Yegge",
             "FileDescription": "beads - AI-supervised issue tracker",
-            "FileVersion": "1.0.5",
+            "FileVersion": "1.1.0-rc.1",
             "InternalName": "bd",
             "LegalCopyright": "Copyright (c) 2024-2026 Steve Yegge. MIT License.",
             "OriginalFilename": "bd.exe",
             "ProductName": "beads",
-            "ProductVersion": "1.0.5"
+            "ProductVersion": "1.1.0-rc.1"
           }
         }
       }

--- a/default.nix
+++ b/default.nix
@@ -7,7 +7,7 @@
 }:
 buildGoModule {
   pname = "beads";
-  version = "1.0.5";
+  version = "1.1.0-rc.1";
 
   src = self;
 

--- a/integrations/beads-mcp/pyproject.toml
+++ b/integrations/beads-mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "beads-mcp"
-version = "1.0.5"
+version = "1.1.0-rc.1"
 description = "MCP server for beads issue tracker."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/integrations/beads-mcp/src/beads_mcp/__init__.py
+++ b/integrations/beads-mcp/src/beads_mcp/__init__.py
@@ -4,4 +4,4 @@ This package provides an MCP (Model Context Protocol) server that exposes
 beads (bd) issue tracker functionality to MCP Clients.
 """
 
-__version__ = "1.0.5"
+__version__ = "1.1.0-rc.1"

--- a/integrations/beads-mcp/uv.lock
+++ b/integrations/beads-mcp/uv.lock
@@ -80,7 +80,7 @@ wheels = [
 
 [[package]]
 name = "beads-mcp"
-version = "1.0.5"
+version = "1.1.0rc1"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },

--- a/npm-package/package.json
+++ b/npm-package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@beads/bd",
-  "version": "1.0.5",
+  "version": "1.1.0-rc.1",
   "description": "Beads issue tracker - lightweight memory system for coding agents with native binary support",
   "main": "bin/bd.js",
   "bin": {

--- a/plugins/beads/.claude-plugin/plugin.json
+++ b/plugins/beads/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "beads",
   "description": "AI-supervised issue tracker for coding workflows. Manage tasks, discover work, and maintain context with simple CLI commands.",
-  "version": "1.0.5",
+  "version": "1.1.0-rc.1",
   "author": {
     "name": "Steve Yegge",
     "url": "https://github.com/steveyegge"

--- a/plugins/beads/.codex-plugin/plugin.json
+++ b/plugins/beads/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "beads",
-  "version": "1.0.5",
+  "version": "1.1.0-rc.1",
   "description": "AI-supervised issue tracking for coding workflows with agent skills.",
   "author": {
     "name": "Steve Yegge",

--- a/plugins/beads/.copilot-plugin/plugin.json
+++ b/plugins/beads/.copilot-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "beads",
   "description": "AI-supervised issue tracker for coding workflows. Manage tasks, discover work, and maintain context with simple CLI commands.",
-  "version": "1.0.5",
+  "version": "1.1.0-rc.1",
   "author": {
     "name": "Steve Yegge",
     "url": "https://github.com/steveyegge"

--- a/scripts/check-docs-version.sh
+++ b/scripts/check-docs-version.sh
@@ -4,8 +4,8 @@
 # Between a version bump and the actual release, cmd/bd/version.go can be ahead
 # of the latest released docs snapshot. In normal PR/main CI, keep validating
 # the latest released docs without forcing it to match the unreleased binary
-# version. Set BEADS_REQUIRE_RELEASE_DOCS=1, or run from a v* tag, to require
-# the released docs snapshot to match the current binary version.
+# version. Set BEADS_REQUIRE_RELEASE_DOCS=1, or run from a stable v* tag, to
+# require the released docs snapshot to match the current binary version.
 
 set -euo pipefail
 
@@ -63,10 +63,14 @@ if [ -n "$LATEST_DOCS_VERSION" ]; then
 fi
 
 REQUIRE_RELEASE_DOCS="${BEADS_REQUIRE_RELEASE_DOCS:-}"
-if [ -z "$REQUIRE_RELEASE_DOCS" ] && [[ "${GITHUB_REF:-}" == refs/tags/v* ]]; then
+IS_PRERELEASE=0
+if [[ "$CANONICAL" == *-* ]]; then
+    IS_PRERELEASE=1
+fi
+if [ -z "$REQUIRE_RELEASE_DOCS" ] && [ "$IS_PRERELEASE" -eq 0 ] && [[ "${GITHUB_REF:-}" == refs/tags/v* ]]; then
     REQUIRE_RELEASE_DOCS=1
 fi
-if [ -z "$REQUIRE_RELEASE_DOCS" ] && [ "${GITHUB_REF_TYPE:-}" = "tag" ]; then
+if [ -z "$REQUIRE_RELEASE_DOCS" ] && [ "$IS_PRERELEASE" -eq 0 ] && [ "${GITHUB_REF_TYPE:-}" = "tag" ]; then
     REQUIRE_RELEASE_DOCS=1
 fi
 

--- a/scripts/gen-winres.sh
+++ b/scripts/gen-winres.sh
@@ -26,6 +26,7 @@ else
 fi
 
 echo "[winres] Generating Windows PE resources for bd v${VERSION}"
+PE_VERSION="${VERSION%%-*}"
 
 # Check for go-winres
 if ! command -v go-winres &> /dev/null; then
@@ -37,8 +38,8 @@ fi
 go-winres make \
     --in "$WINRES_DIR/winres.json" \
     --out "$OUT_PREFIX" \
-    --product-version "$VERSION" \
-    --file-version "$VERSION"
+    --product-version "$PE_VERSION" \
+    --file-version "$PE_VERSION"
 
 echo "[winres] Generated:"
 ls -la "$REPO_ROOT"/cmd/bd/rsrc_windows_*.syso 2>/dev/null || echo "[winres] (no .syso files found - check go-winres output)"

--- a/scripts/update-versions.sh
+++ b/scripts/update-versions.sh
@@ -24,13 +24,16 @@ usage() {
     echo ""
     echo "Updates version numbers across all components (no git operations),"
     echo "and snapshots the Docusaurus release docs so version.go and the docs"
-    echo "snapshot cannot drift apart."
+    echo "snapshot cannot drift apart for stable releases."
     echo ""
     echo "  --skip-docs   Skip the Docusaurus snapshot (e.g. on a host without"
     echo "                Node.js). You must then run scripts/snapshot-release-docs.sh"
-    echo "                <version> elsewhere before tagging, or CI will fail."
+    echo "                <version> elsewhere before tagging a stable release, or CI"
+    echo "                will fail. Prereleases skip docs snapshots by default."
     echo ""
-    echo "Example: $0 0.47.1"
+    echo "Examples:"
+    echo "  $0 0.47.1"
+    echo "  $0 1.1.0-rc.1"
     echo ""
     echo "For full releases, use: bd mol wisp beads-release --var version=X.Y.Z"
 }
@@ -56,11 +59,18 @@ if [ -z "$NEW_VERSION" ]; then
     exit 1
 fi
 
-# Validate semantic versioning
-if ! [[ $NEW_VERSION =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+# Validate semantic versioning. Accept prerelease identifiers so release
+# candidates can be cut without pretending to be stable package releases.
+if ! [[ $NEW_VERSION =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z][0-9A-Za-z.-]*)?$ ]]; then
     echo -e "${RED}Error: Invalid version format '$NEW_VERSION'${NC}"
-    echo "Expected: MAJOR.MINOR.PATCH (e.g., 0.47.1)"
+    echo "Expected: MAJOR.MINOR.PATCH or MAJOR.MINOR.PATCH-prerelease (e.g., 0.47.1 or 1.1.0-rc.1)"
     exit 1
+fi
+
+BASE_VERSION="${NEW_VERSION%%-*}"
+IS_PRERELEASE=0
+if [ "$BASE_VERSION" != "$NEW_VERSION" ]; then
+    IS_PRERELEASE=1
 fi
 
 # Check we're in repo root
@@ -122,12 +132,12 @@ update_file "default.nix" "version = \"$CURRENT_VERSION\";" "version = \"$NEW_VE
 
 # 8. Windows PE resource metadata
 echo "  • cmd/bd/winres/winres.json"
-update_file "cmd/bd/winres/winres.json" "\"file_version\": \"$CURRENT_VERSION\"" "\"file_version\": \"$NEW_VERSION\""
-update_file "cmd/bd/winres/winres.json" "\"product_version\": \"$CURRENT_VERSION\"" "\"product_version\": \"$NEW_VERSION\""
+update_file "cmd/bd/winres/winres.json" "\"file_version\": \"$CURRENT_VERSION\"" "\"file_version\": \"$BASE_VERSION\""
+update_file "cmd/bd/winres/winres.json" "\"product_version\": \"$CURRENT_VERSION\"" "\"product_version\": \"$BASE_VERSION\""
 update_file "cmd/bd/winres/winres.json" "\"FileVersion\": \"$CURRENT_VERSION\"" "\"FileVersion\": \"$NEW_VERSION\""
 update_file "cmd/bd/winres/winres.json" "\"ProductVersion\": \"$CURRENT_VERSION\"" "\"ProductVersion\": \"$NEW_VERSION\""
 echo "  • cmd/bd/winres/manifest.xml"
-update_file "cmd/bd/winres/manifest.xml" "version=\"$CURRENT_VERSION.0\"" "version=\"$NEW_VERSION.0\""
+update_file "cmd/bd/winres/manifest.xml" "version=\"$CURRENT_VERSION.0\"" "version=\"$BASE_VERSION.0\""
 
 echo ""
 echo -e "${GREEN}✓ Version constants updated to $NEW_VERSION${NC}"
@@ -138,8 +148,15 @@ echo ""
 # main red after the 1.0.5 release (version bumped, docs snapshot missing).
 if [ "$SKIP_DOCS" -eq 1 ]; then
     echo -e "${YELLOW}Skipping docs snapshot (--skip-docs).${NC}"
-    echo "  Run scripts/snapshot-release-docs.sh $NEW_VERSION before tagging,"
-    echo "  or CI (check-version-consistency) will fail."
+    if [ "$IS_PRERELEASE" -eq 1 ]; then
+        echo "  Prerelease CI does not require a stable docs snapshot for $NEW_VERSION."
+    else
+        echo "  Run scripts/snapshot-release-docs.sh $NEW_VERSION before tagging,"
+        echo "  or CI (check-version-consistency) will fail."
+    fi
+elif [ "$IS_PRERELEASE" -eq 1 ]; then
+    echo -e "${YELLOW}Skipping docs snapshot for prerelease $NEW_VERSION.${NC}"
+    echo "  Stable docs stay on the latest stable release until $BASE_VERSION ships."
 else
     echo "Snapshotting release docs..."
     ./scripts/snapshot-release-docs.sh "$NEW_VERSION"

--- a/scripts/update-versions.sh
+++ b/scripts/update-versions.sh
@@ -81,6 +81,11 @@ fi
 
 # Get current version
 CURRENT_VERSION=$(grep 'Version = ' cmd/bd/version.go | sed 's/.*"\(.*\)".*/\1/')
+# Base (prerelease-stripped) form of the current version. The Windows PE
+# numeric fields (file_version/product_version, manifest version) only ever
+# hold the base form, so they must be matched on the base, not on the full
+# CURRENT_VERSION which may carry a -rc.N suffix.
+CURRENT_BASE="${CURRENT_VERSION%%-*}"
 echo -e "${YELLOW}Bumping: $CURRENT_VERSION → $NEW_VERSION${NC}"
 echo ""
 
@@ -132,12 +137,12 @@ update_file "default.nix" "version = \"$CURRENT_VERSION\";" "version = \"$NEW_VE
 
 # 8. Windows PE resource metadata
 echo "  • cmd/bd/winres/winres.json"
-update_file "cmd/bd/winres/winres.json" "\"file_version\": \"$CURRENT_VERSION\"" "\"file_version\": \"$BASE_VERSION\""
-update_file "cmd/bd/winres/winres.json" "\"product_version\": \"$CURRENT_VERSION\"" "\"product_version\": \"$BASE_VERSION\""
+update_file "cmd/bd/winres/winres.json" "\"file_version\": \"$CURRENT_BASE\"" "\"file_version\": \"$BASE_VERSION\""
+update_file "cmd/bd/winres/winres.json" "\"product_version\": \"$CURRENT_BASE\"" "\"product_version\": \"$BASE_VERSION\""
 update_file "cmd/bd/winres/winres.json" "\"FileVersion\": \"$CURRENT_VERSION\"" "\"FileVersion\": \"$NEW_VERSION\""
 update_file "cmd/bd/winres/winres.json" "\"ProductVersion\": \"$CURRENT_VERSION\"" "\"ProductVersion\": \"$NEW_VERSION\""
 echo "  • cmd/bd/winres/manifest.xml"
-update_file "cmd/bd/winres/manifest.xml" "version=\"$CURRENT_VERSION.0\"" "version=\"$BASE_VERSION.0\""
+update_file "cmd/bd/winres/manifest.xml" "version=\"$CURRENT_BASE.0\"" "version=\"$BASE_VERSION.0\""
 
 echo ""
 echo -e "${GREEN}✓ Version constants updated to $NEW_VERSION${NC}"


### PR DESCRIPTION
## Why

#4476 auto-merged the v1.1.0-rc.1 release-prep change before maintainers
could review it. #4477 backed that out so the change could land through
normal review instead of by auto-merge. This PR re-lands the RC prep on top
of the post-revert `main` tip, so maintainers can review it here before the
candidate is tagged and published.

This is the review-and-publish gate: merging this PR puts the RC metadata on
`main`; cutting the `v1.1.0-rc.1` tag afterward is what actually publishes the
prerelease. v1.0.5 was pulled from the default release path after #4259; this
candidate carries the cross-clone data-safety fixes for validation before
stable promotion.

## Highlights since 1.0.5

- **Data-safety recovery for #4259.** Dependency and history-table row IDs now
  converge deterministically across clones (migration `0050` rekeys existing
  rows), `schema_migrations` records per-migration content hashes, and
  `bd doctor` surfaces migration-content skew instead of leaving operators
  with cryptic Dolt merge failures.
- **Safer upgrades for shared remotes.** Remote-backed databases no longer
  silently apply pending schema migrations in place unless a designated
  migrator opts in with `BD_ALLOW_REMOTE_MIGRATE=1`; recovery guidance now
  recognizes Dolt primary-key merge refusals and points to the canonical-clone
  bootstrap path (`docs/RECOVERY.md#pk-fork-refused`).
- **More reliable sync/merge behavior.** `bd dolt pull` repairs supported
  foreign-key cascade conflicts, handles mixed-version migration rows where
  safe, recomputes `is_blocked` after merges, and adds `bd recompute-blocked`
  plus doctor repair coverage for stale blocker state.
- **Broader server/proxied mode coverage.** More core commands gained
  server-mode implementations and parity coverage
  (list/update/show/delete/close/dep/reopen/config/ready), with connection
  lifecycle and retry fixes around embedded Dolt / server mode.
- **CLI and workflow polish.** `bd init --init-if-missing`,
  `bd count --include-infra`, `children --pretty`, `defer --reason`,
  non-truncated piped `bd list`, safer worktree/where/no-db routing, and Jira
  custom-field support.
- **Recovery, docs, and release safety.** Compaction archives content before
  destructive cleanup; docs/community tooling/recovery guidance refreshed;
  CI/release gates catch version/docs/migration drift; RC release automation
  builds GitHub prerelease artifacts without updating stable Homebrew / npm /
  PyPI channels.

See `CHANGELOG.md` and the `cmd/bd/info.go` entry restored in this PR for the
full per-change detail and upgrade notes.

## What

Re-applies the exact change reverted in #4477 (revert-of-the-revert on the
current tip), restoring:

- `v1.1.0-rc.1` version metadata across all package manifests (Go, npm,
  PyPI/uv, Nix, Windows PE resources, plugin manifests, marketplace).
- The prerelease-aware release workflow and version scripts
  (`release.yml`, `update-versions.sh`, `check-docs-version.sh`,
  `gen-winres.sh`): prerelease tags skip the stable docs-snapshot
  requirement and stay off the stable Homebrew/npm/PyPI channels.
- The `CHANGELOG.md` `1.1.0-rc.1` section and the `cmd/bd/info.go`
  agent-actionable version entry.

Also regenerates `integrations/beads-mcp/uv.lock` to `1.1.0rc1`. The original
#4476 / #4477 round left `uv.lock` out of sync with `pyproject.toml`, which
reddened the Package Gate (MCP) check; this keeps them consistent.

## Validation

- `uv lock --locked` passes (pyproject and lockfile agree on `1.1.0rc1`).
- `scripts/check-versions.sh`
- Diff vs `main` is exactly the 18 release-prep files, no unrelated changes.

_claude-opus-4-8-high on behalf of matt wilkie_
