### PR TITLE
bd context: proxied-server support

### DIFF
--- a/cmd/bd/context_cmd.go
+++ b/cmd/bd/context_cmd.go
@@ -55,6 +55,10 @@ Examples:
 			}
 		}()
 
+		if usesProxiedServer() {
+			return runContextProxiedServer(cmd, rootCtx)
+		}
+
 		info := ContextInfo{
 			Backend:   configfile.BackendDolt,
 			BdVersion: Version,

--- a/cmd/bd/context_proxied_integration_test.go
+++ b/cmd/bd/context_proxied_integration_test.go
@@ -1,0 +1,107 @@
+//go:build cgo
+
+package main
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/configfile"
+)
+
+func TestProxiedServerContext(t *testing.T) {
+	requireProxiedServerEnv(t)
+	bd := buildEmbeddedBD(t)
+	p := bdProxiedInit(t, bd, "ctx")
+
+	t.Run("default_text", func(t *testing.T) {
+		stdout, stderr, err := bdProxiedRunBuffers(t, bd, p.dir, "context")
+		if err != nil {
+			t.Fatalf("bd context failed: %v\nstdout:\n%s\nstderr:\n%s", err, stdout, stderr)
+		}
+		if !strings.Contains(stdout, configfile.DoltModeProxiedServer) {
+			t.Errorf("expected mode %q in context output:\n%s", configfile.DoltModeProxiedServer, stdout)
+		}
+		if !strings.Contains(stdout, ".beads") {
+			t.Errorf("expected .beads in context output:\n%s", stdout)
+		}
+	})
+
+	t.Run("json_fields", func(t *testing.T) {
+		info := proxiedContextJSON(t, bd, p)
+
+		if info.DoltMode != configfile.DoltModeProxiedServer {
+			t.Errorf("dolt_mode = %q, want %q", info.DoltMode, configfile.DoltModeProxiedServer)
+		}
+		if info.ProxiedDir == "" {
+			t.Error("proxied_dir should be populated in proxied-server mode")
+		}
+		if info.Database != p.database {
+			t.Errorf("database = %q, want %q", info.Database, p.database)
+		}
+		if filepath.Base(info.BeadsDir) != ".beads" {
+			t.Errorf("beads_dir = %q, want a path ending in .beads", info.BeadsDir)
+		}
+		if info.Backend != configfile.BackendDolt {
+			t.Errorf("backend = %q, want %q", info.Backend, configfile.BackendDolt)
+		}
+		if info.BdVersion == "" {
+			t.Error("bd_version should be populated")
+		}
+		if info.ServerHost != "" || info.ServerPort != 0 {
+			t.Errorf("server host/port must be empty in proxied-server mode: host=%q port=%d", info.ServerHost, info.ServerPort)
+		}
+	})
+
+	t.Run("concurrent", func(t *testing.T) {
+		const numWorkers = 8
+		errs := make([]error, numWorkers)
+		modes := make([]string, numWorkers)
+
+		var wg sync.WaitGroup
+		for i := 0; i < numWorkers; i++ {
+			wg.Add(1)
+			go func(idx int) {
+				defer wg.Done()
+				stdout, _, err := bdProxiedRunBuffers(t, bd, p.dir, "context", "--json")
+				if err != nil {
+					errs[idx] = err
+					return
+				}
+				var info ContextInfo
+				if jerr := json.Unmarshal([]byte(stdout), &info); jerr != nil {
+					errs[idx] = jerr
+					return
+				}
+				modes[idx] = info.DoltMode
+			}(i)
+		}
+		wg.Wait()
+
+		for i := 0; i < numWorkers; i++ {
+			if errs[i] != nil {
+				t.Errorf("worker %d: bd context failed: %v", i, errs[i])
+				continue
+			}
+			if modes[i] != configfile.DoltModeProxiedServer {
+				t.Errorf("worker %d: dolt_mode = %q, want %q", i, modes[i], configfile.DoltModeProxiedServer)
+			}
+		}
+	})
+}
+
+func proxiedContextJSON(t *testing.T, bd string, p proxiedProject) ContextInfo {
+	t.Helper()
+	stdout, stderr, err := bdProxiedRunBuffers(t, bd, p.dir, "context", "--json")
+	if err != nil {
+		t.Fatalf("bd context --json failed: %v\nstdout:\n%s\nstderr:\n%s", err, stdout, stderr)
+	}
+	var info ContextInfo
+	if jerr := json.Unmarshal([]byte(stdout), &info); jerr != nil {
+		t.Fatalf("decoding context JSON: %v\noutput:\n%s", jerr, stdout)
+	}
+	return info
+}

--- a/cmd/bd/context_proxied_server.go
+++ b/cmd/bd/context_proxied_server.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/steveyegge/beads/internal/storage/contextinfo"
+	"github.com/steveyegge/beads/internal/storage/domain"
+)
+
+func runContextProxiedServer(cmd *cobra.Command, ctx context.Context) error {
+	if selected := selectedNoDBBeadsDir(cmd); selected != "" {
+		prepareSelectedNoDBContext(selected)
+	}
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		return contextProxiedError("cannot resolve working directory: %v", err)
+	}
+
+	info, err := contextinfo.NewContextProvider(cwd, Version).ContextUseCase().GetContextInfo(ctx)
+	if err != nil {
+		return contextProxiedError("cannot resolve context: %v", err)
+	}
+
+	view := contextInfoView(info)
+	if jsonOutput {
+		return outputJSON(view)
+	}
+	printContextText(view)
+	return nil
+}
+
+func contextProxiedError(format string, args ...any) error {
+	if jsonOutput {
+		if jerr := outputJSON(map[string]string{"error": fmt.Sprintf(format, args...)}); jerr != nil {
+			return jerr
+		}
+		return SilentExit()
+	}
+	return HandleError(format, args...)
+}
+
+func contextInfoView(d domain.ContextInfo) ContextInfo {
+	return ContextInfo{
+		BeadsDir:      d.BeadsDir,
+		RepoRoot:      d.RepoRoot,
+		CWDRepoRoot:   d.CWDRepoRoot,
+		IsRedirected:  d.IsRedirected,
+		IsWorktree:    d.IsWorktree,
+		Backend:       d.Backend,
+		DoltMode:      d.DoltMode,
+		ServerHost:    d.ServerHost,
+		ServerPort:    d.ServerPort,
+		ProxiedDir:    d.ProxiedDir,
+		Database:      d.Database,
+		DataDir:       d.DataDir,
+		ProjectID:     d.ProjectID,
+		SyncRemote:    d.SyncRemote,
+		SyncGitRemote: d.SyncRemote,
+		Role:          d.Role,
+		BdVersion:     d.BdVersion,
+	}
+}

--- a/cmd/bd/init.go
+++ b/cmd/bd/init.go
@@ -132,12 +132,12 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 			}
 		}()
 
-		// if initProxiedServer {
-		// 	// Proxied-server mode has no local Dolt init lifecycle yet. When it
-		// 	// is implemented, that path must mark any local .dolt/ it creates or
-		// 	// acknowledges with doltserver.MarkDoltDirCompatible.
-		// 	return fmt.Errorf("--proxied-server is not yet implemented")
-		// }
+		if initProxiedServer {
+			// Proxied-server mode has no local Dolt init lifecycle yet. When it
+			// is implemented, that path must mark any local .dolt/ it creates or
+			// acknowledges with doltserver.MarkDoltDirCompatible.
+			return fmt.Errorf("--proxied-server is not yet implemented")
+		}
 		if initProxiedServer && initServerMode {
 			return fmt.Errorf("--server and --proxied-server are mutually exclusive")
 		}

--- a/cmd/bd/init.go
+++ b/cmd/bd/init.go
@@ -132,12 +132,12 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 			}
 		}()
 
-		if initProxiedServer {
-			// Proxied-server mode has no local Dolt init lifecycle yet. When it
-			// is implemented, that path must mark any local .dolt/ it creates or
-			// acknowledges with doltserver.MarkDoltDirCompatible.
-			return fmt.Errorf("--proxied-server is not yet implemented")
-		}
+		// if initProxiedServer {
+		// 	// Proxied-server mode has no local Dolt init lifecycle yet. When it
+		// 	// is implemented, that path must mark any local .dolt/ it creates or
+		// 	// acknowledges with doltserver.MarkDoltDirCompatible.
+		// 	return fmt.Errorf("--proxied-server is not yet implemented")
+		// }
 		if initProxiedServer && initServerMode {
 			return fmt.Errorf("--server and --proxied-server are mutually exclusive")
 		}

--- a/internal/storage/contextinfo/provider.go
+++ b/internal/storage/contextinfo/provider.go
@@ -1,0 +1,32 @@
+package contextinfo
+
+import (
+	"github.com/steveyegge/beads/internal/storage/domain"
+	domainfs "github.com/steveyegge/beads/internal/storage/domain/fs"
+)
+
+type ContextProvider interface {
+	ContextUseCase() domain.ContextUseCase
+}
+
+func NewContextProvider(workDir, version string) ContextProvider {
+	return &contextProviderImpl{workDir: workDir, version: version}
+}
+
+type contextProviderImpl struct {
+	workDir        string
+	version        string
+	contextUseCase domain.ContextUseCase
+}
+
+var _ ContextProvider = (*contextProviderImpl)(nil)
+
+func (p *contextProviderImpl) ContextUseCase() domain.ContextUseCase {
+	if p.contextUseCase == nil {
+		p.contextUseCase = domain.NewContextUseCase(
+			domainfs.NewContextRepository(domainfs.NewBeadsDirFSRepository(p.workDir, domain.BeadsDirTemplates{})),
+			p.version,
+		)
+	}
+	return p.contextUseCase
+}

--- a/internal/storage/contextinfo/provider_test.go
+++ b/internal/storage/contextinfo/provider_test.go
@@ -1,0 +1,15 @@
+package contextinfo
+
+import "testing"
+
+func TestContextProvider_UseCaseIsCached(t *testing.T) {
+	p := NewContextProvider(t.TempDir(), "v1")
+
+	first := p.ContextUseCase()
+	if first == nil {
+		t.Fatal("ContextUseCase returned nil")
+	}
+	if second := p.ContextUseCase(); second != first {
+		t.Error("ContextUseCase should return the cached instance")
+	}
+}

--- a/internal/storage/domain/context.go
+++ b/internal/storage/domain/context.go
@@ -1,0 +1,125 @@
+package domain
+
+import (
+	"context"
+
+	"github.com/steveyegge/beads/internal/configfile"
+)
+
+type ContextRepository interface {
+	RepoContext(ctx context.Context) (RepoPaths, error)
+	Role(ctx context.Context) (role string, hasRole bool, err error)
+	BackendConfig(ctx context.Context) (BackendConfig, error)
+	ServerPort(ctx context.Context) (int, error)
+	ProxiedServerRoot(ctx context.Context) (string, error)
+	SyncRemote(ctx context.Context) (string, error)
+}
+
+type RepoPaths struct {
+	BeadsDir     string
+	RepoRoot     string
+	CWDRepoRoot  string
+	IsRedirected bool
+	IsWorktree   bool
+}
+
+type BackendConfig struct {
+	DoltMode            string
+	Database            string
+	ProjectID           string
+	ServerHost          string
+	DataDir             string
+	IsServerMode        bool
+	IsProxiedServerMode bool
+}
+
+type ContextInfo struct {
+	BeadsDir     string
+	RepoRoot     string
+	CWDRepoRoot  string
+	IsRedirected bool
+	IsWorktree   bool
+	Backend      string
+	DoltMode     string
+	ServerHost   string
+	ServerPort   int
+	ProxiedDir   string
+	Database     string
+	DataDir      string
+	ProjectID    string
+	SyncRemote   string
+	Role         string
+	BdVersion    string
+}
+
+type ContextUseCase interface {
+	GetContextInfo(ctx context.Context) (ContextInfo, error)
+}
+
+func NewContextUseCase(repo ContextRepository, version string) ContextUseCase {
+	return &contextUseCaseImpl{repo: repo, version: version}
+}
+
+type contextUseCaseImpl struct {
+	repo    ContextRepository
+	version string
+}
+
+var _ ContextUseCase = (*contextUseCaseImpl)(nil)
+
+func (u *contextUseCaseImpl) GetContextInfo(ctx context.Context) (ContextInfo, error) {
+	paths, err := u.repo.RepoContext(ctx)
+	if err != nil {
+		return ContextInfo{}, err
+	}
+
+	role, _, err := u.repo.Role(ctx)
+	if err != nil {
+		return ContextInfo{}, err
+	}
+
+	backend, err := u.repo.BackendConfig(ctx)
+	if err != nil {
+		return ContextInfo{}, err
+	}
+
+	info := ContextInfo{
+		BeadsDir:     paths.BeadsDir,
+		RepoRoot:     paths.RepoRoot,
+		CWDRepoRoot:  paths.CWDRepoRoot,
+		IsRedirected: paths.IsRedirected,
+		IsWorktree:   paths.IsWorktree,
+		Role:         role,
+		Backend:      configfile.BackendDolt,
+		DoltMode:     backend.DoltMode,
+		Database:     backend.Database,
+		ProjectID:    backend.ProjectID,
+		DataDir:      backend.DataDir,
+		BdVersion:    u.version,
+	}
+
+	if backend.IsServerMode {
+		info.ServerHost = backend.ServerHost
+		port, err := u.repo.ServerPort(ctx)
+		if err != nil {
+			return ContextInfo{}, err
+		}
+		info.ServerPort = port
+	}
+
+	if backend.IsProxiedServerMode {
+		proxiedDir, err := u.repo.ProxiedServerRoot(ctx)
+		if err != nil {
+			return ContextInfo{}, err
+		}
+		info.ProxiedDir = proxiedDir
+	}
+
+	remote, err := u.repo.SyncRemote(ctx)
+	if err != nil {
+		return ContextInfo{}, err
+	}
+	info.SyncRemote = remote
+
+	return info, nil
+}

--- a/internal/storage/domain/context.go
+++ b/internal/storage/domain/context.go
@@ -73,7 +73,7 @@ func (u *contextUseCaseImpl) GetContextInfo(ctx context.Context) (ContextInfo, e
 		return ContextInfo{}, err
 	}
 
-	role, _, err := u.repo.Role(ctx)
+	role, hasRole, err := u.repo.Role(ctx)
 	if err != nil {
 		return ContextInfo{}, err
 	}
@@ -89,13 +89,16 @@ func (u *contextUseCaseImpl) GetContextInfo(ctx context.Context) (ContextInfo, e
 		CWDRepoRoot:  paths.CWDRepoRoot,
 		IsRedirected: paths.IsRedirected,
 		IsWorktree:   paths.IsWorktree,
-		Role:         role,
 		Backend:      configfile.BackendDolt,
 		DoltMode:     backend.DoltMode,
 		Database:     backend.Database,
 		ProjectID:    backend.ProjectID,
 		DataDir:      backend.DataDir,
 		BdVersion:    u.version,
+	}
+
+	if hasRole {
+		info.Role = role
 	}
 
 	if backend.IsServerMode {

--- a/internal/storage/domain/context_test.go
+++ b/internal/storage/domain/context_test.go
@@ -176,6 +176,18 @@ func TestContextUseCase_RoleUnset(t *testing.T) {
 	}
 }
 
+func TestContextUseCase_RoleNotEmittedWhenNotDetermined(t *testing.T) {
+	repo := &fakeContextRepo{role: "contributor", roleOK: false}
+
+	info, err := NewContextUseCase(repo, "v0").GetContextInfo(context.Background())
+	if err != nil {
+		t.Fatalf("GetContextInfo: %v", err)
+	}
+	if info.Role != "" {
+		t.Errorf("Role = %q, want empty when hasRole is false", info.Role)
+	}
+}
+
 func TestContextUseCase_ErrorPropagation(t *testing.T) {
 	sentinel := errors.New("boom")
 

--- a/internal/storage/domain/context_test.go
+++ b/internal/storage/domain/context_test.go
@@ -1,0 +1,199 @@
+package domain
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/configfile"
+)
+
+type fakeContextRepo struct {
+	paths       RepoPaths
+	pathsErr    error
+	role        string
+	roleOK      bool
+	roleErr     error
+	backend     BackendConfig
+	backendErr  error
+	port        int
+	portErr     error
+	portCalled  bool
+	proxiedRoot string
+	proxiedErr  error
+	proxCalled  bool
+	syncRemote  string
+	syncErr     error
+}
+
+func (f *fakeContextRepo) RepoContext(ctx context.Context) (RepoPaths, error) {
+	return f.paths, f.pathsErr
+}
+
+func (f *fakeContextRepo) Role(ctx context.Context) (string, bool, error) {
+	return f.role, f.roleOK, f.roleErr
+}
+
+func (f *fakeContextRepo) BackendConfig(ctx context.Context) (BackendConfig, error) {
+	return f.backend, f.backendErr
+}
+
+func (f *fakeContextRepo) ServerPort(ctx context.Context) (int, error) {
+	f.portCalled = true
+	return f.port, f.portErr
+}
+
+func (f *fakeContextRepo) ProxiedServerRoot(ctx context.Context) (string, error) {
+	f.proxCalled = true
+	return f.proxiedRoot, f.proxiedErr
+}
+
+func (f *fakeContextRepo) SyncRemote(ctx context.Context) (string, error) {
+	return f.syncRemote, f.syncErr
+}
+
+func TestContextUseCase_Embedded(t *testing.T) {
+	repo := &fakeContextRepo{
+		paths: RepoPaths{
+			BeadsDir:     "/repo/.beads",
+			RepoRoot:     "/repo",
+			CWDRepoRoot:  "/cwd",
+			IsRedirected: true,
+			IsWorktree:   true,
+		},
+		role:   "contributor",
+		roleOK: true,
+		backend: BackendConfig{
+			DoltMode:  configfile.DoltModeEmbedded,
+			Database:  "beads",
+			ProjectID: "proj-1",
+			DataDir:   "/data",
+		},
+		syncRemote: "origin-url",
+	}
+
+	info, err := NewContextUseCase(repo, "1.2.3").GetContextInfo(context.Background())
+	if err != nil {
+		t.Fatalf("GetContextInfo: %v", err)
+	}
+
+	if info.BeadsDir != "/repo/.beads" || info.RepoRoot != "/repo" || info.CWDRepoRoot != "/cwd" {
+		t.Errorf("paths not mapped: %+v", info)
+	}
+	if !info.IsRedirected || !info.IsWorktree {
+		t.Errorf("flags not mapped: %+v", info)
+	}
+	if info.Role != "contributor" {
+		t.Errorf("Role = %q, want contributor", info.Role)
+	}
+	if info.Backend != configfile.BackendDolt {
+		t.Errorf("Backend = %q, want %q", info.Backend, configfile.BackendDolt)
+	}
+	if info.BdVersion != "1.2.3" {
+		t.Errorf("BdVersion = %q, want 1.2.3", info.BdVersion)
+	}
+	if info.DoltMode != configfile.DoltModeEmbedded || info.Database != "beads" || info.ProjectID != "proj-1" || info.DataDir != "/data" {
+		t.Errorf("backend config not mapped: %+v", info)
+	}
+	if info.SyncRemote != "origin-url" {
+		t.Errorf("SyncRemote = %q, want origin-url", info.SyncRemote)
+	}
+	if info.ServerHost != "" || info.ServerPort != 0 || info.ProxiedDir != "" {
+		t.Errorf("server/proxied fields should be empty in embedded mode: %+v", info)
+	}
+	if repo.portCalled {
+		t.Error("ServerPort should not be queried outside server mode")
+	}
+	if repo.proxCalled {
+		t.Error("ProxiedServerRoot should not be queried outside proxied-server mode")
+	}
+}
+
+func TestContextUseCase_ServerMode(t *testing.T) {
+	repo := &fakeContextRepo{
+		backend: BackendConfig{
+			DoltMode:     configfile.DoltModeServer,
+			ServerHost:   "db.example.com",
+			IsServerMode: true,
+		},
+		port: 3307,
+	}
+
+	info, err := NewContextUseCase(repo, "v0").GetContextInfo(context.Background())
+	if err != nil {
+		t.Fatalf("GetContextInfo: %v", err)
+	}
+	if info.ServerHost != "db.example.com" {
+		t.Errorf("ServerHost = %q, want db.example.com", info.ServerHost)
+	}
+	if info.ServerPort != 3307 {
+		t.Errorf("ServerPort = %d, want 3307", info.ServerPort)
+	}
+	if info.ProxiedDir != "" {
+		t.Errorf("ProxiedDir = %q, want empty", info.ProxiedDir)
+	}
+	if !repo.portCalled {
+		t.Error("ServerPort should be queried in server mode")
+	}
+}
+
+func TestContextUseCase_ProxiedServerMode(t *testing.T) {
+	repo := &fakeContextRepo{
+		backend: BackendConfig{
+			DoltMode:            configfile.DoltModeProxiedServer,
+			IsProxiedServerMode: true,
+		},
+		proxiedRoot: "/repo/.beads/proxieddb",
+	}
+
+	info, err := NewContextUseCase(repo, "v0").GetContextInfo(context.Background())
+	if err != nil {
+		t.Fatalf("GetContextInfo: %v", err)
+	}
+	if info.ProxiedDir != "/repo/.beads/proxieddb" {
+		t.Errorf("ProxiedDir = %q, want /repo/.beads/proxieddb", info.ProxiedDir)
+	}
+	if info.ServerHost != "" || info.ServerPort != 0 {
+		t.Errorf("server fields should be empty in proxied mode: %+v", info)
+	}
+	if !repo.proxCalled {
+		t.Error("ProxiedServerRoot should be queried in proxied-server mode")
+	}
+	if repo.portCalled {
+		t.Error("ServerPort should not be queried in proxied-server mode")
+	}
+}
+
+func TestContextUseCase_RoleUnset(t *testing.T) {
+	repo := &fakeContextRepo{role: "", roleOK: false}
+
+	info, err := NewContextUseCase(repo, "v0").GetContextInfo(context.Background())
+	if err != nil {
+		t.Fatalf("GetContextInfo: %v", err)
+	}
+	if info.Role != "" {
+		t.Errorf("Role = %q, want empty", info.Role)
+	}
+}
+
+func TestContextUseCase_ErrorPropagation(t *testing.T) {
+	sentinel := errors.New("boom")
+
+	cases := map[string]*fakeContextRepo{
+		"repo_context": {pathsErr: sentinel},
+		"role":         {roleErr: sentinel},
+		"backend":      {backendErr: sentinel},
+		"server_port":  {backend: BackendConfig{IsServerMode: true}, portErr: sentinel},
+		"proxied_root": {backend: BackendConfig{IsProxiedServerMode: true}, proxiedErr: sentinel},
+		"sync_remote":  {syncErr: sentinel},
+	}
+
+	for name, repo := range cases {
+		t.Run(name, func(t *testing.T) {
+			_, err := NewContextUseCase(repo, "v0").GetContextInfo(context.Background())
+			if !errors.Is(err, sentinel) {
+				t.Fatalf("expected sentinel error, got %v", err)
+			}
+		})
+	}
+}

--- a/internal/storage/domain/fs/context.go
+++ b/internal/storage/domain/fs/context.go
@@ -1,0 +1,106 @@
+package fs
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+
+	"github.com/steveyegge/beads/internal/beads"
+	"github.com/steveyegge/beads/internal/config"
+	"github.com/steveyegge/beads/internal/configfile"
+	"github.com/steveyegge/beads/internal/doltserver"
+	"github.com/steveyegge/beads/internal/storage/domain"
+)
+
+const proxiedServerRootDirName = "proxieddb"
+
+func NewContextRepository(fsRepo domain.BeadsDirFSRepository) domain.ContextRepository {
+	return &contextRepositoryImpl{fsRepo: fsRepo}
+}
+
+type contextRepositoryImpl struct {
+	fsRepo domain.BeadsDirFSRepository
+}
+
+var _ domain.ContextRepository = (*contextRepositoryImpl)(nil)
+
+func (r *contextRepositoryImpl) beadsDir(ctx context.Context) string {
+	return r.fsRepo.ResolveBeadsDirPath(ctx).BeadsDir
+}
+
+func (r *contextRepositoryImpl) RepoContext(ctx context.Context) (domain.RepoPaths, error) {
+	rc, err := beads.GetRepoContext()
+	if err != nil {
+		return domain.RepoPaths{}, err
+	}
+	return domain.RepoPaths{
+		BeadsDir:     rc.BeadsDir,
+		RepoRoot:     rc.RepoRoot,
+		CWDRepoRoot:  rc.CWDRepoRoot,
+		IsRedirected: rc.IsRedirected,
+		IsWorktree:   rc.IsWorktree,
+	}, nil
+}
+
+func (r *contextRepositoryImpl) Role(ctx context.Context) (string, bool, error) {
+	rc, err := beads.GetRepoContext()
+	if err != nil {
+		return "", false, err
+	}
+	role, ok := rc.Role()
+	return string(role), ok, nil
+}
+
+func (r *contextRepositoryImpl) BackendConfig(ctx context.Context) (domain.BackendConfig, error) {
+	cfg, err := r.fsRepo.ReadBeadsConfig(ctx)
+	if err != nil || cfg == nil {
+		cfg = configfile.DefaultConfig()
+	}
+	return domain.BackendConfig{
+		DoltMode:            cfg.GetDoltMode(),
+		Database:            cfg.GetDoltDatabase(),
+		ProjectID:           cfg.ProjectID,
+		ServerHost:          cfg.GetDoltServerHost(),
+		DataDir:             cfg.GetDoltDataDir(),
+		IsServerMode:        cfg.IsDoltServerMode(),
+		IsProxiedServerMode: cfg.IsDoltProxiedServerMode(),
+	}, nil
+}
+
+func (r *contextRepositoryImpl) ServerPort(ctx context.Context) (int, error) {
+	return doltserver.DefaultConfig(r.beadsDir(ctx)).Port, nil
+}
+
+func (r *contextRepositoryImpl) ProxiedServerRoot(ctx context.Context) (string, error) {
+	beadsDir := r.beadsDir(ctx)
+	if p := envOrAbsJoin("BEADS_PROXIED_SERVER_ROOT_PATH", beadsDir); p != "" {
+		return p, nil
+	}
+	info, err := configfile.LoadProxiedServerClientInfo(beadsDir)
+	if err != nil {
+		return "", err
+	}
+	if p := info.ResolvedRootPath(beadsDir); p != "" {
+		return p, nil
+	}
+	return filepath.Join(beadsDir, proxiedServerRootDirName), nil
+}
+
+func (r *contextRepositoryImpl) SyncRemote(ctx context.Context) (string, error) {
+	beadsDir := r.beadsDir(ctx)
+	if v := config.GetStringFromDir(beadsDir, "sync.remote"); v != "" {
+		return v, nil
+	}
+	return config.GetStringFromDir(beadsDir, "sync.git-remote"), nil
+}
+
+func envOrAbsJoin(envName, beadsDir string) string {
+	p := os.Getenv(envName)
+	if p == "" {
+		return ""
+	}
+	if filepath.IsAbs(p) {
+		return p
+	}
+	return filepath.Join(beadsDir, p)
+}

--- a/internal/storage/domain/fs/context.go
+++ b/internal/storage/domain/fs/context.go
@@ -76,7 +76,7 @@ func (r *contextRepositoryImpl) ProxiedServerRoot(ctx context.Context) (string, 
 	if p := envOrAbsJoin("BEADS_PROXIED_SERVER_ROOT_PATH", beadsDir); p != "" {
 		return p, nil
 	}
-	info, err := configfile.LoadProxiedServerClientInfo(beadsDir)
+	info, err := r.fsRepo.ReadProxiedServerClientInfo(ctx)
 	if err != nil {
 		return "", err
 	}

--- a/internal/storage/domain/fs/context_test.go
+++ b/internal/storage/domain/fs/context_test.go
@@ -1,0 +1,260 @@
+package fs
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/steveyegge/beads/internal/beads"
+	"github.com/steveyegge/beads/internal/configfile"
+	"github.com/steveyegge/beads/internal/git"
+	"github.com/steveyegge/beads/internal/storage/domain"
+)
+
+func newContextRepoForTest(t *testing.T) (workDir, beadsDir string, repo domain.ContextRepository) {
+	t.Helper()
+	workDir = t.TempDir()
+	beadsDir = filepath.Join(workDir, ".beads")
+	require.NoError(t, os.MkdirAll(beadsDir, 0o750))
+
+	t.Setenv("BEADS_DIR", beadsDir)
+	t.Setenv("BEADS_DOLT_SERVER_MODE", "")
+	t.Setenv("BEADS_DOLT_SHARED_SERVER", "")
+	t.Setenv("BEADS_DOLT_SERVER_DATABASE", "")
+	t.Setenv("BEADS_DOLT_SERVER_HOST", "")
+	t.Setenv("BEADS_DOLT_DATA_DIR", "")
+	t.Setenv("BEADS_DOLT_SERVER_PORT", "")
+	t.Setenv("BEADS_PROXIED_SERVER_ROOT_PATH", "")
+
+	repo = NewContextRepository(NewBeadsDirFSRepository(workDir, testTemplates()))
+	return workDir, beadsDir, repo
+}
+
+func canonicalBeadsDir(t *testing.T, workDir string) string {
+	t.Helper()
+	return NewBeadsDirFSRepository(workDir, testTemplates()).ResolveBeadsDirPath(context.Background()).BeadsDir
+}
+
+func writeMetadata(t *testing.T, beadsDir string, cfg *configfile.Config) {
+	t.Helper()
+	data, err := json.Marshal(cfg)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(beadsDir, "metadata.json"), data, 0o600))
+}
+
+func TestContextRepository_BackendConfig(t *testing.T) {
+	t.Run("DefaultsWithoutMetadata", func(t *testing.T) {
+		_, _, repo := newContextRepoForTest(t)
+
+		got, err := repo.BackendConfig(context.Background())
+		require.NoError(t, err)
+		require.Equal(t, configfile.DoltModeEmbedded, got.DoltMode)
+		require.Equal(t, configfile.DefaultDoltDatabase, got.Database)
+		require.Empty(t, got.ProjectID)
+		require.False(t, got.IsServerMode)
+		require.False(t, got.IsProxiedServerMode)
+	})
+
+	t.Run("EmbeddedWithExplicitValues", func(t *testing.T) {
+		_, beadsDir, repo := newContextRepoForTest(t)
+		writeMetadata(t, beadsDir, &configfile.Config{
+			DoltMode:     configfile.DoltModeEmbedded,
+			DoltDatabase: "mydb",
+			ProjectID:    "proj-123",
+		})
+
+		got, err := repo.BackendConfig(context.Background())
+		require.NoError(t, err)
+		require.Equal(t, configfile.DoltModeEmbedded, got.DoltMode)
+		require.Equal(t, "mydb", got.Database)
+		require.Equal(t, "proj-123", got.ProjectID)
+		require.False(t, got.IsServerMode)
+		require.False(t, got.IsProxiedServerMode)
+	})
+
+	t.Run("ServerMode", func(t *testing.T) {
+		_, beadsDir, repo := newContextRepoForTest(t)
+		writeMetadata(t, beadsDir, &configfile.Config{
+			DoltMode:       configfile.DoltModeServer,
+			DoltServerHost: "db.example.com",
+			DoltDataDir:    "/data/dolt",
+		})
+
+		got, err := repo.BackendConfig(context.Background())
+		require.NoError(t, err)
+		require.True(t, got.IsServerMode)
+		require.False(t, got.IsProxiedServerMode)
+		require.Equal(t, "db.example.com", got.ServerHost)
+		require.Equal(t, "/data/dolt", got.DataDir)
+	})
+
+	t.Run("ProxiedServerMode", func(t *testing.T) {
+		_, beadsDir, repo := newContextRepoForTest(t)
+		writeMetadata(t, beadsDir, &configfile.Config{
+			DoltMode: configfile.DoltModeProxiedServer,
+		})
+
+		got, err := repo.BackendConfig(context.Background())
+		require.NoError(t, err)
+		require.True(t, got.IsProxiedServerMode)
+		require.False(t, got.IsServerMode)
+	})
+
+	t.Run("EnvOverridesDatabase", func(t *testing.T) {
+		_, beadsDir, repo := newContextRepoForTest(t)
+		writeMetadata(t, beadsDir, &configfile.Config{DoltDatabase: "filedb"})
+		t.Setenv("BEADS_DOLT_SERVER_DATABASE", "envdb")
+
+		got, err := repo.BackendConfig(context.Background())
+		require.NoError(t, err)
+		require.Equal(t, "envdb", got.Database)
+	})
+}
+
+func TestContextRepository_ServerPort(t *testing.T) {
+	t.Run("EnvOverride", func(t *testing.T) {
+		_, _, repo := newContextRepoForTest(t)
+		t.Setenv("BEADS_DOLT_SERVER_PORT", "3333")
+
+		got, err := repo.ServerPort(context.Background())
+		require.NoError(t, err)
+		require.Equal(t, 3333, got)
+	})
+
+	t.Run("ReadsPortFile", func(t *testing.T) {
+		_, beadsDir, repo := newContextRepoForTest(t)
+		require.NoError(t, os.WriteFile(filepath.Join(beadsDir, "dolt-server.port"), []byte("4567"), 0o600))
+
+		got, err := repo.ServerPort(context.Background())
+		require.NoError(t, err)
+		require.Equal(t, 4567, got)
+	})
+}
+
+func TestContextRepository_ProxiedServerRoot(t *testing.T) {
+	t.Run("EnvAbsolutePath", func(t *testing.T) {
+		_, _, repo := newContextRepoForTest(t)
+		abs := filepath.Join(t.TempDir(), "abs-root")
+		t.Setenv("BEADS_PROXIED_SERVER_ROOT_PATH", abs)
+
+		got, err := repo.ProxiedServerRoot(context.Background())
+		require.NoError(t, err)
+		require.Equal(t, abs, got)
+	})
+
+	t.Run("EnvRelativePathJoinedWithBeadsDir", func(t *testing.T) {
+		workDir, _, repo := newContextRepoForTest(t)
+		t.Setenv("BEADS_PROXIED_SERVER_ROOT_PATH", "relroot")
+
+		got, err := repo.ProxiedServerRoot(context.Background())
+		require.NoError(t, err)
+		canonBeadsDir := canonicalBeadsDir(t, workDir)
+		require.Equal(t, filepath.Join(canonBeadsDir, "relroot"), got)
+	})
+
+	t.Run("ClientInfoRootPath", func(t *testing.T) {
+		workDir, beadsDir, repo := newContextRepoForTest(t)
+		require.NoError(t, configfile.SaveProxiedServerClientInfo(beadsDir, &configfile.ProxiedServerClientInfo{
+			RootPath: "customroot",
+		}))
+
+		got, err := repo.ProxiedServerRoot(context.Background())
+		require.NoError(t, err)
+		canonBeadsDir := canonicalBeadsDir(t, workDir)
+		require.Equal(t, filepath.Join(canonBeadsDir, "customroot"), got)
+	})
+
+	t.Run("DefaultProxiedDir", func(t *testing.T) {
+		workDir, _, repo := newContextRepoForTest(t)
+
+		got, err := repo.ProxiedServerRoot(context.Background())
+		require.NoError(t, err)
+		canonBeadsDir := canonicalBeadsDir(t, workDir)
+		require.Equal(t, filepath.Join(canonBeadsDir, proxiedServerRootDirName), got)
+	})
+}
+
+func TestContextRepository_SyncRemote(t *testing.T) {
+	writeConfigYAML := func(t *testing.T, beadsDir, body string) {
+		t.Helper()
+		require.NoError(t, os.WriteFile(filepath.Join(beadsDir, "config.yaml"), []byte(body), 0o600))
+	}
+
+	t.Run("ReadsSyncRemote", func(t *testing.T) {
+		_, beadsDir, repo := newContextRepoForTest(t)
+		writeConfigYAML(t, beadsDir, "sync:\n  remote: git@example.com:org/repo.git\n")
+
+		got, err := repo.SyncRemote(context.Background())
+		require.NoError(t, err)
+		require.Equal(t, "git@example.com:org/repo.git", got)
+	})
+
+	t.Run("FallsBackToGitRemote", func(t *testing.T) {
+		_, beadsDir, repo := newContextRepoForTest(t)
+		writeConfigYAML(t, beadsDir, "sync:\n  git-remote: legacy-remote\n")
+
+		got, err := repo.SyncRemote(context.Background())
+		require.NoError(t, err)
+		require.Equal(t, "legacy-remote", got)
+	})
+
+	t.Run("SyncRemoteWinsOverGitRemote", func(t *testing.T) {
+		_, beadsDir, repo := newContextRepoForTest(t)
+		writeConfigYAML(t, beadsDir, "sync:\n  remote: primary\n  git-remote: legacy\n")
+
+		got, err := repo.SyncRemote(context.Background())
+		require.NoError(t, err)
+		require.Equal(t, "primary", got)
+	})
+
+	t.Run("EmptyWhenNoConfig", func(t *testing.T) {
+		_, _, repo := newContextRepoForTest(t)
+
+		got, err := repo.SyncRemote(context.Background())
+		require.NoError(t, err)
+		require.Empty(t, got)
+	})
+}
+
+func TestContextRepository_RepoContextAndRole(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git binary not available")
+	}
+
+	workDir := t.TempDir()
+	cmd := exec.Command("git", "init")
+	cmd.Dir = workDir
+	require.NoError(t, cmd.Run())
+
+	beadsDir := filepath.Join(workDir, ".beads")
+	require.NoError(t, os.MkdirAll(beadsDir, 0o750))
+	require.NoError(t, os.WriteFile(filepath.Join(beadsDir, "metadata.json"), []byte("{}"), 0o600))
+
+	t.Setenv("BEADS_DIR", beadsDir)
+	beads.ResetCaches()
+	git.ResetCaches()
+	t.Cleanup(func() {
+		beads.ResetCaches()
+		git.ResetCaches()
+	})
+
+	repo := NewContextRepository(NewBeadsDirFSRepository(workDir, testTemplates()))
+
+	paths, err := repo.RepoContext(context.Background())
+	if err != nil {
+		t.Skipf("repo context unavailable in this environment: %v", err)
+	}
+	require.True(t, paths.IsRedirected)
+	require.NotEmpty(t, paths.RepoRoot)
+	require.Equal(t, ".beads", filepath.Base(paths.BeadsDir))
+
+	role, ok, err := repo.Role(context.Background())
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, string(beads.Contributor), role)
+}


### PR DESCRIPTION
## Summary

Adds proxied-server support for `bd context`, following the same pattern used for `bd update`/`bd create`/etc.: a minimal branch in the command's `RunE` delegates to a `*_proxied_server.go` handler that goes through the domain use-case interfaces. All other modes (embedded, server) keep the existing inline code path unchanged.

`bd context` is intentionally DB-free (it reports backend identity from config/filesystem and must work in degraded states), so the new use case does **not** run over a SQL `Runner`/`UnitOfWork`. Instead it follows the `GitUseCase`/`BeadsDirFSUseCase` pattern — constructed from a `workDir`, backed by filesystem/config repositories, exposed through its own provider.

## What's added

- **`internal/storage/domain/context.go`** — `ContextUseCase` (`GetContextInfo`), `ContextRepository`, and `ContextInfo`/`RepoPaths`/`BackendConfig` types. The use case holds the conditional assembly logic (server-only fields, proxied-only `proxied_dir`) that was previously inline in the command.
- **`internal/storage/domain/fs/context.go`** — `contextRepositoryImpl`, backed by `BeadsDirFSRepository` as the single canonical beads-dir resolver (`ResolveBeadsDirPath` + `ReadBeadsConfig`), plus `doltserver`/proxied-root/sync-remote reads.
- **`internal/storage/contextinfo/provider.go`** — `ContextProvider` wiring the repository + use case (package named `contextinfo` to avoid shadowing stdlib `context`).
- **`cmd/bd/context_proxied_server.go`** — `runContextProxiedServer`; reuses the existing `printContextText`/`outputJSON` renderers and maps domain → CLI view (incl. the deprecated `sync_git_remote`). Preserves the old path's `--json` error behavior and `--db`/`BEADS_DB` no-DB selection.
- **`cmd/bd/context_cmd.go`** — one `if usesProxiedServer() { return runContextProxiedServer(...) }` branch after metrics setup. Nothing else changes.
- **`cmd/bd/init.go`** — lifts the `--proxied-server is not yet implemented` guard so proxied-server repos can be initialized (required by the integration tests / the proxied path).

## Tests

- Domain use-case unit tests (mode branches + error propagation), fs repository tests (backend config, server port, proxied root, sync remote, repo context/role), and a provider caching test.
- `cmd/bd/context_proxied_integration_test.go` (`//go:build cgo`, gated by `BEADS_TEST_PROXIED_SERVER=1`): default text, `--json` field assertions (`dolt_mode == "proxied-server"`, `proxied_dir` populated, `database`/`beads_dir`, server fields empty), and concurrent invocation.

All unit/repo/provider tests pass; the gated integration test passes against a live proxied server (Dolt 2.1.9).

## Parity note

For `bd context --json`, the proxied path is at full field parity with the direct path; `backend`/`dolt_mode`/`bd_version` match. `schema_version` is emitted by no mode (pre-existing). Config-derived fields resolve beads-dir via `ResolveBeadsDirPath` while repo-path fields use `GetRepoContext()`; these agree except under redirect/worktree/external-`.beads` layouts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)