### PR TITLE
bd query: proxied-server support

### DIFF
--- a/cmd/bd/init.go
+++ b/cmd/bd/init.go
@@ -132,12 +132,12 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 			}
 		}()
 
-		// if initProxiedServer {
-		// 	// Proxied-server mode has no local Dolt init lifecycle yet. When it
-		// 	// is implemented, that path must mark any local .dolt/ it creates or
-		// 	// acknowledges with doltserver.MarkDoltDirCompatible.
-		// 	return fmt.Errorf("--proxied-server is not yet implemented")
-		// }
+		if initProxiedServer {
+			// Proxied-server mode has no local Dolt init lifecycle yet. When it
+			// is implemented, that path must mark any local .dolt/ it creates or
+			// acknowledges with doltserver.MarkDoltDirCompatible.
+			return fmt.Errorf("--proxied-server is not yet implemented")
+		}
 		if initProxiedServer && initServerMode {
 			return fmt.Errorf("--server and --proxied-server are mutually exclusive")
 		}

--- a/cmd/bd/init.go
+++ b/cmd/bd/init.go
@@ -132,12 +132,12 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 			}
 		}()
 
-		if initProxiedServer {
-			// Proxied-server mode has no local Dolt init lifecycle yet. When it
-			// is implemented, that path must mark any local .dolt/ it creates or
-			// acknowledges with doltserver.MarkDoltDirCompatible.
-			return fmt.Errorf("--proxied-server is not yet implemented")
-		}
+		// if initProxiedServer {
+		// 	// Proxied-server mode has no local Dolt init lifecycle yet. When it
+		// 	// is implemented, that path must mark any local .dolt/ it creates or
+		// 	// acknowledges with doltserver.MarkDoltDirCompatible.
+		// 	return fmt.Errorf("--proxied-server is not yet implemented")
+		// }
 		if initProxiedServer && initServerMode {
 			return fmt.Errorf("--server and --proxied-server are mutually exclusive")
 		}

--- a/cmd/bd/list_proxied_integration_test.go
+++ b/cmd/bd/list_proxied_integration_test.go
@@ -596,13 +596,18 @@ func TestProxiedServerList(t *testing.T) {
 		}
 	})
 
-	t.Run("truncation_hint_on_stderr_when_more_results", func(t *testing.T) {
-		stdout, stderr := bdProxiedListCapture(t, bd, p, "--all", "--limit", "2")
-		if !strings.Contains(stderr, "more results matched") {
-			t.Errorf("expected truncation hint on stderr, got:\nstderr: %q\nstdout: %q", stderr, stdout)
+	t.Run("limit_truncates_and_hint_stays_off_stdout", func(t *testing.T) {
+		full := bdProxiedListJSON(t, bd, p, "--all", "--limit", "0")
+		if len(full) <= 2 {
+			t.Fatalf("fixture should have > 2 issues, got %d", len(full))
 		}
+		page := bdProxiedListJSON(t, bd, p, "--all", "--limit", "2")
+		if len(page) != 2 {
+			t.Errorf("--limit 2 should cap at 2 rows, got %d", len(page))
+		}
+		stdout, _ := bdProxiedListCapture(t, bd, p, "--all", "--limit", "2")
 		if strings.Contains(stdout, "more results matched") {
-			t.Errorf("truncation hint leaked into stdout:\n%s", stdout)
+			t.Errorf("truncation hint must not leak into stdout:\n%s", stdout)
 		}
 	})
 
@@ -618,24 +623,21 @@ func TestProxiedServerList(t *testing.T) {
 	// --- M. Pagination across the issues+wisps UNION ALL ---
 
 	t.Run("ready_returns_both_perm_and_wisp", func(t *testing.T) {
-		// Create three ephemeral wisps as ready candidates. The proxied
-		// union path forces IncludeEphemeral=true on the wisp side, so
-		// these must surface in --ready alongside permanent issues.
 		var wispIDs []string
 		for i := 0; i < 3; i++ {
 			w := bdProxiedCreate(t, bd, p.dir, fmt.Sprintf("Wisp ready %d", i), "--ephemeral")
 			wispIDs = append(wispIDs, w.ID)
 		}
 
-		issues := bdProxiedListJSON(t, bd, p, "--ready", "--limit", "0")
+		issues := bdProxiedReadyJSON(t, bd, p, "--include-ephemeral", "--limit", "0")
 		ids := listIssueIDs(issues)
 		for _, wid := range wispIDs {
 			if !containsID(issues, wid) {
-				t.Errorf("ephemeral wisp %s should appear in --ready (UNION path), got %v", wid, ids)
+				t.Errorf("ephemeral wisp %s should appear in ready --include-ephemeral (UNION path), got %v", wid, ids)
 			}
 		}
 		if !containsID(issues, seed.readyTask) {
-			t.Errorf("permanent readyTask %s should still appear in --ready, got %v", seed.readyTask, ids)
+			t.Errorf("permanent readyTask %s should still appear in ready --include-ephemeral, got %v", seed.readyTask, ids)
 		}
 	})
 

--- a/cmd/bd/query.go
+++ b/cmd/bd/query.go
@@ -105,6 +105,9 @@ Examples:
 		reverse, _ := cmd.Flags().GetBool("reverse")
 		parseOnly, _ := cmd.Flags().GetBool("parse-only")
 		offset, _ := cmd.Flags().GetInt("offset")
+		if offset < 0 {
+			return HandleErrorRespectJSON("--offset must be non-negative")
+		}
 		if offset > 0 {
 			return HandleErrorRespectJSON("--offset is only supported under --proxied-server")
 		}

--- a/cmd/bd/query.go
+++ b/cmd/bd/query.go
@@ -84,6 +84,10 @@ Examples:
 			}
 		}()
 
+		if usesProxiedServer() {
+			return runQueryProxiedServer(cmd, rootCtx, args)
+		}
+
 		if len(args) == 0 {
 			fmt.Fprintf(os.Stderr, "Error: query expression is required\n\n")
 			if err := cmd.Help(); err != nil {
@@ -100,6 +104,10 @@ Examples:
 		sortBy, _ := cmd.Flags().GetString("sort")
 		reverse, _ := cmd.Flags().GetBool("reverse")
 		parseOnly, _ := cmd.Flags().GetBool("parse-only")
+		offset, _ := cmd.Flags().GetInt("offset")
+		if offset > 0 {
+			return HandleErrorRespectJSON("--offset is only supported under --proxied-server")
+		}
 
 		node, err := query.Parse(queryStr)
 		if err != nil {
@@ -270,6 +278,7 @@ func formatQueryIssue(buf *strings.Builder, issue *types.Issue) {
 
 func init() {
 	queryCmd.Flags().IntP("limit", "n", 50, "Limit results (default: 50, 0 = unlimited)")
+	queryCmd.Flags().Int("offset", 0, "Skip the first N matching results (0-based). Only supported under --proxied-server.")
 	queryCmd.Flags().BoolP("all", "a", false, "Include closed issues (default: exclude closed)")
 	queryCmd.Flags().Bool("long", false, "Show detailed multi-line output for each issue")
 	queryCmd.Flags().String("sort", "", "Sort by field: priority, created, updated, closed, status, id, title, type, assignee")

--- a/cmd/bd/query_proxied_integration_test.go
+++ b/cmd/bd/query_proxied_integration_test.go
@@ -185,6 +185,22 @@ func TestProxiedServerQuery(t *testing.T) {
 		}
 	})
 
+	t.Run("offset_rejected_with_sort", func(t *testing.T) {
+		for _, sortField := range []string{"priority", "created", "id"} {
+			out := bdProxiedQueryFail(t, bd, p, "priority>=0", "--all", "--sort", sortField, "--offset", "1")
+			if !strings.Contains(out, "--offset is not supported with --sort") {
+				t.Errorf("expected --sort %s + offset rejection, got: %s", sortField, out)
+			}
+		}
+	})
+
+	t.Run("negative_offset_rejected", func(t *testing.T) {
+		out := bdProxiedQueryFail(t, bd, p, "priority>=0", "--offset=-1")
+		if !strings.Contains(out, "--offset must be non-negative") {
+			t.Errorf("expected negative-offset rejection, got: %s", out)
+		}
+	})
+
 	t.Run("parse_only_short_circuits", func(t *testing.T) {
 		stdout, _ := bdProxiedQueryCapture(t, bd, p, "status=open AND priority<=1", "--parse-only")
 		if !strings.Contains(stdout, "Parsed query:") {

--- a/cmd/bd/query_proxied_integration_test.go
+++ b/cmd/bd/query_proxied_integration_test.go
@@ -384,4 +384,38 @@ func TestProxiedServerQuery(t *testing.T) {
 			t.Errorf("default query should include permanent issue %s", seed.openBug)
 		}
 	})
+
+	t.Run("ephemeral_and_label_filters_wisps", func(t *testing.T) {
+		const label = "wq-compound"
+		wisp := bdProxiedCreate(t, bd, p.dir, "Labeled wisp", "--ephemeral", "--label", label)
+		perm := bdProxiedCreate(t, bd, p.dir, "Labeled permanent", "--label", label)
+
+		issues := bdProxiedQueryJSON(t, bd, p, "ephemeral=true AND label="+label, "--limit", "0")
+		if !containsID(issues, wisp.ID) {
+			t.Errorf("ephemeral=true AND label=%s should return wisp %s, got %v", label, wisp.ID, listIssueIDs(issues))
+		}
+		if containsID(issues, perm.ID) {
+			t.Errorf("ephemeral=true AND label=%s must not return permanent issue %s", label, perm.ID)
+		}
+		for _, issue := range issues {
+			if issue.Issue == nil || !issue.Ephemeral {
+				t.Errorf("compound ephemeral+label query returned non-wisp %s", issue.ID)
+			}
+		}
+	})
+
+	t.Run("ephemeral_and_parent_filters_wisps", func(t *testing.T) {
+		parent := bdProxiedCreate(t, bd, p.dir, "Parent wisp", "--ephemeral")
+		child := bdProxiedCreate(t, bd, p.dir, "Child wisp", "--ephemeral", "--parent", parent.ID)
+
+		issues := bdProxiedQueryJSON(t, bd, p, "ephemeral=true AND parent="+parent.ID, "--limit", "0")
+		if !containsID(issues, child.ID) {
+			t.Errorf("ephemeral=true AND parent=%s should return child wisp %s, got %v", parent.ID, child.ID, listIssueIDs(issues))
+		}
+		for _, issue := range issues {
+			if issue.Issue == nil || !issue.Ephemeral {
+				t.Errorf("compound ephemeral+parent query returned non-wisp %s", issue.ID)
+			}
+		}
+	})
 }

--- a/cmd/bd/query_proxied_integration_test.go
+++ b/cmd/bd/query_proxied_integration_test.go
@@ -1,0 +1,387 @@
+//go:build cgo
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/types"
+)
+
+func bdProxiedQueryJSON(t *testing.T, bd string, p proxiedProject, args ...string) []*types.IssueWithCounts {
+	t.Helper()
+	fullArgs := append([]string{"query", "--json"}, args...)
+	stdout, stderr, err := bdProxiedRunBuffers(t, bd, p.dir, fullArgs...)
+	if err != nil {
+		t.Fatalf("bd query --json %s failed: %v\nstdout:\n%s\nstderr:\n%s",
+			strings.Join(args, " "), err, stdout, stderr)
+	}
+	start := strings.Index(stdout, "[")
+	if start < 0 {
+		if strings.Contains(stdout, "null") || strings.TrimSpace(stdout) == "" {
+			return nil
+		}
+		t.Fatalf("no JSON array found in query output:\n%s", stdout)
+	}
+	var issues []*types.IssueWithCounts
+	if err := json.Unmarshal([]byte(stdout[start:]), &issues); err != nil {
+		t.Fatalf("failed to parse query JSON output: %v\nraw: %s", err, stdout[start:])
+	}
+	return issues
+}
+
+func bdProxiedQueryCapture(t *testing.T, bd string, p proxiedProject, args ...string) (string, string) {
+	t.Helper()
+	fullArgs := append([]string{"query"}, args...)
+	stdout, stderr, err := bdProxiedRunBuffers(t, bd, p.dir, fullArgs...)
+	if err != nil {
+		t.Fatalf("bd query %s failed: %v\nstdout:\n%s\nstderr:\n%s",
+			strings.Join(args, " "), err, stdout, stderr)
+	}
+	return stdout, stderr
+}
+
+func bdProxiedQueryFail(t *testing.T, bd string, p proxiedProject, args ...string) string {
+	t.Helper()
+	fullArgs := append([]string{"query"}, args...)
+	stdout, stderr, err := bdProxiedRunBuffers(t, bd, p.dir, fullArgs...)
+	if err == nil {
+		t.Fatalf("expected bd query %s to fail, but it succeeded:\nstdout:\n%s\nstderr:\n%s",
+			strings.Join(args, " "), stdout, stderr)
+	}
+	return stdout + stderr
+}
+
+func TestProxiedServerQuery(t *testing.T) {
+	requireProxiedServerEnv(t)
+	bd := buildEmbeddedBD(t)
+	p := bdProxiedInit(t, bd, "qry")
+	seed := seedProxiedListData(t, bd, p)
+
+	t.Run("filter_only_and_chain", func(t *testing.T) {
+		issues := bdProxiedQueryJSON(t, bd, p, "status=open AND priority<=1")
+		for _, issue := range issues {
+			if issue.Status != types.StatusOpen {
+				t.Errorf("expected status open, got %s for %s", issue.Status, issue.ID)
+			}
+			if issue.Priority > 1 {
+				t.Errorf("expected priority <= 1, got %d for %s", issue.Priority, issue.ID)
+			}
+		}
+		if !containsID(issues, seed.openBug) {
+			t.Errorf("P0 open bug should match status=open AND priority<=1, got %v", listIssueIDs(issues))
+		}
+	})
+
+	t.Run("excludes_closed_by_default", func(t *testing.T) {
+		issues := bdProxiedQueryJSON(t, bd, p, "priority>=0")
+		for _, issue := range issues {
+			if issue.Status == types.StatusClosed {
+				t.Errorf("closed issue %s should be excluded without --all", issue.ID)
+			}
+		}
+	})
+
+	t.Run("type_bug", func(t *testing.T) {
+		issues := bdProxiedQueryJSON(t, bd, p, "type=bug")
+		for _, issue := range issues {
+			if issue.IssueType != types.TypeBug {
+				t.Errorf("expected type bug, got %s for %s", issue.IssueType, issue.ID)
+			}
+		}
+		if !containsID(issues, seed.openBug) {
+			t.Errorf("open bug should match type=bug, got %v", listIssueIDs(issues))
+		}
+	})
+
+	t.Run("or_predicate_post_filters", func(t *testing.T) {
+		issues := bdProxiedQueryJSON(t, bd, p, "type=bug OR type=feature")
+		for _, issue := range issues {
+			if issue.IssueType != types.TypeBug && issue.IssueType != types.TypeFeature {
+				t.Errorf("expected bug or feature, got %s for %s", issue.IssueType, issue.ID)
+			}
+		}
+		if !containsID(issues, seed.openBug) {
+			t.Errorf("bug should match (bug OR feature), got %v", listIssueIDs(issues))
+		}
+		if !containsID(issues, seed.feature) {
+			t.Errorf("feature should match (bug OR feature), got %v", listIssueIDs(issues))
+		}
+	})
+
+	t.Run("offset_plus_limit_returns_slice", func(t *testing.T) {
+		full := bdProxiedQueryJSON(t, bd, p, "priority>=0", "--all", "--limit", "0")
+		if len(full) < 7 {
+			t.Fatalf("seeded fixture should yield >= 7 issues, got %d", len(full))
+		}
+		page := bdProxiedQueryJSON(t, bd, p, "priority>=0", "--all", "--offset", "3", "--limit", "4")
+		if len(page) != 4 {
+			t.Fatalf("--offset 3 --limit 4 should return 4 rows, got %d", len(page))
+		}
+		for i := 0; i < 4; i++ {
+			if page[i].ID != full[3+i].ID {
+				t.Errorf("position %d (offset 3+i): paged returned %s; unlimited had %s at index %d",
+					i, page[i].ID, full[3+i].ID, 3+i)
+			}
+		}
+	})
+
+	t.Run("page_walk_reconstructs_full_result", func(t *testing.T) {
+		full := bdProxiedQueryJSON(t, bd, p, "priority>=0", "--all", "--limit", "0")
+		const pageSize = 4
+		var walked []string
+		seen := make(map[string]bool)
+		for offset := 0; ; offset += pageSize {
+			page := bdProxiedQueryJSON(t, bd, p, "priority>=0", "--all",
+				"--limit", fmt.Sprintf("%d", pageSize),
+				"--offset", fmt.Sprintf("%d", offset))
+			if len(page) == 0 {
+				break
+			}
+			for _, iwc := range page {
+				if seen[iwc.ID] {
+					t.Errorf("page at offset %d returned duplicate %s", offset, iwc.ID)
+				}
+				seen[iwc.ID] = true
+				walked = append(walked, iwc.ID)
+			}
+			if len(page) < pageSize {
+				break
+			}
+		}
+		if len(walked) != len(full) {
+			t.Fatalf("page walk got %d issues, unlimited got %d", len(walked), len(full))
+		}
+		for i, id := range walked {
+			if id != full[i].ID {
+				t.Errorf("position %d: page walk had %s; unlimited had %s", i, id, full[i].ID)
+			}
+		}
+	})
+
+	t.Run("limit_truncates_and_hint_stays_off_stdout", func(t *testing.T) {
+		full := bdProxiedQueryJSON(t, bd, p, "priority>=0", "--all", "--limit", "0")
+		if len(full) <= 2 {
+			t.Fatalf("fixture should have > 2 issues, got %d", len(full))
+		}
+		page := bdProxiedQueryJSON(t, bd, p, "priority>=0", "--all", "--limit", "2")
+		if len(page) != 2 {
+			t.Errorf("--limit 2 should cap at 2 rows, got %d", len(page))
+		}
+		stdout, _ := bdProxiedQueryCapture(t, bd, p, "priority>=0", "--all", "--limit", "2")
+		if strings.Contains(stdout, "more results matched") {
+			t.Errorf("truncation hint must not leak into stdout:\n%s", stdout)
+		}
+	})
+
+	t.Run("offset_rejected_for_predicate_query", func(t *testing.T) {
+		out := bdProxiedQueryFail(t, bd, p, "type=bug OR type=feature", "--offset", "1")
+		if !strings.Contains(out, "--offset is not supported with OR/predicate queries") {
+			t.Errorf("expected predicate+offset rejection, got: %s", out)
+		}
+	})
+
+	t.Run("parse_only_short_circuits", func(t *testing.T) {
+		stdout, _ := bdProxiedQueryCapture(t, bd, p, "status=open AND priority<=1", "--parse-only")
+		if !strings.Contains(stdout, "Parsed query:") {
+			t.Errorf("expected parsed-query output, got: %s", stdout)
+		}
+	})
+
+	t.Run("no_match_returns_empty", func(t *testing.T) {
+		issues := bdProxiedQueryJSON(t, bd, p, "title=this-title-matches-nothing-xyz")
+		if len(issues) != 0 {
+			t.Errorf("expected 0 issues for non-matching query, got %d", len(issues))
+		}
+	})
+
+	t.Run("assignee_equals", func(t *testing.T) {
+		issues := bdProxiedQueryJSON(t, bd, p, "assignee=alice")
+		for _, issue := range issues {
+			if issue.Assignee != "alice" {
+				t.Errorf("expected assignee alice, got %q for %s", issue.Assignee, issue.ID)
+			}
+		}
+		if !containsID(issues, seed.openBug) {
+			t.Errorf("alice's open bug should match assignee=alice, got %v", listIssueIDs(issues))
+		}
+	})
+
+	t.Run("priority_greater_than", func(t *testing.T) {
+		issues := bdProxiedQueryJSON(t, bd, p, "priority>1")
+		for _, issue := range issues {
+			if issue.Priority <= 1 {
+				t.Errorf("expected priority > 1, got %d for %s", issue.Priority, issue.ID)
+			}
+		}
+		if !containsID(issues, seed.decision) {
+			t.Errorf("P4 decision should match priority>1, got %v", listIssueIDs(issues))
+		}
+	})
+
+	t.Run("priority_less_equal", func(t *testing.T) {
+		issues := bdProxiedQueryJSON(t, bd, p, "priority<=1")
+		for _, issue := range issues {
+			if issue.Priority > 1 {
+				t.Errorf("expected priority <= 1, got %d for %s", issue.Priority, issue.ID)
+			}
+		}
+		if !containsID(issues, seed.openBug) {
+			t.Errorf("P0 open bug should match priority<=1, got %v", listIssueIDs(issues))
+		}
+	})
+
+	t.Run("not_type", func(t *testing.T) {
+		issues := bdProxiedQueryJSON(t, bd, p, "NOT type=task")
+		for _, issue := range issues {
+			if issue.IssueType == types.TypeTask {
+				t.Errorf("NOT type=task should exclude tasks, got task %s", issue.ID)
+			}
+		}
+		if !containsID(issues, seed.openBug) {
+			t.Errorf("bug should match NOT type=task, got %v", listIssueIDs(issues))
+		}
+	})
+
+	t.Run("type_inequality", func(t *testing.T) {
+		issues := bdProxiedQueryJSON(t, bd, p, "type!=task")
+		for _, issue := range issues {
+			if issue.IssueType == types.TypeTask {
+				t.Errorf("type!=task should exclude tasks, got task %s", issue.ID)
+			}
+		}
+		if !containsID(issues, seed.feature) {
+			t.Errorf("feature should match type!=task, got %v", listIssueIDs(issues))
+		}
+	})
+
+	t.Run("all_includes_closed", func(t *testing.T) {
+		closed := bdProxiedCreate(t, bd, p.dir, "Closed query task", "--type", "task")
+		bdProxiedClose(t, bd, p.dir, closed.ID)
+
+		def := bdProxiedQueryJSON(t, bd, p, "type=task")
+		if containsID(def, closed.ID) {
+			t.Errorf("closed task %s should be excluded without --all", closed.ID)
+		}
+
+		all := bdProxiedQueryJSON(t, bd, p, "type=task", "--all")
+		if !containsID(all, closed.ID) {
+			t.Errorf("closed task %s should appear with --all, got %v", closed.ID, listIssueIDs(all))
+		}
+	})
+
+	t.Run("sort_priority_ascending", func(t *testing.T) {
+		issues := bdProxiedQueryJSON(t, bd, p, "priority>=0", "--sort", "priority")
+		for i := 1; i < len(issues); i++ {
+			if issues[i-1].Priority > issues[i].Priority {
+				t.Errorf("--sort priority should be ascending, got P%d before P%d at index %d",
+					issues[i-1].Priority, issues[i].Priority, i)
+			}
+		}
+	})
+
+	t.Run("sort_priority_reverse", func(t *testing.T) {
+		issues := bdProxiedQueryJSON(t, bd, p, "priority>=0", "--sort", "priority", "--reverse")
+		for i := 1; i < len(issues); i++ {
+			if issues[i-1].Priority < issues[i].Priority {
+				t.Errorf("--sort priority --reverse should be descending, got P%d before P%d at index %d",
+					issues[i-1].Priority, issues[i].Priority, i)
+			}
+		}
+	})
+
+	t.Run("long_text_output", func(t *testing.T) {
+		stdout, _ := bdProxiedQueryCapture(t, bd, p, "status=open", "--long")
+		if !strings.Contains(stdout, "Found") {
+			t.Errorf("--long should contain 'Found N issues:', got:\n%s", stdout)
+		}
+		if !strings.Contains(stdout, seed.openBug) {
+			t.Errorf("--long output should contain open bug %s, got:\n%s", seed.openBug, stdout)
+		}
+	})
+
+	t.Run("no_expression_fails", func(t *testing.T) {
+		_, _, err := bdProxiedRunBuffers(t, bd, p.dir, "query")
+		if err == nil {
+			t.Error("bd query with no expression should fail")
+		}
+	})
+
+	t.Run("invalid_expression_fails", func(t *testing.T) {
+		out := bdProxiedQueryFail(t, bd, p, "===invalid===")
+		if !strings.Contains(out, "parsing query") {
+			t.Errorf("expected parse error for invalid expression, got: %s", out)
+		}
+	})
+
+	t.Run("concurrent_queries", func(t *testing.T) {
+		const numWorkers = 8
+		variants := [][]string{
+			{"status=open"},
+			{"type=task"},
+			{"--sort", "priority", "priority>=1"},
+			{"--limit", "3", "status=open"},
+			{"--reverse", "--sort", "priority", "status=open"},
+		}
+		errs := make([]error, numWorkers)
+		var wg sync.WaitGroup
+		wg.Add(numWorkers)
+		for w := 0; w < numWorkers; w++ {
+			go func(worker int) {
+				defer wg.Done()
+				v := variants[worker%len(variants)]
+				args := append([]string{"query", "--json"}, v...)
+				_, stderr, err := bdProxiedRunBuffers(t, bd, p.dir, args...)
+				if err != nil {
+					errs[worker] = fmt.Errorf("worker %d query %v failed: %v\n%s", worker, v, err, stderr)
+				}
+			}(w)
+		}
+		wg.Wait()
+		for _, e := range errs {
+			if e != nil {
+				t.Error(e)
+			}
+		}
+	})
+
+	t.Run("ephemeral_true_returns_only_wisps", func(t *testing.T) {
+		var wispIDs []string
+		for i := 0; i < 3; i++ {
+			w := bdProxiedCreate(t, bd, p.dir, fmt.Sprintf("Wisp query %d", i), "--ephemeral")
+			wispIDs = append(wispIDs, w.ID)
+		}
+
+		issues := bdProxiedQueryJSON(t, bd, p, "ephemeral=true", "--limit", "0")
+		for _, wid := range wispIDs {
+			if !containsID(issues, wid) {
+				t.Errorf("ephemeral wisp %s should appear in ephemeral=true query, got %v",
+					wid, listIssueIDs(issues))
+			}
+		}
+		for _, issue := range issues {
+			if issue.Issue == nil || !issue.Ephemeral {
+				t.Errorf("ephemeral=true must return only wisps, but %s is not ephemeral", issue.ID)
+			}
+		}
+		if containsID(issues, seed.openBug) {
+			t.Errorf("permanent issue %s must not appear in ephemeral=true query", seed.openBug)
+		}
+	})
+
+	t.Run("default_query_merges_issues_and_wisps", func(t *testing.T) {
+		w := bdProxiedCreate(t, bd, p.dir, "Wisp merge probe", "--ephemeral")
+
+		merged := bdProxiedQueryJSON(t, bd, p, "priority>=0", "--all", "--limit", "0")
+		if !containsID(merged, w.ID) {
+			t.Errorf("default query should merge in wisp %s, got %v", w.ID, listIssueIDs(merged))
+		}
+		if !containsID(merged, seed.openBug) {
+			t.Errorf("default query should include permanent issue %s", seed.openBug)
+		}
+	})
+}

--- a/cmd/bd/query_proxied_server.go
+++ b/cmd/bd/query_proxied_server.go
@@ -1,0 +1,138 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/steveyegge/beads/internal/query"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+func runQueryProxiedServer(cmd *cobra.Command, ctx context.Context, args []string) error {
+	if len(args) == 0 {
+		fmt.Fprintf(os.Stderr, "Error: query expression is required\n\n")
+		if err := cmd.Help(); err != nil {
+			fmt.Fprintf(os.Stderr, "Error displaying help: %v\n", err)
+		}
+		return SilentExit()
+	}
+
+	queryStr := strings.Join(args, " ")
+
+	limit, _ := cmd.Flags().GetInt("limit")
+	allFlag, _ := cmd.Flags().GetBool("all")
+	longFormat, _ := cmd.Flags().GetBool("long")
+	sortBy, _ := cmd.Flags().GetString("sort")
+	reverse, _ := cmd.Flags().GetBool("reverse")
+	parseOnly, _ := cmd.Flags().GetBool("parse-only")
+	offset, _ := cmd.Flags().GetInt("offset")
+
+	node, err := query.Parse(queryStr)
+	if err != nil {
+		return HandleErrorRespectJSON("parsing query: %v", err)
+	}
+
+	if parseOnly {
+		fmt.Printf("Parsed query: %s\n", node.String())
+		return nil
+	}
+
+	eval := query.NewEvaluator(time.Now())
+	result, err := eval.Evaluate(node)
+	if err != nil {
+		return HandleErrorRespectJSON("evaluating query: %v", err)
+	}
+
+	if result.RequiresPredicate && offset > 0 {
+		return HandleErrorRespectJSON("--offset is not supported with OR/predicate queries")
+	}
+
+	if limit > 0 && !result.RequiresPredicate {
+		result.Filter.Limit = limit
+	}
+
+	if !allFlag && result.Filter.Status == nil && !hasExplicitStatusFilter(node) {
+		result.Filter.ExcludeStatus = append(result.Filter.ExcludeStatus, types.StatusClosed)
+	}
+
+	searchFilter := result.Filter
+	searchFilter.Offset = offset
+	if result.RequiresPredicate && limit > 0 {
+		searchFilter.Limit = limit * 3
+		if searchFilter.Limit < 100 {
+			searchFilter.Limit = 100
+		}
+	}
+
+	uw, err := openProxiedListUOW(ctx)
+	if err != nil {
+		return HandleErrorRespectJSON("%v", err)
+	}
+	defer uw.Close(ctx)
+
+	if jsonOutput {
+		page, err := uw.IssueUseCase().SearchIssuesWithCounts(ctx, "", searchFilter)
+		if err != nil {
+			return HandleErrorRespectJSON("%v", err)
+		}
+		iwc := page.Items
+		truncated := page.HasMore
+		if result.RequiresPredicate && result.Predicate != nil {
+			filtered := make([]*types.IssueWithCounts, 0, len(iwc))
+			for _, item := range iwc {
+				if item == nil || item.Issue == nil {
+					continue
+				}
+				if result.Predicate(item.Issue) {
+					filtered = append(filtered, item)
+				}
+			}
+			iwc = filtered
+			truncated = limit > 0 && len(iwc) > limit
+			if truncated {
+				iwc = iwc[:limit]
+			}
+		}
+		sortIssuesWithCounts(iwc, sortBy, reverse)
+		if iwc == nil {
+			iwc = []*types.IssueWithCounts{}
+		}
+		if err := outputJSON(iwc); err != nil {
+			return err
+		}
+		printTruncationHint(truncated, limit)
+		return nil
+	}
+
+	page, err := uw.IssueUseCase().SearchIssues(ctx, "", searchFilter)
+	if err != nil {
+		return HandleErrorRespectJSON("%v", err)
+	}
+	issues := page.Items
+	truncated := page.HasMore
+
+	if result.RequiresPredicate && result.Predicate != nil {
+		filtered := make([]*types.Issue, 0, len(issues))
+		for _, issue := range issues {
+			if result.Predicate(issue) {
+				filtered = append(filtered, issue)
+			}
+		}
+		issues = filtered
+		truncated = limit > 0 && len(issues) > limit
+		if truncated {
+			issues = issues[:limit]
+		}
+	}
+
+	sortIssues(issues, sortBy, reverse)
+
+	outputQueryResults(issues, queryStr, longFormat)
+	printTruncationHint(truncated, limit)
+	return nil
+}

--- a/cmd/bd/query_proxied_server.go
+++ b/cmd/bd/query_proxied_server.go
@@ -31,6 +31,9 @@ func runQueryProxiedServer(cmd *cobra.Command, ctx context.Context, args []strin
 	reverse, _ := cmd.Flags().GetBool("reverse")
 	parseOnly, _ := cmd.Flags().GetBool("parse-only")
 	offset, _ := cmd.Flags().GetInt("offset")
+	if offset < 0 {
+		return HandleErrorRespectJSON("--offset must be non-negative")
+	}
 
 	node, err := query.Parse(queryStr)
 	if err != nil {
@@ -58,6 +61,10 @@ func runQueryProxiedServer(cmd *cobra.Command, ctx context.Context, args []strin
 
 	if !allFlag && result.Filter.Status == nil && !hasExplicitStatusFilter(node) {
 		result.Filter.ExcludeStatus = append(result.Filter.ExcludeStatus, types.StatusClosed)
+	}
+
+	if offset > 0 && sortBy != "" {
+		return HandleErrorRespectJSON("--offset is not supported with --sort (query applies --sort client-side, which cannot be paginated)")
 	}
 
 	searchFilter := result.Filter

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -1204,6 +1204,7 @@ bd query [expression] [flags]
   -a, --all           Include closed issues (default: exclude closed)
   -n, --limit int     Limit results (default: 50, 0 = unlimited) (default 50)
       --long          Show detailed multi-line output for each issue
+      --offset int    Skip the first N matching results (0-based). Only supported under --proxied-server.
       --parse-only    Only parse the query and show the AST (for debugging)
   -r, --reverse       Reverse sort order
       --sort string   Sort by field: priority, created, updated, closed, status, id, title, type, assignee

--- a/website/docs/cli-reference/query.md
+++ b/website/docs/cli-reference/query.md
@@ -78,6 +78,7 @@ bd query [expression] [flags]
   -a, --all           Include closed issues (default: exclude closed)
   -n, --limit int     Limit results (default: 50, 0 = unlimited) (default 50)
       --long          Show detailed multi-line output for each issue
+      --offset int    Skip the first N matching results (0-based). Only supported under --proxied-server.
       --parse-only    Only parse the query and show the AST (for debugging)
   -r, --reverse       Reverse sort order
       --sort string   Sort by field: priority, created, updated, closed, status, id, title, type, assignee


### PR DESCRIPTION
## Summary

Adds proxied-server support for `bd query`, routing through the domain use-case interfaces (`IssueUseCase.SearchIssues{,WithCounts}`) like the other proxied commands. The non-proxied path is untouched aside from an additive `--offset` flag; all proxied logic lives in a new `query_proxied_server.go`, following the `update.go` / `update_proxied_server.go` split.

## What's included

- **`cmd/bd/query.go`**: early `usesProxiedServer()` dispatch, an additive `--offset` flag (gated to proxied-server, mirroring `list`), and an `--offset > 0` rejection on the non-proxied path.
- **`cmd/bd/query_proxied_server.go`**: `runQueryProxiedServer` — re-parses input, opens a UOW, calls the existing `IssueUseCase.SearchIssues{,WithCounts}`, supports paging (offset + `HasMore`) for filter-only queries, and rejects `--offset` for OR/predicate queries (the embedded union can't page across the issues+wisps merge, which is why `--offset` is proxied-only).
- **`cmd/bd/query_proxied_integration_test.go`**: parity with the embedded query tests (field comparisons, AND/OR/NOT/`!=`, `--all`, sort, `--long`, error cases, concurrency) plus wisp scoping — including the exact compound clauses gascity's `listEphemeral` sends (`ephemeral=true AND label=…` / `AND parent=…`).
- **`cmd/bd/list_proxied_integration_test.go`**: fixes two latent bugs in the existing proxied list tests surfaced once the suite could run end-to-end — the truncation-hint assertion can't observe the TTY-gated stderr hint through a piped subprocess, and the ready-wisp test asserted a behavior `ready_work_union.go` deliberately does not have (ephemerals are excluded from default ready). Both now assert observable behavior.

## Notes

- The `bd init --proxied-server` gate ("not yet implemented") is left **intact**; the query proxied path stays dormant behind it, exactly like the already-merged context/show/etc. proxied commands. Lifting the gate is a separate, deliberate change.
- Behavior matches the embedded path: `ephemeral=true` routes to the wisps table (`searchAcrossIssuesAndWisps`), `label=`/`parent=` filter against `wisp_labels`/`wisp_dependencies`, and JSON output is `[]*types.IssueWithCounts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)