### PR TITLE
bd sql: proxied-server support

### DIFF
--- a/cmd/bd/sql.go
+++ b/cmd/bd/sql.go
@@ -47,6 +47,10 @@ WARNING: Direct database access bypasses the storage layer. Use with caution.`,
 		query := args[0]
 		csvOutput, _ := cmd.Flags().GetBool("csv")
 
+		if usesProxiedServer() {
+			return runSQLProxiedServer(cmd, rootCtx, query, csvOutput)
+		}
+
 		if store == nil {
 			return HandleErrorRespectJSON("no database connection available (%s)", diagHint())
 		}

--- a/cmd/bd/sql.go
+++ b/cmd/bd/sql.go
@@ -48,7 +48,7 @@ WARNING: Direct database access bypasses the storage layer. Use with caution.`,
 		csvOutput, _ := cmd.Flags().GetBool("csv")
 
 		if usesProxiedServer() {
-			return runSQLProxiedServer(cmd, rootCtx, query, csvOutput)
+			return runSQLProxiedServer(rootCtx, query, csvOutput)
 		}
 
 		if store == nil {

--- a/cmd/bd/sql_proxied_integration_test.go
+++ b/cmd/bd/sql_proxied_integration_test.go
@@ -1,0 +1,180 @@
+//go:build cgo
+
+package main
+
+import (
+	"encoding/json"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func bdProxiedSQL(t *testing.T, bd, dir string, args ...string) (string, string) {
+	t.Helper()
+	fullArgs := append([]string{"sql"}, args...)
+	stdout, stderr, err := bdProxiedRunBuffers(t, bd, dir, fullArgs...)
+	if err != nil {
+		t.Fatalf("bd sql %s failed: %v\nstdout:\n%s\nstderr:\n%s",
+			strings.Join(args, " "), err, stdout, stderr)
+	}
+	return stdout, stderr
+}
+
+func bdProxiedSQLJSON(t *testing.T, bd, dir string, query string) []map[string]interface{} {
+	t.Helper()
+	stdout, _ := bdProxiedSQL(t, bd, dir, "--json", query)
+	start := strings.Index(stdout, "[")
+	if start < 0 {
+		t.Fatalf("no JSON array found in sql output:\n%s", stdout)
+	}
+	var rows []map[string]interface{}
+	if err := json.Unmarshal([]byte(stdout[start:]), &rows); err != nil {
+		t.Fatalf("failed to parse sql JSON output: %v\nraw: %s", err, stdout[start:])
+	}
+	return rows
+}
+
+func bdProxiedSQLFail(t *testing.T, bd, dir string, args ...string) string {
+	t.Helper()
+	fullArgs := append([]string{"sql"}, args...)
+	stdout, stderr, err := bdProxiedRunBuffers(t, bd, dir, fullArgs...)
+	if err == nil {
+		t.Fatalf("expected bd sql %s to fail, but it succeeded:\nstdout:\n%s\nstderr:\n%s",
+			strings.Join(args, " "), stdout, stderr)
+	}
+	return stdout + stderr
+}
+
+func TestProxiedServerSQL(t *testing.T) {
+	requireProxiedServerEnv(t)
+	bd := buildEmbeddedBD(t)
+	p := bdProxiedInit(t, bd, "sql")
+
+	one := bdProxiedCreate(t, bd, p.dir, "Test issue one", "--type", "task", "--priority", "1")
+	two := bdProxiedCreate(t, bd, p.dir, "Test issue two", "--type", "bug", "--priority", "2")
+	bdProxiedClose(t, bd, p.dir, two.ID)
+
+	t.Run("select_count", func(t *testing.T) {
+		rows := bdProxiedSQLJSON(t, bd, p.dir, "SELECT COUNT(*) as count FROM issues")
+		if len(rows) != 1 {
+			t.Fatalf("expected 1 row, got %d", len(rows))
+		}
+		count, ok := rows[0]["count"]
+		if !ok {
+			t.Fatal("missing 'count' column in result")
+		}
+		if !sqlValueEquals(count, 2) {
+			t.Errorf("expected count=2, got %v", count)
+		}
+	})
+
+	t.Run("select_with_filter", func(t *testing.T) {
+		rows := bdProxiedSQLJSON(t, bd, p.dir, `SELECT id, title FROM issues WHERE status = 'open'`)
+		if len(rows) != 1 {
+			t.Fatalf("expected 1 open issue, got %d", len(rows))
+		}
+		if rows[0]["title"] != "Test issue one" {
+			t.Errorf("expected 'Test issue one', got %q", rows[0]["title"])
+		}
+		if rows[0]["id"] != one.ID {
+			t.Errorf("expected id %q, got %q", one.ID, rows[0]["id"])
+		}
+	})
+
+	t.Run("empty_result_json", func(t *testing.T) {
+		rows := bdProxiedSQLJSON(t, bd, p.dir, `SELECT * FROM issues WHERE title = 'nonexistent'`)
+		if len(rows) != 0 {
+			t.Errorf("expected 0 rows, got %d", len(rows))
+		}
+	})
+
+	t.Run("table_output", func(t *testing.T) {
+		stdout, _ := bdProxiedSQL(t, bd, p.dir, "SELECT COUNT(*) as count FROM issues")
+		if !strings.Contains(stdout, "count") {
+			t.Errorf("expected table header 'count' in output: %s", stdout)
+		}
+		if !strings.Contains(stdout, "(1 rows)") {
+			t.Errorf("expected '(1 rows)' in output: %s", stdout)
+		}
+	})
+
+	t.Run("empty_table_output", func(t *testing.T) {
+		stdout, _ := bdProxiedSQL(t, bd, p.dir, `SELECT * FROM issues WHERE title = 'nonexistent'`)
+		if !strings.Contains(stdout, "(0 rows)") {
+			t.Errorf("expected '(0 rows)' in output: %s", stdout)
+		}
+	})
+
+	t.Run("csv_output", func(t *testing.T) {
+		stdout, _ := bdProxiedSQL(t, bd, p.dir, "--csv", `SELECT id, title FROM issues WHERE status = 'open'`)
+		lines := strings.Split(strings.TrimSpace(stdout), "\n")
+		if len(lines) != 2 {
+			t.Fatalf("expected header + 1 data row, got %d lines:\n%s", len(lines), stdout)
+		}
+		if lines[0] != "id,title" {
+			t.Errorf("expected CSV header 'id,title', got %q", lines[0])
+		}
+		if !strings.Contains(lines[1], one.ID) || !strings.Contains(lines[1], "Test issue one") {
+			t.Errorf("expected CSV row with open issue, got %q", lines[1])
+		}
+	})
+
+	t.Run("exec_update_reports_rows_affected", func(t *testing.T) {
+		stdout, _ := bdProxiedSQL(t, bd, p.dir,
+			"--json", "UPDATE issues SET priority = 3 WHERE id = '"+one.ID+"'")
+		var res map[string]interface{}
+		start := strings.Index(stdout, "{")
+		if start < 0 {
+			t.Fatalf("no JSON object in exec output:\n%s", stdout)
+		}
+		if err := json.Unmarshal([]byte(stdout[start:]), &res); err != nil {
+			t.Fatalf("parse exec JSON: %v\nraw: %s", err, stdout[start:])
+		}
+		if !sqlValueEquals(res["rows_affected"], 1) {
+			t.Errorf("expected rows_affected=1, got %v", res["rows_affected"])
+		}
+
+		rows := bdProxiedSQLJSON(t, bd, p.dir,
+			"SELECT priority FROM issues WHERE id = '"+one.ID+"'")
+		if len(rows) != 1 {
+			t.Fatalf("expected 1 row after update, got %d", len(rows))
+		}
+		if !sqlValueEquals(rows[0]["priority"], 3) {
+			t.Errorf("expected priority=3 after update, got %v", rows[0]["priority"])
+		}
+	})
+
+	t.Run("exec_persists_across_connections", func(t *testing.T) {
+		bdProxiedSQL(t, bd, p.dir,
+			"UPDATE issues SET priority = 4 WHERE id = '"+two.ID+"'")
+
+		db := openProxiedDB(t, p)
+		var priority int
+		if err := db.QueryRow(
+			"SELECT priority FROM issues WHERE id = ?", two.ID).Scan(&priority); err != nil {
+			t.Fatalf("query priority for %s: %v", two.ID, err)
+		}
+		if priority != 4 {
+			t.Errorf("expected committed priority=4, got %d", priority)
+		}
+	})
+
+	t.Run("invalid_sql_fails", func(t *testing.T) {
+		out := bdProxiedSQLFail(t, bd, p.dir, "SELECT * FROM nonexistent_table")
+		if !strings.Contains(strings.ToLower(out), "error") {
+			t.Errorf("expected error for invalid SQL, got: %s", out)
+		}
+	})
+}
+
+func sqlValueEquals(v any, want float64) bool {
+	switch x := v.(type) {
+	case float64:
+		return x == want
+	case string:
+		f, err := strconv.ParseFloat(x, 64)
+		return err == nil && f == want
+	default:
+		return false
+	}
+}

--- a/cmd/bd/sql_proxied_server.go
+++ b/cmd/bd/sql_proxied_server.go
@@ -1,0 +1,155 @@
+package main
+
+import (
+	"context"
+	"encoding/csv"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/steveyegge/beads/internal/storage/domain"
+	"github.com/steveyegge/beads/internal/storage/uow"
+)
+
+func runSQLProxiedServer(cmd *cobra.Command, ctx context.Context, query string, csvOutput bool) error {
+	trimmed := strings.TrimSpace(strings.ToUpper(query))
+	isRead := strings.HasPrefix(trimmed, "SELECT") ||
+		strings.HasPrefix(trimmed, "EXPLAIN") ||
+		strings.HasPrefix(trimmed, "PRAGMA") ||
+		strings.HasPrefix(trimmed, "SHOW") ||
+		strings.HasPrefix(trimmed, "DESCRIBE") ||
+		strings.HasPrefix(trimmed, "WITH")
+
+	if isRead {
+		uw, err := openProxiedListUOW(ctx)
+		if err != nil {
+			return HandleErrorRespectJSON("%v", err)
+		}
+		defer uw.Close(ctx)
+
+		result, err := uw.RawSQLUseCase().Query(ctx, query)
+		if err != nil {
+			return HandleErrorRespectJSON("query error: %v", err)
+		}
+		return renderRawSQLResult(result, csvOutput)
+	}
+
+	CheckReadonly("sql")
+
+	var affected int64
+	err := uow.RunInTxMsg(ctx, uowProvider, func(uw uow.UnitOfWork) (string, error) {
+		n, err := uw.RawSQLUseCase().Exec(ctx, query)
+		if err != nil {
+			return "", err
+		}
+		affected = n
+		return "bd sql: " + query, nil
+	})
+	if err != nil {
+		return HandleErrorRespectJSON("exec error: %v", err)
+	}
+
+	if jsonOutput {
+		return outputJSON(map[string]interface{}{
+			"rows_affected": affected,
+		})
+	}
+
+	fmt.Printf("OK, %d rows affected\n", affected)
+	return nil
+}
+
+func renderRawSQLResult(result *domain.RawSQLResult, csvOutput bool) error {
+	columns := result.Columns
+
+	if jsonOutput {
+		out := make([]map[string]interface{}, 0, len(result.Rows))
+		for _, row := range result.Rows {
+			m := make(map[string]interface{}, len(columns))
+			for i, col := range columns {
+				m[col] = row[i]
+			}
+			out = append(out, m)
+		}
+		return outputJSON(out)
+	}
+
+	if csvOutput {
+		w := csv.NewWriter(os.Stdout)
+		if err := w.Write(columns); err != nil {
+			return HandleErrorRespectJSON("writing CSV header: %v", err)
+		}
+		for _, row := range result.Rows {
+			record := make([]string, len(columns))
+			for i := range columns {
+				record[i] = fmt.Sprintf("%v", row[i])
+			}
+			if err := w.Write(record); err != nil {
+				return HandleErrorRespectJSON("writing CSV row: %v", err)
+			}
+		}
+		w.Flush()
+		if err := w.Error(); err != nil {
+			return HandleErrorRespectJSON("flushing CSV: %v", err)
+		}
+		return nil
+	}
+
+	if len(result.Rows) == 0 {
+		fmt.Println("(0 rows)")
+		return nil
+	}
+
+	widths := make([]int, len(columns))
+	for i, col := range columns {
+		widths[i] = len(col)
+	}
+	for _, row := range result.Rows {
+		for i := range columns {
+			s := fmt.Sprintf("%v", row[i])
+			if len(s) > widths[i] {
+				widths[i] = len(s)
+			}
+		}
+	}
+	for i := range widths {
+		if widths[i] > 60 {
+			widths[i] = 60
+		}
+	}
+
+	for i, col := range columns {
+		if i > 0 {
+			fmt.Print(" | ")
+		}
+		fmt.Printf("%-*s", widths[i], col)
+	}
+	fmt.Println()
+
+	for i := range columns {
+		if i > 0 {
+			fmt.Print("-+-")
+		}
+		fmt.Print(strings.Repeat("-", widths[i]))
+	}
+	fmt.Println()
+
+	for _, row := range result.Rows {
+		for i := range columns {
+			if i > 0 {
+				fmt.Print(" | ")
+			}
+			s := fmt.Sprintf("%v", row[i])
+			if len(s) > 60 {
+				s = s[:57] + "..."
+			}
+			fmt.Printf("%-*s", widths[i], s)
+		}
+		fmt.Println()
+	}
+
+	fmt.Printf("(%d rows)\n", len(result.Rows))
+	return nil
+}

--- a/cmd/bd/sql_proxied_server.go
+++ b/cmd/bd/sql_proxied_server.go
@@ -7,13 +7,11 @@ import (
 	"os"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/steveyegge/beads/internal/storage/domain"
 	"github.com/steveyegge/beads/internal/storage/uow"
 )
 
-func runSQLProxiedServer(cmd *cobra.Command, ctx context.Context, query string, csvOutput bool) error {
+func runSQLProxiedServer(ctx context.Context, query string, csvOutput bool) error {
 	trimmed := strings.TrimSpace(strings.ToUpper(query))
 	isRead := strings.HasPrefix(trimmed, "SELECT") ||
 		strings.HasPrefix(trimmed, "EXPLAIN") ||

--- a/cmd/bd/sql_proxied_server.go
+++ b/cmd/bd/sql_proxied_server.go
@@ -12,15 +12,7 @@ import (
 )
 
 func runSQLProxiedServer(ctx context.Context, query string, csvOutput bool) error {
-	trimmed := strings.TrimSpace(strings.ToUpper(query))
-	isRead := strings.HasPrefix(trimmed, "SELECT") ||
-		strings.HasPrefix(trimmed, "EXPLAIN") ||
-		strings.HasPrefix(trimmed, "PRAGMA") ||
-		strings.HasPrefix(trimmed, "SHOW") ||
-		strings.HasPrefix(trimmed, "DESCRIBE") ||
-		strings.HasPrefix(trimmed, "WITH")
-
-	if isRead {
+	if sqlQueryIsRead(query) {
 		uw, err := openProxiedListUOW(ctx)
 		if err != nil {
 			return HandleErrorRespectJSON("%v", err)
@@ -35,6 +27,10 @@ func runSQLProxiedServer(ctx context.Context, query string, csvOutput bool) erro
 	}
 
 	CheckReadonly("sql")
+
+	if uowProvider == nil {
+		FatalError("proxied-server UOW provider not initialized")
+	}
 
 	var affected int64
 	err := uow.RunInTxMsg(ctx, uowProvider, func(uw uow.UnitOfWork) (string, error) {
@@ -57,6 +53,59 @@ func runSQLProxiedServer(ctx context.Context, query string, csvOutput bool) erro
 
 	fmt.Printf("OK, %d rows affected\n", affected)
 	return nil
+}
+
+func sqlQueryIsRead(query string) bool {
+	trimmed := strings.TrimSpace(strings.ToUpper(query))
+	switch {
+	case strings.HasPrefix(trimmed, "SELECT"),
+		strings.HasPrefix(trimmed, "EXPLAIN"),
+		strings.HasPrefix(trimmed, "PRAGMA"),
+		strings.HasPrefix(trimmed, "SHOW"),
+		strings.HasPrefix(trimmed, "DESCRIBE"):
+		return true
+	case strings.HasPrefix(trimmed, "WITH"):
+		return withOuterStatementIsRead(trimmed)
+	default:
+		return false
+	}
+}
+
+func withOuterStatementIsRead(upperTrimmed string) bool {
+	depth := 0
+	var quote byte
+	closedCTE := false
+	for i := 0; i < len(upperTrimmed); i++ {
+		c := upperTrimmed[i]
+		if quote != 0 {
+			if c == quote {
+				quote = 0
+			}
+			continue
+		}
+		switch c {
+		case '\'', '"', '`':
+			quote = c
+		case '(':
+			depth++
+		case ')':
+			depth--
+			if depth == 0 {
+				closedCTE = true
+			}
+		case ' ', '\t', '\n', '\r', ',':
+			if c == ',' && depth == 0 {
+				closedCTE = false
+			}
+		default:
+			if depth == 0 && closedCTE {
+				rest := strings.TrimLeft(upperTrimmed[i:], " \t\n\r")
+				return strings.HasPrefix(rest, "SELECT") ||
+					strings.HasPrefix(rest, "EXPLAIN")
+			}
+		}
+	}
+	return true
 }
 
 func renderRawSQLResult(result *domain.RawSQLResult, csvOutput bool) error {

--- a/internal/storage/domain/db/raw_sql.go
+++ b/internal/storage/domain/db/raw_sql.go
@@ -1,0 +1,65 @@
+package db
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/steveyegge/beads/internal/storage/domain"
+)
+
+func NewRawSQLRepository(runner Runner) domain.RawSQLRepository {
+	return &rawSQLRepositoryImpl{runner: runner}
+}
+
+type rawSQLRepositoryImpl struct {
+	runner Runner
+}
+
+var _ domain.RawSQLRepository = (*rawSQLRepositoryImpl)(nil)
+
+func (r *rawSQLRepositoryImpl) Query(ctx context.Context, query string, args ...any) (*domain.RawSQLResult, error) {
+	rows, err := r.runner.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("db: RawSQL Query: %w", err)
+	}
+	defer rows.Close()
+
+	columns, err := rows.Columns()
+	if err != nil {
+		return nil, fmt.Errorf("db: RawSQL Query: columns: %w", err)
+	}
+
+	result := &domain.RawSQLResult{Columns: columns}
+	for rows.Next() {
+		values := make([]any, len(columns))
+		ptrs := make([]any, len(columns))
+		for i := range values {
+			ptrs[i] = &values[i]
+		}
+		if err := rows.Scan(ptrs...); err != nil {
+			return nil, fmt.Errorf("db: RawSQL Query: scan: %w", err)
+		}
+		for i, v := range values {
+			if b, ok := v.([]byte); ok {
+				values[i] = string(b)
+			}
+		}
+		result.Rows = append(result.Rows, values)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("db: RawSQL Query: rows: %w", err)
+	}
+	return result, nil
+}
+
+func (r *rawSQLRepositoryImpl) Exec(ctx context.Context, query string, args ...any) (int64, error) {
+	res, err := r.runner.ExecContext(ctx, query, args...)
+	if err != nil {
+		return 0, fmt.Errorf("db: RawSQL Exec: %w", err)
+	}
+	affected, err := res.RowsAffected()
+	if err != nil {
+		return 0, fmt.Errorf("db: RawSQL Exec: rows affected: %w", err)
+	}
+	return affected, nil
+}

--- a/internal/storage/domain/raw_sql.go
+++ b/internal/storage/domain/raw_sql.go
@@ -1,0 +1,36 @@
+package domain
+
+import "context"
+
+type RawSQLResult struct {
+	Columns []string
+	Rows    [][]any
+}
+
+type RawSQLRepository interface {
+	Query(ctx context.Context, query string, args ...any) (*RawSQLResult, error)
+	Exec(ctx context.Context, query string, args ...any) (int64, error)
+}
+
+type RawSQLUseCase interface {
+	Query(ctx context.Context, query string, args ...any) (*RawSQLResult, error)
+	Exec(ctx context.Context, query string, args ...any) (int64, error)
+}
+
+func NewRawSQLUseCase(repo RawSQLRepository) RawSQLUseCase {
+	return &rawSQLUseCaseImpl{repo: repo}
+}
+
+type rawSQLUseCaseImpl struct {
+	repo RawSQLRepository
+}
+
+var _ RawSQLUseCase = (*rawSQLUseCaseImpl)(nil)
+
+func (u *rawSQLUseCaseImpl) Query(ctx context.Context, query string, args ...any) (*RawSQLResult, error) {
+	return u.repo.Query(ctx, query, args...)
+}
+
+func (u *rawSQLUseCaseImpl) Exec(ctx context.Context, query string, args ...any) (int64, error) {
+	return u.repo.Exec(ctx, query, args...)
+}

--- a/internal/storage/uow/run_in_tx_test.go
+++ b/internal/storage/uow/run_in_tx_test.go
@@ -25,6 +25,7 @@ func (u *stubUOW) IssueUseCase() domain.IssueUseCase           { panic("not impl
 func (u *stubUOW) DependencyUseCase() domain.DependencyUseCase { panic("not implemented") }
 func (u *stubUOW) LabelUseCase() domain.LabelUseCase           { panic("not implemented") }
 func (u *stubUOW) CommentUseCase() domain.CommentUseCase       { panic("not implemented") }
+func (u *stubUOW) RawSQLUseCase() domain.RawSQLUseCase         { panic("not implemented") }
 
 // controlledProvider lets tests inject errors per-attempt.
 type controlledProvider struct {

--- a/internal/storage/uow/uow.go
+++ b/internal/storage/uow/uow.go
@@ -19,6 +19,7 @@ type UnitOfWork interface {
 	DependencyUseCase() domain.DependencyUseCase
 	LabelUseCase() domain.LabelUseCase
 	CommentUseCase() domain.CommentUseCase
+	RawSQLUseCase() domain.RawSQLUseCase
 }
 
 type UnitOfWorkProvider interface {
@@ -45,6 +46,7 @@ type baseUOW struct {
 	dependencyUseCase domain.DependencyUseCase
 	labelUseCase      domain.LabelUseCase
 	commentUseCase    domain.CommentUseCase
+	rawSQLUseCase     domain.RawSQLUseCase
 }
 
 func (u *baseUOW) Commit(ctx context.Context, message string) error {
@@ -116,4 +118,11 @@ func (u *baseUOW) CommentUseCase() domain.CommentUseCase {
 		u.commentUseCase = domain.NewCommentUseCase(db.NewCommentSQLRepository(u.tx.Runner()))
 	}
 	return u.commentUseCase
+}
+
+func (u *baseUOW) RawSQLUseCase() domain.RawSQLUseCase {
+	if u.rawSQLUseCase == nil {
+		u.rawSQLUseCase = domain.NewRawSQLUseCase(db.NewRawSQLRepository(u.tx.Runner()))
+	}
+	return u.rawSQLUseCase
 }


### PR DESCRIPTION
## Summary

Adds proxied-server support for `bd sql`, routing raw SQL through a new domain use-case interface (`RawSQLUseCase`) like the other proxied commands. The non-proxied path is untouched; all proxied logic lives in a new `sql_proxied_server.go`, following the `update.go` / `update_proxied_server.go` split.

The local-vs-proxied difference is confined to the `uow` transaction layer (the mode-polymorphic `db.Runner`), so the new use case is the same code in both modes — consistent with how create/update/query/list already work.

## What's included

- **`internal/storage/domain/raw_sql.go`**: `RawSQLUseCase` (+ `RawSQLRepository`) with `Query`/`Exec` and a `RawSQLResult{Columns, Rows}`. `Query` materializes rows inside the open transaction (the `*sql.Conn` lifetime is bound to the UOW); `[][]any` aligned to `Columns` preserves order and tolerates duplicate column names.
- **`internal/storage/domain/db/raw_sql.go`**: repository over `db.Runner` — generic scan loop with `[]byte`→`string` normalization for `Query`, `RowsAffected` for `Exec`.
- **`internal/storage/uow/uow.go`**: `RawSQLUseCase()` added to the `UnitOfWork` interface and `baseUOW` (lazy accessor), mirroring the other six aggregates.
- **`cmd/bd/sql.go`**: early `usesProxiedServer()` dispatch before the existing `RawDBAccessor`/`store` path (which is `nil` in proxied mode).
- **`cmd/bd/sql_proxied_server.go`**: `runSQLProxiedServer` — read path opens a read-only UOW and calls `RawSQLUseCase().Query`; write path runs `CheckReadonly` then `uow.RunInTxMsg(...)` so the write commits via `CALL DOLT_COMMIT`. JSON/CSV/table rendering matches the embedded `bd sql` output.
- **`cmd/bd/sql_proxied_integration_test.go`**: parity with the embedded `TestSqlCommand` (select count, filtered select, empty result/table) plus proxied-specific coverage — CSV rendering, the exec/`rows_affected` write path, cross-connection persistence (verifies the `DOLT_COMMIT` is visible from an independent `*sql.DB`), and an invalid-SQL error case.

## Notes

- The `bd init --proxied-server` gate ("not yet implemented") is left **intact**; the sql proxied path stays dormant behind it, like the already-merged proxied commands. Lifting the gate is a separate, deliberate change.
- The new integration test is opt-in via `BEADS_TEST_PROXIED_SERVER=1` (requires a Dolt binary), same as the existing proxied command tests. It passes locally end-to-end.
- Behavioral note for review: a proxied raw write becomes an explicit Dolt commit (`bd sql: <query>`), unlike server/embedded auto-commit — consistent with every other proxied mutation, but worth a look since `bd sql` is the escape hatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)