### PR TITLE
fix(dolt): retry mutate+commit methods on serialization conflict (1213/1205)

### DIFF
--- a/internal/storage/dolt/concurrent_test.go
+++ b/internal/storage/dolt/concurrent_test.go
@@ -955,3 +955,127 @@ func TestSerializationConflictRetry(t *testing.T) {
 		t.Fatalf("expected %d labels, got %d: %v", numGoroutines, len(labels), labels)
 	}
 }
+
+// =============================================================================
+// Test: Concurrent Work-Queue Drain (the "Gas Station" scenario)
+//
+// N workers concurrently dequeue from ONE shared ready-front via
+// ClaimReadyIssue until it returns nil, exactly as N agent clones draining a
+// shared Beads work queue would. This is the core Gas Station claim-queue
+// invariant and the scenario the multi-agent port harness depends on:
+//
+//   - every issue is claimed by EXACTLY ONE worker (no double-claim / lost work)
+//   - every issue is claimed (no stranded ready work left behind)
+//   - the count of distinct claims equals the number of issues
+//
+// Dolt has no SKIP LOCKED, so the safety comes from the claim CAS (UPDATE ...
+// SET assignee WHERE assignee IS NULL) colliding on the same cell, surfacing as
+// a 1213/1205 serialization conflict, which ClaimReadyIssue's withRetryTx
+// re-scans and retries. This test is the regression guard for that guarantee.
+// =============================================================================
+
+func TestConcurrentWorkQueueDrain(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping work-queue drain test in short mode")
+	}
+
+	store, cleanup := setupConcurrentTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := concurrentTestContext(t)
+	defer cancel()
+
+	// Seed a ready-front: all open, unassigned, no blockers => all ready.
+	const numIssues = 40
+	want := make(map[string]bool, numIssues)
+	for i := 0; i < numIssues; i++ {
+		id := fmt.Sprintf("queue-%03d", i)
+		issue := &types.Issue{
+			ID:          id,
+			Title:       fmt.Sprintf("Queue item %d", i),
+			Description: "ready work for the shared drain",
+			Status:      types.StatusOpen,
+			Priority:    (i % 4) + 1,
+			IssueType:   types.TypeTask,
+		}
+		if err := store.CreateIssue(ctx, issue, "seeder"); err != nil {
+			t.Fatalf("seed issue %s: %v", id, err)
+		}
+		want[id] = true
+	}
+
+	const numWorkers = 6
+
+	var mu sync.Mutex
+	claimedBy := make(map[string]string, numIssues) // issueID -> worker that claimed it
+	var doubleClaim atomic.Int32
+	var claimErrs atomic.Int32
+	var wg sync.WaitGroup
+
+	for w := 0; w < numWorkers; w++ {
+		wg.Add(1)
+		go func(workerID int) {
+			defer wg.Done()
+			actor := fmt.Sprintf("worker-%d", workerID)
+			for {
+				issue, err := store.ClaimReadyIssue(ctx, types.WorkFilter{}, actor)
+				if err != nil {
+					claimErrs.Add(1)
+					return
+				}
+				if issue == nil {
+					return // ready-front drained from this worker's snapshot
+				}
+				mu.Lock()
+				if prev, ok := claimedBy[issue.ID]; ok {
+					t.Errorf("issue %s double-claimed: first by %s, then by %s", issue.ID, prev, actor)
+					doubleClaim.Add(1)
+				} else {
+					claimedBy[issue.ID] = actor
+				}
+				mu.Unlock()
+			}
+		}(w)
+	}
+
+	done := make(chan struct{})
+	go func() { wg.Wait(); close(done) }()
+	select {
+	case <-done:
+	case <-ctx.Done():
+		t.Fatal("work-queue drain timeout — possible deadlock or claim livelock")
+	}
+
+	if n := claimErrs.Load(); n != 0 {
+		t.Errorf("got %d claim errors; ClaimReadyIssue should retry serialization conflicts internally and never surface one", n)
+	}
+	if n := doubleClaim.Load(); n != 0 {
+		t.Errorf("got %d double-claims; the claim CAS must give each issue to exactly one worker", n)
+	}
+
+	// No stranded work: every seeded issue claimed exactly once.
+	if len(claimedBy) != numIssues {
+		t.Errorf("claimed %d distinct issues, want %d (stranded ready work)", len(claimedBy), numIssues)
+	}
+	for id := range want {
+		if _, ok := claimedBy[id]; !ok {
+			t.Errorf("issue %s was never claimed (stranded)", id)
+		}
+	}
+
+	// Cross-check against the store: nothing should remain ready/open.
+	remaining, err := store.ClaimReadyIssue(ctx, types.WorkFilter{}, "final-sweeper")
+	if err != nil {
+		t.Fatalf("final sweep: %v", err)
+	}
+	if remaining != nil {
+		t.Errorf("ready-front not fully drained: %s still claimable after all workers finished", remaining.ID)
+	}
+
+	// Distribution sanity (informational): how evenly work spread across workers.
+	perWorker := make(map[string]int)
+	for _, actor := range claimedBy {
+		perWorker[actor]++
+	}
+	t.Logf("drain complete: %d issues across %d workers: %v", len(claimedBy), numWorkers, perWorker)
+}

--- a/internal/storage/dolt/issues.go
+++ b/internal/storage/dolt/issues.go
@@ -175,30 +175,27 @@ func (s *DoltStore) UpdateIssue(ctx context.Context, id string, updates map[stri
 		return s.DemoteToWisp(ctx, id, updates, actor)
 	}
 
-	tx, err := s.db.BeginTx(ctx, nil)
-	if err != nil {
-		return fmt.Errorf("failed to begin transaction: %w", err)
-	}
-	defer func() { _ = tx.Rollback() }()
+	// Wrap in withRetryTx so a concurrent writer that loses Dolt's optimistic
+	// commit-time merge (MySQL 1213/1205, guaranteed server-side rollback) is
+	// retried rather than surfaced as a hard failure. Dolt has no real row
+	// locking — FOR UPDATE / SKIP LOCKED are parse-only no-ops
+	// (https://www.dolthub.com/blog/2023-10-23-hold-my-beer/) — so retry is the
+	// only safety net. withRetryTx owns BeginTx and the final Commit.
+	return s.withRetryTx(ctx, func(tx *sql.Tx) error {
+		if _, err := issueops.UpdateIssueInTx(ctx, tx, id, updates, actor); err != nil {
+			return err
+		}
 
-	_, err = issueops.UpdateIssueInTx(ctx, tx, id, updates, actor)
-	if err != nil {
-		return err
-	}
-
-	for _, table := range []string{"issues", "events"} {
-		_, _ = tx.ExecContext(ctx, "CALL DOLT_ADD(?)", table)
-	}
-	commitMsg := fmt.Sprintf("bd: update %s", id)
-	if _, err := tx.ExecContext(ctx, "CALL DOLT_COMMIT('-m', ?, '--author', ?)",
-		commitMsg, s.commitAuthorString()); err != nil && !isDoltNothingToCommit(err) {
-		return fmt.Errorf("dolt commit: %w", err)
-	}
-
-	if err := tx.Commit(); err != nil {
-		return wrapTransactionError("commit update issue", err)
-	}
-	return nil
+		for _, table := range []string{"issues", "events"} {
+			_, _ = tx.ExecContext(ctx, "CALL DOLT_ADD(?)", table)
+		}
+		commitMsg := fmt.Sprintf("bd: update %s", id)
+		if _, err := tx.ExecContext(ctx, "CALL DOLT_COMMIT('-m', ?, '--author', ?)",
+			commitMsg, s.commitAuthorString()); err != nil && !isDoltNothingToCommit(err) {
+			return fmt.Errorf("dolt commit: %w", err)
+		}
+		return nil
+	})
 }
 
 // ClaimIssue atomically claims an issue using compare-and-swap semantics.
@@ -213,60 +210,64 @@ func (s *DoltStore) ClaimIssue(ctx context.Context, id string, actor string) err
 		return s.claimWisp(ctx, id, actor)
 	}
 
-	tx, err := s.db.BeginTx(ctx, nil)
-	if err != nil {
-		return fmt.Errorf("failed to begin transaction: %w", err)
-	}
-	defer func() { _ = tx.Rollback() }()
+	// Wrap in withRetryTx so a concurrent claim that loses Dolt's optimistic
+	// commit-time merge (MySQL 1213/1205, guaranteed server-side rollback) is
+	// retried instead of surfaced as a hard failure. Dolt has no real row
+	// locking — FOR UPDATE / SKIP LOCKED are parse-only no-ops
+	// (https://www.dolthub.com/blog/2023-10-23-hold-my-beer/) — so retry is the
+	// only safety net under concurrent claimants. The body stays a single tx
+	// (CAS + DOLT_COMMIT); withRetryTx owns BeginTx and the final Commit.
+	return s.withRetryTx(ctx, func(tx *sql.Tx) error {
+		if _, err := issueops.ClaimIssueInTx(ctx, tx, id, actor); err != nil {
+			return err
+		}
 
-	if _, err := issueops.ClaimIssueInTx(ctx, tx, id, actor); err != nil {
-		return err
-	}
-
-	// Dolt versioning for permanent issues.
-	// GH#2455: Stage only the tables we modified, then commit without -A.
-	for _, table := range []string{"issues", "events"} {
-		_, _ = tx.ExecContext(ctx, "CALL DOLT_ADD(?)", table)
-	}
-	commitMsg := fmt.Sprintf("bd: claim %s", id)
-	if _, err := tx.ExecContext(ctx, "CALL DOLT_COMMIT('-m', ?, '--author', ?)",
-		commitMsg, s.commitAuthorString()); err != nil && !isDoltNothingToCommit(err) {
-		return fmt.Errorf("dolt commit: %w", err)
-	}
-
-	if err := tx.Commit(); err != nil {
-		return wrapTransactionError("commit claim issue", err)
-	}
-	return nil
+		// Dolt versioning for permanent issues.
+		// GH#2455: Stage only the tables we modified, then commit without -A.
+		for _, table := range []string{"issues", "events"} {
+			_, _ = tx.ExecContext(ctx, "CALL DOLT_ADD(?)", table)
+		}
+		commitMsg := fmt.Sprintf("bd: claim %s", id)
+		if _, err := tx.ExecContext(ctx, "CALL DOLT_COMMIT('-m', ?, '--author', ?)",
+			commitMsg, s.commitAuthorString()); err != nil && !isDoltNothingToCommit(err) {
+			return fmt.Errorf("dolt commit: %w", err)
+		}
+		return nil
+	})
 }
 
 // ClaimReadyIssue atomically claims the first ready issue matching filter.
 func (s *DoltStore) ClaimReadyIssue(ctx context.Context, filter types.WorkFilter, actor string) (*types.Issue, error) {
-	tx, err := s.db.BeginTx(ctx, nil)
-	if err != nil {
-		return nil, fmt.Errorf("failed to begin transaction: %w", err)
-	}
-	defer func() { _ = tx.Rollback() }()
+	// Wrap in withRetryTx: under concurrent workers the loser of Dolt's
+	// optimistic commit-time merge gets MySQL 1213/1205 (guaranteed server-side
+	// rollback). Retrying re-scans the ready front from a fresh snapshot and
+	// claims the next available issue instead of failing the dequeue. Dolt has
+	// no real row locking — FOR UPDATE / SKIP LOCKED are parse-only no-ops
+	// (https://www.dolthub.com/blog/2023-10-23-hold-my-beer/) — so retry is the
+	// safety net. withRetryTx owns BeginTx and the final Commit.
+	var claimed *types.Issue
+	err := s.withRetryTx(ctx, func(tx *sql.Tx) error {
+		var err error
+		claimed, err = issueops.ClaimReadyIssueInTx(ctx, tx, filter, actor)
+		if err != nil {
+			return err
+		}
+		if claimed == nil {
+			return nil
+		}
 
-	claimed, err := issueops.ClaimReadyIssueInTx(ctx, tx, filter, actor)
+		for _, table := range []string{"issues", "events"} {
+			_, _ = tx.ExecContext(ctx, "CALL DOLT_ADD(?)", table)
+		}
+		commitMsg := fmt.Sprintf("bd: claim ready %s", claimed.ID)
+		if _, err := tx.ExecContext(ctx, "CALL DOLT_COMMIT('-m', ?, '--author', ?)",
+			commitMsg, s.commitAuthorString()); err != nil && !isDoltNothingToCommit(err) {
+			return fmt.Errorf("dolt commit: %w", err)
+		}
+		return nil
+	})
 	if err != nil {
 		return nil, err
-	}
-	if claimed == nil {
-		return nil, nil
-	}
-
-	for _, table := range []string{"issues", "events"} {
-		_, _ = tx.ExecContext(ctx, "CALL DOLT_ADD(?)", table)
-	}
-	commitMsg := fmt.Sprintf("bd: claim ready %s", claimed.ID)
-	if _, err := tx.ExecContext(ctx, "CALL DOLT_COMMIT('-m', ?, '--author', ?)",
-		commitMsg, s.commitAuthorString()); err != nil && !isDoltNothingToCommit(err) {
-		return nil, fmt.Errorf("dolt commit: %w", err)
-	}
-
-	if err := tx.Commit(); err != nil {
-		return nil, wrapTransactionError("commit claim ready issue", err)
 	}
 	return claimed, nil
 }
@@ -306,31 +307,29 @@ func (s *DoltStore) CloseIssue(ctx context.Context, id string, reason string, ac
 		return s.closeWisp(ctx, id, reason, actor, session)
 	}
 
-	tx, err := s.db.BeginTx(ctx, nil)
-	if err != nil {
-		return fmt.Errorf("failed to begin transaction: %w", err)
-	}
-	defer func() { _ = tx.Rollback() }()
+	// Wrap in withRetryTx so a concurrent writer that loses Dolt's optimistic
+	// commit-time merge (MySQL 1213/1205, guaranteed server-side rollback) is
+	// retried rather than surfaced as a hard failure. Dolt has no real row
+	// locking — FOR UPDATE / SKIP LOCKED are parse-only no-ops
+	// (https://www.dolthub.com/blog/2023-10-23-hold-my-beer/) — so retry is the
+	// only safety net. withRetryTx owns BeginTx and the final Commit.
+	return s.withRetryTx(ctx, func(tx *sql.Tx) error {
+		if _, err := issueops.CloseIssueInTx(ctx, tx, id, reason, actor, session); err != nil {
+			return err
+		}
 
-	if _, err := issueops.CloseIssueInTx(ctx, tx, id, reason, actor, session); err != nil {
-		return err
-	}
-
-	// Dolt versioning for permanent issues.
-	// GH#2455: Stage only the tables we modified, then commit without -A.
-	for _, table := range []string{"issues", "events"} {
-		_, _ = tx.ExecContext(ctx, "CALL DOLT_ADD(?)", table)
-	}
-	commitMsg := fmt.Sprintf("bd: close %s", id)
-	if _, err := tx.ExecContext(ctx, "CALL DOLT_COMMIT('-m', ?, '--author', ?)",
-		commitMsg, s.commitAuthorString()); err != nil && !isDoltNothingToCommit(err) {
-		return fmt.Errorf("dolt commit: %w", err)
-	}
-
-	if err := tx.Commit(); err != nil {
-		return wrapTransactionError("commit close issue", err)
-	}
-	return nil
+		// Dolt versioning for permanent issues.
+		// GH#2455: Stage only the tables we modified, then commit without -A.
+		for _, table := range []string{"issues", "events"} {
+			_, _ = tx.ExecContext(ctx, "CALL DOLT_ADD(?)", table)
+		}
+		commitMsg := fmt.Sprintf("bd: close %s", id)
+		if _, err := tx.ExecContext(ctx, "CALL DOLT_COMMIT('-m', ?, '--author', ?)",
+			commitMsg, s.commitAuthorString()); err != nil && !isDoltNothingToCommit(err) {
+			return fmt.Errorf("dolt commit: %w", err)
+		}
+		return nil
+	})
 }
 
 // DeleteIssue permanently removes an issue

--- a/scripts/check-testing-short.sh
+++ b/scripts/check-testing-short.sh
@@ -10,6 +10,7 @@ internal/hooks/hooks_test.go::TestRunSync_KillsDescendants
 internal/testutil/fixtures/fixtures_test.go::TestXLargeDolt
 internal/testutil/fixtures/fixtures_test.go::TestLargeFromJSONL
 internal/storage/dolt/concurrent_test.go::TestHighContentionStress
+internal/storage/dolt/concurrent_test.go::TestConcurrentWorkQueueDrain
 EOF
 )
 


### PR DESCRIPTION
## Problem

`ClaimIssue`, `ClaimReadyIssue`, `UpdateIssue`, and `CloseIssue` each hand-roll their own transaction (`BeginTx` + `DOLT_ADD`/`DOLT_COMMIT` + `Commit`) **outside** `withRetryTx`. Under concurrent writers, a transaction that loses Dolt's optimistic commit-time working-set merge gets **MySQL 1213/1205** (`ErrLockDeadlock` wrapping `ErrRetryTransaction`) — a *guaranteed server-side rollback* — and these methods surface it as a hard failure instead of retrying.

These four are exactly the multi-agent **work-queue hot paths**: `bd ready --claim` (dequeue), claim, update, close. With N agents pulling from one shared Dolt server, claim/close contention is the common case, not the edge case.

## Why retry is the only option

Dolt has **no real row locking** — `FOR UPDATE` / `FOR UPDATE OF ... SKIP LOCKED` are *parse-only no-ops*. Straight from the engine:

> `buildForUpdateOf` ... `FOR UPDATE` in general is a no-op, so `FOR UPDATE OF` is also a no-op: https://www.dolthub.com/blog/2023-10-23-hold-my-beer/
> — `go-mysql-server` `sql/planbuilder/select.go`

So the classic `SELECT ... FOR UPDATE SKIP LOCKED` queue pattern can't help here; concurrency safety has to come from **retry on the serialization error**, which `withRetryTx` (`store.go`) already implements with backoff (it explicitly classifies 1213/1205 as retryable). The claim/update/close paths just weren't using it.

## Fix

Move each method body into a `withRetryTx` closure. `withRetryTx`→`withWriteTx` owns `BeginTx` and the final `Commit` and retries serialization failures; the closure keeps the existing **single-tx CAS/mutation + `DOLT_COMMIT`** atomicity exactly (no behavior change on the happy path). On retry, `ClaimReadyIssue` naturally re-scans the ready front from a fresh snapshot and claims the next available issue — the correct dequeue semantics.

No new helpers, no signature changes; `wrapTransactionError` stays in use by other call sites.

## Testing

- `go build` + `go vet ./internal/storage/dolt/` clean
- Concurrency tests pass: `TestEmbeddedReadyClaimConcurrent`, `TestEmbeddedReadyConcurrent`, `TestEmbeddedCloseConcurrent`, `TestEmbeddedUpdateConcurrent`
- Non-concurrent embedded paths pass: `TestEmbeddedUpdate`, `TestEmbeddedClose`, `TestEmbeddedReady` (+ routed/auto-commit variants)
- One unrelated pre-existing failure observed (`TestWatchIssueDetectsFieldUpdate`, a watch-snapshot timing test) — fails identically on the clean base, not touched here.

## Context

Found while building a multi-agent Java→Kotlin port that coordinates several agent clones through one shared Beads DB as a dependency-ordered work queue. `bd ready --claim` + atomic claim is already a great dequeue primitive; this closes the gap that made it fail under the very concurrency it's meant for.
