### PR TITLE
feat(doltserver): add test knob to kill dolt on parent death

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`BEADS_DOLT_KILL_ON_PARENT_DEATH` — test/controller knob to kill the managed
+  dolt sql-server when the parent dies.** When set ("1"/"true"), the dolt child
+  is spawned on Linux with a kernel-enforced `PR_SET_PDEATHSIG = SIGKILL` in
+  addition to the usual process-group detach, so a real-dolt test that is
+  `SIGKILL`ed or hits a `go test` timeout no longer leaks an orphaned
+  `sql-server` reparented to `systemd --user`. Production behavior is unchanged
+  by default — the child still detaches and the orchestrator/systemd owns its
+  lifecycle (be-0eyj / #3550). No-op on non-Linux (only Linux's
+  `syscall.SysProcAttr` carries `Pdeathsig`).
+  ([#4505](https://github.com/gastownhall/beads/issues/4505))
+
 ## [1.1.0] - 2026-07-04
 
 First stable release of the 1.1.0 line. It consolidates everything from

--- a/internal/doltserver/doltserver.go
+++ b/internal/doltserver/doltserver.go
@@ -122,6 +122,22 @@ func IsDebugMode() bool {
 	return config.GetBool("dolt.debug")
 }
 
+// killOnParentDeath reports whether the managed dolt sql-server child should be
+// spawned with a kernel-enforced PR_SET_PDEATHSIG (Linux only), set via the
+// BEADS_DOLT_KILL_ON_PARENT_DEATH env var ("1" or "true").
+//
+// This is a TEST/CONTROLLER-ONLY knob. Production leaves it unset: the
+// orchestrator/systemd owns the dolt lifecycle by design and the child detaches
+// (CHANGELOG be-0eyj / #3550). When set, the kernel kills the dolt child if the
+// parent dies by ANY means — including SIGKILL and a `go test` timeout, where no
+// userspace teardown runs — so real-dolt tests cannot leak an orphaned
+// sql-server reparented to systemd --user (GH#4505). No-op on non-Linux: only
+// Linux's syscall.SysProcAttr carries Pdeathsig.
+func killOnParentDeath() bool {
+	v := os.Getenv("BEADS_DOLT_KILL_ON_PARENT_DEATH")
+	return v == "1" || strings.EqualFold(v, "true")
+}
+
 func DebugProfileDir(beadsDir string) string {
 	p := filepath.Join(resolveServerDir(beadsDir), "dolt-pprof")
 	if abs, err := filepath.Abs(p); err == nil {

--- a/internal/doltserver/doltserver_detach_linux.go
+++ b/internal/doltserver/doltserver_detach_linux.go
@@ -1,0 +1,26 @@
+//go:build linux
+
+package doltserver
+
+import "syscall"
+
+// procAttrDetached returns SysProcAttr for the managed dolt sql-server child.
+//
+// The child is detached into its own process group (Setpgid) so it survives
+// parent exit — the production default, where the orchestrator/systemd owns the
+// dolt lifecycle by design (CHANGELOG be-0eyj / #3550).
+//
+// When the BEADS_DOLT_KILL_ON_PARENT_DEATH test/controller knob is set, the
+// child additionally gets PR_SET_PDEATHSIG = SIGKILL: the kernel kills the dolt
+// server when the parent dies by ANY means, including SIGKILL and a `go test`
+// timeout where no userspace teardown runs. This stops real-dolt tests from
+// leaking an orphaned sql-server reparented to systemd --user (GH#4505).
+// Pdeathsig is a Linux-only field; see doltserver_detach_other.go for the
+// non-Linux Unix path.
+func procAttrDetached() *syscall.SysProcAttr {
+	attr := &syscall.SysProcAttr{Setpgid: true}
+	if killOnParentDeath() {
+		attr.Pdeathsig = syscall.SIGKILL
+	}
+	return attr
+}

--- a/internal/doltserver/doltserver_detach_other.go
+++ b/internal/doltserver/doltserver_detach_other.go
@@ -1,0 +1,16 @@
+//go:build !linux && !windows
+
+package doltserver
+
+import "syscall"
+
+// procAttrDetached returns SysProcAttr to detach the managed dolt sql-server
+// child into its own process group (Setpgid) so it survives parent exit.
+//
+// On non-Linux Unix (macOS/BSD) syscall.SysProcAttr has no Pdeathsig field, so
+// the BEADS_DOLT_KILL_ON_PARENT_DEATH test/controller knob (GH#4505) is a no-op
+// here and the child is always detached. The orphan the knob targets is itself
+// Linux-specific (reparenting to systemd --user); see doltserver_detach_linux.go.
+func procAttrDetached() *syscall.SysProcAttr {
+	return &syscall.SysProcAttr{Setpgid: true}
+}

--- a/internal/doltserver/doltserver_pdeathsig_linux_test.go
+++ b/internal/doltserver/doltserver_pdeathsig_linux_test.go
@@ -1,0 +1,39 @@
+//go:build linux
+
+package doltserver
+
+import (
+	"syscall"
+	"testing"
+)
+
+// TestProcAttrDetachedPdeathsig covers the GH#4505 test/controller knob.
+//
+// BEADS_DOLT_KILL_ON_PARENT_DEATH gates a kernel-enforced PR_SET_PDEATHSIG on
+// the dolt sql-server child so a real-dolt test that is SIGKILLed or hits a
+// `go test` timeout does not leak an orphaned server reparented to
+// systemd --user. Production detach (Setpgid only) is the default and must be
+// preserved when the knob is unset.
+func TestProcAttrDetachedPdeathsig(t *testing.T) {
+	t.Run("default preserves detach without Pdeathsig", func(t *testing.T) {
+		t.Setenv("BEADS_DOLT_KILL_ON_PARENT_DEATH", "")
+		attr := procAttrDetached()
+		if !attr.Setpgid {
+			t.Error("expected Setpgid true (production detach preserved)")
+		}
+		if attr.Pdeathsig != 0 {
+			t.Errorf("expected no Pdeathsig by default, got %v", attr.Pdeathsig)
+		}
+	})
+
+	t.Run("knob adds Pdeathsig SIGKILL while keeping detach", func(t *testing.T) {
+		t.Setenv("BEADS_DOLT_KILL_ON_PARENT_DEATH", "1")
+		attr := procAttrDetached()
+		if !attr.Setpgid {
+			t.Error("expected Setpgid true (detach still set)")
+		}
+		if attr.Pdeathsig != syscall.SIGKILL {
+			t.Errorf("expected Pdeathsig SIGKILL, got %v", attr.Pdeathsig)
+		}
+	})
+}

--- a/internal/doltserver/doltserver_test.go
+++ b/internal/doltserver/doltserver_test.go
@@ -1961,3 +1961,27 @@ func TestEnsureGlobalDatabase_ServerNotReachable(t *testing.T) {
 		t.Error("expected error when server is not reachable")
 	}
 }
+
+func TestKillOnParentDeath(t *testing.T) {
+	tests := []struct {
+		name string
+		env  string
+		want bool
+	}{
+		{"unset", "", false},
+		{"one", "1", true},
+		{"true lowercase", "true", true},
+		{"true uppercase", "TRUE", true},
+		{"zero", "0", false},
+		{"false", "false", false},
+		{"other", "yes", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("BEADS_DOLT_KILL_ON_PARENT_DEATH", tt.env)
+			if got := killOnParentDeath(); got != tt.want {
+				t.Errorf("killOnParentDeath() with env=%q = %v, want %v", tt.env, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/doltserver/doltserver_unix.go
+++ b/internal/doltserver/doltserver_unix.go
@@ -21,12 +21,6 @@ const portConflictHint = "lsof -i :%d"
 // Used in error messages when too many dolt servers are running.
 const processListHint = "pgrep -la 'dolt sql-server'"
 
-// procAttrDetached returns SysProcAttr to detach a child process from the parent
-// process group so it survives parent exit.
-func procAttrDetached() *syscall.SysProcAttr {
-	return &syscall.SysProcAttr{Setpgid: true}
-}
-
 // findPIDOnPort returns the PID of the process listening on a TCP port.
 // Uses lsof to look up the listener. Returns 0 if no process found or on error.
 func findPIDOnPort(port int) int {


### PR DESCRIPTION
## What

Add `BEADS_DOLT_KILL_ON_PARENT_DEATH`, a test/controller-only env knob.
When set (`1`/`true`), the managed dolt `sql-server` child is spawned on
Linux with a kernel-enforced `PR_SET_PDEATHSIG = SIGKILL` in addition to
the existing process-group detach (`Setpgid`). The kernel then kills the
dolt child whenever the parent dies by **any** means — including `SIGKILL`
and a `go test` timeout, where no userspace teardown runs.

## Why

Real-dolt tests that are `SIGKILL`ed or hit a `go test` timeout leave the
detached dolt `sql-server` reparented to `systemd --user`, accumulating as
orphans. A `TestMain` reap plus a `SIGINT`/`SIGTERM` handler cannot cover
these triggers: `SIGKILL` is uncatchable, and a `go test` timeout never
returns from `m.Run()`, so no post-run reap executes. Only a
kernel-enforced `PR_SET_PDEATHSIG` fires regardless of how the parent dies.

## How

- `killOnParentDeath()` reads the env knob (`doltserver.go`).
- `procAttrDetached()` is split by build tag:
  - `doltserver_detach_linux.go` (`//go:build linux`): adds
    `Pdeathsig = SIGKILL` when the knob is set, else `Setpgid`-only.
  - `doltserver_detach_other.go` (`//go:build !linux && !windows`):
    always `Setpgid`-only — `Pdeathsig` is a Linux-only `SysProcAttr`
    field, and the orphan it targets (reparenting to `systemd --user`) is
    itself Linux-specific.
  - The old `procAttrDetached()` is removed from `doltserver_unix.go`.

## Production impact

None by default. The knob is unset in production; the child still detaches
and the orchestrator/systemd owns the dolt lifecycle by design (CHANGELOG
`be-0eyj` / #3550). No-op on non-Linux.

## Tests

- `TestKillOnParentDeath` — env-parse table (`1`/`true`/`TRUE` → on;
  unset/`0`/`false`/other → off).
- `TestProcAttrDetachedPdeathsig` (Linux) — default preserves detach with
  no `Pdeathsig`; knob adds `Pdeathsig = SIGKILL` while keeping `Setpgid`.

Closes #4505.
