### PR TITLE
docs(upgrade): add validated recipe for remote-backed / multi-clone upgrades

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,17 +23,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   upgrade all clones of a shared remote together, letting one designated
   machine migrate and `bd dolt push` first.
 
-- **Upgrading from 1.0.4/1.0.5 with multiple clones: sync before AND
-  immediately after.** This release reshapes the `dependencies` primary key
-  (migration `0050`). If two clones cross that boundary with un-synced
-  dependency edits on both sides, their histories become permanently
-  un-mergeable — Dolt refuses the merge outright (`cannot merge because table
-  dependencies has different primary keys in its common ancestor`) before the
-  pull auto-resolver can run. To stay safe: `bd dolt push` + `bd dolt pull`
-  on every clone *before* upgrading, let one designated machine upgrade,
-  migrate, and `bd dolt push`, then on each remaining clone upgrade and
-  `bd dolt pull` *before* doing tracked work. If clones have already forked,
-  see the recovery playbook:
+- **Upgrading a remote-backed database: one machine migrates, the rest adopt.**
+  This release reshapes the `dependencies` primary key (migration `0050`), and
+  `bd` now refuses to silently migrate a database that has a Dolt remote
+  configured. If two clones cross the `0050` boundary with un-synced dependency
+  edits on both sides, their histories become permanently un-mergeable — Dolt
+  refuses the merge outright (`cannot merge because table dependencies has
+  different primary keys in its common ancestor`) before the pull auto-resolver
+  can run. Replacing the binary alone is not enough; follow the ordered recipe:
+
+  1. With your **current** binary, on **every** clone: `bd dolt push` +
+     `bd dolt pull` until all are in sync, then stop editing. Once the new
+     binary is installed, `push`/`pull` are gated too, so this must happen
+     first.
+  2. Designated migrator **only**: install the new binary, then
+     `BD_ALLOW_REMOTE_MIGRATE=1 bd migrate` and `bd dolt push`.
+  3. Every **other** clone: install the new binary, then `bd bootstrap` to adopt
+     the migrated database (`bd dolt pull` is refused while the clone still has
+     pending migrations; do not migrate on these clones).
+  4. Confirm with `bd version`; in server mode, `bd doctor` adds a
+     migration-content-skew check (not available in embedded mode).
+
+  A single clone with a remote follows the same gate (push with the old binary,
+  then migrate and push). Full recipe and the single-clone variant:
+  [Upgrading bd — remote-backed databases and multiple clones](website/docs/getting-started/upgrading.md#remote-backed-databases-and-multiple-clones).
+  If clones have already forked, see the recovery playbook:
   [docs/RECOVERY.md#pk-fork-refused](docs/RECOVERY.md#pk-fork-refused).
 
 ### Added

--- a/docs/INSTALLING.md
+++ b/docs/INSTALLING.md
@@ -596,6 +596,16 @@ bd hooks install
 bd version
 ```
 
+If your database syncs to a Dolt remote (a single clone or several), upgrading
+across a schema migration needs an explicit, ordered procedure — `bd` refuses
+to silently migrate a remote-backed database, so replacing the binary alone is
+not enough. See [Upgrading bd — remote-backed databases and multiple
+clones](../website/docs/getting-started/upgrading.md#remote-backed-databases-and-multiple-clones).
+
+Prereleases (e.g. release candidates) are published only as GitHub prereleases
+and are not pushed to the stable Homebrew/npm/PyPI channels, so `brew upgrade`
+and friends will not move you onto them — fetch the prerelease build explicitly.
+
 ## Uninstalling
 
 To completely remove Beads from a repository, see [UNINSTALLING.md](UNINSTALLING.md).

--- a/docs/RECOVERY.md
+++ b/docs/RECOVERY.md
@@ -237,9 +237,14 @@ remote already has are skipped. Spot-check with `bd stats` afterwards.
 ### Prevention (upgrades across PK-reshaping migrations)
 
 - **Sync before upgrading**: `bd dolt push` + `bd dolt pull` on every clone
-  while all clones still run the *old* version.
+  while all clones still run the *old* version, then stop editing. Once the new
+  binary is installed, `bd dolt push`/`bd dolt pull` are gated too, so this must
+  happen first.
 - **One designated migrator**: upgrade one machine, let it migrate, then
   `bd dolt push`.
-- **Sync immediately after**: on every other clone, upgrade the binary, then
-  `bd dolt pull` *before* doing tracked work, so no clone accumulates
-  un-synced rows under the old schema.
+- **Every other clone adopts, does not pull**: after the migrator pushes, each
+  other clone upgrades the binary and runs `bd bootstrap` to adopt the migrated
+  database. `bd dolt pull` is *refused* while the clone still has pending
+  migrations, so do not rely on it; the "sync before" step above is what
+  preserves these clones' work, because `bd bootstrap` replaces the local
+  database.

--- a/website/docs/getting-started/upgrading.md
+++ b/website/docs/getting-started/upgrading.md
@@ -119,6 +119,67 @@ bd migrate
 bd migrate --cleanup --yes
 ```
 
+### Remote-backed databases and multiple clones
+
+`bd` refuses to silently apply pending schema migrations to a database that has
+a Dolt remote configured. Migrating more than one clone of a shared remote
+independently forks the schema, after which `bd dolt pull` can no longer merge —
+the break is silent and, across a primary-key-reshaping migration, unrecoverable
+([#4259](https://github.com/gastownhall/beads/issues/4259)). The supported flow
+is: one machine migrates and publishes; every other clone re-clones the migrated
+database.
+
+This applies to **every** upgrade that crosses a pending migration on a
+remote-backed database — the same procedure whether you are moving to a
+prerelease or to a stable release.
+
+**Important ordering:** once the new binary is installed, a database with
+pending migrations is gated on **every** open — `bd dolt push` and `bd dolt
+pull` are refused too, not just `bd migrate`. So do all syncing with your
+**current** binary, *before* you install the new one.
+
+**Single clone (including a solo user with a remote):**
+
+```bash
+bd dolt push                              # 1. CURRENT binary: publish all local work
+# 2. install the new binary (see Upgrading above)
+BD_ALLOW_REMOTE_MIGRATE=1 bd migrate      # 3. migrate as the designated migrator
+bd dolt push                              # 4. publish the migrated schema
+bd version                                # 5. confirm the new version is active
+```
+
+**Multiple clones sharing one remote:**
+
+```bash
+# 1. With your CURRENT (old) binary, on EVERY clone: publish all work and get in
+#    sync, then stop editing until the upgrade is done.
+bd dolt push
+bd dolt pull
+
+# 2. Designated migrator ONLY: install the new binary, then migrate and publish.
+BD_ALLOW_REMOTE_MIGRATE=1 bd migrate
+bd dolt push
+
+# 3. Every OTHER clone: install the new binary, then ADOPT the migrated database.
+#    (bd dolt pull is refused here — the clone still has pending migrations — so
+#    re-clone instead. Safe because step 1 already pushed all work.)
+bd bootstrap
+```
+
+`bd bootstrap` replaces the local database, so any work not pushed in step 1 is
+lost — that is why step 1 publishes everything first. If a clone was instead
+migrated independently and `bd dolt pull` later fails with `cannot merge because
+table dependencies has different primary keys in its common ancestor`, the
+schema has already forked — follow the recovery playbook:
+[RECOVERY.md#pk-fork-refused](https://github.com/gastownhall/beads/blob/main/docs/RECOVERY.md#pk-fork-refused).
+
+:::note
+In **server mode**, `bd doctor` adds a migration-content-skew check that flags a
+forked schema against the cached remote ref — a useful post-upgrade
+verification. It is not available in embedded mode; there, confirm the upgrade
+with `bd version` and a normal read such as `bd ready`.
+:::
+
 ## Cross-era Upgrades
 
 If you're upgrading from a much older version of bd, your project may use a different storage backend. bd has gone through several storage eras:


### PR DESCRIPTION
## Why

Upgrading 1.0.x → 1.1 across a remote-backed database is not "just replace the
binary." 1.1 adds the remote-migrate gate (#4259): `bd` refuses to silently
apply pending schema migrations to a database that has a Dolt remote, and the
`0050` dependencies primary-key reshape can leave independently-migrated clones
permanently un-mergeable. Today that procedure lives only as prose scattered
across the CHANGELOG upgrade note, the gate's own error text, and
`docs/RECOVERY.md` — there is no single ordered recipe in the user-facing
upgrade guide. A user who follows `docs/INSTALLING.md` literally hits the gate
with no forewarning.

This matters more at GA than for the RC: the RC is a GitHub prerelease few
people install, but 1.1.0 will land on stable Homebrew/npm/PyPI, so far more
users will swap the binary effortlessly and walk straight into the gate.

## What

- **`website/docs/getting-started/upgrading.md`** — new "Remote-backed databases
  and multiple clones" section with a single-clone recipe and a multi-clone
  recipe. Written keyed on the *behavior* (remote + pending migration), not on a
  specific version, so it stays correct when the RC is promoted to 1.1.0 and for
  every future migration.
- **`CHANGELOG.md`** — the 1.1.0-rc.1 multi-clone upgrade note rewritten as a
  numbered recipe that links to the guide.
- **`docs/INSTALLING.md`** — "After Upgrading" now points at the recipe and notes
  that prereleases ship only as GitHub prereleases (not on stable channels).

## Validated, not just written

I ran the recipe end-to-end on a live embedded database (v49 → v53): the gated
`BD_ALLOW_REMOTE_MIGRATE=1 bd migrate` + `bd dolt push` succeeded and all 464
issues survived. The dry run corrected two things the existing prose got wrong:

- The gate blocks `bd dolt push` / `bd dolt pull` too, not only `bd migrate`. So
  all pre-upgrade syncing must be done with the **old** binary, and other clones
  adopt the migrated database with **`bd bootstrap`**, not `bd dolt pull`.
- The migration-content-skew check ships inside `bd doctor`, which is **server
  mode only** ("not yet supported in embedded mode"). Embedded users verify with
  `bd version` / `bd ready` instead. (Filed separately as a product gap.)

## Notes

- Docs-only; no code or schema changes.
- Aware of #4286 (split `dependencies` into six target-typed tables). That is a
  separate, unmerged code direction; this PR documents the behavior as shipped in
  `v1.1.0-rc.1` (migration `0050`). If #4286 lands and changes the migration
  story, the recipe should be updated to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

_claude-opus-4-8-high on behalf of matt wilkie_
