### PR TITLE
fix(gate): make the remote-migrate gate agent-safe, not a footgun

### DIFF
--- a/cmd/bd/remote_migrate_gate.go
+++ b/cmd/bd/remote_migrate_gate.go
@@ -2,20 +2,44 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 
 	"github.com/steveyegge/beads/internal/storage/schema"
 )
 
 // handleRemoteMigrateGateJSON renders the #4259 remote-migrate gate error as a
-// structured JSON error block, mirroring handleSchemaSkewJSON.
+// structured JSON error block for agent consumption.
+//
+// The top-level "hint" is deliberately a non-runnable directive, NOT the
+// `BD_ALLOW_REMOTE_MIGRATE=1 bd migrate` escape command: handing an agent a
+// ready-to-run migrate as "the fix" is the footgun that forks shared remotes on
+// multi-clone setups. The migrate command lives only inside
+// remote_migrate_gate.options[migrate], gated on its "single designated
+// migrator" precondition and annotated with its risk, so the agent surfaces a
+// human decision instead of auto-running it.
 func handleRemoteMigrateGateJSON(e *schema.RemoteMigrateGateError) {
-	outer := buildJSONError(e.Error(), e.EscapeHint())
+	outer := buildJSONError(e.Error(), e.AgentDirective())
 	if m, ok := outer.(map[string]interface{}); ok {
+		opts := make([]map[string]interface{}, 0, len(e.Options()))
+		for _, o := range e.Options() {
+			opts = append(opts, map[string]interface{}{
+				"id":       o.ID,
+				"when":     o.When,
+				"commands": o.Commands,
+				"risk":     o.Risk,
+			})
+		}
 		m["remote_migrate_gate"] = map[string]interface{}{
-			"current_version": e.CurrentVersion,
-			"latest_version":  e.LatestVersion,
-			"pending":         e.Pending,
+			"current_version":         e.CurrentVersion,
+			"latest_version":          e.LatestVersion,
+			"pending":                 e.Pending,
+			"severity":                "blocking",
+			"human_decision_required": true,
+			"observed":                fmt.Sprintf("%d pending schema migration(s) and a configured remote", e.Pending),
+			"expected":                "exactly one designated clone migrates and publishes; every other clone adopts the result",
+			"options":                 opts,
+			"docs":                    "https://github.com/gastownhall/beads/blob/main/website/docs/getting-started/upgrading.md#remote-backed-databases-and-multiple-clones",
 		}
 	}
 	encoder := json.NewEncoder(os.Stderr)

--- a/cmd/bd/remote_migrate_gate_test.go
+++ b/cmd/bd/remote_migrate_gate_test.go
@@ -11,8 +11,9 @@ import (
 )
 
 // TestHandleRemoteMigrateGateJSON_Shape verifies the JSON written to stderr has
-// the expected shape: error one-liner, hint (escape-hatch string), and a
-// remote_migrate_gate subobject with current/latest/pending.
+// the expected shape: error one-liner, a non-runnable directive hint (NOT the
+// escape-hatch command), and a remote_migrate_gate subobject carrying the
+// current/latest/pending versions plus the agent-decision fields and options.
 func TestHandleRemoteMigrateGateJSON_Shape(t *testing.T) {
 	gate := &schema.RemoteMigrateGateError{CurrentVersion: 48, LatestVersion: 50, Pending: 2}
 
@@ -42,8 +43,13 @@ func TestHandleRemoteMigrateGateJSON_Shape(t *testing.T) {
 	if got, ok := parsed["error"].(string); !ok || got != gate.Error() {
 		t.Errorf("error = %v, want %q", parsed["error"], gate.Error())
 	}
-	if got, ok := parsed["hint"].(string); !ok || got != gate.EscapeHint() {
-		t.Errorf("hint = %v, want %q", parsed["hint"], gate.EscapeHint())
+	// hint is the non-runnable directive, and must NOT be the runnable escape
+	// command — that swap is the whole point of this change (the agent footgun).
+	if got, ok := parsed["hint"].(string); !ok || got != gate.AgentDirective() {
+		t.Errorf("hint = %v, want directive %q", parsed["hint"], gate.AgentDirective())
+	}
+	if parsed["hint"] == gate.EscapeHint() {
+		t.Errorf("hint must not be the runnable escape command %q (agent footgun)", gate.EscapeHint())
 	}
 
 	obj, ok := parsed["remote_migrate_gate"].(map[string]interface{})
@@ -58,5 +64,46 @@ func TestHandleRemoteMigrateGateJSON_Shape(t *testing.T) {
 	}
 	if got, ok := obj["pending"].(float64); !ok || int(got) != 2 {
 		t.Errorf("pending = %v, want 2", obj["pending"])
+	}
+	if got, ok := obj["human_decision_required"].(bool); !ok || !got {
+		t.Errorf("human_decision_required = %v, want true", obj["human_decision_required"])
+	}
+	if got, ok := obj["severity"].(string); !ok || got != "blocking" {
+		t.Errorf("severity = %v, want \"blocking\"", obj["severity"])
+	}
+
+	// options must carry both paths, and the runnable migrate command must live
+	// ONLY inside the conditional migrate option, never surfaced unconditionally.
+	rawOpts, ok := obj["options"].([]interface{})
+	if !ok || len(rawOpts) != 2 {
+		t.Fatalf("options = %v, want 2 entries", obj["options"])
+	}
+	ids := map[string]bool{}
+	migrateCmdFound := false
+	for _, ro := range rawOpts {
+		o, ok := ro.(map[string]interface{})
+		if !ok {
+			t.Fatalf("option wrong type: %T", ro)
+		}
+		id, _ := o["id"].(string)
+		ids[id] = true
+		if o["when"] == nil || o["risk"] == nil {
+			t.Errorf("option %q missing when/risk: %v", id, o)
+		}
+		cmds, _ := o["commands"].([]interface{})
+		for _, c := range cmds {
+			if c == gate.EscapeHint() {
+				migrateCmdFound = true
+				if id != "migrate" {
+					t.Errorf("escape command appears under option %q, want only \"migrate\"", id)
+				}
+			}
+		}
+	}
+	if !ids["migrate"] || !ids["adopt"] {
+		t.Errorf("options ids = %v, want migrate+adopt", ids)
+	}
+	if !migrateCmdFound {
+		t.Errorf("migrate option must contain the escape command %q", gate.EscapeHint())
 	}
 }

--- a/internal/storage/embeddeddolt/store.go
+++ b/internal/storage/embeddeddolt/store.go
@@ -287,8 +287,12 @@ func (s *EmbeddedDoltStore) initSchema(ctx context.Context) error {
 			fmt.Fprintf(os.Stderr,
 				"Warning: %v\n"+
 					"  Read-only command: continuing on schema v%d without migrating.\n"+
-					"  To resolve, the ONE designated migrator runs: %s=1 bd migrate && bd dolt push\n"+
-					"  Everyone else adopts the migrated database: bd bootstrap\n",
+					"  Writes are blocked until the schema is reconciled. This is a\n"+
+					"  coordination decision, not an auto-fix — do NOT run a migration unless\n"+
+					"  you are the single designated migrator (only ONE clone may migrate a\n"+
+					"  shared remote, else the schema forks; #4259):\n"+
+					"    • designated migrator (only ONE machine): %s=1 bd migrate && bd dolt push\n"+
+					"    • every other clone (another already migrated): bd bootstrap\n",
 				gateErr, gateErr.CurrentVersion, schema.AllowRemoteMigrateEnv)
 			return nil
 		}

--- a/internal/storage/schema/remote_migrate_gate.go
+++ b/internal/storage/schema/remote_migrate_gate.go
@@ -80,6 +80,51 @@ func (e *RemoteMigrateGateError) EscapeHint() string {
 	return AllowRemoteMigrateEnv + "=1 bd migrate"
 }
 
+// AgentDirective is the non-runnable instruction surfaced to agents in place of
+// a ready-to-run migrate command. Migrating a shared remote is a coordination
+// decision — only ONE clone may migrate, and a second clone migrating
+// independently forks the schema unrecoverably (#4259) — so bd deliberately does
+// NOT hand an agent an auto-runnable "fix". The agent should surface the options
+// to the operator and let them choose, per the AgentDiagnostic contract ("Go
+// observes and reports, the agent decides and acts").
+func (e *RemoteMigrateGateError) AgentDirective() string {
+	return "Coordination decision required: only ONE clone may migrate a shared remote; " +
+		"a second clone migrating independently forks the schema unrecoverably (#4259). " +
+		"Do NOT auto-run a migration — surface remote_migrate_gate.options to the operator and let them choose."
+}
+
+// GateOption is one conditional remediation path for the remote-migrate gate.
+// It is intentionally conditional (When) and carries its Risk, so an agent
+// cannot treat any single command as the unconditional fix.
+type GateOption struct {
+	ID       string   `json:"id"`
+	When     string   `json:"when"`
+	Commands []string `json:"commands"`
+	Risk     string   `json:"risk"`
+}
+
+// Options returns the two mutually-exclusive remediation paths — migrate (as the
+// single designated migrator) or adopt (re-clone the already-migrated DB) — each
+// gated on its precondition and annotated with its risk. The migrate command is
+// present but reachable only through its "single designated migrator" condition,
+// never as a top-level hint.
+func (e *RemoteMigrateGateError) Options() []GateOption {
+	return []GateOption{
+		{
+			ID:       "migrate",
+			When:     "you are the single designated migrator (only ONE machine, confirmed with the operator) and no other clone has migrated yet",
+			Commands: []string{AllowRemoteMigrateEnv + "=1 bd migrate", "bd dolt push"},
+			Risk:     "if another clone also migrates independently, the schema forks unrecoverably (#4259)",
+		},
+		{
+			ID:       "adopt",
+			When:     "another machine has already migrated and pushed",
+			Commands: []string{"bd bootstrap"},
+			Risk:     "re-clones and replaces the local database; push or export unpushed work first or it is lost",
+		},
+	}
+}
+
 // IsRemoteMigrateGateError reports whether err (or any error it wraps) is a
 // *RemoteMigrateGateError.
 func IsRemoteMigrateGateError(err error) bool {

--- a/internal/storage/schema/remote_migrate_gate_test.go
+++ b/internal/storage/schema/remote_migrate_gate_test.go
@@ -250,3 +250,52 @@ func TestCheckRemoteMigrateGateWithRemoteCheck(t *testing.T) {
 		}
 	})
 }
+
+// TestRemoteMigrateGateAgentSafety locks the agent-facing safety contract at the
+// source layer: the directive surfaced as the JSON hint is not runnable, and the
+// runnable escape command appears only inside the conditional "migrate" option.
+func TestRemoteMigrateGateAgentSafety(t *testing.T) {
+	e := &RemoteMigrateGateError{CurrentVersion: 49, LatestVersion: 53, Pending: 4}
+
+	// The directive must not be the escape command (the agent footgun).
+	if e.AgentDirective() == e.EscapeHint() {
+		t.Fatalf("AgentDirective must not equal the runnable escape command %q", e.EscapeHint())
+	}
+	if strings.Contains(e.AgentDirective(), AllowRemoteMigrateEnv+"=1 bd migrate") {
+		t.Errorf("AgentDirective must not embed the runnable migrate command: %q", e.AgentDirective())
+	}
+
+	opts := e.Options()
+	if len(opts) != 2 {
+		t.Fatalf("Options len = %d, want 2", len(opts))
+	}
+	byID := map[string]GateOption{}
+	for _, o := range opts {
+		if o.When == "" || o.Risk == "" {
+			t.Errorf("option %q missing When/Risk", o.ID)
+		}
+		byID[o.ID] = o
+	}
+	migrate, ok := byID["migrate"]
+	if !ok {
+		t.Fatal("missing migrate option")
+	}
+	if _, ok := byID["adopt"]; !ok {
+		t.Fatal("missing adopt option")
+	}
+	// The escape command must live under migrate, and nowhere else.
+	foundUnderMigrate := false
+	for _, c := range migrate.Commands {
+		if c == e.EscapeHint() {
+			foundUnderMigrate = true
+		}
+	}
+	if !foundUnderMigrate {
+		t.Errorf("migrate option commands %v must include %q", migrate.Commands, e.EscapeHint())
+	}
+	for _, c := range byID["adopt"].Commands {
+		if c == e.EscapeHint() {
+			t.Errorf("adopt option must not contain the migrate escape command")
+		}
+	}
+}


### PR DESCRIPTION
## Why

Agents are the highest-volume bd users, and the #4259 remote-migrate gate hands
them a loaded gun. When a write is refused on a remote-backed database, the JSON
error's top-level `hint` is the literal runnable command
`BD_ALLOW_REMOTE_MIGRATE=1 bd migrate`. An agent optimizing to unblock the
command will just run it:

- single clone → harmless (it *is* the designated migrator), but
- shared remote / multiple clones → a second clone migrating independently
  forks the schema unrecoverably — the exact hazard the gate exists to prevent.

The gate stops naive humans safely (the terminal message frames the choice), but
the machine-facing payload pre-decides the dangerous action for agents.

## What

De-fangs the agent-facing surfaces. **The gate's decision is unchanged** — this
is messaging only.

- **JSON error (`handleRemoteMigrateGateJSON`)** — `hint` is now a non-runnable
  directive (`AgentDirective()`): "Coordination decision required … do NOT
  auto-run a migration — surface remote_migrate_gate.options to the operator."
  The runnable migrate command moves into
  `remote_migrate_gate.options[migrate]`, gated on its *single designated
  migrator* precondition and annotated with its `risk`, beside the `adopt`
  option. Adds `severity` / `human_decision_required` / `observed` / `expected`
  / `docs`, matching the existing `AgentDiagnostic` contract ("Go observes and
  reports, the agent decides and acts"). Backward-compatible: `error` and
  `current_version`/`latest_version`/`pending` are preserved.
- **Embedded lenient read-only warning** — this fires during `bd prime` and
  every read, i.e. *before* an agent attempts a write. Reframed from
  "To resolve … runs: `<command>`" to a conditional coordination decision
  listing both options, so the agent is steered correctly at session start.

## Tests

- `cmd/bd`: `hint` must equal the directive and must **not** equal the escape
  command; `options` must carry both paths; the migrate command must appear
  **only** under the conditional `migrate` option.
- `internal/storage/schema`: a source-level test locks the same safety contract
  (`AgentDirective` is not runnable; escape command lives only under `migrate`).
- Note: four `dolt`-CLI migration tests in `internal/storage/schema` fail in my
  WSL environment; they fail **identically on pristine `main`** with zero
  changes, so they are pre-existing/environmental and unrelated to this change.

## Scope and follow-up

This is the safe, contained half of a two-part plan to make the agent path
**footgun-free now** and **smooth soon**:

- This PR: stop handing agents an auto-runnable migrate. (footgun-free)
- Follow-up (separate, reviewed): a **smart gate** that fetches the remote
  schema head and resolves the safe cases automatically — adopt when the remote
  is ahead and content-matches, auto-migrate when the remote equals local and
  all pending migrations are deterministic (the hygiene-guarded majority post
  #4259), and stop only on a genuine `content_hash` fork. The determinism work
  already shipped (`rowid`/`depid`, `nondeterminism-allowlist.txt`) makes this
  feasible. Happy to open a design issue if the direction is welcome.

Docs-side companion (recipe users follow once gated): gastownhall/beads#4514.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

_claude-opus-4-8-high on behalf of matt wilkie_
