### PR TITLE
fix(storage): stop appending Dolt audit events

### DIFF
--- a/cmd/bd/create_embedded_test.go
+++ b/cmd/bd/create_embedded_test.go
@@ -767,8 +767,8 @@ A new feature
 			id, types.EventLabelAdded).Scan(&labelEventCount); err != nil {
 			t.Fatalf("count label events: %v", err)
 		}
-		if labelEventCount != 2 {
-			t.Fatalf("label_added event count = %d, want 2", labelEventCount)
+		if labelEventCount != 0 {
+			t.Fatalf("label_added event count = %d, want 0", labelEventCount)
 		}
 	})
 

--- a/cmd/bd/create_proxied_integration_test.go
+++ b/cmd/bd/create_proxied_integration_test.go
@@ -640,8 +640,8 @@ A new feature
 			id, types.EventLabelAdded).Scan(&eventCount); err != nil {
 			t.Fatalf("count label events: %v", err)
 		}
-		if eventCount != 2 {
-			t.Fatalf("label_added event count = %d, want 2", eventCount)
+		if eventCount != 0 {
+			t.Fatalf("label_added event count = %d, want 0", eventCount)
 		}
 	})
 }

--- a/cmd/bd/export_test.go
+++ b/cmd/bd/export_test.go
@@ -737,7 +737,7 @@ func TestExportByteStabilityAllRecordTypes(t *testing.T) {
 	}
 
 	// Comments: several per issue. AddIssueComment writes to the comments table
-	// that export reads (AddComment records an event instead and would not show).
+	// that export reads.
 	for _, issue := range issues {
 		for _, c := range []string{"first note", "second note", "third note"} {
 			if _, err := s.AddIssueComment(ctx, issue.ID, "test", c); err != nil {

--- a/cmd/bd/label_test.go
+++ b/cmd/bd/label_test.go
@@ -97,25 +97,14 @@ func (h *labelTestHelper) assertNotHasLabel(issueID, label string) {
 	}
 }
 
-func (h *labelTestHelper) assertLabelEvent(issueID string, eventType types.EventType, labelName string) {
+func (h *labelTestHelper) assertNoLabelEvents(issueID string) {
 	events, err := h.s.GetEvents(h.ctx, issueID, 100)
 	if err != nil {
 		h.t.Fatalf("Failed to get events: %v", err)
 	}
-
-	expectedComment := ""
-	if eventType == types.EventLabelAdded {
-		expectedComment = "Added label: " + labelName
-	} else if eventType == types.EventLabelRemoved {
-		expectedComment = "Removed label: " + labelName
+	if len(events) != 0 {
+		h.t.Errorf("Expected no label audit events for %s, got %d", issueID, len(events))
 	}
-
-	for _, e := range events {
-		if e.EventType == eventType && e.Comment != nil && *e.Comment == expectedComment {
-			return
-		}
-	}
-	h.t.Errorf("Expected to find event %s for label %s", eventType, labelName)
 }
 
 func TestLabelCommands(t *testing.T) {
@@ -183,12 +172,11 @@ func TestLabelCommands(t *testing.T) {
 		h.assertLabelCount(issue.ID, 0)
 	})
 
-	t.Run("label operations create events", func(t *testing.T) {
+	t.Run("label operations do not create events", func(t *testing.T) {
 		issue := h.createIssue("Event Test", types.TypeTask, 1)
 		h.addLabel(issue.ID, "test-label")
 		h.removeLabel(issue.ID, "test-label")
-		h.assertLabelEvent(issue.ID, types.EventLabelAdded, "test-label")
-		h.assertLabelEvent(issue.ID, types.EventLabelRemoved, "test-label")
+		h.assertNoLabelEvents(issue.ID)
 	})
 
 	t.Run("labels persist after issue update", func(t *testing.T) {

--- a/cmd/bd/promote.go
+++ b/cmd/bd/promote.go
@@ -19,7 +19,7 @@ var promoteCmd = &cobra.Command{
 	Long: `Promote a wisp (ephemeral issue) to a permanent bead.
 
 This copies the issue from the wisps table (dolt_ignored) to the permanent
-issues table (Dolt-versioned), preserving labels, dependencies, events, and
+issues table (Dolt-versioned), preserving labels, dependencies, and
 comments. The original ID is preserved so all links keep working.
 
 A comment is added recording the promotion and optional reason.
@@ -65,10 +65,13 @@ Examples:
 			return HandleErrorRespectJSON("%s is not a wisp (already persistent)", fullID)
 		}
 
+		// Promote: copy from wisps to issues table, preserving labels/deps/comments
 		if err := store.PromoteFromEphemeral(ctx, fullID, actor); err != nil {
 			return HandleErrorRespectJSON("promoting %s: %v", fullID, err)
 		}
 
+		// Add promotion comment (issue is now in permanent table, AddComment
+		// writes a structured comment).
 		comment := "Promoted from wisp to permanent bead"
 		if reason != "" {
 			comment += ": " + reason

--- a/cmd/bd/reopen_proxied_integration_test.go
+++ b/cmd/bd/reopen_proxied_integration_test.go
@@ -64,12 +64,12 @@ func readReopenComment(t *testing.T, db *sql.DB, id string) string {
 	t.Helper()
 	var got sql.NullString
 	err := db.QueryRowContext(context.Background(),
-		"SELECT comment FROM events WHERE issue_id = ? AND event_type = ? ORDER BY created_at DESC LIMIT 1",
-		id, string(types.EventCommented)).Scan(&got)
+		"SELECT text FROM comments WHERE issue_id = ? ORDER BY created_at DESC LIMIT 1",
+		id).Scan(&got)
 	if err == sql.ErrNoRows {
 		if err := db.QueryRowContext(context.Background(),
-			"SELECT comment FROM wisp_events WHERE issue_id = ? AND event_type = ? ORDER BY created_at DESC LIMIT 1",
-			id, string(types.EventCommented)).Scan(&got); err != nil {
+			"SELECT text FROM wisp_comments WHERE issue_id = ? ORDER BY created_at DESC LIMIT 1",
+			id).Scan(&got); err != nil {
 			if err == sql.ErrNoRows {
 				return ""
 			}
@@ -180,8 +180,8 @@ func TestProxiedServerReopen(t *testing.T) {
 			wisp.ID, string(types.EventReopened)).Scan(&evtCount); err != nil {
 			t.Fatalf("count wisp reopened events: %v", err)
 		}
-		if evtCount != 1 {
-			t.Errorf("wisp_events EventReopened count: got %d, want 1", evtCount)
+		if evtCount != 0 {
+			t.Errorf("wisp_events EventReopened count: got %d, want 0", evtCount)
 		}
 	})
 

--- a/cmd/bd/reopen_test.go
+++ b/cmd/bd/reopen_test.go
@@ -82,17 +82,17 @@ func (h *reopenTestHelper) assertClosedAtNil(issueID string) {
 }
 
 func (h *reopenTestHelper) assertCommentEvent(issueID, comment string) {
-	events, err := h.s.GetEvents(h.ctx, issueID, 100)
+	comments, err := h.s.GetIssueComments(h.ctx, issueID)
 	if err != nil {
-		h.t.Fatalf("Failed to get events: %v", err)
+		h.t.Fatalf("Failed to get comments: %v", err)
 	}
 
-	for _, e := range events {
-		if e.EventType == types.EventCommented && e.Comment != nil && *e.Comment == comment {
+	for _, c := range comments {
+		if c.Text == comment {
 			return
 		}
 	}
-	h.t.Errorf("Expected to find comment event with reason '%s'", comment)
+	h.t.Errorf("Expected to find structured comment with reason '%s'", comment)
 }
 
 func TestReopenCommand(t *testing.T) {

--- a/internal/storage/dolt/create_issue_commit_test.go
+++ b/internal/storage/dolt/create_issue_commit_test.go
@@ -66,8 +66,8 @@ func TestCreateIssueCommitsInitialRelationalData(t *testing.T) {
 	).Scan(&labelEventCount); err != nil {
 		t.Fatalf("count committed label events: %v", err)
 	}
-	if labelEventCount != 2 {
-		t.Fatalf("committed label_added event count = %d, want 2", labelEventCount)
+	if labelEventCount != 0 {
+		t.Fatalf("committed label_added event count = %d, want 0", labelEventCount)
 	}
 
 	var dirtyRelationalTables int

--- a/internal/storage/dolt/dolt_test.go
+++ b/internal/storage/dolt/dolt_test.go
@@ -1022,7 +1022,7 @@ func TestDoltStoreEvents(t *testing.T) {
 	ctx, cancel := testContext(t)
 	defer cancel()
 
-	// Create an issue (this creates a creation event)
+	// Create an issue (this no longer creates an audit event)
 	issue := &types.Issue{
 		ID:          "test-event-issue",
 		Title:       "Issue with Events",
@@ -1036,18 +1036,24 @@ func TestDoltStoreEvents(t *testing.T) {
 		t.Fatalf("failed to create issue: %v", err)
 	}
 
-	// Add a comment event
+	// Add a structured comment through the legacy annotation API.
 	if err := store.AddComment(ctx, issue.ID, "user1", "A comment"); err != nil {
 		t.Fatalf("failed to add comment: %v", err)
 	}
 
-	// Get events
 	events, err := store.GetEvents(ctx, issue.ID, 10)
 	if err != nil {
 		t.Fatalf("failed to get events: %v", err)
 	}
-	if len(events) < 2 {
-		t.Errorf("expected at least 2 events, got %d", len(events))
+	if len(events) != 0 {
+		t.Errorf("expected no audit events, got %d", len(events))
+	}
+	comments, err := store.GetIssueComments(ctx, issue.ID)
+	if err != nil {
+		t.Fatalf("failed to get comments: %v", err)
+	}
+	if len(comments) != 1 || comments[0].Text != "A comment" {
+		t.Fatalf("structured comments = %+v, want one comment with text %q", comments, "A comment")
 	}
 }
 

--- a/internal/storage/dolt/ephemeral_routing.go
+++ b/internal/storage/dolt/ephemeral_routing.go
@@ -177,7 +177,7 @@ func (s *DoltStore) batchWispExists(ctx context.Context, ids []string) map[strin
 // clearing the Ephemeral flag. Used by bd promote and mol squash to crystallize wisps.
 //
 // Uses direct SQL inserts to bypass IsEphemeralID routing, which would otherwise
-// redirect label/dependency/event writes back to wisp tables.
+// redirect label/dependency writes back to wisp tables.
 func (s *DoltStore) PromoteFromEphemeral(ctx context.Context, id string, actor string) error {
 	if err := s.withRetryTx(ctx, func(tx *sql.Tx) error {
 		if err := issueops.PromoteFromEphemeralInTx(ctx, tx, id, actor); err != nil {
@@ -237,15 +237,8 @@ func (s *DoltStore) DemoteToWisp(ctx context.Context, id string, updates map[str
 			return fmt.Errorf("delete copied dependencies for demoted issue %s: %w", id, err)
 		}
 
-		if _, err := tx.ExecContext(ctx, `
-		INSERT IGNORE INTO wisp_events (id, issue_id, event_type, actor, old_value, new_value, comment, created_at)
-		SELECT id, issue_id, event_type, actor, old_value, new_value, comment, created_at
-		FROM events WHERE issue_id = ?
-	`, id); err != nil {
-			return fmt.Errorf("copy events for demoted issue %s: %w", id, err)
-		}
 		if _, err := tx.ExecContext(ctx, `DELETE FROM events WHERE issue_id = ?`, id); err != nil {
-			return fmt.Errorf("delete copied events for demoted issue %s: %w", id, err)
+			return fmt.Errorf("delete legacy events for demoted issue %s: %w", id, err)
 		}
 
 		if _, err := tx.ExecContext(ctx, `
@@ -257,13 +250,6 @@ func (s *DoltStore) DemoteToWisp(ctx context.Context, id string, updates map[str
 		}
 		if _, err := tx.ExecContext(ctx, `DELETE FROM comments WHERE issue_id = ?`, id); err != nil {
 			return fmt.Errorf("delete copied comments for demoted issue %s: %w", id, err)
-		}
-
-		if _, err := tx.ExecContext(ctx, `
-		INSERT INTO wisp_events (id, issue_id, event_type, actor, old_value, new_value)
-		VALUES (?, ?, ?, ?, ?, ?)
-	`, issueops.NewEventID(), id, types.EventUpdated, actor, "", "demoted to wisp"); err != nil {
-			return fmt.Errorf("record demotion event for demoted issue %s: %w", id, err)
 		}
 
 		if err := issueops.RetargetInboundDependenciesToWispInTx(ctx, tx, id); err != nil {

--- a/internal/storage/dolt/events.go
+++ b/internal/storage/dolt/events.go
@@ -10,25 +10,10 @@ import (
 	"github.com/steveyegge/beads/internal/types"
 )
 
-// AddComment adds a comment event to an issue
+// AddComment adds a structured comment to an issue.
 func (s *DoltStore) AddComment(ctx context.Context, issueID, actor, comment string) error {
-	isWisp := s.isActiveWisp(ctx, issueID)
-	tx, err := s.db.BeginTx(ctx, nil)
-	if err != nil {
-		return fmt.Errorf("begin tx: %w", err)
-	}
-	defer func() { _ = tx.Rollback() }()
-
-	if err := issueops.AddCommentEventInTx(ctx, tx, issueID, actor, comment); err != nil {
-		return err
-	}
-	if err := tx.Commit(); err != nil {
-		return wrapTransactionError("commit add comment event", err)
-	}
-	if isWisp {
-		return nil
-	}
-	return s.doltAddAndCommit(ctx, []string{"events"}, fmt.Sprintf("bd: comment %s", issueID))
+	_, err := s.AddIssueComment(ctx, issueID, actor, comment)
+	return err
 }
 
 // GetEvents retrieves events for an issue

--- a/internal/storage/dolt/events_test.go
+++ b/internal/storage/dolt/events_test.go
@@ -7,10 +7,9 @@ import (
 	"github.com/steveyegge/beads/internal/types"
 )
 
-// TestGetAllEventsSince_UnionBothTables verifies that GetAllEventsSince returns
-// events from both the events table (permanent issues) and wisp_events table
-// (ephemeral/wisp issues), ordered by created_at.
-func TestGetAllEventsSince_UnionBothTables(t *testing.T) {
+// TestGetAllEventsSince_NoMutationEvents verifies that ordinary issue creation
+// no longer appends audit rows to events/wisp_events.
+func TestGetAllEventsSince_NoMutationEvents(t *testing.T) {
 	store, cleanup := setupTestStore(t)
 	defer cleanup()
 
@@ -19,7 +18,6 @@ func TestGetAllEventsSince_UnionBothTables(t *testing.T) {
 
 	since := time.Now().UTC().Add(-1 * time.Second)
 
-	// Create a permanent issue (events go to 'events' table)
 	perm := &types.Issue{
 		ID:        "test-ev-perm",
 		Title:     "Permanent Issue",
@@ -31,7 +29,6 @@ func TestGetAllEventsSince_UnionBothTables(t *testing.T) {
 		t.Fatalf("failed to create permanent issue: %v", err)
 	}
 
-	// Create an ephemeral issue (events go to 'wisp_events' table)
 	wisp := &types.Issue{
 		ID:        "test-ev-wisp",
 		Title:     "Wisp Issue",
@@ -44,35 +41,12 @@ func TestGetAllEventsSince_UnionBothTables(t *testing.T) {
 		t.Fatalf("failed to create wisp issue: %v", err)
 	}
 
-	// Query events since before both were created
 	events, err := store.GetAllEventsSince(ctx, since)
 	if err != nil {
 		t.Fatalf("GetAllEventsSince failed: %v", err)
 	}
-
-	// Should have events from both tables (at least one 'created' event each)
-	permFound, wispFound := false, false
-	for _, e := range events {
-		if e.IssueID == perm.ID {
-			permFound = true
-		}
-		if e.IssueID == wisp.ID {
-			wispFound = true
-		}
-	}
-	if !permFound {
-		t.Error("expected event from permanent issue (events table), not found")
-	}
-	if !wispFound {
-		t.Error("expected event from wisp issue (wisp_events table), not found")
-	}
-
-	// Verify chronological ordering
-	for i := 1; i < len(events); i++ {
-		if events[i].CreatedAt.Before(events[i-1].CreatedAt) {
-			t.Errorf("events not in chronological order: [%d] %v > [%d] %v",
-				i-1, events[i-1].CreatedAt, i, events[i].CreatedAt)
-		}
+	if len(events) != 0 {
+		t.Fatalf("expected no audit events from issue creation, got %d: %+v", len(events), events)
 	}
 }
 

--- a/internal/storage/dolt/git_remote_test.go
+++ b/internal/storage/dolt/git_remote_test.go
@@ -1060,8 +1060,8 @@ func TestCreateIssueAfterPull(t *testing.T) {
 		t.Fatalf("source Push failed: %v", err)
 	}
 
-	// Simulate a second peer via CLI: clone, add data with UUID
-	// rows (issue + event), commit, and push back to the shared remote.
+	// Simulate a second peer via CLI: clone, add data with a legacy UUID event
+	// row, commit, and push back to the shared remote.
 	cloneDir := filepath.Join(setup.baseDir, "clone-ai")
 	doltClone(t, setup.remoteURL, cloneDir)
 	sourceInsertIssue(t, cloneDir, "ai-clone-001", "Clone issue generating events")
@@ -1094,10 +1094,10 @@ func TestCreateIssueAfterPull(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to count events: %v", err)
 	}
-	// At least 3 events: source created (ai-src-001), clone created (ai-clone-001),
-	// post-pull created (ai-src-002)
-	if eventCount < 3 {
-		t.Errorf("expected at least 3 events, got %d", eventCount)
+	// Only the manually inserted legacy event should remain; normal CreateIssue
+	// no longer appends audit rows.
+	if eventCount != 1 {
+		t.Errorf("expected 1 legacy event, got %d", eventCount)
 	}
 
 	for _, id := range []string{"ai-src-001", "ai-clone-001", "ai-src-002"} {

--- a/internal/storage/dolt/issues.go
+++ b/internal/storage/dolt/issues.go
@@ -186,7 +186,7 @@ func (s *DoltStore) UpdateIssue(ctx context.Context, id string, updates map[stri
 		return err
 	}
 
-	for _, table := range []string{"issues", "events"} {
+	for _, table := range []string{"issues"} {
 		_, _ = tx.ExecContext(ctx, "CALL DOLT_ADD(?)", table)
 	}
 	commitMsg := fmt.Sprintf("bd: update %s", id)
@@ -225,7 +225,7 @@ func (s *DoltStore) ClaimIssue(ctx context.Context, id string, actor string) err
 
 	// Dolt versioning for permanent issues.
 	// GH#2455: Stage only the tables we modified, then commit without -A.
-	for _, table := range []string{"issues", "events"} {
+	for _, table := range []string{"issues"} {
 		_, _ = tx.ExecContext(ctx, "CALL DOLT_ADD(?)", table)
 	}
 	commitMsg := fmt.Sprintf("bd: claim %s", id)
@@ -256,7 +256,7 @@ func (s *DoltStore) ClaimReadyIssue(ctx context.Context, filter types.WorkFilter
 		return nil, nil
 	}
 
-	for _, table := range []string{"issues", "events"} {
+	for _, table := range []string{"issues"} {
 		_, _ = tx.ExecContext(ctx, "CALL DOLT_ADD(?)", table)
 	}
 	commitMsg := fmt.Sprintf("bd: claim ready %s", claimed.ID)
@@ -318,7 +318,7 @@ func (s *DoltStore) CloseIssue(ctx context.Context, id string, reason string, ac
 
 	// Dolt versioning for permanent issues.
 	// GH#2455: Stage only the tables we modified, then commit without -A.
-	for _, table := range []string{"issues", "events"} {
+	for _, table := range []string{"issues"} {
 		_, _ = tx.ExecContext(ctx, "CALL DOLT_ADD(?)", table)
 	}
 	commitMsg := fmt.Sprintf("bd: close %s", id)
@@ -457,14 +457,6 @@ func doltBuildSQLInClause(ids []string) (string, []interface{}) {
 // =============================================================================
 // Helper functions
 // =============================================================================
-
-func recordEvent(ctx context.Context, tx *sql.Tx, issueID string, eventType types.EventType, actor, oldValue, newValue string) error {
-	_, err := tx.ExecContext(ctx, `
-		INSERT INTO events (id, issue_id, event_type, actor, old_value, new_value)
-		VALUES (?, ?, ?, ?, ?, ?)
-	`, issueops.NewEventID(), issueID, eventType, actor, oldValue, newValue)
-	return wrapExecError("record event", err)
-}
 
 // seedCounterFromExistingIssuesTx scans existing issues to find the highest numeric suffix
 // for the given prefix, then seeds the issue_counter table if no row exists yet.

--- a/internal/storage/dolt/labels.go
+++ b/internal/storage/dolt/labels.go
@@ -20,7 +20,7 @@ func (s *DoltStore) AddLabel(ctx context.Context, issueID, label, actor string) 
 	if isWisp {
 		return nil
 	}
-	return s.doltAddAndCommit(ctx, []string{"events", "labels"}, fmt.Sprintf("bd: label add %s", issueID))
+	return s.doltAddAndCommit(ctx, []string{"labels"}, fmt.Sprintf("bd: label add %s", issueID))
 }
 
 // RemoveLabel removes a label from an issue.
@@ -35,7 +35,7 @@ func (s *DoltStore) RemoveLabel(ctx context.Context, issueID, label, actor strin
 	if isWisp {
 		return nil
 	}
-	return s.doltAddAndCommit(ctx, []string{"events", "labels"}, fmt.Sprintf("bd: label remove %s", issueID))
+	return s.doltAddAndCommit(ctx, []string{"labels"}, fmt.Sprintf("bd: label remove %s", issueID))
 }
 
 // GetLabels retrieves all labels for an issue

--- a/internal/storage/dolt/mixed_table_lifecycle_test.go
+++ b/internal/storage/dolt/mixed_table_lifecycle_test.go
@@ -95,7 +95,6 @@ func TestDemoteToWispRollsBackWhenAuxiliaryCopyFails(t *testing.T) {
 	}{
 		{"labels", "wisp_labels", "copy labels for demoted issue", "mixed-demote-labels-fail"},
 		{"dependencies", "wisp_dependencies", "copy dependencies for demoted issue", "mixed-demote-dependencies-fail"},
-		{"events", "wisp_events", "copy events for demoted issue", "mixed-demote-events-fail"},
 		{"comments", "wisp_comments", "copy comments for demoted issue", "mixed-demote-comments-fail"},
 	}
 
@@ -342,7 +341,6 @@ func TestPromoteFromEphemeralRollsBackWhenAuxiliaryCopyFails(t *testing.T) {
 	}{
 		{"labels", "labels", "copy labels for promoted wisp", "mixed-promote-labels-fail"},
 		{"dependencies", "dependencies", "copy dependencies for promoted wisp", "mixed-promote-dependencies-fail"},
-		{"events", "events", "copy events for promoted wisp", "mixed-promote-events-fail"},
 		{"comments", "comments", "copy comments for promoted wisp", "mixed-promote-comments-fail"},
 	}
 
@@ -772,7 +770,7 @@ func TestDeleteIssuesCascadeDeletesNoHistoryWispDependent(t *testing.T) {
 	}
 }
 
-func TestDemoteToWispRecordsOnlyCreateAndDemotionEvents(t *testing.T) {
+func TestDemoteToWispDoesNotRecordEvents(t *testing.T) {
 	store, cleanup := setupTestStore(t)
 	defer cleanup()
 
@@ -791,20 +789,8 @@ func TestDemoteToWispRecordsOnlyCreateAndDemotionEvents(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetEvents: %v", err)
 	}
-	if len(events) != 2 {
-		t.Fatalf("event count = %d, want create plus demotion only: %+v", len(events), events)
-	}
-	foundDemotion := false
-	for _, event := range events {
-		if event.NewValue != nil && *event.NewValue == "demoted to wisp" {
-			foundDemotion = true
-		}
-		if event.NewValue != nil && strings.Contains(*event.NewValue, "no_history") {
-			t.Fatalf("found intermediate update event in demotion stream: %+v", event)
-		}
-	}
-	if !foundDemotion {
-		t.Fatalf("events = %+v, want demotion marker", events)
+	if len(events) != 0 {
+		t.Fatalf("event count = %d, want 0: %+v", len(events), events)
 	}
 }
 

--- a/internal/storage/dolt/rename_test.go
+++ b/internal/storage/dolt/rename_test.go
@@ -509,14 +509,14 @@ func TestUpdateIssueIDRenamesWisp(t *testing.T) {
 		t.Fatalf("expected %q to be an active wisp", oldID)
 	}
 
-	// Verify creation event was recorded in wisp_events
+	// Verify creation did not record a wisp_events audit row.
 	var eventCount int
 	err := store.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM wisp_events WHERE issue_id = ?`, oldID).Scan(&eventCount)
 	if err != nil {
 		t.Fatalf("failed to count wisp_events: %v", err)
 	}
-	if eventCount != 1 {
-		t.Fatalf("expected 1 wisp_events row for old ID, got %d", eventCount)
+	if eventCount != 0 {
+		t.Fatalf("expected 0 wisp_events rows for old ID, got %d", eventCount)
 	}
 
 	// Add a label to the wisp
@@ -541,14 +541,14 @@ func TestUpdateIssueIDRenamesWisp(t *testing.T) {
 		t.Fatal("new wisp ID should exist in wisps table after rename")
 	}
 
-	// Verify wisp_events were updated (1 creation + 1 label_added + 1 rename = 3)
+	// Verify rename did not append wisp_events audit rows.
 	var newEventCount int
 	err = store.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM wisp_events WHERE issue_id = ?`, newID).Scan(&newEventCount)
 	if err != nil {
 		t.Fatalf("failed to count wisp_events for new ID: %v", err)
 	}
-	if newEventCount != 3 {
-		t.Fatalf("expected 3 wisp_events rows for new ID (creation + label_added + rename), got %d", newEventCount)
+	if newEventCount != 0 {
+		t.Fatalf("expected 0 wisp_events rows for new ID, got %d", newEventCount)
 	}
 
 	// Verify no events left under old ID
@@ -624,13 +624,13 @@ func TestUpdateIssueIDStillWorksForRegularIssues(t *testing.T) {
 		t.Fatalf("expected original title, got %q", got.Title)
 	}
 
-	// Verify rename event in events table
+	// Verify rename did not append an event row.
 	var eventCount int
 	err = store.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM events WHERE issue_id = ? AND event_type = 'renamed'`, newID).Scan(&eventCount)
 	if err != nil {
 		t.Fatalf("failed to count rename events: %v", err)
 	}
-	if eventCount != 1 {
-		t.Fatalf("expected 1 rename event for new ID, got %d", eventCount)
+	if eventCount != 0 {
+		t.Fatalf("expected 0 rename events for new ID, got %d", eventCount)
 	}
 }

--- a/internal/storage/dolt/transaction.go
+++ b/internal/storage/dolt/transaction.go
@@ -927,18 +927,14 @@ func (t *doltTransaction) GetIssueComments(ctx context.Context, issueID string) 
 	return comments, rows.Err()
 }
 
-// AddComment adds a comment within the transaction
+// AddComment adds a structured comment within the transaction.
 func (t *doltTransaction) AddComment(ctx context.Context, issueID, actor, comment string) error {
-	table := "events"
+	table := "comments"
 	if t.isActiveWisp(ctx, issueID) {
-		table = "wisp_events"
+		table = "wisp_comments"
 	}
 
-	//nolint:gosec // G201: table is hardcoded
-	_, err := t.txFor(table).ExecContext(ctx, fmt.Sprintf(`
-		INSERT INTO %s (id, issue_id, event_type, actor, comment)
-		VALUES (?, ?, ?, ?, ?)
-	`, table), issueops.NewEventID(), issueID, types.EventCommented, actor, comment)
+	_, err := issueops.AddIssueCommentInTx(ctx, t.txFor(table), issueID, actor, comment)
 	if err == nil {
 		t.dirty.MarkDirty(table)
 	}

--- a/internal/storage/dolt/transaction_test.go
+++ b/internal/storage/dolt/transaction_test.go
@@ -92,8 +92,8 @@ func TestRunInTransactionWispCreatePersistsInitialSideTables(t *testing.T) {
 	).Scan(&labelEventCount); err != nil {
 		t.Fatalf("query wisp label events for %s: %v", wisp.ID, err)
 	}
-	if labelEventCount != 2 {
-		t.Fatalf("wisp label event count for %s = %d, want 2", wisp.ID, labelEventCount)
+	if labelEventCount != 0 {
+		t.Fatalf("wisp label event count for %s = %d, want 0", wisp.ID, labelEventCount)
 	}
 }
 

--- a/internal/storage/domain/db/close_test.go
+++ b/internal/storage/domain/db/close_test.go
@@ -51,7 +51,7 @@ func (s *testSuite) closeMutatesRow() {
 	s.Require().NoError(s.Runner().QueryRowContext(s.Ctx(),
 		"SELECT COUNT(*) FROM events WHERE issue_id = ? AND event_type = ?",
 		"bd-cl-row", string(types.EventClosed)).Scan(&evtCount))
-	s.Equal(1, evtCount)
+	s.Equal(0, evtCount)
 }
 
 func (s *testSuite) closeIdempotent() {
@@ -77,7 +77,7 @@ func (s *testSuite) closeIdempotent() {
 	s.Require().NoError(s.Runner().QueryRowContext(s.Ctx(),
 		"SELECT COUNT(*) FROM events WHERE issue_id = ? AND event_type = ?",
 		"bd-cl-idem", string(types.EventClosed)).Scan(&evtCount))
-	s.Equal(1, evtCount)
+	s.Equal(0, evtCount)
 }
 
 func (s *testSuite) closeRecomputesIsBlocked() {

--- a/internal/storage/domain/db/delete_repo_test.go
+++ b/internal/storage/domain/db/delete_repo_test.go
@@ -426,9 +426,7 @@ func (s *testSuite) eventsDeleteAllRemoves() {
 	s.seedIssueRow("bd-del-evt-c")
 	r := s.eventsRepo()
 	for _, id := range []string{"bd-del-evt-a", "bd-del-evt-a", "bd-del-evt-b", "bd-del-evt-c"} {
-		s.Require().NoError(r.Record(s.Ctx(),
-			domain.Event{IssueID: id, Type: types.EventCreated, Actor: "tester"},
-			domain.RecordEventOpts{}))
+		s.seedLegacyEventRow(id, types.EventCreated, false)
 	}
 
 	n, err := r.DeleteAllForIDs(s.Ctx(),
@@ -445,9 +443,7 @@ func (s *testSuite) eventsDeleteAllRemoves() {
 func (s *testSuite) eventsDeleteAllWispRouting() {
 	s.seedWispRow("bd-del-wevt-1")
 	r := s.eventsRepo()
-	s.Require().NoError(r.Record(s.Ctx(),
-		domain.Event{IssueID: "bd-del-wevt-1", Type: types.EventUpdated, Actor: "tester"},
-		domain.RecordEventOpts{UseWispsTable: true}))
+	s.seedLegacyEventRow("bd-del-wevt-1", types.EventUpdated, true)
 
 	n, err := r.DeleteAllForIDs(s.Ctx(), []string{"bd-del-wevt-1"},
 		domain.RecordEventOpts{UseWispsTable: true})
@@ -466,9 +462,7 @@ func (s *testSuite) eventsCountAllCounts() {
 	s.seedIssueRow("bd-del-ec-b")
 	r := s.eventsRepo()
 	for _, id := range []string{"bd-del-ec-a", "bd-del-ec-a", "bd-del-ec-b"} {
-		s.Require().NoError(r.Record(s.Ctx(),
-			domain.Event{IssueID: id, Type: types.EventCreated, Actor: "tester"},
-			domain.RecordEventOpts{}))
+		s.seedLegacyEventRow(id, types.EventCreated, false)
 	}
 
 	n, err := r.CountAllForIDs(s.Ctx(), []string{"bd-del-ec-a", "bd-del-ec-b"}, domain.RecordEventOpts{})
@@ -479,9 +473,7 @@ func (s *testSuite) eventsCountAllCounts() {
 func (s *testSuite) eventsCountAllWispRouting() {
 	s.seedWispRow("bd-del-wec-1")
 	r := s.eventsRepo()
-	s.Require().NoError(r.Record(s.Ctx(),
-		domain.Event{IssueID: "bd-del-wec-1", Type: types.EventUpdated, Actor: "tester"},
-		domain.RecordEventOpts{UseWispsTable: true}))
+	s.seedLegacyEventRow("bd-del-wec-1", types.EventUpdated, true)
 
 	n, err := r.CountAllForIDs(s.Ctx(), []string{"bd-del-wec-1"},
 		domain.RecordEventOpts{UseWispsTable: true})

--- a/internal/storage/domain/db/events.go
+++ b/internal/storage/domain/db/events.go
@@ -21,18 +21,6 @@ type eventsSQLRepositoryImpl struct {
 var _ domain.EventsSQLRepository = (*eventsSQLRepositoryImpl)(nil)
 
 func (r *eventsSQLRepositoryImpl) Record(ctx context.Context, evt domain.Event, opts domain.RecordEventOpts) error {
-	table := "events"
-	if opts.UseWispsTable {
-		table = "wisp_events"
-	}
-	//nolint:gosec // G201: table is one of two hardcoded constants
-	_, err := r.runner.ExecContext(ctx, fmt.Sprintf(`
-		INSERT INTO %s (id, issue_id, event_type, actor, old_value, new_value)
-		VALUES (?, ?, ?, ?, ?, ?)
-	`, table), issueops.NewEventID(), evt.IssueID, string(evt.Type), evt.Actor, evt.OldValue, evt.NewValue)
-	if err != nil {
-		return fmt.Errorf("db: record event in %s: %w", table, err)
-	}
 	return nil
 }
 

--- a/internal/storage/domain/db/events_test.go
+++ b/internal/storage/domain/db/events_test.go
@@ -2,15 +2,15 @@ package db
 
 import (
 	"github.com/steveyegge/beads/internal/storage/domain"
+	"github.com/steveyegge/beads/internal/storage/issueops"
 	"github.com/steveyegge/beads/internal/types"
 )
 
 func (s *testSuite) TestEventsSQLRepository() {
 	s.Run("Record", func() {
-		s.Run("WritesToEventsTable", s.eventsRecordEvents)
-		s.Run("WritesToWispEventsTable", s.eventsRecordWispEvents)
-		s.Run("FieldsRoundTrip", s.eventsRecordRoundTrip)
-		s.Run("MissingIssueIDFailsFKConstraint", s.eventsRecordFKViolation)
+		s.Run("DoesNotWriteEventsTable", s.eventsRecordDoesNotWriteEvents)
+		s.Run("DoesNotWriteWispEventsTable", s.eventsRecordDoesNotWriteWispEvents)
+		s.Run("MissingIssueIDNoops", s.eventsRecordMissingIssueNoops)
 	})
 }
 
@@ -35,7 +35,19 @@ func (s *testSuite) seedWispRow(id string) {
 	s.Require().NoError(err)
 }
 
-func (s *testSuite) eventsRecordEvents() {
+func (s *testSuite) seedLegacyEventRow(issueID string, eventType types.EventType, useWisps bool) {
+	table := "events"
+	if useWisps {
+		table = "wisp_events"
+	}
+	//nolint:gosec // G201: table is selected from two hardcoded constants.
+	_, err := s.Runner().ExecContext(s.Ctx(),
+		"INSERT INTO "+table+" (id, issue_id, event_type, actor) VALUES (?, ?, ?, ?)",
+		issueops.NewEventID(), issueID, string(eventType), "tester")
+	s.Require().NoError(err)
+}
+
+func (s *testSuite) eventsRecordDoesNotWriteEvents() {
 	s.seedIssueRow("bd-evt-1")
 
 	r := s.eventsRepo()
@@ -47,10 +59,10 @@ func (s *testSuite) eventsRecordEvents() {
 
 	var count int
 	s.Require().NoError(s.Runner().QueryRowContext(s.Ctx(),
-		"SELECT COUNT(*) FROM events WHERE issue_id = ? AND event_type = ?",
-		"bd-evt-1", string(types.EventCreated),
+		"SELECT COUNT(*) FROM events WHERE issue_id = ?",
+		"bd-evt-1",
 	).Scan(&count))
-	s.Equal(1, count, "expected one row in events table")
+	s.Equal(0, count, "Record must not append audit rows to events")
 
 	s.Require().NoError(s.Runner().QueryRowContext(s.Ctx(),
 		"SELECT COUNT(*) FROM wisp_events WHERE issue_id = ?",
@@ -59,7 +71,7 @@ func (s *testSuite) eventsRecordEvents() {
 	s.Equal(0, count, "no row should be in wisp_events")
 }
 
-func (s *testSuite) eventsRecordWispEvents() {
+func (s *testSuite) eventsRecordDoesNotWriteWispEvents() {
 	r := s.eventsRepo()
 	s.Require().NoError(r.Record(s.Ctx(), domain.Event{
 		IssueID: "bd-evt-wisp",
@@ -69,10 +81,10 @@ func (s *testSuite) eventsRecordWispEvents() {
 
 	var count int
 	s.Require().NoError(s.Runner().QueryRowContext(s.Ctx(),
-		"SELECT COUNT(*) FROM wisp_events WHERE issue_id = ? AND event_type = ?",
-		"bd-evt-wisp", string(types.EventUpdated),
+		"SELECT COUNT(*) FROM wisp_events WHERE issue_id = ?",
+		"bd-evt-wisp",
 	).Scan(&count))
-	s.Equal(1, count, "expected one row in wisp_events table")
+	s.Equal(0, count, "Record must not append audit rows to wisp_events")
 
 	s.Require().NoError(s.Runner().QueryRowContext(s.Ctx(),
 		"SELECT COUNT(*) FROM events WHERE issue_id = ?",
@@ -81,37 +93,11 @@ func (s *testSuite) eventsRecordWispEvents() {
 	s.Equal(0, count, "no row should be in events table")
 }
 
-func (s *testSuite) eventsRecordRoundTrip() {
-	s.seedIssueRow("bd-evt-rt")
-
+func (s *testSuite) eventsRecordMissingIssueNoops() {
 	r := s.eventsRepo()
-	in := domain.Event{
-		IssueID:  "bd-evt-rt",
-		Type:     types.EventStatusChanged,
-		Actor:    "alice",
-		OldValue: "open",
-		NewValue: "in_progress",
-	}
-	s.Require().NoError(r.Record(s.Ctx(), in, domain.RecordEventOpts{}))
-
-	var gotIssueID, gotType, gotActor, gotOld, gotNew string
-	s.Require().NoError(s.Runner().QueryRowContext(s.Ctx(),
-		"SELECT issue_id, event_type, actor, old_value, new_value FROM events WHERE issue_id = ?",
-		in.IssueID,
-	).Scan(&gotIssueID, &gotType, &gotActor, &gotOld, &gotNew))
-	s.Equal(in.IssueID, gotIssueID)
-	s.Equal(string(in.Type), gotType)
-	s.Equal(in.Actor, gotActor)
-	s.Equal(in.OldValue, gotOld)
-	s.Equal(in.NewValue, gotNew)
-}
-
-func (s *testSuite) eventsRecordFKViolation() {
-	r := s.eventsRepo()
-	err := r.Record(s.Ctx(), domain.Event{
+	s.Require().NoError(r.Record(s.Ctx(), domain.Event{
 		IssueID: "bd-evt-no-such-issue",
 		Type:    types.EventCreated,
 		Actor:   "tester",
-	}, domain.RecordEventOpts{})
-	s.Require().Error(err, "expected FK violation when issue_id does not exist")
+	}, domain.RecordEventOpts{}))
 }

--- a/internal/storage/domain/db/issue_test.go
+++ b/internal/storage/domain/db/issue_test.go
@@ -14,7 +14,7 @@ func (s *testSuite) TestIssueSQLRepository() {
 		s.Run("RoundTripWithGet", s.issueInsertRoundTrip)
 		s.Run("RequiresExplicitID", s.issueInsertRequiresID)
 		s.Run("IdempotentOnDuplicateKey", s.issueInsertIdempotent)
-		s.Run("RecordsCreatedEvent", s.issueInsertRecordsEvent)
+		s.Run("DoesNotRecordCreatedEvent", s.issueInsertDoesNotRecordEvent)
 		s.Run("RoutesToWispsTable", s.issueInsertWispRouting)
 		s.Run("ComputesContentHashWhenMissing", s.issueInsertComputesHash)
 	})
@@ -38,7 +38,7 @@ func (s *testSuite) TestIssueSQLRepository() {
 		s.Run("ConflictReturnsForeignAssignee", s.issueClaimConflict)
 		s.Run("NotClaimableWhenClosed", s.issueClaimClosed)
 		s.Run("EmptyIDReturnsError", s.issueClaimEmptyID)
-		s.Run("RecordsClaimedEvent", s.issueClaimRecordsEvent)
+		s.Run("DoesNotRecordClaimedEvent", s.issueClaimDoesNotRecordEvent)
 	})
 	s.Run("Get", func() {
 		s.Run("MissingIDReturnsErrNoRows", s.issueGetMissing)
@@ -136,7 +136,7 @@ func (s *testSuite) issueInsertIdempotent() {
 	s.Equal("added on second pass", out.Description)
 }
 
-func (s *testSuite) issueInsertRecordsEvent() {
+func (s *testSuite) issueInsertDoesNotRecordEvent() {
 	r := s.issueRepo()
 	s.Require().NoError(r.Insert(s.Ctx(), newTestIssue("bd-test-evt", "event check"), "tester", domain.InsertIssueOpts{}))
 
@@ -145,7 +145,7 @@ func (s *testSuite) issueInsertRecordsEvent() {
 		"SELECT COUNT(*) FROM events WHERE issue_id = ? AND event_type = ?",
 		"bd-test-evt", string(types.EventCreated),
 	).Scan(&count))
-	s.Equal(1, count, "expected exactly one created event")
+	s.Equal(0, count, "insert must not append audit rows to events")
 }
 
 func (s *testSuite) issueInsertWispRouting() {
@@ -165,7 +165,7 @@ func (s *testSuite) issueInsertWispRouting() {
 		"SELECT COUNT(*) FROM wisp_events WHERE issue_id = ?",
 		"bd-test-wisp",
 	).Scan(&count))
-	s.Equal(1, count, "expected created event in wisp_events")
+	s.Equal(0, count, "wisp insert must not append audit rows to wisp_events")
 }
 
 func (s *testSuite) issueInsertComputesHash() {
@@ -358,12 +358,12 @@ func (s *testSuite) issueWispUpdate() {
 	s.Require().NoError(err)
 	s.Equal("after", out.Title)
 
-	// The update event should land in wisp_events, not events.
+	// Updates should not append audit rows to either event table.
 	var wispEvtCount, permEvtCount int
 	s.Require().NoError(s.Runner().QueryRowContext(s.Ctx(),
 		"SELECT COUNT(*) FROM wisp_events WHERE issue_id = ? AND event_type = ?",
 		"bd-iss-wisp-upd", string(types.EventUpdated)).Scan(&wispEvtCount))
-	s.Equal(1, wispEvtCount)
+	s.Equal(0, wispEvtCount)
 	s.Require().NoError(s.Runner().QueryRowContext(s.Ctx(),
 		"SELECT COUNT(*) FROM events WHERE issue_id = ? AND event_type = ?",
 		"bd-iss-wisp-upd", string(types.EventUpdated)).Scan(&permEvtCount))
@@ -638,7 +638,7 @@ func (s *testSuite) issueClaimEmptyID() {
 	s.Contains(err.Error(), "id must not be empty")
 }
 
-func (s *testSuite) issueClaimRecordsEvent() {
+func (s *testSuite) issueClaimDoesNotRecordEvent() {
 	r := s.issueRepo()
 	s.Require().NoError(r.Insert(s.Ctx(), newTestIssue("bd-claim-evt", "x"), "tester", domain.InsertIssueOpts{}))
 
@@ -650,5 +650,5 @@ func (s *testSuite) issueClaimRecordsEvent() {
 	s.Require().NoError(s.Runner().QueryRowContext(s.Ctx(),
 		"SELECT COUNT(*) FROM events WHERE issue_id = ? AND event_type = ?",
 		"bd-claim-evt", "claimed").Scan(&count))
-	s.Equal(1, count, "successful claim must record exactly one 'claimed' event")
+	s.Equal(0, count, "successful claim must not append audit rows to events")
 }

--- a/internal/storage/domain/db/issue_usecase_delete_test.go
+++ b/internal/storage/domain/db/issue_usecase_delete_test.go
@@ -145,9 +145,7 @@ func (s *testSuite) iucDeleteCleansAuxiliaryTables() {
 		"bd-iuc-aux-a", "tag1", "tester", domain.LabelOpts{}))
 	s.Require().NoError(s.labelRepo().Insert(s.Ctx(),
 		"bd-iuc-aux-a", "tag2", "tester", domain.LabelOpts{}))
-	s.Require().NoError(s.eventsRepo().Record(s.Ctx(),
-		domain.Event{IssueID: "bd-iuc-aux-a", Type: types.EventCreated, Actor: "tester"},
-		domain.RecordEventOpts{}))
+	s.seedLegacyEventRow("bd-iuc-aux-a", types.EventCreated, false)
 
 	res, err := s.issueUseCase().DeleteIssue(s.Ctx(), "bd-iuc-aux-a", "tester")
 	s.Require().NoError(err)

--- a/internal/storage/domain/db/label_test.go
+++ b/internal/storage/domain/db/label_test.go
@@ -9,14 +9,14 @@ func (s *testSuite) TestLabelSQLRepository() {
 	s.Run("Insert", func() {
 		s.Run("RoundTripWithList", s.labelInsertRoundTrip)
 		s.Run("IdempotentDuplicate", s.labelInsertIdempotent)
-		s.Run("RecordsLabelAddedEvent", s.labelInsertRecordsEvent)
+		s.Run("DoesNotRecordLabelAddedEvent", s.labelInsertDoesNotRecordEvent)
 		s.Run("RejectsEmptyIssueID", s.labelInsertEmptyIssueID)
 		s.Run("RejectsEmptyLabel", s.labelInsertEmptyLabel)
 		s.Run("MissingIssueIDFailsFK", s.labelInsertFKViolation)
 	})
 	s.Run("Delete", func() {
 		s.Run("RemovesLabelRow", s.labelDeleteRemoves)
-		s.Run("RecordsLabelRemovedEvent", s.labelDeleteRecordsEvent)
+		s.Run("DoesNotRecordLabelRemovedEvent", s.labelDeleteDoesNotRecordEvent)
 		s.Run("MissingLabelIsNoop", s.labelDeleteMissingNoop)
 		s.Run("OnlyTargetLabelRemoved", s.labelDeleteSpecificLabel)
 		s.Run("RejectsEmptyIssueID", s.labelDeleteEmptyIssueID)
@@ -34,7 +34,7 @@ func (s *testSuite) TestLabelSQLRepository() {
 	})
 	s.Run("Wisp", func() {
 		s.Run("InsertRoutesToWispLabels", s.labelWispInsertRouting)
-		s.Run("InsertRecordsEventInWispEvents", s.labelWispInsertEvent)
+		s.Run("InsertDoesNotRecordWispEvent", s.labelWispInsertNoEvent)
 		s.Run("ListReadsFromWispLabels", s.labelWispListIsolated)
 		s.Run("ListByIssueIDsReadsFromWispLabels", s.labelWispBulkIsolated)
 	})
@@ -69,21 +69,20 @@ func (s *testSuite) labelInsertIdempotent() {
 		"SELECT COUNT(*) FROM events WHERE issue_id = ? AND event_type = ?",
 		"bd-lbl-dup", string(types.EventLabelAdded),
 	).Scan(&count))
-	s.Equal(2, count)
+	s.Equal(0, count)
 }
 
-func (s *testSuite) labelInsertRecordsEvent() {
+func (s *testSuite) labelInsertDoesNotRecordEvent() {
 	s.seedIssueRow("bd-lbl-evt")
 	r := s.labelRepo()
 	s.Require().NoError(r.Insert(s.Ctx(), "bd-lbl-evt", "perf", "alice", domain.LabelOpts{}))
 
-	var actor, newValue string
+	var count int
 	s.Require().NoError(s.Runner().QueryRowContext(s.Ctx(),
-		"SELECT actor, new_value FROM events WHERE issue_id = ? AND event_type = ?",
+		"SELECT COUNT(*) FROM events WHERE issue_id = ? AND event_type = ?",
 		"bd-lbl-evt", string(types.EventLabelAdded),
-	).Scan(&actor, &newValue))
-	s.Equal("alice", actor)
-	s.Equal("perf", newValue, "event new_value should carry the label name")
+	).Scan(&count))
+	s.Equal(0, count)
 }
 
 func (s *testSuite) labelInsertEmptyIssueID() {
@@ -166,7 +165,7 @@ func (s *testSuite) labelWispInsertRouting() {
 	s.Equal(0, permCount, "wisp-routed insert must not write to labels")
 }
 
-func (s *testSuite) labelWispInsertEvent() {
+func (s *testSuite) labelWispInsertNoEvent() {
 	s.seedWispRow("bd-lbl-wisp-evt")
 	r := s.labelRepo()
 	s.Require().NoError(r.Insert(s.Ctx(), "bd-lbl-wisp-evt", "audit", "alice", domain.LabelOpts{UseWispsTable: true}))
@@ -176,7 +175,7 @@ func (s *testSuite) labelWispInsertEvent() {
 		"SELECT COUNT(*) FROM wisp_events WHERE issue_id = ? AND event_type = ?",
 		"bd-lbl-wisp-evt", string(types.EventLabelAdded),
 	).Scan(&wispEvtCount))
-	s.Equal(1, wispEvtCount)
+	s.Equal(0, wispEvtCount)
 	s.Require().NoError(s.Runner().QueryRowContext(s.Ctx(),
 		"SELECT COUNT(*) FROM events WHERE issue_id = ? AND event_type = ?",
 		"bd-lbl-wisp-evt", string(types.EventLabelAdded),
@@ -236,19 +235,18 @@ func (s *testSuite) labelDeleteRemoves() {
 	s.Empty(out, "deleted label should no longer appear in List")
 }
 
-func (s *testSuite) labelDeleteRecordsEvent() {
+func (s *testSuite) labelDeleteDoesNotRecordEvent() {
 	s.seedIssueRow("bd-lbl-del-evt")
 	r := s.labelRepo()
 	s.Require().NoError(r.Insert(s.Ctx(), "bd-lbl-del-evt", "perf", "alice", domain.LabelOpts{}))
 	s.Require().NoError(r.Delete(s.Ctx(), "bd-lbl-del-evt", "perf", "bob", domain.LabelOpts{}))
 
-	var actor, oldValue string
+	var count int
 	s.Require().NoError(s.Runner().QueryRowContext(s.Ctx(),
-		"SELECT actor, old_value FROM events WHERE issue_id = ? AND event_type = ?",
+		"SELECT COUNT(*) FROM events WHERE issue_id = ? AND event_type = ?",
 		"bd-lbl-del-evt", string(types.EventLabelRemoved),
-	).Scan(&actor, &oldValue))
-	s.Equal("bob", actor)
-	s.Equal("perf", oldValue, "event old_value should carry the removed label name (symmetric with Insert's new_value)")
+	).Scan(&count))
+	s.Equal(0, count)
 }
 
 func (s *testSuite) labelDeleteMissingNoop() {
@@ -307,10 +305,10 @@ func (s *testSuite) labelDeleteWispRouting() {
 		"SELECT COUNT(*) FROM wisp_events WHERE issue_id = ? AND event_type = ?",
 		"bd-lbl-del-cross-wisp", string(types.EventLabelRemoved),
 	).Scan(&wispEvt))
-	s.Equal(1, wispEvt)
+	s.Equal(0, wispEvt)
 	s.Require().NoError(s.Runner().QueryRowContext(s.Ctx(),
 		"SELECT COUNT(*) FROM events WHERE issue_id = ? AND event_type = ?",
 		"bd-lbl-del-cross-wisp", string(types.EventLabelRemoved),
 	).Scan(&permEvt))
-	s.Equal(0, permEvt, "wisp-routed Delete must record the event in wisp_events, not events")
+	s.Equal(0, permEvt, "wisp-routed Delete must not append audit rows to events")
 }

--- a/internal/storage/domain/db/reopen_test.go
+++ b/internal/storage/domain/db/reopen_test.go
@@ -43,7 +43,7 @@ func (s *testSuite) reopenMutatesRow() {
 	s.Require().NoError(s.Runner().QueryRowContext(s.Ctx(),
 		"SELECT COUNT(*) FROM events WHERE issue_id = ? AND event_type = ?",
 		"bd-ro-row", string(types.EventReopened)).Scan(&evtCount))
-	s.Equal(1, evtCount)
+	s.Equal(0, evtCount)
 }
 
 func (s *testSuite) reopenIdempotent() {
@@ -110,7 +110,7 @@ func (s *testSuite) reopenRoutesWisp() {
 	s.Require().NoError(s.Runner().QueryRowContext(s.Ctx(),
 		"SELECT COUNT(*) FROM wisp_events WHERE issue_id = ? AND event_type = ?",
 		"bd-ro-wisp", string(types.EventReopened)).Scan(&evtCount))
-	s.Equal(1, evtCount)
+	s.Equal(0, evtCount)
 }
 
 func (s *testSuite) reopenAppendsComment() {
@@ -126,8 +126,8 @@ func (s *testSuite) reopenAppendsComment() {
 
 	var comment string
 	s.Require().NoError(s.Runner().QueryRowContext(s.Ctx(),
-		"SELECT comment FROM events WHERE issue_id = ? AND event_type = ?",
-		"bd-ro-cmt", string(types.EventCommented)).Scan(&comment))
+		"SELECT text FROM comments WHERE issue_id = ?",
+		"bd-ro-cmt").Scan(&comment))
 	s.Equal("regression spotted", comment)
 }
 
@@ -144,7 +144,7 @@ func (s *testSuite) reopenNoCommentEmptyReason() {
 
 	var cmtCount int
 	s.Require().NoError(s.Runner().QueryRowContext(s.Ctx(),
-		"SELECT COUNT(*) FROM events WHERE issue_id = ? AND event_type = ?",
-		"bd-ro-nocmt", string(types.EventCommented)).Scan(&cmtCount))
+		"SELECT COUNT(*) FROM comments WHERE issue_id = ?",
+		"bd-ro-nocmt").Scan(&cmtCount))
 	s.Equal(0, cmtCount)
 }

--- a/internal/storage/domain/db/reopen_usecase_test.go
+++ b/internal/storage/domain/db/reopen_usecase_test.go
@@ -95,7 +95,7 @@ func (s *testSuite) uccReopenReasonComment() {
 
 	var comment string
 	s.Require().NoError(s.Runner().QueryRowContext(s.Ctx(),
-		"SELECT comment FROM events WHERE issue_id = ? AND event_type = ?",
-		"bd-ucc-ro-cmt", string(types.EventCommented)).Scan(&comment))
+		"SELECT text FROM comments WHERE issue_id = ?",
+		"bd-ucc-ro-cmt").Scan(&comment))
 	s.Equal("qa found a regression", comment)
 }

--- a/internal/storage/embeddeddolt/create_issue_test.go
+++ b/internal/storage/embeddeddolt/create_issue_test.go
@@ -339,7 +339,7 @@ func TestCreateIssue(t *testing.T) {
 		te.assertIssueTitle(t, ctx, "issues", "up-dup1", "Updated title")
 	})
 
-	t.Run("event_recorded", func(t *testing.T) {
+	t.Run("event_not_recorded", func(t *testing.T) {
 		te := newTestEnv(t, "ev")
 		ctx := t.Context()
 
@@ -355,7 +355,7 @@ func TestCreateIssue(t *testing.T) {
 			t.Fatalf("CreateIssue: %v", err)
 		}
 
-		te.assertEventCount(t, ctx, "events", "ev-evt1", "created", 1)
+		te.assertEventCount(t, ctx, "events", "ev-evt1", "created", 0)
 	})
 
 	t.Run("ephemeral_routes_to_wisps", func(t *testing.T) {
@@ -830,7 +830,7 @@ func TestCreateIssues(t *testing.T) {
 		}
 	})
 
-	t.Run("upsert_skips_duplicate_events", func(t *testing.T) {
+	t.Run("upsert_does_not_record_events", func(t *testing.T) {
 		te := newTestEnv(t, "ud")
 		ctx := t.Context()
 
@@ -841,7 +841,7 @@ func TestCreateIssues(t *testing.T) {
 			t.Fatalf("first CreateIssues: %v", err)
 		}
 
-		te.assertEventCount(t, ctx, "events", "ud-dup", "created", 1)
+		te.assertEventCount(t, ctx, "events", "ud-dup", "created", 0)
 
 		// Re-import same ID — should upsert without extra event.
 		issues2 := []*types.Issue{
@@ -852,10 +852,10 @@ func TestCreateIssues(t *testing.T) {
 		}
 
 		te.assertIssueTitle(t, ctx, "issues", "ud-dup", "Updated")
-		te.assertEventCount(t, ctx, "events", "ud-dup", "created", 1) // still just 1
+		te.assertEventCount(t, ctx, "events", "ud-dup", "created", 0)
 	})
 
-	t.Run("upsert_records_events_for_new_labels", func(t *testing.T) {
+	t.Run("upsert_adds_new_labels_without_events", func(t *testing.T) {
 		te := newTestEnv(t, "ul")
 		ctx := t.Context()
 
@@ -872,7 +872,7 @@ func TestCreateIssues(t *testing.T) {
 		if err := te.store.CreateIssues(ctx, issues, "tester"); err != nil {
 			t.Fatalf("first CreateIssues: %v", err)
 		}
-		te.assertEventCount(t, ctx, "events", "ul-dup", string(types.EventLabelAdded), 1)
+		te.assertEventCount(t, ctx, "events", "ul-dup", string(types.EventLabelAdded), 0)
 
 		issues2 := []*types.Issue{
 			{
@@ -889,7 +889,7 @@ func TestCreateIssues(t *testing.T) {
 		}
 
 		te.assertLabelCount(t, ctx, "labels", "ul-dup", 2)
-		te.assertEventCount(t, ctx, "events", "ul-dup", string(types.EventLabelAdded), 2)
+		te.assertEventCount(t, ctx, "events", "ul-dup", string(types.EventLabelAdded), 0)
 	})
 
 	t.Run("all_ephemeral", func(t *testing.T) {

--- a/internal/storage/embeddeddolt/store.go
+++ b/internal/storage/embeddeddolt/store.go
@@ -757,7 +757,8 @@ func (s *EmbeddedDoltStore) FindWispDependentsRecursive(ctx context.Context, ids
 
 func (s *EmbeddedDoltStore) AddComment(ctx context.Context, issueID, actor, comment string) error {
 	return s.withConn(ctx, true, func(tx *sql.Tx) error {
-		return issueops.AddCommentEventInTx(ctx, tx, issueID, actor, comment)
+		_, err := issueops.AddIssueCommentInTx(ctx, tx, issueID, actor, comment)
+		return err
 	})
 }
 

--- a/internal/storage/embeddeddolt/transaction.go
+++ b/internal/storage/embeddeddolt/transaction.go
@@ -71,14 +71,12 @@ func (t *embeddedTransaction) CreateIssues(ctx context.Context, issues []*types.
 
 func (t *embeddedTransaction) UpdateIssue(ctx context.Context, id string, updates map[string]interface{}, actor string) error {
 	t.dirty.MarkDirty("issues")
-	t.dirty.MarkDirty("events")
 	_, err := issueops.UpdateIssueInTx(ctx, t.tx, id, updates, actor)
 	return err
 }
 
 func (t *embeddedTransaction) CloseIssue(ctx context.Context, id string, reason string, actor string, session string) error {
 	t.dirty.MarkDirty("issues")
-	t.dirty.MarkDirty("events")
 	_, err := issueops.CloseIssueInTx(ctx, t.tx, id, reason, actor, session)
 	return err
 }

--- a/internal/storage/issueops/bulk_ops.go
+++ b/internal/storage/issueops/bulk_ops.go
@@ -217,12 +217,12 @@ func DeleteIssuesBySourceRepoInTx(ctx context.Context, tx *sql.Tx, sourceRepo st
 //nolint:gosec // G201: table names are hardcoded
 func UpdateIssueIDInTx(ctx context.Context, tx *sql.Tx, oldID, newID string, issue *types.Issue, actor string) error {
 	if IsActiveWispInTx(ctx, tx, oldID) {
-		return updateWispIDInTx(ctx, tx, oldID, newID, issue, actor)
+		return updateWispIDInTx(ctx, tx, oldID, newID, issue)
 	}
-	return updateIssueIDInTx(ctx, tx, oldID, newID, issue, actor)
+	return updateIssueIDInTx(ctx, tx, oldID, newID, issue)
 }
 
-func updateIssueIDInTx(ctx context.Context, tx *sql.Tx, oldID, newID string, issue *types.Issue, actor string) error {
+func updateIssueIDInTx(ctx context.Context, tx *sql.Tx, oldID, newID string, issue *types.Issue) error {
 	now := time.Now().UTC()
 	result, err := tx.ExecContext(ctx, `
 		UPDATE issues
@@ -240,14 +240,10 @@ func updateIssueIDInTx(ctx context.Context, tx *sql.Tx, oldID, newID string, iss
 		return err
 	}
 
-	_, err = tx.ExecContext(ctx, `
-		INSERT INTO events (id, issue_id, event_type, actor, old_value, new_value)
-		VALUES (?, ?, 'renamed', ?, ?, ?)
-	`, NewEventID(), newID, actor, oldID, newID)
-	return err
+	return nil
 }
 
-func updateWispIDInTx(ctx context.Context, tx *sql.Tx, oldID, newID string, issue *types.Issue, actor string) error {
+func updateWispIDInTx(ctx context.Context, tx *sql.Tx, oldID, newID string, issue *types.Issue) error {
 	now := time.Now().UTC()
 	result, err := tx.ExecContext(ctx, `
 		UPDATE wisps
@@ -259,13 +255,6 @@ func updateWispIDInTx(ctx context.Context, tx *sql.Tx, oldID, newID string, issu
 	}
 	if rows, _ := result.RowsAffected(); rows == 0 {
 		return fmt.Errorf("wisp not found: %s", oldID)
-	}
-
-	if _, err = tx.ExecContext(ctx, `
-		INSERT INTO wisp_events (id, issue_id, event_type, actor, old_value, new_value)
-		VALUES (?, ?, 'renamed', ?, ?, ?)
-	`, NewEventID(), newID, actor, oldID, newID); err != nil {
-		return err
 	}
 
 	return UpdateWispIDInDependenciesInTx(ctx, tx, oldID, newID)

--- a/internal/storage/issueops/claim.go
+++ b/internal/storage/issueops/claim.go
@@ -3,7 +3,6 @@ package issueops
 import (
 	"context"
 	"database/sql"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"time"
@@ -30,7 +29,7 @@ type ClaimResult struct {
 //nolint:gosec // G201: table names come from WispTableRouting (hardcoded constants)
 func ClaimIssueInTx(ctx context.Context, tx DBTX, id string, actor string) (*ClaimResult, error) {
 	isWisp := IsActiveWispInTx(ctx, tx, id)
-	issueTable, _, eventTable, _ := WispTableRouting(isWisp)
+	issueTable, _, _, _ := WispTableRouting(isWisp)
 
 	// Read old issue inside the transaction for event recording.
 	oldIssue, err := GetIssueInTx(ctx, tx, id)
@@ -91,18 +90,6 @@ func ClaimIssueInTx(ctx context.Context, tx DBTX, id string, actor string) (*Cla
 			return nil, fmt.Errorf("%w by %s", storage.ErrAlreadyClaimed, assignee)
 		}
 		return nil, fmt.Errorf("%w: status %s", storage.ErrNotClaimable, currentStatus)
-	}
-
-	// Record the claim event.
-	oldData, _ := json.Marshal(oldIssue)
-	newUpdates := map[string]interface{}{
-		"assignee": actor,
-		"status":   "in_progress",
-	}
-	newData, _ := json.Marshal(newUpdates)
-
-	if err := RecordFullEventInTable(ctx, tx, eventTable, id, "claimed", actor, string(oldData), string(newData)); err != nil {
-		return nil, fmt.Errorf("failed to record claim event: %w", err)
 	}
 
 	return &ClaimResult{OldIssue: oldIssue, IsWisp: isWisp}, nil

--- a/internal/storage/issueops/close.go
+++ b/internal/storage/issueops/close.go
@@ -15,8 +15,8 @@ type CloseResult struct {
 	AlreadyClosed bool
 }
 
-// CloseIssueInTx closes an issue within a transaction, setting status to closed
-// and recording the close event. Routes to the correct table (issues/wisps)
+// CloseIssueInTx closes an issue within a transaction, setting status to closed.
+// Routes to the correct table (issues/wisps)
 // automatically. The caller is responsible for Dolt versioning if needed.
 func CloseIssueInTx(ctx context.Context, tx DBTX, id string, reason, actor, session string) (*CloseResult, error) {
 	return closeIssueInTx(ctx, tx, id, reason, actor, session, true)
@@ -27,9 +27,9 @@ func CloseIssueWithoutEventInTx(ctx context.Context, tx DBTX, id string, reason,
 }
 
 //nolint:gosec // G201: table names come from WispTableRouting (hardcoded constants)
-func closeIssueInTx(ctx context.Context, tx DBTX, id string, reason, actor, session string, recordEvent bool) (*CloseResult, error) {
+func closeIssueInTx(ctx context.Context, tx DBTX, id string, reason, _ string, session string, _ bool) (*CloseResult, error) {
 	isWisp := IsActiveWispInTx(ctx, tx, id)
-	issueTable, _, eventTable, _ := WispTableRouting(isWisp)
+	issueTable, _, _, _ := WispTableRouting(isWisp)
 
 	var affectedIssues, affectedWisps []string
 	var aerr error
@@ -71,12 +71,6 @@ func closeIssueInTx(ctx context.Context, tx DBTX, id string, reason, actor, sess
 			return &CloseResult{IsWisp: isWisp, AlreadyClosed: true}, nil
 		}
 		return nil, fmt.Errorf("failed to close issue: %s", id)
-	}
-
-	if recordEvent {
-		if err := RecordEventInTable(ctx, tx, eventTable, id, types.EventClosed, actor, reason); err != nil {
-			return nil, fmt.Errorf("failed to record event: %w", err)
-		}
 	}
 
 	if err := RecomputeIsBlockedInTx(ctx, tx, affectedIssues, affectedWisps); err != nil {

--- a/internal/storage/issueops/comments.go
+++ b/internal/storage/issueops/comments.go
@@ -110,14 +110,14 @@ func GetCommentCountsInTx(ctx context.Context, tx *sql.Tx, issueIDs []string) (m
 // Routes to comments or wisp_comments based on wisp status.
 //
 //nolint:gosec // G201: table names come from hardcoded constants
-func AddIssueCommentInTx(ctx context.Context, tx *sql.Tx, issueID, author, text string) (*types.Comment, error) {
+func AddIssueCommentInTx(ctx context.Context, tx DBTX, issueID, author, text string) (*types.Comment, error) {
 	return ImportIssueCommentInTx(ctx, tx, issueID, author, text, time.Now().UTC())
 }
 
 // ImportIssueCommentInTx adds a comment preserving the original timestamp.
 //
 //nolint:gosec // G201: table names come from hardcoded constants
-func ImportIssueCommentInTx(ctx context.Context, tx *sql.Tx, issueID, author, text string, createdAt time.Time) (*types.Comment, error) {
+func ImportIssueCommentInTx(ctx context.Context, tx DBTX, issueID, author, text string, createdAt time.Time) (*types.Comment, error) {
 	isWisp := IsActiveWispInTx(ctx, tx, issueID)
 	issueTable, _, _, _ := WispTableRouting(isWisp)
 	commentTable := "comments"
@@ -153,19 +153,9 @@ func ImportIssueCommentInTx(ctx context.Context, tx *sql.Tx, issueID, author, te
 	}, nil
 }
 
-// AddCommentEventInTx adds a comment as an event to an issue within a transaction.
-// Routes to events or wisp_events based on wisp status.
-//
-//nolint:gosec // G201: table names come from WispTableRouting (hardcoded constants)
+// AddCommentEventInTx is the legacy annotation API. It now stores the text as a
+// structured issue comment instead of appending to events/wisp_events.
 func AddCommentEventInTx(ctx context.Context, tx DBTX, issueID, actor, comment string) error {
-	isWisp := IsActiveWispInTx(ctx, tx, issueID)
-	_, _, eventTable, _ := WispTableRouting(isWisp)
-
-	if _, err := tx.ExecContext(ctx, fmt.Sprintf(`
-		INSERT INTO %s (id, issue_id, event_type, actor, comment)
-		VALUES (?, ?, ?, ?, ?)
-	`, eventTable), NewEventID(), issueID, types.EventCommented, actor, comment); err != nil {
-		return fmt.Errorf("add comment event to %s: %w", eventTable, err)
-	}
-	return nil
+	_, err := AddIssueCommentInTx(ctx, tx, issueID, actor, comment)
+	return err
 }

--- a/internal/storage/issueops/create.go
+++ b/internal/storage/issueops/create.go
@@ -88,7 +88,7 @@ func CreateIssueInTxWithResult(ctx context.Context, tx *sql.Tx, bc *BatchContext
 		return result, err
 	}
 
-	issueTable, eventTable := TableRouting(issue)
+	issueTable, _ := TableRouting(issue)
 
 	if issue.ID == "" {
 		prefix := bc.ConfigPrefix
@@ -116,7 +116,7 @@ func CreateIssueInTxWithResult(ctx context.Context, tx *sql.Tx, bc *BatchContext
 		return result, nil
 	}
 
-	isNew, staleRejected, err := InsertIssueIfNew(ctx, tx, issueTable, issue, bc.Opts)
+	_, staleRejected, err := InsertIssueIfNew(ctx, tx, issueTable, issue, bc.Opts)
 	if err != nil {
 		return result, err
 	}
@@ -132,14 +132,7 @@ func CreateIssueInTxWithResult(ctx context.Context, tx *sql.Tx, bc *BatchContext
 	}
 	result.markChanged(issueTable)
 
-	if isNew {
-		if err := RecordEventInTable(ctx, tx, eventTable, issue.ID, types.EventCreated, actor, ""); err != nil {
-			return result, fmt.Errorf("failed to record event for %s: %w", issue.ID, err)
-		}
-		result.markChanged(eventTable)
-	}
-
-	labelResult, err := PersistLabels(ctx, tx, issue, actor, eventTable)
+	labelResult, err := PersistLabels(ctx, tx, issue)
 	if err != nil {
 		return result, err
 	}
@@ -564,7 +557,7 @@ func InsertIssueIfNew(ctx context.Context, tx *sql.Tx, issueTable string, issue 
 	return existingCount == 0, false, nil
 }
 
-func PersistLabels(ctx context.Context, tx *sql.Tx, issue *types.Issue, actor, eventTable string) (CreateIssueResult, error) {
+func PersistLabels(ctx context.Context, tx *sql.Tx, issue *types.Issue) (CreateIssueResult, error) {
 	var result CreateIssueResult
 	if len(issue.Labels) == 0 {
 		return result, nil
@@ -595,15 +588,6 @@ func PersistLabels(ctx context.Context, tx *sql.Tx, issue *types.Issue, actor, e
 			continue
 		}
 		result.markChanged(labelTable)
-		comment := "Added label: " + label
-		//nolint:gosec // G201: eventTable is determined by ephemeral flag
-		if _, err := tx.ExecContext(ctx, fmt.Sprintf(`
-			INSERT INTO %s (id, issue_id, event_type, actor, comment)
-			VALUES (?, ?, ?, ?, ?)
-		`, eventTable), NewEventID(), issue.ID, types.EventLabelAdded, actor, comment); err != nil {
-			return result, fmt.Errorf("failed to record label event %q for %s: %w", label, issue.ID, err)
-		}
-		result.markChanged(eventTable)
 	}
 	return result, nil
 }

--- a/internal/storage/issueops/helpers.go
+++ b/internal/storage/issueops/helpers.go
@@ -139,17 +139,10 @@ func insertIssueIntoTable(ctx context.Context, tx *sql.Tx, table string, issue *
 	return nil
 }
 
-// RecordEventInTable records an event in the specified events table.
-//
-//nolint:gosec // G201: table is a hardcoded constant ("events" or "wisp_events")
+// RecordEventInTable is kept as a compatibility hook for legacy callers.
+// Audit events are no longer appended to Dolt event tables; user-visible
+// comments belong in comments/wisp_comments.
 func RecordEventInTable(ctx context.Context, tx DBTX, table, issueID string, eventType types.EventType, actor, newValue string) error {
-	_, err := tx.ExecContext(ctx, fmt.Sprintf(`
-		INSERT INTO %s (id, issue_id, event_type, actor, old_value, new_value)
-		VALUES (?, ?, ?, ?, ?, ?)
-	`, table), NewEventID(), issueID, eventType, actor, "", newValue)
-	if err != nil {
-		return fmt.Errorf("record event in %s: %w", table, err)
-	}
 	return nil
 }
 

--- a/internal/storage/issueops/labels.go
+++ b/internal/storage/issueops/labels.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"fmt"
 	"strings"
-
-	"github.com/steveyegge/beads/internal/types"
 )
 
 // GetLabelsInTx retrieves all labels for an issue within an existing transaction.
@@ -128,7 +126,7 @@ func getLabelsIntoFromTable(ctx context.Context, tx DBTX, labelTable string, ids
 	return nil
 }
 
-// AddLabelInTx adds a label to an issue and records an event within an existing
+// AddLabelInTx adds a label to an issue within an existing
 // transaction. Automatically routes to wisp tables if the ID is an active wisp.
 // Uses INSERT IGNORE for idempotency.
 func AddLabelInTx(ctx context.Context, tx DBTX, labelTable, eventTable, issueID, label, actor string) error {
@@ -146,18 +144,11 @@ func AddLabelInTx(ctx context.Context, tx DBTX, labelTable, eventTable, issueID,
 	if _, err := tx.ExecContext(ctx, fmt.Sprintf(`INSERT IGNORE INTO %s (issue_id, label) VALUES (?, ?)`, labelTable), issueID, label); err != nil {
 		return fmt.Errorf("add label: %w", err)
 	}
-	comment := "Added label: " + label
-	//nolint:gosec // G201: eventTable is from WispTableRouting ("events" or "wisp_events")
-	if _, err := tx.ExecContext(ctx, fmt.Sprintf(`INSERT INTO %s (id, issue_id, event_type, actor, comment) VALUES (?, ?, ?, ?, ?)`, eventTable),
-		NewEventID(), issueID, types.EventLabelAdded, actor, comment); err != nil {
-		return fmt.Errorf("add label: record event: %w", err)
-	}
 	return nil
 }
 
-// RemoveLabelInTx removes a label from an issue and records an event within
-// an existing transaction. Automatically routes to wisp tables if the ID is
-// an active wisp.
+// RemoveLabelInTx removes a label from an issue within an existing transaction.
+// Automatically routes to wisp tables if the ID is an active wisp.
 //
 //nolint:gosec // G201: table names come from WispTableRouting (hardcoded constants)
 func RemoveLabelInTx(ctx context.Context, tx DBTX, labelTable, eventTable, issueID, label, actor string) error {
@@ -173,11 +164,6 @@ func RemoveLabelInTx(ctx context.Context, tx DBTX, labelTable, eventTable, issue
 	}
 	if _, err := tx.ExecContext(ctx, fmt.Sprintf(`DELETE FROM %s WHERE issue_id = ? AND label = ?`, labelTable), issueID, label); err != nil {
 		return fmt.Errorf("remove label: %w", err)
-	}
-	comment := "Removed label: " + label
-	if _, err := tx.ExecContext(ctx, fmt.Sprintf(`INSERT INTO %s (id, issue_id, event_type, actor, comment) VALUES (?, ?, ?, ?, ?)`, eventTable),
-		NewEventID(), issueID, types.EventLabelRemoved, actor, comment); err != nil {
-		return fmt.Errorf("remove label: record event: %w", err)
 	}
 	return nil
 }

--- a/internal/storage/issueops/promote.go
+++ b/internal/storage/issueops/promote.go
@@ -63,15 +63,8 @@ func PromoteFromEphemeralInTx(ctx context.Context, tx *sql.Tx, id string, actor 
 		return fmt.Errorf("delete copied wisp dependencies for promoted wisp %s: %w", id, err)
 	}
 
-	if _, err := tx.ExecContext(ctx, `
-		INSERT IGNORE INTO events (id, issue_id, event_type, actor, old_value, new_value, comment, created_at)
-		SELECT id, issue_id, event_type, actor, old_value, new_value, comment, created_at
-		FROM wisp_events WHERE issue_id = ?
-	`, id); err != nil {
-		return fmt.Errorf("copy events for promoted wisp %s: %w", id, err)
-	}
 	if _, err := tx.ExecContext(ctx, `DELETE FROM wisp_events WHERE issue_id = ?`, id); err != nil {
-		return fmt.Errorf("delete copied wisp events for promoted wisp %s: %w", id, err)
+		return fmt.Errorf("delete legacy wisp events for promoted wisp %s: %w", id, err)
 	}
 
 	if _, err := tx.ExecContext(ctx, `

--- a/internal/storage/issueops/reopen.go
+++ b/internal/storage/issueops/reopen.go
@@ -17,7 +17,7 @@ type ReopenResult struct {
 //nolint:gosec // G201: table names come from WispTableRouting (hardcoded constants)
 func ReopenIssueInTx(ctx context.Context, tx DBTX, id, reason, actor string) (*ReopenResult, error) {
 	isWisp := IsActiveWispInTx(ctx, tx, id)
-	issueTable, _, eventTable, _ := WispTableRouting(isWisp)
+	issueTable, _, _, _ := WispTableRouting(isWisp)
 
 	var affectedIssues, affectedWisps []string
 	var aerr error
@@ -59,10 +59,6 @@ func ReopenIssueInTx(ctx context.Context, tx DBTX, id, reason, actor string) (*R
 			return &ReopenResult{IsWisp: isWisp, AlreadyOpen: true}, nil
 		}
 		return nil, fmt.Errorf("failed to reopen issue: %s", id)
-	}
-
-	if err := RecordEventInTable(ctx, tx, eventTable, id, types.EventReopened, actor, reason); err != nil {
-		return nil, fmt.Errorf("failed to record event: %w", err)
 	}
 
 	if reason != "" {

--- a/internal/storage/issueops/update.go
+++ b/internal/storage/issueops/update.go
@@ -128,17 +128,16 @@ func UpdateIssueInTx(ctx context.Context, tx DBTX, id string, updates map[string
 	return updateIssueInTx(ctx, tx, id, updates, actor, true)
 }
 
-// UpdateIssueWithoutEventInTx applies normal update semantics without recording
-// an intermediate event. Demotion uses this to preserve the historical event
-// stream: create/update history is copied, then a single demotion event is added.
+// UpdateIssueWithoutEventInTx applies normal update semantics through the
+// compatibility path that used to skip audit event writes.
 func UpdateIssueWithoutEventInTx(ctx context.Context, tx DBTX, id string, updates map[string]interface{}, actor string) (*UpdateResult, error) {
 	return updateIssueInTx(ctx, tx, id, updates, actor, false)
 }
 
-func updateIssueInTx(ctx context.Context, tx DBTX, id string, updates map[string]interface{}, actor string, recordEvent bool) (*UpdateResult, error) {
+func updateIssueInTx(ctx context.Context, tx DBTX, id string, updates map[string]interface{}, _ string, _ bool) (*UpdateResult, error) {
 	// Route to correct table.
 	isWisp := IsActiveWispInTx(ctx, tx, id)
-	issueTable, _, eventTable, _ := WispTableRouting(isWisp)
+	issueTable, _, _, _ := WispTableRouting(isWisp)
 
 	// Read old issue inside the transaction for consistency.
 	oldIssue, err := GetIssueInTx(ctx, tx, id)
@@ -223,16 +222,6 @@ func updateIssueInTx(ctx context.Context, tx DBTX, id string, updates map[string
 		return nil, fmt.Errorf("failed to update issue: %w", err)
 	}
 
-	if recordEvent {
-		oldData, _ := json.Marshal(oldIssue)
-		newData, _ := json.Marshal(updates)
-		eventType := DetermineEventType(oldIssue, updates)
-
-		if err := RecordFullEventInTable(ctx, tx, eventTable, id, eventType, actor, string(oldData), string(newData)); err != nil {
-			return nil, fmt.Errorf("failed to record event: %w", err)
-		}
-	}
-
 	if rawStatus, hasStatus := updates["status"]; hasStatus {
 		var newStatus string
 		switch v := rawStatus.(type) {
@@ -263,16 +252,8 @@ func updateIssueInTx(ctx context.Context, tx DBTX, id string, updates map[string
 	return &UpdateResult{OldIssue: oldIssue, IsWisp: isWisp}, nil
 }
 
-// RecordFullEventInTable records an event with both old and new values.
-//
-//nolint:gosec // G201: table is from WispTableRouting ("events" or "wisp_events")
+// RecordFullEventInTable is kept as a compatibility hook for legacy callers.
+// Audit events are no longer appended to Dolt event tables.
 func RecordFullEventInTable(ctx context.Context, tx DBTX, table, issueID string, eventType types.EventType, actor, oldValue, newValue string) error {
-	_, err := tx.ExecContext(ctx, fmt.Sprintf(`
-		INSERT INTO %s (id, issue_id, event_type, actor, old_value, new_value)
-		VALUES (?, ?, ?, ?, ?, ?)
-	`, table), NewEventID(), issueID, eventType, actor, oldValue, newValue)
-	if err != nil {
-		return fmt.Errorf("record event in %s: %w", table, err)
-	}
 	return nil
 }


### PR DESCRIPTION
## Summary

- stop appending audit rows to Dolt `events` / `wisp_events` from normal create, update, close, reopen, claim, label, promotion, and demotion paths
- route legacy `AddComment`-style annotations to structured `comments` / `wisp_comments`
- retain legacy event table reads, counts, and deletes for existing rows and cleanup, with tests seeding legacy rows directly

## Testing

- `PATH="$(go env GOPATH)/bin:$PATH" make ci-pr-lint`
- `go test -tags gms_pure_go ./internal/storage/issueops ./internal/storage/domain/db ./internal/storage/dolt`
- `CGO_ENABLED=1 go test -tags gms_pure_go ./internal/storage/embeddeddolt ./cmd/bd`
- `git diff --check`

## Notes

I also attempted `make test` before final PR prep. It failed on failures that appear unrelated to this change: a root package server-mode test got an invalid connection response from `127.0.0.1:45455`, the aggregate `cmd/bd` package hit the 3 minute package timeout, and `internal/storage/dbproxy/server` saw `TestDoltServer_Dial_BeforeStart` return nil instead of an error. The affected packages listed above pass in isolation.
