### PR TITLE
fix(ado): preserve unmanaged links on push instead of clobbering them

### DIFF
--- a/cmd/bd/ado.go
+++ b/cmd/bd/ado.go
@@ -767,6 +767,24 @@ func pushADOLinks(ctx context.Context, resolver *ado.LinkResolver, at *ado.Track
 	var warnings []string
 	linkCount := 0
 
+	// Build the set of ADO work item IDs beads tracks. PushLinks only removes a
+	// current relation when its target is in this set, so links to items beads
+	// does not track (e.g. human-created Related / Predecessor-Successor links)
+	// are preserved rather than clobbered. See GH#4522.
+	managedTargets := make(map[int]bool)
+	for _, issue := range allIssues {
+		if issue.ExternalRef == nil {
+			continue
+		}
+		ref := *issue.ExternalRef
+		if !at.IsExternalRef(ref) {
+			continue
+		}
+		if id, cerr := strconv.Atoi(at.ExtractIdentifier(ref)); cerr == nil {
+			managedTargets[id] = true
+		}
+	}
+
 	for _, issue := range allIssues {
 		if issue.ExternalRef == nil {
 			continue
@@ -822,7 +840,7 @@ func pushADOLinks(ctx context.Context, resolver *ado.LinkResolver, at *ado.Track
 			continue
 		}
 
-		errs := resolver.PushLinks(ctx, workItemID, items[0].Relations, desired)
+		errs := resolver.PushLinks(ctx, workItemID, items[0].Relations, desired, managedTargets)
 		for _, e := range errs {
 			msg := fmt.Sprintf("Link sync ADO #%d: %v", workItemID, e)
 			warnings = append(warnings, msg)

--- a/internal/ado/links.go
+++ b/internal/ado/links.go
@@ -184,12 +184,34 @@ type adoLinkKey struct {
 	Commented bool // true if the link has a discovered-from comment
 }
 
+// removableRelTypes are the forward-direction ADO relation types beads emits
+// and therefore owns. Only links of these types may be removed during push.
+//
+// Reverse-direction link types — Hierarchy-Reverse (parent) and
+// Dependency-Reverse (predecessor/successor) — are deliberately excluded:
+// beads represents those relationships via the forward link on the *other*
+// work item, so they never appear in the desired set and must not be deleted.
+// Likewise, any other relation type (hyperlinks, attachments, custom link
+// types) is left untouched. See GH#4522.
+var removableRelTypes = map[string]bool{
+	RelDependsOn: true, // Dependency-Forward
+	RelChild:     true, // Hierarchy-Forward
+	RelRelated:   true, // Related
+}
+
 // PushLinks synchronizes beads dependencies to ADO work item relations.
 // It compares the desired state (from beads deps) against current ADO relations,
 // adding missing links and removing stale ones for idempotent convergence.
 // Errors on individual links are collected and returned together; processing
 // continues on partial failures.
-func (r *LinkResolver) PushLinks(ctx context.Context, workItemID int, currentRelations []WorkItemRelation, desiredDeps []tracker.DependencyInfo) []error {
+//
+// managedTargets is the set of ADO work item IDs that beads tracks. A current
+// link is only removed when beads owns it: its relation type is one beads emits
+// (see removableRelTypes) AND its target is in managedTargets. This read-merge-
+// write behavior preserves links beads does not manage — reverse-direction
+// links and human-created Related/Predecessor-Successor links to untracked
+// items — instead of clobbering them. See GH#4522.
+func (r *LinkResolver) PushLinks(ctx context.Context, workItemID int, currentRelations []WorkItemRelation, desiredDeps []tracker.DependencyInfo, managedTargets map[int]bool) []error {
 	// Build desired link set.
 	desired := make(map[adoLinkKey]tracker.DependencyInfo)
 	for _, dep := range desiredDeps {
@@ -234,12 +256,23 @@ func (r *LinkResolver) PushLinks(ctx context.Context, workItemID int, currentRel
 	var errs []error
 
 	// Find relations to remove (in current but not desired).
+	// Only remove links beads owns: a forward-direction type it emits, pointing
+	// at a work item beads tracks. Reverse-direction links and links to
+	// untracked items (e.g. human-created Related / Predecessor-Successor links)
+	// are left untouched so the push does not clobber them. See GH#4522.
 	// Collect indices and remove in reverse order to avoid index shifting.
 	var removeIndices []int
 	for _, cl := range current {
-		if _, ok := desired[cl.key]; !ok {
-			removeIndices = append(removeIndices, cl.index)
+		if _, ok := desired[cl.key]; ok {
+			continue
 		}
+		if !removableRelTypes[cl.key.Rel] {
+			continue
+		}
+		if !managedTargets[cl.key.TargetID] {
+			continue
+		}
+		removeIndices = append(removeIndices, cl.index)
 	}
 	// Sort descending so higher indices are removed first.
 	sort.Sort(sort.Reverse(sort.IntSlice(removeIndices)))

--- a/internal/ado/links_test.go
+++ b/internal/ado/links_test.go
@@ -388,7 +388,7 @@ func TestPushLinks_AddMissing(t *testing.T) {
 		{FromExternalID: "100", ToExternalID: "300", Type: "parent"},
 	}
 
-	errs := resolver.PushLinks(context.Background(), 100, nil, desired)
+	errs := resolver.PushLinks(context.Background(), 100, nil, desired, nil)
 	if len(errs) != 0 {
 		t.Fatalf("unexpected errors: %v", errs)
 	}
@@ -453,8 +453,9 @@ func TestPushLinks_RemoveStale(t *testing.T) {
 		},
 	}
 
-	// No desired deps → both should be removed.
-	errs := resolver.PushLinks(context.Background(), 100, currentRelations, nil)
+	// No desired deps, but both targets are tracked → both should be removed.
+	managedTargets := map[int]bool{200: true, 300: true}
+	errs := resolver.PushLinks(context.Background(), 100, currentRelations, nil, managedTargets)
 	if len(errs) != 0 {
 		t.Fatalf("unexpected errors: %v", errs)
 	}
@@ -477,6 +478,65 @@ func TestPushLinks_RemoveStale(t *testing.T) {
 		if call.ops[0].Op != "remove" {
 			t.Errorf("call %d: op = %q, want %q", i, call.ops[0].Op, "remove")
 		}
+	}
+}
+
+// TestPushLinks_PreservesUnmanagedLinks is the regression test for GH#4522:
+// a push must not delete links beads does not own. That includes
+// reverse-direction links (Dependency-Reverse predecessor/successor and
+// Hierarchy-Reverse parent), which beads represents via the forward link on
+// the other work item, and forward links pointing at items beads does not
+// track (e.g. human-created Related links to work items outside the synced
+// set). None of these may be removed even though they are absent from the
+// desired set.
+func TestPushLinks_PreservesUnmanagedLinks(t *testing.T) {
+	var mu sync.Mutex
+	var patchCalls []patchCall
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPatch {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		body, _ := io.ReadAll(r.Body)
+		var ops []PatchOperation
+		_ = json.Unmarshal(body, &ops)
+		mu.Lock()
+		patchCalls = append(patchCalls, patchCall{ops: ops})
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	t.Cleanup(ts.Close)
+
+	client, err := NewClient(NewSecretString("pat"), "org", "proj").
+		WithBaseURL(ts.URL)
+	if err != nil {
+		t.Fatalf("WithBaseURL error: %v", err)
+	}
+	client = client.WithHTTPClient(ts.Client())
+	resolver := NewLinkResolver(client)
+
+	currentRelations := []WorkItemRelation{
+		// Reverse-direction predecessor/successor link to a tracked item.
+		{Rel: RelDependencyOf, URL: ts.URL + "/proj/_apis/wit/workitems/200"},
+		// Reverse-direction parent link to a tracked item.
+		{Rel: RelParent, URL: ts.URL + "/proj/_apis/wit/workitems/300"},
+		// Forward Related link to an UNtracked item (e.g. created by a human).
+		{Rel: RelRelated, URL: ts.URL + "/proj/_apis/wit/workitems/400"},
+	}
+
+	// 200 and 300 are tracked; 400 is not. No desired deps at all.
+	managedTargets := map[int]bool{200: true, 300: true}
+	errs := resolver.PushLinks(context.Background(), 100, currentRelations, nil, managedTargets)
+	if len(errs) != 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(patchCalls) != 0 {
+		t.Fatalf("got %d PATCH calls, want 0 (no unmanaged link should be removed): %+v", len(patchCalls), patchCalls)
 	}
 }
 
@@ -508,7 +568,7 @@ func TestPushLinks_Idempotent(t *testing.T) {
 		{FromExternalID: "100", ToExternalID: "200", Type: "blocks"},
 	}
 
-	errs := resolver.PushLinks(context.Background(), 100, currentRelations, desired)
+	errs := resolver.PushLinks(context.Background(), 100, currentRelations, desired, map[int]bool{200: true})
 	if len(errs) != 0 {
 		t.Fatalf("unexpected errors: %v", errs)
 	}
@@ -552,7 +612,7 @@ func TestPushLinks_PartialFailure(t *testing.T) {
 		{FromExternalID: "100", ToExternalID: "300", Type: "related"},
 	}
 
-	errs := resolver.PushLinks(context.Background(), 100, nil, desired)
+	errs := resolver.PushLinks(context.Background(), 100, nil, desired, nil)
 
 	// Should have exactly 1 error (first call failed, second succeeded).
 	if len(errs) != 1 {
@@ -719,7 +779,7 @@ func TestPushLinks_InvalidExternalID(t *testing.T) {
 		{FromExternalID: "100", ToExternalID: "200", Type: "related"},
 	}
 
-	errs := resolver.PushLinks(context.Background(), 100, nil, desired)
+	errs := resolver.PushLinks(context.Background(), 100, nil, desired, nil)
 	if len(errs) != 0 {
 		t.Fatalf("unexpected errors: %v", errs)
 	}
@@ -770,8 +830,9 @@ func TestPushLinks_RemoveFailure(t *testing.T) {
 		},
 	}
 
-	// No desired deps → both should be removed, but first fails.
-	errs := resolver.PushLinks(context.Background(), 100, currentRelations, nil)
+	// No desired deps, both targets tracked → both should be removed, first fails.
+	managedTargets := map[int]bool{200: true, 300: true}
+	errs := resolver.PushLinks(context.Background(), 100, currentRelations, nil, managedTargets)
 
 	if len(errs) != 1 {
 		t.Fatalf("got %d errors, want 1: %v", len(errs), errs)


### PR DESCRIPTION
## Problem

Fixes #4522. `bd ado push` (and `bd ado sync --push-only`) silently **deletes Related and Predecessor/Successor links** on the work items it pushes — and, because a scoped push re-asserts the parent link, on the **parent** work item too. Links a human created in ADO disappear the first time bd pushes a status change.

## Root cause

`LinkResolver.PushLinks` built the *desired* relation set only from the forward-direction link types beads emits — `Dependency-Forward`, `Hierarchy-Forward`, `Related` — targeting beads-tracked items, then removed **any** `System.LinkTypes.*` relation not in that set. That swept away two classes of links beads does not manage:

- **Reverse-direction links**: `Dependency-Reverse` (predecessor/successor) and `Hierarchy-Reverse` (parent-on-child). beads represents these relationships via the *forward* link on the **other** work item, so they never appear in the desired set — and were unconditionally deleted on every push.
- **Forward links to untracked items**: e.g. a `Related` link a human added in ADO to a work item outside the beads-synced set. The push call site filters these out of the desired set, so they were deleted too.

## Fix

Make push **read-merge-write** (as suggested in the issue): only remove a current relation when beads actually owns it —

1. its relation type is one beads emits (`removableRelTypes`: `Dependency-Forward`, `Hierarchy-Forward`, `Related`), **and**
2. its target is a beads-tracked work item (`managedTargets`, threaded in from `pushADOLinks`).

Every other relation — reverse-direction links, links to untracked items, hyperlinks, attachments, custom link types — is left untouched. Genuine deletion-sync of beads-owned links between tracked items still works.

## Tests

- New `TestPushLinks_PreservesUnmanagedLinks` asserts a push removes **zero** links when the work item carries only reverse-direction links (to tracked items) and a `Related` link to an untracked item. Verified it fails before the fix (3 spurious `remove` ops — exactly the reported data loss) and passes after.
- Existing `PushLinks` tests updated for the new `managedTargets` parameter; the remove-stale tests now pass the tracked-target set so deletion-sync of owned links is still covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)