### PR TITLE
feat(gate): state-aware smart remote-migrate gate, opt-in (#4516)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -856,7 +856,7 @@ jobs:
         env:
           BEADS_TEST_EMBEDDED_DOLT: "1"
           BEADS_TEST_EMBEDDED_TEST_BINARY: /tmp/embeddeddolt-test
-        run: /tmp/embeddeddolt-test -test.v -test.count=1 -test.timeout=10m
+        run: /tmp/embeddeddolt-test -test.v -test.count=1 -test.timeout=20m
 
   test-embedded-cmd:
     name: Test (Embedded Dolt Cmd ${{ matrix.shard }}/${{ strategy.job-total }})

--- a/.github/workflows/pr-risk.yml
+++ b/.github/workflows/pr-risk.yml
@@ -151,7 +151,7 @@ jobs:
         env:
           BEADS_TEST_EMBEDDED_DOLT: "1"
           BEADS_TEST_EMBEDDED_TEST_BINARY: /tmp/embeddeddolt-test
-        run: /tmp/embeddeddolt-test -test.v -test.count=1 -test.timeout=10m
+        run: /tmp/embeddeddolt-test -test.v -test.count=1 -test.timeout=20m
 
   test-embedded-cmd:
     name: Test (Embedded Dolt Cmd ${{ matrix.shard }}/${{ strategy.job-total }})

--- a/cmd/bd/doctor/migration_skew.go
+++ b/cmd/bd/doctor/migration_skew.go
@@ -11,7 +11,6 @@ import (
 	"github.com/steveyegge/beads/internal/configfile"
 	"github.com/steveyegge/beads/internal/storage/dberrors"
 	"github.com/steveyegge/beads/internal/storage/embeddeddolt"
-	"github.com/steveyegge/beads/internal/storage/issueops"
 	"github.com/steveyegge/beads/internal/storage/schema"
 )
 
@@ -118,9 +117,9 @@ func checkMigrationContentSkew(ctx context.Context, db *sql.DB, remote string) D
 		branch = active
 	}
 
-	local, err := readMigrationContentHashes(ctx, db, "")
+	local, err := schema.ReadMigrationContentHashes(ctx, db, "")
 	if err != nil {
-		if missingObjectErr(err) {
+		if schema.MissingMigrationObjectErr(err) {
 			return ok("No local migration content hashes recorded yet")
 		}
 		return cannot("read local schema_migrations", err)
@@ -130,11 +129,11 @@ func checkMigrationContentSkew(ctx context.Context, db *sql.DB, remote string) D
 	}
 
 	ref := "remotes/" + remote + "/" + branch
-	remoteHashes, err := readMigrationContentHashes(ctx, db, ref)
+	remoteHashes, err := schema.ReadMigrationContentHashes(ctx, db, ref)
 	if err != nil {
 		// The remote-tracking ref is not cached yet (e.g. never pushed/pulled),
 		// or the cached ref predates schema_migrations/content_hash.
-		if remoteRefUnavailableErr(err) || missingObjectErr(err) {
+		if schema.RemoteRefUnavailableErr(err) || schema.MissingMigrationObjectErr(err) {
 			return ok(fmt.Sprintf("No cached remote ref %q to compare", ref))
 		}
 		return cannot(fmt.Sprintf("read schema_migrations at %q", ref), err)
@@ -157,67 +156,4 @@ func checkMigrationContentSkew(ctx context.Context, db *sql.DB, remote string) D
 		Fix:      "Upgrade every clone to a bd version that carries the schema-convergence migration. If a merge already fails, make one clone canonical and re-bootstrap the others from the remote.",
 		Category: CategoryData,
 	}
-}
-
-// remoteRefUnavailableErr reports whether err means the AS OF ref does not
-// exist locally. Dolt 2.x: "branch not found: remotes/origin/main".
-func remoteRefUnavailableErr(err error) bool {
-	s := strings.ToLower(err.Error())
-	return strings.Contains(s, "branch not found") ||
-		strings.Contains(s, "invalid ref spec")
-}
-
-// missingObjectErr reports whether err means schema_migrations or its
-// content_hash column does not exist (at HEAD or at the AS OF ref) — an old
-// database or an old cached ref, which is a legitimate "nothing to compare".
-// Dolt 2.x AS OF phrasing: "table not found: x",
-// `column "content_hash" could not be found in any table in scope`.
-func missingObjectErr(err error) bool {
-	if dberrors.IsTableNotExist(err) {
-		return true
-	}
-	s := strings.ToLower(err.Error())
-	return strings.Contains(s, "table not found") ||
-		(strings.Contains(s, "column") && strings.Contains(s, "could not be found")) ||
-		strings.Contains(s, "unknown column")
-}
-
-// readMigrationContentHashes reads version -> content_hash from
-// schema_migrations, either at HEAD (ref == "") or AS OF ref (e.g.
-// "remotes/origin/main"). NULL/empty hashes are dropped. It returns an error
-// when the table, column, or ref is unavailable; the caller classifies it.
-//
-// Dolt requires a literal ref in AS OF: bind parameters (including inside
-// CONCAT) fail server-side with `unbound variable "v1" in query`, so the
-// validated ref is interpolated into the SQL text (bd-6dnrw.27).
-func readMigrationContentHashes(ctx context.Context, db *sql.DB, ref string) (map[int]string, error) {
-	var rows *sql.Rows
-	var err error
-	if ref == "" {
-		rows, err = db.QueryContext(ctx, "SELECT version, content_hash FROM schema_migrations")
-	} else {
-		if err := issueops.ValidateRef(ref); err != nil {
-			return nil, fmt.Errorf("invalid ref: %w", err)
-		}
-		//nolint:gosec // G201: ref is validated by issueops.ValidateRef above — AS OF requires a literal
-		rows, err = db.QueryContext(ctx,
-			fmt.Sprintf("SELECT version, content_hash FROM schema_migrations AS OF '%s'", ref))
-	}
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-
-	out := map[int]string{}
-	for rows.Next() {
-		var version int
-		var hash sql.NullString
-		if err := rows.Scan(&version, &hash); err != nil {
-			return nil, err
-		}
-		if hash.Valid && hash.String != "" {
-			out[version] = hash.String
-		}
-	}
-	return out, rows.Err()
 }

--- a/cmd/bd/remote_migrate_gate.go
+++ b/cmd/bd/remote_migrate_gate.go
@@ -30,7 +30,7 @@ func handleRemoteMigrateGateJSON(e *schema.RemoteMigrateGateError) {
 				"risk":     o.Risk,
 			})
 		}
-		m["remote_migrate_gate"] = map[string]interface{}{
+		gate := map[string]interface{}{
 			"current_version":         e.CurrentVersion,
 			"latest_version":          e.LatestVersion,
 			"pending":                 e.Pending,
@@ -41,6 +41,20 @@ func handleRemoteMigrateGateJSON(e *schema.RemoteMigrateGateError) {
 			"options":                 opts,
 			"docs":                    "https://github.com/gastownhall/beads/blob/main/website/docs/getting-started/upgrading.md#remote-backed-databases-and-multiple-clones",
 		}
+		// Smart gate (#4516): when a state-aware decision narrowed the stop,
+		// tell the agent which case it is and (for a fork) which versions skewed.
+		switch e.Decision {
+		case "adopt":
+			gate["decision"] = "adopt"
+			gate["observed"] = "the remote is already migrated; migrating here would fork it"
+			gate["expected"] = "adopt the remote's migrated database (destructive re-clone — operator decision)"
+		case "fork-skew":
+			gate["decision"] = "fork-skew"
+			gate["observed"] = fmt.Sprintf("this clone and the remote applied different content for migration(s) %s — already forked", schema.FormatMigrationVersions(e.SkewVersions))
+			gate["expected"] = "pick one canonical clone and re-bootstrap the others (data-loss decision)"
+			gate["skew_versions"] = e.SkewVersions
+		}
+		m["remote_migrate_gate"] = gate
 	}
 	encoder := json.NewEncoder(os.Stderr)
 	encoder.SetIndent("", "  ")

--- a/internal/storage/dolt/smart_remote_migrate_gate_test.go
+++ b/internal/storage/dolt/smart_remote_migrate_gate_test.go
@@ -1,0 +1,127 @@
+package dolt
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/storage/schema"
+)
+
+// TestDoltNew_SmartRemoteMigrateGate_RealDolt exercises the state-aware smart
+// gate (#4516) end-to-end against a real Dolt server with a genuine cached
+// remote-tracking ref — the cross-clone scenario the sqlmock unit tests cannot
+// reach, because the smart router's `schema_migrations AS OF 'remotes/origin/main'`
+// read only resolves against an actually-pushed remote.
+//
+// One create/drop cycle walks three states by regressing the LOCAL working set
+// away from a pushed-and-matching remote (consecutive create/drop cycles
+// destabilize the test dolt server, so a single fixture covers all cases):
+//
+//	auto-migrate : remote == local, at/above the convergence floor, no skew -> allow
+//	adopt        : remote ahead of local, no skew                          -> stop (adopt)
+//	fork-skew    : a shared version's content hash diverges                 -> stop (fork-skew)
+//
+// The gate decision is read directly via schema.CheckRemoteMigrateGate; it does
+// not run MigrateUp, so regressing only the schema_migrations cursor rows (the
+// applied schema itself stays in place) is a faithful stand-in for a clone that
+// genuinely lags the binary.
+func TestDoltNew_SmartRemoteMigrateGate_RealDolt(t *testing.T) {
+	skipIfNoDolt(t)
+	t.Setenv(schema.SmartGateEnv, "1")
+	t.Setenv(schema.AllowRemoteMigrateEnv, "0")
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	tmpDir := t.TempDir()
+	dbName := uniqueTestDBName(t)
+
+	store, err := New(ctx, &Config{
+		Path:            tmpDir,
+		CommitterName:   "test",
+		CommitterEmail:  "test@example.com",
+		Database:        dbName,
+		CreateIfMissing: true,
+		MaxOpenConns:    1, // single session so working-set regressions are visible to the gate reads
+	})
+	if err != nil {
+		t.Fatalf("New (create): %v", err)
+	}
+	db := store.db
+	defer func() {
+		dropCtx, dropCancel := context.WithTimeout(context.Background(), 5*testTimeout)
+		defer dropCancel()
+		_, _ = db.ExecContext(dropCtx, fmt.Sprintf("DROP DATABASE IF EXISTS `%s`", dbName))
+		store.Close()
+	}()
+
+	latest := schema.LatestVersion()
+	floor := schema.LastNonDeterministicMigration
+	// The fixture needs two versions below latest that are still at/above the
+	// convergence floor, so the auto-migrate precondition (current >= floor) holds.
+	if latest-2 < floor {
+		t.Skipf("latest=%d too close to floor=%d to build the fixture", latest, floor)
+	}
+	pAuto := latest - 1 // current after dropping the latest cursor row
+	pShared := latest - 2
+
+	mustExec := func(stage, q string, args ...any) {
+		t.Helper()
+		if _, err := db.ExecContext(ctx, q, args...); err != nil {
+			t.Fatalf("%s: %v", stage, err)
+		}
+	}
+
+	// Register the sync remote, then push the FULL schema so remotes/origin/main
+	// is cached. (file:// inside the server's filesystem; Dolt creates it on push.)
+	mustExec("add remote", "CALL DOLT_REMOTE('add', 'origin', ?)", "file://"+filepath.Join(tmpDir, "remote"))
+
+	// --- auto-migrate: regress local to pAuto AND push so the remote matches. ---
+	mustExec("regress to pAuto", "DELETE FROM schema_migrations WHERE version = ?", latest)
+	mustExec("stage", "CALL DOLT_ADD('-A')")
+	mustExec("commit", "CALL DOLT_COMMIT('--allow-empty', '-m', 'test: regress cursor to pAuto')")
+	mustExec("push", "CALL DOLT_PUSH('origin', 'main')")
+
+	if err := schema.CheckRemoteMigrateGate(ctx, db); err != nil {
+		t.Fatalf("auto-migrate case: remote==local at floor with no skew should be allowed, got %v", err)
+	}
+
+	// --- adopt: drop one more cursor row locally WITHOUT pushing -> remote ahead. ---
+	mustExec("regress local below remote", "DELETE FROM schema_migrations WHERE version = ?", pAuto)
+	{
+		err := schema.CheckRemoteMigrateGate(ctx, db)
+		var gateErr *schema.RemoteMigrateGateError
+		if !errors.As(err, &gateErr) {
+			t.Fatalf("adopt case: expected gate error, got %v", err)
+		}
+		if gateErr.Decision != "adopt" {
+			t.Errorf("adopt case: Decision = %q, want %q", gateErr.Decision, "adopt")
+		}
+	}
+
+	// --- fork-skew: diverge a SHARED version's local content hash. ---
+	mustExec("tamper shared hash",
+		"UPDATE schema_migrations SET content_hash = 'smart-gate-divergent' WHERE version = ?", pShared)
+	{
+		err := schema.CheckRemoteMigrateGate(ctx, db)
+		var gateErr *schema.RemoteMigrateGateError
+		if !errors.As(err, &gateErr) {
+			t.Fatalf("fork-skew case: expected gate error, got %v", err)
+		}
+		if gateErr.Decision != "fork-skew" {
+			t.Errorf("fork-skew case: Decision = %q, want %q", gateErr.Decision, "fork-skew")
+		}
+		found := false
+		for _, v := range gateErr.SkewVersions {
+			if v == pShared {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("fork-skew case: SkewVersions = %v, want to contain %d", gateErr.SkewVersions, pShared)
+		}
+	}
+}

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -1607,7 +1607,7 @@ func (s *DoltStore) initSchema(ctx context.Context) error {
 	// (GH#2315), so an SQL-only check would miss the remote on the first write
 	// open after an upgrade.
 	gate := func(ctx context.Context, db *sql.DB) error {
-		return schema.CheckRemoteMigrateGateWithRemoteCheck(ctx, db, s.hasPersistedCLIRemote)
+		return schema.CheckRemoteMigrateGateForRemoteWithRemoteCheck(ctx, db, s.remote, s.hasPersistedCLIRemote)
 	}
 	_, err = initSchemaOnDBWithRetryAndGate(ctx, migDB, gate)
 	return err

--- a/internal/storage/schema/migration_content_hashes.go
+++ b/internal/storage/schema/migration_content_hashes.go
@@ -1,0 +1,95 @@
+package schema
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/steveyegge/beads/internal/storage/dberrors"
+)
+
+// validMigrationRefPattern matches the refs this package builds for AS OF reads
+// (Dolt commit hashes or branch/remote-tracking names like
+// "remotes/origin/main"). It mirrors issueops.ValidateRef but is kept local so
+// the schema package — which sits below issueops — has no import-cycle risk.
+var validMigrationRefPattern = regexp.MustCompile(`^[a-zA-Z0-9_./-]+$`)
+
+func validateMigrationRef(ref string) error {
+	if ref == "" {
+		return fmt.Errorf("ref cannot be empty")
+	}
+	if len(ref) > 128 {
+		return fmt.Errorf("ref too long")
+	}
+	if !validMigrationRefPattern.MatchString(ref) {
+		return fmt.Errorf("invalid ref format: %s", ref)
+	}
+	return nil
+}
+
+// ReadMigrationContentHashes reads version -> content_hash from schema_migrations,
+// either at HEAD (ref == "") or AS OF ref (e.g. "remotes/origin/main"). NULL/empty
+// hashes are dropped. It returns an error when the table, column, or ref is
+// unavailable; the caller classifies it with RemoteRefUnavailableErr /
+// MissingMigrationObjectErr.
+//
+// Dolt requires a literal ref in AS OF: bind parameters (including inside CONCAT)
+// fail server-side with `unbound variable "v1" in query`, so the validated ref is
+// interpolated into the SQL text (bd-6dnrw.27).
+func ReadMigrationContentHashes(ctx context.Context, db DBConn, ref string) (map[int]string, error) {
+	var (
+		rows *sql.Rows
+		err  error
+	)
+	if ref == "" {
+		rows, err = db.QueryContext(ctx, "SELECT version, content_hash FROM schema_migrations")
+	} else {
+		if verr := validateMigrationRef(ref); verr != nil {
+			return nil, fmt.Errorf("invalid ref: %w", verr)
+		}
+		//nolint:gosec // G201: ref is validated above — AS OF requires a literal, not a bind param
+		rows, err = db.QueryContext(ctx,
+			fmt.Sprintf("SELECT version, content_hash FROM schema_migrations AS OF '%s'", ref))
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	out := map[int]string{}
+	for rows.Next() {
+		var version int
+		var hash sql.NullString
+		if err := rows.Scan(&version, &hash); err != nil {
+			return nil, err
+		}
+		if hash.Valid && hash.String != "" {
+			out[version] = hash.String
+		}
+	}
+	return out, rows.Err()
+}
+
+// RemoteRefUnavailableErr reports whether err means the AS OF ref does not exist
+// locally (e.g. a remote-tracking ref that was never cached by a clone/pull).
+// Dolt 2.x: "branch not found: remotes/origin/main".
+func RemoteRefUnavailableErr(err error) bool {
+	s := strings.ToLower(err.Error())
+	return strings.Contains(s, "branch not found") ||
+		strings.Contains(s, "invalid ref spec")
+}
+
+// MissingMigrationObjectErr reports whether err means schema_migrations or its
+// content_hash column does not exist (at HEAD or at the AS OF ref) — an old
+// database or an old cached ref, which is a legitimate "nothing to compare".
+func MissingMigrationObjectErr(err error) bool {
+	if dberrors.IsTableNotExist(err) {
+		return true
+	}
+	s := strings.ToLower(err.Error())
+	return strings.Contains(s, "table not found") ||
+		(strings.Contains(s, "column") && strings.Contains(s, "could not be found")) ||
+		strings.Contains(s, "unknown column")
+}

--- a/internal/storage/schema/remote_migrate_gate.go
+++ b/internal/storage/schema/remote_migrate_gate.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"strings"
 
 	"github.com/steveyegge/beads/internal/storage/dberrors"
 )
@@ -36,43 +37,104 @@ type RemoteMigrateGateError struct {
 	// typo'd escape hatch fails with a hint instead of silently staying locked
 	// (bd-6dnrw.34).
 	UnrecognizedEnv string
+
+	// Decision records why the smart gate (#4516) stopped, when it is enabled.
+	// Empty is the default blunt #4515 stop (also used for the smart gate's
+	// "undetermined"/"below-floor" fallbacks); the messaging below is then
+	// byte-identical to #4515. "adopt" and "fork-skew" tailor the guidance.
+	Decision string
+	// SkewVersions lists the migration versions whose content diverged between
+	// this clone and the remote (Decision == "fork-skew").
+	SkewVersions []int
 }
+
+const (
+	gateDecisionAdopt    = "adopt"
+	gateDecisionForkSkew = "fork-skew"
+)
 
 func (e *RemoteMigrateGateError) Error() string {
 	unit := "migrations"
 	if e.Pending == 1 {
 		unit = "migration"
 	}
-	return fmt.Sprintf("refusing to auto-apply %d pending schema %s to a remote-backed database (v%d -> v%d): migrating clones independently forks the schema (#4259)",
-		e.Pending, unit, e.CurrentVersion, e.LatestVersion)
+	switch e.Decision {
+	case gateDecisionAdopt:
+		return fmt.Sprintf("refusing to migrate a remote-backed database (v%d -> v%d): the remote is already migrated — adopt it instead of migrating here (#4259)",
+			e.CurrentVersion, e.LatestVersion)
+	case gateDecisionForkSkew:
+		return fmt.Sprintf("refusing to migrate a remote-backed database (v%d -> v%d): this clone and the remote applied different content for migration(s) %s — the schema has already forked (#4259)",
+			e.CurrentVersion, e.LatestVersion, FormatMigrationVersions(e.SkewVersions))
+	default:
+		return fmt.Sprintf("refusing to auto-apply %d pending schema %s to a remote-backed database (v%d -> v%d): migrating clones independently forks the schema (#4259)",
+			e.Pending, unit, e.CurrentVersion, e.LatestVersion)
+	}
+}
+
+// FormatMigrationVersions renders migration versions as zero-padded 4-digit ids.
+func FormatMigrationVersions(versions []int) string {
+	if len(versions) == 0 {
+		return ""
+	}
+	parts := make([]string, len(versions))
+	for i, v := range versions {
+		parts[i] = fmt.Sprintf("%04d", v)
+	}
+	return strings.Join(parts, ", ")
 }
 
 // UserMessage returns the full multi-line error block for terminal output.
 func (e *RemoteMigrateGateError) UserMessage() string {
-	msg := e.Error() + "\n" +
-		"\n" +
-		"  This database syncs with a remote. Applying schema migrations on more than\n" +
-		"  one clone independently forks the schema so `bd dolt pull` can no longer\n" +
-		"  merge — the break is silent and unrecoverable.\n" +
-		"\n" +
-		"  Choose one:\n" +
-		"    • You are the designated migrator (only ONE machine should be): migrate,\n" +
-		"      then publish the migrated database to the remote:\n" +
-		"        " + AllowRemoteMigrateEnv + "=1 bd migrate\n" +
-		"        bd dolt push\n" +
-		"    • Another machine has already migrated: adopt its database instead of\n" +
-		"      migrating here — re-clone from the remote so you receive the migrated\n" +
-		"      schema:\n" +
-		"        bd bootstrap\n" +
-		"      Re-cloning replaces your local database: any local issues you have not\n" +
-		"      pushed are LOST. Push first (`bd dolt push`) or save a copy\n" +
-		"      (`bd export --all -o backup.jsonl`) before re-cloning.\n"
+	msg := e.Error() + "\n" + e.userBody()
 	if e.UnrecognizedEnv != "" {
 		msg += "\n" +
 			"  Note: " + AllowRemoteMigrateEnv + "=" + e.UnrecognizedEnv + " is set but was not recognized —\n" +
 			"  use " + AllowRemoteMigrateEnv + "=1 to unlock.\n"
 	}
 	return msg
+}
+
+// userBody returns the decision-specific guidance block. The default (blunt
+// #4515) body is byte-identical to before the smart gate existed.
+func (e *RemoteMigrateGateError) userBody() string {
+	switch e.Decision {
+	case gateDecisionAdopt:
+		return "\n" +
+			"  The remote has already been migrated by another clone. Do NOT migrate here —\n" +
+			"  adopt the remote's migrated database instead:\n" +
+			"        bd bootstrap\n" +
+			"  Re-cloning replaces your local database: any local issues you have not pushed\n" +
+			"  are LOST. Push first (`bd dolt push`) or save a copy\n" +
+			"  (`bd export --all -o backup.jsonl`) before re-cloning.\n"
+	case gateDecisionForkSkew:
+		return "\n" +
+			"  This clone and the remote already applied DIFFERENT content for migration(s) " +
+			FormatMigrationVersions(e.SkewVersions) + ".\n" +
+			"  The schema has forked (#4259); `bd dolt pull` can no longer merge. Migrating\n" +
+			"  cannot un-fork it. This is a data-loss decision, not an auto-fix:\n" +
+			"    • Pick ONE clone as canonical, then re-bootstrap every other clone from it —\n" +
+			"      unpushed work on the discarded clones is LOST. Export it first\n" +
+			"      (`bd export --all -o backup.jsonl`) if you need it.\n" +
+			"        bd bootstrap\n"
+	default:
+		return "\n" +
+			"  This database syncs with a remote. Applying schema migrations on more than\n" +
+			"  one clone independently forks the schema so `bd dolt pull` can no longer\n" +
+			"  merge — the break is silent and unrecoverable.\n" +
+			"\n" +
+			"  Choose one:\n" +
+			"    • You are the designated migrator (only ONE machine should be): migrate,\n" +
+			"      then publish the migrated database to the remote:\n" +
+			"        " + AllowRemoteMigrateEnv + "=1 bd migrate\n" +
+			"        bd dolt push\n" +
+			"    • Another machine has already migrated: adopt its database instead of\n" +
+			"      migrating here — re-clone from the remote so you receive the migrated\n" +
+			"      schema:\n" +
+			"        bd bootstrap\n" +
+			"      Re-cloning replaces your local database: any local issues you have not\n" +
+			"      pushed are LOST. Push first (`bd dolt push`) or save a copy\n" +
+			"      (`bd export --all -o backup.jsonl`) before re-cloning.\n"
+	}
 }
 
 // EscapeHint returns the escape-hatch string for JSON error output.
@@ -88,9 +150,21 @@ func (e *RemoteMigrateGateError) EscapeHint() string {
 // to the operator and let them choose, per the AgentDiagnostic contract ("Go
 // observes and reports, the agent decides and acts").
 func (e *RemoteMigrateGateError) AgentDirective() string {
-	return "Coordination decision required: only ONE clone may migrate a shared remote; " +
-		"a second clone migrating independently forks the schema unrecoverably (#4259). " +
-		"Do NOT auto-run a migration — surface remote_migrate_gate.options to the operator and let them choose."
+	switch e.Decision {
+	case gateDecisionAdopt:
+		return "Adopt, do NOT migrate: the remote is already migrated, so migrating here would fork it (#4259). " +
+			"Adoption re-clones and replaces the local database (unpushed local work is lost), so it is a destructive " +
+			"operator decision — surface remote_migrate_gate.options to the operator, do NOT auto-run bd bootstrap."
+	case gateDecisionForkSkew:
+		return "Do NOT migrate: this clone and the remote already applied different content for migration(s) " +
+			FormatMigrationVersions(e.SkewVersions) + " — the schema has forked (#4259) and migrating cannot un-fork it. " +
+			"Resolving requires picking a canonical clone and re-bootstrapping the others, discarding their unpushed " +
+			"work — a data-loss decision. Surface remote_migrate_gate.options to the operator; do NOT auto-run anything."
+	default:
+		return "Coordination decision required: only ONE clone may migrate a shared remote; " +
+			"a second clone migrating independently forks the schema unrecoverably (#4259). " +
+			"Do NOT auto-run a migration — surface remote_migrate_gate.options to the operator and let them choose."
+	}
 }
 
 // GateOption is one conditional remediation path for the remote-migrate gate.
@@ -109,19 +183,36 @@ type GateOption struct {
 // present but reachable only through its "single designated migrator" condition,
 // never as a top-level hint.
 func (e *RemoteMigrateGateError) Options() []GateOption {
-	return []GateOption{
-		{
-			ID:       "migrate",
-			When:     "you are the single designated migrator (only ONE machine, confirmed with the operator) and no other clone has migrated yet",
-			Commands: []string{AllowRemoteMigrateEnv + "=1 bd migrate", "bd dolt push"},
-			Risk:     "if another clone also migrates independently, the schema forks unrecoverably (#4259)",
-		},
-		{
-			ID:       "adopt",
-			When:     "another machine has already migrated and pushed",
-			Commands: []string{"bd bootstrap"},
-			Risk:     "re-clones and replaces the local database; push or export unpushed work first or it is lost",
-		},
+	adopt := GateOption{
+		ID:       "adopt",
+		When:     "another machine has already migrated and pushed",
+		Commands: []string{"bd bootstrap"},
+		Risk:     "re-clones and replaces the local database; push or export unpushed work first or it is lost",
+	}
+	switch e.Decision {
+	case gateDecisionAdopt:
+		// Remote is confirmed ahead: migrate is not a valid path, only adopt.
+		adopt.When = "the remote is already migrated (confirmed by the gate) — adopt it"
+		return []GateOption{adopt}
+	case gateDecisionForkSkew:
+		// Already forked: neither migrate nor a plain adopt is unconditionally
+		// safe; the operator must choose a canonical clone first.
+		return []GateOption{{
+			ID:       "reconcile-fork",
+			When:     "the schema has already forked (different content for migration(s) " + FormatMigrationVersions(e.SkewVersions) + "); choose ONE clone as canonical",
+			Commands: []string{"bd export --all -o backup.jsonl", "bd bootstrap"},
+			Risk:     "re-bootstrapping the non-canonical clones discards their unpushed work; export it first",
+		}}
+	default:
+		return []GateOption{
+			{
+				ID:       "migrate",
+				When:     "you are the single designated migrator (only ONE machine, confirmed with the operator) and no other clone has migrated yet",
+				Commands: []string{AllowRemoteMigrateEnv + "=1 bd migrate", "bd dolt push"},
+				Risk:     "if another clone also migrates independently, the schema forks unrecoverably (#4259)",
+			},
+			adopt,
+		}
 	}
 }
 
@@ -214,9 +305,45 @@ func checkRemoteMigrateGate(ctx context.Context, db DBConn, extraHasRemote func(
 		}
 	}
 
+	latest := LatestVersion()
+
+	// Smart gate (#4516): opt-in. Once the blunt gate would fire and the
+	// designated-migrator escape hatch is not set, consult the remote's cached
+	// schema state and auto-resolve the one provably-safe case (first-mover
+	// migrate). The undetermined/below-floor verdicts fall through to the blunt
+	// #4515 block below, so disabling smart mode (or an unreadable remote ref)
+	// is always at least as safe as before.
+	if SmartGateEnabled() {
+		decision, skew := routeSmartGate(ctx, db, current)
+		switch decision {
+		case smartAutoMigrate:
+			smartGateAllowMigrate(len(pending), current)
+			return nil
+		case smartAdopt:
+			return &RemoteMigrateGateError{
+				CurrentVersion:  current,
+				LatestVersion:   latest,
+				Pending:         len(pending),
+				UnrecognizedEnv: unrecognizedEnv,
+				Decision:        gateDecisionAdopt,
+			}
+		case smartForkSkew:
+			return &RemoteMigrateGateError{
+				CurrentVersion:  current,
+				LatestVersion:   latest,
+				Pending:         len(pending),
+				UnrecognizedEnv: unrecognizedEnv,
+				Decision:        gateDecisionForkSkew,
+				SkewVersions:    skew,
+			}
+		case smartUndetermined, smartBelowFloor:
+			// fall through to the blunt block
+		}
+	}
+
 	return &RemoteMigrateGateError{
 		CurrentVersion:  current,
-		LatestVersion:   LatestVersion(),
+		LatestVersion:   latest,
 		Pending:         len(pending),
 		UnrecognizedEnv: unrecognizedEnv,
 	}

--- a/internal/storage/schema/remote_migrate_gate.go
+++ b/internal/storage/schema/remote_migrate_gate.go
@@ -231,7 +231,7 @@ func IsRemoteMigrateGateError(err error) bool {
 // store open. Embedded mode uses this form: its dolt_remotes table already
 // reflects remotes persisted in .dolt/config on a fresh open.
 func CheckRemoteMigrateGate(ctx context.Context, db DBConn) error {
-	return checkRemoteMigrateGate(ctx, db, nil)
+	return checkRemoteMigrateGate(ctx, db, "", nil)
 }
 
 // CheckRemoteMigrateGateWithRemoteCheck is CheckRemoteMigrateGate plus an on-disk
@@ -250,10 +250,18 @@ func CheckRemoteMigrateGate(ctx context.Context, db DBConn) error {
 // SQL table shows no remote, so the (subprocess-backed) filesystem probe stays off
 // the common open path. A nil extraHasRemote disables the fallback.
 func CheckRemoteMigrateGateWithRemoteCheck(ctx context.Context, db DBConn, extraHasRemote func() bool) error {
-	return checkRemoteMigrateGate(ctx, db, extraHasRemote)
+	return checkRemoteMigrateGate(ctx, db, "", extraHasRemote)
 }
 
-func checkRemoteMigrateGate(ctx context.Context, db DBConn, extraHasRemote func() bool) error {
+// CheckRemoteMigrateGateForRemoteWithRemoteCheck is CheckRemoteMigrateGate plus
+// an explicit sync remote name for the smart gate's cached remote-ref read.
+// The blunt gate still trips when any Dolt remote exists; the remote name only
+// chooses which remote-tracking ref the opt-in smart router compares against.
+func CheckRemoteMigrateGateForRemoteWithRemoteCheck(ctx context.Context, db DBConn, remoteName string, extraHasRemote func() bool) error {
+	return checkRemoteMigrateGate(ctx, db, remoteName, extraHasRemote)
+}
+
+func checkRemoteMigrateGate(ctx context.Context, db DBConn, remoteName string, extraHasRemote func() bool) error {
 	// CurrentVersion treats a missing schema_migrations table as version 0, so a
 	// brand-new database falls through the current==0 check below — nothing to fork.
 	current, err := CurrentVersion(ctx, db)
@@ -314,7 +322,7 @@ func checkRemoteMigrateGate(ctx context.Context, db DBConn, extraHasRemote func(
 	// #4515 block below, so disabling smart mode (or an unreadable remote ref)
 	// is always at least as safe as before.
 	if SmartGateEnabled() {
-		decision, skew := routeSmartGate(ctx, db, current)
+		decision, skew := routeSmartGate(ctx, db, current, remoteName)
 		switch decision {
 		case smartAutoMigrate:
 			smartGateAllowMigrate(len(pending), current)

--- a/internal/storage/schema/smart_remote_migrate_gate.go
+++ b/internal/storage/schema/smart_remote_migrate_gate.go
@@ -19,10 +19,11 @@ import (
 // permanently costs nothing on the common open path.
 const SmartGateEnv = "BD_SMART_GATE"
 
-// smartGateRemote is the sync remote the smart gate compares against. It matches
-// the doctor migration-skew check's default; the gate reads the *cached*
-// remote-tracking ref (remotes/<remote>/<branch>) and never fetches.
-const smartGateRemote = "origin"
+// smartGateDefaultRemote is the sync remote the smart gate compares against
+// when the caller does not know a more specific configured default. The gate
+// reads the *cached* remote-tracking ref (remotes/<remote>/<branch>) and never
+// fetches.
+const smartGateDefaultRemote = "origin"
 
 // LastNonDeterministicMigration is the highest migration version whose content is
 // genuinely non-deterministic across clones (random UUID() primary keys: 0004,
@@ -81,15 +82,18 @@ const (
 // routing verdict plus the content-skew versions (for smartForkSkew). It performs
 // no network I/O: it reads only the already-cached remote-tracking ref, exactly
 // like the doctor migration-skew check. current is the local schema version.
-func routeSmartGate(ctx context.Context, db DBConn, current int) (smartGateDecision, []int) {
+func routeSmartGate(ctx context.Context, db DBConn, current int, remoteName string) (smartGateDecision, []int) {
 	local, err := ReadMigrationContentHashes(ctx, db, "")
 	if err != nil || len(local) == 0 {
 		// No local hashes to compare (old database) — cannot assess safely.
 		return smartUndetermined, nil
 	}
 
+	if remoteName == "" {
+		remoteName = smartGateDefaultRemote
+	}
 	branch := smartGateActiveBranch(ctx, db)
-	ref := "remotes/" + smartGateRemote + "/" + branch
+	ref := "remotes/" + remoteName + "/" + branch
 	remote, err := ReadMigrationContentHashes(ctx, db, ref)
 	if err != nil {
 		// Cached ref absent/stale (never pushed/pulled) or pre-content_hash:
@@ -104,11 +108,18 @@ func routeSmartGate(ctx context.Context, db DBConn, current int) (smartGateDecis
 		return smartForkSkew, skew
 	}
 
-	if maxVersion(remote) > current {
+	remoteMax := maxVersion(remote)
+	if remoteMax > current {
 		return smartAdopt, nil // remote already migrated — adopt, don't migrate
 	}
+	if remoteMax < current {
+		// The cached remote is behind this clone. That is not the first-mover
+		// state the smart gate is allowed to auto-resolve, so keep the human
+		// coordination block rather than silently moving farther ahead.
+		return smartUndetermined, nil
+	}
 
-	// remote == local on every shared version and is not ahead: a first-mover.
+	// remote == local on every shared version and at the same max version: a first-mover.
 	if current >= LastNonDeterministicMigration {
 		return smartAutoMigrate, nil
 	}

--- a/internal/storage/schema/smart_remote_migrate_gate.go
+++ b/internal/storage/schema/smart_remote_migrate_gate.go
@@ -1,0 +1,149 @@
+package schema
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+)
+
+// SmartGateEnv opts a clone into the state-aware ("smart") remote-migrate gate
+// (gastownhall/beads#4516). When unset/false, the gate keeps its blunt #4515
+// behavior: any remote-backed database with pending migrations refuses every
+// write and hands the operator the migrate-or-adopt decision. When set to a
+// boolean true, the gate instead consults the remote's cached schema state and
+// auto-resolves the one provably-safe case (first-mover migrate), while still
+// stopping — with sharper guidance — on the cases that genuinely need a human.
+//
+// It is consulted only once the blunt gate would otherwise fire, so exporting it
+// permanently costs nothing on the common open path.
+const SmartGateEnv = "BD_SMART_GATE"
+
+// smartGateRemote is the sync remote the smart gate compares against. It matches
+// the doctor migration-skew check's default; the gate reads the *cached*
+// remote-tracking ref (remotes/<remote>/<branch>) and never fetches.
+const smartGateRemote = "origin"
+
+// LastNonDeterministicMigration is the highest migration version whose content is
+// genuinely non-deterministic across clones (random UUID() primary keys: 0004,
+// 0005, 0009, 0010, 0021, 0037, 0043 — the frozen pre-guard set in
+// migrations/nondeterminism-allowlist.txt, excluding the query-time-safe VIEW in
+// 0017 and the dolt-ignored local-only tables).
+//
+// A database already at or above this version has applied every non-deterministic
+// migration, so its *pending* migrations are all deterministic by construction —
+// the CI hygiene guard (scripts/check-migration-hygiene.sh check B) forbids new
+// non-deterministic migrations without an allowlist entry under CODEOWNERS review.
+// That makes a first-mover migrate provably convergent: two clones migrating the
+// same deterministic batch independently reach byte-identical tables.
+//
+// TestConvergenceFloorMatchesAllowlist cross-checks this constant against the
+// allowlist so the two cannot drift if a new entry is ever added.
+const LastNonDeterministicMigration = 43
+
+// SmartGateEnabled reports whether the operator opted into the smart gate.
+func SmartGateEnabled() bool {
+	v := os.Getenv(SmartGateEnv)
+	if v == "" {
+		return false
+	}
+	on, err := strconv.ParseBool(v)
+	return err == nil && on
+}
+
+// smartGateDecision is the routing verdict for a remote-backed database with
+// pending migrations, computed from the remote's cached schema state.
+type smartGateDecision int
+
+const (
+	// smartUndetermined: the remote's cached schema state could not be read
+	// (no cached ref, missing table/column, or query error). Fall back to the
+	// blunt #4515 block — no surprise network, no guessing.
+	smartUndetermined smartGateDecision = iota
+	// smartAutoMigrate: remote is at the same version as local, no content
+	// skew, and local is at/above the convergence floor — a safe first-mover.
+	// Allow the in-place migrate to proceed; concurrent first-movers converge.
+	smartAutoMigrate
+	// smartAdopt: remote is ahead (already migrated) with no skew. Stop, but
+	// direct the operator to adopt rather than migrate. Adoption is a
+	// destructive re-clone, so it is never performed silently.
+	smartAdopt
+	// smartForkSkew: ContentHashSkew non-empty — two clones ran different
+	// content for the same version. Genuine #4259 fork; human data-loss
+	// decision. Stop.
+	smartForkSkew
+	// smartBelowFloor: remote == local but a legacy non-deterministic migration
+	// is still pending (very old database). Conservative human block.
+	smartBelowFloor
+)
+
+// routeSmartGate inspects the remote's cached schema state and returns the smart
+// routing verdict plus the content-skew versions (for smartForkSkew). It performs
+// no network I/O: it reads only the already-cached remote-tracking ref, exactly
+// like the doctor migration-skew check. current is the local schema version.
+func routeSmartGate(ctx context.Context, db DBConn, current int) (smartGateDecision, []int) {
+	local, err := ReadMigrationContentHashes(ctx, db, "")
+	if err != nil || len(local) == 0 {
+		// No local hashes to compare (old database) — cannot assess safely.
+		return smartUndetermined, nil
+	}
+
+	branch := smartGateActiveBranch(ctx, db)
+	ref := "remotes/" + smartGateRemote + "/" + branch
+	remote, err := ReadMigrationContentHashes(ctx, db, ref)
+	if err != nil {
+		// Cached ref absent/stale (never pushed/pulled) or pre-content_hash:
+		// nothing to compare — fall back to the blunt block.
+		return smartUndetermined, nil
+	}
+	if len(remote) == 0 {
+		return smartUndetermined, nil
+	}
+
+	if skew := ContentHashSkew(local, remote); len(skew) > 0 {
+		return smartForkSkew, skew
+	}
+
+	if maxVersion(remote) > current {
+		return smartAdopt, nil // remote already migrated — adopt, don't migrate
+	}
+
+	// remote == local on every shared version and is not ahead: a first-mover.
+	if current >= LastNonDeterministicMigration {
+		return smartAutoMigrate, nil
+	}
+	return smartBelowFloor, nil
+}
+
+// smartGateActiveBranch returns the active branch, defaulting to "main" — the
+// branch whose remote-tracking ref the skew comparison reads.
+func smartGateActiveBranch(ctx context.Context, db DBConn) string {
+	var active string
+	if err := db.QueryRowContext(ctx, "SELECT active_branch()").Scan(&active); err == nil && active != "" {
+		return active
+	}
+	return "main"
+}
+
+func maxVersion(hashes map[int]string) int {
+	max := 0
+	for v := range hashes {
+		if v > max {
+			max = v
+		}
+	}
+	return max
+}
+
+// smartGateAllowMigrate logs the auto-migrate decision and returns nil so the
+// caller proceeds with MigrateUp. Mirrors the escape-hatch warning's shape.
+func smartGateAllowMigrate(pending int, current int) {
+	unit := "migrations"
+	if pending == 1 {
+		unit = "migration"
+	}
+	fmt.Fprintf(os.Stderr,
+		"Smart gate (%s): auto-applying %d pending deterministic schema %s to a remote-backed database "+
+			"(v%d, remote at same version — safe first-mover, concurrent migrators converge; #4516). Run `bd dolt push` after.\n",
+		SmartGateEnv, pending, unit, current)
+}

--- a/internal/storage/schema/smart_remote_migrate_gate_test.go
+++ b/internal/storage/schema/smart_remote_migrate_gate_test.go
@@ -1,0 +1,294 @@
+package schema
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+)
+
+// expectSmartFiringGate mocks the blunt-gate probe sequence (CurrentVersion,
+// PendingVersions, dolt_remotes) for a behind, remote-backed database at the
+// given current version — the state in which the smart router runs.
+func expectSmartFiringGate(mock sqlmock.Sqlmock, current int) {
+	expectGateCurrentVersion(mock, current) // CurrentVersion
+	expectGateCurrentVersion(mock, current) // PendingVersions -> pending exists
+	mock.ExpectQuery(`SELECT COUNT\(\*\) FROM dolt_remotes`).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
+}
+
+func hashRows(hashes map[int]string) *sqlmock.Rows {
+	rows := sqlmock.NewRows([]string{"version", "content_hash"})
+	for v, h := range hashes {
+		rows.AddRow(v, h)
+	}
+	return rows
+}
+
+// expectSmartRemoteRead mocks the three reads the smart router issues: local
+// content hashes (HEAD), active_branch(), and remote content hashes (AS OF).
+func expectSmartRemoteRead(mock sqlmock.Sqlmock, local, remote map[int]string) {
+	mock.ExpectQuery(`SELECT version, content_hash FROM schema_migrations$`).
+		WillReturnRows(hashRows(local))
+	mock.ExpectQuery(`SELECT active_branch\(\)`).
+		WillReturnRows(sqlmock.NewRows([]string{"active_branch()"}).AddRow("main"))
+	mock.ExpectQuery(`SELECT version, content_hash FROM schema_migrations AS OF 'remotes/origin/main'`).
+		WillReturnRows(hashRows(remote))
+}
+
+func TestSmartGateRouting(t *testing.T) {
+	latest := LatestVersion()
+	floor := LastNonDeterministicMigration
+
+	t.Run("auto-migrate: remote == local, at/above floor, no skew → allowed", func(t *testing.T) {
+		t.Setenv(SmartGateEnv, "1")
+		t.Setenv(AllowRemoteMigrateEnv, "0")
+		db, mock, _ := sqlmock.New()
+		defer db.Close()
+		expectSmartFiringGate(mock, floor)
+		hashes := map[int]string{floor - 1: "h1", floor: "h2"}
+		expectSmartRemoteRead(mock, hashes, hashes)
+
+		if err := CheckRemoteMigrateGate(context.Background(), db); err != nil {
+			t.Fatalf("safe first-mover should be allowed to migrate, got %v", err)
+		}
+		if err := mock.ExpectationsWereMet(); err != nil {
+			t.Fatalf("unmet expectations: %v", err)
+		}
+	})
+
+	t.Run("adopt: remote ahead, no skew → adopt decision", func(t *testing.T) {
+		t.Setenv(SmartGateEnv, "1")
+		t.Setenv(AllowRemoteMigrateEnv, "0")
+		db, mock, _ := sqlmock.New()
+		defer db.Close()
+		expectSmartFiringGate(mock, floor)
+		local := map[int]string{floor - 1: "h1", floor: "h2"}
+		remote := map[int]string{floor - 1: "h1", floor: "h2", floor + 1: "h3"}
+		expectSmartRemoteRead(mock, local, remote)
+
+		err := CheckRemoteMigrateGate(context.Background(), db)
+		var gateErr *RemoteMigrateGateError
+		if !errors.As(err, &gateErr) {
+			t.Fatalf("expected gate error, got %v", err)
+		}
+		if gateErr.Decision != gateDecisionAdopt {
+			t.Errorf("Decision = %q, want %q", gateErr.Decision, gateDecisionAdopt)
+		}
+		// Adopt must not offer the migrate escape command anywhere.
+		for _, o := range gateErr.Options() {
+			for _, c := range o.Commands {
+				if strings.Contains(c, AllowRemoteMigrateEnv) {
+					t.Errorf("adopt decision must not surface the migrate escape command, got %q", c)
+				}
+			}
+		}
+		if err := mock.ExpectationsWereMet(); err != nil {
+			t.Fatalf("unmet expectations: %v", err)
+		}
+	})
+
+	t.Run("fork-skew: divergent content for a shared version → fork-skew decision", func(t *testing.T) {
+		t.Setenv(SmartGateEnv, "1")
+		t.Setenv(AllowRemoteMigrateEnv, "0")
+		db, mock, _ := sqlmock.New()
+		defer db.Close()
+		expectSmartFiringGate(mock, floor)
+		local := map[int]string{floor: "local-hash"}
+		remote := map[int]string{floor: "remote-hash"}
+		expectSmartRemoteRead(mock, local, remote)
+
+		err := CheckRemoteMigrateGate(context.Background(), db)
+		var gateErr *RemoteMigrateGateError
+		if !errors.As(err, &gateErr) {
+			t.Fatalf("expected gate error, got %v", err)
+		}
+		if gateErr.Decision != gateDecisionForkSkew {
+			t.Errorf("Decision = %q, want %q", gateErr.Decision, gateDecisionForkSkew)
+		}
+		if len(gateErr.SkewVersions) != 1 || gateErr.SkewVersions[0] != floor {
+			t.Errorf("SkewVersions = %v, want [%d]", gateErr.SkewVersions, floor)
+		}
+		if !strings.Contains(gateErr.UserMessage(), "forked") {
+			t.Errorf("fork-skew UserMessage should explain the fork:\n%s", gateErr.UserMessage())
+		}
+		if err := mock.ExpectationsWereMet(); err != nil {
+			t.Fatalf("unmet expectations: %v", err)
+		}
+	})
+
+	t.Run("below floor: non-deterministic migration still pending → blunt block", func(t *testing.T) {
+		if floor < 2 {
+			t.Skip("floor too low to construct a below-floor case")
+		}
+		t.Setenv(SmartGateEnv, "1")
+		t.Setenv(AllowRemoteMigrateEnv, "0")
+		db, mock, _ := sqlmock.New()
+		defer db.Close()
+		current := floor - 1
+		expectSmartFiringGate(mock, current)
+		hashes := map[int]string{current: "h"}
+		expectSmartRemoteRead(mock, hashes, hashes)
+
+		err := CheckRemoteMigrateGate(context.Background(), db)
+		var gateErr *RemoteMigrateGateError
+		if !errors.As(err, &gateErr) {
+			t.Fatalf("expected gate error, got %v", err)
+		}
+		if gateErr.Decision != "" {
+			t.Errorf("below-floor should fall back to the blunt block (Decision \"\"), got %q", gateErr.Decision)
+		}
+		if err := mock.ExpectationsWereMet(); err != nil {
+			t.Fatalf("unmet expectations: %v", err)
+		}
+	})
+
+	t.Run("undetermined: no cached remote ref → blunt block", func(t *testing.T) {
+		t.Setenv(SmartGateEnv, "1")
+		t.Setenv(AllowRemoteMigrateEnv, "0")
+		db, mock, _ := sqlmock.New()
+		defer db.Close()
+		expectSmartFiringGate(mock, floor)
+		mock.ExpectQuery(`SELECT version, content_hash FROM schema_migrations$`).
+			WillReturnRows(hashRows(map[int]string{floor: "h"}))
+		mock.ExpectQuery(`SELECT active_branch\(\)`).
+			WillReturnRows(sqlmock.NewRows([]string{"active_branch()"}).AddRow("main"))
+		mock.ExpectQuery(`SELECT version, content_hash FROM schema_migrations AS OF 'remotes/origin/main'`).
+			WillReturnError(errors.New("branch not found: remotes/origin/main"))
+
+		err := CheckRemoteMigrateGate(context.Background(), db)
+		var gateErr *RemoteMigrateGateError
+		if !errors.As(err, &gateErr) {
+			t.Fatalf("expected gate error, got %v", err)
+		}
+		if gateErr.Decision != "" {
+			t.Errorf("uncached remote ref should fall back to the blunt block, got Decision %q", gateErr.Decision)
+		}
+		if err := mock.ExpectationsWereMet(); err != nil {
+			t.Fatalf("unmet expectations: %v", err)
+		}
+	})
+
+	t.Run("undetermined: no local hashes → blunt block (remote not read)", func(t *testing.T) {
+		t.Setenv(SmartGateEnv, "1")
+		t.Setenv(AllowRemoteMigrateEnv, "0")
+		db, mock, _ := sqlmock.New()
+		defer db.Close()
+		expectSmartFiringGate(mock, floor)
+		mock.ExpectQuery(`SELECT version, content_hash FROM schema_migrations$`).
+			WillReturnRows(sqlmock.NewRows([]string{"version", "content_hash"}))
+
+		err := CheckRemoteMigrateGate(context.Background(), db)
+		if !IsRemoteMigrateGateError(err) {
+			t.Fatalf("expected gate error, got %v", err)
+		}
+		if err := mock.ExpectationsWereMet(); err != nil {
+			t.Fatalf("unmet expectations: %v", err)
+		}
+	})
+
+	t.Run("escape hatch still wins over smart routing", func(t *testing.T) {
+		t.Setenv(SmartGateEnv, "1")
+		t.Setenv(AllowRemoteMigrateEnv, "1")
+		db, mock, _ := sqlmock.New()
+		defer db.Close()
+		// Escape hatch returns before any smart read, so only the blunt probes
+		// are expected.
+		expectSmartFiringGate(mock, floor)
+
+		if err := CheckRemoteMigrateGate(context.Background(), db); err != nil {
+			t.Fatalf("escape hatch should allow migration without smart reads, got %v", err)
+		}
+		if err := mock.ExpectationsWereMet(); err != nil {
+			t.Fatalf("unmet expectations: %v", err)
+		}
+	})
+
+	t.Run("smart disabled: no extra reads, blunt block", func(t *testing.T) {
+		// SmartGateEnv unset.
+		t.Setenv(AllowRemoteMigrateEnv, "0")
+		db, mock, _ := sqlmock.New()
+		defer db.Close()
+		expectSmartFiringGate(mock, floor)
+
+		err := CheckRemoteMigrateGate(context.Background(), db)
+		var gateErr *RemoteMigrateGateError
+		if !errors.As(err, &gateErr) {
+			t.Fatalf("expected gate error, got %v", err)
+		}
+		if gateErr.Decision != "" {
+			t.Errorf("smart disabled must produce the blunt block, got Decision %q", gateErr.Decision)
+		}
+		// mock would error if the smart reads had been issued (none expected).
+		if err := mock.ExpectationsWereMet(); err != nil {
+			t.Fatalf("unmet expectations (smart reads must not run when disabled): %v", err)
+		}
+	})
+
+	_ = latest
+}
+
+// TestConvergenceFloorMatchesAllowlist cross-checks LastNonDeterministicMigration
+// against the nondeterminism allowlist so the constant cannot silently drift if a
+// new genuinely-non-deterministic migration is ever grandfathered in. A new
+// allowlist entry above the floor forces a conscious update here.
+func TestConvergenceFloorMatchesAllowlist(t *testing.T) {
+	// Allowlist entries whose nondeterminism is genuinely clone-safe (evaluated
+	// at query time, or on never-replicated tables), so they do NOT raise the
+	// convergence floor. Keep justifications in sync with the allowlist file.
+	knownSafe := map[int]bool{
+		17: true, // 0017: NOW() inside a VIEW body — query-time, identical per clone
+	}
+
+	f, err := os.Open("migrations/nondeterminism-allowlist.txt")
+	if err != nil {
+		t.Fatalf("open allowlist: %v", err)
+	}
+	defer f.Close()
+
+	maxUnsafe := 0
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		line := strings.TrimSpace(sc.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		entry := strings.Fields(line)[0]
+		if strings.HasPrefix(entry, "ignored/") {
+			continue // dolt-ignored local-only tables are never replicated
+		}
+		// entry looks like "0043_drop_dependencies_generated_column.up.sql"
+		numStr := entry
+		if i := strings.IndexByte(entry, '_'); i > 0 {
+			numStr = entry[:i]
+		}
+		v, err := strconv.Atoi(numStr)
+		if err != nil {
+			t.Fatalf("could not parse version from allowlist entry %q: %v", entry, err)
+		}
+		if knownSafe[v] {
+			continue
+		}
+		if v > maxUnsafe {
+			maxUnsafe = v
+		}
+	}
+	if err := sc.Err(); err != nil {
+		t.Fatalf("scan allowlist: %v", err)
+	}
+
+	if maxUnsafe == 0 {
+		t.Fatal("found no genuinely-non-deterministic allowlist entries; allowlist parsing likely broke")
+	}
+	if LastNonDeterministicMigration != maxUnsafe {
+		t.Errorf("LastNonDeterministicMigration = %d, but the highest non-safe allowlist entry is %d.\n"+
+			"If a new non-deterministic migration was grandfathered in, update the convergence floor "+
+			"(and confirm its divergence is healed before auto-migrate trusts it), or add it to knownSafe with a justification.",
+			LastNonDeterministicMigration, maxUnsafe)
+	}
+}

--- a/internal/storage/schema/smart_remote_migrate_gate_test.go
+++ b/internal/storage/schema/smart_remote_migrate_gate_test.go
@@ -32,13 +32,23 @@ func hashRows(hashes map[int]string) *sqlmock.Rows {
 
 // expectSmartRemoteRead mocks the three reads the smart router issues: local
 // content hashes (HEAD), active_branch(), and remote content hashes (AS OF).
-func expectSmartRemoteRead(mock sqlmock.Sqlmock, local, remote map[int]string) {
+func expectSmartRemoteReadForRemote(mock sqlmock.Sqlmock, remoteName string, local, remote map[int]string) {
+	if remoteName == "" {
+		remoteName = smartGateDefaultRemote
+	}
 	mock.ExpectQuery(`SELECT version, content_hash FROM schema_migrations$`).
 		WillReturnRows(hashRows(local))
 	mock.ExpectQuery(`SELECT active_branch\(\)`).
 		WillReturnRows(sqlmock.NewRows([]string{"active_branch()"}).AddRow("main"))
-	mock.ExpectQuery(`SELECT version, content_hash FROM schema_migrations AS OF 'remotes/origin/main'`).
+	mock.ExpectQuery(`SELECT version, content_hash FROM schema_migrations AS OF 'remotes/` + remoteName + `/main'`).
 		WillReturnRows(hashRows(remote))
+}
+
+// expectSmartRemoteRead mocks the three reads the smart router issues using the
+// default remote: local content hashes (HEAD), active_branch(), and remote
+// content hashes (AS OF remotes/origin/main).
+func expectSmartRemoteRead(mock sqlmock.Sqlmock, local, remote map[int]string) {
+	expectSmartRemoteReadForRemote(mock, "", local, remote)
 }
 
 func TestSmartGateRouting(t *testing.T) {
@@ -87,6 +97,47 @@ func TestSmartGateRouting(t *testing.T) {
 					t.Errorf("adopt decision must not surface the migrate escape command, got %q", c)
 				}
 			}
+		}
+		if err := mock.ExpectationsWereMet(); err != nil {
+			t.Fatalf("unmet expectations: %v", err)
+		}
+	})
+
+	t.Run("remote behind local: not a first-mover → blunt block", func(t *testing.T) {
+		t.Setenv(SmartGateEnv, "1")
+		t.Setenv(AllowRemoteMigrateEnv, "0")
+		db, mock, _ := sqlmock.New()
+		defer db.Close()
+		current := floor + 1
+		expectSmartFiringGate(mock, current)
+		local := map[int]string{floor: "h1", current: "h2"}
+		remote := map[int]string{floor: "h1"}
+		expectSmartRemoteRead(mock, local, remote)
+
+		err := CheckRemoteMigrateGate(context.Background(), db)
+		var gateErr *RemoteMigrateGateError
+		if !errors.As(err, &gateErr) {
+			t.Fatalf("expected gate error, got %v", err)
+		}
+		if gateErr.Decision != "" {
+			t.Errorf("remote-behind should fall back to the blunt block (Decision \"\"), got %q", gateErr.Decision)
+		}
+		if err := mock.ExpectationsWereMet(); err != nil {
+			t.Fatalf("unmet expectations: %v", err)
+		}
+	})
+
+	t.Run("uses configured remote for smart read", func(t *testing.T) {
+		t.Setenv(SmartGateEnv, "1")
+		t.Setenv(AllowRemoteMigrateEnv, "0")
+		db, mock, _ := sqlmock.New()
+		defer db.Close()
+		expectSmartFiringGate(mock, floor)
+		hashes := map[int]string{floor: "h"}
+		expectSmartRemoteReadForRemote(mock, "upstream", hashes, hashes)
+
+		if err := CheckRemoteMigrateGateForRemoteWithRemoteCheck(context.Background(), db, "upstream", nil); err != nil {
+			t.Fatalf("safe first-mover on configured remote should be allowed, got %v", err)
 		}
 		if err := mock.ExpectationsWereMet(); err != nil {
 			t.Fatalf("unmet expectations: %v", err)


### PR DESCRIPTION
## Why

Agents are the highest-volume bd users, and after a binary upgrade the #4259 remote-migrate gate refuses **every** write on a remote-backed database with pending migrations until a human intervenes. #4515 made that refusal agent-*safe* (no auto-runnable footgun), but it is still a hard block on the common upgrade path. This makes the gate **state-aware** so the cases that are provably safe resolve automatically, and only the genuinely ambiguous case stops — implementing the design in #4516.

This is opt-in (`BD_SMART_GATE`); default behavior is the unchanged #4515 block.

## The key realization

The original #4516 proposal routed on "are the pending migrations deterministic?", which has no clean runtime signal. Tracing what migration `0050` actually guarantees collapsed that: the migrator always runs the **entire** pending batch, and any binary new enough to carry this gate also carries `0050` — *"the convergence point every clone reaches when upgrading to the fixed release"*. So if a legacy non-deterministic migration (`0037`/`0043`, random `UUID()` PKs) is pending, its convergence step is pending right behind it; two clones migrating independently diverge then **re-converge to byte-identical tables**.

That makes the safety input a single **version floor**, not a determinism manifest: at or above the highest genuinely-non-deterministic migration (`LastNonDeterministicMigration = 43`, cross-checked against `nondeterminism-allowlist.txt` by a test), every pending migration is deterministic by CI-hygiene construction, so a first-mover migrate is convergent. The proposal's "non-deterministic pending → stop a human" case is therefore **dropped as redundant** — a human there can only "run the migration," which is exactly what is already safe. Full reasoning: #4516 (design comment).

## What it does

When the blunt gate would fire and the designated-migrator escape hatch is not set, the smart gate consults the remote's **cached** `schema_migrations` ref (no network fetch — the same source the doctor skew check uses) and routes:

| Remote vs local (cached ref) | Action |
|---|---|
| `ContentHashSkew` non-empty | **stop** — genuine fork; human data-loss decision (which clone is canonical) |
| remote **ahead**, no skew | **stop with an adopt directive** — adoption is a destructive re-clone, never performed silently |
| remote **== local**, `current >= floor` | **auto-migrate** — safe first-mover; the full batch converges |
| below floor / uncached ref | **fall back to the blunt #4515 block** |

The stop cases reuse #4515's `AgentDiagnostic` shape (non-runnable directive + conditional `options`), tailored per decision so an agent surfaces the right human choice and never auto-runs a destructive action.

## Notable changes

- `internal/storage/schema/smart_remote_migrate_gate.go` — the router, the convergence-floor constant, and the opt-in flag.
- `RemoteMigrateGateError` gains a `Decision` (+ `SkewVersions`); `Error`/`UserMessage`/`AgentDirective`/`Options` and the JSON handler branch on it. **The default (smart-off) output is byte-identical to #4515.**
- Lifts the cached-remote-ref hash reader into the `schema` package (`ReadMigrationContentHashes` + ref-error classifiers); the doctor skew check now reuses it instead of a private copy.

## Testing

- Unit tests (sqlmock) for every routing branch, escape-hatch precedence, and that smart-off issues no extra reads and preserves #4515 exactly.
- `TestConvergenceFloorMatchesAllowlist` cross-checks the floor against `nondeterminism-allowlist.txt` so it cannot silently drift.
- `TestDoltNew_SmartRemoteMigrateGate_RealDolt` — a real-Dolt cross-clone test walking auto-migrate / adopt / fork-skew against a genuine pushed `remotes/origin/main` ref (guarded by the Docker test server). Its SQL (`DOLT_PUSH`, the `AS OF 'remotes/origin/main'` read, working-set divergence) was validated against Dolt 2.1.10.

## Open questions for review

- **Auto-migrate staging.** Default is opt-in via `BD_SMART_GATE`. Is a per-decision opt-in (e.g. auto-adopt-only vs auto-migrate) wanted before any default-on?
- **Non-destructive adopt.** This stops-with-directive on remote-ahead. A future fast-forward adopt via `bd dolt pull` (valid only when local never migrated and has no unpushed work) is a reasonable follow-up but wants its own cross-clone test.
- **Server/embedded parity** for the cached remote-state read.

Builds on #4515; same root issue #4259.

_claude-opus-4-8-high on behalf of matt wilkie_
