### PR TITLE
fix(storage): wrap storage.ErrNotFound in CloseIssue for sentinel parity

### DIFF
--- a/internal/storage/dolt/dolt_test.go
+++ b/internal/storage/dolt/dolt_test.go
@@ -627,6 +627,26 @@ func TestDoltStoreIssueClose(t *testing.T) {
 	}
 }
 
+// TestCloseIssueNotFound verifies that closing a non-existent issue returns an
+// error that wraps storage.ErrNotFound, for parity with GetIssue/UpdateIssue/
+// DeleteIssue. Guards against the regression where CloseIssue returned a bare
+// fmt.Errorf that errors.Is(err, storage.ErrNotFound) could not match (mybd-fv7r).
+func TestCloseIssueNotFound(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	err := store.CloseIssue(ctx, "does-not-exist", "completed", "tester", "session123")
+	if err == nil {
+		t.Fatal("expected error closing non-existent issue, got nil")
+	}
+	if !errors.Is(err, storage.ErrNotFound) {
+		t.Fatalf("expected error to wrap storage.ErrNotFound, got: %v", err)
+	}
+}
+
 // TestClosePromotedWisp verifies that bd close works for wisps that were
 // promoted to the issues table via PromoteFromEphemeral (bd-ftc).
 // Promoted wisps have -wisp- in their ID but live in the issues table,

--- a/internal/storage/issueops/close.go
+++ b/internal/storage/issueops/close.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/types"
 )
 
@@ -62,7 +63,7 @@ func closeIssueInTx(ctx context.Context, tx DBTX, id string, reason, actor, sess
 			fmt.Sprintf(`SELECT status FROM %s WHERE id = ?`, issueTable), id,
 		).Scan(&status)
 		if qerr == sql.ErrNoRows {
-			return nil, fmt.Errorf("issue not found: %s", id)
+			return nil, fmt.Errorf("%w: issue %s", storage.ErrNotFound, id)
 		}
 		if qerr != nil {
 			return nil, fmt.Errorf("failed to check issue existence: %w", qerr)


### PR DESCRIPTION
## Why

`CloseIssueInTx` returned a bare `fmt.Errorf("issue not found: %s", id)` when an
issue did not exist, so `errors.Is(err, storage.ErrNotFound)` was `false`. This
breaks parity with `GetIssue`, `UpdateIssue`, and `DeleteIssue`, which all wrap
`storage.ErrNotFound`. Any caller that branches on the sentinel — including the
backend-agnostic storage conformance suite in #4414 — could not reliably detect a
missing issue on close.

## What

- Wrap the sentinel in `internal/storage/issueops/close.go`:
  `fmt.Errorf("%w: issue %s", storage.ErrNotFound, id)`.
- Add `TestCloseIssueNotFound` in `internal/storage/dolt/dolt_test.go` asserting
  the not-found path satisfies `errors.Is(err, storage.ErrNotFound)`, mirroring
  the existing delete/get not-found tests.

## Testing

- `go test -tags gms_pure_go ./internal/storage/issueops/ ./internal/storage/dolt/` — pass.

The conformance-suite case for `CloseIssue` is intentionally left for #4414 (the
suite is not yet on `main`); this PR is the minimal sentinel-parity fix so that
case can simply pass once the suite lands.

_claude-opus-4-8-high on behalf of matt wilkie_
