### PR TITLE
docs: fix broken docs/EXTENDING.md xref to docs/CONFIG.md

### DIFF
--- a/website/docs/reference/configuration.md
+++ b/website/docs/reference/configuration.md
@@ -166,7 +166,7 @@ These are written to the Dolt database by `bd config set` and have no env var ov
 | `types.custom` | Comma-separated list of custom issue types |
 | `types.infra` | Infra types routed to wisps table |
 | `import.orphan_handling` | `allow` (default) \| `resurrect` \| `skip` \| `strict` |
-| `compact_*` | Compaction tuning (see `docs/EXTENDING.md`) |
+| `compact_*` | Compaction tuning (see [docs/CONFIG.md](https://github.com/gastownhall/beads/blob/main/docs/CONFIG.md)) |
 | `issue_id_mode` | `hash` (default) \| `counter` (sequential) |
 | `min_hash_length`, `max_hash_length` | Adaptive ID bounds (defaults `4` and `8`) |
 | `max_collision_prob` | Hash ID collision tolerance (default `0.25`) |

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -13716,7 +13716,7 @@ These are written to the Dolt database by `bd config set` and have no env var ov
 | `types.custom` | Comma-separated list of custom issue types |
 | `types.infra` | Infra types routed to wisps table |
 | `import.orphan_handling` | `allow` (default) \| `resurrect` \| `skip` \| `strict` |
-| `compact_*` | Compaction tuning (see `docs/EXTENDING.md`) |
+| `compact_*` | Compaction tuning (see [docs/CONFIG.md](https://github.com/gastownhall/beads/blob/main/docs/CONFIG.md)) |
 | `issue_id_mode` | `hash` (default) \| `counter` (sequential) |
 | `min_hash_length`, `max_hash_length` | Adaptive ID bounds (defaults `4` and `8`) |
 | `max_collision_prob` | Hash ID collision tolerance (default `0.25`) |

--- a/website/versioned_docs/version-1.0.0/reference/configuration.md
+++ b/website/versioned_docs/version-1.0.0/reference/configuration.md
@@ -145,7 +145,7 @@ These are written to the Dolt database by `bd config set` and have no env var ov
 | `types.custom` | Comma-separated list of custom issue types |
 | `types.infra` | Infra types routed to wisps table |
 | `import.orphan_handling` | `allow` (default) \| `resurrect` \| `skip` \| `strict` |
-| `compact_*` | Compaction tuning (see `docs/EXTENDING.md`) |
+| `compact_*` | Compaction tuning (see [docs/CONFIG.md](https://github.com/gastownhall/beads/blob/main/docs/CONFIG.md)) |
 | `issue_id_mode` | `hash` (default) \| `counter` (sequential) |
 | `min_hash_length`, `max_hash_length` | Adaptive ID bounds (defaults `4` and `8`) |
 | `max_collision_prob` | Hash ID collision tolerance (default `0.25`) |

--- a/website/versioned_docs/version-1.0.4/reference/configuration.md
+++ b/website/versioned_docs/version-1.0.4/reference/configuration.md
@@ -145,7 +145,7 @@ These are written to the Dolt database by `bd config set` and have no env var ov
 | `types.custom` | Comma-separated list of custom issue types |
 | `types.infra` | Infra types routed to wisps table |
 | `import.orphan_handling` | `allow` (default) \| `resurrect` \| `skip` \| `strict` |
-| `compact_*` | Compaction tuning (see `docs/EXTENDING.md`) |
+| `compact_*` | Compaction tuning (see [docs/CONFIG.md](https://github.com/gastownhall/beads/blob/main/docs/CONFIG.md)) |
 | `issue_id_mode` | `hash` (default) \| `counter` (sequential) |
 | `min_hash_length`, `max_hash_length` | Adaptive ID bounds (defaults `4` and `8`) |
 | `max_collision_prob` | Hash ID collision tolerance (default `0.25`) |

--- a/website/versioned_docs/version-1.0.5/reference/configuration.md
+++ b/website/versioned_docs/version-1.0.5/reference/configuration.md
@@ -166,7 +166,7 @@ These are written to the Dolt database by `bd config set` and have no env var ov
 | `types.custom` | Comma-separated list of custom issue types |
 | `types.infra` | Infra types routed to wisps table |
 | `import.orphan_handling` | `allow` (default) \| `resurrect` \| `skip` \| `strict` |
-| `compact_*` | Compaction tuning (see `docs/EXTENDING.md`) |
+| `compact_*` | Compaction tuning (see [docs/CONFIG.md](https://github.com/gastownhall/beads/blob/main/docs/CONFIG.md)) |
 | `issue_id_mode` | `hash` (default) \| `counter` (sequential) |
 | `min_hash_length`, `max_hash_length` | Adaptive ID bounds (defaults `4` and `8`) |
 | `max_collision_prob` | Hash ID collision tolerance (default `0.25`) |


### PR DESCRIPTION
## Why

The configuration reference pointed `compact_*` tuning at `docs/EXTENDING.md`,
a file that has never existed in the repo, so the link broke the moment anyone
followed it. Compaction settings are actually documented in `docs/CONFIG.md`.

## What

Redirect the `compact_*` reference from `docs/EXTENDING.md` to `docs/CONFIG.md`,
matching the existing `docs/CONFIG.md` link style already used elsewhere in the
same file, across:

- `website/docs/reference/configuration.md` (live)
- `website/versioned_docs/version-1.0.0/reference/configuration.md`
- `website/versioned_docs/version-1.0.4/reference/configuration.md`
- `website/versioned_docs/version-1.0.5/reference/configuration.md`
- `website/static/llms-full.txt` (regenerated via `scripts/generate-llms-full.sh`)

After this change `grep -rn 'docs/EXTENDING.md'` returns nothing repo-wide.

## Testing

- `grep -rn 'docs/EXTENDING.md'` — no matches.
- `scripts/check-cli-docs-drift.sh` — PASS (`llms-full.txt` and generated CLI docs fresh).

_claude-opus-4-8-high on behalf of matt wilkie_
