### PR TITLE
build(goreleaser): remove orphaned homebrew brews block

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -159,22 +159,6 @@ archives:
       - README.md
       - CHANGELOG.md
 
-brews:
-  - name: bd
-    repository:
-      owner: gastownhall
-      name: homebrew-beads
-    directory: Formula
-    # Disabled: macOS archives are built by a separate CI job (goreleaser-macos),
-    # so goreleaser can't generate a complete formula. The update-homebrew-formula
-    # job in release.yml generates the formula after all archives are uploaded.
-    skip_upload: true
-    homepage: "https://github.com/gastownhall/beads"
-    description: "AI-supervised issue tracker for coding workflows"
-    license: "MIT"
-    install: |
-      bin.install "bd"
-
 checksum:
   name_template: "checksums.txt"
   algorithm: sha256


### PR DESCRIPTION
## Why

#4478 (merged 2026-06-23) retired the legacy `gastownhall/homebrew-beads` tap
as a release channel and removed the release-workflow job that published
`Formula/bd.rb`. The `.goreleaser.yml` still carried a `brews:` block pointing at
that tap with `skip_upload: true`, so goreleaser never published from it. With
the publish job gone, this block is orphaned dead configuration.

## What

- Remove the orphaned `brews:` block (tap `owner: gastownhall` /
  `name: homebrew-beads`, `skip_upload: true`) from `.goreleaser.yml`.
- No other configuration depended on it: there are no remaining `brews` or
  `homebrew-beads` references in `.goreleaser.yml` or in `.github/workflows/`.

## Testing

- `npx js-yaml .goreleaser.yml` parses cleanly (`YAML_OK`).
- `git diff --check` reports no whitespace errors.
- `grep -rn "brews\|homebrew-beads" .goreleaser.yml .github/workflows/` returns
  no matches after removal.

_claude-opus-4-8-high on behalf of matt wilkie_
