### PR TITLE
feat(prime): remind when AGENTS.md and CLAUDE.md diverge

### DIFF
--- a/cmd/bd/prime.go
+++ b/cmd/bd/prime.go
@@ -168,6 +168,10 @@ Config options:
 			}
 			return nil
 		}
+		// Append the AGENTS.md/CLAUDE.md divergence reminder only when both
+		// files are independent regulars carrying the bd marker; otherwise this
+		// adds nothing (zero output, negligible cost).
+		buf.WriteString(primeDivergenceReminder(""))
 		emit(buf.String())
 		return nil
 	},

--- a/cmd/bd/prime_divergence.go
+++ b/cmd/bd/prime_divergence.go
@@ -12,7 +12,7 @@ const beadsIntegrationMarker = "BEGIN BEADS INTEGRATION"
 
 // primeDivergenceReminder returns a one-line reminder when both AGENTS.md and
 // CLAUDE.md in workspaceDir exist as independent regular files (not symlinks,
-// not hardlinked to each other) that each contain the bd integration marker.
+// not sharing an inode) that each contain the bd integration marker.
 //
 // In every other case it returns the empty string and performs no work beyond
 // a couple of cheap Lstat calls, so the common case (the condition does not
@@ -45,7 +45,7 @@ func primeDivergenceReminder(workspaceDir string) string {
 		return ""
 	}
 
-	// Independent files: not hardlinked to the same inode. Since neither is a
+	// Independent files: not sharing the same inode. Since neither is a
 	// symlink, the Lstat results are equivalent to Stat and carry the sys
 	// identity os.SameFile compares.
 	if os.SameFile(agentsInfo, claudeInfo) {
@@ -56,7 +56,7 @@ func primeDivergenceReminder(workspaceDir string) string {
 		return ""
 	}
 
-	return "\n> **Note**: AGENTS.md and CLAUDE.md are independent files (not symlinked or hardlinked). Mirror substantive edits across both, or symlink one to the other.\n"
+	return "\n> **Note**: AGENTS.md and CLAUDE.md are independent files (not symlinked and not sharing an inode). Mirror substantive edits across both, or symlink one to the other.\n"
 }
 
 // fileContainsMarker reports whether the file at path contains the bd

--- a/cmd/bd/prime_divergence.go
+++ b/cmd/bd/prime_divergence.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// beadsIntegrationMarker is the substring present in agent instruction files
+// (AGENTS.md / CLAUDE.md) that bd manages via its integration block.
+const beadsIntegrationMarker = "BEGIN BEADS INTEGRATION"
+
+// primeDivergenceReminder returns a one-line reminder when both AGENTS.md and
+// CLAUDE.md in workspaceDir exist as independent regular files (not symlinks,
+// not hardlinked to each other) that each contain the bd integration marker.
+//
+// In every other case it returns the empty string and performs no work beyond
+// a couple of cheap Lstat calls, so the common case (the condition does not
+// hold) adds zero output and negligible cost. workspaceDir may be "" to mean
+// the current working directory.
+func primeDivergenceReminder(workspaceDir string) string {
+	if workspaceDir == "" {
+		workspaceDir = "."
+	}
+
+	agentsPath := filepath.Join(workspaceDir, "AGENTS.md")
+	claudePath := filepath.Join(workspaceDir, "CLAUDE.md")
+
+	// Lstat (not Stat) so symlinks are detected rather than followed.
+	agentsInfo, err := os.Lstat(agentsPath)
+	if err != nil {
+		return ""
+	}
+	claudeInfo, err := os.Lstat(claudePath)
+	if err != nil {
+		return ""
+	}
+
+	// Both must be regular files. ModeSymlink is excluded by IsRegular, but
+	// reject symlinks (and any non-regular mode) explicitly for clarity.
+	if agentsInfo.Mode()&os.ModeSymlink != 0 || claudeInfo.Mode()&os.ModeSymlink != 0 {
+		return ""
+	}
+	if !agentsInfo.Mode().IsRegular() || !claudeInfo.Mode().IsRegular() {
+		return ""
+	}
+
+	// Independent files: not hardlinked to the same inode. Since neither is a
+	// symlink, the Lstat results are equivalent to Stat and carry the sys
+	// identity os.SameFile compares.
+	if os.SameFile(agentsInfo, claudeInfo) {
+		return ""
+	}
+
+	if !fileContainsMarker(agentsPath) || !fileContainsMarker(claudePath) {
+		return ""
+	}
+
+	return "\n> **Note**: AGENTS.md and CLAUDE.md are independent files (not symlinked or hardlinked). Mirror substantive edits across both, or symlink one to the other.\n"
+}
+
+// fileContainsMarker reports whether the file at path contains the bd
+// integration marker. Any read error yields false (treated as "no marker").
+func fileContainsMarker(path string) bool {
+	// #nosec G304 -- path is composed from a caller-controlled workspace dir
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return false
+	}
+	return strings.Contains(string(data), beadsIntegrationMarker)
+}

--- a/cmd/bd/prime_divergence_test.go
+++ b/cmd/bd/prime_divergence_test.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+const markerBlock = "<!-- BEGIN BEADS INTEGRATION v:1 profile:agents hash:abc -->\nbody\n<!-- END BEADS INTEGRATION -->\n"
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func TestPrimeDivergenceReminder_BothIndependentWithMarker(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "AGENTS.md"), "# Agents\n"+markerBlock)
+	writeFile(t, filepath.Join(dir, "CLAUDE.md"), "# Claude\n"+markerBlock)
+
+	got := primeDivergenceReminder(dir)
+	if got == "" {
+		t.Fatal("expected reminder, got empty string")
+	}
+	if !strings.Contains(got, "AGENTS.md") || !strings.Contains(got, "CLAUDE.md") {
+		t.Fatalf("reminder missing file names: %q", got)
+	}
+	if strings.Count(got, "\n> ") != 1 {
+		t.Fatalf("expected a single one-line note, got: %q", got)
+	}
+}
+
+func TestPrimeDivergenceReminder_MissingOneFile(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "AGENTS.md"), "# Agents\n"+markerBlock)
+	// CLAUDE.md absent.
+	if got := primeDivergenceReminder(dir); got != "" {
+		t.Fatalf("expected empty when one file missing, got %q", got)
+	}
+}
+
+func TestPrimeDivergenceReminder_MarkerMissingInOne(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "AGENTS.md"), "# Agents\n"+markerBlock)
+	writeFile(t, filepath.Join(dir, "CLAUDE.md"), "# Claude without marker\n")
+	if got := primeDivergenceReminder(dir); got != "" {
+		t.Fatalf("expected empty when one file lacks marker, got %q", got)
+	}
+}
+
+func TestPrimeDivergenceReminder_Symlink(t *testing.T) {
+	dir := t.TempDir()
+	agents := filepath.Join(dir, "AGENTS.md")
+	claude := filepath.Join(dir, "CLAUDE.md")
+	writeFile(t, agents, "# Agents\n"+markerBlock)
+	if err := os.Symlink(agents, claude); err != nil {
+		if runtime.GOOS == "windows" {
+			t.Skipf("symlink unsupported: %v", err)
+		}
+		t.Fatalf("symlink: %v", err)
+	}
+	// CLAUDE.md is a symlink (to a file with the marker); reminder must be empty.
+	if got := primeDivergenceReminder(dir); got != "" {
+		t.Fatalf("expected empty when a file is a symlink, got %q", got)
+	}
+}
+
+func TestPrimeDivergenceReminder_Hardlink(t *testing.T) {
+	dir := t.TempDir()
+	agents := filepath.Join(dir, "AGENTS.md")
+	claude := filepath.Join(dir, "CLAUDE.md")
+	writeFile(t, agents, "# Agents\n"+markerBlock)
+	if err := os.Link(agents, claude); err != nil {
+		t.Skipf("hardlink unsupported: %v", err)
+	}
+	// Same inode: independent-files condition fails, so no reminder.
+	if got := primeDivergenceReminder(dir); got != "" {
+		t.Fatalf("expected empty when files are hardlinked, got %q", got)
+	}
+}
+
+func TestPrimeDivergenceReminder_NeitherPresent(t *testing.T) {
+	dir := t.TempDir()
+	if got := primeDivergenceReminder(dir); got != "" {
+		t.Fatalf("expected empty when neither file present, got %q", got)
+	}
+}
+
+func TestPrimeDivergenceReminder_EmptyDirArgUsesCwd(t *testing.T) {
+	// With "" the helper uses the current working directory; in a temp dir with
+	// no agent files it must return empty (and not error).
+	dir := t.TempDir()
+	t.Chdir(dir)
+	if got := primeDivergenceReminder(""); got != "" {
+		t.Fatalf("expected empty for cwd without files, got %q", got)
+	}
+}

--- a/cmd/bd/prime_divergence_test.go
+++ b/cmd/bd/prime_divergence_test.go
@@ -10,7 +10,7 @@ import (
 
 const markerBlock = "<!-- BEGIN BEADS INTEGRATION v:1 profile:agents hash:abc -->\nbody\n<!-- END BEADS INTEGRATION -->\n"
 
-func writeFile(t *testing.T, path, content string) {
+func writePrimeTestFile(t *testing.T, path, content string) {
 	t.Helper()
 	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
 		t.Fatalf("write %s: %v", path, err)
@@ -19,8 +19,8 @@ func writeFile(t *testing.T, path, content string) {
 
 func TestPrimeDivergenceReminder_BothIndependentWithMarker(t *testing.T) {
 	dir := t.TempDir()
-	writeFile(t, filepath.Join(dir, "AGENTS.md"), "# Agents\n"+markerBlock)
-	writeFile(t, filepath.Join(dir, "CLAUDE.md"), "# Claude\n"+markerBlock)
+	writePrimeTestFile(t, filepath.Join(dir, "AGENTS.md"), "# Agents\n"+markerBlock)
+	writePrimeTestFile(t, filepath.Join(dir, "CLAUDE.md"), "# Claude\n"+markerBlock)
 
 	got := primeDivergenceReminder(dir)
 	if got == "" {
@@ -36,7 +36,7 @@ func TestPrimeDivergenceReminder_BothIndependentWithMarker(t *testing.T) {
 
 func TestPrimeDivergenceReminder_MissingOneFile(t *testing.T) {
 	dir := t.TempDir()
-	writeFile(t, filepath.Join(dir, "AGENTS.md"), "# Agents\n"+markerBlock)
+	writePrimeTestFile(t, filepath.Join(dir, "AGENTS.md"), "# Agents\n"+markerBlock)
 	// CLAUDE.md absent.
 	if got := primeDivergenceReminder(dir); got != "" {
 		t.Fatalf("expected empty when one file missing, got %q", got)
@@ -45,8 +45,8 @@ func TestPrimeDivergenceReminder_MissingOneFile(t *testing.T) {
 
 func TestPrimeDivergenceReminder_MarkerMissingInOne(t *testing.T) {
 	dir := t.TempDir()
-	writeFile(t, filepath.Join(dir, "AGENTS.md"), "# Agents\n"+markerBlock)
-	writeFile(t, filepath.Join(dir, "CLAUDE.md"), "# Claude without marker\n")
+	writePrimeTestFile(t, filepath.Join(dir, "AGENTS.md"), "# Agents\n"+markerBlock)
+	writePrimeTestFile(t, filepath.Join(dir, "CLAUDE.md"), "# Claude without marker\n")
 	if got := primeDivergenceReminder(dir); got != "" {
 		t.Fatalf("expected empty when one file lacks marker, got %q", got)
 	}
@@ -56,7 +56,7 @@ func TestPrimeDivergenceReminder_Symlink(t *testing.T) {
 	dir := t.TempDir()
 	agents := filepath.Join(dir, "AGENTS.md")
 	claude := filepath.Join(dir, "CLAUDE.md")
-	writeFile(t, agents, "# Agents\n"+markerBlock)
+	writePrimeTestFile(t, agents, "# Agents\n"+markerBlock)
 	if err := os.Symlink(agents, claude); err != nil {
 		if runtime.GOOS == "windows" {
 			t.Skipf("symlink unsupported: %v", err)
@@ -73,13 +73,13 @@ func TestPrimeDivergenceReminder_Hardlink(t *testing.T) {
 	dir := t.TempDir()
 	agents := filepath.Join(dir, "AGENTS.md")
 	claude := filepath.Join(dir, "CLAUDE.md")
-	writeFile(t, agents, "# Agents\n"+markerBlock)
+	writePrimeTestFile(t, agents, "# Agents\n"+markerBlock)
 	if err := os.Link(agents, claude); err != nil {
-		t.Skipf("hardlink unsupported: %v", err)
+		t.Skipf("shared-inode link unsupported: %v", err)
 	}
 	// Same inode: independent-files condition fails, so no reminder.
 	if got := primeDivergenceReminder(dir); got != "" {
-		t.Fatalf("expected empty when files are hardlinked, got %q", got)
+		t.Fatalf("expected empty when files share an inode, got %q", got)
 	}
 }
 


### PR DESCRIPTION
## Why

When a workspace keeps both `AGENTS.md` and `CLAUDE.md` as separate real files (rather than one symlinked to the other), and both carry the bd integration block, it is easy to edit one and forget the other. The two agent-instruction surfaces then drift apart silently. `bd prime` is already the place agents read for workflow context, so it is the natural spot to surface this.

## What

`bd prime` now appends a single one-line reminder to its generated output, but only when ALL of these hold:

- both `AGENTS.md` and `CLAUDE.md` exist in the workspace,
- both are regular files (symlinks are rejected via `os.Lstat`),
- they are not hardlinked to the same inode (`os.SameFile`),
- each contains the `BEGIN BEADS INTEGRATION` marker.

In every other case (the common case) it emits nothing and performs only a couple of cheap `Lstat` calls, so workspaces that do not meet all conditions pay no added output and negligible cost. The override path (a custom `PRIME.md`) is untouched.

The check lives in a small, side-effect-free helper `primeDivergenceReminder(workspaceDir)` in `cmd/bd/prime_divergence.go`, wired into `primeCmd` after the context is generated.

## Testing

```
CGO_ENABLED=0 go build -tags gms_pure_go ./...
CGO_ENABLED=0 go test -tags gms_pure_go -run Prime ./cmd/bd/
gofmt -l (changed files)   # clean
go vet -tags gms_pure_go ./cmd/bd/   # clean
git diff --check   # clean
```

New tests in `cmd/bd/prime_divergence_test.go` cover: both present + independent + marker => reminder; one file missing => nothing; marker missing in one => nothing; symlink case => nothing; hardlink (shared inode) => nothing; neither present => nothing; empty-arg/cwd path. Symlink and hardlink tests skip gracefully where the OS cannot create them.

_claude-opus-4-8-high on behalf of matt wilkie_
