### PR TITLE
docs: consolidate Homebrew tap-migration snippet across install/upgrade docs

### DIFF
--- a/docs/INSTALLING.md
+++ b/docs/INSTALLING.md
@@ -1,3 +1,7 @@
+<!-- This GitHub-rendered install guide and the website install page
+     (website/docs/getting-started/installation.md) are deliberate parallel
+     docs for different audiences. When you change platform commands or install
+     methods here, update the website page too so they do not drift. -->
 # Installing bd
 
 Complete installation guide for all platforms.
@@ -42,6 +46,9 @@ brew install beads
 Homebrew core's `beads` formula is the supported Homebrew package. If you
 previously installed the old tap formula as `bd`, migrate to the core formula:
 
+<!-- Tap-migration snippet mirrored from the canonical copy in
+     website/docs/getting-started/upgrading.md (### Homebrew). This file is
+     GitHub-rendered, so the block is inlined rather than linked. Keep in sync. -->
 ```bash
 brew uninstall bd
 brew untap gastownhall/beads 2>/dev/null || true

--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -6,6 +6,11 @@ sidebar_position: 1
 
 # Installing bd
 
+<!-- This website install page and the GitHub-rendered docs/INSTALLING.md are
+     deliberate parallel docs for different audiences. When you change platform
+     commands or install methods here, update docs/INSTALLING.md too so they do
+     not drift. -->
+
 Complete installation guide for all platforms.
 
 ## Quick Install (Recommended)
@@ -17,14 +22,9 @@ brew install beads
 ```
 
 Homebrew core's `beads` formula is the supported Homebrew package. If you
-previously installed the old tap formula as `bd`, migrate to the core formula:
-
-```bash
-brew uninstall bd
-brew untap gastownhall/beads 2>/dev/null || true
-brew untap steveyegge/beads 2>/dev/null || true
-brew install beads
-```
+previously installed the old tap formula as `bd`, see
+[Migrating from the old Homebrew tap](/getting-started/upgrading#homebrew) to
+switch to the core formula.
 
 **Why Homebrew?**
 - Simple one-command install

--- a/website/docs/getting-started/upgrading.md
+++ b/website/docs/getting-started/upgrading.md
@@ -52,6 +52,8 @@ irm https://raw.githubusercontent.com/gastownhall/beads/main/install.ps1 | iex
 brew upgrade beads
 ```
 
+<!-- Canonical Homebrew tap-migration snippet. The installation page links
+     here; docs/INSTALLING.md mirrors this block. Keep all three in sync. -->
 If you still have the old tap formula installed as `bd`, switch to the
 Homebrew core formula:
 


### PR DESCRIPTION
## Why

PR #4478 added the old-tap to Homebrew-core migration commands (`brew uninstall bd` / `brew untap ...` / `brew install beads`). The same four-line block landed verbatim in three docs:

- `docs/INSTALLING.md`
- `website/docs/getting-started/installation.md`
- `website/docs/getting-started/upgrading.md`

Three identical copies are a drift hazard: a future tweak to one (an extra tap to untap, a wording change) silently diverges from the others. This consolidates to a single canonical copy where the docs structure allows, and adds drift guards where it does not.

## What

- Designate `website/docs/getting-started/upgrading.md` (`### Homebrew`) as the **canonical** home for the tap-migration snippet. Migrating off the old tap is an upgrade task, so this is its natural home. Marked with a maintainer comment.
- In `website/docs/getting-started/installation.md`, replace the duplicated block with a link to the canonical upgrading section. Both pages render in the same Docusaurus site, so the intra-site link is clean and removes one copy.
- `docs/INSTALLING.md` is GitHub-rendered, where Docusaurus `/getting-started/...` links do not resolve, so the block stays inline. Added a drift-guard comment pointing maintainers at the canonical copy.
- Documented the deliberate parallel-doc divergence risk between `docs/INSTALLING.md` and the website install page: both are full install guides for different audiences (GitHub README readers vs the docs site), so they are intentionally kept rather than merged, but a comment now reminds editors to keep platform/install commands in sync.

`CHANGELOG.md` and `RELEASING.md` also reference the old tap, but neither carries the user migration snippet (CHANGELOG is historical/append-only; RELEASING describes the release process), so both are left untouched.

## Testing

Docs-only change. The edited pages are the unreleased "Next" docs, not the `versioned_docs/version-1.0.5` snapshot that feeds `website/static/llms-full.txt`, and they are not part of `scripts/sync-website-docs.sh`, so no generated output needs regenerating. The migration commands are unchanged (already identical across all three copies). `git diff --check` is clean. The new comment uses the same `<!-- -->` form already present in other website docs (Docusaurus 3.10).

_claude-opus-4-8-high on behalf of matt wilkie_
