### PR TITLE
fix(release): branch goreleaser install header for prerelease vs stable

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -212,7 +212,28 @@ release:
     ## beads v{{.Version}}
 
     Pre-compiled binaries for Linux, macOS (Intel & Apple Silicon), Windows (AMD64 & ARM64), Android/Termux (ARM64), and FreeBSD.
+    {{ if .Prerelease }}
+    ### Installation (release candidate)
 
+    > **This is a prerelease for validation.** The stable install channels —
+    > Homebrew, the `install.sh` / `install.ps1` scripts, npm, and PyPI —
+    > intentionally keep serving the latest **stable** release, so they will **not**
+    > install this RC. Use one of the methods below.
+
+    **Manual download (recommended):**
+    Download the archive for your platform from the **Assets** below, extract it,
+    and place `bd` on your PATH.
+
+    **Go install (pinned to this RC):**
+    ```bash
+    go install github.com/steveyegge/beads/cmd/bd@v{{ .Version }}
+    # For embedded Dolt support:
+    CGO_ENABLED=1 GOFLAGS=-tags=gms_pure_go go install github.com/steveyegge/beads/cmd/bd@v{{ .Version }}
+    ```
+
+    When you are done validating, return to the stable release through your normal
+    channel (e.g. `brew upgrade beads`).
+    {{ else }}
     ### Installation
 
     **Homebrew (macOS/Linux):**
@@ -232,6 +253,7 @@ release:
 
     **Manual Install:**
     Download the appropriate binary for your platform below, extract it, and place it in your PATH.
+    {{ end }}
 
 # Announce the release
 announce:


### PR DESCRIPTION
## Why

`release.header` in `.goreleaser.yml` is a single static block used for every
release, so prerelease (RC) GitHub releases ship the **stable** install
instructions. Three of the four documented methods are wrong for a prerelease:

- `brew install beads` installs the homebrew-core stable, not the RC.
- `install.sh | bash` resolves `/releases/latest`, which excludes prereleases.
- `install.ps1` follows the same latest-stable path.
- Only the manual asset download actually gets the RC.

`prerelease: auto` flags the release as a prerelease but does not change the
header text, so the `v1.1.0-rc.1` release notes had to be hand-corrected after
the fact. This makes that correction permanent and automatic.

## What

Gate `release.header` on goreleaser's `{{ if .Prerelease }}`:

- **Prerelease branch:** RC-appropriate instructions — manual download from the
  Assets list (recommended) plus `go install github.com/steveyegge/beads/cmd/bd@v{{ .Version }}`
  (for `v1.1.0-rc.1`, `.Version` is `1.1.0-rc.1`, yielding `@v1.1.0-rc.1`), with
  a note that the stable channels (Homebrew, install scripts, npm, PyPI)
  intentionally keep serving the latest **stable** release. Wording matches the
  hand-corrected `v1.1.0-rc.1` release notes.
- **Else (stable) branch:** the existing header content verbatim — Homebrew,
  `install.sh`, `install.ps1`, and Manual Install.

The diff is confined to the header block (+22 lines, no deletions); the `brews:`
block and every other section are untouched.

## Testing

- `goreleaser` is not installed in this environment, so YAML was validated with
  `npx js-yaml .goreleaser.yml` -> parses OK.
- Go-template branching verified with a `text/template` harness using the same
  `{{ if .Prerelease }}...{{ else }}...{{ end }}` body and `.Version=1.1.0-rc.1`:
  the stable branch renders `brew install beads`; the prerelease branch renders
  `go install github.com/steveyegge/beads/cmd/bd@v1.1.0-rc.1`.
- `git diff --check` clean.

_claude-opus-4-8-high on behalf of matt wilkie_
