### PR TITLE
fix(storage): fail fast on writable opens of a schema-newer DB

### DIFF
--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -1154,12 +1154,17 @@ func newServerMode(ctx context.Context, cfg *Config) (*DoltStore, error) {
 		autoStartedServerDir: autoStartedDir,
 	}
 
-	if cfg.ReadOnly {
-		if err := schema.CheckForwardDrift(ctx, db); err != nil {
-			_ = db.Close()
-			return nil, err
-		}
-	} else {
+	// Forward-drift guard runs on read-only AND writable opens. A binary older
+	// than the database's schema cannot migrate it forward: MigrateUp no-ops
+	// when the DB is already past the binary's latest migration (atLatest uses
+	// >=), so without this guard a writable open would proceed and later queries
+	// would fail with cryptic unknown-column errors instead of a clear
+	// "upgrade bd" message (the stale-binary incident behind #4135/#4137).
+	if err := schema.CheckForwardDrift(ctx, db); err != nil {
+		_ = db.Close()
+		return nil, err
+	}
+	if !cfg.ReadOnly {
 		if err := store.initSchema(ctx); err != nil {
 			return nil, fmt.Errorf("failed to initialize schema: %w", err)
 		}

--- a/internal/storage/embeddeddolt/store.go
+++ b/internal/storage/embeddeddolt/store.go
@@ -273,6 +273,17 @@ func (s *EmbeddedDoltStore) initSchema(ctx context.Context) error {
 		}
 	}
 
+	// Forward-drift guard: if this database's schema is AHEAD of the binary,
+	// fail fast with a clear "upgrade bd" message before MigrateUp no-ops and a
+	// later query dies on a dropped/renamed column. Embedded mode is the mode
+	// the stale-binary incident (#4135/#4137) was observed in. The read-only
+	// embedded open (OpenReadOnly) already guards this; the writable open did
+	// not. Runs after the USE switch so the version read resolves against the
+	// target database.
+	if err := schema.CheckForwardDrift(ctx, conn); err != nil {
+		return err
+	}
+
 	// #4259: refuse to silently apply pending migrations to a remote-backed,
 	// already-initialized database — independently migrating each clone forks the
 	// schema. Embedded mode (the mode the original report was filed against) syncs

--- a/internal/storage/schema/schema.go
+++ b/internal/storage/schema/schema.go
@@ -78,10 +78,13 @@ func IsSchemaSkewError(err error) bool {
 // *SchemaSkewError if the DB is ahead of the binary. Returns nil for a fresh
 // DB (version=0) or when BD_IGNORE_SCHEMA_SKEW=1 (prints a warning instead).
 func checkSchemaSkew(ctx context.Context, db DBConn) error {
-	var currentVersion int
-	if err := db.QueryRowContext(ctx,
-		"SELECT COALESCE(MAX(version), 0) FROM schema_migrations",
-	).Scan(&currentVersion); err != nil {
+	// CurrentVersion treats a missing schema_migrations table as version 0, so
+	// this is safe to call before migrations have created the table: a
+	// brand-new database (version 0) falls through the no-op check below. That
+	// matters on the writable open path, where the guard runs before initSchema
+	// creates the table on a fresh database.
+	currentVersion, err := CurrentVersion(ctx, db)
+	if err != nil {
 		return fmt.Errorf("schema skew check: %w", err)
 	}
 	if currentVersion == 0 || currentVersion <= LatestVersion() {
@@ -96,9 +99,13 @@ func checkSchemaSkew(ctx context.Context, db DBConn) error {
 	return &SchemaSkewError{DBVersion: currentVersion, BinaryVersion: LatestVersion()}
 }
 
-// CheckForwardDrift checks for forward schema drift on an existing *sql.DB
-// connection. Used by the read-only store path where MigrateUp is skipped.
-func CheckForwardDrift(ctx context.Context, db *sql.DB) error {
+// CheckForwardDrift reports a *SchemaSkewError when the database's schema
+// version is AHEAD of the binary's (forward drift). It accepts any DBConn (a
+// pooled *sql.DB or a pinned *sql.Conn), so both the read-only store path
+// (where MigrateUp is skipped) and the writable open path (where MigrateUp
+// no-ops on a forward-drifted DB rather than erroring) can fail fast before a
+// query hits a dropped or renamed column.
+func CheckForwardDrift(ctx context.Context, db DBConn) error {
 	return checkSchemaSkew(ctx, db)
 }
 

--- a/internal/storage/schema/schema_skew_test.go
+++ b/internal/storage/schema/schema_skew_test.go
@@ -185,17 +185,25 @@ func TestCheckSchemaSkew_MissingTable_NoError(t *testing.T) {
 // (so the embedded writable path can pass a pinned *sql.Conn) and still reports
 // forward drift.
 func TestCheckForwardDrift_Conn_Ahead(t *testing.T) {
+	ctx := context.Background()
+
 	db, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
 	defer db.Close()
 
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		t.Fatalf("db.Conn: %v", err)
+	}
+	defer conn.Close()
+
 	dbVersion := LatestVersion() + 2
 	mock.ExpectQuery(`SELECT COALESCE\(MAX\(version\), 0\) FROM schema_migrations`).
 		WillReturnRows(sqlmock.NewRows([]string{"version"}).AddRow(dbVersion))
 
-	got := CheckForwardDrift(context.Background(), db)
+	got := CheckForwardDrift(ctx, conn)
 	if !IsSchemaSkewError(got) {
 		t.Fatalf("CheckForwardDrift = %v (%T), want *SchemaSkewError", got, got)
 	}

--- a/internal/storage/schema/schema_skew_test.go
+++ b/internal/storage/schema/schema_skew_test.go
@@ -159,6 +159,51 @@ func TestCheckSchemaSkew_EscapeHatch_ReturnsNilAndWarns(t *testing.T) {
 	}
 }
 
+// TestCheckSchemaSkew_MissingTable_NoError covers the writable open path, where
+// CheckForwardDrift runs before initSchema creates schema_migrations on a fresh
+// database. A table-not-exist error must be treated as version 0 (no forward
+// drift), not surfaced as a skew-check failure.
+func TestCheckSchemaSkew_MissingTable_NoError(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectQuery(`SELECT COALESCE\(MAX\(version\), 0\) FROM schema_migrations`).
+		WillReturnError(errors.New("Error 1146 (42S02): Table 'beads.schema_migrations' doesn't exist"))
+
+	if err := checkSchemaSkew(context.Background(), db); err != nil {
+		t.Fatalf("checkSchemaSkew = %v, want nil when schema_migrations is absent (fresh DB)", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
+// TestCheckForwardDrift_Conn_Ahead confirms the exported guard accepts a DBConn
+// (so the embedded writable path can pass a pinned *sql.Conn) and still reports
+// forward drift.
+func TestCheckForwardDrift_Conn_Ahead(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	dbVersion := LatestVersion() + 2
+	mock.ExpectQuery(`SELECT COALESCE\(MAX\(version\), 0\) FROM schema_migrations`).
+		WillReturnRows(sqlmock.NewRows([]string{"version"}).AddRow(dbVersion))
+
+	got := CheckForwardDrift(context.Background(), db)
+	if !IsSchemaSkewError(got) {
+		t.Fatalf("CheckForwardDrift = %v (%T), want *SchemaSkewError", got, got)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
 // -- SchemaSkewError message copy tests --
 
 func TestSchemaSkewError_Error_Singular(t *testing.T) {


### PR DESCRIPTION
## Why

A stale `bd` that opens a database whose schema is **newer** than the binary
should fail fast with a clear "upgrade bd" message, not a cryptic SQL error.
This is the stale-binary incident behind #4135/#4137: an old `bd` opened a
forward-drifted DB and died with `column "depends_on_id" could not be found`
(a column dropped by a later migration) instead of telling the user the real
problem.

#4152 added the `SchemaSkewError` forward-drift guard and the
`BD_IGNORE_SCHEMA_SKEW` / `--ignore-schema-skew` escape hatch, but it wired
`CheckForwardDrift` only into the **read-only** store paths. The **writable**
open paths were left uncovered:

- `MigrateUp` no-ops when the DB is already past the binary's latest migration
  (`atLatest` uses `>=`), so a writable open of a forward-drifted DB succeeds
  and the failure only surfaces later, as a cryptic unknown-column error.
- The reported incident was in embedded mode, where writes (`bd create`,
  `bd update`, `bd close`) are the common case, so the uncovered writable path
  is the one users actually hit when their binary is behind.

## What

Extends the existing #4152 guard to both writable open paths; no new error
type, message, or flag (the `SchemaSkewError` UX and escape hatch are reused):

- **Server mode** (`internal/storage/dolt`): run `schema.CheckForwardDrift` on
  read-only **and** writable opens, before `initSchema`. Read-only behavior is
  unchanged; the writable branch now fails fast on forward drift.
- **Embedded mode** (`internal/storage/embeddeddolt`): run
  `schema.CheckForwardDrift` in `initSchema`, after the `USE <db>` switch and
  before the remote-migrate gate / `MigrateUp`. The read-only embedded open
  (`OpenReadOnly`) already guarded this; the writable open did not.
- `checkSchemaSkew` now reads the version via `CurrentVersion`, which treats a
  missing `schema_migrations` table as version 0. This makes the guard safe to
  run before `initSchema` creates the table on a fresh database (a fresh DB is
  version 0, i.e. no forward drift).
- `CheckForwardDrift` now accepts a `DBConn` (a pooled `*sql.DB` or a pinned
  `*sql.Conn`) so the embedded path can pass its pinned connection. Existing
  callers pass `*sql.DB`, which satisfies `DBConn`, so they are unaffected.

On the version-hint question (mapping a schema version to a required `bd`
release): this PR keeps #4152's deliberate choice to **not** hard-code a
version table. The message points users to rebuild from `main` or install the
latest release. A hand-maintained schema-version-to-release table would be
brittle and is better introduced separately if maintainers want it.

## Testing

```
CGO_ENABLED=0 go build -tags gms_pure_go ./...
CGO_ENABLED=0 go test -tags gms_pure_go ./internal/storage/schema/...   # ok
CGO_ENABLED=0 go vet  -tags gms_pure_go ./internal/storage/schema/... \
  ./internal/storage/dolt/... ./internal/storage/embeddeddolt/...        # clean
gofmt -l <changed files>   # clean
git diff --check           # clean
```

Added two focused unit tests in
`internal/storage/schema/schema_skew_test.go`:

- `TestCheckSchemaSkew_MissingTable_NoError`: a table-not-exist error is
  treated as version 0 (no drift), covering the new safe-before-`initSchema`
  behavior on the writable path.
- `TestCheckForwardDrift_Conn_Ahead`: the exported guard accepts a `DBConn`
  and still reports forward drift.

The heavier dolt/embeddeddolt integration tests are server-gated; the touched
test binaries compile under `-tags gms_pure_go`.

Related: #4152 (forward-drift guard this builds on), #4135, #4137, #4259.

_claude-opus-4-8-high on behalf of matt wilkie_
