### PR TITLE
fix(scripts): document CGO override + stderr-warn in CLI docgen guard

### DIFF
--- a/scripts/generate-cli-docs.sh
+++ b/scripts/generate-cli-docs.sh
@@ -31,6 +31,11 @@ Usage: scripts/generate-cli-docs.sh [--check] [--versioned VERSION] [path-to-bd]
 Generate live CLI docs from one bd process. Historical Docusaurus snapshots are
 left untouched unless --versioned VERSION is supplied by the release snapshot
 workflow.
+
+If the resolved bd binary is CGO-enabled it emits the full `bd federation` help
+tree that CI (CGO_ENABLED=0) stubs out; the script rebuilds a pinned pure-go
+binary to keep committed docs in sync. Set BD_DOCS_ALLOW_CGO=1 to bypass that
+rebuild and trust the supplied binary as-is.
 EOF
             exit 0
             ;;
@@ -66,16 +71,34 @@ else
     (cd "$PROJECT_ROOT" && CGO_ENABLED=0 go build -tags gms_pure_go -o "$BD" ./cmd/bd/)
 fi
 
-# Guard against a CGO-enabled bd: it exposes `bd federation` subcommands that CI never
-# produces (scripts/ci/pr-policy.sh build_docs_binary uses env CGO_ENABLED=0 go build).
-# If the resolved binary does not print the pure-go stub, rebuild pure-go internally.
+# Guard against a CGO-enabled bd: it exposes the full `bd federation` subcommand tree
+# that CI never produces (scripts/ci/pr-policy.sh build_docs_binary uses env
+# CGO_ENABLED=0 go build). A CGO build therefore emits ~hundreds of lines of federation
+# help that the committed, CI-built docs stub out ("built without CGO support"), so a
+# naive regen on a machine with a C compiler produces spurious federation churn.
+#
+# The pure-go federation stub prints "Federation commands require CGO" (see
+# cmd/bd/federation_nocgo.go); a CGO build does not. If the resolved binary is missing
+# that stub marker, warn and rebuild a pinned CGO_ENABLED=0 -tags gms_pure_go binary so
+# the committed docs always match CI. Set BD_DOCS_ALLOW_CGO=1 to bypass the rebuild and
+# trust the supplied binary as-is (e.g. to deliberately regenerate the full federation
+# tree); you then own any federation churn the diff introduces.
 if [ -x "$BD" ] && ! "$BD" federation --help 2>&1 | grep -q "Federation commands require CGO"; then
-    echo "CGO-enabled bd detected at $BD; rebuilding pure-go binary for CI-consistent docs..."
-    if [ -z "$TMP_BUILD_DIR" ]; then
-        TMP_BUILD_DIR="$(mktemp -d)"
+    if [ "${BD_DOCS_ALLOW_CGO:-0}" = "1" ]; then
+        echo "WARNING: $BD looks CGO-enabled and emits the full 'bd federation' help tree," >&2
+        echo "         which CI's pure-go docs build stubs out. BD_DOCS_ALLOW_CGO=1 is set," >&2
+        echo "         using it anyway; expect federation doc churn unless that is intended." >&2
+    else
+        echo "WARNING: $BD looks CGO-enabled; its 'bd federation' help differs from CI's" >&2
+        echo "         pure-go build and would add spurious federation doc churn." >&2
+        echo "         Rebuilding a pinned pure-go (CGO_ENABLED=0 -tags gms_pure_go) binary" >&2
+        echo "         for CI-consistent docs. Set BD_DOCS_ALLOW_CGO=1 to use it as-is." >&2
+        if [ -z "$TMP_BUILD_DIR" ]; then
+            TMP_BUILD_DIR="$(mktemp -d)"
+        fi
+        BD="$TMP_BUILD_DIR/bd-pure"
+        (cd "$PROJECT_ROOT" && CGO_ENABLED=0 go build -tags gms_pure_go -o "$BD" ./cmd/bd/)
     fi
-    BD="$TMP_BUILD_DIR/bd-pure"
-    (cd "$PROJECT_ROOT" && CGO_ENABLED=0 go build -tags gms_pure_go -o "$BD" ./cmd/bd/)
 fi
 
 if [ ! -x "$BD" ]; then


### PR DESCRIPTION
## Why

Regenerating the CLI doc artifacts (`scripts/generate-cli-docs.sh`, which also
drives `scripts/generate-llms-full.sh`) on a developer machine that has a C
compiler links CGO by default. A CGO-enabled `bd` exposes the full
`bd federation` subcommand tree, whereas CI builds the docs binary with
`CGO_ENABLED=0` (see `scripts/ci/pr-policy.sh`), which stubs federation
("built without CGO support"). The committed docs therefore come from the
stubbed build. A naive local regen produces ~hundreds of lines of spurious
federation churn (`federation.md`, `CLI_REFERENCE.md`, `llms-full.txt`) that
has nothing to do with the change being made — an easy trap to commit by
accident.

`generate-cli-docs.sh` already guards this by force-rebuilding a pure-go binary
when the resolved `bd` lacks the federation stub marker (added in #4474). This
PR hardens that guard's ergonomics: it offered no escape hatch for an
intentional full-federation regen, and announced the binary swap on stdout.

## What

- Route the CGO-mismatch notice to **stderr** so `--check`/CI stdout stays clean
  and the signal reads as a proper warning.
- Add a documented **`BD_DOCS_ALLOW_CGO=1`** override hook: set it to trust the
  supplied binary as-is (e.g. to deliberately regenerate the full federation
  tree). Default behavior is unchanged and safe — rebuild a pinned
  `CGO_ENABLED=0 -tags gms_pure_go` binary that matches CI.
- Make the warning name the pure-go recipe and reference the stub marker
  `Federation commands require CGO` (`cmd/bd/federation_nocgo.go`).
- Document the override in the script's `--help` text.

`generate-llms-full.sh` builds no `bd` binary (it only concatenates markdown),
so it needs no change here.

## Testing

- `bash -n` on both scripts: clean.
- `shellcheck scripts/generate-cli-docs.sh`: no findings. (Pre-existing
  informational/style findings in `generate-llms-full.sh` are untouched.)
- Built a pure-go binary (`CGO_ENABLED=0 go build -tags gms_pure_go`) and
  confirmed its `federation --help` contains the stub marker
  `Federation commands require CGO`; confirmed the CGO `federation.go` Long text
  does not, so the marker reliably distinguishes the two builds.
- Ran `./scripts/generate-cli-docs.sh --check <pure-go-bd>`: guard accepts the
  binary without rebuilding and reports docs fresh (`PASS`).
- `git diff --check`: clean.

(A CGO build could not be produced in this environment — missing ICU headers,
the same reason CI uses pure-go — so the negative-path rebuild was validated by
source inspection of the marker rather than execution.)

_claude-opus-4-8-high on behalf of matt wilkie_
