### PR TITLE
feat(create): add status flag for initial issue status

### DIFF
--- a/cmd/bd/create.go
+++ b/cmd/bd/create.go
@@ -162,6 +162,16 @@ var createCmd = &cobra.Command{
 
 		issueType, _ := cmd.Flags().GetString("type")
 		assignee, _ := cmd.Flags().GetString("assignee")
+		statusFlag, _ := cmd.Flags().GetString("status")
+		if statusFlag != "" {
+			var customStatuses []string
+			if cs, err := store.GetCustomStatuses(rootCtx); err == nil {
+				customStatuses = cs
+			}
+			if !types.Status(statusFlag).IsValidWithCustom(customStatuses) {
+				return HandleErrorRespectJSON("invalid status %q (built-in: open, in_progress, blocked, deferred, closed, pinned, hooked; or configure custom statuses via 'bd config set status.custom')", statusFlag)
+			}
+		}
 
 		labels, _ := cmd.Flags().GetStringSlice("labels")
 		labelAlias, _ := cmd.Flags().GetStringSlice("label")
@@ -344,6 +354,7 @@ var createCmd = &cobra.Command{
 				Labels:             labels,
 				MolType:            molType,
 				WispType:           wispType,
+				InitialStatus:      statusFlag,
 				DueAt:              dueAt,
 				DeferUntil:         deferUntil,
 				Metadata:           metadata,
@@ -503,6 +514,7 @@ var createCmd = &cobra.Command{
 			Actor:              eventActor,
 			Target:             eventTarget,
 			Payload:            eventPayload,
+			InitialStatus:      statusFlag,
 			DueAt:              dueAt,
 			DeferUntil:         deferUntil,
 			Metadata:           metadata,
@@ -727,6 +739,7 @@ type createIssueParams struct {
 	Actor              string
 	Target             string
 	Payload            string
+	InitialStatus      string
 	DueAt              *time.Time
 	DeferUntil         *time.Time
 	Metadata           json.RawMessage
@@ -739,7 +752,9 @@ func buildCreateIssue(params createIssueParams) *types.Issue {
 	}
 
 	status := types.StatusOpen
-	if params.DeferUntil != nil && params.DeferUntil.After(time.Now()) {
+	if params.InitialStatus != "" {
+		status = types.Status(params.InitialStatus)
+	} else if params.DeferUntil != nil && params.DeferUntil.After(time.Now()) {
 		status = types.StatusDeferred
 	}
 
@@ -856,6 +871,7 @@ func init() {
 	createCmd.Flags().Bool("dry-run", false, "Preview what would be created without actually creating")
 	registerPriorityFlag(createCmd, "2")
 	createCmd.Flags().StringP("type", "t", "task", "Issue type (bug|feature|task|epic|chore|decision); custom types require types.custom config; aliases: enhancement/feat→feature, dec/adr→decision")
+	createCmd.Flags().StringP("status", "s", "", "Initial status")
 	registerCommonIssueFlags(createCmd)
 	createCmd.Flags().String("spec-id", "", "Link to specification document")
 	createCmd.Flags().StringSliceP("labels", "l", []string{}, "Labels (comma-separated)")

--- a/cmd/bd/create_embedded_test.go
+++ b/cmd/bd/create_embedded_test.go
@@ -445,6 +445,42 @@ func TestEmbeddedCreate(t *testing.T) {
 		}
 	})
 
+	t.Run("initial_status_builtin", func(t *testing.T) {
+		dir, _, _ := bdInit(t, bd, "--prefix", "sb")
+		issue := bdCreate(t, bd, dir, "Blocked issue", "--status", "blocked")
+		if issue.Status != types.StatusBlocked {
+			t.Errorf("status: got %q, want %q", issue.Status, types.StatusBlocked)
+		}
+	})
+
+	t.Run("initial_status_custom", func(t *testing.T) {
+		dir, _, _ := bdInit(t, bd, "--prefix", "sc")
+		bdConfig(t, bd, dir, "set", "status.custom", "review:wip")
+		issue := bdCreate(t, bd, dir, "Review issue", "--status", "review")
+		if issue.Status != types.Status("review") {
+			t.Errorf("status: got %q, want review", issue.Status)
+		}
+	})
+
+	t.Run("initial_status_invalid", func(t *testing.T) {
+		dir, _, _ := bdInit(t, bd, "--prefix", "si")
+		out := bdCreateFail(t, bd, dir, "Invalid status issue", "--status", "not_a_status")
+		if !strings.Contains(out, `invalid status "not_a_status"`) {
+			t.Fatalf("expected invalid status error, got:\n%s", out)
+		}
+	})
+
+	t.Run("initial_status_wins_over_defer", func(t *testing.T) {
+		dir, _, _ := bdInit(t, bd, "--prefix", "sd")
+		issue := bdCreate(t, bd, dir, "Deferred but blocked issue", "--status", "blocked", "--defer", "+2h")
+		if issue.Status != types.StatusBlocked {
+			t.Errorf("status: got %q, want %q", issue.Status, types.StatusBlocked)
+		}
+		if issue.DeferUntil == nil {
+			t.Fatal("expected DeferUntil to be set")
+		}
+	})
+
 	t.Run("ephemeral", func(t *testing.T) {
 		dir, beadsDir, _ := bdInit(t, bd, "--prefix", "ep")
 		issue := bdCreate(t, bd, dir, "Ephemeral issue", "--ephemeral")

--- a/cmd/bd/create_input.go
+++ b/cmd/bd/create_input.go
@@ -23,6 +23,7 @@ type createInput struct {
 	explicitID         string
 	parentID           string
 	issueType          string
+	status             string
 	priority           int
 	assignee           string
 	externalRef        string
@@ -156,6 +157,7 @@ func gatherCreateInput(cmd *cobra.Command, args []string) (createInput, error) {
 	in.priority = priority
 
 	in.issueType, _ = cmd.Flags().GetString("type")
+	in.status, _ = cmd.Flags().GetString("status")
 	in.assignee, _ = cmd.Flags().GetString("assignee")
 	in.externalRef, _ = cmd.Flags().GetString("external-ref")
 	in.explicitID, _ = cmd.Flags().GetString("id")
@@ -268,6 +270,7 @@ var singleIssueOnlyFlags = []string{
 	"id", "parent", "no-inherit-labels",
 	"deps", "waits-for", "waits-for-gate",
 	"type", "priority", "assignee", "external-ref", "spec-id",
+	"status",
 	"description", "body", "message", "body-file", "description-file", "stdin",
 	"design", "design-file", "acceptance", "notes", "append-notes",
 	"labels", "label", "skills", "context",

--- a/cmd/bd/create_proxied_server.go
+++ b/cmd/bd/create_proxied_server.go
@@ -108,7 +108,6 @@ func runCreateProxiedSingle(_ *cobra.Command, ctx context.Context, in createInpu
 
 	// Load create context (read-only) to validate input before the write tx.
 	configUW, cctx := proxiedOpenUOW(ctx)
-	configUW.Close(ctx)
 
 	customTypes := resolveProxiedCustomTypes(cctx.CustomTypes)
 	if in.issueType != "" {
@@ -117,6 +116,16 @@ func runCreateProxiedSingle(_ *cobra.Command, ctx context.Context, in createInpu
 			FatalError("invalid type %q (allowed: built-ins plus configured custom types)", in.issueType)
 		}
 	}
+	if in.status != "" {
+		customStatuses, err := configUW.ConfigUseCase().GetCustomStatuses(ctx)
+		if err != nil {
+			FatalError("failed to get custom statuses: %v", err)
+		}
+		if !types.Status(in.status).IsValidWithCustom(types.CustomStatusNames(customStatuses)) {
+			FatalErrorRespectJSON("invalid status %q (built-in: open, in_progress, blocked, deferred, closed, pinned, hooked; or configure custom statuses via 'bd config set status.custom')", in.status)
+		}
+	}
+	configUW.Close(ctx)
 	if in.explicitID != "" {
 		effectivePrefix := overlayYAMLPrefix(cctx.IssuePrefix)
 		if err := validation.ValidateIDPrefixAllowed(in.explicitID, effectivePrefix, cctx.AllowedPrefixes, in.force); err != nil {
@@ -208,6 +217,7 @@ func buildCreateIssueFromInput(in createInput) *types.Issue {
 		Actor:              in.eventActor,
 		Target:             in.eventTarget,
 		Payload:            in.eventPayload,
+		InitialStatus:      in.status,
 		DueAt:              in.dueAt,
 		DeferUntil:         in.deferUntil,
 		Metadata:           in.metadata,

--- a/cmd/bd/create_proxied_server_test.go
+++ b/cmd/bd/create_proxied_server_test.go
@@ -100,6 +100,23 @@ func TestBuildCreateIssueFromInput_EmptyExternalRefIsNilPointer(t *testing.T) {
 	}
 }
 
+func TestBuildCreateIssueFromInput_ExplicitStatusWinsOverDefer(t *testing.T) {
+	deferUntil := time.Now().UTC().Add(24 * time.Hour)
+	got := buildCreateIssueFromInput(createInput{
+		title:      "T",
+		priority:   2,
+		issueType:  "task",
+		status:     "blocked",
+		deferUntil: &deferUntil,
+	})
+	if got.Status != types.StatusBlocked {
+		t.Errorf("Status = %q, want %q", got.Status, types.StatusBlocked)
+	}
+	if got.DeferUntil == nil || !got.DeferUntil.Equal(deferUntil) {
+		t.Errorf("DeferUntil = %v, want %v", got.DeferUntil, deferUntil)
+	}
+}
+
 func TestMaterializeGraphNodeIssue_DefaultsAndOpts(t *testing.T) {
 	t.Run("type and priority defaults", func(t *testing.T) {
 		issue := materializeGraphNodeIssue(GraphApplyNode{Key: "n", Title: "N"}, createInput{createdBy: "t"})

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -510,6 +510,7 @@ bd create [title] [flags]
       --silent                  Output only the issue ID (for scripting)
       --skills string           Required skills for this issue
       --spec-id string          Link to specification document
+  -s, --status string           Initial status
       --stdin                   Read description from stdin (alias for --body-file -)
       --title string            Issue title (alternative to positional argument)
   -t, --type string             Issue type (bug|feature|task|epic|chore|decision); custom types require types.custom config; aliases: enhancement/feat→feature, dec/adr→decision (default "task")

--- a/internal/storage/issueops/helpers.go
+++ b/internal/storage/issueops/helpers.go
@@ -379,25 +379,11 @@ func ComputeAdaptiveLength(numIssues int, cfg AdaptiveIDConfig) int {
 
 // GetCustomStatusesTx reads custom statuses from config within a transaction.
 func GetCustomStatusesTx(ctx context.Context, tx *sql.Tx) ([]string, error) {
-	var raw string
-	err := tx.QueryRowContext(ctx, "SELECT value FROM config WHERE `key` = ?", "status.custom").Scan(&raw)
-	if err == sql.ErrNoRows || raw == "" {
-		return nil, nil
-	}
+	detailed, err := ResolveCustomStatusesDetailedInTx(ctx, tx)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read status.custom config: %w", err)
+		return nil, err
 	}
-	var statuses []string
-	if err := json.Unmarshal([]byte(raw), &statuses); err != nil {
-		// Try comma-separated fallback
-		for _, s := range strings.Split(raw, ",") {
-			s = strings.TrimSpace(s)
-			if s != "" {
-				statuses = append(statuses, s)
-			}
-		}
-	}
-	return statuses, nil
+	return types.CustomStatusNames(detailed), nil
 }
 
 // GetCustomTypesTx reads custom types from config within a transaction.

--- a/internal/storage/issueops/helpers_test.go
+++ b/internal/storage/issueops/helpers_test.go
@@ -220,6 +220,43 @@ func TestFormatJSONStringArray(t *testing.T) {
 	}
 }
 
+func TestGetCustomStatusesTxParsesTypedConfigNames(t *testing.T) {
+	t.Parallel()
+
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	mock.ExpectBegin()
+	mock.ExpectQuery("SELECT name, category FROM custom_statuses ORDER BY name").
+		WillReturnRows(sqlmock.NewRows([]string{"name", "category"}))
+	mock.ExpectQuery("SELECT value FROM config WHERE `key` = \\?").
+		WithArgs("status.custom").
+		WillReturnRows(sqlmock.NewRows([]string{"value"}).AddRow("review:wip,on_hold:frozen"))
+	tx, err := db.Begin()
+	if err != nil {
+		t.Fatalf("db.Begin: %v", err)
+	}
+	mock.ExpectRollback()
+
+	got, err := GetCustomStatusesTx(context.Background(), tx)
+	if err != nil {
+		t.Fatalf("GetCustomStatusesTx returned error: %v", err)
+	}
+	want := []string{"review", "on_hold"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("GetCustomStatusesTx() = %#v, want %#v", got, want)
+	}
+	if err := tx.Rollback(); err != nil {
+		t.Fatalf("tx.Rollback: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
 func TestReadConfigPrefix(t *testing.T) {
 	t.Parallel()
 

--- a/website/docs/cli-reference/create.md
+++ b/website/docs/cli-reference/create.md
@@ -56,6 +56,7 @@ bd create [title] [flags]
       --silent                  Output only the issue ID (for scripting)
       --skills string           Required skills for this issue
       --spec-id string          Link to specification document
+  -s, --status string           Initial status
       --stdin                   Read description from stdin (alias for --body-file -)
       --title string            Issue title (alternative to positional argument)
   -t, --type string             Issue type (bug|feature|task|epic|chore|decision); custom types require types.custom config; aliases: enhancement/feat→feature, dec/adr→decision (default "task")


### PR DESCRIPTION
## What

Adds `bd create --status/-s` so a new issue can be created directly in a built-in or configured custom status.

The default remains unchanged: without `--status`, new issues start as `open`, except future `--defer` still starts them as `deferred`. When both `--status` and `--defer` are present, the explicit status wins and `defer_until` is still preserved.

## Why

This completes the existing custom-status workflow rather than adding a new status concept: `bd update --status` already validates built-in and configured custom statuses, and `bd create` should be able to start an issue in the same lifecycle state in one step. This avoids create-then-update transitions for agents or workflows that model their lifecycle in status.

## Notes

- Reuses `types.Status(...).IsValidWithCustom(...)` with configured custom statuses for CLI validation.
- Threads the initial status through the shared create builder and proxied-server input path.
- Normalizes typed `status.custom` entries during create insertion, so config like `review:wip` validates new issues with status `review`.
- PR preflight found #4023, but it is about prune/export/migrate-personal and does not overlap this create/status change.

## Validation

- `CGO_ENABLED=1 go test -tags gms_pure_go ./cmd/bd -run 'TestBuildCreateIssueFromInput'`
- `CGO_ENABLED=1 go test -tags gms_pure_go ./internal/storage/issueops -run 'TestGetCustomStatusesTxParsesTypedConfigNames'`
- `CGO_ENABLED=1 go build -tags gms_pure_go ./...`
- Temp-repo smoke: `bd create --status blocked`, configured `status.custom review:wip` then `bd create --status review`, and invalid `--status nope`
- `./scripts/check-doc-flags.sh ./bd`
- `./scripts/check-doc-freshness.sh`

Known local validation issues unrelated to this diff:

- `make test` timed out in existing doctor tests: `TestDoctorWithBeadsDir` and `TestCheckDocumentationBdPrimeReference`.
- `golangci-lint run ./...` could not start because installed `golangci-lint` was built with Go 1.24 while this module targets Go 1.26.2.
