### PR TITLE
feat(lease): land the leasing stack + schema v54 (claim-TTL, heartbeat, reclaim)

### DIFF
--- a/cmd/bd/heartbeat.go
+++ b/cmd/bd/heartbeat.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/steveyegge/beads/internal/metrics"
+	"github.com/steveyegge/beads/internal/ui"
+)
+
+var heartbeatCmd = &cobra.Command{
+	Use:     "heartbeat <id>",
+	Aliases: []string{"hb"},
+	GroupID: "issues",
+	Short:   "Refresh the lease on an issue you hold in_progress",
+	Long: `Refresh the lease on an issue you currently hold in_progress.
+
+A claim carries a lease that expires after a TTL. A worker keeps its claim alive
+by heartbeating faster than the TTL; once it stops (because it died), the lease
+goes stale and 'bd reclaim' reverts the issue to ready so another worker can pick
+it up. Heartbeat pushes lease_expires_at forward and stamps heartbeat_at = now.
+
+Only the current owner may heartbeat. If the lease has already been reclaimed or
+the issue closed, heartbeat fails so the worker learns to stop.
+
+Heartbeat writes a Dolt commit, so heartbeat well below the TTL but not so fast
+it bloats history — cadence should be a small fraction of the TTL, not per-op.
+
+Examples:
+  bd heartbeat bd-123
+  bd hb bd-123`,
+	Args:          cobra.ExactArgs(1),
+	SilenceUsage:  true,
+	SilenceErrors: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		CheckReadonly("heartbeat")
+
+		evt := metrics.NewCommandEvent("heartbeat")
+		defer func() {
+			if c := metrics.Global(); c != nil {
+				c.CloseEventAndAdd(evt)
+			}
+		}()
+
+		ctx := rootCtx
+		id := args[0]
+
+		result, err := resolveAndGetIssueForMutation(ctx, store, id)
+		if err != nil {
+			if result != nil {
+				result.Close()
+			}
+			return HandleErrorRespectJSON("resolving %s: %v", id, err)
+		}
+		if result == nil || result.Issue == nil {
+			if result != nil {
+				result.Close()
+			}
+			return HandleErrorRespectJSON("issue %s not found", id)
+		}
+		defer result.Close()
+
+		issueStore := result.Store
+		if err := issueStore.HeartbeatIssue(ctx, result.ResolvedID, actor); err != nil {
+			return HandleErrorRespectJSON("heartbeat %s: %v", result.ResolvedID, err)
+		}
+
+		if err := commitPendingIfEmbedded(ctx, issueStore, actor, doltAutoCommitParams{
+			Command:  "heartbeat",
+			IssueIDs: []string{result.ResolvedID},
+		}); err != nil {
+			return HandleErrorRespectJSON("failed to commit: %v", err)
+		}
+
+		SetLastTouchedID(result.ResolvedID)
+
+		if jsonOutput {
+			return outputJSON(map[string]string{
+				"id":     result.ResolvedID,
+				"status": "heartbeat",
+				"owner":  actor,
+			})
+		}
+		fmt.Printf("%s Heartbeat %s (lease refreshed)\n", ui.RenderPass("✓"), formatFeedbackID(result.ResolvedID, result.Issue.Title))
+		return nil
+	},
+}
+
+func init() {
+	heartbeatCmd.ValidArgsFunction = issueIDCompletion
+	rootCmd.AddCommand(heartbeatCmd)
+}

--- a/cmd/bd/reclaim.go
+++ b/cmd/bd/reclaim.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/steveyegge/beads/internal/metrics"
+	"github.com/steveyegge/beads/internal/storage/issueops"
+	"github.com/steveyegge/beads/internal/ui"
+)
+
+var reclaimCmd = &cobra.Command{
+	Use:     "reclaim",
+	GroupID: "issues",
+	Short:   "Revert stale-lease in_progress issues back to ready (dead-worker recovery)",
+	Long: `Revert in_progress issues whose lease has gone stale back to ready.
+
+When a worker claims an issue it takes a lease that expires after a TTL, kept
+alive by 'bd heartbeat'. A worker that dies stops heartbeating, so its lease
+expires and its issue would otherwise stay in_progress forever. reclaim is the
+reaper: it finds in_progress issues whose lease expired more than --older-than
+ago, clears the assignee, and sets them back to open so another worker can
+claim them. The previous owner's stale lease is recorded as a recovery event.
+
+--older-than is a grace window past lease expiry: only leases that expired at
+least this long ago are reclaimed, so a worker briefly paused (GC, clock skew)
+is not robbed of live work. Run it from a supervisor on a timer with a window
+of roughly 2× the claim TTL.
+
+Examples:
+  bd reclaim                       # default grace window (2× the lease TTL)
+  bd reclaim --older-than 10m      # reclaim leases expired >10m ago
+  bd reclaim --older-than 0s       # reclaim every currently-expired lease`,
+	Args:          cobra.NoArgs,
+	SilenceUsage:  true,
+	SilenceErrors: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		CheckReadonly("reclaim")
+
+		evt := metrics.NewCommandEvent("reclaim")
+		defer func() {
+			if c := metrics.Global(); c != nil {
+				c.CloseEventAndAdd(evt)
+			}
+		}()
+
+		olderThan, _ := cmd.Flags().GetDuration("older-than")
+		if olderThan < 0 {
+			return HandleErrorRespectJSON("--older-than must not be negative")
+		}
+
+		ctx := rootCtx
+		reclaimed, err := store.ReclaimExpiredLeases(ctx, olderThan, actor)
+		if err != nil {
+			return HandleErrorRespectJSON("reclaim: %v", err)
+		}
+
+		ids := make([]string, 0, len(reclaimed))
+		for _, r := range reclaimed {
+			ids = append(ids, r.ID)
+		}
+		if err := commitPendingIfEmbedded(ctx, store, actor, doltAutoCommitParams{
+			Command:  "reclaim",
+			IssueIDs: ids,
+		}); err != nil {
+			return HandleErrorRespectJSON("failed to commit: %v", err)
+		}
+
+		if jsonOutput {
+			return outputJSON(map[string]interface{}{
+				"reclaimed": reclaimed,
+				"count":     len(reclaimed),
+			})
+		}
+		if len(reclaimed) == 0 {
+			fmt.Printf("%s No stale leases to reclaim\n", ui.RenderPass("✓"))
+			return nil
+		}
+		fmt.Printf("%s Reclaimed %d stale-lease issue(s):\n", ui.RenderPass("✓"), len(reclaimed))
+		for _, r := range reclaimed {
+			owner := r.PreviousOwner
+			if owner == "" {
+				owner = "(unassigned)"
+			}
+			fmt.Printf("  %s (was held by %s)\n", r.ID, owner)
+		}
+		return nil
+	},
+}
+
+func init() {
+	reclaimCmd.Flags().Duration("older-than", 2*issueops.DefaultLeaseTTL,
+		"Only reclaim leases that expired at least this long ago (grace window)")
+	rootCmd.AddCommand(reclaimCmd)
+}

--- a/cmd/bd/show_format.go
+++ b/cmd/bd/show_format.go
@@ -123,6 +123,16 @@ func formatIssueMetadata(issue *types.Issue) string {
 		lines = append(lines, strings.Join(timeParts, " · "))
 	}
 
+	// Lease line: only when an active lease is held (in_progress + non-null
+	// lease_expires_at). row_lock is internal and never surfaced.
+	if issue.Status == types.StatusInProgress && issue.LeaseExpiresAt != nil {
+		leaseLine := fmt.Sprintf("Lease: expires %s", formatTimeUntil(*issue.LeaseExpiresAt))
+		if issue.HeartbeatAt != nil {
+			leaseLine += fmt.Sprintf(" (heartbeat %s)", formatTimeAgo(*issue.HeartbeatAt))
+		}
+		lines = append(lines, ui.RenderMuted(leaseLine))
+	}
+
 	// Line 3: Close reason (if closed)
 	if issue.Status == types.StatusClosed && issue.CloseReason != "" {
 		lines = append(lines, ui.RenderMuted(fmt.Sprintf("Close reason: %s", issue.CloseReason)))

--- a/cmd/bd/wisp.go
+++ b/cmd/bd/wisp.go
@@ -536,6 +536,38 @@ func formatTimeAgo(t time.Time) string {
 	}
 }
 
+// formatTimeUntil returns a human-readable relative time for a future instant,
+// the forward-looking mirror of formatTimeAgo. Used for lease expiry in bd show.
+// A past (or present) instant renders as "expired".
+func formatTimeUntil(t time.Time) string {
+	d := time.Until(t)
+	if d <= 0 {
+		return "expired"
+	}
+	switch {
+	case d < time.Minute:
+		return "in <1 min"
+	case d < time.Hour:
+		mins := int(d.Minutes())
+		if mins == 1 {
+			return "in 1 min"
+		}
+		return fmt.Sprintf("in %d mins", mins)
+	case d < 24*time.Hour:
+		hours := int(d.Hours())
+		if hours == 1 {
+			return "in 1 hour"
+		}
+		return fmt.Sprintf("in %d hours", hours)
+	default:
+		days := int(d.Hours() / 24)
+		if days == 1 {
+			return "in 1 day"
+		}
+		return fmt.Sprintf("in %d days", days)
+	}
+}
+
 var wispGCCmd = &cobra.Command{
 	Use:   "gc",
 	Short: "Garbage collect old/abandoned wisps",

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -25,6 +25,7 @@ Reference for bd Latest. Generated from `bd help --all`.
   - [bd gate list](#bd-gate-list) — List gate issues
   - [bd gate resolve](#bd-gate-resolve) — Manually resolve (close) a gate
   - [bd gate show](#bd-gate-show) — Show a gate issue
+- [bd heartbeat](#bd-heartbeat) — Refresh the lease on an issue you hold in_progress
 - [bd label](#bd-label) — Manage issue labels
   - [bd label add](#bd-label-add) — Add a label to one or more issues
   - [bd label list](#bd-label-list) — List labels for an issue
@@ -43,6 +44,7 @@ Reference for bd Latest. Generated from `bd help --all`.
 - [bd promote](#bd-promote) — Promote a wisp to a permanent bead
 - [bd q](#bd-q) — Quick capture: create issue and output only ID
 - [bd query](#bd-query) — Query issues using a simple query language
+- [bd reclaim](#bd-reclaim) — Revert stale-lease in_progress issues back to ready (dead-worker recovery)
 - [bd reopen](#bd-reopen) — Reopen one or more closed issues
 - [bd search](#bd-search) — Search issues by text query
 - [bd set-state](#bd-set-state) — Set operational state (creates event + updates label)
@@ -813,6 +815,31 @@ This is similar to 'bd show' but validates that the issue is a gate.
 bd gate show <gate-id>
 ```
 
+### bd heartbeat
+
+Refresh the lease on an issue you currently hold in_progress.
+
+A claim carries a lease that expires after a TTL. A worker keeps its claim alive
+by heartbeating faster than the TTL; once it stops (because it died), the lease
+goes stale and 'bd reclaim' reverts the issue to ready so another worker can pick
+it up. Heartbeat pushes lease_expires_at forward and stamps heartbeat_at = now.
+
+Only the current owner may heartbeat. If the lease has already been reclaimed or
+the issue closed, heartbeat fails so the worker learns to stop.
+
+Heartbeat writes a Dolt commit, so heartbeat well below the TTL but not so fast
+it bloats history — cadence should be a small fraction of the TTL, not per-op.
+
+Examples:
+  bd heartbeat bd-123
+  bd hb bd-123
+
+```
+bd heartbeat <id>
+```
+
+**Aliases:** hb
+
 ### bd label
 
 Manage issue labels
@@ -1208,6 +1235,37 @@ bd query [expression] [flags]
       --parse-only    Only parse the query and show the AST (for debugging)
   -r, --reverse       Reverse sort order
       --sort string   Sort by field: priority, created, updated, closed, status, id, title, type, assignee
+```
+
+### bd reclaim
+
+Revert in_progress issues whose lease has gone stale back to ready.
+
+When a worker claims an issue it takes a lease that expires after a TTL, kept
+alive by 'bd heartbeat'. A worker that dies stops heartbeating, so its lease
+expires and its issue would otherwise stay in_progress forever. reclaim is the
+reaper: it finds in_progress issues whose lease expired more than --older-than
+ago, clears the assignee, and sets them back to open so another worker can
+claim them. The previous owner's stale lease is recorded as a recovery event.
+
+--older-than is a grace window past lease expiry: only leases that expired at
+least this long ago are reclaimed, so a worker briefly paused (GC, clock skew)
+is not robbed of live work. Run it from a supervisor on a timer with a window
+of roughly 2× the claim TTL.
+
+Examples:
+  bd reclaim                       # default grace window (2× the lease TTL)
+  bd reclaim --older-than 10m      # reclaim leases expired &gt;10m ago
+  bd reclaim --older-than 0s       # reclaim every currently-expired lease
+
+```
+bd reclaim [flags]
+```
+
+**Flags:**
+
+```
+      --older-than duration   Only reclaim leases that expired at least this long ago (grace window) (default 10m0s)
 ```
 
 ### bd reopen

--- a/internal/storage/bulk_issues.go
+++ b/internal/storage/bulk_issues.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"context"
+	"time"
 
 	"github.com/steveyegge/beads/internal/types"
 )
@@ -14,6 +15,14 @@ type BulkIssueStore interface {
 	UpdateIssueID(ctx context.Context, oldID, newID string, issue *types.Issue, actor string) error
 	ClaimIssue(ctx context.Context, id string, actor string) error
 	ClaimReadyIssue(ctx context.Context, filter types.WorkFilter, actor string) (*types.Issue, error)
+	// HeartbeatIssue refreshes the lease on an in_progress issue held by actor,
+	// pushing its expiry forward so a reaper won't reclaim it. Returns
+	// ErrNotClaimable/ErrAlreadyClaimed if actor no longer holds the lease.
+	HeartbeatIssue(ctx context.Context, id, actor string) error
+	// ReclaimExpiredLeases reverts in_progress issues whose lease expired more
+	// than olderThan ago back to ready (clearing the assignee), recovering work
+	// stranded by dead workers. Returns the issues it reclaimed.
+	ReclaimExpiredLeases(ctx context.Context, olderThan time.Duration, actor string) ([]types.ReclaimedLease, error)
 	PromoteFromEphemeral(ctx context.Context, id string, actor string) error
 	GetNextChildID(ctx context.Context, parentID string) (string, error)
 }

--- a/internal/storage/dolt/concurrent_test.go
+++ b/internal/storage/dolt/concurrent_test.go
@@ -955,3 +955,127 @@ func TestSerializationConflictRetry(t *testing.T) {
 		t.Fatalf("expected %d labels, got %d: %v", numGoroutines, len(labels), labels)
 	}
 }
+
+// =============================================================================
+// Test: Concurrent Work-Queue Drain (the "Gas Station" scenario)
+//
+// N workers concurrently dequeue from ONE shared ready-front via
+// ClaimReadyIssue until it returns nil, exactly as N agent clones draining a
+// shared Beads work queue would. This is the core Gas Station claim-queue
+// invariant and the scenario the multi-agent port harness depends on:
+//
+//   - every issue is claimed by EXACTLY ONE worker (no double-claim / lost work)
+//   - every issue is claimed (no stranded ready work left behind)
+//   - the count of distinct claims equals the number of issues
+//
+// Dolt has no SKIP LOCKED, so the safety comes from the claim CAS (UPDATE ...
+// SET assignee WHERE assignee IS NULL) colliding on the same cell, surfacing as
+// a 1213/1205 serialization conflict, which ClaimReadyIssue's withRetryTx
+// re-scans and retries. This test is the regression guard for that guarantee.
+// =============================================================================
+
+func TestConcurrentWorkQueueDrain(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping work-queue drain test in short mode")
+	}
+
+	store, cleanup := setupConcurrentTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := concurrentTestContext(t)
+	defer cancel()
+
+	// Seed a ready-front: all open, unassigned, no blockers => all ready.
+	const numIssues = 40
+	want := make(map[string]bool, numIssues)
+	for i := 0; i < numIssues; i++ {
+		id := fmt.Sprintf("queue-%03d", i)
+		issue := &types.Issue{
+			ID:          id,
+			Title:       fmt.Sprintf("Queue item %d", i),
+			Description: "ready work for the shared drain",
+			Status:      types.StatusOpen,
+			Priority:    (i % 4) + 1,
+			IssueType:   types.TypeTask,
+		}
+		if err := store.CreateIssue(ctx, issue, "seeder"); err != nil {
+			t.Fatalf("seed issue %s: %v", id, err)
+		}
+		want[id] = true
+	}
+
+	const numWorkers = 6
+
+	var mu sync.Mutex
+	claimedBy := make(map[string]string, numIssues) // issueID -> worker that claimed it
+	var doubleClaim atomic.Int32
+	var claimErrs atomic.Int32
+	var wg sync.WaitGroup
+
+	for w := 0; w < numWorkers; w++ {
+		wg.Add(1)
+		go func(workerID int) {
+			defer wg.Done()
+			actor := fmt.Sprintf("worker-%d", workerID)
+			for {
+				issue, err := store.ClaimReadyIssue(ctx, types.WorkFilter{}, actor)
+				if err != nil {
+					claimErrs.Add(1)
+					return
+				}
+				if issue == nil {
+					return // ready-front drained from this worker's snapshot
+				}
+				mu.Lock()
+				if prev, ok := claimedBy[issue.ID]; ok {
+					t.Errorf("issue %s double-claimed: first by %s, then by %s", issue.ID, prev, actor)
+					doubleClaim.Add(1)
+				} else {
+					claimedBy[issue.ID] = actor
+				}
+				mu.Unlock()
+			}
+		}(w)
+	}
+
+	done := make(chan struct{})
+	go func() { wg.Wait(); close(done) }()
+	select {
+	case <-done:
+	case <-ctx.Done():
+		t.Fatal("work-queue drain timeout — possible deadlock or claim livelock")
+	}
+
+	if n := claimErrs.Load(); n != 0 {
+		t.Errorf("got %d claim errors; ClaimReadyIssue should retry serialization conflicts internally and never surface one", n)
+	}
+	if n := doubleClaim.Load(); n != 0 {
+		t.Errorf("got %d double-claims; the claim CAS must give each issue to exactly one worker", n)
+	}
+
+	// No stranded work: every seeded issue claimed exactly once.
+	if len(claimedBy) != numIssues {
+		t.Errorf("claimed %d distinct issues, want %d (stranded ready work)", len(claimedBy), numIssues)
+	}
+	for id := range want {
+		if _, ok := claimedBy[id]; !ok {
+			t.Errorf("issue %s was never claimed (stranded)", id)
+		}
+	}
+
+	// Cross-check against the store: nothing should remain ready/open.
+	remaining, err := store.ClaimReadyIssue(ctx, types.WorkFilter{}, "final-sweeper")
+	if err != nil {
+		t.Fatalf("final sweep: %v", err)
+	}
+	if remaining != nil {
+		t.Errorf("ready-front not fully drained: %s still claimable after all workers finished", remaining.ID)
+	}
+
+	// Distribution sanity (informational): how evenly work spread across workers.
+	perWorker := make(map[string]int)
+	for _, actor := range claimedBy {
+		perWorker[actor]++
+	}
+	t.Logf("drain complete: %d issues across %d workers: %v", len(claimedBy), numWorkers, perWorker)
+}

--- a/internal/storage/dolt/issues.go
+++ b/internal/storage/dolt/issues.go
@@ -175,30 +175,27 @@ func (s *DoltStore) UpdateIssue(ctx context.Context, id string, updates map[stri
 		return s.DemoteToWisp(ctx, id, updates, actor)
 	}
 
-	tx, err := s.db.BeginTx(ctx, nil)
-	if err != nil {
-		return fmt.Errorf("failed to begin transaction: %w", err)
-	}
-	defer func() { _ = tx.Rollback() }()
+	// Wrap in withRetryTx so a concurrent writer that loses Dolt's optimistic
+	// commit-time merge (MySQL 1213/1205, guaranteed server-side rollback) is
+	// retried rather than surfaced as a hard failure. Dolt has no real row
+	// locking — FOR UPDATE / SKIP LOCKED are parse-only no-ops
+	// (https://www.dolthub.com/blog/2023-10-23-hold-my-beer/) — so retry is the
+	// only safety net. withRetryTx owns BeginTx and the final Commit.
+	return s.withRetryTx(ctx, func(tx *sql.Tx) error {
+		if _, err := issueops.UpdateIssueInTx(ctx, tx, id, updates, actor); err != nil {
+			return err
+		}
 
-	_, err = issueops.UpdateIssueInTx(ctx, tx, id, updates, actor)
-	if err != nil {
-		return err
-	}
-
-	for _, table := range []string{"issues", "events"} {
-		_, _ = tx.ExecContext(ctx, "CALL DOLT_ADD(?)", table)
-	}
-	commitMsg := fmt.Sprintf("bd: update %s", id)
-	if _, err := tx.ExecContext(ctx, "CALL DOLT_COMMIT('-m', ?, '--author', ?)",
-		commitMsg, s.commitAuthorString()); err != nil && !isDoltNothingToCommit(err) {
-		return fmt.Errorf("dolt commit: %w", err)
-	}
-
-	if err := tx.Commit(); err != nil {
-		return wrapTransactionError("commit update issue", err)
-	}
-	return nil
+		for _, table := range []string{"issues", "events"} {
+			_, _ = tx.ExecContext(ctx, "CALL DOLT_ADD(?)", table)
+		}
+		commitMsg := fmt.Sprintf("bd: update %s", id)
+		if _, err := tx.ExecContext(ctx, "CALL DOLT_COMMIT('-m', ?, '--author', ?)",
+			commitMsg, s.commitAuthorString()); err != nil && !isDoltNothingToCommit(err) {
+			return fmt.Errorf("dolt commit: %w", err)
+		}
+		return nil
+	})
 }
 
 // ClaimIssue atomically claims an issue using compare-and-swap semantics.
@@ -213,60 +210,64 @@ func (s *DoltStore) ClaimIssue(ctx context.Context, id string, actor string) err
 		return s.claimWisp(ctx, id, actor)
 	}
 
-	tx, err := s.db.BeginTx(ctx, nil)
-	if err != nil {
-		return fmt.Errorf("failed to begin transaction: %w", err)
-	}
-	defer func() { _ = tx.Rollback() }()
+	// Wrap in withRetryTx so a concurrent claim that loses Dolt's optimistic
+	// commit-time merge (MySQL 1213/1205, guaranteed server-side rollback) is
+	// retried instead of surfaced as a hard failure. Dolt has no real row
+	// locking — FOR UPDATE / SKIP LOCKED are parse-only no-ops
+	// (https://www.dolthub.com/blog/2023-10-23-hold-my-beer/) — so retry is the
+	// only safety net under concurrent claimants. The body stays a single tx
+	// (CAS + DOLT_COMMIT); withRetryTx owns BeginTx and the final Commit.
+	return s.withRetryTx(ctx, func(tx *sql.Tx) error {
+		if _, err := issueops.ClaimIssueInTx(ctx, tx, id, actor); err != nil {
+			return err
+		}
 
-	if _, err := issueops.ClaimIssueInTx(ctx, tx, id, actor); err != nil {
-		return err
-	}
-
-	// Dolt versioning for permanent issues.
-	// GH#2455: Stage only the tables we modified, then commit without -A.
-	for _, table := range []string{"issues", "events"} {
-		_, _ = tx.ExecContext(ctx, "CALL DOLT_ADD(?)", table)
-	}
-	commitMsg := fmt.Sprintf("bd: claim %s", id)
-	if _, err := tx.ExecContext(ctx, "CALL DOLT_COMMIT('-m', ?, '--author', ?)",
-		commitMsg, s.commitAuthorString()); err != nil && !isDoltNothingToCommit(err) {
-		return fmt.Errorf("dolt commit: %w", err)
-	}
-
-	if err := tx.Commit(); err != nil {
-		return wrapTransactionError("commit claim issue", err)
-	}
-	return nil
+		// Dolt versioning for permanent issues.
+		// GH#2455: Stage only the tables we modified, then commit without -A.
+		for _, table := range []string{"issues", "events"} {
+			_, _ = tx.ExecContext(ctx, "CALL DOLT_ADD(?)", table)
+		}
+		commitMsg := fmt.Sprintf("bd: claim %s", id)
+		if _, err := tx.ExecContext(ctx, "CALL DOLT_COMMIT('-m', ?, '--author', ?)",
+			commitMsg, s.commitAuthorString()); err != nil && !isDoltNothingToCommit(err) {
+			return fmt.Errorf("dolt commit: %w", err)
+		}
+		return nil
+	})
 }
 
 // ClaimReadyIssue atomically claims the first ready issue matching filter.
 func (s *DoltStore) ClaimReadyIssue(ctx context.Context, filter types.WorkFilter, actor string) (*types.Issue, error) {
-	tx, err := s.db.BeginTx(ctx, nil)
-	if err != nil {
-		return nil, fmt.Errorf("failed to begin transaction: %w", err)
-	}
-	defer func() { _ = tx.Rollback() }()
+	// Wrap in withRetryTx: under concurrent workers the loser of Dolt's
+	// optimistic commit-time merge gets MySQL 1213/1205 (guaranteed server-side
+	// rollback). Retrying re-scans the ready front from a fresh snapshot and
+	// claims the next available issue instead of failing the dequeue. Dolt has
+	// no real row locking — FOR UPDATE / SKIP LOCKED are parse-only no-ops
+	// (https://www.dolthub.com/blog/2023-10-23-hold-my-beer/) — so retry is the
+	// safety net. withRetryTx owns BeginTx and the final Commit.
+	var claimed *types.Issue
+	err := s.withRetryTx(ctx, func(tx *sql.Tx) error {
+		var err error
+		claimed, err = issueops.ClaimReadyIssueInTx(ctx, tx, filter, actor)
+		if err != nil {
+			return err
+		}
+		if claimed == nil {
+			return nil
+		}
 
-	claimed, err := issueops.ClaimReadyIssueInTx(ctx, tx, filter, actor)
+		for _, table := range []string{"issues", "events"} {
+			_, _ = tx.ExecContext(ctx, "CALL DOLT_ADD(?)", table)
+		}
+		commitMsg := fmt.Sprintf("bd: claim ready %s", claimed.ID)
+		if _, err := tx.ExecContext(ctx, "CALL DOLT_COMMIT('-m', ?, '--author', ?)",
+			commitMsg, s.commitAuthorString()); err != nil && !isDoltNothingToCommit(err) {
+			return fmt.Errorf("dolt commit: %w", err)
+		}
+		return nil
+	})
 	if err != nil {
 		return nil, err
-	}
-	if claimed == nil {
-		return nil, nil
-	}
-
-	for _, table := range []string{"issues", "events"} {
-		_, _ = tx.ExecContext(ctx, "CALL DOLT_ADD(?)", table)
-	}
-	commitMsg := fmt.Sprintf("bd: claim ready %s", claimed.ID)
-	if _, err := tx.ExecContext(ctx, "CALL DOLT_COMMIT('-m', ?, '--author', ?)",
-		commitMsg, s.commitAuthorString()); err != nil && !isDoltNothingToCommit(err) {
-		return nil, fmt.Errorf("dolt commit: %w", err)
-	}
-
-	if err := tx.Commit(); err != nil {
-		return nil, wrapTransactionError("commit claim ready issue", err)
 	}
 	return claimed, nil
 }
@@ -306,31 +307,29 @@ func (s *DoltStore) CloseIssue(ctx context.Context, id string, reason string, ac
 		return s.closeWisp(ctx, id, reason, actor, session)
 	}
 
-	tx, err := s.db.BeginTx(ctx, nil)
-	if err != nil {
-		return fmt.Errorf("failed to begin transaction: %w", err)
-	}
-	defer func() { _ = tx.Rollback() }()
+	// Wrap in withRetryTx so a concurrent writer that loses Dolt's optimistic
+	// commit-time merge (MySQL 1213/1205, guaranteed server-side rollback) is
+	// retried rather than surfaced as a hard failure. Dolt has no real row
+	// locking — FOR UPDATE / SKIP LOCKED are parse-only no-ops
+	// (https://www.dolthub.com/blog/2023-10-23-hold-my-beer/) — so retry is the
+	// only safety net. withRetryTx owns BeginTx and the final Commit.
+	return s.withRetryTx(ctx, func(tx *sql.Tx) error {
+		if _, err := issueops.CloseIssueInTx(ctx, tx, id, reason, actor, session); err != nil {
+			return err
+		}
 
-	if _, err := issueops.CloseIssueInTx(ctx, tx, id, reason, actor, session); err != nil {
-		return err
-	}
-
-	// Dolt versioning for permanent issues.
-	// GH#2455: Stage only the tables we modified, then commit without -A.
-	for _, table := range []string{"issues", "events"} {
-		_, _ = tx.ExecContext(ctx, "CALL DOLT_ADD(?)", table)
-	}
-	commitMsg := fmt.Sprintf("bd: close %s", id)
-	if _, err := tx.ExecContext(ctx, "CALL DOLT_COMMIT('-m', ?, '--author', ?)",
-		commitMsg, s.commitAuthorString()); err != nil && !isDoltNothingToCommit(err) {
-		return fmt.Errorf("dolt commit: %w", err)
-	}
-
-	if err := tx.Commit(); err != nil {
-		return wrapTransactionError("commit close issue", err)
-	}
-	return nil
+		// Dolt versioning for permanent issues.
+		// GH#2455: Stage only the tables we modified, then commit without -A.
+		for _, table := range []string{"issues", "events"} {
+			_, _ = tx.ExecContext(ctx, "CALL DOLT_ADD(?)", table)
+		}
+		commitMsg := fmt.Sprintf("bd: close %s", id)
+		if _, err := tx.ExecContext(ctx, "CALL DOLT_COMMIT('-m', ?, '--author', ?)",
+			commitMsg, s.commitAuthorString()); err != nil && !isDoltNothingToCommit(err) {
+			return fmt.Errorf("dolt commit: %w", err)
+		}
+		return nil
+	})
 }
 
 // DeleteIssue permanently removes an issue

--- a/internal/storage/dolt/issues.go
+++ b/internal/storage/dolt/issues.go
@@ -272,6 +272,65 @@ func (s *DoltStore) ClaimReadyIssue(ctx context.Context, filter types.WorkFilter
 	return claimed, nil
 }
 
+// HeartbeatIssue refreshes the lease on an issue actor holds in_progress,
+// pushing lease_expires_at forward and rewriting row_lock (see issueops.lease).
+// Wrapped in withRetryTx so a heartbeat that loses Dolt's optimistic merge to a
+// concurrent reclaim/close on the same row is replayed against a fresh snapshot
+// rather than surfaced — the row_lock collision is what forces that retry.
+func (s *DoltStore) HeartbeatIssue(ctx context.Context, id, actor string) error {
+	if s.isActiveWisp(ctx, id) {
+		// Wisps are ephemeral and never leased; nothing to heartbeat.
+		return fmt.Errorf("%w: %s is ephemeral", storage.ErrNotClaimable, id)
+	}
+	return s.withRetryTx(ctx, func(tx *sql.Tx) error {
+		if err := issueops.HeartbeatIssueInTx(ctx, tx, id, actor); err != nil {
+			return err
+		}
+		// GH#2455: stage only the tables we touched, then commit without -A.
+		for _, table := range []string{"issues"} {
+			_, _ = tx.ExecContext(ctx, "CALL DOLT_ADD(?)", table)
+		}
+		commitMsg := fmt.Sprintf("bd: heartbeat %s", id)
+		if _, err := tx.ExecContext(ctx, "CALL DOLT_COMMIT('-m', ?, '--author', ?)",
+			commitMsg, s.commitAuthorString()); err != nil && !isDoltNothingToCommit(err) {
+			return fmt.Errorf("dolt commit: %w", err)
+		}
+		return nil
+	})
+}
+
+// ReclaimExpiredLeases reverts in_progress issues whose lease expired more than
+// olderThan ago back to ready, recovering work stranded by dead workers. The
+// reclaim rewrites row_lock so it conflicts with any racing heartbeat/close on
+// the same row; withRetryTx replays the loser. Returns the reclaimed issues.
+func (s *DoltStore) ReclaimExpiredLeases(ctx context.Context, olderThan time.Duration, actor string) ([]types.ReclaimedLease, error) {
+	cutoff := time.Now().UTC().Add(-olderThan)
+	var reclaimed []types.ReclaimedLease
+	err := s.withRetryTx(ctx, func(tx *sql.Tx) error {
+		var err error
+		reclaimed, err = issueops.ReclaimExpiredLeasesInTx(ctx, tx, cutoff, actor)
+		if err != nil {
+			return err
+		}
+		if len(reclaimed) == 0 {
+			return nil
+		}
+		for _, table := range []string{"issues", "events"} {
+			_, _ = tx.ExecContext(ctx, "CALL DOLT_ADD(?)", table)
+		}
+		commitMsg := fmt.Sprintf("bd: reclaim %d expired lease(s)", len(reclaimed))
+		if _, err := tx.ExecContext(ctx, "CALL DOLT_COMMIT('-m', ?, '--author', ?)",
+			commitMsg, s.commitAuthorString()); err != nil && !isDoltNothingToCommit(err) {
+			return fmt.Errorf("dolt commit: %w", err)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return reclaimed, nil
+}
+
 // ReopenIssue reopens a closed issue, setting status to open and clearing
 // closed_at and defer_until. If reason is non-empty, it is recorded as a comment.
 // Wraps UpdateIssue for Dolt-specific concerns (wisp routing, DOLT_COMMIT, etc.).

--- a/internal/storage/dolt/lease_test.go
+++ b/internal/storage/dolt/lease_test.go
@@ -1,0 +1,416 @@
+package dolt
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/steveyegge/beads/internal/storage"
+	"github.com/steveyegge/beads/internal/storage/issueops"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// leaseState reads the lease columns for an issue directly, for assertions.
+type leaseState struct {
+	status        string
+	assignee      sql.NullString
+	leaseExpires  sql.NullTime
+	heartbeatAt   sql.NullTime
+	rowLock       int64
+	startedAtNull bool
+}
+
+func readLeaseState(t *testing.T, ctx context.Context, store *DoltStore, id string) leaseState {
+	t.Helper()
+	var ls leaseState
+	var startedAt sql.NullTime
+	err := store.db.QueryRowContext(ctx, `
+		SELECT status, assignee, lease_expires_at, heartbeat_at, row_lock, started_at
+		FROM issues WHERE id = ?
+	`, id).Scan(&ls.status, &ls.assignee, &ls.leaseExpires, &ls.heartbeatAt, &ls.rowLock, &startedAt)
+	if err != nil {
+		t.Fatalf("read lease state for %s: %v", id, err)
+	}
+	ls.startedAtNull = !startedAt.Valid
+	return ls
+}
+
+func seedClaimedIssue(t *testing.T, ctx context.Context, store *DoltStore, id, owner string, ttl time.Duration) {
+	t.Helper()
+	issue := &types.Issue{
+		ID:        id,
+		Title:     "lease " + id,
+		Status:    types.StatusOpen,
+		Priority:  2,
+		IssueType: types.TypeTask,
+	}
+	if err := store.CreateIssue(ctx, issue, "seeder"); err != nil {
+		t.Fatalf("seed %s: %v", id, err)
+	}
+	claimCtx := issueops.WithLeaseTTL(ctx, ttl)
+	if err := store.ClaimIssue(claimCtx, id, owner); err != nil {
+		t.Fatalf("claim %s by %s: %v", id, owner, err)
+	}
+}
+
+// TestClaimStampsLease verifies a claim sets a future lease, a heartbeat
+// timestamp, and a non-zero row_lock.
+func TestClaimStampsLease(t *testing.T) {
+	store, cleanup := setupConcurrentTestStore(t)
+	defer cleanup()
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	seedClaimedIssue(t, ctx, store, "lease-claim", "alice", time.Minute)
+	ls := readLeaseState(t, ctx, store, "lease-claim")
+
+	if ls.status != "in_progress" {
+		t.Errorf("status = %q, want in_progress", ls.status)
+	}
+	if ls.assignee.String != "alice" {
+		t.Errorf("assignee = %q, want alice", ls.assignee.String)
+	}
+	if !ls.leaseExpires.Valid || !ls.leaseExpires.Time.After(time.Now()) {
+		t.Errorf("lease_expires_at = %v, want a future time", ls.leaseExpires)
+	}
+	if !ls.heartbeatAt.Valid {
+		t.Error("heartbeat_at is NULL, want set on claim")
+	}
+	if ls.rowLock == 0 {
+		t.Error("row_lock = 0, want a fresh non-zero value on claim")
+	}
+}
+
+// TestHeartbeatExtendsLeaseAndGuardsOwnership verifies heartbeat pushes the
+// lease forward and rewrites row_lock, that only the owner may heartbeat, and
+// that a heartbeat on a closed issue fails.
+func TestHeartbeatExtendsLeaseAndGuardsOwnership(t *testing.T) {
+	store, cleanup := setupConcurrentTestStore(t)
+	defer cleanup()
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	seedClaimedIssue(t, ctx, store, "lease-hb", "alice", time.Minute)
+	before := readLeaseState(t, ctx, store, "lease-hb")
+
+	time.Sleep(1100 * time.Millisecond) // DATETIME is second-granular; ensure a tick
+	if err := store.HeartbeatIssue(ctx, "lease-hb", "alice"); err != nil {
+		t.Fatalf("owner heartbeat: %v", err)
+	}
+	after := readLeaseState(t, ctx, store, "lease-hb")
+	if !after.leaseExpires.Time.After(before.leaseExpires.Time) {
+		t.Errorf("heartbeat did not extend lease: before=%v after=%v", before.leaseExpires.Time, after.leaseExpires.Time)
+	}
+	if after.rowLock == before.rowLock {
+		t.Error("heartbeat did not rewrite row_lock")
+	}
+
+	// A non-owner cannot heartbeat.
+	if err := store.HeartbeatIssue(ctx, "lease-hb", "mallory"); !errors.Is(err, storage.ErrAlreadyClaimed) {
+		t.Errorf("non-owner heartbeat err = %v, want ErrAlreadyClaimed", err)
+	}
+
+	// Once closed, the lease is gone — heartbeat fails.
+	if err := store.CloseIssue(ctx, "lease-hb", "done", "alice", ""); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	if err := store.HeartbeatIssue(ctx, "lease-hb", "alice"); !errors.Is(err, storage.ErrNotClaimable) {
+		t.Errorf("heartbeat after close err = %v, want ErrNotClaimable", err)
+	}
+	closed := readLeaseState(t, ctx, store, "lease-hb")
+	if closed.leaseExpires.Valid || closed.heartbeatAt.Valid {
+		t.Errorf("close did not clear lease columns: %+v", closed)
+	}
+}
+
+// TestReclaimRevertsExpiredOnly verifies reclaim reverts an expired lease to
+// ready (clearing the owner) and leaves a still-valid lease untouched, and that
+// the grace window is honored.
+func TestReclaimRevertsExpiredOnly(t *testing.T) {
+	store, cleanup := setupConcurrentTestStore(t)
+	defer cleanup()
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	// "dead" holds a 1s lease and never heartbeats; "live" holds a long lease.
+	seedClaimedIssue(t, ctx, store, "lease-dead", "dead-worker", time.Second)
+	seedClaimedIssue(t, ctx, store, "lease-live", "live-worker", time.Hour)
+
+	time.Sleep(1500 * time.Millisecond) // let dead's lease expire
+
+	// Grace window larger than how long the lease has been expired: nothing yet.
+	reclaimed, err := store.ReclaimExpiredLeases(ctx, time.Hour, "reaper")
+	if err != nil {
+		t.Fatalf("reclaim with big grace: %v", err)
+	}
+	if len(reclaimed) != 0 {
+		t.Errorf("reclaimed %v with a 1h grace window, want none", reclaimed)
+	}
+
+	// Zero grace: the dead lease (expired) is reclaimed, the live one is not.
+	reclaimed, err = store.ReclaimExpiredLeases(ctx, 0, "reaper")
+	if err != nil {
+		t.Fatalf("reclaim grace=0: %v", err)
+	}
+	if len(reclaimed) != 1 || reclaimed[0].ID != "lease-dead" {
+		t.Fatalf("reclaimed = %+v, want exactly [lease-dead]", reclaimed)
+	}
+	if reclaimed[0].PreviousOwner != "dead-worker" {
+		t.Errorf("PreviousOwner = %q, want dead-worker", reclaimed[0].PreviousOwner)
+	}
+
+	dead := readLeaseState(t, ctx, store, "lease-dead")
+	if dead.status != "open" || dead.assignee.Valid && dead.assignee.String != "" {
+		t.Errorf("reclaimed issue state = %+v, want open + unassigned", dead)
+	}
+	if dead.leaseExpires.Valid || dead.heartbeatAt.Valid || !dead.startedAtNull {
+		t.Errorf("reclaim did not clear lease/started columns: %+v", dead)
+	}
+	live := readLeaseState(t, ctx, store, "lease-live")
+	if live.status != "in_progress" || live.assignee.String != "live-worker" {
+		t.Errorf("live issue disturbed by reclaim: %+v", live)
+	}
+
+	// A recovery event was recorded for the reclaimed issue.
+	var events int
+	if err := store.db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM events WHERE issue_id = ? AND event_type = 'lease_reclaimed'`, "lease-dead").Scan(&events); err != nil {
+		t.Fatalf("count reclaim events: %v", err)
+	}
+	if events != 1 {
+		t.Errorf("lease_reclaimed events = %d, want 1", events)
+	}
+}
+
+// TestRowLockForcesConflictOnDisjointCellWrites is the regression guard for the
+// row_lock trick. It shows, against real Dolt, that two concurrent transactions
+// writing DISJOINT cells of the same issue row silently cell-merge into a
+// corrupt "zombie" state — UNLESS both also rewrite the shared row_lock cell,
+// which forces the second commit to conflict (1213) so withRetryTx can replay.
+//
+// The dangerous pair: a worker's heartbeat (writes heartbeat_at) racing a reaper
+// reverting the row to ready (writes status/assignee). Without a shared lock
+// cell Dolt merges them, producing an open+unassigned issue that still carries
+// the worker's fresh heartbeat — the worker believes it owns work that another
+// worker can now also claim.
+func TestRowLockForcesConflictOnDisjointCellWrites(t *testing.T) {
+	store, cleanup := setupConcurrentTestStore(t)
+	defer cleanup()
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	// runRace commits two concurrent disjoint-cell writers. withLock adds the
+	// shared row_lock cell to both. Returns the error from the second commit.
+	runRace := func(id string, withLock bool) error {
+		seedClaimedIssue(t, ctx, store, id, "owner", time.Hour)
+
+		tx1, err := store.db.BeginTx(ctx, nil)
+		if err != nil {
+			t.Fatalf("begin tx1: %v", err)
+		}
+		tx2, err := store.db.BeginTx(ctx, nil)
+		if err != nil {
+			t.Fatalf("begin tx2: %v", err)
+		}
+
+		hbSQL := "UPDATE issues SET heartbeat_at = ? WHERE id = ?"
+		reclaimSQL := "UPDATE issues SET status = 'open', assignee = NULL WHERE id = ?"
+		hbArgs := []any{time.Now().UTC(), id}
+		reclaimArgs := []any{id}
+		if withLock {
+			hbSQL = "UPDATE issues SET heartbeat_at = ?, row_lock = ? WHERE id = ?"
+			hbArgs = []any{time.Now().UTC(), int64(111111), id}
+			reclaimSQL = "UPDATE issues SET status = 'open', assignee = NULL, row_lock = ? WHERE id = ?"
+			reclaimArgs = []any{int64(222222), id}
+		}
+
+		if _, err := tx1.ExecContext(ctx, hbSQL, hbArgs...); err != nil {
+			t.Fatalf("tx1 heartbeat exec: %v", err)
+		}
+		if _, err := tx2.ExecContext(ctx, reclaimSQL, reclaimArgs...); err != nil {
+			t.Fatalf("tx2 reclaim exec: %v", err)
+		}
+		// Commit the heartbeat first, then the reclaim. The reclaim is the loser
+		// that must conflict when both touch row_lock.
+		if err := tx1.Commit(); err != nil {
+			t.Fatalf("tx1 commit (heartbeat): %v", err)
+		}
+		return tx2.Commit()
+	}
+
+	// WITHOUT row_lock: the disjoint writes merge with no error, leaving a zombie.
+	if err := runRace("zombie-norowlock", false); err != nil {
+		// A conflict here would also be acceptable (still safe), but the point of
+		// the test is to demonstrate the silent merge, so surface if Dolt's
+		// behavior changed.
+		t.Skipf("expected silent merge without row_lock, got conflict %v (Dolt merge semantics changed)", err)
+	}
+	z := readLeaseState(t, ctx, store, "zombie-norowlock")
+	zombie := z.status == "open" && z.heartbeatAt.Valid && (!z.assignee.Valid || z.assignee.String == "")
+	if !zombie {
+		t.Fatalf("without row_lock expected a merged zombie (open+unassigned+heartbeat), got %+v", z)
+	}
+	t.Logf("without row_lock: cell-merge produced zombie state %+v", z)
+
+	// WITH row_lock: both writers touch the shared cell, so the second commit
+	// conflicts (1213/1205) instead of silently merging.
+	err := runRace("zombie-rowlock", true)
+	if err == nil {
+		t.Fatal("with row_lock expected the second commit to conflict, but it succeeded (silent merge not prevented)")
+	}
+	if !isSerializationError(err) {
+		t.Fatalf("with row_lock got err %v, want a serialization conflict (1213/1205)", err)
+	}
+	t.Logf("with row_lock: second commit correctly conflicted: %v", err)
+}
+
+// TestConcurrentHeartbeatReclaimClose is the integration race (the lease analog
+// of TestConcurrentWorkQueueDrain). Half the workers are "live" (heartbeat, then
+// close their issue); half are "dead" (claim, then go silent). A reaper runs
+// continuously with a zero grace window. The store-level withRetryTx + row_lock
+// must keep every issue in a consistent terminal state:
+//
+//   - a live worker's close is never lost and never reverted by a racing reclaim
+//   - a dead worker's issue is recovered to ready (open, unassigned, no lease)
+//   - no issue is ever a zombie: open with a lingering owner/lease, or closed
+//     with a lingering owner/lease
+func TestConcurrentHeartbeatReclaimClose(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping lease recovery race in short mode")
+	}
+	store, cleanup := setupConcurrentTestStore(t)
+	defer cleanup()
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	const numWorkers = 8 // even split live/dead
+	// lease_expires_at/heartbeat_at are second-granular DATETIME columns (and
+	// Dolt ROUNDS, not truncates), so a sub-second TTL is meaningless — it can
+	// round to a whole second in the future. Use second-scale timings: a 2s
+	// lease that live workers refresh every 500ms (always ≥1.5s in the future,
+	// so the reaper never touches a live claim), while dead claims expire after
+	// 2s and get reclaimed.
+	const ttl = 2 * time.Second
+	type job struct {
+		id    string
+		owner string
+		live  bool
+	}
+	jobs := make([]job, numWorkers)
+	for i := 0; i < numWorkers; i++ {
+		j := job{
+			id:    fmt.Sprintf("lease-race-%02d", i),
+			owner: fmt.Sprintf("worker-%02d", i),
+			live:  i%2 == 0,
+		}
+		jobs[i] = j
+		seedClaimedIssue(t, ctx, store, j.id, j.owner, ttl)
+	}
+
+	raceCtx, stopReaper := context.WithCancel(ctx)
+	var reaperErrs atomic.Int32
+	var reaperDone sync.WaitGroup
+	reaperDone.Add(1)
+	go func() {
+		defer reaperDone.Done()
+		for {
+			select {
+			case <-raceCtx.Done():
+				return
+			default:
+			}
+			if _, err := store.ReclaimExpiredLeases(raceCtx, 0, "reaper"); err != nil {
+				if raceCtx.Err() == nil {
+					reaperErrs.Add(1)
+				}
+				return
+			}
+			time.Sleep(15 * time.Millisecond)
+		}
+	}()
+
+	var wg sync.WaitGroup
+	var lostClose atomic.Int32
+	for _, j := range jobs {
+		if !j.live {
+			continue // dead workers do nothing; the reaper recovers them
+		}
+		wg.Add(1)
+		go func(j job) {
+			defer wg.Done()
+			hbCtx := issueops.WithLeaseTTL(ctx, ttl)
+			// Heartbeat every 500ms (well within the 2s TTL) to keep the lease
+			// alive while the reaper scans concurrently, then close. Each heartbeat
+			// and close rewrites row_lock, so they race the reaper's row_lock
+			// rewrites; withRetryTx must absorb any conflict.
+			for k := 0; k < 4; k++ {
+				if err := store.HeartbeatIssue(hbCtx, j.id, j.owner); err != nil {
+					// A live worker keeps its lease well in the future, so the
+					// reaper must never preempt it — a failure is a real defect.
+					t.Errorf("live worker %s heartbeat failed: %v", j.owner, err)
+				}
+				time.Sleep(500 * time.Millisecond)
+			}
+			if err := store.CloseIssue(ctx, j.id, "done", j.owner, ""); err != nil {
+				// A close can only fail here if the reaper reverted the issue to
+				// open and another path re-touched it; with row_lock the close
+				// retries and wins, so a hard failure is a real defect.
+				t.Errorf("live worker %s close failed: %v", j.owner, err)
+				lostClose.Add(1)
+			}
+		}(j)
+	}
+	wg.Wait()
+	stopReaper()
+	reaperDone.Wait()
+
+	if n := reaperErrs.Load(); n != 0 {
+		t.Errorf("reaper surfaced %d errors; ReclaimExpiredLeases should retry conflicts internally", n)
+	}
+	if n := lostClose.Load(); n != 0 {
+		t.Errorf("%d live-worker closes were lost to a racing reclaim", n)
+	}
+
+	// Final consistency sweep: wait past the TTL (plus the ≤1s DATETIME rounding
+	// slop) so every dead claim's lease is unambiguously expired, then drain so
+	// dead workers' issues reach their terminal open state regardless of reaper
+	// timing.
+	time.Sleep(ttl + 1500*time.Millisecond)
+	if _, err := store.ReclaimExpiredLeases(ctx, 0, "final-reaper"); err != nil {
+		t.Fatalf("final reclaim sweep: %v", err)
+	}
+
+	closed, open := 0, 0
+	for _, j := range jobs {
+		ls := readLeaseState(t, ctx, store, j.id)
+		hasOwner := ls.assignee.Valid && ls.assignee.String != ""
+		switch ls.status {
+		case "closed":
+			closed++
+			// A closed issue must carry no live lease (close clears it).
+			if ls.leaseExpires.Valid || ls.heartbeatAt.Valid {
+				t.Errorf("issue %s closed but still leased: %+v", j.id, ls)
+			}
+		case "open":
+			open++
+			// A reclaimed issue must be fully released: no owner, no lease.
+			if hasOwner || ls.leaseExpires.Valid || ls.heartbeatAt.Valid {
+				t.Errorf("issue %s open but still owned/leased (zombie): %+v", j.id, ls)
+			}
+		case "in_progress":
+			t.Errorf("issue %s still in_progress after race settled: %+v", j.id, ls)
+		default:
+			t.Errorf("issue %s unexpected status %q", j.id, ls.status)
+		}
+	}
+	t.Logf("lease race settled: %d closed (live), %d open (reclaimed)", closed, open)
+	// Every live issue should have ended closed; every dead one open.
+	if closed == 0 || open == 0 {
+		t.Errorf("expected a mix of closed (live) and open (reclaimed) issues, got closed=%d open=%d", closed, open)
+	}
+}

--- a/internal/storage/dolt/lease_test.go
+++ b/internal/storage/dolt/lease_test.go
@@ -128,6 +128,44 @@ func TestHeartbeatExtendsLeaseAndGuardsOwnership(t *testing.T) {
 	}
 }
 
+func TestUpdateIssueMaintainsLeaseOwnership(t *testing.T) {
+	store, cleanup := setupConcurrentTestStore(t)
+	defer cleanup()
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	seedClaimedIssue(t, ctx, store, "lease-update", "alice", time.Hour)
+	before := readLeaseState(t, ctx, store, "lease-update")
+
+	if err := store.UpdateIssue(ctx, "lease-update", map[string]interface{}{"assignee": "bob"}, "dispatcher"); err != nil {
+		t.Fatalf("transfer assignee: %v", err)
+	}
+	transferred := readLeaseState(t, ctx, store, "lease-update")
+	if transferred.assignee.String != "bob" {
+		t.Fatalf("assignee after transfer = %q, want bob", transferred.assignee.String)
+	}
+	if !transferred.leaseExpires.Valid || !transferred.heartbeatAt.Valid {
+		t.Fatalf("transfer did not stamp a fresh lease: %+v", transferred)
+	}
+	if !transferred.heartbeatAt.Time.After(before.heartbeatAt.Time) && transferred.rowLock == before.rowLock {
+		t.Fatalf("transfer did not refresh heartbeat or row_lock: before=%+v after=%+v", before, transferred)
+	}
+	if err := store.HeartbeatIssue(ctx, "lease-update", "alice"); !errors.Is(err, storage.ErrAlreadyClaimed) {
+		t.Fatalf("old owner heartbeat err = %v, want ErrAlreadyClaimed", err)
+	}
+	if err := store.HeartbeatIssue(ctx, "lease-update", "bob"); err != nil {
+		t.Fatalf("new owner heartbeat: %v", err)
+	}
+
+	if err := store.UpdateIssue(ctx, "lease-update", map[string]interface{}{"status": string(types.StatusOpen)}, "dispatcher"); err != nil {
+		t.Fatalf("reopen through update: %v", err)
+	}
+	open := readLeaseState(t, ctx, store, "lease-update")
+	if open.leaseExpires.Valid || open.heartbeatAt.Valid {
+		t.Fatalf("status away from in_progress did not clear lease: %+v", open)
+	}
+}
+
 // TestReclaimRevertsExpiredOnly verifies reclaim reverts an expired lease to
 // ready (clearing the owner) and leaves a still-valid lease untouched, and that
 // the grace window is honored.

--- a/internal/storage/dolt/schema_version_test.go
+++ b/internal/storage/dolt/schema_version_test.go
@@ -161,7 +161,13 @@ func TestMigration0053PromotesRigWisps(t *testing.T) {
 		t.Fatalf("commit seed fixture: %v", err)
 	}
 
-	if _, err := store.db.ExecContext(ctx, "DELETE FROM schema_migrations WHERE version = ?", schema.LatestVersion()); err != nil {
+	// This test exercises the rig-wisp promotion in migration 0053 specifically.
+	// MigrateUp only re-applies versions strictly greater than MAX(applied), so to
+	// replay 0053 we delete every row >= 53 (not just LatestVersion(), which now
+	// points past 0053 as later migrations like 0054 land). 0053 re-runs the
+	// promotion; any later migration replays as a guarded no-op.
+	const rigWispsMigrationVersion = 53
+	if _, err := store.db.ExecContext(ctx, "DELETE FROM schema_migrations WHERE version >= ?", rigWispsMigrationVersion); err != nil {
 		t.Fatalf("mark 0053 pending: %v", err)
 	}
 	if _, err := schema.MigrateUp(ctx, store.db); err != nil {

--- a/internal/storage/domain/db/issue_scan_parity_test.go
+++ b/internal/storage/domain/db/issue_scan_parity_test.go
@@ -42,7 +42,7 @@ func TestScanIssue_StringTimestamps(t *testing.T) {
 	for i := range cols {
 		cols[i] = strings.TrimSpace(cols[i])
 	}
-	require.Len(t, cols, 46)
+	require.Len(t, cols, 48)
 
 	row := []driver.Value{
 		"bd-test.1", nil, "title", "desc", "", "", "", // id..notes
@@ -55,8 +55,9 @@ func TestScanIssue_StringTimestamps(t *testing.T) {
 		nil, nil, nil, nil, // event_kind..payload
 		nil, nil, // due_at, defer_until
 		nil, nil, nil, // work_type, source_system, metadata
+		nil, nil, // lease_expires_at, heartbeat_at
 	}
-	require.Len(t, row, 46)
+	require.Len(t, row, 48)
 
 	mock.ExpectQuery("SELECT").WillReturnRows(sqlmock.NewRows(cols).AddRow(row...))
 

--- a/internal/storage/embeddeddolt/issues.go
+++ b/internal/storage/embeddeddolt/issues.go
@@ -7,6 +7,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"time"
 
 	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/storage/issueops"
@@ -51,6 +52,27 @@ func (s *EmbeddedDoltStore) UpdateIssue(ctx context.Context, id string, updates 
 		_, err := issueops.UpdateIssueInTx(ctx, tx, id, updates, actor)
 		return err
 	})
+}
+
+// HeartbeatIssue refreshes the lease on an issue actor holds in_progress.
+// Delegates SQL work to issueops; EmbeddedDolt auto-commits the transaction.
+func (s *EmbeddedDoltStore) HeartbeatIssue(ctx context.Context, id, actor string) error {
+	return s.withConn(ctx, true, func(tx *sql.Tx) error {
+		return issueops.HeartbeatIssueInTx(ctx, tx, id, actor)
+	})
+}
+
+// ReclaimExpiredLeases reverts in_progress issues whose lease expired more than
+// olderThan ago back to ready, recovering work stranded by dead workers.
+func (s *EmbeddedDoltStore) ReclaimExpiredLeases(ctx context.Context, olderThan time.Duration, actor string) ([]types.ReclaimedLease, error) {
+	cutoff := time.Now().UTC().Add(-olderThan)
+	var reclaimed []types.ReclaimedLease
+	err := s.withConn(ctx, true, func(tx *sql.Tx) error {
+		var err error
+		reclaimed, err = issueops.ReclaimExpiredLeasesInTx(ctx, tx, cutoff, actor)
+		return err
+	})
+	return reclaimed, err
 }
 
 // ReopenIssue reopens a closed issue, setting status to open and clearing

--- a/internal/storage/embeddeddolt/issues.go
+++ b/internal/storage/embeddeddolt/issues.go
@@ -58,6 +58,10 @@ func (s *EmbeddedDoltStore) UpdateIssue(ctx context.Context, id string, updates 
 // Delegates SQL work to issueops; EmbeddedDolt auto-commits the transaction.
 func (s *EmbeddedDoltStore) HeartbeatIssue(ctx context.Context, id, actor string) error {
 	return s.withConn(ctx, true, func(tx *sql.Tx) error {
+		if issueops.IsActiveWispInTx(ctx, tx, id) {
+			// Wisps are ephemeral and never leased; nothing to heartbeat.
+			return fmt.Errorf("%w: %s is ephemeral", storage.ErrNotClaimable, id)
+		}
 		return issueops.HeartbeatIssueInTx(ctx, tx, id, actor)
 	})
 }

--- a/internal/storage/embeddeddolt/lease_test.go
+++ b/internal/storage/embeddeddolt/lease_test.go
@@ -1,0 +1,77 @@
+//go:build cgo
+
+package embeddeddolt_test
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/steveyegge/beads/internal/storage"
+	"github.com/steveyegge/beads/internal/storage/issueops"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// TestLeaseLifecycleEmbedded confirms the lease columns exist in the embedded
+// backend and that claim → heartbeat → reclaim are wired through EmbeddedDoltStore.
+func TestLeaseLifecycleEmbedded(t *testing.T) {
+	skipUnlessEmbeddedDolt(t)
+
+	te := newTestEnv(t, "lease")
+	ctx := t.Context()
+
+	issue := &types.Issue{
+		ID:        "lease-1",
+		Title:     "lease lifecycle",
+		Status:    types.StatusOpen,
+		Priority:  2,
+		IssueType: types.TypeTask,
+	}
+	if err := te.store.CreateIssue(ctx, issue, "seeder"); err != nil {
+		t.Fatalf("CreateIssue: %v", err)
+	}
+
+	// Claim with a 1s lease so it expires within the test.
+	claimCtx := issueops.WithLeaseTTL(ctx, time.Second)
+	if err := te.store.ClaimIssue(claimCtx, "lease-1", "alice"); err != nil {
+		t.Fatalf("ClaimIssue: %v", err)
+	}
+
+	// The claim stamped a non-zero row_lock and a lease.
+	var rowLock int64
+	te.queryScalar(t, ctx, "SELECT row_lock FROM issues WHERE id = ?", []any{"lease-1"}, &rowLock)
+	if rowLock == 0 {
+		t.Error("row_lock = 0 after claim, want non-zero")
+	}
+
+	// Owner can heartbeat; a stranger cannot. Heartbeat with the same short TTL
+	// so the lease still expires within the test (a default-TTL heartbeat would
+	// push expiry minutes out).
+	if err := te.store.HeartbeatIssue(claimCtx, "lease-1", "alice"); err != nil {
+		t.Fatalf("owner HeartbeatIssue: %v", err)
+	}
+	if err := te.store.HeartbeatIssue(ctx, "lease-1", "mallory"); !errors.Is(err, storage.ErrAlreadyClaimed) {
+		t.Errorf("stranger heartbeat err = %v, want ErrAlreadyClaimed", err)
+	}
+
+	// Let the lease expire, then reclaim it.
+	time.Sleep(2500 * time.Millisecond)
+	reclaimed, err := te.store.ReclaimExpiredLeases(ctx, 0, "reaper")
+	if err != nil {
+		t.Fatalf("ReclaimExpiredLeases: %v", err)
+	}
+	if len(reclaimed) != 1 || reclaimed[0].ID != "lease-1" || reclaimed[0].PreviousOwner != "alice" {
+		t.Fatalf("reclaimed = %+v, want [{lease-1 alice}]", reclaimed)
+	}
+
+	got, err := te.store.GetIssue(ctx, "lease-1")
+	if err != nil {
+		t.Fatalf("GetIssue: %v", err)
+	}
+	if got.Status != types.StatusOpen {
+		t.Errorf("status = %q after reclaim, want open", got.Status)
+	}
+	if got.Assignee != "" {
+		t.Errorf("assignee = %q after reclaim, want empty", got.Assignee)
+	}
+}

--- a/internal/storage/embeddeddolt/lease_test.go
+++ b/internal/storage/embeddeddolt/lease_test.go
@@ -79,7 +79,7 @@ func TestLeaseLifecycleEmbedded(t *testing.T) {
 func TestHeartbeatRejectsWispEmbedded(t *testing.T) {
 	skipUnlessEmbeddedDolt(t)
 
-	te := newTestEnv(t, "lease-wisp")
+	te := newTestEnv(t, "lease_wisp")
 	ctx := t.Context()
 
 	wisp := &types.Issue{

--- a/internal/storage/embeddeddolt/lease_test.go
+++ b/internal/storage/embeddeddolt/lease_test.go
@@ -75,3 +75,25 @@ func TestLeaseLifecycleEmbedded(t *testing.T) {
 		t.Errorf("assignee = %q after reclaim, want empty", got.Assignee)
 	}
 }
+
+func TestHeartbeatRejectsWispEmbedded(t *testing.T) {
+	skipUnlessEmbeddedDolt(t)
+
+	te := newTestEnv(t, "lease-wisp")
+	ctx := t.Context()
+
+	wisp := &types.Issue{
+		ID:        "lease-wisp-1",
+		Title:     "ephemeral work",
+		Status:    types.StatusOpen,
+		Priority:  2,
+		IssueType: types.TypeTask,
+		Ephemeral: true,
+	}
+	if err := te.store.CreateIssue(ctx, wisp, "seeder"); err != nil {
+		t.Fatalf("CreateIssue wisp: %v", err)
+	}
+	if err := te.store.HeartbeatIssue(ctx, "lease-wisp-1", "alice"); !errors.Is(err, storage.ErrNotClaimable) {
+		t.Fatalf("wisp heartbeat err = %v, want ErrNotClaimable", err)
+	}
+}

--- a/internal/storage/hook_decorator.go
+++ b/internal/storage/hook_decorator.go
@@ -378,6 +378,8 @@ func cloneIssueForHook(issue *types.Issue) *types.Issue {
 	clone.ClosedAt = clonePtr(issue.ClosedAt)
 	clone.DueAt = clonePtr(issue.DueAt)
 	clone.DeferUntil = clonePtr(issue.DeferUntil)
+	clone.LeaseExpiresAt = clonePtr(issue.LeaseExpiresAt)
+	clone.HeartbeatAt = clonePtr(issue.HeartbeatAt)
 	clone.ExternalRef = clonePtr(issue.ExternalRef)
 	clone.Labels = append([]string(nil), issue.Labels...)
 	clone.Metadata = append([]byte(nil), issue.Metadata...)

--- a/internal/storage/hook_decorator_internal_test.go
+++ b/internal/storage/hook_decorator_internal_test.go
@@ -271,6 +271,8 @@ func TestCloneIssueForHookCoversReferenceFields(t *testing.T) {
 		"ClosedAt":          {},
 		"DueAt":             {},
 		"DeferUntil":        {},
+		"LeaseExpiresAt":    {},
+		"HeartbeatAt":       {},
 		"ExternalRef":       {},
 		"Metadata":          {},
 		"CompactedAt":       {},

--- a/internal/storage/issueops/claim.go
+++ b/internal/storage/issueops/claim.go
@@ -40,6 +40,13 @@ func ClaimIssueInTx(ctx context.Context, tx DBTX, id string, actor string) (*Cla
 
 	now := time.Now().UTC()
 
+	// Stamp a lease on the claim: lease_expires_at = now + TTL, heartbeat_at =
+	// now, and a fresh row_lock (see lease.go). The lease is what makes a claim
+	// recoverable — a worker that dies stops heartbeating and bd reclaim later
+	// reverts the issue. row_lock here also forces a concurrent reclaim/heartbeat
+	// to conflict rather than silently cell-merge.
+	leaseClause, leaseArgs := leaseSetClause(now, leaseTTL(ctx))
+
 	// Conditional UPDATE: only succeeds while the issue is still claimable.
 	// Also set started_at on first transition to in_progress (GH#2796); preserve
 	// any existing value so re-claims don't overwrite the original start time.
@@ -47,17 +54,21 @@ func ClaimIssueInTx(ctx context.Context, tx DBTX, id string, actor string) (*Cla
 		result sql.Result
 	)
 	if oldIssue.StartedAt == nil {
+		args := append([]interface{}{actor, now, now}, leaseArgs...)
+		args = append(args, id, actor)
 		result, err = tx.ExecContext(ctx, fmt.Sprintf(`
 			UPDATE %s
-			SET assignee = ?, status = 'in_progress', updated_at = ?, started_at = ?
+			SET assignee = ?, status = 'in_progress', updated_at = ?, started_at = ?, %s
 			WHERE id = ? AND status = 'open' AND (assignee = '' OR assignee IS NULL OR assignee = ?)
-		`, issueTable), actor, now, now, id, actor)
+		`, issueTable, leaseClause), args...)
 	} else {
+		args := append([]interface{}{actor, now}, leaseArgs...)
+		args = append(args, id, actor)
 		result, err = tx.ExecContext(ctx, fmt.Sprintf(`
 			UPDATE %s
-			SET assignee = ?, status = 'in_progress', updated_at = ?
+			SET assignee = ?, status = 'in_progress', updated_at = ?, %s
 			WHERE id = ? AND status = 'open' AND (assignee = '' OR assignee IS NULL OR assignee = ?)
-		`, issueTable), actor, now, id, actor)
+		`, issueTable, leaseClause), args...)
 	}
 	if err != nil {
 		return nil, fmt.Errorf("failed to claim issue: %w", err)

--- a/internal/storage/issueops/close.go
+++ b/internal/storage/issueops/close.go
@@ -45,10 +45,16 @@ func closeIssueInTx(ctx context.Context, tx DBTX, id string, reason, actor, sess
 
 	now := time.Now().UTC()
 
+	// row_lock is rewritten on close so a concurrent reclaim (which also rewrites
+	// row_lock) collides on this cell and is forced to conflict-and-retry rather
+	// than silently cell-merging a revert-to-ready over a completed close (see
+	// lease.go). lease_expires_at/heartbeat_at are cleared: a closed issue holds
+	// no lease.
 	result, err := tx.ExecContext(ctx, fmt.Sprintf(`
-		UPDATE %s SET status = ?, closed_at = ?, updated_at = ?, close_reason = ?, closed_by_session = ?
+		UPDATE %s SET status = ?, closed_at = ?, updated_at = ?, close_reason = ?, closed_by_session = ?,
+			lease_expires_at = NULL, heartbeat_at = NULL, row_lock = ?
 		WHERE id = ? AND status != ?
-	`, issueTable), types.StatusClosed, now, now, reason, session, id, types.StatusClosed)
+	`, issueTable), types.StatusClosed, now, now, reason, session, freshRowLock(), id, types.StatusClosed)
 	if err != nil {
 		return nil, fmt.Errorf("failed to close issue: %w", err)
 	}

--- a/internal/storage/issueops/lease.go
+++ b/internal/storage/issueops/lease.go
@@ -1,0 +1,201 @@
+package issueops
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/binary"
+	"fmt"
+	"time"
+
+	"github.com/steveyegge/beads/internal/storage"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// DefaultLeaseTTL is how long a fresh claim stays valid without a heartbeat.
+// A worker is expected to call HeartbeatIssueInTx well within this window
+// (heartbeat cadence ≫ claim cadence; see the commit-bloat note on bd heartbeat)
+// so a live claim's lease_expires_at always sits in the future. A worker that
+// dies stops heartbeating, its lease_expires_at goes stale, and bd reclaim
+// reverts the issue to ready. Tunable per-claim via WithLeaseTTL on the
+// context, falling back to this default.
+const DefaultLeaseTTL = 5 * time.Minute
+
+// leaseTTLContextKey overrides DefaultLeaseTTL for a single claim. Used by tests
+// (short TTLs) and callers that know their work cadence; unset in normal use.
+type leaseTTLContextKey struct{}
+
+// WithLeaseTTL returns a context whose claims use ttl instead of DefaultLeaseTTL.
+func WithLeaseTTL(ctx context.Context, ttl time.Duration) context.Context {
+	return context.WithValue(ctx, leaseTTLContextKey{}, ttl)
+}
+
+// leaseTTL resolves the lease TTL for the current claim/heartbeat.
+func leaseTTL(ctx context.Context) time.Duration {
+	if ttl, ok := ctx.Value(leaseTTLContextKey{}).(time.Duration); ok && ttl > 0 {
+		return ttl
+	}
+	return DefaultLeaseTTL
+}
+
+// freshRowLock returns a random non-zero int64 for the row_lock cell.
+//
+// row_lock is the keystone of dead-worker recovery on Dolt. Dolt has no real
+// row locking and merges concurrent commits cell-by-cell, so two transactions
+// that touch DIFFERENT cells of the same issue row (a heartbeat writing
+// heartbeat_at, a close writing status) merge silently instead of conflicting —
+// which would let a reclaim quietly revert an issue the owner just closed. By
+// having EVERY mutating path rewrite this one shared cell to a fresh random
+// value, concurrent writers always collide on row_lock, surfacing the 1213/1205
+// serialization conflict that withRetryTx replays. The value's only job is to
+// differ from whatever a concurrent writer wrote, so any source of entropy
+// works; we use crypto/rand to avoid seeding concerns. Never 0 (the column
+// default) so a freshly-claimed row is always distinguishable from a never-
+// touched one.
+func freshRowLock() int64 {
+	var b [8]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		// crypto/rand failing is catastrophic and ~never happens; fall back to a
+		// timestamp so the row_lock still changes rather than wedging the write.
+		return time.Now().UnixNano() | 1
+	}
+	v := int64(binary.LittleEndian.Uint64(b[:]))
+	if v == 0 {
+		v = 1
+	}
+	return v
+}
+
+// leaseSetClause returns the SET-clause fragment and args that stamp a fresh
+// lease onto a row being claimed or heartbeated: a future expiry, a now
+// heartbeat, and a fresh row_lock. Append to an existing UPDATE's SET list.
+func leaseSetClause(now time.Time, ttl time.Duration) (string, []interface{}) {
+	return "lease_expires_at = ?, heartbeat_at = ?, row_lock = ?",
+		[]interface{}{now.Add(ttl), now, freshRowLock()}
+}
+
+// HeartbeatIssueInTx proves the lease owner is still alive: it pushes
+// lease_expires_at forward by the TTL, stamps heartbeat_at = now, and rewrites
+// row_lock so the heartbeat conflicts with any concurrent reclaim/close on the
+// same row (see freshRowLock). Only the current owner of an in_progress issue
+// may heartbeat — a heartbeat from anyone else, or on an issue that is no longer
+// in_progress (already closed or already reclaimed), affects no rows and returns
+// storage.ErrNotClaimable so the caller learns its lease is gone.
+//
+// Routes to the correct table (issues/wisps). The caller owns Dolt versioning.
+//
+//nolint:gosec // G201: table names come from WispTableRouting (hardcoded constants)
+func HeartbeatIssueInTx(ctx context.Context, tx DBTX, id, actor string) error {
+	isWisp := IsActiveWispInTx(ctx, tx, id)
+	issueTable, _, _, _ := WispTableRouting(isWisp)
+
+	now := time.Now().UTC()
+	leaseClause, leaseArgs := leaseSetClause(now, leaseTTL(ctx))
+
+	args := append([]interface{}{}, leaseArgs...)
+	args = append(args, id, actor)
+	result, err := tx.ExecContext(ctx, fmt.Sprintf(`
+		UPDATE %s SET %s
+		WHERE id = ? AND status = 'in_progress' AND assignee = ?
+	`, issueTable, leaseClause), args...)
+	if err != nil {
+		return fmt.Errorf("failed to heartbeat issue: %w", err)
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("failed to get rows affected: %w", err)
+	}
+	if rows == 0 {
+		// Disambiguate for the caller: gone (closed/reopened/reclaimed),
+		// not-found, or owned by someone else.
+		var assignee, status string
+		qerr := tx.QueryRowContext(ctx,
+			fmt.Sprintf("SELECT COALESCE(assignee, ''), status FROM %s WHERE id = ?", issueTable), id,
+		).Scan(&assignee, &status)
+		if qerr != nil {
+			return fmt.Errorf("%w: %s", storage.ErrNotClaimable, id)
+		}
+		if assignee != "" && assignee != actor {
+			return fmt.Errorf("%w by %s", storage.ErrAlreadyClaimed, assignee)
+		}
+		return fmt.Errorf("%w: %s status %s", storage.ErrNotClaimable, id, status)
+	}
+	return nil
+}
+
+// ReclaimExpiredLeasesInTx reverts in_progress issues whose lease has gone stale
+// back to ready: status → open, assignee cleared, started_at cleared, and a
+// fresh row_lock so the reclaim conflicts with a racing heartbeat/close on the
+// same row (see freshRowLock). An issue is stale when its lease_expires_at is
+// non-null and strictly before cutoff. Callers pass cutoff = now - graceWindow
+// (the supervisor uses graceWindow = 2×TTL) so only leases that expired a safe
+// margin ago — i.e. workers that are almost certainly dead — are reclaimed.
+//
+// Reclaim only ever touches the permanent issues table: wisps are ephemeral and
+// are never leased work. Returns the issues it reverted (id + the owner it took
+// the lease from) so the caller can log/emit recovery events. The caller owns
+// Dolt versioning.
+func ReclaimExpiredLeasesInTx(ctx context.Context, tx DBTX, cutoff time.Time, actor string) ([]types.ReclaimedLease, error) {
+	// Snapshot the stale set first so we can report exactly which issues we
+	// reverted and record per-issue recovery events. The UPDATE below repeats
+	// the predicate, so an issue that a concurrent heartbeat rescued between the
+	// SELECT and the UPDATE is simply skipped (0 rows) — it never appears as
+	// reclaimed.
+	rows, err := tx.QueryContext(ctx, `
+		SELECT id, COALESCE(assignee, '') FROM issues
+		WHERE status = 'in_progress'
+		  AND lease_expires_at IS NOT NULL
+		  AND lease_expires_at < ?
+	`, cutoff)
+	if err != nil {
+		return nil, fmt.Errorf("scan for stale leases: %w", err)
+	}
+	var stale []types.ReclaimedLease
+	for rows.Next() {
+		var r types.ReclaimedLease
+		if err := rows.Scan(&r.ID, &r.PreviousOwner); err != nil {
+			rows.Close()
+			return nil, fmt.Errorf("scan stale lease row: %w", err)
+		}
+		stale = append(stale, r)
+	}
+	if err := rows.Err(); err != nil {
+		rows.Close()
+		return nil, fmt.Errorf("iterate stale leases: %w", err)
+	}
+	rows.Close()
+	if len(stale) == 0 {
+		return nil, nil
+	}
+
+	var reclaimed []types.ReclaimedLease
+	for _, r := range stale {
+		// Re-check the predicate inside the UPDATE so a heartbeat that landed
+		// after the snapshot (pushing lease_expires_at back into the future, or
+		// the row already closed) cannot be clobbered. row_lock makes the racing
+		// writer conflict; this WHERE makes a winning racer's rescue stick.
+		res, err := tx.ExecContext(ctx, `
+			UPDATE issues
+			SET status = 'open', assignee = NULL, started_at = NULL,
+			    lease_expires_at = NULL, heartbeat_at = NULL,
+			    updated_at = ?, row_lock = ?
+			WHERE id = ? AND status = 'in_progress'
+			  AND lease_expires_at IS NOT NULL AND lease_expires_at < ?
+		`, time.Now().UTC(), freshRowLock(), r.ID, cutoff)
+		if err != nil {
+			return nil, fmt.Errorf("reclaim %s: %w", r.ID, err)
+		}
+		n, err := res.RowsAffected()
+		if err != nil {
+			return nil, fmt.Errorf("reclaim %s rows affected: %w", r.ID, err)
+		}
+		if n == 0 {
+			continue // rescued by a concurrent heartbeat/close — leave it be
+		}
+		if err := RecordFullEventInTable(ctx, tx, "events", r.ID, types.EventLeaseReclaimed, actor,
+			r.PreviousOwner, ""); err != nil {
+			return nil, fmt.Errorf("record reclaim event for %s: %w", r.ID, err)
+		}
+		reclaimed = append(reclaimed, r)
+	}
+	return reclaimed, nil
+}

--- a/internal/storage/issueops/lease.go
+++ b/internal/storage/issueops/lease.go
@@ -44,13 +44,22 @@ func leaseTTL(ctx context.Context) time.Duration {
 // that touch DIFFERENT cells of the same issue row (a heartbeat writing
 // heartbeat_at, a close writing status) merge silently instead of conflicting —
 // which would let a reclaim quietly revert an issue the owner just closed. By
-// having EVERY mutating path rewrite this one shared cell to a fresh random
-// value, concurrent writers always collide on row_lock, surfacing the 1213/1205
-// serialization conflict that withRetryTx replays. The value's only job is to
-// differ from whatever a concurrent writer wrote, so any source of entropy
-// works; we use crypto/rand to avoid seeding concerns. Never 0 (the column
-// default) so a freshly-claimed row is always distinguishable from a never-
-// touched one.
+// having every status/ownership/lease-mutating path rewrite this one shared cell
+// to a fresh random value, those writers always collide on row_lock, surfacing
+// the 1213/1205 serialization conflict that withRetryTx replays. The value's
+// only job is to differ from whatever a concurrent writer wrote, so any source
+// of entropy works; we use crypto/rand to avoid seeding concerns. Never 0 (the
+// column default) so a freshly-claimed row is always distinguishable from a
+// never-touched one.
+//
+// INVARIANT: any path that mutates status, assignee, started_at, or the lease
+// columns on an in_progress issue MUST rewrite row_lock — that is the set the
+// reclaim/heartbeat races care about (claim, close, updateIssueInTx, heartbeat,
+// reclaim all do). Paths that touch only orthogonal cells (is_blocked,
+// compaction_level, dependency metadata, rename, or reopen — which acts on
+// closed rows) are safe to merge with a reclaim and intentionally do NOT rewrite
+// it. Adding a new path that sets status/assignee/lease outside updateIssueInTx
+// without rewriting row_lock would silently reintroduce the zombie-merge bug.
 func freshRowLock() int64 {
 	var b [8]byte
 	if _, err := rand.Read(b[:]); err != nil {

--- a/internal/storage/issueops/lease.go
+++ b/internal/storage/issueops/lease.go
@@ -162,16 +162,18 @@ func ReclaimExpiredLeasesInTx(ctx context.Context, tx DBTX, cutoff time.Time, ac
 	for rows.Next() {
 		var r types.ReclaimedLease
 		if err := rows.Scan(&r.ID, &r.PreviousOwner); err != nil {
-			rows.Close()
+			_ = rows.Close()
 			return nil, fmt.Errorf("scan stale lease row: %w", err)
 		}
 		stale = append(stale, r)
 	}
 	if err := rows.Err(); err != nil {
-		rows.Close()
+		_ = rows.Close()
 		return nil, fmt.Errorf("iterate stale leases: %w", err)
 	}
-	rows.Close()
+	if err := rows.Close(); err != nil {
+		return nil, fmt.Errorf("close stale lease rows: %w", err)
+	}
 	if len(stale) == 0 {
 		return nil, nil
 	}

--- a/internal/storage/issueops/scan.go
+++ b/internal/storage/issueops/scan.go
@@ -30,6 +30,7 @@ func ScanIssueFrom(s IssueScanner, extra ...any) (*types.Issue, error) {
 	var issue types.Issue
 	var createdAtStr, updatedAtStr sql.NullString // scanned as strings, parsed with format fallbacks
 	var startedAt, closedAt, compactedAt, dueAt, deferUntil sql.NullTime
+	var leaseExpiresAt, heartbeatAt sql.NullTime // lease columns (migration 0054); NULL when no active lease
 	var estimatedMinutes, originalSize, timeoutNs sql.NullInt64
 	var createdBy sql.NullString
 	var assignee, externalRef, specID, compactedAtCommit, owner sql.NullString
@@ -52,6 +53,7 @@ func ScanIssueFrom(s IssueScanner, extra ...any) (*types.Issue, error) {
 		&eventKind, &actor, &target, &payload,
 		&dueAt, &deferUntil,
 		&workType, &sourceSystem, &metadata,
+		&leaseExpiresAt, &heartbeatAt,
 	}
 	dests = append(dests, extra...)
 	if err := s.Scan(dests...); err != nil {
@@ -170,6 +172,13 @@ func ScanIssueFrom(s IssueScanner, extra ...any) (*types.Issue, error) {
 	// Custom metadata field (GH#1406)
 	if metadata.Valid && metadata.String != "" && metadata.String != "{}" {
 		issue.Metadata = []byte(metadata.String)
+	}
+	// Lease columns (migration 0054); NULL when no active lease.
+	if leaseExpiresAt.Valid {
+		issue.LeaseExpiresAt = &leaseExpiresAt.Time
+	}
+	if heartbeatAt.Valid {
+		issue.HeartbeatAt = &heartbeatAt.Time
 	}
 
 	return &issue, nil

--- a/internal/storage/issueops/update.go
+++ b/internal/storage/issueops/update.go
@@ -215,6 +215,14 @@ func updateIssueInTx(ctx context.Context, tx DBTX, id string, updates map[string
 	// Auto-manage started_at (set on transition to in_progress). (GH#2796)
 	setClauses, args = ManageStartedAt(oldIssue, updates, setClauses, args)
 
+	// Rewrite row_lock on every update so a concurrent lease mutation (heartbeat/
+	// reclaim) collides on this shared cell and is forced to conflict-and-retry
+	// rather than silently cell-merging two writes to different columns of the
+	// same row (see lease.go). This is the "every mutating path writes row_lock"
+	// invariant the lease scheme depends on.
+	setClauses = append(setClauses, "row_lock = ?")
+	args = append(args, freshRowLock())
+
 	args = append(args, id)
 
 	//nolint:gosec // G201: issueTable comes from WispTableRouting (hardcoded constants)

--- a/internal/storage/issueops/update.go
+++ b/internal/storage/issueops/update.go
@@ -87,6 +87,51 @@ func ManageStartedAt(oldIssue *types.Issue, updates map[string]interface{}, setC
 	return setClauses, args
 }
 
+// ManageLeaseOnUpdate keeps lease ownership coherent when generic updates alter
+// status or assignee. Claim/heartbeat own the normal lease lifecycle, but bd
+// update can transfer or reopen work directly.
+func ManageLeaseOnUpdate(oldIssue *types.Issue, updates map[string]interface{}, setClauses []string, args []interface{}, ctx context.Context) ([]string, []interface{}) {
+	rawStatus, hasStatus := updates["status"]
+	rawAssignee, hasAssignee := updates["assignee"]
+	if !hasStatus && !hasAssignee {
+		return setClauses, args
+	}
+
+	newStatus := string(oldIssue.Status)
+	if hasStatus {
+		switch v := rawStatus.(type) {
+		case string:
+			newStatus = v
+		case types.Status:
+			newStatus = string(v)
+		default:
+			return setClauses, args
+		}
+	}
+
+	newAssignee := oldIssue.Assignee
+	if hasAssignee {
+		switch v := rawAssignee.(type) {
+		case nil:
+			newAssignee = ""
+		case string:
+			newAssignee = v
+		default:
+			newAssignee = fmt.Sprint(v)
+		}
+	}
+
+	if newStatus != string(types.StatusInProgress) || newAssignee == "" {
+		setClauses = append(setClauses, "lease_expires_at = NULL", "heartbeat_at = NULL")
+		return setClauses, args
+	}
+
+	now := time.Now().UTC()
+	setClauses = append(setClauses, "lease_expires_at = ?", "heartbeat_at = ?")
+	args = append(args, now.Add(leaseTTL(ctx)), now)
+	return setClauses, args
+}
+
 // DetermineEventType returns the appropriate event type for an update.
 func DetermineEventType(oldIssue *types.Issue, updates map[string]interface{}) types.EventType {
 	statusVal, hasStatus := updates["status"]
@@ -214,6 +259,9 @@ func updateIssueInTx(ctx context.Context, tx DBTX, id string, updates map[string
 
 	// Auto-manage started_at (set on transition to in_progress). (GH#2796)
 	setClauses, args = ManageStartedAt(oldIssue, updates, setClauses, args)
+
+	// Auto-manage leases when direct updates change status or assignee.
+	setClauses, args = ManageLeaseOnUpdate(oldIssue, updates, setClauses, args, ctx)
 
 	// Rewrite row_lock on every update so a concurrent lease mutation (heartbeat/
 	// reclaim) collides on this shared cell and is forced to conflict-and-retry

--- a/internal/storage/schema/cli_migrations.go
+++ b/internal/storage/schema/cli_migrations.go
@@ -49,6 +49,11 @@ func cliCompatibleMigrationSQL(name, sqlText string) string {
 		// bundles already have the base wisp tables, and the Dolt CLI test
 		// path needs direct DML for deterministic fixture repair.
 		return cliMigration0053RepairRigWisps
+	case "0054_add_lease_columns.up.sql":
+		// Fresh bundle bakes the lease columns directly: the Dolt CLI does not
+		// apply the prepared ALTER TABLE statements the runtime migration uses
+		// for idempotent re-runs on upgraded databases.
+		return cliMigration0054AddLeaseColumns
 	default:
 		return sqlText
 	}
@@ -67,6 +72,14 @@ const cliMigration0027AddStartedAt = `ALTER TABLE issues ADD COLUMN started_at D
 ALTER TABLE wisps ADD COLUMN started_at DATETIME;`
 
 const cliMigration0032DropSchemaMigrationsAppliedAt = `ALTER TABLE schema_migrations DROP COLUMN applied_at;`
+
+const cliMigration0054AddLeaseColumns = `ALTER TABLE issues ADD COLUMN lease_expires_at DATETIME;
+ALTER TABLE issues ADD COLUMN heartbeat_at DATETIME;
+ALTER TABLE issues ADD COLUMN row_lock BIGINT NOT NULL DEFAULT 0;
+CREATE INDEX idx_issues_lease ON issues (status, lease_expires_at);
+ALTER TABLE wisps ADD COLUMN lease_expires_at DATETIME;
+ALTER TABLE wisps ADD COLUMN heartbeat_at DATETIME;
+ALTER TABLE wisps ADD COLUMN row_lock BIGINT NOT NULL DEFAULT 0;`
 
 const cliMigration0041SplitDependenciesTarget = `DELETE FROM dolt_nonlocal_tables;
 CALL DOLT_COMMIT('-Am', 'disable nonlocal tables for fk migrations');

--- a/internal/storage/schema/migrations/0054_add_lease_columns.down.sql
+++ b/internal/storage/schema/migrations/0054_add_lease_columns.down.sql
@@ -1,0 +1,7 @@
+DROP INDEX idx_issues_lease ON issues;
+ALTER TABLE issues DROP COLUMN lease_expires_at;
+ALTER TABLE issues DROP COLUMN heartbeat_at;
+ALTER TABLE issues DROP COLUMN row_lock;
+ALTER TABLE wisps DROP COLUMN lease_expires_at;
+ALTER TABLE wisps DROP COLUMN heartbeat_at;
+ALTER TABLE wisps DROP COLUMN row_lock;

--- a/internal/storage/schema/migrations/0054_add_lease_columns.down.sql
+++ b/internal/storage/schema/migrations/0054_add_lease_columns.down.sql
@@ -1,7 +1,64 @@
-DROP INDEX idx_issues_lease ON issues;
-ALTER TABLE issues DROP COLUMN lease_expires_at;
-ALTER TABLE issues DROP COLUMN heartbeat_at;
-ALTER TABLE issues DROP COLUMN row_lock;
-ALTER TABLE wisps DROP COLUMN lease_expires_at;
-ALTER TABLE wisps DROP COLUMN heartbeat_at;
-ALTER TABLE wisps DROP COLUMN row_lock;
+-- Roll back lease columns. Guard every statement so an issues-only or
+-- partially-applied workspace can roll back as safely as it migrated up.
+
+DROP INDEX IF EXISTS idx_issues_lease ON issues;
+
+SET @sql = IF(
+  (SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = 'issues'
+      AND COLUMN_NAME = 'lease_expires_at') > 0,
+  'ALTER TABLE issues DROP COLUMN lease_expires_at',
+  'SELECT 1'
+);
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @sql = IF(
+  (SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = 'issues'
+      AND COLUMN_NAME = 'heartbeat_at') > 0,
+  'ALTER TABLE issues DROP COLUMN heartbeat_at',
+  'SELECT 1'
+);
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @sql = IF(
+  (SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = 'issues'
+      AND COLUMN_NAME = 'row_lock') > 0,
+  'ALTER TABLE issues DROP COLUMN row_lock',
+  'SELECT 1'
+);
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @sql = IF(
+  (SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = 'wisps'
+      AND COLUMN_NAME = 'lease_expires_at') > 0,
+  'ALTER TABLE wisps DROP COLUMN lease_expires_at',
+  'SELECT 1'
+);
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @sql = IF(
+  (SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = 'wisps'
+      AND COLUMN_NAME = 'heartbeat_at') > 0,
+  'ALTER TABLE wisps DROP COLUMN heartbeat_at',
+  'SELECT 1'
+);
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @sql = IF(
+  (SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = 'wisps'
+      AND COLUMN_NAME = 'row_lock') > 0,
+  'ALTER TABLE wisps DROP COLUMN row_lock',
+  'SELECT 1'
+);
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;

--- a/internal/storage/schema/migrations/0054_add_lease_columns.up.sql
+++ b/internal/storage/schema/migrations/0054_add_lease_columns.up.sql
@@ -1,0 +1,114 @@
+-- Dead-worker recovery (Gas Station v1.1, wy-5r9j): give a claim a lease.
+--
+-- A claim was previously permanent — a worker that died mid-task stranded its
+-- issue in_progress forever. These columns let a claim expire:
+--
+--   lease_expires_at  the wall-clock instant after which the claim is stale and
+--                     a reaper (bd reclaim) may revert the issue to ready.
+--   heartbeat_at      the last time the lease owner proved it was still alive.
+--   row_lock          a random BIGINT rewritten by EVERY mutating path on the
+--                     row. Dolt has no real row locking and merges concurrent
+--                     writes cell-by-cell, so a heartbeat (touching heartbeat_at)
+--                     and a close (touching status) would otherwise silently
+--                     cell-merge instead of conflicting. Forcing every writer to
+--                     also rewrite this one shared cell turns those into a
+--                     1213/1205 serialization conflict that withRetryTx replays —
+--                     the difference between exactly-once and a lost close.
+--
+-- Guarded so the migration is idempotent on a schema_migrations row that
+-- regressed without its DDL rolled back (see 0052/0046). assignee doubles as the
+-- lease owner; no new owner column is needed.
+
+-- issues.lease_expires_at
+SET @needs_add = (
+    SELECT IF(COUNT(*) = 0, 1, 0)
+    FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = 'issues'
+      AND COLUMN_NAME = 'lease_expires_at'
+);
+SET @sql = IF(@needs_add = 1,
+    'ALTER TABLE issues ADD COLUMN lease_expires_at DATETIME',
+    'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+-- issues.heartbeat_at
+SET @needs_add = (
+    SELECT IF(COUNT(*) = 0, 1, 0)
+    FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = 'issues'
+      AND COLUMN_NAME = 'heartbeat_at'
+);
+SET @sql = IF(@needs_add = 1,
+    'ALTER TABLE issues ADD COLUMN heartbeat_at DATETIME',
+    'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+-- issues.row_lock
+SET @needs_add = (
+    SELECT IF(COUNT(*) = 0, 1, 0)
+    FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = 'issues'
+      AND COLUMN_NAME = 'row_lock'
+);
+SET @sql = IF(@needs_add = 1,
+    'ALTER TABLE issues ADD COLUMN row_lock BIGINT NOT NULL DEFAULT 0',
+    'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+-- idx_issues_lease: the reaper scans in_progress issues by lease_expires_at.
+SET @needs_index = (
+    SELECT IF(COUNT(*) = 0, 1, 0)
+    FROM INFORMATION_SCHEMA.STATISTICS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = 'issues'
+      AND INDEX_NAME = 'idx_issues_lease'
+);
+SET @sql = IF(@needs_index = 1,
+    'CREATE INDEX idx_issues_lease ON issues (status, lease_expires_at)',
+    'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+-- wisps mirror the issues lease columns so the shared issueops claim/heartbeat
+-- SQL (which routes by table name) works uniformly. Wisps are ephemeral and are
+-- never reclaimed, but the columns must exist for the shared UPDATEs to bind.
+-- Guarded on the wisps table existing (older workspaces created issues-only).
+SET @has_wisps = (
+    SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES
+    WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'wisps'
+);
+
+SET @needs_add = IF(@has_wisps > 0 AND
+    (SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
+        WHERE TABLE_SCHEMA = DATABASE()
+          AND TABLE_NAME = 'wisps'
+          AND COLUMN_NAME = 'lease_expires_at') = 0,
+    1, 0);
+SET @sql = IF(@needs_add = 1,
+    'ALTER TABLE wisps ADD COLUMN lease_expires_at DATETIME',
+    'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @needs_add = IF(@has_wisps > 0 AND
+    (SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
+        WHERE TABLE_SCHEMA = DATABASE()
+          AND TABLE_NAME = 'wisps'
+          AND COLUMN_NAME = 'heartbeat_at') = 0,
+    1, 0);
+SET @sql = IF(@needs_add = 1,
+    'ALTER TABLE wisps ADD COLUMN heartbeat_at DATETIME',
+    'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @needs_add = IF(@has_wisps > 0 AND
+    (SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
+        WHERE TABLE_SCHEMA = DATABASE()
+          AND TABLE_NAME = 'wisps'
+          AND COLUMN_NAME = 'row_lock') = 0,
+    1, 0);
+SET @sql = IF(@needs_add = 1,
+    'ALTER TABLE wisps ADD COLUMN row_lock BIGINT NOT NULL DEFAULT 0',
+    'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;

--- a/internal/storage/sqlbuild/sqlbuild.go
+++ b/internal/storage/sqlbuild/sqlbuild.go
@@ -44,7 +44,8 @@ const IssueSelectColumns = `id, content_hash, title, description, design, accept
 	       mol_type,
 	       event_kind, actor, target, payload,
 	       due_at, defer_until,
-	       work_type, source_system, metadata`
+	       work_type, source_system, metadata,
+	       lease_expires_at, heartbeat_at`
 
 // QueryBatchSize bounds IN-clause sizes when long ID lists are folded into
 // WHERE fragments.

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -1006,6 +1006,9 @@ const (
 	EventLabelAdded        EventType = "label_added"
 	EventLabelRemoved      EventType = "label_removed"
 	EventCompacted         EventType = "compacted"
+	// EventLeaseReclaimed records that a stale lease was reverted to ready by
+	// bd reclaim (dead-worker recovery). old_value is the previous owner.
+	EventLeaseReclaimed EventType = "lease_reclaimed"
 )
 
 // BlockedIssue extends Issue with blocking information
@@ -1318,6 +1321,15 @@ func (s SortPolicy) IsValid() bool {
 		return true
 	}
 	return false
+}
+
+// ReclaimedLease names an issue whose stale lease was reverted to ready by
+// bd reclaim, together with the owner the lease was taken from. Returned so
+// callers (the CLI, a supervisor) can report which dead workers' work was
+// recovered.
+type ReclaimedLease struct {
+	ID            string
+	PreviousOwner string
 }
 
 // WorkFilter is used to filter ready work queries

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -45,6 +45,12 @@ type Issue struct {
 	CloseReason     string     `json:"close_reason,omitempty"`      // Reason provided when closing
 	ClosedBySession string     `json:"closed_by_session,omitempty"` // Claude Code session that closed this issue
 
+	// ===== Leasing (claim TTL + heartbeat; migration 0054) =====
+	// NULL when there is no active lease. row_lock is an internal serialization
+	// mechanism and is intentionally NOT surfaced here.
+	LeaseExpiresAt *time.Time `json:"lease_expires_at,omitempty"` // When the current claim's lease expires
+	HeartbeatAt    *time.Time `json:"heartbeat_at,omitempty"`     // Last heartbeat from the lease owner
+
 	// ===== Time-Based Scheduling (GH#820) =====
 	DueAt      *time.Time `json:"due_at,omitempty"`      // When this issue should be completed
 	DeferUntil *time.Time `json:"defer_until,omitempty"` // Hide from bd ready until this time

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -1334,8 +1334,8 @@ func (s SortPolicy) IsValid() bool {
 // callers (the CLI, a supervisor) can report which dead workers' work was
 // recovered.
 type ReclaimedLease struct {
-	ID            string
-	PreviousOwner string
+	ID            string `json:"id"`
+	PreviousOwner string `json:"previous_owner"`
 }
 
 // WorkFilter is used to filter ready work queries

--- a/internal/types/types_test.go
+++ b/internal/types/types_test.go
@@ -891,6 +891,53 @@ func TestIssueStructFields(t *testing.T) {
 	}
 }
 
+// TestIssueLeaseJSONSerialization verifies the leasing columns (migration 0054)
+// are surfaced in JSON when present and omitted when absent, while the internal
+// row_lock is never exposed. Backs `bd show <id> --json` (wy-9cdw).
+func TestIssueLeaseJSONSerialization(t *testing.T) {
+	now := time.Now().UTC()
+	expires := now.Add(15 * time.Minute)
+
+	// With an active lease: both keys appear, row_lock never does.
+	leased := IssueDetails{Issue: Issue{
+		ID:             "test-1",
+		Title:          "Leased",
+		Status:         StatusInProgress,
+		LeaseExpiresAt: &expires,
+		HeartbeatAt:    &now,
+	}}
+	b, err := json.Marshal(leased)
+	if err != nil {
+		t.Fatalf("marshal leased issue: %v", err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(b, &m); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if _, ok := m["lease_expires_at"]; !ok {
+		t.Errorf("expected lease_expires_at in JSON, got: %s", b)
+	}
+	if _, ok := m["heartbeat_at"]; !ok {
+		t.Errorf("expected heartbeat_at in JSON, got: %s", b)
+	}
+	if _, ok := m["row_lock"]; ok {
+		t.Errorf("row_lock must never be surfaced, got: %s", b)
+	}
+
+	// Without a lease (the common case): keys are omitted, not null.
+	unleased := IssueDetails{Issue: Issue{ID: "test-2", Title: "Open", Status: StatusOpen}}
+	b2, err := json.Marshal(unleased)
+	if err != nil {
+		t.Fatalf("marshal unleased issue: %v", err)
+	}
+	if strings.Contains(string(b2), "lease_expires_at") {
+		t.Errorf("lease_expires_at should be omitted when nil, got: %s", b2)
+	}
+	if strings.Contains(string(b2), "heartbeat_at") {
+		t.Errorf("heartbeat_at should be omitted when nil, got: %s", b2)
+	}
+}
+
 func TestBlockedIssueEmbedding(t *testing.T) {
 	blocked := BlockedIssue{
 		Issue: Issue{

--- a/internal/types/types_test.go
+++ b/internal/types/types_test.go
@@ -938,6 +938,26 @@ func TestIssueLeaseJSONSerialization(t *testing.T) {
 	}
 }
 
+func TestReclaimedLeaseJSONSerialization(t *testing.T) {
+	b, err := json.Marshal(ReclaimedLease{ID: "bd-1", PreviousOwner: "worker-a"})
+	if err != nil {
+		t.Fatalf("marshal reclaimed lease: %v", err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(b, &m); err != nil {
+		t.Fatalf("unmarshal reclaimed lease: %v", err)
+	}
+	if m["id"] != "bd-1" || m["previous_owner"] != "worker-a" {
+		t.Fatalf("reclaimed lease JSON = %s, want snake_case id/previous_owner", b)
+	}
+	if _, ok := m["ID"]; ok {
+		t.Fatalf("reclaimed lease JSON leaked Go field name: %s", b)
+	}
+	if _, ok := m["PreviousOwner"]; ok {
+		t.Fatalf("reclaimed lease JSON leaked Go field name: %s", b)
+	}
+}
+
 func TestBlockedIssueEmbedding(t *testing.T) {
 	blocked := BlockedIssue{
 		Issue: Issue{

--- a/scripts/check-testing-short.sh
+++ b/scripts/check-testing-short.sh
@@ -10,6 +10,8 @@ internal/hooks/hooks_test.go::TestRunSync_KillsDescendants
 internal/testutil/fixtures/fixtures_test.go::TestXLargeDolt
 internal/testutil/fixtures/fixtures_test.go::TestLargeFromJSONL
 internal/storage/dolt/concurrent_test.go::TestHighContentionStress
+internal/storage/dolt/concurrent_test.go::TestConcurrentWorkQueueDrain
+internal/storage/dolt/lease_test.go::TestConcurrentHeartbeatReclaimClose
 EOF
 )
 

--- a/website/docs/cli-reference/heartbeat.md
+++ b/website/docs/cli-reference/heartbeat.md
@@ -1,0 +1,34 @@
+---
+id: heartbeat
+title: bd heartbeat
+slug: /cli-reference/heartbeat
+sidebar_position: 999
+---
+
+<!-- AUTO-GENERATED: do not edit manually -->
+Generated from `bd help --doc heartbeat`
+
+## bd heartbeat
+
+Refresh the lease on an issue you currently hold in_progress.
+
+A claim carries a lease that expires after a TTL. A worker keeps its claim alive
+by heartbeating faster than the TTL; once it stops (because it died), the lease
+goes stale and 'bd reclaim' reverts the issue to ready so another worker can pick
+it up. Heartbeat pushes lease_expires_at forward and stamps heartbeat_at = now.
+
+Only the current owner may heartbeat. If the lease has already been reclaimed or
+the issue closed, heartbeat fails so the worker learns to stop.
+
+Heartbeat writes a Dolt commit, so heartbeat well below the TTL but not so fast
+it bloats history — cadence should be a small fraction of the TTL, not per-op.
+
+Examples:
+  bd heartbeat bd-123
+  bd hb bd-123
+
+```
+bd heartbeat <id> [flags]
+```
+
+**Aliases:** hb

--- a/website/docs/cli-reference/index.md
+++ b/website/docs/cli-reference/index.md
@@ -9,7 +9,7 @@ sidebar_position: 0
 <!-- AUTO-GENERATED: do not edit manually -->
 Reference for bd Latest. Generated from `bd help --docs-root`.
 
-This reference covers all 108 live top-level `bd` commands. Regenerate it with:
+This reference covers all 110 live top-level `bd` commands. Regenerate it with:
 
 ```bash
 ./scripts/generate-cli-docs.sh
@@ -59,6 +59,7 @@ This reference covers all 108 live top-level `bd` commands. Regenerate it with:
 - [`bd github`](./github.md)
 - [`bd gitlab`](./gitlab.md)
 - [`bd graph`](./graph.md)
+- [`bd heartbeat`](./heartbeat.md)
 - [`bd history`](./history.md)
 - [`bd hooks`](./hooks.md)
 - [`bd human`](./human.md)
@@ -95,6 +96,7 @@ This reference covers all 108 live top-level `bd` commands. Regenerate it with:
 - [`bd quickstart`](./quickstart.md)
 - [`bd ready`](./ready.md)
 - [`bd recall`](./recall.md)
+- [`bd reclaim`](./reclaim.md)
 - [`bd recompute-blocked`](./recompute-blocked.md)
 - [`bd remember`](./remember.md)
 - [`bd rename`](./rename.md)

--- a/website/docs/cli-reference/reclaim.md
+++ b/website/docs/cli-reference/reclaim.md
@@ -1,0 +1,40 @@
+---
+id: reclaim
+title: bd reclaim
+slug: /cli-reference/reclaim
+sidebar_position: 999
+---
+
+<!-- AUTO-GENERATED: do not edit manually -->
+Generated from `bd help --doc reclaim`
+
+## bd reclaim
+
+Revert in_progress issues whose lease has gone stale back to ready.
+
+When a worker claims an issue it takes a lease that expires after a TTL, kept
+alive by 'bd heartbeat'. A worker that dies stops heartbeating, so its lease
+expires and its issue would otherwise stay in_progress forever. reclaim is the
+reaper: it finds in_progress issues whose lease expired more than --older-than
+ago, clears the assignee, and sets them back to open so another worker can
+claim them. The previous owner's stale lease is recorded as a recovery event.
+
+--older-than is a grace window past lease expiry: only leases that expired at
+least this long ago are reclaimed, so a worker briefly paused (GC, clock skew)
+is not robbed of live work. Run it from a supervisor on a timer with a window
+of roughly 2× the claim TTL.
+
+Examples:
+  bd reclaim                       # default grace window (2× the lease TTL)
+  bd reclaim --older-than 10m      # reclaim leases expired &gt;10m ago
+  bd reclaim --older-than 0s       # reclaim every currently-expired lease
+
+```
+bd reclaim [flags]
+```
+
+**Flags:**
+
+```
+      --older-than duration   Only reclaim leases that expired at least this long ago (grace window) (default 10m0s)
+```


### PR DESCRIPTION
## Why

This stack has been running in production (the gas-station fleet) since late June via locally-built binaries (v1.1.0-rc.1 line), but never landed on main. That divergence is now biting: the fleet's Dolt DBs were migrated to **schema v54** by those binaries, so a main-built `bd` (v53) half-fails against them — reads mostly work, but e.g. `bd export --all` errors, which silently truncated a git-tracked memories backup to 0 bytes tonight before being caught. Main must catch up to the schema its own deployments already created.

## What

Lands `origin/feat/lease-primitive` into main, plus one finished commit stranded on a local checkout:

- `fix(dolt)`: retry mutate+commit methods on serialization conflict (1213/1205)
- `test(dolt)`: concurrent work-queue drain test (gas-station claim invariant)
- `feat(lease)`: claim-TTL + heartbeat + reclaim for dead-worker recovery — **includes migration `0054_add_lease_columns`**
- ci: allowlist lease stress tests / TestConcurrentWorkQueueDrain for the testing.Short() policy
- `feat(show)`: surface lease_expires_at/heartbeat_at in `bd show` (--json + text) (wy-9cdw) — cherry-picked from the local `~/beads` checkout where it was stranded
- merge of origin/main (clean auto-merge, no conflicts)

## Verification

- `go build ./...` green
- `go test ./internal/storage/schema/... ./cmd/bd -run 'TestEmbeddedMemory|Test.*Lease|Test.*Migrat'` green
- Migration 0054 present (up+down)

## Related

- The `bd remember` desire-path fix (bare existing key recalls; bare unknown slug refused) is already on main @ 9ee97c264.
- Branch `pave/remember-reads-rc1` (rc-line backport powering the currently installed binary) becomes redundant once this merges — delete it after the next release build.
- After merge: the beads repo's own tracker DB (v51) needs its designated-migrator run (`BD_ALLOW_REMOTE_MIGRATE=1 bd migrate && bd dolt push`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)