### PR TITLE
chore(release): prep v1.1.0-rc.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "beads",
       "source": "./plugins/beads",
       "description": "AI-supervised issue tracker for coding workflows",
-      "version": "1.1.0-rc.1"
+      "version": "1.1.0-rc.2"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0-rc.2] - 2026-07-02
+
+Second release candidate for 1.1.0. Fixes the two upgrade-breaking migration
+regressions reported against rc.1 (#4502, #4534), hardens the remote-migrate
+gate that rc.1 introduced, and ships the validated upgrade documentation.
+
 ### Upgrade Notes
 
 - **Back up before migrating.** The upgrade guide's remote-backed recipes now
@@ -43,6 +49,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `ON DELETE CASCADE` would have removed had it been in force. Runs
   automatically on the next command with the new binary; already-bitten
   databases are healed in place.
+- **Old binaries fail fast on writable opens of a schema-newer database**
+  instead of proceeding against a schema they do not understand
+  ([#4531](https://github.com/gastownhall/beads/pull/4531)) — the guard rail
+  for the mixed-version window during multi-clone upgrades.
+- **Prerelease GitHub releases now ship prerelease-correct install
+  instructions.** The release notes header previously showed the stable
+  install methods (brew, install scripts), three of which do not deliver a
+  prerelease ([#4530](https://github.com/gastownhall/beads/pull/4530)).
+- **`bd remember` no longer clobbers a memory whose content is its own key**,
+  and a bare `bd remember <existing-key>` now recalls instead of overwriting.
+
+### Added
+
+- **Smarter remote-migrate gate.** The gate introduced in rc.1 is now
+  state-aware and agent-safe: cases that are provably safe to migrate
+  auto-resolve instead of stopping every agent at the wall, while genuinely
+  risky states still require the designated migrator
+  ([#4515](https://github.com/gastownhall/beads/pull/4515),
+  [#4516](https://github.com/gastownhall/beads/pull/4516)).
+- **Backend-agnostic storage conformance test suite**
+  ([#4414](https://github.com/gastownhall/beads/pull/4414)).
+
+### Documentation
+
+- **Validated upgrade recipe for remote-backed / multi-clone databases** in
+  the upgrade guide, exercised end-to-end on a live database
+  ([#4514](https://github.com/gastownhall/beads/pull/4514)), plus a
+  consolidated Homebrew tap-migration snippet across install docs, a README
+  pointer to the upgrade guide, and a pre-migrate backup step in the
+  recipes (this release).
 
 ## [1.1.0-rc.1] - 2026-06-23
 

--- a/cmd/bd/info.go
+++ b/cmd/bd/info.go
@@ -214,6 +214,18 @@ type VersionChange struct {
 // versionChanges contains agent-actionable changes for recent versions
 var versionChanges = []VersionChange{
 	{
+		Version: "1.1.0-rc.2",
+		Date:    "2026-07-02",
+		Changes: []string{
+			"RC: fixes the two upgrade-breaking migration regressions reported against rc.1 (#4502, #4534); back up with bd export --all before migrating a remote-backed database.",
+			"FIX: the v53 migration no longer fails with Unknown column on databases whose issues table predates the rig/agent columns; the runner repairs the drift before applying (#4502).",
+			"FIX: an orphaned child_counters row no longer bricks every bd create after the fk_counter_parent constraint returned; a clone-local cleanup migration heals affected databases automatically (#4534).",
+			"FIX: old binaries fail fast on writable opens of a schema-newer database instead of proceeding blind (#4531).",
+			"NEW: the remote-migrate gate is state-aware and agent-safe — provably safe migrations auto-resolve; risky states still require BD_ALLOW_REMOTE_MIGRATE=1 by the designated migrator (#4515, #4516).",
+			"UPGRADE: the upgrade guide now carries a validated remote-backed / multi-clone recipe with a pre-migrate backup step (#4514).",
+		},
+	},
+	{
 		Version: "1.1.0-rc.1",
 		Date:    "2026-06-23",
 		Changes: []string{

--- a/cmd/bd/version.go
+++ b/cmd/bd/version.go
@@ -16,7 +16,7 @@ import (
 
 var (
 	// Version is the current version of bd (overridden by ldflags at build time)
-	Version = "1.1.0-rc.1"
+	Version = "1.1.0-rc.2"
 	// Build can be set via ldflags at compile time
 	Build = "dev"
 	// Commit and branch the git revision the binary was built from (optional ldflag)

--- a/cmd/bd/winres/winres.json
+++ b/cmd/bd/winres/winres.json
@@ -18,12 +18,12 @@
             "Comments": "AI-supervised issue tracker for coding workflows",
             "CompanyName": "Steve Yegge",
             "FileDescription": "beads - AI-supervised issue tracker",
-            "FileVersion": "1.1.0-rc.1",
+            "FileVersion": "1.1.0-rc.2",
             "InternalName": "bd",
             "LegalCopyright": "Copyright (c) 2024-2026 Steve Yegge. MIT License.",
             "OriginalFilename": "bd.exe",
             "ProductName": "beads",
-            "ProductVersion": "1.1.0-rc.1"
+            "ProductVersion": "1.1.0-rc.2"
           }
         }
       }

--- a/default.nix
+++ b/default.nix
@@ -7,7 +7,7 @@
 }:
 buildGoModule {
   pname = "beads";
-  version = "1.1.0-rc.1";
+  version = "1.1.0-rc.2";
 
   src = self;
 

--- a/integrations/beads-mcp/pyproject.toml
+++ b/integrations/beads-mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "beads-mcp"
-version = "1.1.0-rc.1"
+version = "1.1.0-rc.2"
 description = "MCP server for beads issue tracker."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/integrations/beads-mcp/src/beads_mcp/__init__.py
+++ b/integrations/beads-mcp/src/beads_mcp/__init__.py
@@ -4,4 +4,4 @@ This package provides an MCP (Model Context Protocol) server that exposes
 beads (bd) issue tracker functionality to MCP Clients.
 """
 
-__version__ = "1.1.0-rc.1"
+__version__ = "1.1.0-rc.2"

--- a/integrations/beads-mcp/uv.lock
+++ b/integrations/beads-mcp/uv.lock
@@ -80,7 +80,7 @@ wheels = [
 
 [[package]]
 name = "beads-mcp"
-version = "1.1.0rc1"
+version = "1.1.0rc2"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },

--- a/npm-package/package.json
+++ b/npm-package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@beads/bd",
-  "version": "1.1.0-rc.1",
+  "version": "1.1.0-rc.2",
   "description": "Beads issue tracker - lightweight memory system for coding agents with native binary support",
   "main": "bin/bd.js",
   "bin": {

--- a/plugins/beads/.claude-plugin/plugin.json
+++ b/plugins/beads/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "beads",
   "description": "AI-supervised issue tracker for coding workflows. Manage tasks, discover work, and maintain context with simple CLI commands.",
-  "version": "1.1.0-rc.1",
+  "version": "1.1.0-rc.2",
   "author": {
     "name": "Steve Yegge",
     "url": "https://github.com/steveyegge"

--- a/plugins/beads/.codex-plugin/plugin.json
+++ b/plugins/beads/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "beads",
-  "version": "1.1.0-rc.1",
+  "version": "1.1.0-rc.2",
   "description": "AI-supervised issue tracking for coding workflows with agent skills.",
   "author": {
     "name": "Steve Yegge",

--- a/plugins/beads/.copilot-plugin/plugin.json
+++ b/plugins/beads/.copilot-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "beads",
   "description": "AI-supervised issue tracker for coding workflows. Manage tasks, discover work, and maintain context with simple CLI commands.",
-  "version": "1.1.0-rc.1",
+  "version": "1.1.0-rc.2",
   "author": {
     "name": "Steve Yegge",
     "url": "https://github.com/steveyegge"


### PR DESCRIPTION
## Why

rc.1 is superseded: two upgrade-breaking migration regressions were reported against it and fixed (#4502 — v53 fails on pre-rig `issues` tables; #4534 — one orphaned `child_counters` row bricks every `bd create`), and several release-relevant changes landed after the rc.1 tag: the remote-migrate gate hardening (#4515, #4516), the schema-newer fail-fast (#4531), the prerelease-correct install header (#4530), and the validated multi-clone upgrade recipe (#4514). A fresh candidate is needed to validate all of that through the release pipeline before promoting 1.1.0 to stable.

## What

RC prep per RELEASING.md:

- CHANGELOG.md: dated `[1.1.0-rc.2]` section covering the rc.1-regression fixes, gate hardening, fail-fast, install header, remember fixes, conformance suite, and upgrade-doc work.
- `cmd/bd/info.go`: 1.1.0-rc.2 whats-new entry.
- `./scripts/update-versions.sh 1.1.0-rc.2` (12 files).
- `integrations/beads-mcp` lockfile resynced (`uv lock`, 1.1.0rc2).
- `./scripts/check-versions.sh` passes.

After merge: tag `v1.1.0-rc.2` from the merge commit; goreleaser publishes the GitHub prerelease only (brew/PyPI/npm skipped). With #4530 now in, the prerelease release-notes header will carry the correct install instructions automatically.

_claude-fable-5-high on behalf of matt wilkie_

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0167xsjJDukVKE7BE1i4W2wE
