### PR TITLE
fix(notion): drop in_trash from data-source query body (Notion 400)

### DIFF
--- a/internal/notion/client.go
+++ b/internal/notion/client.go
@@ -124,7 +124,6 @@ func (c *Client) QueryDataSource(ctx context.Context, dataSourceID string) ([]Pa
 		request := map[string]interface{}{
 			"page_size":   maxPageSize,
 			"result_type": "page",
-			"in_trash":    false,
 		}
 		if cursor != "" {
 			request["start_cursor"] = cursor


### PR DESCRIPTION
## What

Removes the `"in_trash": false` key from the `QueryDataSource` request body in
`internal/notion/client.go`. One-line deletion, no behavior change: Notion's
data-source query endpoint excludes trashed pages by default.

## Why

Fixes #4542.

Notion's query endpoint (under the pinned `Notion-Version: 2026-03-11`) rejects
`in_trash` as a body property with:

```
validation_error (400): body failed validation: body.in_trash should be not present
```

`in_trash` is valid on page PATCH bodies (kept as-is in `ArchivePage`) but not on
query bodies. Since `QueryDataSource` is the enumeration step for both sync
directions, every `bd notion sync` invocation currently fails — pull and push.

## Verification

- Rebuilt v1.0.3 and v1.0.4 with only this change; `bd notion sync --pull --dry-run`
  against a live Notion workspace succeeds (previously: 400, exit 1). 3,397 pages
  queried; a subsequent real pull + push round-trip completed cleanly.
- Trashed pages remain excluded from query results (endpoint default).
- `go build -tags gms_pure_go ./cmd/bd` clean.