### PR TITLE
docs(cli): regenerate CLI reference for bd remember bare-key reads

### DIFF
--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -3631,10 +3631,16 @@ Store a memory that persists across sessions and account rotations.
 Memories are injected at prime time (bd prime) so you have them
 in every session without manual loading.
 
+The positional arg is the memory CONTENT (the key is auto-generated from it
+unless --key is given). As a convenience, if the arg is a bare key naming an
+existing memory, it is RECALLED instead of stored (same as 'bd recall');
+a bare key naming nothing is refused. Use --key to store slug-like content.
+
 Examples:
   bd remember "always run tests with -race flag"
   bd remember "Dolt phantom DBs hide in three places" --key dolt-phantoms
   bd remember "auth module uses JWT not sessions" --key auth-jwt
+  bd remember dolt-phantoms        # bare existing key: reads it (= bd recall)
 
 ```
 bd remember "<insight>" [flags]

--- a/website/docs/cli-reference/remember.md
+++ b/website/docs/cli-reference/remember.md
@@ -15,10 +15,16 @@ Store a memory that persists across sessions and account rotations.
 Memories are injected at prime time (bd prime) so you have them
 in every session without manual loading.
 
+The positional arg is the memory CONTENT (the key is auto-generated from it
+unless --key is given). As a convenience, if the arg is a bare key naming an
+existing memory, it is RECALLED instead of stored (same as 'bd recall');
+a bare key naming nothing is refused. Use --key to store slug-like content.
+
 Examples:
   bd remember "always run tests with -race flag"
   bd remember "Dolt phantom DBs hide in three places" --key dolt-phantoms
   bd remember "auth module uses JWT not sessions" --key auth-jwt
+  bd remember dolt-phantoms        # bare existing key: reads it (= bd recall)
 
 ```
 bd remember "<insight>" [flags]


### PR DESCRIPTION
## Why

Main has been red since `9ee97c264` (remember read-paving) landed without a CLI docs regen: `docs/CLI_REFERENCE.md` and the website remember page drifted from live `--help`, so the strict CLI-docs freshness probe fails the Build Artifacts, PR Policy, and doc-flags jobs on every push to main (first failing run 2026-07-02T05:07Z, i.e. before today's release-train merges; every subsequent Main run inherits it, including the rc.2 prep merge).

## What

Regenerated with `scripts/generate-cli-docs.sh` (its pinned `CGO_ENABLED=0` build, so no federation churn). The diff is exactly the new bare-key recall paragraph and example from `9ee97c264` — 12 added lines across the two generated files, nothing else.

_claude-fable-5-high on behalf of matt wilkie_

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0167xsjJDukVKE7BE1i4W2wE
