### PR TITLE
perf(bd): mark query command as read-only

### DIFF
--- a/cmd/bd/dolt_autopush_test.go
+++ b/cmd/bd/dolt_autopush_test.go
@@ -98,7 +98,7 @@ func TestMaybeAutoPush_NilStore(t *testing.T) {
 
 func TestAutoPush_SkippedForReadOnlyCommands(t *testing.T) {
 	// Read-only commands should not trigger auto-push (GH#2191).
-	readOnly := []string{"list", "ready", "show", "stats", "blocked", "search", "graph"}
+	readOnly := []string{"list", "ready", "show", "stats", "blocked", "search", "query", "graph"}
 	for _, cmd := range readOnly {
 		if !isReadOnlyCommand(cmd) {
 			t.Errorf("isReadOnlyCommand(%q) = false, want true", cmd)

--- a/cmd/bd/main.go
+++ b/cmd/bd/main.go
@@ -127,6 +127,7 @@ var readOnlyCommands = map[string]bool{
 	"blocked":    true,
 	"count":      true,
 	"search":     true,
+	"query":      true,
 	"graph":      true,
 	"duplicates": true,
 	"comments":   true, // list comments (not add)


### PR DESCRIPTION
## What

Add `"query"` to `readOnlyCommands` in `cmd/bd/main.go` so `bd query` opens the
Dolt store in read-only mode, like every other pure-read command.

## Why

`bd query` is a pure read — it only calls `store.SearchIssues` /
`store.SearchIssuesWithCounts` and never writes — but it was missing from
`readOnlyCommands`, so it opened the store in **write** mode. This looks like an
oversight from when the command was added: every sibling read command (`list`,
`ready`, `show`, `stats`, `count`, `search`, `graph`, `duplicates`, …) is already
in the map.

Opening read-only skips writer-only setup that is meaningless for a query:

- `validateWorkspaceIdentity` — gated on `!useReadOnly` (`cmd/bd/main.go:1172`)
- `shouldRunAutoImportJSONL` — early-returns when `useReadOnly` (`cmd/bd/main.go:1322`)

So this is both **more correct** (a read command no longer takes a writable open)
and **cheaper** on the hot query path. One PR, one concern; no unrelated changes.

Also adds `query` to the read-only command list already asserted by
`TestAutoPush_SkippedForReadOnlyCommands`, so the classification is guarded the
same way as its siblings (`list`, `ready`, `show`, `search`, …).

## Verification

```sh
go build ./...
go test ./cmd/bd/ -run TestAutoPush_SkippedForReadOnlyCommands
```

- Build passes; `TestAutoPush_SkippedForReadOnlyCommands` passes with `query`
  added to the asserted read-only set.
- `bd query` now classifies as read-only: `isReadOnlyCommand("query")` returns
  true, so the store opens read-only and the writer-only setup above is skipped.
- Behavior of `bd query` output is unchanged — it was already a pure read.