### PR TITLE
feat(gate): turn the smart remote-migrate gate on by default (#4516)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **The state-aware remote-migrate gate is now on by default.** rc.2 shipped
+  the smart gate behind an opt-in env var, but nothing in the gate's block
+  message or docs surfaced that the var existed, so in practice everyone kept
+  hitting the blunt always-block behavior. The provably-safe first-mover case
+  (remote at the same schema version as this clone) now auto-migrates without
+  `BD_ALLOW_REMOTE_MIGRATE`; remote-ahead still stops with an adopt directive
+  and content skew still stops for a human. Set `BD_SMART_GATE=0` to opt out
+  and restore the unconditional block
+  ([#4516](https://github.com/gastownhall/beads/issues/4516)).
+
 ## [1.1.0-rc.2] - 2026-07-02
 
 Second release candidate for 1.1.0. Fixes the two upgrade-breaking migration

--- a/cmd/bd/init_embedded_test.go
+++ b/cmd/bd/init_embedded_test.go
@@ -98,6 +98,18 @@ func bdEnv(dir string) []string {
 	)
 }
 
+// envWithout returns env minus any entries for the named variable.
+func envWithout(env []string, name string) []string {
+	out := make([]string, 0, len(env))
+	for _, e := range env {
+		if strings.HasPrefix(e, name+"=") {
+			continue
+		}
+		out = append(out, e)
+	}
+	return out
+}
+
 func isEmbeddedLockOutput(out string) bool {
 	out = strings.ToLower(out)
 	return strings.Contains(out, "one writer at a time") ||
@@ -671,11 +683,16 @@ func TestEmbeddedInit(t *testing.T) {
 		}
 	})
 
-	t.Run("remote_behind_schema_gates_with_guidance", func(t *testing.T) {
-		// bd-4mpy7: bootstrapping from a remote whose database is behind this
-		// binary's schema must fail with designated-migrator guidance and
-		// leave a finalized workspace where the guidance commands can run —
-		// not a half-initialized directory with a raw gate error.
+	t.Run("remote_behind_schema_gate", func(t *testing.T) {
+		// bd-4mpy7 / #4516: bootstrapping from a remote whose database is
+		// behind this binary's schema. Shared fixture: a published remote
+		// regressed one migration below LatestVersion. Two paths against it:
+		// the default smart gate auto-migrates the clone as a safe
+		// first-mover (remote at the same version — no one has migrated),
+		// while the BD_SMART_GATE=0 opt-out must fail with
+		// designated-migrator guidance and leave a finalized workspace where
+		// the guidance commands can run — not a half-initialized directory
+		// with a raw gate error.
 		remoteDir := filepath.Join(t.TempDir(), "behind-remote")
 		remoteURL := "file://" + remoteDir
 
@@ -705,53 +722,84 @@ func TestEmbeddedInit(t *testing.T) {
 		}
 		_ = cleanupSQL()
 
-		cloneDir := t.TempDir()
-		initGitRepoAt(t, cloneDir)
-		cmd := exec.Command(bd, "init", "--quiet", "--prefix", "bclone", "--remote", remoteURL, "--skip-hooks", "--skip-agents")
-		cmd.Dir = cloneDir
-		cmd.Env = append(bdEnv(cloneDir), schema.AllowRemoteMigrateEnv+"=0")
-		out, err := cmd.CombinedOutput()
-		if err == nil {
-			t.Fatalf("bd init --remote against a behind-schema remote should fail; output:\n%s", out)
-		}
-		for _, want := range []string{
-			"Re-running `bd init` will NOT fix this",
-			schema.AllowRemoteMigrateEnv + "=1",
-			"bd dolt push",
-		} {
-			if !strings.Contains(string(out), want) {
-				t.Fatalf("init output missing %q:\n%s", want, out)
+		t.Run("default_smart_gate_auto_migrates_first_mover", func(t *testing.T) {
+			cloneDir := t.TempDir()
+			initGitRepoAt(t, cloneDir)
+			cmd := exec.Command(bd, "init", "--quiet", "--prefix", "bclone", "--remote", remoteURL, "--skip-hooks", "--skip-agents")
+			cmd.Dir = cloneDir
+			// Exercise the true default: strip any ambient opt-out so
+			// BD_SMART_GATE is genuinely unset.
+			cmd.Env = envWithout(append(bdEnv(cloneDir), schema.AllowRemoteMigrateEnv+"=0"), schema.SmartGateEnv)
+			out, err := cmd.CombinedOutput()
+			if err != nil {
+				t.Fatalf("default smart gate should auto-migrate the safe first-mover during init: %v\n%s", err, out)
 			}
-		}
-
-		// The failed init must leave a finalized workspace (metadata.json,
-		// config.yaml) so the guidance commands can open the cloned database.
-		cloneBeads := filepath.Join(cloneDir, ".beads")
-		for _, f := range []string{"metadata.json", "config.yaml"} {
-			if _, err := os.Stat(filepath.Join(cloneBeads, f)); err != nil {
-				t.Fatalf("failed init should leave %s behind: %v", f, err)
+			if !strings.Contains(string(out), "Smart gate") || !strings.Contains(string(out), "bd dolt push") {
+				t.Fatalf("smart auto-migrate should announce itself and direct a follow-up push:\n%s", out)
 			}
-		}
 
-		// Recovery per the guidance: the designated migrator unlocks,
-		// migrates, and the workspace is usable.
-		cmd = exec.Command(bd, "migrate")
-		cmd.Dir = cloneDir
-		cmd.Env = append(bdEnv(cloneDir), schema.AllowRemoteMigrateEnv+"=1")
-		if migOut, err := cmd.CombinedOutput(); err != nil {
-			t.Fatalf("%s=1 bd migrate failed: %v\n%s", schema.AllowRemoteMigrateEnv, err, migOut)
-		}
+			// The clone is migrated and immediately usable, no unlock needed.
+			cmd = exec.Command(bd, "list")
+			cmd.Dir = cloneDir
+			cmd.Env = bdEnv(cloneDir)
+			listOut, err := cmd.CombinedOutput()
+			if err != nil {
+				t.Fatalf("bd list after smart auto-migrate failed: %v\n%s", err, listOut)
+			}
+			if !strings.Contains(string(listOut), "Behind remote issue") {
+				t.Fatalf("auto-migrated clone missing source issue:\n%s", listOut)
+			}
+		})
 
-		cmd = exec.Command(bd, "list")
-		cmd.Dir = cloneDir
-		cmd.Env = bdEnv(cloneDir)
-		listOut, err := cmd.CombinedOutput()
-		if err != nil {
-			t.Fatalf("bd list after migrate failed: %v\n%s", err, listOut)
-		}
-		if !strings.Contains(string(listOut), "Behind remote issue") {
-			t.Fatalf("migrated clone missing source issue:\n%s", listOut)
-		}
+		t.Run("opt_out_gates_with_guidance", func(t *testing.T) {
+			cloneDir := t.TempDir()
+			initGitRepoAt(t, cloneDir)
+			cmd := exec.Command(bd, "init", "--quiet", "--prefix", "bclone", "--remote", remoteURL, "--skip-hooks", "--skip-agents")
+			cmd.Dir = cloneDir
+			cmd.Env = append(bdEnv(cloneDir), schema.AllowRemoteMigrateEnv+"=0", schema.SmartGateEnv+"=0")
+			out, err := cmd.CombinedOutput()
+			if err == nil {
+				t.Fatalf("bd init --remote against a behind-schema remote should fail; output:\n%s", out)
+			}
+			for _, want := range []string{
+				"Re-running `bd init` will NOT fix this",
+				schema.AllowRemoteMigrateEnv + "=1",
+				"bd dolt push",
+			} {
+				if !strings.Contains(string(out), want) {
+					t.Fatalf("init output missing %q:\n%s", want, out)
+				}
+			}
+
+			// The failed init must leave a finalized workspace (metadata.json,
+			// config.yaml) so the guidance commands can open the cloned database.
+			cloneBeads := filepath.Join(cloneDir, ".beads")
+			for _, f := range []string{"metadata.json", "config.yaml"} {
+				if _, err := os.Stat(filepath.Join(cloneBeads, f)); err != nil {
+					t.Fatalf("failed init should leave %s behind: %v", f, err)
+				}
+			}
+
+			// Recovery per the guidance: the designated migrator unlocks,
+			// migrates, and the workspace is usable.
+			cmd = exec.Command(bd, "migrate")
+			cmd.Dir = cloneDir
+			cmd.Env = append(bdEnv(cloneDir), schema.AllowRemoteMigrateEnv+"=1")
+			if migOut, err := cmd.CombinedOutput(); err != nil {
+				t.Fatalf("%s=1 bd migrate failed: %v\n%s", schema.AllowRemoteMigrateEnv, err, migOut)
+			}
+
+			cmd = exec.Command(bd, "list")
+			cmd.Dir = cloneDir
+			cmd.Env = bdEnv(cloneDir)
+			listOut, err := cmd.CombinedOutput()
+			if err != nil {
+				t.Fatalf("bd list after migrate failed: %v\n%s", err, listOut)
+			}
+			if !strings.Contains(string(listOut), "Behind remote issue") {
+				t.Fatalf("migrated clone missing source issue:\n%s", listOut)
+			}
+		})
 	})
 
 	t.Run("remote_empty_initializes_fresh_and_wires_origin", func(t *testing.T) {

--- a/internal/storage/dolt/remote_migrate_gate_test.go
+++ b/internal/storage/dolt/remote_migrate_gate_test.go
@@ -29,6 +29,8 @@ import (
 func TestDoltNew_RemoteMigrateGate_BlocksReopen(t *testing.T) {
 	skipIfNoDolt(t)
 	t.Setenv(schema.AllowRemoteMigrateEnv, "0")
+	// Blunt-gate coverage: pin the (default-on) smart router off.
+	t.Setenv(schema.SmartGateEnv, "0")
 
 	ctx, cancel := testContext(t)
 	defer cancel()

--- a/internal/storage/embeddeddolt/remote_migrate_gate_test.go
+++ b/internal/storage/embeddeddolt/remote_migrate_gate_test.go
@@ -21,6 +21,8 @@ func TestEmbeddedRemoteMigrateGate_BlocksReopen(t *testing.T) {
 		t.Skip("set BEADS_TEST_EMBEDDED_DOLT=1 to run embedded dolt tests")
 	}
 	t.Setenv(schema.AllowRemoteMigrateEnv, "0")
+	// Blunt-gate coverage: pin the (default-on) smart router off.
+	t.Setenv(schema.SmartGateEnv, "0")
 
 	ctx := t.Context()
 	beadsDir := filepath.Join(t.TempDir(), ".beads")
@@ -71,6 +73,8 @@ func TestEmbeddedOpenReadOnly_SkipsGateAndMigrations(t *testing.T) {
 		t.Skip("set BEADS_TEST_EMBEDDED_DOLT=1 to run embedded dolt tests")
 	}
 	t.Setenv(schema.AllowRemoteMigrateEnv, "0")
+	// Blunt-gate coverage: pin the (default-on) smart router off.
+	t.Setenv(schema.SmartGateEnv, "0")
 
 	ctx := t.Context()
 	beadsDir := filepath.Join(t.TempDir(), ".beads")
@@ -192,6 +196,8 @@ func TestEmbeddedOpenForReadOnlyCommand_LenientGate(t *testing.T) {
 		t.Skip("set BEADS_TEST_EMBEDDED_DOLT=1 to run embedded dolt tests")
 	}
 	t.Setenv(schema.AllowRemoteMigrateEnv, "0")
+	// Blunt-gate coverage: pin the (default-on) smart router off.
+	t.Setenv(schema.SmartGateEnv, "0")
 
 	ctx := t.Context()
 	beadsDir := filepath.Join(t.TempDir(), ".beads")

--- a/internal/storage/schema/remote_migrate_gate.go
+++ b/internal/storage/schema/remote_migrate_gate.go
@@ -315,12 +315,13 @@ func checkRemoteMigrateGate(ctx context.Context, db DBConn, remoteName string, e
 
 	latest := LatestVersion()
 
-	// Smart gate (#4516): opt-in. Once the blunt gate would fire and the
-	// designated-migrator escape hatch is not set, consult the remote's cached
-	// schema state and auto-resolve the one provably-safe case (first-mover
-	// migrate). The undetermined/below-floor verdicts fall through to the blunt
-	// #4515 block below, so disabling smart mode (or an unreadable remote ref)
-	// is always at least as safe as before.
+	// Smart gate (#4516): on by default, BD_SMART_GATE=0 opts out. Once the
+	// blunt gate would fire and the designated-migrator escape hatch is not
+	// set, consult the remote's cached schema state and auto-resolve the one
+	// provably-safe case (first-mover migrate). The undetermined/below-floor
+	// verdicts fall through to the blunt #4515 block below, so opting out of
+	// smart mode (or an unreadable remote ref) is always at least as safe as
+	// before.
 	if SmartGateEnabled() {
 		decision, skew := routeSmartGate(ctx, db, current, remoteName)
 		switch decision {

--- a/internal/storage/schema/remote_migrate_gate_test.go
+++ b/internal/storage/schema/remote_migrate_gate_test.go
@@ -19,6 +19,9 @@ func expectGateCurrentVersion(mock sqlmock.Sqlmock, version int) {
 }
 
 func TestCheckRemoteMigrateGate(t *testing.T) {
+	// These tests cover the blunt #4515 gate; pin the (default-on) smart
+	// router off so no cached-remote reads hit the sqlmock expectations.
+	t.Setenv(SmartGateEnv, "0")
 	latest := LatestVersion()
 
 	// expectFiringGate mocks the probe sequence for a behind, remote-backed
@@ -165,6 +168,8 @@ func TestCheckRemoteMigrateGate(t *testing.T) {
 // table even when a remote is configured, so the gate must fall back to a probe of
 // the persisted CLI remotes before allowing migration (gastownhall/beads#4268).
 func TestCheckRemoteMigrateGateWithRemoteCheck(t *testing.T) {
+	// Blunt-gate coverage; keep the smart router out of the mock expectations.
+	t.Setenv(SmartGateEnv, "0")
 	t.Run("no SQL remote but fallback reports a remote is blocked", func(t *testing.T) {
 		t.Setenv(AllowRemoteMigrateEnv, "0")
 		db, mock, _ := sqlmock.New()

--- a/internal/storage/schema/smart_remote_migrate_gate.go
+++ b/internal/storage/schema/smart_remote_migrate_gate.go
@@ -7,13 +7,19 @@ import (
 	"strconv"
 )
 
-// SmartGateEnv opts a clone into the state-aware ("smart") remote-migrate gate
-// (gastownhall/beads#4516). When unset/false, the gate keeps its blunt #4515
-// behavior: any remote-backed database with pending migrations refuses every
-// write and hands the operator the migrate-or-adopt decision. When set to a
-// boolean true, the gate instead consults the remote's cached schema state and
+// SmartGateEnv controls the state-aware ("smart") remote-migrate gate
+// (gastownhall/beads#4516). The smart gate is ON by default: when the blunt
+// gate would fire, it consults the remote's cached schema state and
 // auto-resolves the one provably-safe case (first-mover migrate), while still
 // stopping — with sharper guidance — on the cases that genuinely need a human.
+// Every fallback path (unreadable remote state, below the convergence floor)
+// degrades to the blunt #4515 block, so the default is never less safe than
+// the blunt gate; it only resolves cases the blunt gate cannot distinguish.
+//
+// Set BD_SMART_GATE=0 (or any boolean false) to opt out and keep the blunt
+// #4515 behavior unconditionally: any remote-backed database with pending
+// migrations refuses every write and hands the operator the
+// migrate-or-adopt decision.
 //
 // It is consulted only once the blunt gate would otherwise fire, so exporting it
 // permanently costs nothing on the common open path.
@@ -42,14 +48,20 @@ const smartGateDefaultRemote = "origin"
 // allowlist so the two cannot drift if a new entry is ever added.
 const LastNonDeterministicMigration = 43
 
-// SmartGateEnabled reports whether the operator opted into the smart gate.
+// SmartGateEnabled reports whether the smart gate is active. It defaults to
+// true; the operator opts out with BD_SMART_GATE=0 (any parseable boolean
+// false). An unparseable value keeps the default rather than silently
+// disabling the gate.
 func SmartGateEnabled() bool {
 	v := os.Getenv(SmartGateEnv)
 	if v == "" {
-		return false
+		return true
 	}
 	on, err := strconv.ParseBool(v)
-	return err == nil && on
+	if err != nil {
+		return true
+	}
+	return on
 }
 
 // smartGateDecision is the routing verdict for a remote-backed database with

--- a/internal/storage/schema/smart_remote_migrate_gate_test.go
+++ b/internal/storage/schema/smart_remote_migrate_gate_test.go
@@ -260,8 +260,8 @@ func TestSmartGateRouting(t *testing.T) {
 		}
 	})
 
-	t.Run("smart disabled: no extra reads, blunt block", func(t *testing.T) {
-		// SmartGateEnv unset.
+	t.Run("smart opted out (BD_SMART_GATE=0): no extra reads, blunt block", func(t *testing.T) {
+		t.Setenv(SmartGateEnv, "0")
 		t.Setenv(AllowRemoteMigrateEnv, "0")
 		db, mock, _ := sqlmock.New()
 		defer db.Close()
@@ -277,11 +277,64 @@ func TestSmartGateRouting(t *testing.T) {
 		}
 		// mock would error if the smart reads had been issued (none expected).
 		if err := mock.ExpectationsWereMet(); err != nil {
-			t.Fatalf("unmet expectations (smart reads must not run when disabled): %v", err)
+			t.Fatalf("unmet expectations (smart reads must not run when opted out): %v", err)
+		}
+	})
+
+	t.Run("default (env unset): smart routing runs and resolves the safe first-mover", func(t *testing.T) {
+		// t.Setenv registers restoration of any inherited value; then clear it
+		// so this subtest sees the true unset default.
+		t.Setenv(SmartGateEnv, "")
+		os.Unsetenv(SmartGateEnv)
+		t.Setenv(AllowRemoteMigrateEnv, "0")
+		db, mock, _ := sqlmock.New()
+		defer db.Close()
+		expectSmartFiringGate(mock, floor)
+		hashes := map[int]string{floor: "aaaa"}
+		expectSmartRemoteRead(mock, hashes, hashes)
+
+		if err := CheckRemoteMigrateGate(context.Background(), db); err != nil {
+			t.Fatalf("smart gate must be on by default and allow the safe first-mover, got %v", err)
+		}
+		if err := mock.ExpectationsWereMet(); err != nil {
+			t.Fatalf("unmet expectations (smart reads must run by default): %v", err)
 		}
 	})
 
 	_ = latest
+}
+
+// TestSmartGateEnabled pins the default-on contract: unset and unparseable
+// values keep the smart gate active; only an explicit boolean false opts out.
+func TestSmartGateEnabled(t *testing.T) {
+	cases := []struct {
+		value string
+		unset bool
+		want  bool
+	}{
+		{unset: true, want: true},
+		{value: "1", want: true},
+		{value: "true", want: true},
+		{value: "0", want: false},
+		{value: "false", want: false},
+		{value: "FALSE", want: false},
+		{value: "banana", want: true}, // unparseable keeps the default, never silently disables
+	}
+	for _, c := range cases {
+		name := c.value
+		if c.unset {
+			name = "(unset)"
+		}
+		t.Run(name, func(t *testing.T) {
+			t.Setenv(SmartGateEnv, c.value)
+			if c.unset {
+				os.Unsetenv(SmartGateEnv)
+			}
+			if got := SmartGateEnabled(); got != c.want {
+				t.Errorf("SmartGateEnabled() with %s = %v, want %v", name, got, c.want)
+			}
+		})
+	}
 }
 
 // TestConvergenceFloorMatchesAllowlist cross-checks LastNonDeterministicMigration

--- a/website/docs/getting-started/upgrading.md
+++ b/website/docs/getting-started/upgrading.md
@@ -135,6 +135,23 @@ This applies to **every** upgrade that crosses a pending migration on a
 remote-backed database — the same procedure whether you are moving to a
 prerelease or to a stable release.
 
+The gate is **state-aware by default**
+([#4516](https://github.com/gastownhall/beads/issues/4516)): before blocking,
+`bd` consults the remote's *cached* schema state and
+
+- **auto-migrates** when the remote is at the same schema version as this
+  clone — no one has migrated yet, so this clone is a safe first-mover
+  (concurrent first-movers converge to identical tables). It reminds you to
+  `bd dolt push` afterwards.
+- **stops and directs you to adopt** (`bd bootstrap`) when the remote has
+  already been migrated by another clone.
+- **stops for a human decision** when this clone and the remote applied
+  different content for the same migration (a genuine fork), or when the
+  remote's schema state cannot be read from the cached ref.
+
+Set `BD_SMART_GATE=0` to opt out and make the gate block unconditionally.
+The recipes below are the explicit path and work the same in either mode.
+
 **Important ordering:** once the new binary is installed, a database with
 pending migrations is gated on **every** open — `bd dolt push` and `bd dolt
 pull` are refused too, not just `bd migrate`. So do all syncing with your


### PR DESCRIPTION
## Why

#4524 shipped the state-aware remote-migrate gate opt-in behind `BD_SMART_GATE`, deliberately leaving default-on as an open question. Two days of real-world use answered it: nothing in the blunt block's message, `--json` output, or docs mentions that the variable exists, so no one discovers it. In practice every clone still hits the always-block wall - today a second clone of a personal database showed the full v49 -> v53 blunt refusal and the operator had to research designated-migrator semantics by hand, even though the smart gate sitting dormant in the same binary would have routed the case correctly.

A safety feature that is provably at-least-as-safe as the behavior it replaces, but that nobody can find, protects no one. This flips the default.

## What

- `SmartGateEnabled()` now returns true when `BD_SMART_GATE` is unset. `BD_SMART_GATE=0` (any parseable boolean false) opts out and restores the unconditional #4515 block. An unparseable value keeps the default rather than silently disabling the gate - a typo must not turn off a safety feature.
- No routing changes. The verdict table from #4524 is untouched, and every fallback path (unreadable cached remote state, below the convergence floor, opted out) still degrades to the blunt block, whose output remains byte-identical to #4515.
- Blunt-gate tests (`schema`, `dolt`, `embeddeddolt`) now pin `BD_SMART_GATE=0` explicitly, since "unset" no longer means "blunt". New tests pin the default-on contract: a `SmartGateEnabled` truth table (unset/1/true/0/false/FALSE/garbage) and a routing test proving an unset env resolves the safe first-mover.
- Docs: the upgrade guide's remote-backed section now describes the default routing and the opt-out; CHANGELOG entry under Unreleased. The existing recipes are kept as the explicit path - they work identically in either mode.

## Safety argument (unchanged from #4524)

The only case that auto-resolves is remote-at-same-version with no content skew at/above the convergence floor: concurrent first-movers re-converge to byte-identical tables via migration 0050, so auto-migrating cannot fork. Remote-ahead still stops with an adopt directive (adoption is destructive, never silent), content skew still stops for a human, and anything unreadable falls back to the blunt block.

## Testing

- `CGO_ENABLED=0 go build -tags gms_pure_go ./...`
- `CGO_ENABLED=0 go test -tags gms_pure_go ./internal/storage/schema/` - all gate tests pass, including the new default-on routing and truth-table tests
- `go test ./internal/storage/schema/` (default CGO test build) - pass
- `go vet` on the three touched storage packages - clean
- Server-mode and embedded real-Dolt gate tests need the CI harness (test Dolt server / cgo); the changes there are test-env pinning only. Full `make test` queued locally.

## Follow-up candidates (out of scope here)

- Surface smart-gate state in the blunt block when it fires as a fallback ("smart gate could not read the remote's cached schema state"), so the remaining blunt cases are self-explaining.
- The non-destructive fast-forward adopt for the remote-ahead case, as noted in #4524's open questions.

Closes #4516.

_claude-fable-5-high on behalf of matt wilkie_

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0167xsjJDukVKE7BE1i4W2wE
