### PR TITLE
test(prime): stop prime tests reading the ambient workspace database

### DIFF
--- a/cmd/bd/prime_test.go
+++ b/cmd/bd/prime_test.go
@@ -4,13 +4,44 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 )
 
+// stubPrimeStoreUnavailable temporarily disconnects prime from any ambient
+// workspace store, so tests assert against prime's own text rather than
+// whatever database (and persistent memories) happens to exist in an ancestor
+// directory of the test process. Without this, a developer or verify runner
+// whose checkout is nested under a real beads workspace gets that workspace's
+// live memory text injected into the output under test — e.g. a memory
+// containing "git pull" fails the stealth-mode rejectText assertions. CI never
+// sees the leak because its checkouts have no ancestor database.
+//
+// Returns a function to restore the original store wiring.
+// Usage:
+//
+//	defer stubPrimeStoreUnavailable()()
+func stubPrimeStoreUnavailable() func() {
+	origStore := store
+	origActive := storeActive
+	origEnsure := ensureStoreActiveForPrime
+	store = nil
+	storeActive = false
+	ensureStoreActiveForPrime = func(context.Context) error {
+		return errors.New("prime store stubbed out in test")
+	}
+	return func() {
+		store = origStore
+		storeActive = origActive
+		ensureStoreActiveForPrime = origEnsure
+	}
+}
+
 func TestOutputContextFunction(t *testing.T) {
+	defer stubPrimeStoreUnavailable()()
 	tests := []struct {
 		name          string
 		mcpMode       bool
@@ -181,6 +212,7 @@ func TestOutputContextFunction(t *testing.T) {
 }
 
 func TestPrimeClaimGuidanceUsesAtomicClaim(t *testing.T) {
+	defer stubPrimeStoreUnavailable()()
 	defer stubIsEphemeralBranch(false)()
 	defer stubPrimeHasGitRemote(true)()
 
@@ -199,6 +231,7 @@ func TestPrimeClaimGuidanceUsesAtomicClaim(t *testing.T) {
 }
 
 func TestPrimeStartsWithTruncationDirective(t *testing.T) {
+	defer stubPrimeStoreUnavailable()()
 	defer stubIsEphemeralBranch(false)()
 	defer stubPrimeHasGitRemote(true)()
 
@@ -214,6 +247,7 @@ func TestPrimeStartsWithTruncationDirective(t *testing.T) {
 }
 
 func TestPrimeMemoriesOnlyNoMemories(t *testing.T) {
+	defer stubPrimeStoreUnavailable()()
 	var buf bytes.Buffer
 	if err := outputPrimeContextWithOptions(&buf, false, false, true); err != nil {
 		t.Fatalf("outputPrimeContextWithOptions failed: %v", err)
@@ -266,6 +300,7 @@ func TestPrimeStoreTimeoutNonPositiveUsesDefault(t *testing.T) {
 }
 
 func TestPrimeContextUsesWorkspaceLanguage(t *testing.T) {
+	defer stubPrimeStoreUnavailable()()
 	defer stubIsEphemeralBranch(false)()
 	defer stubPrimeHasGitRemote(true)()
 
@@ -424,6 +459,7 @@ func TestOutputHookJSON_EmptyContent(t *testing.T) {
 // any hook-free integrations). It would be a regression if the JSON envelope
 // leaked into the default path.
 func TestPrime_RawMarkdown_NotJSON_WithoutFlag(t *testing.T) {
+	defer stubPrimeStoreUnavailable()()
 	defer stubIsEphemeralBranch(false)()
 	defer stubPrimeHasGitRemote(true)()
 


### PR DESCRIPTION
## Why

`TestOutputContextFunction` and five sibling prime tests call `outputPrimeContext` without stubbing the package-global `store`. `formatMemoriesForPrime` then lazily opens whatever beads database an ancestor-directory walk finds from the test process working directory, and the *content of that developer's live workspace* - persistent memories - gets injected into the output under test.

The failure mode is nasty because it's data-dependent: today a local `make test` run failed the stealth and local-only subtests with `Unexpected text found: git pull`, purely because one persistent memory in the enclosing workspace happened to mention `git pull --rebase` in its body. Three unrelated verification runs failed on it back to back before the cause was isolated.

It only reproduces with `CGO_ENABLED=1` (the embedded Dolt store must be openable) in a checkout nested under a real beads workspace. CI checkouts have no ancestor database, which is why CI has never seen it - but any contributor who keeps their beads clone inside a bd-tracked workspace, or runs a verification harness from one, hits it as soon as their memories contain an unlucky phrase.

## What

- Add `stubPrimeStoreUnavailable()`, following the file's existing `stubPrimeHasGitRemote` restore-func idiom. `ensureStoreActiveForPrime` is already a stubbable package var (the store-timeout test uses it), so no production code changes at all - the helper just parks `store`/`storeActive`/`ensureStoreActiveForPrime` and restores them.
- Apply it in the six tests that render prime output: `TestOutputContextFunction`, `TestPrimeClaimGuidanceUsesAtomicClaim`, `TestPrimeStartsWithTruncationDirective`, `TestPrimeMemoriesOnlyNoMemories`, `TestPrimeContextUsesWorkspaceLanguage`, `TestPrime_RawMarkdown_NotJSON_WithoutFlag`.

Memory *formatting* behavior keeps its dedicated coverage via the existing store-stubbing tests (`TestFormatMemoriesForPrimeTimesOutOpeningStore` etc.); these six tests assert prime's own text and should not be at the mercy of ambient data.

## Testing

- `CGO_ENABLED=1 go test -tags gms_pure_go -run "TestOutputContextFunction|TestPrime" ./cmd/bd` - previously failed in a nested checkout with live memories, now passes
- `CGO_ENABLED=0 go test -tags gms_pure_go ./cmd/bd` prime tests - pass
- `go vet` - clean

_claude-fable-5-high on behalf of matt wilkie_

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0167xsjJDukVKE7BE1i4W2wE
