### PR TITLE
fix(export): auto-export JSONL in SQL-server mode via working-set state hash

### DIFF
--- a/cmd/bd/export_auto.go
+++ b/cmd/bd/export_auto.go
@@ -34,12 +34,12 @@ const gitAddTimeout = 5 * time.Second
 
 // maybeAutoExport writes a git-tracked JSONL file if enabled and due.
 // Called from PersistentPostRun after auto-backup.
-func maybeAutoExport(ctx context.Context, serverMode, allowEmptyOverwrite bool) error {
-	if serverMode {
-		debug.Logf("auto-export: skipping — server mode\n")
-		return nil
-	}
-
+//
+// This runs in server mode too: clients of a shared dolt sql-server rely on
+// the JSONL export for git-durable state exactly like embedded users do — in
+// topologies without a Dolt remote it is the only durability. Skipping here
+// made `git push` silently publish stale issue state (wy-4ope).
+func maybeAutoExport(ctx context.Context, allowEmptyOverwrite bool) error {
 	// Skip when running as a git hook to avoid re-export during pre-commit.
 	if os.Getenv("BD_GIT_HOOK") == "1" {
 		debug.Logf("auto-export: skipping — running as git hook\n")
@@ -80,9 +80,9 @@ func maybeAutoExport(ctx context.Context, serverMode, allowEmptyOverwrite bool) 
 		interval = 60 * time.Second
 	}
 
-	// Change detection via Dolt commit hash. This is cheap, so do it before
+	// Change detection via Dolt state hash. This is cheap, so do it before
 	// throttle: when there are no changes, there is nothing to throttle.
-	currentCommit, err := store.GetCurrentCommit(ctx)
+	currentCommit, err := storeStateHash(ctx)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Warning: auto-export skipped: failed to get current commit: %v\n", err)
 		return nil
@@ -162,6 +162,18 @@ func maybeAutoExport(ctx context.Context, serverMode, allowEmptyOverwrite bool) 
 	}
 	saveExportAutoState(beadsDir, &newState)
 	return nil
+}
+
+// storeStateHash returns the hash used for auto-export change detection.
+// It prefers a working-set-aware hash (storage.StateHasher) over the HEAD
+// commit: in server mode dolt auto-commit is off, so writes stay in the
+// working set and HEAD does not advance — HEAD-based detection would go
+// permanently quiet after the first export.
+func storeStateHash(ctx context.Context) (string, error) {
+	if sh, ok := storage.UnwrapStore(store).(storage.StateHasher); ok {
+		return sh.GetStateHash(ctx)
+	}
+	return store.GetCurrentCommit(ctx)
 }
 
 // shouldExport reports whether the throttle window has elapsed, or whether

--- a/cmd/bd/export_auto_test.go
+++ b/cmd/bd/export_auto_test.go
@@ -12,6 +12,8 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/steveyegge/beads/internal/config"
+	"github.com/steveyegge/beads/internal/storage"
+	"github.com/steveyegge/beads/internal/types"
 )
 
 // TestGitAddFile_InWorktreeHook_StagesCorrectPath is a regression test for
@@ -191,25 +193,139 @@ func TestShouldRunPostCommandAutoExportSkipsReadOnlyCommands(t *testing.T) {
 	}
 }
 
-func TestMaybeAutoExportSkipsServerModeBeforeStoreAccess(t *testing.T) {
+// fakeStateHashStore implements the storage.StateHasher optional interface
+// plus the minimal DoltStorage surface maybeAutoExport touches. Any
+// non-overridden method panics via the embedded nil interface.
+type fakeStateHashStore struct {
+	storage.DoltStorage
+	stateHash          string
+	stateHashCalls     int
+	currentCommitCalls int
+	issues             []*types.Issue
+}
+
+func (f *fakeStateHashStore) GetStateHash(_ context.Context) (string, error) {
+	f.stateHashCalls++
+	return f.stateHash, nil
+}
+
+func (f *fakeStateHashStore) GetCurrentCommit(_ context.Context) (string, error) {
+	f.currentCommitCalls++
+	return "head-commit-hash", nil
+}
+
+func (f *fakeStateHashStore) GetInfraTypes(_ context.Context) map[string]bool { return nil }
+
+func (f *fakeStateHashStore) SearchIssues(_ context.Context, _ string, _ types.IssueFilter) ([]*types.Issue, error) {
+	return f.issues, nil
+}
+
+// fakeHeadOnlyStore does NOT implement storage.StateHasher, forcing the
+// GetCurrentCommit fallback.
+type fakeHeadOnlyStore struct {
+	storage.DoltStorage
+	currentCommitCalls int
+}
+
+func (f *fakeHeadOnlyStore) GetCurrentCommit(_ context.Context) (string, error) {
+	f.currentCommitCalls++
+	return "head-commit-hash", nil
+}
+
+func autoExportTestDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	beadsDir := filepath.Join(dir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(beadsDir, "metadata.json"), []byte(`{"database":"beads","backend":"dolt"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(dir)
+	t.Setenv("BEADS_DIR", beadsDir)
+	return dir
+}
+
+// Regression test for wy-4ope: server-mode clients used to skip auto-export
+// entirely, so `git push` published stale JSONL. maybeAutoExport must reach
+// change detection and consult the working-set-aware state hash, not HEAD —
+// server mode runs with dolt auto-commit off, so HEAD does not advance on
+// writes.
+func TestMaybeAutoExportUsesStateHashForChangeDetection(t *testing.T) {
 	initConfigForTest(t)
 	config.Set("export.auto", true)
 
 	saveAndRestoreGlobals(t)
-	store = &fakeFallbackStore{}
+	fake := &fakeStateHashStore{stateHash: "working-set-hash"}
+	store = fake
 
-	dir := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(dir, ".beads"), 0o755); err != nil {
-		t.Fatal(err)
+	dir := autoExportTestDir(t)
+	saveExportAutoState(filepath.Join(dir, ".beads"), &exportAutoState{
+		LastDoltCommit: "working-set-hash",
+		Timestamp:      time.Now(),
+	})
+
+	if err := maybeAutoExport(context.Background(), false); err != nil {
+		t.Fatalf("maybeAutoExport: %v", err)
 	}
-	t.Chdir(dir)
 
-	if err := maybeAutoExport(context.Background(), true, false); err != nil {
-		t.Fatalf("maybeAutoExport(serverMode=true): %v", err)
+	if fake.stateHashCalls != 1 {
+		t.Fatalf("GetStateHash calls = %d, want 1", fake.stateHashCalls)
+	}
+	if fake.currentCommitCalls != 0 {
+		t.Fatalf("GetCurrentCommit calls = %d, want 0 (StateHasher must take precedence)", fake.currentCommitCalls)
+	}
+	if _, err := os.Stat(filepath.Join(dir, ".beads", "issues.jsonl")); !os.IsNotExist(err) {
+		t.Fatalf("unchanged state hash must not export, stat err=%v", err)
+	}
+}
+
+func TestMaybeAutoExportExportsOnStateHashChange(t *testing.T) {
+	initConfigForTest(t)
+	config.Set("export.auto", true)
+
+	saveAndRestoreGlobals(t)
+	fake := &fakeStateHashStore{stateHash: "hash-after-write"}
+	store = fake
+
+	dir := autoExportTestDir(t)
+	saveExportAutoState(filepath.Join(dir, ".beads"), &exportAutoState{
+		LastDoltCommit: "hash-before-write",
+		Timestamp:      time.Time{}, // zero: throttle window open
+	})
+
+	if err := maybeAutoExport(context.Background(), false); err != nil {
+		t.Fatalf("maybeAutoExport: %v", err)
 	}
 
-	if _, err := os.Stat(filepath.Join(dir, ".beads", exportAutoStateFile)); !os.IsNotExist(err) {
-		t.Fatalf("server-mode auto-export wrote state file, stat err=%v", err)
+	state := loadExportAutoState(filepath.Join(dir, ".beads"))
+	if state.LastDoltCommit != "hash-after-write" {
+		t.Fatalf("state LastDoltCommit = %q, want %q (export must run when the state hash moves)",
+			state.LastDoltCommit, "hash-after-write")
+	}
+}
+
+func TestMaybeAutoExportFallsBackToHeadCommit(t *testing.T) {
+	initConfigForTest(t)
+	config.Set("export.auto", true)
+
+	saveAndRestoreGlobals(t)
+	fake := &fakeHeadOnlyStore{}
+	store = fake
+
+	dir := autoExportTestDir(t)
+	saveExportAutoState(filepath.Join(dir, ".beads"), &exportAutoState{
+		LastDoltCommit: "head-commit-hash",
+		Timestamp:      time.Now(),
+	})
+
+	if err := maybeAutoExport(context.Background(), false); err != nil {
+		t.Fatalf("maybeAutoExport: %v", err)
+	}
+
+	if fake.currentCommitCalls != 1 {
+		t.Fatalf("GetCurrentCommit calls = %d, want 1 (fallback when StateHasher is absent)", fake.currentCommitCalls)
 	}
 }
 

--- a/cmd/bd/main.go
+++ b/cmd/bd/main.go
@@ -1262,7 +1262,7 @@ var rootCmd = &cobra.Command{
 			// Read-only commands must not perform post-run maintenance writes or emit
 			// sync guidance after machine-readable output.
 			if shouldRunPostCommandAutoExport(cmd) {
-				if err := maybeAutoExport(rootCtx, serverMode, commandAllowsEmptyAutoExport(cmd)); err != nil {
+				if err := maybeAutoExport(rootCtx, commandAllowsEmptyAutoExport(cmd)); err != nil {
 					return HandleError("%v", err)
 				}
 			}

--- a/internal/storage/dolt/versioned.go
+++ b/internal/storage/dolt/versioned.go
@@ -60,6 +60,20 @@ func (s *DoltStore) GetCurrentCommit(ctx context.Context) (string, error) {
 	return hash, nil
 }
 
+// GetStateHash returns a hash of the entire database including the working
+// set. Unlike GetCurrentCommit it moves on uncommitted writes, so callers can
+// detect changes even when dolt auto-commit is off (SQL-server mode, where
+// writes land in the working set and HEAD does not advance).
+// Implements storage.StateHasher.
+func (s *DoltStore) GetStateHash(ctx context.Context) (string, error) {
+	var hash string
+	if err := s.db.QueryRowContext(ctx, "SELECT DOLT_HASHOF_DB()").Scan(&hash); err == nil {
+		return hash, nil
+	}
+	// Older servers predate DOLT_HASHOF_DB; degrade to HEAD-based detection.
+	return s.GetCurrentCommit(ctx)
+}
+
 // GetConflicts returns any merge conflicts in the current state.
 // Implements storage.VersionedStorage.
 func (s *DoltStore) GetConflicts(ctx context.Context) ([]storage.Conflict, error) {

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -260,6 +260,17 @@ type BlockedRecomputer interface {
 	RecomputeAllBlocked(ctx context.Context) (int, error)
 }
 
+// StateHasher returns a hash covering committed history plus the working set.
+// Unlike GetCurrentCommit (HEAD only), the hash moves on uncommitted writes.
+// Change detection against a SQL server must use this when available: server
+// mode runs with dolt auto-commit off, so writes sit in the working set and
+// HEAD does not advance.
+// Callers should type-assert to this interface and fall back to
+// GetCurrentCommit when the store does not implement it.
+type StateHasher interface {
+	GetStateHash(ctx context.Context) (string, error)
+}
+
 // LifecycleManager provides lifecycle inspection beyond Close().
 type LifecycleManager interface {
 	IsClosed() bool


### PR DESCRIPTION
## Problem

Auto-export is skipped entirely when bd runs as a client of a dolt sql-server (`dolt_mode: server` / shared-server), despite `export.auto: true`. In topologies without a Dolt remote, `.beads/issues.jsonl` is the only git-durable state, so a `git push` without a manual `bd export` silently publishes stale issue state.

## Fix

Two changes, because removing the skip alone is not enough:

1. **Remove the server-mode skip in `maybeAutoExport`** (added in c0bdf4972). Server-mode clients rely on the JSONL export exactly like embedded users do.
2. **Add `storage.StateHasher` (`DOLT_HASHOF_DB()`) and prefer it over `GetCurrentCommit` for change detection.** Server mode runs with dolt auto-commit off, so writes stay in the working set and HEAD does not advance — HEAD-based detection would export once and then go permanently quiet. `DOLT_HASHOF_DB()` covers the working set (verified on dolt 2.1.6); stores without it fall back to HEAD-based detection.

## Testing

- Three new unit tests: StateHasher preference (unchanged hash → no export, `GetCurrentCommit` untouched), export fires on state-hash change, HEAD fallback when StateHasher is absent.
- Verified end-to-end against a scratch `dolt sql-server`: `bd create` and `bd close` both refresh `issues.jsonl` immediately, with the state hash advancing while HEAD stays fixed.
- `./scripts/test.sh ./cmd/bd/ ./internal/storage/ ./internal/storage/dolt/` green except two pre-existing failures reproducible on clean main (`TestInitFromJSONLRefusesWhenRemoteHasDoltData`, `TestInitFromJSONLExplicitRemoteRefusesWhenRemoteHasDoltData`).

## Follow-up (not in this PR)

Proxied-server mode (UOW provider, no global store) still skips all post-run maintenance in `PersistentPostRun` and needs a UOW-based export.

🤖 Generated with [Claude Code](https://claude.com/claude-code)