### PR TITLE
fix(embedded): let working-set reconcile commands open past dirty-table migration guard (#4566)

### DIFF
--- a/cmd/bd/main.go
+++ b/cmd/bd/main.go
@@ -143,6 +143,25 @@ func isReadOnlyCommand(cmdName string) bool {
 	return readOnlyCommands[cmdName]
 }
 
+// isWorkingSetReconcileCommand reports whether cmd's whole purpose is to
+// reconcile the Dolt working set: "bd dolt commit" or "bd vc commit". These
+// commands are the documented recovery from a pending-migration dirty-table
+// refusal, but they also open the store, and an open runs the migration -
+// hitting that same refusal before the commit that would clear the dirty
+// state ever runs. Opening leniently (embeddeddolt.OpenForWorkingSetReconcile)
+// breaks that deadlock by skipping the migration instead of failing the open
+// (gastownhall/beads#4566).
+func isWorkingSetReconcileCommand(cmd *cobra.Command) bool {
+	if cmd.Name() != "commit" {
+		return false
+	}
+	parent := cmd.Parent()
+	if parent == nil {
+		return false
+	}
+	return parent.Name() == "dolt" || parent.Name() == "vc"
+}
+
 // loadBeadsEnvFile loads .beads/.env into process environment for per-project
 // Dolt credentials (GH#2520). Uses gotenv.Load which is non-overriding —
 // existing shell env vars always take precedence.
@@ -985,8 +1004,9 @@ var rootCmd = &cobra.Command{
 		// on a different filesystem (e.g., ext4 for performance on WSL).
 		doltPath := doltserver.ResolveDoltDir(beadsDir)
 		doltCfg := &dolt.Config{
-			ReadOnly: useReadOnly,
-			BeadsDir: beadsDir,
+			ReadOnly:    useReadOnly,
+			BeadsDir:    beadsDir,
+			LenientOpen: isWorkingSetReconcileCommand(cmd),
 		}
 
 		// Load config to get database name and server connection settings

--- a/cmd/bd/store_factory.go
+++ b/cmd/bd/store_factory.go
@@ -60,6 +60,13 @@ func newDoltStore(ctx context.Context, cfg *dolt.Config) (storage.DoltStorage, e
 		// already skip migration entirely.
 		return embeddeddolt.OpenForReadOnlyCommand(ctx, cfg.BeadsDir, cfg.Database, "main")
 	}
+	if cfg.LenientOpen {
+		// Working-set-reconcile commands (bd dolt commit, bd vc commit) must
+		// not be bricked by a pending-migration dirty-table refusal: that
+		// refusal's documented recovery is exactly the commit these commands
+		// run, so failing the open here would deadlock (#4566).
+		return embeddeddolt.OpenForWorkingSetReconcile(ctx, cfg.BeadsDir, cfg.Database, "main")
+	}
 	return embeddeddolt.Open(ctx, cfg.BeadsDir, cfg.Database, "main")
 }
 

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -207,6 +207,14 @@ type Config struct {
 	Database       string // Database name within Dolt (default: "beads")
 	ReadOnly       bool   // Open in read-only mode (skip schema init)
 
+	// LenientOpen opens the store leniently: embedded mode only. A migration
+	// gate refusal (#4259) or a dirty-working-set refusal (#4566) skips the
+	// migration instead of failing the open. Set for working-set-reconcile
+	// commands (bd dolt commit, bd vc commit; #4566), whose entire purpose is
+	// to clear the working set that the migration would otherwise refuse to
+	// touch. Ignored in server mode.
+	LenientOpen bool
+
 	// Server connection options
 	ServerSocket   string // Unix domain socket path (overrides Host/Port when set)
 	ServerHost     string // Server host (default: 127.0.0.1)

--- a/internal/storage/embeddeddolt/cache.go
+++ b/internal/storage/embeddeddolt/cache.go
@@ -29,7 +29,7 @@ type cacheEntry struct {
 // This prevents redundant engine initializations when multiple code paths open
 // connectors against the same data directory in the same process.
 func Open(ctx context.Context, beadsDir, database, branch string) (*EmbeddedDoltStore, error) {
-	return openCached(ctx, beadsDir, database, branch, false)
+	return openCached(ctx, beadsDir, database, branch, openStrict)
 }
 
 // OpenForReadOnlyCommand opens like Open, except that a #4259 remote-migrate
@@ -39,10 +39,22 @@ func Open(ctx context.Context, beadsDir, database, branch string) (*EmbeddedDolt
 // returned store is otherwise a normal writable store (read-only commands
 // can still write incidentally, e.g. the post-command autocommit net).
 func OpenForReadOnlyCommand(ctx context.Context, beadsDir, database, branch string) (*EmbeddedDoltStore, error) {
-	return openCached(ctx, beadsDir, database, branch, true)
+	return openCached(ctx, beadsDir, database, branch, openReadOnlyCommand)
 }
 
-func openCached(ctx context.Context, beadsDir, database, branch string, lenientGate bool) (*EmbeddedDoltStore, error) {
+// OpenForWorkingSetReconcile opens like Open, except that a schema.
+// DirtyTablesError refusal skips the pending migrations with a stderr
+// warning instead of failing the open (#4566): commands whose entire purpose
+// is to reconcile the Dolt working set (bd dolt commit, bd vc commit) must be
+// able to open the store even when pending migrations touch dirty tables -
+// otherwise the commit that would clear the dirty state and unblock the
+// migration can never run. The returned store is otherwise a normal writable
+// store.
+func OpenForWorkingSetReconcile(ctx context.Context, beadsDir, database, branch string) (*EmbeddedDoltStore, error) {
+	return openCached(ctx, beadsDir, database, branch, openWorkingSetReconcile)
+}
+
+func openCached(ctx context.Context, beadsDir, database, branch string, intent openIntent) (*EmbeddedDoltStore, error) {
 	key, err := cacheKey(beadsDir)
 	if err != nil {
 		return nil, err
@@ -50,6 +62,18 @@ func openCached(ctx context.Context, beadsDir, database, branch string, lenientG
 
 	cacheMu.Lock()
 	if entry, ok := cache[key]; ok {
+		// Cache hit: the requested intent is ignored - the store keeps
+		// whatever intent it was opened with on the slow path below. This is
+		// safe today because intent is derived once per process from the
+		// command classification (isReadOnlyCommand / isWorkingSetReconcileCommand
+		// in cmd/bd/main.go), so a single process never opens the same data
+		// directory under two different intents, and autoMigrateOnVersionBump
+		// (cmd/bd/version_tracking.go) always opens its own openStrict store
+		// and closes it before the main command's open runs, so it never
+		// races a cache hit either. A future caller needing a genuinely
+		// different intent on a cache hit would have to plumb intent through
+		// here instead of silently reusing the first store's; it is load-
+		// bearing that no current caller does.
 		entry.refCount++
 		cacheMu.Unlock()
 		return entry.store, nil
@@ -57,7 +81,7 @@ func openCached(ctx context.Context, beadsDir, database, branch string, lenientG
 	cacheMu.Unlock()
 
 	// Slow path: create a new store outside the lock.
-	s, err := newStore(ctx, beadsDir, database, branch, lenientGate)
+	s, err := newStore(ctx, beadsDir, database, branch, intent)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/storage/embeddeddolt/dirty_tables_gate_test.go
+++ b/internal/storage/embeddeddolt/dirty_tables_gate_test.go
@@ -1,0 +1,155 @@
+//go:build cgo
+
+package embeddeddolt_test
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/storage/embeddeddolt"
+	"github.com/steveyegge/beads/internal/storage/schema"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// TestEmbeddedDirtyTablesGate_BlocksReopenThenWorkingSetReconcileRecovers
+// covers gastownhall/beads#4566: a pending schema migration that alters a
+// table with pre-existing dirty (uncommitted) content must refuse a plain
+// open, but a working-set-reconcile open (used by "bd dolt commit" / "bd vc
+// commit") must still be able to open the store, so the commit that clears
+// the dirty state can actually run. Without this, the documented recovery
+// deadlocks against the very guard it is meant to clear.
+func TestEmbeddedDirtyTablesGate_BlocksReopenThenWorkingSetReconcileRecovers(t *testing.T) {
+	if os.Getenv("BEADS_TEST_EMBEDDED_DOLT") != "1" {
+		t.Skip("set BEADS_TEST_EMBEDDED_DOLT=1 to run embedded dolt tests")
+	}
+
+	ctx := t.Context()
+	beadsDir := filepath.Join(t.TempDir(), ".beads")
+	dataDir := filepath.Join(beadsDir, "embeddeddolt")
+
+	// Create and fully migrate the embedded database.
+	store, err := embeddeddolt.Open(ctx, beadsDir, "testdb", "main")
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	if err := store.SetConfig(ctx, "issue_prefix", "testdb"); err != nil {
+		store.Close()
+		t.Fatalf("SetConfig(issue_prefix): %v", err)
+	}
+	if err := store.Commit(ctx, "bd init"); err != nil {
+		store.Close()
+		t.Fatalf("Commit (init): %v", err)
+	}
+
+	// Leave `issues` dirty in the working set: CreateIssue writes through a
+	// SQL transaction but does not run a Dolt commit, so the new row stays
+	// uncommitted.
+	issue := &types.Issue{
+		ID:        "testdb-1",
+		Title:     "dirty working set issue",
+		Status:    types.StatusOpen,
+		Priority:  1,
+		IssueType: types.TypeTask,
+	}
+	if err := store.CreateIssue(ctx, issue, "tester"); err != nil {
+		store.Close()
+		t.Fatalf("CreateIssue: %v", err)
+	}
+
+	// Regress to schema v51, pinned as an absolute version rather than
+	// relative to schema.LatestVersion():
+	//   - not 52: mainSource.currentVersion()==52 routes into the
+	//     failed-v53-migration recovery path (failed0053DirtyTablesAreRecoverable,
+	//     internal/storage/schema/schema.go), which treats a dirty `issues`
+	//     table as expected fallout of a crashed 0053 pass and would swallow
+	//     the guard this test asserts on.
+	//   - absolute (51), not schema.LatestVersion()-2: that expression only
+	//     equals 51 by coincidence of the migration count today. A future
+	//     migration landing would shift it to 52, silently routing this test
+	//     into the recovery path above instead of the guard it means to
+	//     exercise. 51 also still leaves migration 0053 (which alters
+	//     `issues` via a rig-wisp repair INSERT/UPDATE) pending, so the dirty
+	//     `issues` table is still touched by a pending migration.
+	db, cleanup, err := embeddeddolt.OpenSQL(ctx, dataDir, "testdb", "main")
+	if err != nil {
+		store.Close()
+		t.Fatalf("OpenSQL: %v", err)
+	}
+	const regressedVersion = 51
+	if _, err := db.ExecContext(ctx,
+		"DELETE FROM schema_migrations WHERE version > ?", regressedVersion); err != nil {
+		t.Fatalf("regress schema_migrations: %v", err)
+	}
+	_ = cleanup()
+	store.Close()
+
+	// Plain Open must hit the dirty-table guard.
+	gated, gateErr := embeddeddolt.Open(ctx, beadsDir, "testdb", "main")
+	if gateErr == nil {
+		gated.Close()
+		t.Fatal("Open (reopen) = nil, want *schema.DirtyTablesError for a dirty table touched by a pending migration")
+	}
+	var dirtyErr *schema.DirtyTablesError
+	if !errors.As(gateErr, &dirtyErr) {
+		t.Fatalf("Open error = %T (%v), want error wrapping *schema.DirtyTablesError", gateErr, gateErr)
+	}
+	found := false
+	for _, table := range dirtyErr.Tables {
+		if table == "issues" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("DirtyTablesError.Tables = %v, want to include %q", dirtyErr.Tables, "issues")
+	}
+
+	// The working-set-reconcile open must succeed WITHOUT migrating: the
+	// schema stays behind, and the store is otherwise usable.
+	reconcileStore, err := embeddeddolt.OpenForWorkingSetReconcile(ctx, beadsDir, "testdb", "main")
+	if err != nil {
+		t.Fatalf("OpenForWorkingSetReconcile: %v", err)
+	}
+	if current, err := schemaVersion(ctx, dataDir, "testdb"); err != nil {
+		reconcileStore.Close()
+		t.Fatalf("read schema version: %v", err)
+	} else if current != regressedVersion {
+		reconcileStore.Close()
+		t.Fatalf("schema version = %d, want %d (migration must stay skipped)", current, regressedVersion)
+	}
+
+	// Committing the working set (the documented #4566 recovery) must
+	// succeed and clear the dirty `issues` table.
+	if err := reconcileStore.Commit(ctx, "checkpoint"); err != nil {
+		reconcileStore.Close()
+		t.Fatalf("Commit: %v", err)
+	}
+	reconcileStore.Close()
+
+	// A plain reopen now migrates cleanly up to the latest schema.
+	migrated, err := embeddeddolt.Open(ctx, beadsDir, "testdb", "main")
+	if err != nil {
+		t.Fatalf("Open (post-commit reopen): %v", err)
+	}
+	defer migrated.Close()
+	if current, err := schemaVersion(ctx, dataDir, "testdb"); err != nil {
+		t.Fatalf("read schema version: %v", err)
+	} else if current != schema.LatestVersion() {
+		t.Fatalf("schema version after reopen = %d, want latest %d", current, schema.LatestVersion())
+	}
+}
+
+// schemaVersion reads the current main-source schema cursor via a short-lived
+// raw SQL connection.
+func schemaVersion(ctx context.Context, dataDir, database string) (int, error) {
+	db, cleanup, err := embeddeddolt.OpenSQL(ctx, dataDir, database, "main")
+	if err != nil {
+		return 0, err
+	}
+	defer func() { _ = cleanup() }()
+	var version int
+	err = db.QueryRowContext(ctx, "SELECT COALESCE(MAX(version), 0) FROM schema_migrations").Scan(&version)
+	return version, err
+}

--- a/internal/storage/embeddeddolt/store.go
+++ b/internal/storage/embeddeddolt/store.go
@@ -49,14 +49,36 @@ type EmbeddedDoltStore struct {
 	// (CREATE DATABASE, schema migrations) were skipped and write
 	// transactions are refused (bd-6dnrw.32).
 	readOnly bool
-	// lenientGate marks a store opened for a read-only command
-	// (OpenForReadOnlyCommand): a #4259 remote-migrate gate refusal skips
-	// the migration with a warning instead of failing the open, so read
-	// commands keep working on the current schema until the operator makes
-	// the migrate-or-adopt decision (bd-578h9.5). Unlike readOnly, writes
-	// stay allowed (e.g. the post-command autocommit net).
-	lenientGate bool
+	// intent records why this store was opened, controlling how lenient
+	// initSchema is about pending-migration refusals it would otherwise treat
+	// as fatal. Unlike readOnly, a non-strict intent still allows writes
+	// (e.g. the post-command autocommit net, or the commit itself) - only the
+	// migration step is skipped.
+	intent openIntent
 }
+
+// openIntent classifies why a store is being opened. openStrict fails the
+// open on any pending-migration refusal; the other two intents relax both
+// the #4259 remote-migrate gate refusal and the #4566 dirty-table refusal,
+// each with its own warning text (see initSchema).
+type openIntent int
+
+const (
+	// openStrict is the default: any pending-migration refusal fails the
+	// open. Used by Open.
+	openStrict openIntent = iota
+	// openReadOnlyCommand relaxes both refusals for read-only commands: they
+	// must keep working on the current schema until the operator makes the
+	// migrate-or-adopt decision (bd-578h9.5), and must not be bricked by
+	// dirty tables either. Used by OpenForReadOnlyCommand.
+	openReadOnlyCommand
+	// openWorkingSetReconcile relaxes both refusals for working-set-reconcile
+	// commands (bd dolt commit, bd vc commit): their entire purpose is to
+	// clear the dirty working set that a migration would otherwise refuse to
+	// touch, so failing the open here would deadlock the documented recovery
+	// (#4566). Used by OpenForWorkingSetReconcile.
+	openWorkingSetReconcile
+)
 
 // errClosed is returned when a method is called after Close.
 var errClosed = errors.New("embeddeddolt: store is closed")
@@ -78,7 +100,7 @@ func (s *EmbeddedDoltStore) IsClosed() bool {
 // The dolthub/driver/v2 handles its own concurrency internally. File-level locking
 // is only used during bd init (via util.TryLock in the init command) to protect
 // one-time initialization steps — the store itself does not hold any lock.
-func newStore(ctx context.Context, beadsDir, database, branch string, lenientGate bool) (*EmbeddedDoltStore, error) {
+func newStore(ctx context.Context, beadsDir, database, branch string, intent openIntent) (*EmbeddedDoltStore, error) {
 	if database == "" {
 		return nil, fmt.Errorf("embeddeddolt: database name must not be empty (caller should default to %q)", "beads")
 	}
@@ -96,11 +118,11 @@ func newStore(ctx context.Context, beadsDir, database, branch string, lenientGat
 	}
 
 	s := &EmbeddedDoltStore{
-		dataDir:     dataDir,
-		beadsDir:    absBeadsDir,
-		database:    database,
-		branch:      branch,
-		lenientGate: lenientGate,
+		dataDir:  dataDir,
+		beadsDir: absBeadsDir,
+		database: database,
+		branch:   branch,
+		intent:   intent,
 	}
 
 	if err := s.initSchema(ctx); err != nil {
@@ -290,21 +312,33 @@ func (s *EmbeddedDoltStore) initSchema(ctx context.Context) error {
 	// via Dolt remotes too, so it needs the same gate as server mode.
 	if err := schema.CheckRemoteMigrateGate(ctx, conn); err != nil {
 		var gateErr *schema.RemoteMigrateGateError
-		if s.lenientGate && errors.As(err, &gateErr) {
-			// Read-only command: the gate exists to stop in-place
-			// migration, not reads (bd-578h9.5). Warn and continue on
-			// the current schema; write commands still fail the open
-			// with the full migrate-or-adopt guidance.
-			fmt.Fprintf(os.Stderr,
-				"Warning: %v\n"+
-					"  Read-only command: continuing on schema v%d without migrating.\n"+
-					"  Writes are blocked until the schema is reconciled. This is a\n"+
-					"  coordination decision, not an auto-fix — do NOT run a migration unless\n"+
-					"  you are the single designated migrator (only ONE clone may migrate a\n"+
-					"  shared remote, else the schema forks; #4259):\n"+
-					"    • designated migrator (only ONE machine): %s=1 bd migrate && bd dolt push\n"+
-					"    • every other clone (another already migrated): bd bootstrap\n",
-				gateErr, gateErr.CurrentVersion, schema.AllowRemoteMigrateEnv)
+		if s.intent != openStrict && errors.As(err, &gateErr) {
+			// The gate exists to stop in-place migration on a remote-backed,
+			// already-initialized database (#4259), not to block reads or a
+			// working-set commit. Warn and continue on the current schema;
+			// a plain (openStrict) open still fails with the full
+			// migrate-or-adopt guidance.
+			const sharedGuidance = "  This is a\n" +
+				"  coordination decision, not an auto-fix - do NOT run a migration unless\n" +
+				"  you are the single designated migrator (only ONE clone may migrate a\n" +
+				"  shared remote, else the schema forks; #4259):\n" +
+				"    • designated migrator (only ONE machine): %[3]s=1 bd migrate && bd dolt push\n" +
+				"    • every other clone (another already migrated): bd bootstrap\n"
+			switch s.intent {
+			case openWorkingSetReconcile:
+				fmt.Fprintf(os.Stderr,
+					"Warning: %[1]v\n"+
+						"  Working-set reconcile command: continuing on schema v%[2]d without\n"+
+						"  migrating; the commit applies to the working set at the current\n"+
+						"  schema."+sharedGuidance,
+					gateErr, gateErr.CurrentVersion, schema.AllowRemoteMigrateEnv)
+			default: // openReadOnlyCommand
+				fmt.Fprintf(os.Stderr,
+					"Warning: %[1]v\n"+
+						"  Read-only command: continuing on schema v%[2]d without migrating.\n"+
+						"  Writes are blocked until the schema is reconciled."+sharedGuidance,
+					gateErr, gateErr.CurrentVersion, schema.AllowRemoteMigrateEnv)
+			}
 			return nil
 		}
 		return err
@@ -313,6 +347,31 @@ func (s *EmbeddedDoltStore) initSchema(ctx context.Context) error {
 	// Embedded mode relies on the dolthub/driver/v2's local file/concurrency
 	// controls; schema.MigrateUpWithLock requires a sql-server session lock.
 	if _, err := schema.MigrateUp(ctx, conn); err != nil {
+		var dirtyErr *schema.DirtyTablesError
+		if s.intent != openStrict && errors.As(err, &dirtyErr) {
+			// The guard exists to keep dirty user data from being entangled
+			// with a migration, but its documented recovery - committing the
+			// working set - also opens the store and would otherwise hit
+			// this same refusal before it ever runs, deadlocking (#4566). A
+			// read-only command must not be bricked by dirty tables either,
+			// so both non-strict intents warn and continue on the current
+			// schema instead of failing the open.
+			switch s.intent {
+			case openWorkingSetReconcile:
+				fmt.Fprintf(os.Stderr,
+					"Warning: %v\n"+
+						"  Committing the working set at the current schema; when it completes,\n"+
+						"  re-run 'bd migrate'.\n",
+					dirtyErr)
+			default: // openReadOnlyCommand
+				fmt.Fprintf(os.Stderr,
+					"Warning: %v\n"+
+						"  Continuing without migrating. Run 'bd dolt commit' to commit the\n"+
+						"  working set at the current schema, then re-run 'bd migrate'.\n",
+					dirtyErr)
+			}
+			return nil
+		}
 		return fmt.Errorf("embeddeddolt: migrate: %w", err)
 	}
 

--- a/internal/storage/embeddeddolt/store_stub.go
+++ b/internal/storage/embeddeddolt/store_stub.go
@@ -30,3 +30,8 @@ func OpenReadOnly(_ context.Context, _, _, _ string) (*EmbeddedDoltStore, error)
 func OpenForReadOnlyCommand(_ context.Context, _, _, _ string) (*EmbeddedDoltStore, error) {
 	return nil, errNoCGO
 }
+
+// OpenForWorkingSetReconcile returns an error when CGO is not enabled.
+func OpenForWorkingSetReconcile(_ context.Context, _, _, _ string) (*EmbeddedDoltStore, error) {
+	return nil, errNoCGO
+}

--- a/internal/storage/schema/dirty_tables_error.go
+++ b/internal/storage/schema/dirty_tables_error.go
@@ -1,0 +1,28 @@
+package schema
+
+import "strings"
+
+// DirtyTablesError is returned by MigrateUp when pending schema migrations
+// would alter tables that already have uncommitted changes in the working
+// set. The guard protects dirty user data from being entangled with a
+// migration: committing a migration's DDL/DML together with unrelated
+// uncommitted rows in the same table makes the two impossible to separate
+// later.
+//
+// The documented recovery is "bd dolt commit" (or "bd vc commit"), which
+// commits the working set at the current schema so the migration can then
+// run cleanly. But those commit commands also open the store, and an open
+// runs MigrateUp - hitting this same guard before the commit that would
+// clear the dirty state ever gets a chance to run (gastownhall/beads#4566).
+// To break that deadlock, working-set-reconcile opens (embeddeddolt.
+// OpenForWorkingSetReconcile) detect this error type at open time via
+// errors.As and skip the migration instead of failing the open, so the
+// commit can proceed and clear the working set.
+type DirtyTablesError struct {
+	Tables []string
+}
+
+func (e *DirtyTablesError) Error() string {
+	return "pending schema migrations alter pre-existing dirty tables: " + strings.Join(e.Tables, ", ") +
+		"; run 'bd dolt commit' to commit the working set at the current schema, then re-run the migration (gastownhall/beads#4566)"
+}

--- a/internal/storage/schema/schema.go
+++ b/internal/storage/schema/schema.go
@@ -307,7 +307,7 @@ func MigrateUp(ctx context.Context, db DBConn) (int, error) {
 		return 0, fmt.Errorf("checking dirty tables against pending migrations: %w", err)
 	}
 	if len(touchedDirtyTables) > 0 {
-		return 0, fmt.Errorf("pending schema migrations alter pre-existing dirty tables: %s", strings.Join(touchedDirtyTables, ", "))
+		return 0, &DirtyTablesError{Tables: touchedDirtyTables}
 	}
 	dirtyBeforeSignatures, err := dirtyTableSignatures(ctx, db, dirtyBefore)
 	if err != nil {
@@ -365,6 +365,16 @@ func MigrateUp(ctx context.Context, db DBConn) (int, error) {
 		return applied, fmt.Errorf("checking dirty tables against pending ignored migrations: %w", err)
 	}
 	if len(touchedIgnoredDirtyTables) > 0 {
+		// Deliberately a plain, untyped error (unlike the main-source guard
+		// above, which returns *DirtyTablesError): this check fires mid-pass,
+		// after the main-source migrations have already applied. A lenient
+		// caller (embeddeddolt's openReadOnlyCommand / openWorkingSetReconcile
+		// intents) skipping this and returning as if the open succeeded would
+		// let a reconcile commit checkpoint a half-applied migration pass.
+		// The ignored source also tracks bd-internal state (dolt_ignore'd
+		// tables like ignored_schema_migrations), not expected user data, so
+		// there is no dirty-commit recovery story to support here the way
+		// there is for the main-source guard (#4566 scope).
 		return applied, fmt.Errorf("pending ignored schema migrations alter pre-existing dirty tables: %s", strings.Join(touchedIgnoredDirtyTables, ", "))
 	}
 

--- a/internal/storage/schema/schema_test.go
+++ b/internal/storage/schema/schema_test.go
@@ -3,6 +3,7 @@ package schema
 import (
 	"context"
 	"encoding/csv"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -38,6 +39,68 @@ func TestPendingMigrationDirtyTablesDetectsMigration0043Dependencies(t *testing.
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("unmet sql expectations: %v", err)
 	}
+}
+
+// TestMigrateUpReturnsDirtyTablesErrorForPreExistingDirtyTable exercises the
+// full MigrateUp pre-flight guard (gastownhall/beads#4566): a pre-existing
+// dirty `dependencies` table collides with pending migration 0043, which
+// alters it (confirmed against the real migration content by
+// TestPendingMigrationDirtyTablesDetectsMigration0043Dependencies above).
+// MigrateUp must report this with the typed *DirtyTablesError so
+// working-set-reconcile opens can detect it via errors.As and skip the
+// migration instead of failing outright.
+func TestMigrateUpReturnsDirtyTablesErrorForPreExistingDirtyTable(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	// migrationWorkNeeded: mainSource.atLatest reads the current cursor; v42
+	// is behind LatestVersion(), so the || short-circuits before checking
+	// ignoredSource.atLatest or the content-hash/backfill probes.
+	expectScalar(mock, "SELECT COALESCE(MAX(version), 0) FROM schema_migrations", "version", 42)
+
+	// dirtyTables(ctx, db, false): `dependencies` has an uncommitted, unstaged
+	// change in the working set.
+	expectDirtyDoltStatusRow(mock, "dependencies", false)
+	// committableDirtyTables -> dirtyTables(ctx, db, true): same dirty state.
+	expectDirtyDoltStatusRow(mock, "dependencies", false)
+
+	// auxRekeyResumePending: no local_metadata table, so no resume in flight.
+	mock.ExpectQuery(`SELECT COUNT\(\*\) FROM INFORMATION_SCHEMA\.TABLES`).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
+
+	// failed0053DirtyTablesAreRecoverable: current version (42) is not 52, so
+	// this is not the known failed-v53-migration recovery case.
+	expectScalar(mock, "SELECT COALESCE(MAX(version), 0) FROM schema_migrations", "version", 42)
+
+	// pendingMigrationDirtyTables re-reads the current version and finds
+	// migration 0043 touches the dirty `dependencies` table.
+	expectScalar(mock, "SELECT COALESCE(MAX(version), 0) FROM schema_migrations", "version", 42)
+
+	_, err = MigrateUp(context.Background(), db)
+	if err == nil {
+		t.Fatal("MigrateUp() error = nil, want *DirtyTablesError")
+	}
+	var dirtyErr *DirtyTablesError
+	if !errors.As(err, &dirtyErr) {
+		t.Fatalf("MigrateUp() error = %v (%T), want *DirtyTablesError", err, err)
+	}
+	if len(dirtyErr.Tables) != 1 || dirtyErr.Tables[0] != "dependencies" {
+		t.Fatalf("DirtyTablesError.Tables = %v, want [dependencies]", dirtyErr.Tables)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
+// expectDirtyDoltStatusRow mocks a dolt_status query returning a single dirty
+// table row. The regex matches both the plain and dolt_ignore-filtered forms
+// of the dirtyTables query (see lock_test.go's expectDoltStatusRows).
+func expectDirtyDoltStatusRow(mock sqlmock.Sqlmock, table string, staged bool) {
+	mock.ExpectQuery("(?s)SELECT s\\.table_name, s\\.staged\\s+FROM dolt_status s").
+		WillReturnRows(sqlmock.NewRows([]string{"table_name", "staged"}).AddRow(table, staged))
 }
 
 func TestIgnoredPendingMigrationDirtyTablesDetectsWispDependencies(t *testing.T) {


### PR DESCRIPTION
## Why

In embedded mode, every store open runs `init schema` -> `schema.MigrateUp`, and MigrateUp correctly refuses to run when pending migrations would alter tables that already have uncommitted working-set changes. But the documented recovery for that refusal - commit the working set - is itself a `bd` command (`bd dolt commit` / `bd vc commit`) that opens the store and hits the same refusal. The guard blocks the only command that can satisfy it: a deadlock with no in-tool recovery, reported in #4566 (hit in the wild during the #4555 rc.2 window; the only escapes were raw `dolt add . && dolt commit` inside `.beads/embeddeddolt/<db>`, or destroying and re-cloning the store).

This implements option 1 from the issue discussion: make the working-set reconcile commands able to open the store without completing the migration, so the existing documented recovery actually functions. No new footgun flag.

## What

- **`schema.DirtyTablesError`** (new typed error): the pre-flight dirty-table guard in `MigrateUp` now returns this instead of a bare `fmt.Errorf`, and its message tells the operator the recovery path (`bd dolt commit`, then re-run the migration). The guard still fires before any migration statement runs, so a caller that skips on this error skips a fully un-started pass.
- **Open intents in embeddeddolt**: the previous `lenientGate bool` becomes a small open-intent enum (`openStrict` / `openReadOnlyCommand` / `openWorkingSetReconcile`). Read-only commands behave as before for the #4259 remote-migrate gate, and now also survive a dirty-table refusal (a read listing issues should not be bricked by a dirty working set either). The new `OpenForWorkingSetReconcile` intent gets warning text that matches what is actually happening ("committing the working set at the current schema") instead of the read-only wording, which would have been wrong for a commit.
- **`bd dolt commit` and `bd vc commit` open leniently**: a new `dolt.Config.LenientOpen` flag, set only for those two commands (leaf `commit` under `dolt`/`vc`), routes the embedded open through `OpenForWorkingSetReconcile`. On a dirty-table (or remote-gate) refusal the open warns, skips the migration, and lets the commit proceed at the current schema. After the commit the working set is clean and a normal `bd migrate` applies.

Deliberately unchanged:

- The **ignored-source** dirty guard stays a fatal plain error: it fires mid-pass after main-source migrations have applied, so a lenient skip there could checkpoint a half-applied pass. Dirty ignored tables are bd-internal state, not user data (commented in code).
- **Server mode** is untouched; `LenientOpen` is embedded-only and documented as such. `bd migrate` and `bd bootstrap` still hit the guard strictly - the typed error just makes the failure actionable.

## Recovery flow after this change

```bash
bd migrate
# Error: ... pending schema migrations alter pre-existing dirty tables: comments, dependencies, events, issues;
#        run 'bd dolt commit' to commit the working set at the current schema, then re-run the migration (#4566)

bd dolt commit -m "checkpoint before migration"   # now succeeds (was the deadlock)
bd migrate                                        # clean working set -> migration applies
```

## Testing

- `schema`: `TestMigrateUpReturnsDirtyTablesErrorForPreExistingDirtyTable` - full MigrateUp harness asserting the guard now yields `*DirtyTablesError` with the offending tables populated.
- `embeddeddolt`: `TestEmbeddedDirtyTablesGate_BlocksReopenThenWorkingSetReconcileRecovers` - end-to-end reproduction against real embedded Dolt (gated behind `BEADS_TEST_EMBEDDED_DOLT=1`, matching the sibling remote-migrate gate tests): store pinned at schema v51 with a dirty `issues` table -> plain `Open` fails with `DirtyTablesError` -> `OpenForWorkingSetReconcile` succeeds without migrating -> `Commit` clears the working set -> plain reopen migrates to latest. (Pinned to v51, not `LatestVersion()-2`, so future migrations cannot shift the start onto v52 where the failed-0053 recovery path would swallow the guard.)
- Existing remote-migrate gate tests pass against the reworked open path; no code string-matched the old guard message.
- `gofmt`, `go vet` (cgo and non-cgo stub), `go build ./cmd/bd`, full `./internal/storage/schema` package tests: clean.

Fixes #4566.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FWVnjn3Bq4PSG1akpFpKnY

_claude-fable-5-high on behalf of matt wilkie_
