### PR TITLE
fix(dolt): probe SQL for bd dolt status in shared-server mode (GH#3218)

### DIFF
--- a/cmd/bd/dolt.go
+++ b/cmd/bd/dolt.go
@@ -573,10 +573,10 @@ var doltStatusCmd = &cobra.Command{
 In embedded mode, reports that the Dolt engine runs in-process and shows
 the on-disk data directory. For beads-managed (local) servers, displays
 PID, port, and data directory from the local PID file. For externally-
-managed servers — either a remote dolt_server_host or a local server
-managed outside bd (dolt.auto-start: false, e.g. an orchestrator-shared
-sql-server) — pings the configured endpoint via SQL and reports
-reachability, server version, and database.`,
+managed servers — a shared server (dolt.shared-server: true), a remote
+dolt_server_host, or a local server managed outside bd (dolt.auto-start:
+false, e.g. an orchestrator-shared sql-server) — pings the configured
+endpoint via SQL and reports reachability, server version, and database.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		beadsDir := selectedDoltBeadsDir()
 		if beadsDir == "" {
@@ -608,7 +608,7 @@ reachability, server version, and database.`,
 			// — which is the exact failure mode this PR addresses.
 			fmt.Fprintf(os.Stderr, "Warning: cannot load .beads config (%v); falling back to PID-file status path\n", cfgErr)
 		}
-		if cfg != nil && shouldUseExternalDoltStatus(cfg, doltserver.IsAutoStartDisabled()) {
+		if cfg != nil && shouldUseExternalDoltStatus(cfg, doltserver.IsAutoStartDisabled(), doltserver.IsSharedServerMode()) {
 			runExternalDoltStatus(beadsDir, cfg)
 			return
 		}
@@ -659,6 +659,18 @@ func renderLocalDoltStatus(state *doltserver.State, serverDir string) {
 // shouldUseExternalDoltStatus reports whether bd dolt status should treat
 // the server as externally-managed and probe via SQL instead of consulting
 // the local PID file. Returns true when:
+//   - shared-server mode is enabled (and not proxied) — a shared server's
+//     lifecycle is owned by something other than bd (a Homebrew service,
+//     systemd/launchd unit, or a sibling clone), so bd has no PID file for
+//     it even when the host is local and auto-start is enabled. Without this
+//     branch, status reports "not running" while bd CRUD commands, bd dolt
+//     test, and bd dolt show all connect to the server fine (GH#3218). This
+//     is checked BEFORE the server-mode guard because shared-server mode
+//     wins over a stale metadata.json that still pins dolt_mode="embedded"
+//     — mirroring the loadServerMode override in main.go (GH#2946). That
+//     stale-metadata case (dolt.shared-server: true in config.yaml, which
+//     IsDoltServerMode does not consult) is exactly where the residual
+//     GH#3218 bug lived.
 //   - dolt_mode=server with a non-local host (Hosted Dolt, remote shared
 //     sql-server) — the PID file is on a different machine.
 //   - dolt_mode=server with a local host but bd auto-start is disabled —
@@ -670,10 +682,23 @@ func renderLocalDoltStatus(state *doltserver.State, serverDir string) {
 // When false, the caller falls back to the PID-file path that reports
 // PID, port, log path, and data directory for bd-managed servers.
 //
-// autoStartDisabled is passed in (rather than read here) so the predicate
-// is pure and unit-testable without manipulating package-level config.
-func shouldUseExternalDoltStatus(cfg *configfile.Config, autoStartDisabled bool) bool {
-	if cfg == nil || !cfg.IsDoltServerMode() {
+// autoStartDisabled and sharedServerMode are passed in (rather than read
+// here) so the predicate is pure and unit-testable without manipulating
+// package-level config or process env.
+func shouldUseExternalDoltStatus(cfg *configfile.Config, autoStartDisabled, sharedServerMode bool) bool {
+	if cfg == nil {
+		return false
+	}
+	// Shared-server mode wins even over an explicit metadata.json
+	// dolt_mode="embedded" (loadServerMode override, main.go, GH#2946), so
+	// this must precede the IsDoltServerMode guard — otherwise a workspace
+	// with dolt.shared-server: true in config.yaml and stale embedded
+	// metadata still falls through to the PID-file "not running" path.
+	// Proxied-server mode is excluded, matching that override's !psm guard.
+	if sharedServerMode && !cfg.IsDoltProxiedServerMode() {
+		return true
+	}
+	if !cfg.IsDoltServerMode() {
 		return false
 	}
 	if !isLocalHost(cfg.GetDoltServerHost()) {

--- a/cmd/bd/dolt_test.go
+++ b/cmd/bd/dolt_test.go
@@ -1354,15 +1354,17 @@ func TestRunExternalDoltStatus_Unreachable(t *testing.T) {
 // TestShouldUseExternalDoltStatus covers the routing predicate for
 // `bd dolt status`. The predicate decides whether to ping the configured
 // SQL endpoint (externally-managed server) or read the local PID file
-// (bd-managed server). Three scenarios qualify as externally-managed:
-// non-local hosts, and local hosts where bd does not own the lifecycle
-// (auto-start disabled — be-0eyj). Other configurations should keep the
-// PID-file path so bd-managed servers continue to report PID/log/data.
+// (bd-managed server). Scenarios that qualify as externally-managed:
+// shared-server mode (GH#3218), non-local hosts, and local hosts where bd
+// does not own the lifecycle (auto-start disabled — be-0eyj). Other
+// configurations should keep the PID-file path so bd-managed servers
+// continue to report PID/log/data.
 func TestShouldUseExternalDoltStatus(t *testing.T) {
 	tests := []struct {
 		name              string
 		cfg               *configfile.Config
 		autoStartDisabled bool
+		sharedServerMode  bool
 		want              bool
 	}{
 		{
@@ -1411,6 +1413,61 @@ func TestShouldUseExternalDoltStatus(t *testing.T) {
 			want:              false,
 		},
 		{
+			// GH#3218: a shared server on localhost with bd auto-start
+			// ENABLED previously fell through to the PID-file path and
+			// reported "not running" though bd could connect fine. Shared
+			// mode means bd never owns the lifecycle, so probe SQL.
+			name: "server mode + local host + auto-start enabled + shared-server routes to external (GH#3218)",
+			cfg: &configfile.Config{
+				Backend:        "dolt",
+				DoltMode:       "server",
+				DoltServerHost: "127.0.0.1",
+			},
+			autoStartDisabled: false,
+			sharedServerMode:  true,
+			want:              true,
+		},
+		{
+			name: "server mode + empty host + shared-server routes to external (GH#3218)",
+			cfg: &configfile.Config{
+				Backend:  "dolt",
+				DoltMode: "server",
+			},
+			autoStartDisabled: false,
+			sharedServerMode:  true,
+			want:              true,
+		},
+		{
+			// GH#2946/#3218: shared-server mode (e.g. dolt.shared-server:
+			// true in config.yaml) wins over a stale metadata.json that
+			// still pins dolt_mode="embedded". IsDoltServerMode() does not
+			// consult dolt.shared-server, so without the shared-server
+			// branch preceding the server-mode guard this workspace would
+			// fall through to the PID-file "not running" path.
+			name: "shared-server flag wins over stale embedded metadata (GH#2946/#3218)",
+			cfg: &configfile.Config{
+				Backend:  "dolt",
+				DoltMode: "embedded",
+			},
+			autoStartDisabled: false,
+			sharedServerMode:  true,
+			want:              true,
+		},
+		{
+			// Proxied-server mode is excluded from the shared-server
+			// override (matches main.go's !psm guard): bd talks through the
+			// proxy, so keep the non-external path even if the shared-server
+			// flag is also set.
+			name: "proxied-server mode + shared-server flag stays non-external",
+			cfg: &configfile.Config{
+				Backend:  "dolt",
+				DoltMode: configfile.DoltModeProxiedServer,
+			},
+			autoStartDisabled: false,
+			sharedServerMode:  true,
+			want:              false,
+		},
+		{
 			name: "server mode + local host + auto-start disabled routes to external (be-0eyj)",
 			cfg: &configfile.Config{
 				Backend:        "dolt",
@@ -1449,7 +1506,7 @@ func TestShouldUseExternalDoltStatus(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got := shouldUseExternalDoltStatus(tc.cfg, tc.autoStartDisabled)
+			got := shouldUseExternalDoltStatus(tc.cfg, tc.autoStartDisabled, tc.sharedServerMode)
 			if got != tc.want {
 				t.Errorf("shouldUseExternalDoltStatus = %v, want %v", got, tc.want)
 			}

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -3116,10 +3116,10 @@ Show the status of the Dolt engine for the current project.
 In embedded mode, reports that the Dolt engine runs in-process and shows
 the on-disk data directory. For beads-managed (local) servers, displays
 PID, port, and data directory from the local PID file. For externally-
-managed servers — either a remote dolt_server_host or a local server
-managed outside bd (dolt.auto-start: false, e.g. an orchestrator-shared
-sql-server) — pings the configured endpoint via SQL and reports
-reachability, server version, and database.
+managed servers — a shared server (dolt.shared-server: true), a remote
+dolt_server_host, or a local server managed outside bd (dolt.auto-start:
+false, e.g. an orchestrator-shared sql-server) — pings the configured
+endpoint via SQL and reports reachability, server version, and database.
 
 ```
 bd dolt status

--- a/website/docs/cli-reference/dolt.md
+++ b/website/docs/cli-reference/dolt.md
@@ -257,10 +257,10 @@ Show the status of the Dolt engine for the current project.
 In embedded mode, reports that the Dolt engine runs in-process and shows
 the on-disk data directory. For beads-managed (local) servers, displays
 PID, port, and data directory from the local PID file. For externally-
-managed servers — either a remote dolt_server_host or a local server
-managed outside bd (dolt.auto-start: false, e.g. an orchestrator-shared
-sql-server) — pings the configured endpoint via SQL and reports
-reachability, server version, and database.
+managed servers — a shared server (dolt.shared-server: true), a remote
+dolt_server_host, or a local server managed outside bd (dolt.auto-start:
+false, e.g. an orchestrator-shared sql-server) — pings the configured
+endpoint via SQL and reports reachability, server version, and database.
 
 ```
 bd dolt status [flags]


### PR DESCRIPTION
## What

Route `bd dolt status` to the external SQL probe whenever shared-server mode is active, instead of consulting the local PID file. Fixes the case where a shared Dolt server on localhost is falsely reported as "not running."

## Why

Fixes #3218. With a shared Dolt server on localhost and bd auto-start **enabled**, `bd dolt status` printed `Dolt server: not running` even though `bd dolt test`, `bd dolt show`, and normal CRUD all connected fine (last reproduced 2026-06-14 on v1.0.5).

`shouldUseExternalDoltStatus` (`cmd/bd/dolt.go`) only probed SQL for non-local hosts or auto-start-disabled. A shared server on localhost with auto-start enabled matched neither, so status fell back to the PID-file lookup — but bd has no PID file for a server owned by Homebrew/systemd/launchd or a sibling clone. (PR #3550 fixed the non-local / auto-start-disabled variants; this closes the remaining shared-server-on-localhost case.)

There is also a subtler slice: `Config.IsDoltServerMode()` does not consult `dolt.shared-server` from `config.yaml` (only `dolt.mode` and the `BEADS_DOLT_SHARED_SERVER` env var). So `dolt.shared-server: true` in config.yaml + a stale `metadata.json` pinning `dolt_mode="embedded"` reports `IsSharedServerMode() == true` but `IsDoltServerMode() == false`, and still fell through.

The fix places the `sharedServerMode` branch **before** the `IsDoltServerMode` guard, so shared-server mode wins over stale embedded metadata — mirroring the existing `loadServerMode` override in `main.go` (#2946: `if !sm && !psm && IsSharedServerMode() { sm = true }`). Proxied-server mode is excluded (`!cfg.IsDoltProxiedServerMode()`) to match that override's `!psm` guard. The flag is passed in (like `autoStartDisabled`) to keep the predicate pure/testable; the caller supplies `doltserver.IsSharedServerMode()`. The doc comment and `status` help text are updated accordingly.

`bd dolt stop` has the same shared-server gap (#3687) but lives in `doltserver.StopWithForce` — left for a separate change.

## Verification

Extends `TestShouldUseExternalDoltStatus` with:
- shared-server + localhost + auto-start **enabled** → external (primary #3218 regression)
- shared-server + empty host → external
- shared-server flag + stale `embedded` metadata → external (the config.yaml slice; previously fell through)
- proxied-server + shared-server flag → non-external (precedence, matches main.go `!psm`)

```
go test -tags gms_pure_go ./cmd/bd/ -run 'ShouldUseExternalDoltStatus|RenderLocalDoltStatus|RunExternalDoltStatus' -v   # all pass
go test -tags gms_pure_go ./cmd/bd/ -run Dolt                                                                            # full Dolt suite green
go vet -tags gms_pure_go ./cmd/bd/ && gofmt -l cmd/bd/dolt.go cmd/bd/dolt_test.go                                        # clean
```

