### PR TITLE
feat(prime): cap injected memories with count/char budgets and a visible elision banner

### DIFF
--- a/cmd/bd/config.go
+++ b/cmd/bd/config.go
@@ -878,6 +878,7 @@ var recognizedConfigKeys = map[string]bool{
 	"create.require-description": true, "beads.role": true,
 	"auto_compact_enabled": true, "schema_version": true,
 	"output.title-length": true,
+	"prime.max-memories": true, "prime.max-memory-chars": true,
 }
 
 func isRecognizedConfigKey(key string) bool {

--- a/cmd/bd/config.go
+++ b/cmd/bd/config.go
@@ -878,7 +878,7 @@ var recognizedConfigKeys = map[string]bool{
 	"create.require-description": true, "beads.role": true,
 	"auto_compact_enabled": true, "schema_version": true,
 	"output.title-length": true,
-	"prime.max-memories": true, "prime.max-memory-chars": true,
+	"prime.max-memories":  true, "prime.max-memory-chars": true,
 }
 
 func isRecognizedConfigKey(key string) bool {

--- a/cmd/bd/prime.go
+++ b/cmd/bd/prime.go
@@ -9,7 +9,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"sort"
 	"strings"
 	"time"
 
@@ -111,7 +110,9 @@ Memory injection caps:
 	prime.max-memory-chars config keys; an explicit flag wins, and an explicit
 	0 forces unlimited). Caps apply at whole-memory boundaries, at least one
 	memory is always emitted, and a banner ahead of the entries reports how
-	many were elided and how to browse the rest with bd memories.`,
+	many were elided and how to browse the rest with bd memories.
+	--max-memory-chars caps the total bytes of the injected memory entries;
+	the section header and elision banner are excluded from the budget.`,
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -202,7 +203,7 @@ func init() {
 	primeCmd.Flags().BoolVar(&primeMemoriesOnly, "memories-only", false, "Output only persistent memories for compact hook contexts")
 	primeCmd.Flags().BoolVar(&primeHookJSONMode, "hook-json", false, "Wrap output in the SessionStart hook JSON envelope (Claude Code, Gemini CLI, Codex)")
 	primeCmd.Flags().IntVar(&primeMaxMemories, "max-memories", 0, "Cap injected persistent memories to N entries (0 = unlimited; falls back to the prime.max-memories config key)")
-	primeCmd.Flags().IntVar(&primeMaxMemoryChars, "max-memory-chars", 0, "Cap the total characters of injected persistent memories, at whole-memory boundaries (0 = unlimited; falls back to the prime.max-memory-chars config key)")
+	primeCmd.Flags().IntVar(&primeMaxMemoryChars, "max-memory-chars", 0, "Cap the total bytes of injected memory entries, at whole-memory boundaries; section header and banner are not counted (0 = unlimited; falls back to the prime.max-memory-chars config key)")
 	rootCmd.AddCommand(primeCmd)
 }
 
@@ -413,37 +414,36 @@ func primeMemoryCaps() (maxCount, maxChars int) {
 
 // renderPrimeMemories formats memories for injection, applying the given
 // caps. maxCount bounds how many memories are emitted; maxChars bounds the
-// total size of the emitted entries. Both are 0 when uncapped. Caps apply at
-// whole-memory boundaries and at least one memory is always emitted, so a
-// single oversized memory can exceed maxChars rather than vanish. Keys are
-// emitted in sorted order (the memory store keeps no timestamps, so
-// alphabetical is the only stable order available); when entries are elided
-// a banner ahead of the entries says how many and how to reach the rest, so
-// a capped prime never silently drops context.
+// total bytes of the emitted memory entries (the section header and elision
+// banner are not counted against this budget). Both are 0 when uncapped.
+// Caps apply at whole-memory boundaries and at least one memory is always
+// emitted, so a single oversized memory can exceed maxChars rather than
+// vanish. Keys are emitted in sorted order (the memory store keeps no
+// timestamps, so alphabetical is the only stable order available); when
+// entries are elided a banner ahead of the entries says how many and how to
+// reach the rest, so a capped prime never silently drops context. The banner
+// names only the cap that actually fired.
 func renderPrimeMemories(memories map[string]string, compact bool, maxCount, maxChars int) string {
-	keys := make([]string, 0, len(memories))
-	for k := range memories {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
+	keys := sortedKeys(memories)
 
 	entries := make([]string, 0, len(keys))
 	used := 0
+	var countCapHit, charCapHit bool
 	for _, k := range keys {
 		if maxCount > 0 && len(entries) >= maxCount {
+			countCapHit = true
 			break
 		}
 		var entry string
 		if compact {
 			v := strings.ReplaceAll(memories[k], "\n", " ")
-			if len(v) > 150 {
-				v = v[:147] + "..."
-			}
+			v = truncate(v, 150)
 			entry = fmt.Sprintf("- **%s**: %s\n", k, v)
 		} else {
 			entry = fmt.Sprintf("### %s\n%s\n\n", k, memories[k])
 		}
 		if maxChars > 0 && len(entries) > 0 && used+len(entry) > maxChars {
+			charCapHit = true
 			break
 		}
 		entries = append(entries, entry)
@@ -451,11 +451,18 @@ func renderPrimeMemories(memories map[string]string, compact bool, maxCount, max
 	}
 
 	elided := len(keys) - len(entries)
+	var noteCount, noteChars int
+	if countCapHit {
+		noteCount = maxCount
+	}
+	if charCapHit {
+		noteChars = maxChars
+	}
 	var sb strings.Builder
 	if compact {
 		if elided > 0 {
 			sb.WriteString(fmt.Sprintf("\n## Memories (showing %d of %d)\n", len(entries), len(keys)))
-			sb.WriteString(fmt.Sprintf("- %d more not shown (%s); browse with `bd memories <keyword>`\n", elided, primeMemoryCapNote(maxCount, maxChars)))
+			sb.WriteString(fmt.Sprintf("- %d more not shown (%s); browse with `bd memories <keyword>`\n", elided, primeMemoryCapNote(noteCount, noteChars)))
 		} else {
 			sb.WriteString("\n## Memories\n")
 		}
@@ -467,7 +474,7 @@ func renderPrimeMemories(memories map[string]string, compact bool, maxCount, max
 		}
 		sb.WriteString("Stored via `bd remember`. Update in place with `bd remember --key <key> \"new content\"`. Search with `bd memories <keyword>`. Remove with `bd forget <key>`.\n\n")
 		if elided > 0 {
-			sb.WriteString(fmt.Sprintf("> %d more memories are not shown here (%s). Browse the full set with `bd memories <keyword>` or recall one with `bd remember <key>`.\n\n", elided, primeMemoryCapNote(maxCount, maxChars)))
+			sb.WriteString(fmt.Sprintf("> %d more memories are not shown here (%s). Browse the full set with `bd memories <keyword>` or recall one with `bd remember <key>`.\n\n", elided, primeMemoryCapNote(noteCount, noteChars)))
 		}
 	}
 	for _, entry := range entries {

--- a/cmd/bd/prime.go
+++ b/cmd/bd/prime.go
@@ -27,6 +27,11 @@ var (
 	primeExportMode   bool
 	primeMemoriesOnly bool
 	primeHookJSONMode bool
+
+	primeMaxMemories       int
+	primeMaxMemoryChars    int
+	primeMaxMemoriesSet    bool
+	primeMaxMemoryCharsSet bool
 )
 
 const (
@@ -97,7 +102,16 @@ Config options:
 	Workflow customization:
 	- Place a .beads/PRIME.md file in the local clone or resolved workspace to override the default output entirely.
 	- Use --export to dump the default content for customization.
-	- Use --memories-only for hook contexts that should inject only persistent memories.`,
+	- Use --memories-only for hook contexts that should inject only persistent memories.
+
+Memory injection caps:
+	Large memory sets can exceed what a session-start hook host will ingest,
+	and hosts truncate silently. Cap what prime injects with --max-memories N
+	and/or --max-memory-chars N (or the prime.max-memories /
+	prime.max-memory-chars config keys; an explicit flag wins, and an explicit
+	0 forces unlimited). Caps apply at whole-memory boundaries, at least one
+	memory is always emitted, and a banner ahead of the entries reports how
+	many were elided and how to browse the rest with bd memories.`,
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -107,6 +121,9 @@ Config options:
 				c.CloseEventAndAdd(evt)
 			}
 		}()
+
+		primeMaxMemoriesSet = cmd.Flags().Changed("max-memories")
+		primeMaxMemoryCharsSet = cmd.Flags().Changed("max-memory-chars")
 
 		emit := func(content string) {
 			if primeHookJSONMode {
@@ -184,6 +201,8 @@ func init() {
 	primeCmd.Flags().BoolVar(&primeExportMode, "export", false, "Output default content (ignores PRIME.md override)")
 	primeCmd.Flags().BoolVar(&primeMemoriesOnly, "memories-only", false, "Output only persistent memories for compact hook contexts")
 	primeCmd.Flags().BoolVar(&primeHookJSONMode, "hook-json", false, "Wrap output in the SessionStart hook JSON envelope (Claude Code, Gemini CLI, Codex)")
+	primeCmd.Flags().IntVar(&primeMaxMemories, "max-memories", 0, "Cap injected persistent memories to N entries (0 = unlimited; falls back to the prime.max-memories config key)")
+	primeCmd.Flags().IntVar(&primeMaxMemoryChars, "max-memory-chars", 0, "Cap the total characters of injected persistent memories, at whole-memory boundaries (0 = unlimited; falls back to the prime.max-memory-chars config key)")
 	rootCmd.AddCommand(primeCmd)
 }
 
@@ -352,39 +371,121 @@ func formatMemoriesForPrime(compact bool) string {
 	}
 
 	fullPrefix := kvPrefix + memoryPrefix
-	var keys []string
 	memories := make(map[string]string)
 	for k, v := range allConfig {
 		if strings.HasPrefix(k, fullPrefix) {
-			userKey := strings.TrimPrefix(k, fullPrefix)
-			memories[userKey] = v
-			keys = append(keys, userKey)
+			memories[strings.TrimPrefix(k, fullPrefix)] = v
 		}
 	}
 	if len(memories) == 0 {
 		return ""
 	}
+	maxCount, maxChars := primeMemoryCaps()
+	return renderPrimeMemories(memories, compact, maxCount, maxChars)
+}
+
+// primeConfigInt reads an integer config key (stubbable for tests).
+var primeConfigInt = func(key string) int {
+	return config.GetInt(key)
+}
+
+// primeMemoryCaps resolves the memory-injection caps. An explicitly passed
+// flag wins, including an explicit 0 meaning "force unlimited"; otherwise the
+// prime.max-memories / prime.max-memory-chars config keys apply. 0 or unset
+// means uncapped.
+func primeMemoryCaps() (maxCount, maxChars int) {
+	maxCount = primeMaxMemories
+	if !primeMaxMemoriesSet && maxCount == 0 {
+		maxCount = primeConfigInt("prime.max-memories")
+	}
+	maxChars = primeMaxMemoryChars
+	if !primeMaxMemoryCharsSet && maxChars == 0 {
+		maxChars = primeConfigInt("prime.max-memory-chars")
+	}
+	if maxCount < 0 {
+		maxCount = 0
+	}
+	if maxChars < 0 {
+		maxChars = 0
+	}
+	return maxCount, maxChars
+}
+
+// renderPrimeMemories formats memories for injection, applying the given
+// caps. maxCount bounds how many memories are emitted; maxChars bounds the
+// total size of the emitted entries. Both are 0 when uncapped. Caps apply at
+// whole-memory boundaries and at least one memory is always emitted, so a
+// single oversized memory can exceed maxChars rather than vanish. Keys are
+// emitted in sorted order (the memory store keeps no timestamps, so
+// alphabetical is the only stable order available); when entries are elided
+// a banner ahead of the entries says how many and how to reach the rest, so
+// a capped prime never silently drops context.
+func renderPrimeMemories(memories map[string]string, compact bool, maxCount, maxChars int) string {
+	keys := make([]string, 0, len(memories))
+	for k := range memories {
+		keys = append(keys, k)
+	}
 	sort.Strings(keys)
 
-	var sb strings.Builder
-	if compact {
-		sb.WriteString("\n## Memories\n")
-		for _, k := range keys {
-			// Compact: one line per memory
+	entries := make([]string, 0, len(keys))
+	used := 0
+	for _, k := range keys {
+		if maxCount > 0 && len(entries) >= maxCount {
+			break
+		}
+		var entry string
+		if compact {
 			v := strings.ReplaceAll(memories[k], "\n", " ")
 			if len(v) > 150 {
 				v = v[:147] + "..."
 			}
-			sb.WriteString(fmt.Sprintf("- **%s**: %s\n", k, v))
+			entry = fmt.Sprintf("- **%s**: %s\n", k, v)
+		} else {
+			entry = fmt.Sprintf("### %s\n%s\n\n", k, memories[k])
+		}
+		if maxChars > 0 && len(entries) > 0 && used+len(entry) > maxChars {
+			break
+		}
+		entries = append(entries, entry)
+		used += len(entry)
+	}
+
+	elided := len(keys) - len(entries)
+	var sb strings.Builder
+	if compact {
+		if elided > 0 {
+			sb.WriteString(fmt.Sprintf("\n## Memories (showing %d of %d)\n", len(entries), len(keys)))
+			sb.WriteString(fmt.Sprintf("- %d more not shown (%s); browse with `bd memories <keyword>`\n", elided, primeMemoryCapNote(maxCount, maxChars)))
+		} else {
+			sb.WriteString("\n## Memories\n")
 		}
 	} else {
-		sb.WriteString(fmt.Sprintf("\n## Persistent Memories (%d)\n\n", len(memories)))
+		if elided > 0 {
+			sb.WriteString(fmt.Sprintf("\n## Persistent Memories (showing %d of %d, alphabetical)\n\n", len(entries), len(keys)))
+		} else {
+			sb.WriteString(fmt.Sprintf("\n## Persistent Memories (%d)\n\n", len(keys)))
+		}
 		sb.WriteString("Stored via `bd remember`. Update in place with `bd remember --key <key> \"new content\"`. Search with `bd memories <keyword>`. Remove with `bd forget <key>`.\n\n")
-		for _, k := range keys {
-			sb.WriteString(fmt.Sprintf("### %s\n%s\n\n", k, memories[k]))
+		if elided > 0 {
+			sb.WriteString(fmt.Sprintf("> %d more memories are not shown here (%s). Browse the full set with `bd memories <keyword>` or recall one with `bd remember <key>`.\n\n", elided, primeMemoryCapNote(maxCount, maxChars)))
 		}
 	}
+	for _, entry := range entries {
+		sb.WriteString(entry)
+	}
 	return sb.String()
+}
+
+// primeMemoryCapNote names the active cap(s) for the elision banner.
+func primeMemoryCapNote(maxCount, maxChars int) string {
+	var parts []string
+	if maxCount > 0 {
+		parts = append(parts, fmt.Sprintf("max-memories=%d", maxCount))
+	}
+	if maxChars > 0 {
+		parts = append(parts, fmt.Sprintf("max-memory-chars=%d", maxChars))
+	}
+	return "capped by " + strings.Join(parts, ", ")
 }
 
 func formatPrimeMemoryTimeout(compact bool, timeout time.Duration) string {

--- a/cmd/bd/prime_memory_caps_test.go
+++ b/cmd/bd/prime_memory_caps_test.go
@@ -1,0 +1,148 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func testMemories(n int) map[string]string {
+	m := make(map[string]string, n)
+	for i := 0; i < n; i++ {
+		key := fmt.Sprintf("mem-%02d", i)
+		m[key] = fmt.Sprintf("insight body for %s", key)
+	}
+	return m
+}
+
+func TestRenderPrimeMemoriesUncappedMatchesLegacyShape(t *testing.T) {
+	out := renderPrimeMemories(testMemories(3), false, 0, 0)
+
+	if !strings.Contains(out, "## Persistent Memories (3)\n") {
+		t.Fatalf("expected legacy uncapped header, got %q", out)
+	}
+	if strings.Contains(out, "not shown") || strings.Contains(out, "showing") {
+		t.Fatalf("uncapped output must not carry an elision banner, got %q", out)
+	}
+	for i := 0; i < 3; i++ {
+		if !strings.Contains(out, fmt.Sprintf("### mem-%02d\n", i)) {
+			t.Fatalf("missing memory %d in %q", i, out)
+		}
+	}
+}
+
+func TestRenderPrimeMemoriesCountCap(t *testing.T) {
+	out := renderPrimeMemories(testMemories(5), false, 2, 0)
+
+	if !strings.Contains(out, "## Persistent Memories (showing 2 of 5, alphabetical)\n") {
+		t.Fatalf("expected capped header, got %q", out)
+	}
+	if !strings.Contains(out, "> 3 more memories are not shown here (capped by max-memories=2).") {
+		t.Fatalf("expected elision banner, got %q", out)
+	}
+	if !strings.Contains(out, "### mem-00\n") || !strings.Contains(out, "### mem-01\n") {
+		t.Fatalf("expected first two alphabetical memories, got %q", out)
+	}
+	if strings.Contains(out, "### mem-02\n") {
+		t.Fatalf("memory beyond the cap leaked into output: %q", out)
+	}
+	if banner, entries := strings.Index(out, "not shown"), strings.Index(out, "### mem-00"); banner > entries {
+		t.Fatalf("elision banner must precede entries so host truncation cannot hide it: %q", out)
+	}
+}
+
+func TestRenderPrimeMemoriesCharCapStopsAtWholeMemoryBoundary(t *testing.T) {
+	memories := testMemories(4)
+	oneEntry := len(fmt.Sprintf("### mem-00\n%s\n\n", memories["mem-00"]))
+	out := renderPrimeMemories(memories, false, 0, oneEntry+5)
+
+	if !strings.Contains(out, "showing 1 of 4") {
+		t.Fatalf("expected exactly one memory within budget, got %q", out)
+	}
+	if !strings.Contains(out, "capped by max-memory-chars=") {
+		t.Fatalf("banner must name the character cap, got %q", out)
+	}
+	if strings.Contains(out, "### mem-01\n") {
+		t.Fatalf("second memory should not fit the budget: %q", out)
+	}
+}
+
+func TestRenderPrimeMemoriesCharCapAlwaysEmitsFirstMemory(t *testing.T) {
+	memories := map[string]string{"huge": strings.Repeat("x", 4096)}
+	out := renderPrimeMemories(memories, false, 0, 100)
+
+	if !strings.Contains(out, "### huge\n") {
+		t.Fatalf("an oversized first memory must still be emitted, got %q", out)
+	}
+	if strings.Contains(out, "not shown") {
+		t.Fatalf("nothing was elided, banner must be absent: %q", out)
+	}
+}
+
+func TestRenderPrimeMemoriesCompactCaps(t *testing.T) {
+	out := renderPrimeMemories(testMemories(4), true, 3, 0)
+
+	if !strings.Contains(out, "## Memories (showing 3 of 4)\n") {
+		t.Fatalf("expected compact capped header, got %q", out)
+	}
+	if !strings.Contains(out, "- 1 more not shown (capped by max-memories=3); browse with `bd memories <keyword>`\n") {
+		t.Fatalf("expected compact elision line, got %q", out)
+	}
+	if strings.Contains(out, "mem-03") {
+		t.Fatalf("memory beyond the cap leaked into compact output: %q", out)
+	}
+}
+
+func TestRenderPrimeMemoriesCompactUncappedUnchanged(t *testing.T) {
+	out := renderPrimeMemories(testMemories(2), true, 0, 0)
+
+	if !strings.Contains(out, "\n## Memories\n") || strings.Contains(out, "showing") {
+		t.Fatalf("uncapped compact output changed shape: %q", out)
+	}
+}
+
+func TestPrimeMemoryCapsResolution(t *testing.T) {
+	oldMax, oldChars := primeMaxMemories, primeMaxMemoryChars
+	oldMaxSet, oldCharsSet := primeMaxMemoriesSet, primeMaxMemoryCharsSet
+	oldConfigInt := primeConfigInt
+	t.Cleanup(func() {
+		primeMaxMemories, primeMaxMemoryChars = oldMax, oldChars
+		primeMaxMemoriesSet, primeMaxMemoryCharsSet = oldMaxSet, oldCharsSet
+		primeConfigInt = oldConfigInt
+	})
+	configValues := map[string]int{}
+	primeConfigInt = func(key string) int { return configValues[key] }
+
+	// No flags, no config: uncapped.
+	primeMaxMemories, primeMaxMemoryChars = 0, 0
+	primeMaxMemoriesSet, primeMaxMemoryCharsSet = false, false
+	if c, ch := primeMemoryCaps(); c != 0 || ch != 0 {
+		t.Fatalf("expected uncapped defaults, got %d/%d", c, ch)
+	}
+
+	// Config keys apply when flags are absent.
+	configValues["prime.max-memories"] = 20
+	configValues["prime.max-memory-chars"] = 25000
+	if c, ch := primeMemoryCaps(); c != 20 || ch != 25000 {
+		t.Fatalf("expected config caps 20/25000, got %d/%d", c, ch)
+	}
+
+	// An explicit flag wins over config.
+	primeMaxMemories, primeMaxMemoriesSet = 5, true
+	if c, _ := primeMemoryCaps(); c != 5 {
+		t.Fatalf("flag must beat config, got %d", c)
+	}
+
+	// An explicit 0 flag forces unlimited despite config.
+	primeMaxMemories = 0
+	if c, _ := primeMemoryCaps(); c != 0 {
+		t.Fatalf("explicit --max-memories 0 must force unlimited, got %d", c)
+	}
+
+	// Negative values clamp to uncapped.
+	primeMaxMemories, primeMaxMemoriesSet = -3, true
+	primeMaxMemoryChars, primeMaxMemoryCharsSet = -1, true
+	if c, ch := primeMemoryCaps(); c != 0 || ch != 0 {
+		t.Fatalf("negative caps must clamp to 0, got %d/%d", c, ch)
+	}
+}

--- a/cmd/bd/prime_memory_caps_test.go
+++ b/cmd/bd/prime_memory_caps_test.go
@@ -101,6 +101,24 @@ func TestRenderPrimeMemoriesCompactUncappedUnchanged(t *testing.T) {
 	}
 }
 
+func TestRenderPrimeMemoriesBannerNamesOnlyBindingCap(t *testing.T) {
+	// 5 memories, count cap = 50 (won't bind), char cap small enough to stop at ~2 entries.
+	// One entry is roughly: "### mem-00\ninsight body for mem-00\n\n" ~ 40+ bytes.
+	// Set char cap to allow only 1 entry so char cap fires, not count cap.
+	memories := testMemories(5)
+	firstEntry := fmt.Sprintf("### mem-00\n%s\n\n", memories["mem-00"])
+	smallCharBudget := len(firstEntry) + 5 // fits exactly 1 entry
+
+	out := renderPrimeMemories(memories, false, 50, smallCharBudget)
+
+	if !strings.Contains(out, "capped by max-memory-chars=") {
+		t.Fatalf("banner must name the char cap that fired, got %q", out)
+	}
+	if strings.Contains(out, "max-memories") {
+		t.Fatalf("banner must NOT name max-memories when it did not fire, got %q", out)
+	}
+}
+
 func TestPrimeMemoryCapsResolution(t *testing.T) {
 	oldMax, oldChars := primeMaxMemories, primeMaxMemoryChars
 	oldMaxSet, oldCharsSet := primeMaxMemoriesSet, primeMaxMemoryCharsSet

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -3589,6 +3589,17 @@ Config options:
 	- Use --export to dump the default content for customization.
 	- Use --memories-only for hook contexts that should inject only persistent memories.
 
+Memory injection caps:
+	Large memory sets can exceed what a session-start hook host will ingest,
+	and hosts truncate silently. Cap what prime injects with --max-memories N
+	and/or --max-memory-chars N (or the prime.max-memories /
+	prime.max-memory-chars config keys; an explicit flag wins, and an explicit
+	0 forces unlimited). Caps apply at whole-memory boundaries, at least one
+	memory is always emitted, and a banner ahead of the entries reports how
+	many were elided and how to browse the rest with bd memories.
+	--max-memory-chars caps the total bytes of the injected memory entries;
+	the section header and elision banner are excluded from the budget.
+
 ```
 bd prime [flags]
 ```
@@ -3596,12 +3607,14 @@ bd prime [flags]
 **Flags:**
 
 ```
-      --export          Output default content (ignores PRIME.md override)
-      --full            Force full CLI output (ignore MCP detection)
-      --hook-json       Wrap output in the SessionStart hook JSON envelope (Claude Code, Gemini CLI, Codex)
-      --mcp             Force MCP mode (minimal output)
-      --memories-only   Output only persistent memories for compact hook contexts
-      --stealth         Stealth mode (no git operations, flush only)
+      --export                 Output default content (ignores PRIME.md override)
+      --full                   Force full CLI output (ignore MCP detection)
+      --hook-json              Wrap output in the SessionStart hook JSON envelope (Claude Code, Gemini CLI, Codex)
+      --max-memories int       Cap injected persistent memories to N entries (0 = unlimited; falls back to the prime.max-memories config key)
+      --max-memory-chars int   Cap the total bytes of injected memory entries, at whole-memory boundaries; section header and banner are not counted (0 = unlimited; falls back to the prime.max-memory-chars config key)
+      --mcp                    Force MCP mode (minimal output)
+      --memories-only          Output only persistent memories for compact hook contexts
+      --stealth                Stealth mode (no git operations, flush only)
 ```
 
 ### bd quickstart

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -48,6 +48,8 @@ Common tool-level settings you can configure:
 | `create.require-description` | - | `BD_CREATE_REQUIRE_DESCRIPTION` | `false` | Require description when creating issues |
 | `validation.on-create` | - | `BD_VALIDATION_ON_CREATE` | `none` | Template validation on create: `none`, `warn`, `error` |
 | `validation.on-sync` | - | `BD_VALIDATION_ON_SYNC` | `none` | Template validation before sync: `none`, `warn`, `error` |
+| `prime.max-memories` | `--max-memories` | `BD_PRIME_MAX_MEMORIES` | `0` | Max persistent memories injected by bd prime (0 = unlimited) |
+| `prime.max-memory-chars` | `--max-memory-chars` | `BD_PRIME_MAX_MEMORY_CHARS` | `0` | Max total bytes of memory entries injected by bd prime, whole-memory boundaries (0 = unlimited) |
 | `git.author` | - | `BD_GIT_AUTHOR` | (none) | Override commit author for beads commits |
 | `git.no-gpg-sign` | - | `BD_GIT_NO_GPG_SIGN` | `false` | Disable GPG signing for beads commits |
 | `directory.labels` | - | - | (none) | Map directories to labels for automatic filtering |

--- a/internal/config/yaml_config.go
+++ b/internal/config/yaml_config.go
@@ -820,6 +820,22 @@ func validateYamlConfigValue(key, value string) error {
 		if lower != "server" && lower != "embedded" {
 			return fmt.Errorf("dolt.mode must be \"server\" or \"embedded\", got %q", value)
 		}
+	case "prime.max-memories":
+		n, err := strconv.Atoi(value)
+		if err != nil {
+			return fmt.Errorf("prime.max-memories must be a non-negative integer (0 = unlimited), got %q", value)
+		}
+		if n < 0 {
+			return fmt.Errorf("prime.max-memories must be a non-negative integer (0 = unlimited), got %q", value)
+		}
+	case "prime.max-memory-chars":
+		n, err := strconv.Atoi(value)
+		if err != nil {
+			return fmt.Errorf("prime.max-memory-chars must be a non-negative integer (0 = unlimited), got %q", value)
+		}
+		if n < 0 {
+			return fmt.Errorf("prime.max-memory-chars must be a non-negative integer (0 = unlimited), got %q", value)
+		}
 	}
 	return nil
 }

--- a/internal/config/yaml_config.go
+++ b/internal/config/yaml_config.go
@@ -50,6 +50,11 @@ var YamlOnlyKeys = map[string]bool{
 	// Create command settings
 	"create.require-description": true,
 
+	// Prime memory-injection caps (read at session start, possibly before
+	// the database is reachable, so they must live in yaml)
+	"prime.max-memories":     true,
+	"prime.max-memory-chars": true,
+
 	// Validation settings (bd-t7jq)
 	// Values: "warn" | "error" | "none"
 	"validation.on-create": true,

--- a/internal/config/yaml_config_test.go
+++ b/internal/config/yaml_config_test.go
@@ -697,6 +697,76 @@ func TestValidateYamlConfigValue_DoltMode(t *testing.T) {
 	}
 }
 
+// TestValidateYamlConfigValue_PrimeMaxMemories tests validation of prime.max-memories
+func TestValidateYamlConfigValue_PrimeMaxMemories(t *testing.T) {
+	tests := []struct {
+		name      string
+		value     string
+		expectErr bool
+		errMsg    string
+	}{
+		{"valid zero (unlimited)", "0", false, ""},
+		{"valid positive", "10", false, ""},
+		{"valid large value", "1000", false, ""},
+		{"invalid negative", "-1", true, "prime.max-memories must be a non-negative integer (0 = unlimited), got \"-1\""},
+		{"invalid non-integer", "abc", true, "prime.max-memories must be a non-negative integer (0 = unlimited), got \"abc\""},
+		{"invalid float", "3.5", true, "prime.max-memories must be a non-negative integer (0 = unlimited), got \"3.5\""},
+		{"invalid empty", "", true, "prime.max-memories must be a non-negative integer (0 = unlimited), got \"\""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateYamlConfigValue("prime.max-memories", tt.value)
+			if tt.expectErr {
+				if err == nil {
+					t.Errorf("expected error for value %q, got nil", tt.value)
+				} else if err.Error() != tt.errMsg {
+					t.Errorf("expected error %q, got %q", tt.errMsg, err.Error())
+				}
+			} else {
+				if err != nil {
+					t.Errorf("unexpected error for value %q: %v", tt.value, err)
+				}
+			}
+		})
+	}
+}
+
+// TestValidateYamlConfigValue_PrimeMaxMemoryChars tests validation of prime.max-memory-chars
+func TestValidateYamlConfigValue_PrimeMaxMemoryChars(t *testing.T) {
+	tests := []struct {
+		name      string
+		value     string
+		expectErr bool
+		errMsg    string
+	}{
+		{"valid zero (unlimited)", "0", false, ""},
+		{"valid positive", "25000", false, ""},
+		{"valid large value", "1000000", false, ""},
+		{"invalid negative", "-1", true, "prime.max-memory-chars must be a non-negative integer (0 = unlimited), got \"-1\""},
+		{"invalid non-integer", "abc", true, "prime.max-memory-chars must be a non-negative integer (0 = unlimited), got \"abc\""},
+		{"invalid float", "3.5", true, "prime.max-memory-chars must be a non-negative integer (0 = unlimited), got \"3.5\""},
+		{"invalid empty", "", true, "prime.max-memory-chars must be a non-negative integer (0 = unlimited), got \"\""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateYamlConfigValue("prime.max-memory-chars", tt.value)
+			if tt.expectErr {
+				if err == nil {
+					t.Errorf("expected error for value %q, got nil", tt.value)
+				} else if err.Error() != tt.errMsg {
+					t.Errorf("expected error %q, got %q", tt.errMsg, err.Error())
+				}
+			} else {
+				if err != nil {
+					t.Errorf("unexpected error for value %q: %v", tt.value, err)
+				}
+			}
+		})
+	}
+}
+
 func TestIsSecretKey(t *testing.T) {
 	tests := []struct {
 		key      string

--- a/website/docs/cli-reference/prime.md
+++ b/website/docs/cli-reference/prime.md
@@ -29,6 +29,17 @@ Config options:
 	- Use --export to dump the default content for customization.
 	- Use --memories-only for hook contexts that should inject only persistent memories.
 
+Memory injection caps:
+	Large memory sets can exceed what a session-start hook host will ingest,
+	and hosts truncate silently. Cap what prime injects with --max-memories N
+	and/or --max-memory-chars N (or the prime.max-memories /
+	prime.max-memory-chars config keys; an explicit flag wins, and an explicit
+	0 forces unlimited). Caps apply at whole-memory boundaries, at least one
+	memory is always emitted, and a banner ahead of the entries reports how
+	many were elided and how to browse the rest with bd memories.
+	--max-memory-chars caps the total bytes of the injected memory entries;
+	the section header and elision banner are excluded from the budget.
+
 ```
 bd prime [flags]
 ```
@@ -36,10 +47,12 @@ bd prime [flags]
 **Flags:**
 
 ```
-      --export          Output default content (ignores PRIME.md override)
-      --full            Force full CLI output (ignore MCP detection)
-      --hook-json       Wrap output in the SessionStart hook JSON envelope (Claude Code, Gemini CLI, Codex)
-      --mcp             Force MCP mode (minimal output)
-      --memories-only   Output only persistent memories for compact hook contexts
-      --stealth         Stealth mode (no git operations, flush only)
+      --export                 Output default content (ignores PRIME.md override)
+      --full                   Force full CLI output (ignore MCP detection)
+      --hook-json              Wrap output in the SessionStart hook JSON envelope (Claude Code, Gemini CLI, Codex)
+      --max-memories int       Cap injected persistent memories to N entries (0 = unlimited; falls back to the prime.max-memories config key)
+      --max-memory-chars int   Cap the total bytes of injected memory entries, at whole-memory boundaries; section header and banner are not counted (0 = unlimited; falls back to the prime.max-memory-chars config key)
+      --mcp                    Force MCP mode (minimal output)
+      --memories-only          Output only persistent memories for compact hook contexts
+      --stealth                Stealth mode (no git operations, flush only)
 ```


### PR DESCRIPTION
## Problem

`bd prime` injects every persistent memory, whole, in alphabetical key order, with no cap. SessionStart hook hosts cap what they ingest (Claude Code persists a tool result around ~25K tokens and previews far less), so a large memory set silently loses everything past the cut — and because the order is alphabetical, whether a memory survives is an accident of its key's first letter, unrelated to importance or freshness.

Real numbers from the workspace that hit this: 102 memories, ~160KB / ~40K tokens of `--memories-only` output. Roughly 80% of memories were never ingested on any session start. It surfaced as agents "forgetting" in-flight handoffs after every compaction — the fresh session declared all-quiet while two active threads sat stalled, their context sitting past the truncation line. The existing truncation directive ("read the full persisted hook output") mitigates but asks a fresh session to read 40K tokens to find the one thing blocked on it.

## Change

Two opt-in caps, resolved flag-over-config so a repo can adopt them without editing every hook line:

| Flag | Config key | Meaning |
|---|---|---|
| `--max-memories N` | `prime.max-memories` | at most N memories injected |
| `--max-memory-chars N` | `prime.max-memory-chars` | total injected entry characters ≤ N |

- Caps apply at **whole-memory boundaries**; at least one memory is always emitted (a single oversized memory exceeds the char budget rather than vanishing).
- When anything is elided, a **banner ahead of the entries** — where host truncation cannot hide it — reports how many were cut, which cap did it, and points at `bd memories <keyword>` / `bd remember <key>` for the rest. A capped prime never silently drops context.
- An explicit flag value of `0` forces unlimited over a configured cap.
- Defaults (no flag, no config) leave output **byte-identical** to today, verified against a 110-memory store in both `--memories-only` and full prime modes.
- The config keys are registered in `YamlOnlyKeys` (prime can run before the database is reachable, so they must be readable from `config.yaml`) and in the recognized-keys list, so `bd config set prime.max-memories 20` routes to yaml and reads back without warnings.
- Both caps apply in compact (MCP) mode too, with a matching one-line elision note.

`formatMemoriesForPrime` is split so the selection/formatting is a pure function (`renderPrimeMemories`) with direct unit tests; the store-fetch half is unchanged.

## Testing

- 7 new tests (`cmd/bd/prime_memory_caps_test.go`): uncapped legacy shape, count cap + banner-precedes-entries, char cap at whole-memory boundary, oversized-first-memory floor, compact capped/uncapped shapes, and the full flag/config/explicit-zero/negative-clamp resolution matrix.
- All `Prime*` tests pass; `internal/config` suite passes.
- Full `cmd/bd` suite: one failure, `TestIsBackupAutoEnabled`, which fails identically on a pristine `origin/main` checkout in the same environment (env-sensitive, unrelated).
- Behavioral verification on a seeded 110-memory (~158KB) store: byte-identical uncapped output vs a main-built binary; `--max-memories 15` → 22.2KB; `--max-memory-chars 25000` → 25.1KB; config-key path, flag-beats-config, and `--hook-json` envelope validity (banner arrives inside `additionalContext`).
- A `.beads/PRIME.md` override continues to win over everything, so repos curating their own resume-head are unaffected.

## Non-goals / follow-up

Recency- or pinned-first selection would be strictly better than alphabetical-capped, but the memory store keeps no per-key timestamps (memories are rows in the `config` table), so it needs sidecar metadata — left as follow-up so this stays small and backward-compatible.

While testing I also hit a pre-existing, unrelated bug: `bd config unset` of yaml-routed dotted keys (e.g. `backup.git-push`) reports success but leaves the nested yaml entry live — reproducible on main with keys that predate this PR. Filing separately.
