### PR TITLE
docs(changelog): [1.1.0] release notes (v53-line stable prep)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0] - 2026-07-04
+
+First stable release of the 1.1.0 line. It consolidates everything from
+[1.1.0-rc.1] and [1.1.0-rc.2] (see those sections below for the full feature
+set) plus the post-rc.2 migration-recovery fixes listed here. The theme of
+1.1.0 is a safe schema-migration and upgrade path: it repairs the v52/v53
+drift classes that broke real-world rc.1/rc.2 upgrades, makes an interrupted
+migration recoverable in-tool instead of a dead end, and turns the
+remote-migrate gate from a blunt block into a state-aware one.
+
+### Upgrade Notes
+
+- **Back up before migrating** (`bd export --all -o backup.jsonl`) before
+  running `bd migrate` on an older, especially remote-backed, database. The
+  fixes below repair databases that reached a migration with drifted state;
+  an export is cheap insurance while such drift is being repaired.
+
 ### Changed
 
 - **The state-aware remote-migrate gate is now on by default.** rc.2 shipped
@@ -18,6 +35,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and content skew still stops for a human. Set `BD_SMART_GATE=0` to opt out
   and restore the unconditional block
   ([#4516](https://github.com/gastownhall/beads/issues/4516)).
+
+### Fixed
+
+- **A failed v53 migration no longer traps the database, and the v53 repair
+  now covers `wisp_dependencies` split-column drift.** rc.2 repaired the
+  `issues` rig columns, but a database coming from schema v49 could still fail
+  v53 when its `wisp_dependencies` table was missing the split target columns
+  (`depends_on_issue_id`, `depends_on_wisp_id`, `depends_on_external`) — and a
+  half-applied v53 then bricked every subsequent command on open
+  ([#4555](https://github.com/gastownhall/beads/issues/4555)). The migration
+  runner now adds and backfills the missing split columns before v53, and a
+  narrow recovery gate lets an already-failed-v53 database self-heal on the
+  next open — including the `issue_snapshots` / `compaction_snapshots` tables
+  that migration 0051 leaves dirty during a single-pass v49→v53 upgrade
+  ([#4558](https://github.com/gastownhall/beads/pull/4558)).
+- **A dirty working set no longer deadlocks migration recovery in embedded
+  mode.** Every store open runs the migration, which correctly refuses to
+  alter tables that have uncommitted working-set changes — but the documented
+  recovery (commit the working set) is itself a command that opens the store
+  and hits the same refusal, a deadlock with no in-tool escape
+  ([#4566](https://github.com/gastownhall/beads/issues/4566)). `bd dolt commit`
+  and `bd vc commit` now open past that guard, commit at the current schema,
+  after which a normal `bd migrate` applies cleanly; the refusal message now
+  names the recovery path
+  ([#4567](https://github.com/gastownhall/beads/pull/4567)).
 
 ## [1.1.0-rc.2] - 2026-07-02
 


### PR DESCRIPTION
## Why

Release-prep for **v1.1.0 stable**, authored ahead of the version bump per `RELEASING.md` ("update CHANGELOG FIRST"). This adds the `[1.1.0]` section so the release molecule / tag can run against a changelog that already reflects the final scope.

## What

Adds `## [1.1.0]` at the top of `CHANGELOG.md`, consolidating [1.1.0-rc.1] and [1.1.0-rc.2] and logging the two post-rc.2 migration-recovery fixes that landed on `main` after the rc.2 tag:

- **Failed v53 migration no longer traps the DB**, and the v53 repair now covers `wisp_dependencies` split-column drift + the `issue_snapshots`/`compaction_snapshots` recovery case for single-pass v49→v53 upgrades (#4555, #4558).
- **Dirty working set no longer deadlocks migration recovery** in embedded mode — `bd dolt commit` / `bd vc commit` open past the guard so the working set can be committed at the current schema (#4566, #4567).

Also folds the previously-`[Unreleased]` state-aware remote-migrate gate default (#4516) into `[1.1.0]`.

## Scope / not in this PR

- **No version bump.** `1.1.0-rc.2 → 1.1.0` version strings, the docs snapshot, and the `v1.1.0` tag are left to the release tooling (`bd mol wisp beads-release` / `update-versions.sh`), which is the tested path for the mechanical + credentialed steps.
- Cut from the **v53 line** (`main` @ 527ea0c23). The leasing stack + schema v54 (#4537) is intentionally held for the next release so 1.1.0 ships lean after a migration-heavy RC cycle.

## Validation

- Content-only change to `CHANGELOG.md`; entries mirror the existing rc.2 section's format and link every referenced issue/PR.
- Release stability gate on `main` (pre-#4567): `make test-upgrade` 6/6 scenarios, `make test-regression` 93/0. Both recovery fixes' own CI (incl. the embedded end-to-end recovery test) were green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0114QKP3RAfhHHdtsKhi2F7N
