### PR TITLE
docs(release): harden Homebrew formula procedure

### DIFF
--- a/.beads/formulas/beads-release.formula.toml
+++ b/.beads/formulas/beads-release.formula.toml
@@ -7,7 +7,7 @@
 # Phases:
 #   1. Prep & Push: preflight -> push-tag (polecat work)
 #   2. Gate: await-ci (async wait for release.yml)
-#   3. Verify: verify-github, verify-npm, verify-pypi (parallel)
+#   3. Verify: verify-github, verify-npm, verify-pypi, verify-homebrew-core (parallel)
 #   4. Install: local-install -> cleanup-stale-dolt-orphans -> release-complete
 
 formula = "beads-release"
@@ -26,7 +26,7 @@ Gate (Async Wait):
   5. await-ci: Gate on GitHub Actions release.yml completion
 
 Phase 2 (Parallel Verification):
-  6. Verify GitHub release, npm package, PyPI package (concurrent)
+  6. Verify GitHub release, npm package, PyPI package, Homebrew core formula (concurrent)
 
 Phase 3 (Installation):
   7. Local installation update
@@ -726,6 +726,66 @@ Should show {{version}}.
 Note: PyPI may have a small propagation delay (1-2 min).
 """
 
+[[steps]]
+id = "verify-homebrew-core"
+title = "Verify Homebrew core formula"
+needs = ["await-ci"]
+description = """
+Confirm Homebrew core has the stable formula update.
+
+Release candidates are not published to Homebrew. If `{{version}}` contains a
+hyphen, record that Homebrew intentionally remains on the latest stable release
+and skip the rest of this step.
+
+Stable releases:
+
+1. Check whether Homebrew already opened the canonical bump PR:
+   ```bash
+   gh pr list \
+     --repo Homebrew/homebrew-core \
+     --search "beads {{version}} in:title" \
+     --state all
+   ```
+
+2. If a BrewTestBot or `brew bump-formula-pr` PR already exists, track that PR.
+   Do not open a duplicate manual PR. Do not push to the PR branch before
+   Homebrew's bottle commits are pushed.
+
+3. If no PR exists, open it with Homebrew's bump tool:
+   ```bash
+   brew bump-formula-pr \
+     --url="https://github.com/gastownhall/beads/archive/refs/tags/v{{version}}.tar.gz" \
+     beads
+   ```
+
+   This computes the source checksum and lets Homebrew/BrewTestBot manage the
+   bottle block. Do not remove or hand-edit the bottle block.
+
+4. If a manual PR is unavoidable, fill in Homebrew's current PR template before
+   opening or editing the PR:
+   ```bash
+   gh api repos/Homebrew/homebrew-core/contents/.github/PULL_REQUEST_TEMPLATE.md \
+     -H 'Accept: application/vnd.github.raw'
+   ```
+
+   Do not leave the checklist/body blank. An incomplete or stale template causes
+   Homebrew automation to close the PR.
+
+5. Verify the merged formula on `Homebrew/homebrew-core@main`:
+   ```bash
+   gh api '/repos/Homebrew/homebrew-core/contents/Formula/b/beads.rb?ref=main' \
+     -H 'Accept: application/vnd.github.raw' | tee /tmp/homebrew-beads.rb
+
+   grep -F 'homepage "https://github.com/gastownhall/beads"' /tmp/homebrew-beads.rb
+   grep -F 'url "https://github.com/gastownhall/beads/archive/refs/tags/v{{version}}.tar.gz"' /tmp/homebrew-beads.rb
+   grep -F 'bottle do' /tmp/homebrew-beads.rb
+   ```
+
+6. Record the merged Homebrew PR on the release tracker. If a duplicate manual
+   PR was closed by Homebrew automation after the canonical PR merged, leave it
+   closed and note which PR is canonical.
+"""
+
 # =============================================================================
 # Phase 3: Installation (Fan-in)
 # =============================================================================
@@ -733,7 +793,7 @@ Note: PyPI may have a small propagation delay (1-2 min).
 [[steps]]
 id = "local-install"
 title = "Update local installation"
-needs = ["verify-github", "verify-npm", "verify-pypi"]
+needs = ["verify-github", "verify-npm", "verify-pypi", "verify-homebrew-core"]
 description = """
 Update local bd to the new version.
 
@@ -741,7 +801,7 @@ Step 1: Install release binary
 
 Option A - Homebrew:
 ```bash
-brew upgrade bd
+brew upgrade beads
 ```
 
 Option B - Install script:

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -104,8 +104,8 @@ This master script automates the **entire release process**:
 3. ✅ Bumps version in all files
 4. ✅ Commits and pushes version bump
 5. ✅ Creates and pushes git tag
-6. ✅ Updates Homebrew formula
-7. ✅ Upgrades local brew installation
+6. ✅ Verifies or opens the Homebrew core formula PR
+7. ✅ Upgrades local Homebrew installation
 8. ✅ Verifies everything works
 
 **After this script completes, your system is running the new version!**
@@ -141,7 +141,8 @@ The script provides colorful, step-by-step progress output:
 After the script finishes:
 - GitHub Actions builds binaries for all platforms (~5 minutes)
 - PyPI package is published automatically
-- Users can `brew upgrade beads` to get the new version
+- Homebrew core formula is verified or tracked through its canonical PR
+- Users can `brew upgrade beads` to get the new version after Homebrew merges
 - GitHub Release is created with binaries and changelog
 
 ---

--- a/scripts/release_script_test.go
+++ b/scripts/release_script_test.go
@@ -116,6 +116,60 @@ func TestReleaseFormulaCleanupStaleDoltOrphansHandlesLocalModeWithoutJQ(t *testi
 	}
 }
 
+func TestReleaseFormulaHomebrewCoreProcedureCoversTemplateAndBottles(t *testing.T) {
+	repoRoot := sourceRepoRoot(t)
+	formulaPath := filepath.Join(repoRoot, ".beads", "formulas", "beads-release.formula.toml")
+	if _, err := formula.NewParser().ParseFile(formulaPath); err != nil {
+		t.Fatalf("beads-release formula does not parse: %v", err)
+	}
+
+	homebrewStep := releaseFormulaStep(t, formulaPath, `id = "verify-homebrew-core"`)
+	for _, want := range []string{
+		"brew bump-formula-pr",
+		"--url=\"https://github.com/gastownhall/beads/archive/refs/tags/v{{version}}.tar.gz\"",
+		"Homebrew's current PR template",
+		"Do not remove or hand-edit the bottle block.",
+		"Do not open a duplicate manual PR.",
+		"homepage \"https://github.com/gastownhall/beads\"",
+		"Homebrew/homebrew-core@main",
+	} {
+		if !strings.Contains(homebrewStep, want) {
+			t.Fatalf("verify-homebrew-core step missing %q:\n%s", want, homebrewStep)
+		}
+	}
+
+	localInstallStep := releaseFormulaStep(t, formulaPath, `id = "local-install"`)
+	for _, want := range []string{
+		`needs = ["verify-github", "verify-npm", "verify-pypi", "verify-homebrew-core"]`,
+		"brew upgrade beads",
+	} {
+		if !strings.Contains(localInstallStep, want) {
+			t.Fatalf("local-install step missing %q:\n%s", want, localInstallStep)
+		}
+	}
+	if strings.Contains(localInstallStep, "brew upgrade bd") {
+		t.Fatalf("local-install step still references old Homebrew formula name:\n%s", localInstallStep)
+	}
+}
+
+func releaseFormulaStep(t *testing.T, formulaPath, marker string) string {
+	t.Helper()
+	data, err := os.ReadFile(formulaPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(data)
+	start := strings.Index(text, marker)
+	if start < 0 {
+		t.Fatalf("release formula step marker not found: %s", marker)
+	}
+	step := text[start:]
+	if next := strings.Index(step[len(marker):], "\n[[steps]]"); next >= 0 {
+		step = step[:len(marker)+next]
+	}
+	return step
+}
+
 func copyReleaseScriptFixture(t *testing.T) string {
 	t.Helper()
 


### PR DESCRIPTION
## Why

The v1.1.0 release follow-up produced a manual Homebrew/homebrew-core PR that Homebrew automation closed for an incomplete template, while the canonical BrewTestBot PR handled the real formula update. The release workflow should make the correct path explicit before the next stable release.

## What changed

- Add a `verify-homebrew-core` step to the checked-in `beads-release` formula.
- Document the canonical `brew bump-formula-pr` flow, duplicate-PR handling, current Homebrew PR template check, and bottle-block rules.
- Make local installation wait for Homebrew verification and use `brew upgrade beads`.
- Add a targeted release-script test so the Homebrew procedure does not regress.

## Verification

- `go test ./scripts -run TestReleaseFormulaHomebrewCoreProcedureCoversTemplateAndBottles`
- `git diff --check`
- `go test ./scripts` was also tried on Windows and hit an existing path conversion failure in older Bash-invoking tests before reaching this change.

_codex-gpt-5.5-high on behalf of matt wilkie_
