### PR TITLE
feat(schema): name the smart-gate fallback reason on the blunt remote-migrate block

### DIFF
--- a/cmd/bd/remote_migrate_gate.go
+++ b/cmd/bd/remote_migrate_gate.go
@@ -53,6 +53,14 @@ func handleRemoteMigrateGateJSON(e *schema.RemoteMigrateGateError) {
 			gate["observed"] = fmt.Sprintf("this clone and the remote applied different content for migration(s) %s — already forked", schema.FormatMigrationVersions(e.SkewVersions))
 			gate["expected"] = "pick one canonical clone and re-bootstrap the others (data-loss decision)"
 			gate["skew_versions"] = e.SkewVersions
+		default:
+			// Blunt #4515 stop — name WHY the smart gate (#4516) could not do
+			// better (gastownhall/beads#4551 follow-up), so an agent/operator can
+			// tell "unreadable remote state" apart from "below the convergence
+			// floor" apart from "opted out" apart from "unparseable BD_SMART_GATE".
+			if e.FallbackReason != "" {
+				gate["fallback_reason"] = e.FallbackReason
+			}
 		}
 		m["remote_migrate_gate"] = gate
 	}

--- a/cmd/bd/remote_migrate_gate_test.go
+++ b/cmd/bd/remote_migrate_gate_test.go
@@ -107,3 +107,62 @@ func TestHandleRemoteMigrateGateJSON_Shape(t *testing.T) {
 		t.Errorf("migrate option must contain the escape command %q", gate.EscapeHint())
 	}
 }
+
+// TestHandleRemoteMigrateGateJSON_FallbackReason verifies the blunt-block JSON
+// carries the machine-readable fallback_reason field (gastownhall/beads#4551
+// follow-up), and that the smart-tailored adopt/fork-skew decisions never gain
+// it — those already explain themselves via "decision".
+func TestHandleRemoteMigrateGateJSON_FallbackReason(t *testing.T) {
+	captureJSON := func(gate *schema.RemoteMigrateGateError) map[string]interface{} {
+		origStderr := os.Stderr
+		r, w, pipeErr := os.Pipe()
+		if pipeErr != nil {
+			t.Fatal(pipeErr)
+		}
+		os.Stderr = w
+		handleRemoteMigrateGateJSON(gate)
+		_ = w.Close()
+		os.Stderr = origStderr
+
+		var buf bytes.Buffer
+		if _, err := io.Copy(&buf, r); err != nil {
+			t.Fatal(err)
+		}
+		_ = r.Close()
+
+		var parsed map[string]interface{}
+		if err := json.Unmarshal(buf.Bytes(), &parsed); err != nil {
+			t.Fatalf("json.Unmarshal stderr: %v\nstderr was: %s", err, buf.String())
+		}
+		obj, ok := parsed["remote_migrate_gate"].(map[string]interface{})
+		if !ok {
+			t.Fatalf("remote_migrate_gate key missing or wrong type: %T", parsed["remote_migrate_gate"])
+		}
+		return obj
+	}
+
+	t.Run("blunt block carries fallback_reason", func(t *testing.T) {
+		gate := &schema.RemoteMigrateGateError{
+			CurrentVersion: 48, LatestVersion: 50, Pending: 2,
+			FallbackReason: "below-convergence-floor",
+		}
+		obj := captureJSON(gate)
+		if got, ok := obj["fallback_reason"].(string); !ok || got != "below-convergence-floor" {
+			t.Errorf("fallback_reason = %v, want %q", obj["fallback_reason"], "below-convergence-floor")
+		}
+		if _, ok := obj["decision"]; ok {
+			t.Errorf("blunt block must not carry a decision key, got %v", obj["decision"])
+		}
+	})
+
+	t.Run("adopt decision never carries fallback_reason", func(t *testing.T) {
+		gate := &schema.RemoteMigrateGateError{
+			CurrentVersion: 48, LatestVersion: 50, Pending: 2,
+			Decision: "adopt",
+		}
+		obj := captureJSON(gate)
+		if _, ok := obj["fallback_reason"]; ok {
+			t.Errorf("adopt decision must not carry fallback_reason, got %v", obj["fallback_reason"])
+		}
+	})
+}

--- a/internal/storage/schema/remote_migrate_gate.go
+++ b/internal/storage/schema/remote_migrate_gate.go
@@ -46,11 +46,47 @@ type RemoteMigrateGateError struct {
 	// SkewVersions lists the migration versions whose content diverged between
 	// this clone and the remote (Decision == "fork-skew").
 	SkewVersions []int
+
+	// FallbackReason names why the smart gate (#4516) could not do better than
+	// this blunt stop, when Decision is empty (gastownhall/beads#4551
+	// follow-up: every fallback path used to produce the byte-identical #4515
+	// block with no way to tell them apart). See the fallbackReason* constants
+	// for the recognized values. Always empty when Decision is "adopt" or
+	// "fork-skew" — those stops already explain themselves.
+	FallbackReason string
+	// UnrecognizedSmartGateEnv carries a BD_SMART_GATE value that was set but
+	// not understood (only boolean values are recognized), mirroring
+	// UnrecognizedEnv above but for the smart gate's own opt-out variable, so
+	// a typo'd BD_SMART_GATE is surfaced instead of only its silent effect
+	// (the gate staying enabled by default). Set only when
+	// FallbackReason == fallbackReasonUnparseableEnv.
+	UnrecognizedSmartGateEnv string
 }
 
 const (
 	gateDecisionAdopt    = "adopt"
 	gateDecisionForkSkew = "fork-skew"
+)
+
+// fallbackReason* enumerates why the smart gate (#4516) fell back to the
+// blunt #4515 stop instead of resolving or tailoring it. Exactly one applies
+// per blunt stop (gastownhall/beads#4551 follow-up).
+const (
+	// fallbackReasonUnreadableState: the remote's cached schema state could
+	// not be read (no cached ref, a stale/pre-content_hash one, or the cached
+	// remote is simply behind this clone and so not a safe first-mover).
+	fallbackReasonUnreadableState = "unreadable-remote-state"
+	// fallbackReasonBelowFloor: remote and local agree, but a legacy
+	// non-deterministic migration is still pending (below the convergence
+	// floor the smart gate trusts for an unattended first-mover migrate).
+	fallbackReasonBelowFloor = "below-convergence-floor"
+	// fallbackReasonOptedOut: the operator disabled the smart gate outright
+	// (BD_SMART_GATE=0).
+	fallbackReasonOptedOut = "opted-out"
+	// fallbackReasonUnparseableEnv: BD_SMART_GATE was set but not a
+	// recognized boolean, so the gate stayed enabled by default (same as
+	// unset) but still could not resolve this particular stop.
+	fallbackReasonUnparseableEnv = "unparseable-env"
 )
 
 func (e *RemoteMigrateGateError) Error() string {
@@ -86,12 +122,35 @@ func FormatMigrationVersions(versions []int) string {
 // UserMessage returns the full multi-line error block for terminal output.
 func (e *RemoteMigrateGateError) UserMessage() string {
 	msg := e.Error() + "\n" + e.userBody()
+	msg += e.fallbackReasonNote()
 	if e.UnrecognizedEnv != "" {
 		msg += "\n" +
 			"  Note: " + AllowRemoteMigrateEnv + "=" + e.UnrecognizedEnv + " is set but was not recognized —\n" +
 			"  use " + AllowRemoteMigrateEnv + "=1 to unlock.\n"
 	}
 	return msg
+}
+
+// fallbackReasonNote returns the self-explaining line naming why the smart
+// gate (#4516) fell back to this blunt stop instead of resolving or
+// tailoring it (gastownhall/beads#4551 follow-up). Empty when FallbackReason
+// is unset — the smart-tailored adopt and fork-skew stops never set it and
+// already explain themselves in userBody.
+func (e *RemoteMigrateGateError) fallbackReasonNote() string {
+	var why string
+	switch e.FallbackReason {
+	case fallbackReasonUnreadableState:
+		why = "it could not read the remote's cached schema state (no cached ref, a stale/pre-content_hash one, or the cached remote is behind this clone)"
+	case fallbackReasonBelowFloor:
+		why = "this database is below the convergence floor — a legacy non-deterministic migration is still pending, so an unattended first-mover migrate is not safe to trust"
+	case fallbackReasonOptedOut:
+		why = "it is disabled (" + SmartGateEnv + "=0)"
+	case fallbackReasonUnparseableEnv:
+		why = SmartGateEnv + "=" + e.UnrecognizedSmartGateEnv + " is set but was not recognized (only boolean values enable/disable it), so it stayed enabled by default but still could not resolve this stop"
+	default:
+		return ""
+	}
+	return "\n  Smart gate (#4516): " + why + ".\n"
 }
 
 // userBody returns the decision-specific guidance block. The default (blunt
@@ -322,6 +381,15 @@ func checkRemoteMigrateGate(ctx context.Context, db DBConn, remoteName string, e
 	// verdicts fall through to the blunt #4515 block below, so opting out of
 	// smart mode (or an unreadable remote ref) is always at least as safe as
 	// before.
+	//
+	// fallbackReason/unrecognizedSmartGateEnv record WHY, for the blunt block
+	// below: an operator hitting it otherwise cannot tell "couldn't read the
+	// remote's cached state" apart from "below the convergence floor" apart
+	// from "opted out" apart from "unparseable BD_SMART_GATE value" — every
+	// path used to produce the byte-identical #4515 text (gastownhall/beads#4551
+	// follow-up).
+	fallbackReason := ""
+	unrecognizedSmartGateEnv := ""
 	if SmartGateEnabled() {
 		decision, skew := routeSmartGate(ctx, db, current, remoteName)
 		switch decision {
@@ -345,16 +413,30 @@ func checkRemoteMigrateGate(ctx context.Context, db DBConn, remoteName string, e
 				Decision:        gateDecisionForkSkew,
 				SkewVersions:    skew,
 			}
-		case smartUndetermined, smartBelowFloor:
-			// fall through to the blunt block
+		case smartBelowFloor:
+			fallbackReason = fallbackReasonBelowFloor
+		case smartUndetermined:
+			fallbackReason = fallbackReasonUnreadableState
 		}
+		// An unparseable BD_SMART_GATE value defaults to enabled (same as
+		// unset), so routing above still ran — but it is a more actionable
+		// fact for the operator than the technical routing outcome, so it
+		// takes priority as the surfaced reason.
+		if envState, envValue := smartGateEnvValue(); envState == smartGateEnvUnparseable {
+			fallbackReason = fallbackReasonUnparseableEnv
+			unrecognizedSmartGateEnv = envValue
+		}
+	} else {
+		fallbackReason = fallbackReasonOptedOut
 	}
 
 	return &RemoteMigrateGateError{
-		CurrentVersion:  current,
-		LatestVersion:   latest,
-		Pending:         len(pending),
-		UnrecognizedEnv: unrecognizedEnv,
+		CurrentVersion:           current,
+		LatestVersion:            latest,
+		Pending:                  len(pending),
+		UnrecognizedEnv:          unrecognizedEnv,
+		FallbackReason:           fallbackReason,
+		UnrecognizedSmartGateEnv: unrecognizedSmartGateEnv,
 	}
 }
 

--- a/internal/storage/schema/smart_remote_migrate_gate.go
+++ b/internal/storage/schema/smart_remote_migrate_gate.go
@@ -48,20 +48,47 @@ const smartGateDefaultRemote = "origin"
 // allowlist so the two cannot drift if a new entry is ever added.
 const LastNonDeterministicMigration = 43
 
+// smartGateEnvState classifies the raw BD_SMART_GATE value.
+type smartGateEnvState int
+
+const (
+	smartGateEnvUnset smartGateEnvState = iota
+	smartGateEnvEnabled
+	smartGateEnvDisabled
+	// smartGateEnvUnparseable: set but strconv.ParseBool rejected it. Treated
+	// the same as smartGateEnvEnabled by SmartGateEnabled (the default holds),
+	// but callers building the fallback-block message (gastownhall/beads#4551
+	// follow-up) still want to tell the operator their value was ignored.
+	smartGateEnvUnparseable
+)
+
+// smartGateEnvValue reads and classifies BD_SMART_GATE, returning the raw
+// value alongside the classification so a caller can quote it back to the
+// operator. Split out of SmartGateEnabled so "unset"/"valid true" (silently
+// fine) can be told apart from "set but unparseable" (worth a note) without
+// re-parsing.
+func smartGateEnvValue() (smartGateEnvState, string) {
+	v := os.Getenv(SmartGateEnv)
+	if v == "" {
+		return smartGateEnvUnset, ""
+	}
+	on, err := strconv.ParseBool(v)
+	if err != nil {
+		return smartGateEnvUnparseable, v
+	}
+	if on {
+		return smartGateEnvEnabled, v
+	}
+	return smartGateEnvDisabled, v
+}
+
 // SmartGateEnabled reports whether the smart gate is active. It defaults to
 // true; the operator opts out with BD_SMART_GATE=0 (any parseable boolean
 // false). An unparseable value keeps the default rather than silently
 // disabling the gate.
 func SmartGateEnabled() bool {
-	v := os.Getenv(SmartGateEnv)
-	if v == "" {
-		return true
-	}
-	on, err := strconv.ParseBool(v)
-	if err != nil {
-		return true
-	}
-	return on
+	state, _ := smartGateEnvValue()
+	return state != smartGateEnvDisabled
 }
 
 // smartGateDecision is the routing verdict for a remote-backed database with

--- a/internal/storage/schema/smart_remote_migrate_gate_test.go
+++ b/internal/storage/schema/smart_remote_migrate_gate_test.go
@@ -122,6 +122,12 @@ func TestSmartGateRouting(t *testing.T) {
 		if gateErr.Decision != "" {
 			t.Errorf("remote-behind should fall back to the blunt block (Decision \"\"), got %q", gateErr.Decision)
 		}
+		if gateErr.FallbackReason != fallbackReasonUnreadableState {
+			t.Errorf("FallbackReason = %q, want %q", gateErr.FallbackReason, fallbackReasonUnreadableState)
+		}
+		if !strings.Contains(gateErr.UserMessage(), "could not read the remote's cached schema state") {
+			t.Errorf("UserMessage should explain the unreadable-state fallback:\n%s", gateErr.UserMessage())
+		}
 		if err := mock.ExpectationsWereMet(); err != nil {
 			t.Fatalf("unmet expectations: %v", err)
 		}
@@ -194,6 +200,12 @@ func TestSmartGateRouting(t *testing.T) {
 		if gateErr.Decision != "" {
 			t.Errorf("below-floor should fall back to the blunt block (Decision \"\"), got %q", gateErr.Decision)
 		}
+		if gateErr.FallbackReason != fallbackReasonBelowFloor {
+			t.Errorf("FallbackReason = %q, want %q", gateErr.FallbackReason, fallbackReasonBelowFloor)
+		}
+		if !strings.Contains(gateErr.UserMessage(), "below the convergence floor") {
+			t.Errorf("UserMessage should explain the below-floor fallback:\n%s", gateErr.UserMessage())
+		}
 		if err := mock.ExpectationsWereMet(); err != nil {
 			t.Fatalf("unmet expectations: %v", err)
 		}
@@ -220,6 +232,9 @@ func TestSmartGateRouting(t *testing.T) {
 		if gateErr.Decision != "" {
 			t.Errorf("uncached remote ref should fall back to the blunt block, got Decision %q", gateErr.Decision)
 		}
+		if gateErr.FallbackReason != fallbackReasonUnreadableState {
+			t.Errorf("FallbackReason = %q, want %q", gateErr.FallbackReason, fallbackReasonUnreadableState)
+		}
 		if err := mock.ExpectationsWereMet(); err != nil {
 			t.Fatalf("unmet expectations: %v", err)
 		}
@@ -235,8 +250,12 @@ func TestSmartGateRouting(t *testing.T) {
 			WillReturnRows(sqlmock.NewRows([]string{"version", "content_hash"}))
 
 		err := CheckRemoteMigrateGate(context.Background(), db)
-		if !IsRemoteMigrateGateError(err) {
+		var gateErr *RemoteMigrateGateError
+		if !errors.As(err, &gateErr) {
 			t.Fatalf("expected gate error, got %v", err)
+		}
+		if gateErr.FallbackReason != fallbackReasonUnreadableState {
+			t.Errorf("FallbackReason = %q, want %q", gateErr.FallbackReason, fallbackReasonUnreadableState)
 		}
 		if err := mock.ExpectationsWereMet(); err != nil {
 			t.Fatalf("unmet expectations: %v", err)
@@ -275,9 +294,53 @@ func TestSmartGateRouting(t *testing.T) {
 		if gateErr.Decision != "" {
 			t.Errorf("smart disabled must produce the blunt block, got Decision %q", gateErr.Decision)
 		}
+		if gateErr.FallbackReason != fallbackReasonOptedOut {
+			t.Errorf("FallbackReason = %q, want %q", gateErr.FallbackReason, fallbackReasonOptedOut)
+		}
+		if !strings.Contains(gateErr.UserMessage(), SmartGateEnv+"=0") {
+			t.Errorf("UserMessage should explain the opted-out fallback:\n%s", gateErr.UserMessage())
+		}
 		// mock would error if the smart reads had been issued (none expected).
 		if err := mock.ExpectationsWereMet(); err != nil {
 			t.Fatalf("unmet expectations (smart reads must not run when opted out): %v", err)
+		}
+	})
+
+	t.Run("unparseable BD_SMART_GATE value: gate stays enabled but the blunt block names the parse failure", func(t *testing.T) {
+		if floor < 2 {
+			t.Skip("floor too low to construct a below-floor case")
+		}
+		t.Setenv(SmartGateEnv, "banana")
+		t.Setenv(AllowRemoteMigrateEnv, "0")
+		db, mock, _ := sqlmock.New()
+		defer db.Close()
+		current := floor - 1
+		expectSmartFiringGate(mock, current)
+		hashes := map[int]string{current: "h"}
+		// Unparseable defaults to enabled, so smart routing still runs (same
+		// reads as the below-floor case above).
+		expectSmartRemoteRead(mock, hashes, hashes)
+
+		err := CheckRemoteMigrateGate(context.Background(), db)
+		var gateErr *RemoteMigrateGateError
+		if !errors.As(err, &gateErr) {
+			t.Fatalf("expected gate error, got %v", err)
+		}
+		if gateErr.Decision != "" {
+			t.Errorf("unparseable env should still fall back to the blunt block (Decision \"\"), got %q", gateErr.Decision)
+		}
+		if gateErr.FallbackReason != fallbackReasonUnparseableEnv {
+			t.Errorf("FallbackReason = %q, want %q (takes priority over the underlying technical routing reason)", gateErr.FallbackReason, fallbackReasonUnparseableEnv)
+		}
+		if gateErr.UnrecognizedSmartGateEnv != "banana" {
+			t.Errorf("UnrecognizedSmartGateEnv = %q, want %q", gateErr.UnrecognizedSmartGateEnv, "banana")
+		}
+		msg := gateErr.UserMessage()
+		if !strings.Contains(msg, SmartGateEnv+"=banana") || !strings.Contains(msg, "was not recognized") {
+			t.Errorf("UserMessage should quote the unparseable value:\n%s", msg)
+		}
+		if err := mock.ExpectationsWereMet(); err != nil {
+			t.Fatalf("unmet expectations: %v", err)
 		}
 	})
 


### PR DESCRIPTION
## Why

#4551 turned the smart remote-migrate gate on by default, but every fallback path still degrades to the blunt block whose message is byte-identical to #4515 - it never says WHY the smart gate could not help. #4551's own rationale applies recursively: a routing decision the operator cannot see is undiagnosable. Today an operator hitting the blunt block cannot tell "smart gate could not read the remote's cached schema state" apart from "below the convergence floor" apart from "opted out via BD_SMART_GATE=0" apart from "BD_SMART_GATE set to garbage", and has to research designated-migrator semantics by hand.

This was explicitly listed as follow-up candidate No.1 in #4551's PR description.

## What

When the smart gate falls back to the blunt block, append one self-explaining line to the human message and a `fallback_reason` field to the `--json` gate output, naming which of four mutually-exclusive cases produced the blunt stop:

- `unreadable-remote-state` - cached remote schema state could not be read (no cached ref, stale/pre-content_hash ref, or remote behind local)
- `below-convergence-floor` - remote == local but a legacy non-deterministic migration is still pending
- `opted-out` - `BD_SMART_GATE=0`
- `unparseable-env` - `BD_SMART_GATE` set to a value `ParseBool` rejects; the message quotes the offending value (this takes priority as the surfaced reason since it is the most actionable operator error; the gate itself stays enabled-by-default in that case, verdict table unchanged)

Scope is message/output only: no routing changes, verdict table untouched, the #4515 block body text is byte-identical with only a new line appended. The smart-tailored `adopt` / `fork-skew` stops already self-explain and are unchanged. All logic stays inside `internal/storage/schema` except a one-case addition to the existing `Decision` switch in `cmd/bd/remote_migrate_gate.go` for the JSON field.

## Testing

- `internal/storage/schema`: fallback-reason and `UserMessage()` assertions added to the existing below-floor / undetermined / opted-out subtests, plus a new unparseable-env priority subtest.
- `cmd/bd`: new `TestHandleRemoteMigrateGateJSON_FallbackReason` covering field present on the blunt block and absent on `adopt`.
- `CGO_ENABLED=0 -tags gms_pure_go`: build, vet, and package tests green; cross-vendor review (codex gpt-5.5) found no issues.

_claude-fable-5-high on behalf of matt wilkie_

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FWVnjn3Bq4PSG1akpFpKnY
