### PR TITLE
fix(resolve): map embeddeddolt data dir back to its beads dir (GH#4574)

### DIFF
--- a/cmd/bd/store_reopen.go
+++ b/cmd/bd/store_reopen.go
@@ -96,6 +96,14 @@ func resolveBeadsDirForDBPath(dbPath string) string {
 		if utils.PathsEqual(beadsDir, dbPath) || utils.PathsEqual(beadsDir, actualDBPath) {
 			return beadsDir
 		}
+		// dbPath is the data directory living directly inside beadsDir
+		// (<beadsDir>/embeddeddolt for embedded, <beadsDir>/dolt for server).
+		// Match on that parent relationship so resolution works for embedded
+		// stores regardless of the beads dir name; Config.DatabasePath alone
+		// returns the "dolt" name and misses embeddeddolt/ (GH#4574).
+		if utils.PathsEqual(filepath.Dir(dbPath), beadsDir) || utils.PathsEqual(filepath.Dir(actualDBPath), beadsDir) {
+			return beadsDir
+		}
 		if utils.PathsEqual(cfg.DatabasePath(beadsDir), dbPath) || utils.PathsEqual(cfg.DatabasePath(beadsDir), actualDBPath) {
 			return beadsDir
 		}

--- a/cmd/bd/store_reopen_embedded_resolution_test.go
+++ b/cmd/bd/store_reopen_embedded_resolution_test.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/configfile"
+	"github.com/steveyegge/beads/internal/utils"
+)
+
+// TestResolveBeadsDirForDBPath_EmbeddedNonDotBeads guards GH#4574: an embedded
+// store stores its data under <beadsDir>/embeddeddolt/, but Config.DatabasePath
+// returns <beadsDir>/dolt. When the beads dir is not literally named ".beads"
+// the early-return in resolveBeadsDirForDBPath does not fire, so resolution
+// must still map <beadsDir>/embeddeddolt back to <beadsDir> via the parent
+// relationship — otherwise commands silently fall back to an ancestor ~/.beads
+// and report zero issues.
+func TestResolveBeadsDirForDBPath_EmbeddedNonDotBeads(t *testing.T) {
+	root := t.TempDir()
+	// leaf is intentionally NOT ".beads" (mirrors an embedding tool that keeps
+	// its store at e.g. ~/.local/state/<app>/beads).
+	beadsDir := filepath.Join(root, "beads")
+	dbPath := filepath.Join(beadsDir, "embeddeddolt")
+	if err := os.MkdirAll(dbPath, 0o755); err != nil {
+		t.Fatalf("mkdir embeddeddolt dir: %v", err)
+	}
+
+	cfg := &configfile.Config{
+		Database:     "dolt",
+		Backend:      configfile.BackendDolt,
+		DoltMode:     "embedded",
+		DoltDatabase: "mystore",
+	}
+	if err := cfg.Save(beadsDir); err != nil {
+		t.Fatalf("save metadata: %v", err)
+	}
+
+	if got := resolveBeadsDirForDBPath(dbPath); !utils.PathsEqual(got, beadsDir) {
+		t.Fatalf("resolveBeadsDirForDBPath(%q) = %q, want %q", dbPath, got, beadsDir)
+	}
+}


### PR DESCRIPTION
Fixes #4574.

## Problem

An embedded Dolt store pointed to via `BEADS_DIR` whose directory leaf is not literally `.beads` is silently ignored in 1.1.0 — data commands resolve to the auto-created empty `~/.beads` and return 0 issues (looks like data loss; data is intact).

Root cause: in `resolveBeadsDirForDBPath` (`cmd/bd/store_reopen.go`) a candidate beads dir was accepted only when `cfg.DatabasePath(beadsDir) == dbPath`. `Config.DatabasePath` returns `<beadsDir>/dolt`, but the 1.0+ embedded engine stores data at `<beadsDir>/embeddeddolt/`, so the compare never matched. `resolveCommandBeadsDir` then fell back to its ancestor-walk and returned the first `.beads` it found — the auto-created empty `~/.beads`. A store whose dir *is* named `.beads` only works because of the basename early-return that bypasses the broken compare.

## Fix

Match on the parent relationship: `dbPath` is always the data directory living directly inside `beadsDir` (`<beadsDir>/embeddeddolt` embedded, `<beadsDir>/dolt` server), so accept a candidate when `filepath.Dir(dbPath) == beadsDir`. This is guarded by `configfile.Load(beadsDir)` succeeding, so it can't false-match an unrelated parent (the empty `~/.beads` has no `metadata.json` and is skipped). `Config.DatabasePath`'s broad contract is left untouched.

## Test

`TestResolveBeadsDirForDBPath_EmbeddedNonDotBeads` builds an embedded store whose beads dir is *not* named `.beads` and asserts `resolveBeadsDirForDBPath(<dir>/embeddeddolt)` returns `<dir>`. It fails on `main` (returns `""`) and passes with this change.

## Repro (before fix)

```sh
BEADS_DIR=/tmp/bd-seed bd init --prefix seed
BEADS_DIR=/tmp/bd-seed bd create "hello world" -t task
BEADS_DIR=/tmp/bd-seed bd count      # => 1
cp -R /tmp/bd-seed ~/bd-under-home
BEADS_DIR=~/bd-under-home bd count    # => 0  (BUG); fixed => 1
```
