### PR TITLE
fix(doltremote): fold host case, strip creds, recognize user-less SCP in CanonicalForComparison

### DIFF
--- a/cmd/bd/dolt_remote_origin_guard_test.go
+++ b/cmd/bd/dolt_remote_origin_guard_test.go
@@ -134,6 +134,36 @@ func TestCanonicalForComparison_UserlessSCP(t *testing.T) {
 	}
 }
 
+func TestCanonicalForComparison_NonDefaultSSHUserPreserved(t *testing.T) {
+	// Non-default SSH users select the remote account/home directory and
+	// must NOT be stripped like HTTP(S) transport credentials - otherwise
+	// distinct remotes for different accounts on the same host would
+	// falsely canonicalize to the same string.
+	alice := doltremote.CanonicalForComparison("alice@example.com:repo.git")
+	bob := doltremote.CanonicalForComparison("bob@example.com:repo.git")
+	if alice == bob {
+		t.Errorf("distinct SSH users must not canonicalize equal, both got %q", alice)
+	}
+
+	aliceGitSSH := doltremote.CanonicalForComparison("git+ssh://alice@example.com/repo.git")
+	if alice != aliceGitSSH {
+		t.Errorf("SCP and git+ssh forms of the same non-default user must match: %q vs %q", alice, aliceGitSSH)
+	}
+	if bob == aliceGitSSH {
+		t.Errorf("git+ssh://alice@... must not match a bob@... origin: %q vs %q", aliceGitSSH, bob)
+	}
+}
+
+func TestCanonicalForComparison_DefaultGitSSHUserStillFolded(t *testing.T) {
+	// The conventional "git" SSH user remains the documented default-equivalent
+	// case: bare host:path and explicit git@host:path must still match.
+	userless := doltremote.CanonicalForComparison("github.com:org/repo.git")
+	withGitUser := doltremote.CanonicalForComparison("git@github.com:org/repo.git")
+	if userless != withGitUser {
+		t.Errorf("default git@ user must still fold with userless form: %q vs %q", withGitUser, userless)
+	}
+}
+
 func TestCanonicalForComparison_SchemeStaysDistinct(t *testing.T) {
 	// http and https must never be folded together.
 	http := doltremote.CanonicalForComparison("http://github.com/org/repo")

--- a/cmd/bd/dolt_remote_origin_guard_test.go
+++ b/cmd/bd/dolt_remote_origin_guard_test.go
@@ -98,6 +98,51 @@ func TestCanonicalForComparison_TrailingSlashAndDotGit(t *testing.T) {
 	}
 }
 
+func TestCanonicalForComparison_HostCaseFolded(t *testing.T) {
+	// Host case must not cause false negatives in the collision guard.
+	mixed := doltremote.CanonicalForComparison("https://GitHub.com/org/repo.git")
+	lower := doltremote.CanonicalForComparison("https://github.com/org/repo.git")
+	if mixed != lower {
+		t.Errorf("host-case variants canonical mismatch: %q vs %q", mixed, lower)
+	}
+}
+
+func TestCanonicalForComparison_CredentialsStripped(t *testing.T) {
+	// Embedded user[:pass]@ credentials must be stripped before comparison.
+	userPass := doltremote.CanonicalForComparison("https://user:pass@github.com/org/repo.git")
+	tokenOnly := doltremote.CanonicalForComparison("https://ghp_xxx@github.com/org/repo.git")
+	plain := doltremote.CanonicalForComparison("https://github.com/org/repo.git")
+	if userPass != plain {
+		t.Errorf("user:pass@ credentials not stripped: %q vs %q", userPass, plain)
+	}
+	if tokenOnly != plain {
+		t.Errorf("token-only credentials not stripped: %q vs %q", tokenOnly, plain)
+	}
+}
+
+func TestCanonicalForComparison_UserlessSCP(t *testing.T) {
+	// User-less SCP form must canonicalize equal to the user form and to
+	// Dolt's git+ssh:// form.
+	userless := doltremote.CanonicalForComparison("github.com:org/repo.git")
+	withUser := doltremote.CanonicalForComparison("git@github.com:org/repo.git")
+	gitSSH := doltremote.CanonicalForComparison("git+ssh://git@github.com/org/repo.git")
+	if userless != withUser {
+		t.Errorf("user-less and user SCP canonical mismatch: %q vs %q", userless, withUser)
+	}
+	if userless != gitSSH {
+		t.Errorf("user-less SCP and git+ssh canonical mismatch: %q vs %q", userless, gitSSH)
+	}
+}
+
+func TestCanonicalForComparison_SchemeStaysDistinct(t *testing.T) {
+	// http and https must never be folded together.
+	http := doltremote.CanonicalForComparison("http://github.com/org/repo")
+	https := doltremote.CanonicalForComparison("https://github.com/org/repo")
+	if http == https {
+		t.Errorf("http and https canonical must differ, both got %q", http)
+	}
+}
+
 // --- doltRemoteMatchesGitOrigin ---
 
 func TestDoltRemoteMatchesGitOrigin_NoGitDir_ReturnsFalse(t *testing.T) {

--- a/internal/doltremote/remote.go
+++ b/internal/doltremote/remote.go
@@ -67,6 +67,17 @@ func FromGitURL(url string) string {
 // (host:path). The user-less form is only recognized when the pre-colon
 // token looks like a hostname (contains a ".") so that dotless tokens such
 // as a Windows drive letter ("C:foo") are not mistaken for a host.
+//
+// Known limitation: git itself also accepts dotless SSH config aliases in
+// this position (e.g. "github:org/repo.git", "localhost:repo.git"), which
+// the "." check above rejects. Those origins pass through unconverted and
+// won't canonically match an equivalent git+ssh://alias/... or
+// user@alias:path Dolt remote. This is a deliberate trade-off to keep
+// isWindowsDrivePath's single-letter-drive check from being the only guard
+// against misreading "C:foo" as a host; widening the rule (e.g. following
+// git's own convention of treating anything host:path as SCP-style unless
+// the pre-colon token is a single-letter drive) is tracked as a follow-up
+// rather than fixed here.
 func isSCPStyleGitURL(url string) bool {
 	idx := strings.Index(url, ":")
 	if idx <= 0 || strings.Contains(url[:idx], "/") {
@@ -99,10 +110,20 @@ func CanonicalForComparison(url string) string {
 	return url
 }
 
-// stripCredentialsAndFoldHostCase removes any embedded user[:pass]@ from the
+// stripCredentialsAndFoldHostCase removes embedded userinfo from the
 // authority of a scheme://authority/path URL and lowercases the host. The
 // scheme and path are left untouched. URLs without "://" (e.g. an unknown
 // scheme passthrough) are returned unchanged rather than risking corruption.
+//
+// For HTTP(S) authorities, user[:pass]@ is transport credentials, not an
+// account selector, and is stripped unconditionally. For SSH authorities
+// (ssh://, git+ssh://) the userinfo selects the remote account or home
+// directory - alice@host and bob@host on the same host are different
+// endpoints - so it is preserved, except the conventional "git@" user, which
+// git hosting services treat as the default account and which
+// FromGitURL/isSCPStyleGitURL already fold bare host:path forms to (see
+// CanonicalForComparison's github.com:org/repo.git ≡ git@github.com:org/repo.git
+// example).
 //
 // Case is folded for the authority of every scheme://... form. This is correct
 // for DNS hosts (git+https/git+ssh/http/https). For native non-DNS schemes
@@ -116,6 +137,7 @@ func stripCredentialsAndFoldHostCase(url string) string {
 	if schemeEnd < 0 {
 		return url
 	}
+	scheme := url[:schemeEnd]
 	authorityStart := schemeEnd + len("://")
 	rest := url[authorityStart:]
 
@@ -127,11 +149,20 @@ func stripCredentialsAndFoldHostCase(url string) string {
 	}
 
 	if atIdx := strings.LastIndex(authority, "@"); atIdx >= 0 {
-		authority = authority[atIdx+1:]
+		if !isSSHScheme(scheme) || authority[:atIdx] == "git" {
+			authority = authority[atIdx+1:]
+		}
 	}
 	authority = strings.ToLower(authority)
 
 	return url[:authorityStart] + authority + tail
+}
+
+// isSSHScheme reports whether scheme (the part of a URL before "://")
+// identifies an SSH transport, where userinfo selects the remote account
+// rather than carrying transport credentials.
+func isSSHScheme(scheme string) bool {
+	return scheme == "ssh" || scheme == "git+ssh"
 }
 
 func isWindowsDrivePath(path string) bool {

--- a/internal/doltremote/remote.go
+++ b/internal/doltremote/remote.go
@@ -62,25 +62,76 @@ func FromGitURL(url string) string {
 	return "git+" + url
 }
 
+// isSCPStyleGitURL reports whether url looks like an SCP-style git remote:
+// either the classic user form (git@host:path) or the user-less form
+// (host:path). The user-less form is only recognized when the pre-colon
+// token looks like a hostname (contains a ".") so that dotless tokens such
+// as a Windows drive letter ("C:foo") are not mistaken for a host.
 func isSCPStyleGitURL(url string) bool {
-	if idx := strings.Index(url, ":"); idx > 0 && !strings.Contains(url[:idx], "/") && strings.Contains(url, "@") {
+	idx := strings.Index(url, ":")
+	if idx <= 0 || strings.Contains(url[:idx], "/") {
+		return false
+	}
+	if strings.Contains(url, "@") {
 		return true
 	}
-	return false
+	return strings.Contains(url[:idx], ".")
 }
 
 // CanonicalForComparison returns a form of url suitable for equality checks
-// between URLs that refer to the same repository but may use different schemes
-// or representations. Concretely:
-//   - https://github.com/org/repo.git  ≡  git+https://github.com/org/repo.git
-//   - git@github.com:org/repo.git      ≡  git+ssh://git@github.com/org/repo.git
+// between URLs that refer to the same repository but may use different schemes,
+// representations, host casing, or embedded credentials. Concretely:
+//   - https://github.com/org/repo.git       ≡  git+https://github.com/org/repo.git
+//   - git@github.com:org/repo.git           ≡  git+ssh://git@github.com/org/repo.git
+//   - github.com:org/repo.git               ≡  git@github.com:org/repo.git
+//   - https://GitHub.com/org/repo           ≡  https://github.com/org/repo
+//   - https://user:pass@github.com/org/repo ≡  https://github.com/org/repo
 //
-// Algorithm: normalize to Dolt's git+ prefix form, strip trailing slashes and .git.
+// http and https are kept distinct - scheme is never folded.
+//
+// Algorithm: normalize to Dolt's git+ prefix form, strip trailing slashes and
+// .git, then strip embedded user[:pass]@ credentials and lowercase the host.
 func CanonicalForComparison(url string) string {
 	url = Normalize(url)
 	url = strings.TrimRight(url, "/")
 	url = strings.TrimSuffix(url, ".git")
+	url = stripCredentialsAndFoldHostCase(url)
 	return url
+}
+
+// stripCredentialsAndFoldHostCase removes any embedded user[:pass]@ from the
+// authority of a scheme://authority/path URL and lowercases the host. The
+// scheme and path are left untouched. URLs without "://" (e.g. an unknown
+// scheme passthrough) are returned unchanged rather than risking corruption.
+//
+// Case is folded for the authority of every scheme://... form. This is correct
+// for DNS hosts (git+https/git+ssh/http/https). For native non-DNS schemes
+// (dolthub://, aws://) the authority is a case-sensitive identifier, so folding
+// it is technically lossy, but the current callers only compare a Dolt remote
+// against a git origin - which always canonicalizes to git+https/git+ssh - so a
+// folded native-scheme authority can never string-equal it and no false-positive
+// collision can occur.
+func stripCredentialsAndFoldHostCase(url string) string {
+	schemeEnd := strings.Index(url, "://")
+	if schemeEnd < 0 {
+		return url
+	}
+	authorityStart := schemeEnd + len("://")
+	rest := url[authorityStart:]
+
+	authority := rest
+	tail := ""
+	if slashIdx := strings.Index(rest, "/"); slashIdx >= 0 {
+		authority = rest[:slashIdx]
+		tail = rest[slashIdx:]
+	}
+
+	if atIdx := strings.LastIndex(authority, "@"); atIdx >= 0 {
+		authority = authority[atIdx+1:]
+	}
+	authority = strings.ToLower(authority)
+
+	return url[:authorityStart] + authority + tail
 }
 
 func isWindowsDrivePath(path string) bool {


### PR DESCRIPTION
## Why

Follow-up to #4153 (git-origin collision guard in `bd dolt remote add` + `bd doctor`). A re-review of that PR found the shared URL comparator `doltremote.CanonicalForComparison` misses three equivalences, all **false negatives** that silently weaken the collision guard and the `bd doctor` remotes check (flagged in https://github.com/gastownhall/beads/pull/4153#issuecomment-4883818549):

1. **Host case not folded** - `https://GitHub.com/org/repo` did not match `https://github.com/org/repo`, despite DNS being case-insensitive.
2. **Embedded credentials not stripped** - a PAT-in-URL git origin (`https://user:pass@github.com/org/repo`) never matched a clean Dolt remote for the same repo.
3. **User-less SCP form not recognized** - `github.com:org/repo.git` was not treated as SCP-style, so it never canonicalized to the same form as `git@github.com:org/repo.git`.

The direction is fail-safe (the guard fails to fire rather than wrongly blocking), so this was non-blocking for #4153 landing - but each gap lets a genuine same-repo collision slip past the guard.

## What

In `internal/doltremote/remote.go`:

- `CanonicalForComparison` now, after the existing trailing-slash / `.git` trimming, strips any embedded `user[:pass]@` credentials from the authority and lowercases **only** the host (via new helper `stripCredentialsAndFoldHostCase`). Scheme and path are left untouched.
- `isSCPStyleGitURL` now recognizes the user-less SCP form `host:path` when the pre-colon token looks like a hostname (contains a `.`), in addition to the existing `user@host:path` form. Dotless tokens (e.g. a Windows drive letter `C:foo`) are still rejected, and `isWindowsDrivePath` continues to run first in `Normalize`.

Deliberately preserved:
- **`http` vs `https` stay distinct** - the scheme is never folded (different endpoints).
- The org/repo **path case is never folded** (only the host).

## Tests

Extends the existing `TestCanonicalForComparison_*` unit tests in `cmd/bd/dolt_remote_origin_guard_test.go` with the three equivalence classes (host case, credentials incl. token-only form, user-less SCP three-way equivalence) plus a negative guard asserting `http://` != `https://`.

```
CGO_ENABLED=0 go test -tags gms_pure_go -run 'TestCanonicalForComparison|TestDoltRemoteMatchesGitOrigin' ./cmd/bd/   # PASS
CGO_ENABLED=0 go build -tags gms_pure_go ./...                                                                        # clean
gofmt -l ...                                                                                                          # clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
