### PR TITLE
Fix dolt remote canonical URL comparison

### DIFF
--- a/cmd/bd/dolt_remote_origin_guard_test.go
+++ b/cmd/bd/dolt_remote_origin_guard_test.go
@@ -98,6 +98,31 @@ func TestCanonicalForComparison_TrailingSlashAndDotGit(t *testing.T) {
 	}
 }
 
+func TestCanonicalForComparison_LowercasesHost(t *testing.T) {
+	lower := doltremote.CanonicalForComparison("https://github.com/org/repo.git")
+	mixed := doltremote.CanonicalForComparison("https://GitHub.com/org/repo.git")
+	if lower != mixed {
+		t.Errorf("mixed-case host canonical mismatch: %q vs %q", lower, mixed)
+	}
+}
+
+func TestCanonicalForComparison_StripsCredentials(t *testing.T) {
+	clean := doltremote.CanonicalForComparison("https://github.com/org/repo.git")
+	withToken := doltremote.CanonicalForComparison("https://token@github.com/org/repo.git")
+	withUserPass := doltremote.CanonicalForComparison("https://user:pass@github.com/org/repo.git")
+	if clean != withToken || clean != withUserPass {
+		t.Errorf("credential variants differ: %q %q %q", clean, withToken, withUserPass)
+	}
+}
+
+func TestCanonicalForComparison_UserlessSCPAndGitSSH(t *testing.T) {
+	scp := doltremote.CanonicalForComparison("github.com:org/repo.git")
+	ssh := doltremote.CanonicalForComparison("git+ssh://github.com/org/repo.git")
+	if scp != ssh {
+		t.Errorf("user-less SCP and git+ssh canonical mismatch: %q vs %q", scp, ssh)
+	}
+}
+
 // --- doltRemoteMatchesGitOrigin ---
 
 func TestDoltRemoteMatchesGitOrigin_NoGitDir_ReturnsFalse(t *testing.T) {

--- a/internal/doltremote/remote.go
+++ b/internal/doltremote/remote.go
@@ -1,6 +1,9 @@
 package doltremote
 
-import "strings"
+import (
+	"net/url"
+	"strings"
+)
 
 // NativeSchemes are URL schemes that Dolt understands natively and should not
 // be converted through FromGitURL.
@@ -19,23 +22,23 @@ var NativeSchemes = []string{
 // Dolt-native URLs (dolthub://, file://, aws://, gs://, git+...) are returned
 // as-is. Git URLs (https://, ssh://, git@...) are converted via FromGitURL.
 // Unknown schemes are returned as-is and let dolt clone decide.
-func Normalize(url string) string {
+func Normalize(rawURL string) string {
 	for _, scheme := range NativeSchemes {
-		if strings.HasPrefix(url, scheme) {
-			return url
+		if strings.HasPrefix(rawURL, scheme) {
+			return rawURL
 		}
 	}
-	if strings.HasPrefix(url, "https://") || strings.HasPrefix(url, "http://") ||
-		strings.HasPrefix(url, "ssh://") {
-		return FromGitURL(url)
+	if strings.HasPrefix(rawURL, "https://") || strings.HasPrefix(rawURL, "http://") ||
+		strings.HasPrefix(rawURL, "ssh://") {
+		return FromGitURL(rawURL)
 	}
-	if isWindowsDrivePath(url) {
-		return FromGitURL(url)
+	if isWindowsDrivePath(rawURL) {
+		return FromGitURL(rawURL)
 	}
-	if isSCPStyleGitURL(url) {
-		return FromGitURL(url)
+	if isSCPStyleGitURL(rawURL) {
+		return FromGitURL(rawURL)
 	}
-	return url
+	return rawURL
 }
 
 // FromGitURL converts a git remote URL to Dolt's remote format.
@@ -43,27 +46,27 @@ func Normalize(url string) string {
 // SCP-style SSH URLs are converted: git@host:path -> git+ssh://git@host/path
 // SSH URLs get "git+" prefix: ssh://... -> git+ssh://...
 // URLs that already have "git+" prefix are returned as-is.
-func FromGitURL(url string) string {
-	if strings.HasPrefix(url, "git+") {
-		return url
+func FromGitURL(rawURL string) string {
+	if strings.HasPrefix(rawURL, "git+") {
+		return rawURL
 	}
-	if strings.HasPrefix(url, "https://") || strings.HasPrefix(url, "http://") {
-		return "git+" + url
+	if strings.HasPrefix(rawURL, "https://") || strings.HasPrefix(rawURL, "http://") {
+		return "git+" + rawURL
 	}
-	if strings.HasPrefix(url, "ssh://") {
-		return "git+" + url
+	if strings.HasPrefix(rawURL, "ssh://") {
+		return "git+" + rawURL
 	}
-	if isWindowsDrivePath(url) {
-		return "git+" + url
+	if isWindowsDrivePath(rawURL) {
+		return "git+" + rawURL
 	}
-	if idx := strings.Index(url, ":"); idx > 0 && !strings.Contains(url[:idx], "/") {
-		return "git+ssh://" + url[:idx] + "/" + url[idx+1:]
+	if idx := strings.Index(rawURL, ":"); idx > 0 && !strings.Contains(rawURL[:idx], "/") {
+		return "git+ssh://" + rawURL[:idx] + "/" + rawURL[idx+1:]
 	}
-	return "git+" + url
+	return "git+" + rawURL
 }
 
-func isSCPStyleGitURL(url string) bool {
-	if idx := strings.Index(url, ":"); idx > 0 && !strings.Contains(url[:idx], "/") && strings.Contains(url, "@") {
+func isSCPStyleGitURL(rawURL string) bool {
+	if idx := strings.Index(rawURL, ":"); idx > 0 && !strings.Contains(rawURL[:idx], "/") {
 		return true
 	}
 	return false
@@ -75,12 +78,18 @@ func isSCPStyleGitURL(url string) bool {
 //   - https://github.com/org/repo.git  ≡  git+https://github.com/org/repo.git
 //   - git@github.com:org/repo.git      ≡  git+ssh://git@github.com/org/repo.git
 //
-// Algorithm: normalize to Dolt's git+ prefix form, strip trailing slashes and .git.
-func CanonicalForComparison(url string) string {
-	url = Normalize(url)
-	url = strings.TrimRight(url, "/")
-	url = strings.TrimSuffix(url, ".git")
-	return url
+// Algorithm: normalize to Dolt's git+ prefix form, strip credentials, lowercase
+// the host, and strip trailing slashes and .git.
+func CanonicalForComparison(rawURL string) string {
+	rawURL = Normalize(rawURL)
+	if parsed, err := url.Parse(rawURL); err == nil && parsed.Host != "" {
+		parsed.User = nil
+		parsed.Host = strings.ToLower(parsed.Host)
+		rawURL = parsed.String()
+	}
+	rawURL = strings.TrimRight(rawURL, "/")
+	rawURL = strings.TrimSuffix(rawURL, ".git")
+	return rawURL
 }
 
 func isWindowsDrivePath(path string) bool {


### PR DESCRIPTION
## Why

Follow-up from #4153 review: `doltremote.CanonicalForComparison` still had false negatives when comparing remotes that point at the same repository:

- host case differences such as `GitHub.com` vs `github.com`
- embedded URL credentials such as `https://token@github.com/org/repo.git`
- user-less SCP-style git remotes such as `github.com:org/repo.git`

Those misses weaken the git-origin collision guard and doctor remote matching by failing open.

## What

- Strip URL user info before comparison.
- Lowercase the parsed URL host before comparison.
- Treat user-less `host:path` remotes as SCP-style git URLs.
- Add regression coverage for all three equivalence cases.

## Validation

- `go test -tags gms_pure_go ./cmd/bd -run 'TestCanonicalForComparison|TestDoltRemoteMatchesGitOrigin' -count=1`
- `go test -tags gms_pure_go ./internal/doltremote ./cmd/bd -run 'TestCanonicalForComparison|TestDoltRemoteMatchesGitOrigin|TestNormalizeRemoteURL|TestRemoteURLMatchesConfigNormalizesEquivalentGitURLs' -count=1`
- `git diff --check`

_codex-gpt-5.5-high on behalf of matt wilkie_
