### PR TITLE
fix(hooks): skip export when JSONL is staged for deletion (reimplements #3838)

### DIFF
--- a/cmd/bd/hooks.go
+++ b/cmd/bd/hooks.go
@@ -1387,6 +1387,18 @@ func exportJSONLForCommit() {
 		exportPath = "issues.jsonl"
 	}
 	fullPath := filepath.Join(beadsDir, exportPath)
+
+	// If the export file is staged for deletion (user ran `git rm`), do not
+	// re-export or re-stage it. GIT_INDEX_FILE is set during an actual commit,
+	// so git-diff-index reads the pending index — where the deletion lives.
+	// Without this guard, git add fullPath would convert the staged deletion
+	// back to a modification and the file would never be removed from the
+	// repo. Reimplements gastownhall/beads#3838 (ckumar1).
+	if isExportFileStagedForDeletion(fullPath) {
+		debug.Logf("pre-commit: %s staged for deletion — skipping export\n", exportPath)
+		return
+	}
+
 	if !preCommitHasStagedBeadsFiles(beadsDir) {
 		debug.Logf("pre-commit: skipping JSONL export — no staged .beads paths\n")
 		return
@@ -1426,6 +1438,26 @@ func exportJSONLForCommit() {
 			debug.Logf("pre-commit: git add failed: %v\n", err)
 		}
 	}
+}
+
+// isExportFileStagedForDeletion reports whether the beads export file at
+// fullPath is staged for deletion (the user ran `git rm` on it). When true,
+// exportJSONLForCommit must skip re-exporting and re-staging it: running
+// `git add` on a freshly regenerated file would convert the staged deletion
+// back into a modification, silently reviving a file the user intentionally
+// removed.
+//
+// Unlike preCommitHasStagedBeadsFiles and gitAddFile, this deliberately runs
+// git with the hook's inherited environment intact rather than scrubbing
+// GIT_* vars. GIT_INDEX_FILE is set during an actual commit and points at
+// the pending index — where the staged deletion lives — so scrubbing it
+// here would make git fall back to the on-disk index and miss the
+// deletion. Reimplements gastownhall/beads#3838 (ckumar1).
+func isExportFileStagedForDeletion(fullPath string) bool {
+	checkCmd := exec.Command("git", "diff", "--cached", "--diff-filter=D", "--name-only", "--", filepath.Base(fullPath))
+	checkCmd.Dir = filepath.Dir(fullPath)
+	out, _ := checkCmd.Output()
+	return len(out) > 0
 }
 
 func preCommitHasStagedBeadsFiles(beadsDir string) bool {

--- a/cmd/bd/hooks_export_staged_deletion_test.go
+++ b/cmd/bd/hooks_export_staged_deletion_test.go
@@ -1,0 +1,97 @@
+// hooks_export_staged_deletion_test.go - Regression test for GH#3838
+// (reimplemented): exportJSONLForCommit must not re-export and re-stage the
+// JSONL export file when the user has staged its deletion (`git rm`).
+// Without the guard, the pre-commit hook would silently revert the intended
+// deletion by recreating the file and running `git add` on it.
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+// setupExportStagedDeletionRepo creates a throwaway git repo containing a
+// committed file, and returns its absolute path for the caller to mutate
+// and (re)stage as needed.
+func setupExportStagedDeletionRepo(t *testing.T) (repoDir, filePath string) {
+	t.Helper()
+
+	repoDir = t.TempDir()
+
+	run := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = repoDir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Skipf("git %v failed: %v\n%s", args, err, out)
+		}
+	}
+	run("init")
+	run("config", "user.email", "test@example.com")
+	run("config", "user.name", "Test User")
+
+	filePath = filepath.Join(repoDir, "issues.jsonl")
+	if err := os.WriteFile(filePath, []byte(`{"id":"bd-1"}`+"\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	run("add", "issues.jsonl")
+	run("commit", "-m", "Initial commit")
+
+	return repoDir, filePath
+}
+
+func TestIsExportFileStagedForDeletion_StagedDeletion(t *testing.T) {
+	repoDir, filePath := setupExportStagedDeletionRepo(t)
+
+	run := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = repoDir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v failed: %v\n%s", args, err, out)
+		}
+	}
+
+	// Simulate `git rm issues.jsonl`: remove from disk and stage the removal.
+	run("rm", "issues.jsonl")
+
+	if !isExportFileStagedForDeletion(filePath) {
+		t.Fatalf("expected isExportFileStagedForDeletion(%q) to be true after `git rm`, got false", filePath)
+	}
+}
+
+func TestIsExportFileStagedForDeletion_NoStagedDeletion(t *testing.T) {
+	repoDir, filePath := setupExportStagedDeletionRepo(t)
+	_ = repoDir
+
+	// File is committed and untouched: not staged for deletion.
+	if isExportFileStagedForDeletion(filePath) {
+		t.Fatalf("expected isExportFileStagedForDeletion(%q) to be false for an untouched file, got true", filePath)
+	}
+}
+
+func TestIsExportFileStagedForDeletion_StagedModificationNotDeletion(t *testing.T) {
+	repoDir, filePath := setupExportStagedDeletionRepo(t)
+
+	run := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = repoDir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v failed: %v\n%s", args, err, out)
+		}
+	}
+
+	// Modify and re-stage the file (the ordinary export/git-add path):
+	// this must NOT be treated as a staged deletion.
+	if err := os.WriteFile(filePath, []byte(`{"id":"bd-1"}`+"\n"+`{"id":"bd-2"}`+"\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	run("add", "issues.jsonl")
+
+	if isExportFileStagedForDeletion(filePath) {
+		t.Fatalf("expected isExportFileStagedForDeletion(%q) to be false for a staged modification, got true", filePath)
+	}
+}


### PR DESCRIPTION
## Why

`exportJSONLForCommit()` in the pre-commit hook unconditionally exports the JSONL file and runs `git add` on it. If the user has staged a deletion of that file (`git rm`, e.g. deciding to stop tracking it), the hook re-creates the file and re-stages it as a modification, silently reverting the intended deletion. The removal never reaches the repo.

## What

Adds `isExportFileStagedForDeletion(fullPath)`, which runs `git diff --cached --diff-filter=D` for the export path, and short-circuits `exportJSONLForCommit()` before both the export and the later `git add` when a staged deletion is present. The check intentionally keeps the hook's inherited environment intact (`GIT_INDEX_FILE` points at the pending commit index during a commit, where the staged deletion lives), unlike the env-scrubbing helpers used elsewhere in the file.

## Tests

New `cmd/bd/hooks_export_staged_deletion_test.go` exercises the behavior against a real throwaway git repo (same pattern as `hooks_worktree_test.go`):

- staged deletion (`git rm`) → detected, export skipped
- untouched committed file → not detected
- staged modification (the normal export/git-add path) → not detected, guarding against an over-broad check

Preflight local: `gofmt` clean, `CGO_ENABLED=0 go build -tags gms_pure_go ./cmd/bd/` compiles, the three tests pass.

## Provenance

Reimplements #3838 by @ckumar1, which could not be merged as-is because its branch was far behind and in conflict with current `main`. The bug analysis and original fix are ckumar1's; this carries them forward onto current `main` with a unit-testable helper and behavioral tests. Credit preserved via `Co-authored-by`.

*Correction (2026-07-07): an earlier revision of this section said the #3838 branch "predates the late-May-2026 history re-root of `main` (no common ancestor)". That was wrong - no re-root ever occurred; the analysis was run from a shallow clone whose depth boundary was misread as severed history. #3838 has a normal merge-base with `main`; it was simply stale, which is the actual (and sufficient) reason for the reimplementation.*

_claude-code-opus-4-8-high on behalf of matt wilkie_

