### PR TITLE
fix(dolt): emit events from transaction label and close ops

### DIFF
--- a/internal/storage/dolt/transaction.go
+++ b/internal/storage/dolt/transaction.go
@@ -644,14 +644,21 @@ func (t *doltTransaction) UpdateIssue(ctx context.Context, id string, updates ma
 
 func (t *doltTransaction) CloseIssue(ctx context.Context, id string, reason string, actor string, session string) error {
 	table := "issues"
+	eventTable := "events"
 	if t.isActiveWisp(ctx, id) {
 		table = "wisps"
+		eventTable = "wisp_events"
 	}
 
-	if _, err := issueops.CloseIssueWithoutEventInTx(ctx, t.txFor(table), id, reason, actor, session); err != nil {
+	result, err := issueops.CloseIssueInTx(ctx, t.txFor(table), id, reason, actor, session)
+	if err != nil {
 		return wrapExecError("close issue in tx", err)
 	}
+	if result.AlreadyClosed {
+		return nil
+	}
 	t.dirty.MarkDirty(table)
+	t.dirty.MarkDirty(eventTable)
 	return nil
 }
 
@@ -776,18 +783,18 @@ func (t *doltTransaction) RemoveDependency(ctx context.Context, issueID, depends
 // AddLabel adds a label within the transaction
 func (t *doltTransaction) AddLabel(ctx context.Context, issueID, label, actor string) error {
 	table := "labels"
+	eventTable := "events"
 	if t.isActiveWisp(ctx, issueID) {
 		table = "wisp_labels"
+		eventTable = "wisp_events"
 	}
 
-	//nolint:gosec // G201: table is hardcoded
-	_, err := t.txFor(table).ExecContext(ctx, fmt.Sprintf(`
-		INSERT IGNORE INTO %s (issue_id, label) VALUES (?, ?)
-	`, table), issueID, label)
-	if err == nil {
-		t.dirty.MarkDirty(table)
+	if err := issueops.AddLabelInTx(ctx, t.txFor(table), table, eventTable, issueID, label, actor); err != nil {
+		return wrapExecError("add label in tx", err)
 	}
-	return wrapExecError("add label in tx", err)
+	t.dirty.MarkDirty(table)
+	t.dirty.MarkDirty(eventTable)
+	return nil
 }
 
 func (t *doltTransaction) GetLabels(ctx context.Context, issueID string) ([]string, error) {
@@ -816,18 +823,18 @@ func (t *doltTransaction) GetLabels(ctx context.Context, issueID string) ([]stri
 // RemoveLabel removes a label within the transaction
 func (t *doltTransaction) RemoveLabel(ctx context.Context, issueID, label, actor string) error {
 	table := "labels"
+	eventTable := "events"
 	if t.isActiveWisp(ctx, issueID) {
 		table = "wisp_labels"
+		eventTable = "wisp_events"
 	}
 
-	//nolint:gosec // G201: table is hardcoded
-	_, err := t.txFor(table).ExecContext(ctx, fmt.Sprintf(`
-		DELETE FROM %s WHERE issue_id = ? AND label = ?
-	`, table), issueID, label)
-	if err == nil {
-		t.dirty.MarkDirty(table)
+	if err := issueops.RemoveLabelInTx(ctx, t.txFor(table), table, eventTable, issueID, label, actor); err != nil {
+		return wrapExecError("remove label in tx", err)
 	}
-	return wrapExecError("remove label in tx", err)
+	t.dirty.MarkDirty(table)
+	t.dirty.MarkDirty(eventTable)
+	return nil
 }
 
 // SetConfig sets a config value within the transaction

--- a/internal/storage/dolt/transaction_test.go
+++ b/internal/storage/dolt/transaction_test.go
@@ -97,6 +97,157 @@ func TestRunInTransactionWispCreatePersistsInitialSideTables(t *testing.T) {
 	}
 }
 
+func TestRunInTransactionCloseIssueEmitsEvent(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	issue := &types.Issue{
+		ID:          "test-tx-close-event",
+		Title:       "transaction close emits event",
+		Description: "exercise doltTransaction.CloseIssue",
+		Status:      types.StatusOpen,
+		Priority:    2,
+		IssueType:   types.TypeTask,
+	}
+	if err := store.CreateIssue(ctx, issue, "tester"); err != nil {
+		t.Fatalf("CreateIssue: %v", err)
+	}
+
+	if err := store.RunInTransaction(ctx, "test: close emits event", func(tx storage.Transaction) error {
+		return tx.CloseIssue(ctx, issue.ID, "done", "tester", "session-1")
+	}); err != nil {
+		t.Fatalf("RunInTransaction CloseIssue: %v", err)
+	}
+
+	assertCommittedEventCount(ctx, t, store.db, issue.ID, types.EventClosed, 1)
+}
+
+func TestRunInTransactionAlreadyClosedDoesNotCommitUnrelatedEvent(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	issue := &types.Issue{
+		ID:          "test-tx-close-noop-event",
+		Title:       "transaction no-op close leaves events alone",
+		Description: "exercise doltTransaction.CloseIssue already-closed path",
+		Status:      types.StatusOpen,
+		Priority:    2,
+		IssueType:   types.TypeTask,
+	}
+	if err := store.CreateIssue(ctx, issue, "tester"); err != nil {
+		t.Fatalf("CreateIssue: %v", err)
+	}
+	if err := store.CloseIssue(ctx, issue.ID, "done", "tester", "session-1"); err != nil {
+		t.Fatalf("CloseIssue seed: %v", err)
+	}
+
+	const strayComment = "uncommitted stray event"
+	if _, err := store.db.ExecContext(ctx,
+		"INSERT INTO events (id, issue_id, event_type, actor, comment) VALUES (?, ?, ?, ?, ?)",
+		issueops.NewEventID(), issue.ID, types.EventCommented, "tester", strayComment,
+	); err != nil {
+		t.Fatalf("insert stray event: %v", err)
+	}
+
+	if err := store.RunInTransaction(ctx, "test: already closed does not stage events", func(tx storage.Transaction) error {
+		return tx.CloseIssue(ctx, issue.ID, "still done", "tester", "session-2")
+	}); err != nil {
+		t.Fatalf("RunInTransaction CloseIssue already closed: %v", err)
+	}
+
+	var got int
+	if err := store.db.QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM events AS OF 'HEAD' WHERE issue_id = ? AND event_type = ? AND comment = ?",
+		issue.ID, types.EventCommented, strayComment,
+	).Scan(&got); err != nil {
+		t.Fatalf("count committed stray events: %v", err)
+	}
+	if got != 0 {
+		t.Fatalf("committed stray event count = %d, want 0", got)
+	}
+	assertCommittedEventCount(ctx, t, store.db, issue.ID, types.EventClosed, 1)
+}
+
+func TestRunInTransactionAddLabelEmitsEvent(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	issue := &types.Issue{
+		ID:          "test-tx-add-label-event",
+		Title:       "transaction add label emits event",
+		Description: "exercise doltTransaction.AddLabel",
+		Status:      types.StatusOpen,
+		Priority:    2,
+		IssueType:   types.TypeTask,
+	}
+	if err := store.CreateIssue(ctx, issue, "tester"); err != nil {
+		t.Fatalf("CreateIssue: %v", err)
+	}
+
+	if err := store.RunInTransaction(ctx, "test: add label emits event", func(tx storage.Transaction) error {
+		return tx.AddLabel(ctx, issue.ID, "triaged", "tester")
+	}); err != nil {
+		t.Fatalf("RunInTransaction AddLabel: %v", err)
+	}
+
+	assertCommittedEventCount(ctx, t, store.db, issue.ID, types.EventLabelAdded, 1)
+}
+
+func TestRunInTransactionRemoveLabelEmitsEvent(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	issue := &types.Issue{
+		ID:          "test-tx-remove-label-event",
+		Title:       "transaction remove label emits event",
+		Description: "exercise doltTransaction.RemoveLabel",
+		Status:      types.StatusOpen,
+		Priority:    2,
+		IssueType:   types.TypeTask,
+	}
+	if err := store.CreateIssue(ctx, issue, "tester"); err != nil {
+		t.Fatalf("CreateIssue: %v", err)
+	}
+	if err := store.AddLabel(ctx, issue.ID, "triaged", "tester"); err != nil {
+		t.Fatalf("AddLabel seed: %v", err)
+	}
+
+	if err := store.RunInTransaction(ctx, "test: remove label emits event", func(tx storage.Transaction) error {
+		return tx.RemoveLabel(ctx, issue.ID, "triaged", "tester")
+	}); err != nil {
+		t.Fatalf("RunInTransaction RemoveLabel: %v", err)
+	}
+
+	assertCommittedEventCount(ctx, t, store.db, issue.ID, types.EventLabelRemoved, 1)
+}
+
+func assertCommittedEventCount(ctx context.Context, t *testing.T, db *sql.DB, issueID string, eventType types.EventType, want int) {
+	t.Helper()
+
+	var got int
+	if err := db.QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM events AS OF 'HEAD' WHERE issue_id = ? AND event_type = ?",
+		issueID, eventType,
+	).Scan(&got); err != nil {
+		t.Fatalf("count committed %s events for %s: %v", eventType, issueID, err)
+	}
+	if got != want {
+		t.Fatalf("committed %s event count for %s = %d, want %d", eventType, issueID, got, want)
+	}
+}
+
 func TestRunInTransactionCreateIssuesMixedWispReadYourWrites(t *testing.T) {
 	store, cleanup := setupTestStore(t)
 	defer cleanup()


### PR DESCRIPTION
## Why

This reimplements the still-live audit-event fix from #3803 against current `main`.

The original contributor branch is roughly 725 commits behind and conflicts with current `main`, and the surrounding transaction helpers have been rewritten since it was opened (`CloseIssue` now routes through `issueops.CloseIssueWithoutEventInTx`, which did not exist then). So this carries the same bug fix forward as a fresh patch against today's `issueops` APIs rather than force-rewriting the contributor branch.

*Correction (2026-07-07): an earlier revision of this description attributed the divergence to a "late-May history re-root" of `main` severing the branch's ancestry. That was wrong - no re-root ever occurred; the analysis was run from a shallow clone whose depth boundary was misread as severed history. #3803 has a normal merge-base with `main`; it is simply stale and conflicting, which is the actual (and sufficient) reason for the fresh patch.*

Credit to @seanmartinsmith for the root-cause diagnosis and the transaction-path regression coverage idea.

Fixes #3799.

## What

- route `doltTransaction.CloseIssue` through `issueops.CloseIssueInTx`
- route transaction `AddLabel` and `RemoveLabel` through the shared `issueops` helpers
- mark `events`/`wisp_events` dirty when those helpers record audit rows
- avoid dirtying event tables when closing an already-closed issue is a no-op
- add `RunInTransaction` regressions that assert event rows are committed to `HEAD`

## Verification

- `go test ./internal/storage/dolt -run 'TestRunInTransaction(CloseIssueEmitsEvent|AlreadyClosedDoesNotCommitUnrelatedEvent|AddLabelEmitsEvent|RemoveLabelEmitsEvent)$' -count=1`
- `go test ./internal/storage/dolt -count=1`

