### PR TITLE
fix(dolt): borrow ignored-tx from pool + per-dial credential connector (hosted-gateway churn)

### DIFF
--- a/internal/configfile/central_config_test.go
+++ b/internal/configfile/central_config_test.go
@@ -209,6 +209,57 @@ func TestApplyCentralDefaults_NilCentralIsNoOp(t *testing.T) {
 	}
 }
 
+func TestTrustedDoltCredentialCommand(t *testing.T) {
+	const helper = "gasworks getToken beads --org o_1"
+
+	t.Run("env var is the highest-priority trusted source", func(t *testing.T) {
+		t.Setenv("BEADS_DOLT_CREDENTIAL_COMMAND", helper)
+		// A central config naming a different helper must still lose to the env var.
+		central := filepath.Join(t.TempDir(), "server.json")
+		writeCentralConfig(t, central, &Config{DoltCredentialCommand: "central-helper"})
+		t.Setenv("BEADS_CENTRAL_CONFIG", central)
+
+		if got := TrustedDoltCredentialCommand(); got != helper {
+			t.Fatalf("TrustedDoltCredentialCommand() = %q, want env value %q", got, helper)
+		}
+	})
+
+	t.Run("central server config is honored when no env var", func(t *testing.T) {
+		t.Setenv("BEADS_DOLT_CREDENTIAL_COMMAND", "")
+		central := filepath.Join(t.TempDir(), "server.json")
+		writeCentralConfig(t, central, &Config{DoltCredentialCommand: helper})
+		t.Setenv("BEADS_CENTRAL_CONFIG", central)
+
+		if got := TrustedDoltCredentialCommand(); got != helper {
+			t.Fatalf("TrustedDoltCredentialCommand() = %q, want central value %q", got, helper)
+		}
+	})
+
+	t.Run("no trusted source yields empty; project metadata is never a source", func(t *testing.T) {
+		t.Setenv("BEADS_DOLT_CREDENTIAL_COMMAND", "")
+		// Absent central config, and there is deliberately no parameter through which a
+		// project's tracked metadata.json could ever supply the helper.
+		t.Setenv("BEADS_CENTRAL_CONFIG", filepath.Join(t.TempDir(), "absent.json"))
+
+		if got := TrustedDoltCredentialCommand(); got != "" {
+			t.Fatalf("TrustedDoltCredentialCommand() = %q, want empty (no trusted helper)", got)
+		}
+	})
+
+	t.Run("broken central config resolves to no helper", func(t *testing.T) {
+		t.Setenv("BEADS_DOLT_CREDENTIAL_COMMAND", "")
+		central := filepath.Join(t.TempDir(), "server.json")
+		if err := os.WriteFile(central, []byte("{bad json"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		t.Setenv("BEADS_CENTRAL_CONFIG", central)
+
+		if got := TrustedDoltCredentialCommand(); got != "" {
+			t.Fatalf("TrustedDoltCredentialCommand() = %q, want empty (broken central is opt-out)", got)
+		}
+	})
+}
+
 func TestDefaultCentralConfigPath(t *testing.T) {
 	path := DefaultCentralConfigPath()
 	if path == "" {

--- a/internal/configfile/configfile.go
+++ b/internal/configfile/configfile.go
@@ -344,14 +344,40 @@ func (c *Config) GetDoltServerUser() string {
 	return DefaultDoltServerUser
 }
 
-// GetDoltCredentialCommand returns the credential-helper command bd runs to obtain a
-// short-lived server-mode credential. Checks BEADS_DOLT_CREDENTIAL_COMMAND env first, then
-// config. Empty means no helper — the static BEADS_DOLT_SERVER_USER / credentials-file path applies.
-func (c *Config) GetDoltCredentialCommand() string {
+// TrustedDoltCredentialCommand returns the server-mode credential-helper command bd runs to
+// obtain a short-lived credential (presented as the MySQL username), resolved from a TRUSTED,
+// user-local source only, in priority order:
+//
+//  1. the BEADS_DOLT_CREDENTIAL_COMMAND environment variable, then
+//  2. the central per-user server config (BEADS_CENTRAL_CONFIG or ~/.config/beads/server.json).
+//
+// SECURITY: it deliberately IGNORES the dolt_credential_command field of a project's tracked
+// .beads/metadata.json. That file is committed and travels with a git clone, so honoring an
+// executable helper named there would let any checked-out repository run arbitrary shell code
+// through the credential runner (sh -c) during ordinary store open — a reachable CWE-78 OS
+// command injection. Project metadata may point bd at connection endpoints, never at an
+// executable to run; a helper must be established by the machine's operator out-of-band.
+//
+// Empty means no trusted helper is configured — the static BEADS_DOLT_SERVER_USER /
+// credentials-file path applies.
+func TrustedDoltCredentialCommand() string {
 	if v := os.Getenv("BEADS_DOLT_CREDENTIAL_COMMAND"); v != "" {
 		return v
 	}
-	return c.DoltCredentialCommand
+	centralPath := os.Getenv("BEADS_CENTRAL_CONFIG")
+	if centralPath == "" {
+		centralPath = DefaultCentralConfigPath()
+	}
+	if centralPath != "" {
+		// A helper is strictly opt-in, so a missing or broken central config resolves to
+		// "no trusted helper" rather than surfacing an error here.
+		if central, err := LoadCentralConfig(centralPath); err == nil && central != nil {
+			if central.DoltCredentialCommand != "" {
+				return central.DoltCredentialCommand
+			}
+		}
+	}
+	return ""
 }
 
 // GetDoltDatabase returns the Dolt SQL database name.

--- a/internal/storage/dolt/connection_pool_test.go
+++ b/internal/storage/dolt/connection_pool_test.go
@@ -6,6 +6,7 @@ import (
 	"database/sql/driver"
 	"fmt"
 	"io"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -36,6 +37,33 @@ type mockDriver struct {
 	opens  atomic.Int64 // total Open() calls (NewConnection events)
 	closes atomic.Int64 // total Close() calls (ConnectionClosed events)
 	live   atomic.Int64 // currently-open connections
+
+	qmu     sync.Mutex // guards queries
+	queries []string   // every query string passed to Prepare (borrow-path assertions)
+
+	// failCheckout makes Prepare of a DOLT_CHECKOUT statement fail, so borrow-path
+	// tests can force beginTxOnConn to error and fall through to the fallback.
+	failCheckout atomic.Bool
+}
+
+// recordQuery appends a prepared query for later assertion.
+func (d *mockDriver) recordQuery(query string) {
+	d.qmu.Lock()
+	d.queries = append(d.queries, query)
+	d.qmu.Unlock()
+}
+
+// countQuery returns how many recorded queries contain substr.
+func (d *mockDriver) countQuery(substr string) int {
+	d.qmu.Lock()
+	defer d.qmu.Unlock()
+	n := 0
+	for _, q := range d.queries {
+		if strings.Contains(q, substr) {
+			n++
+		}
+	}
+	return n
 }
 
 func (d *mockDriver) Open(name string) (driver.Conn, error) {
@@ -52,6 +80,10 @@ type mockConn struct {
 }
 
 func (c *mockConn) Prepare(query string) (driver.Stmt, error) {
+	c.drv.recordQuery(query)
+	if c.drv.failCheckout.Load() && strings.Contains(query, "DOLT_CHECKOUT") {
+		return nil, fmt.Errorf("mock: forced DOLT_CHECKOUT failure")
+	}
 	return &mockStmt{}, nil
 }
 

--- a/internal/storage/dolt/connection_pool_test.go
+++ b/internal/storage/dolt/connection_pool_test.go
@@ -44,6 +44,23 @@ type mockDriver struct {
 	// failCheckout makes Prepare of a DOLT_CHECKOUT statement fail, so borrow-path
 	// tests can force beginTxOnConn to error and fall through to the fallback.
 	failCheckout atomic.Bool
+
+	// activeBranch is what a SELECT active_branch() query reports; empty means
+	// "main". Borrow-path tests set it to another branch to prove the borrow
+	// refuses to switch a pooled session's branch and falls back instead.
+	activeBranch atomic.Value // string
+
+	// failActiveBranch makes a SELECT active_branch() query fail, modeling a
+	// stale borrowed connection.
+	failActiveBranch atomic.Bool
+}
+
+// reportedBranch returns the branch active_branch() queries report.
+func (d *mockDriver) reportedBranch() string {
+	if v, ok := d.activeBranch.Load().(string); ok && v != "" {
+		return v
+	}
+	return "main"
 }
 
 // recordQuery appends a prepared query for later assertion.
@@ -103,6 +120,13 @@ func (c *mockConn) Begin() (driver.Tx, error) {
 // We simulate a small amount of work so the concurrency test can observe
 // SetMaxOpenConns back-pressure.
 func (c *mockConn) QueryContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
+	if strings.Contains(query, "active_branch") {
+		c.drv.recordQuery(query)
+		if c.drv.failActiveBranch.Load() {
+			return nil, fmt.Errorf("mock: forced active_branch failure")
+		}
+		return &mockRows{val: c.drv.reportedBranch()}, nil
+	}
 	time.Sleep(20 * time.Millisecond)
 	return &mockRows{}, nil
 }
@@ -121,6 +145,7 @@ func (mockStmt) Query(args []driver.Value) (driver.Rows, error)  { return &mockR
 
 type mockRows struct {
 	done bool
+	val  driver.Value // value for the single row; nil means int64(1)
 }
 
 func (r *mockRows) Columns() []string { return []string{"x"} }
@@ -131,7 +156,11 @@ func (r *mockRows) Next(dest []driver.Value) error {
 	}
 	r.done = true
 	if len(dest) > 0 {
-		dest[0] = int64(1)
+		if r.val != nil {
+			dest[0] = r.val
+		} else {
+			dest[0] = int64(1)
+		}
 	}
 	return nil
 }

--- a/internal/storage/dolt/connector.go
+++ b/internal/storage/dolt/connector.go
@@ -1,0 +1,66 @@
+package dolt
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	mysql "github.com/go-sql-driver/mysql"
+)
+
+// openSQLDB opens a *sql.DB for a dolt sql-server DSN.
+//
+// When credCmd is empty (the static-user and local/embedded paths) it is exactly
+// sql.Open("mysql", dsn) — byte-for-byte today's behavior.
+//
+// When credCmd is set (the hosted credential-command path), it returns a
+// connector-backed *sql.DB whose BeforeConnect hook re-resolves a fresh cached
+// credential token at EACH new physical connection dial. The gateway reads that
+// token as the MySQL username, so:
+//   - every new pooled connection authenticates with a live token, and
+//   - EXISTING pooled connections are never re-authenticated by the server, so
+//     they survive token rotation (the warm-connection property).
+//
+// go-sql-driver/mysql v1.9.3 clones the Config before invoking BeforeConnect
+// (connector.go:70-77), so the per-dial User mutation is isolated to that dial.
+// sql.Open("mysql", dsn) and sql.OpenDB(mysql.NewConnector(ParseDSN(dsn))) are
+// equivalent — NewConnector normalizes the config "so calls have the same
+// behavior as MySQLDriver.OpenConnector" (driver.go), and ReadTimeout/
+// WriteTimeout/TLSConfig ride mysql.Config fields through both paths.
+func openSQLDB(dsn, credCmd string) (*sql.DB, error) {
+	if credCmd == "" {
+		return sql.Open("mysql", dsn)
+	}
+
+	cfg, err := mysql.ParseDSN(dsn)
+	if err != nil {
+		return nil, fmt.Errorf("parsing DSN for credential connector: %w", err)
+	}
+	if err := cfg.Apply(mysql.BeforeConnect(credentialBeforeConnect(credCmd))); err != nil {
+		return nil, fmt.Errorf("applying credential connector hook: %w", err)
+	}
+	connector, err := mysql.NewConnector(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("creating credential connector: %w", err)
+	}
+	return sql.OpenDB(connector), nil
+}
+
+// credentialBeforeConnect returns a mysql BeforeConnect hook that stamps a fresh
+// cached credential token onto each new physical connection's username.
+//
+// resolveCredentialToken (credcmd.go) is process-cached with a 10s pre-expiry
+// skew, so the common case is a mutex-guarded map hit (~µs); only near the token
+// expiry boundary does it shell out to the helper. On any resolution error the
+// hook fails closed — the dial is aborted rather than falling back to a stale
+// token. It is a named function so tests can invoke it without a live server.
+func credentialBeforeConnect(credCmd string) func(context.Context, *mysql.Config) error {
+	return func(ctx context.Context, c *mysql.Config) error {
+		tok, err := resolveCredentialToken(ctx, credCmd)
+		if err != nil {
+			return fmt.Errorf("resolving dolt credential command: %w", err)
+		}
+		c.User = tok
+		return nil
+	}
+}

--- a/internal/storage/dolt/connector_test.go
+++ b/internal/storage/dolt/connector_test.go
@@ -1,0 +1,191 @@
+package dolt
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	mysql "github.com/go-sql-driver/mysql"
+)
+
+// stubCredRunner isolates the process-level credential cache and swaps credRunner
+// for the duration of a test, restoring both on cleanup. Tests using it must NOT
+// run in parallel — credCache and credRunner are package globals.
+func stubCredRunner(t *testing.T, fn func(ctx context.Context, command string) ([]byte, error)) {
+	t.Helper()
+	credCacheMu.Lock()
+	credCache = map[string]cachedCred{}
+	credCacheMu.Unlock()
+	orig := credRunner
+	credRunner = fn
+	t.Cleanup(func() {
+		credRunner = orig
+		credCacheMu.Lock()
+		credCache = map[string]cachedCred{}
+		credCacheMu.Unlock()
+	})
+}
+
+func TestCredentialBeforeConnect_SetsUserFromHelper(t *testing.T) {
+	stubCredRunner(t, func(_ context.Context, _ string) ([]byte, error) {
+		return []byte(`{"access_token":"tokA","expires_in":300}`), nil
+	})
+
+	hook := credentialBeforeConnect("helper-sets-user")
+	cfg := mysql.NewConfig()
+	if err := hook(context.Background(), cfg); err != nil {
+		t.Fatalf("hook returned error: %v", err)
+	}
+	if cfg.User != "tokA" {
+		t.Fatalf("cfg.User = %q, want %q", cfg.User, "tokA")
+	}
+}
+
+func TestCredentialBeforeConnect_CachesAcrossDials(t *testing.T) {
+	var calls int
+	stubCredRunner(t, func(_ context.Context, _ string) ([]byte, error) {
+		calls++
+		return []byte(fmt.Sprintf(`{"access_token":"tok-%d","expires_in":300}`, calls)), nil
+	})
+
+	hook := credentialBeforeConnect("helper-caches")
+	cfg1 := mysql.NewConfig()
+	cfg2 := mysql.NewConfig()
+	if err := hook(context.Background(), cfg1); err != nil {
+		t.Fatalf("first hook: %v", err)
+	}
+	if err := hook(context.Background(), cfg2); err != nil {
+		t.Fatalf("second hook: %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("helper ran %d times, want 1 (cache hit on second dial)", calls)
+	}
+	if cfg1.User != cfg2.User || cfg1.User != "tok-1" {
+		t.Fatalf("users = %q / %q, want both %q", cfg1.User, cfg2.User, "tok-1")
+	}
+}
+
+func TestCredentialBeforeConnect_RefreshesExpiredToken(t *testing.T) {
+	var calls int
+	stubCredRunner(t, func(_ context.Context, _ string) ([]byte, error) {
+		calls++
+		return []byte(`{"access_token":"tokB","expires_in":300}`), nil
+	})
+
+	const cmd = "helper-refreshes"
+	credCacheMu.Lock()
+	credCache[cmd] = cachedCred{token: "tokOld", expires: time.Now().Add(-time.Minute)}
+	credCacheMu.Unlock()
+
+	hook := credentialBeforeConnect(cmd)
+	cfg := mysql.NewConfig()
+	if err := hook(context.Background(), cfg); err != nil {
+		t.Fatalf("hook returned error: %v", err)
+	}
+	if cfg.User != "tokB" {
+		t.Fatalf("cfg.User = %q, want fresh token %q", cfg.User, "tokB")
+	}
+	if calls != 1 {
+		t.Fatalf("helper ran %d times, want 1 (expired entry forces a refresh)", calls)
+	}
+}
+
+func TestCredentialBeforeConnect_HelperErrorPropagates(t *testing.T) {
+	stubCredRunner(t, func(_ context.Context, _ string) ([]byte, error) {
+		return nil, fmt.Errorf("boom")
+	})
+
+	hook := credentialBeforeConnect("helper-errors")
+	cfg := mysql.NewConfig()
+	cfg.User = "unchanged"
+	err := hook(context.Background(), cfg)
+	if err == nil {
+		t.Fatal("expected an error when the helper fails (fail-closed)")
+	}
+	if !strings.Contains(err.Error(), "resolving dolt credential command") {
+		t.Fatalf("error = %q, want it to wrap %q", err.Error(), "resolving dolt credential command")
+	}
+	if cfg.User != "unchanged" {
+		t.Fatalf("cfg.User = %q, want it left unchanged on error", cfg.User)
+	}
+}
+
+func TestOpenSQLDB_EmptyCommandNeverRunsHelper(t *testing.T) {
+	stubCredRunner(t, func(_ context.Context, _ string) ([]byte, error) {
+		t.Fatal("credRunner must not be invoked when credCmd is empty")
+		return nil, nil
+	})
+
+	db, err := openSQLDB("root@tcp(127.0.0.1:3307)/beads", "")
+	if err != nil {
+		t.Fatalf("openSQLDB(validDSN, \"\"): %v", err)
+	}
+	if db == nil {
+		t.Fatal("openSQLDB returned a nil *sql.DB")
+	}
+	_ = db.Close()
+}
+
+func TestOpenSQLDB_InvalidDSNWithCommand(t *testing.T) {
+	stubCredRunner(t, func(_ context.Context, _ string) ([]byte, error) {
+		t.Fatal("credRunner must not be invoked when the DSN fails to parse")
+		return nil, nil
+	})
+
+	_, err := openSQLDB("not-a-dsn", "some-cmd")
+	if err == nil {
+		t.Fatal("expected a parse error for an invalid DSN")
+	}
+	if !strings.Contains(err.Error(), "parsing DSN for credential connector") {
+		t.Fatalf("error = %q, want it to wrap %q", err.Error(), "parsing DSN for credential connector")
+	}
+}
+
+func TestOpenSQLDB_ConnectorConfiguredIsLazy(t *testing.T) {
+	stubCredRunner(t, func(_ context.Context, _ string) ([]byte, error) {
+		t.Fatal("credRunner must not run at construction — BeforeConnect is dial-time only")
+		return nil, nil
+	})
+
+	db, err := openSQLDB("root@tcp(127.0.0.1:3307)/beads", "lazy-cmd")
+	if err != nil {
+		t.Fatalf("openSQLDB(validDSN, cmd): %v", err)
+	}
+	if db == nil {
+		t.Fatal("openSQLDB returned a nil *sql.DB")
+	}
+	_ = db.Close()
+}
+
+// TestOpenSQLDB_WiresBeforeConnectOnDial is the FIX #2 teeth test: it fails if the
+// BeforeConnect hook is not actually attached to the connector openSQLDB builds.
+// The mysql connector resolves BeforeConnect BEFORE it dials, so a dial against an
+// unroutable host still invokes the credential helper — observing that invocation
+// proves the hook is wired. Deleting the cfg.Apply(BeforeConnect(...)) line in
+// openSQLDB makes credRunner never run here, and this test then fails (whereas the
+// direct credentialBeforeConnect tests above would still pass — the gap this closes).
+func TestOpenSQLDB_WiresBeforeConnectOnDial(t *testing.T) {
+	var calls int
+	stubCredRunner(t, func(_ context.Context, _ string) ([]byte, error) {
+		calls++
+		return []byte(`{"access_token":"tokWired","expires_in":300}`), nil
+	})
+
+	db, err := openSQLDB("root@tcp(127.0.0.1:1)/x", "wire-probe-cmd")
+	if err != nil {
+		t.Fatalf("openSQLDB: %v", err)
+	}
+	defer db.Close()
+	db.SetMaxOpenConns(1)
+
+	conn, err := db.Conn(context.Background())
+	if err == nil {
+		_ = conn.Close()
+		t.Fatal("expected the dial against the unroutable host to fail")
+	}
+	if calls == 0 {
+		t.Fatal("credential helper never ran on dial — openSQLDB did not wire BeforeConnect; FIX #2's per-dial credential is absent")
+	}
+}

--- a/internal/storage/dolt/credcmd.go
+++ b/internal/storage/dolt/credcmd.go
@@ -64,7 +64,7 @@ var (
 // resolveCredentialToken returns the bearer token for the given helper command, using a
 // process-level cache keyed by the command so repeated opens don't re-spawn the helper until
 // the token is near expiry. It is concurrency-safe.
-func resolveCredentialToken(command string) (string, error) {
+func resolveCredentialToken(ctx context.Context, command string) (string, error) {
 	now := time.Now()
 
 	credCacheMu.Lock()
@@ -75,7 +75,11 @@ func resolveCredentialToken(command string) (string, error) {
 	}
 	credCacheMu.Unlock()
 
-	ctx, cancel := context.WithTimeout(context.Background(), credCommandTimeout)
+	// Derive the mint deadline from the caller's context (the dial context on the
+	// connector path), capped at credCommandTimeout. An expired dial deadline now
+	// aborts a slow or hung helper instead of blocking the caller for the full
+	// timeout; a Background caller (the open-time eager resolve) keeps the cap.
+	ctx, cancel := context.WithTimeout(ctx, credCommandTimeout)
 	defer cancel()
 	raw, err := credRunner(ctx, command)
 	if err != nil {
@@ -93,6 +97,17 @@ func resolveCredentialToken(command string) (string, error) {
 	credCache[command] = cachedCred{token: token, expires: expiry}
 	credCacheMu.Unlock()
 	return token, nil
+}
+
+// invalidateCredentialToken drops any cached token for command so the next resolve
+// re-runs the helper. Called when the server rejects a presented token (auth
+// failure) before its recorded expiry — e.g. a rotating credential revoked
+// mid-life — so a new dial re-mints instead of re-presenting the dead token until
+// its stale expiry. No-op if nothing is cached.
+func invalidateCredentialToken(command string) {
+	credCacheMu.Lock()
+	delete(credCache, command)
+	credCacheMu.Unlock()
 }
 
 // parseCredential extracts the token (and any expiry) from a helper's stdout. A JSON object

--- a/internal/storage/dolt/credcmd_test.go
+++ b/internal/storage/dolt/credcmd_test.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"testing"
 	"time"
+
+	mysql "github.com/go-sql-driver/mysql"
 )
 
 func TestParseCredential(t *testing.T) {
@@ -65,11 +67,11 @@ func TestResolveCredentialTokenCachesUntilExpiry(t *testing.T) {
 			time.Now().Add(time.Hour).Format(time.RFC3339))), nil
 	}
 
-	tok1, err := resolveCredentialToken("helper --x")
+	tok1, err := resolveCredentialToken(context.Background(), "helper --x")
 	if err != nil {
 		t.Fatalf("first resolve: %v", err)
 	}
-	tok2, err := resolveCredentialToken("helper --x")
+	tok2, err := resolveCredentialToken(context.Background(), "helper --x")
 	if err != nil {
 		t.Fatalf("second resolve: %v", err)
 	}
@@ -78,7 +80,7 @@ func TestResolveCredentialTokenCachesUntilExpiry(t *testing.T) {
 	}
 
 	// A different command is a different cache key → a fresh run.
-	if _, err := resolveCredentialToken("helper --y"); err != nil {
+	if _, err := resolveCredentialToken(context.Background(), "helper --y"); err != nil {
 		t.Fatalf("third resolve: %v", err)
 	}
 	if calls != 2 {
@@ -95,7 +97,93 @@ func TestResolveCredentialTokenPropagatesHelperError(t *testing.T) {
 	credRunner = func(_ context.Context, _ string) ([]byte, error) {
 		return nil, fmt.Errorf("boom")
 	}
-	if _, err := resolveCredentialToken("broken-helper"); err == nil {
+	if _, err := resolveCredentialToken(context.Background(), "broken-helper"); err == nil {
 		t.Fatal("expected an error when the helper fails")
+	}
+}
+
+// TestResolveCredentialTokenHonorsCallerContext is the follow-up-A teeth test: the
+// mint must abort when the caller's (dial) context deadline fires, instead of
+// blocking for the full credCommandTimeout. Reverting resolveCredentialToken to
+// context.Background() makes the blocking helper wait the full 30s and this fails.
+func TestResolveCredentialTokenHonorsCallerContext(t *testing.T) {
+	credCacheMu.Lock()
+	credCache = map[string]cachedCred{}
+	credCacheMu.Unlock()
+	orig := credRunner
+	t.Cleanup(func() { credRunner = orig })
+	// Models a slow/hung helper: blocks until its (derived) context is cancelled.
+	credRunner = func(ctx context.Context, _ string) ([]byte, error) {
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	start := time.Now()
+	_, err := resolveCredentialToken(ctx, "slow-helper")
+	elapsed := time.Since(start)
+	if err == nil {
+		t.Fatal("expected an error when the caller context deadline fires")
+	}
+	if elapsed > 5*time.Second {
+		t.Fatalf("resolve took %v — caller context was not honored (would block up to credCommandTimeout=%v)", elapsed, credCommandTimeout)
+	}
+}
+
+// TestInvalidateCredentialToken is the follow-up-B teeth test: after invalidation a
+// still-unexpired cached token is dropped so the next resolve re-mints. If
+// invalidateCredentialToken failed to delete, the third resolve would be a cache
+// hit and calls would stay at 1.
+func TestInvalidateCredentialToken(t *testing.T) {
+	credCacheMu.Lock()
+	credCache = map[string]cachedCred{}
+	credCacheMu.Unlock()
+	orig := credRunner
+	t.Cleanup(func() { credRunner = orig })
+	var calls int
+	credRunner = func(_ context.Context, _ string) ([]byte, error) {
+		calls++
+		return []byte(`{"access_token":"tok","expires_in":3600}`), nil
+	}
+
+	const cmd = "rotating-helper"
+	if _, err := resolveCredentialToken(context.Background(), cmd); err != nil {
+		t.Fatalf("first resolve: %v", err)
+	}
+	if _, err := resolveCredentialToken(context.Background(), cmd); err != nil {
+		t.Fatalf("second resolve: %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("expected 1 helper call before invalidation (long expiry cached), got %d", calls)
+	}
+
+	invalidateCredentialToken(cmd)
+
+	if _, err := resolveCredentialToken(context.Background(), cmd); err != nil {
+		t.Fatalf("post-invalidation resolve: %v", err)
+	}
+	if calls != 2 {
+		t.Fatalf("expected a re-mint after invalidation, got calls=%d", calls)
+	}
+}
+
+// TestIsAuthError classifies the MySQL access-denied (1045) signal that drives
+// credential-cache invalidation, and rejects non-auth errors.
+func TestIsAuthError(t *testing.T) {
+	if !isAuthError(&mysql.MySQLError{Number: 1045, Message: "Access denied for user"}) {
+		t.Fatal("MySQL 1045 must be an auth error")
+	}
+	if isAuthError(&mysql.MySQLError{Number: 1213, Message: "deadlock found"}) {
+		t.Fatal("MySQL 1213 (deadlock) is not an auth error")
+	}
+	if !isAuthError(fmt.Errorf("Error 1045: Access denied for user 'x'@'y'")) {
+		t.Fatal("an access-denied string must match")
+	}
+	if isAuthError(fmt.Errorf("dial tcp: connection refused")) {
+		t.Fatal("connection refused is not an auth error")
+	}
+	if isAuthError(nil) {
+		t.Fatal("nil is not an auth error")
 	}
 }

--- a/internal/storage/dolt/open.go
+++ b/internal/storage/dolt/open.go
@@ -231,13 +231,24 @@ func applyResolvedConfig(beadsDir string, fileCfg *configfile.Config, cfg *Confi
 	// takes precedence over the static user: bd runs the vendor-neutral helper and uses its
 	// short-lived token. Fail closed — never fall back to the static/root user when a helper was
 	// configured but failed, or a wrong identity could connect.
+	//
+	// The eager token here only SEEDS the DSN username so buildServerDSN/connStr stays parseable
+	// (and validates the helper at open time — a broken helper still aborts store construction).
+	// On the credential-command path every physical dial re-resolves a fresh cached token via
+	// BeforeConnect (see connector.go), so the baked username is inert and pooled connections
+	// survive token rotation. The guard stays inside `if cfg.ServerUser == ""`: an explicitly
+	// pre-set ServerUser bypasses the helper and keeps the pure static sql.Open path.
 	if cfg.ServerUser == "" {
 		if helper := fileCfg.GetDoltCredentialCommand(); helper != "" {
-			tok, err := resolveCredentialToken(helper)
+			// Open-time eager resolve: no dial context here, so use Background (the
+			// helper keeps its full credCommandTimeout cap). Per-dial resolves on the
+			// connector path thread the dial context so a deadline can abort the mint.
+			tok, err := resolveCredentialToken(context.Background(), helper)
 			if err != nil {
 				return fmt.Errorf("resolving dolt credential command: %w", err)
 			}
 			cfg.ServerUser = tok
+			cfg.CredentialCommand = helper
 		} else {
 			cfg.ServerUser = fileCfg.GetDoltServerUser()
 		}

--- a/internal/storage/dolt/open.go
+++ b/internal/storage/dolt/open.go
@@ -227,31 +227,10 @@ func applyResolvedConfig(beadsDir string, fileCfg *configfile.Config, cfg *Confi
 		// falls back to 3307 which is wrong for standalone repos.
 		cfg.ServerPort = doltserver.DefaultConfig(beadsDir).Port
 	}
-	// Resolve the server-mode credential (the MySQL username). A configured credential command
-	// takes precedence over the static user: bd runs the vendor-neutral helper and uses its
-	// short-lived token. Fail closed — never fall back to the static/root user when a helper was
-	// configured but failed, or a wrong identity could connect.
-	//
-	// The eager token here only SEEDS the DSN username so buildServerDSN/connStr stays parseable
-	// (and validates the helper at open time — a broken helper still aborts store construction).
-	// On the credential-command path every physical dial re-resolves a fresh cached token via
-	// BeforeConnect (see connector.go), so the baked username is inert and pooled connections
-	// survive token rotation. The guard stays inside `if cfg.ServerUser == ""`: an explicitly
-	// pre-set ServerUser bypasses the helper and keeps the pure static sql.Open path.
-	if cfg.ServerUser == "" {
-		if helper := fileCfg.GetDoltCredentialCommand(); helper != "" {
-			// Open-time eager resolve: no dial context here, so use Background (the
-			// helper keeps its full credCommandTimeout cap). Per-dial resolves on the
-			// connector path thread the dial context so a deadline can abort the mint.
-			tok, err := resolveCredentialToken(context.Background(), helper)
-			if err != nil {
-				return fmt.Errorf("resolving dolt credential command: %w", err)
-			}
-			cfg.ServerUser = tok
-			cfg.CredentialCommand = helper
-		} else {
-			cfg.ServerUser = fileCfg.GetDoltServerUser()
-		}
+	// Resolve the server-mode credential (the MySQL username) from the config and any
+	// trusted credential helper.
+	if err := resolveServerCredential(fileCfg, cfg); err != nil {
+		return err
 	}
 	// Populate password and TLS the same way the CLI CRUD path does. Without
 	// this, callers that rely on NewFromConfigWithOptions (e.g. doctor's
@@ -282,6 +261,53 @@ func applyResolvedConfig(beadsDir string, fileCfg *configfile.Config, cfg *Confi
 			}
 		}
 	}
+	return nil
+}
+
+// resolveServerCredential populates cfg.ServerUser (and, on the hosted credential path,
+// cfg.CredentialCommand) when the caller left ServerUser unset. An explicitly pre-set
+// ServerUser bypasses the helper entirely and keeps the pure static sql.Open path.
+//
+// SECURITY: the credential helper is executed as a shell command (sh -c), so it is accepted
+// ONLY from a trusted user-local source (BEADS_DOLT_CREDENTIAL_COMMAND or the central per-user
+// server config) — never from the project's tracked .beads/metadata.json, which travels with a
+// git clone and would otherwise let a checked-out repository inject shell execution during
+// store open (CWE-78). This single gate covers both the open-time eager resolve and the
+// per-dial BeforeConnect path, because both key off cfg.CredentialCommand set here.
+//
+// A configured helper takes precedence over the static user and fails closed: if it errors,
+// store construction aborts rather than falling back to the static/root identity. The eager
+// token only SEEDS the DSN username so buildServerDSN/connStr stays parseable; every physical
+// dial re-resolves a fresh cached token via BeforeConnect (see connector.go), so the baked
+// username is inert and pooled connections survive token rotation.
+func resolveServerCredential(fileCfg *configfile.Config, cfg *Config) error {
+	if cfg.ServerUser != "" {
+		return nil
+	}
+	helper := configfile.TrustedDoltCredentialCommand()
+	if helper == "" {
+		// A tracked metadata.json may name a credential command, but bd will not run it.
+		// Warn so an operator who intended a helper moves it to a trusted source instead of
+		// silently getting the static-user fallback.
+		if fileCfg.DoltCredentialCommand != "" {
+			fmt.Fprint(os.Stderr,
+				"Warning: ignoring dolt_credential_command from project metadata.json for security.\n"+
+					"A credential helper is executed as a shell command, so it must come from a trusted\n"+
+					"user-local source: set BEADS_DOLT_CREDENTIAL_COMMAND or add dolt_credential_command to\n"+
+					"the central server config (~/.config/beads/server.json). Falling back to the static user.\n")
+		}
+		cfg.ServerUser = fileCfg.GetDoltServerUser()
+		return nil
+	}
+	// Open-time eager resolve: no dial context here, so use Background (the helper keeps its
+	// full credCommandTimeout cap). Per-dial resolves on the connector path thread the dial
+	// context so a deadline can abort the mint.
+	tok, err := resolveCredentialToken(context.Background(), helper)
+	if err != nil {
+		return fmt.Errorf("resolving dolt credential command: %w", err)
+	}
+	cfg.ServerUser = tok
+	cfg.CredentialCommand = helper
 	return nil
 }
 

--- a/internal/storage/dolt/open_test.go
+++ b/internal/storage/dolt/open_test.go
@@ -2,6 +2,8 @@ package dolt
 
 import (
 	"bytes"
+	"context"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -194,6 +196,81 @@ func TestCLIDirUsesDbPathOutsideSharedServerMode(t *testing.T) {
 	if got := store.CLIDir(); got != want {
 		t.Fatalf("CLIDir() = %q, want %q", got, want)
 	}
+}
+
+func TestApplyResolvedConfig_SetsCredentialCommand(t *testing.T) {
+	const helper = "gasworks getToken beads --org o_1"
+
+	t.Run("credential command threaded and eager token seeded", func(t *testing.T) {
+		stubCredRunner(t, func(_ context.Context, _ string) ([]byte, error) {
+			return []byte(`{"access_token":"eager-tok","expires_in":300}`), nil
+		})
+		beadsDir := t.TempDir()
+		fileCfg := &configfile.Config{
+			Backend:               configfile.BackendDolt,
+			DoltMode:              configfile.DoltModeServer,
+			DoltDatabase:          "beads_codex",
+			DoltCredentialCommand: helper,
+		}
+		cfg := &Config{}
+
+		if err := applyResolvedConfig(beadsDir, fileCfg, cfg); err != nil {
+			t.Fatalf("applyResolvedConfig: %v", err)
+		}
+		if cfg.CredentialCommand != helper {
+			t.Fatalf("CredentialCommand = %q, want %q", cfg.CredentialCommand, helper)
+		}
+		if cfg.ServerUser != "eager-tok" {
+			t.Fatalf("ServerUser = %q, want the eager token %q", cfg.ServerUser, "eager-tok")
+		}
+	})
+
+	t.Run("explicit ServerUser bypasses the helper", func(t *testing.T) {
+		stubCredRunner(t, func(_ context.Context, _ string) ([]byte, error) {
+			t.Fatal("helper must not run when ServerUser is pre-set")
+			return nil, nil
+		})
+		beadsDir := t.TempDir()
+		fileCfg := &configfile.Config{
+			Backend:               configfile.BackendDolt,
+			DoltMode:              configfile.DoltModeServer,
+			DoltDatabase:          "beads_codex",
+			DoltCredentialCommand: helper,
+		}
+		cfg := &Config{ServerUser: "preset"}
+
+		if err := applyResolvedConfig(beadsDir, fileCfg, cfg); err != nil {
+			t.Fatalf("applyResolvedConfig: %v", err)
+		}
+		if cfg.CredentialCommand != "" {
+			t.Fatalf("CredentialCommand = %q, want empty (static path preserved)", cfg.CredentialCommand)
+		}
+		if cfg.ServerUser != "preset" {
+			t.Fatalf("ServerUser = %q, want it left as %q", cfg.ServerUser, "preset")
+		}
+	})
+
+	t.Run("failing helper aborts store construction (fail-closed)", func(t *testing.T) {
+		stubCredRunner(t, func(_ context.Context, _ string) ([]byte, error) {
+			return nil, fmt.Errorf("mint denied")
+		})
+		beadsDir := t.TempDir()
+		fileCfg := &configfile.Config{
+			Backend:               configfile.BackendDolt,
+			DoltMode:              configfile.DoltModeServer,
+			DoltDatabase:          "beads_codex",
+			DoltCredentialCommand: helper,
+		}
+		cfg := &Config{}
+
+		err := applyResolvedConfig(beadsDir, fileCfg, cfg)
+		if err == nil {
+			t.Fatal("expected a fail-closed error when the helper fails")
+		}
+		if !strings.Contains(err.Error(), "resolving dolt credential command") {
+			t.Fatalf("error = %q, want it to wrap %q", err.Error(), "resolving dolt credential command")
+		}
+	})
 }
 
 func TestApplyResolvedConfig(t *testing.T) {

--- a/internal/storage/dolt/open_test.go
+++ b/internal/storage/dolt/open_test.go
@@ -201,16 +201,22 @@ func TestCLIDirUsesDbPathOutsideSharedServerMode(t *testing.T) {
 func TestApplyResolvedConfig_SetsCredentialCommand(t *testing.T) {
 	const helper = "gasworks getToken beads --org o_1"
 
-	t.Run("credential command threaded and eager token seeded", func(t *testing.T) {
+	// applyResolvedConfig now resolves the credential helper from trusted sources only
+	// (BEADS_DOLT_CREDENTIAL_COMMAND env + central server config). Point the central path
+	// at an absent file by default so a real ~/.config/beads/server.json on the host can
+	// never leak into these tests; the central-path subtest overrides this with its own file.
+	t.Setenv("BEADS_CENTRAL_CONFIG", filepath.Join(t.TempDir(), "absent-server.json"))
+
+	t.Run("trusted env credential command threaded and eager token seeded", func(t *testing.T) {
+		t.Setenv("BEADS_DOLT_CREDENTIAL_COMMAND", helper)
 		stubCredRunner(t, func(_ context.Context, _ string) ([]byte, error) {
 			return []byte(`{"access_token":"eager-tok","expires_in":300}`), nil
 		})
 		beadsDir := t.TempDir()
 		fileCfg := &configfile.Config{
-			Backend:               configfile.BackendDolt,
-			DoltMode:              configfile.DoltModeServer,
-			DoltDatabase:          "beads_codex",
-			DoltCredentialCommand: helper,
+			Backend:      configfile.BackendDolt,
+			DoltMode:     configfile.DoltModeServer,
+			DoltDatabase: "beads_codex",
 		}
 		cfg := &Config{}
 
@@ -225,9 +231,41 @@ func TestApplyResolvedConfig_SetsCredentialCommand(t *testing.T) {
 		}
 	})
 
-	t.Run("explicit ServerUser bypasses the helper", func(t *testing.T) {
+	t.Run("trusted central config credential command is honored", func(t *testing.T) {
+		central := filepath.Join(t.TempDir(), "server.json")
+		if err := os.WriteFile(central, []byte(fmt.Sprintf(`{"dolt_credential_command":%q}`, helper)), 0o600); err != nil {
+			t.Fatalf("writing central config: %v", err)
+		}
+		t.Setenv("BEADS_CENTRAL_CONFIG", central)
 		stubCredRunner(t, func(_ context.Context, _ string) ([]byte, error) {
-			t.Fatal("helper must not run when ServerUser is pre-set")
+			return []byte(`{"access_token":"central-tok","expires_in":300}`), nil
+		})
+		beadsDir := t.TempDir()
+		fileCfg := &configfile.Config{
+			Backend:      configfile.BackendDolt,
+			DoltMode:     configfile.DoltModeServer,
+			DoltDatabase: "beads_codex",
+		}
+		cfg := &Config{}
+
+		if err := applyResolvedConfig(beadsDir, fileCfg, cfg); err != nil {
+			t.Fatalf("applyResolvedConfig: %v", err)
+		}
+		if cfg.CredentialCommand != helper {
+			t.Fatalf("CredentialCommand = %q, want %q", cfg.CredentialCommand, helper)
+		}
+		if cfg.ServerUser != "central-tok" {
+			t.Fatalf("ServerUser = %q, want the central token %q", cfg.ServerUser, "central-tok")
+		}
+	})
+
+	t.Run("tracked project metadata credential command is ignored, never executed", func(t *testing.T) {
+		// Security regression: a repository-controlled .beads/metadata.json names a helper,
+		// but with no trusted source configured bd must NOT run it. It falls back to the
+		// static user and leaves cfg.CredentialCommand empty, so nothing reaches the sh -c
+		// runner at open time or per dial.
+		stubCredRunner(t, func(_ context.Context, cmd string) ([]byte, error) {
+			t.Fatalf("credential helper from project metadata must never run, but ran %q", cmd)
 			return nil, nil
 		})
 		beadsDir := t.TempDir()
@@ -235,7 +273,47 @@ func TestApplyResolvedConfig_SetsCredentialCommand(t *testing.T) {
 			Backend:               configfile.BackendDolt,
 			DoltMode:              configfile.DoltModeServer,
 			DoltDatabase:          "beads_codex",
-			DoltCredentialCommand: helper,
+			DoltCredentialCommand: helper, // repo-controlled; must be ignored
+		}
+		cfg := &Config{}
+
+		// Capture stderr to confirm the ignored-helper warning is surfaced.
+		oldStderr := os.Stderr
+		r, w, _ := os.Pipe()
+		os.Stderr = w
+
+		err := applyResolvedConfig(beadsDir, fileCfg, cfg)
+
+		w.Close()
+		os.Stderr = oldStderr
+		var buf bytes.Buffer
+		_, _ = io.Copy(&buf, r)
+
+		if err != nil {
+			t.Fatalf("applyResolvedConfig: %v", err)
+		}
+		if cfg.CredentialCommand != "" {
+			t.Fatalf("CredentialCommand = %q, want empty (metadata helper must not be adopted)", cfg.CredentialCommand)
+		}
+		if cfg.ServerUser != fileCfg.GetDoltServerUser() {
+			t.Fatalf("ServerUser = %q, want the static fallback %q", cfg.ServerUser, fileCfg.GetDoltServerUser())
+		}
+		if !strings.Contains(buf.String(), "ignoring dolt_credential_command from project metadata.json") {
+			t.Fatalf("expected an ignored-helper security warning on stderr, got: %q", buf.String())
+		}
+	})
+
+	t.Run("explicit ServerUser bypasses the helper", func(t *testing.T) {
+		t.Setenv("BEADS_DOLT_CREDENTIAL_COMMAND", helper)
+		stubCredRunner(t, func(_ context.Context, _ string) ([]byte, error) {
+			t.Fatal("helper must not run when ServerUser is pre-set")
+			return nil, nil
+		})
+		beadsDir := t.TempDir()
+		fileCfg := &configfile.Config{
+			Backend:      configfile.BackendDolt,
+			DoltMode:     configfile.DoltModeServer,
+			DoltDatabase: "beads_codex",
 		}
 		cfg := &Config{ServerUser: "preset"}
 
@@ -250,16 +328,16 @@ func TestApplyResolvedConfig_SetsCredentialCommand(t *testing.T) {
 		}
 	})
 
-	t.Run("failing helper aborts store construction (fail-closed)", func(t *testing.T) {
+	t.Run("failing trusted helper aborts store construction (fail-closed)", func(t *testing.T) {
+		t.Setenv("BEADS_DOLT_CREDENTIAL_COMMAND", helper)
 		stubCredRunner(t, func(_ context.Context, _ string) ([]byte, error) {
 			return nil, fmt.Errorf("mint denied")
 		})
 		beadsDir := t.TempDir()
 		fileCfg := &configfile.Config{
-			Backend:               configfile.BackendDolt,
-			DoltMode:              configfile.DoltModeServer,
-			DoltDatabase:          "beads_codex",
-			DoltCredentialCommand: helper,
+			Backend:      configfile.BackendDolt,
+			DoltMode:     configfile.DoltModeServer,
+			DoltDatabase: "beads_codex",
 		}
 		cfg := &Config{}
 
@@ -274,6 +352,10 @@ func TestApplyResolvedConfig_SetsCredentialCommand(t *testing.T) {
 }
 
 func TestApplyResolvedConfig(t *testing.T) {
+	// applyResolvedConfig resolves the credential helper from the central server config when
+	// no ServerUser is set; isolate it to an absent path so a host ~/.config/beads/server.json
+	// cannot make these non-credential cases run a helper.
+	t.Setenv("BEADS_CENTRAL_CONFIG", filepath.Join(t.TempDir(), "absent-server.json"))
 	t.Run("fills server config for legacy metadata without dolt_mode", func(t *testing.T) {
 		beadsDir := t.TempDir()
 		fileCfg := &configfile.Config{

--- a/internal/storage/dolt/retry_test.go
+++ b/internal/storage/dolt/retry_test.go
@@ -2,8 +2,13 @@ package dolt
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"testing"
+	"time"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	mysql "github.com/go-sql-driver/mysql"
 )
 
 func TestIsRetryableError(t *testing.T) {
@@ -181,5 +186,103 @@ func TestWithRetry_NonRetryableError(t *testing.T) {
 	}
 	if callCount != 1 {
 		t.Errorf("expected 1 call for non-retryable error, got %d", callCount)
+	}
+}
+
+// TestWithRetryTx_AuthErrorInvalidatesAndRetries is the write-path analogue of
+// withRetry's credential recovery: a MySQL 1045 from a write transaction's dial
+// (a rotating token revoked before its cached expiry) must drop the cached token
+// and retry, not fail permanently. Before withRetryTx learned this, it
+// classified 1045 as non-retryable and surfaced it, so hosted-credential writes
+// could fail for the whole life of a stale-but-unexpired cache entry.
+func TestWithRetryTx_AuthErrorInvalidatesAndRetries(t *testing.T) {
+	const cmd = "rotating-helper"
+	credCacheMu.Lock()
+	credCache = map[string]cachedCred{cmd: {token: "revoked", expires: time.Now().Add(time.Hour)}}
+	credCacheMu.Unlock()
+	t.Cleanup(func() {
+		credCacheMu.Lock()
+		credCache = map[string]cachedCred{}
+		credCacheMu.Unlock()
+	})
+
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	// First dial rejects the revoked token; the retry's dial succeeds and commits.
+	mock.ExpectBegin().WillReturnError(&mysql.MySQLError{Number: 1045, Message: "Access denied for user"})
+	mock.ExpectBegin()
+	mock.ExpectCommit()
+
+	store := &DoltStore{db: db, credCommand: cmd, serverMode: true}
+
+	bodyRuns := 0
+	if err := store.withRetryTx(context.Background(), func(tx *sql.Tx) error {
+		bodyRuns++
+		return nil
+	}); err != nil {
+		t.Fatalf("withRetryTx must retry past the auth rejection, got: %v", err)
+	}
+	if bodyRuns != 1 {
+		t.Fatalf("tx body should run once (only after the successful retry), ran %d times", bodyRuns)
+	}
+
+	credCacheMu.Lock()
+	_, stillCached := credCache[cmd]
+	credCacheMu.Unlock()
+	if stillCached {
+		t.Fatal("auth rejection must invalidate the cached credential so the retry re-mints")
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sqlmock expectations: %v", err)
+	}
+}
+
+// TestWithRetryTx_CommitPhaseAuthErrorNotRetried guards the double-apply
+// invariant: an auth rejection observed during tx.Commit is ambiguous (the
+// commit may have landed), so — exactly like a commit-phase connection loss — it
+// must surface permanently rather than replay the write, even though the cached
+// token is still dropped so future dials re-mint.
+func TestWithRetryTx_CommitPhaseAuthErrorNotRetried(t *testing.T) {
+	const cmd = "rotating-helper"
+	credCacheMu.Lock()
+	credCache = map[string]cachedCred{cmd: {token: "revoked", expires: time.Now().Add(time.Hour)}}
+	credCacheMu.Unlock()
+	t.Cleanup(func() {
+		credCacheMu.Lock()
+		credCache = map[string]cachedCred{}
+		credCacheMu.Unlock()
+	})
+
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	mock.ExpectBegin()
+	mock.ExpectCommit().WillReturnError(&mysql.MySQLError{Number: 1045, Message: "Access denied for user"})
+
+	store := &DoltStore{db: db, credCommand: cmd, serverMode: true}
+
+	bodyRuns := 0
+	err = store.withRetryTx(context.Background(), func(tx *sql.Tx) error {
+		bodyRuns++
+		return nil
+	})
+	if err == nil {
+		t.Fatal("a commit-phase auth rejection must surface, not be silently retried")
+	}
+	if !errors.Is(err, errCommitPhase) {
+		t.Fatalf("commit-phase failure must stay tagged errCommitPhase, got: %v", err)
+	}
+	if bodyRuns != 1 {
+		t.Fatalf("commit-phase failure must not replay the write; body ran %d times", bodyRuns)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sqlmock expectations: %v", err)
 	}
 }

--- a/internal/storage/dolt/retry_test.go
+++ b/internal/storage/dolt/retry_test.go
@@ -394,3 +394,174 @@ func TestPrimeCredentialedConn_NonAuthErrorNotRetried(t *testing.T) {
 		t.Fatalf("must not re-dial after a non-auth error: %v", err)
 	}
 }
+
+// TestRetryStaleCredentialOpen covers the store-open credential recovery primitive
+// used by openServerConnection's first dials (SHOW DATABASES, CREATE DATABASE, and the
+// test-connection ping), which run before the DoltStore's own withRetry/withRetryTx/
+// primeCredentialedConn handlers exist. On the credential-command path a MySQL 1045
+// must drop the cached token and retry the op exactly once; the static path and
+// non-auth errors must run the op once and leave the cache untouched.
+func TestRetryStaleCredentialOpen(t *testing.T) {
+	authErr := &mysql.MySQLError{Number: 1045, Message: "Access denied for user"}
+
+	t.Run("static path runs once and never invalidates", func(t *testing.T) {
+		runs := 0
+		err := retryStaleCredentialOpen("", func() error {
+			runs++
+			return authErr
+		})
+		if !errors.Is(err, authErr) {
+			t.Fatalf("static path must surface the error, got: %v", err)
+		}
+		if runs != 1 {
+			t.Fatalf("static path must run op exactly once, ran %d", runs)
+		}
+	})
+
+	t.Run("auth error invalidates cached token and retries once", func(t *testing.T) {
+		const cmd = "rotating-helper"
+		credCacheMu.Lock()
+		credCache = map[string]cachedCred{cmd: {token: "revoked", expires: time.Now().Add(time.Hour)}}
+		credCacheMu.Unlock()
+		t.Cleanup(func() {
+			credCacheMu.Lock()
+			credCache = map[string]cachedCred{}
+			credCacheMu.Unlock()
+		})
+
+		runs := 0
+		err := retryStaleCredentialOpen(cmd, func() error {
+			runs++
+			if runs == 1 {
+				return authErr
+			}
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("must recover on the retry, got: %v", err)
+		}
+		if runs != 2 {
+			t.Fatalf("auth error must retry the op exactly once (2 runs), ran %d", runs)
+		}
+		credCacheMu.Lock()
+		_, stillCached := credCache[cmd]
+		credCacheMu.Unlock()
+		if stillCached {
+			t.Fatal("auth rejection must invalidate the cached credential so the retry re-mints")
+		}
+	})
+
+	t.Run("non-auth error runs once and keeps the cache", func(t *testing.T) {
+		const cmd = "rotating-helper"
+		credCacheMu.Lock()
+		credCache = map[string]cachedCred{cmd: {token: "live", expires: time.Now().Add(time.Hour)}}
+		credCacheMu.Unlock()
+		t.Cleanup(func() {
+			credCacheMu.Lock()
+			credCache = map[string]cachedCred{}
+			credCacheMu.Unlock()
+		})
+
+		runs := 0
+		wantErr := errors.New("driver: bad connection")
+		err := retryStaleCredentialOpen(cmd, func() error {
+			runs++
+			return wantErr
+		})
+		if !errors.Is(err, wantErr) {
+			t.Fatalf("non-auth error must surface, got: %v", err)
+		}
+		if runs != 1 {
+			t.Fatalf("non-auth error must not retry; ran %d", runs)
+		}
+		credCacheMu.Lock()
+		_, stillCached := credCache[cmd]
+		credCacheMu.Unlock()
+		if !stillCached {
+			t.Fatal("a non-auth error must not invalidate the cached credential")
+		}
+	})
+}
+
+// TestOpenServerConnection_StaleCredentialRecovers proves store construction itself
+// recovers from a rotating credential revoked before its cached expiry — the exact gap
+// the DoltStore's retry handlers cannot cover because they do not exist yet during open.
+// openServerConnection dials two independent pools that share the process credential
+// cache: initDB (no database in the DSN) runs SHOW DATABASES, and db (database in the
+// DSN) runs the open-time catalog ping. With a stale cached token, each pool's first
+// dial is rejected with MySQL 1045; store-open must drop the token and re-dial rather
+// than fail permanently with "failed to check if database" or a ping error.
+func TestOpenServerConnection_StaleCredentialRecovers(t *testing.T) {
+	const cmd = "rotating-helper"
+	credCacheMu.Lock()
+	credCache = map[string]cachedCred{cmd: {token: "revoked", expires: time.Now().Add(time.Hour)}}
+	credCacheMu.Unlock()
+	t.Cleanup(func() {
+		credCacheMu.Lock()
+		credCache = map[string]cachedCred{}
+		credCacheMu.Unlock()
+	})
+
+	mainDB, mainMock, err := sqlmock.New(sqlmock.MonitorPingsOption(true))
+	if err != nil {
+		t.Fatalf("sqlmock.New (main): %v", err)
+	}
+	t.Cleanup(func() { _ = mainDB.Close() })
+	initDB, initMock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New (init): %v", err)
+	}
+	t.Cleanup(func() { _ = initDB.Close() })
+
+	// Route the main vs init pool by the DSN's database name, exactly as
+	// openServerConnection builds them (buildServerDSN(cfg, cfg.Database) vs "").
+	origOpener := serverConnOpener
+	serverConnOpener = func(dsn, credCmd string) (*sql.DB, error) {
+		parsed, perr := mysql.ParseDSN(dsn)
+		if perr != nil {
+			t.Fatalf("unexpected DSN %q: %v", dsn, perr)
+		}
+		if parsed.DBName == "" {
+			return initDB, nil
+		}
+		return mainDB, nil
+	}
+	t.Cleanup(func() { serverConnOpener = origOpener })
+
+	authErr := &mysql.MySQLError{Number: 1045, Message: "Access denied for user"}
+	// Each pool's first dial presents the revoked token and is rejected; the
+	// invalidate-and-re-dial retry then succeeds.
+	initMock.ExpectQuery("SHOW DATABASES").WillReturnError(authErr)
+	initMock.ExpectQuery("SHOW DATABASES").WillReturnRows(sqlmock.NewRows([]string{"Database"}).AddRow("beads"))
+	mainMock.ExpectPing().WillReturnError(authErr)
+	mainMock.ExpectPing()
+
+	cfg := &Config{
+		Database:          "beads",
+		ServerHost:        "127.0.0.1",
+		ServerPort:        3999,
+		ServerUser:        "placeholder",
+		CredentialCommand: cmd,
+		CreateIfMissing:   true,
+	}
+	db, _, err := openServerConnection(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("store-open must recover past the revoked-token dials, got: %v", err)
+	}
+	if db == nil {
+		t.Fatal("store-open must return a live connection on recovery")
+	}
+
+	credCacheMu.Lock()
+	_, stillCached := credCache[cmd]
+	credCacheMu.Unlock()
+	if stillCached {
+		t.Fatal("store-open auth rejection must invalidate the cached credential so the re-dial re-mints")
+	}
+	if err := initMock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet init-pool expectations: %v", err)
+	}
+	if err := mainMock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet main-pool expectations: %v", err)
+	}
+}

--- a/internal/storage/dolt/retry_test.go
+++ b/internal/storage/dolt/retry_test.go
@@ -286,3 +286,111 @@ func TestWithRetryTx_CommitPhaseAuthErrorNotRetried(t *testing.T) {
 		t.Fatalf("unmet sqlmock expectations: %v", err)
 	}
 }
+
+// TestExecWithLongTimeout_RevokedTokenRecovers proves the long-timeout side pool —
+// which dials outside withRetry/withRetryTx — recovers from a rotating credential
+// revoked before its cached expiry. The first dial's MySQL 1045 must invalidate the
+// cached token so the re-dial re-mints, and the wrapped pull operation must then run
+// exactly once: the auth retry recovers the dial without replaying committed work.
+// The migration and pull side pools (openMigrationDB, openLongTimeoutConn) share the
+// same primeCredentialedConn path.
+func TestExecWithLongTimeout_RevokedTokenRecovers(t *testing.T) {
+	const cmd = "rotating-helper"
+	credCacheMu.Lock()
+	credCache = map[string]cachedCred{cmd: {token: "revoked", expires: time.Now().Add(time.Hour)}}
+	credCacheMu.Unlock()
+	t.Cleanup(func() {
+		credCacheMu.Lock()
+		credCache = map[string]cachedCred{}
+		credCacheMu.Unlock()
+	})
+
+	db, mock, err := sqlmock.New(sqlmock.MonitorPingsOption(true))
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	origOpener := sideConnOpener
+	sideConnOpener = func(dsn, credCmd string) (*sql.DB, error) { return db, nil }
+	t.Cleanup(func() { sideConnOpener = origOpener })
+
+	// Prime dials first: the revoked token is rejected (1045), then the re-minted
+	// dial succeeds. Only afterward does the single pull operation run — once.
+	mock.ExpectPing().WillReturnError(&mysql.MySQLError{Number: 1045, Message: "Access denied for user"})
+	mock.ExpectPing()
+	mock.ExpectBegin()
+	mock.ExpectExec("CALL DOLT_PULL").WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectCommit()
+
+	store := &DoltStore{connStr: "user:pass@tcp(127.0.0.1:3306)/beads", credCommand: cmd}
+	if err := store.execWithLongTimeout(context.Background(), "CALL DOLT_PULL(?, ?)", "origin", "main"); err != nil {
+		t.Fatalf("execWithLongTimeout must recover past the revoked-token dial, got: %v", err)
+	}
+
+	credCacheMu.Lock()
+	_, stillCached := credCache[cmd]
+	credCacheMu.Unlock()
+	if stillCached {
+		t.Fatal("revoked-token dial must invalidate the cached credential so the retry re-mints")
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sqlmock expectations: %v", err)
+	}
+}
+
+// TestPrimeCredentialedConn_StaticPathIsNoOp verifies the static-user/local path
+// (empty credCommand) is left byte-for-byte unchanged: priming adds no dial.
+func TestPrimeCredentialedConn_StaticPathIsNoOp(t *testing.T) {
+	db, mock, err := sqlmock.New(sqlmock.MonitorPingsOption(true))
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	// No ping is expected; a stray dial would surface here and fail the check.
+	store := &DoltStore{} // credCommand == ""
+	if err := store.primeCredentialedConn(context.Background(), db); err != nil {
+		t.Fatalf("static path must be a no-op, got: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("static path must not dial: %v", err)
+	}
+}
+
+// TestPrimeCredentialedConn_NonAuthErrorNotRetried verifies a non-auth dial error
+// surfaces immediately without dropping the cached credential or re-dialing — only a
+// MySQL 1045 triggers the invalidate-and-retry recovery.
+func TestPrimeCredentialedConn_NonAuthErrorNotRetried(t *testing.T) {
+	const cmd = "rotating-helper"
+	credCacheMu.Lock()
+	credCache = map[string]cachedCred{cmd: {token: "live", expires: time.Now().Add(time.Hour)}}
+	credCacheMu.Unlock()
+	t.Cleanup(func() {
+		credCacheMu.Lock()
+		credCache = map[string]cachedCred{}
+		credCacheMu.Unlock()
+	})
+
+	db, mock, err := sqlmock.New(sqlmock.MonitorPingsOption(true))
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	mock.ExpectPing().WillReturnError(errors.New("driver: bad connection"))
+
+	store := &DoltStore{credCommand: cmd}
+	if err := store.primeCredentialedConn(context.Background(), db); err == nil {
+		t.Fatal("a non-auth dial error must surface")
+	}
+	credCacheMu.Lock()
+	_, stillCached := credCache[cmd]
+	credCacheMu.Unlock()
+	if !stillCached {
+		t.Fatal("a non-auth error must not invalidate the cached credential")
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("must not re-dial after a non-auth error: %v", err)
+	}
+}

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -696,6 +696,21 @@ func (s *DoltStore) withRetryTx(ctx context.Context, fn func(tx *sql.Tx) error) 
 		if err == nil {
 			return nil
 		}
+		// A rotating credential revoked before its cached expiry surfaces as a
+		// server auth rejection (MySQL 1045) when a write dials a fresh pooled
+		// connection. Mirror withRetry: drop the cached token so the retry's new
+		// dial re-mints via BeforeConnect, only on the credential-command path (a
+		// static user has nothing to refresh). A pre-commit rejection is safe to
+		// replay; a commit-phase rejection stays permanent for the same
+		// double-apply reason as a commit-phase connection loss below.
+		if s.credCommand != "" && isAuthError(err) {
+			invalidateCredentialToken(s.credCommand)
+			if errors.Is(err, errCommitPhase) {
+				return backoff.Permanent(fmt.Errorf("write commit result indeterminate after auth rejection (not retried to avoid double-apply): %w", err))
+			}
+			doltMetrics.writeRetries.Add(ctx, 1, metric.WithAttributes(attribute.String("type", "auth")))
+			return err // pre-commit auth rejection: retryable after cache invalidation
+		}
 		// Serialization failures (1213/1205) guarantee a server-side rollback,
 		// so the write never landed — safe to replay at any phase.
 		if isSerializationError(err) {

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -219,8 +219,9 @@ type Config struct {
 	// CredentialCommand is the helper command re-run at each new physical
 	// connection dial (the hosted credential-command path). Empty means the
 	// static ServerUser is baked into the DSN and connections use plain
-	// sql.Open. Set by applyResolvedConfig from the dolt_credential_command
-	// config when no explicit ServerUser is configured.
+	// sql.Open. Set by applyResolvedConfig from a trusted user-local source
+	// (BEADS_DOLT_CREDENTIAL_COMMAND or the central server config) when no
+	// explicit ServerUser is configured — never from tracked project metadata.
 	CredentialCommand string
 
 	// Remote auth for Hosted Dolt push/pull (optional)

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -488,6 +488,10 @@ func (s *DoltStore) withRetry(ctx context.Context, op func() error) error {
 		// re-mints a fresh one via BeforeConnect; only on the credential-command path
 		// (a static user has nothing to refresh). Bounded by the retry backoff, so a
 		// genuinely dead credential fails after a few attempts rather than looping.
+		// Unlike withRetryTx this retries unconditionally (no errCommitPhase guard):
+		// a 1045 is a dial-time rejection — it can only surface where a new physical
+		// connection authenticates, which is strictly before any commit on it — so the
+		// RunInTransaction write path this also wraps can never replay a committed write here.
 		if err != nil && s.credCommand != "" && isAuthError(err) {
 			invalidateCredentialToken(s.credCommand)
 			return err
@@ -1355,6 +1359,40 @@ func buildServerDSN(cfg *Config, database string) string {
 	return parsed.FormatDSN()
 }
 
+// sideConnOpener opens the one-shot *sql.DB used by the long-timeout (push/pull)
+// and schema-migration side pools. Like credRunner, it is a package var so tests
+// can substitute a mock connection without a live server; production always
+// resolves to openSQLDB.
+var sideConnOpener = openSQLDB
+
+// primeCredentialedConn forces the single physical dial of a one-shot side-pool
+// *sql.DB to happen up front, recovering once from a rotating credential revoked
+// before its cached expiry. The long-timeout and migration side pools dial outside
+// withRetry/withRetryTx, so without this a revoked-token MySQL 1045 on the pool's
+// first dial would surface as a permanent failure until another path evicts the
+// cached token or it naturally expires. Mirroring withRetry/withRetryTx, it drops
+// the cached token (invalidateCredentialToken) so the retry's dial re-mints a fresh
+// one via BeforeConnect. Only the credential-command path can refresh; static-user
+// and local paths are left byte-for-byte unchanged (no extra dial).
+//
+// Priming deliberately isolates the retryable dial from the operation that follows.
+// A 1045 can only surface when a new physical connection authenticates — strictly
+// before any statement runs on it — so once the ping authenticates, the caller's
+// Begin/Exec/Commit reuses this connection (these pools pin MaxOpenConns=1) and is
+// never re-dialed. The operation therefore runs exactly once, and the auth retry
+// never replays committed side-pool work.
+func (s *DoltStore) primeCredentialedConn(ctx context.Context, db *sql.DB) error {
+	if s.credCommand == "" {
+		return nil
+	}
+	err := db.PingContext(ctx)
+	if err != nil && isAuthError(err) {
+		invalidateCredentialToken(s.credCommand)
+		err = db.PingContext(ctx)
+	}
+	return err
+}
+
 // execWithLongTimeout opens a one-shot database connection with readTimeout=5m
 // and executes the given query. Push/pull operations can exceed the default
 // readTimeout when the server performs network I/O to git remotes.
@@ -1369,12 +1407,15 @@ func (s *DoltStore) execWithLongTimeout(ctx context.Context, query string, args 
 		return fmt.Errorf("failed to parse DSN for long-timeout connection: %w", err)
 	}
 	cfg.ReadTimeout = 5 * time.Minute
-	db, err := openSQLDB(cfg.FormatDSN(), s.credCommand)
+	db, err := sideConnOpener(cfg.FormatDSN(), s.credCommand)
 	if err != nil {
 		return fmt.Errorf("failed to open long-timeout connection: %w", err)
 	}
 	defer db.Close()
 	db.SetMaxOpenConns(1)
+	if err := s.primeCredentialedConn(ctx, db); err != nil {
+		return fmt.Errorf("failed to establish long-timeout connection: %w", err)
+	}
 	tx, err := db.BeginTx(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("failed to begin transaction: %w", err)
@@ -1396,12 +1437,15 @@ func (s *DoltStore) execWithLongTimeoutNoTx(ctx context.Context, query string, a
 		return fmt.Errorf("failed to parse DSN for long-timeout connection: %w", err)
 	}
 	cfg.ReadTimeout = 5 * time.Minute
-	db, err := openSQLDB(cfg.FormatDSN(), s.credCommand)
+	db, err := sideConnOpener(cfg.FormatDSN(), s.credCommand)
 	if err != nil {
 		return fmt.Errorf("failed to open long-timeout connection: %w", err)
 	}
 	defer db.Close()
 	db.SetMaxOpenConns(1)
+	if err := s.primeCredentialedConn(ctx, db); err != nil {
+		return fmt.Errorf("failed to establish long-timeout connection: %w", err)
+	}
 	_, err = db.ExecContext(ctx, query, args...)
 	return err
 }
@@ -1645,7 +1689,7 @@ func (s *DoltStore) initSchema(ctx context.Context) error {
 	// which then blocks every subsequent migration attempt. Run the migration
 	// pass over a dedicated connection with no read/write timeout. Cancellation
 	// is governed by the caller's context, not a fixed deadline.
-	migDB, err := s.openMigrationDB()
+	migDB, err := s.openMigrationDB(ctx)
 	if err != nil {
 		return err
 	}
@@ -1670,7 +1714,7 @@ func (s *DoltStore) initSchema(ctx context.Context) error {
 // per-database advisory lock, with retry for transient lock contention.
 // Implements storage.SchemaMigrator.
 func (s *DoltStore) ApplySchemaMigrations(ctx context.Context) (int, error) {
-	migDB, err := s.openMigrationDB()
+	migDB, err := s.openMigrationDB(ctx)
 	if err != nil {
 		return 0, err
 	}
@@ -1682,18 +1726,22 @@ func (s *DoltStore) ApplySchemaMigrations(ctx context.Context) (int, error) {
 // read/write timeout. Migrations may run far longer than the default 10s pool
 // timeout, and timing out part-way leaves the database in a dirty, half-migrated
 // state. The single connection is closed by the caller once migration completes.
-func (s *DoltStore) openMigrationDB() (*sql.DB, error) {
+func (s *DoltStore) openMigrationDB(ctx context.Context) (*sql.DB, error) {
 	cfg, err := mysql.ParseDSN(s.connStr)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse DSN for migration connection: %w", err)
 	}
 	cfg.ReadTimeout = 0
 	cfg.WriteTimeout = 0
-	db, err := openSQLDB(cfg.FormatDSN(), s.credCommand)
+	db, err := sideConnOpener(cfg.FormatDSN(), s.credCommand)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open migration connection: %w", err)
 	}
 	db.SetMaxOpenConns(1)
+	if err := s.primeCredentialedConn(ctx, db); err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("failed to establish migration connection: %w", err)
+	}
 	return db, nil
 }
 
@@ -2654,17 +2702,21 @@ func (s *DoltStore) pullTransport(ctx context.Context, remote string) error {
 // openLongTimeoutConn opens a dedicated single-connection *sql.DB to this store's
 // database with a long read timeout, for merge/pull/conflict operations that can run
 // longer than the default connection timeout. The caller must Close the returned DB.
-func (s *DoltStore) openLongTimeoutConn() (*sql.DB, error) {
+func (s *DoltStore) openLongTimeoutConn(ctx context.Context) (*sql.DB, error) {
 	cfg, err := mysql.ParseDSN(s.connStr)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse DSN for long-timeout connection: %w", err)
 	}
 	cfg.ReadTimeout = 5 * time.Minute
-	db, err := openSQLDB(cfg.FormatDSN(), s.credCommand)
+	db, err := sideConnOpener(cfg.FormatDSN(), s.credCommand)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open long-timeout connection: %w", err)
 	}
 	db.SetMaxOpenConns(1)
+	if err := s.primeCredentialedConn(ctx, db); err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("failed to establish long-timeout connection: %w", err)
+	}
 	return db, nil
 }
 
@@ -2672,7 +2724,7 @@ func (s *DoltStore) openLongTimeoutConn() (*sql.DB, error) {
 // fallback targets it directly, so pulls from non-default remotes (PullRemote,
 // federation peers) no longer fall back to s.remote.
 func (s *DoltStore) pullWithAutoResolve(ctx context.Context, remote string, query string, args ...any) error {
-	db, err := s.openLongTimeoutConn()
+	db, err := s.openLongTimeoutConn(ctx)
 	if err != nil {
 		return err
 	}

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -162,6 +162,7 @@ type DoltStore struct {
 	database      string       // Database name (subdirectory under dbPath)
 	closed        atomic.Bool  // Tracks whether Close() has been called
 	connStr       string       // Connection string for reconnection
+	credCommand   string       // non-empty on the hosted credential-command path; drives openSQLDB
 	mu            sync.RWMutex // Protects concurrent access
 	readOnly      bool         // True if opened in read-only mode
 	credentialKey []byte       // Random encryption key for federation credentials
@@ -214,6 +215,13 @@ type Config struct {
 	ServerUser     string // MySQL user (default: root)
 	ServerPassword string // MySQL password (default: empty, can be set via BEADS_DOLT_PASSWORD)
 	ServerTLS      bool   // Enable TLS for server connections (required for Hosted Dolt)
+
+	// CredentialCommand is the helper command re-run at each new physical
+	// connection dial (the hosted credential-command path). Empty means the
+	// static ServerUser is baked into the DSN and connections use plain
+	// sql.Open. Set by applyResolvedConfig from the dolt_credential_command
+	// config when no explicit ServerUser is configured.
+	CredentialCommand string
 
 	// Remote auth for Hosted Dolt push/pull (optional)
 	// When set, Push/Pull use the --user flag and set DOLT_REMOTE_PASSWORD env var.
@@ -313,6 +321,20 @@ func newServerRetryBackoff() backoff.BackOff {
 	bo := backoff.NewExponentialBackOff()
 	bo.MaxElapsedTime = serverRetryMaxElapsed
 	return bo
+}
+
+// isAuthError reports whether err is a MySQL access-denied (1045) failure — the
+// server rejecting a presented credential. On the credential-command path this is
+// the signal that a cached rotating token was revoked before its recorded expiry.
+func isAuthError(err error) bool {
+	if err == nil {
+		return false
+	}
+	var myErr *mysql.MySQLError
+	if errors.As(err, &myErr) {
+		return myErr.Number == 1045
+	}
+	return strings.Contains(strings.ToLower(err.Error()), "access denied")
 }
 
 // isRetryableError returns true if the error is a transient connection error
@@ -460,6 +482,15 @@ func (s *DoltStore) withRetry(ctx context.Context, op func() error) error {
 	err := backoff.Retry(func() error {
 		attempts++
 		err := op()
+		// A rotating credential revoked before its cached expiry surfaces as a server
+		// auth rejection (MySQL 1045). Drop the cached token so the retry's new dial
+		// re-mints a fresh one via BeforeConnect; only on the credential-command path
+		// (a static user has nothing to refresh). Bounded by the retry backoff, so a
+		// genuinely dead credential fails after a few attempts rather than looping.
+		if err != nil && s.credCommand != "" && isAuthError(err) {
+			invalidateCredentialToken(s.credCommand)
+			return err
+		}
 		if err != nil && isRetryableError(err) {
 			// Record connection-level failures to the circuit breaker
 			if s.breaker != nil && isConnectionError(err) {
@@ -504,6 +535,7 @@ var doltMetrics struct {
 	connAcquireMs       metric.Float64Histogram
 	poolWaitCount       metric.Int64Counter
 	poolWaitMs          metric.Float64Histogram
+	ignoredTxFreshPool  metric.Int64Counter
 }
 
 func init() {
@@ -543,6 +575,10 @@ func init() {
 	doltMetrics.poolWaitMs, _ = m.Float64Histogram("bd.db.pool_wait_ms",
 		metric.WithDescription("Total time connections spent waiting due to pool exhaustion"),
 		metric.WithUnit("ms"),
+	)
+	doltMetrics.ignoredTxFreshPool, _ = m.Int64Counter("bd.db.ignored_tx_fresh_pool",
+		metric.WithDescription("ignored-tx transactions that fell back to a dedicated single-connection pool instead of borrowing from the main pool"),
+		metric.WithUnit("{tx}"),
 	)
 }
 
@@ -1142,6 +1178,7 @@ func newServerMode(ctx context.Context, cfg *Config) (*DoltStore, error) {
 		beadsDir:             beadsDir,
 		database:             cfg.Database,
 		connStr:              connStr,
+		credCommand:          cfg.CredentialCommand,
 		breaker:              breaker,
 		committerName:        cfg.CommitterName,
 		committerEmail:       cfg.CommitterEmail,
@@ -1316,7 +1353,7 @@ func (s *DoltStore) execWithLongTimeout(ctx context.Context, query string, args 
 		return fmt.Errorf("failed to parse DSN for long-timeout connection: %w", err)
 	}
 	cfg.ReadTimeout = 5 * time.Minute
-	db, err := sql.Open("mysql", cfg.FormatDSN())
+	db, err := openSQLDB(cfg.FormatDSN(), s.credCommand)
 	if err != nil {
 		return fmt.Errorf("failed to open long-timeout connection: %w", err)
 	}
@@ -1343,7 +1380,7 @@ func (s *DoltStore) execWithLongTimeoutNoTx(ctx context.Context, query string, a
 		return fmt.Errorf("failed to parse DSN for long-timeout connection: %w", err)
 	}
 	cfg.ReadTimeout = 5 * time.Minute
-	db, err := sql.Open("mysql", cfg.FormatDSN())
+	db, err := openSQLDB(cfg.FormatDSN(), s.credCommand)
 	if err != nil {
 		return fmt.Errorf("failed to open long-timeout connection: %w", err)
 	}
@@ -1396,7 +1433,7 @@ func applyPoolLimits(db *sql.DB, cfg *Config) {
 func openServerConnection(ctx context.Context, cfg *Config) (*sql.DB, string, error) {
 	connStr := buildServerDSN(cfg, cfg.Database)
 
-	db, err := sql.Open("mysql", connStr)
+	db, err := openSQLDB(connStr, cfg.CredentialCommand)
 	if err != nil {
 		return nil, "", fmt.Errorf("failed to open Dolt server connection: %w", err)
 	}
@@ -1411,7 +1448,7 @@ func openServerConnection(ctx context.Context, cfg *Config) (*sql.DB, string, er
 	// Ensure database exists (may need to create it)
 	// First connect without database to create it
 	initConnStr := buildServerDSN(cfg, "")
-	initDB, err := sql.Open("mysql", initConnStr)
+	initDB, err := openSQLDB(initConnStr, cfg.CredentialCommand)
 	if err != nil {
 		_ = db.Close()
 		return nil, "", fmt.Errorf("failed to open init connection: %w", err)
@@ -1636,7 +1673,7 @@ func (s *DoltStore) openMigrationDB() (*sql.DB, error) {
 	}
 	cfg.ReadTimeout = 0
 	cfg.WriteTimeout = 0
-	db, err := sql.Open("mysql", cfg.FormatDSN())
+	db, err := openSQLDB(cfg.FormatDSN(), s.credCommand)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open migration connection: %w", err)
 	}
@@ -2607,7 +2644,7 @@ func (s *DoltStore) openLongTimeoutConn() (*sql.DB, error) {
 		return nil, fmt.Errorf("failed to parse DSN for long-timeout connection: %w", err)
 	}
 	cfg.ReadTimeout = 5 * time.Minute
-	db, err := sql.Open("mysql", cfg.FormatDSN())
+	db, err := openSQLDB(cfg.FormatDSN(), s.credCommand)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open long-timeout connection: %w", err)
 	}

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -335,6 +335,11 @@ func isAuthError(err error) bool {
 	if errors.As(err, &myErr) {
 		return myErr.Number == 1045
 	}
+	// Backstop for a 1045 that reached us without its typed *mysql.MySQLError (e.g.
+	// stringified across a boundary). The driver always types real server auth
+	// rejections, so callers must not route remote/git auth failures (DOLT_PULL/PUSH
+	// "access denied") through here, or this would invalidate the credential cache
+	// for an unrelated error.
 	return strings.Contains(strings.ToLower(err.Error()), "access denied")
 }
 
@@ -1181,8 +1186,13 @@ func newServerMode(ctx context.Context, cfg *Config) (*DoltStore, error) {
 		return nil, err
 	}
 
-	// Test connection
-	if err := db.PingContext(ctx); err != nil {
+	// Test connection. Wrap in the same stale-credential recovery as the open-time
+	// dials above: this is the last credentialed dial before the DoltStore (and its
+	// retry handlers) exists, so a rotating token revoked before its cached expiry
+	// must invalidate-and-re-dial here too rather than fail store construction.
+	if err := retryStaleCredentialOpen(cfg.CredentialCommand, func() error {
+		return db.PingContext(ctx)
+	}); err != nil {
 		_ = db.Close()
 		return nil, fmt.Errorf("failed to ping Dolt database: %w", err)
 	}
@@ -1365,6 +1375,11 @@ func buildServerDSN(cfg *Config, database string) string {
 // resolves to openSQLDB.
 var sideConnOpener = openSQLDB
 
+// serverConnOpener opens the main and init *sql.DB handles in openServerConnection.
+// Like sideConnOpener it is a package var so tests can substitute a mock connection
+// without a live server; production always resolves to openSQLDB.
+var serverConnOpener = openSQLDB
+
 // primeCredentialedConn forces the single physical dial of a one-shot side-pool
 // *sql.DB to happen up front, recovering once from a rotating credential revoked
 // before its cached expiry. The long-timeout and migration side pools dial outside
@@ -1489,11 +1504,32 @@ func applyPoolLimits(db *sql.DB, cfg *Config) {
 	db.SetConnMaxIdleTime(idle)
 }
 
+// retryStaleCredentialOpen runs a store-open operation that performs a credentialed
+// dial, recovering once from a rotating credential revoked before its cached expiry.
+// The first store-open dials — databaseExistsOnServer's SHOW DATABASES, CREATE
+// DATABASE, and the open-time ping — happen before the DoltStore, and therefore its
+// withRetry/withRetryTx/primeCredentialedConn handlers, exist. Without this a
+// revoked-token MySQL 1045 on those dials would surface as a permanent store-open
+// failure until the cached token naturally expires. Mirroring primeCredentialedConn,
+// it drops the cached token (invalidateCredentialToken) so the retry's dial re-mints a
+// fresh one via BeforeConnect; only the credential-command path can refresh, so
+// static-user and local paths run op exactly once with no extra dial. Every wrapped
+// store-open op is idempotent (a read, CREATE ... IF NOT EXISTS, or a ping), so the
+// single retry never duplicates an effect.
+func retryStaleCredentialOpen(credCommand string, op func() error) error {
+	err := op()
+	if err != nil && credCommand != "" && isAuthError(err) {
+		invalidateCredentialToken(credCommand)
+		err = op()
+	}
+	return err
+}
+
 // openServerConnection opens a connection to a dolt sql-server via MySQL protocol
 func openServerConnection(ctx context.Context, cfg *Config) (*sql.DB, string, error) {
 	connStr := buildServerDSN(cfg, cfg.Database)
 
-	db, err := openSQLDB(connStr, cfg.CredentialCommand)
+	db, err := serverConnOpener(connStr, cfg.CredentialCommand)
 	if err != nil {
 		return nil, "", fmt.Errorf("failed to open Dolt server connection: %w", err)
 	}
@@ -1508,7 +1544,7 @@ func openServerConnection(ctx context.Context, cfg *Config) (*sql.DB, string, er
 	// Ensure database exists (may need to create it)
 	// First connect without database to create it
 	initConnStr := buildServerDSN(cfg, "")
-	initDB, err := openSQLDB(initConnStr, cfg.CredentialCommand)
+	initDB, err := serverConnOpener(initConnStr, cfg.CredentialCommand)
 	if err != nil {
 		_ = db.Close()
 		return nil, "", fmt.Errorf("failed to open init connection: %w", err)
@@ -1540,7 +1576,12 @@ func openServerConnection(ctx context.Context, cfg *Config) (*sql.DB, string, er
 	// because LIKE treats _ and % as wildcards and Dolt does not support backslash
 	// escaping. Database names like "beads_vulcan" contain underscores which would
 	// match unrelated databases with LIKE.
-	dbExists, checkErr := databaseExistsOnServer(ctx, initDB, cfg.Database)
+	var dbExists bool
+	checkErr := retryStaleCredentialOpen(cfg.CredentialCommand, func() error {
+		var e error
+		dbExists, e = databaseExistsOnServer(ctx, initDB, cfg.Database)
+		return e
+	})
 	if checkErr != nil {
 		_ = db.Close()
 		return nil, "", fmt.Errorf("failed to check if database %q exists on server %s:%d: %w",
@@ -1553,7 +1594,10 @@ func openServerConnection(ctx context.Context, cfg *Config) (*sql.DB, string, er
 			return nil, "", databaseNotFoundError(cfg)
 		}
 
-		_, err = initDB.ExecContext(ctx, fmt.Sprintf("CREATE DATABASE IF NOT EXISTS `%s`", cfg.Database)) //nolint:gosec // G201: cfg.Database validated by ValidateDatabaseName above
+		err = retryStaleCredentialOpen(cfg.CredentialCommand, func() error {
+			_, e := initDB.ExecContext(ctx, fmt.Sprintf("CREATE DATABASE IF NOT EXISTS `%s`", cfg.Database)) //nolint:gosec // G201: cfg.Database validated by ValidateDatabaseName above
+			return e
+		})
 		if err != nil {
 			// Dolt may return error 1007 even with IF NOT EXISTS - ignore if database already exists
 			errLower := strings.ToLower(err.Error())
@@ -1580,13 +1624,21 @@ func openServerConnection(ctx context.Context, cfg *Config) (*sql.DB, string, er
 	bo.MaxElapsedTime = 10 * time.Second
 	if err := backoff.Retry(func() error {
 		pingErr := db.PingContext(ctx)
-		if pingErr != nil && isRetryableError(pingErr) {
-			return pingErr // retryable — backoff will retry
+		if pingErr == nil {
+			return nil
 		}
-		if pingErr != nil {
-			return backoff.Permanent(pingErr)
+		// A rotating credential revoked before its cached expiry surfaces as MySQL
+		// 1045 on this open-time dial too, before the DoltStore's retry handlers
+		// exist. Drop the cached token so the next ping re-mints via BeforeConnect;
+		// only on the credential-command path (a static user has nothing to refresh).
+		if cfg.CredentialCommand != "" && isAuthError(pingErr) {
+			invalidateCredentialToken(cfg.CredentialCommand)
+			return pingErr // retryable — the re-dial re-mints
 		}
-		return nil
+		if isRetryableError(pingErr) {
+			return pingErr // retryable — backoff will retry (catalog race, GH-1851)
+		}
+		return backoff.Permanent(pingErr)
 	}, backoff.WithContext(bo, ctx)); err != nil {
 		_ = db.Close()
 		return nil, "", fmt.Errorf("database %q not available after CREATE DATABASE: %w", cfg.Database, err)

--- a/internal/storage/dolt/transaction.go
+++ b/internal/storage/dolt/transaction.go
@@ -98,13 +98,17 @@ func (s *DoltStore) runDoltTransaction(ctx context.Context, commitMsg string, fn
 		return fmt.Errorf("failed to begin regular tx: %w", err)
 	}
 
-	ignoredDB, ignoredConn, ignoredTx, err := s.beginIgnoredTxOnBranch(ctx, currentBranch)
+	// NOTE (GH#3140 metrics skew): the pool-wait bracket above measures only the
+	// FIRST acquisition (the regular conn). A borrow inside beginIgnoredTxOnBranch
+	// that has to wait increments the pool's global WaitCount, which the NEXT
+	// transaction's delta then misattributes. Rare given the InUse pre-check in
+	// borrowConnForIgnoredTx; not worth restructuring the metrics for.
+	ignoredCleanup, ignoredTx, err := s.beginIgnoredTxOnBranch(ctx, currentBranch)
 	if err != nil {
 		_ = regularTx.Rollback()
 		return err
 	}
-	defer ignoredDB.Close()
-	defer ignoredConn.Close()
+	defer ignoredCleanup()
 
 	tx := &doltTransaction{regularTx: regularTx, ignoredTx: ignoredTx, store: s}
 
@@ -138,38 +142,103 @@ func (s *DoltStore) runDoltTransaction(ctx context.Context, commitMsg string, fn
 	return nil
 }
 
-func (s *DoltStore) beginIgnoredTxOnBranch(ctx context.Context, branch string) (*sql.DB, *sql.Conn, *sql.Tx, error) {
-	// Use an independent single-connection pool for ignored tables. Reusing the
-	// main pool can deadlock when MaxOpenConns=1, and each Dolt SQL session has
-	// its own active branch. This intentionally pays one extra connection setup
-	// for mixed regular/ignored writes so the ignored transaction can be checked
-	// out to the regular transaction's branch before writes.
-	db, err := sql.Open("mysql", s.connStr)
+// ignoredTxBorrowTimeout bounds how long a borrow of a second warm connection
+// from the main pool may wait before falling back to a dedicated fresh dial. It
+// keeps the second acquisition from ever waiting unboundedly while the caller
+// already holds the first (regular-tx) connection, which is what makes deadlock
+// impossible by construction on the borrow path.
+const ignoredTxBorrowTimeout = 250 * time.Millisecond
+
+// beginIgnoredTxOnBranch starts the ignored-tables transaction, checked out to
+// the regular transaction's branch. It borrows a second warm connection from the
+// main pool when one is safely available — the hosted-gateway churn fix: once the
+// pool is warm this costs zero new MySQL handshakes and zero Dolt session-setup
+// round-trips per write. It falls back to a dedicated single-connection pool when
+// borrowing could deadlock (MaxOpenConns==1, the documented case that every
+// branch-isolated test exercises) or when the pool is exhausted or a borrowed
+// connection turns out to be stale.
+//
+// The returned cleanup closure releases whichever acquisition path was taken, so
+// the caller does not need to know which one ran.
+func (s *DoltStore) beginIgnoredTxOnBranch(ctx context.Context, branch string) (cleanup func(), tx *sql.Tx, err error) {
+	// Borrow fast path: reuse an already-open pooled connection.
+	if conn := s.borrowConnForIgnoredTx(ctx); conn != nil {
+		tx, err := beginTxOnConn(ctx, conn, branch)
+		if err == nil {
+			return func() { _ = conn.Close() }, tx, nil
+		}
+		// A stale pooled connection or a bad branch: a fresh dial always worked
+		// before, so discard this one and fall through to the fallback.
+		_ = conn.Close()
+	}
+
+	// Fallback: a dedicated single-connection pool. On the hosted credential-
+	// command path openSQLDB re-resolves a live token per dial, so a fresh
+	// ignored-tx connection here still authenticates after the open-time token
+	// has rotated.
+	doltMetrics.ignoredTxFreshPool.Add(ctx, 1)
+	db, err := openSQLDB(s.connStr, s.credCommand)
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("failed to open ignored tx connection: %w", err)
+		return nil, nil, fmt.Errorf("failed to open ignored tx connection: %w", err)
 	}
 	db.SetMaxOpenConns(1)
 
 	conn, err := db.Conn(ctx)
 	if err != nil {
 		_ = db.Close()
-		return nil, nil, nil, fmt.Errorf("failed to acquire ignored tx connection: %w", err)
+		return nil, nil, fmt.Errorf("failed to acquire ignored tx connection: %w", err)
 	}
 
-	if _, err := conn.ExecContext(ctx, "CALL DOLT_CHECKOUT(?)", branch); err != nil {
-		_ = conn.Close()
-		_ = db.Close()
-		return nil, nil, nil, fmt.Errorf("failed to checkout ignored tx branch %s: %w", branch, err)
-	}
-
-	tx, err := conn.BeginTx(ctx, nil)
+	tx, err = beginTxOnConn(ctx, conn, branch)
 	if err != nil {
 		_ = conn.Close()
 		_ = db.Close()
-		return nil, nil, nil, fmt.Errorf("failed to begin ignored tx: %w", err)
+		return nil, nil, err
 	}
 
-	return db, conn, tx, nil
+	return func() { _ = conn.Close(); _ = db.Close() }, tx, nil
+}
+
+// borrowConnForIgnoredTx returns a second connection borrowed from the main pool
+// for the ignored-tables transaction, or nil if borrowing is unsafe or would
+// block. The caller falls back to a dedicated single-connection pool on nil.
+func (s *DoltStore) borrowConnForIgnoredTx(ctx context.Context) *sql.Conn {
+	st := s.db.Stats()
+	// MaxOpenConns==1: the caller already pinned the pool's only connection for
+	// the regular tx, so a borrow would deadlock. Preserve today's behavior.
+	if st.MaxOpenConnections == 1 {
+		return nil
+	}
+	// Exhausted pool: skip the wait and go straight to the fallback.
+	// MaxOpenConnections==0 means unlimited — always safe to grow.
+	if st.MaxOpenConnections > 0 && st.InUse >= st.MaxOpenConnections {
+		return nil
+	}
+
+	bctx, cancel := context.WithTimeout(ctx, ignoredTxBorrowTimeout)
+	defer cancel()
+	conn, err := s.db.Conn(bctx)
+	if err != nil {
+		// Lost a stats/Conn race, parent ctx canceled, or a slow token-mint dial
+		// exceeded the borrow timeout — fall back to a fresh dial.
+		return nil
+	}
+	return conn
+}
+
+// beginTxOnConn checks a connection out to branch and begins a transaction on it.
+// Both the borrow and fallback paths use it, so their session setup is identical.
+// Every Dolt SQL session has its own active branch, so the explicit checkout is
+// required even on a borrowed pooled connection.
+func beginTxOnConn(ctx context.Context, conn *sql.Conn, branch string) (*sql.Tx, error) {
+	if _, err := conn.ExecContext(ctx, "CALL DOLT_CHECKOUT(?)", branch); err != nil {
+		return nil, fmt.Errorf("failed to checkout ignored tx branch %s: %w", branch, err)
+	}
+	tx, err := conn.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to begin ignored tx: %w", err)
+	}
+	return tx, nil
 }
 
 // isDoltNothingToCommit returns true if the error indicates there were no

--- a/internal/storage/dolt/transaction.go
+++ b/internal/storage/dolt/transaction.go
@@ -161,14 +161,17 @@ const ignoredTxBorrowTimeout = 250 * time.Millisecond
 // The returned cleanup closure releases whichever acquisition path was taken, so
 // the caller does not need to know which one ran.
 func (s *DoltStore) beginIgnoredTxOnBranch(ctx context.Context, branch string) (cleanup func(), tx *sql.Tx, err error) {
-	// Borrow fast path: reuse an already-open pooled connection.
+	// Borrow fast path: reuse an already-open pooled connection. Unlike the
+	// fallback below, this path never switches the session's branch — see
+	// beginBorrowedTx for the pool invariant it preserves.
 	if conn := s.borrowConnForIgnoredTx(ctx); conn != nil {
-		tx, err := beginTxOnConn(ctx, conn, branch)
+		tx, err := beginBorrowedTx(ctx, conn, branch)
 		if err == nil {
 			return func() { _ = conn.Close() }, tx, nil
 		}
-		// A stale pooled connection or a bad branch: a fresh dial always worked
-		// before, so discard this one and fall through to the fallback.
+		// A stale pooled connection or a session on another branch: a fresh
+		// dial always worked before, so discard this one (its session state is
+		// untouched) and fall through to the fallback.
 		_ = conn.Close()
 	}
 
@@ -226,10 +229,43 @@ func (s *DoltStore) borrowConnForIgnoredTx(ctx context.Context) *sql.Conn {
 	return conn
 }
 
-// beginTxOnConn checks a connection out to branch and begins a transaction on it.
-// Both the borrow and fallback paths use it, so their session setup is identical.
-// Every Dolt SQL session has its own active branch, so the explicit checkout is
-// required even on a borrowed pooled connection.
+// beginBorrowedTx begins the ignored-tables transaction on a connection
+// borrowed from the main pool, without ever changing that session's branch.
+//
+// Pool invariant: DOLT_CHECKOUT is session-level, and the borrow cleanup
+// returns the connection to the pool as-is — so switching its branch here
+// would leak a foreign branch into the pool for an unrelated later caller.
+// Every other production checkout site (federation staging, compact, flatten)
+// restores the branch before releasing the connection; the borrow path
+// preserves the same invariant by refusing instead of switching. Today no
+// shipped flow diverges a pool session's branch from the regular tx's branch
+// (DoltStore.Checkout has no non-test callers), so this is defense in depth
+// for future Checkout callers and for multi-connection tests.
+//
+// Instead of an unconditional checkout it verifies the session is already on
+// the requested branch — the overwhelmingly common case — and sends the
+// caller to the fresh-dial fallback otherwise. Same round-trip count as the
+// checkout it replaces (one statement), so the borrow fast path stays free.
+func beginBorrowedTx(ctx context.Context, conn *sql.Conn, branch string) (*sql.Tx, error) {
+	var active string
+	if err := conn.QueryRowContext(ctx, "SELECT active_branch()").Scan(&active); err != nil {
+		return nil, fmt.Errorf("failed to read borrowed conn's active branch: %w", err)
+	}
+	if active != branch {
+		return nil, fmt.Errorf("borrowed conn is on branch %q, want %q: refusing to switch a pooled session's branch", active, branch)
+	}
+	tx, err := conn.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to begin ignored tx: %w", err)
+	}
+	return tx, nil
+}
+
+// beginTxOnConn checks a connection out to branch and begins a transaction on
+// it. Only the fallback path uses it: the fallback owns a dedicated
+// single-connection pool, so checking its session out is safe. Every Dolt SQL
+// session has its own active branch, so the explicit checkout is required on
+// a fresh dial.
 func beginTxOnConn(ctx context.Context, conn *sql.Conn, branch string) (*sql.Tx, error) {
 	if _, err := conn.ExecContext(ctx, "CALL DOLT_CHECKOUT(?)", branch); err != nil {
 		return nil, fmt.Errorf("failed to checkout ignored tx branch %s: %w", branch, err)

--- a/internal/storage/dolt/transaction_borrow_test.go
+++ b/internal/storage/dolt/transaction_borrow_test.go
@@ -1,0 +1,193 @@
+package dolt
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+// These pure-Go unit tests exercise the FIX #1 ignored-tx borrow path using the
+// in-process mock driver from connection_pool_test.go. No Dolt sql-server is
+// needed. An unroutable connStr makes the fresh-pool fallback fail fast and
+// observably, so tests can distinguish a borrow (mock-backed, succeeds) from a
+// fallback (real "mysql" driver, dial error).
+
+const unroutableConnStr = "root@tcp(127.0.0.1:1)/x"
+
+func newMockStore(t *testing.T, maxOpen int) (*DoltStore, *mockDriver) {
+	t.Helper()
+	db, drv := openMockDB(t)
+	db.SetMaxOpenConns(maxOpen)
+	db.SetMaxIdleConns(5)
+	s := &DoltStore{db: db, connStr: unroutableConnStr}
+	t.Cleanup(func() { _ = db.Close() })
+	return s, drv
+}
+
+func TestBorrowConnForIgnoredTxGuards(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("MaxOpenConns==1 never touches the pool", func(t *testing.T) {
+		s, drv := newMockStore(t, 1)
+		if conn := s.borrowConnForIgnoredTx(ctx); conn != nil {
+			_ = conn.Close()
+			t.Fatal("borrow should return nil when MaxOpenConns==1")
+		}
+		if got := drv.opens.Load(); got != 0 {
+			t.Fatalf("drv.opens = %d, want 0 (guard fires before any dial)", got)
+		}
+	})
+
+	t.Run("exhausted pool falls back without waiting", func(t *testing.T) {
+		s, _ := newMockStore(t, 2)
+		c1, err := s.db.Conn(ctx)
+		if err != nil {
+			t.Fatalf("hold conn 1: %v", err)
+		}
+		defer c1.Close()
+		c2, err := s.db.Conn(ctx)
+		if err != nil {
+			t.Fatalf("hold conn 2: %v", err)
+		}
+		defer c2.Close()
+
+		start := time.Now()
+		conn := s.borrowConnForIgnoredTx(ctx)
+		elapsed := time.Since(start)
+		if conn != nil {
+			_ = conn.Close()
+			t.Fatal("borrow should return nil when the pool is exhausted")
+		}
+		if elapsed >= ignoredTxBorrowTimeout {
+			t.Fatalf("borrow took %v, want the InUse pre-check to return well under %v", elapsed, ignoredTxBorrowTimeout)
+		}
+	})
+
+	t.Run("spare capacity borrows a conn", func(t *testing.T) {
+		s, _ := newMockStore(t, 2)
+		c1, err := s.db.Conn(ctx)
+		if err != nil {
+			t.Fatalf("hold conn 1: %v", err)
+		}
+		defer c1.Close()
+
+		conn := s.borrowConnForIgnoredTx(ctx)
+		if conn == nil {
+			t.Fatal("borrow should succeed with spare capacity")
+		}
+		_ = conn.Close()
+	})
+
+	t.Run("unlimited pool always borrows", func(t *testing.T) {
+		s, _ := newMockStore(t, 0)
+		conn := s.borrowConnForIgnoredTx(ctx)
+		if conn == nil {
+			t.Fatal("borrow should succeed on an unlimited pool")
+		}
+		_ = conn.Close()
+	})
+}
+
+func TestIgnoredTxBorrowReusesPooledConn(t *testing.T) {
+	ctx := context.Background()
+	s, drv := newMockStore(t, 10)
+
+	const iterations = 5
+	for i := 0; i < iterations; i++ {
+		cleanup, tx, err := s.beginIgnoredTxOnBranch(ctx, "main")
+		if err != nil {
+			t.Fatalf("iter %d: beginIgnoredTxOnBranch: %v", i, err)
+		}
+		if tx == nil {
+			t.Fatalf("iter %d: nil tx", i)
+		}
+		if err := tx.Commit(); err != nil {
+			t.Fatalf("iter %d: commit: %v", i, err)
+		}
+		cleanup()
+	}
+
+	if got := drv.opens.Load(); got != 1 {
+		t.Fatalf("drv.opens = %d after %d borrows, want 1 (pooled conn reused, no per-write churn)", got, iterations)
+	}
+	if got := drv.countQuery("DOLT_CHECKOUT"); got != iterations {
+		t.Fatalf("DOLT_CHECKOUT ran %d times, want %d (checkout on the borrowed conn each write)", got, iterations)
+	}
+}
+
+func TestIgnoredTxFallsBackWhenPoolPinned(t *testing.T) {
+	ctx := context.Background()
+	s, drv := newMockStore(t, 1) // MaxOpenConns==1 → borrow guard forces the fallback
+
+	cleanup, tx, err := s.beginIgnoredTxOnBranch(ctx, "main")
+	if err == nil {
+		// Resolve the tx BEFORE cleanup: cleanup closes the sql.Conn, which blocks
+		// on closemu until an open Tx is committed/rolled back — a discarded open tx
+		// would hang the package instead of failing this assertion cleanly.
+		if tx != nil {
+			_ = tx.Rollback()
+		}
+		cleanup()
+		t.Fatal("expected the fallback dial to fail against the unroutable connStr")
+	}
+	if !strings.Contains(err.Error(), "failed to acquire ignored tx connection") {
+		t.Fatalf("error = %q, want the fallback's %q", err.Error(), "failed to acquire ignored tx connection")
+	}
+	if got := drv.opens.Load(); got != 0 {
+		t.Fatalf("drv.opens = %d, want 0 (fallback dials the real mysql driver, not the mock)", got)
+	}
+}
+
+// TestIgnoredTxFallbackUsesCredentialCommand is the FIX#1→FIX#2 seam teeth test: the
+// ignored-tx fallback must dial via openSQLDB(s.connStr, s.credCommand), NOT with an
+// empty credential command. MaxOpenConns==1 forces the fallback; the unroutable connStr
+// makes the dial fail, but the mysql connector resolves the credential BEFORE dialing,
+// so a wired fallback invokes the helper. Mutating the fallback to openSQLDB(s.connStr,
+// "") makes credRunner never run here and this test fails.
+func TestIgnoredTxFallbackUsesCredentialCommand(t *testing.T) {
+	var calls int
+	stubCredRunner(t, func(_ context.Context, _ string) ([]byte, error) {
+		calls++
+		return []byte(`{"access_token":"tokFallback","expires_in":300}`), nil
+	})
+
+	db, _ := openMockDB(t)
+	db.SetMaxOpenConns(1) // borrow guard returns nil → the fallback path runs
+	t.Cleanup(func() { _ = db.Close() })
+	s := &DoltStore{db: db, connStr: unroutableConnStr, credCommand: "fallback-cred-probe"}
+
+	cleanup, tx, err := s.beginIgnoredTxOnBranch(context.Background(), "main")
+	if err == nil {
+		if tx != nil {
+			_ = tx.Rollback()
+		}
+		cleanup()
+		t.Fatal("expected the fallback dial to fail against the unroutable connStr")
+	}
+	if calls == 0 {
+		t.Fatal("fallback dialed without resolving the credential command — openSQLDB was called with an empty credCmd (FIX#1→FIX#2 seam broken)")
+	}
+}
+
+func TestIgnoredTxBorrowFallsThroughOnBadConn(t *testing.T) {
+	ctx := context.Background()
+	s, drv := newMockStore(t, 10)
+	drv.failCheckout.Store(true) // borrow succeeds, but DOLT_CHECKOUT fails on it
+
+	cleanup, tx, err := s.beginIgnoredTxOnBranch(ctx, "main")
+	if err == nil {
+		if tx != nil {
+			_ = tx.Rollback()
+		}
+		cleanup()
+		t.Fatal("expected the fallback dial to fail after the borrowed conn's checkout failed")
+	}
+	if !strings.Contains(err.Error(), "failed to acquire ignored tx connection") {
+		t.Fatalf("error = %q, want the fallback's %q (proves it fell through)", err.Error(), "failed to acquire ignored tx connection")
+	}
+	// The borrowed conn must have been closed back to the pool, not leaked.
+	if inUse := s.db.Stats().InUse; inUse != 0 {
+		t.Fatalf("s.db InUse = %d after fall-through, want 0 (borrowed conn returned to pool)", inUse)
+	}
+}

--- a/internal/storage/dolt/transaction_borrow_test.go
+++ b/internal/storage/dolt/transaction_borrow_test.go
@@ -111,8 +111,40 @@ func TestIgnoredTxBorrowReusesPooledConn(t *testing.T) {
 	if got := drv.opens.Load(); got != 1 {
 		t.Fatalf("drv.opens = %d after %d borrows, want 1 (pooled conn reused, no per-write churn)", got, iterations)
 	}
-	if got := drv.countQuery("DOLT_CHECKOUT"); got != iterations {
-		t.Fatalf("DOLT_CHECKOUT ran %d times, want %d (checkout on the borrowed conn each write)", got, iterations)
+	if got := drv.countQuery("active_branch"); got != iterations {
+		t.Fatalf("active_branch ran %d times, want %d (branch verified on the borrowed conn each write)", got, iterations)
+	}
+	if got := drv.countQuery("DOLT_CHECKOUT"); got != 0 {
+		t.Fatalf("DOLT_CHECKOUT ran %d times on the pool, want 0 (a borrow must never switch a pooled session's branch)", got)
+	}
+}
+
+// TestIgnoredTxBorrowRefusesForeignBranch is the pool-invariant teeth test: a
+// pooled session sitting on a branch other than the regular tx's must NOT be
+// checked out to it (the cleanup returns the conn to the pool without a
+// restore, so a checkout would leak the branch switch to an unrelated later
+// caller). The borrow must refuse and fall back to the fresh dial instead.
+func TestIgnoredTxBorrowRefusesForeignBranch(t *testing.T) {
+	ctx := context.Background()
+	s, drv := newMockStore(t, 10)
+	drv.activeBranch.Store("feature-x") // pool sessions report a foreign branch
+
+	cleanup, tx, err := s.beginIgnoredTxOnBranch(ctx, "main")
+	if err == nil {
+		if tx != nil {
+			_ = tx.Rollback()
+		}
+		cleanup()
+		t.Fatal("expected the fallback dial to fail after the borrow refused the foreign branch")
+	}
+	if !strings.Contains(err.Error(), "failed to acquire ignored tx connection") {
+		t.Fatalf("error = %q, want the fallback's %q (proves the borrow refused and fell through)", err.Error(), "failed to acquire ignored tx connection")
+	}
+	if got := drv.countQuery("DOLT_CHECKOUT"); got != 0 {
+		t.Fatalf("DOLT_CHECKOUT ran %d times on the pool, want 0 (borrow must refuse, not switch, a foreign-branch session)", got)
+	}
+	if inUse := s.db.Stats().InUse; inUse != 0 {
+		t.Fatalf("s.db InUse = %d after refusal, want 0 (borrowed conn returned to pool untouched)", inUse)
 	}
 }
 
@@ -173,7 +205,7 @@ func TestIgnoredTxFallbackUsesCredentialCommand(t *testing.T) {
 func TestIgnoredTxBorrowFallsThroughOnBadConn(t *testing.T) {
 	ctx := context.Background()
 	s, drv := newMockStore(t, 10)
-	drv.failCheckout.Store(true) // borrow succeeds, but DOLT_CHECKOUT fails on it
+	drv.failActiveBranch.Store(true) // borrow succeeds, but the conn is stale (branch read fails)
 
 	cleanup, tx, err := s.beginIgnoredTxOnBranch(ctx, "main")
 	if err == nil {
@@ -181,7 +213,7 @@ func TestIgnoredTxBorrowFallsThroughOnBadConn(t *testing.T) {
 			_ = tx.Rollback()
 		}
 		cleanup()
-		t.Fatal("expected the fallback dial to fail after the borrowed conn's checkout failed")
+		t.Fatal("expected the fallback dial to fail after the borrowed conn turned out stale")
 	}
 	if !strings.Contains(err.Error(), "failed to acquire ignored tx connection") {
 		t.Fatalf("error = %q, want the fallback's %q (proves it fell through)", err.Error(), "failed to acquire ignored tx connection")


### PR DESCRIPTION
Kills the ~10–20s/op connection churn against the hosted beads-gateway.

**Measured: ~37 ms/write saved (2.0×) at an 18 ms RTT** (latency-injected local bench; a lower bound — prod TLS makes each fresh dial costlier).

- **FIX #1** — `beginIgnoredTxOnBranch` borrows a warm connection from the main pool instead of a fresh single-conn `sql.DB` per write (MaxOpenConns==1 deadlock guard, InUse exhaustion pre-check, 250 ms bounded borrow; falls back to today's fresh-dial path when unsafe).
- **FIX #2** — `openSQLDB` builds a go-sql-driver `BeforeConnect` connector that re-resolves the cached credential token per new physical dial (hosted credential-command path only). Pooled connections survive EIA rotation. Local/static path byte-identical.
- **Follow-ups** — `resolveCredentialToken` honors the dial context; a MySQL 1045 invalidates the cached token so the retry re-mints.

Unit tests mutation-verified (deleting the BeforeConnect attachment / dropping the fallback credCmd fails the teeth tests); `go vet` clean; dolt-package tests pass in isolation (monolithic-run failures are docker-contention schema-init timeouts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)