### PR TITLE
test(migration): assert bd ready/blocked/close on migrated DB

### DIFF
--- a/scripts/migration-test/lib/snapshot.sh
+++ b/scripts/migration-test/lib/snapshot.sh
@@ -172,3 +172,88 @@ check_fidelity() {
 
     return "$violations"
 }
+
+# Post-upgrade blocker-query assertions.
+#
+# check_fidelity (above) only reads back list/show JSON — it never exercises
+# bd's blocker-aware query paths (bd ready, bd blocked) or bd close on a
+# migrated DB. That is exactly the surface of the historical "bd close"
+# errno 1105 failure on a stale post-migration dependency schema (mybd-ihg5,
+# verified manually for the 1.0.5 release in mybd-kdxj). This function gives
+# that path permanent regression coverage.
+#
+# Uses the BUG->TASK dependency created by create_dataset() (features.sh):
+# `dep add "$bug_id" "$task_id"` means the bug DEPENDS ON the task, i.e. the
+# task is the blocker and the bug is the blocked dependent. Requires
+# DATASET_IDS[task] and DATASET_IDS[bug] to be set and "dependency" to be
+# present in DATASET_FEATURES; skips gracefully (0 violations) when the
+# source version's dataset has no dependency (e.g. `dep add` unsupported).
+#
+# Args: ws bin
+# Returns the number of violations found.
+check_blocker_paths() {
+    local ws="$1"
+    local bin="$2"
+    local violations=0
+
+    local has_dep=false
+    local f
+    for f in "${DATASET_FEATURES[@]:-}"; do
+        if [ "$f" = "dependency" ]; then
+            has_dep=true
+            break
+        fi
+    done
+    if ! $has_dep; then
+        echo "  BLOCKER-CHECK: skipped (no dependency in dataset)"
+        return 0
+    fi
+
+    local blocker_id="${DATASET_IDS[task]:-}"
+    local dependent_id="${DATASET_IDS[bug]:-}"
+    if [ -z "$blocker_id" ] || [ -z "$dependent_id" ]; then
+        echo "  BLOCKER-CHECK: skipped (task/bug id missing from dataset)"
+        return 0
+    fi
+
+    # 1. bd blocked must list the dependent (bug) while the blocker (task) is
+    #    still open — proves is_blocked survived migration on the dependent.
+    local blocked_json
+    blocked_json=$(bd_in "$ws" "$bin" blocked --json 2>/dev/null) || true
+    if ! echo "$blocked_json" | jq -e --arg id "$dependent_id" 'any(.[]?; .id == $id)' >/dev/null 2>&1; then
+        echo -e "  ${RED:-}BLOCKER-CHECK VIOLATION: 'bd blocked' does not list dependent '$dependent_id' while blocker '$blocker_id' is open${NC:-}"
+        violations=$((violations + 1))
+    fi
+
+    # 2. bd ready must NOT list the dependent, but MUST list the blocker.
+    local ready_json
+    ready_json=$(bd_in "$ws" "$bin" ready --json 2>/dev/null) || true
+    if echo "$ready_json" | jq -e --arg id "$dependent_id" 'any(.[]?; .id == $id)' >/dev/null 2>&1; then
+        echo -e "  ${RED:-}BLOCKER-CHECK VIOLATION: 'bd ready' lists blocked dependent '$dependent_id'${NC:-}"
+        violations=$((violations + 1))
+    fi
+    if ! echo "$ready_json" | jq -e --arg id "$blocker_id" 'any(.[]?; .id == $id)' >/dev/null 2>&1; then
+        echo -e "  ${RED:-}BLOCKER-CHECK VIOLATION: 'bd ready' does not list open blocker '$blocker_id'${NC:-}"
+        violations=$((violations + 1))
+    fi
+
+    # 3. Closing the blocker must succeed on the migrated schema (the errno
+    #    1105 surface) and must unblock the dependent (is_blocked recompute).
+    if ! bd_in "$ws" "$bin" close "$blocker_id" >/dev/null 2>&1; then
+        echo -e "  ${RED:-}BLOCKER-CHECK VIOLATION: 'bd close $blocker_id' failed after migration (errno 1105 / stale-schema regression)${NC:-}"
+        violations=$((violations + 1))
+    else
+        local ready_after_json
+        ready_after_json=$(bd_in "$ws" "$bin" ready --json 2>/dev/null) || true
+        if ! echo "$ready_after_json" | jq -e --arg id "$dependent_id" 'any(.[]?; .id == $id)' >/dev/null 2>&1; then
+            echo -e "  ${RED:-}BLOCKER-CHECK VIOLATION: dependent '$dependent_id' not ready after blocker '$blocker_id' closed${NC:-}"
+            violations=$((violations + 1))
+        fi
+    fi
+
+    if [ "$violations" -eq 0 ]; then
+        echo -e "  ${GREEN:-}BLOCKER-CHECK: bd blocked/ready/close all correct on migrated DB${NC:-}"
+    fi
+
+    return "$violations"
+}

--- a/scripts/migration-test/run.sh
+++ b/scripts/migration-test/run.sh
@@ -159,11 +159,20 @@ test_direct_path() {
 
         local violations=0
         check_fidelity "$version" "$SNAPSHOTS_DIR/before.json" "$SNAPSHOTS_DIR/after.json" || violations=$?
+
+        local blocker_violations=0
+        check_blocker_paths "$WS" "$cand_bin" || blocker_violations=$?
+        violations=$((violations + blocker_violations))
+
         stop_dolt_server "$WS"
 
         cleanup_workspace "$WS"
         rm -rf "$SNAPSHOTS_DIR"
-        record_result "$path_label" "AUTO" "direct upgrade, $violations fidelity violations" "" "$violations"
+        if [ "$blocker_violations" -gt 0 ]; then
+            record_result "$path_label" "BLOCKED" "direct upgrade, $violations fidelity/blocker violations" "" "$violations"
+        else
+            record_result "$path_label" "AUTO" "direct upgrade, $violations fidelity violations" "" "$violations"
+        fi
         return 0
     fi
 
@@ -213,11 +222,20 @@ test_direct_path() {
 
         local violations=0
         check_fidelity "$version" "$SNAPSHOTS_DIR/before.json" "$SNAPSHOTS_DIR/after.json" || violations=$?
+
+        local blocker_violations=0
+        check_blocker_paths "$WS" "$cand_bin" || blocker_violations=$?
+        violations=$((violations + blocker_violations))
+
         stop_dolt_server "$WS"
 
         cleanup_workspace "$WS"
         rm -rf "$SNAPSHOTS_DIR"
-        record_result "$path_label" "MANUAL" "recipe: $recipe_name, $violations fidelity violations" "$recipe_name" "$violations"
+        if [ "$blocker_violations" -gt 0 ]; then
+            record_result "$path_label" "BLOCKED" "recipe: $recipe_name, $violations fidelity/blocker violations" "$recipe_name" "$violations"
+        else
+            record_result "$path_label" "MANUAL" "recipe: $recipe_name, $violations fidelity violations" "$recipe_name" "$violations"
+        fi
         return 0
     fi
 
@@ -365,10 +383,18 @@ test_stepping_stone_path() {
     local violations=0
     check_fidelity "${first_ver}" "$SNAPSHOTS_DIR/before.json" "$SNAPSHOTS_DIR/after.json" || violations=$?
 
+    local blocker_violations=0
+    check_blocker_paths "$WS" "$cand_bin" || blocker_violations=$?
+    violations=$((violations + blocker_violations))
+
     stop_dolt_server "$WS"
     cleanup_workspace "$WS"
     rm -rf "$SNAPSHOTS_DIR"
-    record_result "$path_label" "AUTO" "all steps passed, $violations fidelity violations" "" "$violations"
+    if [ "$blocker_violations" -gt 0 ]; then
+        record_result "$path_label" "BLOCKED" "steps passed, $violations fidelity/blocker violations" "" "$violations"
+    else
+        record_result "$path_label" "AUTO" "all steps passed, $violations fidelity violations" "" "$violations"
+    fi
 }
 
 # ---------------------------------------------------------------------------
@@ -449,8 +475,16 @@ if $SELF_TEST; then
             violations=0
             check_fidelity "candidate" "$SNAPSHOTS_DIR/before.json" "$SNAPSHOTS_DIR/after.json" || violations=$?
 
+            blocker_violations=0
+            check_blocker_paths "$WS" "$CAND_BIN" || blocker_violations=$?
+            violations=$((violations + blocker_violations))
+
             stop_dolt_server "$WS"
-            record_result "candidate → candidate" "AUTO" "self-test, $violations fidelity violations" "" "$violations"
+            if [ "$blocker_violations" -gt 0 ]; then
+                record_result "candidate → candidate" "BLOCKED" "self-test, $violations fidelity/blocker violations" "" "$violations"
+            else
+                record_result "candidate → candidate" "AUTO" "self-test, $violations fidelity violations" "" "$violations"
+            fi
         else
             record_result "candidate → candidate" "BLOCKED" "could not create test data"
         fi


### PR DESCRIPTION
## Why

The migration-test harness (`scripts/migration-test/`) builds a BUG→TASK dependency fixture and migrates it in place with the candidate binary, but only verified fidelity by reading back `bd list`/`bd show` JSON. It never exercised bd's blocker-aware query paths (`bd ready`, `bd blocked`) or `bd close` on the migrated DB.

That is exactly the surface of the historical `bd close` **Dolt errno 1105** failure on a stale post-migration dependency schema. That path was only ever verified manually (during the 1.0.5 release gate). This PR gives it permanent regression coverage.

## What

Adds `check_blocker_paths()` in `lib/snapshot.sh`, run after `check_fidelity` in all three harness outcomes (direct upgrade, recipe fallback, stepping-stone) plus `--self-test`. Against the **migrated** DB it asserts:

- `bd blocked` lists the dependent while its blocker is still open
- `bd ready` excludes the blocked dependent but includes the open blocker
- `bd close <blocker>` succeeds on the migrated schema (the errno-1105 surface)
- `bd ready` then lists the now-unblocked dependent (is_blocked recompute)

Violations fold into the existing violation count and flip an AUTO/MANUAL result to BLOCKED, so a regression fails the harness exit code. Skips gracefully (0 violations) when the source version's dataset has no dependency.

### Notes

- Dependency direction matches the fixture: `create_dataset` runs `dep add "$bug_id" "$task_id"` (bug depends on task), so the **task is the blocker** and the **bug is the dependent**. This mirrors the existing Scenario 6 convention in `scripts/upgrade-smoke-test.sh` (PR #4238).
- No change to `cross-version-smoke.yml`: it runs `upgrade-smoke-test.sh`, which already got equivalent blocker-path assertions in #4238. This PR fills the same gap in the separate in-place migration-test harness.

## Testing

- `./scripts/migration-test/run.sh --self-test` → `1 auto, 0 manual, 0 blocked`, new green `BLOCKER-CHECK` line.
- `./scripts/migration-test/run.sh v0.63.3` → real cross-version migration from a downloaded v0.63.3 release binary; AUTO, 0 violations, blocker-check green.
- `bash -n` + `shellcheck` clean (only pre-existing warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

_claude-opus-4-8-high on behalf of matt wilkie_
