### PR TITLE
feat(prime): add agent.profile config + BD_AGENT_PROFILE runtime knob

### DIFF
--- a/cmd/bd/config.go
+++ b/cmd/bd/config.go
@@ -868,7 +868,7 @@ var recognizedConfigPrefixes = []string{
 	"export.", "import.", "dolt.", "jira.", "linear.", "github.", "custom.",
 	"status.", "types.", "doctor.suppress.", "routing.", "sync.", "git.",
 	"directory.", "repos.", "external_projects.", "validation.",
-	"hierarchy.", "ai.", "backup.", "federation.", "metrics.",
+	"hierarchy.", "ai.", "backup.", "federation.", "metrics.", "agent.",
 }
 
 // recognizedConfigKeys lists valid non-namespaced config keys.

--- a/cmd/bd/config_validate_key_test.go
+++ b/cmd/bd/config_validate_key_test.go
@@ -10,7 +10,7 @@ func TestIsRecognizedConfigKey(t *testing.T) {
 		"export.auto", "dolt.auto-push", "jira.url", "custom.anything",
 		"doctor.suppress.git-hooks", "no-git-ops", "beads.role",
 		"status.custom", "types.custom", "types.infra", "ai.model",
-		"backup.enabled", "import.path", "dolt.local-only",
+		"backup.enabled", "import.path", "dolt.local-only", "agent.profile",
 	}
 	for _, key := range recognized {
 		if !isRecognizedConfigKey(key) {

--- a/cmd/bd/prime.go
+++ b/cmd/bd/prime.go
@@ -97,6 +97,11 @@ Config options:
 - no-git-ops: When true, outputs stealth mode (no git commands in session close protocol).
   Set via: bd config set no-git-ops true
   Useful when you want to control when commits happen manually.
+- agent.profile: Explicit policy profile for git/commit authority wording
+  (conservative | minimal | team-maintainer; default conservative).
+  Set via: bd config set agent.profile team-maintainer
+  Or per-session: BD_AGENT_PROFILE=team-maintainer (env var takes precedence).
+  See docs/SETUP.md#policy-profiles for what each profile means.
 
 	Workflow customization:
 	- Place a .beads/PRIME.md file in the local clone or resolved workspace to override the default output entirely.
@@ -284,6 +289,13 @@ var isEphemeralBranch = func() bool {
 // (stubbable for tests).
 var primeNoPushConfigured = func() bool {
 	return config.GetBool("no-push")
+}
+
+// primeAgentProfile reports the explicit agent.profile knob (gh#3423,
+// follow-up to #4220), resolved via BD_AGENT_PROFILE env override / config
+// key with a safe fallback to conservative (stubbable for tests).
+var primeAgentProfile = func() config.AgentProfile {
+	return config.GetAgentProfile()
 }
 
 // primeHasGitRemote detects if any git remote is configured (stubbable for tests)
@@ -524,6 +536,13 @@ func outputMCPContext(w io.Writer, stealthMode bool) error {
 	} else if noPush {
 		closeProtocol = "Before saying \"done\": bd close <completed-ids>; run checks; report git status and proposed handoff (push disabled)"
 		profileRule = "Profile model: conservative by default; push only with explicit user/orchestrator authority"
+	} else if primeAgentProfile() == config.ProfileTeamMaintainer {
+		// Explicit agent.profile=team-maintainer knob: commit/sync/push are
+		// routine work here, not conditional on a per-session "enabled" ask.
+		// Hard constraints above (stealth/local-only/ephemeral/no-push) still
+		// take precedence over this profile.
+		closeProtocol = "Before saying \"done\": bd close <completed-ids>; run checks; commit, bd dolt push, and git push as part of routine work (agent.profile=team-maintainer), unless current instructions say otherwise."
+		profileRule = "Profile: team-maintainer active (agent.profile=team-maintainer) - commit, sync, and push are routine; explicit no-commit/no-push instructions still override."
 	} else {
 		closeProtocol = "Before saying \"done\": bd close <completed-ids>; run checks. Then follow the active profile — conservative reports handoff; team-maintainer may commit/sync/push when explicitly enabled."
 		profileRule = "Default: do not commit, push, or run dolt remote sync without explicit authority. Team-maintainer behavior is opt-in and still subordinate to user/orchestrator instructions."
@@ -625,6 +644,31 @@ git status                  # Report changed files and proposed commands
 ` + "```"
 		gitWorkflowRule = "Git workflow: push disabled; report handoff unless explicitly authorized"
 		profileRule = "Profile model: conservative/minimal report handoff; team-maintainer still respects no-push/user instructions"
+	} else if primeAgentProfile() == config.ProfileTeamMaintainer {
+		// Explicit agent.profile=team-maintainer knob: commit/sync/push are
+		// routine work here, not conditional on a per-session "enabled" ask.
+		// Hard constraints above (stealth/local-only/ephemeral/no-push) still
+		// take precedence over this profile.
+		closeProtocol = `[ ] 1. bd close <id1> <id2> ...   (close completed issues)
+[ ] 2. run quality gates        (tests, linters, builds when relevant)
+[ ] 3. git status               (check what changed)
+[ ] 4. team-maintainer: commit, sync, push as part of routine work (unless current instructions say otherwise)`
+		closeNote = "**Policy:** agent.profile=team-maintainer is active. Commit, sync, and push as part of routine work; explicit \"do not commit\"/\"do not push\" instructions still override."
+		syncSection = `### Sync & Collaboration
+- ` + "`bd dolt push`" + ` - Push beads to Dolt remote
+- ` + "`bd dolt pull`" + ` - Pull beads from Dolt remote
+- ` + "`bd search <query>`" + ` - Search issues by keyword`
+		completingWorkflow = `**Completing work:**
+` + "```bash" + `
+bd close <id1> <id2> ...    # Close all completed issues at once
+git status                  # Check changed files
+# team-maintainer: commit, sync, push are routine unless instructions forbid it
+git add . && git commit -m "..."
+bd dolt push
+git push
+` + "```"
+		gitWorkflowRule = "Git workflow: team-maintainer active - commit/push are routine unless explicitly restricted"
+		profileRule = "Profile: team-maintainer active (agent.profile=team-maintainer) - commit, sync, and push are routine; explicit no-commit/no-push instructions still override."
 	} else {
 		closeProtocol = `[ ] 1. bd close <id1> <id2> ...   (close completed issues)
 [ ] 2. run quality gates        (tests, linters, builds when relevant)

--- a/cmd/bd/prime_test.go
+++ b/cmd/bd/prime_test.go
@@ -9,6 +9,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/steveyegge/beads/internal/config"
 )
 
 // stubPrimeStoreUnavailable temporarily disconnects prime from any ambient
@@ -49,6 +51,7 @@ func TestOutputContextFunction(t *testing.T) {
 		ephemeralMode bool
 		localOnlyMode bool
 		noPushMode    bool
+		profile       config.AgentProfile // "" stubs config.ProfileConservative (default)
 		expectText    []string
 		rejectText    []string
 	}{
@@ -60,6 +63,16 @@ func TestOutputContextFunction(t *testing.T) {
 			localOnlyMode: false,
 			expectText:    []string{"Beads Workflow Context", "bd dolt push", "Team-maintainer behavior is opt-in", "conservative by default"},
 			rejectText:    []string{"bd export", "--from-main"},
+		},
+		{
+			name:          "CLI team-maintainer profile (non-ephemeral)",
+			mcpMode:       false,
+			stealthMode:   false,
+			ephemeralMode: false,
+			localOnlyMode: false,
+			profile:       config.ProfileTeamMaintainer,
+			expectText:    []string{"Beads Workflow Context", "agent.profile=team-maintainer", "bd dolt push", "git push"},
+			rejectText:    []string{"bd export", "--from-main", "Team-maintainer behavior is opt-in"},
 		},
 		{
 			name:          "CLI Normal (ephemeral)",
@@ -126,6 +139,16 @@ func TestOutputContextFunction(t *testing.T) {
 			rejectText:    []string{"bd export", "--from-main"},
 		},
 		{
+			name:          "MCP team-maintainer profile (non-ephemeral)",
+			mcpMode:       true,
+			stealthMode:   false,
+			ephemeralMode: false,
+			localOnlyMode: false,
+			profile:       config.ProfileTeamMaintainer,
+			expectText:    []string{"Beads Issue Tracker Active", "agent.profile=team-maintainer", "bd dolt push"},
+			rejectText:    []string{"bd export", "--from-main", "Team-maintainer behavior is opt-in"},
+		},
+		{
 			name:          "MCP Normal (ephemeral)",
 			mcpMode:       true,
 			stealthMode:   false,
@@ -187,6 +210,11 @@ func TestOutputContextFunction(t *testing.T) {
 			defer stubIsEphemeralBranch(tt.ephemeralMode)()
 			defer stubPrimeHasGitRemote(!tt.localOnlyMode)() // localOnly = !primeHasGitRemote
 			defer stubPrimeNoPushConfigured(tt.noPushMode)()
+			profile := tt.profile
+			if profile == "" {
+				profile = config.ProfileConservative
+			}
+			defer stubPrimeAgentProfile(profile)()
 
 			var buf bytes.Buffer
 			err := outputPrimeContext(&buf, tt.mcpMode, tt.stealthMode)
@@ -361,6 +389,18 @@ func stubPrimeNoPushConfigured(noPush bool) func() {
 	}
 	return func() {
 		primeNoPushConfigured = original
+	}
+}
+
+// stubPrimeAgentProfile temporarily replaces primeAgentProfile with a stub
+// returning profile (gh#3423 agent.profile knob).
+func stubPrimeAgentProfile(profile config.AgentProfile) func() {
+	original := primeAgentProfile
+	primeAgentProfile = func() config.AgentProfile {
+		return profile
+	}
+	return func() {
+		primeAgentProfile = original
 	}
 }
 

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -42,6 +42,7 @@ Common tool-level settings you can configure:
 |---------|------|---------------------|---------|-------------|
 | `json` | `--json` | `BD_JSON` | `false` | Output in JSON format |
 | `no-push` | `--no-push` | `BD_NO_PUSH` | `false` | Skip pushing to remote in `bd dolt push` |
+| `agent.profile` | - | `BD_AGENT_PROFILE` | `conservative` | Policy profile `bd prime` uses for git/commit authority wording: `conservative`, `minimal`, `team-maintainer` (see [SETUP.md](SETUP.md#policy-profiles)); invalid values fall back to `conservative` |
 | `federation.remote` | - | `BD_FEDERATION_REMOTE` | (none) | Dolt remote URL for federation |
 | `federation.sovereignty` | - | `BD_FEDERATION_SOVEREIGNTY` | (none) | Data sovereignty tier: `T1`, `T2`, `T3`, `T4` |
 | `dolt.auto-commit` | `--dolt-auto-commit` | `BD_DOLT_AUTO_COMMIT` | `on` | (Dolt backend) Automatically create a Dolt commit after successful write commands |

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -37,9 +37,17 @@ Template profiles control how much text gets installed. Policy profiles control 
 |--------|---------------|----------------------|
 | `conservative` | Standalone projects, unknown projects, and one-off assistance | Use `bd` for task tracking, then report changed files, validation, and proposed commands. Do not commit, push, or run Dolt remote sync without explicit user or orchestrator approval. |
 | `minimal` | Hook-first integrations where `bd prime` carries the detailed workflow | Same git authority as conservative; the installed file stays short and points to `bd prime`. |
-| `team-maintainer` | Repositories that explicitly delegate session close to agents | Agents may close beads, run quality gates, commit, run `bd dolt push`, and `git push` only when repository/user/orchestrator instructions grant that authority. Current "do not commit" or "do not push" instructions override the profile. |
+| `team-maintainer` | Repositories that explicitly delegate session close to agents | Agents may close beads, run quality gates, commit, run `bd dolt push`, and `git push` as part of routine work. Current "do not commit" or "do not push" instructions still override the profile. |
 
-The generated Beads block and `bd prime` default to conservative git authority. Projects that want team-maintainer behavior should say so in their own top-level instructions; Beads does not infer that authority merely because a remote exists.
+The generated Beads block and `bd prime` default to conservative git authority. Set the profile explicitly with the `agent.profile` config key or the `BD_AGENT_PROFILE` environment variable (values: `conservative`, `minimal`, `team-maintainer`; env var takes precedence; an unrecognized value falls back to `conservative`):
+
+```bash
+bd config set agent.profile team-maintainer
+# or, for a single session/process:
+BD_AGENT_PROFILE=team-maintainer bd prime
+```
+
+`bd prime` layers this explicit knob on top of its existing per-branch git-authority checks (stealth mode, no git remote, ephemeral branch, `no-push`); those hard constraints still take precedence, and `team-maintainer` remains subordinate to any explicit "do not commit"/"do not push" instruction. Beads does not infer team-maintainer authority merely because a remote exists; it must be set via this knob (or, for tools without config access, via top-level project instructions).
 
 ### Built-in Recipes
 

--- a/internal/config/agent_profile.go
+++ b/internal/config/agent_profile.go
@@ -1,0 +1,75 @@
+package config
+
+import "strings"
+
+// AgentProfile represents the explicit policy profile that controls agent
+// git/commit authority (gh#3423, follow-up to #4220's PROFILE_VOCABULARY doc).
+//
+// See docs/SETUP.md "Policy Profiles" for the full description of each value.
+type AgentProfile string
+
+const (
+	// ProfileConservative is the default: report changed files, validation,
+	// and proposed commands; do not commit, push, or run Dolt remote sync
+	// without explicit user or orchestrator approval.
+	ProfileConservative AgentProfile = "conservative"
+	// ProfileMinimal has the same git authority as ProfileConservative; it
+	// only differs in how much text hook-first integrations install.
+	ProfileMinimal AgentProfile = "minimal"
+	// ProfileTeamMaintainer allows an agent to close beads, run quality
+	// gates, commit, `bd dolt push`, and `git push` as part of routine work,
+	// subordinate to any explicit "do not commit"/"do not push" instruction.
+	ProfileTeamMaintainer AgentProfile = "team-maintainer"
+)
+
+// validAgentProfiles is the set of allowed agent.profile values.
+var validAgentProfiles = map[AgentProfile]bool{
+	ProfileConservative:   true,
+	ProfileMinimal:        true,
+	ProfileTeamMaintainer: true,
+}
+
+// ValidAgentProfiles returns the list of valid agent.profile values.
+func ValidAgentProfiles() []string {
+	return []string{
+		string(ProfileConservative),
+		string(ProfileMinimal),
+		string(ProfileTeamMaintainer),
+	}
+}
+
+// IsValidAgentProfile returns true if the given string is a recognized
+// agent profile (case-insensitive).
+func IsValidAgentProfile(profile string) bool {
+	return validAgentProfiles[AgentProfile(strings.ToLower(strings.TrimSpace(profile)))]
+}
+
+// GetAgentProfile retrieves the explicit agent policy profile.
+//
+// Config key: agent.profile
+// Env var: BD_AGENT_PROFILE (bound automatically via viper's BD env prefix)
+// Valid values: conservative | minimal | team-maintainer
+//
+// Returns ProfileConservative if unset, empty, or invalid; an invalid
+// non-empty value logs a warning rather than erroring, matching the
+// fallback behavior of GetSovereignty.
+func GetAgentProfile() AgentProfile {
+	value := strings.ToLower(strings.TrimSpace(GetString("agent.profile")))
+	if value == "" {
+		return ProfileConservative
+	}
+
+	profile := AgentProfile(value)
+	if !validAgentProfiles[profile] {
+		logConfigWarning("Warning: invalid agent.profile %q in config (valid: %s), using %q\n",
+			value, strings.Join(ValidAgentProfiles(), ", "), ProfileConservative)
+		return ProfileConservative
+	}
+
+	return profile
+}
+
+// String returns the string representation of the AgentProfile.
+func (p AgentProfile) String() string {
+	return string(p)
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -206,6 +206,13 @@ func Initialize() error {
 	// Push configuration defaults
 	v.SetDefault("no-push", false)
 
+	// Agent profile configuration (gh#3423, follow-up to #4220)
+	// Explicit runtime knob for the policy profile (git/commit authority)
+	// documented in docs/SETUP.md. `bd prime` uses this to select its
+	// close-protocol wording. Values: conservative | minimal | team-maintainer.
+	// Invalid values fall back to "conservative" (see GetAgentProfile).
+	v.SetDefault("agent.profile", string(ProfileConservative))
+
 	// Create command defaults
 	v.SetDefault("create.require-description", false)
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1165,6 +1165,141 @@ func TestSovereigntyConstants(t *testing.T) {
 	}
 }
 
+// Agent profile knob (gh#3423, follow-up to #4220): agent.profile config key
+// with a BD_AGENT_PROFILE env override, defaulting to "conservative".
+
+func TestAgentProfileConstants(t *testing.T) {
+	if ProfileConservative != "conservative" {
+		t.Errorf("ProfileConservative = %q, want \"conservative\"", ProfileConservative)
+	}
+	if ProfileMinimal != "minimal" {
+		t.Errorf("ProfileMinimal = %q, want \"minimal\"", ProfileMinimal)
+	}
+	if ProfileTeamMaintainer != "team-maintainer" {
+		t.Errorf("ProfileTeamMaintainer = %q, want \"team-maintainer\"", ProfileTeamMaintainer)
+	}
+}
+
+func TestGetAgentProfileDefault(t *testing.T) {
+	// Isolate from environment variables
+	restore := envSnapshot(t)
+	defer restore()
+
+	if err := Initialize(); err != nil {
+		t.Fatalf("Initialize() returned error: %v", err)
+	}
+
+	if got := GetAgentProfile(); got != ProfileConservative {
+		t.Errorf("GetAgentProfile() default = %q, want %q", got, ProfileConservative)
+	}
+}
+
+func TestGetAgentProfileFromConfigFile(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	configContent := `
+agent:
+  profile: team-maintainer
+`
+	beadsDir := filepath.Join(tmpDir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0750); err != nil {
+		t.Fatalf("failed to create .beads directory: %v", err)
+	}
+	configPath := filepath.Join(beadsDir, "config.yaml")
+	if err := os.WriteFile(configPath, []byte(configContent), 0600); err != nil {
+		t.Fatalf("failed to write config file: %v", err)
+	}
+
+	// Isolate from environment variables so BD_AGENT_PROFILE from the host
+	// (or a prior test) can't leak in and shadow the config-file value.
+	restore := envSnapshot(t)
+	defer restore()
+
+	t.Chdir(tmpDir)
+
+	if err := Initialize(); err != nil {
+		t.Fatalf("Initialize() returned error: %v", err)
+	}
+
+	if got := GetAgentProfile(); got != ProfileTeamMaintainer {
+		t.Errorf("GetAgentProfile() from config file = %q, want %q", got, ProfileTeamMaintainer)
+	}
+}
+
+func TestGetAgentProfileEnvOverridesConfigFile(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Config file says "team-maintainer"; the env var below should win.
+	configContent := `
+agent:
+  profile: team-maintainer
+`
+	beadsDir := filepath.Join(tmpDir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0750); err != nil {
+		t.Fatalf("failed to create .beads directory: %v", err)
+	}
+	configPath := filepath.Join(beadsDir, "config.yaml")
+	if err := os.WriteFile(configPath, []byte(configContent), 0600); err != nil {
+		t.Fatalf("failed to write config file: %v", err)
+	}
+
+	restore := envSnapshot(t)
+	defer restore()
+	t.Setenv("BD_AGENT_PROFILE", "minimal")
+
+	t.Chdir(tmpDir)
+
+	if err := Initialize(); err != nil {
+		t.Fatalf("Initialize() returned error: %v", err)
+	}
+
+	if got := GetAgentProfile(); got != ProfileMinimal {
+		t.Errorf("GetAgentProfile() with BD_AGENT_PROFILE set = %q, want %q (env should override config file)", got, ProfileMinimal)
+	}
+}
+
+func TestGetAgentProfileInvalidFallsBackToConservative(t *testing.T) {
+	// Isolate from environment variables
+	restore := envSnapshot(t)
+	defer restore()
+
+	if err := Initialize(); err != nil {
+		t.Fatalf("Initialize() returned error: %v", err)
+	}
+
+	Set("agent.profile", "yolo")
+	if got := GetAgentProfile(); got != ProfileConservative {
+		t.Errorf("GetAgentProfile() with invalid value = %q, want %q (fallback)", got, ProfileConservative)
+	}
+}
+
+func TestGetAgentProfileInvalidEnvFallsBackToConservative(t *testing.T) {
+	restore := envSnapshot(t)
+	defer restore()
+	t.Setenv("BD_AGENT_PROFILE", "not-a-real-profile")
+
+	if err := Initialize(); err != nil {
+		t.Fatalf("Initialize() returned error: %v", err)
+	}
+
+	if got := GetAgentProfile(); got != ProfileConservative {
+		t.Errorf("GetAgentProfile() with invalid BD_AGENT_PROFILE = %q, want %q (fallback)", got, ProfileConservative)
+	}
+}
+
+func TestIsValidAgentProfile(t *testing.T) {
+	for _, valid := range []string{"conservative", "minimal", "team-maintainer", "CONSERVATIVE", " team-maintainer "} {
+		if !IsValidAgentProfile(valid) {
+			t.Errorf("IsValidAgentProfile(%q) = false, want true", valid)
+		}
+	}
+	for _, invalid := range []string{"", "yolo", "full"} {
+		if IsValidAgentProfile(invalid) {
+			t.Errorf("IsValidAgentProfile(%q) = true, want false", invalid)
+		}
+	}
+}
+
 func TestFederationConfigDefaults(t *testing.T) {
 	// Isolate from environment variables
 	restore := envSnapshot(t)

--- a/internal/config/yaml_config.go
+++ b/internal/config/yaml_config.go
@@ -35,6 +35,7 @@ var YamlOnlyKeys = map[string]bool{
 	"git.no-gpg-sign": true,
 	"no-push":         true,
 	"no-git-ops":      true, // Disable git ops in bd prime session close protocol (GH#593)
+	"agent.profile":   true, // Explicit policy profile for bd prime's close protocol (GH#3423)
 
 	// Sync settings
 	"sync.remote":     true, // Primary: any Dolt-compatible remote URL


### PR DESCRIPTION
## Why

#4220 shipped the conservative/minimal/team-maintainer **profile vocabulary** into the generated Beads block and `bd prime` output, but left no runtime knob: profile wording was only ever selected implicitly (from no-push / ephemeral-branch / no-remote conditions). "team-maintainer is opt-in" in practice meant "hand-edit your own AGENTS.md."

This adds the missing runtime plumbing that #3423 (first-class versioned Beads context profile) asks for, so an operator can explicitly select the profile that `bd prime` speaks in.

## What

- **New config key `agent.profile`** (`conservative | minimal | team-maintainer`, default `conservative`), registered in `internal/config/config.go` defaults and added to `YamlOnlyKeys` (a startup-time setting, same class as `no-push`/`no-git-ops`).
- **Env override `BD_AGENT_PROFILE`** — no new wiring needed; viper's existing `BD` env prefix + key replacer already binds it, and it takes precedence over the config file (covered by a test).
- **`internal/config/agent_profile.go`** (new) — `AgentProfile` type + constants, `GetAgentProfile()` resolving the knob with case-insensitive parsing and a safe fallback to `conservative` (logged warning on an invalid value), mirroring the existing `GetSovereignty()` pattern.
- **`cmd/bd/prime.go`** — a stubbable `primeAgentProfile` var (matching `primeNoPushConfigured`/`primeHasGitRemote`) and a new `team-maintainer` branch in both `outputMCPContext` and `outputCLIContext`. When `agent.profile=team-maintainer` is explicit, the close-protocol/profile wording becomes definitive (commit, `bd dolt push`, `git push` are routine). **Existing behavior is unchanged when the knob is unset** — the branch sits between the `no-push` branch and the prior default `else`, so hard constraints (stealth / local-only / ephemeral / no-push) still take precedence, and conservative/minimal fall through to the untouched default wording.
- **Docs** — `docs/SETUP.md` Policy Profiles section and `docs/CONFIG.md` table now reference the actual knob (config key + env var, precedence, fallback) instead of "edit your own instructions."

## Testing

```
CGO_ENABLED=0 go build -tags gms_pure_go ./cmd/bd/... ./internal/config/...   # clean
CGO_ENABLED=0 go vet   -tags gms_pure_go ./cmd/bd/... ./internal/config/...   # clean
CGO_ENABLED=0 go test  -tags gms_pure_go ./internal/config/...                # ok
CGO_ENABLED=0 go test  -tags gms_pure_go ./cmd/bd/ -run 'TestOutputContextFunction|TestPrime|TestCodexHook'   # PASS
```
New tests cover: default profile, config-file override, **env-var precedence over config file**, invalid value + invalid env fallback to conservative, constants/validation, and two new team-maintainer subtests in `TestOutputContextFunction` (CLI + MCP).

## Deliberately out of scope

The generated `AGENTS.md`/`CLAUDE.md` golden templates (`internal/templates/agents/defaults/*.md`, `internal/recipes/template.go`) still narrate profiles for tools without config access. Wiring the knob into those templates is a larger, separate follow-up; left untouched here to keep this change minimal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

_claude-opus-4-8-high on behalf of matt wilkie_
