### PR TITLE
build: auto gms_pure_go tag + make doctor-build preflight

### DIFF
--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -10,7 +10,15 @@ set -e
 echo "⚙️  Persisting -tags=gms_pure_go in go env..."
 PERSISTED_GOFLAGS="$(go env GOFLAGS)"
 if [[ "$PERSISTED_GOFLAGS" != *gms_pure_go* ]]; then
-  go env -w GOFLAGS="${PERSISTED_GOFLAGS:+$PERSISTED_GOFLAGS }-tags=gms_pure_go"
+  if [[ "$PERSISTED_GOFLAGS" == *-tags=* ]]; then
+    # Merge into the existing -tags value instead of appending a second
+    # -tags flag: Go does not merge repeated -tags flags, so a second one
+    # would silently replace the first and disable the existing tags.
+    PERSISTED_GOFLAGS="$(printf '%s' "$PERSISTED_GOFLAGS" | sed -E 's/-tags=([^[:space:]]*)/-tags=\1,gms_pure_go/')"
+  else
+    PERSISTED_GOFLAGS="${PERSISTED_GOFLAGS:+$PERSISTED_GOFLAGS }-tags=gms_pure_go"
+  fi
+  go env -w GOFLAGS="$PERSISTED_GOFLAGS"
 fi
 
 # Canonical build flags (GOFLAGS=-tags=gms_pure_go, CGO_ENABLED=1).

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -1,6 +1,18 @@
 #!/bin/bash
 set -e
 
+# Persist -tags=gms_pure_go in the go env config file (`go env -w`), so a
+# bare `go build`/`go test` run later from a shell that never sourced
+# .buildflags still picks up the tag (see docs/ICU-POLICY.md and
+# `make doctor-build`). Read the persisted value here, before sourcing
+# .buildflags below, since that export would otherwise shadow the on-disk
+# go env value for the rest of this script.
+echo "⚙️  Persisting -tags=gms_pure_go in go env..."
+PERSISTED_GOFLAGS="$(go env GOFLAGS)"
+if [[ "$PERSISTED_GOFLAGS" != *gms_pure_go* ]]; then
+  go env -w GOFLAGS="${PERSISTED_GOFLAGS:+$PERSISTED_GOFLAGS }-tags=gms_pure_go"
+fi
+
 # Canonical build flags (GOFLAGS=-tags=gms_pure_go, CGO_ENABLED=1).
 # shellcheck source=../.buildflags
 source "$(dirname "$0")/../.buildflags"

--- a/Makefile
+++ b/Makefile
@@ -82,8 +82,9 @@ doctor-build:
 		echo "  CC on PATH:  NO - $$CC_VAL not found"; \
 	fi; \
 	echo ""; \
-	case "$$GOFLAGS_VAL" in \
-		*gms_pure_go*) \
+	EFFECTIVE_TAGS="$$(printf '%s\n' "$$GOFLAGS_VAL" | tr ' ' '\n' | sed -n 's/^-tags=//p' | tail -n 1)"; \
+	case ",$$EFFECTIVE_TAGS," in \
+		*,gms_pure_go,*) \
 			echo "PASS: GOFLAGS carries -tags=gms_pure_go; bare 'go build'/'go test' are safe." ;; \
 		*) \
 			echo "WARN: GOFLAGS is missing -tags=gms_pure_go."; \

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ SHELL := $(subst cmd,bin,$(subst git.exe,bash.exe,$(GIT_BASH)))
 endif
 endif
 
-.PHONY: all build test test-icu-path test-full-cgo test-regression test-upgrade test-cross-version test-migration corpus-regen bench bench-quick clean clean-test-tmp install install-force help check-up-to-date fmt fmt-check check-testing-short
+.PHONY: all build doctor-build test test-icu-path test-full-cgo test-regression test-upgrade test-cross-version test-migration corpus-regen bench bench-quick clean clean-test-tmp install install-force help check-up-to-date fmt fmt-check check-testing-short
 .PHONY: ci-pr-core ci-pr-policy ci-pr-lint ci-package-mcp ci-package-npm ci-website
 
 # Default target
@@ -61,6 +61,42 @@ ifeq ($(shell uname),Darwin)
 	@echo "Signed bd for macOS"
 endif
 endif
+
+# Diagnose the local build environment for the gms_pure_go/CGO build trap
+# (mybd-t7mk.1). A bare `CGO_ENABLED=1 go build ./cmd/bd` without
+# -tags=gms_pure_go fails with a C-linker error from go-icu-regex
+# (unicode/uregex.h: No such file or directory) because go-mysql-server
+# links ICU by default under cgo; CGO_ENABLED=0 avoids that but can't open
+# embedded Dolt at runtime. See docs/ICU-POLICY.md.
+doctor-build:
+	@echo "Build environment diagnostic (doctor-build):"
+	@GOFLAGS_VAL="$$(go env GOFLAGS)"; \
+	CGO_VAL="$$(go env CGO_ENABLED)"; \
+	CC_VAL="$$(go env CC)"; \
+	echo "  GOFLAGS:     $${GOFLAGS_VAL:-<empty>}"; \
+	echo "  CGO_ENABLED: $$CGO_VAL"; \
+	echo "  CC:          $$CC_VAL"; \
+	if command -v "$$CC_VAL" >/dev/null 2>&1; then \
+		echo "  CC on PATH:  yes ($$(command -v "$$CC_VAL"))"; \
+	else \
+		echo "  CC on PATH:  NO - $$CC_VAL not found"; \
+	fi; \
+	echo ""; \
+	case "$$GOFLAGS_VAL" in \
+		*gms_pure_go*) \
+			echo "PASS: GOFLAGS carries -tags=gms_pure_go; bare 'go build'/'go test' are safe." ;; \
+		*) \
+			echo "WARN: GOFLAGS is missing -tags=gms_pure_go."; \
+			echo "      A bare 'CGO_ENABLED=1 go build ./cmd/bd' will fail with a C-linker error"; \
+			echo "      (unicode/uregex.h: No such file or directory) from go-icu-regex, because"; \
+			echo "      go-mysql-server links ICU by default under cgo."; \
+			echo ""; \
+			echo "      Remedy - persist the tag so bare go commands pick it up:"; \
+			echo "        go env -w GOFLAGS=-tags=gms_pure_go"; \
+			echo "      Or build explicitly this once (CGO_ENABLED=1 is required for"; \
+			echo "      embedded Dolt at runtime; CGO_ENABLED=0 cannot open it):"; \
+			echo "        CGO_ENABLED=1 go build -tags gms_pure_go ./cmd/bd" ;; \
+	esac
 
 # Run all tests (skips known broken tests listed in .test-skip)
 test:
@@ -239,6 +275,7 @@ clean-test-tmp:
 help:
 	@echo "Beads Makefile targets:"
 	@echo "  make build        - Build the bd binary"
+	@echo "  make doctor-build - Diagnose build env (GOFLAGS/CGO/CC) for the ICU build trap"
 	@echo "  make test         - Run all tests"
 	@echo "  make test-icu-path - Run opt-in ICU regex path tests (maintainer-only)"
 	@echo "  make test-full-cgo - Deprecated alias for make test-icu-path"


### PR DESCRIPTION
## Why

Omitting `-tags=gms_pure_go` is the single most common per-session build trap. A bare `CGO_ENABLED=1 go build ./cmd/bd` fails with a cryptic C-linker error (`unicode/uregex.h: No such file or directory` from go-icu-regex) because go-mysql-server links ICU by default under cgo; the `gms_pure_go` tag swaps in a pure-Go regex and avoids it. `CGO_ENABLED=0` sidesteps ICU but can't open embedded Dolt at runtime. The correct local build is `CGO_ENABLED=1 -tags gms_pure_go` — but nothing makes that automatic for a bare `go` command, and there's no diagnostic when someone gets it wrong. (This one bit me this session: a plain CGO build hit the exact ICU error.)

## What

1. **Persist the tag for bare `go build`/`go test`.** `.devcontainer/setup.sh` now runs `go env -w GOFLAGS=...-tags=gms_pure_go` so a later shell that never sourced `.buildflags` still picks up the tag. It's idempotent (skips if already present) and merges with any existing `GOFLAGS`. Placed **before** `source .buildflags`, because that source exports `GOFLAGS` into the script's shell and would otherwise shadow the on-disk `go env` value the check reads. The existing `.buildflags` sourcing is unchanged.

2. **`make doctor-build` preflight.** New target reporting `GOFLAGS` / `CGO_ENABLED` / `CC` (and whether CC is on PATH), with a PASS/WARN verdict. On WARN it names the exact `uregex.h` failure it prevents and prints the remedy (`go env -w GOFLAGS=-tags=gms_pure_go`, or the one-shot `CGO_ENABLED=1 go build -tags gms_pure_go ./cmd/bd`). It's a diagnostic (exit 0 on both paths), not a CI gate. Added to `.PHONY` and `make help`.

## Testing

```
GOFLAGS= make doctor-build                        # WARN path: names uregex.h + remedy
GOFLAGS=-tags=gms_pure_go make doctor-build       # PASS path
bash -n .devcontainer/setup.sh                    # clean
./scripts/check-build-tags.sh                     # repo's own ICU-tag guard: all clear
```
The `setup.sh` persist logic was unit-tested in isolation with a sandboxed `GOENV` (idempotent on rerun); the full `setup.sh` (which does `sudo mv`, `bd init`, etc.) was not run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

_claude-opus-4-8-high on behalf of matt wilkie_
