### PR TITLE
docs: clarify reserved log export

### DIFF
--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -7,7 +7,7 @@ Beads exports metrics via OTLP HTTP. Telemetry is **disabled by default** — ze
 | Service | Port | Role |
 |---------|------|------|
 | VictoriaMetrics | 8428 | OTLP metrics storage |
-| VictoriaLogs | 9428 | OTLP log storage |
+| VictoriaLogs | 9428 | Reserved for future OTLP log storage |
 | Grafana | 9429 | Dashboards |
 
 ```bash
@@ -25,6 +25,9 @@ export BD_OTEL_METRICS_URL=http://localhost:8428/opentelemetry/api/v1/push
 
 Every `bd` command will then automatically push its metrics.
 
+Log export is not implemented yet. `BD_OTEL_LOGS_URL` is reserved for a future
+VictoriaLogs exporter and does not activate telemetry today.
+
 ### Shell profile (recommended)
 
 ```bash
@@ -37,6 +40,7 @@ export BD_OTEL_METRICS_URL=http://localhost:8428/opentelemetry/api/v1/push
 | Variable | Example | Description |
 |----------|---------|-------------|
 | `BD_OTEL_METRICS_URL` | `http://localhost:8428/opentelemetry/api/v1/push` | Push metrics to VictoriaMetrics. Activates telemetry. |
+| `BD_OTEL_LOGS_URL` | `http://localhost:9428/insert/opentelemetry/v1/logs` | Reserved for future log export. Does not activate telemetry today. |
 | `BD_OTEL_STDOUT` | `true` | Write spans and metrics to stderr (dev/debug). Also activates telemetry. |
 
 ### Local debug mode

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -10,7 +10,7 @@
 //	    Presence of this variable enables telemetry.
 //
 //	BD_OTEL_LOGS_URL=http://localhost:9428/insert/opentelemetry/v1/logs
-//	    Push logs to VictoriaLogs (reserved for future log export).
+//	    Reserved for future log export to VictoriaLogs.
 //
 //	BD_OTEL_STDOUT=true
 //	    Write spans and metrics to stderr (dev/debug mode).
@@ -19,7 +19,7 @@
 // # Recommended local stack
 //
 //	VictoriaMetrics :8428  — metrics storage
-//	VictoriaLogs    :9428  — log storage
+//	VictoriaLogs    :9428  — future log storage
 //	Grafana         :9429  — dashboards
 //
 // See docs/OBSERVABILITY.md for the full reference.


### PR DESCRIPTION
## Why

`docs/OBSERVABILITY.md` described VictoriaLogs as active OTLP log storage, but
the telemetry package only exports metrics remotely today. The logs URL is
reserved for a future exporter and does not activate telemetry.

## What changed

- Clarified that VictoriaLogs is reserved for future log export.
- Documented `BD_OTEL_LOGS_URL` as reserved and non-activating.
- Matched the telemetry package comment to the public doc wording.

## Verification

- `go test ./internal/telemetry`

_codex-gpt-5.5-high on behalf of matt wilkie_
