### PR TITLE
ci(lint): enforce Dolt storage boundary with depguard (deny dolthub imports outside storage adapter)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,6 +7,7 @@ run:
 linters:
   default: 'none'
   enable:
+    - depguard
     - errcheck
     - gosec
     - misspell
@@ -15,6 +16,50 @@ linters:
     - sloglint
 
   settings:
+    depguard:
+      rules:
+        # Mechanical enforcement of the Storage Boundary in
+        # docs/PROJECT_CHARTER.md: only the storage adapter packages may
+        # depend on the Dolt engine directly.
+        dolt-storage-boundary:
+          list-mode: lax
+          files:
+            - "$all"
+            # Storage adapter packages are the intended home for Dolt access.
+            - "!**/internal/storage/**"
+            - "!**/internal/doltserver/**"
+            # Exception: the proxied-server surface needs Dolt server config
+            # (servercfg, filesys) to launch/manage a real `dolt sql-server`
+            # process. Candidate for migration behind the storage adapter.
+            - "!**/cmd/bd/proxied_server.go"
+            # Exception: eventkit is DoltHub's analytics/telemetry client,
+            # not the Dolt storage engine - dropped here so the narrower
+            # dolt-storage-boundary-metrics-exception rule below can allow
+            # eventkit specifically while still denying any other dolthub
+            # import (e.g. the engine itself) in these two files.
+            - "!**/internal/metrics/flusher.go"
+            - "!**/internal/metrics/metrics.go"
+          deny:
+            - pkg: github.com/dolthub
+              desc: "Dolt engine access is restricted to the storage adapter packages (internal/storage, internal/doltserver) - see docs/PROJECT_CHARTER.md 'Storage Boundary'"
+        # Companion rule for the two files excluded above: allow only
+        # DoltHub's eventkit telemetry client, still deny the Dolt engine
+        # (or any other dolthub package) so metrics can't become a backdoor
+        # around the storage boundary.
+        dolt-storage-boundary-metrics-exception:
+          list-mode: lax
+          # No "$all" here: this rule's files list is a plain allowlist
+          # (not "!$all" + inclusions) because depguard expands "$all" to
+          # "**/*.go" even when negated, which would match every file
+          # (including these two) and make the rule apply nowhere.
+          files:
+            - "**/internal/metrics/flusher.go"
+            - "**/internal/metrics/metrics.go"
+          allow:
+            - github.com/dolthub/eventkit
+          deny:
+            - pkg: github.com/dolthub
+              desc: "Dolt engine access is restricted to the storage adapter packages (internal/storage, internal/doltserver) - see docs/PROJECT_CHARTER.md 'Storage Boundary'"
     errcheck:
       exclude-functions:
         - (*database/sql.DB).Close

--- a/docs/PROJECT_CHARTER.md
+++ b/docs/PROJECT_CHARTER.md
@@ -56,6 +56,13 @@ If the current storage interface cannot express a needed operation, widen the
 interface or route the issue to the driver instead of embedding storage-engine
 logic in core.
 
+This boundary is mechanically enforced for non-test code by a `depguard`
+rule in `.golangci.yml` that denies `github.com/dolthub/` imports outside
+`internal/storage/` and `internal/doltserver/` (the linter config does not
+analyze `_test.go` files). The rule's `files` list documents the only
+justified exceptions (the proxied-server surface and DoltHub's `eventkit`
+telemetry client) alongside why each one is allowed.
+
 ## Schema Boundary
 
 The database schema is considered stable. Schema changes are allowed when there


### PR DESCRIPTION
## Why

`docs/PROJECT_CHARTER.md`'s **Storage Boundary** section says beads packages must not depend on the Dolt engine directly outside the storage adapter packages - but until now that was enforced only socially (charter text + reviewer vigilance). Nothing stopped a new `github.com/dolthub/*` import from landing in `cmd/bd` or `internal/*` unnoticed. This PR turns the boundary into a lint/CI failure.

## What

- Add a `depguard` rule (`dolt-storage-boundary`) to `.golangci.yml` (schema v2) denying `github.com/dolthub/*` imports outside `internal/storage/**` and `internal/doltserver/**`, with an error message pointing back at the charter section.
- Carve out the two pre-existing legitimate exceptions, each documented inline:
  - `cmd/bd/proxied_server.go` - imports dolt `servercfg`/`filesys` to launch and manage a real `dolt sql-server`; candidate for later migration behind the storage adapter.
  - `internal/metrics/{flusher,metrics}.go` - imports DoltHub's `eventkit` telemetry client, which is not the storage engine. A companion rule (`dolt-storage-boundary-metrics-exception`) allows **only** `github.com/dolthub/eventkit` in these two files and still denies everything else `dolthub/*` (including the engine), so metrics cannot become a backdoor around the boundary.
- One-paragraph note in `docs/PROJECT_CHARTER.md` that the boundary is now mechanically enforced for non-test code (`_test.go` files are not analyzed under the current `run.tests: false` config).

## Verification

Against the CI-pinned golangci-lint **v2.9.0** with CI's exact args (`--timeout=5m --build-tags=gms_pure_go ./...`):

- Baseline: `0 issues` on this branch.
- Negative probe 1: a temporary blank import of `github.com/dolthub/driver/v2` in `cmd/bd` fails with the boundary message (probe reverted).
- Negative probe 2: a temporary blank import of `github.com/dolthub/go-mysql-server/sql` in `internal/metrics/metrics.go` fails via the companion rule - proving the metrics carve-out admits eventkit only (probe reverted).
- Removing the `proxied_server.go` exception line produces exactly the 2 expected depguard errors (restored).
- `cmd/bd/compact.go`'s `dolthub` grep hit is a URL string in a hint message, not an import - correctly unaffected.

## Notes

- `list-mode: lax` + `files` globs with `**/`-anchored negations were validated empirically against v2.9.0; the config also runs clean under the pre-commit-pinned v2.10.1 (which reports unrelated pre-existing `gosec` findings from gosec version drift - out of scope here).
- Follow-up candidates deliberately not in this PR: migrating `proxied_server.go`'s dolt-config usage behind the storage adapter, and forbidding filesystem reach-across (`.dolt/` paths, flock) outside storage packages (a `forbidigo`-shaped rule, different linter).

Implementation by a delegated builder agent (claude-sonnet-5), independently reviewed by a delegated reviewer agent (claude-opus-4-8) before posting; review findings (metrics-exception tightening, charter wording) are incorporated.

_claude-fable-5-high on behalf of matt wilkie_
