### PR TITLE
fix(doltserver): stop test sql-server children on parent death

### DIFF
--- a/internal/doltserver/doltserver_linux.go
+++ b/internal/doltserver/doltserver_linux.go
@@ -1,0 +1,14 @@
+//go:build linux
+
+package doltserver
+
+import (
+	"os"
+	"syscall"
+)
+
+func applyTestModeParentDeathSignal(attr *syscall.SysProcAttr) {
+	if os.Getenv("BEADS_TEST_MODE") == "1" {
+		attr.Pdeathsig = syscall.SIGTERM
+	}
+}

--- a/internal/doltserver/doltserver_linux_test.go
+++ b/internal/doltserver/doltserver_linux_test.go
@@ -1,0 +1,32 @@
+//go:build linux
+
+package doltserver
+
+import (
+	"syscall"
+	"testing"
+)
+
+func TestProcAttrDetachedAddsParentDeathSignalInTestMode(t *testing.T) {
+	t.Setenv("BEADS_TEST_MODE", "1")
+
+	attr := procAttrDetached()
+	if !attr.Setpgid {
+		t.Fatal("procAttrDetached() did not keep Setpgid=true")
+	}
+	if attr.Pdeathsig != syscall.SIGTERM {
+		t.Fatalf("Pdeathsig = %v, want SIGTERM", attr.Pdeathsig)
+	}
+}
+
+func TestProcAttrDetachedLeavesProductionServerDetached(t *testing.T) {
+	t.Setenv("BEADS_TEST_MODE", "")
+
+	attr := procAttrDetached()
+	if !attr.Setpgid {
+		t.Fatal("procAttrDetached() did not keep Setpgid=true")
+	}
+	if attr.Pdeathsig != 0 {
+		t.Fatalf("Pdeathsig = %v, want 0 outside test mode", attr.Pdeathsig)
+	}
+}

--- a/internal/doltserver/doltserver_nonlinux.go
+++ b/internal/doltserver/doltserver_nonlinux.go
@@ -1,0 +1,7 @@
+//go:build !windows && !linux
+
+package doltserver
+
+import "syscall"
+
+func applyTestModeParentDeathSignal(_ *syscall.SysProcAttr) {}

--- a/internal/doltserver/doltserver_unix.go
+++ b/internal/doltserver/doltserver_unix.go
@@ -24,7 +24,9 @@ const processListHint = "pgrep -la 'dolt sql-server'"
 // procAttrDetached returns SysProcAttr to detach a child process from the parent
 // process group so it survives parent exit.
 func procAttrDetached() *syscall.SysProcAttr {
-	return &syscall.SysProcAttr{Setpgid: true}
+	attr := &syscall.SysProcAttr{Setpgid: true}
+	applyTestModeParentDeathSignal(attr)
+	return attr
 }
 
 // findPIDOnPort returns the PID of the process listening on a TCP port.


### PR DESCRIPTION
## Why

Interrupted Go test runs can leave managed `dolt sql-server` children alive after the test binary is gone. Those servers keep running against deleted tempdirs and accumulate until they are manually reaped.

Production server survival is intentional, so the fix must not make normal managed servers die with a single `bd` invocation.

## What

- Preserve the existing detached Unix process group behavior.
- On Linux only, when `BEADS_TEST_MODE=1`, add `Pdeathsig=SIGTERM` to the managed `dolt sql-server` child.
- Keep non-Linux Unix and Windows behavior unchanged.
- Cover the Linux `SysProcAttr` contract with focused tests.

Coordination: `mybd-q6cz`.

## Verification

- `go test ./internal/doltserver`
- `go test ./internal/storage/dolt -run 'TestShouldStopAutoStartedServerOnClose|TestApplyConfigDefaults'`
- `GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go test -c ./internal/doltserver`
