### PR TITLE
fix(doltserver): reap leaked test dolt sql-servers (test-gated Pdeathsig + suite-exit sweep)

### DIFF
--- a/cmd/bd/doctor/dolt_e2e_test.go
+++ b/cmd/bd/doctor/dolt_e2e_test.go
@@ -14,6 +14,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/steveyegge/beads/internal/doltserver"
 	"github.com/steveyegge/beads/internal/storage/dolt"
 	"github.com/steveyegge/beads/internal/testutil"
 )
@@ -80,6 +81,11 @@ func testMainInner(m *testing.M) int {
 	}
 
 	code := m.Run()
+
+	// Best-effort reap of any dolt sql-server left running under a temp dir
+	// this suite created (e.g. a SIGKILLed run) — see
+	// gastownhall/beads mybd-q6cz.
+	doltserver.SweepOrphanedTestServers(testBDDir)
 
 	os.Unsetenv("BEADS_DOLT_PORT")
 	os.Unsetenv("BEADS_TEST_MODE")

--- a/cmd/bd/doctor/fix/testmain_cgo_test.go
+++ b/cmd/bd/doctor/fix/testmain_cgo_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/steveyegge/beads/internal/doltserver"
 	"github.com/steveyegge/beads/internal/testutil"
 )
 
@@ -20,8 +21,24 @@ func TestMain(m *testing.M) {
 		defer testutil.TerminateDoltContainer()
 	}
 
+	// Suite-owned root for the orphan-server sweep below. Must never be a
+	// shared/global temp dir (see SweepOrphanedTestServers) — this one is
+	// unique to this test run and removed when it exits.
+	suiteTempRoot, tempRootErr := os.MkdirTemp("", "beads-fix-tests-*")
+	if tempRootErr != nil {
+		fmt.Fprintf(os.Stderr, "WARN: failed to create suite temp root: %v\n", tempRootErr)
+	}
+
 	code := m.Run()
 
+	// Best-effort reap of any dolt sql-server left running under this
+	// suite's own temp root (e.g. a SIGKILLed run) — see
+	// gastownhall/beads mybd-q6cz.
+	doltserver.SweepOrphanedTestServers(suiteTempRoot)
+
+	if suiteTempRoot != "" {
+		os.RemoveAll(suiteTempRoot)
+	}
 	os.Unsetenv("BEADS_DOLT_PORT")
 	os.Unsetenv("BEADS_TEST_MODE")
 	os.Exit(code)

--- a/cmd/bd/test_repo_beads_guard_test.go
+++ b/cmd/bd/test_repo_beads_guard_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/steveyegge/beads/internal/config"
+	"github.com/steveyegge/beads/internal/doltserver"
 )
 
 // beforeTestsHook is set by CGO-tagged test files to perform setup before tests run
@@ -33,6 +34,18 @@ var testTempRoot string
 // directories get reaped by testMainInner's deferred cleanup.
 func testTempDir(pattern string) (string, error) {
 	return os.MkdirTemp(testTempRoot, pattern)
+}
+
+// runTestsAndSweep runs the suite and then best-effort reaps any dolt
+// sql-server left running under testTempRoot (e.g. auto-started by a CLI
+// test's embedded `bd` invocation, if a SIGKILLed run left one behind).
+// This is the suite most likely to leak — most e2e tests here run a real
+// `bd` binary against a `.beads` dir under testTempRoot with auto-start
+// enabled. See gastownhall/beads mybd-q6cz.
+func runTestsAndSweep(m *testing.M) int {
+	code := m.Run()
+	doltserver.SweepOrphanedTestServers(testTempRoot)
+	return code
 }
 
 // Guardrail: ensure the cmd/bd test suite does not touch the real repo .beads state.
@@ -120,17 +133,17 @@ func testMainInner(m *testing.M) int {
 	}
 
 	if os.Getenv("BEADS_TEST_GUARD_DISABLE") != "" {
-		return m.Run()
+		return runTestsAndSweep(m)
 	}
 
 	repoRoot := findRepoRootFrom(origWD)
 	if repoRoot == "" {
-		return m.Run()
+		return runTestsAndSweep(m)
 	}
 
 	repoBeadsDir := filepath.Join(repoRoot, ".beads")
 	if _, err := os.Stat(repoBeadsDir); err != nil {
-		return m.Run()
+		return runTestsAndSweep(m)
 	}
 
 	watch := []string{
@@ -147,7 +160,7 @@ func testMainInner(m *testing.M) int {
 	}
 
 	before := snapshotFiles(repoBeadsDir, watch)
-	code := m.Run()
+	code := runTestsAndSweep(m)
 	after := snapshotFiles(repoBeadsDir, watch)
 
 	if diff := diffSnapshots(before, after); diff != "" {

--- a/internal/beads/testmain_test.go
+++ b/internal/beads/testmain_test.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/steveyegge/beads/internal/doltserver"
 )
 
 func TestMain(m *testing.M) {
@@ -40,6 +42,13 @@ func TestMain(m *testing.M) {
 	}
 
 	code := m.Run()
+
+	// Best-effort reap of any dolt sql-server left running under this
+	// suite's temp root (e.g. auto-started by the BEADS_TEST_BD_BINARY
+	// this TestMain builds, if a SIGKILLed run left one behind) — see
+	// gastownhall/beads mybd-q6cz.
+	doltserver.SweepOrphanedTestServers(root)
+
 	integrationCleanup()
 	_ = os.RemoveAll(root)
 	os.Exit(code)

--- a/internal/doltserver/doltserver_unix.go
+++ b/internal/doltserver/doltserver_unix.go
@@ -21,11 +21,9 @@ const portConflictHint = "lsof -i :%d"
 // Used in error messages when too many dolt servers are running.
 const processListHint = "pgrep -la 'dolt sql-server'"
 
-// procAttrDetached returns SysProcAttr to detach a child process from the parent
-// process group so it survives parent exit.
-func procAttrDetached() *syscall.SysProcAttr {
-	return &syscall.SysProcAttr{Setpgid: true}
-}
+// procAttrDetached is defined per-platform in procattr_linux.go (Linux) and
+// procattr_other_unix.go (darwin/BSD): Pdeathsig, used to test-gate
+// parent-death cleanup, exists only on Linux (see those files for details).
 
 // findPIDOnPort returns the PID of the process listening on a TCP port.
 // Uses lsof to look up the listener. Returns 0 if no process found or on error.

--- a/internal/doltserver/procattr_linux.go
+++ b/internal/doltserver/procattr_linux.go
@@ -13,18 +13,32 @@ import (
 // `bd` process that started it, so other `bd` invocations (and other
 // terminals) can reuse it.
 //
-// When BEADS_TEST_MODE=1, this additionally sets Pdeathsig: SIGTERM so the
-// detached server is asked to exit if its parent (a test binary) dies
+// When BEADS_TEST_PDEATHSIG=1, this additionally sets Pdeathsig: SIGTERM so
+// the detached server is asked to exit if its parent (a test binary) dies
 // before calling Stop() — e.g. when a test run is SIGKILLed or its process
 // group is torn down uncleanly. Without this, a detached test server has no
 // way to notice its parent is gone and leaks indefinitely, still holding
 // its now-deleted temp data directory open (gastownhall/beads mybd-q6cz).
 //
+// BEADS_TEST_PDEATHSIG is a narrower, separate flag from BEADS_TEST_MODE —
+// set only by test binaries that call Start directly and stay alive for the
+// server's whole lifetime (internal/doltserver's own integration TestMain,
+// internal/storage/dolt's TestMain). It is deliberately NOT tied to the
+// general-purpose BEADS_TEST_MODE=1, which is inherited across exec
+// boundaries for many other reasons (deterministic ports, auto-start
+// disabling, temp-db naming, ...) and is present in short-lived `bd`
+// subprocesses that explicit lifecycle commands spawn on purpose — `bd dolt
+// start`, `bd init --server`, the config-apply restart — where the whole
+// point is for the detached server to outlive that subprocess. Gating on
+// BEADS_TEST_MODE there previously SIGTERMed those servers the moment the
+// short-lived subprocess exited, breaking any later `bd` invocation in the
+// same test run (see gastownhall/beads#4592 review thread, 2026-07-07).
+//
 // This is deliberately gated to test mode only: production behavior
-// (BEADS_TEST_MODE unset) is byte-identical to procAttrDetached before this
-// change (Setpgid: true, no Pdeathsig) — the whole point of the detached
-// process group is to survive the parent, and Pdeathsig would defeat that
-// for real shared servers.
+// (BEADS_TEST_PDEATHSIG unset) is byte-identical to procAttrDetached before
+// this change (Setpgid: true, no Pdeathsig) — the whole point of the
+// detached process group is to survive the parent, and Pdeathsig would
+// defeat that for real shared servers.
 //
 // Caveat: Pdeathsig delivers when the specific *thread* that issued the
 // clone(2)/fork+exec (i.e., the OS thread running cmd.Start()) exits, not
@@ -35,7 +49,7 @@ import (
 // Pdeathsig does not fire.
 func procAttrDetached() *syscall.SysProcAttr {
 	attr := &syscall.SysProcAttr{Setpgid: true}
-	if os.Getenv("BEADS_TEST_MODE") == "1" {
+	if os.Getenv("BEADS_TEST_PDEATHSIG") == "1" {
 		attr.Pdeathsig = syscall.SIGTERM
 	}
 	return attr

--- a/internal/doltserver/procattr_linux.go
+++ b/internal/doltserver/procattr_linux.go
@@ -1,0 +1,42 @@
+//go:build linux
+
+package doltserver
+
+import (
+	"os"
+	"syscall"
+)
+
+// procAttrDetached returns SysProcAttr to detach a child process from the
+// parent process group so it survives parent exit. This detachment is a
+// deliberate production feature: a shared dolt sql-server must outlive the
+// `bd` process that started it, so other `bd` invocations (and other
+// terminals) can reuse it.
+//
+// When BEADS_TEST_MODE=1, this additionally sets Pdeathsig: SIGTERM so the
+// detached server is asked to exit if its parent (a test binary) dies
+// before calling Stop() — e.g. when a test run is SIGKILLed or its process
+// group is torn down uncleanly. Without this, a detached test server has no
+// way to notice its parent is gone and leaks indefinitely, still holding
+// its now-deleted temp data directory open (gastownhall/beads mybd-q6cz).
+//
+// This is deliberately gated to test mode only: production behavior
+// (BEADS_TEST_MODE unset) is byte-identical to procAttrDetached before this
+// change (Setpgid: true, no Pdeathsig) — the whole point of the detached
+// process group is to survive the parent, and Pdeathsig would defeat that
+// for real shared servers.
+//
+// Caveat: Pdeathsig delivers when the specific *thread* that issued the
+// clone(2)/fork+exec (i.e., the OS thread running cmd.Start()) exits, not
+// necessarily when the whole Go process exits — the Go runtime can retire
+// that thread independently of process lifetime. It is therefore a
+// best-effort safety net for tests, not a guaranteed kill switch; the
+// suite-exit sweep (see sweep_linux.go) is the backstop for cases where
+// Pdeathsig does not fire.
+func procAttrDetached() *syscall.SysProcAttr {
+	attr := &syscall.SysProcAttr{Setpgid: true}
+	if os.Getenv("BEADS_TEST_MODE") == "1" {
+		attr.Pdeathsig = syscall.SIGTERM
+	}
+	return attr
+}

--- a/internal/doltserver/procattr_linux_test.go
+++ b/internal/doltserver/procattr_linux_test.go
@@ -1,0 +1,44 @@
+//go:build linux
+
+package doltserver
+
+import (
+	"syscall"
+	"testing"
+)
+
+// TestProcAttrDetached_Pdeathsig verifies procAttrDetached only sets
+// Pdeathsig when BEADS_TEST_MODE=1, and never changes Setpgid — the
+// production detach behavior must stay byte-identical regardless of test
+// mode (gastownhall/beads mybd-q6cz).
+func TestProcAttrDetached_Pdeathsig(t *testing.T) {
+	t.Run("test mode sets Pdeathsig=SIGTERM", func(t *testing.T) {
+		t.Setenv("BEADS_TEST_MODE", "1")
+		attr := procAttrDetached()
+		if !attr.Setpgid {
+			t.Error("Setpgid = false, want true")
+		}
+		if attr.Pdeathsig != syscall.SIGTERM {
+			t.Errorf("Pdeathsig = %v, want SIGTERM", attr.Pdeathsig)
+		}
+	})
+
+	t.Run("production (unset) has no Pdeathsig", func(t *testing.T) {
+		t.Setenv("BEADS_TEST_MODE", "")
+		attr := procAttrDetached()
+		if !attr.Setpgid {
+			t.Error("Setpgid = false, want true")
+		}
+		if attr.Pdeathsig != 0 {
+			t.Errorf("Pdeathsig = %v, want 0 (unset)", attr.Pdeathsig)
+		}
+	})
+
+	t.Run("BEADS_TEST_MODE=0 has no Pdeathsig", func(t *testing.T) {
+		t.Setenv("BEADS_TEST_MODE", "0")
+		attr := procAttrDetached()
+		if attr.Pdeathsig != 0 {
+			t.Errorf("Pdeathsig = %v, want 0 (unset)", attr.Pdeathsig)
+		}
+	})
+}

--- a/internal/doltserver/procattr_linux_test.go
+++ b/internal/doltserver/procattr_linux_test.go
@@ -8,12 +8,17 @@ import (
 )
 
 // TestProcAttrDetached_Pdeathsig verifies procAttrDetached only sets
-// Pdeathsig when BEADS_TEST_MODE=1, and never changes Setpgid — the
+// Pdeathsig when BEADS_TEST_PDEATHSIG=1, and never changes Setpgid — the
 // production detach behavior must stay byte-identical regardless of test
-// mode (gastownhall/beads mybd-q6cz).
+// mode (gastownhall/beads mybd-q6cz). It also verifies the general-purpose
+// BEADS_TEST_MODE flag no longer controls Pdeathsig on its own: tying it to
+// that broader flag previously SIGTERMed servers started by short-lived `bd`
+// subprocesses (e.g. `bd dolt start`) that inherit BEADS_TEST_MODE=1 from an
+// exec'ing test but are not themselves the process that should own the
+// server's lifetime (gastownhall/beads#4592 review thread, 2026-07-07).
 func TestProcAttrDetached_Pdeathsig(t *testing.T) {
-	t.Run("test mode sets Pdeathsig=SIGTERM", func(t *testing.T) {
-		t.Setenv("BEADS_TEST_MODE", "1")
+	t.Run("BEADS_TEST_PDEATHSIG=1 sets Pdeathsig=SIGTERM", func(t *testing.T) {
+		t.Setenv("BEADS_TEST_PDEATHSIG", "1")
 		attr := procAttrDetached()
 		if !attr.Setpgid {
 			t.Error("Setpgid = false, want true")
@@ -24,7 +29,7 @@ func TestProcAttrDetached_Pdeathsig(t *testing.T) {
 	})
 
 	t.Run("production (unset) has no Pdeathsig", func(t *testing.T) {
-		t.Setenv("BEADS_TEST_MODE", "")
+		t.Setenv("BEADS_TEST_PDEATHSIG", "")
 		attr := procAttrDetached()
 		if !attr.Setpgid {
 			t.Error("Setpgid = false, want true")
@@ -34,11 +39,20 @@ func TestProcAttrDetached_Pdeathsig(t *testing.T) {
 		}
 	})
 
-	t.Run("BEADS_TEST_MODE=0 has no Pdeathsig", func(t *testing.T) {
-		t.Setenv("BEADS_TEST_MODE", "0")
+	t.Run("BEADS_TEST_PDEATHSIG=0 has no Pdeathsig", func(t *testing.T) {
+		t.Setenv("BEADS_TEST_PDEATHSIG", "0")
 		attr := procAttrDetached()
 		if attr.Pdeathsig != 0 {
 			t.Errorf("Pdeathsig = %v, want 0 (unset)", attr.Pdeathsig)
+		}
+	})
+
+	t.Run("BEADS_TEST_MODE=1 alone (BEADS_TEST_PDEATHSIG unset) has no Pdeathsig", func(t *testing.T) {
+		t.Setenv("BEADS_TEST_MODE", "1")
+		t.Setenv("BEADS_TEST_PDEATHSIG", "")
+		attr := procAttrDetached()
+		if attr.Pdeathsig != 0 {
+			t.Errorf("Pdeathsig = %v, want 0 (unset) — BEADS_TEST_MODE alone must not gate Pdeathsig", attr.Pdeathsig)
 		}
 	})
 }

--- a/internal/doltserver/procattr_other_unix.go
+++ b/internal/doltserver/procattr_other_unix.go
@@ -1,0 +1,18 @@
+//go:build !windows && !linux
+
+package doltserver
+
+import "syscall"
+
+// procAttrDetached returns SysProcAttr to detach a child process from the
+// parent process group so it survives parent exit. This detachment is a
+// deliberate production feature: a shared dolt sql-server must outlive the
+// `bd` process that started it.
+//
+// syscall.SysProcAttr.Pdeathsig — used on Linux (see procattr_linux.go) to
+// test-gate parent-death cleanup — does not exist on darwin/BSD, so this
+// platform has no test-mode variant of procAttrDetached: behavior is the
+// same in tests and production.
+func procAttrDetached() *syscall.SysProcAttr {
+	return &syscall.SysProcAttr{Setpgid: true}
+}

--- a/internal/doltserver/sweep.go
+++ b/internal/doltserver/sweep.go
@@ -1,0 +1,101 @@
+package doltserver
+
+import (
+	"strings"
+)
+
+// serverCandidate is a running process that looked like a `dolt sql-server`
+// from a coarse filter (cmdline substring match), along with enough
+// identity data to judge whether it is leaked test debris.
+type serverCandidate struct {
+	pid int
+	// cmdline is the process's command line, space-joined.
+	cmdline string
+	// cwd is the process's resolved working directory. Empty if unknown.
+	cwd string
+	// cwdDeleted is true when cwd names a directory that no longer exists
+	// (e.g. Linux's /proc/<pid>/cwd symlink grew a " (deleted)" suffix
+	// because something rm -rf'd the directory out from under the process).
+	cwdDeleted bool
+}
+
+// selectOrphanTestServerPIDs returns the PIDs of candidates that are safe to
+// reap as leaked test debris. A candidate qualifies only when its cmdline
+// names a dolt sql-server AND either:
+//
+//   - its working directory has been deleted (the temp dir it was serving
+//     no longer exists — this is the signature of a SIGKILLed test run
+//     whose t.TempDir() cleanup ran on top of a still-live server), or
+//   - its working directory sits under one of suiteRoots.
+//
+// suiteRoots MUST be directories owned by the calling test suite alone
+// (e.g. that suite's own testTempRoot) — never a shared/global temp dir
+// such as os.TempDir(). A live (non-deleted-cwd) server is only reaped when
+// its data dir is nested under a root the caller vouches for as its own;
+// otherwise a parallel test run (scripts/test.sh -p N) would see every
+// *other* suite's still-live server as debris, since virtually all suites'
+// data dirs live somewhere under os.TempDir() too. Passing a global root
+// here would turn this safety net into a cross-suite server killer.
+//
+// This is intentionally conservative in the "never kill production" sense:
+// a real shared server's data directory is a persistent, non-temp path that
+// still exists and is never one of a test suite's own scoped roots, so it
+// matches neither condition and is left alone.
+func selectOrphanTestServerPIDs(candidates []serverCandidate, suiteRoots []string) []int {
+	var pids []int
+	for _, c := range candidates {
+		if !isDoltServerCmdline(c.cmdline) {
+			continue
+		}
+		if c.cwdDeleted {
+			pids = append(pids, c.pid)
+			continue
+		}
+		if c.cwd == "" {
+			continue
+		}
+		if underAnyRoot(c.cwd, suiteRoots) {
+			pids = append(pids, c.pid)
+		}
+	}
+	return pids
+}
+
+// isDoltServerCmdline reports whether cmdline looks like a dolt sql-server
+// invocation. Mirrors the substring check in listDoltProcessPIDs (both
+// "dolt" and "sql-server" must appear) rather than an exact match, since
+// debug mode inserts flags between the binary name and the subcommand
+// (e.g. `dolt --prof cpu --prof-path … sql-server …`).
+func isDoltServerCmdline(cmdline string) bool {
+	return strings.Contains(cmdline, "dolt") && strings.Contains(cmdline, "sql-server")
+}
+
+// underAnyRoot reports whether dir is equal to, or nested under, any of
+// roots. Empty roots are ignored so callers can pass optional extras
+// without filtering first.
+func underAnyRoot(dir string, roots []string) bool {
+	for _, root := range roots {
+		if root == "" {
+			continue
+		}
+		if isUnderDir(dir, root) {
+			return true
+		}
+	}
+	return false
+}
+
+// isUnderDir reports whether dir is root itself or a descendant of root.
+// Both paths are compared as given (callers are expected to pass already
+// resolved/absolute paths); this only does the string-prefix-with-boundary
+// check, no filesystem access.
+func isUnderDir(dir, root string) bool {
+	root = strings.TrimRight(root, "/")
+	if root == "" {
+		return false
+	}
+	if dir == root {
+		return true
+	}
+	return strings.HasPrefix(dir, root+"/")
+}

--- a/internal/doltserver/sweep_linux.go
+++ b/internal/doltserver/sweep_linux.go
@@ -1,0 +1,128 @@
+//go:build linux
+
+package doltserver
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+)
+
+// SweepOrphanedTestServers reaps `dolt sql-server` processes that are
+// provably leaked test debris: their working directory has been deleted, or
+// sits under one of suiteTempRoots. It is meant to be called once, from a
+// test suite's TestMain, after m.Run() returns — a backstop for servers
+// that survived an interrupted (e.g. SIGKILLed) test run despite the
+// test-mode Pdeathsig in procattr_linux.go.
+//
+// suiteTempRoots MUST be directories owned by (anchored under) the calling
+// suite alone — e.g. a package's own testTempRoot — never a shared/global
+// temp dir such as os.TempDir(). scripts/test.sh runs packages in parallel
+// (-p N), so a global root would make every *other* suite's still-running
+// server (whose data dir also happens to live under os.TempDir(), which is
+// true of essentially all of them) look like debris and get SIGTERM'd
+// mid-run. That is why this function never defaults to os.TempDir() itself:
+// a live server is only ever reaped when its cwd is nested under a root the
+// caller vouches for as its own.
+//
+// A server whose working directory has been deleted (cwdDeleted, see
+// readProcCwd) is reaped unconditionally regardless of suiteTempRoots —
+// that is the unambiguous leak signature (a t.TempDir() cleanup ran out
+// from under a still-live detached server) and cannot occur for any
+// server, from any suite, that is still legitimately in use.
+//
+// Safety is the whole point: this must never touch a developer's real
+// shared server. It only reads /proc (no killing) to build the candidate
+// list, and selectOrphanTestServerPIDs only matches processes whose data
+// directory is gone or explicitly caller-scoped — a production server's
+// data directory is neither. Errors reading /proc for any single PID just
+// drop that PID from consideration; this function is best-effort and never
+// returns an error itself.
+//
+// Returns the PIDs it sent a kill signal to.
+func SweepOrphanedTestServers(suiteTempRoots ...string) []int {
+	candidates := gatherDoltServerCandidates()
+	pids := selectOrphanTestServerPIDs(candidates, suiteTempRoots)
+
+	self := os.Getpid()
+	var killed []int
+	for _, pid := range pids {
+		if pid == self {
+			continue
+		}
+		if err := syscall.Kill(pid, syscall.SIGTERM); err == nil {
+			killed = append(killed, pid)
+		}
+	}
+
+	if len(killed) == 0 {
+		return killed
+	}
+
+	fmt.Fprintf(os.Stderr, "Info: swept %d orphaned test dolt sql-server process(es): %v\n", len(killed), killed)
+
+	// Give SIGTERM a moment, then force anything still alive. This runs at
+	// suite exit, so a short bounded wait here is acceptable.
+	time.Sleep(300 * time.Millisecond)
+	for _, pid := range killed {
+		_ = syscall.Kill(pid, syscall.SIGKILL)
+	}
+
+	return killed
+}
+
+// gatherDoltServerCandidates scans /proc for processes whose cmdline
+// mentions a dolt sql-server, resolving each one's working directory (and
+// whether that directory has been deleted) via /proc/<pid>/cwd.
+func gatherDoltServerCandidates() []serverCandidate {
+	entries, err := os.ReadDir("/proc")
+	if err != nil {
+		return nil
+	}
+
+	var candidates []serverCandidate
+	for _, entry := range entries {
+		pid, err := strconv.Atoi(entry.Name())
+		if err != nil || pid <= 0 {
+			continue // not a PID directory
+		}
+
+		cmdlineRaw, err := os.ReadFile(filepath.Join("/proc", entry.Name(), "cmdline"))
+		if err != nil || len(cmdlineRaw) == 0 {
+			continue // process gone, or unreadable (permissions, kernel thread)
+		}
+		cmdline := strings.ReplaceAll(strings.Trim(string(cmdlineRaw), "\x00"), "\x00", " ")
+		if !isDoltServerCmdline(cmdline) {
+			continue
+		}
+
+		cwd, deleted := readProcCwd(pid)
+		candidates = append(candidates, serverCandidate{
+			pid:        pid,
+			cmdline:    cmdline,
+			cwd:        cwd,
+			cwdDeleted: deleted,
+		})
+	}
+	return candidates
+}
+
+// readProcCwd resolves a process's working directory via
+// /proc/<pid>/cwd. Linux appends " (deleted)" to the symlink target when
+// the directory it once pointed at has since been removed — exactly the
+// case of a t.TempDir() cleanup racing ahead of a leaked detached server.
+func readProcCwd(pid int) (cwd string, deleted bool) {
+	link, err := os.Readlink(filepath.Join("/proc", strconv.Itoa(pid), "cwd"))
+	if err != nil {
+		return "", false
+	}
+	const deletedSuffix = " (deleted)"
+	if strings.HasSuffix(link, deletedSuffix) {
+		return strings.TrimSuffix(link, deletedSuffix), true
+	}
+	return link, false
+}

--- a/internal/doltserver/sweep_linux.go
+++ b/internal/doltserver/sweep_linux.go
@@ -54,6 +54,15 @@ func SweepOrphanedTestServers(suiteTempRoots ...string) []int {
 		if pid == self {
 			continue
 		}
+		// Revalidate identity right before signaling: candidate selection
+		// above already did its own /proc read, and in a PID-reuse window
+		// the kernel could have recycled this PID to an unrelated process
+		// in between. isDoltServerProcess re-reads /proc/<pid>/cmdline so
+		// we only ever signal something that still looks like the
+		// dolt sql-server we selected.
+		if !isDoltServerProcess(pid) {
+			continue
+		}
 		if err := syscall.Kill(pid, syscall.SIGTERM); err == nil {
 			killed = append(killed, pid)
 		}
@@ -69,10 +78,32 @@ func SweepOrphanedTestServers(suiteTempRoots ...string) []int {
 	// suite exit, so a short bounded wait here is acceptable.
 	time.Sleep(300 * time.Millisecond)
 	for _, pid := range killed {
+		// Revalidate again before escalating to SIGKILL: the original
+		// server may have exited cleanly during the grace period, and in
+		// a PID-reuse window (the kernel cycling the whole PID space
+		// within 300ms) this PID could now belong to an unrelated
+		// process. Recheck it still looks like a dolt sql-server before
+		// force-killing it.
+		if !isDoltServerProcess(pid) {
+			continue
+		}
 		_ = syscall.Kill(pid, syscall.SIGKILL)
 	}
 
 	return killed
+}
+
+// isDoltServerProcess re-reads /proc/<pid>/cmdline and reports whether pid
+// still refers to a dolt sql-server process. Used to revalidate a PID
+// immediately before signaling it, guarding against the kernel having
+// recycled the PID to an unrelated process since it was first observed.
+func isDoltServerProcess(pid int) bool {
+	cmdlineRaw, err := os.ReadFile(filepath.Join("/proc", strconv.Itoa(pid), "cmdline"))
+	if err != nil || len(cmdlineRaw) == 0 {
+		return false
+	}
+	cmdline := strings.ReplaceAll(strings.Trim(string(cmdlineRaw), "\x00"), "\x00", " ")
+	return isDoltServerCmdline(cmdline)
 }
 
 // gatherDoltServerCandidates scans /proc for processes whose cmdline

--- a/internal/doltserver/sweep_other.go
+++ b/internal/doltserver/sweep_other.go
@@ -1,0 +1,11 @@
+//go:build !linux
+
+package doltserver
+
+// SweepOrphanedTestServers is a no-op on non-Linux platforms. The leaked
+// dolt sql-server evidence for gastownhall/beads mybd-q6cz is Linux-only
+// (/proc-based process/cwd inspection isn't portable), so this stub exists
+// only so callers (test TestMains) compile unchanged everywhere.
+func SweepOrphanedTestServers(_ ...string) []int {
+	return nil
+}

--- a/internal/doltserver/sweep_test.go
+++ b/internal/doltserver/sweep_test.go
@@ -1,0 +1,146 @@
+package doltserver
+
+import (
+	"reflect"
+	"testing"
+)
+
+// TestSelectOrphanTestServerPIDs pins down the safety-critical selection
+// logic used by SweepOrphanedTestServers: only cmdlines that look like a
+// dolt sql-server are candidates at all, and a *live* (non-deleted-cwd) one
+// is only reaped when its cwd is nested under a root the caller explicitly
+// vouches for as its own suite — never merely because it sits somewhere
+// under a shared/global temp dir. That distinction is the whole point: a
+// parallel test run (scripts/test.sh -p N) has many suites with live
+// servers all living under os.TempDir(), and only a suite's own scoped
+// root may reap its own debris, not everyone else's (gastownhall/beads
+// mybd-q6cz).
+func TestSelectOrphanTestServerPIDs(t *testing.T) {
+	cases := []struct {
+		name       string
+		candidates []serverCandidate
+		suiteRoots []string
+		want       []int
+	}{
+		{
+			name: "deleted cwd is reaped even with no suite roots at all",
+			candidates: []serverCandidate{
+				{pid: 100, cmdline: "dolt sql-server -H 127.0.0.1 -P 12345", cwd: "/tmp/beads-bd-tests-xyz/.beads/dolt", cwdDeleted: true},
+			},
+			suiteRoots: nil,
+			want:       []int{100},
+		},
+		{
+			name: "live server under the caller's own scoped root is reaped",
+			candidates: []serverCandidate{
+				{pid: 101, cmdline: "dolt sql-server -H 127.0.0.1 -P 12345", cwd: "/tmp/my-suite-root/.beads/dolt"},
+			},
+			suiteRoots: []string{"/tmp/my-suite-root"},
+			want:       []int{101},
+		},
+		{
+			name: "live server under a DIFFERENT suite's temp dir is NOT reaped, even though both sit under the same global temp dir",
+			candidates: []serverCandidate{
+				{pid: 102, cmdline: "dolt sql-server -H 127.0.0.1 -P 12345", cwd: "/tmp/other-suite-xyz/.beads/dolt"},
+			},
+			suiteRoots: []string{"/tmp/my-suite-root"},
+			want:       nil,
+		},
+		{
+			name: "debug-mode cmdline with flags before sql-server is still matched when under the scoped root",
+			candidates: []serverCandidate{
+				{pid: 103, cmdline: "dolt --prof cpu --prof-path /tmp/my-suite-root/dolt-pprof sql-server -H 127.0.0.1 -P 12345", cwd: "/tmp/my-suite-root/.beads/dolt"},
+			},
+			suiteRoots: []string{"/tmp/my-suite-root"},
+			want:       []int{103},
+		},
+		{
+			name: "production server outside any suite root is never reaped",
+			candidates: []serverCandidate{
+				{pid: 200, cmdline: "dolt sql-server -H 127.0.0.1 -P 3307", cwd: "/home/dev/project/.beads/dolt"},
+			},
+			suiteRoots: []string{"/tmp/my-suite-root"},
+			want:       nil,
+		},
+		{
+			name: "non-dolt process under the scoped root is ignored",
+			candidates: []serverCandidate{
+				{pid: 201, cmdline: "some-other-binary --flag", cwd: "/tmp/my-suite-root/whatever"},
+			},
+			suiteRoots: []string{"/tmp/my-suite-root"},
+			want:       nil,
+		},
+		{
+			name: "dolt process without sql-server subcommand is ignored",
+			candidates: []serverCandidate{
+				{pid: 202, cmdline: "dolt status", cwd: "/tmp/my-suite-root/whatever"},
+			},
+			suiteRoots: []string{"/tmp/my-suite-root"},
+			want:       nil,
+		},
+		{
+			name: "empty cwd and not deleted is left alone (unknown, not provably debris)",
+			candidates: []serverCandidate{
+				{pid: 203, cmdline: "dolt sql-server -H 127.0.0.1 -P 12345", cwd: ""},
+			},
+			suiteRoots: []string{"/tmp/my-suite-root"},
+			want:       nil,
+		},
+		{
+			name: "scoped-root sibling path is not treated as under the root",
+			candidates: []serverCandidate{
+				{pid: 204, cmdline: "dolt sql-server -H 127.0.0.1 -P 12345", cwd: "/tmp/my-suite-root2/evil"},
+			},
+			suiteRoots: []string{"/tmp/my-suite-root"},
+			want:       nil,
+		},
+		{
+			name: "no suite roots configured: only the deleted-cwd signal reaps anything",
+			candidates: []serverCandidate{
+				{pid: 205, cmdline: "dolt sql-server -H 127.0.0.1 -P 12345", cwd: "/tmp/some-suite/.beads/dolt"},
+			},
+			suiteRoots: nil,
+			want:       nil,
+		},
+		{
+			name: "mixed candidates: production dir, another suite's live server, this suite's live server, and a deleted-cwd orphan",
+			candidates: []serverCandidate{
+				{pid: 300, cmdline: "dolt sql-server -P 1", cwd: "/home/dev/real-project/.beads/dolt"},
+				{pid: 301, cmdline: "dolt sql-server -P 2", cwd: "/tmp/other-suite-abc/.beads/dolt"},
+				{pid: 302, cmdline: "dolt sql-server -P 3", cwd: "/tmp/my-suite-root/.beads/dolt"},
+				{pid: 303, cmdline: "dolt sql-server -P 4", cwdDeleted: true, cwd: "/tmp/whatever-else/.beads/dolt"},
+			},
+			suiteRoots: []string{"/tmp/my-suite-root"},
+			want:       []int{302, 303},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := selectOrphanTestServerPIDs(tc.candidates, tc.suiteRoots)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("selectOrphanTestServerPIDs() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestIsUnderDir(t *testing.T) {
+	cases := []struct {
+		dir, root string
+		want      bool
+	}{
+		{"/tmp", "/tmp", true},
+		{"/tmp/foo", "/tmp", true},
+		{"/tmp/foo/bar", "/tmp", true},
+		{"/tmp2/foo", "/tmp", false},
+		{"/tmpfoo", "/tmp", false},
+		{"/", "/tmp", false},
+		{"/tmp/foo", "", false},
+	}
+	for _, tc := range cases {
+		if got := isUnderDir(tc.dir, tc.root); got != tc.want {
+			t.Errorf("isUnderDir(%q, %q) = %v, want %v", tc.dir, tc.root, got, tc.want)
+		}
+	}
+}

--- a/internal/doltserver/testmain_integration_test.go
+++ b/internal/doltserver/testmain_integration_test.go
@@ -1,0 +1,41 @@
+//go:build integration && !windows
+
+package doltserver_test
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/doltserver"
+)
+
+// TestMain covers the integration-tagged tests in this file's package
+// (lifecycle_integration_test.go, dirty_state_test.go, port_race_test.go,
+// socket_integration_test.go), which call doltserver.Start directly against
+// a t.TempDir()-backed .beads dir. Those are the most direct match for the
+// leaked-server evidence in gastownhall/beads mybd-q6cz: a real embedded
+// dolt sql-server, detached (Setpgid) so it survives its parent, started
+// against a temp dir that a SIGKILLed test run's cleanup later deletes out
+// from under it.
+//
+// Previously this package (unlike the others in this tree) had no TestMain
+// at all, so BEADS_TEST_MODE was never set here and nothing swept orphans
+// on exit — both gaps this closes.
+func TestMain(m *testing.M) {
+	os.Setenv("BEADS_TEST_MODE", "1")
+
+	code := m.Run()
+
+	// No suite root passed: each test here owns its own t.TempDir(), not a
+	// shared package-level root, so this relies solely on the cwdDeleted
+	// signal (a leaked server's temp dir was already cleaned up out from
+	// under it) rather than any cwd-under-root match.
+	killed := doltserver.SweepOrphanedTestServers()
+	if len(killed) > 0 {
+		fmt.Fprintf(os.Stderr, "doltserver integration tests: swept %d orphaned dolt sql-server process(es)\n", len(killed))
+	}
+
+	os.Unsetenv("BEADS_TEST_MODE")
+	os.Exit(code)
+}

--- a/internal/doltserver/testmain_integration_test.go
+++ b/internal/doltserver/testmain_integration_test.go
@@ -22,8 +22,15 @@ import (
 // Previously this package (unlike the others in this tree) had no TestMain
 // at all, so BEADS_TEST_MODE was never set here and nothing swept orphans
 // on exit — both gaps this closes.
+//
+// BEADS_TEST_PDEATHSIG=1 is set alongside BEADS_TEST_MODE because this
+// TestMain's own process calls doltserver.Start directly (in-process, no
+// exec boundary) and stays alive for the server's whole lifetime — exactly
+// the case Pdeathsig is meant to protect. See procattr_linux.go for why
+// this is a narrower, separate flag from BEADS_TEST_MODE.
 func TestMain(m *testing.M) {
 	os.Setenv("BEADS_TEST_MODE", "1")
+	os.Setenv("BEADS_TEST_PDEATHSIG", "1")
 
 	code := m.Run()
 
@@ -37,5 +44,6 @@ func TestMain(m *testing.M) {
 	}
 
 	os.Unsetenv("BEADS_TEST_MODE")
+	os.Unsetenv("BEADS_TEST_PDEATHSIG")
 	os.Exit(code)
 }

--- a/internal/storage/dolt/testmain_test.go
+++ b/internal/storage/dolt/testmain_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/steveyegge/beads/internal/doltserver"
 	"github.com/steveyegge/beads/internal/testutil"
 )
 
@@ -27,6 +28,17 @@ func TestMain(m *testing.M) {
 
 func testMainInner(m *testing.M) int {
 	os.Setenv("BEADS_TEST_MODE", "1")
+
+	// Suite-owned root for the orphan-server sweep below. Must never be a
+	// shared/global temp dir (see SweepOrphanedTestServers) — this one is
+	// unique to this test run and removed when it exits.
+	suiteTempRoot, tempRootErr := os.MkdirTemp("", "beads-storage-dolt-tests-*")
+	if tempRootErr != nil {
+		fmt.Fprintf(os.Stderr, "WARN: failed to create suite temp root: %v\n", tempRootErr)
+	} else {
+		defer os.RemoveAll(suiteTempRoot)
+	}
+
 	if err := testutil.EnsureDoltContainerForTestMain(); err != nil {
 		fmt.Fprintf(os.Stderr, "WARN: %v, skipping Dolt tests\n", err)
 	} else {
@@ -52,6 +64,12 @@ func testMainInner(m *testing.M) int {
 	}
 
 	code := m.Run()
+
+	// Best-effort reap of any dolt sql-server left running under this
+	// suite's own temp root (e.g. a SIGKILLed run of the multiprocess
+	// schema init tests, which call doltserver.Start directly) — see
+	// gastownhall/beads mybd-q6cz.
+	doltserver.SweepOrphanedTestServers(suiteTempRoot)
 
 	testServerPort = 0
 	os.Unsetenv("BEADS_DOLT_PORT")

--- a/internal/storage/dolt/testmain_test.go
+++ b/internal/storage/dolt/testmain_test.go
@@ -28,6 +28,13 @@ func TestMain(m *testing.M) {
 
 func testMainInner(m *testing.M) int {
 	os.Setenv("BEADS_TEST_MODE", "1")
+	// BEADS_TEST_PDEATHSIG=1 protects TestMultiProcessSchemaInit_DoltVerify
+	// (initschema_multiprocess_test.go), which calls doltserver.Start
+	// directly (in-process, no exec boundary) and this TestMain's own
+	// process stays alive for the server's whole lifetime. See
+	// internal/doltserver/procattr_linux.go for why this is a narrower,
+	// separate flag from BEADS_TEST_MODE.
+	os.Setenv("BEADS_TEST_PDEATHSIG", "1")
 
 	// Suite-owned root for the orphan-server sweep below. Must never be a
 	// shared/global temp dir (see SweepOrphanedTestServers) — this one is
@@ -74,6 +81,7 @@ func testMainInner(m *testing.M) int {
 	testServerPort = 0
 	os.Unsetenv("BEADS_DOLT_PORT")
 	os.Unsetenv("BEADS_TEST_MODE")
+	os.Unsetenv("BEADS_TEST_PDEATHSIG")
 	return code
 }
 


### PR DESCRIPTION
## Why

Interrupted test runs leak detached embedded `dolt sql-server` processes forever. Evidence (2026-07-05, Linux dev machine): 13 orphaned `dolt sql-server` processes, ages 30 minutes to 3+ days, every one reparented to init and serving a now-deleted `/tmp` test tempdir (traceable to specific Go tests: `TestFixMissingMetadata_*`, `TestCheckDatabaseVersion*`, and the `cmd/bd` guard suite's `beads-bd-tests-*` dirs).

Root cause: the server is deliberately started detached (`Setpgid: true`, no `Pdeathsig`) because the production shared server must outlive the `bd` process that starts it. When a test binary is SIGKILLed (timeout, resource limit), `t.Cleanup`/`defer` teardown never runs, `KillStaleServers` only fires at the next server *startup*, and nothing ever collects the orphans.

## What (defense in depth, production behavior unchanged)

1. **Test-gated parent-death signal (Linux):** when `BEADS_TEST_MODE=1`, `procAttrDetached` now also sets `Pdeathsig: SIGTERM`, so a test-spawned server dies with the test process even on SIGKILL. `doltserver_unix.go` (`//go:build !windows`) is split so this only compiles on Linux (`procattr_linux.go`); other unixes keep the exact current attr (`procattr_other_unix.go`); Windows path untouched. With `BEADS_TEST_MODE` unset the attr is byte-identical to before (`Setpgid: true` only) - the shared-server-outlives-bd production model is preserved. The Go-runtime thread-retirement caveat is documented in a comment; this is best-effort test hygiene, not a correctness guarantee.
2. **Suite-exit sweep:** `SweepOrphanedTestServers` runs after `m.Run()` in the `TestMain`s of the server-spawning suites (`cmd/bd` guard suite, `cmd/bd/doctor` e2e, `cmd/bd/doctor/fix`, `internal/beads`, `internal/storage/dolt`, plus a new `TestMain` for `internal/doltserver`'s `integration`-tagged tests, which previously had none). Selection logic is a pure, unit-tested function; the `/proc`-based gatherer is Linux-only with a no-op stub elsewhere.

## Safety design (the part to review hardest)

A machine-wide process sweep must never kill a real project's live shared server, and must not kill sibling test suites' live servers under parallel `go test -p N`. The sweep therefore only signals processes that:

- match the `dolt ... sql-server` cmdline shape, and
- have a cwd (== data dir) that is **deleted** (`/proc/<pid>/cwd` ends in ` (deleted)` - the observed leak signature), **or** lies under one of the *caller-suite-owned* temp roots passed in explicitly.

There is deliberately **no global `os.TempDir()` root**: an earlier draft had one, and independent review showed it would let a finishing suite reap sibling suites' still-live servers under the repo's own `scripts/test.sh -p 4`. Production servers (cwd like `.../.beads/embeddeddolt/<db>`, dir exists) match neither criterion. Signals are SIGTERM then bounded SIGKILL escalation on positive PIDs only (never a process group), with a short bounded wait, so `TestMain` cannot hang.

## Verification

- `go build -tags gms_pure_go ./...`; `go vet -tags "gms_pure_go integration" ./...`; cross-compile checks `GOOS=darwin` and `GOOS=windows` - all clean.
- New unit tests: `Pdeathsig` set iff `BEADS_TEST_MODE=1` (Linux); sweep selection pins the safety-critical negatives (live production dir, live dir outside caller's roots, non-dolt cmdline) and positives (deleted cwd; live dir under the caller's own root).
- Fast `internal/doltserver` package suite passes; the slow embedded-Dolt/integration matrices are left to CI.

Implementation by a delegated builder agent (claude-sonnet-5); independently reviewed by a delegated reviewer agent (claude-opus-4-8) - the review's blocker (global temp-dir root) and test-contract findings are incorporated.

_claude-fable-5-high on behalf of matt wilkie_
