### PR TITLE
docs: remove stale sync-branch worktree guidance

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -453,7 +453,7 @@ git worktree prune
 bd config set sync.branch ""
 ```
 
-See [WORKTREES.md#beads-created-worktrees-sync-branch](WORKTREES.md#beads-created-worktrees-sync-branch) for full details.
+See [WORKTREES.md#legacy-cleanup](WORKTREES.md#legacy-cleanup) for full details.
 
 ### What's the difference between database corruption and ID collisions?
 

--- a/docs/PROTECTED_BRANCHES.md
+++ b/docs/PROTECTED_BRANCHES.md
@@ -19,7 +19,7 @@ Commit the small tracked configuration files if your project policy requires
 them:
 
 ```bash
-git add .beads/.gitignore .beads/metadata.json .beads/config.yaml .gitattributes
+git add .beads/.gitignore .beads/metadata.json .beads/config.yaml .gitignore
 git commit -m "Initialize beads issue tracker"
 ```
 
@@ -98,10 +98,10 @@ bd dolt push
 ### Conflicts During `bd dolt pull`
 
 Dolt reports database-level conflicts separately from Git branch conflicts. Use
-the conflict commands or doctor guidance printed by the failed command:
+the merge strategy or doctor guidance printed by the failed command:
 
 ```bash
-bd vc conflicts
+bd vc merge <branch> --strategy [ours|theirs]
 bd doctor --fix
 ```
 

--- a/docs/PROTECTED_BRANCHES.md
+++ b/docs/PROTECTED_BRANCHES.md
@@ -1,653 +1,120 @@
-# Protected Branch Workflow
+# Protected Branches
 
-This guide explains how to use beads with protected branches on platforms like GitHub, GitLab, and Bitbucket.
+Beads does not need a protected-branch workaround in current releases.
 
-## Table of Contents
+Issue data is stored in Dolt under `refs/dolt/data`, separate from normal Git
+branches such as `main`. Beads commands do not commit issue updates to your
+current code branch, so GitHub, GitLab, and Bitbucket branch protection rules
+continue to apply only to your code history.
 
-- [Overview](#overview)
-- [Quick Start](#quick-start)
-- [How It Works](#how-it-works)
-- [Setup](#setup)
-- [Daily Workflow](#daily-workflow)
-- [Merging Changes](#merging-changes)
-- [Troubleshooting](#troubleshooting)
-- [FAQ](#faq)
+## Current Workflow
 
-## Overview
-
-**Note:** This document describes a workflow that has been **removed**. Beads now stores data in Dolt under `refs/dolt/data`, separate from standard Git refs. Beads does not commit to any Git branch, so protected branch workflows are not affected.
-
-**Previous problem:** GitHub and other platforms let you protect branches (like `main`) to require pull requests for all changes. Previously, beads committed issue data to Git branches, which conflicted with branch protection.
-
-**Current solution:** Beads uses Dolt-native sync (`bd dolt push` / `bd dolt pull`). No Git branch commits are needed. The information below is retained for historical reference and for users migrating from older versions.
-
-**Benefits:**
-- ✅ Works with any git platform's branch protection
-- ✅ Main branch stays protected
-- ✅ No disruption to your primary working directory
-- ✅ Backward compatible (opt-in via config)
-- ✅ Minimal disk overhead (uses sparse checkout)
-- ✅ Platform-agnostic solution
-
-## Quick Start
-
-**1. Initialize beads with a separate sync branch:**
+Initialize beads in the project:
 
 ```bash
-cd your-project
 bd init
 ```
 
-This creates a `.beads/` directory with a Dolt database. Sync is handled via `bd dolt push` / `bd dolt pull`.
-
-**Important:** After initialization, you'll see some untracked files that should be committed to your protected branch:
+Commit the small tracked configuration files if your project policy requires
+them:
 
 ```bash
-# Check what files were created
-git status
-
-# Commit the beads configuration to your protected branch
-git add .beads/.gitignore .gitattributes
+git add .beads/.gitignore .beads/metadata.json .beads/config.yaml .gitattributes
 git commit -m "Initialize beads issue tracker"
-git push origin main  # Or create a PR if required
 ```
 
-**Files created by `bd init`:**
-
-Files that should be committed to your protected branch (main):
-- `.beads/.gitignore` - Tells git what to ignore in .beads/ directory
-- `.gitattributes` - Configures merge driver for beads data
-
-Files that are automatically gitignored (do NOT commit):
-- `.beads/dolt/` - Dolt database directory (local only)
-- `.beads/dolt/sql-server.pid`, `sql-server.log` - Dolt server runtime files
-
-The sync branch (beads-sync) will contain:
-- `.beads/metadata.json` - Metadata about the beads installation
-- `.beads/config.yaml` - Configuration template (optional)
-
-**2. Start the Dolt server:**
+The local Dolt database directory remains gitignored. Sync issue data through a
+Dolt remote:
 
 ```bash
-dolt sql-server
-```
-
-With git hooks installed (`bd hooks install`), issue changes are automatically committed to the `beads-sync` branch.
-
-**3. When ready, merge to main:**
-
-```bash
-# Check what's changed
-bd dolt show
-
-# Merge to main
-git merge beads-sync
-```
-
-That's it! The complete workflow is described below.
-
-## How It Works
-
-### Git Worktrees
-
-Beads uses [git worktrees](https://git-scm.com/docs/git-worktree) to maintain a lightweight checkout of your sync branch. Think of it as a mini git clone that shares the same repository history.
-
-**Directory structure:**
-
-```
-your-project/
-├── .git/                    # Main git directory
-│   └── beads-worktrees/
-│       └── beads-sync/  # Worktree (only .beads/ checked out)
-│           └── .beads/
-│               └── dolt/
-├── .beads/                  # Your main copy
-│   ├── dolt/
-│   └── .gitignore
-├── .gitattributes           # Merge driver config (in main branch)
-└── src/                     # Your code (untouched)
-```
-
-**What lives in each branch:**
-
-Main branch (protected):
-- `.beads/.gitignore` - Tells git what to ignore
-- `.gitattributes` - Merge driver configuration
-
-Sync branch (beads-sync):
-- `.beads/metadata.json` - Repository metadata
-- `.beads/config.yaml` - Configuration template
-
-Not tracked (gitignored):
-- `.beads/dolt/` - Dolt database directory (local only)
-- `.beads/dolt/sql-server.*` - Dolt server runtime files
-
-**Key points:**
-- The worktree is in `.git/beads-worktrees/` (hidden from your workspace)
-- Only `.beads/` is checked out in the worktree (sparse checkout)
-- Changes to issues are committed in the worktree
-- Your main working directory is never affected
-- Disk overhead is minimal (~few MB for the worktree)
-
-### Automatic Sync
-
-When you update an issue:
-
-1. Issue is updated in the Dolt database (`.beads/dolt/`)
-2. Dolt automatically commits the change to its version history
-3. Changes are synced to remotes via `bd dolt push`
-4. Main branch stays untouched (no commits on `main`)
-
-## Setup
-
-### Option 1: Initialize New Project
-
-```bash
-cd your-project
-bd init
-```
-
-This will:
-- Create `.beads/` directory with Dolt database
-- Prompt to install git hooks (recommended: say yes)
-
-### Option 2: Migrate Existing Project
-
-If you already have beads set up and want to switch to a separate branch:
-
-```bash
-# Set the sync branch
-bd config set sync.branch beads-sync
-
-# Start the Dolt server and install git hooks
-bd dolt start
-bd hooks install
-```
-
-### Sync Configuration
-
-For automatic commits to the sync branch, install git hooks:
-
-```bash
-bd hooks install
-```
-
-Git hooks help maintain sync consistency. Use `bd dolt push` for manual sync when needed.
-
-### Environment Variables
-
-You can also configure the sync branch via environment variable:
-
-```bash
-export BEADS_SYNC_BRANCH=beads-sync
-```
-
-This is useful for CI/CD or temporary overrides.
-
-## Daily Workflow
-
-### For AI Agents
-
-AI agents work exactly the same way as before:
-
-```bash
-# Create issues
-bd create "Implement user authentication" -t feature -p 1
-
-# Update issues
-bd update bd-a1b2 --claim
-
-# Close issues
-bd close bd-a1b2 "Completed authentication"
-```
-
-All changes are automatically committed to the `beads-sync` branch via git hooks. No changes are needed to agent workflows!
-
-### For Humans
-
-**Check status:**
-
-```bash
-# See what's changed on the sync branch
-bd dolt show
-```
-
-This shows the current Dolt configuration and connection status.
-
-**Manual commit:**
-
-```bash
-bd dolt commit  # Commit pending changes
-```
-
-**Pull changes from remote:**
-
-```bash
-# Pull updates from other collaborators
 bd dolt pull
-```
-
-This pulls changes from the remote and imports them to your local database.
-
-## Merging Changes
-
-### Option 1: Via Pull Request (Recommended)
-
-For protected branches with required reviews:
-
-```bash
-# 1. Push your sync branch
-git push origin beads-sync
-
-# 2. Create PR on GitHub/GitLab/etc.
-#    - Base: main
-#    - Compare: beads-sync
-
-# 3. After PR is merged, update your local main
-git checkout main
-git pull
-bd dolt pull  # Pull latest changes
-```
-
-### Option 2: Direct Merge (If Allowed)
-
-If you have push access to `main`:
-
-```bash
-# Sync via Dolt (no git branch merge needed)
 bd dolt push
+```
+
+No `beads-sync` Git branch, protected-branch exception, or beads-managed Git
+worktree is required.
+
+## Why Protected Branches Are Safe
+
+Protected branches guard Git refs such as `refs/heads/main`. Dolt stores beads
+data in its own ref namespace. That means:
+
+- `bd create`, `bd update`, and `bd close` do not create commits on `main`.
+- `bd dolt push` pushes Dolt data, not a code branch.
+- Normal code changes still go through your existing pull-request workflow.
+
+## Team Usage
+
+For a shared tracker:
+
+```bash
+bd init --team
 bd dolt pull
+bd ready
+bd update <id> --claim
+bd dolt push
 ```
 
-**Safety checks:**
-- ✅ Verifies you're not on the sync branch
-- ✅ Checks for uncommitted changes in working tree
-- ✅ Detects merge conflicts and provides resolution steps
-- ✅ Uses `--no-ff` for clear history
+Pull before starting work and push before handing off so other clones see the
+latest issue state.
 
-### Merge Conflicts
+## Legacy Sync-Branch Cleanup
 
-If you encounter conflicts during merge:
+Older beads versions documented an experimental `sync.branch` workflow that
+committed `.beads` changes to a branch such as `beads-sync` and used hidden Git
+worktrees under `.git/beads-worktrees/`. That workflow has been removed.
+
+If an old checkout still has sync-branch config, clear it:
 
 ```bash
-# git merge may detect conflicts and show:
-Auto-merging .beads/...
-CONFLICT (content): Merge conflict in .beads/...
-
-To resolve:
-1. Use bd vc conflicts to view conflicts
-2. Resolve conflicts
-3. Commit the resolution
+bd config set sync.branch ""
 ```
 
-**Resolving merge conflicts:**
-
-Dolt handles merge conflicts natively with cell-level merge. When concurrent changes affect the same issue field, Dolt detects the conflict and allows resolution:
+If stale hidden worktrees prevent branch checkout, remove them and prune Git's
+worktree registry:
 
 ```bash
-# After a Dolt pull with conflicts
-bd vc conflicts     # View conflicts
-bd vc resolve       # Resolve conflicts
+rm -rf .git/beads-worktrees
+rm -rf .git/worktrees/beads-*
+git worktree prune
 ```
+
+If a remote `beads-sync` branch exists only for the removed workflow, archive or
+delete it according to your repository policy after confirming all current issue
+data has been synced through Dolt.
 
 ## Troubleshooting
 
-### "fatal: refusing to merge unrelated histories"
+### `bd dolt push` Has No Remote
 
-This happens if you created the sync branch independently. Merge with `--allow-unrelated-histories`:
-
-```bash
-git merge beads-sync --allow-unrelated-histories --no-ff
-```
-
-Or merge manually with `git merge beads-sync --allow-unrelated-histories --no-ff`.
-
-### "worktree already exists"
-
-If the worktree is corrupted or in a bad state:
+Add or inspect the Dolt remote:
 
 ```bash
-# Remove the worktree
-rm -rf .git/beads-worktrees/beads-sync
-
-# Prune stale worktree entries
-git worktree prune
-
-# Restart Dolt server (it will recreate the worktree)
-bd dolt stop && bd dolt start
-```
-
-### "branch 'beads-sync' not found"
-
-The sync branch doesn't exist yet. It will be created on the first commit. Create it manually:
-
-```bash
-git checkout -b beads-sync
-git checkout main  # Switch back
-```
-
-### "Cannot push to protected branch"
-
-If the sync branch itself is protected:
-
-1. **Option 1:** Unprotect the sync branch (it's metadata, doesn't need protection)
-2. **Option 2:** Use `--auto-commit` without `--auto-push`, and push manually when ready
-3. **Option 3:** Use a different branch name that's not protected
-
-### Dolt server won't start
-
-Check server status and logs:
-
-```bash
-# Check status
-bd dolt status
-
-# View logs
-tail -f .beads/dolt/sql-server.log
-
-# Restart server
-bd dolt stop && bd dolt start
-```
-
-Common issues:
-- Port already in use: Another Dolt server is running
-- Permission denied: Check `.beads/` directory permissions
-- Git errors: Ensure git is installed and repository is initialized
-
-### Changes not syncing between clones
-
-Ensure all clones are configured the same way:
-
-```bash
-# On each clone, verify:
-bd config get sync.branch  # Should be the same (e.g., beads-sync)
-
-# Pull latest changes
-bd dolt pull
-
-# Check Dolt server is running
-bd dolt status
-```
-
-## FAQ
-
-### Do I need to configure anything on GitHub/GitLab?
-
-No! This is a pure git solution that works on any platform. Just protect your `main` branch as usual.
-
-### Can I use a different branch name?
-
-Yes! Use any branch name except `main` or `master` (git worktrees cannot checkout the same branch in multiple locations):
-
-```bash
+bd dolt remote list
 bd dolt remote add origin <remote-url>
 bd dolt push
 ```
 
-### Can I change the branch name later?
+### Conflicts During `bd dolt pull`
 
-Yes:
-
-```bash
-bd config set sync.branch new-branch-name
-bd dolt stop && bd dolt start
-```
-
-The old worktree will remain (no harm), and a new worktree will be created for the new branch.
-
-### What if I want to go back to committing to main?
-
-Unset the sync branch config:
+Dolt reports database-level conflicts separately from Git branch conflicts. Use
+the conflict commands or doctor guidance printed by the failed command:
 
 ```bash
-bd config set sync.branch ""
-bd dolt stop && bd dolt start
+bd vc conflicts
+bd doctor --fix
 ```
 
-Beads will go back to committing directly to your current branch.
+### Stale Hooks Mention Legacy Sync Commands
 
-### Does this work with multiple collaborators?
-
-Yes! Each collaborator configures their own sync branch:
+Refresh generated hooks:
 
 ```bash
-# All collaborators use the same branch
-bd config set sync.branch beads-sync
+bd hooks install
 ```
 
-Everyone's changes sync via the `beads-sync` branch. Periodically merge to `main` via PR.
-
-### How often should I merge to main?
-
-This depends on your workflow:
-
-- **Daily:** If you want issue history in `main` frequently
-- **Per sprint:** If you batch metadata updates
-- **As needed:** Only when you need others to see issue updates
-
-There's no "right" answer - choose what fits your team.
-
-### Can I review changes before merging?
-
-Yes! Use `bd dolt show` to check current status, or use git to compare branches:
-
-```bash
-git log main..beads-sync --oneline
-# Shows commits on beads-sync not yet in main
-```
-
-Or create a pull request and review on GitHub/GitLab.
-
-### What about disk space?
-
-Worktrees are very lightweight:
-- Sparse checkout means only `.beads/` is checked out
-- Typically < 1 MB for the worktree
-- Shared git history (no duplication)
-
-### Can I delete the worktree?
-
-Yes, but it may be recreated on next sync. If you want to clean up permanently:
-
-```bash
-# Stop Dolt server
-bd dolt stop
-
-# Remove worktree
-git worktree remove .git/beads-worktrees/beads-sync
-
-# Unset sync branch
-bd config set sync.branch ""
-```
-
-### Does this work with `bd dolt push`?
-
-Yes! `bd dolt push` works normally. Related commands for the merge workflow:
-
-- `bd dolt show` - Show current Dolt configuration and connection status
-- `git merge beads-sync` - Merge sync branch to main
-
-### Can AI agents merge automatically?
-
-Not recommended! Merging to `main` is a deliberate action that should be human-reviewed, especially with protected branches. Agents should create issues and update them; humans should merge to `main`.
-
-However, if you want fully automated sync:
-
-```bash
-# WARNING: This bypasses branch protection!
-git merge beads-sync  # Run periodically (e.g., via cron)
-```
-
-### What if I forget to merge for a long time?
-
-No problem! The sync branch accumulates all changes. When you eventually merge:
-
-```bash
-git checkout main
-git merge beads-sync --no-ff
-git push
-```
-
-All accumulated changes will be merged at once. Git history will show the full timeline.
-
-### Can I use this with GitHub Actions or CI/CD?
-
-Yes! Example GitHub Actions workflow:
-
-```yaml
-name: Sync Beads Metadata
-
-on:
-  schedule:
-    - cron: '0 0 * * *'  # Daily at midnight
-  workflow_dispatch:     # Manual trigger
-
-jobs:
-  sync:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0  # Full history
-
-      - name: Install bd
-        run: |
-          curl -fsSL https://raw.githubusercontent.com/gastownhall/beads/main/scripts/install.sh | bash
-
-      - name: Pull changes
-        run: |
-          git fetch origin beads-sync
-          bd dolt pull
-
-      - name: Merge to main (if changes)
-        run: |
-          if git log main..beads-sync --oneline | grep -q '.'; then
-            git merge beads-sync --no-ff -m "Merge beads-sync metadata"
-            git push origin main
-          fi
-```
-
-**Note:** Make sure the GitHub Action has write permissions to push to `main`.
-
-## Platform-Specific Notes
-
-### GitHub
-
-Protected branch settings:
-1. Go to Settings → Branches → Add rule
-2. Branch name pattern: `main`
-3. Check "Require pull request before merging"
-4. Save
-
-Create sync branch PR:
-```bash
-git push origin beads-sync
-gh pr create --base main --head beads-sync --title "Update beads metadata"
-```
-
-### GitLab
-
-Protected branch settings:
-1. Settings → Repository → Protected Branches
-2. Branch: `main`
-3. Allowed to merge: Maintainers
-4. Allowed to push: No one
-
-Create sync branch MR:
-```bash
-git push origin beads-sync
-glab mr create --source-branch beads-sync --target-branch main
-```
-
-### Bitbucket
-
-Protected branch settings:
-1. Repository settings → Branch permissions
-2. Branch: `main`
-3. Check "Prevent direct pushes"
-
-Create sync branch PR:
-```bash
-git push origin beads-sync
-# Create PR via Bitbucket web UI
-```
-
-## Advanced Topics
-
-### Multiple Sync Branches
-
-You can use different sync branches for different purposes:
-
-```bash
-# Development branch
-bd config set sync.branch beads-dev
-
-# Production branch
-bd config set sync.branch beads-prod
-```
-
-Switch between them as needed.
-
-### Syncing with Upstream
-
-If you're working on a fork:
-
-```bash
-# Add upstream
-git remote add upstream https://github.com/original/repo.git
-
-# Fetch upstream changes
-git fetch upstream
-
-# Merge upstream beads-sync to yours
-git checkout beads-sync
-git merge upstream/beads-sync
-bd dolt pull  # Pull merged changes
-```
-
-### Custom Worktree Location
-
-By default, worktrees are in `.git/beads-worktrees/`. This is hidden and automatic. If you need a custom location, you'll need to manage worktrees manually (not recommended).
-
-## Migration Guide
-
-### From Direct Commits to Sync Branch
-
-If you have an existing beads setup committing to `main`:
-
-1. **Set sync branch:**
-   ```bash
-   bd config set sync.branch beads-sync
-   ```
-
-2. **Restart Dolt server:**
-   ```bash
-   bd dolt stop && bd dolt start
-   ```
-
-3. **Verify:**
-   ```bash
-   bd config get sync.branch  # Should show: beads-sync
-   ```
-
-Future commits will go to `beads-sync`. Historical commits on `main` are preserved.
-
-### From Sync Branch to Direct Commits
-
-If you want to stop using a sync branch:
-
-1. **Unset sync branch:**
-   ```bash
-   bd config set sync.branch ""
-   ```
-
-2. **Restart Dolt server:**
-   ```bash
-   bd dolt stop && bd dolt start
-   ```
-
-Future commits will go to your current branch (e.g., `main`).
-
----
-
-**Need help?** Open an issue at https://github.com/gastownhall/beads/issues
+## See Also
+
+- [WORKTREES.md](WORKTREES.md) - Git worktree behavior
+- [GIT_INTEGRATION.md](GIT_INTEGRATION.md) - general Git integration guide
+- [RECOVERY.md](RECOVERY.md) - recovery playbooks

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -700,7 +700,7 @@ git checkout main
 bd config set sync.branch ""
 ```
 
-See [WORKTREES.md#beads-created-worktrees-sync-branch](WORKTREES.md#beads-created-worktrees-sync-branch) for details.
+See [WORKTREES.md#legacy-cleanup](WORKTREES.md#legacy-cleanup) for details.
 
 ### Unexpected worktree directories in .git/
 

--- a/docs/WORKTREES.md
+++ b/docs/WORKTREES.md
@@ -1,515 +1,131 @@
 # Git Worktrees Guide
 
-**Enhanced Git worktree compatibility for Beads issue tracking**
+Beads works from normal Git worktrees without a separate sync branch. Current
+beads stores issue data in Dolt under `refs/dolt/data`, so issue sync is
+separate from Git branch commits.
 
-## Overview
+## Current Model
 
-Beads now provides **enhanced Git worktree support** with a shared database architecture. All worktrees in a repository share the same `.beads` database located in the main repository, enabling seamless issue tracking across multiple working directories.
-
-**Note:** While comprehensively implemented and tested internally, this feature may benefit from real-world usage feedback to identify any remaining edge cases.
-
----
-
-## Beads-Created Worktrees (Sync Branch)
-
-**Important:** Beads automatically creates git worktrees internally for its sync-branch feature. This is different from user-created worktrees for parallel development.
-
-### Why Beads Creates Worktrees
-
-**Note:** The sync-branch feature has been removed. Dolt now stores data under `refs/dolt/data`, separate from standard Git refs, so a separate branch is no longer needed. The information below applies only to older versions of beads.
-
-When a **sync branch** was configured (via `bd config set sync.branch <name>`), beads needed to commit issue updates to that branch without switching your working directory away from your current branch.
-
-**Solution:** Beads creates a lightweight worktree that:
-- Contains only the `.beads/` directory (sparse checkout)
-- Lives in `.git/beads-worktrees/<sync-branch>/`
-- Commits issue changes to the sync branch automatically
-- Leaves your main working directory untouched
-
-### Where to Find These Worktrees
+All worktrees in the same repository use the same beads workspace unless you
+override discovery with `BEADS_DIR`.
 
 ```
-your-project/
-├── .git/
-│   ├── beads-worktrees/          # Beads-created worktrees live here
-│   │   └── beads-sync/           # Default sync branch worktree
-│   │       └── .beads/
-│   │           └── dolt/         # Dolt database
-│   └── worktrees/                # Standard git worktrees directory
-├── .beads/                       # Your working copy
-│   └── dolt/                     # Local Dolt database
-└── src/                          # Your code (untouched by sync)
+project/
+├── .git/                 # Shared Git directory
+├── .beads/               # Shared beads config and local Dolt data
+├── main-worktree/
+└── feature-worktree/
 ```
 
-### Common Confusion: "Beads took over main!"
+Key points:
 
-If you see worktrees pointing to `main` and can't switch branches normally, this is likely because:
+- `bd` discovers the repository's `.beads` directory from linked worktrees.
+- Issue changes are stored in Dolt, not committed to the current Git branch.
+- Cross-clone sync uses `bd dolt pull` and `bd dolt push`.
+- No `sync.branch` or beads-managed Git worktree is required.
 
-1. Your sync branch was created from `main`
-2. Beads created a worktree for that branch
-3. Git worktrees lock branches they're checked out to
+## Basic Usage
 
-**Symptoms:**
+Initialize beads once in the repository:
+
 ```bash
-$ git checkout main
-fatal: 'main' is already checked out at '/path/to/.git/beads-worktrees/beads-sync'
+cd project
+bd init
 ```
 
-**Quick Fix:**
+Create linked worktrees normally:
+
 ```bash
-# Remove the beads worktree
+git worktree add ../project-feature feature-branch
+cd ../project-feature
+bd ready
+bd create "Implement feature X" -t feature -p 1
+```
+
+Sync issue data through the configured Dolt remote:
+
+```bash
+bd dolt pull
+bd dolt push
+```
+
+## External Beads Workspace
+
+If you want a separate issue-tracker repository shared by many code worktrees,
+point `BEADS_DIR` at that workspace:
+
+```bash
+export BEADS_DIR=~/project-beads/.beads
+
+cd ~/project/main       && bd list
+cd ~/project/feature-1  && bd list
+cd ~/project/feature-2  && bd list
+```
+
+With an external `BEADS_DIR`, `bd dolt push` and `bd dolt pull` target the
+external beads workspace, not the code repository.
+
+## Hooks
+
+Git hooks installed by beads are worktree-aware. If hooks are stale or mention
+removed legacy sync commands, refresh them:
+
+```bash
+bd hooks install
+```
+
+## Legacy Cleanup
+
+Older beads versions had an experimental `sync.branch` workflow that created
+hidden worktrees such as `.git/beads-worktrees/<branch>/`. That workflow has
+been removed.
+
+If a legacy checkout cannot switch branches because a beads-created worktree
+still holds the branch, remove the stale worktree records:
+
+```bash
 rm -rf .git/beads-worktrees
-
-# Prune stale worktree references
-git worktree prune
-
-# Also remove any stray worktrees in .git/worktrees (older versions)
 rm -rf .git/worktrees/beads-*
 git worktree prune
 ```
 
-### Disabling Sync Branch (Remove Worktrees)
-
-If you don't want beads to use a separate sync branch:
+If old config still contains a sync branch, clear it:
 
 ```bash
-# Unset the sync branch configuration
 bd config set sync.branch ""
-
-# Clean up existing worktrees
-rm -rf .git/beads-worktrees
-git worktree prune
-```
-
-### Checking Your Sync Branch Configuration
-
-```bash
-# See current sync branch setting
-bd config get sync.branch
-
-# Check if worktrees exist
-ls -la .git/beads-worktrees/ 2>/dev/null || echo "No beads worktrees"
-ls -la .git/worktrees/ 2>/dev/null || echo "No standard worktrees"
-
-# List all git worktrees
-git worktree list
-```
-
-### See Also
-
-For complete sync-branch documentation, see [PROTECTED_BRANCHES.md](PROTECTED_BRANCHES.md).
-
----
-
-## How It Works
-
-### Shared Database Architecture
-
-```
-Main Repository
-├── .git/                    # Shared git directory
-├── .beads/                  # Shared database (main repo)
-│   ├── dolt/               # Dolt database directory
-│   └── config.yaml         # Configuration
-├── feature-branch/         # Worktree 1
-│   └── (code files only)
-└── bugfix-branch/          # Worktree 2
-    └── (code files only)
-```
-
-**Key points:**
-- ✅ **One database** - All worktrees share the same `.beads` directory in main repo
-- ✅ **Automatic discovery** - Database found regardless of which worktree you're in
-- ✅ **Concurrent access** - Database locking prevents corruption
-- ✅ **Dolt sync** - Issues sync via Dolt remotes
-
-### Worktree Detection
-
-bd automatically detects when you're in a git worktree:
-
-**Default behavior (no sync-branch configured):**
-- Uses embedded mode for safety (single-writer, no server needed)
-- All commands work correctly without additional setup
-
-**With sync-branch configured:**
-- Commits go to dedicated sync branch (e.g., `beads-sync`)
-- Server mode available across all worktrees for concurrent access
-
-## Usage Patterns
-
-### Recommended: Configure Sync-Branch for Full Server Support
-
-```bash
-# Configure sync-branch once (in main repo or any worktree)
-bd config set sync-branch beads-sync
-
-# Now server mode works safely in all worktrees
-cd feature-worktree
-bd create "Implement feature X" -t feature -p 1
-bd update bd-a1b2 --claim
-bd ready  # Auto-syncs to beads-sync branch
-```
-
-### Alternative: Embedded Mode (No Configuration Needed)
-
-```bash
-# Without sync-branch, worktrees use embedded mode automatically
-cd feature-worktree
-bd create "Implement feature X" -t feature -p 1
-bd ready  # Uses embedded mode automatically
-bd dolt push   # Manual sync when needed
-```
-
-## Worktree-Aware Features
-
-### Database Discovery
-
-bd intelligently finds the correct database:
-
-1. **Priority search**: Main repository `.beads` directory first
-2. **Fallback logic**: Searches worktree if main repo doesn't have database
-3. **Path resolution**: Handles symlinks and relative paths correctly
-4. **Validation**: Ensures `.beads` contains actual project files
-
-### Git Hooks Integration
-
-Pre-commit hooks adapt to worktree context:
-
-```bash
-# In main repo: Runs beads checks normally
-
-# In worktree: Safely handles shared database context
-# Hook detects context and handles appropriately
-```
-
-### Sync Operations
-
-Worktree-aware sync operations:
-
-- **Repository root detection**: Uses `git rev-parse --show-toplevel` for main repo
-- **Git directory handling**: Distinguishes between `.git` (file) and `.git/` (directory)
-- **Path resolution**: Converts between worktree and main repo paths
-- **Concurrent safety**: Database locking prevents corruption
-
-## Setup Examples
-
-### Basic Worktree Setup
-
-```bash
-# Create main worktree
-git worktree add main-repo
-
-# Create feature worktree
-git worktree add feature-worktree
-
-# Initialize beads in main repo
-cd main-repo
-bd init
-
-# Worktrees automatically share the database
-cd ../feature-worktree
-bd ready  # Works immediately - sees same issues
-```
-
-### Multi-Feature Development
-
-```bash
-# Main development
-cd main-repo
-bd create "Epic: User authentication" -t epic -p 1
-# Returns: bd-a3f8e9
-
-# Feature branch worktree
-git worktree add auth-feature
-cd auth-feature
-bd create "Design login UI" -p 1
-# Auto-assigned: bd-a3f8e9.1 (child of epic)
-
-# Bugfix worktree
-git worktree add auth-bugfix
-cd auth-bugfix
-bd create "Fix password validation" -t bug -p 0
-# Auto-assigned: bd-f14c3
 ```
 
 ## Troubleshooting
 
-### Issue: "Branch already checked out" error
+### Database Not Found In A Worktree
 
-**Symptoms:**
-```bash
-$ git checkout main
-fatal: 'main' is already checked out at '/path/to/.git/beads-worktrees/beads-sync'
-```
-
-**Cause:** Beads created a worktree for its sync branch feature, and that worktree has your target branch checked out. Git doesn't allow the same branch to be checked out in multiple worktrees.
-
-**Solution:**
-```bash
-# Remove beads worktrees
-rm -rf .git/beads-worktrees
-rm -rf .git/worktrees/beads-*
-
-# Clean up git's worktree registry
-git worktree prune
-
-# Now you can checkout the branch
-git checkout main
-```
-
-**Prevention:** If you use trunk-based development and don't need a separate sync branch, disable it:
-```bash
-bd config set sync.branch ""
-```
-
-### Issue: Unexpected worktree directories appeared
-
-**Symptoms:** You notice `.git/beads-worktrees/` or entries in `.git/worktrees/` that you didn't create.
-
-**Cause:** Older versions of beads created worktrees for the sync-branch feature (configured via `bd config set sync.branch`). This feature has been removed.
-
-**Solution:** See [Beads-Created Worktrees](#beads-created-worktrees-sync-branch) section above for details on what these are and how to remove them if unwanted.
-
-### Issue: Commits to wrong branch
-
-**Symptoms:** Changes appear on unexpected branch in git history
-
-**Note:** This issue should no longer occur with the worktree safety feature. Worktrees use embedded mode automatically unless sync-branch is configured.
-
-**Solution (if still occurring):**
-```bash
-# Configure sync-branch (recommended)
-bd config set sync-branch beads-sync
-```
-
-### Issue: Database not found in worktree
-
-**Symptoms:** `bd: database not found` error
-
-**Solutions:**
-```bash
-# Ensure main repo has .beads directory
-cd main-repo
-ls -la .beads/
-
-# Re-run bd init if needed
-bd init
-
-# Check worktree can access main repo
-cd ../worktree-name
-bd info  # Should show database path in main repo
-```
-
-### Issue: Multiple databases detected
-
-**Symptoms:** Warning about multiple `.beads` directories
-
-**Solution:**
-```bash
-# bd shows warning with database locations
-# Typically, the closest database (in main repo) is correct
-# Remove extra .beads directories if they're not needed
-```
-
-### Issue: Git hooks fail in worktrees
-
-**Symptoms:** Pre-commit hook errors about staging files outside working tree
-
-**Solution:** This is now automatically handled. The hook detects worktree context and adapts its behavior. No manual intervention needed.
-
-## Advanced Configuration
-
-### Environment Variables
+Check that the main repository has a `.beads` directory and that the worktree
+belongs to that repository:
 
 ```bash
-# Force specific database location
-export BEADS_DB=/path/to/specific/.beads/dolt
+git worktree list
+cd /path/to/main/repo
+ls -la .beads
 ```
 
-### Configuration Options
+If the repository has no beads workspace yet, run `bd init` from the main
+repository.
 
-```bash
-# Configure sync behavior
-bd config set sync.branch beads-sync  # Use separate sync branch
+### Multiple `.beads` Directories
 
-# Configure Dolt auto-commit
-bd config set dolt.auto-commit true
-```
+If a worktree has its own accidental `.beads` directory, remove or archive the
+extra copy after confirming it does not contain unique issue data. By default,
+worktrees should share the repository workspace.
 
-## Performance Considerations
+### Concurrent Writers
 
-### Database Sharing Benefits
-
-- **Reduced overhead**: One database instead of per-worktree copies
-- **Instant sync**: Changes visible across all worktrees immediately
-- **Memory efficient**: Single database instance vs multiple
-- **Storage efficient**: One Dolt database vs multiple
-
-### Concurrent Access
-
-- **Database locking**: Prevents corruption during simultaneous access (use Dolt server mode via `bd dolt start` for multi-writer)
-- **Git operations**: Safe concurrent commits from different worktrees
-- **Sync coordination**: Dolt-based sync with cell-level merge prevents conflicts
-
-## Migration from Limited Support
-
-### Before (Limited Worktree Support)
-
-- ❌ Broken in worktrees
-- ❌ Manual workarounds required
-- ❌ Complex setup procedures
-- ❌ Limited documentation
-
-### After (Enhanced Worktree Support)
-
-- ✅ Shared database architecture
-- ✅ Automatic worktree detection
-- ✅ Clear user guidance and warnings
-- ✅ Comprehensive documentation
-- ✅ Git hooks work correctly
-- ✅ All bd commands function properly
-
-**Note:** Based on comprehensive internal testing. Real-world usage may reveal additional refinements needed.
-
-## Examples in the Wild
-
-### Monorepo Development
-
-```bash
-# Monorepo with multiple service worktrees
-git worktree add services/auth
-git worktree add services/api
-git worktree add services/web
-
-# Each service team works in their worktree
-cd services/auth
-bd create "Add OAuth support" -t feature -p 1
-
-cd ../api
-bd create "Implement auth endpoints" -p 1
-# Issues automatically linked and visible across worktrees
-```
-
-### Feature Branch Workflow
-
-```bash
-# Create feature worktree
-git worktree add feature/user-profiles
-cd feature/user-profiles
-
-# Work on feature with full issue tracking
-bd create "Design user profile schema" -t task -p 1
-bd create "Implement profile API" -t task -p 1
-bd create "Add profile UI components" -t task -p 2
-
-# Issues tracked in shared database
-# Code changes isolated to worktree
-# Clean merge back to main when ready
-```
-
-## Fully Separate Beads Repository
-
-For users who want complete separation between code history and issue tracking, beads supports storing issues in a completely separate git repository.
-
-### Why Use a Separate Repo?
-
-- **Clean code history** - No beads commits polluting your project's git log
-- **Shared across worktrees** - All worktrees can use the same Dolt database via BEADS_DIR
-- **Platform agnostic** - Works even if your main project isn't git-based
-- **Monorepo friendly** - Single beads repo for multiple projects
-
-### Setup
-
-**Option A: Initialize with BEADS_DIR (simplest)**
-```bash
-# 1. Create the directory structure
-mkdir -p ~/my-project-beads/.beads
-
-# 2. Set BEADS_DIR and initialize from anywhere
-export BEADS_DIR=~/my-project-beads/.beads
-bd init --prefix myproj    # Creates database at $BEADS_DIR
-
-# 3. Initialize git in the beads repo (optional, for sync)
-cd ~/my-project-beads && git init
-```
-
-**Option B: Traditional approach**
-```bash
-# 1. Create a dedicated beads repository (one-time)
-mkdir ~/my-project-beads
-cd ~/my-project-beads
-git init
-bd init --prefix myproj
-
-# 2. Add a remote for cross-machine sync (optional)
-git remote add origin git@github.com:you/my-project-beads.git
-git push -u origin main
-```
-
-### Usage
-
-Set `BEADS_DIR` to point at your separate beads repository:
-
-```bash
-cd ~/my-project
-export BEADS_DIR=~/my-project-beads/.beads
-
-# All bd commands now use the separate repo
-bd create "My task" -t task
-bd list
-bd dolt push  # commits to ~/my-project-beads, pushes there
-```
-
-### Making It Permanent
-
-**Option 1: Shell profile**
-```bash
-# Add to ~/.bashrc or ~/.zshrc
-export BEADS_DIR=~/my-project-beads/.beads
-```
-
-**Option 2: direnv (per-project)**
-```bash
-# In ~/my-project/.envrc
-export BEADS_DIR=~/my-project-beads/.beads
-```
-
-**Option 3: Wrapper script**
-```bash
-# ~/bin/bd-myproj
-#!/bin/bash
-BEADS_DIR=~/my-project-beads/.beads exec bd "$@"
-```
-
-### How It Works
-
-When `BEADS_DIR` points to a different git repository than your current directory:
-
-1. `bd dolt push` detects "External BEADS_DIR"
-2. Git operations (add, commit, push, pull) target the beads repo
-3. Your code repository is never touched
-
-This was contributed by @dand-oss in [PR #533](https://github.com/gastownhall/beads/pull/533).
-
-### Combining with Worktrees
-
-This approach elegantly solves the worktree isolation problem:
-
-```bash
-# All worktrees share the same external beads repo
-export BEADS_DIR=~/project-beads/.beads
-
-cd ~/project/main       && bd list  # Same issues
-cd ~/project/feature-1  && bd list  # Same issues
-cd ~/project/feature-2  && bd list  # Same issues
-```
-
-No conflicts, no branch confusion - all worktrees see the same issues because they all use the same external repository.
+For ordinary single-user worktree use, run commands directly. For true
+multi-writer workflows across machines or agents, sync frequently with
+`bd dolt pull` and `bd dolt push`, and coordinate through the tracker to avoid
+working the same issue concurrently.
 
 ## See Also
 
-- [REPO_CONTEXT.md](REPO_CONTEXT.md) - RepoContext API for contributors
-- [GIT_INTEGRATION.md](GIT_INTEGRATION.md) - General git integration guide
-- [AGENTS.md](../AGENTS.md) - Agent usage instructions
-- [README.md](../README.md) - Main project documentation
-- [MULTI_REPO_MIGRATION.md](MULTI_REPO_MIGRATION.md) - Multi-workspace patterns
+- [PROTECTED_BRANCHES.md](PROTECTED_BRANCHES.md) - protected branch behavior
+- [GIT_INTEGRATION.md](GIT_INTEGRATION.md) - general Git integration guide
+- [MULTI_REPO_MIGRATION.md](MULTI_REPO_MIGRATION.md) - multi-workspace patterns

--- a/website/docs/reference/git-integration.md
+++ b/website/docs/reference/git-integration.md
@@ -63,17 +63,27 @@ bd doctor --fix
 
 ## Protected Branches
 
-Dolt stores data under `refs/dolt/data`, separate from Git refs. This means beads data doesn't conflict with protected Git branches — no special branch flag is needed. On new projects with a git `origin`, `bd init` configures that origin as the Dolt remote automatically.
+Dolt stores data under `refs/dolt/data`, separate from Git refs. This means
+beads data does not conflict with protected Git branches, and no separate
+`beads-sync` branch or protected-branch exception is needed. On new projects
+with a Git `origin`, `bd init` configures that origin as the Dolt remote
+automatically.
 
 ## Git Worktrees
 
-Beads works in git worktrees using embedded mode:
+Beads works in Git worktrees without extra setup. Linked worktrees discover the
+repository's `.beads` workspace and sync issue data through Dolt:
 
 ```bash
-# In worktree — just run commands directly
+# In a linked worktree
 bd create "Task"
 bd list
+bd dolt pull
+bd dolt push
 ```
+
+Older beads versions documented a `sync.branch` workflow that created hidden
+Git worktrees. That workflow has been removed; current sync uses Dolt remotes.
 
 ## Branch Workflows
 
@@ -118,4 +128,4 @@ bd duplicates --auto-merge
 1. **Install hooks** - `bd hooks install`
 2. **Push regularly** - `bd dolt push` at session end
 3. **Pull before work** - `bd dolt pull` to get latest issues
-4. **Worktrees use embedded mode automatically**
+4. **Use normal Git worktrees** - no sync branch is required

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -14172,17 +14172,27 @@ bd doctor --fix
 
 ## Protected Branches
 
-Dolt stores data under `refs/dolt/data`, separate from Git refs. This means beads data doesn't conflict with protected Git branches — no special branch flag is needed. On new projects with a git `origin`, `bd init` configures that origin as the Dolt remote automatically.
+Dolt stores data under `refs/dolt/data`, separate from Git refs. This means
+beads data does not conflict with protected Git branches, and no separate
+`beads-sync` branch or protected-branch exception is needed. On new projects
+with a Git `origin`, `bd init` configures that origin as the Dolt remote
+automatically.
 
 ## Git Worktrees
 
-Beads works in git worktrees using embedded mode:
+Beads works in Git worktrees without extra setup. Linked worktrees discover the
+repository's `.beads` workspace and sync issue data through Dolt:
 
 ```bash
-# In worktree — just run commands directly
+# In a linked worktree
 bd create "Task"
 bd list
+bd dolt pull
+bd dolt push
 ```
+
+Older beads versions documented a `sync.branch` workflow that created hidden
+Git worktrees. That workflow has been removed; current sync uses Dolt remotes.
 
 ## Branch Workflows
 
@@ -14227,7 +14237,7 @@ bd duplicates --auto-merge
 1. **Install hooks** - `bd hooks install`
 2. **Push regularly** - `bd dolt push` at session end
 3. **Pull before work** - `bd dolt pull` to get latest issues
-4. **Worktrees use embedded mode automatically**
+4. **Use normal Git worktrees** - no sync branch is required
 
 </document>
 

--- a/website/versioned_docs/version-1.1.0/reference/git-integration.md
+++ b/website/versioned_docs/version-1.1.0/reference/git-integration.md
@@ -63,17 +63,27 @@ bd doctor --fix
 
 ## Protected Branches
 
-Dolt stores data under `refs/dolt/data`, separate from Git refs. This means beads data doesn't conflict with protected Git branches — no special branch flag is needed. On new projects with a git `origin`, `bd init` configures that origin as the Dolt remote automatically.
+Dolt stores data under `refs/dolt/data`, separate from Git refs. This means
+beads data does not conflict with protected Git branches, and no separate
+`beads-sync` branch or protected-branch exception is needed. On new projects
+with a Git `origin`, `bd init` configures that origin as the Dolt remote
+automatically.
 
 ## Git Worktrees
 
-Beads works in git worktrees using embedded mode:
+Beads works in Git worktrees without extra setup. Linked worktrees discover the
+repository's `.beads` workspace and sync issue data through Dolt:
 
 ```bash
-# In worktree — just run commands directly
+# In a linked worktree
 bd create "Task"
 bd list
+bd dolt pull
+bd dolt push
 ```
+
+Older beads versions documented a `sync.branch` workflow that created hidden
+Git worktrees. That workflow has been removed; current sync uses Dolt remotes.
 
 ## Branch Workflows
 
@@ -118,4 +128,4 @@ bd duplicates --auto-merge
 1. **Install hooks** - `bd hooks install`
 2. **Push regularly** - `bd dolt push` at session end
 3. **Pull before work** - `bd dolt pull` to get latest issues
-4. **Worktrees use embedded mode automatically**
+4. **Use normal Git worktrees** - no sync branch is required


### PR DESCRIPTION
## Why

The worktree and protected-branch docs still mixed current Dolt-native sync
with the removed `sync.branch` workflow. That made the public guidance look as
if users should configure a `beads-sync` branch or expect beads-created Git
worktrees, even though current beads syncs issue data through Dolt refs.

## What

- Rewrite `docs/WORKTREES.md` around the current shared-workspace model and
  keep only a legacy cleanup section for stale beads-created worktrees.
- Rewrite `docs/PROTECTED_BRANCHES.md` to explain why protected branches no
  longer need a special beads workflow.
- Update current and latest-version website Git integration docs.
- Regenerate `website/static/llms-full.txt`.

## Verification

- `bd-main/scripts/pr-preflight.sh --search "worktree protected branch sync-branch docs" --repo gastownhall/beads`
- `scripts/generate-llms-full.sh`
- `npm ci`
- `npm run typecheck`
- `npm run build` (passes; existing webpack warning from `vscode-languageserver-types`)
- `go build -tags gms_pure_go -o bd ./cmd/bd`
- `scripts/check-doc-flags.sh ./bd`
- `git diff --check`

_codex-gpt-5.5-high on behalf of matt wilkie_
