### PR TITLE
ci(lint): align golangci-lint pins at v2.10.1 and triage new gosec findings

### DIFF
--- a/.github/workflows/ci-measurements.yml
+++ b/.github/workflows/ci-measurements.yml
@@ -84,7 +84,7 @@ jobs:
           source ./.buildflags
 
           ci_time "install gotestsum" -- go install gotest.tools/gotestsum@v1.13.0
-          ci_time "install golangci-lint" -- go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.9.0
+          ci_time "install golangci-lint" -- go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.10.1
           status=0
           ci_time "pr-policy wrapper" -- make ci-pr-policy || status=$?
           ci_time "pr-core gotestsum" -- gotestsum --junitfile artifacts/pr-core-junit.xml --format testdox -- -race -short -skip '^TestEmbedded' ./... || status=$?

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,7 +63,7 @@ jobs:
           go-version-file: 'go.mod'
 
       - name: Install golangci-lint
-        run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.9.0
+        run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.10.1
 
       - name: Run policy checks
         run: make ci-pr-policy
@@ -416,7 +416,7 @@ jobs:
           go-version-file: 'go.mod'
 
       - name: Install golangci-lint
-        run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.9.0
+        run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.10.1
 
       - name: Run PR lint wrapper
         run: make ci-pr-lint

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -29,7 +29,7 @@ jobs:
           go-version-file: 'go.mod'
 
       - name: Install golangci-lint
-        run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.9.0
+        run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.10.1
 
       - name: Run policy checks
         run: make ci-pr-policy
@@ -416,7 +416,7 @@ jobs:
           go-version-file: 'go.mod'
 
       - name: Install golangci-lint
-        run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.9.0
+        run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.10.1
 
       - name: Run PR lint wrapper
         run: make ci-pr-lint

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -85,7 +85,7 @@ linters:
           - gosec
         text: "G115"
       # G117: Exported struct fields matching secret patterns are intentional API fields
-      - path: 'internal/compact/compactor\.go|internal/jira/client\.go|internal/linear/types\.go|internal/storage/versioned\.go'
+      - path: 'internal/compact/compactor\.go|internal/jira/client\.go|internal/linear/types\.go|internal/linear/oauth\.go|internal/storage/versioned\.go'
         linters:
           - gosec
         text: "G117"
@@ -104,12 +104,12 @@ linters:
           - gosec
         text: "G703"
       # G704: SSRF via taint in API clients with user-configured URLs
-      - path: 'cmd/bd/doctor/(claude|version)\.go|internal/gitlab/client\.go|internal/jira/client\.go|internal/linear/client\.go'
+      - path: 'cmd/bd/doctor/(claude|version)\.go|internal/github/client\.go|internal/gitlab/client\.go|internal/jira/client\.go|internal/linear/client\.go|internal/linear/oauth\.go'
         linters:
           - gosec
         text: "G704"
       # G705: XSS via taint in CLI template rendering (no browser context)
-      - path: 'cmd/bd/compact\.go'
+      - path: 'cmd/bd/compact\.go|internal/linear/client\.go'
         linters:
           - gosec
         text: "G705"

--- a/scripts/repro-dolt-prod-timeouts/main.go
+++ b/scripts/repro-dolt-prod-timeouts/main.go
@@ -265,7 +265,7 @@ func openWorkspace(ctx context.Context, cfg config, dir string) (*workspace, err
 }
 
 func isPortOpen(port int) bool {
-	conn, err := net.DialTimeout("tcp", fmt.Sprintf("127.0.0.1:%d", port), time.Second)
+	conn, err := net.DialTimeout("tcp", fmt.Sprintf("127.0.0.1:%d", port), time.Second) // #nosec G704 -- loopback probe of a locally started dolt server; not attacker-controlled
 	if err != nil {
 		return false
 	}
@@ -287,7 +287,7 @@ func createWorkspace(ctx context.Context, cfg config) (*workspace, error) {
 	defer cancel()
 
 	fmt.Printf("initializing server workspace timeout=%s\n", initTimeout)
-	cmd := exec.CommandContext(initCtx, cfg.BDPath,
+	cmd := exec.CommandContext(initCtx, cfg.BDPath, // #nosec G702 -- fixed subcommand args; cfg.BDPath is an operator-supplied local binary path, not attacker input
 		"init",
 		"--server",
 		"--prefix=perf",
@@ -325,7 +325,7 @@ func startWorkspaceDolt(ctx context.Context, cfg config, dir string) error {
 	startCtx, cancel := context.WithTimeout(ctx, startTimeout)
 	defer cancel()
 
-	cmd := exec.CommandContext(startCtx, cfg.BDPath, "dolt", "start")
+	cmd := exec.CommandContext(startCtx, cfg.BDPath, "dolt", "start") // #nosec G702 -- fixed subcommand args; cfg.BDPath is an operator-supplied local binary path, not attacker input
 	cmd.Dir = dir
 	cmd.Env = subprocessEnv("BD_NON_INTERACTIVE=1")
 	if out, err := cmd.CombinedOutput(); err != nil {


### PR DESCRIPTION
## Why

CI installs golangci-lint v2.9.0 (`go install` in the workflow scripts) while `.pre-commit-config.yaml` pins v2.10.1. Under v2.10.1, gosec reports 8 findings that v2.9.0 does not (G702/G704/G705/G117), so contributors running pre-commit hit lint failures CI never shows. Found while verifying #4589.

## What

- Bump every `go install ...golangci-lint@v2.9.0` pin to `v2.10.1`: `.github/workflows/main.yml` (x2), `.github/workflows/pr.yml` (x2), `.github/workflows/ci-measurements.yml` (x1). CI now matches pre-commit.
- Triage the 8 new gosec findings so the tree is clean under v2.10.1:
  - `internal/github/client.go` (G704), `internal/linear/oauth.go` (G704, G117 x2), `internal/linear/client.go` (G705): added to the existing `.golangci.yml` exclusion rules for the same categories already accepted there (user-configured API base URLs, intentional exported credential config fields, CLI stderr output with no browser context). Each is the same false-positive class as the gitlab/jira/linear entries that precede it.
  - `scripts/repro-dolt-prod-timeouts/main.go` (G704, G702 x2): inline `#nosec` with justification, matching existing repo style - loopback probe of a locally started dolt server, and fixed subcommand args on an operator-supplied local binary path.

## Notes

- Scope is the pinned `go install` paths. The dedicated `Lint` job (`golangci-lint-action` with `version: latest`) is intentionally left floating; the tree is also clean under current latest (verified with 2.12.2), and that job is always >= 2.10.1 so it reproduces the pre-commit findings.
- Verified: `golangci-lint run --build-tags=gms_pure_go ./...` clean at v2.10.1, `go build -tags gms_pure_go ./...`, `go test ./internal/github/... ./internal/linear/...`, `make fmt-check` all pass.
- Disjoint from #4589 (depguard edits different `.golangci.yml` regions); merge order does not matter.

Tracked in mybd as bead mybd-kpd7.

_claude-fable-5-high on behalf of matt wilkie_ (implementation: claude-sonnet-5 builder agent; review: claude-opus reviewer agent)
