### PR TITLE
fix(import): respect import.auto=false in the empty-DB import-on-write path

### DIFF
--- a/cmd/bd/auto_import_upgrade_unit_test.go
+++ b/cmd/bd/auto_import_upgrade_unit_test.go
@@ -224,6 +224,49 @@ func TestShouldRunAutoImportJSONL_RespectsImportAutoFalse(t *testing.T) {
 	}
 }
 
+// TestIsDisablingImportAutoViaConfigCommand is the regression test for the
+// P2 finding on gastownhall/beads#4595 (Codex cross-vendor review,
+// 2026-07-07): shouldRunAutoImportJSONL runs in PersistentPreRun before
+// "bd config set import.auto false" writes the new value, so the command
+// meant to disable auto-import triggered it on its own invocation whenever a
+// stale .beads/issues.jsonl sat next to an empty database (GH#4304). This
+// exemption must fire for "config set import.auto false"/"0" and for
+// "config set-many ... import.auto=false", but not for unrelated config
+// keys, truthy values, or commands outside the config subtree.
+func TestIsDisablingImportAutoViaConfigCommand(t *testing.T) {
+	configCmd := &cobra.Command{Use: "config"}
+	setCmd := &cobra.Command{Use: "set"}
+	setManyCmd := &cobra.Command{Use: "set-many"}
+	configCmd.AddCommand(setCmd, setManyCmd)
+	writeCmd := &cobra.Command{Use: "update"}
+
+	tests := []struct {
+		name string
+		cmd  *cobra.Command
+		args []string
+		want bool
+	}{
+		{name: "config set import.auto false", cmd: setCmd, args: []string{"import.auto", "false"}, want: true},
+		{name: "config set import.auto 0", cmd: setCmd, args: []string{"import.auto", "0"}, want: true},
+		{name: "config set import.auto true", cmd: setCmd, args: []string{"import.auto", "true"}, want: false},
+		{name: "config set other key", cmd: setCmd, args: []string{"export.auto", "false"}, want: false},
+		{name: "config set-many import.auto=false", cmd: setManyCmd, args: []string{"jira.url=x", "import.auto=false"}, want: true},
+		{name: "config set-many import.auto=true", cmd: setManyCmd, args: []string{"import.auto=true"}, want: false},
+		{name: "unrelated command", cmd: writeCmd, args: []string{"import.auto", "false"}, want: false},
+		{name: "set without config parent", cmd: &cobra.Command{Use: "set"}, args: []string{"import.auto", "false"}, want: false},
+		{name: "nil command", cmd: nil, args: []string{"import.auto", "false"}, want: false},
+		{name: "too few args", cmd: setCmd, args: []string{"import.auto"}, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isDisablingImportAutoViaConfigCommand(tt.cmd, tt.args); got != tt.want {
+				t.Fatalf("isDisablingImportAutoViaConfigCommand(%v, %v) = %v, want %v", tt.cmd, tt.args, got, tt.want)
+			}
+		})
+	}
+}
+
 // TestMaybeAutoImportJSONL_FallbackImporter_SkipsWhenStatisticsNil covers
 // the defensive nil-statistics guard: if the store reports no error but also
 // no counts, auto-import should skip rather than panic or assume emptiness.

--- a/cmd/bd/auto_import_upgrade_unit_test.go
+++ b/cmd/bd/auto_import_upgrade_unit_test.go
@@ -162,6 +162,7 @@ func TestMaybeAutoImportJSONL_FallbackImporter_SkipsWhenStatisticsReportNonEmpty
 }
 
 func TestShouldRunAutoImportJSONL(t *testing.T) {
+	initConfigForTest(t)
 	store := &fakeFallbackStore{}
 	writeCmd := &cobra.Command{Use: "update"}
 
@@ -190,6 +191,36 @@ func TestShouldRunAutoImportJSONL(t *testing.T) {
 				t.Fatalf("shouldRunAutoImportJSONL() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+// TestShouldRunAutoImportJSONL_RespectsImportAutoFalse is the regression test
+// for GH#4304: bd update (and any other write command) auto-imported
+// issues.jsonl into an empty database even when import.auto was explicitly
+// set to false (via config.yaml or BD_IMPORT_AUTO=false). shouldRunAutoImportJSONL
+// previously never consulted the import.auto config key at all — only the
+// separate git-hook sync path (importJSONLForSync) checked it. This test fails
+// on the buggy code (want=true) and passes once the config check is restored.
+func TestShouldRunAutoImportJSONL_RespectsImportAutoFalse(t *testing.T) {
+	initConfigForTest(t)
+	store := &fakeFallbackStore{}
+	writeCmd := &cobra.Command{Use: "update"}
+	importCmd := &cobra.Command{Use: "import"}
+
+	config.Set("import.auto", false)
+	if got := shouldRunAutoImportJSONL(writeCmd, store, false, false, false); got {
+		t.Fatalf("regression GH#4304: shouldRunAutoImportJSONL() = %v with import.auto=false, want false", got)
+	}
+	// The explicit "bd import" command must remain unaffected either way —
+	// confirm it's still gated off (for a different reason) so the config
+	// check above isn't the only thing keeping it from double-running.
+	if got := shouldRunAutoImportJSONL(importCmd, store, false, false, false); got {
+		t.Fatalf("shouldRunAutoImportJSONL() = %v for the import command with import.auto=false, want false", got)
+	}
+
+	config.Set("import.auto", true)
+	if got := shouldRunAutoImportJSONL(writeCmd, store, false, false, false); !got {
+		t.Fatalf("shouldRunAutoImportJSONL() = %v with import.auto=true, want true (negative control)", got)
 	}
 }
 

--- a/cmd/bd/config_setmany_test.go
+++ b/cmd/bd/config_setmany_test.go
@@ -53,7 +53,7 @@ func TestConfigSetManyArgParsing(t *testing.T) {
 // TestConfigSetManyYamlKeyDetection tests that yaml-only keys are correctly identified
 // for routing in the set-many command.
 func TestConfigSetManyYamlKeyDetection(t *testing.T) {
-	yamlKeys := []string{"no-db", "json", "routing.mode", "routing.default", "no-push", "import.path"}
+	yamlKeys := []string{"no-db", "json", "routing.mode", "routing.default", "no-push", "import.auto", "import.path"}
 	for _, key := range yamlKeys {
 		if !config.IsYamlOnlyKey(key) {
 			t.Errorf("expected %q to be yaml-only", key)

--- a/cmd/bd/main.go
+++ b/cmd/bd/main.go
@@ -1342,6 +1342,14 @@ func shouldRunAutoImportJSONL(cmd *cobra.Command, s storage.DoltStorage, useRead
 	if cmd == nil || s == nil || useReadOnly || globalFlag || serverMode {
 		return false
 	}
+	// import.auto=false (or BD_IMPORT_AUTO=false) must disable ALL auto-import
+	// behavior, not just the git-hook sync path (importJSONLForSync). Without
+	// this check, a fresh/empty database would silently auto-import stale
+	// issues.jsonl on every write command regardless of the config setting
+	// (GH#4304).
+	if !config.GetBool("import.auto") {
+		return false
+	}
 	return cmd.Name() != "import"
 }
 

--- a/cmd/bd/main.go
+++ b/cmd/bd/main.go
@@ -11,6 +11,7 @@ import (
 	"runtime/pprof"
 	"runtime/trace"
 	"slices"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -1181,7 +1182,8 @@ var rootCmd = &cobra.Command{
 		// Skip auto-import when the user is explicitly running "bd import" —
 		// the import command handles JSONL files itself and auto-importing
 		// first would interfere (double-import / upsert confusion).
-		if shouldRunAutoImportJSONL(cmd, store, useReadOnly, globalFlag, doltCfg.ServerMode) {
+		if shouldRunAutoImportJSONL(cmd, store, useReadOnly, globalFlag, doltCfg.ServerMode) &&
+			!isDisablingImportAutoViaConfigCommand(cmd, args) {
 			maybeAutoImportJSONL(rootCtx, store, beadsDir)
 		}
 
@@ -1351,6 +1353,38 @@ func shouldRunAutoImportJSONL(cmd *cobra.Command, s storage.DoltStorage, useRead
 		return false
 	}
 	return cmd.Name() != "import"
+}
+
+// isDisablingImportAutoViaConfigCommand reports whether the command about to
+// run is "bd config set import.auto false" (or an equivalent
+// "bd config set-many ... import.auto=false" pair). shouldRunAutoImportJSONL
+// runs in PersistentPreRun before configSetCmd/configSetManyCmd write the new
+// value to config.yaml, so without this exemption the master switch would
+// trigger the very auto-import it is meant to disable on its own invocation
+// when a stale .beads/issues.jsonl sits next to an empty database (GH#4304).
+func isDisablingImportAutoViaConfigCommand(cmd *cobra.Command, args []string) bool {
+	if cmd == nil || cmd.Parent() == nil || cmd.Parent().Name() != "config" {
+		return false
+	}
+	switch cmd.Name() {
+	case "set":
+		return len(args) >= 2 && args[0] == "import.auto" && isFalsyConfigValue(args[1])
+	case "set-many":
+		for _, arg := range args {
+			key, value, ok := strings.Cut(arg, "=")
+			if ok && key == "import.auto" && isFalsyConfigValue(value) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// isFalsyConfigValue reports whether a config value string parses as a
+// boolean false (e.g. "false", "0", "f").
+func isFalsyConfigValue(value string) bool {
+	parsed, err := strconv.ParseBool(value)
+	return err == nil && !parsed
 }
 
 func commandAllowsEmptyAutoExport(cmd *cobra.Command) bool {

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -358,7 +358,7 @@ Configuration keys use dot-notation namespaces to organize settings:
 - `export.skip_encoding_errors` - Skip issues that fail JSON encoding (default: false)
 - `export.write_manifest` - Write .manifest.json with export metadata (default: false)
 - `auto_export.error_policy` - Override error policy for auto-exports (default: `best-effort`)
-- `import.auto` - Legacy hook fallback that imports JSONL after git merge/checkout only when no Dolt remote is configured (default: `true`)
+- `import.auto` - Master switch for automatic JSONL imports (default: `true`). Gates both the legacy hook fallback that imports JSONL after git merge/checkout when no Dolt remote is configured, and the empty-database recovery import that write commands run when `.beads/issues.jsonl` exists but the database is empty. Set to `false` to disable all auto-imports; explicit `bd import` always works.
 - `sync.branch` - Name of the dedicated sync branch for beads data (see docs/PROTECTED_BRANCHES.md)
 - `sync.require_confirmation_on_mass_delete` - Require interactive confirmation before pushing when >50% of issues vanish during a merge AND more than 5 issues existed before (default: `false`)
 

--- a/internal/config/yaml_config.go
+++ b/internal/config/yaml_config.go
@@ -66,6 +66,7 @@ var YamlOnlyKeys = map[string]bool{
 	"backup.git-repo": true,
 
 	// Import settings
+	"import.auto": true,
 	"import.path": true,
 
 	// Dolt server settings

--- a/internal/config/yaml_config_test.go
+++ b/internal/config/yaml_config_test.go
@@ -43,6 +43,7 @@ func TestIsYamlOnlyKey(t *testing.T) {
 		{"backup.future-key", true}, // prefix match
 
 		// Import settings
+		{"import.auto", true},
 		{"import.path", true},
 		{"import.orphan_handling", false},
 


### PR DESCRIPTION
Fixes #4304.

## Why

With `import.auto=false` (env `BD_IMPORT_AUTO=false` or `config.yaml`), any write command (`bd update`, `bd close`, ...) against an empty database with a `.beads/issues.jsonl` present still silently auto-imported the JSONL - the exact data-safety hazard #4304 reports. Reproduced on current main (c4e51986b): `bd config show` reports `import.auto = false (env_var)`, yet `bd update` prints `auto-imported 2 issues from .../issues.jsonl`.

## Root cause

`shouldRunAutoImportJSONL` (cmd/bd/main.go), the gate in front of the empty-DB upgrade-recovery import that every write command runs through, checked read-only mode, `--global`, server mode, and `cmd.Name() != "import"` - but never consulted `import.auto`. Only the separate git-hook sync path (`importJSONLForSync` in cmd/bd/hooks.go) honored the key, so disabling auto-import silenced the hook importer while the import-on-write path kept firing.

## What

- Add the same `config.GetBool("import.auto")` guard to `shouldRunAutoImportJSONL`, making the two auto-import paths consistent. The registered default is `true` (internal/config/config.go), so default behavior - empty-DB recovery import on write - is unchanged; only an explicit opt-out is now respected everywhere.
- Regression test `TestShouldRunAutoImportJSONL_RespectsImportAutoFalse`, plus config initialization in the pre-existing table test so its default-on cases assert the registered default rather than ambient state.
- Update the `import.auto` entry in docs/CONFIG.md: the key is now the master auto-import switch, gating both the post-merge/checkout hook fallback and the empty-database import-on-write path.

## Scope note for reviewers

This deliberately broadens `import.auto` from "legacy hook fallback switch" to "all auto-import" - a user who sets `import.auto=false` expects no silent imports anywhere, per #4304. Explicit `bd import` is unaffected (it short-circuits on command name independent of the flag), as are server mode and read-only commands.

Follow-up commit 24dc3af also folds in the adjacent mybd-gai7 bug: `import.auto` is now marked YAML-only like `import.path`, so `bd config set import.auto false` writes to `.beads/config.yaml` where the startup auto-import gates read it.

Verified: pure-Go build, targeted `go test` on the auto-import gate/import tests, gofmt clean; end-to-end repro confirmed suppressed with the fixed binary (env var and config.yaml variants), and default-on behavior confirmed intact. Follow-up local checks: `go test ./internal/config -run TestIsYamlOnlyKey` and `CGO_ENABLED=0 go test -tags gms_pure_go ./cmd/bd -run TestConfigSetMany`.

Tracked in mybd as beads mybd-3fvn and mybd-gai7.

_claude-fable-5-high on behalf of matt wilkie_ (implementation: claude-sonnet-5 builder agent; review: claude-opus reviewer agent)

_codex-gpt-5.5-high on behalf of matt wilkie_ (follow-up mybd-gai7 fix)
