### PR TITLE
feat(q): add --parent for hierarchical quick capture

### DIFF
--- a/cmd/bd/quick.go
+++ b/cmd/bd/quick.go
@@ -1,11 +1,13 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/steveyegge/beads/internal/metrics"
+	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/types"
 	"github.com/steveyegge/beads/internal/validation"
 )
@@ -20,7 +22,8 @@ Designed for scripting and AI agent integration.
 Example:
   bd q "Fix login bug"           # Outputs: bd-a1b2
   ISSUE=$(bd q "New feature")    # Capture ID in variable
-  bd q "Task" | xargs bd show    # Pipe to other commands`,
+  bd q "Task" | xargs bd show    # Pipe to other commands
+  bd q "Subtask" --parent=bd-a1b2  # Hierarchical child (outputs: bd-a1b2.1)`,
 	Args:          cobra.MinimumNArgs(1),
 	SilenceUsage:  true,
 	SilenceErrors: true,
@@ -42,10 +45,26 @@ Example:
 		priorityStr, _ := cmd.Flags().GetString("priority")
 		issueType, _ := cmd.Flags().GetString("type")
 		labels, _ := cmd.Flags().GetStringSlice("labels")
+		parentID, _ := cmd.Flags().GetString("parent")
 
 		priority, err := validation.ValidatePriority(priorityStr)
 		if err != nil {
 			return HandleError("%v", err)
+		}
+
+		ctx := rootCtx
+
+		// Mirrors bd create's parent handling: validate the parent exists,
+		// inherit its labels, and reserve a hierarchical child ID.
+		var inheritedLabels []string
+		if parentID != "" {
+			if _, err := store.GetIssue(ctx, parentID); err != nil {
+				if errors.Is(err, storage.ErrNotFound) {
+					return HandleError("parent issue %s not found", parentID)
+				}
+				return HandleError("failed to check parent issue: %v", err)
+			}
+			inheritedLabels, _ = store.GetLabels(ctx, parentID)
 		}
 
 		issue := &types.Issue{
@@ -53,15 +72,48 @@ Example:
 			Status:    types.StatusOpen,
 			Priority:  priority,
 			IssueType: types.IssueType(issueType).Normalize(),
-			Labels:    mergeCreateLabels(labels, nil),
+			Labels:    mergeCreateLabels(labels, inheritedLabels),
 		}
 
-		ctx := rootCtx
+		if parentID != "" {
+			childID, err := store.GetNextChildID(ctx, parentID)
+			if err != nil {
+				return HandleError("%v", err)
+			}
+			issue.ID = childID
+			ctx = storage.WithReservedChildCounter(ctx, parentID, childID)
+		}
+
 		if err := store.CreateIssue(ctx, issue, actor); err != nil {
 			return HandleError("%v", err)
 		}
 
 		commandDidWrite.Store(true)
+
+		if parentID != "" {
+			dep := &types.Dependency{
+				IssueID:     issue.ID,
+				DependsOnID: parentID,
+				Type:        types.DepParentChild,
+			}
+			if err := store.AddDependency(ctx, dep, actor); err != nil {
+				WarnError("failed to add parent-child dependency %s -> %s: %v", issue.ID, parentID, err)
+			} else {
+				// CreateIssue commits internally, but the dependency write
+				// only lands in the working set (GH#2009) — same follow-up
+				// commit bd create performs.
+				shouldCommit, err := shouldCommitCreatePostWrites(issue, true)
+				if err != nil {
+					return HandleError("dolt auto-commit failed: %v", err)
+				}
+				if shouldCommit {
+					commitMsg := fmt.Sprintf("bd: create %s", issue.ID)
+					if err := store.Commit(ctx, commitMsg); err != nil && !isDoltNothingToCommit(err) {
+						WarnError("failed to commit: %v", err)
+					}
+				}
+			}
+		}
 
 		fmt.Println(issue.ID)
 		return nil
@@ -72,5 +124,6 @@ func init() {
 	quickCmd.Flags().StringP("priority", "p", "2", "Priority (0-4 or P0-P4)")
 	quickCmd.Flags().StringP("type", "t", "task", "Issue type")
 	quickCmd.Flags().StringSliceP("labels", "l", []string{}, "Labels")
+	quickCmd.Flags().String("parent", "", "Parent issue ID for hierarchical child (e.g., 'bd-a3f8e9')")
 	rootCmd.AddCommand(quickCmd)
 }

--- a/cmd/bd/quick_embedded_test.go
+++ b/cmd/bd/quick_embedded_test.go
@@ -29,7 +29,7 @@ func TestEmbeddedQuick(t *testing.T) {
 	t.Parallel()
 
 	bd := buildEmbeddedBD(t)
-	dir, _, _ := bdInit(t, bd, "--prefix", "qq")
+	dir, beadsDir, _ := bdInit(t, bd, "--prefix", "qq")
 
 	t.Run("basic_quick_create", func(t *testing.T) {
 		id := bdQuick(t, bd, dir, "Quick task")
@@ -127,6 +127,51 @@ func TestEmbeddedQuick(t *testing.T) {
 		out, err := cmd.CombinedOutput()
 		if err == nil {
 			t.Fatalf("expected bd q with no title to fail, got: %s", out)
+		}
+	})
+
+	t.Run("quick_parent", func(t *testing.T) {
+		parent := bdCreate(t, bd, dir, "Quick parent epic", "-t", "epic")
+		id := bdQuick(t, bd, dir, "Quick child", "--parent", parent.ID)
+
+		if !strings.HasPrefix(id, parent.ID+".") {
+			t.Errorf("child ID %q should start with %q.", id, parent.ID)
+		}
+		// Output contract: still ID-only, single line
+		if lines := strings.Split(id, "\n"); len(lines) != 1 {
+			t.Errorf("expected single-line ID output, got %d lines: %q", len(lines), id)
+		}
+
+		assertDepExists(t, beadsDir, "qq", id, parent.ID)
+	})
+
+	t.Run("quick_parent_label_inheritance", func(t *testing.T) {
+		parent := bdCreate(t, bd, dir, "Quick labeled parent", "-t", "epic", "-l", "team-q,inherited")
+		id := bdQuick(t, bd, dir, "Quick labeled child", "--parent", parent.ID, "-l", "own")
+
+		m := bdShowDetails(t, bd, dir, id)
+		labels, _ := m["labels"].([]interface{})
+		labelSet := map[string]bool{}
+		for _, l := range labels {
+			labelSet[l.(string)] = true
+		}
+		for _, want := range []string{"team-q", "inherited", "own"} {
+			if !labelSet[want] {
+				t.Errorf("expected label %q, got %v", want, labels)
+			}
+		}
+	})
+
+	t.Run("quick_parent_not_found_fails", func(t *testing.T) {
+		cmd := exec.Command(bd, "q", "Orphan child", "--parent", "qq-doesnotexist")
+		cmd.Dir = dir
+		cmd.Env = bdEnv(dir)
+		out, err := cmd.CombinedOutput()
+		if err == nil {
+			t.Fatalf("expected bd q --parent with nonexistent parent to fail, got: %s", out)
+		}
+		if !strings.Contains(string(out), "not found") {
+			t.Errorf("expected 'not found' in error output, got: %s", out)
 		}
 	})
 }

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -1150,6 +1150,7 @@ Example:
   bd q "Fix login bug"           # Outputs: bd-a1b2
   ISSUE=$(bd q "New feature")    # Capture ID in variable
   bd q "Task" | xargs bd show    # Pipe to other commands
+  bd q "Subtask" --parent=bd-a1b2  # Hierarchical child (outputs: bd-a1b2.1)
 
 ```
 bd q [title] [flags]
@@ -1159,6 +1160,7 @@ bd q [title] [flags]
 
 ```
   -l, --labels strings    Labels
+      --parent string     Parent issue ID for hierarchical child (e.g., 'bd-a3f8e9')
   -p, --priority string   Priority (0-4 or P0-P4) (default "2")
   -t, --type string       Issue type (default "task")
 ```

--- a/website/docs/cli-reference/q.md
+++ b/website/docs/cli-reference/q.md
@@ -17,6 +17,7 @@ Example:
   bd q "Fix login bug"           # Outputs: bd-a1b2
   ISSUE=$(bd q "New feature")    # Capture ID in variable
   bd q "Task" | xargs bd show    # Pipe to other commands
+  bd q "Subtask" --parent=bd-a1b2  # Hierarchical child (outputs: bd-a1b2.1)
 
 ```
 bd q [title] [flags]
@@ -26,6 +27,7 @@ bd q [title] [flags]
 
 ```
   -l, --labels strings    Labels
+      --parent string     Parent issue ID for hierarchical child (e.g., 'bd-a3f8e9')
   -p, --priority string   Priority (0-4 or P0-P4) (default "2")
   -t, --type string       Issue type (default "task")
 ```


### PR DESCRIPTION
## Summary

Closes #4596.

`bd q` is documented as "designed for scripting and AI agent integration", but the most common agent scripting pattern — batch-creating an epic breakdown — required abandoning it for the much heavier `bd create --parent`:

```bash
EPIC=$(bd q "Big initiative" -t epic)
T1=$(bd q "First child" --parent="$EPIC")   # previously: Error: unknown flag: --parent
```

This PR adds `--parent` to `bd q`, mirroring `create.go`'s parent handling:

- Validate the parent exists (`parent issue <id> not found` on miss, nothing created)
- Inherit parent labels, merged with `-l` labels (matches `bd create`'s default)
- Reserve the hierarchical child ID via `GetNextChildID` + `WithReservedChildCounter`
- Add the `parent-child` dependency after `CreateIssue`, followed by the post-write Dolt commit (same GH#2009 pattern as `create.go`)
- Output contract unchanged: single line, child ID only (`bd-a1b2.1`)

Deliberately **not** ported from `create`: `--no-inherit-labels`, `--deps`, `--dry-run`, etc. `q` stays minimal — anyone needing those flags should use `bd create`.

Docs regenerated with `scripts/generate-cli-docs.sh` (CLI_REFERENCE.md + live website page).

## Test plan

Test-first: the three new subtests were written and run before the implementation, failing with `Error: unknown flag: --parent`; they pass after.

- [x] `BEADS_TEST_EMBEDDED_DOLT=1 go test -tags gms_pure_go ./cmd/bd/ -run 'TestEmbeddedQuick$'` — all 13 subtests pass (58s), including new:
  - `quick_parent` — hierarchical ID (`qq-xxx.1`), single-line ID-only output, dependency row asserted via `assertDepExists`
  - `quick_parent_label_inheritance` — parent labels merged with `-l` labels
  - `quick_parent_not_found_fails` — non-zero exit, "not found" error, nothing created
- [x] `gofmt -l` clean on changed files
- [x] Not a duplicate: `gh pr list --search "q parent"` / `"quick capture parent"` — no matching open PRs

---

> **Disclosure:** AI assistance (Claude) was used for this change under my direction. I reviewed every line; the implementation intentionally mirrors the existing parent path in `create.go` (validation, child-ID reservation, dependency write, post-write commit) rather than inventing new behavior.

Assisted-by: Claude:claude-fable-5 [Cursor]

Made with [Cursor](https://cursor.com)