### PR TITLE
fix(bootstrap): retry failed clone cleanup

### DIFF
--- a/internal/storage/dolt/bootstrap.go
+++ b/internal/storage/dolt/bootstrap.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strings"
 	"time"
 
 	"github.com/steveyegge/beads/internal/configfile"
@@ -54,8 +53,8 @@ func BootstrapFromRemoteWithDB(ctx context.Context, doltDir, remoteURL, database
 		return false, fmt.Errorf("invalid remote URL: %w", err)
 	}
 
-	if strings.TrimSpace(database) == "" {
-		return false, fmt.Errorf("database name must not be empty; use cfg.GetDoltDatabase() to resolve the configured name")
+	if err := ValidateDatabaseName(database); err != nil {
+		return false, fmt.Errorf("invalid database name %q (use cfg.GetDoltDatabase() to resolve the configured name): %w", database, err)
 	}
 
 	// Verify dolt CLI is available
@@ -71,8 +70,17 @@ func BootstrapFromRemoteWithDB(ctx context.Context, doltDir, remoteURL, database
 	// Clone into <doltDir>/<database>/ so the embedded driver can find it.
 	// `dolt clone <url> <target>` creates <target>/.dolt/ directly.
 	cloneTarget := filepath.Join(doltDir, database)
+	// Record whether the target already existed before this clone attempt.
+	// If it did, the failed-clone cleanup below must never touch it: it
+	// wasn't created by us, so it could be a pre-existing Dolt repo (e.g.
+	// from an earlier bootstrap that a stale/empty doltExists() check
+	// missed) that we must not delete.
+	targetPreExisted := pathExists(cloneTarget)
 	cmd := exec.CommandContext(ctx, "dolt", doltCloneArgs(remoteURL, cloneTarget)...)
 	if output, err := cmd.CombinedOutput(); err != nil {
+		if targetPreExisted {
+			return false, fmt.Errorf("dolt clone failed: %w\nOutput: %s\nClone target %q already existed before this attempt; left untouched to avoid deleting a pre-existing Dolt repo", err, output, cloneTarget)
+		}
 		cleaned, cleanupErr := removeFailedCloneTargetWithRetry(cloneTarget)
 		return false, formatFailedCloneTargetError(err, output, cloneTarget, cleaned, cleanupErr)
 	}
@@ -136,6 +144,15 @@ func doltCloneArgs(remoteURL, target string) []string {
 // BootstrapFromGitRemoteWithDB is deprecated. Use BootstrapFromRemoteWithDB instead.
 func BootstrapFromGitRemoteWithDB(ctx context.Context, doltDir, gitRemoteURL, database string) (bool, error) {
 	return BootstrapFromRemoteWithDB(ctx, doltDir, gitRemoteURL, database)
+}
+
+// pathExists reports whether path exists (of any type), without following
+// symlinks. Used to detect whether a clone target pre-existed before a
+// clone attempt, so failed-clone cleanup never deletes something it didn't
+// create.
+func pathExists(path string) bool {
+	_, err := os.Lstat(path)
+	return err == nil
 }
 
 // doltExists checks if a Dolt database directory exists

--- a/internal/storage/dolt/bootstrap.go
+++ b/internal/storage/dolt/bootstrap.go
@@ -73,11 +73,56 @@ func BootstrapFromRemoteWithDB(ctx context.Context, doltDir, remoteURL, database
 	cloneTarget := filepath.Join(doltDir, database)
 	cmd := exec.CommandContext(ctx, "dolt", doltCloneArgs(remoteURL, cloneTarget)...)
 	if output, err := cmd.CombinedOutput(); err != nil {
-		return false, fmt.Errorf("dolt clone failed: %w\nOutput: %s", err, output)
+		cleaned, cleanupErr := removeFailedCloneTargetWithRetry(cloneTarget)
+		return false, formatFailedCloneTargetError(err, output, cloneTarget, cleaned, cleanupErr)
 	}
 
 	fmt.Fprintf(os.Stderr, "Bootstrapped from remote: %s\n", remoteURL)
 	return true, nil
+}
+
+var failedCloneCleanupRetryDelays = []time.Duration{
+	50 * time.Millisecond,
+	100 * time.Millisecond,
+	250 * time.Millisecond,
+	500 * time.Millisecond,
+}
+
+func removeFailedCloneTargetWithRetry(path string) (bool, error) {
+	info, err := os.Lstat(filepath.Join(path, ".dolt"))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	if !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+		return false, nil
+	}
+
+	for attempt := 0; ; attempt++ {
+		err := os.RemoveAll(path)
+		if err == nil || os.IsNotExist(err) {
+			return true, nil
+		}
+		if attempt >= len(failedCloneCleanupRetryDelays) {
+			return true, err
+		}
+		time.Sleep(failedCloneCleanupRetryDelays[attempt])
+	}
+}
+
+func formatFailedCloneTargetError(cloneErr error, output []byte, cloneTarget string, cleaned bool, cleanupErr error) error {
+	if cleanupErr == nil && cleaned {
+		return fmt.Errorf("dolt clone failed: %w\nOutput: %s\nCleaned up failed clone target %q; fix the clone error above and retry `bd bootstrap`", cloneErr, output, cloneTarget)
+	}
+	if cleanupErr == nil {
+		return fmt.Errorf("dolt clone failed: %w\nOutput: %s", cloneErr, output)
+	}
+	if !cleaned {
+		return fmt.Errorf("dolt clone failed: %w\nOutput: %s\nCould not inspect failed clone target %q before cleanup: %v\nOn Windows this usually means a dolt or bd process, or antivirus scanner, still has a file handle open under `.dolt/noms/LOCK`. Stop stuck dolt/bd processes, wait a moment, delete the directory manually if it remains, then retry `bd bootstrap`", cloneErr, output, cloneTarget, cleanupErr)
+	}
+	return fmt.Errorf("dolt clone failed: %w\nOutput: %s\nCould not clean up failed clone target %q after retrying: %v\nOn Windows this usually means a dolt or bd process, or antivirus scanner, still has a file handle open under `.dolt/noms/LOCK`. Stop stuck dolt/bd processes, wait a moment, delete the directory manually if it remains, then retry `bd bootstrap`", cloneErr, output, cloneTarget, cleanupErr)
 }
 
 func doltCloneArgs(remoteURL, target string) []string {

--- a/internal/storage/dolt/bootstrap_test.go
+++ b/internal/storage/dolt/bootstrap_test.go
@@ -2,8 +2,12 @@ package dolt
 
 import (
 	"context"
+	"errors"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 // TestBootstrapFromRemoteWithDB_RejectsEmptyDatabase verifies that
@@ -85,5 +89,107 @@ func TestDoltCloneArgs(t *testing.T) {
 	want = []string{"clone", "--user", "alice", "https://example.com/repo", "/tmp/clone"}
 	if strings.Join(got, "\x00") != strings.Join(want, "\x00") {
 		t.Fatalf("doltCloneArgs() = %q, want %q", got, want)
+	}
+}
+
+func TestRemoveFailedCloneTargetWithRetryRemovesPartialClone(t *testing.T) {
+	oldDelays := failedCloneCleanupRetryDelays
+	failedCloneCleanupRetryDelays = []time.Duration{0}
+	t.Cleanup(func() { failedCloneCleanupRetryDelays = oldDelays })
+
+	target := filepath.Join(t.TempDir(), "beads")
+	if err := os.MkdirAll(filepath.Join(target, ".dolt", "noms"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(target, ".dolt", "noms", "LOCK"), []byte("lock"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cleaned, err := removeFailedCloneTargetWithRetry(target)
+	if err != nil {
+		t.Fatalf("removeFailedCloneTargetWithRetry() error = %v", err)
+	}
+	if !cleaned {
+		t.Fatal("expected cleanup to report removing a partial Dolt clone")
+	}
+	if _, err := os.Stat(target); !os.IsNotExist(err) {
+		t.Fatalf("expected failed clone target to be removed, stat err=%v", err)
+	}
+}
+
+func TestRemoveFailedCloneTargetWithRetryPreservesNonDoltTarget(t *testing.T) {
+	target := filepath.Join(t.TempDir(), "beads")
+	if err := os.MkdirAll(target, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(target, "README.txt"), []byte("not a dolt clone"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cleaned, err := removeFailedCloneTargetWithRetry(target)
+	if err != nil {
+		t.Fatalf("removeFailedCloneTargetWithRetry() error = %v", err)
+	}
+	if cleaned {
+		t.Fatal("non-Dolt target should not report cleanup")
+	}
+	if _, err := os.Stat(filepath.Join(target, "README.txt")); err != nil {
+		t.Fatalf("non-Dolt target should be preserved, stat err=%v", err)
+	}
+}
+
+func TestRemoveFailedCloneTargetWithRetryPreservesDotDoltFile(t *testing.T) {
+	target := filepath.Join(t.TempDir(), "beads")
+	if err := os.MkdirAll(target, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(target, ".dolt"), []byte("not a directory"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cleaned, err := removeFailedCloneTargetWithRetry(target)
+	if err != nil {
+		t.Fatalf("removeFailedCloneTargetWithRetry() error = %v", err)
+	}
+	if cleaned {
+		t.Fatal("target with non-directory .dolt marker should not report cleanup")
+	}
+	if _, err := os.Stat(filepath.Join(target, ".dolt")); err != nil {
+		t.Fatalf("non-directory .dolt marker should be preserved, stat err=%v", err)
+	}
+}
+
+func TestFormatFailedCloneTargetErrorCleanupSucceeded(t *testing.T) {
+	err := formatFailedCloneTargetError(errors.New("exit status 1"), []byte("clone failed"), `C:\tmp\beads`, true, nil)
+
+	msg := err.Error()
+	if !strings.Contains(msg, "Cleaned up failed clone target") {
+		t.Fatalf("expected cleanup success note, got:\n%s", msg)
+	}
+	if !strings.Contains(msg, "retry `bd bootstrap`") {
+		t.Fatalf("expected retry guidance, got:\n%s", msg)
+	}
+}
+
+func TestFormatFailedCloneTargetErrorNoCleanup(t *testing.T) {
+	err := formatFailedCloneTargetError(errors.New("exit status 1"), []byte("clone failed before target"), `C:\tmp\beads`, false, nil)
+
+	msg := err.Error()
+	if strings.Contains(msg, "Cleaned up failed clone target") {
+		t.Fatalf("should not claim cleanup when no cleanup ran, got:\n%s", msg)
+	}
+	if !strings.Contains(msg, "clone failed before target") {
+		t.Fatalf("expected original output, got:\n%s", msg)
+	}
+}
+
+func TestFormatFailedCloneTargetErrorCleanupFailed(t *testing.T) {
+	err := formatFailedCloneTargetError(errors.New("exit status 1"), []byte("unable to clean up failed clone"), `C:\tmp\beads`, true, errors.New("file is in use"))
+
+	msg := err.Error()
+	for _, want := range []string{"Could not clean up failed clone target", "Windows", ".dolt/noms/LOCK", "Stop stuck dolt/bd processes"} {
+		if !strings.Contains(msg, want) {
+			t.Fatalf("expected %q in error, got:\n%s", want, msg)
+		}
 	}
 }

--- a/internal/storage/dolt/bootstrap_test.go
+++ b/internal/storage/dolt/bootstrap_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -22,7 +23,7 @@ func TestBootstrapFromRemoteWithDB_RejectsEmptyDatabase(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for empty database name, got nil")
 	}
-	if !strings.Contains(err.Error(), "database name must not be empty") {
+	if !strings.Contains(err.Error(), "invalid database name") {
 		t.Errorf("unexpected error message: %v", err)
 	}
 }
@@ -36,8 +37,28 @@ func TestBootstrapFromRemoteWithDB_RejectsWhitespaceDatabase(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for whitespace-only database name, got nil")
 	}
-	if !strings.Contains(err.Error(), "database name must not be empty") {
+	if !strings.Contains(err.Error(), "invalid database name") {
 		t.Errorf("unexpected error message: %v", err)
+	}
+}
+
+// TestBootstrapFromRemoteWithDB_RejectsPathLikeDatabase verifies that
+// database names containing path separators or traversal segments are
+// rejected before a clone is attempted. Such names would let the pre-clone
+// doltExists() existence check miss a database that was already cloned
+// under a different-looking path, which previously allowed the
+// failed-clone cleanup to RemoveAll a pre-existing Dolt repo
+// (P1 data-loss finding, cross-vendor review 2026-07-07).
+func TestBootstrapFromRemoteWithDB_RejectsPathLikeDatabase(t *testing.T) {
+	for _, name := range []string{"foo/bar", "../other-db", "foo\\bar"} {
+		doltDir := t.TempDir()
+		_, err := BootstrapFromRemoteWithDB(context.Background(), doltDir, "file:///dev/null", name)
+		if err == nil {
+			t.Fatalf("expected error for path-like database name %q, got nil", name)
+		}
+		if !strings.Contains(err.Error(), "invalid database name") {
+			t.Errorf("database name %q: unexpected error message: %v", name, err)
+		}
 	}
 }
 
@@ -49,14 +70,14 @@ func TestBootstrapFromRemote_UsesDefaultDatabase(t *testing.T) {
 	// returns early (skips clone) without needing the dolt CLI.
 	doltDir := t.TempDir()
 
-	// BootstrapFromRemote should not error with "database name must not be empty"
+	// BootstrapFromRemote should not error with "invalid database name"
 	// because it passes configfile.DefaultDoltDatabase explicitly.
 	// It will return false (skipped) because doltExists returns false for an
 	// empty dir, then it will fail trying to run dolt clone — but the error
-	// should be about dolt CLI, not about empty database name.
+	// should be about dolt CLI, not about an invalid database name.
 	_, err := BootstrapFromRemote(context.Background(), doltDir, "file:///dev/null")
-	if err != nil && strings.Contains(err.Error(), "database name must not be empty") {
-		t.Fatal("BootstrapFromRemote should pass an explicit database name, not empty string")
+	if err != nil && strings.Contains(err.Error(), "invalid database name") {
+		t.Fatal("BootstrapFromRemote should pass an explicit, valid database name")
 	}
 	// Any other error (dolt CLI not found, clone failure) is fine — we only care
 	// that the empty-database guard didn't fire.
@@ -71,8 +92,42 @@ func TestBootstrapFromGitRemoteWithDB_DeprecatedWrapper(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for empty database name, got nil")
 	}
-	if !strings.Contains(err.Error(), "database name must not be empty") {
+	if !strings.Contains(err.Error(), "invalid database name") {
 		t.Errorf("unexpected error message: %v", err)
+	}
+}
+
+// TestBootstrapFromRemoteWithDB_PreservesPreExistingCloneTarget verifies
+// that a failed clone never runs cleanup on a clone target that already
+// existed before this bootstrap attempt started. This is the defense in
+// depth requested alongside database-name validation for the P1 data-loss
+// finding (cross-vendor review 2026-07-07): a target directory not created
+// by this attempt must be left untouched, even if `dolt clone` fails
+// because the target already exists.
+func TestBootstrapFromRemoteWithDB_PreservesPreExistingCloneTarget(t *testing.T) {
+	if _, err := exec.LookPath("dolt"); err != nil {
+		t.Skip("dolt CLI not available")
+	}
+
+	doltDir := t.TempDir()
+	cloneTarget := filepath.Join(doltDir, "beads")
+	if err := os.MkdirAll(cloneTarget, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	marker := filepath.Join(cloneTarget, "README.txt")
+	if err := os.WriteFile(marker, []byte("pre-existing content"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := BootstrapFromRemoteWithDB(context.Background(), doltDir, "file:///dev/null", "beads")
+	if err == nil {
+		t.Fatal("expected error from failed clone, got nil")
+	}
+	if !strings.Contains(err.Error(), "already existed before this attempt") {
+		t.Errorf("expected error to note the pre-existing target, got: %v", err)
+	}
+	if data, statErr := os.ReadFile(marker); statErr != nil || string(data) != "pre-existing content" {
+		t.Fatalf("pre-existing clone target content was not preserved: data=%q err=%v", data, statErr)
 	}
 }
 


### PR DESCRIPTION
Fixes #4310.

## Why

On Windows, a failed `dolt clone` during `bd bootstrap` can leave a partial clone target behind when Dolt's own failure cleanup cannot delete `.dolt/noms/LOCK` because another process or scanner still has the file open. The user then sees the clone failure plus a nested cleanup failure and may be left with a broken partial target.

## What

- After `dolt clone` fails in the CLI/owned-server bootstrap path, retry cleanup of the clone target briefly.
- Only remove the target when it contains a real `.dolt` directory, so a pre-existing non-Dolt directory with the configured database name is preserved.
- If cleanup still fails, add actionable Windows guidance about stuck `dolt`/`bd` processes, antivirus file handles, manual deletion, and retrying `bd bootstrap`.
- Preserve the original clone error and output.

## Verification

- `go test ./internal/storage/dolt -run 'Test(BootstrapFromRemote|DoltCloneArgs|RemoveFailedCloneTarget|FormatFailedCloneTarget)'`
- `git diff --check`

Tracked in mybd as bead mybd-kj2v.

_codex-gpt-5.5-high on behalf of matt wilkie_
