### PR TITLE
test: port Windows hardening fixes

### DIFF
--- a/cmd/bd/init_embedded_test.go
+++ b/cmd/bd/init_embedded_test.go
@@ -1877,7 +1877,7 @@ func TestEmbeddedInitConcurrent(t *testing.T) {
 	for i := 0; i < N; i++ {
 		go func(idx int) {
 			defer wg.Done()
-			ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
+			ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
 			defer cancel()
 
 			cmd := exec.CommandContext(ctx, bd, "init", "--prefix", "conc", "--force", "--quiet", "--skip-agents")
@@ -1889,10 +1889,11 @@ func TestEmbeddedInitConcurrent(t *testing.T) {
 	}
 	wg.Wait()
 
-	successes, lockErrors := 0, 0
+	successes, lockErrors, timeoutKills := 0, 0, 0
 	for _, r := range results {
 		if r.timedOut {
-			t.Errorf("process %d timed out after 45s running concurrent bd init: %v\n%s", r.idx, r.err, r.out)
+			t.Logf("process %d timed out after 90s running concurrent bd init: %v\n%s", r.idx, r.err, r.out)
+			timeoutKills++
 			continue
 		}
 		if strings.Contains(r.out, "panic") {
@@ -1909,10 +1910,18 @@ func TestEmbeddedInitConcurrent(t *testing.T) {
 	if successes < 1 {
 		t.Errorf("expected at least 1 success, got %d", successes)
 	}
-	if successes+lockErrors != N {
-		t.Errorf("expected successes (%d) + lock errors (%d) = %d, got %d", successes, lockErrors, N, successes+lockErrors)
+	if lockErrors < 1 {
+		t.Errorf("expected at least 1 lock error, got %d", lockErrors)
 	}
-	t.Logf("%d/%d succeeded, %d/%d got lock error", successes, N, lockErrors, N)
+	// timeoutKills > 2 (i.e. > N/5) indicates a systemic runner problem, not normal load variance.
+	if timeoutKills > 2 {
+		t.Errorf("too many timeout-killed processes: %d/%d (cap is 2)", timeoutKills, N)
+	}
+	if successes+lockErrors+timeoutKills != N {
+		t.Errorf("expected successes (%d) + lock errors (%d) + timeout kills (%d) = %d, got %d",
+			successes, lockErrors, timeoutKills, N, successes+lockErrors+timeoutKills)
+	}
+	t.Logf("%d/%d succeeded, %d/%d got lock error, %d/%d timed out", successes, N, lockErrors, N, timeoutKills, N)
 
 	beadsDir := filepath.Join(dir, ".beads")
 	embeddedDir := filepath.Join(beadsDir, "embeddeddolt")

--- a/cmd/bd/update_close_hook_test.go
+++ b/cmd/bd/update_close_hook_test.go
@@ -13,6 +13,7 @@ package main
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/steveyegge/beads/internal/hooks"
@@ -22,6 +23,16 @@ import (
 // TestUpdateCloseHookFiring verifies hook firing logic for status transitions.
 // Uses RunSync to test hooks without needing the full CLI or Dolt infrastructure.
 func TestUpdateCloseHookFiring(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		// The hook runner on Windows executes hook files directly via CreateProcess,
+		// which has no shebang dispatch. An extensionless file containing #!/bin/sh
+		// cannot be executed as a shell script, so the marker file is never created
+		// and the assertion fails. Skipping until the runner gains Windows script
+		// support (PATHEXT-aware extension lookup + interpreter dispatch).
+		// See: https://github.com/gastownhall/beads/issues/3800
+		t.Skip("hook script execution not supported on Windows - see GH#3800")
+	}
+
 	t.Run("on_close_fires_for_status_transition_to_closed", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		markerFile := filepath.Join(tmpDir, "on_close_fired.txt")

--- a/internal/hooks/hooks_test.go
+++ b/internal/hooks/hooks_test.go
@@ -148,6 +148,16 @@ func TestRunSync_NotExecutable(t *testing.T) {
 }
 
 func TestRunSync_Success(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		// The hook runner on Windows executes hook files directly via CreateProcess,
+		// which has no shebang dispatch. An extensionless file containing #!/bin/sh
+		// cannot be executed as a shell script, so the marker file is never created
+		// and the assertion fails. Skipping until the runner gains Windows script
+		// support (PATHEXT-aware extension lookup + interpreter dispatch).
+		// See: https://github.com/gastownhall/beads/issues/3800
+		t.Skip("hook script execution not supported on Windows - see GH#3800")
+	}
+
 	tmpDir := t.TempDir()
 	hookPath := filepath.Join(tmpDir, HookOnCreate)
 	outputFile := filepath.Join(tmpDir, "output.txt")
@@ -180,6 +190,16 @@ echo "$1 $2" > ` + outputFile
 }
 
 func TestRunSync_ReceivesJSON(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		// The hook runner on Windows executes hook files directly via CreateProcess,
+		// which has no shebang dispatch. An extensionless file containing #!/bin/sh
+		// cannot be executed as a shell script, so stdin is never read and the JSON
+		// assertion fails. Skipping until the runner gains Windows script support
+		// (PATHEXT-aware extension lookup + interpreter dispatch).
+		// See: https://github.com/gastownhall/beads/issues/3800
+		t.Skip("hook script execution not supported on Windows - see GH#3800")
+	}
+
 	tmpDir := t.TempDir()
 	hookPath := filepath.Join(tmpDir, HookOnCreate)
 	outputFile := filepath.Join(tmpDir, "stdin.txt")
@@ -219,6 +239,16 @@ cat > ` + outputFile
 }
 
 func TestRunSync_Timeout(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		// The hook runner on Windows executes hook files directly via CreateProcess,
+		// which has no shebang dispatch. The 'sleep 60' shell hook silently no-ops
+		// instead of running, so RunSync returns immediately rather than hitting the
+		// timeout path and the expected timeout error never surfaces. Skipping until
+		// the runner gains Windows script support (PATHEXT-aware extension lookup +
+		// interpreter dispatch). See: https://github.com/gastownhall/beads/issues/3800
+		t.Skip("hook script execution not supported on Windows - see GH#3800")
+	}
+
 	if testing.Short() {
 		t.Skip("Skipping timeout test in short mode")
 	}
@@ -311,6 +341,16 @@ func TestRunSync_KillsDescendants(t *testing.T) {
 }
 
 func TestRunSync_HookFailure(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		// The hook runner on Windows executes hook files directly via CreateProcess,
+		// which has no shebang dispatch. An extensionless file containing #!/bin/sh
+		// cannot be executed as a shell script, so the hook silently no-ops instead
+		// of exiting 1, and the expected error is never returned. Skipping until the
+		// runner gains Windows script support (PATHEXT-aware extension lookup +
+		// interpreter dispatch). See: https://github.com/gastownhall/beads/issues/3800
+		t.Skip("hook script execution not supported on Windows - see GH#3800")
+	}
+
 	tmpDir := t.TempDir()
 	hookPath := filepath.Join(tmpDir, HookOnUpdate)
 
@@ -331,6 +371,16 @@ exit 1`
 }
 
 func TestRun_Async(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		// The hook runner on Windows executes hook files directly via CreateProcess,
+		// which has no shebang dispatch. An extensionless file containing #!/bin/sh
+		// cannot be executed as a shell script, so the marker file is never created
+		// and the assertion fails. Skipping until the runner gains Windows script
+		// support (PATHEXT-aware extension lookup + interpreter dispatch).
+		// See: https://github.com/gastownhall/beads/issues/3800
+		t.Skip("hook script execution not supported on Windows - see GH#3800")
+	}
+
 	tmpDir := t.TempDir()
 	hookPath := filepath.Join(tmpDir, HookOnClose)
 	outputFile := filepath.Join(tmpDir, "async_output.txt")

--- a/internal/storage/dbproxy/server/doltserver_test.go
+++ b/internal/storage/dbproxy/server/doltserver_test.go
@@ -65,6 +65,10 @@ func newDoltServer(t *testing.T) (*server.DoltServer, string) {
 	log := filepath.Join(t.TempDir(), "server.log")
 	s, err := server.NewDoltServer(bin, rootDir, cfg, log, 0)
 	require.NoError(t, err)
+	// Close the log file handle before t.TempDir's RemoveAll runs.
+	// On Windows, an open handle prevents directory removal; Stop is
+	// idempotent so this is safe even when the test calls Stop itself.
+	t.Cleanup(func() { _ = s.Stop(context.Background()) })
 	return s, rootDir
 }
 

--- a/scripts/release_script_test.go
+++ b/scripts/release_script_test.go
@@ -197,16 +197,10 @@ func copyReleaseScriptFixture(t *testing.T) string {
 
 func releaseTestTempDir(t *testing.T) string {
 	t.Helper()
-	root := filepath.Join(sourceRepoRoot(t), ".tmp-release-tests")
-	if err := os.MkdirAll(root, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	dir, err := os.MkdirTemp(root, "case-*")
-	if err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() { _ = os.RemoveAll(dir) })
-	return dir
+	// Keep fixtures out of the source tree (t.TempDir handles cleanup and
+	// works from read-only checkouts); shellPath converts the resulting
+	// host path for Bash separately at the call sites that need it.
+	return t.TempDir()
 }
 
 func sourceRepoRoot(t *testing.T) string {
@@ -226,7 +220,10 @@ func runReleaseDryRun(t *testing.T, repo, bin string) (string, error) {
 func runReleaseDryRunWithEnv(t *testing.T, repo, bin string, extraEnv ...string) (string, error) {
 	t.Helper()
 	assignments := []string{
-		"PATH=" + shSingleQuote(shellPath(t, bin)+":/usr/bin:/bin"),
+		// Fake bin first, then the caller's PATH (Nix/Guix coreutils), then a
+		// /usr/bin:/bin baseline: on Windows git-bash the coreutils release.sh
+		// needs live there but are absent from the Go process's PATH.
+		"PATH=" + shSingleQuote(shellPath(t, bin)+":"+bashPathList(t, os.Getenv("PATH"))+":/usr/bin:/bin"),
 		"BD_FAKE_FORMULA_SOURCE=" + shSingleQuote(shellPath(t, filepath.Join(repo, ".beads", "formulas", "beads-release.formula.toml"))),
 	}
 	for _, env := range extraEnv {
@@ -284,6 +281,24 @@ func shellPath(t *testing.T, path string) string {
 		}
 	}
 	return msysPath(path)
+}
+
+// bashPathList converts a host-style PATH value (entries separated by
+// os.PathListSeparator) into a Bash-visible, colon-separated PATH so the
+// caller's PATH is preserved (not just /usr/bin:/bin) when it is prepended
+// with the fake bd directory. This matters on systems such as Nix/Guix
+// where bash and core utilities live outside /usr/bin and /bin.
+func bashPathList(t *testing.T, hostPath string) string {
+	t.Helper()
+	entries := filepath.SplitList(hostPath)
+	converted := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if entry == "" {
+			continue
+		}
+		converted = append(converted, shellPath(t, entry))
+	}
+	return strings.Join(converted, ":")
 }
 
 func shSingleQuote(s string) string {

--- a/scripts/release_script_test.go
+++ b/scripts/release_script_test.go
@@ -19,7 +19,7 @@ echo "stale repo bd should not run" >&2
 exit 42
 `)
 
-	bin := filepath.Join(t.TempDir(), "bin")
+	bin := filepath.Join(repo, "bin")
 	if err := os.MkdirAll(bin, 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -44,7 +44,7 @@ exit 99
 func TestReleaseScriptInstalledBDSelectionDoesNotRequireJQ(t *testing.T) {
 	repo := copyReleaseScriptFixture(t)
 
-	bin := filepath.Join(t.TempDir(), "bin")
+	bin := filepath.Join(repo, "bin")
 	if err := os.MkdirAll(bin, 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -65,7 +65,7 @@ exit 99
 
 func TestReleaseScriptRejectsExplicitBDThatDoesNotResolveRepoFormula(t *testing.T) {
 	repo := copyReleaseScriptFixture(t)
-	bin := filepath.Join(t.TempDir(), "bin")
+	bin := filepath.Join(repo, "bin")
 	if err := os.MkdirAll(bin, 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -179,7 +179,7 @@ func copyReleaseScriptFixture(t *testing.T) string {
 		t.Fatal(err)
 	}
 
-	repo := t.TempDir()
+	repo := releaseTestTempDir(t)
 	if err := os.MkdirAll(filepath.Join(repo, "scripts"), 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -193,6 +193,20 @@ func copyReleaseScriptFixture(t *testing.T) string {
 		t.Fatal(err)
 	}
 	return repo
+}
+
+func releaseTestTempDir(t *testing.T) string {
+	t.Helper()
+	root := filepath.Join(sourceRepoRoot(t), ".tmp-release-tests")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	dir, err := os.MkdirTemp(root, "case-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	return dir
 }
 
 func sourceRepoRoot(t *testing.T) string {
@@ -211,19 +225,85 @@ func runReleaseDryRun(t *testing.T, repo, bin string) (string, error) {
 
 func runReleaseDryRunWithEnv(t *testing.T, repo, bin string, extraEnv ...string) (string, error) {
 	t.Helper()
-	cmd := exec.Command("bash", filepath.Join(repo, "scripts", "release.sh"), "1.2.3", "--dry-run")
+	assignments := []string{
+		"PATH=" + shSingleQuote(shellPath(t, bin)+":/usr/bin:/bin"),
+		"BD_FAKE_FORMULA_SOURCE=" + shSingleQuote(shellPath(t, filepath.Join(repo, ".beads", "formulas", "beads-release.formula.toml"))),
+	}
+	for _, env := range extraEnv {
+		key, value, ok := strings.Cut(env, "=")
+		if !ok {
+			continue
+		}
+		if key == "BD" && value != "" {
+			value = shellPath(t, value)
+		}
+		assignments = append(assignments, key+"="+shSingleQuote(value))
+	}
+	cmd := exec.Command("bash", "-lc", strings.Join(assignments, " ")+" bash scripts/release.sh 1.2.3 --dry-run")
 	cmd.Dir = repo
-	cmd.Env = append(os.Environ(), "PATH="+bin+string(os.PathListSeparator)+os.Getenv("PATH"))
-	cmd.Env = append(cmd.Env, extraEnv...)
 	out, err := cmd.CombinedOutput()
 	return string(out), err
 }
 
+func msysPath(path string) string {
+	path = filepath.Clean(path)
+	path = filepath.ToSlash(path)
+	if len(path) >= 3 && path[1] == ':' && path[2] == '/' {
+		return "/" + strings.ToLower(path[:1]) + path[2:]
+	}
+	return path
+}
+
+func shellPath(t *testing.T, path string) string {
+	t.Helper()
+	clean := filepath.Clean(path)
+	dir := clean
+	base := ""
+	if info, err := os.Stat(clean); err == nil && !info.IsDir() {
+		dir = filepath.Dir(clean)
+		base = filepath.Base(clean)
+	}
+	cmd := exec.Command("bash", "-lc", "pwd")
+	cmd.Dir = dir
+	if out, err := cmd.Output(); err == nil {
+		converted := strings.TrimSpace(string(out))
+		if converted != "" {
+			if base != "" {
+				return converted + "/" + filepath.ToSlash(base)
+			}
+			return converted
+		}
+	}
+	for _, tool := range []string{"wslpath", "cygpath"} {
+		out, err := exec.Command(tool, "-u", path).Output()
+		if err == nil {
+			converted := strings.TrimSpace(string(out))
+			if converted != "" {
+				return converted
+			}
+		}
+	}
+	return msysPath(path)
+}
+
+func shSingleQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'"'"'`) + "'"
+}
+
 func writeFakeBD(t *testing.T, bin, repo string) {
 	t.Helper()
-	source := filepath.Join(repo, ".beads", "formulas", "beads-release.formula.toml")
+	// Let bash itself canonicalize the formula path. release.sh derives
+	// FORMULA_PATH from `pwd`, which on Windows under Git Bash/MSYS produces
+	// mount-aware forms. Keep the fake bd path repo-relative so bash can
+	// `cd` there portably, then let `pwd` resolve it to the exact form that
+	// release.sh will compare against.
+	formulaDir := ".beads/formulas"
 	body := fmt.Sprintf(`#!/bin/sh
-SOURCE=%q
+if [ -n "${BD_FAKE_FORMULA_SOURCE:-}" ]; then
+  SOURCE="$BD_FAKE_FORMULA_SOURCE"
+else
+  SOURCE="$(cd %q && pwd)/beads-release.formula.toml"
+fi
 if [ "$1 $2 $3 $4" = "formula show beads-release --json" ]; then
   printf '%%s\n' "{\"source\":\"$SOURCE\"}"
   exit 0
@@ -235,7 +315,7 @@ if [ "$1 $2 $3" = "formula show beads-release" ]; then
 fi
 echo "unexpected fake bd invocation: $*" >&2
 exit 64
-`, source)
+`, formulaDir)
 	writeExecutable(t, filepath.Join(bin, "bd"), body)
 }
 
@@ -243,5 +323,17 @@ func writeExecutable(t *testing.T, path, body string) {
 	t.Helper()
 	if err := os.WriteFile(path, []byte(body), 0o755); err != nil {
 		t.Fatal(err)
+	}
+	if runtime.GOOS == "windows" {
+		chmodPath := shellPath(t, path)
+		if wd, err := os.Getwd(); err == nil {
+			if rel, relErr := filepath.Rel(wd, path); relErr == nil {
+				chmodPath = filepath.ToSlash(rel)
+			}
+		}
+		cmd := exec.Command("bash", "-lc", "chmod +x "+shSingleQuote(chmodPath))
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("chmod +x %s failed: %v\n%s", path, err, out)
+		}
 	}
 }


### PR DESCRIPTION
## Why

Port the live Windows test-hardening fixes from contributor PRs #3797, #3801, #3802, #3806, and #3812 onto current `main`.

This keeps the contributor value while avoiding stale-branch drift in the orphan-band queue. #3801 now conflicts because the Dolt server test moved to `internal/storage/dbproxy/server/doltserver_test.go`, so that fix is re-applied at the current path. The release-script test also needs Windows-hosted Bash path handling so the fake `bd` helper is selected reliably during tests.

## What Changed

- Let release-script tests use Bash-native paths for the fake `bd` helper.
- Stop Windows hook-script tests that rely on POSIX shebang execution until the runner supports it.
- Ensure Dolt server cleanup closes the log handle before Windows temp-dir removal.
- Tolerate bounded timeout kills in `TestEmbeddedInitConcurrent`.

## Validation

- `CGO_ENABLED=0 go test -tags gms_pure_go ./scripts`
- `CGO_ENABLED=0 go test -tags gms_pure_go ./cmd/bd -run '^TestUpdateCloseHookFiring$'`
- `go test ./internal/hooks -run '^(TestRunSync_Success|TestRunSync_ReceivesJSON|TestRunSync_Timeout|TestRunSync_HookFailure|TestRun_Async)$'`
- `go test ./internal/storage/dbproxy/server -run '^(TestDoltServer_|TestNewDoltServer_)'`
- `BEADS_TEST_EMBEDDED_DOLT=1 go test -tags 'cgo gms_pure_go' ./cmd/bd -run '^TestEmbeddedInitConcurrent$' -count=1`

Co-authored-by: sms <114885497+seanmartinsmith@users.noreply.github.com>
