### PR TITLE
feat(beads-mcp): add comment, comments, and note MCP tools

### DIFF
--- a/integrations/beads-mcp/CHANGELOG.md
+++ b/integrations/beads-mcp/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- New `comment`, `comments`, and `note` MCP tools, wrapping the existing
+  `bd comment` / `bd comments` / `bd note` CLI commands. Previously the MCP
+  server exposed no way to add or read comments, so MCP-only agents could only
+  overwrite the single `notes` field — `show()` reports `comment_count` but not
+  the bodies. `comment` leaves a durable, timestamped work trail, `comments`
+  reads them back, and `note` appends to the notes field.
+
 ### Fixed
 - `mcp__beads__show()` no longer crashes with `pydantic literal_error` when an
   issue has dependency types beyond the original four (`blocks`, `related`,

--- a/integrations/beads-mcp/README.md
+++ b/integrations/beads-mcp/README.md
@@ -218,6 +218,9 @@ await beads_ready_work(workspace_root="/Users/you/project-a")
 - `update` - Update issue (status, priority, design, notes, etc). Note: `status="closed"` or `status="open"` automatically route to `close` or `reopen` tools to respect approval workflows
 - `close` - Close completed issue
 - `dep` - Add dependency (blocks, related, parent-child, discovered-from)
+- `comment` - Add a durable, timestamped comment to an issue (a record of work/decisions)
+- `comments` - List all comments on an issue (`show` reports comment_count but not the bodies)
+- `note` - Append a note to an issue's notes field
 - `blocked` - Get blocked issues
 - `stats` - Get project statistics
 - `reopen` - Reopen a closed issue with optional reason

--- a/integrations/beads-mcp/src/beads_mcp/bd_client.py
+++ b/integrations/beads-mcp/src/beads_mcp/bd_client.py
@@ -10,14 +10,18 @@ from typing import Any
 
 from .config import load_config
 from .models import (
+    AddCommentParams,
     AddDependencyParams,
+    AddNoteParams,
     BlockedIssue,
     BlockedParams,
     ClaimIssueParams,
     CloseIssueParams,
+    Comment,
     CreateIssueParams,
     InitParams,
     Issue,
+    ListCommentsParams,
     ListIssuesParams,
     ReadyWorkParams,
     ReopenIssueParams,
@@ -139,6 +143,21 @@ class BdClientBase(ABC):
     @abstractmethod
     async def add_dependency(self, params: AddDependencyParams) -> None:
         """Add a dependency between issues."""
+        pass
+
+    @abstractmethod
+    async def add_comment(self, params: AddCommentParams) -> str:
+        """Add a comment to an issue."""
+        pass
+
+    @abstractmethod
+    async def list_comments(self, params: ListCommentsParams) -> list[Comment]:
+        """List comments on an issue."""
+        pass
+
+    @abstractmethod
+    async def add_note(self, params: AddNoteParams) -> str:
+        """Append a note to an issue's notes field."""
         pass
 
     @abstractmethod
@@ -674,6 +693,80 @@ class BdCliClient(BdClientBase):
                 stderr=stderr.decode(),
                 returncode=process.returncode or 1,
             )
+
+    async def _run_text_command(self, *args: str) -> str:
+        """Run a bd command that returns plain text (not JSON) and return stdout.
+
+        Used for subcommands like `comment`/`note` that print a confirmation
+        line rather than JSON. Mirrors _run_command's env and error handling.
+        """
+        cmd = [self.bd_path, *args, *self._global_flags()]
+
+        env = os.environ.copy()
+        if self.beads_dir:
+            env["BEADS_DIR"] = self.beads_dir
+        elif self.beads_db:
+            env["BEADS_DB"] = self.beads_db
+
+        try:
+            process = await asyncio.create_subprocess_exec(
+                *cmd,
+                stdin=asyncio.subprocess.DEVNULL,  # Prevent inheriting MCP's stdin
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                cwd=self._get_working_dir(),
+                env=env,
+            )
+            stdout, stderr = await process.communicate()
+        except FileNotFoundError as e:
+            raise BdNotFoundError(BdNotFoundError.installation_message(self.bd_path)) from e
+
+        if process.returncode != 0:
+            raise BdCommandError(
+                f"bd {args[0]} failed: {stderr.decode()}",
+                stderr=stderr.decode(),
+                returncode=process.returncode or 1,
+            )
+
+        return stdout.decode().strip()
+
+    async def add_comment(self, params: AddCommentParams) -> str:
+        """Add a comment to an issue via `bd comment <id> <text>`.
+
+        Args:
+            params: Comment parameters (issue_id, text)
+
+        Returns:
+            Confirmation message
+        """
+        await self._run_text_command("comment", params.issue_id, params.text)
+        return f"Added comment to {params.issue_id}"
+
+    async def list_comments(self, params: ListCommentsParams) -> list[Comment]:
+        """List comments on an issue via `bd comments <id>`.
+
+        Args:
+            params: Parameters containing the issue_id
+
+        Returns:
+            List of comments in chronological order
+        """
+        data = await self._run_command("comments", params.issue_id)
+        if not isinstance(data, list):
+            return []
+        return [Comment.model_validate(comment) for comment in data]
+
+    async def add_note(self, params: AddNoteParams) -> str:
+        """Append a note to an issue's notes field via `bd note <id> <text>`.
+
+        Args:
+            params: Note parameters (issue_id, text)
+
+        Returns:
+            Confirmation message
+        """
+        await self._run_text_command("note", params.issue_id, params.text)
+        return f"Appended note to {params.issue_id}"
 
     async def quickstart(self) -> str:
         """Get bd quickstart guide.

--- a/integrations/beads-mcp/src/beads_mcp/models.py
+++ b/integrations/beads-mcp/src/beads_mcp/models.py
@@ -326,3 +326,38 @@ class InitResult(BaseModel):
     database: str
     prefix: str
     message: str
+
+
+# =============================================================================
+# COMMENTS & NOTES
+# =============================================================================
+
+
+class Comment(BaseModel):
+    """A comment on an issue (matches `bd comments <id> --json`)."""
+
+    id: str
+    issue_id: str
+    author: str | None = None
+    text: str
+    created_at: datetime
+
+
+class AddCommentParams(BaseModel):
+    """Parameters for adding a comment to an issue."""
+
+    issue_id: str
+    text: str
+
+
+class ListCommentsParams(BaseModel):
+    """Parameters for listing comments on an issue."""
+
+    issue_id: str
+
+
+class AddNoteParams(BaseModel):
+    """Parameters for appending a note to an issue's notes field."""
+
+    issue_id: str
+    text: str

--- a/integrations/beads-mcp/src/beads_mcp/server.py
+++ b/integrations/beads-mcp/src/beads_mcp/server.py
@@ -28,6 +28,7 @@ from beads_mcp.models import (
     BlockedIssue,
     BriefDep,
     BriefIssue,
+    Comment,
     CompactedResult,
     DependencyType,
     Issue,
@@ -39,7 +40,9 @@ from beads_mcp.models import (
     Stats,
 )
 from beads_mcp.tools import (
+    beads_add_comment,
     beads_add_dependency,
+    beads_add_note,
     beads_blocked,
     beads_claim_issue,
     beads_close_issue,
@@ -48,6 +51,7 @@ from beads_mcp.tools import (
     beads_get_schema_info,
     beads_init,
     beads_inspect_migration,
+    beads_list_comments,
     beads_list_issues,
     beads_quickstart,
     beads_ready_work,
@@ -345,6 +349,9 @@ _TOOL_CATALOG = {
     "close": "Close/complete an issue",
     "reopen": "Reopen closed issues",
     "dep": "Add dependency between issues",
+    "comment": "Add a comment to an issue (durable, timestamped work record)",
+    "comments": "List all comments on an issue",
+    "note": "Append a note to an issue's notes field",
     "stats": "Get issue statistics",
     "blocked": "Show blocked issues and what blocks them",
     "context": "Manage workspace context (set, show, init)",
@@ -526,6 +533,38 @@ async def get_tool_info(tool_name: str) -> dict[str, Any]:
             },
             "returns": "Confirmation message",
             "example": "dep(issue_id='bd-f1a2', depends_on_id='bd-a1b2', dep_type='blocks')",
+        },
+        "comment": {
+            "name": "comment",
+            "description": "Add a durable, timestamped comment to an issue (a record of work/decisions)",
+            "parameters": {
+                "issue_id": "str (required)",
+                "text": "str (required) - human-readable summary of what changed/was decided/verified",
+                "workspace_root": "str (optional)",
+            },
+            "returns": "Confirmation message",
+            "example": "comment(issue_id='bd-a1b2', text='Fixed the race in worker.py; tests pass')",
+        },
+        "comments": {
+            "name": "comments",
+            "description": "List all comments on an issue (show reports comment_count but not the bodies)",
+            "parameters": {
+                "issue_id": "str (required)",
+                "workspace_root": "str (optional)",
+            },
+            "returns": "List of Comment {id, issue_id, author, text, created_at}",
+            "example": "comments(issue_id='bd-a1b2')",
+        },
+        "note": {
+            "name": "note",
+            "description": "Append a note to an issue's notes field (for a per-turn trail, prefer comment)",
+            "parameters": {
+                "issue_id": "str (required)",
+                "text": "str (required) - note text to append",
+                "workspace_root": "str (optional)",
+            },
+            "returns": "Confirmation message",
+            "example": "note(issue_id='bd-a1b2', text='Blocked on upstream PR #56954')",
         },
         "stats": {
             "name": "stats",
@@ -1234,6 +1273,56 @@ async def add_dependency(
         depends_on_id=depends_on_id,
         dep_type=dep_type,
     )
+
+
+@mcp.tool(
+    name="comment",
+    description=(
+        "Add a human-readable comment to an issue — a durable, timestamped record of what "
+        "changed, was decided, or verified, so nobody has to read the agent transcript. "
+        "Prefer this over overwriting notes; comments accumulate as a per-turn trail."
+    ),
+)
+@with_workspace
+@require_context
+async def comment(
+    issue_id: str,
+    text: str,
+    workspace_root: str | None = None,
+) -> str:
+    """Add a comment to an issue."""
+    return await beads_add_comment(issue_id=issue_id, text=text)
+
+
+@mcp.tool(
+    name="comments",
+    description="List all comments on an issue (show reports comment_count but not the comment bodies).",
+)
+@with_workspace
+async def comments(
+    issue_id: str,
+    workspace_root: str | None = None,
+) -> list[Comment]:
+    """List all comments on an issue in chronological order."""
+    return await beads_list_comments(issue_id=issue_id)
+
+
+@mcp.tool(
+    name="note",
+    description=(
+        "Append a note to an issue's notes field. For a per-turn, timestamped trail that "
+        "multiple actors can follow, prefer comment()."
+    ),
+)
+@with_workspace
+@require_context
+async def note(
+    issue_id: str,
+    text: str,
+    workspace_root: str | None = None,
+) -> str:
+    """Append a note to an issue's notes field."""
+    return await beads_add_note(issue_id=issue_id, text=text)
 
 
 @mcp.tool(

--- a/integrations/beads-mcp/src/beads_mcp/tools.py
+++ b/integrations/beads-mcp/src/beads_mcp/tools.py
@@ -10,17 +10,21 @@ from typing import Annotated, Any
 
 from .bd_client import BdClientBase, BdError, create_bd_client
 from .models import (
+    AddCommentParams,
     AddDependencyParams,
+    AddNoteParams,
     BlockedIssue,
     BlockedParams,
     ClaimIssueParams,
     CloseIssueParams,
+    Comment,
     CreateIssueParams,
     DependencyType,
     InitParams,
     Issue,
     IssueStatus,
     IssueType,
+    ListCommentsParams,
     ListIssuesParams,
     ReadyWorkParams,
     ReopenIssueParams,
@@ -613,6 +617,50 @@ async def beads_add_dependency(
         return f"Added dependency: {issue_id} depends on {depends_on_id} ({dep_type})"
     except BdError as e:
         return f"Error: {str(e)}"
+
+
+async def beads_add_comment(
+    issue_id: Annotated[str, "Issue ID (e.g., bd-1)"],
+    text: Annotated[str, "Comment text — a human-readable summary of work done, decisions, or verification"],
+) -> str:
+    """Add a comment to an issue.
+
+    Leave a durable, timestamped record of what you did, decided, or verified so
+    humans don't have to read the agent transcript to know what happened. `show`
+    reports comment_count but not the bodies — use beads_list_comments to read them.
+
+    Prefer a comment over overwriting `notes`: comments accumulate as a per-turn
+    trail, whereas the notes field is a single value that gets replaced.
+    """
+    client = await _get_client()
+    params = AddCommentParams(issue_id=issue_id, text=text)
+    return await client.add_comment(params)
+
+
+async def beads_list_comments(
+    issue_id: Annotated[str, "Issue ID (e.g., bd-1)"],
+) -> list[Comment]:
+    """List all comments on an issue in chronological order.
+
+    `show` returns comment_count but not the comment bodies; use this to read them.
+    """
+    client = await _get_client()
+    params = ListCommentsParams(issue_id=issue_id)
+    return await client.list_comments(params)
+
+
+async def beads_add_note(
+    issue_id: Annotated[str, "Issue ID (e.g., bd-1)"],
+    text: Annotated[str, "Note text to append to the issue's notes field"],
+) -> str:
+    """Append a note to an issue's notes field (`bd note`).
+
+    Notes are a single running field on the issue. For a per-turn, timestamped
+    trail that multiple actors can follow, prefer beads_add_comment.
+    """
+    client = await _get_client()
+    params = AddNoteParams(issue_id=issue_id, text=text)
+    return await client.add_note(params)
 
 
 async def beads_quickstart() -> str:

--- a/integrations/beads-mcp/tests/test_bd_client.py
+++ b/integrations/beads-mcp/tests/test_bd_client.py
@@ -7,10 +7,13 @@ import pytest
 
 from beads_mcp.bd_client import BdClient, BdCommandError, BdNotFoundError
 from beads_mcp.models import (
+    AddCommentParams,
     AddDependencyParams,
+    AddNoteParams,
     ClaimIssueParams,
     CloseIssueParams,
     CreateIssueParams,
+    ListCommentsParams,
     ListIssuesParams,
     ReadyWorkParams,
     ReopenIssueParams,
@@ -810,3 +813,104 @@ async def test_detect_pollution_clean_adds_flags(bd_client):
     with patch.object(bd_client, "_run_command", new=AsyncMock(return_value={})) as run:
         await bd_client.detect_pollution(clean=True)
     run.assert_awaited_once_with("doctor", "--check=pollution", "--clean", "--yes")
+
+
+@pytest.mark.asyncio
+async def test_add_comment(bd_client, mock_process):
+    """Test add_comment method (bd comment <id> <text>)."""
+    mock_process.communicate = AsyncMock(return_value=(b"Comment added\n", b""))
+
+    with patch("asyncio.create_subprocess_exec", return_value=mock_process) as mock_exec:
+        params = AddCommentParams(issue_id="bd-1", text="Working on this now")
+        result = await bd_client.add_comment(params)
+
+    assert "bd-1" in result
+    # Verify the comment subcommand and positional args were passed through
+    call_args = mock_exec.call_args[0]
+    assert "comment" in call_args
+    assert "bd-1" in call_args
+    assert "Working on this now" in call_args
+
+
+@pytest.mark.asyncio
+async def test_add_comment_failure(bd_client, mock_process):
+    """Test add_comment surfaces a bd failure."""
+    mock_process.returncode = 1
+    mock_process.communicate = AsyncMock(return_value=(b"", b"issue not found"))
+
+    with (
+        patch("asyncio.create_subprocess_exec", return_value=mock_process),
+        pytest.raises(BdCommandError, match="bd comment failed"),
+    ):
+        params = AddCommentParams(issue_id="bd-999", text="hi")
+        await bd_client.add_comment(params)
+
+
+@pytest.mark.asyncio
+async def test_add_comment_not_found(bd_client):
+    """Test add_comment when bd executable not found."""
+    with (
+        patch("asyncio.create_subprocess_exec", side_effect=FileNotFoundError()),
+        pytest.raises(BdNotFoundError, match="bd CLI not found"),
+    ):
+        params = AddCommentParams(issue_id="bd-1", text="hi")
+        await bd_client.add_comment(params)
+
+
+@pytest.mark.asyncio
+async def test_add_note(bd_client, mock_process):
+    """Test add_note method (bd note <id> <text>)."""
+    mock_process.communicate = AsyncMock(return_value=(b"Note appended\n", b""))
+
+    with patch("asyncio.create_subprocess_exec", return_value=mock_process) as mock_exec:
+        params = AddNoteParams(issue_id="bd-1", text="Fixed the flaky test")
+        result = await bd_client.add_note(params)
+
+    assert "bd-1" in result
+    call_args = mock_exec.call_args[0]
+    assert "note" in call_args
+    assert "bd-1" in call_args
+
+
+@pytest.mark.asyncio
+async def test_list_comments(bd_client, mock_process):
+    """Test list_comments parses `bd comments --json` output."""
+    comments_data = [
+        {
+            "id": "c-1",
+            "issue_id": "bd-1",
+            "author": "alice",
+            "text": "First comment",
+            "created_at": "2025-01-25T00:00:00Z",
+        },
+        {
+            "id": "c-2",
+            "issue_id": "bd-1",
+            "author": None,
+            "text": "Second comment",
+            "created_at": "2025-01-25T01:00:00Z",
+        },
+    ]
+    mock_process.communicate = AsyncMock(return_value=(json.dumps(comments_data).encode(), b""))
+
+    with patch("asyncio.create_subprocess_exec", return_value=mock_process):
+        params = ListCommentsParams(issue_id="bd-1")
+        comments = await bd_client.list_comments(params)
+
+    assert len(comments) == 2
+    assert comments[0].id == "c-1"
+    assert comments[0].author == "alice"
+    assert comments[1].author is None
+    assert comments[1].text == "Second comment"
+
+
+@pytest.mark.asyncio
+async def test_list_comments_invalid_response(bd_client, mock_process):
+    """Test list_comments returns [] for a non-list response."""
+    mock_process.communicate = AsyncMock(return_value=(json.dumps({"error": "nope"}).encode(), b""))
+
+    with patch("asyncio.create_subprocess_exec", return_value=mock_process):
+        params = ListCommentsParams(issue_id="bd-1")
+        comments = await bd_client.list_comments(params)
+
+    assert comments == []

--- a/integrations/beads-mcp/tests/test_bd_client_integration.py
+++ b/integrations/beads-mcp/tests/test_bd_client_integration.py
@@ -9,10 +9,13 @@ import pytest
 
 from beads_mcp.bd_client import BdClient, BdCommandError
 from beads_mcp.models import (
+    AddCommentParams,
     AddDependencyParams,
+    AddNoteParams,
     ClaimIssueParams,
     CloseIssueParams,
     CreateIssueParams,
+    ListCommentsParams,
     ListIssuesParams,
     ReadyWorkParams,
     ReopenIssueParams,
@@ -302,6 +305,33 @@ async def test_add_dependency(bd_client):
 
     assert len(shown.dependencies) > 0
     assert any(dep.id == issue2.id for dep in shown.dependencies)
+
+
+@pytest.mark.asyncio
+async def test_comments_and_notes(bd_client):
+    """Test comment/comments/note round-trip with real bd."""
+    issue = await bd_client.create(CreateIssueParams(title="Comment target", priority=1, issue_type="task"))
+
+    # Add two comments and read them back
+    result = await bd_client.add_comment(AddCommentParams(issue_id=issue.id, text="First comment"))
+    assert issue.id in result
+    await bd_client.add_comment(AddCommentParams(issue_id=issue.id, text="Second comment"))
+
+    comments = await bd_client.list_comments(ListCommentsParams(issue_id=issue.id))
+    assert len(comments) >= 2
+    texts = [c.text for c in comments]
+    assert "First comment" in texts
+    assert "Second comment" in texts
+    assert all(c.issue_id == issue.id for c in comments)
+    # Chronological order: first added comes first
+    assert texts.index("First comment") < texts.index("Second comment")
+
+    # Append a note and verify it lands in the notes field
+    note_result = await bd_client.add_note(AddNoteParams(issue_id=issue.id, text="A durable note"))
+    assert issue.id in note_result
+
+    shown = await bd_client.show(ShowIssueParams(issue_id=issue.id))
+    assert "A durable note" in (shown.notes or "")
 
 
 @pytest.mark.asyncio

--- a/integrations/beads-mcp/tests/test_mcp_server_integration.py
+++ b/integrations/beads-mcp/tests/test_mcp_server_integration.py
@@ -406,6 +406,37 @@ async def test_add_dependency_tool(mcp_client):
 
 
 @pytest.mark.asyncio
+async def test_comment_comments_and_note_tools(mcp_client):
+    """Test comment, comments, and note tools end to end."""
+    import json
+
+    issue_result = await mcp_client.call_tool(
+        "create", {"title": "Comment tool target", "priority": 1, "issue_type": "task", "brief": False}
+    )
+    issue = json.loads(issue_result.content[0].text)
+
+    # Add a comment
+    comment_result = await mcp_client.call_tool("comment", {"issue_id": issue["id"], "text": "Comment via MCP"})
+    assert issue["id"] in comment_result.content[0].text
+
+    # Read comments back
+    comments_result = await mcp_client.call_tool("comments", {"issue_id": issue["id"]})
+    comments = json.loads(comments_result.content[0].text)
+    if isinstance(comments, dict):
+        comments = [comments]
+    assert any(c["text"] == "Comment via MCP" for c in comments)
+    assert all(c["issue_id"] == issue["id"] for c in comments)
+
+    # Append a note and verify via show
+    note_result = await mcp_client.call_tool("note", {"issue_id": issue["id"], "text": "Note via MCP"})
+    assert issue["id"] in note_result.content[0].text
+
+    show_result = await mcp_client.call_tool("show", {"issue_id": issue["id"]})
+    shown = json.loads(show_result.content[0].text)
+    assert "Note via MCP" in (shown.get("notes") or "")
+
+
+@pytest.mark.asyncio
 async def test_create_with_all_fields(mcp_client):
     """Test create_issue with all optional fields."""
     import json

--- a/integrations/beads-mcp/tests/test_tools.py
+++ b/integrations/beads-mcp/tests/test_tools.py
@@ -5,14 +5,17 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from beads_mcp.models import BlockedIssue, Issue, Stats, StatsSummary
+from beads_mcp.models import BlockedIssue, Comment, Issue, Stats, StatsSummary
 from beads_mcp.tools import (
+    beads_add_comment,
     beads_add_dependency,
+    beads_add_note,
     beads_blocked,
     beads_claim_issue,
     beads_close_issue,
     beads_create_issue,
     beads_init,
+    beads_list_comments,
     beads_list_issues,
     beads_quickstart,
     beads_ready_work,
@@ -276,6 +279,122 @@ async def test_beads_add_dependency_error():
 
     assert "Error" in result
     mock_client.add_dependency.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_beads_add_comment_success():
+    """Test beads_add_comment tool success."""
+    mock_client = AsyncMock()
+    mock_client.add_comment = AsyncMock(return_value="Added comment to bd-1")
+
+    with patch("beads_mcp.tools._get_client", return_value=mock_client):
+        result = await beads_add_comment(issue_id="bd-1", text="Fixed the race; tests pass")
+
+    assert result == "Added comment to bd-1"
+    mock_client.add_comment.assert_called_once()
+    params = mock_client.add_comment.call_args[0][0]
+    assert params.issue_id == "bd-1"
+    assert params.text == "Fixed the race; tests pass"
+
+
+@pytest.mark.asyncio
+async def test_beads_add_comment_error_propagates():
+    """Test that a BdError from the client propagates out of beads_add_comment."""
+    from beads_mcp.bd_client import BdError
+
+    mock_client = AsyncMock()
+    mock_client.add_comment = AsyncMock(side_effect=BdError("Issue not found: bd-404"))
+
+    with (
+        patch("beads_mcp.tools._get_client", return_value=mock_client),
+        pytest.raises(BdError, match="not found"),
+    ):
+        await beads_add_comment(issue_id="bd-404", text="orphan comment")
+
+    mock_client.add_comment.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_beads_list_comments_success():
+    """Test beads_list_comments tool success."""
+    comments = [
+        Comment(
+            id="c-1",
+            issue_id="bd-1",
+            author="agent",
+            text="First comment",
+            created_at=datetime(2026, 7, 7, 12, 0, 0, tzinfo=timezone.utc),
+        ),
+        Comment(
+            id="c-2",
+            issue_id="bd-1",
+            author=None,
+            text="Second comment",
+            created_at=datetime(2026, 7, 7, 12, 5, 0, tzinfo=timezone.utc),
+        ),
+    ]
+    mock_client = AsyncMock()
+    mock_client.list_comments = AsyncMock(return_value=comments)
+
+    with patch("beads_mcp.tools._get_client", return_value=mock_client):
+        result = await beads_list_comments(issue_id="bd-1")
+
+    assert len(result) == 2
+    assert result[0].text == "First comment"
+    assert result[1].author is None
+    mock_client.list_comments.assert_called_once()
+    params = mock_client.list_comments.call_args[0][0]
+    assert params.issue_id == "bd-1"
+
+
+@pytest.mark.asyncio
+async def test_beads_list_comments_error_propagates():
+    """Test that a BdError from the client propagates out of beads_list_comments."""
+    from beads_mcp.bd_client import BdError
+
+    mock_client = AsyncMock()
+    mock_client.list_comments = AsyncMock(side_effect=BdError("Issue not found: bd-404"))
+
+    with (
+        patch("beads_mcp.tools._get_client", return_value=mock_client),
+        pytest.raises(BdError, match="not found"),
+    ):
+        await beads_list_comments(issue_id="bd-404")
+
+    mock_client.list_comments.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_beads_add_note_success():
+    """Test beads_add_note tool success."""
+    mock_client = AsyncMock()
+    mock_client.add_note = AsyncMock(return_value="Appended note to bd-1")
+
+    with patch("beads_mcp.tools._get_client", return_value=mock_client):
+        result = await beads_add_note(issue_id="bd-1", text="Blocked on upstream PR")
+
+    assert result == "Appended note to bd-1"
+    mock_client.add_note.assert_called_once()
+    params = mock_client.add_note.call_args[0][0]
+    assert params.issue_id == "bd-1"
+    assert params.text == "Blocked on upstream PR"
+
+
+@pytest.mark.asyncio
+async def test_beads_add_note_error_propagates():
+    """Test that a BdError from the client propagates out of beads_add_note."""
+    from beads_mcp.bd_client import BdError
+
+    mock_client = AsyncMock()
+    mock_client.add_note = AsyncMock(side_effect=BdError("Issue not found: bd-404"))
+
+    with (
+        patch("beads_mcp.tools._get_client", return_value=mock_client),
+        pytest.raises(BdError, match="not found"),
+    ):
+        await beads_add_note(issue_id="bd-404", text="orphan note")
+
+    mock_client.add_note.assert_called_once()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What

Adds three MCP tools to `beads-mcp`, each wrapping an existing `bd` CLI command:

| Tool | Wraps | Purpose |
|------|-------|---------|
| `comment` | `bd comment <id> <text>` | Add a durable, timestamped comment |
| `comments` | `bd comments <id> --json` | Read an issue's comments back |
| `note` | `bd note <id> <text>` | Append to the issue's `notes` field |

## Why

The MCP server currently exposes no way to add or read comments. MCP-only agents can therefore only overwrite the single `notes` field via `update`, and `show()` returns `comment_count` but not the comment bodies.

In multi-agent setups this means agents that drive the board purely through the MCP leave no readable per-turn trail of what they did — a human (or another agent) has to read the raw transcript or dig through files to find out. The `bd` CLI already supports `comment` / `comments` / `note`; this just surfaces them through the MCP so agents that don't shell out to the CLI reach parity.

## How

- `comment` / `note` reuse a small `_run_text_command` helper, since those `bd` subcommands print a confirmation line rather than JSON (mirrors the existing `add_dependency` approach).
- `comments` parses `bd comments <id> --json` into a new `Comment` model (`id`, `issue_id`, `author`, `text`, `created_at`).
- New param models: `AddCommentParams`, `ListCommentsParams`, `AddNoteParams`.
- Registered in `server.py` with the same `@with_workspace` / `@require_context` decorators as the other write tools, and added to `_TOOL_CATALOG` / `get_tool_info`.

Purely additive — no existing behavior changes.

## Testing

- `ruff check` clean.
- Added unit tests for `add_comment`, `add_note`, and `list_comments` (success, failure, not-found, invalid-response) mirroring the existing `add_dependency` tests. `pytest tests/test_bd_client.py tests/test_tools.py tests/test_config.py` → 87 passed.
- Manual end-to-end against a real `bd` database: `comment` / `note` / `comments` round-trip correctly, and the `Comment` model parses real `bd comments --json` output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
