### PR TITLE
feat(prune): prune and purge proxied-server support

### DIFF
--- a/cmd/bd/delete_proxied_server.go
+++ b/cmd/bd/delete_proxied_server.go
@@ -78,6 +78,7 @@ func runDeleteProxiedServer(cmd *cobra.Command, ctx context.Context, args []stri
 
 	res, err := issueUC.DeleteIssues(ctx, domain.DeleteIssuesParams{
 		IDs:                  in.ids,
+		Cascade:              true,
 		UpdateTextReferences: true,
 	}, actor)
 	if err != nil {
@@ -105,8 +106,9 @@ func runDeleteProxiedPreview(ctx context.Context, issueUC domain.IssueUseCase, i
 	}
 
 	res, err := issueUC.DeleteIssues(ctx, domain.DeleteIssuesParams{
-		IDs:    in.ids,
-		DryRun: true,
+		IDs:     in.ids,
+		Cascade: true,
+		DryRun:  true,
 	}, actor)
 	if err != nil {
 		FatalErrorRespectJSON("preview counts: %v", err)

--- a/cmd/bd/prune_proxied_integration_test.go
+++ b/cmd/bd/prune_proxied_integration_test.go
@@ -1,0 +1,165 @@
+//go:build cgo
+
+package main
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func issueRowExists(t *testing.T, db *sql.DB, id string) bool {
+	t.Helper()
+	var n int
+	if err := db.QueryRowContext(context.Background(),
+		"SELECT COUNT(*) FROM issues WHERE id = ?", id).Scan(&n); err != nil {
+		t.Fatalf("count issue %s: %v", id, err)
+	}
+	return n > 0
+}
+
+func bdProxiedPrune(t *testing.T, bd, dir string, args ...string) string {
+	t.Helper()
+	fullArgs := append([]string{"prune"}, args...)
+	stdout, stderr, err := bdProxiedRunBuffers(t, bd, dir, fullArgs...)
+	if err != nil {
+		t.Fatalf("bd prune %s failed: %v\nstdout:\n%s\nstderr:\n%s",
+			strings.Join(args, " "), err, stdout, stderr)
+	}
+	return stdout
+}
+
+func bdProxiedPruneFail(t *testing.T, bd, dir string, args ...string) string {
+	t.Helper()
+	fullArgs := append([]string{"prune"}, args...)
+	stdout, stderr, err := bdProxiedRunBuffers(t, bd, dir, fullArgs...)
+	if err == nil {
+		t.Fatalf("expected bd prune %s to fail, got:\nstdout:\n%s\nstderr:\n%s",
+			strings.Join(args, " "), stdout, stderr)
+	}
+	return stdout + stderr
+}
+
+func TestProxiedServerPrune(t *testing.T) {
+	requireProxiedServerEnv(t)
+	bd := buildEmbeddedBD(t)
+
+	t.Run("requires_filter", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "prf")
+		out := bdProxiedPruneFail(t, bd, p.dir)
+		if !strings.Contains(out, "requires --older-than or --pattern") {
+			t.Errorf("expected requires-filter error, got: %s", out)
+		}
+	})
+
+	t.Run("dry_run_deletes_nothing", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "pdr")
+		issue := bdProxiedCreate(t, bd, p.dir, "Prune me")
+		bdProxiedClose(t, bd, p.dir, issue.ID)
+		out := bdProxiedPrune(t, bd, p.dir, "--pattern", "*", "--dry-run")
+		if !strings.Contains(out, "Would prune") {
+			t.Errorf("dry-run output missing 'Would prune': %s", out)
+		}
+		db := openProxiedDB(t, p)
+		if !issueRowExists(t, db, issue.ID) {
+			t.Errorf("dry-run must not delete %s", issue.ID)
+		}
+	})
+
+	t.Run("force_deletes_closed", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "pfd")
+		issue := bdProxiedCreate(t, bd, p.dir, "Delete me")
+		bdProxiedClose(t, bd, p.dir, issue.ID)
+		bdProxiedPrune(t, bd, p.dir, "--pattern", "*", "--force")
+		db := openProxiedDB(t, p)
+		if issueRowExists(t, db, issue.ID) {
+			t.Errorf("closed bead %s should be pruned", issue.ID)
+		}
+	})
+
+	t.Run("skips_open", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "pso")
+		open := bdProxiedCreate(t, bd, p.dir, "Still open")
+		closed := bdProxiedCreate(t, bd, p.dir, "Now closed")
+		bdProxiedClose(t, bd, p.dir, closed.ID)
+		bdProxiedPrune(t, bd, p.dir, "--pattern", "*", "--force")
+		db := openProxiedDB(t, p)
+		if !issueRowExists(t, db, open.ID) {
+			t.Errorf("open bead %s must survive prune", open.ID)
+		}
+		if issueRowExists(t, db, closed.ID) {
+			t.Errorf("closed bead %s should be pruned", closed.ID)
+		}
+	})
+
+	t.Run("reference_aware_skip", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "pras")
+		referenced := bdProxiedCreate(t, bd, p.dir, "Cited decision")
+		_ = bdProxiedCreate(t, bd, p.dir, "Open citer",
+			"--description", "per "+referenced.ID+" we decided X")
+		bdProxiedClose(t, bd, p.dir, referenced.ID)
+
+		out := bdProxiedPrune(t, bd, p.dir, "--pattern", "*", "--force")
+		if !strings.Contains(out, "protected by open-bead references") {
+			t.Errorf("expected referenced-protection note, got: %s", out)
+		}
+		db := openProxiedDB(t, p)
+		if !issueRowExists(t, db, referenced.ID) {
+			t.Errorf("referenced closed bead %s must be protected from prune", referenced.ID)
+		}
+	})
+
+	t.Run("ignore_references_deletes_referenced", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "pir")
+		referenced := bdProxiedCreate(t, bd, p.dir, "Cited decision")
+		_ = bdProxiedCreate(t, bd, p.dir, "Open citer",
+			"--description", "per "+referenced.ID+" we decided X")
+		bdProxiedClose(t, bd, p.dir, referenced.ID)
+
+		bdProxiedPrune(t, bd, p.dir, "--pattern", "*", "--force", "--ignore-references")
+		db := openProxiedDB(t, p)
+		if issueRowExists(t, db, referenced.ID) {
+			t.Errorf("--ignore-references should delete referenced bead %s", referenced.ID)
+		}
+	})
+
+	t.Run("json_output", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "pjo")
+		a := bdProxiedCreate(t, bd, p.dir, "JSON prune A")
+		b := bdProxiedCreate(t, bd, p.dir, "JSON prune B")
+		bdProxiedClose(t, bd, p.dir, a.ID, b.ID)
+		stdout, stderr, err := bdProxiedRunBuffers(t, bd, p.dir, "prune", "--json", "--pattern", "*", "--force")
+		if err != nil {
+			t.Fatalf("bd prune --json failed: %v\nstdout:\n%s\nstderr:\n%s", err, stdout, stderr)
+		}
+		start := strings.Index(stdout, "{")
+		if start < 0 {
+			t.Fatalf("no JSON object in prune output:\n%s", stdout)
+		}
+		var stats map[string]any
+		if err := json.Unmarshal([]byte(stdout[start:]), &stats); err != nil {
+			t.Fatalf("parse prune JSON: %v\nraw: %s", err, stdout[start:])
+		}
+		if got, ok := stats["pruned_count"].(float64); !ok || int(got) != 2 {
+			t.Errorf("pruned_count: got %v, want 2", stats["pruned_count"])
+		}
+	})
+
+	t.Run("commits_deletion", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "pcd")
+		issue := bdProxiedCreate(t, bd, p.dir, "Commit prune")
+		bdProxiedClose(t, bd, p.dir, issue.ID)
+		db := openProxiedDB(t, p)
+		before := readDoltHead(t, db)
+		bdProxiedPrune(t, bd, p.dir, "--pattern", "*", "--force")
+		if got := readDoltLogCountSince(t, db, before); got < 1 {
+			t.Errorf("prune should create a dolt commit, got %d new commits", got)
+		}
+		msg := readDoltLogTopMessage(t, db)
+		if !strings.HasPrefix(msg, "bd: prune ") {
+			t.Errorf("dolt commit message should begin with 'bd: prune ', got: %q", msg)
+		}
+	})
+}

--- a/cmd/bd/prune_proxied_integration_test.go
+++ b/cmd/bd/prune_proxied_integration_test.go
@@ -130,6 +130,10 @@ func TestProxiedServerPrune(t *testing.T) {
 		a := bdProxiedCreate(t, bd, p.dir, "JSON prune A")
 		b := bdProxiedCreate(t, bd, p.dir, "JSON prune B")
 		bdProxiedClose(t, bd, p.dir, a.ID, b.ID)
+		referenced := bdProxiedCreate(t, bd, p.dir, "JSON cited decision")
+		bdProxiedCreate(t, bd, p.dir, "JSON open citing bead",
+			"--description", "per "+referenced.ID+" we decided X")
+		bdProxiedClose(t, bd, p.dir, referenced.ID)
 		stdout, stderr, err := bdProxiedRunBuffers(t, bd, p.dir, "prune", "--json", "--pattern", "*", "--force")
 		if err != nil {
 			t.Fatalf("bd prune --json failed: %v\nstdout:\n%s\nstderr:\n%s", err, stdout, stderr)
@@ -144,6 +148,13 @@ func TestProxiedServerPrune(t *testing.T) {
 		}
 		if got, ok := stats["pruned_count"].(float64); !ok || int(got) != 2 {
 			t.Errorf("pruned_count: got %v, want 2", stats["pruned_count"])
+		}
+		if got, ok := stats["referenced_skipped"].(float64); !ok || int(got) != 1 {
+			t.Errorf("referenced_skipped: got %v, want 1", stats["referenced_skipped"])
+		}
+		sample, ok := stats["referenced_ids_sample"].([]any)
+		if !ok || len(sample) != 1 || sample[0] != referenced.ID {
+			t.Errorf("referenced_ids_sample: got %v, want [%s]", stats["referenced_ids_sample"], referenced.ID)
 		}
 	})
 

--- a/cmd/bd/purge.go
+++ b/cmd/bd/purge.go
@@ -164,6 +164,10 @@ func buildReferencedSet(ctx context.Context, st storage.DoltStorage, candidateID
 // both `bd purge` (ephemeral scope) and `bd prune` (non-ephemeral scope).
 // The caller's scope controls the filter, messaging, and safety gate.
 func runPurgeOrPrune(cmd *cobra.Command, scope purgeScope) error {
+	if usesProxiedServer() {
+		return runPurgeOrPruneProxied(cmd, scope)
+	}
+
 	CheckReadonly(scope.cmdName)
 
 	force, _ := cmd.Flags().GetBool("force")

--- a/cmd/bd/purge_proxied_server.go
+++ b/cmd/bd/purge_proxied_server.go
@@ -1,0 +1,346 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/steveyegge/beads/internal/storage/domain"
+	"github.com/steveyegge/beads/internal/storage/uow"
+	"github.com/steveyegge/beads/internal/types"
+	"github.com/steveyegge/beads/internal/ui"
+)
+
+// runPurgeOrPruneProxied is the proxied-server counterpart of runPurgeOrPrune.
+// It drives the same delete-closed-beads flow through a UnitOfWork and the
+// domain use cases instead of the embedded store.
+func runPurgeOrPruneProxied(cmd *cobra.Command, scope purgeScope) error {
+	CheckReadonly(scope.cmdName)
+
+	force, _ := cmd.Flags().GetBool("force")
+	dryRun, _ := cmd.Flags().GetBool("dry-run")
+	olderThan, _ := cmd.Flags().GetString("older-than")
+	pattern, _ := cmd.Flags().GetString("pattern")
+
+	if scope.requireFilter && olderThan == "" && pattern == "" {
+		return HandleErrorWithHint(
+			fmt.Sprintf("bd %s requires --older-than or --pattern", scope.cmdName),
+			"Protects against accidental bulk deletion. Use `--pattern '*'` to\n"+
+				"  include all closed beads in this scope, or `--older-than 1d`\n"+
+				"  / `--pattern '<glob>'` to narrow the deletion.")
+	}
+
+	if uowProvider == nil {
+		return HandleErrorRespectJSON("proxied-server UOW provider not initialized")
+	}
+	ctx := rootCtx
+	uw, err := uowProvider.NewUOW(ctx)
+	if err != nil {
+		return HandleErrorRespectJSON("open unit of work: %v", err)
+	}
+	defer uw.Close(ctx)
+
+	statusClosed := types.StatusClosed
+	ephemeralFlag := scope.ephemeralOnly
+	filter := types.IssueFilter{
+		Status:    &statusClosed,
+		Ephemeral: &ephemeralFlag,
+	}
+
+	var cutoff *time.Time
+	if olderThan != "" {
+		days, err := parseHumanDuration(olderThan)
+		if err != nil {
+			return HandleErrorRespectJSON("invalid --older-than value %q: %v", olderThan, err)
+		}
+		cutoffTime := time.Now().UTC().AddDate(0, 0, -days)
+		cutoff = &cutoffTime
+		filter.ClosedBefore = cutoff
+	}
+
+	page, err := uw.IssueUseCase().SearchIssues(ctx, "", filter)
+	if err != nil {
+		return HandleErrorRespectJSON("listing issues: %v", err)
+	}
+	closedIssues := page.Items
+
+	if pattern != "" {
+		var matched []*types.Issue
+		for _, issue := range closedIssues {
+			if ok, _ := filepath.Match(pattern, issue.ID); ok {
+				matched = append(matched, issue)
+			}
+		}
+		closedIssues = matched
+	}
+
+	var safetyStats closedDeletionCandidateStats
+	closedIssues, safetyStats = filterClosedDeletionCandidates(closedIssues, cutoff)
+	pinnedCount := safetyStats.PinnedSkipped
+	warnClosedDeletionSafetySkips(safetyStats)
+
+	referencedCount := 0
+	var referencedSample []string
+	if scope.cmdName == "prune" && !scope.ignoreReferences {
+		candidateIDs := make(map[string]bool, len(closedIssues))
+		for _, iss := range closedIssues {
+			candidateIDs[iss.ID] = true
+		}
+		refSet, err := buildReferencedSetProxied(ctx, uw, candidateIDs)
+		if err != nil {
+			return HandleErrorRespectJSON("scanning open beads for references: %v", err)
+		}
+		nonReferenced := closedIssues[:0]
+		for _, iss := range closedIssues {
+			if refSet[iss.ID] {
+				referencedCount++
+				if len(referencedSample) < 100 {
+					referencedSample = append(referencedSample, iss.ID)
+				}
+			} else {
+				nonReferenced = append(nonReferenced, iss)
+			}
+		}
+		closedIssues = nonReferenced
+	}
+
+	if len(closedIssues) == 0 {
+		return emitProxiedPruneEmpty(scope, olderThan, pattern, referencedCount, referencedSample)
+	}
+
+	issueIDs := make([]string, len(closedIssues))
+	for i, issue := range closedIssues {
+		issueIDs[i] = issue.ID
+	}
+
+	if dryRun {
+		result, derr := uw.IssueUseCase().DeleteIssues(ctx, domain.DeleteIssuesParams{
+			IDs:    issueIDs,
+			DryRun: true,
+		}, actor)
+		return emitProxiedPruneDryRun(scope, issueIDs, result, derr, pinnedCount, referencedCount, referencedSample)
+	}
+
+	if !force {
+		return emitProxiedPruneConfirm(scope, issueIDs, olderThan, pattern, pinnedCount, referencedCount)
+	}
+
+	result, err := uw.IssueUseCase().DeleteIssues(ctx, domain.DeleteIssuesParams{
+		IDs: issueIDs,
+	}, actor)
+	if err != nil {
+		return HandleErrorRespectJSON("%s failed: %v", scope.cmdName, err)
+	}
+
+	if err := uw.Commit(ctx, fmt.Sprintf("bd: %s %d bead(s)", scope.cmdName, result.DeletedCount)); err != nil && !isDoltNothingToCommit(err) {
+		return HandleErrorRespectJSON("commit: %v", err)
+	}
+
+	return emitProxiedPruneResult(scope, result, pinnedCount, referencedCount)
+}
+
+// buildReferencedSetProxied mirrors buildReferencedSet using the domain use
+// cases behind a UnitOfWork. It scans every non-done bead's description,
+// notes, and comments for literal occurrences of any candidate ID.
+func buildReferencedSetProxied(ctx context.Context, uw uow.UnitOfWork, candidateIDs map[string]bool) (map[string]bool, error) {
+	if len(candidateIDs) == 0 {
+		return nil, nil
+	}
+	ids := make([]string, 0, len(candidateIDs))
+	for id := range candidateIDs {
+		ids = append(ids, regexp.QuoteMeta(id))
+	}
+	sort.Strings(ids)
+	pat := regexp.MustCompile(`\b(` + strings.Join(ids, "|") + `)\b`)
+
+	notClosedStatuses := []types.Status{
+		types.StatusOpen,
+		types.StatusInProgress,
+		types.StatusBlocked,
+		types.StatusDeferred,
+		types.StatusPinned,
+		types.StatusHooked,
+	}
+	customStatuses, err := uw.ConfigUseCase().GetCustomStatuses(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("reading custom statuses for reference scan: %w", err)
+	}
+	for _, cs := range customStatuses {
+		if cs.Category != types.CategoryDone {
+			notClosedStatuses = append(notClosedStatuses, types.Status(cs.Name))
+		}
+	}
+	notClosed := types.IssueFilter{Statuses: notClosedStatuses}
+	page, err := uw.IssueUseCase().SearchIssues(ctx, "", notClosed)
+	if err != nil {
+		return nil, err
+	}
+	openBeads := page.Items
+
+	openIDs := make([]string, len(openBeads))
+	for i, iss := range openBeads {
+		openIDs[i] = iss.ID
+	}
+	commentsByIssue, err := uw.CommentUseCase().GetCommentsForIssues(ctx, openIDs)
+	if err != nil {
+		return nil, err
+	}
+
+	refSet := make(map[string]bool)
+	scanText := func(text string) {
+		for _, m := range pat.FindAllString(text, -1) {
+			refSet[m] = true
+		}
+	}
+
+	for _, iss := range openBeads {
+		scanText(iss.Description)
+		scanText(iss.Notes)
+		for _, c := range commentsByIssue[iss.ID] {
+			scanText(c.Text)
+		}
+	}
+	return refSet, nil
+}
+
+func emitProxiedPruneEmpty(scope purgeScope, olderThan, pattern string, referencedCount int, referencedSample []string) error {
+	if jsonOutput {
+		stats := map[string]interface{}{
+			scope.countKey: 0,
+			"message":      fmt.Sprintf("No %ss to %s", scope.subjectNoun, scope.cmdName),
+		}
+		if scope.cmdName == "prune" {
+			stats["referenced_skipped"] = referencedCount
+			stats["referenced_count"] = referencedCount
+			if len(referencedSample) > 0 {
+				stats["referenced_ids_sample"] = referencedSample
+			}
+		}
+		return outputJSON(stats)
+	}
+	msg := fmt.Sprintf("No %ss to %s", scope.subjectNoun, scope.cmdName)
+	if olderThan != "" {
+		msg += fmt.Sprintf(" (older than %s)", olderThan)
+	}
+	if pattern != "" {
+		msg += fmt.Sprintf(" (matching %q)", pattern)
+	}
+	fmt.Println(msg)
+	if referencedCount > 0 {
+		fmt.Println(ui.MutedStyle.Render(fmt.Sprintf(
+			"  (%d closed bead(s) protected by open-bead references — use --ignore-references to override)",
+			referencedCount)))
+	}
+	return nil
+}
+
+func emitProxiedPruneDryRun(scope purgeScope, issueIDs []string, result domain.DeleteIssuesResult, resultErr error, pinnedCount, referencedCount int, referencedSample []string) error {
+	if jsonOutput {
+		stats := map[string]interface{}{
+			"dry_run":            true,
+			scope.dryRunCountKey: len(issueIDs),
+			"dependencies":       0,
+			"labels":             0,
+			"events":             0,
+		}
+		if resultErr == nil {
+			stats["dependencies"] = result.DependenciesCount
+			stats["labels"] = result.LabelsCount
+			stats["events"] = result.EventsCount
+		}
+		if pinnedCount > 0 {
+			stats["pinned_skipped"] = pinnedCount
+		}
+		if scope.cmdName == "prune" {
+			stats["referenced_skipped"] = referencedCount
+			stats["referenced_count"] = referencedCount
+			if len(referencedSample) > 0 {
+				stats["referenced_ids_sample"] = referencedSample
+			}
+		}
+		return outputJSON(stats)
+	}
+	fmt.Printf("Would %s %d %s(s)\n", scope.cmdName, len(issueIDs), scope.subjectNoun)
+	if resultErr == nil {
+		fmt.Printf("  Dependencies: %d\n", result.DependenciesCount)
+		fmt.Printf("  Labels:       %d\n", result.LabelsCount)
+		fmt.Printf("  Events:       %d\n", result.EventsCount)
+	}
+	if pinnedCount > 0 {
+		fmt.Printf("  Pinned (skipped): %d\n", pinnedCount)
+	}
+	if referencedCount > 0 {
+		fmt.Printf("  %s   %d\n", ui.MutedStyle.Render("Referenced (skipped):"), referencedCount)
+		sample := referencedSample
+		if len(sample) > 5 {
+			sample = sample[:5]
+		}
+		idStrs := make([]string, len(sample))
+		for i, id := range sample {
+			idStrs[i] = ui.IDStyle.Render(id)
+		}
+		suffix := ""
+		if referencedCount > 5 {
+			suffix = ui.MutedStyle.Render(", ...")
+		}
+		fmt.Printf("  %s %s%s\n", ui.MutedStyle.Render("Referenced IDs (sample):"), strings.Join(idStrs, ", "), suffix)
+	}
+	fmt.Printf("\n(Dry-run mode — no changes made)\n")
+	return nil
+}
+
+func emitProxiedPruneConfirm(scope purgeScope, issueIDs []string, olderThan, pattern string, pinnedCount, referencedCount int) error {
+	fmt.Printf("Found %d %s(s) to %s\n", len(issueIDs), scope.subjectNoun, scope.cmdName)
+	if pinnedCount > 0 {
+		fmt.Printf("Skipping %d pinned bead(s)\n", pinnedCount)
+	}
+	if referencedCount > 0 {
+		fmt.Println(ui.MutedStyle.Render(fmt.Sprintf("Skipping %d referenced bead(s)", referencedCount)))
+	}
+	hint := fmt.Sprintf("bd %s --force", scope.cmdName)
+	if olderThan != "" {
+		hint += " --older-than " + olderThan
+	}
+	if pattern != "" {
+		hint += " --pattern " + pattern
+	}
+	return HandleErrorWithHint(
+		fmt.Sprintf("would %s %d bead(s)", scope.cmdName, len(issueIDs)),
+		fmt.Sprintf("Use --force to confirm or --dry-run to preview.\n  %s", hint))
+}
+
+func emitProxiedPruneResult(scope purgeScope, result domain.DeleteIssuesResult, pinnedCount, referencedCount int) error {
+	if jsonOutput {
+		stats := map[string]interface{}{
+			scope.countKey: result.DeletedCount,
+			"dependencies": result.DependenciesCount,
+			"labels":       result.LabelsCount,
+			"events":       result.EventsCount,
+		}
+		if pinnedCount > 0 {
+			stats["pinned_skipped"] = pinnedCount
+		}
+		if scope.cmdName == "prune" {
+			stats["referenced_skipped"] = referencedCount
+			stats["referenced_count"] = referencedCount
+		}
+		return outputJSON(stats)
+	}
+	fmt.Printf("%s %s %d %s(s)\n", ui.RenderPass("✓"), capitalize(scope.pastTense), result.DeletedCount, scope.subjectNoun)
+	fmt.Printf("  Dependencies removed: %d\n", result.DependenciesCount)
+	fmt.Printf("  Labels removed:       %d\n", result.LabelsCount)
+	fmt.Printf("  Events removed:       %d\n", result.EventsCount)
+	if pinnedCount > 0 {
+		fmt.Printf("  Pinned (skipped):     %d\n", pinnedCount)
+	}
+	if referencedCount > 0 {
+		fmt.Printf("  %s %d\n", ui.MutedStyle.Render("Referenced (skipped):"), referencedCount)
+	}
+	return nil
+}

--- a/cmd/bd/purge_proxied_server.go
+++ b/cmd/bd/purge_proxied_server.go
@@ -142,7 +142,7 @@ func runPurgeOrPruneProxied(cmd *cobra.Command, scope purgeScope) error {
 		return HandleErrorRespectJSON("commit: %v", err)
 	}
 
-	return emitProxiedPruneResult(scope, result, pinnedCount, referencedCount)
+	return emitProxiedPruneResult(scope, result, pinnedCount, referencedCount, referencedSample)
 }
 
 // buildReferencedSetProxied mirrors buildReferencedSet using the domain use
@@ -315,7 +315,7 @@ func emitProxiedPruneConfirm(scope purgeScope, issueIDs []string, olderThan, pat
 		fmt.Sprintf("Use --force to confirm or --dry-run to preview.\n  %s", hint))
 }
 
-func emitProxiedPruneResult(scope purgeScope, result domain.DeleteIssuesResult, pinnedCount, referencedCount int) error {
+func emitProxiedPruneResult(scope purgeScope, result domain.DeleteIssuesResult, pinnedCount, referencedCount int, referencedSample []string) error {
 	if jsonOutput {
 		stats := map[string]interface{}{
 			scope.countKey: result.DeletedCount,
@@ -329,6 +329,9 @@ func emitProxiedPruneResult(scope purgeScope, result domain.DeleteIssuesResult, 
 		if scope.cmdName == "prune" {
 			stats["referenced_skipped"] = referencedCount
 			stats["referenced_count"] = referencedCount
+			if len(referencedSample) > 0 {
+				stats["referenced_ids_sample"] = referencedSample
+			}
 		}
 		return outputJSON(stats)
 	}

--- a/internal/storage/domain/issue.go
+++ b/internal/storage/domain/issue.go
@@ -83,6 +83,7 @@ type ReopenRowResult struct {
 
 type DeleteIssuesParams struct {
 	IDs                  []string
+	Cascade              bool
 	DryRun               bool
 	UpdateTextReferences bool
 }

--- a/internal/storage/domain/issue_delete.go
+++ b/internal/storage/domain/issue_delete.go
@@ -15,6 +15,7 @@ func (u *issueUseCaseImpl) DeleteIssue(ctx context.Context, id, actor string) (D
 	}
 	return u.deleteMany(ctx, DeleteIssuesParams{
 		IDs:                  []string{id},
+		Cascade:              true,
 		UpdateTextReferences: true,
 	}, actor)
 }
@@ -25,6 +26,7 @@ func (u *issueUseCaseImpl) DeleteWisp(ctx context.Context, id, actor string) (De
 	}
 	return u.deleteMany(ctx, DeleteIssuesParams{
 		IDs:                  []string{id},
+		Cascade:              true,
 		UpdateTextReferences: true,
 	}, actor)
 }
@@ -50,9 +52,13 @@ func (u *issueUseCaseImpl) deleteMany(ctx context.Context, params DeleteIssuesPa
 		return DeleteIssuesResult{}, nil
 	}
 
-	allIDs, err := u.issueRepo.FindAllDependents(ctx, params.IDs)
-	if err != nil {
-		return DeleteIssuesResult{}, fmt.Errorf("delete: cascade expansion: %w", err)
+	allIDs := params.IDs
+	if params.Cascade {
+		expanded, err := u.issueRepo.FindAllDependents(ctx, params.IDs)
+		if err != nil {
+			return DeleteIssuesResult{}, fmt.Errorf("delete: cascade expansion: %w", err)
+		}
+		allIDs = expanded
 	}
 	if len(allIDs) == 0 {
 		return DeleteIssuesResult{}, nil


### PR DESCRIPTION
## What

Adds proxied-server support for `bd prune` (and, since they share the code path, `bd purge`) by routing the delete-closed-beads flow through a `UnitOfWork` and the domain use cases instead of the embedded store.

## How

- **Domain (`DeleteIssuesParams` gains `Cascade`)**: `deleteMany` previously always expanded to dependents via `FindAllDependents` (cascade-always). It now only expands when `params.Cascade` is set; otherwise it operates on the exact `IDs`. The `DeleteIssue`/`DeleteWisp` convenience wrappers and the existing `bd delete` proxied callers set `Cascade: true` to preserve their current always-cascade contract. Prune sets `Cascade: false` to delete exactly the matched closed beads — matching the embedded store's `cascade=false, force=true` semantics.
- **Dispatch**: `runPurgeOrPrune` forks to a new `runPurgeOrPruneProxied` when `usesProxiedServer()`.
- **New handler (`purge_proxied_server.go`)**: mirrors the embedded flow over the UOW — `IssueUseCase().SearchIssues` for candidates, `ConfigUseCase().GetCustomStatuses` + batched `CommentUseCase().GetCommentsForIssues` for the reference-aware skip scan, and `IssueUseCase().DeleteIssues(Cascade:false)` for dry-run counts and the real delete, followed by `uw.Commit`. Reuses the existing pure helpers (`parseHumanDuration`, `filterClosedDeletionCandidates`, safety-skip warnings, output formatting).

No new domain use-case methods were needed — `SearchIssues`, `GetCustomStatuses`, and `GetCommentsForIssue(s)` already existed; only `DeleteIssuesParams` was extended.

## Testing

`prune_proxied_integration_test.go` (runs with `BEADS_TEST_PROXIED_SERVER=1`, gated behind the existing `bd init --proxied-server` guard like the other proxied integration tests): requires-filter, dry-run no-op, force-deletes-closed, skips-open, reference-aware-skip, `--ignore-references`, JSON output, and dolt-commit — all green. Domain delete unit tests and embedded `prune`/`purge`/`delete` tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)