### PR TITLE
fix(jira): use UTC suffix in JQL updated timestamp filter

### DIFF
--- a/internal/jira/tracker.go
+++ b/internal/jira/tracker.go
@@ -207,7 +207,7 @@ func (t *Tracker) FetchIssues(ctx context.Context, opts tracker.FetchOptions) ([
 
 	// Incremental sync
 	if opts.Since != nil {
-		jql += fmt.Sprintf(" AND updated >= %q", opts.Since.Format("2006-01-02 15:04"))
+		jql += fmt.Sprintf(` AND updated >= "%s"`, opts.Since.UTC().Format("2006-01-02 15:04 UTC"))
 	}
 
 	jql += " ORDER BY updated DESC"


### PR DESCRIPTION
## Why

Replacement for #3789. That PR's fix is correct and the bug is still live on
`main`, but the PR's branch sits on a pre-history-re-root commit graph that
cannot be merged or rebased normally. Rather than ask @jmdaly to redo the
work, this cherry-picks the original commit as-is onto current `main`.

## What

`bd jira sync --pull` builds an incremental JQL filter like:

```
AND updated >= "2026-05-07 12:00"
```

using a bare, timezone-less timestamp. Per Atlassian's JQL docs, a
timezone-less datetime literal is interpreted in the searching user's Jira
profile timezone, not UTC. Since the stored `last_sync` value is UTC, any
user whose Jira profile timezone is behind UTC (for example US Eastern,
UTC-4) gets a cutoff shifted several hours into the future, silently
dropping all recently-updated issues from the pull.

Confirmed present on `main` at `internal/jira/tracker.go:210` prior to this
change.

The fix is a one-line change: call `.UTC()` on the timestamp and format it
with an explicit `UTC` suffix, which Jira JQL accepts as an unambiguous
timezone qualifier.

## Preserved from #3789

- The original commit, unchanged, with authorship intact
  (`John Daly <john.daly@ouster.io>`) and a `Co-authored-by:` trailer.
- The root-cause diagnosis and reproduction steps from the original PR
  description.

Closes #3788.
Supersedes #3789 (same fix; opened as a replacement only because the source
branch predates a history re-root and can't be merged in place).

Thanks to @jmdaly for the precise root-cause diagnosis, citation of the
Atlassian JQL timezone semantics, and a minimal, correct fix.

## Testing

- `CGO_ENABLED=0 go build -tags gms_pure_go ./...`
- `CGO_ENABLED=0 go test -tags gms_pure_go ./internal/jira/...` — passes

_claude-fable-5-medium on behalf of matt wilkie_
