### PR TITLE
feat(linear): linear.exclude_id_prefix and linear.exclude_id_patterns (hand-port of #3759)

### DIFF
--- a/cmd/bd/linear.go
+++ b/cmd/bd/linear.go
@@ -123,6 +123,18 @@ Type Filtering (--push only):
   --parent TICKET           Only push this ticket and its descendants
   --relations               Import Linear relations as bd dependencies on pull
 
+Persistent push-direction ID filters (workflow artifacts, sandbox beads, etc.):
+  bd config set linear.exclude_id_prefix "hw-mol-"
+  bd config set linear.exclude_id_patterns "-wisp-,sandbox-,scratch-"
+
+  exclude_id_prefix is a single case-sensitive prefix on the bead ID.
+  exclude_id_patterns is a comma-separated list of case-sensitive substrings
+  (matched anywhere in the ID). Both are combined as a union: a bead
+  matching either rule is skipped from push (no create, no update). Beads
+  with an existing external_ref that NOW match are silently skipped on
+  future syncs; the Linear-side issue persists — archive/delete it manually
+  if desired.
+
 Conflict Resolution:
   By default, newer timestamp wins. Override with:
   --prefer-local    Always prefer local beads version
@@ -349,6 +361,7 @@ func runLinearSync(cmd *cobra.Command, args []string) error {
 	for _, t := range excludeTypes {
 		opts.ExcludeTypes = append(opts.ExcludeTypes, types.IssueType(strings.ToLower(t)))
 	}
+	applyLinearExcludeIDConfig(ctx, store, &opts)
 	if !includeEphemeral {
 		opts.ExcludeEphemeral = true
 	}
@@ -1180,6 +1193,37 @@ func getLinearIDMode(ctx context.Context) string {
 		return "hash"
 	}
 	return mode
+}
+
+// linearConfigReader is the minimal slice of storage.Storage that the
+// linear-config helpers depend on. Lets tests inject a fake without
+// spinning up a Dolt server.
+type linearConfigReader interface {
+	GetConfig(ctx context.Context, key string) (string, error)
+}
+
+// applyLinearExcludeIDConfig reads linear.exclude_id_prefix and
+// linear.exclude_id_patterns from the given config reader and applies them
+// to opts. Both keys are push-direction-only filters; see the help text on
+// linearSyncCmd for the user-facing semantics.
+//
+// Empty values are no-ops. Patterns are comma-split, trimmed, with empty
+// entries dropped. If reader is nil (no store configured), this is a no-op.
+func applyLinearExcludeIDConfig(ctx context.Context, reader linearConfigReader, opts *tracker.SyncOptions) {
+	if reader == nil || opts == nil {
+		return
+	}
+	if v, _ := reader.GetConfig(ctx, "linear.exclude_id_prefix"); v != "" {
+		opts.ExcludeIDPrefix = strings.TrimSpace(v)
+	}
+	if v, _ := reader.GetConfig(ctx, "linear.exclude_id_patterns"); v != "" {
+		for _, p := range strings.Split(v, ",") {
+			p = strings.TrimSpace(p)
+			if p != "" {
+				opts.ExcludeIDPatterns = append(opts.ExcludeIDPatterns, p)
+			}
+		}
+	}
 }
 
 // getLinearHashLength returns the configured hash length for Linear imports.

--- a/cmd/bd/linear_test.go
+++ b/cmd/bd/linear_test.go
@@ -10,11 +10,13 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/steveyegge/beads/internal/linear"
+	"github.com/steveyegge/beads/internal/tracker"
 	"github.com/steveyegge/beads/internal/types"
 )
 
@@ -1767,4 +1769,90 @@ func TestIsValidUUID(t *testing.T) {
 			}
 		})
 	}
+}
+
+// fakeLinearConfigReader is a test double for linearConfigReader that
+// returns values from an in-memory map. Unset keys return "" with no error
+// (matches storage.Storage's behavior for missing config keys).
+type fakeLinearConfigReader map[string]string
+
+func (f fakeLinearConfigReader) GetConfig(_ context.Context, key string) (string, error) {
+	return f[key], nil
+}
+
+// TestApplyLinearExcludeIDConfig covers the bd-ee0 config-read path that
+// wires linear.exclude_id_prefix / linear.exclude_id_patterns into
+// SyncOptions. The engine-side filter behavior (applying the rules to
+// individual issues) is tested by the TestEngineExcludeID* family in
+// internal/tracker/engine_test.go; this test exercises the cmd/bd surface.
+func TestApplyLinearExcludeIDConfig(t *testing.T) {
+	tests := []struct {
+		name         string
+		cfg          fakeLinearConfigReader
+		wantPrefix   string
+		wantPatterns []string
+	}{
+		{
+			name:         "both keys set",
+			cfg:          fakeLinearConfigReader{"linear.exclude_id_prefix": "hw-mol-", "linear.exclude_id_patterns": "-wisp-,sandbox-,scratch-"},
+			wantPrefix:   "hw-mol-",
+			wantPatterns: []string{"-wisp-", "sandbox-", "scratch-"},
+		},
+		{
+			name:         "prefix only",
+			cfg:          fakeLinearConfigReader{"linear.exclude_id_prefix": "hw-mol-"},
+			wantPrefix:   "hw-mol-",
+			wantPatterns: nil,
+		},
+		{
+			name:         "patterns only",
+			cfg:          fakeLinearConfigReader{"linear.exclude_id_patterns": "wisp-,sandbox-"},
+			wantPrefix:   "",
+			wantPatterns: []string{"wisp-", "sandbox-"},
+		},
+		{
+			name:         "patterns trimmed and empty entries skipped",
+			cfg:          fakeLinearConfigReader{"linear.exclude_id_patterns": "  a  , ,  b  ,"},
+			wantPrefix:   "",
+			wantPatterns: []string{"a", "b"},
+		},
+		{
+			name:         "prefix trimmed",
+			cfg:          fakeLinearConfigReader{"linear.exclude_id_prefix": "  hw-mol-  "},
+			wantPrefix:   "hw-mol-",
+			wantPatterns: nil,
+		},
+		{
+			name:         "neither key set is no-op",
+			cfg:          fakeLinearConfigReader{},
+			wantPrefix:   "",
+			wantPatterns: nil,
+		},
+		{
+			name:         "empty string values treated as unset",
+			cfg:          fakeLinearConfigReader{"linear.exclude_id_prefix": "", "linear.exclude_id_patterns": ""},
+			wantPrefix:   "",
+			wantPatterns: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var opts tracker.SyncOptions
+			applyLinearExcludeIDConfig(context.Background(), tt.cfg, &opts)
+			if opts.ExcludeIDPrefix != tt.wantPrefix {
+				t.Errorf("ExcludeIDPrefix = %q, want %q", opts.ExcludeIDPrefix, tt.wantPrefix)
+			}
+			if !reflect.DeepEqual(opts.ExcludeIDPatterns, tt.wantPatterns) {
+				t.Errorf("ExcludeIDPatterns = %v, want %v", opts.ExcludeIDPatterns, tt.wantPatterns)
+			}
+		})
+	}
+}
+
+// TestApplyLinearExcludeIDConfig_NilSafe verifies the helper is safe to
+// call with nil reader or nil opts (defensive guards).
+func TestApplyLinearExcludeIDConfig_NilSafe(t *testing.T) {
+	var opts tracker.SyncOptions
+	applyLinearExcludeIDConfig(context.Background(), nil, &opts)                    // must not panic
+	applyLinearExcludeIDConfig(context.Background(), fakeLinearConfigReader{}, nil) // must not panic
 }

--- a/internal/tracker/engine.go
+++ b/internal/tracker/engine.go
@@ -1395,6 +1395,20 @@ func (e *Engine) shouldPushIssue(issue *types.Issue, opts SyncOptions) bool {
 		}
 	}
 
+	// ExcludeIDPrefix: case-sensitive prefix match on the bead ID. Filters
+	// workflow-artifact beads (e.g. "hw-mol-foo") from external sync without
+	// requiring them to share a type or label.
+	if opts.ExcludeIDPrefix != "" && strings.HasPrefix(issue.ID, opts.ExcludeIDPrefix) {
+		return false
+	}
+	// ExcludeIDPatterns: case-sensitive substring match anywhere in the ID.
+	// Union with ExcludeIDPrefix — matching either rule excludes the issue.
+	for _, p := range opts.ExcludeIDPatterns {
+		if p != "" && strings.Contains(issue.ID, p) {
+			return false
+		}
+	}
+
 	if opts.State == "open" && issue.Status == types.StatusClosed {
 		return false
 	}

--- a/internal/tracker/engine_test.go
+++ b/internal/tracker/engine_test.go
@@ -2797,3 +2797,245 @@ func TestEngineWarnCollectsMessages(t *testing.T) {
 		t.Errorf("expected 3 total warnings, got %d", len(engine.warnings))
 	}
 }
+
+// TestEngineExcludeIDPrefix verifies that beads whose ID starts with the
+// configured prefix are skipped from push. Mirrors mayor's bd-ee0
+// houmanoids_www use case where `hw-mol-*` workflow-artifact beads must
+// not propagate to Linear regardless of issue type.
+func TestEngineExcludeIDPrefix(t *testing.T) {
+	ctx := context.Background()
+	store := newTestStore(t)
+	defer store.Close()
+
+	for _, id := range []string{"hw-mol-foo", "hw-mol-bar", "hw-real-1", "hw-real-2"} {
+		issue := &types.Issue{
+			ID: id, Title: "Issue " + id, Status: types.StatusOpen, IssueType: types.TypeTask, Priority: 2,
+		}
+		if err := store.CreateIssue(ctx, issue, "test-actor"); err != nil {
+			t.Fatalf("CreateIssue(%s) error: %v", id, err)
+		}
+	}
+
+	tracker := newMockTracker("test")
+	engine := NewEngine(tracker, store, "test-actor")
+
+	result, err := engine.Sync(ctx, SyncOptions{Push: true, ExcludeIDPrefix: "hw-mol-"})
+	if err != nil {
+		t.Fatalf("Sync() error: %v", err)
+	}
+	if !result.Success {
+		t.Fatalf("Sync() not successful: %s", result.Error)
+	}
+	if len(tracker.created) != 2 {
+		t.Errorf("created %d issues; want 2 (only hw-real-*)", len(tracker.created))
+	}
+	for _, i := range tracker.created {
+		if strings.HasPrefix(i.ID, "hw-mol-") {
+			t.Errorf("hw-mol- bead leaked through filter: %s", i.ID)
+		}
+	}
+}
+
+// TestEngineExcludeIDPatterns verifies the comma-separated substring filter:
+// beads whose ID contains ANY listed substring (anywhere in the ID) are
+// skipped.
+func TestEngineExcludeIDPatterns(t *testing.T) {
+	ctx := context.Background()
+	store := newTestStore(t)
+	defer store.Close()
+
+	for _, id := range []string{"hw-mol-x", "hw-wisp-y", "hw-sandbox-z", "hw-real-keep"} {
+		issue := &types.Issue{
+			ID: id, Title: "Issue " + id, Status: types.StatusOpen, IssueType: types.TypeTask, Priority: 2,
+		}
+		if err := store.CreateIssue(ctx, issue, "test-actor"); err != nil {
+			t.Fatalf("CreateIssue(%s) error: %v", id, err)
+		}
+	}
+
+	tracker := newMockTracker("test")
+	engine := NewEngine(tracker, store, "test-actor")
+
+	result, err := engine.Sync(ctx, SyncOptions{
+		Push:              true,
+		ExcludeIDPatterns: []string{"mol-", "wisp-", "sandbox-"},
+	})
+	if err != nil {
+		t.Fatalf("Sync() error: %v", err)
+	}
+	if !result.Success {
+		t.Fatalf("Sync() not successful: %s", result.Error)
+	}
+	if len(tracker.created) != 1 || tracker.created[0].ID != "hw-real-keep" {
+		ids := make([]string, len(tracker.created))
+		for i, c := range tracker.created {
+			ids[i] = c.ID
+		}
+		t.Errorf("created IDs = %v, want [hw-real-keep]", ids)
+	}
+}
+
+// TestEngineExcludeIDBoth verifies union semantics: a bead matching EITHER
+// the prefix rule OR the patterns rule is excluded.
+func TestEngineExcludeIDBoth(t *testing.T) {
+	ctx := context.Background()
+	store := newTestStore(t)
+	defer store.Close()
+
+	for _, id := range []string{
+		"hw-mol-via-prefix",  // matches prefix
+		"hw-evt-via-pattern", // matches pattern (-evt-)
+		"hw-mol-evt-both",    // matches both
+		"hw-real-keep",       // matches neither — pushed
+	} {
+		issue := &types.Issue{
+			ID: id, Title: "Issue " + id, Status: types.StatusOpen, IssueType: types.TypeTask, Priority: 2,
+		}
+		if err := store.CreateIssue(ctx, issue, "test-actor"); err != nil {
+			t.Fatalf("CreateIssue(%s) error: %v", id, err)
+		}
+	}
+
+	tracker := newMockTracker("test")
+	engine := NewEngine(tracker, store, "test-actor")
+
+	result, err := engine.Sync(ctx, SyncOptions{
+		Push:              true,
+		ExcludeIDPrefix:   "hw-mol-",
+		ExcludeIDPatterns: []string{"-evt-"},
+	})
+	if err != nil {
+		t.Fatalf("Sync() error: %v", err)
+	}
+	if !result.Success {
+		t.Fatalf("Sync() not successful: %s", result.Error)
+	}
+	if len(tracker.created) != 1 || tracker.created[0].ID != "hw-real-keep" {
+		ids := make([]string, len(tracker.created))
+		for i, c := range tracker.created {
+			ids[i] = c.ID
+		}
+		t.Errorf("created IDs = %v, want [hw-real-keep]", ids)
+	}
+}
+
+// TestEngineExcludeID_AlreadySynced verifies that a bead with an existing
+// external_ref but matching an exclude rule produces NO update API call.
+// The Linear-side issue is left alone (the spec calls this out: users who
+// add a rule for an already-synced bead must manually archive/delete the
+// remote issue if desired).
+func TestEngineExcludeID_AlreadySynced(t *testing.T) {
+	ctx := context.Background()
+	store := newTestStore(t)
+	defer store.Close()
+
+	// A previously-synced bead — has external_ref. After the new exclude
+	// rule lands, it must not be updated.
+	stale := &types.Issue{
+		ID: "hw-mol-stale", Title: "Previously synced", Status: types.StatusOpen,
+		IssueType: types.TypeTask, Priority: 2,
+		ExternalRef: strPtr("https://test.test/EXT-STALE"),
+	}
+	if err := store.CreateIssue(ctx, stale, "test-actor"); err != nil {
+		t.Fatalf("CreateIssue() error: %v", err)
+	}
+
+	tracker := newMockTracker("test")
+	tracker.issues = []TrackerIssue{
+		{ID: "EXT-STALE", Identifier: "EXT-STALE", Title: "Old remote title"},
+	}
+	engine := NewEngine(tracker, store, "test-actor")
+
+	result, err := engine.Sync(ctx, SyncOptions{Push: true, ExcludeIDPrefix: "hw-mol-"})
+	if err != nil {
+		t.Fatalf("Sync() error: %v", err)
+	}
+	if !result.Success {
+		t.Fatalf("Sync() not successful: %s", result.Error)
+	}
+	if len(tracker.updated) != 0 {
+		t.Errorf("excluded already-synced bead was updated: %v", tracker.updated)
+	}
+	if len(tracker.created) != 0 {
+		t.Errorf("excluded already-synced bead was created: %d", len(tracker.created))
+	}
+}
+
+// TestEngineDryRunRespectsExcludeID verifies that --dry-run does not print
+// "Would create" / "Would update" lines for excluded beads. Asserts via the
+// engine's stats: an excluded bead increments Skipped, not Created or
+// Updated.
+func TestEngineDryRunRespectsExcludeID(t *testing.T) {
+	ctx := context.Background()
+	store := newTestStore(t)
+	defer store.Close()
+
+	for _, id := range []string{"hw-mol-skip", "hw-real-1"} {
+		issue := &types.Issue{
+			ID: id, Title: "Issue " + id, Status: types.StatusOpen, IssueType: types.TypeTask, Priority: 2,
+		}
+		if err := store.CreateIssue(ctx, issue, "test-actor"); err != nil {
+			t.Fatalf("CreateIssue(%s) error: %v", id, err)
+		}
+	}
+
+	tracker := newMockTracker("test")
+	engine := NewEngine(tracker, store, "test-actor")
+
+	result, err := engine.Sync(ctx, SyncOptions{Push: true, DryRun: true, ExcludeIDPrefix: "hw-mol-"})
+	if err != nil {
+		t.Fatalf("Sync() error: %v", err)
+	}
+	if !result.Success {
+		t.Fatalf("Sync() not successful: %s", result.Error)
+	}
+	// Dry-run should NOT have called the tracker (even for the unexcluded one,
+	// since DryRun=true short-circuits the API call).
+	if len(tracker.created) != 0 {
+		t.Errorf("dry-run created issues: %d", len(tracker.created))
+	}
+	// PushStats.Created counts intended creates; the excluded bead must NOT
+	// count there. Only hw-real-1 should be classified as a would-be create.
+	if result.PushStats.Created != 1 {
+		t.Errorf("PushStats.Created = %d, want 1 (only hw-real-1 should be a would-be create)", result.PushStats.Created)
+	}
+	if result.PushStats.Skipped != 1 {
+		t.Errorf("PushStats.Skipped = %d, want 1 (hw-mol-skip should be Skipped)", result.PushStats.Skipped)
+	}
+}
+
+// TestShouldPushIssue_ExcludeIDDirect tests the filter logic in isolation,
+// without the storage layer. Runs locally without Dolt/Docker.
+func TestShouldPushIssue_ExcludeIDDirect(t *testing.T) {
+	tracker := newMockTracker("test")
+	engine := NewEngine(tracker, nil, "test-actor")
+
+	tests := []struct {
+		name string
+		opts SyncOptions
+		id   string
+		want bool
+	}{
+		{"prefix match excludes", SyncOptions{ExcludeIDPrefix: "hw-mol-"}, "hw-mol-foo", false},
+		{"prefix non-match passes", SyncOptions{ExcludeIDPrefix: "hw-mol-"}, "hw-real-1", true},
+		{"empty prefix is no-op", SyncOptions{ExcludeIDPrefix: ""}, "hw-mol-foo", true},
+		{"prefix is case-sensitive", SyncOptions{ExcludeIDPrefix: "hw-mol-"}, "HW-MOL-foo", true},
+		{"pattern match anywhere excludes", SyncOptions{ExcludeIDPatterns: []string{"-wisp-"}}, "hw-wisp-x", false},
+		{"pattern match middle excludes", SyncOptions{ExcludeIDPatterns: []string{"sandbox"}}, "x-sandbox-y", false},
+		{"pattern non-match passes", SyncOptions{ExcludeIDPatterns: []string{"sandbox"}}, "hw-real-1", true},
+		{"empty pattern entry skipped", SyncOptions{ExcludeIDPatterns: []string{"", "wisp-"}}, "hw-wisp-x", false},
+		{"all empty patterns no-op", SyncOptions{ExcludeIDPatterns: []string{""}}, "hw-mol-foo", true},
+		{"prefix and pattern union: prefix match", SyncOptions{ExcludeIDPrefix: "hw-mol-", ExcludeIDPatterns: []string{"-evt-"}}, "hw-mol-foo", false},
+		{"prefix and pattern union: pattern match", SyncOptions{ExcludeIDPrefix: "hw-mol-", ExcludeIDPatterns: []string{"-evt-"}}, "hw-evt-foo", false},
+		{"prefix and pattern union: neither", SyncOptions{ExcludeIDPrefix: "hw-mol-", ExcludeIDPatterns: []string{"-evt-"}}, "hw-real-foo", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			issue := &types.Issue{ID: tt.id, IssueType: types.TypeTask, Status: types.StatusOpen}
+			got := engine.shouldPushIssue(issue, tt.opts)
+			if got != tt.want {
+				t.Errorf("shouldPushIssue(%q, %+v) = %v, want %v", tt.id, tt.opts, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/tracker/types.go
+++ b/internal/tracker/types.go
@@ -82,6 +82,15 @@ type SyncOptions struct {
 	TypeFilter []types.IssueType
 	// ExcludeTypes excludes specific issue types from sync.
 	ExcludeTypes []types.IssueType
+	// ExcludeIDPrefix skips issues whose ID starts with this prefix (case-
+	// sensitive). Used to filter workflow-artifact beads (e.g. "hw-mol-")
+	// from external sync. Empty means no prefix filter.
+	ExcludeIDPrefix string
+	// ExcludeIDPatterns skips issues whose ID contains any of these
+	// substrings (case-sensitive, anywhere in the ID). Empty means no
+	// pattern filter. Combined with ExcludeIDPrefix as a union (matches
+	// either rule → excluded).
+	ExcludeIDPatterns []string
 	// ExcludeEphemeral skips ephemeral/wisp issues from push (default behavior in CLI).
 	ExcludeEphemeral bool
 	// ParentID limits push to this beads issue and all its descendants via


### PR DESCRIPTION
## Summary

Replacement PR that lands the feature from #3759 (author @aphexcx) on current `main`: two push-direction-only config keys that filter beads from Linear sync by their local ID.

- `linear.exclude_id_prefix` - single case-sensitive prefix on the bead ID.
- `linear.exclude_id_patterns` - comma-separated case-sensitive substrings, matched anywhere in the ID; empty entries dropped.

Both combine as a union (matching either rule skips the bead: no create, no update). Already-synced beads that newly match are silently skipped and the Linear-side issue persists (documented in the help text). Pull is gated by `external_ref` and unaffected. This mirrors the existing `linear.exclude_types` / `linear.exclude_labels` design for the case where neither type nor label reliably identifies workflow-artifact beads (e.g. `hw-mol-*`) but their IDs share a stable pattern.

## Why a replacement instead of merging #3759

#3759 sits on an orphan pre-history-rewrite branch: `git merge-base upstream/main <pr-branch>` is empty, so an in-place rebase has no base to land on and GitHub reports the branch as conflicting. A mechanical `git apply --3way` of the PR diff succeeds textually but is wrong: because the diff was generated against the old base, applying it would silently revert three newer refactors on `main`:

1. `cmd/bd/linear.go`: `runLinearSync` is now an error-returning `RunE` with `metrics.NewCommandEvent` instrumentation and `SilenceUsage`/`SilenceErrors` (the orphan branch had the old void `Run`).
2. `internal/tracker/engine.go`: the `pulledIDs` echo-suppression fix, the `last_sync` Dolt-rounding race fix, the warnings-append fix, and external-ref URL-variant matching.
3. Stale generated-doc churn.

An in-place fix-merge is therefore not viable. This PR re-applies only the feature deltas by hand, adapted to the current code shape, and preserves the newer refactors.

## What was preserved from #3759

- The design and push-only scoping (@aphexcx).
- The `applyLinearExcludeIDConfig` helper with the minimal `linearConfigReader` interface for storage-free testing (from the codecov follow-up commit).
- The full test suite, adapted: `TestShouldPushIssue_ExcludeIDDirect` (12 sub-cases, storage-free), `TestEngineExcludeIDPrefix` / `Patterns` / `Both` / `AlreadySynced` / `DryRunRespectsExcludeID` (Dolt-gated), and `TestApplyLinearExcludeIDConfig` / `_NilSafe`.

Credit to @aphexcx via `Co-authored-by:` on the commit.

## What was deliberately not ported

- The PR's regenerated CLI reference docs (`docs/CLI_REFERENCE.md`, `website/docs/...`), which carried unrelated federation/regen drift from the stale base. Help text is inline in `linear.go`; `check-doc-flags` passes because the feature adds config keys, not CLI flags. A clean `scripts/generate-cli-docs.sh` regen can fold the new help section in as a follow-up.

## Test plan

- `CGO_ENABLED=0 go build -tags gms_pure_go ./...` - clean.
- `go test -tags gms_pure_go ./internal/tracker/... ./internal/linear/... ./cmd/bd/...` - all pass. The storage-free filter tests and the `applyLinearExcludeIDConfig` tests run locally; the full `Sync()` path tests are Dolt-gated and run in CI.

Closes #3759 once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
