### PR TITLE
fix(create): respect --repo when cwd has no .beads workspace (GH#3686)

### DIFF
--- a/cmd/bd/create_repo_no_cwd_beads_embedded_test.go
+++ b/cmd/bd/create_repo_no_cwd_beads_embedded_test.go
@@ -1,0 +1,68 @@
+//go:build cgo
+
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestEmbeddedCreateRepoFromNonBeadsCwd reproduces GH#3686: running
+// `bd create --repo=<local path>` from a directory that has no .beads/
+// workspace of its own must resolve the target repo's workspace instead of
+// failing with "no beads database found".
+//
+// Before the fix, PersistentPreRun exited early with that error because the
+// current directory had no discoverable database, so create.go's --repo
+// handling never ran. The reproduction, contributor bug report, and expected
+// behavior are due to kevglynn (GH#3774).
+func TestEmbeddedCreateRepoFromNonBeadsCwd(t *testing.T) {
+	if os.Getenv("BEADS_TEST_EMBEDDED_DOLT") != "1" {
+		t.Skip("set BEADS_TEST_EMBEDDED_DOLT=1 to run embedded dolt create tests")
+	}
+	t.Parallel()
+
+	bd := buildEmbeddedBD(t)
+
+	t.Run("repo_flag_resolves_target_workspace", func(t *testing.T) {
+		// Target repo with a real .beads/ workspace.
+		targetDir, targetBeadsDir, _ := bdInit(t, bd, "--prefix", "rp")
+
+		// A separate directory with NO .beads/ workspace (and no .beads
+		// ancestor, since it is an independent temp dir).
+		noBeadsCwd := t.TempDir()
+
+		// Sanity: the cwd genuinely has no .beads workspace.
+		if _, err := os.Stat(noBeadsCwd + "/.beads"); err == nil {
+			t.Fatalf("test setup: %s unexpectedly has a .beads dir", noBeadsCwd)
+		}
+
+		// Create from the non-beads cwd, targeting the other repo. Before the
+		// fix this failed with "no beads database found".
+		issue := bdCreate(t, bd, noBeadsCwd, "Routed from non-beads cwd", "--repo", targetDir)
+		if issue.ID == "" {
+			t.Fatal("expected issue ID")
+		}
+		if !strings.HasPrefix(issue.ID, "rp-") {
+			t.Errorf("ID should have target prefix rp-, got %q", issue.ID)
+		}
+		if issue.Title != "Routed from non-beads cwd" {
+			t.Errorf("title: got %q, want %q", issue.Title, "Routed from non-beads cwd")
+		}
+
+		// The issue must land in the target repo's store.
+		assertIssueInStore(t, targetBeadsDir, "rp", issue.ID)
+	})
+
+	t.Run("no_repo_flag_still_errors_in_non_beads_cwd", func(t *testing.T) {
+		// Regression guard: the no-database-found error must still fire for an
+		// ordinary create with no --repo when the cwd has no workspace, so the
+		// fix does not swallow the diagnostic for the common mistake.
+		noBeadsCwd := t.TempDir()
+		out := bdCreateFail(t, bd, noBeadsCwd, "should fail")
+		if !strings.Contains(out, "no beads database found") {
+			t.Errorf("expected 'no beads database found' error, got:\n%s", out)
+		}
+	})
+}

--- a/cmd/bd/main.go
+++ b/cmd/bd/main.go
@@ -28,6 +28,8 @@ import (
 	"github.com/steveyegge/beads/internal/hooks"
 	"github.com/steveyegge/beads/internal/metrics"
 	"github.com/steveyegge/beads/internal/molecules"
+	"github.com/steveyegge/beads/internal/remotecache"
+	"github.com/steveyegge/beads/internal/routing"
 	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/storage/dolt"
 	"github.com/steveyegge/beads/internal/storage/schema"
@@ -965,7 +967,21 @@ var rootCmd = &cobra.Command{
 					return nil
 				}
 
-				if cmd.Name() != "import" && cmd.Name() != "setup" {
+				// GH#3686: `bd create --repo=<local path>` targets a different
+				// repo's workspace. Without this, PreRun exits with "no beads
+				// database found" before create.go's --repo handling runs, even
+				// when the target repo has a valid .beads/. Resolve the target
+				// workspace here so store initialization points at it. Remote
+				// --repo URLs are handled by create.go via the remote cache, so
+				// only local paths are resolved here.
+				if cmd.Name() == "create" && cmd.Flags().Changed("repo") {
+					if repoVal, _ := cmd.Flags().GetString("repo"); repoVal != "" && !remotecache.IsRemoteURL(repoVal) {
+						targetBeadsDir := filepath.Join(routing.ExpandPath(repoVal), ".beads")
+						dbPath = utils.CanonicalizePath(filepath.Join(targetBeadsDir, beads.CanonicalDatabaseName))
+					}
+				}
+
+				if dbPath == "" && cmd.Name() != "import" && cmd.Name() != "setup" {
 					// No database found - provide context-aware error message
 					fmt.Fprintf(os.Stderr, "Error: no beads database found\n")
 					fmt.Fprintf(os.Stderr, "Hint: %s\n", diagHint())
@@ -973,19 +989,22 @@ var rootCmd = &cobra.Command{
 					metrics.CloseAndFlush()
 					os.Exit(1)
 				}
-				// For import/setup commands, set default database path
-				// Invariant: dbPath must always be absolute. Use CanonicalizePath for OS-agnostic
-				// handling (symlinks, case normalization on macOS).
-				//
-				// IMPORTANT: Use FindBeadsDir() to get the correct .beads directory,
-				// which follows redirect files. Without this, a redirected .beads
-				// would create a local database instead of using the redirect target.
-				// (GH#bd-0qel)
-				targetBeadsDir := beads.FindBeadsDir()
-				if targetBeadsDir == "" {
-					targetBeadsDir = ".beads"
+
+				if dbPath == "" {
+					// For import/setup commands, set default database path
+					// Invariant: dbPath must always be absolute. Use CanonicalizePath for OS-agnostic
+					// handling (symlinks, case normalization on macOS).
+					//
+					// IMPORTANT: Use FindBeadsDir() to get the correct .beads directory,
+					// which follows redirect files. Without this, a redirected .beads
+					// would create a local database instead of using the redirect target.
+					// (GH#bd-0qel)
+					targetBeadsDir := beads.FindBeadsDir()
+					if targetBeadsDir == "" {
+						targetBeadsDir = ".beads"
+					}
+					dbPath = utils.CanonicalizePath(filepath.Join(targetBeadsDir, beads.CanonicalDatabaseName))
 				}
-				dbPath = utils.CanonicalizePath(filepath.Join(targetBeadsDir, beads.CanonicalDatabaseName))
 			}
 		}
 


### PR DESCRIPTION
## Why

`bd create --repo=<local path>` fails with `no beads database found` when run
from a directory that has no `.beads/` workspace of its own, even though the
target repo has a valid one. `PersistentPreRunE` exits early with that error
before `create.go`'s `--repo` handling ever runs. This is the bug reported and
diagnosed in #3774 (closes #3686).

## Why a replacement instead of merging #3774

`main`'s `PersistentPreRunE` has drifted substantially since #3774 was opened.
The "no beads database found" block is now reached only after a
`configCommandCanRunWithoutStore` gate and a `FindDatabasePath` lookup, and the
import/setup default-path logic sits in the same branch. kevglynn's original
single-block patch no longer applies against that shape, so this carries the
same fix forward, adapted idiomatically to current `main`.

## What changed

- In `PersistentPreRunE`, when `create --repo` names a **local** path and no
  database was discovered in the cwd, resolve the target repo's `.beads/`
  workspace and set `dbPath` so store initialization points at it. Remote
  `--repo` URLs remain the responsibility of `create.go`'s remote-cache path
  (`IsRemoteURL` short-circuits), so their behavior is unchanged.
- The no-database-found error and the import/setup default-path fallback are now
  guarded by `dbPath == ""`, preserving both behaviors for every other command.

## Credit

The diagnosis, reproduction recipe, and expected behavior are kevglynn's, from
#3774. That work is preserved via a `Co-authored-by:` trailer on the commit and
an embedded regression test that encodes the reported reproduction.

## Tests

New CGO-gated embedded test `TestEmbeddedCreateRepoFromNonBeadsCwd` in
`cmd/bd/create_repo_no_cwd_beads_embedded_test.go`:

- `repo_flag_resolves_target_workspace` - `bd create --repo=<target>` from a
  non-beads cwd creates the issue in the target store with the target's prefix.
  Reverting the fix makes this subtest fail with `no beads database found`
  (verified).
- `no_repo_flag_still_errors_in_non_beads_cwd` - regression guard that an
  ordinary `bd create` with no `--repo` in a non-beads cwd still emits the
  `no beads database found` diagnostic.

Verification:

- `CGO_ENABLED=0 go build -tags gms_pure_go ./...` - clean.
- `gofmt` / `go vet -tags gms_pure_go ./cmd/bd/` - clean.
- `BEADS_TEST_EMBEDDED_DOLT=1 go test -tags gms_pure_go -run TestEmbeddedCreateRepoFromNonBeadsCwd ./cmd/bd/` - pass.
- `BEADS_TEST_EMBEDDED_DOLT=1 go test -tags gms_pure_go -run 'TestEmbeddedCreate$' ./cmd/bd/` - pass (no regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
