### PR TITLE
docs: regenerate CLI reference (fixes doc-flags-freshness after #4613)

### DIFF
--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -518,7 +518,7 @@ bd create [title] [flags]
   -s, --status string           Initial status
       --stdin                   Read description from stdin (alias for --body-file -)
       --title string            Issue title (alternative to positional argument)
-  -t, --type string             Issue type (bug|feature|task|epic|chore|decision); custom types require types.custom config; aliases: enhancement/feat→feature, dec/adr→decision (default "task")
+  -t, --type string             Issue type (bug|feature|task|epic|chore|decision|spike|story|milestone); custom types require types.custom config; aliases: enhancement/feat→feature, dec/adr→decision (default "task")
       --validate                Validate description contains required sections for issue type
       --waits-for string        Spawner issue ID to wait for (creates waits-for dependency for fanout gate)
       --waits-for-gate string   Gate type: all-children (wait for all) or any-children (wait for first) (default "all-children")
@@ -1733,11 +1733,7 @@ Section requirements by type:
   task:     Acceptance Criteria
   feature:  Acceptance Criteria
   epic:     Success Criteria
-  decision: Decision, Rationale, Alternatives Considered
-  spike:    Goal, Findings
-  story:    Acceptance Criteria
   chore:    (none)
-  milestone: (none)
 
 Examples:
   bd lint                    # Lint all open issues
@@ -1755,7 +1751,7 @@ bd lint [issue-id...] [flags]
 
 ```
   -s, --status string   Filter by status (default: open, use 'all' for all)
-  -t, --type string     Filter by issue type (bug, task, feature, epic)
+  -t, --type string     Filter by issue type (bug, task, feature, epic, decision, spike, story, chore, milestone)
 ```
 
 ### bd stale
@@ -1846,16 +1842,23 @@ bd statuses
 
 List all valid issue types that can be used with bd create --type.
 
-Core work types (bug, task, feature, chore, epic, decision) are always valid.
+Core work types (bug, task, feature, chore, epic, decision, spike, story, milestone) are always valid.
 Additional types require configuration via types.custom in .beads/config.yaml.
 
 Examples:
   bd types              # List all types with descriptions
+  bd types --sections   # List required sections for each type
   bd types --json       # Output as JSON
 
 
 ```
-bd types
+bd types [flags]
+```
+
+**Flags:**
+
+```
+      --sections   Show required sections for each issue type
 ```
 
 ## Dependencies & Structure:
@@ -5150,6 +5153,18 @@ Type Filtering (--push only):
   --include-ephemeral       Include ephemeral issues (wisps, etc.); default is to exclude
   --parent TICKET           Only push this ticket and its descendants
   --relations               Import Linear relations as bd dependencies on pull
+
+Persistent push-direction ID filters (workflow artifacts, sandbox beads, etc.):
+  bd config set linear.exclude_id_prefix "hw-mol-"
+  bd config set linear.exclude_id_patterns "-wisp-,sandbox-,scratch-"
+
+  exclude_id_prefix is a single case-sensitive prefix on the bead ID.
+  exclude_id_patterns is a comma-separated list of case-sensitive substrings
+  (matched anywhere in the ID). Both are combined as a union: a bead
+  matching either rule is skipped from push (no create, no update). Beads
+  with an existing external_ref that NOW match are silently skipped on
+  future syncs; the Linear-side issue persists — archive/delete it manually
+  if desired.
 
 Conflict Resolution:
   By default, newer timestamp wins. Override with:

--- a/website/docs/cli-reference/create.md
+++ b/website/docs/cli-reference/create.md
@@ -59,7 +59,7 @@ bd create [title] [flags]
   -s, --status string           Initial status
       --stdin                   Read description from stdin (alias for --body-file -)
       --title string            Issue title (alternative to positional argument)
-  -t, --type string             Issue type (bug|feature|task|epic|chore|decision); custom types require types.custom config; aliases: enhancement/feat→feature, dec/adr→decision (default "task")
+  -t, --type string             Issue type (bug|feature|task|epic|chore|decision|spike|story|milestone); custom types require types.custom config; aliases: enhancement/feat→feature, dec/adr→decision (default "task")
       --validate                Validate description contains required sections for issue type
       --waits-for string        Spawner issue ID to wait for (creates waits-for dependency for fanout gate)
       --waits-for-gate string   Gate type: all-children (wait for all) or any-children (wait for first) (default "all-children")

--- a/website/docs/cli-reference/formula.md
+++ b/website/docs/cli-reference/formula.md
@@ -118,7 +118,7 @@ Curated smoke-tested fixtures for wired primitives live in
 examples/formulas/primitives/ (with a smoke harness that proves they work).
 
 ```
-bd formula schema [primitive]
+bd formula schema [primitive] [flags]
 ```
 
 **Aliases:** primitives

--- a/website/docs/cli-reference/index.md
+++ b/website/docs/cli-reference/index.md
@@ -9,7 +9,7 @@ sidebar_position: 0
 <!-- AUTO-GENERATED: do not edit manually -->
 Reference for bd Latest. Generated from `bd help --docs-root`.
 
-This reference covers all 111 live top-level `bd` commands. Regenerate it with:
+This reference covers all 112 live top-level `bd` commands. Regenerate it with:
 
 ```bash
 ./scripts/generate-cli-docs.sh
@@ -121,6 +121,7 @@ This reference covers all 111 live top-level `bd` commands. Regenerate it with:
 - [`bd tag`](./tag.md)
 - [`bd todo`](./todo.md)
 - [`bd types`](./types.md)
+- [`bd unclaim`](./unclaim.md)
 - [`bd undefer`](./undefer.md)
 - [`bd update`](./update.md)
 - [`bd upgrade`](./upgrade.md)

--- a/website/docs/cli-reference/linear.md
+++ b/website/docs/cli-reference/linear.md
@@ -154,6 +154,18 @@ Type Filtering (--push only):
   --parent TICKET           Only push this ticket and its descendants
   --relations               Import Linear relations as bd dependencies on pull
 
+Persistent push-direction ID filters (workflow artifacts, sandbox beads, etc.):
+  bd config set linear.exclude_id_prefix "hw-mol-"
+  bd config set linear.exclude_id_patterns "-wisp-,sandbox-,scratch-"
+
+  exclude_id_prefix is a single case-sensitive prefix on the bead ID.
+  exclude_id_patterns is a comma-separated list of case-sensitive substrings
+  (matched anywhere in the ID). Both are combined as a union: a bead
+  matching either rule is skipped from push (no create, no update). Beads
+  with an existing external_ref that NOW match are silently skipped on
+  future syncs; the Linear-side issue persists — archive/delete it manually
+  if desired.
+
 Conflict Resolution:
   By default, newer timestamp wins. Override with:
   --prefer-local    Always prefer local beads version

--- a/website/docs/cli-reference/lint.md
+++ b/website/docs/cli-reference/lint.md
@@ -37,5 +37,5 @@ bd lint [issue-id...] [flags]
 
 ```
   -s, --status string   Filter by status (default: open, use 'all' for all)
-  -t, --type string     Filter by issue type (bug, task, feature, epic)
+  -t, --type string     Filter by issue type (bug, task, feature, epic, decision, spike, story, chore, milestone)
 ```

--- a/website/docs/cli-reference/types.md
+++ b/website/docs/cli-reference/types.md
@@ -12,14 +12,21 @@ Generated from `bd help --doc types`
 
 List all valid issue types that can be used with bd create --type.
 
-Core work types (bug, task, feature, chore, epic, decision) are always valid.
+Core work types (bug, task, feature, chore, epic, decision, spike, story, milestone) are always valid.
 Additional types require configuration via types.custom in .beads/config.yaml.
 
 Examples:
   bd types              # List all types with descriptions
+  bd types --sections   # List required sections for each type
   bd types --json       # Output as JSON
 
 
 ```
 bd types [flags]
+```
+
+**Flags:**
+
+```
+      --sections   Show required sections for each issue type
 ```


### PR DESCRIPTION
## Summary

Follow-up to #4613 (hand-port of #3759). That PR added inline help text to `bd linear sync` for the new `linear.exclude_id_prefix` / `linear.exclude_id_patterns` config keys but deliberately skipped the CLI-docs regen to avoid pulling unrelated churn, on the assumption that `check-doc-flags.sh` only validates flag *existence*. It also compares the full generated doc set against what's checked in, so it failed after merge: `docs/CLI_REFERENCE.md` and the website CLI reference pages had already drifted from several other recent merges (new issue types `spike`/`story`/`milestone`, the `bd unclaim` command, a `bd formula schema` flag, `bd types --sections`), none of which regenerated docs either.

## Fix

Regenerated via `./scripts/generate-cli-docs.sh`, built with a pinned `CGO_ENABLED=0 -tags gms_pure_go` binary per `AGENTS.md`'s doc-regen guidance (confirmed the diff is identical whether generated via the script's own build or the pinned pure-Go binary, so there is no federation-help churn to worry about).

## Test plan

- `./scripts/generate-cli-docs.sh --check <pinned-bd>` - now passes (`PASS: generated CLI docs are fresh`).
- No Go source changed; docs-only diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
