### PR TITLE
feat(dolt): interpolate params in the server DSN

### DIFF
--- a/internal/storage/doltutil/dsn.go
+++ b/internal/storage/doltutil/dsn.go
@@ -36,13 +36,26 @@ func (d ServerDSN) String() string {
 	}
 
 	cfg := mysql.Config{
-		User:                 d.User,
-		Passwd:               d.Password,
-		Net:                  net,
-		Addr:                 addr,
-		DBName:               d.Database,
-		ParseTime:            true,
-		MultiStatements:      true,
+		User:            d.User,
+		Passwd:          d.Password,
+		Net:             net,
+		Addr:            addr,
+		DBName:          d.Database,
+		ParseTime:       true,
+		MultiStatements: true,
+		// InterpolateParams renders bound parameters into the SQL client-side, so
+		// a parameterized query is a single round-trip instead of a server-side
+		// PREPARE + EXECUTE pair. Over a high-latency connection (e.g. a remote
+		// TLS-fronted Dolt server), a write that issues many parameterized
+		// statements — such as creating an issue and its labels, events, and
+		// dependencies inside one transaction — otherwise pays a full round-trip
+		// per statement for the prepare alone. The driver falls back to a
+		// server-side prepare (driver.ErrSkip) whenever it cannot safely
+		// interpolate an argument, so results never change; this only removes the
+		// extra round-trip when interpolation is safe. Independent of
+		// MultiStatements. The driver rejects it only with custom unsafe
+		// collations, which this DSN never sets.
+		InterpolateParams:    true,
 		Timeout:              timeout,
 		AllowNativePasswords: true,
 	}

--- a/internal/storage/doltutil/dsn_test.go
+++ b/internal/storage/doltutil/dsn_test.go
@@ -21,6 +21,22 @@ func TestServerDSN_TLSExplicitlyDisabledByDefault(t *testing.T) {
 	}
 }
 
+func TestServerDSN_InterpolatesParams(t *testing.T) {
+	dsn := ServerDSN{
+		Host: "dolt.example.com",
+		Port: 3307,
+		User: "root",
+	}.String()
+
+	// InterpolateParams collapses parameterized statements from a server-side
+	// PREPARE + EXECUTE pair to a single round-trip, which matters over
+	// high-latency connections. The formatted DSN must carry it so every
+	// connection built from this struct benefits.
+	if !strings.Contains(dsn, "interpolateParams=true") {
+		t.Errorf("DSN should contain interpolateParams=true; got %q", dsn)
+	}
+}
+
 func TestServerDSN_UnixSocket(t *testing.T) {
 	dsn := ServerDSN{
 		Socket: "/tmp/dolt.sock",


### PR DESCRIPTION
## What

Set `InterpolateParams=true` on the Dolt server DSN (`ServerDSN.String()`), so parameterized statements are rendered client-side into the SQL and sent as a single round-trip instead of a server-side PREPARE + EXECUTE pair.

## Why

Over a high-latency connection (for example a remote, TLS-fronted Dolt server), a write that issues many parameterized statements inside one transaction — creating an issue and its labels, events, and dependencies — otherwise pays a full network round-trip per statement just to prepare it. Interpolating parameters roughly halves the statement count on the wire for these write batches.

The driver falls back to a server-side prepare (`driver.ErrSkip`) whenever it cannot safely interpolate an argument, so query results never change; this only removes the extra round-trip when interpolation is safe. It is independent of `MultiStatements` and is rejected by the driver only with custom unsafe collations, which this DSN never sets.

## Verification

```
go test -tags gms_pure_go ./internal/storage/doltutil/ -run TestServerDSN
```

Added `TestServerDSN_InterpolatesParams`, which asserts `interpolateParams=true` is present in the formatted DSN. Existing `TestServerDSN_*` cases continue to pass.
