### PR TITLE
fix(config): recognize the types.* config namespace

### DIFF
--- a/cmd/bd/config.go
+++ b/cmd/bd/config.go
@@ -866,7 +866,7 @@ Examples:
 // Keys under custom.* are always accepted (user-extensible).
 var recognizedConfigPrefixes = []string{
 	"export.", "import.", "dolt.", "jira.", "linear.", "github.", "custom.",
-	"status.", "doctor.suppress.", "routing.", "sync.", "git.",
+	"status.", "types.", "doctor.suppress.", "routing.", "sync.", "git.",
 	"directory.", "repos.", "external_projects.", "validation.",
 	"hierarchy.", "ai.", "backup.", "federation.", "metrics.",
 }

--- a/cmd/bd/config_validate_key_test.go
+++ b/cmd/bd/config_validate_key_test.go
@@ -9,8 +9,8 @@ func TestIsRecognizedConfigKey(t *testing.T) {
 	recognized := []string{
 		"export.auto", "dolt.auto-push", "jira.url", "custom.anything",
 		"doctor.suppress.git-hooks", "no-git-ops", "beads.role",
-		"status.custom", "ai.model", "backup.enabled", "import.path",
-		"dolt.local-only",
+		"status.custom", "types.custom", "types.infra", "ai.model",
+		"backup.enabled", "import.path", "dolt.local-only",
 	}
 	for _, key := range recognized {
 		if !isRecognizedConfigKey(key) {


### PR DESCRIPTION
## What

Add `types.` to `recognizedConfigPrefixes` in `cmd/bd/config.go`.

## Why

`types.custom` and `types.infra` are first-class config keys:

- The type resolver reads them (`internal/config/config.go`, `getConfigList("types.custom")` / `getConfigList("types.infra")`).
- `bd types` explicitly instructs users to run `bd config set types.custom "type1,type2,..."`.

But `types.` was missing from `recognizedConfigPrefixes`, so `bd config set types.custom ...` printed a spurious `Warning: "types.custom" is not a recognized config key.` even though it stored the value correctly. This adds `types.` to the recognized prefixes so the warning no longer fires for a key bd itself documents.

## Verification

```
go test -tags gms_pure_go ./cmd/bd/ -run TestIsRecognizedConfigKey
```

Extended `TestIsRecognizedConfigKey` to cover `types.custom` and `types.infra`.
