### PR TITLE
fix(formula): check outputJSON error return in schema command

### DIFF
--- a/cmd/bd/formula_schema.go
+++ b/cmd/bd/formula_schema.go
@@ -43,7 +43,10 @@ func runFormulaSchema(cmd *cobra.Command, args []string) {
 
 func runFormulaSchemaList() {
 	if jsonOutput {
-		outputJSON(formula.Primitives)
+		if err := outputJSON(formula.Primitives); err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			os.Exit(1)
+		}
 		return
 	}
 
@@ -68,7 +71,10 @@ func runFormulaSchemaShow(name string) {
 	}
 
 	if jsonOutput {
-		outputJSON(p)
+		if err := outputJSON(p); err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			os.Exit(1)
+		}
 		return
 	}
 


### PR DESCRIPTION
## Problem

`bd formula schema [--json]` (and its `primitives` alias) discarded the error returned by `outputJSON` at two call sites (`cmd/bd/formula_schema.go:46,71`). golangci-lint's **errcheck** flags these, which turned **main red**:

- `Lint` (golangci-lint latest / v2.12.2)
- `PR Lint (wrapper timing)` (v2.9.0)
- `Build Artifacts` (its lint step)

```
cmd/bd/formula_schema.go:46:13: Error return value is not checked (errcheck)
cmd/bd/formula_schema.go:71:13: Error return value is not checked (errcheck)
```

## Fix

Handle the returned error by reporting it to stderr and exiting non-zero, matching the existing `os.Exit(1)` idiom already used a few lines up in `runFormulaSchemaShow`.

## Validation

- `golangci-lint run --timeout=5m --build-tags=gms_pure_go ./...` → **0 issues** (was 2)
- `gofmt -l` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)