### PR TITLE
test(quiet): run quiet embedded test under embedded Dolt instead of skipping

### DIFF
--- a/cmd/bd/verbosity_quiet_embedded_test.go
+++ b/cmd/bd/verbosity_quiet_embedded_test.go
@@ -3,20 +3,22 @@
 package main
 
 import (
+	"encoding/json"
+	"os"
 	"os/exec"
 	"strings"
 	"testing"
 )
 
-// TestQuietFlagSuppressesSuccessOutput verifies that --quiet suppresses success
-// output on create, close, and update while still exiting 0.
+// TestEmbeddedQuietFlagSuppressesSuccessOutput verifies that --quiet suppresses
+// success output on create, close, and update while still exiting 0.
 //
 // Each sub-test: run the command with --quiet, capture stdout+stderr separately,
 // assert stdout is empty and exit code is 0. Errors still flow to stderr (not
 // tested here — the contract is "success output suppressed", not "all output").
-func TestQuietFlagSuppressesSuccessOutput(t *testing.T) {
-	if testing.Short() {
-		t.Skip("skipping slow embedded-bd quiet-mode tests in short mode")
+func TestEmbeddedQuietFlagSuppressesSuccessOutput(t *testing.T) {
+	if os.Getenv("BEADS_TEST_EMBEDDED_DOLT") != "1" {
+		t.Skip("set BEADS_TEST_EMBEDDED_DOLT=1 to run embedded dolt integration tests")
 	}
 
 	bd := buildEmbeddedBD(t)
@@ -53,30 +55,16 @@ func TestQuietFlagSuppressesSuccessOutput(t *testing.T) {
 	if err != nil {
 		t.Fatalf("bd list --json failed: %v", err)
 	}
-	issueID := ""
-	for _, line := range strings.Split(listStdout.String(), "\n") {
-		line = strings.TrimSpace(line)
-		if strings.HasPrefix(line, `"id"`) {
-			parts := strings.SplitN(line, `"`, 4)
-			if len(parts) >= 4 {
-				issueID = parts[3]
-			}
-			break
-		}
+	var listed []struct {
+		ID string `json:"id"`
 	}
-	if issueID == "" {
-		// Fallback: scan for first `"id": "..."` pattern
-		s := listStdout.String()
-		if idx := strings.Index(s, `"id": "`); idx >= 0 {
-			rest := s[idx+7:]
-			if end := strings.Index(rest, `"`); end >= 0 {
-				issueID = rest[:end]
-			}
-		}
+	if err := json.Unmarshal(listStdout.Bytes(), &listed); err != nil {
+		t.Fatalf("failed to parse bd list --json output: %v\n%s", err, listStdout.String())
 	}
-	if issueID == "" {
-		t.Skip("could not determine created issue ID; skipping close/update quiet tests")
+	if len(listed) == 0 || listed[0].ID == "" {
+		t.Fatalf("bd list --json returned no usable issue ID:\n%s", listStdout.String())
 	}
+	issueID := listed[0].ID
 
 	t.Run("update", func(t *testing.T) {
 		cmd := exec.Command(bd, "--quiet", "update", issueID, "--priority", "1")


### PR DESCRIPTION
## Problem

`TestQuietFlagSuppressesSuccessOutput` gated itself with `testing.Short()`, which the repo's `scripts/check-testing-short.sh` policy disallows for integration boundaries. This turned **main red**:

- `PR Policy (wrapper timing)`
- `Build Artifacts` (its policy step, which runs first)

```
Disallowed testing.Short() at cmd/bd/verbosity_quiet_embedded_test.go:18 in TestQuietFlagSuppressesSuccessOutput
```

It also meant the test **never actually ran in CI**: skipped in the `-short` cross-platform job, and not discovered by the embedded shard runner (which greps for `^func TestEmbedded`).

## Fix

- **Rename** to `TestEmbeddedQuietFlagSuppressesSuccessOutput` and gate on `BEADS_TEST_EMBEDDED_DOLT=1` — the sanctioned embedded-integration pattern used by every other embedded test — so it runs in the embedded cmd shards.
- **Fix a latent parser bug**: `SplitN(line, '"', 4)` captured a trailing `",` from the pretty-printed `"id": "q-71m",` line, feeding a malformed ID (`q-71m",`) to the update/close subtests. Replaced the hand-rolled parser with a proper `json.Unmarshal` of `bd list --json`.

The `--quiet` feature itself is correct — the failure was entirely in the test's ID extraction.

## Validation

Built the embedded cmd test binary (`go test -tags gms_pure_go -c`) and ran under `BEADS_TEST_EMBEDDED_DOLT=1`:

```
--- PASS: TestEmbeddedQuietFlagSuppressesSuccessOutput (3.9s)
    --- PASS: .../create
    --- PASS: .../update
    --- PASS: .../close
```

> Note: this test runs only in the `Test (Embedded Dolt Cmd …)` shards (Main workflow), not in PR CI — validated locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)