### PR TITLE
test(unclaim): fix stale --json and claim-error assertions (embedded shards 5 & 19)

### DIFF
--- a/cmd/bd/unclaim_embedded_test.go
+++ b/cmd/bd/unclaim_embedded_test.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"encoding/json"
 	"os"
 	"os/exec"
 	"strings"
@@ -99,11 +100,24 @@ func TestEmbeddedUnclaim(t *testing.T) {
 		issue := bdCreate(t, bd, dir, "JSON test", "--type", "task")
 		bdUpdate(t, bd, dir, issue.ID, "--claim")
 		out := bdUnclaim(t, bd, dir, issue.ID, "--json")
-		if !strings.Contains(out, `"assignee":""`) && !strings.Contains(out, `"assignee": null`) {
-			t.Errorf("expected empty assignee in JSON output, got: %s", out)
+		// bd unclaim --json emits an array of the affected issues. A cleared
+		// assignee is empty and omitempty drops it from the payload, so parse
+		// and assert on the decoded fields rather than raw substrings.
+		var unclaimed []struct {
+			Assignee string `json:"assignee"`
+			Status   string `json:"status"`
 		}
-		if !strings.Contains(out, `"status":"open"`) {
-			t.Errorf("expected status open in JSON output, got: %s", out)
+		if err := json.Unmarshal([]byte(out), &unclaimed); err != nil {
+			t.Fatalf("failed to parse unclaim --json output: %v\n%s", err, out)
+		}
+		if len(unclaimed) != 1 {
+			t.Fatalf("expected 1 issue in unclaim --json output, got %d:\n%s", len(unclaimed), out)
+		}
+		if unclaimed[0].Assignee != "" {
+			t.Errorf("expected empty assignee after unclaim, got %q", unclaimed[0].Assignee)
+		}
+		if unclaimed[0].Status != "open" {
+			t.Errorf("expected status open after unclaim, got %q", unclaimed[0].Status)
 		}
 	})
 

--- a/cmd/bd/update_embedded_test.go
+++ b/cmd/bd/update_embedded_test.go
@@ -665,8 +665,8 @@ func TestEmbeddedUpdate(t *testing.T) {
 		issue := bdCreate(t, bd, dir, "Claim fail test", "--type", "task")
 		bdUpdate(t, bd, dir, issue.ID, "--assignee", "alice")
 		out := bdUpdateFail(t, bd, dir, issue.ID, "--claim")
-		if !strings.Contains(out, "already claimed") {
-			t.Errorf("expected 'already claimed' error, got: %s", out)
+		if !strings.Contains(out, "already assigned to") {
+			t.Errorf("expected 'already assigned to' error, got: %s", out)
 		}
 	})
 


### PR DESCRIPTION
## Problem

The `bd unclaim` feature (#4614) left two embedded cmd tests red on **main** — they only run in the `Test (Embedded Dolt Cmd …)` shards, which the perpetually-cancelled Main workflow never completed, so the breakage slipped through:

**Shard 5 — `TestEmbeddedUnclaim/unclaim_json_output`:**
```
unclaim_embedded_test.go:103: expected empty assignee in JSON output, got: [ ... ]
```
`Assignee` is `json:"assignee,omitempty"`, so a *cleared* assignee is **omitted**, never rendered as `"assignee":""`. The output is also a pretty-printed array. The substring assertion could never match. (`owner` is a separate attribution field that unclaim correctly leaves intact — not a bug.)

**Shard 19 — `TestEmbeddedUpdate/update_claim_already_claimed`:**
```
update_embedded_test.go:669: expected 'already claimed' error, got:
Error claiming tu-5qb: issue already assigned to "alice". Use `bd unclaim tu-5qb` to release it before re-claiming
```
#4614 changed the claim error message (`internal/storage/issueops/claim.go`), breaking this pre-existing (#3665) assertion.

## Fix

- Parse the unclaim `--json` array and assert the decoded `assignee` is empty and `status` is `open`, rather than brittle raw substrings.
- Update the claim-conflict expectation to `"already assigned to"` to match the new message.

## Validation

Built the embedded cmd test binary and ran under `BEADS_TEST_EMBEDDED_DOLT=1`:

```
--- PASS: TestEmbeddedUnclaim (11.4s)
--- PASS: TestEmbeddedUpdate (64.7s)
```

> Note: these run only in the Embedded Dolt Cmd shards (Main workflow), not in PR CI — validated locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)