### PR TITLE
fix: unbreak red main CI (errcheck, testing.Short policy, unclaim test regressions)

### DIFF
--- a/cmd/bd/formula_schema.go
+++ b/cmd/bd/formula_schema.go
@@ -43,7 +43,10 @@ func runFormulaSchema(cmd *cobra.Command, args []string) {
 
 func runFormulaSchemaList() {
 	if jsonOutput {
-		outputJSON(formula.Primitives)
+		if err := outputJSON(formula.Primitives); err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			os.Exit(1)
+		}
 		return
 	}
 
@@ -68,7 +71,10 @@ func runFormulaSchemaShow(name string) {
 	}
 
 	if jsonOutput {
-		outputJSON(p)
+		if err := outputJSON(p); err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			os.Exit(1)
+		}
 		return
 	}
 

--- a/cmd/bd/unclaim_embedded_test.go
+++ b/cmd/bd/unclaim_embedded_test.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"encoding/json"
 	"os"
 	"os/exec"
 	"strings"
@@ -99,11 +100,24 @@ func TestEmbeddedUnclaim(t *testing.T) {
 		issue := bdCreate(t, bd, dir, "JSON test", "--type", "task")
 		bdUpdate(t, bd, dir, issue.ID, "--claim")
 		out := bdUnclaim(t, bd, dir, issue.ID, "--json")
-		if !strings.Contains(out, `"assignee":""`) && !strings.Contains(out, `"assignee": null`) {
-			t.Errorf("expected empty assignee in JSON output, got: %s", out)
+		// bd unclaim --json emits an array of the affected issues. A cleared
+		// assignee is empty and omitempty drops it from the payload, so parse
+		// and assert on the decoded fields rather than raw substrings.
+		var unclaimed []struct {
+			Assignee string `json:"assignee"`
+			Status   string `json:"status"`
 		}
-		if !strings.Contains(out, `"status":"open"`) {
-			t.Errorf("expected status open in JSON output, got: %s", out)
+		if err := json.Unmarshal([]byte(out), &unclaimed); err != nil {
+			t.Fatalf("failed to parse unclaim --json output: %v\n%s", err, out)
+		}
+		if len(unclaimed) != 1 {
+			t.Fatalf("expected 1 issue in unclaim --json output, got %d:\n%s", len(unclaimed), out)
+		}
+		if unclaimed[0].Assignee != "" {
+			t.Errorf("expected empty assignee after unclaim, got %q", unclaimed[0].Assignee)
+		}
+		if unclaimed[0].Status != "open" {
+			t.Errorf("expected status open after unclaim, got %q", unclaimed[0].Status)
 		}
 	})
 

--- a/cmd/bd/update_embedded_test.go
+++ b/cmd/bd/update_embedded_test.go
@@ -665,8 +665,8 @@ func TestEmbeddedUpdate(t *testing.T) {
 		issue := bdCreate(t, bd, dir, "Claim fail test", "--type", "task")
 		bdUpdate(t, bd, dir, issue.ID, "--assignee", "alice")
 		out := bdUpdateFail(t, bd, dir, issue.ID, "--claim")
-		if !strings.Contains(out, "already claimed") {
-			t.Errorf("expected 'already claimed' error, got: %s", out)
+		if !strings.Contains(out, "already assigned to") {
+			t.Errorf("expected 'already assigned to' error, got: %s", out)
 		}
 	})
 

--- a/cmd/bd/verbosity_quiet_embedded_test.go
+++ b/cmd/bd/verbosity_quiet_embedded_test.go
@@ -3,20 +3,22 @@
 package main
 
 import (
+	"encoding/json"
+	"os"
 	"os/exec"
 	"strings"
 	"testing"
 )
 
-// TestQuietFlagSuppressesSuccessOutput verifies that --quiet suppresses success
-// output on create, close, and update while still exiting 0.
+// TestEmbeddedQuietFlagSuppressesSuccessOutput verifies that --quiet suppresses
+// success output on create, close, and update while still exiting 0.
 //
 // Each sub-test: run the command with --quiet, capture stdout+stderr separately,
 // assert stdout is empty and exit code is 0. Errors still flow to stderr (not
 // tested here — the contract is "success output suppressed", not "all output").
-func TestQuietFlagSuppressesSuccessOutput(t *testing.T) {
-	if testing.Short() {
-		t.Skip("skipping slow embedded-bd quiet-mode tests in short mode")
+func TestEmbeddedQuietFlagSuppressesSuccessOutput(t *testing.T) {
+	if os.Getenv("BEADS_TEST_EMBEDDED_DOLT") != "1" {
+		t.Skip("set BEADS_TEST_EMBEDDED_DOLT=1 to run embedded dolt integration tests")
 	}
 
 	bd := buildEmbeddedBD(t)
@@ -53,30 +55,16 @@ func TestQuietFlagSuppressesSuccessOutput(t *testing.T) {
 	if err != nil {
 		t.Fatalf("bd list --json failed: %v", err)
 	}
-	issueID := ""
-	for _, line := range strings.Split(listStdout.String(), "\n") {
-		line = strings.TrimSpace(line)
-		if strings.HasPrefix(line, `"id"`) {
-			parts := strings.SplitN(line, `"`, 4)
-			if len(parts) >= 4 {
-				issueID = parts[3]
-			}
-			break
-		}
+	var listed []struct {
+		ID string `json:"id"`
 	}
-	if issueID == "" {
-		// Fallback: scan for first `"id": "..."` pattern
-		s := listStdout.String()
-		if idx := strings.Index(s, `"id": "`); idx >= 0 {
-			rest := s[idx+7:]
-			if end := strings.Index(rest, `"`); end >= 0 {
-				issueID = rest[:end]
-			}
-		}
+	if err := json.Unmarshal(listStdout.Bytes(), &listed); err != nil {
+		t.Fatalf("failed to parse bd list --json output: %v\n%s", err, listStdout.String())
 	}
-	if issueID == "" {
-		t.Skip("could not determine created issue ID; skipping close/update quiet tests")
+	if len(listed) == 0 || listed[0].ID == "" {
+		t.Fatalf("bd list --json returned no usable issue ID:\n%s", listStdout.String())
 	}
+	issueID := listed[0].ID
 
 	t.Run("update", func(t *testing.T) {
 		cmd := exec.Command(bd, "--quiet", "update", issueID, "--priority", "1")


### PR DESCRIPTION
Main `HEAD` is red on **three independent axes**. Because each is a
separate required check, no single-axis PR can go green off red main —
so this fixes all three together, one focused commit each.

Root cause of the accumulation: the **Main** workflow is perpetually
**cancelled** by concurrency (each rapid push kills the prior in-flight
run), so the policy/lint gates and the embedded-Dolt shards never
complete on main — breakage lands unseen. (Flagged as a follow-up below.)

## Fixes

**1. `fix(formula)` — errcheck** (`cmd/bd/formula_schema.go`)
`bd formula schema [--json]` discarded `outputJSON`'s error at two sites.
Breaks **Lint**, **PR Lint**, and **Build Artifacts** (lint step).
```
cmd/bd/formula_schema.go:46:13: Error return value is not checked (errcheck)
cmd/bd/formula_schema.go:71:13: Error return value is not checked (errcheck)
```

**2. `test(quiet)` — testing.Short policy** (`cmd/bd/verbosity_quiet_embedded_test.go`)
`testing.Short()` is disallowed by `check-testing-short.sh` for integration
boundaries. Breaks **PR Policy** and **Build Artifacts** (policy step).
The test also never actually ran in CI. Renamed to `TestEmbedded*` + gated
on `BEADS_TEST_EMBEDDED_DOLT=1` so it runs in the embedded shards, and
fixed a latent ID-parse bug (`SplitN(line,'"',4)` captured a trailing `",`)
by switching to `json.Unmarshal`.

**3. `test(unclaim)` — stale assertions** (`cmd/bd/unclaim_embedded_test.go`, `cmd/bd/update_embedded_test.go`)
From #4614. Breaks **Embedded Dolt Cmd 5/20 & 19/20**.
- `unclaim_json_output` asserted `"assignee":""`, but assignee is
  `omitempty` (absent when cleared) and output is a pretty array → parse
  and assert on decoded fields.
- `update_claim_already_claimed` expected `"already claimed"`; #4614
  changed the message to `"already assigned to …"`.

## Validation (local)

- `golangci-lint … ./...` → **0 issues** (was 2)
- `make ci-pr-policy` → exit 0
- Embedded Dolt cmd tests under `BEADS_TEST_EMBEDDED_DOLT=1`:
  `TestEmbeddedUnclaim` PASS, `TestEmbeddedUpdate` PASS,
  `TestEmbeddedQuietFlagSuppressesSuccessOutput` PASS (all subtests)

> The embedded shards and the quiet test run only in the **Main** workflow,
> not PR CI — validated locally.

## Follow-up (not in this PR)

The Main-workflow concurrency cancellation lets post-merge breakage slip
through. Worth reconsidering (don't cancel on `main`, or serialize) so
main's full suite actually completes.

Supersedes #4620, #4621, #4622.

🤖 Generated with [Claude Code](https://claude.com/claude-code)