### PR TITLE
test(prune): don't enforce wall-clock budget under -race

### DIFF
--- a/cmd/bd/prune_bench_test.go
+++ b/cmd/bd/prune_bench_test.go
@@ -97,8 +97,12 @@ func TestPruneLargeFixture(t *testing.T) {
 		t.Fatalf("buildReferencedSet error: %v", err)
 	}
 
-	// Performance assertion (NFR-02).
-	if elapsed > maxDurationSeconds*time.Second {
+	// Performance assertion (NFR-02). The race detector adds multi-x overhead
+	// that invalidates a wall-clock budget (buildReferencedSet measures ~4x
+	// slower under -race), so only enforce the bound in non-race builds. The
+	// correctness assertions below still run under -race, which is where the
+	// large-fixture pass earns its keep as a data-race check.
+	if !raceEnabled && elapsed > maxDurationSeconds*time.Second {
 		t.Errorf("buildReferencedSet took %v; must complete in <%ds on 10K-bead fixture", elapsed, maxDurationSeconds)
 	}
 

--- a/cmd/bd/race_detector_off_test.go
+++ b/cmd/bd/race_detector_off_test.go
@@ -1,0 +1,6 @@
+//go:build !race
+
+package main
+
+// raceEnabled is false in non-race builds; see race_detector_on_test.go.
+const raceEnabled = false

--- a/cmd/bd/race_detector_on_test.go
+++ b/cmd/bd/race_detector_on_test.go
@@ -1,0 +1,9 @@
+//go:build race
+
+package main
+
+// raceEnabled reports whether the test binary was built with the race
+// detector (-race). Wall-clock performance budgets are unreliable under
+// race instrumentation (it adds multi-x overhead), so timing-sensitive
+// benches consult this flag before enforcing a duration bound.
+const raceEnabled = true


### PR DESCRIPTION
## Problem

The post-merge Main run after #4623 went green on 57/58 jobs, surfacing one **pre-existing** failure that had been masked: **`Main Linux integration cmd/bd (4/8)`**.

```
prune_bench_test.go:102: buildReferencedSet took 19.51s; must complete in <5s on 10K-bead fixture
--- FAIL: TestPruneLargeFixture (19.58s)
```

`TestPruneLargeFixture` asserts `buildReferencedSet` finishes in <5s on a 10K-bead × 5KB fixture. The Main integration cmd/bd shard runs the suite with **`-race`**, and the race detector adds multi-x overhead — a wall-clock budget is meaningless under it.

Measured locally:

| build | buildReferencedSet | result |
|---|---|---|
| no `-race` | ~1.2s | PASS |
| `-race` | ~19.5s | FAIL (budget) |

Why it was hidden: the job `needs: build-artifacts`, which was red (see #4623), so it was **skipped**. It last actually ran — and failed the same way — on the previous completed Main run (`b0ec22f3b`).

## Fix

Add a build-tag `raceEnabled` flag (`race_detector_{on,off}_test.go`) and enforce the timing bound **only in non-race builds**. The correctness assertions still run under `-race`, where exercising the 10K-bead fixture doubles as a data-race check.

## Validation (local)

- `-race`: **PASS** (timing bound skipped; correctness still checked)
- no `-race`: **PASS**, budget still enforced (~1.2s)
- `golangci-lint … ./cmd/bd/...` → 0 issues
- `CGO_ENABLED=0 go test -tags gms_pure_go -c` compiles
- `check-testing-short.sh` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)