### PR TITLE
fix(create): let --repo with a remote URL past the no-local-db guard (completes #4615 / #3774)

### DIFF
--- a/cmd/bd/create.go
+++ b/cmd/bd/create.go
@@ -110,7 +110,10 @@ var createCmd = &cobra.Command{
 
 		// Warn if creating a test issue in a database with existing issues.
 		// A brand-new repo with zero issues is not a "production database" (#2898).
-		if isTestIssue(title) && !silent && !debug.IsQuiet() {
+		// store is nil here for `create --repo=<remote URL>` from a directory with
+		// no local .beads/: PersistentPreRunE skips local store init entirely for
+		// that path, so this check is best-effort only.
+		if store != nil && isTestIssue(title) && !silent && !debug.IsQuiet() {
 			if stats, err := store.GetStatistics(context.Background()); err == nil && stats != nil && stats.TotalIssues >= 5 {
 				fmt.Fprintf(os.Stderr, "%s Creating test issue in production database\n", ui.RenderWarn("⚠"))
 				fmt.Fprintf(os.Stderr, "  Title: %q appears to be test data\n", title)
@@ -165,8 +168,12 @@ var createCmd = &cobra.Command{
 		statusFlag, _ := cmd.Flags().GetString("status")
 		if statusFlag != "" {
 			var customStatuses []string
-			if cs, err := store.GetCustomStatuses(rootCtx); err == nil {
-				customStatuses = cs
+			// store is nil for `create --repo=<remote URL>` with no local
+			// .beads/; fall back to built-in statuses only.
+			if store != nil {
+				if cs, err := store.GetCustomStatuses(rootCtx); err == nil {
+					customStatuses = cs
+				}
 			}
 			if !types.Status(statusFlag).IsValidWithCustom(customStatuses) {
 				return HandleErrorRespectJSON("invalid status %q (built-in: open, in_progress, blocked, deferred, closed, pinned, hooked; or configure custom statuses via 'bd config set status.custom')", statusFlag)

--- a/cmd/bd/create_repo_remote_url_preprun_test.go
+++ b/cmd/bd/create_repo_remote_url_preprun_test.go
@@ -56,7 +56,9 @@ func TestCreateRemoteRepoSkipsLocalDatabaseGuard(t *testing.T) {
 	t.Cleanup(func() { _ = os.Chdir(originalWD) })
 
 	// Hide the `dolt` CLI so remotecache.Ensure fails fast and
-	// deterministically, without attempting a real network call.
+	// deterministically in CGO-enabled builds, without attempting a real network
+	// call. Pure-Go builds can fail earlier when the remote cache store tries to
+	// use embedded Dolt, which is also downstream of the guard under test.
 	emptyPathDir := t.TempDir()
 	t.Setenv("PATH", emptyPathDir)
 
@@ -96,7 +98,8 @@ func TestCreateRemoteRepoSkipsLocalDatabaseGuard(t *testing.T) {
 		t.Fatalf("guard was not bypassed for remote --repo: got the pre-fix error.\nOutput:\n%s", combined)
 	}
 
-	if !strings.Contains(combined, "dolt CLI not found") {
-		t.Fatalf("expected downstream remote-cache failure (dolt CLI not found), got:\n%s", combined)
+	if !strings.Contains(combined, "dolt CLI not found") &&
+		!strings.Contains(combined, "embedded Dolt requires a CGO build") {
+		t.Fatalf("expected downstream remote-cache/open failure, got:\n%s", combined)
 	}
 }

--- a/cmd/bd/create_repo_remote_url_preprun_test.go
+++ b/cmd/bd/create_repo_remote_url_preprun_test.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestCreateRemoteRepoSkipsLocalDatabaseGuard is a regression test for a gap
+// left by gastownhall/beads#4615 (itself a reimplement of #3774). #4615
+// taught PersistentPreRunE to resolve a *local* `--repo` path's
+// workspace so `bd create --repo=<local path>` works from a directory with no
+// .beads/ of its own. Remote --repo URLs were left unhandled: PreRunE still
+// exited with "no beads database found" before create.go's remote-cache path
+// (internal/remotecache) ever ran, even though that path opens its own store
+// against the remote and needs no local database at all.
+//
+// This test does not exercise the real clone/pull (that needs network and a
+// live dolt remote); it hides the `dolt` CLI from PATH so
+// remotecache.Cache.Ensure fails fast and deterministically with "dolt CLI
+// not found" instead of attempting a network call. That failure occurring at
+// all is exactly what proves the earlier "no beads database found" guard got
+// bypassed for a remote --repo value.
+func TestCreateRemoteRepoSkipsLocalDatabaseGuard(t *testing.T) {
+	saveAndRestoreGlobals(t)
+	ensureCleanGlobalState(t)
+
+	originalReadonly := readonlyMode
+	t.Cleanup(func() { readonlyMode = originalReadonly })
+	readonlyMode = false
+
+	repoFlag := createCmd.Flags().Lookup("repo")
+	originalRepoValue := repoFlag.Value.String()
+	originalRepoChanged := repoFlag.Changed
+	t.Cleanup(func() {
+		_ = repoFlag.Value.Set(originalRepoValue)
+		repoFlag.Changed = originalRepoChanged
+	})
+
+	// Directory with no .beads/ workspace at all (and no .beads ancestor,
+	// since it is an independent temp dir).
+	noBeadsCwd := t.TempDir()
+	if _, err := os.Stat(filepath.Join(noBeadsCwd, ".beads")); err == nil {
+		t.Fatalf("test setup: %s unexpectedly has a .beads dir", noBeadsCwd)
+	}
+
+	originalWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(noBeadsCwd); err != nil {
+		t.Fatalf("chdir(%q): %v", noBeadsCwd, err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(originalWD) })
+
+	// Hide the `dolt` CLI so remotecache.Ensure fails fast and
+	// deterministically, without attempting a real network call.
+	emptyPathDir := t.TempDir()
+	t.Setenv("PATH", emptyPathDir)
+
+	store = nil
+	dbPath = ""
+
+	oldStdout := os.Stdout
+	oldStderr := os.Stderr
+	rOut, wOut, _ := os.Pipe()
+	rErr, wErr, _ := os.Pipe()
+	os.Stdout = wOut
+	os.Stderr = wErr
+	t.Cleanup(func() {
+		os.Stdout = oldStdout
+		os.Stderr = oldStderr
+	})
+
+	rootCmd.SetArgs([]string{"create", "--repo", "https://doltremoteapi.dolthub.com/example/does-not-exist", "remote --repo preprun guard test"})
+	execErr := rootCmd.Execute()
+	rootCmd.SetArgs(nil)
+
+	_ = wOut.Close()
+	_ = wErr.Close()
+	os.Stdout = oldStdout
+	os.Stderr = oldStderr
+
+	var stdoutBuf, stderrBuf bytes.Buffer
+	_, _ = stdoutBuf.ReadFrom(rOut)
+	_, _ = stderrBuf.ReadFrom(rErr)
+	combined := stdoutBuf.String() + stderrBuf.String()
+
+	if execErr == nil {
+		t.Fatalf("expected an error (dolt CLI is hidden from PATH), got success. Output:\n%s", combined)
+	}
+
+	if strings.Contains(combined, "no beads database found") {
+		t.Fatalf("guard was not bypassed for remote --repo: got the pre-fix error.\nOutput:\n%s", combined)
+	}
+
+	if !strings.Contains(combined, "dolt CLI not found") {
+		t.Fatalf("expected downstream remote-cache failure (dolt CLI not found), got:\n%s", combined)
+	}
+}

--- a/cmd/bd/main.go
+++ b/cmd/bd/main.go
@@ -967,15 +967,22 @@ var rootCmd = &cobra.Command{
 					return nil
 				}
 
-				// GH#3686: `bd create --repo=<local path>` targets a different
+				// GH#3686: `bd create --repo=<path-or-URL>` targets a different
 				// repo's workspace. Without this, PreRun exits with "no beads
 				// database found" before create.go's --repo handling runs, even
-				// when the target repo has a valid .beads/. Resolve the target
-				// workspace here so store initialization points at it. Remote
-				// --repo URLs are handled by create.go via the remote cache, so
-				// only local paths are resolved here.
+				// when the target has a valid workspace of its own. Resolve
+				// local targets here so store initialization points at them.
+				// Remote --repo URLs need no local database at all: create.go
+				// opens the remote store itself via the remote cache and never
+				// touches the local `store` global on that path (a gap left by
+				// #4615, which only handled local paths), so skip local
+				// discovery entirely instead of falling through to the "no
+				// beads database found" exit below.
 				if cmd.Name() == "create" && cmd.Flags().Changed("repo") {
-					if repoVal, _ := cmd.Flags().GetString("repo"); repoVal != "" && !remotecache.IsRemoteURL(repoVal) {
+					if repoVal, _ := cmd.Flags().GetString("repo"); repoVal != "" {
+						if remotecache.IsRemoteURL(repoVal) {
+							return nil
+						}
 						targetBeadsDir := filepath.Join(routing.ExpandPath(repoVal), ".beads")
 						dbPath = utils.CanonicalizePath(filepath.Join(targetBeadsDir, beads.CanonicalDatabaseName))
 					}


### PR DESCRIPTION
## Why

`bd create --repo <REMOTE-URL>` run from a directory with no `.beads/` still dies with "no beads database found" before `create.go`'s remote-cache path ever runs. #4615 fixed the local-path half of #3774's report; this completes the remote-URL half. Remote-first workflows (create an issue in a shared remote DB from anywhere) currently require cd-ing into some unrelated beads workspace first.

## What

- `cmd/bd/main.go` PersistentPreRunE: when no local database is found and `--repo` is a remote URL per `remotecache.IsRemoteURL`, return early instead of falling through to the hard exit. The early return is nested inside the no-local-DB branch, so behavior inside an existing workspace is completely unchanged (migrations, locks, store open all still run there).
- `cmd/bd/create.go`: two `store != nil` guards on dereferences that were previously unreachable with a nil store (test-issue production-DB warning, `--status` custom-statuses lookup). They degrade gracefully now.

Both the PreRun guard and create.go's branch selector call the same `IsRemoteURL` on the same raw string, so they can never disagree about which path handles the value.

## Behavior note

Remote create from a bare directory uses local/global config for `create.require-description`, `validation.on-create`, and the default issue prefix, since no workspace config exists to load. Not a regression (this path previously hard-exited), and explicit `--id` prefix validation still falls back to the remote store, but worth knowing.

## Testing

- New regression test `TestCreateRemoteRepoSkipsLocalDatabaseGuard`: runs create in-process from a bare dir with PATH scrubbed (deterministic, no network); passes with the fix, fails without it (verified both ways).
- `CGO_ENABLED=0 go build -tags gms_pure_go ./cmd/bd/...` clean; gofmt clean; targeted create/repo/routing suites pass.
- Manual repro: the failure moved from the local guard rejection to a genuine remote `permission denied` from dolt, as expected.
- An independent read-only review traced every nil-store path reachable in create's RunE before `setStore` (including `--dry-run --parent` and PersistentPostRunE) and found all guarded or nil-safe.

_claude-fable-5-high on behalf of matt wilkie_
