### PR TITLE
docs: regenerate CLI reference after clean-databases prefix-list change (fixes red main)

### DIFF
--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -3015,7 +3015,7 @@ bd dolt
 Identify and drop leftover test and agent databases that accumulate
 on the shared Dolt server from interrupted test runs and terminated agents.
 
-Stale database prefixes: testdb_*, doctest_*, doctortest_*, beads_pt*, beads_vr*, beads_t*
+Stale database prefixes: testdb_*, beads_test*, beads_pt*, beads_vr*, doctest_*, doctortest_*, benchdb_*
 
 These waste server memory and can degrade performance under concurrent load.
 Use --dry-run to see what would be dropped without actually dropping.

--- a/website/docs/cli-reference/dolt.md
+++ b/website/docs/cli-reference/dolt.md
@@ -61,7 +61,7 @@ bd dolt [flags]
 Identify and drop leftover test and agent databases that accumulate
 on the shared Dolt server from interrupted test runs and terminated agents.
 
-Stale database prefixes: testdb_*, doctest_*, doctortest_*, beads_pt*, beads_vr*, beads_t*
+Stale database prefixes: testdb_*, beads_test*, beads_pt*, beads_vr*, doctest_*, doctortest_*, benchdb_*
 
 These waste server memory and can degrade performance under concurrent load.
 Use --dry-run to see what would be dropped without actually dropping.


### PR DESCRIPTION
## Why

Main is red. Since 64d67e09 (`chore(dolt): converge bd dolt clean-databases prefix list`, merged ~14:49 UTC today) the Main workflow fails in three jobs — **Check doc flags freshness**, **Build Artifacts**, and **PR Policy** — all with:

```
FAIL: docs/CLI_REFERENCE.md is out of sync with live CLI help.
```

That commit changed the `bd dolt clean-databases` help text (the stale-prefix list) without regenerating the generated docs.

## What

Regenerated with `scripts/generate-cli-docs.sh` (pinned pure-Go binary, per repo guidance — no CGO federation churn). The delta is exactly the prefix-list line in the two generated files:

- `docs/CLI_REFERENCE.md`
- `website/docs/cli-reference/dolt.md`

No hand edits.

Note: the same red run also had `Test (Embedded Dolt Storage)` panic at the 20m test timeout — that is a separate flake-family issue, not addressed here.

_claude-fable-5-high on behalf of matt wilkie_
