### PR TITLE
ci(main): split conformance out of embedded storage job (fixes 20m timeout red main)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -856,7 +856,41 @@ jobs:
         env:
           BEADS_TEST_EMBEDDED_DOLT: "1"
           BEADS_TEST_EMBEDDED_TEST_BINARY: /tmp/embeddeddolt-test
-        run: /tmp/embeddeddolt-test -test.v -test.count=1 -test.timeout=20m
+        # Conformance runs in the dedicated test-embedded-conformance job
+        # below (mirrors pr-risk.yml); skip it here so this job stays inside
+        # its 20m envelope as the base embedded suite grows.
+        run: /tmp/embeddeddolt-test -test.v -test.count=1 -test.timeout=20m -test.skip '^TestConformance$'
+
+  test-embedded-conformance:
+    name: Test (Embedded Dolt Conformance)
+    needs: [detect-ci-tier, build-embedded]
+    if: needs.detect-ci-tier.outputs.full_embedded == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+
+      - name: Download binaries
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: embedded-test-binaries
+          path: /tmp/
+
+      - name: Fix permissions
+        run: chmod +x /tmp/embeddeddolt-test
+
+      - name: Configure Git
+        run: |
+          git config --global user.name "CI Bot"
+          git config --global user.email "ci@beads.test"
+
+      - name: Test
+        env:
+          BEADS_TEST_EMBEDDED_DOLT: "1"
+          BEADS_TEST_EMBEDDED_TEST_BINARY: /tmp/embeddeddolt-test
+        # Conformance suite (conformance.RunAll via TestConformance) against
+        # the embedded Dolt backend, split from test-embedded-storage so each
+        # job stays well under its timeout - same structure as pr-risk.yml.
+        run: /tmp/embeddeddolt-test -test.v -test.count=1 -test.timeout=15m -test.run '^TestConformance$'
 
   test-embedded-cmd:
     name: Test (Embedded Dolt Cmd ${{ matrix.shard }}/${{ strategy.job-total }})


### PR DESCRIPTION
## Why

Main is red on **Test (Embedded Dolt Storage)**: `panic: test timed out after 20m0s` on both completed Main runs today ([c88db21c](https://github.com/gastownhall/beads/actions/runs/28875848419), [c3d68d9f](https://github.com/gastownhall/beads/actions/runs/28882075422)). It is not a hung test — at alarm time the running test was only 14s in. The suite as a whole outgrew its envelope: recent green runs took 15–16 min against the 20m limit, and today's merge train added storage tests that pushed it over.

Root cause is an asymmetry between the two workflows. #4414 split `TestConformance` into a dedicated **Test (Embedded Dolt Conformance)** job in `pr-risk.yml` and added `-test.skip '^TestConformance$'` to the storage job ("keeps this job inside its envelope"). `main.yml` never got the same split, so main's storage job still runs the full binary — base storage suite *plus* conformance — in one 20m envelope. That is exactly why PR checks stay green while main goes red.

## What

Port the split to `main.yml`, mirroring `pr-risk.yml`:

- `test-embedded-storage` gains `-test.skip '^TestConformance$'`
- new `test-embedded-conformance` job (same pinned action SHAs, `-test.run '^TestConformance$'`, 15m timeout)

No gate/`needs:` wiring needed — main.yml's embedded jobs are independent. actionlint passes.

Under stop-the-line this is the fix for main and mergeable while red.

Tracked by mybd-socu.

_claude-fable-5-high on behalf of matt wilkie_
