### PR TITLE
fix(dolt): report pre-push fsck timeout as timeout, not dangling chunk reference

### DIFF
--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -60,6 +60,7 @@ Common tool-level settings you can configure:
 | `dolt.auto-push` | - | `BD_DOLT_AUTO_PUSH` | `false` | Auto-push to Dolt remote after writes (explicit opt-in) |
 | `dolt.auto-push-interval` | - | `BD_DOLT_AUTO_PUSH_INTERVAL` | `5m` | Minimum time between auto-pushes |
 | `dolt.auto-push-timeout` | - | `BD_DOLT_AUTO_PUSH_TIMEOUT` | `30s` | Timeout for a single auto-push attempt |
+| pre-push fsck timeout | - | `BEADS_FSCK_TIMEOUT` | `30s` | Runtime-only timeout for the pre-push `dolt fsck --quiet` integrity check |
 | `dolt.shared-server` | `--shared-server` | `BEADS_DOLT_SHARED_SERVER` | `false` | Share a single Dolt server across all projects at `~/.beads/shared-server/` |
 | `db` | `--db` | `BD_DB` | (auto-discover) | Database path |
 | `actor` | `--actor` | `BEADS_ACTOR` | `git config user.name` | Actor name for audit trail (see below) |

--- a/internal/storage/dolt/errors.go
+++ b/internal/storage/dolt/errors.go
@@ -36,6 +36,14 @@ var (
 	// to diagnose and recover.
 	ErrDanglingReference = errors.New("dangling chunk reference")
 
+	// ErrFSCKTimeout indicates that the pre-push integrity check (dolt fsck) did
+	// not complete within the configured timeout. The push was aborted without
+	// verifying chunk integrity — the store is not necessarily corrupt. Large
+	// stores can be shrunk with `dolt gc` (or `CALL DOLT_GC()` on a running
+	// sql-server); the timeout can be raised via the BEADS_FSCK_TIMEOUT
+	// environment variable.
+	ErrFSCKTimeout = errors.New("pre-push integrity check timed out")
+
 	// errCommitPhase marks an error as having occurred during tx.Commit (as
 	// opposed to BeginTx or the transaction body). A connection failure during
 	// commit is ambiguous — the commit may have landed on the server before the

--- a/internal/storage/dolt/fsck_test.go
+++ b/internal/storage/dolt/fsck_test.go
@@ -2,10 +2,13 @@ package dolt
 
 import (
 	"context"
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
+	"time"
 )
 
 // TestPrePushFSCK_EmptyCLIDir verifies that prePushFSCK is a no-op when
@@ -126,4 +129,170 @@ func TestFsckCouldNotOpen(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestClassifyFSCKFailure verifies that classifyFSCKFailure maps every failure
+// mode to the correct outcome, and includes negative sentinel checks to guard
+// against misclassification.
+func TestClassifyFSCKFailure(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name         string
+		parentErr    error
+		fsckErr      error
+		output       string
+		wantNil      bool    // true → expect nil (could-not-open skip path)
+		wantIs       error   // positive errors.Is assertion
+		wantIsNot    []error // negative errors.Is assertions
+		wantContains string  // substring expected in error message
+		wantAbsent   string  // substring that must NOT appear
+	}{
+		// (a) Non-empty output wins over context state: real dangling reference
+		//     arriving exactly at the deadline must not be masked as a timeout.
+		{
+			name:      "non-empty output + DeadlineExceeded → ErrDanglingReference, not ErrFSCKTimeout",
+			parentErr: context.DeadlineExceeded,
+			fsckErr:   context.DeadlineExceeded,
+			output:    "dangling chunk reference: hash abc123 not found",
+			wantIs:    ErrDanglingReference,
+			wantIsNot: []error{ErrFSCKTimeout},
+		},
+		// (a) could-not-open output → nil (skip, caller logs).
+		{
+			name:      "non-empty could-not-open output → nil (skip, not an abort)",
+			parentErr: nil,
+			fsckErr:   nil,
+			output:    "Could not open dolt database: some reason",
+			wantNil:   true,
+		},
+		// (b) Parent context canceled → plain cancellation, not ErrDanglingReference
+		//     or ErrFSCKTimeout.
+		{
+			name:         "parent Canceled → cancellation error, not dangling or timeout",
+			parentErr:    context.Canceled,
+			fsckErr:      context.Canceled,
+			output:       "",
+			wantIs:       context.Canceled,
+			wantIsNot:    []error{ErrDanglingReference, ErrFSCKTimeout},
+			wantContains: "interrupted",
+		},
+		// (c) Parent deadline exceeded → ErrFSCKTimeout, guidance names
+		//     dolt.auto-push-timeout; the "raise via BEADS_FSCK_TIMEOUT env var"
+		//     phrasing must NOT appear (it cannot extend the caller deadline).
+		{
+			name:         "parent DeadlineExceeded → ErrFSCKTimeout with caller-timeout guidance",
+			parentErr:    context.DeadlineExceeded,
+			fsckErr:      context.DeadlineExceeded,
+			output:       "",
+			wantIs:       ErrFSCKTimeout,
+			wantIsNot:    []error{ErrDanglingReference},
+			wantContains: "dolt.auto-push-timeout",
+			wantAbsent:   "BEADS_FSCK_TIMEOUT environment variable",
+		},
+		// (d) Only fsck's own timeout fired (parent still running) → ErrFSCKTimeout
+		//     with BEADS_FSCK_TIMEOUT guidance. Message must differ from (c).
+		{
+			name:         "own fsck DeadlineExceeded → ErrFSCKTimeout with BEADS_FSCK_TIMEOUT guidance",
+			parentErr:    nil,
+			fsckErr:      context.DeadlineExceeded,
+			output:       "",
+			wantIs:       ErrFSCKTimeout,
+			wantIsNot:    []error{ErrDanglingReference},
+			wantContains: "BEADS_FSCK_TIMEOUT",
+		},
+		// (e) Generic non-zero exit, empty output, no context error → ErrDanglingReference.
+		{
+			name:      "generic failure (empty output, no ctx error) → ErrDanglingReference",
+			parentErr: nil,
+			fsckErr:   nil,
+			output:    "",
+			wantIs:    ErrDanglingReference,
+			wantIsNot: []error{ErrFSCKTimeout},
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := classifyFSCKFailure(tc.parentErr, tc.fsckErr, tc.output)
+
+			if tc.wantNil {
+				if err != nil {
+					t.Errorf("want nil, got %v", err)
+				}
+				return
+			}
+
+			if err == nil {
+				t.Fatalf("want non-nil error, got nil")
+			}
+
+			if tc.wantIs != nil && !errors.Is(err, tc.wantIs) {
+				t.Errorf("errors.Is(err, %v) = false; err = %v", tc.wantIs, err)
+			}
+			for _, notErr := range tc.wantIsNot {
+				if errors.Is(err, notErr) {
+					t.Errorf("errors.Is(err, %v) = true, want false; err = %v", notErr, err)
+				}
+			}
+			if tc.wantContains != "" && !strings.Contains(err.Error(), tc.wantContains) {
+				t.Errorf("error message %q does not contain %q", err.Error(), tc.wantContains)
+			}
+			if tc.wantAbsent != "" && strings.Contains(err.Error(), tc.wantAbsent) {
+				t.Errorf("error message %q must not contain %q", err.Error(), tc.wantAbsent)
+			}
+		})
+	}
+}
+
+// TestClassifyFSCKFailure_CallerVsOwnTimeout verifies that caller-deadline (c)
+// and own-timeout (d) produce distinct guidance text — the first must name
+// dolt.auto-push-timeout and the second must name BEADS_FSCK_TIMEOUT.
+func TestClassifyFSCKFailure_CallerVsOwnTimeout(t *testing.T) {
+	t.Parallel()
+
+	callerErr := classifyFSCKFailure(context.DeadlineExceeded, context.DeadlineExceeded, "")
+	ownErr := classifyFSCKFailure(nil, context.DeadlineExceeded, "")
+
+	if callerErr == nil || ownErr == nil {
+		t.Fatal("both cases must return non-nil errors")
+	}
+	callerMsg := callerErr.Error()
+	ownMsg := ownErr.Error()
+
+	if !strings.Contains(callerMsg, "dolt.auto-push-timeout") {
+		t.Errorf("caller-deadline message should name dolt.auto-push-timeout; got: %q", callerMsg)
+	}
+	if strings.Contains(callerMsg, "BEADS_FSCK_TIMEOUT environment variable") {
+		t.Errorf("caller-deadline message must not say BEADS_FSCK_TIMEOUT environment variable; got: %q", callerMsg)
+	}
+	if !strings.Contains(ownMsg, "BEADS_FSCK_TIMEOUT") {
+		t.Errorf("own-timeout message should name BEADS_FSCK_TIMEOUT; got: %q", ownMsg)
+	}
+	if strings.Contains(ownMsg, "dolt.auto-push-timeout") {
+		t.Errorf("own-timeout message must not name dolt.auto-push-timeout; got: %q", ownMsg)
+	}
+}
+
+// TestFsckTimeoutDuration verifies BEADS_FSCK_TIMEOUT parsing: valid durations
+// are honored, unset and invalid values fall back to the compiled-in default.
+func TestFsckTimeoutDuration(t *testing.T) {
+	t.Run("valid duration honored", func(t *testing.T) {
+		t.Setenv(fsckTimeoutEnv, "2m")
+		if got := fsckTimeoutDuration(); got != 2*time.Minute {
+			t.Errorf("want 2m, got %v", got)
+		}
+	})
+	t.Run("unset returns default", func(t *testing.T) {
+		t.Setenv(fsckTimeoutEnv, "")
+		if got := fsckTimeoutDuration(); got != fsckTimeout {
+			t.Errorf("want %v (default), got %v", fsckTimeout, got)
+		}
+	})
+	t.Run("invalid returns default", func(t *testing.T) {
+		t.Setenv(fsckTimeoutEnv, "not-a-duration")
+		if got := fsckTimeoutDuration(); got != fsckTimeout {
+			t.Errorf("want %v (default), got %v", fsckTimeout, got)
+		}
+	})
 }

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -308,10 +308,39 @@ func withCLIExecTimeout(ctx context.Context) (context.Context, context.CancelFun
 	return context.WithTimeout(ctx, cliExecTimeout)
 }
 
-// fsckTimeout is the maximum time to wait for dolt fsck to verify the local
-// chunk store before a push. fsck reads local files only; 30 seconds is ample
-// for any DB size we currently operate.
+// fsckTimeout is the default maximum time to wait for dolt fsck to verify the
+// local chunk store before a push. fsck reads local files only; 30 seconds is
+// ample for small stores. Large stores may need more time; set
+// BEADS_FSCK_TIMEOUT to override.
 const fsckTimeout = 30 * time.Second
+
+// fsckTimeoutEnv is the environment variable that overrides fsckTimeout.
+const fsckTimeoutEnv = "BEADS_FSCK_TIMEOUT"
+
+// fsckTimeoutDuration returns the configured fsck timeout. The env var
+// BEADS_FSCK_TIMEOUT overrides the compiled-in fsckTimeout const; valid
+// time.ParseDuration strings (e.g. "2m", "90s") or bare numbers treated as
+// seconds (e.g. "90") are accepted. Unset or invalid values fall back to
+// fsckTimeout.
+func fsckTimeoutDuration() time.Duration {
+	raw := strings.TrimSpace(os.Getenv(fsckTimeoutEnv))
+	if raw == "" {
+		return fsckTimeout
+	}
+	if d, err := time.ParseDuration(raw); err == nil {
+		if d > 0 {
+			return d
+		}
+		return fsckTimeout
+	}
+	if d, err := time.ParseDuration(raw + "s"); err == nil {
+		if d > 0 {
+			return d
+		}
+		return fsckTimeout
+	}
+	return fsckTimeout
+}
 
 // Retry configuration for transient connection errors (stale pool connections,
 // brief network issues, server restarts).
@@ -2330,7 +2359,12 @@ func (s *DoltStore) credentialsForRemote(remote string) *remoteCredentials {
 // re-pushes that remote faithfully propagates the dangling reference.
 //
 // If CLIDir is empty or .dolt/noms does not exist, the check is skipped.
-// Any fsck failure returns ErrDanglingReference — the push is NOT attempted.
+// Five outcomes are possible when fsck exits non-zero (see classifyFSCKFailure):
+//   - non-empty output, could-not-open: skipped with a log warning.
+//   - non-empty output, other: ErrDanglingReference — push aborted.
+//   - parent context canceled: cancellation error — push aborted.
+//   - parent context deadline exceeded: ErrFSCKTimeout (caller timeout) — push aborted.
+//   - fsck own timeout: ErrFSCKTimeout (raise BEADS_FSCK_TIMEOUT) — push aborted.
 func (s *DoltStore) prePushFSCK(ctx context.Context) error {
 	dir := s.CLIDir()
 	if dir == "" {
@@ -2339,34 +2373,84 @@ func (s *DoltStore) prePushFSCK(ctx context.Context) error {
 	if _, err := os.Stat(filepath.Join(dir, ".dolt", "noms")); os.IsNotExist(err) {
 		return nil
 	}
-	fsckCtx, cancel := context.WithTimeout(ctx, fsckTimeout)
+	fsckCtx, cancel := context.WithTimeout(ctx, fsckTimeoutDuration())
 	defer cancel()
 	cmd := exec.CommandContext(fsckCtx, "dolt", "fsck", "--quiet") // #nosec G204 -- fixed command
 	cmd.Dir = dir
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		output := strings.TrimSpace(string(out))
-		// Distinguish "fsck couldn't run the integrity check" (environmental /
-		// tooling issue) from "fsck ran and found integrity problems" (the actual
-		// concern of PR #3447). Wrapping an open-failure as ErrDanglingReference
-		// misleads users into thinking their db is corrupt.
-		//
-		// Concrete example: dolthub/dolt#10915 (Windows url.Parse bug, pre-v1.86.4)
-		// caused fsck to construct a malformed file path and fail to open; users
-		// running `bd dolt push` saw "dangling chunk reference" errors on perfectly
-		// healthy databases.
-		//
-		// The two known "couldn't open" signatures from dolt are covered below.
-		// Any other fsck failure still aborts the push so real dangling references
-		// continue to block propagation.
+		if classified := classifyFSCKFailure(ctx.Err(), fsckCtx.Err(), output); classified != nil {
+			return classified
+		}
+		log.Printf("pre-push fsck could not run, skipping integrity check: %s", output)
+		return nil
+	}
+	return nil
+}
+
+// classifyFSCKFailure maps a failed dolt fsck exit into one of five outcomes,
+// evaluated in priority order:
+//
+//	(a) Non-empty output → route by content: could-not-open → nil (caller logs
+//	    and skips); any other content → ErrDanglingReference abort. Non-empty
+//	    output means fsck actually ran and said something (--quiet fsck is
+//	    silent until it finds a problem), so content wins over context state.
+//	    This also closes the race where real corruption arrives at the deadline
+//	    instant and would otherwise be masked as a timeout.
+//
+//	(b) Parent context canceled (Ctrl-C, caller abort) → plain cancellation
+//	    error wrapping context.Canceled; neither ErrDanglingReference nor
+//	    ErrFSCKTimeout (the store is not implicated).
+//
+//	(c) Parent context deadline exceeded → ErrFSCKTimeout, but guidance points
+//	    at the CALLER's timeout (e.g. dolt.auto-push-timeout for auto-push)
+//	    and explicitly notes BEADS_FSCK_TIMEOUT cannot extend it. Checked
+//	    before fsck's own deadline because a fired parent context propagates
+//	    cancellation into all child contexts, making both parentErr and fsckErr
+//	    DeadlineExceeded simultaneously.
+//
+//	(d) fsck's own deadline exceeded, parent still running → ErrFSCKTimeout
+//	    with dolt gc / CALL DOLT_GC() / BEADS_FSCK_TIMEOUT guidance.
+//
+//	(e) Generic non-zero exit, empty output → ErrDanglingReference abort.
+//
+// Returning nil for the could-not-open case (branch a) distinguishes "fsck
+// couldn't run at all" from "fsck ran and found a problem". Wrapping an
+// open-failure as ErrDanglingReference misleads users (dolthub/dolt#10915).
+func classifyFSCKFailure(parentErr, fsckErr error, output string) error {
+	// (a) Non-empty output: fsck actually reported something; route by content.
+	if output != "" {
 		if fsckCouldNotOpen(output) {
-			log.Printf("pre-push fsck could not run, skipping integrity check: %s", output)
 			return nil
 		}
 		return fmt.Errorf("%w: aborting push to prevent propagating corrupt chunks: %s",
 			ErrDanglingReference, output)
 	}
-	return nil
+	// (b) Parent context canceled — user interrupt or caller abort.
+	if errors.Is(parentErr, context.Canceled) {
+		return fmt.Errorf("pre-push integrity check interrupted: %w", parentErr)
+	}
+	// (c) Caller's deadline expired during fsck. Point at the caller's timeout;
+	// BEADS_FSCK_TIMEOUT cannot extend a deadline imposed by the caller.
+	if errors.Is(parentErr, context.DeadlineExceeded) {
+		return fmt.Errorf("%w: the surrounding operation's deadline expired during the "+
+			"pre-push integrity check; to extend it, raise the caller timeout "+
+			"(for auto-push: the dolt.auto-push-timeout config); "+
+			"note that BEADS_FSCK_TIMEOUT cannot extend the caller deadline",
+			ErrFSCKTimeout)
+	}
+	// (d) fsck's own per-call timeout expired (parent still running).
+	if errors.Is(fsckErr, context.DeadlineExceeded) {
+		return fmt.Errorf("%w: fsck did not complete within the configured timeout; "+
+			"the push was aborted without checking integrity (the store is not necessarily corrupt); "+
+			"large stores can be shrunk with `dolt gc` (or `CALL DOLT_GC()` on a running sql-server); "+
+			"the timeout can be raised via the BEADS_FSCK_TIMEOUT environment variable",
+			ErrFSCKTimeout)
+	}
+	// (e) Generic failure with no output and no recognized context error.
+	return fmt.Errorf("%w: aborting push to prevent propagating corrupt chunks",
+		ErrDanglingReference)
 }
 
 // fsckCouldNotOpen reports whether dolt fsck output indicates the check


### PR DESCRIPTION
## Why

Fixes the false-positive corruption report in #4258. `prePushFSCK` runs `dolt fsck --quiet` under a 30s timeout; when fsck exceeds it, `exec.CommandContext` SIGKILLs the process and the killed run (empty output) was wrapped as `ErrDanglingReference` — so users with large, perfectly healthy stores saw `Error: dangling chunk reference:` (note the empty suffix) on every `bd dolt push`. Independently root-caused by @jonathanpberger in https://github.com/gastownhall/beads/issues/4258#issuecomment-4904911432 (2.6 GB store, fsck needs 67.8 s; after `CALL DOLT_GC()` it passes in 0.5 s and push succeeds).

## What

- New sentinel `ErrFSCKTimeout`; fsck failures are now classified by a small pure helper `classifyFSCKFailure(parentErr, fsckErr, output)`:
  1. non-empty fsck output → existing routing (could-not-open signatures skip with a log; anything else stays `ErrDanglingReference` and aborts) — real corruption findings always win;
  2. parent context canceled (e.g. Ctrl-C) → plain interruption error, no corruption/timeout wording;
  3. parent context deadline expired (e.g. auto-push's `dolt.auto-push-timeout`) → guidance points at the caller's timeout and notes `BEADS_FSCK_TIMEOUT` cannot extend it;
  4. fsck's own timeout → `ErrFSCKTimeout` with actionable guidance: the store is not necessarily corrupt; shrink with `dolt gc` / `CALL DOLT_GC()`, or raise `BEADS_FSCK_TIMEOUT`;
  5. anything else → `ErrDanglingReference` abort, unchanged.
- `BEADS_FSCK_TIMEOUT` duration env override (default 30s), mirroring the existing `BEADS_PRIME_TIMEOUT` pattern.
- The push is still aborted on timeout — this changes the *diagnosis*, not the safety gate. No cross-boundary behavior added; this corrects beads' own error classification around its fsck subprocess.

## Tests

Table-driven unit tests cover all five classification branches (including "non-empty output wins over deadline" and caller-vs-own-timeout message divergence), plus `BEADS_FSCK_TIMEOUT` parsing (valid/unset/invalid). `gofmt`/`go vet` clean; `go test ./internal/storage/dolt/ -run 'FSCK|Fsck|fsck'` — 11 pass.

Reviewed pre-submission by two independent model families (Claude opus reviewer + Codex `gpt-5.5` review); the caller-deadline misattribution (point 3) was a cross-vendor finding.

_claude-fable-5-high on behalf of matt wilkie_
