### PR TITLE
cmd/bd: wire bd dolt remote remove for proxied-server mode

### DIFF
--- a/cmd/bd/dolt.go
+++ b/cmd/bd/dolt.go
@@ -1262,12 +1262,18 @@ var doltRemoteRemoveCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx := context.Background()
+		name := args[0]
+
+		if usesProxiedServer() {
+			runDoltRemoteRemoveProxied(ctx, name)
+			return
+		}
+
 		st := getStore()
 		if st == nil {
 			fmt.Fprintf(os.Stderr, "Error: no store available\n")
 			os.Exit(1)
 		}
-		name := args[0]
 
 		if err := st.RemoveRemote(ctx, name); err != nil {
 			if jsonOutput {

--- a/cmd/bd/dolt_remote_proxied_server.go
+++ b/cmd/bd/dolt_remote_proxied_server.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/steveyegge/beads/internal/config"
+)
+
+func runDoltRemoteRemoveProxied(ctx context.Context, name string) {
+	if uowProvider == nil {
+		fmt.Fprintf(os.Stderr, "Error: proxied-server UOW provider not initialized\n")
+		os.Exit(1)
+	}
+	uw, err := uowProvider.NewUOW(ctx)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error opening unit of work: %v\n", err)
+		os.Exit(1)
+	}
+	defer uw.Close(ctx)
+
+	if err := uw.DoltRemoteUseCase().DeleteRemote(ctx, name); err != nil {
+		if jsonOutput {
+			_ = outputJSONError(err, "remote_remove_failed")
+		} else {
+			fmt.Fprintf(os.Stderr, "Error removing remote: %v\n", err)
+		}
+		os.Exit(1)
+	}
+
+	if err := uw.Commit(ctx, fmt.Sprintf("bd: remove remote %s", name)); err != nil && !isDoltNothingToCommit(err) {
+		fmt.Fprintf(os.Stderr, "Error committing remote removal: %v\n", err)
+		os.Exit(1)
+	}
+
+	if name == "origin" {
+		if current := config.GetYamlConfig("sync.remote"); current != "" {
+			if err := config.UnsetYamlConfig("sync.remote"); err != nil {
+				fmt.Fprintf(os.Stderr, "Warning: failed to clear sync.remote from config.yaml: %v\n", err)
+			}
+			if isGitRepo() {
+				commitBeadsConfig("bd: clear sync.remote")
+			}
+		}
+	}
+
+	if jsonOutput {
+		if err := outputJSON(map[string]interface{}{
+			"name":    name,
+			"removed": true,
+		}); err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		}
+	} else {
+		fmt.Printf("Removed remote %q\n", name)
+	}
+}

--- a/cmd/bd/dolt_remote_proxied_server.go
+++ b/cmd/bd/dolt_remote_proxied_server.go
@@ -10,13 +10,11 @@ import (
 
 func runDoltRemoteRemoveProxied(ctx context.Context, name string) {
 	if uowProvider == nil {
-		fmt.Fprintf(os.Stderr, "Error: proxied-server UOW provider not initialized\n")
-		os.Exit(1)
+		FatalError("proxied-server UOW provider not initialized")
 	}
 	uw, err := uowProvider.NewUOW(ctx)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error opening unit of work: %v\n", err)
-		os.Exit(1)
+		FatalErrorRespectJSON("open unit of work: %v", err)
 	}
 	defer uw.Close(ctx)
 
@@ -30,8 +28,7 @@ func runDoltRemoteRemoveProxied(ctx context.Context, name string) {
 	}
 
 	if err := uw.Commit(ctx, fmt.Sprintf("bd: remove remote %s", name)); err != nil && !isDoltNothingToCommit(err) {
-		fmt.Fprintf(os.Stderr, "Error committing remote removal: %v\n", err)
-		os.Exit(1)
+		FatalErrorRespectJSON("commit: %v", err)
 	}
 
 	if name == "origin" {

--- a/cmd/bd/dolt_remote_remove_proxied_integration_test.go
+++ b/cmd/bd/dolt_remote_remove_proxied_integration_test.go
@@ -1,0 +1,87 @@
+//go:build cgo
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestProxiedServerDoltRemoteRemove(t *testing.T) {
+	requireProxiedServerEnv(t)
+	bd := buildEmbeddedBD(t)
+
+	seedRemote := func(t *testing.T, p proxiedProject, name, url string) {
+		t.Helper()
+		db := openProxiedDB(t, p)
+		if _, err := db.ExecContext(context.Background(),
+			"CALL DOLT_REMOTE('add', ?, ?)", name, url); err != nil {
+			t.Fatalf("seed remote %s: %v", name, err)
+		}
+	}
+
+	remoteCount := func(t *testing.T, p proxiedProject, name string) int {
+		t.Helper()
+		db := openProxiedDB(t, p)
+		var count int
+		if err := db.QueryRowContext(context.Background(),
+			"SELECT COUNT(*) FROM dolt_remotes WHERE name = ?", name).Scan(&count); err != nil {
+			t.Fatalf("query dolt_remotes: %v", err)
+		}
+		return count
+	}
+
+	t.Run("removes_existing_remote", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "prr1")
+		seedRemote(t, p, "backup", "https://doltremoteapi.dolthub.com/org/backup")
+
+		out, err := bdProxiedRun(t, bd, p.dir, "dolt", "remote", "remove", "backup")
+		if err != nil {
+			t.Fatalf("remote remove failed: %v\n%s", err, out)
+		}
+		if !strings.Contains(string(out), `Removed remote "backup"`) {
+			t.Errorf("unexpected output: %s", out)
+		}
+		if c := remoteCount(t, p, "backup"); c != 0 {
+			t.Errorf("remote 'backup' still present after remove (count=%d)", c)
+		}
+	})
+
+	t.Run("json_output", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "prr2")
+		seedRemote(t, p, "backup", "https://doltremoteapi.dolthub.com/org/backup")
+
+		out, err := bdProxiedRun(t, bd, p.dir, "dolt", "remote", "remove", "--json", "backup")
+		if err != nil {
+			t.Fatalf("remote remove --json failed: %v\n%s", err, out)
+		}
+		s := string(out)
+		start := strings.Index(s, "{")
+		if start < 0 {
+			t.Fatalf("no JSON object in output: %s", s)
+		}
+		var res struct {
+			Name    string `json:"name"`
+			Removed bool   `json:"removed"`
+		}
+		if err := json.Unmarshal([]byte(s[start:]), &res); err != nil {
+			t.Fatalf("parse JSON: %v\n%s", err, s)
+		}
+		if res.Name != "backup" || !res.Removed {
+			t.Errorf("unexpected JSON result: %+v", res)
+		}
+		if c := remoteCount(t, p, "backup"); c != 0 {
+			t.Errorf("remote 'backup' still present after remove (count=%d)", c)
+		}
+	})
+
+	t.Run("nonexistent_remote_errors", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "prr3")
+		out, err := bdProxiedRun(t, bd, p.dir, "dolt", "remote", "remove", "ghost")
+		if err == nil {
+			t.Fatalf("expected error removing nonexistent remote, got:\n%s", out)
+		}
+	})
+}

--- a/cmd/bd/dolt_remote_remove_proxied_integration_test.go
+++ b/cmd/bd/dolt_remote_remove_proxied_integration_test.go
@@ -83,5 +83,9 @@ func TestProxiedServerDoltRemoteRemove(t *testing.T) {
 		if err == nil {
 			t.Fatalf("expected error removing nonexistent remote, got:\n%s", out)
 		}
+		s := string(out)
+		if !strings.Contains(s, "removing remote") || !strings.Contains(s, "ghost") {
+			t.Errorf("expected a remove-failure error naming %q, got:\n%s", "ghost", s)
+		}
 	})
 }


### PR DESCRIPTION
## What

Wires `bd dolt remote remove <name>` to work in proxied-server mode. Previously the command called `getStore()`, which returns `nil` in proxied-server mode (the early-return in `main.go` sets `uowProvider` but never a store), so the handler died at its `if st == nil` guard.

## How

Mirrors the existing proxied dispatch pattern (`update.go` / `create.go` / `list.go`):

- **`cmd/bd/dolt.go`** — minimal change: `doltRemoteRemoveCmd.Run` now dispatches to the proxied handler when `usesProxiedServer()` before touching the store; the embedded path is unchanged.
- **`cmd/bd/dolt_remote_proxied_server.go`** (new) — self-contained handler: opens a UnitOfWork, calls the pre-existing `DoltRemoteUseCase().DeleteRemote`, commits (guarded by `isDoltNothingToCommit`), and preserves the embedded path's `origin` → `sync.remote` config side-effect and JSON/text output.

No new domain use-case method was needed — `DoltRemoteUseCase.DeleteRemote` already exists and is wired into the UOW; this only routes the CLI to it.

## Testing

- **`cmd/bd/dolt_remote_remove_proxied_integration_test.go`** (new, `//go:build cgo`, gated behind `BEADS_TEST_PROXIED_SERVER=1`) — seeds a remote directly via `CALL DOLT_REMOTE('add', …)`, then verifies removal, JSON output shape, and the nonexistent-remote error against `dolt_remotes`.
- All three subtests pass locally (`removes_existing_remote`, `json_output`, `nonexistent_remote_errors`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)