### PR TITLE
ci(docs): auto-apply CLI docs regeneration to PR branches

### DIFF
--- a/.github/workflows/docs-autofix.yml
+++ b/.github/workflows/docs-autofix.yml
@@ -1,0 +1,83 @@
+# Auto-fix stale generated CLI docs on PRs.
+#
+# The PR workflow's check-doc-flags job already computes the exact
+# regeneration patch with CI's canonical pinned build and uploads it as the
+# cli-docs-freshness-patch artifact (scripts/check-cli-docs-drift.sh). This
+# workflow closes the loop: when a PR run fails and left that artifact, it
+# pushes the regen commit to the PR branch (same-repo PRs) or leaves an
+# idempotent comment with the one-liner apply recipe (fork PRs).
+#
+# SECURITY MODEL: this runs with write permissions via workflow_run, so it
+# never checks out or executes PR code. It checks out the base default branch
+# for scripts, and treats the artifact strictly as data: every path in the
+# patch must match an anchored generated-docs allowlist (single path segment,
+# no traversal, no symlink modes) and `git apply --index` supplies the
+# underlying escape guards (scripts/docs-autofix-push.sh), so a hostile patch
+# can at most rewrite generated doc files on its own PR branch.
+#
+# TOKEN NOTE: pushes made with the default GITHUB_TOKEN do not retrigger PR
+# checks. Configure a DOCS_AUTOFIX_TOKEN repo secret (fine-grained PAT or
+# GitHub App token with contents:write on this repo) for fully hands-off
+# operation on same-repo PRs; without it the pushed fix still lands but
+# checks need a manual re-run. Fork PRs always get the apply-recipe comment -
+# no token we hold can push to a fork.
+
+name: Docs Autofix
+
+on:
+  workflow_run:
+    workflows: ["PR"]
+    types: [completed]
+
+permissions:
+  contents: write
+  pull-requests: write
+  actions: read
+
+concurrency:
+  group: docs-autofix-${{ github.event.workflow_run.head_repository.full_name }}-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: true
+
+jobs:
+  autofix:
+    name: Apply CLI docs regeneration to PR
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'failure'
+    runs-on: ubuntu-latest
+    steps:
+      # Trusted side only: base repo default branch, never the PR head.
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+
+      - name: Download docs freshness patch (if any)
+        id: patch
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+        run: |
+          artifact_ids="$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${RUN_ID}/artifacts" \
+            --jq '.artifacts[] | select(.name == "cli-docs-freshness-patch") | .id')"
+          artifact_id="$(printf '%s\n' "$artifact_ids" | head -1)"
+          if [ -z "$artifact_id" ]; then
+            echo "No docs patch artifact on run ${RUN_ID}; PR failed for other reasons."
+            echo "found=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          gh api "repos/${GITHUB_REPOSITORY}/actions/artifacts/${artifact_id}/zip" > patch.zip
+          unzip -o patch.zip -d "${RUNNER_TEMP}/docs-patch"
+          ls -la "${RUNNER_TEMP}/docs-patch"
+          echo "found=true" >> "$GITHUB_OUTPUT"
+
+      - name: Push regen commit or leave apply recipe
+        if: steps.patch.outputs.found == 'true'
+        env:
+          BASE_REPO: ${{ github.repository }}
+          HEAD_REPO: ${{ github.event.workflow_run.head_repository.full_name }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          PATCH_FILE: ${{ runner.temp }}/docs-patch/cli-docs-freshness.patch
+          RUN_ID: ${{ github.event.workflow_run.id }}
+          RUN_URL: ${{ github.event.workflow_run.html_url }}
+          GH_TOKEN: ${{ secrets.DOCS_AUTOFIX_TOKEN || github.token }}
+          AUTOFIX_TOKEN_KIND: ${{ secrets.DOCS_AUTOFIX_TOKEN && 'pat' || 'default' }}
+        run: ./scripts/docs-autofix-push.sh

--- a/.github/workflows/docs-autofix.yml
+++ b/.github/workflows/docs-autofix.yml
@@ -78,6 +78,11 @@ jobs:
           PATCH_FILE: ${{ runner.temp }}/docs-patch/cli-docs-freshness.patch
           RUN_ID: ${{ github.event.workflow_run.id }}
           RUN_URL: ${{ github.event.workflow_run.html_url }}
-          GH_TOKEN: ${{ secrets.DOCS_AUTOFIX_TOKEN || github.token }}
+          # Split tokens: gh api calls (PR lookup, comments) always use the
+          # workflow token, which carries this job's pull-requests:write; the
+          # optional PAT is used ONLY for the git push, so it needs no more
+          # than contents:write.
+          GH_TOKEN: ${{ github.token }}
+          PUSH_TOKEN: ${{ secrets.DOCS_AUTOFIX_TOKEN || github.token }}
           AUTOFIX_TOKEN_KIND: ${{ secrets.DOCS_AUTOFIX_TOKEN && 'pat' || 'default' }}
         run: ./scripts/docs-autofix-push.sh

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -173,7 +173,9 @@ jobs:
 
       # When the drift check fails, it writes the exact regenerated-docs fix
       # (produced with CI's canonical build) so contributors can apply it with
-      # `git apply` instead of reproducing CI's environment locally.
+      # `git apply` instead of reproducing CI's environment locally. The
+      # docs-autofix.yml workflow_run job consumes this same artifact to push
+      # the fix to same-repo PR branches automatically.
       - name: Upload docs fix patch
         if: failure()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/scripts/docs-autofix-push.sh
+++ b/scripts/docs-autofix-push.sh
@@ -21,8 +21,11 @@
 #   PATCH_FILE   path to the downloaded cli-docs-freshness.patch
 #   RUN_ID       workflow run id that produced the patch (for comment text)
 #   RUN_URL      html url of that run (for commit/comment provenance)
-#   GH_TOKEN     token for gh api calls and same-repo pushes
-#   AUTOFIX_TOKEN_KIND  "pat" when a dedicated token is in use, "default"
+#   GH_TOKEN     token for gh api calls (PR lookup, comments) - needs the
+#                workflow's pull-requests:write; never the PAT
+#   PUSH_TOKEN   token for the git push only (optional; defaults to GH_TOKEN),
+#                so a dedicated DOCS_AUTOFIX_TOKEN needs contents:write only
+#   AUTOFIX_TOKEN_KIND  "pat" when a dedicated push token is in use, "default"
 #                       for the workflow's GITHUB_TOKEN (retrigger caveat)
 #
 # Exit 0 on every non-actionable outcome (PR closed, head moved, no patch);
@@ -37,6 +40,7 @@ fi
 : "${BASE_REPO:?}" "${HEAD_SHA:?}"
 : "${PATCH_FILE:?}" "${RUN_ID:?}" "${RUN_URL:?}" "${GH_TOKEN:?}"
 AUTOFIX_TOKEN_KIND="${AUTOFIX_TOKEN_KIND:-default}"
+PUSH_TOKEN="${PUSH_TOKEN:-$GH_TOKEN}"
 PATCH_FILE="$(readlink -f "$PATCH_FILE")"
 
 COMMENT_MARKER="<!-- cli-docs-autofix -->"
@@ -176,7 +180,8 @@ fi
 # --- Same-repo PRs: push the regen commit -------------------------------------
 
 # Keep the token out of on-disk .git/config: pass the auth header per command.
-AUTH_CONFIG="http.https://github.com/.extraheader=AUTHORIZATION: basic $(printf 'x-access-token:%s' "$GH_TOKEN" | base64 -w0)"
+# Uses PUSH_TOKEN (the optional contents:write PAT), not the API token.
+AUTH_CONFIG="http.https://github.com/.extraheader=AUTHORIZATION: basic $(printf 'x-access-token:%s' "$PUSH_TOKEN" | base64 -w0)"
 
 WORK="$(mktemp -d)"
 trap 'rm -rf "$WORK"' EXIT

--- a/scripts/docs-autofix-push.sh
+++ b/scripts/docs-autofix-push.sh
@@ -1,0 +1,229 @@
+#!/usr/bin/env bash
+# docs-autofix-push.sh - apply a CI-generated CLI docs regeneration patch to a
+# PR branch, or fall back to an instructive PR comment when pushing is not
+# possible.
+#
+# Runs on the PRIVILEGED side of the docs-autofix workflow_run pipeline: the
+# checkout is always the base repository's default branch (trusted code), and
+# the patch produced by the unprivileged PR build is treated as UNTRUSTED DATA.
+# Confinement is layered: the path allowlist below pins WHICH files a patch may
+# name (anchored regexes, single path segment, no traversal, no symlink modes),
+# and `git apply --index` supplies the underlying escape guards (rejects `..`
+# paths, absolute paths, and writes through in-patch symlinks). A hostile patch
+# can therefore at most rewrite generated doc files on its own PR branch.
+#
+# Inputs (environment):
+#   BASE_REPO    base "owner/name" (e.g. gastownhall/beads)
+#   HEAD_REPO    PR head "owner/name" (same as BASE_REPO for branch PRs;
+#                may be empty if the head fork was deleted)
+#   HEAD_BRANCH  PR head branch name
+#   HEAD_SHA     head commit the failing run was built from
+#   PATCH_FILE   path to the downloaded cli-docs-freshness.patch
+#   RUN_ID       workflow run id that produced the patch (for comment text)
+#   RUN_URL      html url of that run (for commit/comment provenance)
+#   GH_TOKEN     token for gh api calls and same-repo pushes
+#   AUTOFIX_TOKEN_KIND  "pat" when a dedicated token is in use, "default"
+#                       for the workflow's GITHUB_TOKEN (retrigger caveat)
+#
+# Exit 0 on every non-actionable outcome (PR closed, head moved, no patch);
+# exit 1 only on genuine errors so the workflow surfaces them.
+
+set -euo pipefail
+
+if [ -z "${HEAD_REPO:-}" ] || [ -z "${HEAD_BRANCH:-}" ]; then
+    echo "Head repository/branch unavailable (deleted fork?); nothing to do."
+    exit 0
+fi
+: "${BASE_REPO:?}" "${HEAD_SHA:?}"
+: "${PATCH_FILE:?}" "${RUN_ID:?}" "${RUN_URL:?}" "${GH_TOKEN:?}"
+AUTOFIX_TOKEN_KIND="${AUTOFIX_TOKEN_KIND:-default}"
+PATCH_FILE="$(readlink -f "$PATCH_FILE")"
+
+COMMENT_MARKER="<!-- cli-docs-autofix -->"
+AUTOFIX_SUBJECT="docs: auto-regenerate CLI reference"
+
+# Files the doc generators may write - a superset of GEN_PATHSPECS in
+# scripts/check-cli-docs-drift.sh (generate-cli-docs.sh also refreshes the
+# versioned CLI snapshot). Anchored, single path segment where a wildcard
+# appears, conservative filename charset: no traversal, no nesting, no
+# metacharacters can slip through.
+path_allowed() {
+    case "$1" in *..*) return 1 ;; esac
+    [[ "$1" == "docs/CLI_REFERENCE.md" ]] && return 0
+    [[ "$1" == "website/static/llms-full.txt" ]] && return 0
+    [[ "$1" =~ ^website/docs/cli-reference/[A-Za-z0-9_.-]+\.md$ ]] && return 0
+    [[ "$1" =~ ^website/versioned_docs/[A-Za-z0-9_.-]+/cli-reference/[A-Za-z0-9_.-]+\.md$ ]] && return 0
+    return 1
+}
+
+if [ ! -s "$PATCH_FILE" ]; then
+    echo "No patch content; nothing to do."
+    exit 0
+fi
+
+# --- Validate the untrusted patch --------------------------------------------
+
+# Generated docs are regular files; refuse any symlink (120000) mode before
+# git apply can materialize one at an allowlisted path.
+if grep -qE '^(new|old) file mode 120000$|^new mode 120000$' "$PATCH_FILE"; then
+    echo "REFUSED: patch introduces a symlink mode."
+    exit 1
+fi
+
+# --numstat prints "added<TAB>deleted<TAB>path"; renames appear as
+# "old => new" forms, which the allowlist match rejects.
+BAD_PATHS=""
+while IFS=$'\t' read -r _ _ path; do
+    [ -n "$path" ] || continue
+    if ! path_allowed "$path"; then
+        BAD_PATHS="${BAD_PATHS}${path}\n"
+    fi
+done < <(git apply --numstat "$PATCH_FILE")
+
+if [ -n "$BAD_PATHS" ]; then
+    printf 'REFUSED: patch touches paths outside the generated-docs allowlist:\n%b' "$BAD_PATHS"
+    exit 1
+fi
+
+# --- Resolve the PR and confirm the patch is still current -------------------
+
+# List-and-filter client side: branch names with URL metacharacters would
+# corrupt a ?head= query string, and jq --arg needs no encoding.
+PULLS_JSON="$(gh api --paginate "repos/$BASE_REPO/pulls?state=open&per_page=100")"
+PR_MATCH="$(printf '%s' "$PULLS_JSON" | jq -r -s --arg repo "$HEAD_REPO" --arg branch "$HEAD_BRANCH" \
+    'add | [ .[] | select(.head.ref == $branch and (.head.repo.full_name // "") == $repo) ]
+     | .[0] | if . == null then "" else "\(.number) \(.head.sha)" end')"
+PR_NUMBER="${PR_MATCH%% *}"
+PR_HEAD_NOW="${PR_MATCH##* }"
+
+if [ -z "$PR_NUMBER" ]; then
+    echo "No open PR for $HEAD_REPO:$HEAD_BRANCH; nothing to do."
+    exit 0
+fi
+if [ "$PR_HEAD_NOW" != "$HEAD_SHA" ]; then
+    echo "PR #$PR_NUMBER head moved ($HEAD_SHA -> $PR_HEAD_NOW); a newer run owns the fix."
+    exit 0
+fi
+
+# Circuit breaker: if the failing head is already one of our autofix commits,
+# regeneration is not converging (or something keeps dirtying the docs) -
+# stacking more bot commits would loop. Fail safe to the recipe comment.
+HEAD_MSG="$(gh api "repos/$BASE_REPO/commits/$HEAD_SHA" --jq '.commit.message' 2>/dev/null || true)"
+case "$HEAD_MSG" in
+    "$AUTOFIX_SUBJECT"*)
+        echo "Head $HEAD_SHA is already an autofix commit; refusing to stack another."
+        NONCONVERGENT=1
+        ;;
+    *) NONCONVERGENT=0 ;;
+esac
+
+post_or_update_comment() {
+    local body_file="$1"
+    # Capture fully before taking the first id: head -1 on a live --paginate
+    # stream SIGPIPEs gh under pipefail.
+    local ids existing
+    ids="$(gh api --paginate "repos/$BASE_REPO/issues/$PR_NUMBER/comments" \
+        --jq ".[] | select(.body | startswith(\"$COMMENT_MARKER\")) | .id")"
+    existing="$(printf '%s\n' "$ids" | head -1)"
+    if [ -n "$existing" ]; then
+        gh api --method PATCH "repos/$BASE_REPO/issues/comments/$existing" \
+            -F body=@"$body_file" >/dev/null
+        echo "Updated autofix comment $existing on PR #$PR_NUMBER."
+    else
+        gh api --method POST "repos/$BASE_REPO/issues/$PR_NUMBER/comments" \
+            -F body=@"$body_file" >/dev/null
+        echo "Posted autofix comment on PR #$PR_NUMBER."
+    fi
+}
+
+comment_fallback() {
+    local reason="$1"
+    local body
+    body="$(mktemp)"
+    cat > "$body" <<EOF
+$COMMENT_MARKER
+**Generated CLI docs are stale on this PR** (${reason}).
+
+CI already produced the exact fix with its canonical pinned build. Apply it locally:
+
+\`\`\`bash
+gh run download $RUN_ID -R $BASE_REPO -n cli-docs-freshness-patch
+git apply --index cli-docs-freshness.patch
+git commit -m "docs: regenerate CLI reference"
+git push
+\`\`\`
+
+Or regenerate from scratch: \`CGO_ENABLED=0 go build -tags gms_pure_go -o ./bd-docs ./cmd/bd/ && ./scripts/generate-cli-docs.sh ./bd-docs && ./scripts/generate-llms-full.sh && rm ./bd-docs\`
+
+_Automated by the [docs-autofix workflow]($RUN_URL); this comment is updated in place on each failing run._
+EOF
+    post_or_update_comment "$body"
+    rm -f "$body"
+}
+
+if [ "$NONCONVERGENT" = "1" ]; then
+    comment_fallback "an earlier auto-fix did not converge - please regenerate manually"
+    exit 0
+fi
+
+# --- Fork PRs: no token we hold can push there, leave the recipe --------------
+
+if [ "$HEAD_REPO" != "$BASE_REPO" ]; then
+    comment_fallback "fork PR - CI cannot push the fix to your branch"
+    exit 0
+fi
+
+# --- Same-repo PRs: push the regen commit -------------------------------------
+
+# Keep the token out of on-disk .git/config: pass the auth header per command.
+AUTH_CONFIG="http.https://github.com/.extraheader=AUTHORIZATION: basic $(printf 'x-access-token:%s' "$GH_TOKEN" | base64 -w0)"
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+git -c "$AUTH_CONFIG" clone --quiet --no-checkout --filter=blob:none \
+    "https://github.com/${BASE_REPO}.git" "$WORK/repo"
+cd "$WORK/repo"
+git -c "$AUTH_CONFIG" fetch --quiet origin "$HEAD_BRANCH"
+git checkout --quiet "$HEAD_SHA" 2>/dev/null || {
+    echo "Head $HEAD_SHA no longer reachable on $BASE_REPO/$HEAD_BRANCH; skipping."
+    exit 0
+}
+
+if ! git apply --index "$PATCH_FILE" 2>/dev/null; then
+    cd - >/dev/null
+    comment_fallback "the regeneration patch no longer applies cleanly"
+    exit 0
+fi
+
+git -c user.name="github-actions[bot]" \
+    -c user.email="41898282+github-actions[bot]@users.noreply.github.com" \
+    commit --quiet -m "$AUTOFIX_SUBJECT
+
+Applied from the cli-docs-freshness-patch artifact of $RUN_URL
+(generated with CI's canonical pinned build). See
+scripts/check-cli-docs-drift.sh for how drift is attributed."
+
+if ! git -c "$AUTH_CONFIG" push --quiet origin "HEAD:refs/heads/$HEAD_BRANCH"; then
+    cd - >/dev/null
+    comment_fallback "pushing the fix to $HEAD_BRANCH failed (branch protection or a concurrent push)"
+    exit 0
+fi
+NEW_SHA="$(git rev-parse HEAD)"
+cd - >/dev/null
+
+echo "Pushed regen commit $NEW_SHA to $BASE_REPO/$HEAD_BRANCH."
+
+BODY="$(mktemp)"
+cat > "$BODY" <<EOF
+$COMMENT_MARKER
+**Pushed \`${NEW_SHA:0:12}\` regenerating the stale CLI docs**, from the canonical-build patch of the [failing run]($RUN_URL).
+EOF
+if [ "$AUTOFIX_TOKEN_KIND" = "default" ]; then
+    cat >> "$BODY" <<'EOF'
+
+Note: this commit was pushed with the default workflow token, which does **not** retrigger PR checks - re-run them (or push any commit) to refresh the gate. Configuring a `DOCS_AUTOFIX_TOKEN` repo secret removes this step.
+EOF
+fi
+post_or_update_comment "$BODY"
+rm -f "$BODY"


### PR DESCRIPTION
## Why

Generated CLI docs (`docs/CLI_REFERENCE.md`, website CLI pages, `llms-full.txt`) are a recurring friction point: every change to CLI help text requires a manual regeneration step, and when it's forgotten the `check-doc-flags` gate goes red — most recently on 2026-07-07, when the `agent.profile` drift briefly turned main red after a merge. The gate is well designed (it attributes drift to the PR and even uploads the exact fix as the `cli-docs-freshness-patch` artifact), but a human still has to notice the artifact, download it, and apply it by hand.

Moving the check to nightly was considered and rejected: main-green is load-bearing for merge decisions (#4630 preflight base-CI health), and the check is cheap and deterministic. The right fix is to automate the regen, not defer the signal.

## What

A `workflow_run` job (`docs-autofix.yml`) that closes the loop when a PR run fails and left the patch artifact:

- **Same-repo PR branches**: applies the patch and pushes a `docs: auto-regenerate CLI reference` commit, then leaves/updates one marker comment.
- **Fork PRs**: leaves an idempotent comment with the one-liner apply recipe (`gh run download … && git apply --index … `) — no token we hold can push to a fork.
- Skips cleanly when the artifact is absent, the PR is closed, or the head moved since the failing run.
- Circuit breaker: if the failing head is already an autofix commit, it refuses to stack another and falls back to the recipe comment.

The apply logic lives in `scripts/docs-autofix-push.sh` so it is shellcheckable and locally testable.

## Security model

The privileged side never checks out or executes PR code — it checks out base `main` for scripts and treats the artifact strictly as data:

- anchored path allowlist: only the generated doc files, single path segment where a wildcard appears, conservative filename charset, `..` and symlink file modes refused before `git apply`;
- `git apply --index` supplies the underlying escape guards (rejects traversal/absolute paths and writes through in-patch symlinks);
- PR-controlled values (`head_branch`, `head_repository`, …) reach the shell only via `env:`, never inline `${{ }}` interpolation;
- the push token is passed per git command via `http.extraheader`, never written to on-disk config.

Worst case for a hostile patch: rewriting generated doc files on its own PR branch.

## Token note

Pushes with the default `GITHUB_TOKEN` do not retrigger PR checks — the fix lands but checks need a manual re-run (the bot comment says so). Configuring a `DOCS_AUTOFIX_TOKEN` repo secret (fine-grained PAT or App token, `contents:write` on this repo) makes same-repo PRs fully hands-off. Worth doing if this lands.

## Verification

- `shellcheck -S warning scripts/docs-autofix-push.sh` clean; workflow YAML parses.
- Functional tests with a stubbed `gh` against the script: workflow-file patch, `cli-reference/../../../` traversal, nested-subdir `.md`, and symlink-mode patches all REFUSED; allowed-paths patch proceeds; closed-PR / moved-head / deleted-fork inputs no-op with exit 0; circuit-breaker path posts the fallback comment.
- Cross-vendor review before opening: Codex (`codex review`, gpt-5.5, high) found two P2s (fallback recipe losing newly-added files with `commit -am`; fork+PAT falling through to a doomed push) — both fixed. An independent Claude reviewer confirmed the privilege model and found the allowlist glob laxity (`*` spanning `/`), the `--paginate | head -1` SIGPIPE-under-pipefail hazard, and the symlink-mode gap — all fixed as above; its P3 suggestions (token-in-URL, URL-encoding, deleted-fork guard, circuit breaker) are incorporated.

`workflow_run` behavior can only be exercised end-to-end after this merges (it runs the workflow file from the default branch); a follow-up drift PR can serve as the live test.

_claude-fable-5-high on behalf of matt wilkie_
