### PR TITLE
perf(ready): make `bd ready --json` O(page), not O(N²) (~25× at 10k)

### DIFF
--- a/cmd/bd/ready.go
+++ b/cmd/bd/ready.go
@@ -16,6 +16,14 @@ import (
 	"github.com/steveyegge/beads/internal/utils"
 )
 
+// readyWorkCounter is the optional store capability that sizes the total ready
+// count cheaply (SELECT COUNT(*) over the ready predicate) instead of re-running
+// the counts mega-query unbounded. Local backends implement it; callers fall
+// back to GetReadyWorkWithCounts when a store does not.
+type readyWorkCounter interface {
+	CountReadyWork(ctx context.Context, filter types.WorkFilter) (int, error)
+}
+
 var readyCmd = &cobra.Command{
 	Use:   "ready",
 	Short: "Show ready work (open, no active blockers)",
@@ -237,12 +245,26 @@ This is useful for agents executing molecules to see which steps can run next.`,
 			totalReady := len(results)
 			truncated := false
 			if filter.Limit > 0 && len(results) == filter.Limit {
-				countFilter := filter
-				countFilter.Limit = 0
-				all, countErr := activeStore.GetReadyWorkWithCounts(ctx, countFilter)
-				if countErr == nil && len(all) > len(results) {
-					totalReady = len(all)
-					truncated = true
+				// The page is full, so there may be more ready work. Size the true
+				// total N with a cheap COUNT(*) over the same ready predicate rather
+				// than re-running the whole counts mega-query unbounded. The count is
+				// byte-identical to len(GetReadyWorkWithCounts(Limit=0)); fall back to
+				// that method only if the store predates the ReadyCounter capability.
+				// Unwrap past the HookFiringStore decorator so the assertion reaches
+				// the concrete store that carries the optional ReadyCounter method.
+				if counter, ok := storage.UnwrapStore(activeStore).(readyWorkCounter); ok {
+					if n, countErr := counter.CountReadyWork(ctx, filter); countErr == nil && n > len(results) {
+						totalReady = n
+						truncated = true
+					}
+				} else {
+					countFilter := filter
+					countFilter.Limit = 0
+					all, countErr := activeStore.GetReadyWorkWithCounts(ctx, countFilter)
+					if countErr == nil && len(all) > len(results) {
+						totalReady = len(all)
+						truncated = true
+					}
 				}
 			}
 			if results == nil {

--- a/internal/storage/issueops/ready_work.go
+++ b/internal/storage/issueops/ready_work.go
@@ -14,7 +14,11 @@ import (
 )
 
 type readyWorkPredicates struct {
-	whereSQL         string
+	whereSQL string
+	// whereArgs binds only the WHERE placeholders (no ORDER BY params). It is
+	// what a bare COUNT(*) over the ready predicate needs; args carries the
+	// WHERE params followed by the ORDER BY params for the full page query.
+	whereArgs        []interface{}
 	orderBySQL       string
 	limitSQL         string
 	args             []interface{}
@@ -60,12 +64,14 @@ func buildReadyWorkPredicates(ctx context.Context, tx DBTX, filter types.WorkFil
 		inputs.ParentDescendantIDs = descendantIDs
 	}
 
-	whereSQL, args, err := sqlbuild.BuildReadyWorkWhere(filter, tables, inputs)
+	whereSQL, whereArgs, err := sqlbuild.BuildReadyWorkWhere(filter, tables, inputs)
 	if err != nil {
 		return nil, err
 	}
 
 	orderBy := buildReadyWorkOrder(filter.SortPolicy)
+	args := make([]interface{}, 0, len(whereArgs)+len(orderBy.Args))
+	args = append(args, whereArgs...)
 	args = append(args, orderBy.Args...)
 
 	var limitSQL string
@@ -75,6 +81,7 @@ func buildReadyWorkPredicates(ctx context.Context, tx DBTX, filter types.WorkFil
 
 	return &readyWorkPredicates{
 		whereSQL:         whereSQL,
+		whereArgs:        whereArgs,
 		orderBySQL:       orderBy.SQL,
 		limitSQL:         limitSQL,
 		args:             args,

--- a/internal/storage/issueops/ready_work_counts.go
+++ b/internal/storage/issueops/ready_work_counts.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"sort"
 
+	"github.com/steveyegge/beads/internal/storage/sqlbuild"
 	"github.com/steveyegge/beads/internal/types"
 )
 
@@ -20,7 +21,7 @@ func GetReadyWorkWithCountsInTx(ctx context.Context, tx *sql.Tx, filter types.Wo
 	if err != nil {
 		return nil, err
 	}
-	out, err := runSearchQueryInTx(ctx, tx, IssuesFilterTables, issuePreds.whereSQL, issuePreds.orderBySQL, issuePreds.limitSQL, issuePreds.args, wispDepsExist, false)
+	out, err := runReadyCountsInTx(ctx, tx, IssuesFilterTables, filter.Limit, issuePreds, wispDepsExist, false)
 	if err != nil {
 		return nil, err
 	}
@@ -40,7 +41,7 @@ func GetReadyWorkWithCountsInTx(ctx context.Context, tx *sql.Tx, filter types.Wo
 	if err != nil {
 		return nil, err
 	}
-	wisps, err := runSearchQueryInTx(ctx, tx, WispsFilterTables, wispPreds.whereSQL, wispPreds.orderBySQL, wispPreds.limitSQL, wispPreds.args, true, false)
+	wisps, err := runReadyCountsInTx(ctx, tx, WispsFilterTables, filter.Limit, wispPreds, true, false)
 	if err != nil {
 		if isTableNotExistError(err) {
 			return out, nil
@@ -74,6 +75,146 @@ func GetReadyWorkWithCountsInTx(ctx context.Context, tx *sql.Tx, filter types.Wo
 		kept = kept[:filter.Limit]
 	}
 	return kept, nil
+}
+
+// runReadyCountsInTx renders the ready-work counts mega-query for one table
+// family, pushing the page down when the caller bounded it.
+//
+// For a bounded page (limit > 0) it first resolves the ≤limit ready IDs with the
+// cheap indexed ID query (the same SELECT id … the non-counts GetReadyWork path
+// uses), then computes the counts constrained to exactly those IDs
+// (WHERE i.id IN (…)). This is what de-quadratics the query: the reverse-blocker
+// subquery rc joins on COALESCE(depends_on_issue_id, …), an expression SQLite
+// cannot auto-index, so the planner re-scans rc's whole materialization once per
+// driver row. Bounding the driver to the page (not every ready issue) turns that
+// O(candidates × blockers) scan into O(page × blockers). Each per-issue count is
+// a function of the full dependency graph, not of the candidate set, so
+// constraining the driver leaves every emitted count byte-identical to the
+// unbounded mega-query; the page is the same top-N the ORDER BY … LIMIT selected
+// because the ready order ends in a unique `id` tiebreak.
+//
+// For limit <= 0 (unbounded) there is no page to push down, so it runs the
+// original mega-query unchanged.
+//
+//nolint:gosec // G201: whereSQL/orderBySQL/limitSQL are hardcoded fragments; user input rides ? placeholders.
+func runReadyCountsInTx(ctx context.Context, tx *sql.Tx, tables FilterTables, limit int, preds *readyWorkPredicates, includeWispReverseDeps, skipLabels bool) ([]*types.IssueWithCounts, error) {
+	if limit <= 0 {
+		return runSearchQueryInTx(ctx, tx, tables, preds.whereSQL, preds.orderBySQL, preds.limitSQL, preds.args, includeWispReverseDeps, skipLabels)
+	}
+
+	idQuery := fmt.Sprintf("SELECT id FROM %s %s %s %s", tables.Main, preds.whereSQL, preds.orderBySQL, preds.limitSQL)
+	pageIDs, err := queryReadyIssueIDPage(ctx, tx, idQuery, preds.args)
+	if err != nil {
+		return nil, err
+	}
+	if len(pageIDs) == 0 {
+		return nil, nil
+	}
+
+	// The by-IDs form binds the page up to eight times (driver + each subquery).
+	// For an unusually large page fall back to the unbounded mega-query rather
+	// than risk a per-statement placeholder limit; correctness is unchanged.
+	if len(pageIDs) > readyCountsPushdownMaxPage {
+		return runSearchQueryInTx(ctx, tx, tables, preds.whereSQL, preds.orderBySQL, preds.limitSQL, preds.args, includeWispReverseDeps, skipLabels)
+	}
+
+	countsSQL, idArgs := sqlbuild.SearchCountsByIDsSQL(tables, pageIDs, includeWispReverseDeps, skipLabels)
+	rows, err := scanReadyCountsRows(ctx, tx, tables, countsSQL, idArgs)
+	if err != nil {
+		return nil, err
+	}
+
+	// The by-IDs query returns the page in arbitrary row order; restore the ready
+	// order the ID query already computed so the result stays identical to the
+	// unbounded mega-query's ORDER BY … LIMIT.
+	byID := make(map[string]*types.IssueWithCounts, len(rows))
+	for _, r := range rows {
+		if r != nil && r.Issue != nil {
+			byID[r.Issue.ID] = r
+		}
+	}
+	ordered := make([]*types.IssueWithCounts, 0, len(pageIDs))
+	for _, id := range pageIDs {
+		if r, ok := byID[id]; ok {
+			ordered = append(ordered, r)
+		}
+	}
+	return ordered, nil
+}
+
+// readyCountsPushdownMaxPage caps the page size for the by-IDs counts form.
+// 1000 IDs bound up to ~8000 placeholders, comfortably under every backend's
+// per-statement parameter limit; larger pages fall back to the mega-query.
+const readyCountsPushdownMaxPage = 1000
+
+// scanReadyCountsRows runs a prebuilt counts query and hydrates the rows through
+// the same scan path runSearchQueryInTx uses, deduping by issue ID.
+//
+//nolint:gosec // G201: countsSQL is builder-produced; user input rides ? placeholders.
+func scanReadyCountsRows(ctx context.Context, tx *sql.Tx, tables FilterTables, countsSQL string, args []any) ([]*types.IssueWithCounts, error) {
+	rows, err := tx.QueryContext(ctx, countsSQL, args...)
+	if err != nil {
+		return nil, fmt.Errorf("ready counts %s: %w", tables.Main, err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var out []*types.IssueWithCounts
+	seen := make(map[string]bool)
+	for rows.Next() {
+		iwc, scanErr := ScanReadyWorkRowWithCounts(rows)
+		if scanErr != nil {
+			return nil, scanErr
+		}
+		if iwc == nil || iwc.Issue == nil {
+			continue
+		}
+		if seen[iwc.Issue.ID] {
+			continue
+		}
+		seen[iwc.Issue.ID] = true
+		out = append(out, iwc)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("ready counts %s: rows: %w", tables.Main, err)
+	}
+	return out, nil
+}
+
+// CountReadyWorkInTx returns the number of ready-work items — identical to
+// len(GetReadyWorkWithCountsInTx(filter with Limit=0)) — without materializing
+// the counts mega-query. When no wisps exist (the common case) the ready set is
+// exactly the issues matching the ready predicate, so a single indexed COUNT(*)
+// over that predicate is authoritative. When wisps exist it falls back to the
+// full method so the wisp-merge/dedup count stays exact. This backs the
+// "Showing X of N" total that `bd ready` prints when the page is capped, so it
+// avoids re-running the whole mega-query unbounded just to size N.
+func CountReadyWorkInTx(ctx context.Context, tx *sql.Tx, filter types.WorkFilter) (int, error) {
+	countFilter := filter
+	countFilter.Limit = 0
+
+	empty, err := wispsTableEmptyOrMissingInTx(ctx, tx)
+	if err != nil {
+		return 0, fmt.Errorf("count ready work: wisp probe: %w", err)
+	}
+	if empty {
+		preds, err := buildReadyWorkPredicates(ctx, tx, countFilter, IssuesFilterTables)
+		if err != nil {
+			return 0, err
+		}
+		//nolint:gosec // G201: whereSQL is hardcoded fragments; user input rides ? placeholders.
+		q := "SELECT COUNT(*) FROM issues " + preds.whereSQL
+		var n int
+		if err := tx.QueryRowContext(ctx, q, preds.whereArgs...).Scan(&n); err != nil {
+			return 0, fmt.Errorf("count ready work: %w", err)
+		}
+		return n, nil
+	}
+
+	rows, err := GetReadyWorkWithCountsInTx(ctx, tx, countFilter)
+	if err != nil {
+		return 0, err
+	}
+	return len(rows), nil
 }
 
 func sortIssuesWithCountsByPolicy(items []*types.IssueWithCounts, policy types.SortPolicy) {

--- a/internal/storage/sqlbuild/counts.go
+++ b/internal/storage/sqlbuild/counts.go
@@ -110,3 +110,122 @@ func SearchCountsSQL(tables FilterTables, whereSQL, orderBySQL, limitSQL string,
 		limitSQL,
 	)
 }
+
+// SearchCountsByIDsSQL is the page-pushed form of SearchCountsSQL: it renders the
+// counts mega-query for an explicit, already-resolved set of issue IDs, with the
+// driver AND every count subquery constrained to those IDs. This keeps each
+// subquery from scanning/aggregating its whole side table and keeps the
+// reverse-blocker rc self-join (whose COALESCE(...) key SQLite cannot auto-index)
+// from re-scanning its full materialization per candidate — the cost is bounded
+// by the page, not by every ready issue.
+//
+// It stays byte-identical to SearchCountsSQL for the same IDs: each per-issue
+// count is a function of the whole dependency graph restricted to that issue, so
+// filtering a subquery's input to the page issues cannot change any surviving
+// row's count. Comment/dep/parent counts are order-insensitive; labels are
+// re-sorted in Go (ScanReadyWorkRowWithCounts); deps_json's element order is the
+// per-issue row order, which the issue_id filter preserves.
+//
+// Returns the SQL plus its args in left-to-right placeholder order (ids repeated
+// once per injection point). ids must be non-empty; the scan side is the same
+// issueops.ScanReadyWorkRowWithCounts.
+func SearchCountsByIDsSQL(tables FilterTables, ids []string, includeWispReverseDeps, skipLabels bool) (string, []any) {
+	inSQL, idArgs := InPlaceholders(ids)
+
+	reverseBlockerSelect := fmt.Sprintf(`
+				SELECT %[1]s AS dep_id
+				FROM dependencies WHERE type = 'blocks' AND %[1]s IN (%[2]s)
+	`, DepTargetExpr, inSQL)
+	if includeWispReverseDeps {
+		reverseBlockerSelect += fmt.Sprintf(`
+				UNION ALL
+				SELECT %[1]s AS dep_id
+				FROM wisp_dependencies WHERE type = 'blocks' AND %[1]s IN (%[2]s)
+		`, DepTargetExpr, inSQL)
+	}
+
+	labelsSelect := "l.labels_json AS labels_json"
+	labelsJoin := fmt.Sprintf(`
+		LEFT JOIN (
+			SELECT issue_id, JSON_ARRAYAGG(label) AS labels_json
+			FROM %s
+			WHERE issue_id IN (%s)
+			GROUP BY issue_id
+		) l ON l.issue_id = i.id`, tables.Labels, inSQL)
+	if skipLabels {
+		labelsSelect = "NULL AS labels_json"
+		labelsJoin = ""
+	}
+
+	sqlText := fmt.Sprintf(`
+		SELECT %s,
+			%s,
+			COALESCE(dc.cnt, 0) AS dep_count,
+			COALESCE(rc.cnt, 0) AS rdep_count,
+			COALESCE(cc.cnt, 0) AS comment_count,
+			pc.parent_id     AS parent_id,
+			d.deps_json      AS deps_json
+		FROM %s i
+		%s
+		LEFT JOIN (
+			SELECT issue_id, COUNT(*) AS cnt
+			FROM %s
+			WHERE type = 'blocks' AND issue_id IN (%s)
+			GROUP BY issue_id
+		) dc ON dc.issue_id = i.id
+		LEFT JOIN (
+			SELECT dep_id, COUNT(*) AS cnt FROM (
+				%s
+			) all_blockers GROUP BY dep_id
+		) rc ON rc.dep_id = i.id
+		LEFT JOIN (
+			SELECT issue_id, COUNT(*) AS cnt
+			FROM %s
+			WHERE issue_id IN (%s)
+			GROUP BY issue_id
+		) cc ON cc.issue_id = i.id
+		LEFT JOIN (
+			SELECT issue_id,
+			       MIN(%s) AS parent_id
+			FROM %s
+			WHERE type = 'parent-child' AND issue_id IN (%s)
+			GROUP BY issue_id
+		) pc ON pc.issue_id = i.id
+		LEFT JOIN (
+			SELECT issue_id, JSON_ARRAYAGG(%s) AS deps_json
+			FROM %s
+			WHERE issue_id IN (%s)
+			GROUP BY issue_id
+		) d ON d.issue_id = i.id
+		WHERE i.id IN (%s)
+	`,
+		ReadyWorkIssueColumns,
+		labelsSelect,
+		tables.Main,
+		labelsJoin,
+		tables.Dependencies, inSQL,
+		reverseBlockerSelect,
+		tables.Comments, inSQL,
+		DepTargetExpr, tables.Dependencies, inSQL,
+		DepJSONObject, tables.Dependencies, inSQL,
+		inSQL,
+	)
+
+	// args must follow the placeholder order in sqlText: labels join (unless
+	// skipped), dc, rc dependencies branch, rc wisp branch (if any), cc, pc, d,
+	// then the driver.
+	args := make([]any, 0, len(idArgs)*8)
+	if !skipLabels {
+		args = append(args, idArgs...)
+	}
+	args = append(args, idArgs...) // dc
+	args = append(args, idArgs...) // rc dependencies
+	if includeWispReverseDeps {
+		args = append(args, idArgs...) // rc wisp_dependencies
+	}
+	args = append(args, idArgs...) // cc
+	args = append(args, idArgs...) // pc
+	args = append(args, idArgs...) // d
+	args = append(args, idArgs...) // driver
+	return sqlText, args
+}


### PR DESCRIPTION
## What

`bd ready --json` was **O(N²)** at scale — ~**4.2 s** at 10k issues on the SQLite backend — and agents call it on **every work cycle**. This makes it **O(page)**: **~4.2 s → 0.16 s (~25×)** at 10k on SQLite, with **byte-identical output**. The bug is in backend-agnostic code, so every backend benefits (SQLite most; Postgres/MySQL/Dolt were already faster because they compile the same SQL to O(N) hash joins).

## Root cause

`bd ready --json` builds a six-way LEFT-JOIN "counts" mega-query (`sqlbuild.SearchCountsSQL`). The reverse-blocker `rc` subquery keys on a computed `COALESCE(depends_on_issue_id, …) AS dep_id`; SQLite can't auto-index that materialized expression, so it degrades to an `O(candidates × distinct_blockers)` nested loop (`EXPLAIN QUERY PLAN` → `SCAN rc LEFT-JOIN`). At 10k that's ~11 M inner visits. Separately, `cmd/bd/ready.go` re-ran the **entire mega-query unbounded** just to size the "Showing X of N" total.

## Fix

- **Page pushdown** (`sqlbuild.SearchCountsByIDsSQL`, `issueops`): resolve the ≤N ready IDs first via the cheap indexed ready query, then constrain the six count subqueries to those IDs. Per-issue counts are a function of the target issue's subgraph, so restricting the subquery inputs to the page cannot change any surviving row's count — output is byte-identical. Falls back to the unbounded query for pages > 1000 (placeholder safety).
- **Kill the double-count** (`cmd/bd/ready.go`): replace the unbounded re-count with a single indexed `COUNT(*)` over the ready predicate (`CountReadyWorkInTx`), exposed via `CountReadyWork` on the sqlkit / dolt / embedded-dolt stores (unwrapped past `HookFiringStore`).

## Proof

| | old | new |
|---|---|---|
| `ready -n 1 --json` @10k SQLite | 4.15 / 4.24 / 4.10 s | **0.18 / 0.16 / 0.16 s** |
| output (`-n 1`, `-n 20`, `--limit 0`) | — | **byte-identical** (643 B / 12,512 B / 6 MB) |

**Conformance:** embedded-Dolt (the oracle) **fully green (290 s)**; SQLite green; Postgres + MySQL ready/counts suites **`ok`**. The one Postgres failure in the full run — `Audit/…/LabelCollationOrder` — is **pre-existing** (it fails identically on the clean base: `GetLabels` binary-vs-case-insensitive collation divergence, unrelated to this change). Build / gofmt / golangci-lint clean on the changed files.

## Notes

- Base is `feat/choose-your-own-backend` because `CountReadyWork` is exposed on `sqlkit.Store` (this branch). The **page-pushdown** and **double-count** parts are backend-agnostic and backportable to `main`.
- Discovered while front-door-benchmarking the storage backends; this was the standout hot-path regression at scale.
