### PR TITLE
docs(website): refresh committed mirrors and add CI drift gate

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -171,6 +171,14 @@ jobs:
           ./scripts/check-doc-flags.sh ./bd
           ./scripts/check-doc-freshness.sh
 
+      # Website doc mirrors (website/docs/... and, when applicable,
+      # website/versioned_docs/version-<latest>/...) are a pure text
+      # transform of their docs/ sources, so this needs no bd build and no
+      # merge-base attribution: it just fails if scripts/sync-website-docs.sh
+      # produces any diff against the committed mirrors.
+      - name: Validate website doc mirrors
+        run: ./scripts/check-website-docs-drift.sh
+
       # When the drift check fails, it writes the exact regenerated-docs fix
       # (produced with CI's canonical build) so contributors can apply it with
       # `git apply` instead of reproducing CI's environment locally. The

--- a/scripts/check-website-docs-drift.sh
+++ b/scripts/check-website-docs-drift.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+# check-website-docs-drift.sh — Freshness check for committed website doc mirrors.
+#
+# scripts/sync-website-docs.sh regenerates the Docusaurus mirrors of selected
+# root docs (website/docs/..., and, when a versioned snapshot exists,
+# website/versioned_docs/version-<latest>/... plus
+# website/versioned_sidebars/version-<latest>-sidebars.json) from their
+# source files in docs/. Unlike the CLI reference docs, this mirroring is a
+# pure text transform of files already committed in this repo — no bd binary
+# build and no blame-scoped attribution across a merge-base is needed. The
+# check simply runs the sync script and fails if it produces any diff
+# (tracked or untracked), then restores the working tree so the check itself
+# is side-effect-free.
+#
+# Usage: check-website-docs-drift.sh
+
+set -euo pipefail
+export LC_ALL=C
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+
+cd "$PROJECT_ROOT"
+
+# All paths sync-website-docs.sh can write to. Checked, backed up, diffed,
+# and restored as a set.
+CHECK_PATHS=(website/docs website/versioned_docs website/versioned_sidebars)
+
+if [ -n "$(git status --porcelain -- "${CHECK_PATHS[@]}" 2>/dev/null)" ]; then
+    echo "WARN: working tree has uncommitted changes under ${CHECK_PATHS[*]};"
+    echo "      this check compares against the working tree as-is and will"
+    echo "      restore it to its pre-check state on exit."
+fi
+
+TMP_BACKUP="$(mktemp -d)"
+mkdir -p "$TMP_BACKUP/website"
+cp -Rf website/docs "$TMP_BACKUP/website/docs"
+if [ -d website/versioned_docs ]; then
+    cp -Rf website/versioned_docs "$TMP_BACKUP/website/versioned_docs"
+fi
+if [ -d website/versioned_sidebars ]; then
+    cp -Rf website/versioned_sidebars "$TMP_BACKUP/website/versioned_sidebars"
+fi
+
+restore_tree() {
+    rm -rf website/docs website/versioned_docs website/versioned_sidebars
+    cp -Rf "$TMP_BACKUP/website/docs" website/docs
+    if [ -d "$TMP_BACKUP/website/versioned_docs" ]; then
+        cp -Rf "$TMP_BACKUP/website/versioned_docs" website/versioned_docs
+    fi
+    if [ -d "$TMP_BACKUP/website/versioned_sidebars" ]; then
+        cp -Rf "$TMP_BACKUP/website/versioned_sidebars" website/versioned_sidebars
+    fi
+    rm -rf "$TMP_BACKUP"
+}
+trap restore_tree EXIT
+
+"$SCRIPT_DIR/sync-website-docs.sh"
+
+# git diff alone misses drift where sync-website-docs.sh recreates a mirror
+# file that isn't currently tracked (e.g. a committed mirror was deleted, or
+# a new sync target was never committed): the recreated file is untracked
+# and invisible to `git diff`. Treat any new untracked file under the
+# checked paths as drift too.
+UNTRACKED="$(git ls-files --others --exclude-standard -- "${CHECK_PATHS[@]}")"
+
+if git diff --quiet -- "${CHECK_PATHS[@]}" && [ -z "$UNTRACKED" ]; then
+    echo "PASS: committed website doc mirrors are fresh (sync-website-docs.sh produces no changes)."
+    exit 0
+fi
+
+echo "FAIL: website doc mirrors are out of sync with their source docs."
+echo "Run: ./scripts/sync-website-docs.sh"
+echo ""
+if ! git diff --quiet -- "${CHECK_PATHS[@]}"; then
+    git diff --stat -- "${CHECK_PATHS[@]}" | sed 's/^/  /'
+    echo ""
+    git diff -- "${CHECK_PATHS[@]}" | sed -n '1,200p'
+fi
+if [ -n "$UNTRACKED" ]; then
+    echo ""
+    echo "New (untracked) mirror files sync-website-docs.sh produced:"
+    echo "$UNTRACKED" | sed 's/^/  /'
+fi
+exit 1

--- a/website/docs/community-tools.md
+++ b/website/docs/community-tools.md
@@ -21,11 +21,15 @@ A curated list of community-built UIs, extensions, and integrations for Beads. R
 
 ## Web UIs
 
+- **[bd-board](https://github.com/jeanpfs/bd-board)** - Local-first web dashboard for browsing Beads projects, viewing kanban boards by status or epic swimlanes, and filtering by priority, text search, or sort order. Uses the `bd` CLI for Dolt compatibility, with writes disabled unless explicitly enabled. Built by [@jeanpfs](https://github.com/jeanpfs). (TanStack Start/React)
+
 - **[beads-ui](https://github.com/mantoni/beads-ui)** - Local web interface with live updates and kanban board. Uses the `bd` CLI for Dolt compatibility. Run with `npx beads-ui start`. Built by [@mantoni](https://github.com/mantoni). (Node.js)
 
 - **[BeadBoard](https://github.com/zenchantlive/beadboard)** - Multi-agent orchestration and communication system with a live dashboard. Agent-to-agent messaging (HANDOFF/BLOCKED/DECISION/INFO), DAG dependency graph, swarm coordination with archetypes and templates, scope-based work reservations, and an embedded execution runtime (bb-pi) built on [Pi](https://github.com/badlogic/pi-mono) that spawns typed worker agents. Cross-platform (macOS, Linux, Windows). Includes the `beadboard-driver` skill for agent integration (`npx skills add zenchantlive/beadboard --skill beadboard-driver`). Built by [@zenchantlive](https://github.com/zenchantlive). (Next.js/TypeScript)
 
 - **[beads-web](https://github.com/weselow/beads-web)** - Actively maintained fork of beads-kanban-ui. Cross-platform single-binary distribution (macOS, Linux, Windows), 7 visual themes, Dolt direct SQL integration, Windows multi-drive path support, drag-and-drop status updates. Download from [GitHub Releases](https://github.com/weselow/beads-web/releases). Built by [@weselow](https://github.com/weselow). (TypeScript/Rust)
+
+- **[Bead Me Up, Scotty](https://github.com/brendan-appstart/bead-me-up-scotty)** - Polished multi-project web UI for creating, updating, and prioritizing beads across all your repos from one place. Kanban board with drag-and-drop status changes and reordering, plus list, epics (with progress bars), and dependency-graph views; faceted filtering and full-text search; live updates via SSE that react the moment `.beads/` changes; and human-vs-agent attribution throughout. Uses the `bd` CLI for full Dolt compatibility. Global install (`scotty`) opens the current directory's project in your browser, and a built-in Publish view generates a shareable static showcase site from your beads. Live demo at [beadmeupscotty.com](https://beadmeupscotty.com). Built by [@brendan-appstart](https://github.com/brendan-appstart). (Next.js/TypeScript)
 
 ## Editor Extensions
 
@@ -36,6 +40,7 @@ A curated list of community-built UIs, extensions, and integrations for Beads. R
 - **[Lista Beads](https://marketplace.visualstudio.com/items?itemName=ListaDev.lista-beads)** - Full-featured VS Code extension: filterable tree view, issue detail panel, dashboard with metrics, dependency graph, Dolt push/pull, CodeLens for bead references, wisps & formula support, stale issue management, and multi-tracker sync (Azure DevOps, GitHub, Jira, Linear, GitLab). Built by [@harry-miller-trimble](https://github.com/harry-miller-trimble). (TypeScript)
 
 - **[nvim-beads (fancypantalons)](https://github.com/fancypantalons/nvim-beads)** - Neovim plugin for managing Beads issues. By [@fancypantalons](https://github.com/fancypantalons). (Lua)
+- **[beads.nvim](https://github.com/tomfordweb/beads.nvim)** - Neovim UI for managing Beads issues — ready queue, editable floating detail view, create/quick-capture, Telescope pickers, memories, and dependency graph. Uses the `bd` CLI for Dolt compatibility. By [@tomfordweb](https://github.com/tomfordweb). (Lua)
 
 - **[beads-manager](https://plugins.jetbrains.com/plugin/30089-beads-manager)** - Jetbrains IDE plugin to manage and view bead details. Maintained by [@developmeh](https://github.com/developmeh). (Kotlin)
 
@@ -44,6 +49,8 @@ A curated list of community-built UIs, extensions, and integrations for Beads. R
 - **[Beads Task-Issue Tracker](https://github.com/w3dev33/beads-task-issue-tracker)** - Cross-platform desktop application (macOS, Windows, Linux) for browsing, creating, and managing Beads issues with a visual interface. Features multi-project support with favorites, image attachments, dashboard with statistics, advanced filtering, and dark/light theme. Built by [@w3dev33](https://github.com/w3dev33). (Tauri/Vue)
 
 - **[Beadbox](https://github.com/beadbox/beadbox)** - Native macOS dashboard with real-time sync, epic tree progress bars, multi-workspace support, and inline editing. Install with `brew tap beadbox/cask && brew install --cask beadbox`. Built by [@nmelo](https://github.com/nmelo). (Tauri/Next.js)
+
+- **[BeadSpec](https://github.com/boardthatpowder/BeadSpec)** - Cross-platform native desktop app (macOS, Windows, Linux) with first-class [OpenSpec](https://github.com/gastownhall/openspec) integration — the only Beads GUI that surfaces in-flight change proposals alongside the task list, lets you open spec artifacts in side-by-side tabs, imports a change's task list to Beads in one click, and shows which OpenSpec change each issue was imported from. Also includes an interactive dependency graph (React Flow + Cytoscape), IDE-style workspace tabs with split panes, a global quick-capture shortcut, system tray, command palette, TipTap Markdown description editor, human decision queue, and optional [Ruflo](https://github.com/gastownhall/ruflo) memory integration. Reads Dolt SQL directly for speed; writes through `bd` to preserve hook logic and ID assignment. Download from [GitHub Releases](https://github.com/boardthatpowder/BeadSpec/releases). Built by [@boardthatpowder](https://github.com/boardthatpowder). (Tauri/React/TypeScript)
 
 ## Data Source Middleware
 
@@ -68,6 +75,8 @@ Install with `uv tool install git+https://github.com/jklenk/thread`. Built by [@
 - **[claude-handoff](https://github.com/REMvisual/claude-handoff)** - Session handoff skills for Claude Code. Captures decisions, failed approaches, measurements, and next steps into structured files so the next session picks up where you left off. Uses bead IDs as chain tags for multi-session continuity, auto-detects active beads, and updates bead notes on close. Includes `/handoff`, `/handoffplan`, and a PreCompact safety-net hook. Built by [@REMvisual](https://github.com/REMvisual). (Markdown/Bash)
 - **[claude-workspace-snapshot](https://github.com/REMvisual/claude-workspace-snapshot)** - Snapshot and restore live Claude Code sessions as named, color-coded Windows Terminal tabs. Detects running sessions via process inspection and .jsonl file activity. Restores tab layout after any restart. Pairs with claude-handoff for full session continuity. Built by [@REMvisual](https://github.com/REMvisual). (PowerShell/Batch)
 - **[claude-protocol](https://github.com/weselow/claude-protocol)** - Actively maintained fork of beads-orchestration. Ground-up rewrite optimized for Claude 4.6 family models: trigger-based dev rules (TDD, logging, resilience), cross-platform Node.js hooks (replaced 19 bash scripts with 8 .cjs hooks), mandatory checklist verification, session-start dashboard, knowledge base with auto-capture. Install via `npx claude-protocol init`. Built by [@weselow](https://github.com/weselow). (Node.js/Python)
+
+- **[LoopTroop](https://github.com/looptroop-ai/LoopTroop)** - Local AI coding orchestrator for automated task planning, execution, and feedback loops. Uses a Beads-inspired methodology with LLM Council consensus and worktree isolation. Built by [@looptroop-ai](https://github.com/looptroop-ai). (Node.js/TypeScript)
 
 ## Coordination Servers
 

--- a/website/docs/core-concepts/metadata.md
+++ b/website/docs/core-concepts/metadata.md
@@ -39,14 +39,22 @@ These keys are advisory metadata, not core issue fields. When a workflow uses
 them, they take precedence over free-form notes for execution routing. Notes
 remain useful for rationale, ownership, and exact prompts.
 
+Model and effort values are portable hints, not runtime bindings. The
+`execution_reasoning_effort` values above are a canonical advisory scale:
+writers should store canonical values rather than runtime-local ones, and a
+consumer whose runtime uses a different scale should map the stored value to
+its nearest native level instead of dropping the hint. Likewise,
+`execution_suggested_model` is a capability-tier suggestion: a consumer on a
+different provider should substitute a model of the same tier rather than
+ignore the hint.
+
 Parent/orchestrator agents must consume these keys before spawning subagents.
 Model and reasoning effort are normally fixed at launch, so reading metadata
 after delegation is too late.
 
 Do not add a first-class helper such as `bd show <id> --execution` or
-`bd plan <id> --json` yet. Keep using the JSON/JQ snippet until upstream
-issue gh-3541 determines whether schedulers or runners need these fields as a
-stable CLI surface.
+`bd plan <id> --json`. Issue gh-3541 resolved to keep execution hints as
+metadata only; the JSON/JQ snippet remains the supported access path.
 
 ## Example: Tracker Round-Trip Metadata
 

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -2525,14 +2525,22 @@ These keys are advisory metadata, not core issue fields. When a workflow uses
 them, they take precedence over free-form notes for execution routing. Notes
 remain useful for rationale, ownership, and exact prompts.
 
+Model and effort values are portable hints, not runtime bindings. The
+`execution_reasoning_effort` values above are a canonical advisory scale:
+writers should store canonical values rather than runtime-local ones, and a
+consumer whose runtime uses a different scale should map the stored value to
+its nearest native level instead of dropping the hint. Likewise,
+`execution_suggested_model` is a capability-tier suggestion: a consumer on a
+different provider should substitute a model of the same tier rather than
+ignore the hint.
+
 Parent/orchestrator agents must consume these keys before spawning subagents.
 Model and reasoning effort are normally fixed at launch, so reading metadata
 after delegation is too late.
 
 Do not add a first-class helper such as `bd show <id> --execution` or
-`bd plan <id> --json` yet. Keep using the JSON/JQ snippet until upstream
-issue gh-3541 determines whether schedulers or runners need these fields as a
-stable CLI surface.
+`bd plan <id> --json`. Issue gh-3541 resolved to keep execution hints as
+metadata only; the JSON/JQ snippet remains the supported access path.
 
 ## Example: Tracker Round-Trip Metadata
 
@@ -12738,11 +12746,15 @@ A curated list of community-built UIs, extensions, and integrations for Beads. R
 
 ## Web UIs
 
+- **[bd-board](https://github.com/jeanpfs/bd-board)** - Local-first web dashboard for browsing Beads projects, viewing kanban boards by status or epic swimlanes, and filtering by priority, text search, or sort order. Uses the `bd` CLI for Dolt compatibility, with writes disabled unless explicitly enabled. Built by [@jeanpfs](https://github.com/jeanpfs). (TanStack Start/React)
+
 - **[beads-ui](https://github.com/mantoni/beads-ui)** - Local web interface with live updates and kanban board. Uses the `bd` CLI for Dolt compatibility. Run with `npx beads-ui start`. Built by [@mantoni](https://github.com/mantoni). (Node.js)
 
 - **[BeadBoard](https://github.com/zenchantlive/beadboard)** - Multi-agent orchestration and communication system with a live dashboard. Agent-to-agent messaging (HANDOFF/BLOCKED/DECISION/INFO), DAG dependency graph, swarm coordination with archetypes and templates, scope-based work reservations, and an embedded execution runtime (bb-pi) built on [Pi](https://github.com/badlogic/pi-mono) that spawns typed worker agents. Cross-platform (macOS, Linux, Windows). Includes the `beadboard-driver` skill for agent integration (`npx skills add zenchantlive/beadboard --skill beadboard-driver`). Built by [@zenchantlive](https://github.com/zenchantlive). (Next.js/TypeScript)
 
 - **[beads-web](https://github.com/weselow/beads-web)** - Actively maintained fork of beads-kanban-ui. Cross-platform single-binary distribution (macOS, Linux, Windows), 7 visual themes, Dolt direct SQL integration, Windows multi-drive path support, drag-and-drop status updates. Download from [GitHub Releases](https://github.com/weselow/beads-web/releases). Built by [@weselow](https://github.com/weselow). (TypeScript/Rust)
+
+- **[Bead Me Up, Scotty](https://github.com/brendan-appstart/bead-me-up-scotty)** - Polished multi-project web UI for creating, updating, and prioritizing beads across all your repos from one place. Kanban board with drag-and-drop status changes and reordering, plus list, epics (with progress bars), and dependency-graph views; faceted filtering and full-text search; live updates via SSE that react the moment `.beads/` changes; and human-vs-agent attribution throughout. Uses the `bd` CLI for full Dolt compatibility. Global install (`scotty`) opens the current directory's project in your browser, and a built-in Publish view generates a shareable static showcase site from your beads. Live demo at [beadmeupscotty.com](https://beadmeupscotty.com). Built by [@brendan-appstart](https://github.com/brendan-appstart). (Next.js/TypeScript)
 
 ## Editor Extensions
 
@@ -12753,6 +12765,7 @@ A curated list of community-built UIs, extensions, and integrations for Beads. R
 - **[Lista Beads](https://marketplace.visualstudio.com/items?itemName=ListaDev.lista-beads)** - Full-featured VS Code extension: filterable tree view, issue detail panel, dashboard with metrics, dependency graph, Dolt push/pull, CodeLens for bead references, wisps & formula support, stale issue management, and multi-tracker sync (Azure DevOps, GitHub, Jira, Linear, GitLab). Built by [@harry-miller-trimble](https://github.com/harry-miller-trimble). (TypeScript)
 
 - **[nvim-beads (fancypantalons)](https://github.com/fancypantalons/nvim-beads)** - Neovim plugin for managing Beads issues. By [@fancypantalons](https://github.com/fancypantalons). (Lua)
+- **[beads.nvim](https://github.com/tomfordweb/beads.nvim)** - Neovim UI for managing Beads issues — ready queue, editable floating detail view, create/quick-capture, Telescope pickers, memories, and dependency graph. Uses the `bd` CLI for Dolt compatibility. By [@tomfordweb](https://github.com/tomfordweb). (Lua)
 
 - **[beads-manager](https://plugins.jetbrains.com/plugin/30089-beads-manager)** - Jetbrains IDE plugin to manage and view bead details. Maintained by [@developmeh](https://github.com/developmeh). (Kotlin)
 
@@ -12761,6 +12774,8 @@ A curated list of community-built UIs, extensions, and integrations for Beads. R
 - **[Beads Task-Issue Tracker](https://github.com/w3dev33/beads-task-issue-tracker)** - Cross-platform desktop application (macOS, Windows, Linux) for browsing, creating, and managing Beads issues with a visual interface. Features multi-project support with favorites, image attachments, dashboard with statistics, advanced filtering, and dark/light theme. Built by [@w3dev33](https://github.com/w3dev33). (Tauri/Vue)
 
 - **[Beadbox](https://github.com/beadbox/beadbox)** - Native macOS dashboard with real-time sync, epic tree progress bars, multi-workspace support, and inline editing. Install with `brew tap beadbox/cask && brew install --cask beadbox`. Built by [@nmelo](https://github.com/nmelo). (Tauri/Next.js)
+
+- **[BeadSpec](https://github.com/boardthatpowder/BeadSpec)** - Cross-platform native desktop app (macOS, Windows, Linux) with first-class [OpenSpec](https://github.com/gastownhall/openspec) integration — the only Beads GUI that surfaces in-flight change proposals alongside the task list, lets you open spec artifacts in side-by-side tabs, imports a change's task list to Beads in one click, and shows which OpenSpec change each issue was imported from. Also includes an interactive dependency graph (React Flow + Cytoscape), IDE-style workspace tabs with split panes, a global quick-capture shortcut, system tray, command palette, TipTap Markdown description editor, human decision queue, and optional [Ruflo](https://github.com/gastownhall/ruflo) memory integration. Reads Dolt SQL directly for speed; writes through `bd` to preserve hook logic and ID assignment. Download from [GitHub Releases](https://github.com/boardthatpowder/BeadSpec/releases). Built by [@boardthatpowder](https://github.com/boardthatpowder). (Tauri/React/TypeScript)
 
 ## Data Source Middleware
 
@@ -12785,6 +12800,8 @@ Install with `uv tool install git+https://github.com/jklenk/thread`. Built by [@
 - **[claude-handoff](https://github.com/REMvisual/claude-handoff)** - Session handoff skills for Claude Code. Captures decisions, failed approaches, measurements, and next steps into structured files so the next session picks up where you left off. Uses bead IDs as chain tags for multi-session continuity, auto-detects active beads, and updates bead notes on close. Includes `/handoff`, `/handoffplan`, and a PreCompact safety-net hook. Built by [@REMvisual](https://github.com/REMvisual). (Markdown/Bash)
 - **[claude-workspace-snapshot](https://github.com/REMvisual/claude-workspace-snapshot)** - Snapshot and restore live Claude Code sessions as named, color-coded Windows Terminal tabs. Detects running sessions via process inspection and .jsonl file activity. Restores tab layout after any restart. Pairs with claude-handoff for full session continuity. Built by [@REMvisual](https://github.com/REMvisual). (PowerShell/Batch)
 - **[claude-protocol](https://github.com/weselow/claude-protocol)** - Actively maintained fork of beads-orchestration. Ground-up rewrite optimized for Claude 4.6 family models: trigger-based dev rules (TDD, logging, resilience), cross-platform Node.js hooks (replaced 19 bash scripts with 8 .cjs hooks), mandatory checklist verification, session-start dashboard, knowledge base with auto-capture. Install via `npx claude-protocol init`. Built by [@weselow](https://github.com/weselow). (Node.js/Python)
+
+- **[LoopTroop](https://github.com/looptroop-ai/LoopTroop)** - Local AI coding orchestrator for automated task planning, execution, and feedback loops. Uses a Beads-inspired methodology with LLM Council consensus and worktree isolation. Built by [@looptroop-ai](https://github.com/looptroop-ai). (Node.js/TypeScript)
 
 ## Coordination Servers
 

--- a/website/versioned_docs/version-1.1.0/community-tools.md
+++ b/website/versioned_docs/version-1.1.0/community-tools.md
@@ -21,11 +21,15 @@ A curated list of community-built UIs, extensions, and integrations for Beads. R
 
 ## Web UIs
 
+- **[bd-board](https://github.com/jeanpfs/bd-board)** - Local-first web dashboard for browsing Beads projects, viewing kanban boards by status or epic swimlanes, and filtering by priority, text search, or sort order. Uses the `bd` CLI for Dolt compatibility, with writes disabled unless explicitly enabled. Built by [@jeanpfs](https://github.com/jeanpfs). (TanStack Start/React)
+
 - **[beads-ui](https://github.com/mantoni/beads-ui)** - Local web interface with live updates and kanban board. Uses the `bd` CLI for Dolt compatibility. Run with `npx beads-ui start`. Built by [@mantoni](https://github.com/mantoni). (Node.js)
 
 - **[BeadBoard](https://github.com/zenchantlive/beadboard)** - Multi-agent orchestration and communication system with a live dashboard. Agent-to-agent messaging (HANDOFF/BLOCKED/DECISION/INFO), DAG dependency graph, swarm coordination with archetypes and templates, scope-based work reservations, and an embedded execution runtime (bb-pi) built on [Pi](https://github.com/badlogic/pi-mono) that spawns typed worker agents. Cross-platform (macOS, Linux, Windows). Includes the `beadboard-driver` skill for agent integration (`npx skills add zenchantlive/beadboard --skill beadboard-driver`). Built by [@zenchantlive](https://github.com/zenchantlive). (Next.js/TypeScript)
 
 - **[beads-web](https://github.com/weselow/beads-web)** - Actively maintained fork of beads-kanban-ui. Cross-platform single-binary distribution (macOS, Linux, Windows), 7 visual themes, Dolt direct SQL integration, Windows multi-drive path support, drag-and-drop status updates. Download from [GitHub Releases](https://github.com/weselow/beads-web/releases). Built by [@weselow](https://github.com/weselow). (TypeScript/Rust)
+
+- **[Bead Me Up, Scotty](https://github.com/brendan-appstart/bead-me-up-scotty)** - Polished multi-project web UI for creating, updating, and prioritizing beads across all your repos from one place. Kanban board with drag-and-drop status changes and reordering, plus list, epics (with progress bars), and dependency-graph views; faceted filtering and full-text search; live updates via SSE that react the moment `.beads/` changes; and human-vs-agent attribution throughout. Uses the `bd` CLI for full Dolt compatibility. Global install (`scotty`) opens the current directory's project in your browser, and a built-in Publish view generates a shareable static showcase site from your beads. Live demo at [beadmeupscotty.com](https://beadmeupscotty.com). Built by [@brendan-appstart](https://github.com/brendan-appstart). (Next.js/TypeScript)
 
 ## Editor Extensions
 
@@ -36,6 +40,7 @@ A curated list of community-built UIs, extensions, and integrations for Beads. R
 - **[Lista Beads](https://marketplace.visualstudio.com/items?itemName=ListaDev.lista-beads)** - Full-featured VS Code extension: filterable tree view, issue detail panel, dashboard with metrics, dependency graph, Dolt push/pull, CodeLens for bead references, wisps & formula support, stale issue management, and multi-tracker sync (Azure DevOps, GitHub, Jira, Linear, GitLab). Built by [@harry-miller-trimble](https://github.com/harry-miller-trimble). (TypeScript)
 
 - **[nvim-beads (fancypantalons)](https://github.com/fancypantalons/nvim-beads)** - Neovim plugin for managing Beads issues. By [@fancypantalons](https://github.com/fancypantalons). (Lua)
+- **[beads.nvim](https://github.com/tomfordweb/beads.nvim)** - Neovim UI for managing Beads issues — ready queue, editable floating detail view, create/quick-capture, Telescope pickers, memories, and dependency graph. Uses the `bd` CLI for Dolt compatibility. By [@tomfordweb](https://github.com/tomfordweb). (Lua)
 
 - **[beads-manager](https://plugins.jetbrains.com/plugin/30089-beads-manager)** - Jetbrains IDE plugin to manage and view bead details. Maintained by [@developmeh](https://github.com/developmeh). (Kotlin)
 
@@ -44,6 +49,8 @@ A curated list of community-built UIs, extensions, and integrations for Beads. R
 - **[Beads Task-Issue Tracker](https://github.com/w3dev33/beads-task-issue-tracker)** - Cross-platform desktop application (macOS, Windows, Linux) for browsing, creating, and managing Beads issues with a visual interface. Features multi-project support with favorites, image attachments, dashboard with statistics, advanced filtering, and dark/light theme. Built by [@w3dev33](https://github.com/w3dev33). (Tauri/Vue)
 
 - **[Beadbox](https://github.com/beadbox/beadbox)** - Native macOS dashboard with real-time sync, epic tree progress bars, multi-workspace support, and inline editing. Install with `brew tap beadbox/cask && brew install --cask beadbox`. Built by [@nmelo](https://github.com/nmelo). (Tauri/Next.js)
+
+- **[BeadSpec](https://github.com/boardthatpowder/BeadSpec)** - Cross-platform native desktop app (macOS, Windows, Linux) with first-class [OpenSpec](https://github.com/gastownhall/openspec) integration — the only Beads GUI that surfaces in-flight change proposals alongside the task list, lets you open spec artifacts in side-by-side tabs, imports a change's task list to Beads in one click, and shows which OpenSpec change each issue was imported from. Also includes an interactive dependency graph (React Flow + Cytoscape), IDE-style workspace tabs with split panes, a global quick-capture shortcut, system tray, command palette, TipTap Markdown description editor, human decision queue, and optional [Ruflo](https://github.com/gastownhall/ruflo) memory integration. Reads Dolt SQL directly for speed; writes through `bd` to preserve hook logic and ID assignment. Download from [GitHub Releases](https://github.com/boardthatpowder/BeadSpec/releases). Built by [@boardthatpowder](https://github.com/boardthatpowder). (Tauri/React/TypeScript)
 
 ## Data Source Middleware
 
@@ -68,6 +75,8 @@ Install with `uv tool install git+https://github.com/jklenk/thread`. Built by [@
 - **[claude-handoff](https://github.com/REMvisual/claude-handoff)** - Session handoff skills for Claude Code. Captures decisions, failed approaches, measurements, and next steps into structured files so the next session picks up where you left off. Uses bead IDs as chain tags for multi-session continuity, auto-detects active beads, and updates bead notes on close. Includes `/handoff`, `/handoffplan`, and a PreCompact safety-net hook. Built by [@REMvisual](https://github.com/REMvisual). (Markdown/Bash)
 - **[claude-workspace-snapshot](https://github.com/REMvisual/claude-workspace-snapshot)** - Snapshot and restore live Claude Code sessions as named, color-coded Windows Terminal tabs. Detects running sessions via process inspection and .jsonl file activity. Restores tab layout after any restart. Pairs with claude-handoff for full session continuity. Built by [@REMvisual](https://github.com/REMvisual). (PowerShell/Batch)
 - **[claude-protocol](https://github.com/weselow/claude-protocol)** - Actively maintained fork of beads-orchestration. Ground-up rewrite optimized for Claude 4.6 family models: trigger-based dev rules (TDD, logging, resilience), cross-platform Node.js hooks (replaced 19 bash scripts with 8 .cjs hooks), mandatory checklist verification, session-start dashboard, knowledge base with auto-capture. Install via `npx claude-protocol init`. Built by [@weselow](https://github.com/weselow). (Node.js/Python)
+
+- **[LoopTroop](https://github.com/looptroop-ai/LoopTroop)** - Local AI coding orchestrator for automated task planning, execution, and feedback loops. Uses a Beads-inspired methodology with LLM Council consensus and worktree isolation. Built by [@looptroop-ai](https://github.com/looptroop-ai). (Node.js/TypeScript)
 
 ## Coordination Servers
 

--- a/website/versioned_docs/version-1.1.0/core-concepts/metadata.md
+++ b/website/versioned_docs/version-1.1.0/core-concepts/metadata.md
@@ -39,14 +39,22 @@ These keys are advisory metadata, not core issue fields. When a workflow uses
 them, they take precedence over free-form notes for execution routing. Notes
 remain useful for rationale, ownership, and exact prompts.
 
+Model and effort values are portable hints, not runtime bindings. The
+`execution_reasoning_effort` values above are a canonical advisory scale:
+writers should store canonical values rather than runtime-local ones, and a
+consumer whose runtime uses a different scale should map the stored value to
+its nearest native level instead of dropping the hint. Likewise,
+`execution_suggested_model` is a capability-tier suggestion: a consumer on a
+different provider should substitute a model of the same tier rather than
+ignore the hint.
+
 Parent/orchestrator agents must consume these keys before spawning subagents.
 Model and reasoning effort are normally fixed at launch, so reading metadata
 after delegation is too late.
 
 Do not add a first-class helper such as `bd show <id> --execution` or
-`bd plan <id> --json` yet. Keep using the JSON/JQ snippet until upstream
-issue gh-3541 determines whether schedulers or runners need these fields as a
-stable CLI surface.
+`bd plan <id> --json`. Issue gh-3541 resolved to keep execution hints as
+metadata only; the JSON/JQ snippet remains the supported access path.
 
 ## Example: Tracker Round-Trip Metadata
 


### PR DESCRIPTION
## Why

The 2026-07-07 docs health check (run against upstream/main 1ecabad27) found the committed website mirrors had drifted from their `docs/` sources: `website/docs/core-concepts/metadata.md` (and the version-1.1.0 copy) lacked `docs/METADATA.md`'s "portable hints" paragraph and the gh-3541 resolution wording from #4358, and `website/docs/community-tools.md` lacked five tools present in `docs/COMMUNITY_TOOLS.md` (bd-board, Bead Me Up Scotty, beads.nvim, BeadSpec, LoopTroop). The deploy workflow re-runs `scripts/sync-website-docs.sh` before build, so the published site is fine, but the committed in-tree copies mislead repo readers, and nothing gates them, so the drift class will recur. The CLI-reference seam (`generate-cli-docs.sh` + `check-cli-docs-drift.sh`) is the working model this copies.

## What

1. **Refresh the committed mirrors** by re-running `scripts/sync-website-docs.sh` and committing its output verbatim. The script also regenerates `website/versioned_docs/version-1.1.0/`, so both drifted copies of metadata.md were fixed in one pass; no hand edits.
2. **Add a CI drift gate**: new `scripts/check-website-docs-drift.sh` mirroring the `check-cli-docs-drift.sh` pattern (back up targets, regenerate, diff against committed, restore byte-identical), wired into the `check-doc-flags` job in `pr.yml`. The gate covers `website/docs/`, `website/versioned_docs/`, and `website/versioned_sidebars/`, and counts untracked regenerated files as drift so a deleted mirror or a never-committed new sync target cannot false-pass. Verified: passes on the refreshed tree, fails on a perturbed synced target, a deleted target, and a perturbed versioned sidebar, and leaves the working tree byte-identical in every case.

Not included: extending the `docs-autofix` auto-push loop to website mirrors. That needs its own patch artifact, path allowlist, and workflow_run wiring, so it is left as a follow-up rather than half-mirrored here.

Tracked in my coordination tracker as mybd-ioma, discovered by the recurring docs health check (mybd-76hh). Reviewed cross-vendor before opening (Claude reviewer plus a Codex `gpt-5.5` review); the untracked-file and versioned-sidebar gate hardening came out of that review.

_claude-fable-5-high on behalf of matt wilkie_
