### PR TITLE
fix(storage): cascade wisp_dependencies when deleting wisps (mol burn / wisp GC orphan leak)

### DIFF
--- a/internal/storage/issueops/dependencies.go
+++ b/internal/storage/issueops/dependencies.go
@@ -372,14 +372,29 @@ func cycleDetectionTables() []string {
 	return []string{"dependencies", "wisp_dependencies"}
 }
 
+// DeleteWispFromDependenciesInTx removes every dependency row involving a
+// deleted wisp: rows in the regular dependencies table that target it, plus
+// its rows in wisp_dependencies — both the wisp's own outgoing rows
+// (issue_id: step-ordering blocks, parent-child) and rows that target it
+// (depends_on_wisp_id). Without the wisp_dependencies cleanup every
+// mol burn / wisp GC leaked its step-dependency rows as permanent orphans
+// (gastownhall/beads#4673).
 func DeleteWispFromDependenciesInTx(ctx context.Context, tx *sql.Tx, wispID string) error {
 	if _, err := tx.ExecContext(ctx,
 		"DELETE FROM dependencies WHERE depends_on_wisp_id = ?", wispID); err != nil {
 		return fmt.Errorf("delete wisp %s from dependencies: %w", wispID, err)
 	}
+	if _, err := tx.ExecContext(ctx,
+		"DELETE FROM wisp_dependencies WHERE issue_id = ? OR depends_on_wisp_id = ?",
+		wispID, wispID); err != nil && !isTableNotExistError(err) {
+		return fmt.Errorf("delete wisp %s from wisp_dependencies: %w", wispID, err)
+	}
 	return nil
 }
 
+// DeleteWispsFromDependenciesInTx is the batch form of
+// DeleteWispFromDependenciesInTx; see its doc comment for what is cascaded.
+//
 //nolint:gosec // G201: inClause contains only ? placeholders
 func DeleteWispsFromDependenciesInTx(ctx context.Context, tx *sql.Tx, wispIDs []string) error {
 	if len(wispIDs) == 0 {
@@ -390,6 +405,14 @@ func DeleteWispsFromDependenciesInTx(ctx context.Context, tx *sql.Tx, wispIDs []
 		fmt.Sprintf("DELETE FROM dependencies WHERE depends_on_wisp_id IN (%s)", inClause),
 		args...); err != nil {
 		return fmt.Errorf("delete wisps from dependencies: %w", err)
+	}
+	wispArgs := make([]interface{}, 0, len(args)*2)
+	wispArgs = append(wispArgs, args...)
+	wispArgs = append(wispArgs, args...)
+	if _, err := tx.ExecContext(ctx,
+		fmt.Sprintf("DELETE FROM wisp_dependencies WHERE issue_id IN (%s) OR depends_on_wisp_id IN (%s)", inClause, inClause),
+		wispArgs...); err != nil && !isTableNotExistError(err) {
+		return fmt.Errorf("delete wisps from wisp_dependencies: %w", err)
 	}
 	return nil
 }

--- a/internal/storage/issueops/wisp_dep_cascade_test.go
+++ b/internal/storage/issueops/wisp_dep_cascade_test.go
@@ -1,0 +1,102 @@
+package issueops
+
+import (
+	"context"
+	"regexp"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+)
+
+// TestDeleteWispFromDependenciesCascadesWispDependencies verifies that deleting
+// a wisp removes its rows from BOTH dependency tables: rows in `dependencies`
+// that target it, plus its `wisp_dependencies` rows in both directions — its
+// own outgoing rows (issue_id: step-ordering blocks, parent-child) and rows
+// that target it (depends_on_wisp_id). Regression for gastownhall/beads#4673:
+// only the `dependencies` table was cleaned, so every mol burn / wisp GC leaked
+// its step-dependency rows as permanent orphans (~26 rows per patrol-wisp burn
+// observed in production).
+func TestDeleteWispFromDependenciesCascadesWispDependencies(t *testing.T) {
+	t.Parallel()
+
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectBegin()
+	mock.ExpectExec(regexp.QuoteMeta("DELETE FROM dependencies WHERE depends_on_wisp_id = ?")).
+		WithArgs("hq-wisp-1").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec(regexp.QuoteMeta("DELETE FROM wisp_dependencies WHERE issue_id = ? OR depends_on_wisp_id = ?")).
+		WithArgs("hq-wisp-1", "hq-wisp-1").
+		WillReturnResult(sqlmock.NewResult(0, 26))
+
+	tx, err := db.Begin()
+	if err != nil {
+		t.Fatalf("begin: %v", err)
+	}
+	if err := DeleteWispFromDependenciesInTx(context.Background(), tx, "hq-wisp-1"); err != nil {
+		t.Fatalf("DeleteWispFromDependenciesInTx: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+// TestDeleteWispsFromDependenciesCascadesWispDependencies is the batch-form
+// counterpart of TestDeleteWispFromDependenciesCascadesWispDependencies.
+func TestDeleteWispsFromDependenciesCascadesWispDependencies(t *testing.T) {
+	t.Parallel()
+
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectBegin()
+	mock.ExpectExec(regexp.QuoteMeta("DELETE FROM dependencies WHERE depends_on_wisp_id IN (?,?)")).
+		WithArgs("w-1", "w-2").
+		WillReturnResult(sqlmock.NewResult(0, 2))
+	mock.ExpectExec(regexp.QuoteMeta("DELETE FROM wisp_dependencies WHERE issue_id IN (?,?) OR depends_on_wisp_id IN (?,?)")).
+		WithArgs("w-1", "w-2", "w-1", "w-2").
+		WillReturnResult(sqlmock.NewResult(0, 52))
+
+	tx, err := db.Begin()
+	if err != nil {
+		t.Fatalf("begin: %v", err)
+	}
+	if err := DeleteWispsFromDependenciesInTx(context.Background(), tx, []string{"w-1", "w-2"}); err != nil {
+		t.Fatalf("DeleteWispsFromDependenciesInTx: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+// TestDeleteWispsFromDependenciesEmptyIsNoOp verifies the batch helper issues
+// no SQL for an empty id list.
+func TestDeleteWispsFromDependenciesEmptyIsNoOp(t *testing.T) {
+	t.Parallel()
+
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectBegin()
+
+	tx, err := db.Begin()
+	if err != nil {
+		t.Fatalf("begin: %v", err)
+	}
+	if err := DeleteWispsFromDependenciesInTx(context.Background(), tx, nil); err != nil {
+		t.Fatalf("DeleteWispsFromDependenciesInTx: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #4673.

Wisp deletion cleaned only the regular `dependencies` table (`WHERE depends_on_wisp_id = ?`) and never touched **`wisp_dependencies`**, so every `bd mol burn` and wisp GC leaked the wisp's step-ordering `blocks` rows and parent-child rows as permanent orphans. Observed in production 2026-07-08: ~26 orphaned rows per patrol-wisp burn, ~40–50 eventually-dangling rows/hour, 2,902 orphaned rows on one town DB at cleanup time.

## Change

`DeleteWispFromDependenciesInTx` and its batch form `DeleteWispsFromDependenciesInTx` (`internal/storage/issueops/dependencies.go`) now also delete the wisp's `wisp_dependencies` rows in both directions — its own outgoing rows (`issue_id = <wisp>`) and rows targeting it (`depends_on_wisp_id = <wisp>`) — in the same transaction as the `wisps`-row delete.

All wisp-deletion paths route through these two helpers, so the cascade covers them all:

- `bd mol burn` → `burnWisps` → `tx.DeleteIssue` → `issueops.deleteIssueRowInTx`
- the embedded store's `DeleteIssue` / `DeleteIssues` (same `issueops` routines)
- `DoltStore.deleteWisp` / `deleteWispBatch` (wisp GC)

A missing `wisp_dependencies` table is tolerated (`isTableNotExistError`), matching how the read paths treat that optional table.

## Tests

sqlmock tests (the established pattern in `internal/storage/issueops`):

- `TestDeleteWispFromDependenciesCascadesWispDependencies` — single delete hits both tables with the right predicates/args
- `TestDeleteWispsFromDependenciesCascadesWispDependencies` — batch form ditto
- `TestDeleteWispsFromDependenciesEmptyIsNoOp` — no SQL for an empty id list

Full `internal/storage/issueops` and `internal/storage/dolt` wisp-GC test runs pass.

## Cleanup of existing orphans

This fix stops the leak; existing orphans still need a one-time sweep (SQL in #4673). Happy to add a `bd doctor` check/fix in a follow-up if wanted.
