### PR TITLE
proxied-server: configurable proxy port, shutdown GC, and commit retries

### DIFF
--- a/cmd/bd/close_proxied_server.go
+++ b/cmd/bd/close_proxied_server.go
@@ -100,7 +100,7 @@ func runCloseProxiedServer(cmd *cobra.Command, ctx context.Context, args []strin
 
 	if len(outcomes) > 0 {
 		msg := closeProxiedCommitMessage(outcomes, claimedNextIssue, continueResult)
-		if err := uw.Commit(ctx, msg); err != nil && !isDoltNothingToCommit(err) {
+		if err := uow.CommitWithRetries(ctx, uw, msg); err != nil && !isDoltNothingToCommit(err) {
 			return HandleErrorRespectJSON("commit close: %v", err)
 		}
 		for _, o := range outcomes {

--- a/cmd/bd/config_proxied_server.go
+++ b/cmd/bd/config_proxied_server.go
@@ -37,7 +37,7 @@ func runConfigSetProxiedServer(ctx context.Context, key, value string) error {
 		return HandleErrorRespectJSON("Error setting config: %v", err)
 	}
 
-	if err := uw.Commit(ctx, fmt.Sprintf("bd: config set %s", key)); err != nil && !isDoltNothingToCommit(err) {
+	if err := uow.CommitWithRetries(ctx, uw, fmt.Sprintf("bd: config set %s", key)); err != nil && !isDoltNothingToCommit(err) {
 		return HandleErrorRespectJSON("failed to commit: %v", err)
 	}
 
@@ -128,7 +128,7 @@ func runConfigUnsetProxiedServer(ctx context.Context, key string) error {
 		return HandleErrorRespectJSON("Error deleting config: %v", err)
 	}
 
-	if err := uw.Commit(ctx, fmt.Sprintf("bd: config unset %s", key)); err != nil && !isDoltNothingToCommit(err) {
+	if err := uow.CommitWithRetries(ctx, uw, fmt.Sprintf("bd: config unset %s", key)); err != nil && !isDoltNothingToCommit(err) {
 		return HandleErrorRespectJSON("failed to commit: %v", err)
 	}
 
@@ -160,7 +160,7 @@ func runConfigSetManyProxiedServer(ctx context.Context, keys, values []string) e
 		}
 	}
 
-	if err := uw.Commit(ctx, fmt.Sprintf("bd: config set-many (%d keys)", len(keys))); err != nil && !isDoltNothingToCommit(err) {
+	if err := uow.CommitWithRetries(ctx, uw, fmt.Sprintf("bd: config set-many (%d keys)", len(keys))); err != nil && !isDoltNothingToCommit(err) {
 		return HandleErrorRespectJSON("failed to commit: %v", err)
 	}
 	return nil

--- a/cmd/bd/create_proxied_server.go
+++ b/cmd/bd/create_proxied_server.go
@@ -160,7 +160,7 @@ func runCreateProxiedSingle(_ *cobra.Command, ctx context.Context, in createInpu
 		return HandleError("%v", err)
 	}
 
-	if err := uw.Commit(ctx, fmt.Sprintf("bd: create %s", result.Issue.ID)); err != nil && !isDoltNothingToCommit(err) {
+	if err := uow.CommitWithRetries(ctx, uw, fmt.Sprintf("bd: create %s", result.Issue.ID)); err != nil && !isDoltNothingToCommit(err) {
 		return HandleError("commit: %v", err)
 	}
 
@@ -318,7 +318,7 @@ func runCreateProxiedMarkdown(_ *cobra.Command, ctx context.Context, in createIn
 	}
 
 	commitMsg := fmt.Sprintf("bd: create %d issue(s) from %s", len(result.Issues), in.markdownFile)
-	if err := uw.Commit(ctx, commitMsg); err != nil && !isDoltNothingToCommit(err) {
+	if err := uow.CommitWithRetries(ctx, uw, commitMsg); err != nil && !isDoltNothingToCommit(err) {
 		return HandleError("commit: %v", err)
 	}
 
@@ -435,7 +435,7 @@ func runCreateProxiedGraph(_ *cobra.Command, ctx context.Context, in createInput
 		commitMsg = fmt.Sprintf("bd: graph-apply %d nodes", len(plan.Nodes))
 	}
 
-	if err := uw.Commit(ctx, commitMsg); err != nil && !isDoltNothingToCommit(err) {
+	if err := uow.CommitWithRetries(ctx, uw, commitMsg); err != nil && !isDoltNothingToCommit(err) {
 		return HandleError("commit: %v", err)
 	}
 

--- a/cmd/bd/db_proxy_child.go
+++ b/cmd/bd/db_proxy_child.go
@@ -21,6 +21,7 @@ var (
 	dbProxyChildConfig              string
 	dbProxyChildLogPath             string
 	dbProxyChildDoltBin             string
+	dbProxyChildDatabase            string
 	dbProxyChildExternalHost        string
 	dbProxyChildExternalPort        int
 	dbProxyChildExternalSocketPath  string
@@ -57,7 +58,7 @@ not intended to be invoked directly by users.`,
 			KeepAlivePeriod: dbProxyChildExternalKeepAlive,
 		}
 
-		srv, err := newDatabaseServer(backend, dbProxyChildRoot, dbProxyChildConfig, dbProxyChildLogPath, dbProxyChildDoltBin, external)
+		srv, err := newDatabaseServer(backend, dbProxyChildRoot, dbProxyChildConfig, dbProxyChildLogPath, dbProxyChildDoltBin, dbProxyChildDatabase, external)
 		if err != nil {
 			return err
 		}
@@ -78,10 +79,10 @@ not intended to be invoked directly by users.`,
 	},
 }
 
-func newDatabaseServer(backend proxy.Backend, rootDir, configPath, logPath, doltBin string, external configfile.ExternalDoltConfig) (server.DatabaseServer, error) {
+func newDatabaseServer(backend proxy.Backend, rootDir, configPath, logPath, doltBin, database string, external configfile.ExternalDoltConfig) (server.DatabaseServer, error) {
 	switch backend {
 	case proxy.BackendLocalServer:
-		return server.NewDoltServer(doltBin, rootDir, configPath, logPath, 0)
+		return server.NewDoltServer(doltBin, rootDir, configPath, logPath, 0, database)
 	case proxy.BackendExternal:
 		return server.NewExternalDoltServer(external)
 	case proxy.BackendLocalSharedServer:
@@ -99,6 +100,7 @@ func init() {
 	dbProxyChildCmd.Flags().StringVar(&dbProxyChildConfig, "config", "", "path to backend server config (e.g. dolt sql-server YAML)")
 	dbProxyChildCmd.Flags().StringVar(&dbProxyChildLogPath, "logpath", "", "path the backend server should write its stdout/stderr to")
 	dbProxyChildCmd.Flags().StringVar(&dbProxyChildDoltBin, "dolt-bin", "", "path to the dolt executable")
+	dbProxyChildCmd.Flags().StringVar(&dbProxyChildDatabase, "database", "", "database to select when running shutdown maintenance (local-server backend)")
 	dbProxyChildCmd.Flags().StringVar(&dbProxyChildExternalHost, "external-host", "", "external backend: hostname or IP of the dolt sql-server")
 	dbProxyChildCmd.Flags().IntVar(&dbProxyChildExternalPort, "external-port", 0, "external backend: TCP port of the dolt sql-server")
 	dbProxyChildCmd.Flags().StringVar(&dbProxyChildExternalSocketPath, "external-socket-path", "", "external backend: absolute path to a unix domain socket (overrides host/port)")

--- a/cmd/bd/db_proxy_child_test.go
+++ b/cmd/bd/db_proxy_child_test.go
@@ -14,7 +14,7 @@ func TestNewDatabaseServer_BackendExternal(t *testing.T) {
 	t.Run("valid tcp config builds an ExternalDoltServer", func(t *testing.T) {
 		srv, err := newDatabaseServer(
 			proxy.BackendExternal,
-			"", "", "", "",
+			"", "", "", "", "",
 			configfile.ExternalDoltConfig{Host: "db.internal", Port: 3306},
 		)
 		require.NoError(t, err)
@@ -26,7 +26,7 @@ func TestNewDatabaseServer_BackendExternal(t *testing.T) {
 	t.Run("invalid config bubbles validation error", func(t *testing.T) {
 		_, err := newDatabaseServer(
 			proxy.BackendExternal,
-			"", "", "", "",
+			"", "", "", "", "",
 			configfile.ExternalDoltConfig{},
 		)
 		require.Error(t, err)
@@ -36,7 +36,7 @@ func TestNewDatabaseServer_BackendExternal(t *testing.T) {
 	t.Run("unix socket config builds an ExternalDoltServer", func(t *testing.T) {
 		srv, err := newDatabaseServer(
 			proxy.BackendExternal,
-			"", "", "", "",
+			"", "", "", "", "",
 			configfile.ExternalDoltConfig{Socket: "/var/run/dolt.sock"},
 		)
 		require.NoError(t, err)
@@ -49,7 +49,7 @@ func TestNewDatabaseServer_BackendExternal(t *testing.T) {
 func TestNewDatabaseServer_BackendLocalSharedServerStillStubbed(t *testing.T) {
 	_, err := newDatabaseServer(
 		proxy.BackendLocalSharedServer,
-		"/tmp/root", "/tmp/cfg", "/tmp/log", "/usr/bin/dolt",
+		"/tmp/root", "/tmp/cfg", "/tmp/log", "/usr/bin/dolt", "",
 		configfile.ExternalDoltConfig{},
 	)
 	require.Error(t, err)
@@ -59,7 +59,7 @@ func TestNewDatabaseServer_BackendLocalSharedServerStillStubbed(t *testing.T) {
 func TestNewDatabaseServer_UnknownBackendRejected(t *testing.T) {
 	_, err := newDatabaseServer(
 		proxy.Backend("bogus"),
-		"", "", "", "",
+		"", "", "", "", "",
 		configfile.ExternalDoltConfig{},
 	)
 	require.Error(t, err)

--- a/cmd/bd/delete_proxied_server.go
+++ b/cmd/bd/delete_proxied_server.go
@@ -9,6 +9,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/steveyegge/beads/internal/storage/domain"
+	"github.com/steveyegge/beads/internal/storage/uow"
 	"github.com/steveyegge/beads/internal/ui"
 )
 
@@ -88,7 +89,7 @@ func runDeleteProxiedServer(cmd *cobra.Command, ctx context.Context, args []stri
 	}
 
 	commitMsg := fmt.Sprintf("bd: delete %d issue(s)", res.DeletedCount)
-	if err := uw.Commit(ctx, commitMsg); err != nil && !isDoltNothingToCommit(err) {
+	if err := uow.CommitWithRetries(ctx, uw, commitMsg); err != nil && !isDoltNothingToCommit(err) {
 		return HandleErrorRespectJSON("commit: %v", err)
 	}
 

--- a/cmd/bd/dep_proxied_server.go
+++ b/cmd/bd/dep_proxied_server.go
@@ -96,7 +96,7 @@ func runDepBlocksProxiedServer(cmd *cobra.Command, ctx context.Context, blockerI
 	blockerTitle := proxiedLookupTitle(ctx, uw, blockerID)
 	blockedTitle := proxiedLookupTitle(ctx, uw, blockedID)
 
-	if err := uw.Commit(ctx, fmt.Sprintf("bd: dep add %s %s", blockedID, blockerID)); err != nil && !isDoltNothingToCommit(err) {
+	if err := uow.CommitWithRetries(ctx, uw, fmt.Sprintf("bd: dep add %s %s", blockedID, blockerID)); err != nil && !isDoltNothingToCommit(err) {
 		return HandleErrorRespectJSON("failed to commit: %v", err)
 	}
 
@@ -177,7 +177,7 @@ func runDepAddProxiedServer(cmd *cobra.Command, ctx context.Context, args []stri
 	fromTitle := proxiedLookupTitle(ctx, uw, fromID)
 	toTitle := proxiedLookupTitle(ctx, uw, toID)
 
-	if err := uw.Commit(ctx, fmt.Sprintf("bd: dep add %s %s", fromID, toID)); err != nil && !isDoltNothingToCommit(err) {
+	if err := uow.CommitWithRetries(ctx, uw, fmt.Sprintf("bd: dep add %s %s", fromID, toID)); err != nil && !isDoltNothingToCommit(err) {
 		return HandleErrorRespectJSON("failed to commit: %v", err)
 	}
 
@@ -242,7 +242,7 @@ func runDepAddBulkProxied(cmd *cobra.Command, ctx context.Context, file, default
 		proxiedWarnCycles(ctx, uw)
 	}
 
-	if err := uw.Commit(ctx, fmt.Sprintf("dependency: add %d edges", len(deps))); err != nil && !isDoltNothingToCommit(err) {
+	if err := uow.CommitWithRetries(ctx, uw, fmt.Sprintf("dependency: add %d edges", len(deps))); err != nil && !isDoltNothingToCommit(err) {
 		return HandleErrorRespectJSON("failed to commit: %v", err)
 	}
 
@@ -289,7 +289,7 @@ func runDepRemoveProxiedServer(_ *cobra.Command, ctx context.Context, args []str
 	fromTitle := proxiedLookupTitle(ctx, uw, fromID)
 	toTitle := proxiedLookupTitle(ctx, uw, toID)
 
-	if err := uw.Commit(ctx, fmt.Sprintf("bd: dep remove %s %s", fromID, toID)); err != nil && !isDoltNothingToCommit(err) {
+	if err := uow.CommitWithRetries(ctx, uw, fmt.Sprintf("bd: dep remove %s %s", fromID, toID)); err != nil && !isDoltNothingToCommit(err) {
 		return HandleErrorRespectJSON("failed to commit: %v", err)
 	}
 

--- a/cmd/bd/dolt_remote_proxied_server.go
+++ b/cmd/bd/dolt_remote_proxied_server.go
@@ -6,6 +6,7 @@ import (
 	"os"
 
 	"github.com/steveyegge/beads/internal/config"
+	"github.com/steveyegge/beads/internal/storage/uow"
 )
 
 func runDoltRemoteRemoveProxied(ctx context.Context, name string) error {
@@ -27,7 +28,7 @@ func runDoltRemoteRemoveProxied(ctx context.Context, name string) error {
 		return SilentExit()
 	}
 
-	if err := uw.Commit(ctx, fmt.Sprintf("bd: remove remote %s", name)); err != nil && !isDoltNothingToCommit(err) {
+	if err := uow.CommitWithRetries(ctx, uw, fmt.Sprintf("bd: remove remote %s", name)); err != nil && !isDoltNothingToCommit(err) {
 		return HandleErrorRespectJSON("commit: %v", err)
 	}
 

--- a/cmd/bd/init.go
+++ b/cmd/bd/init.go
@@ -113,6 +113,7 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 		serverConfigPath, _ := cmd.Flags().GetString("proxied-server-config-path")
 		serverLogPath, _ := cmd.Flags().GetString("proxied-server-log-path")
 		serverRootPath, _ := cmd.Flags().GetString("proxied-server-root-path")
+		serverProxyPort, _ := cmd.Flags().GetInt("proxied-server-port")
 		externalHost, _ := cmd.Flags().GetString("proxied-server-external-host")
 		externalPort, _ := cmd.Flags().GetInt("proxied-server-external-port")
 		externalSocketPath, _ := cmd.Flags().GetString("proxied-server-external-socket-path")
@@ -178,6 +179,14 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 			}
 			if err := validateProxiedServerRootPath(serverRootPath); err != nil {
 				return fmt.Errorf("--proxied-server-root-path %v", err)
+			}
+		}
+		if serverProxyPort != 0 {
+			if !initProxiedServer {
+				return fmt.Errorf("--proxied-server-port requires --proxied-server")
+			}
+			if serverProxyPort < 1 || serverProxyPort > 65535 {
+				return fmt.Errorf("--proxied-server-port must be between 1 and 65535, got %d", serverProxyPort)
 			}
 		}
 
@@ -293,6 +302,7 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 				serverConfigPath:  serverConfigPath,
 				serverLogPath:     serverLogPath,
 				serverRootPath:    serverRootPath,
+				serverProxyPort:   serverProxyPort,
 				externalConfig:    externalConfig,
 				quiet:             quiet,
 				stealth:           stealth,
@@ -1767,6 +1777,7 @@ func init() {
 	initCmd.Flags().String("proxied-server-config-path", "", "[EXPERIMENTAL] Absolute path to an existing dolt sql-server YAML config (proxied-server mode only). When set, bd uses this file instead of auto-generating one. Relative paths are rejected.")
 	initCmd.Flags().String("proxied-server-log-path", "", "[EXPERIMENTAL] Absolute path to the proxied dolt sql-server log file (proxied-server mode only). Default: <beadsDir>/proxieddb/server.log. Relative paths are rejected.")
 	initCmd.Flags().String("proxied-server-root-path", "", "[EXPERIMENTAL] Absolute directory holding the proxied dolt sql-server's lockfiles, pidfiles, and child .dolt repository (proxied-server mode only). Default: <beadsDir>/proxieddb. May not exist yet — bd will create it. Relative paths are rejected.")
+	initCmd.Flags().Int("proxied-server-port", 0, "[EXPERIMENTAL] Fixed TCP port for the proxy's loopback listener (proxied-server mode only). Default 0 = an OS-assigned free port. Startup fails if the port is already in use.")
 	initCmd.Flags().String("proxied-server-external-host", "", "[EXPERIMENTAL] Hostname or IP of an externally-managed dolt sql-server the proxy should front (proxied-server mode only). Mutually exclusive with --proxied-server-external-socket-path.")
 	initCmd.Flags().Int("proxied-server-external-port", 0, "[EXPERIMENTAL] TCP port of the externally-managed dolt sql-server (proxied-server mode only). Required when --proxied-server-external-host is set.")
 	initCmd.Flags().String("proxied-server-external-socket-path", "", "[EXPERIMENTAL] Absolute unix socket path of the externally-managed dolt sql-server (proxied-server mode only). Mutually exclusive with --proxied-server-external-host. Relative paths are rejected.")

--- a/cmd/bd/init_proxied_server.go
+++ b/cmd/bd/init_proxied_server.go
@@ -17,6 +17,7 @@ import (
 	"github.com/steveyegge/beads/internal/storage/domain"
 	"github.com/steveyegge/beads/internal/storage/fs"
 	"github.com/steveyegge/beads/internal/storage/git"
+	"github.com/steveyegge/beads/internal/storage/uow"
 	"github.com/steveyegge/beads/internal/ui"
 )
 
@@ -30,6 +31,7 @@ type initProxiedServerInput struct {
 	serverConfigPath  string
 	serverLogPath     string
 	serverRootPath    string
+	serverProxyPort   int
 	externalConfig    *configfile.ExternalDoltConfig
 	quiet             bool
 	stealth           bool
@@ -118,7 +120,7 @@ func runInitProxiedServer(cmd *cobra.Command, ctx context.Context, in initProxie
 	}
 	configYAMLBody := renderInitConfigYAML("", false)
 
-	clientInfo, err := buildProxiedServerClientInfo(in.serverRootPath, in.serverConfigPath, in.serverLogPath, in.externalConfig)
+	clientInfo, err := buildProxiedServerClientInfo(in.serverRootPath, in.serverConfigPath, in.serverLogPath, in.serverProxyPort, in.externalConfig)
 	if err != nil {
 		return err
 	}
@@ -182,7 +184,7 @@ func runInitProxiedServer(cmd *cobra.Command, ctx context.Context, in initProxie
 		return HandleError("bootstrap project: %v", err)
 	}
 
-	if err := uw.Commit(ctx, "bd init"); err != nil {
+	if err := uow.CommitWithRetries(ctx, uw, "bd init"); err != nil {
 		return HandleError("commit init: %v", err)
 	}
 
@@ -254,7 +256,7 @@ func composeProxiedServerMetadataJSON(in proxiedMetadataInputs) ([]byte, error) 
 	return json.MarshalIndent(cfg, "", "  ")
 }
 
-func buildProxiedServerClientInfo(rootPath, configPath, logPath string, external *configfile.ExternalDoltConfig) (*configfile.ProxiedServerClientInfo, error) {
+func buildProxiedServerClientInfo(rootPath, configPath, logPath string, port int, external *configfile.ExternalDoltConfig) (*configfile.ProxiedServerClientInfo, error) {
 	if rootPath == "" && configPath == "" && logPath == "" && external == nil {
 		return nil, nil
 	}
@@ -288,6 +290,7 @@ func buildProxiedServerClientInfo(rootPath, configPath, logPath string, external
 		RootPath:   rootAbs,
 		ConfigPath: configAbs,
 		LogPath:    logAbs,
+		Port:       port,
 		External:   external,
 	}, nil
 }

--- a/cmd/bd/init_proxied_server_test.go
+++ b/cmd/bd/init_proxied_server_test.go
@@ -10,13 +10,13 @@ import (
 
 func TestBuildProxiedServerClientInfo(t *testing.T) {
 	t.Run("all empty returns nil", func(t *testing.T) {
-		info, err := buildProxiedServerClientInfo("", "", "", nil)
+		info, err := buildProxiedServerClientInfo("", "", "", 0, nil)
 		require.NoError(t, err)
 		assert.Nil(t, info)
 	})
 
 	t.Run("absolute paths pass through cleaned", func(t *testing.T) {
-		info, err := buildProxiedServerClientInfo("/var/lib/beads/proxieddb", "/etc/dolt/server.yaml", "/var/log/server.log", nil)
+		info, err := buildProxiedServerClientInfo("/var/lib/beads/proxieddb", "/etc/dolt/server.yaml", "/var/log/server.log", 0, nil)
 		require.NoError(t, err)
 		require.NotNil(t, info)
 		assert.Equal(t, "/var/lib/beads/proxieddb", info.RootPath)
@@ -26,14 +26,14 @@ func TestBuildProxiedServerClientInfo(t *testing.T) {
 	})
 
 	t.Run("filepath.Clean normalizes redundant separators and . segments", func(t *testing.T) {
-		info, err := buildProxiedServerClientInfo("/var/lib//beads/./proxieddb", "", "", nil)
+		info, err := buildProxiedServerClientInfo("/var/lib//beads/./proxieddb", "", "", 0, nil)
 		require.NoError(t, err)
 		require.NotNil(t, info)
 		assert.Equal(t, "/var/lib/beads/proxieddb", info.RootPath)
 	})
 
 	t.Run("mixed absolute + empty", func(t *testing.T) {
-		info, err := buildProxiedServerClientInfo("/var/lib/beads/proxieddb", "", "/var/log/server.log", nil)
+		info, err := buildProxiedServerClientInfo("/var/lib/beads/proxieddb", "", "/var/log/server.log", 0, nil)
 		require.NoError(t, err)
 		require.NotNil(t, info)
 		assert.Equal(t, "/var/lib/beads/proxieddb", info.RootPath)
@@ -42,26 +42,26 @@ func TestBuildProxiedServerClientInfo(t *testing.T) {
 	})
 
 	t.Run("relative root path is rejected", func(t *testing.T) {
-		_, err := buildProxiedServerClientInfo("alt-root", "", "", nil)
+		_, err := buildProxiedServerClientInfo("alt-root", "", "", 0, nil)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "not absolute")
 	})
 
 	t.Run("relative config path is rejected", func(t *testing.T) {
-		_, err := buildProxiedServerClientInfo("", "configs/server.yaml", "", nil)
+		_, err := buildProxiedServerClientInfo("", "configs/server.yaml", "", 0, nil)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "not absolute")
 	})
 
 	t.Run("relative log path is rejected", func(t *testing.T) {
-		_, err := buildProxiedServerClientInfo("", "", "logs/server.log", nil)
+		_, err := buildProxiedServerClientInfo("", "", "logs/server.log", 0, nil)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "not absolute")
 	})
 
 	t.Run("absolute paths survive a round-trip through the sidecar resolver", func(t *testing.T) {
 		const beadsDir = "/proj/.beads"
-		info, err := buildProxiedServerClientInfo("/var/lib/beads/proxieddb", "", "", nil)
+		info, err := buildProxiedServerClientInfo("/var/lib/beads/proxieddb", "", "", 0, nil)
 		require.NoError(t, err)
 		require.NotNil(t, info)
 		assert.Equal(t, info.RootPath, (&configfile.ProxiedServerClientInfo{RootPath: info.RootPath}).ResolvedRootPath(beadsDir))
@@ -69,7 +69,7 @@ func TestBuildProxiedServerClientInfo(t *testing.T) {
 
 	t.Run("external config alone populates External section", func(t *testing.T) {
 		ext := &configfile.ExternalDoltConfig{Host: "db.internal", Port: 3306}
-		info, err := buildProxiedServerClientInfo("", "", "", ext)
+		info, err := buildProxiedServerClientInfo("", "", "", 0, ext)
 		require.NoError(t, err)
 		require.NotNil(t, info)
 		assert.Empty(t, info.RootPath)
@@ -88,7 +88,7 @@ func TestBuildProxiedServerClientInfo(t *testing.T) {
 			TLSCert:     "/etc/beads/client.pem",
 			TLSKey:      "/etc/beads/client.key",
 		}
-		info, err := buildProxiedServerClientInfo("", "", "", ext)
+		info, err := buildProxiedServerClientInfo("", "", "", 0, ext)
 		require.NoError(t, err)
 		require.NotNil(t, info.External)
 		assert.True(t, info.External.TLSRequired)
@@ -98,7 +98,7 @@ func TestBuildProxiedServerClientInfo(t *testing.T) {
 
 	t.Run("external unix socket config flows through", func(t *testing.T) {
 		ext := &configfile.ExternalDoltConfig{Socket: "/var/run/dolt.sock"}
-		info, err := buildProxiedServerClientInfo("", "", "", ext)
+		info, err := buildProxiedServerClientInfo("", "", "", 0, ext)
 		require.NoError(t, err)
 		require.NotNil(t, info.External)
 		assert.Equal(t, "/var/run/dolt.sock", info.External.Socket)
@@ -107,13 +107,13 @@ func TestBuildProxiedServerClientInfo(t *testing.T) {
 	})
 
 	t.Run("invalid external config is rejected", func(t *testing.T) {
-		_, err := buildProxiedServerClientInfo("", "", "", &configfile.ExternalDoltConfig{})
+		_, err := buildProxiedServerClientInfo("", "", "", 0, &configfile.ExternalDoltConfig{})
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "ExternalDoltConfig")
 	})
 
 	t.Run("invalid external config with tls cert without key is rejected", func(t *testing.T) {
-		_, err := buildProxiedServerClientInfo("", "", "", &configfile.ExternalDoltConfig{
+		_, err := buildProxiedServerClientInfo("", "", "", 0, &configfile.ExternalDoltConfig{
 			Host:    "db",
 			Port:    3306,
 			TLSCert: "/etc/beads/client.pem",
@@ -125,7 +125,7 @@ func TestBuildProxiedServerClientInfo(t *testing.T) {
 	t.Run("external survives round-trip via SaveProxiedServerClientInfo", func(t *testing.T) {
 		dir := t.TempDir()
 		ext := &configfile.ExternalDoltConfig{Host: "db.internal", Port: 3306, TLSRequired: true}
-		info, err := buildProxiedServerClientInfo("", "", "", ext)
+		info, err := buildProxiedServerClientInfo("", "", "", 0, ext)
 		require.NoError(t, err)
 		require.NotNil(t, info)
 		require.NoError(t, configfile.SaveProxiedServerClientInfo(dir, info))

--- a/cmd/bd/purge_proxied_server.go
+++ b/cmd/bd/purge_proxied_server.go
@@ -136,7 +136,7 @@ func runPurgeOrPruneProxied(cmd *cobra.Command, scope purgeScope) error {
 		return HandleErrorRespectJSON("%s failed: %v", scope.cmdName, err)
 	}
 
-	if err := uw.Commit(ctx, fmt.Sprintf("bd: %s %d bead(s)", scope.cmdName, result.DeletedCount)); err != nil && !isDoltNothingToCommit(err) {
+	if err := uow.CommitWithRetries(ctx, uw, fmt.Sprintf("bd: %s %d bead(s)", scope.cmdName, result.DeletedCount)); err != nil && !isDoltNothingToCommit(err) {
 		return HandleErrorRespectJSON("commit: %v", err)
 	}
 

--- a/cmd/bd/ready_proxied_server.go
+++ b/cmd/bd/ready_proxied_server.go
@@ -179,7 +179,7 @@ func runReadyProxiedClaim(ctx context.Context, uw uow.UnitOfWork, in readyInput)
 		jsonPayload = buildReadyIssueOutputProxied(ctx, uw, []*types.Issue{res.Issue})
 	}
 
-	if err := uw.Commit(ctx, fmt.Sprintf("bd: ready --claim %s", res.Issue.ID)); err != nil && !isDoltNothingToCommit(err) {
+	if err := uow.CommitWithRetries(ctx, uw, fmt.Sprintf("bd: ready --claim %s", res.Issue.ID)); err != nil && !isDoltNothingToCommit(err) {
 		return HandleErrorRespectJSON("failed to commit: %v", err)
 	}
 	SetLastTouchedID(res.Issue.ID)

--- a/cmd/bd/reopen_proxied_server.go
+++ b/cmd/bd/reopen_proxied_server.go
@@ -66,7 +66,7 @@ func runReopenProxiedServer(cmd *cobra.Command, ctx context.Context, args []stri
 
 	if len(outcomes) > 0 {
 		msg := reopenProxiedCommitMessage(outcomes)
-		if err := uw.Commit(ctx, msg); err != nil && !isDoltNothingToCommit(err) {
+		if err := uow.CommitWithRetries(ctx, uw, msg); err != nil && !isDoltNothingToCommit(err) {
 			return HandleErrorRespectJSON("commit reopen: %v", err)
 		}
 		for _, o := range outcomes {

--- a/cmd/bd/sql_proxied_server.go
+++ b/cmd/bd/sql_proxied_server.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/steveyegge/beads/internal/storage/domain"
+	"github.com/steveyegge/beads/internal/storage/uow"
 )
 
 func runSQLProxiedServer(ctx context.Context, query string, csvOutput bool) error {
@@ -42,7 +43,7 @@ func runSQLProxiedServer(ctx context.Context, query string, csvOutput bool) erro
 		return HandleErrorRespectJSON("exec error: %v", err)
 	}
 
-	if err := uw.Commit(ctx, "bd sql: "+query); err != nil && !isDoltNothingToCommit(err) {
+	if err := uow.CommitWithRetries(ctx, uw, "bd sql: "+query); err != nil && !isDoltNothingToCommit(err) {
 		return HandleErrorRespectJSON("commit: %v", err)
 	}
 

--- a/cmd/bd/uow_factory.go
+++ b/cmd/bd/uow_factory.go
@@ -24,17 +24,22 @@ func newProxiedServerUOWProvider(ctx context.Context, beadsDir string) (uow.Unit
 	}
 
 	info, _ := configfile.LoadProxiedServerClientInfo(beadsDir)
+	var proxyPort int
+	if info != nil {
+		proxyPort = info.Port
+	}
 	if info != nil && info.External != nil {
-		return newExternalProxiedServerUOWProvider(ctx, beadsDir, database, info.External)
+		return newExternalProxiedServerUOWProvider(ctx, beadsDir, database, info.External, proxyPort)
 	}
 
-	return newManagedProxiedServerUOWProvider(ctx, beadsDir, database)
+	return newManagedProxiedServerUOWProvider(ctx, beadsDir, database, proxyPort)
 }
 
 func newExternalProxiedServerUOWProvider(
 	ctx context.Context,
 	beadsDir, database string,
 	external *configfile.ExternalDoltConfig,
+	proxyPort int,
 ) (uow.UnitOfWorkProvider, error) {
 	rootPath, err := resolveProxiedServerRootPath(beadsDir)
 	if err != nil {
@@ -66,12 +71,14 @@ func newExternalProxiedServerUOWProvider(
 		*external,
 		external.ResolvedUser(),
 		os.Getenv(configfile.ExternalDoltPasswordEnvVar),
+		proxyPort,
 	)
 }
 
 func newManagedProxiedServerUOWProvider(
 	ctx context.Context,
 	beadsDir, database string,
+	proxyPort int,
 ) (uow.UnitOfWorkProvider, error) {
 	doltBin, err := exec.LookPath("dolt")
 	if err != nil {
@@ -111,5 +118,6 @@ func newManagedProxiedServerUOWProvider(
 		"root",
 		"", // proxy is loopback-only, no auth
 		doltBin,
+		proxyPort,
 	)
 }

--- a/cmd/bd/uow_factory_test.go
+++ b/cmd/bd/uow_factory_test.go
@@ -28,7 +28,7 @@ func TestNewExternalProxiedServerUOWProvider_CreatesRootDir(t *testing.T) {
 	beadsDir := t.TempDir()
 	external := &configfile.ExternalDoltConfig{Host: "db.invalid"}
 
-	_, err := newExternalProxiedServerUOWProvider(context.Background(), beadsDir, "beads_test", external)
+	_, err := newExternalProxiedServerUOWProvider(context.Background(), beadsDir, "beads_test", external, 0)
 	require.Error(t, err, "invalid external config must surface a validation error")
 
 	wantRoot := proxiedServerRoot(beadsDir)

--- a/cmd/bd/update_proxied_server.go
+++ b/cmd/bd/update_proxied_server.go
@@ -13,6 +13,7 @@ import (
 	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/storage/domain"
 	"github.com/steveyegge/beads/internal/storage/fs"
+	"github.com/steveyegge/beads/internal/storage/uow"
 	"github.com/steveyegge/beads/internal/types"
 	"github.com/steveyegge/beads/internal/ui"
 )
@@ -105,7 +106,7 @@ func applyUpdateProxiedOne(ctx context.Context, id string, in *updateInput) (*ty
 		return nil, false, nil
 	}
 
-	if err := uw.Commit(ctx, fmt.Sprintf("bd: update %s", id)); err != nil && !isDoltNothingToCommit(err) {
+	if err := uow.CommitWithRetries(ctx, uw, fmt.Sprintf("bd: update %s", id)); err != nil && !isDoltNothingToCommit(err) {
 		fmt.Fprintf(os.Stderr, "Error committing %s: %v\n", id, err)
 		return nil, false, nil
 	}

--- a/cmd/bd/version_proxied_server.go
+++ b/cmd/bd/version_proxied_server.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/steveyegge/beads/internal/debug"
+	"github.com/steveyegge/beads/internal/storage/uow"
 )
 
 func reconcileVersionProxiedServer(ctx context.Context) {
@@ -25,7 +26,7 @@ func reconcileVersionProxiedServer(ctx context.Context) {
 		return
 	}
 
-	if err := uw.Commit(ctx, fmt.Sprintf("bd: reconcile version -> %s", res.Current)); err != nil && !isDoltNothingToCommit(err) {
+	if err := uow.CommitWithRetries(ctx, uw, fmt.Sprintf("bd: reconcile version -> %s", res.Current)); err != nil && !isDoltNothingToCommit(err) {
 		debug.Logf("reconcile-version: commit: %v", err)
 		return
 	}

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -3550,6 +3550,7 @@ bd init [flags]
       --proxied-server-external-tls-key-path string    [EXPERIMENTAL] Absolute path to the client TLS private key (for mTLS to the externally-managed dolt sql-server). Must be paired with --proxied-server-external-tls-cert-path. Relative paths are rejected.
       --proxied-server-external-user string            [EXPERIMENTAL] MySQL user for the externally-managed dolt sql-server (proxied-server mode only). Defaults to "root" when empty. Password is read at runtime from $BEADS_PROXIED_SERVER_EXTERNAL_PASSWORD and is never persisted to disk.
       --proxied-server-log-path string                 [EXPERIMENTAL] Absolute path to the proxied dolt sql-server log file (proxied-server mode only). Default: <beadsDir>/proxieddb/server.log. Relative paths are rejected.
+      --proxied-server-port int                        [EXPERIMENTAL] Fixed TCP port for the proxy's loopback listener (proxied-server mode only). Default 0 = an OS-assigned free port. Startup fails if the port is already in use.
       --proxied-server-root-path string                [EXPERIMENTAL] Absolute directory holding the proxied dolt sql-server's lockfiles, pidfiles, and child .dolt repository (proxied-server mode only). Default: <beadsDir>/proxieddb. May not exist yet — bd will create it. Relative paths are rejected.
   -q, --quiet                                          Suppress output (quiet mode)
       --reinit-local                                   Re-initialize local .beads/ over existing local data. Does NOT authorize remote divergence; see --discard-remote.

--- a/internal/configfile/proxied_server_client_info.go
+++ b/internal/configfile/proxied_server_client_info.go
@@ -13,6 +13,7 @@ type ProxiedServerClientInfo struct {
 	RootPath   string              `json:"root_path,omitempty"`
 	ConfigPath string              `json:"config_path,omitempty"`
 	LogPath    string              `json:"log_path,omitempty"`
+	Port       int                 `json:"port,omitempty"`
 	External   *ExternalDoltConfig `json:"external,omitempty"`
 }
 

--- a/internal/storage/dbproxy/proxy/endpoint.go
+++ b/internal/storage/dbproxy/proxy/endpoint.go
@@ -54,6 +54,8 @@ type OpenOpts struct {
 	ConfigFilePath string
 	LogFilePath    string
 	DoltBinPath    string
+	Database       string
+	Port           int
 	External       configfile.ExternalDoltConfig
 }
 
@@ -169,9 +171,12 @@ func spawnAndHandoff(rootDir string, opts OpenOpts, deadline time.Time, lock *ut
 		}
 	}
 
-	port, err := PickFreePort()
-	if err != nil {
-		return Endpoint{}, fmt.Errorf("pick port: %w", err)
+	port := opts.Port
+	if port == 0 {
+		var err error
+		if port, err = PickFreePort(); err != nil {
+			return Endpoint{}, fmt.Errorf("pick port: %w", err)
+		}
 	}
 
 	handedOff = true
@@ -237,6 +242,9 @@ func forkExecChild(rootDir string, opts OpenOpts, port int, lock *util.Lock) (*e
 	}
 	if opts.DoltBinPath != "" {
 		args = append(args, "--dolt-bin", opts.DoltBinPath)
+	}
+	if opts.Database != "" {
+		args = append(args, "--database", opts.Database)
 	}
 	if opts.Backend == BackendExternal {
 		ext := opts.External

--- a/internal/storage/dbproxy/proxy/endpoint.go
+++ b/internal/storage/dbproxy/proxy/endpoint.go
@@ -81,6 +81,9 @@ func GetCreateDatabaseProxyServerEndpoint(rootDir string, opts OpenOpts) (Endpoi
 	if err := opts.Backend.Validate(); err != nil {
 		return Endpoint{}, fmt.Errorf("OpenOpts.Backend: %w", err)
 	}
+	if opts.Port != 0 && (opts.Port < 1 || opts.Port > 65535) {
+		return Endpoint{}, fmt.Errorf("OpenOpts.Port: must be 0 or 1-65535, got %d", opts.Port)
+	}
 	switch opts.Backend {
 	case BackendLocalServer:
 		if opts.ConfigFilePath == "" {

--- a/internal/storage/dbproxy/proxy/server.go
+++ b/internal/storage/dbproxy/proxy/server.go
@@ -71,7 +71,7 @@ const (
 	readyInitialBackoff    = 50 * time.Millisecond
 	readyMaxBackoff        = 1 * time.Second
 	idleWatcherMinInterval = 1 * time.Second
-	backendStopTimeout     = 10 * time.Second
+	backendStopTimeout     = 5 * time.Minute
 	tcpKeepAlivePeriod     = 30 * time.Second
 )
 
@@ -176,13 +176,14 @@ func (p *proxyServer) ListenAndServe(parentCtx context.Context) error {
 	runErr := g.Wait()
 	_ = p.conns.Wait()
 	p.stats.IncBackendStop()
-	if stopErr := stopBackendBounded(p.server); stopErr != nil && runErr == nil {
-		runErr = fmt.Errorf("stop database server: %w", stopErr)
+	stopErr := stopBackendBounded(p.server)
+	if stopErr != nil {
+		stopErr = fmt.Errorf("stop database server: %w", stopErr)
 	}
 	if errors.Is(runErr, errIdleTimeout) || sigReceived.Load() {
-		return nil
+		runErr = nil
 	}
-	return runErr
+	return errors.Join(runErr, stopErr)
 }
 
 func stopBackendBounded(s server.DatabaseServer) error {

--- a/internal/storage/dbproxy/server/doltserver.go
+++ b/internal/storage/dbproxy/server/doltserver.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"crypto/sha256"
+	"database/sql"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -17,6 +18,7 @@ import (
 	"github.com/cenkalti/backoff/v4"
 	"github.com/dolthub/dolt/go/libraries/doltcore/servercfg"
 	"github.com/dolthub/dolt/go/libraries/utils/filesys"
+	_ "github.com/go-sql-driver/mysql"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/steveyegge/beads/internal/storage/dbproxy/pidfile"
@@ -41,6 +43,7 @@ type DoltServer struct {
 	doltBinExec     string
 	rootDir         string
 	configPath      string
+	database        string
 	config          servercfg.ServerConfig
 	keepAlivePeriod time.Duration
 
@@ -53,7 +56,7 @@ type DoltServer struct {
 
 var _ DatabaseServer = (*DoltServer)(nil)
 
-func NewDoltServer(doltBinExec, rootDir, configPath, logFilePath string, keepAlivePeriod time.Duration) (*DoltServer, error) {
+func NewDoltServer(doltBinExec, rootDir, configPath, logFilePath string, keepAlivePeriod time.Duration, database string) (*DoltServer, error) {
 	if doltBinExec == "" {
 		return nil, errors.New("server: NewDoltServer: doltBinExec is required")
 	}
@@ -99,6 +102,7 @@ func NewDoltServer(doltBinExec, rootDir, configPath, logFilePath string, keepAli
 		doltBinExec:     absDoltBinExec,
 		rootDir:         absRootDir,
 		configPath:      absConfigPath,
+		database:        database,
 		config:          cfg,
 		keepAlivePeriod: keepAlivePeriod,
 		logFile:         logFile,
@@ -313,7 +317,12 @@ func (s *DoltServer) waitReady(ctx context.Context) error {
 	}
 }
 
-func (s *DoltServer) Stop(_ context.Context) error {
+func (s *DoltServer) Stop(ctx context.Context) error {
+	gcErr := s.runShutdownGC(ctx)
+	if gcErr != nil {
+		gcErr = fmt.Errorf("server: DoltServer.Stop: %w", gcErr)
+	}
+
 	if s.cancel != nil {
 		s.cancel()
 	}
@@ -325,26 +334,51 @@ func (s *DoltServer) Stop(_ context.Context) error {
 			waitErr = nil
 		}
 	}
+	if waitErr != nil {
+		waitErr = fmt.Errorf("server: DoltServer.Stop: %w", waitErr)
+	}
 	var closeErr error
 	if s.logFile != nil {
 		closeErr = s.logFile.Close()
 		s.logFile = nil
+	}
+	if closeErr != nil {
+		closeErr = fmt.Errorf("server: DoltServer.Stop: close log: %w", closeErr)
 	}
 	var rmErr error
 	if s.pid != 0 {
 		rmErr = pidfile.Remove(s.rootDir, PIDFileName)
 		s.pid = 0
 	}
-	if waitErr != nil {
-		return fmt.Errorf("server: DoltServer.Stop: %w", waitErr)
-	}
-	if closeErr != nil {
-		return fmt.Errorf("server: DoltServer.Stop: close log: %w", closeErr)
-	}
 	if rmErr != nil {
-		return fmt.Errorf("server: DoltServer.Stop: remove pidfile: %w", rmErr)
+		rmErr = fmt.Errorf("server: DoltServer.Stop: remove pidfile: %w", rmErr)
 	}
-	return nil
+	return errors.Join(gcErr, waitErr, closeErr, rmErr)
+}
+
+func (s *DoltServer) runShutdownGC(ctx context.Context) (retErr error) {
+	if s.database == "" || !s.Running(ctx) {
+		return nil
+	}
+	db, err := sql.Open("mysql", s.DSN(ctx, s.database, "root", ""))
+	if err != nil {
+		return fmt.Errorf("open gc connection: %w", err)
+	}
+	defer func() { retErr = errors.Join(retErr, db.Close()) }()
+
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		return fmt.Errorf("acquire gc connection: %w", err)
+	}
+	defer func() { retErr = errors.Join(retErr, conn.Close()) }()
+
+	if _, err := conn.ExecContext(ctx, "CALL DOLT_GC()"); err != nil {
+		retErr = errors.Join(retErr, fmt.Errorf("dolt_gc: %w", err))
+	}
+	if _, err := conn.ExecContext(ctx, "CALL DOLT_STATS_GC()"); err != nil {
+		retErr = errors.Join(retErr, fmt.Errorf("dolt_stats_gc: %w", err))
+	}
+	return retErr
 }
 
 func (s *DoltServer) Running(_ context.Context) bool {

--- a/internal/storage/dbproxy/server/doltserver_test.go
+++ b/internal/storage/dbproxy/server/doltserver_test.go
@@ -63,7 +63,7 @@ func newDoltServer(t *testing.T) (*server.DoltServer, string) {
 	port := freePort(t)
 	cfg := writeConfig(t, port)
 	log := filepath.Join(t.TempDir(), "server.log")
-	s, err := server.NewDoltServer(bin, rootDir, cfg, log, 0)
+	s, err := server.NewDoltServer(bin, rootDir, cfg, log, 0, "")
 	require.NoError(t, err)
 	// Close the log file handle before t.TempDir's RemoveAll runs.
 	// On Windows, an open handle prevents directory removal; Stop is
@@ -103,7 +103,7 @@ func TestNewDoltServer_Validation(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			s, err := server.NewDoltServer(tc.bin, tc.root, tc.cfg, "", 0)
+			s, err := server.NewDoltServer(tc.bin, tc.root, tc.cfg, "", 0, "")
 			assert.Nil(t, s)
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), tc.want)
@@ -116,11 +116,11 @@ func TestDoltServer_ID_Stable(t *testing.T) {
 	rootA := t.TempDir()
 	rootB := t.TempDir()
 
-	a1, err := server.NewDoltServer("dolt", rootA, cfgPath, "", 0)
+	a1, err := server.NewDoltServer("dolt", rootA, cfgPath, "", 0, "")
 	require.NoError(t, err)
-	a2, err := server.NewDoltServer("dolt", rootA, cfgPath, "", 0)
+	a2, err := server.NewDoltServer("dolt", rootA, cfgPath, "", 0, "")
 	require.NoError(t, err)
-	b, err := server.NewDoltServer("dolt", rootB, cfgPath, "", 0)
+	b, err := server.NewDoltServer("dolt", rootB, cfgPath, "", 0, "")
 	require.NoError(t, err)
 
 	ctx := context.Background()
@@ -130,7 +130,7 @@ func TestDoltServer_ID_Stable(t *testing.T) {
 
 func TestDoltServer_DSN(t *testing.T) {
 	cfgPath := writeConfig(t, 13306)
-	s, err := server.NewDoltServer("dolt", t.TempDir(), cfgPath, "", 0)
+	s, err := server.NewDoltServer("dolt", t.TempDir(), cfgPath, "", 0, "")
 	require.NoError(t, err)
 
 	ctx := context.Background()
@@ -209,7 +209,7 @@ listener:
 	require.NoError(t, os.WriteFile(cfgPath, []byte(body), 0o600))
 
 	logPath := filepath.Join(t.TempDir(), "server.log")
-	s, err := server.NewDoltServer(bin, rootDir, cfgPath, logPath, 0)
+	s, err := server.NewDoltServer(bin, rootDir, cfgPath, logPath, 0, "")
 	require.NoError(t, err)
 
 	ctx := context.Background()
@@ -237,6 +237,31 @@ listener:
 	require.NoError(t, err)
 	assert.Equal(t, "unix", conn.RemoteAddr().Network())
 	require.NoError(t, conn.Close())
+
+	require.NoError(t, s.Stop(ctx))
+	assert.False(t, s.Running(ctx))
+}
+
+func TestDoltServer_Stop_RunsGCWhenDatabaseSet(t *testing.T) {
+	bin := requireDolt(t)
+	t.Setenv("HOME", t.TempDir())
+	rootDir := t.TempDir()
+	port := freePort(t)
+	cfg := writeConfig(t, port)
+	log := filepath.Join(t.TempDir(), "server.log")
+
+	const dbName = "gc_test_db"
+	s, err := server.NewDoltServer(bin, rootDir, cfg, log, 0, dbName)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	require.NoError(t, s.Start(ctx))
+
+	db, err := sql.Open("mysql", s.DSN(ctx, "", "root", ""))
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx, "CREATE DATABASE IF NOT EXISTS "+dbName)
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
 
 	require.NoError(t, s.Stop(ctx))
 	assert.False(t, s.Running(ctx))
@@ -274,7 +299,7 @@ func TestDoltServer_StartStopStart_NewInstanceSameRootDirSucceeds(t *testing.T) 
 
 	port1 := freePort(t)
 	cfg1 := writeConfig(t, port1)
-	s1, err := server.NewDoltServer(bin, rootDir, cfg1, logPath, 0)
+	s1, err := server.NewDoltServer(bin, rootDir, cfg1, logPath, 0, "")
 	require.NoError(t, err)
 	require.NoError(t, s1.Start(ctx))
 	require.NoError(t, s1.Stop(ctx))
@@ -282,7 +307,7 @@ func TestDoltServer_StartStopStart_NewInstanceSameRootDirSucceeds(t *testing.T) 
 	// Fresh port to dodge any TIME_WAIT lingering on the old one.
 	port2 := freePort(t)
 	cfg2 := writeConfig(t, port2)
-	s2, err := server.NewDoltServer(bin, rootDir, cfg2, logPath, 0)
+	s2, err := server.NewDoltServer(bin, rootDir, cfg2, logPath, 0, "")
 	require.NoError(t, err)
 	require.NoError(t, s2.Start(ctx), "new instance at same rootDir must start")
 	t.Cleanup(func() { stopWithTimeout(t, s2) })
@@ -335,7 +360,7 @@ func TestDoltServer_LogFile_CapturesOutput(t *testing.T) {
 	cfgPath := writeConfig(t, port)
 	logPath := filepath.Join(t.TempDir(), "server.log")
 
-	s, err := server.NewDoltServer(bin, rootDir, cfgPath, logPath, 0)
+	s, err := server.NewDoltServer(bin, rootDir, cfgPath, logPath, 0, "")
 	require.NoError(t, err)
 	ctx := context.Background()
 	require.NoError(t, s.Start(ctx))
@@ -387,7 +412,7 @@ func TestDoltServer_ConcurrentStart_SameRootDir_OneWins(t *testing.T) {
 		port := freePort(t)
 		cfg := writeConfig(t, port)
 		log := filepath.Join(logDir, fmt.Sprintf("server-%d.log", i))
-		s, err := server.NewDoltServer(bin, rootDir, cfg, log, 0)
+		s, err := server.NewDoltServer(bin, rootDir, cfg, log, 0, "")
 		require.NoError(t, err)
 		servers[i] = s
 	}
@@ -448,7 +473,7 @@ func TestDoltServer_DoltInit_Idempotent(t *testing.T) {
 
 	port := freePort(t)
 	cfgPath := writeConfig(t, port)
-	s, err := server.NewDoltServer(bin, rootDir, cfgPath, "", 0)
+	s, err := server.NewDoltServer(bin, rootDir, cfgPath, "", 0, "")
 	require.NoError(t, err)
 
 	ctx := context.Background()

--- a/internal/storage/uow/doltserver_provider.go
+++ b/internal/storage/uow/doltserver_provider.go
@@ -22,6 +22,7 @@ func NewDoltServerUOWProvider(
 	rootUser string,
 	rootPassword string,
 	doltBinExec string,
+	proxyPort int,
 ) (UnitOfWorkProvider, error) {
 	if database == "" {
 		return nil, fmt.Errorf("uow: database name must not be empty (caller should default to %q)", "beads")
@@ -54,7 +55,9 @@ func NewDoltServerUOWProvider(
 		ConfigFilePath: serverConfigFilePath,
 		LogFilePath:    serverLogFilePath,
 		DoltBinPath:    absDoltBinExec,
+		Database:       database,
 		IdleTimeout:    defaultProxyIdleTimeout,
+		Port:           proxyPort,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("uow: get proxy endpoint: %w", err)

--- a/internal/storage/uow/doltserver_provider_test.go
+++ b/internal/storage/uow/doltserver_provider_test.go
@@ -61,6 +61,7 @@ func TestNewDoltServerUOWProvider_ValidationErrors(t *testing.T) {
 				tc.database,
 				"", "", tc.backend,
 				tc.rootUser, "", tc.doltBin,
+				0,
 			)
 			assert.Nil(t, p)
 			require.Error(t, err)
@@ -103,6 +104,7 @@ func TestNewDoltServerUOWProvider_HappyPath(t *testing.T) {
 		"root",
 		"",
 		bin,
+		0,
 	)
 
 	require.NoError(t, err)
@@ -157,6 +159,7 @@ func TestNewDoltServerUOWProvider_ConcurrentInstantiation(t *testing.T) {
 				"root",
 				"",
 				bin,
+				0,
 			)
 			results[i] = result{provider: p, err: err}
 		}()

--- a/internal/storage/uow/doltserver_tx.go
+++ b/internal/storage/uow/doltserver_tx.go
@@ -23,9 +23,12 @@ func (t *doltServerTx) Commit(ctx context.Context, message string) error {
 	if t.done {
 		return errors.New("uow: commit: already done")
 	}
-	t.done = true
-	defer t.releaseConn()
 	_, err := t.conn.ExecContext(ctx, "CALL DOLT_COMMIT('-Am', ?);", message)
+	if err != nil && isSerializationError(err) {
+		return err
+	}
+	t.done = true
+	t.releaseConn()
 	return err
 }
 

--- a/internal/storage/uow/external_doltserver_provider.go
+++ b/internal/storage/uow/external_doltserver_provider.go
@@ -21,6 +21,7 @@ func NewExternalDoltServerUOWProvider(
 	external configfile.ExternalDoltConfig,
 	rootUser string,
 	rootPassword string,
+	proxyPort int,
 ) (UnitOfWorkProvider, error) {
 	if database == "" {
 		return nil, fmt.Errorf("uow: database name must not be empty (caller should default to %q)", "beads")
@@ -46,6 +47,7 @@ func NewExternalDoltServerUOWProvider(
 		LogFilePath: serverLogFilePath,
 		External:    external,
 		IdleTimeout: defaultProxyIdleTimeout,
+		Port:        proxyPort,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("uow: get proxy endpoint: %w", err)

--- a/internal/storage/uow/external_doltserver_provider_test.go
+++ b/internal/storage/uow/external_doltserver_provider_test.go
@@ -45,6 +45,7 @@ func TestNewExternalDoltServerUOWProvider_ValidationErrors(t *testing.T) {
 				tc.external,
 				tc.rootUser,
 				"",
+				0,
 			)
 			assert.Nil(t, p)
 			require.Error(t, err)
@@ -85,6 +86,7 @@ func TestNewExternalDoltServerUOWProvider_EndToEnd(t *testing.T) {
 		configfile.ExternalDoltConfig{Host: "127.0.0.1", Port: portInt},
 		"root",
 		"",
+		0,
 	)
 	require.NoError(t, err)
 	require.NotNil(t, provider)
@@ -158,6 +160,7 @@ func TestNewExternalDoltServerUOWProvider_ConcurrentInstantiation(t *testing.T) 
 				external,
 				"root",
 				"",
+				0,
 			)
 			results[i] = result{provider: p, err: err}
 		}()

--- a/internal/storage/uow/retry.go
+++ b/internal/storage/uow/retry.go
@@ -1,0 +1,28 @@
+package uow
+
+import (
+	"context"
+	"time"
+
+	"github.com/cenkalti/backoff/v4"
+)
+
+type Committer interface {
+	Commit(ctx context.Context, message string) error
+}
+
+func CommitWithRetries(ctx context.Context, c Committer, message string) error {
+	bo := backoff.NewExponentialBackOff()
+	bo.InitialInterval = 25 * time.Millisecond
+	bo.MaxElapsedTime = 15 * time.Second
+	return backoff.Retry(func() error {
+		err := c.Commit(ctx, message)
+		if err == nil {
+			return nil
+		}
+		if isSerializationError(err) {
+			return err
+		}
+		return backoff.Permanent(err)
+	}, backoff.WithContext(bo, ctx))
+}

--- a/internal/storage/uow/retry_test.go
+++ b/internal/storage/uow/retry_test.go
@@ -1,0 +1,66 @@
+package uow
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	mysql "github.com/go-sql-driver/mysql"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/steveyegge/beads/internal/storage/domain/db"
+)
+
+type fakeTx struct {
+	failFirst int
+	failErr   error
+	calls     int
+}
+
+func (f *fakeTx) Runner() db.Runner { return nil }
+
+func (f *fakeTx) Commit(_ context.Context, _ string) error {
+	f.calls++
+	if f.calls <= f.failFirst {
+		return f.failErr
+	}
+	return nil
+}
+
+func (f *fakeTx) Rollback(_ context.Context) error          { return nil }
+func (f *fakeTx) RollbackUnlessCommitted(_ context.Context) {}
+
+func serializationErr() error {
+	return &mysql.MySQLError{Number: 1213, Message: "deadlock detected"}
+}
+
+func TestCommitWithRetries_SuccessFirstTry(t *testing.T) {
+	tx := &fakeTx{}
+	require.NoError(t, CommitWithRetries(context.Background(), tx, "msg"))
+	assert.Equal(t, 1, tx.calls)
+}
+
+func TestCommitWithRetries_RetriesSerializationThenSucceeds(t *testing.T) {
+	tx := &fakeTx{failFirst: 2, failErr: serializationErr()}
+	require.NoError(t, CommitWithRetries(context.Background(), tx, "msg"))
+	assert.Equal(t, 3, tx.calls)
+}
+
+func TestCommitWithRetries_NonRetryableStopsImmediately(t *testing.T) {
+	boom := errors.New("boom")
+	tx := &fakeTx{failFirst: 100, failErr: boom}
+	err := CommitWithRetries(context.Background(), tx, "msg")
+	require.Error(t, err)
+	assert.Equal(t, boom, err)
+	assert.Equal(t, 1, tx.calls)
+}
+
+func TestCommitWithRetries_ContextCancelled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	tx := &fakeTx{failFirst: 100, failErr: serializationErr()}
+	err := CommitWithRetries(ctx, tx, "msg")
+	require.Error(t, err)
+	assert.LessOrEqual(t, tx.calls, 2)
+}

--- a/internal/storage/uow/version_reconcile_integration_test.go
+++ b/internal/storage/uow/version_reconcile_integration_test.go
@@ -49,6 +49,7 @@ func newTestUOWProvider(t *testing.T) UnitOfWorkProvider {
 		"root",
 		"",
 		bin,
+		0,
 	)
 	require.NoError(t, err)
 	require.NotNil(t, provider)

--- a/website/docs/cli-reference/init.md
+++ b/website/docs/cli-reference/init.md
@@ -77,6 +77,7 @@ bd init [flags]
       --proxied-server-external-tls-key-path string    [EXPERIMENTAL] Absolute path to the client TLS private key (for mTLS to the externally-managed dolt sql-server). Must be paired with --proxied-server-external-tls-cert-path. Relative paths are rejected.
       --proxied-server-external-user string            [EXPERIMENTAL] MySQL user for the externally-managed dolt sql-server (proxied-server mode only). Defaults to "root" when empty. Password is read at runtime from $BEADS_PROXIED_SERVER_EXTERNAL_PASSWORD and is never persisted to disk.
       --proxied-server-log-path string                 [EXPERIMENTAL] Absolute path to the proxied dolt sql-server log file (proxied-server mode only). Default: <beadsDir>/proxieddb/server.log. Relative paths are rejected.
+      --proxied-server-port int                        [EXPERIMENTAL] Fixed TCP port for the proxy's loopback listener (proxied-server mode only). Default 0 = an OS-assigned free port. Startup fails if the port is already in use.
       --proxied-server-root-path string                [EXPERIMENTAL] Absolute directory holding the proxied dolt sql-server's lockfiles, pidfiles, and child .dolt repository (proxied-server mode only). Default: <beadsDir>/proxieddb. May not exist yet — bd will create it. Relative paths are rejected.
   -q, --quiet                                          Suppress output (quiet mode)
       --reinit-local                                   Re-initialize local .beads/ over existing local data. Does NOT authorize remote divergence; see --discard-remote.


### PR DESCRIPTION
## Summary

Three related changes to the proxied-server path (a managed Dolt `sql-server` fronted by a per-workspace TCP proxy).

### 1. Configurable proxy port
New `--proxied-server-port` init flag to pin the proxy's loopback listener instead of always using an OS-assigned free port. Plumbed the same way as the existing proxied-server settings: flag → `ProxiedServerClientInfo` sidecar → `proxy.OpenOpts.Port` → `spawnAndHandoff` (falls back to `PickFreePort()` when `0`). Validated (1–65535, requires `--proxied-server`).

### 2. Shutdown GC on the managed Dolt server
`server.DoltServer.Stop` now runs `CALL DOLT_GC()` then `CALL DOLT_STATS_GC()` against the still-running server before teardown, on every stop.
- The beads database name is plumbed across the fork/exec boundary (`--database` on `db-proxy-child` → `NewDoltServer`) so the GC session has a database selected — verified against real dolt that `DOLT_GC` errors with `Empty database name` otherwise.
- Errors are not swallowed: every step is `errors.Join`-ed and propagated out of `Stop`; the proxy's `ListenAndServe` no longer discards the backend stop error on idle/signal shutdown. `backendStopTimeout` raised to give GC room.
- `ExternalDoltServer.Stop` stays a no-op (we don't own external servers).

### 3. Commit retries
New `uow.CommitWithRetries` retries a commit under exponential backoff on MySQL serialization failures (1213/1205), reusing the existing `isSerializationError`. `doltServerTx.Commit` was made retry-safe (keeps the session open on a serialization error). All 20 unit-of-work `Commit` call sites in `cmd/bd` (the `*_proxied_server.go` commands) now route through it; `DoltStorage` and raw `*sql.Tx` commits are untouched.

## Testing
- `go build ./...`, `go vet`, `gofmt` clean.
- New unit tests: `CommitWithRetries` (success / retry-then-succeed / non-retryable / context-cancel) and `DoltServer.Stop` GC-with-database against real dolt 1.87.0.
- Proxied-server integration suite (incl. concurrent config/close contention tests) passes with `BEADS_TEST_PROXIED_SERVER=1`.

## Notes
- The `--proxied-server` init path remains behind its existing `not yet implemented` gate; these flags/plumbing are wired for when it lifts, and the live runtime path (sidecar + metadata `dolt_mode=proxied-server`) is exercised today.
- Shutdown GC runs on every `Stop`, including the ~30s idle auto-shutdown — intentional per request; can be gated on write activity later if the frequency is a concern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
