### PR TITLE
perf(ready): fix O(N²) `bd ready --json` counts (page-push + COUNT(*) sizing)

### DIFF
--- a/cmd/bd/ready.go
+++ b/cmd/bd/ready.go
@@ -236,12 +236,26 @@ This is useful for agents executing molecules to see which steps can run next.`,
 			totalReady := len(results)
 			truncated := false
 			if filter.Limit > 0 && len(results) == filter.Limit {
+				// The page is full, so there may be more ready work. Size the true
+				// total N over the same ready predicate, zeroing the limit so the
+				// count is the full ready set (byte-identical to
+				// len(GetReadyWorkWithCounts(Limit=0))). Prefer the cheap COUNT(*)
+				// capability; unwrap past decorators (e.g. HookFiringStore) so the
+				// assertion reaches the concrete store. Fall back to the unbounded
+				// mega-query only when a store predates ReadyWorkCounter.
 				countFilter := filter
 				countFilter.Limit = 0
-				all, countErr := activeStore.GetReadyWorkWithCounts(ctx, countFilter)
-				if countErr == nil && len(all) > len(results) {
-					totalReady = len(all)
-					truncated = true
+				if counter, ok := storage.UnwrapStore(activeStore).(storage.ReadyWorkCounter); ok {
+					if n, countErr := counter.CountReadyWork(ctx, countFilter); countErr == nil && n > len(results) {
+						totalReady = n
+						truncated = true
+					}
+				} else {
+					all, countErr := activeStore.GetReadyWorkWithCounts(ctx, countFilter)
+					if countErr == nil && len(all) > len(results) {
+						totalReady = len(all)
+						truncated = true
+					}
 				}
 			}
 			if results == nil {

--- a/internal/storage/conformance/conformance.go
+++ b/internal/storage/conformance/conformance.go
@@ -11,7 +11,9 @@ package conformance
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"fmt"
 	"sort"
 	"testing"
 	"time"
@@ -66,6 +68,9 @@ func RunAll(t *testing.T, factory Factory) {
 	t.Run("ReadyUnblockedByClose", func(t *testing.T) { testReadyUnblockedByClose(t, factory) })
 	t.Run("BlockedIssues", func(t *testing.T) { testBlockedIssues(t, factory) })
 	t.Run("EpicsEligibleForClosure", func(t *testing.T) { testEpicsEligible(t, factory) })
+	t.Run("ReadyCountsPageEquivalence", func(t *testing.T) { testReadyCountsPageEquivalence(t, factory) })
+	t.Run("ReadyCountsWithWisps", func(t *testing.T) { testReadyCountsWithWisps(t, factory) })
+	t.Run("ReadyCountsPageChunking", func(t *testing.T) { testReadyCountsPageChunking(t, factory) })
 
 	// Labels
 	t.Run("Labels", func(t *testing.T) { testLabels(t, factory) })
@@ -697,4 +702,129 @@ func testTransaction(t *testing.T, f Factory) {
 	if !found {
 		t.Errorf("label 'from-tx' not found, got %v", labels)
 	}
+}
+
+// --- Ready-work counts equivalence (perf/ready-counts) ---
+
+// marshalCounts renders a counts slice to JSON for byte-equivalence comparison
+// between the page-pushed and unbounded queries.
+func marshalCounts(t *testing.T, items []*types.IssueWithCounts) string {
+	t.Helper()
+	b, err := json.Marshal(items)
+	if err != nil {
+		t.Fatalf("marshal counts: %v", err)
+	}
+	return string(b)
+}
+
+// assertReadyCountsEquivalence checks the two central claims of the ready-counts
+// fast path against a real backend: (a) each bounded page — which resolves a
+// page of IDs then hydrates counts constrained to those IDs — is byte-identical
+// to the same-length prefix of the unbounded predicate query, and (b)
+// CountReadyWork equals len(unbounded) regardless of the page cap.
+func assertReadyCountsEquivalence(t *testing.T, s storage.DoltStorage, base types.WorkFilter, pages []int) {
+	t.Helper()
+	c := ctx()
+
+	unboundedFilter := base
+	unboundedFilter.Limit = 0
+	unbounded, err := s.GetReadyWorkWithCounts(c, unboundedFilter)
+	if err != nil {
+		t.Fatalf("GetReadyWorkWithCounts(unbounded): %v", err)
+	}
+
+	counter, ok := s.(storage.ReadyWorkCounter)
+	if !ok {
+		t.Fatalf("store does not implement storage.ReadyWorkCounter")
+	}
+
+	for _, page := range pages {
+		pf := base
+		pf.Limit = page
+
+		got, err := s.GetReadyWorkWithCounts(c, pf)
+		if err != nil {
+			t.Fatalf("GetReadyWorkWithCounts(limit=%d): %v", page, err)
+		}
+		want := unbounded
+		if page > 0 && page < len(unbounded) {
+			want = unbounded[:page]
+		}
+		if gj, wj := marshalCounts(t, got), marshalCounts(t, want); gj != wj {
+			t.Fatalf("ready counts page (limit=%d) not byte-identical to unbounded prefix:\n got: %s\nwant: %s", page, gj, wj)
+		}
+
+		n, err := counter.CountReadyWork(c, pf)
+		if err != nil {
+			t.Fatalf("CountReadyWork(limit=%d): %v", page, err)
+		}
+		if n != len(unbounded) {
+			t.Fatalf("CountReadyWork(limit=%d) = %d, want %d (len unbounded)", page, n, len(unbounded))
+		}
+	}
+}
+
+func testReadyCountsPageEquivalence(t *testing.T, f Factory) {
+	s := f(t)
+	c := ctx()
+
+	// 12 ready issues with varied priority.
+	for i := 1; i <= 12; i++ {
+		id := fmt.Sprintf("rc-%02d", i)
+		must(t, s.CreateIssue(c, withDefaults(&types.Issue{ID: id, Title: id, Priority: i % 4, Status: types.StatusOpen}), "a"))
+	}
+	// A closed blocker leaves rc-01 ready but with DependencyCount=1, so the
+	// hydrated counts are non-trivial (not all zero).
+	must(t, s.CreateIssue(c, withDefaults(&types.Issue{ID: "rc-dep", Title: "dep", Status: types.StatusOpen}), "a"))
+	must(t, s.AddDependency(c, &types.Dependency{IssueID: "rc-01", DependsOnID: "rc-dep", Type: types.DepBlocks}, "a"))
+	must(t, s.CloseIssue(c, "rc-dep", "done", "a", "s"))
+	// A still-open blocker keeps rc-blocked out of the ready set (rc-blk stays ready).
+	must(t, s.CreateIssue(c, withDefaults(&types.Issue{ID: "rc-blk", Title: "blk", Status: types.StatusOpen}), "a"))
+	must(t, s.CreateIssue(c, withDefaults(&types.Issue{ID: "rc-blocked", Title: "blocked", Status: types.StatusOpen}), "a"))
+	must(t, s.AddDependency(c, &types.Dependency{IssueID: "rc-blocked", DependsOnID: "rc-blk", Type: types.DepBlocks}, "a"))
+	// Comment, label, and parent-child so those columns vary across rows.
+	must(t, s.AddComment(c, "rc-02", "a", "hi"))
+	must(t, s.AddLabel(c, "rc-03", "urgent", "a"))
+	must(t, s.AddDependency(c, &types.Dependency{IssueID: "rc-04", DependsOnID: "rc-01", Type: types.DepParentChild}, "a"))
+
+	// Ready set: rc-01..rc-12 plus rc-blk = 13. Page < ready exercises the
+	// by-IDs path; page == and > ready exercise the boundary.
+	assertReadyCountsEquivalence(t, s, types.WorkFilter{SortPolicy: types.SortPolicyOldest}, []int{1, 5, 13, 50})
+}
+
+func testReadyCountsWithWisps(t *testing.T, f Factory) {
+	s := f(t)
+	c := ctx()
+
+	// Durable ready issues.
+	for i := 1; i <= 4; i++ {
+		id := fmt.Sprintf("wc-i%02d", i)
+		must(t, s.CreateIssue(c, withDefaults(&types.Issue{ID: id, Title: id, Priority: i % 3, Status: types.StatusOpen}), "a"))
+	}
+	// Ready ephemeral wisps (routed to the wisps table).
+	for i := 1; i <= 3; i++ {
+		id := fmt.Sprintf("wc-w%02d", i)
+		must(t, s.CreateIssue(c, withDefaults(&types.Issue{ID: id, Title: id, Priority: i % 3, Status: types.StatusOpen, Ephemeral: true}), "a"))
+	}
+
+	// IncludeEphemeral makes the ready set the issues∪wisps union the counts path
+	// merges, exercising CountReadyWork's two-family COUNT(*) + overlap path.
+	assertReadyCountsEquivalence(t, s, types.WorkFilter{SortPolicy: types.SortPolicyOldest, IncludeEphemeral: true}, []int{1, 3, 7, 20})
+}
+
+func testReadyCountsPageChunking(t *testing.T, f Factory) {
+	s := f(t)
+	c := ctx()
+
+	// A page larger than sqlbuild.QueryBatchSize (200) forces the by-IDs
+	// hydration to chunk its IN-list; the merged result must still match the
+	// unbounded query byte-for-byte.
+	const n = 205
+	for i := 0; i < n; i++ {
+		id := fmt.Sprintf("ch-%04d", i)
+		must(t, s.CreateIssue(c, withDefaults(&types.Issue{ID: id, Title: id, Status: types.StatusOpen}), "a"))
+	}
+
+	// limit=100 stays within one chunk; limit=205 and 250 span two chunks.
+	assertReadyCountsEquivalence(t, s, types.WorkFilter{SortPolicy: types.SortPolicyOldest}, []int{100, n, 250})
 }

--- a/internal/storage/dolt/queries.go
+++ b/internal/storage/dolt/queries.go
@@ -63,6 +63,20 @@ func (s *DoltStore) GetReadyWorkWithCounts(ctx context.Context, filter types.Wor
 	return result, err
 }
 
+// CountReadyWork returns the total ready-work count for filter. It is identical
+// to len(GetReadyWorkWithCounts(filter with Limit=0)) but sizes the total with
+// cheap indexed COUNT(*)s instead of re-running the counts mega-query. Backs the
+// storage.ReadyWorkCounter capability.
+func (s *DoltStore) CountReadyWork(ctx context.Context, filter types.WorkFilter) (int, error) {
+	var n int
+	err := s.withReadTx(ctx, func(tx *sql.Tx) error {
+		var err error
+		n, err = issueops.CountReadyWorkInTx(ctx, tx, filter)
+		return err
+	})
+	return n, err
+}
+
 func (s *DoltStore) GetBlockedIssues(ctx context.Context, filter types.WorkFilter) ([]*types.BlockedIssue, error) {
 	var result []*types.BlockedIssue
 	err := s.withReadTx(ctx, func(tx *sql.Tx) error {

--- a/internal/storage/domain/db/issue_search_counts.go
+++ b/internal/storage/domain/db/issue_search_counts.go
@@ -138,7 +138,7 @@ func (r *issueSQLRepositoryImpl) runFilterSearchQuery(ctx context.Context, query
 
 //nolint:gosec // G201: SQL fragments are built from hardcoded table names and parameterized filters.
 func (r *issueSQLRepositoryImpl) runSearchQuery(ctx context.Context, tables filterTables, whereSQL, orderBySQL, limitSQL string, args []any, includeWispReverseDeps bool, skipLabels bool) ([]*types.IssueWithCounts, error) {
-	searchSQL := sqlbuild.SearchCountsSQL(tables, whereSQL, orderBySQL, limitSQL, includeWispReverseDeps, skipLabels)
+	searchSQL, _ := sqlbuild.SearchCountsSQL(tables, nil, whereSQL, orderBySQL, limitSQL, includeWispReverseDeps, skipLabels)
 
 	rows, err := r.runner.QueryContext(ctx, searchSQL, args...)
 	if err != nil {

--- a/internal/storage/embeddeddolt/queries.go
+++ b/internal/storage/embeddeddolt/queries.go
@@ -30,6 +30,20 @@ func (s *EmbeddedDoltStore) GetReadyWorkWithCounts(ctx context.Context, filter t
 	return result, err
 }
 
+// CountReadyWork returns the total ready-work count for filter. It is identical
+// to len(GetReadyWorkWithCounts(filter with Limit=0)) but sizes the total with
+// cheap indexed COUNT(*)s instead of re-running the counts mega-query. Backs the
+// storage.ReadyWorkCounter capability.
+func (s *EmbeddedDoltStore) CountReadyWork(ctx context.Context, filter types.WorkFilter) (int, error) {
+	var n int
+	err := s.withConn(ctx, false, func(tx *sql.Tx) error {
+		var err error
+		n, err = issueops.CountReadyWorkInTx(ctx, tx, filter)
+		return err
+	})
+	return n, err
+}
+
 func (s *EmbeddedDoltStore) GetMoleculeProgress(ctx context.Context, moleculeID string) (*types.MoleculeProgressStats, error) {
 	var result *types.MoleculeProgressStats
 	err := s.withConn(ctx, false, func(tx *sql.Tx) error {

--- a/internal/storage/issueops/ready_work.go
+++ b/internal/storage/issueops/ready_work.go
@@ -14,7 +14,11 @@ import (
 )
 
 type readyWorkPredicates struct {
-	whereSQL         string
+	whereSQL string
+	// whereArgs binds only the WHERE placeholders (no ORDER BY params); it is
+	// what a bare COUNT(*) over the ready predicate needs. args carries the
+	// WHERE params followed by the ORDER BY params for the full page query.
+	whereArgs        []interface{}
 	orderBySQL       string
 	limitSQL         string
 	args             []interface{}
@@ -60,12 +64,14 @@ func buildReadyWorkPredicates(ctx context.Context, tx DBTX, filter types.WorkFil
 		inputs.ParentDescendantIDs = descendantIDs
 	}
 
-	whereSQL, args, err := sqlbuild.BuildReadyWorkWhere(filter, tables, inputs)
+	whereSQL, whereArgs, err := sqlbuild.BuildReadyWorkWhere(filter, tables, inputs)
 	if err != nil {
 		return nil, err
 	}
 
 	orderBy := buildReadyWorkOrder(filter.SortPolicy)
+	args := make([]interface{}, 0, len(whereArgs)+len(orderBy.Args))
+	args = append(args, whereArgs...)
 	args = append(args, orderBy.Args...)
 
 	var limitSQL string
@@ -75,6 +81,7 @@ func buildReadyWorkPredicates(ctx context.Context, tx DBTX, filter types.WorkFil
 
 	return &readyWorkPredicates{
 		whereSQL:         whereSQL,
+		whereArgs:        whereArgs,
 		orderBySQL:       orderBy.SQL,
 		limitSQL:         limitSQL,
 		args:             args,

--- a/internal/storage/issueops/ready_work_counts.go
+++ b/internal/storage/issueops/ready_work_counts.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"sort"
 
+	"github.com/steveyegge/beads/internal/storage/sqlbuild"
 	"github.com/steveyegge/beads/internal/types"
 )
 
@@ -20,7 +21,7 @@ func GetReadyWorkWithCountsInTx(ctx context.Context, tx *sql.Tx, filter types.Wo
 	if err != nil {
 		return nil, err
 	}
-	out, err := runSearchQueryInTx(ctx, tx, IssuesFilterTables, issuePreds.whereSQL, issuePreds.orderBySQL, issuePreds.limitSQL, issuePreds.args, wispDepsExist, false)
+	out, err := runReadyCountsInTx(ctx, tx, IssuesFilterTables, filter.Limit, issuePreds, wispDepsExist, false)
 	if err != nil {
 		return nil, err
 	}
@@ -40,7 +41,7 @@ func GetReadyWorkWithCountsInTx(ctx context.Context, tx *sql.Tx, filter types.Wo
 	if err != nil {
 		return nil, err
 	}
-	wisps, err := runSearchQueryInTx(ctx, tx, WispsFilterTables, wispPreds.whereSQL, wispPreds.orderBySQL, wispPreds.limitSQL, wispPreds.args, true, false)
+	wisps, err := runReadyCountsInTx(ctx, tx, WispsFilterTables, filter.Limit, wispPreds, true, false)
 	if err != nil {
 		if isTableNotExistError(err) {
 			return out, nil
@@ -74,6 +75,164 @@ func GetReadyWorkWithCountsInTx(ctx context.Context, tx *sql.Tx, filter types.Wo
 		kept = kept[:filter.Limit]
 	}
 	return kept, nil
+}
+
+// runReadyCountsInTx renders the ready-work counts mega-query for one table
+// family, pushing the page down when the caller bounded it.
+//
+// For a bounded page (limit > 0) it first resolves the ≤limit ready IDs with the
+// cheap indexed ID query (the same SELECT id … the non-counts GetReadyWork path
+// uses), then hydrates the counts constrained to exactly those IDs. This is what
+// de-quadratics the query: the reverse-blocker subquery rc joins on
+// COALESCE(depends_on_issue_id, …), an expression the pure-Go GMS analyzer
+// cannot auto-index, so the planner re-scans rc's whole materialization once per
+// driver row. Bounding the driver to the page turns that O(candidates × blockers)
+// scan into O(page × blockers). Each per-issue count is a function of the full
+// dependency graph, not of the candidate set, so constraining the driver leaves
+// every emitted count byte-identical to the unbounded mega-query; the page is
+// the same top-N the ORDER BY … LIMIT selected because the ready order ends in a
+// unique `id` tiebreak.
+//
+// The page IDs are chunked into sqlbuild.QueryBatchSize batches so a large page
+// stays within every backend's per-statement placeholder limit (the by-IDs form
+// binds the page up to eight times) without falling back to the quadratic query.
+//
+// For limit <= 0 (unbounded) there is no page to push down, so it runs the
+// predicate-form mega-query unchanged.
+//
+//nolint:gosec // G201: whereSQL/orderBySQL/limitSQL are hardcoded fragments; user input rides ? placeholders.
+func runReadyCountsInTx(ctx context.Context, tx *sql.Tx, tables FilterTables, limit int, preds *readyWorkPredicates, includeWispReverseDeps, skipLabels bool) ([]*types.IssueWithCounts, error) {
+	if limit <= 0 {
+		return runSearchQueryInTx(ctx, tx, tables, preds.whereSQL, preds.orderBySQL, preds.limitSQL, preds.args, includeWispReverseDeps, skipLabels)
+	}
+
+	idQuery := fmt.Sprintf("SELECT id FROM %s %s %s %s", tables.Main, preds.whereSQL, preds.orderBySQL, preds.limitSQL)
+	pageIDs, err := queryReadyIssueIDPage(ctx, tx, idQuery, preds.args)
+	if err != nil {
+		return nil, err
+	}
+	if len(pageIDs) == 0 {
+		return nil, nil
+	}
+
+	// Hydrate the counts for the resolved page, chunking the IN-list. The page
+	// IDs are already distinct, so a per-chunk scan needs no cross-chunk dedup.
+	byID := make(map[string]*types.IssueWithCounts, len(pageIDs))
+	for start := 0; start < len(pageIDs); start += sqlbuild.QueryBatchSize {
+		end := start + sqlbuild.QueryBatchSize
+		if end > len(pageIDs) {
+			end = len(pageIDs)
+		}
+		countsSQL, idArgs := sqlbuild.SearchCountsSQL(tables, pageIDs[start:end], "", "", "", includeWispReverseDeps, skipLabels)
+		rows, scanErr := scanCountsRowsInTx(ctx, tx, tables.Main, countsSQL, idArgs)
+		if scanErr != nil {
+			return nil, scanErr
+		}
+		for _, r := range rows {
+			if r != nil && r.Issue != nil {
+				byID[r.Issue.ID] = r
+			}
+		}
+	}
+
+	// Restore the ready order the ID query already computed so the result stays
+	// identical to the unbounded mega-query's ORDER BY … LIMIT.
+	ordered := make([]*types.IssueWithCounts, 0, len(pageIDs))
+	for _, id := range pageIDs {
+		if r, ok := byID[id]; ok {
+			ordered = append(ordered, r)
+		}
+	}
+	return ordered, nil
+}
+
+// CountReadyWorkInTx returns the number of ready-work items — identical to
+// len(GetReadyWorkWithCountsInTx(filter with Limit=0)) — without materializing
+// the counts mega-query. The ready set is a union of the issues and wisps that
+// match the ready predicate, so it sizes each family with a single indexed
+// COUNT(*) over that predicate and subtracts the overlap (IDs present in both
+// ready sets, which GetReadyWorkWithCountsInTx dedupes wisp-wins). It never
+// re-runs the mega-query, so a single wisp no longer disables the fast path.
+// This backs the "Showing X of N" total `bd ready` prints when the page is
+// capped.
+func CountReadyWorkInTx(ctx context.Context, tx *sql.Tx, filter types.WorkFilter) (int, error) {
+	countFilter := filter
+	countFilter.Limit = 0
+
+	wispDepsExist, err := optionalTableExistsInTx(ctx, tx, "wisp_dependencies")
+	if err != nil {
+		return 0, fmt.Errorf("count ready work: wisp dependency probe: %w", err)
+	}
+
+	issuePreds, err := buildReadyWorkPredicates(ctx, tx, countFilter, IssuesFilterTables)
+	if err != nil {
+		return 0, err
+	}
+	issueCount, err := countReadyPredicateInTx(ctx, tx, "issues", issuePreds.whereSQL, issuePreds.whereArgs)
+	if err != nil {
+		return 0, fmt.Errorf("count ready work: issues: %w", err)
+	}
+
+	// Mirror GetReadyWorkWithCountsInTx's wisp gating: an empty/missing wisps
+	// table or absent wisp_dependencies means the ready set is issues-only.
+	empty, err := wispsTableEmptyOrMissingInTx(ctx, tx)
+	if err != nil {
+		return 0, fmt.Errorf("count ready work: wisp probe: %w", err)
+	}
+	if empty || !wispDepsExist {
+		return issueCount, nil
+	}
+
+	wispPreds, err := buildReadyWorkPredicates(ctx, tx, countFilter, WispsFilterTables)
+	if err != nil {
+		return 0, err
+	}
+	wispCount, err := countReadyPredicateInTx(ctx, tx, "wisps", wispPreds.whereSQL, wispPreds.whereArgs)
+	if err != nil {
+		if isTableNotExistError(err) {
+			return issueCount, nil
+		}
+		return 0, fmt.Errorf("count ready work: wisps: %w", err)
+	}
+	if wispCount == 0 {
+		return issueCount, nil
+	}
+
+	overlap, err := countReadyOverlapInTx(ctx, tx, issuePreds, wispPreds)
+	if err != nil {
+		return 0, fmt.Errorf("count ready work: overlap: %w", err)
+	}
+	return issueCount + wispCount - overlap, nil
+}
+
+// countReadyPredicateInTx counts the rows in one table family that match the
+// ready predicate. whereSQL already begins with "WHERE " and whereArgs binds
+// only its placeholders (no ORDER BY params).
+//
+//nolint:gosec // G201: whereSQL is hardcoded fragments; user input rides ? placeholders.
+func countReadyPredicateInTx(ctx context.Context, tx *sql.Tx, table, whereSQL string, whereArgs []interface{}) (int, error) {
+	var n int
+	if err := tx.QueryRowContext(ctx, fmt.Sprintf("SELECT COUNT(*) FROM %s %s", table, whereSQL), whereArgs...).Scan(&n); err != nil {
+		return 0, err
+	}
+	return n, nil
+}
+
+// countReadyOverlapInTx counts the IDs that satisfy the ready predicate as both
+// an issue and a wisp. GetReadyWorkWithCountsInTx keeps the wisp row and drops
+// the issue row for such an ID, so |ready| = issueCount + wispCount - overlap.
+//
+//nolint:gosec // G201: whereSQL fragments are hardcoded; user input rides ? placeholders.
+func countReadyOverlapInTx(ctx context.Context, tx *sql.Tx, issuePreds, wispPreds *readyWorkPredicates) (int, error) {
+	q := fmt.Sprintf("SELECT COUNT(*) FROM issues %s AND id IN (SELECT id FROM wisps %s)", issuePreds.whereSQL, wispPreds.whereSQL)
+	args := make([]interface{}, 0, len(issuePreds.whereArgs)+len(wispPreds.whereArgs))
+	args = append(args, issuePreds.whereArgs...)
+	args = append(args, wispPreds.whereArgs...)
+	var n int
+	if err := tx.QueryRowContext(ctx, q, args...).Scan(&n); err != nil {
+		return 0, err
+	}
+	return n, nil
 }
 
 func sortIssuesWithCountsByPolicy(items []*types.IssueWithCounts, policy types.SortPolicy) {

--- a/internal/storage/issueops/search_counts.go
+++ b/internal/storage/issueops/search_counts.go
@@ -115,11 +115,20 @@ func runFilterSearchQueryInTx(ctx context.Context, tx *sql.Tx, query string, fil
 
 //nolint:gosec // G201: SQL fragments are caller-built from hardcoded shapes
 func runSearchQueryInTx(ctx context.Context, tx *sql.Tx, tables FilterTables, whereSQL, orderBySQL, limitSQL string, args []interface{}, includeWispReverseDeps bool, skipLabels bool) ([]*types.IssueWithCounts, error) {
-	searchSQL := sqlbuild.SearchCountsSQL(tables, whereSQL, orderBySQL, limitSQL, includeWispReverseDeps, skipLabels)
+	searchSQL, _ := sqlbuild.SearchCountsSQL(tables, nil, whereSQL, orderBySQL, limitSQL, includeWispReverseDeps, skipLabels)
+	return scanCountsRowsInTx(ctx, tx, tables.Main, searchSQL, args)
+}
 
-	rows, err := tx.QueryContext(ctx, searchSQL, args...)
+// scanCountsRowsInTx runs a prebuilt counts mega-query and hydrates each row
+// through ScanReadyWorkRowWithCounts, deduping by issue ID. It is the single
+// scan/dedupe loop shared by the predicate-form search path and the by-IDs
+// ready-counts path.
+//
+//nolint:gosec // G201: query is builder-produced; user input rides ? placeholders.
+func scanCountsRowsInTx(ctx context.Context, tx *sql.Tx, mainTable, query string, args []interface{}) ([]*types.IssueWithCounts, error) {
+	rows, err := tx.QueryContext(ctx, query, args...)
 	if err != nil {
-		return nil, fmt.Errorf("search count %s: %w", tables.Main, err)
+		return nil, fmt.Errorf("search count %s: %w", mainTable, err)
 	}
 	defer func() { _ = rows.Close() }()
 
@@ -140,7 +149,7 @@ func runSearchQueryInTx(ctx context.Context, tx *sql.Tx, tables FilterTables, wh
 		out = append(out, iwc)
 	}
 	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("search count %s: rows: %w", tables.Main, err)
+		return nil, fmt.Errorf("search count %s: rows: %w", mainTable, err)
 	}
 	return out, nil
 }

--- a/internal/storage/sqlbuild/counts.go
+++ b/internal/storage/sqlbuild/counts.go
@@ -21,24 +21,64 @@ const DepJSONObject = `JSON_OBJECT(
 
 // SearchCountsSQL renders the counts mega-query: full issue rows aliased "i"
 // plus labels JSON, dep/rdep/comment counts, parent ID, and dependency JSON,
-// for one table family. whereSQL/orderBySQL/limitSQL may be empty; the
-// reverse-blocker count unions wisp_dependencies only when the caller has
-// probed that the table exists.
+// for one table family. The scan side is issueops.ScanReadyWorkRowWithCounts,
+// which scans IssueSelectColumns positionally followed by the six extra
+// columns in the order projected here.
 //
-// The scan side is issueops.ScanReadyWorkRowWithCounts, which scans
-// IssueSelectColumns positionally followed by the six extra columns in the
-// order projected here.
-func SearchCountsSQL(tables FilterTables, whereSQL, orderBySQL, limitSQL string, includeWispReverseDeps, skipLabels bool) string {
-	reverseBlockerSelect := `
-				SELECT COALESCE(depends_on_issue_id, depends_on_wisp_id, depends_on_external) AS dep_id
-				FROM dependencies WHERE type = 'blocks'
-	`
+// There are two forms of the same projection, selected by ids:
+//
+//   - Predicate form (ids empty): the driver is bounded by whereSQL/orderBySQL/
+//     limitSQL and each count subquery aggregates its whole side table. The
+//     caller supplies its own args; the returned args slice is nil.
+//
+//   - By-IDs form (ids non-empty): whereSQL/orderBySQL/limitSQL are ignored and
+//     the driver AND every count subquery are constrained to ids. This keeps
+//     each subquery from scanning its whole side table and, crucially, keeps
+//     the reverse-blocker rc self-join — whose COALESCE(...) key the pure-Go
+//     GMS analyzer cannot auto-index — from re-scanning its full materialization
+//     once per driver row. The returned args are the ids repeated once per
+//     injection point, in left-to-right placeholder order.
+//
+// The by-IDs form is result-identical to the predicate form over the same set
+// of surviving rows: each per-issue count is a function of the whole dependency
+// graph restricted to that issue, so filtering a subquery's input to ids cannot
+// change any surviving row's count. dep/comment/parent counts are
+// order-insensitive; labels are re-sorted in Go (ScanReadyWorkRowWithCounts).
+// deps_json's element order is whatever JSON_ARRAYAGG emits (SQL does not
+// guarantee one), but it is the same in both forms: restricting the aggregate's
+// input to ids drops only rows for other issues, so the per-issue rows it
+// aggregates — and their relative order — are unchanged.
+//
+// The reverse-blocker rc subquery unions wisp_dependencies only when the caller
+// has probed that the table exists (includeWispReverseDeps).
+func SearchCountsSQL(tables FilterTables, ids []string, whereSQL, orderBySQL, limitSQL string, includeWispReverseDeps, skipLabels bool) (string, []any) {
+	byIDs := len(ids) > 0
+	inSQL, idArgs := InPlaceholders(ids)
+
+	// Per-subquery id constraints. Empty strings in the predicate form leave the
+	// projection unchanged; in the by-IDs form they push the page down so no
+	// subquery aggregates more than the page's worth of rows.
+	var labelWhere, depBlocksExtra, rcDepExtra, rcWispExtra, ccWhere, pcExtra, depWhere string
+	if byIDs {
+		labelWhere = fmt.Sprintf("WHERE issue_id IN (%s)", inSQL)
+		depBlocksExtra = fmt.Sprintf(" AND issue_id IN (%s)", inSQL)
+		rcDepExtra = fmt.Sprintf(" AND %s IN (%s)", DepTargetExpr, inSQL)
+		rcWispExtra = fmt.Sprintf(" AND %s IN (%s)", DepTargetExpr, inSQL)
+		ccWhere = fmt.Sprintf("WHERE issue_id IN (%s)", inSQL)
+		pcExtra = fmt.Sprintf(" AND issue_id IN (%s)", inSQL)
+		depWhere = fmt.Sprintf("WHERE issue_id IN (%s)", inSQL)
+	}
+
+	reverseBlockerSelect := fmt.Sprintf(`
+				SELECT %s AS dep_id
+				FROM dependencies WHERE type = 'blocks'%s
+	`, DepTargetExpr, rcDepExtra)
 	if includeWispReverseDeps {
-		reverseBlockerSelect += `
+		reverseBlockerSelect += fmt.Sprintf(`
 				UNION ALL
-				SELECT COALESCE(depends_on_issue_id, depends_on_wisp_id, depends_on_external) AS dep_id
-				FROM wisp_dependencies WHERE type = 'blocks'
-		`
+				SELECT %s AS dep_id
+				FROM wisp_dependencies WHERE type = 'blocks'%s
+		`, DepTargetExpr, rcWispExtra)
 	}
 
 	labelsSelect := "l.labels_json AS labels_json"
@@ -46,14 +86,20 @@ func SearchCountsSQL(tables FilterTables, whereSQL, orderBySQL, limitSQL string,
 		LEFT JOIN (
 			SELECT issue_id, JSON_ARRAYAGG(label) AS labels_json
 			FROM %s
+			%s
 			GROUP BY issue_id
-		) l ON l.issue_id = i.id`, tables.Labels)
+		) l ON l.issue_id = i.id`, tables.Labels, labelWhere)
 	if skipLabels {
 		labelsSelect = "NULL AS labels_json"
 		labelsJoin = ""
 	}
 
-	return fmt.Sprintf(`
+	outerClause := fmt.Sprintf("%s\n\t\t%s\n\t\t%s", whereSQL, orderBySQL, limitSQL)
+	if byIDs {
+		outerClause = fmt.Sprintf("WHERE i.id IN (%s)", inSQL)
+	}
+
+	sqlText := fmt.Sprintf(`
 		SELECT %s,
 			%s,
 			COALESCE(dc.cnt, 0) AS dep_count,
@@ -66,7 +112,7 @@ func SearchCountsSQL(tables FilterTables, whereSQL, orderBySQL, limitSQL string,
 		LEFT JOIN (
 			SELECT issue_id, COUNT(*) AS cnt
 			FROM %s
-			WHERE type = 'blocks'
+			WHERE type = 'blocks'%s
 			GROUP BY issue_id
 		) dc ON dc.issue_id = i.id
 		LEFT JOIN (
@@ -77,36 +123,55 @@ func SearchCountsSQL(tables FilterTables, whereSQL, orderBySQL, limitSQL string,
 		LEFT JOIN (
 			SELECT issue_id, COUNT(*) AS cnt
 			FROM %s
+			%s
 			GROUP BY issue_id
 		) cc ON cc.issue_id = i.id
 		LEFT JOIN (
 			SELECT issue_id,
-			       MIN(COALESCE(depends_on_issue_id, depends_on_wisp_id, depends_on_external)) AS parent_id
+			       MIN(%s) AS parent_id
 			FROM %s
-			WHERE type = 'parent-child'
+			WHERE type = 'parent-child'%s
 			GROUP BY issue_id
 		) pc ON pc.issue_id = i.id
 		LEFT JOIN (
 			SELECT issue_id, JSON_ARRAYAGG(%s) AS deps_json
 			FROM %s
+			%s
 			GROUP BY issue_id
 		) d ON d.issue_id = i.id
-		%s
-		%s
 		%s
 	`,
 		ReadyWorkIssueColumns,
 		labelsSelect,
 		tables.Main,
 		labelsJoin,
-		tables.Dependencies,
+		tables.Dependencies, depBlocksExtra,
 		reverseBlockerSelect,
-		tables.Comments,
-		tables.Dependencies,
-		DepJSONObject,
-		tables.Dependencies,
-		whereSQL,
-		orderBySQL,
-		limitSQL,
+		tables.Comments, ccWhere,
+		DepTargetExpr, tables.Dependencies, pcExtra,
+		DepJSONObject, tables.Dependencies, depWhere,
+		outerClause,
 	)
+
+	if !byIDs {
+		return sqlText, nil
+	}
+
+	// args follow the placeholder order in sqlText: labels join (unless
+	// skipped), dc, rc dependencies branch, rc wisp branch (if any), cc, pc, d,
+	// then the driver.
+	args := make([]any, 0, len(idArgs)*8)
+	if !skipLabels {
+		args = append(args, idArgs...)
+	}
+	args = append(args, idArgs...) // dc
+	args = append(args, idArgs...) // rc dependencies
+	if includeWispReverseDeps {
+		args = append(args, idArgs...) // rc wisp_dependencies
+	}
+	args = append(args, idArgs...) // cc
+	args = append(args, idArgs...) // pc
+	args = append(args, idArgs...) // d
+	args = append(args, idArgs...) // driver
+	return sqlText, args
 }

--- a/internal/storage/sqlbuild/sqlbuild_test.go
+++ b/internal/storage/sqlbuild/sqlbuild_test.go
@@ -119,7 +119,10 @@ func TestBuildReadyWorkWhereBatchesIDSets(t *testing.T) {
 func TestSearchCountsSQLShape(t *testing.T) {
 	t.Parallel()
 
-	sql := SearchCountsSQL(WispsFilterTables, "WHERE x = ?", "ORDER BY y", "LIMIT 5", true, false)
+	sql, args := SearchCountsSQL(WispsFilterTables, nil, "WHERE x = ?", "ORDER BY y", "LIMIT 5", true, false)
+	if args != nil {
+		t.Errorf("predicate form must not return generated args, got %d", len(args))
+	}
 	for _, want := range []string{
 		"FROM wisps i",
 		"FROM wisp_dependencies",
@@ -135,7 +138,7 @@ func TestSearchCountsSQLShape(t *testing.T) {
 		}
 	}
 
-	noWispDeps := SearchCountsSQL(IssuesFilterTables, "", "", "", false, true)
+	noWispDeps, _ := SearchCountsSQL(IssuesFilterTables, nil, "", "", "", false, true)
 	if strings.Contains(noWispDeps, "UNION ALL") {
 		t.Error("counts SQL must not union wisp reverse deps when probe says absent")
 	}
@@ -144,5 +147,26 @@ func TestSearchCountsSQLShape(t *testing.T) {
 	}
 	if !strings.Contains(noWispDeps, "NULL AS labels_json") {
 		t.Error("counts SQL must project NULL labels_json when skipLabels is set")
+	}
+
+	// By-IDs form: driver and every subquery are constrained to the ids, and the
+	// arg count matches the placeholder injection points (labels, dc, rc-deps,
+	// rc-wisp, cc, pc, d, driver = 8 for the wisp family with labels).
+	byIDs, idArgs := SearchCountsSQL(WispsFilterTables, []string{"a", "b"}, "", "", "", true, false)
+	if !strings.Contains(byIDs, "WHERE i.id IN (?,?)") {
+		t.Errorf("by-IDs counts SQL missing driver id filter:\n%s", byIDs)
+	}
+	if strings.Contains(byIDs, "ORDER BY") || strings.Contains(byIDs, "LIMIT") {
+		t.Error("by-IDs counts SQL must not carry ORDER BY / LIMIT (order restored in Go)")
+	}
+	if len(idArgs) != 8*2 {
+		t.Errorf("by-IDs args = %d, want %d", len(idArgs), 8*2)
+	}
+
+	// skipLabels drops the labels point and !includeWispReverseDeps drops the
+	// rc-wisp point, leaving 6 injection points (dc, rc-deps, cc, pc, d, driver).
+	_, idArgsNoLabels := SearchCountsSQL(IssuesFilterTables, []string{"a", "b"}, "", "", "", false, true)
+	if len(idArgsNoLabels) != 6*2 {
+		t.Errorf("by-IDs args (skipLabels, no wisp deps) = %d, want %d", len(idArgsNoLabels), 6*2)
 	}
 }

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -302,6 +302,17 @@ type BackupStore interface {
 	RestoreDatabase(ctx context.Context, dir string, force bool) error
 }
 
+// ReadyWorkCounter sizes the total ready-work count for a filter without
+// materializing the counts mega-query. It is identical to
+// len(GetReadyWorkWithCounts(filter with Limit=0)) but computed with cheap
+// indexed COUNT(*)s over the ready predicate. `bd ready --json` type-asserts to
+// this (via UnwrapStore) to render the "Showing X of N" total when a page is
+// capped, and falls back to the unbounded GetReadyWorkWithCounts when a store
+// does not implement it.
+type ReadyWorkCounter interface {
+	CountReadyWork(ctx context.Context, filter types.WorkFilter) (int, error)
+}
+
 // Transaction provides atomic multi-operation support within a single database transaction.
 //
 // The Transaction interface exposes a subset of storage methods that execute within


### PR DESCRIPTION
## What

`bd ready --json` runs an O(N²) counts query on `main` today (independent of the multi-backend work). Two wastes in backend-agnostic code:

- The six-way counts mega-query (`sqlbuild.SearchCountsSQL`) joins **all** ready candidates against a reverse-blocker `rc` subquery keyed on `COALESCE(depends_on_issue_id, …)` — un-indexable, so it degrades to an `O(candidates × blockers)` nested loop.
- `cmd/bd/ready.go` re-ran the **entire mega-query unbounded** just to size the "Showing X of N" total.

This fixes both: **page-push** the counts (resolve the ≤N ready IDs, then constrain every count subquery to that page, chunked by `QueryBatchSize`), and **size the total with cheap indexed `COUNT(*)`s** over the ready predicate (issues + wisps families, minus overlap) instead of the mega-query. Output is **byte-identical** — the per-issue counts are a function of the target's subgraph, so constraining subquery *inputs* to the page can't change any surviving row's count.

## Why `main` (not the feature branch)

The bug is on `main`: `counts.go:33` has the `rc` COALESCE nested loop and `ready.go` has the unbounded re-count — and `counts.go` is byte-identical between `main` and the multi-backend branch. `main`'s backends (`dolt`, `embeddeddolt`) both get the fix here. The one feature-only piece — a ~6-line `sqlkit.Store.CountReadyWork` so sqlite/postgres/mysql inherit it — is a **follow-up on the backend-refactor branch** (sqlkit doesn't exist on `main`).

## Impact

- **Dolt (embedded), 10k issues:** `ready -n 1 --json` ~2.3 s → ~1.65 s. Modest in absolute terms because embedded-Dolt's per-invocation cost is dominated by ~1.6 s of engine startup — but the structural change is **O(N²) → O(page)**, so it removes a cliff that grows with repo size rather than a fixed constant.
- **SQLite backend** (feature branch, once the sqlkit follow-up lands): the same fix is ~**25×** (SQLite has no startup floor and no hash join, so the O(N²) counts was the entire cost).
- Byte-identical results/counts across the board.

## Correctness

- New conformance tests (`internal/storage/conformance/conformance.go`): `ReadyCountsPageEquivalence` (page bytes == unbounded), `ReadyCountsWithWisps`, `ReadyCountsPageChunking` (page > `QueryBatchSize`) — each asserts by-IDs byte-identity **and** `CountReadyWork == len(unbounded)`. Run under every conformance backend.
- **embedded-Dolt conformance green**; `go build`/`go vet` clean.

## Review

This supersedes #4658 and incorporates its full review (thanks @maphew) — all 8 findings addressed: real `CountReadyWork` on the stores with the capability interface moved into `internal/storage`; predicate-`COUNT(*)` sizing so a single wisp no longer disables the fast path; call-site limit zeroing; cap-before-query; one generalized counts builder; IN-list chunking instead of a quadratic fallback; shared scan/dedupe helper; and the previously-missing equivalence tests.
