### PR TITLE
fix(sqlite): safe multi-process access (WAL + busy_timeout + single connection)

### DIFF
--- a/internal/storage/sqlite/concurrency_bench_test.go
+++ b/internal/storage/sqlite/concurrency_bench_test.go
@@ -1,0 +1,151 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestSQLiteMultiProcessContention is the standalone before/after measurement for the
+// multi-process concurrency fix. It simulates N separate bd PROCESSES with N independent
+// *sql.DB handles (each its own pool) to one file, plus a long-lived reader holding an
+// open snapshot — gascity's real shape (a persistent controller reader + short-lived
+// agent writers). It runs the OLD DSN (rollback-journal, busy_timeout=0) and the NEW DSN
+// (WAL + busy_timeout=5000), logs "database is locked" rate + write-latency percentiles
+// for each, and ASSERTS the new config is clean (0 locked). The OLD arm is logged, not
+// asserted (its failure rate is inherently racy — the point is the contrast).
+//
+// Run just this: go test ./internal/storage/sqlite -run TestSQLiteMultiProcessContention -v
+func TestSQLiteMultiProcessContention(t *testing.T) {
+	if testing.Short() {
+		t.Skip("multi-process contention benchmark; skipped in -short")
+	}
+	const (
+		procs    = 8  // independent *sql.DB handles ≈ separate processes
+		perProc  = 30 // point writes each
+		attempts = procs * perProc
+	)
+
+	old := runContentionArm(t, "OLD (rollback-journal, busy_timeout=0)", false, 0, procs, perProc)
+	neu := runContentionArm(t, "NEW (WAL, busy_timeout=5000)", true, 5000, procs, perProc)
+
+	t.Logf("\n  ARM                                   attempts  locked  p50        p99        wall")
+	for _, r := range []armResult{old, neu} {
+		t.Logf("  %-36s  %8d  %6d  %-9s  %-9s  %s", r.name, r.attempts, r.locked,
+			r.p50.Round(time.Microsecond), r.p99.Round(time.Microsecond), r.wall.Round(time.Millisecond))
+	}
+
+	if neu.locked != 0 {
+		t.Fatalf("NEW config still produced %d/%d 'database is locked' errors — WAL+busy_timeout not effective", neu.locked, attempts)
+	}
+}
+
+type armResult struct {
+	name             string
+	attempts, locked int
+	p50, p99, wall   time.Duration
+}
+
+// benchDSN builds a DSN for the arm. wal toggles journal_mode(WAL); busyMs>0 adds
+// busy_timeout; immediate adds _txlock=immediate (writers use it, the reader does not).
+func benchDSN(path string, wal bool, busyMs int, immediate bool) string {
+	dsn := "file:" + path + "?_pragma=foreign_keys(1)"
+	if wal {
+		dsn += "&_pragma=journal_mode(WAL)"
+	}
+	if busyMs > 0 {
+		dsn += fmt.Sprintf("&_pragma=busy_timeout(%d)", busyMs)
+	}
+	if immediate {
+		dsn += "&_txlock=immediate"
+	}
+	return dsn
+}
+
+func runContentionArm(t *testing.T, name string, wal bool, busyMs, procs, perProc int) armResult {
+	t.Helper()
+	ctx := context.Background()
+	path := fmt.Sprintf("%s/bench-%v-%d.db", t.TempDir(), wal, busyMs)
+
+	// Provision: create the table and set the file's journal mode (persistent).
+	prov, err := sql.Open("sqlite", benchDSN(path, wal, busyMs, true))
+	if err != nil {
+		t.Fatalf("%s: open provisioner: %v", name, err)
+	}
+	if _, err := prov.ExecContext(ctx, "CREATE TABLE IF NOT EXISTS bench(id INTEGER PRIMARY KEY AUTOINCREMENT, n INTEGER)"); err != nil {
+		t.Fatalf("%s: create table: %v", name, err)
+	}
+	_ = prov.Close()
+
+	// A long-lived reader holding an open snapshot (no _txlock=immediate — a real reader).
+	reader, err := sql.Open("sqlite", benchDSN(path, wal, busyMs, false))
+	if err != nil {
+		t.Fatalf("%s: open reader: %v", name, err)
+	}
+	reader.SetMaxOpenConns(1)
+	rtx, err := reader.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
+	if err != nil {
+		t.Fatalf("%s: reader begin: %v", name, err)
+	}
+	var cnt int
+	_ = rtx.QueryRowContext(ctx, "SELECT count(*) FROM bench").Scan(&cnt) // acquire the read lock/snapshot
+
+	// N independent writer "processes", each its own pool pinned to one connection.
+	type res struct {
+		lat    []time.Duration
+		locked int
+	}
+	results := make([]res, procs)
+	var wg sync.WaitGroup
+	start := time.Now()
+	for p := 0; p < procs; p++ {
+		wg.Add(1)
+		go func(p int) {
+			defer wg.Done()
+			db, err := sql.Open("sqlite", benchDSN(path, wal, busyMs, true))
+			if err != nil {
+				results[p].locked = perProc
+				return
+			}
+			db.SetMaxOpenConns(1)
+			defer db.Close()
+			for i := 0; i < perProc; i++ {
+				t0 := time.Now()
+				_, err := db.ExecContext(ctx, "INSERT INTO bench(n) VALUES(?)", p*1000+i)
+				results[p].lat = append(results[p].lat, time.Since(t0))
+				if err != nil {
+					e := strings.ToLower(err.Error())
+					if strings.Contains(e, "locked") || strings.Contains(e, "busy") {
+						results[p].locked++
+					}
+				}
+			}
+		}(p)
+	}
+	wg.Wait()
+	wall := time.Since(start)
+
+	_ = rtx.Rollback()
+	_ = reader.Close()
+
+	var all []time.Duration
+	locked := 0
+	for _, r := range results {
+		all = append(all, r.lat...)
+		locked += r.locked
+	}
+	sort.Slice(all, func(i, j int) bool { return all[i] < all[j] })
+	pct := func(p float64) time.Duration {
+		if len(all) == 0 {
+			return 0
+		}
+		idx := int(p * float64(len(all)-1))
+		return all[idx]
+	}
+	return armResult{name: name, attempts: procs * perProc, locked: locked, p50: pct(0.50), p99: pct(0.99), wall: wall}
+}

--- a/internal/storage/sqlite/concurrency_test.go
+++ b/internal/storage/sqlite/concurrency_test.go
@@ -1,0 +1,112 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// TestDSNEnablesWALAndBusyTimeout pins the multi-process concurrency pragmas in the
+// DSN. Without WAL + busy_timeout, concurrent bd processes hit "database is locked"
+// under the fleet's normal reader/writer interleaving (see dsn.go).
+func TestDSNEnablesWALAndBusyTimeout(t *testing.T) {
+	got := dsn("beads.db")
+	for _, want := range []string{
+		"_pragma=foreign_keys(1)",
+		"_pragma=journal_mode(WAL)",
+		"_pragma=busy_timeout(5000)",
+		"_txlock=immediate",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("dsn missing %q; got %q", want, got)
+		}
+	}
+	// A caller supplying a full file: DSN opts out verbatim.
+	passthrough := "file:custom.db?_pragma=journal_mode(DELETE)"
+	if dsn(passthrough) != passthrough {
+		t.Errorf("dsn must pass a file: DSN through unchanged; got %q", dsn(passthrough))
+	}
+}
+
+// TestProvisionSwitchesFileToWAL proves the DSN actually put the database file into
+// WAL mode (persistent on the file) — a fresh, pragma-less connection reads it back.
+func TestProvisionSwitchesFileToWAL(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "wal.db")
+	st, err := Provision(ctx, path)
+	if err != nil {
+		t.Fatalf("Provision: %v", err)
+	}
+	defer st.Close()
+
+	raw, err := sql.Open("sqlite", "file:"+path) // no pragmas: read the file's persistent mode
+	if err != nil {
+		t.Fatalf("open raw: %v", err)
+	}
+	defer raw.Close()
+	var mode string
+	if err := raw.QueryRowContext(ctx, "PRAGMA journal_mode").Scan(&mode); err != nil {
+		t.Fatalf("PRAGMA journal_mode: %v", err)
+	}
+	if strings.ToLower(mode) != "wal" {
+		t.Fatalf("journal_mode = %q, want wal (the file was not switched to WAL)", mode)
+	}
+}
+
+// TestDSNBusyTimeoutHonoredByDriver guards against a DSN-syntax typo silently leaving
+// busy_timeout at 0 (instant SQLITE_BUSY). It asserts modernc actually applies the
+// _pragma=busy_timeout(5000) from the DSN to every connection.
+func TestDSNBusyTimeoutHonoredByDriver(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "bt.db")
+	raw, err := sql.Open("sqlite", dsn(path))
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer raw.Close()
+	var ms int
+	if err := raw.QueryRowContext(ctx, "PRAGMA busy_timeout").Scan(&ms); err != nil {
+		t.Fatalf("PRAGMA busy_timeout: %v", err)
+	}
+	if ms != 5000 {
+		t.Fatalf("busy_timeout = %d, want 5000 (DSN pragma not honored — check syntax)", ms)
+	}
+}
+
+// TestConcurrentWritersNoDatabaseLocked drives many concurrent in-process writers
+// through the real store. With _txlock=immediate + the default (unbounded) pool this
+// would self-collide on the write lock; SetMaxOpenConns(1) (dialect.go) serializes them
+// so every write succeeds. Zero "database is locked" is the contract.
+func TestConcurrentWritersNoDatabaseLocked(t *testing.T) {
+	ctx := context.Background()
+	st, err := Provision(ctx, filepath.Join(t.TempDir(), "conc.db"))
+	if err != nil {
+		t.Fatalf("Provision: %v", err)
+	}
+	defer st.Close()
+
+	const writers, perWriter = 16, 25
+	var wg sync.WaitGroup
+	errs := make(chan error, writers*perWriter)
+	for w := 0; w < writers; w++ {
+		wg.Add(1)
+		go func(w int) {
+			defer wg.Done()
+			for i := 0; i < perWriter; i++ {
+				if err := st.SetConfig(ctx, fmt.Sprintf("k.%d.%d", w, i), "v"); err != nil {
+					errs <- fmt.Errorf("writer %d op %d: %w", w, i, err)
+					return
+				}
+			}
+		}(w)
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Errorf("concurrent write failed: %v", err)
+	}
+}

--- a/internal/storage/sqlite/dialect.go
+++ b/internal/storage/sqlite/dialect.go
@@ -15,5 +15,16 @@ type sqliteDialect struct{ dsn string }
 func (d sqliteDialect) Name() string { return "sqlite" }
 
 func (d sqliteDialect) Open(_ context.Context) (*sql.DB, error) {
-	return sqlitedialect.Open(d.dsn)
+	db, err := sqlitedialect.Open(d.dsn)
+	if err != nil {
+		return nil, err
+	}
+	// Serialize this process's access to a single connection. With _txlock=immediate,
+	// database/sql's default (unbounded) pool would let two goroutines each open a
+	// connection and instantly collide on the write lock. One connection makes
+	// in-process access race-free; cross-PROCESS concurrency is handled by WAL +
+	// busy_timeout in the DSN. At bd's write rate the lost in-process read parallelism
+	// is irrelevant, and correctness is trivial.
+	db.SetMaxOpenConns(1)
+	return db, nil
 }

--- a/internal/storage/sqlite/dsn.go
+++ b/internal/storage/sqlite/dsn.go
@@ -2,12 +2,29 @@ package sqlite
 
 import "strings"
 
-// dsn builds a modernc.org/sqlite DSN for a database file path, enabling foreign-key
-// enforcement (off by default in SQLite) and an immediate-lock transaction mode so
-// concurrent writers fail fast rather than deadlock.
+// dsn builds a modernc.org/sqlite DSN for a database file path. The pragmas make the
+// backend safe under multi-PROCESS access (bd is a separate binary many callers shell
+// out to concurrently, alongside a long-lived reader):
+//
+//   - foreign_keys(1)     — FK enforcement (off by default in SQLite).
+//   - journal_mode(WAL)   — write-ahead logging: readers no longer block the writer and
+//     vice versa (the default rollback-journal mode mutually excludes them). Persistent
+//     on the file; asserting it per-connection is an idempotent no-op after the first.
+//   - busy_timeout(5000)  — a connection that can't acquire the lock WAITS up to 5s
+//     rather than returning SQLITE_BUSY instantly (the default is 0 = fail immediately).
+//     busy_timeout is per-connection, so it must live in the DSN, not be set once.
+//   - _txlock=immediate   — every transaction takes the write lock up front (BEGIN
+//     IMMEDIATE), so a read-then-write never fails the upgrade with BUSY_SNAPSHOT and
+//     writers serialize correctly.
+//
+// synchronous stays at the SQLite default (FULL) — durable per commit under WAL. Drop to
+// NORMAL (fsync only at checkpoint) as a perf lever if the "lose the last commits on an
+// OS/power crash" trade is acceptable; that is a deliberate durability choice, left off here.
+//
+// A caller supplying a full "file:...?..." DSN opts out of these defaults verbatim.
 func dsn(path string) string {
 	if strings.HasPrefix(path, "file:") {
 		return path
 	}
-	return "file:" + path + "?_pragma=foreign_keys(1)&_txlock=immediate"
+	return "file:" + path + "?_pragma=foreign_keys(1)&_pragma=journal_mode(WAL)&_pragma=busy_timeout(5000)&_txlock=immediate"
 }


### PR DESCRIPTION
## What

Harden the SQLite backend for multi-**process** access: enable WAL + `busy_timeout` in the DSN and pin the connection pool to a single connection. **Stacked PR** — base is `feat/hosted-multibackend`, so the diff is one commit on top of the SQLite backend.

## Why

As written, the SQLite DSN set only `foreign_keys(1)` + `_txlock=immediate`, so the backend ran in the default **rollback-journal** mode with `busy_timeout=0` and `database/sql`'s unbounded pool. Under the real deployment shape — a long-lived reader (the gascity controller) plus many short-lived `bd` writer processes — that yields `database is locked` on essentially every write: rollback-journal makes a reader mutually exclude all writers, and `busy_timeout=0` fails instantly instead of waiting. `_txlock=immediate` (already present) is necessary but not sufficient; the WAL / busy_timeout / single-conn trio is what makes it concurrent.

- `internal/storage/sqlite/dsn.go` — add `journal_mode(WAL)` (readers no longer block the writer and vice versa) and `busy_timeout(5000)` (a contended connection waits up to 5s instead of failing instantly). `synchronous` left at the durable default (FULL under WAL); NORMAL noted in-code as an opt-in perf lever, not taken here.
- `internal/storage/sqlite/dialect.go` — `db.SetMaxOpenConns(1)` so this process's writers serialize on one connection rather than self-colliding under `_txlock=immediate`; cross-process concurrency is handled by WAL + busy_timeout.

No schema change (DSN + pool only), consistent with the project charter.

## Verification

`go test ./internal/storage/sqlite/` — full package including the storage **conformance** suite: green. `gofmt`, `go build`, `go vet`: clean.

New `TestSQLiteMultiProcessContention` (8 independent `*sql.DB` handles ≈ separate processes + a held-open reader, 240 point writes) measures the before/after:

```
OLD (rollback-journal, busy_timeout=0):  240/240  'database is locked'
NEW (WAL, busy_timeout=5000):              0/240   (p50 ~0.4ms, p99 ~82ms under 8-way contention)
```

Also added: DSN pragma assertions, a live WAL/busy_timeout readback (guards against a DSN typo silently disabling busy_timeout), and a concurrent-in-process-writers-succeed test.

Run just the new tests:
```
go test ./internal/storage/sqlite -run 'TestDSNEnablesWALAndBusyTimeout|TestProvisionSwitchesFileToWAL|TestDSNBusyTimeoutHonoredByDriver|TestConcurrentWritersNoDatabaseLocked|TestSQLiteMultiProcessContention' -v
```

## Notes

- Stacked on the SQLite backend from `feat/hosted-multibackend` — review/merge after the base lands, or fold the single commit in directly.
- Deliberately **not** included (to keep this focused; sequence after): app-level `SQLITE_BUSY` retry (touches shared `sqlkit`), WAL checkpoint-starvation handling under a long-lived reader, and `synchronous=NORMAL` as a durability/perf lever.
