### PR TITLE
test(watch): fix flaky TestWatchIssueDetectsFieldUpdate (1s updated_at tie)

### DIFF
--- a/cmd/bd/show_watch_test.go
+++ b/cmd/bd/show_watch_test.go
@@ -124,13 +124,20 @@ func TestWatchIssueDetectsFieldUpdate(t *testing.T) {
 	dbPath := filepath.Join(tmpDir, ".beads", "test.db")
 	s := newTestStore(t, dbPath)
 
+	// Seed updated_at an hour in the past so the title update's fresh (now)
+	// timestamp is unambiguously newer. A title change is not itself reflected in
+	// singleIssueSnapshot, which compares updated_at at 1-second granularity — so a
+	// same-second create+update (the common case on a fast machine) would tie and
+	// spuriously fail. CreateIssue honors a non-zero UpdatedAt (see issueops
+	// create.go), making the gap deterministic.
+	seeded := time.Now().Add(-time.Hour)
 	issue := &types.Issue{
 		ID:        generateUniqueTestID(t, "test", 0),
 		Title:     "original title",
 		Status:    types.StatusOpen,
 		IssueType: types.TypeTask,
-		CreatedAt: time.Now(),
-		UpdatedAt: time.Now(),
+		CreatedAt: seeded,
+		UpdatedAt: seeded,
 	}
 	if err := s.CreateIssue(ctx, issue, "test-actor"); err != nil {
 		t.Fatalf("CreateIssue: %v", err)
@@ -142,7 +149,7 @@ func TestWatchIssueDetectsFieldUpdate(t *testing.T) {
 	}
 	snapBefore := singleIssueSnapshot(got)
 
-	// Update title (which bumps UpdatedAt)
+	// Update title (which bumps UpdatedAt to now, an hour after the seed)
 	if err := s.UpdateIssue(ctx, issue.ID, map[string]interface{}{"title": "updated title"}, "test-actor"); err != nil {
 		t.Fatalf("UpdateIssue: %v", err)
 	}


### PR DESCRIPTION
## What

Deterministically seed `updated_at` an hour in the past in `TestWatchIssueDetectsFieldUpdate` so the title update's fresh timestamp is unambiguously newer. Test-only; no production change.

## Why

`singleIssueSnapshot` compares `updated_at` at 1-second granularity, and a title change is not otherwise reflected in the snapshot. The test created and updated the issue back-to-back, so on a fast machine both landed in the same wall-clock second → `updated_at` tied → the snapshot compared equal → spurious failure. `CreateIssue` honors a non-zero `UpdatedAt` (issueops `create.go`), so seeding it in the past makes the gap deterministic.

## Verification

The failing test went from 6/6 fail to **10/10 pass** across repeated runs; the sibling `TestWatchIssueDetectsStatusChange` (which changes a snapshot-visible field) and `TestWatchIssueFlags` still pass.

```
go test ./cmd/bd/ -run TestWatchIssue -count=10
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)