### PR TITLE
feat(worktree): support default worktree directory

### DIFF
--- a/cmd/bd/worktree_cmd.go
+++ b/cmd/bd/worktree_cmd.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/steveyegge/beads/internal/beads"
+	"github.com/steveyegge/beads/internal/config"
 	"github.com/steveyegge/beads/internal/git"
 	"github.com/steveyegge/beads/internal/metrics"
 	"github.com/steveyegge/beads/internal/ui"
@@ -53,7 +54,7 @@ var worktreeCreateCmd = &cobra.Command{
 	Long: `Create a git worktree for parallel development.
 
 This command:
-1. Creates a git worktree at ./<name> (or specified path)
+1. Creates a git worktree at ./<name> or worktree.dir/<name> when configured
 2. Adds the worktree path to .gitignore (if inside repo root)
 
 The worktree automatically shares the same beads database as the main
@@ -61,6 +62,7 @@ repository via git common directory discovery — no redirect file needed.
 
 Examples:
   bd worktree create feature-auth           # Create at ./feature-auth
+  bd config set worktree.dir .worktrees     # Put bare worktree names under .worktrees/
   bd worktree create bugfix --branch fix-1  # Create with branch name
   bd worktree create ../agents/worker-1     # Create at relative path`,
 	Args:          cobra.ExactArgs(1),
@@ -160,17 +162,6 @@ func runWorktreeCreate(cmd *cobra.Command, args []string) error {
 
 	name := args[0]
 
-	// Determine worktree path
-	worktreePath, err := filepath.Abs(name)
-	if err != nil {
-		return fmt.Errorf("failed to resolve path: %w", err)
-	}
-
-	// Check if path already exists
-	if _, err := os.Stat(worktreePath); err == nil {
-		return fmt.Errorf("path already exists: %s", worktreePath)
-	}
-
 	// Get repository context (validates .beads exists and resolves paths)
 	rc, err := beads.GetRepoContext()
 	if err != nil {
@@ -181,6 +172,21 @@ func runWorktreeCreate(cmd *cobra.Command, args []string) error {
 	repoRoot := rc.CWDRepoRoot
 	if repoRoot == "" {
 		return fmt.Errorf("not in a git repository")
+	}
+	if err := checkCanCreateWorktree(repoRoot, rc.IsWorktree); err != nil {
+		return err
+	}
+
+	// Determine worktree path after repository context is known, so a
+	// repo-relative worktree.dir can be honored for bare names.
+	worktreePath, err := resolveCreateWorktreePath(name, repoRoot)
+	if err != nil {
+		return fmt.Errorf("failed to resolve path: %w", err)
+	}
+
+	// Check if path already exists
+	if _, err := os.Stat(worktreePath); err == nil {
+		return fmt.Errorf("path already exists: %s", worktreePath)
 	}
 
 	// Determine branch name
@@ -227,6 +233,58 @@ func runWorktreeCreate(cmd *cobra.Command, args []string) error {
 	fmt.Printf("%s Created worktree: %s\n", ui.RenderPass("✓"), worktreePath)
 	fmt.Printf("  Branch: %s\n", branch)
 	return nil
+}
+
+func resolveCreateWorktreePath(name, repoRoot string) (string, error) {
+	target := name
+	if isBareWorktreeName(name) {
+		worktreeDir := strings.TrimSpace(config.GetString("worktree.dir"))
+		if worktreeDir != "" {
+			if expanded, ok := expandHomeDir(worktreeDir); ok {
+				worktreeDir = expanded
+			}
+			if filepath.IsAbs(worktreeDir) {
+				target = filepath.Join(worktreeDir, name)
+			} else {
+				target = filepath.Join(repoRoot, worktreeDir, name)
+			}
+		}
+	}
+
+	return filepath.Abs(target)
+}
+
+func checkCanCreateWorktree(repoRoot string, isWorktree bool) error {
+	if !isWorktree {
+		return nil
+	}
+	return fmt.Errorf("refusing to create a worktree from inside an existing git worktree; run this command from the main repository at %s", repoRoot)
+}
+
+func isBareWorktreeName(name string) bool {
+	cleaned := filepath.Clean(strings.TrimSpace(name))
+	if cleaned == "" || cleaned == "." || cleaned == ".." {
+		return false
+	}
+	return cleaned == filepath.Base(cleaned)
+}
+
+func expandHomeDir(path string) (string, bool) {
+	if path == "~" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return path, false
+		}
+		return home, true
+	}
+	if strings.HasPrefix(path, "~/") {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return path, false
+		}
+		return filepath.Join(home, path[2:]), true
+	}
+	return path, true
 }
 
 func runWorktreeList(cmd *cobra.Command, args []string) error {

--- a/cmd/bd/worktree_cmd_test.go
+++ b/cmd/bd/worktree_cmd_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/steveyegge/beads/internal/config"
 	"github.com/steveyegge/beads/internal/utils"
 )
 
@@ -85,6 +86,77 @@ func TestGetRedirectTarget(t *testing.T) {
 			t.Errorf("expected empty string for missing redirect, got %q", got)
 		}
 	})
+}
+
+func TestResolveCreateWorktreePath(t *testing.T) {
+	t.Setenv("BEADS_TEST_IGNORE_REPO_CONFIG", "1")
+	repoRoot := t.TempDir()
+	t.Chdir(repoRoot)
+
+	config.ResetForTesting()
+	if err := config.Initialize(); err != nil {
+		t.Fatalf("config.Initialize failed: %v", err)
+	}
+	t.Cleanup(config.ResetForTesting)
+
+	t.Run("bare name uses configured worktree dir", func(t *testing.T) {
+		config.Set("worktree.dir", ".worktrees")
+
+		got, err := resolveCreateWorktreePath("feature-auth", repoRoot)
+		if err != nil {
+			t.Fatalf("resolveCreateWorktreePath failed: %v", err)
+		}
+
+		want := filepath.Join(repoRoot, ".worktrees", "feature-auth")
+		if got != want {
+			t.Fatalf("resolveCreateWorktreePath() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("explicit relative path is unchanged", func(t *testing.T) {
+		config.Set("worktree.dir", ".worktrees")
+
+		got, err := resolveCreateWorktreePath("../agents/worker-1", repoRoot)
+		if err != nil {
+			t.Fatalf("resolveCreateWorktreePath failed: %v", err)
+		}
+
+		want, err := filepath.Abs("../agents/worker-1")
+		if err != nil {
+			t.Fatalf("filepath.Abs failed: %v", err)
+		}
+		if got != want {
+			t.Fatalf("resolveCreateWorktreePath() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("bare name keeps old cwd default when unset", func(t *testing.T) {
+		config.Set("worktree.dir", "")
+
+		got, err := resolveCreateWorktreePath("feature-auth", repoRoot)
+		if err != nil {
+			t.Fatalf("resolveCreateWorktreePath failed: %v", err)
+		}
+
+		want := filepath.Join(repoRoot, "feature-auth")
+		if got != want {
+			t.Fatalf("resolveCreateWorktreePath() = %q, want %q", got, want)
+		}
+	})
+}
+
+func TestCheckCanCreateWorktree(t *testing.T) {
+	if err := checkCanCreateWorktree("/repo", false); err != nil {
+		t.Fatalf("checkCanCreateWorktree returned unexpected error: %v", err)
+	}
+
+	err := checkCanCreateWorktree("/repo", true)
+	if err == nil {
+		t.Fatal("checkCanCreateWorktree should reject creating from an existing worktree")
+	}
+	if !strings.Contains(err.Error(), "inside an existing git worktree") {
+		t.Fatalf("unexpected error: %v", err)
+	}
 }
 
 func TestAddToGitignore(t *testing.T) {

--- a/docs/WORKTREES.md
+++ b/docs/WORKTREES.md
@@ -42,6 +42,25 @@ bd ready
 bd create "Implement feature X" -t feature -p 1
 ```
 
+Or let `bd` create them. By default, a bare worktree name is created relative to
+the current directory. Configure `worktree.dir` in a repository to make bare
+names default under a shared parent such as `.worktrees/`:
+
+```bash
+bd config set worktree.dir .worktrees
+bd worktree create feature-branch --branch feature-branch
+```
+
+Explicit paths still win:
+
+```bash
+bd worktree create ../agents/worker-1 --branch worker-1
+bd worktree create .custom-trees/worker-2 --branch worker-2
+```
+
+Run `bd worktree create` from the main repository, not from inside an existing
+linked worktree.
+
 Sync issue data through the configured Dolt remote:
 
 ```bash


### PR DESCRIPTION
## Summary

Completes Accent bead ac-eorjp.

- Adds support for repo config `worktree.dir` so bare `bd worktree create <name>` targets a configured parent such as `.worktrees/<name>`.
- Preserves explicit relative and absolute paths.
- Rejects `bd worktree create` when invoked from inside an existing linked worktree, directing users back to the main repository.
- Documents the new configuration in `docs/WORKTREES.md`.

## Validation

- [x] `go test ./cmd/bd -run 'TestResolveCreateWorktreePath|TestCheckCanCreateWorktree|TestAddToGitignore|TestGetRedirectTarget|TestResolveWorktreePath'`
- [x] `go test ./cmd/bd`
- [ ] `go test ./cmd/bd/... ./internal/...` - attempted from a pre-patch process; not used as final validation. It later exposed unrelated local Dolt environment failures requiring Dolt user identity and a dbproxy timing failure.

## Beads

Assigned bead:
- ac-eorjp

Follow-up beads created:
- None

## Risk / Rollback

- Risk: Low. The new default only applies to bare worktree names when `worktree.dir` is configured; explicit paths keep existing behavior.
- Rollback: Revert this PR.

## Notes

This was requested from the Accent product repo. The upstream repo is read-only for me, so this PR is opened from my fork. Third-party tests involving Dolt remotes may require local Dolt identity/configuration to run fully.