### PR TITLE
fix(list): nest bd list --tree by parent-child edges only, not any dep on an epic

### DIFF
--- a/cmd/bd/list_helpers_test.go
+++ b/cmd/bd/list_helpers_test.go
@@ -156,6 +156,44 @@ func TestListBuildIssueTree_NoDuplicateChildrenFromMultipleDeps(t *testing.T) {
 	}
 }
 
+// A non-parent-child dependency on an epic (blocks / waits-for / discovered-from)
+// is a workflow edge, not membership. It must not nest the source under the epic
+// in `bd list --tree`. The storage layer already scopes an epic's children to
+// parent-child edges only (epic_closure.go), so the tree view must match: nesting
+// a mere blocker as a child made 2-layer parent trees render as 6+ level tangles
+// and triggered false "the hierarchy is broken" conclusions during grooming.
+func TestListBuildIssueTree_NonParentChildDepOnEpicDoesNotNest(t *testing.T) {
+	epic := &types.Issue{ID: "bd-epic", Title: "Epic", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeEpic}
+
+	// Each non-parent-child edge type that AffectsReadyWork or is otherwise a
+	// legitimate cross-cutting link to an epic — none of these imply parenthood.
+	for _, depType := range []types.DependencyType{
+		types.DepBlocks,
+		types.DepWaitsFor,
+		types.DepConditionalBlocks,
+		types.DepDiscoveredFrom,
+		types.DepRelated,
+	} {
+		t.Run(string(depType), func(t *testing.T) {
+			task := &types.Issue{ID: "bd-task", Title: "Task", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask}
+			allDeps := map[string][]*types.Dependency{
+				"bd-task": {
+					{IssueID: "bd-task", DependsOnID: "bd-epic", Type: depType},
+				},
+			}
+
+			roots, children := buildIssueTreeWithDeps([]*types.Issue{epic, task}, allDeps)
+
+			if len(roots) != 2 {
+				t.Fatalf("expected both epic and task as roots (no nesting), got %d: %+v", len(roots), roots)
+			}
+			if len(children["bd-epic"]) != 0 {
+				t.Fatalf("%s edge on an epic must not nest the source as a child, got: %+v", depType, children["bd-epic"])
+			}
+		})
+	}
+}
+
 func TestFormatPrettyIssueWithContext(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/bd/list_tree.go
+++ b/cmd/bd/list_tree.go
@@ -19,26 +19,33 @@ func buildIssueTree(issues []*types.Issue) (roots []*types.Issue, childrenMap ma
 
 // buildIssueTreeWithDeps builds parent-child tree using dependency records
 // If allDeps is nil, falls back to dotted ID hierarchy (e.g., "parent.1")
-// Treats any dependency on an epic as a parent-child relationship
+// Only parent-child dependency edges establish nesting; other edge types
+// (blocks, waits-for, discovered-from, relates-to, ...) are workflow/graph
+// links and are not rendered as hierarchy.
 func buildIssueTreeWithDeps(issues []*types.Issue, allDeps map[string][]*types.Dependency) (roots []*types.Issue, childrenMap map[string][]*types.Issue) {
 	issueMap := make(map[string]*types.Issue)
 	childrenMap = make(map[string][]*types.Issue)
 	isChild := make(map[string]bool)
 
-	// Build issue map and identify epics
-	epicIDs := make(map[string]bool)
 	for _, issue := range issues {
 		issueMap[issue.ID] = issue
-		if issue.IssueType == "epic" {
-			epicIDs[issue.ID] = true
-		}
 	}
 
-	// If we have dependency records, use them to find parent-child relationships
+	// If we have dependency records, use them to find parent-child relationships.
+	// Nesting is driven strictly by the parent-child edge type. Earlier versions
+	// also nested any dependency whose target was an epic, but that conflated
+	// workflow edges (a task that merely blocks an epic) with membership, so a
+	// genuinely 2-layer parent tree could render as a 6+ level tangle and trigger
+	// false "the hierarchy is broken" conclusions. This now matches the storage
+	// layer, which scopes an epic's children to parent-child edges only
+	// (see epic_closure.go); non-hierarchical edges stay off the tree.
 	if allDeps != nil {
 		addedChild := make(map[string]bool) // tracks "parentID:childID" to prevent duplicates
 		for issueID, deps := range allDeps {
 			for _, dep := range deps {
+				if dep.Type != types.DepParentChild {
+					continue
+				}
 				parentID := dep.DependsOnID
 				// Only include if both parent and child are in the issue set
 				child, childOk := issueMap[issueID]
@@ -47,26 +54,12 @@ func buildIssueTreeWithDeps(issues []*types.Issue, allDeps map[string][]*types.D
 					continue
 				}
 
-				// relates-to is a loose graph link, not a hierarchical edge:
-				// treating it as parent-child causes incorrect nesting and, when
-				// bidirectional, marks both endpoints as children of each other
-				// — collapsing them out of the root set and silently dropping
-				// whole subtrees from `bd list`. See gastownhall/beads#3936.
-				if dep.Type == types.DepRelatesTo {
-					continue
+				key := parentID + ":" + issueID
+				if !addedChild[key] {
+					childrenMap[parentID] = append(childrenMap[parentID], child)
+					addedChild[key] = true
 				}
-
-				// Treat as parent-child if:
-				// 1. Explicit parent-child dependency type, OR
-				// 2. Any dependency where the target is an epic
-				if dep.Type == types.DepParentChild || epicIDs[parentID] {
-					key := parentID + ":" + issueID
-					if !addedChild[key] {
-						childrenMap[parentID] = append(childrenMap[parentID], child)
-						addedChild[key] = true
-					}
-					isChild[issueID] = true
-				}
+				isChild[issueID] = true
 			}
 		}
 	}


### PR DESCRIPTION
## Problem

`bd list --tree` (the default list view) rendered **any** dependency whose
target is an epic as a parent-child relationship. So a task that merely
`blocks` — or `waits-for`, `discovered-from`, etc. — an epic was drawn as
that epic's *child*. A genuinely 2-layer parent tree could therefore display
as a 6+ level tangle, repeatedly causing false "the hierarchy is broken"
conclusions when the parent tree was actually clean.

## Impact on agents consuming the output

beads is heavily driven by coding agents, and `bd list --tree` is a primary
way they read the shape of an epic. The false nesting was especially costly
here: an agent reading the tangled tree would conclude the hierarchy was
broken and start "fixing" a structure that was already correct — re-parenting
tasks, opening grooming spikes, second-guessing a clean plan. In practice
this drove real churn (wasted grooming passes and reorg work) that traced
back entirely to the rendering, not the data. Making the view match the
underlying parent-child structure removes that whole class of false signal.

## Fix

`buildIssueTreeWithDeps` now nests strictly on the `parent-child` edge type
(plus the existing dotted-ID fallback). This makes the tree view consistent
with the rest of beads:

- The storage layer already scopes an epic's children to `parent-child`
  edges only (`epic_closure.go` — `WHERE type = 'parent-child'`).
- Genuine parenthood is always written as a `parent-child` edge
  (`create.go`, `update.go`), so no real children are dropped.
- Non-hierarchical edges stay off the tree but remain fully visible via
  `bd show`, `bd dep tree`, and the compact list view (`blocked by:` /
  `blocks:`).
- The prior `relates-to` special-case (#3936) is naturally subsumed by the
  single parent-child guard, and its regression test still passes.

## Tests

Adds `TestListBuildIssueTree_NonParentChildDepOnEpicDoesNotNest`, a
table-driven regression over `blocks`, `waits-for`, `conditional-blocks`,
`discovered-from`, and `related` edges on an epic — each must leave the
source as a root rather than nesting it. The test fails on the previous
behaviour and passes with this change. All existing tree/list/epic tests
pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
