### PR TITLE
fix(is_blocked): de-alias UPDATE targets so the recompute runs on SQLite/DoltLite

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/dolthub/driver/v2 v2.1.10
 	github.com/dolthub/eventkit v0.0.0-20260611184414-99f5693e696a
 	github.com/go-sql-driver/mysql v1.10.0
+	github.com/mattn/go-sqlite3 v1.14.8
 	github.com/olebedev/when v1.1.0
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/viper v1.21.0

--- a/internal/storage/dolt/blocked_state_dolt_test.go
+++ b/internal/storage/dolt/blocked_state_dolt_test.go
@@ -1,0 +1,53 @@
+package dolt
+
+import (
+	"context"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/storage/issueops"
+)
+
+// TestRecomputeIsBlockedInTx_DoltDialect is the go-mysql-server / Dolt
+// (MySQL-dialect) companion to TestRecomputeIsBlockedInTx_SQLiteGrammar in
+// internal/storage/issueops. The is_blocked recompute templates are shared by
+// both the embedded (SQLite/DoltLite) and server/proxied (MySQL/gms) backends
+// (see the DBTX doc comment in blocked_state.go), so de-aliasing the UPDATE
+// targets to fix the SQLite grammar must not regress the MySQL path — in
+// particular it must not re-trigger MySQL ERROR 1093 on the same-table EXISTS
+// subqueries. This drives the de-aliased mark and unmark templates against the
+// real Dolt engine.
+func TestRecomputeIsBlockedInTx_DoltDialect(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	// mark: bm-w blocked on open bm-x, established through the normal write
+	// path (AddDependency), which runs the shared mark template on Dolt.
+	seedBlockedPair(ctx, t, store, true)
+	if !isBlocked(ctx, t, store.db, "bm-w") {
+		t.Fatalf("bm-w should be blocked by open bm-x (mark template on Dolt)")
+	}
+	if isBlocked(ctx, t, store.db, "bm-x") {
+		t.Fatalf("bm-x blocks others but is not itself blocked")
+	}
+
+	// unmark: close the blocker, then drive the shared recompute directly so
+	// the de-aliased unmark template runs against Dolt and clears the flag.
+	if _, err := store.db.ExecContext(ctx, "UPDATE issues SET status = 'closed' WHERE id = ?", "bm-x"); err != nil {
+		t.Fatalf("close blocker: %v", err)
+	}
+	tx, err := store.db.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatalf("begin recompute tx: %v", err)
+	}
+	if err := issueops.RecomputeIsBlockedInTx(ctx, tx, []string{"bm-w", "bm-x"}, nil); err != nil {
+		_ = tx.Rollback()
+		t.Fatalf("RecomputeIsBlockedInTx on Dolt (regression: de-alias must not break MySQL): %v", err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("commit recompute tx: %v", err)
+	}
+	if isBlocked(ctx, t, store.db, "bm-w") {
+		t.Errorf("bm-w should be unblocked after bm-x closed (unmark template on Dolt)")
+	}
+}

--- a/internal/storage/issueops/blocked_state.go
+++ b/internal/storage/issueops/blocked_state.go
@@ -140,42 +140,42 @@ func markIsBlockedPassForIssuesInTx(ctx context.Context, tx DBTX, ids []string) 
 // An explicit assignment suppresses the ON UPDATE clause.
 func markBlockedTemplateForIssues() string {
 	return fmt.Sprintf(`
-		UPDATE issues i SET i.is_blocked = 1, i.updated_at = i.updated_at
-		WHERE i.id IN (%%s)
-		  AND i.is_blocked = 0
-		  AND i.status <> 'closed' AND i.status <> 'pinned'
+		UPDATE issues SET is_blocked = 1, updated_at = updated_at
+		WHERE issues.id IN (%%s)
+		  AND issues.is_blocked = 0
+		  AND issues.status <> 'closed' AND issues.status <> 'pinned'
 		  AND (
 		    EXISTS (
 		      SELECT 1 FROM dependencies d
 		      JOIN issues t ON t.id = d.depends_on_issue_id
-		      WHERE d.issue_id = i.id
+		      WHERE d.issue_id = issues.id
 		        AND (d.type = 'blocks' OR d.type = 'conditional-blocks')
 		        AND t.status <> 'closed' AND t.status <> 'pinned'
 		    )
 		    OR EXISTS (
 		      SELECT 1 FROM dependencies d
 		      JOIN wisps t ON t.id = d.depends_on_wisp_id
-		      WHERE d.issue_id = i.id
+		      WHERE d.issue_id = issues.id
 		        AND (d.type = 'blocks' OR d.type = 'conditional-blocks')
 		        AND t.status <> 'closed' AND t.status <> 'pinned'
 		    )
 		    OR EXISTS (
 		      SELECT 1 FROM dependencies d
 		      JOIN issues p ON p.id = d.depends_on_issue_id
-		      WHERE d.issue_id = i.id
+		      WHERE d.issue_id = issues.id
 		        AND d.type = 'parent-child'
 		        AND p.is_blocked = 1
 		    )
 		    OR EXISTS (
 		      SELECT 1 FROM dependencies d
 		      JOIN wisps p ON p.id = d.depends_on_wisp_id
-		      WHERE d.issue_id = i.id
+		      WHERE d.issue_id = issues.id
 		        AND d.type = 'parent-child'
 		        AND p.is_blocked = 1
 		    )
 		    OR EXISTS (
 		      SELECT 1 FROM dependencies d
-		      WHERE d.issue_id = i.id AND d.type = 'waits-for'
+		      WHERE d.issue_id = issues.id AND d.type = 'waits-for'
 		        AND (%s)
 		    )
 		  )
@@ -184,43 +184,43 @@ func markBlockedTemplateForIssues() string {
 
 func unmarkBlockedTemplateForIssues() string {
 	return fmt.Sprintf(`
-		UPDATE issues i SET i.is_blocked = 0, i.updated_at = i.updated_at
-		WHERE i.id IN (%%s)
-		  AND i.is_blocked = 1
+		UPDATE issues SET is_blocked = 0, updated_at = updated_at
+		WHERE issues.id IN (%%s)
+		  AND issues.is_blocked = 1
 		  AND (
-		    i.status = 'closed' OR i.status = 'pinned'
+		    issues.status = 'closed' OR issues.status = 'pinned'
 		    OR (
 		      NOT EXISTS (
 		        SELECT 1 FROM dependencies d
 		        JOIN issues t ON t.id = d.depends_on_issue_id
-		        WHERE d.issue_id = i.id
+		        WHERE d.issue_id = issues.id
 		          AND (d.type = 'blocks' OR d.type = 'conditional-blocks')
 		          AND t.status <> 'closed' AND t.status <> 'pinned'
 		      )
 		      AND NOT EXISTS (
 		        SELECT 1 FROM dependencies d
 		        JOIN wisps t ON t.id = d.depends_on_wisp_id
-		        WHERE d.issue_id = i.id
+		        WHERE d.issue_id = issues.id
 		          AND (d.type = 'blocks' OR d.type = 'conditional-blocks')
 		          AND t.status <> 'closed' AND t.status <> 'pinned'
 		      )
 		      AND NOT EXISTS (
 		        SELECT 1 FROM dependencies d
 		        JOIN issues p ON p.id = d.depends_on_issue_id
-		        WHERE d.issue_id = i.id
+		        WHERE d.issue_id = issues.id
 		          AND d.type = 'parent-child'
 		          AND p.is_blocked = 1
 		      )
 		      AND NOT EXISTS (
 		        SELECT 1 FROM dependencies d
 		        JOIN wisps p ON p.id = d.depends_on_wisp_id
-		        WHERE d.issue_id = i.id
+		        WHERE d.issue_id = issues.id
 		          AND d.type = 'parent-child'
 		          AND p.is_blocked = 1
 		      )
 		      AND NOT EXISTS (
 		        SELECT 1 FROM dependencies d
-		        WHERE d.issue_id = i.id AND d.type = 'waits-for'
+		        WHERE d.issue_id = issues.id AND d.type = 'waits-for'
 		          AND (%s)
 		      )
 		    )
@@ -246,42 +246,42 @@ func markIsBlockedPassForWispsInTx(ctx context.Context, tx DBTX, ids []string) (
 
 func markBlockedTemplateForWisps() string {
 	return fmt.Sprintf(`
-		UPDATE wisps w SET w.is_blocked = 1, w.updated_at = w.updated_at
-		WHERE w.id IN (%%s)
-		  AND w.is_blocked = 0
-		  AND w.status <> 'closed' AND w.status <> 'pinned'
+		UPDATE wisps SET is_blocked = 1, updated_at = updated_at
+		WHERE wisps.id IN (%%s)
+		  AND wisps.is_blocked = 0
+		  AND wisps.status <> 'closed' AND wisps.status <> 'pinned'
 		  AND (
 		    EXISTS (
 		      SELECT 1 FROM wisp_dependencies d
 		      JOIN issues t ON t.id = d.depends_on_issue_id
-		      WHERE d.issue_id = w.id
+		      WHERE d.issue_id = wisps.id
 		        AND (d.type = 'blocks' OR d.type = 'conditional-blocks')
 		        AND t.status <> 'closed' AND t.status <> 'pinned'
 		    )
 		    OR EXISTS (
 		      SELECT 1 FROM wisp_dependencies d
 		      JOIN wisps t ON t.id = d.depends_on_wisp_id
-		      WHERE d.issue_id = w.id
+		      WHERE d.issue_id = wisps.id
 		        AND (d.type = 'blocks' OR d.type = 'conditional-blocks')
 		        AND t.status <> 'closed' AND t.status <> 'pinned'
 		    )
 		    OR EXISTS (
 		      SELECT 1 FROM wisp_dependencies d
 		      JOIN issues p ON p.id = d.depends_on_issue_id
-		      WHERE d.issue_id = w.id
+		      WHERE d.issue_id = wisps.id
 		        AND d.type = 'parent-child'
 		        AND p.is_blocked = 1
 		    )
 		    OR EXISTS (
 		      SELECT 1 FROM wisp_dependencies d
 		      JOIN wisps p ON p.id = d.depends_on_wisp_id
-		      WHERE d.issue_id = w.id
+		      WHERE d.issue_id = wisps.id
 		        AND d.type = 'parent-child'
 		        AND p.is_blocked = 1
 		    )
 		    OR EXISTS (
 		      SELECT 1 FROM wisp_dependencies d
-		      WHERE d.issue_id = w.id AND d.type = 'waits-for'
+		      WHERE d.issue_id = wisps.id AND d.type = 'waits-for'
 		        AND (%s)
 		    )
 		  )
@@ -290,43 +290,43 @@ func markBlockedTemplateForWisps() string {
 
 func unmarkBlockedTemplateForWisps() string {
 	return fmt.Sprintf(`
-		UPDATE wisps w SET w.is_blocked = 0, w.updated_at = w.updated_at
-		WHERE w.id IN (%%s)
-		  AND w.is_blocked = 1
+		UPDATE wisps SET is_blocked = 0, updated_at = updated_at
+		WHERE wisps.id IN (%%s)
+		  AND wisps.is_blocked = 1
 		  AND (
-		    w.status = 'closed' OR w.status = 'pinned'
+		    wisps.status = 'closed' OR wisps.status = 'pinned'
 		    OR (
 		      NOT EXISTS (
 		        SELECT 1 FROM wisp_dependencies d
 		        JOIN issues t ON t.id = d.depends_on_issue_id
-		        WHERE d.issue_id = w.id
+		        WHERE d.issue_id = wisps.id
 		          AND (d.type = 'blocks' OR d.type = 'conditional-blocks')
 		          AND t.status <> 'closed' AND t.status <> 'pinned'
 		      )
 		      AND NOT EXISTS (
 		        SELECT 1 FROM wisp_dependencies d
 		        JOIN wisps t ON t.id = d.depends_on_wisp_id
-		        WHERE d.issue_id = w.id
+		        WHERE d.issue_id = wisps.id
 		          AND (d.type = 'blocks' OR d.type = 'conditional-blocks')
 		          AND t.status <> 'closed' AND t.status <> 'pinned'
 		      )
 		      AND NOT EXISTS (
 		        SELECT 1 FROM wisp_dependencies d
 		        JOIN issues p ON p.id = d.depends_on_issue_id
-		        WHERE d.issue_id = w.id
+		        WHERE d.issue_id = wisps.id
 		          AND d.type = 'parent-child'
 		          AND p.is_blocked = 1
 		      )
 		      AND NOT EXISTS (
 		        SELECT 1 FROM wisp_dependencies d
 		        JOIN wisps p ON p.id = d.depends_on_wisp_id
-		        WHERE d.issue_id = w.id
+		        WHERE d.issue_id = wisps.id
 		          AND d.type = 'parent-child'
 		          AND p.is_blocked = 1
 		      )
 		      AND NOT EXISTS (
 		        SELECT 1 FROM wisp_dependencies d
-		        WHERE d.issue_id = w.id AND d.type = 'waits-for'
+		        WHERE d.issue_id = wisps.id AND d.type = 'waits-for'
 		          AND (%s)
 		      )
 		    )

--- a/internal/storage/issueops/blocked_state_sqlite_test.go
+++ b/internal/storage/issueops/blocked_state_sqlite_test.go
@@ -1,0 +1,152 @@
+//go:build cgo
+
+package issueops
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	sqlite3 "github.com/mattn/go-sqlite3"
+)
+
+// The DoltLite backend runs beads SQL through SQLite's grammar while providing
+// a MySQL-compatible scalar-function library (JSON_UNQUOTE, ...). A stock
+// SQLite engine reproduces that grammar exactly, so it is a faithful proxy for
+// the DoltLite parse path; we only have to register the MySQL-only functions
+// the recompute templates reference so the full statement can prepare. The bug
+// under test — a target-table alias in UPDATE (UPDATE issues i SET i.col = ...),
+// which SQLite rejects with `near "i": syntax error` — is a grammar-level
+// defect and is unaffected by these function registrations.
+func init() {
+	sql.Register("sqlite3_beads_blockedstate", &sqlite3.SQLiteDriver{
+		ConnectHook: func(conn *sqlite3.SQLiteConn) error {
+			// The waits-for gate fragment calls JSON_EXTRACT/JSON_UNQUOTE, which
+			// DoltLite provides but a stock mattn SQLite build does not. They only
+			// have to *register* so the full statement can prepare; the recompute
+			// never evaluates them here (no waits-for gate rows are seeded), so
+			// trivial stand-ins are sufficient and faithful to the grammar bug.
+			if err := conn.RegisterFunc("json_extract", func(doc, path string) string { return doc }, true); err != nil {
+				return err
+			}
+			return conn.RegisterFunc("json_unquote", func(s string) string { return s }, true)
+		},
+	})
+}
+
+func openBlockedStateSQLite(t *testing.T) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("sqlite3_beads_blockedstate", ":memory:")
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	// mattn :memory: databases are per-connection; pin to a single connection
+	// so DDL, seed, the recompute tx, and the assertions all see one store.
+	db.SetMaxOpenConns(1)
+
+	for _, ddl := range []string{
+		`CREATE TABLE issues (id TEXT PRIMARY KEY, is_blocked INTEGER NOT NULL DEFAULT 0, updated_at TEXT, status TEXT NOT NULL)`,
+		`CREATE TABLE wisps  (id TEXT PRIMARY KEY, is_blocked INTEGER NOT NULL DEFAULT 0, updated_at TEXT, status TEXT NOT NULL)`,
+		`CREATE TABLE dependencies      (issue_id TEXT, depends_on_issue_id TEXT, depends_on_wisp_id TEXT, type TEXT, metadata TEXT)`,
+		`CREATE TABLE wisp_dependencies (issue_id TEXT, depends_on_issue_id TEXT, depends_on_wisp_id TEXT, type TEXT, metadata TEXT)`,
+	} {
+		if _, err := db.Exec(ddl); err != nil {
+			t.Fatalf("schema %q: %v", ddl, err)
+		}
+	}
+	return db
+}
+
+// TestRecomputeIsBlockedInTx_SQLiteGrammar is a regression test for the
+// DoltLite `recompute is_blocked (mark): near "i": syntax error` failure: the
+// mark/unmark templates emitted a MySQL-style target-table alias
+// (`UPDATE issues i SET i.is_blocked = ...`) that SQLite's grammar rejects.
+// It exercises all four templates (issue mark+unmark, wisp mark+unmark) against
+// a real SQLite engine — the first real-engine coverage of the recompute, which
+// the go-sqlmock-only suite could never catch.
+func TestRecomputeIsBlockedInTx_SQLiteGrammar(t *testing.T) {
+	db := openBlockedStateSQLite(t)
+	ctx := context.Background()
+
+	for _, seed := range []string{
+		// blocked-i is blocked by an open blocker -> mark should set is_blocked=1.
+		`INSERT INTO issues (id,is_blocked,updated_at,status) VALUES ('blocked-i',0,'t','open'),('blocker-i',0,'t','open')`,
+		`INSERT INTO dependencies (issue_id,depends_on_issue_id,type) VALUES ('blocked-i','blocker-i','blocks')`,
+		// a wisp blocked by the same open issue -> exercises the wisp templates.
+		`INSERT INTO wisps (id,is_blocked,updated_at,status) VALUES ('blocked-w',0,'t','open')`,
+		`INSERT INTO wisp_dependencies (issue_id,depends_on_issue_id,type) VALUES ('blocked-w','blocker-i','blocks')`,
+	} {
+		if _, err := db.Exec(seed); err != nil {
+			t.Fatalf("seed %q: %v", seed, err)
+		}
+	}
+
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatalf("begin: %v", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	// Pre-fix, the very first template execution fails with
+	// `recompute is_blocked (mark): near "i": syntax error`.
+	if err := RecomputeIsBlockedInTx(ctx, tx, []string{"blocked-i", "blocker-i"}, []string{"blocked-w"}); err != nil {
+		t.Fatalf("RecomputeIsBlockedInTx (regression: DoltLite parse error): %v", err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+
+	assertBlocked := func(table, id string, want int) {
+		t.Helper()
+		var got int
+		if err := db.QueryRow("SELECT is_blocked FROM "+table+" WHERE id = ?", id).Scan(&got); err != nil {
+			t.Fatalf("query %s.%s: %v", table, id, err)
+		}
+		if got != want {
+			t.Errorf("%s %s: is_blocked = %d, want %d", table, id, got, want)
+		}
+	}
+	assertBlocked("issues", "blocked-i", 1) // blocked by an open blocker
+	assertBlocked("issues", "blocker-i", 0) // blocks others but is not itself blocked
+	assertBlocked("wisps", "blocked-w", 1)  // blocked by the same open blocker
+}
+
+// TestRecomputeIsBlockedInTx_SQLiteUnmark covers the unmark path: a bead flagged
+// is_blocked whose blocker has since closed must be cleared. This drives the
+// unmark templates (also target-table aliased) to a real SQLite engine.
+func TestRecomputeIsBlockedInTx_SQLiteUnmark(t *testing.T) {
+	db := openBlockedStateSQLite(t)
+	ctx := context.Background()
+
+	for _, seed := range []string{
+		// was-blocked is flagged, but its only blocker is already closed.
+		`INSERT INTO issues (id,is_blocked,updated_at,status) VALUES ('was-blocked',1,'t','open'),('done-blocker',0,'t','closed')`,
+		`INSERT INTO dependencies (issue_id,depends_on_issue_id,type) VALUES ('was-blocked','done-blocker','blocks')`,
+	} {
+		if _, err := db.Exec(seed); err != nil {
+			t.Fatalf("seed %q: %v", seed, err)
+		}
+	}
+
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatalf("begin: %v", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	if err := RecomputeIsBlockedInTx(ctx, tx, []string{"was-blocked"}, nil); err != nil {
+		t.Fatalf("RecomputeIsBlockedInTx (unmark): %v", err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+
+	var got int
+	if err := db.QueryRow("SELECT is_blocked FROM issues WHERE id = 'was-blocked'").Scan(&got); err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if got != 0 {
+		t.Errorf("was-blocked: is_blocked = %d, want 0 (blocker is closed)", got)
+	}
+}


### PR DESCRIPTION
## Summary

The `is_blocked` mark/unmark recompute in `internal/storage/issueops/blocked_state.go` emits MySQL-style **target-table-aliased** `UPDATE`s:

```sql
UPDATE issues i SET i.is_blocked = ... WHERE i.id IN (...) ...
UPDATE wisps  w SET w.is_blocked = ... WHERE w.id IN (...) ...
```

SQLite's grammar does not permit aliasing the `UPDATE` **target** table, so on the SQLite-backed DoltLite backend every recompute fails to parse:

```
recompute is_blocked (mark): near "i": syntax error
```

Because it is a *parse* error, it fires on **every** execution regardless of data — on any active⇄closed transition that recomputes `is_blocked` (`bd update --status closed`, `bd reopen`, `bd remove-dependency`, ...). `bd close` takes a different recompute path and succeeds, which makes the failure look intermittent when it is actually deterministic per command path.

The `DBTX` abstraction deliberately shares these templates between the embedded (`*sql.Tx`, SQLite/DoltLite) path and the server/proxied (MySQL / go-mysql-server) path, so the fix must remain valid on **both** dialects.

## Fix

De-alias all **four** templates (issue + wisp, mark + unmark):

- SQLite forbids a table-qualified `SET` LHS, so the `SET` columns are left **bare** (`SET is_blocked = 1, updated_at = updated_at`). The `updated_at = updated_at` self-assignment that suppresses `ON UPDATE CURRENT_TIMESTAMP` is preserved.
- Outer references in the `WHERE` clause and the correlated `EXISTS` subqueries are qualified **by table name** (`issues.id` / `wisps.id`) instead of by alias.
- Every subquery `FROM` clause is unchanged, so the MySQL **ERROR 1093** posture is identical to before (the templates already select from the target table inside `EXISTS`; this change does not add any new such reference).
- The shared `waitsForGateBlockedSQL` fragment only references the subquery alias `d.` and is untouched.

## Testing

The existing `issueops` suite uses **go-sqlmock**, which never parses real SQL — which is why this defect shipped. This PR adds the first real-engine coverage of the recompute:

- **`internal/storage/issueops/blocked_state_sqlite_test.go`** drives `RecomputeIsBlockedInTx` against a real SQLite engine (the grammar DoltLite uses). It **fails before this change** with `recompute is_blocked (mark): near "i": syntax error`, and passes after, asserting correct `is_blocked` flags for both the mark path and the unmark path. (`JSON_UNQUOTE`/`JSON_EXTRACT`, which DoltLite provides on top of the SQLite grammar, are registered as trivial prepare-time stand-ins; the grammar bug under test is independent of them.)
- **`internal/storage/dolt/blocked_state_dolt_test.go`** is the MySQL/Dolt (go-mysql-server) companion, exercising the de-aliased mark and unmark templates on the real engine to guard against a regression on the shared server/proxied path (runs under the Dolt test server in CI).

Additionally verified end-to-end on a real DoltLite store: the aliased `UPDATE` reproduces `near "i": syntax error`; the de-aliased `UPDATE` succeeds and sets `is_blocked` correctly.

`gofmt` and `go vet` are clean; the full `issueops` package suite is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
