### PR TITLE
feat(ownership): claim_fence + guarded verbs + tier-complete requested leases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,115 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`claim_fence`: a monotonic claim fence on every claimable row**
+  ([#4697](https://github.com/gastownhall/beads/pull/4697)). A `BIGINT NOT NULL
+  DEFAULT 0` column on `issues` (migration 0062) and on `wisps` (ignored
+  migration 0019 — `wisps` is `dolt_ignored`, so fresh clones never execute the
+  synced track and the column has to ship on the ignored one, following the
+  `0013_add_wisp_row_lock` precedent). It advances only on ownership
+  transitions: claim; unclaim/release (including `--force` and the
+  `--if-assignee` CAS form); lease reclaim; an assignee change, through the
+  generic update path *or* an import/upsert that changes the stored owner; and
+  reopen (closed→open) through the reopen verb or the generic update path.
+  Content mutations never move it, and neither does close. One exception on the
+  import side is deliberate: the upsert bump keys on an assignee change alone,
+  so an import that flips a stored closed row back to open with the *same*
+  assignee does not bump, where the reopen verb does — import is convergence
+  toward a peer's snapshot, not an ownership verb performed here, and a routine
+  sync must not retire the `--if-fence` guards live workers hold on this
+  replica. Unlike the `RowVersion` token — random per write and deliberately
+  unreadable — the fence is deterministic and monotonic, so it rides
+  `bd show --json` and the JSONL interchange as `claim_fence` (with
+  `omitempty`, so a never-claimed issue exports byte-identically to before).
+  That readability is the whole point: a caller can snapshot the ownership
+  state it decided on and later prove that state is still current.
+
+  Two decisions here are not the obvious ones and are pinned by tests. The
+  claim compare-and-swap bumps **unconditionally** — a successful claim of an
+  open row *already assigned to the claiming actor* still advances the fence,
+  because two sessions of one user are two ownership holders and the arriving
+  session must be able to fence out whatever the earlier one snapshotted;
+  keying the bump on "did the assignee string change" would leave exactly that
+  case silently shared. (The idempotent same-actor re-claim of an already
+  `in_progress` row is a different path: `in_progress` is not a claimable
+  source status, so it never matches the CAS, writes nothing, and does not
+  bump.) And every statement that bumps the fence rewrites `row_lock` in the
+  same statement. A bare monotonic counter is precisely the write pattern Dolt
+  cell-merges silently — two concurrent N→N+1 bumps produce identical cell
+  values and therefore no conflict — so the paired random `row_lock` rewrite is
+  what forces racing ownership transitions to serialize into the 1213/1205
+  failure the retry loop replays. A source-scanning test
+  (`TestFenceBumpAlwaysPairsRowLock`) stops a later edit from dropping it.
+
+  `bd reclaim --json` reports the post-bump fence for each recovered issue
+  (`claim_fence` on every element of `reclaimed`), so a reaper's log names the
+  generation that fenced the dead worker out.
+
+- **`--if-fence`: the claim fence as a guard on `bd update`, `bd close` and
+  `bd unclaim`** ([#4697](https://github.com/gastownhall/beads/pull/4697)). The
+  fence becomes a guard by joining the surface bd already ships (`--if-assignee`
+  / `--if-status`, and the engine's `ExpectedVersion` row CAS) rather than
+  building a second one beside it: `ExpectedFence *int64` is a new field on
+  `UpdateIssueOptions` and `CloseIssueOptions`, `nil` meaning "no check" and a
+  pointer to `0` being the real "expected never claimed" assertion. There is no
+  parallel guard interface and no new exit code — a stale fence is
+  `storage.ErrFenceMismatch`, a sentinel sitting beside `ErrVersionMismatch` and
+  `ErrStatusMismatch`. Guards stay conjunctive: assignee, status, version and
+  fence are ANDed, every read shares the writing transaction, and a refusal
+  rolls that transaction back so nothing — not even the event row — is written.
+  What the fence adds over `--if-assignee` is that it survives the holder's own
+  content writes and still catches a release-and-re-claim by the *same*
+  assignee, which an assignee guard cannot see.
+
+  Exit codes follow the existing taxonomy rather than the fence's own
+  preferences: `bd update` and `bd close` exit **13** when every failed ID lost
+  on a stale guard and nothing was written, and 1 for anything mixed in (close
+  keeps its partial-success and already-closed exit-0 contracts intact).
+  `bd unclaim` deliberately does not adopt 13 — its shipped `--if-assignee`
+  contract is exit 1 for any failed release, and a fence miss is just another
+  failed release. A guard establishes **freshness, not authority**: on unclaim
+  the fence is an additional conjunct on both release forms and never a
+  substitute for either, so a stranger quoting the correct live fence still gets
+  `ErrNotOwner`, and `--force` — which waives the ownership check, not the
+  guard — never skips a supplied fence. In proxied-server mode `bd update`
+  threads the guard through to the re-read inside the unit of work's
+  transaction; `bd close` and `bd unclaim` have no compare-and-set on their
+  proxied paths at all, so `--if-fence` there is refused loudly rather than
+  silently dropped.
+
+  Library consumers get the guard through the existing `UpdateIssueChecked` /
+  `CloseIssueChecked` calls; out-of-tree `Storage` implementations that ignore
+  the new option field simply do not enforce it and should add support before
+  advertising fence semantics — the same caveat the `--if-assignee` guards
+  recorded. `UnclaimIssue` / `UnclaimIssueIfAssignee` did change signature; see
+  Changed.
+
+- **Opt out of automatic claim leases: `lease.auto` and `bd lease disarm`**
+  ([#4697](https://github.com/gastownhall/beads/pull/4697)). By default every
+  claim stamps a lease and a supervisor's `bd reclaim` recovers the work of
+  dead workers — the right default for a fleet with no other recovery
+  authority, and unchanged here. Deployments where an orchestrator already
+  holds its own liveness evidence can now turn stamping off, so a fleet that
+  does not heartbeat is never one stray `bd reclaim` away from mass-reverting
+  live work. `bd lease disarm` is the safe form of that flip: it sets the new
+  `lease.auto` config key to off and clears the lease rows of the claims
+  already holding one in a single transaction, then re-sweeps a bounded number
+  of times to catch claims whose transactions read `lease.auto` before the flip
+  committed (they touch disjoint rows, so nothing forces them to conflict).
+  Nothing is released — status, assignee and the claim fence (`claim_fence`)
+  are all untouched, because disarming is lease bookkeeping, not an ownership
+  transition. `bd config set lease.auto off` does the flip alone, without the
+  sweep.
+
+  With leases off, claims carry no lease row and are invisible to the reaper,
+  and `bd heartbeat` on such a claim returns the new `storage.ErrUnleased`
+  instead of arming one: heartbeat is strictly a renewal there, since arming a
+  lease as a side effect would silently re-create the very reclaim exposure the
+  disarm removes. A claim that still holds a lease row keeps renewing normally,
+  so disarming is a one-shot sweep rather than a standing rejection. Only an
+  explicitly falsy value (`off`, or anything `strconv.ParseBool` reads as false)
+  disarms; unset, `on`, and a typo all leave the shipped default armed.
+
 - **Replica-aware leases: `bd reclaim` no longer reverts a lease another
   replica granted** (wy-jpd3.7). A lease is only meaningful on the replica that
   granted it — the other machine's liveness view is stale by up to one sync
@@ -85,6 +194,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   one.
 
 ### Changed
+
+- **`beads.Storage.UnclaimIssue` / `UnclaimIssueIfAssignee` gained an
+  `expectedFence *int64` parameter, and `beads.BulkIssueStore` gained
+  `DisarmAutoLeases`** ([#4697](https://github.com/gastownhall/beads/pull/4697)).
+  Callers that release without a fence guard pass `nil` (unchanged behavior);
+  any external type that *implements* either interface must update the two
+  unclaim signatures and add `DisarmAutoLeases(ctx) (int64, error)` to compile.
+  Decorators that embed the interface for passthrough are unaffected.
 
 - **`beads.BulkIssueStore.ReclaimExpiredLeases` gained a `types.ReclaimFilter`
   parameter** (wy-jpd3.3), threaded through the domain use-case/repository

--- a/beads.go
+++ b/beads.go
@@ -378,6 +378,7 @@ var (
 	ErrNotClaimable    = storage.ErrNotClaimable
 	ErrCloseBlocked    = storage.ErrCloseBlocked
 	ErrVersionMismatch = storage.ErrVersionMismatch
+	ErrFenceMismatch   = storage.ErrFenceMismatch
 	ErrSelfDependency  = domain.ErrSelfDependency
 	ErrDependencyCycle = domain.ErrDependencyCycle
 	ErrFieldTooLong    = types.ErrFieldTooLong

--- a/cmd/bd/claim_fence_guard_embedded_test.go
+++ b/cmd/bd/claim_fence_guard_embedded_test.go
@@ -1,0 +1,424 @@
+//go:build cgo
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// fenceOf reads an issue's claim fence back through the same surface a caller
+// would use to construct --if-fence: bd show --json.
+func fenceOf(t *testing.T, bd, dir, id string) int64 {
+	t.Helper()
+	return bdShow(t, bd, dir, id).ClaimFence
+}
+
+// TestUpdateIfFenceCLI drives `bd update --if-fence` end-to-end against the
+// embedded backend. The fence guard joins the bd-wsqvw guard family, so a stale
+// fence writes nothing and exits ExitGuardMismatch; what it adds over
+// --if-assignee is that it survives the holder's own content writes and still
+// catches a release-and-re-claim by the SAME assignee.
+func TestUpdateIfFenceCLI(t *testing.T) {
+	if os.Getenv("BEADS_TEST_EMBEDDED_DOLT") != "1" {
+		t.Skip("set BEADS_TEST_EMBEDDED_DOLT=1 to run embedded dolt integration tests")
+	}
+	t.Parallel()
+
+	bd := buildEmbeddedBD(t)
+	dir, _, _ := bdInit(t, bd, "--prefix", "uif")
+
+	t.Run("live_fence_applies_stale_fence_exits_13", func(t *testing.T) {
+		issue := bdCreate(t, bd, dir, "Fence guard", "--type", "task")
+		bdUpdate(t, bd, dir, issue.ID, "--assignee", "alice", "--status", "in_progress")
+		fence := fenceOf(t, bd, dir, issue.ID)
+		if fence == 0 {
+			t.Fatalf("claim_fence = 0 after an assignee change; --if-fence has nothing to guard on")
+		}
+
+		// The live fence: the update applies.
+		bdUpdate(t, bd, dir, issue.ID, "--if-fence", fmt.Sprint(fence), "--notes", "still mine")
+		if got := bdShow(t, bd, dir, issue.ID).Notes; got != "still mine" {
+			t.Errorf("notes = %q after a matching --if-fence, want %q", got, "still mine")
+		}
+
+		// A content write does not move the fence, so the same guard still holds.
+		if got := fenceOf(t, bd, dir, issue.ID); got != fence {
+			t.Errorf("claim_fence = %d after a content write, want unchanged %d", got, fence)
+		}
+
+		// Ownership moves and comes back to the SAME assignee: --if-assignee
+		// would still pass here, --if-fence must not.
+		bdUnclaim(t, bd, dir, issue.ID, "--actor", "alice")
+		bdUpdate(t, bd, dir, issue.ID, "--assignee", "alice", "--status", "in_progress")
+
+		out, code := bdUpdateFailCode(t, bd, dir, issue.ID,
+			"--if-fence", fmt.Sprint(fence), "--notes", "should-not-apply")
+		if code != ExitGuardMismatch {
+			t.Errorf("stale fence exit code = %d, want %d\n%s", code, ExitGuardMismatch, out)
+		}
+		if !strings.Contains(out, "fence") {
+			t.Errorf("mismatch error should name the fence, got:\n%s", out)
+		}
+		if got := bdShow(t, bd, dir, issue.ID).Notes; got != "still mine" {
+			t.Errorf("stale --if-fence wrote through: notes = %q, want unchanged", got)
+		}
+	})
+
+	t.Run("fence_zero_is_a_real_assertion", func(t *testing.T) {
+		issue := bdCreate(t, bd, dir, "Never claimed", "--type", "task")
+		bdUpdate(t, bd, dir, issue.ID, "--if-fence", "0", "--notes", "pristine")
+		if got := bdShow(t, bd, dir, issue.ID).Notes; got != "pristine" {
+			t.Errorf("notes = %q after --if-fence 0 on a never-claimed bead, want %q", got, "pristine")
+		}
+
+		bdUpdate(t, bd, dir, issue.ID, "--assignee", "alice", "--status", "in_progress")
+		out, code := bdUpdateFailCode(t, bd, dir, issue.ID, "--if-fence", "0", "--notes", "should-not-apply")
+		if code != ExitGuardMismatch {
+			t.Errorf("--if-fence 0 on a claimed bead: exit code = %d, want %d\n%s", code, ExitGuardMismatch, out)
+		}
+	})
+
+	t.Run("mixed_batch_failure_exits_1_not_13", func(t *testing.T) {
+		issue := bdCreate(t, bd, dir, "Mixed fence batch", "--type", "task")
+		bdUpdate(t, bd, dir, issue.ID, "--assignee", "alice", "--status", "in_progress")
+
+		out, code := bdUpdateFailCode(t, bd, dir, issue.ID, "uif-nope99",
+			"--if-fence", "99", "--priority", "1")
+		if code != 1 {
+			t.Errorf("mixed fence+lookup failure exit code = %d, want 1\n%s", code, out)
+		}
+	})
+}
+
+// TestUpdateIfFenceFlagValidation pins the CLI-surface rules --if-fence shares
+// with the rest of the guard family: no --claim (the claim CAS bumps the very
+// fence a pre-claim guard would name), no --force, and a field update to ride
+// on. Every rejection must exit 1 — 13 is reserved for real mismatches — and
+// write nothing.
+func TestUpdateIfFenceFlagValidation(t *testing.T) {
+	if os.Getenv("BEADS_TEST_EMBEDDED_DOLT") != "1" {
+		t.Skip("set BEADS_TEST_EMBEDDED_DOLT=1 to run embedded dolt integration tests")
+	}
+	t.Parallel()
+
+	bd := buildEmbeddedBD(t)
+	dir, _, _ := bdInit(t, bd, "--prefix", "ufv")
+
+	issue := bdCreate(t, bd, dir, "Fence flag validation", "--type", "task")
+
+	t.Run("claim_and_if_fence_mutually_exclusive", func(t *testing.T) {
+		out, code := bdUpdateFailCode(t, bd, dir, issue.ID, "--if-fence", "0", "--claim")
+		if code != 1 {
+			t.Errorf("flag-validation exit code = %d, want 1\n%s", code, out)
+		}
+		if !strings.Contains(out, "--claim") {
+			t.Errorf("expected the --claim exclusion in the error, got:\n%s", out)
+		}
+		if got := bdShow(t, bd, dir, issue.ID); got.Assignee != "" {
+			t.Errorf("rejected flag combo still claimed the issue: assignee = %q", got.Assignee)
+		}
+	})
+
+	t.Run("force_and_if_fence_mutually_exclusive", func(t *testing.T) {
+		out, code := bdUpdateFailCode(t, bd, dir, issue.ID, "--if-fence", "0", "--force", "--assignee", "bob")
+		if code != 1 {
+			t.Errorf("flag-validation exit code = %d, want 1\n%s", code, out)
+		}
+		if !strings.Contains(out, "force") || !strings.Contains(out, "if-fence") {
+			t.Errorf("--force with --if-fence should be rejected as mutually exclusive, got:\n%s", out)
+		}
+	})
+
+	t.Run("if_fence_requires_a_field_update", func(t *testing.T) {
+		out, code := bdUpdateFailCode(t, bd, dir, issue.ID, "--if-fence", "0", "--add-label", "x")
+		if code != 1 {
+			t.Errorf("flag-validation exit code = %d, want 1 (%d is reserved for real mismatches)\n%s", code, ExitGuardMismatch, out)
+		}
+		if !strings.Contains(out, "field update") {
+			t.Errorf("expected the field-update requirement in the error, got:\n%s", out)
+		}
+	})
+
+	t.Run("negative_if_fence_is_a_usage_error", func(t *testing.T) {
+		// The fence starts at 0 and only increments, so a negative value can
+		// never match. It is rejected as bad input (exit 1) rather than reported
+		// as a lost race (exit 13), and in both spellings a caller might type.
+		for _, args := range [][]string{
+			{"--if-fence=-1", "--notes", "should-not-apply"},
+			{"--if-fence", "-5", "--notes", "should-not-apply"},
+		} {
+			out, code := bdUpdateFailCode(t, bd, dir, append([]string{issue.ID}, args...)...)
+			if code != 1 {
+				t.Errorf("%v: exit code = %d, want 1 (%d is reserved for real mismatches)\n%s", args, code, ExitGuardMismatch, out)
+			}
+			if !strings.Contains(out, "--if-fence must be >= 0") {
+				t.Errorf("%v: expected the negative-fence rejection, got:\n%s", args, out)
+			}
+		}
+		if got := bdShow(t, bd, dir, issue.ID).Notes; got == "should-not-apply" {
+			t.Error("a rejected --if-fence still wrote the update")
+		}
+	})
+}
+
+// TestCloseIfFenceCLI drives `bd close --if-fence`: the guard that stops a
+// worker whose claim was retired from completing a bead it no longer owns.
+// Close keeps its shipped contracts — partial success and an already-closed
+// no-op both stay exit 0 — and adds exit 13 for the all-stale-guard case.
+func TestCloseIfFenceCLI(t *testing.T) {
+	if os.Getenv("BEADS_TEST_EMBEDDED_DOLT") != "1" {
+		t.Skip("set BEADS_TEST_EMBEDDED_DOLT=1 to run embedded dolt integration tests")
+	}
+	t.Parallel()
+
+	bd := buildEmbeddedBD(t)
+	dir, _, _ := bdInit(t, bd, "--prefix", "cif")
+
+	t.Run("stale_fence_refuses_with_13_live_fence_closes", func(t *testing.T) {
+		issue := bdCreate(t, bd, dir, "Zombie close", "--type", "task")
+		bdUpdate(t, bd, dir, issue.ID, "--assignee", "alice", "--status", "in_progress")
+		stale := fenceOf(t, bd, dir, issue.ID)
+
+		// The claim is retired and re-taken; the zombie still holds `stale`.
+		bdUnclaim(t, bd, dir, issue.ID, "--actor", "alice")
+		bdUpdate(t, bd, dir, issue.ID, "--assignee", "alice", "--status", "in_progress")
+
+		// Run as the holder: bd close refuses another actor's live claim before
+		// any guard runs (that refusal is a policy exit 1, not a guard verdict).
+		out, code := bdRunFailCode(t, bd, dir, "close", issue.ID, "--actor", "alice", "--if-fence", fmt.Sprint(stale))
+		if code != ExitGuardMismatch {
+			t.Errorf("stale-fence close exit code = %d, want %d\n%s", code, ExitGuardMismatch, out)
+		}
+		if got := bdShow(t, bd, dir, issue.ID).Status; got == types.StatusClosed {
+			t.Errorf("zombie close landed: status = %q", got)
+		}
+
+		// Re-observe and close for real.
+		live := fenceOf(t, bd, dir, issue.ID)
+		bdClose(t, bd, dir, issue.ID, "--actor", "alice", "--if-fence", fmt.Sprint(live))
+		if got := bdShow(t, bd, dir, issue.ID).Status; got != types.StatusClosed {
+			t.Errorf("status = %q after a matching --if-fence close, want closed", got)
+		}
+
+		// Close is not an ownership transition, so the same fence still holds
+		// and the idempotent re-close stays exit 0.
+		bdClose(t, bd, dir, issue.ID, "--actor", "alice", "--if-fence", fmt.Sprint(live))
+
+		// A stale fence on an already-closed bead is still a refusal: the guard
+		// is evaluated against the row, not waived by idempotency.
+		out, code = bdRunFailCode(t, bd, dir, "close", issue.ID, "--actor", "alice", "--if-fence", fmt.Sprint(live+1))
+		if code != ExitGuardMismatch {
+			t.Errorf("stale-fence re-close exit code = %d, want %d\n%s", code, ExitGuardMismatch, out)
+		}
+	})
+
+	t.Run("force_does_not_waive_the_fence", func(t *testing.T) {
+		issue := bdCreate(t, bd, dir, "Force plus fence", "--type", "task")
+		bdUpdate(t, bd, dir, issue.ID, "--assignee", "alice", "--status", "in_progress")
+		fence := fenceOf(t, bd, dir, issue.ID)
+
+		out, code := bdRunFailCode(t, bd, dir, "close", issue.ID, "--force", "--if-fence", fmt.Sprint(fence+1))
+		if code != ExitGuardMismatch {
+			t.Errorf("--force with a stale fence: exit code = %d, want %d\n%s", code, ExitGuardMismatch, out)
+		}
+		if got := bdShow(t, bd, dir, issue.ID).Status; got == types.StatusClosed {
+			t.Errorf("--force bypassed the fence guard: status = %q", got)
+		}
+		// --force with a live fence is allowed: force waives only the is_blocked
+		// and gate refusals.
+		bdClose(t, bd, dir, issue.ID, "--force", "--if-fence", fmt.Sprint(fence))
+		if got := bdShow(t, bd, dir, issue.ID).Status; got != types.StatusClosed {
+			t.Errorf("status = %q after --force --if-fence with the live fence, want closed", got)
+		}
+	})
+
+	t.Run("partial_success_still_exits_0", func(t *testing.T) {
+		// Shipped contract: a multi-ID close that settles at least one issue
+		// exits 0 even when another ID failed. The fence taxonomy only fires
+		// when NOTHING settled.
+		open := bdCreate(t, bd, dir, "Unclaimed target", "--type", "task")
+		claimed := bdCreate(t, bd, dir, "Claimed target", "--type", "task")
+		bdUpdate(t, bd, dir, claimed.ID, "--assignee", "alice", "--status", "in_progress")
+
+		bdClose(t, bd, dir, open.ID, claimed.ID, "--actor", "alice", "--if-fence", "0")
+		if got := bdShow(t, bd, dir, open.ID).Status; got != types.StatusClosed {
+			t.Errorf("never-claimed target status = %q, want closed (its fence is 0)", got)
+		}
+		if got := bdShow(t, bd, dir, claimed.ID).Status; got == types.StatusClosed {
+			t.Errorf("claimed target closed despite a fence-0 guard: status = %q", got)
+		}
+	})
+
+	t.Run("all_stale_fences_exit_13_mixed_batch_exits_1", func(t *testing.T) {
+		// The taxonomy switch is "nothing settled AND every attempted ID lost on
+		// a guard". Two batches, both settling nothing, differing only in whether
+		// a non-guard failure is mixed in.
+		mine := bdCreate(t, bd, dir, "Stale fence A", "--type", "task")
+		alsoMine := bdCreate(t, bd, dir, "Stale fence B", "--type", "task")
+		theirs := bdCreate(t, bd, dir, "Held by bob", "--type", "task")
+		for _, id := range []string{mine.ID, alsoMine.ID} {
+			bdUpdate(t, bd, dir, id, "--assignee", "alice", "--status", "in_progress")
+		}
+		bdUpdate(t, bd, dir, theirs.ID, "--assignee", "bob", "--status", "in_progress")
+
+		// Every failure is a stale fence: 13.
+		out, code := bdRunFailCode(t, bd, dir, "close", mine.ID, alsoMine.ID,
+			"--actor", "alice", "--if-fence", "9999")
+		if code != ExitGuardMismatch {
+			t.Errorf("all-stale-fence batch exit code = %d, want %d\n%s", code, ExitGuardMismatch, out)
+		}
+
+		// One stale fence plus one ownership refusal (a policy failure, not a
+		// guard verdict): 1, because retrying the batch is NOT pointless.
+		out, code = bdRunFailCode(t, bd, dir, "close", mine.ID, theirs.ID,
+			"--actor", "alice", "--if-fence", "9999")
+		if code != 1 {
+			t.Errorf("mixed fence+ownership batch exit code = %d, want 1\n%s", code, out)
+		}
+		for _, id := range []string{mine.ID, alsoMine.ID, theirs.ID} {
+			if got := bdShow(t, bd, dir, id).Status; got == types.StatusClosed {
+				t.Errorf("%s closed despite a refused batch: status = %q", id, got)
+			}
+		}
+	})
+
+	t.Run("negative_if_fence_is_a_usage_error", func(t *testing.T) {
+		issue := bdCreate(t, bd, dir, "Negative close fence", "--type", "task")
+		out, code := bdRunFailCode(t, bd, dir, "close", issue.ID, "--if-fence=-1")
+		if code != 1 {
+			t.Errorf("negative --if-fence exit code = %d, want 1 (%d is reserved for real mismatches)\n%s", code, ExitGuardMismatch, out)
+		}
+		if !strings.Contains(out, "--if-fence must be >= 0") {
+			t.Errorf("expected the negative-fence rejection, got:\n%s", out)
+		}
+		if got := bdShow(t, bd, dir, issue.ID).Status; got == types.StatusClosed {
+			t.Errorf("a rejected --if-fence still closed the issue: status = %q", got)
+		}
+	})
+}
+
+// TestUnclaimIfFenceCLI drives `bd unclaim --if-fence`. Unclaim keeps its
+// shipped exit-1 contract for guard failures (13 is an update/close taxonomy),
+// the fence is an ADDITIONAL conjunct on both release forms, and it never
+// authorizes a release the owner check would refuse.
+func TestUnclaimIfFenceCLI(t *testing.T) {
+	if os.Getenv("BEADS_TEST_EMBEDDED_DOLT") != "1" {
+		t.Skip("set BEADS_TEST_EMBEDDED_DOLT=1 to run embedded dolt integration tests")
+	}
+	t.Parallel()
+
+	bd := buildEmbeddedBD(t)
+	dir, _, _ := bdInit(t, bd, "--prefix", "nif")
+
+	t.Run("stale_fence_refuses_with_1_live_fence_releases", func(t *testing.T) {
+		issue := bdCreate(t, bd, dir, "Guarded release", "--type", "task")
+		bdUpdate(t, bd, dir, issue.ID, "--assignee", "alice", "--status", "in_progress")
+		stale := fenceOf(t, bd, dir, issue.ID)
+
+		bdUnclaim(t, bd, dir, issue.ID, "--actor", "alice")
+		bdUpdate(t, bd, dir, issue.ID, "--assignee", "alice", "--status", "in_progress")
+
+		out, code := bdRunFailCode(t, bd, dir, "unclaim", issue.ID,
+			"--actor", "alice", "--if-fence", fmt.Sprint(stale))
+		if code != 1 {
+			t.Errorf("stale-fence unclaim exit code = %d, want 1 (unclaim's shipped guard contract)\n%s", code, out)
+		}
+		if !strings.Contains(out, "fence") {
+			t.Errorf("mismatch error should name the fence, got:\n%s", out)
+		}
+		if got := bdShow(t, bd, dir, issue.ID).Assignee; got != "alice" {
+			t.Errorf("stale --if-fence released the claim: assignee = %q", got)
+		}
+
+		live := fenceOf(t, bd, dir, issue.ID)
+		bdUnclaim(t, bd, dir, issue.ID, "--actor", "alice", "--if-fence", fmt.Sprint(live))
+		if got := bdShow(t, bd, dir, issue.ID).Assignee; got != "" {
+			t.Errorf("assignee = %q after a matching --if-fence release, want empty", got)
+		}
+	})
+
+	t.Run("fence_never_authorizes_a_cross_actor_release", func(t *testing.T) {
+		issue := bdCreate(t, bd, dir, "Not a credential", "--type", "task")
+		bdUpdate(t, bd, dir, issue.ID, "--assignee", "alice", "--status", "in_progress")
+		live := fenceOf(t, bd, dir, issue.ID)
+
+		// A stranger quoting the CORRECT fence is still not the owner.
+		out, code := bdRunFailCode(t, bd, dir, "unclaim", issue.ID,
+			"--actor", "stranger", "--if-fence", fmt.Sprint(live))
+		if code != 1 {
+			t.Errorf("cross-actor guarded release exit code = %d, want 1\n%s", code, out)
+		}
+		if !strings.Contains(out, "held by") {
+			t.Errorf("expected the ownership refusal, got:\n%s", out)
+		}
+		if got := bdShow(t, bd, dir, issue.ID).Assignee; got != "alice" {
+			t.Errorf("cross-actor release landed: assignee = %q", got)
+		}
+	})
+
+	t.Run("force_does_not_skip_a_supplied_fence", func(t *testing.T) {
+		issue := bdCreate(t, bd, dir, "Force plus fence", "--type", "task")
+		bdUpdate(t, bd, dir, issue.ID, "--assignee", "alice", "--status", "in_progress")
+		fence := fenceOf(t, bd, dir, issue.ID)
+
+		out, code := bdRunFailCode(t, bd, dir, "unclaim", issue.ID,
+			"--actor", "admin", "--force", "--if-fence", fmt.Sprint(fence+7))
+		if code != 1 {
+			t.Errorf("--force with a stale fence: exit code = %d, want 1\n%s", code, out)
+		}
+		if got := bdShow(t, bd, dir, issue.ID).Assignee; got != "alice" {
+			t.Errorf("--force bypassed a failing fence guard: assignee = %q", got)
+		}
+		// --force with the live fence still performs the admin release.
+		bdUnclaim(t, bd, dir, issue.ID, "--actor", "admin", "--force", "--if-fence", fmt.Sprint(fence))
+		if got := bdShow(t, bd, dir, issue.ID).Assignee; got != "" {
+			t.Errorf("assignee = %q after a forced guarded release, want empty", got)
+		}
+	})
+
+	t.Run("if_assignee_and_if_fence_compose", func(t *testing.T) {
+		issue := bdCreate(t, bd, dir, "Both guards", "--type", "task")
+		bdUpdate(t, bd, dir, issue.ID, "--assignee", "alice", "--status", "in_progress")
+		stale := fenceOf(t, bd, dir, issue.ID)
+
+		bdUnclaim(t, bd, dir, issue.ID, "--actor", "alice")
+		bdUpdate(t, bd, dir, issue.ID, "--assignee", "alice", "--status", "in_progress")
+
+		// The assignee guard holds and only the fence is stale: the whole
+		// conjunction must still refuse.
+		out := bdUnclaimFail(t, bd, dir, issue.ID, "--if-assignee", "alice", "--if-fence", fmt.Sprint(stale))
+		if !strings.Contains(out, "fence") {
+			t.Errorf("fence-only miss should name the fence, got:\n%s", out)
+		}
+		if got := bdShow(t, bd, dir, issue.ID).Assignee; got != "alice" {
+			t.Errorf("refused conditional release clobbered the claim: assignee = %q", got)
+		}
+
+		live := fenceOf(t, bd, dir, issue.ID)
+		bdUnclaim(t, bd, dir, issue.ID, "--if-assignee", "alice", "--if-fence", fmt.Sprint(live))
+		if got := bdShow(t, bd, dir, issue.ID).Assignee; got != "" {
+			t.Errorf("assignee = %q after both guards held, want empty", got)
+		}
+	})
+
+	t.Run("negative_if_fence_is_a_usage_error", func(t *testing.T) {
+		issue := bdCreate(t, bd, dir, "Negative release fence", "--type", "task")
+		bdUpdate(t, bd, dir, issue.ID, "--assignee", "alice", "--status", "in_progress")
+
+		out, code := bdRunFailCode(t, bd, dir, "unclaim", issue.ID, "--actor", "alice", "--if-fence=-1")
+		if code != 1 {
+			t.Errorf("negative --if-fence exit code = %d, want 1\n%s", code, out)
+		}
+		if !strings.Contains(out, "--if-fence must be >= 0") {
+			t.Errorf("expected the negative-fence rejection, got:\n%s", out)
+		}
+		if got := bdShow(t, bd, dir, issue.ID).Assignee; got != "alice" {
+			t.Errorf("a rejected --if-fence still released the claim: assignee = %q", got)
+		}
+	})
+}

--- a/cmd/bd/close.go
+++ b/cmd/bd/close.go
@@ -32,7 +32,19 @@ create, update, show, or close operation).
 When closing multiple issues, provide one --reason for all IDs or repeat
 --reason once per ID. Reasons map positionally: the first --reason applies
 to the first ID, the second --reason to the second ID, regardless of where
-the flags appear in the command line.`,
+the flags appear in the command line.
+
+With --if-fence, each close is a compare-and-set on the issue's claim fence: a
+monotonic ownership token (claim_fence in bd show --json) that advances on
+every ownership transition — claim, release, reclaim, reassign, reopen — and on
+nothing else. Use it to stop a worker whose claim was reclaimed and re-issued
+from completing a bead it no longer owns; its own intervening content writes do
+not invalidate the guard. --force may be combined with it: --force bypasses
+only the is_blocked gate, never a guard you supplied.
+
+Exit codes: 0 when at least one issue settled as closed (a real close or an
+already-closed no-op); 13 when nothing settled and every attempted ID failed on
+a stale --if-fence guard; 1 otherwise.`,
 	Args:          cobra.MinimumNArgs(0),
 	SilenceUsage:  true,
 	SilenceErrors: true,
@@ -46,7 +58,20 @@ the flags appear in the command line.`,
 			}
 		}()
 
+		// Presence-selected and negative-rejecting; see ifFenceGuardFromFlags.
+		ifFence, fenceErr := ifFenceGuardFromFlags(cmd)
+		if fenceErr != nil {
+			return fenceErr
+		}
+
 		if usesProxiedServer() {
+			// The proxied close path carries no compare-and-set at all
+			// (domain.CloseIssueParams has no guard fields), so accepting the
+			// flag here would silently drop the guard. Refuse loudly instead —
+			// the unclaim --if-assignee precedent.
+			if ifFence != nil {
+				return HandleErrorRespectJSON("--if-fence is not supported in proxied-server mode")
+			}
 			return runCloseProxiedServer(cmd, rootCtx, args)
 		}
 
@@ -108,6 +133,7 @@ the flags appear in the command line.`,
 		closedIssues := []*types.Issue{}
 		closedCount := 0
 		alreadyClosed := 0
+		guardMismatches := 0
 		firstSettledID := ""
 
 		for i, id := range resolvedIDs {
@@ -148,11 +174,14 @@ the flags appear in the command line.`,
 			// Delegate the is_blocked guard to the engine (GH#962). CloseIssueChecked
 			// runs the guard and the close in ONE transaction, so there is no
 			// read-then-write TOCTOU window between the check and the close. --force
-			// bypasses the guard; ExpectedVersion is unused on this path.
+			// bypasses the is_blocked guard only; ExpectedFence (from --if-fence) is
+			// an orthogonal CAS it does not waive, and ExpectedVersion is unused on
+			// this path.
 			res, err := activeStore.CloseIssueChecked(ctx, id, actor, storage.CloseIssueOptions{
-				Reason:  reason,
-				Session: session,
-				Force:   force,
+				Reason:        reason,
+				Session:       session,
+				Force:         force,
+				ExpectedFence: ifFence,
 			})
 			if err != nil {
 				if errors.Is(err, storage.ErrCloseBlocked) {
@@ -161,6 +190,9 @@ the flags appear in the command line.`,
 					fmt.Fprintf(os.Stderr, "%v (use --force to override)\n", err)
 				} else {
 					fmt.Fprintf(os.Stderr, "Error closing %s: %v\n", id, err)
+				}
+				if isGuardMismatch(err) {
+					guardMismatches++
 				}
 				continue
 			}
@@ -376,6 +408,14 @@ the flags appear in the command line.`,
 
 		totalAttempted := len(resolvedIDs)
 		if totalAttempted > 0 && closedCount == 0 && alreadyClosed == 0 {
+			// Nothing settled. Mirror bd update's taxonomy: exit 13 only when
+			// EVERY attempted ID failed on a stale guard — nothing was written
+			// and retrying the same guard is pointless — and 1 for anything
+			// mixed in. Partial success never reaches here, so the shipped
+			// "some closed ⇒ exit 0" contract is untouched.
+			if guardMismatches == totalAttempted {
+				return &exitError{Code: ExitGuardMismatch}
+			}
 			return SilentExit()
 		}
 		return nil
@@ -392,6 +432,9 @@ func init() {
 	_ = closeCmd.Flags().MarkHidden("comment") // Hidden alias for agent/CLI ergonomics
 	closeCmd.Flags().String("reason-file", "", "Read close reason from file (use - for stdin)")
 	closeCmd.Flags().BoolP("force", "f", false, "Force close pinned issues or unsatisfied gates")
+	// Deliberately NOT exclusive with --force: --force bypasses only the
+	// is_blocked/gate refusals, and a supplied guard is never waived with it.
+	closeCmd.Flags().Int64("if-fence", 0, "Close only while the claim fence equals this value (monotonic ownership token from claim_fence in bd show --json; --if-fence 0 requires never-claimed); a mismatch closes nothing and exits 13 when it is the only failure")
 	closeCmd.Flags().Bool("continue", false, "Auto-advance to next step in molecule")
 	closeCmd.Flags().Bool("no-auto", false, "With --continue, show next step but don't claim it")
 	closeCmd.Flags().Bool("suggest-next", false, "Show newly unblocked issues after closing")

--- a/cmd/bd/config.go
+++ b/cmd/bd/config.go
@@ -1000,6 +1000,7 @@ var recognizedConfigKeys = map[string]bool{
 	"no-db": true, "json": true, "db": true, "actor": true,
 	"identity": true, "no-push": true, "no-git-ops": true,
 	"node_id":                    true, // replica identity for the lease guard (read from yaml/env, never the DB)
+	"lease.auto":                 true, // store-wide claim-lease policy, DB-stored (unlike node_id, it is not per-machine)
 	"create.require-description": true, "beads.role": true,
 	"auto_compact_enabled": true, "schema_version": true,
 	"output.title-length": true,

--- a/cmd/bd/config_validate_key_test.go
+++ b/cmd/bd/config_validate_key_test.go
@@ -13,7 +13,7 @@ func TestIsRecognizedConfigKey(t *testing.T) {
 		"doctor.suppress.git-hooks", "no-git-ops", "beads.role",
 		"status.custom", "types.custom", "types.infra", "ai.model",
 		"backup.enabled", "import.path", "dolt.local-only", "agent.profile",
-		"claim.pools",
+		"claim.pools", "lease.auto",
 		// Tracker namespaces are derived from the registry (GH#4427); cover
 		// ado (the original bug) plus the others removed from the static list.
 		"ado.org", "ado.project", "github.token", "linear.api-key",

--- a/cmd/bd/heartbeat.go
+++ b/cmd/bd/heartbeat.go
@@ -29,6 +29,11 @@ and no history, so any cadence comfortably below the TTL is fine. Leases are
 only enforceable on the node that granted them; cross-machine claim visibility
 rides the issue's status and assignee, which do commit.
 
+On a store that turned automatic leases off ('bd lease disarm', config key
+lease.auto), heartbeat is a renewal and nothing more: an unleased claim is
+rejected rather than quietly armed, since arming one would put the claim back
+in reach of 'bd reclaim'.
+
 Examples:
   bd heartbeat bd-123
   bd hb bd-123`,

--- a/cmd/bd/lease.go
+++ b/cmd/bd/lease.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/steveyegge/beads/internal/metrics"
+	"github.com/steveyegge/beads/internal/storage/issueops"
+	"github.com/steveyegge/beads/internal/ui"
+)
+
+var leaseCmd = &cobra.Command{
+	Use:     "lease",
+	GroupID: "issues",
+	Short:   "Manage automatic claim leases",
+	Long: `Manage the store's automatic claim-lease behavior.
+
+By default every claim stamps a lease (` + "`lease.auto` on" + `): a worker that
+stops heartbeating loses its claim to 'bd reclaim'. Deployments whose recovery
+authority lives elsewhere — an orchestrator that already holds its own liveness
+evidence — can disarm automatic stamping, so an un-renewed fleet is never one
+stray reclaim away from mass-reverting live work.`,
+}
+
+var leaseDisarmCmd = &cobra.Command{
+	Use:   "disarm",
+	Short: "Turn off automatic claim leases and clear the armed ones",
+	Long: `Set ` + issueops.LeaseAutoConfigKey + `=off and clear the lease rows of the claims
+already holding one. The flip and the first sweep share one transaction, and
+bounded follow-up sweeps catch claims that were in flight during the flip.
+
+Nothing is released: status, assignee and the claim fence (the claim_fence
+value in 'bd show --json', the token '--if-fence' guards on) are untouched.
+Only the leases go, so nothing in_progress is left for 'bd reclaim' to revert.
+
+After disarming, claims carry no lease, 'bd heartbeat' on an unleased claim is
+rejected rather than quietly arming one, and 'bd reclaim' finds nothing to
+reap. This is a one-shot sweep, not a standing rejection: an import that
+carries a live lease from another replica still restores it.
+
+Re-arm with: bd config set ` + issueops.LeaseAutoConfigKey + ` on
+(existing claims stay unleased until they are re-claimed).`,
+	Args:          cobra.NoArgs,
+	SilenceUsage:  true,
+	SilenceErrors: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		CheckReadonly("lease disarm")
+
+		if usesProxiedServer() {
+			return HandleErrorWithHintRespectJSON(
+				"lease disarm is not supported in proxied-server mode",
+				fmt.Sprintf("run 'bd config set %s off' for the flip; leases already armed then have to expire or be cleared by hand",
+					issueops.LeaseAutoConfigKey))
+		}
+
+		evt := metrics.NewCommandEvent("lease-disarm")
+		defer func() {
+			if c := metrics.Global(); c != nil {
+				c.CloseEventAndAdd(evt)
+			}
+		}()
+
+		if store == nil {
+			return HandleErrorWithHint("database not initialized", diagHint())
+		}
+
+		n, err := store.DisarmAutoLeases(rootCtx)
+		if err != nil {
+			return HandleErrorRespectJSON("lease disarm: %v", err)
+		}
+		if err := commitPendingIfEmbedded(rootCtx, store, actor, doltAutoCommitParams{
+			Command: "lease disarm",
+		}); err != nil {
+			return HandleErrorRespectJSON("lease disarm commit: %v", err)
+		}
+
+		if jsonOutput {
+			return outputJSON(map[string]interface{}{
+				"lease_auto": "off",
+				"disarmed":   n,
+			})
+		}
+		fmt.Printf("%s Automatic claim leases disarmed (%s=off); cleared %d lease(s)\n",
+			ui.RenderPass("✓"), issueops.LeaseAutoConfigKey, n)
+		return nil
+	},
+}
+
+func init() {
+	leaseCmd.AddCommand(leaseDisarmCmd)
+	rootCmd.AddCommand(leaseCmd)
+}

--- a/cmd/bd/lease_disarm_embedded_test.go
+++ b/cmd/bd/lease_disarm_embedded_test.go
@@ -1,0 +1,138 @@
+//go:build cgo
+
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// bdConfigSet runs `bd config set` and fails the test if the key is not
+// recognized — the exit code alone misses that, and an unrecognized key would
+// make the whole feature warn at every adopter's setup step.
+func bdConfigSet(t *testing.T, bd, dir, key, value string) {
+	t.Helper()
+	cmd := exec.Command(bd, "config", "set", key, value)
+	cmd.Dir = dir
+	cmd.Env = bdEnv(dir)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("bd config set %s %s failed: %v\n%s", key, value, err, out)
+	}
+	if strings.Contains(string(out), "not a recognized config key") {
+		t.Fatalf("bd config set %s warned about an unrecognized key:\n%s", key, out)
+	}
+}
+
+// TestEmbeddedLeaseDisarm drives `bd lease disarm` end to end: the one-shot
+// flip reports what it cleared, releases nothing, survives as store config so
+// later claims are unleased, and is idempotent on a second run.
+func TestEmbeddedLeaseDisarm(t *testing.T) {
+	if os.Getenv("BEADS_TEST_EMBEDDED_DOLT") != "1" {
+		t.Skip("set BEADS_TEST_EMBEDDED_DOLT=1 to run embedded dolt integration tests")
+	}
+	t.Parallel()
+
+	bd := buildEmbeddedBD(t)
+	dir, _, _ := bdInit(t, bd, "--prefix", "ld")
+
+	issue := bdCreate(t, bd, dir, "Held across the disarm", "--type", "task")
+	bdUpdate(t, bd, dir, issue.ID, "--claim", "--actor", "alice")
+	claimed := bdShow(t, bd, dir, issue.ID)
+	if claimed.LeaseExpiresAt == nil {
+		t.Fatal("test setup: a default (lease.auto on) claim did not stamp a lease")
+	}
+
+	out, code := bdRunRaw(t, bd, dir, nil, "lease", "disarm")
+	if code != 0 {
+		t.Fatalf("bd lease disarm exit = %d, want 0\n%s", code, out)
+	}
+	if !strings.Contains(out, "cleared 1 lease") {
+		t.Errorf("bd lease disarm should report the lease it cleared, got:\n%s", out)
+	}
+
+	// Nothing released: the claim, its holder and its fence all stand.
+	after := bdShow(t, bd, dir, issue.ID)
+	if after.Status != types.StatusInProgress || after.Assignee != "alice" {
+		t.Errorf("disarm released the claim: status=%s assignee=%q", after.Status, after.Assignee)
+	}
+	if after.ClaimFence != claimed.ClaimFence {
+		t.Errorf("disarm moved claim_fence %d → %d; disarming is not an ownership transition",
+			claimed.ClaimFence, after.ClaimFence)
+	}
+	if after.LeaseExpiresAt != nil {
+		t.Error("disarm left the lease armed")
+	}
+
+	// The flip persisted: a later claim carries no lease, and heartbeating it
+	// is refused rather than silently re-arming.
+	next := bdCreate(t, bd, dir, "Claimed after the disarm", "--type", "task")
+	bdUpdate(t, bd, dir, next.ID, "--claim", "--actor", "bob")
+	if got := bdShow(t, bd, dir, next.ID); got.LeaseExpiresAt != nil {
+		t.Error("post-disarm claim stamped a lease")
+	}
+	hbOut, hbCode := bdRunRaw(t, bd, dir, nil, "heartbeat", next.ID, "--actor", "bob")
+	if hbCode == 0 {
+		t.Errorf("heartbeat on an unleased claim should fail, got:\n%s", hbOut)
+	}
+	if !strings.Contains(hbOut, "no lease") {
+		t.Errorf("heartbeat refusal should name the missing lease, got:\n%s", hbOut)
+	}
+
+	// Idempotent: a second run flips an already-off key and sweeps nothing.
+	againOut, againCode := bdRunRaw(t, bd, dir, nil, "lease", "disarm", "--json")
+	if againCode != 0 {
+		t.Fatalf("second bd lease disarm exit = %d, want 0\n%s", againCode, againOut)
+	}
+	var payload struct {
+		LeaseAuto string `json:"lease_auto"`
+		Disarmed  int64  `json:"disarmed"`
+	}
+	if err := json.Unmarshal([]byte(strings.TrimSpace(againOut)), &payload); err != nil {
+		t.Fatalf("bd lease disarm --json emitted unparseable output %q: %v", againOut, err)
+	}
+	if payload.LeaseAuto != "off" || payload.Disarmed != 0 {
+		t.Errorf("second disarm reported %+v, want lease_auto=off disarmed=0", payload)
+	}
+}
+
+// TestEmbeddedLeaseAutoConfigRoundTrip: the config key is the documented way
+// to reach the same state without the sweep, so `bd config set lease.auto
+// false` must be accepted as a recognized key and honored by the next claim.
+func TestEmbeddedLeaseAutoConfigRoundTrip(t *testing.T) {
+	if os.Getenv("BEADS_TEST_EMBEDDED_DOLT") != "1" {
+		t.Skip("set BEADS_TEST_EMBEDDED_DOLT=1 to run embedded dolt integration tests")
+	}
+	t.Parallel()
+
+	bd := buildEmbeddedBD(t)
+	dir, _, _ := bdInit(t, bd, "--prefix", "lc")
+
+	bdConfigSet(t, bd, dir, "lease.auto", "false")
+
+	issue := bdCreate(t, bd, dir, "Unleased by config", "--type", "task")
+	bdUpdate(t, bd, dir, issue.ID, "--claim", "--actor", "alice")
+	got := bdShow(t, bd, dir, issue.ID)
+	if got.Status != types.StatusInProgress || got.Assignee != "alice" {
+		t.Fatalf("claim did not take: status=%s assignee=%q", got.Status, got.Assignee)
+	}
+	if got.LeaseExpiresAt != nil {
+		t.Error("claim under lease.auto=false stamped a lease")
+	}
+	if got.ClaimFence == 0 {
+		t.Error("claim under lease.auto=false did not bump claim_fence; the claim is still an ownership transition")
+	}
+
+	// Re-arming through the same key restores the shipped behavior.
+	bdConfigSet(t, bd, dir, "lease.auto", "on")
+	rearmed := bdCreate(t, bd, dir, "Leased again", "--type", "task")
+	bdUpdate(t, bd, dir, rearmed.ID, "--claim", "--actor", "alice")
+	if bdShow(t, bd, dir, rearmed.ID).LeaseExpiresAt == nil {
+		t.Error("claim after re-arming lease.auto did not stamp a lease")
+	}
+}

--- a/cmd/bd/lease_disarm_proxied_test.go
+++ b/cmd/bd/lease_disarm_proxied_test.go
@@ -1,0 +1,54 @@
+//go:build cgo
+
+package main
+
+import (
+	"errors"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// TestProxiedServerLeaseDisarmRefused: the proxied-server path has no store to
+// run the flip-and-sweep transaction on, so `bd lease disarm` is refused
+// loudly rather than half-done. The refusal points at the config key, which
+// does the flip on its own — but not the sweep, so it says so.
+func TestProxiedServerLeaseDisarmRefused(t *testing.T) {
+	requireSharedProxiedServer(t)
+	t.Parallel()
+
+	bd := buildEmbeddedBD(t)
+	p := newSharedProxiedProject(t, bd, "pld")
+
+	issue := bdProxiedCreate(t, bd, p.dir, "Claimed over the proxy")
+	if out, err := bdProxiedRun(t, bd, p.dir, "update", issue.ID, "--assignee", "worker", "--status", "in_progress"); err != nil {
+		t.Fatalf("seed assign failed: %v\n%s", err, out)
+	}
+
+	stdout, stderr, err := bdProxiedRunBuffers(t, bd, p.dir, "lease", "disarm")
+	if err == nil {
+		t.Fatalf("bd lease disarm should be refused in proxied-server mode; got:\n%s%s", stdout, stderr)
+	}
+	var ee *exec.ExitError
+	if !errors.As(err, &ee) {
+		t.Fatalf("bd lease disarm failed without an exit code: %v", err)
+	}
+	if ee.ExitCode() != 1 {
+		t.Errorf("bd lease disarm exit code = %d, want 1", ee.ExitCode())
+	}
+	combined := stdout + stderr
+	if !strings.Contains(combined, "not supported in proxied-server mode") {
+		t.Errorf("refusal should name proxied-server mode, got:\n%s", combined)
+	}
+	if !strings.Contains(combined, "bd config set lease.auto off") {
+		t.Errorf("refusal should point at the config-key alternative, got:\n%s", combined)
+	}
+
+	// The refusal wrote nothing: the claim is untouched.
+	got := bdProxiedShow(t, bd, p.dir, issue.ID)
+	if got.Assignee != "worker" || got.Status != types.StatusInProgress {
+		t.Errorf("refused disarm mutated the claim: assignee=%q status=%s", got.Assignee, got.Status)
+	}
+}

--- a/cmd/bd/prime.go
+++ b/cmd/bd/prime.go
@@ -868,7 +868,7 @@ git status                  # Check changed files
 - ` + "`bd update <id> --claim`" + ` - Claim work
 - ` + "`bd unclaim <id>`" + ` - Release stuck issue (agent crashed)
 - ` + "`bd update <id> --assignee=username`" + ` - Assign to someone
-- ` + "`bd update <id> --if-assignee=<expected> --assignee=<new>`" + ` - Atomic reassign: applies only if the assignee still matches (--if-status=<expected> guards status; --if-assignee='' requires unassigned). Mismatch exits non-zero with nothing written — never retry blindly
+- ` + "`bd update <id> --if-assignee=<expected> --assignee=<new>`" + ` - Atomic reassign: applies only if the assignee still matches (--if-status=<expected> guards status; --if-fence=<n> guards the claim_fence from bd show --json; --if-assignee='' requires unassigned). Mismatch exits non-zero with nothing written — never retry blindly
 - ` + "`bd update <id> --title/--description/--notes/--design`" + ` - Update fields inline
 - ` + "`bd close <id>`" + ` - Mark complete
 - ` + "`bd close <id1> <id2> ...`" + ` - Close multiple issues at once (more efficient)

--- a/cmd/bd/protocol/testdata/corpus/envelope/list.json
+++ b/cmd/bd/protocol/testdata/corpus/envelope/list.json
@@ -1,6 +1,7 @@
 {
   "data": [
     {
+      "claim_fence": 1,
       "comment_count": 0,
       "created_at": "<TS>",
       "created_by": "protocol-test",

--- a/cmd/bd/protocol/testdata/corpus/envelope/ready.json
+++ b/cmd/bd/protocol/testdata/corpus/envelope/ready.json
@@ -1,6 +1,7 @@
 {
   "data": [
     {
+      "claim_fence": 1,
       "comment_count": 0,
       "created_at": "<TS>",
       "created_by": "protocol-test",

--- a/cmd/bd/protocol/testdata/corpus/envelope/reopen.json
+++ b/cmd/bd/protocol/testdata/corpus/envelope/reopen.json
@@ -1,6 +1,7 @@
 {
   "data": [
     {
+      "claim_fence": 1,
       "created_at": "<TS>",
       "created_by": "protocol-test",
       "description": "deterministic corpus closeable",

--- a/cmd/bd/protocol/testdata/corpus/flat/list.json
+++ b/cmd/bd/protocol/testdata/corpus/flat/list.json
@@ -1,5 +1,6 @@
 [
   {
+    "claim_fence": 1,
     "comment_count": 0,
     "created_at": "<TS>",
     "created_by": "protocol-test",

--- a/cmd/bd/protocol/testdata/corpus/flat/ready.json
+++ b/cmd/bd/protocol/testdata/corpus/flat/ready.json
@@ -1,5 +1,6 @@
 [
   {
+    "claim_fence": 1,
     "comment_count": 0,
     "created_at": "<TS>",
     "created_by": "protocol-test",

--- a/cmd/bd/protocol/testdata/corpus/flat/reopen.json
+++ b/cmd/bd/protocol/testdata/corpus/flat/reopen.json
@@ -1,5 +1,6 @@
 [
   {
+    "claim_fence": 1,
     "created_at": "<TS>",
     "created_by": "protocol-test",
     "description": "deterministic corpus closeable",

--- a/cmd/bd/protocol/testdata/corpus/manifest.json
+++ b/cmd/bd/protocol/testdata/corpus/manifest.json
@@ -49,15 +49,15 @@
     },
     "envelope/list": {
       "cmd": "bd list --all --json",
-      "sha256": "9a06f84b6522a6ecfeb9290c0f1af6a89ac1f6e8c4ccb4318cb167a384d5bb90"
+      "sha256": "f647cecdf720729aeba8894347bace3871b0d3d6cc9b0809ca1f45eeaa867546"
     },
     "envelope/ready": {
       "cmd": "bd ready --json",
-      "sha256": "9a06f84b6522a6ecfeb9290c0f1af6a89ac1f6e8c4ccb4318cb167a384d5bb90"
+      "sha256": "f647cecdf720729aeba8894347bace3871b0d3d6cc9b0809ca1f45eeaa867546"
     },
     "envelope/reopen": {
       "cmd": "bd reopen --json corpus-closed",
-      "sha256": "dfab601890c2bc3ad27ee8be7899daad96bb6f8af460616a7d531205de21aa7f"
+      "sha256": "f3a945ecba4c0798f229edc69b2c2b8a19622b4e2382cc98ce32191c0b5296fb"
     },
     "envelope/show": {
       "cmd": "bd show corpus-root --json",
@@ -117,15 +117,15 @@
     },
     "flat/list": {
       "cmd": "bd list --all --json",
-      "sha256": "6d7b3535591a4e85385a96cb02e220853d7e81f4212d4032d4567aa991418dae"
+      "sha256": "a1b09b5b133110d50621a7421c4a8d10ff4c12dcda938da36fe2218e349a954b"
     },
     "flat/ready": {
       "cmd": "bd ready --json",
-      "sha256": "6d7b3535591a4e85385a96cb02e220853d7e81f4212d4032d4567aa991418dae"
+      "sha256": "a1b09b5b133110d50621a7421c4a8d10ff4c12dcda938da36fe2218e349a954b"
     },
     "flat/reopen": {
       "cmd": "bd reopen --json corpus-closed",
-      "sha256": "c2eebbe621462c21665b17188029adb8a0700c99d7cf2907ea62868b57090136"
+      "sha256": "07dc87d2e9c8c0066bf157cefe3b8596071fb519a8e6f8204e7e7233f075165a"
     },
     "flat/show": {
       "cmd": "bd show corpus-root --json",

--- a/cmd/bd/reclaim.go
+++ b/cmd/bd/reclaim.go
@@ -63,6 +63,14 @@ or leave it unset. There is no hostname fallback — the hostname names the clie
 process's machine, not the store — so an unnamed deployment keeps the old,
 unguarded behavior instead of stranding its own work.
 
+reclaim only ever sees claims that carry a lease. Turning automatic leases off
+('bd lease disarm', config key lease.auto) stops new claims from arming one and
+sweeps away the rows already there, so on a disarmed store there is normally
+nothing to reap and recovery is the orchestrator's job. That sweep is one-shot,
+not a standing rejection: a JSONL import can restore a live lease that rode the
+interchange, and re-arming lease.auto starts stamping again. reclaim treats any
+lease it then finds exactly as it always has.
+
 Examples:
   bd reclaim                       # default grace window (2× the lease TTL)
   bd reclaim --older-than 10m      # reclaim leases expired >10m ago

--- a/cmd/bd/unclaim.go
+++ b/cmd/bd/unclaim.go
@@ -34,14 +34,27 @@ specific worker's issue without ever clobbering someone else's live claim.
 --if-assignee requires a non-empty assignee and cannot be combined with --force
 (they encode contradictory intent).
 
+With --if-fence, the release additionally requires the issue's claim fence to
+still equal the given value. The claim fence is a monotonic ownership token
+(claim_fence in bd show --json) that advances on every ownership transition —
+claim, release, reclaim, reassign, reopen — so it names the exact generation of
+a claim rather than just its holder: a worker whose lease was reclaimed and
+re-issued to a fresh session of the SAME assignee is refused here, where
+--if-assignee would let it through. It composes with --if-assignee (both must
+hold) and, unlike --if-assignee, is allowed with --force — because --force
+waives only the ownership check, never a guard you supplied. A fence guard
+establishes freshness, not authority: it never authorizes releasing another
+actor's claim.
+
 Exit status: 0 when every issue was released; 1 when any release failed
-(including an --if-assignee mismatch).
+(including an --if-assignee or --if-fence mismatch).
 
 Examples:
   bd unclaim bd-123
   bd unclaim bd-123 --reason "Agent crashed"
   bd unclaim bd-123 bd-456
-  bd unclaim bd-123 --if-assignee worker-7   # only if still held by worker-7`,
+  bd unclaim bd-123 --if-assignee worker-7   # only if still held by worker-7
+  bd unclaim bd-123 --if-fence 4             # only if the claim is still generation 4`,
 	Args: cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		reason, _ := cmd.Flags().GetString("reason")
@@ -58,12 +71,21 @@ Examples:
 		if conditional && ifAssignee == "" {
 			return HandleErrorRespectJSON("--if-assignee requires a non-empty assignee; it releases the issue only while that assignee still holds it")
 		}
+		// --if-fence is likewise presence-selected, and negative-rejecting; see
+		// ifFenceGuardFromFlags.
+		ifFence, fenceErr := ifFenceGuardFromFlags(cmd)
+		if fenceErr != nil {
+			return fenceErr
+		}
 
 		CheckReadonly("unclaim")
 
 		if usesProxiedServer() {
 			if conditional {
 				return HandleErrorRespectJSON("--if-assignee is not supported in proxied-server mode")
+			}
+			if ifFence != nil {
+				return HandleErrorRespectJSON("--if-fence is not supported in proxied-server mode")
 			}
 			return runUnclaimProxiedServer(rootCtx, args, reason, force)
 		}
@@ -89,9 +111,9 @@ Examples:
 
 			var unclaimErr error
 			if conditional {
-				unclaimErr = issueStore.UnclaimIssueIfAssignee(ctx, fullID, actor, ifAssignee)
+				unclaimErr = issueStore.UnclaimIssueIfAssignee(ctx, fullID, actor, ifAssignee, ifFence)
 			} else {
-				unclaimErr = issueStore.UnclaimIssue(ctx, fullID, actor, force)
+				unclaimErr = issueStore.UnclaimIssue(ctx, fullID, actor, force, ifFence)
 			}
 			if unclaimErr != nil {
 				fmt.Fprintf(os.Stderr, "Error unclaiming %s: %v\n", fullID, unclaimErr)
@@ -146,6 +168,10 @@ func init() {
 	// habitually passes --force from silently dropping it when it also passes
 	// --if-assignee for one case.
 	unclaimCmd.MarkFlagsMutuallyExclusive("force", "if-assignee")
+	// --if-fence is deliberately NOT exclusive with --force: --force waives the
+	// ownership check, and a supplied guard is never waived with it. A reaper
+	// that forces a release can still pin it to the generation it observed.
+	unclaimCmd.Flags().Int64("if-fence", 0, "Only release while the claim fence still equals this value (monotonic ownership token from claim_fence in bd show --json; composes with --if-assignee and --force)")
 	unclaimCmd.ValidArgsFunction = issueIDCompletion
 	rootCmd.AddCommand(unclaimCmd)
 }

--- a/cmd/bd/unclaim_test.go
+++ b/cmd/bd/unclaim_test.go
@@ -63,4 +63,18 @@ func TestUnclaimCommand_Flags(t *testing.T) {
 	if ifAssigneeFlag.DefValue != "" {
 		t.Errorf("expected if-assignee default value '', got %q", ifAssigneeFlag.DefValue)
 	}
+
+	// The --if-fence flag pins the release to one ownership generation. Its
+	// zero default is inert only because presence is detected via Changed():
+	// `--if-fence 0` is a real "expected never claimed" assertion.
+	ifFenceFlag := unclaimCmd.Flags().Lookup("if-fence")
+	if ifFenceFlag == nil {
+		t.Fatal("if-fence flag should be defined")
+	}
+	if ifFenceFlag.DefValue != "0" {
+		t.Errorf("expected if-fence default value '0', got %q", ifFenceFlag.DefValue)
+	}
+	if ifFenceFlag.Value.Type() != "int64" {
+		t.Errorf("expected if-fence to be int64, got %q", ifFenceFlag.Value.Type())
+	}
 }

--- a/cmd/bd/update.go
+++ b/cmd/bd/update.go
@@ -35,9 +35,23 @@ fail, the remaining issues are still updated, every failed ID is reported on
 stderr, and the command exits nonzero.
 
 Exit codes: 1 for general failures; 13 when every failure is a stale
---if-assignee/--if-status guard (the precondition no longer held, nothing was
-written — another actor won the race, so retrying the same guard is
-pointless).`,
+--if-assignee/--if-status/--if-fence guard (the precondition no longer held,
+nothing was written — another actor won the race, so retrying the same guard is
+pointless).
+
+--if-fence guards on the claim fence: a monotonic ownership token (claim_fence
+in bd show --json) that advances on ownership transitions — claim, release,
+reclaim, reassign (including an import that changes the owner), reopen — and on
+no content write, so a holder's own edits never invalidate it.
+
+--if-fence does NOT sanction taking over another actor's live claim. A plain -a
+that would overwrite an in_progress claim held by someone else is refused
+(exit 1) whether or not you pass --if-fence. Naming the holder with
+--if-assignee is what makes that transfer explicit and lets it through; --force
+overrides the refusal outright, and is mutually exclusive with both guards.
+That refusal is the live-claim reassign fence — a policy check, a different
+thing from this flag, which is only a compare-and-set on the ownership
+generation you observed.`,
 	Args:          cobra.MinimumNArgs(0),
 	SilenceUsage:  true,
 	SilenceErrors: true,
@@ -333,7 +347,7 @@ pointless).`,
 		// status set as --status, mutually exclusive with --claim (which is
 		// its own compare-and-set), and only meaningful with a field update
 		// to ride on.
-		ifAssignee, ifStatus, err := updateGuardsFromFlags(cmd, claimFlag, updates)
+		ifAssignee, ifStatus, ifFence, err := updateGuardsFromFlags(cmd, claimFlag, updates)
 		if err != nil {
 			return err
 		}
@@ -462,9 +476,9 @@ pointless).`,
 				// mismatch error and MUST surface as a non-zero exit — never
 				// collapse it to success (finding #10).
 				var updateErr error
-				if ifAssignee != nil || ifStatus != nil {
+				if ifAssignee != nil || ifStatus != nil || ifFence != nil {
 					updateErr = issueStore.UpdateIssueChecked(ctx, result.ResolvedID, regularUpdates, actor,
-						storage.UpdateIssueOptions{ExpectedAssignee: ifAssignee, ExpectedStatus: ifStatus})
+						storage.UpdateIssueOptions{ExpectedAssignee: ifAssignee, ExpectedStatus: ifStatus, ExpectedFence: ifFence})
 				} else {
 					updateErr = issueStore.UpdateIssue(ctx, result.ResolvedID, regularUpdates, actor)
 				}
@@ -654,21 +668,24 @@ func warnNotesReplacement(id string) {
 	fmt.Fprintf(os.Stderr, "warning: %s: --notes replaced existing notes (use --append-notes to preserve history)\n", id) //nolint:gosec // G705: stderr, not a browser context
 }
 
-// ExitGuardMismatch is the exit code when a `bd update` run failed solely
-// because --if-assignee/--if-status guards did not match: the precondition no
-// longer held, nothing was written, and retrying is pointless — another actor
-// won the race. Scripts branch on it to tell "racer won, skip gracefully"
-// (13) from infra failure (1, retry/abort). Mixed batches — any failure that
-// is NOT a guard mismatch — exit 1, the conservative "something needs a
-// retry" verdict. The stderr line carries the machine-greppable sentinel
-// text ("assignee mismatch" / "status mismatch") either way.
+// ExitGuardMismatch is the exit code when a `bd update` or `bd close` run
+// failed solely because --if-assignee/--if-status/--if-fence guards did not
+// match: the precondition no longer held, nothing was written, and retrying is
+// pointless — another actor won the race. Scripts branch on it to tell "racer
+// won, skip gracefully" (13) from infra failure (1, retry/abort). Mixed
+// batches — any failure that is NOT a guard mismatch — exit 1, the
+// conservative "something needs a retry" verdict. The stderr line carries the
+// machine-greppable sentinel text ("assignee mismatch" / "status mismatch" /
+// "fence mismatch") either way.
 const ExitGuardMismatch = 13
 
-// isGuardMismatch reports whether err is a bd-wsqvw conditional-update guard
-// refusal (stale --if-assignee/--if-status), the failure class that exits
-// ExitGuardMismatch instead of 1.
+// isGuardMismatch reports whether err is a bd-wsqvw conditional-write guard
+// refusal (stale --if-assignee/--if-status/--if-fence), the failure class that
+// exits ExitGuardMismatch instead of 1.
 func isGuardMismatch(err error) bool {
-	return errors.Is(err, storage.ErrAssigneeMismatch) || errors.Is(err, storage.ErrStatusMismatch)
+	return errors.Is(err, storage.ErrAssigneeMismatch) ||
+		errors.Is(err, storage.ErrStatusMismatch) ||
+		errors.Is(err, storage.ErrFenceMismatch)
 }
 
 // updateIDFailure records one issue ID that could not be updated and why.
@@ -751,17 +768,43 @@ func toJSONValue(s string) json.RawMessage {
 	return storage.MetadataEditValue(s)
 }
 
+// ifFenceGuardFromFlags reads --if-fence with presence detected via Changed(),
+// so `--if-fence 0` is the real "expected never claimed" assertion rather than
+// "no guard". Shared by all four parse sites — bd update direct and proxied,
+// bd close, bd unclaim — so the rejection below and its wording cannot drift
+// between verbs.
+//
+// A negative fence can never match: claim_fence starts at 0 and only ever
+// increments, so `--if-fence -1` is a typo, not a guard that will legitimately
+// refuse. Letting it through would report it as a mismatch — exit 13 on update
+// and close, whose contract says "another actor won the race, retrying this
+// guard is pointless" — for a race the caller never entered. It is a usage
+// error: exit 1, like any other bad flag value, before any issue is touched.
+func ifFenceGuardFromFlags(cmd *cobra.Command) (*int64, error) {
+	if !cmd.Flags().Changed("if-fence") {
+		return nil, nil
+	}
+	v, _ := cmd.Flags().GetInt64("if-fence")
+	if v < 0 {
+		return nil, HandleErrorRespectJSON("--if-fence must be >= 0 (the claim fence starts at 0 and only increments, so a negative value can never match)")
+	}
+	return &v, nil
+}
+
 // updateGuardsFromFlags reads the bd-wsqvw conditional-update guards
-// (--if-assignee/--if-status) with presence detected via Changed(), so
-// `--if-assignee ""` is a real guard meaning "expected unassigned" rather than
+// (--if-assignee/--if-status/--if-fence) with presence detected via Changed(),
+// so `--if-assignee ""` is a real guard meaning "expected unassigned" and
+// `--if-fence 0` a real guard meaning "expected never claimed", rather than
 // "no guard" (the unclaim.go idiom). It rejects combining guards with --claim
 // (--claim is its own compare-and-set with claim-pool semantics; the guards
-// would silently duplicate or contradict it) and guards with no regular field
-// update to ride on (the CAS applies to the issues-row UPDATE; label and
-// parent edits run outside it and would not be guarded). An --if-status value
-// is validated against the same built-in + custom status set as --status, so a
-// typo fails fast instead of mismatching forever.
-func updateGuardsFromFlags(cmd *cobra.Command, claimFlag bool, updates map[string]interface{}) (ifAssignee, ifStatus *string, err error) {
+// would silently duplicate or contradict it — and a fresh claim bumps the
+// claim fence, so a pre-claim --if-fence would conflict with the very claim it
+// rides on) and guards with no regular field update to ride on (the CAS applies
+// to the issues-row UPDATE; label and parent edits run outside it and would not
+// be guarded). An --if-status value is validated against the same built-in +
+// custom status set as --status, so a typo fails fast instead of mismatching
+// forever.
+func updateGuardsFromFlags(cmd *cobra.Command, claimFlag bool, updates map[string]interface{}) (ifAssignee, ifStatus *string, ifFence *int64, err error) {
 	if cmd.Flags().Changed("if-assignee") {
 		v, _ := cmd.Flags().GetString("if-assignee")
 		ifAssignee = &v
@@ -775,15 +818,18 @@ func updateGuardsFromFlags(cmd *cobra.Command, claimFlag bool, updates map[strin
 			}
 		}
 		if !types.Status(v).IsValidWithCustom(customStatuses) {
-			return nil, nil, HandleErrorRespectJSON("invalid --if-status %q (built-in: open, in_progress, blocked, deferred, closed, pinned, hooked; or configure custom statuses via 'bd config set status.custom')", v)
+			return nil, nil, nil, HandleErrorRespectJSON("invalid --if-status %q (built-in: open, in_progress, blocked, deferred, closed, pinned, hooked; or configure custom statuses via 'bd config set status.custom')", v)
 		}
 		ifStatus = &v
 	}
-	if ifAssignee == nil && ifStatus == nil {
-		return nil, nil, nil
+	if ifFence, err = ifFenceGuardFromFlags(cmd); err != nil {
+		return nil, nil, nil, err
+	}
+	if ifAssignee == nil && ifStatus == nil && ifFence == nil {
+		return nil, nil, nil, nil
 	}
 	if claimFlag {
-		return nil, nil, HandleErrorRespectJSON("cannot combine --if-assignee/--if-status with --claim (--claim is already an atomic compare-and-set)")
+		return nil, nil, nil, HandleErrorRespectJSON("cannot combine --if-assignee/--if-status/--if-fence with --claim (--claim is already an atomic compare-and-set, and it bumps the claim fence a pre-claim --if-fence would name)")
 	}
 	hasFieldUpdate := false
 	for k := range updates {
@@ -794,9 +840,9 @@ func updateGuardsFromFlags(cmd *cobra.Command, claimFlag bool, updates map[strin
 		}
 	}
 	if !hasFieldUpdate {
-		return nil, nil, HandleErrorRespectJSON("--if-assignee/--if-status require at least one field update (e.g. -a, -s); label and parent edits are not covered by the guard")
+		return nil, nil, nil, HandleErrorRespectJSON("--if-assignee/--if-status/--if-fence require at least one field update (e.g. -a, -s); label and parent edits are not covered by the guard")
 	}
-	return ifAssignee, ifStatus, nil
+	return ifAssignee, ifStatus, ifFence, nil
 }
 
 func init() {
@@ -821,12 +867,15 @@ func init() {
 	// Conditional (compare-and-set) update guards (bd-wsqvw)
 	updateCmd.Flags().String("if-assignee", "", "Apply the update only if the current assignee equals this value (--if-assignee '' requires unassigned); a mismatch writes nothing and exits 13 (vs 1 for other failures). Requires a field update; cannot combine with --claim")
 	updateCmd.Flags().String("if-status", "", "Apply the update only if the current status equals this value; a mismatch writes nothing and exits 13 (vs 1 for other failures). Requires a field update; cannot combine with --claim")
+	updateCmd.Flags().Int64("if-fence", 0, "Apply the update only if the claim fence equals this value (monotonic ownership token from claim_fence in bd show --json; --if-fence 0 requires never-claimed); a mismatch writes nothing and exits 13. Requires a field update; cannot combine with --claim")
 	// --force (unconditional bypass of the reassign fence) and --if-assignee
 	// (write only while a specific assignee still holds it) encode
 	// contradictory intent — same rationale as unclaim's pairing. Rejecting the
 	// combination stops a script that habitually passes --force from silently
-	// dropping its --if-assignee guard.
+	// dropping its --if-assignee guard. --if-fence is held to the same rule so
+	// the guard family behaves uniformly on update.
 	updateCmd.MarkFlagsMutuallyExclusive("force", "if-assignee")
+	updateCmd.MarkFlagsMutuallyExclusive("force", "if-fence")
 	updateCmd.Flags().String("session", "", "Claude Code session ID for status=closed (or set CLAUDE_SESSION_ID env var)")
 	// Time-based scheduling flags (GH#820)
 	// Examples:

--- a/cmd/bd/update_conditional_proxied_test.go
+++ b/cmd/bd/update_conditional_proxied_test.go
@@ -4,9 +4,12 @@ package main
 
 import (
 	"errors"
+	"fmt"
 	"os/exec"
 	"strings"
 	"testing"
+
+	"github.com/steveyegge/beads/internal/types"
 )
 
 // bdProxiedUpdateFailCode runs a proxied "bd update" expecting failure and
@@ -101,6 +104,143 @@ func TestProxiedServerUpdateIfGuards(t *testing.T) {
 		out := bdProxiedUpdateFail(t, bd, p.dir, issue.ID, "--if-assignee", "", "--claim")
 		if !strings.Contains(out, "--claim") {
 			t.Errorf("expected the --claim exclusion in the error, got:\n%s", out)
+		}
+	})
+}
+
+// TestProxiedServerUpdateIfFence proves --if-fence threads through the proxied
+// path the same way --if-assignee/--if-status do: the guard rides
+// domain.UpdateSpec.ExpectedFence into ApplyUpdate, which re-reads the row
+// inside the unit of work's transaction. A stale fence is a terminal per-issue
+// failure with the guard-mismatch exit code and nothing written; and because
+// the fence only tracks OWNERSHIP, it still refuses a claim that was released
+// and re-taken by the same assignee, which --if-assignee cannot detect.
+func TestProxiedServerUpdateIfFence(t *testing.T) {
+	requireSharedProxiedServer(t)
+	t.Parallel()
+	bd := buildEmbeddedBD(t)
+
+	t.Run("stale_fence_loses_with_exit_13", func(t *testing.T) {
+		t.Parallel()
+		p := newSharedProxiedProject(t, bd, "ufp")
+		issue := bdProxiedCreate(t, bd, p.dir, "Fence via proxy")
+		if out, err := bdProxiedRun(t, bd, p.dir, "update", issue.ID, "--assignee", "worker", "--status", "in_progress"); err != nil {
+			t.Fatalf("seed assign failed: %v\n%s", err, out)
+		}
+		fence := bdProxiedShow(t, bd, p.dir, issue.ID).ClaimFence
+		if fence == 0 {
+			t.Fatalf("claim_fence = 0 after an assignee change on the proxied path")
+		}
+
+		// The live fence applies.
+		if out, err := bdProxiedRun(t, bd, p.dir, "update", issue.ID,
+			"--if-fence", fmt.Sprint(fence), "--notes", "still mine"); err != nil {
+			t.Fatalf("guarded update with a live fence failed: %v\n%s", err, out)
+		}
+		if got := bdProxiedShow(t, bd, p.dir, issue.ID).Notes; got != "still mine" {
+			t.Fatalf("notes = %q after a matching --if-fence, want %q", got, "still mine")
+		}
+
+		// Ownership cycles back to the same assignee; only the fence moved.
+		if out, err := bdProxiedRun(t, bd, p.dir, "unclaim", issue.ID, "--actor", "worker"); err != nil {
+			t.Fatalf("release failed: %v\n%s", err, out)
+		}
+		if out, err := bdProxiedRun(t, bd, p.dir, "update", issue.ID, "--assignee", "worker", "--status", "in_progress"); err != nil {
+			t.Fatalf("re-assign failed: %v\n%s", err, out)
+		}
+
+		out, code := bdProxiedUpdateFailCode(t, bd, p.dir, issue.ID,
+			"--if-fence", fmt.Sprint(fence), "--notes", "should-not-apply")
+		if code != ExitGuardMismatch {
+			t.Errorf("stale fence exit code = %d, want %d\n%s", code, ExitGuardMismatch, out)
+		}
+		if !strings.Contains(out, "fence") {
+			t.Errorf("mismatch error should name the fence, got:\n%s", out)
+		}
+		if got := bdProxiedShow(t, bd, p.dir, issue.ID).Notes; got != "still mine" {
+			t.Errorf("stale --if-fence wrote through: notes = %q, want unchanged", got)
+		}
+	})
+
+	t.Run("proxied_claim_bumps_the_fence", func(t *testing.T) {
+		t.Parallel()
+		p := newSharedProxiedProject(t, bd, "ufb")
+		issue := bdProxiedCreate(t, bd, p.dir, "Claim bumps via proxy")
+
+		before := bdProxiedShow(t, bd, p.dir, issue.ID).ClaimFence
+		if before != 0 {
+			t.Fatalf("pristine claim_fence = %d, want 0", before)
+		}
+
+		// The proxied claim CAS lives in internal/storage/domain/db, a hand-
+		// written dual of issueops.ClaimIssueInTx that composes the bump as a
+		// FRAGMENT — invisible to the source-literal pairing scan. Nothing but a
+		// behavioral pin here proves the proxied dispatch layer actually bumps.
+		if out, err := bdProxiedRun(t, bd, p.dir, "update", issue.ID, "--claim"); err != nil {
+			t.Fatalf("proxied claim failed: %v\n%s", err, out)
+		}
+		after := bdProxiedShow(t, bd, p.dir, issue.ID).ClaimFence
+		if after <= before {
+			t.Errorf("claim_fence = %d after a proxied claim, want greater than %d", after, before)
+		}
+	})
+
+	t.Run("negative_if_fence_is_a_usage_error", func(t *testing.T) {
+		t.Parallel()
+		p := newSharedProxiedProject(t, bd, "ufn")
+		issue := bdProxiedCreate(t, bd, p.dir, "Negative fence via proxy")
+
+		// The proxied parse site is gatherUpdateInput, a separate reader from the
+		// direct path's updateGuardsFromFlags; both must reject it as usage.
+		out, code := bdProxiedUpdateFailCode(t, bd, p.dir, issue.ID, "--if-fence=-1", "--notes", "should-not-apply")
+		if code != 1 {
+			t.Errorf("negative --if-fence exit code = %d, want 1 (%d is reserved for real mismatches)\n%s", code, ExitGuardMismatch, out)
+		}
+		if !strings.Contains(out, "--if-fence must be >= 0") {
+			t.Errorf("expected the negative-fence rejection, got:\n%s", out)
+		}
+		if got := bdProxiedShow(t, bd, p.dir, issue.ID).Notes; got == "should-not-apply" {
+			t.Error("a rejected --if-fence still wrote through the proxied path")
+		}
+	})
+
+	t.Run("close_and_unclaim_refuse_the_fence_guard_loudly", func(t *testing.T) {
+		t.Parallel()
+		p := newSharedProxiedProject(t, bd, "ufr")
+		issue := bdProxiedCreate(t, bd, p.dir, "Unsupported fence guard")
+		if out, err := bdProxiedRun(t, bd, p.dir, "update", issue.ID, "--assignee", "worker", "--status", "in_progress"); err != nil {
+			t.Fatalf("seed assign failed: %v\n%s", err, out)
+		}
+
+		// Neither the proxied close nor the proxied release carries a
+		// compare-and-set, so the guard must be refused rather than dropped.
+		for _, args := range [][]string{
+			{"close", issue.ID, "--if-fence", "1"},
+			{"unclaim", issue.ID, "--actor", "worker", "--if-fence", "1"},
+		} {
+			stdout, stderr, err := bdProxiedRunBuffers(t, bd, p.dir, args...)
+			if err == nil {
+				t.Errorf("bd %s should be refused in proxied-server mode; got:\n%s%s",
+					strings.Join(args, " "), stdout, stderr)
+				continue
+			}
+			var ee *exec.ExitError
+			if !errors.As(err, &ee) {
+				t.Errorf("bd %s failed without an exit code: %v", strings.Join(args, " "), err)
+				continue
+			}
+			if ee.ExitCode() != 1 {
+				t.Errorf("bd %s exit code = %d, want 1", strings.Join(args, " "), ee.ExitCode())
+			}
+			if !strings.Contains(stdout+stderr, "--if-fence is not supported in proxied-server mode") {
+				t.Errorf("bd %s should name the unsupported flag, got:\n%s%s",
+					strings.Join(args, " "), stdout, stderr)
+			}
+		}
+		// The refusal must not have written anything.
+		got := bdProxiedShow(t, bd, p.dir, issue.ID)
+		if got.Assignee != "worker" || got.Status != types.StatusInProgress {
+			t.Errorf("refused guard mutated the issue: assignee=%q status=%q", got.Assignee, got.Status)
 		}
 	})
 }

--- a/cmd/bd/update_input.go
+++ b/cmd/bd/update_input.go
@@ -32,9 +32,10 @@ type updateInput struct {
 	clearDeferStatus bool
 	// bd-wsqvw conditional-update guards; non-nil only when the flag was
 	// explicitly passed (a pointer to "" is the real "expected unassigned"
-	// guard).
+	// guard, and a pointer to fence 0 the real "expected never claimed" one).
 	ifAssignee *string
 	ifStatus   *string
+	ifFence    *int64
 	// bd-98s5c: --force bypasses the live-claim reassign fence (mutually
 	// exclusive with --if-assignee at the flag-group level).
 	force bool
@@ -250,9 +251,9 @@ func gatherUpdateInput(ctx context.Context, cmd *cobra.Command) (*updateInput, e
 
 	// bd-wsqvw conditional-update guards, mirroring the non-proxied path's
 	// updateGuardsFromFlags rules: Changed()-detected presence (so
-	// `--if-assignee ""` guards on unassigned), --if-status validated against
-	// the live status set, mutually exclusive with --claim, and requiring a
-	// field update to ride on.
+	// `--if-assignee ""` guards on unassigned and `--if-fence 0` on
+	// never-claimed), --if-status validated against the live status set,
+	// mutually exclusive with --claim, and requiring a field update to ride on.
 	if cmd.Flags().Changed("if-assignee") {
 		v, _ := cmd.Flags().GetString("if-assignee")
 		in.ifAssignee = &v
@@ -264,12 +265,17 @@ func gatherUpdateInput(ctx context.Context, cmd *cobra.Command) (*updateInput, e
 		}
 		in.ifStatus = &v
 	}
-	if in.ifAssignee != nil || in.ifStatus != nil {
+	ifFence, fenceErr := ifFenceGuardFromFlags(cmd)
+	if fenceErr != nil {
+		return nil, fenceErr
+	}
+	in.ifFence = ifFence
+	if in.ifAssignee != nil || in.ifStatus != nil || in.ifFence != nil {
 		if in.claim {
-			return nil, HandleErrorRespectJSON("cannot combine --if-assignee/--if-status with --claim (--claim is already an atomic compare-and-set)")
+			return nil, HandleErrorRespectJSON("cannot combine --if-assignee/--if-status/--if-fence with --claim (--claim is already an atomic compare-and-set, and it bumps the claim fence a pre-claim --if-fence would name)")
 		}
 		if len(in.fields) == 0 && !in.hasAppendNotes && len(in.mergeMetadataIn) == 0 && len(in.setMetadata) == 0 && len(in.unsetMetadata) == 0 {
-			return nil, HandleErrorRespectJSON("--if-assignee/--if-status require at least one field update (e.g. -a, -s); label and parent edits are not covered by the guard")
+			return nil, HandleErrorRespectJSON("--if-assignee/--if-status/--if-fence require at least one field update (e.g. -a, -s); label and parent edits are not covered by the guard")
 		}
 	}
 	return in, nil

--- a/cmd/bd/update_proxied_server.go
+++ b/cmd/bd/update_proxied_server.go
@@ -308,5 +308,6 @@ func buildUpdateSpecForIssue(current *types.Issue, in *updateInput) domain.Updat
 		Reparent:         in.reparent,
 		ExpectedAssignee: in.ifAssignee,
 		ExpectedStatus:   in.ifStatus,
+		ExpectedFence:    in.ifFence,
 	}
 }

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -5,7 +5,7 @@ description: Complete reference for bd configuration across config.yaml and data
 
 Complete configuration reference for beads.
 
-Last reviewed: 2026-07-10
+Last reviewed: 2026-07-29
 
 Freshness source: `cmd/bd/main.go`, `cmd/bd/config.go`, and `internal/configfile/`.
 
@@ -279,6 +279,7 @@ These are written to the Dolt database by `bd config set` and have no env var ov
 | `min_hash_length`, `max_hash_length` | Adaptive ID bounds (defaults `3` and `8`) |
 | `max_collision_prob` | Hash ID collision tolerance (default `0.25`) |
 | `doctor.suppress.*` | Suppress specific `bd doctor` warnings by check slug (warnings only; errors always show) |
+| `lease.auto` | Whether a claim stamps a recovery lease (default on; see [below](#claim-leases)) |
 
 Issue prefix (`issue_prefix`) is **not** settable via `bd config set` — use `bd init --prefix`, `bd bootstrap`, or `bd rename-prefix`.
 
@@ -350,6 +351,21 @@ bd config set max_collision_prob "0.01"   # Stricter collision tolerance (defaul
 bd config set min_hash_length "5"         # Force minimum 5-char IDs (default 3)
 bd config set max_hash_length "8"         # Upper bound (default 8)
 ```
+
+### Claim Leases
+
+By default every claim takes a lease: the worker keeps it alive with `bd heartbeat`, and when the worker dies the lease goes stale and `bd reclaim` reverts the issue to ready. That is the right default for a fleet with no other recovery authority.
+
+Deployments where an orchestrator already tracks worker liveness can turn automatic stamping off, so a fleet that does not heartbeat is never one stray `bd reclaim` away from mass-reverting live work:
+
+```bash
+bd lease disarm                  # flip lease.auto off and clear the armed leases
+bd config set lease.auto on      # re-arm (existing claims stay unleased until re-claimed)
+```
+
+`bd lease disarm` is the safe form of the flip: it turns stamping off and clears the leases already granted in one transaction, so no in-flight claim is left reclaimable. `bd config set lease.auto off` does the flip only. Neither releases anything — status, assignee and the claim fence (`claim_fence`, the ownership token `--if-fence` guards on) are untouched.
+
+With leases off, claims carry no lease, `bd reclaim` finds nothing to reap, and `bd heartbeat` on an unleased claim is rejected instead of quietly arming one. The sweep is one-shot rather than a standing rejection: an import can restore a live lease that rode the JSONL interchange, and re-arming `lease.auto` starts stamping again — `bd reclaim` handles either normally.
 
 ## Sync and Federation
 

--- a/errors_test.go
+++ b/errors_test.go
@@ -62,6 +62,35 @@ func TestUpdateIssueOptionsIsExported(t *testing.T) {
 	}
 }
 
+// TestReExportFenceMismatch proves beads.ErrFenceMismatch composes through
+// errors.Is when wrapped — how a guarded-write caller detects a retired
+// ownership generation without importing internal/storage — and that the
+// ExpectedFence guard field is reachable on both exported options aliases, with
+// nil ("no check") as the zero value so a fence of 0 stays a real assertion.
+// Alias IDENTITY is not re-asserted here: TestReExportedSentinelIdentity's
+// table carries the ErrFenceMismatch row.
+func TestReExportFenceMismatch(t *testing.T) {
+	t.Parallel()
+
+	wrapped := fmt.Errorf("x: %w", beads.ErrFenceMismatch)
+	if !errors.Is(wrapped, beads.ErrFenceMismatch) {
+		t.Errorf("errors.Is(wrapped, beads.ErrFenceMismatch) = false; err = %v", wrapped)
+	}
+
+	zero := int64(0)
+	upd := beads.UpdateIssueOptions{ExpectedFence: &zero}
+	if upd.ExpectedFence == nil || *upd.ExpectedFence != 0 {
+		t.Fatalf("ExpectedFence did not round-trip through beads.UpdateIssueOptions: %+v", upd)
+	}
+	cls := beads.CloseIssueOptions{ExpectedFence: &zero}
+	if cls.ExpectedFence == nil || *cls.ExpectedFence != 0 {
+		t.Fatalf("ExpectedFence did not round-trip through beads.CloseIssueOptions: %+v", cls)
+	}
+	if (beads.UpdateIssueOptions{}).ExpectedFence != nil || (beads.CloseIssueOptions{}).ExpectedFence != nil {
+		t.Fatal("zero-value options must have a nil ExpectedFence (no check), so &0 stays a real guard")
+	}
+}
+
 // TestReExportedSentinelIdentity proves each public sentinel is the SAME value
 // as the internal one it aliases, so errors.Is composes across the package
 // boundary without any bridging.
@@ -77,6 +106,7 @@ func TestReExportedSentinelIdentity(t *testing.T) {
 		{"ErrAlreadyClaimed", beads.ErrAlreadyClaimed, storage.ErrAlreadyClaimed},
 		{"ErrNotClaimable", beads.ErrNotClaimable, storage.ErrNotClaimable},
 		{"ErrVersionMismatch", beads.ErrVersionMismatch, storage.ErrVersionMismatch},
+		{"ErrFenceMismatch", beads.ErrFenceMismatch, storage.ErrFenceMismatch},
 		{"ErrSelfDependency", beads.ErrSelfDependency, domain.ErrSelfDependency},
 		{"ErrDependencyCycle", beads.ErrDependencyCycle, domain.ErrDependencyCycle},
 		{"ErrFieldTooLong", beads.ErrFieldTooLong, types.ErrFieldTooLong},

--- a/internal/jira/tracker_test.go
+++ b/internal/jira/tracker_test.go
@@ -754,9 +754,11 @@ func (s *configStore) MergeMetadata(_ context.Context, _, _ string, _ json.RawMe
 func (s *configStore) SlotGet(_ context.Context, _, _ string) (string, error) {
 	return "", nil
 }
-func (s *configStore) SlotClear(_ context.Context, _, _, _ string) error                { return nil }
-func (s *configStore) UnclaimIssue(_ context.Context, _ string, _ string, _ bool) error { return nil }
-func (s *configStore) UnclaimIssueIfAssignee(_ context.Context, _ string, _ string, _ string) error {
+func (s *configStore) SlotClear(_ context.Context, _, _, _ string) error { return nil }
+func (s *configStore) UnclaimIssue(_ context.Context, _ string, _ string, _ bool, _ *int64) error {
+	return nil
+}
+func (s *configStore) UnclaimIssueIfAssignee(_ context.Context, _ string, _ string, _ string, _ *int64) error {
 	return nil
 }
 

--- a/internal/storage/bulk_issues.go
+++ b/internal/storage/bulk_issues.go
@@ -17,7 +17,9 @@ type BulkIssueStore interface {
 	ClaimReadyIssue(ctx context.Context, filter types.WorkFilter, actor string) (*types.Issue, error)
 	// HeartbeatIssue refreshes the lease on an in_progress issue held by actor,
 	// pushing its expiry forward so a reaper won't reclaim it. Returns
-	// ErrNotClaimable/ErrAlreadyClaimed if actor no longer holds the lease.
+	// ErrNotClaimable/ErrAlreadyClaimed if actor no longer holds the lease, and
+	// ErrUnleased when actor does hold the claim but the store disarmed
+	// automatic leases (heartbeat renews, it never arms).
 	HeartbeatIssue(ctx context.Context, id, actor string) error
 	// ReclaimExpiredLeases reverts in_progress issues whose lease expired more
 	// than olderThan ago back to ready (clearing the assignee), recovering work
@@ -25,6 +27,12 @@ type BulkIssueStore interface {
 	// (the zero ReclaimFilter reclaims globally, the historical behavior).
 	// Returns the issues it reclaimed.
 	ReclaimExpiredLeases(ctx context.Context, olderThan time.Duration, filter types.ReclaimFilter, actor string) ([]types.ReclaimedLease, error)
+	// DisarmAutoLeases turns automatic lease stamping off (the lease.auto
+	// config key) and clears the lease rows of the claims already holding one,
+	// so the flip and the removal of the existing reclaim exposure land in one
+	// transaction. Nothing is released: status, assignee and the ownership
+	// fence are untouched. Returns the number of lease rows cleared.
+	DisarmAutoLeases(ctx context.Context) (int64, error)
 	PromoteFromEphemeral(ctx context.Context, id string, actor string) error
 	GetNextChildID(ctx context.Context, parentID string) (string, error)
 }

--- a/internal/storage/conformance/claim.go
+++ b/internal/storage/conformance/claim.go
@@ -43,6 +43,25 @@ func testClaim(t *testing.T, f Factory) {
 	}
 }
 
+// testClaimBumpsFence: a claim is an ownership transition, so it advances the
+// row's claim_fence off the never-claimed 0 and the value is readable back
+// through the normal hydration path (migration 0062 + ignored/0019). The
+// idempotent re-claim below is the case that does NOT bump.
+func testClaimBumpsFence(t *testing.T, f Factory) {
+	s := f(t)
+	c := ctx()
+	must(t, s.CreateIssue(c, withDefaults(&types.Issue{ID: "cl-fence-1", Title: "T", Status: types.StatusOpen}), "a"))
+	must(t, s.ClaimIssue(c, "cl-fence-1", "alice"))
+	got, err := s.GetIssue(c, "cl-fence-1")
+	must(t, err)
+	if got.ClaimFence == 0 {
+		t.Error("claim did not bump claim_fence off zero")
+	}
+	if got.Assignee != "alice" || got.Status != types.StatusInProgress {
+		t.Errorf("after claim: assignee=%q status=%q", got.Assignee, got.Status)
+	}
+}
+
 // testClaimIdempotent: re-claiming an in_progress issue by the SAME actor is a no-op
 // success (supports agent retry workflows).
 func testClaimIdempotent(t *testing.T, f Factory) {

--- a/internal/storage/conformance/claim.go
+++ b/internal/storage/conformance/claim.go
@@ -298,7 +298,7 @@ func testUnclaimIfAssigneeMatch(t *testing.T, f Factory) {
 	must(t, s.CreateIssue(ctx(), withDefaults(&types.Issue{ID: "ur-1", Title: "T"}), "a"))
 	must(t, s.ClaimIssue(ctx(), "ur-1", "worker1"))
 
-	must(t, s.UnclaimIssueIfAssignee(ctx(), "ur-1", "releaser", "worker1"))
+	must(t, s.UnclaimIssueIfAssignee(ctx(), "ur-1", "releaser", "worker1", nil))
 	got, err := s.GetIssue(ctx(), "ur-1")
 	must(t, err)
 	if got.Assignee != "" {
@@ -308,7 +308,7 @@ func testUnclaimIfAssigneeMatch(t *testing.T, f Factory) {
 		t.Errorf("after conditional release: status = %q, want open", got.Status)
 	}
 
-	err = s.UnclaimIssueIfAssignee(ctx(), "ur-1", "releaser", "worker1")
+	err = s.UnclaimIssueIfAssignee(ctx(), "ur-1", "releaser", "worker1", nil)
 	if !errors.Is(err, storage.ErrAssigneeMismatch) {
 		t.Errorf("repeat conditional release: err = %v, want ErrAssigneeMismatch", err)
 	}
@@ -325,7 +325,7 @@ func testUnclaimIfAssigneeStale(t *testing.T, f Factory) {
 	must(t, s.CreateIssue(ctx(), withDefaults(&types.Issue{ID: "ur-2", Title: "T"}), "a"))
 	must(t, s.ClaimIssue(ctx(), "ur-2", "worker2"))
 
-	err := s.UnclaimIssueIfAssignee(ctx(), "ur-2", "releaser", "worker1")
+	err := s.UnclaimIssueIfAssignee(ctx(), "ur-2", "releaser", "worker1", nil)
 	if !errors.Is(err, storage.ErrAssigneeMismatch) {
 		t.Errorf("stale conditional release: err = %v, want ErrAssigneeMismatch", err)
 	}
@@ -345,5 +345,97 @@ func testUnclaimIfAssigneeStale(t *testing.T, f Factory) {
 		if e.EventType == types.EventType("unclaimed") {
 			t.Errorf("stale conditional release recorded an unclaimed event: %+v", e)
 		}
+	}
+}
+
+// testGuardedReleaseFenceConflict: a release pinned to an ownership generation
+// (UnclaimIssue/UnclaimIssueIfAssignee expectedFence) must refuse with
+// storage.ErrFenceMismatch once that generation has been retired, and succeed
+// against a freshly observed one. The intervening transition here is a release
+// and re-claim by the SAME actor: the assignee is identical afterwards, so this
+// is exactly the stomp window --if-assignee cannot see.
+func testGuardedReleaseFenceConflict(t *testing.T, f Factory) {
+	s := f(t)
+	c := ctx()
+	fptr := func(v int64) *int64 { return &v }
+
+	must(t, s.CreateIssue(c, withDefaults(&types.Issue{ID: "gf-1", Title: "T"}), "a"))
+	must(t, s.ClaimIssue(c, "gf-1", "worker1"))
+	snapshot, err := s.GetIssue(c, "gf-1")
+	must(t, err)
+
+	// Ownership moves on while the caller holds its snapshot.
+	must(t, s.UnclaimIssue(c, "gf-1", "worker1", false, nil))
+	must(t, s.ClaimIssue(c, "gf-1", "worker1"))
+
+	if err := s.UnclaimIssue(c, "gf-1", "worker1", false, fptr(snapshot.ClaimFence)); !errors.Is(err, storage.ErrFenceMismatch) {
+		t.Errorf("stale guarded release: err = %v, want ErrFenceMismatch", err)
+	}
+	live, err := s.GetIssue(c, "gf-1")
+	must(t, err)
+	if live.Assignee != "worker1" || live.Status != types.StatusInProgress {
+		t.Errorf("refused release disturbed the live claim: assignee=%q status=%q", live.Assignee, live.Status)
+	}
+
+	// A guard establishes freshness, not authority: the live fence does not let
+	// a non-owner release the claim.
+	if err := s.UnclaimIssue(c, "gf-1", "stranger", false, fptr(live.ClaimFence)); !errors.Is(err, storage.ErrNotOwner) {
+		t.Errorf("cross-actor release with a live fence: err = %v, want ErrNotOwner", err)
+	}
+
+	// Re-observed fence: both release forms accept it.
+	if err := s.UnclaimIssueIfAssignee(c, "gf-1", "supervisor", "worker1", fptr(live.ClaimFence)); err != nil {
+		t.Errorf("guarded conditional release with a fresh fence: %v", err)
+	}
+	got, err := s.GetIssue(c, "gf-1")
+	must(t, err)
+	if got.Assignee != "" || got.Status != types.StatusOpen {
+		t.Errorf("after guarded release: assignee=%q status=%q, want unassigned/open", got.Assignee, got.Status)
+	}
+	if got.ClaimFence != live.ClaimFence+1 {
+		t.Errorf("claim_fence = %d after release, want %d", got.ClaimFence, live.ClaimFence+1)
+	}
+}
+
+// testGuardedCloseFenceConflict: CloseIssueOptions.ExpectedFence stops a worker
+// whose claim was retired from completing the bead with its stale snapshot,
+// while a caller quoting the current fence closes — and can re-close
+// idempotently, since close is not an ownership transition and leaves the fence
+// where it was.
+func testGuardedCloseFenceConflict(t *testing.T, f Factory) {
+	s := f(t)
+	c := ctx()
+	fptr := func(v int64) *int64 { return &v }
+
+	must(t, s.CreateIssue(c, withDefaults(&types.Issue{ID: "gf-2", Title: "T"}), "a"))
+	must(t, s.ClaimIssue(c, "gf-2", "worker1"))
+	stale, err := s.GetIssue(c, "gf-2")
+	must(t, err)
+
+	must(t, s.UnclaimIssue(c, "gf-2", "worker1", false, nil))
+	must(t, s.ClaimIssue(c, "gf-2", "worker2"))
+
+	if _, err := s.CloseIssueChecked(c, "gf-2", "worker1",
+		storage.CloseIssueOptions{Reason: "stale completion", ExpectedFence: fptr(stale.ClaimFence)}); !errors.Is(err, storage.ErrFenceMismatch) {
+		t.Errorf("zombie close: err = %v, want ErrFenceMismatch", err)
+	}
+	live, err := s.GetIssue(c, "gf-2")
+	must(t, err)
+	if live.Status == types.StatusClosed {
+		t.Fatalf("zombie close landed; status = %q", live.Status)
+	}
+
+	res, err := s.CloseIssueChecked(c, "gf-2", "worker2",
+		storage.CloseIssueOptions{Reason: "done", ExpectedFence: fptr(live.ClaimFence)})
+	must(t, err)
+	if res.Unchanged {
+		t.Error("close with the live fence reported Unchanged, want a real close")
+	}
+
+	res, err = s.CloseIssueChecked(c, "gf-2", "worker2",
+		storage.CloseIssueOptions{Reason: "again", ExpectedFence: fptr(live.ClaimFence)})
+	must(t, err)
+	if !res.Unchanged {
+		t.Error("guarded re-close of an already-closed issue: Unchanged = false, want true")
 	}
 }

--- a/internal/storage/conformance/conformance.go
+++ b/internal/storage/conformance/conformance.go
@@ -145,6 +145,7 @@ func RunAll(t *testing.T, factory Factory) {
 
 	// Claim / lease (dead-worker recovery)
 	t.Run("Claim", func(t *testing.T) { testClaim(t, factory) })
+	t.Run("ClaimBumpsFence", func(t *testing.T) { testClaimBumpsFence(t, factory) })
 	t.Run("ClaimIdempotent", func(t *testing.T) { testClaimIdempotent(t, factory) })
 	t.Run("ClaimAlreadyClaimed", func(t *testing.T) { testClaimAlreadyClaimed(t, factory) })
 	t.Run("ClaimOpenForeignAssignee", func(t *testing.T) { testClaimOpenForeignAssignee(t, factory) })

--- a/internal/storage/conformance/conformance.go
+++ b/internal/storage/conformance/conformance.go
@@ -159,6 +159,8 @@ func RunAll(t *testing.T, factory Factory) {
 	t.Run("ReclaimScoped", func(t *testing.T) { testReclaimScoped(t, factory) })
 	t.Run("UnclaimIfAssigneeMatch", func(t *testing.T) { testUnclaimIfAssigneeMatch(t, factory) })
 	t.Run("UnclaimIfAssigneeStale", func(t *testing.T) { testUnclaimIfAssigneeStale(t, factory) })
+	t.Run("GuardedReleaseFenceConflict", func(t *testing.T) { testGuardedReleaseFenceConflict(t, factory) })
+	t.Run("GuardedCloseFenceConflict", func(t *testing.T) { testGuardedCloseFenceConflict(t, factory) })
 
 	// Labels
 	t.Run("Labels", func(t *testing.T) { testLabels(t, factory) })

--- a/internal/storage/dolt/claim_verify.go
+++ b/internal/storage/dolt/claim_verify.go
@@ -86,7 +86,10 @@ func unclaimed() claimPostcondition {
 // machinery: keep guarded coordination writes single-purpose (assignee/status
 // only), which is how the wheelhouse park/restore consumers use them.
 func guardedUpdatePostcondition(opts storage.UpdateIssueOptions, updates map[string]interface{}) (claimPostcondition, bool) {
-	if opts.ExpectedAssignee == nil && opts.ExpectedStatus == nil {
+	// ExpectedFence joins the trigger set: a fence-guarded coordination write
+	// is claim-family for the same reason, and the replay is equally safe
+	// because the fence is re-checked inside the replayed transaction.
+	if opts.ExpectedAssignee == nil && opts.ExpectedStatus == nil && opts.ExpectedFence == nil {
 		return claimPostcondition{}, false
 	}
 	newAssignee, setsAssignee := updates["assignee"].(string)

--- a/internal/storage/dolt/claim_verify_test.go
+++ b/internal/storage/dolt/claim_verify_test.go
@@ -231,7 +231,7 @@ func TestClaimUnclaimVerifiedEndToEnd(t *testing.T) {
 		t.Fatalf("idempotent re-claim: %v", err)
 	}
 
-	if err := s.UnclaimIssue(ctx, id, "alice", false); err != nil {
+	if err := s.UnclaimIssue(ctx, id, "alice", false, nil); err != nil {
 		t.Fatalf("unclaim: %v", err)
 	}
 	assignee, status, err = s.readClaimState(ctx, id)

--- a/internal/storage/dolt/close_issue_checked_test.go
+++ b/internal/storage/dolt/close_issue_checked_test.go
@@ -640,3 +640,286 @@ func TestCloseIssueCheckedVersionCAS(t *testing.T) {
 		}
 	})
 }
+
+// TestCloseIssueCheckedFenceCAS exercises CloseIssueOptions.ExpectedFence — the
+// ownership-generation guard behind `bd close --if-fence`. It closes the P2
+// "zombie completion" window: a worker whose lease was reclaimed and re-issued
+// must not be able to complete the bead with the snapshot it took before it was
+// evicted, even when the row came back to an assignee with the same name. The
+// guard runs before the is_blocked guard and Force bypasses neither, and — since
+// it is evaluated against the row's CURRENT fence — an already-closed row keeps
+// its idempotent Unchanged=true result for a caller quoting that same fence.
+func TestCloseIssueCheckedFenceCAS(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	getIssue := func(t *testing.T, id string) *types.Issue {
+		t.Helper()
+		iss, err := store.GetIssue(ctx, id)
+		if err != nil {
+			t.Fatalf("GetIssue(%s): %v", id, err)
+		}
+		if iss == nil {
+			t.Fatalf("GetIssue(%s) returned nil issue", id)
+		}
+		return iss
+	}
+	countClosed := func(t *testing.T, id string) int {
+		t.Helper()
+		events, err := store.GetEvents(ctx, id, 0)
+		if err != nil {
+			t.Fatalf("GetEvents(%s): %v", id, err)
+		}
+		n := 0
+		for _, e := range events {
+			if e.EventType == types.EventClosed {
+				n++
+			}
+		}
+		return n
+	}
+	ptr := func(v int64) *int64 { return &v }
+
+	t.Run("fresh fence closes", func(t *testing.T) {
+		createPerm(t, ctx, store, "fcas-fresh")
+		if err := store.ClaimIssue(ctx, "fcas-fresh", "worker"); err != nil {
+			t.Fatalf("seed claim: %v", err)
+		}
+		fence := getIssue(t, "fcas-fresh").ClaimFence
+		res, err := store.CloseIssueChecked(ctx, "fcas-fresh", "worker",
+			storage.CloseIssueOptions{Reason: "done", ExpectedFence: ptr(fence)})
+		if err != nil {
+			t.Fatalf("close with live fence err = %v, want nil", err)
+		}
+		if res.Unchanged {
+			t.Fatalf("res.Unchanged = true, want false (a real close)")
+		}
+		if got := getIssue(t, "fcas-fresh").Status; got != types.StatusClosed {
+			t.Fatalf("status = %q, want closed", got)
+		}
+	})
+
+	t.Run("stale fence refuses atomically", func(t *testing.T) {
+		createPerm(t, ctx, store, "fcas-zombie")
+		if err := store.ClaimIssue(ctx, "fcas-zombie", "worker"); err != nil {
+			t.Fatalf("seed claim: %v", err)
+		}
+		zombie := getIssue(t, "fcas-zombie").ClaimFence
+		// The claim is released and re-taken by the same-named actor: the
+		// zombie's assignee snapshot still matches, only the fence moved.
+		if err := store.UnclaimIssue(ctx, "fcas-zombie", "worker", false, nil); err != nil {
+			t.Fatalf("unclaim: %v", err)
+		}
+		if err := store.ClaimIssue(ctx, "fcas-zombie", "worker"); err != nil {
+			t.Fatalf("re-claim: %v", err)
+		}
+		res, err := store.CloseIssueChecked(ctx, "fcas-zombie", "worker",
+			storage.CloseIssueOptions{Reason: "stale completion", ExpectedFence: ptr(zombie)})
+		if !errors.Is(err, storage.ErrFenceMismatch) {
+			t.Fatalf("err = %v, want errors.Is(_, ErrFenceMismatch)", err)
+		}
+		if res.Unchanged {
+			t.Fatalf("res.Unchanged = true on mismatch, want false")
+		}
+		if got := getIssue(t, "fcas-zombie").Status; got == types.StatusClosed {
+			t.Fatalf("zombie close landed; the fence CAS did not abort the tx")
+		}
+		if n := countClosed(t, "fcas-zombie"); n != 0 {
+			t.Fatalf("closed event count = %d, want 0 (tx must have rolled back)", n)
+		}
+	})
+
+	t.Run("Force does not bypass the fence check", func(t *testing.T) {
+		createPerm(t, ctx, store, "fcas-force")
+		if err := store.ClaimIssue(ctx, "fcas-force", "worker"); err != nil {
+			t.Fatalf("seed claim: %v", err)
+		}
+		fence := getIssue(t, "fcas-force").ClaimFence
+		res, err := store.CloseIssueChecked(ctx, "fcas-force", "worker",
+			storage.CloseIssueOptions{Reason: "done", Force: true, ExpectedFence: ptr(fence + 1)})
+		if !errors.Is(err, storage.ErrFenceMismatch) {
+			t.Fatalf("err = %v, want errors.Is(_, ErrFenceMismatch) even with Force", err)
+		}
+		if res.Unchanged {
+			t.Fatalf("res.Unchanged = true on mismatch+Force, want false")
+		}
+		if got := getIssue(t, "fcas-force").Status; got == types.StatusClosed {
+			t.Fatalf("closed under Force despite a stale fence; the guard is not orthogonal to Force")
+		}
+	})
+
+	t.Run("already closed re-close with the same fence is idempotent", func(t *testing.T) {
+		createPerm(t, ctx, store, "fcas-idem")
+		if err := store.ClaimIssue(ctx, "fcas-idem", "worker"); err != nil {
+			t.Fatalf("seed claim: %v", err)
+		}
+		fence := getIssue(t, "fcas-idem").ClaimFence
+		if _, err := store.CloseIssueChecked(ctx, "fcas-idem", "worker",
+			storage.CloseIssueOptions{Reason: "done", ExpectedFence: ptr(fence)}); err != nil {
+			t.Fatalf("initial close err = %v, want nil", err)
+		}
+		// Close does not bump the fence, so the caller's snapshot is still
+		// current and the retry must reach the idempotent no-op rather than a
+		// spurious mismatch.
+		if got := getIssue(t, "fcas-idem").ClaimFence; got != fence {
+			t.Fatalf("claim_fence = %d after close, want %d (close is not an ownership transition)", got, fence)
+		}
+		res, err := store.CloseIssueChecked(ctx, "fcas-idem", "worker",
+			storage.CloseIssueOptions{Reason: "again", ExpectedFence: ptr(fence)})
+		if err != nil {
+			t.Fatalf("re-close with the same fence err = %v, want nil (guard passes, idempotent)", err)
+		}
+		if !res.Unchanged {
+			t.Fatalf("res.Unchanged = false, want true (already closed)")
+		}
+		if n := countClosed(t, "fcas-idem"); n != 1 {
+			t.Fatalf("closed event count = %d, want 1 (no second close)", n)
+		}
+	})
+
+	t.Run("already closed re-close with a stale fence still refuses", func(t *testing.T) {
+		createPerm(t, ctx, store, "fcas-idem-stale")
+		if err := store.ClaimIssue(ctx, "fcas-idem-stale", "worker"); err != nil {
+			t.Fatalf("seed claim: %v", err)
+		}
+		fence := getIssue(t, "fcas-idem-stale").ClaimFence
+		if _, err := store.CloseIssueChecked(ctx, "fcas-idem-stale", "worker",
+			storage.CloseIssueOptions{Reason: "done"}); err != nil {
+			t.Fatalf("initial close err = %v, want nil", err)
+		}
+		// The guard is checked against the row's current state, so idempotency
+		// is not a licence to skip it: a superseded snapshot is still refused.
+		res, err := store.CloseIssueChecked(ctx, "fcas-idem-stale", "worker",
+			storage.CloseIssueOptions{Reason: "again", ExpectedFence: ptr(fence + 1)})
+		if !errors.Is(err, storage.ErrFenceMismatch) {
+			t.Fatalf("err = %v, want errors.Is(_, ErrFenceMismatch) on an already-closed row", err)
+		}
+		if res.Unchanged {
+			t.Fatalf("res.Unchanged = true on mismatch, want false")
+		}
+		if n := countClosed(t, "fcas-idem-stale"); n != 1 {
+			t.Fatalf("closed event count = %d, want 1", n)
+		}
+	})
+
+	t.Run("nil ExpectedFence skips the check", func(t *testing.T) {
+		createPerm(t, ctx, store, "fcas-nil")
+		if err := store.ClaimIssue(ctx, "fcas-nil", "worker"); err != nil {
+			t.Fatalf("seed claim: %v", err)
+		}
+		res, err := store.CloseIssueChecked(ctx, "fcas-nil", "worker",
+			storage.CloseIssueOptions{Reason: "done", ExpectedFence: nil})
+		if err != nil {
+			t.Fatalf("nil ExpectedFence close err = %v, want nil (back-compat)", err)
+		}
+		if res.Unchanged {
+			t.Fatalf("res.Unchanged = true, want false (a real close)")
+		}
+	})
+
+	// closeWispChecked runs the same guard on the bare-tx wisp path: a stale
+	// fence must leave the wisp untouched via the deferred Rollback.
+	t.Run("wisp fence guard routes to wisps table", func(t *testing.T) {
+		createWisp(t, ctx, store, "fcas-wisp")
+		res, err := store.CloseIssueChecked(ctx, "fcas-wisp", "tester",
+			storage.CloseIssueOptions{Reason: "done", ExpectedFence: ptr(9)})
+		if !errors.Is(err, storage.ErrFenceMismatch) {
+			t.Fatalf("wisp err = %v, want errors.Is(_, ErrFenceMismatch)", err)
+		}
+		if res.Unchanged {
+			t.Fatalf("res.Unchanged = true on wisp mismatch, want false")
+		}
+		if got := getIssue(t, "fcas-wisp").Status; got == types.StatusClosed {
+			t.Fatalf("wisp closed after a refused guard; the wisp tx did not roll back")
+		}
+		// Fence 0 is the wisp's real, never-claimed generation.
+		if _, err := store.CloseIssueChecked(ctx, "fcas-wisp", "tester",
+			storage.CloseIssueOptions{Reason: "done", ExpectedFence: ptr(0)}); err != nil {
+			t.Fatalf("wisp close with fence 0 err = %v, want nil", err)
+		}
+		if got := getIssue(t, "fcas-wisp").Status; got != types.StatusClosed {
+			t.Fatalf("wisp status = %q, want closed", got)
+		}
+	})
+
+	// ExpectedVersion and ExpectedFence are independent preconditions on the
+	// same close, and CloseIssueCheckedInTx evaluates them in that order. The
+	// conjunction is the interesting case: either one alone failing must refuse
+	// the whole close, and only both holding may let it through. Without this,
+	// a fold that dropped one of the two checks would still pass every
+	// single-guard test above.
+	t.Run("version and fence conjoin", func(t *testing.T) {
+		rowVersion := func(t *testing.T, id string) int64 {
+			t.Helper()
+			return getIssue(t, id).RowVersion
+		}
+
+		// Stale version, live fence: the version check runs first and wins.
+		createPerm(t, ctx, store, "fcas-both-v")
+		if err := store.ClaimIssue(ctx, "fcas-both-v", "worker"); err != nil {
+			t.Fatalf("seed claim: %v", err)
+		}
+		res, err := store.CloseIssueChecked(ctx, "fcas-both-v", "worker", storage.CloseIssueOptions{
+			Reason:          "done",
+			ExpectedVersion: ptr(rowVersion(t, "fcas-both-v") + 1),
+			ExpectedFence:   ptr(getIssue(t, "fcas-both-v").ClaimFence),
+		})
+		if !errors.Is(err, storage.ErrVersionMismatch) {
+			t.Fatalf("stale version + live fence: err = %v, want errors.Is(_, ErrVersionMismatch)", err)
+		}
+		if res.Unchanged {
+			t.Fatalf("res.Unchanged = true on mismatch, want false")
+		}
+		if got := getIssue(t, "fcas-both-v").Status; got == types.StatusClosed {
+			t.Fatalf("closed despite a stale version conjunct")
+		}
+		if n := countClosed(t, "fcas-both-v"); n != 0 {
+			t.Fatalf("closed event count = %d, want 0 (tx must have rolled back)", n)
+		}
+
+		// Live version, stale fence: the fence conjunct refuses on its own.
+		createPerm(t, ctx, store, "fcas-both-f")
+		if err := store.ClaimIssue(ctx, "fcas-both-f", "worker"); err != nil {
+			t.Fatalf("seed claim: %v", err)
+		}
+		res, err = store.CloseIssueChecked(ctx, "fcas-both-f", "worker", storage.CloseIssueOptions{
+			Reason:          "done",
+			ExpectedVersion: ptr(rowVersion(t, "fcas-both-f")),
+			ExpectedFence:   ptr(getIssue(t, "fcas-both-f").ClaimFence + 1),
+		})
+		if !errors.Is(err, storage.ErrFenceMismatch) {
+			t.Fatalf("live version + stale fence: err = %v, want errors.Is(_, ErrFenceMismatch)", err)
+		}
+		if res.Unchanged {
+			t.Fatalf("res.Unchanged = true on mismatch, want false")
+		}
+		if got := getIssue(t, "fcas-both-f").Status; got == types.StatusClosed {
+			t.Fatalf("closed despite a stale fence conjunct")
+		}
+		if n := countClosed(t, "fcas-both-f"); n != 0 {
+			t.Fatalf("closed event count = %d, want 0 (tx must have rolled back)", n)
+		}
+
+		// Both live: the close lands.
+		createPerm(t, ctx, store, "fcas-both-ok")
+		if err := store.ClaimIssue(ctx, "fcas-both-ok", "worker"); err != nil {
+			t.Fatalf("seed claim: %v", err)
+		}
+		res, err = store.CloseIssueChecked(ctx, "fcas-both-ok", "worker", storage.CloseIssueOptions{
+			Reason:          "done",
+			ExpectedVersion: ptr(rowVersion(t, "fcas-both-ok")),
+			ExpectedFence:   ptr(getIssue(t, "fcas-both-ok").ClaimFence),
+		})
+		if err != nil {
+			t.Fatalf("both guards live: err = %v, want nil", err)
+		}
+		if res.Unchanged {
+			t.Fatalf("res.Unchanged = true, want false (a real close)")
+		}
+		if got := getIssue(t, "fcas-both-ok").Status; got != types.StatusClosed {
+			t.Fatalf("status = %q, want closed", got)
+		}
+	})
+}

--- a/internal/storage/dolt/fence_test.go
+++ b/internal/storage/dolt/fence_test.go
@@ -132,7 +132,7 @@ func TestUnclaimBumpsFence(t *testing.T) {
 	seedClaimedIssue(t, ctx, store, "fence-unclaim", "alice", time.Hour)
 	before := readFenceState(t, ctx, store, "fence-unclaim")
 
-	if err := store.UnclaimIssue(ctx, "fence-unclaim", "alice", false); err != nil {
+	if err := store.UnclaimIssue(ctx, "fence-unclaim", "alice", false, nil); err != nil {
 		t.Fatalf("unclaim: %v", err)
 	}
 	assertFenceBumped(t, before, readFenceState(t, ctx, store, "fence-unclaim"), "unclaim")
@@ -149,7 +149,7 @@ func TestUnclaimIfAssigneeBumpsFence(t *testing.T) {
 	seedClaimedIssue(t, ctx, store, "fence-unclaim-cas", "alice", time.Hour)
 	before := readFenceState(t, ctx, store, "fence-unclaim-cas")
 
-	if err := store.UnclaimIssueIfAssignee(ctx, "fence-unclaim-cas", "admin", "alice"); err != nil {
+	if err := store.UnclaimIssueIfAssignee(ctx, "fence-unclaim-cas", "admin", "alice", nil); err != nil {
 		t.Fatalf("conditional unclaim: %v", err)
 	}
 	assertFenceBumped(t, before, readFenceState(t, ctx, store, "fence-unclaim-cas"), "unclaim --if-assignee")
@@ -394,7 +394,7 @@ func TestWispClaimBumpsFence(t *testing.T) {
 		t.Errorf("wisp claim_fence = %d, want %d", after, before+1)
 	}
 
-	if err := store.UnclaimIssue(ctx, "fence-wisp", "alice", false); err != nil {
+	if err := store.UnclaimIssue(ctx, "fence-wisp", "alice", false, nil); err != nil {
 		t.Fatalf("unclaim wisp: %v", err)
 	}
 	if released := wispFence(); released != after+1 {
@@ -469,7 +469,7 @@ func TestUpsertFenceDiscipline(t *testing.T) {
 	// ""/NULL normalization: release (stored assignee becomes ""), then
 	// re-import the unassigned row (binds NULL). Both mean unassigned — a
 	// content-only sync must not bump.
-	if err := store.UnclaimIssue(ctx, "fence-upsert", "carol", false); err != nil {
+	if err := store.UnclaimIssue(ctx, "fence-upsert", "carol", false, nil); err != nil {
 		t.Fatalf("unclaim: %v", err)
 	}
 	released := readFenceState(t, ctx, store, "fence-upsert")

--- a/internal/storage/dolt/fence_test.go
+++ b/internal/storage/dolt/fence_test.go
@@ -1,0 +1,555 @@
+package dolt
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/steveyegge/beads/internal/storage"
+	"github.com/steveyegge/beads/internal/storage/issueops"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// fenceState reads the fence and its paired concurrency cell directly.
+type fenceState struct {
+	fence   int64
+	rowLock int64
+}
+
+func readFenceState(t *testing.T, ctx context.Context, store *DoltStore, id string) fenceState {
+	t.Helper()
+	var fs fenceState
+	err := store.db.QueryRowContext(ctx, `
+		SELECT claim_fence, row_lock FROM issues WHERE id = ?
+	`, id).Scan(&fs.fence, &fs.rowLock)
+	if err != nil {
+		t.Fatalf("read fence state for %s: %v", id, err)
+	}
+	return fs
+}
+
+func seedOpenIssue(t *testing.T, ctx context.Context, store *DoltStore, id string) {
+	t.Helper()
+	issue := &types.Issue{
+		ID:        id,
+		Title:     "fence " + id,
+		Status:    types.StatusOpen,
+		Priority:  2,
+		IssueType: types.TypeTask,
+	}
+	if err := store.CreateIssue(ctx, issue, "seeder"); err != nil {
+		t.Fatalf("seed %s: %v", id, err)
+	}
+}
+
+// assertFenceBumped asserts the fence advanced by exactly one and row_lock was
+// rewritten in the same mutation — the pairing invariant that keeps a
+// monotonic cell from silently cell-merging under Dolt (two concurrent N→N+1
+// bumps write identical cells; only the random row_lock forces the conflict).
+func assertFenceBumped(t *testing.T, before, after fenceState, what string) {
+	t.Helper()
+	if after.fence != before.fence+1 {
+		t.Errorf("%s: claim_fence = %d, want %d (bump by exactly one)", what, after.fence, before.fence+1)
+	}
+	if after.rowLock == before.rowLock {
+		t.Errorf("%s: row_lock unchanged (%d) — every fence bump must rewrite row_lock in the same statement", what, after.rowLock)
+	}
+}
+
+// TestClaimBumpsFence: a fresh row starts at fence 0; claiming it is an
+// ownership transition and bumps to 1.
+func TestClaimBumpsFence(t *testing.T) {
+	store, cleanup := setupConcurrentTestStore(t)
+	defer cleanup()
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	seedOpenIssue(t, ctx, store, "fence-claim")
+	before := readFenceState(t, ctx, store, "fence-claim")
+	if before.fence != 0 {
+		t.Fatalf("pristine claim_fence = %d, want 0", before.fence)
+	}
+
+	if err := store.ClaimIssue(ctx, "fence-claim", "alice"); err != nil {
+		t.Fatalf("claim: %v", err)
+	}
+	assertFenceBumped(t, before, readFenceState(t, ctx, store, "fence-claim"), "claim")
+}
+
+// TestClaimOfOwnOpenRowBumpsFence pins the deliberate asymmetry in the bump
+// policy: the claim CAS bumps UNCONDITIONALLY, so claiming an OPEN row that
+// is already assigned to the claiming actor still advances the fence. That is
+// what lets a second session of one user fence out whatever the first session
+// snapshotted — two sessions are two ownership holders even under one name.
+// Contrast TestSameOwnerReclaimDoesNotBumpFence, where the row is already
+// in_progress and the CAS never matches.
+func TestClaimOfOwnOpenRowBumpsFence(t *testing.T) {
+	store, cleanup := setupConcurrentTestStore(t)
+	defer cleanup()
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	seedOpenIssue(t, ctx, store, "fence-own-open")
+	// Assign without claiming: the row stays open, so it is still claimable.
+	if err := store.UpdateIssue(ctx, "fence-own-open", map[string]interface{}{"assignee": "alice"}, "admin"); err != nil {
+		t.Fatalf("assign: %v", err)
+	}
+	before := readFenceState(t, ctx, store, "fence-own-open")
+
+	if err := store.ClaimIssue(ctx, "fence-own-open", "alice"); err != nil {
+		t.Fatalf("claim own open row: %v", err)
+	}
+	assertFenceBumped(t, before, readFenceState(t, ctx, store, "fence-own-open"), "same-actor claim of an open row")
+}
+
+// TestSameOwnerReclaimDoesNotBumpFence: the idempotent same-actor re-claim is
+// a no-write success and must not advance the ownership context.
+func TestSameOwnerReclaimDoesNotBumpFence(t *testing.T) {
+	store, cleanup := setupConcurrentTestStore(t)
+	defer cleanup()
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	seedClaimedIssue(t, ctx, store, "fence-idem", "alice", time.Hour)
+	before := readFenceState(t, ctx, store, "fence-idem")
+
+	if err := store.ClaimIssue(ctx, "fence-idem", "alice"); err != nil {
+		t.Fatalf("idempotent re-claim: %v", err)
+	}
+	after := readFenceState(t, ctx, store, "fence-idem")
+	if after.fence != before.fence {
+		t.Errorf("idempotent re-claim moved claim_fence %d → %d, want unchanged", before.fence, after.fence)
+	}
+}
+
+// TestUnclaimBumpsFence: release is an ownership transition.
+func TestUnclaimBumpsFence(t *testing.T) {
+	store, cleanup := setupConcurrentTestStore(t)
+	defer cleanup()
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	seedClaimedIssue(t, ctx, store, "fence-unclaim", "alice", time.Hour)
+	before := readFenceState(t, ctx, store, "fence-unclaim")
+
+	if err := store.UnclaimIssue(ctx, "fence-unclaim", "alice", false); err != nil {
+		t.Fatalf("unclaim: %v", err)
+	}
+	assertFenceBumped(t, before, readFenceState(t, ctx, store, "fence-unclaim"), "unclaim")
+}
+
+// TestUnclaimIfAssigneeBumpsFence: the CAS release form is the same
+// transition and carries the same bump.
+func TestUnclaimIfAssigneeBumpsFence(t *testing.T) {
+	store, cleanup := setupConcurrentTestStore(t)
+	defer cleanup()
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	seedClaimedIssue(t, ctx, store, "fence-unclaim-cas", "alice", time.Hour)
+	before := readFenceState(t, ctx, store, "fence-unclaim-cas")
+
+	if err := store.UnclaimIssueIfAssignee(ctx, "fence-unclaim-cas", "admin", "alice"); err != nil {
+		t.Fatalf("conditional unclaim: %v", err)
+	}
+	assertFenceBumped(t, before, readFenceState(t, ctx, store, "fence-unclaim-cas"), "unclaim --if-assignee")
+}
+
+// TestReclaimBumpsFence: a lease reclaim takes ownership away and must fence
+// out the previous holder.
+func TestReclaimBumpsFence(t *testing.T) {
+	store, cleanup := setupConcurrentTestStore(t)
+	defer cleanup()
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	seedClaimedIssue(t, ctx, store, "fence-reclaim", "alice", time.Second)
+	before := readFenceState(t, ctx, store, "fence-reclaim")
+	// lease_expires_at is second-granular DATETIME; sleep well past the 1s TTL
+	// so rounding can never leave the lease looking unexpired at the cutoff.
+	time.Sleep(3 * time.Second)
+
+	reclaimed, err := store.ReclaimExpiredLeases(ctx, 0, types.ReclaimFilter{}, "reaper")
+	if err != nil {
+		t.Fatalf("reclaim: %v", err)
+	}
+	if len(reclaimed) != 1 {
+		t.Fatalf("reclaimed %d issues, want 1", len(reclaimed))
+	}
+	after := readFenceState(t, ctx, store, "fence-reclaim")
+	assertFenceBumped(t, before, after, "reclaim")
+	if reclaimed[0].ClaimFence != after.fence {
+		t.Errorf("reported reclaim fence = %d, want the post-bump value %d", reclaimed[0].ClaimFence, after.fence)
+	}
+}
+
+// TestPlainUpdateDoesNotBumpFence: a content mutation on a claimed row is not
+// an ownership transition.
+func TestPlainUpdateDoesNotBumpFence(t *testing.T) {
+	store, cleanup := setupConcurrentTestStore(t)
+	defer cleanup()
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	seedClaimedIssue(t, ctx, store, "fence-plain", "alice", time.Hour)
+	before := readFenceState(t, ctx, store, "fence-plain")
+
+	if err := store.UpdateIssue(ctx, "fence-plain", map[string]interface{}{"notes": "still mine"}, "alice"); err != nil {
+		t.Fatalf("update notes: %v", err)
+	}
+	after := readFenceState(t, ctx, store, "fence-plain")
+	if after.fence != before.fence {
+		t.Errorf("plain update moved claim_fence %d → %d, want unchanged", before.fence, after.fence)
+	}
+}
+
+// TestAssigneeChangeUpdateBumpsFence: reassignment through the generic update
+// path is an ownership transition.
+func TestAssigneeChangeUpdateBumpsFence(t *testing.T) {
+	store, cleanup := setupConcurrentTestStore(t)
+	defer cleanup()
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	seedClaimedIssue(t, ctx, store, "fence-reassign", "alice", time.Hour)
+	before := readFenceState(t, ctx, store, "fence-reassign")
+
+	if err := store.UpdateIssue(ctx, "fence-reassign", map[string]interface{}{"assignee": "bob"}, "admin"); err != nil {
+		t.Fatalf("reassign: %v", err)
+	}
+	assertFenceBumped(t, before, readFenceState(t, ctx, store, "fence-reassign"), "assignee-change update")
+}
+
+// TestReopenBumpsFence: reopening a closed row resets its ownership context —
+// both through the dedicated verb and through the generic status update that
+// the dolt/embedded stores actually use for reopen.
+func TestReopenBumpsFence(t *testing.T) {
+	store, cleanup := setupConcurrentTestStore(t)
+	defer cleanup()
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	// Via generic update (the primary path on this store).
+	seedClaimedIssue(t, ctx, store, "fence-reopen-upd", "alice", time.Hour)
+	if err := store.CloseIssue(ctx, "fence-reopen-upd", "done", "alice", ""); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	closed := readFenceState(t, ctx, store, "fence-reopen-upd")
+	if err := store.UpdateIssue(ctx, "fence-reopen-upd", map[string]interface{}{"status": "open"}, "admin"); err != nil {
+		t.Fatalf("reopen via update: %v", err)
+	}
+	assertFenceBumped(t, closed, readFenceState(t, ctx, store, "fence-reopen-upd"), "reopen via update")
+
+	// Via the dedicated verb (proxied-path parity).
+	seedClaimedIssue(t, ctx, store, "fence-reopen-verb", "alice", time.Hour)
+	if err := store.CloseIssue(ctx, "fence-reopen-verb", "done", "alice", ""); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	closedVerb := readFenceState(t, ctx, store, "fence-reopen-verb")
+	if err := store.ReopenIssue(ctx, "fence-reopen-verb", "not done after all", "admin"); err != nil {
+		t.Fatalf("reopen verb: %v", err)
+	}
+	assertFenceBumped(t, closedVerb, readFenceState(t, ctx, store, "fence-reopen-verb"), "reopen verb")
+}
+
+// TestClaimAfterReopenBumpsFence exercises the SECOND claim UPDATE form. The
+// claim CAS is written as two literals: one that stamps started_at (the first
+// transition to in_progress) and one that leaves it alone because the row
+// already carries a started_at from an earlier run. Every other claim test in
+// this file hits the first. Close and reopen both PRESERVE started_at, so the
+// re-claim of a reopened row is exactly that else-branch — and it has to bump
+// too, or a worker picking a reopened issue back up would inherit the fence of
+// the generation that closed it.
+func TestClaimAfterReopenBumpsFence(t *testing.T) {
+	store, cleanup := setupConcurrentTestStore(t)
+	defer cleanup()
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	seedClaimedIssue(t, ctx, store, "fence-claim-after-reopen", "alice", time.Hour)
+	if err := store.CloseIssue(ctx, "fence-claim-after-reopen", "done", "alice", ""); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	if err := store.ReopenIssue(ctx, "fence-claim-after-reopen", "not done after all", "admin"); err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+
+	reopened, err := store.GetIssue(ctx, "fence-claim-after-reopen")
+	if err != nil {
+		t.Fatalf("get reopened: %v", err)
+	}
+	if reopened.StartedAt == nil {
+		t.Fatal("reopened row lost started_at — this test no longer reaches the StartedAt-non-nil claim branch it exists to cover")
+	}
+
+	before := readFenceState(t, ctx, store, "fence-claim-after-reopen")
+	if err := store.ClaimIssue(ctx, "fence-claim-after-reopen", "alice"); err != nil {
+		t.Fatalf("claim after reopen: %v", err)
+	}
+	assertFenceBumped(t, before, readFenceState(t, ctx, store, "fence-claim-after-reopen"),
+		"claim after reopen (started_at preserved)")
+}
+
+// TestCloseDoesNotBumpFence: close is not a fence transition — guarded verbs
+// protect against closed rows through their status predicates, and bumping on
+// close would invalidate legitimate orchestrator snapshots for no gain.
+func TestCloseDoesNotBumpFence(t *testing.T) {
+	store, cleanup := setupConcurrentTestStore(t)
+	defer cleanup()
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	seedClaimedIssue(t, ctx, store, "fence-close", "alice", time.Hour)
+	before := readFenceState(t, ctx, store, "fence-close")
+
+	if err := store.CloseIssue(ctx, "fence-close", "done", "alice", ""); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	after := readFenceState(t, ctx, store, "fence-close")
+	if after.fence != before.fence {
+		t.Errorf("close moved claim_fence %d → %d, want unchanged", before.fence, after.fence)
+	}
+}
+
+// TestFenceScanPosition: value-level sentinel test that the trailing columns
+// land in the right Issue fields — a const-equality parity test alone would
+// pass a silent claim_fence↔row_lock swap when two branches append trailing
+// BIGINTs in different orders.
+func TestFenceScanPosition(t *testing.T) {
+	store, cleanup := setupConcurrentTestStore(t)
+	defer cleanup()
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	seedOpenIssue(t, ctx, store, "fence-scan")
+	lease := time.Date(2031, 1, 2, 3, 4, 5, 0, time.UTC)
+	heartbeat := time.Date(2032, 6, 7, 8, 9, 10, 0, time.UTC)
+	// The lease sentinels live in the leases overlay (LEFT JOIN hydration);
+	// the fence and row_lock are issues columns. Stamp all of them directly.
+	if _, err := store.db.ExecContext(ctx, `
+		INSERT INTO leases (issue_id, holder, granted_at, lease_expires_at, heartbeat_at)
+		VALUES (?, 'sentinel-holder', ?, ?, ?)
+	`, "fence-scan", heartbeat, lease, heartbeat); err != nil {
+		t.Fatalf("stamp lease sentinels: %v", err)
+	}
+	if _, err := store.db.ExecContext(ctx, `
+		UPDATE issues SET claim_fence = 7777, row_lock = 4242 WHERE id = ?
+	`, "fence-scan"); err != nil {
+		t.Fatalf("stamp fence sentinel: %v", err)
+	}
+
+	got, err := store.GetIssue(ctx, "fence-scan")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.ClaimFence != 7777 {
+		t.Errorf("ClaimFence = %d, want sentinel 7777 (trailing-column position swap?)", got.ClaimFence)
+	}
+	if got.RowVersion != 4242 {
+		t.Errorf("RowVersion = %d, want sentinel 4242", got.RowVersion)
+	}
+	if got.LeaseExpiresAt == nil || !got.LeaseExpiresAt.Equal(lease) {
+		t.Errorf("LeaseExpiresAt = %v, want %v", got.LeaseExpiresAt, lease)
+	}
+	if got.HeartbeatAt == nil || !got.HeartbeatAt.Equal(heartbeat) {
+		t.Errorf("HeartbeatAt = %v, want %v", got.HeartbeatAt, heartbeat)
+	}
+}
+
+// TestWispClaimBumpsFence: the fence is tier-complete — wisp-table rows carry
+// and bump it exactly like permanent issues (they are claimable work, they
+// are just never leased).
+func TestWispClaimBumpsFence(t *testing.T) {
+	store, cleanup := setupConcurrentTestStore(t)
+	defer cleanup()
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	issue := &types.Issue{
+		ID:        "fence-wisp",
+		Title:     "fence wisp",
+		Status:    types.StatusOpen,
+		Priority:  2,
+		IssueType: types.TypeTask,
+		Ephemeral: true,
+	}
+	if err := store.CreateIssue(ctx, issue, "seeder"); err != nil {
+		t.Fatalf("seed wisp: %v", err)
+	}
+	wispFence := func() int64 {
+		t.Helper()
+		var v int64
+		if err := store.db.QueryRowContext(ctx, `SELECT claim_fence FROM wisps WHERE id = ?`, "fence-wisp").Scan(&v); err != nil {
+			t.Fatalf("read wisp fence: %v", err)
+		}
+		return v
+	}
+	before := wispFence()
+
+	if err := store.ClaimIssue(ctx, "fence-wisp", "alice"); err != nil {
+		t.Fatalf("claim wisp: %v", err)
+	}
+	after := wispFence()
+	if after != before+1 {
+		t.Errorf("wisp claim_fence = %d, want %d", after, before+1)
+	}
+
+	if err := store.UnclaimIssue(ctx, "fence-wisp", "alice", false); err != nil {
+		t.Fatalf("unclaim wisp: %v", err)
+	}
+	if released := wispFence(); released != after+1 {
+		t.Errorf("wisp unclaim claim_fence = %d, want %d", released, after+1)
+	}
+}
+
+// TestUpsertFenceDiscipline: the import/upsert path bumps the fence exactly
+// when the stored assignee changes — with "" and NULL treated as the same
+// unassigned state (unclaim writes "", NullString-bound imports write NULL) so
+// content-only re-imports of unassigned rows never bump.
+func TestUpsertFenceDiscipline(t *testing.T) {
+	store, cleanup := setupConcurrentTestStore(t)
+	defer cleanup()
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	seedClaimedIssue(t, ctx, store, "fence-upsert", "alice", time.Hour)
+	claimed := readFenceState(t, ctx, store, "fence-upsert")
+
+	upsert := func(assignee string, updatedAt time.Time, rejectStale bool) {
+		t.Helper()
+		snapshot := &types.Issue{
+			ID:        "fence-upsert",
+			Title:     "fence fence-upsert",
+			Status:    types.StatusInProgress,
+			Priority:  2,
+			IssueType: types.TypeTask,
+			Assignee:  assignee,
+			CreatedAt: time.Now().UTC().Add(-time.Hour),
+			UpdatedAt: updatedAt,
+		}
+		tx, err := store.db.BeginTx(ctx, nil)
+		if err != nil {
+			t.Fatalf("begin: %v", err)
+		}
+		defer func() { _ = tx.Rollback() }()
+		if rejectStale {
+			if _, _, err := issueops.InsertIssueIfNew(ctx, tx, "issues", snapshot, storage.BatchCreateOptions{RejectStaleUpserts: true}); err != nil {
+				t.Fatalf("stale-guarded upsert: %v", err)
+			}
+		} else if err := issueops.InsertIssueIntoTable(ctx, tx, "issues", snapshot); err != nil {
+			t.Fatalf("upsert: %v", err)
+		}
+		if err := tx.Commit(); err != nil {
+			t.Fatalf("commit: %v", err)
+		}
+	}
+
+	// Same-assignee re-import (newer timestamp): content only, no bump.
+	upsert("alice", time.Now().UTC().Add(time.Minute), false)
+	same := readFenceState(t, ctx, store, "fence-upsert")
+	if same.fence != claimed.fence {
+		t.Errorf("same-assignee upsert moved claim_fence %d → %d, want unchanged", claimed.fence, same.fence)
+	}
+
+	// Assignee-change import: ownership transition, bump + row_lock rewrite.
+	upsert("bob", time.Now().UTC().Add(2*time.Minute), false)
+	assertFenceBumped(t, same, readFenceState(t, ctx, store, "fence-upsert"), "assignee-change upsert")
+
+	// Stale-guarded branch: an OLDER incoming row does not change the assignee
+	// and must not bump; a NEWER one with a changed assignee must.
+	afterBob := readFenceState(t, ctx, store, "fence-upsert")
+	upsert("carol", time.Now().UTC().Add(-2*time.Hour), true)
+	stale := readFenceState(t, ctx, store, "fence-upsert")
+	if stale.fence != afterBob.fence {
+		t.Errorf("stale upsert moved claim_fence %d → %d, want unchanged", afterBob.fence, stale.fence)
+	}
+	upsert("carol", time.Now().UTC().Add(3*time.Minute), true)
+	assertFenceBumped(t, stale, readFenceState(t, ctx, store, "fence-upsert"), "stale-guarded assignee-change upsert")
+
+	// ""/NULL normalization: release (stored assignee becomes ""), then
+	// re-import the unassigned row (binds NULL). Both mean unassigned — a
+	// content-only sync must not bump.
+	if err := store.UnclaimIssue(ctx, "fence-upsert", "carol", false); err != nil {
+		t.Fatalf("unclaim: %v", err)
+	}
+	released := readFenceState(t, ctx, store, "fence-upsert")
+	snapshot := &types.Issue{
+		ID:        "fence-upsert",
+		Title:     "fence fence-upsert",
+		Status:    types.StatusOpen,
+		Priority:  2,
+		IssueType: types.TypeTask,
+		CreatedAt: time.Now().UTC().Add(-time.Hour),
+		UpdatedAt: time.Now().UTC().Add(4 * time.Minute),
+	}
+	tx, err := store.db.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatalf("begin: %v", err)
+	}
+	if err := issueops.InsertIssueIntoTable(ctx, tx, "issues", snapshot); err != nil {
+		_ = tx.Rollback()
+		t.Fatalf("unassigned upsert: %v", err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+	after := readFenceState(t, ctx, store, "fence-upsert")
+	if after.fence != released.fence {
+		t.Errorf("unassigned re-import moved claim_fence %d → %d — \"\"/NULL must normalize to the same unassigned state", released.fence, after.fence)
+	}
+}
+
+// TestFenceSurvivesTableMove: promote/demote rebuild the row in the other
+// table; the fence must carry, not reset to the column default — a fence
+// moving backward re-validates retired ownership snapshots, the one unsound
+// direction.
+func TestFenceSurvivesTableMove(t *testing.T) {
+	store, cleanup := setupConcurrentTestStore(t)
+	defer cleanup()
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	// Wisp → issues (promote).
+	wisp := &types.Issue{
+		ID:        "fence-promote",
+		Title:     "fence promote",
+		Status:    types.StatusOpen,
+		Priority:  2,
+		IssueType: types.TypeTask,
+		Ephemeral: true,
+	}
+	if err := store.CreateIssue(ctx, wisp, "seeder"); err != nil {
+		t.Fatalf("seed wisp: %v", err)
+	}
+	if err := store.ClaimIssue(ctx, "fence-promote", "alice"); err != nil {
+		t.Fatalf("claim wisp: %v", err)
+	}
+	var wispFence int64
+	if err := store.db.QueryRowContext(ctx, `SELECT claim_fence FROM wisps WHERE id = ?`, "fence-promote").Scan(&wispFence); err != nil {
+		t.Fatalf("read wisp fence: %v", err)
+	}
+	if wispFence == 0 {
+		t.Fatal("claimed wisp fence = 0, want bumped before the move")
+	}
+	if err := store.PromoteFromEphemeral(ctx, "fence-promote", "admin"); err != nil {
+		t.Fatalf("promote: %v", err)
+	}
+	promoted := readFenceState(t, ctx, store, "fence-promote")
+	if promoted.fence != wispFence {
+		t.Errorf("promote reset claim_fence %d → %d, want carried", wispFence, promoted.fence)
+	}
+
+	// Issues → wisps (demote).
+	seedClaimedIssue(t, ctx, store, "fence-demote", "alice", time.Hour)
+	before := readFenceState(t, ctx, store, "fence-demote")
+	if err := store.DemoteToWisp(ctx, "fence-demote", map[string]interface{}{"wisp": true}, "admin"); err != nil {
+		t.Fatalf("demote: %v", err)
+	}
+	var demoted int64
+	if err := store.db.QueryRowContext(ctx, `SELECT claim_fence FROM wisps WHERE id = ?`, "fence-demote").Scan(&demoted); err != nil {
+		t.Fatalf("read demoted fence: %v", err)
+	}
+	if demoted != before.fence {
+		t.Errorf("demote reset claim_fence %d → %d, want carried", before.fence, demoted)
+	}
+}

--- a/internal/storage/dolt/issues.go
+++ b/internal/storage/dolt/issues.go
@@ -258,7 +258,7 @@ func (s *DoltStore) UpdateIssueChecked(ctx context.Context, id string, updates m
 			if err := checkExpectedVersionInTx(ctx, tx, id, opts.ExpectedVersion); err != nil {
 				return err
 			}
-			if err := issueops.CheckExpectedFieldsInTx(ctx, tx, id, opts.ExpectedAssignee, opts.ExpectedStatus); err != nil {
+			if err := issueops.CheckExpectedFieldsInTx(ctx, tx, id, opts.ExpectedAssignee, opts.ExpectedStatus, opts.ExpectedFence); err != nil {
 				return err
 			}
 			return s.demoteToWispInTx(ctx, tx, id, updates, actor)
@@ -269,7 +269,7 @@ func (s *DoltStore) UpdateIssueChecked(ctx context.Context, id string, updates m
 	// loses Dolt's optimistic commit-time merge (MySQL 1213/1205, guaranteed
 	// server-side rollback) is retried rather than surfaced as a hard failure.
 	// A precondition mismatch (storage.ErrVersionMismatch /
-	// ErrAssigneeMismatch / ErrStatusMismatch) is NOT a serialization error, so
+	// ErrAssigneeMismatch / ErrStatusMismatch / ErrFenceMismatch) is NOT a serialization error, so
 	// withRetryTx surfaces it permanently and the transaction rolls back — no
 	// update and no event are written (the atomic-refuse property). A
 	// concurrent write that commits DURING this tx collides on the row_lock cell
@@ -280,7 +280,7 @@ func (s *DoltStore) UpdateIssueChecked(ctx context.Context, id string, updates m
 			if err := checkExpectedVersionInTx(ctx, tx, id, opts.ExpectedVersion); err != nil {
 				return err
 			}
-			if err := issueops.CheckExpectedFieldsInTx(ctx, tx, id, opts.ExpectedAssignee, opts.ExpectedStatus); err != nil {
+			if err := issueops.CheckExpectedFieldsInTx(ctx, tx, id, opts.ExpectedAssignee, opts.ExpectedStatus, opts.ExpectedFence); err != nil {
 				return err
 			}
 			if _, err := issueops.UpdateIssueInTx(ctx, tx, id, updates, actor); err != nil {
@@ -510,18 +510,20 @@ func (s *DoltStore) ReclaimExpiredLeases(ctx context.Context, olderThan time.Dur
 // UnclaimIssue atomically unclaims an issue by clearing the assignee, resetting
 // status to "open", deleting its lease row and rewriting row_lock. Records
 // an "unclaimed" event. Only the current assignee may release its own claim
-// unless force is set (admin/reaper override). Delegates SQL work to
+// unless force is set (admin/reaper override). A non-nil expectedFence pins the
+// release to that ownership generation (storage.ErrFenceMismatch otherwise) —
+// an additional conjunct that force does not waive. Delegates SQL work to
 // issueops.UnclaimIssueInTx; handles Dolt-specific concerns (DOLT_ADD/COMMIT).
 //
 // Wrapped in withRetryTx like the other claim-family writes so a concurrent
 // writer that loses Dolt's optimistic commit-time merge (1213/1205) is retried
 // rather than surfaced as a hard failure.
-func (s *DoltStore) UnclaimIssue(ctx context.Context, id string, actor string, force bool) error {
+func (s *DoltStore) UnclaimIssue(ctx context.Context, id string, actor string, force bool, expectedFence *int64) error {
 	// verify-by-re-read (bd-zccb9): a phantom unclaim leaves the caller
 	// believing the issue is released while it still holds the claim.
 	return s.verifiedClaimWrite(ctx, id, unclaimed(), func() error {
 		return s.withRetryTx(ctx, func(tx *sql.Tx) error {
-			if err := issueops.UnclaimIssueInTx(ctx, tx, id, actor, force); err != nil {
+			if err := issueops.UnclaimIssueInTx(ctx, tx, id, actor, force, expectedFence); err != nil {
 				return err
 			}
 
@@ -542,15 +544,17 @@ func (s *DoltStore) UnclaimIssue(ctx context.Context, id string, actor string, f
 // UnclaimIssueIfAssignee releases a claim only while the issue is still assigned
 // to expectedAssignee (compare-and-swap, the inverse of ClaimIssue). Returns
 // storage.ErrAssigneeMismatch, leaving the issue untouched, when the current
-// assignee differs. Delegates SQL work to issueops.UnclaimIssueIfAssigneeInTx;
-// handles Dolt-specific concerns (DOLT_ADD/COMMIT). Wrapped in withRetryTx like
-// UnclaimIssue so a concurrent writer that loses Dolt's optimistic commit-time
-// merge is retried rather than surfaced as a hard failure.
-func (s *DoltStore) UnclaimIssueIfAssignee(ctx context.Context, id string, actor string, expectedAssignee string) error {
+// assignee differs, and storage.ErrFenceMismatch when a non-nil expectedFence
+// names a superseded ownership generation. Delegates SQL work to
+// issueops.UnclaimIssueIfAssigneeInTx; handles Dolt-specific concerns
+// (DOLT_ADD/COMMIT). Wrapped in withRetryTx like UnclaimIssue so a concurrent
+// writer that loses Dolt's optimistic commit-time merge is retried rather than
+// surfaced as a hard failure.
+func (s *DoltStore) UnclaimIssueIfAssignee(ctx context.Context, id string, actor string, expectedAssignee string, expectedFence *int64) error {
 	// verify-by-re-read (bd-zccb9), same reasoning as UnclaimIssue.
 	return s.verifiedClaimWrite(ctx, id, unclaimed(), func() error {
 		return s.withRetryTx(ctx, func(tx *sql.Tx) error {
-			if err := issueops.UnclaimIssueIfAssigneeInTx(ctx, tx, id, actor, expectedAssignee); err != nil {
+			if err := issueops.UnclaimIssueIfAssigneeInTx(ctx, tx, id, actor, expectedAssignee, expectedFence); err != nil {
 				return err
 			}
 
@@ -630,9 +634,10 @@ func (s *DoltStore) CloseIssue(ctx context.Context, id string, reason string, ac
 
 // CloseIssueChecked closes an issue but refuses with storage.ErrCloseBlocked
 // when it has a live direct blocker unless opts.Force is set, and — when
-// opts.ExpectedVersion is non-nil — with storage.ErrVersionMismatch when the
-// row's current RowVersion no longer matches (an orthogonal CAS that Force does
-// not bypass). Both checks and the close share one transaction, so they are
+// opts.ExpectedVersion / opts.ExpectedFence are non-nil — with
+// storage.ErrVersionMismatch / storage.ErrFenceMismatch when the row's current
+// RowVersion / ClaimFence no longer matches (orthogonal CAS guards that Force
+// does not bypass). All checks and the close share one transaction, so they are
 // atomic (no TOCTOU). Mirrors CloseIssue's Dolt-specific concerns (wisp routing,
 // DOLT_ADD/COMMIT).
 func (s *DoltStore) CloseIssueChecked(ctx context.Context, id string, actor string, opts storage.CloseIssueOptions) (storage.CloseIssueResult, error) {
@@ -650,7 +655,7 @@ func (s *DoltStore) CloseIssueChecked(ctx context.Context, id string, actor stri
 	// event are written (the atomic-refuse property).
 	var result storage.CloseIssueResult
 	if err := s.withRetryTx(ctx, func(tx *sql.Tx) error {
-		res, err := issueops.CloseIssueCheckedInTx(ctx, tx, id, opts.Reason, actor, opts.Session, opts.Force, opts.ExpectedVersion)
+		res, err := issueops.CloseIssueCheckedInTx(ctx, tx, id, opts.Reason, actor, opts.Session, opts.Force, opts.ExpectedVersion, opts.ExpectedFence)
 		if err != nil {
 			return err
 		}

--- a/internal/storage/dolt/issues.go
+++ b/internal/storage/dolt/issues.go
@@ -507,6 +507,50 @@ func (s *DoltStore) ReclaimExpiredLeases(ctx context.Context, olderThan time.Dur
 	return reclaimed, nil
 }
 
+// DisarmAutoLeases sets lease.auto=off and deletes the lease rows of the
+// claims already holding one, without releasing them. The flip and the first
+// sweep share one transaction, and bounded follow-up sweeps close the window
+// where a claim in flight across the flip arms a lease the first sweep never
+// saw — issueops.DisarmAutoLeasesWith owns that sequencing; this is only the
+// one-transaction closure it drives. Only the config flip is Dolt-versioned:
+// lease rows live in the ephemeral (dolt_ignored) leases table, so clearing
+// them mints no commit.
+func (s *DoltStore) DisarmAutoLeases(ctx context.Context) (int64, error) {
+	return issueops.DisarmAutoLeasesWith(func(flip bool) (int64, error) {
+		var swept int64
+		err := s.withRetryTx(ctx, func(tx *sql.Tx) error {
+			swept = 0 // withRetryTx replays this closure; don't accumulate
+			if flip {
+				if err := issueops.DisarmLeaseConfigInTx(ctx, tx); err != nil {
+					return err
+				}
+			}
+			n, err := issueops.ClearArmedLeasesInTx(ctx, tx)
+			if err != nil {
+				return err
+			}
+			swept = n
+			if !flip {
+				return nil // lease-row deletes are ephemeral: nothing to version
+			}
+			// config is the one table here that is NOT dolt_ignore'd, so the
+			// best-effort ignore idiom the issue-table stagers use does not
+			// apply: a silently skipped failed ADD leaves config dirty and the
+			// flip uncommitted (see commitWorkingSet in store.go).
+			if _, err := tx.ExecContext(ctx, "CALL DOLT_ADD(?)", "config"); err != nil {
+				return fmt.Errorf("failed to stage config before commit: %w", err)
+			}
+			commitMsg := fmt.Sprintf("bd: disarm auto-leases (%d lease(s) cleared)", swept)
+			if _, err := tx.ExecContext(ctx, "CALL DOLT_COMMIT('-m', ?, '--author', ?)",
+				commitMsg, s.commitAuthorString()); err != nil && !isDoltNothingToCommit(err) {
+				return fmt.Errorf("dolt commit: %w", err)
+			}
+			return nil
+		})
+		return swept, err
+	})
+}
+
 // UnclaimIssue atomically unclaims an issue by clearing the assignee, resetting
 // status to "open", deleting its lease row and rewriting row_lock. Records
 // an "unclaimed" event. Only the current assignee may release its own claim

--- a/internal/storage/dolt/lease_disarm_test.go
+++ b/internal/storage/dolt/lease_disarm_test.go
@@ -1,0 +1,245 @@
+package dolt
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/steveyegge/beads/internal/storage"
+	"github.com/steveyegge/beads/internal/storage/issueops"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// TestAutoLeaseOffClaimStampsNothing: with lease.auto=off a claim carries no
+// lease, so there is nothing for bd reclaim to reap and an un-renewed fleet is
+// never one stray reclaim away from mass-revert. The claim is otherwise
+// untouched — the fence still bumps (it is an ownership transition either way)
+// and row_lock is still rewritten with it (pairing invariant).
+func TestAutoLeaseOffClaimStampsNothing(t *testing.T) {
+	store, cleanup := setupConcurrentTestStore(t)
+	defer cleanup()
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	if err := store.SetConfig(ctx, issueops.LeaseAutoConfigKey, "off"); err != nil {
+		t.Fatalf("set lease.auto=off: %v", err)
+	}
+
+	seedOpenIssue(t, ctx, store, "disarm-claim")
+	before := readFenceState(t, ctx, store, "disarm-claim")
+	if err := store.ClaimIssue(ctx, "disarm-claim", "alice"); err != nil {
+		t.Fatalf("claim: %v", err)
+	}
+
+	ls := readLeaseState(t, ctx, store, "disarm-claim")
+	if ls.leaseExpires.Valid || ls.heartbeatAt.Valid {
+		t.Errorf("lease.auto=off claim stamped a lease: expires=%v heartbeat=%v", ls.leaseExpires, ls.heartbeatAt)
+	}
+	if ls.status != "in_progress" {
+		t.Errorf("status = %q, want in_progress (disarming leases must not affect the claim)", ls.status)
+	}
+	assertFenceBumped(t, before, readFenceState(t, ctx, store, "disarm-claim"), "unleased claim")
+
+	// Nothing to reclaim: the unleased claim is invisible to the reaper.
+	reclaimed, err := store.ReclaimExpiredLeases(ctx, 0, types.ReclaimFilter{}, "reaper")
+	if err != nil {
+		t.Fatalf("reclaim: %v", err)
+	}
+	if len(reclaimed) != 0 {
+		t.Errorf("reclaim reaped %d unleased claims, want 0", len(reclaimed))
+	}
+}
+
+// TestAutoLeaseOffIgnoresLeaseTTLContext pins the scope of this commit: the
+// WithLeaseTTL context knob is a TTL override, NOT an opt-in that survives
+// disarming. A per-claim "requested lease" surface (--lease-ttl and its
+// renewal API) is parked pending the wisp-leasing ruling, so on a disarmed
+// store every claim is unleased, however it was made.
+func TestAutoLeaseOffIgnoresLeaseTTLContext(t *testing.T) {
+	store, cleanup := setupConcurrentTestStore(t)
+	defer cleanup()
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	if err := store.SetConfig(ctx, issueops.LeaseAutoConfigKey, "off"); err != nil {
+		t.Fatalf("set lease.auto=off: %v", err)
+	}
+
+	seedOpenIssue(t, ctx, store, "disarm-explicit")
+	if err := store.ClaimIssue(issueops.WithLeaseTTL(ctx, time.Second), "disarm-explicit", "alice"); err != nil {
+		t.Fatalf("claim with explicit TTL: %v", err)
+	}
+	if ls := readLeaseState(t, ctx, store, "disarm-explicit"); ls.leaseExpires.Valid {
+		t.Error("WithLeaseTTL claim stamped a lease under lease.auto=off")
+	}
+}
+
+// TestHeartbeatOnUnleasedClaimRejected: heartbeat must never ARM a lease as a
+// side effect — one stray bd heartbeat on a deliberately unleased claim would
+// re-create the reclaim exposure the disarm removes.
+func TestHeartbeatOnUnleasedClaimRejected(t *testing.T) {
+	store, cleanup := setupConcurrentTestStore(t)
+	defer cleanup()
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	if err := store.SetConfig(ctx, issueops.LeaseAutoConfigKey, "off"); err != nil {
+		t.Fatalf("set lease.auto=off: %v", err)
+	}
+	seedOpenIssue(t, ctx, store, "disarm-hb")
+	if err := store.ClaimIssue(ctx, "disarm-hb", "alice"); err != nil {
+		t.Fatalf("claim: %v", err)
+	}
+
+	err := store.HeartbeatIssue(ctx, "disarm-hb", "alice")
+	if !errors.Is(err, storage.ErrUnleased) {
+		t.Fatalf("heartbeat on unleased claim: got %v, want ErrUnleased", err)
+	}
+	if ls := readLeaseState(t, ctx, store, "disarm-hb"); ls.leaseExpires.Valid {
+		t.Error("rejected heartbeat armed a lease")
+	}
+
+	// Owner/status errors still take precedence over unleased.
+	if err := store.HeartbeatIssue(ctx, "disarm-hb", "mallory"); !errors.Is(err, storage.ErrAlreadyClaimed) {
+		t.Errorf("stranger heartbeat: got %v, want ErrAlreadyClaimed", err)
+	}
+}
+
+// TestHeartbeatRenewsLeaseGrantedBeforeDisarm: disarming is a one-shot sweep,
+// not a standing rejection. A claim that still holds a lease row — granted
+// before the flip, or restored by an import — keeps renewing normally; only an
+// owned claim with no lease row at all is refused.
+func TestHeartbeatRenewsLeaseGrantedBeforeDisarm(t *testing.T) {
+	store, cleanup := setupConcurrentTestStore(t)
+	defer cleanup()
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	seedClaimedIssue(t, ctx, store, "disarm-renew", "alice", time.Minute)
+	if err := store.SetConfig(ctx, issueops.LeaseAutoConfigKey, "off"); err != nil {
+		t.Fatalf("set lease.auto=off: %v", err)
+	}
+
+	before := readLeaseState(t, ctx, store, "disarm-renew")
+	if !before.leaseExpires.Valid {
+		t.Fatal("test setup: claim under lease.auto=on did not stamp a lease")
+	}
+	if err := store.HeartbeatIssue(issueops.WithLeaseTTL(ctx, time.Hour), "disarm-renew", "alice"); err != nil {
+		t.Fatalf("heartbeat on a still-leased claim: %v", err)
+	}
+	after := readLeaseState(t, ctx, store, "disarm-renew")
+	if !after.leaseExpires.Valid {
+		t.Fatal("heartbeat dropped the lease row")
+	}
+	if !after.leaseExpires.Time.After(before.leaseExpires.Time) {
+		t.Errorf("lease_expires_at %v did not advance past %v", after.leaseExpires.Time, before.leaseExpires.Time)
+	}
+}
+
+// TestDisarmAutoLeases: the one-shot flip — sets lease.auto=off and clears the
+// lease rows of the claims already holding one, so a fleet opting out of the
+// lease regime is safe from bd reclaim in the same transaction that turns
+// stamping off. Idempotent: a second run flips an already-flipped key and
+// sweeps nothing.
+func TestDisarmAutoLeases(t *testing.T) {
+	store, cleanup := setupConcurrentTestStore(t)
+	defer cleanup()
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	// Two armed claims under the default (auto=on) semantics.
+	seedClaimedIssue(t, ctx, store, "disarm-a", "alice", time.Minute)
+	seedClaimedIssue(t, ctx, store, "disarm-b", "bob", time.Minute)
+	fenceA := readFenceState(t, ctx, store, "disarm-a")
+
+	n, err := store.DisarmAutoLeases(ctx)
+	if err != nil {
+		t.Fatalf("disarm: %v", err)
+	}
+	if n != 2 {
+		t.Errorf("disarmed %d leases, want 2", n)
+	}
+
+	for _, id := range []string{"disarm-a", "disarm-b"} {
+		ls := readLeaseState(t, ctx, store, id)
+		if ls.leaseExpires.Valid || ls.heartbeatAt.Valid {
+			t.Errorf("%s still armed after disarm", id)
+		}
+		if ls.status != "in_progress" {
+			t.Errorf("%s status = %q, want in_progress (disarm must not release)", id, ls.status)
+		}
+		if !ls.assignee.Valid || ls.assignee.String == "" {
+			t.Errorf("%s lost its assignee to the disarm", id)
+		}
+	}
+	// Disarm is not an ownership transition — the fence must NOT move.
+	if after := readFenceState(t, ctx, store, "disarm-a"); after.fence != fenceA.fence {
+		t.Errorf("disarm moved claim_fence %d → %d, want unchanged", fenceA.fence, after.fence)
+	}
+
+	// The config flip persisted: subsequent claims stamp nothing.
+	seedOpenIssue(t, ctx, store, "disarm-c")
+	if err := store.ClaimIssue(ctx, "disarm-c", "carol"); err != nil {
+		t.Fatalf("post-disarm claim: %v", err)
+	}
+	if ls := readLeaseState(t, ctx, store, "disarm-c"); ls.leaseExpires.Valid {
+		t.Error("post-disarm claim stamped a lease")
+	}
+
+	// Nothing reclaimable remains.
+	reclaimed, err := store.ReclaimExpiredLeases(ctx, 0, types.ReclaimFilter{}, "reaper")
+	if err != nil {
+		t.Fatalf("reclaim: %v", err)
+	}
+	if len(reclaimed) != 0 {
+		t.Errorf("reclaim reaped %d post-disarm, want 0", len(reclaimed))
+	}
+
+	// Idempotent: the key is already off and there is nothing left to sweep.
+	again, err := store.DisarmAutoLeases(ctx)
+	if err != nil {
+		t.Fatalf("second disarm: %v", err)
+	}
+	if again != 0 {
+		t.Errorf("second disarm cleared %d leases, want 0", again)
+	}
+}
+
+// TestLeaseAutoValueParsing pins which config values disarm stamping. Only an
+// explicitly falsy value does; unset, "on" and a typo all leave the shipped
+// default armed, because a knob that silently drops recovery on a misspelling
+// is worse than one that ignores it.
+func TestLeaseAutoValueParsing(t *testing.T) {
+	store, cleanup := setupConcurrentTestStore(t)
+	defer cleanup()
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	cases := []struct {
+		value  string
+		leased bool
+	}{
+		{"off", false},
+		{"false", false},
+		{"0", false},
+		{"OFF", false},
+		{"on", true},
+		{"true", true},
+		{"", true},
+		{"maybe", true},
+	}
+	for i, tc := range cases {
+		if err := store.SetConfig(ctx, issueops.LeaseAutoConfigKey, tc.value); err != nil {
+			t.Fatalf("set lease.auto=%q: %v", tc.value, err)
+		}
+		id := fmt.Sprintf("disarm-parse-%d", i)
+		seedOpenIssue(t, ctx, store, id)
+		if err := store.ClaimIssue(ctx, id, "alice"); err != nil {
+			t.Fatalf("claim %s: %v", id, err)
+		}
+		if got := readLeaseState(t, ctx, store, id).leaseExpires.Valid; got != tc.leased {
+			t.Errorf("lease.auto=%q: leased = %v, want %v", tc.value, got, tc.leased)
+		}
+	}
+}

--- a/internal/storage/dolt/lease_test.go
+++ b/internal/storage/dolt/lease_test.go
@@ -192,7 +192,7 @@ func TestUnclaimOwnershipAndLease(t *testing.T) {
 	// (a) Non-owner cannot release someone else's claim.
 	seedClaimedIssue(t, ctx, store, "unclaim-a", "alice", time.Hour)
 	before := readLeaseState(t, ctx, store, "unclaim-a")
-	if err := store.UnclaimIssue(ctx, "unclaim-a", "mallory", false); !errors.Is(err, storage.ErrNotOwner) {
+	if err := store.UnclaimIssue(ctx, "unclaim-a", "mallory", false, nil); !errors.Is(err, storage.ErrNotOwner) {
 		t.Fatalf("non-owner unclaim err = %v, want ErrNotOwner", err)
 	}
 	stillClaimed := readLeaseState(t, ctx, store, "unclaim-a")
@@ -205,7 +205,7 @@ func TestUnclaimOwnershipAndLease(t *testing.T) {
 
 	// (b) Owner releases: status → open, assignee cleared, lease columns
 	// cleared, row_lock rewritten.
-	if err := store.UnclaimIssue(ctx, "unclaim-a", "alice", false); err != nil {
+	if err := store.UnclaimIssue(ctx, "unclaim-a", "alice", false, nil); err != nil {
 		t.Fatalf("owner unclaim: %v", err)
 	}
 	released := readLeaseState(t, ctx, store, "unclaim-a")
@@ -232,7 +232,7 @@ func TestUnclaimOwnershipAndLease(t *testing.T) {
 
 	// (c) --force lets an admin/reaper release a claim held by someone else.
 	seedClaimedIssue(t, ctx, store, "unclaim-c", "alice", time.Hour)
-	if err := store.UnclaimIssue(ctx, "unclaim-c", "reaper", true); err != nil {
+	if err := store.UnclaimIssue(ctx, "unclaim-c", "reaper", true, nil); err != nil {
 		t.Fatalf("forced unclaim by non-owner: %v", err)
 	}
 	forced := readLeaseState(t, ctx, store, "unclaim-c")

--- a/internal/storage/dolt/unclaim_fence_test.go
+++ b/internal/storage/dolt/unclaim_fence_test.go
@@ -1,0 +1,159 @@
+package dolt
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/storage"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// TestUnclaimFenceGuard covers the ownership-fence conjunct on both release
+// paths (`bd unclaim --if-fence`). The security rule under test: a guard
+// establishes FRESHNESS, not AUTHORITY. Passing the right fence never lets a
+// non-owner release someone else's claim, and --force — which waives the owner
+// check — never waives a fence the caller supplied.
+func TestUnclaimFenceGuard(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	get := func(t *testing.T, id string) *types.Issue {
+		t.Helper()
+		iss, err := store.GetIssue(ctx, id)
+		if err != nil {
+			t.Fatalf("GetIssue(%s): %v", id, err)
+		}
+		if iss == nil {
+			t.Fatalf("GetIssue(%s) returned nil issue", id)
+		}
+		return iss
+	}
+	iptr := func(v int64) *int64 { return &v }
+	claimed := func(t *testing.T, id, actor string) int64 {
+		t.Helper()
+		createPerm(t, ctx, store, id)
+		if err := store.ClaimIssue(ctx, id, actor); err != nil {
+			t.Fatalf("seed claim %s: %v", id, err)
+		}
+		return get(t, id).ClaimFence
+	}
+
+	t.Run("owner with the live fence releases", func(t *testing.T) {
+		fence := claimed(t, "uf-rel-ok", "alice")
+		if err := store.UnclaimIssue(ctx, "uf-rel-ok", "alice", false, iptr(fence)); err != nil {
+			t.Fatalf("guarded release by the holder err = %v, want nil", err)
+		}
+		iss := get(t, "uf-rel-ok")
+		if iss.Assignee != "" || iss.Status != types.StatusOpen {
+			t.Fatalf("after release: assignee=%q status=%q, want unassigned/open", iss.Assignee, iss.Status)
+		}
+		if iss.ClaimFence != fence+1 {
+			t.Fatalf("claim_fence = %d after release, want %d", iss.ClaimFence, fence+1)
+		}
+	})
+
+	t.Run("owner with a stale fence is refused", func(t *testing.T) {
+		fence := claimed(t, "uf-rel-stale", "alice")
+		// The claim is released and re-taken by the same actor: same holder,
+		// new ownership generation.
+		if err := store.UnclaimIssue(ctx, "uf-rel-stale", "alice", false, nil); err != nil {
+			t.Fatalf("unclaim: %v", err)
+		}
+		if err := store.ClaimIssue(ctx, "uf-rel-stale", "alice"); err != nil {
+			t.Fatalf("re-claim: %v", err)
+		}
+		err := store.UnclaimIssue(ctx, "uf-rel-stale", "alice", false, iptr(fence))
+		if !errors.Is(err, storage.ErrFenceMismatch) {
+			t.Fatalf("err = %v, want errors.Is(_, ErrFenceMismatch)", err)
+		}
+		iss := get(t, "uf-rel-stale")
+		if iss.Assignee != "alice" || iss.Status != types.StatusInProgress {
+			t.Fatalf("stale guarded release disturbed the live claim: assignee=%q status=%q", iss.Assignee, iss.Status)
+		}
+	})
+
+	// The P0 rule: a fence NEVER authorizes a cross-actor release. A stranger
+	// quoting the correct, live fence still gets ErrNotOwner — the owner check
+	// runs first and is unchanged.
+	t.Run("correct fence does not authorize a cross-actor release", func(t *testing.T) {
+		fence := claimed(t, "uf-rel-cross", "alice")
+		err := store.UnclaimIssue(ctx, "uf-rel-cross", "controller", false, iptr(fence))
+		if !errors.Is(err, storage.ErrNotOwner) {
+			t.Fatalf("err = %v, want errors.Is(_, ErrNotOwner) — a guard is not a credential", err)
+		}
+		iss := get(t, "uf-rel-cross")
+		if iss.Assignee != "alice" || iss.ClaimFence != fence {
+			t.Fatalf("cross-actor release landed: assignee=%q fence=%d", iss.Assignee, iss.ClaimFence)
+		}
+	})
+
+	t.Run("force does not skip a supplied fence", func(t *testing.T) {
+		fence := claimed(t, "uf-rel-force", "alice")
+		err := store.UnclaimIssue(ctx, "uf-rel-force", "admin", true, iptr(fence+7))
+		if !errors.Is(err, storage.ErrFenceMismatch) {
+			t.Fatalf("err = %v, want errors.Is(_, ErrFenceMismatch) under --force", err)
+		}
+		iss := get(t, "uf-rel-force")
+		if iss.Assignee != "alice" || iss.Status != types.StatusInProgress {
+			t.Fatalf("force bypassed a failing guard: assignee=%q status=%q", iss.Assignee, iss.Status)
+		}
+		// With the live fence, force still does what it always did.
+		if err := store.UnclaimIssue(ctx, "uf-rel-force", "admin", true, iptr(fence)); err != nil {
+			t.Fatalf("forced release with the live fence err = %v, want nil", err)
+		}
+		if got := get(t, "uf-rel-force").Assignee; got != "" {
+			t.Fatalf("assignee = %q after forced release, want empty", got)
+		}
+	})
+
+	t.Run("if-assignee CAS composes with the fence", func(t *testing.T) {
+		fence := claimed(t, "uf-cas-ok", "alice")
+		if err := store.UnclaimIssueIfAssignee(ctx, "uf-cas-ok", "supervisor", "alice", iptr(fence)); err != nil {
+			t.Fatalf("conditional release with both guards held err = %v, want nil", err)
+		}
+		if got := get(t, "uf-cas-ok").Assignee; got != "" {
+			t.Fatalf("assignee = %q after conditional release, want empty", got)
+		}
+	})
+
+	t.Run("if-assignee CAS reports a fence-only miss as a fence mismatch", func(t *testing.T) {
+		fence := claimed(t, "uf-cas-fence", "alice")
+		if err := store.UnclaimIssue(ctx, "uf-cas-fence", "alice", false, nil); err != nil {
+			t.Fatalf("unclaim: %v", err)
+		}
+		if err := store.ClaimIssue(ctx, "uf-cas-fence", "alice"); err != nil {
+			t.Fatalf("re-claim: %v", err)
+		}
+		// The assignee guard holds (still alice) — only the fence is stale, so
+		// the verdict must name the fence rather than the holder.
+		err := store.UnclaimIssueIfAssignee(ctx, "uf-cas-fence", "supervisor", "alice", iptr(fence))
+		if !errors.Is(err, storage.ErrFenceMismatch) {
+			t.Fatalf("err = %v, want errors.Is(_, ErrFenceMismatch)", err)
+		}
+		if errors.Is(err, storage.ErrAssigneeMismatch) {
+			t.Fatalf("fence-only miss reported as an assignee mismatch: %v", err)
+		}
+		if got := get(t, "uf-cas-fence").Assignee; got != "alice" {
+			t.Fatalf("assignee = %q after refused conditional release, want alice", got)
+		}
+	})
+
+	t.Run("if-assignee CAS still reports a holder change as an assignee mismatch", func(t *testing.T) {
+		fence := claimed(t, "uf-cas-holder", "alice")
+		if err := store.UnclaimIssue(ctx, "uf-cas-holder", "alice", false, nil); err != nil {
+			t.Fatalf("unclaim: %v", err)
+		}
+		if err := store.ClaimIssue(ctx, "uf-cas-holder", "bob"); err != nil {
+			t.Fatalf("re-claim by bob: %v", err)
+		}
+		err := store.UnclaimIssueIfAssignee(ctx, "uf-cas-holder", "supervisor", "alice", iptr(fence))
+		if !errors.Is(err, storage.ErrAssigneeMismatch) {
+			t.Fatalf("err = %v, want errors.Is(_, ErrAssigneeMismatch) when the holder moved", err)
+		}
+		if got := get(t, "uf-cas-holder").Assignee; got != "bob" {
+			t.Fatalf("bob's claim was disturbed: assignee = %q", got)
+		}
+	})
+}

--- a/internal/storage/dolt/update_guards_test.go
+++ b/internal/storage/dolt/update_guards_test.go
@@ -166,6 +166,173 @@ func TestUpdateIssueCheckedFieldGuards(t *testing.T) {
 	})
 }
 
+// TestUpdateIssueCheckedFenceGuard exercises UpdateIssueOptions.ExpectedFence:
+// the ownership-generation compare-and-set behind `bd update --if-fence`. It is
+// the guard that survives the holder's own content writes (unlike
+// ExpectedVersion, whose row_lock moves on every write) and still catches a
+// reclaim-and-reissue to the SAME assignee (which --if-assignee cannot see).
+func TestUpdateIssueCheckedFenceGuard(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	get := func(t *testing.T, id string) *types.Issue {
+		t.Helper()
+		iss, err := store.GetIssue(ctx, id)
+		if err != nil {
+			t.Fatalf("GetIssue(%s): %v", id, err)
+		}
+		if iss == nil {
+			t.Fatalf("GetIssue(%s) returned nil issue", id)
+		}
+		return iss
+	}
+	sptr := func(v string) *string { return &v }
+	iptr := func(v int64) *int64 { return &v }
+
+	t.Run("matching fence applies", func(t *testing.T) {
+		createPerm(t, ctx, store, "uf-match")
+		if err := store.ClaimIssue(ctx, "uf-match", "worker"); err != nil {
+			t.Fatalf("seed claim: %v", err)
+		}
+		fence := get(t, "uf-match").ClaimFence
+		if err := store.UpdateIssueChecked(ctx, "uf-match",
+			map[string]interface{}{"notes": "still mine"}, "worker",
+			storage.UpdateIssueOptions{ExpectedFence: iptr(fence)}); err != nil {
+			t.Fatalf("guarded update with live fence err = %v, want nil", err)
+		}
+		if got := get(t, "uf-match").Notes; got != "still mine" {
+			t.Fatalf("notes = %q, want %q", got, "still mine")
+		}
+	})
+
+	t.Run("fence 0 is a real never-claimed assertion", func(t *testing.T) {
+		createPerm(t, ctx, store, "uf-zero")
+		if err := store.UpdateIssueChecked(ctx, "uf-zero",
+			map[string]interface{}{"notes": "pristine"}, "tester",
+			storage.UpdateIssueOptions{ExpectedFence: iptr(0)}); err != nil {
+			t.Fatalf("fence-0 guard on a never-claimed row err = %v, want nil", err)
+		}
+		if err := store.ClaimIssue(ctx, "uf-zero", "worker"); err != nil {
+			t.Fatalf("claim: %v", err)
+		}
+		err := store.UpdateIssueChecked(ctx, "uf-zero",
+			map[string]interface{}{"notes": "should-not-apply"}, "tester",
+			storage.UpdateIssueOptions{ExpectedFence: iptr(0)})
+		if !errors.Is(err, storage.ErrFenceMismatch) {
+			t.Fatalf("err = %v, want errors.Is(_, ErrFenceMismatch) once the row has been claimed", err)
+		}
+		if got := get(t, "uf-zero").Notes; got != "pristine" {
+			t.Fatalf("notes = %q after refused update, want unchanged %q", got, "pristine")
+		}
+	})
+
+	t.Run("stale fence refuses atomically", func(t *testing.T) {
+		createPerm(t, ctx, store, "uf-stale")
+		if err := store.ClaimIssue(ctx, "uf-stale", "worker"); err != nil {
+			t.Fatalf("seed claim: %v", err)
+		}
+		stale := get(t, "uf-stale").ClaimFence
+		// Ownership moves on: release + re-claim by the SAME actor. The assignee
+		// is identical afterwards, so only the fence can catch this.
+		if err := store.UnclaimIssue(ctx, "uf-stale", "worker", false, nil); err != nil {
+			t.Fatalf("unclaim: %v", err)
+		}
+		if err := store.ClaimIssue(ctx, "uf-stale", "worker"); err != nil {
+			t.Fatalf("re-claim: %v", err)
+		}
+		err := store.UpdateIssueChecked(ctx, "uf-stale",
+			map[string]interface{}{"notes": "should-not-apply", "priority": 1}, "worker",
+			storage.UpdateIssueOptions{ExpectedAssignee: sptr("worker"), ExpectedFence: iptr(stale)})
+		if !errors.Is(err, storage.ErrFenceMismatch) {
+			t.Fatalf("err = %v, want errors.Is(_, ErrFenceMismatch)", err)
+		}
+		iss := get(t, "uf-stale")
+		if iss.Notes == "should-not-apply" || iss.Priority == 1 {
+			t.Fatalf("refused update partially applied (notes=%q priority=%d); the tx must roll back", iss.Notes, iss.Priority)
+		}
+	})
+
+	t.Run("content writes do not invalidate the fence", func(t *testing.T) {
+		createPerm(t, ctx, store, "uf-content")
+		if err := store.ClaimIssue(ctx, "uf-content", "worker"); err != nil {
+			t.Fatalf("seed claim: %v", err)
+		}
+		fence := get(t, "uf-content").ClaimFence
+		version := get(t, "uf-content").RowVersion
+		if err := store.UpdateIssue(ctx, "uf-content",
+			map[string]interface{}{"title": "edited"}, "worker"); err != nil {
+			t.Fatalf("content update: %v", err)
+		}
+		if got := get(t, "uf-content").RowVersion; got == version {
+			t.Fatalf("RowVersion unchanged after a content write; the premise of this test is wrong")
+		}
+		if err := store.UpdateIssueChecked(ctx, "uf-content",
+			map[string]interface{}{"notes": "second write"}, "worker",
+			storage.UpdateIssueOptions{ExpectedFence: iptr(fence)}); err != nil {
+			t.Fatalf("fence guard err = %v after a content-only write, want nil (fence tracks ownership, not writes)", err)
+		}
+	})
+
+	t.Run("fence composes with assignee, status and version guards", func(t *testing.T) {
+		createPerm(t, ctx, store, "uf-compose")
+		if err := store.ClaimIssue(ctx, "uf-compose", "worker"); err != nil {
+			t.Fatalf("seed claim: %v", err)
+		}
+		iss := get(t, "uf-compose")
+		// Every guard holds: the update applies.
+		if err := store.UpdateIssueChecked(ctx, "uf-compose",
+			map[string]interface{}{"notes": "all-held"}, "worker",
+			storage.UpdateIssueOptions{
+				ExpectedVersion:  iptr(iss.RowVersion),
+				ExpectedAssignee: sptr("worker"),
+				ExpectedStatus:   sptr(string(types.StatusInProgress)),
+				ExpectedFence:    iptr(iss.ClaimFence),
+			}); err != nil {
+			t.Fatalf("all four guards held but err = %v, want nil", err)
+		}
+		if got := get(t, "uf-compose").Notes; got != "all-held" {
+			t.Fatalf("notes = %q, want %q", got, "all-held")
+		}
+		// Conjunction: assignee and status still hold, only the fence is stale.
+		cur := get(t, "uf-compose")
+		err := store.UpdateIssueChecked(ctx, "uf-compose",
+			map[string]interface{}{"notes": "should-not-apply"}, "worker",
+			storage.UpdateIssueOptions{
+				ExpectedAssignee: sptr("worker"),
+				ExpectedStatus:   sptr(string(types.StatusInProgress)),
+				ExpectedFence:    iptr(cur.ClaimFence + 1),
+			})
+		if !errors.Is(err, storage.ErrFenceMismatch) {
+			t.Fatalf("err = %v, want errors.Is(_, ErrFenceMismatch) when only the fence is stale", err)
+		}
+		if got := get(t, "uf-compose").Notes; got != "all-held" {
+			t.Fatalf("notes = %q after refused update, want unchanged", got)
+		}
+	})
+
+	t.Run("wisp fence guard routes to wisps table", func(t *testing.T) {
+		createWisp(t, ctx, store, "uf-wisp")
+		// A wisp starts unclaimed at fence 0; reading it at all requires the
+		// wisps route (an issues-table read for this id would miss and refuse).
+		if err := store.UpdateIssueChecked(ctx, "uf-wisp",
+			map[string]interface{}{"title": "wisp-fenced"}, "tester",
+			storage.UpdateIssueOptions{ExpectedFence: iptr(0)}); err != nil {
+			t.Fatalf("guarded wisp update err = %v, want nil", err)
+		}
+		err := store.UpdateIssueChecked(ctx, "uf-wisp",
+			map[string]interface{}{"title": "should-not-apply"}, "tester",
+			storage.UpdateIssueOptions{ExpectedFence: iptr(9)})
+		if !errors.Is(err, storage.ErrFenceMismatch) {
+			t.Fatalf("wisp err = %v, want errors.Is(_, ErrFenceMismatch)", err)
+		}
+		if got := get(t, "uf-wisp").Title; got != "wisp-fenced" {
+			t.Fatalf("wisp title = %q after refused update, want unchanged", got)
+		}
+	})
+}
+
 // TestGuardedReassignConcurrent races two guarded reassigns of the same row —
 // both conditioned on the same expected assignee — and requires exactly one
 // winner: the loser must observe the winner's write (via the shared-tx guard

--- a/internal/storage/dolt/wisps.go
+++ b/internal/storage/dolt/wisps.go
@@ -202,9 +202,10 @@ func (s *DoltStore) updateWisp(ctx context.Context, id string, updates map[strin
 // updateWispChecked updates a wisp with the optional atomic preconditions of
 // UpdateIssueChecked, mirroring updateWisp but first enforcing — in the SAME
 // transaction — opts.ExpectedVersion (issueops.CheckVersionInTx →
-// storage.ErrVersionMismatch) and the opts.ExpectedAssignee/ExpectedStatus
-// field guards (issueops.CheckExpectedFieldsInTx → ErrAssigneeMismatch/
-// ErrStatusMismatch), so a stale precondition refuses before any write and the
+// storage.ErrVersionMismatch) and the opts.ExpectedAssignee/ExpectedStatus/
+// ExpectedFence field guards (issueops.CheckExpectedFieldsInTx →
+// ErrAssigneeMismatch/ErrStatusMismatch/ErrFenceMismatch), so a stale
+// precondition refuses before any write and the
 // deferred Rollback discards the transaction (a true compare-and-swap). Like
 // updateWisp it uses a bare BeginTx/Commit with no withRetryTx (consistent with
 // the rest of the wisp write path — do not add one here); wisps live in
@@ -221,7 +222,7 @@ func (s *DoltStore) updateWispChecked(ctx context.Context, id string, updates ma
 			return err
 		}
 	}
-	if err := issueops.CheckExpectedFieldsInTx(ctx, tx, id, opts.ExpectedAssignee, opts.ExpectedStatus); err != nil {
+	if err := issueops.CheckExpectedFieldsInTx(ctx, tx, id, opts.ExpectedAssignee, opts.ExpectedStatus, opts.ExpectedFence); err != nil {
 		return err
 	}
 	if _, err := issueops.UpdateIssueInTx(ctx, tx, id, updates, actor); err != nil {
@@ -250,9 +251,10 @@ func (s *DoltStore) closeWisp(ctx context.Context, id string, reason string, act
 
 // closeWispChecked closes a wisp with the is_blocked guard, mirroring closeWisp
 // but refusing with storage.ErrCloseBlocked when the wisp is still blocked
-// unless opts.Force is set — and, when opts.ExpectedVersion is non-nil, with
-// storage.ErrVersionMismatch when the row's RowVersion no longer matches (an
-// orthogonal CAS that Force does not bypass). The checks and the close share the
+// unless opts.Force is set — and, when opts.ExpectedVersion/opts.ExpectedFence
+// are non-nil, with storage.ErrVersionMismatch/storage.ErrFenceMismatch when the
+// row's RowVersion/ClaimFence no longer matches (orthogonal CAS guards that
+// Force does not bypass). The checks and the close share the
 // same transaction; wisps live in dolt_ignored tables, so there is no
 // DOLT_COMMIT. On any rejection the deferred Rollback discards the transaction —
 // no close or event is written.
@@ -271,7 +273,7 @@ func (s *DoltStore) closeWispChecked(ctx context.Context, id string, actor strin
 	}
 	defer func() { _ = tx.Rollback() }()
 
-	res, err := issueops.CloseIssueCheckedInTx(ctx, tx, id, opts.Reason, actor, opts.Session, opts.Force, opts.ExpectedVersion)
+	res, err := issueops.CloseIssueCheckedInTx(ctx, tx, id, opts.Reason, actor, opts.Session, opts.Force, opts.ExpectedVersion, opts.ExpectedFence)
 	if err != nil {
 		return storage.CloseIssueResult{}, err
 	}

--- a/internal/storage/domain/db/issue.go
+++ b/internal/storage/domain/db/issue.go
@@ -109,6 +109,7 @@ func (r *issueSQLRepositoryImpl) Update(ctx context.Context, id string, updates 
 	table := pickIssueTable(opts.UseWispsTable)
 
 	_, statusChanging := updates["status"]
+	_, assigneeChanging := updates["assignee"]
 	mergeOps := issueops.HasMergeOps(updates)
 
 	// When the status changes we need the prior row to reproduce the embedded
@@ -119,8 +120,11 @@ func (r *issueSQLRepositoryImpl) Update(ctx context.Context, id string, updates 
 	// all four use the same snapshot; the ErrNoRows contract is preserved.
 	// Merge operations (metadata edits, note appends) need the same read: they
 	// are resolved against the row as seen by THIS unit-of-work transaction.
+	// An assignee write needs it too: whether it is an ownership transition
+	// (and so bumps claim_fence) is decided against the stored assignee, and
+	// the embedded path reads the row unconditionally for the same reason.
 	var oldIssue *types.Issue
-	if statusChanging || mergeOps {
+	if statusChanging || assigneeChanging || mergeOps {
 		var err error
 		oldIssue, err = r.Get(ctx, id, opts)
 		if err != nil {
@@ -171,6 +175,15 @@ func (r *issueSQLRepositoryImpl) Update(ctx context.Context, id string, updates 
 	if statusChanging {
 		setClauses, args = issueops.ManageClosedAt(oldIssue, updates, setClauses, args)
 		setClauses, args = issueops.ManageStartedAt(oldIssue, updates, setClauses, args)
+	}
+
+	// Ownership transitions bump the fence, paired with the row_lock rewrite
+	// below in the same statement — the proxied path shares issueops'
+	// transition predicate so the two dispatch layers cannot drift (see
+	// issueops/fence.go). oldIssue is populated whenever the update can be one
+	// (status or assignee write).
+	if oldIssue != nil && issueops.IsOwnershipTransition(oldIssue.Status, oldIssue.Assignee, updates) {
+		setClauses = append(setClauses, issueops.FenceBumpExpr)
 	}
 
 	// Rewrite row_lock on every generic update, mirroring the classic
@@ -275,6 +288,8 @@ func (r *issueSQLRepositoryImpl) Claim(ctx context.Context, id, actor string, op
 	// (uow) path leaves row_lock unchanged — open to the cell-merge bug the
 	// row_lock invariant guards against (see issueops/lease.go). The lease
 	// itself is granted into the ephemeral leases table below, after the CAS.
+	// The same statement bumps claim_fence: every landed claim CAS is an
+	// ownership transition (see issueops/fence.go).
 	rowLockClause, rowLockArgs := issueops.RowLockClause()
 
 	// Mirror the primary path's pool-aware predicate (bd-bguz6): aliases in
@@ -315,9 +330,9 @@ func (r *issueSQLRepositoryImpl) Claim(ctx context.Context, id, actor string, op
 		//nolint:gosec // G201: table is one of two hardcoded constants
 		res, err = r.runner.ExecContext(ctx, fmt.Sprintf(`
 			UPDATE %s
-			SET assignee = ?, status = 'in_progress', updated_at = ?, started_at = ?, %s
+			SET assignee = ?, status = 'in_progress', updated_at = ?, started_at = ?, %s, %s
 			WHERE id = ? AND (%s) AND (%s)
-		`, table, rowLockClause, statusPredicate, assigneePredicate), args...)
+		`, table, issueops.FenceBumpExpr, rowLockClause, statusPredicate, assigneePredicate), args...)
 	} else {
 		args := append([]any{actor, now}, rowLockArgs...)
 		args = append(args, id)
@@ -326,9 +341,9 @@ func (r *issueSQLRepositoryImpl) Claim(ctx context.Context, id, actor string, op
 		//nolint:gosec // G201: table is one of two hardcoded constants
 		res, err = r.runner.ExecContext(ctx, fmt.Sprintf(`
 			UPDATE %s
-			SET assignee = ?, status = 'in_progress', updated_at = ?, %s
+			SET assignee = ?, status = 'in_progress', updated_at = ?, %s, %s
 			WHERE id = ? AND (%s) AND (%s)
-		`, table, rowLockClause, statusPredicate, assigneePredicate), args...)
+		`, table, issueops.FenceBumpExpr, rowLockClause, statusPredicate, assigneePredicate), args...)
 	}
 	if err != nil {
 		return domain.ClaimRowResult{}, fmt.Errorf("db: Claim %s: %w", id, err)
@@ -603,6 +618,11 @@ func insertIssueRow(ctx context.Context, runner Runner, table string, issue *typ
 	// RowVersion CAS token is stale-zero on read — the backend-divergent break
 	// the RowVersion contract (types.Issue.RowVersion) forbids. The duplicate-key
 	// path rewrites it too so an upsert also advances the token.
+	//
+	// Fence discipline on the duplicate-key path (see issueops/fence.go): an
+	// upsert that changes the stored assignee is an ownership transition, so
+	// its assignment comes FIRST, before assignee is reassigned below. The
+	// incoming fence is used for fresh rows only.
 	_, err := runner.ExecContext(ctx, fmt.Sprintf(`
 		INSERT INTO %s (
 			id, content_hash, title, description, design, acceptance_criteria, notes,
@@ -614,7 +634,7 @@ func insertIssueRow(ctx context.Context, runner Runner, table string, issue *typ
 			event_kind, actor, target, payload,
 			await_type, await_id, timeout_ns, waiters,
 			due_at, defer_until, metadata,
-			row_lock, storage_class
+			row_lock, storage_class, claim_fence
 		) VALUES (
 			?, ?, ?, ?, ?, ?, ?,
 			?, ?, ?, ?, ?,
@@ -625,9 +645,10 @@ func insertIssueRow(ctx context.Context, runner Runner, table string, issue *typ
 			?, ?, ?, ?,
 			?, ?, ?, ?,
 			?, ?, ?,
-			?, ?
+			?, ?, ?
 		)
 		ON DUPLICATE KEY UPDATE
+			%s,
 			content_hash = VALUES(content_hash),
 			title = VALUES(title),
 			description = VALUES(description),
@@ -647,7 +668,7 @@ func insertIssueRow(ctx context.Context, runner Runner, table string, issue *typ
 			close_reason = VALUES(close_reason),
 			metadata = VALUES(metadata),
 			row_lock = VALUES(row_lock)
-	`, table),
+	`, table, issueops.UpsertFenceAssignments(table, false)),
 		issue.ID, issue.ContentHash, issue.Title, issue.Description, issue.Design, issue.AcceptanceCriteria, issue.Notes,
 		string(issue.Status), issue.Priority, string(issue.IssueType), nullString(issue.Assignee), nullIntPtr(issue.EstimatedMinutes),
 		issue.CreatedAt, issue.CreatedBy, issue.Owner, issue.UpdatedAt, issue.StartedAt, issue.ClosedAt, nullStringPtr(issue.ExternalRef), issue.SpecID,
@@ -657,7 +678,7 @@ func insertIssueRow(ctx context.Context, runner Runner, table string, issue *typ
 		issue.EventKind, issue.Actor, issue.Target, issue.Payload,
 		issue.AwaitType, issue.AwaitID, issue.Timeout.Nanoseconds(), formatJSONStringArray(issue.Waiters),
 		issue.DueAt, issue.DeferUntil, jsonMetadata(issue.Metadata),
-		issueops.FreshRowLock(), nullString(string(issue.StorageClass.Normalize())),
+		issueops.FreshRowLock(), nullString(string(issue.StorageClass.Normalize())), issue.ClaimFence,
 	)
 	if err != nil {
 		return fmt.Errorf("db: insert into %s: %w", table, err)

--- a/internal/storage/domain/db/issue.go
+++ b/internal/storage/domain/db/issue.go
@@ -1031,7 +1031,9 @@ func (r *issueSQLRepositoryImpl) GetEpicsEligibleForClosure(ctx context.Context)
 }
 
 func (r *issueSQLRepositoryImpl) UnclaimIssue(ctx context.Context, id, actor string, force bool) error {
-	if err := issueops.UnclaimIssueInTx(ctx, r.runner, id, actor, force); err != nil {
+	// nil fence: `bd unclaim --if-fence` is refused in proxied-server mode
+	// rather than silently dropped, so no guard ever reaches this path.
+	if err := issueops.UnclaimIssueInTx(ctx, r.runner, id, actor, force, nil); err != nil {
 		return fmt.Errorf("db: IssueSQLRepository.UnclaimIssue: %w", err)
 	}
 	return nil

--- a/internal/storage/domain/db/issue.go
+++ b/internal/storage/domain/db/issue.go
@@ -377,10 +377,11 @@ func (r *issueSQLRepositoryImpl) Claim(ctx context.Context, id, actor string, op
 	}
 
 	// Grant the lease in the ephemeral leases table, mirroring
-	// issueops.ClaimIssueInTx. Wisps are never leased. This dual must stay in
-	// lockstep with the primary path (see the row_lock comment above).
+	// issueops.ClaimIssueInTx. Wisps are never leased. Both paths go through
+	// ClaimLeaseUpsert so the lease.auto grant policy cannot drift between
+	// them (see the row_lock comment above for the same lockstep rule).
 	if !opts.UseWispsTable {
-		if err := issueops.UpsertLeaseInTx(ctx, r.runner, id, actor, now, issueops.LeaseTTL(ctx)); err != nil {
+		if err := issueops.ClaimLeaseUpsert(ctx, r.runner, id, actor, now); err != nil {
 			return domain.ClaimRowResult{}, fmt.Errorf("db: Claim %s: %w", id, err)
 		}
 	}

--- a/internal/storage/domain/db/issue_scan_parity_test.go
+++ b/internal/storage/domain/db/issue_scan_parity_test.go
@@ -42,7 +42,7 @@ func TestScanIssue_StringTimestamps(t *testing.T) {
 	for i := range cols {
 		cols[i] = strings.TrimSpace(cols[i])
 	}
-	require.Len(t, cols, 51)
+	require.Len(t, cols, 52)
 
 	row := []driver.Value{
 		"bd-test.1", nil, "title", "desc", "", "", "", // id..notes
@@ -57,9 +57,10 @@ func TestScanIssue_StringTimestamps(t *testing.T) {
 		nil, nil, nil, // work_type, source_system, metadata
 		int64(12345),  // row_lock
 		nil,           // storage_class
+		int64(7),      // claim_fence
 		nil, nil, nil, // lease_expires_at, heartbeat_at, granted_node
 	}
-	require.Len(t, row, 51)
+	require.Len(t, row, 52)
 
 	mock.ExpectQuery("SELECT").WillReturnRows(sqlmock.NewRows(cols).AddRow(row...))
 
@@ -74,4 +75,7 @@ func TestScanIssue_StringTimestamps(t *testing.T) {
 	assert.Equal(t, time.Date(2026, 6, 12, 10, 0, 1, 0, time.UTC), issue.UpdatedAt)
 	// row_lock hydrates into the opaque RowVersion token at its positional slot.
 	assert.Equal(t, int64(12345), issue.RowVersion)
+	// claim_fence sits immediately after it; a swap between the two adjacent
+	// BIGINTs would otherwise scan clean.
+	assert.Equal(t, int64(7), issue.ClaimFence)
 }

--- a/internal/storage/domain/issue.go
+++ b/internal/storage/domain/issue.go
@@ -248,6 +248,15 @@ type UpdateSpec struct {
 	// whole-attempt retry re-checks the guards on the redo.
 	ExpectedAssignee *string
 	ExpectedStatus   *string
+
+	// ExpectedFence is the ownership-fence guard (`bd update --if-fence`),
+	// enforced by ApplyUpdate exactly like the two above: non-nil means the
+	// update applies only while the issue's ClaimFence still equals the
+	// expected value, else storage.ErrFenceMismatch and nothing is written. A
+	// pointer to 0 is a real assertion ("expected never claimed"). Unlike the
+	// assignee/status guards it survives the holder's own content writes —
+	// claim_fence moves only on ownership transitions.
+	ExpectedFence *int64
 }
 
 type IssueUseCase interface {
@@ -502,12 +511,12 @@ func (u *issueUseCaseImpl) ApplyUpdate(ctx context.Context, id string, spec Upda
 	}
 
 	// bd-wsqvw field guards: refuse the whole spec atomically on a stale
-	// assignee/status. The read shares this unit of work's transaction, and
-	// every field update rewrites row_lock, so a writer that commits during
+	// assignee/status/fence. The read shares this unit of work's transaction,
+	// and every field update rewrites row_lock, so a writer that commits during
 	// the attempt collides at commit time and the caller's whole-attempt
 	// retry re-checks here on the redo — same CAS invariant as the store-level
 	// UpdateIssueChecked path.
-	if spec.ExpectedAssignee != nil || spec.ExpectedStatus != nil {
+	if spec.ExpectedAssignee != nil || spec.ExpectedStatus != nil || spec.ExpectedFence != nil {
 		var current *types.Issue
 		if useWisp {
 			current, err = u.GetWisp(ctx, id)
@@ -527,6 +536,10 @@ func (u *issueUseCaseImpl) ApplyUpdate(ctx context.Context, id string, spec Upda
 		if spec.ExpectedStatus != nil && string(current.Status) != *spec.ExpectedStatus {
 			return nil, fmt.Errorf("%w: %s has status %q, expected %q",
 				storage.ErrStatusMismatch, id, current.Status, *spec.ExpectedStatus)
+		}
+		if spec.ExpectedFence != nil && current.ClaimFence != *spec.ExpectedFence {
+			return nil, fmt.Errorf("%w: %s has fence %d, expected %d",
+				storage.ErrFenceMismatch, id, current.ClaimFence, *spec.ExpectedFence)
 		}
 	}
 

--- a/internal/storage/embeddeddolt/issues.go
+++ b/internal/storage/embeddeddolt/issues.go
@@ -35,22 +35,25 @@ func (s *EmbeddedDoltStore) ClaimReadyIssue(ctx context.Context, filter types.Wo
 }
 
 // UnclaimIssue atomically unclaims an issue by clearing the assignee
-// and resetting status to "open". Records an "unclaimed" event.
+// and resetting status to "open". Records an "unclaimed" event. A non-nil
+// expectedFence pins the release to that ownership generation, refusing with
+// storage.ErrFenceMismatch otherwise (force does not waive it).
 // Delegates SQL work to issueops; EmbeddedDolt auto-commits the transaction.
-func (s *EmbeddedDoltStore) UnclaimIssue(ctx context.Context, id string, actor string, force bool) error {
+func (s *EmbeddedDoltStore) UnclaimIssue(ctx context.Context, id string, actor string, force bool, expectedFence *int64) error {
 	return s.withConn(ctx, true, func(tx *sql.Tx) error {
-		return issueops.UnclaimIssueInTx(ctx, tx, id, actor, force)
+		return issueops.UnclaimIssueInTx(ctx, tx, id, actor, force, expectedFence)
 	})
 }
 
 // UnclaimIssueIfAssignee releases a claim only while the issue is still assigned
 // to expectedAssignee (compare-and-swap, the inverse of ClaimIssue). Returns
 // storage.ErrAssigneeMismatch, leaving the issue untouched, when the current
-// assignee differs. Delegates SQL work to issueops; EmbeddedDolt auto-commits
-// the transaction.
-func (s *EmbeddedDoltStore) UnclaimIssueIfAssignee(ctx context.Context, id string, actor string, expectedAssignee string) error {
+// assignee differs, and storage.ErrFenceMismatch when a non-nil expectedFence
+// names a superseded ownership generation. Delegates SQL work to issueops;
+// EmbeddedDolt auto-commits the transaction.
+func (s *EmbeddedDoltStore) UnclaimIssueIfAssignee(ctx context.Context, id string, actor string, expectedAssignee string, expectedFence *int64) error {
 	return s.withConn(ctx, true, func(tx *sql.Tx) error {
-		return issueops.UnclaimIssueIfAssigneeInTx(ctx, tx, id, actor, expectedAssignee)
+		return issueops.UnclaimIssueIfAssigneeInTx(ctx, tx, id, actor, expectedAssignee, expectedFence)
 	})
 }
 
@@ -104,7 +107,7 @@ func (s *EmbeddedDoltStore) UpdateIssueChecked(ctx context.Context, id string, u
 				return err
 			}
 		}
-		if err := issueops.CheckExpectedFieldsInTx(ctx, tx, id, opts.ExpectedAssignee, opts.ExpectedStatus); err != nil {
+		if err := issueops.CheckExpectedFieldsInTx(ctx, tx, id, opts.ExpectedAssignee, opts.ExpectedStatus, opts.ExpectedFence); err != nil {
 			return err
 		}
 		_, err := issueops.UpdateIssueInTx(ctx, tx, id, updates, actor)
@@ -181,7 +184,7 @@ func (s *EmbeddedDoltStore) CloseIssue(ctx context.Context, id string, reason st
 func (s *EmbeddedDoltStore) CloseIssueChecked(ctx context.Context, id string, actor string, opts storage.CloseIssueOptions) (storage.CloseIssueResult, error) {
 	var result storage.CloseIssueResult
 	err := s.withConn(ctx, true, func(tx *sql.Tx) error {
-		res, err := issueops.CloseIssueCheckedInTx(ctx, tx, id, opts.Reason, actor, opts.Session, opts.Force, opts.ExpectedVersion)
+		res, err := issueops.CloseIssueCheckedInTx(ctx, tx, id, opts.Reason, actor, opts.Session, opts.Force, opts.ExpectedVersion, opts.ExpectedFence)
 		if err != nil {
 			return err
 		}

--- a/internal/storage/embeddeddolt/issues.go
+++ b/internal/storage/embeddeddolt/issues.go
@@ -140,6 +140,32 @@ func (s *EmbeddedDoltStore) ReclaimExpiredLeases(ctx context.Context, olderThan 
 	return reclaimed, err
 }
 
+// DisarmAutoLeases sets lease.auto=off and clears the lease rows of the claims
+// already holding one, without releasing them. The flip-then-resweep
+// sequencing (and the race it closes) belongs to
+// issueops.DisarmAutoLeasesWith; this supplies the one-transaction closure it
+// drives. Dolt versioning is the caller's job here, as everywhere in the
+// embedded store.
+func (s *EmbeddedDoltStore) DisarmAutoLeases(ctx context.Context) (int64, error) {
+	return issueops.DisarmAutoLeasesWith(func(flip bool) (int64, error) {
+		var swept int64
+		err := s.withConn(ctx, true, func(tx *sql.Tx) error {
+			if flip {
+				if err := issueops.DisarmLeaseConfigInTx(ctx, tx); err != nil {
+					return err
+				}
+			}
+			n, err := issueops.ClearArmedLeasesInTx(ctx, tx)
+			if err != nil {
+				return err
+			}
+			swept = n
+			return nil
+		})
+		return swept, err
+	})
+}
+
 // ReopenIssue reopens a closed issue, setting status to open and clearing
 // closed_at and defer_until. If reason is non-empty, it is recorded as a comment.
 // Wraps UpdateIssue; EmbeddedDolt auto-commits the transaction.

--- a/internal/storage/embeddeddolt/lease_test.go
+++ b/internal/storage/embeddeddolt/lease_test.go
@@ -205,3 +205,78 @@ func TestHeartbeatRejectsWispEmbedded(t *testing.T) {
 		t.Fatalf("wisp heartbeat err = %v, want ErrNotClaimable", err)
 	}
 }
+
+// TestEmbeddedDisarmAutoLeases mirrors the dolt-server disarm test on the
+// embedded backend, whose transaction plumbing (withConn plus a CLI-level
+// commit) is distinct from the server store's withRetryTx plus in-tx
+// DOLT_COMMIT, so the flip-and-sweep has to be exercised on both.
+func TestEmbeddedDisarmAutoLeases(t *testing.T) {
+	skipUnlessEmbeddedDolt(t)
+
+	te := newTestEnv(t, "disarm")
+	ctx := t.Context()
+
+	seed := func(id string) {
+		t.Helper()
+		issue := &types.Issue{ID: id, Title: id, Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask}
+		if err := te.store.CreateIssue(ctx, issue, "seeder"); err != nil {
+			t.Fatalf("seed %s: %v", id, err)
+		}
+	}
+
+	seed("ed-disarm")
+	if err := te.store.ClaimIssue(ctx, "ed-disarm", "alice"); err != nil {
+		t.Fatalf("claim: %v", err)
+	}
+
+	n, err := te.store.DisarmAutoLeases(ctx)
+	if err != nil {
+		t.Fatalf("disarm: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("disarmed %d, want 1", n)
+	}
+	held, err := te.store.GetIssue(ctx, "ed-disarm")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if held.Status != types.StatusInProgress || held.Assignee != "alice" {
+		t.Errorf("disarm released the claim: status=%q assignee=%q", held.Status, held.Assignee)
+	}
+	if held.LeaseExpiresAt != nil {
+		t.Error("disarm left the lease armed")
+	}
+
+	// The flip persisted: a later claim stamps nothing, and a heartbeat on it
+	// is rejected rather than arming one.
+	seed("ed-disarm2")
+	if err := te.store.ClaimIssue(ctx, "ed-disarm2", "bob"); err != nil {
+		t.Fatalf("claim2: %v", err)
+	}
+	got, err := te.store.GetIssue(ctx, "ed-disarm2")
+	if err != nil {
+		t.Fatalf("get2: %v", err)
+	}
+	if got.LeaseExpiresAt != nil {
+		t.Error("post-disarm claim stamped a lease")
+	}
+	if err := te.store.HeartbeatIssue(ctx, "ed-disarm2", "bob"); !errors.Is(err, storage.ErrUnleased) {
+		t.Errorf("heartbeat on unleased claim: got %v, want ErrUnleased", err)
+	}
+
+	// Nothing left for the reaper, and a second disarm is a no-op.
+	reclaimed, err := te.store.ReclaimExpiredLeases(ctx, 0, types.ReclaimFilter{}, "reaper")
+	if err != nil {
+		t.Fatalf("reclaim: %v", err)
+	}
+	if len(reclaimed) != 0 {
+		t.Errorf("reclaim reaped %d post-disarm, want 0", len(reclaimed))
+	}
+	again, err := te.store.DisarmAutoLeases(ctx)
+	if err != nil {
+		t.Fatalf("second disarm: %v", err)
+	}
+	if again != 0 {
+		t.Errorf("second disarm cleared %d leases, want 0", again)
+	}
+}

--- a/internal/storage/hook_decorator.go
+++ b/internal/storage/hook_decorator.go
@@ -116,9 +116,11 @@ func (h *HookFiringStore) UpdateIssue(ctx context.Context, id string, updates ma
 	return nil
 }
 
-// UpdateIssueChecked applies the guarded update (optional ExpectedVersion CAS)
-// and fires on_update on success — mirroring UpdateIssue. A version mismatch
-// (ErrVersionMismatch) or any other error returns without firing.
+// UpdateIssueChecked applies the guarded update (optional ExpectedVersion CAS
+// plus the ExpectedAssignee/ExpectedStatus/ExpectedFence field guards) and
+// fires on_update on success — mirroring UpdateIssue. A guard mismatch
+// (ErrVersionMismatch/ErrAssigneeMismatch/ErrStatusMismatch/ErrFenceMismatch)
+// or any other error returns without firing.
 func (h *HookFiringStore) UpdateIssueChecked(ctx context.Context, id string, updates map[string]interface{}, actor string, opts UpdateIssueOptions) error {
 	if err := h.inner.UpdateIssueChecked(ctx, id, updates, actor, opts); err != nil {
 		return err

--- a/internal/storage/issueops/claim.go
+++ b/internal/storage/issueops/claim.go
@@ -172,9 +172,11 @@ func ClaimIssueInTx(ctx context.Context, tx DBTX, id string, actor string) (*Cla
 	// Grant the lease: what makes the claim recoverable — a worker that dies
 	// stops heartbeating and bd reclaim later reverts the issue. Lease rows
 	// live in the ephemeral leases table (no Dolt commit, node-local). Wisps
-	// are never leased (they are ephemeral, not reclaimable work).
+	// are never leased (they are ephemeral, not reclaimable work), and a store
+	// that disarmed lease.auto gets no lease either (ClaimLeaseUpsert) — the
+	// claim itself is unaffected, fence bump included.
 	if !isWisp {
-		if err := UpsertLeaseInTx(ctx, tx, id, actor, now, leaseTTL(ctx)); err != nil {
+		if err := ClaimLeaseUpsert(ctx, tx, id, actor, now); err != nil {
 			return nil, err
 		}
 	}

--- a/internal/storage/issueops/claim.go
+++ b/internal/storage/issueops/claim.go
@@ -55,6 +55,10 @@ func ClaimIssueInTx(ctx context.Context, tx DBTX, id string, actor string) (*Cla
 	// cell-merge. The lease itself is granted separately below, in the
 	// ephemeral leases table — claims commit (status/assignee are
 	// history-worthy) but lease grants and heartbeats do not (bd-lrgn1).
+	//
+	// Every CAS that lands is an ownership transition, so it also bumps
+	// claim_fence in the same statement (see fence.go for why the bump is
+	// unconditional and why the row_lock pairing is mandatory).
 	rowLockClause, rowLockArgs := RowLockClause()
 
 	// An issue is claimable from "open" plus any configured custom status whose
@@ -96,9 +100,9 @@ func ClaimIssueInTx(ctx context.Context, tx DBTX, id string, actor string) (*Cla
 		args = append(args, assigneeArgs...)
 		result, err = tx.ExecContext(ctx, fmt.Sprintf(`
 			UPDATE %s
-			SET assignee = ?, status = 'in_progress', updated_at = ?, started_at = ?, %s
+			SET assignee = ?, status = 'in_progress', updated_at = ?, started_at = ?, %s, %s
 			WHERE id = ? AND status IN (%s) AND (%s)
-		`, issueTable, rowLockClause, statusPlaceholders, assigneePredicate), args...)
+		`, issueTable, fenceBumpExpr, rowLockClause, statusPlaceholders, assigneePredicate), args...)
 	} else {
 		args := append([]interface{}{actor, now}, rowLockArgs...)
 		args = append(args, id)
@@ -106,9 +110,9 @@ func ClaimIssueInTx(ctx context.Context, tx DBTX, id string, actor string) (*Cla
 		args = append(args, assigneeArgs...)
 		result, err = tx.ExecContext(ctx, fmt.Sprintf(`
 			UPDATE %s
-			SET assignee = ?, status = 'in_progress', updated_at = ?, %s
+			SET assignee = ?, status = 'in_progress', updated_at = ?, %s, %s
 			WHERE id = ? AND status IN (%s) AND (%s)
-		`, issueTable, rowLockClause, statusPlaceholders, assigneePredicate), args...)
+		`, issueTable, fenceBumpExpr, rowLockClause, statusPlaceholders, assigneePredicate), args...)
 	}
 	if err != nil {
 		return nil, fmt.Errorf("failed to claim issue: %w", err)

--- a/internal/storage/issueops/close.go
+++ b/internal/storage/issueops/close.go
@@ -53,9 +53,25 @@ func CloseIssueWithoutEventInTx(ctx context.Context, tx DBTX, id string, reason,
 // so this guards against a concurrent lifecycle change — not against concurrent
 // label, dependency, rename, or is_blocked writes that leave row_lock untouched
 // (see the freshRowLock invariant in lease.go).
-func CloseIssueCheckedInTx(ctx context.Context, tx DBTX, id, reason, actor, session string, force bool, expectedVersion *int64) (*CloseResult, error) {
+//
+// expectedFence is the same shape of precondition against the ownership fence
+// (storage.ErrFenceMismatch, `bd close --if-fence`), and runs alongside the
+// version check for the same reasons — before the is_blocked guard, unaffected
+// by force. It is the narrower guard of the two: claim_fence moves only on
+// ownership transitions, so a holder's own content writes do not invalidate it
+// while a reclaim-and-reissue does. Because the guard reads the row's CURRENT
+// fence, an already-closed row still holds the fence it carried at close time:
+// re-closing it with the same fence stays the idempotent no-op the
+// Storage.CloseIssueChecked contract promises, and only a genuinely superseded
+// snapshot refuses.
+func CloseIssueCheckedInTx(ctx context.Context, tx DBTX, id, reason, actor, session string, force bool, expectedVersion, expectedFence *int64) (*CloseResult, error) {
 	if expectedVersion != nil {
 		if err := CheckVersionInTx(ctx, tx, id, *expectedVersion); err != nil {
+			return nil, err
+		}
+	}
+	if expectedFence != nil {
+		if err := CheckExpectedFieldsInTx(ctx, tx, id, nil, nil, expectedFence); err != nil {
 			return nil, err
 		}
 	}

--- a/internal/storage/issueops/fence.go
+++ b/internal/storage/issueops/fence.go
@@ -1,0 +1,152 @@
+package issueops
+
+import (
+	"fmt"
+
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// fenceBumpExpr is the single SET fragment that advances a row's ownership
+// fence. claim_fence is a monotonic counter bumped ONLY on ownership
+// transitions. The canonical list — every other enumeration of it (migration
+// 0062's header, types.Issue.ClaimFence, the CHANGELOG entry) must match this
+// one:
+//
+//   - claim (the CAS in claim.go and its proxied dual in domain/db)
+//   - unclaim/release, including --force and the --if-assignee CAS form
+//   - lease reclaim
+//   - assignee change, through the generic update path or an import/upsert
+//   - reopen (closed→open) through the reopen verb or the generic update path
+//
+// Content mutations never move it, and neither does close. A caller holding a
+// stale read of the ownership state can therefore be told so, instead of
+// silently stomping newer ownership. See migration 0062 (issues) and
+// ignored/0019 (wisps).
+//
+// The claim CAS bumps UNCONDITIONALLY, and that is deliberate: a successful
+// claim of an open row already assigned to the same actor still bumps. Two
+// sessions of one user are two ownership holders, and the arriving session
+// must be able to fence out whatever the earlier one snapshotted; keying the
+// bump on "did the assignee string change" would leave that case silently
+// shared. The idempotent same-actor re-claim of an already in_progress row is
+// a different path — it never matches the CAS (in_progress is not a claimable
+// source status), returns success without writing, and so does not bump.
+//
+// IMPORT-REOPEN EXCEPTION. UpsertFenceAssignments keys the import/upsert bump
+// on an assignee change ALONE, so an import that flips a stored closed row
+// back to open while keeping the same assignee does NOT bump — where the
+// reopen verb (and the generic update path) does. That asymmetry is
+// deliberate, not an oversight: import is convergence toward a peer's
+// snapshot, not an ownership verb exercised by a live holder, and the fence is
+// a live-coordination token. Bumping on every imported status flip would let
+// a routine sync invalidate outstanding --if-fence guards held by workers on
+// this replica, for a "transition" no one on this replica performed. The
+// upsert path's one bump condition stays the one thing an import can say
+// about ownership: the owner is now someone else.
+//
+// INVARIANT: every SQL statement that bumps claim_fence MUST also rewrite
+// row_lock in the same statement. A monotonic cell is exactly the write
+// pattern Dolt cell-merges silently (two concurrent N→N+1 bumps write
+// identical values, no conflict); the random row_lock rewrite is what forces
+// racing ownership transitions to serialize. The fragment itself carries no
+// row_lock — statements that compose it own the pairing (claim pairs via
+// RowLockClause, updateIssueInTx via its unconditional row_lock append, the
+// upsert paths via their existing row_lock assignment). Literal-form bumps
+// are checked by TestFenceBumpAlwaysPairsRowLock; fragment-composed
+// statements are covered by the behavioral fence tests in
+// internal/storage/dolt.
+const fenceBumpExpr = "claim_fence = claim_fence + 1"
+
+// FenceBumpExpr exposes the bump fragment to sibling storage layers that
+// hand-roll their ownership SQL (the proxied-server domain/db repository),
+// so the fence discipline cannot drift between dispatch layers.
+const FenceBumpExpr = fenceBumpExpr
+
+// upsertAssigneeChanged renders the ON DUPLICATE KEY UPDATE predicate for
+// "this upsert changes the row's owner", with the stored side qualified by
+// the target table (main's convention for existing-row references in an
+// upsert). Both sides are COALESCEd to "" because the system has two
+// representations of unassigned — unclaim writes "", while reclaim and
+// NullString-bound inserts write NULL — and the claim WHERE clauses already
+// treat them as equivalent. Without the normalization, a content-only
+// re-import of a previously-unclaimed row ("" stored, NULL incoming) would
+// spuriously bump the fence and conflict legitimate outstanding guards.
+func upsertAssigneeChanged(table string) string {
+	return fmt.Sprintf("COALESCE(%s.assignee, '') <> COALESCE(VALUES(assignee), '')", table)
+}
+
+// UpsertFenceAssignments returns the leading ON DUPLICATE KEY UPDATE
+// assignment that applies the fence discipline to import/upsert paths: an
+// upsert that changes the stored assignee is an ownership transition, so it
+// bumps claim_fence. Callers MUST place the fragment FIRST in the assignment
+// list — ON DUPLICATE KEY UPDATE evaluates assignments in order and column
+// references see pre-assignment values only until the column is reassigned,
+// so the assignee/updated_at comparisons must run before those columns are
+// rewritten.
+//
+// Assignee change is the ONLY condition here — see the import-reopen
+// exception on fenceBumpExpr for why an imported closed→open flip that keeps
+// the owner deliberately does not bump.
+//
+// The bump⇒row_lock pairing is satisfied by the caller's own row_lock
+// assignment, which both upsert sites already carry (row_lock = VALUES(...),
+// bound to a fresh freshRowLock() on the INSERT side).
+//
+// With rejectStaleUpdate, the bump mirrors the stale guard on the column
+// assignments: the assignee only actually changes when the incoming row is
+// strictly newer, so the fence only moves then too — and row_lock, guarded by
+// the same comparison, is rewritten in exactly those cases.
+func UpsertFenceAssignments(table string, rejectStaleUpdate bool) string {
+	if rejectStaleUpdate {
+		return fmt.Sprintf("claim_fence = %s.claim_fence + IF(VALUES(updated_at) > %s.updated_at AND %s, 1, 0)",
+			table, table, upsertAssigneeChanged(table))
+	}
+	return fmt.Sprintf("claim_fence = %s.claim_fence + IF(%s, 1, 0)", table, upsertAssigneeChanged(table))
+}
+
+// IsOwnershipTransition reports whether a generic update changes the row's
+// ownership context: an assignee change, or a reopen (any transition out of
+// closed — after which a fresh claim starts a new ownership generation).
+// Shared by updateIssueInTx and the proxied domain/db Update so the
+// transition predicate cannot drift between dispatch layers.
+//
+// Deliberate exclusions: close is not a transition (guarded verbs reject
+// closed rows through their status predicates, and bumping on close would
+// invalidate legitimate orchestrator ownership snapshots for no protective
+// gain); an in_progress→open status change that keeps the assignee is not a
+// transition either — the row remains claimable only by the same assignee,
+// and the eventual re-claim or release bumps the fence at the actual
+// ownership boundary.
+func IsOwnershipTransition(oldStatus types.Status, oldAssignee string, updates map[string]interface{}) bool {
+	if raw, ok := updates["assignee"]; ok {
+		switch v := raw.(type) {
+		case string:
+			if v != oldAssignee {
+				return true
+			}
+		case nil:
+			// A nil assignee writes SQL NULL — the unassigned state
+			// (ManageLeaseOnUpdate maps it to "" the same way).
+			if oldAssignee != "" {
+				return true
+			}
+		default:
+			// Unknown value shape: treat conservatively as a transition so
+			// guards fail safe (bump when unsure).
+			return true
+		}
+	}
+	if raw, ok := updates["status"]; ok && oldStatus == types.StatusClosed {
+		var statusStr string
+		switch v := raw.(type) {
+		case string:
+			statusStr = v
+		case types.Status:
+			statusStr = string(v)
+		}
+		if statusStr != "" && types.Status(statusStr) != types.StatusClosed {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/storage/issueops/fence_invariant_test.go
+++ b/internal/storage/issueops/fence_invariant_test.go
@@ -1,0 +1,177 @@
+package issueops
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// rowLockAssigned reports whether sql assigns row_lock in its SET clause, and
+// not merely mentions it. Two near-misses have to fail: a WHERE-only reference
+// (`WHERE id = ? AND row_lock = ?` reads the cell, it does not rewrite it, so
+// it does nothing to force the conflict the fence bump needs) and a self-
+// assignment (`row_lock = row_lock` writes the same value, which is exactly
+// the silent cell-merge shape the invariant exists to prevent). The SET clause
+// is everything ahead of the first WHERE — true of every ownership UPDATE we
+// write, and of the ON DUPLICATE KEY UPDATE upsert form, which has no WHERE at
+// all.
+func rowLockAssigned(sql string) bool {
+	setClause := sql
+	if loc := whereKeyword.FindStringIndex(sql); loc != nil {
+		setClause = sql[:loc[0]]
+	}
+	if rowLockNoOp.MatchString(setClause) {
+		return false
+	}
+	return rowLockAssign.MatchString(setClause)
+}
+
+var (
+	whereKeyword  = regexp.MustCompile(`(?i)(^|\W)where(\W|$)`)
+	rowLockAssign = regexp.MustCompile(`row_lock\s*=`)
+	rowLockNoOp   = regexp.MustCompile(`row_lock\s*=\s*row_lock\b`)
+)
+
+// TestRowLockAssignedRejectsNonAssignments self-tests the guard above: the
+// pairing check is only worth anything if the near-misses fail it.
+func TestRowLockAssignedRejectsNonAssignments(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		sql  string
+		want bool
+	}{
+		{"set assignment", "UPDATE issues SET claim_fence = claim_fence + 1, row_lock = ? WHERE id = ?", true},
+		{"set assignment multiline", "UPDATE issues\n\tSET claim_fence = claim_fence + 1,\n\t    row_lock = ?\n\tWHERE id = ?", true},
+		{"upsert assignment", "INSERT ... ON DUPLICATE KEY UPDATE claim_fence = claim_fence + 1, row_lock = VALUES(row_lock)", true},
+		{"where-only mention", "UPDATE issues SET claim_fence = claim_fence + 1 WHERE id = ? AND row_lock = ?", false},
+		{"self-assignment", "UPDATE issues SET claim_fence = claim_fence + 1, row_lock = row_lock WHERE id = ?", false},
+		{"column list only", "SELECT claim_fence, row_lock FROM issues WHERE id = ?", false},
+	} {
+		if got := rowLockAssigned(tc.sql); got != tc.want {
+			t.Errorf("%s: rowLockAssigned = %v, want %v for:\n%s", tc.name, got, tc.want, tc.sql)
+		}
+	}
+}
+
+// TestFenceBumpAlwaysPairsRowLock enforces the claim_fence pairing invariant
+// at the source level for LITERAL-form bumps: every SQL string literal that
+// bumps claim_fence must ASSIGN row_lock in the same literal's SET clause — a
+// WHERE-clause mention reads the cell without rewriting it and does not
+// satisfy the invariant (see rowLockAssigned). A monotonic
+// cell is exactly the write pattern Dolt cell-merges silently — two
+// concurrent N→N+1 bumps produce identical cell values and no conflict — so
+// the random row_lock rewrite is what forces racing ownership transitions to
+// serialize (1213/1205 → withRetryTx replay). See freshRowLock in lease.go.
+//
+// Scope and honest limits: the scan covers this package AND the proxied
+// domain/db repository (the two dispatch layers that hand-write ownership
+// SQL). It cannot see fragment-composed statements — claim.go pairs
+// fenceBumpExpr with RowLockClause, updateIssueInTx with its unconditional
+// row_lock append, the upsert paths with their row_lock assignment — those
+// pairings are asserted behaviorally by the fence tests in
+// internal/storage/dolt (readFenceState checks row_lock movement on every
+// bump).
+func TestFenceBumpAlwaysPairsRowLock(t *testing.T) {
+	dirs := []string{".", "../domain/db"}
+	found := 0
+	for _, dir := range dirs {
+		fset := token.NewFileSet()
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			t.Fatalf("read %s: %v", dir, err)
+		}
+		for _, e := range entries {
+			name := e.Name()
+			if !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+				continue
+			}
+			// fence.go holds the bump expression's own definition and the
+			// shared upsert fragment builder; the fragment's pairing is owned
+			// by the statement that composes it.
+			if dir == "." && name == "fence.go" {
+				continue
+			}
+			path := filepath.Join(dir, name)
+			f, err := parser.ParseFile(fset, path, nil, 0)
+			if err != nil {
+				t.Fatalf("parse %s: %v", path, err)
+			}
+			ast.Inspect(f, func(n ast.Node) bool {
+				lit, ok := n.(*ast.BasicLit)
+				if !ok || lit.Kind != token.STRING {
+					return true
+				}
+				val, err := strconv.Unquote(lit.Value)
+				if err != nil {
+					return true
+				}
+				if !strings.Contains(val, "claim_fence = claim_fence +") {
+					return true
+				}
+				found++
+				pos := fset.Position(lit.Pos())
+				if !rowLockAssigned(val) {
+					t.Errorf("%s: SQL literal bumps claim_fence without ASSIGNING row_lock in the same statement's SET clause (a WHERE-clause mention or a row_lock = row_lock self-assignment does not count):\n%s",
+						pos, val)
+				}
+				return true
+			})
+		}
+	}
+
+	if found == 0 {
+		t.Fatal("no claim_fence bump literals found — the fence bump discipline moved or was removed; update this guard")
+	}
+}
+
+// TestFenceTransitionCoverage enforces that every ownership-transition entry
+// point in this package carries a fence bump. Transitions are enumerated
+// semantically: any statement that writes assignee, or moves status across
+// the closed boundary, changes the ownership context.
+func TestFenceTransitionCoverage(t *testing.T) {
+	// Files whose non-test SQL performs ownership transitions and therefore
+	// must contain at least one fence bump. update.go builds its SET
+	// dynamically; its bump is asserted via the fenceBumpExpr reference scan
+	// below.
+	mustBump := []string{"claim.go", "unclaim.go", "lease.go", "reopen.go"}
+	for _, name := range mustBump {
+		data, err := os.ReadFile(filepath.Clean(name))
+		if err != nil {
+			t.Fatalf("read %s: %v", name, err)
+		}
+		if !strings.Contains(string(data), "claim_fence = claim_fence + 1") &&
+			!strings.Contains(string(data), "fenceBumpExpr") {
+			t.Errorf("%s performs ownership transitions but contains no claim_fence bump", name)
+		}
+	}
+
+	// update.go: the dynamic SET builder must reference the shared bump
+	// expression for its assignee-change / reopen branches.
+	data, err := os.ReadFile("update.go")
+	if err != nil {
+		t.Fatalf("read update.go: %v", err)
+	}
+	if !strings.Contains(string(data), "fenceBumpExpr") {
+		t.Error("update.go must apply fenceBumpExpr on assignee-change and closed→open transitions")
+	}
+
+	// The proxied-server repository is the second dispatch layer: it hand-writes
+	// its own claim/update SQL and composes the bump as a fragment, which makes
+	// it INVISIBLE to the literal scan in TestFenceBumpAlwaysPairsRowLock (the
+	// literal there reads `%s` where the bump goes). Require the shared
+	// FenceBumpExpr by name so deleting the proxied bump — or open-coding a
+	// divergent one — fails here rather than only under a live proxied server.
+	proxied, err := os.ReadFile(filepath.Clean("../domain/db/issue.go"))
+	if err != nil {
+		t.Fatalf("read ../domain/db/issue.go: %v", err)
+	}
+	if !strings.Contains(string(proxied), "issueops.FenceBumpExpr") {
+		t.Error("../domain/db/issue.go performs ownership transitions on the proxied path and must compose issueops.FenceBumpExpr (its fragment-composed SQL is invisible to the literal scan)")
+	}
+}

--- a/internal/storage/issueops/helpers.go
+++ b/internal/storage/issueops/helpers.go
@@ -52,6 +52,13 @@ func TableRouting(issue *types.Issue) (issueTable, eventTable string) {
 // round-trip the JSONL interchange, wy-urlct). row_lock rides along because
 // any write that can change status/assignee must rewrite it to collide with a
 // concurrent reclaim/close on the same row (see freshRowLock in lease.go).
+//
+// claim_fence is deliberately NOT here: an incoming snapshot's fence must
+// never overwrite the stored one, because a snapshot older than the local row
+// would move the fence BACKWARD and re-validate ownership snapshots the local
+// transitions already retired. The imported value is used for fresh rows
+// only (the INSERT side); on an existing row the fence moves solely through
+// the assignee-change bump prepended by issueUpsertAssignments.
 var issueUpsertColumns = []string{
 	"content_hash", "title", "description", "design", "acceptance_criteria",
 	"notes", "status", "priority", "issue_type", "assignee",
@@ -73,7 +80,11 @@ var issueUpsertColumns = []string{
 // pre-check in InsertIssueIfNew, so their aux data (labels/comments/deps,
 // which never bump updated_at) still merges additively.
 func issueUpsertAssignments(table string, rejectStaleUpdate bool) string {
-	assignments := make([]string, 0, len(issueUpsertColumns))
+	assignments := make([]string, 0, len(issueUpsertColumns)+1)
+	// Ownership-fence discipline on import/sync (see fence.go): the fence
+	// fragment comes FIRST so its assignee/updated_at comparisons see
+	// pre-assignment values. row_lock below is what pairs with the bump.
+	assignments = append(assignments, UpsertFenceAssignments(table, rejectStaleUpdate))
 	for _, col := range issueUpsertColumns {
 		if rejectStaleUpdate {
 			// Qualify existing-row references with the table name so the target value
@@ -107,7 +118,7 @@ func insertIssueIntoTable(ctx context.Context, tx *sql.Tx, table string, issue *
 			event_kind, actor, target, payload,
 			await_type, await_id, timeout_ns, waiters,
 			due_at, defer_until, metadata,
-			row_lock, storage_class
+			row_lock, storage_class, claim_fence
 		) VALUES (
 			?, ?, ?, ?, ?, ?, ?,
 			?, ?, ?, ?, ?,
@@ -118,7 +129,7 @@ func insertIssueIntoTable(ctx context.Context, tx *sql.Tx, table string, issue *
 			?, ?, ?, ?,
 			?, ?, ?, ?,
 			?, ?, ?,
-			?, ?
+			?, ?, ?
 		)
 		ON DUPLICATE KEY UPDATE
 			%s
@@ -133,6 +144,12 @@ func insertIssueIntoTable(ctx context.Context, tx *sql.Tx, table string, issue *
 		issue.AwaitType, issue.AwaitID, issue.Timeout.Nanoseconds(), FormatJSONStringArray(issue.Waiters),
 		issue.DueAt, issue.DeferUntil, JSONMetadata(issue.Metadata),
 		freshRowLock(), NullString(string(issue.StorageClass.Normalize())),
+		// claim_fence rides fresh inserts so promote/demote table moves and
+		// import-new rows carry the ownership fence instead of resetting it to
+		// the column default; on the duplicate-key path the stored fence is
+		// governed solely by the assignee-change bump in
+		// issueUpsertAssignments, never overwritten by the incoming value.
+		issue.ClaimFence,
 	)
 	if err != nil {
 		return fmt.Errorf("insert issue into %s: %w", table, err)

--- a/internal/storage/issueops/lease.go
+++ b/internal/storage/issueops/lease.go
@@ -6,6 +6,8 @@ import (
 	"encoding/binary"
 	"fmt"
 	"os"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/steveyegge/beads/internal/config"
@@ -39,6 +41,37 @@ func leaseTTL(ctx context.Context) time.Duration {
 		return ttl
 	}
 	return DefaultLeaseTTL
+}
+
+// LeaseAutoConfigKey is the store config key governing automatic lease
+// stamping on claim. Default (unset, or anything not falsy) is ON, which is
+// the shipped behavior: every claim stamps a DefaultLeaseTTL lease and a
+// supervisor's bd reclaim recovers dead workers. Off disarms stamping for
+// deployments whose recovery authority lives elsewhere — an orchestrator with
+// its own liveness evidence — so an un-renewed fleet is never one stray
+// reclaim away from mass-reverting live work: claims carry no lease row and
+// are therefore invisible to the reaper. See `bd lease disarm`.
+const LeaseAutoConfigKey = "lease.auto"
+
+// autoLeaseEnabled reads the lease.auto store config inside the caller's
+// transaction. Only an explicitly falsy value disarms; unset, unrecognized,
+// and unreadable all leave stamping ARMED, because armed is what every store
+// shipped with and a knob that silently changes claim semantics on a failed
+// read is worse than one that ignores a typo. Disarming is an explicit
+// operator action (bd lease disarm), never an inference.
+func autoLeaseEnabled(ctx context.Context, tx DBTX) bool {
+	v, err := GetConfigInTx(ctx, tx, LeaseAutoConfigKey)
+	if err != nil {
+		return true
+	}
+	// The repo's opt-out convention (see doltserver.IsAutoStartDisabled):
+	// anything strconv.ParseBool reads as false, plus "off".
+	v = strings.TrimSpace(v)
+	if strings.EqualFold(v, "off") {
+		return false
+	}
+	b, perr := strconv.ParseBool(v)
+	return perr != nil || b
 }
 
 // freshRowLock returns a random non-zero int64 for the row_lock cell.
@@ -102,13 +135,6 @@ func FreshRowLock() int64 {
 	return freshRowLock()
 }
 
-// LeaseTTL is the exported form of leaseTTL: it resolves the lease TTL for the
-// current claim from the context (WithLeaseTTL) or falls back to
-// DefaultLeaseTTL.
-func LeaseTTL(ctx context.Context) time.Duration {
-	return leaseTTL(ctx)
-}
-
 // nodeIDContextKey overrides config.NodeID() for a single call. Used by tests
 // that have to be two replicas at once (one process, one database, two
 // granting nodes); unset in normal use, where every call resolves the real
@@ -166,6 +192,20 @@ func UpsertLeaseInTx(ctx context.Context, tx DBTX, id, holder string, now time.T
 		return fmt.Errorf("upsert lease for %s: %w", id, err)
 	}
 	return nil
+}
+
+// ClaimLeaseUpsert grants the lease for a claim that just won its CAS,
+// honoring lease.auto (see LeaseAutoConfigKey). On a disarmed store the claim
+// gets no lease, and any lease row left over from an earlier regime is
+// scrubbed so a later reclaim cannot key on it. Both claim dispatch layers —
+// ClaimIssueInTx and the proxied-server dual in internal/storage/domain/db —
+// call this one helper, so the grant policy cannot drift between them.
+// Callers route wisps away first: wisps are never leased.
+func ClaimLeaseUpsert(ctx context.Context, tx DBTX, id, holder string, now time.Time) error {
+	if !autoLeaseEnabled(ctx, tx) {
+		return DeleteLeaseInTx(ctx, tx, id)
+	}
+	return UpsertLeaseInTx(ctx, tx, id, holder, now, leaseTTL(ctx))
 }
 
 // DeleteLeaseInTx removes the lease row for an issue, if any. Call from every
@@ -272,6 +312,13 @@ func RestoreLeaseOnImportInTx(ctx context.Context, tx DBTX, issue *types.Issue, 
 // stamp issues.updated_at — updated_at keeps its merge/LWW meaning and bd
 // stale consults leases.heartbeat_at for in_progress rows instead (bd-lrgn1).
 //
+// On a disarmed store (lease.auto off) heartbeat is strictly a RENEWAL: an
+// owned in_progress row that carries no lease row is rejected with
+// storage.ErrUnleased rather than armed, because arming one as a heartbeat
+// side effect would silently re-create the unrequested reclaim exposure
+// `bd lease disarm` exists to remove. A claim that still holds a lease row
+// keeps renewing normally.
+//
 //nolint:gosec // G201: table names come from WispTableRouting (hardcoded constants)
 func HeartbeatIssueInTx(ctx context.Context, tx DBTX, id, actor string) error {
 	now := time.Now().UTC()
@@ -312,15 +359,108 @@ func HeartbeatIssueInTx(ctx context.Context, tx DBTX, id, actor string) error {
 			return fmt.Errorf("%w by %s", storage.ErrAlreadyClaimed, assignee)
 		}
 		if !isWisp && assignee == actor && status == string(types.StatusInProgress) {
-			// The caller genuinely holds the claim but has no lease row — e.g.
+			// The caller genuinely holds the claim. Either its lease row exists
+			// and the UPDATE above simply changed nothing (a same-second renewal
+			// writing identical values), or there is no lease row at all — e.g.
 			// the claim was hand-doled through a generic update (which never
 			// arms a lease, bd-9hpgf) and the worker is now opting into lease
-			// semantics. A real worker's heartbeat re-arms recovery.
+			// semantics. A real worker's heartbeat re-arms recovery, except on a
+			// disarmed store, where an unleased claim is deliberate.
+			var leased int
+			if err := tx.QueryRowContext(ctx,
+				"SELECT COUNT(*) FROM leases WHERE issue_id = ? AND holder = ?", id, actor,
+			).Scan(&leased); err != nil {
+				return fmt.Errorf("read lease row for %s: %w", id, err)
+			}
+			if leased == 0 && !autoLeaseEnabled(ctx, tx) {
+				return fmt.Errorf("%w: %s", storage.ErrUnleased, id)
+			}
 			return UpsertLeaseInTx(ctx, tx, id, actor, now, leaseTTL(ctx))
 		}
 		return fmt.Errorf("%w: %s status %s", storage.ErrNotClaimable, id, status)
 	}
 	return nil
+}
+
+// DisarmLeaseConfigInTx flips the store's lease.auto config to off. Pair it
+// with ClearArmedLeasesInTx inside the SAME transaction so turning stamping
+// off and removing the existing reclaim exposure land together, then run
+// ClearArmedLeasesInTx again in follow-up transactions until it clears zero
+// rows: a claim transaction that read lease.auto before the flip committed can
+// stamp a lease the first sweep's snapshot never saw, and because the two
+// touch disjoint rows nothing forces them to conflict. The bounded re-sweep is
+// what closes that window (see DoltStore.DisarmAutoLeases).
+func DisarmLeaseConfigInTx(ctx context.Context, tx DBTX) error {
+	if err := SetConfigInTx(ctx, tx, LeaseAutoConfigKey, "off"); err != nil {
+		return fmt.Errorf("set %s=off: %w", LeaseAutoConfigKey, err)
+	}
+	return nil
+}
+
+// ClearArmedLeasesInTx deletes the lease row of every live claim without
+// releasing anything: status, assignee and started_at are untouched and
+// claim_fence does not move, because disarming is lease bookkeeping, not an
+// ownership transition. Wisps are never leased, so there is a single tier to
+// sweep. A racing heartbeat or reclaim contends on the same lease row being
+// deleted and conflicts rather than cell-merging. Returns the number of lease
+// rows cleared.
+func ClearArmedLeasesInTx(ctx context.Context, tx DBTX) (int64, error) {
+	res, err := tx.ExecContext(ctx, `
+		DELETE FROM leases
+		WHERE issue_id IN (SELECT id FROM issues WHERE status = 'in_progress')
+	`)
+	if err != nil {
+		return 0, fmt.Errorf("disarm armed leases: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return 0, fmt.Errorf("disarm rows affected: %w", err)
+	}
+	return n, nil
+}
+
+// maxDisarmResweeps bounds the follow-up sweeps in DisarmAutoLeasesWith.
+const maxDisarmResweeps = 3
+
+// DisarmAutoLeasesWith drives the flip-then-resweep protocol that
+// DisarmLeaseConfigInTx and ClearArmedLeasesInTx are two halves of, so the loop
+// and its bound live beside them instead of being copied into every backend.
+//
+// run performs exactly ONE transaction and returns the lease rows it cleared.
+// flip=true means "set lease.auto=off AND sweep" — the pair MUST share a
+// transaction, or a claim landing between them arms a lease nothing removes;
+// flip=false means "sweep only". Each store passes its own closure so its
+// transaction plumbing and Dolt versioning stay its own business (the server
+// store commits the config flip inside the closure; the embedded store leaves
+// versioning to its caller).
+//
+// After the flip, up to maxDisarmResweeps follow-up sweeps catch claims whose
+// transactions read lease.auto BEFORE the flip committed and stamped a lease
+// the first sweep's snapshot never saw — disjoint rows, so nothing forces them
+// to conflict. Every transaction begun after the flip reads off, so the sweeps
+// converge in a pass or two rather than chasing a moving target; the bound is
+// what stops a pathological arrival rate from spinning here, and a store that
+// somehow has not converged is simply swept again by the next disarm.
+//
+// Returns the total rows cleared. A failure in the flip transaction returns 0
+// (nothing is known to have been swept); a failure in a later sweep returns the
+// partial total alongside the error, because those rows really were cleared.
+func DisarmAutoLeasesWith(run func(flip bool) (int64, error)) (int64, error) {
+	total, err := run(true)
+	if err != nil {
+		return 0, err
+	}
+	for i := 0; i < maxDisarmResweeps; i++ {
+		n, err := run(false)
+		if err != nil {
+			return total, err
+		}
+		total += n
+		if n == 0 {
+			break
+		}
+	}
+	return total, nil
 }
 
 // warnReplica writes a replica-guard audit line to STDERR (never stdout —

--- a/internal/storage/issueops/lease.go
+++ b/internal/storage/issueops/lease.go
@@ -60,13 +60,15 @@ func leaseTTL(ctx context.Context) time.Duration {
 // in_progress issue MUST rewrite row_lock — that is the set the reclaim/close
 // races care about (claim, close, updateIssueInTx, reclaim, unclaim all do).
 // Paths that touch only orthogonal cells (is_blocked, compaction_level,
-// dependency metadata, rename, or reopen — which acts on closed rows) are safe
-// to merge with a reclaim and intentionally do NOT rewrite it. Heartbeats no
-// longer touch the issues row at all (bd-lrgn1): the lease lives in the
-// ephemeral leases table, where a racing heartbeat and reclaim contend on the
-// SAME lease row and conflict without any help. Adding a new path that sets
-// status/assignee outside updateIssueInTx without rewriting row_lock would
-// silently reintroduce the zombie-merge bug.
+// dependency metadata, rename) are safe to merge with a reclaim and
+// intentionally do NOT rewrite it. Reopen does rewrite it — not for the
+// reclaim race (it acts on closed rows) but because it bumps claim_fence, and
+// every fence bump must pair with a row_lock rewrite (see fence.go).
+// Heartbeats no longer touch the issues row at all (bd-lrgn1): the lease
+// lives in the ephemeral leases table, where a racing heartbeat and reclaim
+// contend on the SAME lease row and conflict without any help. Adding a new
+// path that sets status/assignee outside updateIssueInTx without rewriting
+// row_lock would silently reintroduce the zombie-merge bug.
 func freshRowLock() int64 {
 	var b [8]byte
 	if _, err := rand.Read(b[:]); err != nil {
@@ -387,9 +389,10 @@ func reclaimReplicaSQL(filter types.ReclaimFilter, localNode string) (string, []
 
 // ReclaimExpiredLeasesInTx reverts in_progress issues whose lease has gone stale
 // back to ready: the lease row is deleted, then status → open, assignee cleared,
-// started_at cleared, and a fresh row_lock so the reclaim conflicts with a
-// racing close/update on the same issues row (see freshRowLock). An issue is
-// stale when its lease row's lease_expires_at is strictly before cutoff.
+// started_at cleared, claim_fence bumped (the previous holder is fenced out),
+// and a fresh row_lock so the reclaim conflicts with a racing close/update on
+// the same issues row (see freshRowLock). An issue is stale when its lease
+// row's lease_expires_at is strictly before cutoff.
 // Callers pass cutoff = now - graceWindow (the supervisor uses graceWindow =
 // 2×TTL) so only leases that expired a safe margin ago — i.e. workers that are
 // almost certainly dead — are reclaimed.
@@ -427,9 +430,9 @@ func reclaimReplicaSQL(filter types.ReclaimFilter, localNode string) (string, []
 // round.
 //
 // Reclaim only ever touches the permanent issues table: wisps are ephemeral and
-// are never leased work. Returns the issues it reverted (id + the owner it took
-// the lease from) so the caller can log/emit recovery events. The caller owns
-// Dolt versioning.
+// are never leased work. Returns the issues it reverted (id, the owner it took
+// the lease from, and the post-bump claim_fence that fences that owner out) so
+// the caller can log/emit recovery events. The caller owns Dolt versioning.
 //
 // filter narrows which stale leases are eligible (see types.ReclaimFilter); the
 // zero filter keeps the historical global behavior. Scoping is applied to the
@@ -449,7 +452,7 @@ func ReclaimExpiredLeasesInTx(ctx context.Context, tx DBTX, cutoff time.Time, fi
 	args := append([]any{cutoff}, replicaArgs...)
 	args = append(args, scopeArgs...)
 	rows, err := tx.QueryContext(ctx, `
-		SELECT l.issue_id, COALESCE(i.assignee, ''), COALESCE(l.granted_node, '') FROM leases l
+		SELECT l.issue_id, COALESCE(i.assignee, ''), COALESCE(l.granted_node, ''), i.claim_fence FROM leases l
 		JOIN issues i ON i.id = l.issue_id
 		WHERE i.status = 'in_progress'
 		  AND l.lease_expires_at < ?
@@ -464,9 +467,11 @@ func ReclaimExpiredLeasesInTx(ctx context.Context, tx DBTX, cutoff time.Time, fi
 	// recovery record every backend returns to callers.
 	staleNodes := map[string]string{}
 	for rows.Next() {
+		// r.ClaimFence holds the PRE-bump fence until the revert below lands;
+		// see the derivation comment there.
 		var r types.ReclaimedLease
 		var grantedNode string
-		if err := rows.Scan(&r.ID, &r.PreviousOwner, &grantedNode); err != nil {
+		if err := rows.Scan(&r.ID, &r.PreviousOwner, &grantedNode, &r.ClaimFence); err != nil {
 			_ = rows.Close()
 			return nil, fmt.Errorf("scan stale lease row: %w", err)
 		}
@@ -517,10 +522,13 @@ func ReclaimExpiredLeasesInTx(ctx context.Context, tx DBTX, cutoff time.Time, fi
 		// Revert the issue itself. status is re-checked so a row that stopped
 		// being in_progress under us (closed) is left alone; row_lock makes a
 		// concurrent close/update conflict at commit time rather than
-		// cell-merge with this write.
+		// cell-merge with this write. Taking a claim away is an ownership
+		// transition, so claim_fence advances in the same statement (see
+		// fence.go).
 		res, err = tx.ExecContext(ctx, `
 			UPDATE issues
 			SET status = 'open', assignee = NULL, started_at = NULL,
+			    claim_fence = claim_fence + 1,
 			    updated_at = ?, row_lock = ?
 			WHERE id = ? AND status = 'in_progress'
 		`, time.Now().UTC(), freshRowLock(), r.ID)
@@ -534,6 +542,28 @@ func ReclaimExpiredLeasesInTx(ctx context.Context, tx DBTX, cutoff time.Time, fi
 		if n == 0 {
 			continue // no longer in_progress — its lease row was stale anyway
 		}
+		// Report the post-bump fence so the caller holds the value that fences
+		// out the previous holder — DERIVED, not re-read.
+		//
+		// The derivation is exact, and a read-back could not be more accurate.
+		// The snapshot SELECT above and this UPDATE run in the SAME sql.Tx,
+		// i.e. on one pinned connection, and each Dolt connection has its own
+		// independent working set (see dolt.runDoltTransaction): reads and
+		// writes inside the transaction both resolve against that working set,
+		// so `claim_fence + 1` increments precisely the value the snapshot
+		// read. Nothing between them touches this row's fence — the DELETE
+		// hits leases, and leases.issue_id is a PRIMARY KEY, so each id
+		// appears in the snapshot at most once. A read-back here would return
+		// the transaction's own uncommitted write, which is this same number.
+		//
+		// A concurrent bump from another session cannot make the report lie
+		// either: it lands in a different working set, and the paired row_lock
+		// rewrite (see fence.go) turns the overlap into a commit-time conflict
+		// (1213/1205) that withRetryTx replays from the top with a fresh
+		// snapshot, or that surfaces as an error and discards the report
+		// entirely. The number is only ever observed on the commit that
+		// actually wrote it.
+		r.ClaimFence++
 		if err := RecordFullEventInTable(ctx, tx, "events", r.ID, types.EventLeaseReclaimed, actor,
 			r.PreviousOwner, ""); err != nil {
 			return nil, fmt.Errorf("record reclaim event for %s: %w", r.ID, err)

--- a/internal/storage/issueops/lease_disarm_test.go
+++ b/internal/storage/issueops/lease_disarm_test.go
@@ -1,0 +1,110 @@
+package issueops
+
+import (
+	"errors"
+	"testing"
+)
+
+// stubSweeps turns a scripted list of per-call results into a run closure for
+// DisarmAutoLeasesWith, recording the flip argument of every call so the
+// protocol (exactly one flip, first, then sweep-only) is checkable.
+func stubSweeps(results []struct {
+	n   int64
+	err error
+}) (func(bool) (int64, error), *[]bool) {
+	var flips []bool
+	i := 0
+	return func(flip bool) (int64, error) {
+		flips = append(flips, flip)
+		if i >= len(results) {
+			// Not a t.Fatalf: the driver is the thing under test, and an
+			// over-run is reported by the call-count assertions.
+			return 0, errors.New("run called more times than the script allows")
+		}
+		r := results[i]
+		i++
+		return r.n, r.err
+	}, &flips
+}
+
+type sweepResult = struct {
+	n   int64
+	err error
+}
+
+// TestDisarmAutoLeasesWithConverges: the flip sweeps 2, the first re-sweep
+// finds 1 more (a claim that read lease.auto before the flip committed), the
+// second finds nothing and the driver stops there rather than burning its
+// remaining budget.
+func TestDisarmAutoLeasesWithConverges(t *testing.T) {
+	run, flips := stubSweeps([]sweepResult{{n: 2}, {n: 1}, {n: 0}})
+
+	total, err := DisarmAutoLeasesWith(run)
+	if err != nil {
+		t.Fatalf("err = %v, want nil", err)
+	}
+	if total != 3 {
+		t.Errorf("total = %d, want 3 (2 + 1 + 0)", total)
+	}
+	if got := *flips; len(got) != 3 {
+		t.Fatalf("run called %d times, want 3 (flip + two sweeps, stopping on the zero)", len(got))
+	}
+	if !(*flips)[0] || (*flips)[1] || (*flips)[2] {
+		t.Errorf("flip sequence = %v, want [true false false] (exactly one flip, first)", *flips)
+	}
+}
+
+// TestDisarmAutoLeasesWithBoundsResweeps: a store that keeps producing lease
+// rows must not spin. The driver runs the flip plus at most three re-sweeps and
+// returns what it cleared, even though the last one was nonzero.
+func TestDisarmAutoLeasesWithBoundsResweeps(t *testing.T) {
+	run, flips := stubSweeps([]sweepResult{{n: 5}, {n: 4}, {n: 3}, {n: 2}, {n: 1}})
+
+	total, err := DisarmAutoLeasesWith(run)
+	if err != nil {
+		t.Fatalf("err = %v, want nil", err)
+	}
+	if got := len(*flips); got != 4 {
+		t.Fatalf("run called %d times, want 4 (flip + %d re-sweeps, never a 4th re-sweep)", got, maxDisarmResweeps)
+	}
+	if total != 14 {
+		t.Errorf("total = %d, want 14 (5 + 4 + 3 + 2)", total)
+	}
+}
+
+// TestDisarmAutoLeasesWithFlipError: nothing is known to have been swept when
+// the flip transaction itself fails, so the count is 0 and the error surfaces.
+func TestDisarmAutoLeasesWithFlipError(t *testing.T) {
+	boom := errors.New("flip failed")
+	run, flips := stubSweeps([]sweepResult{{n: 7, err: boom}})
+
+	total, err := DisarmAutoLeasesWith(run)
+	if !errors.Is(err, boom) {
+		t.Fatalf("err = %v, want the flip error", err)
+	}
+	if total != 0 {
+		t.Errorf("total = %d, want 0 (the flip transaction did not land)", total)
+	}
+	if got := len(*flips); got != 1 {
+		t.Errorf("run called %d times, want 1 (no re-sweeps after a failed flip)", got)
+	}
+}
+
+// TestDisarmAutoLeasesWithResweepError: a re-sweep failing mid-loop must report
+// the partial total alongside the error — those rows really were cleared, and a
+// caller told "0" would misreport the exposure it just removed.
+func TestDisarmAutoLeasesWithResweepError(t *testing.T) {
+	boom := errors.New("resweep failed")
+	run, flips := stubSweeps([]sweepResult{{n: 6}, {n: 2}, {n: 0, err: boom}})
+
+	total, err := DisarmAutoLeasesWith(run)
+	if !errors.Is(err, boom) {
+		t.Fatalf("err = %v, want the re-sweep error", err)
+	}
+	if total != 8 {
+		t.Errorf("total = %d, want 8 (the 6 + 2 already cleared before the failure)", total)
+	}
+	if got := len(*flips); got != 3 {
+		t.Errorf("run called %d times, want 3 (the loop stops at the failure)", got)
+	}
+}

--- a/internal/storage/issueops/reopen.go
+++ b/internal/storage/issueops/reopen.go
@@ -32,10 +32,16 @@ func ReopenIssueInTx(ctx context.Context, tx DBTX, id, reason, actor string) (*R
 
 	now := time.Now().UTC()
 
+	// Reopen resets the row's ownership context (a later claim starts a fresh
+	// ownership generation), so it bumps claim_fence — paired with a row_lock
+	// rewrite in the same statement per the fence invariant (see fence.go).
+	// The generic status-update reopen path in updateIssueInTx applies the
+	// same bump.
 	result, err := tx.ExecContext(ctx, fmt.Sprintf(`
-		UPDATE %s SET status = ?, closed_at = NULL, close_reason = '', closed_by_session = '', defer_until = NULL, updated_at = ?
+		UPDATE %s SET status = ?, closed_at = NULL, close_reason = '', closed_by_session = '', defer_until = NULL, updated_at = ?,
+			claim_fence = claim_fence + 1, row_lock = ?
 		WHERE id = ? AND status = ?
-	`, issueTable), types.StatusOpen, now, id, types.StatusClosed)
+	`, issueTable), types.StatusOpen, now, freshRowLock(), id, types.StatusClosed)
 	if err != nil {
 		return nil, fmt.Errorf("failed to reopen issue: %w", err)
 	}

--- a/internal/storage/issueops/scan.go
+++ b/internal/storage/issueops/scan.go
@@ -23,13 +23,15 @@ const IssueSelectColumns = sqlbuild.IssueSelectColumns
 //
 // metadata is intentionally retained — it is small and read by routing.
 //
-// row_lock and the leases.* overlay (lease_expires_at, heartbeat_at,
-// granted_node; lease_expires_at/heartbeat_at added by migration 0054 after
-// this list was first written, see #4150; granted_node added by migration
-// 0016/wy-jpd3.7 for replica-aware leases) are also retained: all three are
-// small, non-TEXT columns that routing/claim code reads (optimistic
-// concurrency token, active-lease state, granting replica), not the
-// multi-KB bodies this split exists to skip. Any query selecting
+// row_lock, storage_class, claim_fence and the leases.* overlay
+// (lease_expires_at, heartbeat_at, granted_node; lease_expires_at/heartbeat_at
+// added by migration 0054 after this list was first written, see #4150;
+// granted_node added by migration 0016/wy-jpd3.7 for replica-aware leases;
+// storage_class by migration 0060; claim_fence by migration 0062) are also
+// retained: they are all small, non-TEXT columns that routing/claim code reads
+// (optimistic concurrency token, storage class, ownership fence, active-lease
+// state, granting replica), not the multi-KB bodies this
+// split exists to skip. Any query selecting
 // IssueSelectColumnsLite must include sqlbuild.LeaseJoin(table) in its FROM
 // clause, exactly as full hydration does (see issueLiteProjection in
 // search.go, joinLeases: true).
@@ -42,7 +44,7 @@ const IssueSelectColumnsLite = `id, content_hash, title,
 	       mol_type,
 	       event_kind, actor, target,
 	       due_at, defer_until,
-	       work_type, source_system, metadata, row_lock, storage_class,
+	       work_type, source_system, metadata, row_lock, storage_class, claim_fence,
 	       leases.lease_expires_at, leases.heartbeat_at, leases.granted_node`
 
 // HeavyDropList enumerates the columns omitted from IssueSelectColumnsLite.
@@ -91,6 +93,7 @@ func ScanIssueFrom(s IssueScanner, extra ...any) (*types.Issue, error) {
 	var metadata sql.NullString
 	var rowLock sql.NullInt64       // row_lock column (NOT NULL DEFAULT 0); scanned defensively so NULL maps to 0
 	var storageClass sql.NullString // storage_class column (migration 0060); NULL = unset, resolves per EffectiveStorageClass
+	var claimFence sql.NullInt64    // claim_fence column (migration 0062; NOT NULL DEFAULT 0), same defensive scan
 
 	dests := []any{
 		&issue.ID, &contentHash, &issue.Title, &issue.Description, &issue.Design,
@@ -103,7 +106,7 @@ func ScanIssueFrom(s IssueScanner, extra ...any) (*types.Issue, error) {
 		&molType,
 		&eventKind, &actor, &target, &payload,
 		&dueAt, &deferUntil,
-		&workType, &sourceSystem, &metadata, &rowLock, &storageClass,
+		&workType, &sourceSystem, &metadata, &rowLock, &storageClass, &claimFence,
 		&leaseExpiresAt, &heartbeatAt, &leaseGrantedNode,
 	}
 	dests = append(dests, extra...)
@@ -232,6 +235,9 @@ func ScanIssueFrom(s IssueScanner, extra ...any) (*types.Issue, error) {
 	if storageClass.Valid {
 		issue.StorageClass = types.StorageClass(storageClass.String)
 	}
+	// Ownership fence (migration 0062); 0 on rows never claimed since the
+	// column was added.
+	issue.ClaimFence = claimFence.Int64
 	// Lease columns (migration 0054); NULL when no active lease.
 	if leaseExpiresAt.Valid {
 		issue.LeaseExpiresAt = &leaseExpiresAt.Time
@@ -269,6 +275,7 @@ func ScanIssueLiteFrom(s IssueScanner, extra ...any) (*types.Issue, error) {
 	var metadata sql.NullString
 	var rowLock sql.NullInt64       // row_lock column (NOT NULL DEFAULT 0); scanned defensively so NULL maps to 0
 	var storageClass sql.NullString // storage_class column (migration 0060); NULL = unset, resolves per EffectiveStorageClass
+	var claimFence sql.NullInt64    // claim_fence column (migration 0062; NOT NULL DEFAULT 0), same defensive scan
 
 	dests := []any{
 		&issue.ID, &contentHash, &issue.Title,
@@ -281,7 +288,7 @@ func ScanIssueLiteFrom(s IssueScanner, extra ...any) (*types.Issue, error) {
 		&molType,
 		&eventKind, &actor, &target,
 		&dueAt, &deferUntil,
-		&workType, &sourceSystem, &metadata, &rowLock, &storageClass,
+		&workType, &sourceSystem, &metadata, &rowLock, &storageClass, &claimFence,
 		&leaseExpiresAt, &heartbeatAt, &leaseGrantedNode,
 	}
 	dests = append(dests, extra...)
@@ -401,6 +408,9 @@ func ScanIssueLiteFrom(s IssueScanner, extra ...any) (*types.Issue, error) {
 	if storageClass.Valid {
 		issue.StorageClass = types.StorageClass(storageClass.String)
 	}
+	// Ownership fence (migration 0062); 0 on rows never claimed since the
+	// column was added.
+	issue.ClaimFence = claimFence.Int64
 	// Lease columns (migration 0054); NULL when no active lease.
 	if leaseExpiresAt.Valid {
 		issue.LeaseExpiresAt = &leaseExpiresAt.Time

--- a/internal/storage/issueops/search_lite_merge_test.go
+++ b/internal/storage/issueops/search_lite_merge_test.go
@@ -25,7 +25,7 @@ func liteColumnNames() []string {
 		"mol_type",
 		"event_kind", "actor", "target",
 		"due_at", "defer_until",
-		"work_type", "source_system", "metadata", "row_lock", "storage_class",
+		"work_type", "source_system", "metadata", "row_lock", "storage_class", "claim_fence",
 		"lease_expires_at", "heartbeat_at", "granted_node",
 	}
 }
@@ -45,7 +45,7 @@ func liteMergeRow(id string, createdAt time.Time) []driver.Value {
 		nil,           // mol_type
 		nil, nil, nil, // event_kind, actor, target
 		nil, nil, // due_at, defer_until
-		nil, nil, nil, 0, nil, // work_type, source_system, metadata, row_lock, storage_class
+		nil, nil, nil, 0, nil, 0, // work_type, source_system, metadata, row_lock, storage_class, claim_fence
 		nil, nil, nil, // lease_expires_at, heartbeat_at, granted_node
 	}
 }

--- a/internal/storage/issueops/unclaim.go
+++ b/internal/storage/issueops/unclaim.go
@@ -10,6 +10,19 @@ import (
 	"github.com/steveyegge/beads/internal/types"
 )
 
+// fenceMismatch returns the ownership-fence refusal when expectedFence is set
+// and does not match the row's current claim_fence, and nil otherwise. Both
+// release forms check the fence twice — once up front against the read row, and
+// once more when disambiguating a 0-row UPDATE — so all four checks route
+// through here and the wording (mirroring the ErrStatusMismatch shape) cannot
+// drift between them.
+func fenceMismatch(id string, current int64, expectedFence *int64) error {
+	if expectedFence == nil || current == *expectedFence {
+		return nil
+	}
+	return fmt.Errorf("%w: %s has fence %d, expected %d", storage.ErrFenceMismatch, id, current, *expectedFence)
+}
+
 // UnclaimIssueInTx atomically releases a claimed issue: it clears the assignee,
 // resets status to "open", clears started_at, deletes the issue's lease row
 // (see UpsertLeaseInTx) and rewrites row_lock so a concurrent reclaim or close
@@ -21,14 +34,23 @@ import (
 // second agent cannot yank a claim it does not hold. Pass force=true to bypass
 // the ownership check (admin/reaper use, threaded from `bd unclaim --force`).
 //
+// A non-nil expectedFence pins the release to one ownership generation: the
+// issue's current claim_fence must still equal *expectedFence or the release
+// refuses with storage.ErrFenceMismatch, leaving the row untouched. It is an
+// ADDITIONAL conjunct, never a substitute: the ownership check above runs
+// first and unchanged, so a satisfied fence does not authorize a cross-actor
+// release (a guard establishes freshness, not authority), and force — which
+// waives ownership — does not waive a supplied fence.
+//
 // Only works on issues that have an assignee and status is "open" or
 // "in_progress". Returns error if:
 //   - Issue is closed (cannot unclaim closed issues)
 //   - Issue has no assignee (nothing to unclaim)
 //   - Issue is claimed by a different actor and force is false (ErrNotOwner)
+//   - expectedFence is non-nil and the current fence differs (ErrFenceMismatch)
 //
 //nolint:gosec // G201: table names come from WispTableRouting (hardcoded constants)
-func UnclaimIssueInTx(ctx context.Context, tx DBTX, id string, actor string, force bool) error {
+func UnclaimIssueInTx(ctx context.Context, tx DBTX, id string, actor string, force bool, expectedFence *int64) error {
 	// Route to the correct table (issues/wisps) automatically, matching
 	// ClaimIssueInTx — a wisp claim lives in the wisp tables, so its release
 	// must update them too rather than no-op against the permanent issues table.
@@ -57,13 +79,21 @@ func UnclaimIssueInTx(ctx context.Context, tx DBTX, id string, actor string, for
 			storage.ErrNotOwner, id, oldIssue.Assignee)
 	}
 
+	// Ownership fence conjunct. Checked AFTER the owner check so a stale
+	// releaser is told it does not own the issue rather than which generation
+	// it missed, and applied even under force.
+	if err := fenceMismatch(id, oldIssue.ClaimFence, expectedFence); err != nil {
+		return err
+	}
+
 	now := time.Now().UTC()
 
 	// Atomic UPDATE: clear assignee, reset status to open, clear started_at,
 	// and rewrite row_lock. The predicate re-checks ownership (unless forced)
-	// so a claim that changed hands between the read above and this write is
-	// not clobbered. row_lock forces a racing reclaim/close on the same row to
-	// conflict rather than silently merge (see lease.go invariant).
+	// and the fence (when supplied) so a claim that changed hands between the
+	// read above and this write is not clobbered. row_lock forces a racing
+	// reclaim/close on the same row to conflict rather than silently merge (see
+	// lease.go invariant).
 	ownerPredicate := "AND assignee = ?"
 	args := []interface{}{now, freshRowLock(), id, actor}
 	if force {
@@ -71,12 +101,17 @@ func UnclaimIssueInTx(ctx context.Context, tx DBTX, id string, actor string, for
 		ownerPredicate = "AND assignee != ''"
 		args = []interface{}{now, freshRowLock(), id}
 	}
+	fencePredicate := ""
+	if expectedFence != nil {
+		fencePredicate = "AND claim_fence = ?"
+		args = append(args, *expectedFence)
+	}
 	result, err := tx.ExecContext(ctx, fmt.Sprintf(`
 		UPDATE %s
 		SET assignee = '', status = 'open', updated_at = ?,
 		    started_at = NULL, claim_fence = claim_fence + 1, row_lock = ?
-		WHERE id = ? AND status IN ('open', 'in_progress') %s
-	`, issueTable, ownerPredicate), args...)
+		WHERE id = ? AND status IN ('open', 'in_progress') %s %s
+	`, issueTable, ownerPredicate, fencePredicate), args...)
 	if err != nil {
 		return fmt.Errorf("failed to unclaim issue: %w", err)
 	}
@@ -97,6 +132,9 @@ func UnclaimIssueInTx(ctx context.Context, tx DBTX, id string, actor string, for
 		if !force && current.Assignee != actor {
 			return fmt.Errorf("%w: %s is held by %s; coordinate with the holder — pass --force only if their claim is abandoned (crashed agent, expired lease)",
 				storage.ErrNotOwner, id, current.Assignee)
+		}
+		if err := fenceMismatch(id, current.ClaimFence, expectedFence); err != nil {
+			return err
 		}
 		return fmt.Errorf("failed to unclaim issue %s: no matching row", id)
 	}
@@ -137,8 +175,13 @@ func finishUnclaimInTx(ctx context.Context, tx DBTX, eventTable string, id strin
 // storage.ErrAssigneeMismatch naming the current holder and leaves the row
 // untouched. actor is recorded as the event author.
 //
+// A non-nil expectedFence adds the ownership-fence conjunct: both the assignee
+// and the fence must match, and a fence-only miss is reported distinctly as
+// storage.ErrFenceMismatch so a caller can tell "someone else holds it" from
+// "the same holder, but a later generation of the claim".
+//
 //nolint:gosec // G201: table names come from WispTableRouting (hardcoded constants)
-func UnclaimIssueIfAssigneeInTx(ctx context.Context, tx DBTX, id string, actor string, expectedAssignee string) error {
+func UnclaimIssueIfAssigneeInTx(ctx context.Context, tx DBTX, id string, actor string, expectedAssignee string, expectedFence *int64) error {
 	if expectedAssignee == "" {
 		return fmt.Errorf("conditional unclaim of %s: expected assignee must not be empty (use UnclaimIssueInTx for an unconditional release)", id)
 	}
@@ -165,19 +208,29 @@ func UnclaimIssueIfAssigneeInTx(ctx context.Context, tx DBTX, id string, actor s
 	if oldIssue.Assignee != expectedAssignee {
 		return fmt.Errorf("%w: %s is held by %q, expected %q", storage.ErrAssigneeMismatch, id, oldIssue.Assignee, expectedAssignee)
 	}
+	if err := fenceMismatch(id, oldIssue.ClaimFence, expectedFence); err != nil {
+		return err
+	}
 
 	now := time.Now().UTC()
 
-	// Atomic UPDATE pinned to the expected assignee (CAS), applying the same
-	// transition as UnclaimIssueInTx: clear assignee, reset status to open,
-	// clear started_at, and rewrite row_lock so a racing reclaim/close on the
-	// same row conflicts rather than silently merging (see lease.go invariant).
+	// Atomic UPDATE pinned to the expected assignee (CAS) and, when supplied,
+	// the expected fence, applying the same transition as UnclaimIssueInTx:
+	// clear assignee, reset status to open, clear started_at, and rewrite
+	// row_lock so a racing reclaim/close on the same row conflicts rather than
+	// silently merging (see lease.go invariant).
+	args := []interface{}{now, freshRowLock(), id, expectedAssignee}
+	fencePredicate := ""
+	if expectedFence != nil {
+		fencePredicate = "AND claim_fence = ?"
+		args = append(args, *expectedFence)
+	}
 	result, err := tx.ExecContext(ctx, fmt.Sprintf(`
 		UPDATE %s
 		SET assignee = '', status = 'open', updated_at = ?,
 		    started_at = NULL, claim_fence = claim_fence + 1, row_lock = ?
-		WHERE id = ? AND status IN ('open', 'in_progress') AND assignee = ?
-	`, issueTable), now, freshRowLock(), id, expectedAssignee)
+		WHERE id = ? AND status IN ('open', 'in_progress') AND assignee = ? %s
+	`, issueTable, fencePredicate), args...)
 	if err != nil {
 		return fmt.Errorf("failed to unclaim issue: %w", err)
 	}
@@ -191,14 +244,19 @@ func UnclaimIssueIfAssigneeInTx(ctx context.Context, tx DBTX, id string, actor s
 		// The precheck passed and the read + UPDATE share this transaction, so a
 		// 0-row result is not an assignee race (the row cannot change under us
 		// mid-tx). Re-read and disambiguate, mirroring UnclaimIssueInTx: a
-		// mismatched holder is the CAS verdict (ErrAssigneeMismatch), otherwise
-		// the status is no longer releasable.
+		// mismatched holder is the CAS verdict (ErrAssigneeMismatch), a
+		// mismatched fence is the fence verdict (ErrFenceMismatch — same holder,
+		// later ownership generation), otherwise the status is no longer
+		// releasable.
 		current, gerr := GetIssueInTx(ctx, tx, id)
 		if gerr != nil {
 			return fmt.Errorf("failed to unclaim issue %s: no matching row", id)
 		}
 		if current.Assignee != expectedAssignee {
 			return fmt.Errorf("%w: %s is held by %q, expected %q", storage.ErrAssigneeMismatch, id, current.Assignee, expectedAssignee)
+		}
+		if err := fenceMismatch(id, current.ClaimFence, expectedFence); err != nil {
+			return err
 		}
 		return fmt.Errorf("failed to unclaim issue %s: no matching row", id)
 	}

--- a/internal/storage/issueops/unclaim.go
+++ b/internal/storage/issueops/unclaim.go
@@ -74,7 +74,7 @@ func UnclaimIssueInTx(ctx context.Context, tx DBTX, id string, actor string, for
 	result, err := tx.ExecContext(ctx, fmt.Sprintf(`
 		UPDATE %s
 		SET assignee = '', status = 'open', updated_at = ?,
-		    started_at = NULL, row_lock = ?
+		    started_at = NULL, claim_fence = claim_fence + 1, row_lock = ?
 		WHERE id = ? AND status IN ('open', 'in_progress') %s
 	`, issueTable, ownerPredicate), args...)
 	if err != nil {
@@ -175,7 +175,7 @@ func UnclaimIssueIfAssigneeInTx(ctx context.Context, tx DBTX, id string, actor s
 	result, err := tx.ExecContext(ctx, fmt.Sprintf(`
 		UPDATE %s
 		SET assignee = '', status = 'open', updated_at = ?,
-		    started_at = NULL, row_lock = ?
+		    started_at = NULL, claim_fence = claim_fence + 1, row_lock = ?
 		WHERE id = ? AND status IN ('open', 'in_progress') AND assignee = ?
 	`, issueTable), now, freshRowLock(), id, expectedAssignee)
 	if err != nil {

--- a/internal/storage/issueops/update.go
+++ b/internal/storage/issueops/update.go
@@ -298,6 +298,15 @@ func updateIssueInTx(ctx context.Context, tx DBTX, id string, updates map[string
 	// Clears stale leases only; arming is reserved for claim/heartbeat.
 	clearLease := ManageLeaseOnUpdate(oldIssue, updates)
 
+	// Ownership transitions through the generic update path bump the fence:
+	// an assignee change, or a reopen (closed→open) — the primary reopen path
+	// on the dolt/embedded stores, whose ReopenIssue delegates here. The
+	// bump⇒row_lock pairing invariant holds because row_lock is rewritten
+	// unconditionally just below.
+	if IsOwnershipTransition(oldIssue.Status, oldIssue.Assignee, updates) {
+		setClauses = append(setClauses, fenceBumpExpr)
+	}
+
 	// Rewrite row_lock on every update so a concurrent status/ownership
 	// mutation (reclaim/close) collides on this shared cell and is forced to
 	// conflict-and-retry rather than silently cell-merging two writes to

--- a/internal/storage/issueops/update_cas.go
+++ b/internal/storage/issueops/update_cas.go
@@ -9,11 +9,13 @@ import (
 	"github.com/steveyegge/beads/internal/storage"
 )
 
-// CheckExpectedFieldsInTx reads the current assignee and status for id and
-// returns ErrAssigneeMismatch/ErrStatusMismatch (wrapped with actual vs
-// expected) when a non-nil guard differs — the semantic-field compare-and-swap
-// behind `bd update --if-assignee/--if-status` (bd-wsqvw). A non-nil pointer to
-// "" is a real guard meaning "expected unassigned"; nil disables that check.
+// CheckExpectedFieldsInTx reads the current assignee, status and ownership
+// fence for id and returns ErrAssigneeMismatch/ErrStatusMismatch/
+// ErrFenceMismatch (wrapped with actual vs expected) when a non-nil guard
+// differs — the semantic-field compare-and-swap behind `bd update
+// --if-assignee/--if-status/--if-fence` (bd-wsqvw). A non-nil pointer to "" is
+// a real guard meaning "expected unassigned", and a non-nil pointer to fence 0
+// is a real guard meaning "expected never claimed"; nil disables that check.
 // Routes to the issues or wisps table. Returns ErrNotFound when the row is
 // absent.
 //
@@ -25,8 +27,8 @@ import (
 // Together they close the read-then-write window.
 //
 //nolint:gosec // G201: table name comes from WispTableRouting (hardcoded constants)
-func CheckExpectedFieldsInTx(ctx context.Context, tx DBTX, id string, expectedAssignee, expectedStatus *string) error {
-	if expectedAssignee == nil && expectedStatus == nil {
+func CheckExpectedFieldsInTx(ctx context.Context, tx DBTX, id string, expectedAssignee, expectedStatus *string, expectedFence *int64) error {
+	if expectedAssignee == nil && expectedStatus == nil && expectedFence == nil {
 		return nil
 	}
 	isWisp := IsActiveWispInTx(ctx, tx, id)
@@ -34,9 +36,10 @@ func CheckExpectedFieldsInTx(ctx context.Context, tx DBTX, id string, expectedAs
 
 	var assignee sql.NullString
 	var status string
+	var fence int64
 	err := tx.QueryRowContext(ctx,
-		fmt.Sprintf("SELECT assignee, status FROM %s WHERE id = ?", issueTable), id,
-	).Scan(&assignee, &status)
+		fmt.Sprintf("SELECT assignee, status, claim_fence FROM %s WHERE id = ?", issueTable), id,
+	).Scan(&assignee, &status, &fence)
 	if errors.Is(err, sql.ErrNoRows) {
 		return fmt.Errorf("%w: issue %s", storage.ErrNotFound, id)
 	}
@@ -48,6 +51,9 @@ func CheckExpectedFieldsInTx(ctx context.Context, tx DBTX, id string, expectedAs
 	}
 	if expectedStatus != nil && status != *expectedStatus {
 		return fmt.Errorf("%w: %s has status %q, expected %q", storage.ErrStatusMismatch, id, status, *expectedStatus)
+	}
+	if expectedFence != nil && fence != *expectedFence {
+		return fmt.Errorf("%w: %s has fence %d, expected %d", storage.ErrFenceMismatch, id, fence, *expectedFence)
 	}
 	return nil
 }

--- a/internal/storage/schema/cli_migrations.go
+++ b/internal/storage/schema/cli_migrations.go
@@ -60,6 +60,11 @@ func cliCompatibleMigrationSQL(name, sqlText string) string {
 		// schema delta: create the ephemeral leases table, drop the issues/
 		// wisps lease columns 0054 added. row_lock stays (see the migration).
 		return cliMigration0055MoveLeasesToTable
+	case "0062_add_claim_fence.up.sql":
+		// Direct DDL for the same reason as 0054/0055. issues only — the
+		// wisps column ships on the ignored track (ignored/0019), which the
+		// CLI bundle does not carry.
+		return cliMigration0062AddClaimFence
 	default:
 		return sqlText
 	}
@@ -100,6 +105,8 @@ ALTER TABLE issues DROP COLUMN lease_expires_at;
 ALTER TABLE issues DROP COLUMN heartbeat_at;
 ALTER TABLE wisps DROP COLUMN lease_expires_at;
 ALTER TABLE wisps DROP COLUMN heartbeat_at;`
+
+const cliMigration0062AddClaimFence = `ALTER TABLE issues ADD COLUMN claim_fence BIGINT NOT NULL DEFAULT 0;`
 
 const cliMigration0041SplitDependenciesTarget = `DELETE FROM dolt_nonlocal_tables;
 CALL DOLT_COMMIT('-Am', 'disable nonlocal tables for fk migrations');

--- a/internal/storage/schema/migrations/0062_add_claim_fence.down.sql
+++ b/internal/storage/schema/migrations/0062_add_claim_fence.down.sql
@@ -1,0 +1,17 @@
+-- Documentary rollback for 0062_add_claim_fence. NOTE: down migrations are
+-- not runtime-applied (the embed is up-only); the operational rollback for
+-- this slice is binary rollback — old binaries tolerate the additive column.
+-- The wisps column lives on the ignored track (ignored/0019) and is dropped
+-- by re-materializing that clone-local table, not from here.
+
+SET @has_col = (
+    SELECT COUNT(*)
+    FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = 'issues'
+      AND COLUMN_NAME = 'claim_fence'
+);
+SET @sql = IF(@has_col = 1,
+    'ALTER TABLE issues DROP COLUMN claim_fence',
+    'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;

--- a/internal/storage/schema/migrations/0062_add_claim_fence.up.sql
+++ b/internal/storage/schema/migrations/0062_add_claim_fence.up.sql
@@ -1,0 +1,56 @@
+-- Work-ownership integrity: give every claim a fence.
+--
+--   claim_fence   a monotonic counter bumped on every OWNERSHIP TRANSITION of
+--                 the row — claim; unclaim/release (including --force and the
+--                 --if-assignee CAS form); lease reclaim; an assignee change
+--                 through the generic update path or an import/upsert; and
+--                 reopen (closed->open) through the reopen verb or the generic
+--                 update path. There is no separate "transfer" transition: a
+--                 transfer IS an assignee change. It is NOT bumped by content
+--                 mutations (notes, metadata, close), unlike row_lock which
+--                 every mutating path rewrites. An orchestrator that read
+--                 (assignee, claim_fence) can therefore release or reassign a
+--                 row guarded on exactly the ownership state it decided on,
+--                 and a holder fenced out by a transition can be rejected with
+--                 a typed conflict instead of silently stomping newer
+--                 ownership.
+--
+-- Every successful claim CAS bumps, including a same-actor claim of an open
+-- row already assigned to that actor: two sessions of one user are two
+-- ownership holders, and the second session's claim must fence out the
+-- first's snapshot. The idempotent same-actor re-claim of an already
+-- in_progress row never reaches the CAS (its status is not claimable) and so
+-- does not bump. See internal/storage/issueops/fence.go.
+--
+-- Import-reopen exception: the import/upsert path bumps on an assignee change
+-- ALONE, so an import that flips a stored closed row back to open with the
+-- SAME assignee does not bump, where the reopen verb does. Import is
+-- convergence toward a peer's snapshot, not an ownership verb, and the fence
+-- is a live-coordination token — a routine sync must not invalidate the
+-- --if-fence guards live workers hold on this replica. Same reference.
+--
+-- Pairing invariant: every statement that bumps claim_fence also rewrites
+-- row_lock — a monotonic cell alone cell-merges silently under Dolt (two
+-- concurrent N->N+1 bumps write identical values), so the random row_lock is
+-- what forces racing transitions to serialize. Enforced by
+-- TestFenceBumpAlwaysPairsRowLock in issueops.
+--
+-- issues only. wisps is dolt_ignored, so its schema is clone-local and a
+-- fresh clone never executes this migration (the schema_migrations cursor
+-- arrives at-latest); the wisps column ships on the ignored track as
+-- ignored/0019_add_wisp_claim_fence, the 0013_add_wisp_row_lock precedent.
+--
+-- Guarded so the migration is idempotent on a schema_migrations row that
+-- regressed without its DDL rolled back (see 0052/0046).
+
+SET @needs_add = (
+    SELECT IF(COUNT(*) = 0, 1, 0)
+    FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = 'issues'
+      AND COLUMN_NAME = 'claim_fence'
+);
+SET @sql = IF(@needs_add = 1,
+    'ALTER TABLE issues ADD COLUMN claim_fence BIGINT NOT NULL DEFAULT 0',
+    'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;

--- a/internal/storage/schema/migrations/ignored/0019_add_wisp_claim_fence.up.sql
+++ b/internal/storage/schema/migrations/ignored/0019_add_wisp_claim_fence.up.sql
@@ -1,0 +1,30 @@
+-- Ignored migration 0019: ensure wisps.claim_fence exists on every clone.
+--
+-- Synced migration 0062 adds claim_fence to issues only. wisps is
+-- dolt-ignored (by synced migration 0019_wisps_dolt_ignore), so its schema is
+-- clone-local: a workspace that bootstraps or re-clones from a remote whose
+-- schema_migrations cursor is already >= 0062 adopts the cursor without ever
+-- executing 0062, and a wisps table materialized by ignored/0001 would lack the
+-- column. Every wisp claim/unclaim then soft-fails with Error 1054, the
+-- failure mode 0013 fixed for row_lock (wy-pt82l).
+--
+-- Wisps are claimable work — the shared claim/unclaim/update SQL routes by
+-- table name and bumps the fence on either tier — so the ownership fence is
+-- tier-complete even though wisps are never leased.
+--
+-- The guard makes this a no-op on workspaces that already carry the column
+-- and on workspaces with no local wisps table yet.
+SET @needs_add = IF(
+    (SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES
+        WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'wisps') > 0
+    AND
+    (SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
+        WHERE TABLE_SCHEMA = DATABASE()
+          AND TABLE_NAME = 'wisps'
+          AND COLUMN_NAME = 'claim_fence') = 0,
+    1, 0
+);
+SET @sql = IF(@needs_add = 1,
+    'ALTER TABLE wisps ADD COLUMN claim_fence BIGINT NOT NULL DEFAULT 0',
+    'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;

--- a/internal/storage/schema/schema_test.go
+++ b/internal/storage/schema/schema_test.go
@@ -1533,6 +1533,7 @@ func TestAllMigrationsSQLUsesDirectDDLForKnownCLIIncompatibilities(t *testing.T)
 		"ALTER TABLE schema_migrations DROP COLUMN applied_at",
 		"ALTER TABLE issues MODIFY COLUMN close_reason LONGTEXT DEFAULT ''",
 		"ALTER TABLE comments MODIFY COLUMN text LONGTEXT NOT NULL",
+		"ALTER TABLE issues ADD COLUMN claim_fence BIGINT NOT NULL DEFAULT 0",
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("AllMigrationsSQL missing direct CLI DDL %q", want)
@@ -1587,6 +1588,7 @@ WHERE table_schema = DATABASE()
 	requireDoltColumnShape(t, dir, "wisps", "no_history", "tinyint(1)", "YES")
 	requireDoltColumnShape(t, dir, "wisps", "started_at", "datetime", "YES")
 	requireDoltColumnShape(t, dir, "wisps", "wisp_type", "varchar(32)", "YES")
+	requireDoltColumnShape(t, dir, "issues", "claim_fence", "bigint", "NO")
 }
 
 func runDoltCommand(t *testing.T, dir string, args ...string) {

--- a/internal/storage/sqlbuild/sqlbuild.go
+++ b/internal/storage/sqlbuild/sqlbuild.go
@@ -44,7 +44,7 @@ const IssueBaseColumns = `id, content_hash, title, description, design, acceptan
 	       mol_type,
 	       event_kind, actor, target, payload,
 	       due_at, defer_until,
-	       work_type, source_system, metadata, row_lock, storage_class`
+	       work_type, source_system, metadata, row_lock, storage_class, claim_fence`
 
 // LeaseSelectColumns is the lease overlay for full issue hydration. Leases
 // live in the ephemeral leases table (bd-lrgn1), not on the issues row, so

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -75,6 +75,15 @@ var ErrVersionMismatch = errors.New("version mismatch")
 // ErrAssigneeMismatch, shared with UnclaimIssueIfAssignee.
 var ErrStatusMismatch = errors.New("status mismatch")
 
+// ErrFenceMismatch is returned by a guarded op given an ExpectedFence that no
+// longer matches the row's current ClaimFence — the ownership generation the
+// caller snapshotted has been retired by a claim, release, reclaim, reassign or
+// reopen. The issue is left untouched. Unlike ErrVersionMismatch (row_lock,
+// which moves on every content write) this fires only on an ownership
+// transition, so it is the guard a worker uses to prove it is still the holder
+// it thought it was.
+var ErrFenceMismatch = errors.New("fence mismatch")
+
 // CommentPageCursor is the resume position for a keyset page of an issue's
 // comments: the (created_at, id) of the last comment already returned. The zero
 // value starts a walk from the beginning of the thread.
@@ -104,17 +113,26 @@ type Storage interface {
 	GetIssueByExternalRef(ctx context.Context, externalRef string) (*types.Issue, error)
 	GetIssuesByIDs(ctx context.Context, ids []string) ([]*types.Issue, error)
 	UpdateIssue(ctx context.Context, id string, updates map[string]interface{}, actor string) error
-	// UpdateIssueChecked applies the update like UpdateIssue, with an optional
-	// optimistic-concurrency precondition: see UpdateIssueOptions.ExpectedVersion.
-	// The version read and the update share one transaction (a true CAS).
+	// UpdateIssueChecked applies the update like UpdateIssue, with optional
+	// preconditions: see UpdateIssueOptions.ExpectedVersion/ExpectedAssignee/
+	// ExpectedStatus/ExpectedFence. Every guard read and the update share one
+	// transaction (a true CAS).
 	UpdateIssueChecked(ctx context.Context, id string, updates map[string]interface{}, actor string, opts UpdateIssueOptions) error
 	ReopenIssue(ctx context.Context, id string, reason string, actor string) error
-	UnclaimIssue(ctx context.Context, id string, actor string, force bool) error
+	// UnclaimIssue releases a claim held by actor (or, with force, held by
+	// anyone). A non-nil expectedFence additionally pins the release to an
+	// ownership generation: the release proceeds only while the issue's current
+	// ClaimFence equals *expectedFence, else it refuses with ErrFenceMismatch
+	// and the issue is left untouched. The fence establishes freshness, not
+	// authority — it is conjunctive with the ownership check, never a
+	// substitute for it, and force does not skip it.
+	UnclaimIssue(ctx context.Context, id string, actor string, force bool, expectedFence *int64) error
 	// UnclaimIssueIfAssignee releases a claim only while the issue is still
 	// assigned to expectedAssignee (compare-and-swap, the inverse of
 	// ClaimIssue). Returns ErrAssigneeMismatch, leaving the issue untouched,
-	// when the current assignee differs.
-	UnclaimIssueIfAssignee(ctx context.Context, id string, actor string, expectedAssignee string) error
+	// when the current assignee differs. A non-nil expectedFence adds the
+	// ownership-fence conjunct described on UnclaimIssue (ErrFenceMismatch).
+	UnclaimIssueIfAssignee(ctx context.Context, id string, actor string, expectedAssignee string, expectedFence *int64) error
 	UpdateIssueType(ctx context.Context, id string, issueType string, actor string) error
 	CloseIssue(ctx context.Context, id string, reason string, actor string, session string) error
 	// CloseIssueChecked closes an issue, but refuses with ErrCloseBlocked when
@@ -126,9 +144,10 @@ type Storage interface {
 	// (no TOCTOU). When opts.ExpectedVersion is non-nil it adds an orthogonal
 	// optimistic-concurrency precondition: the close proceeds only if the issue's
 	// current RowVersion still equals *opts.ExpectedVersion, else it refuses with
-	// ErrVersionMismatch atomically (Force does NOT bypass this check). Already-
-	// closed is an idempotent success with Unchanged=true; a missing issue returns
-	// ErrNotFound.
+	// ErrVersionMismatch atomically (Force does NOT bypass this check).
+	// opts.ExpectedFence is the same kind of precondition against the ownership
+	// fence (ErrFenceMismatch). Already-closed is an idempotent success with
+	// Unchanged=true; a missing issue returns ErrNotFound.
 	CloseIssueChecked(ctx context.Context, id string, actor string, opts CloseIssueOptions) (CloseIssueResult, error)
 	DeleteIssue(ctx context.Context, id string) error
 	SearchIssues(ctx context.Context, query string, filter types.IssueFilter) ([]*types.Issue, error)
@@ -320,6 +339,21 @@ type CloseIssueOptions struct {
 	// row_lock and are not caught here (see the freshRowLock invariant in
 	// internal/storage/issueops/lease.go).
 	ExpectedVersion *int64
+
+	// ExpectedFence, when non-nil, gates the close on the issue's ownership
+	// fence: the close proceeds only if the current ClaimFence equals
+	// *ExpectedFence, else it refuses with ErrFenceMismatch atomically. nil
+	// disables the check; a pointer to 0 is a real assertion ("never claimed").
+	// It is conjunctive with ExpectedVersion and with the is_blocked guard, and
+	// Force bypasses none of it.
+	//
+	// This is the "close only if I am still the holder I was" guard: unlike
+	// ExpectedVersion, claim_fence moves ONLY on ownership transitions (claim,
+	// release, reclaim, reassign, reopen), so intervening content writes by the
+	// same holder do not invalidate it. A worker whose lease was reclaimed and
+	// re-issued to someone else is refused here instead of completing a bead it
+	// no longer owns.
+	ExpectedFence *int64
 }
 
 // CloseIssueResult reports the outcome of CloseIssueChecked.
@@ -350,6 +384,22 @@ type UpdateIssueOptions struct {
 	// and refuses (the same invariant as ExpectedVersion).
 	ExpectedAssignee *string
 	ExpectedStatus   *string
+
+	// ExpectedFence is the ownership-fence guard (`bd update --if-fence`): when
+	// non-nil the update proceeds only if the issue's current ClaimFence equals
+	// *ExpectedFence, else it refuses atomically with ErrFenceMismatch naming
+	// the actual fence. nil disables the check; a pointer to 0 is a real
+	// assertion ("expected never claimed"). It joins the same conjunction as
+	// the assignee/status guards and ExpectedVersion, with the same
+	// one-transaction read-and-write guarantee.
+	//
+	// The fence is a distinct token from ExpectedVersion's row_lock: row_lock is
+	// rewritten by every content write, while claim_fence advances ONLY on
+	// ownership transitions (claim, release, reclaim, reassign, reopen). Guard
+	// on the fence to mean "the ownership generation I decided against is still
+	// current"; guard on the version to mean "nobody has touched the row at
+	// all".
+	ExpectedFence *int64
 }
 
 // MergeSlotStatus is returned by MergeSlotCheck and describes the current

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -35,6 +35,14 @@ var ErrNotOwner = errors.New("issue claimed by a different actor")
 // stale; the issue is left untouched.
 var ErrAssigneeMismatch = errors.New("assignee mismatch")
 
+// ErrUnleased is returned by HeartbeatIssue when the actor holds the claim it
+// is heartbeating but that claim carries no lease, on a store that disarmed
+// automatic stamping (lease.auto off — see bd lease disarm). Heartbeat is
+// strictly a renewal there: arming a lease on a deliberately unleased claim
+// would silently re-create the reclaim exposure disarming exists to remove.
+// The claim is untouched; the caller should stop heartbeating, not retry.
+var ErrUnleased = errors.New("issue has no lease")
+
 // ClaimedByFragment and NotClaimableStatusFragment are the exact message
 // fragments the claim path (issueops/claim.go) appends after the sentinel to
 // carry the conflicting assignee/status: ErrAlreadyClaimed is wrapped as

--- a/internal/telemetry/storage.go
+++ b/internal/telemetry/storage.go
@@ -176,26 +176,26 @@ func (s *InstrumentedStorage) ReopenIssue(ctx context.Context, id string, reason
 	return err
 }
 
-func (s *InstrumentedStorage) UnclaimIssue(ctx context.Context, id string, actor string, force bool) error {
+func (s *InstrumentedStorage) UnclaimIssue(ctx context.Context, id string, actor string, force bool, expectedFence *int64) error {
 	attrs := []attribute.KeyValue{
 		attribute.String("bd.issue.id", id),
 		attribute.String("bd.actor", actor),
 		attribute.Bool("bd.force", force),
 	}
 	ctx, span, t := s.op(ctx, "UnclaimIssue", attrs...)
-	err := s.inner.UnclaimIssue(ctx, id, actor, force)
+	err := s.inner.UnclaimIssue(ctx, id, actor, force, expectedFence)
 	s.done(ctx, span, t, err, attrs...)
 	return err
 }
 
-func (s *InstrumentedStorage) UnclaimIssueIfAssignee(ctx context.Context, id string, actor string, expectedAssignee string) error {
+func (s *InstrumentedStorage) UnclaimIssueIfAssignee(ctx context.Context, id string, actor string, expectedAssignee string, expectedFence *int64) error {
 	attrs := []attribute.KeyValue{
 		attribute.String("bd.issue.id", id),
 		attribute.String("bd.actor", actor),
 		attribute.String("bd.issue.expected_assignee", expectedAssignee),
 	}
 	ctx, span, t := s.op(ctx, "UnclaimIssueIfAssignee", attrs...)
-	err := s.inner.UnclaimIssueIfAssignee(ctx, id, actor, expectedAssignee)
+	err := s.inner.UnclaimIssueIfAssignee(ctx, id, actor, expectedAssignee, expectedFence)
 	s.done(ctx, span, t, err, attrs...)
 	return err
 }

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -66,6 +66,32 @@ type Issue struct {
 	// granting replica.
 	LeaseGrantedNode string `json:"lease_granted_node,omitempty"`
 
+	// ===== Ownership fence (migration 0062 + ignored/0019) =====
+	// ClaimFence is a monotonic counter on the issues/wisps row, bumped only
+	// by OWNERSHIP TRANSITIONS: claim; unclaim/release (including --force and
+	// the --if-assignee CAS form); lease reclaim; an assignee change through
+	// the generic update path or an import/upsert; and reopen (closed->open)
+	// through the reopen verb or the generic update path. Content mutations
+	// never move it, and neither does close. Every successful claim CAS bumps
+	// — including a same-actor claim of an open row already assigned to that
+	// actor, which is what lets one session of a user fence out another
+	// session of the same user; the idempotent same-actor re-claim of an
+	// already in_progress row misses the CAS entirely and does not bump.
+	//
+	// One exception on the import side: the upsert bump keys on an assignee
+	// change alone, so an import that flips a stored closed row back to open
+	// with the SAME assignee does not bump, where the reopen verb does.
+	// Import is convergence toward a peer's snapshot, not an ownership verb,
+	// and the fence is a live-coordination token — a routine sync must not
+	// retire the guards live workers hold here. See
+	// internal/storage/issueops/fence.go for the canonical policy.
+	//
+	// Unlike RowVersion it is deterministic and monotonic, so it rides the
+	// JSONL interchange and bd show --json: a caller can snapshot the value
+	// it decided on and quote it back as a precondition. omitempty keeps
+	// never-claimed rows byte-identical to their pre-fence export.
+	ClaimFence int64 `json:"claim_fence,omitempty"`
+
 	// ===== Concurrency (Go-only; never serialized) =====
 	// RowVersion is an opaque optimistic-concurrency token for the library's own
 	// Go call sites: the issues/wisps row_lock cell, a random non-zero value the
@@ -76,12 +102,15 @@ type Issue struct {
 	// --json goldens and bd export round-trips; a Go consumer reads
 	// issue.RowVersion directly instead.
 	//
-	// Coverage is deliberately partial: it changes on claim/close/unclaim and the
-	// generic update path, but NOT on direct-UPDATE paths that rewrite text
-	// without touching row_lock (RestoreFromSnapshotInTx, the compaction
-	// text-truncation path). For a complete change-detection key, combine it with
-	// updated_at (which those paths DO bump), status, and the label set
-	// (label-only and reopen writes change those, not row_lock).
+	// Coverage is deliberately partial: it changes on claim/close/unclaim, on
+	// reopen, and on the generic update path, but NOT on direct-UPDATE paths that
+	// rewrite text without touching row_lock (RestoreFromSnapshotInTx, the
+	// compaction text-truncation path). Reopen joined that list with migration
+	// 0062: the reopen verb now rewrites row_lock because every claim_fence bump
+	// must pair with one (see ClaimFence above and issueops/fence.go). For a
+	// complete change-detection key, combine it with updated_at (which those
+	// paths DO bump), status, and the label set (label-only writes change those,
+	// not row_lock).
 	//
 	// 0 appears only on legacy rows backfilled by migration 0054 (DEFAULT 0) that
 	// have not been mutated since; any issue created by the current code path is
@@ -1770,6 +1799,12 @@ func (s SortPolicy) IsValid() bool {
 type ReclaimedLease struct {
 	ID            string `json:"id"`
 	PreviousOwner string `json:"previous_owner"`
+	// ClaimFence is the row's Issue.ClaimFence AFTER the reclaim's bump: the
+	// previous holder is fenced out, and a caller quoting an older fence
+	// conflicts. No omitempty: a reclaim always bumps, so the post-bump value
+	// is always ≥ 1 and the tag could never fire — and an operator reading the
+	// JSON should see the field on every reclaimed row, not infer it.
+	ClaimFence int64 `json:"claim_fence"`
 }
 
 // ReclaimFilter scopes which stale-lease issues bd reclaim may revert. The

--- a/scripts/check-migration-hygiene.sh
+++ b/scripts/check-migration-hygiene.sh
@@ -23,9 +23,15 @@
 #      exists on the base branch. New files only. Fix-forward with a new
 #      migration instead: applied migration content is content-hashed
 #      (PR 4270), so editing history creates cross-clone hash skew.
+#   D. Every migration file ADDED relative to the base carries a version
+#      strictly above the base branch's highest (per directory). The cursor is
+#      MAX(version), so a migration numbered at or below an already-applied
+#      version never runs on an upgraded store while fresh clones do apply it —
+#      failure class 3 reached by a different road. Reserving a number for a
+#      concurrent PR leaves a hole and is fine; LANDING under the ceiling is not.
 #
-# Check C compares against $BASE_SHA if set (CI passes the PR base), else
-# origin/main, else main; it is skipped with a warning when no base is
+# Checks C and D compare against $BASE_SHA if set (CI passes the PR base), else
+# origin/main, else main; they are skipped with a warning when no base is
 # resolvable (e.g. shallow clone without the base commit).
 
 set -euo pipefail
@@ -133,7 +139,7 @@ if [ -z "$base" ]; then
 fi
 
 if [ -z "$base" ] || ! merge_base=$(git merge-base "$base" HEAD 2>/dev/null); then
-  echo "WARN (frozen migrations) no usable base ref; skipping check C." >&2
+  echo "WARN (frozen migrations) no usable base ref; skipping checks C and D." >&2
 else
   # Diff merge-base against the working tree (no HEAD) so local uncommitted
   # edits are caught too; in CI the tree is clean so this equals the PR diff.
@@ -150,6 +156,43 @@ else
   Write a NEW migration with the next version number instead.
 EOF
   fi
+
+  # --- Check D: new migrations land above the base's highest version ---------
+  # Per directory, like check A: migrations/ and migrations/ignored/ are
+  # independent sequences with independent cursors.
+  for dir in "$MIG_DIR" "$MIG_DIR/ignored"; do
+    # Anchored so the parent directory's listing does not swallow ignored/.
+    pattern="^${dir}/[0-9][0-9]*_.*\.up\.sql$"
+    base_max=$(
+      git ls-tree -r --name-only "$merge_base" -- "$dir" 2>/dev/null \
+        | grep -E "$pattern" \
+        | sed "s|^${dir}/||; s/^\([0-9][0-9]*\)_.*/\1/" \
+        | sort -n | tail -1
+    )
+    [ -n "$base_max" ] || continue
+    added=$(
+      git diff --name-only --diff-filter=A "$merge_base" -- "$dir" 2>/dev/null \
+        | grep -E "$pattern" || true
+    )
+    [ -n "$added" ] || continue
+    while IFS= read -r f; do
+      v=$(sed 's|.*/||; s/^\([0-9][0-9]*\)_.*/\1/' <<< "$f")
+      # 10# forces base 10: an unpadded 0018 is not valid octal.
+      if [ "$((10#$v))" -le "$((10#$base_max))" ]; then
+        fail=1
+        echo "FAIL (non-monotonic version) $f:"
+        echo "  version $v is not above $base_max, the highest already on the base branch."
+        cat <<EOF
+  The migration cursor is MAX(version) (schema.pendingVersions applies a file
+  only when its version is strictly greater than the recorded maximum), so a
+  store that has already applied $base_max will NEVER run $v — while a fresh
+  clone applies it during initial migration. The two populations then report
+  the same schema_migrations version with different actual schemas, silently
+  and permanently. Renumber this migration above $base_max.
+EOF
+      fi
+    done <<< "$added"
+  done
 fi
 
 if [ "$fail" -ne 0 ]; then

--- a/tests/regression/regression_test.go
+++ b/tests/regression/regression_test.go
@@ -525,6 +525,11 @@ var versionSpecificFields = []string{
 	"_type", "deleted_at", "deleted_by", "delete_reason", "original_type",
 	"comment_count", "dependency_count", "dependent_count",
 	"epic_total_children", "epic_closed_children", "epic_closeable",
+	// claim_fence postdates the baseline: any scenario that transitions
+	// ownership (reopen, claim, release) exports a fence the baseline has no
+	// column for, so comparing it would diff the feature rather than a
+	// regression.
+	"claim_fence",
 }
 
 // normalizeJSONL parses JSONL, normalizes each issue, applies ID canonicalization,


### PR DESCRIPTION
## What

Work-ownership integrity primitives, re-authored from current main as three
self-contained slices (one per commit) after the 2026-07-27 review:

1. **`claim_fence`** — a monotonic ownership fence on `issues` and `wisps`
   (synced migration `0062_add_claim_fence` for issues; wisps ride
   `ignored/0019_add_wisp_claim_fence`, the `row_lock`/ignored-0013 precedent,
   so fresh clones materialize it too). Bumped on ownership transitions —
   claim, unclaim/release, lease reclaim, assignee change (verb or
   import-upsert), reopen via the verb path — and paired with a `row_lock`
   rewrite in the same SQL statement so Dolt's cell merge can never silently
   converge two divergent bumps (`TestFenceBumpAlwaysPairsRowLock` enforces
   this at the source level, including the fragment-composed proxied SQL).
   The claim CAS bumps **unconditionally** — including a same-actor claim of an
   open row already assigned to them, so one session of a user can fence out
   another — while the idempotent same-actor re-claim of an `in_progress` row
   misses the CAS and does not bump. Both pinned by tests. `claim_fence`
   serializes as `claim_fence,omitempty` (readable via `bd show --json`), rides
   `IssueSelectColumnsLite`, and survives import without ever moving backward
   (fresh rows adopt the imported fence; existing rows bump only on
   assignee change).

2. **`--if-fence` guards, folded into the shipped surface** — `ExpectedFence
   *int64` on `UpdateIssueOptions` and `CloseIssueOptions` beside
   `ExpectedVersion`/`ExpectedAssignee`/`ExpectedStatus` (#4911/#5008 pattern),
   `ErrFenceMismatch` beside `ErrVersionMismatch`, re-exported at the root.
   `bd update --if-fence` and `bd close --if-fence` follow #5008's exit
   taxonomy (13 iff every failure was a stale guard, nothing written; 1
   otherwise); `bd update --if-fence` also works in proxied-server mode via
   `domain.UpdateSpec`, exactly like the shipped guards. `bd unclaim
   --if-fence` is an additional conjunct on both release paths and keeps
   unclaim's shipped guard contract (mismatch = exit 1; `--if-assignee`
   semantics byte-unchanged). Security rule per the review: **a fence guard
   establishes freshness, not authority** — `--if-fence` alone never lifts the
   unclaim owner check, and `--force` never skips a supplied guard.

3. **`lease.auto` + `bd lease disarm`** — a DB-stored config key (default
   **on**, preserving shipped behavior byte-for-byte) that gates automatic
   lease stamping on claim, and a one-shot `bd lease disarm` that flips the
   key and sweeps armed lease rows in one transaction (bounded re-sweeps for
   claims in flight). Heartbeat on a disarmed store returns a typed
   `storage.ErrUnleased` instead of silently re-arming. Disarm is a sweep, not
   a standing rejection: an import can restore live lease rows and `bd
   reclaim` handles them normally.

## Why

A claim in beads is atomic, but every other ownership transition (release,
reclaim, reassignment) is unguarded, and an assignee string cannot distinguish
two processes with the same name. A stale release can stomp a fresh re-claim,
and a reclaimed-but-still-live worker can close a bead it no longer owns.
`claim_fence` gives every ownership transition a monotonic marker so a caller
that read `(assignee, fence)` can release or complete against exactly the
state it observed — and a holder fenced out by an intervening transition gets
a typed mismatch instead of silently winning the write. Unlike
`ExpectedVersion` (which rides `row_lock` and moves on every content write), a
fence guard survives unrelated edits and fails only when ownership actually
moved.

## Changes from the previous revision (responding to the 07-27 review)

- Rebased/re-authored onto current main; the #4675 commits are gone (merged).
- Migration renumbered to the next free number on each independent sequence:
  synced **0062** and **ignored/0019** (main owns synced through 0061 —
  `0060_add_storage_class`, `0061_content_derived_aux_ids` — and ignored
  through 0018). Both number lines stay gapless, so the CLI-bundle test keeps
  main's strict `COUNT(*) == MAX(version) == LatestVersion()` assertion
  unchanged. `check-migration-hygiene.sh` gains a monotonic-landing check
  (Check D): any added migration whose version is not strictly above the base
  branch's per-track max now fails, naming the failure mode — because the
  cursor is `MAX`-based, a below-max migration silently never applies on
  already-migrated stores while fresh clones still get it. That check caught
  this branch's own collision when main landed 0060/0061 mid-review.
- The import-upsert `row_lock` regression is undone (fresh INSERTs keep
  `freshRowLock()`).
- Guard slice re-built on `UpdateIssueOptions`/`CloseIssueOptions` — the
  context transport, `PreconditionFailedError`, exit 9, and typed
  `{code:...}` stderr bodies are gone; no `--if-assignee` re-registration.
- Cross-actor release now requires `--if-assignee` or `--force`; the fence is
  never a credential.
- Slice 4 (wisp leasing, `--lease-ttl`, batch renew APIs) is **out**, parked
  pending the maintainer ruling; the migration-repair helpers are **dropped**
  (evidence in the review thread — 0054 is self-guarded, 0055 drops those
  columns, and main's #4878/#4690 already cover the v53 drift and the commit
  boundary).
- All doc regeneration dropped (CLI docs are release-pinned); anti-steamroller
  copy and shipped guard semantics untouched by construction.

## Verification

Built and tested at the tip of main (`423afdcb2`), all via real
infrastructure — no mocked Dolt:

```
go build ./... && go vet ./...                        # clean
go test ./internal/storage/{issueops,sqlbuild,schema}/ ./internal/types/
go test ./internal/storage/dolt/ -run 'Fence|Guard|Checked|Disarm|Lease|Reclaim|Conformance'
BEADS_TEST_EMBEDDED_DOLT=1 go test ./internal/storage/embeddeddolt/   # incl. 0062+ignored/0019 convergence/selfheal
go test ./cmd/bd/ [-run ...] (+ BEADS_TEST_PROXIED_SERVER=1)          # incl. proxied fence-bump + guard pins
go test ./cmd/bd/protocol/                            # corpus green; only golden churn = claim_fence:1 on the reopened bead
golangci-lint run ./...                               # only the 2 pre-existing cmd/bd/main.go G304s
BASE_SHA=origin/main scripts/check-migration-hygiene.sh && make check-docs
```

Known pre-existing flake, measured on pristine main (fails ~2/5 there):
`TestReclaimRevertsExpiredOnly` — unrelated to this change.

The branch was additionally taken through an adversarial multi-lens review
(fence/SQL correctness, guard-surface conformance, security, shipped-contract
regressions, migration hygiene, review fidelity, test adequacy, code quality)
with independent refutation of every finding; all 11 confirmed findings and 11
selected nits are fixed in these commits (details in the review-response
comment).

Compatibility notes (also in CHANGELOG): `Storage.UnclaimIssue` /
`UnclaimIssueIfAssignee` gained an `expectedFence *int64` parameter (breaking
for direct interface consumers); out-of-tree `Storage` implementations ignore
`ExpectedFence` fail-open, same caveat #5008 documented for the sibling
guards.
