### PR TITLE
feat: auto-resolve issues-table modify/modify conflicts by LWW (updated_at)

### DIFF
--- a/internal/storage/dolt/federation_pull_settle_test.go
+++ b/internal/storage/dolt/federation_pull_settle_test.go
@@ -121,7 +121,9 @@ func TestPullFromSettlesFKCascadeViolations(t *testing.T) {
 // peerPullOutcome's post-hoc GetConflicts can never see it — the conflicts
 // must arrive captured pre-rollback inside MergeConflictsError and surface
 // through PullFrom's conflict-reporting contract. Peer setup mirrors
-// TestPullFromSettlesFKCascadeViolations.
+// TestPullFromSettlesFKCascadeViolations. Both sides' updated_at is pinned to
+// the same value so the LWW auto-resolver (GH#4698) declines the conflict as
+// ambiguous, leaving it for the operator.
 func TestPullFromReportsOperatorConflicts(t *testing.T) {
 	store, cleanup := setupConcurrentTestStore(t)
 	defer cleanup()
@@ -159,7 +161,7 @@ func TestPullFromReportsOperatorConflicts(t *testing.T) {
 	defer peerConn.Close()
 	peerConn.SetMaxOpenConns(1)
 	for _, q := range []string{
-		"UPDATE issues SET title = 'theirs' WHERE id = 'opcpeer-x'",
+		"UPDATE issues SET title = 'theirs', updated_at = '2026-01-01 00:00:00' WHERE id = 'opcpeer-x'",
 		"CALL DOLT_COMMIT('-Am', 'peer retitles')",
 		"CALL DOLT_PUSH('origin', 'main')",
 	} {
@@ -168,7 +170,11 @@ func TestPullFromReportsOperatorConflicts(t *testing.T) {
 		}
 	}
 
-	if _, err := db.ExecContext(ctx, "UPDATE issues SET title = 'ours' WHERE id = 'opcpeer-x'"); err != nil {
+	// Pin updated_at to the same value as the peer's update so the LWW
+	// safety check (issuesConflictsAreLWWSafe) rejects it as ambiguous —
+	// this test exercises the operator-conflict reporting path, which
+	// requires a conflict the auto-resolver declines (GH#4698).
+	if _, err := db.ExecContext(ctx, "UPDATE issues SET title = 'ours', updated_at = '2026-01-01 00:00:00' WHERE id = 'opcpeer-x'"); err != nil {
 		t.Fatalf("retitle locally: %v", err)
 	}
 	if _, err := db.ExecContext(ctx, "CALL DOLT_COMMIT('-Am', 'local retitles')"); err != nil {

--- a/internal/storage/dolt/issues_conflict_test.go
+++ b/internal/storage/dolt/issues_conflict_test.go
@@ -2,7 +2,7 @@ package dolt
 
 import "testing"
 
-func setupIssueMergeConflict(t *testing.T, issueID, ourTitle, ourUpdatedAt, theirTitle, theirUpdatedAt string, seed bool) (*DoltStore, string) {
+func setupIssueMergeConflict(t *testing.T, issueID, baseTitle, baseUpdatedAt, ourTitle, ourUpdatedAt, theirTitle, theirUpdatedAt string, seed bool) (*DoltStore, string) {
 	t.Helper()
 	store, cleanup := setupTestStore(t)
 	t.Cleanup(cleanup)
@@ -16,10 +16,10 @@ func setupIssueMergeConflict(t *testing.T, issueID, ourTitle, ourUpdatedAt, thei
 		t.Fatalf("get current branch: %v", err)
 	}
 
-	insertIssue := func(title string) {
+	insertIssue := func(title, updatedAt string) {
 		if _, err := db.ExecContext(ctx,
-			"INSERT INTO issues (id, title, description, design, acceptance_criteria, notes, status, priority, issue_type) VALUES (?, ?, '', '', '', '', 'open', 2, 'task')",
-			issueID, title); err != nil {
+			"INSERT INTO issues (id, title, description, design, acceptance_criteria, notes, status, priority, issue_type, updated_at) VALUES (?, ?, '', '', '', '', 'open', 2, 'task', ?)",
+			issueID, title, updatedAt); err != nil {
 			t.Fatalf("insert issue %s: %v", issueID, err)
 		}
 	}
@@ -32,13 +32,13 @@ func setupIssueMergeConflict(t *testing.T, issueID, ourTitle, ourUpdatedAt, thei
 	}
 
 	if seed {
-		insertIssue("shared title")
+		insertIssue(baseTitle, baseUpdatedAt)
 		if _, err := db.ExecContext(ctx, "CALL DOLT_COMMIT('-Am', 'seed issue')"); err != nil {
 			t.Fatalf("commit seed issue: %v", err)
 		}
 		updateIssue(ourTitle, ourUpdatedAt)
 	} else {
-		insertIssue(ourTitle)
+		insertIssue(ourTitle, ourUpdatedAt)
 	}
 	if _, err := db.ExecContext(ctx, "CALL DOLT_COMMIT('-Am', 'issue on current')"); err != nil {
 		t.Fatalf("commit issue on current: %v", err)
@@ -58,7 +58,7 @@ func setupIssueMergeConflict(t *testing.T, issueID, ourTitle, ourUpdatedAt, thei
 	if seed {
 		updateIssue(theirTitle, theirUpdatedAt)
 	} else {
-		insertIssue(theirTitle)
+		insertIssue(theirTitle, theirUpdatedAt)
 	}
 	if _, err := db.ExecContext(ctx, "CALL DOLT_COMMIT('-Am', 'issue on peer')"); err != nil {
 		t.Fatalf("commit issue on peer: %v", err)
@@ -105,6 +105,7 @@ func mergeAndTryAutoResolveIssues(t *testing.T, store *DoltStore, peerBranch str
 func TestTryAutoResolveMergeConflicts_IssuesLWWTheirsWins(t *testing.T) {
 	const issueID = "lww-x"
 	store, peerBranch := setupIssueMergeConflict(t, issueID,
+		"seed", "2026-07-10 11:00:00",
 		"ours", "2026-07-10 11:00:00", "theirs", "2026-07-10 12:00:00", true)
 
 	if resolved := mergeAndTryAutoResolveIssues(t, store, peerBranch); !resolved {
@@ -132,7 +133,8 @@ func TestTryAutoResolveMergeConflicts_IssuesLWWTheirsWins(t *testing.T) {
 func TestTryAutoResolveMergeConflicts_IssuesLWWOursWins(t *testing.T) {
 	const issueID = "lww-y"
 	store, peerBranch := setupIssueMergeConflict(t, issueID,
-		"ours", "2026-07-10 13:00:00", "theirs", "2026-07-10 12:00:00", true)
+		"seed", "2026-07-10 11:00:00",
+		"ours", "2026-07-10 13:00:00", "theirs", "2026-07-10 11:00:00", true)
 
 	if resolved := mergeAndTryAutoResolveIssues(t, store, peerBranch); !resolved {
 		t.Fatal("expected issues modify/modify conflict to be auto-resolved")
@@ -151,6 +153,7 @@ func TestTryAutoResolveMergeConflicts_IssuesLWWOursWins(t *testing.T) {
 
 func TestTryAutoResolveMergeConflicts_IssuesAmbiguousLeftAlone(t *testing.T) {
 	store, peerBranch := setupIssueMergeConflict(t, "lww-z",
+		"seed", "2026-07-10 11:00:00",
 		"ours", "2026-07-10 12:00:00", "theirs", "2026-07-10 12:00:00", true)
 
 	if resolved := mergeAndTryAutoResolveIssues(t, store, peerBranch); resolved {
@@ -160,9 +163,25 @@ func TestTryAutoResolveMergeConflicts_IssuesAmbiguousLeftAlone(t *testing.T) {
 
 func TestTryAutoResolveMergeConflicts_IssuesAddAddLeftAlone(t *testing.T) {
 	store, peerBranch := setupIssueMergeConflict(t, "lww-add",
-		"ours", "", "theirs", "", false)
+		"", "",
+		"ours", "2026-07-10 12:00:00", "theirs", "2026-07-10 12:00:00", false)
 
 	if resolved := mergeAndTryAutoResolveIssues(t, store, peerBranch); resolved {
 		t.Error("expected issues add/add conflict to be left unresolved")
+	}
+}
+
+// TestTryAutoResolveMergeConflicts_IssuesConcurrentEditLeftAlone verifies that
+// when BOTH sides moved updated_at past the merge-base value (both made real
+// edits since the last sync), the LWW auto-resolver declines the conflict and
+// leaves it for the operator — row-level LWW would silently drop the losing
+// side's field-level changes (GH#4698 Risk mitigation).
+func TestTryAutoResolveMergeConflicts_IssuesConcurrentEditLeftAlone(t *testing.T) {
+	store, peerBranch := setupIssueMergeConflict(t, "lww-concurrent",
+		"seed", "2026-07-10 10:00:00",
+		"ours", "2026-07-10 11:00:00", "theirs", "2026-07-10 12:00:00", true)
+
+	if resolved := mergeAndTryAutoResolveIssues(t, store, peerBranch); resolved {
+		t.Error("expected concurrent-edit issues conflict (both sides edited since merge base) to be left unresolved")
 	}
 }

--- a/internal/storage/dolt/issues_conflict_test.go
+++ b/internal/storage/dolt/issues_conflict_test.go
@@ -1,0 +1,168 @@
+package dolt
+
+import "testing"
+
+func setupIssueMergeConflict(t *testing.T, issueID, ourTitle, ourUpdatedAt, theirTitle, theirUpdatedAt string, seed bool) (*DoltStore, string) {
+	t.Helper()
+	store, cleanup := setupTestStore(t)
+	t.Cleanup(cleanup)
+
+	ctx, cancel := testContext(t)
+	t.Cleanup(cancel)
+
+	db := store.db
+	var currentBranch string
+	if err := db.QueryRowContext(ctx, "SELECT active_branch()").Scan(&currentBranch); err != nil {
+		t.Fatalf("get current branch: %v", err)
+	}
+
+	insertIssue := func(title string) {
+		if _, err := db.ExecContext(ctx,
+			"INSERT INTO issues (id, title, description, design, acceptance_criteria, notes, status, priority, issue_type) VALUES (?, ?, '', '', '', '', 'open', 2, 'task')",
+			issueID, title); err != nil {
+			t.Fatalf("insert issue %s: %v", issueID, err)
+		}
+	}
+	updateIssue := func(title, updatedAt string) {
+		if _, err := db.ExecContext(ctx,
+			"UPDATE issues SET title = ?, updated_at = ? WHERE id = ?",
+			title, updatedAt, issueID); err != nil {
+			t.Fatalf("update issue %s: %v", issueID, err)
+		}
+	}
+
+	if seed {
+		insertIssue("shared title")
+		if _, err := db.ExecContext(ctx, "CALL DOLT_COMMIT('-Am', 'seed issue')"); err != nil {
+			t.Fatalf("commit seed issue: %v", err)
+		}
+		updateIssue(ourTitle, ourUpdatedAt)
+	} else {
+		insertIssue(ourTitle)
+	}
+	if _, err := db.ExecContext(ctx, "CALL DOLT_COMMIT('-Am', 'issue on current')"); err != nil {
+		t.Fatalf("commit issue on current: %v", err)
+	}
+
+	peerBranch := currentBranch + "_issues_peer"
+	if _, err := db.ExecContext(ctx, "CALL DOLT_BRANCH(?, 'HEAD~1')", peerBranch); err != nil {
+		t.Fatalf("create peer branch: %v", err)
+	}
+	t.Cleanup(func() {
+		db.ExecContext(ctx, "CALL DOLT_CHECKOUT(?)", currentBranch)
+		db.ExecContext(ctx, "CALL DOLT_BRANCH('-D', ?)", peerBranch)
+	})
+	if _, err := db.ExecContext(ctx, "CALL DOLT_CHECKOUT(?)", peerBranch); err != nil {
+		t.Fatalf("checkout peer branch: %v", err)
+	}
+	if seed {
+		updateIssue(theirTitle, theirUpdatedAt)
+	} else {
+		insertIssue(theirTitle)
+	}
+	if _, err := db.ExecContext(ctx, "CALL DOLT_COMMIT('-Am', 'issue on peer')"); err != nil {
+		t.Fatalf("commit issue on peer: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, "CALL DOLT_CHECKOUT(?)", currentBranch); err != nil {
+		t.Fatalf("checkout current branch: %v", err)
+	}
+
+	return store, peerBranch
+}
+
+func mergeAndTryAutoResolveIssues(t *testing.T, store *DoltStore, peerBranch string) bool {
+	t.Helper()
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	tx, err := store.db.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatalf("begin tx: %v", err)
+	}
+	if _, err := tx.ExecContext(ctx, "SET @@dolt_allow_commit_conflicts = 1"); err != nil {
+		_ = tx.Rollback()
+		t.Fatalf("allow commit conflicts: %v", err)
+	}
+	if _, err := tx.ExecContext(ctx, "CALL DOLT_MERGE(?)", peerBranch); err != nil {
+		t.Logf("merge returned: %v", err)
+	}
+
+	resolved, err := store.tryAutoResolveMergeConflicts(ctx, tx)
+	if err != nil {
+		_ = tx.Rollback()
+		t.Fatalf("resolver error: %v", err)
+	}
+	if resolved {
+		if err := tx.Commit(); err != nil {
+			t.Fatalf("commit after resolve: %v", err)
+		}
+	} else {
+		_ = tx.Rollback()
+	}
+	return resolved
+}
+
+func TestTryAutoResolveMergeConflicts_IssuesLWWTheirsWins(t *testing.T) {
+	const issueID = "lww-x"
+	store, peerBranch := setupIssueMergeConflict(t, issueID,
+		"ours", "2026-07-10 11:00:00", "theirs", "2026-07-10 12:00:00", true)
+
+	if resolved := mergeAndTryAutoResolveIssues(t, store, peerBranch); !resolved {
+		t.Fatal("expected issues modify/modify conflict to be auto-resolved")
+	}
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+	var title string
+	if err := store.db.QueryRowContext(ctx, "SELECT title FROM issues WHERE id = ?", issueID).Scan(&title); err != nil {
+		t.Fatalf("read title: %v", err)
+	}
+	if title != "theirs" {
+		t.Errorf("expected peer title %q, got %q", "theirs", title)
+	}
+	var count int
+	if err := store.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM issues WHERE id = ?", issueID).Scan(&count); err != nil {
+		t.Fatalf("count issues: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("expected 1 issue row after auto-resolve, got %d", count)
+	}
+}
+
+func TestTryAutoResolveMergeConflicts_IssuesLWWOursWins(t *testing.T) {
+	const issueID = "lww-y"
+	store, peerBranch := setupIssueMergeConflict(t, issueID,
+		"ours", "2026-07-10 13:00:00", "theirs", "2026-07-10 12:00:00", true)
+
+	if resolved := mergeAndTryAutoResolveIssues(t, store, peerBranch); !resolved {
+		t.Fatal("expected issues modify/modify conflict to be auto-resolved")
+	}
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+	var title string
+	if err := store.db.QueryRowContext(ctx, "SELECT title FROM issues WHERE id = ?", issueID).Scan(&title); err != nil {
+		t.Fatalf("read title: %v", err)
+	}
+	if title != "ours" {
+		t.Errorf("expected current title %q, got %q", "ours", title)
+	}
+}
+
+func TestTryAutoResolveMergeConflicts_IssuesAmbiguousLeftAlone(t *testing.T) {
+	store, peerBranch := setupIssueMergeConflict(t, "lww-z",
+		"ours", "2026-07-10 12:00:00", "theirs", "2026-07-10 12:00:00", true)
+
+	if resolved := mergeAndTryAutoResolveIssues(t, store, peerBranch); resolved {
+		t.Error("expected equal-timestamp issues conflict to be left unresolved")
+	}
+}
+
+func TestTryAutoResolveMergeConflicts_IssuesAddAddLeftAlone(t *testing.T) {
+	store, peerBranch := setupIssueMergeConflict(t, "lww-add",
+		"ours", "", "theirs", "", false)
+
+	if resolved := mergeAndTryAutoResolveIssues(t, store, peerBranch); resolved {
+		t.Error("expected issues add/add conflict to be left unresolved")
+	}
+}

--- a/internal/storage/dolt/pull_conflict_test.go
+++ b/internal/storage/dolt/pull_conflict_test.go
@@ -104,7 +104,10 @@ func TestPullAutoResolveMetadataConflicts(t *testing.T) {
 }
 
 // TestPullAutoResolveSkipsNonMetadataConflicts verifies that conflicts on
-// tables other than metadata are NOT auto-resolved.
+// tables other than metadata are NOT auto-resolved. The issues-table conflict
+// here is add/add (both branches insert the same PK), which the LWW safety
+// check rejects (GH#4698); modify/modify conflicts with different timestamps
+// ARE auto-resolved by LWW, covered by issues_conflict_test.go.
 func TestPullAutoResolveSkipsNonMetadataConflicts(t *testing.T) {
 	store, cleanup := setupTestStore(t)
 	defer cleanup()

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -3002,7 +3002,8 @@ func (s *DoltStore) finishCLIPull(ctx context.Context, pullErr error) error {
 
 // autoResolveConflictsAfterCLIPull inspects the working set and auto-resolves the
 // conflict classes that are safe without operator input (#4259 audit-only dependency
-// edges, GH#2466 metadata). It runs on a connection from the store pool (s.db) on
+// edges, GH#2466 metadata, GH#4698 issues-table LWW). It runs on a connection from
+// the store pool (s.db) on
 // purpose: those connections are on the same branch the CLI `dolt pull` merged into,
 // whereas a separately opened connection would default to the base branch and never
 // see the conflicts. The pull's
@@ -3077,8 +3078,9 @@ func (s *DoltStore) autoResolveConflictsAfterCLIPull(ctx context.Context) (bool,
 // tryAutoResolveMergeConflicts auto-resolves merge conflicts that are safe to
 // resolve without operator input (GH#2466 metadata, #4259 audit-only
 // dependency edges, bd-6dnrw.29 schema_migrations vintage rows, GH#2474
-// convergent kv.memory.* config rows), returning
-// (true, nil) only if ALL conflicts were resolved. The implementation is
+// convergent kv.memory.* config rows, GH#4698 issues-table LWW by updated_at),
+// returning (true, nil) only if ALL conflicts were resolved. The
+// implementation is
 // shared with the embedded pull path (bd-6dnrw.40); see
 // versioncontrolops.TryAutoResolveMergeConflicts for the full contract.
 func (s *DoltStore) tryAutoResolveMergeConflicts(ctx context.Context, tx *sql.Tx) (bool, error) {

--- a/internal/storage/versioncontrolops/mergesettle.go
+++ b/internal/storage/versioncontrolops/mergesettle.go
@@ -229,14 +229,18 @@ func workingSetClean(ctx context.Context, db DBConn) bool {
 //     are resolved row-wise by last-write-wins (updated_at) — whichever side
 //     has the strictly newer timestamp wins the whole row. add/add (no base
 //     row) and delete/modify are left for the operator, as are rows where both
-//     sides share the same updated_at (ambiguous). This eliminates the biggest
-//     manual wall in multi-clone sync: the issues-table conflicts that follow
-//     routine cross-clone pulls (GH#4698). LWW on the whole row loses
-//     field-level changes from the losing side (local updates notes at T1,
-//     remote updates status at T2 → remote row wins, local notes lost), the
-//     same convergent trade-off metadata and config already make; bd is
-//     primarily single-user-multi-machine so concurrent same-issue edits are
-//     rare.
+//     sides share the same updated_at (ambiguous). A row is only auto-resolved
+//     when the losing side's updated_at predates the merge base (equals the
+//     base row's updated_at): if the losing side also moved its updated_at past
+//     the base value, both sides made real edits since the last sync and LWW
+//     would silently drop the losing side's field-level changes, so the row is
+//     left for the operator. This eliminates the biggest manual wall in
+//     multi-clone sync: the issues-table conflicts that follow routine
+//     cross-clone pulls (GH#4698), while preserving the common case where one
+//     side's conflict is a migration artifact (the row was rewritten by a
+//     schema change but updated_at did not move) and the other side made the
+//     only real edit. bd is primarily single-user-multi-machine so concurrent
+//     same-issue edits since a shared merge base are rare.
 //
 // Any conflict on another table, or an unresolvable dependencies,
 // schema_migrations, config, or issues conflict, returns (false, nil) so the
@@ -381,13 +385,16 @@ func CommitResolvedConflicts(ctx context.Context, db DBConn) error {
 
 // issuesConflictsAreLWWSafe reports whether every conflicted row in the issues
 // table is a modify/modify conflict (the row existed at the merge base and was
-// modified on both sides) with strictly different updated_at timestamps — the
-// only class safe to auto-resolve by last-write-wins. add/add conflicts (no
-// base row), delete/modify conflicts (one side deleted), and rows where both
-// sides share the same updated_at (ambiguous) are left for the operator.
+// modified on both sides) with strictly different updated_at timestamps where
+// the losing side's timestamp predates the merge base — the only class safe to
+// auto-resolve by last-write-wins. add/add conflicts (no base row),
+// delete/modify conflicts (one side deleted), rows where both sides share the
+// same updated_at (ambiguous), and rows where the losing side's updated_at
+// moved past the base value (both sides made real edits since the last sync)
+// are left for the operator.
 func issuesConflictsAreLWWSafe(ctx context.Context, db DBConn) (bool, error) {
 	rows, err := db.QueryContext(ctx, `
-		SELECT base_id, our_id, their_id, our_updated_at, their_updated_at
+		SELECT base_id, our_id, their_id, base_updated_at, our_updated_at, their_updated_at
 		FROM dolt_conflicts_issues`)
 	if err != nil {
 		return false, fmt.Errorf("query issues conflicts: %w", err)
@@ -396,8 +403,8 @@ func issuesConflictsAreLWWSafe(ctx context.Context, db DBConn) (bool, error) {
 
 	for rows.Next() {
 		var baseID, ourID, theirID sql.NullString
-		var ourUpdatedAt, theirUpdatedAt sql.NullTime
-		if err := rows.Scan(&baseID, &ourID, &theirID, &ourUpdatedAt, &theirUpdatedAt); err != nil {
+		var baseUpdatedAt, ourUpdatedAt, theirUpdatedAt sql.NullTime
+		if err := rows.Scan(&baseID, &ourID, &theirID, &baseUpdatedAt, &ourUpdatedAt, &theirUpdatedAt); err != nil {
 			return false, fmt.Errorf("scan issues conflict: %w", err)
 		}
 		// One side deleted the row (delete/modify): leave for the operator.
@@ -414,6 +421,25 @@ func issuesConflictsAreLWWSafe(ctx context.Context, db DBConn) (bool, error) {
 		}
 		// Equal timestamps are ambiguous: leave for the operator.
 		if ourUpdatedAt.Time.Equal(theirUpdatedAt.Time) {
+			return false, nil
+		}
+		// The base row exists (modify/modify was confirmed above), so its
+		// updated_at should always be valid (the column is NOT NULL). Guard
+		// defensively: if it is somehow absent we cannot evaluate the
+		// predates check, so leave the row for the operator.
+		if !baseUpdatedAt.Valid {
+			return false, nil
+		}
+		// The losing side (older updated_at) must not have edited the issue
+		// since the merge base. If its updated_at moved past the base value,
+		// both sides made real edits since the last sync and row-level LWW
+		// would silently drop the losing side's field-level changes — leave
+		// that concurrent-edit case for the operator (GH#4698 Risk).
+		losing := ourUpdatedAt.Time
+		if theirUpdatedAt.Time.Before(losing) {
+			losing = theirUpdatedAt.Time
+		}
+		if losing.After(baseUpdatedAt.Time) {
 			return false, nil
 		}
 	}

--- a/internal/storage/versioncontrolops/mergesettle.go
+++ b/internal/storage/versioncontrolops/mergesettle.go
@@ -199,6 +199,7 @@ func workingSetClean(ctx context.Context, db DBConn) bool {
 //
 //   - metadata: machine-local rows (e.g. dolt_auto_push_*) that routinely diverge
 //     across clones (GH#2466). Resolved with "theirs".
+//
 //   - dependencies: with deterministic ids (#4259) the same logical edge has the
 //     same primary key on every clone, so a same-PK conflict is the SAME edge.
 //     When the two sides differ only in audit columns (created_at, created_by,
@@ -207,6 +208,7 @@ func workingSetClean(ctx context.Context, db DBConn) bool {
 //     convergent across clones pulling from the same remote). A conflict where the
 //     dependency type differs, or one side deleted the edge, is a real semantic
 //     conflict and is left for the operator.
+//
 //   - schema_migrations: pre-#4270 binaries record (version, NULL content_hash)
 //     while post-#4270 binaries record (version, sha256), so two clones applying
 //     the SAME migration with mixed binary vintages conflict on the cursor row
@@ -215,6 +217,7 @@ func workingSetClean(ctx context.Context, db DBConn) bool {
 //     provenance beats its absence, and the result converges across clones.
 //     Two DIFFERENT non-empty hashes are the #4259 schema fork itself and are
 //     left for the operator (bd doctor reports them as Migration Content Skew).
+//
 //   - config: persistent memories live in config as kv.memory.* rows (the
 //     pre-pull auto-commit now commits config so they sync). Like metadata,
 //     same-key memory edits across clones are machine-convergent: resolved with
@@ -222,9 +225,22 @@ func workingSetClean(ctx context.Context, db DBConn) bool {
 //     value. A conflict touching ANY non-memory config key (issue_prefix above
 //     all) is a real semantic conflict and is left for the operator.
 //
+//   - issues: modify/modify conflicts where both sides updated the same issue
+//     are resolved row-wise by last-write-wins (updated_at) — whichever side
+//     has the strictly newer timestamp wins the whole row. add/add (no base
+//     row) and delete/modify are left for the operator, as are rows where both
+//     sides share the same updated_at (ambiguous). This eliminates the biggest
+//     manual wall in multi-clone sync: the issues-table conflicts that follow
+//     routine cross-clone pulls (GH#4698). LWW on the whole row loses
+//     field-level changes from the losing side (local updates notes at T1,
+//     remote updates status at T2 → remote row wins, local notes lost), the
+//     same convergent trade-off metadata and config already make; bd is
+//     primarily single-user-multi-machine so concurrent same-issue edits are
+//     rare.
+//
 // Any conflict on another table, or an unresolvable dependencies,
-// schema_migrations, or config conflict, returns (false, nil) so the caller
-// fails the pull and the operator resolves it.
+// schema_migrations, config, or issues conflict, returns (false, nil) so the
+// caller fails the pull and the operator resolves it.
 //
 // The resolved tables are staged but NOT committed: the caller must run
 // CommitResolvedConflicts after the FK cascade repair, because DOLT_COMMIT
@@ -291,6 +307,15 @@ func TryAutoResolveMergeConflicts(ctx context.Context, db DBConn) (bool, error) 
 				return false, nil
 			}
 			resolvable = append(resolvable, "config")
+		case "issues":
+			lwwSafe, err := issuesConflictsAreLWWSafe(ctx, db)
+			if err != nil {
+				return false, err
+			}
+			if !lwwSafe {
+				return false, nil
+			}
+			resolvable = append(resolvable, "issues")
 		default:
 			return false, nil
 		}
@@ -321,6 +346,10 @@ func TryAutoResolveMergeConflicts(ctx context.Context, db DBConn) (bool, error) 
 			if _, err := db.ExecContext(ctx, "CALL DOLT_CONFLICTS_RESOLVE('--theirs', 'config')"); err != nil {
 				return false, fmt.Errorf("failed to resolve config conflicts: %w", err)
 			}
+		case "issues":
+			if err := resolveIssuesLWWConflicts(ctx, db); err != nil {
+				return false, err
+			}
 		default:
 			//nolint:gosec // G201: table is one of the hardcoded constants above.
 			if _, err := db.ExecContext(ctx, "CALL DOLT_CONFLICTS_RESOLVE('--theirs', '"+table+"')"); err != nil {
@@ -344,8 +373,114 @@ func TryAutoResolveMergeConflicts(ctx context.Context, db DBConn) (bool, error) 
 // cascade violation could never settle while the resolver committed first
 // (bd-578h9.14).
 func CommitResolvedConflicts(ctx context.Context, db DBConn) error {
-	if _, err := db.ExecContext(ctx, "CALL DOLT_COMMIT('-m', 'auto-resolve merge conflicts (GH#2466, #4259, GH#2474)')"); err != nil {
+	if _, err := db.ExecContext(ctx, "CALL DOLT_COMMIT('-m', 'auto-resolve merge conflicts (GH#2466, #4259, GH#2474, GH#4698)')"); err != nil {
 		return fmt.Errorf("failed to commit resolved conflicts: %w", err)
+	}
+	return nil
+}
+
+// issuesConflictsAreLWWSafe reports whether every conflicted row in the issues
+// table is a modify/modify conflict (the row existed at the merge base and was
+// modified on both sides) with strictly different updated_at timestamps — the
+// only class safe to auto-resolve by last-write-wins. add/add conflicts (no
+// base row), delete/modify conflicts (one side deleted), and rows where both
+// sides share the same updated_at (ambiguous) are left for the operator.
+func issuesConflictsAreLWWSafe(ctx context.Context, db DBConn) (bool, error) {
+	rows, err := db.QueryContext(ctx, `
+		SELECT base_id, our_id, their_id, our_updated_at, their_updated_at
+		FROM dolt_conflicts_issues`)
+	if err != nil {
+		return false, fmt.Errorf("query issues conflicts: %w", err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var baseID, ourID, theirID sql.NullString
+		var ourUpdatedAt, theirUpdatedAt sql.NullTime
+		if err := rows.Scan(&baseID, &ourID, &theirID, &ourUpdatedAt, &theirUpdatedAt); err != nil {
+			return false, fmt.Errorf("scan issues conflict: %w", err)
+		}
+		// One side deleted the row (delete/modify): leave for the operator.
+		if !ourID.Valid || !theirID.Valid {
+			return false, nil
+		}
+		// No base row means both sides added (add/add): leave for the operator.
+		if !baseID.Valid {
+			return false, nil
+		}
+		// Both timestamps must be present to compare.
+		if !ourUpdatedAt.Valid || !theirUpdatedAt.Valid {
+			return false, nil
+		}
+		// Equal timestamps are ambiguous: leave for the operator.
+		if ourUpdatedAt.Time.Equal(theirUpdatedAt.Time) {
+			return false, nil
+		}
+	}
+	return true, rows.Err()
+}
+
+// resolveIssuesLWWConflicts resolves modify/modify issues-table conflicts
+// (validated by issuesConflictsAreLWWSafe) row-wise by last-write-wins: for
+// each conflicted row, whichever side has the strictly newer updated_at wins
+// the whole row. DOLT_CONFLICTS_RESOLVE is table-level (--ours/--theirs), so
+// per-row resolution uses Dolt's manual-resolution path: for rows where ours
+// wins, deleting the conflict row from dolt_conflicts_issues signals resolution
+// (the working set already holds our values); the remaining rows (theirs wins)
+// are then resolved with a single --theirs call.
+func resolveIssuesLWWConflicts(ctx context.Context, db DBConn) error {
+	rows, err := db.QueryContext(ctx, `
+		SELECT our_id, our_updated_at, their_updated_at
+		FROM dolt_conflicts_issues`)
+	if err != nil {
+		return fmt.Errorf("query issues conflicts for LWW: %w", err)
+	}
+
+	type oursWin struct {
+		id string
+	}
+	var oursWins []oursWin
+	theirsCount := 0
+	for rows.Next() {
+		var ourID sql.NullString
+		var ourUpdatedAt, theirUpdatedAt sql.NullTime
+		if err := rows.Scan(&ourID, &ourUpdatedAt, &theirUpdatedAt); err != nil {
+			_ = rows.Close()
+			return fmt.Errorf("scan issues conflict for LWW: %w", err)
+		}
+		if !ourID.Valid || !ourUpdatedAt.Valid || !theirUpdatedAt.Valid {
+			// issuesConflictsAreLWWSafe already screened these out; a row
+			// that slipped through must not be silently resolved.
+			_ = rows.Close()
+			return fmt.Errorf("unexpected invalid conflict row in dolt_conflicts_issues (safety check bypassed)")
+		}
+		if ourUpdatedAt.Time.After(theirUpdatedAt.Time) {
+			oursWins = append(oursWins, oursWin{id: ourID.String})
+		} else {
+			theirsCount++
+		}
+	}
+	if err := errors.Join(rows.Err(), rows.Close()); err != nil {
+		return err
+	}
+
+	// For rows where ours wins: delete the conflict row. The working set
+	// already holds our values, so deleting the conflict entry signals
+	// resolution. Dolt applies this per-row using the primary key.
+	for _, w := range oursWins {
+		if _, err := db.ExecContext(ctx,
+			"DELETE FROM dolt_conflicts_issues WHERE our_id = ?", w.id); err != nil {
+			return fmt.Errorf("delete ours-wins conflict for issue %s: %w", w.id, err)
+		}
+	}
+
+	// For the remaining rows (theirs wins): resolve with --theirs. If there
+	// are none, skip the call — DOLT_CONFLICTS_RESOLVE on a conflict-free
+	// table is a no-op but skipping it avoids an unnecessary round-trip.
+	if theirsCount > 0 {
+		if _, err := db.ExecContext(ctx, "CALL DOLT_CONFLICTS_RESOLVE('--theirs', 'issues')"); err != nil {
+			return fmt.Errorf("failed to resolve theirs-wins issues conflicts: %w", err)
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
## Why

`bd dolt pull` bails to manual conflict resolution for the issues table even when every conflict is a provably-safe modify/modify where one side is strictly newer by `updated_at`. The existing auto-resolver (`TryAutoResolveMergeConflicts`) handles metadata, dependencies, schema_migrations, and config with table-specific safety checks, but issues hits the default case and dumps every conflict to the operator.

Observed 2026-07-10: after migrating v49→v54 and pulling, 36 issues-table conflicts required manual `dolt conflicts resolve --theirs`. Every one was modify/modify with the remote strictly newer by `updated_at`. This is the biggest remaining manual wall in the core multi-clone sync workflow.

Closes gastownhall/beads#4698.

## What

1. **Safety predicate** (`issuesConflictsAreLWWSafe`): only handle modify/modify (base row exists, both sides have the row). Reject add/add (no base row), delete/modify (one side deleted), and equal `updated_at` (ambiguous).
2. **Resolution** (`resolveIssuesLWWConflicts`): row-wise last-write-wins by `updated_at`. For rows where ours wins, delete the conflict row from `dolt_conflicts_issues` (the working set already holds our values — Dolt's manual-resolution path). For remaining rows (theirs wins), resolve with a single `DOLT_CONFLICTS_RESOLVE('--theirs', 'issues')`.
3. **Stage** with `DOLT_ADD('issues')` after resolution.

Never less safe than today: today every issues conflict bails regardless. The change only auto-resolves the provably-safe subset.

## Risk

LWW on the whole row loses field-level changes from the losing side (local updates notes at T1, remote updates status at T2 → remote row wins, local notes lost). **Mitigation implemented:** the safety predicate now also checks that the losing side's `updated_at` predates the merge base (equals the base row's `updated_at`). If the losing side also moved its `updated_at` past the base value, both sides made real edits since the last sync and the conflict is left for the operator. This preserves the common case (one side's conflict is a migration artifact — the row was rewritten by a schema change but `updated_at` did not move — and the other side made the only real edit) while declining the rarer concurrent-edit case where row-level LWW would silently drop field-level changes. See [follow-up comment](#issuecomment-4939374832).

## Tests

- `TestTryAutoResolveMergeConflicts_IssuesLWWTheirsWins` — theirs has newer `updated_at`, verify title matches theirs
- `TestTryAutoResolveMergeConflicts_IssuesLWWOursWins` — ours has newer `updated_at`, verify title matches ours
- `TestTryAutoResolveMergeConflicts_IssuesAmbiguousLeftAlone` — equal timestamps, verify unresolved
- `TestTryAutoResolveMergeConflicts_IssuesAddAddLeftAlone` — add/add, verify unresolved
- Updated `TestPullFromReportsOperatorConflicts` to pin `updated_at` to equal values (ambiguous → operator path still exercised)

