### PR TITLE
fix(label): support comma-separated multi-label add/remove; fail hard on bad issue IDs

### DIFF
--- a/cmd/bd/label.go
+++ b/cmd/bd/label.go
@@ -4,7 +4,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"os"
 	"sort"
 	"strings"
 
@@ -22,14 +21,17 @@ var labelCmd = &cobra.Command{
 	Short:   "Manage issue labels",
 }
 
-func processBatchLabelOperation(issueIDs []string, label string, operation string, jsonOut bool,
+func processBatchLabelOperation(issueIDs []string, labels []string, operation string, jsonOut bool,
 	txFunc func(context.Context, storage.Transaction, string, string, string) error) error {
 	ctx := rootCtx
-	commitMsg := fmt.Sprintf("bd: label %s '%s' on %d issue(s)", operation, label, len(issueIDs))
+	labelDesc := strings.Join(labels, "', '")
+	commitMsg := fmt.Sprintf("bd: label %s '%s' on %d issue(s)", operation, labelDesc, len(issueIDs))
 	err := transactHonoringAutoCommit(ctx, store, commitMsg, func(tx storage.Transaction) error {
 		for _, issueID := range issueIDs {
-			if err := txFunc(ctx, tx, issueID, label, actor); err != nil {
-				return fmt.Errorf("%s label '%s' on %s: %w", operation, label, issueID, err)
+			for _, label := range labels {
+				if err := txFunc(ctx, tx, issueID, label, actor); err != nil {
+					return fmt.Errorf("%s label '%s' on %s: %w", operation, label, issueID, err)
+				}
 			}
 		}
 		return nil
@@ -39,13 +41,15 @@ func processBatchLabelOperation(issueIDs []string, label string, operation strin
 	}
 	commandDidWrite.Store(true)
 	if jsonOut {
-		results := make([]map[string]interface{}, 0, len(issueIDs))
+		results := make([]map[string]interface{}, 0, len(issueIDs)*len(labels))
 		for _, issueID := range issueIDs {
-			results = append(results, map[string]interface{}{
-				"status":   operation,
-				"issue_id": issueID,
-				"label":    label,
-			})
+			for _, label := range labels {
+				results = append(results, map[string]interface{}{
+					"status":   operation,
+					"issue_id": issueID,
+					"label":    label,
+				})
+			}
 		}
 		return outputJSON(results)
 	}
@@ -55,21 +59,64 @@ func processBatchLabelOperation(issueIDs []string, label string, operation strin
 		verb = "Removed"
 		prep = "from"
 	}
+	noun := "label"
+	if len(labels) > 1 {
+		noun = "labels"
+	}
 	for _, issueID := range issueIDs {
-		fmt.Printf("%s %s label '%s' %s %s\n", ui.RenderPass("✓"), verb, label, prep, issueID)
+		fmt.Printf("%s %s %s '%s' %s %s\n", ui.RenderPass("✓"), verb, noun, labelDesc, prep, issueID)
 	}
 	return nil
 }
-func parseLabelArgs(args []string) (issueIDs []string, label string) {
-	label = args[len(args)-1]
+
+// parseLabelArgs splits positional args into issue IDs and labels. The final
+// arg is the label spec; commas separate multiple labels ("label1,label2").
+func parseLabelArgs(args []string) (issueIDs []string, labels []string) {
+	labels = splitLabelArg(args[len(args)-1])
 	issueIDs = args[:len(args)-1]
 	return
 }
 
+// splitLabelArg splits a comma-separated label argument into individual
+// labels, trimming whitespace and dropping empty entries. Matches the
+// comma-separated convention of bd create --labels.
+func splitLabelArg(arg string) []string {
+	parts := strings.Split(arg, ",")
+	labels := make([]string, 0, len(parts))
+	for _, part := range parts {
+		if part = strings.TrimSpace(part); part != "" {
+			labels = append(labels, part)
+		}
+	}
+	return labels
+}
+
+// resolveLabelIssueIDs resolves every issue-ID positional arg, failing hard on
+// the first arg that doesn't resolve. Labels come last on the command line, so
+// when several ID-position args fail the caller almost certainly passed labels
+// space-separated ("bd label add bd-123 a b c"); the error hints at the
+// comma-separated form instead of silently skipping the bad args (bd-vu5kv).
+func resolveLabelIssueIDs(ctx context.Context, subcommand string, issueIDs []string) ([]string, error) {
+	resolved := make([]string, 0, len(issueIDs))
+	for _, id := range issueIDs {
+		fullID, err := utils.ResolvePartialID(ctx, store, id)
+		if err != nil {
+			if len(issueIDs) > 1 {
+				return nil, fmt.Errorf("resolving issue ID %q: %w (to %s multiple labels, pass one comma-separated argument: bd label %s <issue-id> label1,label2)",
+					id, err, subcommand, subcommand)
+			}
+			return nil, fmt.Errorf("resolving issue ID %q: %w", id, err)
+		}
+		resolved = append(resolved, fullID)
+	}
+	return resolved, nil
+}
+
 //nolint:dupl // labelAddCmd and labelRemoveCmd are similar but serve different operations
 var labelAddCmd = &cobra.Command{
-	Use:           "add [issue-id...] [label]",
-	Short:         "Add a label to one or more issues",
+	Use:           "add [issue-id...] [label[,label...]]",
+	Short:         "Add one or more labels to one or more issues",
+	Long:          "Add labels to issues. Issue IDs come first; the final argument is the label. Pass multiple labels comma-separated: bd label add bd-123 label1,label2",
 	Args:          cobra.MinimumNArgs(2),
 	SilenceUsage:  true,
 	SilenceErrors: true,
@@ -83,30 +130,23 @@ var labelAddCmd = &cobra.Command{
 			}
 		}()
 
-		issueIDs, label := parseLabelArgs(args)
-		label = strings.TrimSpace(label)
-		if label == "" {
+		issueIDs, labels := parseLabelArgs(args)
+		if len(labels) == 0 {
 			return HandleErrorRespectJSON("label cannot be empty")
 		}
 		ctx := rootCtx
-		resolvedIDs := make([]string, 0, len(issueIDs))
-		for _, id := range issueIDs {
-			var fullID string
-			var err error
-			fullID, err = utils.ResolvePartialID(ctx, store, id)
-			if err != nil {
-				fmt.Fprintf(os.Stderr, "Error resolving %s: %v\n", id, err)
-				continue
+		issueIDs, err := resolveLabelIssueIDs(ctx, "add", issueIDs)
+		if err != nil {
+			return HandleErrorRespectJSON("%v", err)
+		}
+
+		for _, label := range labels {
+			if strings.HasPrefix(label, "provides:") {
+				return HandleErrorRespectJSON("'provides:' labels are reserved for cross-project capabilities. Hint: use 'bd ship %s' instead", strings.TrimPrefix(label, "provides:"))
 			}
-			resolvedIDs = append(resolvedIDs, fullID)
-		}
-		issueIDs = resolvedIDs
-
-		if strings.HasPrefix(label, "provides:") {
-			return HandleErrorRespectJSON("'provides:' labels are reserved for cross-project capabilities. Hint: use 'bd ship %s' instead", strings.TrimPrefix(label, "provides:"))
 		}
 
-		return processBatchLabelOperation(issueIDs, label, "added", jsonOutput,
+		return processBatchLabelOperation(issueIDs, labels, "added", jsonOutput,
 			func(ctx context.Context, tx storage.Transaction, issueID, lbl, act string) error {
 				return tx.AddLabel(ctx, issueID, lbl, act)
 			})
@@ -115,8 +155,9 @@ var labelAddCmd = &cobra.Command{
 
 //nolint:dupl // labelRemoveCmd and labelAddCmd are similar but serve different operations
 var labelRemoveCmd = &cobra.Command{
-	Use:           "remove [issue-id...] [label]",
-	Short:         "Remove a label from one or more issues",
+	Use:           "remove [issue-id...] [label[,label...]]",
+	Short:         "Remove one or more labels from one or more issues",
+	Long:          "Remove labels from issues. Issue IDs come first; the final argument is the label. Pass multiple labels comma-separated: bd label remove bd-123 label1,label2",
 	Args:          cobra.MinimumNArgs(2),
 	SilenceUsage:  true,
 	SilenceErrors: true,
@@ -130,21 +171,16 @@ var labelRemoveCmd = &cobra.Command{
 			}
 		}()
 
-		issueIDs, label := parseLabelArgs(args)
-		ctx := rootCtx
-		resolvedIDs := make([]string, 0, len(issueIDs))
-		for _, id := range issueIDs {
-			var fullID string
-			var err error
-			fullID, err = utils.ResolvePartialID(ctx, store, id)
-			if err != nil {
-				fmt.Fprintf(os.Stderr, "Error resolving %s: %v\n", id, err)
-				continue
-			}
-			resolvedIDs = append(resolvedIDs, fullID)
+		issueIDs, labels := parseLabelArgs(args)
+		if len(labels) == 0 {
+			return HandleErrorRespectJSON("label cannot be empty")
 		}
-		issueIDs = resolvedIDs
-		return processBatchLabelOperation(issueIDs, label, "removed", jsonOutput,
+		ctx := rootCtx
+		issueIDs, err := resolveLabelIssueIDs(ctx, "remove", issueIDs)
+		if err != nil {
+			return HandleErrorRespectJSON("%v", err)
+		}
+		return processBatchLabelOperation(issueIDs, labels, "removed", jsonOutput,
 			func(ctx context.Context, tx storage.Transaction, issueID, lbl, act string) error {
 				return tx.RemoveLabel(ctx, issueID, lbl, act)
 			})

--- a/cmd/bd/label_embedded_test.go
+++ b/cmd/bd/label_embedded_test.go
@@ -144,6 +144,45 @@ func TestEmbeddedLabel(t *testing.T) {
 		}
 	})
 
+	t.Run("label_add_comma_separated_multi", func(t *testing.T) {
+		issue := bdCreate(t, bd, dir, "Multi label add", "--type", "task")
+		out := bdLabel(t, bd, dir, "add", issue.ID, "multi-a,multi-b,multi-c")
+		if !strings.Contains(out, "Added") {
+			t.Errorf("expected 'Added' in output: %s", out)
+		}
+		labels := bdLabelListJSON(t, bd, dir, issue.ID)
+		labelSet := map[string]bool{}
+		for _, l := range labels {
+			labelSet[l] = true
+		}
+		for _, want := range []string{"multi-a", "multi-b", "multi-c"} {
+			if !labelSet[want] {
+				t.Errorf("expected %q in labels: %v", want, labels)
+			}
+		}
+	})
+
+	t.Run("label_remove_comma_separated_multi", func(t *testing.T) {
+		issue := bdCreate(t, bd, dir, "Multi label remove", "--type", "task",
+			"--label", "rm-a", "--label", "rm-b", "--label", "rm-keep")
+		bdLabel(t, bd, dir, "remove", issue.ID, "rm-a,rm-b")
+		labels := bdLabelListJSON(t, bd, dir, issue.ID)
+		for _, l := range labels {
+			if l == "rm-a" || l == "rm-b" {
+				t.Errorf("label %q should have been removed: %v", l, labels)
+			}
+		}
+		found := false
+		for _, l := range labels {
+			if l == "rm-keep" {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("expected 'rm-keep' to survive: %v", labels)
+		}
+	})
+
 	t.Run("label_add_duplicate_idempotent", func(t *testing.T) {
 		issue := bdCreate(t, bd, dir, "Dup label", "--type", "task")
 		bdLabel(t, bd, dir, "add", issue.ID, "dup")
@@ -321,6 +360,33 @@ func TestEmbeddedLabel(t *testing.T) {
 	t.Run("label_add_reserved_provides", func(t *testing.T) {
 		issue := bdCreate(t, bd, dir, "Reserved label", "--type", "task")
 		bdLabelFail(t, bd, dir, "add", issue.ID, "provides:auth")
+	})
+
+	t.Run("label_add_reserved_provides_in_comma_list", func(t *testing.T) {
+		issue := bdCreate(t, bd, dir, "Reserved label in list", "--type", "task")
+		bdLabelFail(t, bd, dir, "add", issue.ID, "ok-label,provides:auth")
+	})
+
+	t.Run("label_add_unresolvable_id_fails", func(t *testing.T) {
+		bdLabelFail(t, bd, dir, "add", "tl-doesnotexist", "some-label")
+	})
+
+	t.Run("label_add_space_separated_labels_fails_loudly", func(t *testing.T) {
+		// Regression test for bd-vu5kv: "bd label add <id> a b c" used to
+		// treat a/b as unresolvable issue IDs, skip them with a stderr
+		// warning, and exit 0 having applied only "c". It must now fail
+		// hard, apply nothing, and hint at the comma-separated form.
+		issue := bdCreate(t, bd, dir, "Space separated labels", "--type", "task")
+		out := bdLabelFail(t, bd, dir, "add", issue.ID, "space-a", "space-b", "space-c")
+		if !strings.Contains(out, "comma-separated") {
+			t.Errorf("expected comma-separated hint in error output: %s", out)
+		}
+		labels := bdLabelListJSON(t, bd, dir, issue.ID)
+		for _, l := range labels {
+			if strings.HasPrefix(l, "space-") {
+				t.Errorf("no label should have been applied, found %q: %v", l, labels)
+			}
+		}
 	})
 }
 

--- a/cmd/bd/simple_helpers_test.go
+++ b/cmd/bd/simple_helpers_test.go
@@ -7,41 +7,64 @@ import (
 
 func TestParseLabelArgs(t *testing.T) {
 	tests := []struct {
-		name        string
-		args        []string
-		expectIDs   int
-		expectLabel string
+		name         string
+		args         []string
+		expectIDs    int
+		expectLabels []string
 	}{
 		{
-			name:        "single ID single label",
-			args:        []string{"bd-1", "bug"},
-			expectIDs:   1,
-			expectLabel: "bug",
+			name:         "single ID single label",
+			args:         []string{"bd-1", "bug"},
+			expectIDs:    1,
+			expectLabels: []string{"bug"},
 		},
 		{
-			name:        "multiple IDs single label",
-			args:        []string{"bd-1", "bd-2", "critical"},
-			expectIDs:   2,
-			expectLabel: "critical",
+			name:         "multiple IDs single label",
+			args:         []string{"bd-1", "bd-2", "critical"},
+			expectIDs:    2,
+			expectLabels: []string{"critical"},
 		},
 		{
-			name:        "three IDs one label",
-			args:        []string{"bd-1", "bd-2", "bd-3", "bug"},
-			expectIDs:   3,
-			expectLabel: "bug",
+			name:         "three IDs one label",
+			args:         []string{"bd-1", "bd-2", "bd-3", "bug"},
+			expectIDs:    3,
+			expectLabels: []string{"bug"},
+		},
+		{
+			name:         "comma-separated labels",
+			args:         []string{"bd-1", "bug,critical,needs-review"},
+			expectIDs:    1,
+			expectLabels: []string{"bug", "critical", "needs-review"},
+		},
+		{
+			name:         "comma-separated labels with whitespace and empties",
+			args:         []string{"bd-1", " bug , ,critical,"},
+			expectIDs:    1,
+			expectLabels: []string{"bug", "critical"},
+		},
+		{
+			name:         "whitespace-only label yields no labels",
+			args:         []string{"bd-1", "  "},
+			expectIDs:    1,
+			expectLabels: []string{},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ids, label := parseLabelArgs(tt.args)
+			ids, labels := parseLabelArgs(tt.args)
 
 			if len(ids) != tt.expectIDs {
 				t.Errorf("Expected %d IDs, got %d", tt.expectIDs, len(ids))
 			}
 
-			if label != tt.expectLabel {
-				t.Errorf("Expected label %q, got %q", tt.expectLabel, label)
+			if len(labels) != len(tt.expectLabels) {
+				t.Fatalf("Expected labels %v, got %v", tt.expectLabels, labels)
+			}
+			for i, want := range tt.expectLabels {
+				if labels[i] != want {
+					t.Errorf("Expected label %d to be %q, got %q", i, want, labels[i])
+				}
 			}
 		})
 	}

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -27,11 +27,11 @@ Reference for bd Latest. Generated from `bd help --all`.
   - [bd gate show](#bd-gate-show) — Show a gate issue
 - [bd heartbeat](#bd-heartbeat) — Refresh the lease on an issue you hold in_progress
 - [bd label](#bd-label) — Manage issue labels
-  - [bd label add](#bd-label-add) — Add a label to one or more issues
+  - [bd label add](#bd-label-add) — Add one or more labels to one or more issues
   - [bd label list](#bd-label-list) — List labels for an issue
   - [bd label list-all](#bd-label-list-all) — List all unique labels in the database
   - [bd label propagate](#bd-label-propagate) — Propagate a label from a parent issue to all its children
-  - [bd label remove](#bd-label-remove) — Remove a label from one or more issues
+  - [bd label remove](#bd-label-remove) — Remove one or more labels from one or more issues
 - [bd link](#bd-link) — Link two issues with a dependency
 - [bd list](#bd-list) — List issues
 - [bd merge-slot](#bd-merge-slot) — Manage merge-slot gates for serialized conflict resolution
@@ -854,10 +854,10 @@ bd label
 
 #### bd label add
 
-Add a label to one or more issues
+Add labels to issues. Issue IDs come first; the final argument is the label. Pass multiple labels comma-separated: bd label add bd-123 label1,label2
 
 ```
-bd label add [issue-id...] [label]
+bd label add [issue-id...] [label[,label...]]
 ```
 
 #### bd label list
@@ -886,10 +886,10 @@ bd label propagate [parent-id] [label]
 
 #### bd label remove
 
-Remove a label from one or more issues
+Remove labels from issues. Issue IDs come first; the final argument is the label. Pass multiple labels comma-separated: bd label remove bd-123 label1,label2
 
 ```
-bd label remove [issue-id...] [label]
+bd label remove [issue-id...] [label[,label...]]
 ```
 
 ### bd link

--- a/docs/LABELS.md
+++ b/docs/LABELS.md
@@ -29,11 +29,17 @@ bd create "Fix auth bug" -t bug -p 1 -l auth,backend,urgent
 bd label add bd-42 security
 bd label add bd-42 breaking-change
 
+# Add multiple labels at once (comma-separated, no spaces around commas)
+bd label add bd-42 security,breaking-change
+
 # List issue labels
 bd label list bd-42
 
 # Remove a label
 bd label remove bd-42 urgent
+
+# Remove multiple labels at once
+bd label remove bd-42 urgent,needs-review
 
 # List all labels in use
 bd label list-all

--- a/website/docs/cli-reference/label.md
+++ b/website/docs/cli-reference/label.md
@@ -18,10 +18,10 @@ bd label [flags]
 
 ### bd label add
 
-Add a label to one or more issues
+Add labels to issues. Issue IDs come first; the final argument is the label. Pass multiple labels comma-separated: bd label add bd-123 label1,label2
 
 ```
-bd label add [issue-id...] [label] [flags]
+bd label add [issue-id...] [label[,label...]] [flags]
 ```
 
 ### bd label list
@@ -50,8 +50,8 @@ bd label propagate [parent-id] [label] [flags]
 
 ### bd label remove
 
-Remove a label from one or more issues
+Remove labels from issues. Issue IDs come first; the final argument is the label. Pass multiple labels comma-separated: bd label remove bd-123 label1,label2
 
 ```
-bd label remove [issue-id...] [label] [flags]
+bd label remove [issue-id...] [label[,label...]] [flags]
 ```

--- a/website/docs/core-concepts/labels.md
+++ b/website/docs/core-concepts/labels.md
@@ -35,11 +35,17 @@ bd create "Fix auth bug" -t bug -p 1 -l auth,backend,urgent
 bd label add bd-42 security
 bd label add bd-42 breaking-change
 
+# Add multiple labels at once (comma-separated, no spaces around commas)
+bd label add bd-42 security,breaking-change
+
 # List issue labels
 bd label list bd-42
 
 # Remove a label
 bd label remove bd-42 urgent
+
+# Remove multiple labels at once
+bd label remove bd-42 urgent,needs-review
 
 # List all labels in use
 bd label list-all

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -1774,11 +1774,17 @@ bd create "Fix auth bug" -t bug -p 1 -l auth,backend,urgent
 bd label add bd-42 security
 bd label add bd-42 breaking-change
 
+# Add multiple labels at once (comma-separated, no spaces around commas)
+bd label add bd-42 security,breaking-change
+
 # List issue labels
 bd label list bd-42
 
 # Remove a label
 bd label remove bd-42 urgent
+
+# Remove multiple labels at once
+bd label remove bd-42 urgent,needs-review
 
 # List all labels in use
 bd label list-all

--- a/website/versioned_docs/version-1.1.0/core-concepts/labels.md
+++ b/website/versioned_docs/version-1.1.0/core-concepts/labels.md
@@ -35,11 +35,17 @@ bd create "Fix auth bug" -t bug -p 1 -l auth,backend,urgent
 bd label add bd-42 security
 bd label add bd-42 breaking-change
 
+# Add multiple labels at once (comma-separated, no spaces around commas)
+bd label add bd-42 security,breaking-change
+
 # List issue labels
 bd label list bd-42
 
 # Remove a label
 bd label remove bd-42 urgent
+
+# Remove multiple labels at once
+bd label remove bd-42 urgent,needs-review
 
 # List all labels in use
 bd label list-all


### PR DESCRIPTION
## Problem (bd-vu5kv)

`bd label add <id> a b c` silently applies only `c`. The grammar is `add [issue-id...] [label]` — the last arg is the only label, and everything before it is treated as an issue ID. `a` and `b` fail to resolve, print a stderr warning, get **skipped**, and the command exits 0. A Fable agent hit this in the wild and only caught it because `bd ready --label program:castellan` came back empty.

The warn-and-continue also meant a plain typo'd issue ID in a batch call could exit 0 having labeled nothing.

## Fix

1. **Comma-separated multi-label**: the final positional arg now splits on commas, so `bd label add bd-123 a,b,c` adds all three labels in one transaction. Matches the existing `bd create --labels a,b,c` convention. Same for `bd label remove`.
2. **Fail hard on unresolvable issue IDs**: resolution failure is now an error *before any mutation* (resolution happens ahead of the transaction, so nothing is partially applied). When multiple ID-position args fail — the space-separated-labels mistake — the error hints at the comma form:
   ```
   Error: resolving issue ID "a": no issue found matching "a" (to add multiple
   labels, pass one comma-separated argument: bd label add <issue-id> label1,label2)
   ```

Space-separated positional labels can't be made to Just Work: ID resolution is fuzzy (partial hashes, prefix-less forms), so guessing the ID/label boundary risks applying labels to the wrong issue. Loud error + hint is the safe behavior.

The reserved `provides:` check now runs against every label in the list.

## Behavior changes

- Batch calls with an unresolvable ID now exit non-zero and apply nothing (previously: warn, skip, exit 0).
- A label containing a literal comma can no longer be added/removed positionally — already impossible via `bd create --labels`, which splits on commas.

## Testing

- New parser unit tests (comma splitting, whitespace, empties).
- 4 new embedded end-to-end tests, including a regression test for the exact reported invocation (`add <id> space-a space-b space-c` → hard error, comma hint, zero labels applied). Full `TestEmbeddedLabel` suite: 22/22 pass.
- Full `go test ./cmd/bd/` suite green; `golangci-lint` clean.
- CLI reference regenerated with `scripts/generate-cli-docs.sh` (pinned pure-go build) for the doc-freshness probe; docs/LABELS.md updated.

Closes bd-vu5kv

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012VBUR4qkHbssPomBDuJgkQ