### PR TITLE
fix(lease): stop arming worker leases on bare status/assignee updates

### DIFF
--- a/internal/storage/dolt/lease_test.go
+++ b/internal/storage/dolt/lease_test.go
@@ -137,6 +137,9 @@ func TestUpdateIssueMaintainsLeaseOwnership(t *testing.T) {
 	seedClaimedIssue(t, ctx, store, "lease-update", "alice", time.Hour)
 	before := readLeaseState(t, ctx, store, "lease-update")
 
+	// An assignee transfer through generic update clears the old owner's lease
+	// rather than stamping a fresh one: the new holder did not claim through the
+	// lease-aware verb, so their hold is durable until they opt in (bd-9hpgf).
 	if err := store.UpdateIssue(ctx, "lease-update", map[string]interface{}{"assignee": "bob"}, "dispatcher"); err != nil {
 		t.Fatalf("transfer assignee: %v", err)
 	}
@@ -144,17 +147,22 @@ func TestUpdateIssueMaintainsLeaseOwnership(t *testing.T) {
 	if transferred.assignee.String != "bob" {
 		t.Fatalf("assignee after transfer = %q, want bob", transferred.assignee.String)
 	}
-	if !transferred.leaseExpires.Valid || !transferred.heartbeatAt.Valid {
-		t.Fatalf("transfer did not stamp a fresh lease: %+v", transferred)
+	if transferred.leaseExpires.Valid || transferred.heartbeatAt.Valid {
+		t.Fatalf("transfer should clear the old owner's lease, got %+v", transferred)
 	}
-	if !transferred.heartbeatAt.Time.After(before.heartbeatAt.Time) && transferred.rowLock == before.rowLock {
-		t.Fatalf("transfer did not refresh heartbeat or row_lock: before=%+v after=%+v", before, transferred)
+	if transferred.rowLock == before.rowLock {
+		t.Fatalf("transfer did not rewrite row_lock: before=%+v after=%+v", before, transferred)
 	}
 	if err := store.HeartbeatIssue(ctx, "lease-update", "alice"); !errors.Is(err, storage.ErrAlreadyClaimed) {
 		t.Fatalf("old owner heartbeat err = %v, want ErrAlreadyClaimed", err)
 	}
+	// The new owner can opt back into lease semantics by heartbeating.
 	if err := store.HeartbeatIssue(ctx, "lease-update", "bob"); err != nil {
 		t.Fatalf("new owner heartbeat: %v", err)
+	}
+	rearmed := readLeaseState(t, ctx, store, "lease-update")
+	if !rearmed.leaseExpires.Valid || !rearmed.heartbeatAt.Valid {
+		t.Fatalf("heartbeat by new owner should re-arm the lease, got %+v", rearmed)
 	}
 
 	if err := store.UpdateIssue(ctx, "lease-update", map[string]interface{}{"status": string(types.StatusOpen)}, "dispatcher"); err != nil {
@@ -163,6 +171,94 @@ func TestUpdateIssueMaintainsLeaseOwnership(t *testing.T) {
 	open := readLeaseState(t, ctx, store, "lease-update")
 	if open.leaseExpires.Valid || open.heartbeatAt.Valid {
 		t.Fatalf("status away from in_progress did not clear lease: %+v", open)
+	}
+}
+
+// TestBareUpdateClaimDoesNotArmLease is the regression guard for bd-9hpgf
+// (GH#4716): a plain interactive claim — `bd update -s in_progress -a <who>`
+// with no worker/lease semantics intended — must NOT arm a lease. Nobody
+// heartbeats an interactive session, so an armed lease just lapses and the
+// reclaim reaper reverts the bead out from under its owner.
+func TestBareUpdateClaimDoesNotArmLease(t *testing.T) {
+	store, cleanup := setupConcurrentTestStore(t)
+	defer cleanup()
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	issue := &types.Issue{
+		ID:        "lease-handdole",
+		Title:     "hand-dole claim",
+		Status:    types.StatusOpen,
+		Priority:  2,
+		IssueType: types.TypeTask,
+	}
+	if err := store.CreateIssue(ctx, issue, "seeder"); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	if err := store.UpdateIssue(ctx, "lease-handdole", map[string]interface{}{
+		"status":   string(types.StatusInProgress),
+		"assignee": "crow",
+	}, "crow"); err != nil {
+		t.Fatalf("bare interactive claim: %v", err)
+	}
+	ls := readLeaseState(t, ctx, store, "lease-handdole")
+	if ls.status != "in_progress" || ls.assignee.String != "crow" {
+		t.Fatalf("claim did not stick: %+v", ls)
+	}
+	if ls.leaseExpires.Valid || ls.heartbeatAt.Valid {
+		t.Fatalf("bare status+assignee update armed a lease: %+v", ls)
+	}
+
+	// Even a reclaim sweep with its cutoff pushed into the future (which would
+	// reap ANY leased issue) must leave the interactive claim alone: durable
+	// until the actor releases it or a human reclaims.
+	reclaimed, err := store.ReclaimExpiredLeases(ctx, -time.Hour, "reaper")
+	if err != nil {
+		t.Fatalf("reclaim sweep: %v", err)
+	}
+	for _, r := range reclaimed {
+		if r.ID == "lease-handdole" {
+			t.Fatalf("interactive claim was reclaimed: %+v", r)
+		}
+	}
+	after := readLeaseState(t, ctx, store, "lease-handdole")
+	if after.status != "in_progress" || after.assignee.String != "crow" {
+		t.Fatalf("interactive claim disturbed by reclaim: %+v", after)
+	}
+}
+
+// TestUpdatePreservesLeaseOnSameClaim: a generic update that does not change
+// who holds the claim (same assignee, still in_progress) must leave a worker's
+// live lease untouched — a supervisor tweaking priority or re-asserting the
+// same status must not disarm dead-worker recovery for a real worker claim.
+func TestUpdatePreservesLeaseOnSameClaim(t *testing.T) {
+	store, cleanup := setupConcurrentTestStore(t)
+	defer cleanup()
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	seedClaimedIssue(t, ctx, store, "lease-same", "alice", time.Hour)
+	before := readLeaseState(t, ctx, store, "lease-same")
+	if !before.leaseExpires.Valid {
+		t.Fatalf("seed claim did not arm a lease: %+v", before)
+	}
+
+	// Re-assert the same status+assignee alongside an unrelated field edit.
+	if err := store.UpdateIssue(ctx, "lease-same", map[string]interface{}{
+		"status":   string(types.StatusInProgress),
+		"assignee": "alice",
+		"priority": 1,
+	}, "supervisor"); err != nil {
+		t.Fatalf("same-claim update: %v", err)
+	}
+	after := readLeaseState(t, ctx, store, "lease-same")
+	if !after.leaseExpires.Valid || !after.heartbeatAt.Valid {
+		t.Fatalf("same-claim update dropped the worker's lease: %+v", after)
+	}
+	if !after.leaseExpires.Time.Equal(before.leaseExpires.Time) {
+		t.Errorf("same-claim update moved lease_expires_at: before=%v after=%v",
+			before.leaseExpires.Time, after.leaseExpires.Time)
 	}
 }
 

--- a/internal/storage/issueops/update.go
+++ b/internal/storage/issueops/update.go
@@ -88,9 +88,23 @@ func ManageStartedAt(oldIssue *types.Issue, updates map[string]interface{}, setC
 }
 
 // ManageLeaseOnUpdate keeps lease ownership coherent when generic updates alter
-// status or assignee. Claim/heartbeat own the normal lease lifecycle, but bd
-// update can transfer or reopen work directly.
-func ManageLeaseOnUpdate(oldIssue *types.Issue, updates map[string]interface{}, setClauses []string, args []interface{}, ctx context.Context) ([]string, []interface{}) {
+// status or assignee. Leases are armed ONLY by the lease-aware verbs — claim
+// (ClaimIssueInTx, bd update --claim, bd ready --claim) and heartbeat — never by
+// a generic update. A bare `bd update -s in_progress -a <who>` is an interactive
+// hand-dole claim: nobody is heartbeating it, so arming a lease here just turns
+// the claim into reclaim-bait that reverts to open after the TTL (bd-9hpgf,
+// GH#4716). This helper therefore only ever CLEARS lease columns:
+//
+//   - the update moves the row out of the claimed state (not in_progress, or
+//     unassigned): any lease is stale — clear it.
+//   - the update changes who holds the claim (assignee transfer, or a fresh
+//     transition into in_progress): the previous owner's lease must not count
+//     down against the new holder — clear it. The new holder gets a lease only
+//     via the claim verb; a real worker's next heartbeat re-arms one.
+//   - the update leaves the same claim in place (already in_progress, same
+//     assignee): leave the lease columns untouched, so a worker's live lease
+//     survives unrelated edits to its issue.
+func ManageLeaseOnUpdate(oldIssue *types.Issue, updates map[string]interface{}, setClauses []string, args []interface{}) ([]string, []interface{}) {
 	rawStatus, hasStatus := updates["status"]
 	rawAssignee, hasAssignee := updates["assignee"]
 	if !hasStatus && !hasAssignee {
@@ -121,14 +135,13 @@ func ManageLeaseOnUpdate(oldIssue *types.Issue, updates map[string]interface{}, 
 		}
 	}
 
-	if newStatus != string(types.StatusInProgress) || newAssignee == "" {
-		setClauses = append(setClauses, "lease_expires_at = NULL", "heartbeat_at = NULL")
+	sameClaim := newStatus == string(types.StatusInProgress) && newAssignee != "" &&
+		oldIssue.Status == types.StatusInProgress && newAssignee == oldIssue.Assignee
+	if sameClaim {
 		return setClauses, args
 	}
 
-	now := time.Now().UTC()
-	setClauses = append(setClauses, "lease_expires_at = ?", "heartbeat_at = ?")
-	args = append(args, now.Add(leaseTTL(ctx)), now)
+	setClauses = append(setClauses, "lease_expires_at = NULL", "heartbeat_at = NULL")
 	return setClauses, args
 }
 
@@ -261,7 +274,8 @@ func updateIssueInTx(ctx context.Context, tx DBTX, id string, updates map[string
 	setClauses, args = ManageStartedAt(oldIssue, updates, setClauses, args)
 
 	// Auto-manage leases when direct updates change status or assignee.
-	setClauses, args = ManageLeaseOnUpdate(oldIssue, updates, setClauses, args, ctx)
+	// Clears stale leases only; arming is reserved for claim/heartbeat.
+	setClauses, args = ManageLeaseOnUpdate(oldIssue, updates, setClauses, args)
 
 	// Rewrite row_lock on every update so a concurrent lease mutation (heartbeat/
 	// reclaim) collides on this shared cell and is forced to conflict-and-retry

--- a/internal/storage/issueops/update_test.go
+++ b/internal/storage/issueops/update_test.go
@@ -1,0 +1,111 @@
+package issueops
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// TestManageLeaseOnUpdate pins the clear-only contract (bd-9hpgf, GH#4716):
+// generic updates never arm a lease — arming belongs to claim/heartbeat. The
+// helper clears the lease columns whenever the update leaves the claimed state
+// or changes who holds the claim, and leaves them untouched when the same
+// claim stays in place.
+func TestManageLeaseOnUpdate(t *testing.T) {
+	const clearClause = "lease_expires_at = NULL"
+
+	tests := []struct {
+		name      string
+		oldStatus types.Status
+		oldOwner  string
+		updates   map[string]interface{}
+		wantClear bool // false = lease columns untouched
+	}{
+		{
+			name:      "bare hand-dole claim does not arm",
+			oldStatus: types.StatusOpen,
+			updates:   map[string]interface{}{"status": "in_progress", "assignee": "crow"},
+			wantClear: true,
+		},
+		{
+			name:      "status-only transition into in_progress with existing assignee does not arm",
+			oldStatus: types.StatusOpen,
+			oldOwner:  "crow",
+			updates:   map[string]interface{}{"status": "in_progress"},
+			wantClear: true,
+		},
+		{
+			name:      "assignee transfer clears the old owner's lease",
+			oldStatus: types.StatusInProgress,
+			oldOwner:  "alice",
+			updates:   map[string]interface{}{"assignee": "bob"},
+			wantClear: true,
+		},
+		{
+			name:      "reopen clears the lease",
+			oldStatus: types.StatusInProgress,
+			oldOwner:  "alice",
+			updates:   map[string]interface{}{"status": "open"},
+			wantClear: true,
+		},
+		{
+			name:      "unassign clears the lease",
+			oldStatus: types.StatusInProgress,
+			oldOwner:  "alice",
+			updates:   map[string]interface{}{"assignee": nil},
+			wantClear: true,
+		},
+		{
+			name:      "same-claim status re-assert leaves lease alone",
+			oldStatus: types.StatusInProgress,
+			oldOwner:  "alice",
+			updates:   map[string]interface{}{"status": "in_progress"},
+			wantClear: false,
+		},
+		{
+			name:      "same-claim assignee re-assert leaves lease alone",
+			oldStatus: types.StatusInProgress,
+			oldOwner:  "alice",
+			updates:   map[string]interface{}{"status": types.StatusInProgress, "assignee": "alice"},
+			wantClear: false,
+		},
+		{
+			name:      "no status or assignee in updates is a no-op",
+			oldStatus: types.StatusInProgress,
+			oldOwner:  "alice",
+			updates:   map[string]interface{}{"priority": 1},
+			wantClear: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			oldIssue := &types.Issue{Status: tt.oldStatus, Assignee: tt.oldOwner}
+			inClauses := []string{"updated_at = ?"}
+			inArgs := []interface{}{"now"}
+
+			gotClauses, gotArgs := ManageLeaseOnUpdate(oldIssue, tt.updates, inClauses, inArgs)
+
+			cleared := false
+			for _, c := range gotClauses {
+				if c == clearClause {
+					cleared = true
+				}
+			}
+			if cleared != tt.wantClear {
+				t.Errorf("clear = %v, want %v (clauses: %v)", cleared, tt.wantClear, gotClauses)
+			}
+			// The helper must never arm: no new args beyond what came in, and no
+			// parameterized lease clause.
+			if !reflect.DeepEqual(gotArgs, inArgs) {
+				t.Errorf("args changed — generic update must never stamp lease values: %v", gotArgs)
+			}
+			for _, c := range gotClauses {
+				if c == "lease_expires_at = ?" || c == "heartbeat_at = ?" {
+					t.Errorf("generic update armed a lease via clause %q", c)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #4716 (local bead: bd-9hpgf, P1).

## Problem

`ManageLeaseOnUpdate` armed a 5-minute worker lease whenever a generic update left an issue `in_progress` + assigned — it gated on the **resulting state**, not the **verb**. So a plain interactive claim (`bd update -s in_progress -a <who>`) silently entered the heartbeat/reclaim protocol that nobody was running for it:

1. Interactive session claims a bead by hand — lease armed, no one heartbeats.
2. Lease lapses; `bd reclaim` reverts the bead to open while the owner keeps working.
3. Supervisor restores the assignment — which re-arms the lease, making the churn self-sustaining (~15 min revert/restore cycles across every crew-held bead).
4. Eventually a headless fleet worker legitimately claims a reverted bead whose owner is mid-implementation → duplicate work, force-close + collision cleanup.

Observed live on the wyvern shared-dolt constellation (their wy-nx8pt); every multi-agent deployment mixing interactive and fleet claims would hit it.

## Fix

Leases now arm **only** via the lease-aware verbs — `ClaimIssueInTx` (`bd update --claim`, `bd ready --claim`) and heartbeat. `ManageLeaseOnUpdate` is clear-only:

- **Leaving the claimed state** (not in_progress, or unassigned): clears the lease, as before.
- **Changing who holds the claim** (assignee transfer, or a fresh transition into in_progress): clears the previous owner's lease so it can't count down against the new holder. The new holder gets a lease only by claiming/heartbeating through the lease-aware verbs.
- **Same-claim edit** (already in_progress, same assignee): lease columns untouched — a worker's live lease survives unrelated edits to its issue.

This also defuses the supervisor-restore churn amplifier: a restore via `bd update` no longer re-arms anything. Real workers restored that way self-heal — their next heartbeat re-arms the lease (heartbeat only requires `in_progress` + owner match, not an existing lease).

`updateIssueInTx` still rewrites `row_lock` on every mutation, so the reclaim/heartbeat conflict invariant is unchanged. The domain/db backend never managed leases on update (pre-existing parity gap tracked in bd-6dnrw.44), so no changes there.

## Tests

- `TestBareUpdateClaimDoesNotArmLease` (new, real Dolt): the bd-9hpgf repro — hand-dole claim carries no lease and survives a reclaim sweep whose cutoff would reap any leased issue.
- `TestUpdatePreservesLeaseOnSameClaim` (new, real Dolt): a same-claim edit doesn't disarm a worker's live lease.
- `TestUpdateIssueMaintainsLeaseOwnership` (flipped): previously pinned the buggy transfer-stamps-fresh-lease behavior; now asserts transfer clears the lease, old owner can't heartbeat, new owner re-arms via heartbeat.
- `TestManageLeaseOnUpdate` (new, pure unit table-test): pins the clear-only contract — a generic update never emits lease-arming SQL.

Verified end-to-end with the built binary: bare `bd update -s in_progress -a crow` leaves `lease_expires_at`/`heartbeat_at` NULL and `bd reclaim` leaves it alone; `bd update --claim` still stamps the 5-minute lease.

Full `internal/storage` (non-dolt) suite passes; dolt-package and `cmd/bd` suites show only failures identical to `origin/main` baselines run on the same machine (known container-contention flakes + pre-existing failures, lists diffed by name).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U5mtSXJuNGs4tmeKDbwNif