### PR TITLE
fix(postgres): serialize concurrent schema initialization

### DIFF
--- a/internal/storage/postgres/schema.go
+++ b/internal/storage/postgres/schema.go
@@ -476,6 +476,21 @@ func InitSchema(ctx context.Context, db *sql.DB, schema string) error {
 	}
 	defer conn.Close()
 
+	// InitSchema runs on every backend open. Separate bd processes can open the
+	// same workspace concurrently, and PostgreSQL's IF NOT EXISTS / CREATE OR
+	// REPLACE forms are not safe against concurrent catalog updates (for
+	// example pg_namespace uniqueness and function replacement can race). Hold
+	// a session advisory lock for this database+schema while applying bootstrap
+	// DDL. The lock is automatically released when conn closes even if the
+	// explicit unlock cannot run because ctx was canceled.
+	const lockKey = `hashtextextended(current_database() || ':' || $1, 0)`
+	if _, err := conn.ExecContext(ctx, `SELECT pg_advisory_lock(`+lockKey+`)`, schema); err != nil {
+		return fmt.Errorf("postgres: lock schema %q initialization: %w", schema, err)
+	}
+	defer func() {
+		_, _ = conn.ExecContext(context.Background(), `SELECT pg_advisory_unlock(`+lockKey+`)`, schema)
+	}()
+
 	if _, err := conn.ExecContext(ctx, `CREATE SCHEMA IF NOT EXISTS "`+schema+`"`); err != nil {
 		return fmt.Errorf("postgres: create schema %q: %w", schema, err)
 	}

--- a/internal/storage/postgres/schema_test.go
+++ b/internal/storage/postgres/schema_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"fmt"
 	"os"
+	"sync"
 	"testing"
 	"time"
 
@@ -52,6 +53,56 @@ func TestInitSchema(t *testing.T) {
 		if !tableExists(ctx, t, db, schema, table) {
 			t.Errorf("expected table %q to exist in schema %q", table, schema)
 		}
+	}
+}
+
+// TestInitSchemaConcurrent guards process-level startup: Gas City and other
+// orchestrators may launch several short-lived bd commands for one workspace at
+// once. Every command opens the backend and calls InitSchema, so the bootstrap
+// DDL must serialize across independent PostgreSQL sessions.
+func TestInitSchemaConcurrent(t *testing.T) {
+	pgURL := os.Getenv("BEADS_PG_TEST_URL")
+	if pgURL == "" {
+		t.Skip("BEADS_PG_TEST_URL not set; skipping concurrent Postgres schema test")
+	}
+	schema := fmt.Sprintf("bd_schema_concurrent_%d", time.Now().UnixNano())
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	const workers = 8
+	start := make(chan struct{})
+	errs := make(chan error, workers)
+	var wg sync.WaitGroup
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			raw, err := pgdialect.OpenRaw(pgURL, schema)
+			if err != nil {
+				errs <- err
+				return
+			}
+			defer raw.Close()
+			<-start
+			errs <- InitSchema(ctx, raw, schema)
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("concurrent InitSchema: %v", err)
+		}
+	}
+
+	raw, err := pgdialect.OpenRaw(pgURL, schema)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer raw.Close()
+	if _, err := raw.ExecContext(ctx, `DROP SCHEMA IF EXISTS "`+schema+`" CASCADE`); err != nil {
+		t.Fatalf("drop schema: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- serialize PostgreSQL schema bootstrap with a database-and-schema-scoped advisory lock
- prevent concurrent `bd` processes from racing PostgreSQL catalog DDL
- add a regression test using eight independent PostgreSQL sessions

## Root cause

Every native PostgreSQL backend open runs `InitSchema`. Gas City can start several short-lived `bd` commands concurrently, and PostgreSQL `IF NOT EXISTS` / `CREATE OR REPLACE` DDL is not concurrency-safe across sessions. This produced catalog errors such as `tuple concurrently updated` and duplicate `pg_namespace` keys.

## Validation

- `go test ./internal/storage/postgres -count=1`
- live PostgreSQL `TestInitSchemaConcurrent` and `TestInitSchema`
- 12 concurrent `bd list --json` calls against a Gas City native PostgreSQL workspace
- `gc session list` no longer reports schema initialization errors