### PR TITLE
fix(postgres): serialize InitSchema DDL with a per-schema advisory lock

### DIFF
--- a/internal/storage/postgres/schema.go
+++ b/internal/storage/postgres/schema.go
@@ -5,9 +5,19 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"hash/fnv"
 	"regexp"
 	"strings"
 )
+
+// schemaAdvisoryLockKey derives a stable Postgres advisory-lock key from a
+// workspace schema name. Distinct schemas map to distinct keys so per-workspace
+// InitSchema calls serialize against themselves but never against each other.
+func schemaAdvisoryLockKey(schema string) int64 {
+	h := fnv.New64a()
+	_, _ = h.Write([]byte("bd.initschema:" + schema))
+	return int64(h.Sum64())
+}
 
 // ddl is the Postgres backend schema, embedded verbatim from
 // internal/storage/postgres/schema.sql. It is applied statement-by-statement by
@@ -475,6 +485,33 @@ func InitSchema(ctx context.Context, db *sql.DB, schema string) error {
 		return fmt.Errorf("postgres: acquire connection: %w", err)
 	}
 	defer conn.Close()
+
+	// InitSchema runs on EVERY open and re-applies idempotent DDL (CREATE OR
+	// REPLACE FUNCTION, CREATE INDEX IF NOT EXISTS, ...). Idempotent is not the
+	// same as concurrency-safe: concurrent opens rewriting the same pg catalog
+	// tuples collide with "tuple concurrently updated" (SQLSTATE XX000). When a
+	// gc controller drives this store, the dispatcher, session reconciler, and
+	// agent subprocesses open bd concurrently, so the race is routine and it
+	// surfaces as spurious bd failures (e.g. the reconciler's assigned-work probe
+	// failing and orphan-draining live sessions). Serialize DDL application per
+	// schema with a session advisory lock so only one initializer touches the
+	// catalog at a time; distinct schemas hash to distinct keys and never block
+	// each other. Held on this connection and released before it returns to the
+	// pool.
+	lockKey := schemaAdvisoryLockKey(schema)
+	if _, err := conn.ExecContext(ctx, `SELECT pg_advisory_lock($1)`, lockKey); err != nil {
+		return fmt.Errorf("postgres: acquire schema-init advisory lock: %w", err)
+	}
+	// The unlock must run even when ctx is already canceled: with a done ctx,
+	// database/sql returns before touching the driver, the connection goes back
+	// to the pool healthy, and its backend session keeps holding the advisory
+	// lock — wedging every later open of this schema. WithoutCancel guarantees
+	// the unlock is attempted; if it fails on the wire instead, the driver marks
+	// the connection bad, the backend session dies with it, and Postgres releases
+	// the lock anyway, so the error is safe to drop.
+	defer func() {
+		_, _ = conn.ExecContext(context.WithoutCancel(ctx), `SELECT pg_advisory_unlock($1)`, lockKey)
+	}()
 
 	if _, err := conn.ExecContext(ctx, `CREATE SCHEMA IF NOT EXISTS "`+schema+`"`); err != nil {
 		return fmt.Errorf("postgres: create schema %q: %w", schema, err)

--- a/internal/storage/postgres/schema_test.go
+++ b/internal/storage/postgres/schema_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"fmt"
 	"os"
+	"sync"
 	"testing"
 	"time"
 
@@ -65,4 +66,90 @@ func tableExists(ctx context.Context, t *testing.T, db *sql.DB, schema, table st
 		t.Fatalf("query information_schema.tables for %q: %v", table, err)
 	}
 	return count > 0
+}
+
+// TestSchemaAdvisoryLockKey pins the advisory-lock key derivation. The key is a
+// cross-process contract: every bd binary that opens the same workspace schema
+// must derive the same key, or their InitSchema calls stop serializing against
+// each other. The golden values fail loudly if the hash, prefix, or truncation
+// ever changes — such a change would silently break lock interop with
+// already-deployed binaries during a rolling upgrade.
+func TestSchemaAdvisoryLockKey(t *testing.T) {
+	golden := map[string]int64{
+		"beads":  -7207352757236036547,
+		"public": -3420031902527778135,
+	}
+	for schema, want := range golden {
+		if got := schemaAdvisoryLockKey(schema); got != want {
+			t.Errorf("schemaAdvisoryLockKey(%q) = %d, want %d — changing the derivation breaks locking against deployed binaries", schema, got, want)
+		}
+	}
+	if a, b := schemaAdvisoryLockKey("workspace_a"), schemaAdvisoryLockKey("workspace_b"); a == b {
+		t.Errorf("distinct schemas derived the same advisory-lock key %d; per-workspace inits must not serialize against each other", a)
+	}
+}
+
+// TestInitSchemaConcurrentOpens is the regression test for the catalog race the
+// advisory lock fixes: InitSchema runs on EVERY open and re-applies idempotent
+// DDL, and bd is a short-lived CLI, so a busy deployment runs many concurrent
+// opens. Without per-schema serialization those opens rewrite the same pg
+// catalog tuples and fail with "tuple concurrently updated" (SQLSTATE XX000).
+// Each worker gets its own *sql.DB pool — its own backend session — to mimic
+// separate bd processes, and all hammer InitSchema on the same fresh schema.
+// Gated on BEADS_PG_TEST_URL like TestInitSchema.
+func TestInitSchemaConcurrentOpens(t *testing.T) {
+	url := os.Getenv("BEADS_PG_TEST_URL")
+	if url == "" {
+		t.Skip("BEADS_PG_TEST_URL not set; skipping Postgres schema test")
+	}
+
+	schema := fmt.Sprintf("bd_schema_race_%d", time.Now().UnixNano())
+	ctx := context.Background()
+
+	const workers = 8
+	const opensPerWorker = 3
+
+	dbs := make([]*sql.DB, workers)
+	for i := range dbs {
+		raw, err := pgdialect.OpenRaw(url, schema)
+		if err != nil {
+			t.Fatalf("openraw %d: %v", i, err)
+		}
+		dbs[i] = raw
+	}
+	// Registered first so it runs last (cleanups are LIFO): the schema drop
+	// below still has open pools when it runs.
+	t.Cleanup(func() {
+		for _, db := range dbs {
+			_ = db.Close()
+		}
+	})
+	t.Cleanup(func() {
+		if _, err := dbs[0].ExecContext(ctx, `DROP SCHEMA IF EXISTS "`+schema+`" CASCADE`); err != nil {
+			t.Errorf("drop schema %q: %v", schema, err)
+		}
+	})
+
+	start := make(chan struct{})
+	errs := make(chan error, workers)
+	var wg sync.WaitGroup
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func(db *sql.DB) {
+			defer wg.Done()
+			<-start
+			for j := 0; j < opensPerWorker; j++ {
+				if err := InitSchema(ctx, db, schema); err != nil {
+					errs <- err
+					return
+				}
+			}
+		}(dbs[i])
+	}
+	close(start)
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Errorf("concurrent InitSchema: %v", err)
+	}
 }


### PR DESCRIPTION
## What

Serializes `InitSchema` DDL application with a per-schema Postgres session advisory lock (`pg_advisory_lock`), keyed by an FNV-64a hash of the workspace schema name.

- `internal/storage/postgres/schema.go`: acquire the lock on the pinned connection before applying DDL; release via `pg_advisory_unlock` under `context.WithoutCancel` so a canceled ctx can never return a lock-holding connection to the pool and wedge every later open of the schema. Distinct schemas hash to distinct keys, so per-workspace inits serialize against themselves but never against each other.
- `internal/storage/postgres/schema_test.go`: `TestSchemaAdvisoryLockKey` pins the key derivation with golden values (the key is a cross-process contract — changing the hash silently breaks lock interop with already-deployed binaries), and `TestInitSchemaConcurrentOpens` is the regression test: 8 separate `*sql.DB` pools (mimicking separate bd processes) hammering `InitSchema` on one fresh schema, gated on `BEADS_PG_TEST_URL` like the existing Postgres tests.

## Why (live incident: concurrent bd opens race pg catalog DDL -> tuple concurrently updated -> orphan-drained sessions)

`InitSchema` runs on EVERY open and re-applies idempotent DDL (`CREATE OR REPLACE FUNCTION`, `CREATE INDEX IF NOT EXISTS`, ...). Idempotent is not concurrency-safe: concurrent opens rewriting the same pg catalog tuples collide with `ERROR: tuple concurrently updated (SQLSTATE XX000)`.

Diagnosed live on a running gc fleet: the dispatcher, session reconciler, and agent subprocesses all open bd concurrently, so the race is routine — and it surfaced as the reconciler's assigned-work probe failing on exactly this error and orphan-draining healthy worker sessions mid-workflow. The failure looks like a bd/store outage, but it is a DDL race on open.

## Verification

- `go test -tags gms_pure_go ./internal/storage/postgres/` — pass (`TestSchemaAdvisoryLockKey` runs everywhere; the concurrency test additionally ran against live Postgres via `BEADS_PG_TEST_URL`).
- `go vet` and `golangci-lint run` clean on the package.
- Red-team storm (`bd list` first-op opens, 8 concurrent processes per round, same workspace schema, real Postgres):
  - **Unpatched bd: 19/80 opens failed** with `tuple concurrently updated (SQLSTATE XX000)`.
  - **Patched bd: 0/120 failures** on the pre-existing schema and **0/40** on a fresh schema.
  - Mixed fleet (patched + unpatched binaries concurrently): 4/40 failures — expected, unpatched binaries bypass the lock, so full protection lands only once all binaries in a deployment are upgraded (rolling-upgrade caveat, no worse than today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
