### PR TITLE
fix(sqlkit): run withReadTx read-only to keep WAL reader concurrency

### DIFF
--- a/internal/storage/sqlite/locking_test.go
+++ b/internal/storage/sqlite/locking_test.go
@@ -61,6 +61,56 @@ func TestConcurrentAccessNoLockError(t *testing.T) {
 	}
 }
 
+// TestReadConcurrentWithHeldWriteLock guards WAL reader/writer independence
+// across separate store handles — the cross-process analog: two bd processes on
+// one database file. Handle A holds SQLite's single write lock in an open
+// transaction (the DSN's `_txlock=immediate` takes it at BEGIN); a read through
+// handle B must still succeed, because under WAL readers never wait on the
+// writer. Before withReadTx passed sql.TxOptions{ReadOnly: true}, B's read also
+// issued BEGIN IMMEDIATE, queued on the write lock, and surfaced SQLITE_BUSY
+// after busy_timeout — so during any long write (e.g. a large import) every
+// concurrent read failed, forfeiting WAL's reader concurrency entirely.
+func TestReadConcurrentWithHeldWriteLock(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "wal-read.db")
+	stA, err := Provision(ctx, path)
+	if err != nil {
+		t.Fatalf("Provision: %v", err)
+	}
+	t.Cleanup(func() { _ = stA.Close() })
+	if err := stA.SetConfig(ctx, "issue_prefix", "test"); err != nil {
+		t.Fatalf("SetConfig(issue_prefix): %v", err)
+	}
+
+	// Second, independent handle (own pool/connection) on the same file.
+	stB, err := New(ctx, Config{DSN: dsn(path)})
+	if err != nil {
+		t.Fatalf("New (second handle): %v", err)
+	}
+	t.Cleanup(func() { _ = stB.Close() })
+
+	// Hold the write lock on A: with _txlock=immediate, BeginTx issues BEGIN
+	// IMMEDIATE. The uncommitted INSERT makes it a real in-flight write.
+	writeTx, err := stA.(*Store).DB().BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatalf("begin write tx on handle A: %v", err)
+	}
+	defer func() { _ = writeTx.Rollback() }()
+	if _, err := writeTx.ExecContext(ctx,
+		"INSERT INTO metadata (key, value) VALUES ('lock_probe', 'held')"); err != nil {
+		t.Fatalf("write inside held tx: %v", err)
+	}
+
+	// The read on B must complete while A's write transaction is still open.
+	got, err := stB.GetConfig(ctx, "issue_prefix")
+	if err != nil {
+		t.Fatalf("read during held write lock: %v", err)
+	}
+	if got != "test" {
+		t.Fatalf("read during held write lock: got %q, want %q", got, "test")
+	}
+}
+
 // withDefaults mirrors the conformance helper (Status/IssueType defaulting) so this
 // package-internal test can build a minimally-valid issue without the harness.
 func withDefaults(i *types.Issue) *types.Issue {

--- a/internal/storage/sqlkit/store.go
+++ b/internal/storage/sqlkit/store.go
@@ -69,12 +69,22 @@ func (s *Store) Close() error {
 	return s.db.Close()
 }
 
-// withReadTx runs fn in a read transaction that is always rolled back.
+// withReadTx runs fn in a read-only transaction that is always rolled back.
+//
+// ReadOnly is load-bearing on SQLite: the DSN's `_txlock=immediate` makes every
+// default BeginTx issue BEGIN IMMEDIATE (modernc.org/sqlite honors it via
+// beginMode), which takes SQLite's single write lock — so plain-BEGIN reads
+// would queue behind any in-flight writer and fail with SQLITE_BUSY after
+// busy_timeout, forfeiting WAL's reader/writer independence. TxOptions.ReadOnly
+// suppresses beginMode (plain deferred BEGIN), letting reads run concurrently
+// with a writer. On the server backends it maps to START TRANSACTION READ ONLY
+// (mysql) / BEGIN READ ONLY (pgx), which every withReadTx callback satisfies:
+// they are pure issueops reads.
 func (s *Store) withReadTx(ctx context.Context, fn func(tx *sql.Tx) error) error {
 	if s.closed.Load() {
 		return ErrStoreClosed
 	}
-	tx, err := s.db.BeginTx(ctx, nil)
+	tx, err := s.db.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
 	if err != nil {
 		return fmt.Errorf("begin read tx: %w", err)
 	}


### PR DESCRIPTION
## What

`withReadTx` now begins its transaction with `sql.TxOptions{ReadOnly: true}` instead of `nil` options, so reads no longer take SQLite's single write lock; a regression test pins reader/writer independence across two independent store handles on one database file.

## Why

SQLite concurrency audit caveat #5 (MED severity): the DSN sets `_txlock=immediate`, so a default `BeginTx` issues `BEGIN IMMEDIATE` and acquires the write lock — even in `withReadTx`, which only reads and always rolls back. Every read therefore queued behind any in-flight writer and surfaced `SQLITE_BUSY` after `busy_timeout`, forfeiting WAL's reader/writer independence. This was the amplifier that turned any long write into a full-store outage: in the audit hammer, a 26,238-issue `bd import` held the write lock for 118s, during which **100% of concurrent bd operations failed, reads included**. `TxOptions{ReadOnly: true}` suppresses the immediate begin mode (plain deferred `BEGIN` on SQLite; `START TRANSACTION READ ONLY` / `BEGIN READ ONLY` on the mysql/pgx backends — safe, since every `withReadTx` callback is a pure issueops read). Immediate mode bought nothing in `withReadTx` anyway: it always rolls back.

## Verification

TDD regression test (fails on the old code with `SQLITE_BUSY`, passes with the fix):

```
go test -tags gms_pure_go -count=1 -run TestReadConcurrentWithHeldWriteLock ./internal/storage/sqlite/   # PASS (0.07s)
go test -tags gms_pure_go -count=1 ./internal/storage/sqlite/                                            # ok (17.3s)
```

Red-team empirical re-run (real bd binaries, real OS processes, 6k-issue `bd import` holding the write lock ~28s while a second process loops `list`/`show`/`ready`):

- **Baseline binary (cc5d0563a):** reads during hold: 1 ok / 1 fail (each read stalled on the write lock, then errored)
- **Patched binary:** reads during hold: **190 ok / 0 fail** over the same ~28s window
- Write-path semantics preserved: 8-way cross-process claim race on one issue → exactly 1 winner (rc=0), 7 loud losers (rc=1, "issue already claimed")
- Post-run: `PRAGMA integrity_check` = ok, 0 foreign-key violations, row counts exact (6,005/6,005 imported issues present) in both runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)