### PR TITLE
feat(storage): add ExternalRefHistoryQuerier capability for external-ref history (#4549)

### DIFF
--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -153,6 +153,7 @@ var _ storage.GarbageCollector = (*DoltStore)(nil)
 var _ storage.Flattener = (*DoltStore)(nil)
 var _ storage.Compactor = (*DoltStore)(nil)
 var _ storage.SchemaMigrator = (*DoltStore)(nil)
+var _ storage.ExternalRefHistoryQuerier = (*DoltStore)(nil)
 
 // DoltStore implements the Storage interface using Dolt
 type DoltStore struct {

--- a/internal/storage/dolt/versioned.go
+++ b/internal/storage/dolt/versioned.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"time"
 
 	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/storage/issueops"
@@ -41,6 +42,23 @@ func (s *DoltStore) Diff(ctx context.Context, fromRef, toRef string) ([]*storage
 		return err
 	})
 	return result, err
+}
+
+// PreviousExternalRef returns the external_ref value recorded for issueID
+// as of the most recent commit at or before asOf.
+// Implements storage.ExternalRefHistoryQuerier.
+func (s *DoltStore) PreviousExternalRef(ctx context.Context, issueID string, asOf time.Time) (string, bool, error) {
+	var ref string
+	var found bool
+	err := s.withReadTx(ctx, func(tx *sql.Tx) error {
+		var err error
+		ref, found, err = issueops.PreviousExternalRefInTx(ctx, tx, issueID, asOf)
+		if err != nil {
+			return wrapQueryError("get previous external ref", err)
+		}
+		return nil
+	})
+	return ref, found, err
 }
 
 // ListBranches returns the names of all branches.

--- a/internal/storage/embeddeddolt/store.go
+++ b/internal/storage/embeddeddolt/store.go
@@ -29,6 +29,7 @@ var _ storage.GarbageCollector = (*EmbeddedDoltStore)(nil)
 var _ storage.Flattener = (*EmbeddedDoltStore)(nil)
 var _ storage.Compactor = (*EmbeddedDoltStore)(nil)
 var _ storage.SchemaMigrator = (*EmbeddedDoltStore)(nil)
+var _ storage.ExternalRefHistoryQuerier = (*EmbeddedDoltStore)(nil)
 
 // EmbeddedDoltStore implements storage.DoltStorage backed by the embedded Dolt engine.
 // Each method call opens a short-lived connection, executes within an explicit
@@ -756,6 +757,20 @@ func (s *EmbeddedDoltStore) Diff(ctx context.Context, fromRef, toRef string) ([]
 		return err
 	})
 	return result, err
+}
+
+// PreviousExternalRef returns the external_ref value recorded for issueID
+// as of the most recent commit at or before asOf.
+// Implements storage.ExternalRefHistoryQuerier.
+func (s *EmbeddedDoltStore) PreviousExternalRef(ctx context.Context, issueID string, asOf time.Time) (string, bool, error) {
+	var ref string
+	var found bool
+	err := s.withConn(ctx, false, func(tx *sql.Tx) error {
+		var err error
+		ref, found, err = issueops.PreviousExternalRefInTx(ctx, tx, issueID, asOf)
+		return err
+	})
+	return ref, found, err
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/storage/history_viewer.go
+++ b/internal/storage/history_viewer.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"context"
+	"time"
 
 	"github.com/steveyegge/beads/internal/types"
 )
@@ -11,4 +12,30 @@ type HistoryViewer interface {
 	History(ctx context.Context, issueID string) ([]*HistoryEntry, error)
 	AsOf(ctx context.Context, issueID string, ref string) (*types.Issue, error)
 	Diff(ctx context.Context, fromRef, toRef string) ([]*DiffEntry, error)
+}
+
+// ExternalRefHistoryQuerier is implemented by history-capable Dolt storage
+// backends that can resolve what a given issue's external_ref was as of a
+// point in time, by querying Dolt's dolt_history_issues system table.
+//
+// This is intentionally a separate capability from RawDBAccessor
+// (storage.go): a backend can have Dolt's history tables without exposing a
+// raw *sql.DB (EmbeddedDoltStore executes all SQL through its own
+// transaction-scoped connection helper rather than a pooled *sql.DB), and a
+// hypothetical non-Dolt SQL backend could conceivably expose a *sql.DB
+// (e.g. for diagnostics) without ever having dolt_history_issues. Gating
+// dolt_history_issues queries on this capability -- rather than on DB()
+// presence -- keeps the fast path tied to the thing it actually depends on.
+type ExternalRefHistoryQuerier interface {
+	HistoryViewer
+
+	// PreviousExternalRef returns the external_ref value recorded for
+	// issueID as of the most recent commit at or before asOf.
+	//
+	// found is false when no history entry exists for issueID at or
+	// before asOf (e.g. the issue was created after asOf); callers should
+	// treat that as "changed" since there is nothing to compare against.
+	// ref is the empty string when the historical row's external_ref
+	// column was NULL.
+	PreviousExternalRef(ctx context.Context, issueID string, asOf time.Time) (ref string, found bool, err error)
 }

--- a/internal/storage/issueops/history.go
+++ b/internal/storage/issueops/history.go
@@ -98,3 +98,30 @@ func HistoryInTx(ctx context.Context, tx *sql.Tx, issueID string) ([]*storage.Hi
 
 	return entries, rows.Err()
 }
+
+// PreviousExternalRefInTx returns the external_ref value recorded for
+// issueID as of the most recent commit at or before asOf, by querying the
+// dolt_history_issues system table. found is false if no history entry
+// exists for issueID at or before asOf.
+//
+// The subquery wrapper avoids Dolt's max1Row optimization on PK lookup, for
+// the same reason described on HistoryInTx above.
+func PreviousExternalRefInTx(ctx context.Context, tx *sql.Tx, issueID string, asOf time.Time) (string, bool, error) {
+	var previousRef sql.NullString
+	err := tx.QueryRowContext(ctx, `
+		SELECT external_ref
+		FROM (
+			SELECT id, external_ref, commit_date FROM dolt_history_issues
+		) h
+		WHERE h.id = ? AND h.commit_date <= ?
+		ORDER BY h.commit_date DESC
+		LIMIT 1
+	`, issueID, asOf.UTC()).Scan(&previousRef)
+	if err == sql.ErrNoRows {
+		return "", false, nil
+	}
+	if err != nil {
+		return "", false, fmt.Errorf("failed to get previous external_ref: %w", err)
+	}
+	return previousRef.String, true, nil
+}


### PR DESCRIPTION
## What

Adds `ExternalRefHistoryQuerier` — a storage capability interface for backends
that can resolve an issue's `external_ref` as of a point in time via Dolt's
`dolt_history_issues` system table. Implemented on
`DoltStore` and `EmbeddedDoltStore`; the consumer PR (#4734) discovers the
capability by unwrapping decorator-wrapped stores with the existing
(non-generic) `storage.UnwrapStore` helper.

This is the **primitive half** of the #4549 fix. The tracker wiring that consumes
it is in a stacked follow-up PR, per `CONTRIBUTING_PR_GUIDELINES.md`'s
primitive-before-wiring rule.

## Why

The sync fast-path needs to ask "did this issue's `external_ref` change since we
last synced?" — a question only history-capable Dolt backends can answer.
Exposing that as a *named capability*, rather than having callers type-assert a
raw `*sql.DB`, ties the fast-path to the behaviour it actually depends on instead
of to an implementation detail of how a store is built. The bug this enables
fixing is described in the follow-up PR.

## What changed

- `internal/storage/history_viewer.go` — `ExternalRefHistoryQuerier` (embeds
  `HistoryViewer`, adds `PreviousExternalRef`).
- `internal/storage/issueops/history.go` — `PreviousExternalRefInTx`, the
  `dolt_history_issues` query used by both stores' `PreviousExternalRef`
  implementations.
- `internal/storage/dolt/versioned.go`, `internal/storage/embeddeddolt/store.go`
  — implement `PreviousExternalRef` against `dolt_history_issues`, plus
  compile-time `var _ storage.ExternalRefHistoryQuerier` asserts alongside the
  existing interface checks.

## Verification

- `go build ./...` clean (cgo, `gms_pure_go` tag).
- Exercised and tested end-to-end in the stacked follow-up PR.

Root-cause analysis credited to the #4549 reporter.



---
_Consumer / wiring PR: **#4734** (stacked on this one)._
