### PR TITLE
fix(sqlite): make LIKE case-sensitive to match the other backends (bd-oyvc2.10)

### DIFF
--- a/internal/storage/conformance/audit_molecule_wisp_batch_iter.go
+++ b/internal/storage/conformance/audit_molecule_wisp_batch_iter.go
@@ -38,6 +38,7 @@ func RunAudit_molecule_wisp_batch_iter(t *testing.T, f Factory) {
 	t.Run("CreateInBatchCycle", func(t *testing.T) { testAuditCreateInBatchCycle(t, f) })
 	t.Run("ListWisps", func(t *testing.T) { testAuditListWisps(t, f) })
 	t.Run("GetNextChildID", func(t *testing.T) { testAuditGetNextChildID(t, f) })
+	t.Run("GetNextChildIDCaseSensitive", func(t *testing.T) { testAuditGetNextChildIDCaseSensitive(t, f) })
 }
 
 // auditDepTargets returns the sorted DependsOnID set for a dependency slice.
@@ -661,5 +662,23 @@ func testAuditGetNextChildID(t *testing.T, f Factory) {
 	must(t, err)
 	if wid != "test-wp.1" {
 		t.Errorf("wisp parent = %q, want test-wp.1", wid)
+	}
+}
+
+// The self-heal scan (id LIKE parent.'%') is case-sensitive on every backend
+// (Dolt/MySQL bin collation, Postgres "C", SQLite case_sensitive_like — see
+// bd-oyvc2.10), so a different-cased sibling parent's children never advance
+// this parent's counter.
+func testAuditGetNextChildIDCaseSensitive(t *testing.T, f Factory) {
+	s := f(t)
+	c := ctx()
+	must(t, s.CreateIssue(c, withDefaults(&types.Issue{ID: "test-q", Title: "lower parent"}), "a"))
+	must(t, s.CreateIssue(c, withDefaults(&types.Issue{ID: "test-Q", Title: "upper parent"}), "a"))
+	must(t, s.CreateIssue(c, withDefaults(&types.Issue{ID: "test-Q.7", Title: "upper child"}), "a"))
+
+	id, err := s.GetNextChildID(c, "test-q")
+	must(t, err)
+	if id != "test-q.1" {
+		t.Errorf("GetNextChildID(test-q) = %q, want test-q.1 (test-Q.7 must not advance test-q's counter)", id)
 	}
 }

--- a/internal/storage/conformance/audit_search-counts-stats.go
+++ b/internal/storage/conformance/audit_search-counts-stats.go
@@ -36,6 +36,8 @@ func RunAudit_search_counts_stats(t *testing.T, f Factory) {
 	t.Run("SearchIdenticalTimestampIDOrder", func(t *testing.T) { testAuditSearchIdenticalTimestampIDOrder(t, f) })
 	t.Run("SearchSortByClosedNullsLast", func(t *testing.T) { testAuditSearchSortByClosedNullsLast(t, f) })
 	t.Run("SearchTextIDBranchExternalRef", func(t *testing.T) { testAuditSearchTextIDBranchExternalRef(t, f) })
+	t.Run("SearchIDPrefixCaseSensitive", func(t *testing.T) { testAuditSearchIDPrefixCaseSensitive(t, f) })
+	t.Run("SearchParentDescendantCaseSensitive", func(t *testing.T) { testAuditSearchParentDescendantCaseSensitive(t, f) })
 	t.Run("StaleStatusOverride", func(t *testing.T) { testAuditStaleStatusOverride(t, f) })
 	t.Run("EpicsEligiblePartial", func(t *testing.T) { testAuditEpicsEligiblePartial(t, f) })
 	t.Run("GetIssuesByLabelWithWisp", func(t *testing.T) { testAuditGetIssuesByLabelWithWisp(t, f) })
@@ -404,6 +406,57 @@ func testAuditSearchTextIDBranchExternalRef(t *testing.T, f Factory) {
 	must(t, err)
 	if ids := issueIDs(got); !reflect.DeepEqual(ids, []string{"test-9"}) {
 		t.Errorf("search 'test-9' = %v, want [test-9]", ids)
+	}
+}
+
+// LIKE over raw-cased operands is case-sensitive on every backend: Dolt/MySQL use
+// the utf8mb4_0900_bin table collation, Postgres uses collation "C", and SQLite
+// sets PRAGMA case_sensitive_like (sqlite/dsn.go) — its default LIKE is
+// ASCII-case-insensitive and silently diverged (bd-oyvc2.10). IDPrefix filtering
+// (sqlbuild/filter.go `id LIKE ?`) must therefore distinguish test-AB from test-ab.
+func testAuditSearchIDPrefixCaseSensitive(t *testing.T, f Factory) {
+	s := f(t)
+	c := ctx()
+	must(t, s.CreateIssue(c, withDefaults(&types.Issue{ID: "test-AB1", Title: "Upper"}), "a"))
+	must(t, s.CreateIssue(c, withDefaults(&types.Issue{ID: "test-ab2", Title: "Lower"}), "a"))
+
+	got, err := s.SearchIssues(c, "", types.IssueFilter{IDPrefix: "test-AB"})
+	must(t, err)
+	if ids := issueIDs(got); !reflect.DeepEqual(ids, []string{"test-AB1"}) {
+		t.Errorf("IDPrefix test-AB = %v, want [test-AB1] (LIKE must be case-sensitive)", ids)
+	}
+
+	got, err = s.SearchIssues(c, "", types.IssueFilter{IDPrefix: "test-ab"})
+	must(t, err)
+	if ids := issueIDs(got); !reflect.DeepEqual(ids, []string{"test-ab2"}) {
+		t.Errorf("IDPrefix test-ab = %v, want [test-ab2] (LIKE must be case-sensitive)", ids)
+	}
+}
+
+// The ParentID descendant branch (sqlbuild/filter.go `id LIKE CONCAT(?, '.%')`)
+// is likewise case-sensitive: with two sibling parents differing only by case,
+// each with a dotted child and no parent-child dep rows, listing one parent's
+// descendants must not leak the other-cased parent's child (bd-oyvc2.10).
+func testAuditSearchParentDescendantCaseSensitive(t *testing.T, f Factory) {
+	s := f(t)
+	c := ctx()
+	must(t, s.CreateIssue(c, withDefaults(&types.Issue{ID: "test-pc", Title: "lower parent"}), "a"))
+	must(t, s.CreateIssue(c, withDefaults(&types.Issue{ID: "test-PC", Title: "upper parent"}), "a"))
+	must(t, s.CreateIssue(c, withDefaults(&types.Issue{ID: "test-pc.1", Title: "lower child"}), "a"))
+	must(t, s.CreateIssue(c, withDefaults(&types.Issue{ID: "test-PC.1", Title: "upper child"}), "a"))
+
+	parent := "test-pc"
+	got, err := s.SearchIssues(c, "", types.IssueFilter{ParentID: &parent})
+	must(t, err)
+	if ids := issueIDs(got); !reflect.DeepEqual(ids, []string{"test-pc.1"}) {
+		t.Errorf("ParentID test-pc = %v, want [test-pc.1] (different-cased sibling's child must be excluded)", ids)
+	}
+
+	upper := "test-PC"
+	got, err = s.SearchIssues(c, "", types.IssueFilter{ParentID: &upper})
+	must(t, err)
+	if ids := issueIDs(got); !reflect.DeepEqual(ids, []string{"test-PC.1"}) {
+		t.Errorf("ParentID test-PC = %v, want [test-PC.1] (different-cased sibling's child must be excluded)", ids)
 	}
 }
 

--- a/internal/storage/sqlite/dsn.go
+++ b/internal/storage/sqlite/dsn.go
@@ -13,6 +13,14 @@ import "strings"
 //     inter-process contention.
 //   - _txlock=immediate: writers take the write lock up front and fail fast rather
 //     than deadlocking mid-transaction on lock upgrade.
+//   - case_sensitive_like(1): LIKE parity with the other backends. Dolt/MySQL use
+//     the utf8mb4_0900_bin table collation and Postgres uses collation "C", so
+//     `id LIKE 'bd-A%'` is case-sensitive there; SQLite's default LIKE is
+//     ASCII-case-INsensitive, which silently diverged on raw-cased operands
+//     (--id-prefix filtering, parent-descendant `id LIKE parent || '.%'`,
+//     GetNextChildID's child scan). Intentionally case-insensitive searches are
+//     unaffected: they wrap both sides in LOWER(). _pragma params are applied by
+//     modernc on EVERY new connection, so the whole pool gets it (bd-oyvc2.10).
 //
 // _time_format=datetime is required for Dolt parity, not a nicety. Without it modernc
 // binds every time.Time through t.String() ("2026-07-09 12:34:56.123 +0000 UTC"), a
@@ -32,5 +40,5 @@ func dsn(path string) string {
 	if strings.HasPrefix(path, "file:") {
 		return path
 	}
-	return "file:" + path + "?_pragma=foreign_keys(1)&_pragma=journal_mode(WAL)&_pragma=busy_timeout(5000)&_txlock=immediate&_time_format=datetime"
+	return "file:" + path + "?_pragma=foreign_keys(1)&_pragma=journal_mode(WAL)&_pragma=busy_timeout(5000)&_pragma=case_sensitive_like(1)&_txlock=immediate&_time_format=datetime"
 }

--- a/internal/storage/sqlite/dsn_test.go
+++ b/internal/storage/sqlite/dsn_test.go
@@ -1,0 +1,32 @@
+package sqlite
+
+import (
+	"database/sql"
+	"path/filepath"
+	"testing"
+)
+
+// TestDSNCaseSensitiveLike pins the mechanism behind bd-oyvc2.10: dsn() must carry
+// _pragma=case_sensitive_like(1), and modernc.org/sqlite must apply it on EVERY new
+// connection (DSN _pragma params are per-connection), so raw-cased LIKE matches the
+// other backends' case-sensitive collations. The behavioral contract is covered by
+// the conformance corpus (Audit/*CaseSensitive); this guards the DSN wiring itself.
+func TestDSNCaseSensitiveLike(t *testing.T) {
+	db, err := sql.Open("sqlite", dsn(filepath.Join(t.TempDir(), "like.db")))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	// Multiple pooled connections, each of which must have the pragma applied.
+	db.SetMaxOpenConns(4)
+	for i := 0; i < 4; i++ {
+		var v int
+		if err := db.QueryRow("SELECT 'a' LIKE 'A'").Scan(&v); err != nil {
+			t.Fatal(err)
+		}
+		if v != 0 {
+			t.Fatalf("'a' LIKE 'A' = %d, want 0 (case-sensitive; SQLite default is ASCII-case-insensitive)", v)
+		}
+	}
+}


### PR DESCRIPTION
## What

Adds `_pragma=case_sensitive_like(1)` to the SQLite DSN so LIKE on the sqlite backend matches Dolt/MySQL (`utf8mb4_0900_bin`) and Postgres (collation "C"). Adds three Dolt-reference conformance audit cases plus a DSN unit test.

## Why

The new SQLite backend (#4601) left LIKE at SQLite's default ASCII-case-insensitive behavior (**bd-oyvc2.10**, from the post-merge review). Raw-cased emitters silently diverged: `bd list --id-prefix` with mixed case returned extra rows, parent-descendant listing (`id LIKE parent || '.%'`) leaked a same-lettered-different-case sibling parent's children, and `GetNextChildID` could count another parent's children into the counter. Intentionally case-insensitive searches wrap both sides in `LOWER()` and are unaffected — a full classification of every LIKE emitter is in the review notes; none relied on SQLite's case-insensitivity. No GLOB usage exists in the codebase.

## How verified

- modernc.org/sqlite applies `_pragma` DSN params on every new connection; the new `TestDSNCaseSensitiveLike` asserts `'a' LIKE 'A'` = 0 across a 4-connection pool.
- New conformance cases (`SearchIDPrefixCaseSensitive`, `SearchParentDescendantCaseSensitive`, `GetNextChildIDCaseSensitive`) run on all four backends via `RunAll`. They **fail on unfixed sqlite** with the exact predicted divergences (e.g. `IDPrefix test-AB = [test-AB1 test-ab2]`) and pass after the fix.
- The embedded-Dolt reference lane (`BEADS_TEST_EMBEDDED_DOLT=1`, Audit suite, 471s) passes the new cases unchanged — proving the asserted behavior is the reference behavior, not an assumption.
- Full sqlite package green; `go build -tags gms_pure_go ./...` and `go vet` clean. Postgres/MySQL lanes get their case-sensitivity from schema collation and run in the Conformance CI workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)