### PR TITLE
fix(proxied): fresh-UOW retry for Dolt serialization conflicts

### DIFF
--- a/cmd/bd/close_proxied_server.go
+++ b/cmd/bd/close_proxied_server.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -29,11 +28,20 @@ type closeProxiedInput struct {
 }
 
 type closeProxiedOutcome struct {
-	id     string
-	before *types.Issue
-	after  *types.Issue
-	closed bool
+	id                 string
+	before             *types.Issue
+	after              *types.Issue
+	closed             bool
+	autoClosedMolecule *types.Issue
 }
+
+// errProxiedNoCommit signals a completed attempt that intentionally left no
+// durable mutation, so RunWithFreshUOWRetries must not Commit.
+var errProxiedNoCommit = errors.New("proxied: no durable mutation")
+
+// errProxiedSoftFailure signals a user-visible, non-retryable close failure that
+// was already reported on stderr (not found, validation, etc.).
+var errProxiedSoftFailure = errors.New("proxied: soft failure")
 
 func runCloseProxiedServer(cmd *cobra.Command, ctx context.Context, args []string) error {
 	if len(args) == 0 {
@@ -61,17 +69,17 @@ func runCloseProxiedServer(cmd *cobra.Command, ctx context.Context, args []strin
 	if uowProvider == nil {
 		return HandleError("proxied-server UOW provider not initialized")
 	}
-	uw, err := uowProvider.NewUOW(ctx)
-	if err != nil {
-		return HandleErrorRespectJSON("open unit of work: %v", err)
-	}
-	defer uw.Close(ctx)
 
 	outcomes := make([]closeProxiedOutcome, 0, len(args))
 	closedIssues := []*types.Issue{}
 	for i, id := range args {
 		reason := reasonForCloseIndex(reasons, i)
-		outcome, ok := closeProxiedOne(ctx, uw, id, reason, in)
+		// Each close must open, mutate, and commit on a fresh UOW. Retrying only
+		// Commit on a failed UOW cannot recover Dolt serialization losses.
+		outcome, ok, closeErr := closeProxiedOneFresh(ctx, id, reason, in)
+		if closeErr != nil {
+			return closeErr
+		}
 		if !ok {
 			continue
 		}
@@ -80,36 +88,38 @@ func runCloseProxiedServer(cmd *cobra.Command, ctx context.Context, args []strin
 			closedIssues = append(closedIssues, outcome.after)
 		} else {
 			fmt.Printf("%s Closed %s: %s\n", ui.RenderPass("✓"), formatFeedbackID(outcome.after.ID, outcome.after.Title), reason)
+			if outcome.autoClosedMolecule != nil {
+				fmt.Printf("%s Auto-closed completed molecule %s\n", ui.RenderPass("✓"),
+					formatFeedbackID(outcome.autoClosedMolecule.ID, outcome.autoClosedMolecule.Title))
+			}
+		}
+		if outcome.closed {
+			if err := fireProxiedCloseHooks(ctx, outcome.before, outcome.after); err != nil {
+				fmt.Fprintf(os.Stderr, "warning: %s: %v\n", outcome.id, err)
+			}
 		}
 	}
 
 	var unblocked []*types.Issue
 	if in.suggestNext && len(args) == 1 && len(outcomes) > 0 {
-		unblocked = closeProxiedSuggestNext(ctx, uw, args[0])
+		unblocked = closeProxiedSuggestNextFresh(ctx, args[0])
 	}
 
 	var continueResult *ContinueResult
 	if in.continueOn && len(args) == 1 && len(outcomes) > 0 {
-		continueResult = closeProxiedContinue(ctx, uw, args[0], !in.noAuto)
+		var contErr error
+		continueResult, contErr = closeProxiedContinueFresh(ctx, args[0], !in.noAuto)
+		if contErr != nil {
+			return contErr
+		}
 	}
 
 	var claimedNextIssue *types.Issue
 	if in.claimNext && len(outcomes) > 0 && !in.continueOn {
-		claimedNextIssue = closeProxiedClaimNext(ctx, uw, in.jsonOut)
-	}
-
-	if len(outcomes) > 0 {
-		msg := closeProxiedCommitMessage(outcomes, claimedNextIssue, continueResult)
-		if err := uow.CommitWithRetries(ctx, uw, msg); err != nil && !isDoltNothingToCommit(err) {
-			return HandleErrorRespectJSON("commit close: %v", err)
-		}
-		for _, o := range outcomes {
-			if !o.closed {
-				continue
-			}
-			if err := fireProxiedCloseHooks(ctx, o.before, o.after); err != nil {
-				fmt.Fprintf(os.Stderr, "warning: %s: %v\n", o.id, err)
-			}
+		var claimErr error
+		claimedNextIssue, claimErr = closeProxiedClaimNextFresh(ctx, in.jsonOut)
+		if claimErr != nil {
+			return claimErr
 		}
 	}
 
@@ -162,16 +172,39 @@ func gatherCloseProxiedInput(cmd *cobra.Command) closeProxiedInput {
 	return in
 }
 
-func closeProxiedOne(ctx context.Context, uw uow.UnitOfWork, id, reason string, in closeProxiedInput) (closeProxiedOutcome, bool) {
+// closeProxiedOneFresh closes one issue/wisp with full-operation retry on a
+// fresh UOW snapshot. Hooks and user-facing success output run only after a
+// durable commit succeeds.
+func closeProxiedOneFresh(ctx context.Context, id, reason string, in closeProxiedInput) (closeProxiedOutcome, bool, error) {
+	var outcome closeProxiedOutcome
+	err := uow.RunWithFreshUOWRetries(ctx, uowProvider, fmt.Sprintf("bd: close %s", id), func(ctx context.Context, uw uow.UnitOfWork) error {
+		outcome = closeProxiedOutcome{}
+		o, applyErr := closeProxiedOne(ctx, uw, id, reason, in)
+		if applyErr != nil {
+			return applyErr
+		}
+		outcome = o
+		return nil
+	})
+	if errors.Is(err, errProxiedSoftFailure) {
+		return closeProxiedOutcome{}, false, nil
+	}
+	if err != nil && !isDoltNothingToCommit(err) {
+		return closeProxiedOutcome{}, false, HandleErrorRespectJSON("close %s: %v", id, err)
+	}
+	return outcome, true, nil
+}
+
+func closeProxiedOne(ctx context.Context, uw uow.UnitOfWork, id, reason string, in closeProxiedInput) (closeProxiedOutcome, error) {
 	current, isWisp := proxiedResolveIssueOrWisp(ctx, uw, id)
 	if current == nil {
 		fmt.Fprintf(os.Stderr, "Issue %s not found\n", id)
-		return closeProxiedOutcome{}, false
+		return closeProxiedOutcome{}, errProxiedSoftFailure
 	}
 
 	if err := validateIssueClosable(id, current, actor, in.force); err != nil {
 		fmt.Fprintf(os.Stderr, "%s\n", err)
-		return closeProxiedOutcome{}, false
+		return closeProxiedOutcome{}, errProxiedSoftFailure
 	}
 
 	if !in.force && current.IssueType == types.TypeEpic {
@@ -184,14 +217,14 @@ func closeProxiedOne(ctx context.Context, uw uow.UnitOfWork, id, reason string, 
 		}
 		if err == nil && openChildren > 0 {
 			fmt.Fprintf(os.Stderr, "cannot close epic %s: %d open child issue(s); close children first or use --force to override\n", id, openChildren)
-			return closeProxiedOutcome{}, false
+			return closeProxiedOutcome{}, errProxiedSoftFailure
 		}
 	}
 
 	if !in.force {
 		if err := checkGateSatisfaction(current); err != nil {
 			fmt.Fprintf(os.Stderr, "cannot close %s: %s\n", id, err)
-			return closeProxiedOutcome{}, false
+			return closeProxiedOutcome{}, errProxiedSoftFailure
 		}
 	}
 
@@ -206,11 +239,11 @@ func closeProxiedOne(ctx context.Context, uw uow.UnitOfWork, id, reason string, 
 		}
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error checking blockers for %s: %v\n", id, err)
-			return closeProxiedOutcome{}, false
+			return closeProxiedOutcome{}, errProxiedSoftFailure
 		}
 		if blocked && len(blockers) > 0 {
 			fmt.Fprintf(os.Stderr, "cannot close %s: blocked by open issues %v (use --force to override)\n", id, blockers)
-			return closeProxiedOutcome{}, false
+			return closeProxiedOutcome{}, errProxiedSoftFailure
 		}
 	}
 
@@ -226,7 +259,7 @@ func closeProxiedOne(ctx context.Context, uw uow.UnitOfWork, id, reason string, 
 	}
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error closing %s: %v\n", id, err)
-		return closeProxiedOutcome{}, false
+		return closeProxiedOutcome{}, errProxiedSoftFailure
 	}
 
 	oldStatus := string(current.Status)
@@ -235,24 +268,17 @@ func closeProxiedOne(ctx context.Context, uw uow.UnitOfWork, id, reason string, 
 	}
 	audit.LogFieldChange(id, "status", oldStatus, "closed", actor, reason)
 
-	autoCloseProxiedCompletedMolecule(ctx, uw, id, actor, in.session, in.jsonOut)
+	// Defer molecule auto-close user output until after durable commit so a
+	// retried attempt does not print twice for a rolled-back first attempt.
+	mol := autoCloseProxiedCompletedMolecule(ctx, uw, id, actor, in.session)
 
-	return closeProxiedOutcome{id: id, before: current, after: res.Issue, closed: res.Closed}, true
-}
-
-func closeProxiedCommitMessage(outcomes []closeProxiedOutcome, claimed *types.Issue, cont *ContinueResult) string {
-	ids := make([]string, 0, len(outcomes))
-	for _, o := range outcomes {
-		ids = append(ids, o.id)
-	}
-	msg := "bd: close " + strings.Join(ids, ", ")
-	if cont != nil && cont.AutoAdvanced && cont.NextStep != nil {
-		msg += "; advance to " + cont.NextStep.ID
-	}
-	if claimed != nil {
-		msg += "; claim " + claimed.ID
-	}
-	return msg
+	return closeProxiedOutcome{
+		id:                 id,
+		before:             current,
+		after:              res.Issue,
+		closed:             res.Closed,
+		autoClosedMolecule: mol,
+	}, nil
 }
 
 func proxiedResolveIssueOrWisp(ctx context.Context, uw uow.UnitOfWork, id string) (*types.Issue, bool) {
@@ -289,6 +315,19 @@ func fireProxiedCloseHooks(ctx context.Context, before, after *types.Issue) erro
 	return nil
 }
 
+func closeProxiedSuggestNextFresh(ctx context.Context, closedID string) []*types.Issue {
+	if uowProvider == nil {
+		return nil
+	}
+	uw, err := uowProvider.NewUOW(ctx)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: could not open unit of work for suggest-next: %v\n", err)
+		return nil
+	}
+	defer uw.Close(ctx)
+	return closeProxiedSuggestNext(ctx, uw, closedID)
+}
+
 func closeProxiedSuggestNext(ctx context.Context, uw uow.UnitOfWork, closedID string) []*types.Issue {
 	unblocked, err := uw.IssueUseCase().GetNewlyUnblockedByClose(ctx, closedID)
 	if err != nil {
@@ -296,6 +335,31 @@ func closeProxiedSuggestNext(ctx context.Context, uw uow.UnitOfWork, closedID st
 		return nil
 	}
 	return unblocked
+}
+
+func closeProxiedClaimNextFresh(ctx context.Context, jsonOut bool) (*types.Issue, error) {
+	var claimed *types.Issue
+	err := uow.RunWithFreshUOWRetriesDynamicMessage(ctx, uowProvider, func() string {
+		if claimed == nil {
+			return "bd: close claim-next"
+		}
+		return "bd: close claim-next " + claimed.ID
+	}, func(ctx context.Context, uw uow.UnitOfWork) error {
+		claimed = nil
+		next := closeProxiedClaimNext(ctx, uw, jsonOut)
+		if next == nil {
+			return errProxiedNoCommit
+		}
+		claimed = next
+		return nil
+	})
+	if errors.Is(err, errProxiedNoCommit) {
+		return nil, nil
+	}
+	if err != nil && !isDoltNothingToCommit(err) {
+		return nil, HandleErrorRespectJSON("claim-next after close: %v", err)
+	}
+	return claimed, nil
 }
 
 func closeProxiedClaimNext(ctx context.Context, uw uow.UnitOfWork, jsonOut bool) *types.Issue {
@@ -323,6 +387,34 @@ func closeProxiedClaimNext(ctx context.Context, uw uow.UnitOfWork, jsonOut bool)
 	return nextIssue
 }
 
+func closeProxiedContinueFresh(ctx context.Context, closedID string, autoClaim bool) (*ContinueResult, error) {
+	var result *ContinueResult
+	err := uow.RunWithFreshUOWRetriesDynamicMessage(ctx, uowProvider, func() string {
+		msg := "bd: close continue " + closedID
+		if result != nil && result.AutoAdvanced && result.NextStep != nil {
+			msg += "; advance to " + result.NextStep.ID
+		}
+		return msg
+	}, func(ctx context.Context, uw uow.UnitOfWork) error {
+		result = nil
+		cont := closeProxiedContinue(ctx, uw, closedID, autoClaim)
+		if cont == nil || !cont.AutoAdvanced {
+			// Read-only continue or no advance: nothing durable to commit.
+			result = cont
+			return errProxiedNoCommit
+		}
+		result = cont
+		return nil
+	})
+	if errors.Is(err, errProxiedNoCommit) {
+		return result, nil
+	}
+	if err != nil && !isDoltNothingToCommit(err) {
+		return nil, HandleErrorRespectJSON("continue after close: %v", err)
+	}
+	return result, nil
+}
+
 func closeProxiedContinue(ctx context.Context, uw uow.UnitOfWork, closedID string, autoClaim bool) *ContinueResult {
 	result, err := proxiedAdvanceToNextStep(ctx, uw, closedID, autoClaim, actor)
 	if err != nil {
@@ -332,39 +424,43 @@ func closeProxiedContinue(ctx context.Context, uw uow.UnitOfWork, closedID strin
 	return result
 }
 
-func autoCloseProxiedCompletedMolecule(ctx context.Context, uw uow.UnitOfWork, closedStepID string, actorName, session string, jsonOut bool) {
+// autoCloseProxiedCompletedMolecule closes a completed parent molecule in the
+// same UOW as the step close. Caller prints success only after durable commit.
+func autoCloseProxiedCompletedMolecule(ctx context.Context, uw uow.UnitOfWork, closedStepID string, actorName, session string) *types.Issue {
 	moleculeID := proxiedFindParentMolecule(ctx, uw, closedStepID)
 	if moleculeID == "" {
-		return
+		return nil
 	}
 
 	root, err := uw.IssueUseCase().GetIssue(ctx, moleculeID)
 	if err != nil || root == nil || root.Status == types.StatusClosed {
-		return
+		return nil
 	}
 	if labels, err := uw.LabelUseCase().GetLabels(ctx, moleculeID); err == nil {
 		root.Labels = labels
 	}
 	if !shouldAutoCloseCompletedRoot(root) {
-		return
+		return nil
 	}
 
 	progress, err := proxiedGetMoleculeProgress(ctx, uw, moleculeID)
 	if err != nil {
-		return
+		return nil
 	}
 	if progress.Completed < progress.Total {
-		return
+		return nil
 	}
 
 	params := domain.CloseIssueParams{Reason: "all steps complete", Session: session}
-	if _, err := uw.IssueUseCase().CloseIssue(ctx, moleculeID, params, actorName); err != nil {
+	res, err := uw.IssueUseCase().CloseIssue(ctx, moleculeID, params, actorName)
+	if err != nil {
 		fmt.Fprintf(os.Stderr, "Warning: could not auto-close completed molecule %s: %v\n", moleculeID, err)
-		return
+		return nil
 	}
-	if !jsonOut {
-		fmt.Printf("%s Auto-closed completed molecule %s\n", ui.RenderPass("✓"), formatFeedbackID(moleculeID, root.Title))
+	if res.Issue != nil {
+		return res.Issue
 	}
+	return root
 }
 
 func proxiedFindParentMolecule(ctx context.Context, uw uow.UnitOfWork, issueID string) string {

--- a/cmd/bd/create_proxied_server.go
+++ b/cmd/bd/create_proxied_server.go
@@ -108,60 +108,79 @@ func runCreateProxiedSingle(_ *cobra.Command, ctx context.Context, in createInpu
 		return nil
 	}
 
-	uw, cctx, err := proxiedOpenUOW(ctx)
-	if err != nil {
-		return err
-	}
-	defer uw.Close(ctx)
-
-	customTypes := resolveProxiedCustomTypes(cctx.CustomTypes)
-	if in.issueType != "" {
-		it := types.IssueType(in.issueType).Normalize()
-		if !it.IsValidWithCustom(customTypes) {
-			return HandleError("invalid type %q (allowed: built-ins plus configured custom types)", in.issueType)
-		}
-	}
-	if in.status != "" {
-		customStatuses, err := uw.ConfigUseCase().GetCustomStatuses(ctx)
-		if err != nil {
-			return HandleError("failed to get custom statuses: %v", err)
-		}
-		if !types.Status(in.status).IsValidWithCustom(types.CustomStatusNames(customStatuses)) {
-			return HandleErrorRespectJSON("invalid status %q (built-in: open, in_progress, blocked, deferred, closed, pinned, hooked; or configure custom statuses via 'bd config set status.custom')", in.status)
-		}
-	}
-	if in.explicitID != "" {
-		effectivePrefix := overlayYAMLPrefix(cctx.IssuePrefix)
-		if err := validation.ValidateIDPrefixAllowed(in.explicitID, effectivePrefix, cctx.AllowedPrefixes, in.force); err != nil {
-			return HandleError("%v", err)
-		}
+	if uowProvider == nil {
+		return HandleError("proxied-server UOW provider not initialized")
 	}
 
-	issue := buildCreateIssueFromInput(in)
-	params := domain.CreateIssueParams{
-		Issue:                   issue,
-		ExplicitID:              in.explicitID,
-		ParentID:                in.parentID,
-		Labels:                  in.labels,
-		InheritLabelsFromParent: !in.noInheritLabels && in.parentID != "",
-		Dependencies:            deps,
-		WaitsFor:                waitsFor,
-		DiscoveredFromParent:    discoveredFromParent(in.deps),
-		ForcePrefix:             in.force,
-	}
-
+	// Create must replay the full high-level operation on a fresh UOW. The
+	// durable issue ID is selected inside the attempt, so the commit message is
+	// resolved after a successful create.
 	var result domain.CreateIssueResult
-	if issue.Ephemeral {
-		result, err = uw.IssueUseCase().CreateWisp(ctx, params, in.createdBy)
-	} else {
-		result, err = uw.IssueUseCase().CreateIssue(ctx, params, in.createdBy)
-	}
-	if err != nil {
+	commitMsg := "bd: create"
+	err = uow.RunWithFreshUOWRetriesDynamicMessage(ctx, uowProvider, func() string { return commitMsg }, func(ctx context.Context, uw uow.UnitOfWork) error {
+		result = domain.CreateIssueResult{}
+		commitMsg = "bd: create"
+
+		cctx, loadErr := uw.ConfigUseCase().LoadCreateContext(ctx)
+		if loadErr != nil {
+			return fmt.Errorf("load create context: %w", loadErr)
+		}
+
+		customTypes := resolveProxiedCustomTypes(cctx.CustomTypes)
+		if in.issueType != "" {
+			it := types.IssueType(in.issueType).Normalize()
+			if !it.IsValidWithCustom(customTypes) {
+				return fmt.Errorf("invalid type %q (allowed: built-ins plus configured custom types)", in.issueType)
+			}
+		}
+		if in.status != "" {
+			customStatuses, stErr := uw.ConfigUseCase().GetCustomStatuses(ctx)
+			if stErr != nil {
+				return fmt.Errorf("failed to get custom statuses: %w", stErr)
+			}
+			if !types.Status(in.status).IsValidWithCustom(types.CustomStatusNames(customStatuses)) {
+				return fmt.Errorf("invalid status %q (built-in: open, in_progress, blocked, deferred, closed, pinned, hooked; or configure custom statuses via 'bd config set status.custom')", in.status)
+			}
+		}
+		if in.explicitID != "" {
+			effectivePrefix := overlayYAMLPrefix(cctx.IssuePrefix)
+			if vErr := validation.ValidateIDPrefixAllowed(in.explicitID, effectivePrefix, cctx.AllowedPrefixes, in.force); vErr != nil {
+				return vErr
+			}
+		}
+
+		issue := buildCreateIssueFromInput(in)
+		params := domain.CreateIssueParams{
+			Issue:                   issue,
+			ExplicitID:              in.explicitID,
+			ParentID:                in.parentID,
+			Labels:                  in.labels,
+			InheritLabelsFromParent: !in.noInheritLabels && in.parentID != "",
+			Dependencies:            deps,
+			WaitsFor:                waitsFor,
+			DiscoveredFromParent:    discoveredFromParent(in.deps),
+			ForcePrefix:             in.force,
+		}
+
+		var createErr error
+		if issue.Ephemeral {
+			result, createErr = uw.IssueUseCase().CreateWisp(ctx, params, in.createdBy)
+		} else {
+			result, createErr = uw.IssueUseCase().CreateIssue(ctx, params, in.createdBy)
+		}
+		if createErr != nil {
+			return createErr
+		}
+		if result.Issue != nil {
+			commitMsg = fmt.Sprintf("bd: create %s", result.Issue.ID)
+		}
+		return nil
+	})
+	if err != nil && !isDoltNothingToCommit(err) {
 		return HandleError("%v", err)
 	}
-
-	if err := uow.CommitWithRetries(ctx, uw, fmt.Sprintf("bd: create %s", result.Issue.ID)); err != nil && !isDoltNothingToCommit(err) {
-		return HandleError("commit: %v", err)
+	if result.Issue == nil {
+		return HandleError("create produced no issue")
 	}
 
 	switch {

--- a/cmd/bd/delete_proxied_server.go
+++ b/cmd/bd/delete_proxied_server.go
@@ -56,41 +56,47 @@ func runDeleteProxiedServer(cmd *cobra.Command, ctx context.Context, args []stri
 	if uowProvider == nil {
 		return HandleError("proxied-server UOW provider not initialized")
 	}
-	uw, err := uowProvider.NewUOW(ctx)
-	if err != nil {
-		return HandleErrorRespectJSON("open unit of work: %v", err)
-	}
-	defer uw.Close(ctx)
-
-	issueUC := uw.IssueUseCase()
 
 	if in.dryRun || !in.force {
-		return runDeleteProxiedPreview(ctx, issueUC, in)
+		uw, err := uowProvider.NewUOW(ctx)
+		if err != nil {
+			return HandleErrorRespectJSON("open unit of work: %v", err)
+		}
+		defer uw.Close(ctx)
+		return runDeleteProxiedPreview(ctx, uw.IssueUseCase(), in)
 	}
 
-	preview, err := issueUC.PreviewDelete(ctx, in.ids)
-	if err != nil {
-		return HandleErrorRespectJSON("preview: %v", err)
-	}
-	if len(preview.NotFound) > 0 {
-		return HandleErrorRespectJSON("issues not found: %s", strings.Join(preview.NotFound, ", "))
-	}
-
-	res, err := issueUC.DeleteIssues(ctx, domain.DeleteIssuesParams{
-		IDs:                  in.ids,
-		Cascade:              true,
-		UpdateTextReferences: true,
-	}, actor)
-	if err != nil {
-		return HandleErrorRespectJSON("delete: %v", err)
-	}
-	if res.DeletedCount == 0 {
-		return HandleErrorRespectJSON("issues not found: %s", strings.Join(in.ids, ", "))
-	}
-
-	commitMsg := fmt.Sprintf("bd: delete %d issue(s)", res.DeletedCount)
-	if err := uow.CommitWithRetries(ctx, uw, commitMsg); err != nil && !isDoltNothingToCommit(err) {
-		return HandleErrorRespectJSON("commit: %v", err)
+	// Mutating delete must replay preview+delete on a fresh UOW snapshot.
+	var res domain.DeleteIssuesResult
+	commitMsg := "bd: delete"
+	err = uow.RunWithFreshUOWRetriesDynamicMessage(ctx, uowProvider, func() string { return commitMsg }, func(ctx context.Context, uw uow.UnitOfWork) error {
+		res = domain.DeleteIssuesResult{}
+		commitMsg = "bd: delete"
+		issueUC := uw.IssueUseCase()
+		preview, pErr := issueUC.PreviewDelete(ctx, in.ids)
+		if pErr != nil {
+			return pErr
+		}
+		if len(preview.NotFound) > 0 {
+			return fmt.Errorf("issues not found: %s", strings.Join(preview.NotFound, ", "))
+		}
+		attempt, dErr := issueUC.DeleteIssues(ctx, domain.DeleteIssuesParams{
+			IDs:                  in.ids,
+			Cascade:              true,
+			UpdateTextReferences: true,
+		}, actor)
+		if dErr != nil {
+			return dErr
+		}
+		if attempt.DeletedCount == 0 {
+			return fmt.Errorf("issues not found: %s", strings.Join(in.ids, ", "))
+		}
+		res = attempt
+		commitMsg = fmt.Sprintf("bd: delete %d issue(s)", res.DeletedCount)
+		return nil
+	})
+	if err != nil && !isDoltNothingToCommit(err) {
+		return HandleErrorRespectJSON("%v", err)
 	}
 
 	renderDeleteProxiedResult(in, res)

--- a/cmd/bd/dep_proxied_server.go
+++ b/cmd/bd/dep_proxied_server.go
@@ -72,32 +72,31 @@ func runDepBlocksProxiedServer(cmd *cobra.Command, ctx context.Context, blockerI
 	if isChildOf(blockedID, blockerID) {
 		return HandleErrorRespectJSON("cannot add dependency: %s is already a child of %s. Children inherit dependency on parent completion via hierarchy. Adding an explicit dependency would create a deadlock", blockedID, blockerID)
 	}
-
-	uw, err := openDepProxiedUOW(ctx)
-	if err != nil {
-		return err
-	}
-	defer uw.Close(ctx)
-
-	dep := &types.Dependency{
-		IssueID:     blockedID,
-		DependsOnID: blockerID,
-		Type:        types.DepBlocks,
-	}
-	if _, err := uw.DependencyUseCase().AddDependencies(ctx, []*types.Dependency{dep}, actor, domain.BulkAddDepsOpts{}); err != nil {
-		return HandleErrorRespectJSON("%v", err)
+	if uowProvider == nil {
+		return HandleErrorRespectJSON("proxied-server UOW provider not initialized")
 	}
 
 	noCycleCheck, _ := cmd.Flags().GetBool("no-cycle-check")
-	if !noCycleCheck {
-		proxiedWarnCycles(ctx, uw)
-	}
-
-	blockerTitle := proxiedLookupTitle(ctx, uw, blockerID)
-	blockedTitle := proxiedLookupTitle(ctx, uw, blockedID)
-
-	if err := uow.CommitWithRetries(ctx, uw, fmt.Sprintf("bd: dep add %s %s", blockedID, blockerID)); err != nil && !isDoltNothingToCommit(err) {
-		return HandleErrorRespectJSON("failed to commit: %v", err)
+	var blockerTitle, blockedTitle string
+	err := uow.RunWithFreshUOWRetries(ctx, uowProvider, fmt.Sprintf("bd: dep add %s %s", blockedID, blockerID), func(ctx context.Context, uw uow.UnitOfWork) error {
+		blockerTitle, blockedTitle = "", ""
+		dep := &types.Dependency{
+			IssueID:     blockedID,
+			DependsOnID: blockerID,
+			Type:        types.DepBlocks,
+		}
+		if _, addErr := uw.DependencyUseCase().AddDependencies(ctx, []*types.Dependency{dep}, actor, domain.BulkAddDepsOpts{}); addErr != nil {
+			return addErr
+		}
+		if !noCycleCheck {
+			proxiedWarnCycles(ctx, uw)
+		}
+		blockerTitle = proxiedLookupTitle(ctx, uw, blockerID)
+		blockedTitle = proxiedLookupTitle(ctx, uw, blockedID)
+		return nil
+	})
+	if err != nil && !isDoltNothingToCommit(err) {
+		return HandleErrorRespectJSON("%v", err)
 	}
 
 	if jsonOutput {
@@ -157,28 +156,27 @@ func runDepAddProxiedServer(cmd *cobra.Command, ctx context.Context, args []stri
 	if !dt.IsValid() {
 		return HandleErrorRespectJSON("invalid dependency type %q: must be non-empty and at most 50 characters", depType)
 	}
-
-	uw, err := openDepProxiedUOW(ctx)
-	if err != nil {
-		return err
-	}
-	defer uw.Close(ctx)
-
-	dep := &types.Dependency{IssueID: fromID, DependsOnID: toID, Type: dt}
-	if _, err := uw.DependencyUseCase().AddDependencies(ctx, []*types.Dependency{dep}, actor, domain.BulkAddDepsOpts{}); err != nil {
-		return HandleErrorRespectJSON("%v", err)
+	if uowProvider == nil {
+		return HandleErrorRespectJSON("proxied-server UOW provider not initialized")
 	}
 
 	noCycleCheck, _ := cmd.Flags().GetBool("no-cycle-check")
-	if !noCycleCheck {
-		proxiedWarnCycles(ctx, uw)
-	}
-
-	fromTitle := proxiedLookupTitle(ctx, uw, fromID)
-	toTitle := proxiedLookupTitle(ctx, uw, toID)
-
-	if err := uow.CommitWithRetries(ctx, uw, fmt.Sprintf("bd: dep add %s %s", fromID, toID)); err != nil && !isDoltNothingToCommit(err) {
-		return HandleErrorRespectJSON("failed to commit: %v", err)
+	var fromTitle, toTitle string
+	err := uow.RunWithFreshUOWRetries(ctx, uowProvider, fmt.Sprintf("bd: dep add %s %s", fromID, toID), func(ctx context.Context, uw uow.UnitOfWork) error {
+		fromTitle, toTitle = "", ""
+		dep := &types.Dependency{IssueID: fromID, DependsOnID: toID, Type: dt}
+		if _, addErr := uw.DependencyUseCase().AddDependencies(ctx, []*types.Dependency{dep}, actor, domain.BulkAddDepsOpts{}); addErr != nil {
+			return addErr
+		}
+		if !noCycleCheck {
+			proxiedWarnCycles(ctx, uw)
+		}
+		fromTitle = proxiedLookupTitle(ctx, uw, fromID)
+		toTitle = proxiedLookupTitle(ctx, uw, toID)
+		return nil
+	})
+	if err != nil && !isDoltNothingToCommit(err) {
+		return HandleErrorRespectJSON("%v", err)
 	}
 
 	if jsonOutput {
@@ -225,25 +223,23 @@ func runDepAddBulkProxied(cmd *cobra.Command, ctx context.Context, file, default
 		})
 	}
 
-	uw, err := openDepProxiedUOW(ctx)
-	if err != nil {
-		return err
+	if uowProvider == nil {
+		return HandleErrorRespectJSON("proxied-server UOW provider not initialized")
 	}
-	defer uw.Close(ctx)
-
 	noCycleCheck, _ := cmd.Flags().GetBool("no-cycle-check")
-	if _, err := uw.DependencyUseCase().AddDependencies(ctx, deps, actor, domain.BulkAddDepsOpts{
-		SkipPerEdgeCycleCheck: noCycleCheck,
-	}); err != nil {
+	err = uow.RunWithFreshUOWRetries(ctx, uowProvider, fmt.Sprintf("dependency: add %d edges", len(deps)), func(ctx context.Context, uw uow.UnitOfWork) error {
+		if _, addErr := uw.DependencyUseCase().AddDependencies(ctx, deps, actor, domain.BulkAddDepsOpts{
+			SkipPerEdgeCycleCheck: noCycleCheck,
+		}); addErr != nil {
+			return addErr
+		}
+		if !noCycleCheck {
+			proxiedWarnCycles(ctx, uw)
+		}
+		return nil
+	})
+	if err != nil && !isDoltNothingToCommit(err) {
 		return HandleErrorRespectJSON("%v", err)
-	}
-
-	if !noCycleCheck {
-		proxiedWarnCycles(ctx, uw)
-	}
-
-	if err := uow.CommitWithRetries(ctx, uw, fmt.Sprintf("dependency: add %d edges", len(deps))); err != nil && !isDoltNothingToCommit(err) {
-		return HandleErrorRespectJSON("failed to commit: %v", err)
 	}
 
 	if jsonOutput {
@@ -275,22 +271,22 @@ func runDepRemoveProxiedServer(_ *cobra.Command, ctx context.Context, args []str
 			return HandleErrorRespectJSON("%v", err)
 		}
 	}
-
-	uw, err := openDepProxiedUOW(ctx)
-	if err != nil {
-		return err
+	if uowProvider == nil {
+		return HandleErrorRespectJSON("proxied-server UOW provider not initialized")
 	}
-	defer uw.Close(ctx)
 
-	if err := uw.DependencyUseCase().RemoveDependency(ctx, fromID, toID, actor); err != nil {
+	var fromTitle, toTitle string
+	err := uow.RunWithFreshUOWRetries(ctx, uowProvider, fmt.Sprintf("bd: dep remove %s %s", fromID, toID), func(ctx context.Context, uw uow.UnitOfWork) error {
+		fromTitle, toTitle = "", ""
+		if remErr := uw.DependencyUseCase().RemoveDependency(ctx, fromID, toID, actor); remErr != nil {
+			return remErr
+		}
+		fromTitle = proxiedLookupTitle(ctx, uw, fromID)
+		toTitle = proxiedLookupTitle(ctx, uw, toID)
+		return nil
+	})
+	if err != nil && !isDoltNothingToCommit(err) {
 		return HandleErrorRespectJSON("%v", err)
-	}
-
-	fromTitle := proxiedLookupTitle(ctx, uw, fromID)
-	toTitle := proxiedLookupTitle(ctx, uw, toID)
-
-	if err := uow.CommitWithRetries(ctx, uw, fmt.Sprintf("bd: dep remove %s %s", fromID, toID)); err != nil && !isDoltNothingToCommit(err) {
-		return HandleErrorRespectJSON("failed to commit: %v", err)
 	}
 
 	if jsonOutput {

--- a/cmd/bd/fresh_uow_retry_test.go
+++ b/cmd/bd/fresh_uow_retry_test.go
@@ -110,6 +110,8 @@ type proxiedRetryTestIssueUC struct {
 	claimReadyCalls int
 	closeCalls      int
 	createCalls     int
+	reopenCalls     int
+	reopened        *types.Issue
 }
 
 func (u *proxiedRetryTestIssueUC) GetIssue(context.Context, string) (*types.Issue, error) {
@@ -371,5 +373,44 @@ func TestRunDepBlocksProxiedServerRetriesWholeOperationOnFreshUOW(t *testing.T) 
 		if uw.commitCalls != 1 || uw.commitMessage != "bd: dep add blocked-1 blocker-1" {
 			t.Errorf("UOW %d commit calls/message = %d/%q", i, uw.commitCalls, uw.commitMessage)
 		}
+	}
+}
+
+func (u *proxiedRetryTestIssueUC) ReopenIssue(_ context.Context, _ string, _ domain.ReopenIssueParams, _ string) (domain.ReopenIssueResult, error) {
+	u.reopenCalls++
+	if u.reopened == nil {
+		return domain.ReopenIssueResult{}, errors.New("missing reopen result")
+	}
+	return domain.ReopenIssueResult{Issue: u.reopened, Reopened: true}, nil
+}
+
+func TestReopenProxiedOneFreshRetriesWholeOperationOnFreshUOW(t *testing.T) {
+	t.Chdir(t.TempDir())
+	oldProvider, oldActor := uowProvider, actor
+	t.Cleanup(func() { uowProvider, actor = oldProvider, oldActor })
+	actor = "reopen-retry-agent"
+
+	firstUC := &proxiedRetryTestIssueUC{
+		current:  &types.Issue{ID: "reopen-1", Title: "first", Status: types.StatusClosed, IssueType: types.TypeTask},
+		reopened: &types.Issue{ID: "reopen-1", Title: "failed", Status: types.StatusOpen, IssueType: types.TypeTask},
+	}
+	secondUC := &proxiedRetryTestIssueUC{
+		current:  &types.Issue{ID: "reopen-1", Title: "fresh", Status: types.StatusClosed, IssueType: types.TypeTask},
+		reopened: &types.Issue{ID: "reopen-1", Title: "durable", Status: types.StatusOpen, IssueType: types.TypeTask},
+	}
+	firstUOW := &proxiedRetryTestUOW{issueUC: firstUC, commitErr: &mysql.MySQLError{Number: 1213, Message: "serialization conflict"}}
+	secondUOW := &proxiedRetryTestUOW{issueUC: secondUC}
+	uowProvider = &proxiedRetryTestProvider{uows: []uow.UnitOfWork{firstUOW, secondUOW}}
+
+	got, ok, soft, err := reopenProxiedOneFresh(context.Background(), "reopen-1", "again")
+	if err != nil || soft || !ok {
+		t.Fatalf("result err=%v soft=%v ok=%v", err, soft, ok)
+	}
+	if got.after != secondUC.reopened {
+		t.Fatalf("want durable reopen, got %#v", got.after)
+	}
+	if firstUC.reopenCalls != 1 || secondUC.reopenCalls != 1 || firstUOW.commitCalls != 1 || secondUOW.commitCalls != 1 {
+		t.Fatalf("replay counts reopen first=%d second=%d commit first=%d second=%d",
+			firstUC.reopenCalls, secondUC.reopenCalls, firstUOW.commitCalls, secondUOW.commitCalls)
 	}
 }

--- a/cmd/bd/fresh_uow_retry_test.go
+++ b/cmd/bd/fresh_uow_retry_test.go
@@ -135,7 +135,6 @@ func (u *proxiedRetryTestIssueUC) ClaimReadyIssue(context.Context, types.WorkFil
 	return u.ready, nil
 }
 
-
 func (u *proxiedRetryTestIssueUC) CloseIssue(_ context.Context, _ string, _ domain.CloseIssueParams, _ string) (domain.CloseIssueResult, error) {
 	u.closeCalls++
 	if u.closed == nil {
@@ -243,7 +242,6 @@ func TestRunReadyProxiedClaimRetriesWholeOperationOnFreshUOW(t *testing.T) {
 		}
 	}
 }
-
 
 func TestCloseProxiedOneFreshRetriesWholeOperationOnFreshUOW(t *testing.T) {
 	t.Chdir(t.TempDir())

--- a/cmd/bd/fresh_uow_retry_test.go
+++ b/cmd/bd/fresh_uow_retry_test.go
@@ -1,0 +1,377 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	mysql "github.com/go-sql-driver/mysql"
+	"github.com/spf13/cobra"
+
+	"github.com/steveyegge/beads/internal/storage/domain"
+	"github.com/steveyegge/beads/internal/storage/uow"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+type proxiedRetryTestProvider struct {
+	uows  []uow.UnitOfWork
+	calls int
+}
+
+func (p *proxiedRetryTestProvider) NewUOW(context.Context) (uow.UnitOfWork, error) {
+	if p.calls >= len(p.uows) {
+		return nil, fmt.Errorf("unexpected NewUOW call %d", p.calls+1)
+	}
+	uw := p.uows[p.calls]
+	p.calls++
+	return uw, nil
+}
+
+func (*proxiedRetryTestProvider) Close(context.Context) error { return nil }
+
+type proxiedRetryTestUOW struct {
+	uow.UnitOfWork
+	issueUC       domain.IssueUseCase
+	depUC         domain.DependencyUseCase
+	configUC      domain.ConfigUseCase
+	commitErr     error
+	commitCalls   int
+	closeCalls    int
+	commitMessage string
+}
+
+func (u *proxiedRetryTestUOW) IssueUseCase() domain.IssueUseCase { return u.issueUC }
+func (u *proxiedRetryTestUOW) DependencyUseCase() domain.DependencyUseCase {
+	if u.depUC != nil {
+		return u.depUC
+	}
+	return &proxiedRetryTestDepUC{}
+}
+func (u *proxiedRetryTestUOW) ConfigUseCase() domain.ConfigUseCase {
+	if u.configUC != nil {
+		return u.configUC
+	}
+	return &proxiedRetryTestConfigUC{}
+}
+func (u *proxiedRetryTestUOW) Commit(_ context.Context, message string) error {
+	u.commitCalls++
+	u.commitMessage = message
+	return u.commitErr
+}
+func (u *proxiedRetryTestUOW) Close(context.Context) { u.closeCalls++ }
+
+type proxiedRetryTestDepUC struct {
+	domain.DependencyUseCase
+	addCalls    int
+	removeCalls int
+}
+
+func (*proxiedRetryTestDepUC) GetForIssueIDs(context.Context, []string) (map[string][]*types.Dependency, error) {
+	return map[string][]*types.Dependency{}, nil
+}
+func (*proxiedRetryTestDepUC) IsBlocked(context.Context, string) (bool, []string, error) {
+	return false, nil, nil
+}
+func (*proxiedRetryTestDepUC) DetectCycles(context.Context) ([][]*types.Issue, error) {
+	return nil, nil
+}
+func (d *proxiedRetryTestDepUC) AddDependencies(context.Context, []*types.Dependency, string, domain.BulkAddDepsOpts) (domain.BulkAddDepsResult, error) {
+	d.addCalls++
+	return domain.BulkAddDepsResult{}, nil
+}
+func (d *proxiedRetryTestDepUC) RemoveDependency(context.Context, string, string, string) error {
+	d.removeCalls++
+	return nil
+}
+
+type proxiedRetryTestConfigUC struct {
+	domain.ConfigUseCase
+	cctx domain.CreateContext
+}
+
+func (c *proxiedRetryTestConfigUC) LoadCreateContext(context.Context) (domain.CreateContext, error) {
+	return c.cctx, nil
+}
+func (*proxiedRetryTestConfigUC) GetCustomStatuses(context.Context) ([]types.CustomStatus, error) {
+	return nil, nil
+}
+
+type proxiedRetryTestIssueUC struct {
+	domain.IssueUseCase
+	current         *types.Issue
+	updated         *types.Issue
+	closed          *types.Issue
+	created         *types.Issue
+	ready           domain.ClaimReadyResult
+	getCalls        int
+	applyCalls      int
+	claimReadyCalls int
+	closeCalls      int
+	createCalls     int
+}
+
+func (u *proxiedRetryTestIssueUC) GetIssue(context.Context, string) (*types.Issue, error) {
+	u.getCalls++
+	if u.current == nil {
+		// Title lookup and optional resolve paths treat missing as not-found.
+		return nil, nil
+	}
+	return u.current, nil
+}
+
+func (*proxiedRetryTestIssueUC) GetWisp(context.Context, string) (*types.Issue, error) {
+	return nil, nil
+}
+
+func (u *proxiedRetryTestIssueUC) ApplyUpdate(context.Context, string, domain.UpdateSpec, string) (*types.Issue, error) {
+	u.applyCalls++
+	return u.updated, nil
+}
+
+func (u *proxiedRetryTestIssueUC) ClaimReadyIssue(context.Context, types.WorkFilter, string) (domain.ClaimReadyResult, error) {
+	u.claimReadyCalls++
+	return u.ready, nil
+}
+
+
+func (u *proxiedRetryTestIssueUC) CloseIssue(_ context.Context, _ string, _ domain.CloseIssueParams, _ string) (domain.CloseIssueResult, error) {
+	u.closeCalls++
+	if u.closed == nil {
+		return domain.CloseIssueResult{}, errors.New("missing test close result")
+	}
+	return domain.CloseIssueResult{Issue: u.closed, Closed: true}, nil
+}
+
+func (u *proxiedRetryTestIssueUC) CreateIssue(_ context.Context, _ domain.CreateIssueParams, _ string) (domain.CreateIssueResult, error) {
+	u.createCalls++
+	if u.created == nil {
+		return domain.CreateIssueResult{}, errors.New("missing test create result")
+	}
+	return domain.CreateIssueResult{Issue: u.created}, nil
+}
+
+func TestApplyUpdateProxiedOneRetriesWholeOperationOnFreshUOW(t *testing.T) {
+	t.Chdir(t.TempDir())
+	oldProvider, oldActor := uowProvider, actor
+	t.Cleanup(func() { uowProvider, actor = oldProvider, oldActor })
+	actor = "retry-agent"
+
+	firstUC := &proxiedRetryTestIssueUC{
+		current: &types.Issue{ID: "retry-1", Title: "first snapshot", Status: types.StatusOpen, IssueType: types.TypeTask},
+		updated: &types.Issue{ID: "retry-1", Title: "failed attempt", Status: types.StatusOpen, IssueType: types.TypeTask},
+	}
+	secondUC := &proxiedRetryTestIssueUC{
+		current: &types.Issue{ID: "retry-1", Title: "fresh snapshot", Status: types.StatusOpen, IssueType: types.TypeTask},
+		updated: &types.Issue{ID: "retry-1", Title: "durable attempt", Status: types.StatusOpen, IssueType: types.TypeTask},
+	}
+	firstUOW := &proxiedRetryTestUOW{
+		issueUC:   firstUC,
+		commitErr: &mysql.MySQLError{Number: 1213, Message: "serialization conflict"},
+	}
+	secondUOW := &proxiedRetryTestUOW{issueUC: secondUC}
+	provider := &proxiedRetryTestProvider{uows: []uow.UnitOfWork{firstUOW, secondUOW}}
+	uowProvider = provider
+
+	got, ok, claimLost, err := applyUpdateProxiedOne(context.Background(), "retry-1", &updateInput{
+		fields: map[string]any{"title": "requested title"},
+	})
+	if err != nil {
+		t.Fatalf("applyUpdateProxiedOne: %v", err)
+	}
+	if !ok || claimLost {
+		t.Fatalf("result ok=%v claimLost=%v, want true/false", ok, claimLost)
+	}
+	if got != secondUC.updated {
+		t.Fatalf("returned issue = %#v, want durable second-attempt issue %#v", got, secondUC.updated)
+	}
+	if provider.calls != 2 || firstUC.getCalls != 1 || firstUC.applyCalls != 1 || secondUC.getCalls != 1 || secondUC.applyCalls != 1 {
+		t.Fatalf("fresh replay counts: provider=%d first(get=%d apply=%d) second(get=%d apply=%d)",
+			provider.calls, firstUC.getCalls, firstUC.applyCalls, secondUC.getCalls, secondUC.applyCalls)
+	}
+	if firstUOW.closeCalls != 1 || secondUOW.closeCalls != 1 {
+		t.Fatalf("UOW closes: first=%d second=%d, want 1/1", firstUOW.closeCalls, secondUOW.closeCalls)
+	}
+	for i, uw := range []*proxiedRetryTestUOW{firstUOW, secondUOW} {
+		if uw.commitCalls != 1 || uw.commitMessage != "bd: update retry-1" {
+			t.Errorf("UOW %d commit calls/message = %d/%q", i, uw.commitCalls, uw.commitMessage)
+		}
+	}
+}
+
+func TestRunReadyProxiedClaimRetriesWholeOperationOnFreshUOW(t *testing.T) {
+	t.Chdir(t.TempDir())
+	oldProvider, oldActor, oldReadonly := uowProvider, actor, readonlyMode
+	t.Cleanup(func() { uowProvider, actor, readonlyMode = oldProvider, oldActor, oldReadonly })
+	actor = "ready-retry-agent"
+	readonlyMode = false
+
+	firstUC := &proxiedRetryTestIssueUC{ready: domain.ClaimReadyResult{
+		Issue:   &types.Issue{ID: "ready-failed", Title: "failed attempt", Status: types.StatusInProgress, IssueType: types.TypeTask},
+		Claimed: true,
+	}}
+	secondUC := &proxiedRetryTestIssueUC{ready: domain.ClaimReadyResult{
+		Issue:   &types.Issue{ID: "ready-durable", Title: "durable attempt", Status: types.StatusInProgress, IssueType: types.TypeTask},
+		Claimed: true,
+	}}
+	firstUOW := &proxiedRetryTestUOW{
+		issueUC:   firstUC,
+		commitErr: &mysql.MySQLError{Number: 1213, Message: "serialization conflict"},
+	}
+	secondUOW := &proxiedRetryTestUOW{issueUC: secondUC}
+	provider := &proxiedRetryTestProvider{uows: []uow.UnitOfWork{firstUOW, secondUOW}}
+	uowProvider = provider
+
+	out := captureStdout(t, func() error {
+		return runReadyProxiedClaim(context.Background(), readyInput{claim: true})
+	})
+	if !strings.Contains(out, "ready-durable") || strings.Contains(out, "ready-failed") {
+		t.Fatalf("output exposed failed attempt instead of durable retry: %q", out)
+	}
+	if provider.calls != 2 || firstUC.claimReadyCalls != 1 || secondUC.claimReadyCalls != 1 {
+		t.Fatalf("fresh ready replay counts: provider=%d first=%d second=%d",
+			provider.calls, firstUC.claimReadyCalls, secondUC.claimReadyCalls)
+	}
+	if firstUOW.closeCalls != 1 || secondUOW.closeCalls != 1 {
+		t.Fatalf("UOW closes: first=%d second=%d, want 1/1", firstUOW.closeCalls, secondUOW.closeCalls)
+	}
+	wantMessages := []string{"bd: ready --claim ready-failed", "bd: ready --claim ready-durable"}
+	for i, uw := range []*proxiedRetryTestUOW{firstUOW, secondUOW} {
+		if uw.commitCalls != 1 || uw.commitMessage != wantMessages[i] {
+			t.Errorf("UOW %d commit calls/message = %d/%q, want 1/%q", i, uw.commitCalls, uw.commitMessage, wantMessages[i])
+		}
+	}
+}
+
+
+func TestCloseProxiedOneFreshRetriesWholeOperationOnFreshUOW(t *testing.T) {
+	t.Chdir(t.TempDir())
+	oldProvider, oldActor := uowProvider, actor
+	t.Cleanup(func() { uowProvider, actor = oldProvider, oldActor })
+	actor = "close-retry-agent"
+
+	firstUC := &proxiedRetryTestIssueUC{
+		current: &types.Issue{ID: "close-1", Title: "first snapshot", Status: types.StatusOpen, IssueType: types.TypeTask},
+		closed:  &types.Issue{ID: "close-1", Title: "failed attempt", Status: types.StatusClosed, IssueType: types.TypeTask},
+	}
+	secondUC := &proxiedRetryTestIssueUC{
+		current: &types.Issue{ID: "close-1", Title: "fresh snapshot", Status: types.StatusOpen, IssueType: types.TypeTask},
+		closed:  &types.Issue{ID: "close-1", Title: "durable attempt", Status: types.StatusClosed, IssueType: types.TypeTask},
+	}
+	firstUOW := &proxiedRetryTestUOW{
+		issueUC:   firstUC,
+		commitErr: &mysql.MySQLError{Number: 1213, Message: "serialization conflict"},
+	}
+	secondUOW := &proxiedRetryTestUOW{issueUC: secondUC}
+	provider := &proxiedRetryTestProvider{uows: []uow.UnitOfWork{firstUOW, secondUOW}}
+	uowProvider = provider
+
+	got, ok, err := closeProxiedOneFresh(context.Background(), "close-1", "done", closeProxiedInput{force: true})
+	if err != nil {
+		t.Fatalf("closeProxiedOneFresh: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected successful close")
+	}
+	if got.after != secondUC.closed {
+		t.Fatalf("returned issue = %#v, want durable second-attempt issue %#v", got.after, secondUC.closed)
+	}
+	if provider.calls != 2 || firstUC.getCalls != 1 || firstUC.closeCalls != 1 || secondUC.getCalls != 1 || secondUC.closeCalls != 1 {
+		t.Fatalf("fresh close replay counts: provider=%d first(get=%d close=%d) second(get=%d close=%d)",
+			provider.calls, firstUC.getCalls, firstUC.closeCalls, secondUC.getCalls, secondUC.closeCalls)
+	}
+	if firstUOW.closeCalls != 1 || secondUOW.closeCalls != 1 {
+		t.Fatalf("UOW closes: first=%d second=%d, want 1/1", firstUOW.closeCalls, secondUOW.closeCalls)
+	}
+	for i, uw := range []*proxiedRetryTestUOW{firstUOW, secondUOW} {
+		if uw.commitCalls != 1 || uw.commitMessage != "bd: close close-1" {
+			t.Errorf("UOW %d commit calls/message = %d/%q", i, uw.commitCalls, uw.commitMessage)
+		}
+	}
+}
+
+func TestRunCreateProxiedSingleRetriesWholeOperationOnFreshUOW(t *testing.T) {
+	t.Chdir(t.TempDir())
+	oldProvider, oldActor := uowProvider, actor
+	t.Cleanup(func() { uowProvider, actor = oldProvider, oldActor })
+	actor = "create-retry-agent"
+
+	firstUC := &proxiedRetryTestIssueUC{
+		created: &types.Issue{ID: "create-failed", Title: "failed attempt", Status: types.StatusOpen, IssueType: types.TypeTask, Priority: 2},
+	}
+	secondUC := &proxiedRetryTestIssueUC{
+		created: &types.Issue{ID: "create-durable", Title: "durable attempt", Status: types.StatusOpen, IssueType: types.TypeTask, Priority: 2},
+	}
+	firstUOW := &proxiedRetryTestUOW{
+		issueUC:   firstUC,
+		commitErr: &mysql.MySQLError{Number: 1213, Message: "serialization conflict"},
+	}
+	secondUOW := &proxiedRetryTestUOW{issueUC: secondUC}
+	provider := &proxiedRetryTestProvider{uows: []uow.UnitOfWork{firstUOW, secondUOW}}
+	uowProvider = provider
+
+	out := captureStdout(t, func() error {
+		return runCreateProxiedSingle(nil, context.Background(), createInput{
+			title:     "new issue",
+			issueType: "task",
+			priority:  2,
+			createdBy: actor,
+		})
+	})
+	if !strings.Contains(out, "create-durable") || strings.Contains(out, "create-failed") {
+		t.Fatalf("output exposed failed attempt instead of durable retry: %q", out)
+	}
+	if provider.calls != 2 || firstUC.createCalls != 1 || secondUC.createCalls != 1 {
+		t.Fatalf("fresh create replay counts: provider=%d first=%d second=%d",
+			provider.calls, firstUC.createCalls, secondUC.createCalls)
+	}
+	wantMessages := []string{"bd: create create-failed", "bd: create create-durable"}
+	for i, uw := range []*proxiedRetryTestUOW{firstUOW, secondUOW} {
+		if uw.commitCalls != 1 || uw.commitMessage != wantMessages[i] {
+			t.Errorf("UOW %d commit calls/message = %d/%q, want 1/%q", i, uw.commitCalls, uw.commitMessage, wantMessages[i])
+		}
+	}
+}
+
+func TestRunDepBlocksProxiedServerRetriesWholeOperationOnFreshUOW(t *testing.T) {
+	t.Chdir(t.TempDir())
+	oldProvider, oldActor, oldJSON := uowProvider, actor, jsonOutput
+	t.Cleanup(func() { uowProvider, actor, jsonOutput = oldProvider, oldActor, oldJSON })
+	actor = "dep-retry-agent"
+	jsonOutput = false
+
+	firstDep := &proxiedRetryTestDepUC{}
+	secondDep := &proxiedRetryTestDepUC{}
+	firstUOW := &proxiedRetryTestUOW{
+		issueUC:   &proxiedRetryTestIssueUC{},
+		depUC:     firstDep,
+		commitErr: &mysql.MySQLError{Number: 1213, Message: "serialization conflict"},
+	}
+	secondUOW := &proxiedRetryTestUOW{
+		issueUC: &proxiedRetryTestIssueUC{},
+		depUC:   secondDep,
+	}
+	provider := &proxiedRetryTestProvider{uows: []uow.UnitOfWork{firstUOW, secondUOW}}
+	uowProvider = provider
+
+	// cobra command only needed for --no-cycle-check flag; use a minimal flag set.
+	cmd := &cobra.Command{}
+	cmd.Flags().Bool("no-cycle-check", true, "")
+
+	out := captureStdout(t, func() error {
+		return runDepBlocksProxiedServer(cmd, context.Background(), "blocker-1", "blocked-1")
+	})
+	if !strings.Contains(out, "blocker-1") || !strings.Contains(out, "blocked-1") {
+		t.Fatalf("unexpected dep output: %q", out)
+	}
+	if provider.calls != 2 || firstDep.addCalls != 1 || secondDep.addCalls != 1 {
+		t.Fatalf("fresh dep replay counts: provider=%d first=%d second=%d",
+			provider.calls, firstDep.addCalls, secondDep.addCalls)
+	}
+	for i, uw := range []*proxiedRetryTestUOW{firstUOW, secondUOW} {
+		if uw.commitCalls != 1 || uw.commitMessage != "bd: dep add blocked-1 blocker-1" {
+			t.Errorf("UOW %d commit calls/message = %d/%q", i, uw.commitCalls, uw.commitMessage)
+		}
+	}
+}

--- a/cmd/bd/ready_proxied_server.go
+++ b/cmd/bd/ready_proxied_server.go
@@ -24,6 +24,12 @@ func runReadyProxiedServer(cmd *cobra.Command, ctx context.Context) error {
 	if uowProvider == nil {
 		return HandleError("proxied-server UOW provider not initialized")
 	}
+	// Preserve the existing option precedence while giving the mutating claim
+	// path ownership of the provider, so it can reopen a fresh UOW after a Dolt
+	// serialization conflict. The remaining paths are read-only.
+	if in.claim && !in.gated && in.molID == "" && !in.explain {
+		return runReadyProxiedClaim(ctx, in)
+	}
 	uw, err := uowProvider.NewUOW(ctx)
 	if err != nil {
 		return HandleErrorRespectJSON("open unit of work: %v", err)
@@ -37,8 +43,6 @@ func runReadyProxiedServer(cmd *cobra.Command, ctx context.Context) error {
 		return runReadyProxiedMolecule(ctx, uw, in)
 	case in.explain:
 		return runReadyProxiedExplain(ctx, uw, in)
-	case in.claim:
-		return runReadyProxiedClaim(ctx, uw, in)
 	default:
 		return runReadyProxiedList(ctx, uw, in)
 	}
@@ -158,12 +162,34 @@ func runReadyProxiedList(ctx context.Context, uw uow.UnitOfWork, in readyInput) 
 	return nil
 }
 
-func runReadyProxiedClaim(ctx context.Context, uw uow.UnitOfWork, in readyInput) error {
+func runReadyProxiedClaim(ctx context.Context, in readyInput) error {
 	CheckReadonly("ready --claim")
 
-	res, err := uw.IssueUseCase().ClaimReadyIssue(ctx, in.filter, actor)
-	if err != nil {
-		return HandleErrorRespectJSON("%v", err)
+	var (
+		res         domain.ClaimReadyResult
+		jsonPayload []*types.IssueWithCounts
+		commitMsg   = "bd: ready --claim"
+	)
+	err := uow.RunWithFreshUOWRetriesDynamicMessage(ctx, uowProvider, func() string { return commitMsg }, func(ctx context.Context, uw uow.UnitOfWork) error {
+		res = domain.ClaimReadyResult{}
+		jsonPayload = nil
+		commitMsg = "bd: ready --claim"
+
+		attempt, claimErr := uw.IssueUseCase().ClaimReadyIssue(ctx, in.filter, actor)
+		if claimErr != nil {
+			return claimErr
+		}
+		res = attempt
+		if res.Claimed {
+			commitMsg = fmt.Sprintf("bd: ready --claim %s", res.Issue.ID)
+		}
+		if in.jsonOut && res.Claimed {
+			jsonPayload = buildReadyIssueOutputProxied(ctx, uw, []*types.Issue{res.Issue})
+		}
+		return nil
+	})
+	if err != nil && !isDoltNothingToCommit(err) {
+		return HandleErrorRespectJSON("failed to claim ready work: %v", err)
 	}
 	if !res.Claimed {
 		if in.jsonOut {
@@ -174,14 +200,6 @@ func runReadyProxiedClaim(ctx context.Context, uw uow.UnitOfWork, in readyInput)
 		return nil
 	}
 
-	var jsonPayload []*types.IssueWithCounts
-	if in.jsonOut {
-		jsonPayload = buildReadyIssueOutputProxied(ctx, uw, []*types.Issue{res.Issue})
-	}
-
-	if err := uow.CommitWithRetries(ctx, uw, fmt.Sprintf("bd: ready --claim %s", res.Issue.ID)); err != nil && !isDoltNothingToCommit(err) {
-		return HandleErrorRespectJSON("failed to commit: %v", err)
-	}
 	SetLastTouchedID(res.Issue.ID)
 
 	if in.jsonOut {

--- a/cmd/bd/reopen_proxied_server.go
+++ b/cmd/bd/reopen_proxied_server.go
@@ -2,9 +2,9 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
-	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -33,23 +33,22 @@ func runReopenProxiedServer(cmd *cobra.Command, ctx context.Context, args []stri
 	if uowProvider == nil {
 		return HandleError("proxied-server UOW provider not initialized")
 	}
-	uw, err := uowProvider.NewUOW(ctx)
-	if err != nil {
-		return HandleErrorRespectJSON("open unit of work: %v", err)
-	}
-	defer uw.Close(ctx)
 
 	outcomes := make([]reopenProxiedOutcome, 0, len(args))
 	reopenedIssues := []*types.Issue{}
 	hasError := false
 
 	for _, id := range args {
-		outcome, ok := reopenProxiedOne(ctx, uw, id, reason)
-		if !ok {
+		// Per-ID fresh UOW: commit-only retries cannot recover a lost Dolt snapshot.
+		outcome, ok, soft, err := reopenProxiedOneFresh(ctx, id, reason)
+		if err != nil {
+			return err
+		}
+		if soft {
 			hasError = true
 			continue
 		}
-		if !outcome.reopened {
+		if !ok || !outcome.reopened {
 			continue
 		}
 		outcomes = append(outcomes, outcome)
@@ -62,17 +61,8 @@ func runReopenProxiedServer(cmd *cobra.Command, ctx context.Context, args []stri
 			}
 			fmt.Printf("%s Reopened %s%s\n", ui.RenderAccent("↻"), outcome.id, suffix)
 		}
-	}
-
-	if len(outcomes) > 0 {
-		msg := reopenProxiedCommitMessage(outcomes)
-		if err := uow.CommitWithRetries(ctx, uw, msg); err != nil && !isDoltNothingToCommit(err) {
-			return HandleErrorRespectJSON("commit reopen: %v", err)
-		}
-		for _, o := range outcomes {
-			if err := fireProxiedReopenHooks(ctx, o.after); err != nil {
-				fmt.Fprintf(os.Stderr, "warning: %s: %v\n", o.id, err)
-			}
+		if err := fireProxiedReopenHooks(ctx, outcome.after); err != nil {
+			fmt.Fprintf(os.Stderr, "warning: %s: %v\n", outcome.id, err)
 		}
 	}
 
@@ -85,15 +75,50 @@ func runReopenProxiedServer(cmd *cobra.Command, ctx context.Context, args []stri
 	return nil
 }
 
-func reopenProxiedOne(ctx context.Context, uw uow.UnitOfWork, id, reason string) (reopenProxiedOutcome, bool) {
+func reopenProxiedOneFresh(ctx context.Context, id, reason string) (reopenProxiedOutcome, bool, bool, error) {
+	var outcome reopenProxiedOutcome
+	err := uow.RunWithFreshUOWRetries(ctx, uowProvider, fmt.Sprintf("bd: reopen %s", id), func(ctx context.Context, uw uow.UnitOfWork) error {
+		outcome = reopenProxiedOutcome{}
+		o, ok, softFail := reopenProxiedOne(ctx, uw, id, reason)
+		if softFail {
+			return errProxiedSoftFailure
+		}
+		if !ok {
+			// already open: durable no-op, skip commit
+			outcome = o
+			return errProxiedNoCommit
+		}
+		if !o.reopened {
+			outcome = o
+			return errProxiedNoCommit
+		}
+		outcome = o
+		return nil
+	})
+	if errors.Is(err, errProxiedSoftFailure) {
+		return reopenProxiedOutcome{}, false, true, nil
+	}
+	if errors.Is(err, errProxiedNoCommit) {
+		return outcome, true, false, nil
+	}
+	if err != nil && !isDoltNothingToCommit(err) {
+		return reopenProxiedOutcome{}, false, false, HandleErrorRespectJSON("reopen %s: %v", id, err)
+	}
+	return outcome, true, false, nil
+}
+
+// reopenProxiedOne returns (outcome, reopenedOK, softFailure).
+// softFailure means not found / domain error already printed.
+// reopenedOK false with softFailure false means already open (not an error).
+func reopenProxiedOne(ctx context.Context, uw uow.UnitOfWork, id, reason string) (reopenProxiedOutcome, bool, bool) {
 	current, isWisp := proxiedResolveIssueOrWisp(ctx, uw, id)
 	if current == nil {
 		fmt.Fprintf(os.Stderr, "Issue %s not found\n", id)
-		return reopenProxiedOutcome{}, false
+		return reopenProxiedOutcome{}, false, true
 	}
 	if current.Status != types.StatusClosed {
 		fmt.Fprintf(os.Stderr, "%s is already %s\n", id, current.Status)
-		return reopenProxiedOutcome{id: id, before: current, after: current, reopened: false}, true
+		return reopenProxiedOutcome{id: id, before: current, after: current, reopened: false}, false, false
 	}
 
 	params := domain.ReopenIssueParams{Reason: reason}
@@ -108,7 +133,7 @@ func reopenProxiedOne(ctx context.Context, uw uow.UnitOfWork, id, reason string)
 	}
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error reopening %s: %v\n", id, err)
-		return reopenProxiedOutcome{}, false
+		return reopenProxiedOutcome{}, false, true
 	}
 
 	oldStatus := string(current.Status)
@@ -116,15 +141,7 @@ func reopenProxiedOne(ctx context.Context, uw uow.UnitOfWork, id, reason string)
 		oldStatus = "closed"
 	}
 	audit.LogFieldChange(id, "status", oldStatus, string(types.StatusOpen), actor, reason)
-	return reopenProxiedOutcome{id: id, before: current, after: res.Issue, reopened: res.Reopened}, true
-}
-
-func reopenProxiedCommitMessage(outcomes []reopenProxiedOutcome) string {
-	ids := make([]string, 0, len(outcomes))
-	for _, o := range outcomes {
-		ids = append(ids, o.id)
-	}
-	return "bd: reopen " + strings.Join(ids, ", ")
+	return reopenProxiedOutcome{id: id, before: current, after: res.Issue, reopened: res.Reopened}, true, false
 }
 
 func fireProxiedReopenHooks(ctx context.Context, after *types.Issue) error {

--- a/cmd/bd/update_proxied_server.go
+++ b/cmd/bd/update_proxied_server.go
@@ -35,11 +35,20 @@ func runUpdateProxiedServer(cmd *cobra.Command, ctx context.Context, args []stri
 	jsonOut, _ := cmd.Flags().GetBool("json")
 	var updated []*types.Issue
 	var anyUpdated bool
+	// claimFailed records a requested-but-lost --claim. In a mixed batch (one
+	// claim won, another lost to a different owner) anyUpdated is set by the
+	// winner, so the command would otherwise exit 0 and hide the lost claim from
+	// exit-code automation. Track it separately and exit non-zero, mirroring the
+	// non-proxied path in update.go (beads audit finding #10).
+	claimFailed := false
 
 	for _, id := range args {
-		issue, ok, err := applyUpdateProxiedOne(ctx, id, in)
+		issue, ok, claimLost, err := applyUpdateProxiedOne(ctx, id, in)
 		if err != nil {
 			return err
+		}
+		if claimLost {
+			claimFailed = true
 		}
 		if !ok {
 			continue
@@ -55,66 +64,96 @@ func runUpdateProxiedServer(cmd *cobra.Command, ctx context.Context, args []stri
 	if jsonOut && len(updated) > 0 {
 		_ = outputJSON(updated)
 	}
-	if !anyUpdated {
+	if !anyUpdated || claimFailed {
 		return SilentExit()
 	}
 	return nil
 }
 
-func applyUpdateProxiedOne(ctx context.Context, id string, in *updateInput) (*types.Issue, bool, error) {
+// applyUpdateProxiedOne applies one ID's update on the proxied path. The third
+// return (claimLost) reports a requested --claim that lost to a different owner
+// (already-claimed / not-claimable), so the caller can flip the batch exit code
+// even when another ID succeeded — matching the non-proxied path.
+func applyUpdateProxiedOne(ctx context.Context, id string, in *updateInput) (*types.Issue, bool, bool, error) {
 	if uowProvider == nil {
-		return nil, false, HandleError("proxied-server UOW provider not initialized")
+		return nil, false, false, HandleError("proxied-server UOW provider not initialized")
 	}
-	uw, err := uowProvider.NewUOW(ctx)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error opening unit of work for %s: %v\n", id, err)
-		return nil, false, nil
-	}
-	defer uw.Close(ctx)
 
-	issueUC := uw.IssueUseCase()
-	current, err := issueUC.GetIssue(ctx, id)
-	if err != nil || current == nil {
-		wispCurrent, wispErr := issueUC.GetWisp(ctx, id)
-		if wispErr == nil && wispCurrent != nil {
-			current = wispCurrent
-		} else if err != nil {
-			fmt.Fprintf(os.Stderr, "Error resolving %s: %v\n", id, err)
-			return nil, false, nil
-		} else {
-			fmt.Fprintf(os.Stderr, "Issue %s not found\n", id)
-			return nil, false, nil
+	// The whole read/derive/mutate sequence must replay on a fresh snapshot.
+	// Retrying Commit on the same UOW cannot recover a Dolt serialization
+	// failure because that transaction has already lost. Keep attempt-local
+	// values inside this callback; hooks and output run only after one attempt is
+	// durably committed.
+	var current, updated *types.Issue
+	stage := "open"
+	err := uow.RunWithFreshUOWRetries(ctx, uowProvider, fmt.Sprintf("bd: update %s", id), func(ctx context.Context, uw uow.UnitOfWork) error {
+		current = nil
+		updated = nil
+		issueUC := uw.IssueUseCase()
+
+		stage = "resolve"
+		resolved, getErr := issueUC.GetIssue(ctx, id)
+		if getErr != nil || resolved == nil {
+			wispCurrent, wispErr := issueUC.GetWisp(ctx, id)
+			if wispErr == nil && wispCurrent != nil {
+				resolved = wispCurrent
+			} else if getErr != nil {
+				return getErr
+			} else {
+				stage = "not_found"
+				return fmt.Errorf("issue %s not found", id)
+			}
 		}
-	}
-	if err := validateIssueUpdatable(id, current); err != nil {
-		fmt.Fprintf(os.Stderr, "%s\n", err)
-		return nil, false, nil
-	}
 
-	spec, err := buildUpdateSpecForIssue(current, in)
-	if err != nil {
-		return nil, false, HandleErrorRespectJSON("%v", err)
-	}
+		stage = "validate"
+		if validateErr := validateIssueUpdatable(id, resolved); validateErr != nil {
+			return validateErr
+		}
 
-	updated, err := issueUC.ApplyUpdate(ctx, id, spec, actor)
-	if err != nil {
+		stage = "build"
+		spec, buildErr := buildUpdateSpecForIssue(resolved, in)
+		if buildErr != nil {
+			return buildErr
+		}
+
+		stage = "apply"
+		attemptUpdated, applyErr := issueUC.ApplyUpdate(ctx, id, spec, actor)
+		if applyErr != nil {
+			return applyErr
+		}
+		current = resolved
+		updated = attemptUpdated
+		stage = "commit"
+		return nil
+	})
+	if err != nil && !isDoltNothingToCommit(err) {
 		if errors.Is(err, storage.ErrAlreadyClaimed) || errors.Is(err, storage.ErrNotClaimable) {
 			fmt.Fprintf(os.Stderr, "Error claiming %s: %v\n", id, err)
-		} else {
+			// A requested --claim that lost to another owner must flip the exit
+			// code even if another ID in the same batch was updated.
+			return nil, false, in.claim, nil
+		}
+		switch stage {
+		case "resolve":
+			fmt.Fprintf(os.Stderr, "Error resolving %s: %v\n", id, err)
+		case "not_found":
+			fmt.Fprintf(os.Stderr, "Issue %s not found\n", id)
+		case "validate":
+			fmt.Fprintf(os.Stderr, "%s\n", err)
+		case "build":
+			return nil, false, false, HandleErrorRespectJSON("%v", err)
+		case "commit":
+			fmt.Fprintf(os.Stderr, "Error committing %s: %v\n", id, err)
+		default:
 			fmt.Fprintf(os.Stderr, "Error updating %s: %v\n", id, err)
 		}
-		return nil, false, nil
-	}
-
-	if err := uow.CommitWithRetries(ctx, uw, fmt.Sprintf("bd: update %s", id)); err != nil && !isDoltNothingToCommit(err) {
-		fmt.Fprintf(os.Stderr, "Error committing %s: %v\n", id, err)
-		return nil, false, nil
+		return nil, false, false, nil
 	}
 
 	if err := fireProxiedUpdateHooks(ctx, current, updated); err != nil {
 		fmt.Fprintf(os.Stderr, "warning: %s: %v\n", id, err)
 	}
-	return updated, true, nil
+	return updated, true, false, nil
 }
 
 func fireProxiedUpdateHooks(ctx context.Context, before, after *types.Issue) error {

--- a/docs/performance/ENGOS_FORK_BD_DISTRIBUTION.md
+++ b/docs/performance/ENGOS_FORK_BD_DISTRIBUTION.md
@@ -1,0 +1,86 @@
+# Safe fork `bd` distribution for EngOS (no dotfiles)
+
+## Goals
+- Run a **private-fork** `bd` that includes UOW fresh-retry (PR #4) while EngOS remains unchanged.
+- Stay able to **upgrade to stock** `gastownhall/beads` / module `github.com/steveyegge/beads` when fixes merge upstream.
+- **Never** modify EngOS or user dotfiles from this program.
+
+## Recommended model: PATH-shadow binary (not module replace)
+
+EngOS and agents typically invoke `bd` from `$PATH`. Prefer installing a **versioned binary** under a private prefix, then prepend that prefix to PATH **only in the shells/sessions that need the fork**.
+
+### Build / install (operator machine)
+
+```bash
+# Pin the fork branch or tag you validated (example: PR #4 head after CI green)
+FORK_REF=AI/perf-remote-server-uow-fresh-retry-main
+PREFIX="$HOME/.local/beads-fork"
+
+git clone --depth 1 --branch "$FORK_REF" https://github.com/medhatgalal/beads.git /tmp/beads-fork-src
+cd /tmp/beads-fork-src
+
+# Prefer the same mode EngOS uses today. Server-mode-only example:
+CGO_ENABLED=0 GOBIN="$PREFIX/bin" go install ./cmd/bd
+
+# Or embedded-capable (needs CGO + gms_pure_go):
+# CGO_ENABLED=1 GOFLAGS=-tags=gms_pure_go GOBIN="$PREFIX/bin" go install ./cmd/bd
+
+"$PREFIX/bin/bd" version
+# Record: git rev-parse HEAD, go version, sha256 of binary
+shasum -a 256 "$PREFIX/bin/bd" | tee "$PREFIX/bd.sha256"
+echo "$FORK_REF $(git rev-parse HEAD)" | tee "$PREFIX/SOURCE.txt"
+```
+
+### Activate without touching EngOS or tracked dotfiles
+
+**Session-only (safest):**
+```bash
+export PATH="$HOME/.local/beads-fork/bin:$PATH"
+hash -r
+which bd   # must show ~/.local/beads-fork/bin/bd
+bd version
+```
+
+**Optional per-project env file** (not EngOS, not home global):
+- e.g. `direnv` / project `.envrc` that only exports `PATH=...` for that repo.
+- Do **not** commit PATH overrides into EngOS.
+
+### Deactivate / upgrade to stock
+
+```bash
+# Remove shadow
+export PATH=$(echo "$PATH" | tr ':' '\n' | grep -v 'beads-fork' | paste -sd: -)
+hash -r
+# Stock install per upstream docs/INSTALLING.md:
+CGO_ENABLED=0 go install github.com/steveyegge/beads/cmd/bd@latest
+# or brew / release tarball
+```
+
+When upstream merges the UOW fix: delete `$HOME/.local/beads-fork`, reinstall stock `@latest` or pinned release tag.
+
+## Models to avoid
+
+| Model | Why avoid |
+| --- | --- |
+| `replace` in EngOS `go.mod` | Couples EngOS to fork; hard upgrades; charter/boundary noise |
+| Rewriting `~/.*rc` from agents | Dotfile blast radius; forbidden by program |
+| `GOPROXY` / module path hacks to impersonate steveyegge/beads | Breaks verification and future stock upgrades |
+| Overwriting Homebrew cellar in place | Opaque upgrades; fights package managers |
+
+## Compatibility notes
+
+- Module path remains `github.com/steveyegge/beads` even when cloning `gastownhall`/`medhatgalal` remotes — use `go install ./cmd/bd` from a checkout, or `go install github.com/medhatgalal/beads/cmd/bd@branch` only if module path redirects allow it; **checkout + `./cmd/bd` is reliable**.
+- Verify proxy/server mode: fork fixes target **proxied-server** paths; confirm EngOS uses the same mode (`bd` against Dolt server vs embedded).
+- Do not point EngOS at production Dolt from lab binaries.
+
+## Packaging checklist before EngOS trial
+
+- [ ] PR #4 hosted **CI Gate / Required** green
+- [ ] `bd version` + binary sha256 recorded
+- [ ] Smoke: create/update/close/ready/claim against **synthetic** Dolt only
+- [ ] Rollback path tested (PATH remove + stock reinstall)
+- [ ] EngOS tree `git status` clean (no accidental edits)
+
+## Relation to integrated cell (PR #5)
+
+PR #5 is a **lab harness**, not a drop-in EngOS dependency. EngOS should keep calling `bd` CLI/API. Cell packages stay under `scripts/bench-remote-server/` until a separate product decision places a gateway outside core Beads (charter).

--- a/docs/performance/FORK_UOW_FRESH_RETRY.md
+++ b/docs/performance/FORK_UOW_FRESH_RETRY.md
@@ -1,0 +1,25 @@
+# Proxied UOW fresh-retry (fork correctness slice)
+
+See operator PR https://github.com/medhatgalal/beads/pull/4 for full maintainer notes.
+
+## Problem
+`CommitWithRetries` re-ran only `DOLT_COMMIT` after MySQL 1213/1205, which cannot recover a lost Dolt transaction snapshot.
+
+## Fix
+`uow.RunWithFreshUOWRetries` replays the full high-level operation on a new UOW for proxied update/ready-claim/close/create/dep/reopen/delete.
+
+## Install this fork binary (PATH shadow)
+
+```bash
+PREFIX="$HOME/.local/beads-fork"
+git clone --depth 1 --branch AI/perf-remote-server-uow-fresh-retry-main \
+  https://github.com/medhatgalal/beads.git /tmp/beads-uow-src
+cd /tmp/beads-uow-src
+CGO_ENABLED=0 GOBIN="$PREFIX/bin" go install ./cmd/bd
+export PATH="$PREFIX/bin:$PATH"
+bd version
+```
+
+Rollback: remove the prefix from PATH and reinstall stock `github.com/steveyegge/beads/cmd/bd@latest`.
+
+Do not modify EngOS or home dotfiles for activation.

--- a/internal/storage/uow/dolt_sql_provider.go
+++ b/internal/storage/uow/dolt_sql_provider.go
@@ -52,7 +52,11 @@ func (p *doltSQLProvider) BeginTx(ctx context.Context) (Tx, error) {
 
 	_, err = conn.ExecContext(ctx, "START TRANSACTION;")
 	if err != nil {
-		_ = conn.Close()
+		// START TRANSACTION can commit pending session work before beginning the
+		// new transaction. Its failure therefore leaves the session state
+		// uncertain; discard the physical connection rather than leaking the pinned
+		// handle or returning it dirty to the pool.
+		discardSQLConn(conn)
 		return nil, fmt.Errorf("uow: failed to start transaction: %w", err)
 	}
 

--- a/internal/storage/uow/dolt_sql_provider_lifecycle_test.go
+++ b/internal/storage/uow/dolt_sql_provider_lifecycle_test.go
@@ -1,0 +1,57 @@
+package uow
+
+import (
+	"context"
+	"errors"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	mysql "github.com/go-sql-driver/mysql"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDoltSQLProviderBeginTxDiscardsConnectionOnStartFailure(t *testing.T) {
+	database, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	database.SetMaxOpenConns(1)
+	database.SetMaxIdleConns(1)
+	t.Cleanup(func() { require.NoError(t, database.Close()) })
+
+	startErr := &mysql.MySQLError{Number: 1213, Message: "start transaction conflict"}
+	mock.ExpectExec(regexp.QuoteMeta("START TRANSACTION;")).WillReturnError(startErr)
+
+	provider := &doltSQLProvider{defaultBranch: defaultBranch, db: database}
+	tx, err := provider.BeginTx(context.Background())
+	require.Nil(t, tx)
+	var mysqlErr *mysql.MySQLError
+	require.ErrorAs(t, err, &mysqlErr)
+	require.Equal(t, uint16(1213), mysqlErr.Number)
+	require.Eventually(t, func() bool {
+		stats := database.Stats()
+		return stats.InUse == 0 && stats.OpenConnections == 0
+	}, time.Second, 10*time.Millisecond, "failed START TRANSACTION leaked or pooled its pinned connection")
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestDoltServerTxDiscardsConnectionWhenRollbackFails(t *testing.T) {
+	database, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	database.SetMaxOpenConns(1)
+	database.SetMaxIdleConns(1)
+	t.Cleanup(func() { require.NoError(t, database.Close()) })
+
+	mock.ExpectExec(regexp.QuoteMeta("START TRANSACTION;")).WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec(regexp.QuoteMeta("ROLLBACK;")).WillReturnError(errors.New("rollback transport failure"))
+
+	provider := &doltSQLProvider{defaultBranch: defaultBranch, db: database}
+	tx, err := provider.BeginTx(context.Background())
+	require.NoError(t, err)
+	require.ErrorContains(t, tx.Rollback(context.Background()), "rollback transport failure")
+	require.Eventually(t, func() bool {
+		stats := database.Stats()
+		return stats.InUse == 0 && stats.OpenConnections == 0
+	}, time.Second, 10*time.Millisecond, "failed rollback returned a dirty session to the pool")
+	require.NoError(t, mock.ExpectationsWereMet())
+}

--- a/internal/storage/uow/doltserver_tx.go
+++ b/internal/storage/uow/doltserver_tx.go
@@ -25,15 +25,29 @@ func (t *doltServerTx) Commit(ctx context.Context, message string) error {
 		return errors.New("uow: commit: already done")
 	}
 	_, err := t.conn.ExecContext(ctx, "CALL DOLT_COMMIT('-Am', ?);", message)
-	if err != nil {
-		// Leave the transaction open so Close can roll it back with its bounded,
-		// cancellation-independent cleanup context. Fresh-UOW retries always open
-		// a new unit of work; commit-only retry on this session is not used.
+	if err == nil {
+		t.done = true
+		t.releaseConn()
+		return nil
+	}
+	if isSerializationError(err) {
+		// Serialization failures guarantee the transaction was already rolled
+		// back by the engine. Leave the session for CommitWithRetries on this
+		// UOW, or for Close cleanup when RunWithFreshUOWRetries opens a new UOW.
 		return err
 	}
+	// Non-serialization DOLT_COMMIT failure leaves the transaction open on the
+	// pinned session. Roll it back before releasing the connection so the next
+	// borrower cannot inherit and implicitly commit the orphaned writes. If the
+	// rollback also fails the session state is unknown, so poison the connection
+	// and let the pool discard it instead of handing it out again.
 	t.done = true
-	t.releaseConn()
-	return nil
+	if rbErr := t.rollbackConn(ctx); rbErr != nil {
+		t.poisonConn()
+	} else {
+		t.releaseConn()
+	}
+	return err
 }
 
 func (t *doltServerTx) Rollback(ctx context.Context) error {

--- a/internal/storage/uow/doltserver_tx.go
+++ b/internal/storage/uow/doltserver_tx.go
@@ -25,29 +25,15 @@ func (t *doltServerTx) Commit(ctx context.Context, message string) error {
 		return errors.New("uow: commit: already done")
 	}
 	_, err := t.conn.ExecContext(ctx, "CALL DOLT_COMMIT('-Am', ?);", message)
-	if err == nil {
-		t.done = true
-		t.releaseConn()
-		return nil
-	}
-	if isSerializationError(err) {
-		// Serialization failures guarantee the transaction was already rolled
-		// back and the caller retries them, so leave the pinned session in place
-		// for the retry rather than tearing it down here.
+	if err != nil {
+		// Leave the transaction open so Close can roll it back with its bounded,
+		// cancellation-independent cleanup context. Fresh-UOW retries always open
+		// a new unit of work; commit-only retry on this session is not used.
 		return err
 	}
-	// A non-serialization DOLT_COMMIT failure leaves the transaction open on the
-	// pinned session. Roll it back before releasing the connection so the next
-	// borrower cannot inherit and implicitly commit the orphaned writes. If the
-	// rollback also fails the session state is unknown, so poison the connection
-	// and let the pool discard it instead of handing it out again.
 	t.done = true
-	if rbErr := t.rollbackConn(ctx); rbErr != nil {
-		t.poisonConn()
-	} else {
-		t.releaseConn()
-	}
-	return err
+	t.releaseConn()
+	return nil
 }
 
 func (t *doltServerTx) Rollback(ctx context.Context) error {
@@ -98,4 +84,16 @@ func (t *doltServerTx) poisonConn() {
 	_ = t.conn.Raw(func(any) error { return driver.ErrBadConn })
 	_ = t.conn.Close()
 	t.conn = nil
+}
+
+// discardSQLConn marks a pinned database/sql connection bad before closing its
+// handle. Returning driver.ErrBadConn from Raw makes database/sql close the
+// physical driver connection instead of putting a potentially dirty session
+// back in the pool.
+func discardSQLConn(conn *sql.Conn) {
+	if conn == nil {
+		return
+	}
+	_ = conn.Raw(func(any) error { return driver.ErrBadConn })
+	_ = conn.Close()
 }

--- a/internal/storage/uow/retry.go
+++ b/internal/storage/uow/retry.go
@@ -2,6 +2,7 @@ package uow
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/cenkalti/backoff/v4"
@@ -25,4 +26,94 @@ func CommitWithRetries(ctx context.Context, c Committer, message string) error {
 		}
 		return backoff.Permanent(err)
 	}, backoff.WithContext(bo, ctx))
+}
+
+// RunWithFreshUOWRetries runs operation and commits it in a newly opened unit
+// of work on every attempt. It retries only typed MySQL/Dolt serialization
+// failures (1213 and 1205). Close rolls back and releases every failed attempt,
+// so a serialization failure from NewUOW, operation, or Commit restarts the
+// entire operation against a fresh snapshot.
+//
+// Generic connection failures are deliberately not retried. In particular, a
+// connection loss during Commit is ambiguous: the commit may have landed, so a
+// blind replay could apply the mutation twice. Callers that need to recover an
+// ambiguous result must use an idempotency receipt outside this helper.
+//
+// The operation may run more than once. It must keep attempt-local results inside
+// the callback until this helper returns success.
+//
+// Every successfully opened UnitOfWork is closed before the attempt returns.
+// The provider remains owned by the caller and is not closed here.
+func RunWithFreshUOWRetries(
+	ctx context.Context,
+	provider UnitOfWorkProvider,
+	message string,
+	operation func(context.Context, UnitOfWork) error,
+) error {
+	return runWithFreshUOWRetries(ctx, provider, func() string { return message }, operation)
+}
+
+// RunWithFreshUOWRetriesDynamicMessage is the dynamic-message form of
+// RunWithFreshUOWRetries. It is intended for operations such as claim-next,
+// where the durable issue ID is selected inside each attempt and therefore is
+// not known until immediately before Commit. message is evaluated once per
+// commit attempt, after operation returns successfully.
+func RunWithFreshUOWRetriesDynamicMessage(
+	ctx context.Context,
+	provider UnitOfWorkProvider,
+	message func() string,
+	operation func(context.Context, UnitOfWork) error,
+) error {
+	if message == nil {
+		return errors.New("uow: fresh retry message function must not be nil")
+	}
+	return runWithFreshUOWRetries(ctx, provider, message, operation)
+}
+
+func runWithFreshUOWRetries(
+	ctx context.Context,
+	provider UnitOfWorkProvider,
+	message func() string,
+	operation func(context.Context, UnitOfWork) error,
+) error {
+	if provider == nil {
+		return errors.New("uow: fresh retry provider must not be nil")
+	}
+	if operation == nil {
+		return errors.New("uow: fresh retry operation must not be nil")
+	}
+
+	bo := backoff.NewExponentialBackOff()
+	bo.InitialInterval = 25 * time.Millisecond
+	bo.MaxElapsedTime = 15 * time.Second
+
+	return backoff.Retry(func() error {
+		if err := ctx.Err(); err != nil {
+			return backoff.Permanent(err)
+		}
+
+		uw, err := provider.NewUOW(ctx)
+		if err != nil {
+			return freshUOWRetryError(err)
+		}
+		if uw == nil {
+			return backoff.Permanent(errors.New("uow: provider returned a nil unit of work"))
+		}
+		defer uw.Close(ctx)
+
+		if err := operation(ctx, uw); err != nil {
+			return freshUOWRetryError(err)
+		}
+		if err := uw.Commit(ctx, message()); err != nil {
+			return freshUOWRetryError(err)
+		}
+		return nil
+	}, backoff.WithContext(bo, ctx))
+}
+
+func freshUOWRetryError(err error) error {
+	if isSerializationError(err) {
+		return err
+	}
+	return backoff.Permanent(err)
 }

--- a/internal/storage/uow/retry_test.go
+++ b/internal/storage/uow/retry_test.go
@@ -2,13 +2,16 @@ package uow
 
 import (
 	"context"
+	"database/sql/driver"
 	"errors"
+	"fmt"
 	"testing"
 
 	mysql "github.com/go-sql-driver/mysql"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/steveyegge/beads/internal/storage/domain"
 	"github.com/steveyegge/beads/internal/storage/domain/db"
 )
 
@@ -63,4 +66,192 @@ func TestCommitWithRetries_ContextCancelled(t *testing.T) {
 	err := CommitWithRetries(ctx, tx, "msg")
 	require.Error(t, err)
 	assert.LessOrEqual(t, tx.calls, 2)
+}
+
+type fakeRetryUOW struct {
+	commitErr   error
+	commitCalls int
+	closeCalls  int
+}
+
+func (f *fakeRetryUOW) Close(context.Context) { f.closeCalls++ }
+
+func (f *fakeRetryUOW) Commit(context.Context, string) error {
+	f.commitCalls++
+	return f.commitErr
+}
+
+func (f *fakeRetryUOW) ConfigUseCase() domain.ConfigUseCase         { return nil }
+func (f *fakeRetryUOW) DoltRemoteUseCase() domain.DoltRemoteUseCase { return nil }
+func (f *fakeRetryUOW) BootstrapUseCase() domain.BootstrapUseCase   { return nil }
+func (f *fakeRetryUOW) IssueUseCase() domain.IssueUseCase           { return nil }
+func (f *fakeRetryUOW) DependencyUseCase() domain.DependencyUseCase { return nil }
+func (f *fakeRetryUOW) LabelUseCase() domain.LabelUseCase           { return nil }
+func (f *fakeRetryUOW) CommentUseCase() domain.CommentUseCase       { return nil }
+func (f *fakeRetryUOW) RawSQLUseCase() domain.RawSQLUseCase         { return nil }
+
+type fakeRetryProvider struct {
+	newUOW func(call int) (UnitOfWork, error)
+	calls  int
+}
+
+func (f *fakeRetryProvider) NewUOW(context.Context) (UnitOfWork, error) {
+	f.calls++
+	return f.newUOW(f.calls)
+}
+
+func (f *fakeRetryProvider) Close(context.Context) error { return nil }
+
+func mysqlSerializationErr(number uint16) error {
+	return &mysql.MySQLError{Number: number, Message: "serialization failure"}
+}
+
+func TestRunWithFreshUOWRetries_SerializationRestartsEveryPhaseWithFreshUOW(t *testing.T) {
+	for _, code := range []uint16{1205, 1213} {
+		for _, phase := range []string{"begin", "body", "commit"} {
+			t.Run(fmt.Sprintf("%s_%d", phase, code), func(t *testing.T) {
+				failed := &fakeRetryUOW{}
+				succeeded := &fakeRetryUOW{}
+				if phase == "commit" {
+					failed.commitErr = mysqlSerializationErr(code)
+				}
+				provider := &fakeRetryProvider{}
+				provider.newUOW = func(call int) (UnitOfWork, error) {
+					if call == 1 {
+						if phase == "begin" {
+							return nil, mysqlSerializationErr(code)
+						}
+						return failed, nil
+					}
+					return succeeded, nil
+				}
+
+				var seen []UnitOfWork
+				bodyCalls := 0
+				err := RunWithFreshUOWRetries(context.Background(), provider, "message", func(_ context.Context, uw UnitOfWork) error {
+					bodyCalls++
+					seen = append(seen, uw)
+					if phase == "body" && bodyCalls == 1 {
+						return mysqlSerializationErr(code)
+					}
+					return nil
+				})
+				require.NoError(t, err)
+				assert.Equal(t, 2, provider.calls)
+				assert.Equal(t, 1, succeeded.commitCalls)
+				assert.Equal(t, 1, succeeded.closeCalls)
+
+				if phase == "begin" {
+					assert.Equal(t, 1, bodyCalls)
+					require.Len(t, seen, 1)
+					assert.Same(t, succeeded, seen[0])
+					assert.Equal(t, 0, failed.closeCalls)
+					return
+				}
+
+				require.Len(t, seen, 2)
+				assert.NotSame(t, seen[0], seen[1], "retry reused the failed unit of work")
+				assert.Equal(t, 1, failed.closeCalls)
+				if phase == "body" {
+					assert.Equal(t, 0, failed.commitCalls)
+				} else {
+					assert.Equal(t, 1, failed.commitCalls)
+				}
+			})
+		}
+	}
+}
+
+func TestRunWithFreshUOWRetries_NonRetryableBeginErrorStopsImmediately(t *testing.T) {
+	beginErr := fmt.Errorf("connect: %w", driver.ErrBadConn)
+	provider := &fakeRetryProvider{newUOW: func(int) (UnitOfWork, error) { return nil, beginErr }}
+	bodyCalls := 0
+
+	err := RunWithFreshUOWRetries(context.Background(), provider, "message", func(context.Context, UnitOfWork) error {
+		bodyCalls++
+		return nil
+	})
+	require.ErrorIs(t, err, driver.ErrBadConn)
+	assert.Equal(t, 1, provider.calls)
+	assert.Equal(t, 0, bodyCalls)
+}
+
+func TestRunWithFreshUOWRetries_BodyErrorStopsImmediately(t *testing.T) {
+	uw := &fakeRetryUOW{}
+	provider := &fakeRetryProvider{newUOW: func(int) (UnitOfWork, error) { return uw, nil }}
+	bodyErr := errors.New("validation failed")
+
+	err := RunWithFreshUOWRetries(context.Background(), provider, "message", func(context.Context, UnitOfWork) error {
+		return bodyErr
+	})
+	require.ErrorIs(t, err, bodyErr)
+	assert.Equal(t, 1, provider.calls)
+	assert.Equal(t, 0, uw.commitCalls)
+	assert.Equal(t, 1, uw.closeCalls)
+}
+
+func TestRunWithFreshUOWRetries_BodyConnectionErrorIsNotRetried(t *testing.T) {
+	uw := &fakeRetryUOW{}
+	provider := &fakeRetryProvider{newUOW: func(int) (UnitOfWork, error) { return uw, nil }}
+
+	err := RunWithFreshUOWRetries(context.Background(), provider, "message", func(context.Context, UnitOfWork) error {
+		return fmt.Errorf("body connection lost: %w", driver.ErrBadConn)
+	})
+	require.ErrorIs(t, err, driver.ErrBadConn)
+	assert.Equal(t, 1, provider.calls)
+	assert.Equal(t, 0, uw.commitCalls)
+	assert.Equal(t, 1, uw.closeCalls)
+}
+
+func TestRunWithFreshUOWRetries_NonRetryableCommitErrorStopsImmediately(t *testing.T) {
+	commitErr := fmt.Errorf("commit result ambiguous: %w", driver.ErrBadConn)
+	uw := &fakeRetryUOW{commitErr: commitErr}
+	provider := &fakeRetryProvider{newUOW: func(int) (UnitOfWork, error) { return uw, nil }}
+	bodyCalls := 0
+
+	err := RunWithFreshUOWRetries(context.Background(), provider, "message", func(context.Context, UnitOfWork) error {
+		bodyCalls++
+		return nil
+	})
+	require.ErrorIs(t, err, driver.ErrBadConn)
+	assert.Equal(t, 1, provider.calls)
+	assert.Equal(t, 1, bodyCalls)
+	assert.Equal(t, 1, uw.commitCalls)
+	assert.Equal(t, 1, uw.closeCalls)
+}
+
+func TestRunWithFreshUOWRetries_ContextCancellationStopsRetry(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	uw := &fakeRetryUOW{}
+	provider := &fakeRetryProvider{newUOW: func(int) (UnitOfWork, error) { return uw, nil }}
+	bodyCalls := 0
+
+	err := RunWithFreshUOWRetries(ctx, provider, "message", func(context.Context, UnitOfWork) error {
+		bodyCalls++
+		cancel()
+		return mysqlSerializationErr(1213)
+	})
+	require.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, provider.calls)
+	assert.Equal(t, 1, bodyCalls)
+	assert.Equal(t, 0, uw.commitCalls)
+	assert.Equal(t, 1, uw.closeCalls)
+}
+
+func TestRunWithFreshUOWRetries_ClosesSuccessfulAttempt(t *testing.T) {
+	uw := &fakeRetryUOW{}
+	provider := &fakeRetryProvider{newUOW: func(int) (UnitOfWork, error) { return uw, nil }}
+
+	require.NoError(t, RunWithFreshUOWRetries(context.Background(), provider, "message", func(context.Context, UnitOfWork) error {
+		return nil
+	}))
+	assert.Equal(t, 1, provider.calls)
+	assert.Equal(t, 1, uw.commitCalls)
+	assert.Equal(t, 1, uw.closeCalls)
+}
+
+func TestRunWithFreshUOWRetriesDynamicMessage_RejectsNilMessage(t *testing.T) {
+	err := RunWithFreshUOWRetriesDynamicMessage(context.Background(), &fakeRetryProvider{}, nil,
+		func(context.Context, UnitOfWork) error { return nil })
+	require.EqualError(t, err, "uow: fresh retry message function must not be nil")
 }

--- a/internal/storage/uow/uow.go
+++ b/internal/storage/uow/uow.go
@@ -2,10 +2,13 @@ package uow
 
 import (
 	"context"
+	"time"
 
 	"github.com/steveyegge/beads/internal/storage/domain"
 	"github.com/steveyegge/beads/internal/storage/domain/db"
 )
+
+const uowCleanupTimeout = 5 * time.Second
 
 type UnitOfWork interface {
 	Close(ctx context.Context)
@@ -54,7 +57,12 @@ func (u *baseUOW) Commit(ctx context.Context, message string) error {
 }
 
 func (u *baseUOW) Close(ctx context.Context) {
-	u.tx.RollbackUnlessCommitted(ctx)
+	// Command contexts are commonly canceled precisely when cleanup is most
+	// important. Using that canceled context would prevent ROLLBACK from reaching
+	// Dolt and could return a dirty session to database/sql's pool.
+	cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), uowCleanupTimeout)
+	defer cancel()
+	u.tx.RollbackUnlessCommitted(cleanupCtx)
 }
 
 func (u *baseUOW) ConfigUseCase() domain.ConfigUseCase {

--- a/internal/storage/uow/uow_cleanup_test.go
+++ b/internal/storage/uow/uow_cleanup_test.go
@@ -1,0 +1,42 @@
+package uow
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/steveyegge/beads/internal/storage/domain/db"
+)
+
+type cleanupObservingTx struct {
+	contextErr  error
+	deadline    time.Time
+	hasDeadline bool
+}
+
+func (t *cleanupObservingTx) Runner() db.Runner { return nil }
+
+func (t *cleanupObservingTx) Commit(context.Context, string) error { return nil }
+
+func (t *cleanupObservingTx) Rollback(context.Context) error { return nil }
+
+func (t *cleanupObservingTx) RollbackUnlessCommitted(ctx context.Context) {
+	t.contextErr = ctx.Err()
+	t.deadline, t.hasDeadline = ctx.Deadline()
+}
+
+func TestBaseUOWCloseUsesBoundedUncanceledContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	started := time.Now()
+	tx := &cleanupObservingTx{}
+	(&baseUOW{tx: tx}).Close(ctx)
+
+	require.NoError(t, tx.contextErr, "rollback cleanup inherited the canceled command context")
+	require.True(t, tx.hasDeadline, "rollback cleanup must remain bounded")
+	require.GreaterOrEqual(t, tx.deadline.Sub(started), uowCleanupTimeout-time.Second)
+	require.LessOrEqual(t, tx.deadline.Sub(started), uowCleanupTimeout+time.Second)
+}


### PR DESCRIPTION
## Summary

**Correctness fix for proxied-server (Dolt SQL server) mode:** when a Dolt serialization conflict (MySQL 1213/1205) occurs, replay the **entire high-level operation** on a **fresh unit of work / snapshot**, instead of retrying only `DOLT_COMMIT` on a transaction that has already lost.

This is a storage/CLI correctness slice. It is **not** the WAN performance fix. Lab verdict remains `GATEWAY_ARCHITECTURE_REQUIRED` until an integrated near-data cell meets promotion gates on current source.

## What was fixed

| Problem | Fix |
| --- | --- |
| `CommitWithRetries` only re-ran `DOLT_COMMIT` after 1213 | Added `uow.RunWithFreshUOWRetries` / `RunWithFreshUOWRetriesDynamicMessage` |
| Proxied update/claim/close/create/dep/reopen/delete could commit partial/stale state | Each path now reopens UOW, re-reads, re-applies, then commits |
| Failed `START TRANSACTION` could leak pinned connections | `discardSQLConn` on BeginTx failure |
| Canceled command context could skip ROLLBACK | UOW `Close` uses bounded `context.WithoutCancel` cleanup |
| Non-serialization commit failure could pool dirty sessions | ROLLBACK (or poison) before release — preserves existing tests |

## How it was fixed

1. **Kernel:** `internal/storage/uow/retry.go` — full-operation retry with backoff on serialization errors only; connection loss on commit is **not** blindly retried (ambiguous commit).
2. **CLI surface:** proxied handlers under `cmd/bd/*_proxied_server.go` call the kernel instead of `CommitWithRetries` for the listed ops.
3. **Tests:** `cmd/bd/fresh_uow_retry_test.go` proves 1213 forces a second `NewUOW` + re-apply; `internal/storage/uow` keeps pool-safety tests green.

## What this PR replaces / relates to

| PR | Relationship |
| --- | --- |
| Operator Draft **#1** (UOW on 4675 base) | **Superseded as the CI vehicle.** Same idea, wrong base for fork workflows (`pull_request` only targets `main`). Keep #1 as archaeology of the 4675 stack. |
| Upstream **#4675** (claim/lease) | **Not replaced.** Coordinate; this PR does **not** re-arm leases on bare status updates (compatible with main lease fixes). |
| Operator Draft **#2** (gateway lab) | **Not replaced.** Research/evidence only. |
| Operator Draft **#3** (docs) | Complementary RFC/evidence package. |
| Operator Draft **#5** (integrated cell lab packages) | Follow-on lab integration; depends on this correctness kernel. |

## Setup / validation guide

### Prerequisites
- Go matching `go.mod` (1.26.x in this tree)
- For full embedded tests: `CGO_ENABLED=1` + `gms_pure_go` tags

### Checkout
```bash
git clone https://github.com/medhatgalal/beads.git
cd beads
git fetch origin AI/perf-remote-server-uow-fresh-retry-main
git checkout AI/perf-remote-server-uow-fresh-retry-main
```

### Unit tests (required)
```bash
CGO_ENABLED=1 go test -tags gms_pure_go -count=1 ./internal/storage/uow/
CGO_ENABLED=1 go test -tags gms_pure_go -count=1 \
  -run 'TestCloseProxiedOneFresh|TestRunCreateProxiedSingle|TestRunDepBlocks|TestApplyUpdateProxiedOne|TestRunReadyProxiedClaim|TestReopenProxiedOneFresh' \
  ./cmd/bd/
```

### Optional package gate style
```bash
make test   # or ./scripts/test.sh — repo default
```

### Build `bd` from this branch
```bash
# Server-mode only
CGO_ENABLED=0 go install ./cmd/bd

# Embedded-capable (matches docs/INSTALLING.md)
CGO_ENABLED=1 GOFLAGS=-tags=gms_pure_go go install ./cmd/bd
bd version
```

## Non-claims
- Not a WAN latency fix; not production gateway.
- Remaining same-UOW callers: create graph/markdown, purge, config×3, init, sql, version, heartbeat domain port.
- Not ready to undraft until hosted **CI Gate / Required** is green.

## Reviewer ask
Please review retry semantics and pool safety. Focus packages: `internal/storage/uow`, proxied `cmd/bd` paths, new unit tests.

## Maintainers (please review)
@steveyegge @maphew @julianknutsen @HackAttack @chrisjunlee  
Team: @gastownhall/beads-maintainers

_Agent session on behalf of Medhat Galal — Grok Superheavy continuation of remote performance lab._
