### PR TITLE
fix(schema): commit the dolt_ignore seed before the migration pass (fixes red main)

### DIFF
--- a/internal/storage/schema/lock_test.go
+++ b/internal/storage/schema/lock_test.go
@@ -199,6 +199,13 @@ func expectOnePendingMigration(t *testing.T, mock sqlmock.Sqlmock) {
 	expectIgnorePatternSeed(mock)
 	expectScalar(mock, "SELECT COALESCE(MAX(version), 0) FROM schema_migrations", "version", latest-1)
 	expectDoltStatusRows(mock)
+	// The seed changed rows (expectIgnorePatternSeed reports RowsAffected=1),
+	// so MigrateUp commits it scoped+labeled before the pass runs (#4566: the
+	// seed must not ride the per-step pass commits).
+	mock.ExpectExec(regexp.QuoteMeta("CALL DOLT_ADD('dolt_ignore')")).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec(regexp.QuoteMeta("CALL DOLT_COMMIT('-m', 'schema: seed dolt_ignore patterns')")).
+		WillReturnResult(sqlmock.NewResult(0, 0))
 	expectDoltStatusRows(mock)
 	// MigrateUp probes the aux-rekey crash sentinel (bd-578h9.16); this
 	// mocked world has no local_metadata table, so no crashed pass.

--- a/internal/storage/schema/schema.go
+++ b/internal/storage/schema/schema.go
@@ -256,6 +256,21 @@ func seedDoltIgnorePatterns(ctx context.Context, db DBConn) (bool, error) {
 	return changed, nil
 }
 
+// commitSeededDoltIgnore stages and commits freshly seeded dolt_ignore rows
+// in a scoped, labeled commit. Both MigrateUp paths use it: on the no-work
+// short-circuit nothing downstream would ever commit the seed, and on the
+// migration path the seed must be committed before the first step so an
+// interrupted pass leaves a clean working set (#4566 self-heal contract).
+func commitSeededDoltIgnore(ctx context.Context, db DBConn) error {
+	if _, err := db.ExecContext(ctx, "CALL DOLT_ADD('dolt_ignore')"); err != nil {
+		return fmt.Errorf("staging seeded dolt_ignore patterns: %w", err)
+	}
+	if _, err := db.ExecContext(ctx, "CALL DOLT_COMMIT('-m', 'schema: seed dolt_ignore patterns')"); err != nil {
+		return fmt.Errorf("committing seeded dolt_ignore patterns: %w", err)
+	}
+	return nil
+}
+
 func LatestVersion() int {
 	latestOnce.Do(func() {
 		latestVer = mainSource.latest()
@@ -345,11 +360,8 @@ func MigrateUp(ctx context.Context, db DBConn) (int, error) {
 		// it indefinitely). Commit it here, scoped and labeled, so the
 		// out-of-band-copy heal converges in one pass.
 		if seedChanged {
-			if _, err := db.ExecContext(ctx, "CALL DOLT_ADD('dolt_ignore')"); err != nil {
-				return 0, fmt.Errorf("staging seeded dolt_ignore patterns: %w", err)
-			}
-			if _, err := db.ExecContext(ctx, "CALL DOLT_COMMIT('-m', 'schema: seed dolt_ignore patterns')"); err != nil {
-				return 0, fmt.Errorf("committing seeded dolt_ignore patterns: %w", err)
+			if err := commitSeededDoltIgnore(ctx, db); err != nil {
+				return 0, err
 			}
 		}
 		return 0, nil
@@ -362,11 +374,22 @@ func MigrateUp(ctx context.Context, db DBConn) (int, error) {
 	// dolt_ignore is pass-owned state: seedDoltIgnorePatterns above may have
 	// just dirtied it on an under-seeded database. Exempting it from the
 	// pre-existing-dirty guards (like the aux-rekey tables below) keeps the
-	// pending-migration and changed-signature gates off it and lets
-	// stageSchemaTables commit the seeded patterns with the pass.
+	// pending-migration and changed-signature gates off it.
 	delete(dirtyBeforeAll, "dolt_ignore")
 	if err := unstagePreExistingTables(ctx, db, dirtyBeforeAll); err != nil {
 		return 0, fmt.Errorf("unstaging pre-migration tables: %w", err)
+	}
+	// The seed must not ride the migration pass: every step of the pass
+	// commits atomically, and a pass killed between steps must leave a CLEAN
+	// working set (the #4566 self-heal contract) — but the seeded dolt_ignore
+	// rows would stay dirty until the pass's final commit, so an interrupted
+	// retry sees a dirty working set and refuses to converge. Commit the seed
+	// scoped and labeled now, after pre-existing staged tables were unstaged
+	// (so nothing else rides into the commit) and before the first step runs.
+	if seedChanged {
+		if err := commitSeededDoltIgnore(ctx, db); err != nil {
+			return 0, err
+		}
 	}
 	dirtyBefore, err := committableDirtyTables(ctx, db)
 	if err != nil {

--- a/internal/storage/schema/schema_test.go
+++ b/internal/storage/schema/schema_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strconv"
 	"strings"
 	"testing"
@@ -59,8 +60,8 @@ func TestMigrateUpReturnsDirtyTablesErrorForPreExistingDirtyTable(t *testing.T) 
 	defer db.Close()
 
 	// MigrateUp re-asserts the canonical dolt_ignore patterns before anything
-	// else (GH#4378); migration work IS needed here, so the pass (not a
-	// scoped commit) owns the seeded rows.
+	// else (GH#4378); the rows changed, so a scoped commit lands before the
+	// pass runs (#4566: the seed must not ride the per-step pass commits).
 	expectIgnorePatternSeed(mock)
 	// migrationWorkNeeded: mainSource.atLatest reads the current cursor; v42
 	// is behind LatestVersion(), so the || short-circuits before checking
@@ -70,6 +71,12 @@ func TestMigrateUpReturnsDirtyTablesErrorForPreExistingDirtyTable(t *testing.T) 
 	// dirtyTables(ctx, db, false): `dependencies` has an uncommitted, unstaged
 	// change in the working set.
 	expectDirtyDoltStatusRow(mock, "dependencies", false)
+	// The seed changed rows, so it is committed scoped+labeled right after
+	// pre-existing tables are unstaged, before the dirty-table guards run.
+	mock.ExpectExec(regexp.QuoteMeta("CALL DOLT_ADD('dolt_ignore')")).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec(regexp.QuoteMeta("CALL DOLT_COMMIT('-m', 'schema: seed dolt_ignore patterns')")).
+		WillReturnResult(sqlmock.NewResult(0, 0))
 	// committableDirtyTables -> dirtyTables(ctx, db, true): same dirty state.
 	expectDirtyDoltStatusRow(mock, "dependencies", false)
 


### PR DESCRIPTION
## Why

Main is red at 615d68a50 (#4518): `TestEmbeddedMigrateConvergesUnderConcurrentInterruptedRetries_4566` fails deterministically —

```
killed pass left a DIRTY working set [dolt_ignore] at version 49 (per-step commit violated)
```

The #4378 seed dirties `dolt_ignore` at the top of `MigrateUp` and, when migration work is needed, deferred its commit to the end of the pass. That violates the #4566 self-heal contract (every step commits atomically; a killed pass must leave a clean working set), so interrupted retries refuse to converge. Every PR merge-ref built on current main inherits the failure (observed on gastownhall/beads PR 4500, PR 4675, PR 4712 check runs). This is the stop-the-line fix for main.

Root cause slipped through because #4518's own green checks predated the #4566 convergence test landing on main (#4611) — stale-check hazard, noted for the maintainer playbook.

## What

- Extract `commitSeededDoltIgnore` and call it on **both** paths: the existing no-work short-circuit, and now the needed path — right after `unstagePreExistingTables` (so nothing else rides into the scoped commit) and before the first migration step.
- Keep the dirty-guard exemptions as belt-and-suspenders for the degraded `RowsAffected`-error path.
- Update the #4567 dirty-guard test and the two lock tests to expect the scoped commit; keep the no-op-seed negative test asserting no commit when nothing changed.

## Validation

- `TestEmbeddedMigrateConvergesUnderConcurrentInterruptedRetries_4566`: fails on 615d68a50, passes with this fix (`-count=2`).
- Full `internal/storage/schema` suite: green (includes both #4378 seed regression guards and the #4567 dirty-guard).
- Embedded-dolt `-run 'Migrate'` suite: green.
- `gofmt`/`go vet` clean.

_claude-fable-5-high on behalf of maphew_
