### PR TITLE
fix(telemetry,security): scrub positional federation peer URL; split DSN password extractor (post-merge #4712)

### DIFF
--- a/cmd/bd/main.go
+++ b/cmd/bd/main.go
@@ -743,7 +743,7 @@ var rootCmd = &cobra.Command{
 			oteltrace.WithAttributes(
 				attribute.String("bd.command", cmd.Name()),
 				attribute.String("bd.version", Version),
-				attribute.String("bd.args", scrubArgsForTelemetry(os.Args[1:], secretFlagTokens(cmd))),
+				attribute.String("bd.args", scrubArgsForTelemetry(os.Args[1:], secretFlagTokens(cmd), dsnPositionalValues(cmd))),
 			),
 		)
 
@@ -1765,6 +1765,28 @@ func secretFlagTokens(cmd *cobra.Command) map[string]bool {
 	return tokens
 }
 
+// dsnPositionalValues returns the exact positional-argument values for cmd whose
+// content is a connection string, so scrubArgsForTelemetry can give them the same full
+// DSN scrub as the --pg-url/--mysql-url flags. federation add-peer takes its peer URL
+// as a positional operand rather than a DSN flag, so a password embedded in that URL
+// (?password=/?sslpassword= or a libpq keyword) would otherwise reach bd.args through
+// only the narrow userinfo scrub. Matching by exact operand value keeps the broad DSN
+// scan off every other positional arg, so ordinary text is never over-redacted. Flags
+// are parsed before PersistentPreRunE runs, so Flags().Args() holds the positionals.
+func dsnPositionalValues(cmd *cobra.Command) map[string]bool {
+	vals := make(map[string]bool)
+	if cmd == nil {
+		return vals
+	}
+	// federation add-peer <name> <url>: the second operand is a connection string.
+	if cmd.Name() == "add-peer" && cmd.Parent() != nil && cmd.Parent().Name() == "federation" {
+		if args := cmd.Flags().Args(); len(args) >= 2 && args[1] != "" {
+			vals[args[1]] = true
+		}
+	}
+	return vals
+}
+
 // scrubArgsForTelemetry joins argv for the bd.args span attribute with any
 // credential-bearing values redacted. --pg-url/--mysql-url may carry a password
 // for init, and federation add-peer --password/-p carries a SQL password;
@@ -1774,12 +1796,14 @@ func secretFlagTokens(cmd *cobra.Command) map[string]bool {
 // A DSN flag's value is scrubbed through the parser-backed pgdialect logic so every
 // password form pgx accepts is caught — URL userinfo, URL `?password=`/`?sslpassword=`
 // query params, and libpq `password=`/`sslpassword=` keyword/value tokens — in both
-// the `--pg-url=<dsn>` and `--pg-url <dsn>` spellings. A secretFlags token's value is
-// an opaque credential and is redacted wholesale across the `--password <v>`,
-// `--password=<v>`, `-p <v>`, `-p=<v>`, and `-p<v>` spellings pflag accepts. Every
-// other arg still gets the narrow user:PASS@host userinfo scrub as defense in depth,
-// without the broad keyword scan that would over-redact ordinary text.
-func scrubArgsForTelemetry(argv []string, secretFlags map[string]bool) string {
+// the `--pg-url=<dsn>` and `--pg-url <dsn>` spellings. A DSN that arrives as a
+// positional operand instead of a flag (federation add-peer's peer URL, listed in
+// dsnPositionals by exact value) gets that same full scrub. A secretFlags token's value
+// is an opaque credential and is redacted wholesale across the `--password <v>`,
+// `--password=<v>`, `-p <v>`, `-p=<v>`, and `-p<v>` spellings pflag accepts. Every other
+// arg still gets the narrow user:PASS@host userinfo scrub as defense in depth, without
+// the broad keyword scan that would over-redact ordinary text.
+func scrubArgsForTelemetry(argv []string, secretFlags, dsnPositionals map[string]bool) string {
 	parts := make([]string, len(argv))
 	for i, a := range argv {
 		if name, val, ok := strings.Cut(a, "="); ok {
@@ -1809,6 +1833,12 @@ func scrubArgsForTelemetry(argv []string, secretFlags map[string]bool) string {
 		if short, ok := secretShorthandPrefix(a, secretFlags); ok {
 			// -p<secret> — pflag's concatenated shorthand spelling.
 			parts[i] = short + "xxxxx"
+			continue
+		}
+		if dsnPositionals[a] {
+			// federation add-peer's positional peer URL — a full DSN, so scrub every
+			// password form, not just the userinfo the fallthrough below would catch.
+			parts[i] = scrubDSNValue(a)
 			continue
 		}
 		parts[i] = scrubUserinfoPassword(a)

--- a/cmd/bd/telemetry_scrub_test.go
+++ b/cmd/bd/telemetry_scrub_test.go
@@ -53,7 +53,7 @@ func TestScrubArgsForTelemetry(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			out := scrubArgsForTelemetry(tc.argv, nil)
+			out := scrubArgsForTelemetry(tc.argv, nil, nil)
 			if strings.Contains(out, secret) {
 				t.Fatalf("PASSWORD LEAK: scrubArgsForTelemetry(%v) = %q still contains %q", tc.argv, out, secret)
 			}
@@ -75,12 +75,12 @@ func TestScrubArgsForTelemetry(t *testing.T) {
 // bare user:pass@host userinfo anywhere is still redacted as defense in depth.
 func TestScrubArgsForTelemetryLeavesOrdinaryArgs(t *testing.T) {
 	argv := []string{"create", "--title", "document the password= knob"}
-	if out := scrubArgsForTelemetry(argv, nil); out != "create --title document the password= knob" {
+	if out := scrubArgsForTelemetry(argv, nil, nil); out != "create --title document the password= knob" {
 		t.Fatalf("over-redacted ordinary args: got %q", out)
 	}
 
 	argv = []string{"weird", "postgres://u:leak@h:5432/db"}
-	if out := scrubArgsForTelemetry(argv, nil); strings.Contains(out, "leak") {
+	if out := scrubArgsForTelemetry(argv, nil, nil); strings.Contains(out, "leak") {
 		t.Fatalf("userinfo password not scrubbed as defense in depth: %q", out)
 	}
 }
@@ -152,7 +152,7 @@ func TestScrubArgsForTelemetryRedactsFederationPassword(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			out := scrubArgsForTelemetry(tc.argv, secretFlags)
+			out := scrubArgsForTelemetry(tc.argv, secretFlags, nil)
 			if strings.Contains(out, secret) {
 				t.Fatalf("PASSWORD LEAK: scrubArgsForTelemetry(%v) = %q still contains %q", tc.argv, out, secret)
 			}
@@ -193,7 +193,7 @@ func TestScrubArgsForTelemetryRedactsShorthandCluster(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			out := scrubArgsForTelemetry(tc.argv, secretFlags)
+			out := scrubArgsForTelemetry(tc.argv, secretFlags, nil)
 			if strings.Contains(out, secret) {
 				t.Fatalf("PASSWORD LEAK: scrubArgsForTelemetry(%v) = %q still contains %q", tc.argv, out, secret)
 			}
@@ -210,13 +210,128 @@ func TestScrubArgsForTelemetryRedactsShorthandCluster(t *testing.T) {
 // pass through untouched. Without this guarantee the fix would silently redact
 // priority/prefix on the most common bd invocations.
 func TestScrubArgsForTelemetryKeepsOverloadedShortFlag(t *testing.T) {
-	if out := scrubArgsForTelemetry([]string{"ready", "-p", "1"}, nil); out != "ready -p 1" {
+	if out := scrubArgsForTelemetry([]string{"ready", "-p", "1"}, nil, nil); out != "ready -p 1" {
 		t.Fatalf("over-redacted non-secret -p priority: got %q", out)
 	}
-	if out := scrubArgsForTelemetry([]string{"init", "-p", "myprefix"}, map[string]bool{}); out != "init -p myprefix" {
+	if out := scrubArgsForTelemetry([]string{"init", "-p", "myprefix"}, map[string]bool{}, nil); out != "init -p myprefix" {
 		t.Fatalf("over-redacted non-secret -p prefix: got %q", out)
 	}
-	if out := scrubArgsForTelemetry([]string{"init", "-p=myprefix"}, nil); out != "init -p=myprefix" {
+	if out := scrubArgsForTelemetry([]string{"init", "-p=myprefix"}, nil, nil); out != "init -p=myprefix" {
 		t.Fatalf("over-redacted non-secret -p=prefix: got %q", out)
+	}
+}
+
+// TestScrubArgsForTelemetryRedactsPositionalPeerURL locks that a password embedded in
+// federation add-peer's POSITIONAL peer URL never reaches bd.args. --password/-p and
+// URL userinfo were already covered, but the connection target is a positional operand,
+// not a --pg-url/--mysql-url flag, so its ?password=/?sslpassword= query params and
+// libpq keyword passwords otherwise fell through to the userinfo-only scrub and leaked.
+// dsnPositionalValues lists the exact operand so it gets the full parser-backed scrub.
+func TestScrubArgsForTelemetryRedactsPositionalPeerURL(t *testing.T) {
+	const secret = "s3cr3t-pw"
+	secretFlags := map[string]bool{"--password": true, "-p": true}
+	cases := []struct {
+		name string
+		url  string
+		keep []string // non-secret structure that must survive redaction
+	}{
+		{
+			name: "query password param",
+			url:  "postgres://bts@127.0.0.1:5432/db?password=" + secret,
+			keep: []string{"127.0.0.1:5432/db", "password="},
+		},
+		{
+			name: "query sslpassword param",
+			url:  "postgres://bts@h:5432/db?sslpassword=" + secret + "&sslmode=require",
+			keep: []string{"sslmode=require"},
+		},
+		{
+			name: "userinfo password",
+			url:  "postgres://bts:" + secret + "@127.0.0.1:5432/db",
+			keep: []string{"127.0.0.1:5432/db"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			argv := []string{"federation", "add-peer", "partner", tc.url, "--user", "admin"}
+			dsnPositionals := map[string]bool{tc.url: true}
+			out := scrubArgsForTelemetry(argv, secretFlags, dsnPositionals)
+			if strings.Contains(out, secret) {
+				t.Fatalf("PASSWORD LEAK: scrubArgsForTelemetry(%v) = %q still contains %q", argv, out, secret)
+			}
+			if !strings.Contains(out, "xxxxx") {
+				t.Fatalf("expected redaction marker xxxxx in %q", out)
+			}
+			if !strings.Contains(out, "--user admin") {
+				t.Errorf("expected non-secret --user admin to survive in %q", out)
+			}
+			for _, k := range tc.keep {
+				if !strings.Contains(out, k) {
+					t.Errorf("expected %q to survive redaction in %q", k, out)
+				}
+			}
+		})
+	}
+
+	// A positional URL that is NOT listed (e.g. some other command's operand) still gets
+	// only the userinfo scrub, so an ordinary token carrying a literal "password=" is
+	// never over-redacted by a broad keyword scan.
+	argv := []string{"create", "--title", "postgres://h/db?password=notascan"}
+	if out := scrubArgsForTelemetry(argv, nil, nil); !strings.Contains(out, "password=notascan") {
+		t.Fatalf("over-redacted an unlisted positional as a DSN: got %q", out)
+	}
+}
+
+// TestDSNPositionalValuesResolvesFederationAddPeerURL proves the resolver returns
+// federation add-peer's <url> operand (its second positional) after flag parsing, and
+// nothing for other commands, too-few operands, or a nil command — so only the peer URL
+// is matched for the full DSN scrub.
+func TestDSNPositionalValuesResolvesFederationAddPeerURL(t *testing.T) {
+	newAddPeer := func() *cobra.Command {
+		fed := &cobra.Command{Use: "federation"}
+		var user, pw string
+		addPeer := &cobra.Command{Use: "add-peer <name> <url>", RunE: func(*cobra.Command, []string) error { return nil }}
+		addPeer.Flags().StringVarP(&user, "user", "u", "", "")
+		addPeer.Flags().StringVarP(&pw, "password", "p", "", "")
+		fed.AddCommand(addPeer)
+		return addPeer
+	}
+
+	const url = "postgres://bts@127.0.0.1:5432/db?password=s3cr3t"
+	addPeer := newAddPeer()
+	if err := addPeer.ParseFlags([]string{"partner", url, "--user", "admin"}); err != nil {
+		t.Fatalf("ParseFlags: %v", err)
+	}
+	got := dsnPositionalValues(addPeer)
+	if !got[url] || len(got) != 1 {
+		t.Fatalf("dsnPositionalValues = %v, want exactly {%q}", got, url)
+	}
+
+	// Fewer than two operands: no peer URL to scrub.
+	onlyName := newAddPeer()
+	if err := onlyName.ParseFlags([]string{"partner"}); err != nil {
+		t.Fatalf("ParseFlags: %v", err)
+	}
+	if got := dsnPositionalValues(onlyName); len(got) != 0 {
+		t.Fatalf("dsnPositionalValues(one operand) = %v, want empty", got)
+	}
+
+	// A same-named command whose parent is not federation must not match.
+	orphan := &cobra.Command{Use: "add-peer"}
+	if err := orphan.ParseFlags([]string{"a", "b"}); err != nil {
+		t.Fatalf("ParseFlags: %v", err)
+	}
+	if got := dsnPositionalValues(orphan); len(got) != 0 {
+		t.Fatalf("dsnPositionalValues(no federation parent) = %v, want empty", got)
+	}
+
+	// Unrelated command and nil resolve to nothing.
+	other := &cobra.Command{Use: "init"}
+	_ = other.ParseFlags([]string{"--backend", "postgres"})
+	if got := dsnPositionalValues(other); len(got) != 0 {
+		t.Fatalf("dsnPositionalValues(init) = %v, want empty", got)
+	}
+	if got := dsnPositionalValues(nil); len(got) != 0 {
+		t.Fatalf("dsnPositionalValues(nil) = %v, want empty", got)
 	}
 }

--- a/internal/storage/pgdialect/redact.go
+++ b/internal/storage/pgdialect/redact.go
@@ -143,47 +143,73 @@ func dsnPasswordValues(dsn string) []string {
 		vals = append(vals, v)
 	}
 	if u, err := url.Parse(dsn); err == nil && u.Scheme != "" {
-		if u.User != nil {
-			if pw, ok := u.User.Password(); ok {
-				// url.Parse percent-decodes userinfo, so u.User.Password() is only
-				// the decoded value. pgx and telemetry sinks echo the DSN verbatim,
-				// so also scrub the raw as-written form — mirroring the query-param
-				// branch below, which adds both raw and decoded values.
-				add(pw)
-				add(rawURLUserinfoPassword(dsn))
-			}
+		addURLUserinfoPassword(dsn, u, add)
+		addURLQueryPasswords(u, add)
+	}
+	addLibpqKeywordPasswords(dsn, add)
+	return vals
+}
+
+// addURLUserinfoPassword passes the userinfo password of a URL-form DSN to add in
+// both its decoded and raw as-written forms. url.Parse percent-decodes userinfo, so
+// u.User.Password() is only the decoded value; pgx and telemetry sinks echo the DSN
+// verbatim, so the raw form is added too — mirroring addURLQueryPasswords, which adds
+// both raw and decoded values.
+func addURLUserinfoPassword(dsn string, u *url.URL, add func(string)) {
+	if u.User == nil {
+		return
+	}
+	pw, ok := u.User.Password()
+	if !ok {
+		return
+	}
+	add(pw)
+	add(rawURLUserinfoPassword(dsn))
+}
+
+// addURLQueryPasswords passes the value of every URL query password/sslpassword param
+// to add. pgx echoes the raw query string back verbatim, so the raw value is matched;
+// the decoded value is added too in case a caller logs the parsed form.
+func addURLQueryPasswords(u *url.URL, add func(string)) {
+	for _, pair := range strings.Split(u.RawQuery, "&") {
+		key, val, ok := strings.Cut(pair, "=")
+		if !ok {
+			continue
 		}
-		// pgx echoes the raw query string back verbatim, so match the raw value;
-		// also add the decoded value in case a caller logs the parsed form.
-		for _, pair := range strings.Split(u.RawQuery, "&") {
-			key, val, ok := strings.Cut(pair, "=")
-			if !ok {
-				continue
-			}
-			// url.Query() (which pgx.ParseConfig uses) percent-decodes query KEYS as
-			// well as values, so a query key of pass%77ord or %70assword is a live
-			// "password" param even though the raw key string doesn't say so. Compare
-			// both the raw (as-written) key and its unescaped form — ignoring an
-			// unescape error and falling back to the raw compare, which already ran.
-			matched := isPasswordKey(key)
-			if !matched {
-				if dk, err := url.QueryUnescape(key); err == nil {
-					matched = isPasswordKey(dk)
-				}
-			}
-			if matched {
-				add(val)
-				if dec, err := url.QueryUnescape(val); err == nil {
-					add(dec)
-				}
-			}
+		if !queryKeyIsPassword(key) {
+			continue
+		}
+		add(val)
+		if dec, err := url.QueryUnescape(val); err == nil {
+			add(dec)
 		}
 	}
+}
+
+// queryKeyIsPassword reports whether a raw URL query key names a password param.
+// url.Query() (which pgx.ParseConfig uses) percent-decodes query KEYS as well as
+// values, so a query key of pass%77ord or %70assword is a live "password" param even
+// though the raw key string doesn't say so. Both the raw (as-written) key and its
+// unescaped form are compared — an unescape error falls back to the raw compare, which
+// already ran.
+func queryKeyIsPassword(key string) bool {
+	if isPasswordKey(key) {
+		return true
+	}
+	if dk, err := url.QueryUnescape(key); err == nil {
+		return isPasswordKey(dk)
+	}
+	return false
+}
+
+// addLibpqKeywordPasswords passes the value of every libpq keyword/value password
+// token (password=, sslpassword=) in dsn to add, in both its single-quoted body and
+// unquoted-token spellings.
+func addLibpqKeywordPasswords(dsn string, add func(string)) {
 	for _, m := range pwValueRe.FindAllStringSubmatch(dsn, -1) {
 		add(m[1]) // single-quoted body
 		add(m[2]) // unquoted token
 	}
-	return vals
 }
 
 // rawURLUserinfoPassword returns the userinfo password of a URL-form DSN exactly


### PR DESCRIPTION
## Post-merge remediation for #4712

This is a follow-up to the landed change in #4712
(`fix(security,ci): redact all DSN password forms in telemetry; require pg/mysql conformance`).
A post-merge review of the landed range `e662228464..ddca3e3ef` surfaced two
items, both addressed here in the same subsystem.

### 1. Security: positional federation peer URL could leak a password into telemetry

`federation add-peer <name> <url>` takes its connection target as a **positional**
operand, not a `--pg-url`/`--mysql-url` flag. The full DSN scrub added in #4712 was
keyed to those flag names, so a password embedded in a positional peer URL — e.g.
`postgres://u@h/db?password=SECRET` (query param / `sslpassword`) or a libpq keyword
form — fell through to the userinfo-only scrub and could reach the `bd.args` telemetry
root span. Idiomatic credentials via `--password`/`-p` and URL userinfo were already
redacted; this closes the residual positional entry point.

`dsnPositionalValues` resolves the `add-peer` `<url>` operand and `scrubArgsForTelemetry`
now routes it through the same parser-backed DSN scrub. It matches by **exact operand
value**, so the broad DSN scan never touches any other positional argument and ordinary
text is not over-redacted.

### 2. Maintainability: split the DSN password extractor

`dsnPasswordValues` combined URL-userinfo, URL-query, and libpq-keyword extraction in one
function. It is split into `addURLUserinfoPassword`, `addURLQueryPasswords`
(+`queryKeyIsPassword`), and `addLibpqKeywordPasswords`. The extraction is
behavior-preserving — the existing `pgdialect` redaction tests are the oracle — and each
resulting function is small and single-purpose.

### Tests

- Existing telemetry (`cmd/bd/telemetry_scrub_test.go`) and `pgdialect` redaction suites
  pass unchanged, proving behavior is preserved.
- New `TestScrubArgsForTelemetryRedactsPositionalPeerURL` covers the positional peer URL
  in `?password=`, `?sslpassword=`, and userinfo forms, and asserts an unlisted positional
  is not over-redacted.
- New `TestDSNPositionalValuesResolvesFederationAddPeerURL` covers the resolver, including
  the too-few-operands, wrong-parent, unrelated-command, and nil cases.

```
CGO_ENABLED=1 go test -tags gms_pure_go ./cmd/bd -run 'TestScrubArgsForTelemetry|TestSecretFlagTokens|TestDSNPositionalValues'
CGO_ENABLED=1 go test -tags gms_pure_go ./internal/storage/pgdialect
```
