### PR TITLE
fix(init): skip hooks for bootstrap commit

### DIFF
--- a/cmd/bd/init.go
+++ b/cmd/bd/init.go
@@ -1717,10 +1717,11 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 					giCmd := exec.Command("git", "add", ".gitignore")
 					_ = giCmd.Run()
 				}
-				// Hooks installed by this init can call back into bd. Skip them
-				// for the bootstrap commit to avoid self-deadlocking while init
-				// still owns the embedded Dolt lock.
-				commitArgs := []string{"commit", "--no-verify", "-m", "bd init: initialize beads issue tracking"}
+				// Hooks installed by this init can call back into bd. Skip all
+				// of them for the bootstrap commit to avoid self-deadlocking
+				// while init still owns the embedded Dolt lock. --no-verify
+				// alone does not skip prepare-commit-msg.
+				commitArgs := []string{"-c", "core.hooksPath=", "commit", "--no-verify", "-m", "bd init: initialize beads issue tracking"}
 				commitCmd := exec.Command("git", commitArgs...)
 				if commitOut, commitErr := commitCmd.CombinedOutput(); commitErr != nil {
 					if !quiet && !strings.Contains(string(commitOut), "nothing to commit") {

--- a/cmd/bd/init_embedded_test.go
+++ b/cmd/bd/init_embedded_test.go
@@ -1114,9 +1114,9 @@ func TestEmbeddedInit(t *testing.T) {
 	t.Run("auto_commit_bypasses_hooks", func(t *testing.T) {
 		dir := t.TempDir()
 		initGitRepoAt(t, dir)
-		preCommitPath := filepath.Join(dir, ".git", "hooks", "pre-commit")
-		preCommit := "#!/bin/sh\necho hook-fired >> .hook-ran\nexit 1\n"
-		if err := os.WriteFile(preCommitPath, []byte(preCommit), 0755); err != nil {
+		hookPath := filepath.Join(dir, ".git", "hooks", "prepare-commit-msg")
+		hook := "#!/bin/sh\necho hook-fired >> .hook-ran\nexit 1\n"
+		if err := os.WriteFile(hookPath, []byte(hook), 0755); err != nil {
 			t.Fatal(err)
 		}
 		unsetHooksPath := exec.Command("git", "config", "--unset", "core.hooksPath")

--- a/cmd/bd/init_proxied_server.go
+++ b/cmd/bd/init_proxied_server.go
@@ -426,8 +426,9 @@ func runInitProxiedServerTail(cmd *cobra.Command, ctx context.Context, in initPr
 				"CLAUDE.md",
 				".gitignore",
 			},
-			Message:  "bd init: initialize beads issue tracking",
-			NoVerify: true,
+			Message:   "bd init: initialize beads issue tracking",
+			NoVerify:  true,
+			SkipHooks: true,
 		})
 		switch {
 		case err != nil && !in.quiet:

--- a/internal/storage/domain/git.go
+++ b/internal/storage/domain/git.go
@@ -29,8 +29,9 @@ type GitRepository interface {
 }
 
 type GitCommitParams struct {
-	Message  string
-	NoVerify bool
+	Message   string
+	NoVerify  bool
+	SkipHooks bool
 }
 
 type GitCommitResult struct {
@@ -67,6 +68,7 @@ type CommitInitArtifactsParams struct {
 	OptionalPaths []string
 	Message       string
 	NoVerify      bool
+	SkipHooks     bool
 }
 
 type CommitInitArtifactsResult struct {
@@ -203,7 +205,11 @@ func (u *gitUseCaseImpl) CommitInitArtifacts(ctx context.Context, params CommitI
 		return CommitInitArtifactsResult{}, fmt.Errorf("CommitInitArtifacts: add: %w", err)
 	}
 
-	commit, err := u.repo.Commit(ctx, GitCommitParams{Message: params.Message, NoVerify: params.NoVerify})
+	commit, err := u.repo.Commit(ctx, GitCommitParams{
+		Message:   params.Message,
+		NoVerify:  params.NoVerify,
+		SkipHooks: params.SkipHooks,
+	})
 	if err != nil {
 		return CommitInitArtifactsResult{}, fmt.Errorf("CommitInitArtifacts: commit: %w", err)
 	}

--- a/internal/storage/domain/git/git.go
+++ b/internal/storage/domain/git/git.go
@@ -200,7 +200,11 @@ func (r *gitRepositoryImpl) Commit(ctx context.Context, params domain.GitCommitP
 	if params.Message == "" {
 		return domain.GitCommitResult{}, fmt.Errorf("git: Commit: Message must not be empty")
 	}
-	args := []string{"commit"}
+	args := []string{}
+	if params.SkipHooks {
+		args = append(args, "-c", "core.hooksPath=")
+	}
+	args = append(args, "commit")
 	if params.NoVerify {
 		args = append(args, "--no-verify")
 	}

--- a/internal/storage/domain/git/git_test.go
+++ b/internal/storage/domain/git/git_test.go
@@ -159,6 +159,18 @@ func (s *testSuite) TestCommit_NoVerifyBypassesHook() {
 	s.True(result.DidCommit)
 }
 
+func (s *testSuite) TestCommit_SkipHooksBypassesPrepareCommitMsgHook() {
+	s.gitInit()
+	hookPath := filepath.Join(s.tmpDir, ".git", "hooks", "prepare-commit-msg")
+	s.Require().NoError(os.WriteFile(hookPath, []byte("#!/bin/sh\nexit 1\n"), 0755)) //nolint:gosec // test hook
+	s.writeFile("a.txt", "x")
+	s.Require().NoError(s.repo.Add(s.Ctx(), "a.txt"))
+
+	result, err := s.repo.Commit(s.Ctx(), domain.GitCommitParams{Message: "test", SkipHooks: true})
+	s.Require().NoError(err)
+	s.True(result.DidCommit)
+}
+
 func (s *testSuite) TestCommit_NothingToCommitDidCommitFalse() {
 	s.gitInit()
 	s.writeFile("a.txt", "x")


### PR DESCRIPTION
## What

Fix `bd init` bootstrap commits so they skip every Git hook, including `prepare-commit-msg`.

## Why

`bd init` already intended to skip hooks for its bootstrap Git commit because init can still hold the embedded Dolt writer lock. The old command used `git commit --no-verify`, but Git still runs `prepare-commit-msg` with `--no-verify`. When that hook shells back into `bd`, the second process can wait on the writer lock until the hook timeout.

## Changes

- Use `git -c core.hooksPath= commit --no-verify` for the direct `bd init` bootstrap commit.
- Add an explicit internal `SkipHooks` option to the domain Git commit helper and use it for proxied init bootstrap commits.
- Update the embedded init hook-bypass regression to use `prepare-commit-msg`, the hook that `--no-verify` does not skip.
- Add a domain Git regression test for `SkipHooks` bypassing `prepare-commit-msg`.

## Validation

- `scripts/pr-preflight.sh --search "bd init hook deadlock bootstrap commit prepare-commit-msg" --repo gastownhall/beads`
- `source ./.buildflags && go test ./internal/storage/domain/git -run 'TestDomainGit/TestCommit_SkipHooksBypassesPrepareCommitMsgHook' -count=1`
- `source ./.buildflags && go test ./internal/storage/domain/git -count=1`
- `source ./.buildflags && go build ./cmd/bd/`
- `source ./.buildflags && BEADS_TEST_EMBEDDED_DOLT=1 go test ./cmd/bd/ -run '^TestEmbeddedInit$/not_quiet$' -count=1 -timeout 5m`
- `source ./.buildflags && BEADS_TEST_EMBEDDED_DOLT=1 go test ./cmd/bd/ -run '^TestEmbeddedInit$/auto_commit_bypasses_hooks$' -count=1 -timeout 5m`
- `source ./.buildflags && BEADS_TEST_EMBEDDED_DOLT=1 go test ./cmd/bd/ -run '^TestEmbeddedCreate$' -count=1 -timeout 10m`
- `git diff --check`

GitHub Actions on draft PR #4748: all checks passed, including PR core/lint/policy, differential regression, upgrade smoke, storage backend conformance, and the embedded Dolt command/conformance/storage matrix.

`BEADS_TEST_EMBEDDED_DOLT=1 go test ./cmd/bd/ -run 'TestEmbeddedCreate$/default_status'` completed quickly but reported `[no tests to run]` on current `upstream/main`; the available equivalent broader test is `TestEmbeddedCreate`, which passed.

`make test` was also run and failed in doctor tests outside the files changed by this PR:

- `github.com/steveyegge/beads/cmd/bd`: `TestDoctorWithBeadsDir` timed out after 3m.
- `github.com/steveyegge/beads/cmd/bd/doctor`: `TestCheckDocumentationBdPrimeReference/AGENTS.md_references_bd_prime` timed out after 3m.

I did not establish a clean `upstream/main` baseline for those failures in this run.

`golangci-lint run ./...` could not run in this environment because the installed `golangci-lint` binary was built with Go 1.24 while the repo targets Go 1.26.2.

## Review Notes

Local Fable and Codex adversarial review passes found no blocking issues after the embedded `prepare-commit-msg` regression test was added. Residual non-blocking risk: proxied init wiring is covered through the shared Git helper and audited, but the live proxied CLI suite was not run because it is explicitly environment-gated and this environment has a live system Dolt server.

_codex-unknown-model-unknown-reasoning on behalf of thewoolleyman_
