### PR TITLE
test(protocol): pin the §E/§M/§V conformance clauses at the CLI level (wy-ge2h8)

### DIFF
--- a/cmd/bd/protocol/errors_contract_test.go
+++ b/cmd/bd/protocol/errors_contract_test.go
@@ -1,0 +1,240 @@
+// errors_contract_test.go — protocol v0 §E (errors and exit codes), the
+// error-class half.
+//
+// E4 (error classes). Implementations MUST distinguish, in message and
+// structured output (NOT by exit code), at least: not-found, already-claimed
+// (naming the holder), not-claimable (naming the state), and validation. The
+// Go error values (storage.ErrAlreadyClaimed & co.) are accident; what an agent
+// branches on is the message and the --json shape, so that is what these tests
+// pin.
+//
+// E5 (structured errors). With --json, an error is a JSON object carrying at
+// least "error" (message), optionally "hint", and schema_version: 1.
+//
+// E1/E2 (empty is success, failure is nonzero) are pinned in exit_codes_test.go
+// and reinforced here: every error class below exits 1, none exits 0.
+package protocol
+
+import (
+	"strings"
+	"testing"
+)
+
+const (
+	actorAlice = "BEADS_ACTOR=alice"
+	actorBob   = "BEADS_ACTOR=bob"
+)
+
+// isNotFound reports whether a message expresses the not-found class. The
+// clause requires the CLASS to be recognizable, not one blessed phrase, so this
+// tolerates both spellings an implementation is likely to use ("not found",
+// "no issue found matching …") rather than freezing bd's current wording as
+// though it were the protocol.
+func isNotFound(msg string) bool {
+	lower := strings.ToLower(msg)
+	if strings.Contains(lower, "not found") {
+		return true
+	}
+	return (strings.Contains(lower, "no issue found") || strings.Contains(lower, "no issues found")) &&
+		strings.Contains(lower, "matching")
+}
+
+// TestProtocol_ErrorClass_NotFound pins the not-found class: a nonzero exit,
+// a message that expresses not-found, and a structured --json error (§E5).
+func TestProtocol_ErrorClass_NotFound(t *testing.T) {
+	t.Parallel()
+	w := newWorkspace(t)
+
+	out, code := w.runExpectError("show", "nonexistent-xyz")
+	if code == 0 {
+		t.Errorf("exit code = 0, want nonzero (§E2)")
+	}
+	if !isNotFound(out) {
+		t.Errorf("message does not express the not-found class (§E4):\n%s", out)
+	}
+	if !strings.Contains(out, "nonexistent-xyz") {
+		t.Errorf("not-found message does not name the missing id (§E4):\n%s", out)
+	}
+
+	jsonOut, jsonCode := w.runExpectError("show", "nonexistent-xyz", "--json")
+	if jsonCode == 0 {
+		t.Errorf("--json exit code = 0, want nonzero (§E2)")
+	}
+	obj := requireJSONError(t, jsonOut, "not-found --json")
+	if !isNotFound(errorMessage(obj)) {
+		t.Errorf("--json error message does not express the not-found class (§E4/§E5): %q", errorMessage(obj))
+	}
+}
+
+// TestProtocol_ErrorClass_AlreadyClaimedNamesHolder pins the already-claimed
+// class (§E4, §L2.4): claiming an issue another actor holds must fail with a
+// message that NAMES THE HOLDER — an agent that cannot see who holds the claim
+// cannot decide whether to wait, escalate, or move on.
+func TestProtocol_ErrorClass_AlreadyClaimedNamesHolder(t *testing.T) {
+	t.Parallel()
+	w := newWorkspace(t)
+	id := w.create("Contended issue")
+
+	w.runEnv([]string{actorAlice}, "update", id, "--claim")
+
+	out, code := w.runEnvExpectError([]string{actorBob}, "update", id, "--claim")
+	if code == 0 {
+		t.Errorf("exit code = 0, want nonzero (§L2.4)")
+	}
+	lower := strings.ToLower(out)
+	if !strings.Contains(lower, "already claimed") {
+		t.Errorf("message does not identify the already-claimed class (§E4):\n%s", out)
+	}
+	if !strings.Contains(out, "alice") {
+		t.Errorf("message does not name the holder (§E4/§L2.4):\n%s", out)
+	}
+}
+
+// TestProtocol_ErrorClass_NotClaimableNamesState pins the not-claimable class
+// (§E4): claiming an issue that is in a non-claimable STATE (here: closed) is a
+// different failure from already-claimed, and the message must name the state.
+// Distinguishing the two is the whole point of the clause — "retry later" is
+// right for a contended claim and wrong for a closed issue.
+func TestProtocol_ErrorClass_NotClaimableNamesState(t *testing.T) {
+	t.Parallel()
+	w := newWorkspace(t)
+	id := w.create("Closed issue")
+	w.run("close", id)
+
+	out, code := w.runEnvExpectError([]string{actorBob}, "update", id, "--claim")
+	if code == 0 {
+		t.Errorf("exit code = 0, want nonzero (§E2)")
+	}
+	lower := strings.ToLower(out)
+	if !strings.Contains(lower, "not claimable") {
+		t.Errorf("message does not identify the not-claimable class (§E4):\n%s", out)
+	}
+	if !strings.Contains(lower, "closed") {
+		t.Errorf("message does not name the blocking state (§E4):\n%s", out)
+	}
+}
+
+// TestProtocol_ErrorClass_ClaimFailures_StructuredJSON is the §E5 half of the
+// claim error classes — and it is SKIPPED because bd-go does not satisfy it
+// today (wy-kxgf4).
+//
+// bd routes not-found through the JSON-respecting error helper, so
+// `bd show <missing> --json` emits {error, schema_version:1} (pinned above).
+// The claim path does not: `bd update <id> --claim --json` prints
+//
+//	Error claiming t04…-qqr: issue already claimed by alice
+//
+// as plain text, so an agent driving bd with --json gets an unparseable stderr
+// line for the single most common contended-write failure it must branch on.
+// The message contract (§E4) holds; the structured contract (§E5) does not.
+//
+// Per proposal §14, where bd's behavior deviates from a clause the clause wins
+// and the deviation is a bug — so this test asserts the clause and stays
+// skipped until wy-kxgf4 lands, at which point it becomes the guardrail.
+func TestProtocol_ErrorClass_ClaimFailures_StructuredJSON(t *testing.T) {
+	t.Skip("bd emits claim failures as plain text even with --json; violates §E5 (wy-kxgf4)")
+
+	t.Parallel()
+	w := newWorkspace(t)
+
+	claimed := w.create("Held by alice")
+	w.runEnv([]string{actorAlice}, "update", claimed, "--claim")
+
+	closed := w.create("Closed")
+	w.run("close", closed)
+
+	// already-claimed: structured, and still naming the holder.
+	out, _ := w.runEnvExpectError([]string{actorBob}, "update", claimed, "--claim", "--json")
+	obj := requireJSONError(t, out, "already-claimed --json")
+	msg := errorMessage(obj)
+	if !strings.Contains(strings.ToLower(msg), "already claimed") || !strings.Contains(msg, "alice") {
+		t.Errorf("--json error does not name class + holder (§E4/§E5): %q", msg)
+	}
+
+	// not-claimable: structured, and still naming the state.
+	out, _ = w.runEnvExpectError([]string{actorBob}, "update", closed, "--claim", "--json")
+	obj = requireJSONError(t, out, "not-claimable --json")
+	msg = strings.ToLower(errorMessage(obj))
+	if !strings.Contains(msg, "not claimable") || !strings.Contains(msg, "closed") {
+		t.Errorf("--json error does not name class + state (§E4/§E5): %q", errorMessage(obj))
+	}
+}
+
+// TestProtocol_ErrorClass_Validation pins the validation class (§E4): a
+// malformed argument fails with a message about the argument, and is NOT
+// reported as a not-found.
+func TestProtocol_ErrorClass_Validation(t *testing.T) {
+	t.Parallel()
+	w := newWorkspace(t)
+	id := w.create("Valid issue")
+
+	out, code := w.runExpectError("update", id, "--status", "not_a_status")
+	if code == 0 {
+		t.Errorf("exit code = 0, want nonzero (§E2)")
+	}
+	lower := strings.ToLower(out)
+	if !strings.Contains(lower, "status") {
+		t.Errorf("validation message does not name the offending input (§E4):\n%s", out)
+	}
+	if strings.Contains(lower, "not found") {
+		t.Errorf("validation failure misreported as not-found (§E4):\n%s", out)
+	}
+}
+
+// TestProtocol_ErrorClasses_AreDistinguishable is the clause itself (§E4): the
+// three claim-adjacent failures — not-found, already-claimed, not-claimable —
+// must be told apart from the message alone. Exit codes deliberately do NOT
+// distinguish them in v0 (§E2), so if the messages collapse, an agent has
+// nothing left to branch on.
+func TestProtocol_ErrorClasses_AreDistinguishable(t *testing.T) {
+	t.Parallel()
+	w := newWorkspace(t)
+
+	claimed := w.create("Held by alice")
+	w.runEnv([]string{actorAlice}, "update", claimed, "--claim")
+
+	closed := w.create("Closed")
+	w.run("close", closed)
+
+	notFoundOut, notFoundCode := w.runExpectError("update", "nonexistent-xyz", "--claim")
+	claimedOut, claimedCode := w.runEnvExpectError([]string{actorBob}, "update", claimed, "--claim")
+	closedOut, closedCode := w.runEnvExpectError([]string{actorBob}, "update", closed, "--claim")
+
+	// §E2: all three fail nonzero. §E4: none of them may be told apart by the
+	// exit code — the message carries the class.
+	for name, code := range map[string]int{
+		"not-found":       notFoundCode,
+		"already-claimed": claimedCode,
+		"not-claimable":   closedCode,
+	} {
+		if code == 0 {
+			t.Errorf("%s: exit code = 0, want nonzero (§E2)", name)
+		}
+	}
+
+	// Each class is recognized by its own predicate, and must be recognized by
+	// EXACTLY one: a message that reads as two classes at once (or as none) is
+	// as useless to an agent as a shared exit code.
+	recognizers := map[string]func(string) bool{
+		"not-found":       isNotFound,
+		"already-claimed": func(s string) bool { return strings.Contains(strings.ToLower(s), "already claimed") },
+		"not-claimable":   func(s string) bool { return strings.Contains(strings.ToLower(s), "not claimable") },
+	}
+	outputs := map[string]string{
+		"not-found":       notFoundOut,
+		"already-claimed": claimedOut,
+		"not-claimable":   closedOut,
+	}
+	for class, out := range outputs {
+		var matched []string
+		for name, recognize := range recognizers {
+			if recognize(out) {
+				matched = append(matched, name)
+			}
+		}
+		if len(matched) != 1 || matched[0] != class {
+			t.Errorf("%s failure is recognized as %v, want exactly [%s] — the classes are not distinguishable from the message (§E4):\n%s",
+				class, matched, class, out)
+		}
+	}
+}

--- a/cmd/bd/protocol/exit_codes_init_test.go
+++ b/cmd/bd/protocol/exit_codes_init_test.go
@@ -1,0 +1,286 @@
+// exit_codes_init_test.go — protocol v0 §E3 (documented-stable exit codes).
+//
+// Beyond 0 (success) and 1 (general failure), v0 freezes four exit codes as
+// scriptable API:
+//
+//	10  init-safety: remote divergence refused
+//	11  init-safety: local data exists, refused
+//	12  init-safety: destroy-token missing or wrong
+//	130 interactive prompt canceled (SIGINT)
+//
+// The clause is about the NUMBERS, not about bd's Go constants, so these tests
+// assert the literals: a conforming implementation with a different internal
+// spelling still has to exit 10 when it refuses a divergent init. New stable
+// codes require a spec revision.
+//
+// These tests drive `bd init`, which refuses before it opens any store, so they
+// need no Dolt fixture — only a built binary and a temp git repo.
+package protocol
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// Literal exit codes frozen by §E3. Deliberately NOT bd's Go constants: the
+// corpus pins the wire contract an agent scripts against.
+const (
+	exitRemoteDivergenceRefused = 10
+	exitLocalExistsRefused      = 11
+	exitDestroyTokenMissing     = 12
+	exitPromptCanceled          = 130
+)
+
+// initEnv is a clean environment for a bd init subprocess. It strips any
+// ambient beads workspace so the init under test resolves only from the
+// process's working directory, and pins the test Dolt server when one is
+// running so a successful init can never reach a real database.
+//
+// home MUST NOT be the repo the init runs in: bd keeps a user-level ~/.beads
+// alongside the workspace-level one, so pointing HOME at the repo would make
+// "did the refusal create .beads/?" unanswerable.
+func initEnv(home string, extra ...string) []string {
+	env := []string{
+		"PATH=" + os.Getenv("PATH"),
+		"HOME=" + home,
+		"XDG_CONFIG_HOME=" + filepath.Join(home, "xdg-config"),
+		"GIT_CONFIG_NOSYSTEM=1",
+		"BEADS_TEST_MODE=1",
+		// See the note in helpers_test.go env(): the detached metrics child
+		// writes under HOME after bd exits and races t.TempDir() cleanup.
+		"BD_DISABLE_METRICS=1",
+		"BEADS_DB=",
+		"BEADS_DIR=",
+	}
+	if testDoltPort > 0 {
+		env = append(env, "BEADS_DOLT_PORT="+strconv.Itoa(testDoltPort))
+	}
+	if v := os.Getenv("TMPDIR"); v != "" {
+		env = append(env, "TMPDIR="+v)
+	}
+	return append(env, extra...)
+}
+
+func gitIn(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	if dir != "" {
+		cmd.Dir = dir
+	}
+	cmd.Env = initEnv(t.TempDir())
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, out)
+	}
+}
+
+// cloneOfRemoteWithDoltData returns a fresh, un-initialized git repo whose
+// origin advertises refs/dolt/data — the state that makes `bd init` refuse a
+// local-source init rather than orphan the remote's history.
+func cloneOfRemoteWithDoltData(t *testing.T) string {
+	t.Helper()
+
+	bare := filepath.Join(t.TempDir(), "bare.git")
+	gitIn(t, "", "init", "--bare", bare)
+
+	source := t.TempDir()
+	gitIn(t, source, "init", "-b", "main")
+	gitIn(t, source, "config", "user.email", "test@protocol.test")
+	gitIn(t, source, "config", "user.name", "protocol-test")
+	gitIn(t, source, "commit", "--allow-empty", "-m", "init")
+	gitIn(t, source, "remote", "add", "origin", bare)
+	gitIn(t, source, "push", "origin", "main")
+	gitIn(t, source, "push", "origin", "HEAD:refs/dolt/data")
+
+	clone := t.TempDir()
+	gitIn(t, clone, "init", "-b", "main")
+	gitIn(t, clone, "remote", "add", "origin", bare)
+	gitIn(t, clone, "config", "core.hooksPath", ".git/hooks")
+	return clone
+}
+
+// runInitExpectRefusal runs bd init in dir and returns combined output + exit
+// code, requiring a non-zero exit.
+func runInitExpectRefusal(t *testing.T, dir string, args ...string) (string, int) {
+	t.Helper()
+	cmd := exec.Command(buildBD(t), append([]string{"init"}, args...)...)
+	cmd.Dir = dir
+	cmd.Env = initEnv(t.TempDir())
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("bd init %s: expected refusal, got success\n%s", strings.Join(args, " "), out)
+	}
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("bd init %s: unexpected error type: %v\n%s", strings.Join(args, " "), err, out)
+	}
+	return string(out), exitErr.ExitCode()
+}
+
+// TestProtocol_ExitCode10_RemoteDivergenceRefused pins §E3's exit 10: a
+// local-source init (--force) against an origin that already advertises
+// refs/dolt/data must refuse with 10, not with the generic failure code 1 — a
+// CI script branches on the difference between "you would have orphaned remote
+// history" and "something went wrong".
+func TestProtocol_ExitCode10_RemoteDivergenceRefused(t *testing.T) {
+	t.Parallel()
+	clone := cloneOfRemoteWithDoltData(t)
+
+	out, code := runInitExpectRefusal(t, clone,
+		"--force", "--prefix", "pe3", "--quiet", "--non-interactive", "--skip-hooks", "--skip-agents")
+	if code != exitRemoteDivergenceRefused {
+		t.Errorf("exit code = %d, want %d (§E3 remote-divergence refusal)\n%s", code, exitRemoteDivergenceRefused, out)
+	}
+
+	// A refusal must not half-init the workspace.
+	if _, err := os.Stat(filepath.Join(clone, ".beads")); err == nil {
+		t.Errorf("refusal created .beads/ — refusal must be a no-op")
+	}
+}
+
+// TestProtocol_ExitCode12_DestroyTokenMissing pins §E3's exit 12: authorizing
+// the cross-boundary operation (--discard-remote) without the destroy token, in
+// non-interactive mode, is its own refusal class — distinct from 10, so an
+// agent can tell "you must authorize this" from "you must supply the token".
+func TestProtocol_ExitCode12_DestroyTokenMissing(t *testing.T) {
+	t.Parallel()
+	clone := cloneOfRemoteWithDoltData(t)
+
+	out, code := runInitExpectRefusal(t, clone,
+		"--discard-remote", "--prefix", "pe3", "--quiet", "--non-interactive", "--skip-hooks", "--skip-agents")
+	if code != exitDestroyTokenMissing {
+		t.Errorf("exit code = %d, want %d (§E3 destroy-token refusal)\n%s", code, exitDestroyTokenMissing, out)
+	}
+	if code == exitRemoteDivergenceRefused {
+		t.Errorf("destroy-token refusal collapsed into the divergence code — §E3 codes must stay distinct")
+	}
+}
+
+// TestProtocol_ExitCode11_LocalExistsRefused is the §E3 gap: exit 11 is
+// returned only from the INTERACTIVE typed-confirmation abort in
+// `bd init --reinit-local` (cmd/bd/init.go, guarded by term.IsTerminal on
+// stdin). The non-interactive branch of the same guard returns 12 instead, so
+// no piped-stdin subprocess can produce 11 — pinning it needs a PTY-backed run
+// helper, tracked in wy-vh5y8. Un-skip when that lands.
+func TestProtocol_ExitCode11_LocalExistsRefused(t *testing.T) {
+	t.Skip("exit 11 is reachable only through an interactive TTY prompt; needs a PTY harness (wy-vh5y8)")
+	_ = exitLocalExistsRefused
+}
+
+// TestProtocol_ExitCode130_PromptCanceled pins §E3's exit 130: SIGINT at an
+// interactive prompt exits 130 (the shell convention, 128+SIGINT), not 1. An
+// agent supervising a bd subprocess uses this to tell "the operator canceled"
+// from "the command failed".
+func TestProtocol_ExitCode130_PromptCanceled(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("no SIGINT on Windows")
+	}
+	t.Parallel()
+
+	dir := t.TempDir()
+	gitIn(t, dir, "init", "-b", "main")
+
+	stdinR, stdinW, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("stdin pipe: %v", err)
+	}
+	defer func() { _ = stdinW.Close() }()
+
+	outR, outW, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("stdout pipe: %v", err)
+	}
+	defer func() { _ = outR.Close() }()
+
+	cmd := exec.Command(buildBD(t), "init", "--prefix", "pe3", "--contributor")
+	cmd.Dir = dir
+	cmd.Stdin = stdinR
+	cmd.Stdout = outW
+	cmd.Stderr = outW
+	// BD_NON_INTERACTIVE=0 keeps the prompt alive in a pipe-driven subprocess;
+	// without it bd would take the non-interactive path and never prompt.
+	cmd.Env = initEnv(t.TempDir(), "BD_NON_INTERACTIVE=0", "CI=")
+
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start bd init: %v", err)
+	}
+	_ = stdinR.Close()
+	_ = outW.Close()
+
+	var (
+		mu         sync.Mutex
+		output     bytes.Buffer
+		promptSeen = make(chan struct{})
+		once       sync.Once
+		readerDone = make(chan struct{})
+	)
+	prompts := [][]byte{
+		[]byte("Continue with contributor setup? [y/N]: "),
+		[]byte("Continue anyway? [y/N]: "),
+	}
+	go func() {
+		defer close(readerDone)
+		buf := make([]byte, 1024)
+		for {
+			n, err := outR.Read(buf)
+			if n > 0 {
+				mu.Lock()
+				output.Write(buf[:n])
+				for _, p := range prompts {
+					if bytes.Contains(output.Bytes(), p) {
+						once.Do(func() { close(promptSeen) })
+						break
+					}
+				}
+				mu.Unlock()
+			}
+			if err != nil {
+				return
+			}
+		}
+	}()
+
+	waitCh := make(chan error, 1)
+	go func() { waitCh <- cmd.Wait() }()
+
+	got := func() string {
+		mu.Lock()
+		defer mu.Unlock()
+		return output.String()
+	}
+
+	select {
+	case <-promptSeen:
+		if err := cmd.Process.Signal(os.Interrupt); err != nil {
+			t.Fatalf("send SIGINT: %v", err)
+		}
+	case err := <-waitCh:
+		t.Fatalf("bd init exited before prompting: %v\n%s", err, got())
+	case <-time.After(15 * time.Second):
+		_ = cmd.Process.Kill()
+		<-waitCh
+		t.Fatalf("timed out waiting for the prompt\n%s", got())
+	}
+
+	err = <-waitCh
+	select {
+	case <-readerDone:
+	case <-time.After(2 * time.Second):
+	}
+
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("canceled init: expected a non-zero exit, got %v\n%s", err, got())
+	}
+	if code := exitErr.ExitCode(); code != exitPromptCanceled {
+		t.Errorf("exit code = %d, want %d (§E3 prompt cancel)\n%s", code, exitPromptCanceled, got())
+	}
+}

--- a/cmd/bd/protocol/helpers_test.go
+++ b/cmd/bd/protocol/helpers_test.go
@@ -215,6 +215,13 @@ func (w *workspace) env() []string {
 		"HOME=" + w.dir,
 		"GIT_CONFIG_NOSYSTEM=1",
 		"BEADS_TEST_MODE=1",
+		// Metrics off. Two reasons, one of them a test-stability bug: bd spawns a
+		// DETACHED `bd send-metrics` child that writes $HOME/.beads/eventsData
+		// after the parent exits, and HOME here is the t.TempDir() workspace — so
+		// the child races Go's RemoveAll and the test fails its own cleanup with
+		// "unlinkat …: directory not empty". (The other reason: a test suite
+		// should not ship telemetry.)
+		"BD_DISABLE_METRICS=1",
 	}
 	if testDoltPort > 0 {
 		env = append(env, "BEADS_DOLT_PORT="+strconv.Itoa(testDoltPort))

--- a/cmd/bd/protocol/memory_contract_test.go
+++ b/cmd/bd/protocol/memory_contract_test.go
@@ -1,0 +1,105 @@
+// memory_contract_test.go — protocol v0 §M (memories).
+//
+// M1 (model). A memory is a (key, value) pair in a namespace separate from
+// issues, with the surface: bd remember / bd memories (list, search) /
+// bd recall <key> / bd forget <key>. This file pins that CRUD surface at the
+// CLI level — the four verbs, the round trip through the store, and the
+// post-forget disappearance.
+//
+// M4 (reserved namespace). The memory keyspace is reserved to the memory
+// commands: a generic KV surface MUST NOT write into it. bd stores memories as
+// kv.memory.* rows, so an unbarred `bd kv set memory.x` would mint something
+// indistinguishable from a `bd remember` memory — and the merge resolver
+// auto-resolves kv.memory.* conflicts with --theirs (GH#2474), so a remote pull
+// could silently overwrite the operator's deliberate KV value. The bar is what
+// keeps the namespace owned.
+package protocol
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestProtocol_MemoryCRUDSurface pins §M1: the remember → recall → list →
+// search → forget cycle over the frozen CLI surface.
+func TestProtocol_MemoryCRUDSurface(t *testing.T) {
+	t.Parallel()
+	w := newWorkspace(t)
+
+	const (
+		key  = "auth-jwt"
+		text = "auth module uses JWT not sessions"
+	)
+
+	// Create.
+	w.run("remember", text, "--key", key)
+
+	// Read by key.
+	recalled := w.run("recall", key)
+	if !strings.Contains(recalled, text) {
+		t.Errorf("bd recall %s did not return the stored value (§M1):\n%s", key, recalled)
+	}
+
+	// List.
+	list := w.run("memories")
+	if !strings.Contains(list, key) {
+		t.Errorf("bd memories does not list the stored key (§M1):\n%s", list)
+	}
+
+	// Search (bd memories <term>).
+	found := w.run("memories", "JWT")
+	if !strings.Contains(found, text) {
+		t.Errorf("bd memories JWT did not match the stored memory (§M1):\n%s", found)
+	}
+
+	// Update in place: same key, new value.
+	const updated = "auth module uses JWT with a 15m TTL"
+	w.run("remember", updated, "--key", key)
+	recalled = w.run("recall", key)
+	if !strings.Contains(recalled, updated) {
+		t.Errorf("bd remember --key did not overwrite in place (§M1):\n%s", recalled)
+	}
+
+	// Delete.
+	w.run("forget", key)
+	if _, code := w.runExpectError("recall", key); code == 0 {
+		t.Errorf("bd recall after forget exited 0, want nonzero (§M1/§E2)")
+	}
+	if list := w.run("memories"); strings.Contains(list, key) {
+		t.Errorf("forgotten key still listed by bd memories (§M1):\n%s", list)
+	}
+}
+
+// TestProtocol_MemoryReservedNamespace pins §M4: the generic KV surface must
+// refuse to write into the memory namespace, and the refusal must point at the
+// commands that own it.
+func TestProtocol_MemoryReservedNamespace(t *testing.T) {
+	t.Parallel()
+	w := newWorkspace(t)
+
+	// Control: an ordinary KV key is accepted, so the refusal below is about the
+	// namespace and not about `bd kv set` being broken.
+	w.run("kv", "set", "deploy-target", "staging")
+	if got := w.run("kv", "get", "deploy-target"); !strings.Contains(got, "staging") {
+		t.Fatalf("bd kv set/get round trip failed for an ordinary key:\n%s", got)
+	}
+
+	for _, key := range []string{"memory.auth-jwt", "memory.nested.key"} {
+		out, code := w.runExpectError("kv", "set", key, "smuggled")
+		if code == 0 {
+			t.Errorf("bd kv set %s exited 0, want refusal (§M4)", key)
+		}
+		lower := strings.ToLower(out)
+		if !strings.Contains(lower, "reserved") {
+			t.Errorf("bd kv set %s: refusal does not say the namespace is reserved (§M4):\n%s", key, out)
+		}
+		if !strings.Contains(lower, "bd remember") {
+			t.Errorf("bd kv set %s: refusal does not name the owning command (§M4):\n%s", key, out)
+		}
+	}
+
+	// The bar must not have leaked a value into the memory namespace.
+	if out := w.run("memories"); strings.Contains(out, "smuggled") {
+		t.Errorf("a refused kv set still reached the memory namespace (§M4):\n%s", out)
+	}
+}

--- a/cmd/bd/protocol/versioning_contract_test.go
+++ b/cmd/bd/protocol/versioning_contract_test.go
@@ -1,0 +1,169 @@
+// versioning_contract_test.go — protocol v0 §V (versioning and migration), at
+// the CLI level.
+//
+// V2 (designated migrator). An implementation MUST NOT auto-migrate a database
+// that has a replication remote configured. Independent migration of two
+// replicas is the canonical schema-fork generator (GH#4259): both clones apply
+// the same pending migration in place, the histories diverge, and `bd dolt pull`
+// can no longer merge them. The gate refuses the silent in-place migration and
+// makes the operator choose migrate-as-the-designated-migrator
+// (BD_ALLOW_REMOTE_MIGRATE=1) or adopt-the-remote.
+//
+// V3 (version skew). An older implementation opening a NEWER database MUST
+// refuse by default with a clear version statement, not half-work — a stale
+// binary querying a migrated schema fails with cryptic "column X could not be
+// found" errors deep in unrelated commands. An explicit override
+// (BD_IGNORE_SCHEMA_SKEW=1) MAY downgrade the refusal to a warning; accepting
+// partial failure is the documented cost, never the default.
+//
+// Both clauses are properties of the DATABASE, so each test stages its
+// precondition with a store fixture (writing schema_migrations behind bd's
+// back — proposal §14 explicitly allows this) and then asserts the behavior
+// through the frozen CLI surface.
+package protocol
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/storage/schema"
+)
+
+// TestProtocol_V3_SchemaSkewRefusal pins §V3: a database ahead of the binary is
+// refused, the refusal states both versions, and --json carries a structured
+// skew block.
+func TestProtocol_V3_SchemaSkewRefusal(t *testing.T) {
+	t.Parallel()
+	w := newWorkspace(t)
+
+	// Stage a database one migration AHEAD of this binary: from bd's point of
+	// view it is now the stale implementation.
+	ahead := stageDatabaseAheadOfBinary(t, w)
+
+	out, code := w.runExpectError("list")
+	if code == 0 {
+		t.Fatalf("bd list against a newer database exited 0 — §V3 requires a refusal\n%s", out)
+	}
+	if !strings.Contains(strings.ToLower(out), "schema version mismatch") {
+		t.Errorf("refusal does not state the skew (§V3):\n%s", out)
+	}
+	// "not half-work": the refusal must name both versions so the operator can
+	// see which side is stale.
+	if !strings.Contains(out, "v"+strconv.Itoa(ahead)) || !strings.Contains(out, "v"+strconv.Itoa(schema.LatestVersion())) {
+		t.Errorf("refusal does not name both DB (v%d) and binary (v%d) versions (§V3):\n%s",
+			ahead, schema.LatestVersion(), out)
+	}
+
+	jsonOut, _ := w.runExpectError("list", "--json")
+	obj := requireJSONError(t, jsonOut, "schema-skew --json")
+	skew, ok := obj["schema_skew"].(map[string]any)
+	if !ok {
+		t.Fatalf("--json refusal carries no schema_skew block (§V3/§E5):\n%s", jsonOut)
+	}
+	if got, want := skew["current_version"], float64(ahead); got != want {
+		t.Errorf("schema_skew.current_version = %v, want %v", got, want)
+	}
+	if got, want := skew["required_version"], float64(schema.LatestVersion()); got != want {
+		t.Errorf("schema_skew.required_version = %v, want %v", got, want)
+	}
+}
+
+// TestProtocol_V3_SkewOverrideDowngradesToWarning pins the second half of §V3:
+// the explicit override downgrades the refusal to a warning, and the command
+// runs. The override is the escape hatch the refusal itself advertises; if it
+// stopped working, the refusal would be a dead end.
+func TestProtocol_V3_SkewOverrideDowngradesToWarning(t *testing.T) {
+	t.Parallel()
+	w := newWorkspace(t)
+	id := w.create("Readable under skew")
+
+	stageDatabaseAheadOfBinary(t, w)
+
+	// Default: refused.
+	if _, code := w.runExpectError("list"); code == 0 {
+		t.Fatal("skewed database was not refused by default (§V3)")
+	}
+
+	// Override: proceeds, and warns that it is doing so.
+	out := w.runEnv([]string{"BD_IGNORE_SCHEMA_SKEW=1"}, "list", "--json")
+	if !strings.Contains(out, id) {
+		t.Errorf("BD_IGNORE_SCHEMA_SKEW=1 did not let the read through (§V3):\n%s", out)
+	}
+	if !strings.Contains(strings.ToLower(out), "warning") {
+		t.Errorf("override proceeded silently — §V3 requires the downgraded refusal to still warn:\n%s", out)
+	}
+}
+
+// TestProtocol_V2_RemoteMigrateGate pins §V2: a behind, remote-backed database
+// is NOT auto-migrated. The gate must fire on the write path with a message
+// that names the pending migrations and the two ways out.
+func TestProtocol_V2_RemoteMigrateGate(t *testing.T) {
+	t.Parallel()
+	w := newWorkspace(t)
+
+	stageBehindRemoteBackedDB(t, w)
+
+	// BD_SMART_GATE=0 pins the blunt gate: the smart router (GH#4516) can
+	// auto-resolve provably-safe cases, which is a bd refinement, not the v0
+	// clause. The clause is "MUST NOT auto-migrate a remote-backed database" —
+	// that is what this asserts.
+	out, code := w.runEnvExpectError([]string{"BD_SMART_GATE=0", "BD_ALLOW_REMOTE_MIGRATE=0"},
+		"create", "Should not get through the gate")
+	if code == 0 {
+		t.Fatalf("a behind, remote-backed database was auto-migrated — §V2 requires a refusal\n%s", out)
+	}
+	lower := strings.ToLower(out)
+	if !strings.Contains(lower, "migrat") {
+		t.Errorf("gate refusal does not mention migration (§V2):\n%s", out)
+	}
+	if !strings.Contains(lower, "remote") {
+		t.Errorf("gate refusal does not name the remote as the reason (§V2):\n%s", out)
+	}
+}
+
+// TestProtocol_V2_DesignatedMigratorOverride pins the other half of §V2: the
+// operator who has decided to be the single designated migrator gets through
+// with BD_ALLOW_REMOTE_MIGRATE=1, and the database is migrated (the write
+// lands). A gate with no deliberate way through would just be a wall.
+func TestProtocol_V2_DesignatedMigratorOverride(t *testing.T) {
+	t.Parallel()
+	w := newWorkspace(t)
+
+	stageBehindRemoteBackedDB(t, w)
+
+	out := w.runEnv([]string{"BD_SMART_GATE=0", "BD_ALLOW_REMOTE_MIGRATE=1"},
+		"create", "Designated migrator writes")
+	if strings.TrimSpace(out) == "" {
+		t.Fatal("bd create produced no output under BD_ALLOW_REMOTE_MIGRATE=1")
+	}
+
+	// The migration was applied, so the gate no longer fires: a plain command
+	// (no override) now succeeds against the same remote-backed database.
+	w.runEnv([]string{"BD_SMART_GATE=0", "BD_ALLOW_REMOTE_MIGRATE=0"}, "list")
+}
+
+// stageDatabaseAheadOfBinary records a migration this binary does not know
+// about, so the next bd command opens a database from the future. Returns that
+// version.
+func stageDatabaseAheadOfBinary(t *testing.T, w *workspace) int {
+	t.Helper()
+	ahead := schema.LatestVersion() + 1
+	w.storeExec(t, fmt.Sprintf(
+		"INSERT INTO schema_migrations (version, content_hash) VALUES (%d, '%s')",
+		ahead, strings.Repeat("f", 64)))
+	return ahead
+}
+
+// stageBehindRemoteBackedDB makes the workspace's database look like a clone
+// that upgraded its binary but not its schema: one migration pending, and a
+// Dolt remote configured. Both halves are required — the gate exists to stop
+// exactly that combination, and neither alone is a fork risk.
+func stageBehindRemoteBackedDB(t *testing.T, w *workspace) {
+	t.Helper()
+	w.storeExec(t, fmt.Sprintf("DELETE FROM schema_migrations WHERE version = %d", schema.LatestVersion()))
+	// The remote is never contacted: the gate reads dolt_remotes to learn that
+	// this database replicates somewhere, which is all the clause turns on.
+	w.storeExec(t, fmt.Sprintf("CALL DOLT_REMOTE('add', 'origin', 'file://%s')", t.TempDir()))
+}

--- a/cmd/bd/protocol/wp4_helpers_test.go
+++ b/cmd/bd/protocol/wp4_helpers_test.go
@@ -1,0 +1,198 @@
+// wp4_helpers_test.go — shared helpers for the errors / memories / versioning
+// contract tests (protocol v0 §E, §M, §V).
+//
+// Two things the base workspace harness does not do:
+//
+//  1. Run bd with extra environment. The versioning clauses (V2/V3) are gated
+//     on env vars (BD_ALLOW_REMOTE_MIGRATE, BD_IGNORE_SCHEMA_SKEW) and the
+//     claim error classes (E4) need two distinct actors, so these tests need to
+//     append to the workspace's fixed environment.
+//
+//  2. Reach the store directly. V2 (pending migration) and V3 (database ahead
+//     of the binary) are properties of the *database*, not of any bd command —
+//     the only way to stage them is to write the schema-cursor table behind
+//     bd's back. That is the "store fixture" the conformance corpus explicitly
+//     allows (proposal §14): the assertion still runs against the frozen CLI
+//     surface, only the precondition is staged out-of-band.
+package protocol
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// command builds a bd invocation in the workspace with extra environment
+// appended to the workspace's fixed env.
+func (w *workspace) command(extraEnv []string, args ...string) *exec.Cmd {
+	cmd := exec.Command(w.bd, args...)
+	cmd.Dir = w.dir
+	cmd.Env = append(w.env(), extraEnv...)
+	return cmd
+}
+
+// exitCodeOf unwraps the process exit code from an *exec.ExitError.
+func exitCodeOf(t *testing.T, err error, args []string) int {
+	t.Helper()
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("bd %s: unexpected error type: %v", strings.Join(args, " "), err)
+	}
+	return exitErr.ExitCode()
+}
+
+// runEnv runs bd with extra environment appended, expecting success.
+func (w *workspace) runEnv(extraEnv []string, args ...string) string {
+	w.t.Helper()
+	out, err := w.tryRunEnv(extraEnv, args...)
+	if err != nil {
+		w.t.Fatalf("bd %s (env %v): %v\n%s", strings.Join(args, " "), extraEnv, err, out)
+	}
+	return out
+}
+
+// tryRunEnv runs bd with extra environment appended, returning output and error.
+func (w *workspace) tryRunEnv(extraEnv []string, args ...string) (string, error) {
+	w.t.Helper()
+	cmd := w.command(extraEnv, args...)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+// runEnvExpectError runs bd with extra environment appended, expecting a
+// non-zero exit. Returns the combined output and the exit code.
+func (w *workspace) runEnvExpectError(extraEnv []string, args ...string) (string, int) {
+	w.t.Helper()
+	out, err := w.tryRunEnv(extraEnv, args...)
+	if err == nil {
+		w.t.Fatalf("bd %s (env %v): expected non-zero exit, got success\nOutput: %s",
+			strings.Join(args, " "), extraEnv, out)
+	}
+	code := exitCodeOf(w.t, err, args)
+	return out, code
+}
+
+// ---------------------------------------------------------------------------
+// Structured-error helpers (§E5)
+// ---------------------------------------------------------------------------
+
+// jsonErrorFrom extracts the structured error object from a failed --json
+// command's output. bd emits JSON errors on stderr for some paths and stdout
+// for others (proposal OQ-5), and other lines may share the stream, so the
+// object is located rather than assumed to be the whole output.
+//
+// It returns the first JSON object in the output that carries an "error" key,
+// unwrapping the BD_JSON_ENVELOPE form ({schema_version, data:{...}}) so callers
+// see one shape either way. The second return reports whether an object was
+// found.
+func jsonErrorFrom(t *testing.T, out string) (map[string]any, bool) {
+	t.Helper()
+	for i, r := range out {
+		if r != '{' {
+			continue
+		}
+		dec := json.NewDecoder(strings.NewReader(out[i:]))
+		var obj map[string]any
+		if err := dec.Decode(&obj); err != nil {
+			continue
+		}
+		if _, ok := obj["error"]; ok {
+			return obj, true
+		}
+		// BD_JSON_ENVELOPE=1 nests the error under "data".
+		if data, ok := obj["data"].(map[string]any); ok {
+			if _, ok := data["error"]; ok {
+				// Lift schema_version from the envelope so the caller can
+				// assert one shape.
+				if sv, ok := obj["schema_version"]; ok {
+					data["schema_version"] = sv
+				}
+				return data, true
+			}
+		}
+	}
+	return nil, false
+}
+
+// requireJSONError asserts the output carries a structured error object with a
+// non-empty message and schema_version == 1 (§E5), and returns it.
+func requireJSONError(t *testing.T, out, context string) map[string]any {
+	t.Helper()
+	obj, ok := jsonErrorFrom(t, out)
+	if !ok {
+		t.Fatalf("%s: no JSON error object in output:\n%s", context, out)
+	}
+	msg, _ := obj["error"].(string)
+	if strings.TrimSpace(msg) == "" {
+		t.Errorf("%s: JSON error has empty %q field:\n%s", context, "error", out)
+	}
+	sv, ok := obj["schema_version"].(float64)
+	if !ok || int(sv) != 1 {
+		t.Errorf("%s: schema_version = %v, want 1 (§E5):\n%s", context, obj["schema_version"], out)
+	}
+	return obj
+}
+
+// errorMessage returns the "error" field of a structured error object.
+func errorMessage(obj map[string]any) string {
+	msg, _ := obj["error"].(string)
+	return msg
+}
+
+// ---------------------------------------------------------------------------
+// Store fixture: direct SQL against the workspace's database (§V2/§V3)
+// ---------------------------------------------------------------------------
+//
+// The workspace is backed by an embedded Dolt database under
+// .beads/embeddeddolt/<db>, so the fixture drives the `dolt` CLI against that
+// directory — the same binary newWorkspace already requires, and no new
+// dependency. bd holds no lock between commands, so a write here is visible to
+// the next bd invocation.
+
+// storeDatabase returns the name of the database backing the workspace, as the
+// workspace itself recorded it at init. Read from bd's metadata rather than
+// re-derived from the prefix, so a fixture that guesses wrong fails loudly here
+// instead of silently testing nothing.
+func (w *workspace) storeDatabase(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(w.dir, ".beads", "metadata.json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	var meta struct {
+		Database     string `json:"database"`
+		DoltDatabase string `json:"dolt_database"`
+	}
+	if err := json.Unmarshal(data, &meta); err != nil {
+		t.Fatalf("parse %s: %v", path, err)
+	}
+	if meta.DoltDatabase != "" {
+		return meta.DoltDatabase
+	}
+	if meta.Database == "" {
+		t.Fatalf("%s names no database:\n%s", path, data)
+	}
+	return meta.Database
+}
+
+// storeExec runs one SQL statement against the workspace's database, behind
+// bd's back. Values are interpolated (the dolt CLI takes no bind parameters),
+// so callers must pass only test-controlled literals.
+func (w *workspace) storeExec(t *testing.T, query string) {
+	t.Helper()
+	dbDir := filepath.Join(w.dir, ".beads", "embeddeddolt", w.storeDatabase(t))
+	if _, err := os.Stat(dbDir); err != nil {
+		t.Fatalf("workspace is not embedded-Dolt backed (%s): %v", dbDir, err)
+	}
+	cmd := exec.Command("dolt", "sql", "-q", query)
+	cmd.Dir = dbDir
+	cmd.Env = append(os.Environ(), "DOLT_ROOT_PATH="+t.TempDir())
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("dolt sql -q %q: %v\n%s", query, err, out)
+	}
+}


### PR DESCRIPTION
Conformance-corpus work package 4 from `PROPOSAL-beads-protocol-v0.md` §11 — the errors, memories, and versioning clauses the manifest listed as TODO. Test-only; no change to bd's behavior.

All of these are CLI-surface clauses, so they land in `cmd/bd/protocol`, the corpus an alternate implementation replays against its own binary.

## Pinned

| Clause | What it now guarantees |
| --- | --- |
| E3 | exit **10** (remote-divergence refused), **12** (destroy-token missing), **130** (prompt canceled) — asserted as literals, not as bd's Go constants, because the clause freezes the numbers a script branches on |
| E4 | not-found / already-claimed (naming the holder) / not-claimable (naming the state) / validation are distinguishable **from the message alone** — v0 deliberately does not distinguish them by exit code |
| E5 | `--json` errors are `{error, hint?, schema_version: 1}` |
| M1 | memory CRUD surface: `remember` / `recall` / `memories` / `forget` |
| M4 | reserved namespace — `bd kv set memory.*` refuses and names the owning command |
| V2 | designated-migrator gate: a behind, remote-backed DB is not auto-migrated; `BD_ALLOW_REMOTE_MIGRATE=1` is the deliberate way through |
| V3 | schema-skew refusal (DB ahead of binary) + the `BD_IGNORE_SCHEMA_SKEW` downgrade to a warning |

## Two clauses could not be pinned — skipped with a reason, not dropped

- **exit 11** is returned only from the *interactive* typed-confirmation abort in `bd init --reinit-local` (behind `term.IsTerminal` on stdin); the non-interactive branch of the same guard returns 12, so no piped-stdin subprocess can produce it. Needs a PTY harness — tracked as `wy-vh5y8`.
- **claim failures print plain text even under `--json`** — `bd update <id> --claim --json` emits `Error claiming …: issue already claimed by alice` on stderr rather than a structured error. E4 (message) holds; **E5 (structured) does not**. Per proposal §14 the clause wins and the deviation is a bug, so the test asserts the clause and stays skipped until `wy-kxgf4` lands, at which point it becomes the guardrail. `bd show <missing> --json` *is* conforming, which is what makes the claim path's divergence visible.

## Notes for the reviewer

- **Store fixtures.** V2/V3 are properties of the *database*, not of any command, so each stages its precondition by writing `schema_migrations` behind bd's back (via the `dolt` CLI the harness already requires) and then asserts through the frozen CLI surface. §14 explicitly allows this.
- **`BD_DISABLE_METRICS=1` in the workspace env** is a real flake fix, not cosmetics: bd spawns a *detached* `bd send-metrics` child that writes `$HOME/.beads/eventsData` after the parent exits, and `HOME` in this harness is the `t.TempDir()` workspace — so the child raced Go's `RemoveAll` and tests failed their own cleanup with `unlinkat …: directory not empty`. The flake predates this PR (it hit untouched tests on a pristine tree). A test suite should not be shipping telemetry either way.
- **Pre-existing reds, unrelated to this PR:** on a pristine `main` (303e263fe) five protocol tests already fail — `Comments/ScalarUpdate/StatusTransitions/ImportPreserves*` (comments missing from `show --json`) and `ParentChildDepShowRoundTrip` (dependents empty). Verified by stashing this branch's changes. Filed separately (`wy-ruya3`); worth knowing that this package is not currently green on main.

Local run: the 12 new tests pass (10 asserting, 2 documented skips); `gofmt` and `go vet` clean.

_claude-code-opus-4.8-high on behalf of Steve Yegge_