### PR TITLE
docs: redirect legacy GitHub Pages site to Mintlify

### DIFF
--- a/.github/pages-redirect/index.html
+++ b/.github/pages-redirect/index.html
@@ -1,0 +1,42 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="robots" content="noindex" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Beads documentation has moved</title>
+  </head>
+  <body>
+    <p>
+      The Beads documentation has moved to
+      <a id="destination" href="https://beads.gascity.com/">beads.gascity.com</a>.
+    </p>
+    <noscript>
+      <p>
+        JavaScript is required to preserve this page's path. Continue to the
+        <a href="https://beads.gascity.com/">current Beads documentation</a>.
+      </p>
+    </noscript>
+    <script>
+      (function () {
+        var path = window.location.pathname;
+        var destinationPath = path;
+
+        if (path === "/beads" || path === "/beads/") {
+          destinationPath = "/";
+        } else if (path.indexOf("/beads/") === 0) {
+          destinationPath = path.slice("/beads".length);
+        }
+
+        var destination =
+          "https://beads.gascity.com" +
+          destinationPath +
+          window.location.search +
+          window.location.hash;
+
+        document.getElementById("destination").href = destination;
+        window.location.replace(destination);
+      })();
+    </script>
+  </body>
+</html>

--- a/.github/pages-redirect/index.html
+++ b/.github/pages-redirect/index.html
@@ -4,6 +4,8 @@
     <meta charset="utf-8" />
     <meta name="robots" content="noindex" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="redirect-destination" content="https://beads.gascity.com" />
+    <meta http-equiv="refresh" content="1; url=https://beads.gascity.com/" />
     <title>Beads documentation has moved</title>
   </head>
   <body>
@@ -29,7 +31,7 @@
         }
 
         var destination =
-          "https://beads.gascity.com" +
+          document.querySelector('meta[name="redirect-destination"]').content +
           destinationPath +
           window.location.search +
           window.location.hash;

--- a/.github/workflows/deploy-pages-redirect.yml
+++ b/.github/workflows/deploy-pages-redirect.yml
@@ -16,14 +16,20 @@ permissions:
 
 concurrency:
   group: pages
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
-  build:
+  deploy:
+    if: ${{ github.repository == 'gastownhall/beads' }}
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+        with:
+          sparse-checkout: .github/pages-redirect
 
       - name: Build redirect artifact
         run: |
@@ -36,14 +42,6 @@ jobs:
         with:
           path: _site
 
-  deploy:
-    if: ${{ github.repository == 'gastownhall/beads' }}
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5

--- a/.github/workflows/deploy-pages-redirect.yml
+++ b/.github/workflows/deploy-pages-redirect.yml
@@ -1,0 +1,49 @@
+name: Deploy legacy docs redirect
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/pages-redirect/**'
+      - '.github/workflows/deploy-pages-redirect.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+
+      - name: Build redirect artifact
+        run: |
+          mkdir -p _site
+          cp -f .github/pages-redirect/index.html _site/index.html
+          cp -f .github/pages-redirect/index.html _site/404.html
+
+      - name: Upload redirect artifact
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5
+        with:
+          path: _site
+
+  deploy:
+    if: ${{ github.repository == 'gastownhall/beads' }}
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![npm version](https://img.shields.io/npm/v/@beads/bd)](https://www.npmjs.com/package/@beads/bd)
 [![PyPI](https://img.shields.io/pypi/v/beads-mcp)](https://pypi.org/project/beads-mcp/)
 
-**Docs:** https://gastownhall.github.io/beads/
+**Docs:** https://beads.gascity.com/
 
 Beads provides a persistent, structured memory for coding agents. It replaces messy markdown plans with a dependency-aware graph, allowing agents to handle long-horizon tasks without losing context.
 
@@ -111,7 +111,7 @@ version: sync remote-backed databases with your current `bd`, back up with
 migration on a remote-backed database, exactly one designated clone runs
 `bd migrate --force` and `bd dolt push`; other clones install the new binary
 and run `bd bootstrap`. See the full
-[upgrade guide](https://gastownhall.github.io/beads/getting-started/upgrading)
+[upgrade guide](https://beads.gascity.com/getting-started/upgrading)
 or [docs/getting-started/installation.md](docs/getting-started/installation.md#updating-bd).
 
 ### Security And Verification
@@ -184,5 +184,5 @@ For daemon mode without git, use `bd daemon start --local`
 
 ## 📝 Documentation
 
-* [Documentation site](https://gastownhall.github.io/beads/) (versioned) | [Installing](docs/getting-started/installation.md) | [Sync Concepts](docs/core-concepts/sync-concepts.md) | [Agent Workflow](AGENT_INSTRUCTIONS.md) | [Copilot CLI Setup](docs/integrations/copilot-cli.md) | [Copilot VS Code MCP](docs/integrations/github-copilot.md) | [Articles](ARTICLES.md) | [Sync Branch Mode](docs/reference/protected-branches.md) | [Troubleshooting](docs/reference/troubleshooting.md) | [FAQ](docs/reference/faq.md)
+* [Documentation site](https://beads.gascity.com/) | [Installing](docs/getting-started/installation.md) | [Sync Concepts](docs/core-concepts/sync-concepts.md) | [Agent Workflow](AGENT_INSTRUCTIONS.md) | [Copilot CLI Setup](docs/integrations/copilot-cli.md) | [Copilot VS Code MCP](docs/integrations/github-copilot.md) | [Articles](ARTICLES.md) | [Sync Branch Mode](docs/reference/protected-branches.md) | [Troubleshooting](docs/reference/troubleshooting.md) | [FAQ](docs/reference/faq.md)
 * [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/gastownhall/beads)

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -210,6 +210,10 @@
     {
       "source": "/1.0.5/:slug*",
       "destination": "/:slug*"
+    },
+    {
+      "source": "/1.1.0/:slug*",
+      "destination": "/:slug*"
     }
   ],
   "navigation": {

--- a/examples/formulas/README.md
+++ b/examples/formulas/README.md
@@ -37,4 +37,4 @@ commands to match your project before first use.
 
 ## Creating Your Own
 
-See the [Formulas documentation](https://gastownhall.github.io/beads/workflows/formulas) for the full reference.
+See the [Formulas documentation](https://beads.gascity.com/workflows/formulas) for the full reference.

--- a/npm-package/README.md
+++ b/npm-package/README.md
@@ -100,7 +100,7 @@ This package downloads the appropriate native binary for your platform:
 For complete documentation, see the [beads GitHub repository](https://github.com/gastownhall/beads):
 
 - [Complete README](https://github.com/gastownhall/beads#readme)
-- [Quick Start (documentation site)](https://gastownhall.github.io/beads/getting-started/quickstart) · [in-repo source](https://github.com/gastownhall/beads/blob/main/docs/getting-started/quickstart.md)
+- [Quick Start (documentation site)](https://beads.gascity.com/getting-started/quickstart) · [in-repo source](https://github.com/gastownhall/beads/blob/main/docs/getting-started/quickstart.md)
 - [Installation Guide](https://github.com/gastownhall/beads/blob/main/docs/getting-started/installation.md)
 - [FAQ](https://github.com/gastownhall/beads/blob/main/docs/reference/faq.md)
 - [Troubleshooting](https://github.com/gastownhall/beads/blob/main/docs/reference/troubleshooting.md)

--- a/plugins/beads/skills/beads/commands/quickstart.md
+++ b/plugins/beads/skills/beads/commands/quickstart.md
@@ -3,7 +3,7 @@ description: Quick start guide for bd workflows (deprecated)
 argument-hint: []
 ---
 
-**Note:** The `bd quickstart` command is deprecated. See the [Quick Start](https://gastownhall.github.io/beads/getting-started/quickstart) on the documentation site, or the in-repo source [docs/getting-started/quickstart.md](https://github.com/gastownhall/beads/blob/main/docs/getting-started/quickstart.md).
+**Note:** The `bd quickstart` command is deprecated. See the [Quick Start](https://beads.gascity.com/getting-started/quickstart) on the documentation site, or the in-repo source [docs/getting-started/quickstart.md](https://github.com/gastownhall/beads/blob/main/docs/getting-started/quickstart.md).
 
 The quickstart documentation covers:
 - Getting started with bd

--- a/plugins/beads/skills/beads/resources/CLI_REFERENCE.md
+++ b/plugins/beads/skills/beads/resources/CLI_REFERENCE.md
@@ -8,6 +8,6 @@ Use these live sources instead:
 - `bd <command> --help` for command-specific usage
 - `bd help --all` for the complete local CLI reference
 - `docs/CLI_REFERENCE.md` in the beads repository for the generated Markdown reference
-- <https://gastownhall.github.io/beads/cli-reference/> for the published generated reference
+- <https://beads.gascity.com/cli-reference/> for the published generated reference
 
 Maintainers: regenerate repository CLI docs with `./scripts/generate-cli-docs.sh`. Do not paste generated command output into this skill resource.


### PR DESCRIPTION
## What changed

- replace the frozen Docusaurus GitHub Pages deployment with a two-file redirect artifact (`index.html` and `404.html`) built from one committed source
- preserve bookmarked deep-link paths, query strings, and fragments while moving from `gastownhall.github.io/beads` to `beads.gascity.com`
- cover the retired `1.1.0` version route and repoint remaining live repository links to the Mintlify site

## Why

The Mintlify cutover in #4722 intentionally stopped publishing Docusaurus, but the last Pages artifact is still live and silently serves stale documentation. Disabling Pages would break saved links. A redirect-only artifact keeps those bookmarks useful and sends readers to the current docs.

The deployment remains separate from Mintlify: after this PR merges, the `main` push publishes only the redirect stubs to GitHub Pages. The new documentation continues to be hosted at `https://beads.gascity.com/`.

## Validation

- `go test ./test/docsync`
- `go test -tags=gms_pure_go ./test/docsync`
- dependency-free Node VM checks for `/beads`, `/beads/`, deep paths, query strings, fragments, and exact-prefix handling
- generated artifact check confirms identical `index.html` and `404.html`
- all replacement target URLs return HTTP 200
- independent standards and spec reviews: no findings
- `git diff --check`

`actionlint` was not installed locally; the workflow reuses the exact immutable Pages action pins and deployment pattern from the retired workflow.

_codex-gpt-5.6-sol-high on behalf of matt wilkie_
