### PR TITLE
ci: shard embedded Dolt conformance gate

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -844,10 +844,18 @@ jobs:
         run: /tmp/embeddeddolt-test -test.v -test.count=1 -test.timeout=30m -test.skip '^TestConformance$'
 
   test-embedded-conformance:
-    name: Test (Embedded Dolt Conformance)
+    name: Test (Embedded Dolt Conformance - ${{ matrix.partition }})
     needs: [detect-ci-tier, build-embedded]
     if: needs.detect-ci-tier.outputs.full_embedded == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 35
+    strategy:
+      fail-fast: false
+      matrix:
+        partition: [core, audit]
+    env:
+      BEADS_TEST_EMBEDDED_DOLT: "1"
+      BEADS_TEST_EMBEDDED_TEST_BINARY: /tmp/embeddeddolt-test
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
 
@@ -865,16 +873,18 @@ jobs:
           git config --global user.name "CI Bot"
           git config --global user.email "ci@beads.test"
 
-      - name: Test
-        env:
-          BEADS_TEST_EMBEDDED_DOLT: "1"
-          BEADS_TEST_EMBEDDED_TEST_BINARY: /tmp/embeddeddolt-test
-        # Conformance suite (conformance.RunAll via TestConformance) against
-        # the embedded Dolt backend, split from test-embedded-storage so each
-        # job stays well under its timeout - same structure as pr-risk.yml.
-        # 30m matches the repo's integration timeout: the audit suite is large and
-        # embedded Dolt under -race is slow, so 15m no longer left headroom.
-        run: /tmp/embeddeddolt-test -test.v -test.count=1 -test.timeout=30m -test.run '^TestConformance$'
+      - name: Test core conformance
+        if: matrix.partition == 'core'
+        # RunAll has a natural Audit seam. Run everything except Audit in the
+        # core shard and Audit alone in the other shard. The combined suite has
+        # exceeded 30m under runner variance; each half currently takes ~15m.
+        # Keep the Go timeout below the job timeout so a real stall still emits
+        # a diagnostic goroutine dump before Actions stops the job.
+        run: /tmp/embeddeddolt-test -test.v -test.count=1 -test.timeout=30m -test.run '^TestConformance$' -test.skip '^TestConformance$/^Audit$'
+
+      - name: Test audit conformance
+        if: matrix.partition == 'audit'
+        run: /tmp/embeddeddolt-test -test.v -test.count=1 -test.timeout=30m -test.run '^TestConformance$/^Audit$'
 
   test-embedded-cmd:
     name: Test (Embedded Dolt Cmd ${{ matrix.shard }}/${{ strategy.job-total }})

--- a/.github/workflows/pr-risk.yml
+++ b/.github/workflows/pr-risk.yml
@@ -175,10 +175,18 @@ jobs:
         run: /tmp/embeddeddolt-test -test.v -test.count=1 -test.timeout=30m -test.skip '^TestConformance$'
 
   test-embedded-conformance:
-    name: Test (Embedded Dolt Conformance)
+    name: Test (Embedded Dolt Conformance - ${{ matrix.partition }})
     needs: [detect-ci-tier, build-embedded]
     if: needs.detect-ci-tier.outputs.full_embedded == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 35
+    strategy:
+      fail-fast: false
+      matrix:
+        partition: [core, audit]
+    env:
+      BEADS_TEST_EMBEDDED_DOLT: "1"
+      BEADS_TEST_EMBEDDED_TEST_BINARY: /tmp/embeddeddolt-test
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
 
@@ -196,16 +204,18 @@ jobs:
           git config --global user.name "CI Bot"
           git config --global user.email "ci@beads.test"
 
-      - name: Test
-        env:
-          BEADS_TEST_EMBEDDED_DOLT: "1"
-          BEADS_TEST_EMBEDDED_TEST_BINARY: /tmp/embeddeddolt-test
-        # Conformance suite (conformance.RunAll via TestConformance) against the
-        # embedded Dolt backend. Split from test-embedded-storage so each job
-        # stays well under its timeout; the server twin runs in mybd-665b's job.
-        # 45m gives the audit-heavy embedded run enough headroom without making
-        # the workflow open-ended.
-        run: /tmp/embeddeddolt-test -test.v -test.count=1 -test.timeout=45m -test.run '^TestConformance$'
+      - name: Test core conformance
+        if: matrix.partition == 'core'
+        # RunAll has a natural Audit seam. Run everything except Audit in the
+        # core shard and Audit alone in the other shard. The combined suite has
+        # exceeded 30m under runner variance; each half currently takes ~15m.
+        # Keep the Go timeout below the job timeout so a real stall still emits
+        # a diagnostic goroutine dump before Actions stops the job.
+        run: /tmp/embeddeddolt-test -test.v -test.count=1 -test.timeout=30m -test.run '^TestConformance$' -test.skip '^TestConformance$/^Audit$'
+
+      - name: Test audit conformance
+        if: matrix.partition == 'audit'
+        run: /tmp/embeddeddolt-test -test.v -test.count=1 -test.timeout=30m -test.run '^TestConformance$/^Audit$'
 
   test-server-storage:
     name: Test (Server Dolt Conformance)


### PR DESCRIPTION
## What

- Split embedded-Dolt conformance into `core` and `audit` matrix partitions.
- Keep the existing 30-minute Go timeout per partition.
- Add a 35-minute Actions timeout so a real Go timeout can still emit diagnostics before the runner stops.
- Apply the same partitioning to `main.yml` and `pr-risk.yml` so PR coverage matches main.

## Why

[Main run 29278903172](https://github.com/gastownhall/beads/actions/runs/29278903172) timed out `TestConformance` at exactly 30 minutes. The suite was not hung: it was still entering new subtests, with only the tail of `Audit` plus three short top-level tests remaining.

Recent green runs took 21-25 minutes, while the failed runner was uniformly about 1.4x slower. Raising the timeout again would repeat the recent 15-to-30-minute ratchet. `RunAll` already has a natural `Audit` boundary, and splitting there gives each partition about 2x headroom while roughly halving wall-clock time.

The earlier red lint wrapper was a transient Go proxy HTTP/2 download error and passed on the replacement run. The conformance timeout is the remaining reproducible main failure.

## Verification

- `actionlint` v1.7.12 passes both changed workflows.
- A synthetic nested Go test confirms the `-test.run`/`-test.skip` filters assign all non-Audit tests to `core` and the full Audit subtree to `audit`.
- `scripts/check-build-tags.sh` passes.
- `git diff --check` passes.
- Independent review confirmed the PR-risk aggregate gate consumes the matrix job's combined result.

Coordination: `mybd-ie8n`

_codex-gpt-5.6-sol-high on behalf of matt wilkie_
