### PR TITLE
cmd/bd: error on unsupported commands in proxied-server mode

### DIFF
--- a/cmd/bd/ado.go
+++ b/cmd/bd/ado.go
@@ -356,6 +356,9 @@ type adoStatusResult struct {
 
 // runADOStatus implements the ado status command.
 func runADOStatus(cmd *cobra.Command, _ []string) error {
+	if usesProxiedServer() {
+		return HandleErrorRespectJSON("ado status is not supported in proxied-server mode")
+	}
 	evt := metrics.NewCommandEvent("ado-status")
 	defer func() {
 		if c := metrics.Global(); c != nil {
@@ -409,6 +412,9 @@ func runADOStatus(cmd *cobra.Command, _ []string) error {
 
 // runADOProjects implements the ado projects command.
 func runADOProjects(cmd *cobra.Command, _ []string) error {
+	if usesProxiedServer() {
+		return HandleErrorRespectJSON("ado projects is not supported in proxied-server mode")
+	}
 	evt := metrics.NewCommandEvent("ado-projects")
 	defer func() {
 		if c := metrics.Global(); c != nil {
@@ -478,6 +484,9 @@ type adoSyncResult struct {
 // runADOSync implements the ado sync command.
 // Uses the tracker.Engine for all sync operations.
 func runADOSync(cmd *cobra.Command, _ []string) error {
+	if usesProxiedServer() {
+		return HandleErrorRespectJSON("ado sync is not supported in proxied-server mode")
+	}
 	evt := metrics.NewCommandEvent("ado-sync")
 	defer func() {
 		if c := metrics.Global(); c != nil {

--- a/cmd/bd/assign.go
+++ b/cmd/bd/assign.go
@@ -24,6 +24,9 @@ Examples:
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if usesProxiedServer() {
+			return HandleErrorRespectJSON("assign is not supported in proxied-server mode")
+		}
 		CheckReadonly("assign")
 
 		id := args[0]

--- a/cmd/bd/backup.go
+++ b/cmd/bd/backup.go
@@ -37,6 +37,9 @@ var backupStatusCmd = &cobra.Command{
 	Use:   "status",
 	Short: "Show last backup status",
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if usesProxiedServer() {
+			return HandleErrorRespectJSON("backup status is not supported in proxied-server mode")
+		}
 		evt := metrics.NewCommandEvent("backup-status")
 		defer func() {
 			if c := metrics.Global(); c != nil {

--- a/cmd/bd/backup_dolt.go
+++ b/cmd/bd/backup_dolt.go
@@ -46,6 +46,9 @@ DoltHub (recommended for cloud backup):
 After adding, run 'bd backup sync' to push your data.`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if usesProxiedServer() {
+			return HandleErrorRespectJSON("backup init is not supported in proxied-server mode")
+		}
 		evt := metrics.NewCommandEvent("backup-init")
 		defer func() {
 			if c := metrics.Global(); c != nil {
@@ -121,6 +124,9 @@ The backup is atomic — if the sync fails, the previous backup state is preserv
 
 Run 'bd backup init <path>' first to configure a destination.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if usesProxiedServer() {
+			return HandleErrorRespectJSON("backup sync is not supported in proxied-server mode")
+		}
 		evt := metrics.NewCommandEvent("backup-sync")
 		defer func() {
 			if c := metrics.Global(); c != nil {
@@ -403,6 +409,9 @@ This unregisters the backup remote from Dolt and removes the local
 backup configuration. The backup data at the destination is not deleted.`,
 	Aliases: []string{"rm"},
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if usesProxiedServer() {
+			return HandleErrorRespectJSON("backup remove is not supported in proxied-server mode")
+		}
 		evt := metrics.NewCommandEvent("backup-remove")
 		defer func() {
 			if c := metrics.Global(); c != nil {

--- a/cmd/bd/backup_restore.go
+++ b/cmd/bd/backup_restore.go
@@ -32,6 +32,9 @@ The database must already be initialized (run 'bd init' first if needed).
 To initialize and restore in one step, use: bd init && bd backup restore`,
 	Args: cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if usesProxiedServer() {
+			return HandleErrorRespectJSON("backup restore is not supported in proxied-server mode")
+		}
 		evt := metrics.NewCommandEvent("backup-restore")
 		defer func() {
 			if c := metrics.Global(); c != nil {

--- a/cmd/bd/batch.go
+++ b/cmd/bd/batch.go
@@ -78,6 +78,9 @@ normal 'bd' subcommands for interactive/read operations.`,
 	SilenceUsage:  true,
 	SilenceErrors: false,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if usesProxiedServer() {
+			return HandleErrorRespectJSON("batch is not supported in proxied-server mode")
+		}
 		CheckReadonly("batch")
 
 		evt := metrics.NewCommandEvent("batch")

--- a/cmd/bd/branch.go
+++ b/cmd/bd/branch.go
@@ -24,6 +24,9 @@ Examples:
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if usesProxiedServer() {
+			return HandleErrorRespectJSON("branch is not supported in proxied-server mode")
+		}
 		evt := metrics.NewCommandEvent("branch")
 		defer func() {
 			if c := metrics.Global(); c != nil {

--- a/cmd/bd/children.go
+++ b/cmd/bd/children.go
@@ -24,6 +24,9 @@ Examples:
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if usesProxiedServer() {
+			return HandleErrorRespectJSON("children is not supported in proxied-server mode")
+		}
 		evt := metrics.NewCommandEvent("children")
 		defer func() {
 			if c := metrics.Global(); c != nil {

--- a/cmd/bd/cleanup.go
+++ b/cmd/bd/cleanup.go
@@ -49,6 +49,9 @@ SEE ALSO:
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if usesProxiedServer() {
+			return HandleErrorRespectJSON("admin cleanup is not supported in proxied-server mode")
+		}
 		evt := metrics.NewCommandEvent("admin-cleanup")
 		defer func() {
 			if c := metrics.Global(); c != nil {

--- a/cmd/bd/comment.go
+++ b/cmd/bd/comment.go
@@ -28,6 +28,9 @@ Examples:
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if usesProxiedServer() {
+			return HandleErrorRespectJSON("comment is not supported in proxied-server mode")
+		}
 		CheckReadonly("comment")
 
 		evt := metrics.NewCommandEvent("comment")

--- a/cmd/bd/comments.go
+++ b/cmd/bd/comments.go
@@ -33,6 +33,9 @@ Examples:
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if usesProxiedServer() {
+			return HandleErrorRespectJSON("comments is not supported in proxied-server mode")
+		}
 		evt := metrics.NewCommandEvent("comments")
 		defer func() {
 			if c := metrics.Global(); c != nil {
@@ -132,6 +135,9 @@ Examples:
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if usesProxiedServer() {
+			return HandleErrorRespectJSON("comments add is not supported in proxied-server mode")
+		}
 		CheckReadonly("comment add")
 
 		evt := metrics.NewCommandEvent("comments-add")

--- a/cmd/bd/compact.go
+++ b/cmd/bd/compact.go
@@ -81,6 +81,9 @@ Examples:
   bd compact --stats                       # Show statistics
 `,
 	RunE: func(_ *cobra.Command, _ []string) error {
+		if usesProxiedServer() {
+			return HandleErrorRespectJSON("admin compact is not supported in proxied-server mode")
+		}
 		// Block mutating operations in embedded mode; allow --stats, --analyze, --dry-run read-only paths.
 		if !compactStats && !compactAnalyze && !compactDryRun {
 			if err := requireServerMode("compact"); err != nil {

--- a/cmd/bd/compact_dolt.go
+++ b/cmd/bd/compact_dolt.go
@@ -43,6 +43,9 @@ Examples:
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(_ *cobra.Command, _ []string) error {
+		if usesProxiedServer() {
+			return HandleErrorRespectJSON("compact is not supported in proxied-server mode")
+		}
 		evt := metrics.NewCommandEvent("compact")
 		defer func() {
 			if c := metrics.Global(); c != nil {

--- a/cmd/bd/cook.go
+++ b/cmd/bd/cook.go
@@ -355,6 +355,9 @@ func persistCookFormula(ctx context.Context, resolved *formula.Formula, protoID 
 }
 
 func runCook(cmd *cobra.Command, args []string) error {
+	if usesProxiedServer() {
+		return HandleErrorRespectJSON("cook is not supported in proxied-server mode")
+	}
 	evt := metrics.NewCommandEvent("cook")
 	defer func() {
 		if c := metrics.Global(); c != nil {

--- a/cmd/bd/count.go
+++ b/cmd/bd/count.go
@@ -35,6 +35,9 @@ Examples:
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if usesProxiedServer() {
+			return HandleErrorRespectJSON("count is not supported in proxied-server mode")
+		}
 		evt := metrics.NewCommandEvent("count")
 		defer func() {
 			if c := metrics.Global(); c != nil {

--- a/cmd/bd/create_form.go
+++ b/cmd/bd/create_form.go
@@ -278,6 +278,9 @@ The form uses keyboard navigation:
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if usesProxiedServer() {
+			return HandleErrorRespectJSON("create-form is not supported in proxied-server mode")
+		}
 		CheckReadonly("create-form")
 
 		evt := metrics.NewCommandEvent("create-form")

--- a/cmd/bd/defer.go
+++ b/cmd/bd/defer.go
@@ -35,6 +35,9 @@ Examples:
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if usesProxiedServer() {
+			return HandleErrorRespectJSON("defer is not supported in proxied-server mode")
+		}
 		CheckReadonly("defer")
 
 		evt := metrics.NewCommandEvent("defer")

--- a/cmd/bd/diff.go
+++ b/cmd/bd/diff.go
@@ -28,6 +28,9 @@ Examples:
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if usesProxiedServer() {
+			return HandleErrorRespectJSON("diff is not supported in proxied-server mode")
+		}
 		evt := metrics.NewCommandEvent("diff")
 		defer func() {
 			if c := metrics.Global(); c != nil {

--- a/cmd/bd/duplicate.go
+++ b/cmd/bd/duplicate.go
@@ -58,6 +58,9 @@ func init() {
 }
 
 func runDuplicate(cmd *cobra.Command, args []string) error {
+	if usesProxiedServer() {
+		return HandleErrorRespectJSON("duplicate is not supported in proxied-server mode")
+	}
 	CheckReadonly("duplicate")
 
 	evt := metrics.NewCommandEvent("duplicate")
@@ -128,6 +131,9 @@ func runDuplicate(cmd *cobra.Command, args []string) error {
 }
 
 func runSupersede(cmd *cobra.Command, args []string) error {
+	if usesProxiedServer() {
+		return HandleErrorRespectJSON("supersede is not supported in proxied-server mode")
+	}
 	CheckReadonly("supersede")
 
 	evt := metrics.NewCommandEvent("supersede")

--- a/cmd/bd/duplicates.go
+++ b/cmd/bd/duplicates.go
@@ -28,6 +28,9 @@ Example:
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, _ []string) error {
+		if usesProxiedServer() {
+			return HandleErrorRespectJSON("duplicates is not supported in proxied-server mode")
+		}
 		evt := metrics.NewCommandEvent("duplicates")
 		defer func() {
 			if c := metrics.Global(); c != nil {

--- a/cmd/bd/edit.go
+++ b/cmd/bd/edit.go
@@ -30,6 +30,9 @@ Examples:
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if usesProxiedServer() {
+			return HandleErrorRespectJSON("edit is not supported in proxied-server mode")
+		}
 		CheckReadonly("edit")
 
 		evt := metrics.NewCommandEvent("edit")

--- a/cmd/bd/epic.go
+++ b/cmd/bd/epic.go
@@ -20,6 +20,9 @@ var epicStatusCmd = &cobra.Command{
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if usesProxiedServer() {
+			return HandleErrorRespectJSON("epic status is not supported in proxied-server mode")
+		}
 		evt := metrics.NewCommandEvent("epic-status")
 		defer func() {
 			if c := metrics.Global(); c != nil {
@@ -85,6 +88,9 @@ var closeEligibleEpicsCmd = &cobra.Command{
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if usesProxiedServer() {
+			return HandleErrorRespectJSON("epic close-eligible is not supported in proxied-server mode")
+		}
 		evt := metrics.NewCommandEvent("epic-close-eligible")
 		defer func() {
 			if c := metrics.Global(); c != nil {

--- a/cmd/bd/export.go
+++ b/cmd/bd/export.go
@@ -76,6 +76,9 @@ func init() {
 }
 
 func runExport(cmd *cobra.Command, args []string) error {
+	if usesProxiedServer() {
+		return HandleErrorRespectJSON("export is not supported in proxied-server mode")
+	}
 	evt := metrics.NewCommandEvent("export")
 	defer func() {
 		if c := metrics.Global(); c != nil {

--- a/cmd/bd/federation.go
+++ b/cmd/bd/federation.go
@@ -148,6 +148,9 @@ func getFederatedStore() (storage.DoltStorage, error) {
 }
 
 func runFederationSync(cmd *cobra.Command, args []string) error {
+	if usesProxiedServer() {
+		return HandleErrorRespectJSON("federation sync is not supported in proxied-server mode")
+	}
 	evt := metrics.NewCommandEvent("federation-sync")
 	defer func() {
 		if c := metrics.Global(); c != nil {
@@ -243,6 +246,9 @@ func runFederationSync(cmd *cobra.Command, args []string) error {
 }
 
 func runFederationStatus(cmd *cobra.Command, args []string) error {
+	if usesProxiedServer() {
+		return HandleErrorRespectJSON("federation status is not supported in proxied-server mode")
+	}
 	evt := metrics.NewCommandEvent("federation-status")
 	defer func() {
 		if c := metrics.Global(); c != nil {
@@ -363,6 +369,9 @@ func runFederationStatus(cmd *cobra.Command, args []string) error {
 }
 
 func runFederationAddPeer(cmd *cobra.Command, args []string) error {
+	if usesProxiedServer() {
+		return HandleErrorRespectJSON("federation add-peer is not supported in proxied-server mode")
+	}
 	evt := metrics.NewCommandEvent("federation-add-peer")
 	defer func() {
 		if c := metrics.Global(); c != nil {
@@ -431,6 +440,9 @@ func runFederationAddPeer(cmd *cobra.Command, args []string) error {
 }
 
 func runFederationRemovePeer(cmd *cobra.Command, args []string) error {
+	if usesProxiedServer() {
+		return HandleErrorRespectJSON("federation remove-peer is not supported in proxied-server mode")
+	}
 	evt := metrics.NewCommandEvent("federation-remove-peer")
 	defer func() {
 		if c := metrics.Global(); c != nil {
@@ -457,6 +469,9 @@ func runFederationRemovePeer(cmd *cobra.Command, args []string) error {
 }
 
 func runFederationListPeers(cmd *cobra.Command, args []string) error {
+	if usesProxiedServer() {
+		return HandleErrorRespectJSON("federation list-peers is not supported in proxied-server mode")
+	}
 	evt := metrics.NewCommandEvent("federation-list-peers")
 	defer func() {
 		if c := metrics.Global(); c != nil {

--- a/cmd/bd/find_duplicates.go
+++ b/cmd/bd/find_duplicates.go
@@ -78,6 +78,9 @@ type duplicatePair struct {
 }
 
 func runFindDuplicates(cmd *cobra.Command, _ []string) error {
+	if usesProxiedServer() {
+		return HandleErrorRespectJSON("find-duplicates is not supported in proxied-server mode")
+	}
 	evt := metrics.NewCommandEvent("find-duplicates")
 	defer func() {
 		if c := metrics.Global(); c != nil {

--- a/cmd/bd/flatten.go
+++ b/cmd/bd/flatten.go
@@ -42,6 +42,9 @@ Examples:
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(_ *cobra.Command, _ []string) error {
+		if usesProxiedServer() {
+			return HandleErrorRespectJSON("flatten is not supported in proxied-server mode")
+		}
 		evt := metrics.NewCommandEvent("flatten")
 		defer func() {
 			if c := metrics.Global(); c != nil {

--- a/cmd/bd/gate.go
+++ b/cmd/bd/gate.go
@@ -58,6 +58,9 @@ By default, shows only open gates. Use --all to include closed gates.`,
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if usesProxiedServer() {
+			return HandleErrorRespectJSON("gate list is not supported in proxied-server mode")
+		}
 		evt := metrics.NewCommandEvent("gate-list")
 		defer func() {
 			if c := metrics.Global(); c != nil {
@@ -226,6 +229,9 @@ This is used by 'bd done --phase-complete' to register for gate wake notificatio
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if usesProxiedServer() {
+			return HandleErrorRespectJSON("gate add-waiter is not supported in proxied-server mode")
+		}
 		CheckReadonly("gate add-waiter")
 
 		evt := metrics.NewCommandEvent("gate-add-waiter")
@@ -297,6 +303,9 @@ Examples:
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if usesProxiedServer() {
+			return HandleErrorRespectJSON("gate create is not supported in proxied-server mode")
+		}
 		CheckReadonly("gate create")
 
 		evt := metrics.NewCommandEvent("gate-create")
@@ -397,6 +406,9 @@ This is similar to 'bd show' but validates that the issue is a gate.`,
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if usesProxiedServer() {
+			return HandleErrorRespectJSON("gate show is not supported in proxied-server mode")
+		}
 		evt := metrics.NewCommandEvent("gate-show")
 		defer func() {
 			if c := metrics.Global(); c != nil {
@@ -462,6 +474,9 @@ Use --reason to provide context for why the gate was resolved.`,
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if usesProxiedServer() {
+			return HandleErrorRespectJSON("gate resolve is not supported in proxied-server mode")
+		}
 		CheckReadonly("gate resolve")
 
 		evt := metrics.NewCommandEvent("gate-resolve")
@@ -542,6 +557,9 @@ Examples:
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if usesProxiedServer() {
+			return HandleErrorRespectJSON("gate check is not supported in proxied-server mode")
+		}
 		CheckReadonly("gate check")
 
 		evt := metrics.NewCommandEvent("gate-check")

--- a/cmd/bd/gate_discover.go
+++ b/cmd/bd/gate_discover.go
@@ -66,6 +66,9 @@ func init() {
 }
 
 func runGateDiscover(cmd *cobra.Command, args []string) error {
+	if usesProxiedServer() {
+		return HandleErrorRespectJSON("gate discover is not supported in proxied-server mode")
+	}
 	CheckReadonly("gate discover")
 
 	evt := metrics.NewCommandEvent("gate-discover")

--- a/cmd/bd/gc.go
+++ b/cmd/bd/gc.go
@@ -42,6 +42,9 @@ Examples:
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, _ []string) error {
+		if usesProxiedServer() {
+			return HandleErrorRespectJSON("gc is not supported in proxied-server mode")
+		}
 		evt := metrics.NewCommandEvent("gc")
 		defer func() {
 			if c := metrics.Global(); c != nil {

--- a/cmd/bd/github.go
+++ b/cmd/bd/github.go
@@ -294,6 +294,9 @@ func getGitHubClient(config GitHubConfig) *github.Client {
 
 // runGitHubStatus implements the github status command.
 func runGitHubStatus(cmd *cobra.Command, args []string) error {
+	if usesProxiedServer() {
+		return HandleErrorRespectJSON("github status is not supported in proxied-server mode")
+	}
 	evt := metrics.NewCommandEvent("github-status")
 	defer func() {
 		if c := metrics.Global(); c != nil {
@@ -326,6 +329,9 @@ func runGitHubStatus(cmd *cobra.Command, args []string) error {
 
 // runGitHubRepos implements the github repos command.
 func runGitHubRepos(cmd *cobra.Command, args []string) error {
+	if usesProxiedServer() {
+		return HandleErrorRespectJSON("github repos is not supported in proxied-server mode")
+	}
 	evt := metrics.NewCommandEvent("github-repos")
 	defer func() {
 		if c := metrics.Global(); c != nil {
@@ -368,6 +374,9 @@ func runGitHubRepos(cmd *cobra.Command, args []string) error {
 // runGitHubSync implements the github sync command.
 // Uses the tracker.Engine for all sync operations.
 func runGitHubSync(cmd *cobra.Command, args []string) error {
+	if usesProxiedServer() {
+		return HandleErrorRespectJSON("github sync is not supported in proxied-server mode")
+	}
 	evt := metrics.NewCommandEvent("github-sync")
 	defer func() {
 		if c := metrics.Global(); c != nil {

--- a/cmd/bd/gitlab.go
+++ b/cmd/bd/gitlab.go
@@ -342,6 +342,9 @@ func getGitLabClient(config GitLabConfig) *gitlab.Client {
 
 // runGitLabStatus implements the gitlab status command.
 func runGitLabStatus(cmd *cobra.Command, args []string) error {
+	if usesProxiedServer() {
+		return HandleErrorRespectJSON("gitlab status is not supported in proxied-server mode")
+	}
 	evt := metrics.NewCommandEvent("gitlab-status")
 	defer func() {
 		if c := metrics.Global(); c != nil {
@@ -402,6 +405,9 @@ func runGitLabStatus(cmd *cobra.Command, args []string) error {
 
 // runGitLabProjects implements the gitlab projects command.
 func runGitLabProjects(cmd *cobra.Command, args []string) error {
+	if usesProxiedServer() {
+		return HandleErrorRespectJSON("gitlab projects is not supported in proxied-server mode")
+	}
 	evt := metrics.NewCommandEvent("gitlab-projects")
 	defer func() {
 		if c := metrics.Global(); c != nil {
@@ -459,6 +465,9 @@ type gitlabSyncResult struct {
 // runGitLabSync implements the gitlab sync command.
 // Uses the tracker.Engine for all sync operations.
 func runGitLabSync(cmd *cobra.Command, args []string) error {
+	if usesProxiedServer() {
+		return HandleErrorRespectJSON("gitlab sync is not supported in proxied-server mode")
+	}
 	evt := metrics.NewCommandEvent("gitlab-sync")
 	defer func() {
 		if c := metrics.Global(); c != nil {

--- a/cmd/bd/graph.go
+++ b/cmd/bd/graph.go
@@ -74,6 +74,9 @@ Examples:
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if usesProxiedServer() {
+			return HandleErrorRespectJSON("graph is not supported in proxied-server mode")
+		}
 		evt := metrics.NewCommandEvent("graph")
 		defer func() {
 			if c := metrics.Global(); c != nil {
@@ -178,6 +181,9 @@ Returns exit code 0 if the graph is clean, 1 if issues are found.`,
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if usesProxiedServer() {
+			return HandleErrorRespectJSON("graph check is not supported in proxied-server mode")
+		}
 		evt := metrics.NewCommandEvent("graph-check")
 		defer func() {
 			if c := metrics.Global(); c != nil {

--- a/cmd/bd/heartbeat.go
+++ b/cmd/bd/heartbeat.go
@@ -34,6 +34,9 @@ Examples:
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if usesProxiedServer() {
+			return HandleErrorRespectJSON("heartbeat is not supported in proxied-server mode")
+		}
 		CheckReadonly("heartbeat")
 
 		evt := metrics.NewCommandEvent("heartbeat")

--- a/cmd/bd/history.go
+++ b/cmd/bd/history.go
@@ -30,6 +30,9 @@ Examples:
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if usesProxiedServer() {
+			return HandleErrorRespectJSON("history is not supported in proxied-server mode")
+		}
 		evt := metrics.NewCommandEvent("history")
 		defer func() {
 			if c := metrics.Global(); c != nil {

--- a/cmd/bd/import.go
+++ b/cmd/bd/import.go
@@ -104,6 +104,9 @@ func init() {
 }
 
 func runImport(cmd *cobra.Command, args []string) error {
+	if usesProxiedServer() {
+		return HandleErrorRespectJSON("import is not supported in proxied-server mode")
+	}
 	evt := metrics.NewCommandEvent("import")
 	defer func() {
 		if c := metrics.Global(); c != nil {

--- a/cmd/bd/info.go
+++ b/cmd/bd/info.go
@@ -32,6 +32,9 @@ Examples:
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if usesProxiedServer() {
+			return HandleErrorRespectJSON("info is not supported in proxied-server mode")
+		}
 		evt := metrics.NewCommandEvent("info")
 		defer func() {
 			if c := metrics.Global(); c != nil {

--- a/cmd/bd/jira.go
+++ b/cmd/bd/jira.go
@@ -96,6 +96,9 @@ func init() {
 }
 
 func runJiraSync(cmd *cobra.Command, args []string) error {
+	if usesProxiedServer() {
+		return HandleErrorRespectJSON("jira sync is not supported in proxied-server mode")
+	}
 	evt := metrics.NewCommandEvent("jira-sync")
 	defer func() {
 		if c := metrics.Global(); c != nil {
@@ -223,6 +226,9 @@ func buildJiraPushHooks(ctx context.Context) *tracker.PushHooks {
 }
 
 func runJiraStatus(cmd *cobra.Command, args []string) error {
+	if usesProxiedServer() {
+		return HandleErrorRespectJSON("jira status is not supported in proxied-server mode")
+	}
 	evt := metrics.NewCommandEvent("jira-status")
 	defer func() {
 		if c := metrics.Global(); c != nil {

--- a/cmd/bd/kv.go
+++ b/cmd/bd/kv.go
@@ -81,6 +81,9 @@ Examples:
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if usesProxiedServer() {
+			return HandleErrorRespectJSON("kv set is not supported in proxied-server mode")
+		}
 		CheckReadonly("kv set")
 
 		evt := metrics.NewCommandEvent("kv-set")
@@ -130,6 +133,9 @@ Examples:
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if usesProxiedServer() {
+			return HandleErrorRespectJSON("kv get is not supported in proxied-server mode")
+		}
 		evt := metrics.NewCommandEvent("kv-get")
 		defer func() {
 			if c := metrics.Global(); c != nil {
@@ -185,6 +191,9 @@ Examples:
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if usesProxiedServer() {
+			return HandleErrorRespectJSON("kv clear is not supported in proxied-server mode")
+		}
 		CheckReadonly("kv clear")
 
 		evt := metrics.NewCommandEvent("kv-clear")
@@ -232,6 +241,9 @@ Examples:
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if usesProxiedServer() {
+			return HandleErrorRespectJSON("kv list is not supported in proxied-server mode")
+		}
 		evt := metrics.NewCommandEvent("kv-list")
 		defer func() {
 			if c := metrics.Global(); c != nil {

--- a/cmd/bd/label.go
+++ b/cmd/bd/label.go
@@ -121,6 +121,9 @@ var labelAddCmd = &cobra.Command{
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if usesProxiedServer() {
+			return HandleErrorRespectJSON("label add is not supported in proxied-server mode")
+		}
 		CheckReadonly("label add")
 
 		evt := metrics.NewCommandEvent("label-add")
@@ -162,6 +165,9 @@ var labelRemoveCmd = &cobra.Command{
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if usesProxiedServer() {
+			return HandleErrorRespectJSON("label remove is not supported in proxied-server mode")
+		}
 		CheckReadonly("label remove")
 
 		evt := metrics.NewCommandEvent("label-remove")
@@ -193,6 +199,9 @@ var labelListCmd = &cobra.Command{
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if usesProxiedServer() {
+			return HandleErrorRespectJSON("label list is not supported in proxied-server mode")
+		}
 		evt := metrics.NewCommandEvent("label-list")
 		defer func() {
 			if c := metrics.Global(); c != nil {
@@ -236,6 +245,9 @@ var labelListAllCmd = &cobra.Command{
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if usesProxiedServer() {
+			return HandleErrorRespectJSON("label list-all is not supported in proxied-server mode")
+		}
 		evt := metrics.NewCommandEvent("label-list-all")
 		defer func() {
 			if c := metrics.Global(); c != nil {
@@ -310,6 +322,9 @@ var labelPropagateCmd = &cobra.Command{
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if usesProxiedServer() {
+			return HandleErrorRespectJSON("label propagate is not supported in proxied-server mode")
+		}
 		CheckReadonly("label propagate")
 
 		evt := metrics.NewCommandEvent("label-propagate")

--- a/cmd/bd/linear.go
+++ b/cmd/bd/linear.go
@@ -215,6 +215,9 @@ func init() {
 }
 
 func runLinearSync(cmd *cobra.Command, args []string) error {
+	if usesProxiedServer() {
+		return HandleErrorRespectJSON("linear sync is not supported in proxied-server mode")
+	}
 	evt := metrics.NewCommandEvent("linear-sync")
 	defer func() {
 		if c := metrics.Global(); c != nil {
@@ -813,6 +816,9 @@ func buildLinearPushHooks(ctx context.Context, lt *linear.Tracker, allowProjectC
 }
 
 func runLinearStatus(cmd *cobra.Command, args []string) error {
+	if usesProxiedServer() {
+		return HandleErrorRespectJSON("linear status is not supported in proxied-server mode")
+	}
 	evt := metrics.NewCommandEvent("linear-status")
 	defer func() {
 		if c := metrics.Global(); c != nil {
@@ -926,6 +932,9 @@ func runLinearStatus(cmd *cobra.Command, args []string) error {
 }
 
 func runLinearTeams(cmd *cobra.Command, args []string) error {
+	if usesProxiedServer() {
+		return HandleErrorRespectJSON("linear teams is not supported in proxied-server mode")
+	}
 	evt := metrics.NewCommandEvent("linear-teams")
 	defer func() {
 		if c := metrics.Global(); c != nil {

--- a/cmd/bd/link.go
+++ b/cmd/bd/link.go
@@ -26,6 +26,9 @@ Examples:
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if usesProxiedServer() {
+			return HandleErrorRespectJSON("link is not supported in proxied-server mode")
+		}
 		CheckReadonly("link")
 
 		evt := metrics.NewCommandEvent("link")

--- a/cmd/bd/lint.go
+++ b/cmd/bd/lint.go
@@ -45,6 +45,9 @@ Examples:
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if usesProxiedServer() {
+			return HandleErrorRespectJSON("lint is not supported in proxied-server mode")
+		}
 		evt := metrics.NewCommandEvent("lint")
 		defer func() {
 			if c := metrics.Global(); c != nil {

--- a/cmd/bd/memory.go
+++ b/cmd/bd/memory.go
@@ -91,6 +91,9 @@ Examples:
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if usesProxiedServer() {
+			return HandleErrorRespectJSON("remember is not supported in proxied-server mode")
+		}
 		CheckReadonly("remember")
 
 		evt := metrics.NewCommandEvent("remember")
@@ -208,6 +211,9 @@ Examples:
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if usesProxiedServer() {
+			return HandleErrorRespectJSON("memories is not supported in proxied-server mode")
+		}
 		evt := metrics.NewCommandEvent("memories")
 		defer func() {
 			if c := metrics.Global(); c != nil {
@@ -299,6 +305,9 @@ Examples:
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if usesProxiedServer() {
+			return HandleErrorRespectJSON("forget is not supported in proxied-server mode")
+		}
 		CheckReadonly("forget")
 
 		evt := metrics.NewCommandEvent("forget")
@@ -362,6 +371,9 @@ Examples:
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if usesProxiedServer() {
+			return HandleErrorRespectJSON("recall is not supported in proxied-server mode")
+		}
 		evt := metrics.NewCommandEvent("recall")
 		defer func() {
 			if c := metrics.Global(); c != nil {

--- a/cmd/bd/merge_slot.go
+++ b/cmd/bd/merge_slot.go
@@ -114,6 +114,9 @@ func init() {
 }
 
 func runMergeSlotCreate(cmd *cobra.Command, args []string) error {
+	if usesProxiedServer() {
+		return HandleErrorRespectJSON("merge-slot create is not supported in proxied-server mode")
+	}
 	CheckReadonly("merge-slot create")
 
 	evt := metrics.NewCommandEvent("merge-slot-create")
@@ -145,6 +148,9 @@ func runMergeSlotCreate(cmd *cobra.Command, args []string) error {
 }
 
 func runMergeSlotCheck(cmd *cobra.Command, args []string) error {
+	if usesProxiedServer() {
+		return HandleErrorRespectJSON("merge-slot check is not supported in proxied-server mode")
+	}
 	evt := metrics.NewCommandEvent("merge-slot-check")
 	defer func() {
 		if c := metrics.Global(); c != nil {
@@ -202,6 +208,9 @@ func runMergeSlotCheck(cmd *cobra.Command, args []string) error {
 }
 
 func runMergeSlotAcquire(cmd *cobra.Command, args []string) error {
+	if usesProxiedServer() {
+		return HandleErrorRespectJSON("merge-slot acquire is not supported in proxied-server mode")
+	}
 	CheckReadonly("merge-slot acquire")
 
 	evt := metrics.NewCommandEvent("merge-slot-acquire")
@@ -284,6 +293,9 @@ func runMergeSlotAcquire(cmd *cobra.Command, args []string) error {
 }
 
 func runMergeSlotRelease(cmd *cobra.Command, args []string) error {
+	if usesProxiedServer() {
+		return HandleErrorRespectJSON("merge-slot release is not supported in proxied-server mode")
+	}
 	CheckReadonly("merge-slot release")
 
 	evt := metrics.NewCommandEvent("merge-slot-release")

--- a/cmd/bd/migrate.go
+++ b/cmd/bd/migrate.go
@@ -44,6 +44,9 @@ BD_ALLOW_REMOTE_MIGRATE=1 remains supported for scripted/CI use.
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, _ []string) error {
+		if usesProxiedServer() {
+			return HandleErrorRespectJSON("migrate is not supported in proxied-server mode")
+		}
 		evt := metrics.NewCommandEvent("migrate")
 		defer func() {
 			if c := metrics.Global(); c != nil {
@@ -746,6 +749,9 @@ Example:
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if usesProxiedServer() {
+			return HandleErrorRespectJSON("migrate sync is not supported in proxied-server mode")
+		}
 		evt := metrics.NewCommandEvent("migrate-sync")
 		defer func() {
 			if c := metrics.Global(); c != nil {
@@ -777,6 +783,9 @@ Example:
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, _ []string) error {
+		if usesProxiedServer() {
+			return HandleErrorRespectJSON("migrate schema is not supported in proxied-server mode")
+		}
 		CheckReadonly("migrate schema")
 
 		evt := metrics.NewCommandEvent("migrate-schema")

--- a/cmd/bd/migrate_personal.go
+++ b/cmd/bd/migrate_personal.go
@@ -46,6 +46,9 @@ func init() {
 }
 
 func runMigratePersonal(cmd *cobra.Command, args []string) error {
+	if usesProxiedServer() {
+		return HandleErrorRespectJSON("migrate-personal is not supported in proxied-server mode")
+	}
 	ctx := rootCtx
 
 	identity := getActorWithGit()

--- a/cmd/bd/mol_bond.go
+++ b/cmd/bd/mol_bond.go
@@ -84,6 +84,9 @@ type BondResult struct {
 }
 
 func runMolBond(cmd *cobra.Command, args []string) error {
+	if usesProxiedServer() {
+		return HandleErrorRespectJSON("mol bond is not supported in proxied-server mode")
+	}
 	CheckReadonly("mol bond")
 
 	evt := metrics.NewCommandEvent("mol-bond")

--- a/cmd/bd/mol_burn.go
+++ b/cmd/bd/mol_burn.go
@@ -56,6 +56,9 @@ type BatchBurnResult struct {
 }
 
 func runMolBurn(cmd *cobra.Command, args []string) error {
+	if usesProxiedServer() {
+		return HandleErrorRespectJSON("mol burn is not supported in proxied-server mode")
+	}
 	CheckReadonly("mol burn")
 
 	evt := metrics.NewCommandEvent("mol-burn")

--- a/cmd/bd/mol_current.go
+++ b/cmd/bd/mol_current.go
@@ -61,6 +61,9 @@ Use --limit or --range to view specific steps:
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if usesProxiedServer() {
+			return HandleErrorRespectJSON("mol current is not supported in proxied-server mode")
+		}
 		evt := metrics.NewCommandEvent("mol-current")
 		defer func() {
 			if c := metrics.Global(); c != nil {

--- a/cmd/bd/mol_distill.go
+++ b/cmd/bd/mol_distill.go
@@ -103,6 +103,9 @@ func parseDistillVar(varFlag, searchableText string) (string, string, error) {
 }
 
 func runMolDistill(cmd *cobra.Command, args []string) error {
+	if usesProxiedServer() {
+		return HandleErrorRespectJSON("mol distill is not supported in proxied-server mode")
+	}
 	evt := metrics.NewCommandEvent("mol-distill")
 	defer func() {
 		if c := metrics.Global(); c != nil {

--- a/cmd/bd/mol_last_activity.go
+++ b/cmd/bd/mol_last_activity.go
@@ -29,6 +29,9 @@ Examples:
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if usesProxiedServer() {
+			return HandleErrorRespectJSON("mol last-activity is not supported in proxied-server mode")
+		}
 		evt := metrics.NewCommandEvent("mol-last-activity")
 		defer func() {
 			if c := metrics.Global(); c != nil {

--- a/cmd/bd/mol_progress.go
+++ b/cmd/bd/mol_progress.go
@@ -34,6 +34,9 @@ Example:
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if usesProxiedServer() {
+			return HandleErrorRespectJSON("mol progress is not supported in proxied-server mode")
+		}
 		evt := metrics.NewCommandEvent("mol-progress")
 		defer func() {
 			if c := metrics.Global(); c != nil {

--- a/cmd/bd/mol_ready_gated.go
+++ b/cmd/bd/mol_ready_gated.go
@@ -49,6 +49,9 @@ Examples:
 }
 
 func runMolReadyGated(cmd *cobra.Command, args []string) error {
+	if usesProxiedServer() {
+		return HandleErrorRespectJSON("mol ready is not supported in proxied-server mode")
+	}
 	evt := metrics.NewCommandEvent("mol-ready-gated")
 	defer func() {
 		if c := metrics.Global(); c != nil {

--- a/cmd/bd/mol_show.go
+++ b/cmd/bd/mol_show.go
@@ -32,6 +32,9 @@ Example:
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if usesProxiedServer() {
+			return HandleErrorRespectJSON("mol show is not supported in proxied-server mode")
+		}
 		evt := metrics.NewCommandEvent("mol-show")
 		defer func() {
 			if c := metrics.Global(); c != nil {

--- a/cmd/bd/mol_squash.go
+++ b/cmd/bd/mol_squash.go
@@ -63,6 +63,9 @@ type SquashResult struct {
 }
 
 func runMolSquash(cmd *cobra.Command, args []string) error {
+	if usesProxiedServer() {
+		return HandleErrorRespectJSON("mol squash is not supported in proxied-server mode")
+	}
 	CheckReadonly("mol squash")
 
 	evt := metrics.NewCommandEvent("mol-squash")

--- a/cmd/bd/mol_stale.go
+++ b/cmd/bd/mol_stale.go
@@ -54,6 +54,9 @@ type StaleResult struct {
 }
 
 func runMolStale(cmd *cobra.Command, args []string) error {
+	if usesProxiedServer() {
+		return HandleErrorRespectJSON("mol stale is not supported in proxied-server mode")
+	}
 	evt := metrics.NewCommandEvent("mol-stale")
 	defer func() {
 		if c := metrics.Global(); c != nil {

--- a/cmd/bd/note.go
+++ b/cmd/bd/note.go
@@ -28,6 +28,9 @@ Examples:
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if usesProxiedServer() {
+			return HandleErrorRespectJSON("note is not supported in proxied-server mode")
+		}
 		CheckReadonly("note")
 
 		evt := metrics.NewCommandEvent("note")

--- a/cmd/bd/notion.go
+++ b/cmd/bd/notion.go
@@ -219,6 +219,9 @@ func maskNotionAuth(auth *notion.ResolvedAuth) string {
 }
 
 func runNotionStatus(cmd *cobra.Command, _ []string) error {
+	if usesProxiedServer() {
+		return HandleErrorRespectJSON("notion status is not supported in proxied-server mode")
+	}
 	evt := metrics.NewCommandEvent("notion-status")
 	defer func() {
 		if c := metrics.Global(); c != nil {
@@ -289,6 +292,9 @@ func runNotionStatus(cmd *cobra.Command, _ []string) error {
 }
 
 func runNotionInit(cmd *cobra.Command, _ []string) error {
+	if usesProxiedServer() {
+		return HandleErrorRespectJSON("notion init is not supported in proxied-server mode")
+	}
 	CheckReadonly("notion init")
 
 	evt := metrics.NewCommandEvent("notion-init")
@@ -339,6 +345,9 @@ func runNotionInit(cmd *cobra.Command, _ []string) error {
 }
 
 func runNotionConnect(cmd *cobra.Command, _ []string) error {
+	if usesProxiedServer() {
+		return HandleErrorRespectJSON("notion connect is not supported in proxied-server mode")
+	}
 	CheckReadonly("notion connect")
 
 	evt := metrics.NewCommandEvent("notion-connect")
@@ -428,6 +437,9 @@ func renderNotionStatus(cmd *cobra.Command, auth *notion.ResolvedAuth, cfg notio
 }
 
 func runNotionSync(cmd *cobra.Command, _ []string) error {
+	if usesProxiedServer() {
+		return HandleErrorRespectJSON("notion sync is not supported in proxied-server mode")
+	}
 	evt := metrics.NewCommandEvent("notion-sync")
 	defer func() {
 		if c := metrics.Global(); c != nil {

--- a/cmd/bd/orphans.go
+++ b/cmd/bd/orphans.go
@@ -44,6 +44,9 @@ Examples:
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if usesProxiedServer() {
+			return HandleErrorRespectJSON("orphans is not supported in proxied-server mode")
+		}
 		evt := metrics.NewCommandEvent("orphans")
 		defer func() {
 			if c := metrics.Global(); c != nil {

--- a/cmd/bd/ping.go
+++ b/cmd/bd/ping.go
@@ -33,6 +33,9 @@ Examples:
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if usesProxiedServer() {
+			return HandleErrorRespectJSON("ping is not supported in proxied-server mode")
+		}
 		evt := metrics.NewCommandEvent("ping")
 		defer func() {
 			if c := metrics.Global(); c != nil {

--- a/cmd/bd/priority.go
+++ b/cmd/bd/priority.go
@@ -31,6 +31,9 @@ Examples:
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if usesProxiedServer() {
+			return HandleErrorRespectJSON("priority is not supported in proxied-server mode")
+		}
 		CheckReadonly("priority")
 
 		evt := metrics.NewCommandEvent("priority")

--- a/cmd/bd/promote.go
+++ b/cmd/bd/promote.go
@@ -31,6 +31,9 @@ Examples:
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if usesProxiedServer() {
+			return HandleErrorRespectJSON("promote is not supported in proxied-server mode")
+		}
 		CheckReadonly("promote")
 
 		evt := metrics.NewCommandEvent("promote")

--- a/cmd/bd/quick.go
+++ b/cmd/bd/quick.go
@@ -28,6 +28,9 @@ Example:
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if usesProxiedServer() {
+			return HandleErrorRespectJSON("q is not supported in proxied-server mode")
+		}
 		// Create the event before the readonly guard so the operation label
 		// matches this command ("q", not "create") and the readonly exit path
 		// still flushes queued metrics via CheckReadonly's CloseAndFlush.

--- a/cmd/bd/reclaim.go
+++ b/cmd/bd/reclaim.go
@@ -36,6 +36,9 @@ Examples:
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if usesProxiedServer() {
+			return HandleErrorRespectJSON("reclaim is not supported in proxied-server mode")
+		}
 		CheckReadonly("reclaim")
 
 		evt := metrics.NewCommandEvent("reclaim")

--- a/cmd/bd/recompute_blocked.go
+++ b/cmd/bd/recompute_blocked.go
@@ -32,6 +32,9 @@ Examples:
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(_ *cobra.Command, _ []string) error {
+		if usesProxiedServer() {
+			return HandleErrorRespectJSON("recompute-blocked is not supported in proxied-server mode")
+		}
 		CheckReadonly("recompute-blocked")
 
 		evt := metrics.NewCommandEvent("recompute-blocked")

--- a/cmd/bd/rename.go
+++ b/cmd/bd/rename.go
@@ -40,6 +40,9 @@ func init() {
 }
 
 func runRename(cmd *cobra.Command, args []string) error {
+	if usesProxiedServer() {
+		return HandleErrorRespectJSON("rename is not supported in proxied-server mode")
+	}
 	evt := metrics.NewCommandEvent("rename")
 	defer func() {
 		if c := metrics.Global(); c != nil {

--- a/cmd/bd/rename_prefix.go
+++ b/cmd/bd/rename_prefix.go
@@ -55,6 +55,9 @@ NOTE: This is a rare operation. Most users never need this command.`,
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if usesProxiedServer() {
+			return HandleErrorRespectJSON("rename-prefix is not supported in proxied-server mode")
+		}
 		evt := metrics.NewCommandEvent("rename-prefix")
 		defer func() {
 			if c := metrics.Global(); c != nil {

--- a/cmd/bd/repo.go
+++ b/cmd/bd/repo.go
@@ -54,6 +54,9 @@ shared across all clones of this repository.`,
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if usesProxiedServer() {
+			return HandleErrorRespectJSON("repo add is not supported in proxied-server mode")
+		}
 		evt := metrics.NewCommandEvent("repo-add")
 		defer func() {
 			if c := metrics.Global(); c != nil {
@@ -117,6 +120,9 @@ that came from the removed repository.`,
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if usesProxiedServer() {
+			return HandleErrorRespectJSON("repo remove is not supported in proxied-server mode")
+		}
 		evt := metrics.NewCommandEvent("repo-remove")
 		defer func() {
 			if c := metrics.Global(); c != nil {
@@ -186,6 +192,9 @@ repositories configured for hydration.`,
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if usesProxiedServer() {
+			return HandleErrorRespectJSON("repo list is not supported in proxied-server mode")
+		}
 		evt := metrics.NewCommandEvent("repo-list")
 		defer func() {
 			if c := metrics.Global(); c != nil {
@@ -245,6 +254,9 @@ Also triggers Dolt push/pull if a remote is configured.`,
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if usesProxiedServer() {
+			return HandleErrorRespectJSON("repo sync is not supported in proxied-server mode")
+		}
 		evt := metrics.NewCommandEvent("repo-sync")
 		defer func() {
 			if c := metrics.Global(); c != nil {

--- a/cmd/bd/reset.go
+++ b/cmd/bd/reset.go
@@ -41,6 +41,9 @@ func init() {
 }
 
 func runReset(cmd *cobra.Command, args []string) error {
+	if usesProxiedServer() {
+		return HandleErrorRespectJSON("admin reset is not supported in proxied-server mode")
+	}
 	evt := metrics.NewCommandEvent("admin-reset")
 	defer func() {
 		if c := metrics.Global(); c != nil {

--- a/cmd/bd/restore.go
+++ b/cmd/bd/restore.go
@@ -35,6 +35,9 @@ before snapshot archiving), restore falls back to a best-effort reconstruction
 from Dolt version history, which can only be displayed, not applied.`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if usesProxiedServer() {
+			return HandleErrorRespectJSON("restore is not supported in proxied-server mode")
+		}
 		issueID := args[0]
 		ctx := rootCtx
 

--- a/cmd/bd/search.go
+++ b/cmd/bd/search.go
@@ -39,6 +39,9 @@ Examples:
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if usesProxiedServer() {
+			return HandleErrorRespectJSON("search is not supported in proxied-server mode")
+		}
 		evt := metrics.NewCommandEvent("search")
 		defer func() {
 			if c := metrics.Global(); c != nil {

--- a/cmd/bd/ship.go
+++ b/cmd/bd/ship.go
@@ -37,6 +37,9 @@ Examples:
 }
 
 func runShip(cmd *cobra.Command, args []string) error {
+	if usesProxiedServer() {
+		return HandleErrorRespectJSON("ship is not supported in proxied-server mode")
+	}
 	CheckReadonly("ship")
 
 	evt := metrics.NewCommandEvent("ship")

--- a/cmd/bd/stale.go
+++ b/cmd/bd/stale.go
@@ -22,6 +22,9 @@ This helps identify:
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if usesProxiedServer() {
+			return HandleErrorRespectJSON("stale is not supported in proxied-server mode")
+		}
 		evt := metrics.NewCommandEvent("stale")
 		defer func() {
 			if c := metrics.Global(); c != nil {

--- a/cmd/bd/state.go
+++ b/cmd/bd/state.go
@@ -36,6 +36,9 @@ Examples:
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if usesProxiedServer() {
+			return HandleErrorRespectJSON("state is not supported in proxied-server mode")
+		}
 		evt := metrics.NewCommandEvent("state")
 		defer func() {
 			if c := metrics.Global(); c != nil {
@@ -116,6 +119,9 @@ The --reason flag provides context for the event bead (recommended).`,
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if usesProxiedServer() {
+			return HandleErrorRespectJSON("set-state is not supported in proxied-server mode")
+		}
 		CheckReadonly("set-state")
 
 		evt := metrics.NewCommandEvent("set-state")
@@ -272,6 +278,9 @@ Example:
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if usesProxiedServer() {
+			return HandleErrorRespectJSON("state list is not supported in proxied-server mode")
+		}
 		evt := metrics.NewCommandEvent("state-list")
 		defer func() {
 			if c := metrics.Global(); c != nil {

--- a/cmd/bd/status.go
+++ b/cmd/bd/status.go
@@ -55,6 +55,9 @@ Examples:
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if usesProxiedServer() {
+			return HandleErrorRespectJSON("status is not supported in proxied-server mode")
+		}
 		evt := metrics.NewCommandEvent("status")
 		defer func() {
 			if c := metrics.Global(); c != nil {

--- a/cmd/bd/statuses.go
+++ b/cmd/bd/statuses.go
@@ -51,6 +51,9 @@ Examples:
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if usesProxiedServer() {
+			return HandleErrorRespectJSON("statuses is not supported in proxied-server mode")
+		}
 		evt := metrics.NewCommandEvent("statuses")
 		defer func() {
 			if c := metrics.Global(); c != nil {

--- a/cmd/bd/swarm.go
+++ b/cmd/bd/swarm.go
@@ -157,6 +157,9 @@ Examples:
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if usesProxiedServer() {
+			return HandleErrorRespectJSON("swarm validate is not supported in proxied-server mode")
+		}
 		evt := metrics.NewCommandEvent("swarm-validate")
 		defer func() {
 			if c := metrics.Global(); c != nil {
@@ -620,6 +623,9 @@ Examples:
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if usesProxiedServer() {
+			return HandleErrorRespectJSON("swarm status is not supported in proxied-server mode")
+		}
 		evt := metrics.NewCommandEvent("swarm-status")
 		defer func() {
 			if c := metrics.Global(); c != nil {
@@ -904,6 +910,9 @@ Examples:
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if usesProxiedServer() {
+			return HandleErrorRespectJSON("swarm create is not supported in proxied-server mode")
+		}
 		CheckReadonly("swarm create")
 
 		evt := metrics.NewCommandEvent("swarm-create")
@@ -1086,6 +1095,9 @@ Examples:
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if usesProxiedServer() {
+			return HandleErrorRespectJSON("swarm list is not supported in proxied-server mode")
+		}
 		evt := metrics.NewCommandEvent("swarm-list")
 		defer func() {
 			if c := metrics.Global(); c != nil {

--- a/cmd/bd/tag.go
+++ b/cmd/bd/tag.go
@@ -23,6 +23,9 @@ Examples:
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if usesProxiedServer() {
+			return HandleErrorRespectJSON("tag is not supported in proxied-server mode")
+		}
 		CheckReadonly("tag")
 
 		evt := metrics.NewCommandEvent("tag")

--- a/cmd/bd/todo.go
+++ b/cmd/bd/todo.go
@@ -30,6 +30,9 @@ TODOs can be promoted to full issues by changing type or priority:
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if usesProxiedServer() {
+			return HandleErrorRespectJSON("todo is not supported in proxied-server mode")
+		}
 		evt := metrics.NewCommandEvent("todo")
 		defer func() {
 			if c := metrics.Global(); c != nil {
@@ -50,6 +53,9 @@ var addTodoCmd = &cobra.Command{
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if usesProxiedServer() {
+			return HandleErrorRespectJSON("todo add is not supported in proxied-server mode")
+		}
 		CheckReadonly("todo add")
 
 		evt := metrics.NewCommandEvent("todo-add")
@@ -103,6 +109,9 @@ var listTodosCmd = &cobra.Command{
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if usesProxiedServer() {
+			return HandleErrorRespectJSON("todo list is not supported in proxied-server mode")
+		}
 		evt := metrics.NewCommandEvent("todo-list")
 		defer func() {
 			if c := metrics.Global(); c != nil {
@@ -172,6 +181,9 @@ var doneTodoCmd = &cobra.Command{
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if usesProxiedServer() {
+			return HandleErrorRespectJSON("todo done is not supported in proxied-server mode")
+		}
 		CheckReadonly("todo done")
 
 		evt := metrics.NewCommandEvent("todo-done")

--- a/cmd/bd/types.go
+++ b/cmd/bd/types.go
@@ -43,6 +43,9 @@ Examples:
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if usesProxiedServer() {
+			return HandleErrorRespectJSON("types is not supported in proxied-server mode")
+		}
 		evt := metrics.NewCommandEvent("types")
 		defer func() {
 			if c := metrics.Global(); c != nil {

--- a/cmd/bd/unclaim.go
+++ b/cmd/bd/unclaim.go
@@ -26,6 +26,9 @@ Examples:
   bd unclaim bd-123 bd-456`,
 	Args: cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if usesProxiedServer() {
+			return HandleErrorRespectJSON("unclaim is not supported in proxied-server mode")
+		}
 		CheckReadonly("unclaim")
 		reason, _ := cmd.Flags().GetString("reason")
 		force, _ := cmd.Flags().GetBool("force")

--- a/cmd/bd/undefer.go
+++ b/cmd/bd/undefer.go
@@ -26,6 +26,9 @@ Examples:
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if usesProxiedServer() {
+			return HandleErrorRespectJSON("undefer is not supported in proxied-server mode")
+		}
 		CheckReadonly("undefer")
 
 		evt := metrics.NewCommandEvent("undefer")

--- a/cmd/bd/vc.go
+++ b/cmd/bd/vc.go
@@ -43,6 +43,9 @@ Examples:
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if usesProxiedServer() {
+			return HandleErrorRespectJSON("vc merge is not supported in proxied-server mode")
+		}
 		evt := metrics.NewCommandEvent("vc-merge")
 		defer func() {
 			if c := metrics.Global(); c != nil {
@@ -146,6 +149,9 @@ Examples:
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if usesProxiedServer() {
+			return HandleErrorRespectJSON("vc commit is not supported in proxied-server mode")
+		}
 		evt := metrics.NewCommandEvent("vc-commit")
 		defer func() {
 			if c := metrics.Global(); c != nil {
@@ -214,6 +220,9 @@ Examples:
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if usesProxiedServer() {
+			return HandleErrorRespectJSON("vc status is not supported in proxied-server mode")
+		}
 		evt := metrics.NewCommandEvent("vc-status")
 		defer func() {
 			if c := metrics.Global(); c != nil {


### PR DESCRIPTION
## Summary

Adds early-return `not supported in proxied-server mode` guards to every `bd` CLI command that requires the DB store but has no proxied-server implementation.

In proxied-server mode, the root `PersistentPreRunE` short-circuits to the `uowProvider` path and leaves the global `store` nil. Commands that dereference `store` would nil-panic (or emit a generic `no store available`); this replaces that with a clear, consistent `HandleErrorRespectJSON("<cmd> is not supported in proxied-server mode")` guard at the top of each affected `RunE`.

## Classification rule

A command is guarded iff it requires the global `store`. Left untouched:
- Commands that already dispatch through the proxied path (`usesProxiedServer()`): `create`, `list`, `query`, `show`, `update`, `close`, `reopen`, `delete`, `dep`, `ready`, `blocked`, `purge`, `prune`, `sql`, `config`.
- `noDbCommands` (skip the store path entirely): `bootstrap`, `context`, `dolt`, `doctor`, `hooks`, `human`, `init`, `onboard`, `prime`, `quickstart`, `setup`, `where`, `completion`, `formula`, `help`, `metrics`, `version`.
- No DB dependency: `preflight`, `rules`, `upgrade`, `worktree`, `audit`, `init-safety`, `mail`, `mol seed`.

## Notable judgment calls

- **`migrate`**: guarded the DB-backed leaves (bare `migrate`, `migrate sync`, `migrate schema`) but deliberately left the four mode-switch subcommands (`from-*-to-*`) and `migrate hooks` alone — the mode-switchers are exactly how you transition in/out of proxied mode and must keep working.
- **Integrations** (`jira`/`linear`/`ado`/`github`/`gitlab`/`notion`): guarded every leaf for a uniform message, even the ones that only degrade gracefully via env-var config fallback, matching the `backup` family treatment.

83 files changed, guards only — no behavior change outside proxied-server mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)