### PR TITLE
perf(schema): skip migration lock on already-migrated opens

### DIFF
--- a/internal/storage/schema/lock.go
+++ b/internal/storage/schema/lock.go
@@ -53,7 +53,17 @@ func MigrationLockName(databaseName string) string {
 // server session. Embedded Dolt intentionally uses bare MigrateUp because it
 // relies on the embedded driver's file/concurrency controls instead of
 // sql-server session locks.
+//
+// A read-only fast path skips the lock entirely when the database is provably
+// at-latest and seeded, so the common open no longer serializes every concurrent
+// connection on the per-database GET_LOCK.
 func MigrateUpWithLock(ctx context.Context, conn *sql.Conn, databaseName string) (applied int, err error) {
+	if noop, err := migrateUpWouldNoop(ctx, conn); err != nil {
+		return 0, err
+	} else if noop {
+		return 0, nil
+	}
+
 	lockName := MigrationLockName(databaseName)
 	if err := AcquireMigrationLock(ctx, conn, lockName); err != nil {
 		return 0, err
@@ -65,6 +75,23 @@ func MigrateUpWithLock(ctx context.Context, conn *sql.Conn, databaseName string)
 	}()
 
 	return MigrateUp(ctx, conn)
+}
+
+// migrateUpWouldNoop reports whether MigrateUp is guaranteed to do nothing on
+// this database: no pending migration work AND the canonical dolt_ignore
+// patterns already seeded. Both probes are read-only, letting an at-latest open
+// skip the serializing per-database migration lock. Pending work or an
+// under-seeded out-of-band copy returns false so the caller takes the lock and
+// runs the authoritative MigrateUp.
+func migrateUpWouldNoop(ctx context.Context, conn *sql.Conn) (bool, error) {
+	needed, err := migrationWorkNeeded(ctx, conn)
+	if err != nil {
+		return false, err
+	}
+	if needed {
+		return false, nil
+	}
+	return doltIgnorePatternsSeeded(ctx, conn)
 }
 
 // AcquireMigrationLock acquires the named schema migration lock on the pinned

--- a/internal/storage/schema/lock_test.go
+++ b/internal/storage/schema/lock_test.go
@@ -75,6 +75,9 @@ func TestMigrateUpWithLockUsesDatabaseScopedLockOnly(t *testing.T) {
 	defer conn.Close()
 
 	lockName := MigrationLockName("testdb")
+	// The pre-lock fast-path probe finds the main cursor behind latest and
+	// reports work needed, so MigrateUpWithLock still takes the lock.
+	expectScalar(mock, "SELECT COALESCE(MAX(version), 0) FROM schema_migrations", "version", LatestVersion()-1)
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT GET_LOCK(?, ?)")).
 		WithArgs(lockName, migrationLockAcquireTimeoutSeconds).
 		WillReturnRows(sqlmock.NewRows([]string{"locked"}).AddRow(1))
@@ -93,6 +96,116 @@ func TestMigrateUpWithLockUsesDatabaseScopedLockOnly(t *testing.T) {
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("unmet SQL expectations: %v", err)
 	}
+}
+
+// TestMigrateUpWithLockSkipsLockWhenAtLatestAndSeeded proves the fast path: an
+// already-migrated, already-seeded database must NOT acquire the per-database
+// GET_LOCK, so concurrent opens stop serializing on it. sqlmock fails on any
+// unexpected query, so an errant GET_LOCK would fail this test.
+func TestMigrateUpWithLockSkipsLockWhenAtLatestAndSeeded(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("create sql mock: %v", err)
+	}
+	defer db.Close()
+
+	ctx := context.Background()
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		t.Fatalf("pin mock connection: %v", err)
+	}
+	defer conn.Close()
+
+	// migrationWorkNeeded: both cursors at latest, both content_hash columns
+	// present, no custom backfill -> no work needed.
+	expectScalar(mock, "SELECT COALESCE(MAX(version), 0) FROM schema_migrations", "version", LatestVersion())
+	expectScalar(mock, "SELECT COALESCE(MAX(version), 0) FROM ignored_schema_migrations", "version", LatestIgnoredVersion())
+	expectContentHashColumnExists(mock)
+	expectContentHashColumnExists(mock)
+	expectScalar(mock, "SELECT COUNT(*) FROM custom_types", "count", 1)
+	expectScalar(mock, "SELECT COUNT(*) FROM custom_statuses", "count", 1)
+	// dolt_ignore fully seeded -> the open is provably a no-op; no lock taken.
+	expectDoltIgnoreSeeded(mock, len(doltIgnorePatterns))
+
+	applied, err := MigrateUpWithLock(ctx, conn, "testdb")
+	if err != nil {
+		t.Fatalf("MigrateUpWithLock() error = %v", err)
+	}
+	if applied != 0 {
+		t.Fatalf("MigrateUpWithLock() applied = %d, want 0", applied)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet SQL expectations (at-latest seeded open must skip GET_LOCK): %v", err)
+	}
+}
+
+// TestMigrateUpWithLockTakesLockWhenUnderSeeded proves the fast path preserves
+// the #4566 self-heal contract: a database at latest but missing dolt_ignore
+// patterns (out-of-band copy) still takes the lock, so the seed and its commit
+// stay serialized instead of racing across concurrent opens.
+func TestMigrateUpWithLockTakesLockWhenUnderSeeded(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("create sql mock: %v", err)
+	}
+	defer db.Close()
+
+	ctx := context.Background()
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		t.Fatalf("pin mock connection: %v", err)
+	}
+	defer conn.Close()
+
+	lockName := MigrationLockName("testdb")
+	// Fast-path probe: at latest (no migration pass)...
+	expectScalar(mock, "SELECT COALESCE(MAX(version), 0) FROM schema_migrations", "version", LatestVersion())
+	expectScalar(mock, "SELECT COALESCE(MAX(version), 0) FROM ignored_schema_migrations", "version", LatestIgnoredVersion())
+	expectContentHashColumnExists(mock)
+	expectContentHashColumnExists(mock)
+	expectScalar(mock, "SELECT COUNT(*) FROM custom_types", "count", 1)
+	expectScalar(mock, "SELECT COUNT(*) FROM custom_statuses", "count", 1)
+	// ...but dolt_ignore is under-seeded, so the fast path declines the no-op
+	// and the lock path runs the authoritative MigrateUp under GET_LOCK.
+	expectDoltIgnoreSeeded(mock, len(doltIgnorePatterns)-1)
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT GET_LOCK(?, ?)")).
+		WithArgs(lockName, migrationLockAcquireTimeoutSeconds).
+		WillReturnRows(sqlmock.NewRows([]string{"locked"}).AddRow(1))
+	// MigrateUp re-seeds (rows change), re-checks work, then commits the seed
+	// scoped+labeled and short-circuits (no migration pass).
+	expectIgnorePatternSeed(mock)
+	expectScalar(mock, "SELECT COALESCE(MAX(version), 0) FROM schema_migrations", "version", LatestVersion())
+	expectScalar(mock, "SELECT COALESCE(MAX(version), 0) FROM ignored_schema_migrations", "version", LatestIgnoredVersion())
+	expectContentHashColumnExists(mock)
+	expectContentHashColumnExists(mock)
+	expectScalar(mock, "SELECT COUNT(*) FROM custom_types", "count", 1)
+	expectScalar(mock, "SELECT COUNT(*) FROM custom_statuses", "count", 1)
+	mock.ExpectExec(regexp.QuoteMeta("CALL DOLT_ADD('dolt_ignore')")).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec(regexp.QuoteMeta("CALL DOLT_COMMIT('-m', 'schema: seed dolt_ignore patterns')")).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT RELEASE_LOCK(?)")).
+		WithArgs(lockName).
+		WillReturnRows(sqlmock.NewRows([]string{"released"}).AddRow(1))
+
+	applied, err := MigrateUpWithLock(ctx, conn, "testdb")
+	if err != nil {
+		t.Fatalf("MigrateUpWithLock() error = %v", err)
+	}
+	if applied != 0 {
+		t.Fatalf("MigrateUpWithLock() applied = %d, want 0", applied)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet SQL expectations (under-seeded at-latest open must take the lock): %v", err)
+	}
+}
+
+// expectDoltIgnoreSeeded mocks the read-only dolt_ignore pattern-presence probe
+// that gates the lock-free fast path, reporting present of len(doltIgnorePatterns).
+func expectDoltIgnoreSeeded(mock sqlmock.Sqlmock, present int) {
+	placeholders := strings.TrimSuffix(strings.Repeat("?, ", len(doltIgnorePatterns)), ", ")
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT COUNT(*) FROM dolt_ignore WHERE pattern IN (" + placeholders + ")")).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(present))
 }
 
 // TestMigrateUpSeedsIgnorePatternsWhenNoWorkNeeded is the regression guard for

--- a/internal/storage/schema/schema.go
+++ b/internal/storage/schema/schema.go
@@ -256,6 +256,24 @@ func seedDoltIgnorePatterns(ctx context.Context, db DBConn) (bool, error) {
 	return changed, nil
 }
 
+// doltIgnorePatternsSeeded reports whether every canonical dolt_ignore pattern
+// is already present. It is the read-only counterpart to seedDoltIgnorePatterns
+// used to prove an at-latest open would be a pure no-op.
+func doltIgnorePatternsSeeded(ctx context.Context, db DBConn) (bool, error) {
+	placeholders := make([]string, len(doltIgnorePatterns))
+	args := make([]any, len(doltIgnorePatterns))
+	for i, pattern := range doltIgnorePatterns {
+		placeholders[i] = "?"
+		args[i] = pattern
+	}
+	query := "SELECT COUNT(*) FROM dolt_ignore WHERE pattern IN (" + strings.Join(placeholders, ", ") + ")"
+	var present int
+	if err := db.QueryRowContext(ctx, query, args...).Scan(&present); err != nil {
+		return false, err
+	}
+	return present == len(doltIgnorePatterns), nil
+}
+
 // commitSeededDoltIgnore stages and commits freshly seeded dolt_ignore rows
 // in a scoped, labeled commit. Both MigrateUp paths use it: on the no-work
 // short-circuit nothing downstream would ever commit the seed, and on the


### PR DESCRIPTION
## Summary

`schema.MigrateUpWithLock` acquires the per-database schema-migration advisory lock (`SELECT GET_LOCK`) on **every** server-mode database open (via `dolt.initSchemaOnDB`). Because `bd` opens a fresh connection per operation and the lock is a single named lock per database, **every concurrent open on a shared Dolt sql-server serializes through that one lock** — even when the schema is already at the latest version and no migration will run.

Under load on a busy shared database the lock queue deepens until acquisition exceeds the 5s `GET_LOCK` timeout and opens fail with:

```
schema: acquire migration lock: schema migration lock unavailable: timeout
```

A hot-but-healthy server degrades into one that drops writes and thrashes on retries.

## Where

- `internal/storage/schema/lock.go` — `MigrateUpWithLock` unconditionally `AcquireMigrationLock` → `MigrateUp` → `ReleaseMigrationLock`.
- Caller: `internal/storage/dolt/store.go` `initSchemaOnDB`, run on every server-mode open.

The lock is only actually needed to serialize a migration pass (or the `dolt_ignore` self-heal commit). An open on an already-migrated, already-seeded database runs `MigrateUp` as a pure no-op, so it never needed the lock.

## Fix

Read-only double-checked locking. `MigrateUpWithLock` now probes `migrationWorkNeeded` and a new `doltIgnorePatternsSeeded` — **both plain reads** — and returns immediately without touching `GET_LOCK` when the open is provably a no-op. Any uncertainty (a pending migration, or an under-seeded out-of-band copy that still needs the `dolt_ignore` heal) falls through to the unchanged locked `MigrateUp`, so the #4566 self-heal contract and concurrent-migration serialization are preserved exactly.

Single layer (`internal/storage/schema`), +158 lines.

## Proof (beads-only, no orchestrator)

- `TestMigrateUpWithLockSkipsLockWhenAtLatestAndSeeded` — an at-latest, seeded open issues **no `GET_LOCK`** (sqlmock fails on any unexpected query, so an errant lock acquisition fails the test).
- `TestMigrateUpWithLockTakesLockWhenUnderSeeded` — an at-latest but under-seeded copy **still takes the lock** and commits the heal under it (the zero-regression / #4566 guard).
- `TestMigrateUpWithLockUsesDatabaseScopedLockOnly` — the unchanged pending-migration path still locks.

`go test ./internal/storage/schema/`, `go vet ./internal/storage/schema/`, and `gofmt -l` are all clean.

## Real-world corroboration

Surfaced in a high-concurrency deployment (~two dozen processes plus tight-cooldown health probes all opening one shared coordination database): `SHOW FULL PROCESSLIST` showed multiple connections parked in `SELECT GET_LOCK(...)` at once; the server log flooded with `Error reading packet from client ... i/o timeout`; trivial queries oscillated between ~3s and >40s (timeout). Restarting the server rebuilt the same contention within minutes — because the lock is re-acquired on every reconnect, not a wedged-process issue. The mechanism and the fix are entirely within beads; the tests above need no orchestrator.

## Out of scope

The same deployment also shows high connection **churn** (a fresh connect/close per `bd` invocation, no pooling). That is process/orchestrator-level, not a `schema`-layer concern, so it is intentionally excluded here (one layer per PR). This change targets the serialization that made opens *fail*; churn is a separate follow-up.

I couldn't add a wall-clock benchmark that is meaningful under `sqlmock` (no lock latency to measure); happy to add a real-server concurrent-open benchmark if you'd like one for the record.
