### PR TITLE
docs: Fix flowchart references in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,12 @@ Beads provides a persistent, structured memory for coding agents. It replaces me
 
 ```mermaid
 flowchart LR
-    create["bd create<br/>new bead"] --> graph["dependency<br/>graph"]
-    graph --> ready["bd ready<br/>claimable work"]
+    create["bd create<br/>new bead"] --> dep_graph["dependency<br/>graph"]
+    dep_graph --> ready["bd ready<br/>claimable work"]
     ready --> claim["bd update --claim<br/>agent takes it"]
     claim --> close["bd close<br/>work done"]
     close -->|blockers released| ready
-    graph <-->|"bd dolt push / pull"| remote[("other machines<br/>and agents")]
+    dep_graph <-->|"bd dolt push / pull"| remote[("other machines<br/>and agents")]
 ```
 
 ## ⚡ Quick Start


### PR DESCRIPTION
<!--
This is a starting scaffold to help reviewers (human and agent) parse intent before diff.
Replace, expand, or delete sections freely. CONTRIBUTING.md has the full hygiene rules.
-->

## What

Fix the "Unable to render rich display" error in the mermaid rendering because `graph` is a reserved word.

## Why

<img width="989" height="522" alt="image" src="https://github.com/user-attachments/assets/71ff3d64-ceaa-4eb9-8076-fb6eded27830" />

## Verification

Rendered the README.md confirming the fix.

<img width="1187" height="466" alt="image" src="https://github.com/user-attachments/assets/def173e8-f09d-47af-b43d-625e670d249b" />
