### PR TITLE
docs(doctor): record the per-subcommand embedded-support policy at the gate (GH#3794)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,11 @@ crash-recovery logic, or public SDK return types that leak driver internals.
 If the boundary is too narrow, widen the interface or route the issue to the
 driver instead of patching around it in beads.
 
+A live application of this rule: `bd doctor` support for embedded mode is
+enabled one subcommand at a time, each human-vetted (GH#3794). Do not lift the
+embedded-mode gate in `cmd/bd/doctor.go` wholesale, and keep database-layer
+checks and fixes server-gated until the driver interface covers them.
+
 ## Agent Warning: Interactive Commands
 
 **DO NOT use `bd edit`** - it opens an interactive editor ($EDITOR) which AI agents cannot use.

--- a/cmd/bd/doctor.go
+++ b/cmd/bd/doctor.go
@@ -263,6 +263,10 @@ Examples:
 
 		// Bare `bd doctor` and the remaining mode-specific flags (--deep,
 		// --server, --migration) aren't wired up for embedded mode yet.
+		// Policy (GH#3794): embedded support is enabled one subcommand at a
+		// time, each human-vetted — do not lift this gate wholesale. Checks
+		// that reach into the database layer stay server-gated until the
+		// storage driver interface covers them (AGENTS.md "Storage Boundary").
 		if isEmbeddedMode() {
 			printEmbeddedUnsupported("doctor")
 			return nil


### PR DESCRIPTION
## Why

The maintainer policy for `bd doctor` in embedded mode — support is enabled **one subcommand at a time, each human-vetted**, with database-layer checks staying server-gated until the storage driver interface covers them — currently lives only in #3794 and in PR review threads. Nothing at the code site records it.

The embedded gate in `cmd/bd/doctor.go` is exactly where the next contributor (human or agent) will be tempted to remove the stub wholesale: #3439 did precisely that and was closed for it, and #3758 landed the sanctioned per-subcommand path instead. This PR writes the rule down at the two places someone will actually be looking:

- a comment at the embedded-mode gate in `doctor.go`, pointing to #3794;
- four lines in `AGENTS.md` under **Storage Boundary**, since the doctor policy is a live application of that boundary rule.

Comment/docs only; no behavior change. Follows up #3758; related to #3597 / #3794.

_claude-fable-5-high on behalf of matt wilkie_
