### PR TITLE
fix(linear): use OAuth auth header for idempotent create

### DIFF
--- a/internal/linear/client.go
+++ b/internal/linear/client.go
@@ -829,7 +829,11 @@ func (c *Client) createIssueSingleAttempt(ctx context.Context, title, descriptio
 	}
 
 	httpReq.Header.Set("Content-Type", "application/json")
-	httpReq.Header.Set("Authorization", c.APIKey)
+	authValue, err := c.authHeader()
+	if err != nil {
+		return nil, err
+	}
+	httpReq.Header.Set("Authorization", authValue)
 
 	resp, err := c.HTTPClient.Do(httpReq)
 	if err != nil {

--- a/internal/linear/idempotency_test.go
+++ b/internal/linear/idempotency_test.go
@@ -288,6 +288,115 @@ func TestCreateIssueIdempotentEmptyDescription(t *testing.T) {
 	}
 }
 
+func TestCreateIssueIdempotentOAuthAuthHeader(t *testing.T) {
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(oauthTokenResponse{
+			AccessToken: "lin_oauth_test_token",
+			TokenType:   "Bearer",
+			ExpiresIn:   3600,
+			Scope:       "read write",
+		})
+	}))
+	defer tokenServer.Close()
+
+	searchCalls := 0
+	createCalls := 0
+	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer lin_oauth_test_token" {
+			w.WriteHeader(http.StatusUnauthorized)
+			w.Write([]byte(`{"error":"unauthorized"}`))
+			return
+		}
+
+		var req GraphQLRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("failed to decode request: %v", err)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		if strings.Contains(req.Query, "FindByDescription") {
+			searchCalls++
+			resp := map[string]interface{}{
+				"data": map[string]interface{}{
+					"issues": map[string]interface{}{
+						"nodes":    []Issue{},
+						"pageInfo": map[string]interface{}{"hasNextPage": false, "endCursor": ""},
+					},
+				},
+			}
+			json.NewEncoder(w).Encode(resp)
+			return
+		}
+
+		if strings.Contains(req.Query, "issueCreate") {
+			createCalls++
+			input, _ := req.Variables["input"].(map[string]interface{})
+			description, _ := input["description"].(string)
+			resp := map[string]interface{}{
+				"data": map[string]interface{}{
+					"issueCreate": map[string]interface{}{
+						"success": true,
+						"issue": map[string]interface{}{
+							"id":          "oauth-new-uuid",
+							"identifier":  "TEAM-100",
+							"title":       input["title"],
+							"description": description,
+							"url":         "https://linear.app/team/issue/TEAM-100",
+							"priority":    input["priority"],
+							"state": map[string]interface{}{
+								"id":   "state-1",
+								"name": "Todo",
+								"type": "unstarted",
+							},
+							"createdAt": "2026-05-01T10:00:00Z",
+							"updatedAt": "2026-05-01T10:00:00Z",
+						},
+					},
+				},
+			}
+			json.NewEncoder(w).Encode(resp)
+			return
+		}
+
+		t.Fatalf("unexpected query: %s", req.Query)
+	}))
+	defer apiServer.Close()
+
+	client := NewOAuthClient(OAuthConfig{
+		ClientID:     "test-client-id",
+		ClientSecret: "test-secret",
+		TokenURL:     tokenServer.URL,
+	}, "team-1").WithEndpoint(apiServer.URL)
+
+	marker := GenerateIdempotencyMarker("bead-oauth", "dev@test.com", 300)
+	issue, deduped, err := client.CreateIssueIdempotent(
+		context.Background(),
+		"OAuth Issue",
+		"oauth description",
+		1, "", nil,
+		marker,
+	)
+	if err != nil {
+		t.Fatalf("CreateIssueIdempotent failed for OAuth client: %v", err)
+	}
+	if deduped {
+		t.Error("expected deduped=false for fresh OAuth create")
+	}
+	if issue == nil || issue.Identifier != "TEAM-100" {
+		t.Fatalf("expected TEAM-100 issue, got %#v", issue)
+	}
+	if searchCalls != 1 {
+		t.Errorf("search calls = %d, want 1", searchCalls)
+	}
+	if createCalls != 1 {
+		t.Errorf("create calls = %d, want 1", createCalls)
+	}
+	if !strings.Contains(issue.Description, marker) {
+		t.Errorf("issue description should contain marker, got %q", issue.Description)
+	}
+}
+
 // recoveryHandler simulates an ambiguous create failure followed by a
 // successful dedup search. It models the scenario where issueCreate reaches
 // Linear (the issue is created) but the HTTP response is lost, so the next


### PR DESCRIPTION
## Summary

`createIssueSingleAttempt` used `c.APIKey` directly instead of `c.authHeader()`, so OAuth client-credentials setups sent an empty Authorization header on issue create, breaking idempotency retries.

## Split context

Split out of #4374, which consolidated 8 duplicate `cursor/critical-bug-investigation-*` branches (4 of which were duplicates of this exact fix) into one PR. Splitting into independent, single-concern PRs per review feedback — see [PR_MAINTAINER_GUIDELINES.md](https://github.com/gastownhall/beads/blob/main/PR_MAINTAINER_GUIDELINES.md).

## Test plan

- `go test ./internal/linear/... -run TestOAuth -count=1`
- Regression test uses `NewOAuthClient` with a real token server (`internal/linear/idempotency_test.go`)
