### PR TITLE
fix(linear): arm rate-limit breaker after successful calls

### DIFF
--- a/internal/linear/client.go
+++ b/internal/linear/client.go
@@ -119,6 +119,11 @@ type rateLimitState struct {
 	resetsAt  time.Time
 }
 
+// maxRateLimitResetHorizon accommodates Linear's short quota windows and
+// clock skew without allowing a nonsensical timestamp to block requests
+// effectively forever.
+const maxRateLimitResetHorizon = 24 * time.Hour
+
 func newRateLimitState() *rateLimitState {
 	return &rateLimitState{remaining: -1}
 }
@@ -257,7 +262,8 @@ func (c *Client) recordRateLimitHeaders(info RateLimitInfo) {
 	}
 	c.rateLimitState.mu.Lock()
 	defer c.rateLimitState.mu.Unlock()
-	if info.RequestsReset.IsZero() || !time.Now().Before(info.RequestsReset) {
+	now := time.Now()
+	if info.RequestsReset.IsZero() || !now.Before(info.RequestsReset) || info.RequestsReset.After(now.Add(maxRateLimitResetHorizon)) {
 		c.rateLimitState.remaining = -1
 		c.rateLimitState.resetsAt = time.Time{}
 		return

--- a/internal/linear/client.go
+++ b/internal/linear/client.go
@@ -234,9 +234,14 @@ func (c *Client) circuitBreakerError() *ErrRateLimitExhausted {
 	if c.rateLimitState == nil {
 		return nil
 	}
-	c.rateLimitState.mu.RLock()
-	defer c.rateLimitState.mu.RUnlock()
+	c.rateLimitState.mu.Lock()
+	defer c.rateLimitState.mu.Unlock()
 	if c.rateLimitState.remaining < 0 || c.rateLimitState.remaining >= c.rateLimitFloor() {
+		return nil
+	}
+	if !c.rateLimitState.resetsAt.IsZero() && !time.Now().Before(c.rateLimitState.resetsAt) {
+		c.rateLimitState.remaining = -1
+		c.rateLimitState.resetsAt = time.Time{}
 		return nil
 	}
 	return &ErrRateLimitExhausted{

--- a/internal/linear/client.go
+++ b/internal/linear/client.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/steveyegge/beads/internal/debug"
@@ -112,6 +113,16 @@ const issuesQuery = `
 	}
 `
 
+type rateLimitState struct {
+	mu        sync.RWMutex
+	remaining int
+	resetsAt  time.Time
+}
+
+func newRateLimitState() *rateLimitState {
+	return &rateLimitState{remaining: -1}
+}
+
 // NewClient creates a new Linear client with the given API key and team ID.
 func NewClient(apiKey, teamID string) *Client {
 	return &Client{
@@ -122,6 +133,7 @@ func NewClient(apiKey, teamID string) *Client {
 		HTTPClient: &http.Client{
 			Timeout: DefaultTimeout,
 		},
+		rateLimitState: newRateLimitState(),
 	}
 }
 
@@ -136,6 +148,7 @@ func NewOAuthClient(oauthConfig OAuthConfig, teamID string) *Client {
 		HTTPClient: &http.Client{
 			Timeout: DefaultTimeout,
 		},
+		rateLimitState: newRateLimitState(),
 	}
 }
 
@@ -151,6 +164,7 @@ func (c *Client) WithEndpoint(endpoint string) *Client {
 		AuthMode:       c.AuthMode,
 		TokenManager:   c.TokenManager,
 		RateLimitFloor: c.RateLimitFloor,
+		rateLimitState: c.rateLimitState,
 	}
 }
 
@@ -166,6 +180,7 @@ func (c *Client) WithHTTPClient(httpClient *http.Client) *Client {
 		AuthMode:       c.AuthMode,
 		TokenManager:   c.TokenManager,
 		RateLimitFloor: c.RateLimitFloor,
+		rateLimitState: c.rateLimitState,
 	}
 }
 
@@ -181,6 +196,7 @@ func (c *Client) WithProjectID(projectID string) *Client {
 		AuthMode:       c.AuthMode,
 		TokenManager:   c.TokenManager,
 		RateLimitFloor: c.RateLimitFloor,
+		rateLimitState: c.rateLimitState,
 	}
 }
 
@@ -210,7 +226,34 @@ func (c *Client) WithRateLimitFloor(floor int) *Client {
 		AuthMode:       c.AuthMode,
 		TokenManager:   c.TokenManager,
 		RateLimitFloor: floor,
+		rateLimitState: c.rateLimitState,
 	}
+}
+
+func (c *Client) circuitBreakerError() *ErrRateLimitExhausted {
+	if c.rateLimitState == nil {
+		return nil
+	}
+	c.rateLimitState.mu.RLock()
+	defer c.rateLimitState.mu.RUnlock()
+	if c.rateLimitState.remaining < 0 || c.rateLimitState.remaining >= c.rateLimitFloor() {
+		return nil
+	}
+	return &ErrRateLimitExhausted{
+		Remaining: c.rateLimitState.remaining,
+		Floor:     c.rateLimitFloor(),
+		ResetsAt:  c.rateLimitState.resetsAt,
+	}
+}
+
+func (c *Client) recordRateLimitHeaders(info RateLimitInfo) {
+	if c.rateLimitState == nil || info.RequestsRemaining < 0 {
+		return
+	}
+	c.rateLimitState.mu.Lock()
+	c.rateLimitState.remaining = info.RequestsRemaining
+	c.rateLimitState.resetsAt = info.RequestsReset
+	c.rateLimitState.mu.Unlock()
 }
 
 // rateLimitFloor returns the effective circuit-breaker floor, using the
@@ -298,6 +341,10 @@ func (c *Client) executeOnce(ctx context.Context, req *GraphQLRequest) (json.Raw
 	var lastErr error
 	var lastStatus int
 	for attempt := 0; attempt <= MaxRetries; attempt++ {
+		if rlErr := c.circuitBreakerError(); rlErr != nil {
+			return nil, lastStatus, rlErr
+		}
+
 		httpReq, err := http.NewRequestWithContext(ctx, "POST", c.Endpoint, bytes.NewReader(body))
 		if err != nil {
 			return nil, 0, fmt.Errorf("failed to create request: %w", err)
@@ -325,15 +372,7 @@ func (c *Client) executeOnce(ctx context.Context, req *GraphQLRequest) (json.Raw
 
 		lastStatus = resp.StatusCode
 		rl := parseRateLimitHeaders(resp.Header)
-
-		// Circuit breaker: stop early when remaining quota is critically low.
-		if rl.RequestsRemaining >= 0 && rl.RequestsRemaining < c.rateLimitFloor() {
-			return nil, lastStatus, &ErrRateLimitExhausted{
-				Remaining: rl.RequestsRemaining,
-				Floor:     c.rateLimitFloor(),
-				ResetsAt:  rl.RequestsReset,
-			}
-		}
+		c.recordRateLimitHeaders(rl)
 
 		if resp.StatusCode == http.StatusTooManyRequests {
 			delay := rl.RetryAfter

--- a/internal/linear/client.go
+++ b/internal/linear/client.go
@@ -302,8 +302,8 @@ func parseRateLimitHeaders(h http.Header) RateLimitInfo {
 		}
 	}
 	if v := h.Get("X-RateLimit-Requests-Reset"); v != "" {
-		if t, err := time.Parse(time.RFC3339, v); err == nil {
-			info.RequestsReset = t
+		if milliseconds, err := strconv.ParseInt(v, 10, 64); err == nil {
+			info.RequestsReset = time.UnixMilli(milliseconds).UTC()
 		}
 	}
 	return info

--- a/internal/linear/client.go
+++ b/internal/linear/client.go
@@ -256,9 +256,14 @@ func (c *Client) recordRateLimitHeaders(info RateLimitInfo) {
 		return
 	}
 	c.rateLimitState.mu.Lock()
+	defer c.rateLimitState.mu.Unlock()
+	if info.RequestsReset.IsZero() || !time.Now().Before(info.RequestsReset) {
+		c.rateLimitState.remaining = -1
+		c.rateLimitState.resetsAt = time.Time{}
+		return
+	}
 	c.rateLimitState.remaining = info.RequestsRemaining
 	c.rateLimitState.resetsAt = info.RequestsReset
-	c.rateLimitState.mu.Unlock()
 }
 
 // rateLimitFloor returns the effective circuit-breaker floor, using the
@@ -302,7 +307,7 @@ func parseRateLimitHeaders(h http.Header) RateLimitInfo {
 		}
 	}
 	if v := h.Get("X-RateLimit-Requests-Reset"); v != "" {
-		if milliseconds, err := strconv.ParseInt(v, 10, 64); err == nil {
+		if milliseconds, err := strconv.ParseInt(v, 10, 64); err == nil && milliseconds > 0 {
 			info.RequestsReset = time.UnixMilli(milliseconds).UTC()
 		}
 	}

--- a/internal/linear/client_test.go
+++ b/internal/linear/client_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -531,7 +532,7 @@ func TestParseRateLimitHeaders(t *testing.T) {
 		h := http.Header{}
 		h.Set("Retry-After", "45")
 		h.Set("X-RateLimit-Requests-Remaining", "80")
-		h.Set("X-RateLimit-Requests-Reset", "2026-01-01T00:00:00Z")
+		h.Set("X-RateLimit-Requests-Reset", "1767225600000")
 
 		info := parseRateLimitHeaders(h)
 		if info.RetryAfter != 45*time.Second {
@@ -540,7 +541,7 @@ func TestParseRateLimitHeaders(t *testing.T) {
 		if info.RequestsRemaining != 80 {
 			t.Errorf("RequestsRemaining = %d, want 80", info.RequestsRemaining)
 		}
-		wantReset, _ := time.Parse(time.RFC3339, "2026-01-01T00:00:00Z")
+		wantReset := time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC)
 		if !info.RequestsReset.Equal(wantReset) {
 			t.Errorf("RequestsReset = %v, want %v", info.RequestsReset, wantReset)
 		}
@@ -638,7 +639,7 @@ func TestExecute_NoRetryAfterFallsBackToExponential(t *testing.T) {
 
 func TestExecute_CircuitBreakerTripsOnSubsequentRequest(t *testing.T) {
 	requestCount := 0
-	resetAt := time.Now().Add(time.Hour).UTC().Format(time.RFC3339)
+	resetAt := strconv.FormatInt(time.Now().Add(time.Hour).UnixMilli(), 10)
 	srv := mockServer(t, func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
 		w.Header().Set("X-RateLimit-Requests-Remaining", "50")
@@ -681,8 +682,8 @@ func TestExecute_CircuitBreakerTripsOnSubsequentRequest(t *testing.T) {
 
 func TestExecute_CircuitBreakerAllowsRequestAfterResetThenRearms(t *testing.T) {
 	requestCount := 0
-	pastReset := time.Now().Add(-time.Hour).UTC().Format(time.RFC3339)
-	futureReset := time.Now().Add(time.Hour).UTC().Format(time.RFC3339)
+	pastReset := strconv.FormatInt(time.Now().Add(-time.Hour).UnixMilli(), 10)
+	futureReset := strconv.FormatInt(time.Now().Add(time.Hour).UnixMilli(), 10)
 	srv := mockServer(t, func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
 		w.Header().Set("X-RateLimit-Requests-Remaining", "50")

--- a/internal/linear/client_test.go
+++ b/internal/linear/client_test.go
@@ -559,6 +559,16 @@ func TestParseRateLimitHeaders(t *testing.T) {
 			t.Errorf("RequestsReset should be zero, got %v", info.RequestsReset)
 		}
 	})
+
+	for _, value := range []string{"not-a-timestamp", "-1", "9223372036854775808"} {
+		t.Run("invalid reset "+value, func(t *testing.T) {
+			h := http.Header{}
+			h.Set("X-RateLimit-Requests-Reset", value)
+			if got := parseRateLimitHeaders(h).RequestsReset; !got.IsZero() {
+				t.Errorf("RequestsReset = %v, want zero", got)
+			}
+		})
+	}
 }
 
 // mockServer returns an httptest.Server and a function to set the handler per request.
@@ -711,6 +721,59 @@ func TestExecute_CircuitBreakerAllowsRequestAfterResetThenRearms(t *testing.T) {
 	}
 	if requestCount != 2 {
 		t.Errorf("requestCount = %d, want 2 (expired breaker should allow one request, then re-arm)", requestCount)
+	}
+}
+
+func TestExecute_CircuitBreakerRequiresValidFutureReset(t *testing.T) {
+	futureReset := strconv.FormatInt(time.Now().Add(time.Hour).UnixMilli(), 10)
+	tests := []struct {
+		name      string
+		reset     string
+		wantArmed bool
+	}{
+		{name: "missing reset"},
+		{name: "malformed reset", reset: "not-a-timestamp"},
+		{name: "overflow reset", reset: "9223372036854775808"},
+		{name: "negative reset", reset: "-1"},
+		{name: "valid future reset", reset: futureReset, wantArmed: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			requestCount := 0
+			srv := mockServer(t, func(w http.ResponseWriter, r *http.Request) {
+				requestCount++
+				w.Header().Set("X-RateLimit-Requests-Remaining", "50")
+				if tt.reset != "" {
+					w.Header().Set("X-RateLimit-Requests-Reset", tt.reset)
+				}
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(`{"data":{"ok":true}}`))
+			})
+
+			client := NewClient("key", "team").WithEndpoint(srv.Server.URL)
+			request := &GraphQLRequest{Query: "{ viewer { id } }"}
+			if data, err := client.Execute(context.Background(), request); err != nil {
+				t.Fatalf("first Execute returned error: %v", err)
+			} else if data == nil {
+				t.Fatal("first Execute returned nil data")
+			}
+
+			_, err := client.WithProjectID("project-id").Execute(context.Background(), request)
+			if tt.wantArmed && err == nil {
+				t.Fatal("expected valid future reset to arm breaker")
+			}
+			if !tt.wantArmed && err != nil {
+				t.Fatalf("invalid reset permanently armed breaker: %v", err)
+			}
+			wantRequests := 2
+			if tt.wantArmed {
+				wantRequests = 1
+			}
+			if requestCount != wantRequests {
+				t.Errorf("requestCount = %d, want %d", requestCount, wantRequests)
+			}
+		})
 	}
 }
 

--- a/internal/linear/client_test.go
+++ b/internal/linear/client_test.go
@@ -636,8 +636,10 @@ func TestExecute_NoRetryAfterFallsBackToExponential(t *testing.T) {
 	}
 }
 
-func TestExecute_CircuitBreakerTrips(t *testing.T) {
+func TestExecute_CircuitBreakerTripsOnSubsequentRequest(t *testing.T) {
+	requestCount := 0
 	srv := mockServer(t, func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
 		w.Header().Set("X-RateLimit-Requests-Remaining", "50")
 		w.Header().Set("X-RateLimit-Requests-Reset", "2026-06-01T00:00:00Z")
 		w.WriteHeader(http.StatusOK)
@@ -647,7 +649,15 @@ func TestExecute_CircuitBreakerTrips(t *testing.T) {
 	client := NewClient("key", "team").WithEndpoint(srv.Server.URL)
 	ctx := context.Background()
 
-	_, err := client.Execute(ctx, &GraphQLRequest{Query: "{ viewer { id } }"})
+	data, err := client.Execute(ctx, &GraphQLRequest{Query: "{ viewer { id } }"})
+	if err != nil {
+		t.Fatalf("first Execute returned error: %v", err)
+	}
+	if data == nil {
+		t.Fatal("first Execute returned nil data")
+	}
+
+	_, err = client.Execute(ctx, &GraphQLRequest{Query: "{ viewer { id } }"})
 	if err == nil {
 		t.Fatal("expected ErrRateLimitExhausted, got nil")
 	}
@@ -661,6 +671,9 @@ func TestExecute_CircuitBreakerTrips(t *testing.T) {
 	}
 	if rlErr.Floor != DefaultRateLimitFloor {
 		t.Errorf("Floor = %d, want %d", rlErr.Floor, DefaultRateLimitFloor)
+	}
+	if requestCount != 1 {
+		t.Errorf("requestCount = %d, want 1 (second call should trip locally)", requestCount)
 	}
 }
 

--- a/internal/linear/client_test.go
+++ b/internal/linear/client_test.go
@@ -725,7 +725,8 @@ func TestExecute_CircuitBreakerAllowsRequestAfterResetThenRearms(t *testing.T) {
 }
 
 func TestExecute_CircuitBreakerRequiresValidFutureReset(t *testing.T) {
-	futureReset := strconv.FormatInt(time.Now().Add(time.Hour).UnixMilli(), 10)
+	futureReset := strconv.FormatInt(time.Now().Add(maxRateLimitResetHorizon-time.Hour).UnixMilli(), 10)
+	beyondHorizon := strconv.FormatInt(time.Now().Add(maxRateLimitResetHorizon+time.Minute).UnixMilli(), 10)
 	tests := []struct {
 		name      string
 		reset     string
@@ -735,7 +736,9 @@ func TestExecute_CircuitBreakerRequiresValidFutureReset(t *testing.T) {
 		{name: "malformed reset", reset: "not-a-timestamp"},
 		{name: "overflow reset", reset: "9223372036854775808"},
 		{name: "negative reset", reset: "-1"},
-		{name: "valid future reset", reset: futureReset, wantArmed: true},
+		{name: "maximum int64 reset", reset: "9223372036854775807"},
+		{name: "reset beyond maximum horizon", reset: beyondHorizon},
+		{name: "valid reset near maximum horizon", reset: futureReset, wantArmed: true},
 	}
 
 	for _, tt := range tests {

--- a/internal/linear/client_test.go
+++ b/internal/linear/client_test.go
@@ -638,10 +638,11 @@ func TestExecute_NoRetryAfterFallsBackToExponential(t *testing.T) {
 
 func TestExecute_CircuitBreakerTripsOnSubsequentRequest(t *testing.T) {
 	requestCount := 0
+	resetAt := time.Now().Add(time.Hour).UTC().Format(time.RFC3339)
 	srv := mockServer(t, func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
 		w.Header().Set("X-RateLimit-Requests-Remaining", "50")
-		w.Header().Set("X-RateLimit-Requests-Reset", "2026-06-01T00:00:00Z")
+		w.Header().Set("X-RateLimit-Requests-Reset", resetAt)
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte(`{"data":{"ok":true}}`))
 	})
@@ -657,7 +658,8 @@ func TestExecute_CircuitBreakerTripsOnSubsequentRequest(t *testing.T) {
 		t.Fatal("first Execute returned nil data")
 	}
 
-	_, err = client.Execute(ctx, &GraphQLRequest{Query: "{ viewer { id } }"})
+	clone := client.WithProjectID("project-id")
+	_, err = clone.Execute(ctx, &GraphQLRequest{Query: "{ viewer { id } }"})
 	if err == nil {
 		t.Fatal("expected ErrRateLimitExhausted, got nil")
 	}
@@ -674,6 +676,40 @@ func TestExecute_CircuitBreakerTripsOnSubsequentRequest(t *testing.T) {
 	}
 	if requestCount != 1 {
 		t.Errorf("requestCount = %d, want 1 (second call should trip locally)", requestCount)
+	}
+}
+
+func TestExecute_CircuitBreakerAllowsRequestAfterResetThenRearms(t *testing.T) {
+	requestCount := 0
+	pastReset := time.Now().Add(-time.Hour).UTC().Format(time.RFC3339)
+	futureReset := time.Now().Add(time.Hour).UTC().Format(time.RFC3339)
+	srv := mockServer(t, func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("X-RateLimit-Requests-Remaining", "50")
+		if requestCount == 1 {
+			w.Header().Set("X-RateLimit-Requests-Reset", pastReset)
+		} else {
+			w.Header().Set("X-RateLimit-Requests-Reset", futureReset)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"data":{"ok":true}}`))
+	})
+
+	client := NewClient("key", "team").WithEndpoint(srv.Server.URL)
+	ctx := context.Background()
+	request := &GraphQLRequest{Query: "{ viewer { id } }"}
+
+	if _, err := client.Execute(ctx, request); err != nil {
+		t.Fatalf("first Execute returned error: %v", err)
+	}
+	if _, err := client.WithRateLimitFloor(DefaultRateLimitFloor).Execute(ctx, request); err != nil {
+		t.Fatalf("Execute after reset returned error: %v", err)
+	}
+	if _, err := client.Execute(ctx, request); err == nil {
+		t.Fatal("expected re-armed breaker to block after future reset was recorded")
+	}
+	if requestCount != 2 {
+		t.Errorf("requestCount = %d, want 2 (expired breaker should allow one request, then re-arm)", requestCount)
 	}
 }
 

--- a/internal/linear/parent_reconcile_test.go
+++ b/internal/linear/parent_reconcile_test.go
@@ -6,8 +6,10 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"testing"
+	"time"
 )
 
 // linearMockHandler is a tiny GraphQL mock that routes by query keyword.
@@ -49,11 +51,14 @@ func (h *linearMockHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 
 	// If failNextRL is set, return rate-limit-exhausted on this single
-	// response (header drives the circuit breaker in Execute).
+	// response (header drives the circuit breaker in Execute). The breaker
+	// only arms when the reset header carries a valid future timestamp, so
+	// send one alongside the low remaining count.
 	if h.failNextRL {
 		h.failNextRL = false
 		h.rateLimited++
 		w.Header().Set("X-RateLimit-Requests-Remaining", "1") // < DefaultRateLimitFloor (100)
+		w.Header().Set("X-RateLimit-Requests-Reset", strconv.FormatInt(time.Now().Add(time.Hour).UnixMilli(), 10))
 		_ = json.NewEncoder(w).Encode(map[string]interface{}{"data": map[string]interface{}{}})
 		return
 	}

--- a/internal/linear/types.go
+++ b/internal/linear/types.go
@@ -63,6 +63,7 @@ type Client struct {
 	AuthMode       AuthMode
 	TokenManager   *OAuthTokenManager
 	RateLimitFloor int // Minimum remaining quota before circuit breaker trips (0 = use DefaultRateLimitFloor)
+	rateLimitState *rateLimitState
 }
 
 // RateLimitInfo captures rate-limit state from Linear API response headers.


### PR DESCRIPTION
## Summary

The rate-limit circuit-breaker tripped on the *current* request that revealed low remaining quota, discarding a successful response. Now records state and trips on the *next* call instead, via a persistent `rateLimitState` struct with mutex.

## Split context

Split out of #4374, which consolidated 8 duplicate `cursor/critical-bug-investigation-*` branches into one PR. Splitting into independent, single-concern PRs per review feedback — see [PR_MAINTAINER_GUIDELINES.md](https://github.com/gastownhall/beads/blob/main/PR_MAINTAINER_GUIDELINES.md).

## Test plan

- `go test ./internal/linear/... -run TestRateLimit -count=1`
