### PR TITLE
fix(linear): avoid double-format skip mismatch in batch push

### DIFF
--- a/internal/linear/tracker.go
+++ b/internal/linear/tracker.go
@@ -503,7 +503,14 @@ func (t *Tracker) BatchPush(ctx context.Context, issues []*types.Issue, forceIDs
 			fetched, lookupErr := routeClient.FetchIssueByIdentifier(ctx, externalID)
 			if lookupErr == nil && fetched != nil {
 				remoteIssue = fetched
-				if PushFieldsEqual(issue, remoteIssue, t.config, teamLabelCache) {
+				// BatchPush receives pre-formatted descriptions from the sync
+				// engine (FormatDescription hook). Clear structured fields before
+				// comparison so PushFieldsEqual does not re-append them.
+				comparableIssue := *issue
+				comparableIssue.AcceptanceCriteria = ""
+				comparableIssue.Design = ""
+				comparableIssue.Notes = ""
+				if PushFieldsEqual(&comparableIssue, remoteIssue, t.config, teamLabelCache) {
 					result.Skipped = append(result.Skipped, issue.ID)
 					continue
 				}

--- a/internal/linear/tracker_test.go
+++ b/internal/linear/tracker_test.go
@@ -157,6 +157,79 @@ func TestBatchPush_SkipsUnchangedIssue(t *testing.T) {
 	}
 }
 
+// TestBatchPush_SkipsUnchangedIssueWithPreformattedDescription verifies that
+// BatchPush skip semantics still work when descriptions were pre-formatted by
+// the engine's FormatDescription hook (BuildLinearDescription). This guards
+// against double-formatting during skip comparison.
+func TestBatchPush_SkipsUnchangedIssueWithPreformattedDescription(t *testing.T) {
+	var updateCalled bool
+	formattedDescription := "Base body\n\n## Acceptance Criteria\nMust pass"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var req GraphQLRequest
+		_ = json.Unmarshal(body, &req)
+		w.Header().Set("Content-Type", "application/json")
+
+		switch {
+		case strings.Contains(req.Query, "TeamStates"):
+			json.NewEncoder(w).Encode(teamStatesResp("team-1", "state-open", "Backlog", "backlog"))
+		case strings.Contains(req.Query, "IssueByIdentifier"):
+			json.NewEncoder(w).Encode(issueByIdentifierResp(
+				"remote-uuid", "TEAM-1", "My Issue", formattedDescription, 0,
+				"state-open", "Backlog", "backlog",
+			))
+		case strings.Contains(req.Query, "issueUpdate"):
+			updateCalled = true
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"data": map[string]interface{}{
+					"issueUpdate": map[string]interface{}{
+						"success": true,
+						"issue":   map[string]interface{}{"id": "remote-uuid", "url": "https://linear.app/team/issue/TEAM-1", "updatedAt": "2026-01-01T00:00:00Z"},
+					},
+				},
+			})
+		}
+	}))
+	defer server.Close()
+
+	cfg := DefaultMappingConfig()
+	cfg.ExplicitStateMap = map[string]string{"backlog": "open"}
+
+	extRef := "https://linear.app/team/issue/TEAM-1"
+	local := &types.Issue{
+		ID:                 "local-1",
+		Title:              "My Issue",
+		Description:        formattedDescription,
+		AcceptanceCriteria: "Must pass",
+		Status:             types.StatusOpen,
+		Priority:           4,
+		ExternalRef:        &extRef,
+	}
+
+	tr := &Tracker{
+		teamIDs: []string{"team-1"},
+		clients: map[string]*Client{
+			"team-1": NewClient("key", "team-1").WithEndpoint(server.URL),
+		},
+		config: cfg,
+	}
+
+	result, err := tr.BatchPush(context.Background(), []*types.Issue{local}, nil)
+	if err != nil {
+		t.Fatalf("BatchPush: %v", err)
+	}
+	if updateCalled {
+		t.Error("UpdateIssue was called for an unchanged pre-formatted issue; expected it to be skipped")
+	}
+	if len(result.Skipped) != 1 || result.Skipped[0] != "local-1" {
+		t.Errorf("Skipped = %v, want [local-1]", result.Skipped)
+	}
+	if len(result.Updated) != 0 {
+		t.Errorf("Updated = %v, want []", result.Updated)
+	}
+}
+
 // TestBatchPush_ForceBypassesSkip verifies that an issue in forceIDs is
 // updated even when PushFieldsEqual would normally skip it.
 func TestBatchPush_ForceBypassesSkip(t *testing.T) {

--- a/internal/linear/tracker_test.go
+++ b/internal/linear/tracker_test.go
@@ -174,6 +174,8 @@ func TestBatchPush_SkipsUnchangedIssueWithPreformattedDescription(t *testing.T) 
 		switch {
 		case strings.Contains(req.Query, "TeamStates"):
 			json.NewEncoder(w).Encode(teamStatesResp("team-1", "state-open", "Backlog", "backlog"))
+		case strings.Contains(req.Query, "TeamLabels"):
+			json.NewEncoder(w).Encode(teamLabelsEmptyResp("team-1"))
 		case strings.Contains(req.Query, "IssueByIdentifier"):
 			json.NewEncoder(w).Encode(issueByIdentifierResp(
 				"remote-uuid", "TEAM-1", "My Issue", formattedDescription, 0,


### PR DESCRIPTION
## Summary

Pre-formatted descriptions from the `FormatDescription` hook caused `PushFieldsEqual` to see a mismatch, since structured fields (`AcceptanceCriteria`/`Design`/`Notes`) were still populated on the local issue. Clears those fields before comparison so `BatchPush` doesn't skip issues it shouldn't.

Includes a follow-up commit adding a `TeamLabels` mock handler to the regression test, needed because the label-push feature already on `main` builds a per-team label cache during `BatchPush`.

## Split context

Split out of #4374, which consolidated 8 duplicate `cursor/critical-bug-investigation-*` branches into one PR. Splitting into independent, single-concern PRs per review feedback — see [PR_MAINTAINER_GUIDELINES.md](https://github.com/gastownhall/beads/blob/main/PR_MAINTAINER_GUIDELINES.md).

## Test plan

- `go test ./internal/linear/... -run TestBatchPush -count=1`
