### PR TITLE
fix(doctor): harden project_id/metadata reconciliation against unsafe auto-switch

### DIFF
--- a/cmd/bd/doctor/fix/metadata.go
+++ b/cmd/bd/doctor/fix/metadata.go
@@ -344,6 +344,7 @@ func reconcileAuthoritativeServerMetadata(cfg *configfile.Config, databases []se
 			schemaCandidates = append(schemaCandidates, db)
 		}
 	}
+	current, hasCurrent := byName[cfg.GetDoltDatabase()]
 
 	if cfg.ProjectID != "" {
 		var matches []serverDatabaseMetadata
@@ -365,14 +366,26 @@ func reconcileAuthoritativeServerMetadata(cfg *configfile.Config, databases []se
 			)
 		}
 		if len(matches) == 1 && cfg.DoltDatabase != matches[0].Name {
+			// Safety guard: when the configured database has its own project_id that
+			// disagrees with metadata.json, and a different database matches the local
+			// project_id, we have conflicting identity signals. Auto-switching databases
+			// here can silently attach this workspace to another project.
+			if hasCurrent && current.HasSchema && current.ProjectID != "" && current.ProjectID != cfg.ProjectID {
+				return false, "", fmt.Errorf(
+					"conflicting project identity: metadata.json project_id %s matches database %q, but configured database %q reports project_id %s",
+					cfg.ProjectID,
+					matches[0].Name,
+					current.Name,
+					current.ProjectID,
+				)
+			}
 			from := cfg.GetDoltDatabase()
 			cfg.DoltDatabase = matches[0].Name
 			return true, fmt.Sprintf("repaired dolt_database: %q -> %q using project_id %s", from, matches[0].Name, cfg.ProjectID), nil
 		}
 	}
 
-	current, ok := byName[cfg.GetDoltDatabase()]
-	if ok && current.HasSchema && current.ProjectID != "" && cfg.ProjectID != current.ProjectID {
+	if hasCurrent && current.HasSchema && current.ProjectID != "" && cfg.ProjectID != current.ProjectID {
 		from := cfg.ProjectID
 		cfg.ProjectID = current.ProjectID
 		if from == "" {

--- a/cmd/bd/doctor/fix/metadata.go
+++ b/cmd/bd/doctor/fix/metadata.go
@@ -394,7 +394,10 @@ func reconcileAuthoritativeServerMetadata(cfg *configfile.Config, databases []se
 		return true, fmt.Sprintf("repaired project_id: %s -> %s from database %q", from, current.ProjectID, current.Name), nil
 	}
 
-	if cfg.ProjectID == "" && len(schemaCandidates) == 1 {
+	// In shared-server mode, a sole schema candidate can belong to a different
+	// workspace. Without a local project_id anchor, auto-adopting that database
+	// can redirect this workspace to another project's data.
+	if cfg.ProjectID == "" && len(schemaCandidates) == 1 && !doltserver.IsSharedServerMode() {
 		candidate := schemaCandidates[0]
 		var repairs []string
 		if cfg.DoltDatabase != candidate.Name {

--- a/cmd/bd/doctor/fix/metadata_test.go
+++ b/cmd/bd/doctor/fix/metadata_test.go
@@ -228,7 +228,7 @@ func TestReconcileAuthoritativeServerMetadata_UsesProjectIDToRepairDatabaseName(
 	}
 
 	changed, msg, err := reconcileAuthoritativeServerMetadata(cfg, []serverDatabaseMetadata{
-		{Name: "wrong_db", HasSchema: true, ProjectID: "other-proj"},
+		{Name: "wrong_db", HasSchema: true, ProjectID: ""},
 		{Name: "canonical_db", HasSchema: true, ProjectID: "proj-123"},
 	})
 	if err != nil {
@@ -242,6 +242,37 @@ func TestReconcileAuthoritativeServerMetadata_UsesProjectIDToRepairDatabaseName(
 	}
 	if !strings.Contains(msg, "canonical_db") || !strings.Contains(msg, "proj-123") {
 		t.Fatalf("unexpected repair message: %q", msg)
+	}
+}
+
+func TestReconcileAuthoritativeServerMetadata_ErrorsOnConflictingIdentitySignals(t *testing.T) {
+	cfg := &configfile.Config{
+		DoltMode:     configfile.DoltModeServer,
+		DoltDatabase: "current_db",
+		ProjectID:    "stale-local-id",
+	}
+
+	changed, msg, err := reconcileAuthoritativeServerMetadata(cfg, []serverDatabaseMetadata{
+		{Name: "current_db", HasSchema: true, ProjectID: "server-authoritative-id"},
+		{Name: "other_db", HasSchema: true, ProjectID: "stale-local-id"},
+	})
+	if err == nil {
+		t.Fatal("expected conflict error when project_id and configured database disagree")
+	}
+	if changed {
+		t.Fatal("changed = true, want false on conflict")
+	}
+	if msg != "" {
+		t.Fatalf("msg = %q, want empty on conflict", msg)
+	}
+	if !strings.Contains(err.Error(), "conflicting project identity") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.DoltDatabase != "current_db" {
+		t.Fatalf("DoltDatabase mutated to %q, want %q", cfg.DoltDatabase, "current_db")
+	}
+	if cfg.ProjectID != "stale-local-id" {
+		t.Fatalf("ProjectID mutated to %q, want %q", cfg.ProjectID, "stale-local-id")
 	}
 }
 

--- a/cmd/bd/doctor/fix/metadata_test.go
+++ b/cmd/bd/doctor/fix/metadata_test.go
@@ -349,6 +349,35 @@ func TestReconcileAuthoritativeServerMetadata_SoleCandidateFallback(t *testing.T
 	}
 }
 
+func TestReconcileAuthoritativeServerMetadata_DoesNotAdoptSoleCandidateInSharedServerMode(t *testing.T) {
+	t.Setenv("BEADS_DOLT_SHARED_SERVER", "1")
+
+	cfg := &configfile.Config{
+		DoltMode:     configfile.DoltModeServer,
+		DoltDatabase: "wrong_db",
+		// No ProjectID; in shared-server mode this must not trigger candidate adoption.
+	}
+
+	changed, msg, err := reconcileAuthoritativeServerMetadata(cfg, []serverDatabaseMetadata{
+		{Name: "only_db", HasSchema: true, ProjectID: "other-project"},
+	})
+	if err != nil {
+		t.Fatalf("reconcileAuthoritativeServerMetadata error: %v", err)
+	}
+	if changed {
+		t.Fatalf("expected no change in shared-server mode, got msg: %q", msg)
+	}
+	if msg != "" {
+		t.Fatalf("expected empty msg when no change, got %q", msg)
+	}
+	if cfg.DoltDatabase != "wrong_db" {
+		t.Fatalf("DoltDatabase = %q, want unchanged %q", cfg.DoltDatabase, "wrong_db")
+	}
+	if cfg.ProjectID != "" {
+		t.Fatalf("ProjectID = %q, want empty", cfg.ProjectID)
+	}
+}
+
 func TestReconcileAuthoritativeServerMetadata_NoChangeWhenAlreadyCorrect(t *testing.T) {
 	cfg := &configfile.Config{
 		DoltMode:     configfile.DoltModeServer,


### PR DESCRIPTION
## Summary

Two related safety guards on `reconcileAuthoritativeServerMetadata`'s auto-switch logic, kept together as one PR since the second commit's diff is directly adjacent to the first's in the same function:

1. **Block unsafe cross-project auto-switch.** When the configured database has its own `project_id` that disagrees with `metadata.json`, and a different database matches the local `project_id`, doctor now errors instead of silently switching databases — the two signals conflict and auto-switching could silently attach the workspace to a different project.
2. **Avoid shared-server sole-candidate adoption.** Gates sole-candidate database adoption on `!doltserver.IsSharedServerMode()`, since a sole schema candidate on a shared server can belong to a different workspace, and there's no local `project_id` anchor to safely resolve the ambiguity.

## Split context

Split out of #4374, which consolidated 8 duplicate `cursor/critical-bug-investigation-*` branches into one PR. Splitting into independent, single-concern PRs per review feedback — see [PR_MAINTAINER_GUIDELINES.md](https://github.com/gastownhall/beads/blob/main/PR_MAINTAINER_GUIDELINES.md). These two commits are kept together (rather than split further) because they touch adjacent hunks of the same function in `cmd/bd/doctor/fix/metadata.go`.

## Test plan

- `go test ./cmd/bd/doctor/fix/... -run TestReconcile -count=1`
