### PR TITLE
feat(list): add notes_preview field to JSON output

### DIFF
--- a/.github/sync-fork
+++ b/.github/sync-fork
@@ -1,0 +1,1 @@
+trigger sync

--- a/cmd/bd/list.go
+++ b/cmd/bd/list.go
@@ -516,6 +516,12 @@ var listCmd = &cobra.Command{
 			if iwc == nil {
 				iwc = []*types.IssueWithCounts{}
 			}
+			// Populate notes_preview for JSON consumers (GH#3501).
+			for _, item := range iwc {
+				if item.Issue != nil {
+					item.NotesPreview = types.ComputeNotesPreview(item.Issue.Notes)
+				}
+			}
 			if in.skipLabels {
 				outputJSON(newSkipLabelsListJSONResponse(iwc))
 				printTruncationHint(truncated, in.effectiveLimit)

--- a/cmd/bd/query.go
+++ b/cmd/bd/query.go
@@ -161,6 +161,12 @@ Examples:
 			if iwc == nil {
 				iwc = []*types.IssueWithCounts{}
 			}
+			// Populate notes_preview for JSON consumers (GH#3501).
+			for _, item := range iwc {
+				if item.Issue != nil {
+					item.NotesPreview = types.ComputeNotesPreview(item.Issue.Notes)
+				}
+			}
 			outputJSON(iwc)
 			return
 		}

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -746,7 +746,23 @@ type IssueWithCounts struct {
 	DependencyCount int     `json:"dependency_count"`
 	DependentCount  int     `json:"dependent_count"`
 	CommentCount    int     `json:"comment_count"`
-	Parent          *string `json:"parent,omitempty"` // Computed parent from parent-child dep (bd-ym8c)
+	Parent       *string `json:"parent,omitempty"`        // Computed parent from parent-child dep (bd-ym8c)
+	NotesPreview string  `json:"notes_preview,omitempty"` // First 200 chars of notes (truncated with "...")
+}
+
+// NotesPreviewMaxLen is the maximum character length for NotesPreview before truncation.
+const NotesPreviewMaxLen = 200
+
+// ComputeNotesPreview returns the first NotesPreviewMaxLen characters of notes,
+// appending "..." if truncated. Returns empty string if notes is empty.
+func ComputeNotesPreview(notes string) string {
+	if notes == "" {
+		return ""
+	}
+	if len([]rune(notes)) <= NotesPreviewMaxLen {
+		return notes
+	}
+	return string([]rune(notes)[:NotesPreviewMaxLen]) + "..."
 }
 
 // IssueDetails extends Issue with labels, dependencies, dependents, and comments.

--- a/internal/types/types_test.go
+++ b/internal/types/types_test.go
@@ -1612,3 +1612,77 @@ func TestBondRefUnmarshalJSON(t *testing.T) {
 		})
 	}
 }
+
+func TestComputeNotesPreview(t *testing.T) {
+	tests := []struct {
+		name  string
+		notes string
+		want  string
+	}{
+		{
+			name:  "empty notes",
+			notes: "",
+			want:  "",
+		},
+		{
+			name:  "short notes unchanged",
+			notes: "Quick note about this issue.",
+			want:  "Quick note about this issue.",
+		},
+		{
+			name:  "exactly 200 chars not truncated",
+			notes: strings.Repeat("a", NotesPreviewMaxLen),
+			want:  strings.Repeat("a", NotesPreviewMaxLen),
+		},
+		{
+			name:  "201 chars truncated with ellipsis",
+			notes: strings.Repeat("b", NotesPreviewMaxLen+1),
+			want:  strings.Repeat("b", NotesPreviewMaxLen) + "...",
+		},
+		{
+			name:  "long notes truncated",
+			notes: strings.Repeat("x", 500),
+			want:  strings.Repeat("x", NotesPreviewMaxLen) + "...",
+		},
+		{
+			name:  "unicode handled by rune count",
+			notes: strings.Repeat("\U0001f600", NotesPreviewMaxLen+1), // emoji (multi-byte)
+			want:  strings.Repeat("\U0001f600", NotesPreviewMaxLen) + "...",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ComputeNotesPreview(tt.notes)
+			if got != tt.want {
+				t.Errorf("ComputeNotesPreview() = %q (len %d), want %q (len %d)",
+					got, len(got), tt.want, len(tt.want))
+			}
+		})
+	}
+}
+
+func TestIssueWithCounts_NotesPreviewJSON(t *testing.T) {
+	iwc := &IssueWithCounts{
+		Issue: &Issue{
+			ID:    "test-1",
+			Title: "No notes",
+		},
+	}
+	data, err := json.Marshal(iwc)
+	if err != nil {
+		t.Fatalf("Marshal error: %v", err)
+	}
+	if strings.Contains(string(data), "notes_preview") {
+		t.Errorf("expected notes_preview to be omitted when empty, got: %s", data)
+	}
+
+	iwc.NotesPreview = "Some preview text"
+	data, err = json.Marshal(iwc)
+	if err != nil {
+		t.Fatalf("Marshal error: %v", err)
+	}
+	if !strings.Contains(string(data), `"notes_preview":"Some preview text"`) {
+		t.Errorf("expected notes_preview in JSON output, got: %s", data)
+	}
+}


### PR DESCRIPTION
Superseded by a clean version rebased on current main. Closing.