### PR TITLE
feat(list): add notes_preview field to JSON output

### DIFF
--- a/cmd/bd/list.go
+++ b/cmd/bd/list.go
@@ -538,6 +538,12 @@ func runListCore(cmd *cobra.Command, _ []string) error {
 		if iwc == nil {
 			iwc = []*types.IssueWithCounts{}
 		}
+		// Populate notes_preview for JSON consumers (GH#3501).
+		for _, item := range iwc {
+			if item.Issue != nil {
+				item.NotesPreview = types.ComputeNotesPreview(item.Issue.Notes)
+			}
+		}
 		if in.skipLabels {
 			if err := outputJSON(newSkipLabelsListJSONResponse(iwc)); err != nil {
 				return err

--- a/cmd/bd/list.go
+++ b/cmd/bd/list.go
@@ -538,7 +538,6 @@ func runListCore(cmd *cobra.Command, _ []string) error {
 		if iwc == nil {
 			iwc = []*types.IssueWithCounts{}
 		}
-		// Populate notes_preview for JSON consumers (GH#3501).
 		for _, item := range iwc {
 			if item.Issue != nil {
 				item.NotesPreview = types.ComputeNotesPreview(item.Issue.Notes)

--- a/cmd/bd/query.go
+++ b/cmd/bd/query.go
@@ -174,6 +174,12 @@ Examples:
 			if iwc == nil {
 				iwc = []*types.IssueWithCounts{}
 			}
+			// Populate notes_preview for JSON consumers (GH#3501).
+			for _, item := range iwc {
+				if item.Issue != nil {
+					item.NotesPreview = types.ComputeNotesPreview(item.Issue.Notes)
+				}
+			}
 			return outputJSON(iwc)
 		}
 

--- a/cmd/bd/query.go
+++ b/cmd/bd/query.go
@@ -174,7 +174,6 @@ Examples:
 			if iwc == nil {
 				iwc = []*types.IssueWithCounts{}
 			}
-			// Populate notes_preview for JSON consumers (GH#3501).
 			for _, item := range iwc {
 				if item.Issue != nil {
 					item.NotesPreview = types.ComputeNotesPreview(item.Issue.Notes)

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -752,7 +752,23 @@ type IssueWithCounts struct {
 	DependencyCount int     `json:"dependency_count"`
 	DependentCount  int     `json:"dependent_count"`
 	CommentCount    int     `json:"comment_count"`
-	Parent          *string `json:"parent,omitempty"` // Computed parent from parent-child dep (bd-ym8c)
+	Parent          *string `json:"parent,omitempty"`         // Computed parent from parent-child dep (bd-ym8c)
+	NotesPreview    string  `json:"notes_preview,omitempty"` // First 200 chars of notes (truncated with "...")
+}
+
+// NotesPreviewMaxLen is the maximum character length for NotesPreview before truncation.
+const NotesPreviewMaxLen = 200
+
+// ComputeNotesPreview returns the first NotesPreviewMaxLen characters of notes,
+// appending "..." if truncated. Returns empty string if notes is empty.
+func ComputeNotesPreview(notes string) string {
+	if notes == "" {
+		return ""
+	}
+	if len([]rune(notes)) <= NotesPreviewMaxLen {
+		return notes
+	}
+	return string([]rune(notes)[:NotesPreviewMaxLen]) + "..."
 }
 
 // IssueDetails extends Issue with labels, dependencies, dependents, and comments.

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -752,7 +752,7 @@ type IssueWithCounts struct {
 	DependencyCount int     `json:"dependency_count"`
 	DependentCount  int     `json:"dependent_count"`
 	CommentCount    int     `json:"comment_count"`
-	Parent          *string `json:"parent,omitempty"`         // Computed parent from parent-child dep (bd-ym8c)
+	Parent          *string `json:"parent,omitempty"`        // Computed parent from parent-child dep (bd-ym8c)
 	NotesPreview    string  `json:"notes_preview,omitempty"` // First 200 chars of notes (truncated with "...")
 }
 

--- a/internal/types/types_test.go
+++ b/internal/types/types_test.go
@@ -1679,3 +1679,26 @@ func TestBondRefUnmarshalJSON(t *testing.T) {
 		})
 	}
 }
+
+func TestComputeNotesPreview(t *testing.T) {
+	tests := []struct {
+		name  string
+		notes string
+		want  string
+	}{
+		{name: "empty", notes: "", want: ""},
+		{name: "short", notes: "Quick note.", want: "Quick note."},
+		{name: "exactly 200", notes: strings.Repeat("a", NotesPreviewMaxLen), want: strings.Repeat("a", NotesPreviewMaxLen)},
+		{name: "201 truncated", notes: strings.Repeat("b", NotesPreviewMaxLen+1), want: strings.Repeat("b", NotesPreviewMaxLen) + "..."},
+		{name: "long", notes: strings.Repeat("x", 500), want: strings.Repeat("x", NotesPreviewMaxLen) + "..."},
+		{name: "unicode emoji", notes: strings.Repeat("\U0001f600", NotesPreviewMaxLen+1), want: strings.Repeat("\U0001f600", NotesPreviewMaxLen) + "..."},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ComputeNotesPreview(tt.notes)
+			if got != tt.want {
+				t.Errorf("ComputeNotesPreview() = %q (len %d), want %q (len %d)", got, len(got), tt.want, len(tt.want))
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Adds a `notes_preview` field to `bd list --json` and `bd query --json` output — the first 200 characters of an issue's notes, truncated with `...` if longer.

**Motivation:** Tooling that consumes `bd list --json` (hooks, TUI wrappers, dashboard scripts) often only needs a quick glance at notes to decide relevance — not the full multi-KB body. Today the only option is `bd show <id>` per issue. A short preview in the list response eliminates N+1 round-trips.

## Changes

- `internal/types/types.go`: Add `NotesPreview` field to `IssueWithCounts`, `ComputeNotesPreview()` helper (rune-aware truncation at 200 chars)
- `cmd/bd/list.go`: Populate `NotesPreview` in `runListCore` before JSON serialization
- `cmd/bd/query.go`: Same population loop for query's JSON output path
- `internal/types/types_test.go`: Unit tests covering empty, short, boundary (200), long, and multi-byte unicode cases

## Test plan

- [x] `go test ./internal/types/` — all pass
- [x] Manual: `bd list --json | jq '.[0].notes_preview'` returns truncated preview