### PR TITLE
feat(list): add --label-exact server-side filter

### DIFF
--- a/cmd/bd/list.go
+++ b/cmd/bd/list.go
@@ -688,7 +688,7 @@ func init() {
 	listCmd.Flags().String("notes-contains", "", "Filter by notes substring (case-insensitive)")
 	listCmd.Flags().String("external-contains", "", "Filter by external ref substring (case-insensitive)")
 	listCmd.Flags().String("external-ref", "", "Filter by exact external_ref value")
-	listCmd.Flags().String("label-exact", "", "Filter by exact label name (single label, server-side)")
+	listCmd.Flags().String("label-exact", "", "Filter by exact label name (single label, server-side; ANDs with other label filters)")
 
 	// Date ranges
 	listCmd.Flags().String("created-after", "", "Filter issues created after date (YYYY-MM-DD or RFC3339)")

--- a/cmd/bd/list.go
+++ b/cmd/bd/list.go
@@ -688,6 +688,7 @@ func init() {
 	listCmd.Flags().String("notes-contains", "", "Filter by notes substring (case-insensitive)")
 	listCmd.Flags().String("external-contains", "", "Filter by external ref substring (case-insensitive)")
 	listCmd.Flags().String("external-ref", "", "Filter by exact external_ref value")
+	listCmd.Flags().String("label-exact", "", "Filter by exact label name (single label, server-side)")
 
 	// Date ranges
 	listCmd.Flags().String("created-after", "", "Filter issues created after date (YYYY-MM-DD or RFC3339)")

--- a/cmd/bd/list_embedded_test.go
+++ b/cmd/bd/list_embedded_test.go
@@ -369,6 +369,26 @@ func TestEmbeddedList(t *testing.T) {
 		}
 	})
 
+	t.Run("label_exact_ands_with_label", func(t *testing.T) {
+		// --label-exact composes with --label as an AND: an issue must carry
+		// BOTH labels to match, not either. Seed a dedicated issue with both
+		// backend and frontend since no existing seed issue has that pair.
+		both := bdCreate(t, bd, dir, "Backend+frontend task", "--type", "task",
+			"--priority", "2", "--label", "backend", "--label", "frontend")
+
+		matched := bdListJSON(t, bd, dir, "--label-exact", "backend", "--label", "frontend")
+		if !containsID(matched, both.ID) {
+			t.Errorf("--label-exact backend --label frontend should return %s (has both), got %v",
+				both.ID, listIssueIDs(matched))
+		}
+
+		none := bdListJSON(t, bd, dir, "--label-exact", "backend", "--label", "nonexistent")
+		if len(none) != 0 {
+			t.Errorf("--label-exact backend --label nonexistent should return none (AND excludes all), got %v",
+				listIssueIDs(none))
+		}
+	})
+
 	t.Run("exclude_label", func(t *testing.T) {
 		issues := bdListJSON(t, bd, dir, "--exclude-label", "urgent")
 		// openBug has labels: backend,urgent — should be excluded

--- a/cmd/bd/list_filter.go
+++ b/cmd/bd/list_filter.go
@@ -220,6 +220,9 @@ func buildListFilter(in listInput, cfg listFilterConfig) (types.IssueFilter, err
 	if in.externalRef != "" {
 		filter.ExternalRef = &in.externalRef
 	}
+	if in.labelExact != "" {
+		filter.Label = &in.labelExact
+	}
 
 	filter.CreatedAfter = in.createdAfter
 	filter.CreatedBefore = in.createdBefore

--- a/cmd/bd/list_input.go
+++ b/cmd/bd/list_input.go
@@ -34,6 +34,7 @@ type listInput struct {
 	notesContains    string
 	externalContains string
 	externalRef      string
+	labelExact       string
 
 	createdBefore *time.Time
 	createdAfter  *time.Time
@@ -143,6 +144,7 @@ func gatherListInput(cmd *cobra.Command) (listInput, error) {
 	in.notesContains, _ = cmd.Flags().GetString("notes-contains")
 	in.externalContains, _ = cmd.Flags().GetString("external-contains")
 	in.externalRef, _ = cmd.Flags().GetString("external-ref")
+	in.labelExact, _ = cmd.Flags().GetString("label-exact")
 
 	in.emptyDesc, _ = cmd.Flags().GetBool("empty-description")
 	in.noAssignee, _ = cmd.Flags().GetBool("no-assignee")

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -961,7 +961,7 @@ bd list [flags]
       --include-templates            Include template molecules in output
   -l, --label strings                Filter by labels (AND: must have ALL). Can combine with --label-any
       --label-any strings            Filter by labels (OR: must have AT LEAST ONE). Can combine with --label
-      --label-exact string           Filter by exact label name (single label, server-side)
+      --label-exact string           Filter by exact label name (single label, server-side; ANDs with other label filters)
       --label-pattern string         Filter by label glob pattern (e.g., 'tech-*' matches tech-debt, tech-legacy)
       --label-regex string           Filter by label regex pattern (e.g., 'tech-(debt|legacy)')
   -n, --limit int                    Limit results (default 50, use 0 for unlimited) (default 50)

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -961,6 +961,7 @@ bd list [flags]
       --include-templates            Include template molecules in output
   -l, --label strings                Filter by labels (AND: must have ALL). Can combine with --label-any
       --label-any strings            Filter by labels (OR: must have AT LEAST ONE). Can combine with --label
+      --label-exact string           Filter by exact label name (single label, server-side)
       --label-pattern string         Filter by label glob pattern (e.g., 'tech-*' matches tech-debt, tech-legacy)
       --label-regex string           Filter by label regex pattern (e.g., 'tech-(debt|legacy)')
   -n, --limit int                    Limit results (default 50, use 0 for unlimited) (default 50)

--- a/docs/cli-reference/list.md
+++ b/docs/cli-reference/list.md
@@ -42,6 +42,7 @@ bd list [flags]
       --include-templates            Include template molecules in output
   -l, --label strings                Filter by labels (AND: must have ALL). Can combine with --label-any
       --label-any strings            Filter by labels (OR: must have AT LEAST ONE). Can combine with --label
+      --label-exact string           Filter by exact label name (single label, server-side)
       --label-pattern string         Filter by label glob pattern (e.g., 'tech-*' matches tech-debt, tech-legacy)
       --label-regex string           Filter by label regex pattern (e.g., 'tech-(debt|legacy)')
   -n, --limit int                    Limit results (default 50, use 0 for unlimited) (default 50)

--- a/docs/cli-reference/list.md
+++ b/docs/cli-reference/list.md
@@ -42,7 +42,7 @@ bd list [flags]
       --include-templates            Include template molecules in output
   -l, --label strings                Filter by labels (AND: must have ALL). Can combine with --label-any
       --label-any strings            Filter by labels (OR: must have AT LEAST ONE). Can combine with --label
-      --label-exact string           Filter by exact label name (single label, server-side)
+      --label-exact string           Filter by exact label name (single label, server-side; ANDs with other label filters)
       --label-pattern string         Filter by label glob pattern (e.g., 'tech-*' matches tech-debt, tech-legacy)
       --label-regex string           Filter by label regex pattern (e.g., 'tech-(debt|legacy)')
   -n, --limit int                    Limit results (default 50, use 0 for unlimited) (default 50)

--- a/internal/storage/dolt/queries_test.go
+++ b/internal/storage/dolt/queries_test.go
@@ -3150,3 +3150,48 @@ func TestSearchIssues_StableOrdering(t *testing.T) {
 		}
 	}
 }
+
+func TestSearchIssues_ByLabelExact(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	issue := &types.Issue{
+		ID:        "si-label-exact",
+		Title:     "Label Exact Filter Test",
+		Status:    types.StatusOpen,
+		Priority:  2,
+		IssueType: types.TypeTask,
+	}
+	if err := store.CreateIssue(ctx, issue, "tester"); err != nil {
+		t.Fatalf("failed to create issue: %v", err)
+	}
+	if err := store.AddLabel(ctx, issue.ID, "backend", "tester"); err != nil {
+		t.Fatalf("failed to add label: %v", err)
+	}
+
+	// Exact label match should find the issue.
+	labelBackend := "backend"
+	results, err := store.SearchIssues(ctx, "", types.IssueFilter{Label: &labelBackend})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("Label exact match: expected 1 result, got %d", len(results))
+	}
+	if results[0].ID != issue.ID {
+		t.Errorf("expected %s, got %s", issue.ID, results[0].ID)
+	}
+
+	// Non-existent label should return nothing.
+	labelNonexistent := "nonexistent"
+	results, err = store.SearchIssues(ctx, "", types.IssueFilter{Label: &labelNonexistent})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(results) != 0 {
+		t.Fatalf("Label exact match with nonexistent: expected 0 results, got %d", len(results))
+	}
+}

--- a/internal/storage/dolt/transaction.go
+++ b/internal/storage/dolt/transaction.go
@@ -341,6 +341,11 @@ func (t *doltTransaction) SearchIssues(ctx context.Context, query string, filter
 		whereClauses = append(whereClauses, "external_ref = ?")
 		args = append(args, *filter.ExternalRef)
 	}
+	if filter.Label != nil {
+		//nolint:gosec // G201: labelTable is hardcoded to "labels" or "wisp_labels"
+		whereClauses = append(whereClauses, fmt.Sprintf("id IN (SELECT issue_id FROM %s WHERE label = ?)", labelTable))
+		args = append(args, *filter.Label)
+	}
 
 	// Status
 	if filter.Status != nil {

--- a/internal/storage/issueops/filters_test.go
+++ b/internal/storage/issueops/filters_test.go
@@ -218,6 +218,41 @@ func TestBuildIssueFilterClauses_LabelsAny(t *testing.T) {
 	}
 }
 
+func TestBuildIssueFilterClauses_LabelExact(t *testing.T) {
+	t.Parallel()
+
+	label := "backend"
+	clauses, args, err := BuildIssueFilterClauses("", types.IssueFilter{Label: &label}, IssuesFilterTables)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(clauses) != 1 {
+		t.Fatalf("expected 1 clause for exact label, got %d: %v", len(clauses), clauses)
+	}
+	if want := "id IN (SELECT issue_id FROM labels WHERE label = ?)"; clauses[0] != want {
+		t.Errorf("clause = %q, want %q", clauses[0], want)
+	}
+	if len(args) != 1 || args[0] != label {
+		t.Errorf("args = %#v, want [%q]", args, label)
+	}
+}
+
+func TestBuildIssueFilterClauses_LabelExactWispsTable(t *testing.T) {
+	t.Parallel()
+
+	label := "backend"
+	clauses, _, err := BuildIssueFilterClauses("", types.IssueFilter{Label: &label}, WispsFilterTables)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(clauses) != 1 {
+		t.Fatalf("expected 1 clause for exact label, got %d: %v", len(clauses), clauses)
+	}
+	if !strings.Contains(clauses[0], WispsFilterTables.Labels) {
+		t.Errorf("clause %q does not reference wisp labels table %q", clauses[0], WispsFilterTables.Labels)
+	}
+}
+
 func TestBuildLabelDrivenSearchUsesLabelJoins(t *testing.T) {
 	t.Parallel()
 

--- a/internal/storage/sqlbuild/filter.go
+++ b/internal/storage/sqlbuild/filter.go
@@ -53,6 +53,10 @@ func BuildIssueFilterClauses(query string, filter types.IssueFilter, tables Filt
 		whereClauses = append(whereClauses, "external_ref = ?")
 		args = append(args, *filter.ExternalRef)
 	}
+	if filter.Label != nil {
+		whereClauses = append(whereClauses, fmt.Sprintf("id IN (SELECT issue_id FROM %s WHERE label = ?)", tables.Labels))
+		args = append(args, *filter.Label)
+	}
 
 	if filter.Status != nil {
 		whereClauses = append(whereClauses, "status = ?")

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -1224,6 +1224,7 @@ type IssueFilter struct {
 	NotesContains       string
 	ExternalRefContains string
 	ExternalRef         *string // exact match on external_ref
+	Label               *string // exact single-label match (server-side subquery)
 
 	// Date ranges
 	CreatedAfter  *time.Time


### PR DESCRIPTION
## Summary

Adds `--label-exact` flag to `bd list` for efficient server-side single-label filtering.

**Motivation:** The existing `--label` flag is a multi-value AND filter (StringSlice). For automation (hooks, CI scripts) that needs to find issues with one specific label, the only option today is to fetch a large result set and filter client-side. This flag pushes the filter into the SQL layer via a subquery (`id IN (SELECT issue_id FROM labels WHERE label = ?)`), returning 0–few rows directly.

## Changes

- `cmd/bd/list.go`: Register `--label-exact` flag
- `cmd/bd/list_input.go`: Wire flag into `listInput` struct
- `cmd/bd/list_filter.go`: Map input to `IssueFilter.Label`
- `internal/types/types.go`: Add `Label *string` to `IssueFilter`
- `internal/storage/dolt/transaction.go`: SQL WHERE clause with label subquery
- `internal/storage/sqlbuild/filter.go`: Same logic for the shared sqlbuild path
- `internal/storage/dolt/queries_test.go`: Integration test for exact-match label filter

## Test plan

- [x] `CGO_ENABLED=0 go test -tags gms_pure_go -short ./...` — all pass
- [x] Manual: `bd list --label-exact "pr-review"` returns only issues with that label