### PR TITLE
fix(comments): reject swapped-order `comments <id> add` instead of silent no-op (#4642)

### DIFF
--- a/cmd/bd/cli_fast_test.go
+++ b/cmd/bd/cli_fast_test.go
@@ -1149,6 +1149,62 @@ func TestCLI_CommentsListMisplacedSyntax(t *testing.T) {
 	}
 }
 
+// TestCLI_CommentsSwappedAddRejectedBeforeStoreOpen is a regression test for
+// GH#4642's should-fix: the swapped-order rejection (`bd comments <id> add
+// <text>`) must fire from commentsCmd's Args validator, before
+// PersistentPreRunE ever opens a store or runs a migration, and before
+// RunE's usesProxiedServer() dispatch — not from a check inside RunE that
+// only the local-store branch reaches. Using a directory with no .beads/ at
+// all proves the store was never touched: the old RunE-only check needed an
+// already-initialized store (PersistentPreRunE would have failed first with
+// "no beads database found"), so this would fail with the wrong error before
+// the fix.
+func TestCLI_CommentsSwappedAddRejectedBeforeStoreOpen(t *testing.T) {
+	noBeadsCwd := t.TempDir()
+	if _, err := os.Stat(filepath.Join(noBeadsCwd, ".beads")); err == nil {
+		t.Fatalf("test setup: %s unexpectedly has a .beads dir", noBeadsCwd)
+	}
+
+	stdout, stderr, err := runBDInProcessAllowError(t, noBeadsCwd, "comments", "bd-123", "add", "should not be stored")
+	if err == nil {
+		t.Fatalf("expected non-zero exit for swapped-order add, got success:\nstdout: %s", stdout)
+	}
+	combined := stdout + stderr
+	if strings.Contains(combined, "no beads database found") {
+		t.Fatalf("Args validation did not run before store open: got the pre-fix error.\nOutput:\n%s", combined)
+	}
+	if !strings.Contains(combined, "bd comments add") {
+		t.Errorf("expected hint pointing to `bd comments add`, got:\n%s", combined)
+	}
+}
+
+// TestCLI_CommentsSwappedAddRejectedInProxiedServerMode is the proxied-server
+// counterpart: forcing proxiedServerMode simulates the dispatch that GH#4642's
+// merge-base drift routes around a RunE-only check (main added
+// runCommentsProxiedServer after this fix branched, consuming only args[0]
+// and ignoring trailing `add <text>`). Because validateCommentsArgs runs in
+// Args — before RunE ever branches on usesProxiedServer() — the rejection
+// fires identically regardless of backend, without needing a real proxied
+// server.
+func TestCLI_CommentsSwappedAddRejectedInProxiedServerMode(t *testing.T) {
+	origProxied := proxiedServerMode
+	t.Cleanup(func() { proxiedServerMode = origProxied })
+	proxiedServerMode = true
+
+	tmpDir := setupCLITestDB(t)
+	stdout, stderr, err := runBDInProcessAllowError(t, tmpDir, "comments", "bd-123", "add", "should not be stored")
+	if err == nil {
+		t.Fatalf("expected non-zero exit for swapped-order add in proxied-server mode, got success:\nstdout: %s", stdout)
+	}
+	combined := stdout + stderr
+	if strings.Contains(combined, "not supported in proxied-server mode") {
+		t.Fatalf("Args validation did not run before the proxied dispatch: got RunE's proxied-mode stub error instead.\nOutput:\n%s", combined)
+	}
+	if !strings.Contains(combined, "bd comments add") {
+		t.Errorf("expected hint pointing to `bd comments add`, got:\n%s", combined)
+	}
+}
+
 // TestCLI_CommentsAddShortID tests that 'comments add' accepts short IDs (issue #1070)
 // Most bd commands accept short IDs (e.g., "5wbm") but comments add previously required
 // full IDs (e.g., "mike.vibe-coding-5wbm"). This test ensures short IDs work.

--- a/cmd/bd/comments.go
+++ b/cmd/bd/comments.go
@@ -11,6 +11,48 @@ import (
 	"github.com/steveyegge/beads/internal/uimd"
 )
 
+// validateCommentsArgs runs as cobra's Args validation for the parent
+// "comments" command, which executes before PersistentPreRunE opens the
+// store (or runs migrations) and before RunE's usesProxiedServer() dispatch.
+// The parent command only lists comments for a single issue, so any trailing
+// positional arg is a mistake — most commonly the swapped-order add,
+// `bd comments <id> add <text>`, which otherwise falls through, reads only
+// args[0], and silently drops the rest with exit 0 (GH#4642). Validating
+// here (rather than inside RunE, local-store-only) rejects the malformed
+// invocation identically for the direct and proxied-server paths, before
+// either one can open a store, run a migration, or hit the remote-migrate
+// gate for an invocation that is guaranteed to fail.
+func validateCommentsArgs(cmd *cobra.Command, args []string) error {
+	if err := cobra.MinimumNArgs(1)(cmd, args); err != nil {
+		return err
+	}
+	if len(args) <= 1 {
+		return nil
+	}
+
+	issueID := args[0]
+	if args[1] == "add" {
+		return HandleErrorRespectJSON(`"bd comments <issue-id> add ..." is not valid — the subcommand must come first.
+
+To add a comment, run:
+  bd comments add <issue-id> <text>
+
+Example:
+  bd comments add %s "your comment"
+
+See: bd comments --help`, issueID)
+	}
+	return HandleErrorRespectJSON(`"bd comments" takes a single issue id and lists its comments.
+
+To list comments:
+  bd comments <issue-id>
+
+To add a comment:
+  bd comments add <issue-id> <text>
+
+See: bd comments --help`)
+}
+
 var commentsCmd = &cobra.Command{
 	Use:     "comments [issue-id]",
 	GroupID: "issues",
@@ -29,7 +71,7 @@ Examples:
 
   # Add a comment from a file
   bd comments add bd-123 -f notes.txt`,
-	Args:          cobra.MinimumNArgs(1),
+	Args:          validateCommentsArgs,
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -45,33 +87,6 @@ Examples:
 
 		localTime, _ := cmd.Flags().GetBool("local-time")
 		issueID := args[0]
-
-		// The parent "comments" command only lists comments for a single issue.
-		// Reject stray trailing args instead of silently dropping them — the
-		// common offender is the swapped-order add, `bd comments <id> add <text>`,
-		// which otherwise falls through here and no-ops with exit 0 (GH#4642).
-		if len(args) > 1 {
-			if args[1] == "add" {
-				return HandleErrorRespectJSON(`"bd comments <issue-id> add ..." is not valid — the subcommand must come first.
-
-To add a comment, run:
-  bd comments add <issue-id> <text>
-
-Example:
-  bd comments add %s "your comment"
-
-See: bd comments --help`, issueID)
-			}
-			return HandleErrorRespectJSON(`"bd comments" takes a single issue id and lists its comments.
-
-To list comments:
-  bd comments <issue-id>
-
-To add a comment:
-  bd comments add <issue-id> <text>
-
-See: bd comments --help`)
-		}
 
 		if err := ensureStoreActive(); err != nil {
 			return HandleErrorRespectJSON("getting comments: %v", err)

--- a/cmd/bd/comments.go
+++ b/cmd/bd/comments.go
@@ -46,6 +46,33 @@ Examples:
 		localTime, _ := cmd.Flags().GetBool("local-time")
 		issueID := args[0]
 
+		// The parent "comments" command only lists comments for a single issue.
+		// Reject stray trailing args instead of silently dropping them — the
+		// common offender is the swapped-order add, `bd comments <id> add <text>`,
+		// which otherwise falls through here and no-ops with exit 0 (GH#4642).
+		if len(args) > 1 {
+			if args[1] == "add" {
+				return HandleErrorRespectJSON(`"bd comments <issue-id> add ..." is not valid — the subcommand must come first.
+
+To add a comment, run:
+  bd comments add <issue-id> <text>
+
+Example:
+  bd comments add %s "your comment"
+
+See: bd comments --help`, issueID)
+			}
+			return HandleErrorRespectJSON(`"bd comments" takes a single issue id and lists its comments.
+
+To list comments:
+  bd comments <issue-id>
+
+To add a comment:
+  bd comments add <issue-id> <text>
+
+See: bd comments --help`)
+		}
+
 		if err := ensureStoreActive(); err != nil {
 			return HandleErrorRespectJSON("getting comments: %v", err)
 		}

--- a/cmd/bd/comments_cli_embedded_test.go
+++ b/cmd/bd/comments_cli_embedded_test.go
@@ -92,6 +92,41 @@ func TestEmbeddedCommentsCLI(t *testing.T) {
 		}
 	})
 
+	// Swapped-order add (`bd comments <id> add <text>`) must be rejected, not
+	// silently dropped with exit 0 (GH#4642).
+	t.Run("comments_swapped_add_rejected", func(t *testing.T) {
+		issue := bdCreate(t, bd, dir, "Swapped add target", "--type", "task")
+
+		cmd := exec.Command(bd, "comments", issue.ID, "add", "should not be stored")
+		cmd.Dir = dir
+		cmd.Env = bdEnv(dir)
+		out, err := cmd.CombinedOutput()
+		if err == nil {
+			t.Fatalf("expected non-zero exit for swapped-order add, got success:\n%s", out)
+		}
+		if !strings.Contains(string(out), "bd comments add") {
+			t.Errorf("expected hint pointing to `bd comments add`, got:\n%s", out)
+		}
+
+		// The stray "add"/text must NOT have been written as a comment.
+		list := bdComments(t, bd, dir, issue.ID)
+		if strings.Contains(list, "should not be stored") {
+			t.Errorf("swapped-order add silently stored a comment:\n%s", list)
+		}
+	})
+
+	// Any other stray trailing arg on the list form is also rejected.
+	t.Run("comments_extra_arg_rejected", func(t *testing.T) {
+		issue := bdCreate(t, bd, dir, "Extra arg target", "--type", "task")
+		cmd := exec.Command(bd, "comments", issue.ID, "stray")
+		cmd.Dir = dir
+		cmd.Env = bdEnv(dir)
+		out, err := cmd.CombinedOutput()
+		if err == nil {
+			t.Fatalf("expected non-zero exit for stray trailing arg, got success:\n%s", out)
+		}
+	})
+
 	// ===== comments list =====
 
 	t.Run("comments_list", func(t *testing.T) {


### PR DESCRIPTION
Closes #4642

## Problem

`bd comments <issue-id> add <text>` — issue id *before* the `add` subcommand — silently no-ops with exit 0 (GH#4642). Cobra only routes to the `add` subcommand when `add` is the first positional token; with the id first it falls through to the parent `comments` command, whose `RunE` reads only `args[0]` (the issue id) and ignores everything after it. So it lists existing comments and exits 0 without ever writing the intended comment.

In scripted/agent pipelines (output often piped through `tail`/`head` or discarded on success) this reads as a successful add and is only caught by re-listing comments afterward.

## Repro (before)

```
$ bd comments zz-4dq add "hello from swapped form"
Comments on zz-4dq:
  ... (only pre-existing comments) ...
$ echo $?
0            # comment never stored
```

## Fix

The parent `comments` command only lists comments for a single issue, so any trailing positional arg is a mistake. Reject it with a clear error instead of dropping it. The common swapped-`add` case gets a targeted hint:

```
$ bd comments zz-4dq add "hello"
Error: "bd comments <issue-id> add ..." is not valid — the subcommand must come first.

To add a comment, run:
  bd comments add <issue-id> <text>

Example:
  bd comments add zz-4dq "your comment"

See: bd comments --help
$ echo $?
1
```

## Tests

Adds embedded regression tests (`comments_swapped_add_rejected`, `comments_extra_arg_rejected`) verifying the swapped form exits non-zero, surfaces the hint, and stores nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)