### PR TITLE
fix(create): reject whitespace-only titles (#4771)

### DIFF
--- a/cmd/bd/cli_fast_test.go
+++ b/cmd/bd/cli_fast_test.go
@@ -1350,6 +1350,49 @@ func TestCLI_CreateRejectsEmptyTitle(t *testing.T) {
 	}
 }
 
+// TestCLI_CreateRejectsEmptyTitle_ProxiedServerMode is a proxied-server
+// regression for GH#4771. Before this fix, the whitespace-only guard lived
+// only in create's local-store RunE branch: gatherCreateInput/
+// runCreateProxiedServer (the path taken when usesProxiedServer() is true)
+// never re-checked, so proxied-mode create still minted a blank-titled bead.
+// The fix moved the check into resolveTitle, invoked from createCmd's Args
+// validator — which runs for every invocation regardless of backend, before
+// RunE ever branches on usesProxiedServer(). Setting proxiedServerMode here
+// exercises that dispatch without needing a real proxied server: Args
+// validation must reject before gatherCreateInput/runCreateProxiedServer (or
+// any store open) ever runs.
+func TestCLI_CreateRejectsEmptyTitle_ProxiedServerMode(t *testing.T) {
+	origProxied := proxiedServerMode
+	t.Cleanup(func() { proxiedServerMode = origProxied })
+	proxiedServerMode = true
+
+	// createCmd is a shared package-level *cobra.Command, so a --title value
+	// set by an earlier in-process test invocation (e.g. TestCLI_CreateRejectsEmptyTitle's
+	// own FlagTab case) survives on the FlagSet across rootCmd.Execute() calls.
+	// Reset it explicitly so this test's outcome doesn't depend on suite
+	// ordering — a pre-existing gap, not something this test should also fall
+	// victim to.
+	titleFlag := createCmd.Flags().Lookup("title")
+	origTitleValue := titleFlag.Value.String()
+	origTitleChanged := titleFlag.Changed
+	t.Cleanup(func() {
+		_ = titleFlag.Value.Set(origTitleValue)
+		titleFlag.Changed = origTitleChanged
+	})
+	_ = titleFlag.Value.Set("")
+	titleFlag.Changed = false
+
+	tmpDir := setupCLITestDB(t)
+	stdout, stderr, err := runBDInProcessAllowError(t, tmpDir, "create", "   ", "-p", "2")
+	if err == nil {
+		t.Fatalf("expected error for whitespace-only title in proxied-server mode, got success\nstdout: %s", stdout)
+	}
+	combined := stdout + stderr
+	if !strings.Contains(combined, "title cannot be empty") {
+		t.Errorf("expected 'title cannot be empty' error, got: %s", combined)
+	}
+}
+
 // TestCLI_CreateNoHistory tests that the --no-history CLI flag is wired through
 // to the created issue (GH#2619). A storage-layer test already covers the DB
 // semantics; this test verifies the CLI flag is actually parsed and passed.

--- a/cmd/bd/cli_fast_test.go
+++ b/cmd/bd/cli_fast_test.go
@@ -1323,6 +1323,33 @@ func TestCLI_CreateRejectsFlagLikeTitles(t *testing.T) {
 	})
 }
 
+// TestCLI_CreateRejectsEmptyTitle verifies that a whitespace-only title is
+// refused rather than silently creating a title-less bead (GH#4771). Such a
+// bead is functionally invisible in title-based views.
+func TestCLI_CreateRejectsEmptyTitle(t *testing.T) {
+	cases := []struct {
+		name string
+		args []string
+	}{
+		{"FlagSpaces", []string{"create", "--title", "   ", "-p", "2"}},
+		{"FlagTab", []string{"create", "--title", "\t", "-p", "2"}},
+		{"PositionalSpaces", []string{"create", "   ", "-p", "2"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tmpDir := setupCLITestDB(t)
+			stdout, stderr, err := runBDInProcessAllowError(t, tmpDir, tc.args...)
+			if err == nil {
+				t.Fatalf("expected error for whitespace-only title, got success\nstdout: %s", stdout)
+			}
+			combined := stdout + stderr
+			if !strings.Contains(combined, "title cannot be empty") {
+				t.Errorf("expected 'title cannot be empty' error, got: %s", combined)
+			}
+		})
+	}
+}
+
 // TestCLI_CreateNoHistory tests that the --no-history CLI flag is wired through
 // to the created issue (GH#2619). A storage-layer test already covers the DB
 // semantics; this test verifies the CLI flag is actually parsed and passed.

--- a/cmd/bd/create.go
+++ b/cmd/bd/create.go
@@ -26,12 +26,27 @@ import (
 	"github.com/steveyegge/beads/internal/validation"
 )
 
+// validateCreateArgs runs as cobra's Args validation, which executes before
+// PersistentPreRunE opens the store or runs migrations. It reuses
+// resolveTitle — the same shared validator gatherCreateInput calls for the
+// proxied-server create path — so a whitespace-only title (GH#4771) is
+// rejected identically for both backends, and before any invocation that is
+// guaranteed to fail wastes a store open/migration.
+func validateCreateArgs(cmd *cobra.Command, args []string) error {
+	markdownFile, _ := cmd.Flags().GetString("file")
+	graphFile, _ := cmd.Flags().GetString("graph")
+	titleFlag, _ := cmd.Flags().GetString("title")
+
+	_, err := resolveTitle(args, titleFlag, markdownFile, graphFile)
+	return err
+}
+
 var createCmd = &cobra.Command{
 	Use:           "create [title]",
 	GroupID:       "issues",
 	Aliases:       []string{"new"},
 	Short:         "Create a new issue (or batch from markdown/graph JSON)",
-	Args:          cobra.MinimumNArgs(0),
+	Args:          validateCreateArgs,
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -86,29 +101,9 @@ var createCmd = &cobra.Command{
 		}
 
 		titleFlag, _ := cmd.Flags().GetString("title")
-		var title string
-
-		if len(args) > 0 && titleFlag != "" {
-			if args[0] != titleFlag {
-				return HandleError("cannot specify different titles as both positional argument and --title flag\n  Positional: %q\n  --title:    %q", args[0], titleFlag)
-			}
-			title = args[0]
-		} else if len(args) > 0 {
-			if strings.HasPrefix(args[0], "-") {
-				return HandleError("title %q looks like a flag (starts with '-').\n  Run 'bd create --help' for available options.\n  To use this title anyway, pass it explicitly: bd create --title=%q", args[0], args[0])
-			}
-			title = args[0]
-		} else if titleFlag != "" {
-			title = titleFlag
-		} else {
-			return HandleError("title required (or use --file to create from markdown)")
-		}
-
-		// Refuse a whitespace-only title. Such a bead is functionally invisible
-		// in title-based views (board scans, search, title-sorted listings) and
-		// reads as "no title" to any downstream consumer (GH#4771).
-		if strings.TrimSpace(title) == "" {
-			return HandleError("title cannot be empty or whitespace-only")
+		title, err := resolveTitle(args, titleFlag, "", "")
+		if err != nil {
+			return err
 		}
 
 		// Get silent flag

--- a/cmd/bd/create.go
+++ b/cmd/bd/create.go
@@ -104,6 +104,13 @@ var createCmd = &cobra.Command{
 			return HandleError("title required (or use --file to create from markdown)")
 		}
 
+		// Refuse a whitespace-only title. Such a bead is functionally invisible
+		// in title-based views (board scans, search, title-sorted listings) and
+		// reads as "no title" to any downstream consumer (GH#4771).
+		if strings.TrimSpace(title) == "" {
+			return HandleError("title cannot be empty or whitespace-only")
+		}
+
 		// Get silent flag
 		silent, _ := cmd.Flags().GetBool("silent")
 

--- a/cmd/bd/create_input.go
+++ b/cmd/bd/create_input.go
@@ -305,20 +305,26 @@ func resolveTitle(args []string, titleFlag, markdownFile, graphFile string) (str
 		return "", nil
 	}
 
+	var title string
 	switch {
 	case len(args) > 0 && titleFlag != "":
 		if args[0] != titleFlag {
 			return "", HandleError("cannot specify different titles as both positional argument and --title flag\n  Positional: %q\n  --title:    %q", args[0], titleFlag)
 		}
-		return args[0], nil
+		title = args[0]
 	case len(args) > 0:
 		if strings.HasPrefix(args[0], "-") {
 			return "", HandleError("title %q looks like a flag (starts with '-').\n  Run 'bd create --help' for available options.\n  To use this title anyway, pass it explicitly: bd create --title=%q", args[0], args[0])
 		}
-		return args[0], nil
+		title = args[0]
 	case titleFlag != "":
-		return titleFlag, nil
+		title = titleFlag
 	default:
 		return "", HandleError("title required (or use --file to create from markdown)")
 	}
+
+	if strings.TrimSpace(title) == "" {
+		return "", HandleError("title cannot be empty or whitespace-only")
+	}
+	return title, nil
 }


### PR DESCRIPTION
Closes #4771

## Problem

`bd create` accepts a whitespace-only title, minting a bead with a blank title (GH#4771). Such a bead is functionally invisible in every title-based view — board scans, `bd search` (title/description only), title-sorted listings — and reads as "no title" to any downstream consumer. In the reporter's repo this produced multiple indistinguishable title-less beads under one epic, two of which were nearly closed as noise.

The existing guards reject a truly empty/absent title, but a title made of spaces or tabs slips past both the positional and `--title` paths:

```
$ bd create --title "   " --type bug
✓ Created issue: tt-vd1 —
$ bd create "  "
✓ Created issue: tt-36b —
```

## Fix

Add a single `strings.TrimSpace(title) == ""` check right after title resolution, so both the positional and `--title` paths refuse a blank title with a clear, non-zero-exit error:

```
$ bd create --title "   " --type bug
Error: title cannot be empty or whitespace-only
$ echo $?
1
```

Valid titles (including intentionally dash-prefixed `--title` values) are unaffected.

## Tests

`TestCLI_CreateRejectsEmptyTitle` covers whitespace-only titles via `--title` (spaces, tab) and via a positional arg.

## Note

The issue also reports the title defaulting to the bare *type* string (e.g. `title: "task"`). That exact symptom no longer reproduces on `main` — a missing/empty title is already rejected — but the whitespace-only gap remained, which is the same class of "title-less bead" the issue asks to prevent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)