### PR TITLE
fix(actor): let BEADS_ACTOR outrank deprecated BD_ACTOR (#4645)

### DIFF
--- a/cmd/bd/actor_test.go
+++ b/cmd/bd/actor_test.go
@@ -5,6 +5,8 @@ import (
 	"os/exec"
 	"strings"
 	"testing"
+
+	"github.com/steveyegge/beads/internal/config"
 )
 
 // TestGetActorWithGit tests the actor resolution fallback chain.
@@ -153,6 +155,51 @@ func TestGetActorWithGit(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestResolveConfiguredActor verifies that BEADS_ACTOR (primary override)
+// outranks the deprecated BD_ACTOR alias when the --actor flag is not set,
+// even though viper's AutomaticEnv binds BD_ACTOR to the "actor" config key
+// (GH#4645). This is the resolution the pre-run hooks use to pre-populate the
+// global actor before getActorWithGit runs.
+func TestResolveConfiguredActor(t *testing.T) {
+	origBd, bdSet := os.LookupEnv("BD_ACTOR")
+	origBeads, beadsSet := os.LookupEnv("BEADS_ACTOR")
+	defer func() {
+		if bdSet {
+			os.Setenv("BD_ACTOR", origBd)
+		} else {
+			os.Unsetenv("BD_ACTOR")
+		}
+		if beadsSet {
+			os.Setenv("BEADS_ACTOR", origBeads)
+		} else {
+			os.Unsetenv("BEADS_ACTOR")
+		}
+		_ = config.Initialize()
+	}()
+
+	t.Run("BEADS_ACTOR outranks BD_ACTOR", func(t *testing.T) {
+		os.Setenv("BD_ACTOR", "from-bd-actor")
+		os.Setenv("BEADS_ACTOR", "from-beads-actor")
+		if err := config.Initialize(); err != nil {
+			t.Fatalf("config.Initialize(): %v", err)
+		}
+		if got := resolveConfiguredActor(); got != "from-beads-actor" {
+			t.Errorf("resolveConfiguredActor() = %q, want %q (BEADS_ACTOR must win)", got, "from-beads-actor")
+		}
+	})
+
+	t.Run("BD_ACTOR used when BEADS_ACTOR unset", func(t *testing.T) {
+		os.Unsetenv("BEADS_ACTOR")
+		os.Setenv("BD_ACTOR", "from-bd-actor")
+		if err := config.Initialize(); err != nil {
+			t.Fatalf("config.Initialize(): %v", err)
+		}
+		if got := resolveConfiguredActor(); got != "from-bd-actor" {
+			t.Errorf("resolveConfiguredActor() = %q, want %q (BD_ACTOR fallback)", got, "from-bd-actor")
+		}
+	})
 }
 
 // TestGetActorWithGit_PriorityOrder tests that the priority order is respected

--- a/cmd/bd/cli_fast_test.go
+++ b/cmd/bd/cli_fast_test.go
@@ -248,6 +248,37 @@ func TestCLI_Create(t *testing.T) {
 	}
 }
 
+// TestCLI_CreateActorPrecedence is a CLI-level regression test for GH#4645:
+// with both BEADS_ACTOR and the deprecated BD_ACTOR set, `bd create` must
+// stamp created_by with BEADS_ACTOR's value. Unlike TestResolveConfiguredActor
+// (which calls resolveConfiguredActor() directly), this drives the real
+// command through rootCmd.Execute() so it also covers the root
+// PersistentPreRunE / refreshBoundCommandConfig wiring that pre-populates the
+// global actor before create.go ever runs — reverting either call site would
+// leave TestResolveConfiguredActor green but this test red.
+func TestCLI_CreateActorPrecedence(t *testing.T) {
+	// Note: Not using t.Parallel() because inProcessMutex serializes execution anyway
+	tmpDir := setupCLITestDB(t)
+	t.Setenv("BD_ACTOR", "from-bd-actor")
+	t.Setenv("BEADS_ACTOR", "from-beads-actor")
+
+	out := runBDInProcess(t, tmpDir, "create", "Actor precedence test", "-p", "1", "--json")
+
+	jsonStart := strings.Index(out, "{")
+	if jsonStart == -1 {
+		t.Fatalf("No JSON found in output: %s", out)
+	}
+	jsonOut := out[jsonStart:]
+
+	var result map[string]interface{}
+	if err := json.Unmarshal([]byte(jsonOut), &result); err != nil {
+		t.Fatalf("Failed to parse JSON: %v\nOutput: %s", err, jsonOut)
+	}
+	if result["created_by"] != "from-beads-actor" {
+		t.Errorf("created_by = %v, want %q (BEADS_ACTOR must outrank deprecated BD_ACTOR)", result["created_by"], "from-beads-actor")
+	}
+}
+
 func TestCLI_List(t *testing.T) {
 	// Note: Not using t.Parallel() because inProcessMutex serializes execution anyway
 	tmpDir := setupCLITestDB(t)

--- a/cmd/bd/config_show.go
+++ b/cmd/bd/config_show.go
@@ -132,6 +132,20 @@ func collectViperEntries() []configEntry {
 		source := config.GetValueSource(key)
 		sourceLabel := viperSourceLabel(key, source)
 
+		// The "actor" key gets the same BEADS_ACTOR > BD_ACTOR precedence as
+		// the runtime path (resolveConfiguredActor in main.go): viper's
+		// AutomaticEnv binds the deprecated BD_ACTOR ahead of any explicit
+		// binding, so config.GetString("actor")/viperSourceLabel alone would
+		// report BD_ACTOR's value and provenance even when BEADS_ACTOR is
+		// also set — contradicting the actor that mutations actually use
+		// (GH#4645). Recompute both here so `config show` matches reality.
+		if key == "actor" {
+			value = formatViperValue(resolveConfiguredActor())
+			if beadsActor := os.Getenv("BEADS_ACTOR"); beadsActor != "" {
+				sourceLabel = "env: BEADS_ACTOR"
+			}
+		}
+
 		// User-global keys (metrics.*) are honored at runtime from the user-global
 		// config.yaml only, never merged project config; report that authoritative
 		// value AND its user-global source so the listing matches what bd actually

--- a/cmd/bd/config_show_test.go
+++ b/cmd/bd/config_show_test.go
@@ -308,6 +308,41 @@ func TestCollectViperEntriesWithEnvOverride(t *testing.T) {
 	t.Error("expected actor key in Viper entries")
 }
 
+// TestCollectViperEntriesActorPrecedenceOverBDActor is a regression test for
+// GH#4645: `bd config show` must report the same actor value AND provenance
+// that mutations actually use (resolveConfiguredActor in main.go), not the
+// deprecated BD_ACTOR that viper's AutomaticEnv binds ahead of any explicit
+// binding. With both env vars set, the entry must show BEADS_ACTOR's value
+// with "env: BEADS_ACTOR" provenance, never BD_ACTOR's.
+func TestCollectViperEntriesActorPrecedenceOverBDActor(t *testing.T) {
+	t.Setenv("BD_ACTOR", "from-bd-actor")
+	t.Setenv("BEADS_ACTOR", "from-beads-actor")
+	t.Setenv("BEADS_TEST_IGNORE_REPO_CONFIG", "1")
+	config.ResetForTesting()
+	if err := config.Initialize(); err != nil {
+		t.Fatalf("config.Initialize() failed: %v", err)
+	}
+	defer func() {
+		config.ResetForTesting()
+		_ = config.Initialize()
+	}()
+
+	entries := collectViperEntries()
+
+	for _, e := range entries {
+		if e.Key == "actor" {
+			if e.Value != "from-beads-actor" {
+				t.Errorf("actor value = %q, want %q (BEADS_ACTOR must win)", e.Value, "from-beads-actor")
+			}
+			if e.Source != "env: BEADS_ACTOR" {
+				t.Errorf("actor source = %q, want %q", e.Source, "env: BEADS_ACTOR")
+			}
+			return
+		}
+	}
+	t.Error("expected actor key in Viper entries")
+}
+
 // TestCollectViperEntriesMetricsUserGlobalProvenance verifies that user-global
 // metrics.* keys report the user-global value AND the user-global config path as
 // their source, even when a project .beads/config.yaml sets a conflicting value

--- a/cmd/bd/main.go
+++ b/cmd/bd/main.go
@@ -540,7 +540,6 @@ func resolveCommandBeadsDir(dbPath string) string {
 	return filepath.Dir(dbPath)
 }
 
-// getActorWithGit returns the actor for audit trails with git config fallback.
 // resolveConfiguredActor returns the actor implied by env/config when no
 // explicit --actor flag was passed, honoring the documented priority
 // BEADS_ACTOR > BD_ACTOR (deprecated) > config.yaml `actor`.
@@ -557,6 +556,7 @@ func resolveConfiguredActor() string {
 	return config.GetString("actor")
 }
 
+// getActorWithGit returns the actor for audit trails with git config fallback.
 // Priority: --actor flag > BEADS_ACTOR env > BD_ACTOR env (deprecated) > git config user.name > $USER > "unknown"
 // This provides a sensible default for developers: their git identity is used unless
 // explicitly overridden

--- a/cmd/bd/main.go
+++ b/cmd/bd/main.go
@@ -504,7 +504,7 @@ func refreshBoundCommandConfig(cmd *cobra.Command) {
 		readonlyMode = config.GetBool("readonly")
 	}
 	if !root.PersistentFlags().Changed("actor") {
-		actor = config.GetString("actor")
+		actor = resolveConfiguredActor()
 	}
 	if !root.PersistentFlags().Changed("dolt-auto-commit") {
 		doltAutoCommit = config.GetString("dolt.auto-commit")
@@ -541,6 +541,22 @@ func resolveCommandBeadsDir(dbPath string) string {
 }
 
 // getActorWithGit returns the actor for audit trails with git config fallback.
+// resolveConfiguredActor returns the actor implied by env/config when no
+// explicit --actor flag was passed, honoring the documented priority
+// BEADS_ACTOR > BD_ACTOR (deprecated) > config.yaml `actor`.
+//
+// viper's AutomaticEnv binds the deprecated BD_ACTOR to the "actor" key (env
+// prefix "BD"), and it is consulted ahead of any explicit binding — so
+// config.GetString("actor") alone returns BD_ACTOR's value even when
+// BEADS_ACTOR is also set, silently letting the deprecated alias win (GH#4645).
+// Check BEADS_ACTOR explicitly first so the primary override outranks it.
+func resolveConfiguredActor() string {
+	if beadsActor := os.Getenv("BEADS_ACTOR"); beadsActor != "" {
+		return beadsActor
+	}
+	return config.GetString("actor")
+}
+
 // Priority: --actor flag > BEADS_ACTOR env > BD_ACTOR env (deprecated) > git config user.name > $USER > "unknown"
 // This provides a sensible default for developers: their git identity is used unless
 // explicitly overridden
@@ -820,7 +836,7 @@ var rootCmd = &cobra.Command{
 			}{dbPath, true}
 		}
 		if !cmd.Root().PersistentFlags().Changed("actor") && actor == "" {
-			actor = config.GetString("actor")
+			actor = resolveConfiguredActor()
 		} else if cmd.Root().PersistentFlags().Changed("actor") {
 			flagOverrides["actor"] = struct {
 				Value  interface{}


### PR DESCRIPTION
Closes #4645

## Problem

The documented actor priority (in `getActorWithGit`'s doc comment and `TestGetActorWithGit`) is:

```
--actor flag > BEADS_ACTOR env > BD_ACTOR env (deprecated) > git user.name > $USER > "unknown"
```

But when both `BEADS_ACTOR` and `BD_ACTOR` are set, the **deprecated** `BD_ACTOR` won.

## Root cause

`internal/config` calls `v.SetEnvPrefix("BD")` + `v.AutomaticEnv()`, which binds `BD_ACTOR` → the `actor` config key. viper consults the prefixed auto-binding *ahead of* any explicit `BindEnv`, so `config.GetString("actor")` returns `BD_ACTOR`'s value even when `BEADS_ACTOR` is also set (`BEADS_ACTOR` isn't under the `BD` prefix, so viper never maps it to `actor`).

The pre-run hooks (`refreshBoundCommandConfig` and the persistent pre-run) pre-populate the global `actor` from `config.GetString("actor")` when `--actor` wasn't passed. `getActorWithGit()` then hits its `if actor != "" { return actor }` early return and hands back the `BD_ACTOR` value, never reaching its own `BEADS_ACTOR` check.

## Fix

Add `resolveConfiguredActor()`, which checks `BEADS_ACTOR` explicitly before falling back to `config.GetString("actor")`, and use it in both pre-run hooks. This restores the documented precedence without touching viper's global env wiring (which other keys depend on). `BD_ACTOR` and a `config.yaml` `actor:` value still apply when `BEADS_ACTOR` is unset.

## Verification

End-to-end with an embedded workspace:

```
# before (upstream/main)
$ BEADS_ACTOR=beads-wins BD_ACTOR=bd-loses bd create "x" --json | jq .created_by
"bd-loses"      # bug

# after
"beads-wins"    # BEADS_ACTOR wins
$ BD_ACTOR=bd-only bd create "y" --json | jq .created_by
"bd-only"       # deprecated alias still works as fallback
```

Adds `TestResolveConfiguredActor` covering both cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)