### PR TITLE
Support comment/comments in proxied-server mode

### DIFF
--- a/cmd/bd/comment.go
+++ b/cmd/bd/comment.go
@@ -28,9 +28,6 @@ Examples:
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if usesProxiedServer() {
-			return HandleErrorRespectJSON("comment is not supported in proxied-server mode")
-		}
 		CheckReadonly("comment")
 
 		evt := metrics.NewCommandEvent("comment")
@@ -39,6 +36,10 @@ Examples:
 				c.CloseEventAndAdd(evt)
 			}
 		}()
+
+		if usesProxiedServer() {
+			return runCommentProxiedServer(cmd, rootCtx, args)
+		}
 
 		id := args[0]
 		textArgs := args[1:]

--- a/cmd/bd/comment_proxied_integration_test.go
+++ b/cmd/bd/comment_proxied_integration_test.go
@@ -1,0 +1,296 @@
+//go:build cgo
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/types"
+)
+
+func bdProxiedComment(t *testing.T, bd, dir string, args ...string) string {
+	t.Helper()
+	fullArgs := append([]string{"comment"}, args...)
+	stdout, stderr, err := bdProxiedRunBuffers(t, bd, dir, fullArgs...)
+	if err != nil {
+		t.Fatalf("bd comment %s failed: %v\nstdout:\n%s\nstderr:\n%s",
+			strings.Join(args, " "), err, stdout, stderr)
+	}
+	return stdout
+}
+
+func bdProxiedCommentFail(t *testing.T, bd, dir string, args ...string) string {
+	t.Helper()
+	fullArgs := append([]string{"comment"}, args...)
+	stdout, stderr, err := bdProxiedRunBuffers(t, bd, dir, fullArgs...)
+	if err == nil {
+		t.Fatalf("expected bd comment %s to fail, got:\nstdout:\n%s\nstderr:\n%s",
+			strings.Join(args, " "), stdout, stderr)
+	}
+	return stdout + stderr
+}
+
+func bdProxiedComments(t *testing.T, bd, dir string, args ...string) string {
+	t.Helper()
+	fullArgs := append([]string{"comments"}, args...)
+	stdout, stderr, err := bdProxiedRunBuffers(t, bd, dir, fullArgs...)
+	if err != nil {
+		t.Fatalf("bd comments %s failed: %v\nstdout:\n%s\nstderr:\n%s",
+			strings.Join(args, " "), err, stdout, stderr)
+	}
+	return stdout
+}
+
+func bdProxiedCommentsJSON(t *testing.T, bd, dir string, args ...string) []*types.Comment {
+	t.Helper()
+	fullArgs := append([]string{"comments", "--json"}, args...)
+	stdout, stderr, err := bdProxiedRunBuffers(t, bd, dir, fullArgs...)
+	if err != nil {
+		t.Fatalf("bd comments --json %s failed: %v\nstdout:\n%s\nstderr:\n%s",
+			strings.Join(args, " "), err, stdout, stderr)
+	}
+	start := strings.Index(stdout, "[")
+	if start < 0 {
+		t.Fatalf("no JSON array in comments output:\n%s", stdout)
+	}
+	var comments []*types.Comment
+	if err := json.Unmarshal([]byte(stdout[start:]), &comments); err != nil {
+		t.Fatalf("parse comments JSON: %v\nraw: %s", err, stdout[start:])
+	}
+	return comments
+}
+
+func TestProxiedServerComment(t *testing.T) {
+	requireProxiedServerEnv(t)
+
+	bd := buildEmbeddedBD(t)
+
+	t.Run("comment_shorthand_then_list", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "cm")
+		issue := bdProxiedCreate(t, bd, p.dir, "Needs a comment")
+
+		out := bdProxiedComment(t, bd, p.dir, issue.ID, "first thoughts")
+		if !strings.Contains(out, "Comment added to") {
+			t.Errorf("expected confirmation, got:\n%s", out)
+		}
+
+		listed := bdProxiedComments(t, bd, p.dir, issue.ID)
+		if !strings.Contains(listed, "first thoughts") {
+			t.Errorf("expected listed comment text, got:\n%s", listed)
+		}
+	})
+
+	t.Run("comments_add_subcommand", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "ca")
+		issue := bdProxiedCreate(t, bd, p.dir, "Add via subcommand")
+
+		if _, _, err := bdProxiedRunBuffers(t, bd, p.dir, "comments", "add", issue.ID, "via add"); err != nil {
+			t.Fatalf("comments add failed: %v", err)
+		}
+
+		comments := bdProxiedCommentsJSON(t, bd, p.dir, issue.ID)
+		if len(comments) != 1 {
+			t.Fatalf("expected 1 comment, got %d", len(comments))
+		}
+		if comments[0].Text != "via add" {
+			t.Errorf("text: got %q, want %q", comments[0].Text, "via add")
+		}
+	})
+
+	t.Run("multiple_comments_ordered", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "mo")
+		issue := bdProxiedCreate(t, bd, p.dir, "Multi comment")
+
+		bdProxiedComment(t, bd, p.dir, issue.ID, "one")
+		bdProxiedComment(t, bd, p.dir, issue.ID, "two")
+		bdProxiedComment(t, bd, p.dir, issue.ID, "three")
+
+		comments := bdProxiedCommentsJSON(t, bd, p.dir, issue.ID)
+		if len(comments) != 3 {
+			t.Fatalf("expected 3 comments, got %d", len(comments))
+		}
+		if comments[0].Text != "one" || comments[1].Text != "two" || comments[2].Text != "three" {
+			t.Errorf("unexpected ordering: %q, %q, %q", comments[0].Text, comments[1].Text, comments[2].Text)
+		}
+	})
+
+	t.Run("comment_json_output", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "cj")
+		issue := bdProxiedCreate(t, bd, p.dir, "JSON comment")
+
+		stdout, stderr, err := bdProxiedRunBuffers(t, bd, p.dir, "comment", "--json", issue.ID, "json body")
+		if err != nil {
+			t.Fatalf("comment --json failed: %v\nstderr:\n%s", err, stderr)
+		}
+		start := strings.Index(stdout, "{")
+		if start < 0 {
+			t.Fatalf("no JSON object in output:\n%s", stdout)
+		}
+		var c types.Comment
+		if err := json.Unmarshal([]byte(stdout[start:]), &c); err != nil {
+			t.Fatalf("parse comment JSON: %v\nraw: %s", err, stdout[start:])
+		}
+		if c.Text != "json body" {
+			t.Errorf("text: got %q, want %q", c.Text, "json body")
+		}
+		if c.IssueID != issue.ID {
+			t.Errorf("issue_id: got %q, want %q", c.IssueID, issue.ID)
+		}
+		if c.ID == "" {
+			t.Error("expected comment ID")
+		}
+	})
+
+	t.Run("no_comments_message", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "nc")
+		issue := bdProxiedCreate(t, bd, p.dir, "Uncommented")
+
+		out := bdProxiedComments(t, bd, p.dir, issue.ID)
+		if !strings.Contains(out, "No comments on") {
+			t.Errorf("expected empty-state message, got:\n%s", out)
+		}
+	})
+
+	t.Run("empty_text_fails", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "et")
+		issue := bdProxiedCreate(t, bd, p.dir, "Empty text")
+
+		out := bdProxiedCommentFail(t, bd, p.dir, issue.ID, "")
+		if !strings.Contains(out, "empty") {
+			t.Errorf("expected empty-text error, got:\n%s", out)
+		}
+	})
+
+	t.Run("missing_issue_fails", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "mi")
+		out := bdProxiedCommentFail(t, bd, p.dir, "mi-99999", "orphan comment")
+		if !strings.Contains(out, "not found") {
+			t.Errorf("expected not-found error, got:\n%s", out)
+		}
+	})
+
+	t.Run("comments_add_json", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "aj")
+		issue := bdProxiedCreate(t, bd, p.dir, "Add JSON")
+
+		stdout, stderr, err := bdProxiedRunBuffers(t, bd, p.dir, "comments", "add", issue.ID, "add json body", "--json")
+		if err != nil {
+			t.Fatalf("comments add --json failed: %v\nstderr:\n%s", err, stderr)
+		}
+		start := strings.Index(stdout, "{")
+		if start < 0 {
+			t.Fatalf("no JSON object in output:\n%s", stdout)
+		}
+		var c types.Comment
+		if err := json.Unmarshal([]byte(stdout[start:]), &c); err != nil {
+			t.Fatalf("parse comment JSON: %v\nraw: %s", err, stdout[start:])
+		}
+		if c.Text != "add json body" {
+			t.Errorf("text: got %q, want %q", c.Text, "add json body")
+		}
+		if c.IssueID != issue.ID {
+			t.Errorf("issue_id: got %q, want %q", c.IssueID, issue.ID)
+		}
+	})
+
+	t.Run("comment_from_file", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "cf")
+		issue := bdProxiedCreate(t, bd, p.dir, "Comment from file")
+
+		file := filepath.Join(t.TempDir(), "body.txt")
+		if err := os.WriteFile(file, []byte("body from a file"), 0o644); err != nil {
+			t.Fatalf("write comment file: %v", err)
+		}
+
+		out := bdProxiedComment(t, bd, p.dir, issue.ID, "--file", file)
+		if !strings.Contains(out, "Comment added to") {
+			t.Errorf("expected confirmation, got:\n%s", out)
+		}
+
+		comments := bdProxiedCommentsJSON(t, bd, p.dir, issue.ID)
+		if len(comments) != 1 || comments[0].Text != "body from a file" {
+			t.Fatalf("expected 1 file-sourced comment, got %+v", comments)
+		}
+	})
+
+	t.Run("comments_add_from_file", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "af")
+		issue := bdProxiedCreate(t, bd, p.dir, "Add from file")
+
+		file := filepath.Join(t.TempDir(), "note.txt")
+		if err := os.WriteFile(file, []byte("note from file"), 0o644); err != nil {
+			t.Fatalf("write comment file: %v", err)
+		}
+
+		if _, stderr, err := bdProxiedRunBuffers(t, bd, p.dir, "comments", "add", issue.ID, "-f", file); err != nil {
+			t.Fatalf("comments add -f failed: %v\nstderr:\n%s", err, stderr)
+		}
+
+		comments := bdProxiedCommentsJSON(t, bd, p.dir, issue.ID)
+		if len(comments) != 1 || comments[0].Text != "note from file" {
+			t.Fatalf("expected 1 file-sourced comment, got %+v", comments)
+		}
+	})
+
+	t.Run("comments_list_local_time", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "lt")
+		issue := bdProxiedCreate(t, bd, p.dir, "Local time")
+		bdProxiedComment(t, bd, p.dir, issue.ID, "timed comment")
+
+		out := bdProxiedComments(t, bd, p.dir, issue.ID, "--local-time")
+		if !strings.Contains(out, "timed comment") {
+			t.Errorf("expected comment text with --local-time, got:\n%s", out)
+		}
+	})
+
+	t.Run("comment_on_wisp_routes_to_wisp_comments", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "wc")
+		wisp := bdProxiedCreate(t, bd, p.dir, "Wisp target", "--ephemeral")
+
+		out := bdProxiedComment(t, bd, p.dir, wisp.ID, "wisp comment")
+		if !strings.Contains(out, "Comment added to") {
+			t.Errorf("expected confirmation, got:\n%s", out)
+		}
+
+		comments := bdProxiedCommentsJSON(t, bd, p.dir, wisp.ID)
+		if len(comments) != 1 || comments[0].Text != "wisp comment" {
+			t.Fatalf("expected 1 wisp comment via list, got %+v", comments)
+		}
+
+		db := openProxiedDB(t, p)
+		var wispCount, permCount int
+		if err := db.QueryRowContext(context.Background(),
+			"SELECT COUNT(*) FROM wisp_comments WHERE issue_id = ?", wisp.ID).Scan(&wispCount); err != nil {
+			t.Fatalf("count wisp_comments: %v", err)
+		}
+		if err := db.QueryRowContext(context.Background(),
+			"SELECT COUNT(*) FROM comments WHERE issue_id = ?", wisp.ID).Scan(&permCount); err != nil {
+			t.Fatalf("count comments: %v", err)
+		}
+		if wispCount != 1 {
+			t.Errorf("wisp_comments count = %d, want 1", wispCount)
+		}
+		if permCount != 0 {
+			t.Errorf("comments (permanent) count = %d, want 0 — wisp comment must not leak into the permanent table", permCount)
+		}
+	})
+
+	t.Run("comments_add_on_wisp", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "wa")
+		wisp := bdProxiedCreate(t, bd, p.dir, "Wisp add target", "--ephemeral")
+
+		if _, stderr, err := bdProxiedRunBuffers(t, bd, p.dir, "comments", "add", wisp.ID, "wisp via add"); err != nil {
+			t.Fatalf("comments add on wisp failed: %v\nstderr:\n%s", err, stderr)
+		}
+
+		comments := bdProxiedCommentsJSON(t, bd, p.dir, wisp.ID)
+		if len(comments) != 1 || comments[0].Text != "wisp via add" {
+			t.Fatalf("expected 1 wisp comment, got %+v", comments)
+		}
+	})
+}

--- a/cmd/bd/comments.go
+++ b/cmd/bd/comments.go
@@ -33,15 +33,16 @@ Examples:
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if usesProxiedServer() {
-			return HandleErrorRespectJSON("comments is not supported in proxied-server mode")
-		}
 		evt := metrics.NewCommandEvent("comments")
 		defer func() {
 			if c := metrics.Global(); c != nil {
 				c.CloseEventAndAdd(evt)
 			}
 		}()
+
+		if usesProxiedServer() {
+			return runCommentsProxiedServer(cmd, rootCtx, args)
+		}
 
 		localTime, _ := cmd.Flags().GetBool("local-time")
 		issueID := args[0]
@@ -135,9 +136,6 @@ Examples:
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if usesProxiedServer() {
-			return HandleErrorRespectJSON("comments add is not supported in proxied-server mode")
-		}
 		CheckReadonly("comment add")
 
 		evt := metrics.NewCommandEvent("comments-add")
@@ -146,6 +144,10 @@ Examples:
 				c.CloseEventAndAdd(evt)
 			}
 		}()
+
+		if usesProxiedServer() {
+			return runCommentsAddProxiedServer(cmd, rootCtx, args)
+		}
 
 		issueID := args[0]
 

--- a/cmd/bd/comments_proxied_server.go
+++ b/cmd/bd/comments_proxied_server.go
@@ -1,0 +1,189 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/steveyegge/beads/internal/storage/uow"
+	"github.com/steveyegge/beads/internal/types"
+	"github.com/steveyegge/beads/internal/ui"
+	"github.com/steveyegge/beads/internal/uimd"
+)
+
+func runCommentsProxiedServer(cmd *cobra.Command, ctx context.Context, args []string) error {
+	localTime, _ := cmd.Flags().GetBool("local-time")
+	issueID := args[0]
+
+	uw, err := proxiedOpenReadUOW(ctx)
+	if err != nil {
+		return err
+	}
+	defer uw.Close(ctx)
+
+	issue, isWisp, err := proxiedGetIssueOrWisp(ctx, uw, issueID)
+	if err != nil {
+		return HandleErrorRespectJSON("resolving %s: %v", issueID, err)
+	}
+	if issue == nil {
+		return HandleErrorRespectJSON("issue %s not found", issueID)
+	}
+	issueID = issue.ID
+
+	comments, err := proxiedGetComments(ctx, uw, issueID, isWisp)
+	if err != nil {
+		return HandleErrorRespectJSON("getting comments: %v", err)
+	}
+	if comments == nil {
+		comments = make([]*types.Comment, 0)
+	}
+
+	if jsonOutput {
+		return outputJSON(comments)
+	}
+
+	if len(comments) == 0 {
+		fmt.Printf("No comments on %s\n", issueID)
+		return nil
+	}
+
+	fmt.Printf("\nComments on %s:\n\n", issueID)
+	for _, comment := range comments {
+		ts := comment.CreatedAt
+		if localTime {
+			ts = ts.Local()
+		}
+		fmt.Printf("[%s] at %s\n", comment.Author, ts.Format("2006-01-02 15:04"))
+		rendered := uimd.RenderMarkdown(comment.Text)
+		for _, line := range strings.Split(strings.TrimRight(rendered, "\n"), "\n") {
+			fmt.Printf("  %s\n", line)
+		}
+		fmt.Println()
+	}
+	return nil
+}
+
+func runCommentProxiedServer(cmd *cobra.Command, ctx context.Context, args []string) error {
+	id := args[0]
+	textArgs := args[1:]
+
+	stdinFlag, _ := cmd.Flags().GetBool("stdin")
+	fileFlag, _ := cmd.Flags().GetString("file")
+
+	var commentText string
+	switch {
+	case stdinFlag:
+		content, err := io.ReadAll(os.Stdin)
+		if err != nil {
+			return HandleErrorRespectJSON("reading from stdin: %v", err)
+		}
+		commentText = strings.TrimRight(string(content), "\n")
+	case fileFlag != "":
+		content, err := readBodyFile(fileFlag)
+		if err != nil {
+			return HandleErrorRespectJSON("reading file: %v", err)
+		}
+		commentText = content
+	case len(textArgs) > 0:
+		commentText = strings.Join(textArgs, " ")
+	default:
+		return HandleErrorRespectJSON("no comment text provided (use positional args, --stdin, or --file)")
+	}
+
+	if strings.TrimSpace(commentText) == "" {
+		return HandleErrorRespectJSON("comment text cannot be empty")
+	}
+
+	author := getActorWithGit()
+
+	comment, issue, err := addCommentProxied(ctx, id, author, commentText)
+	if err != nil {
+		return HandleErrorRespectJSON("%v", err)
+	}
+
+	SetLastTouchedID(issue.ID)
+
+	if jsonOutput {
+		return outputJSON(comment)
+	}
+	fmt.Printf("%s Comment added to %s\n", ui.RenderPass("✓"), formatFeedbackID(issue.ID, issue.Title))
+	return nil
+}
+
+func runCommentsAddProxiedServer(cmd *cobra.Command, ctx context.Context, args []string) error {
+	issueID := args[0]
+
+	commentText, _ := cmd.Flags().GetString("file")
+	if commentText != "" {
+		data, err := os.ReadFile(commentText) // #nosec G304 - user-provided file path is intentional
+		if err != nil {
+			return HandleErrorRespectJSON("reading file: %v", err)
+		}
+		commentText = string(data)
+	} else if len(args) < 2 {
+		return HandleErrorRespectJSON("comment text required (use -f to read from file)")
+	} else {
+		commentText = args[1]
+	}
+
+	if strings.TrimSpace(commentText) == "" {
+		return HandleErrorRespectJSON("comment text cannot be empty")
+	}
+
+	author, _ := cmd.Flags().GetString("author")
+	if author == "" {
+		author = getActorWithGit()
+	}
+
+	comment, issue, err := addCommentProxied(ctx, issueID, author, commentText)
+	if err != nil {
+		return HandleErrorRespectJSON("%v", err)
+	}
+
+	if jsonOutput {
+		return outputJSON(comment)
+	}
+	fmt.Printf("Comment added to %s\n", issue.ID)
+	return nil
+}
+
+type addCommentProxiedResult struct {
+	comment *types.Comment
+	issue   *types.Issue
+}
+
+func addCommentProxied(ctx context.Context, id, author, text string) (*types.Comment, *types.Issue, error) {
+	if uowProvider == nil {
+		return nil, nil, HandleError("proxied-server UOW provider not initialized")
+	}
+	res, err := uow.RunTxResult(ctx, uowProvider, func(ctx context.Context, uw uow.UnitOfWork) (addCommentProxiedResult, string, error) {
+		issue, isWisp := proxiedResolveIssueOrWisp(ctx, uw, id)
+		if issue == nil {
+			return addCommentProxiedResult{}, "", fmt.Errorf("issue %s not found", id)
+		}
+		if err := validateIssueUpdatable(id, issue); err != nil {
+			return addCommentProxiedResult{}, "", err
+		}
+		var (
+			comment *types.Comment
+			cerr    error
+		)
+		if isWisp {
+			comment, cerr = uw.CommentUseCase().AddCommentToWisp(ctx, issue.ID, author, text)
+		} else {
+			comment, cerr = uw.CommentUseCase().AddCommentToIssue(ctx, issue.ID, author, text)
+		}
+		if cerr != nil {
+			return addCommentProxiedResult{}, "", fmt.Errorf("adding comment: %w", cerr)
+		}
+		return addCommentProxiedResult{comment: comment, issue: issue}, fmt.Sprintf("bd: comment %s", issue.ID), nil
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	return res.comment, res.issue, nil
+}

--- a/internal/storage/domain/comment.go
+++ b/internal/storage/domain/comment.go
@@ -16,6 +16,7 @@ type CommentSQLRepository interface {
 	CountsByIssueIDs(ctx context.Context, issueIDs []string, opts CommentOpts) (map[string]int, error)
 	ListByIssueIDs(ctx context.Context, issueIDs []string, opts CommentOpts) (map[string][]*types.Comment, error)
 	IterByIssueID(ctx context.Context, issueID string, opts CommentOpts) (storage.Iter[types.Comment], error)
+	Insert(ctx context.Context, issueID, author, text string, opts CommentOpts) (*types.Comment, error)
 }
 
 type CommentUseCase interface {
@@ -30,6 +31,9 @@ type CommentUseCase interface {
 	GetCommentsForWisp(ctx context.Context, wispID string) ([]*types.Comment, error)
 	CountCommentsForWisp(ctx context.Context, wispID string) (int64, error)
 	IterCommentsForWisp(ctx context.Context, wispID string) (storage.Iter[types.Comment], error)
+
+	AddCommentToIssue(ctx context.Context, issueID, author, text string) (*types.Comment, error)
+	AddCommentToWisp(ctx context.Context, wispID, author, text string) (*types.Comment, error)
 }
 
 func NewCommentUseCase(commentRepo CommentSQLRepository) CommentUseCase {
@@ -124,6 +128,21 @@ func (u *commentUseCaseImpl) iterOne(ctx context.Context, id string, useWisp boo
 		return nil, fmt.Errorf("comment iter: %w", err)
 	}
 	return it, nil
+}
+
+func (u *commentUseCaseImpl) AddCommentToIssue(ctx context.Context, issueID, author, text string) (*types.Comment, error) {
+	return u.add(ctx, issueID, author, text, false)
+}
+
+func (u *commentUseCaseImpl) AddCommentToWisp(ctx context.Context, wispID, author, text string) (*types.Comment, error) {
+	return u.add(ctx, wispID, author, text, true)
+}
+
+func (u *commentUseCaseImpl) add(ctx context.Context, id, author, text string, useWisp bool) (*types.Comment, error) {
+	if id == "" {
+		return nil, fmt.Errorf("comment add: id must not be empty")
+	}
+	return u.commentRepo.Insert(ctx, id, author, text, CommentOpts{UseWispsTable: useWisp})
 }
 
 func (u *commentUseCaseImpl) list(ctx context.Context, ids []string, useWisp bool) (map[string][]*types.Comment, error) {

--- a/internal/storage/domain/db/comment.go
+++ b/internal/storage/domain/db/comment.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
+
+	"github.com/google/uuid"
 
 	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/storage/domain"
@@ -109,4 +112,39 @@ func (r *commentSQLRepositoryImpl) IterByIssueID(ctx context.Context, issueID st
 		return nil, err
 	}
 	return storage.NewSliceIter(bulk[issueID]), nil
+}
+
+func (r *commentSQLRepositoryImpl) Insert(ctx context.Context, issueID, author, text string, opts domain.CommentOpts) (*types.Comment, error) {
+	if issueID == "" {
+		return nil, fmt.Errorf("db: CommentSQLRepository.Insert: issueID must not be empty")
+	}
+
+	issueTable := pickIssueTable(opts.UseWispsTable)
+	var exists bool
+	//nolint:gosec // G201: issueTable is one of two hardcoded constants
+	if err := r.runner.QueryRowContext(ctx,
+		fmt.Sprintf("SELECT EXISTS(SELECT 1 FROM %s WHERE id = ?)", issueTable), issueID).Scan(&exists); err != nil {
+		return nil, fmt.Errorf("db: CommentSQLRepository.Insert: check issue existence: %w", err)
+	}
+	if !exists {
+		return nil, fmt.Errorf("db: CommentSQLRepository.Insert: issue %s not found", issueID)
+	}
+
+	createdAt := time.Now().UTC()
+	id := uuid.Must(uuid.NewV7()).String()
+	commentTable := pickCommentTable(opts.UseWispsTable)
+	//nolint:gosec // G201: commentTable is one of two hardcoded constants
+	if _, err := r.runner.ExecContext(ctx,
+		fmt.Sprintf("INSERT INTO %s (id, issue_id, author, text, created_at) VALUES (?, ?, ?, ?, ?)", commentTable),
+		id, issueID, author, text, createdAt); err != nil {
+		return nil, fmt.Errorf("db: CommentSQLRepository.Insert: %w", err)
+	}
+
+	return &types.Comment{
+		ID:        id,
+		IssueID:   issueID,
+		Author:    author,
+		Text:      text,
+		CreatedAt: createdAt,
+	}, nil
 }

--- a/internal/storage/domain/db/comment_test.go
+++ b/internal/storage/domain/db/comment_test.go
@@ -26,6 +26,14 @@ func (s *testSuite) TestCommentSQLRepository() {
 		s.Run("ListRoutesToWispComments", s.commentWispListRouting)
 		s.Run("IsolatedFromPermanent", s.commentWispIsolated)
 	})
+	s.Run("Insert", func() {
+		s.Run("EmptyIssueIDReturnsError", s.commentInsertEmptyID)
+		s.Run("MissingIssueReturnsError", s.commentInsertMissingIssue)
+		s.Run("MissingWispReturnsError", s.commentInsertMissingWisp)
+		s.Run("PopulatesReturnedComment", s.commentInsertPopulatesReturn)
+		s.Run("RoundTripsThroughList", s.commentInsertRoundTrip)
+		s.Run("RoutesToWispComments", s.commentInsertWispRouting)
+	})
 }
 
 func (s *testSuite) commentRepo() domain.CommentSQLRepository {
@@ -177,6 +185,71 @@ func (s *testSuite) commentWispListRouting() {
 	s.Require().Len(out["bd-cmt-wisp-lst"], 2)
 	s.Equal("first", out["bd-cmt-wisp-lst"][0].Text)
 	s.Equal("second", out["bd-cmt-wisp-lst"][1].Text)
+}
+
+func (s *testSuite) commentInsertEmptyID() {
+	_, err := s.commentRepo().Insert(s.Ctx(), "", "alice", "hi", domain.CommentOpts{})
+	s.Require().Error(err)
+}
+
+func (s *testSuite) commentInsertMissingIssue() {
+	_, err := s.commentRepo().Insert(s.Ctx(), "bd-cmt-ins-ghost", "alice", "hi", domain.CommentOpts{})
+	s.Require().Error(err)
+	s.Contains(err.Error(), "not found")
+}
+
+func (s *testSuite) commentInsertMissingWisp() {
+	s.seedIssueRow("bd-cmt-ins-perm-only")
+	_, err := s.commentRepo().Insert(s.Ctx(), "bd-cmt-ins-perm-only", "alice", "hi", domain.CommentOpts{UseWispsTable: true})
+	s.Require().Error(err)
+	s.Contains(err.Error(), "not found")
+}
+
+func (s *testSuite) commentInsertPopulatesReturn() {
+	s.seedIssueRow("bd-cmt-ins-ret")
+	before := time.Now().UTC().Add(-time.Second)
+
+	c, err := s.commentRepo().Insert(s.Ctx(), "bd-cmt-ins-ret", "alice", "hello world", domain.CommentOpts{})
+	s.Require().NoError(err)
+	s.Require().NotNil(c)
+	s.NotEmpty(c.ID)
+	s.Equal("bd-cmt-ins-ret", c.IssueID)
+	s.Equal("alice", c.Author)
+	s.Equal("hello world", c.Text)
+	s.False(c.CreatedAt.Before(before), "CreatedAt should be stamped at insert time")
+}
+
+func (s *testSuite) commentInsertRoundTrip() {
+	s.seedIssueRow("bd-cmt-ins-rt")
+
+	inserted, err := s.commentRepo().Insert(s.Ctx(), "bd-cmt-ins-rt", "bob", "a note", domain.CommentOpts{})
+	s.Require().NoError(err)
+
+	out, err := s.commentRepo().ListByIssueIDs(s.Ctx(), []string{"bd-cmt-ins-rt"}, domain.CommentOpts{})
+	s.Require().NoError(err)
+	s.Require().Len(out["bd-cmt-ins-rt"], 1)
+	got := out["bd-cmt-ins-rt"][0]
+	s.Equal(inserted.ID, got.ID)
+	s.Equal("bob", got.Author)
+	s.Equal("a note", got.Text)
+	s.WithinDuration(inserted.CreatedAt, got.CreatedAt, 2*time.Second)
+}
+
+func (s *testSuite) commentInsertWispRouting() {
+	s.seedWispRow("bd-cmt-ins-wisp")
+
+	inserted, err := s.commentRepo().Insert(s.Ctx(), "bd-cmt-ins-wisp", "carol", "wisp note", domain.CommentOpts{UseWispsTable: true})
+	s.Require().NoError(err)
+
+	wispOut, err := s.commentRepo().ListByIssueIDs(s.Ctx(), []string{"bd-cmt-ins-wisp"}, domain.CommentOpts{UseWispsTable: true})
+	s.Require().NoError(err)
+	s.Require().Len(wispOut["bd-cmt-ins-wisp"], 1)
+	s.Equal(inserted.ID, wispOut["bd-cmt-ins-wisp"][0].ID)
+	s.Equal("wisp note", wispOut["bd-cmt-ins-wisp"][0].Text)
+
+	permOut, err := s.commentRepo().ListByIssueIDs(s.Ctx(), []string{"bd-cmt-ins-wisp"}, domain.CommentOpts{})
+	s.Require().NoError(err)
+	s.Empty(permOut, "wisp comment should not land in the permanent comments table")
 }
 
 func (s *testSuite) commentWispIsolated() {

--- a/internal/storage/domain/db/comment_usecase_test.go
+++ b/internal/storage/domain/db/comment_usecase_test.go
@@ -21,6 +21,12 @@ func (s *testSuite) TestCommentUseCase() {
 		s.Run("CountCommentsForWispRoutes", s.commentUCWispCount)
 		s.Run("PermLookupOfWispCommentsReturnsEmpty", s.commentUCWispIsolated)
 	})
+	s.Run("Add", func() {
+		s.Run("AddCommentToIssueIsReadableBack", s.commentUCAddIssue)
+		s.Run("AddCommentToWispRoutes", s.commentUCAddWisp)
+		s.Run("AddToMissingIssueReturnsError", s.commentUCAddMissing)
+		s.Run("EmptyIDRejected", s.commentUCAddEmptyID)
+	})
 }
 
 func (s *testSuite) commentUseCase() domain.CommentUseCase {
@@ -130,6 +136,60 @@ func (s *testSuite) commentUCWispCount() {
 	n, err := s.commentUseCase().CountCommentsForWisp(s.Ctx(), "bd-cuc-wisp-cnt")
 	s.Require().NoError(err)
 	s.Equal(int64(2), n)
+}
+
+func (s *testSuite) commentUCAddIssue() {
+	s.seedIssueRow("bd-cuc-add")
+	uc := s.commentUseCase()
+
+	added, err := uc.AddCommentToIssue(s.Ctx(), "bd-cuc-add", "alice", "working on it")
+	s.Require().NoError(err)
+	s.Require().NotNil(added)
+	s.NotEmpty(added.ID)
+
+	out, err := uc.GetCommentsForIssue(s.Ctx(), "bd-cuc-add")
+	s.Require().NoError(err)
+	s.Require().Len(out, 1)
+	s.Equal(added.ID, out[0].ID)
+	s.Equal("alice", out[0].Author)
+	s.Equal("working on it", out[0].Text)
+}
+
+func (s *testSuite) commentUCAddWisp() {
+	s.seedWispRow("bd-cuc-add-wisp")
+	uc := s.commentUseCase()
+
+	_, err := uc.AddCommentToWisp(s.Ctx(), "bd-cuc-add-wisp", "bob", "wisp note")
+	s.Require().NoError(err)
+
+	out, err := uc.GetCommentsForWisp(s.Ctx(), "bd-cuc-add-wisp")
+	s.Require().NoError(err)
+	s.Require().Len(out, 1)
+	s.Equal("wisp note", out[0].Text)
+
+	perm, err := uc.GetCommentsForIssue(s.Ctx(), "bd-cuc-add-wisp")
+	s.Require().NoError(err)
+	s.Empty(perm, "wisp comment must not land in the permanent table")
+}
+
+func (s *testSuite) commentUCAddMissing() {
+	uc := s.commentUseCase()
+
+	_, err := uc.AddCommentToIssue(s.Ctx(), "bd-cuc-add-ghost", "alice", "hi")
+	s.Require().Error(err)
+	s.Contains(err.Error(), "not found")
+}
+
+func (s *testSuite) commentUCAddEmptyID() {
+	uc := s.commentUseCase()
+
+	_, err := uc.AddCommentToIssue(s.Ctx(), "", "alice", "hi")
+	s.Require().Error(err)
+	s.Contains(err.Error(), "id must not be empty")
+
+	_, err = uc.AddCommentToWisp(s.Ctx(), "", "alice", "hi")
+	s.Require().Error(err)
+	s.Contains(err.Error(), "id must not be empty")
 }
 
 func (s *testSuite) commentUCWispIsolated() {


### PR DESCRIPTION
## What

Adds proxied-server support for `comment`, `comments`, and `comments add` — three commands previously blocked with `"... is not supported in proxied-server mode"`.

## Layers

- **Storage repo** (`internal/storage/domain/db/comment.go`): new `CommentSQLRepository.Insert` — verifies the issue exists in the wisp-routed issue table, stamps `time.Now().UTC()`, generates a UUIDv7 id, and inserts into `comments`/`wisp_comments`. Mirrors `issueops.ImportIssueCommentInTx`.
- **Domain use case** (`internal/storage/domain/comment.go`): new `CommentUseCase.AddCommentToIssue` / `AddCommentToWisp`, paralleling the existing read pair. Stays thin (validate id, wisp-route, delegate); existence-check + timestamping live in the repo, matching how `store.AddIssueComment` pushes work into `issueops`.
- **Command duals** (`cmd/bd/comments_proxied_server.go`): `runCommentsProxiedServer` (list, read UOW), `runCommentProxiedServer` (shorthand), `runCommentsAddProxiedServer`, and the shared `addCommentProxied` write helper wrapping the mutation in `uow.RunTxResult`. Guards in `comment.go` / `comments.go` now dispatch instead of erroring, positioned after `CheckReadonly` + metrics per the `close`/`create` convention.

## Tests

- **Unit** (`db/comment_test.go`, `db/comment_usecase_test.go`): `Insert` and `AddCommentTo{Issue,Wisp}` — round-trip, wisp routing/isolation, not-found, empty-id.
- **Integration** (`cmd/bd/comment_proxied_integration_test.go`, `BEADS_TEST_PROXIED_SERVER=1`): 13 subtests covering add/list, JSON on both add forms, `--file` input, `--local-time`, empty-text and missing-issue rejection, ordering, and **wisp routing verified via direct SQL** (comment lands in `wisp_comments`, `COUNT(*) FROM comments = 0`).

All pass end-to-end against a live proxied Dolt server; `gofmt` and `go vet -tags cgo` clean.

## Known differences from embedded

- Partial/short-ID resolution is not applied (resolves the literal ID via `GetIssue`/`GetWisp`), consistent with the existing `close`/`update` proxied duals.
- No concurrent-writer test (proxied serializes writes through the UOW transaction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
