### PR TITLE
Support label subcommands in proxied-server mode

### DIFF
--- a/cmd/bd/label.go
+++ b/cmd/bd/label.go
@@ -121,9 +121,6 @@ var labelAddCmd = &cobra.Command{
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if usesProxiedServer() {
-			return HandleErrorRespectJSON("label add is not supported in proxied-server mode")
-		}
 		CheckReadonly("label add")
 
 		evt := metrics.NewCommandEvent("label-add")
@@ -132,6 +129,10 @@ var labelAddCmd = &cobra.Command{
 				c.CloseEventAndAdd(evt)
 			}
 		}()
+
+		if usesProxiedServer() {
+			return runLabelAddProxiedServer(cmd, rootCtx, args)
+		}
 
 		issueIDs, labels := parseLabelArgs(args)
 		if len(labels) == 0 {
@@ -165,9 +166,6 @@ var labelRemoveCmd = &cobra.Command{
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if usesProxiedServer() {
-			return HandleErrorRespectJSON("label remove is not supported in proxied-server mode")
-		}
 		CheckReadonly("label remove")
 
 		evt := metrics.NewCommandEvent("label-remove")
@@ -176,6 +174,10 @@ var labelRemoveCmd = &cobra.Command{
 				c.CloseEventAndAdd(evt)
 			}
 		}()
+
+		if usesProxiedServer() {
+			return runLabelRemoveProxiedServer(cmd, rootCtx, args)
+		}
 
 		issueIDs, labels := parseLabelArgs(args)
 		if len(labels) == 0 {
@@ -199,15 +201,16 @@ var labelListCmd = &cobra.Command{
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if usesProxiedServer() {
-			return HandleErrorRespectJSON("label list is not supported in proxied-server mode")
-		}
 		evt := metrics.NewCommandEvent("label-list")
 		defer func() {
 			if c := metrics.Global(); c != nil {
 				c.CloseEventAndAdd(evt)
 			}
 		}()
+
+		if usesProxiedServer() {
+			return runLabelListProxiedServer(cmd, rootCtx, args)
+		}
 
 		ctx := rootCtx
 		var issueID string
@@ -245,15 +248,16 @@ var labelListAllCmd = &cobra.Command{
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if usesProxiedServer() {
-			return HandleErrorRespectJSON("label list-all is not supported in proxied-server mode")
-		}
 		evt := metrics.NewCommandEvent("label-list-all")
 		defer func() {
 			if c := metrics.Global(); c != nil {
 				c.CloseEventAndAdd(evt)
 			}
 		}()
+
+		if usesProxiedServer() {
+			return runLabelListAllProxiedServer(cmd, rootCtx)
+		}
 
 		ctx := rootCtx
 		var issues []*types.Issue
@@ -322,9 +326,6 @@ var labelPropagateCmd = &cobra.Command{
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if usesProxiedServer() {
-			return HandleErrorRespectJSON("label propagate is not supported in proxied-server mode")
-		}
 		CheckReadonly("label propagate")
 
 		evt := metrics.NewCommandEvent("label-propagate")
@@ -333,6 +334,10 @@ var labelPropagateCmd = &cobra.Command{
 				c.CloseEventAndAdd(evt)
 			}
 		}()
+
+		if usesProxiedServer() {
+			return runLabelPropagateProxiedServer(cmd, rootCtx, args)
+		}
 
 		ctx := rootCtx
 

--- a/cmd/bd/label.go
+++ b/cmd/bd/label.go
@@ -131,7 +131,7 @@ var labelAddCmd = &cobra.Command{
 		}()
 
 		if usesProxiedServer() {
-			return runLabelAddProxiedServer(cmd, rootCtx, args)
+			return runLabelAddProxiedServer(rootCtx, args)
 		}
 
 		issueIDs, labels := parseLabelArgs(args)
@@ -176,7 +176,7 @@ var labelRemoveCmd = &cobra.Command{
 		}()
 
 		if usesProxiedServer() {
-			return runLabelRemoveProxiedServer(cmd, rootCtx, args)
+			return runLabelRemoveProxiedServer(rootCtx, args)
 		}
 
 		issueIDs, labels := parseLabelArgs(args)
@@ -209,7 +209,7 @@ var labelListCmd = &cobra.Command{
 		}()
 
 		if usesProxiedServer() {
-			return runLabelListProxiedServer(cmd, rootCtx, args)
+			return runLabelListProxiedServer(rootCtx, args)
 		}
 
 		ctx := rootCtx
@@ -256,7 +256,7 @@ var labelListAllCmd = &cobra.Command{
 		}()
 
 		if usesProxiedServer() {
-			return runLabelListAllProxiedServer(cmd, rootCtx)
+			return runLabelListAllProxiedServer(rootCtx)
 		}
 
 		ctx := rootCtx
@@ -336,7 +336,7 @@ var labelPropagateCmd = &cobra.Command{
 		}()
 
 		if usesProxiedServer() {
-			return runLabelPropagateProxiedServer(cmd, rootCtx, args)
+			return runLabelPropagateProxiedServer(rootCtx, args)
 		}
 
 		ctx := rootCtx

--- a/cmd/bd/label_proxied_integration_test.go
+++ b/cmd/bd/label_proxied_integration_test.go
@@ -1,0 +1,444 @@
+//go:build cgo
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"sort"
+	"strings"
+	"testing"
+)
+
+func bdProxiedLabel(t *testing.T, bd, dir string, args ...string) string {
+	t.Helper()
+	fullArgs := append([]string{"label"}, args...)
+	stdout, stderr, err := bdProxiedRunBuffers(t, bd, dir, fullArgs...)
+	if err != nil {
+		t.Fatalf("bd label %s failed: %v\nstdout:\n%s\nstderr:\n%s",
+			strings.Join(args, " "), err, stdout, stderr)
+	}
+	return stdout
+}
+
+func bdProxiedLabelFail(t *testing.T, bd, dir string, args ...string) string {
+	t.Helper()
+	fullArgs := append([]string{"label"}, args...)
+	stdout, stderr, err := bdProxiedRunBuffers(t, bd, dir, fullArgs...)
+	if err == nil {
+		t.Fatalf("expected bd label %s to fail, got:\nstdout:\n%s\nstderr:\n%s",
+			strings.Join(args, " "), stdout, stderr)
+	}
+	return stdout + stderr
+}
+
+func bdProxiedLabelListJSON(t *testing.T, bd, dir, issueID string) []string {
+	t.Helper()
+	stdout, stderr, err := bdProxiedRunBuffers(t, bd, dir, "label", "list", issueID, "--json")
+	if err != nil {
+		t.Fatalf("bd label list %s --json failed: %v\nstdout:\n%s\nstderr:\n%s", issueID, err, stdout, stderr)
+	}
+	start := strings.Index(stdout, "[")
+	if start < 0 {
+		t.Fatalf("no JSON array in label list output:\n%s", stdout)
+	}
+	var labels []string
+	if err := json.Unmarshal([]byte(stdout[start:]), &labels); err != nil {
+		t.Fatalf("parse label list JSON: %v\nraw: %s", err, stdout[start:])
+	}
+	sort.Strings(labels)
+	return labels
+}
+
+func TestProxiedServerLabel(t *testing.T) {
+	requireProxiedServerEnv(t)
+
+	bd := buildEmbeddedBD(t)
+
+	t.Run("add_list_remove", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "la")
+		issue := bdProxiedCreate(t, bd, p.dir, "Label target")
+
+		out := bdProxiedLabel(t, bd, p.dir, "add", issue.ID, "alpha,beta")
+		if !strings.Contains(out, "Added") {
+			t.Errorf("expected 'Added' confirmation, got:\n%s", out)
+		}
+
+		if got := bdProxiedLabelListJSON(t, bd, p.dir, issue.ID); len(got) != 2 || got[0] != "alpha" || got[1] != "beta" {
+			t.Fatalf("labels after add = %v, want [alpha beta]", got)
+		}
+
+		db := openProxiedDB(t, p)
+		persisted := getProxiedLabels(t, db, issue.ID)
+		sort.Strings(persisted)
+		if len(persisted) != 2 || persisted[0] != "alpha" || persisted[1] != "beta" {
+			t.Errorf("persisted labels = %v, want [alpha beta]", persisted)
+		}
+
+		bdProxiedLabel(t, bd, p.dir, "remove", issue.ID, "alpha")
+		if got := bdProxiedLabelListJSON(t, bd, p.dir, issue.ID); len(got) != 1 || got[0] != "beta" {
+			t.Fatalf("labels after remove = %v, want [beta]", got)
+		}
+	})
+
+	t.Run("add_multiple_issues", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "lm")
+		a := bdProxiedCreate(t, bd, p.dir, "Issue A")
+		b := bdProxiedCreate(t, bd, p.dir, "Issue B")
+
+		bdProxiedLabel(t, bd, p.dir, "add", a.ID, b.ID, "shared")
+
+		if got := bdProxiedLabelListJSON(t, bd, p.dir, a.ID); len(got) != 1 || got[0] != "shared" {
+			t.Errorf("issue A labels = %v, want [shared]", got)
+		}
+		if got := bdProxiedLabelListJSON(t, bd, p.dir, b.ID); len(got) != 1 || got[0] != "shared" {
+			t.Errorf("issue B labels = %v, want [shared]", got)
+		}
+	})
+
+	t.Run("list_empty", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "le")
+		issue := bdProxiedCreate(t, bd, p.dir, "No labels")
+		out := bdProxiedLabel(t, bd, p.dir, "list", issue.ID)
+		if !strings.Contains(out, "no labels") {
+			t.Errorf("expected empty-state message, got:\n%s", out)
+		}
+	})
+
+	t.Run("list_all", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "ll")
+		a := bdProxiedCreate(t, bd, p.dir, "A")
+		b := bdProxiedCreate(t, bd, p.dir, "B")
+		bdProxiedLabel(t, bd, p.dir, "add", a.ID, "common")
+		bdProxiedLabel(t, bd, p.dir, "add", b.ID, "common")
+		bdProxiedLabel(t, bd, p.dir, "add", a.ID, "solo")
+
+		stdout, stderr, err := bdProxiedRunBuffers(t, bd, p.dir, "label", "list-all", "--json")
+		if err != nil {
+			t.Fatalf("label list-all --json failed: %v\nstderr:\n%s", err, stderr)
+		}
+		start := strings.Index(stdout, "[")
+		if start < 0 {
+			t.Fatalf("no JSON array in list-all output:\n%s", stdout)
+		}
+		var infos []struct {
+			Label string `json:"label"`
+			Count int    `json:"count"`
+		}
+		if err := json.Unmarshal([]byte(stdout[start:]), &infos); err != nil {
+			t.Fatalf("parse list-all JSON: %v\nraw: %s", err, stdout[start:])
+		}
+		counts := map[string]int{}
+		for _, i := range infos {
+			counts[i.Label] = i.Count
+		}
+		if counts["common"] != 2 {
+			t.Errorf("common count = %d, want 2", counts["common"])
+		}
+		if counts["solo"] != 1 {
+			t.Errorf("solo count = %d, want 1", counts["solo"])
+		}
+	})
+
+	t.Run("propagate", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "lp")
+		parent := bdProxiedCreate(t, bd, p.dir, "Parent epic", "--type", "epic")
+		c1 := bdProxiedCreate(t, bd, p.dir, "Child 1", "--parent", parent.ID)
+		c2 := bdProxiedCreate(t, bd, p.dir, "Child 2", "--parent", parent.ID)
+
+		out := bdProxiedLabel(t, bd, p.dir, "propagate", parent.ID, "branch:x")
+		if !strings.Contains(out, "Propagated") {
+			t.Errorf("expected 'Propagated' output, got:\n%s", out)
+		}
+
+		for _, child := range []string{c1.ID, c2.ID} {
+			if got := bdProxiedLabelListJSON(t, bd, p.dir, child); len(got) != 1 || got[0] != "branch:x" {
+				t.Errorf("child %s labels = %v, want [branch:x]", child, got)
+			}
+		}
+	})
+
+	t.Run("propagate_no_children", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "pn")
+		lonely := bdProxiedCreate(t, bd, p.dir, "Lonely")
+		out := bdProxiedLabel(t, bd, p.dir, "propagate", lonely.ID, "nope")
+		if !strings.Contains(out, "No children found") {
+			t.Errorf("expected no-children message, got:\n%s", out)
+		}
+	})
+
+	t.Run("add_json", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "aj")
+		issue := bdProxiedCreate(t, bd, p.dir, "Add JSON")
+
+		stdout, stderr, err := bdProxiedRunBuffers(t, bd, p.dir, "label", "add", issue.ID, "j1,j2", "--json")
+		if err != nil {
+			t.Fatalf("label add --json failed: %v\nstderr:\n%s", err, stderr)
+		}
+		start := strings.Index(stdout, "[")
+		if start < 0 {
+			t.Fatalf("no JSON array in add output:\n%s", stdout)
+		}
+		var rows []struct {
+			Status  string `json:"status"`
+			IssueID string `json:"issue_id"`
+			Label   string `json:"label"`
+		}
+		if err := json.Unmarshal([]byte(stdout[start:]), &rows); err != nil {
+			t.Fatalf("parse add JSON: %v\nraw: %s", err, stdout[start:])
+		}
+		if len(rows) != 2 {
+			t.Fatalf("expected 2 result rows, got %d", len(rows))
+		}
+		for _, r := range rows {
+			if r.Status != "added" || r.IssueID != issue.ID {
+				t.Errorf("unexpected row: %+v", r)
+			}
+		}
+	})
+
+	t.Run("remove_json", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "rj")
+		issue := bdProxiedCreate(t, bd, p.dir, "Remove JSON")
+		bdProxiedLabel(t, bd, p.dir, "add", issue.ID, "rmj")
+
+		stdout, stderr, err := bdProxiedRunBuffers(t, bd, p.dir, "label", "remove", issue.ID, "rmj", "--json")
+		if err != nil {
+			t.Fatalf("label remove --json failed: %v\nstderr:\n%s", err, stderr)
+		}
+		start := strings.Index(stdout, "[")
+		if start < 0 {
+			t.Fatalf("no JSON array in remove output:\n%s", stdout)
+		}
+		var rows []struct {
+			Status string `json:"status"`
+			Label  string `json:"label"`
+		}
+		if err := json.Unmarshal([]byte(stdout[start:]), &rows); err != nil {
+			t.Fatalf("parse remove JSON: %v\nraw: %s", err, stdout[start:])
+		}
+		if len(rows) != 1 || rows[0].Status != "removed" || rows[0].Label != "rmj" {
+			t.Fatalf("unexpected remove rows: %+v", rows)
+		}
+	})
+
+	t.Run("add_duplicate_idempotent", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "di")
+		issue := bdProxiedCreate(t, bd, p.dir, "Dup label")
+		bdProxiedLabel(t, bd, p.dir, "add", issue.ID, "dup")
+		bdProxiedLabel(t, bd, p.dir, "add", issue.ID, "dup")
+
+		if got := bdProxiedLabelListJSON(t, bd, p.dir, issue.ID); len(got) != 1 || got[0] != "dup" {
+			t.Fatalf("labels after duplicate add = %v, want [dup]", got)
+		}
+	})
+
+	t.Run("remove_comma_separated_multi", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "rm")
+		issue := bdProxiedCreate(t, bd, p.dir, "Multi remove")
+		bdProxiedLabel(t, bd, p.dir, "add", issue.ID, "rm-a,rm-b,rm-keep")
+
+		bdProxiedLabel(t, bd, p.dir, "remove", issue.ID, "rm-a,rm-b")
+		if got := bdProxiedLabelListJSON(t, bd, p.dir, issue.ID); len(got) != 1 || got[0] != "rm-keep" {
+			t.Fatalf("labels after multi remove = %v, want [rm-keep]", got)
+		}
+	})
+
+	t.Run("remove_batch", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "rb")
+		a := bdProxiedCreate(t, bd, p.dir, "Batch rm A")
+		b := bdProxiedCreate(t, bd, p.dir, "Batch rm B")
+		bdProxiedLabel(t, bd, p.dir, "add", a.ID, b.ID, "batch-rm")
+
+		bdProxiedLabel(t, bd, p.dir, "remove", a.ID, b.ID, "batch-rm")
+		for _, id := range []string{a.ID, b.ID} {
+			if got := bdProxiedLabelListJSON(t, bd, p.dir, id); len(got) != 0 {
+				t.Errorf("labels on %s after batch remove = %v, want none", id, got)
+			}
+		}
+	})
+
+	t.Run("list_text", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "lx")
+		issue := bdProxiedCreate(t, bd, p.dir, "Text list")
+		bdProxiedLabel(t, bd, p.dir, "add", issue.ID, "alpha,beta")
+
+		out := bdProxiedLabel(t, bd, p.dir, "list", issue.ID)
+		if !strings.Contains(out, "alpha") || !strings.Contains(out, "beta") {
+			t.Errorf("expected both labels in text list, got:\n%s", out)
+		}
+	})
+
+	t.Run("propagate_json", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "pj")
+		parent := bdProxiedCreate(t, bd, p.dir, "JSON propagate", "--type", "epic")
+		child := bdProxiedCreate(t, bd, p.dir, "JSON prop child", "--parent", parent.ID)
+
+		stdout, stderr, err := bdProxiedRunBuffers(t, bd, p.dir, "label", "propagate", parent.ID, "prop-json", "--json")
+		if err != nil {
+			t.Fatalf("label propagate --json failed: %v\nstderr:\n%s", err, stderr)
+		}
+		start := strings.Index(stdout, "[")
+		if start < 0 {
+			t.Fatalf("no JSON array in propagate output:\n%s", stdout)
+		}
+		var rows []struct {
+			Status  string `json:"status"`
+			IssueID string `json:"issue_id"`
+			Label   string `json:"label"`
+		}
+		if err := json.Unmarshal([]byte(stdout[start:]), &rows); err != nil {
+			t.Fatalf("parse propagate JSON: %v\nraw: %s", err, stdout[start:])
+		}
+		if len(rows) != 1 || rows[0].Status != "propagated" || rows[0].IssueID != child.ID || rows[0].Label != "prop-json" {
+			t.Fatalf("unexpected propagate rows: %+v", rows)
+		}
+	})
+
+	t.Run("add_empty_label_rejected", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "el")
+		issue := bdProxiedCreate(t, bd, p.dir, "Empty label")
+		out := bdProxiedLabelFail(t, bd, p.dir, "add", issue.ID, "")
+		if !strings.Contains(out, "empty") {
+			t.Errorf("expected empty-label error, got:\n%s", out)
+		}
+	})
+
+	t.Run("provides_label_rejected", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "pv")
+		issue := bdProxiedCreate(t, bd, p.dir, "Provides guard")
+		out := bdProxiedLabelFail(t, bd, p.dir, "add", issue.ID, "provides:foo")
+		if !strings.Contains(out, "provides:") {
+			t.Errorf("expected provides guard error, got:\n%s", out)
+		}
+	})
+
+	t.Run("provides_in_comma_list_rejected", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "pc")
+		issue := bdProxiedCreate(t, bd, p.dir, "Provides in list")
+		out := bdProxiedLabelFail(t, bd, p.dir, "add", issue.ID, "ok-label,provides:auth")
+		if !strings.Contains(out, "provides:") {
+			t.Errorf("expected provides guard error, got:\n%s", out)
+		}
+		if got := bdProxiedLabelListJSON(t, bd, p.dir, issue.ID); len(got) != 0 {
+			t.Errorf("no label should be applied when the batch is rejected, got %v", got)
+		}
+	})
+
+	t.Run("wisp_label_routes_to_wisp_labels", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "lw")
+		wisp := bdProxiedCreate(t, bd, p.dir, "Wisp target", "--ephemeral")
+
+		bdProxiedLabel(t, bd, p.dir, "add", wisp.ID, "wlabel")
+
+		if got := bdProxiedLabelListJSON(t, bd, p.dir, wisp.ID); len(got) != 1 || got[0] != "wlabel" {
+			t.Fatalf("wisp labels via list = %v, want [wlabel]", got)
+		}
+
+		db := openProxiedDB(t, p)
+		var wispCount, permCount int
+		if err := db.QueryRowContext(context.Background(),
+			"SELECT COUNT(*) FROM wisp_labels WHERE issue_id = ?", wisp.ID).Scan(&wispCount); err != nil {
+			t.Fatalf("count wisp_labels: %v", err)
+		}
+		if err := db.QueryRowContext(context.Background(),
+			"SELECT COUNT(*) FROM labels WHERE issue_id = ?", wisp.ID).Scan(&permCount); err != nil {
+			t.Fatalf("count labels: %v", err)
+		}
+		if wispCount != 1 {
+			t.Errorf("wisp_labels count = %d, want 1", wispCount)
+		}
+		if permCount != 0 {
+			t.Errorf("labels (permanent) count = %d, want 0 — wisp label must not leak into the permanent table", permCount)
+		}
+	})
+
+	t.Run("wisp_label_remove_routes_to_wisp_labels", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "wr")
+		wisp := bdProxiedCreate(t, bd, p.dir, "Wisp remove target", "--ephemeral")
+
+		bdProxiedLabel(t, bd, p.dir, "add", wisp.ID, "keep,drop")
+		bdProxiedLabel(t, bd, p.dir, "remove", wisp.ID, "drop")
+
+		if got := bdProxiedLabelListJSON(t, bd, p.dir, wisp.ID); len(got) != 1 || got[0] != "keep" {
+			t.Fatalf("wisp labels after remove = %v, want [keep]", got)
+		}
+
+		db := openProxiedDB(t, p)
+		var wispCount int
+		if err := db.QueryRowContext(context.Background(),
+			"SELECT COUNT(*) FROM wisp_labels WHERE issue_id = ?", wisp.ID).Scan(&wispCount); err != nil {
+			t.Fatalf("count wisp_labels: %v", err)
+		}
+		if wispCount != 1 {
+			t.Errorf("wisp_labels count after remove = %d, want 1", wispCount)
+		}
+	})
+
+	t.Run("list_all_includes_wisp_labels", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "law")
+		perm := bdProxiedCreate(t, bd, p.dir, "Perm issue")
+		wisp := bdProxiedCreate(t, bd, p.dir, "Wisp issue", "--ephemeral")
+		bdProxiedLabel(t, bd, p.dir, "add", perm.ID, "shared")
+		bdProxiedLabel(t, bd, p.dir, "add", wisp.ID, "shared")
+		bdProxiedLabel(t, bd, p.dir, "add", wisp.ID, "wisp-only")
+
+		stdout, stderr, err := bdProxiedRunBuffers(t, bd, p.dir, "label", "list-all", "--json")
+		if err != nil {
+			t.Fatalf("label list-all --json failed: %v\nstderr:\n%s", err, stderr)
+		}
+		start := strings.Index(stdout, "[")
+		if start < 0 {
+			t.Fatalf("no JSON array in list-all output:\n%s", stdout)
+		}
+		var infos []struct {
+			Label string `json:"label"`
+			Count int    `json:"count"`
+		}
+		if err := json.Unmarshal([]byte(stdout[start:]), &infos); err != nil {
+			t.Fatalf("parse list-all JSON: %v\nraw: %s", err, stdout[start:])
+		}
+		counts := map[string]int{}
+		for _, i := range infos {
+			counts[i.Label] = i.Count
+		}
+		if counts["shared"] != 2 {
+			t.Errorf("shared count = %d, want 2 (one perm + one wisp)", counts["shared"])
+		}
+		if counts["wisp-only"] != 1 {
+			t.Errorf("wisp-only count = %d, want 1", counts["wisp-only"])
+		}
+	})
+
+	t.Run("propagate_to_wisp_children", func(t *testing.T) {
+		p := bdProxiedInit(t, bd, "pw")
+		parent := bdProxiedCreate(t, bd, p.dir, "Wisp parent", "--ephemeral", "--type", "epic")
+		child := bdProxiedCreate(t, bd, p.dir, "Wisp child", "--ephemeral", "--parent", parent.ID)
+
+		out := bdProxiedLabel(t, bd, p.dir, "propagate", parent.ID, "branch:w")
+		if !strings.Contains(out, "Propagated") {
+			t.Errorf("expected 'Propagated' output, got:\n%s", out)
+		}
+
+		if got := bdProxiedLabelListJSON(t, bd, p.dir, child.ID); len(got) != 1 || got[0] != "branch:w" {
+			t.Fatalf("wisp child labels = %v, want [branch:w]", got)
+		}
+
+		db := openProxiedDB(t, p)
+		var wispCount, permCount int
+		if err := db.QueryRowContext(context.Background(),
+			"SELECT COUNT(*) FROM wisp_labels WHERE issue_id = ?", child.ID).Scan(&wispCount); err != nil {
+			t.Fatalf("count wisp_labels: %v", err)
+		}
+		if err := db.QueryRowContext(context.Background(),
+			"SELECT COUNT(*) FROM labels WHERE issue_id = ?", child.ID).Scan(&permCount); err != nil {
+			t.Fatalf("count labels: %v", err)
+		}
+		if wispCount != 1 {
+			t.Errorf("wisp_labels count = %d, want 1", wispCount)
+		}
+		if permCount != 0 {
+			t.Errorf("labels (permanent) count = %d, want 0 — propagated wisp label must not leak into the permanent table", permCount)
+		}
+	})
+}

--- a/cmd/bd/label_proxied_server.go
+++ b/cmd/bd/label_proxied_server.go
@@ -1,0 +1,304 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/steveyegge/beads/internal/storage/uow"
+	"github.com/steveyegge/beads/internal/types"
+	"github.com/steveyegge/beads/internal/ui"
+)
+
+func runLabelAddProxiedServer(cmd *cobra.Command, ctx context.Context, args []string) error {
+	return labelMutateProxied(ctx, args, "added")
+}
+
+func runLabelRemoveProxiedServer(cmd *cobra.Command, ctx context.Context, args []string) error {
+	return labelMutateProxied(ctx, args, "removed")
+}
+
+func labelMutateProxied(ctx context.Context, args []string, operation string) error {
+	issueIDs, labels := parseLabelArgs(args)
+	if len(labels) == 0 {
+		return HandleErrorRespectJSON("label cannot be empty")
+	}
+	if operation == "added" {
+		for _, label := range labels {
+			if strings.HasPrefix(label, "provides:") {
+				return HandleErrorRespectJSON("'provides:' labels are reserved for cross-project capabilities. Hint: use 'bd ship %s' instead", strings.TrimPrefix(label, "provides:"))
+			}
+		}
+	}
+	if uowProvider == nil {
+		return HandleError("proxied-server UOW provider not initialized")
+	}
+
+	labelDesc := strings.Join(labels, "', '")
+	commitMsg := fmt.Sprintf("bd: label %s '%s' on %d issue(s)", operation, labelDesc, len(issueIDs))
+
+	var resolvedIDs []string
+	err := uow.RunTx(ctx, uowProvider, func(ctx context.Context, uw uow.UnitOfWork) (string, error) {
+		resolvedIDs = resolvedIDs[:0]
+		for _, inputID := range issueIDs {
+			issue, isWisp := proxiedResolveIssueOrWisp(ctx, uw, inputID)
+			if issue == nil {
+				return "", fmt.Errorf("resolving issue ID %q: not found", inputID)
+			}
+			for _, label := range labels {
+				var e error
+				switch {
+				case operation == "added" && isWisp:
+					e = uw.LabelUseCase().AddWispLabel(ctx, issue.ID, label, actor)
+				case operation == "added":
+					e = uw.LabelUseCase().AddLabel(ctx, issue.ID, label, actor)
+				case isWisp:
+					e = uw.LabelUseCase().RemoveWispLabel(ctx, issue.ID, label, actor)
+				default:
+					e = uw.LabelUseCase().RemoveLabel(ctx, issue.ID, label, actor)
+				}
+				if e != nil {
+					return "", fmt.Errorf("%s label '%s' on %s: %w", operation, label, issue.ID, e)
+				}
+			}
+			resolvedIDs = append(resolvedIDs, issue.ID)
+		}
+		return commitMsg, nil
+	})
+	if err != nil {
+		return HandleErrorRespectJSON("label %s: %v", operation, err)
+	}
+	commandDidWrite.Store(true)
+
+	if jsonOutput {
+		results := make([]map[string]interface{}, 0, len(resolvedIDs)*len(labels))
+		for _, issueID := range resolvedIDs {
+			for _, label := range labels {
+				results = append(results, map[string]interface{}{
+					"status":   operation,
+					"issue_id": issueID,
+					"label":    label,
+				})
+			}
+		}
+		return outputJSON(results)
+	}
+
+	verb, prep := "Added", "to"
+	if operation == "removed" {
+		verb, prep = "Removed", "from"
+	}
+	noun := "label"
+	if len(labels) > 1 {
+		noun = "labels"
+	}
+	for _, issueID := range resolvedIDs {
+		fmt.Printf("%s %s %s '%s' %s %s\n", ui.RenderPass("✓"), verb, noun, labelDesc, prep, issueID)
+	}
+	return nil
+}
+
+func runLabelListProxiedServer(cmd *cobra.Command, ctx context.Context, args []string) error {
+	uw, err := proxiedOpenReadUOW(ctx)
+	if err != nil {
+		return err
+	}
+	defer uw.Close(ctx)
+
+	issue, isWisp, err := proxiedGetIssueOrWisp(ctx, uw, args[0])
+	if err != nil {
+		return HandleErrorRespectJSON("resolving %s: %v", args[0], err)
+	}
+	if issue == nil {
+		return HandleErrorRespectJSON("resolving %s: not found", args[0])
+	}
+	issueID := issue.ID
+
+	var labels []string
+	if isWisp {
+		labels, err = uw.LabelUseCase().GetWispLabels(ctx, issueID)
+	} else {
+		labels, err = uw.LabelUseCase().GetLabels(ctx, issueID)
+	}
+	if err != nil {
+		return HandleErrorRespectJSON("%v", err)
+	}
+
+	if jsonOutput {
+		if labels == nil {
+			labels = []string{}
+		}
+		return outputJSON(labels)
+	}
+	if len(labels) == 0 {
+		fmt.Printf("\n%s has no labels\n", issueID)
+		return nil
+	}
+	fmt.Printf("\n%s Labels for %s:\n", ui.RenderAccent("🏷"), issueID)
+	for _, label := range labels {
+		fmt.Printf("  - %s\n", label)
+	}
+	fmt.Println()
+	return nil
+}
+
+func runLabelListAllProxiedServer(cmd *cobra.Command, ctx context.Context) error {
+	uw, err := proxiedOpenReadUOW(ctx)
+	if err != nil {
+		return err
+	}
+	defer uw.Close(ctx)
+
+	page, err := uw.IssueUseCase().SearchIssues(ctx, "", types.IssueFilter{})
+	if err != nil {
+		return HandleErrorRespectJSON("%v", err)
+	}
+
+	var permIDs, wispIDs []string
+	for _, issue := range page.Items {
+		if issue.Ephemeral {
+			wispIDs = append(wispIDs, issue.ID)
+		} else {
+			permIDs = append(permIDs, issue.ID)
+		}
+	}
+
+	labelCounts := make(map[string]int)
+	accumulate := func(byIssue map[string][]string) {
+		for _, labels := range byIssue {
+			for _, label := range labels {
+				labelCounts[label]++
+			}
+		}
+	}
+	if len(permIDs) > 0 {
+		byIssue, err := uw.LabelUseCase().GetLabelsForIssues(ctx, permIDs)
+		if err != nil {
+			return HandleErrorRespectJSON("getting labels: %v", err)
+		}
+		accumulate(byIssue)
+	}
+	if len(wispIDs) > 0 {
+		byWisp, err := uw.LabelUseCase().GetLabelsForWisps(ctx, wispIDs)
+		if err != nil {
+			return HandleErrorRespectJSON("getting labels: %v", err)
+		}
+		accumulate(byWisp)
+	}
+
+	type labelInfo struct {
+		Label string `json:"label"`
+		Count int    `json:"count"`
+	}
+	if len(labelCounts) == 0 {
+		if jsonOutput {
+			return outputJSON([]labelInfo{})
+		}
+		fmt.Println("\nNo labels found in database")
+		return nil
+	}
+
+	labels := make([]string, 0, len(labelCounts))
+	for label := range labelCounts {
+		labels = append(labels, label)
+	}
+	sort.Strings(labels)
+
+	if jsonOutput {
+		result := make([]labelInfo, 0, len(labels))
+		for _, label := range labels {
+			result = append(result, labelInfo{Label: label, Count: labelCounts[label]})
+		}
+		return outputJSON(result)
+	}
+	fmt.Printf("\n%s All labels (%d unique):\n", ui.RenderAccent("🏷"), len(labels))
+	maxLen := 0
+	for _, label := range labels {
+		if len(label) > maxLen {
+			maxLen = len(label)
+		}
+	}
+	for _, label := range labels {
+		padding := strings.Repeat(" ", maxLen-len(label))
+		fmt.Printf("  %s%s  (%d issues)\n", label, padding, labelCounts[label])
+	}
+	fmt.Println()
+	return nil
+}
+
+func runLabelPropagateProxiedServer(cmd *cobra.Command, ctx context.Context, args []string) error {
+	label := strings.TrimSpace(args[1])
+	if label == "" {
+		return HandleErrorRespectJSON("label cannot be empty")
+	}
+	if strings.HasPrefix(label, "provides:") {
+		return HandleErrorRespectJSON("'provides:' labels are reserved for cross-project capabilities. Hint: use 'bd ship %s' instead", strings.TrimPrefix(label, "provides:"))
+	}
+	if uowProvider == nil {
+		return HandleError("proxied-server UOW provider not initialized")
+	}
+
+	var (
+		children []*types.Issue
+		parentID string
+	)
+	err := uow.RunTx(ctx, uowProvider, func(ctx context.Context, uw uow.UnitOfWork) (string, error) {
+		parent, _ := proxiedResolveIssueOrWisp(ctx, uw, args[0])
+		if parent == nil {
+			return "", fmt.Errorf("resolving parent %q: not found", args[0])
+		}
+		parentID = parent.ID
+
+		page, err := uw.IssueUseCase().SearchIssues(ctx, "", types.IssueFilter{ParentID: &parentID})
+		if err != nil {
+			return "", fmt.Errorf("searching children of %s: %w", parentID, err)
+		}
+		children = page.Items
+		if len(children) == 0 {
+			return "", nil
+		}
+		for _, child := range children {
+			var e error
+			if child.Ephemeral {
+				e = uw.LabelUseCase().AddWispLabel(ctx, child.ID, label, actor)
+			} else {
+				e = uw.LabelUseCase().AddLabel(ctx, child.ID, label, actor)
+			}
+			if e != nil {
+				return "", fmt.Errorf("add label '%s' on %s: %w", label, child.ID, e)
+			}
+		}
+		return fmt.Sprintf("bd: propagate label '%s' from %s to %d children", label, parentID, len(children)), nil
+	})
+	if err != nil {
+		return HandleErrorRespectJSON("label propagate: %v", err)
+	}
+
+	if len(children) == 0 {
+		if jsonOutput {
+			return outputJSON([]map[string]interface{}{})
+		}
+		fmt.Printf("No children found for %s\n", parentID)
+		return nil
+	}
+	commandDidWrite.Store(true)
+
+	if jsonOutput {
+		results := make([]map[string]interface{}, 0, len(children))
+		for _, child := range children {
+			results = append(results, map[string]interface{}{
+				"status":   "propagated",
+				"issue_id": child.ID,
+				"label":    label,
+			})
+		}
+		return outputJSON(results)
+	}
+	for _, child := range children {
+		fmt.Printf("%s Propagated label '%s' to %s\n", ui.RenderPass("✓"), label, child.ID)
+	}
+	return nil
+}

--- a/cmd/bd/label_proxied_server.go
+++ b/cmd/bd/label_proxied_server.go
@@ -6,18 +6,16 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/steveyegge/beads/internal/storage/uow"
 	"github.com/steveyegge/beads/internal/types"
 	"github.com/steveyegge/beads/internal/ui"
 )
 
-func runLabelAddProxiedServer(cmd *cobra.Command, ctx context.Context, args []string) error {
+func runLabelAddProxiedServer(ctx context.Context, args []string) error {
 	return labelMutateProxied(ctx, args, "added")
 }
 
-func runLabelRemoveProxiedServer(cmd *cobra.Command, ctx context.Context, args []string) error {
+func runLabelRemoveProxiedServer(ctx context.Context, args []string) error {
 	return labelMutateProxied(ctx, args, "removed")
 }
 
@@ -101,7 +99,7 @@ func labelMutateProxied(ctx context.Context, args []string, operation string) er
 	return nil
 }
 
-func runLabelListProxiedServer(cmd *cobra.Command, ctx context.Context, args []string) error {
+func runLabelListProxiedServer(ctx context.Context, args []string) error {
 	uw, err := proxiedOpenReadUOW(ctx)
 	if err != nil {
 		return err
@@ -145,7 +143,7 @@ func runLabelListProxiedServer(cmd *cobra.Command, ctx context.Context, args []s
 	return nil
 }
 
-func runLabelListAllProxiedServer(cmd *cobra.Command, ctx context.Context) error {
+func runLabelListAllProxiedServer(ctx context.Context) error {
 	uw, err := proxiedOpenReadUOW(ctx)
 	if err != nil {
 		return err
@@ -229,7 +227,7 @@ func runLabelListAllProxiedServer(cmd *cobra.Command, ctx context.Context) error
 	return nil
 }
 
-func runLabelPropagateProxiedServer(cmd *cobra.Command, ctx context.Context, args []string) error {
+func runLabelPropagateProxiedServer(ctx context.Context, args []string) error {
 	label := strings.TrimSpace(args[1])
 	if label == "" {
 		return HandleErrorRespectJSON("label cannot be empty")


### PR DESCRIPTION
## What

Adds proxied-server support for the `bd label` subcommands — `add`, `remove`, `list`, `list-all`, `propagate` — which previously errored with `"... is not supported in proxied-server mode"`.

## No new domain/repo code

Every operation these commands need already exists on the UOW use cases, so this is pure command-layer wiring:

| Store/tx call | Existing replacement |
| --- | --- |
| `tx.AddLabel` / `tx.RemoveLabel` | `LabelUseCase.AddLabel`/`RemoveLabel` (+ `AddWispLabel`/`RemoveWispLabel`) |
| `store.GetLabels` | `LabelUseCase.GetLabels` / `GetWispLabels` |
| `store.GetLabels` in a loop (`list-all`) | `LabelUseCase.GetLabelsForIssues` / `GetLabelsForWisps` (batch, avoids N+1) |
| `store.SearchIssues` | `IssueUseCase.SearchIssues(...).Items` |

## Command duals (`cmd/bd/label_proxied_server.go`)

- `add` / `remove` share `labelMutateProxied`: one `uow.RunTx`, resolves each issue-or-wisp, routes to the issue vs. wisp label method, emits the same per-issue confirmations and JSON shape as embedded, keeps the `provides:` guard on add, and resets its accumulator on tx retry.
- `list` / `list-all` open a read UOW; `list-all` partitions items by `Ephemeral` and batch-fetches labels.
- `propagate` runs in a `uow.RunTx`, routing each child by `Ephemeral`.
- The five guards in `label.go` now dispatch instead of erroring, positioned after `CheckReadonly` + metrics per the `close`/`create` convention.

## Tests (`cmd/bd/label_proxied_integration_test.go`, `BEADS_TEST_PROXIED_SERVER=1`)

21 subtests, full parity with the embedded label suite plus wisp coverage embedded lacks:

- CRUD + `--json` on add/remove/propagate, comma-separated multi-label, batch multi-issue, idempotent duplicate-add, text + JSON list, list-all counts, propagate + no-children.
- Validation: empty-label and `provides:` rejection (including inside a comma list, asserting nothing is applied).
- **Wisp routing verified via direct SQL** across every routing branch in the dual: add, remove, `list-all` partition, and propagate-to-wisp-children all land in `wisp_labels` with `labels` untouched.

All pass end-to-end against a live proxied Dolt server; `gofmt` and `go vet -tags cgo` clean.

## Known differences from embedded

- Partial/short-ID resolution is not applied (resolves the literal ID via `GetIssue`/`GetWisp`), consistent with the existing `close`/`update`/`comment` proxied duals. This also means the space-separated-labels "did you mean comma-separated?" hint (from `resolveLabelIssueIDs`) is not reproduced — the batch still applies nothing, but with a generic not-found error.
- `list-all` counts wisp labels too (`SearchIssues` scans issues and wisps).
- No concurrent-writer test (proxied serializes writes through the UOW transaction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
