### PR TITLE
test(migration): gate real v0.49.6 SQLite upgrade and rollback safety

### DIFF
--- a/.github/workflows/migration-test.yml
+++ b/.github/workflows/migration-test.yml
@@ -24,16 +24,33 @@ on:
           - direct-only
           - stepping-only
 
+permissions:
+  contents: read
+
 env:
   BD_DISABLE_METRICS: "1"
   BD_DISABLE_EVENT_FLUSH: "1"
 
 jobs:
-  sqlite-history:
-    name: SQLite v0.49.6 upgrade qualification
+  historical-upgrades:
+    name: ${{ matrix.qualification }} upgrade qualification
     if: ${{ github.event_name == 'pull_request' }}
-    runs-on: ubuntu-latest
+    # v0.55.4 is dynamically linked against the ICU version shipped here.
+    # Pin the image so a runner alias update cannot invalidate the fixture.
+    runs-on: ubuntu-24.04
     timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - qualification: SQLite v0.49.6
+            version: v0.49.6
+            expected: MANUAL
+            cache-identity: sqlite-v0.49.6-8546dc9a47e11dc31ac2bc9a0224a9c690975e91850932cbb62623053fbb7db8
+          - qualification: Legacy Dolt-dir v0.55.4
+            version: v0.55.4
+            expected: MANUAL
+            cache-identity: legacy-dolt-v0.55.4-e0fa25456dd82890230eef17653448a0bf995104c78864be91c5ed84426a5f49
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
 
@@ -56,7 +73,7 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: ~/.cache/beads-regression
-          key: migration-sqlite-v0.49.6-8546dc9a47e11dc3-${{ runner.os }}-${{ runner.arch }}
+          key: migration-${{ matrix.cache-identity }}-${{ runner.os }}-${{ runner.arch }}
 
       - name: Build candidate
         run: make build
@@ -64,16 +81,18 @@ jobs:
       - name: Verify strict harness guards
         run: ./scripts/migration-test/strict-mode-test.sh
 
-      - name: Qualify v0.49.6 SQLite upgrade
+      - name: Qualify ${{ matrix.qualification }} upgrade
         env:
           CANDIDATE_BIN: ./bd
           GIT_CONFIG_NOSYSTEM: "1"
-        run: ./scripts/migration-test/run.sh --strict --expect MANUAL v0.49.6
+          EXPECTED_STATUS: ${{ matrix.expected }}
+          HISTORICAL_VERSION: ${{ matrix.version }}
+        run: ./scripts/migration-test/run.sh --strict --expect "$EXPECTED_STATUS" "$HISTORICAL_VERSION"
 
   migration-test:
     name: Migration fidelity
     if: ${{ github.event_name != 'pull_request' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6

--- a/.github/workflows/migration-test.yml
+++ b/.github/workflows/migration-test.yml
@@ -1,6 +1,11 @@
 name: Migration Test Harness
 
 on:
+  pull_request:
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - 'website/**'
   push:
     tags: ['v*']
   workflow_dispatch:
@@ -24,8 +29,50 @@ env:
   BD_DISABLE_EVENT_FLUSH: "1"
 
 jobs:
+  sqlite-history:
+    name: SQLite v0.49.6 upgrade qualification
+    if: ${{ github.event_name == 'pull_request' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: 'go.mod'
+
+      - name: Install test dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y jq sqlite3
+
+      - name: Configure Git
+        run: |
+          git config --global user.name "CI Bot"
+          git config --global user.email "ci@beads.test"
+
+      - name: Cache pinned historical release
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        with:
+          path: ~/.cache/beads-regression
+          key: migration-sqlite-v0.49.6-8546dc9a47e11dc3-${{ runner.os }}-${{ runner.arch }}
+
+      - name: Build candidate
+        run: make build
+
+      - name: Verify strict harness guards
+        run: ./scripts/migration-test/strict-mode-test.sh
+
+      - name: Qualify v0.49.6 SQLite upgrade
+        env:
+          CANDIDATE_BIN: ./bd
+          GIT_CONFIG_NOSYSTEM: "1"
+        run: ./scripts/migration-test/run.sh --strict --expect MANUAL v0.49.6
+
   migration-test:
     name: Migration fidelity
+    if: ${{ github.event_name != 'pull_request' }}
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:

--- a/cmd/bd/doctor.go
+++ b/cmd/bd/doctor.go
@@ -387,6 +387,30 @@ func runDiagnostics(path string) doctorResult {
 	// Check 1b: Metadata config file (GH#2478)
 	// Must come before database checks since they depend on metadata.json.
 	beadsDir := doctor.ResolveBeadsDirForRepo(path)
+
+	// Refuse to diagnose an incompatible workspace through the lenient,
+	// migrating store opens below. doctor is in noDbCommands, so it skips the
+	// PersistentPreRun pre-store guard; without this, an incompatible
+	// metadata.json (or legacy config.json) would be version-tracked,
+	// auto-migrated, and opened by NewSharedStore before the incompatibility is
+	// reported. This mirrors guardWorkspaceMetadata's read-only probe but stays
+	// non-fatal: doctor is the documented repair path (see
+	// TestCorruptMetadataDiagnosticsRunAndDataFailsLoud), so it surfaces the
+	// problem and points at --force instead of exiting like a data command, and
+	// it does not flip OverallOK. Retired same-lineage keys are tolerated by the
+	// probe and handled as a separate cleanup warning below; a concurrent atomic
+	// rewrite is a transient race, not incompatibility.
+	if err := workspaceMetadataCompatibility(beadsDir); err != nil && !configfile.IsConcurrentMetadataChange(err) {
+		result.Checks = append(result.Checks, doctorCheck{
+			Name:     "Metadata Compatibility",
+			Status:   statusWarning,
+			Message:  fmt.Sprintf("metadata is incompatible with this bd version: %v", err),
+			Fix:      "Upgrade bd if this workspace was created by a newer bd, or run 'bd init --force' to regenerate metadata.json ('bd doctor --fix' only strips retired same-lineage keys, not foreign fields)",
+			Category: doctor.CategoryCore,
+		})
+		return result
+	}
+
 	configPath := configfile.ConfigPath(beadsDir)
 	if _, err := os.Stat(configPath); os.IsNotExist(err) {
 		metaCheck := doctorCheck{
@@ -399,12 +423,28 @@ func runDiagnostics(path string) doctorResult {
 		result.Checks = append(result.Checks, metaCheck)
 		result.OverallOK = false
 	} else {
-		result.Checks = append(result.Checks, doctorCheck{
+		metaCheck := doctorCheck{
 			Name:     "Metadata Config",
 			Status:   statusOK,
 			Message:  "metadata.json present",
 			Category: doctor.CategoryCore,
-		})
+		}
+		// Surface obsolete keys a newer bd retired from Config so 'bd doctor
+		// --fix' can strip them. These are tolerated by the pre-store guard, so
+		// this is cleanup, not a lockout — but leaving them makes the metadata
+		// harder to reason about and can confuse older tooling.
+		if retired := configfile.RetiredMetadataFields(beadsDir); len(retired) > 0 {
+			metaCheck.Status = statusWarning
+			metaCheck.Message = fmt.Sprintf("metadata.json carries retired field(s): %s", strings.Join(retired, ", "))
+			metaCheck.Fix = "Run 'bd doctor --fix' to remove obsolete metadata keys"
+			// A retired same-lineage key is tolerated by the pre-store guard, so
+			// the workspace opens fine and is not unhealthy: surface it as a
+			// cleanup warning without flipping OverallOK, so automation that gates
+			// on doctor's exit status is not newly failed by benign cruft. (This
+			// also keeps the severity ordering sane: genuinely incompatible
+			// metadata above is a non-fatal warning too.)
+		}
+		result.Checks = append(result.Checks, metaCheck)
 	}
 
 	// Check 1c: Managed-city handoff port conflict (GH#3926)

--- a/cmd/bd/doctor/fix/metadata_json.go
+++ b/cmd/bd/doctor/fix/metadata_json.go
@@ -2,8 +2,10 @@ package fix
 
 import (
 	"fmt"
-	"github.com/steveyegge/beads/internal/configfile"
 	"os"
+	"strings"
+
+	"github.com/steveyegge/beads/internal/configfile"
 )
 
 // FixMissingMetadataJSON detects and regenerates a missing metadata.json file.
@@ -31,5 +33,27 @@ func FixMissingMetadataJSON(path string) error {
 	}
 
 	fmt.Printf("  Regenerated metadata.json with default values\n")
+	return nil
+}
+
+// FixRetiredMetadataKeys strips metadata.json keys that a newer bd version has
+// retired from Config, preserving every other key. It is safe cruft cleanup that
+// never opens the store: it removes only keys bd knows are retired, never an
+// unknown key a newer bd might still require, so a workspace written by a newer
+// bd stays refused by the pre-store metadata guard. This is the in-band recovery
+// path the guard's refusal message points at for obsolete metadata keys.
+func FixRetiredMetadataKeys(path string) error {
+	beadsDir, err := resolvedWorkspaceBeadsDir(path)
+	if err != nil {
+		return err
+	}
+
+	removed, err := configfile.RemoveRetiredMetadataFields(beadsDir)
+	if err != nil {
+		return fmt.Errorf("failed to strip retired metadata keys: %w", err)
+	}
+	if len(removed) > 0 {
+		fmt.Printf("  Removed %d retired metadata key(s): %s\n", len(removed), strings.Join(removed, ", "))
+	}
 	return nil
 }

--- a/cmd/bd/doctor/fix/retired_metadata_json_test.go
+++ b/cmd/bd/doctor/fix/retired_metadata_json_test.go
@@ -1,0 +1,74 @@
+package fix
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestFixRetiredMetadataKeys_StripsRetiredPreservesForeign verifies the doctor
+// remediation the guard's refusal message points at: it strips a same-lineage
+// key a newer bd retired from Config, while preserving a genuinely-foreign key
+// so a workspace written by a newer bd stays refused by the pre-store guard.
+func TestFixRetiredMetadataKeys_StripsRetiredPreservesForeign(t *testing.T) {
+	dir := setupTestWorkspace(t)
+	configPath := filepath.Join(dir, ".beads", "metadata.json")
+
+	metadata := []byte(`{
+  "database": "dolt",
+  "backend": "dolt",
+  "dolt_proxied_server_config": "proxied-config.yaml",
+  "jsonl_export": "issues.jsonl"
+}`)
+	if err := os.WriteFile(configPath, metadata, 0o600); err != nil {
+		t.Fatalf("write metadata.json: %v", err)
+	}
+
+	if err := FixRetiredMetadataKeys(dir); err != nil {
+		t.Fatalf("FixRetiredMetadataKeys failed: %v", err)
+	}
+
+	raw, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &fields); err != nil {
+		t.Fatalf("decode rewritten metadata.json: %v", err)
+	}
+	if _, ok := fields["dolt_proxied_server_config"]; ok {
+		t.Error("retired key survived FixRetiredMetadataKeys")
+	}
+	if _, ok := fields["jsonl_export"]; !ok {
+		t.Error("foreign key was dropped; guard's forward-incompat protection weakened")
+	}
+	if _, ok := fields["database"]; !ok {
+		t.Error("recognized key was dropped")
+	}
+}
+
+// TestFixRetiredMetadataKeys_NoOpWhenClean verifies the fix leaves a workspace
+// without retired keys byte-for-byte unchanged.
+func TestFixRetiredMetadataKeys_NoOpWhenClean(t *testing.T) {
+	dir := setupTestWorkspace(t)
+	configPath := filepath.Join(dir, ".beads", "metadata.json")
+
+	original := []byte(`{"database":"dolt","backend":"dolt"}`)
+	if err := os.WriteFile(configPath, original, 0o600); err != nil {
+		t.Fatalf("write metadata.json: %v", err)
+	}
+
+	if err := FixRetiredMetadataKeys(dir); err != nil {
+		t.Fatalf("FixRetiredMetadataKeys failed: %v", err)
+	}
+
+	after, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(after, original) {
+		t.Fatalf("clean metadata was rewritten: got %q want %q", after, original)
+	}
+}

--- a/cmd/bd/doctor_fix.go
+++ b/cmd/bd/doctor_fix.go
@@ -269,6 +269,11 @@ func applyFixList(path string, fixes []doctorCheck) {
 		switch check.Name {
 		case "Metadata Config":
 			err = fix.FixMissingMetadataJSON(path)
+			// Also strip retired metadata keys from an existing metadata.json so
+			// obsolete cruft (e.g. removed proxied-server paths) is cleaned up.
+			if rErr := fix.FixRetiredMetadataKeys(path); rErr != nil && err == nil {
+				err = rErr
+			}
 		case "Gitignore":
 			err = doctor.FixGitignore(path)
 		case "Project Gitignore":

--- a/cmd/bd/main.go
+++ b/cmd/bd/main.go
@@ -318,7 +318,13 @@ func loadServerModeFromBeadsDir(beadsDir string) error {
 	if beadsDir == "" {
 		return nil
 	}
-	cfg, err := configfile.Load(beadsDir)
+	// Storage-mode probe, not a migration point. For store-free commands (e.g.
+	// bd doctor via loadServerModeFromConfig) this runs before
+	// guardWorkspaceMetadata, so it must never migrate a legacy config.json as a
+	// side effect of reading the mode. LoadForDiscovery preserves the existing
+	// lenient behavior (a parse-unloadable metadata.json is still a hard error)
+	// while never writing.
+	cfg, err := configfile.LoadForDiscovery(beadsDir)
 	if err != nil {
 		return fmt.Errorf("load %s: %w (storage mode unknown; data commands will refuse to run rather than fall back to the embedded store)", configfile.ConfigPath(beadsDir), err)
 	}
@@ -680,6 +686,47 @@ func restoreChangeDirSelection() {
 	changeDirEnvSnapshot = nil
 }
 
+// workspaceMetadataCompatibility reports whether this bd version can safely
+// decode beadsDir's workspace metadata without mutating it. It returns nil when
+// the metadata is absent or compatible. A non-nil error is classified: when
+// configfile.IsConcurrentMetadataChange reports true it is a transient
+// atomic-rewrite race (already retried once here); any other non-nil error is a
+// genuine incompatibility. It canonicalizes first because supported .beads roots
+// may themselves be symlinks. The fatal pre-store guard and bd doctor's
+// non-fatal metadata report share this probe so they classify incompatibility
+// identically.
+func workspaceMetadataCompatibility(beadsDir string) error {
+	canonicalBeadsDir := utils.CanonicalizePath(beadsDir)
+	_, err := configfile.LoadReadOnly(canonicalBeadsDir)
+	if err != nil && configfile.IsConcurrentMetadataChange(err) {
+		_, err = configfile.LoadReadOnly(canonicalBeadsDir)
+	}
+	return err
+}
+
+// guardWorkspaceMetadata refuses to open or modify a workspace whose metadata
+// this bd version cannot safely decode, before any version tracking, migration,
+// or store open. A concurrent atomic metadata rewrite can change the file's
+// identity mid-read; that is a transient race, not incompatibility, so it is
+// retried once (in workspaceMetadataCompatibility) and, if it persists, reported
+// distinctly rather than as a version mismatch. For genuine incompatibility the
+// message names the offending field (via the wrapped error) and points at
+// concrete recovery paths that do not require opening the store.
+func guardWorkspaceMetadata(beadsDir string) error {
+	err := workspaceMetadataCompatibility(beadsDir)
+	if err == nil {
+		return nil
+	}
+	if configfile.IsConcurrentMetadataChange(err) {
+		return HandleError("workspace metadata.json in %s is being modified concurrently; retry the command: %v", beadsDir, err)
+	}
+	return HandleError("workspace metadata is incompatible with this bd version: %v\n"+
+		"Refusing to open or modify %s. If this workspace was created by a newer bd, upgrade bd; "+
+		"if metadata.json carries an obsolete or hand-edited key, run 'bd doctor --fix' or "+
+		"'bd init --force' to regenerate it. Store-free commands (e.g. 'bd version', 'bd doctor') still work.",
+		err, beadsDir)
+}
+
 var rootCmd = &cobra.Command{
 	Use:   "bd",
 	Short: "bd - Dependency-aware issue tracker",
@@ -989,7 +1036,12 @@ var rootCmd = &cobra.Command{
 
 		if dbPath == "" {
 			if bd := beads.FindBeadsDir(); bd != "" {
-				if cfg, _ := configfile.Load(bd); cfg != nil && (cfg.IsDoltProxiedServerMode() || cfg.GetBackend() == configfile.BackendPostgres || cfg.GetBackend() == configfile.BackendMySQL || cfg.GetBackend() == configfile.BackendSQLite) {
+				// Discovery probe: this runs before guardWorkspaceMetadata, so it
+				// must never migrate a legacy config.json or otherwise mutate the
+				// workspace. LoadForDiscovery is lenient (an incompatible workspace
+				// still resolves so the guard below refuses it with a precise
+				// message) but non-migrating.
+				if cfg, _ := configfile.LoadForDiscovery(bd); cfg != nil && (cfg.IsDoltProxiedServerMode() || cfg.GetBackend() == configfile.BackendPostgres || cfg.GetBackend() == configfile.BackendMySQL || cfg.GetBackend() == configfile.BackendSQLite) {
 					// A non-Dolt SQL (or proxied-server) workspace has no local Dolt
 					// database file; the .beads dir with metadata.json IS the workspace.
 					dbPath = bd
@@ -1069,8 +1121,8 @@ var rootCmd = &cobra.Command{
 		beadsDir := resolveCommandBeadsDir(dbPath)
 		// Refuse incompatible metadata before version tracking, migration, or store open.
 		// Canonicalize first because supported .beads roots may themselves be symlinks.
-		if _, err := configfile.LoadReadOnly(utils.CanonicalizePath(beadsDir)); err != nil {
-			return HandleError("workspace metadata is incompatible with this bd version: %v (refusing to open or modify %s)", err, beadsDir)
+		if guardErr := guardWorkspaceMetadata(beadsDir); guardErr != nil {
+			return guardErr
 		}
 		prepareSelectedCommandContext(beadsDir, true)
 		refreshBoundCommandConfig(cmd)

--- a/cmd/bd/main.go
+++ b/cmd/bd/main.go
@@ -1067,6 +1067,11 @@ var rootCmd = &cobra.Command{
 		}
 
 		beadsDir := resolveCommandBeadsDir(dbPath)
+		// Refuse incompatible metadata before version tracking, migration, or store open.
+		// Canonicalize first because supported .beads roots may themselves be symlinks.
+		if _, err := configfile.LoadReadOnly(utils.CanonicalizePath(beadsDir)); err != nil {
+			return HandleError("workspace metadata is incompatible with this bd version: %v (refusing to open or modify %s)", err, beadsDir)
+		}
 		prepareSelectedCommandContext(beadsDir, true)
 		refreshBoundCommandConfig(cmd)
 		if _, err := getDoltAutoCommitMode(); err != nil {

--- a/cmd/bd/prestore_metadata_guard_e2e_test.go
+++ b/cmd/bd/prestore_metadata_guard_e2e_test.go
@@ -155,6 +155,173 @@ func TestCanonicalSQLiteMetadataThroughSymlinkPassesCompatibilityGuard(t *testin
 	}
 }
 
+func TestRetiredSameLineageMetadataFieldPassesCompatibilityGuard(t *testing.T) {
+	bd := buildBDUnderTest(t)
+	repoDir := newPrestoreGuardRepo(t)
+
+	stdout, stderr, err := runPrestoreGuardCommand(t, bd, repoDir,
+		"init", "--quiet", "--non-interactive", "--prefix", "retired",
+		"--backend", "sqlite", "--skip-hooks", "--skip-agents")
+	if err != nil {
+		t.Fatalf("initialize workspace: %v\nstdout:\n%s\nstderr:\n%s", err, stdout, stderr)
+	}
+
+	// Inject a field this lineage persisted under an older bd version and has
+	// since removed from Config (dolt_proxied_server_config, removed in
+	// 5a7cc3e1a). The lenient store-open loader has always ignored such keys;
+	// the strict pre-store guard must tolerate them too, or every field removal
+	// silently locks out existing same-lineage workspaces. This is the mirror of
+	// TestListRejectsV0554MetadataBeforeWorkspaceMutation, which proves a
+	// genuinely foreign field is still refused.
+	metadataPath := filepath.Join(repoDir, ".beads", "metadata.json")
+	injectMetadataField(t, metadataPath, "dolt_proxied_server_config", "proxied-config.yaml")
+
+	stdout, stderr, err = runPrestoreGuardCommand(t, bd, repoDir, "list", "--json", "--limit", "0", "--all")
+	if err != nil {
+		t.Fatalf("list workspace carrying a retired same-lineage field: %v\nstdout:\n%s\nstderr:\n%s", err, stdout, stderr)
+	}
+	var issues []json.RawMessage
+	if err := json.Unmarshal([]byte(stdout), &issues); err != nil {
+		t.Fatalf("parse list JSON: %v\nstdout:\n%s\nstderr:\n%s", err, stdout, stderr)
+	}
+	if len(issues) != 0 {
+		t.Fatalf("workspace returned %d issues, want none", len(issues))
+	}
+}
+
+// A legacy .beads/config.json (the pre-metadata.json filename) carrying a
+// forward-incompatible field must be refused by the guard just like a canonical
+// metadata.json, and — critically — discovery must not migrate/strip it before
+// the guard runs. Before the fix, the pre-guard discovery reads
+// (findDatabaseInBeadsDir, resolveBeadsDirForDBPath, the backend probe) went
+// through the migrating configfile.Load, which rewrote config.json into a
+// field-stripped metadata.json and opened the workspace instead of refusing it.
+func TestListRejectsLegacyConfigJSONBeforeWorkspaceMutation(t *testing.T) {
+	bd := buildBDUnderTest(t)
+	repoDir, beadsDir := newV0554LegacyConfigWorkspace(t)
+	before := hashBackendPreflightTree(t, beadsDir)
+
+	stdout, stderr, err := runPrestoreGuardCommand(t, bd, repoDir, "list", "--json", "--limit", "0", "--all")
+	output := stdout + stderr
+
+	if err == nil {
+		t.Errorf("bd list succeeded against incompatible legacy config.json; stdout:\n%s\nstderr:\n%s", stdout, stderr)
+	}
+	if !strings.Contains(output, `unknown or noncanonical metadata field "jsonl_export"`) {
+		t.Errorf("bd list did not report the incompatible legacy field; err=%v\nstdout:\n%s\nstderr:\n%s", err, stdout, stderr)
+	}
+
+	if _, statErr := os.Stat(filepath.Join(beadsDir, "metadata.json")); !os.IsNotExist(statErr) {
+		t.Errorf("bd list migrated the legacy config.json into metadata.json before refusing: %v", statErr)
+	}
+	after := hashBackendPreflightTree(t, beadsDir)
+	if before != after {
+		t.Errorf("bd list changed the legacy config.json workspace before refusing: before=%x after=%x", before, after)
+	}
+}
+
+// A SQL-backend (or server-mode) workspace has no local Dolt directory, so its
+// database path is resolved from metadata.json alone. Discovery therefore must
+// stay lenient: a strict read here would fail to resolve the workspace and the
+// command would exit "no beads database found" instead of the guard's precise
+// incompatibility message. This pins that discovery uses the lenient,
+// never-migrating LoadForDiscovery rather than the strict LoadReadOnly.
+func TestListRejectsIncompatibleSQLBackendMetadataWithoutLocalDir(t *testing.T) {
+	bd := buildBDUnderTest(t)
+	repoDir := newPrestoreGuardRepo(t)
+	beadsDir := filepath.Join(repoDir, ".beads")
+	writeFile(t, filepath.Join(beadsDir, "metadata.json"), []byte(`{
+  "database": "beads.db",
+  "jsonl_export": "issues.jsonl",
+  "backend": "sqlite"
+}`))
+	writeFile(t, filepath.Join(beadsDir, ".local_version"), []byte("0.55.4\n"))
+	before := hashBackendPreflightTree(t, beadsDir)
+
+	stdout, stderr, err := runPrestoreGuardCommand(t, bd, repoDir, "list", "--json", "--limit", "0", "--all")
+	output := stdout + stderr
+
+	if err == nil {
+		t.Errorf("bd list succeeded against incompatible SQL-backend metadata; stdout:\n%s\nstderr:\n%s", stdout, stderr)
+	}
+	if !strings.Contains(output, `unknown or noncanonical metadata field "jsonl_export"`) {
+		t.Errorf("bd list did not report the incompatibility for a no-local-dir workspace; err=%v\nstdout:\n%s\nstderr:\n%s", err, stdout, stderr)
+	}
+	if strings.Contains(output, "no beads database found") {
+		t.Errorf("discovery regressed to \"no beads database found\" instead of the guard message:\nstdout:\n%s\nstderr:\n%s", stdout, stderr)
+	}
+
+	after := hashBackendPreflightTree(t, beadsDir)
+	if before != after {
+		t.Errorf("bd list changed the incompatible workspace before refusing: before=%x after=%x", before, after)
+	}
+}
+
+// bd doctor is in noDbCommands and skips the pre-store guard, so it must run its
+// own strict metadata check before version tracking, auto-migration, or store
+// open. Full diagnostics only run in server mode (embedded/proxied short-circuit
+// earlier), which is exactly the path that would otherwise reach the lenient,
+// migrating NewSharedStore. The check stays non-fatal (doctor is the repair
+// path): it reports the incompatibility and exits zero without mutating the
+// workspace or opening the store.
+func TestDoctorReportsIncompatibleMetadataWithoutMutation(t *testing.T) {
+	bd := buildBDUnderTest(t)
+	repoDir := newPrestoreGuardRepo(t)
+	beadsDir := filepath.Join(repoDir, ".beads")
+	// Server mode so `bd doctor` runs full diagnostics; the foreign field
+	// (jsonl_export) makes the metadata incompatible with this bd version.
+	writeFile(t, filepath.Join(beadsDir, "metadata.json"), []byte(`{
+  "database": "dolt",
+  "jsonl_export": "issues.jsonl",
+  "backend": "dolt",
+  "dolt_mode": "server",
+  "dolt_database": "beads_smoke"
+}`))
+	writeFile(t, filepath.Join(beadsDir, ".local_version"), []byte("0.55.4\n"))
+	before := hashBackendPreflightTree(t, beadsDir)
+
+	stdout, stderr, err := runPrestoreGuardCommand(t, bd, repoDir, "doctor", "--json")
+	output := stdout + stderr
+	if err != nil {
+		t.Fatalf("bd doctor failed against incompatible metadata (doctor is the repair path and must run): %v\nstdout:\n%s\nstderr:\n%s", err, stdout, stderr)
+	}
+	if !strings.Contains(output, "jsonl_export") {
+		t.Errorf("bd doctor did not report the metadata incompatibility; stdout:\n%s\nstderr:\n%s", stdout, stderr)
+	}
+
+	after := hashBackendPreflightTree(t, beadsDir)
+	if before != after {
+		t.Errorf("bd doctor changed the incompatible workspace: before=%x after=%x", before, after)
+	}
+}
+
+// injectMetadataField adds or overwrites a single top-level key in a
+// metadata.json file, preserving the other keys, so tests can simulate a
+// workspace carrying an extra (e.g. retired) field.
+func injectMetadataField(t *testing.T, metadataPath, key string, value any) {
+	t.Helper()
+	raw, err := os.ReadFile(metadataPath)
+	if err != nil {
+		t.Fatalf("read metadata for field injection: %v", err)
+	}
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &fields); err != nil {
+		t.Fatalf("decode metadata for field injection: %v", err)
+	}
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		t.Fatalf("encode injected metadata value: %v", err)
+	}
+	fields[key] = encoded
+	updated, err := json.MarshalIndent(fields, "", "  ")
+	if err != nil {
+		t.Fatalf("encode metadata after field injection: %v", err)
+	}
+	if err := os.WriteFile(metadataPath, updated, 0o600); err != nil {
+		t.Fatalf("write metadata after field injection: %v", err)
+	}
+}
+
 func newV0554MetadataWorkspace(t *testing.T) (repoDir, beadsDir string) {
 	t.Helper()
 	repoDir = newPrestoreGuardRepo(t)
@@ -165,6 +332,30 @@ func newV0554MetadataWorkspace(t *testing.T) (repoDir, beadsDir string) {
 	// field, so a store-backed command must refuse before running any upgrade
 	// tracking, migration, or store-open path.
 	writeFile(t, filepath.Join(beadsDir, "metadata.json"), []byte(`{
+  "database": "dolt",
+  "jsonl_export": "issues.jsonl",
+  "backend": "dolt",
+  "dolt_database": "beads_smoke"
+}`))
+	writeFile(t, filepath.Join(beadsDir, ".local_version"), []byte("0.55.4\n"))
+	writeFile(t, filepath.Join(beadsDir, "dolt", "source-marker"), []byte("legacy source\n"))
+	if err := os.Chmod(beadsDir, 0o700); err != nil {
+		t.Fatalf("chmod legacy beads directory: %v", err)
+	}
+	return repoDir, beadsDir
+}
+
+// newV0554LegacyConfigWorkspace mirrors newV0554MetadataWorkspace but persists
+// the forward-incompatible field in a legacy .beads/config.json (the filename
+// used before the metadata.json rename) with no metadata.json, exercising the
+// discovery paths that historically migrated the legacy file before the guard
+// could refuse it.
+func newV0554LegacyConfigWorkspace(t *testing.T) (repoDir, beadsDir string) {
+	t.Helper()
+	repoDir = newPrestoreGuardRepo(t)
+
+	beadsDir = filepath.Join(repoDir, ".beads")
+	writeFile(t, filepath.Join(beadsDir, "config.json"), []byte(`{
   "database": "dolt",
   "jsonl_export": "issues.jsonl",
   "backend": "dolt",

--- a/cmd/bd/prestore_metadata_guard_e2e_test.go
+++ b/cmd/bd/prestore_metadata_guard_e2e_test.go
@@ -1,0 +1,230 @@
+//go:build cgo
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestListRejectsV0554MetadataBeforeWorkspaceMutation(t *testing.T) {
+	bd := buildBDUnderTest(t)
+	repoDir, beadsDir := newV0554MetadataWorkspace(t)
+	before := hashBackendPreflightTree(t, beadsDir)
+
+	stdout, stderr, err := runPrestoreGuardCommand(t, bd, repoDir, "list", "--json", "--limit", "0", "--all")
+	output := stdout + stderr
+
+	if err == nil {
+		t.Errorf("bd list succeeded against incompatible v0.55.4 metadata; stdout:\n%s\nstderr:\n%s", stdout, stderr)
+	}
+	if !strings.Contains(output, `unknown or noncanonical metadata field "jsonl_export"`) {
+		t.Errorf("bd list did not report the incompatible v0.55.4 metadata field; err=%v\nstdout:\n%s\nstderr:\n%s", err, stdout, stderr)
+	}
+
+	after := hashBackendPreflightTree(t, beadsDir)
+	if before != after {
+		t.Errorf("bd list changed the legacy workspace before refusing: before=%x after=%x", before, after)
+	}
+}
+
+func TestIncompatibleMetadataStillAllowsStoreFreeCommands(t *testing.T) {
+	bd := buildBDUnderTest(t)
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{name: "version", args: []string{"version"}},
+		{name: "root_help_flag", args: []string{"--help"}},
+		{name: "help_command", args: []string{"help"}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			repoDir, beadsDir := newV0554MetadataWorkspace(t)
+			before := hashBackendPreflightTree(t, beadsDir)
+
+			stdout, stderr, err := runPrestoreGuardCommand(t, bd, repoDir, test.args...)
+			if err != nil {
+				t.Fatalf("bd %s failed against incompatible store metadata: %v\nstdout:\n%s\nstderr:\n%s", strings.Join(test.args, " "), err, stdout, stderr)
+			}
+			if strings.TrimSpace(stdout) == "" {
+				t.Errorf("bd %s succeeded without its expected command output", strings.Join(test.args, " "))
+			}
+
+			after := hashBackendPreflightTree(t, beadsDir)
+			if before != after {
+				t.Errorf("bd %s changed the incompatible workspace: before=%x after=%x", strings.Join(test.args, " "), before, after)
+			}
+		})
+	}
+}
+
+func TestCanonicalSQLiteMetadataPassesCompatibilityGuard(t *testing.T) {
+	bd := buildBDUnderTest(t)
+	repoDir := newPrestoreGuardRepo(t)
+
+	stdout, stderr, err := runPrestoreGuardCommand(t, bd, repoDir,
+		"init", "--quiet", "--non-interactive", "--prefix", "current",
+		"--backend", "sqlite", "--skip-hooks", "--skip-agents")
+	if err != nil {
+		t.Fatalf("initialize canonical SQLite workspace: %v\nstdout:\n%s\nstderr:\n%s", err, stdout, stderr)
+	}
+
+	stdout, stderr, err = runPrestoreGuardCommand(t, bd, repoDir, "list", "--json", "--limit", "0", "--all")
+	if err != nil {
+		t.Fatalf("list canonical SQLite workspace: %v\nstdout:\n%s\nstderr:\n%s", err, stdout, stderr)
+	}
+	var issues []json.RawMessage
+	if err := json.Unmarshal([]byte(stdout), &issues); err != nil {
+		t.Fatalf("parse list JSON from canonical SQLite workspace: %v\nstdout:\n%s\nstderr:\n%s", err, stdout, stderr)
+	}
+	if len(issues) != 0 {
+		t.Fatalf("new canonical SQLite workspace returned %d issues, want none", len(issues))
+	}
+}
+
+func TestCanonicalSQLiteMetadataThroughSymlinkPassesCompatibilityGuard(t *testing.T) {
+	bd := buildBDUnderTest(t)
+	repoDir := newPrestoreGuardRepo(t)
+
+	stdout, stderr, err := runPrestoreGuardCommand(t, bd, repoDir,
+		"init", "--quiet", "--non-interactive", "--prefix", "current-link",
+		"--backend", "sqlite", "--skip-hooks", "--skip-agents")
+	if err != nil {
+		t.Fatalf("initialize canonical SQLite workspace: %v\nstdout:\n%s\nstderr:\n%s", err, stdout, stderr)
+	}
+
+	beadsLink := filepath.Join(repoDir, ".beads")
+	targetBeadsDir := filepath.Join(t.TempDir(), "beads-data")
+	if err := os.Rename(beadsLink, targetBeadsDir); err != nil {
+		t.Fatalf("move candidate-created beads directory to symlink target: %v", err)
+	}
+	if err := os.Symlink(targetBeadsDir, beadsLink); err != nil {
+		t.Skipf("symlinked .beads directories are unavailable: %v", err)
+	}
+	linkInfo, err := os.Lstat(beadsLink)
+	if err != nil || linkInfo.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("repo .beads is not the expected symlink: info=%v err=%v", linkInfo, err)
+	}
+	resolvedLink, err := filepath.EvalSymlinks(beadsLink)
+	if err != nil {
+		t.Fatalf("resolve repo .beads symlink: %v", err)
+	}
+	resolvedTarget, err := filepath.EvalSymlinks(targetBeadsDir)
+	if err != nil {
+		t.Fatalf("resolve target beads directory: %v", err)
+	}
+	if resolvedLink != resolvedTarget {
+		t.Fatalf("repo .beads resolves to %q, want %q", resolvedLink, resolvedTarget)
+	}
+
+	metadataPath := filepath.Join(targetBeadsDir, "metadata.json")
+	metadataBefore, err := os.ReadFile(metadataPath)
+	if err != nil {
+		t.Fatalf("read canonical metadata before list: %v", err)
+	}
+	stdout, stderr, err = runPrestoreGuardCommand(t, bd, repoDir, "list", "--json", "--limit", "0", "--all")
+	if err != nil {
+		t.Fatalf("list canonical SQLite workspace through .beads symlink: %v\nstdout:\n%s\nstderr:\n%s", err, stdout, stderr)
+	}
+	var issues []json.RawMessage
+	if err := json.Unmarshal([]byte(stdout), &issues); err != nil {
+		t.Fatalf("parse list JSON from symlinked SQLite workspace: %v\nstdout:\n%s\nstderr:\n%s", err, stdout, stderr)
+	}
+	if len(issues) != 0 {
+		t.Fatalf("new symlinked SQLite workspace returned %d issues, want none", len(issues))
+	}
+	metadataAfter, err := os.ReadFile(metadataPath)
+	if err != nil {
+		t.Fatalf("read canonical metadata after list: %v", err)
+	}
+	if !bytes.Equal(metadataBefore, metadataAfter) {
+		t.Error("list changed canonical metadata through the .beads symlink")
+	}
+
+	if target, err := os.Readlink(beadsLink); err != nil || target != targetBeadsDir {
+		t.Errorf("repo .beads symlink changed: target=%q err=%v, want %q", target, err, targetBeadsDir)
+	}
+}
+
+func newV0554MetadataWorkspace(t *testing.T) (repoDir, beadsDir string) {
+	t.Helper()
+	repoDir = newPrestoreGuardRepo(t)
+
+	beadsDir = filepath.Join(repoDir, ".beads")
+	// v0.55.4 persisted jsonl_export even when it held the default filename.
+	// The current strict metadata reader deliberately no longer accepts that
+	// field, so a store-backed command must refuse before running any upgrade
+	// tracking, migration, or store-open path.
+	writeFile(t, filepath.Join(beadsDir, "metadata.json"), []byte(`{
+  "database": "dolt",
+  "jsonl_export": "issues.jsonl",
+  "backend": "dolt",
+  "dolt_database": "beads_smoke"
+}`))
+	writeFile(t, filepath.Join(beadsDir, ".local_version"), []byte("0.55.4\n"))
+	writeFile(t, filepath.Join(beadsDir, "dolt", "source-marker"), []byte("legacy source\n"))
+	if err := os.Chmod(beadsDir, 0o700); err != nil {
+		t.Fatalf("chmod legacy beads directory: %v", err)
+	}
+	return repoDir, beadsDir
+}
+
+func newPrestoreGuardRepo(t *testing.T) string {
+	t.Helper()
+	repoDir := t.TempDir()
+	initGitRepo(t, repoDir)
+	runGitForBootstrapTest(t, repoDir, "config", "core.hooksPath", ".git/hooks")
+	runGitForBootstrapTest(t, repoDir, "config", "beads.role", "maintainer")
+	return repoDir
+}
+
+func runPrestoreGuardCommand(t *testing.T, bd, repoDir string, args ...string) (stdout, stderr string, err error) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bd, args...)
+	cmd.Dir = repoDir
+	cmd.Env = sanitizedPrestoreGuardEnv(t)
+	var stdoutBuffer, stderrBuffer bytes.Buffer
+	cmd.Stdout = &stdoutBuffer
+	cmd.Stderr = &stderrBuffer
+	err = cmd.Run()
+	return stdoutBuffer.String(), stderrBuffer.String(), err
+}
+
+func sanitizedPrestoreGuardEnv(t *testing.T) []string {
+	t.Helper()
+	home := t.TempDir()
+	env := make([]string, 0, len(os.Environ())+8)
+	for _, entry := range os.Environ() {
+		name, _, _ := strings.Cut(entry, "=")
+		if strings.HasPrefix(name, "BEADS_") || strings.HasPrefix(name, "BD_") {
+			continue
+		}
+		switch name {
+		case "HOME", "USERPROFILE", "XDG_CONFIG_HOME", "GIT_CONFIG_GLOBAL", "GIT_CONFIG_NOSYSTEM":
+			continue
+		}
+		env = append(env, entry)
+	}
+	return append(env,
+		"HOME="+home,
+		"USERPROFILE="+home,
+		"XDG_CONFIG_HOME="+filepath.Join(home, "xdg-config"),
+		"GIT_CONFIG_GLOBAL="+filepath.Join(home, "gitconfig"),
+		"GIT_CONFIG_NOSYSTEM=1",
+		"BEADS_DOLT_AUTO_START=0",
+		"BEADS_NO_DAEMON=1",
+		"BD_DISABLE_METRICS=1",
+		"BD_DISABLE_EVENT_FLUSH=1",
+	)
+}

--- a/cmd/bd/store_reopen.go
+++ b/cmd/bd/store_reopen.go
@@ -89,7 +89,12 @@ func resolveBeadsDirForDBPath(dbPath string) string {
 	}
 
 	for _, beadsDir := range candidates {
-		cfg, err := configfile.Load(beadsDir)
+		// Discovery-only: resolveCommandBeadsDir runs before
+		// guardWorkspaceMetadata, so mapping a db path back to its .beads dir must
+		// not migrate a legacy config.json as a side effect. LoadForDiscovery is
+		// lenient (so incompatible candidates still match by database path and are
+		// refused by the guard) but never writes.
+		cfg, err := configfile.LoadForDiscovery(beadsDir)
 		if err != nil || cfg == nil {
 			continue
 		}

--- a/internal/beads/beads.go
+++ b/internal/beads/beads.go
@@ -804,8 +804,13 @@ func findLocalBeadsDir() string {
 // directory (where the embedded engine stores data) and the legacy dolt/ path.
 // Returns empty string if no database is found.
 func findDatabaseInBeadsDir(beadsDir string, _ bool) string {
-	// Check for metadata.json first (single source of truth)
-	if cfg, err := configfile.Load(beadsDir); err == nil && cfg != nil {
+	// Check for metadata.json first (single source of truth). Use the discovery
+	// loader: database discovery runs before the CLI's pre-store incompatibility
+	// guard, so it must never migrate a legacy config.json or otherwise mutate
+	// the workspace as a side effect. It stays lenient so an incompatible
+	// workspace still resolves to its database path and is refused by the guard,
+	// not by a misleading "no beads database found".
+	if cfg, err := configfile.LoadForDiscovery(beadsDir); err == nil && cfg != nil {
 		// For Dolt server mode, database is on the server - no local directory required
 		if cfg.IsDoltServerMode() {
 			return cfg.DatabasePath(beadsDir)

--- a/internal/configfile/configfile.go
+++ b/internal/configfile/configfile.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -241,6 +242,21 @@ func Load(beadsDir string) (*Config, error) {
 	return cfg, nil
 }
 
+// LoadForDiscovery decodes current or legacy workspace metadata for the path
+// discovery and storage-mode probes that run BEFORE the pre-store
+// incompatibility guard (cmd/bd's guardWorkspaceMetadata) and before bd doctor's
+// own metadata check. Like Load it decodes leniently, so a forward-incompatible
+// workspace still resolves to a database path and is refused by the strict guard
+// with a precise message instead of a misleading "no beads database found".
+// Unlike Load it NEVER migrates a legacy config.json or writes anything:
+// discovery must not mutate a workspace before the guard has decided whether it
+// is safe to open. Compatibility migration still happens later, at store-open
+// time, through Load.
+func LoadForDiscovery(beadsDir string) (*Config, error) {
+	cfg, _, err := loadConfig(beadsDir, os.ReadFile, decodeConfigCompatible, isCompatibleConfigAbsent)
+	return cfg, err
+}
+
 func decodeConfigCompatible(data []byte, cfg *Config) error {
 	return json.Unmarshal(data, cfg)
 }
@@ -251,6 +267,19 @@ func isCompatibleConfigAbsent(err error) bool {
 
 func isStrictConfigAbsent(err error) bool {
 	return errors.Is(err, errStrictConfigAbsent)
+}
+
+// retiredConfigFields are metadata.json keys this lineage persisted under an
+// older bd version and has since removed from Config (dolt_proxied_server_* were
+// removed in 5a7cc3e1a). The strict metadata guard tolerates them as ignorable,
+// matching the lenient store-open loader, so deleting a Config field never
+// silently locks out an existing same-lineage workspace. Only add genuinely
+// retired same-lineage keys here — never a typo or a field a newer bd
+// introduced, or the guard would stop refusing forward-incompatible workspaces.
+var retiredConfigFields = map[string]struct{}{
+	"dolt_proxied_server_config":    {},
+	"dolt_proxied_server_log":       {},
+	"dolt_proxied_server_root_path": {},
 }
 
 func decodeConfigStrict(data []byte, cfg *Config) error {
@@ -292,7 +321,18 @@ func decodeConfigStrict(data []byte, cfg *Config) error {
 		}
 		seen[folded] = key
 		if _, ok := allowed[key]; !ok {
-			return fmt.Errorf("unknown or noncanonical metadata field %q", key)
+			if _, retired := retiredConfigFields[key]; !retired {
+				return fmt.Errorf("unknown or noncanonical metadata field %q", key)
+			}
+			// A field this lineage persisted under an older bd version and has
+			// since removed from Config. The lenient store-open loader has always
+			// ignored such keys, so tolerate them here too instead of locking out
+			// an otherwise-openable same-lineage workspace. Consume and skip the
+			// value; genuinely foreign or newer fields are still rejected above.
+			if err := decoder.Decode(new(json.RawMessage)); err != nil {
+				return err
+			}
+			continue
 		}
 		var raw json.RawMessage
 		if err := decoder.Decode(&raw); err != nil {
@@ -337,9 +377,77 @@ func decodeConfigStrict(data []byte, cfg *Config) error {
 		return errors.New("metadata must contain exactly one JSON object")
 	}
 
-	decoder = json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	return decoder.Decode(cfg)
+	// The loop above is the authoritative field gate: it rejects unknown,
+	// duplicate, case-variant, and null fields, tolerating only known-retired
+	// keys. Bind the recognized fields with a plain decode so those tolerated
+	// retired keys are ignored (exactly as the lenient loader ignores them)
+	// instead of re-tripping DisallowUnknownFields. Config is a flat struct, so
+	// there are no nested objects a DisallowUnknownFields pass would have guarded.
+	return json.Unmarshal(data, cfg)
+}
+
+// IsConcurrentMetadataChange reports whether err was caused by metadata.json
+// changing identity mid-read — an atomic temp-then-rename Save racing the read —
+// rather than by incompatible or malformed metadata. Such an error is transient
+// and safe to retry; callers must not report it as workspace incompatibility.
+func IsConcurrentMetadataChange(err error) bool {
+	return errors.Is(err, errConfigChanged)
+}
+
+// RetiredMetadataFields returns the keys present in beadsDir's metadata.json
+// that this bd version has retired from Config, sorted. It reads leniently and
+// never mutates the workspace; an absent or undecodable file yields no names.
+// Callers use it to detect obsolete cruft that RemoveRetiredMetadataFields strips.
+func RetiredMetadataFields(beadsDir string) []string {
+	names, _ := retiredFieldsInFile(ConfigPath(beadsDir))
+	return names
+}
+
+// RemoveRetiredMetadataFields rewrites metadata.json in beadsDir to drop any
+// keys this bd version has retired from Config, preserving every other key —
+// including genuinely-unknown ones, so a workspace written by a newer bd stays
+// refused by the strict guard. It never opens the store. It returns the names
+// removed (nil when there were none) so callers can report the cleanup.
+func RemoveRetiredMetadataFields(beadsDir string) ([]string, error) {
+	configPath := ConfigPath(beadsDir)
+	names, fields := retiredFieldsInFile(configPath)
+	if len(names) == 0 {
+		return nil, nil
+	}
+	for _, name := range names {
+		delete(fields, name)
+	}
+	data, err := json.MarshalIndent(fields, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("marshaling metadata: %w", err)
+	}
+	if err := writeFileAtomic(configPath, data, 0o600); err != nil {
+		return nil, fmt.Errorf("writing metadata: %w", err)
+	}
+	return names, nil
+}
+
+// retiredFieldsInFile reads path as a JSON object and returns the retired keys
+// present (sorted) alongside the full decoded field map. It uses the same
+// bounded, no-follow reader as the strict guard, so an absent, symlinked, or
+// undecodable file yields no names and a nil map (a safe no-op for cleanup).
+func retiredFieldsInFile(path string) ([]string, map[string]json.RawMessage) {
+	data, err := readStableConfigFile(path)
+	if err != nil {
+		return nil, nil
+	}
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(data, &fields); err != nil {
+		return nil, nil
+	}
+	var names []string
+	for key := range fields {
+		if _, retired := retiredConfigFields[key]; retired {
+			names = append(names, key)
+		}
+	}
+	sort.Strings(names)
+	return names, fields
 }
 
 func validateReadOnlyConfigRoot(beadsDir string) (bool, error) {

--- a/internal/configfile/load_for_discovery_test.go
+++ b/internal/configfile/load_for_discovery_test.go
@@ -1,0 +1,112 @@
+package configfile
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// LoadForDiscovery backs the pre-store path/mode probes. It must behave like
+// Load (lenient decode) EXCEPT that it never migrates a legacy config.json or
+// writes anything, so discovery cannot mutate a workspace before the pre-store
+// guard has decided whether it is safe to open.
+
+func TestLoadForDiscoveryDoesNotMigrateLegacyConfig(t *testing.T) {
+	beadsDir := t.TempDir()
+	legacyPath := filepath.Join(beadsDir, "config.json")
+	legacyBytes := []byte("{\n  \"database\": \"dolt\",\n  \"backend\": \"dolt\"\n}\n")
+	if err := os.WriteFile(legacyPath, legacyBytes, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadForDiscovery(beadsDir)
+	if err != nil {
+		t.Fatalf("LoadForDiscovery: %v", err)
+	}
+	if cfg == nil || cfg.GetBackend() != BackendDolt {
+		t.Fatalf("loaded config = %#v, want legacy Dolt", cfg)
+	}
+	if _, err := os.Stat(ConfigPath(beadsDir)); !os.IsNotExist(err) {
+		t.Fatalf("LoadForDiscovery created metadata.json (migrated the legacy config): %v", err)
+	}
+	after, err := os.ReadFile(legacyPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(after, legacyBytes) {
+		t.Fatalf("LoadForDiscovery changed legacy config bytes: got %q want %q", after, legacyBytes)
+	}
+}
+
+func TestLoadForDiscoveryToleratesForwardIncompatibleField(t *testing.T) {
+	// A forward-incompatible field must NOT make discovery error: if it did, a
+	// server-mode or SQL workspace (no local dolt directory) would resolve to no
+	// database path and the command would report a misleading "no beads database
+	// found" instead of the guard's precise incompatibility message. Discovery
+	// stays lenient; the strict guard is what refuses the workspace.
+	beadsDir := t.TempDir()
+	metadata := []byte(`{"database":"dolt","backend":"dolt","jsonl_export":"issues.jsonl"}`)
+	if err := os.WriteFile(ConfigPath(beadsDir), metadata, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadForDiscovery(beadsDir)
+	if err != nil {
+		t.Fatalf("LoadForDiscovery rejected a forward-incompatible field: %v", err)
+	}
+	if cfg == nil || cfg.GetBackend() != BackendDolt {
+		t.Fatalf("loaded config = %#v, want Dolt backend with the unknown field ignored", cfg)
+	}
+}
+
+func TestLoadForDiscoveryDoesNotMigrateForwardIncompatibleLegacyConfig(t *testing.T) {
+	// The exact bug this fixes: a legacy config.json carrying a forward-
+	// incompatible field must not be silently migrated (field-stripped) during
+	// discovery. LoadForDiscovery reads it leniently but leaves it on disk so the
+	// strict guard refuses the workspace instead of a lenient probe mutating it.
+	beadsDir := t.TempDir()
+	legacyPath := filepath.Join(beadsDir, "config.json")
+	legacyBytes := []byte(`{"database":"dolt","backend":"dolt","jsonl_export":"issues.jsonl"}`)
+	if err := os.WriteFile(legacyPath, legacyBytes, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := LoadForDiscovery(beadsDir); err != nil {
+		t.Fatalf("LoadForDiscovery: %v", err)
+	}
+	if _, err := os.Stat(ConfigPath(beadsDir)); !os.IsNotExist(err) {
+		t.Fatalf("LoadForDiscovery migrated an incompatible legacy config to metadata.json: %v", err)
+	}
+	after, err := os.ReadFile(legacyPath)
+	if err != nil {
+		t.Fatalf("legacy config.json was removed by discovery: %v", err)
+	}
+	if !bytes.Equal(after, legacyBytes) {
+		t.Fatalf("LoadForDiscovery changed legacy config bytes: got %q want %q", after, legacyBytes)
+	}
+}
+
+func TestLoadForDiscoveryAbsentMetadataIsNil(t *testing.T) {
+	beadsDir := t.TempDir()
+	cfg, err := LoadForDiscovery(beadsDir)
+	if err != nil {
+		t.Fatalf("LoadForDiscovery for absent metadata: %v", err)
+	}
+	if cfg != nil {
+		t.Fatalf("LoadForDiscovery for absent metadata = %#v, want nil", cfg)
+	}
+}
+
+func TestLoadForDiscoveryReturnsErrorForMalformedMetadata(t *testing.T) {
+	// A present-but-unparseable metadata.json must still be a hard error so the
+	// storage-mode probe (loadServerModeFromBeadsDir) refuses rather than falling
+	// back to the embedded store.
+	beadsDir := t.TempDir()
+	if err := os.WriteFile(ConfigPath(beadsDir), []byte(`{"dolt_mode":"serv`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if cfg, err := LoadForDiscovery(beadsDir); err == nil || cfg != nil {
+		t.Fatalf("LoadForDiscovery accepted malformed metadata: cfg=%#v err=%v", cfg, err)
+	}
+}

--- a/internal/configfile/retired_fields_test.go
+++ b/internal/configfile/retired_fields_test.go
@@ -1,0 +1,157 @@
+package configfile
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"testing"
+)
+
+func TestParseReadOnlyMetadataToleratesRetiredSameLineageField(t *testing.T) {
+	// dolt_proxied_server_* were persisted by this lineage and removed from
+	// Config in 5a7cc3e1a. The strict guard must ignore them, matching the
+	// lenient store-open loader, rather than lock out an otherwise-openable
+	// same-lineage workspace.
+	data := []byte(`{
+  "database": "dolt",
+  "backend": "dolt",
+  "dolt_proxied_server_config": "proxied-config.yaml",
+  "dolt_proxied_server_log": "proxied.log",
+  "dolt_proxied_server_root_path": "proxieddb"
+}`)
+	cfg, err := ParseReadOnlyMetadata(data)
+	if err != nil {
+		t.Fatalf("ParseReadOnlyMetadata rejected retired same-lineage fields: %v", err)
+	}
+	if cfg == nil || cfg.GetBackend() != BackendDolt {
+		t.Fatalf("decoded config = %#v, want Dolt backend", cfg)
+	}
+}
+
+func TestParseReadOnlyMetadataStillRejectsForeignField(t *testing.T) {
+	// A field this lineage never had (a newer/foreign workspace marker) must
+	// still be refused so forward-incompatibility protection is preserved.
+	data := []byte(`{"database":"dolt","backend":"dolt","jsonl_export":"issues.jsonl"}`)
+	if cfg, err := ParseReadOnlyMetadata(data); err == nil || cfg != nil {
+		t.Fatalf("ParseReadOnlyMetadata accepted a foreign field: cfg=%#v err=%v", cfg, err)
+	}
+}
+
+func TestParseReadOnlyMetadataRejectsNoncanonicalRetiredCase(t *testing.T) {
+	// Only the exact canonical retired key is tolerated; a case-variant is still
+	// noncanonical and must be rejected.
+	data := []byte(`{"database":"dolt","Dolt_Proxied_Server_Config":"x"}`)
+	if cfg, err := ParseReadOnlyMetadata(data); err == nil || cfg != nil {
+		t.Fatalf("ParseReadOnlyMetadata accepted a noncanonical retired key: cfg=%#v err=%v", cfg, err)
+	}
+}
+
+func TestRetiredMetadataFieldsReportsPresentRetired(t *testing.T) {
+	beadsDir := t.TempDir()
+	writeMetadataForRetiredTest(t, beadsDir, `{
+  "database": "dolt",
+  "backend": "dolt",
+  "dolt_proxied_server_log": "proxied.log",
+  "dolt_proxied_server_config": "proxied-config.yaml"
+}`)
+	got := RetiredMetadataFields(beadsDir)
+	want := []string{"dolt_proxied_server_config", "dolt_proxied_server_log"}
+	if len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+		t.Fatalf("RetiredMetadataFields = %v, want %v (sorted)", got, want)
+	}
+}
+
+func TestRemoveRetiredMetadataFieldsStripsOnlyRetired(t *testing.T) {
+	beadsDir := t.TempDir()
+	// A retired key plus a genuinely-foreign key. Only the retired key must go;
+	// the foreign key must survive so the strict guard still refuses this
+	// forward-incompatible workspace.
+	writeMetadataForRetiredTest(t, beadsDir, `{
+  "database": "dolt",
+  "backend": "dolt",
+  "dolt_proxied_server_config": "proxied-config.yaml",
+  "jsonl_export": "issues.jsonl"
+}`)
+
+	removed, err := RemoveRetiredMetadataFields(beadsDir)
+	if err != nil {
+		t.Fatalf("RemoveRetiredMetadataFields: %v", err)
+	}
+	if len(removed) != 1 || removed[0] != "dolt_proxied_server_config" {
+		t.Fatalf("removed = %v, want [dolt_proxied_server_config]", removed)
+	}
+
+	fields := decodeMetadataFields(t, beadsDir)
+	if _, ok := fields["dolt_proxied_server_config"]; ok {
+		t.Error("retired key survived RemoveRetiredMetadataFields")
+	}
+	if _, ok := fields["jsonl_export"]; !ok {
+		t.Error("foreign key was dropped; forward-incompat protection weakened")
+	}
+	if _, ok := fields["database"]; !ok {
+		t.Error("recognized key was dropped")
+	}
+
+	// Idempotent: a second run finds nothing to remove.
+	again, err := RemoveRetiredMetadataFields(beadsDir)
+	if err != nil {
+		t.Fatalf("second RemoveRetiredMetadataFields: %v", err)
+	}
+	if len(again) != 0 {
+		t.Fatalf("second run removed %v, want none", again)
+	}
+}
+
+func TestRemoveRetiredMetadataFieldsNoopWithoutRetired(t *testing.T) {
+	beadsDir := t.TempDir()
+	original := `{"database":"dolt","backend":"dolt"}`
+	writeMetadataForRetiredTest(t, beadsDir, original)
+
+	removed, err := RemoveRetiredMetadataFields(beadsDir)
+	if err != nil {
+		t.Fatalf("RemoveRetiredMetadataFields: %v", err)
+	}
+	if len(removed) != 0 {
+		t.Fatalf("removed %v from clean metadata, want none", removed)
+	}
+	// A no-op must not rewrite the file.
+	after, err := os.ReadFile(ConfigPath(beadsDir))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(after) != original {
+		t.Fatalf("clean metadata was rewritten: got %q want %q", after, original)
+	}
+}
+
+func TestIsConcurrentMetadataChange(t *testing.T) {
+	if !IsConcurrentMetadataChange(configChangedError("opening config", "metadata.json")) {
+		t.Error("IsConcurrentMetadataChange did not classify errConfigChanged")
+	}
+	if IsConcurrentMetadataChange(errors.New(`unknown or noncanonical metadata field "x"`)) {
+		t.Error("IsConcurrentMetadataChange misclassified an incompatibility error")
+	}
+	if IsConcurrentMetadataChange(nil) {
+		t.Error("IsConcurrentMetadataChange classified nil")
+	}
+}
+
+func writeMetadataForRetiredTest(t *testing.T, beadsDir, body string) {
+	t.Helper()
+	if err := os.WriteFile(ConfigPath(beadsDir), []byte(body), 0o600); err != nil {
+		t.Fatalf("write metadata.json: %v", err)
+	}
+}
+
+func decodeMetadataFields(t *testing.T, beadsDir string) map[string]json.RawMessage {
+	t.Helper()
+	raw, err := os.ReadFile(ConfigPath(beadsDir))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &fields); err != nil {
+		t.Fatalf("decode metadata.json: %v", err)
+	}
+	return fields
+}

--- a/scripts/migration-test/lib/binary.sh
+++ b/scripts/migration-test/lib/binary.sh
@@ -17,6 +17,12 @@ esac
 download_binary() {
     local version="$1"
     local ver_bare="${version#v}"
+
+    if ${STRICT_MODE:-false}; then
+        download_verified_release_binary "$version"
+        return
+    fi
+
     local cached="$CACHE_DIR/bd-${ver_bare}"
 
     if [ -x "$cached" ]; then
@@ -60,6 +66,100 @@ download_binary() {
 
     # Fallback: build from source at the given tag
     build_from_source "$version" "$cached"
+}
+
+sha256_file() {
+    if command -v sha256sum >/dev/null 2>&1; then
+        sha256sum "$1" | awk '{print $1}'
+        return
+    fi
+    if command -v shasum >/dev/null 2>&1; then
+        shasum -a 256 "$1" | awk '{print $1}'
+        return
+    fi
+    echo "ERROR: no SHA-256 utility is available" >&2
+    return 1
+}
+
+verify_release_archive() {
+    local version="$1"
+    local archive="$2"
+    local expected actual
+    expected=$(strict_release_sha256 "$version" "$OS" "$ARCH") || {
+        echo "ERROR: no pinned release checksum for $version ($OS/$ARCH)" >&2
+        return 1
+    }
+    actual=$(sha256_file "$archive") || return 1
+    if [ "$actual" != "$expected" ]; then
+        echo "ERROR: checksum mismatch for $version: got $actual, want $expected" >&2
+        return 1
+    fi
+}
+
+verify_release_binary_version() {
+    local version="$1"
+    local binary="$2"
+    local bare="${version#v}"
+    local output
+    output=$("$binary" version 2>&1) || {
+        echo "ERROR: verified $version binary does not run" >&2
+        return 1
+    }
+    if [[ " $output " != *" $bare "* ]]; then
+        echo "ERROR: release binary reports unexpected version: $output" >&2
+        return 1
+    fi
+}
+
+download_verified_release_binary() {
+    local version="$1"
+    local asset expected release_dir archive binary
+    asset=$(strict_release_asset "$version" "$OS" "$ARCH") || {
+        echo "ERROR: no strict release manifest for $version ($OS/$ARCH)" >&2
+        return 1
+    }
+    expected=$(strict_release_sha256 "$version" "$OS" "$ARCH") || return 1
+    release_dir="$CACHE_DIR/verified/${version}-${OS}-${ARCH}-${expected}"
+    archive="$release_dir/$asset"
+    binary="$release_dir/bd"
+    mkdir -p "$release_dir"
+
+    if [ ! -f "$archive" ]; then
+        local url tmp
+        url="https://github.com/gastownhall/beads/releases/download/${version}/${asset}"
+        tmp="$archive.tmp.$$"
+        echo -e "  ${YELLOW:-}downloading verified ${version}...${NC:-}" >&2
+        if ! curl -fsSL --max-time "$DOWNLOAD_TIMEOUT" "$url" -o "$tmp"; then
+            rm -f "$tmp"
+            echo "ERROR: could not download pinned release asset for $version" >&2
+            return 1
+        fi
+        if ! verify_release_archive "$version" "$tmp"; then
+            rm -f "$tmp"
+            return 1
+        fi
+        mv -f "$tmp" "$archive"
+    fi
+    verify_release_archive "$version" "$archive" || return 1
+
+    local extract_dir extracted
+    extract_dir=$(mktemp -d)
+    if ! tar -xzf "$archive" -C "$extract_dir"; then
+        rm -rf "$extract_dir"
+        echo "ERROR: could not extract pinned release asset for $version" >&2
+        return 1
+    fi
+    extracted=$(find "$extract_dir" -name bd -type f | head -1)
+    if [ -z "$extracted" ]; then
+        rm -rf "$extract_dir"
+        echo "ERROR: pinned release asset for $version contains no bd binary" >&2
+        return 1
+    fi
+    cp -f "$extracted" "$binary"
+    chmod +x "$binary"
+    rm -rf "$extract_dir"
+    verify_release_binary_version "$version" "$binary" || return 1
+    printf '%s\n' "$binary"
 }
 
 # Build a specific version from source by checking out its tag in a temp dir.

--- a/scripts/migration-test/lib/direct_probe.sh
+++ b/scripts/migration-test/lib/direct_probe.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+# Candidate direct-upgrade probe helpers.
+
+candidate_list_has_nonempty_issue_ids() {
+    local ws="$1"
+    local bin="$2"
+    local output
+
+    if ! output=$(bd_in "$ws" "$bin" list --json -n 0 --all 2>/dev/null); then
+        return 1
+    fi
+
+    jq -e -s '
+        length == 1 and
+        (.[0] |
+            type == "array" and
+            length > 0 and
+            all(.[];
+                type == "object" and
+                ((.id? | type) == "string") and
+                ((.id? | length) > 0)))
+    ' >/dev/null 2>&1 <<< "$output"
+}
+
+DIRECT_PROBE_FAILURE_DETAIL=""
+
+candidate_probe_source_is_unchanged() {
+    local ws="$1"
+    local expected_fingerprint="$2"
+    local stage="$3"
+    local actual_fingerprint
+
+    stop_dolt_server "$ws"
+    if ! actual_fingerprint=$(source_artifact_fingerprint "$ws/.beads"); then
+        DIRECT_PROBE_FAILURE_DETAIL="could not fingerprint historical source tree after candidate $stage"
+        return 1
+    fi
+    if [ "$actual_fingerprint" != "$expected_fingerprint" ]; then
+        DIRECT_PROBE_FAILURE_DETAIL="candidate $stage mutated the historical source tree"
+        return 1
+    fi
+}
+
+probe_candidate_direct_upgrade() {
+    local ws="$1"
+    local bin="$2"
+    local expected_fingerprint="${3:-}"
+    local strict="${4:-false}"
+
+    DIRECT_PROBE_FAILURE_DETAIL=""
+    if $strict && [ -z "$expected_fingerprint" ]; then
+        DIRECT_PROBE_FAILURE_DETAIL="strict candidate probe has no historical source fingerprint"
+        return 2
+    fi
+
+    if candidate_list_has_nonempty_issue_ids "$ws" "$bin"; then
+        return 0
+    fi
+    if $strict && ! candidate_probe_source_is_unchanged \
+        "$ws" "$expected_fingerprint" "list probe"; then
+        return 2
+    fi
+
+    if ! bd_in "$ws" "$bin" init --quiet --non-interactive --prefix smoke \
+        </dev/null >/dev/null 2>&1; then
+        if $strict && ! candidate_probe_source_is_unchanged \
+            "$ws" "$expected_fingerprint" "init probe"; then
+            return 2
+        fi
+        return 1
+    fi
+
+    if candidate_list_has_nonempty_issue_ids "$ws" "$bin"; then
+        return 0
+    fi
+    if $strict && ! candidate_probe_source_is_unchanged \
+        "$ws" "$expected_fingerprint" "post-init list probe"; then
+        return 2
+    fi
+    return 1
+}

--- a/scripts/migration-test/lib/features.sh
+++ b/scripts/migration-test/lib/features.sh
@@ -106,7 +106,15 @@ create_dataset() {
 
     # 5. Standalone task with description
     local standalone_id
-    standalone_id=$(bd_create "$ws" "$bin" --title "Standalone detailed task" --type task --priority 2 --description "This task has a detailed description for fidelity testing.") || true
+    standalone_id=$(bd_create "$ws" "$bin" \
+        --title "Standalone detailed task" \
+        --type task \
+        --priority 2 \
+        --description "This task has a detailed description for fidelity testing." \
+        --notes "Historical notes must survive the upgrade." \
+        --design "Historical design must survive the upgrade." \
+        --acceptance "Historical acceptance criteria must survive the upgrade." \
+        --external-ref "legacy-upgrade-42") || true
     if [ -n "${standalone_id:-}" ]; then
         DATASET_IDS[standalone]="$standalone_id"
         DATASET_FEATURES+=("standalone")
@@ -116,9 +124,13 @@ create_dataset() {
     local closed_id
     closed_id=$(bd_create "$ws" "$bin" --title "Already closed issue" --type task --priority 3) || true
     if [ -n "${closed_id:-}" ]; then
-        bd_in "$ws" "$bin" close "$closed_id" >/dev/null 2>&1 || true
-        DATASET_IDS[closed]="$closed_id"
-        DATASET_FEATURES+=("closed")
+        if bd_in "$ws" "$bin" close "$closed_id" >/dev/null 2>&1; then
+            DATASET_IDS[closed]="$closed_id"
+            DATASET_FEATURES+=("closed")
+        else
+            echo "  ERROR: could not close source fixture issue" >&2
+            errors=$((errors + 1))
+        fi
     fi
 
     # --- Optional features (version-gated, empirical) ---
@@ -132,7 +144,9 @@ create_dataset() {
 
     # Comments
     if [ -n "${task_id:-}" ]; then
-        if bd_in "$ws" "$bin" comment add "$task_id" "Test comment for fidelity checking" >/dev/null 2>&1; then
+        if bd_in "$ws" "$bin" comments add "$task_id" \
+            "Historical comment must survive the upgrade." \
+            --author "legacy-author" >/dev/null 2>&1; then
             DATASET_FEATURES+=("comment")
         fi
     fi

--- a/scripts/migration-test/lib/report.sh
+++ b/scripts/migration-test/lib/report.sh
@@ -142,3 +142,36 @@ print_summary_line() {
     fi
     echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 }
+
+# strict_results_match enforces the single-path release-gate contract after a
+# run has populated the result arrays. Human output remains unchanged; strict
+# callers get a nonzero exit for every unqualified outcome.
+strict_results_match() {
+    local expected_status="$1"
+    local expected_recipe="$2"
+
+    if [ "${#RESULT_STATUSES[@]}" -ne 1 ]; then
+        echo "STRICT: expected exactly one result, got ${#RESULT_STATUSES[@]}" >&2
+        return 1
+    fi
+
+    local status="${RESULT_STATUSES[0]}"
+    local recipe="${RESULT_RECIPES[0]}"
+    local violations="${RESULT_VIOLATIONS[0]}"
+    if [ "$status" = "SKIP" ] || [ "$status" = "BLOCKED" ]; then
+        echo "STRICT: unqualified result status $status" >&2
+        return 1
+    fi
+    if ! [[ "$violations" =~ ^[0-9]+$ ]] || [ "$violations" -ne 0 ]; then
+        echo "STRICT: fidelity/blocker violations=$violations" >&2
+        return 1
+    fi
+    if [ "$status" != "$expected_status" ]; then
+        echo "STRICT: outcome drifted from $expected_status to $status" >&2
+        return 1
+    fi
+    if [ "$recipe" != "$expected_recipe" ]; then
+        echo "STRICT: recipe drifted from $expected_recipe to ${recipe:-none}" >&2
+        return 1
+    fi
+}

--- a/scripts/migration-test/lib/snapshot.sh
+++ b/scripts/migration-test/lib/snapshot.sh
@@ -207,6 +207,14 @@ classic_sqlite_artifact_manifest() {
 
     for relative in "${CLASSIC_SQLITE_ROLLBACK_FILES[@]}"; do
         path="$beads_dir/${relative}${suffix}"
+        # Reject symlinks with no-follow (lstat) semantics before the -e/-f tests,
+        # which follow links: a symlinked artifact can resolve outside the
+        # workspace, so checksumming its target would let a non-self-contained
+        # rollback copy pass strict verification. Mirrors legacy_dolt_artifact_manifest.
+        if [ -L "$path" ]; then
+            echo "  FIDELITY: rollback artifact is a symlink: $path" >&2
+            return 1
+        fi
         if [ -e "$path" ]; then
             if [ ! -f "$path" ]; then
                 echo "  FIDELITY: rollback artifact is not a regular file: $path" >&2

--- a/scripts/migration-test/lib/snapshot.sh
+++ b/scripts/migration-test/lib/snapshot.sh
@@ -14,7 +14,24 @@ capture_snapshot() {
 
     # bd list --json returns a flat array of issue objects
     local list_json
-    list_json=$(bd_in "$ws" "$bin" list --json -n 0 --all 2>/dev/null) || true
+    if ! list_json=$(bd_in "$ws" "$bin" list --json -n 0 --all 2>/dev/null); then
+        echo "  FIDELITY: bd list failed while capturing snapshot" >&2
+        echo "[]"
+        return 1
+    fi
+
+    if ${STRICT_MODE:-false} && ! jq -e '
+        type == "array" and
+        length > 0 and
+        all(.[];
+            type == "object" and
+            ((.id? | type) == "string") and
+            ((.id? | length) > 0))
+        ' >/dev/null 2>&1 <<< "$list_json"; then
+        echo "  FIDELITY: bd list returned an invalid snapshot inventory" >&2
+        echo "[]"
+        return 1
+    fi
 
     if [ -z "$list_json" ] || [ "$list_json" = "null" ] || [ "$list_json" = "[]" ]; then
         echo "[]"
@@ -39,15 +56,30 @@ capture_snapshot() {
         local show_json
         # Current binaries require --include-comments for full bodies; older
         # releases included them by default and reject the newer flag.
-        show_json=$(bd_in "$ws" "$bin" show "$id" --json --include-comments 2>/dev/null) || \
-            show_json=$(bd_in "$ws" "$bin" show "$id" --json 2>/dev/null) || true
+        local show_ok=false
+        if show_json=$(bd_in "$ws" "$bin" show "$id" --json --include-comments 2>/dev/null); then
+            show_ok=true
+        elif show_json=$(bd_in "$ws" "$bin" show "$id" --json 2>/dev/null); then
+            show_ok=true
+        fi
+        if ! $show_ok; then
+            echo "  FIDELITY: bd show failed for listed source id $id" >&2
+            return 1
+        fi
+        if ${STRICT_MODE:-false} && ! jq -e --arg id "$id" '
+            (if type == "array" then . else [.] end) |
+            length == 1 and
+            (.[0] | type == "object") and
+            ((.[0].id? | type) == "string") and
+            .[0].id == $id
+            ' >/dev/null 2>&1 <<< "$show_json"; then
+            echo "  FIDELITY: bd show returned an invalid snapshot for source id $id" >&2
+            return 1
+        fi
         if [ -n "$show_json" ] && [ "$show_json" != "null" ]; then
             # show returns an array — concatenate it
             items=$(echo "$items" | jq --argjson arr "$show_json" \
                 'if ($arr | type) == "array" then . + $arr else . + [$arr] end' 2>/dev/null) || true
-        elif ${STRICT_MODE:-false}; then
-            echo "  FIDELITY: bd show failed for listed source id $id" >&2
-            return 1
         fi
     done <<< "$ids"
 
@@ -71,6 +103,44 @@ capture_snapshot() {
     echo "$items" | jq -S 'sort_by(.title // "")' 2>/dev/null || echo "$items"
 }
 
+source_artifact_fingerprint() {
+    local beads_dir="$1"
+    local manifest_file digest
+
+    [ -d "$beads_dir" ] && [ ! -L "$beads_dir" ] || return 1
+    manifest_file=$(mktemp "${TMPDIR:-/tmp}/bd-source-fingerprint.XXXXXX") || return 1
+    if ! (
+        set -o pipefail
+        cd "$beads_dir" || exit 1
+        find . -mindepth 1 -print0 | LC_ALL=C sort -z | while IFS= read -r -d '' path; do
+            local mode checksum target
+            if [ -L "$path" ]; then
+                target=$(readlink -- "$path") || exit 1
+                printf 'link\0%s\0%s\0' "$path" "$target" || exit 1
+            elif [ -d "$path" ]; then
+                mode=$(stat -c '%a' -- "$path") || exit 1
+                printf 'directory\0%s\0%s\0' "$path" "$mode" || exit 1
+            elif [ -f "$path" ]; then
+                mode=$(stat -c '%a' -- "$path") || exit 1
+                checksum=$(sha256_file "$path") || exit 1
+                printf 'file\0%s\0%s\0%s\0' "$path" "$mode" "$checksum" || exit 1
+            else
+                echo "  FIDELITY: unsupported path in historical source tree: $beads_dir/$path" >&2
+                exit 1
+            fi
+        done
+    ) > "$manifest_file"; then
+        rm -f "$manifest_file"
+        return 1
+    fi
+    digest=$(sha256_file "$manifest_file") || {
+        rm -f "$manifest_file"
+        return 1
+    }
+    rm -f "$manifest_file"
+    printf '%s\n' "$digest"
+}
+
 # Validate the exact source values that make a strict historical fixture
 # meaningful. Without this check, an unsupported create flag can silently
 # disappear from both snapshots and produce a false fidelity pass.
@@ -79,18 +149,28 @@ strict_snapshot_has_expected_fixture() {
     local snapshot="$2"
 
     case "$version" in
-        v0.49.6)
+        v0.49.6|v0.55.4)
+            local epic_id="${DATASET_IDS[epic]:-}"
             local standalone_id="${DATASET_IDS[standalone]:-}"
             local closed_id="${DATASET_IDS[closed]:-}"
             local task_id="${DATASET_IDS[task]:-}"
             local bug_id="${DATASET_IDS[bug]:-}"
-            [ -n "$standalone_id" ] && [ -n "$closed_id" ] && \
+            [ -n "$epic_id" ] && [ -n "$standalone_id" ] && [ -n "$closed_id" ] && \
                 [ -n "$task_id" ] && [ -n "$bug_id" ] || return 1
             jq -e \
+                --arg epic "$epic_id" \
                 --arg standalone "$standalone_id" \
                 --arg closed "$closed_id" \
                 --arg task "$task_id" \
                 --arg bug "$bug_id" '
+                length == 5 and
+                any(.[];
+                    .id == $epic and
+                    .title == "Migration epic" and
+                    .description == "Epic for migration testing" and
+                    .priority == 2 and
+                    .issue_type == "epic" and
+                    .status == "open") and
                 any(.[];
                     .id == $standalone and
                     .title == "Standalone detailed task" and
@@ -150,6 +230,136 @@ verify_retained_sqlite_source() {
     actual_manifest=$(classic_sqlite_artifact_manifest "$beads_dir" ".pre-migration") || return 1
     if [ "$actual_manifest" != "$expected_manifest" ]; then
         echo "  FIDELITY: retained classic SQLite rollback artifacts changed" >&2
+        return 1
+    fi
+}
+
+legacy_dolt_artifact_manifest() {
+    local root="$1"
+    local dolt_dir="$root/dolt"
+    local manifest_file digest relative path mode checksum
+
+    if [ -L "$root" ] || [ ! -d "$root" ]; then
+        echo "  FIDELITY: legacy Dolt artifact root is not a regular directory: $root" >&2
+        return 1
+    fi
+    if [ -L "$dolt_dir" ] || [ ! -d "$dolt_dir" ]; then
+        echo "  FIDELITY: legacy Dolt source is not a regular directory: $dolt_dir" >&2
+        return 1
+    fi
+
+    manifest_file=$(mktemp "${TMPDIR:-/tmp}/bd-legacy-dolt-manifest.XXXXXX") || return 1
+    if ! (
+        set -o pipefail
+        cd "$root" || exit 1
+
+        if ! find dolt -mindepth 0 -print0 | sort -z | while IFS= read -r -d '' path; do
+            if [ -L "$path" ]; then
+                echo "  FIDELITY: symlink in legacy Dolt source: $root/$path" >&2
+                exit 1
+            elif [ -d "$path" ]; then
+                mode=$(stat -c '%a' -- "$path") || exit 1
+                printf 'directory\0%s\0%s\0' "$path" "$mode"
+            elif [ -f "$path" ]; then
+                mode=$(stat -c '%a' -- "$path") || exit 1
+                checksum=$(sha256_file "$path") || exit 1
+                printf 'file\0%s\0%s\0%s\0' "$path" "$mode" "$checksum"
+            else
+                echo "  FIDELITY: non-regular path in legacy Dolt source: $root/$path" >&2
+                exit 1
+            fi
+        done; then
+            exit 1
+        fi
+
+        for relative in "${LEGACY_DOLT_ROLLBACK_FILES[@]}"; do
+            path="$relative"
+            if [ -L "$path" ]; then
+                echo "  FIDELITY: symlink rollback artifact: $root/$path" >&2
+                exit 1
+            fi
+            if [ -e "$path" ]; then
+                if [ ! -f "$path" ]; then
+                    echo "  FIDELITY: rollback artifact is not a regular file: $root/$path" >&2
+                    exit 1
+                fi
+                mode=$(stat -c '%a' -- "$path") || exit 1
+                checksum=$(sha256_file "$path") || exit 1
+                printf 'file\0%s\0%s\0%s\0' "$path" "$mode" "$checksum"
+            fi
+        done
+    ) > "$manifest_file"; then
+        rm -f "$manifest_file"
+        return 1
+    fi
+
+    digest=$(sha256_file "$manifest_file") || {
+        rm -f "$manifest_file"
+        return 1
+    }
+    rm -f "$manifest_file"
+    printf '%s\n' "$digest"
+}
+
+verify_retained_legacy_dolt_source() {
+    local beads_dir="$1"
+    local expected_manifest="$2"
+    local retained="$beads_dir/legacy-dolt.pre-migration"
+
+    verify_legacy_dolt_rollback_root "$retained" "$expected_manifest"
+}
+
+legacy_dolt_rollback_inventory_is_exact() {
+    local root="$1"
+    local inventory_file name allowed relative invalid_name=""
+
+    if [ -L "$root" ] || [ ! -d "$root" ]; then
+        echo "  FIDELITY: retained legacy Dolt source is not a regular directory: $root" >&2
+        return 1
+    fi
+    inventory_file=$(mktemp "${TMPDIR:-/tmp}/bd-legacy-dolt-inventory.XXXXXX") || return 1
+    if ! find "$root" -mindepth 1 -maxdepth 1 -printf '%f\0' > "$inventory_file"; then
+        rm -f "$inventory_file"
+        return 1
+    fi
+
+    while IFS= read -r -d '' name; do
+        allowed=false
+        if [ "$name" = "dolt" ]; then
+            allowed=true
+        else
+            for relative in "${LEGACY_DOLT_ROLLBACK_FILES[@]}"; do
+                if [ "$name" = "$relative" ]; then
+                    allowed=true
+                    break
+                fi
+            done
+        fi
+        if ! $allowed; then
+            invalid_name="$name"
+            break
+        fi
+    done < "$inventory_file"
+    rm -f "$inventory_file"
+    if [ -n "$invalid_name" ]; then
+        echo "  FIDELITY: unexpected path in retained legacy Dolt source: $root/$invalid_name" >&2
+        return 1
+    fi
+}
+
+verify_legacy_dolt_rollback_root() {
+    local root="$1"
+    local expected_manifest="$2"
+    local actual_manifest
+
+    if [ -z "$expected_manifest" ]; then
+        echo "  FIDELITY: expected legacy Dolt rollback manifest is empty" >&2
+        return 1
+    fi
+    legacy_dolt_rollback_inventory_is_exact "$root" || return 1
+    actual_manifest=$(legacy_dolt_artifact_manifest "$root") || return 1
+    if [ "$actual_manifest" != "$expected_manifest" ]; then
+        echo "  FIDELITY: retained legacy Dolt rollback artifacts changed" >&2
         return 1
     fi
 }
@@ -348,16 +558,24 @@ check_blocker_paths() {
 
     # 1. bd blocked must list the dependent (bug) while the blocker (task) is
     #    still open — proves is_blocked survived migration on the dependent.
-    local blocked_json
-    blocked_json=$(bd_in "$ws" "$bin" blocked --json 2>/dev/null) || true
+    local blocked_json blocked_status=0
+    blocked_json=$(bd_in "$ws" "$bin" blocked --json 2>/dev/null) || blocked_status=$?
+    if [ "$blocked_status" -ne 0 ]; then
+        echo -e "  ${RED:-}BLOCKER-CHECK VIOLATION: 'bd blocked' exited $blocked_status${NC:-}"
+        violations=$((violations + 1))
+    fi
     if ! echo "$blocked_json" | jq -e --arg id "$dependent_id" 'any(.[]?; .id == $id)' >/dev/null 2>&1; then
         echo -e "  ${RED:-}BLOCKER-CHECK VIOLATION: 'bd blocked' does not list dependent '$dependent_id' while blocker '$blocker_id' is open${NC:-}"
         violations=$((violations + 1))
     fi
 
     # 2. bd ready must NOT list the dependent, but MUST list the blocker.
-    local ready_json
-    ready_json=$(bd_in "$ws" "$bin" ready --json 2>/dev/null) || true
+    local ready_json ready_status=0
+    ready_json=$(bd_in "$ws" "$bin" ready --json 2>/dev/null) || ready_status=$?
+    if [ "$ready_status" -ne 0 ]; then
+        echo -e "  ${RED:-}BLOCKER-CHECK VIOLATION: 'bd ready' exited $ready_status${NC:-}"
+        violations=$((violations + 1))
+    fi
     if echo "$ready_json" | jq -e --arg id "$dependent_id" 'any(.[]?; .id == $id)' >/dev/null 2>&1; then
         echo -e "  ${RED:-}BLOCKER-CHECK VIOLATION: 'bd ready' lists blocked dependent '$dependent_id'${NC:-}"
         violations=$((violations + 1))
@@ -373,8 +591,12 @@ check_blocker_paths() {
         echo -e "  ${RED:-}BLOCKER-CHECK VIOLATION: 'bd close $blocker_id' failed after migration (errno 1105 / stale-schema regression)${NC:-}"
         violations=$((violations + 1))
     else
-        local ready_after_json
-        ready_after_json=$(bd_in "$ws" "$bin" ready --json 2>/dev/null) || true
+        local ready_after_json ready_after_status=0
+        ready_after_json=$(bd_in "$ws" "$bin" ready --json 2>/dev/null) || ready_after_status=$?
+        if [ "$ready_after_status" -ne 0 ]; then
+            echo -e "  ${RED:-}BLOCKER-CHECK VIOLATION: post-close 'bd ready' exited $ready_after_status${NC:-}"
+            violations=$((violations + 1))
+        fi
         if ! echo "$ready_after_json" | jq -e --arg id "$dependent_id" 'any(.[]?; .id == $id)' >/dev/null 2>&1; then
             echo -e "  ${RED:-}BLOCKER-CHECK VIOLATION: dependent '$dependent_id' not ready after blocker '$blocker_id' closed${NC:-}"
             violations=$((violations + 1))

--- a/scripts/migration-test/lib/snapshot.sh
+++ b/scripts/migration-test/lib/snapshot.sh
@@ -37,16 +37,121 @@ capture_snapshot() {
     while IFS= read -r id; do
         [ -z "$id" ] && continue
         local show_json
-        show_json=$(bd_in "$ws" "$bin" show "$id" --json 2>/dev/null) || true
+        # Current binaries require --include-comments for full bodies; older
+        # releases included them by default and reject the newer flag.
+        show_json=$(bd_in "$ws" "$bin" show "$id" --json --include-comments 2>/dev/null) || \
+            show_json=$(bd_in "$ws" "$bin" show "$id" --json 2>/dev/null) || true
         if [ -n "$show_json" ] && [ "$show_json" != "null" ]; then
             # show returns an array — concatenate it
             items=$(echo "$items" | jq --argjson arr "$show_json" \
                 'if ($arr | type) == "array" then . + $arr else . + [$arr] end' 2>/dev/null) || true
+        elif ${STRICT_MODE:-false}; then
+            echo "  FIDELITY: bd show failed for listed source id $id" >&2
+            return 1
         fi
     done <<< "$ids"
 
+    if ${STRICT_MODE:-false}; then
+        local list_ids show_ids expected_id
+        list_ids=$(echo "$list_json" | jq -c '[.[].id // empty] | sort' 2>/dev/null) || return 1
+        show_ids=$(echo "$items" | jq -c '[.[].id // empty] | sort' 2>/dev/null) || return 1
+        if [ "$show_ids" != "$list_ids" ]; then
+            echo "  FIDELITY: list/show id inventories differ" >&2
+            return 1
+        fi
+        for expected_id in "${DATASET_IDS[@]:-}"; do
+            if ! echo "$items" | jq -e --arg id "$expected_id" 'any(.[]; .id == $id)' >/dev/null 2>&1; then
+                echo "  FIDELITY: required source id $expected_id is absent from snapshot" >&2
+                return 1
+            fi
+        done
+    fi
+
     # Sort by title for stable comparison
     echo "$items" | jq -S 'sort_by(.title // "")' 2>/dev/null || echo "$items"
+}
+
+# Validate the exact source values that make a strict historical fixture
+# meaningful. Without this check, an unsupported create flag can silently
+# disappear from both snapshots and produce a false fidelity pass.
+strict_snapshot_has_expected_fixture() {
+    local version="$1"
+    local snapshot="$2"
+
+    case "$version" in
+        v0.49.6)
+            local standalone_id="${DATASET_IDS[standalone]:-}"
+            local closed_id="${DATASET_IDS[closed]:-}"
+            local task_id="${DATASET_IDS[task]:-}"
+            local bug_id="${DATASET_IDS[bug]:-}"
+            [ -n "$standalone_id" ] && [ -n "$closed_id" ] && \
+                [ -n "$task_id" ] && [ -n "$bug_id" ] || return 1
+            jq -e \
+                --arg standalone "$standalone_id" \
+                --arg closed "$closed_id" \
+                --arg task "$task_id" \
+                --arg bug "$bug_id" '
+                any(.[];
+                    .id == $standalone and
+                    .title == "Standalone detailed task" and
+                    .description == "This task has a detailed description for fidelity testing." and
+                    .notes == "Historical notes must survive the upgrade." and
+                    .design == "Historical design must survive the upgrade." and
+                    .acceptance_criteria == "Historical acceptance criteria must survive the upgrade." and
+                    .external_ref == "legacy-upgrade-42") and
+                any(.[]; .id == $closed and .status == "closed") and
+                any(.[];
+                    .id == $task and
+                    ((.labels // []) | index("urgent") != null) and
+                    ((.comments // [] | map({author, text})) |
+                        index({"author":"legacy-author","text":"Historical comment must survive the upgrade."}) != null)) and
+                any(.[];
+                    .id == $bug and
+                    ((.dependencies // [] | map(.id // .)) | index($task) != null))
+                ' "$snapshot" >/dev/null 2>&1 || {
+                    echo "  FIDELITY: $version source fixture is missing exact required values" >&2
+                    return 1
+                }
+            ;;
+        *)
+            echo "  FIDELITY: no exact source-fixture contract for $version" >&2
+            return 1
+            ;;
+    esac
+}
+
+classic_sqlite_artifact_manifest() {
+    local beads_dir="$1"
+    local suffix="${2:-}"
+    local relative path checksum found_database=false
+
+    for relative in "${CLASSIC_SQLITE_ROLLBACK_FILES[@]}"; do
+        path="$beads_dir/${relative}${suffix}"
+        if [ -e "$path" ]; then
+            if [ ! -f "$path" ]; then
+                echo "  FIDELITY: rollback artifact is not a regular file: $path" >&2
+                return 1
+            fi
+            checksum=$(sha256_file "$path") || return 1
+            printf '%s=%s\n' "$relative" "$checksum"
+            [ "$relative" = "beads.db" ] && found_database=true
+        fi
+    done
+    $found_database || {
+        echo "  FIDELITY: classic SQLite database is missing" >&2
+        return 1
+    }
+}
+
+verify_retained_sqlite_source() {
+    local beads_dir="$1"
+    local expected_manifest="$2"
+    local actual_manifest
+    actual_manifest=$(classic_sqlite_artifact_manifest "$beads_dir" ".pre-migration") || return 1
+    if [ "$actual_manifest" != "$expected_manifest" ]; then
+        echo "  FIDELITY: retained classic SQLite rollback artifacts changed" >&2
+        return 1
+    fi
 }
 
 # Compare two snapshots and report fidelity.
@@ -76,10 +181,17 @@ check_fidelity() {
         echo -e "  ${RED:-}FIDELITY VIOLATION: item count dropped from $before_count to $after_count${NC:-}"
         violations=$(( before_count - after_count ))
     fi
+    if ${STRICT_MODE:-false} && [ "$after_count" -gt "$before_count" ]; then
+        echo -e "  ${RED:-}FIDELITY VIOLATION: item count grew from $before_count to $after_count${NC:-}"
+        violations=$(( violations + after_count - before_count ))
+    fi
 
     # Critical invariant fields to check.
     # bd uses "issue_type" not "type" in its JSON output.
     local INVARIANTS=("title" "description" "priority" "issue_type")
+    if ${STRICT_MODE:-false}; then
+        INVARIANTS+=("id" "notes" "design" "acceptance_criteria" "external_ref" "status")
+    fi
 
     local i=0
     while [ "$i" -lt "$before_count" ]; do
@@ -102,16 +214,29 @@ check_fidelity() {
             i=$((i + 1))
             continue
         fi
+        if ${STRICT_MODE:-false}; then
+            local match_count
+            match_count=$(jq --arg t "$title" '[.[] | select(.title == $t)] | length' "$after" 2>/dev/null) || match_count=0
+            if [ "$match_count" -ne 1 ]; then
+                echo -e "  ${RED:-}FIDELITY VIOLATION: '$title' has $match_count post-upgrade matches, want exactly 1${NC:-}"
+                violations=$((violations + 1))
+            fi
+        fi
 
         # Check each invariant field
         for field in "${INVARIANTS[@]}"; do
             local before_val after_val
-            before_val=$(jq -r ".[$i].${field} // \"\"" "$before" 2>/dev/null)
-            after_val=$(echo "$match" | jq -r ".${field} // \"\"" 2>/dev/null)
+            if ${STRICT_MODE:-false}; then
+                before_val=$(jq -c --arg field "$field" ".[$i] | .[\$field]" "$before" 2>/dev/null)
+                after_val=$(echo "$match" | jq -c --arg field "$field" '.[ $field ]' 2>/dev/null)
+            else
+                before_val=$(jq -r ".[$i].${field} // \"\"" "$before" 2>/dev/null)
+                after_val=$(echo "$match" | jq -r ".${field} // \"\"" 2>/dev/null)
 
-            # Skip empty/null fields (feature not available in old version)
-            [ -z "$before_val" ] && continue
-            [ "$before_val" = "null" ] && continue
+                # Skip fields unavailable in the historical source version.
+                [ -z "$before_val" ] && continue
+                [ "$before_val" = "null" ] && continue
+            fi
 
             if [ "$before_val" != "$after_val" ]; then
                 echo -e "  ${RED:-}FIDELITY VIOLATION: '$title'.${field}: '$before_val' -> '$after_val'${NC:-}"
@@ -123,7 +248,7 @@ check_fidelity() {
         local before_status after_status
         before_status=$(jq -r ".[$i].status // \"\"" "$before" 2>/dev/null)
         after_status=$(echo "$match" | jq -r ".status // \"\"" 2>/dev/null)
-        if [ -n "$before_status" ] && [ -n "$after_status" ]; then
+        if ! ${STRICT_MODE:-false} && [ -n "$before_status" ] && [ -n "$after_status" ]; then
             local before_closed after_closed
             before_closed=$(echo "$before_status" | grep -ciE "closed|done|resolved" || true)
             after_closed=$(echo "$after_status" | grep -ciE "closed|done|resolved" || true)
@@ -137,20 +262,25 @@ check_fidelity() {
         local before_deps after_deps
         before_deps=$(jq -r ".[$i].dependencies // [] | [.[].id // .] | sort | join(\",\")" "$before" 2>/dev/null)
         after_deps=$(echo "$match" | jq -r ".dependencies // [] | [.[].id // .] | sort | join(\",\")" 2>/dev/null)
-        if [ -n "$before_deps" ] && [ "$before_deps" != "$after_deps" ]; then
+        if { ${STRICT_MODE:-false} || [ -n "$before_deps" ]; } && [ "$before_deps" != "$after_deps" ]; then
             echo -e "  ${RED:-}FIDELITY VIOLATION: '$title' dependencies changed: '$before_deps' -> '$after_deps'${NC:-}"
             violations=$((violations + 1))
         fi
 
-        # Check comment count preservation
+        # Check comment preservation. Strict mode compares the user-authored
+        # text, not only the count, so content rewrites cannot pass.
         local before_comments after_comments
-        before_comments=$(jq -r ".[$i].comment_count // (.comments // [] | length) // 0" "$before" 2>/dev/null)
-        after_comments=$(echo "$match" | jq -r ".comment_count // (.comments // [] | length) // 0" 2>/dev/null)
-        # Normalize: treat empty/null as 0
-        [ -z "$before_comments" ] && before_comments=0
-        [ -z "$after_comments" ] && after_comments=0
-        if [ "$before_comments" != "0" ] && [ "$before_comments" != "$after_comments" ]; then
-            echo -e "  ${RED:-}FIDELITY VIOLATION: '$title' comment count: $before_comments -> $after_comments${NC:-}"
+        if ${STRICT_MODE:-false}; then
+            before_comments=$(jq -c ".[$i].comments // [] | map({author: (.author // \"\"), text: (.text // \"\")}) | sort_by(.author, .text)" "$before" 2>/dev/null)
+            after_comments=$(echo "$match" | jq -c '.comments // [] | map({author: (.author // ""), text: (.text // "")}) | sort_by(.author, .text)' 2>/dev/null)
+        else
+            before_comments=$(jq -r ".[$i].comment_count // (.comments // [] | length) // 0" "$before" 2>/dev/null)
+            after_comments=$(echo "$match" | jq -r ".comment_count // (.comments // [] | length) // 0" 2>/dev/null)
+            [ -z "$before_comments" ] && before_comments=0
+            [ -z "$after_comments" ] && after_comments=0
+        fi
+        if { ${STRICT_MODE:-false} || [ "$before_comments" != "0" ]; } && [ "$before_comments" != "$after_comments" ]; then
+            echo -e "  ${RED:-}FIDELITY VIOLATION: '$title' comments changed: $before_comments -> $after_comments${NC:-}"
             violations=$((violations + 1))
         fi
 
@@ -158,7 +288,7 @@ check_fidelity() {
         local before_labels after_labels
         before_labels=$(jq -r ".[$i].labels // [] | sort | join(\",\")" "$before" 2>/dev/null)
         after_labels=$(echo "$match" | jq -r ".labels // [] | sort | join(\",\")" 2>/dev/null)
-        if [ -n "$before_labels" ] && [ "$before_labels" != "$after_labels" ]; then
+        if { ${STRICT_MODE:-false} || [ -n "$before_labels" ]; } && [ "$before_labels" != "$after_labels" ]; then
             echo -e "  ${RED:-}FIDELITY VIOLATION: '$title' labels changed: '$before_labels' -> '$after_labels'${NC:-}"
             violations=$((violations + 1))
         fi

--- a/scripts/migration-test/lib/versions.sh
+++ b/scripts/migration-test/lib/versions.sh
@@ -29,24 +29,41 @@ declare -ar CLASSIC_SQLITE_ROLLBACK_FILES=(
     "config.yaml"
 )
 
+# Legacy Dolt-server metadata that must be retained with the dolt/ directory
+# before the manual bridge clears the active source.
+declare -ar LEGACY_DOLT_ROLLBACK_FILES=(
+    "metadata.json"
+    "config.json"
+    "config.yaml"
+    "issues.jsonl"
+)
+
 # Release artifacts and expected qualification outcomes for strict CI lanes.
 # Strict entries are deliberately explicit: adding a historical lane requires
 # reviewing the official asset, checksum, source capabilities, and supported
 # migration outcome instead of silently discovering them at runtime.
 declare -Ar STRICT_RELEASE_ASSETS=(
     ["v0.49.6|linux|amd64"]="beads_0.49.6_linux_amd64.tar.gz"
+    ["v0.55.4|linux|amd64"]="beads_0.55.4_linux_amd64.tar.gz"
 )
 declare -Ar STRICT_RELEASE_SHA256=(
     ["v0.49.6|linux|amd64"]="8546dc9a47e11dc31ac2bc9a0224a9c690975e91850932cbb62623053fbb7db8"
+    ["v0.55.4|linux|amd64"]="e0fa25456dd82890230eef17653448a0bf995104c78864be91c5ed84426a5f49"
 )
 declare -Ar STRICT_EXPECTED_STATUSES=(
     ["v0.49.6"]="MANUAL"
+    ["v0.55.4"]="MANUAL"
 )
 declare -Ar STRICT_EXPECTED_RECIPES=(
     ["v0.49.6"]="sqlite_to_current"
+    ["v0.55.4"]="server_to_embedded"
 )
 declare -Ar STRICT_EXPECTED_FEATURES=(
     ["v0.49.6"]="epic task bug dependency standalone closed label comment"
+    ["v0.55.4"]="epic task bug dependency standalone closed label comment"
+)
+declare -Ar SERVER_BRIDGE_STRATEGIES=(
+    ["v0.55.4"]="native_export"
 )
 
 strict_release_asset() {
@@ -75,6 +92,12 @@ strict_expected_recipe() {
 
 strict_expected_features() {
     local value="${STRICT_EXPECTED_FEATURES[$1]:-}"
+    [ -n "$value" ] || return 1
+    printf '%s\n' "$value"
+}
+
+server_bridge_strategy() {
+    local value="${SERVER_BRIDGE_STRATEGIES[$1]:-}"
     [ -n "$value" ] || return 1
     printf '%s\n' "$value"
 }

--- a/scripts/migration-test/lib/versions.sh
+++ b/scripts/migration-test/lib/versions.sh
@@ -18,6 +18,81 @@ DIRECT_PATHS=(
     "v0.63.3"
 )
 
+# Classic SQLite files that must be retained byte-for-byte for rollback before
+# the manual bridge removes the active copies.
+declare -ar CLASSIC_SQLITE_ROLLBACK_FILES=(
+    "beads.db"
+    "beads.db-wal"
+    "beads.db-shm"
+    "metadata.json"
+    "config.json"
+    "config.yaml"
+)
+
+# Release artifacts and expected qualification outcomes for strict CI lanes.
+# Strict entries are deliberately explicit: adding a historical lane requires
+# reviewing the official asset, checksum, source capabilities, and supported
+# migration outcome instead of silently discovering them at runtime.
+declare -Ar STRICT_RELEASE_ASSETS=(
+    ["v0.49.6|linux|amd64"]="beads_0.49.6_linux_amd64.tar.gz"
+)
+declare -Ar STRICT_RELEASE_SHA256=(
+    ["v0.49.6|linux|amd64"]="8546dc9a47e11dc31ac2bc9a0224a9c690975e91850932cbb62623053fbb7db8"
+)
+declare -Ar STRICT_EXPECTED_STATUSES=(
+    ["v0.49.6"]="MANUAL"
+)
+declare -Ar STRICT_EXPECTED_RECIPES=(
+    ["v0.49.6"]="sqlite_to_current"
+)
+declare -Ar STRICT_EXPECTED_FEATURES=(
+    ["v0.49.6"]="epic task bug dependency standalone closed label comment"
+)
+
+strict_release_asset() {
+    local value="${STRICT_RELEASE_ASSETS["$1|$2|$3"]:-}"
+    [ -n "$value" ] || return 1
+    printf '%s\n' "$value"
+}
+
+strict_release_sha256() {
+    local value="${STRICT_RELEASE_SHA256["$1|$2|$3"]:-}"
+    [ -n "$value" ] || return 1
+    printf '%s\n' "$value"
+}
+
+strict_expected_status() {
+    local value="${STRICT_EXPECTED_STATUSES[$1]:-}"
+    [ -n "$value" ] || return 1
+    printf '%s\n' "$value"
+}
+
+strict_expected_recipe() {
+    local value="${STRICT_EXPECTED_RECIPES[$1]:-}"
+    [ -n "$value" ] || return 1
+    printf '%s\n' "$value"
+}
+
+strict_expected_features() {
+    local value="${STRICT_EXPECTED_FEATURES[$1]:-}"
+    [ -n "$value" ] || return 1
+    printf '%s\n' "$value"
+}
+
+strict_fixture_has_expected_features() {
+    local version="$1"
+    shift
+    local expected feature actual
+    expected=$(strict_expected_features "$version") || return 1
+    actual=" $* "
+    for feature in $expected; do
+        if [[ "$actual" != *" $feature "* ]]; then
+            printf 'missing required source feature %s for %s\n' "$feature" "$version" >&2
+            return 1
+        fi
+    done
+}
+
 # Stepping-stone paths: version1,version2,...,versionN
 # Each version upgrades to the next, then finally to candidate.
 #

--- a/scripts/migration-test/recipes/server_to_embedded.sh
+++ b/scripts/migration-test/recipes/server_to_embedded.sh
@@ -1,10 +1,9 @@
 #!/bin/bash
-# Recipe: Dolt-server era (v0.50.0–v0.58.0) → current embedded Dolt.
+# Recipe: qualified v0.55.4 legacy Dolt directory → current embedded Dolt.
 #
-# Server-era versions store data in .beads/dolt/ and expect a running
-# Dolt SQL server. The current binary uses .beads/embeddeddolt/ with
-# an in-process engine. When metadata.json says server mode, the
-# candidate tries to TCP connect instead of falling back to embedded.
+# Other v0.50.0–v0.58.0 releases need release-specific extraction: v0.56.1
+# has no export command, while v0.57/v0.58 exports omit comment bodies. Do not
+# extend this recipe to those releases without a lossless fixture-backed path.
 #
 # Strategy:
 #   1. Stop any running Dolt server
@@ -13,22 +12,203 @@
 #   4. If candidate DB is empty, reimport from JSONL export
 #
 # User-facing instructions:
-#   If upgrading from a Dolt-server version (v0.50–v0.58):
-#     1. Stop your Dolt server: dolt sql-server --stop (or kill the process)
-#     2. Remove stale metadata: rm .beads/metadata.json
-#     3. Run: bd init --quiet
-#     4. Verify: bd list --all
+#   Use the pinned migration harness for v0.55.4. It stops the historical
+#   server, retains a byte-verified rollback tree, exports with the historical
+#   binary, validates the JSONL, and only then initializes the candidate.
+
+publish_legacy_dolt_rollback() {
+    mv --no-target-directory --no-clobber --no-copy -- "$1" "$2"
+}
+
+remove_file_and_verify_absent() {
+    local path="$1"
+    if [ -e "$path" ] || [ -L "$path" ]; then
+        rm -f -- "$path" || return 1
+    fi
+    [ ! -e "$path" ] && [ ! -L "$path" ]
+}
+
+remove_tree_and_verify_absent() {
+    local path="$1"
+    if [ -e "$path" ] || [ -L "$path" ]; then
+        rm -rf -- "$path" || return 1
+    fi
+    [ ! -e "$path" ] && [ ! -L "$path" ]
+}
+
+migration_jsonl_id_inventory() {
+    local path="$1"
+    [ -f "$path" ] && [ ! -L "$path" ] || return 1
+    jq -erRs '
+        (split("\n") |
+            if length > 0 and .[-1] == "" then .[:-1] else . end) as $lines |
+        if ($lines | length) == 0 or any($lines[]; test("\\S") | not) then
+            error("empty or blank JSONL record")
+        else
+            $lines | map(fromjson) |
+            if all(.[];
+                type == "object" and
+                ((.id? | type) == "string") and
+                ((.id? | length) > 0))
+            then .[].id | @json
+            else error("invalid issue record")
+            end
+        end
+    ' "$path"
+}
+
+migration_jsonl_matches_snapshot() {
+    local path="$1"
+    local snapshot="$2"
+    local export_ids expected_ids
+
+    export_ids=$(migration_jsonl_id_inventory "$path" 2>/dev/null) || return 1
+    [ -n "$export_ids" ] || return 1
+    expected_ids=$(jq -er '
+        if type == "array" and length > 0 and
+            all(.[];
+                type == "object" and
+                ((.id? | type) == "string") and
+                ((.id? | length) > 0))
+        then .[].id | @json
+        else error("invalid source snapshot")
+        end
+    ' "$snapshot" 2>/dev/null) || return 1
+    [ -n "$expected_ids" ] || return 1
+
+    [ -z "$(printf '%s\n' "$export_ids" | LC_ALL=C sort | uniq -d)" ] || return 1
+    [ -z "$(printf '%s\n' "$expected_ids" | LC_ALL=C sort | uniq -d)" ] || return 1
+    [ "$(printf '%s\n' "$export_ids" | LC_ALL=C sort)" = \
+        "$(printf '%s\n' "$expected_ids" | LC_ALL=C sort)" ]
+}
+
+migration_jsonl_is_snapshot_subset() {
+    local path="$1"
+    local snapshot="$2"
+    local existing_ids expected_ids extra_ids
+
+    [ -f "$path" ] && [ ! -L "$path" ] || return 1
+    [ -s "$path" ] || return 0
+    existing_ids=$(migration_jsonl_id_inventory "$path" 2>/dev/null) || return 1
+    expected_ids=$(jq -er '.[].id | @json' "$snapshot" 2>/dev/null) || return 1
+    [ -z "$(printf '%s\n' "$existing_ids" | LC_ALL=C sort | uniq -d)" ] || return 1
+    extra_ids=$(comm -23 \
+        <(printf '%s\n' "$existing_ids" | LC_ALL=C sort) \
+        <(printf '%s\n' "$expected_ids" | LC_ALL=C sort)) || return 1
+    [ -z "$extra_ids" ]
+}
+
+preserve_legacy_dolt_source() {
+    local ws="$1"
+    local expected_manifest="$2"
+    local beads_dir="$ws/.beads"
+    local backup_dir="$beads_dir/legacy-dolt.pre-migration"
+    local temp_dir="$beads_dir/.legacy-dolt.pre-migration.tmp.$$"
+    local actual_manifest relative
+
+    if [ -e "$backup_dir" ] || [ -L "$backup_dir" ]; then
+        if [ ! -d "$backup_dir" ] || [ -L "$backup_dir" ]; then
+            echo "  FAILED: legacy Dolt rollback destination is not a regular directory"
+            return 1
+        fi
+        if ! verify_legacy_dolt_rollback_root "$backup_dir" "$expected_manifest"; then
+            echo "  FAILED: legacy Dolt rollback destination contains different source data"
+            return 1
+        fi
+        return 0
+    fi
+
+    if [ -e "$temp_dir" ] || [ -L "$temp_dir" ]; then
+        echo "  FAILED: temporary legacy Dolt rollback destination already exists"
+        return 1
+    fi
+
+    actual_manifest=$(legacy_dolt_artifact_manifest "$beads_dir") || return 1
+    if [ "$actual_manifest" != "$expected_manifest" ]; then
+        echo "  FAILED: active legacy Dolt source changed before backup"
+        return 1
+    fi
+
+    mkdir "$temp_dir" || return 1
+    if ! cp -a -- "$beads_dir/dolt" "$temp_dir/dolt"; then
+        rm -rf "$temp_dir"
+        echo "  FAILED: could not copy legacy Dolt rollback data"
+        return 1
+    fi
+    for relative in "${LEGACY_DOLT_ROLLBACK_FILES[@]}"; do
+        if [ -f "$beads_dir/$relative" ]; then
+            if ! cp -p -- "$beads_dir/$relative" "$temp_dir/$relative"; then
+                rm -rf "$temp_dir"
+                echo "  FAILED: could not copy legacy Dolt rollback metadata"
+                return 1
+            fi
+        fi
+    done
+
+    actual_manifest=$(legacy_dolt_artifact_manifest "$temp_dir") || {
+        rm -rf "$temp_dir"
+        return 1
+    }
+    if [ "$actual_manifest" != "$expected_manifest" ] || \
+        ! verify_legacy_dolt_rollback_root "$temp_dir" "$expected_manifest"; then
+        rm -rf "$temp_dir"
+        echo "  FAILED: copied legacy Dolt rollback data failed verification"
+        return 1
+    fi
+
+    if ! publish_legacy_dolt_rollback "$temp_dir" "$backup_dir"; then
+        rm -rf "$temp_dir"
+        echo "  FAILED: could not publish legacy Dolt rollback data"
+        return 1
+    fi
+    if [ -e "$temp_dir" ] || [ -L "$temp_dir" ] || \
+        ! verify_legacy_dolt_rollback_root "$backup_dir" "$expected_manifest"; then
+        echo "  FAILED: published legacy Dolt rollback data failed verification"
+        return 1
+    fi
+}
 
 recipe_server_to_embedded() {
     local ws="$1"
     local old_bin="$2"
     local cand_bin="$3"
     local version="$4"
+    local before_snapshot="${5:-}"
+    local strategy
+    local export_path="$ws/.beads/issues.jsonl"
+    local existing_export_state="absent"
+    local existing_export_checksum=""
 
     echo "  Trying server→embedded recipe..."
+    strategy=$(server_bridge_strategy "$version") || {
+        echo "  FAILED: no lossless server→embedded recipe is qualified for $version"
+        return 1
+    }
+    if [ "$strategy" != "native_export" ] || [ ! -f "$before_snapshot" ]; then
+        echo "  FAILED: incomplete server→embedded inputs for $version"
+        return 1
+    fi
+    if [ -e "$export_path" ] || [ -L "$export_path" ]; then
+        if [ -L "$export_path" ] || [ ! -f "$export_path" ] || \
+            ! migration_jsonl_is_snapshot_subset "$export_path" "$before_snapshot"; then
+            echo "  FAILED: existing historical JSONL is unsafe to replace"
+            return 1
+        fi
+        existing_export_checksum=$(sha256_file "$export_path") || return 1
+        existing_export_state="present"
+    fi
 
     # Step 1: Stop any running server (we'll restart via old binary as needed)
     stop_dolt_server "$ws"
+
+    # Preserve the stopped source before an old export command or candidate
+    # probe can update its Dolt working set or metadata.
+    local rollback_manifest
+    rollback_manifest=$(legacy_dolt_artifact_manifest "$ws/.beads") || {
+        echo "  FAILED: could not inventory legacy Dolt rollback source"
+        return 1
+    }
+    preserve_legacy_dolt_source "$ws" "$rollback_manifest" || return 1
 
     # Step 2: Export data via old binary BEFORE clearing metadata.
     # The old binary needs metadata.json to know it's in server mode and
@@ -36,34 +216,60 @@ recipe_server_to_embedded() {
     # previously) makes the old binary unable to find its data. (GH#3071)
     echo "  exporting data via old binary..."
     local export_ok=false
-    if bd_in "$ws" "$old_bin" list --json -n 0 --all > "$ws/.beads/issues.jsonl.tmp" 2>/dev/null; then
-        if [ -s "$ws/.beads/issues.jsonl.tmp" ]; then
-            jq -c '.[]' "$ws/.beads/issues.jsonl.tmp" > "$ws/.beads/issues.jsonl" 2>/dev/null || true
-            rm -f "$ws/.beads/issues.jsonl.tmp"
-            if [ -s "$ws/.beads/issues.jsonl" ]; then
-                local export_count
-                export_count=$(wc -l < "$ws/.beads/issues.jsonl" 2>/dev/null) || export_count=0
-                echo "  exported $export_count items to JSONL"
-                export_ok=true
+    local export_tmp
+    export_tmp=$(mktemp "$ws/.beads/.issues.jsonl.migration.tmp.XXXXXX") || {
+        echo "  FAILED: could not create a safe historical export destination"
+        return 1
+    }
+    if bd_in "$ws" "$old_bin" export --format jsonl \
+        -o "$export_tmp" >/dev/null 2>&1; then
+        local export_destination_unchanged=false
+        if [ "$existing_export_state" = "present" ]; then
+            if [ -f "$export_path" ] && [ ! -L "$export_path" ] && \
+                [ "$(sha256_file "$export_path")" = "$existing_export_checksum" ]; then
+                export_destination_unchanged=true
             fi
-        else
-            rm -f "$ws/.beads/issues.jsonl.tmp"
+        elif [ ! -e "$export_path" ] && [ ! -L "$export_path" ]; then
+            export_destination_unchanged=true
+        fi
+        if $export_destination_unchanged && \
+            migration_jsonl_matches_snapshot "$export_tmp" "$before_snapshot" && \
+            mv --no-target-directory --force -- "$export_tmp" "$export_path" && \
+            migration_jsonl_matches_snapshot "$export_path" "$before_snapshot"; then
+            local export_count
+            export_count=$(jq -s 'length' "$export_path" 2>/dev/null) || export_count=0
+            echo "  exported $export_count items to JSONL"
+            export_ok=true
         fi
     fi
+    if ! remove_file_and_verify_absent "$export_tmp"; then
+        echo "  FAILED: could not remove the historical export staging file"
+        return 1
+    fi
     stop_dolt_server "$ws"
+    if ! $export_ok; then
+        echo "  FAILED: historical export did not produce a nonempty JSONL file"
+        return 1
+    fi
+    if ! verify_legacy_dolt_rollback_root \
+        "$ws/.beads/legacy-dolt.pre-migration" "$rollback_manifest"; then
+        echo "  FAILED: retained rollback source changed during historical export"
+        return 1
+    fi
 
     # Step 3: Clear stale server metadata that causes TCP connect attempts,
     # then try candidate init.
-    rm -f "$ws/.beads/metadata.json" 2>/dev/null || true
-    rm -f "$ws/.beads/dolt-server.pid" 2>/dev/null || true
-    rm -f "$ws/.beads/dolt-server.lock" 2>/dev/null || true
+    if ! remove_file_and_verify_absent "$ws/.beads/dolt-server.pid" || \
+        ! remove_file_and_verify_absent "$ws/.beads/dolt-server.lock" || \
+        ! remove_file_and_verify_absent "$ws/.beads/metadata.json"; then
+        echo "  FAILED: could not clear legacy server metadata"
+        return 1
+    fi
 
     if bd_in "$ws" "$cand_bin" init --quiet --non-interactive </dev/null >/dev/null 2>&1; then
         # Verify candidate actually has data — init may succeed but create
         # an empty database if it didn't detect the old dolt/ data. (GH#3071)
-        local verify_out
-        verify_out=$(bd_in "$ws" "$cand_bin" list --json -n 0 --all 2>/dev/null) || true
-        if [ -n "$verify_out" ] && [ "$verify_out" != "[]" ] && [ "$verify_out" != "null" ]; then
+        if candidate_list_has_nonempty_issue_ids "$ws" "$cand_bin"; then
             echo "  candidate init succeeded with data intact"
             return 0
         fi
@@ -71,15 +277,23 @@ recipe_server_to_embedded() {
     fi
 
     # Step 4: Candidate init produced an empty DB (or failed).
-    # Move old storage directories out of the way so checkExistingBeadsData
-    # doesn't block --from-jsonl. The old dolt/ is server-era data; the
-    # embeddeddolt/ (if any) was just created empty by step 3.
+    # Remove active storage only after the verified rollback copy and JSONL
+    # export exist. The old dolt/ is legacy data; embeddeddolt/ (if any) was
+    # just created empty by step 3.
     stop_dolt_server "$ws"
-    for old_dir in "$ws/.beads/dolt" "$ws/.beads/embeddeddolt"; do
-        [ -d "$old_dir" ] && mv "$old_dir" "${old_dir}.pre-migration" 2>/dev/null || true
-    done
-    rm -f "$ws/.beads/metadata.json" 2>/dev/null || true
-    rm -f "$ws/.beads/config.json" 2>/dev/null || true
+    if ! verify_legacy_dolt_rollback_root \
+        "$ws/.beads/legacy-dolt.pre-migration" "$rollback_manifest"; then
+        echo "  FAILED: retained rollback source changed before active-source removal"
+        return 1
+    fi
+    if ! remove_file_and_verify_absent "$ws/.beads/metadata.json" || \
+        ! remove_file_and_verify_absent "$ws/.beads/config.json" || \
+        ! remove_file_and_verify_absent "$ws/.beads/config.yaml" || \
+        ! remove_tree_and_verify_absent "$ws/.beads/dolt" || \
+        ! remove_tree_and_verify_absent "$ws/.beads/embeddeddolt"; then
+        echo "  FAILED: could not remove active legacy storage artifacts"
+        return 1
+    fi
 
     # Reimport from the JSONL export captured in step 2.
     if $export_ok && [ -s "$ws/.beads/issues.jsonl" ]; then

--- a/scripts/migration-test/recipes/sqlite_to_current.sh
+++ b/scripts/migration-test/recipes/sqlite_to_current.sh
@@ -29,6 +29,21 @@ preserve_sqlite_source_artifacts() {
         source_file="$ws/.beads/$relative"
         backup_file="${source_file}.pre-migration"
 
+        # Reject symlinks with no-follow (lstat) semantics before any -e/-f test,
+        # which follow links. A symlinked active source or .pre-migration rollback
+        # artifact can point outside the workspace, so the retained "rollback" copy
+        # would not be self-contained and strict rollback verification could pass
+        # after the real source is deleted. Mirror the server->embedded recipe,
+        # which likewise rejects symlinked rollback artifacts.
+        if [ -L "$source_file" ]; then
+            echo "  FAILED: SQLite source artifact is a symlink: $source_file"
+            return 1
+        fi
+        if [ -L "$backup_file" ]; then
+            echo "  FAILED: SQLite rollback artifact is a symlink: $backup_file"
+            return 1
+        fi
+
         if [ ! -e "$source_file" ]; then
             if [ -e "$backup_file" ]; then
                 echo "  FAILED: stale rollback artifact has no active source: $backup_file"

--- a/scripts/migration-test/recipes/sqlite_to_current.sh
+++ b/scripts/migration-test/recipes/sqlite_to_current.sh
@@ -19,6 +19,47 @@
 #     3. Run: bd init --from-jsonl --quiet
 #     4. Verify: bd list --all
 
+preserve_sqlite_source_artifacts() {
+    local ws="$1"
+    local relative source_file backup_file
+
+    # Validate the entire destination set before copying anything so a late
+    # collision cannot leave a partial backup behind.
+    for relative in "${CLASSIC_SQLITE_ROLLBACK_FILES[@]}"; do
+        source_file="$ws/.beads/$relative"
+        backup_file="${source_file}.pre-migration"
+
+        if [ ! -e "$source_file" ]; then
+            if [ -e "$backup_file" ]; then
+                echo "  FAILED: stale rollback artifact has no active source: $backup_file"
+                return 1
+            fi
+            continue
+        fi
+        if [ ! -f "$source_file" ]; then
+            echo "  FAILED: SQLite source artifact is not a regular file: $source_file"
+            return 1
+        fi
+        if [ -e "$backup_file" ]; then
+            if [ ! -f "$backup_file" ] || ! cmp -s "$source_file" "$backup_file"; then
+                echo "  FAILED: rollback artifact collides with different source data: $backup_file"
+                return 1
+            fi
+        fi
+    done
+
+    for relative in "${CLASSIC_SQLITE_ROLLBACK_FILES[@]}"; do
+        source_file="$ws/.beads/$relative"
+        backup_file="${source_file}.pre-migration"
+        if [ -f "$source_file" ] && [ ! -e "$backup_file" ]; then
+            cp -pf "$source_file" "$backup_file" || {
+                echo "  FAILED: could not preserve rollback source $source_file"
+                return 1
+            }
+        fi
+    done
+}
+
 recipe_sqlite_to_current() {
     local ws="$1"
     local old_bin="$2"
@@ -26,6 +67,12 @@ recipe_sqlite_to_current() {
     local version="$4"
 
     echo "  Trying SQLite→current recipe..."
+
+    # Preserve the rollback source before invoking any historical command.
+    # Some old binaries update SQLite bookkeeping even for export/read paths;
+    # backing up afterward would retain a migration-touched database instead
+    # of the exact source that the user started with.
+    preserve_sqlite_source_artifacts "$ws" || return 1
 
     # Strategy 1: Use old binary's export command
     if bd_in "$ws" "$old_bin" export --format jsonl > "$ws/.beads/issues.jsonl.tmp" 2>/dev/null; then
@@ -137,13 +184,14 @@ recipe_sqlite_to_current() {
     # Stop any old dolt server
     stop_dolt_server "$ws"
 
-    # Move old artifacts out of the way so the candidate's
+    # Remove active old artifacts now that the byte-identical rollback copies
+    # and JSONL export are durable. This lets the candidate's
     # checkExistingBeadsData guard does not reject init as "already initialized".
     # Includes embeddeddolt/ which may have been created empty by a failed
     # direct upgrade attempt in the harness.
-    for old_file in "$ws/.beads/beads.db" "$ws/.beads/beads.db-wal" "$ws/.beads/beads.db-shm" \
-                     "$ws/.beads/metadata.json" "$ws/.beads/config.json"; do
-        [ -f "$old_file" ] && mv "$old_file" "${old_file}.pre-migration" 2>/dev/null || true
+    local old_file
+    for old_file in "${CLASSIC_SQLITE_ROLLBACK_FILES[@]}"; do
+        [ -f "$ws/.beads/$old_file" ] && rm -f "$ws/.beads/$old_file"
     done
     for old_dir in "$ws/.beads/embeddeddolt" "$ws/.beads/dolt"; do
         [ -d "$old_dir" ] && mv "$old_dir" "${old_dir}.pre-migration" 2>/dev/null || true

--- a/scripts/migration-test/run.sh
+++ b/scripts/migration-test/run.sh
@@ -23,6 +23,7 @@ set -uo pipefail
 #   ./scripts/migration-test/run.sh --direct-only      # only direct paths
 #   ./scripts/migration-test/run.sh --stepping-only    # only stepping-stone paths
 #   ./scripts/migration-test/run.sh --self-test        # candidate → candidate (harness validation)
+#   ./scripts/migration-test/run.sh --strict --expect MANUAL v0.49.6
 #   ./scripts/migration-test/run.sh v0.49.6            # single version
 #   CANDIDATE_BIN=./bd ./scripts/migration-test/run.sh # prebuilt candidate
 #
@@ -34,8 +35,8 @@ set -uo pipefail
 #   DOWNLOAD_TIMEOUT   Timeout in seconds for binary downloads (default: 60)
 #
 # Exit codes:
-#   0  No BLOCKED paths (AUTO and MANUAL are both acceptable)
-#   1  One or more paths are BLOCKED (data loss risk)
+#   0  No BLOCKED paths (or the exact qualified result in strict mode)
+#   1  A path is BLOCKED, or strict qualification fails
 # =============================================================================
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -43,9 +44,9 @@ PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 
 # Source library modules
 source "$SCRIPT_DIR/lib/report.sh"      # colors + result tracking (must be first for color vars)
+source "$SCRIPT_DIR/lib/versions.sh"    # release manifest, ERAS, DIRECT_PATHS, get_era
 source "$SCRIPT_DIR/lib/binary.sh"      # download_binary, build_candidate
 source "$SCRIPT_DIR/lib/workspace.sh"   # new_workspace, bd_in, bd_create, cleanup_workspace
-source "$SCRIPT_DIR/lib/versions.sh"    # ERAS, DIRECT_PATHS, version_lte, get_era
 source "$SCRIPT_DIR/lib/features.sh"    # create_dataset, try_feature
 source "$SCRIPT_DIR/lib/snapshot.sh"    # capture_snapshot, check_fidelity
 
@@ -53,6 +54,29 @@ source "$SCRIPT_DIR/lib/snapshot.sh"    # capture_snapshot, check_fidelity
 source "$SCRIPT_DIR/recipes/sqlite_to_current.sh"
 source "$SCRIPT_DIR/recipes/server_to_embedded.sh"
 source "$SCRIPT_DIR/recipes/fix_dash_prefix.sh"
+
+source_artifact_fingerprint() {
+    local beads_dir="$1"
+    [ -d "$beads_dir" ] || return 1
+    (
+        cd "$beads_dir" || exit 1
+        while IFS= read -r -d '' path; do
+            if [ -L "$path" ]; then
+                printf 'link\0%s\0%s\0' "$path" "$(readlink "$path")"
+            elif [ -d "$path" ]; then
+                printf 'directory\0%s\0%s\0' "$path" "$(stat -c '%a' "$path")"
+            elif [ -f "$path" ]; then
+                printf 'file\0%s\0%s\0%s\0' "$path" "$(stat -c '%a' "$path")" "$(sha256_file "$path")"
+            else
+                printf 'other\0%s\0' "$path"
+            fi
+        done < <(find . -mindepth 1 -print0 | sort -z)
+    ) | if command -v sha256sum >/dev/null 2>&1; then
+        sha256sum | awk '{print $1}'
+    else
+        shasum -a 256 | awk '{print $1}'
+    fi
+}
 
 # Ensure jq is available
 if ! command -v jq >/dev/null 2>&1; then
@@ -75,11 +99,19 @@ test_direct_path() {
 
     # Download source binary
     local src_bin
-    src_bin=$(download_binary "$version" 2>/dev/null) || {
-        record_result "$path_label" "SKIP" "no binary for ${OS}/${ARCH}"
-        echo -e "  ${YELLOW}SKIP: no binary for ${OS}/${ARCH}${NC}"
-        return 0
-    }
+    if $STRICT_MODE; then
+        src_bin=$(download_binary "$version") || {
+            record_result "$path_label" "BLOCKED" "verified release unavailable for ${OS}/${ARCH}"
+            echo -e "  ${RED}BLOCKED: verified release unavailable for ${OS}/${ARCH}${NC}"
+            return 0
+        }
+    else
+        src_bin=$(download_binary "$version" 2>/dev/null) || {
+            record_result "$path_label" "SKIP" "no binary for ${OS}/${ARCH}"
+            echo -e "  ${YELLOW}SKIP: no binary for ${OS}/${ARCH}${NC}"
+            return 0
+        }
+    fi
 
     local WS
     WS=$(new_workspace)
@@ -120,15 +152,61 @@ test_direct_path() {
         echo -e "  ${RED}BLOCKED: could not create test data${NC}"
         return 0
     fi
+    if $STRICT_MODE && ! strict_fixture_has_expected_features "$version" "${DATASET_FEATURES[@]}"; then
+        cleanup_workspace "$WS"
+        rm -rf "$SNAPSHOTS_DIR"
+        record_result "$path_label" "BLOCKED" "source fixture is missing required features"
+        echo -e "  ${RED}BLOCKED: source fixture is missing required features${NC}"
+        return 0
+    fi
 
     # Step 3: Capture before-snapshot
-    capture_snapshot "$WS" "$src_bin" > "$SNAPSHOTS_DIR/before.json"
+    if ! capture_snapshot "$WS" "$src_bin" > "$SNAPSHOTS_DIR/before.json"; then
+        if $STRICT_MODE; then
+            cleanup_workspace "$WS"
+            rm -rf "$SNAPSHOTS_DIR"
+            record_result "$path_label" "BLOCKED" "could not capture the complete source snapshot"
+            echo -e "  ${RED}BLOCKED: could not capture the complete source snapshot${NC}"
+            return 0
+        fi
+    fi
     local before_count
     before_count=$(jq 'length' "$SNAPSHOTS_DIR/before.json" 2>/dev/null) || before_count=0
     echo "  before-snapshot: $before_count items"
+    if $STRICT_MODE && [ "$before_count" -eq 0 ]; then
+        cleanup_workspace "$WS"
+        rm -rf "$SNAPSHOTS_DIR"
+        record_result "$path_label" "BLOCKED" "source snapshot is empty"
+        echo -e "  ${RED}BLOCKED: source snapshot is empty${NC}"
+        return 0
+    fi
+    if $STRICT_MODE && ! strict_snapshot_has_expected_fixture "$version" "$SNAPSHOTS_DIR/before.json"; then
+        cleanup_workspace "$WS"
+        rm -rf "$SNAPSHOTS_DIR"
+        record_result "$path_label" "BLOCKED" "source snapshot does not match the exact fixture contract"
+        echo -e "  ${RED}BLOCKED: source snapshot does not match the exact fixture contract${NC}"
+        return 0
+    fi
 
     # Stop source server before upgrade
     stop_dolt_server "$WS"
+
+    local source_fingerprint=""
+    local source_sqlite_manifest=""
+    if $STRICT_MODE && [ "$(get_era "$version")" = "sqlite" ]; then
+        source_fingerprint=$(source_artifact_fingerprint "$WS/.beads") || {
+            cleanup_workspace "$WS"
+            rm -rf "$SNAPSHOTS_DIR"
+            record_result "$path_label" "BLOCKED" "could not fingerprint classic SQLite source"
+            return 0
+        }
+        source_sqlite_manifest=$(classic_sqlite_artifact_manifest "$WS/.beads") || {
+            cleanup_workspace "$WS"
+            rm -rf "$SNAPSHOTS_DIR"
+            record_result "$path_label" "BLOCKED" "could not inventory classic SQLite rollback source"
+            return 0
+        }
+    fi
 
     # Step 4: Try direct upgrade with candidate
     echo "  upgrading to candidate..."
@@ -148,6 +226,21 @@ test_direct_path() {
         if [ -n "$list_out" ] && [ "$list_out" != "[]" ] && [ "$list_out" != "null" ]; then
             upgrade_ok=true
         fi
+    fi
+
+    if $STRICT_MODE && ! $upgrade_ok && [ -n "$source_fingerprint" ]; then
+        local after_probe_fingerprint
+        stop_dolt_server "$WS"
+        after_probe_fingerprint=$(source_artifact_fingerprint "$WS/.beads") || after_probe_fingerprint="unreadable"
+        if [ "$after_probe_fingerprint" != "$source_fingerprint" ]; then
+            stop_dolt_server "$WS"
+            cleanup_workspace "$WS"
+            rm -rf "$SNAPSHOTS_DIR"
+            record_result "$path_label" "BLOCKED" "candidate probe mutated the classic SQLite source"
+            echo -e "  ${RED}BLOCKED: candidate probe mutated the classic SQLite source${NC}"
+            return 0
+        fi
+        echo -e "  ${GREEN}SOURCE-CHECK: failed direct probe left classic SQLite artifacts unchanged${NC}"
     fi
 
     if $upgrade_ok; then
@@ -214,6 +307,16 @@ test_direct_path() {
     esac
 
     if $recipe_worked; then
+        if $STRICT_MODE && [ -n "$source_sqlite_manifest" ] && \
+            ! verify_retained_sqlite_source "$WS/.beads" "$source_sqlite_manifest"; then
+            stop_dolt_server "$WS"
+            cleanup_workspace "$WS"
+            rm -rf "$SNAPSHOTS_DIR"
+            record_result "$path_label" "BLOCKED" "manual bridge mutated the retained classic SQLite database"
+            echo -e "  ${RED}BLOCKED: manual bridge mutated the retained classic SQLite database${NC}"
+            return 0
+        fi
+
         # Re-capture and check fidelity after recipe
         capture_snapshot "$WS" "$cand_bin" > "$SNAPSHOTS_DIR/after.json"
         local after_count
@@ -228,6 +331,15 @@ test_direct_path() {
         violations=$((violations + blocker_violations))
 
         stop_dolt_server "$WS"
+
+        if $STRICT_MODE && [ -n "$source_sqlite_manifest" ] && \
+            ! verify_retained_sqlite_source "$WS/.beads" "$source_sqlite_manifest"; then
+            cleanup_workspace "$WS"
+            rm -rf "$SNAPSHOTS_DIR"
+            record_result "$path_label" "BLOCKED" "post-upgrade commands mutated the retained SQLite rollback source"
+            echo -e "  ${RED}BLOCKED: post-upgrade commands mutated the retained SQLite rollback source${NC}"
+            return 0
+        fi
 
         cleanup_workspace "$WS"
         rm -rf "$SNAPSHOTS_DIR"
@@ -404,6 +516,9 @@ test_stepping_stone_path() {
 RUN_DIRECT=true
 RUN_STEPPING=true
 SELF_TEST=false
+STRICT_MODE=false
+EXPECTED_STATUS=""
+EXPECTED_RECIPE=""
 SPECIFIC_VERSIONS=()
 
 while [ $# -gt 0 ]; do
@@ -422,6 +537,22 @@ while [ $# -gt 0 ]; do
             RUN_STEPPING=false
             shift
             ;;
+        --strict)
+            STRICT_MODE=true
+            shift
+            ;;
+        --expect)
+            if [ $# -lt 2 ]; then
+                echo "ERROR: --expect requires AUTO or MANUAL" >&2
+                exit 1
+            fi
+            EXPECTED_STATUS="$2"
+            shift 2
+            ;;
+        --expect=*)
+            EXPECTED_STATUS="${1#--expect=}"
+            shift
+            ;;
         --help|-h)
             head -30 "$0" | grep '^#' | sed 's/^# \?//'
             exit 0
@@ -433,6 +564,29 @@ while [ $# -gt 0 ]; do
             ;;
     esac
 done
+
+if $STRICT_MODE; then
+    if $SELF_TEST || ! $RUN_DIRECT || $RUN_STEPPING || [ "${#SPECIFIC_VERSIONS[@]}" -ne 1 ]; then
+        echo "ERROR: --strict requires exactly one direct historical version" >&2
+        exit 1
+    fi
+    if [ "$EXPECTED_STATUS" != "AUTO" ] && [ "$EXPECTED_STATUS" != "MANUAL" ]; then
+        echo "ERROR: --strict requires --expect AUTO or --expect MANUAL" >&2
+        exit 1
+    fi
+    manifest_status=$(strict_expected_status "${SPECIFIC_VERSIONS[0]}") || {
+        echo "ERROR: ${SPECIFIC_VERSIONS[0]} has no strict qualification manifest" >&2
+        exit 1
+    }
+    if [ "$EXPECTED_STATUS" != "$manifest_status" ]; then
+        echo "ERROR: --expect $EXPECTED_STATUS disagrees with manifest outcome $manifest_status" >&2
+        exit 1
+    fi
+    EXPECTED_RECIPE=$(strict_expected_recipe "${SPECIFIC_VERSIONS[0]}") || {
+        echo "ERROR: ${SPECIFIC_VERSIONS[0]} has no strict recipe manifest" >&2
+        exit 1
+    }
+fi
 
 # ---------------------------------------------------------------------------
 # Main
@@ -540,6 +694,10 @@ if [ -z "${CANDIDATE_BIN:-}" ] && [ -f "$CAND_BIN" ]; then
 fi
 
 # Exit with failure only if any path is BLOCKED
+if $STRICT_MODE; then
+    strict_results_match "$EXPECTED_STATUS" "$EXPECTED_RECIPE" || exit 1
+    exit 0
+fi
 for status in "${RESULT_STATUSES[@]}"; do
     if [ "$status" = "BLOCKED" ]; then
         exit 1

--- a/scripts/migration-test/run.sh
+++ b/scripts/migration-test/run.sh
@@ -49,33 +49,32 @@ source "$SCRIPT_DIR/lib/binary.sh"      # download_binary, build_candidate
 source "$SCRIPT_DIR/lib/workspace.sh"   # new_workspace, bd_in, bd_create, cleanup_workspace
 source "$SCRIPT_DIR/lib/features.sh"    # create_dataset, try_feature
 source "$SCRIPT_DIR/lib/snapshot.sh"    # capture_snapshot, check_fidelity
+source "$SCRIPT_DIR/lib/direct_probe.sh" # fail-closed candidate probing
 
 # Source recipe scripts
 source "$SCRIPT_DIR/recipes/sqlite_to_current.sh"
 source "$SCRIPT_DIR/recipes/server_to_embedded.sh"
 source "$SCRIPT_DIR/recipes/fix_dash_prefix.sh"
 
-source_artifact_fingerprint() {
-    local beads_dir="$1"
-    [ -d "$beads_dir" ] || return 1
-    (
-        cd "$beads_dir" || exit 1
-        while IFS= read -r -d '' path; do
-            if [ -L "$path" ]; then
-                printf 'link\0%s\0%s\0' "$path" "$(readlink "$path")"
-            elif [ -d "$path" ]; then
-                printf 'directory\0%s\0%s\0' "$path" "$(stat -c '%a' "$path")"
-            elif [ -f "$path" ]; then
-                printf 'file\0%s\0%s\0%s\0' "$path" "$(stat -c '%a' "$path")" "$(sha256_file "$path")"
-            else
-                printf 'other\0%s\0' "$path"
-            fi
-        done < <(find . -mindepth 1 -print0 | sort -z)
-    ) | if command -v sha256sum >/dev/null 2>&1; then
-        sha256sum | awk '{print $1}'
-    else
-        shasum -a 256 | awk '{print $1}'
-    fi
+verify_strict_retained_source() {
+    local ws="$1"
+    local era="$2"
+    local sqlite_manifest="$3"
+    local legacy_dolt_manifest="$4"
+
+    case "$era" in
+        sqlite)
+            [ -n "$sqlite_manifest" ] && \
+                verify_retained_sqlite_source "$ws/.beads" "$sqlite_manifest"
+            ;;
+        dolt_server)
+            [ -n "$legacy_dolt_manifest" ] && \
+                verify_retained_legacy_dolt_source "$ws/.beads" "$legacy_dolt_manifest"
+            ;;
+        *)
+            return 0
+            ;;
+    esac
 }
 
 # Ensure jq is available
@@ -191,61 +190,70 @@ test_direct_path() {
     # Stop source server before upgrade
     stop_dolt_server "$WS"
 
+    local source_era
+    source_era=$(get_era "$version")
     local source_fingerprint=""
     local source_sqlite_manifest=""
-    if $STRICT_MODE && [ "$(get_era "$version")" = "sqlite" ]; then
+    local source_legacy_dolt_manifest=""
+    if $STRICT_MODE; then
         source_fingerprint=$(source_artifact_fingerprint "$WS/.beads") || {
             cleanup_workspace "$WS"
             rm -rf "$SNAPSHOTS_DIR"
-            record_result "$path_label" "BLOCKED" "could not fingerprint classic SQLite source"
+            record_result "$path_label" "BLOCKED" "could not fingerprint historical source tree"
             return 0
         }
-        source_sqlite_manifest=$(classic_sqlite_artifact_manifest "$WS/.beads") || {
-            cleanup_workspace "$WS"
-            rm -rf "$SNAPSHOTS_DIR"
-            record_result "$path_label" "BLOCKED" "could not inventory classic SQLite rollback source"
-            return 0
-        }
+        case "$source_era" in
+            sqlite)
+                source_sqlite_manifest=$(classic_sqlite_artifact_manifest "$WS/.beads") || {
+                    cleanup_workspace "$WS"
+                    rm -rf "$SNAPSHOTS_DIR"
+                    record_result "$path_label" "BLOCKED" "could not inventory classic SQLite rollback source"
+                    return 0
+                }
+                ;;
+            dolt_server)
+                source_legacy_dolt_manifest=$(legacy_dolt_artifact_manifest "$WS/.beads") || {
+                    cleanup_workspace "$WS"
+                    rm -rf "$SNAPSHOTS_DIR"
+                    record_result "$path_label" "BLOCKED" "could not inventory legacy Dolt rollback source"
+                    return 0
+                }
+                ;;
+        esac
     fi
 
     # Step 4: Try direct upgrade with candidate
     echo "  upgrading to candidate..."
     local upgrade_ok=false
-
-    # First try: just use candidate directly (auto-detect + migrate)
-    local list_out
-    list_out=$(bd_in "$WS" "$cand_bin" list --json -n 0 --all 2>/dev/null) || true
-    if [ -n "$list_out" ] && [ "$list_out" != "[]" ] && [ "$list_out" != "null" ]; then
+    local probe_status=0
+    probe_candidate_direct_upgrade \
+        "$WS" "$cand_bin" "$source_fingerprint" "$STRICT_MODE" || probe_status=$?
+    if [ "$probe_status" -eq 0 ]; then
         upgrade_ok=true
     fi
 
-    # Second try: run candidate init
-    if ! $upgrade_ok; then
-        bd_in "$WS" "$cand_bin" init --quiet --non-interactive --prefix smoke </dev/null >/dev/null 2>&1 || true
-        list_out=$(bd_in "$WS" "$cand_bin" list --json -n 0 --all 2>/dev/null) || true
-        if [ -n "$list_out" ] && [ "$list_out" != "[]" ] && [ "$list_out" != "null" ]; then
-            upgrade_ok=true
-        fi
-    fi
-
-    if $STRICT_MODE && ! $upgrade_ok && [ -n "$source_fingerprint" ]; then
-        local after_probe_fingerprint
+    if [ "$probe_status" -eq 2 ]; then
         stop_dolt_server "$WS"
-        after_probe_fingerprint=$(source_artifact_fingerprint "$WS/.beads") || after_probe_fingerprint="unreadable"
-        if [ "$after_probe_fingerprint" != "$source_fingerprint" ]; then
-            stop_dolt_server "$WS"
-            cleanup_workspace "$WS"
-            rm -rf "$SNAPSHOTS_DIR"
-            record_result "$path_label" "BLOCKED" "candidate probe mutated the classic SQLite source"
-            echo -e "  ${RED}BLOCKED: candidate probe mutated the classic SQLite source${NC}"
-            return 0
-        fi
-        echo -e "  ${GREEN}SOURCE-CHECK: failed direct probe left classic SQLite artifacts unchanged${NC}"
+        cleanup_workspace "$WS"
+        rm -rf "$SNAPSHOTS_DIR"
+        record_result "$path_label" "BLOCKED" "$DIRECT_PROBE_FAILURE_DETAIL"
+        echo -e "  ${RED}BLOCKED: $DIRECT_PROBE_FAILURE_DETAIL${NC}"
+        return 0
+    fi
+    if $STRICT_MODE && ! $upgrade_ok; then
+        echo -e "  ${GREEN}SOURCE-CHECK: failed direct probe left historical source artifacts unchanged${NC}"
     fi
 
     if $upgrade_ok; then
         # Capture after-snapshot and check fidelity
-        capture_snapshot "$WS" "$cand_bin" > "$SNAPSHOTS_DIR/after.json"
+        if ! capture_snapshot "$WS" "$cand_bin" > "$SNAPSHOTS_DIR/after.json"; then
+            stop_dolt_server "$WS"
+            cleanup_workspace "$WS"
+            rm -rf "$SNAPSHOTS_DIR"
+            record_result "$path_label" "BLOCKED" "could not capture the complete candidate snapshot"
+            echo -e "  ${RED}BLOCKED: could not capture the complete candidate snapshot${NC}"
+            return 0
+        fi
         local after_count
         after_count=$(jq 'length' "$SNAPSHOTS_DIR/after.json" 2>/dev/null) || after_count=0
         echo "  after-snapshot: $after_count items"
@@ -273,8 +281,7 @@ test_direct_path() {
     stop_dolt_server "$WS"
     echo "  direct upgrade failed, trying recipes..."
 
-    local era
-    era=$(get_era "$version")
+    local era="$source_era"
     local recipe_worked=false
     local recipe_name=""
 
@@ -286,7 +293,8 @@ test_direct_path() {
             fi
             ;;
         dolt_server)
-            if recipe_server_to_embedded "$WS" "$src_bin" "$cand_bin" "$version"; then
+            if recipe_server_to_embedded \
+                "$WS" "$src_bin" "$cand_bin" "$version" "$SNAPSHOTS_DIR/before.json"; then
                 recipe_worked=true
                 recipe_name="server_to_embedded"
             fi
@@ -298,7 +306,8 @@ test_direct_path() {
             fi
             # Also try server recipe if prefix fix didn't help
             if ! $recipe_worked; then
-                if recipe_server_to_embedded "$WS" "$src_bin" "$cand_bin" "$version"; then
+                if recipe_server_to_embedded \
+                    "$WS" "$src_bin" "$cand_bin" "$version" "$SNAPSHOTS_DIR/before.json"; then
                     recipe_worked=true
                     recipe_name="server_to_embedded"
                 fi
@@ -307,18 +316,25 @@ test_direct_path() {
     esac
 
     if $recipe_worked; then
-        if $STRICT_MODE && [ -n "$source_sqlite_manifest" ] && \
-            ! verify_retained_sqlite_source "$WS/.beads" "$source_sqlite_manifest"; then
+        if $STRICT_MODE && ! verify_strict_retained_source \
+            "$WS" "$era" "$source_sqlite_manifest" "$source_legacy_dolt_manifest"; then
             stop_dolt_server "$WS"
             cleanup_workspace "$WS"
             rm -rf "$SNAPSHOTS_DIR"
-            record_result "$path_label" "BLOCKED" "manual bridge mutated the retained classic SQLite database"
-            echo -e "  ${RED}BLOCKED: manual bridge mutated the retained classic SQLite database${NC}"
+            record_result "$path_label" "BLOCKED" "manual bridge mutated the retained historical rollback source"
+            echo -e "  ${RED}BLOCKED: manual bridge mutated the retained historical rollback source${NC}"
             return 0
         fi
 
         # Re-capture and check fidelity after recipe
-        capture_snapshot "$WS" "$cand_bin" > "$SNAPSHOTS_DIR/after.json"
+        if ! capture_snapshot "$WS" "$cand_bin" > "$SNAPSHOTS_DIR/after.json"; then
+            stop_dolt_server "$WS"
+            cleanup_workspace "$WS"
+            rm -rf "$SNAPSHOTS_DIR"
+            record_result "$path_label" "BLOCKED" "could not capture the complete candidate snapshot after recipe"
+            echo -e "  ${RED}BLOCKED: could not capture the complete candidate snapshot after recipe${NC}"
+            return 0
+        fi
         local after_count
         after_count=$(jq 'length' "$SNAPSHOTS_DIR/after.json" 2>/dev/null) || after_count=0
         echo "  after-recipe snapshot: $after_count items"
@@ -332,12 +348,12 @@ test_direct_path() {
 
         stop_dolt_server "$WS"
 
-        if $STRICT_MODE && [ -n "$source_sqlite_manifest" ] && \
-            ! verify_retained_sqlite_source "$WS/.beads" "$source_sqlite_manifest"; then
+        if $STRICT_MODE && ! verify_strict_retained_source \
+            "$WS" "$era" "$source_sqlite_manifest" "$source_legacy_dolt_manifest"; then
             cleanup_workspace "$WS"
             rm -rf "$SNAPSHOTS_DIR"
-            record_result "$path_label" "BLOCKED" "post-upgrade commands mutated the retained SQLite rollback source"
-            echo -e "  ${RED}BLOCKED: post-upgrade commands mutated the retained SQLite rollback source${NC}"
+            record_result "$path_label" "BLOCKED" "post-upgrade commands mutated the retained historical rollback source"
+            echo -e "  ${RED}BLOCKED: post-upgrade commands mutated the retained historical rollback source${NC}"
             return 0
         fi
 

--- a/scripts/migration-test/strict-mode-test.sh
+++ b/scripts/migration-test/strict-mode-test.sh
@@ -153,6 +153,38 @@ fi
 [ ! -e "$tmp/collision/.beads/beads.db.pre-migration" ] ||
     fail "rollback preflight left a partial backup before reporting collision"
 
+# A symlinked rollback artifact must be rejected with no-follow semantics. A
+# .pre-migration copy (or active source) that resolves outside the workspace is
+# not self-contained, so following it would let strict rollback verification
+# pass after the real source is deleted. Mirrors the legacy Dolt recipe.
+mkdir -p "$tmp/symlink-retained/.beads"
+printf 'outside retained bytes' > "$tmp/outside-retained.db"
+ln -s "$tmp/outside-retained.db" "$tmp/symlink-retained/.beads/beads.db.pre-migration"
+if classic_sqlite_artifact_manifest "$tmp/symlink-retained/.beads" ".pre-migration" >/dev/null 2>&1; then
+    fail "symlinked retained SQLite rollback artifact was accepted"
+fi
+
+mkdir -p "$tmp/symlink-source/.beads"
+printf 'outside source bytes' > "$tmp/outside-source.db"
+ln -s "$tmp/outside-source.db" "$tmp/symlink-source/.beads/beads.db"
+if preserve_sqlite_source_artifacts "$tmp/symlink-source" >/dev/null 2>&1; then
+    fail "symlinked active SQLite source was accepted"
+fi
+[ -L "$tmp/symlink-source/.beads/beads.db" ] ||
+    fail "symlinked active SQLite source preflight mutated the source link"
+[ ! -e "$tmp/symlink-source/.beads/beads.db.pre-migration" ] ||
+    fail "symlinked active SQLite source preflight left a backup"
+
+mkdir -p "$tmp/symlink-backup/.beads"
+printf 'active bytes' > "$tmp/symlink-backup/.beads/beads.db"
+printf 'outside backup bytes' > "$tmp/outside-backup.db"
+ln -s "$tmp/outside-backup.db" "$tmp/symlink-backup/.beads/beads.db.pre-migration"
+if preserve_sqlite_source_artifacts "$tmp/symlink-backup" >/dev/null 2>&1; then
+    fail "symlinked SQLite rollback artifact was accepted"
+fi
+[ "$(cat "$tmp/symlink-backup/.beads/beads.db")" = "active bytes" ] ||
+    fail "symlinked rollback preflight mutated the active source"
+
 fingerprint_root="$tmp/fingerprint-source/.beads"
 mkdir -p "$fingerprint_root/nested"
 printf 'stable bytes' > "$fingerprint_root/nested/data"

--- a/scripts/migration-test/strict-mode-test.sh
+++ b/scripts/migration-test/strict-mode-test.sh
@@ -7,7 +7,9 @@ source "$SCRIPT_DIR/lib/versions.sh"
 source "$SCRIPT_DIR/lib/binary.sh"
 source "$SCRIPT_DIR/lib/workspace.sh"
 source "$SCRIPT_DIR/lib/snapshot.sh"
+source "$SCRIPT_DIR/lib/direct_probe.sh"
 source "$SCRIPT_DIR/recipes/sqlite_to_current.sh"
+source "$SCRIPT_DIR/recipes/server_to_embedded.sh"
 
 fail() {
     echo "strict-mode-test: $*" >&2
@@ -19,15 +21,43 @@ asset=$(strict_release_asset v0.49.6 linux amd64)
 sha=$(strict_release_sha256 v0.49.6 linux amd64)
 [ "$sha" = "8546dc9a47e11dc31ac2bc9a0224a9c690975e91850932cbb62623053fbb7db8" ] || fail "unexpected release checksum"
 
+asset=$(strict_release_asset v0.55.4 linux amd64) || fail "missing v0.55.4 release asset"
+[ "$asset" = "beads_0.55.4_linux_amd64.tar.gz" ] || fail "unexpected v0.55.4 release asset"
+sha=$(strict_release_sha256 v0.55.4 linux amd64) || fail "missing v0.55.4 release checksum"
+[ "$sha" = "e0fa25456dd82890230eef17653448a0bf995104c78864be91c5ed84426a5f49" ] ||
+    fail "unexpected v0.55.4 release checksum"
+[ "$(strict_expected_status v0.55.4)" = "MANUAL" ] || fail "unexpected v0.55.4 status"
+[ "$(strict_expected_recipe v0.55.4)" = "server_to_embedded" ] || fail "unexpected v0.55.4 recipe"
+[ "$(strict_expected_features v0.55.4)" = "epic task bug dependency standalone closed label comment" ] ||
+    fail "unexpected v0.55.4 source features"
+[ "${LEGACY_DOLT_ROLLBACK_FILES[*]}" = "metadata.json config.json config.yaml issues.jsonl" ] ||
+    fail "unexpected legacy Dolt rollback file inventory"
+
+for lookup in strict_release_asset strict_release_sha256; do
+    if "$lookup" v9.9.9 linux amd64 >/dev/null 2>&1; then
+        fail "$lookup accepted an unknown release manifest"
+    fi
+done
+for lookup in strict_expected_status strict_expected_recipe strict_expected_features; do
+    if "$lookup" v9.9.9 >/dev/null 2>&1; then
+        fail "$lookup accepted an unknown qualification manifest"
+    fi
+done
+
 tmp=$(mktemp -d)
 trap 'rm -rf "$tmp"' EXIT
 printf 'not the release archive' > "$tmp/archive.tar.gz"
 if OS=linux ARCH=amd64 verify_release_archive v0.49.6 "$tmp/archive.tar.gz" >/dev/null 2>&1; then
     fail "tampered release archive was accepted"
 fi
+if OS=linux ARCH=amd64 verify_release_archive v0.55.4 "$tmp/archive.tar.gz" >/dev/null 2>&1; then
+    fail "tampered v0.55.4 release archive was accepted"
+fi
 
 strict_fixture_has_expected_features v0.49.6 epic task bug dependency standalone closed label comment ||
     fail "complete source fixture was rejected"
+strict_fixture_has_expected_features v0.55.4 epic task bug dependency standalone closed label comment ||
+    fail "complete v0.55.4 source fixture was rejected"
 if strict_fixture_has_expected_features v0.49.6 epic task bug standalone closed label >/dev/null 2>&1; then
     fail "source fixture without dependency was accepted"
 fi
@@ -36,12 +66,14 @@ if strict_fixture_has_expected_features v0.49.6 epic task bug dependency standal
 fi
 
 declare -gA DATASET_IDS=(
+    [epic]="old-epic"
     [standalone]="old-standalone"
     [closed]="old-closed"
     [task]="old-task"
     [bug]="old-bug"
 )
 printf '%s\n' '[
+  {"id":"old-epic","title":"Migration epic","description":"Epic for migration testing","priority":2,"issue_type":"epic","status":"open"},
   {"id":"old-standalone","title":"Standalone detailed task","description":"This task has a detailed description for fidelity testing.","notes":"Historical notes must survive the upgrade.","design":"Historical design must survive the upgrade.","acceptance_criteria":"Historical acceptance criteria must survive the upgrade.","external_ref":"legacy-upgrade-42","status":"open"},
   {"id":"old-closed","title":"Already closed issue","status":"closed"},
   {"id":"old-task","title":"Implement core feature","status":"open","labels":["urgent"],"comments":[{"author":"legacy-author","text":"Historical comment must survive the upgrade."}]},
@@ -49,20 +81,51 @@ printf '%s\n' '[
 ]' > "$tmp/fixture.json"
 strict_snapshot_has_expected_fixture v0.49.6 "$tmp/fixture.json" ||
     fail "exact v0.49.6 source fixture was rejected"
+strict_snapshot_has_expected_fixture v0.55.4 "$tmp/fixture.json" ||
+    fail "exact v0.55.4 source fixture was rejected"
+jq 'map(select(.id != "old-epic"))' "$tmp/fixture.json" > "$tmp/fixture-four-items.json"
+for version in v0.49.6 v0.55.4; do
+    if strict_snapshot_has_expected_fixture "$version" "$tmp/fixture-four-items.json" >/dev/null 2>&1; then
+        fail "$version source fixture with four items was accepted"
+    fi
+done
+jq '. + [{"id":"old-extra","title":"Unexpected extra issue"}]' \
+    "$tmp/fixture.json" > "$tmp/fixture-six-items.json"
+for version in v0.49.6 v0.55.4; do
+    if strict_snapshot_has_expected_fixture "$version" "$tmp/fixture-six-items.json" >/dev/null 2>&1; then
+        fail "$version source fixture with six items was accepted"
+    fi
+done
+jq 'map(if .id == "old-epic" then .issue_type = "task" else . end)' \
+    "$tmp/fixture.json" > "$tmp/fixture-wrong-epic.json"
+for version in v0.49.6 v0.55.4; do
+    if strict_snapshot_has_expected_fixture "$version" "$tmp/fixture-wrong-epic.json" >/dev/null 2>&1; then
+        fail "$version source fixture with an inexact epic was accepted"
+    fi
+done
 jq 'map(if .id == "old-standalone" then .external_ref = null else . end)' \
     "$tmp/fixture.json" > "$tmp/fixture-missing-rich-field.json"
 if strict_snapshot_has_expected_fixture v0.49.6 "$tmp/fixture-missing-rich-field.json" >/dev/null 2>&1; then
     fail "source fixture without the exact rich fields was accepted"
+fi
+if strict_snapshot_has_expected_fixture v0.55.4 "$tmp/fixture-missing-rich-field.json" >/dev/null 2>&1; then
+    fail "v0.55.4 source fixture without the exact rich fields was accepted"
 fi
 jq 'map(if .id == "old-task" then .labels = [] else . end)' \
     "$tmp/fixture.json" > "$tmp/fixture-missing-label.json"
 if strict_snapshot_has_expected_fixture v0.49.6 "$tmp/fixture-missing-label.json" >/dev/null 2>&1; then
     fail "source fixture without the exact label was accepted"
 fi
+if strict_snapshot_has_expected_fixture v0.55.4 "$tmp/fixture-missing-label.json" >/dev/null 2>&1; then
+    fail "v0.55.4 source fixture without the exact label was accepted"
+fi
 jq 'map(if .id == "old-bug" then .dependencies = [] else . end)' \
     "$tmp/fixture.json" > "$tmp/fixture-missing-dependency.json"
 if strict_snapshot_has_expected_fixture v0.49.6 "$tmp/fixture-missing-dependency.json" >/dev/null 2>&1; then
     fail "source fixture without the exact dependency was accepted"
+fi
+if strict_snapshot_has_expected_fixture v0.55.4 "$tmp/fixture-missing-dependency.json" >/dev/null 2>&1; then
+    fail "v0.55.4 source fixture without the exact dependency was accepted"
 fi
 
 mkdir -p "$tmp/source/.beads"
@@ -89,6 +152,218 @@ fi
     fail "rollback collision mutated the active source"
 [ ! -e "$tmp/collision/.beads/beads.db.pre-migration" ] ||
     fail "rollback preflight left a partial backup before reporting collision"
+
+fingerprint_root="$tmp/fingerprint-source/.beads"
+mkdir -p "$fingerprint_root/nested"
+printf 'stable bytes' > "$fingerprint_root/nested/data"
+ln -s nested/data "$fingerprint_root/data-link"
+fingerprint_one=$(source_artifact_fingerprint "$fingerprint_root") ||
+    fail "stable historical source could not be fingerprinted"
+fingerprint_two=$(source_artifact_fingerprint "$fingerprint_root") ||
+    fail "stable historical source could not be fingerprinted twice"
+[ "$fingerprint_one" = "$fingerprint_two" ] ||
+    fail "stable historical source produced different fingerprints"
+
+if (
+    find() { command find "$@"; return 1; }
+    source_artifact_fingerprint "$fingerprint_root"
+) >/dev/null 2>&1; then
+    fail "historical source fingerprint ignored a failed find"
+fi
+if (
+    stat() { return 1; }
+    source_artifact_fingerprint "$fingerprint_root"
+) >/dev/null 2>&1; then
+    fail "historical source fingerprint ignored a failed stat"
+fi
+if (
+    sha256_file() {
+        if [ "$1" = "./nested/data" ]; then
+            return 1
+        fi
+        sha256sum -- "$1" | awk '{print $1}'
+    }
+    source_artifact_fingerprint "$fingerprint_root"
+) >/dev/null 2>&1; then
+    fail "historical source fingerprint ignored a failed checksum"
+fi
+if (
+    sha256_file() {
+        if [[ "$1" == */bd-source-fingerprint.* ]]; then
+            return 1
+        fi
+        sha256sum -- "$1" | awk '{print $1}'
+    }
+    source_artifact_fingerprint "$fingerprint_root"
+) >/dev/null 2>&1; then
+    fail "historical source fingerprint ignored a failed final digest"
+fi
+if (
+    readlink() { return 1; }
+    source_artifact_fingerprint "$fingerprint_root"
+) >/dev/null 2>&1; then
+    fail "historical source fingerprint ignored a failed readlink"
+fi
+mkfifo "$fingerprint_root/unsupported-fifo"
+if source_artifact_fingerprint "$fingerprint_root" >/dev/null 2>&1; then
+    fail "historical source fingerprint accepted a special file"
+fi
+rm -f "$fingerprint_root/unsupported-fifo"
+printf 'changed bytes' >> "$fingerprint_root/nested/data"
+fingerprint_changed=$(source_artifact_fingerprint "$fingerprint_root") ||
+    fail "changed historical source could not be fingerprinted"
+[ "$fingerprint_changed" != "$fingerprint_one" ] ||
+    fail "historical source fingerprint ignored changed file bytes"
+
+mkdir -p "$tmp/legacy-source/.beads/dolt/nested"
+printf 'legacy table bytes' > "$tmp/legacy-source/.beads/dolt/nested/table.dat"
+printf 'legacy metadata' > "$tmp/legacy-source/.beads/metadata.json"
+printf 'legacy config json' > "$tmp/legacy-source/.beads/config.json"
+printf 'legacy config yaml' > "$tmp/legacy-source/.beads/config.yaml"
+legacy_manifest=$(legacy_dolt_artifact_manifest "$tmp/legacy-source/.beads")
+preserve_legacy_dolt_source "$tmp/legacy-source" "$legacy_manifest" ||
+    fail "unchanged legacy Dolt source could not be preserved"
+verify_retained_legacy_dolt_source "$tmp/legacy-source/.beads" "$legacy_manifest" ||
+    fail "unchanged retained legacy Dolt source was rejected"
+printf 'corruption' >> "$tmp/legacy-source/.beads/legacy-dolt.pre-migration/config.yaml"
+if verify_retained_legacy_dolt_source "$tmp/legacy-source/.beads" "$legacy_manifest" >/dev/null 2>&1; then
+    fail "mutated retained legacy Dolt source was accepted"
+fi
+
+mkdir -p "$tmp/legacy-collision/.beads/dolt" \
+    "$tmp/legacy-collision/.beads/legacy-dolt.pre-migration/dolt"
+printf 'active legacy data' > "$tmp/legacy-collision/.beads/dolt/table.dat"
+printf 'active metadata' > "$tmp/legacy-collision/.beads/metadata.json"
+printf 'stale legacy data' > "$tmp/legacy-collision/.beads/legacy-dolt.pre-migration/dolt/table.dat"
+collision_manifest=$(legacy_dolt_artifact_manifest "$tmp/legacy-collision/.beads")
+if preserve_legacy_dolt_source "$tmp/legacy-collision" "$collision_manifest" >/dev/null 2>&1; then
+    fail "stale legacy Dolt rollback collision was accepted"
+fi
+[ "$(legacy_dolt_artifact_manifest "$tmp/legacy-collision/.beads")" = "$collision_manifest" ] ||
+    fail "legacy Dolt rollback collision mutated the active source"
+if find "$tmp/legacy-collision/.beads" -maxdepth 1 \
+    -name '.legacy-dolt.pre-migration.tmp.*' -print -quit | grep -q .; then
+    fail "legacy Dolt rollback collision left a partial temporary backup"
+fi
+
+mkdir -p "$tmp/legacy-partial/.beads/dolt"
+printf 'active legacy data' > "$tmp/legacy-partial/.beads/dolt/table.dat"
+printf 'active metadata' > "$tmp/legacy-partial/.beads/metadata.json"
+partial_manifest=$(legacy_dolt_artifact_manifest "$tmp/legacy-partial/.beads")
+cp() {
+    local arg
+    for arg in "$@"; do
+        if [[ "$arg" == */metadata.json ]]; then
+            return 1
+        fi
+    done
+    command cp "$@"
+}
+if preserve_legacy_dolt_source "$tmp/legacy-partial" "$partial_manifest" >/dev/null 2>&1; then
+    unset -f cp
+    fail "partial legacy Dolt rollback copy was accepted"
+fi
+unset -f cp
+[ ! -e "$tmp/legacy-partial/.beads/legacy-dolt.pre-migration" ] ||
+    fail "partial legacy Dolt rollback copy published an incomplete backup"
+if find "$tmp/legacy-partial/.beads" -maxdepth 1 \
+    -name '.legacy-dolt.pre-migration.tmp.*' -print -quit | grep -q .; then
+    fail "partial legacy Dolt rollback copy left a temporary backup"
+fi
+[ "$(legacy_dolt_artifact_manifest "$tmp/legacy-partial/.beads")" = "$partial_manifest" ] ||
+    fail "partial legacy Dolt rollback copy mutated the active source"
+
+legacy_extra_ws="$tmp/legacy-extra"
+mkdir -p "$legacy_extra_ws/.beads/dolt"
+printf 'active data' > "$legacy_extra_ws/.beads/dolt/table.dat"
+printf 'active metadata' > "$legacy_extra_ws/.beads/metadata.json"
+legacy_extra_manifest=$(legacy_dolt_artifact_manifest "$legacy_extra_ws/.beads")
+preserve_legacy_dolt_source "$legacy_extra_ws" "$legacy_extra_manifest" ||
+    fail "could not create exact rollback source for extra-inventory test"
+printf 'stale extra' > "$legacy_extra_ws/.beads/legacy-dolt.pre-migration/unexpected"
+if verify_retained_legacy_dolt_source \
+    "$legacy_extra_ws/.beads" "$legacy_extra_manifest" >/dev/null 2>&1; then
+    fail "retained legacy Dolt source accepted unexpected top-level content"
+fi
+if preserve_legacy_dolt_source "$legacy_extra_ws" "$legacy_extra_manifest" >/dev/null 2>&1; then
+    fail "legacy Dolt preservation reused a rollback source with extra content"
+fi
+[ "$(legacy_dolt_artifact_manifest "$legacy_extra_ws/.beads")" = "$legacy_extra_manifest" ] ||
+    fail "extra rollback collision mutated the active legacy source"
+
+legacy_race_ws="$tmp/legacy-publish-race"
+legacy_race_calls="$tmp/legacy-publish-race.calls"
+legacy_race_old_bin="$tmp/fake-race-old-bd"
+legacy_race_candidate_bin="$tmp/fake-race-candidate-bd"
+legacy_race_before="$tmp/legacy-publish-race-before.json"
+mkdir -p "$legacy_race_ws/.beads/dolt"
+printf 'active race data' > "$legacy_race_ws/.beads/dolt/table.dat"
+printf 'active race metadata' > "$legacy_race_ws/.beads/metadata.json"
+legacy_race_manifest=$(legacy_dolt_artifact_manifest "$legacy_race_ws/.beads")
+printf '%s\n' '[{"id":"race-1"}]' > "$legacy_race_before"
+cat > "$legacy_race_old_bin" <<'EOF'
+#!/bin/bash
+printf 'old:%s\n' "$*" >> "$LEGACY_RACE_CALLS"
+exit 2
+EOF
+cat > "$legacy_race_candidate_bin" <<'EOF'
+#!/bin/bash
+printf 'candidate:%s\n' "$*" >> "$LEGACY_RACE_CALLS"
+exit 2
+EOF
+chmod +x "$legacy_race_old_bin" "$legacy_race_candidate_bin"
+export LEGACY_RACE_CALLS="$legacy_race_calls"
+: > "$legacy_race_calls"
+if (
+    stop_dolt_server() { :; }
+    publish_legacy_dolt_rollback() {
+        local source="$1"
+        local destination="$2"
+        mkdir -p "$destination"
+        printf 'racer sentinel' > "$destination/racer"
+        command mv --no-target-directory --no-clobber --no-copy -- "$source" "$destination"
+    }
+    recipe_server_to_embedded \
+        "$legacy_race_ws" "$legacy_race_old_bin" "$legacy_race_candidate_bin" \
+        v0.55.4 "$legacy_race_before"
+) >/dev/null 2>&1; then
+    fail "legacy Dolt rollback publication accepted a racing destination"
+fi
+[ ! -s "$legacy_race_calls" ] ||
+    fail "rollback publication race invoked a migration binary"
+[ "$(legacy_dolt_artifact_manifest "$legacy_race_ws/.beads")" = "$legacy_race_manifest" ] ||
+    fail "rollback publication race mutated the active legacy source"
+[ "$(cat "$legacy_race_ws/.beads/legacy-dolt.pre-migration/racer")" = "racer sentinel" ] ||
+    fail "rollback publication race replaced the competing destination"
+if find "$legacy_race_ws/.beads" -maxdepth 2 \
+    -name '.legacy-dolt.pre-migration.tmp.*' -print -quit | grep -q .; then
+    fail "rollback publication race left a temporary copy"
+fi
+
+[ "$(server_bridge_strategy v0.55.4)" = "native_export" ] ||
+    fail "v0.55.4 did not select its pinned server bridge strategy"
+for unsupported_version in v0.56.1 v0.57.0 v0.58.0 v9.9.9; do
+    if server_bridge_strategy "$unsupported_version" >/dev/null 2>&1; then
+        fail "$unsupported_version unexpectedly selected a server bridge strategy"
+    fi
+done
+
+unsupported_ws="$tmp/unsupported-server-bridge"
+unsupported_calls="$tmp/unsupported-server-bridge.calls"
+mkdir -p "$unsupported_ws/.beads/dolt"
+printf 'unsupported data' > "$unsupported_ws/.beads/dolt/table.dat"
+unsupported_fingerprint=$(source_artifact_fingerprint "$unsupported_ws/.beads")
+export LEGACY_RACE_CALLS="$unsupported_calls"
+: > "$unsupported_calls"
+if recipe_server_to_embedded \
+    "$unsupported_ws" "$legacy_race_old_bin" "$legacy_race_candidate_bin" \
+    v0.56.1 "$legacy_race_before" >/dev/null 2>&1; then
+    fail "unqualified v0.56.1 server bridge was accepted"
+fi
+[ ! -s "$unsupported_calls" ] ||
+    fail "unqualified server bridge invoked a migration binary"
+[ "$(source_artifact_fingerprint "$unsupported_ws/.beads")" = "$unsupported_fingerprint" ] ||
+    fail "unqualified server bridge mutated the historical source"
 
 RESULT_PATHS=("v0.49.6 → candidate")
 RESULT_STATUSES=("MANUAL")
@@ -133,6 +408,470 @@ printf '%s\n' \
 if check_fidelity v0.49.6 "$tmp/before-comment.json" "$tmp/after-comment.json" >/dev/null 2>&1; then
     fail "strict fidelity accepted changed comment text"
 fi
+
+snapshot_contract_ws="$tmp/snapshot-contract-workspace"
+snapshot_contract_bin="$tmp/fake-snapshot-contract-bd"
+mkdir -p "$snapshot_contract_ws"
+cat > "$snapshot_contract_bin" <<'EOF'
+#!/bin/bash
+case "$1" in
+    list)
+        case "$SNAPSHOT_LIST_SHAPE" in
+            array) printf '%s\n' '[{"id":"old-1","title":"One"}]' ;;
+            empty-id) printf '%s\n' '[{"id":"","title":"One"}]' ;;
+            object) printf '%s\n' '{"id":"old-1","title":"One"}' ;;
+            invalid) printf '%s\n' 'not JSON' ;;
+            *) exit 2 ;;
+        esac
+        [ "$SNAPSHOT_FAIL_COMMAND" != "list" ]
+        ;;
+    show)
+        printf '%s\n' '[{"id":"old-1","title":"One"}]'
+        [ "$SNAPSHOT_FAIL_COMMAND" != "show" ]
+        ;;
+    *)
+        exit 2
+        ;;
+esac
+EOF
+chmod +x "$snapshot_contract_bin"
+DATASET_IDS=([one]="old-1")
+
+assert_strict_snapshot_rejected() {
+    local name="$1"
+    local list_shape="$2"
+    local fail_command="$3"
+    export SNAPSHOT_LIST_SHAPE="$list_shape"
+    export SNAPSHOT_FAIL_COMMAND="$fail_command"
+    if capture_snapshot "$snapshot_contract_ws" "$snapshot_contract_bin" \
+        > "$tmp/rejected-snapshot.json" 2>/dev/null; then
+        fail "strict snapshot accepted $name"
+    fi
+}
+
+assert_strict_snapshot_rejected "valid list JSON from a nonzero command" array list
+assert_strict_snapshot_rejected "valid show JSON from a nonzero command" array show
+assert_strict_snapshot_rejected "malformed list JSON" invalid none
+assert_strict_snapshot_rejected "a list JSON object" object none
+assert_strict_snapshot_rejected "a list item with an empty id" empty-id none
+
+blocker_contract_ws="$tmp/blocker-contract-workspace"
+blocker_contract_bin="$tmp/fake-blocker-contract-bd"
+mkdir -p "$blocker_contract_ws"
+cat > "$blocker_contract_bin" <<'EOF'
+#!/bin/bash
+case "$1" in
+    blocked)
+        printf '%s\n' '[{"id":"old-bug"}]'
+        [ "$BLOCKER_FAIL_COMMAND" != "blocked" ]
+        ;;
+    ready)
+        if [ -e "$BLOCKER_STATE" ]; then
+            printf '%s\n' '[{"id":"old-bug"}]'
+        else
+            printf '%s\n' '[{"id":"old-task"}]'
+        fi
+        [ "$BLOCKER_FAIL_COMMAND" != "ready" ]
+        ;;
+    close)
+        : > "$BLOCKER_STATE"
+        ;;
+    *)
+        exit 2
+        ;;
+esac
+EOF
+chmod +x "$blocker_contract_bin"
+DATASET_FEATURES=("dependency")
+DATASET_IDS=([task]="old-task" [bug]="old-bug")
+export BLOCKER_STATE="$tmp/blocker-contract-closed"
+
+assert_blocker_command_failures_counted() {
+    local command="$1"
+    local expected_violations="$2"
+    local violations=0
+    export BLOCKER_FAIL_COMMAND="$command"
+    rm -f "$BLOCKER_STATE"
+    check_blocker_paths "$blocker_contract_ws" "$blocker_contract_bin" \
+        >/dev/null 2>&1 || violations=$?
+    [ "$violations" -eq "$expected_violations" ] ||
+        fail "nonzero $command produced $violations blocker violations, want $expected_violations"
+}
+
+assert_blocker_command_failures_counted blocked 1
+assert_blocker_command_failures_counted ready 2
+
+jsonl_contract_snapshot="$tmp/jsonl-contract-snapshot.json"
+jsonl_contract_file="$tmp/jsonl-contract.jsonl"
+printf '%s\n' '[{"id":"jsonl-1"},{"id":"jsonl-2"}]' > "$jsonl_contract_snapshot"
+printf '%s\n' '{"id":"jsonl-2"}' '{"id":"jsonl-1"}' > "$jsonl_contract_file"
+migration_jsonl_matches_snapshot "$jsonl_contract_file" "$jsonl_contract_snapshot" ||
+    fail "valid reordered historical JSONL did not match its source snapshot"
+
+assert_jsonl_contract_rejected() {
+    local name="$1"
+    shift
+    printf '%s\n' "$@" > "$jsonl_contract_file"
+    if migration_jsonl_matches_snapshot \
+        "$jsonl_contract_file" "$jsonl_contract_snapshot" >/dev/null 2>&1; then
+        fail "historical JSONL contract accepted $name"
+    fi
+}
+
+assert_jsonl_contract_rejected "malformed JSON" 'not JSON'
+assert_jsonl_contract_rejected "a blank record" '{"id":"jsonl-1"}' '   ' '{"id":"jsonl-2"}'
+assert_jsonl_contract_rejected "a duplicate id" '{"id":"jsonl-1"}' '{"id":"jsonl-1"}'
+assert_jsonl_contract_rejected "a missing id" '{"title":"missing"}' '{"id":"jsonl-2"}'
+assert_jsonl_contract_rejected "an empty id" '{"id":""}' '{"id":"jsonl-2"}'
+assert_jsonl_contract_rejected "an array record" '[{"id":"jsonl-1"}]' '{"id":"jsonl-2"}'
+assert_jsonl_contract_rejected "an extra id" '{"id":"jsonl-1"}' '{"id":"jsonl-2"}' '{"id":"jsonl-3"}'
+assert_jsonl_contract_rejected "a missing source id" '{"id":"jsonl-1"}'
+printf '%s\n' '{"id":"jsonl-1"} {"id":"jsonl-2"}' > "$jsonl_contract_file"
+if migration_jsonl_matches_snapshot \
+    "$jsonl_contract_file" "$jsonl_contract_snapshot" >/dev/null 2>&1; then
+    fail "historical JSONL contract accepted two records on one line"
+fi
+
+server_export_ws="$tmp/server-export-workspace"
+server_export_calls="$tmp/server-export-calls"
+server_export_old_bin="$tmp/fake-v0.55.4-bd"
+server_export_candidate_bin="$tmp/fake-candidate-bd"
+server_export_before="$tmp/server-export-before.json"
+mkdir -p "$server_export_ws/.beads/dolt"
+printf 'legacy Dolt data' > "$server_export_ws/.beads/dolt/table.dat"
+printf 'legacy metadata' > "$server_export_ws/.beads/metadata.json"
+printf '%s\n' '{"id":"old-task","title":"stale passive export"}' \
+    > "$server_export_ws/.beads/issues.jsonl"
+server_export_original_jsonl=$(sha256_file "$server_export_ws/.beads/issues.jsonl")
+: > "$server_export_calls"
+printf '%s\n' '[{"id":"old-task","title":"Implement core feature"}]' > "$server_export_before"
+cat > "$server_export_old_bin" <<'EOF'
+#!/bin/bash
+printf '%s\n' "$*" >> "$SERVER_EXPORT_CALLS"
+case "$1" in
+    list)
+        printf '%s\n' '[{"id":"old-task","title":"Implement core feature","comment_count":1}]'
+        ;;
+    export)
+        [ "$#" -eq 5 ] && [ "$2" = "--format" ] && [ "$3" = "jsonl" ] &&
+            [ "$4" = "-o" ] && [ -n "$5" ] || exit 2
+        printf '%s\n' '{"id":"old-task","title":"Implement core feature","comments":[{"author":"legacy-author","text":"Historical comment must survive the upgrade."}]}' > "$5"
+        ;;
+    *)
+        exit 2
+        ;;
+esac
+EOF
+cat > "$server_export_candidate_bin" <<'EOF'
+#!/bin/bash
+[ "$1" = "init" ] || exit 2
+for arg in "$@"; do
+    if [ "$arg" = "--from-jsonl" ]; then
+        jq -e 'select(.id == "old-task") | any(.comments[]?; .author == "legacy-author" and .text == "Historical comment must survive the upgrade.")' \
+            .beads/issues.jsonl >/dev/null
+        exit
+    fi
+done
+exit 1
+EOF
+chmod +x "$server_export_old_bin" "$server_export_candidate_bin"
+export SERVER_EXPORT_CALLS="$server_export_calls"
+if ! recipe_server_to_embedded \
+    "$server_export_ws" "$server_export_old_bin" "$server_export_candidate_bin" \
+    v0.55.4 "$server_export_before" \
+    >/dev/null; then
+    fail "server-to-embedded recipe lost comments exposed only by historical export"
+fi
+grep -E "^export --format jsonl -o $server_export_ws/\.beads/\.issues\.jsonl\.migration\.tmp\." \
+    "$server_export_calls" >/dev/null ||
+    fail "server-to-embedded recipe did not invoke historical export with an output path"
+jq -e 'select(.id == "old-task") | any(.comments[]?; .author == "legacy-author" and .text == "Historical comment must survive the upgrade.")' \
+    "$server_export_ws/.beads/issues.jsonl" >/dev/null ||
+    fail "server-to-embedded JSONL export omitted the historical comment body"
+[ "$(sha256_file "$server_export_ws/.beads/legacy-dolt.pre-migration/issues.jsonl")" = \
+    "$server_export_original_jsonl" ] ||
+    fail "server-to-embedded recipe did not retain the original passive JSONL"
+
+server_export_fail_ws="$tmp/server-export-failure-workspace"
+server_export_fail_old_bin="$tmp/fake-failing-v0.55.4-bd"
+server_export_fail_candidate_bin="$tmp/fake-unexpected-candidate-bd"
+server_export_fail_candidate_calls="$tmp/server-export-failure-candidate-calls"
+mkdir -p "$server_export_fail_ws/.beads/dolt"
+printf 'active legacy Dolt data' > "$server_export_fail_ws/.beads/dolt/table.dat"
+printf 'active legacy metadata' > "$server_export_fail_ws/.beads/metadata.json"
+server_export_fail_manifest=$(legacy_dolt_artifact_manifest "$server_export_fail_ws/.beads")
+cat > "$server_export_fail_old_bin" <<'EOF'
+#!/bin/bash
+[ "$1" = "export" ] || exit 2
+exit 1
+EOF
+cat > "$server_export_fail_candidate_bin" <<'EOF'
+#!/bin/bash
+printf '%s\n' "$*" >> "$SERVER_EXPORT_FAIL_CANDIDATE_CALLS"
+exit 1
+EOF
+chmod +x "$server_export_fail_old_bin" "$server_export_fail_candidate_bin"
+export SERVER_EXPORT_FAIL_CANDIDATE_CALLS="$server_export_fail_candidate_calls"
+: > "$server_export_fail_candidate_calls"
+if (
+    stop_dolt_server() { :; }
+    recipe_server_to_embedded \
+        "$server_export_fail_ws" "$server_export_fail_old_bin" \
+        "$server_export_fail_candidate_bin" v0.55.4 "$server_export_before"
+) >/dev/null; then
+    fail "server-to-embedded recipe accepted a failed historical export"
+fi
+server_export_fail_after=$(legacy_dolt_artifact_manifest "$server_export_fail_ws/.beads") ||
+    fail "failed historical export removed the active legacy source"
+[ "$server_export_fail_after" = "$server_export_fail_manifest" ] ||
+    fail "failed historical export mutated the active legacy source"
+[ ! -s "$server_export_fail_candidate_calls" ] ||
+    fail "failed historical export still invoked the candidate"
+verify_retained_legacy_dolt_source \
+    "$server_export_fail_ws/.beads" "$server_export_fail_manifest" ||
+    fail "failed historical export corrupted the retained rollback source"
+
+server_export_malformed_ws="$tmp/server-export-malformed-workspace"
+server_export_malformed_old_bin="$tmp/fake-malformed-v0.55.4-bd"
+mkdir -p "$server_export_malformed_ws/.beads/dolt"
+printf 'active malformed-test data' > "$server_export_malformed_ws/.beads/dolt/table.dat"
+printf 'active malformed-test metadata' > "$server_export_malformed_ws/.beads/metadata.json"
+server_export_malformed_manifest=$(legacy_dolt_artifact_manifest "$server_export_malformed_ws/.beads")
+cat > "$server_export_malformed_old_bin" <<'EOF'
+#!/bin/bash
+[ "$1" = "export" ] && [ "$4" = "-o" ] && [ -n "$5" ] || exit 2
+printf '%s\n' 'not JSONL' > "$5"
+EOF
+chmod +x "$server_export_malformed_old_bin"
+: > "$server_export_fail_candidate_calls"
+if (
+    stop_dolt_server() { :; }
+    recipe_server_to_embedded \
+        "$server_export_malformed_ws" "$server_export_malformed_old_bin" \
+        "$server_export_fail_candidate_bin" v0.55.4 "$server_export_before"
+) >/dev/null; then
+    fail "server-to-embedded recipe accepted malformed historical JSONL"
+fi
+[ ! -s "$server_export_fail_candidate_calls" ] ||
+    fail "malformed historical export still invoked the candidate"
+[ "$(legacy_dolt_artifact_manifest "$server_export_malformed_ws/.beads")" = \
+    "$server_export_malformed_manifest" ] ||
+    fail "malformed historical export mutated the active legacy source"
+[ ! -e "$server_export_malformed_ws/.beads/issues.jsonl" ] ||
+    fail "malformed historical export was published"
+if find "$server_export_malformed_ws/.beads" -maxdepth 1 \
+    -name '.issues.jsonl.migration.tmp.*' -print -quit | grep -q .; then
+    fail "malformed historical export left a temporary file"
+fi
+
+server_export_symlink_ws="$tmp/server-export-symlink-workspace"
+server_export_symlink_target="$tmp/server-export-symlink-target"
+mkdir -p "$server_export_symlink_ws/.beads/dolt"
+printf 'active symlink-test data' > "$server_export_symlink_ws/.beads/dolt/table.dat"
+printf 'external sentinel' > "$server_export_symlink_target"
+ln -s "$server_export_symlink_target" "$server_export_symlink_ws/.beads/issues.jsonl"
+if recipe_server_to_embedded \
+    "$server_export_symlink_ws" "$server_export_fail_old_bin" \
+    "$server_export_fail_candidate_bin" v0.55.4 "$server_export_before" \
+    >/dev/null 2>&1; then
+    fail "server-to-embedded recipe accepted a symlinked JSONL destination"
+fi
+[ "$(cat "$server_export_symlink_target")" = "external sentinel" ] ||
+    fail "server-to-embedded recipe followed a symlinked JSONL destination"
+[ ! -e "$server_export_symlink_ws/.beads/legacy-dolt.pre-migration" ] ||
+    fail "unsafe JSONL destination was detected only after rollback mutation"
+
+rollback_corruption_ws="$tmp/rollback-corruption-workspace"
+rollback_corruption_old_bin="$tmp/fake-rollback-corrupting-v0.55.4-bd"
+rollback_corruption_candidate_calls="$tmp/rollback-corruption-candidate.calls"
+mkdir -p "$rollback_corruption_ws/.beads/dolt"
+printf 'active corruption-test data' > "$rollback_corruption_ws/.beads/dolt/table.dat"
+printf 'active corruption-test metadata' > "$rollback_corruption_ws/.beads/metadata.json"
+printf 'active corruption-test config' > "$rollback_corruption_ws/.beads/config.yaml"
+cat > "$rollback_corruption_old_bin" <<'EOF'
+#!/bin/bash
+[ "$1" = "export" ] && [ "$4" = "-o" ] && [ -n "$5" ] || exit 2
+printf '%s\n' '{"id":"old-task","title":"Implement core feature"}' > "$5"
+printf 'corrupted during export' >> .beads/legacy-dolt.pre-migration/metadata.json
+EOF
+chmod +x "$rollback_corruption_old_bin"
+export SERVER_EXPORT_FAIL_CANDIDATE_CALLS="$rollback_corruption_candidate_calls"
+: > "$rollback_corruption_candidate_calls"
+if (
+    stop_dolt_server() { :; }
+    recipe_server_to_embedded \
+        "$rollback_corruption_ws" "$rollback_corruption_old_bin" \
+        "$server_export_fail_candidate_bin" v0.55.4 "$server_export_before"
+) >/dev/null 2>&1; then
+    fail "server-to-embedded recipe accepted rollback corruption during export"
+fi
+[ ! -s "$rollback_corruption_candidate_calls" ] ||
+    fail "rollback corruption during export still invoked the candidate"
+[ "$(cat "$rollback_corruption_ws/.beads/metadata.json")" = \
+    "active corruption-test metadata" ] ||
+    fail "rollback corruption caused active metadata deletion"
+[ "$(cat "$rollback_corruption_ws/.beads/config.yaml")" = \
+    "active corruption-test config" ] ||
+    fail "rollback corruption changed active config"
+[ "$(cat "$rollback_corruption_ws/.beads/dolt/table.dat")" = \
+    "active corruption-test data" ] ||
+    fail "rollback corruption changed active Dolt data"
+
+metadata_removal_ws="$tmp/metadata-removal-failure-workspace"
+metadata_removal_old_calls="$tmp/metadata-removal-old.calls"
+metadata_removal_candidate_calls="$tmp/metadata-removal-candidate.calls"
+mkdir -p "$metadata_removal_ws/.beads/dolt"
+printf 'active removal-test data' > "$metadata_removal_ws/.beads/dolt/table.dat"
+printf 'active removal-test metadata' > "$metadata_removal_ws/.beads/metadata.json"
+export SERVER_EXPORT_CALLS="$metadata_removal_old_calls"
+export SERVER_EXPORT_FAIL_CANDIDATE_CALLS="$metadata_removal_candidate_calls"
+: > "$metadata_removal_old_calls"
+: > "$metadata_removal_candidate_calls"
+if (
+    stop_dolt_server() { :; }
+    rm() {
+        local arg
+        for arg in "$@"; do
+            if [[ "$arg" == */metadata.json ]]; then
+                return 1
+            fi
+        done
+        command rm "$@"
+    }
+    recipe_server_to_embedded \
+        "$metadata_removal_ws" "$server_export_old_bin" \
+        "$server_export_fail_candidate_bin" v0.55.4 "$server_export_before"
+) >/dev/null; then
+    fail "server-to-embedded recipe ignored active metadata removal failure"
+fi
+[ ! -s "$metadata_removal_candidate_calls" ] ||
+    fail "active metadata removal failure still invoked the candidate"
+[ "$(cat "$metadata_removal_ws/.beads/metadata.json")" = \
+    "active removal-test metadata" ] ||
+    fail "active metadata removal failure changed metadata"
+[ "$(cat "$metadata_removal_ws/.beads/dolt/table.dat")" = \
+    "active removal-test data" ] ||
+    fail "active metadata removal failure changed Dolt data"
+
+probe_list_ws="$tmp/probe-list-workspace"
+probe_list_bin="$tmp/fake-probe-list-bd"
+mkdir -p "$probe_list_ws"
+cat > "$probe_list_bin" <<'EOF'
+#!/bin/bash
+[ "$1" = "list" ] || exit 2
+printf '%s' "$PROBE_LIST_OUTPUT"
+exit "$PROBE_LIST_EXIT"
+EOF
+chmod +x "$probe_list_bin"
+
+assert_probe_list_rejected() {
+    local name="$1"
+    local output="$2"
+    local exit_code="$3"
+    export PROBE_LIST_OUTPUT="$output"
+    export PROBE_LIST_EXIT="$exit_code"
+    if candidate_list_has_nonempty_issue_ids "$probe_list_ws" "$probe_list_bin"; then
+        fail "candidate list probe accepted $name"
+    fi
+}
+
+assert_probe_list_rejected "invalid output" 'not JSON' 0
+assert_probe_list_rejected "valid JSON from a nonzero command" '[{"id":"old-1"}]' 1
+assert_probe_list_rejected "an empty array" '[]' 0
+assert_probe_list_rejected "a JSON object" '{"id":"old-1"}' 0
+assert_probe_list_rejected "an empty issue id" '[{"id":""}]' 0
+assert_probe_list_rejected "a non-string issue id" '[{"id":7}]' 0
+assert_probe_list_rejected "multiple JSON documents" $'[{"id":"old-1"}]\n[{"id":"old-2"}]' 0
+export PROBE_LIST_OUTPUT='[{"id":"old-1"},{"id":"old-2"}]'
+export PROBE_LIST_EXIT=0
+candidate_list_has_nonempty_issue_ids "$probe_list_ws" "$probe_list_bin" ||
+    fail "candidate list probe rejected a valid nonempty issue array"
+
+probe_flow_bin="$tmp/fake-probe-flow-bd"
+cat > "$probe_flow_bin" <<'EOF'
+#!/bin/bash
+printf '%s\n' "$1" >> "$PROBE_FLOW_LOG"
+case "$PROBE_FLOW_MODE:$1" in
+    first-list-mutation:list)
+        printf 'mutated\n' >> .beads/source-marker
+        exit 1
+        ;;
+    init-mutation:list|safe-failure:list)
+        exit 1
+        ;;
+    init-mutation:init)
+        printf 'mutated\n' >> .beads/source-marker
+        exit 1
+        ;;
+    safe-failure:init)
+        exit 1
+        ;;
+    second-list-mutation:list|retry-success:list)
+        count=0
+        [ ! -f "$PROBE_FLOW_STATE" ] || count=$(cat "$PROBE_FLOW_STATE")
+        count=$((count + 1))
+        printf '%s\n' "$count" > "$PROBE_FLOW_STATE"
+        if [ "$count" -eq 1 ]; then
+            exit 1
+        fi
+        if [ "$PROBE_FLOW_MODE" = "second-list-mutation" ]; then
+            printf 'mutated\n' >> .beads/source-marker
+            printf '%s\n' '[]'
+        else
+            printf '%s\n' '[{"id":"old-1"}]'
+        fi
+        ;;
+    second-list-mutation:init|retry-success:init)
+        exit 0
+        ;;
+    *)
+        exit 2
+        ;;
+esac
+EOF
+chmod +x "$probe_flow_bin"
+
+assert_probe_flow() {
+    local mode="$1"
+    local expected_status="$2"
+    local expected_calls="$3"
+    local ws="$tmp/probe-flow-$mode"
+    local status=0
+    local actual_calls
+    local source_fingerprint
+
+    mkdir -p "$ws/.beads"
+    printf 'original\n' > "$ws/.beads/source-marker"
+    export PROBE_FLOW_MODE="$mode"
+    export PROBE_FLOW_LOG="$tmp/probe-flow-$mode.calls"
+    export PROBE_FLOW_STATE="$tmp/probe-flow-$mode.state"
+    : > "$PROBE_FLOW_LOG"
+    rm -f "$PROBE_FLOW_STATE"
+    source_fingerprint=$(source_artifact_fingerprint "$ws/.beads") ||
+        fail "could not fingerprint fake probe source for $mode"
+
+    if (
+        stop_dolt_server() { :; }
+        probe_candidate_direct_upgrade "$ws" "$probe_flow_bin" \
+            "$source_fingerprint" true
+    ); then
+        status=0
+    else
+        status=$?
+    fi
+
+    [ "$status" -eq "$expected_status" ] ||
+        fail "candidate probe $mode returned $status, want $expected_status"
+    actual_calls=$(paste -sd, "$PROBE_FLOW_LOG")
+    [ "$actual_calls" = "$expected_calls" ] ||
+        fail "candidate probe $mode called $actual_calls, want $expected_calls"
+}
+
+assert_probe_flow first-list-mutation 2 list
+assert_probe_flow init-mutation 2 list,init
+assert_probe_flow second-list-mutation 2 list,init,list
+assert_probe_flow safe-failure 1 list,init
+assert_probe_flow retry-success 0 list,init,list
 
 fake="$tmp/fake-bd"
 printf '%s\n' \

--- a/scripts/migration-test/strict-mode-test.sh
+++ b/scripts/migration-test/strict-mode-test.sh
@@ -1,0 +1,149 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/lib/report.sh"
+source "$SCRIPT_DIR/lib/versions.sh"
+source "$SCRIPT_DIR/lib/binary.sh"
+source "$SCRIPT_DIR/lib/workspace.sh"
+source "$SCRIPT_DIR/lib/snapshot.sh"
+source "$SCRIPT_DIR/recipes/sqlite_to_current.sh"
+
+fail() {
+    echo "strict-mode-test: $*" >&2
+    exit 1
+}
+
+asset=$(strict_release_asset v0.49.6 linux amd64)
+[ "$asset" = "beads_0.49.6_linux_amd64.tar.gz" ] || fail "unexpected release asset"
+sha=$(strict_release_sha256 v0.49.6 linux amd64)
+[ "$sha" = "8546dc9a47e11dc31ac2bc9a0224a9c690975e91850932cbb62623053fbb7db8" ] || fail "unexpected release checksum"
+
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+printf 'not the release archive' > "$tmp/archive.tar.gz"
+if OS=linux ARCH=amd64 verify_release_archive v0.49.6 "$tmp/archive.tar.gz" >/dev/null 2>&1; then
+    fail "tampered release archive was accepted"
+fi
+
+strict_fixture_has_expected_features v0.49.6 epic task bug dependency standalone closed label comment ||
+    fail "complete source fixture was rejected"
+if strict_fixture_has_expected_features v0.49.6 epic task bug standalone closed label >/dev/null 2>&1; then
+    fail "source fixture without dependency was accepted"
+fi
+if strict_fixture_has_expected_features v0.49.6 epic task bug dependency standalone closed label >/dev/null 2>&1; then
+    fail "source fixture without comment was accepted"
+fi
+
+declare -gA DATASET_IDS=(
+    [standalone]="old-standalone"
+    [closed]="old-closed"
+    [task]="old-task"
+    [bug]="old-bug"
+)
+printf '%s\n' '[
+  {"id":"old-standalone","title":"Standalone detailed task","description":"This task has a detailed description for fidelity testing.","notes":"Historical notes must survive the upgrade.","design":"Historical design must survive the upgrade.","acceptance_criteria":"Historical acceptance criteria must survive the upgrade.","external_ref":"legacy-upgrade-42","status":"open"},
+  {"id":"old-closed","title":"Already closed issue","status":"closed"},
+  {"id":"old-task","title":"Implement core feature","status":"open","labels":["urgent"],"comments":[{"author":"legacy-author","text":"Historical comment must survive the upgrade."}]},
+  {"id":"old-bug","title":"Fix migration blocker","status":"open","dependencies":[{"id":"old-task"}]}
+]' > "$tmp/fixture.json"
+strict_snapshot_has_expected_fixture v0.49.6 "$tmp/fixture.json" ||
+    fail "exact v0.49.6 source fixture was rejected"
+jq 'map(if .id == "old-standalone" then .external_ref = null else . end)' \
+    "$tmp/fixture.json" > "$tmp/fixture-missing-rich-field.json"
+if strict_snapshot_has_expected_fixture v0.49.6 "$tmp/fixture-missing-rich-field.json" >/dev/null 2>&1; then
+    fail "source fixture without the exact rich fields was accepted"
+fi
+jq 'map(if .id == "old-task" then .labels = [] else . end)' \
+    "$tmp/fixture.json" > "$tmp/fixture-missing-label.json"
+if strict_snapshot_has_expected_fixture v0.49.6 "$tmp/fixture-missing-label.json" >/dev/null 2>&1; then
+    fail "source fixture without the exact label was accepted"
+fi
+jq 'map(if .id == "old-bug" then .dependencies = [] else . end)' \
+    "$tmp/fixture.json" > "$tmp/fixture-missing-dependency.json"
+if strict_snapshot_has_expected_fixture v0.49.6 "$tmp/fixture-missing-dependency.json" >/dev/null 2>&1; then
+    fail "source fixture without the exact dependency was accepted"
+fi
+
+mkdir -p "$tmp/source/.beads"
+printf 'original sqlite bytes' > "$tmp/source/.beads/beads.db"
+printf 'original sqlite config' > "$tmp/source/.beads/config.yaml"
+source_manifest=$(classic_sqlite_artifact_manifest "$tmp/source/.beads")
+mv -f "$tmp/source/.beads/beads.db" "$tmp/source/.beads/beads.db.pre-migration"
+mv -f "$tmp/source/.beads/config.yaml" "$tmp/source/.beads/config.yaml.pre-migration"
+verify_retained_sqlite_source "$tmp/source/.beads" "$source_manifest" ||
+    fail "unchanged retained SQLite source was rejected"
+printf 'corruption' >> "$tmp/source/.beads/config.yaml.pre-migration"
+if verify_retained_sqlite_source "$tmp/source/.beads" "$source_manifest" >/dev/null 2>&1; then
+    fail "mutated retained SQLite source was accepted"
+fi
+
+mkdir -p "$tmp/collision/.beads"
+printf 'current' > "$tmp/collision/.beads/beads.db"
+printf 'current config' > "$tmp/collision/.beads/config.yaml"
+printf 'stale config' > "$tmp/collision/.beads/config.yaml.pre-migration"
+if preserve_sqlite_source_artifacts "$tmp/collision" >/dev/null 2>&1; then
+    fail "stale rollback collision was accepted"
+fi
+[ "$(cat "$tmp/collision/.beads/beads.db")" = "current" ] ||
+    fail "rollback collision mutated the active source"
+[ ! -e "$tmp/collision/.beads/beads.db.pre-migration" ] ||
+    fail "rollback preflight left a partial backup before reporting collision"
+
+RESULT_PATHS=("v0.49.6 → candidate")
+RESULT_STATUSES=("MANUAL")
+RESULT_DETAILS=("recipe: sqlite_to_current, 0 fidelity violations")
+RESULT_RECIPES=("sqlite_to_current")
+RESULT_VIOLATIONS=("0")
+strict_results_match MANUAL sqlite_to_current || fail "qualified result was rejected"
+
+RESULT_STATUSES=("SKIP")
+if strict_results_match MANUAL sqlite_to_current >/dev/null 2>&1; then
+    fail "SKIP result was accepted"
+fi
+RESULT_STATUSES=("MANUAL")
+RESULT_VIOLATIONS=("1")
+if strict_results_match MANUAL sqlite_to_current >/dev/null 2>&1; then
+    fail "fidelity violation was accepted"
+fi
+RESULT_VIOLATIONS=("0")
+if strict_results_match AUTO sqlite_to_current >/dev/null 2>&1; then
+    fail "outcome drift was accepted"
+fi
+if strict_results_match MANUAL different_recipe >/dev/null 2>&1; then
+    fail "recipe drift was accepted"
+fi
+
+STRICT_MODE=true
+printf '%s\n' \
+    '[{"id":"old-1","title":"One","description":"","priority":2,"issue_type":"task","status":"open","dependencies":[],"labels":[],"comment_count":0}]' \
+    > "$tmp/before.json"
+printf '%s\n' \
+    '[{"id":"old-1","title":"One","description":"","priority":2,"issue_type":"task","status":"open","dependencies":[{"id":"invented"}],"labels":["invented"],"comment_count":1}]' \
+    > "$tmp/after-invented.json"
+if check_fidelity v0.49.6 "$tmp/before.json" "$tmp/after-invented.json" >/dev/null 2>&1; then
+    fail "strict fidelity accepted invented collections"
+fi
+printf '%s\n' \
+    '[{"id":"old-1","title":"One","description":"","priority":2,"issue_type":"task","status":"open","dependencies":[],"labels":[],"comments":[{"author":"legacy-author","text":"before"}]}]' \
+    > "$tmp/before-comment.json"
+printf '%s\n' \
+    '[{"id":"old-1","title":"One","description":"","priority":2,"issue_type":"task","status":"open","dependencies":[],"labels":[],"comments":[{"author":"legacy-author","text":"after"}]}]' \
+    > "$tmp/after-comment.json"
+if check_fidelity v0.49.6 "$tmp/before-comment.json" "$tmp/after-comment.json" >/dev/null 2>&1; then
+    fail "strict fidelity accepted changed comment text"
+fi
+
+fake="$tmp/fake-bd"
+printf '%s\n' \
+    '#!/bin/bash' \
+    'if [ "$1" = "list" ]; then printf '\''[{"id":"old-1"},{"id":"old-2"}]\n'\''; exit 0; fi' \
+    'if [ "$1" = "show" ] && [ "$2" = "old-1" ]; then printf '\''[{"id":"old-1","title":"One"}]\n'\''; exit 0; fi' \
+    'exit 1' > "$fake"
+chmod +x "$fake"
+DATASET_IDS=([one]="old-1" [two]="old-2")
+if capture_snapshot "$tmp" "$fake" > "$tmp/partial.json" 2>/dev/null; then
+    fail "strict snapshot accepted a failed bd show"
+fi
+
+echo "strict-mode-test: PASS"


### PR DESCRIPTION
## What

Adds a required black-box PR gate that creates a real workspace with the checksum-pinned official v0.49.6 Linux amd64 release, probes it with the current multi-provider candidate, and runs the explicit `sqlite_to_current` bridge.

The strict lane fails on an unavailable or tampered release, skip, outcome/recipe drift, incomplete fixtures or snapshots, source mutation, unsafe rollback preservation, data-fidelity loss, or broken blocked/ready/close behavior.

## Why

Historical upgrades have failed for users without a deterministic release gate. This is the first thin end-to-end spine: a real released SQLite-era binary, a real legacy database, the current candidate, an explicit bridge, and fail-closed assertions in normal PR CI.

The expected result remains `MANUAL(sqlite_to_current)`; this PR does not make upgrades automatic.

Bead: `bd-ldt0f.3.22`

## Migration safety

- The direct candidate probe must leave the complete classic `.beads` tree unchanged.
- The bridge preserves byte-identical rollback copies of the SQLite DB, WAL/SHM, metadata, `config.json`, and `config.yaml` before invoking historical commands.
- Existing stale or conflicting rollback destinations fail before any copy or source removal.
- Rollback artifacts are verified both immediately after the bridge and after post-upgrade mutation checks.
- Exact IDs, rich fields, closed state, dependency, label, comment author/text, item cardinality, and empty collections are compared.
- The strict PR job runs for PRs into any target branch, including the multi-provider integration branch; only documentation/website-only changes are ignored.

## Verification

- `make build`
- `./scripts/migration-test/strict-mode-test.sh`
- `CANDIDATE_BIN="$PWD/bd" GIT_CONFIG_NOSYSTEM=1 ./scripts/migration-test/run.sh --strict --expect MANUAL v0.49.6`
  - 5/5 issues preserved
  - 8 required source features present
  - 0 fidelity/blocker violations
  - result: `MANUAL(sqlite_to_current)`
- `CANDIDATE_BIN="$PWD/bd" GIT_CONFIG_NOSYSTEM=1 ./scripts/migration-test/run.sh --self-test`
- `actionlint .github/workflows/migration-test.yml`
- `shellcheck -x -S error scripts/migration-test/run.sh scripts/migration-test/lib/*.sh scripts/migration-test/recipes/sqlite_to_current.sh scripts/migration-test/strict-mode-test.sh`
- `make ci-pr-policy`
- `make ci-pr-lint`

The repository-wide `make test` baseline was also exercised during this slice; `cmd/bd/TestGlobalDBIdentityCheck` timed out with a missing temporary `metadata.json`, and the same failure reproduced on the unchanged multi-provider base. This shell/CI change did not introduce that failure.

## Exact-diff review

Staged diff SHA-256 before commit: `6758cc9e35e0001a8885ac03472796d19336bf1d47ca3590b7e1c362714adf91`.

- Correctness council: 0 Critical, 0 Important
- Security/CI council: 0 Critical, 0 Important

This migration-path change requires substantive human review before merge.

_codex-gpt-5-unknown-reasoning on behalf of Test User_
