### PR TITLE
test(migration): gate v0.55.4 legacy Dolt upgrades

### DIFF
--- a/.github/workflows/migration-test.yml
+++ b/.github/workflows/migration-test.yml
@@ -24,16 +24,33 @@ on:
           - direct-only
           - stepping-only
 
+permissions:
+  contents: read
+
 env:
   BD_DISABLE_METRICS: "1"
   BD_DISABLE_EVENT_FLUSH: "1"
 
 jobs:
-  sqlite-history:
-    name: SQLite v0.49.6 upgrade qualification
+  historical-upgrades:
+    name: ${{ matrix.qualification }} upgrade qualification
     if: ${{ github.event_name == 'pull_request' }}
-    runs-on: ubuntu-latest
+    # v0.55.4 is dynamically linked against the ICU version shipped here.
+    # Pin the image so a runner alias update cannot invalidate the fixture.
+    runs-on: ubuntu-24.04
     timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - qualification: SQLite v0.49.6
+            version: v0.49.6
+            expected: MANUAL
+            cache-identity: sqlite-v0.49.6-8546dc9a47e11dc31ac2bc9a0224a9c690975e91850932cbb62623053fbb7db8
+          - qualification: Legacy Dolt-dir v0.55.4
+            version: v0.55.4
+            expected: MANUAL
+            cache-identity: legacy-dolt-v0.55.4-e0fa25456dd82890230eef17653448a0bf995104c78864be91c5ed84426a5f49
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
 
@@ -56,7 +73,7 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: ~/.cache/beads-regression
-          key: migration-sqlite-v0.49.6-8546dc9a47e11dc3-${{ runner.os }}-${{ runner.arch }}
+          key: migration-${{ matrix.cache-identity }}-${{ runner.os }}-${{ runner.arch }}
 
       - name: Build candidate
         run: make build
@@ -64,16 +81,18 @@ jobs:
       - name: Verify strict harness guards
         run: ./scripts/migration-test/strict-mode-test.sh
 
-      - name: Qualify v0.49.6 SQLite upgrade
+      - name: Qualify ${{ matrix.qualification }} upgrade
         env:
           CANDIDATE_BIN: ./bd
           GIT_CONFIG_NOSYSTEM: "1"
-        run: ./scripts/migration-test/run.sh --strict --expect MANUAL v0.49.6
+          EXPECTED_STATUS: ${{ matrix.expected }}
+          HISTORICAL_VERSION: ${{ matrix.version }}
+        run: ./scripts/migration-test/run.sh --strict --expect "$EXPECTED_STATUS" "$HISTORICAL_VERSION"
 
   migration-test:
     name: Migration fidelity
     if: ${{ github.event_name != 'pull_request' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6

--- a/scripts/migration-test/lib/direct_probe.sh
+++ b/scripts/migration-test/lib/direct_probe.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+# Candidate direct-upgrade probe helpers.
+
+candidate_list_has_nonempty_issue_ids() {
+    local ws="$1"
+    local bin="$2"
+    local output
+
+    if ! output=$(bd_in "$ws" "$bin" list --json -n 0 --all 2>/dev/null); then
+        return 1
+    fi
+
+    jq -e -s '
+        length == 1 and
+        (.[0] |
+            type == "array" and
+            length > 0 and
+            all(.[];
+                type == "object" and
+                ((.id? | type) == "string") and
+                ((.id? | length) > 0)))
+    ' >/dev/null 2>&1 <<< "$output"
+}
+
+DIRECT_PROBE_FAILURE_DETAIL=""
+
+candidate_probe_source_is_unchanged() {
+    local ws="$1"
+    local expected_fingerprint="$2"
+    local stage="$3"
+    local actual_fingerprint
+
+    stop_dolt_server "$ws"
+    if ! actual_fingerprint=$(source_artifact_fingerprint "$ws/.beads"); then
+        DIRECT_PROBE_FAILURE_DETAIL="could not fingerprint historical source tree after candidate $stage"
+        return 1
+    fi
+    if [ "$actual_fingerprint" != "$expected_fingerprint" ]; then
+        DIRECT_PROBE_FAILURE_DETAIL="candidate $stage mutated the historical source tree"
+        return 1
+    fi
+}
+
+probe_candidate_direct_upgrade() {
+    local ws="$1"
+    local bin="$2"
+    local expected_fingerprint="${3:-}"
+    local strict="${4:-false}"
+
+    DIRECT_PROBE_FAILURE_DETAIL=""
+    if $strict && [ -z "$expected_fingerprint" ]; then
+        DIRECT_PROBE_FAILURE_DETAIL="strict candidate probe has no historical source fingerprint"
+        return 2
+    fi
+
+    if candidate_list_has_nonempty_issue_ids "$ws" "$bin"; then
+        return 0
+    fi
+    if $strict && ! candidate_probe_source_is_unchanged \
+        "$ws" "$expected_fingerprint" "list probe"; then
+        return 2
+    fi
+
+    if ! bd_in "$ws" "$bin" init --quiet --non-interactive --prefix smoke \
+        </dev/null >/dev/null 2>&1; then
+        if $strict && ! candidate_probe_source_is_unchanged \
+            "$ws" "$expected_fingerprint" "init probe"; then
+            return 2
+        fi
+        return 1
+    fi
+
+    if candidate_list_has_nonempty_issue_ids "$ws" "$bin"; then
+        return 0
+    fi
+    if $strict && ! candidate_probe_source_is_unchanged \
+        "$ws" "$expected_fingerprint" "post-init list probe"; then
+        return 2
+    fi
+    return 1
+}

--- a/scripts/migration-test/lib/snapshot.sh
+++ b/scripts/migration-test/lib/snapshot.sh
@@ -14,7 +14,24 @@ capture_snapshot() {
 
     # bd list --json returns a flat array of issue objects
     local list_json
-    list_json=$(bd_in "$ws" "$bin" list --json -n 0 --all 2>/dev/null) || true
+    if ! list_json=$(bd_in "$ws" "$bin" list --json -n 0 --all 2>/dev/null); then
+        echo "  FIDELITY: bd list failed while capturing snapshot" >&2
+        echo "[]"
+        return 1
+    fi
+
+    if ${STRICT_MODE:-false} && ! jq -e '
+        type == "array" and
+        length > 0 and
+        all(.[];
+            type == "object" and
+            ((.id? | type) == "string") and
+            ((.id? | length) > 0))
+        ' >/dev/null 2>&1 <<< "$list_json"; then
+        echo "  FIDELITY: bd list returned an invalid snapshot inventory" >&2
+        echo "[]"
+        return 1
+    fi
 
     if [ -z "$list_json" ] || [ "$list_json" = "null" ] || [ "$list_json" = "[]" ]; then
         echo "[]"
@@ -39,15 +56,30 @@ capture_snapshot() {
         local show_json
         # Current binaries require --include-comments for full bodies; older
         # releases included them by default and reject the newer flag.
-        show_json=$(bd_in "$ws" "$bin" show "$id" --json --include-comments 2>/dev/null) || \
-            show_json=$(bd_in "$ws" "$bin" show "$id" --json 2>/dev/null) || true
+        local show_ok=false
+        if show_json=$(bd_in "$ws" "$bin" show "$id" --json --include-comments 2>/dev/null); then
+            show_ok=true
+        elif show_json=$(bd_in "$ws" "$bin" show "$id" --json 2>/dev/null); then
+            show_ok=true
+        fi
+        if ! $show_ok; then
+            echo "  FIDELITY: bd show failed for listed source id $id" >&2
+            return 1
+        fi
+        if ${STRICT_MODE:-false} && ! jq -e --arg id "$id" '
+            (if type == "array" then . else [.] end) |
+            length == 1 and
+            (.[0] | type == "object") and
+            ((.[0].id? | type) == "string") and
+            .[0].id == $id
+            ' >/dev/null 2>&1 <<< "$show_json"; then
+            echo "  FIDELITY: bd show returned an invalid snapshot for source id $id" >&2
+            return 1
+        fi
         if [ -n "$show_json" ] && [ "$show_json" != "null" ]; then
             # show returns an array — concatenate it
             items=$(echo "$items" | jq --argjson arr "$show_json" \
                 'if ($arr | type) == "array" then . + $arr else . + [$arr] end' 2>/dev/null) || true
-        elif ${STRICT_MODE:-false}; then
-            echo "  FIDELITY: bd show failed for listed source id $id" >&2
-            return 1
         fi
     done <<< "$ids"
 
@@ -71,6 +103,44 @@ capture_snapshot() {
     echo "$items" | jq -S 'sort_by(.title // "")' 2>/dev/null || echo "$items"
 }
 
+source_artifact_fingerprint() {
+    local beads_dir="$1"
+    local manifest_file digest
+
+    [ -d "$beads_dir" ] && [ ! -L "$beads_dir" ] || return 1
+    manifest_file=$(mktemp "${TMPDIR:-/tmp}/bd-source-fingerprint.XXXXXX") || return 1
+    if ! (
+        set -o pipefail
+        cd "$beads_dir" || exit 1
+        find . -mindepth 1 -print0 | LC_ALL=C sort -z | while IFS= read -r -d '' path; do
+            local mode checksum target
+            if [ -L "$path" ]; then
+                target=$(readlink -- "$path") || exit 1
+                printf 'link\0%s\0%s\0' "$path" "$target" || exit 1
+            elif [ -d "$path" ]; then
+                mode=$(stat -c '%a' -- "$path") || exit 1
+                printf 'directory\0%s\0%s\0' "$path" "$mode" || exit 1
+            elif [ -f "$path" ]; then
+                mode=$(stat -c '%a' -- "$path") || exit 1
+                checksum=$(sha256_file "$path") || exit 1
+                printf 'file\0%s\0%s\0%s\0' "$path" "$mode" "$checksum" || exit 1
+            else
+                echo "  FIDELITY: unsupported path in historical source tree: $beads_dir/$path" >&2
+                exit 1
+            fi
+        done
+    ) > "$manifest_file"; then
+        rm -f "$manifest_file"
+        return 1
+    fi
+    digest=$(sha256_file "$manifest_file") || {
+        rm -f "$manifest_file"
+        return 1
+    }
+    rm -f "$manifest_file"
+    printf '%s\n' "$digest"
+}
+
 # Validate the exact source values that make a strict historical fixture
 # meaningful. Without this check, an unsupported create flag can silently
 # disappear from both snapshots and produce a false fidelity pass.
@@ -79,18 +149,28 @@ strict_snapshot_has_expected_fixture() {
     local snapshot="$2"
 
     case "$version" in
-        v0.49.6)
+        v0.49.6|v0.55.4)
+            local epic_id="${DATASET_IDS[epic]:-}"
             local standalone_id="${DATASET_IDS[standalone]:-}"
             local closed_id="${DATASET_IDS[closed]:-}"
             local task_id="${DATASET_IDS[task]:-}"
             local bug_id="${DATASET_IDS[bug]:-}"
-            [ -n "$standalone_id" ] && [ -n "$closed_id" ] && \
+            [ -n "$epic_id" ] && [ -n "$standalone_id" ] && [ -n "$closed_id" ] && \
                 [ -n "$task_id" ] && [ -n "$bug_id" ] || return 1
             jq -e \
+                --arg epic "$epic_id" \
                 --arg standalone "$standalone_id" \
                 --arg closed "$closed_id" \
                 --arg task "$task_id" \
                 --arg bug "$bug_id" '
+                length == 5 and
+                any(.[];
+                    .id == $epic and
+                    .title == "Migration epic" and
+                    .description == "Epic for migration testing" and
+                    .priority == 2 and
+                    .issue_type == "epic" and
+                    .status == "open") and
                 any(.[];
                     .id == $standalone and
                     .title == "Standalone detailed task" and
@@ -150,6 +230,136 @@ verify_retained_sqlite_source() {
     actual_manifest=$(classic_sqlite_artifact_manifest "$beads_dir" ".pre-migration") || return 1
     if [ "$actual_manifest" != "$expected_manifest" ]; then
         echo "  FIDELITY: retained classic SQLite rollback artifacts changed" >&2
+        return 1
+    fi
+}
+
+legacy_dolt_artifact_manifest() {
+    local root="$1"
+    local dolt_dir="$root/dolt"
+    local manifest_file digest relative path mode checksum
+
+    if [ -L "$root" ] || [ ! -d "$root" ]; then
+        echo "  FIDELITY: legacy Dolt artifact root is not a regular directory: $root" >&2
+        return 1
+    fi
+    if [ -L "$dolt_dir" ] || [ ! -d "$dolt_dir" ]; then
+        echo "  FIDELITY: legacy Dolt source is not a regular directory: $dolt_dir" >&2
+        return 1
+    fi
+
+    manifest_file=$(mktemp "${TMPDIR:-/tmp}/bd-legacy-dolt-manifest.XXXXXX") || return 1
+    if ! (
+        set -o pipefail
+        cd "$root" || exit 1
+
+        if ! find dolt -mindepth 0 -print0 | sort -z | while IFS= read -r -d '' path; do
+            if [ -L "$path" ]; then
+                echo "  FIDELITY: symlink in legacy Dolt source: $root/$path" >&2
+                exit 1
+            elif [ -d "$path" ]; then
+                mode=$(stat -c '%a' -- "$path") || exit 1
+                printf 'directory\0%s\0%s\0' "$path" "$mode"
+            elif [ -f "$path" ]; then
+                mode=$(stat -c '%a' -- "$path") || exit 1
+                checksum=$(sha256_file "$path") || exit 1
+                printf 'file\0%s\0%s\0%s\0' "$path" "$mode" "$checksum"
+            else
+                echo "  FIDELITY: non-regular path in legacy Dolt source: $root/$path" >&2
+                exit 1
+            fi
+        done; then
+            exit 1
+        fi
+
+        for relative in "${LEGACY_DOLT_ROLLBACK_FILES[@]}"; do
+            path="$relative"
+            if [ -L "$path" ]; then
+                echo "  FIDELITY: symlink rollback artifact: $root/$path" >&2
+                exit 1
+            fi
+            if [ -e "$path" ]; then
+                if [ ! -f "$path" ]; then
+                    echo "  FIDELITY: rollback artifact is not a regular file: $root/$path" >&2
+                    exit 1
+                fi
+                mode=$(stat -c '%a' -- "$path") || exit 1
+                checksum=$(sha256_file "$path") || exit 1
+                printf 'file\0%s\0%s\0%s\0' "$path" "$mode" "$checksum"
+            fi
+        done
+    ) > "$manifest_file"; then
+        rm -f "$manifest_file"
+        return 1
+    fi
+
+    digest=$(sha256_file "$manifest_file") || {
+        rm -f "$manifest_file"
+        return 1
+    }
+    rm -f "$manifest_file"
+    printf '%s\n' "$digest"
+}
+
+verify_retained_legacy_dolt_source() {
+    local beads_dir="$1"
+    local expected_manifest="$2"
+    local retained="$beads_dir/legacy-dolt.pre-migration"
+
+    verify_legacy_dolt_rollback_root "$retained" "$expected_manifest"
+}
+
+legacy_dolt_rollback_inventory_is_exact() {
+    local root="$1"
+    local inventory_file name allowed relative invalid_name=""
+
+    if [ -L "$root" ] || [ ! -d "$root" ]; then
+        echo "  FIDELITY: retained legacy Dolt source is not a regular directory: $root" >&2
+        return 1
+    fi
+    inventory_file=$(mktemp "${TMPDIR:-/tmp}/bd-legacy-dolt-inventory.XXXXXX") || return 1
+    if ! find "$root" -mindepth 1 -maxdepth 1 -printf '%f\0' > "$inventory_file"; then
+        rm -f "$inventory_file"
+        return 1
+    fi
+
+    while IFS= read -r -d '' name; do
+        allowed=false
+        if [ "$name" = "dolt" ]; then
+            allowed=true
+        else
+            for relative in "${LEGACY_DOLT_ROLLBACK_FILES[@]}"; do
+                if [ "$name" = "$relative" ]; then
+                    allowed=true
+                    break
+                fi
+            done
+        fi
+        if ! $allowed; then
+            invalid_name="$name"
+            break
+        fi
+    done < "$inventory_file"
+    rm -f "$inventory_file"
+    if [ -n "$invalid_name" ]; then
+        echo "  FIDELITY: unexpected path in retained legacy Dolt source: $root/$invalid_name" >&2
+        return 1
+    fi
+}
+
+verify_legacy_dolt_rollback_root() {
+    local root="$1"
+    local expected_manifest="$2"
+    local actual_manifest
+
+    if [ -z "$expected_manifest" ]; then
+        echo "  FIDELITY: expected legacy Dolt rollback manifest is empty" >&2
+        return 1
+    fi
+    legacy_dolt_rollback_inventory_is_exact "$root" || return 1
+    actual_manifest=$(legacy_dolt_artifact_manifest "$root") || return 1
+    if [ "$actual_manifest" != "$expected_manifest" ]; then
+        echo "  FIDELITY: retained legacy Dolt rollback artifacts changed" >&2
         return 1
     fi
 }
@@ -348,16 +558,24 @@ check_blocker_paths() {
 
     # 1. bd blocked must list the dependent (bug) while the blocker (task) is
     #    still open — proves is_blocked survived migration on the dependent.
-    local blocked_json
-    blocked_json=$(bd_in "$ws" "$bin" blocked --json 2>/dev/null) || true
+    local blocked_json blocked_status=0
+    blocked_json=$(bd_in "$ws" "$bin" blocked --json 2>/dev/null) || blocked_status=$?
+    if [ "$blocked_status" -ne 0 ]; then
+        echo -e "  ${RED:-}BLOCKER-CHECK VIOLATION: 'bd blocked' exited $blocked_status${NC:-}"
+        violations=$((violations + 1))
+    fi
     if ! echo "$blocked_json" | jq -e --arg id "$dependent_id" 'any(.[]?; .id == $id)' >/dev/null 2>&1; then
         echo -e "  ${RED:-}BLOCKER-CHECK VIOLATION: 'bd blocked' does not list dependent '$dependent_id' while blocker '$blocker_id' is open${NC:-}"
         violations=$((violations + 1))
     fi
 
     # 2. bd ready must NOT list the dependent, but MUST list the blocker.
-    local ready_json
-    ready_json=$(bd_in "$ws" "$bin" ready --json 2>/dev/null) || true
+    local ready_json ready_status=0
+    ready_json=$(bd_in "$ws" "$bin" ready --json 2>/dev/null) || ready_status=$?
+    if [ "$ready_status" -ne 0 ]; then
+        echo -e "  ${RED:-}BLOCKER-CHECK VIOLATION: 'bd ready' exited $ready_status${NC:-}"
+        violations=$((violations + 1))
+    fi
     if echo "$ready_json" | jq -e --arg id "$dependent_id" 'any(.[]?; .id == $id)' >/dev/null 2>&1; then
         echo -e "  ${RED:-}BLOCKER-CHECK VIOLATION: 'bd ready' lists blocked dependent '$dependent_id'${NC:-}"
         violations=$((violations + 1))
@@ -373,8 +591,12 @@ check_blocker_paths() {
         echo -e "  ${RED:-}BLOCKER-CHECK VIOLATION: 'bd close $blocker_id' failed after migration (errno 1105 / stale-schema regression)${NC:-}"
         violations=$((violations + 1))
     else
-        local ready_after_json
-        ready_after_json=$(bd_in "$ws" "$bin" ready --json 2>/dev/null) || true
+        local ready_after_json ready_after_status=0
+        ready_after_json=$(bd_in "$ws" "$bin" ready --json 2>/dev/null) || ready_after_status=$?
+        if [ "$ready_after_status" -ne 0 ]; then
+            echo -e "  ${RED:-}BLOCKER-CHECK VIOLATION: post-close 'bd ready' exited $ready_after_status${NC:-}"
+            violations=$((violations + 1))
+        fi
         if ! echo "$ready_after_json" | jq -e --arg id "$dependent_id" 'any(.[]?; .id == $id)' >/dev/null 2>&1; then
             echo -e "  ${RED:-}BLOCKER-CHECK VIOLATION: dependent '$dependent_id' not ready after blocker '$blocker_id' closed${NC:-}"
             violations=$((violations + 1))

--- a/scripts/migration-test/lib/versions.sh
+++ b/scripts/migration-test/lib/versions.sh
@@ -29,24 +29,41 @@ declare -ar CLASSIC_SQLITE_ROLLBACK_FILES=(
     "config.yaml"
 )
 
+# Legacy Dolt-server metadata that must be retained with the dolt/ directory
+# before the manual bridge clears the active source.
+declare -ar LEGACY_DOLT_ROLLBACK_FILES=(
+    "metadata.json"
+    "config.json"
+    "config.yaml"
+    "issues.jsonl"
+)
+
 # Release artifacts and expected qualification outcomes for strict CI lanes.
 # Strict entries are deliberately explicit: adding a historical lane requires
 # reviewing the official asset, checksum, source capabilities, and supported
 # migration outcome instead of silently discovering them at runtime.
 declare -Ar STRICT_RELEASE_ASSETS=(
     ["v0.49.6|linux|amd64"]="beads_0.49.6_linux_amd64.tar.gz"
+    ["v0.55.4|linux|amd64"]="beads_0.55.4_linux_amd64.tar.gz"
 )
 declare -Ar STRICT_RELEASE_SHA256=(
     ["v0.49.6|linux|amd64"]="8546dc9a47e11dc31ac2bc9a0224a9c690975e91850932cbb62623053fbb7db8"
+    ["v0.55.4|linux|amd64"]="e0fa25456dd82890230eef17653448a0bf995104c78864be91c5ed84426a5f49"
 )
 declare -Ar STRICT_EXPECTED_STATUSES=(
     ["v0.49.6"]="MANUAL"
+    ["v0.55.4"]="MANUAL"
 )
 declare -Ar STRICT_EXPECTED_RECIPES=(
     ["v0.49.6"]="sqlite_to_current"
+    ["v0.55.4"]="server_to_embedded"
 )
 declare -Ar STRICT_EXPECTED_FEATURES=(
     ["v0.49.6"]="epic task bug dependency standalone closed label comment"
+    ["v0.55.4"]="epic task bug dependency standalone closed label comment"
+)
+declare -Ar SERVER_BRIDGE_STRATEGIES=(
+    ["v0.55.4"]="native_export"
 )
 
 strict_release_asset() {
@@ -75,6 +92,12 @@ strict_expected_recipe() {
 
 strict_expected_features() {
     local value="${STRICT_EXPECTED_FEATURES[$1]:-}"
+    [ -n "$value" ] || return 1
+    printf '%s\n' "$value"
+}
+
+server_bridge_strategy() {
+    local value="${SERVER_BRIDGE_STRATEGIES[$1]:-}"
     [ -n "$value" ] || return 1
     printf '%s\n' "$value"
 }

--- a/scripts/migration-test/recipes/server_to_embedded.sh
+++ b/scripts/migration-test/recipes/server_to_embedded.sh
@@ -1,10 +1,9 @@
 #!/bin/bash
-# Recipe: Dolt-server era (v0.50.0–v0.58.0) → current embedded Dolt.
+# Recipe: qualified v0.55.4 legacy Dolt directory → current embedded Dolt.
 #
-# Server-era versions store data in .beads/dolt/ and expect a running
-# Dolt SQL server. The current binary uses .beads/embeddeddolt/ with
-# an in-process engine. When metadata.json says server mode, the
-# candidate tries to TCP connect instead of falling back to embedded.
+# Other v0.50.0–v0.58.0 releases need release-specific extraction: v0.56.1
+# has no export command, while v0.57/v0.58 exports omit comment bodies. Do not
+# extend this recipe to those releases without a lossless fixture-backed path.
 #
 # Strategy:
 #   1. Stop any running Dolt server
@@ -13,22 +12,203 @@
 #   4. If candidate DB is empty, reimport from JSONL export
 #
 # User-facing instructions:
-#   If upgrading from a Dolt-server version (v0.50–v0.58):
-#     1. Stop your Dolt server: dolt sql-server --stop (or kill the process)
-#     2. Remove stale metadata: rm .beads/metadata.json
-#     3. Run: bd init --quiet
-#     4. Verify: bd list --all
+#   Use the pinned migration harness for v0.55.4. It stops the historical
+#   server, retains a byte-verified rollback tree, exports with the historical
+#   binary, validates the JSONL, and only then initializes the candidate.
+
+publish_legacy_dolt_rollback() {
+    mv --no-target-directory --no-clobber --no-copy -- "$1" "$2"
+}
+
+remove_file_and_verify_absent() {
+    local path="$1"
+    if [ -e "$path" ] || [ -L "$path" ]; then
+        rm -f -- "$path" || return 1
+    fi
+    [ ! -e "$path" ] && [ ! -L "$path" ]
+}
+
+remove_tree_and_verify_absent() {
+    local path="$1"
+    if [ -e "$path" ] || [ -L "$path" ]; then
+        rm -rf -- "$path" || return 1
+    fi
+    [ ! -e "$path" ] && [ ! -L "$path" ]
+}
+
+migration_jsonl_id_inventory() {
+    local path="$1"
+    [ -f "$path" ] && [ ! -L "$path" ] || return 1
+    jq -erRs '
+        (split("\n") |
+            if length > 0 and .[-1] == "" then .[:-1] else . end) as $lines |
+        if ($lines | length) == 0 or any($lines[]; test("\\S") | not) then
+            error("empty or blank JSONL record")
+        else
+            $lines | map(fromjson) |
+            if all(.[];
+                type == "object" and
+                ((.id? | type) == "string") and
+                ((.id? | length) > 0))
+            then .[].id | @json
+            else error("invalid issue record")
+            end
+        end
+    ' "$path"
+}
+
+migration_jsonl_matches_snapshot() {
+    local path="$1"
+    local snapshot="$2"
+    local export_ids expected_ids
+
+    export_ids=$(migration_jsonl_id_inventory "$path" 2>/dev/null) || return 1
+    [ -n "$export_ids" ] || return 1
+    expected_ids=$(jq -er '
+        if type == "array" and length > 0 and
+            all(.[];
+                type == "object" and
+                ((.id? | type) == "string") and
+                ((.id? | length) > 0))
+        then .[].id | @json
+        else error("invalid source snapshot")
+        end
+    ' "$snapshot" 2>/dev/null) || return 1
+    [ -n "$expected_ids" ] || return 1
+
+    [ -z "$(printf '%s\n' "$export_ids" | LC_ALL=C sort | uniq -d)" ] || return 1
+    [ -z "$(printf '%s\n' "$expected_ids" | LC_ALL=C sort | uniq -d)" ] || return 1
+    [ "$(printf '%s\n' "$export_ids" | LC_ALL=C sort)" = \
+        "$(printf '%s\n' "$expected_ids" | LC_ALL=C sort)" ]
+}
+
+migration_jsonl_is_snapshot_subset() {
+    local path="$1"
+    local snapshot="$2"
+    local existing_ids expected_ids extra_ids
+
+    [ -f "$path" ] && [ ! -L "$path" ] || return 1
+    [ -s "$path" ] || return 0
+    existing_ids=$(migration_jsonl_id_inventory "$path" 2>/dev/null) || return 1
+    expected_ids=$(jq -er '.[].id | @json' "$snapshot" 2>/dev/null) || return 1
+    [ -z "$(printf '%s\n' "$existing_ids" | LC_ALL=C sort | uniq -d)" ] || return 1
+    extra_ids=$(comm -23 \
+        <(printf '%s\n' "$existing_ids" | LC_ALL=C sort) \
+        <(printf '%s\n' "$expected_ids" | LC_ALL=C sort)) || return 1
+    [ -z "$extra_ids" ]
+}
+
+preserve_legacy_dolt_source() {
+    local ws="$1"
+    local expected_manifest="$2"
+    local beads_dir="$ws/.beads"
+    local backup_dir="$beads_dir/legacy-dolt.pre-migration"
+    local temp_dir="$beads_dir/.legacy-dolt.pre-migration.tmp.$$"
+    local actual_manifest relative
+
+    if [ -e "$backup_dir" ] || [ -L "$backup_dir" ]; then
+        if [ ! -d "$backup_dir" ] || [ -L "$backup_dir" ]; then
+            echo "  FAILED: legacy Dolt rollback destination is not a regular directory"
+            return 1
+        fi
+        if ! verify_legacy_dolt_rollback_root "$backup_dir" "$expected_manifest"; then
+            echo "  FAILED: legacy Dolt rollback destination contains different source data"
+            return 1
+        fi
+        return 0
+    fi
+
+    if [ -e "$temp_dir" ] || [ -L "$temp_dir" ]; then
+        echo "  FAILED: temporary legacy Dolt rollback destination already exists"
+        return 1
+    fi
+
+    actual_manifest=$(legacy_dolt_artifact_manifest "$beads_dir") || return 1
+    if [ "$actual_manifest" != "$expected_manifest" ]; then
+        echo "  FAILED: active legacy Dolt source changed before backup"
+        return 1
+    fi
+
+    mkdir "$temp_dir" || return 1
+    if ! cp -a -- "$beads_dir/dolt" "$temp_dir/dolt"; then
+        rm -rf "$temp_dir"
+        echo "  FAILED: could not copy legacy Dolt rollback data"
+        return 1
+    fi
+    for relative in "${LEGACY_DOLT_ROLLBACK_FILES[@]}"; do
+        if [ -f "$beads_dir/$relative" ]; then
+            if ! cp -p -- "$beads_dir/$relative" "$temp_dir/$relative"; then
+                rm -rf "$temp_dir"
+                echo "  FAILED: could not copy legacy Dolt rollback metadata"
+                return 1
+            fi
+        fi
+    done
+
+    actual_manifest=$(legacy_dolt_artifact_manifest "$temp_dir") || {
+        rm -rf "$temp_dir"
+        return 1
+    }
+    if [ "$actual_manifest" != "$expected_manifest" ] || \
+        ! verify_legacy_dolt_rollback_root "$temp_dir" "$expected_manifest"; then
+        rm -rf "$temp_dir"
+        echo "  FAILED: copied legacy Dolt rollback data failed verification"
+        return 1
+    fi
+
+    if ! publish_legacy_dolt_rollback "$temp_dir" "$backup_dir"; then
+        rm -rf "$temp_dir"
+        echo "  FAILED: could not publish legacy Dolt rollback data"
+        return 1
+    fi
+    if [ -e "$temp_dir" ] || [ -L "$temp_dir" ] || \
+        ! verify_legacy_dolt_rollback_root "$backup_dir" "$expected_manifest"; then
+        echo "  FAILED: published legacy Dolt rollback data failed verification"
+        return 1
+    fi
+}
 
 recipe_server_to_embedded() {
     local ws="$1"
     local old_bin="$2"
     local cand_bin="$3"
     local version="$4"
+    local before_snapshot="${5:-}"
+    local strategy
+    local export_path="$ws/.beads/issues.jsonl"
+    local existing_export_state="absent"
+    local existing_export_checksum=""
 
     echo "  Trying server→embedded recipe..."
+    strategy=$(server_bridge_strategy "$version") || {
+        echo "  FAILED: no lossless server→embedded recipe is qualified for $version"
+        return 1
+    }
+    if [ "$strategy" != "native_export" ] || [ ! -f "$before_snapshot" ]; then
+        echo "  FAILED: incomplete server→embedded inputs for $version"
+        return 1
+    fi
+    if [ -e "$export_path" ] || [ -L "$export_path" ]; then
+        if [ -L "$export_path" ] || [ ! -f "$export_path" ] || \
+            ! migration_jsonl_is_snapshot_subset "$export_path" "$before_snapshot"; then
+            echo "  FAILED: existing historical JSONL is unsafe to replace"
+            return 1
+        fi
+        existing_export_checksum=$(sha256_file "$export_path") || return 1
+        existing_export_state="present"
+    fi
 
     # Step 1: Stop any running server (we'll restart via old binary as needed)
     stop_dolt_server "$ws"
+
+    # Preserve the stopped source before an old export command or candidate
+    # probe can update its Dolt working set or metadata.
+    local rollback_manifest
+    rollback_manifest=$(legacy_dolt_artifact_manifest "$ws/.beads") || {
+        echo "  FAILED: could not inventory legacy Dolt rollback source"
+        return 1
+    }
+    preserve_legacy_dolt_source "$ws" "$rollback_manifest" || return 1
 
     # Step 2: Export data via old binary BEFORE clearing metadata.
     # The old binary needs metadata.json to know it's in server mode and
@@ -36,34 +216,60 @@ recipe_server_to_embedded() {
     # previously) makes the old binary unable to find its data. (GH#3071)
     echo "  exporting data via old binary..."
     local export_ok=false
-    if bd_in "$ws" "$old_bin" list --json -n 0 --all > "$ws/.beads/issues.jsonl.tmp" 2>/dev/null; then
-        if [ -s "$ws/.beads/issues.jsonl.tmp" ]; then
-            jq -c '.[]' "$ws/.beads/issues.jsonl.tmp" > "$ws/.beads/issues.jsonl" 2>/dev/null || true
-            rm -f "$ws/.beads/issues.jsonl.tmp"
-            if [ -s "$ws/.beads/issues.jsonl" ]; then
-                local export_count
-                export_count=$(wc -l < "$ws/.beads/issues.jsonl" 2>/dev/null) || export_count=0
-                echo "  exported $export_count items to JSONL"
-                export_ok=true
+    local export_tmp
+    export_tmp=$(mktemp "$ws/.beads/.issues.jsonl.migration.tmp.XXXXXX") || {
+        echo "  FAILED: could not create a safe historical export destination"
+        return 1
+    }
+    if bd_in "$ws" "$old_bin" export --format jsonl \
+        -o "$export_tmp" >/dev/null 2>&1; then
+        local export_destination_unchanged=false
+        if [ "$existing_export_state" = "present" ]; then
+            if [ -f "$export_path" ] && [ ! -L "$export_path" ] && \
+                [ "$(sha256_file "$export_path")" = "$existing_export_checksum" ]; then
+                export_destination_unchanged=true
             fi
-        else
-            rm -f "$ws/.beads/issues.jsonl.tmp"
+        elif [ ! -e "$export_path" ] && [ ! -L "$export_path" ]; then
+            export_destination_unchanged=true
+        fi
+        if $export_destination_unchanged && \
+            migration_jsonl_matches_snapshot "$export_tmp" "$before_snapshot" && \
+            mv --no-target-directory --force -- "$export_tmp" "$export_path" && \
+            migration_jsonl_matches_snapshot "$export_path" "$before_snapshot"; then
+            local export_count
+            export_count=$(jq -s 'length' "$export_path" 2>/dev/null) || export_count=0
+            echo "  exported $export_count items to JSONL"
+            export_ok=true
         fi
     fi
+    if ! remove_file_and_verify_absent "$export_tmp"; then
+        echo "  FAILED: could not remove the historical export staging file"
+        return 1
+    fi
     stop_dolt_server "$ws"
+    if ! $export_ok; then
+        echo "  FAILED: historical export did not produce a nonempty JSONL file"
+        return 1
+    fi
+    if ! verify_legacy_dolt_rollback_root \
+        "$ws/.beads/legacy-dolt.pre-migration" "$rollback_manifest"; then
+        echo "  FAILED: retained rollback source changed during historical export"
+        return 1
+    fi
 
     # Step 3: Clear stale server metadata that causes TCP connect attempts,
     # then try candidate init.
-    rm -f "$ws/.beads/metadata.json" 2>/dev/null || true
-    rm -f "$ws/.beads/dolt-server.pid" 2>/dev/null || true
-    rm -f "$ws/.beads/dolt-server.lock" 2>/dev/null || true
+    if ! remove_file_and_verify_absent "$ws/.beads/dolt-server.pid" || \
+        ! remove_file_and_verify_absent "$ws/.beads/dolt-server.lock" || \
+        ! remove_file_and_verify_absent "$ws/.beads/metadata.json"; then
+        echo "  FAILED: could not clear legacy server metadata"
+        return 1
+    fi
 
     if bd_in "$ws" "$cand_bin" init --quiet --non-interactive </dev/null >/dev/null 2>&1; then
         # Verify candidate actually has data — init may succeed but create
         # an empty database if it didn't detect the old dolt/ data. (GH#3071)
-        local verify_out
-        verify_out=$(bd_in "$ws" "$cand_bin" list --json -n 0 --all 2>/dev/null) || true
-        if [ -n "$verify_out" ] && [ "$verify_out" != "[]" ] && [ "$verify_out" != "null" ]; then
+        if candidate_list_has_nonempty_issue_ids "$ws" "$cand_bin"; then
             echo "  candidate init succeeded with data intact"
             return 0
         fi
@@ -71,15 +277,23 @@ recipe_server_to_embedded() {
     fi
 
     # Step 4: Candidate init produced an empty DB (or failed).
-    # Move old storage directories out of the way so checkExistingBeadsData
-    # doesn't block --from-jsonl. The old dolt/ is server-era data; the
-    # embeddeddolt/ (if any) was just created empty by step 3.
+    # Remove active storage only after the verified rollback copy and JSONL
+    # export exist. The old dolt/ is legacy data; embeddeddolt/ (if any) was
+    # just created empty by step 3.
     stop_dolt_server "$ws"
-    for old_dir in "$ws/.beads/dolt" "$ws/.beads/embeddeddolt"; do
-        [ -d "$old_dir" ] && mv "$old_dir" "${old_dir}.pre-migration" 2>/dev/null || true
-    done
-    rm -f "$ws/.beads/metadata.json" 2>/dev/null || true
-    rm -f "$ws/.beads/config.json" 2>/dev/null || true
+    if ! verify_legacy_dolt_rollback_root \
+        "$ws/.beads/legacy-dolt.pre-migration" "$rollback_manifest"; then
+        echo "  FAILED: retained rollback source changed before active-source removal"
+        return 1
+    fi
+    if ! remove_file_and_verify_absent "$ws/.beads/metadata.json" || \
+        ! remove_file_and_verify_absent "$ws/.beads/config.json" || \
+        ! remove_file_and_verify_absent "$ws/.beads/config.yaml" || \
+        ! remove_tree_and_verify_absent "$ws/.beads/dolt" || \
+        ! remove_tree_and_verify_absent "$ws/.beads/embeddeddolt"; then
+        echo "  FAILED: could not remove active legacy storage artifacts"
+        return 1
+    fi
 
     # Reimport from the JSONL export captured in step 2.
     if $export_ok && [ -s "$ws/.beads/issues.jsonl" ]; then

--- a/scripts/migration-test/run.sh
+++ b/scripts/migration-test/run.sh
@@ -49,33 +49,32 @@ source "$SCRIPT_DIR/lib/binary.sh"      # download_binary, build_candidate
 source "$SCRIPT_DIR/lib/workspace.sh"   # new_workspace, bd_in, bd_create, cleanup_workspace
 source "$SCRIPT_DIR/lib/features.sh"    # create_dataset, try_feature
 source "$SCRIPT_DIR/lib/snapshot.sh"    # capture_snapshot, check_fidelity
+source "$SCRIPT_DIR/lib/direct_probe.sh" # fail-closed candidate probing
 
 # Source recipe scripts
 source "$SCRIPT_DIR/recipes/sqlite_to_current.sh"
 source "$SCRIPT_DIR/recipes/server_to_embedded.sh"
 source "$SCRIPT_DIR/recipes/fix_dash_prefix.sh"
 
-source_artifact_fingerprint() {
-    local beads_dir="$1"
-    [ -d "$beads_dir" ] || return 1
-    (
-        cd "$beads_dir" || exit 1
-        while IFS= read -r -d '' path; do
-            if [ -L "$path" ]; then
-                printf 'link\0%s\0%s\0' "$path" "$(readlink "$path")"
-            elif [ -d "$path" ]; then
-                printf 'directory\0%s\0%s\0' "$path" "$(stat -c '%a' "$path")"
-            elif [ -f "$path" ]; then
-                printf 'file\0%s\0%s\0%s\0' "$path" "$(stat -c '%a' "$path")" "$(sha256_file "$path")"
-            else
-                printf 'other\0%s\0' "$path"
-            fi
-        done < <(find . -mindepth 1 -print0 | sort -z)
-    ) | if command -v sha256sum >/dev/null 2>&1; then
-        sha256sum | awk '{print $1}'
-    else
-        shasum -a 256 | awk '{print $1}'
-    fi
+verify_strict_retained_source() {
+    local ws="$1"
+    local era="$2"
+    local sqlite_manifest="$3"
+    local legacy_dolt_manifest="$4"
+
+    case "$era" in
+        sqlite)
+            [ -n "$sqlite_manifest" ] && \
+                verify_retained_sqlite_source "$ws/.beads" "$sqlite_manifest"
+            ;;
+        dolt_server)
+            [ -n "$legacy_dolt_manifest" ] && \
+                verify_retained_legacy_dolt_source "$ws/.beads" "$legacy_dolt_manifest"
+            ;;
+        *)
+            return 0
+            ;;
+    esac
 }
 
 # Ensure jq is available
@@ -191,61 +190,70 @@ test_direct_path() {
     # Stop source server before upgrade
     stop_dolt_server "$WS"
 
+    local source_era
+    source_era=$(get_era "$version")
     local source_fingerprint=""
     local source_sqlite_manifest=""
-    if $STRICT_MODE && [ "$(get_era "$version")" = "sqlite" ]; then
+    local source_legacy_dolt_manifest=""
+    if $STRICT_MODE; then
         source_fingerprint=$(source_artifact_fingerprint "$WS/.beads") || {
             cleanup_workspace "$WS"
             rm -rf "$SNAPSHOTS_DIR"
-            record_result "$path_label" "BLOCKED" "could not fingerprint classic SQLite source"
+            record_result "$path_label" "BLOCKED" "could not fingerprint historical source tree"
             return 0
         }
-        source_sqlite_manifest=$(classic_sqlite_artifact_manifest "$WS/.beads") || {
-            cleanup_workspace "$WS"
-            rm -rf "$SNAPSHOTS_DIR"
-            record_result "$path_label" "BLOCKED" "could not inventory classic SQLite rollback source"
-            return 0
-        }
+        case "$source_era" in
+            sqlite)
+                source_sqlite_manifest=$(classic_sqlite_artifact_manifest "$WS/.beads") || {
+                    cleanup_workspace "$WS"
+                    rm -rf "$SNAPSHOTS_DIR"
+                    record_result "$path_label" "BLOCKED" "could not inventory classic SQLite rollback source"
+                    return 0
+                }
+                ;;
+            dolt_server)
+                source_legacy_dolt_manifest=$(legacy_dolt_artifact_manifest "$WS/.beads") || {
+                    cleanup_workspace "$WS"
+                    rm -rf "$SNAPSHOTS_DIR"
+                    record_result "$path_label" "BLOCKED" "could not inventory legacy Dolt rollback source"
+                    return 0
+                }
+                ;;
+        esac
     fi
 
     # Step 4: Try direct upgrade with candidate
     echo "  upgrading to candidate..."
     local upgrade_ok=false
-
-    # First try: just use candidate directly (auto-detect + migrate)
-    local list_out
-    list_out=$(bd_in "$WS" "$cand_bin" list --json -n 0 --all 2>/dev/null) || true
-    if [ -n "$list_out" ] && [ "$list_out" != "[]" ] && [ "$list_out" != "null" ]; then
+    local probe_status=0
+    probe_candidate_direct_upgrade \
+        "$WS" "$cand_bin" "$source_fingerprint" "$STRICT_MODE" || probe_status=$?
+    if [ "$probe_status" -eq 0 ]; then
         upgrade_ok=true
     fi
 
-    # Second try: run candidate init
-    if ! $upgrade_ok; then
-        bd_in "$WS" "$cand_bin" init --quiet --non-interactive --prefix smoke </dev/null >/dev/null 2>&1 || true
-        list_out=$(bd_in "$WS" "$cand_bin" list --json -n 0 --all 2>/dev/null) || true
-        if [ -n "$list_out" ] && [ "$list_out" != "[]" ] && [ "$list_out" != "null" ]; then
-            upgrade_ok=true
-        fi
-    fi
-
-    if $STRICT_MODE && ! $upgrade_ok && [ -n "$source_fingerprint" ]; then
-        local after_probe_fingerprint
+    if [ "$probe_status" -eq 2 ]; then
         stop_dolt_server "$WS"
-        after_probe_fingerprint=$(source_artifact_fingerprint "$WS/.beads") || after_probe_fingerprint="unreadable"
-        if [ "$after_probe_fingerprint" != "$source_fingerprint" ]; then
-            stop_dolt_server "$WS"
-            cleanup_workspace "$WS"
-            rm -rf "$SNAPSHOTS_DIR"
-            record_result "$path_label" "BLOCKED" "candidate probe mutated the classic SQLite source"
-            echo -e "  ${RED}BLOCKED: candidate probe mutated the classic SQLite source${NC}"
-            return 0
-        fi
-        echo -e "  ${GREEN}SOURCE-CHECK: failed direct probe left classic SQLite artifacts unchanged${NC}"
+        cleanup_workspace "$WS"
+        rm -rf "$SNAPSHOTS_DIR"
+        record_result "$path_label" "BLOCKED" "$DIRECT_PROBE_FAILURE_DETAIL"
+        echo -e "  ${RED}BLOCKED: $DIRECT_PROBE_FAILURE_DETAIL${NC}"
+        return 0
+    fi
+    if $STRICT_MODE && ! $upgrade_ok; then
+        echo -e "  ${GREEN}SOURCE-CHECK: failed direct probe left historical source artifacts unchanged${NC}"
     fi
 
     if $upgrade_ok; then
         # Capture after-snapshot and check fidelity
-        capture_snapshot "$WS" "$cand_bin" > "$SNAPSHOTS_DIR/after.json"
+        if ! capture_snapshot "$WS" "$cand_bin" > "$SNAPSHOTS_DIR/after.json"; then
+            stop_dolt_server "$WS"
+            cleanup_workspace "$WS"
+            rm -rf "$SNAPSHOTS_DIR"
+            record_result "$path_label" "BLOCKED" "could not capture the complete candidate snapshot"
+            echo -e "  ${RED}BLOCKED: could not capture the complete candidate snapshot${NC}"
+            return 0
+        fi
         local after_count
         after_count=$(jq 'length' "$SNAPSHOTS_DIR/after.json" 2>/dev/null) || after_count=0
         echo "  after-snapshot: $after_count items"
@@ -273,8 +281,7 @@ test_direct_path() {
     stop_dolt_server "$WS"
     echo "  direct upgrade failed, trying recipes..."
 
-    local era
-    era=$(get_era "$version")
+    local era="$source_era"
     local recipe_worked=false
     local recipe_name=""
 
@@ -286,7 +293,8 @@ test_direct_path() {
             fi
             ;;
         dolt_server)
-            if recipe_server_to_embedded "$WS" "$src_bin" "$cand_bin" "$version"; then
+            if recipe_server_to_embedded \
+                "$WS" "$src_bin" "$cand_bin" "$version" "$SNAPSHOTS_DIR/before.json"; then
                 recipe_worked=true
                 recipe_name="server_to_embedded"
             fi
@@ -298,7 +306,8 @@ test_direct_path() {
             fi
             # Also try server recipe if prefix fix didn't help
             if ! $recipe_worked; then
-                if recipe_server_to_embedded "$WS" "$src_bin" "$cand_bin" "$version"; then
+                if recipe_server_to_embedded \
+                    "$WS" "$src_bin" "$cand_bin" "$version" "$SNAPSHOTS_DIR/before.json"; then
                     recipe_worked=true
                     recipe_name="server_to_embedded"
                 fi
@@ -307,18 +316,25 @@ test_direct_path() {
     esac
 
     if $recipe_worked; then
-        if $STRICT_MODE && [ -n "$source_sqlite_manifest" ] && \
-            ! verify_retained_sqlite_source "$WS/.beads" "$source_sqlite_manifest"; then
+        if $STRICT_MODE && ! verify_strict_retained_source \
+            "$WS" "$era" "$source_sqlite_manifest" "$source_legacy_dolt_manifest"; then
             stop_dolt_server "$WS"
             cleanup_workspace "$WS"
             rm -rf "$SNAPSHOTS_DIR"
-            record_result "$path_label" "BLOCKED" "manual bridge mutated the retained classic SQLite database"
-            echo -e "  ${RED}BLOCKED: manual bridge mutated the retained classic SQLite database${NC}"
+            record_result "$path_label" "BLOCKED" "manual bridge mutated the retained historical rollback source"
+            echo -e "  ${RED}BLOCKED: manual bridge mutated the retained historical rollback source${NC}"
             return 0
         fi
 
         # Re-capture and check fidelity after recipe
-        capture_snapshot "$WS" "$cand_bin" > "$SNAPSHOTS_DIR/after.json"
+        if ! capture_snapshot "$WS" "$cand_bin" > "$SNAPSHOTS_DIR/after.json"; then
+            stop_dolt_server "$WS"
+            cleanup_workspace "$WS"
+            rm -rf "$SNAPSHOTS_DIR"
+            record_result "$path_label" "BLOCKED" "could not capture the complete candidate snapshot after recipe"
+            echo -e "  ${RED}BLOCKED: could not capture the complete candidate snapshot after recipe${NC}"
+            return 0
+        fi
         local after_count
         after_count=$(jq 'length' "$SNAPSHOTS_DIR/after.json" 2>/dev/null) || after_count=0
         echo "  after-recipe snapshot: $after_count items"
@@ -332,12 +348,12 @@ test_direct_path() {
 
         stop_dolt_server "$WS"
 
-        if $STRICT_MODE && [ -n "$source_sqlite_manifest" ] && \
-            ! verify_retained_sqlite_source "$WS/.beads" "$source_sqlite_manifest"; then
+        if $STRICT_MODE && ! verify_strict_retained_source \
+            "$WS" "$era" "$source_sqlite_manifest" "$source_legacy_dolt_manifest"; then
             cleanup_workspace "$WS"
             rm -rf "$SNAPSHOTS_DIR"
-            record_result "$path_label" "BLOCKED" "post-upgrade commands mutated the retained SQLite rollback source"
-            echo -e "  ${RED}BLOCKED: post-upgrade commands mutated the retained SQLite rollback source${NC}"
+            record_result "$path_label" "BLOCKED" "post-upgrade commands mutated the retained historical rollback source"
+            echo -e "  ${RED}BLOCKED: post-upgrade commands mutated the retained historical rollback source${NC}"
             return 0
         fi
 

--- a/scripts/migration-test/strict-mode-test.sh
+++ b/scripts/migration-test/strict-mode-test.sh
@@ -7,7 +7,9 @@ source "$SCRIPT_DIR/lib/versions.sh"
 source "$SCRIPT_DIR/lib/binary.sh"
 source "$SCRIPT_DIR/lib/workspace.sh"
 source "$SCRIPT_DIR/lib/snapshot.sh"
+source "$SCRIPT_DIR/lib/direct_probe.sh"
 source "$SCRIPT_DIR/recipes/sqlite_to_current.sh"
+source "$SCRIPT_DIR/recipes/server_to_embedded.sh"
 
 fail() {
     echo "strict-mode-test: $*" >&2
@@ -19,15 +21,43 @@ asset=$(strict_release_asset v0.49.6 linux amd64)
 sha=$(strict_release_sha256 v0.49.6 linux amd64)
 [ "$sha" = "8546dc9a47e11dc31ac2bc9a0224a9c690975e91850932cbb62623053fbb7db8" ] || fail "unexpected release checksum"
 
+asset=$(strict_release_asset v0.55.4 linux amd64) || fail "missing v0.55.4 release asset"
+[ "$asset" = "beads_0.55.4_linux_amd64.tar.gz" ] || fail "unexpected v0.55.4 release asset"
+sha=$(strict_release_sha256 v0.55.4 linux amd64) || fail "missing v0.55.4 release checksum"
+[ "$sha" = "e0fa25456dd82890230eef17653448a0bf995104c78864be91c5ed84426a5f49" ] ||
+    fail "unexpected v0.55.4 release checksum"
+[ "$(strict_expected_status v0.55.4)" = "MANUAL" ] || fail "unexpected v0.55.4 status"
+[ "$(strict_expected_recipe v0.55.4)" = "server_to_embedded" ] || fail "unexpected v0.55.4 recipe"
+[ "$(strict_expected_features v0.55.4)" = "epic task bug dependency standalone closed label comment" ] ||
+    fail "unexpected v0.55.4 source features"
+[ "${LEGACY_DOLT_ROLLBACK_FILES[*]}" = "metadata.json config.json config.yaml issues.jsonl" ] ||
+    fail "unexpected legacy Dolt rollback file inventory"
+
+for lookup in strict_release_asset strict_release_sha256; do
+    if "$lookup" v9.9.9 linux amd64 >/dev/null 2>&1; then
+        fail "$lookup accepted an unknown release manifest"
+    fi
+done
+for lookup in strict_expected_status strict_expected_recipe strict_expected_features; do
+    if "$lookup" v9.9.9 >/dev/null 2>&1; then
+        fail "$lookup accepted an unknown qualification manifest"
+    fi
+done
+
 tmp=$(mktemp -d)
 trap 'rm -rf "$tmp"' EXIT
 printf 'not the release archive' > "$tmp/archive.tar.gz"
 if OS=linux ARCH=amd64 verify_release_archive v0.49.6 "$tmp/archive.tar.gz" >/dev/null 2>&1; then
     fail "tampered release archive was accepted"
 fi
+if OS=linux ARCH=amd64 verify_release_archive v0.55.4 "$tmp/archive.tar.gz" >/dev/null 2>&1; then
+    fail "tampered v0.55.4 release archive was accepted"
+fi
 
 strict_fixture_has_expected_features v0.49.6 epic task bug dependency standalone closed label comment ||
     fail "complete source fixture was rejected"
+strict_fixture_has_expected_features v0.55.4 epic task bug dependency standalone closed label comment ||
+    fail "complete v0.55.4 source fixture was rejected"
 if strict_fixture_has_expected_features v0.49.6 epic task bug standalone closed label >/dev/null 2>&1; then
     fail "source fixture without dependency was accepted"
 fi
@@ -36,12 +66,14 @@ if strict_fixture_has_expected_features v0.49.6 epic task bug dependency standal
 fi
 
 declare -gA DATASET_IDS=(
+    [epic]="old-epic"
     [standalone]="old-standalone"
     [closed]="old-closed"
     [task]="old-task"
     [bug]="old-bug"
 )
 printf '%s\n' '[
+  {"id":"old-epic","title":"Migration epic","description":"Epic for migration testing","priority":2,"issue_type":"epic","status":"open"},
   {"id":"old-standalone","title":"Standalone detailed task","description":"This task has a detailed description for fidelity testing.","notes":"Historical notes must survive the upgrade.","design":"Historical design must survive the upgrade.","acceptance_criteria":"Historical acceptance criteria must survive the upgrade.","external_ref":"legacy-upgrade-42","status":"open"},
   {"id":"old-closed","title":"Already closed issue","status":"closed"},
   {"id":"old-task","title":"Implement core feature","status":"open","labels":["urgent"],"comments":[{"author":"legacy-author","text":"Historical comment must survive the upgrade."}]},
@@ -49,20 +81,51 @@ printf '%s\n' '[
 ]' > "$tmp/fixture.json"
 strict_snapshot_has_expected_fixture v0.49.6 "$tmp/fixture.json" ||
     fail "exact v0.49.6 source fixture was rejected"
+strict_snapshot_has_expected_fixture v0.55.4 "$tmp/fixture.json" ||
+    fail "exact v0.55.4 source fixture was rejected"
+jq 'map(select(.id != "old-epic"))' "$tmp/fixture.json" > "$tmp/fixture-four-items.json"
+for version in v0.49.6 v0.55.4; do
+    if strict_snapshot_has_expected_fixture "$version" "$tmp/fixture-four-items.json" >/dev/null 2>&1; then
+        fail "$version source fixture with four items was accepted"
+    fi
+done
+jq '. + [{"id":"old-extra","title":"Unexpected extra issue"}]' \
+    "$tmp/fixture.json" > "$tmp/fixture-six-items.json"
+for version in v0.49.6 v0.55.4; do
+    if strict_snapshot_has_expected_fixture "$version" "$tmp/fixture-six-items.json" >/dev/null 2>&1; then
+        fail "$version source fixture with six items was accepted"
+    fi
+done
+jq 'map(if .id == "old-epic" then .issue_type = "task" else . end)' \
+    "$tmp/fixture.json" > "$tmp/fixture-wrong-epic.json"
+for version in v0.49.6 v0.55.4; do
+    if strict_snapshot_has_expected_fixture "$version" "$tmp/fixture-wrong-epic.json" >/dev/null 2>&1; then
+        fail "$version source fixture with an inexact epic was accepted"
+    fi
+done
 jq 'map(if .id == "old-standalone" then .external_ref = null else . end)' \
     "$tmp/fixture.json" > "$tmp/fixture-missing-rich-field.json"
 if strict_snapshot_has_expected_fixture v0.49.6 "$tmp/fixture-missing-rich-field.json" >/dev/null 2>&1; then
     fail "source fixture without the exact rich fields was accepted"
+fi
+if strict_snapshot_has_expected_fixture v0.55.4 "$tmp/fixture-missing-rich-field.json" >/dev/null 2>&1; then
+    fail "v0.55.4 source fixture without the exact rich fields was accepted"
 fi
 jq 'map(if .id == "old-task" then .labels = [] else . end)' \
     "$tmp/fixture.json" > "$tmp/fixture-missing-label.json"
 if strict_snapshot_has_expected_fixture v0.49.6 "$tmp/fixture-missing-label.json" >/dev/null 2>&1; then
     fail "source fixture without the exact label was accepted"
 fi
+if strict_snapshot_has_expected_fixture v0.55.4 "$tmp/fixture-missing-label.json" >/dev/null 2>&1; then
+    fail "v0.55.4 source fixture without the exact label was accepted"
+fi
 jq 'map(if .id == "old-bug" then .dependencies = [] else . end)' \
     "$tmp/fixture.json" > "$tmp/fixture-missing-dependency.json"
 if strict_snapshot_has_expected_fixture v0.49.6 "$tmp/fixture-missing-dependency.json" >/dev/null 2>&1; then
     fail "source fixture without the exact dependency was accepted"
+fi
+if strict_snapshot_has_expected_fixture v0.55.4 "$tmp/fixture-missing-dependency.json" >/dev/null 2>&1; then
+    fail "v0.55.4 source fixture without the exact dependency was accepted"
 fi
 
 mkdir -p "$tmp/source/.beads"
@@ -89,6 +152,218 @@ fi
     fail "rollback collision mutated the active source"
 [ ! -e "$tmp/collision/.beads/beads.db.pre-migration" ] ||
     fail "rollback preflight left a partial backup before reporting collision"
+
+fingerprint_root="$tmp/fingerprint-source/.beads"
+mkdir -p "$fingerprint_root/nested"
+printf 'stable bytes' > "$fingerprint_root/nested/data"
+ln -s nested/data "$fingerprint_root/data-link"
+fingerprint_one=$(source_artifact_fingerprint "$fingerprint_root") ||
+    fail "stable historical source could not be fingerprinted"
+fingerprint_two=$(source_artifact_fingerprint "$fingerprint_root") ||
+    fail "stable historical source could not be fingerprinted twice"
+[ "$fingerprint_one" = "$fingerprint_two" ] ||
+    fail "stable historical source produced different fingerprints"
+
+if (
+    find() { command find "$@"; return 1; }
+    source_artifact_fingerprint "$fingerprint_root"
+) >/dev/null 2>&1; then
+    fail "historical source fingerprint ignored a failed find"
+fi
+if (
+    stat() { return 1; }
+    source_artifact_fingerprint "$fingerprint_root"
+) >/dev/null 2>&1; then
+    fail "historical source fingerprint ignored a failed stat"
+fi
+if (
+    sha256_file() {
+        if [ "$1" = "./nested/data" ]; then
+            return 1
+        fi
+        sha256sum -- "$1" | awk '{print $1}'
+    }
+    source_artifact_fingerprint "$fingerprint_root"
+) >/dev/null 2>&1; then
+    fail "historical source fingerprint ignored a failed checksum"
+fi
+if (
+    sha256_file() {
+        if [[ "$1" == */bd-source-fingerprint.* ]]; then
+            return 1
+        fi
+        sha256sum -- "$1" | awk '{print $1}'
+    }
+    source_artifact_fingerprint "$fingerprint_root"
+) >/dev/null 2>&1; then
+    fail "historical source fingerprint ignored a failed final digest"
+fi
+if (
+    readlink() { return 1; }
+    source_artifact_fingerprint "$fingerprint_root"
+) >/dev/null 2>&1; then
+    fail "historical source fingerprint ignored a failed readlink"
+fi
+mkfifo "$fingerprint_root/unsupported-fifo"
+if source_artifact_fingerprint "$fingerprint_root" >/dev/null 2>&1; then
+    fail "historical source fingerprint accepted a special file"
+fi
+rm -f "$fingerprint_root/unsupported-fifo"
+printf 'changed bytes' >> "$fingerprint_root/nested/data"
+fingerprint_changed=$(source_artifact_fingerprint "$fingerprint_root") ||
+    fail "changed historical source could not be fingerprinted"
+[ "$fingerprint_changed" != "$fingerprint_one" ] ||
+    fail "historical source fingerprint ignored changed file bytes"
+
+mkdir -p "$tmp/legacy-source/.beads/dolt/nested"
+printf 'legacy table bytes' > "$tmp/legacy-source/.beads/dolt/nested/table.dat"
+printf 'legacy metadata' > "$tmp/legacy-source/.beads/metadata.json"
+printf 'legacy config json' > "$tmp/legacy-source/.beads/config.json"
+printf 'legacy config yaml' > "$tmp/legacy-source/.beads/config.yaml"
+legacy_manifest=$(legacy_dolt_artifact_manifest "$tmp/legacy-source/.beads")
+preserve_legacy_dolt_source "$tmp/legacy-source" "$legacy_manifest" ||
+    fail "unchanged legacy Dolt source could not be preserved"
+verify_retained_legacy_dolt_source "$tmp/legacy-source/.beads" "$legacy_manifest" ||
+    fail "unchanged retained legacy Dolt source was rejected"
+printf 'corruption' >> "$tmp/legacy-source/.beads/legacy-dolt.pre-migration/config.yaml"
+if verify_retained_legacy_dolt_source "$tmp/legacy-source/.beads" "$legacy_manifest" >/dev/null 2>&1; then
+    fail "mutated retained legacy Dolt source was accepted"
+fi
+
+mkdir -p "$tmp/legacy-collision/.beads/dolt" \
+    "$tmp/legacy-collision/.beads/legacy-dolt.pre-migration/dolt"
+printf 'active legacy data' > "$tmp/legacy-collision/.beads/dolt/table.dat"
+printf 'active metadata' > "$tmp/legacy-collision/.beads/metadata.json"
+printf 'stale legacy data' > "$tmp/legacy-collision/.beads/legacy-dolt.pre-migration/dolt/table.dat"
+collision_manifest=$(legacy_dolt_artifact_manifest "$tmp/legacy-collision/.beads")
+if preserve_legacy_dolt_source "$tmp/legacy-collision" "$collision_manifest" >/dev/null 2>&1; then
+    fail "stale legacy Dolt rollback collision was accepted"
+fi
+[ "$(legacy_dolt_artifact_manifest "$tmp/legacy-collision/.beads")" = "$collision_manifest" ] ||
+    fail "legacy Dolt rollback collision mutated the active source"
+if find "$tmp/legacy-collision/.beads" -maxdepth 1 \
+    -name '.legacy-dolt.pre-migration.tmp.*' -print -quit | grep -q .; then
+    fail "legacy Dolt rollback collision left a partial temporary backup"
+fi
+
+mkdir -p "$tmp/legacy-partial/.beads/dolt"
+printf 'active legacy data' > "$tmp/legacy-partial/.beads/dolt/table.dat"
+printf 'active metadata' > "$tmp/legacy-partial/.beads/metadata.json"
+partial_manifest=$(legacy_dolt_artifact_manifest "$tmp/legacy-partial/.beads")
+cp() {
+    local arg
+    for arg in "$@"; do
+        if [[ "$arg" == */metadata.json ]]; then
+            return 1
+        fi
+    done
+    command cp "$@"
+}
+if preserve_legacy_dolt_source "$tmp/legacy-partial" "$partial_manifest" >/dev/null 2>&1; then
+    unset -f cp
+    fail "partial legacy Dolt rollback copy was accepted"
+fi
+unset -f cp
+[ ! -e "$tmp/legacy-partial/.beads/legacy-dolt.pre-migration" ] ||
+    fail "partial legacy Dolt rollback copy published an incomplete backup"
+if find "$tmp/legacy-partial/.beads" -maxdepth 1 \
+    -name '.legacy-dolt.pre-migration.tmp.*' -print -quit | grep -q .; then
+    fail "partial legacy Dolt rollback copy left a temporary backup"
+fi
+[ "$(legacy_dolt_artifact_manifest "$tmp/legacy-partial/.beads")" = "$partial_manifest" ] ||
+    fail "partial legacy Dolt rollback copy mutated the active source"
+
+legacy_extra_ws="$tmp/legacy-extra"
+mkdir -p "$legacy_extra_ws/.beads/dolt"
+printf 'active data' > "$legacy_extra_ws/.beads/dolt/table.dat"
+printf 'active metadata' > "$legacy_extra_ws/.beads/metadata.json"
+legacy_extra_manifest=$(legacy_dolt_artifact_manifest "$legacy_extra_ws/.beads")
+preserve_legacy_dolt_source "$legacy_extra_ws" "$legacy_extra_manifest" ||
+    fail "could not create exact rollback source for extra-inventory test"
+printf 'stale extra' > "$legacy_extra_ws/.beads/legacy-dolt.pre-migration/unexpected"
+if verify_retained_legacy_dolt_source \
+    "$legacy_extra_ws/.beads" "$legacy_extra_manifest" >/dev/null 2>&1; then
+    fail "retained legacy Dolt source accepted unexpected top-level content"
+fi
+if preserve_legacy_dolt_source "$legacy_extra_ws" "$legacy_extra_manifest" >/dev/null 2>&1; then
+    fail "legacy Dolt preservation reused a rollback source with extra content"
+fi
+[ "$(legacy_dolt_artifact_manifest "$legacy_extra_ws/.beads")" = "$legacy_extra_manifest" ] ||
+    fail "extra rollback collision mutated the active legacy source"
+
+legacy_race_ws="$tmp/legacy-publish-race"
+legacy_race_calls="$tmp/legacy-publish-race.calls"
+legacy_race_old_bin="$tmp/fake-race-old-bd"
+legacy_race_candidate_bin="$tmp/fake-race-candidate-bd"
+legacy_race_before="$tmp/legacy-publish-race-before.json"
+mkdir -p "$legacy_race_ws/.beads/dolt"
+printf 'active race data' > "$legacy_race_ws/.beads/dolt/table.dat"
+printf 'active race metadata' > "$legacy_race_ws/.beads/metadata.json"
+legacy_race_manifest=$(legacy_dolt_artifact_manifest "$legacy_race_ws/.beads")
+printf '%s\n' '[{"id":"race-1"}]' > "$legacy_race_before"
+cat > "$legacy_race_old_bin" <<'EOF'
+#!/bin/bash
+printf 'old:%s\n' "$*" >> "$LEGACY_RACE_CALLS"
+exit 2
+EOF
+cat > "$legacy_race_candidate_bin" <<'EOF'
+#!/bin/bash
+printf 'candidate:%s\n' "$*" >> "$LEGACY_RACE_CALLS"
+exit 2
+EOF
+chmod +x "$legacy_race_old_bin" "$legacy_race_candidate_bin"
+export LEGACY_RACE_CALLS="$legacy_race_calls"
+: > "$legacy_race_calls"
+if (
+    stop_dolt_server() { :; }
+    publish_legacy_dolt_rollback() {
+        local source="$1"
+        local destination="$2"
+        mkdir -p "$destination"
+        printf 'racer sentinel' > "$destination/racer"
+        command mv --no-target-directory --no-clobber --no-copy -- "$source" "$destination"
+    }
+    recipe_server_to_embedded \
+        "$legacy_race_ws" "$legacy_race_old_bin" "$legacy_race_candidate_bin" \
+        v0.55.4 "$legacy_race_before"
+) >/dev/null 2>&1; then
+    fail "legacy Dolt rollback publication accepted a racing destination"
+fi
+[ ! -s "$legacy_race_calls" ] ||
+    fail "rollback publication race invoked a migration binary"
+[ "$(legacy_dolt_artifact_manifest "$legacy_race_ws/.beads")" = "$legacy_race_manifest" ] ||
+    fail "rollback publication race mutated the active legacy source"
+[ "$(cat "$legacy_race_ws/.beads/legacy-dolt.pre-migration/racer")" = "racer sentinel" ] ||
+    fail "rollback publication race replaced the competing destination"
+if find "$legacy_race_ws/.beads" -maxdepth 2 \
+    -name '.legacy-dolt.pre-migration.tmp.*' -print -quit | grep -q .; then
+    fail "rollback publication race left a temporary copy"
+fi
+
+[ "$(server_bridge_strategy v0.55.4)" = "native_export" ] ||
+    fail "v0.55.4 did not select its pinned server bridge strategy"
+for unsupported_version in v0.56.1 v0.57.0 v0.58.0 v9.9.9; do
+    if server_bridge_strategy "$unsupported_version" >/dev/null 2>&1; then
+        fail "$unsupported_version unexpectedly selected a server bridge strategy"
+    fi
+done
+
+unsupported_ws="$tmp/unsupported-server-bridge"
+unsupported_calls="$tmp/unsupported-server-bridge.calls"
+mkdir -p "$unsupported_ws/.beads/dolt"
+printf 'unsupported data' > "$unsupported_ws/.beads/dolt/table.dat"
+unsupported_fingerprint=$(source_artifact_fingerprint "$unsupported_ws/.beads")
+export LEGACY_RACE_CALLS="$unsupported_calls"
+: > "$unsupported_calls"
+if recipe_server_to_embedded \
+    "$unsupported_ws" "$legacy_race_old_bin" "$legacy_race_candidate_bin" \
+    v0.56.1 "$legacy_race_before" >/dev/null 2>&1; then
+    fail "unqualified v0.56.1 server bridge was accepted"
+fi
+[ ! -s "$unsupported_calls" ] ||
+    fail "unqualified server bridge invoked a migration binary"
+[ "$(source_artifact_fingerprint "$unsupported_ws/.beads")" = "$unsupported_fingerprint" ] ||
+    fail "unqualified server bridge mutated the historical source"
 
 RESULT_PATHS=("v0.49.6 → candidate")
 RESULT_STATUSES=("MANUAL")
@@ -133,6 +408,470 @@ printf '%s\n' \
 if check_fidelity v0.49.6 "$tmp/before-comment.json" "$tmp/after-comment.json" >/dev/null 2>&1; then
     fail "strict fidelity accepted changed comment text"
 fi
+
+snapshot_contract_ws="$tmp/snapshot-contract-workspace"
+snapshot_contract_bin="$tmp/fake-snapshot-contract-bd"
+mkdir -p "$snapshot_contract_ws"
+cat > "$snapshot_contract_bin" <<'EOF'
+#!/bin/bash
+case "$1" in
+    list)
+        case "$SNAPSHOT_LIST_SHAPE" in
+            array) printf '%s\n' '[{"id":"old-1","title":"One"}]' ;;
+            empty-id) printf '%s\n' '[{"id":"","title":"One"}]' ;;
+            object) printf '%s\n' '{"id":"old-1","title":"One"}' ;;
+            invalid) printf '%s\n' 'not JSON' ;;
+            *) exit 2 ;;
+        esac
+        [ "$SNAPSHOT_FAIL_COMMAND" != "list" ]
+        ;;
+    show)
+        printf '%s\n' '[{"id":"old-1","title":"One"}]'
+        [ "$SNAPSHOT_FAIL_COMMAND" != "show" ]
+        ;;
+    *)
+        exit 2
+        ;;
+esac
+EOF
+chmod +x "$snapshot_contract_bin"
+DATASET_IDS=([one]="old-1")
+
+assert_strict_snapshot_rejected() {
+    local name="$1"
+    local list_shape="$2"
+    local fail_command="$3"
+    export SNAPSHOT_LIST_SHAPE="$list_shape"
+    export SNAPSHOT_FAIL_COMMAND="$fail_command"
+    if capture_snapshot "$snapshot_contract_ws" "$snapshot_contract_bin" \
+        > "$tmp/rejected-snapshot.json" 2>/dev/null; then
+        fail "strict snapshot accepted $name"
+    fi
+}
+
+assert_strict_snapshot_rejected "valid list JSON from a nonzero command" array list
+assert_strict_snapshot_rejected "valid show JSON from a nonzero command" array show
+assert_strict_snapshot_rejected "malformed list JSON" invalid none
+assert_strict_snapshot_rejected "a list JSON object" object none
+assert_strict_snapshot_rejected "a list item with an empty id" empty-id none
+
+blocker_contract_ws="$tmp/blocker-contract-workspace"
+blocker_contract_bin="$tmp/fake-blocker-contract-bd"
+mkdir -p "$blocker_contract_ws"
+cat > "$blocker_contract_bin" <<'EOF'
+#!/bin/bash
+case "$1" in
+    blocked)
+        printf '%s\n' '[{"id":"old-bug"}]'
+        [ "$BLOCKER_FAIL_COMMAND" != "blocked" ]
+        ;;
+    ready)
+        if [ -e "$BLOCKER_STATE" ]; then
+            printf '%s\n' '[{"id":"old-bug"}]'
+        else
+            printf '%s\n' '[{"id":"old-task"}]'
+        fi
+        [ "$BLOCKER_FAIL_COMMAND" != "ready" ]
+        ;;
+    close)
+        : > "$BLOCKER_STATE"
+        ;;
+    *)
+        exit 2
+        ;;
+esac
+EOF
+chmod +x "$blocker_contract_bin"
+DATASET_FEATURES=("dependency")
+DATASET_IDS=([task]="old-task" [bug]="old-bug")
+export BLOCKER_STATE="$tmp/blocker-contract-closed"
+
+assert_blocker_command_failures_counted() {
+    local command="$1"
+    local expected_violations="$2"
+    local violations=0
+    export BLOCKER_FAIL_COMMAND="$command"
+    rm -f "$BLOCKER_STATE"
+    check_blocker_paths "$blocker_contract_ws" "$blocker_contract_bin" \
+        >/dev/null 2>&1 || violations=$?
+    [ "$violations" -eq "$expected_violations" ] ||
+        fail "nonzero $command produced $violations blocker violations, want $expected_violations"
+}
+
+assert_blocker_command_failures_counted blocked 1
+assert_blocker_command_failures_counted ready 2
+
+jsonl_contract_snapshot="$tmp/jsonl-contract-snapshot.json"
+jsonl_contract_file="$tmp/jsonl-contract.jsonl"
+printf '%s\n' '[{"id":"jsonl-1"},{"id":"jsonl-2"}]' > "$jsonl_contract_snapshot"
+printf '%s\n' '{"id":"jsonl-2"}' '{"id":"jsonl-1"}' > "$jsonl_contract_file"
+migration_jsonl_matches_snapshot "$jsonl_contract_file" "$jsonl_contract_snapshot" ||
+    fail "valid reordered historical JSONL did not match its source snapshot"
+
+assert_jsonl_contract_rejected() {
+    local name="$1"
+    shift
+    printf '%s\n' "$@" > "$jsonl_contract_file"
+    if migration_jsonl_matches_snapshot \
+        "$jsonl_contract_file" "$jsonl_contract_snapshot" >/dev/null 2>&1; then
+        fail "historical JSONL contract accepted $name"
+    fi
+}
+
+assert_jsonl_contract_rejected "malformed JSON" 'not JSON'
+assert_jsonl_contract_rejected "a blank record" '{"id":"jsonl-1"}' '   ' '{"id":"jsonl-2"}'
+assert_jsonl_contract_rejected "a duplicate id" '{"id":"jsonl-1"}' '{"id":"jsonl-1"}'
+assert_jsonl_contract_rejected "a missing id" '{"title":"missing"}' '{"id":"jsonl-2"}'
+assert_jsonl_contract_rejected "an empty id" '{"id":""}' '{"id":"jsonl-2"}'
+assert_jsonl_contract_rejected "an array record" '[{"id":"jsonl-1"}]' '{"id":"jsonl-2"}'
+assert_jsonl_contract_rejected "an extra id" '{"id":"jsonl-1"}' '{"id":"jsonl-2"}' '{"id":"jsonl-3"}'
+assert_jsonl_contract_rejected "a missing source id" '{"id":"jsonl-1"}'
+printf '%s\n' '{"id":"jsonl-1"} {"id":"jsonl-2"}' > "$jsonl_contract_file"
+if migration_jsonl_matches_snapshot \
+    "$jsonl_contract_file" "$jsonl_contract_snapshot" >/dev/null 2>&1; then
+    fail "historical JSONL contract accepted two records on one line"
+fi
+
+server_export_ws="$tmp/server-export-workspace"
+server_export_calls="$tmp/server-export-calls"
+server_export_old_bin="$tmp/fake-v0.55.4-bd"
+server_export_candidate_bin="$tmp/fake-candidate-bd"
+server_export_before="$tmp/server-export-before.json"
+mkdir -p "$server_export_ws/.beads/dolt"
+printf 'legacy Dolt data' > "$server_export_ws/.beads/dolt/table.dat"
+printf 'legacy metadata' > "$server_export_ws/.beads/metadata.json"
+printf '%s\n' '{"id":"old-task","title":"stale passive export"}' \
+    > "$server_export_ws/.beads/issues.jsonl"
+server_export_original_jsonl=$(sha256_file "$server_export_ws/.beads/issues.jsonl")
+: > "$server_export_calls"
+printf '%s\n' '[{"id":"old-task","title":"Implement core feature"}]' > "$server_export_before"
+cat > "$server_export_old_bin" <<'EOF'
+#!/bin/bash
+printf '%s\n' "$*" >> "$SERVER_EXPORT_CALLS"
+case "$1" in
+    list)
+        printf '%s\n' '[{"id":"old-task","title":"Implement core feature","comment_count":1}]'
+        ;;
+    export)
+        [ "$#" -eq 5 ] && [ "$2" = "--format" ] && [ "$3" = "jsonl" ] &&
+            [ "$4" = "-o" ] && [ -n "$5" ] || exit 2
+        printf '%s\n' '{"id":"old-task","title":"Implement core feature","comments":[{"author":"legacy-author","text":"Historical comment must survive the upgrade."}]}' > "$5"
+        ;;
+    *)
+        exit 2
+        ;;
+esac
+EOF
+cat > "$server_export_candidate_bin" <<'EOF'
+#!/bin/bash
+[ "$1" = "init" ] || exit 2
+for arg in "$@"; do
+    if [ "$arg" = "--from-jsonl" ]; then
+        jq -e 'select(.id == "old-task") | any(.comments[]?; .author == "legacy-author" and .text == "Historical comment must survive the upgrade.")' \
+            .beads/issues.jsonl >/dev/null
+        exit
+    fi
+done
+exit 1
+EOF
+chmod +x "$server_export_old_bin" "$server_export_candidate_bin"
+export SERVER_EXPORT_CALLS="$server_export_calls"
+if ! recipe_server_to_embedded \
+    "$server_export_ws" "$server_export_old_bin" "$server_export_candidate_bin" \
+    v0.55.4 "$server_export_before" \
+    >/dev/null; then
+    fail "server-to-embedded recipe lost comments exposed only by historical export"
+fi
+grep -E "^export --format jsonl -o $server_export_ws/\.beads/\.issues\.jsonl\.migration\.tmp\." \
+    "$server_export_calls" >/dev/null ||
+    fail "server-to-embedded recipe did not invoke historical export with an output path"
+jq -e 'select(.id == "old-task") | any(.comments[]?; .author == "legacy-author" and .text == "Historical comment must survive the upgrade.")' \
+    "$server_export_ws/.beads/issues.jsonl" >/dev/null ||
+    fail "server-to-embedded JSONL export omitted the historical comment body"
+[ "$(sha256_file "$server_export_ws/.beads/legacy-dolt.pre-migration/issues.jsonl")" = \
+    "$server_export_original_jsonl" ] ||
+    fail "server-to-embedded recipe did not retain the original passive JSONL"
+
+server_export_fail_ws="$tmp/server-export-failure-workspace"
+server_export_fail_old_bin="$tmp/fake-failing-v0.55.4-bd"
+server_export_fail_candidate_bin="$tmp/fake-unexpected-candidate-bd"
+server_export_fail_candidate_calls="$tmp/server-export-failure-candidate-calls"
+mkdir -p "$server_export_fail_ws/.beads/dolt"
+printf 'active legacy Dolt data' > "$server_export_fail_ws/.beads/dolt/table.dat"
+printf 'active legacy metadata' > "$server_export_fail_ws/.beads/metadata.json"
+server_export_fail_manifest=$(legacy_dolt_artifact_manifest "$server_export_fail_ws/.beads")
+cat > "$server_export_fail_old_bin" <<'EOF'
+#!/bin/bash
+[ "$1" = "export" ] || exit 2
+exit 1
+EOF
+cat > "$server_export_fail_candidate_bin" <<'EOF'
+#!/bin/bash
+printf '%s\n' "$*" >> "$SERVER_EXPORT_FAIL_CANDIDATE_CALLS"
+exit 1
+EOF
+chmod +x "$server_export_fail_old_bin" "$server_export_fail_candidate_bin"
+export SERVER_EXPORT_FAIL_CANDIDATE_CALLS="$server_export_fail_candidate_calls"
+: > "$server_export_fail_candidate_calls"
+if (
+    stop_dolt_server() { :; }
+    recipe_server_to_embedded \
+        "$server_export_fail_ws" "$server_export_fail_old_bin" \
+        "$server_export_fail_candidate_bin" v0.55.4 "$server_export_before"
+) >/dev/null; then
+    fail "server-to-embedded recipe accepted a failed historical export"
+fi
+server_export_fail_after=$(legacy_dolt_artifact_manifest "$server_export_fail_ws/.beads") ||
+    fail "failed historical export removed the active legacy source"
+[ "$server_export_fail_after" = "$server_export_fail_manifest" ] ||
+    fail "failed historical export mutated the active legacy source"
+[ ! -s "$server_export_fail_candidate_calls" ] ||
+    fail "failed historical export still invoked the candidate"
+verify_retained_legacy_dolt_source \
+    "$server_export_fail_ws/.beads" "$server_export_fail_manifest" ||
+    fail "failed historical export corrupted the retained rollback source"
+
+server_export_malformed_ws="$tmp/server-export-malformed-workspace"
+server_export_malformed_old_bin="$tmp/fake-malformed-v0.55.4-bd"
+mkdir -p "$server_export_malformed_ws/.beads/dolt"
+printf 'active malformed-test data' > "$server_export_malformed_ws/.beads/dolt/table.dat"
+printf 'active malformed-test metadata' > "$server_export_malformed_ws/.beads/metadata.json"
+server_export_malformed_manifest=$(legacy_dolt_artifact_manifest "$server_export_malformed_ws/.beads")
+cat > "$server_export_malformed_old_bin" <<'EOF'
+#!/bin/bash
+[ "$1" = "export" ] && [ "$4" = "-o" ] && [ -n "$5" ] || exit 2
+printf '%s\n' 'not JSONL' > "$5"
+EOF
+chmod +x "$server_export_malformed_old_bin"
+: > "$server_export_fail_candidate_calls"
+if (
+    stop_dolt_server() { :; }
+    recipe_server_to_embedded \
+        "$server_export_malformed_ws" "$server_export_malformed_old_bin" \
+        "$server_export_fail_candidate_bin" v0.55.4 "$server_export_before"
+) >/dev/null; then
+    fail "server-to-embedded recipe accepted malformed historical JSONL"
+fi
+[ ! -s "$server_export_fail_candidate_calls" ] ||
+    fail "malformed historical export still invoked the candidate"
+[ "$(legacy_dolt_artifact_manifest "$server_export_malformed_ws/.beads")" = \
+    "$server_export_malformed_manifest" ] ||
+    fail "malformed historical export mutated the active legacy source"
+[ ! -e "$server_export_malformed_ws/.beads/issues.jsonl" ] ||
+    fail "malformed historical export was published"
+if find "$server_export_malformed_ws/.beads" -maxdepth 1 \
+    -name '.issues.jsonl.migration.tmp.*' -print -quit | grep -q .; then
+    fail "malformed historical export left a temporary file"
+fi
+
+server_export_symlink_ws="$tmp/server-export-symlink-workspace"
+server_export_symlink_target="$tmp/server-export-symlink-target"
+mkdir -p "$server_export_symlink_ws/.beads/dolt"
+printf 'active symlink-test data' > "$server_export_symlink_ws/.beads/dolt/table.dat"
+printf 'external sentinel' > "$server_export_symlink_target"
+ln -s "$server_export_symlink_target" "$server_export_symlink_ws/.beads/issues.jsonl"
+if recipe_server_to_embedded \
+    "$server_export_symlink_ws" "$server_export_fail_old_bin" \
+    "$server_export_fail_candidate_bin" v0.55.4 "$server_export_before" \
+    >/dev/null 2>&1; then
+    fail "server-to-embedded recipe accepted a symlinked JSONL destination"
+fi
+[ "$(cat "$server_export_symlink_target")" = "external sentinel" ] ||
+    fail "server-to-embedded recipe followed a symlinked JSONL destination"
+[ ! -e "$server_export_symlink_ws/.beads/legacy-dolt.pre-migration" ] ||
+    fail "unsafe JSONL destination was detected only after rollback mutation"
+
+rollback_corruption_ws="$tmp/rollback-corruption-workspace"
+rollback_corruption_old_bin="$tmp/fake-rollback-corrupting-v0.55.4-bd"
+rollback_corruption_candidate_calls="$tmp/rollback-corruption-candidate.calls"
+mkdir -p "$rollback_corruption_ws/.beads/dolt"
+printf 'active corruption-test data' > "$rollback_corruption_ws/.beads/dolt/table.dat"
+printf 'active corruption-test metadata' > "$rollback_corruption_ws/.beads/metadata.json"
+printf 'active corruption-test config' > "$rollback_corruption_ws/.beads/config.yaml"
+cat > "$rollback_corruption_old_bin" <<'EOF'
+#!/bin/bash
+[ "$1" = "export" ] && [ "$4" = "-o" ] && [ -n "$5" ] || exit 2
+printf '%s\n' '{"id":"old-task","title":"Implement core feature"}' > "$5"
+printf 'corrupted during export' >> .beads/legacy-dolt.pre-migration/metadata.json
+EOF
+chmod +x "$rollback_corruption_old_bin"
+export SERVER_EXPORT_FAIL_CANDIDATE_CALLS="$rollback_corruption_candidate_calls"
+: > "$rollback_corruption_candidate_calls"
+if (
+    stop_dolt_server() { :; }
+    recipe_server_to_embedded \
+        "$rollback_corruption_ws" "$rollback_corruption_old_bin" \
+        "$server_export_fail_candidate_bin" v0.55.4 "$server_export_before"
+) >/dev/null 2>&1; then
+    fail "server-to-embedded recipe accepted rollback corruption during export"
+fi
+[ ! -s "$rollback_corruption_candidate_calls" ] ||
+    fail "rollback corruption during export still invoked the candidate"
+[ "$(cat "$rollback_corruption_ws/.beads/metadata.json")" = \
+    "active corruption-test metadata" ] ||
+    fail "rollback corruption caused active metadata deletion"
+[ "$(cat "$rollback_corruption_ws/.beads/config.yaml")" = \
+    "active corruption-test config" ] ||
+    fail "rollback corruption changed active config"
+[ "$(cat "$rollback_corruption_ws/.beads/dolt/table.dat")" = \
+    "active corruption-test data" ] ||
+    fail "rollback corruption changed active Dolt data"
+
+metadata_removal_ws="$tmp/metadata-removal-failure-workspace"
+metadata_removal_old_calls="$tmp/metadata-removal-old.calls"
+metadata_removal_candidate_calls="$tmp/metadata-removal-candidate.calls"
+mkdir -p "$metadata_removal_ws/.beads/dolt"
+printf 'active removal-test data' > "$metadata_removal_ws/.beads/dolt/table.dat"
+printf 'active removal-test metadata' > "$metadata_removal_ws/.beads/metadata.json"
+export SERVER_EXPORT_CALLS="$metadata_removal_old_calls"
+export SERVER_EXPORT_FAIL_CANDIDATE_CALLS="$metadata_removal_candidate_calls"
+: > "$metadata_removal_old_calls"
+: > "$metadata_removal_candidate_calls"
+if (
+    stop_dolt_server() { :; }
+    rm() {
+        local arg
+        for arg in "$@"; do
+            if [[ "$arg" == */metadata.json ]]; then
+                return 1
+            fi
+        done
+        command rm "$@"
+    }
+    recipe_server_to_embedded \
+        "$metadata_removal_ws" "$server_export_old_bin" \
+        "$server_export_fail_candidate_bin" v0.55.4 "$server_export_before"
+) >/dev/null; then
+    fail "server-to-embedded recipe ignored active metadata removal failure"
+fi
+[ ! -s "$metadata_removal_candidate_calls" ] ||
+    fail "active metadata removal failure still invoked the candidate"
+[ "$(cat "$metadata_removal_ws/.beads/metadata.json")" = \
+    "active removal-test metadata" ] ||
+    fail "active metadata removal failure changed metadata"
+[ "$(cat "$metadata_removal_ws/.beads/dolt/table.dat")" = \
+    "active removal-test data" ] ||
+    fail "active metadata removal failure changed Dolt data"
+
+probe_list_ws="$tmp/probe-list-workspace"
+probe_list_bin="$tmp/fake-probe-list-bd"
+mkdir -p "$probe_list_ws"
+cat > "$probe_list_bin" <<'EOF'
+#!/bin/bash
+[ "$1" = "list" ] || exit 2
+printf '%s' "$PROBE_LIST_OUTPUT"
+exit "$PROBE_LIST_EXIT"
+EOF
+chmod +x "$probe_list_bin"
+
+assert_probe_list_rejected() {
+    local name="$1"
+    local output="$2"
+    local exit_code="$3"
+    export PROBE_LIST_OUTPUT="$output"
+    export PROBE_LIST_EXIT="$exit_code"
+    if candidate_list_has_nonempty_issue_ids "$probe_list_ws" "$probe_list_bin"; then
+        fail "candidate list probe accepted $name"
+    fi
+}
+
+assert_probe_list_rejected "invalid output" 'not JSON' 0
+assert_probe_list_rejected "valid JSON from a nonzero command" '[{"id":"old-1"}]' 1
+assert_probe_list_rejected "an empty array" '[]' 0
+assert_probe_list_rejected "a JSON object" '{"id":"old-1"}' 0
+assert_probe_list_rejected "an empty issue id" '[{"id":""}]' 0
+assert_probe_list_rejected "a non-string issue id" '[{"id":7}]' 0
+assert_probe_list_rejected "multiple JSON documents" $'[{"id":"old-1"}]\n[{"id":"old-2"}]' 0
+export PROBE_LIST_OUTPUT='[{"id":"old-1"},{"id":"old-2"}]'
+export PROBE_LIST_EXIT=0
+candidate_list_has_nonempty_issue_ids "$probe_list_ws" "$probe_list_bin" ||
+    fail "candidate list probe rejected a valid nonempty issue array"
+
+probe_flow_bin="$tmp/fake-probe-flow-bd"
+cat > "$probe_flow_bin" <<'EOF'
+#!/bin/bash
+printf '%s\n' "$1" >> "$PROBE_FLOW_LOG"
+case "$PROBE_FLOW_MODE:$1" in
+    first-list-mutation:list)
+        printf 'mutated\n' >> .beads/source-marker
+        exit 1
+        ;;
+    init-mutation:list|safe-failure:list)
+        exit 1
+        ;;
+    init-mutation:init)
+        printf 'mutated\n' >> .beads/source-marker
+        exit 1
+        ;;
+    safe-failure:init)
+        exit 1
+        ;;
+    second-list-mutation:list|retry-success:list)
+        count=0
+        [ ! -f "$PROBE_FLOW_STATE" ] || count=$(cat "$PROBE_FLOW_STATE")
+        count=$((count + 1))
+        printf '%s\n' "$count" > "$PROBE_FLOW_STATE"
+        if [ "$count" -eq 1 ]; then
+            exit 1
+        fi
+        if [ "$PROBE_FLOW_MODE" = "second-list-mutation" ]; then
+            printf 'mutated\n' >> .beads/source-marker
+            printf '%s\n' '[]'
+        else
+            printf '%s\n' '[{"id":"old-1"}]'
+        fi
+        ;;
+    second-list-mutation:init|retry-success:init)
+        exit 0
+        ;;
+    *)
+        exit 2
+        ;;
+esac
+EOF
+chmod +x "$probe_flow_bin"
+
+assert_probe_flow() {
+    local mode="$1"
+    local expected_status="$2"
+    local expected_calls="$3"
+    local ws="$tmp/probe-flow-$mode"
+    local status=0
+    local actual_calls
+    local source_fingerprint
+
+    mkdir -p "$ws/.beads"
+    printf 'original\n' > "$ws/.beads/source-marker"
+    export PROBE_FLOW_MODE="$mode"
+    export PROBE_FLOW_LOG="$tmp/probe-flow-$mode.calls"
+    export PROBE_FLOW_STATE="$tmp/probe-flow-$mode.state"
+    : > "$PROBE_FLOW_LOG"
+    rm -f "$PROBE_FLOW_STATE"
+    source_fingerprint=$(source_artifact_fingerprint "$ws/.beads") ||
+        fail "could not fingerprint fake probe source for $mode"
+
+    if (
+        stop_dolt_server() { :; }
+        probe_candidate_direct_upgrade "$ws" "$probe_flow_bin" \
+            "$source_fingerprint" true
+    ); then
+        status=0
+    else
+        status=$?
+    fi
+
+    [ "$status" -eq "$expected_status" ] ||
+        fail "candidate probe $mode returned $status, want $expected_status"
+    actual_calls=$(paste -sd, "$PROBE_FLOW_LOG")
+    [ "$actual_calls" = "$expected_calls" ] ||
+        fail "candidate probe $mode called $actual_calls, want $expected_calls"
+}
+
+assert_probe_flow first-list-mutation 2 list
+assert_probe_flow init-mutation 2 list,init
+assert_probe_flow second-list-mutation 2 list,init,list
+assert_probe_flow safe-failure 1 list,init
+assert_probe_flow retry-success 0 list,init,list
 
 fake="$tmp/fake-bd"
 printf '%s\n' \


### PR DESCRIPTION
## What

Adds a second checksum-pinned historical upgrade gate to normal PR CI: an official v0.55.4 legacy Dolt-directory workspace upgraded by the current multi-provider candidate through the explicit `server_to_embedded` bridge.

This is stacked on #4802 (pre-store compatibility guard), which is stacked on #4801 (v0.49.6 SQLite upgrade gate).

## Why

The existing strict gate proves only the v0.49.6 SQLite era. Users also have real v0.55.x Dolt-directory workspaces, and that path must prove both data fidelity and non-destructive failure behavior before an upgrade can be called deterministic.

The riskiest behavior in this diff is the historical bridge's source handling. It now creates and verifies an exact rollback copy before any removal, rejects collisions and partial exports, checks source immutability after failed candidate probes, and refuses to invoke the candidate after any preservation or extraction failure.

Tracks `bd-ldt0f.3.23`.

## Safety and migration checklist

- [x] Official archive name and SHA-256 are pinned explicitly.
- [x] Failed direct probes must leave the complete source tree byte-identical.
- [x] Historical export must be valid JSONL with unique IDs and exact fixture inventory.
- [x] Rollback publication is atomic, collision-safe, and verified before destructive removal.
- [x] Every removal checks command success and verifies absence.
- [x] Final candidate snapshot requires all five issues, eight semantic features, and preserved comment bodies.
- [x] v0.49.6 remains an independent matrix cell with fail-fast disabled.
- [x] No production command, storage driver, schema, public API, or automatic-migration policy changes.
- [ ] Human review is required before merge; this PR must not be self-merged.

## Verification

Passed on the exact reviewed diff:

```text
./scripts/migration-test/strict-mode-test.sh
bash -n scripts/migration-test/lib/direct_probe.sh scripts/migration-test/lib/snapshot.sh scripts/migration-test/lib/versions.sh scripts/migration-test/recipes/server_to_embedded.sh scripts/migration-test/run.sh scripts/migration-test/strict-mode-test.sh
actionlint .github/workflows/migration-test.yml
git diff --check
CANDIDATE_BIN="$PWD/bd" GIT_CONFIG_NOSYSTEM=1 ./scripts/migration-test/run.sh --strict --expect MANUAL v0.49.6
CANDIDATE_BIN="$PWD/bd" GIT_CONFIG_NOSYSTEM=1 ./scripts/migration-test/run.sh --strict --expect MANUAL v0.55.4
```

Observed real-lane results:

- v0.49.6: `MANUAL(sqlite_to_current)`, 5/5 issues, 8 features, 0 violations.
- v0.55.4: `MANUAL(server_to_embedded)`, 5/5 issues, 8 features, comment preserved, 0 violations.

Three independent exact-diff reviews approved SHA-256 `7de803125f4408a761cd3f100a7eadfcb0bcb3e55572bdcfba002145aa114083` with 0 Critical and 0 Important findings.

`make test` was also attempted, but this shared host run timed out in unrelated process-spawning tests (`TestInitMetricsEmittedPerDoltMode` and `TestIsDoltProcessSelf`) while concurrent agents were exercising historical Dolt binaries. No Go files are changed here; isolated PR CI is the repository-wide gate.

---

Authored by an automated Codex agent on behalf of Test User.
