### PR TITLE
test(windows): make the cmd/bd and storage suites pass on Windows

### DIFF
--- a/cmd/bd/bootstrap_test.go
+++ b/cmd/bd/bootstrap_test.go
@@ -955,9 +955,12 @@ func TestDetectBootstrapAction_SharedServerEnvUsesSharedPath(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Override HOME so SharedDoltDir() resolves to our temp directory
-	// instead of the real ~/.beads/shared-server/dolt/.
+	// Override the home dir so SharedDoltDir() resolves to our temp directory
+	// instead of the real ~/.beads/shared-server/dolt/. It goes through
+	// os.UserHomeDir(), which reads USERPROFILE on Windows and HOME elsewhere,
+	// so both must be set for this to be portable.
 	t.Setenv("HOME", tmpDir)
+	t.Setenv("USERPROFILE", tmpDir)
 
 	// Create a database directory at the shared-server location.
 	// SharedDoltDir() returns $HOME/.beads/shared-server/dolt/.
@@ -1093,7 +1096,11 @@ func TestDetectBootstrapAction_SynthesizedDirWithoutRecoveryStillUsesExistingSha
 	t.Setenv("BEADS_DOLT_SHARED_SERVER", "1")
 
 	homeDir := t.TempDir()
+	// detectBootstrapAction resolves the home dir with os.UserHomeDir(), which reads
+	// USERPROFILE on Windows and HOME elsewhere; set both so the shared-server probe
+	// looks inside the temp home on every platform.
 	t.Setenv("HOME", homeDir)
+	t.Setenv("USERPROFILE", homeDir)
 
 	worktreeDir := filepath.Join(t.TempDir(), "worktree")
 	if err := os.MkdirAll(worktreeDir, 0o750); err != nil {

--- a/cmd/bd/context_cmd_test.go
+++ b/cmd/bd/context_cmd_test.go
@@ -268,9 +268,14 @@ func TestContextInfo_SaveStripAbsoluteDataDir(t *testing.T) {
 		t.Fatalf("mkdir: %v", err)
 	}
 
+	// Save() strips DoltDataDir when filepath.IsAbs() reports it absolute, so the
+	// fixture must be absolute ON THIS PLATFORM: a POSIX path like /absolute/path is
+	// NOT absolute on Windows (no volume), which silently turned this into a no-op
+	// assertion there. t.TempDir() is always platform-absolute.
+	absDataDir := filepath.Join(t.TempDir(), "dolt-data")
 	cfg := &configfile.Config{
 		Database:    "dolt",
-		DoltDataDir: "/absolute/path/dolt-data",
+		DoltDataDir: absDataDir,
 	}
 	if err := cfg.Save(beadsDir); err != nil {
 		t.Fatalf("save config: %v", err)

--- a/cmd/bd/db_proxy_child_test.go
+++ b/cmd/bd/db_proxy_child_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/steveyegge/beads/internal/configfile"
@@ -34,10 +36,18 @@ func TestNewDatabaseServer_BackendExternal(t *testing.T) {
 	})
 
 	t.Run("unix socket config builds an ExternalDoltServer", func(t *testing.T) {
+		// ExternalDoltConfig.Validate() requires an absolute Socket via filepath.IsAbs,
+		// which is platform-dependent: /var/run/dolt.sock is NOT absolute on Windows
+		// (no volume). Use a platform-absolute socket path so the same construction
+		// path is exercised everywhere.
+		socket := "/var/run/dolt.sock"
+		if runtime.GOOS == "windows" {
+			socket = filepath.Join(t.TempDir(), "dolt.sock")
+		}
 		srv, err := newDatabaseServer(
 			proxy.BackendExternal,
 			"", "", "", "", "",
-			configfile.ExternalDoltConfig{Socket: "/var/run/dolt.sock"},
+			configfile.ExternalDoltConfig{Socket: socket},
 		)
 		require.NoError(t, err)
 		require.NotNil(t, srv)

--- a/cmd/bd/doctor_test.go
+++ b/cmd/bd/doctor_test.go
@@ -544,10 +544,11 @@ func TestGetClaudePluginVersion(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			// Temporarily override home directory
-			origHome := os.Getenv("HOME")
-			os.Setenv("HOME", tmpHome)
-			defer os.Setenv("HOME", origHome)
+			// Temporarily override the home directory. GetClaudePluginVersion resolves it
+			// with os.UserHomeDir(), which reads USERPROFILE on Windows and HOME elsewhere,
+			// so both must be set for this to be portable (t.Setenv also restores them).
+			t.Setenv("HOME", tmpHome)
+			t.Setenv("USERPROFILE", tmpHome)
 
 			version, installed, err := doctor.GetClaudePluginVersion()
 

--- a/internal/storage/dolt/pull_branch_tracking_test.go
+++ b/internal/storage/dolt/pull_branch_tracking_test.go
@@ -65,6 +65,15 @@ func TestPullWithAutoResolve_BranchTrackingFallback(t *testing.T) {
 }
 
 func TestPullWithAutoResolve_BranchTrackingFallbackSuccess(t *testing.T) {
+	// The fallback assertion needs a real file:// remote, which is built with the
+	// dolt CLI (runDoltCmdForBranchTracking / runDoltSQLForBranchTracking). Skip when
+	// the binary is absent, matching the existing guard in this package
+	// (bootstrap_test.go, fsck_test.go). The store itself talks the MySQL protocol
+	// and needs no local dolt binary.
+	if _, err := exec.LookPath("dolt"); err != nil {
+		t.Skip("dolt CLI not available")
+	}
+
 	remoteDir := filepath.Join(t.TempDir(), "remote")
 	if err := os.MkdirAll(remoteDir, 0o755); err != nil {
 		t.Fatalf("mkdir remote: %v", err)

--- a/internal/storage/embeddeddolt/create_issue_test.go
+++ b/internal/storage/embeddeddolt/create_issue_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"strings"
 	"testing"
@@ -1265,6 +1266,14 @@ func TestCreateIssues(t *testing.T) {
 }
 
 func TestHookFiringStoreCreateIssuesFiresDependencyUpdatesFromEmbeddedStore(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		// The hook runner on Windows executes hook files directly via CreateProcess,
+		// which has no shebang dispatch. The extensionless #!/bin/sh hook written by
+		// newEmbeddedHookStore cannot be executed as a shell script, so no payload is
+		// ever logged and the assertions fail. Same limitation already skipped in
+		// internal/hooks/hooks_test.go. See: https://github.com/gastownhall/beads/issues/3800
+		t.Skip("hook script execution not supported on Windows - see GH#3800")
+	}
 	t.Run("non_transactional", func(t *testing.T) {
 		te := newTestEnv(t, "hk")
 		ctx := t.Context()


### PR DESCRIPTION
## What

Make the `cmd/bd` and storage test suites pass on Windows (and on hosts without the `dolt` CLI). Test-only — no product-code changes.

## Why

Six tests fail on a Windows checkout for platform-portability reasons unrelated to the code under test:

- **HOME vs USERPROFILE** — `TestGetClaudePluginVersion` and two `TestDetectBootstrapAction_*` cases override `HOME` to redirect discovery at a temp dir, but the code resolves the home dir with `os.UserHomeDir()`, which reads `USERPROFILE` on Windows.
- **filepath.IsAbs** — `TestContextInfo_SaveStripAbsoluteDataDir` and `TestNewDatabaseServer_BackendExternal` use the POSIX literals `"/absolute/path"` / `"/var/run/dolt.sock"`, which `filepath.IsAbs` reports as **not** absolute on Windows (no volume) — so the assertions were silent no-ops there.
- **GH#3800** — the embedded-Dolt hook-firing test writes an extensionless `#!/bin/sh` hook, which Windows `CreateProcess` cannot execute (no shebang dispatch).
- **dolt CLI absent** — the branch-tracking pull test builds its `file://` remote with the `dolt` CLI, so it hard-fails with `exec: "dolt": executable file not found` on hosts without the binary.

## Fix

Four focused commits, one per class:

1. `test(windows): resolve the home dir via USERPROFILE` — set both `HOME` and `USERPROFILE`.
2. `test(windows): use platform-absolute paths in fixtures` — derive absolute paths from `t.TempDir()`.
3. `test: skip embedded hook-firing test on Windows (GH#3800)` — matches the existing `runtime.GOOS == "windows"` skip in `internal/hooks/hooks_test.go`.
4. `test: skip branch-tracking pull test when the dolt CLI is absent` — matches the existing `exec.LookPath` guards in `bootstrap_test.go` / `fsck_test.go`.

Each skip/guard follows a convention already present in the same package.

## Verification

```
go test -tags gms_pure_go -run 'TestGetClaudePluginVersion|TestDetectBootstrapAction|TestContextInfo_SaveStripAbsoluteDataDir|TestNewDatabaseServer_BackendExternal' ./cmd/bd/   # pass on Windows
go test -tags gms_pure_go -run TestHookFiringStoreCreateIssuesFiresDependencyUpdatesFromEmbeddedStore ./internal/storage/embeddeddolt/   # skips on Windows
go test -tags gms_pure_go -run TestPullWithAutoResolve_BranchTrackingFallbackSuccess ./internal/storage/dolt/   # skips without the dolt CLI
go vet -tags gms_pure_go ./cmd/bd/ ./internal/storage/embeddeddolt/ ./internal/storage/dolt/   # clean
```

Linux/macOS behavior is unchanged: setting `USERPROFILE` is a no-op for `os.UserHomeDir()` there, and the fixtures stay absolute.

## Note

Companion to #4808 (the `config_drift` Windows server-liveness bug). These are the test-only portability fixes; #4808 is the one behavior change. Kept separate per CONTRIBUTING's one-issue-per-PR rule.

---

_Prepared with AI assistance (Claude Code); reviewed and submitted by the author. Disclosed via the `Agent-Signature:` trailers per `engdocs/AGENT_SIGNING.md`._
