### PR TITLE
Gate official v0.57.0 upgrades with a fail-closed Dolt bridge

### DIFF
--- a/.github/workflows/migration-test.yml
+++ b/.github/workflows/migration-test.yml
@@ -51,6 +51,10 @@ jobs:
             version: v0.55.4
             expected: MANUAL
             cache-identity: legacy-dolt-v0.55.4-e0fa25456dd82890230eef17653448a0bf995104c78864be91c5ed84426a5f49
+          - qualification: Legacy Dolt-dir v0.57.0
+            version: v0.57.0
+            expected: MANUAL
+            cache-identity: legacy-dolt-v0.57.0-f8629d5627bed7d25f06f92334addc171d679f9aed9d08c5d42a9684205dc04b
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
 
@@ -63,6 +67,27 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y jq sqlite3
+
+      - name: Install pinned Dolt runtime for v0.57.0
+        if: matrix.version == 'v0.57.0'
+        env:
+          HISTORICAL_VERSION: ${{ matrix.version }}
+        run: |
+          source scripts/migration-test/lib/versions.sh
+          DOLT_VERSION=$(strict_required_dolt_version "$HISTORICAL_VERSION")
+          DOLT_SHA256=$(strict_required_dolt_sha256 "$HISTORICAL_VERSION" linux amd64)
+          archive="$RUNNER_TEMP/dolt-linux-amd64.tar.gz"
+          extract_dir="$RUNNER_TEMP/dolt-${DOLT_VERSION}"
+          curl --fail --location --silent --show-error --retry 3 \
+            "https://github.com/dolthub/dolt/releases/download/v${DOLT_VERSION}/dolt-linux-amd64.tar.gz" \
+            --output "$archive"
+          printf '%s  %s\n' "$DOLT_SHA256" "$archive" | sha256sum --check --strict
+          mkdir -p "$extract_dir"
+          tar -xzf "$archive" -C "$extract_dir"
+          dolt_bin=$(find "$extract_dir" -type f -path '*/bin/dolt' -print -quit)
+          test -n "$dolt_bin"
+          sudo install -m 0755 "$dolt_bin" /usr/local/bin/dolt
+          test "$(dolt version | head -1)" = "dolt version ${DOLT_VERSION}"
 
       - name: Configure Git
         run: |

--- a/scripts/migration-test/lib/direct_probe.sh
+++ b/scripts/migration-test/lib/direct_probe.sh
@@ -30,7 +30,10 @@ candidate_probe_source_is_unchanged() {
     local stage="$3"
     local actual_fingerprint
 
-    stop_dolt_server "$ws"
+    if ! stop_dolt_server "$ws"; then
+        DIRECT_PROBE_FAILURE_DETAIL="could not prove the historical server stopped after candidate $stage"
+        return 1
+    fi
     if ! actual_fingerprint=$(source_artifact_fingerprint "$ws/.beads"); then
         DIRECT_PROBE_FAILURE_DETAIL="could not fingerprint historical source tree after candidate $stage"
         return 1

--- a/scripts/migration-test/lib/report.sh
+++ b/scripts/migration-test/lib/report.sh
@@ -28,6 +28,22 @@ record_result() {
     RESULT_VIOLATIONS+=("$violations")
 }
 
+record_result_after_workspace_cleanup() {
+    local ws="$1"
+    local path="$2"
+    local status="$3"
+    local detail="$4"
+    local recipe="${5:-}"
+    local violations="${6:-0}"
+
+    if ! cleanup_workspace "$ws"; then
+        record_result "$path" "BLOCKED" \
+            "could not prove isolated workspace cleanup; preserved at $ws" "" "$violations"
+        return 1
+    fi
+    record_result "$path" "$status" "$detail" "$recipe" "$violations"
+}
+
 print_results_table() {
     echo ""
     echo -e "${BOLD}Migration Test Results${NC}"

--- a/scripts/migration-test/lib/snapshot.sh
+++ b/scripts/migration-test/lib/snapshot.sh
@@ -149,7 +149,7 @@ strict_snapshot_has_expected_fixture() {
     local snapshot="$2"
 
     case "$version" in
-        v0.49.6|v0.55.4)
+        v0.49.6|v0.55.4|v0.57.0)
             local epic_id="${DATASET_IDS[epic]:-}"
             local standalone_id="${DATASET_IDS[standalone]:-}"
             local closed_id="${DATASET_IDS[closed]:-}"

--- a/scripts/migration-test/lib/versions.sh
+++ b/scripts/migration-test/lib/versions.sh
@@ -45,25 +45,37 @@ declare -ar LEGACY_DOLT_ROLLBACK_FILES=(
 declare -Ar STRICT_RELEASE_ASSETS=(
     ["v0.49.6|linux|amd64"]="beads_0.49.6_linux_amd64.tar.gz"
     ["v0.55.4|linux|amd64"]="beads_0.55.4_linux_amd64.tar.gz"
+    ["v0.57.0|linux|amd64"]="beads_0.57.0_linux_amd64.tar.gz"
 )
 declare -Ar STRICT_RELEASE_SHA256=(
     ["v0.49.6|linux|amd64"]="8546dc9a47e11dc31ac2bc9a0224a9c690975e91850932cbb62623053fbb7db8"
     ["v0.55.4|linux|amd64"]="e0fa25456dd82890230eef17653448a0bf995104c78864be91c5ed84426a5f49"
+    ["v0.57.0|linux|amd64"]="f8629d5627bed7d25f06f92334addc171d679f9aed9d08c5d42a9684205dc04b"
 )
 declare -Ar STRICT_EXPECTED_STATUSES=(
     ["v0.49.6"]="MANUAL"
     ["v0.55.4"]="MANUAL"
+    ["v0.57.0"]="MANUAL"
 )
 declare -Ar STRICT_EXPECTED_RECIPES=(
     ["v0.49.6"]="sqlite_to_current"
     ["v0.55.4"]="server_to_embedded"
+    ["v0.57.0"]="server_to_embedded"
 )
 declare -Ar STRICT_EXPECTED_FEATURES=(
     ["v0.49.6"]="epic task bug dependency standalone closed label comment"
     ["v0.55.4"]="epic task bug dependency standalone closed label comment"
+    ["v0.57.0"]="epic task bug dependency standalone closed label comment"
 )
 declare -Ar SERVER_BRIDGE_STRATEGIES=(
     ["v0.55.4"]="native_export"
+    ["v0.57.0"]="native_export_show_comments"
+)
+declare -Ar STRICT_REQUIRED_DOLT_VERSIONS=(
+    ["v0.57.0"]="2.1.8"
+)
+declare -Ar STRICT_REQUIRED_DOLT_SHA256=(
+    ["v0.57.0|linux|amd64"]="f66318f08ed66e409fc39363ae0fff8ce6fbf6dba9f5bac632b91527b9632a74"
 )
 
 strict_release_asset() {
@@ -100,6 +112,30 @@ server_bridge_strategy() {
     local value="${SERVER_BRIDGE_STRATEGIES[$1]:-}"
     [ -n "$value" ] || return 1
     printf '%s\n' "$value"
+}
+
+strict_required_dolt_version() {
+    local value="${STRICT_REQUIRED_DOLT_VERSIONS[$1]:-}"
+    [ -n "$value" ] || return 1
+    printf '%s\n' "$value"
+}
+
+strict_required_dolt_sha256() {
+    local value="${STRICT_REQUIRED_DOLT_SHA256["$1|$2|$3"]:-}"
+    [ -n "$value" ] || return 1
+    printf '%s\n' "$value"
+}
+
+verify_strict_historical_runtime() {
+    local version="$1"
+    local expected output
+
+    if ! expected=$(strict_required_dolt_version "$version"); then
+        return 0
+    fi
+    command -v dolt >/dev/null 2>&1 || return 1
+    output=$(dolt version 2>/dev/null) || return 1
+    grep -Fqx "dolt version $expected" <<< "$output"
 }
 
 strict_fixture_has_expected_features() {

--- a/scripts/migration-test/lib/workspace.sh
+++ b/scripts/migration-test/lib/workspace.sh
@@ -8,30 +8,301 @@
 # risk of polluting a production database.  Telemetry is opt-in (needs
 # BD_OTEL_METRICS_URL) and prompts are avoided by piping </dev/null.
 export BEADS_TEST_MODE="${BEADS_TEST_MODE:-0}"
-export GIT_CONFIG_NOSYSTEM="${GIT_CONFIG_NOSYSTEM:-1}"
+export GIT_CONFIG_NOSYSTEM=1
+export GIT_CONFIG_GLOBAL=/dev/null
 
 # Timeout for bd operations (seconds). Prevents hangs from dolt server
 # startup, embedded engine locks, etc.  Server-era versions may need the
 # full 30 s for a cold Dolt auto-start.
 BD_OP_TIMEOUT="${BD_OP_TIMEOUT:-30}"
 
-new_workspace() {
-    local dir
-    dir=$(mktemp -d /tmp/bd-migration-XXXXXX)
-    git -C "$dir" init --quiet
-    git -C "$dir" config user.name "migration-test"
-    git -C "$dir" config user.email "test@beads.test"
-    touch "$dir/.gitkeep"
-    git -C "$dir" add .
-    git -C "$dir" commit --quiet -m "initial"
-    echo "$dir"
+migration_server_port_in_use() {
+    local port="$1"
+    local hex table status
+    local inspected=false
+
+    [[ "$port" =~ ^[0-9]+$ ]] || return 2
+    hex=$(printf '%04X' "$port") || return 2
+    for table in /proc/net/tcp /proc/net/tcp6; do
+        [ -r "$table" ] || continue
+        inspected=true
+        if awk -v suffix=":$hex" '
+            $4 == "0A" && substr($2, length($2) - length(suffix) + 1) == suffix {
+                found = 1
+            }
+            END { exit(found ? 0 : 1) }
+        ' "$table"; then
+            return 0
+        else
+            status=$?
+            [ "$status" -eq 1 ] || return 2
+        fi
+    done
+    if ! $inspected; then
+        command -v lsof >/dev/null 2>&1 || return 2
+        if lsof -nP -iTCP:"$port" -sTCP:LISTEN -t >/dev/null 2>&1; then
+            return 0
+        else
+            status=$?
+            [ "$status" -eq 1 ] || return 2
+        fi
+    fi
+    return 1
 }
+
+migration_port_reservation_root() {
+    local root
+    root="${TMPDIR:-/tmp}/bd-migration-server-ports-$(id -u)"
+    if [ -L "$root" ]; then
+        return 1
+    fi
+    if [ ! -d "$root" ]; then
+        if ! mkdir -m 700 -- "$root" 2>/dev/null; then
+            [ -d "$root" ] && [ ! -L "$root" ] || return 1
+        fi
+    fi
+    [ -d "$root" ] && [ ! -L "$root" ] || return 1
+    [ "$(stat -c '%u' -- "$root")" = "$(id -u)" ] || return 1
+    chmod 700 -- "$root" || return 1
+    printf '%s\n' "$root"
+}
+
+reap_stale_migration_port_reservations() {
+    local root="$1"
+    local lock owner_file owner port status stale
+
+    [ -d "$root" ] && [ ! -L "$root" ] || return 1
+    for lock in "$root"/2????; do
+        [ -e "$lock" ] || continue
+        [ -d "$lock" ] && [ ! -L "$lock" ] || continue
+        port="${lock##*/}"
+        owner_file="$lock/owner"
+        owner=""
+        if [ -f "$owner_file" ] && [ ! -L "$owner_file" ]; then
+            owner=$(cat "$owner_file" 2>/dev/null) || owner=""
+        fi
+        if [[ "$owner" =~ ^[0-9]+$ ]] && kill -0 "$owner" 2>/dev/null; then
+            continue
+        fi
+        if migration_server_port_in_use "$port"; then
+            continue
+        else
+            status=$?
+            [ "$status" -eq 1 ] || continue
+        fi
+        stale="$lock.stale.$BASHPID.$RANDOM"
+        if mv --no-target-directory --no-clobber -- "$lock" "$stale" 2>/dev/null; then
+            rm -rf -- "$stale"
+        fi
+    done
+}
+
+reserve_migration_server_port() {
+    local ws="$1"
+    local git_dir="$ws/.git"
+    local port_file="$git_dir/bd-migration-server-port"
+    local lock_file="$git_dir/bd-migration-server-port-lock"
+    local root attempt port lock status
+
+    [ -d "$git_dir" ] && [ ! -L "$git_dir" ] || return 1
+    if [ -e "$port_file" ] || [ -L "$port_file" ] || \
+        [ -e "$lock_file" ] || [ -L "$lock_file" ]; then
+        return 1
+    fi
+    root=$(migration_port_reservation_root) || return 1
+    reap_stale_migration_port_reservations "$root" || return 1
+
+    for ((attempt = 0; attempt < 256; attempt++)); do
+        port=$((20000 + ((BASHPID + RANDOM + attempt * 997) % 10000)))
+        lock="$root/$port"
+        if ! mkdir -- "$lock" 2>/dev/null; then
+            continue
+        fi
+        if ! printf '%s\n' "$$" > "$lock/owner"; then
+            rm -f -- "$lock/owner"
+            rmdir -- "$lock" 2>/dev/null || true
+            return 1
+        fi
+        if migration_server_port_in_use "$port"; then
+            rm -f -- "$lock/owner"
+            rmdir -- "$lock" || return 1
+            continue
+        else
+            status=$?
+            if [ "$status" -ne 1 ]; then
+                rm -f -- "$lock/owner"
+                rmdir -- "$lock" 2>/dev/null || true
+                return 1
+            fi
+        fi
+        if ! printf '%s\n' "$port" > "$port_file" || \
+            ! printf '%s\n' "$lock" > "$lock_file"; then
+            rm -f -- "$port_file" "$lock_file"
+            rm -f -- "$lock/owner"
+            rmdir -- "$lock" 2>/dev/null || true
+            return 1
+        fi
+        return 0
+    done
+    return 1
+}
+
+release_migration_server_port() {
+    local ws="$1"
+    local git_dir="$ws/.git"
+    local port_file="$git_dir/bd-migration-server-port"
+    local lock_file="$git_dir/bd-migration-server-port-lock"
+    local root port lock owner
+
+    if [ ! -e "$port_file" ] && [ ! -L "$port_file" ] && \
+        [ ! -e "$lock_file" ] && [ ! -L "$lock_file" ]; then
+        return 0
+    fi
+    [ -f "$port_file" ] && [ ! -L "$port_file" ] || return 1
+    [ -f "$lock_file" ] && [ ! -L "$lock_file" ] || return 1
+    port=$(cat "$port_file") || return 1
+    lock=$(cat "$lock_file") || return 1
+    [[ "$port" =~ ^2[0-9]{4}$ ]] || return 1
+    root=$(migration_port_reservation_root) || return 1
+    [ "$lock" = "$root/$port" ] || return 1
+    [ -d "$lock" ] && [ ! -L "$lock" ] || return 1
+    [ -f "$lock/owner" ] && [ ! -L "$lock/owner" ] || return 1
+    owner=$(cat "$lock/owner") || return 1
+    [ "$owner" = "$$" ] || return 1
+    rm -f -- "$lock/owner" || return 1
+    rmdir -- "$lock" || return 1
+    rm -f -- "$port_file" "$lock_file" || return 1
+    [ ! -e "$port_file" ] && [ ! -L "$port_file" ] && \
+        [ ! -e "$lock_file" ] && [ ! -L "$lock_file" ]
+}
+
+prepare_migration_subprocess_home() {
+    local ws="$1"
+    local private_root home dir
+
+    [ -d "$ws" ] && [ ! -L "$ws" ] || return 1
+    [ "$(stat -c '%u' -- "$ws")" = "$(id -u)" ] || return 1
+    if [ -d "$ws/.git" ] && [ ! -L "$ws/.git" ]; then
+        private_root="$ws/.git"
+    else
+        private_root="$ws"
+    fi
+    home="$private_root/bd-migration-home"
+    for dir in \
+        "$home" "$home/.config" "$home/.cache" "$home/.local" \
+        "$home/.local/share" "$home/.local/state" \
+        "$private_root/bd-migration-tmp" "$private_root/bd-migration-runtime"; do
+        if [ -e "$dir" ] || [ -L "$dir" ]; then
+            [ -d "$dir" ] && [ ! -L "$dir" ] || return 1
+            [ "$(stat -c '%u' -- "$dir")" = "$(id -u)" ] || return 1
+        else
+            mkdir -m 700 -- "$dir" || return 1
+        fi
+        chmod 700 -- "$dir" || return 1
+    done
+    printf '%s\n' "$home"
+}
+
+new_workspace() (
+    local dir
+    local env_name
+
+    while IFS= read -r env_name; do
+        case "$env_name" in
+            GIT_*) unset "$env_name" ;;
+        esac
+    done < <(compgen -e)
+    export GIT_CONFIG_NOSYSTEM=1
+    export GIT_CONFIG_GLOBAL=/dev/null
+    export GIT_TERMINAL_PROMPT=0
+
+    dir=$(mktemp -d /tmp/bd-migration-XXXXXX) || return 1
+    if ! git -C "$dir" init --quiet || \
+        ! git -C "$dir" config core.hooksPath .git/hooks || \
+        ! git -C "$dir" config user.name "migration-test" || \
+        ! git -C "$dir" config user.email "test@beads.test" || \
+        ! touch "$dir/.gitkeep" || \
+        ! git -C "$dir" add . || \
+        ! git -C "$dir" commit --quiet -m "initial"; then
+        rm -rf -- "$dir"
+        return 1
+    fi
+    if ! reserve_migration_server_port "$dir"; then
+        rm -rf -- "$dir"
+        return 1
+    fi
+    if ! prepare_migration_subprocess_home "$dir" >/dev/null; then
+        release_migration_server_port "$dir" || true
+        rm -rf -- "$dir"
+        return 1
+    fi
+    echo "$dir"
+)
 
 bd_in() {
     local ws="$1"
     local bin="$2"
+    local port_file="$ws/.git/bd-migration-server-port"
+    local port=""
+    local subprocess_home private_root env_name
+    local -a clean_env
     shift 2
-    (cd "$ws" && timeout "$BD_OP_TIMEOUT" "$bin" "$@")
+    if [ -e "$port_file" ] || [ -L "$port_file" ]; then
+        [ -f "$port_file" ] && [ ! -L "$port_file" ] || return 1
+        port=$(cat "$port_file") || return 1
+        [[ "$port" =~ ^2[0-9]{4}$ ]] || return 1
+    fi
+    subprocess_home=$(prepare_migration_subprocess_home "$ws") || return 1
+    if [ -d "$ws/.git" ] && [ ! -L "$ws/.git" ]; then
+        private_root="$ws/.git"
+    else
+        private_root="$ws"
+    fi
+    clean_env=(
+        env -i
+        "PATH=$PATH"
+        "HOME=$subprocess_home"
+        "XDG_CONFIG_HOME=$subprocess_home/.config"
+        "XDG_CACHE_HOME=$subprocess_home/.cache"
+        "XDG_DATA_HOME=$subprocess_home/.local/share"
+        "XDG_STATE_HOME=$subprocess_home/.local/state"
+        "XDG_RUNTIME_DIR=$private_root/bd-migration-runtime"
+        "TMPDIR=$private_root/bd-migration-tmp"
+        "GIT_CONFIG_NOSYSTEM=1"
+        "GIT_CONFIG_GLOBAL=/dev/null"
+        "GIT_TERMINAL_PROMPT=0"
+        "BEADS_TEST_MODE=0"
+        "BEADS_NO_DAEMON=1"
+        "BEADS_DOLT_AUTO_START=1"
+        "BD_NON_INTERACTIVE=1"
+        "BD_NO_PAGER=1"
+        "BD_DISABLE_METRICS=1"
+        "BD_DISABLE_EVENT_FLUSH=1"
+        "NO_COLOR=1"
+        "CI=1"
+        "USER=migration-test"
+        "LOGNAME=migration-test"
+        "SHELL=/bin/bash"
+        "LANG=C.UTF-8"
+        "LC_ALL=C.UTF-8"
+        "TZ=UTC"
+        "TERM=dumb"
+    )
+    if [ -n "$port" ]; then
+        clean_env+=("BEADS_DOLT_SERVER_PORT=$port")
+    fi
+    for env_name in \
+        BLOCKER_FAIL_COMMAND BLOCKER_STATE LEGACY_RACE_CALLS \
+        PROBE_FLOW_LOG PROBE_FLOW_MODE PROBE_FLOW_STATE \
+        PROBE_LIST_EXIT PROBE_LIST_OUTPUT \
+        SERVER_EXPORT_CALLS SERVER_EXPORT_FAIL_CANDIDATE_CALLS \
+        SNAPSHOT_FAIL_COMMAND SNAPSHOT_LIST_SHAPE \
+        V057_CANDIDATE_CALLS V057_MODE V057_OLD_CALLS; do
+        if [[ -v "$env_name" ]]; then
+            clean_env+=("$env_name=${!env_name}")
+        fi
+    done
+    (cd "$ws" && "${clean_env[@]}" timeout "$BD_OP_TIMEOUT" "$bin" "$@")
 }
 
 # Create an issue, returning just the ID on stdout.
@@ -47,22 +318,114 @@ bd_create() {
     return 1
 }
 
+migration_workspace_owned_by_harness() {
+    local ws="$1"
+    local git_dir port_file lock_file root port lock owner
+
+    [[ "$ws" =~ ^/tmp/bd-migration-[[:alnum:]]{6}$ ]] || return 1
+    [ -d "$ws" ] && [ ! -L "$ws" ] || return 1
+    [ "$(stat -c '%u' -- "$ws")" = "$(id -u)" ] || return 1
+
+    git_dir="$ws/.git"
+    port_file="$git_dir/bd-migration-server-port"
+    lock_file="$git_dir/bd-migration-server-port-lock"
+    [ -d "$git_dir" ] && [ ! -L "$git_dir" ] || return 1
+    [ -f "$port_file" ] && [ ! -L "$port_file" ] || return 1
+    [ -f "$lock_file" ] && [ ! -L "$lock_file" ] || return 1
+
+    port=$(cat "$port_file") || return 1
+    lock=$(cat "$lock_file") || return 1
+    [[ "$port" =~ ^2[0-9]{4}$ ]] || return 1
+    root="${TMPDIR:-/tmp}/bd-migration-server-ports-$(id -u)"
+    [ -d "$root" ] && [ ! -L "$root" ] || return 1
+    [ "$(stat -c '%u' -- "$root")" = "$(id -u)" ] || return 1
+    [ "$lock" = "$root/$port" ] || return 1
+    [ -d "$lock" ] && [ ! -L "$lock" ] || return 1
+    [ -f "$lock/owner" ] && [ ! -L "$lock/owner" ] || return 1
+    owner=$(cat "$lock/owner") || return 1
+    [ "$owner" = "$$" ]
+}
+
+migration_process_command_line() {
+    local pid="$1"
+
+    if [ -r "/proc/$pid/cmdline" ]; then
+        tr '\0' ' ' < "/proc/$pid/cmdline"
+        return
+    fi
+    ps -p "$pid" -o command= 2>/dev/null
+}
+
+migration_process_cwd() {
+    local pid="$1"
+
+    if [ -L "/proc/$pid/cwd" ]; then
+        readlink "/proc/$pid/cwd"
+        return
+    fi
+    command -v lsof >/dev/null 2>&1 || return 1
+    lsof -a -p "$pid" -d cwd -Fn 2>/dev/null | sed -n 's/^n//p' | head -1
+}
+
+migration_pid_belongs_to_workspace() {
+    local pid="$1"
+    local ws="$2"
+    local pidfile_name="$3"
+    local command_line="" cwd="" dolt_root=""
+
+    [[ "$pid" =~ ^[0-9]+$ ]] && [ "$pid" -gt 1 ] || return 1
+    command_line=$(migration_process_command_line "$pid") || return 1
+    [ -n "$command_line" ] || return 1
+
+    case "$pidfile_name" in
+        dolt-server.pid)
+            [[ "$command_line" == *dolt* ]] && [[ "$command_line" == *sql-server* ]] || return 1
+            cwd=$(migration_process_cwd "$pid") || return 1
+            dolt_root=$(cd -P -- "$ws/.beads/dolt" 2>/dev/null && pwd) || return 1
+            [ "$cwd" = "$dolt_root" ] || [[ "$cwd" == "$dolt_root/"* ]]
+            ;;
+        dolt-monitor.pid)
+            [[ "$command_line" == *bd* ]] && [[ "$command_line" == *idle-monitor* ]] &&
+                [[ "$command_line" == *"$ws"* ]]
+            ;;
+        daemon.pid)
+            [[ "$command_line" == *bd* ]] && [[ "$command_line" == *daemon* ]] &&
+                [[ "$command_line" == *"$ws"* ]]
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
 stop_dolt_server() {
     local ws="$1"
-    local pid=""
-    for pidfile in "$ws/.beads/dolt-server.pid" "$ws/.beads/dolt-monitor.pid" "$ws/.beads/daemon.pid"; do
-        if [ -f "$pidfile" ]; then
+    local pid="" pidfile_name="" port="" status=0
+    migration_workspace_owned_by_harness "$ws" || return 1
+    for pidfile in "$ws/.beads/dolt-monitor.pid" "$ws/.beads/daemon.pid" "$ws/.beads/dolt-server.pid"; do
+        if [ -f "$pidfile" ] && [ ! -L "$pidfile" ]; then
             pid=$(cat "$pidfile" 2>/dev/null) || true
-            [ -n "$pid" ] && kill -9 "$pid" 2>/dev/null || true
+            pidfile_name="${pidfile##*/}"
+            if migration_pid_belongs_to_workspace "$pid" "$ws" "$pidfile_name"; then
+                kill -9 -- "$pid" 2>/dev/null || true
+            fi
         fi
     done
-    pkill -9 -f "$ws" 2>/dev/null || true
     sleep 1
+    port=$(cat "$ws/.git/bd-migration-server-port") || return 1
+    if migration_server_port_in_use "$port"; then
+        return 1
+    else
+        status=$?
+        [ "$status" -eq 1 ] || return 1
+    fi
     rm -f "$ws/.beads/bd.sock" "$ws/.beads/dolt-server.lock" 2>/dev/null || true
 }
 
 cleanup_workspace() {
     local ws="$1"
-    stop_dolt_server "$ws"
-    rm -rf "$ws"
+    migration_workspace_owned_by_harness "$ws" || return 1
+    stop_dolt_server "$ws" || return 1
+    release_migration_server_port "$ws" || return 1
+    rm -rf -- "$ws"
 }

--- a/scripts/migration-test/recipes/fix_dash_prefix.sh
+++ b/scripts/migration-test/recipes/fix_dash_prefix.sh
@@ -48,7 +48,10 @@ recipe_fix_dash_prefix() {
     echo "  sanitizing prefix: '$prefix' → '$sanitized'"
 
     # Stop server, export data, re-init with sanitized prefix
-    stop_dolt_server "$ws"
+    if ! stop_dolt_server "$ws"; then
+        echo "  FAILED: could not prove the workspace server stopped"
+        return 1
+    fi
 
     # Export data with old binary first
     local list_json

--- a/scripts/migration-test/recipes/server_to_embedded.sh
+++ b/scripts/migration-test/recipes/server_to_embedded.sh
@@ -1,20 +1,21 @@
 #!/bin/bash
-# Recipe: qualified v0.55.4 legacy Dolt directory → current embedded Dolt.
+# Recipe: qualified legacy Dolt directory → current embedded Dolt.
 #
-# Other v0.50.0–v0.58.0 releases need release-specific extraction: v0.56.1
-# has no export command, while v0.57/v0.58 exports omit comment bodies. Do not
-# extend this recipe to those releases without a lossless fixture-backed path.
+# Each server-era release needs an explicit extraction strategy. v0.55.4 has
+# a lossless native export for the qualified fixture. v0.57.0 needs its native
+# export enriched with comment bodies from one-item show queries. v0.56.1 and
+# v0.58.0 remain unqualified.
 #
 # Strategy:
 #   1. Stop any running Dolt server
-#   2. Export all data via old binary (which auto-starts its own server)
+#   2. Extract the qualified core fixture via the old binary
 #   3. Stop server, clear stale metadata, init with candidate
 #   4. If candidate DB is empty, reimport from JSONL export
 #
 # User-facing instructions:
-#   Use the pinned migration harness for v0.55.4. It stops the historical
-#   server, retains a byte-verified rollback tree, exports with the historical
-#   binary, validates the JSONL, and only then initializes the candidate.
+#   Use the pinned migration harness for qualified v0.55.4 and v0.57.0 core
+#   fixtures. It stops the historical server, retains a byte-verified rollback
+#   tree, extracts and validates JSONL, and only then initializes the candidate.
 
 publish_legacy_dolt_rollback() {
     mv --no-target-directory --no-clobber --no-copy -- "$1" "$2"
@@ -96,6 +97,196 @@ migration_jsonl_is_snapshot_subset() {
         <(printf '%s\n' "$existing_ids" | LC_ALL=C sort) \
         <(printf '%s\n' "$expected_ids" | LC_ALL=C sort)) || return 1
     [ -z "$extra_ids" ]
+}
+
+v057_export_matches_snapshot() {
+    local export_path="$1"
+    local before_snapshot="$2"
+
+    jq -en \
+        --slurpfile exports "$export_path" \
+        --slurpfile before "$before_snapshot" '
+        def by_id: map({key: .id, value: .}) | from_entries;
+        def core:
+            del(
+                .labels,
+                .dependencies,
+                .dependents,
+                .comments,
+                .comment_count,
+                .dependency_count,
+                .dependent_count,
+                .parent
+            );
+        def has_unsupported_issue_data:
+            has("crystallizes") or
+            has("creator") or
+            has("quality_score") or
+            has("validations") or
+            has("hook_bead") or
+            has("role_bead") or
+            has("agent_state") or
+            has("last_activity") or
+            has("role_type") or
+            has("rig") or
+            has("holder") or
+            has("closed_by_session");
+        ($exports | by_id) as $export |
+        ($before[0] | by_id) as $expected |
+        (($export | keys | sort) == ($expected | keys | sort)) and
+        ([($export | keys[]) as $id |
+            ($export[$id].labels // []) as $export_labels |
+            ($expected[$id].labels // []) as $expected_labels |
+            ($export[$id].dependencies // []) as $export_dependencies |
+            ($expected[$id].dependencies // []) as $expected_dependencies |
+            ($export[$id].dependency_count) as $dependency_count |
+            ($export[$id].comment_count) as $comment_count |
+            (($export[$id] | core) == ($expected[$id] | core)) and
+            (($export[$id] | has_unsupported_issue_data) | not) and
+            (($export_labels | type) == "array") and
+            (all($export_labels[]; type == "string")) and
+            (($export_labels | length) == ($export_labels | unique | length)) and
+            (($export_labels | sort) == ($expected_labels | sort)) and
+            (($export_dependencies | type) == "array") and
+            (all($export_dependencies[];
+                type == "object" and
+                .issue_id == $id and
+                ((.depends_on_id? | type) == "string") and
+                ((.depends_on_id? | length) > 0) and
+                ((.type? | type) == "string") and
+                ((.type? | length) > 0) and
+                ((.metadata? // "{}") as $metadata |
+                    (($metadata | type) == "string") and
+                    ((try ($metadata | fromjson) catch null) == {})) and
+                ((.thread_id? // "") == ""))) and
+            (($dependency_count | type) == "number") and
+            ($dependency_count >= 0) and
+            (($dependency_count | floor) == $dependency_count) and
+            ($dependency_count ==
+                ([$export_dependencies[] | select(.type == "blocks")] | length)) and
+            (([$export_dependencies[] | {id: .depends_on_id, type: .type}] |
+                sort_by(.id, .type)) ==
+             ([$expected_dependencies[] | {id: .id, type: .dependency_type}] |
+                sort_by(.id, .type))) and
+            (($comment_count | type) == "number") and
+            ($comment_count >= 0) and
+            (($comment_count | floor) == $comment_count)
+        ] | all)
+    ' >/dev/null 2>&1
+}
+
+v057_export_and_show_comments_agree() {
+    local export_path="$1"
+    local show_path="$2"
+    local before_snapshot="$3"
+
+    jq -en \
+        --slurpfile exports "$export_path" \
+        --slurpfile shows "$show_path" \
+        --slurpfile before "$before_snapshot" '
+        def by_id: map({key: .id, value: .}) | from_entries;
+        ($exports | by_id) as $export |
+        ($shows | by_id) as $show |
+        ($before[0] | by_id) as $expected |
+        (($export | keys | sort) == ($show | keys | sort)) and
+        (($export | keys | sort) == ($expected | keys | sort)) and
+        ([($export | keys[]) as $id |
+            ($export[$id].comment_count) as $count |
+            ($show[$id].comments // []) as $comments |
+            ($expected[$id].comments // []) as $expected_comments |
+            (($count | type) == "number") and
+            ($count >= 0) and
+            (($count | floor) == $count) and
+            (($comments | type) == "array") and
+            ($count == ($comments | length)) and
+            ($comments == $expected_comments) and
+            ($show[$id] == $expected[$id])
+        ] | all)
+    ' >/dev/null 2>&1
+}
+
+enrich_v057_export_comments() {
+    local ws="$1"
+    local old_bin="$2"
+    local export_path="$3"
+    local before_snapshot="$4"
+    local enriched_path="$5"
+    local show_path ids encoded_id id show_json show_record
+    local extraction_ok=true
+
+    [ -f "$export_path" ] && [ ! -L "$export_path" ] || return 1
+    [ -f "$before_snapshot" ] && [ ! -L "$before_snapshot" ] || return 1
+    [ -f "$enriched_path" ] && [ ! -L "$enriched_path" ] || return 1
+    migration_jsonl_matches_snapshot "$export_path" "$before_snapshot" || return 1
+    v057_export_matches_snapshot "$export_path" "$before_snapshot" || return 1
+
+    show_path=$(mktemp "$ws/.beads/.issues.jsonl.show.tmp.XXXXXX") || return 1
+    ids=$(jq -ce '.[] | .id' "$before_snapshot" 2>/dev/null) || extraction_ok=false
+
+    if $extraction_ok; then
+        while IFS= read -r encoded_id; do
+            id=$(jq -er 'if type == "string" and length > 0 then . else error("invalid id") end' \
+                <<< "$encoded_id" 2>/dev/null) || {
+                extraction_ok=false
+                break
+            }
+            if ! show_json=$(bd_in "$ws" "$old_bin" show --id="$id" --json 2>/dev/null); then
+                extraction_ok=false
+                break
+            fi
+            show_record=$(jq -ce --arg id "$id" '
+                if type == "array" and length == 1 and
+                    (.[0] | type) == "object" and
+                    ((.[0].id? | type) == "string") and
+                    .[0].id == $id and
+                    ((.[0].comments? // []) | type) == "array"
+                then .[0]
+                else error("invalid one-item show result")
+                end
+            ' <<< "$show_json" 2>/dev/null) || {
+                extraction_ok=false
+                break
+            }
+            if ! printf '%s\n' "$show_record" >> "$show_path"; then
+                extraction_ok=false
+                break
+            fi
+        done <<< "$ids"
+    fi
+
+    if $extraction_ok && \
+        migration_jsonl_matches_snapshot "$show_path" "$before_snapshot" && \
+        v057_export_and_show_comments_agree \
+            "$export_path" "$show_path" "$before_snapshot"; then
+        if ! jq -cn \
+            --slurpfile exports "$export_path" \
+            --slurpfile shows "$show_path" '
+            def by_id: map({key: .id, value: .}) | from_entries;
+            ($shows | by_id) as $show |
+            $exports[] |
+            ($show[.id].comments // []) as $comments |
+            if ($comments | length) > 0
+            then .comments = $comments
+            else del(.comments)
+            end
+        ' > "$enriched_path"; then
+            extraction_ok=false
+        fi
+    else
+        extraction_ok=false
+    fi
+
+    if $extraction_ok && \
+        ! migration_jsonl_matches_snapshot "$enriched_path" "$before_snapshot"; then
+        extraction_ok=false
+    fi
+    if ! remove_file_and_verify_absent "$show_path"; then
+        extraction_ok=false
+    fi
+    if ! $extraction_ok; then
+        remove_file_and_verify_absent "$enriched_path" >/dev/null 2>&1 || true
+        return 1
+    fi
 }
 
 preserve_legacy_dolt_source() {
@@ -184,7 +375,14 @@ recipe_server_to_embedded() {
         echo "  FAILED: no lossless server→embedded recipe is qualified for $version"
         return 1
     }
-    if [ "$strategy" != "native_export" ] || [ ! -f "$before_snapshot" ]; then
+    case "$strategy" in
+        native_export|native_export_show_comments) ;;
+        *)
+            echo "  FAILED: incomplete server→embedded inputs for $version"
+            return 1
+            ;;
+    esac
+    if [ ! -f "$before_snapshot" ] || [ -L "$before_snapshot" ]; then
         echo "  FAILED: incomplete server→embedded inputs for $version"
         return 1
     fi
@@ -199,7 +397,10 @@ recipe_server_to_embedded() {
     fi
 
     # Step 1: Stop any running server (we'll restart via old binary as needed)
-    stop_dolt_server "$ws"
+    if ! stop_dolt_server "$ws"; then
+        echo "  FAILED: could not prove the historical server stopped before rollback capture"
+        return 1
+    fi
 
     # Preserve the stopped source before an old export command or candidate
     # probe can update its Dolt working set or metadata.
@@ -216,13 +417,35 @@ recipe_server_to_embedded() {
     # previously) makes the old binary unable to find its data. (GH#3071)
     echo "  exporting data via old binary..."
     local export_ok=false
-    local export_tmp
+    local historical_export_ok=false
+    local export_tmp enriched_tmp="" export_publish_source
     export_tmp=$(mktemp "$ws/.beads/.issues.jsonl.migration.tmp.XXXXXX") || {
         echo "  FAILED: could not create a safe historical export destination"
         return 1
     }
-    if bd_in "$ws" "$old_bin" export --format jsonl \
-        -o "$export_tmp" >/dev/null 2>&1; then
+    export_publish_source="$export_tmp"
+    case "$strategy" in
+        native_export)
+            if bd_in "$ws" "$old_bin" export --format jsonl \
+                -o "$export_tmp" >/dev/null 2>&1; then
+                historical_export_ok=true
+            fi
+            ;;
+        native_export_show_comments)
+            if bd_in "$ws" "$old_bin" export -o "$export_tmp" >/dev/null 2>&1; then
+                enriched_tmp=$(mktemp "$ws/.beads/.issues.jsonl.enriched.tmp.XXXXXX") || true
+                if [ -n "$enriched_tmp" ] && \
+                    enrich_v057_export_comments \
+                        "$ws" "$old_bin" "$export_tmp" \
+                        "$before_snapshot" "$enriched_tmp"; then
+                    export_publish_source="$enriched_tmp"
+                    historical_export_ok=true
+                fi
+            fi
+            ;;
+    esac
+
+    if $historical_export_ok; then
         local export_destination_unchanged=false
         if [ "$existing_export_state" = "present" ]; then
             if [ -f "$export_path" ] && [ ! -L "$export_path" ] && \
@@ -233,8 +456,8 @@ recipe_server_to_embedded() {
             export_destination_unchanged=true
         fi
         if $export_destination_unchanged && \
-            migration_jsonl_matches_snapshot "$export_tmp" "$before_snapshot" && \
-            mv --no-target-directory --force -- "$export_tmp" "$export_path" && \
+            migration_jsonl_matches_snapshot "$export_publish_source" "$before_snapshot" && \
+            mv --no-target-directory --force -- "$export_publish_source" "$export_path" && \
             migration_jsonl_matches_snapshot "$export_path" "$before_snapshot"; then
             local export_count
             export_count=$(jq -s 'length' "$export_path" 2>/dev/null) || export_count=0
@@ -242,11 +465,21 @@ recipe_server_to_embedded() {
             export_ok=true
         fi
     fi
+    local staging_cleanup_ok=true
     if ! remove_file_and_verify_absent "$export_tmp"; then
         echo "  FAILED: could not remove the historical export staging file"
+        staging_cleanup_ok=false
+    fi
+    if [ -n "$enriched_tmp" ] && \
+        ! remove_file_and_verify_absent "$enriched_tmp"; then
+        echo "  FAILED: could not remove the enriched export staging file"
+        staging_cleanup_ok=false
+    fi
+    if ! stop_dolt_server "$ws"; then
+        echo "  FAILED: could not prove the historical server stopped after export"
         return 1
     fi
-    stop_dolt_server "$ws"
+    $staging_cleanup_ok || return 1
     if ! $export_ok; then
         echo "  FAILED: historical export did not produce a nonempty JSONL file"
         return 1
@@ -280,7 +513,10 @@ recipe_server_to_embedded() {
     # Remove active storage only after the verified rollback copy and JSONL
     # export exist. The old dolt/ is legacy data; embeddeddolt/ (if any) was
     # just created empty by step 3.
-    stop_dolt_server "$ws"
+    if ! stop_dolt_server "$ws"; then
+        echo "  FAILED: could not prove all workspace servers stopped before active-source removal"
+        return 1
+    fi
     if ! verify_legacy_dolt_rollback_root \
         "$ws/.beads/legacy-dolt.pre-migration" "$rollback_manifest"; then
         echo "  FAILED: retained rollback source changed before active-source removal"

--- a/scripts/migration-test/recipes/sqlite_to_current.sh
+++ b/scripts/migration-test/recipes/sqlite_to_current.sh
@@ -182,7 +182,10 @@ recipe_sqlite_to_current() {
     fi
 
     # Stop any old dolt server
-    stop_dolt_server "$ws"
+    if ! stop_dolt_server "$ws"; then
+        echo "  FAILED: could not prove the workspace server stopped"
+        return 1
+    fi
 
     # Remove active old artifacts now that the byte-identical rollback copies
     # and JSONL export are durable. This lets the candidate's

--- a/scripts/migration-test/run.sh
+++ b/scripts/migration-test/run.sh
@@ -96,6 +96,15 @@ test_direct_path() {
     echo ""
     echo -e "${BOLD}● Direct: ${path_label}${NC}"
 
+    if $STRICT_MODE && ! verify_strict_historical_runtime "$version"; then
+        local required_runtime=""
+        required_runtime=$(strict_required_dolt_version "$version" 2>/dev/null) || true
+        record_result "$path_label" "BLOCKED" \
+            "required Dolt runtime ${required_runtime:-unknown} is unavailable"
+        echo -e "  ${RED}BLOCKED: required Dolt runtime ${required_runtime:-unknown} is unavailable${NC}"
+        return 0
+    fi
+
     # Download source binary
     local src_bin
     if $STRICT_MODE; then
@@ -113,9 +122,18 @@ test_direct_path() {
     fi
 
     local WS
-    WS=$(new_workspace)
-    local SNAPSHOTS_DIR
-    SNAPSHOTS_DIR=$(mktemp -d /tmp/bd-snapshots-XXXXXX)
+    if ! WS=$(new_workspace); then
+        record_result "$path_label" "BLOCKED" "could not create isolated workspace"
+        echo -e "  ${RED}BLOCKED: could not create isolated workspace${NC}"
+        return 0
+    fi
+    local SNAPSHOTS_DIR=""
+    if ! SNAPSHOTS_DIR=$(mktemp -d /tmp/bd-snapshots-XXXXXX); then
+        record_result_after_workspace_cleanup \
+            "$WS" "$path_label" "BLOCKED" "could not create isolated snapshot directory" || true
+        echo -e "  ${RED}BLOCKED: ${RESULT_DETAILS[-1]}${NC}"
+        return 0
+    fi
 
     # Step 1: Init with source binary
     local init_ok=false
@@ -126,17 +144,22 @@ test_direct_path() {
     fi
 
     if ! $init_ok; then
-        local init_err
+        local init_err init_status init_detail
         init_err=$(bd_in "$WS" "$src_bin" init --quiet --prefix smoke </dev/null 2>&1 | head -1 || true)
-        cleanup_workspace "$WS"
-        rm -rf "$SNAPSHOTS_DIR"
 
         if echo "$init_err" | grep -qi "CGO"; then
-            record_result "$path_label" "SKIP" "binary built without CGO"
+            init_status="SKIP"
+            init_detail="binary built without CGO"
         elif echo "$init_err" | grep -qi "dolt.*server\|unreachable\|auto-start"; then
-            record_result "$path_label" "SKIP" "needs dolt server"
+            init_status="SKIP"
+            init_detail="needs dolt server"
         else
-            record_result "$path_label" "BLOCKED" "init failed: ${init_err}"
+            init_status="BLOCKED"
+            init_detail="init failed: ${init_err}"
+        fi
+        if record_result_after_workspace_cleanup \
+            "$WS" "$path_label" "$init_status" "$init_detail"; then
+            rm -rf "$SNAPSHOTS_DIR"
         fi
         echo -e "  ${RESULT_STATUSES[-1]}: ${RESULT_DETAILS[-1]}"
         return 0
@@ -188,7 +211,12 @@ test_direct_path() {
     fi
 
     # Stop source server before upgrade
-    stop_dolt_server "$WS"
+    if ! stop_dolt_server "$WS"; then
+        record_result "$path_label" "BLOCKED" \
+            "could not prove the historical server stopped before upgrade; preserved at $WS"
+        echo -e "  ${RED}BLOCKED: could not prove the historical server stopped before upgrade${NC}"
+        return 0
+    fi
 
     local source_era
     source_era=$(get_era "$version")
@@ -233,7 +261,6 @@ test_direct_path() {
     fi
 
     if [ "$probe_status" -eq 2 ]; then
-        stop_dolt_server "$WS"
         cleanup_workspace "$WS"
         rm -rf "$SNAPSHOTS_DIR"
         record_result "$path_label" "BLOCKED" "$DIRECT_PROBE_FAILURE_DETAIL"
@@ -247,7 +274,6 @@ test_direct_path() {
     if $upgrade_ok; then
         # Capture after-snapshot and check fidelity
         if ! capture_snapshot "$WS" "$cand_bin" > "$SNAPSHOTS_DIR/after.json"; then
-            stop_dolt_server "$WS"
             cleanup_workspace "$WS"
             rm -rf "$SNAPSHOTS_DIR"
             record_result "$path_label" "BLOCKED" "could not capture the complete candidate snapshot"
@@ -265,20 +291,30 @@ test_direct_path() {
         check_blocker_paths "$WS" "$cand_bin" || blocker_violations=$?
         violations=$((violations + blocker_violations))
 
-        stop_dolt_server "$WS"
-
-        cleanup_workspace "$WS"
-        rm -rf "$SNAPSHOTS_DIR"
+        local direct_status direct_detail
         if [ "$blocker_violations" -gt 0 ]; then
-            record_result "$path_label" "BLOCKED" "direct upgrade, $violations fidelity/blocker violations" "" "$violations"
+            direct_status="BLOCKED"
+            direct_detail="direct upgrade, $violations fidelity/blocker violations"
         else
-            record_result "$path_label" "AUTO" "direct upgrade, $violations fidelity violations" "" "$violations"
+            direct_status="AUTO"
+            direct_detail="direct upgrade, $violations fidelity violations"
+        fi
+        if record_result_after_workspace_cleanup \
+            "$WS" "$path_label" "$direct_status" "$direct_detail" "" "$violations"; then
+            rm -rf "$SNAPSHOTS_DIR"
+        else
+            echo -e "  ${RED}BLOCKED: could not prove isolated workspace cleanup${NC}"
         fi
         return 0
     fi
 
     # Step 5: Direct upgrade failed — try recipes
-    stop_dolt_server "$WS"
+    if ! stop_dolt_server "$WS"; then
+        record_result "$path_label" "BLOCKED" \
+            "could not prove the direct-probe server stopped before migration recipes; preserved at $WS"
+        echo -e "  ${RED}BLOCKED: could not prove the direct-probe server stopped before migration recipes${NC}"
+        return 0
+    fi
     echo "  direct upgrade failed, trying recipes..."
 
     local era="$source_era"
@@ -318,7 +354,6 @@ test_direct_path() {
     if $recipe_worked; then
         if $STRICT_MODE && ! verify_strict_retained_source \
             "$WS" "$era" "$source_sqlite_manifest" "$source_legacy_dolt_manifest"; then
-            stop_dolt_server "$WS"
             cleanup_workspace "$WS"
             rm -rf "$SNAPSHOTS_DIR"
             record_result "$path_label" "BLOCKED" "manual bridge mutated the retained historical rollback source"
@@ -328,7 +363,6 @@ test_direct_path() {
 
         # Re-capture and check fidelity after recipe
         if ! capture_snapshot "$WS" "$cand_bin" > "$SNAPSHOTS_DIR/after.json"; then
-            stop_dolt_server "$WS"
             cleanup_workspace "$WS"
             rm -rf "$SNAPSHOTS_DIR"
             record_result "$path_label" "BLOCKED" "could not capture the complete candidate snapshot after recipe"
@@ -346,7 +380,12 @@ test_direct_path() {
         check_blocker_paths "$WS" "$cand_bin" || blocker_violations=$?
         violations=$((violations + blocker_violations))
 
-        stop_dolt_server "$WS"
+        if ! stop_dolt_server "$WS"; then
+            record_result "$path_label" "BLOCKED" \
+                "could not prove the candidate server stopped before rollback verification; preserved at $WS"
+            echo -e "  ${RED}BLOCKED: could not prove the candidate server stopped before rollback verification${NC}"
+            return 0
+        fi
 
         if $STRICT_MODE && ! verify_strict_retained_source \
             "$WS" "$era" "$source_sqlite_manifest" "$source_legacy_dolt_manifest"; then
@@ -357,20 +396,27 @@ test_direct_path() {
             return 0
         fi
 
-        cleanup_workspace "$WS"
-        rm -rf "$SNAPSHOTS_DIR"
+        local recipe_status recipe_detail
         if [ "$blocker_violations" -gt 0 ]; then
-            record_result "$path_label" "BLOCKED" "recipe: $recipe_name, $violations fidelity/blocker violations" "$recipe_name" "$violations"
+            recipe_status="BLOCKED"
+            recipe_detail="recipe: $recipe_name, $violations fidelity/blocker violations"
         else
-            record_result "$path_label" "MANUAL" "recipe: $recipe_name, $violations fidelity violations" "$recipe_name" "$violations"
+            recipe_status="MANUAL"
+            recipe_detail="recipe: $recipe_name, $violations fidelity violations"
+        fi
+        if record_result_after_workspace_cleanup \
+            "$WS" "$path_label" "$recipe_status" "$recipe_detail" "$recipe_name" "$violations"; then
+            rm -rf "$SNAPSHOTS_DIR"
+        else
+            echo -e "  ${RED}BLOCKED: could not prove isolated workspace cleanup${NC}"
         fi
         return 0
     fi
 
     # All recipes failed
-    stop_dolt_server "$WS"
-    cleanup_workspace "$WS"
-    rm -rf "$SNAPSHOTS_DIR"
+    if cleanup_workspace "$WS"; then
+        rm -rf "$SNAPSHOTS_DIR"
+    fi
     record_result "$path_label" "BLOCKED" "no working upgrade path found"
     echo -e "  ${RED}BLOCKED: no working upgrade path${NC}"
 }
@@ -404,9 +450,18 @@ test_stepping_stone_path() {
     done
 
     local WS
-    WS=$(new_workspace)
-    local SNAPSHOTS_DIR
-    SNAPSHOTS_DIR=$(mktemp -d /tmp/bd-snapshots-XXXXXX)
+    if ! WS=$(new_workspace); then
+        record_result "$path_label" "BLOCKED" "could not create isolated workspace"
+        echo -e "  ${RED}BLOCKED: could not create isolated workspace${NC}"
+        return 0
+    fi
+    local SNAPSHOTS_DIR=""
+    if ! SNAPSHOTS_DIR=$(mktemp -d /tmp/bd-snapshots-XXXXXX); then
+        record_result_after_workspace_cleanup \
+            "$WS" "$path_label" "BLOCKED" "could not create isolated snapshot directory" || true
+        echo -e "  ${RED}BLOCKED: ${RESULT_DETAILS[-1]}${NC}"
+        return 0
+    fi
 
     # Init with first version
     local first_bin="${bins[0]}"
@@ -420,10 +475,11 @@ test_stepping_stone_path() {
     fi
 
     if ! $init_ok; then
-        cleanup_workspace "$WS"
-        rm -rf "$SNAPSHOTS_DIR"
-        record_result "$path_label" "SKIP" "could not init with $first_ver"
-        echo -e "  ${YELLOW}SKIP: could not init with $first_ver${NC}"
+        if record_result_after_workspace_cleanup \
+            "$WS" "$path_label" "SKIP" "could not init with $first_ver"; then
+            rm -rf "$SNAPSHOTS_DIR"
+        fi
+        echo -e "  ${RESULT_STATUSES[-1]}: ${RESULT_DETAILS[-1]}"
         return 0
     fi
     git -C "$WS" config beads.role maintainer 2>/dev/null || true
@@ -438,7 +494,12 @@ test_stepping_stone_path() {
 
     # Capture initial snapshot
     capture_snapshot "$WS" "$first_bin" > "$SNAPSHOTS_DIR/before.json"
-    stop_dolt_server "$WS"
+    if ! stop_dolt_server "$WS"; then
+        record_result "$path_label" "BLOCKED" \
+            "could not prove the first historical server stopped before stepping; preserved at $WS"
+        echo -e "  ${RED}BLOCKED: could not prove the first historical server stopped before stepping${NC}"
+        return 0
+    fi
 
     # Step through intermediate versions
     local step_failed=false
@@ -463,7 +524,11 @@ test_stepping_stone_path() {
             fi
         fi
 
-        stop_dolt_server "$WS"
+        if ! stop_dolt_server "$WS"; then
+            step_failed=true
+            failed_at="$step_ver (server stop unverified)"
+            break
+        fi
 
         if ! $step_ok; then
             step_failed=true
@@ -498,7 +563,6 @@ test_stepping_stone_path() {
     fi
 
     if ! $upgrade_ok; then
-        stop_dolt_server "$WS"
         cleanup_workspace "$WS"
         rm -rf "$SNAPSHOTS_DIR"
         record_result "$path_label" "BLOCKED" "final step to candidate failed"
@@ -515,13 +579,19 @@ test_stepping_stone_path() {
     check_blocker_paths "$WS" "$cand_bin" || blocker_violations=$?
     violations=$((violations + blocker_violations))
 
-    stop_dolt_server "$WS"
-    cleanup_workspace "$WS"
-    rm -rf "$SNAPSHOTS_DIR"
+    local step_status step_detail
     if [ "$blocker_violations" -gt 0 ]; then
-        record_result "$path_label" "BLOCKED" "steps passed, $violations fidelity/blocker violations" "" "$violations"
+        step_status="BLOCKED"
+        step_detail="steps passed, $violations fidelity/blocker violations"
     else
-        record_result "$path_label" "AUTO" "all steps passed, $violations fidelity violations" "" "$violations"
+        step_status="AUTO"
+        step_detail="all steps passed, $violations fidelity violations"
+    fi
+    if record_result_after_workspace_cleanup \
+        "$WS" "$path_label" "$step_status" "$step_detail" "" "$violations"; then
+        rm -rf "$SNAPSHOTS_DIR"
+    else
+        echo -e "  ${RED}BLOCKED: could not prove isolated workspace cleanup${NC}"
     fi
 }
 
@@ -621,45 +691,61 @@ if $SELF_TEST; then
     echo ""
     echo -e "${BOLD}● Self-test: candidate → candidate${NC}"
 
-    WS=$(new_workspace)
-    SNAPSHOTS_DIR=$(mktemp -d /tmp/bd-snapshots-XXXXXX)
-
-    # Init with candidate
-    if ! bd_in "$WS" "$CAND_BIN" init --quiet --non-interactive --prefix smoke </dev/null >/dev/null 2>&1; then
-        cleanup_workspace "$WS"
-        rm -rf "$SNAPSHOTS_DIR"
-        echo -e "  ${RED}BLOCKED: candidate init failed${NC}"
-        record_result "candidate → candidate" "BLOCKED" "init failed"
+    if ! WS=$(new_workspace); then
+        echo -e "  ${RED}BLOCKED: could not create isolated workspace${NC}"
+        record_result "candidate → candidate" "BLOCKED" "could not create isolated workspace"
     else
-        git -C "$WS" config beads.role maintainer 2>/dev/null || true
-
-        # Create dataset
-        if create_dataset "$WS" "$CAND_BIN" "candidate"; then
-            capture_snapshot "$WS" "$CAND_BIN" > "$SNAPSHOTS_DIR/before.json"
-            before_count=$(jq 'length' "$SNAPSHOTS_DIR/before.json" 2>/dev/null) || before_count=0
-            echo "  snapshot: $before_count items"
-
-            # "Upgrade" is a no-op — just re-read with the same binary
-            capture_snapshot "$WS" "$CAND_BIN" > "$SNAPSHOTS_DIR/after.json"
-
-            violations=0
-            check_fidelity "candidate" "$SNAPSHOTS_DIR/before.json" "$SNAPSHOTS_DIR/after.json" || violations=$?
-
-            blocker_violations=0
-            check_blocker_paths "$WS" "$CAND_BIN" || blocker_violations=$?
-            violations=$((violations + blocker_violations))
-
-            stop_dolt_server "$WS"
-            if [ "$blocker_violations" -gt 0 ]; then
-                record_result "candidate → candidate" "BLOCKED" "self-test, $violations fidelity/blocker violations" "" "$violations"
-            else
-                record_result "candidate → candidate" "AUTO" "self-test, $violations fidelity violations" "" "$violations"
+        SNAPSHOTS_DIR=""
+        if ! SNAPSHOTS_DIR=$(mktemp -d /tmp/bd-snapshots-XXXXXX); then
+            record_result_after_workspace_cleanup \
+                "$WS" "candidate → candidate" "BLOCKED" \
+                "could not create isolated snapshot directory" || true
+            echo -e "  ${RED}BLOCKED: ${RESULT_DETAILS[-1]}${NC}"
+        # Init with candidate
+        elif ! bd_in "$WS" "$CAND_BIN" init --quiet --non-interactive --prefix smoke </dev/null >/dev/null 2>&1; then
+            if record_result_after_workspace_cleanup \
+                "$WS" "candidate → candidate" "BLOCKED" "init failed"; then
+                rm -rf "$SNAPSHOTS_DIR"
             fi
+            echo -e "  ${RED}BLOCKED: ${RESULT_DETAILS[-1]}${NC}"
         else
-            record_result "candidate → candidate" "BLOCKED" "could not create test data"
+            git -C "$WS" config beads.role maintainer 2>/dev/null || true
+            self_status="BLOCKED"
+            self_detail="could not create test data"
+            self_violations=0
+
+            # Create dataset
+            if create_dataset "$WS" "$CAND_BIN" "candidate"; then
+                capture_snapshot "$WS" "$CAND_BIN" > "$SNAPSHOTS_DIR/before.json"
+                before_count=$(jq 'length' "$SNAPSHOTS_DIR/before.json" 2>/dev/null) || before_count=0
+                echo "  snapshot: $before_count items"
+
+                # "Upgrade" is a no-op — just re-read with the same binary
+                capture_snapshot "$WS" "$CAND_BIN" > "$SNAPSHOTS_DIR/after.json"
+
+                violations=0
+                check_fidelity "candidate" "$SNAPSHOTS_DIR/before.json" "$SNAPSHOTS_DIR/after.json" || violations=$?
+
+                blocker_violations=0
+                check_blocker_paths "$WS" "$CAND_BIN" || blocker_violations=$?
+                violations=$((violations + blocker_violations))
+                self_violations="$violations"
+
+                if [ "$blocker_violations" -gt 0 ]; then
+                    self_status="BLOCKED"
+                    self_detail="self-test, $violations fidelity/blocker violations"
+                else
+                    self_status="AUTO"
+                    self_detail="self-test, $violations fidelity violations"
+                fi
+            fi
+            if record_result_after_workspace_cleanup \
+                "$WS" "candidate → candidate" "$self_status" "$self_detail" "" "$self_violations"; then
+                rm -rf "$SNAPSHOTS_DIR"
+            else
+                echo -e "  ${RED}BLOCKED: could not prove isolated workspace cleanup${NC}"
+            fi
         fi
-        cleanup_workspace "$WS"
-        rm -rf "$SNAPSHOTS_DIR"
     fi
 fi
 

--- a/scripts/migration-test/strict-mode-test.sh
+++ b/scripts/migration-test/strict-mode-test.sh
@@ -30,6 +30,21 @@ sha=$(strict_release_sha256 v0.55.4 linux amd64) || fail "missing v0.55.4 releas
 [ "$(strict_expected_recipe v0.55.4)" = "server_to_embedded" ] || fail "unexpected v0.55.4 recipe"
 [ "$(strict_expected_features v0.55.4)" = "epic task bug dependency standalone closed label comment" ] ||
     fail "unexpected v0.55.4 source features"
+
+asset=$(strict_release_asset v0.57.0 linux amd64) || fail "missing v0.57.0 release asset"
+[ "$asset" = "beads_0.57.0_linux_amd64.tar.gz" ] || fail "unexpected v0.57.0 release asset"
+sha=$(strict_release_sha256 v0.57.0 linux amd64) || fail "missing v0.57.0 release checksum"
+[ "$sha" = "f8629d5627bed7d25f06f92334addc171d679f9aed9d08c5d42a9684205dc04b" ] ||
+    fail "unexpected v0.57.0 release checksum"
+[ "$(strict_expected_status v0.57.0)" = "MANUAL" ] || fail "unexpected v0.57.0 status"
+[ "$(strict_expected_recipe v0.57.0)" = "server_to_embedded" ] || fail "unexpected v0.57.0 recipe"
+[ "$(strict_expected_features v0.57.0)" = "epic task bug dependency standalone closed label comment" ] ||
+    fail "unexpected v0.57.0 source features"
+[ "$(strict_required_dolt_version v0.57.0)" = "2.1.8" ] ||
+    fail "unexpected v0.57.0 Dolt runtime version"
+[ "$(strict_required_dolt_sha256 v0.57.0 linux amd64)" = \
+    "f66318f08ed66e409fc39363ae0fff8ce6fbf6dba9f5bac632b91527b9632a74" ] ||
+    fail "unexpected v0.57.0 Dolt runtime checksum"
 [ "${LEGACY_DOLT_ROLLBACK_FILES[*]}" = "metadata.json config.json config.yaml issues.jsonl" ] ||
     fail "unexpected legacy Dolt rollback file inventory"
 
@@ -43,9 +58,307 @@ for lookup in strict_expected_status strict_expected_recipe strict_expected_feat
         fail "$lookup accepted an unknown qualification manifest"
     fi
 done
+for lookup in strict_required_dolt_version strict_required_dolt_sha256; do
+    if "$lookup" v9.9.9 linux amd64 >/dev/null 2>&1; then
+        fail "$lookup accepted an unknown historical runtime manifest"
+    fi
+done
 
 tmp=$(mktemp -d)
-trap 'rm -rf "$tmp"' EXIT
+guard_server_pid=""
+trap '[ -z "${guard_server_pid:-}" ] || kill -9 -- "$guard_server_pid" 2>/dev/null || true; rm -rf "$tmp"' EXIT
+
+unsafe_cleanup_calls="$tmp/unsafe-cleanup.calls"
+if (
+    pkill() { printf 'pkill %s\n' "$*" >> "$unsafe_cleanup_calls"; }
+    rm() { printf 'rm %s\n' "$*" >> "$unsafe_cleanup_calls"; }
+    sleep() { :; }
+    cleanup_workspace ""
+); then
+    fail "cleanup accepted an empty workspace path"
+fi
+[ ! -e "$unsafe_cleanup_calls" ] ||
+    fail "empty workspace cleanup invoked a process or filesystem command"
+
+unowned_workspace="$tmp/unowned-workspace"
+mkdir -p "$unowned_workspace"
+if (
+    pkill() { printf 'pkill %s\n' "$*" >> "$unsafe_cleanup_calls"; }
+    rm() { printf 'rm %s\n' "$*" >> "$unsafe_cleanup_calls"; }
+    sleep() { :; }
+    cleanup_workspace "$unowned_workspace"
+); then
+    fail "cleanup accepted a workspace not owned by this harness"
+fi
+[ ! -e "$unsafe_cleanup_calls" ] ||
+    fail "unowned workspace cleanup invoked a process or filesystem command"
+
+allocation_failure_tmp="$tmp/not-a-directory"
+allocation_failure_bin="$tmp/allocation-failure-bin"
+allocation_failure_log="$tmp/allocation-failure-process.calls"
+allocation_failure_output="$tmp/allocation-failure.out"
+printf 'not a directory\n' > "$allocation_failure_tmp"
+mkdir -p "$allocation_failure_bin"
+cat > "$allocation_failure_bin/pkill" <<'EOF'
+#!/bin/bash
+printf 'pkill %s\n' "$*" >> "${MIGRATION_TEST_PROCESS_LOG:?}"
+EOF
+chmod +x "$allocation_failure_bin/pkill"
+if PATH="$allocation_failure_bin:$PATH" \
+    TMPDIR="$allocation_failure_tmp" \
+    MIGRATION_TEST_PROCESS_LOG="$allocation_failure_log" \
+    CANDIDATE_BIN=/bin/true \
+    "$SCRIPT_DIR/run.sh" --self-test > "$allocation_failure_output" 2>&1; then
+    fail "self-test unexpectedly passed after workspace allocation failed"
+fi
+grep -q 'BLOCKED: could not create isolated workspace' "$allocation_failure_output" ||
+    fail "workspace allocation failure did not produce an explicit BLOCKED result"
+[ ! -e "$allocation_failure_log" ] ||
+    fail "workspace allocation failure reached process cleanup"
+if (
+    mktemp() { return 1; }
+    new_workspace
+); then
+    fail "workspace creation accepted a failed mktemp allocation"
+fi
+
+snapshot_failure_bin="$tmp/snapshot-failure-bin"
+snapshot_failure_output="$tmp/snapshot-failure.out"
+real_mktemp=$(command -v mktemp)
+mkdir -p "$snapshot_failure_bin"
+cat > "$snapshot_failure_bin/mktemp" <<EOF
+#!/bin/bash
+case "\${*: -1}" in
+    /tmp/bd-snapshots-*) exit 1 ;;
+    *) exec "$real_mktemp" "\$@" ;;
+esac
+EOF
+chmod +x "$snapshot_failure_bin/mktemp"
+if PATH="$snapshot_failure_bin:$PATH" \
+    CANDIDATE_BIN=/bin/false \
+    "$SCRIPT_DIR/run.sh" --self-test > "$snapshot_failure_output" 2>&1; then
+    fail "self-test unexpectedly passed after snapshot allocation failed"
+fi
+grep -q 'BLOCKED: could not create isolated snapshot directory' "$snapshot_failure_output" ||
+    fail "snapshot allocation failure did not produce an explicit BLOCKED result"
+
+host_hooks_dir="$tmp/host-hooks"
+host_hook_log="$tmp/host-hook.calls"
+host_git_config="$tmp/host.gitconfig"
+mkdir -p "$host_hooks_dir"
+cat > "$host_hooks_dir/pre-commit" <<'EOF'
+#!/bin/bash
+printf 'host hook ran\n' >> "${HOST_HOOK_LOG:?}"
+exit 99
+EOF
+chmod +x "$host_hooks_dir/pre-commit"
+git config -f "$host_git_config" core.hooksPath "$host_hooks_dir"
+if ! hook_guard_workspace=$(
+    HOST_HOOK_LOG="$host_hook_log" GIT_CONFIG_GLOBAL="$host_git_config" new_workspace
+); then
+    fail "workspace creation inherited a failing host-global Git hook"
+fi
+[ ! -e "$host_hook_log" ] ||
+    fail "workspace creation executed a host-global Git hook"
+cleanup_workspace "$hook_guard_workspace" ||
+    fail "could not clean up the Git-hook isolation workspace"
+
+pid_guard_workspace=$(new_workspace) ||
+    fail "could not create a workspace for PID cleanup guards"
+mkdir -p "$pid_guard_workspace/.beads"
+for unsafe_pid in 0 -1 not-a-pid "$$"; do
+    pid_guard_calls="$tmp/pid-guard-${unsafe_pid//[^[:alnum:]]/_}.calls"
+    printf '%s\n' "$unsafe_pid" > "$pid_guard_workspace/.beads/dolt-server.pid"
+    if ! (
+        kill() { printf 'kill %s\n' "$*" >> "$pid_guard_calls"; }
+        pkill() { printf 'pkill %s\n' "$*" >> "$pid_guard_calls"; }
+        sleep() { :; }
+        migration_server_port_in_use() { return 1; }
+        stop_dolt_server "$pid_guard_workspace"
+    ); then
+        fail "server cleanup rejected its owned workspace for PID value $unsafe_pid"
+    fi
+    if [ -e "$pid_guard_calls" ]; then
+        fail "server cleanup trusted unsafe or unrelated PID value $unsafe_pid"
+    fi
+done
+
+printf '0\n' > "$pid_guard_workspace/.beads/dolt-server.pid"
+for occupancy_status in 0 2; do
+    pid_guard_calls="$tmp/pid-guard-occupancy-$occupancy_status.calls"
+    if (
+        kill() { printf 'kill %s\n' "$*" >> "$pid_guard_calls"; }
+        pkill() { printf 'pkill %s\n' "$*" >> "$pid_guard_calls"; }
+        sleep() { :; }
+        migration_server_port_in_use() { return "$occupancy_status"; }
+        stop_dolt_server "$pid_guard_workspace"
+    ); then
+        fail "server cleanup accepted unsafe PID 0 with port occupancy status $occupancy_status"
+    fi
+    [ ! -e "$pid_guard_calls" ] ||
+        fail "server cleanup signaled a process for unsafe PID 0 with occupancy status $occupancy_status"
+done
+
+external_dolt_cwd="$tmp/external-dolt-cwd"
+mkdir -p "$external_dolt_cwd"
+(
+    cd "$external_dolt_cwd"
+    exec -a 'dolt sql-server' sleep 600
+) &
+guard_server_pid=$!
+for _ in $(seq 1 50); do
+    if [ "$(readlink "/proc/$guard_server_pid/cwd" 2>/dev/null || true)" = "$external_dolt_cwd" ] &&
+        tr '\0' ' ' < "/proc/$guard_server_pid/cmdline" 2>/dev/null | grep -q 'dolt.*sql-server'; then
+        break
+    fi
+    sleep 0.02
+done
+printf '%s\n' "$guard_server_pid" > "$pid_guard_workspace/.beads/dolt-server.pid"
+stop_dolt_server "$pid_guard_workspace" ||
+    fail "server cleanup rejected a free port for an unrelated Dolt-shaped process"
+if ! kill -0 "$guard_server_pid" 2>/dev/null; then
+    guard_server_pid=""
+    fail "server cleanup killed a Dolt-shaped process rooted outside its workspace"
+fi
+kill -9 -- "$guard_server_pid" 2>/dev/null || true
+wait "$guard_server_pid" 2>/dev/null || true
+guard_server_pid=""
+
+fake_dolt_cwd="$pid_guard_workspace/.beads/dolt"
+mkdir -p "$fake_dolt_cwd"
+(
+    cd "$fake_dolt_cwd"
+    exec -a 'dolt sql-server' sleep 600
+) &
+guard_server_pid=$!
+for _ in $(seq 1 50); do
+    if [ "$(readlink "/proc/$guard_server_pid/cwd" 2>/dev/null || true)" = "$fake_dolt_cwd" ] &&
+        tr '\0' ' ' < "/proc/$guard_server_pid/cmdline" 2>/dev/null | grep -q 'dolt.*sql-server'; then
+        break
+    fi
+    sleep 0.02
+done
+printf '%s\n' "$guard_server_pid" > "$pid_guard_workspace/.beads/dolt-server.pid"
+stop_dolt_server "$pid_guard_workspace" ||
+    fail "server cleanup rejected a verified Dolt server rooted in its workspace"
+if kill -0 "$guard_server_pid" 2>/dev/null; then
+    kill -9 -- "$guard_server_pid" 2>/dev/null || true
+    wait "$guard_server_pid" 2>/dev/null || true
+    guard_server_pid=""
+    fail "server cleanup left a verified Dolt server running"
+fi
+wait "$guard_server_pid" 2>/dev/null || true
+guard_server_pid=""
+
+rm -f "$pid_guard_workspace/.beads/dolt-server.pid"
+cleanup_workspace "$pid_guard_workspace" ||
+    fail "could not clean up the PID guard workspace"
+
+port_ws_one="$tmp/port-workspace-one"
+port_ws_two="$tmp/port-workspace-two"
+port_probe_bin="$tmp/port-probe-bd"
+mkdir -p "$port_ws_one/.git" "$port_ws_two/.git"
+reserve_migration_server_port "$port_ws_one" ||
+    fail "could not reserve the first isolated historical server port"
+reserve_migration_server_port "$port_ws_two" ||
+    fail "could not reserve the second isolated historical server port"
+port_one=$(cat "$port_ws_one/.git/bd-migration-server-port")
+port_two=$(cat "$port_ws_two/.git/bd-migration-server-port")
+[[ "$port_one" =~ ^2[0-9]{4}$ ]] || fail "first isolated server port is outside the reserved range"
+[[ "$port_two" =~ ^2[0-9]{4}$ ]] || fail "second isolated server port is outside the reserved range"
+[ "$port_one" != "$port_two" ] || fail "concurrent workspaces reused a historical server port"
+port_lock_one=$(cat "$port_ws_one/.git/bd-migration-server-port-lock")
+port_lock_two=$(cat "$port_ws_two/.git/bd-migration-server-port-lock")
+[ -d "$port_lock_one" ] && [ -d "$port_lock_two" ] ||
+    fail "isolated historical server port was not reserved atomically"
+cat > "$port_probe_bin" <<'EOF'
+#!/bin/bash
+printf '%s\n' "${BEADS_DOLT_SERVER_PORT:-}"
+EOF
+chmod +x "$port_probe_bin"
+[ "$(bd_in "$port_ws_one" "$port_probe_bin")" = "$port_one" ] ||
+    fail "bd_in did not propagate the workspace-specific historical server port"
+
+env_probe_bin="$tmp/environment-probe-bd"
+cat > "$env_probe_bin" <<'EOF'
+#!/bin/bash
+env | sort
+EOF
+chmod +x "$env_probe_bin"
+poisoned_env_output=$(
+    BEADS_DB=/production/beads.db \
+    BEADS_DIR=/production/.beads \
+    BEADS_DOLT_DATA_DIR=/production/dolt \
+    BEADS_BACKEND=postgres \
+    BD_DB=/production/bd.db \
+    GT_ROOT=/production/town \
+    DOLT_ROOT_PATH=/production/dolt-root \
+    HOME=/production/home \
+    XDG_CONFIG_HOME=/production/config \
+    GIT_CONFIG_GLOBAL=/production/gitconfig \
+    BASH_ENV=/production/bash-env \
+    bd_in "$port_ws_one" "$env_probe_bin"
+)
+if grep -Eq \
+    '^(BEADS_DB|BEADS_DIR|BEADS_DOLT_DATA_DIR|BEADS_BACKEND|BD_DB|GT_ROOT|DOLT_ROOT_PATH|BASH_ENV)=' \
+    <<< "$poisoned_env_output"; then
+    fail "bd_in exposed a poisoned host routing or shell environment"
+fi
+grep -Fqx "HOME=$port_ws_one/.git/bd-migration-home" <<< "$poisoned_env_output" ||
+    fail "bd_in did not isolate HOME inside the workspace"
+grep -Fqx "XDG_CONFIG_HOME=$port_ws_one/.git/bd-migration-home/.config" \
+    <<< "$poisoned_env_output" ||
+    fail "bd_in did not isolate XDG configuration inside the workspace"
+grep -Fqx "TMPDIR=$port_ws_one/.git/bd-migration-tmp" <<< "$poisoned_env_output" ||
+    fail "bd_in did not isolate temporary files inside the workspace"
+grep -Fqx 'GIT_CONFIG_GLOBAL=/dev/null' <<< "$poisoned_env_output" ||
+    fail "bd_in did not disable host-global Git configuration"
+grep -Fqx "BEADS_DOLT_SERVER_PORT=$port_one" <<< "$poisoned_env_output" ||
+    fail "bd_in did not retain the workspace-specific Dolt port"
+grep -Fqx 'BEADS_TEST_MODE=0' <<< "$poisoned_env_output" ||
+    fail "bd_in did not force the server-capable migration test mode"
+grep -Fqx 'BEADS_NO_DAEMON=1' <<< "$poisoned_env_output" ||
+    fail "bd_in did not disable the historical background daemon"
+grep -Fqx 'BEADS_DOLT_AUTO_START=1' <<< "$poisoned_env_output" ||
+    fail "bd_in did not force the intended historical server auto-start behavior"
+
+release_migration_server_port "$port_ws_one" ||
+    fail "could not release the first isolated historical server port"
+release_migration_server_port "$port_ws_two" ||
+    fail "could not release the second isolated historical server port"
+[ ! -e "$port_lock_one" ] && [ ! -e "$port_lock_two" ] ||
+    fail "historical server port reservation leaked after release"
+
+port_unknown_ws="$tmp/port-workspace-unknown-occupancy"
+mkdir -p "$port_unknown_ws/.git"
+if (
+    migration_server_port_in_use() { return 2; }
+    reserve_migration_server_port "$port_unknown_ws"
+); then
+    fail "historical server port reservation treated unknown occupancy as free"
+fi
+[ ! -e "$port_unknown_ws/.git/bd-migration-server-port" ] &&
+    [ ! -e "$port_unknown_ws/.git/bd-migration-server-port-lock" ] ||
+    fail "failed historical server port reservation left workspace markers"
+
+runtime_bin_dir="$tmp/runtime-bin"
+mkdir -p "$runtime_bin_dir"
+cat > "$runtime_bin_dir/dolt" <<'EOF'
+#!/bin/bash
+printf 'dolt version %s\n' "${FAKE_DOLT_VERSION:-unknown}"
+EOF
+chmod +x "$runtime_bin_dir/dolt"
+if ! PATH="$runtime_bin_dir:$PATH" FAKE_DOLT_VERSION=2.1.8 \
+    verify_strict_historical_runtime v0.57.0; then
+    fail "qualified v0.57.0 Dolt runtime was rejected"
+fi
+if PATH="$runtime_bin_dir:$PATH" FAKE_DOLT_VERSION=2.1.9 \
+    verify_strict_historical_runtime v0.57.0 >/dev/null 2>&1; then
+    fail "unqualified v0.57.0 Dolt runtime was accepted"
+fi
+verify_strict_historical_runtime v0.49.6 ||
+    fail "a release without an external Dolt requirement was rejected"
+
 printf 'not the release archive' > "$tmp/archive.tar.gz"
 if OS=linux ARCH=amd64 verify_release_archive v0.49.6 "$tmp/archive.tar.gz" >/dev/null 2>&1; then
     fail "tampered release archive was accepted"
@@ -53,11 +366,16 @@ fi
 if OS=linux ARCH=amd64 verify_release_archive v0.55.4 "$tmp/archive.tar.gz" >/dev/null 2>&1; then
     fail "tampered v0.55.4 release archive was accepted"
 fi
+if OS=linux ARCH=amd64 verify_release_archive v0.57.0 "$tmp/archive.tar.gz" >/dev/null 2>&1; then
+    fail "tampered v0.57.0 release archive was accepted"
+fi
 
 strict_fixture_has_expected_features v0.49.6 epic task bug dependency standalone closed label comment ||
     fail "complete source fixture was rejected"
 strict_fixture_has_expected_features v0.55.4 epic task bug dependency standalone closed label comment ||
     fail "complete v0.55.4 source fixture was rejected"
+strict_fixture_has_expected_features v0.57.0 epic task bug dependency standalone closed label comment ||
+    fail "complete v0.57.0 source fixture was rejected"
 if strict_fixture_has_expected_features v0.49.6 epic task bug standalone closed label >/dev/null 2>&1; then
     fail "source fixture without dependency was accepted"
 fi
@@ -83,22 +401,24 @@ strict_snapshot_has_expected_fixture v0.49.6 "$tmp/fixture.json" ||
     fail "exact v0.49.6 source fixture was rejected"
 strict_snapshot_has_expected_fixture v0.55.4 "$tmp/fixture.json" ||
     fail "exact v0.55.4 source fixture was rejected"
+strict_snapshot_has_expected_fixture v0.57.0 "$tmp/fixture.json" ||
+    fail "exact v0.57.0 source fixture was rejected"
 jq 'map(select(.id != "old-epic"))' "$tmp/fixture.json" > "$tmp/fixture-four-items.json"
-for version in v0.49.6 v0.55.4; do
+for version in v0.49.6 v0.55.4 v0.57.0; do
     if strict_snapshot_has_expected_fixture "$version" "$tmp/fixture-four-items.json" >/dev/null 2>&1; then
         fail "$version source fixture with four items was accepted"
     fi
 done
 jq '. + [{"id":"old-extra","title":"Unexpected extra issue"}]' \
     "$tmp/fixture.json" > "$tmp/fixture-six-items.json"
-for version in v0.49.6 v0.55.4; do
+for version in v0.49.6 v0.55.4 v0.57.0; do
     if strict_snapshot_has_expected_fixture "$version" "$tmp/fixture-six-items.json" >/dev/null 2>&1; then
         fail "$version source fixture with six items was accepted"
     fi
 done
 jq 'map(if .id == "old-epic" then .issue_type = "task" else . end)' \
     "$tmp/fixture.json" > "$tmp/fixture-wrong-epic.json"
-for version in v0.49.6 v0.55.4; do
+for version in v0.49.6 v0.55.4 v0.57.0; do
     if strict_snapshot_has_expected_fixture "$version" "$tmp/fixture-wrong-epic.json" >/dev/null 2>&1; then
         fail "$version source fixture with an inexact epic was accepted"
     fi
@@ -111,6 +431,9 @@ fi
 if strict_snapshot_has_expected_fixture v0.55.4 "$tmp/fixture-missing-rich-field.json" >/dev/null 2>&1; then
     fail "v0.55.4 source fixture without the exact rich fields was accepted"
 fi
+if strict_snapshot_has_expected_fixture v0.57.0 "$tmp/fixture-missing-rich-field.json" >/dev/null 2>&1; then
+    fail "v0.57.0 source fixture without the exact rich fields was accepted"
+fi
 jq 'map(if .id == "old-task" then .labels = [] else . end)' \
     "$tmp/fixture.json" > "$tmp/fixture-missing-label.json"
 if strict_snapshot_has_expected_fixture v0.49.6 "$tmp/fixture-missing-label.json" >/dev/null 2>&1; then
@@ -119,6 +442,9 @@ fi
 if strict_snapshot_has_expected_fixture v0.55.4 "$tmp/fixture-missing-label.json" >/dev/null 2>&1; then
     fail "v0.55.4 source fixture without the exact label was accepted"
 fi
+if strict_snapshot_has_expected_fixture v0.57.0 "$tmp/fixture-missing-label.json" >/dev/null 2>&1; then
+    fail "v0.57.0 source fixture without the exact label was accepted"
+fi
 jq 'map(if .id == "old-bug" then .dependencies = [] else . end)' \
     "$tmp/fixture.json" > "$tmp/fixture-missing-dependency.json"
 if strict_snapshot_has_expected_fixture v0.49.6 "$tmp/fixture-missing-dependency.json" >/dev/null 2>&1; then
@@ -126,6 +452,9 @@ if strict_snapshot_has_expected_fixture v0.49.6 "$tmp/fixture-missing-dependency
 fi
 if strict_snapshot_has_expected_fixture v0.55.4 "$tmp/fixture-missing-dependency.json" >/dev/null 2>&1; then
     fail "v0.55.4 source fixture without the exact dependency was accepted"
+fi
+if strict_snapshot_has_expected_fixture v0.57.0 "$tmp/fixture-missing-dependency.json" >/dev/null 2>&1; then
+    fail "v0.57.0 source fixture without the exact dependency was accepted"
 fi
 
 mkdir -p "$tmp/source/.beads"
@@ -340,9 +669,34 @@ if find "$legacy_race_ws/.beads" -maxdepth 2 \
     fail "rollback publication race left a temporary copy"
 fi
 
+stop_refusal_ws="$tmp/stop-refusal-workspace"
+stop_refusal_calls="$tmp/stop-refusal.calls"
+mkdir -p "$stop_refusal_ws/.beads/dolt"
+printf 'active stop-refusal data' > "$stop_refusal_ws/.beads/dolt/table.dat"
+printf 'active stop-refusal metadata' > "$stop_refusal_ws/.beads/metadata.json"
+stop_refusal_fingerprint=$(source_artifact_fingerprint "$stop_refusal_ws/.beads")
+export LEGACY_RACE_CALLS="$stop_refusal_calls"
+: > "$stop_refusal_calls"
+if (
+    stop_dolt_server() { return 1; }
+    recipe_server_to_embedded \
+        "$stop_refusal_ws" "$legacy_race_old_bin" "$legacy_race_candidate_bin" \
+        v0.55.4 "$legacy_race_before"
+) >/dev/null 2>&1; then
+    fail "server bridge continued after server-stop verification failed"
+fi
+[ ! -s "$stop_refusal_calls" ] ||
+    fail "server-stop verification failure invoked a migration binary"
+[ "$(source_artifact_fingerprint "$stop_refusal_ws/.beads")" = "$stop_refusal_fingerprint" ] ||
+    fail "server-stop verification failure mutated the active source"
+[ ! -e "$stop_refusal_ws/.beads/legacy-dolt.pre-migration" ] ||
+    fail "server-stop verification failure created a rollback tree"
+
 [ "$(server_bridge_strategy v0.55.4)" = "native_export" ] ||
     fail "v0.55.4 did not select its pinned server bridge strategy"
-for unsupported_version in v0.56.1 v0.57.0 v0.58.0 v9.9.9; do
+[ "$(server_bridge_strategy v0.57.0)" = "native_export_show_comments" ] ||
+    fail "v0.57.0 did not select its lossless export+show server bridge strategy"
+for unsupported_version in v0.56.1 v0.58.0 v9.9.9; do
     if server_bridge_strategy "$unsupported_version" >/dev/null 2>&1; then
         fail "$unsupported_version unexpectedly selected a server bridge strategy"
     fi
@@ -371,6 +725,22 @@ RESULT_DETAILS=("recipe: sqlite_to_current, 0 fidelity violations")
 RESULT_RECIPES=("sqlite_to_current")
 RESULT_VIOLATIONS=("0")
 strict_results_match MANUAL sqlite_to_current || fail "qualified result was rejected"
+
+cleanup_blocked_result=$(
+    RESULT_PATHS=()
+    RESULT_STATUSES=()
+    RESULT_DETAILS=()
+    RESULT_RECIPES=()
+    RESULT_VIOLATIONS=()
+    cleanup_workspace() { return 1; }
+    record_result_after_workspace_cleanup \
+        "/tmp/bd-migration-ABC123" "v0.57.0 → candidate" \
+        "MANUAL" "recipe passed" "server_to_embedded" "0" || true
+    printf '%s|%s|%s\n' \
+        "${RESULT_STATUSES[0]}" "${RESULT_RECIPES[0]}" "${RESULT_DETAILS[0]}"
+)
+[[ "$cleanup_blocked_result" == BLOCKED\|\|*preserved* ]] ||
+    fail "cleanup verification failure did not override a successful lane result"
 
 RESULT_STATUSES=("SKIP")
 if strict_results_match MANUAL sqlite_to_current >/dev/null 2>&1; then
@@ -532,6 +902,309 @@ if migration_jsonl_matches_snapshot \
     fail "historical JSONL contract accepted two records on one line"
 fi
 
+# v0.57.0's native export preserves issue/label/dependency records and a
+# comment_count, but omits comment bodies. Its release-specific bridge must use
+# `export -o PATH`, enrich each exported ID from `show ID --json`, and finish
+# validating the list/export/show consensus before invoking the candidate.
+v057_before="$tmp/v057-before.json"
+v057_old_bin="$tmp/fake-v0.57.0-bd"
+v057_candidate_bin="$tmp/fake-v0.57.0-candidate-bd"
+v057_old_calls="$tmp/v057-old.calls"
+v057_candidate_calls="$tmp/v057-candidate.calls"
+printf '%s\n' '[
+  {"id":"v57-task","title":"Legacy task","labels":["urgent"],"dependencies":[{"id":"v57-bug","dependency_type":"parent-child"}],"comments":[{"id":7,"issue_id":"v57-task","author":"legacy-author","text":"v0.57 comment body","created_at":"2025-01-02T03:04:05Z"}]},
+  {"id":"v57-bug","title":"Legacy bug","dependencies":[{"id":"v57-task","dependency_type":"blocks"}],"comments":[]}
+]' > "$v057_before"
+cat > "$v057_old_bin" <<'EOF'
+#!/bin/bash
+printf '%s\n' "$*" >> "$V057_OLD_CALLS"
+
+write_valid_export() {
+    printf '%s\n' \
+        '{"id":"v57-task","title":"Legacy task","labels":["urgent"],"dependencies":[{"issue_id":"v57-task","depends_on_id":"v57-bug","type":"parent-child","metadata":"{}"}],"dependency_count":0,"comment_count":1}' \
+        '{"id":"v57-bug","title":"Legacy bug","dependencies":[{"issue_id":"v57-bug","depends_on_id":"v57-task","type":"blocks","metadata":"{}"}],"dependency_count":1,"comment_count":0}' \
+        > "$1"
+}
+
+write_valid_task_show() {
+    printf '%s\n' '[{"id":"v57-task","title":"Legacy task","labels":["urgent"],"dependencies":[{"id":"v57-bug","dependency_type":"parent-child"}],"comments":[{"id":7,"issue_id":"v57-task","author":"legacy-author","text":"v0.57 comment body","created_at":"2025-01-02T03:04:05Z"}]}]'
+}
+
+write_valid_bug_show() {
+    printf '%s\n' '[{"id":"v57-bug","title":"Legacy bug","dependencies":[{"id":"v57-task","dependency_type":"blocks"}],"comments":[]}]'
+}
+
+case "$1" in
+    export)
+        # v0.57.0 removed v0.55.4's --format flag. Pin the actual release CLI.
+        [ "$#" -eq 3 ] && [ "$2" = "-o" ] && [ -n "$3" ] || exit 2
+        case "${V057_MODE:-valid}" in
+            export-missing)
+                printf '%s\n' \
+                    '{"id":"v57-task","title":"Legacy task","labels":["urgent"],"dependencies":[{"issue_id":"v57-task","depends_on_id":"v57-bug","type":"parent-child","metadata":"{}"}],"dependency_count":0,"comment_count":1}' \
+                    > "$3"
+                ;;
+            export-extra)
+                write_valid_export "$3"
+                printf '%s\n' \
+                    '{"id":"v57-extra","title":"Unexpected","comment_count":0}' \
+                    >> "$3"
+                ;;
+            export-duplicate)
+                write_valid_export "$3"
+                printf '%s\n' \
+                    '{"id":"v57-task","title":"Duplicate","comment_count":1}' \
+                    >> "$3"
+                ;;
+            export-core-changed)
+                write_valid_export "$3"
+                sed -i 's/"title":"Legacy task"/"title":"Changed task"/' "$3"
+                ;;
+            export-label-changed)
+                write_valid_export "$3"
+                sed -i 's/"labels":\["urgent"\]/"labels":[]/' "$3"
+                ;;
+            export-dependency-changed)
+                write_valid_export "$3"
+                sed -i 's/"depends_on_id":"v57-task"/"depends_on_id":"v57-other"/' "$3"
+                ;;
+            export-unsupported-field)
+                write_valid_export "$3"
+                sed -i 's/"title":"Legacy task"/"title":"Legacy task","quality_score":0.5/' "$3"
+                ;;
+            export-unsupported-creator)
+                write_valid_export "$3"
+                sed -i 's/"title":"Legacy task"/"title":"Legacy task","creator":{"type":"human","id":"legacy"}/' "$3"
+                ;;
+            export-unsupported-validations)
+                write_valid_export "$3"
+                sed -i 's/"title":"Legacy task"/"title":"Legacy task","validations":[{"validator":"legacy"}]/' "$3"
+                ;;
+            export-unsupported-holder)
+                write_valid_export "$3"
+                sed -i 's/"title":"Legacy task"/"title":"Legacy task","holder":"legacy-agent"/' "$3"
+                ;;
+            export-unsupported-closed-session)
+                write_valid_export "$3"
+                sed -i 's/"title":"Legacy task"/"title":"Legacy task","closed_by_session":"legacy-session"/' "$3"
+                ;;
+            export-dependency-metadata)
+                write_valid_export "$3"
+                sed -i 's/"metadata":"{}"/"metadata":"legacy-edge-data"/' "$3"
+                ;;
+            *)
+                write_valid_export "$3"
+                ;;
+        esac
+        ;;
+    show)
+        shift
+        id=""
+        json=false
+        while [ "$#" -gt 0 ]; do
+            case "$1" in
+                --json) json=true ;;
+                --id=*)
+                    [ -z "$id" ] || exit 2
+                    id="${1#--id=}"
+                    ;;
+                --id)
+                    shift
+                    [ "$#" -gt 0 ] && [ -z "$id" ] || exit 2
+                    id="$1"
+                    ;;
+                --*) exit 2 ;;
+                *)
+                    [ -z "$id" ] || exit 2
+                    id="$1"
+                    ;;
+            esac
+            shift
+        done
+        $json && [ -n "$id" ] || exit 2
+        if [ "$id" = "v57-task" ]; then
+            case "${V057_MODE:-valid}" in
+                show-fail)
+                    write_valid_task_show
+                    exit 1
+                    ;;
+                show-malformed) printf '%s\n' 'not JSON' ;;
+                show-object) printf '%s\n' '{"id":"v57-task","title":"Legacy task","comments":[]}' ;;
+                show-empty) printf '%s\n' '[]' ;;
+                show-wrong-id) printf '%s\n' '[{"id":"v57-other","comments":[]}]' ;;
+                show-duplicate)
+                    printf '%s\n' '[{"id":"v57-task","comments":[]},{"id":"v57-task","comments":[]}]'
+                    ;;
+                show-core-changed)
+                    printf '%s\n' '[{"id":"v57-task","title":"Changed task","labels":["urgent"],"dependencies":[{"id":"v57-bug","dependency_type":"parent-child"}],"comments":[{"id":7,"issue_id":"v57-task","author":"legacy-author","text":"v0.57 comment body","created_at":"2025-01-02T03:04:05Z"}]}]'
+                    ;;
+                comment-missing)
+                    printf '%s\n' '[{"id":"v57-task","title":"Legacy task","labels":["urgent"],"dependencies":[{"id":"v57-bug","dependency_type":"parent-child"}],"comments":[]}]'
+                    ;;
+                comment-changed)
+                    printf '%s\n' '[{"id":"v57-task","title":"Legacy task","labels":["urgent"],"dependencies":[{"id":"v57-bug","dependency_type":"parent-child"}],"comments":[{"id":7,"issue_id":"v57-task","author":"legacy-author","text":"changed body","created_at":"2025-01-02T03:04:05Z"}]}]'
+                    ;;
+                *) write_valid_task_show ;;
+            esac
+        elif [ "$id" = "v57-bug" ]; then
+            write_valid_bug_show
+        else
+            exit 2
+        fi
+        ;;
+    *)
+        exit 2
+        ;;
+esac
+EOF
+cat > "$v057_candidate_bin" <<'EOF'
+#!/bin/bash
+printf '%s\n' "$*" >> "$V057_CANDIDATE_CALLS"
+[ "$1" = "init" ] || exit 2
+for arg in "$@"; do
+    if [ "$arg" = "--from-jsonl" ]; then
+        jq -se '
+            length == 2 and
+            ([.[].id] | sort) == ["v57-bug", "v57-task"] and
+            ([.[] | select(.id == "v57-task")] | length) == 1 and
+            (first(.[] | select(.id == "v57-task")) |
+                .comment_count == 1 and
+                (.comments | length) == 1 and
+                .comments[0].author == "legacy-author" and
+                .comments[0].text == "v0.57 comment body") and
+            (first(.[] | select(.id == "v57-bug")) |
+                .comment_count == 0 and ((.comments // []) | length) == 0)
+        ' .beads/issues.jsonl >/dev/null
+        exit
+    fi
+done
+exit 1
+EOF
+chmod +x "$v057_old_bin" "$v057_candidate_bin"
+
+prepare_v057_workspace() {
+    local ws="$1"
+    mkdir -p "$ws/.beads/dolt"
+    printf 'v0.57 legacy Dolt bytes' > "$ws/.beads/dolt/table.dat"
+    printf 'v0.57 legacy metadata' > "$ws/.beads/metadata.json"
+    printf '%s\n' '{"id":"v57-task","title":"Original passive export"}' \
+        > "$ws/.beads/issues.jsonl"
+}
+
+v057_happy_ws="$tmp/v057-happy-workspace"
+prepare_v057_workspace "$v057_happy_ws"
+v057_happy_manifest=$(legacy_dolt_artifact_manifest "$v057_happy_ws/.beads")
+v057_happy_original_jsonl=$(sha256_file "$v057_happy_ws/.beads/issues.jsonl")
+export V057_MODE=valid
+export V057_OLD_CALLS="$v057_old_calls"
+export V057_CANDIDATE_CALLS="$v057_candidate_calls"
+: > "$v057_old_calls"
+: > "$v057_candidate_calls"
+if ! (
+    stop_dolt_server() { :; }
+    recipe_server_to_embedded \
+        "$v057_happy_ws" "$v057_old_bin" "$v057_candidate_bin" \
+        v0.57.0 "$v057_before"
+) >/dev/null; then
+    fail "v0.57.0 export+show bridge did not produce a lossless candidate import"
+fi
+grep -E "^export -o $v057_happy_ws/\.beads/\.issues\.jsonl\.migration\.tmp\." \
+    "$v057_old_calls" >/dev/null ||
+    fail "v0.57.0 bridge did not use its release-specific native export syntax"
+if grep -q -- '--format' "$v057_old_calls"; then
+    fail "v0.57.0 bridge used the unsupported historical --format flag"
+fi
+[ "$(grep -c '^show ' "$v057_old_calls")" -eq 2 ] ||
+    fail "v0.57.0 bridge did not issue exactly one show query per exported id"
+grep '^show ' "$v057_old_calls" | grep 'v57-task' >/dev/null ||
+    fail "v0.57.0 bridge did not enrich v57-task"
+grep '^show ' "$v057_old_calls" | grep 'v57-bug' >/dev/null ||
+    fail "v0.57.0 bridge did not enrich v57-bug"
+jq -se '
+    length == 2 and
+    (first(.[] | select(.id == "v57-task")) |
+        .comment_count == 1 and
+        (.comments | length) == 1 and
+        .comments[0].author == "legacy-author" and
+        .comments[0].text == "v0.57 comment body")
+' "$v057_happy_ws/.beads/issues.jsonl" >/dev/null ||
+    fail "v0.57.0 bridge did not publish the show-enriched comment body"
+verify_retained_legacy_dolt_source \
+    "$v057_happy_ws/.beads" "$v057_happy_manifest" ||
+    fail "v0.57.0 bridge did not retain an exact rollback source"
+[ "$(sha256_file "$v057_happy_ws/.beads/legacy-dolt.pre-migration/issues.jsonl")" = \
+    "$v057_happy_original_jsonl" ] ||
+    fail "v0.57.0 bridge did not retain the original passive JSONL"
+
+assert_v057_bridge_rejected() {
+    local mode="$1"
+    local description="$2"
+    local ws="$tmp/v057-reject-$mode"
+    local before_manifest original_jsonl after_manifest
+
+    prepare_v057_workspace "$ws"
+    before_manifest=$(legacy_dolt_artifact_manifest "$ws/.beads")
+    original_jsonl=$(sha256_file "$ws/.beads/issues.jsonl")
+    export V057_MODE="$mode"
+    : > "$v057_old_calls"
+    : > "$v057_candidate_calls"
+
+    if (
+        stop_dolt_server() { :; }
+        recipe_server_to_embedded \
+            "$ws" "$v057_old_bin" "$v057_candidate_bin" \
+            v0.57.0 "$v057_before"
+    ) >/dev/null 2>&1; then
+        fail "v0.57.0 bridge accepted $description"
+    fi
+    [ ! -s "$v057_candidate_calls" ] ||
+        fail "$description invoked the candidate before lossless extraction completed"
+    after_manifest=$(legacy_dolt_artifact_manifest "$ws/.beads") ||
+        fail "$description removed the active legacy source"
+    [ "$after_manifest" = "$before_manifest" ] ||
+        fail "$description mutated the active legacy source"
+    [ "$(sha256_file "$ws/.beads/issues.jsonl")" = "$original_jsonl" ] ||
+        fail "$description replaced the original passive JSONL"
+    verify_retained_legacy_dolt_source "$ws/.beads" "$before_manifest" ||
+        fail "$description did not leave an exact rollback source"
+    if find "$ws/.beads" -maxdepth 1 \
+        \( -name '.issues.jsonl.migration.tmp.*' -o \
+           -name '.issues.jsonl.enriched.tmp.*' -o \
+           -name '.issues.jsonl.show.tmp.*' \) \
+        -print -quit | grep -q .; then
+        fail "$description left an extraction staging file"
+    fi
+    case "$mode" in
+        export-*)
+            if grep -q '^show ' "$v057_old_calls"; then
+                fail "$description invoked show after export inventory validation failed"
+            fi
+            ;;
+    esac
+}
+
+assert_v057_bridge_rejected export-missing "an export missing a listed id"
+assert_v057_bridge_rejected export-extra "an export with an unlisted id"
+assert_v057_bridge_rejected export-duplicate "an export with a duplicate id"
+assert_v057_bridge_rejected export-core-changed "an export with changed core issue data"
+assert_v057_bridge_rejected export-label-changed "an export with changed labels"
+assert_v057_bridge_rejected export-dependency-changed "an export with changed dependencies"
+assert_v057_bridge_rejected export-unsupported-field "an export with candidate-unsupported issue data"
+assert_v057_bridge_rejected export-unsupported-creator "an export with a candidate-unsupported creator"
+assert_v057_bridge_rejected export-unsupported-validations "an export with candidate-unsupported validations"
+assert_v057_bridge_rejected export-unsupported-holder "an export with a candidate-unsupported holder"
+assert_v057_bridge_rejected export-unsupported-closed-session "an export with a candidate-unsupported close session"
+assert_v057_bridge_rejected export-dependency-metadata "an export with candidate-unsupported dependency metadata"
+assert_v057_bridge_rejected show-fail "a nonzero show command with valid-looking JSON"
+assert_v057_bridge_rejected show-malformed "malformed show JSON"
+assert_v057_bridge_rejected show-object "a show object instead of a one-item array"
+assert_v057_bridge_rejected show-empty "a show result missing its requested id"
+assert_v057_bridge_rejected show-wrong-id "a show result with a mismatched id"
+assert_v057_bridge_rejected show-duplicate "a show result with a duplicate id"
+assert_v057_bridge_rejected show-core-changed "a show result with changed core issue data"
+assert_v057_bridge_rejected comment-missing "a show result missing an exported comment"
+assert_v057_bridge_rejected comment-changed "a show result with changed comment text"
+
 server_export_ws="$tmp/server-export-workspace"
 server_export_calls="$tmp/server-export-calls"
 server_export_old_bin="$tmp/fake-v0.55.4-bd"
@@ -576,10 +1249,12 @@ exit 1
 EOF
 chmod +x "$server_export_old_bin" "$server_export_candidate_bin"
 export SERVER_EXPORT_CALLS="$server_export_calls"
-if ! recipe_server_to_embedded \
-    "$server_export_ws" "$server_export_old_bin" "$server_export_candidate_bin" \
-    v0.55.4 "$server_export_before" \
-    >/dev/null; then
+if ! (
+    stop_dolt_server() { :; }
+    recipe_server_to_embedded \
+        "$server_export_ws" "$server_export_old_bin" "$server_export_candidate_bin" \
+        v0.55.4 "$server_export_before"
+) >/dev/null; then
     fail "server-to-embedded recipe lost comments exposed only by historical export"
 fi
 grep -E "^export --format jsonl -o $server_export_ws/\.beads/\.issues\.jsonl\.migration\.tmp\." \


### PR DESCRIPTION
## What

Add an independently named PR CI lane that runs the official, checksum-pinned v0.57.0 `bd` release with the checksum-pinned Dolt 2.1.8 runtime, creates the canonical historical fixture, refuses an unsafe direct open, and qualifies a manual server-to-embedded bridge into the current multi-provider candidate.

The v0.57 bridge combines the historical native export with per-ID `show --json` enrichment because v0.57 export records comment counts but omit comment bodies. It requires exact list/export/show inventory and core-field agreement before invoking the candidate.

Tracked by `bd-ldt0f.3.25`. Stacked on PR #4810, which adds the required pre-mutation product guard.

## Why

Users on v0.57 had no executable, release-gating proof that their legacy Dolt-directory workspace could reach the current provider architecture without losing the issue graph or comments. The previous harness explicitly blocked this release.

The harness also had unsafe nondeterminism: host routing variables and HOME could leak into historical commands, workspace allocation/cleanup failures could be ignored, and PID cleanup could target unrelated processes or report success while a server remained live. This change makes those conditions fail closed.

## Qualification boundary

This lane certifies the exact five-issue/eight-feature core fixture used by the historical matrix:

- epic, task, bug, standalone, and closed issues
- one dependency and blocker/ready/close behavior
- one label
- one historical comment body
- exact issue count and list/export/show ID agreement
- zero fidelity or blocker violations

It does not claim universal v0.57 losslessness for fields outside that fixture. Candidate-unsupported fields and nonempty dependency metadata are rejected before migration.

## Safety and rollback

- Historical and candidate subprocesses receive a hermetic environment with workspace-owned HOME/XDG/TMP state and no host Beads/Dolt/Git routing.
- Every workspace has an atomically reserved port and owned cleanup markers.
- Server PIDs must have a canonical positive PID, Dolt sql-server command identity, and a cwd under the owned workspace; busy or unknown port state blocks cleanup/migration.
- Server-stop failures block before rollback capture, export, or active-source removal.
- AUTO/MANUAL cannot be recorded unless cleanup succeeds.
- A byte-verified `legacy-dolt.pre-migration` rollback source is retained through the bridge and reverified after candidate commands.
- This is migration-path code and requires substantive human review; it must not be self-merged.

## Verification

Exact E2 diff SHA-256: `59f6597d592984740911a893e44bfc6c9455ce5a22e5ffb19ab82fd336f4a91d`.

- Synthetic strict-mode suite: PASS
- Bash syntax checks: PASS
- `actionlint .github/workflows/migration-test.yml`: PASS
- `git diff --check`: PASS
- Exact-diff correctness council: 0 Critical, 0 Important
- Exact-diff safety council: 0 Critical, 0 Important

Real release lanes against the same candidate/diff:

| Source | Result | Issues | Features | Violations |
|---|---|---:|---:|---:|
| v0.49.6 | `MANUAL(sqlite_to_current)` | 5/5 | 8 | 0 |
| v0.55.4 | `MANUAL(server_to_embedded)` | 5/5 | 8 | 0 |
| v0.57.0 + Dolt 2.1.8 | `MANUAL(server_to_embedded)` | 5/5 | 8 | 0 |

For all three, the direct probe failed safely with the historical source unchanged; migrated blocker/ready/close behavior was correct.

_codex-gpt-5-unknown-reasoning on behalf of Test User_
