### PR TITLE
docs: remove stale 8-char prefix limit claim from rename-prefix help (GH#770)

### DIFF
--- a/cmd/bd/rename_prefix.go
+++ b/cmd/bd/rename_prefix.go
@@ -34,7 +34,6 @@ USE CASES:
 - Migrating to team naming standards
 
 Prefix validation rules:
-- Max length: 8 characters
 - Allowed characters: lowercase letters, numbers, hyphens
 - Must start with a letter
 - Must end with a hyphen (e.g., 'kw-', 'work-')

--- a/docs/reference/advanced.md
+++ b/docs/reference/advanced.md
@@ -30,7 +30,7 @@ bd rename-prefix kw-            # Every knowledge-work-* ID becomes kw-*
 ```
 
 The rename updates all issue IDs and all text references across all fields.
-Prefixes are at most 8 characters of lowercase letters, numbers, and hyphens,
+Prefixes are lowercase letters, numbers, and hyphens,
 must start with a letter, and must end with a hyphen. If a corrupted database
 contains issues with multiple prefixes, `bd rename-prefix <prefix> --repair`
 consolidates them. See [bd rename-prefix](/cli-reference/rename-prefix).

--- a/plugins/beads/skills/beads/commands/rename-prefix.md
+++ b/plugins/beads/skills/beads/commands/rename-prefix.md
@@ -9,7 +9,6 @@ Updates all issue IDs and all text references across all fields.
 
 ## Prefix Rules
 
-- Max length: 8 characters
 - Allowed: lowercase letters, numbers, hyphens
 - Must start with a letter
 - Must end with a hyphen (e.g., 'kw-', 'work-')


### PR DESCRIPTION
## Summary

- Commit ab3feda00 removed the `len(prefix) > 8` check from `validatePrefix` (closing #770), but the `Max length: 8 characters` line survived in the command's `Long:` help text, so `bd rename-prefix --help` and every generated doc still document a limit that no longer exists. Observed in the wild: the dry run happily accepts 9- and 16-char prefixes while the help says the max is 8.
- Removes the stale line from the Go source (`cmd/bd/rename_prefix.go`) and the hand-written plugin skill page, then regenerates the CLI docs with `./scripts/generate-cli-docs.sh`.
- The regen also picks up pre-existing drift in the `bd backup` pages (the "Auto-backup default" help section had not been regenerated on main), which keeps `generate-cli-docs.sh --check` green.

## Test plan

- [x] `./scripts/generate-cli-docs.sh --check` passes (generated docs fresh)
- [x] `CGO_ENABLED=1 go test -tags gms_pure_go -run '^TestValidatePrefix$' ./cmd/bd/` passes (existing test already asserts `verylongprefix-` is valid, "No length limit (GH#770)")
- [x] `scripts/pr-preflight.sh --search` found no open PRs or issues covering this