### PR TITLE
docs(update): list all core work types in bd update --type help

### DIFF
--- a/cmd/bd/update.go
+++ b/cmd/bd/update.go
@@ -655,7 +655,7 @@ func init() {
 	updateCmd.Flags().StringP("status", "s", "", "New status")
 	registerPriorityFlag(updateCmd, "")
 	updateCmd.Flags().String("title", "", "New title")
-	updateCmd.Flags().StringP("type", "t", "", "New type (bug|feature|task|epic|chore|decision); custom types require types.custom config")
+	updateCmd.Flags().StringP("type", "t", "", "New type (bug|feature|task|epic|chore|decision|spike|story|milestone); custom types require types.custom config; aliases: enhancement/feat→feature, dec/adr→decision")
 	registerCommonIssueFlags(updateCmd)
 	updateCmd.Flags().Bool("allow-empty-description", false, "Allow empty description replacement when reading from stdin or file")
 	updateCmd.Flags().String("spec-id", "", "Link to specification document")


### PR DESCRIPTION
## Problem

`bd update --type` help lists only `(bug|feature|task|epic|chore|decision)`, omitting `spike`, `story`, and `milestone` — all first-class core work types per `internal/types` `coreWorkTypes` and `bd types` output. This misleads users into thinking those types require `types.custom` configuration when they are built-in and accepted directly.

`bd create --type` already lists the full set (with alias hints). This PR brings `update` into line so the two commands document the same type surface.

## Change

One line in `cmd/bd/update.go` — the `--type` flag help string:

```
- New type (bug|feature|task|epic|chore|decision); custom types require types.custom config
+ New type (bug|feature|task|epic|chore|decision|spike|story|milestone); custom types require types.custom config; aliases: enhancement/feat→feature, dec/adr→decision
```

Scope is deliberately limited to the **9 documented core work types** shown by `bd types` — the internal-use types (`molecule`, `gate`, `message`, `event`) that `IsValid()`/`IsBuiltIn()` also accept are intentionally not surfaced here, matching the existing `bd create --type` help.

## Verification

- `go build` clean.
- `bd update --help` now renders the full list and matches `bd create --help` exactly.
- Existing `cmd/bd` type/help tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)