### PR TITLE
docs: regenerate backup help

### DIFF
--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -2358,6 +2358,16 @@ DoltHub is recommended for cloud backup:
   bd backup init https://doltremoteapi.dolthub.com/&lt;user&gt;/&lt;repo&gt;
   Set DOLT_REMOTE_USER and DOLT_REMOTE_PASSWORD for authentication.
 
+Auto-backup default:
+  When backup.enabled is unset, auto-backup turns ON in embedded mode if a
+  git remote exists, and stays OFF in sql-server / shared-server mode. In
+  server mode many bd clients share one Dolt server, and each would register
+  a server-side backup remote under the same name pointing at its own local
+  dir and full-sync the whole database — a self-amplifying storm. To back up
+  a shared server, run 'bd backup' explicitly (or set backup.enabled=true and
+  coordinate destinations). 'bd config get backup.enabled' shows the effective
+  value and its source.
+
 ```
 bd backup [command]
 ```

--- a/docs/cli-reference/backup.md
+++ b/docs/cli-reference/backup.md
@@ -25,6 +25,16 @@ DoltHub is recommended for cloud backup:
   bd backup init https://doltremoteapi.dolthub.com/&lt;user&gt;/&lt;repo&gt;
   Set DOLT_REMOTE_USER and DOLT_REMOTE_PASSWORD for authentication.
 
+Auto-backup default:
+  When backup.enabled is unset, auto-backup turns ON in embedded mode if a
+  git remote exists, and stays OFF in sql-server / shared-server mode. In
+  server mode many bd clients share one Dolt server, and each would register
+  a server-side backup remote under the same name pointing at its own local
+  dir and full-sync the whole database — a self-amplifying storm. To back up
+  a shared server, run 'bd backup' explicitly (or set backup.enabled=true and
+  coordinate destinations). 'bd config get backup.enabled' shows the effective
+  value and its source.
+
 ```
 bd backup [command]
 ```


### PR DESCRIPTION
## Why

`main` is red at [Actions run 29434366508](https://github.com/gastownhall/beads/actions/runs/29434366508): the strict CLI-doc freshness check finds the recently added `bd backup` auto-backup help in the live CLI but not in the generated reference. This blocks every non-main-fix PR.

## Change

Regenerate the two canonical CLI reference artifacts. The update records the auto-backup default: enabled for embedded mode with a Git remote, disabled for shared server mode unless explicitly enabled.

## Verification

- `./scripts/generate-cli-docs.sh --check <CGO_ENABLED=0 -tags gms_pure_go binary>`
- `./scripts/check-doc-flags.sh <same binary>`
- `git diff --check`

The doc-flags check retains its existing legacy-SQLite prose warnings but exits successfully.
