### PR TITLE
fix(storage): total ORDER BY on dependency bulk-loaders (#4749)

### DIFF
--- a/internal/storage/issueops/dependency_queries.go
+++ b/internal/storage/issueops/dependency_queries.go
@@ -30,11 +30,12 @@ func GetAllDependencyRecordsInTx(ctx context.Context, tx DBTX) (map[string][]*ty
 func getAllDependencyRecordsIntoFromTable(ctx context.Context, tx DBTX, depTable string, result map[string][]*types.Dependency) error {
 	// Total order: issue_id alone is only a grouping key; without a tiebreaker the
 	// intra-issue dependency slice is plan-dependent (export churn, unstable --json).
-	// Mirrors labels bulk-load (issue_id, label). Unique key is (issue_id, target).
+	// Mirrors labels bulk-load (issue_id, label). The separate typed-target unique
+	// keys don't make (issue_id, depends_on_id, type) total, so `id` closes it.
 	rows, err := tx.QueryContext(ctx, fmt.Sprintf(`
 			SELECT issue_id, %s AS depends_on_id, type, created_at, created_by, metadata, thread_id
 			FROM %s
-			ORDER BY issue_id, depends_on_id, type
+			ORDER BY issue_id, depends_on_id, type, id
 		`, DepTargetExpr, depTable))
 	if err != nil {
 		return fmt.Errorf("get all dependency records from %s: %w", depTable, err)
@@ -113,7 +114,7 @@ func getDependencyRecordsIntoFromTable(ctx context.Context, tx DBTX, depTable st
 		}
 		rows, err := tx.QueryContext(ctx, fmt.Sprintf(
 			`SELECT issue_id, %s AS depends_on_id, type, created_at, created_by, metadata, thread_id
-			 FROM %s WHERE issue_id IN (%s) ORDER BY issue_id, depends_on_id, type`,
+			 FROM %s WHERE issue_id IN (%s) ORDER BY issue_id, depends_on_id, type, id`,
 			DepTargetExpr, depTable, strings.Join(placeholders, ",")), args...)
 		if err != nil {
 			return fmt.Errorf("get dependency records from %s: %w", depTable, err)

--- a/internal/storage/issueops/dependency_queries.go
+++ b/internal/storage/issueops/dependency_queries.go
@@ -28,10 +28,13 @@ func GetAllDependencyRecordsInTx(ctx context.Context, tx DBTX) (map[string][]*ty
 
 //nolint:gosec // G201: depTable is "dependencies" or "wisp_dependencies" (hardcoded by caller).
 func getAllDependencyRecordsIntoFromTable(ctx context.Context, tx DBTX, depTable string, result map[string][]*types.Dependency) error {
+	// Total order: issue_id alone is only a grouping key; without a tiebreaker the
+	// intra-issue dependency slice is plan-dependent (export churn, unstable --json).
+	// Mirrors labels bulk-load (issue_id, label). Unique key is (issue_id, target).
 	rows, err := tx.QueryContext(ctx, fmt.Sprintf(`
 			SELECT issue_id, %s AS depends_on_id, type, created_at, created_by, metadata, thread_id
 			FROM %s
-			ORDER BY issue_id
+			ORDER BY issue_id, depends_on_id, type
 		`, DepTargetExpr, depTable))
 	if err != nil {
 		return fmt.Errorf("get all dependency records from %s: %w", depTable, err)
@@ -110,7 +113,7 @@ func getDependencyRecordsIntoFromTable(ctx context.Context, tx DBTX, depTable st
 		}
 		rows, err := tx.QueryContext(ctx, fmt.Sprintf(
 			`SELECT issue_id, %s AS depends_on_id, type, created_at, created_by, metadata, thread_id
-			 FROM %s WHERE issue_id IN (%s) ORDER BY issue_id`,
+			 FROM %s WHERE issue_id IN (%s) ORDER BY issue_id, depends_on_id, type`,
 			DepTargetExpr, depTable, strings.Join(placeholders, ",")), args...)
 		if err != nil {
 			return fmt.Errorf("get dependency records from %s: %w", depTable, err)

--- a/internal/storage/issueops/dependency_queries_test.go
+++ b/internal/storage/issueops/dependency_queries_test.go
@@ -11,9 +11,17 @@ import (
 	"github.com/steveyegge/beads/internal/types"
 )
 
+// Shared by both bulk-loader query shapes so they can't drift apart.
+const dependencyProjectionRegex = `SELECT issue_id, COALESCE\(depends_on_issue_id, depends_on_wisp_id, depends_on_external\) AS depends_on_id, type, created_at, created_by, metadata, thread_id\s+FROM `
+
 func allDependencyRecordsQueryRegex(table string) string {
-	return `(?s)SELECT issue_id, COALESCE\(depends_on_issue_id, depends_on_wisp_id, depends_on_external\) AS depends_on_id, type, created_at, created_by, metadata, thread_id\s+FROM ` +
-		regexp.QuoteMeta(table) + `\s+ORDER BY issue_id, depends_on_id, type`
+	return `(?s)` + dependencyProjectionRegex +
+		regexp.QuoteMeta(table) + `\s+ORDER BY issue_id, depends_on_id, type, id`
+}
+
+func dependencyRecordsForIssuesQueryRegex(table string) string {
+	return `(?s)` + dependencyProjectionRegex +
+		regexp.QuoteMeta(table) + ` WHERE issue_id IN \(\?\) ORDER BY issue_id, depends_on_id, type, id`
 }
 
 func dependencyRows() *sqlmock.Rows {
@@ -105,13 +113,10 @@ func TestGetDependencyRecordsForIssuesOrdersByDependsOnID(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = db.Close() })
 
-	// PartitionWispIDsInTx: empty wisps → all permanent.
-	// Match whatever partition query looks like loosely if used; if Partition expects
-	// specific SQL, use ExpectQuery with a flexible pattern.
-	// Simpler path: call getDependencyRecordsIntoFromTable via FromTable helper.
+	// The FromTable fast path skips PartitionWispIDsInTx, so no partition query.
 	now := time.Now()
-	flex := `(?s)SELECT issue_id, COALESCE\(depends_on_issue_id, depends_on_wisp_id, depends_on_external\) AS depends_on_id, type, created_at, created_by, metadata, thread_id\s+FROM dependencies WHERE issue_id IN \(\?\) ORDER BY issue_id, depends_on_id, type`
-	mock.ExpectQuery(flex).
+	depsForIssuesRegex := dependencyRecordsForIssuesQueryRegex("dependencies")
+	mock.ExpectQuery(depsForIssuesRegex).
 		WithArgs("src").
 		WillReturnRows(dependencyRows().
 			AddRow("src", "a-target", types.DepBlocks, now, "t", "{}", "").

--- a/internal/storage/issueops/dependency_queries_test.go
+++ b/internal/storage/issueops/dependency_queries_test.go
@@ -13,7 +13,7 @@ import (
 
 func allDependencyRecordsQueryRegex(table string) string {
 	return `(?s)SELECT issue_id, COALESCE\(depends_on_issue_id, depends_on_wisp_id, depends_on_external\) AS depends_on_id, type, created_at, created_by, metadata, thread_id\s+FROM ` +
-		regexp.QuoteMeta(table) + `\s+ORDER BY issue_id`
+		regexp.QuoteMeta(table) + `\s+ORDER BY issue_id, depends_on_id, type`
 }
 
 func dependencyRows() *sqlmock.Rows {
@@ -91,4 +91,50 @@ func onlyDependency(t *testing.T, deps map[string][]*types.Dependency, issueID s
 		t.Fatalf("deps[%q] length = %d, want 1: %+v", issueID, len(got), got)
 	}
 	return got[0]
+}
+
+// TestGetDependencyRecordsForIssuesOrdersByDependsOnID asserts the IN-list bulk
+// loader requests a total ORDER BY (issue_id, depends_on_id, type) and preserves
+// that row order in the returned slice — the property #4749 needs for stable export.
+func TestGetDependencyRecordsForIssuesOrdersByDependsOnID(t *testing.T) {
+	t.Parallel()
+
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	// PartitionWispIDsInTx: empty wisps → all permanent.
+	// Match whatever partition query looks like loosely if used; if Partition expects
+	// specific SQL, use ExpectQuery with a flexible pattern.
+	// Simpler path: call getDependencyRecordsIntoFromTable via FromTable helper.
+	now := time.Now()
+	q := regexp.QuoteMeta(
+		"SELECT issue_id, COALESCE(depends_on_issue_id, depends_on_wisp_id, depends_on_external) AS depends_on_id, type, created_at, created_by, metadata, thread_id\n" +
+			"\t\t\t FROM dependencies WHERE issue_id IN (?) ORDER BY issue_id, depends_on_id, type",
+	)
+	// The actual query uses fmt with tabs/spaces — use flexible regex like the all-query helper.
+	flex := `(?s)SELECT issue_id, COALESCE\(depends_on_issue_id, depends_on_wisp_id, depends_on_external\) AS depends_on_id, type, created_at, created_by, metadata, thread_id\s+FROM dependencies WHERE issue_id IN \(\?\) ORDER BY issue_id, depends_on_id, type`
+	_ = q
+	mock.ExpectQuery(flex).
+		WithArgs("src").
+		WillReturnRows(dependencyRows().
+			AddRow("src", "a-target", types.DepBlocks, now, "t", "{}", "").
+			AddRow("src", "z-target", types.DepBlocks, now, "t", "{}", ""))
+
+	got, err := GetDependencyRecordsForIssuesFromTableInTx(context.Background(), db, "dependencies", []string{"src"})
+	if err != nil {
+		t.Fatalf("GetDependencyRecordsForIssuesFromTableInTx: %v", err)
+	}
+	deps := got["src"]
+	if len(deps) != 2 {
+		t.Fatalf("len = %d, want 2", len(deps))
+	}
+	if deps[0].DependsOnID != "a-target" || deps[1].DependsOnID != "z-target" {
+		t.Fatalf("order = [%q, %q], want [a-target, z-target]", deps[0].DependsOnID, deps[1].DependsOnID)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet SQL expectations: %v", err)
+	}
 }

--- a/internal/storage/issueops/dependency_queries_test.go
+++ b/internal/storage/issueops/dependency_queries_test.go
@@ -110,13 +110,7 @@ func TestGetDependencyRecordsForIssuesOrdersByDependsOnID(t *testing.T) {
 	// specific SQL, use ExpectQuery with a flexible pattern.
 	// Simpler path: call getDependencyRecordsIntoFromTable via FromTable helper.
 	now := time.Now()
-	q := regexp.QuoteMeta(
-		"SELECT issue_id, COALESCE(depends_on_issue_id, depends_on_wisp_id, depends_on_external) AS depends_on_id, type, created_at, created_by, metadata, thread_id\n" +
-			"\t\t\t FROM dependencies WHERE issue_id IN (?) ORDER BY issue_id, depends_on_id, type",
-	)
-	// The actual query uses fmt with tabs/spaces — use flexible regex like the all-query helper.
 	flex := `(?s)SELECT issue_id, COALESCE\(depends_on_issue_id, depends_on_wisp_id, depends_on_external\) AS depends_on_id, type, created_at, created_by, metadata, thread_id\s+FROM dependencies WHERE issue_id IN \(\?\) ORDER BY issue_id, depends_on_id, type`
-	_ = q
 	mock.ExpectQuery(flex).
 		WithArgs("src").
 		WillReturnRows(dependencyRows().


### PR DESCRIPTION
## Summary

Dependency bulk-loaders ordered only by `issue_id`, which groups rows but does not totally order dependencies *within* an issue. The engine could return different intra-issue orders depending on plan/access path, which showed up as pure reorder noise in `bd export` and unstable dependency arrays in ready/list JSON.

Both loaders now use:

```sql
ORDER BY issue_id, depends_on_id, type
```

matching the labels bulk-loader style (`issue_id, label`). `(issue_id, target)` is unique, so this is a total order.

Fixes #4749.

Thanks for the detailed measurement and diagnosis in the issue.

## Test plan

- [x] `go test ./internal/storage/issueops/ -count=1 -run 'DependencyRecords|GetAllDependency'` — pass
- [x] Updated sqlmock regex for full-scan `ORDER BY`
- [x] New `TestGetDependencyRecordsForIssuesOrdersByDependsOnID` — asserts IN-list query includes the tiebreaker and preserves row order
