### PR TITLE
fix(dolt): show remotes from persisted repo_state when store is nil (#4619)

### DIFF
--- a/cmd/bd/dolt.go
+++ b/cmd/bd/dolt.go
@@ -1441,27 +1441,36 @@ func selectedDoltBeadsDir() string {
 // `show` is a no-store diagnostic command, so getStore() is usually nil and
 // ListRemotes is unavailable. Fall back to on-disk repo_state.json (same
 // source as the remote-migrate gate) so remotes match `bd dolt remote list`
-// in embedded mode (GH#4619).
-func resolveDoltShowRemotes(beadsDir string, cfg *configfile.Config, embeddedDataDir string) []storage.RemoteInfo {
+// (GH#4619).
+//
+// Only the candidate path(s) for the active mode (embedded vs. server) are
+// probed; a repo in one mode must not surface stale remotes persisted under
+// the other mode's data directory. Within the mode-appropriate candidates,
+// the first repo_state.json found on disk is authoritative: an empty
+// remotes list there means "no remotes", not "keep looking" — this stops
+// an authoritative-but-empty active database from falling through to a
+// stale candidate. A corrupt or unreadable repo_state.json is surfaced as a
+// warning rather than silently rendered as "(none)".
+func resolveDoltShowRemotes(beadsDir string, cfg *configfile.Config, embeddedDataDir string, embedded bool) []storage.RemoteInfo {
 	ctx := context.Background()
 	if st := getStore(); st != nil {
 		if remotes, err := st.ListRemotes(ctx); err == nil && len(remotes) > 0 {
 			return remotes
 		}
 	}
-	// Probe persisted remotes under common Dolt data roots without opening a store.
 	dbName := ""
 	if cfg != nil {
 		dbName = cfg.GetDoltDatabase()
 	}
 	var candidates []string
-	if embeddedDataDir != "" {
-		candidates = append(candidates, embeddedDataDir)
-		if dbName != "" {
-			candidates = append(candidates, filepath.Join(embeddedDataDir, dbName))
+	if embedded {
+		if embeddedDataDir != "" {
+			candidates = append(candidates, embeddedDataDir)
+			if dbName != "" {
+				candidates = append(candidates, filepath.Join(embeddedDataDir, dbName))
+			}
 		}
-	}
-	if beadsDir != "" {
+	} else if beadsDir != "" {
 		candidates = append(candidates, filepath.Join(beadsDir, "dolt"))
 		if dbName != "" {
 			candidates = append(candidates, filepath.Join(beadsDir, "dolt", dbName))
@@ -1471,10 +1480,19 @@ func resolveDoltShowRemotes(beadsDir string, cfg *configfile.Config, embeddedDat
 		if dir == "" {
 			continue
 		}
-		remotes, err := doltutil.PersistedRemotes(dir)
-		if err != nil || len(remotes) == 0 {
+		statePath := filepath.Join(dir, ".dolt", "repo_state.json")
+		if _, err := os.Stat(statePath); err != nil {
+			// No dolt repo state at this candidate; try the next
+			// mode-appropriate candidate.
 			continue
 		}
+		remotes, err := doltutil.PersistedRemotes(dir)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "%s\n", ui.RenderWarn(fmt.Sprintf("could not read remotes from %s: %v", statePath, err)))
+			return nil
+		}
+		// repo_state.json exists at this candidate: its remotes (even if
+		// empty) are authoritative for the active mode.
 		return remotes
 	}
 	return nil
@@ -1563,7 +1581,7 @@ func showDoltConfig(testConnection bool) error {
 	}
 
 	fmt.Println("\nRemotes:")
-	remotes := resolveDoltShowRemotes(beadsDir, cfg, embeddedDataDir)
+	remotes := resolveDoltShowRemotes(beadsDir, cfg, embeddedDataDir, embedded)
 	if len(remotes) == 0 {
 		fmt.Println("  (none)")
 	} else {

--- a/cmd/bd/dolt.go
+++ b/cmd/bd/dolt.go
@@ -1437,6 +1437,49 @@ func selectedDoltBeadsDir() string {
 	return beadsDir
 }
 
+// resolveDoltShowRemotes returns remotes for `bd dolt show`.
+// `show` is a no-store diagnostic command, so getStore() is usually nil and
+// ListRemotes is unavailable. Fall back to on-disk repo_state.json (same
+// source as the remote-migrate gate) so remotes match `bd dolt remote list`
+// in embedded mode (GH#4619).
+func resolveDoltShowRemotes(beadsDir string, cfg *configfile.Config, embeddedDataDir string) []storage.RemoteInfo {
+	ctx := context.Background()
+	if st := getStore(); st != nil {
+		if remotes, err := st.ListRemotes(ctx); err == nil && len(remotes) > 0 {
+			return remotes
+		}
+	}
+	// Probe persisted remotes under common Dolt data roots without opening a store.
+	dbName := ""
+	if cfg != nil {
+		dbName = cfg.GetDoltDatabase()
+	}
+	var candidates []string
+	if embeddedDataDir != "" {
+		candidates = append(candidates, embeddedDataDir)
+		if dbName != "" {
+			candidates = append(candidates, filepath.Join(embeddedDataDir, dbName))
+		}
+	}
+	if beadsDir != "" {
+		candidates = append(candidates, filepath.Join(beadsDir, "dolt"))
+		if dbName != "" {
+			candidates = append(candidates, filepath.Join(beadsDir, "dolt", dbName))
+		}
+	}
+	for _, dir := range candidates {
+		if dir == "" {
+			continue
+		}
+		remotes, err := doltutil.PersistedRemotes(dir)
+		if err != nil || len(remotes) == 0 {
+			continue
+		}
+		return remotes
+	}
+	return nil
+}
+
 func showDoltConfig(testConnection bool) error {
 	beadsDir := selectedDoltBeadsDir()
 	if beadsDir == "" {
@@ -1520,12 +1563,7 @@ func showDoltConfig(testConnection bool) error {
 	}
 
 	fmt.Println("\nRemotes:")
-	ctx := context.Background()
-	st := getStore()
-	var remotes []storage.RemoteInfo
-	if st != nil {
-		remotes, _ = st.ListRemotes(ctx)
-	}
+	remotes := resolveDoltShowRemotes(beadsDir, cfg, embeddedDataDir)
 	if len(remotes) == 0 {
 		fmt.Println("  (none)")
 	} else {

--- a/cmd/bd/dolt_test.go
+++ b/cmd/bd/dolt_test.go
@@ -1783,9 +1783,27 @@ func TestNoPushDoesNotSkipDoltPull(t *testing.T) {
 	}
 }
 
+// withNilStoreForShow sets store and cmdCtx.Store to nil (getStore() prefers
+// cmdCtx over the legacy global, so both must be cleared to reproduce the
+// `bd dolt show` no-store diagnostic path), restoring both on cleanup. See
+// TestDoltPushPullCommitNeedStore for the same pattern.
+func withNilStoreForShow(t *testing.T) {
+	t.Helper()
+	originalStore := store
+	originalCmdCtx := cmdCtx
+	t.Cleanup(func() {
+		store = originalStore
+		cmdCtx = originalCmdCtx
+	})
+	store = nil
+	cmdCtx = &CommandContext{}
+}
+
 // GH#4619: bd dolt show is a no-store command; remotes must still surface from
 // on-disk repo_state.json when getStore() is nil.
 func TestResolveDoltShowRemotesFromPersistedState(t *testing.T) {
+	withNilStoreForShow(t)
+
 	beadsDir := t.TempDir()
 	dbName := "beads"
 	dbPath := filepath.Join(beadsDir, "embeddeddolt", dbName)
@@ -1803,9 +1821,7 @@ func TestResolveDoltShowRemotesFromPersistedState(t *testing.T) {
 		t.Fatalf("default dolt database = %q, want %q for fixture layout", cfg.GetDoltDatabase(), dbName)
 	}
 
-	// getStore() is nil outside PersistentPreRun — same as real `bd dolt show`.
-	store = nil
-	remotes := resolveDoltShowRemotes(beadsDir, cfg, filepath.Join(beadsDir, "embeddeddolt"))
+	remotes := resolveDoltShowRemotes(beadsDir, cfg, filepath.Join(beadsDir, "embeddeddolt"), true)
 	if len(remotes) != 1 || remotes[0].Name != "origin" {
 		t.Fatalf("resolveDoltShowRemotes = %+v, want origin", remotes)
 	}
@@ -1815,9 +1831,119 @@ func TestResolveDoltShowRemotesFromPersistedState(t *testing.T) {
 }
 
 func TestResolveDoltShowRemotesNoneWhenNoState(t *testing.T) {
-	store = nil
-	remotes := resolveDoltShowRemotes(t.TempDir(), configfile.DefaultConfig(), filepath.Join(t.TempDir(), "embeddeddolt"))
+	withNilStoreForShow(t)
+
+	remotes := resolveDoltShowRemotes(t.TempDir(), configfile.DefaultConfig(), filepath.Join(t.TempDir(), "embeddeddolt"), true)
 	if len(remotes) != 0 {
 		t.Fatalf("want no remotes, got %+v", remotes)
+	}
+}
+
+// TestResolveDoltShowRemotesModeAppropriate verifies GH#4830 should-fix 1:
+// a server-mode repo must not surface remotes persisted under the embedded
+// data dir, and vice versa — only the active mode's candidate path(s) are
+// probed.
+func TestResolveDoltShowRemotesModeAppropriate(t *testing.T) {
+	withNilStoreForShow(t)
+
+	beadsDir := t.TempDir()
+	dbName := "beads"
+
+	// Populate ONLY the embedded candidate with remotes.
+	embeddedDBPath := filepath.Join(beadsDir, "embeddeddolt", dbName)
+	if err := os.MkdirAll(filepath.Join(embeddedDBPath, ".dolt"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	state := `{"remotes":{"origin":{"name":"origin","url":"https://doltremoteapi.dolthub.com/embedded"}}}`
+	if err := os.WriteFile(filepath.Join(embeddedDBPath, ".dolt", "repo_state.json"), []byte(state), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := configfile.DefaultConfig()
+	embeddedDataDir := filepath.Join(beadsDir, "embeddeddolt")
+
+	// Active mode is server (embedded=false): the embedded-only remotes
+	// must not leak through.
+	remotes := resolveDoltShowRemotes(beadsDir, cfg, embeddedDataDir, false)
+	if len(remotes) != 0 {
+		t.Fatalf("server-mode resolve leaked embedded remotes: %+v", remotes)
+	}
+}
+
+// TestResolveDoltShowRemotesAuthoritativeEmpty verifies GH#4830 should-fix 1:
+// an active database with a persisted-but-empty remotes map is authoritative
+// and must not fall through to a stale candidate directory that still has
+// remotes recorded.
+func TestResolveDoltShowRemotesAuthoritativeEmpty(t *testing.T) {
+	withNilStoreForShow(t)
+
+	beadsDir := t.TempDir()
+	dbName := "beads"
+
+	// The bare embedded data dir (checked first) is present but has no
+	// remotes — this must be treated as authoritative, not skipped in
+	// favor of the dbName-suffixed candidate below.
+	barePath := filepath.Join(beadsDir, "embeddeddolt")
+	if err := os.MkdirAll(filepath.Join(barePath, ".dolt"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(barePath, ".dolt", "repo_state.json"), []byte(`{"remotes":{}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// A stale candidate with remotes recorded — must not be consulted.
+	stalePath := filepath.Join(barePath, dbName)
+	if err := os.MkdirAll(filepath.Join(stalePath, ".dolt"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	staleState := `{"remotes":{"origin":{"name":"origin","url":"https://doltremoteapi.dolthub.com/stale"}}}`
+	if err := os.WriteFile(filepath.Join(stalePath, ".dolt", "repo_state.json"), []byte(staleState), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := configfile.DefaultConfig()
+	remotes := resolveDoltShowRemotes(beadsDir, cfg, barePath, true)
+	if len(remotes) != 0 {
+		t.Fatalf("authoritative empty result was overridden by stale candidate: %+v", remotes)
+	}
+}
+
+// TestResolveDoltShowRemotesCorruptStateWarns verifies GH#4830 should-fix 2:
+// a corrupt repo_state.json must not silently render as "(none)" — the
+// caller gets no remotes back, but a warning is surfaced.
+func TestResolveDoltShowRemotesCorruptStateWarns(t *testing.T) {
+	withNilStoreForShow(t)
+
+	beadsDir := t.TempDir()
+	dbName := "beads"
+	dbPath := filepath.Join(beadsDir, "embeddeddolt", dbName)
+	if err := os.MkdirAll(filepath.Join(dbPath, ".dolt"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dbPath, ".dolt", "repo_state.json"), []byte("{not valid json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := configfile.DefaultConfig()
+	origStderr := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stderr = w
+	defer func() { os.Stderr = origStderr }()
+
+	remotes := resolveDoltShowRemotes(beadsDir, cfg, filepath.Join(beadsDir, "embeddeddolt"), true)
+
+	_ = w.Close()
+	os.Stderr = origStderr
+	var buf bytes.Buffer
+	_, _ = buf.ReadFrom(r)
+
+	if len(remotes) != 0 {
+		t.Fatalf("want no remotes from corrupt state, got %+v", remotes)
+	}
+	if !strings.Contains(buf.String(), "repo_state.json") {
+		t.Fatalf("expected a warning naming repo_state.json, got: %q", buf.String())
 	}
 }

--- a/cmd/bd/dolt_test.go
+++ b/cmd/bd/dolt_test.go
@@ -1782,3 +1782,42 @@ func TestNoPushDoesNotSkipDoltPull(t *testing.T) {
 		t.Errorf("expected pull attempt output, got: %q", out)
 	}
 }
+
+// GH#4619: bd dolt show is a no-store command; remotes must still surface from
+// on-disk repo_state.json when getStore() is nil.
+func TestResolveDoltShowRemotesFromPersistedState(t *testing.T) {
+	beadsDir := t.TempDir()
+	dbName := "beads"
+	dbPath := filepath.Join(beadsDir, "embeddeddolt", dbName)
+	if err := os.MkdirAll(filepath.Join(dbPath, ".dolt"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	state := `{"remotes":{"origin":{"name":"origin","url":"https://doltremoteapi.dolthub.com/org/db"}}}`
+	if err := os.WriteFile(filepath.Join(dbPath, ".dolt", "repo_state.json"), []byte(state), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := configfile.DefaultConfig()
+	// Ensure database name matches fixture path.
+	if cfg.GetDoltDatabase() != dbName {
+		t.Fatalf("default dolt database = %q, want %q for fixture layout", cfg.GetDoltDatabase(), dbName)
+	}
+
+	// getStore() is nil outside PersistentPreRun — same as real `bd dolt show`.
+	store = nil
+	remotes := resolveDoltShowRemotes(beadsDir, cfg, filepath.Join(beadsDir, "embeddeddolt"))
+	if len(remotes) != 1 || remotes[0].Name != "origin" {
+		t.Fatalf("resolveDoltShowRemotes = %+v, want origin", remotes)
+	}
+	if remotes[0].URL != "https://doltremoteapi.dolthub.com/org/db" {
+		t.Fatalf("origin URL = %q", remotes[0].URL)
+	}
+}
+
+func TestResolveDoltShowRemotesNoneWhenNoState(t *testing.T) {
+	store = nil
+	remotes := resolveDoltShowRemotes(t.TempDir(), configfile.DefaultConfig(), filepath.Join(t.TempDir(), "embeddeddolt"))
+	if len(remotes) != 0 {
+		t.Fatalf("want no remotes, got %+v", remotes)
+	}
+}


### PR DESCRIPTION
## Summary

In embedded mode, `bd dolt show` always printed `Remotes: (none)` even when `bd dolt remote list` showed a working `origin`.

`dolt show` is a no-store diagnostic (`getStore()` is nil), so the remotes block never called `ListRemotes`. This change resolves remotes for show via:

1. `store.ListRemotes` when a store happens to be present, else  
2. `doltutil.PersistedRemotes` under `.beads/embeddeddolt[/database]` (and server-mode `dolt[/database]` paths) — the same on-disk `repo_state.json` source used by the remote-migrate gate.

Fixes #4619.

Thanks for the clear root-cause analysis and suggested approach.

## Test plan

- [x] `go test ./cmd/bd/ -count=1 -run 'ResolveDoltShowRemotes'` with icu4c CGO flags — pass  
- [x] `TestResolveDoltShowRemotesFromPersistedState` — fixture `repo_state.json` with origin  
- [x] `TestResolveDoltShowRemotesNoneWhenNoState` — empty when no `.dolt` state  
