### PR TITLE
fix(swarm): exclude closed issues from ready-front waves (#4564)

### DIFF
--- a/cmd/bd/swarm.go
+++ b/cmd/bd/swarm.go
@@ -314,6 +314,13 @@ func analyzeEpicForSwarm(ctx context.Context, s SwarmStorage, epic *types.Issue)
 	return analysis, nil
 }
 
+// issueIsClosed reports whether id is closed. Closed issues count as satisfied
+// and are excluded from cycle detection and ready-front scheduling (GH#4564).
+func issueIsClosed(analysis *SwarmAnalysis, id string) bool {
+	n, ok := analysis.Issues[id]
+	return ok && n.Status == string(types.StatusClosed)
+}
+
 // detectStructuralIssues looks for common problems in the dependency graph.
 //
 //nolint:unparam // issues reserved for future use
@@ -402,6 +409,7 @@ func detectStructuralIssues(analysis *SwarmAnalysis, _ []*types.Issue) {
 
 	// 5. Detect cycles using simple DFS
 	// (The main DetectCycles in storage is more sophisticated, but we do a simple check here)
+	// Closed issues are excluded: a closed cycle must not block open children (GH#4564).
 	inProgress := make(map[string]bool)
 	completed := make(map[string]bool)
 	var cyclePath []string
@@ -409,6 +417,9 @@ func detectStructuralIssues(analysis *SwarmAnalysis, _ []*types.Issue) {
 
 	var detectCycle func(id string) bool
 	detectCycle = func(id string) bool {
+		if issueIsClosed(analysis, id) {
+			return false
+		}
 		if completed[id] {
 			return false
 		}
@@ -434,6 +445,9 @@ func detectStructuralIssues(analysis *SwarmAnalysis, _ []*types.Issue) {
 	}
 
 	for id := range analysis.Issues {
+		if issueIsClosed(analysis, id) {
+			continue
+		}
 		if !completed[id] {
 			if detectCycle(id) {
 				break
@@ -457,8 +471,7 @@ func computeReadyFronts(analysis *SwarmAnalysis) {
 	}
 
 	isClosed := func(id string) bool {
-		n, ok := analysis.Issues[id]
-		return ok && n.Status == string(types.StatusClosed)
+		return issueIsClosed(analysis, id)
 	}
 
 	// Kahn's algorithm over open issues only; in-degree counts open blockers.

--- a/cmd/bd/swarm.go
+++ b/cmd/bd/swarm.go
@@ -448,19 +448,35 @@ func detectStructuralIssues(analysis *SwarmAnalysis, _ []*types.Issue) {
 }
 
 // computeReadyFronts calculates the waves of parallel work.
+// Closed issues are excluded from waves and do not block dependents (GH#4564):
+// a closed dependency is treated as already satisfied for ready-front purposes.
 func computeReadyFronts(analysis *SwarmAnalysis) {
 	if len(analysis.Errors) > 0 {
 		// Can't compute ready fronts if there are cycles
 		return
 	}
 
-	// Use Kahn's algorithm for topological sort with level tracking
-	inDegree := make(map[string]int)
-	for id, node := range analysis.Issues {
-		inDegree[id] = len(node.DependsOn)
+	isClosed := func(id string) bool {
+		n, ok := analysis.Issues[id]
+		return ok && n.Status == string(types.StatusClosed)
 	}
 
-	// Start with all nodes that have no dependencies (wave 0)
+	// Kahn's algorithm over open issues only; in-degree counts open blockers.
+	inDegree := make(map[string]int)
+	for id, node := range analysis.Issues {
+		if isClosed(id) {
+			continue
+		}
+		openBlockers := 0
+		for _, depID := range node.DependsOn {
+			if !isClosed(depID) {
+				openBlockers++
+			}
+		}
+		inDegree[id] = openBlockers
+	}
+
+	// Wave 0: open issues with no open dependencies
 	var currentWave []string
 	for id, degree := range inDegree {
 		if degree == 0 {
@@ -494,11 +510,17 @@ func computeReadyFronts(analysis *SwarmAnalysis) {
 			analysis.MaxParallelism = len(currentWave)
 		}
 
-		// Find next wave
+		// Find next wave among open dependents
 		var nextWave []string
 		for _, id := range currentWave {
 			if node, ok := analysis.Issues[id]; ok {
 				for _, dependentID := range node.DependedOnBy {
+					if isClosed(dependentID) {
+						continue
+					}
+					if _, tracked := inDegree[dependentID]; !tracked {
+						continue
+					}
 					inDegree[dependentID]--
 					if inDegree[dependentID] == 0 {
 						nextWave = append(nextWave, dependentID)
@@ -512,8 +534,14 @@ func computeReadyFronts(analysis *SwarmAnalysis) {
 		wave++
 	}
 
-	// Estimated sessions = total issues (each issue is roughly one session)
-	analysis.EstimatedSessions = analysis.TotalIssues
+	// Estimated sessions ≈ remaining open issues (each issue is roughly one session)
+	openCount := 0
+	for id := range analysis.Issues {
+		if !isClosed(id) {
+			openCount++
+		}
+	}
+	analysis.EstimatedSessions = openCount
 }
 
 // renderSwarmAnalysis outputs human-readable analysis.

--- a/cmd/bd/swarm_ready_fronts_test.go
+++ b/cmd/bd/swarm_ready_fronts_test.go
@@ -1,10 +1,40 @@
 package main
 
 import (
+	"context"
 	"testing"
 
 	"github.com/steveyegge/beads/internal/types"
 )
+
+// fakeSwarmStorage is a minimal in-memory SwarmStorage. deps is keyed by the
+// issue holding them (issue_id -> its outgoing dependency records).
+type fakeSwarmStorage struct {
+	issues map[string]*types.Issue
+	deps   map[string][]*types.Dependency
+}
+
+func (f *fakeSwarmStorage) GetIssue(_ context.Context, id string) (*types.Issue, error) {
+	return f.issues[id], nil
+}
+
+func (f *fakeSwarmStorage) GetDependents(_ context.Context, id string) ([]*types.Issue, error) {
+	var out []*types.Issue
+	for issueID, deps := range f.deps {
+		for _, d := range deps {
+			if d.DependsOnID == id {
+				if issue, ok := f.issues[issueID]; ok {
+					out = append(out, issue)
+				}
+			}
+		}
+	}
+	return out, nil
+}
+
+func (f *fakeSwarmStorage) GetDependencyRecords(_ context.Context, id string) ([]*types.Dependency, error) {
+	return f.deps[id], nil
+}
 
 func TestComputeReadyFrontsExcludesClosed(t *testing.T) {
 	analysis := &SwarmAnalysis{
@@ -64,5 +94,71 @@ func TestComputeReadyFrontsClosedLeafNotInWave0(t *testing.T) {
 	computeReadyFronts(analysis)
 	if len(analysis.ReadyFronts) != 1 || len(analysis.ReadyFronts[0].Issues) != 1 || analysis.ReadyFronts[0].Issues[0] != "todo" {
 		t.Fatalf("ready fronts = %+v, want single wave with only todo", analysis.ReadyFronts)
+	}
+}
+
+// A closed<->open cycle must not be reported as a structural error, nor suppress
+// ready fronts for unrelated open children (GH#4564). Pre-fix, the recorded cycle
+// error made computeReadyFronts bail out and left ReadyFronts empty.
+func TestAnalyzeEpicForSwarmClosedCycleDoesNotSuppressOpenFronts(t *testing.T) {
+	ctx := context.Background()
+
+	epic := &types.Issue{ID: "epic-1", Title: "Epic", Status: types.StatusOpen}
+	closedA := &types.Issue{ID: "closed-a", Title: "Closed A", Status: types.StatusClosed}
+	openB := &types.Issue{ID: "open-b", Title: "Open B", Status: types.StatusOpen}
+	openC := &types.Issue{ID: "open-c", Title: "Unrelated Open C", Status: types.StatusOpen}
+
+	store := &fakeSwarmStorage{
+		issues: map[string]*types.Issue{
+			epic.ID:    epic,
+			closedA.ID: closedA,
+			openB.ID:   openB,
+			openC.ID:   openC,
+		},
+		deps: map[string][]*types.Dependency{
+			// closed-a <-> open-b: mutual cycle, one side closed.
+			"closed-a": {
+				{IssueID: "closed-a", DependsOnID: epic.ID, Type: types.DepParentChild},
+				{IssueID: "closed-a", DependsOnID: "open-b", Type: types.DepBlocks},
+			},
+			"open-b": {
+				{IssueID: "open-b", DependsOnID: epic.ID, Type: types.DepParentChild},
+				{IssueID: "open-b", DependsOnID: "closed-a", Type: types.DepBlocks},
+			},
+			// open-c: unrelated open child with no dependencies of its own.
+			"open-c": {
+				{IssueID: "open-c", DependsOnID: epic.ID, Type: types.DepParentChild},
+			},
+		},
+	}
+
+	analysis, err := analyzeEpicForSwarm(ctx, store, epic)
+	if err != nil {
+		t.Fatalf("analyzeEpicForSwarm() error = %v", err)
+	}
+
+	if len(analysis.Errors) != 0 {
+		t.Fatalf("Errors = %v, want none (closed-a/open-b cycle should be excluded)", analysis.Errors)
+	}
+	if !analysis.Swarmable {
+		t.Fatalf("Swarmable = false, want true")
+	}
+	if len(analysis.ReadyFronts) == 0 {
+		t.Fatalf("ReadyFronts is empty, want at least wave 0 with open-b and open-c")
+	}
+
+	wave0 := analysis.ReadyFronts[0].Issues
+	inWave0 := make(map[string]bool, len(wave0))
+	for _, id := range wave0 {
+		inWave0[id] = true
+	}
+	if !inWave0["open-b"] {
+		t.Fatalf("wave 0 = %v, want open-b present (closed-a dependency satisfied)", wave0)
+	}
+	if !inWave0["open-c"] {
+		t.Fatalf("wave 0 = %v, want unrelated open-c present", wave0)
+	}
+	if inWave0["closed-a"] {
+		t.Fatalf("wave 0 = %v, closed-a must not appear in a ready front", wave0)
 	}
 }

--- a/cmd/bd/swarm_ready_fronts_test.go
+++ b/cmd/bd/swarm_ready_fronts_test.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/steveyegge/beads/internal/types"
+)
+
+func TestComputeReadyFrontsExcludesClosed(t *testing.T) {
+	analysis := &SwarmAnalysis{
+		Issues: map[string]*IssueNode{
+			"open-a": {
+				ID: "open-a", Title: "Open A", Status: string(types.StatusOpen),
+				DependsOn: nil, DependedOnBy: []string{"open-b"}, Wave: -1,
+			},
+			"closed-c": {
+				ID: "closed-c", Title: "Closed C", Status: string(types.StatusClosed),
+				DependsOn: nil, DependedOnBy: []string{"open-b"}, Wave: -1,
+			},
+			"open-b": {
+				ID: "open-b", Title: "Open B", Status: string(types.StatusOpen),
+				// blocked by closed-c and open-a; closed should not hold it out of later wave
+				DependsOn: []string{"open-a", "closed-c"}, DependedOnBy: nil, Wave: -1,
+			},
+		},
+	}
+
+	computeReadyFronts(analysis)
+
+	// closed-c must not appear in any ready front
+	for _, front := range analysis.ReadyFronts {
+		for _, id := range front.Issues {
+			if id == "closed-c" {
+				t.Fatalf("closed issue listed in wave %d: %v", front.Wave, front.Issues)
+			}
+		}
+	}
+	if analysis.Issues["closed-c"].Wave != -1 {
+		t.Fatalf("closed issue Wave = %d, want -1 (not assigned)", analysis.Issues["closed-c"].Wave)
+	}
+
+	// open-a is wave 0; open-b becomes ready after open-a (closed-c ignored)
+	if analysis.Issues["open-a"].Wave != 0 {
+		t.Fatalf("open-a Wave = %d, want 0", analysis.Issues["open-a"].Wave)
+	}
+	if analysis.Issues["open-b"].Wave != 1 {
+		t.Fatalf("open-b Wave = %d, want 1 (only open-a is an open blocker)", analysis.Issues["open-b"].Wave)
+	}
+	if analysis.MaxParallelism != 1 {
+		t.Fatalf("MaxParallelism = %d, want 1", analysis.MaxParallelism)
+	}
+	if analysis.EstimatedSessions != 2 {
+		t.Fatalf("EstimatedSessions = %d, want 2 open issues", analysis.EstimatedSessions)
+	}
+}
+
+func TestComputeReadyFrontsClosedLeafNotInWave0(t *testing.T) {
+	analysis := &SwarmAnalysis{
+		Issues: map[string]*IssueNode{
+			"done":  {ID: "done", Title: "Done", Status: string(types.StatusClosed), Wave: -1},
+			"todo":  {ID: "todo", Title: "Todo", Status: string(types.StatusOpen), Wave: -1},
+		},
+	}
+	computeReadyFronts(analysis)
+	if len(analysis.ReadyFronts) != 1 || len(analysis.ReadyFronts[0].Issues) != 1 || analysis.ReadyFronts[0].Issues[0] != "todo" {
+		t.Fatalf("ready fronts = %+v, want single wave with only todo", analysis.ReadyFronts)
+	}
+}

--- a/cmd/bd/swarm_ready_fronts_test.go
+++ b/cmd/bd/swarm_ready_fronts_test.go
@@ -57,8 +57,8 @@ func TestComputeReadyFrontsExcludesClosed(t *testing.T) {
 func TestComputeReadyFrontsClosedLeafNotInWave0(t *testing.T) {
 	analysis := &SwarmAnalysis{
 		Issues: map[string]*IssueNode{
-			"done":  {ID: "done", Title: "Done", Status: string(types.StatusClosed), Wave: -1},
-			"todo":  {ID: "todo", Title: "Todo", Status: string(types.StatusOpen), Wave: -1},
+			"done": {ID: "done", Title: "Done", Status: string(types.StatusClosed), Wave: -1},
+			"todo": {ID: "todo", Title: "Todo", Status: string(types.StatusOpen), Wave: -1},
 		},
 	}
 	computeReadyFronts(analysis)


### PR DESCRIPTION
## Summary

`bd swarm validate` listed **closed** children in "Ready Fronts" waves. The wave algorithm treated every child as work to schedule and counted closed nodes as unresolved blockers.

This change:

- Excludes `status=closed` issues from ready-front membership
- Treats closed dependencies as already satisfied for open dependents
- Sets estimated sessions from open issues only

Fixes #4564.

## Test plan

- [x] `go test ./cmd/bd/ -count=1 -run TestComputeReadyFronts` (icu4c CGO) — pass
  - closed leaf not in wave 0
  - closed blocker does not hold open dependent forever; open-only path advances
