### PR TITLE
Gate official v0.62.0 server upgrades with a fail-closed bridge

### DIFF
--- a/.github/workflows/migration-test.yml
+++ b/.github/workflows/migration-test.yml
@@ -244,6 +244,12 @@ jobs:
         if: steps.selection.outputs.selected == 'true'
         run: make build
 
+      - name: Verify public v0.62 migration bridge
+        if: steps.selection.outputs.selected == 'true' && matrix.version == 'v0.62.0'
+        env:
+          PUBLIC_V062_REAL_TARGET_BD: ./bd
+        run: ./scripts/migration-test/public-v062-bridge-test.sh
+
       - name: Verify strict harness guards
         if: steps.selection.outputs.selected == 'true'
         run: ./scripts/migration-test/strict-mode-test.sh

--- a/.github/workflows/migration-test.yml
+++ b/.github/workflows/migration-test.yml
@@ -32,9 +32,112 @@ env:
   BD_DISABLE_EVENT_FLUSH: "1"
 
 jobs:
+  migration-test-plan:
+    name: Validate and plan migration lanes
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    outputs:
+      has-supplemental-work: ${{ steps.plan.outputs.has_supplemental_work }}
+      supplemental-versions: ${{ steps.plan.outputs.supplemental_versions }}
+      run-stepping: ${{ steps.plan.outputs.run_stepping }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+
+      - name: Validate ownership and classify supplemental work
+        id: plan
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          REQUESTED_MODE: ${{ github.event.inputs.mode }}
+          REQUESTED_VERSIONS: ${{ github.event.inputs.versions }}
+        run: |
+          set -euo pipefail
+          source scripts/migration-test/lib/versions.sh
+
+          mapfile -t matrix_versions < <(
+            awk '
+              /^  historical-upgrades:/ { in_historical = 1; next }
+              in_historical && /^    steps:/ { exit }
+              in_historical && $1 == "version:" { print $2 }
+            ' .github/workflows/migration-test.yml | sort -V
+          )
+          mapfile -t manifest_versions < <(
+            printf '%s\n' "${!STRICT_EXPECTED_STATUSES[@]}" | sort -V
+          )
+          if ! diff -u \
+              <(printf '%s\n' "${manifest_versions[@]}") \
+              <(printf '%s\n' "${matrix_versions[@]}"); then
+            echo "::error::strict workflow matrix and qualification manifest disagree"
+            exit 1
+          fi
+
+          has_supplemental_work=false
+          run_stepping=false
+          supplemental_versions=()
+
+          classify_version() {
+            local version="$1"
+            if [[ ! "$version" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
+              echo "::error::versions must be space-separated vMAJOR.MINOR.PATCH releases"
+              return 1
+            fi
+            if strict_expected_status "$version" >/dev/null 2>&1; then
+              echo "$version is owned by its pinned strict qualification lane"
+            else
+              supplemental_versions+=("$version")
+              has_supplemental_work=true
+            fi
+          }
+
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            mode="${REQUESTED_MODE:-all}"
+            case "$mode" in
+              all|direct-only|stepping-only) ;;
+              *)
+                echo "::error::invalid migration test mode"
+                exit 1
+                ;;
+            esac
+
+            if [ -n "$REQUESTED_VERSIONS" ]; then
+              if [[ "$REQUESTED_VERSIONS" == *$'\n'* ]]; then
+                echo "::error::versions must be provided on one line"
+                exit 1
+              fi
+              read -r -a requested_versions <<< "$REQUESTED_VERSIONS"
+              if [ "${#requested_versions[@]}" -eq 0 ]; then
+                echo "::error::versions must include at least one release"
+                exit 1
+              fi
+              # Explicit versions have always selected direct paths regardless
+              # of mode; preserve that workflow_dispatch contract.
+              for version in "${requested_versions[@]}"; do
+                classify_version "$version"
+              done
+            else
+              if [ "$mode" != "stepping-only" ]; then
+                for version in "${DIRECT_PATHS[@]}"; do
+                  classify_version "$version"
+                done
+              fi
+              if [ "$mode" != "direct-only" ] && [ "${#STEPPING_STONE_PATHS[@]}" -gt 0 ]; then
+                run_stepping=true
+                has_supplemental_work=true
+              fi
+            fi
+          fi
+
+          {
+            printf 'has_supplemental_work=%s\n' "$has_supplemental_work"
+            printf 'supplemental_versions=%s\n' "${supplemental_versions[*]}"
+            printf 'run_stepping=%s\n' "$run_stepping"
+          } >> "$GITHUB_OUTPUT"
+
   historical-upgrades:
     name: ${{ matrix.qualification }} upgrade qualification
-    if: ${{ github.event_name == 'pull_request' }}
+    # Every direct release with a strict manifest is owned by this matrix on
+    # every CI trigger. Manual stepping-only runs remain available without
+    # paying for direct qualifications unless explicit versions were supplied.
+    if: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.mode != 'stepping-only' || github.event.inputs.versions != '' }}
     # v0.55.4 and v0.63.3 are dynamically linked against ICU 74.
     # Pin the image and install that runtime explicitly so a runner alias
     # update cannot invalidate either historical fixture.
@@ -56,30 +159,60 @@ jobs:
             version: v0.57.0
             expected: MANUAL
             cache-identity: legacy-dolt-v0.57.0-f8629d5627bed7d25f06f92334addc171d679f9aed9d08c5d42a9684205dc04b
+          - qualification: Dolt server v0.62.0
+            version: v0.62.0
+            expected: MANUAL
+            cache-identity: dolt-server-v0.62.0-4cca7265b22e5c3ca8d62ab0b9752bec31f68b7f5fa636282a4c7e5454c35535
           - qualification: Embedded Dolt v0.63.3
             version: v0.63.3
             expected: AUTO
             cache-identity: embedded-dolt-v0.63.3-5f4efd2e010209b3f381dbcd783b2a3a652f50ea72f40ef04c8ba434d408bf9e
     steps:
+      - name: Select requested qualification
+        id: selection
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          REQUESTED_VERSIONS: ${{ github.event.inputs.versions }}
+          HISTORICAL_VERSION: ${{ matrix.version }}
+        run: |
+          selected=true
+          if [ "$EVENT_NAME" = "workflow_dispatch" ] && [ -n "$REQUESTED_VERSIONS" ]; then
+            selected=false
+            read -r -a requested_versions <<< "$REQUESTED_VERSIONS"
+            for version in "${requested_versions[@]}"; do
+              if [ "$version" = "$HISTORICAL_VERSION" ]; then
+                selected=true
+                break
+              fi
+            done
+          fi
+          printf 'selected=%s\n' "$selected" >> "$GITHUB_OUTPUT"
+
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+        if: steps.selection.outputs.selected == 'true'
 
       - name: Set up Go
+        if: steps.selection.outputs.selected == 'true'
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: 'go.mod'
 
       - name: Install test dependencies
+        if: steps.selection.outputs.selected == 'true'
         run: |
           sudo apt-get update
           sudo apt-get install -y jq sqlite3 libicu74
 
-      - name: Install pinned Dolt runtime for v0.57.0
-        if: matrix.version == 'v0.57.0'
+      - name: Install pinned Dolt runtime
+        if: steps.selection.outputs.selected == 'true'
         env:
           HISTORICAL_VERSION: ${{ matrix.version }}
         run: |
           source scripts/migration-test/lib/versions.sh
-          DOLT_VERSION=$(strict_required_dolt_version "$HISTORICAL_VERSION")
+          if ! DOLT_VERSION=$(strict_required_dolt_version "$HISTORICAL_VERSION"); then
+            echo "No external Dolt runtime required for $HISTORICAL_VERSION"
+            exit 0
+          fi
           DOLT_SHA256=$(strict_required_dolt_sha256 "$HISTORICAL_VERSION" linux amd64)
           archive="$RUNNER_TEMP/dolt-linux-amd64.tar.gz"
           extract_dir="$RUNNER_TEMP/dolt-${DOLT_VERSION}"
@@ -95,23 +228,28 @@ jobs:
           test "$(dolt version | head -1)" = "dolt version ${DOLT_VERSION}"
 
       - name: Configure Git
+        if: steps.selection.outputs.selected == 'true'
         run: |
           git config --global user.name "CI Bot"
           git config --global user.email "ci@beads.test"
 
       - name: Cache pinned historical release
+        if: steps.selection.outputs.selected == 'true'
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: ~/.cache/beads-regression
           key: migration-${{ matrix.cache-identity }}-${{ runner.os }}-${{ runner.arch }}
 
       - name: Build candidate
+        if: steps.selection.outputs.selected == 'true'
         run: make build
 
       - name: Verify strict harness guards
+        if: steps.selection.outputs.selected == 'true'
         run: ./scripts/migration-test/strict-mode-test.sh
 
       - name: Qualify ${{ matrix.qualification }} upgrade
+        if: steps.selection.outputs.selected == 'true'
         env:
           CANDIDATE_BIN: ./bd
           GIT_CONFIG_NOSYSTEM: "1"
@@ -120,8 +258,9 @@ jobs:
         run: ./scripts/migration-test/run.sh --strict --expect "$EXPECTED_STATUS" "$HISTORICAL_VERSION"
 
   migration-test:
-    name: Migration fidelity
-    if: ${{ github.event_name != 'pull_request' }}
+    name: Manual supplemental migration fidelity
+    needs: migration-test-plan
+    if: ${{ github.event_name == 'workflow_dispatch' && needs.migration-test-plan.outputs.has-supplemental-work == 'true' }}
     runs-on: ubuntu-24.04
     timeout-minutes: 45
     steps:
@@ -139,7 +278,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y jq sqlite3
 
-      - name: Install Dolt
+      - name: Install current Dolt for ad-hoc paths
         run: |
           curl -fsSL https://github.com/dolthub/dolt/releases/latest/download/install.sh | sudo bash
           dolt version
@@ -162,15 +301,21 @@ jobs:
         env:
           CANDIDATE_BIN: ./bd
           GIT_CONFIG_NOSYSTEM: "1"
+          RUN_STEPPING: ${{ needs.migration-test-plan.outputs.run-stepping }}
+          SUPPLEMENTAL_VERSIONS: ${{ needs.migration-test-plan.outputs.supplemental-versions }}
         run: |
-          ARGS=""
-          if [ "${{ github.event.inputs.mode }}" = "direct-only" ]; then
-            ARGS="--direct-only"
-          elif [ "${{ github.event.inputs.mode }}" = "stepping-only" ]; then
-            ARGS="--stepping-only"
+          set -euo pipefail
+          ran_supplemental_work=false
+          if [ -n "$SUPPLEMENTAL_VERSIONS" ]; then
+            read -r -a supplemental_versions <<< "$SUPPLEMENTAL_VERSIONS"
+            ./scripts/migration-test/run.sh "${supplemental_versions[@]}"
+            ran_supplemental_work=true
           fi
-          if [ -n "${{ github.event.inputs.versions }}" ]; then
-            ./scripts/migration-test/run.sh ${{ github.event.inputs.versions }}
-          else
-            ./scripts/migration-test/run.sh $ARGS
+          if [ "$RUN_STEPPING" = "true" ]; then
+            ./scripts/migration-test/run.sh --stepping-only
+            ran_supplemental_work=true
           fi
+          $ran_supplemental_work || {
+            echo "::error::supplemental migration job was provisioned without planned work"
+            exit 1
+          }

--- a/cmd/bd/main.go
+++ b/cmd/bd/main.go
@@ -585,10 +585,18 @@ func getOwner() string {
 	return ""
 }
 
+func isMigrationV062InspectRawEntrypoint(args []string) bool {
+	return len(args) > 1 && args[1] == "__migration-v062-inspect"
+}
+
 func init() {
-	// Initialize viper configuration
-	if err := config.Initialize(); err != nil {
-		fmt.Fprintf(os.Stderr, "Warning: failed to initialize config: %v\n", err)
+	// The private v0.62 inspector's supported grammar requires its command token
+	// to be argv[1]. Skip ambient config (and its git-backed discovery) before
+	// Cobra starts; the leaf and root lifecycle bypasses remain defense in depth.
+	if !isMigrationV062InspectRawEntrypoint(os.Args) {
+		if err := config.Initialize(); err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: failed to initialize config: %v\n", err)
+		}
 	}
 
 	// Register persistent flags
@@ -694,6 +702,12 @@ var rootCmd = &cobra.Command{
 		_ = cmd.Help() // Help() always returns nil for cobra commands
 	},
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) (returnErr error) {
+		// Private migration admission must not discover ambient workspaces, load
+		// project configuration, initialize metrics, or select a store before its
+		// descriptor-relative inspector runs.
+		if cmd == migrationV062InspectCmd {
+			return nil
+		}
 		defer func() {
 			if cmd == initCmd {
 				clearInitBackendPreflightAfterError(cmd, &returnErr)
@@ -855,8 +869,9 @@ var rootCmd = &cobra.Command{
 		// to avoid spawning git subprocesses for simple commands
 		// like "bd version" that don't need database access.
 		noDbCommands := []string{
-			"__complete",       // Cobra's internal completion command (shell completions work without db)
-			"__completeNoDesc", // Cobra's completion without descriptions (used by fish)
+			"__migration-v062-inspect", // private, descriptor-relative source admission
+			"__complete",               // Cobra's internal completion command (shell completions work without db)
+			"__completeNoDesc",         // Cobra's completion without descriptions (used by fish)
 			"bash",
 			"bootstrap",
 			"completion",
@@ -1392,6 +1407,9 @@ var rootCmd = &cobra.Command{
 		return nil
 	},
 	PersistentPostRunE: func(cmd *cobra.Command, args []string) error {
+		if cmd == migrationV062InspectCmd {
+			return nil
+		}
 		defer restoreChangeDirSelection()
 
 		if proxiedServerMode {

--- a/cmd/bd/migration_v062_inspect.go
+++ b/cmd/bd/migration_v062_inspect.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/steveyegge/beads/internal/v062migration"
+)
+
+// newMigrationV062InspectCmd builds the private, read-only protocol endpoint
+// used by scripts/migrate-v062-server-to-current.sh. It deliberately owns
+// no product-facing command surface. Its supported argv grammar begins with
+// the hidden command token; root flags placed before that token are outside the
+// protocol because the public bridge never emits them.
+func newMigrationV062InspectCmd() *cobra.Command {
+	var workspace string
+	emitUsageError := func() error {
+		if err := outputJSONRaw(v062migration.UsageErrorResult()); err != nil {
+			return err
+		}
+		return &exitError{Code: 2}
+	}
+	cmd := &cobra.Command{
+		Use:           "__migration-v062-inspect",
+		Hidden:        true,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		Args: func(_ *cobra.Command, args []string) error {
+			if len(args) != 0 {
+				return emitUsageError()
+			}
+			return nil
+		},
+
+		// The root lifecycle discovers ambient workspaces, loads configuration,
+		// and initializes metrics before its normal no-store classification.
+		// Suppress it so the descriptor-relative inspector is the only code that
+		// observes the explicitly named source. main.go carries matching early
+		// bypasses as defense in depth if Cobra traversal semantics ever change.
+		PersistentPreRunE: func(*cobra.Command, []string) error {
+			if workspace == "" {
+				return emitUsageError()
+			}
+			return nil
+		},
+		PersistentPostRunE: func(*cobra.Command, []string) error { return nil },
+
+		RunE: func(*cobra.Command, []string) error {
+			result, err := v062migration.Inspect(workspace, Version)
+			if err == nil {
+				return outputJSONRaw(result)
+			}
+
+			refusal, ok := v062migration.AsRefusal(err)
+			if !ok {
+				refusal = &v062migration.Refusal{
+					Code:      v062migration.CodeSourceUnverifiable,
+					Retryable: true,
+					Effect:    v062migration.EffectNone,
+				}
+			}
+			if err := outputJSONRaw(v062migration.RefusedResult(refusal.Code, refusal.Retryable)); err != nil {
+				return err
+			}
+			return SilentExit()
+		},
+	}
+	cmd.Flags().StringVar(&workspace, "workspace", "", "absolute canonical project path")
+	cmd.SetFlagErrorFunc(func(*cobra.Command, error) error {
+		return emitUsageError()
+	})
+	return cmd
+}
+
+var migrationV062InspectCmd = newMigrationV062InspectCmd()
+
+func init() {
+	rootCmd.AddCommand(migrationV062InspectCmd)
+}

--- a/cmd/bd/migration_v062_inspect_test.go
+++ b/cmd/bd/migration_v062_inspect_test.go
@@ -1,0 +1,405 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/steveyegge/beads/internal/v062migration"
+)
+
+func TestMigrationV062InspectRawEntrypointGrammar(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want bool
+	}{
+		{name: "no argv", args: nil, want: false},
+		{name: "binary only", args: []string{"bd"}, want: false},
+		{name: "exact token first", args: []string{"bd", "__migration-v062-inspect"}, want: true},
+		{name: "root flag before token", args: []string{"bd", "--json", "__migration-v062-inspect"}, want: false},
+		{name: "similar token", args: []string{"bd", "__migration-v062-inspect-extra"}, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isMigrationV062InspectRawEntrypoint(tt.args); got != tt.want {
+				t.Fatalf("isMigrationV062InspectRawEntrypoint(%q) = %v, want %v", tt.args, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMigrationV062InspectRawEntrypointDoesNotInitializeAmbientConfig(t *testing.T) {
+	bd := buildMigrationV062LifecycleBinary(t)
+	fixture := newMigrationV062AmbientConfigFixture(t)
+	missingWorkspace := filepath.Join(fixture.root, "missing-v062-workspace")
+
+	t.Run("hidden token first ignores ambient config", func(t *testing.T) {
+		stdout, stderr, err := runMigrationV062LifecycleProcess(
+			t,
+			bd,
+			fixture.cwd,
+			fixture.env,
+			"__migration-v062-inspect",
+			"--workspace", missingWorkspace,
+		)
+		if code := migrationV062ProcessExitCode(err); code != 1 {
+			t.Fatalf("exit code = %d, want 1\nstdout:\n%s\nstderr:\n%s", code, stdout, stderr)
+		}
+		if stderr != "" {
+			t.Fatalf("private migration entrypoint observed ambient initialization:\n%s", stderr)
+		}
+		var result v062migration.Result
+		if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+			t.Fatalf("decode protocol output: %v\nstdout: %s", err, stdout)
+		}
+		if result.Status != v062migration.StatusRefused || result.Effect != v062migration.EffectNone {
+			t.Fatalf("unexpected refusal envelope: %#v", result)
+		}
+	})
+
+	t.Run("normal command still initializes ambient config", func(t *testing.T) {
+		stdout, stderr, err := runMigrationV062LifecycleProcess(t, bd, fixture.cwd, fixture.env, "version")
+		if code := migrationV062ProcessExitCode(err); code != 0 {
+			t.Fatalf("exit code = %d, want 0\nstdout:\n%s\nstderr:\n%s", code, stdout, stderr)
+		}
+		if !strings.Contains(stderr, "Warning: failed to initialize config:") {
+			t.Fatalf("normal command did not observe hostile ambient config:\n%s", stderr)
+		}
+	})
+
+	t.Run("hidden token not first still initializes ambient config", func(t *testing.T) {
+		stdout, stderr, err := runMigrationV062LifecycleProcess(
+			t,
+			bd,
+			fixture.cwd,
+			fixture.env,
+			"--json",
+			"__migration-v062-inspect",
+			"--workspace", missingWorkspace,
+		)
+		if code := migrationV062ProcessExitCode(err); code != 1 {
+			t.Fatalf("exit code = %d, want 1\nstdout:\n%s\nstderr:\n%s", code, stdout, stderr)
+		}
+		if !strings.Contains(stderr, "Warning: failed to initialize config:") {
+			t.Fatalf("token-not-first invocation incorrectly bypassed ambient config:\n%s", stderr)
+		}
+	})
+}
+
+func TestMigrationV062InspectRawEntrypointDoesNotInvokeGitDuringInitialization(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake executable probe uses a POSIX shell")
+	}
+
+	bd := buildMigrationV062LifecycleBinary(t)
+	root := t.TempDir()
+	cwd := filepath.Join(root, "caller")
+	binDir := filepath.Join(root, "bin")
+	marker := filepath.Join(root, "git-was-invoked")
+	for _, dir := range []string{cwd, binDir} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+	gitProbe := filepath.Join(binDir, "git")
+	if err := os.WriteFile(gitProbe, []byte("#!/bin/sh\n: > \"$BD_V062_GIT_PROBE\"\nexit 1\n"), 0o755); err != nil {
+		t.Fatalf("write git probe: %v", err)
+	}
+	env := migrationV062LifecycleEnv(
+		filepath.Join(root, "home"),
+		filepath.Join(root, "xdg"),
+		"PATH="+binDir,
+		"BD_V062_GIT_PROBE="+marker,
+	)
+
+	stdout, stderr, err := runMigrationV062LifecycleProcess(
+		t,
+		bd,
+		cwd,
+		env,
+		"__migration-v062-inspect",
+		"--workspace", filepath.Join(root, "missing-v062-workspace"),
+	)
+	if code := migrationV062ProcessExitCode(err); code != 1 {
+		t.Fatalf("exit code = %d, want 1\nstdout:\n%s\nstderr:\n%s", code, stdout, stderr)
+	}
+	if _, err := os.Stat(marker); !os.IsNotExist(err) {
+		t.Fatalf("private migration entrypoint invoked ambient git probe: %v", err)
+	}
+
+	// Root help does not run Cobra's command lifecycle, so this marker can only
+	// come from the eager configuration initialization performed by init().
+	stdout, stderr, err = runMigrationV062LifecycleProcess(t, bd, cwd, env, "--help")
+	if code := migrationV062ProcessExitCode(err); code != 0 {
+		t.Fatalf("control exit code = %d, want 0\nstdout:\n%s\nstderr:\n%s", code, stdout, stderr)
+	}
+	if _, err := os.Stat(marker); err != nil {
+		t.Fatalf("control command did not invoke git during config initialization: %v", err)
+	}
+}
+
+func TestMigrationV062InspectCommandBypassesParentLifecycle(t *testing.T) {
+	t.Setenv("BD_BACKEND", "postgres")
+	t.Setenv("BD_DATABASE_BACKEND", "mysql")
+
+	parentPreRun := false
+	parentPostRun := false
+	root := &cobra.Command{
+		Use: "bd",
+		PersistentPreRunE: func(*cobra.Command, []string) error {
+			parentPreRun = true
+			return nil
+		},
+		PersistentPostRunE: func(*cobra.Command, []string) error {
+			parentPostRun = true
+			return nil
+		},
+	}
+	command := newMigrationV062InspectCmd()
+	root.AddCommand(command)
+	root.SetArgs([]string{
+		"__migration-v062-inspect",
+		"--workspace", "/definitely/not/a/v062/workspace",
+	})
+
+	stdout, executeErr := captureMigrationV062Stdout(t, root.Execute)
+	if code, ok := exitCodeFromError(executeErr); !ok || code != 1 {
+		t.Fatalf("Execute() error = %T %v, want exit code 1", executeErr, executeErr)
+	}
+	if parentPreRun || parentPostRun {
+		t.Fatalf("hidden protocol ran parent lifecycle: pre=%v post=%v", parentPreRun, parentPostRun)
+	}
+	if !command.Hidden {
+		t.Fatal("migration inspection plumbing must remain hidden")
+	}
+
+	var result v062migration.Result
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("decode protocol output: %v\nstdout: %s", err, stdout)
+	}
+	if result.SchemaVersion != v062migration.SchemaVersion ||
+		result.Operation != v062migration.Operation ||
+		result.Status != v062migration.StatusRefused ||
+		result.Effect != v062migration.EffectNone ||
+		result.Code == "" {
+		t.Fatalf("unexpected refusal envelope: %#v", result)
+	}
+}
+
+func TestMigrationV062InspectCommandUsageContract(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{name: "missing workspace", args: nil},
+		{name: "empty workspace", args: []string{"--workspace", ""}},
+		{name: "unexpected argument", args: []string{"--workspace", "/tmp", "extra"}},
+		{name: "unknown flag", args: []string{"--unknown"}},
+		{name: "missing flag value", args: []string{"--workspace"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := &cobra.Command{Use: "bd"}
+			root.AddCommand(newMigrationV062InspectCmd())
+			root.SetArgs(append([]string{"__migration-v062-inspect"}, tt.args...))
+
+			stdout, executeErr := captureMigrationV062Stdout(t, root.Execute)
+			if code, ok := exitCodeFromError(executeErr); !ok || code != 2 {
+				t.Fatalf("Execute() error = %T %v, want exit code 2", executeErr, executeErr)
+			}
+			var result v062migration.Result
+			if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+				t.Fatalf("decode protocol output: %v\nstdout: %s", err, stdout)
+			}
+			if result != v062migration.UsageErrorResult() {
+				t.Fatalf("usage result = %#v, want %#v", result, v062migration.UsageErrorResult())
+			}
+		})
+	}
+}
+
+func TestMigrationV062InspectCommandIsAbsentFromHelp(t *testing.T) {
+	root := &cobra.Command{Use: "bd"}
+	root.AddCommand(newMigrationV062InspectCmd())
+	var output bytes.Buffer
+	root.SetOut(&output)
+	root.SetErr(&output)
+	if err := root.Help(); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(output.String(), "__migration-v062-inspect") {
+		t.Fatalf("hidden protocol leaked into help:\n%s", output.String())
+	}
+}
+
+func captureMigrationV062Stdout(t *testing.T, fn func() error) (string, error) {
+	t.Helper()
+
+	stdioMutex.Lock()
+	defer stdioMutex.Unlock()
+
+	previous := os.Stdout
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = writer
+
+	executeErr := fn()
+	_ = writer.Close()
+	os.Stdout = previous
+
+	data, readErr := io.ReadAll(reader)
+	_ = reader.Close()
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	return string(data), executeErr
+}
+
+type migrationV062AmbientConfigFixture struct {
+	root string
+	cwd  string
+	env  []string
+}
+
+func newMigrationV062AmbientConfigFixture(t *testing.T) migrationV062AmbientConfigFixture {
+	t.Helper()
+
+	root := t.TempDir()
+	home := filepath.Join(root, "home")
+	xdg := filepath.Join(root, "xdg")
+	cwd := filepath.Join(root, "caller", "nested")
+	configPaths := []string{
+		filepath.Join(home, ".beads", "config.yaml"),
+		filepath.Join(xdg, "bd", "config.yaml"),
+		filepath.Join(root, "caller", ".beads", "config.yaml"),
+	}
+	if err := os.MkdirAll(cwd, 0o755); err != nil {
+		t.Fatalf("mkdir caller: %v", err)
+	}
+	for _, path := range configPaths {
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("mkdir config parent: %v", err)
+		}
+		if err := os.WriteFile(path, []byte("json: [unterminated\n"), 0o600); err != nil {
+			t.Fatalf("write hostile config: %v", err)
+		}
+	}
+
+	return migrationV062AmbientConfigFixture{
+		root: root,
+		cwd:  cwd,
+		env:  migrationV062LifecycleEnv(home, xdg),
+	}
+}
+
+var (
+	migrationV062LifecycleBuildOnce sync.Once
+	migrationV062LifecycleBD        string
+	migrationV062LifecycleBuildErr  string
+)
+
+func buildMigrationV062LifecycleBinary(t *testing.T) string {
+	t.Helper()
+
+	migrationV062LifecycleBuildOnce.Do(func() {
+		packageDir, err := os.Getwd()
+		if err != nil {
+			migrationV062LifecycleBuildErr = "get package directory: " + err.Error()
+			return
+		}
+		buildDir, err := testTempDir("bd-v062-lifecycle-*")
+		if err != nil {
+			migrationV062LifecycleBuildErr = "create build directory: " + err.Error()
+			return
+		}
+		name := "bd"
+		if runtime.GOOS == "windows" {
+			name = "bd.exe"
+		}
+		migrationV062LifecycleBD = filepath.Join(buildDir, name)
+		cmd := exec.Command("go", "build", "-tags", "gms_pure_go", "-o", migrationV062LifecycleBD, ".")
+		cmd.Dir = packageDir
+		if output, err := cmd.CombinedOutput(); err != nil {
+			migrationV062LifecycleBuildErr = "build bd: " + err.Error() + "\n" + string(output)
+		}
+	})
+	if migrationV062LifecycleBuildErr != "" {
+		t.Fatal(migrationV062LifecycleBuildErr)
+	}
+	return migrationV062LifecycleBD
+}
+
+func migrationV062LifecycleEnv(home, xdg string, extra ...string) []string {
+	blocked := map[string]bool{
+		"HOME":                true,
+		"USERPROFILE":         true,
+		"XDG_CONFIG_HOME":     true,
+		"GIT_CONFIG_GLOBAL":   true,
+		"GIT_CONFIG_NOSYSTEM": true,
+		"PATH":                true,
+	}
+	env := make([]string, 0, len(os.Environ())+len(extra)+9)
+	for _, entry := range os.Environ() {
+		name, _, _ := strings.Cut(entry, "=")
+		if blocked[name] || strings.HasPrefix(name, "BD_") || strings.HasPrefix(name, "BEADS_") {
+			continue
+		}
+		env = append(env, entry)
+	}
+	env = append(env,
+		"HOME="+home,
+		"USERPROFILE="+home,
+		"XDG_CONFIG_HOME="+xdg,
+		"GIT_CONFIG_GLOBAL="+filepath.Join(home, "gitconfig"),
+		"GIT_CONFIG_NOSYSTEM=1",
+		"PATH="+os.Getenv("PATH"),
+		"BEADS_DOLT_AUTO_START=0",
+		"BEADS_NO_DAEMON=1",
+		"BD_DISABLE_METRICS=1",
+		"BD_DISABLE_EVENT_FLUSH=1",
+	)
+	return append(env, extra...)
+}
+
+func runMigrationV062LifecycleProcess(
+	t *testing.T,
+	bd string,
+	dir string,
+	env []string,
+	args ...string,
+) (stdout, stderr string, runErr error) {
+	t.Helper()
+
+	cmd := exec.Command(bd, args...)
+	cmd.Dir = dir
+	cmd.Env = env
+	var stdoutBuffer bytes.Buffer
+	var stderrBuffer bytes.Buffer
+	cmd.Stdout = &stdoutBuffer
+	cmd.Stderr = &stderrBuffer
+	runErr = cmd.Run()
+	return stdoutBuffer.String(), stderrBuffer.String(), runErr
+}
+
+func migrationV062ProcessExitCode(err error) int {
+	if err == nil {
+		return 0
+	}
+	if exitErr, ok := err.(*exec.ExitError); ok {
+		return exitErr.ExitCode()
+	}
+	return -1
+}

--- a/cmd/bd/prestore_metadata_guard_e2e_test.go
+++ b/cmd/bd/prestore_metadata_guard_e2e_test.go
@@ -96,6 +96,52 @@ func TestListRejectsV0620ServerWorkspaceBeforeMutation(t *testing.T) {
 	}
 }
 
+// TestDoctorDoesNotClobberV0620WitnessOrMigrate proves the doctor path, which
+// skips PersistentPreRunE (and therefore the store-init legacy guard), does not
+// rewrite the .local_version witness or migrate a genuine v0.62 server
+// workspace. bd doctor calls trackBdVersion()/autoMigrateOnVersionBump()
+// directly; before PR #4835 that rewrote the witness to the current version,
+// permanently flipping refuseLegacyDoltServerWorkspace fail-open for every later
+// command. The witness must survive byte-for-byte so the guard keeps refusing.
+func TestDoctorDoesNotClobberV0620WitnessOrMigrate(t *testing.T) {
+	bd := buildBDUnderTest(t)
+	repoDir, beadsDir := newV0620ServerWorkspace(t)
+
+	// The witness and metadata are the classification surface the store-init
+	// guard reads; the dolt state files are what a migration would rewrite. None
+	// may change. (bd doctor legitimately writes an unrelated dolt-server.port
+	// hint via a pre-existing check, so this asserts the migration-critical files
+	// rather than the whole tree.)
+	protected := []string{
+		".local_version",
+		"metadata.json",
+		filepath.Join("dolt", ".dolt", "repo_state.json"),
+		filepath.Join("dolt", "smoke", ".dolt", "repo_state.json"),
+	}
+	before := make(map[string]string, len(protected))
+	for _, rel := range protected {
+		data, err := os.ReadFile(filepath.Join(beadsDir, rel))
+		if err != nil {
+			t.Fatalf("read %s before doctor: %v", rel, err)
+		}
+		before[rel] = string(data)
+	}
+
+	// bd doctor may surface errors for the (unreachable) legacy store, but it
+	// must not rewrite the witness or migrate the workspace on its way there.
+	_, _, _ = runPrestoreGuardCommand(t, bd, repoDir, "doctor")
+
+	for _, rel := range protected {
+		data, err := os.ReadFile(filepath.Join(beadsDir, rel))
+		if err != nil {
+			t.Fatalf("read %s after doctor: %v", rel, err)
+		}
+		if string(data) != before[rel] {
+			t.Errorf("bd doctor mutated %s on a legacy v0.62.0 workspace: before=%q after=%q", rel, before[rel], data)
+		}
+	}
+}
+
 func TestIncompatibleMetadataStillAllowsStoreFreeCommands(t *testing.T) {
 	bd := buildBDUnderTest(t)
 	tests := []struct {

--- a/cmd/bd/prestore_metadata_guard_e2e_test.go
+++ b/cmd/bd/prestore_metadata_guard_e2e_test.go
@@ -69,6 +69,33 @@ func TestListRejectsV0570ServerWorkspaceBeforeMutation(t *testing.T) {
 	}
 }
 
+func TestListRejectsV0620ServerWorkspaceBeforeMutation(t *testing.T) {
+	bd := buildBDUnderTest(t)
+	repoDir, beadsDir := newV0620ServerWorkspace(t)
+	before := hashBackendPreflightTree(t, beadsDir)
+
+	started := time.Now()
+	stdout, stderr, err := runPrestoreGuardCommand(t, bd, repoDir,
+		"list", "--json", "--limit", "0", "--all")
+	elapsed := time.Since(started)
+	output := stdout + stderr
+
+	if err == nil {
+		t.Errorf("bd list succeeded against a v0.62.0 server workspace; stdout:\n%s\nstderr:\n%s", stdout, stderr)
+	}
+	if elapsed > 2*time.Second {
+		t.Errorf("bd list took %s to refuse the v0.62.0 server workspace, want at most 2s", elapsed)
+	}
+	if !strings.Contains(output, "requires explicit migration") || !strings.Contains(output, "bd 0.62.0") {
+		t.Errorf("bd list did not explain the required v0.62.0 migration; err=%v\nstdout:\n%s\nstderr:\n%s", err, stdout, stderr)
+	}
+
+	after := hashBackendPreflightTree(t, beadsDir)
+	if before != after {
+		t.Errorf("bd list changed the v0.62.0 workspace before refusing: before=%x after=%x", before, after)
+	}
+}
+
 func TestIncompatibleMetadataStillAllowsStoreFreeCommands(t *testing.T) {
 	bd := buildBDUnderTest(t)
 	tests := []struct {
@@ -225,6 +252,167 @@ func TestLegacyDoltServerGuardAcceptsCurrentWorkspaceShapes(t *testing.T) {
 	}
 }
 
+func TestLegacyDoltServerGuardAcceptsCurrentRemoteServerWorkspace(t *testing.T) {
+	beadsDir := t.TempDir()
+	writeFile(t, filepath.Join(beadsDir, ".local_version"), []byte(Version+"\n"))
+	cfg := &configfile.Config{
+		Database:     "dolt",
+		Backend:      configfile.BackendDolt,
+		DoltMode:     configfile.DoltModeServer,
+		DoltDatabase: "remote_beads",
+		ProjectID:    "current-project-id",
+	}
+
+	if err := refuseLegacyDoltServerWorkspace(beadsDir, cfg); err != nil {
+		t.Fatalf("current remote-server workspace rejected: %v", err)
+	}
+}
+
+func TestLegacyDoltServerGuardAcceptsCurrentRemoteServerWorkspaceWithoutLocalVersion(t *testing.T) {
+	beadsDir := t.TempDir()
+	cfg := &configfile.Config{
+		Database:     "dolt",
+		Backend:      configfile.BackendDolt,
+		DoltMode:     configfile.DoltModeServer,
+		DoltDatabase: "remote_beads",
+		ProjectID:    "current-project-id",
+	}
+
+	if err := refuseLegacyDoltServerWorkspace(beadsDir, cfg); err != nil {
+		t.Fatalf("current remote-server workspace without a local version rejected: %v", err)
+	}
+}
+
+func TestLegacyDoltServerGuardRejectsV0620RemoteServerWorkspace(t *testing.T) {
+	beadsDir := t.TempDir()
+	writeFile(t, filepath.Join(beadsDir, ".local_version"), []byte("0.62.0\n"))
+	cfg := &configfile.Config{
+		Database:     "dolt",
+		Backend:      configfile.BackendDolt,
+		DoltMode:     configfile.DoltModeServer,
+		DoltDatabase: "remote_beads",
+		ProjectID:    "historical-project-id",
+	}
+
+	err := refuseLegacyDoltServerWorkspace(beadsDir, cfg)
+	if err == nil {
+		t.Fatal("v0.62.0 remote-server workspace was accepted without a local Dolt data root")
+	}
+	if !strings.Contains(err.Error(), "bd 0.62.0") || !strings.Contains(err.Error(), "requires explicit migration") {
+		t.Fatalf("v0.62.0 remote-server refusal lacks migration guidance: %v", err)
+	}
+}
+
+func TestLegacyDoltServerGuardRejectsVersionWitnessPathReplacement(t *testing.T) {
+	beadsDir := t.TempDir()
+	versionPath := filepath.Join(beadsDir, ".local_version")
+	replacementPath := filepath.Join(beadsDir, ".local_version.replacement")
+	writeFile(t, versionPath, []byte("0.62.0\n"))
+	writeFile(t, replacementPath, []byte("1.10.0\n"))
+	stableModTime := time.Unix(1_700_000_000, 0)
+	if err := os.Chtimes(versionPath, stableModTime, stableModTime); err != nil {
+		t.Fatalf("set source version witness timestamp: %v", err)
+	}
+	if err := os.Chtimes(replacementPath, stableModTime, stableModTime); err != nil {
+		t.Fatalf("set replacement version witness timestamp: %v", err)
+	}
+	cfg := &configfile.Config{
+		Database:     "dolt",
+		Backend:      configfile.BackendDolt,
+		DoltMode:     configfile.DoltModeServer,
+		DoltDatabase: "remote_beads",
+		ProjectID:    "historical-project-id",
+	}
+
+	err := refuseLegacyDoltServerWorkspaceWithVersionWitnessOpener(beadsDir, cfg, func(path string) (*os.File, error) {
+		opened, err := os.Open(path)
+		if err != nil {
+			return nil, err
+		}
+		if err := os.Rename(replacementPath, versionPath); err != nil {
+			_ = opened.Close()
+			return nil, err
+		}
+		return opened, nil
+	})
+	if err == nil {
+		t.Fatal("project-identity server workspace was accepted after its version witness path was replaced")
+	}
+	if !strings.Contains(err.Error(), "cannot safely classify") ||
+		!strings.Contains(err.Error(), "refusing to open or modify") {
+		t.Fatalf("path-replacement refusal lacks safe recovery guidance: %v", err)
+	}
+}
+
+func TestLegacyDoltServerGuardRejectsVersionWitnessInPlaceRewrite(t *testing.T) {
+	beadsDir := t.TempDir()
+	versionPath := filepath.Join(beadsDir, ".local_version")
+	writeFile(t, versionPath, []byte("0.62.0\n"))
+	cfg := &configfile.Config{
+		Database:     "dolt",
+		Backend:      configfile.BackendDolt,
+		DoltMode:     configfile.DoltModeServer,
+		DoltDatabase: "remote_beads",
+		ProjectID:    "historical-project-id",
+	}
+
+	err := refuseLegacyDoltServerWorkspaceWithVersionWitnessOpener(beadsDir, cfg, func(path string) (*os.File, error) {
+		opened, err := os.Open(path)
+		if err != nil {
+			return nil, err
+		}
+		if err := os.WriteFile(path, []byte("1.10.0\n"), 0o600); err != nil {
+			_ = opened.Close()
+			return nil, err
+		}
+		changed := time.Now().Add(time.Hour)
+		if err := os.Chtimes(path, changed, changed); err != nil {
+			_ = opened.Close()
+			return nil, err
+		}
+		return opened, nil
+	})
+	if err == nil {
+		t.Fatal("project-identity server workspace was accepted after its version witness was rewritten in place")
+	}
+	if !strings.Contains(err.Error(), "cannot safely classify") ||
+		!strings.Contains(err.Error(), "refusing to open or modify") {
+		t.Fatalf("in-place-rewrite refusal lacks safe recovery guidance: %v", err)
+	}
+}
+
+func TestLegacyDoltVersionWitnessBoundaries(t *testing.T) {
+	tests := []struct {
+		version         string
+		legacy          bool
+		projectIdentity bool
+	}{
+		{version: "0.49.9"},
+		{version: "0.50.0", legacy: true},
+		{version: "0.58.99", legacy: true},
+		{version: "0.59.0", legacy: true, projectIdentity: true},
+		{version: "0.62.99", legacy: true, projectIdentity: true},
+		{version: "0.63.0"},
+		{version: "v0.62.0"},
+		{version: "0.62"},
+		{version: "0.62.0-rc.1"},
+		{version: "00.62.0"},
+		{version: "0.062.0"},
+		{version: "0.62.+0"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.version, func(t *testing.T) {
+			if got := isLegacyDoltVersionWitness(test.version); got != test.legacy {
+				t.Errorf("isLegacyDoltVersionWitness(%q) = %v, want %v", test.version, got, test.legacy)
+			}
+			if got := isProjectIdentityLegacyDoltVersionWitness(test.version); got != test.projectIdentity {
+				t.Errorf("isProjectIdentityLegacyDoltVersionWitness(%q) = %v, want %v", test.version, got, test.projectIdentity)
+			}
+		})
+	}
+}
+
 func TestLegacyDoltServerGuardDoesNotTrustMutableVersionMarkers(t *testing.T) {
 	tests := []struct {
 		name  string
@@ -354,6 +542,35 @@ func newV0570ServerWorkspace(t *testing.T) (repoDir, beadsDir string) {
 	writeFile(t, filepath.Join(beadsDir, "dolt", "smoke", ".dolt", "config.json"), []byte("{}\n"))
 	writeFile(t, filepath.Join(beadsDir, "dolt", "smoke", ".dolt", "repo_state.json"), []byte("{\"head\":\"refs/heads/main\"}\n"))
 	writeFile(t, filepath.Join(beadsDir, "dolt", "config.yaml"), []byte("listener:\n  host: 127.0.0.1\n  port: 3307\n"))
+	return repoDir, beadsDir
+}
+
+func newV0620ServerWorkspace(t *testing.T) (repoDir, beadsDir string) {
+	t.Helper()
+	repoDir = newPrestoreGuardRepo(t)
+	beadsDir = filepath.Join(repoDir, ".beads")
+
+	// This is the canonical server metadata written by the official v0.62.0
+	// release. Unlike v0.57.0, it includes a project identity, but it still uses
+	// the external Dolt layout and schema that require an explicit bridge.
+	writeFile(t, filepath.Join(beadsDir, "metadata.json"), []byte(`{
+  "database": "dolt",
+  "backend": "dolt",
+  "dolt_mode": "server",
+  "dolt_server_host": "127.0.0.1",
+  "dolt_server_port": 3307,
+  "dolt_database": "smoke",
+  "project_id": "7ef372b4-4c3c-4e2c-a6cc-29dd2d0a28c6"
+}`))
+	writeFile(t, filepath.Join(beadsDir, ".local_version"), []byte("0.62.0\n"))
+	writeFile(t, filepath.Join(beadsDir, "dolt", ".dolt", "config.json"), []byte("{}\n"))
+	writeFile(t, filepath.Join(beadsDir, "dolt", ".dolt", "repo_state.json"), []byte("{\"head\":\"refs/heads/main\"}\n"))
+	writeFile(t, filepath.Join(beadsDir, "dolt", "smoke", ".dolt", "config.json"), []byte("{}\n"))
+	writeFile(t, filepath.Join(beadsDir, "dolt", "smoke", ".dolt", "repo_state.json"), []byte("{\"head\":\"refs/heads/main\"}\n"))
+	writeFile(t, filepath.Join(beadsDir, "dolt", "config.yaml"), []byte("listener:\n  host: 127.0.0.1\n  port: 3307\n"))
+	if err := os.Chmod(beadsDir, 0o700); err != nil {
+		t.Fatalf("chmod v0.62.0 beads directory: %v", err)
+	}
 	return repoDir, beadsDir
 }
 

--- a/cmd/bd/version_tracking.go
+++ b/cmd/bd/version_tracking.go
@@ -231,6 +231,22 @@ func trackBdVersion() {
 		return
 	}
 
+	// PR #4835: never rewrite the version witness on a legacy v0.59-v0.62
+	// Dolt-server workspace. The store-init path already refuses such a workspace
+	// before reaching here, but guard-skipping callers (notably bd doctor, which
+	// is in noDbCommands) run this directly. Clobbering .local_version to the
+	// current version would flip refuseLegacyDoltServerWorkspace fail-open for
+	// every later command. Returning before both upgrade detection and the
+	// witness write also keeps versionUpgradeDetected false, so the version-bump
+	// migration (gated on it) stays inert on this path too. Best-effort,
+	// read-only classification: an unreadable config cannot prove legacy, so fall
+	// through to normal tracking.
+	if cfg, err := configfile.LoadReadOnly(beadsDir); err == nil {
+		if refuseLegacyDoltServerWorkspace(beadsDir, cfg) != nil {
+			return
+		}
+	}
+
 	// Read last version from local (gitignored) file
 	localVersionPath := filepath.Join(beadsDir, localVersionFile)
 	lastVersion := readLocalVersion(localVersionPath)

--- a/cmd/bd/version_tracking.go
+++ b/cmd/bd/version_tracking.go
@@ -23,22 +23,44 @@ import (
 // reset the tracked metadata.json file.
 const localVersionFile = ".local_version"
 
-// refuseLegacyDoltServerWorkspace recognizes the durable storage contract used
-// by v0.50-v0.58: canonical pre-project-identity server metadata and an existing
-// persisted Dolt server data root. The gitignored local version
-// and the compatibility marker are deliberately not discriminators: an earlier
-// failed upgrade can rewrite both before timing out. This check is store-free
-// and has no migration side effects.
+// refuseLegacyDoltServerWorkspace recognizes the server storage contract used
+// by v0.50-v0.62. The v0.50-v0.58 metadata predates project identity and is
+// unambiguous. v0.59-v0.62 metadata otherwise overlaps supported modern server
+// providers, so that later cohort additionally requires an exact, safely read
+// historical version witness. This check is store-free and has no migration
+// side effects.
 func refuseLegacyDoltServerWorkspace(beadsDir string, cfg *configfile.Config) error {
+	return refuseLegacyDoltServerWorkspaceWithVersionWitnessOpener(beadsDir, cfg, safefile.OpenReadOnlyNoFollow)
+}
+
+func refuseLegacyDoltServerWorkspaceWithVersionWitnessOpener(
+	beadsDir string,
+	cfg *configfile.Config,
+	opener func(string) (*os.File, error),
+) error {
 	if cfg == nil || cfg.GetBackend() != configfile.BackendDolt ||
 		!strings.EqualFold(cfg.DoltMode, configfile.DoltModeServer) {
 		return nil
 	}
+	legacySource := ""
+	hasHistoricalProjectIdentity := false
 	if cfg.ProjectID != "" {
-		return nil
+		version, state := readLegacyDoltVersionWitnessWithOpener(beadsDir, opener)
+		if state == legacyDoltVersionWitnessAmbiguous {
+			return fmt.Errorf("cannot safely classify possible legacy Dolt-server workspace at %q because its %s witness changed or could not be read consistently; preserve a byte-for-byte backup of .beads, stop other bd processes touching the workspace, and retry (refusing to open or modify it)", beadsDir, localVersionFile)
+		}
+		if state != legacyDoltVersionWitnessStable || !isProjectIdentityLegacyDoltVersionWitness(version) {
+			return nil
+		}
+		legacySource = "bd " + version
+		hasHistoricalProjectIdentity = true
 	}
 	if err := dolt.ValidateDatabaseName(cfg.DoltDatabase); err != nil {
 		return fmt.Errorf("possible legacy Dolt-server workspace has an invalid database name %q: %v; preserve a byte-for-byte backup of .beads and use the matching historical bd binary for explicit migration (refusing to open or modify it)", cfg.DoltDatabase, err)
+	}
+	if hasHistoricalProjectIdentity {
+		return fmt.Errorf("legacy %s Dolt-server workspace requires explicit migration before bd %s can open it; first preserve a byte-for-byte backup of .beads and keep/use the matching historical bd binary for a qualified version-specific migration bridge; this build refuses automatic modification of %q",
+			legacySource, Version, beadsDir)
 	}
 	doltDir := cfg.PersistedDoltDataPath(beadsDir)
 	if doltDir == "" {
@@ -49,55 +71,107 @@ func refuseLegacyDoltServerWorkspace(beadsDir string, cfg *configfile.Config) er
 		if os.IsNotExist(err) {
 			return nil
 		}
-		return fmt.Errorf("cannot safely classify possible legacy Dolt-server workspace at %s: %w (refusing to open or modify it)", doltDir, err)
+		return fmt.Errorf("cannot safely classify possible legacy Dolt-server workspace at %q: %w (refusing to open or modify it)", doltDir, err)
 	}
 	if !info.IsDir() {
-		return fmt.Errorf("possible legacy Dolt-server workspace has an ambiguous non-directory data root at %s; preserve it and run a version-specific explicit migration (refusing to open or modify it)", doltDir)
+		return fmt.Errorf("possible legacy Dolt-server workspace has an ambiguous non-directory data root at %q; preserve it and run a version-specific explicit migration (refusing to open or modify it)", doltDir)
 	}
 
-	source := safeLegacyDoltVersionLabel(beadsDir)
-	return fmt.Errorf("legacy %s Dolt-server workspace requires explicit migration before bd %s can open it; first preserve a byte-for-byte backup of .beads and keep/use the matching historical bd binary for a qualified version-specific migration bridge; this build refuses automatic modification of %s",
+	source := legacySource
+	if source == "" {
+		source = safeLegacyDoltVersionLabel(beadsDir)
+	}
+	return fmt.Errorf("legacy %s Dolt-server workspace requires explicit migration before bd %s can open it; first preserve a byte-for-byte backup of .beads and keep/use the matching historical bd binary for a qualified version-specific migration bridge; this build refuses automatic modification of %q",
 		source, Version, beadsDir)
 }
 
 const maxLegacyVersionWitnessBytes = 64
 
+type legacyDoltVersionWitnessState uint8
+
+const (
+	legacyDoltVersionWitnessMissing legacyDoltVersionWitnessState = iota
+	legacyDoltVersionWitnessStable
+	legacyDoltVersionWitnessAmbiguous
+)
+
 func safeLegacyDoltVersionLabel(beadsDir string) string {
-	path := filepath.Join(beadsDir, localVersionFile)
-	info, err := os.Lstat(path)
-	if err != nil || !info.Mode().IsRegular() || info.Size() <= 0 || info.Size() > maxLegacyVersionWitnessBytes {
-		return "v0.50-v0.58-era"
-	}
-	file, err := safefile.OpenReadOnlyNoFollow(path)
-	if err != nil {
-		return "v0.50-v0.58-era"
-	}
-	defer func() { _ = file.Close() }()
-	openedInfo, err := file.Stat()
-	if err != nil || !openedInfo.Mode().IsRegular() || openedInfo.Size() != info.Size() {
-		return "v0.50-v0.58-era"
-	}
-	data, err := io.ReadAll(io.LimitReader(file, maxLegacyVersionWitnessBytes+1))
-	if err != nil || len(data) > maxLegacyVersionWitnessBytes {
-		return "v0.50-v0.58-era"
-	}
-	version := strings.TrimSpace(string(data))
-	if !isLegacyDoltVersionWitness(version) {
+	version, state := readLegacyDoltVersionWitness(beadsDir)
+	if state != legacyDoltVersionWitnessStable || !isLegacyDoltVersionWitness(version) {
 		return "v0.50-v0.58-era"
 	}
 	return "bd " + version
 }
 
+func readLegacyDoltVersionWitness(beadsDir string) (string, legacyDoltVersionWitnessState) {
+	return readLegacyDoltVersionWitnessWithOpener(beadsDir, safefile.OpenReadOnlyNoFollow)
+}
+
+func readLegacyDoltVersionWitnessWithOpener(
+	beadsDir string,
+	opener func(string) (*os.File, error),
+) (string, legacyDoltVersionWitnessState) {
+	path := filepath.Join(beadsDir, localVersionFile)
+	info, err := os.Lstat(path)
+	if os.IsNotExist(err) {
+		return "", legacyDoltVersionWitnessMissing
+	}
+	if err != nil || !info.Mode().IsRegular() || info.Size() <= 0 || info.Size() > maxLegacyVersionWitnessBytes {
+		return "", legacyDoltVersionWitnessAmbiguous
+	}
+	file, err := opener(path)
+	if err != nil {
+		return "", legacyDoltVersionWitnessAmbiguous
+	}
+	defer func() { _ = file.Close() }()
+	openedInfo, err := file.Stat()
+	if err != nil || !openedInfo.Mode().IsRegular() || !os.SameFile(info, openedInfo) ||
+		openedInfo.Size() != info.Size() || !openedInfo.ModTime().Equal(info.ModTime()) {
+		return "", legacyDoltVersionWitnessAmbiguous
+	}
+	data, err := io.ReadAll(io.LimitReader(file, maxLegacyVersionWitnessBytes+1))
+	if err != nil || len(data) > maxLegacyVersionWitnessBytes {
+		return "", legacyDoltVersionWitnessAmbiguous
+	}
+	afterInfo, err := file.Stat()
+	if err != nil {
+		return "", legacyDoltVersionWitnessAmbiguous
+	}
+	namedAfter, err := os.Lstat(path)
+	if err != nil || !namedAfter.Mode().IsRegular() ||
+		!os.SameFile(openedInfo, afterInfo) || !os.SameFile(openedInfo, namedAfter) ||
+		openedInfo.Size() != afterInfo.Size() || int64(len(data)) != afterInfo.Size() ||
+		!openedInfo.ModTime().Equal(afterInfo.ModTime()) {
+		return "", legacyDoltVersionWitnessAmbiguous
+	}
+	version := strings.TrimSpace(string(data))
+	return version, legacyDoltVersionWitnessStable
+}
+
 func isLegacyDoltVersionWitness(version string) bool {
+	major, minor, ok := parseCanonicalBdVersion(version)
+	return ok && major == 0 && minor >= 50 && minor <= 62
+}
+
+func isProjectIdentityLegacyDoltVersionWitness(version string) bool {
+	major, minor, ok := parseCanonicalBdVersion(version)
+	return ok && major == 0 && minor >= 59 && minor <= 62
+}
+
+func parseCanonicalBdVersion(version string) (major, minor int, ok bool) {
 	parts := strings.Split(version, ".")
 	if len(parts) != 3 {
-		return false
+		return 0, 0, false
 	}
 	major, majorErr := strconv.Atoi(parts[0])
 	minor, minorErr := strconv.Atoi(parts[1])
 	patch, patchErr := strconv.Atoi(parts[2])
-	return majorErr == nil && minorErr == nil && patchErr == nil &&
-		major == 0 && minor >= 50 && minor <= 58 && patch >= 0
+	if majorErr != nil || minorErr != nil || patchErr != nil ||
+		major < 0 || minor < 0 || patch < 0 ||
+		strconv.Itoa(major) != parts[0] || strconv.Itoa(minor) != parts[1] || strconv.Itoa(patch) != parts[2] {
+		return 0, 0, false
+	}
+	return major, minor, true
 }
 
 // trackBdVersion checks if bd version has changed since last run and updates the local version file.

--- a/cmd/bd/version_tracking.go
+++ b/cmd/bd/version_tracking.go
@@ -29,6 +29,17 @@ const localVersionFile = ".local_version"
 // providers, so that later cohort additionally requires an exact, safely read
 // historical version witness. This check is store-free and has no migration
 // side effects.
+//
+// Accepted limitation (maintainer signed off): the .local_version witness is
+// positive proof of a specific legacy version, and it is gitignored, so a fresh
+// clone of a *modern* v0.59+ server workspace routinely has no witness. Because
+// v0.59-v0.62 server metadata is byte-indistinguishable from modern server
+// metadata, absence of the witness cannot separate "legacy without witness"
+// from "modern without witness", and refusing on absence would false-refuse the
+// common shared-server clone workflow. We therefore fail OPEN on a missing
+// witness and refuse only on a present legacy witness or a tampered/ambiguous
+// one. A fresh clone of a genuinely legacy v0.59-v0.62 server workspace that
+// lacks its local witness is admitted; see docs/getting-started/upgrading.md.
 func refuseLegacyDoltServerWorkspace(beadsDir string, cfg *configfile.Config) error {
 	return refuseLegacyDoltServerWorkspaceWithVersionWitnessOpener(beadsDir, cfg, safefile.OpenReadOnlyNoFollow)
 }
@@ -49,6 +60,11 @@ func refuseLegacyDoltServerWorkspaceWithVersionWitnessOpener(
 		if state == legacyDoltVersionWitnessAmbiguous {
 			return fmt.Errorf("cannot safely classify possible legacy Dolt-server workspace at %q because its %s witness changed or could not be read consistently; preserve a byte-for-byte backup of .beads, stop other bd processes touching the workspace, and retry (refusing to open or modify it)", beadsDir, localVersionFile)
 		}
+		// Deliberate fail-open: a missing witness (state Missing) or a witness
+		// for a non-project-identity version cannot prove this is a legacy
+		// v0.59-v0.62 workspace, and the witness is gitignored so modern fresh
+		// clones legitimately lack it. Admit rather than false-refuse modern
+		// server clones. See the function doc for the accepted trade-off.
 		if state != legacyDoltVersionWitnessStable || !isProjectIdentityLegacyDoltVersionWitness(version) {
 			return nil
 		}
@@ -116,7 +132,7 @@ func readLegacyDoltVersionWitnessWithOpener(
 	if os.IsNotExist(err) {
 		return "", legacyDoltVersionWitnessMissing
 	}
-	if err != nil || !info.Mode().IsRegular() || info.Size() <= 0 || info.Size() > maxLegacyVersionWitnessBytes {
+	if err != nil || !plausibleLegacyVersionWitnessInfo(info) {
 		return "", legacyDoltVersionWitnessAmbiguous
 	}
 	file, err := opener(path)
@@ -125,8 +141,7 @@ func readLegacyDoltVersionWitnessWithOpener(
 	}
 	defer func() { _ = file.Close() }()
 	openedInfo, err := file.Stat()
-	if err != nil || !openedInfo.Mode().IsRegular() || !os.SameFile(info, openedInfo) ||
-		openedInfo.Size() != info.Size() || !openedInfo.ModTime().Equal(info.ModTime()) {
+	if err != nil || !openedWitnessMatchesLstat(info, openedInfo) {
 		return "", legacyDoltVersionWitnessAmbiguous
 	}
 	data, err := io.ReadAll(io.LimitReader(file, maxLegacyVersionWitnessBytes+1))
@@ -138,14 +153,45 @@ func readLegacyDoltVersionWitnessWithOpener(
 		return "", legacyDoltVersionWitnessAmbiguous
 	}
 	namedAfter, err := os.Lstat(path)
-	if err != nil || !namedAfter.Mode().IsRegular() ||
-		!os.SameFile(openedInfo, afterInfo) || !os.SameFile(openedInfo, namedAfter) ||
-		openedInfo.Size() != afterInfo.Size() || int64(len(data)) != afterInfo.Size() ||
-		!openedInfo.ModTime().Equal(afterInfo.ModTime()) {
+	if err != nil || !witnessStableAfterRead(openedInfo, afterInfo, namedAfter, len(data)) {
 		return "", legacyDoltVersionWitnessAmbiguous
 	}
-	version := strings.TrimSpace(string(data))
-	return version, legacyDoltVersionWitnessStable
+	return strings.TrimSpace(string(data)), legacyDoltVersionWitnessStable
+}
+
+// plausibleLegacyVersionWitnessInfo reports whether a pre-open Lstat result
+// looks like a readable version witness: a regular file whose size is within
+// the bounded witness window. A symlink or other non-regular shape is treated
+// as ambiguous rather than read.
+func plausibleLegacyVersionWitnessInfo(info os.FileInfo) bool {
+	return info.Mode().IsRegular() &&
+		info.Size() > 0 &&
+		info.Size() <= maxLegacyVersionWitnessBytes
+}
+
+// openedWitnessMatchesLstat reports whether the opened descriptor still
+// describes the same regular file the pre-open Lstat saw — same inode
+// (os.SameFile), size, and mtime. It closes the open-by-name TOCTOU window
+// between Lstat and open before any bytes are trusted.
+func openedWitnessMatchesLstat(lstatInfo, openedInfo os.FileInfo) bool {
+	return openedInfo.Mode().IsRegular() &&
+		os.SameFile(lstatInfo, openedInfo) &&
+		openedInfo.Size() == lstatInfo.Size() &&
+		openedInfo.ModTime().Equal(lstatInfo.ModTime())
+}
+
+// witnessStableAfterRead reports whether the witness still resolves to the same
+// regular file after the read, verified through both the open descriptor
+// (afterInfo) and a fresh path Lstat (namedAfter), and that the bytes read
+// account for the whole file. A concurrent in-place rewrite or path swap fails
+// one of these checks and is reported as ambiguous.
+func witnessStableAfterRead(openedInfo, afterInfo, namedAfter os.FileInfo, readLen int) bool {
+	return namedAfter.Mode().IsRegular() &&
+		os.SameFile(openedInfo, afterInfo) &&
+		os.SameFile(openedInfo, namedAfter) &&
+		openedInfo.Size() == afterInfo.Size() &&
+		int64(readLen) == afterInfo.Size() &&
+		openedInfo.ModTime().Equal(afterInfo.ModTime())
 }
 
 func isLegacyDoltVersionWitness(version string) bool {

--- a/docs/getting-started/upgrading.md
+++ b/docs/getting-started/upgrading.md
@@ -244,16 +244,25 @@ Identify your installation's era by what lives under `.beads/`:
 
 | Era | Storage layout |
 |---|---|
-| SQLite (pre-Dolt, up to ~v0.50) | `.beads/beads.db` |
-| Dolt server | `.beads/dolt/` |
-| Embedded Dolt (the default since its introduction) | `.beads/embeddeddolt/` |
-### From v0.63.3+ (current era)
+| SQLite (default through v0.49.x; selectable later) | `.beads/beads.db` |
+| Dolt server (common/default in v0.50.x-v0.62.x) | `.beads/dolt/` |
+| Embedded Dolt (selectable earlier; default from v0.63.x) | `.beads/embeddeddolt/` |
+
+Route by the observed storage layout, not the version alone. Some historical
+releases allowed more than one backend.
+
+### From v0.63.3+ embedded-Dolt workspaces
 
 Upgrade the binary and run:
 
 ```bash
 bd migrate
 ```
+
+The pinned embedded-era qualification begins at the official v0.63.3 release.
+For an embedded layout created by an earlier binary, preserve the matching
+binary and a complete `.beads` backup rather than assuming this direct path is
+qualified.
 
 If the project was initialized before `bd init` automatically wired git origin
 as the Dolt remote, verify the remote after upgrading:
@@ -274,38 +283,37 @@ bd dolt push
 Commit the resulting `.beads/config.yaml` change so other clones can run
 `bd bootstrap` or `bd dolt pull`.
 
-### From v0.59–v0.63.2 (old embedded)
+### From v0.50.x-v0.62.x Dolt-server workspaces
 
-Direct upgrade works automatically:
+Releases in this range commonly used an external Dolt SQL server, including
+v0.59-v0.62. Current `bd` refuses to open this storage layout until an explicit
+version-specific bridge is used; an ordinary command such as `bd list` will not
+convert it automatically.
 
-```bash
-# Just use the new binary — it handles the conversion
-bd list
-```
+The refusal is intentional. Opening the server-era layout directly can rewrite
+version markers or storage state before the old data has been exported. Do not
+delete `.beads/dolt`, remove metadata, or run `bd init` over the only copy.
 
-### From v0.50–v0.58 (Dolt server era)
+Before changing binaries:
 
-The old binary used an external Dolt SQL server. The new binary uses an embedded engine.
+1. Keep the matching historical `bd` binary and Dolt runtime available.
+2. Stop all writes and stop the historical server.
+3. Preserve and verify a byte-for-byte copy of the complete `.beads` directory
+   before running any extraction command.
+4. Restart the historical stack only against a separate working copy, then make
+   the release-specific export and any supplemental per-issue snapshots there.
+5. Revalidate the sealed rollback copy, and retain it until issue counts,
+   fields, comments, labels, and dependency edges have been verified.
 
-```bash
-# 1. Export your data while the old binary still works
-bd list --json -n 0 --all > .beads/issues.jsonl
+The repository's migration CI contains release-specific bridges for its pinned
+historical fixtures, but those recipes are test infrastructure, not a supported
+command for arbitrary user databases. A generic `list --json` export is not a
+lossless substitute: historical release shapes can omit comments, labels, or
+dependency details. Until a user-facing bridge is published, keep using the
+matching historical binary rather than applying the old destructive conversion
+steps.
 
-# 2. Stop the Dolt server
-# stop the dolt sql-server process (kill its PID; there is no --stop flag)
-
-# 3. Remove stale server metadata and old storage directories
-rm -f .beads/metadata.json .beads/config.json
-rm -rf .beads/dolt .beads/embeddeddolt
-
-# 4. Initialize with the new binary
-bd init --from-jsonl --quiet
-
-# 5. Verify
-bd list --all
-```
-
-### From v0.30–v0.50 (SQLite era)
+### From v0.30.x-v0.50.x SQLite workspaces
 
 The old binary stored data in SQLite. The new binary uses Dolt.
 

--- a/docs/getting-started/upgrading.md
+++ b/docs/getting-started/upgrading.md
@@ -313,6 +313,19 @@ dependency details. Until a user-facing bridge is published, keep using the
 matching historical binary rather than applying the old destructive conversion
 steps.
 
+> **Known limitation (fresh clones of v0.59-v0.62 server workspaces).** The
+> refusal for the v0.59-v0.62 range relies on the gitignored `.local_version`
+> witness, because that era's committed `.beads/metadata.json` is otherwise
+> indistinguishable from a modern server workspace. A brand-new clone of a
+> genuinely legacy v0.59-v0.62 server workspace has no local `.local_version`,
+> so `bd` cannot detect the era from committed metadata alone and will open it
+> like a modern server workspace. This is a deliberate trade-off: adding a
+> store-free "modern" marker that refused on its absence would false-refuse the
+> far more common case of cloning a healthy modern shared server workspace. If
+> you are migrating a v0.59-v0.62 server database, run the historical binary in
+> the original checkout (which still has `.local_version`) and follow the backup
+> and export steps above before cloning or upgrading.
+
 ### From v0.30.x-v0.50.x SQLite workspaces
 
 The old binary stored data in SQLite. The new binary uses Dolt.

--- a/internal/v062migration/embedded_build_cgo.go
+++ b/internal/v062migration/embedded_build_cgo.go
@@ -1,0 +1,5 @@
+//go:build cgo
+
+package v062migration
+
+const embeddedBuildCapable = true

--- a/internal/v062migration/embedded_build_nocgo.go
+++ b/internal/v062migration/embedded_build_nocgo.go
@@ -1,0 +1,5 @@
+//go:build !cgo
+
+package v062migration
+
+const embeddedBuildCapable = false

--- a/internal/v062migration/inspect_linux.go
+++ b/internal/v062migration/inspect_linux.go
@@ -1,0 +1,1012 @@
+//go:build linux
+
+package v062migration
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"hash"
+	"io"
+	"os"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"sort"
+	"strconv"
+	"strings"
+
+	"golang.org/x/sys/unix"
+)
+
+const (
+	versionWitness       = "0.62.0\n"
+	maxVersionBytes      = 64
+	maxMetadataBytes     = 1 << 20
+	rollbackDirectory    = ".beads-v0.62.0-rollback"
+	directoryOpenFlags   = unix.O_RDONLY | unix.O_DIRECTORY | unix.O_CLOEXEC | unix.O_NOFOLLOW | unix.O_NOATIME
+	regularFileOpenFlags = unix.O_RDONLY | unix.O_CLOEXEC | unix.O_NOFOLLOW | unix.O_NOATIME | unix.O_NONBLOCK
+)
+
+var (
+	databaseNamePattern       = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_-]{0,63}$`)
+	projectIDPattern          = regexp.MustCompile(`^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$`)
+	errWitnessOutsideBound    = errors.New("witness outside size bound")
+	errWitnessChanged         = errors.New("witness changed while read")
+	allowedV062MetadataFields = map[string]struct{}{
+		"backend":                  {},
+		"database":                 {},
+		"deletions_retention_days": {},
+		"dolt_data_dir":            {},
+		"dolt_database":            {},
+		"dolt_mode":                {},
+		"dolt_remotesapi_port":     {},
+		"dolt_server_host":         {},
+		"dolt_server_port":         {},
+		"dolt_server_tls":          {},
+		"dolt_server_user":         {},
+		"last_bd_version":          {},
+		"project_id":               {},
+		"stale_closed_issues_days": {},
+	}
+)
+
+type metadataShape struct {
+	database string
+}
+
+type treeSnapshot struct {
+	treeSHA256      string
+	structureSHA256 string
+	kinds           map[string]byte
+}
+
+type mountIDReader func(dirfd int, path string, flags int) (uint64, error)
+
+type pathOpener func(path string, flags int, mode uint32) (int, error)
+
+// sourceFS binds every traversal observation to both the source filesystem
+// device and the Linux mount that contained the retained project descriptor.
+// st_dev alone cannot distinguish bind mounts on the same filesystem.
+type sourceFS struct {
+	device      uint64
+	mountID     uint64
+	readMountID mountIDReader
+}
+
+type inspectHooks struct {
+	afterFirstTree func()
+	mountIDAt      mountIDReader
+}
+
+func sameAdmissionObservation(first, second treeSnapshot) bool {
+	return first.structureSHA256 == second.structureSHA256 && first.treeSHA256 == second.treeSHA256
+}
+
+// Inspect admits only an exact, physical v0.62.0 local Dolt-server source.
+// Every source read is rooted at retained O_NOFOLLOW descriptors and no source
+// path is opened for writing.
+func Inspect(project, targetVersion string) (result Result, returnErr error) {
+	return inspectWithHooks(project, targetVersion, inspectHooks{})
+}
+
+func inspectWithHooks(project, targetVersion string, hooks inspectHooks) (result Result, returnErr error) {
+	if err := checkInspectPreconditions(project); err != nil {
+		return Result{}, err
+	}
+
+	readMountID := hooks.mountIDAt
+	if readMountID == nil {
+		readMountID = readMountIDAt
+	}
+	projectFile, projectStat, projectMountID, err := openProject(project, readMountID)
+	if err != nil {
+		return Result{}, err
+	}
+	defer closeForInspection(&result, &returnErr, projectFile)
+	fs := sourceFS{device: projectStat.Dev, mountID: projectMountID, readMountID: readMountID}
+
+	beadsFile, beadsStat, err := fs.openDirectoryAt(projectFile, ".beads")
+	if err != nil {
+		return Result{}, classifyBeadsOpen(err)
+	}
+	defer closeForInspection(&result, &returnErr, beadsFile)
+
+	if err := rejectRollbackCollision(projectFile); err != nil {
+		return Result{}, err
+	}
+
+	versionFile, versionStat, version, err := fs.readBoundedWitness(beadsFile, ".local_version", CodeSourceVersionMissing, CodeSourceVersionAmbiguous, maxVersionBytes, CodeSourceVersionMismatch)
+	defer closeForInspection(&result, &returnErr, versionFile)
+	if err != nil {
+		return Result{}, err
+	}
+	if !bytes.Equal(version, []byte(versionWitness)) {
+		return Result{}, refuse(CodeSourceVersionMismatch, false, nil)
+	}
+
+	metadataFile, metadataStat, metadata, err := fs.readBoundedWitness(beadsFile, "metadata.json", CodeSourceMetadataMissing, CodeUnsafeSourceSymlink, maxMetadataBytes, CodeSourceMetadataMismatch)
+	defer closeForInspection(&result, &returnErr, metadataFile)
+	if err != nil {
+		return Result{}, err
+	}
+	shape, err := parseMetadata(metadata)
+	if err != nil {
+		return Result{}, refuse(CodeSourceMetadataMismatch, false, err)
+	}
+
+	first, err := fs.inspectTree(beadsFile, beadsStat, true)
+	if err != nil {
+		return Result{}, err
+	}
+	if err := validateRequiredLayout(first.kinds, shape.database); err != nil {
+		return Result{}, err
+	}
+	if hooks.afterFirstTree != nil {
+		hooks.afterFirstTree()
+	}
+	if err := fs.revalidateSource(project, projectFile, projectStat, beadsFile, beadsStat, versionFile, versionStat, metadataFile, metadataStat, version, metadata); err != nil {
+		return Result{}, err
+	}
+
+	second, err := fs.inspectTree(beadsFile, beadsStat, true)
+	if err != nil {
+		return Result{}, err
+	}
+	if !sameAdmissionObservation(first, second) {
+		return Result{}, refuse(CodeSourceChanged, true, nil)
+	}
+	if err := fs.revalidateSource(project, projectFile, projectStat, beadsFile, beadsStat, versionFile, versionStat, metadataFile, metadataStat, version, metadata); err != nil {
+		return Result{}, err
+	}
+
+	return QualifiedResult(project, targetVersion, first.treeSHA256), nil
+}
+
+// checkInspectPreconditions rejects environments and workspace arguments that
+// the descriptor-bound inspector cannot admit before any source is opened.
+func checkInspectPreconditions(project string) error {
+	if runtime.GOARCH != "amd64" {
+		return refuse(CodePlatformUnsupported, false, nil)
+	}
+	wsl, err := runningUnderWSL()
+	if err != nil {
+		return refuse(CodeSourceUnverifiable, true, err)
+	}
+	if wsl {
+		return refuse(CodePlatformUnsupported, false, nil)
+	}
+	if !embeddedBuildCapable {
+		return refuse(CodeEmbeddedTargetUnavailable, false, nil)
+	}
+	if project == "" || !filepath.IsAbs(project) {
+		return refuse(CodeWorkspaceInvalid, false, nil)
+	}
+	if filepath.Clean(project) != project {
+		return refuse(CodeWorkspaceNotCanonical, false, nil)
+	}
+	return nil
+}
+
+func runningUnderWSL() (bool, error) {
+	var name unix.Utsname
+	if err := unix.Uname(&name); err != nil {
+		return false, err
+	}
+	return isWSLRelease(utsnameString(name.Release[:])), nil
+}
+
+func isWSLRelease(release string) bool {
+	lower := strings.ToLower(release)
+	return strings.Contains(lower, "microsoft") || strings.Contains(lower, "wsl")
+}
+
+func utsnameString(raw []byte) string {
+	for index, value := range raw {
+		if value == 0 {
+			return string(raw[:index])
+		}
+	}
+	return string(raw)
+}
+
+func openProject(project string, readMountID mountIDReader) (*os.File, unix.Stat_t, uint64, error) {
+	return openProjectWith(project, readMountID, unix.Open)
+}
+
+func openProjectWith(project string, readMountID mountIDReader, open pathOpener) (*os.File, unix.Stat_t, uint64, error) {
+	fd, err := open(project, directoryOpenFlags, 0)
+	if err != nil {
+		if errors.Is(err, unix.ELOOP) {
+			return nil, unix.Stat_t{}, 0, refuse(CodeWorkspaceNotCanonical, false, err)
+		}
+		if errors.Is(err, unix.EPERM) || errors.Is(err, unix.EACCES) {
+			// O_NOATIME is mandatory: retrying without it would mutate atime and
+			// violate the inspector's effect:none contract.
+			return nil, unix.Stat_t{}, 0, refuse(CodeSourceUnverifiable, true, err)
+		}
+		return nil, unix.Stat_t{}, 0, refuse(CodeWorkspaceInvalid, false, err)
+	}
+	file := os.NewFile(uintptr(fd), project)
+	if file == nil {
+		_ = unix.Close(fd)
+		return nil, unix.Stat_t{}, 0, refuse(CodeSourceUnverifiable, true, nil)
+	}
+	var stat unix.Stat_t
+	if err := unix.Fstat(fd, &stat); err != nil {
+		_ = file.Close()
+		return nil, unix.Stat_t{}, 0, refuse(CodeSourceUnverifiable, true, err)
+	}
+	mountID, err := readMountID(fd, "", unix.AT_EMPTY_PATH|unix.AT_SYMLINK_NOFOLLOW)
+	if err != nil {
+		_ = file.Close()
+		return nil, unix.Stat_t{}, 0, refuse(CodeSourceUnverifiable, true, err)
+	}
+	canonical, err := os.Readlink(fmt.Sprintf("/proc/self/fd/%d", fd))
+	if err != nil {
+		_ = file.Close()
+		return nil, unix.Stat_t{}, 0, refuse(CodeSourceUnverifiable, true, err)
+	}
+	if canonical != project {
+		_ = file.Close()
+		return nil, unix.Stat_t{}, 0, refuse(CodeWorkspaceNotCanonical, false, nil)
+	}
+	return file, stat, mountID, nil
+}
+
+func readMountIDAt(dirfd int, path string, flags int) (uint64, error) {
+	var stat unix.Statx_t
+	if err := unix.Statx(dirfd, path, flags, unix.STATX_MNT_ID, &stat); err != nil {
+		return 0, err
+	}
+	if stat.Mask&unix.STATX_MNT_ID == 0 {
+		return 0, unix.EOPNOTSUPP
+	}
+	return stat.Mnt_id, nil
+}
+
+func (fs sourceFS) checkMountAt(dirfd int, path string, flags int) error {
+	mountID, err := fs.readMountID(dirfd, path, flags)
+	if err != nil {
+		return refuse(CodeSourceUnverifiable, true, err)
+	}
+	return checkMountID(mountID, fs.mountID)
+}
+
+func checkMountID(actual, expected uint64) error {
+	if actual != expected {
+		return refuse(CodeCrossDeviceSource, false, nil)
+	}
+	return nil
+}
+
+func (fs sourceFS) openDirectoryAt(parent *os.File, name string) (*os.File, unix.Stat_t, error) {
+	var named unix.Stat_t
+	if err := unix.Fstatat(int(parent.Fd()), name, &named, unix.AT_SYMLINK_NOFOLLOW); err != nil {
+		return nil, unix.Stat_t{}, err
+	}
+	if named.Mode&unix.S_IFMT == unix.S_IFLNK {
+		return nil, unix.Stat_t{}, unix.ELOOP
+	}
+	if named.Mode&unix.S_IFMT != unix.S_IFDIR {
+		return nil, unix.Stat_t{}, unix.ENOTDIR
+	}
+	if err := checkDevice(named.Dev, fs.device); err != nil {
+		return nil, unix.Stat_t{}, err
+	}
+	if err := fs.checkMountAt(int(parent.Fd()), name, unix.AT_SYMLINK_NOFOLLOW); err != nil {
+		return nil, unix.Stat_t{}, err
+	}
+	fd, err := unix.Openat(int(parent.Fd()), name, directoryOpenFlags, 0)
+	if err != nil {
+		return nil, unix.Stat_t{}, err
+	}
+	file := os.NewFile(uintptr(fd), name)
+	if file == nil {
+		_ = unix.Close(fd)
+		return nil, unix.Stat_t{}, unix.EBADF
+	}
+	var opened unix.Stat_t
+	if err := unix.Fstat(fd, &opened); err != nil {
+		_ = file.Close()
+		return nil, unix.Stat_t{}, err
+	}
+	if err := checkDevice(opened.Dev, fs.device); err != nil {
+		_ = file.Close()
+		return nil, unix.Stat_t{}, err
+	}
+	if err := fs.checkMountAt(fd, "", unix.AT_EMPTY_PATH|unix.AT_SYMLINK_NOFOLLOW); err != nil {
+		_ = file.Close()
+		return nil, unix.Stat_t{}, err
+	}
+	if !sameStat(named, opened) {
+		_ = file.Close()
+		return nil, unix.Stat_t{}, unix.ESTALE
+	}
+	return file, opened, nil
+}
+
+func (fs sourceFS) openWitnessAt(parent *os.File, name string, missingCode, symlinkCode Code) (*os.File, unix.Stat_t, error) {
+	var named unix.Stat_t
+	if err := unix.Fstatat(int(parent.Fd()), name, &named, unix.AT_SYMLINK_NOFOLLOW); err != nil {
+		if errors.Is(err, unix.ENOENT) {
+			return nil, unix.Stat_t{}, refuse(missingCode, false, err)
+		}
+		return nil, unix.Stat_t{}, refuse(CodeSourceUnverifiable, true, err)
+	}
+	switch named.Mode & unix.S_IFMT {
+	case unix.S_IFLNK:
+		return nil, unix.Stat_t{}, refuse(symlinkCode, false, nil)
+	case unix.S_IFREG:
+		// Continue below.
+	default:
+		return nil, unix.Stat_t{}, refuse(CodeUnsafeSourceObject, false, nil)
+	}
+	if err := checkDevice(named.Dev, fs.device); err != nil {
+		return nil, unix.Stat_t{}, err
+	}
+	if err := fs.checkMountAt(int(parent.Fd()), name, unix.AT_SYMLINK_NOFOLLOW); err != nil {
+		return nil, unix.Stat_t{}, err
+	}
+	if named.Nlink != 1 {
+		return nil, unix.Stat_t{}, refuse(CodeUnsafeSourceHardlink, false, nil)
+	}
+	fd, err := unix.Openat(int(parent.Fd()), name, regularFileOpenFlags, 0)
+	if err != nil {
+		if errors.Is(err, unix.ELOOP) {
+			return nil, unix.Stat_t{}, refuse(symlinkCode, false, err)
+		}
+		return nil, unix.Stat_t{}, refuse(CodeSourceUnverifiable, true, err)
+	}
+	file := os.NewFile(uintptr(fd), name)
+	if file == nil {
+		_ = unix.Close(fd)
+		return nil, unix.Stat_t{}, refuse(CodeSourceUnverifiable, true, nil)
+	}
+	var opened unix.Stat_t
+	if err := unix.Fstat(fd, &opened); err != nil {
+		_ = file.Close()
+		return nil, unix.Stat_t{}, refuse(CodeSourceUnverifiable, true, err)
+	}
+	if err := checkDevice(opened.Dev, fs.device); err != nil {
+		_ = file.Close()
+		return nil, unix.Stat_t{}, err
+	}
+	if err := fs.checkMountAt(fd, "", unix.AT_EMPTY_PATH|unix.AT_SYMLINK_NOFOLLOW); err != nil {
+		_ = file.Close()
+		return nil, unix.Stat_t{}, err
+	}
+	if !sameStat(named, opened) {
+		_ = file.Close()
+		return nil, unix.Stat_t{}, refuse(CodeSourceChanged, true, nil)
+	}
+	return file, opened, nil
+}
+
+// readBoundedWitness opens a required regular-file witness under the retained
+// beads descriptor and reads it under the stable-size contract. An oversized
+// but stable witness is a non-retryable mismatch. The file is returned even on
+// a read failure so the caller can register its deferred close; it is nil only
+// when the open itself failed.
+func (fs sourceFS) readBoundedWitness(beads *os.File, name string, missingCode, symlinkCode Code, limit int64, mismatchCode Code) (*os.File, unix.Stat_t, []byte, error) {
+	file, stat, err := fs.openWitnessAt(beads, name, missingCode, symlinkCode)
+	if err != nil {
+		return nil, unix.Stat_t{}, nil, err
+	}
+	data, err := readStableBounded(file, stat, limit)
+	if err != nil {
+		if errors.Is(err, errWitnessOutsideBound) {
+			return file, stat, nil, refuse(mismatchCode, false, err)
+		}
+		return file, stat, nil, classifyWitnessReadFailure(err)
+	}
+	return file, stat, data, nil
+}
+
+func classifyBeadsOpen(err error) error {
+	if _, ok := AsRefusal(err); ok {
+		return err
+	}
+	switch {
+	case errors.Is(err, unix.ENOENT), errors.Is(err, unix.ENOTDIR):
+		return refuse(CodeSourceLayoutMissing, false, err)
+	case errors.Is(err, unix.ELOOP):
+		return refuse(CodeUnsafeSourceSymlink, false, err)
+	case errors.Is(err, unix.EXDEV):
+		return refuse(CodeCrossDeviceSource, false, err)
+	default:
+		return refuse(CodeSourceUnverifiable, true, err)
+	}
+}
+
+func rejectRollbackCollision(project *os.File) error {
+	var stat unix.Stat_t
+	err := unix.Fstatat(int(project.Fd()), rollbackDirectory, &stat, unix.AT_SYMLINK_NOFOLLOW)
+	if err == nil {
+		return refuse(CodeRollbackCollision, false, nil)
+	}
+	if errors.Is(err, unix.ENOENT) {
+		return nil
+	}
+	return refuse(CodeSourceUnverifiable, true, err)
+}
+
+func readStableBounded(file *os.File, expected unix.Stat_t, limit int64) ([]byte, error) {
+	if expected.Size < 0 || expected.Size > limit {
+		var after unix.Stat_t
+		if err := unix.Fstat(int(file.Fd()), &after); err != nil {
+			return nil, err
+		}
+		if !sameStat(expected, after) {
+			return nil, errWitnessChanged
+		}
+		return nil, errWitnessOutsideBound
+	}
+	data, err := io.ReadAll(io.NewSectionReader(file, 0, limit+1))
+	if err != nil {
+		return nil, err
+	}
+	var after unix.Stat_t
+	if err := unix.Fstat(int(file.Fd()), &after); err != nil {
+		return nil, err
+	}
+	if !sameStat(expected, after) || int64(len(data)) != after.Size {
+		return nil, errWitnessChanged
+	}
+	if int64(len(data)) > limit {
+		return nil, errWitnessOutsideBound
+	}
+	return data, nil
+}
+
+func classifyWitnessReadFailure(err error) error {
+	if errors.Is(err, errWitnessChanged) {
+		return refuse(CodeSourceChanged, true, err)
+	}
+	return refuse(CodeSourceUnverifiable, true, err)
+}
+
+func parseMetadata(data []byte) (metadataShape, error) {
+	values, err := decodeUniqueObject(data)
+	if err != nil {
+		return metadataShape{}, err
+	}
+	database, err := requiredMetadataShape(values)
+	if err != nil {
+		return metadataShape{}, err
+	}
+	if err := rejectDisallowedMetadataFields(values); err != nil {
+		return metadataShape{}, err
+	}
+	return metadataShape{database: database}, nil
+}
+
+// requiredMetadataShape enforces the exact scalar contract of a v0.62 local
+// Dolt-server metadata document and returns the validated dolt database name.
+func requiredMetadataShape(values map[string]json.RawMessage) (string, error) {
+	for _, field := range []struct{ key, want string }{
+		{"backend", "dolt"},
+		{"database", "dolt"},
+		{"dolt_mode", "server"},
+	} {
+		if got, ok := requiredString(values, field.key); !ok || got != field.want {
+			return "", errors.New(field.key)
+		}
+	}
+	if _, present := values["dolt_server_host"]; present {
+		if host, ok := requiredString(values, "dolt_server_host"); !ok || host != "127.0.0.1" {
+			return "", errors.New("dolt_server_host")
+		}
+	}
+	database, ok := requiredString(values, "dolt_database")
+	if !ok || !databaseNamePattern.MatchString(database) {
+		return "", errors.New("dolt_database")
+	}
+	if projectID, ok := requiredString(values, "project_id"); !ok || !projectIDPattern.MatchString(projectID) {
+		return "", errors.New("project_id")
+	}
+	if _, present := values["dolt_server_port"]; present {
+		if port, ok := requiredInteger(values, "dolt_server_port"); !ok || port < 1 || port > 65535 {
+			return "", errors.New("dolt_server_port")
+		}
+	}
+	return database, nil
+}
+
+// rejectDisallowedMetadataFields fails closed on any field outside the allowed
+// v0.62 set, any foreign-provider metadata, and any non-empty custom data dir.
+func rejectDisallowedMetadataFields(values map[string]json.RawMessage) error {
+	for key, raw := range values {
+		if _, allowed := allowedV062MetadataFields[key]; !allowed {
+			return errors.New("unknown v0.62 metadata field")
+		}
+		lower := strings.ToLower(key)
+		if strings.HasPrefix(lower, "postgres") || strings.HasPrefix(lower, "mysql") ||
+			strings.HasPrefix(lower, "sqlite") || strings.HasPrefix(lower, "proxied") {
+			return errors.New("foreign provider metadata")
+		}
+		if key == "dolt_data_dir" {
+			var value string
+			if err := json.Unmarshal(raw, &value); err != nil || value != "" {
+				return errors.New("custom server path")
+			}
+		}
+	}
+	return nil
+}
+
+func decodeUniqueObject(data []byte) (map[string]json.RawMessage, error) {
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	token, err := decoder.Token()
+	if err != nil || token != json.Delim('{') {
+		return nil, errors.New("metadata is not an object")
+	}
+	values := make(map[string]json.RawMessage)
+	for decoder.More() {
+		token, err := decoder.Token()
+		if err != nil {
+			return nil, err
+		}
+		key, ok := token.(string)
+		if !ok {
+			return nil, errors.New("metadata key is not a string")
+		}
+		if _, duplicate := values[key]; duplicate {
+			return nil, errors.New("duplicate metadata key")
+		}
+		var raw json.RawMessage
+		if err := decoder.Decode(&raw); err != nil {
+			return nil, err
+		}
+		values[key] = raw
+	}
+	if token, err = decoder.Token(); err != nil || token != json.Delim('}') {
+		return nil, errors.New("unterminated metadata object")
+	}
+	if token, err = decoder.Token(); !errors.Is(err, io.EOF) || token != nil {
+		return nil, errors.New("trailing metadata content")
+	}
+	return values, nil
+}
+
+func requiredString(values map[string]json.RawMessage, key string) (string, bool) {
+	raw, ok := values[key]
+	if !ok {
+		return "", false
+	}
+	var value string
+	if err := json.Unmarshal(raw, &value); err != nil {
+		return "", false
+	}
+	return value, true
+}
+
+func requiredInteger(values map[string]json.RawMessage, key string) (int64, bool) {
+	raw, ok := values[key]
+	if !ok {
+		return 0, false
+	}
+	value, err := strconv.ParseInt(string(raw), 10, 64)
+	return value, err == nil
+}
+
+func (fs sourceFS) inspectTree(root *os.File, rootStat unix.Stat_t, includeContent bool) (treeSnapshot, error) {
+	rootCopy, opened, err := fs.openDirectoryAt(root, ".")
+	if err != nil {
+		return treeSnapshot{}, classifyTreeOpen(err)
+	}
+	if !sameStat(rootStat, opened) {
+		_ = rootCopy.Close()
+		return treeSnapshot{}, refuse(CodeSourceChanged, true, nil)
+	}
+	treeHash := sha256.New()
+	structureHash := sha256.New()
+	kinds := make(map[string]byte)
+	writeTreeRecord(treeHash, 'd', ".", opened, nil)
+	writeStructureRecord(structureHash, 'd', ".", opened)
+	inspectErr := fs.inspectDirectory(rootCopy, "", includeContent, treeHash, structureHash, kinds)
+	closeErr := rootCopy.Close()
+	if inspectErr != nil {
+		return treeSnapshot{}, inspectErr
+	}
+	if closeErr != nil {
+		return treeSnapshot{}, refuse(CodeSourceUnverifiable, true, closeErr)
+	}
+	return treeSnapshot{
+		treeSHA256:      hex.EncodeToString(treeHash.Sum(nil)),
+		structureSHA256: hex.EncodeToString(structureHash.Sum(nil)),
+		kinds:           kinds,
+	}, nil
+}
+
+func (fs sourceFS) inspectDirectory(dir *os.File, relative string, includeContent bool, treeHash, structureHash hash.Hash, kinds map[string]byte) error {
+	names, err := dir.Readdirnames(-1)
+	if err != nil {
+		return refuse(CodeSourceUnverifiable, true, err)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		path := joinRelative(relative, name)
+		named, err := fs.statTreeEntry(dir, name)
+		if err != nil {
+			return err
+		}
+		switch named.Mode & unix.S_IFMT {
+		case unix.S_IFLNK:
+			return refuse(CodeUnsafeSourceSymlink, false, nil)
+		case unix.S_IFDIR:
+			if err := fs.inspectSubdirectory(dir, name, path, includeContent, treeHash, structureHash, kinds); err != nil {
+				return err
+			}
+		case unix.S_IFREG:
+			if err := fs.hashRegularTreeEntry(dir, name, path, named, includeContent, treeHash, structureHash, kinds); err != nil {
+				return err
+			}
+		default:
+			return refuse(CodeUnsafeSourceObject, false, nil)
+		}
+	}
+	return nil
+}
+
+func joinRelative(relative, name string) string {
+	if relative == "" {
+		return name
+	}
+	return relative + "/" + name
+}
+
+// statTreeEntry stats a directory entry without following symlinks and binds it
+// to the retained source device and mount before the caller inspects its kind.
+func (fs sourceFS) statTreeEntry(dir *os.File, name string) (unix.Stat_t, error) {
+	var named unix.Stat_t
+	if err := unix.Fstatat(int(dir.Fd()), name, &named, unix.AT_SYMLINK_NOFOLLOW); err != nil {
+		if errors.Is(err, unix.ENOENT) || errors.Is(err, unix.ESTALE) {
+			return unix.Stat_t{}, refuse(CodeSourceChanged, true, err)
+		}
+		return unix.Stat_t{}, refuse(CodeSourceUnverifiable, true, err)
+	}
+	if err := checkDevice(named.Dev, fs.device); err != nil {
+		return unix.Stat_t{}, err
+	}
+	if err := fs.checkMountAt(int(dir.Fd()), name, unix.AT_SYMLINK_NOFOLLOW); err != nil {
+		return unix.Stat_t{}, err
+	}
+	return named, nil
+}
+
+func (fs sourceFS) inspectSubdirectory(dir *os.File, name, path string, includeContent bool, treeHash, structureHash hash.Hash, kinds map[string]byte) error {
+	child, opened, err := fs.openDirectoryAt(dir, name)
+	if err != nil {
+		return classifyTreeOpen(err)
+	}
+	kinds[path] = 'd'
+	writeTreeRecord(treeHash, 'd', path, opened, nil)
+	writeStructureRecord(structureHash, 'd', path, opened)
+	err = fs.inspectDirectory(child, path, includeContent, treeHash, structureHash, kinds)
+	closeErr := child.Close()
+	if err != nil {
+		return err
+	}
+	if closeErr != nil {
+		return refuse(CodeSourceUnverifiable, true, closeErr)
+	}
+	return nil
+}
+
+// hashRegularTreeEntry opens a regular tree file under its retained descriptor,
+// folds its content and structure into the running digests, and re-stats it to
+// prove it did not change during the read.
+func (fs sourceFS) hashRegularTreeEntry(dir *os.File, name, path string, named unix.Stat_t, includeContent bool, treeHash, structureHash hash.Hash, kinds map[string]byte) error {
+	if named.Nlink != 1 {
+		return refuse(CodeUnsafeSourceHardlink, false, nil)
+	}
+	file, opened, err := fs.openRegularTreeFile(dir, name, named)
+	if err != nil {
+		return err
+	}
+	var contentDigest []byte
+	if includeContent {
+		contentHash := sha256.New()
+		if _, err := io.Copy(contentHash, file); err != nil {
+			_ = file.Close()
+			return refuse(CodeSourceUnverifiable, true, err)
+		}
+		contentDigest = contentHash.Sum(nil)
+	}
+	var after unix.Stat_t
+	statErr := unix.Fstat(int(file.Fd()), &after)
+	closeErr := file.Close()
+	if statErr != nil {
+		return refuse(CodeSourceUnverifiable, true, statErr)
+	}
+	if !sameStat(opened, after) {
+		return refuse(CodeSourceChanged, true, nil)
+	}
+	if closeErr != nil {
+		return refuse(CodeSourceUnverifiable, true, closeErr)
+	}
+	kinds[path] = 'f'
+	if includeContent {
+		writeTreeRecord(treeHash, 'f', path, opened, contentDigest)
+	}
+	writeStructureRecord(structureHash, 'f', path, opened)
+	return nil
+}
+
+func (fs sourceFS) openRegularTreeFile(parent *os.File, name string, named unix.Stat_t) (*os.File, unix.Stat_t, error) {
+	fd, err := unix.Openat(int(parent.Fd()), name, regularFileOpenFlags, 0)
+	if err != nil {
+		return nil, unix.Stat_t{}, classifyTreeOpen(err)
+	}
+	file := os.NewFile(uintptr(fd), name)
+	if file == nil {
+		_ = unix.Close(fd)
+		return nil, unix.Stat_t{}, refuse(CodeSourceUnverifiable, true, nil)
+	}
+	var opened unix.Stat_t
+	if err := unix.Fstat(fd, &opened); err != nil {
+		_ = file.Close()
+		return nil, unix.Stat_t{}, refuse(CodeSourceUnverifiable, true, err)
+	}
+	if err := checkDevice(opened.Dev, fs.device); err != nil {
+		_ = file.Close()
+		return nil, unix.Stat_t{}, err
+	}
+	if err := fs.checkMountAt(fd, "", unix.AT_EMPTY_PATH|unix.AT_SYMLINK_NOFOLLOW); err != nil {
+		_ = file.Close()
+		return nil, unix.Stat_t{}, err
+	}
+	if opened.Mode&unix.S_IFMT != unix.S_IFREG || opened.Nlink != 1 {
+		_ = file.Close()
+		return nil, unix.Stat_t{}, refuse(CodeUnsafeSourceObject, false, nil)
+	}
+	if !sameStat(named, opened) {
+		_ = file.Close()
+		return nil, unix.Stat_t{}, refuse(CodeSourceChanged, true, nil)
+	}
+	return file, opened, nil
+}
+
+func classifyTreeOpen(err error) error {
+	if _, ok := AsRefusal(err); ok {
+		return err
+	}
+	switch {
+	case errors.Is(err, unix.ELOOP):
+		return refuse(CodeUnsafeSourceSymlink, false, err)
+	case errors.Is(err, unix.EXDEV):
+		return refuse(CodeCrossDeviceSource, false, err)
+	case errors.Is(err, unix.ENOENT), errors.Is(err, unix.ESTALE):
+		return refuse(CodeSourceChanged, true, err)
+	default:
+		return refuse(CodeSourceUnverifiable, true, err)
+	}
+}
+
+func checkDevice(actual, expected uint64) error {
+	if actual != expected {
+		return refuse(CodeCrossDeviceSource, false, nil)
+	}
+	return nil
+}
+
+func validateRequiredLayout(kinds map[string]byte, database string) error {
+	for _, mixed := range []string{"embeddeddolt", "beads.db", "proxieddb", "sqlite.db"} {
+		if _, exists := kinds[mixed]; exists {
+			return refuse(CodeMixedStorageLayout, false, nil)
+		}
+	}
+	for path, kind := range kinds {
+		if kind == 'f' && isRootSQLiteArtifact(path) {
+			return refuse(CodeMixedStorageLayout, false, nil)
+		}
+		parts := strings.Split(path, "/")
+		if kind == 'd' && len(parts) == 3 && parts[0] == "dolt" && parts[2] == ".dolt" && parts[1] != database {
+			// An immediate dolt/<name>/.dolt is another database root. Nested
+			// stats repositories such as dolt/.dolt/stats/.dolt and
+			// dolt/<database>/.dolt/stats/.dolt are authentic Dolt layout.
+			return refuse(CodeMixedStorageLayout, false, nil)
+		}
+	}
+	required := map[string]byte{
+		".local_version":                              'f',
+		"metadata.json":                               'f',
+		"dolt":                                        'd',
+		"dolt/config.yaml":                            'f',
+		"dolt/.dolt":                                  'd',
+		"dolt/.dolt/config.json":                      'f',
+		"dolt/.dolt/repo_state.json":                  'f',
+		"dolt/" + database:                            'd',
+		"dolt/" + database + "/.dolt":                 'd',
+		"dolt/" + database + "/.dolt/config.json":     'f',
+		"dolt/" + database + "/.dolt/repo_state.json": 'f',
+	}
+	for path, kind := range required {
+		if kinds[path] != kind {
+			return refuse(CodeSourceLayoutMissing, false, nil)
+		}
+	}
+	return nil
+}
+
+func isRootSQLiteArtifact(path string) bool {
+	if strings.Contains(path, "/") {
+		return false
+	}
+	name := strings.ToLower(path)
+	for _, ancillary := range []string{
+		"ephemeral.sqlite3",
+		"ephemeral.sqlite3-journal",
+		"ephemeral.sqlite3-wal",
+		"ephemeral.sqlite3-shm",
+	} {
+		if name == ancillary {
+			return false
+		}
+	}
+	for _, suffix := range []string{
+		".db", ".db-journal", ".db-wal", ".db-shm",
+		".sqlite", ".sqlite-journal", ".sqlite-wal", ".sqlite-shm",
+		".sqlite3", ".sqlite3-journal", ".sqlite3-wal", ".sqlite3-shm",
+	} {
+		if strings.HasSuffix(name, suffix) {
+			return true
+		}
+	}
+	return strings.Contains(name, ".db?")
+}
+
+func (fs sourceFS) revalidateSource(projectPath string, project *os.File, projectStat unix.Stat_t, beads *os.File, beadsStat unix.Stat_t, version *os.File, versionStat unix.Stat_t, metadata *os.File, metadataStat unix.Stat_t, expectedVersion, expectedMetadata []byte) error {
+	for _, item := range []struct {
+		file *os.File
+		want unix.Stat_t
+	}{
+		{project, projectStat},
+		{beads, beadsStat},
+		{version, versionStat},
+		{metadata, metadataStat},
+	} {
+		var current unix.Stat_t
+		if err := unix.Fstat(int(item.file.Fd()), &current); err != nil {
+			return refuse(CodeSourceUnverifiable, true, err)
+		}
+		if !sameStat(item.want, current) {
+			return refuse(CodeSourceChanged, true, nil)
+		}
+		if err := checkDevice(current.Dev, fs.device); err != nil {
+			return err
+		}
+		if err := fs.checkMountAt(int(item.file.Fd()), "", unix.AT_EMPTY_PATH|unix.AT_SYMLINK_NOFOLLOW); err != nil {
+			return err
+		}
+	}
+	if err := fs.entryStillNames(project, ".beads", beadsStat); err != nil {
+		return err
+	}
+	if err := fs.entryStillNames(beads, ".local_version", versionStat); err != nil {
+		return err
+	}
+	if err := fs.entryStillNames(beads, "metadata.json", metadataStat); err != nil {
+		return err
+	}
+	versionBytes, err := readStableBounded(version, versionStat, maxVersionBytes)
+	if err != nil {
+		return classifyWitnessReadFailure(err)
+	}
+	if !bytes.Equal(versionBytes, expectedVersion) {
+		return refuse(CodeSourceChanged, true, nil)
+	}
+	metadataBytes, err := readStableBounded(metadata, metadataStat, maxMetadataBytes)
+	if err != nil {
+		return classifyWitnessReadFailure(err)
+	}
+	if !bytes.Equal(metadataBytes, expectedMetadata) {
+		return refuse(CodeSourceChanged, true, nil)
+	}
+	canonical, err := os.Readlink(fmt.Sprintf("/proc/self/fd/%d", project.Fd()))
+	if err != nil {
+		return refuse(CodeSourceUnverifiable, true, err)
+	}
+	if canonical != projectPath {
+		return refuse(CodeSourceChanged, true, nil)
+	}
+	return fs.reverifyProjectIdentity(projectPath, projectStat)
+}
+
+// reverifyProjectIdentity reopens the canonical project path and proves the
+// fresh descriptor still names the same inode on the same source mount, closing
+// the residual window between the retained descriptor and a path-based reopen.
+func (fs sourceFS) reverifyProjectIdentity(projectPath string, projectStat unix.Stat_t) error {
+	reopened, reopenedStat, reopenedMountID, err := openProject(projectPath, fs.readMountID)
+	if err != nil {
+		if refusal, ok := AsRefusal(err); ok && refusal.Code == CodeSourceUnverifiable {
+			return err
+		}
+		return refuse(CodeSourceChanged, true, err)
+	}
+	closeErr := reopened.Close()
+	if !sameStat(projectStat, reopenedStat) {
+		return refuse(CodeSourceChanged, true, nil)
+	}
+	if err := checkMountID(reopenedMountID, fs.mountID); err != nil {
+		return err
+	}
+	if closeErr != nil {
+		return refuse(CodeSourceUnverifiable, true, closeErr)
+	}
+	return nil
+}
+
+func (fs sourceFS) entryStillNames(parent *os.File, name string, expected unix.Stat_t) error {
+	var current unix.Stat_t
+	if err := unix.Fstatat(int(parent.Fd()), name, &current, unix.AT_SYMLINK_NOFOLLOW); err != nil {
+		if errors.Is(err, unix.ENOENT) || errors.Is(err, unix.ESTALE) {
+			return refuse(CodeSourceChanged, true, err)
+		}
+		return refuse(CodeSourceUnverifiable, true, err)
+	}
+	if !sameStat(expected, current) {
+		return refuse(CodeSourceChanged, true, nil)
+	}
+	if err := checkDevice(current.Dev, fs.device); err != nil {
+		return err
+	}
+	if err := fs.checkMountAt(int(parent.Fd()), name, unix.AT_SYMLINK_NOFOLLOW); err != nil {
+		return err
+	}
+	return nil
+}
+
+func sameStat(left, right unix.Stat_t) bool {
+	return left.Dev == right.Dev && left.Ino == right.Ino && left.Mode == right.Mode &&
+		left.Nlink == right.Nlink && left.Rdev == right.Rdev && left.Size == right.Size &&
+		left.Mtim == right.Mtim && left.Ctim == right.Ctim
+}
+
+func writeTreeRecord(writer hash.Hash, kind byte, path string, stat unix.Stat_t, contentDigest []byte) {
+	writeField(writer, []byte{kind})
+	writeField(writer, []byte(path))
+	var numeric [16]byte
+	binary.BigEndian.PutUint64(numeric[:8], uint64(stat.Mode&0o7777))
+	if kind == 'f' {
+		binary.BigEndian.PutUint64(numeric[8:], uint64(stat.Size))
+	}
+	writeField(writer, numeric[:])
+	writeField(writer, contentDigest)
+}
+
+func writeStructureRecord(writer hash.Hash, kind byte, path string, stat unix.Stat_t) {
+	writeField(writer, []byte{kind})
+	writeField(writer, []byte(path))
+	values := []uint64{
+		stat.Dev, stat.Ino, uint64(stat.Mode), stat.Nlink, stat.Rdev, uint64(stat.Size),
+		uint64(stat.Mtim.Sec), uint64(stat.Mtim.Nsec), uint64(stat.Ctim.Sec), uint64(stat.Ctim.Nsec),
+	}
+	var numeric [8]byte
+	for _, value := range values {
+		binary.BigEndian.PutUint64(numeric[:], value)
+		writeField(writer, numeric[:])
+	}
+}
+
+func writeField(writer hash.Hash, value []byte) {
+	var size [8]byte
+	binary.BigEndian.PutUint64(size[:], uint64(len(value)))
+	_, _ = writer.Write(size[:])
+	_, _ = writer.Write(value)
+}
+
+func closeForInspection(result *Result, returnErr *error, file *os.File) {
+	if file == nil {
+		return
+	}
+	if err := file.Close(); err != nil {
+		*result = Result{}
+		*returnErr = refuse(CodeSourceUnverifiable, true, err)
+	}
+}

--- a/internal/v062migration/inspect_linux.go
+++ b/internal/v062migration/inspect_linux.go
@@ -33,25 +33,33 @@ const (
 )
 
 var (
-	databaseNamePattern       = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_-]{0,63}$`)
-	projectIDPattern          = regexp.MustCompile(`^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$`)
-	errWitnessOutsideBound    = errors.New("witness outside size bound")
-	errWitnessChanged         = errors.New("witness changed while read")
-	allowedV062MetadataFields = map[string]struct{}{
-		"backend":                  {},
-		"database":                 {},
-		"deletions_retention_days": {},
-		"dolt_data_dir":            {},
-		"dolt_database":            {},
-		"dolt_mode":                {},
-		"dolt_remotesapi_port":     {},
-		"dolt_server_host":         {},
-		"dolt_server_port":         {},
-		"dolt_server_tls":          {},
-		"dolt_server_user":         {},
-		"last_bd_version":          {},
-		"project_id":               {},
-		"stale_closed_issues_days": {},
+	databaseNamePattern    = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_-]{0,63}$`)
+	projectIDPattern       = regexp.MustCompile(`^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$`)
+	errWitnessOutsideBound = errors.New("witness outside size bound")
+	errWitnessChanged      = errors.New("witness changed while read")
+	// allowedV062MetadataFields is both the field allow-list and the exact
+	// scalar contract every allowed field must satisfy. Each validator fails
+	// closed on a non-scalar or wrong-typed value so malformed or non-v0.62
+	// metadata (for example an object where a string belongs) can never be
+	// advertised as a qualified source. Fields whose value is additionally
+	// pinned (backend=="dolt", dolt_data_dir=="") are checked further in
+	// requiredMetadataShape / rejectDisallowedMetadataFields; the validator here
+	// still guarantees the underlying scalar type.
+	allowedV062MetadataFields = map[string]func(json.RawMessage) bool{
+		"backend":                  isJSONString,
+		"database":                 isJSONString,
+		"deletions_retention_days": isNonNegativeJSONInteger,
+		"dolt_data_dir":            isJSONString,
+		"dolt_database":            isJSONString,
+		"dolt_mode":                isJSONString,
+		"dolt_remotesapi_port":     isJSONPort,
+		"dolt_server_host":         isJSONString,
+		"dolt_server_port":         isJSONPort,
+		"dolt_server_tls":          isJSONBool,
+		"dolt_server_user":         isJSONString,
+		"last_bd_version":          isJSONString,
+		"project_id":               isJSONString,
+		"stale_closed_issues_days": isNonNegativeJSONInteger,
 	}
 )
 
@@ -518,12 +526,20 @@ func requiredMetadataShape(values map[string]json.RawMessage) (string, error) {
 }
 
 // rejectDisallowedMetadataFields fails closed on any field outside the allowed
-// v0.62 set, any foreign-provider metadata, and any non-empty custom data dir.
+// v0.62 set, any allowed field whose value is not the exact v0.62 scalar shape,
+// any foreign-provider metadata, and any non-empty custom data dir.
 func rejectDisallowedMetadataFields(values map[string]json.RawMessage) error {
 	for key, raw := range values {
-		if _, allowed := allowedV062MetadataFields[key]; !allowed {
+		validate, allowed := allowedV062MetadataFields[key]
+		if !allowed {
 			return errors.New("unknown v0.62 metadata field")
 		}
+		if !validate(raw) {
+			return errors.New("malformed v0.62 metadata field")
+		}
+		// Deliberate defense-in-depth: the allow-list above admits no key with
+		// these prefixes, so this branch is currently unreachable, but it fails
+		// closed if a future allow-list edit ever adds a foreign-provider field.
 		lower := strings.ToLower(key)
 		if strings.HasPrefix(lower, "postgres") || strings.HasPrefix(lower, "mysql") ||
 			strings.HasPrefix(lower, "sqlite") || strings.HasPrefix(lower, "proxied") {
@@ -590,8 +606,36 @@ func requiredInteger(values map[string]json.RawMessage, key string) (int64, bool
 	if !ok {
 		return 0, false
 	}
+	return parseJSONInteger(raw)
+}
+
+func parseJSONInteger(raw json.RawMessage) (int64, bool) {
 	value, err := strconv.ParseInt(string(raw), 10, 64)
 	return value, err == nil
+}
+
+// isJSONString, isJSONBool, isNonNegativeJSONInteger, and isJSONPort are the
+// per-field scalar validators referenced by allowedV062MetadataFields. Each
+// rejects any value that is not exactly the required v0.62 scalar type, closing
+// the gap where a malformed optional field could be advertised as qualified.
+func isJSONString(raw json.RawMessage) bool {
+	var value string
+	return json.Unmarshal(raw, &value) == nil
+}
+
+func isJSONBool(raw json.RawMessage) bool {
+	var value bool
+	return json.Unmarshal(raw, &value) == nil
+}
+
+func isNonNegativeJSONInteger(raw json.RawMessage) bool {
+	value, ok := parseJSONInteger(raw)
+	return ok && value >= 0
+}
+
+func isJSONPort(raw json.RawMessage) bool {
+	value, ok := parseJSONInteger(raw)
+	return ok && value >= 1 && value <= 65535
 }
 
 func (fs sourceFS) inspectTree(root *os.File, rootStat unix.Stat_t, includeContent bool) (treeSnapshot, error) {

--- a/internal/v062migration/inspect_linux_nocgo_test.go
+++ b/internal/v062migration/inspect_linux_nocgo_test.go
@@ -1,0 +1,16 @@
+//go:build linux && !cgo
+
+package v062migration
+
+import "testing"
+
+func TestInspectWithoutCGORefusesBeforeSourceAccess(t *testing.T) {
+	_, err := Inspect("/definitely/not/a/source", "1.1.0")
+	refusal, ok := AsRefusal(err)
+	if !ok {
+		t.Fatalf("Inspect() error = %T %v, want Refusal", err, err)
+	}
+	if refusal.Code != CodeEmbeddedTargetUnavailable || refusal.Retryable || refusal.Effect != EffectNone {
+		t.Fatalf("refusal = %#v", refusal)
+	}
+}

--- a/internal/v062migration/inspect_linux_test.go
+++ b/internal/v062migration/inspect_linux_test.go
@@ -1,0 +1,822 @@
+//go:build linux && cgo
+
+package v062migration
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+func TestInspectQualifiesExactV062ServerTreeWithoutMutation(t *testing.T) {
+	project := newV062Project(t)
+	before := snapshotTree(t, project)
+
+	result, err := Inspect(project, "1.1.0")
+	if err != nil {
+		t.Fatalf("Inspect() error = %v", err)
+	}
+	if result.SchemaVersion != 1 || result.Operation != Operation || result.Status != StatusQualified {
+		t.Fatalf("unexpected envelope: %#v", result)
+	}
+	if result.Retryable || result.Effect != EffectNone {
+		t.Fatalf("qualified retryable/effect = %v/%q", result.Retryable, result.Effect)
+	}
+	if result.Source.Workspace != project || result.Source.Version != "0.62.0" || result.Source.Backend != "dolt-server" {
+		t.Fatalf("unexpected source: %#v", result.Source)
+	}
+	if result.Source.DigestScope != DigestScopeAdmissionObservation {
+		t.Fatalf("digest scope = %q, want %q", result.Source.DigestScope, DigestScopeAdmissionObservation)
+	}
+	if len(result.Source.TreeSHA256) != 64 {
+		t.Fatalf("tree digest = %q", result.Source.TreeSHA256)
+	}
+	if result.Target.Version != "1.1.0" || result.Target.Backend != "dolt-embedded" || !result.Target.EmbeddedCapable {
+		t.Fatalf("unexpected target: %#v", result.Target)
+	}
+	if after := snapshotTree(t, project); after != before {
+		t.Fatalf("inspection mutated source tree\nbefore: %s\nafter:  %s", before, after)
+	}
+}
+
+func TestInspectAdmitsAuthenticV062DoltAncillaryLayout(t *testing.T) {
+	project := newV062Project(t)
+	for _, dir := range []string{
+		filepath.Join(project, ".beads", "dolt", ".doltcfg"),
+		filepath.Join(project, ".beads", "dolt", ".dolt", "stats", ".dolt"),
+		filepath.Join(project, ".beads", "dolt", "smoke", ".dolt", "stats", ".dolt"),
+	} {
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for path, content := range map[string]string{
+		filepath.Join(project, ".beads", ".gitignore"):                                              "dolt/\n*.db\n",
+		filepath.Join(project, ".beads", ".beads-credential-key"):                                   "fixture-key\n",
+		filepath.Join(project, ".beads", "config.yaml"):                                             "dolt:\n  auto-start: true\n",
+		filepath.Join(project, ".beads", "dolt-server.port"):                                        "3307\n",
+		filepath.Join(project, ".beads", "ephemeral.sqlite3"):                                       "known v0.62 ephemeral store\n",
+		filepath.Join(project, ".beads", "interactions.jsonl"):                                      "",
+		filepath.Join(project, ".beads", "last-touched"):                                            "0\n",
+		filepath.Join(project, ".beads", "dolt", ".doltcfg", "privileges.db"):                       "dolt-owned ancillary database\n",
+		filepath.Join(project, ".beads", "dolt", ".dolt", "stats", ".dolt", "config.json"):          "{}\n",
+		filepath.Join(project, ".beads", "dolt", ".dolt", "stats", ".dolt", "repo_state.json"):      "{\"head\":\"refs/heads/main\"}\n",
+		filepath.Join(project, ".beads", "dolt", "smoke", ".dolt", "stats", ".dolt", "config.json"): "{}\n",
+	} {
+		mustWrite(t, path, content)
+	}
+
+	if _, err := Inspect(project, "1.1.0"); err != nil {
+		t.Fatalf("Inspect() rejected authentic v0.62 ancillary layout: %v", err)
+	}
+}
+
+func TestInspectAdmitsDefaultV062MetadataWithoutPersistedServerEndpoint(t *testing.T) {
+	project := newV062Project(t)
+	mustWrite(t, filepath.Join(project, ".beads", "metadata.json"), `{
+  "database": "dolt",
+  "backend": "dolt",
+  "dolt_mode": "server",
+  "dolt_database": "smoke",
+  "project_id": "7ef372b4-4c3c-4e2c-a6cc-29dd2d0a28c6"
+}
+`)
+	before := snapshotTree(t, project)
+
+	if _, err := Inspect(project, "1.1.0"); err != nil {
+		t.Fatalf("Inspect() rejected default v0.62 metadata: %v", err)
+	}
+	if after := snapshotTree(t, project); after != before {
+		t.Fatalf("inspection mutated source tree\nbefore: %s\nafter:  %s", before, after)
+	}
+}
+
+func TestInspectTreeDigestChangesWithRegularFileContent(t *testing.T) {
+	first := newV062Project(t)
+	second := newV062Project(t)
+	if err := os.WriteFile(filepath.Join(second, ".beads", "dolt", "smoke", ".dolt", "repo_state.json"), []byte("{\"head\":\"other\"}\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	left, err := Inspect(first, "1.1.0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	right, err := Inspect(second, "1.1.0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if left.Source.TreeSHA256 == right.Source.TreeSHA256 {
+		t.Fatalf("different trees produced digest %q", left.Source.TreeSHA256)
+	}
+}
+
+func TestInspectTreeDigestIsStableAcrossRepeatedAndEquivalentTrees(t *testing.T) {
+	first := newV062Project(t)
+	second := newV062Project(t)
+
+	firstResult, err := Inspect(first, "1.1.0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	repeatedResult, err := Inspect(first, "1.1.0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	secondResult, err := Inspect(second, "1.1.0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if firstResult.Source.TreeSHA256 != repeatedResult.Source.TreeSHA256 {
+		t.Fatalf("repeated inspection changed digest: %q != %q", firstResult.Source.TreeSHA256, repeatedResult.Source.TreeSHA256)
+	}
+	if firstResult.Source.TreeSHA256 != secondResult.Source.TreeSHA256 {
+		t.Fatalf("equivalent trees changed digest: %q != %q", firstResult.Source.TreeSHA256, secondResult.Source.TreeSHA256)
+	}
+}
+
+func TestInspectRefusesUnsafeAndMixedSourceShapes(t *testing.T) {
+	tests := []struct {
+		name string
+		want Code
+		edit func(*testing.T, string)
+	}{
+		{
+			name: "version missing",
+			want: CodeSourceVersionMissing,
+			edit: func(t *testing.T, project string) {
+				t.Helper()
+				if err := os.Remove(filepath.Join(project, ".beads", ".local_version")); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			name: "version mismatch",
+			want: CodeSourceVersionMismatch,
+			edit: func(t *testing.T, project string) {
+				t.Helper()
+				mustWrite(t, filepath.Join(project, ".beads", ".local_version"), "0.61.0\n")
+			},
+		},
+		{
+			name: "version symlink",
+			want: CodeSourceVersionAmbiguous,
+			edit: func(t *testing.T, project string) {
+				t.Helper()
+				version := filepath.Join(project, ".beads", ".local_version")
+				if err := os.Rename(version, version+".real"); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.Symlink(".local_version.real", version); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			name: "version fifo is an unsafe object, not an ambiguous symlink",
+			want: CodeUnsafeSourceObject,
+			edit: func(t *testing.T, project string) {
+				t.Helper()
+				version := filepath.Join(project, ".beads", ".local_version")
+				if err := os.Remove(version); err != nil {
+					t.Fatal(err)
+				}
+				if err := unix.Mkfifo(version, 0o600); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			name: "metadata mismatch",
+			want: CodeSourceMetadataMismatch,
+			edit: func(t *testing.T, project string) {
+				t.Helper()
+				setV062MetadataField(t, project, "backend", "postgres")
+			},
+		},
+		{
+			name: "current global Dolt database selector",
+			want: CodeSourceMetadataMismatch,
+			edit: func(t *testing.T, project string) {
+				t.Helper()
+				setV062MetadataField(t, project, "global_dolt_database", "other")
+			},
+		},
+		{
+			name: "current global project selector",
+			want: CodeSourceMetadataMismatch,
+			edit: func(t *testing.T, project string) {
+				t.Helper()
+				setV062MetadataField(t, project, "global_project_id", "other")
+			},
+		},
+		{
+			name: "metadata symlink",
+			want: CodeUnsafeSourceSymlink,
+			edit: func(t *testing.T, project string) {
+				t.Helper()
+				metadata := filepath.Join(project, ".beads", "metadata.json")
+				if err := os.Rename(metadata, metadata+".real"); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.Symlink("metadata.json.real", metadata); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			name: "metadata fifo is an unsafe object, not a symlink",
+			want: CodeUnsafeSourceObject,
+			edit: func(t *testing.T, project string) {
+				t.Helper()
+				metadata := filepath.Join(project, ".beads", "metadata.json")
+				if err := os.Remove(metadata); err != nil {
+					t.Fatal(err)
+				}
+				if err := unix.Mkfifo(metadata, 0o600); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			name: "symlinked dolt root",
+			want: CodeUnsafeSourceSymlink,
+			edit: func(t *testing.T, project string) {
+				t.Helper()
+				dolt := filepath.Join(project, ".beads", "dolt")
+				if err := os.Rename(dolt, dolt+".real"); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.Symlink("dolt.real", dolt); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			name: "mixed provider",
+			want: CodeMixedStorageLayout,
+			edit: func(t *testing.T, project string) {
+				t.Helper()
+				if err := os.Mkdir(filepath.Join(project, ".beads", "embeddeddolt"), 0o700); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			name: "arbitrary root db artifact",
+			want: CodeMixedStorageLayout,
+			edit: func(t *testing.T, project string) {
+				t.Helper()
+				mustWrite(t, filepath.Join(project, ".beads", "unrecognized.DB"), "sqlite-like bytes")
+			},
+		},
+		{
+			name: "arbitrary root sqlite artifact",
+			want: CodeMixedStorageLayout,
+			edit: func(t *testing.T, project string) {
+				t.Helper()
+				mustWrite(t, filepath.Join(project, ".beads", "unrecognized.sqlite3"), "sqlite-like bytes")
+			},
+		},
+		{
+			name: "unexpected additional dolt database root",
+			want: CodeMixedStorageLayout,
+			edit: func(t *testing.T, project string) {
+				t.Helper()
+				other := filepath.Join(project, ".beads", "dolt", "other", ".dolt")
+				if err := os.MkdirAll(other, 0o700); err != nil {
+					t.Fatal(err)
+				}
+				mustWrite(t, filepath.Join(other, "config.json"), "{}\n")
+				mustWrite(t, filepath.Join(other, "repo_state.json"), "{\"head\":\"refs/heads/main\"}\n")
+			},
+		},
+		{
+			name: "rollback collision",
+			want: CodeRollbackCollision,
+			edit: func(t *testing.T, project string) {
+				t.Helper()
+				if err := os.Mkdir(filepath.Join(project, ".beads-v0.62.0-rollback"), 0o700); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			name: "hard link",
+			want: CodeUnsafeSourceHardlink,
+			edit: func(t *testing.T, project string) {
+				t.Helper()
+				source := filepath.Join(project, ".beads", "dolt", "config.yaml")
+				if err := os.Link(source, filepath.Join(project, ".beads", "hardlink")); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			name: "fifo",
+			want: CodeUnsafeSourceObject,
+			edit: func(t *testing.T, project string) {
+				t.Helper()
+				if err := unix.Mkfifo(filepath.Join(project, ".beads", "pipe"), 0o600); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			project := newV062Project(t)
+			tt.edit(t, project)
+			before := snapshotTree(t, project)
+			_, err := Inspect(project, "1.1.0")
+			assertRefusalCode(t, err, tt.want)
+			if after := snapshotTree(t, project); after != before {
+				t.Fatalf("refusal mutated source tree")
+			}
+		})
+	}
+}
+
+func TestInspectRefusesMissingRequiredLayoutEntries(t *testing.T) {
+	// The required-layout gate is one of the two central admission decisions.
+	// Deleting any required layout entry must fail closed with a stable
+	// source_layout_missing code, never admit a partial Dolt-server tree.
+	tests := []struct {
+		name   string
+		remove string
+		want   Code
+	}{
+		{"beads directory", ".beads", CodeSourceLayoutMissing},
+		{"dolt root", ".beads/dolt", CodeSourceLayoutMissing},
+		{"dolt config", ".beads/dolt/config.yaml", CodeSourceLayoutMissing},
+		{"server dolt directory", ".beads/dolt/.dolt", CodeSourceLayoutMissing},
+		{"server config", ".beads/dolt/.dolt/config.json", CodeSourceLayoutMissing},
+		{"server repo state", ".beads/dolt/.dolt/repo_state.json", CodeSourceLayoutMissing},
+		{"database dolt directory", ".beads/dolt/smoke/.dolt", CodeSourceLayoutMissing},
+		{"database config", ".beads/dolt/smoke/.dolt/config.json", CodeSourceLayoutMissing},
+		{"database repo state", ".beads/dolt/smoke/.dolt/repo_state.json", CodeSourceLayoutMissing},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			project := newV062Project(t)
+			if err := os.RemoveAll(filepath.Join(project, filepath.FromSlash(tt.remove))); err != nil {
+				t.Fatal(err)
+			}
+			before := snapshotTree(t, project)
+			_, err := Inspect(project, "1.1.0")
+			assertRefusalCode(t, err, tt.want)
+			if after := snapshotTree(t, project); after != before {
+				t.Fatalf("refusal mutated source tree")
+			}
+		})
+	}
+}
+
+func TestInspectRefusesMissingMetadata(t *testing.T) {
+	project := newV062Project(t)
+	if err := os.Remove(filepath.Join(project, ".beads", "metadata.json")); err != nil {
+		t.Fatal(err)
+	}
+	before := snapshotTree(t, project)
+	_, err := Inspect(project, "1.1.0")
+	assertRefusalCode(t, err, CodeSourceMetadataMissing)
+	if after := snapshotTree(t, project); after != before {
+		t.Fatalf("refusal mutated source tree")
+	}
+}
+
+func TestInspectRefusesMalformedV062Metadata(t *testing.T) {
+	// parseMetadata is the second central admission gate. Every rejected field,
+	// pattern, and JSON-shape branch must collapse to a non-retryable
+	// source_metadata_mismatch rather than admit a foreign or ambiguous source.
+	tests := []struct {
+		name string
+		edit func(*testing.T, string)
+	}{
+		{
+			name: "backend not dolt",
+			edit: func(t *testing.T, project string) { setV062MetadataField(t, project, "backend", "sqlite") },
+		},
+		{
+			name: "database not dolt",
+			edit: func(t *testing.T, project string) { setV062MetadataField(t, project, "database", "sqlite") },
+		},
+		{
+			name: "dolt mode not server",
+			edit: func(t *testing.T, project string) { setV062MetadataField(t, project, "dolt_mode", "embedded") },
+		},
+		{
+			name: "non-loopback server host",
+			edit: func(t *testing.T, project string) { setV062MetadataField(t, project, "dolt_server_host", "10.0.0.5") },
+		},
+		{
+			name: "invalid dolt database name",
+			edit: func(t *testing.T, project string) { setV062MetadataField(t, project, "dolt_database", "smoke;drop") },
+		},
+		{
+			name: "non-uuid project id",
+			edit: func(t *testing.T, project string) { setV062MetadataField(t, project, "project_id", "not-a-uuid") },
+		},
+		{
+			name: "server port below range",
+			edit: func(t *testing.T, project string) { setV062MetadataField(t, project, "dolt_server_port", 0) },
+		},
+		{
+			name: "server port above range",
+			edit: func(t *testing.T, project string) { setV062MetadataField(t, project, "dolt_server_port", 70000) },
+		},
+		{
+			name: "non-empty custom data dir",
+			edit: func(t *testing.T, project string) { setV062MetadataField(t, project, "dolt_data_dir", "/srv/dolt") },
+		},
+		{
+			name: "unknown metadata field",
+			edit: func(t *testing.T, project string) { setV062MetadataField(t, project, "shared_server", "true") },
+		},
+		{
+			name: "duplicate metadata key",
+			edit: func(t *testing.T, project string) {
+				mustWrite(t, filepath.Join(project, ".beads", "metadata.json"),
+					`{"backend":"dolt","backend":"dolt","database":"dolt","dolt_mode":"server","dolt_database":"smoke","project_id":"7ef372b4-4c3c-4e2c-a6cc-29dd2d0a28c6"}`)
+			},
+		},
+		{
+			name: "trailing content after object",
+			edit: func(t *testing.T, project string) {
+				mustWrite(t, filepath.Join(project, ".beads", "metadata.json"),
+					`{"backend":"dolt","database":"dolt","dolt_mode":"server","dolt_database":"smoke","project_id":"7ef372b4-4c3c-4e2c-a6cc-29dd2d0a28c6"}{}`)
+			},
+		},
+		{
+			name: "not a json object",
+			edit: func(t *testing.T, project string) {
+				mustWrite(t, filepath.Join(project, ".beads", "metadata.json"), `["dolt"]`)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			project := newV062Project(t)
+			tt.edit(t, project)
+			before := snapshotTree(t, project)
+			_, err := Inspect(project, "1.1.0")
+			assertRefusalCode(t, err, CodeSourceMetadataMismatch)
+			if after := snapshotTree(t, project); after != before {
+				t.Fatalf("refusal mutated source tree")
+			}
+		})
+	}
+}
+
+func TestInspectClassifiesStableOversizedWitnessesAsNonRetryableMismatch(t *testing.T) {
+	tests := []struct {
+		name    string
+		path    string
+		content string
+		want    Code
+	}{
+		{
+			name:    "version",
+			path:    ".local_version",
+			content: strings.Repeat("0", maxVersionBytes+1),
+			want:    CodeSourceVersionMismatch,
+		},
+		{
+			name:    "metadata",
+			path:    "metadata.json",
+			content: strings.Repeat("{", maxMetadataBytes+1),
+			want:    CodeSourceMetadataMismatch,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			project := newV062Project(t)
+			mustWrite(t, filepath.Join(project, ".beads", tt.path), tt.content)
+			_, err := Inspect(project, "1.1.0")
+			refusal, ok := AsRefusal(err)
+			if !ok {
+				t.Fatalf("Inspect() error = %T %v, want Refusal", err, err)
+			}
+			if refusal.Code != tt.want || refusal.Retryable || refusal.Effect != EffectNone {
+				t.Fatalf("refusal = %#v, want code %q/nonretryable/effect none", refusal, tt.want)
+			}
+		})
+	}
+}
+
+func TestWitnessReadFailureClassificationDistinguishesDriftFromUnverifiableIO(t *testing.T) {
+	changed, ok := AsRefusal(classifyWitnessReadFailure(errWitnessChanged))
+	if !ok || changed.Code != CodeSourceChanged || !changed.Retryable || changed.Effect != EffectNone {
+		t.Fatalf("changed witness classified as %#v", changed)
+	}
+	unverifiable, ok := AsRefusal(classifyWitnessReadFailure(unix.EIO))
+	if !ok || unverifiable.Code != CodeSourceUnverifiable || !unverifiable.Retryable || unverifiable.Effect != EffectNone {
+		t.Fatalf("witness I/O failure classified as %#v", unverifiable)
+	}
+}
+
+func TestInspectRequiresAbsoluteCanonicalProject(t *testing.T) {
+	project := newV062Project(t)
+	_, err := Inspect(project+string(os.PathSeparator)+".", "1.1.0")
+	assertRefusalCode(t, err, CodeWorkspaceNotCanonical)
+
+	_, err = Inspect("relative/project", "1.1.0")
+	assertRefusalCode(t, err, CodeWorkspaceInvalid)
+}
+
+func TestInspectRefusesInjectedCrossDeviceObservation(t *testing.T) {
+	err := checkDevice(2, 1)
+	assertRefusalCode(t, err, CodeCrossDeviceSource)
+}
+
+func TestInspectRefusesDifferentNamedAndOpenedMountIdentityInsideTree(t *testing.T) {
+	tests := []struct {
+		name   string
+		target func(int, string) bool
+	}{
+		{
+			name: "named entry",
+			target: func(dirfd int, path string) bool {
+				return path == "repo_state.json" && descriptorPathHasSuffix(dirfd, "/dolt/smoke/.dolt")
+			},
+		},
+		{
+			name: "opened descriptor after safe named lookup",
+			target: func(dirfd int, path string) bool {
+				return path == "" && descriptorPathHasSuffix(dirfd, "/dolt/smoke/.dolt/repo_state.json")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			project := newV062Project(t)
+			injected := false
+			_, err := inspectWithHooks(project, "1.1.0", inspectHooks{
+				mountIDAt: func(dirfd int, path string, flags int) (uint64, error) {
+					mountID, readErr := readMountIDAt(dirfd, path, flags)
+					if readErr != nil {
+						return 0, readErr
+					}
+					if tt.target(dirfd, path) {
+						injected = true
+						return mountID + 1, nil
+					}
+					return mountID, nil
+				},
+			})
+			if !injected {
+				t.Fatal("mount identity seam did not observe the nested Dolt witness")
+			}
+			assertRefusalCode(t, err, CodeCrossDeviceSource)
+		})
+	}
+}
+
+func TestInspectFailsClosedWhenMountIdentityCannotBeRead(t *testing.T) {
+	project := newV062Project(t)
+	injected := false
+	_, err := inspectWithHooks(project, "1.1.0", inspectHooks{
+		mountIDAt: func(dirfd int, path string, flags int) (uint64, error) {
+			if path == "config.yaml" && descriptorPathHasSuffix(dirfd, "/.beads/dolt") {
+				injected = true
+				return 0, unix.ENOSYS
+			}
+			return readMountIDAt(dirfd, path, flags)
+		},
+	})
+	if !injected {
+		t.Fatal("mount identity seam did not observe the nested config")
+	}
+	refusal, ok := AsRefusal(err)
+	if !ok || refusal.Code != CodeSourceUnverifiable || !refusal.Retryable || refusal.Effect != EffectNone {
+		t.Fatalf("refusal = %#v (%v), want source_unverifiable/retryable/effect none", refusal, err)
+	}
+}
+
+func TestProjectNoAtimePermissionFailureIsUnverifiableWithoutRetryOpen(t *testing.T) {
+	for _, openErr := range []error{unix.EPERM, unix.EACCES} {
+		attempts := 0
+		_, _, _, err := openProjectWith("/absolute/project", readMountIDAt, func(_ string, flags int, _ uint32) (int, error) {
+			attempts++
+			if flags&unix.O_NOATIME == 0 {
+				t.Fatalf("open flags %#x omitted O_NOATIME", flags)
+			}
+			return -1, openErr
+		})
+		if attempts != 1 {
+			t.Fatalf("open attempts = %d, want exactly one O_NOATIME attempt", attempts)
+		}
+		refusal, ok := AsRefusal(err)
+		if !ok || refusal.Code != CodeSourceUnverifiable || !refusal.Retryable || refusal.Effect != EffectNone {
+			t.Fatalf("open error %v classified as %#v (%v)", openErr, refusal, err)
+		}
+	}
+}
+
+func TestAdmissionObservationsCompareBothStructureAndContent(t *testing.T) {
+	first := treeSnapshot{treeSHA256: "first-content", structureSHA256: "same-structure"}
+	second := treeSnapshot{treeSHA256: "second-content", structureSHA256: "same-structure"}
+	if sameAdmissionObservation(first, second) {
+		t.Fatal("equal structure with different content digest was accepted")
+	}
+	second.treeSHA256 = first.treeSHA256
+	if !sameAdmissionObservation(first, second) {
+		t.Fatal("identical admission observations were rejected")
+	}
+}
+
+func TestInspectRefusesDeterministicRevalidationDrift(t *testing.T) {
+	project := newV062Project(t)
+	changed := filepath.Join(project, ".beads", "dolt", "smoke", ".dolt", "repo_state.json")
+	result, err := inspectWithHooks(project, "1.1.0", inspectHooks{
+		afterFirstTree: func() {
+			if writeErr := os.WriteFile(changed, []byte("{\"head\":\"changed\"}\n"), 0o600); writeErr != nil {
+				t.Fatalf("inject drift: %v", writeErr)
+			}
+		},
+	})
+	if result.Status != "" {
+		t.Fatalf("drift returned result %#v", result)
+	}
+	assertRefusalCode(t, err, CodeSourceChanged)
+}
+
+func TestInspectReleasesDescriptorsOnSuccessAndRefusal(t *testing.T) {
+	project := newV062Project(t)
+	before := openDescriptorCount(t)
+	for range 20 {
+		if _, err := Inspect(project, "1.1.0"); err != nil {
+			t.Fatalf("qualified Inspect() error = %v", err)
+		}
+	}
+	mustWrite(t, filepath.Join(project, ".beads", ".local_version"), "0.61.0\n")
+	for range 20 {
+		_, err := Inspect(project, "1.1.0")
+		assertRefusalCode(t, err, CodeSourceVersionMismatch)
+	}
+	if after := openDescriptorCount(t); after != before {
+		t.Fatalf("descriptor count changed from %d to %d", before, after)
+	}
+}
+
+func TestWSLReleaseDetection(t *testing.T) {
+	for _, release := range []string{"5.15.90.1-microsoft-standard-WSL2", "4.4.0-Microsoft", "6.1.0-wsl"} {
+		if !isWSLRelease(release) {
+			t.Errorf("isWSLRelease(%q) = false", release)
+		}
+	}
+	if isWSLRelease("6.8.0-1018-azure") {
+		t.Fatal("native Linux release classified as WSL")
+	}
+}
+
+func assertRefusalCode(t *testing.T, err error, want Code) {
+	t.Helper()
+	refusal, ok := AsRefusal(err)
+	if !ok {
+		t.Fatalf("error %T %v is not a Refusal", err, err)
+	}
+	if refusal.Code != want || refusal.Effect != EffectNone {
+		t.Fatalf("refusal = %#v, want code %q/effect none", refusal, want)
+	}
+}
+
+func newV062Project(t *testing.T) string {
+	t.Helper()
+	project := filepath.Join(t.TempDir(), "project")
+	for _, dir := range []string{
+		filepath.Join(project, ".beads", "dolt", ".dolt"),
+		filepath.Join(project, ".beads", "dolt", "smoke", ".dolt"),
+	} {
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	mustWrite(t, filepath.Join(project, ".beads", ".local_version"), "0.62.0\n")
+	mustWrite(t, filepath.Join(project, ".beads", "metadata.json"), `{
+  "database": "dolt",
+  "backend": "dolt",
+  "dolt_mode": "server",
+  "dolt_server_host": "127.0.0.1",
+  "dolt_server_port": 3307,
+  "dolt_database": "smoke",
+  "project_id": "7ef372b4-4c3c-4e2c-a6cc-29dd2d0a28c6"
+}
+`)
+	mustWrite(t, filepath.Join(project, ".beads", "dolt", "config.yaml"), "listener:\n  host: 127.0.0.1\n  port: 3307\n")
+	mustWrite(t, filepath.Join(project, ".beads", "dolt", ".dolt", "config.json"), "{}\n")
+	mustWrite(t, filepath.Join(project, ".beads", "dolt", ".dolt", "repo_state.json"), "{\"head\":\"refs/heads/main\"}\n")
+	mustWrite(t, filepath.Join(project, ".beads", "dolt", "smoke", ".dolt", "config.json"), "{}\n")
+	mustWrite(t, filepath.Join(project, ".beads", "dolt", "smoke", ".dolt", "repo_state.json"), "{\"head\":\"refs/heads/main\"}\n")
+	return project
+}
+
+func mustWrite(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func setV062MetadataField(t *testing.T, project, key string, fieldValue any) {
+	t.Helper()
+	metadata := filepath.Join(project, ".beads", "metadata.json")
+	var value map[string]any
+	data, err := os.ReadFile(metadata)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(data, &value); err != nil {
+		t.Fatal(err)
+	}
+	value[key] = fieldValue
+	updated, err := json.Marshal(value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(metadata, updated, 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func snapshotTree(t *testing.T, root string) string {
+	t.Helper()
+	var records []string
+	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		record := rel + "|" + info.Mode().String() + "|" + info.ModTime().UTC().String()
+		if info.Mode().IsRegular() {
+			stat, ok := info.Sys().(*syscall.Stat_t)
+			if !ok {
+				return errors.New("file stat is not syscall.Stat_t")
+			}
+			record += "|atime=" + strconv.FormatInt(stat.Atim.Sec, 10) + "." + strconv.FormatInt(stat.Atim.Nsec, 10)
+			fd, err := unix.Open(path, unix.O_RDONLY|unix.O_CLOEXEC|unix.O_NOFOLLOW|unix.O_NOATIME, 0)
+			if err != nil {
+				return err
+			}
+			file := os.NewFile(uintptr(fd), path)
+			if file == nil {
+				_ = unix.Close(fd)
+				return errors.New("could not wrap snapshot descriptor")
+			}
+			data, readErr := io.ReadAll(file)
+			closeErr := file.Close()
+			if readErr != nil {
+				return readErr
+			}
+			if closeErr != nil {
+				return closeErr
+			}
+			record += "|" + string(data)
+		} else if info.Mode()&os.ModeSymlink != 0 {
+			target, err := os.Readlink(path)
+			if err != nil {
+				return err
+			}
+			record += "|" + target
+		}
+		records = append(records, record)
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	sort.Strings(records)
+	return strings.Join(records, "\n")
+}
+
+func openDescriptorCount(t *testing.T) int {
+	t.Helper()
+	entries, err := os.ReadDir("/proc/self/fd")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return len(entries)
+}
+
+func descriptorPathHasSuffix(fd int, suffix string) bool {
+	path, err := os.Readlink("/proc/self/fd/" + strconv.Itoa(fd))
+	return err == nil && strings.HasSuffix(path, suffix)
+}

--- a/internal/v062migration/inspect_linux_test.go
+++ b/internal/v062migration/inspect_linux_test.go
@@ -100,6 +100,38 @@ func TestInspectAdmitsDefaultV062MetadataWithoutPersistedServerEndpoint(t *testi
 	}
 }
 
+func TestInspectAdmitsWellFormedOptionalV062Metadata(t *testing.T) {
+	// The allow-listed optional fields (retention days, remotesapi port, server
+	// user/tls, last_bd_version) are legitimately present in real v0.62 server
+	// metadata. Enforcing their scalar contract must reject malformed values
+	// without false-refusing the correctly typed ones.
+	project := newV062Project(t)
+	mustWrite(t, filepath.Join(project, ".beads", "metadata.json"), `{
+  "database": "dolt",
+  "backend": "dolt",
+  "dolt_mode": "server",
+  "dolt_server_host": "127.0.0.1",
+  "dolt_server_port": 3307,
+  "dolt_server_user": "root",
+  "dolt_server_tls": false,
+  "dolt_remotesapi_port": 8080,
+  "deletions_retention_days": 3,
+  "stale_closed_issues_days": 30,
+  "last_bd_version": "0.62.0",
+  "dolt_database": "smoke",
+  "project_id": "7ef372b4-4c3c-4e2c-a6cc-29dd2d0a28c6"
+}
+`)
+	before := snapshotTree(t, project)
+
+	if _, err := Inspect(project, "1.1.0"); err != nil {
+		t.Fatalf("Inspect() rejected well-formed optional v0.62 metadata: %v", err)
+	}
+	if after := snapshotTree(t, project); after != before {
+		t.Fatalf("inspection mutated source tree\nbefore: %s\nafter:  %s", before, after)
+	}
+}
+
 func TestInspectTreeDigestChangesWithRegularFileContent(t *testing.T) {
 	first := newV062Project(t)
 	second := newV062Project(t)
@@ -440,6 +472,50 @@ func TestInspectRefusesMalformedV062Metadata(t *testing.T) {
 		{
 			name: "non-empty custom data dir",
 			edit: func(t *testing.T, project string) { setV062MetadataField(t, project, "dolt_data_dir", "/srv/dolt") },
+		},
+		{
+			name: "object last_bd_version",
+			edit: func(t *testing.T, project string) {
+				setV062MetadataField(t, project, "last_bd_version", map[string]any{"not": "a v0.62 scalar"})
+			},
+		},
+		{
+			name: "array last_bd_version",
+			edit: func(t *testing.T, project string) {
+				setV062MetadataField(t, project, "last_bd_version", []any{"0.62.0"})
+			},
+		},
+		{
+			name: "non-string dolt server user",
+			edit: func(t *testing.T, project string) { setV062MetadataField(t, project, "dolt_server_user", 5) },
+		},
+		{
+			name: "non-boolean dolt server tls",
+			edit: func(t *testing.T, project string) { setV062MetadataField(t, project, "dolt_server_tls", "yes") },
+		},
+		{
+			name: "negative deletions retention days",
+			edit: func(t *testing.T, project string) { setV062MetadataField(t, project, "deletions_retention_days", -1) },
+		},
+		{
+			name: "non-integer deletions retention days",
+			edit: func(t *testing.T, project string) {
+				setV062MetadataField(t, project, "deletions_retention_days", "thirty")
+			},
+		},
+		{
+			name: "object stale closed issues days",
+			edit: func(t *testing.T, project string) {
+				setV062MetadataField(t, project, "stale_closed_issues_days", map[string]any{})
+			},
+		},
+		{
+			name: "out-of-range remotesapi port",
+			edit: func(t *testing.T, project string) { setV062MetadataField(t, project, "dolt_remotesapi_port", 70000) },
+		},
+		{
+			name: "non-integer remotesapi port",
+			edit: func(t *testing.T, project string) { setV062MetadataField(t, project, "dolt_remotesapi_port", "8080") },
 		},
 		{
 			name: "unknown metadata field",

--- a/internal/v062migration/inspect_unsupported.go
+++ b/internal/v062migration/inspect_unsupported.go
@@ -1,0 +1,9 @@
+//go:build !linux
+
+package v062migration
+
+// Inspect fails before touching the source on platforms outside the single
+// qualified Linux/amd64 migration environment.
+func Inspect(_ string, _ string) (Result, error) {
+	return Result{}, refuse(CodePlatformUnsupported, false, nil)
+}

--- a/internal/v062migration/types.go
+++ b/internal/v062migration/types.go
@@ -1,0 +1,148 @@
+// Package v062migration performs the private, read-only admission inspection
+// used by the v0.62.0 server-to-embedded migration bridge.
+package v062migration
+
+import "errors"
+
+const (
+	SchemaVersion = 1
+	Operation     = "v062_source_inspection"
+	EffectNone    = "none"
+
+	// DigestScopeAdmissionObservation means the digest describes the two
+	// consecutive descriptor-bound reads performed by admission. It is not a
+	// lifetime lease on the source. Any future effectful apply must rebind and
+	// reinspect the source while holding its own operation fence.
+	DigestScopeAdmissionObservation = "admission_observation"
+
+	StatusQualified  = "qualified"
+	StatusRefused    = "refused"
+	StatusUsageError = "usage_error"
+)
+
+// Code is a stable machine-readable admission outcome.
+type Code string
+
+const (
+	CodeInvalidUsage              Code = "invalid_usage"
+	CodePlatformUnsupported       Code = "platform_unsupported"
+	CodeEmbeddedTargetUnavailable Code = "embedded_target_unavailable"
+	CodeWorkspaceInvalid          Code = "workspace_invalid"
+	CodeWorkspaceNotCanonical     Code = "workspace_not_canonical"
+	CodeSourceVersionMissing      Code = "source_version_missing"
+	CodeSourceVersionMismatch     Code = "source_version_mismatch"
+	CodeSourceVersionAmbiguous    Code = "source_version_ambiguous"
+	CodeSourceMetadataMissing     Code = "source_metadata_missing"
+	CodeSourceMetadataMismatch    Code = "source_metadata_mismatch"
+	CodeSourceLayoutMissing       Code = "source_layout_missing"
+	CodeUnsafeSourceSymlink       Code = "unsafe_source_symlink"
+	CodeUnsafeSourceHardlink      Code = "unsafe_source_hardlink"
+	CodeUnsafeSourceObject        Code = "unsafe_source_object"
+	CodeCrossDeviceSource         Code = "cross_device_source"
+	CodeMixedStorageLayout        Code = "mixed_storage_layout"
+	CodeRollbackCollision         Code = "rollback_collision"
+	CodeSourceChanged             Code = "source_changed"
+	CodeSourceUnverifiable        Code = "source_unverifiable"
+)
+
+// Result is the versioned JSON protocol shared by the hidden inspector and
+// its shell bridge. Qualified results include Source and Target.
+type Result struct {
+	SchemaVersion int     `json:"schema_version"`
+	Operation     string  `json:"operation"`
+	Status        string  `json:"status"`
+	Retryable     bool    `json:"retryable"`
+	Effect        string  `json:"effect"`
+	Code          Code    `json:"code,omitempty"`
+	Source        *Source `json:"source,omitempty"`
+	Target        *Target `json:"target,omitempty"`
+}
+
+type Source struct {
+	Workspace string `json:"workspace"`
+	Version   string `json:"version"`
+	Backend   string `json:"backend"`
+	// TreeSHA256 is admission evidence with the lifetime explicitly bounded
+	// by DigestScope; it must never authorize a later effectful operation.
+	TreeSHA256 string `json:"tree_sha256"`
+	// DigestScope requires a future apply to rebind/reinspect under its fence.
+	DigestScope string `json:"digest_scope"`
+}
+
+type Target struct {
+	Version         string `json:"version"`
+	Backend         string `json:"backend"`
+	EmbeddedCapable bool   `json:"embedded_capable"`
+}
+
+// Refusal is the sole typed negative admission outcome. Error deliberately
+// exposes only the stable code; OS paths and values never cross the protocol.
+type Refusal struct {
+	Code      Code   `json:"code"`
+	Retryable bool   `json:"retryable"`
+	Effect    string `json:"effect"`
+	cause     error
+}
+
+func (r *Refusal) Error() string {
+	if r == nil {
+		return ""
+	}
+	return string(r.Code)
+}
+
+func (r *Refusal) Unwrap() error {
+	if r == nil {
+		return nil
+	}
+	return r.cause
+}
+
+func AsRefusal(err error) (*Refusal, bool) {
+	var refusal *Refusal
+	ok := errors.As(err, &refusal)
+	return refusal, ok
+}
+
+func refuse(code Code, retryable bool, cause error) error {
+	return &Refusal{Code: code, Retryable: retryable, Effect: EffectNone, cause: cause}
+}
+
+func QualifiedResult(workspace, targetVersion, treeSHA256 string) Result {
+	return Result{
+		SchemaVersion: SchemaVersion,
+		Operation:     Operation,
+		Status:        StatusQualified,
+		Retryable:     false,
+		Effect:        EffectNone,
+		Source: &Source{
+			Workspace:   workspace,
+			Version:     "0.62.0",
+			Backend:     "dolt-server",
+			TreeSHA256:  treeSHA256,
+			DigestScope: DigestScopeAdmissionObservation,
+		},
+		Target: &Target{
+			Version:         targetVersion,
+			Backend:         "dolt-embedded",
+			EmbeddedCapable: true,
+		},
+	}
+}
+
+func RefusedResult(code Code, retryable bool) Result {
+	return Result{
+		SchemaVersion: SchemaVersion,
+		Operation:     Operation,
+		Status:        StatusRefused,
+		Retryable:     retryable,
+		Effect:        EffectNone,
+		Code:          code,
+	}
+}
+
+func UsageErrorResult() Result {
+	result := RefusedResult(CodeInvalidUsage, false)
+	result.Status = StatusUsageError
+	return result
+}

--- a/scripts/migrate-v062-server-to-current.sh
+++ b/scripts/migrate-v062-server-to-current.sh
@@ -1,0 +1,312 @@
+#!/usr/bin/env bash
+# Qualified public bridge for v0.62.0 Dolt-server workspaces.
+# Source admission is delegated to hidden no-follow plumbing in current bd.
+
+set -uo pipefail
+umask 077
+
+readonly OPERATION=v062_server_to_current
+readonly ENV_BIN=/usr/bin/env
+readonly JQ_BIN=/usr/bin/jq
+readonly READLINK_BIN=/usr/bin/readlink
+readonly REALPATH_BIN=/usr/bin/realpath
+readonly TIMEOUT_BIN=/usr/bin/timeout
+
+MODE=inspect
+MODE_SET=false
+JSON_OUTPUT=false
+YES=false
+WORKSPACE_ARG=
+TARGET_BD_ARG=
+
+# Honor --json even when a preceding argument is invalid.
+for argument in "$@"; do
+    [ "$argument" = --json ] && JSON_OUTPUT=true
+done
+
+usage() {
+    cat >&2 <<'EOF'
+Usage: migrate-v062-server-to-current.sh [options]
+
+  --workspace PROJECT  Project containing the v0.62.0 .beads directory
+  --target-bd PATH     Absolute path to the current embedded-capable bd
+  --inspect            Inspect only (default; no workspace effects)
+  --apply              Perform the migration
+  --yes                Required confirmation for --apply
+  --json               Emit exactly one JSON result on stdout
+  -h, --help           Show this help
+EOF
+}
+
+bootstrap_json() {
+    local status="$1" code="$2" retryable="$3" effect="$4"
+    printf '{"schema_version":1,"operation":"%s",' "$OPERATION"
+    printf '"mode":"%s","status":"%s","retryable":%s,' \
+        "$MODE" "$status" "$retryable"
+    printf '"effect":"%s","code":"%s"}\n' "$effect" "$code"
+}
+
+emit_base_json() {
+    "$JQ_BIN" -cn \
+        --arg operation "$OPERATION" --arg mode "$MODE" \
+        --arg status "$1" --arg code "$2" \
+        --argjson retryable "$3" --arg effect "$4" '
+        {
+            schema_version: 1, operation: $operation, mode: $mode,
+            status: $status, retryable: $retryable, effect: $effect
+        } + if $code == "" then {} else {code: $code} end
+    '
+}
+
+finish_error() {
+    local exit_status="$1" status="$2" code="$3"
+    local retryable="$4" effect="$5" message="$6"
+    printf '%s: %s\n' "$OPERATION" "$message" >&2
+    if $JSON_OUTPUT; then
+        if [ -x "$JQ_BIN" ]; then
+            emit_base_json "$status" "$code" "$retryable" "$effect"
+        else
+            bootstrap_json "$status" "$code" "$retryable" "$effect"
+        fi
+    fi
+    exit "$exit_status"
+}
+
+invalid_usage() {
+    finish_error 2 usage_error "$1" false none "$2"
+}
+
+refuse() {
+    finish_error 1 refused "$1" "$2" none "$3"
+}
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --workspace)
+            [ "$#" -ge 2 ] ||
+                invalid_usage invalid_usage "--workspace requires a value"
+            WORKSPACE_ARG="$2"
+            shift 2
+            ;;
+        --target-bd)
+            [ "$#" -ge 2 ] ||
+                invalid_usage invalid_usage "--target-bd requires a value"
+            TARGET_BD_ARG="$2"
+            shift 2
+            ;;
+        --inspect|--apply)
+            requested_mode="${1#--}"
+            if $MODE_SET && [ "$MODE" != "$requested_mode" ]; then
+                invalid_usage invalid_usage \
+                    "--inspect and --apply are mutually exclusive"
+            fi
+            MODE="$requested_mode"
+            MODE_SET=true
+            shift
+            ;;
+        --yes)
+            YES=true
+            shift
+            ;;
+        --json)
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        --*)
+            invalid_usage invalid_usage "unknown option: $1"
+            ;;
+        *)
+            invalid_usage invalid_usage "unexpected argument: $1"
+            ;;
+    esac
+done
+
+if [ "$MODE" = apply ] && ! $YES; then
+    invalid_usage confirmation_required \
+        "--apply requires explicit --yes confirmation"
+fi
+if $YES && [ "$MODE" != apply ]; then
+    invalid_usage invalid_usage "--yes is valid only with --apply"
+fi
+
+INSPECT_TIMEOUT_SECONDS=${BD_V062_INSPECT_TIMEOUT_SECONDS:-600}
+if [[ ! "$INSPECT_TIMEOUT_SECONDS" =~ ^[1-9][0-9]*$ ]] ||
+    [ "${#INSPECT_TIMEOUT_SECONDS}" -gt 4 ] ||
+    [ "$INSPECT_TIMEOUT_SECONDS" -gt 3600 ]; then
+    invalid_usage invalid_environment \
+        "BD_V062_INSPECT_TIMEOUT_SECONDS must be an integer from 1 to 3600"
+fi
+
+for helper in \
+    "$ENV_BIN" "$JQ_BIN" "$READLINK_BIN" "$REALPATH_BIN" "$TIMEOUT_BIN"; do
+    [ -f "$helper" ] && [ -x "$helper" ] && [ ! -L "$helper" ] ||
+        refuse missing_requirement true \
+            "required fixed helper is unavailable: $helper"
+done
+
+[ -n "$WORKSPACE_ARG" ] || WORKSPACE_ARG="$PWD"
+WORKSPACE=$("$REALPATH_BIN" -e -- "$WORKSPACE_ARG" 2>/dev/null) ||
+    refuse workspace_invalid true "workspace cannot be resolved"
+[ -d "$WORKSPACE" ] && [ ! -L "$WORKSPACE" ] ||
+    refuse workspace_invalid true \
+        "workspace must be a physical project directory"
+
+if [ -z "$TARGET_BD_ARG" ]; then
+    TARGET_BD_ARG=$(type -P bd 2>/dev/null) ||
+        refuse target_binary_missing true "no current bd binary was found"
+elif [[ "$TARGET_BD_ARG" != /* ]]; then
+    refuse target_binary_invalid false \
+        "--target-bd must be an absolute path"
+fi
+TARGET_BD=$("$READLINK_BIN" -f -- "$TARGET_BD_ARG" 2>/dev/null) ||
+    refuse target_binary_invalid false \
+        "the target bd path cannot be resolved"
+[ -f "$TARGET_BD" ] && [ -x "$TARGET_BD" ] ||
+    refuse target_binary_invalid false \
+        "the target bd path is not an executable regular file"
+
+inspection_stdout=$(
+    "$ENV_BIN" -i \
+        PATH=/usr/bin:/bin HOME=/nonexistent \
+        XDG_CONFIG_HOME=/nonexistent XDG_CACHE_HOME=/nonexistent \
+        XDG_DATA_HOME=/nonexistent XDG_STATE_HOME=/nonexistent \
+        GIT_CONFIG_NOSYSTEM=1 GIT_CONFIG_GLOBAL=/dev/null \
+        GIT_TERMINAL_PROMPT=0 BD_DISABLE_METRICS=1 \
+        BD_DISABLE_EVENT_FLUSH=1 BD_NON_INTERACTIVE=1 \
+        NO_COLOR=1 CI=1 LANG=C.UTF-8 LC_ALL=C.UTF-8 TZ=UTC TERM=dumb \
+        "$TIMEOUT_BIN" --kill-after=5s "${INSPECT_TIMEOUT_SECONDS}s" \
+        "$TARGET_BD" __migration-v062-inspect \
+            --workspace "$WORKSPACE" --json 2>/dev/null
+)
+inspection_status=$?
+
+if [ "$inspection_status" -eq 124 ] || [ "$inspection_status" -eq 137 ]; then
+    refuse target_inspection_timeout true \
+        "target bd inspection exceeded its bounded runtime"
+fi
+
+if ! inspection_json=$("$JQ_BIN" -cse \
+    --argjson process_status "$inspection_status" '
+    def has_code($codes):
+        .code as $code | $codes | index($code) != null;
+    def nonretryable_refusal:
+        .retryable == false and has_code([
+            "platform_unsupported",
+            "embedded_target_unavailable",
+            "workspace_invalid",
+            "workspace_not_canonical",
+            "source_version_missing",
+            "source_version_mismatch",
+            "source_version_ambiguous",
+            "source_metadata_missing",
+            "source_metadata_mismatch",
+            "source_layout_missing",
+            "unsafe_source_symlink",
+            "unsafe_source_hardlink",
+            "unsafe_source_object",
+            "cross_device_source",
+            "mixed_storage_layout",
+            "rollback_collision"
+        ]);
+    def retryable_refusal:
+        .retryable == true and has_code([
+            "source_changed",
+            "source_unverifiable"
+        ]);
+    if length != 1 then empty else .[0] end |
+    select(
+        type == "object" and .schema_version == 1 and
+        .operation == "v062_source_inspection" and .effect == "none" and
+        (
+            (
+                .status == "qualified" and $process_status == 0 and
+                .retryable == false and
+                keys == [
+                    "effect", "operation", "retryable", "schema_version",
+                    "source", "status", "target"
+                ]
+            ) or
+            (
+                .status == "refused" and $process_status == 1 and
+                keys == [
+                    "code", "effect", "operation", "retryable",
+                    "schema_version", "status"
+                ] and
+                (nonretryable_refusal or retryable_refusal)
+            )
+        )
+    )
+' 2>/dev/null <<< "$inspection_stdout"); then
+    refuse target_capability_missing false \
+        "target bd does not implement the qualified inspection protocol"
+fi
+
+inspection_result_status=$("$JQ_BIN" -r '.status' <<< "$inspection_json")
+if [ "$inspection_result_status" = refused ]; then
+    inspection_code=$("$JQ_BIN" -r '.code' <<< "$inspection_json")
+    inspection_retryable=$("$JQ_BIN" -r '.retryable' <<< "$inspection_json")
+    finish_error 1 refused "$inspection_code" \
+        "$inspection_retryable" none \
+        "the no-follow source inspector refused this workspace"
+fi
+
+if [ "$inspection_status" -ne 0 ] ||
+    ! "$JQ_BIN" -e --arg workspace "$WORKSPACE" '
+        .status == "qualified" and
+        .source.workspace == $workspace and
+        .source.version == "0.62.0" and
+        .source.backend == "dolt-server" and
+        .source.digest_scope == "admission_observation" and
+        (.source.tree_sha256 | type) == "string" and
+        (.source.tree_sha256 | test("^[0-9a-f]{64}$")) and
+        .target.backend == "dolt-embedded" and
+        .target.embedded_capable == true and
+        (.target.version | type) == "string" and
+        (.target.version |
+            test("^[0-9]+[.][0-9]+[.][0-9]+([+-].*)?$")) and
+        ((.target.version | split(".")[0] | tonumber) >= 1)
+    ' >/dev/null 2>&1 <<< "$inspection_json"; then
+    reported_target_version=$(
+        "$JQ_BIN" -r '.target.version // ""' <<< "$inspection_json" \
+            2>/dev/null
+    ) || reported_target_version=
+    if [ "$reported_target_version" = 0.62.0 ]; then
+        refuse target_binary_invalid false \
+            "the historical bd binary cannot be the migration target"
+    fi
+    refuse target_capability_missing false \
+        "target bd is not a qualified embedded-capable migration target"
+fi
+
+rollback_path="$WORKSPACE/.beads-v0.62.0-rollback"
+
+# Be truthful while this stack contains admission but not the effectful bridge.
+if $JSON_OUTPUT; then
+    "$JQ_BIN" -cn \
+        --argjson inspection "$inspection_json" \
+        --arg operation "$OPERATION" --arg mode "$MODE" \
+        --arg rollback "$rollback_path" '
+        {
+            schema_version: 1, operation: $operation, mode: $mode,
+            status: "failed", code: "apply_not_available",
+            retryable: false, effect: "none",
+            source: $inspection.source, target: $inspection.target,
+            rollback: {path: $rollback, policy: "retain"},
+            verification: {
+                source_shape: "qualified",
+                source_tree_sha256: $inspection.source.tree_sha256,
+                source_digest_scope: $inspection.source.digest_scope,
+                apply_reinspection_required: true,
+                apply_available: false,
+                workspace_effects: false
+            }
+        }
+    '
+else
+    printf '%s\n' \
+        'Qualified v0.62.0 source; apply is not available in this build.' >&2
+fi
+exit 1

--- a/scripts/migrate-v062-server-to-current.sh
+++ b/scripts/migrate-v062-server-to-current.sh
@@ -227,7 +227,24 @@ if ! inspection_json=$("$JQ_BIN" -cse \
                 keys == [
                     "effect", "operation", "retryable", "schema_version",
                     "source", "status", "target"
-                ]
+                ] and
+                (.source | type) == "object" and
+                (.source | keys) == [
+                    "backend", "digest_scope", "tree_sha256",
+                    "version", "workspace"
+                ] and
+                (.source.workspace | type) == "string" and
+                (.source.version | type) == "string" and
+                (.source.backend | type) == "string" and
+                (.source.tree_sha256 | type) == "string" and
+                (.source.digest_scope | type) == "string" and
+                (.target | type) == "object" and
+                (.target | keys) == [
+                    "backend", "embedded_capable", "version"
+                ] and
+                (.target.version | type) == "string" and
+                (.target.backend | type) == "string" and
+                (.target.embedded_capable | type) == "boolean"
             ) or
             (
                 .status == "refused" and $process_status == 1 and
@@ -293,7 +310,18 @@ if $JSON_OUTPUT; then
             schema_version: 1, operation: $operation, mode: $mode,
             status: "failed", code: "apply_not_available",
             retryable: false, effect: "none",
-            source: $inspection.source, target: $inspection.target,
+            source: {
+                workspace: $inspection.source.workspace,
+                version: $inspection.source.version,
+                backend: $inspection.source.backend,
+                tree_sha256: $inspection.source.tree_sha256,
+                digest_scope: $inspection.source.digest_scope
+            },
+            target: {
+                version: $inspection.target.version,
+                backend: $inspection.target.backend,
+                embedded_capable: $inspection.target.embedded_capable
+            },
             rollback: {path: $rollback, policy: "retain"},
             verification: {
                 source_shape: "qualified",

--- a/scripts/migration-test/lib/features.sh
+++ b/scripts/migration-test/lib/features.sh
@@ -71,7 +71,12 @@ create_dataset() {
 
     # 2. Task (will be child of epic if supported)
     local task_args=(--title "Migration task alpha" --type task --priority 1)
-    if try_feature "parent_child" "$version" "$ws" "$bin" create --silent --title "__probe__" --parent "$epic_id" --type task; then
+    if ${STRICT_MODE:-false}; then
+        # Qualified strict fixtures require this relationship. Construct it
+        # directly so a stale feature cache or a retained probe cannot turn a
+        # broken source fixture into an apparent fidelity pass.
+        task_args+=(--parent "$epic_id")
+    elif try_feature "parent_child" "$version" "$ws" "$bin" create --silent --title "__probe__" --parent "$epic_id" --type task; then
         task_args+=(--parent "$epic_id")
         # clean up probe issue — best effort
         bd_in "$ws" "$bin" close "$(__last_created_id "$ws" "$bin")" 2>/dev/null || true

--- a/scripts/migration-test/lib/snapshot.sh
+++ b/scripts/migration-test/lib/snapshot.sh
@@ -149,7 +149,7 @@ strict_snapshot_has_expected_fixture() {
     local snapshot="$2"
 
     case "$version" in
-        v0.49.6|v0.55.4|v0.57.0|v0.63.3)
+        v0.49.6|v0.55.4|v0.57.0|v0.62.0|v0.63.3)
             local epic_id="${DATASET_IDS[epic]:-}"
             local standalone_id="${DATASET_IDS[standalone]:-}"
             local closed_id="${DATASET_IDS[closed]:-}"
@@ -170,7 +170,8 @@ strict_snapshot_has_expected_fixture() {
                     .description == "Epic for migration testing" and
                     .priority == 2 and
                     .issue_type == "epic" and
-                    .status == "open") and
+                    .status == "open" and
+                    ((.dependencies // []) | length == 0)) and
                 any(.[];
                     .id == $standalone and
                     .title == "Standalone detailed task" and
@@ -178,16 +179,34 @@ strict_snapshot_has_expected_fixture() {
                     .notes == "Historical notes must survive the upgrade." and
                     .design == "Historical design must survive the upgrade." and
                     .acceptance_criteria == "Historical acceptance criteria must survive the upgrade." and
-                    .external_ref == "legacy-upgrade-42") and
-                any(.[]; .id == $closed and .status == "closed") and
+                    .external_ref == "legacy-upgrade-42" and
+                    ((.dependencies // []) | length == 0)) and
+                any(.[];
+                    .id == $closed and
+                    .status == "closed" and
+                    ((.dependencies // []) | length == 0)) and
                 any(.[];
                     .id == $task and
+                    .parent == $epic and
+                    ((.dependencies // [] |
+                        map({
+                            id: (.id // .depends_on_id),
+                            type: (.dependency_type // .type)
+                        }) |
+                        sort_by(.id, .type)) ==
+                        [{id: $epic, type: "parent-child"}]) and
                     ((.labels // []) | index("urgent") != null) and
                     ((.comments // [] | map({author, text})) |
                         index({"author":"legacy-author","text":"Historical comment must survive the upgrade."}) != null)) and
                 any(.[];
                     .id == $bug and
-                    ((.dependencies // [] | map(.id // .)) | index($task) != null))
+                    ((.dependencies // [] |
+                        map({
+                            id: (.id // .depends_on_id),
+                            type: (.dependency_type // .type)
+                        }) |
+                        sort_by(.id, .type)) ==
+                        [{id: $task, type: "blocks"}]))
                 ' "$snapshot" >/dev/null 2>&1 || {
                     echo "  FIDELITY: $version source fixture is missing exact required values" >&2
                     return 1
@@ -400,7 +419,7 @@ check_fidelity() {
     # bd uses "issue_type" not "type" in its JSON output.
     local INVARIANTS=("title" "description" "priority" "issue_type")
     if ${STRICT_MODE:-false}; then
-        INVARIANTS+=("id" "notes" "design" "acceptance_criteria" "external_ref" "status")
+        INVARIANTS+=("id" "notes" "design" "acceptance_criteria" "external_ref" "status" "parent")
     fi
 
     local i=0
@@ -470,8 +489,21 @@ check_fidelity() {
 
         # Check dependency preservation
         local before_deps after_deps
-        before_deps=$(jq -r ".[$i].dependencies // [] | [.[].id // .] | sort | join(\",\")" "$before" 2>/dev/null)
-        after_deps=$(echo "$match" | jq -r ".dependencies // [] | [.[].id // .] | sort | join(\",\")" 2>/dev/null)
+        if ${STRICT_MODE:-false}; then
+            before_deps=$(jq -c ".[$i].dependencies // [] |
+                map({
+                    id: (.id // .depends_on_id),
+                    type: (.dependency_type // .type)
+                }) | sort_by(.id, .type)" "$before" 2>/dev/null)
+            after_deps=$(echo "$match" | jq -c '.dependencies // [] |
+                map({
+                    id: (.id // .depends_on_id),
+                    type: (.dependency_type // .type)
+                }) | sort_by(.id, .type)' 2>/dev/null)
+        else
+            before_deps=$(jq -r ".[$i].dependencies // [] | [.[].id // .] | sort | join(\",\")" "$before" 2>/dev/null)
+            after_deps=$(echo "$match" | jq -r ".dependencies // [] | [.[].id // .] | sort | join(\",\")" 2>/dev/null)
+        fi
         if { ${STRICT_MODE:-false} || [ -n "$before_deps" ]; } && [ "$before_deps" != "$after_deps" ]; then
             echo -e "  ${RED:-}FIDELITY VIOLATION: '$title' dependencies changed: '$before_deps' -> '$after_deps'${NC:-}"
             violations=$((violations + 1))

--- a/scripts/migration-test/lib/versions.sh
+++ b/scripts/migration-test/lib/versions.sh
@@ -5,8 +5,7 @@
 # Format: era_name|representative_version|storage_dir|description
 ERAS=(
     "sqlite|v0.49.6|beads.db|SQLite era (pre-Dolt)"
-    "dolt_server|v0.57.0|dolt|Dolt server mode"
-    "embedded_old|v0.62.0|dolt|Old embedded Dolt (in-process)"
+    "dolt_server|v0.62.0|dolt|Dolt server mode"
     "embedded_current|v0.63.3|embeddeddolt|Current embedded Dolt"
 )
 
@@ -46,41 +45,52 @@ declare -Ar STRICT_RELEASE_ASSETS=(
     ["v0.49.6|linux|amd64"]="beads_0.49.6_linux_amd64.tar.gz"
     ["v0.55.4|linux|amd64"]="beads_0.55.4_linux_amd64.tar.gz"
     ["v0.57.0|linux|amd64"]="beads_0.57.0_linux_amd64.tar.gz"
+    ["v0.62.0|linux|amd64"]="beads_0.62.0_linux_amd64.tar.gz"
     ["v0.63.3|linux|amd64"]="beads_0.63.3_linux_amd64.tar.gz"
 )
 declare -Ar STRICT_RELEASE_SHA256=(
     ["v0.49.6|linux|amd64"]="8546dc9a47e11dc31ac2bc9a0224a9c690975e91850932cbb62623053fbb7db8"
     ["v0.55.4|linux|amd64"]="e0fa25456dd82890230eef17653448a0bf995104c78864be91c5ed84426a5f49"
     ["v0.57.0|linux|amd64"]="f8629d5627bed7d25f06f92334addc171d679f9aed9d08c5d42a9684205dc04b"
+    ["v0.62.0|linux|amd64"]="4cca7265b22e5c3ca8d62ab0b9752bec31f68b7f5fa636282a4c7e5454c35535"
     ["v0.63.3|linux|amd64"]="5f4efd2e010209b3f381dbcd783b2a3a652f50ea72f40ef04c8ba434d408bf9e"
 )
 declare -Ar STRICT_EXPECTED_STATUSES=(
     ["v0.49.6"]="MANUAL"
     ["v0.55.4"]="MANUAL"
     ["v0.57.0"]="MANUAL"
+    ["v0.62.0"]="MANUAL"
     ["v0.63.3"]="AUTO"
 )
 declare -Ar STRICT_EXPECTED_RECIPES=(
     ["v0.49.6"]="sqlite_to_current"
     ["v0.55.4"]="server_to_embedded"
     ["v0.57.0"]="server_to_embedded"
+    ["v0.62.0"]="server_to_embedded"
     ["v0.63.3"]=""
 )
 declare -Ar STRICT_EXPECTED_FEATURES=(
     ["v0.49.6"]="epic task bug dependency standalone closed label comment"
     ["v0.55.4"]="epic task bug dependency standalone closed label comment"
     ["v0.57.0"]="epic task bug dependency standalone closed label comment"
+    ["v0.62.0"]="epic task bug dependency standalone closed label comment"
     ["v0.63.3"]="epic task bug dependency standalone closed label comment"
 )
 declare -Ar SERVER_BRIDGE_STRATEGIES=(
     ["v0.55.4"]="native_export"
     ["v0.57.0"]="native_export_show_comments"
+    ["v0.62.0"]="native_export_show_comments"
+)
+declare -Ar SERVER_BOOTSTRAP_STRATEGIES=(
+    ["v0.62.0"]="prestarted_server"
 )
 declare -Ar STRICT_REQUIRED_DOLT_VERSIONS=(
     ["v0.57.0"]="2.1.8"
+    ["v0.62.0"]="1.84.0"
 )
 declare -Ar STRICT_REQUIRED_DOLT_SHA256=(
     ["v0.57.0|linux|amd64"]="f66318f08ed66e409fc39363ae0fff8ce6fbf6dba9f5bac632b91527b9632a74"
+    ["v0.62.0|linux|amd64"]="afcdaa9530ae0b4f317ed6041a41d20096e156b2556eb0e03c7c57a624ccc0b3"
 )
 
 strict_release_asset() {
@@ -115,6 +125,12 @@ strict_expected_features() {
 
 server_bridge_strategy() {
     local value="${SERVER_BRIDGE_STRATEGIES[$1]:-}"
+    [ -n "$value" ] || return 1
+    printf '%s\n' "$value"
+}
+
+server_bootstrap_strategy() {
+    local value="${SERVER_BOOTSTRAP_STRATEGIES[$1]:-}"
     [ -n "$value" ] || return 1
     printf '%s\n' "$value"
 }
@@ -185,10 +201,8 @@ get_era() {
     local version="$1"
     if version_lt "$version" "v0.50.0"; then
         echo "sqlite"
-    elif version_lt "$version" "v0.59.0"; then
-        echo "dolt_server"
     elif version_lt "$version" "v0.63.3"; then
-        echo "embedded_old"
+        echo "dolt_server"
     else
         echo "embedded_current"
     fi

--- a/scripts/migration-test/lib/workspace.sh
+++ b/scripts/migration-test/lib/workspace.sh
@@ -15,6 +15,31 @@ export GIT_CONFIG_GLOBAL=/dev/null
 # startup, embedded engine locks, etc.  Server-era versions may need the
 # full 30 s for a cold Dolt auto-start.
 BD_OP_TIMEOUT="${BD_OP_TIMEOUT:-30}"
+BD_OP_KILL_AFTER="${BD_OP_KILL_AFTER:-5s}"
+MIGRATION_DOLT_READY_ATTEMPTS_MAX=200
+MIGRATION_DOLT_READY_TIMEOUT_MAX=120
+
+migration_validate_operation_timeouts() {
+    local kill_seconds
+
+    [[ "$BD_OP_TIMEOUT" =~ ^[1-9][0-9]*$ ]] || return 1
+    [ "$BD_OP_TIMEOUT" -le 300 ] || return 1
+    [[ "$BD_OP_KILL_AFTER" =~ ^([1-9][0-9]*)(s)?$ ]] || return 1
+    kill_seconds="${BASH_REMATCH[1]}"
+    [ "$kill_seconds" -le 60 ]
+}
+
+migration_validate_readiness_settings() {
+    local attempts="$1"
+    local delay="$2"
+    local ready_timeout="$3"
+
+    [[ "$attempts" =~ ^[1-9][0-9]*$ ]] || return 1
+    [ "$attempts" -le "$MIGRATION_DOLT_READY_ATTEMPTS_MAX" ] || return 1
+    [[ "$delay" =~ ^(0([.][0-9]+)?|1([.]0+)?)$ ]] || return 1
+    [[ "$ready_timeout" =~ ^[1-9][0-9]*$ ]] || return 1
+    [ "$ready_timeout" -le "$MIGRATION_DOLT_READY_TIMEOUT_MAX" ]
+}
 
 migration_server_port_in_use() {
     local port="$1"
@@ -203,6 +228,42 @@ prepare_migration_subprocess_home() {
     printf '%s\n' "$home"
 }
 
+migration_subprocess_environment() {
+    local ws="$1"
+    local result_name="$2"
+    local subprocess_home private_root
+    local -n result="$result_name"
+
+    subprocess_home=$(prepare_migration_subprocess_home "$ws") || return 1
+    if [ -d "$ws/.git" ] && [ ! -L "$ws/.git" ]; then
+        private_root="$ws/.git"
+    else
+        private_root="$ws"
+    fi
+    # shellcheck disable=SC2034 # result is populated through the caller's nameref.
+    result=(
+        env -i
+        "PATH=$PATH"
+        "HOME=$subprocess_home"
+        "XDG_CONFIG_HOME=$subprocess_home/.config"
+        "XDG_CACHE_HOME=$subprocess_home/.cache"
+        "XDG_DATA_HOME=$subprocess_home/.local/share"
+        "XDG_STATE_HOME=$subprocess_home/.local/state"
+        "XDG_RUNTIME_DIR=$private_root/bd-migration-runtime"
+        "TMPDIR=$private_root/bd-migration-tmp"
+        "GIT_CONFIG_NOSYSTEM=1"
+        "GIT_CONFIG_GLOBAL=/dev/null"
+        "GIT_TERMINAL_PROMPT=0"
+        "USER=migration-test"
+        "LOGNAME=migration-test"
+        "SHELL=/bin/bash"
+        "LANG=C.UTF-8"
+        "LC_ALL=C.UTF-8"
+        "TZ=UTC"
+        "TERM=dumb"
+    )
+}
+
 new_workspace() (
     local dir
     local env_name
@@ -243,50 +304,34 @@ bd_in() {
     local ws="$1"
     local bin="$2"
     local port_file="$ws/.git/bd-migration-server-port"
+    local prestarted_file="$ws/.git/bd-migration-prestarted-server"
     local port=""
-    local subprocess_home private_root env_name
+    local auto_start=1 env_name prestarted_port
     local -a clean_env
     shift 2
+    migration_validate_operation_timeouts || return 1
     if [ -e "$port_file" ] || [ -L "$port_file" ]; then
         [ -f "$port_file" ] && [ ! -L "$port_file" ] || return 1
         port=$(cat "$port_file") || return 1
         [[ "$port" =~ ^2[0-9]{4}$ ]] || return 1
     fi
-    subprocess_home=$(prepare_migration_subprocess_home "$ws") || return 1
-    if [ -d "$ws/.git" ] && [ ! -L "$ws/.git" ]; then
-        private_root="$ws/.git"
-    else
-        private_root="$ws"
+    if [ -e "$prestarted_file" ] || [ -L "$prestarted_file" ]; then
+        [ -f "$prestarted_file" ] && [ ! -L "$prestarted_file" ] || return 1
+        prestarted_port=$(cat "$prestarted_file") || return 1
+        [ -n "$port" ] && [ "$prestarted_port" = "$port" ] || return 1
+        auto_start=0
     fi
-    clean_env=(
-        env -i
-        "PATH=$PATH"
-        "HOME=$subprocess_home"
-        "XDG_CONFIG_HOME=$subprocess_home/.config"
-        "XDG_CACHE_HOME=$subprocess_home/.cache"
-        "XDG_DATA_HOME=$subprocess_home/.local/share"
-        "XDG_STATE_HOME=$subprocess_home/.local/state"
-        "XDG_RUNTIME_DIR=$private_root/bd-migration-runtime"
-        "TMPDIR=$private_root/bd-migration-tmp"
-        "GIT_CONFIG_NOSYSTEM=1"
-        "GIT_CONFIG_GLOBAL=/dev/null"
-        "GIT_TERMINAL_PROMPT=0"
+    migration_subprocess_environment "$ws" clean_env || return 1
+    clean_env+=(
         "BEADS_TEST_MODE=0"
         "BEADS_NO_DAEMON=1"
-        "BEADS_DOLT_AUTO_START=1"
+        "BEADS_DOLT_AUTO_START=$auto_start"
         "BD_NON_INTERACTIVE=1"
         "BD_NO_PAGER=1"
         "BD_DISABLE_METRICS=1"
         "BD_DISABLE_EVENT_FLUSH=1"
         "NO_COLOR=1"
         "CI=1"
-        "USER=migration-test"
-        "LOGNAME=migration-test"
-        "SHELL=/bin/bash"
-        "LANG=C.UTF-8"
-        "LC_ALL=C.UTF-8"
-        "TZ=UTC"
-        "TERM=dumb"
     )
     if [ -n "$port" ]; then
         clean_env+=("BEADS_DOLT_SERVER_PORT=$port")
@@ -302,7 +347,8 @@ bd_in() {
             clean_env+=("$env_name=${!env_name}")
         fi
     done
-    (cd "$ws" && "${clean_env[@]}" timeout "$BD_OP_TIMEOUT" "$bin" "$@")
+    (cd "$ws" && "${clean_env[@]}" timeout \
+        --kill-after="$BD_OP_KILL_AFTER" "$BD_OP_TIMEOUT" "$bin" "$@")
 }
 
 # Create an issue, returning just the ID on stdout.
@@ -360,11 +406,209 @@ migration_process_cwd() {
     local pid="$1"
 
     if [ -L "/proc/$pid/cwd" ]; then
-        readlink "/proc/$pid/cwd"
+        readlink "/proc/$pid/cwd" 2>/dev/null
         return
     fi
     command -v lsof >/dev/null 2>&1 || return 1
     lsof -a -p "$pid" -d cwd -Fn 2>/dev/null | sed -n 's/^n//p' | head -1
+}
+
+migration_process_stat_field() {
+    local pid="$1"
+    local field_index="$2"
+    local stat_line remainder
+    local -a fields
+
+    [[ "$field_index" =~ ^[0-9]+$ ]] || return 1
+    IFS= read -r stat_line 2>/dev/null < "/proc/$pid/stat" || return 1
+    [[ "$stat_line" == *") "* ]] || return 1
+    remainder="${stat_line##*) }"
+    read -r -a fields <<< "$remainder"
+    [ "${#fields[@]}" -gt "$field_index" ] || return 1
+    printf '%s\n' "${fields[$field_index]}"
+}
+
+migration_process_start_time() {
+    local value
+    value=$(migration_process_stat_field "$1" 19) || return 1
+    [[ "$value" =~ ^[0-9]+$ ]] || return 1
+    printf '%s\n' "$value"
+}
+
+migration_process_state() {
+    migration_process_stat_field "$1" 0
+}
+
+migration_process_parent_pid() {
+    local value
+    value=$(migration_process_stat_field "$1" 1) || return 1
+    [[ "$value" =~ ^[0-9]+$ ]] || return 1
+    printf '%s\n' "$value"
+}
+
+migration_path_identity() {
+    local path="$1"
+    [ -e "$path" ] && [ ! -L "$path" ] || return 1
+    stat -Lc '%d:%i' -- "$path"
+}
+
+MIGRATION_PROVISIONAL_OWNED_WS=""
+MIGRATION_PROVISIONAL_OWNED_PID=""
+MIGRATION_PROVISIONAL_OWNED_START=""
+MIGRATION_PROVISIONAL_OWNED_PARENT=""
+MIGRATION_PROVISIONAL_OWNED_IDENTITY=()
+
+migration_begin_provisional_owned_process() {
+    MIGRATION_PROVISIONAL_OWNED_WS="$1"
+    MIGRATION_PROVISIONAL_OWNED_PID="$2"
+    MIGRATION_PROVISIONAL_OWNED_START="$3"
+    MIGRATION_PROVISIONAL_OWNED_PARENT="$BASHPID"
+    MIGRATION_PROVISIONAL_OWNED_IDENTITY=()
+}
+
+migration_clear_provisional_owned_process() {
+    local ws="$1"
+
+    [ "$MIGRATION_PROVISIONAL_OWNED_WS" = "$ws" ] || return 0
+    MIGRATION_PROVISIONAL_OWNED_WS=""
+    MIGRATION_PROVISIONAL_OWNED_PID=""
+    MIGRATION_PROVISIONAL_OWNED_START=""
+    MIGRATION_PROVISIONAL_OWNED_PARENT=""
+    MIGRATION_PROVISIONAL_OWNED_IDENTITY=()
+}
+
+migration_provisional_owned_process_matches() {
+    local ws="$1"
+    local current_start current_parent
+
+    [ "$MIGRATION_PROVISIONAL_OWNED_WS" = "$ws" ] || return 1
+    [ "$MIGRATION_PROVISIONAL_OWNED_PARENT" = "$BASHPID" ] || return 1
+    current_start=$(migration_process_start_time "$MIGRATION_PROVISIONAL_OWNED_PID") || return 1
+    [ "$current_start" = "$MIGRATION_PROVISIONAL_OWNED_START" ] || return 1
+    current_parent=$(migration_process_parent_pid "$MIGRATION_PROVISIONAL_OWNED_PID") || return 1
+    [ "$current_parent" = "$MIGRATION_PROVISIONAL_OWNED_PARENT" ] || return 1
+    jobs -pr | grep -Fqx -- "$MIGRATION_PROVISIONAL_OWNED_PID"
+}
+
+migration_owned_process_shape() {
+    local pid="$1"
+    local dolt_bin="$2"
+    local port="$3"
+    local -a arguments
+
+    [ -r "/proc/$pid/cmdline" ] || return 1
+    mapfile -d '' -t arguments < "/proc/$pid/cmdline" 2>/dev/null || return 1
+    if [ "${#arguments[@]}" -eq 6 ] &&
+        [ "${arguments[0]}" = "$dolt_bin" ] &&
+        [ "${arguments[1]}" = "sql-server" ] &&
+        [ "${arguments[2]}" = "--host" ] &&
+        [ "${arguments[3]}" = "127.0.0.1" ] &&
+        [ "${arguments[4]}" = "--port" ] &&
+        [ "${arguments[5]}" = "$port" ]; then
+        printf '%s\n' binary
+    elif [ "${#arguments[@]}" -eq 7 ] &&
+        [ "${arguments[1]}" = "$dolt_bin" ] &&
+        [ "${arguments[2]}" = "sql-server" ] &&
+        [ "${arguments[3]}" = "--host" ] &&
+        [ "${arguments[4]}" = "127.0.0.1" ] &&
+        [ "${arguments[5]}" = "--port" ] &&
+        [ "${arguments[6]}" = "$port" ]; then
+        printf '%s\n' script
+    else
+        return 1
+    fi
+}
+
+migration_capture_owned_process_identity() {
+    local pid="$1"
+    local ws="$2"
+    local dolt_bin="$3"
+    local port="$4"
+    local result_name="$5"
+    local start_time start_time_after process_exe_identity
+    local launch_identity launch_mode cwd dolt_root cwd_identity
+    local -n output_ref="$result_name"
+
+    start_time=$(migration_process_start_time "$pid") || return 1
+    launch_mode=$(migration_owned_process_shape "$pid" "$dolt_bin" "$port") || return 1
+    cwd=$(migration_process_cwd "$pid") || return 1
+    dolt_root=$(cd -P -- "$ws/.beads/dolt" 2>/dev/null && pwd) || return 1
+    [ "$cwd" = "$dolt_root" ] || return 1
+    cwd_identity=$(stat -Lc '%d:%i' -- "/proc/$pid/cwd" 2>/dev/null) || return 1
+    [ "$cwd_identity" = "$(migration_path_identity "$dolt_root")" ] || return 1
+    process_exe_identity=$(stat -Lc '%d:%i' -- "/proc/$pid/exe" 2>/dev/null) || return 1
+    launch_identity=$(migration_path_identity "$dolt_bin") || return 1
+    [[ "$dolt_bin" != *$'\n'* ]] || return 1
+    start_time_after=$(migration_process_start_time "$pid") || return 1
+    [ "$start_time_after" = "$start_time" ] || return 1
+    output_ref=(
+        "$pid" "$start_time" "$process_exe_identity" "$dolt_bin"
+        "$launch_identity" "$launch_mode" "$cwd_identity"
+    )
+}
+
+migration_owned_process_matches_identity() {
+    local pid="$1"
+    local ws="$2"
+    local identity_name="$3"
+    local port start_time process_exe_identity
+    local dolt_bin launch_identity expected_mode cwd_identity
+    local current_start current_mode current_cwd_identity dolt_root
+    local -n identity_ref="$identity_name"
+
+    [ "${#identity_ref[@]}" -eq 7 ] || return 1
+    [ "${identity_ref[0]}" = "$pid" ] || return 1
+    start_time="${identity_ref[1]}"
+    process_exe_identity="${identity_ref[2]}"
+    dolt_bin="${identity_ref[3]}"
+    launch_identity="${identity_ref[4]}"
+    expected_mode="${identity_ref[5]}"
+    cwd_identity="${identity_ref[6]}"
+    [[ "$start_time" =~ ^[0-9]+$ ]] || return 1
+    [ "$expected_mode" = "binary" ] || [ "$expected_mode" = "script" ] || return 1
+    port=$(cat "$ws/.git/bd-migration-server-port") || return 1
+    [[ "$port" =~ ^2[0-9]{4}$ ]] || return 1
+    current_start=$(migration_process_start_time "$pid") || return 1
+    [ "$current_start" = "$start_time" ] || return 1
+    [ "$(migration_path_identity "$dolt_bin")" = "$launch_identity" ] || return 1
+    [ "$(stat -Lc '%d:%i' -- "/proc/$pid/exe" 2>/dev/null)" = "$process_exe_identity" ] || return 1
+    current_mode=$(migration_owned_process_shape "$pid" "$dolt_bin" "$port") || return 1
+    [ "$current_mode" = "$expected_mode" ] || return 1
+    current_cwd_identity=$(stat -Lc '%d:%i' -- "/proc/$pid/cwd" 2>/dev/null) || return 1
+    [ "$current_cwd_identity" = "$cwd_identity" ] || return 1
+    dolt_root=$(cd -P -- "$ws/.beads/dolt" 2>/dev/null && pwd) || return 1
+    [ "$(migration_path_identity "$dolt_root")" = "$cwd_identity" ] || return 1
+    current_start=$(migration_process_start_time "$pid") || return 1
+    [ "$current_start" = "$start_time" ]
+}
+
+migration_read_owned_process_identity() {
+    local ws="$1"
+    local result_name="$2"
+    local identity_file="$ws/.git/bd-migration-owned-dolt-server.identity"
+    local -a reread
+    # shellcheck disable=SC2178 # output_ref names the caller's array.
+    local -n output_ref="$result_name"
+
+    [ -f "$identity_file" ] && [ ! -L "$identity_file" ] || return 1
+    [ "$(stat -c '%u' -- "$identity_file")" = "$(id -u)" ] || return 1
+    mapfile -t output_ref < "$identity_file" || return 1
+    [ "${#output_ref[@]}" -eq 7 ] || return 1
+    mapfile -t reread < "$identity_file" || return 1
+    [ "${#reread[@]}" -eq 7 ] || return 1
+    [ "${output_ref[*]}" = "${reread[*]}" ]
+}
+
+migration_owned_process_matches_launch() {
+    local pid="$1"
+    local ws="$2"
+    local dolt_bin="$3"
+    local port="$4"
+    local -a identity
+
+    migration_capture_owned_process_identity \
+        "$pid" "$ws" "$dolt_bin" "$port" identity || return 1
+    [ "${#identity[@]}" -eq 7 ]
 }
 
 migration_pid_belongs_to_workspace() {
@@ -372,6 +616,7 @@ migration_pid_belongs_to_workspace() {
     local ws="$2"
     local pidfile_name="$3"
     local command_line="" cwd="" dolt_root=""
+    local -a owned_identity
 
     [[ "$pid" =~ ^[0-9]+$ ]] && [ "$pid" -gt 1 ] || return 1
     command_line=$(migration_process_command_line "$pid") || return 1
@@ -383,6 +628,10 @@ migration_pid_belongs_to_workspace() {
             cwd=$(migration_process_cwd "$pid") || return 1
             dolt_root=$(cd -P -- "$ws/.beads/dolt" 2>/dev/null && pwd) || return 1
             [ "$cwd" = "$dolt_root" ] || [[ "$cwd" == "$dolt_root/"* ]]
+            ;;
+        bd-migration-owned-dolt-server.pid)
+            migration_read_owned_process_identity "$ws" owned_identity || return 1
+            migration_owned_process_matches_identity "$pid" "$ws" owned_identity
             ;;
         dolt-monitor.pid)
             [[ "$command_line" == *bd* ]] && [[ "$command_line" == *idle-monitor* ]] &&
@@ -398,10 +647,535 @@ migration_pid_belongs_to_workspace() {
     esac
 }
 
+migration_publish_owned_process_identity() {
+    local ws="$1"
+    local identity_name="$2"
+    local git_dir="$ws/.git"
+    local pid_file="$git_dir/bd-migration-owned-dolt-server.pid"
+    local identity_file="$git_dir/bd-migration-owned-dolt-server.identity"
+    local pid_tmp="$pid_file.tmp.$BASHPID.$RANDOM"
+    local identity_tmp="$identity_file.tmp.$BASHPID.$RANDOM"
+    local -n identity_ref="$identity_name"
+
+    [ "${#identity_ref[@]}" -eq 7 ] || return 1
+    if [ -e "$pid_file" ] || [ -L "$pid_file" ] ||
+        [ -e "$identity_file" ] || [ -L "$identity_file" ]; then
+        return 1
+    fi
+    if ! (
+        set -o noclobber
+        umask 077
+        printf '%s\n' "${identity_ref[@]}" > "$identity_tmp" &&
+            printf '%s\n' "${identity_ref[0]}" > "$pid_tmp"
+    ) 2>/dev/null; then
+        rm -f -- "$pid_tmp" "$identity_tmp"
+        return 1
+    fi
+    if ! mv --no-target-directory --no-clobber -- "$identity_tmp" "$identity_file"; then
+        rm -f -- "$pid_tmp" "$identity_tmp"
+        return 1
+    fi
+    if ! mv --no-target-directory --no-clobber -- "$pid_tmp" "$pid_file"; then
+        rm -f -- "$pid_tmp"
+        if [ -f "$identity_file" ] && [ ! -L "$identity_file" ]; then
+            rm -f -- "$identity_file"
+        fi
+        return 1
+    fi
+    return 0
+}
+
+migration_signal_owned_process() {
+    local signal_name="$1"
+    local pid="$2"
+
+    [ "$signal_name" = "TERM" ] || [ "$signal_name" = "KILL" ] || return 1
+    kill "-$signal_name" -- "$pid"
+}
+
+migration_wait_process_exit_by_start_time() {
+    local pid="$1"
+    local expected_start="$2"
+    local attempts="$3"
+    local attempt current_start state
+
+    for ((attempt = 0; attempt < attempts; attempt++)); do
+        if [ ! -e "/proc/$pid" ]; then
+            wait "$pid" 2>/dev/null || true
+            return 0
+        fi
+        current_start=$(migration_process_start_time "$pid" 2>/dev/null) || {
+            [ -e "/proc/$pid" ] || {
+                wait "$pid" 2>/dev/null || true
+                return 0
+            }
+            sleep 0.05
+            continue
+        }
+        [ "$current_start" = "$expected_start" ] || return 2
+        state=$(migration_process_state "$pid" 2>/dev/null) || {
+            [ -e "/proc/$pid" ] || {
+                wait "$pid" 2>/dev/null || true
+                return 0
+            }
+            sleep 0.05
+            continue
+        }
+        case "$state" in
+            Z|X|x)
+                wait "$pid" 2>/dev/null || true
+                return 0
+                ;;
+        esac
+        sleep 0.05
+    done
+    return 1
+}
+
+migration_wait_provisional_owned_process_exit() {
+    local attempts="$2"
+
+    migration_wait_process_exit_by_start_time \
+        "$MIGRATION_PROVISIONAL_OWNED_PID" \
+        "$MIGRATION_PROVISIONAL_OWNED_START" "$attempts"
+}
+
+migration_terminate_provisional_owned_process() {
+    local ws="$1"
+    local wait_status=0 state
+
+    if [ ! -e "/proc/$MIGRATION_PROVISIONAL_OWNED_PID" ]; then
+        wait "$MIGRATION_PROVISIONAL_OWNED_PID" 2>/dev/null || true
+        return 0
+    fi
+    state=$(migration_process_state "$MIGRATION_PROVISIONAL_OWNED_PID" 2>/dev/null) || return 1
+    case "$state" in
+        Z|X|x)
+            wait "$MIGRATION_PROVISIONAL_OWNED_PID" 2>/dev/null || true
+            return 0
+            ;;
+    esac
+    migration_provisional_owned_process_matches "$ws" || return 1
+    migration_signal_owned_process TERM "$MIGRATION_PROVISIONAL_OWNED_PID" || return 1
+    migration_wait_provisional_owned_process_exit "$ws" 40 || wait_status=$?
+    if [ "$wait_status" -eq 0 ]; then
+        return 0
+    fi
+    [ "$wait_status" -eq 1 ] || return 1
+    migration_provisional_owned_process_matches "$ws" || return 1
+    migration_signal_owned_process KILL "$MIGRATION_PROVISIONAL_OWNED_PID" || return 1
+    migration_wait_provisional_owned_process_exit "$ws" 40
+}
+
+migration_wait_owned_process_exit() {
+    local pid="$1"
+    local identity_name="$3"
+    local attempts="$4"
+    local -n identity_ref="$identity_name"
+
+    [ "${#identity_ref[@]}" -eq 7 ] || return 2
+    [ "${identity_ref[0]}" = "$pid" ] || return 2
+    migration_wait_process_exit_by_start_time \
+        "$pid" "${identity_ref[1]}" "$attempts"
+}
+
+migration_terminate_owned_process() {
+    local pid="$1"
+    local ws="$2"
+    local identity_name="$3"
+    local wait_status=0 state
+
+    if [ ! -e "/proc/$pid" ]; then
+        wait "$pid" 2>/dev/null || true
+        return 0
+    fi
+    state=$(migration_process_state "$pid" 2>/dev/null) || {
+        [ -e "/proc/$pid" ] || {
+            wait "$pid" 2>/dev/null || true
+            return 0
+        }
+        return 1
+    }
+    case "$state" in
+        Z|X|x)
+            wait "$pid" 2>/dev/null || true
+            return 0
+            ;;
+    esac
+    migration_owned_process_matches_identity "$pid" "$ws" "$identity_name" || return 1
+    migration_signal_owned_process TERM "$pid" || return 1
+    migration_wait_owned_process_exit "$pid" "$ws" "$identity_name" 40 || wait_status=$?
+    if [ "$wait_status" -eq 0 ]; then
+        return 0
+    fi
+    [ "$wait_status" -eq 1 ] || return 1
+    migration_owned_process_matches_identity "$pid" "$ws" "$identity_name" || return 1
+    migration_signal_owned_process KILL "$pid" || return 1
+    migration_wait_owned_process_exit "$pid" "$ws" "$identity_name" 40
+}
+
+migration_wait_server_port_free() {
+    local ws="$1"
+    local port status=0 attempt
+
+    port=$(cat "$ws/.git/bd-migration-server-port") || return 1
+    [[ "$port" =~ ^2[0-9]{4}$ ]] || return 1
+    for ((attempt = 0; attempt < 100; attempt++)); do
+        if migration_server_port_in_use "$port"; then
+            sleep 0.05
+            continue
+        else
+            status=$?
+            [ "$status" -eq 1 ] || return 1
+            return 0
+        fi
+    done
+    return 1
+}
+
+migration_remove_provisional_identity_files() {
+    local ws="$1"
+    local pid_file="$ws/.git/bd-migration-owned-dolt-server.pid"
+    local identity_file="$ws/.git/bd-migration-owned-dolt-server.identity"
+    local -a recorded_identity
+
+    if [ -e "$pid_file" ] || [ -L "$pid_file" ]; then
+        [ -f "$pid_file" ] && [ ! -L "$pid_file" ] || return 1
+        [ "$(cat "$pid_file")" = "$MIGRATION_PROVISIONAL_OWNED_PID" ] || return 1
+    fi
+    if [ -e "$identity_file" ] || [ -L "$identity_file" ]; then
+        [ -f "$identity_file" ] && [ ! -L "$identity_file" ] || return 1
+        [ "${#MIGRATION_PROVISIONAL_OWNED_IDENTITY[@]}" -eq 7 ] || return 1
+        mapfile -t recorded_identity < "$identity_file" || return 1
+        [ "${recorded_identity[*]}" = "${MIGRATION_PROVISIONAL_OWNED_IDENTITY[*]}" ] || return 1
+    fi
+    rm -f -- "$pid_file" "$identity_file" || return 1
+    [ ! -e "$pid_file" ] && [ ! -L "$pid_file" ] &&
+        [ ! -e "$identity_file" ] && [ ! -L "$identity_file" ]
+}
+
+migration_rollback_provisional_owned_process() {
+    local ws="$1"
+
+    if ! migration_terminate_provisional_owned_process "$ws" ||
+        ! migration_wait_server_port_free "$ws" ||
+        ! migration_remove_provisional_identity_files "$ws"; then
+        echo "provisional owned Dolt server rollback failed; preserved at $ws" >&2
+        return 1
+    fi
+    migration_clear_provisional_owned_process "$ws"
+}
+
+migration_owned_identity_files_match() {
+    local ws="$1"
+    local identity_name="$2"
+    local pid_file="$ws/.git/bd-migration-owned-dolt-server.pid"
+    local -a recorded_identity
+    local -n identity_ref="$identity_name"
+
+    [ -f "$pid_file" ] && [ ! -L "$pid_file" ] || return 1
+    [ "$(cat "$pid_file")" = "${identity_ref[0]}" ] || return 1
+    migration_read_owned_process_identity "$ws" recorded_identity || return 1
+    [ "${recorded_identity[*]}" = "${identity_ref[*]}" ]
+}
+
+migration_remove_owned_identity_files() {
+    local ws="$1"
+    local identity_name="$2"
+    local pid_file="$ws/.git/bd-migration-owned-dolt-server.pid"
+    local identity_file="$ws/.git/bd-migration-owned-dolt-server.identity"
+
+    migration_owned_identity_files_match "$ws" "$identity_name" || return 1
+    rm -f -- "$pid_file" "$identity_file" || return 1
+    [ ! -e "$pid_file" ] && [ ! -L "$pid_file" ] &&
+        [ ! -e "$identity_file" ] && [ ! -L "$identity_file" ]
+}
+
+migration_rollback_started_server() {
+    local ws="$1"
+    local identity_name="$2"
+    local remove_prestarted_marker="$3"
+    local prestarted_file="$ws/.git/bd-migration-prestarted-server"
+    local -n identity_ref="$identity_name"
+
+    if ! migration_terminate_owned_process "${identity_ref[0]}" "$ws" "$identity_name" ||
+        ! migration_wait_server_port_free "$ws" ||
+        ! migration_remove_owned_identity_files "$ws" "$identity_name"; then
+        echo "owned Dolt server rollback failed; preserved at $ws" >&2
+        return 1
+    fi
+    if $remove_prestarted_marker; then
+        rm -f -- "$prestarted_file" || {
+            echo "owned Dolt server rollback failed to remove its mode marker; preserved at $ws" >&2
+            return 1
+        }
+        [ ! -e "$prestarted_file" ] && [ ! -L "$prestarted_file" ] || return 1
+    fi
+    migration_clear_provisional_owned_process "$ws"
+}
+
+owned_migration_dolt_server_ready() {
+    local ws="$1"
+    local dolt_bin="$2"
+    local port="$3"
+    local pid="$4"
+    local attempts="${MIGRATION_DOLT_READY_ATTEMPTS:-100}"
+    local delay="${MIGRATION_DOLT_READY_DELAY:-0.1}"
+    local ready_timeout="${MIGRATION_DOLT_READY_TIMEOUT:-30}"
+    local attempt deadline
+    local -a clean_env
+
+    migration_validate_readiness_settings \
+        "$attempts" "$delay" "$ready_timeout" || return 1
+    migration_subprocess_environment "$ws" clean_env || return 1
+    deadline=$((SECONDS + ready_timeout))
+    for ((attempt = 0; attempt < attempts; attempt++)); do
+        [ "$SECONDS" -lt "$deadline" ] || return 1
+        migration_pid_belongs_to_workspace \
+            "$pid" "$ws" "bd-migration-owned-dolt-server.pid" || return 1
+        if "${clean_env[@]}" timeout --kill-after=1s 2s \
+            "$dolt_bin" --host 127.0.0.1 --port "$port" \
+                --no-tls sql -q 'SELECT 1' \
+            >/dev/null 2>&1; then
+            return 0
+        fi
+        [ "$SECONDS" -lt "$deadline" ] || return 1
+        [ "$delay" = "0" ] || sleep "$delay"
+    done
+    return 1
+}
+
+migration_owned_dolt_sql() {
+    local ws="$1"
+    local database="$2"
+    local query="$3"
+    local git_dir="$ws/.git"
+    local port_file="$git_dir/bd-migration-server-port"
+    local pid_file="$git_dir/bd-migration-owned-dolt-server.pid"
+    local prestarted_file="$git_dir/bd-migration-prestarted-server"
+    local expected_query="SELECT value AS schema_version FROM config WHERE \`key\` = 'schema_version'"
+    local dolt_bin port marker_port pid
+    local -a clean_env
+
+    migration_validate_operation_timeouts || return 1
+    migration_workspace_owned_by_harness "$ws" || return 1
+    [[ "$database" =~ ^[[:alnum:]_][[:alnum:]_-]*$ ]] || return 1
+    [ "${#database}" -le 64 ] || return 1
+    [ "$query" = "$expected_query" ] || return 1
+    [ -f "$port_file" ] && [ ! -L "$port_file" ] || return 1
+    [ -f "$pid_file" ] && [ ! -L "$pid_file" ] || return 1
+    [ -f "$prestarted_file" ] && [ ! -L "$prestarted_file" ] || return 1
+    port=$(cat "$port_file") || return 1
+    marker_port=$(cat "$prestarted_file") || return 1
+    pid=$(cat "$pid_file") || return 1
+    [[ "$port" =~ ^2[0-9]{4}$ ]] && [ "$marker_port" = "$port" ] || return 1
+    migration_pid_belongs_to_workspace \
+        "$pid" "$ws" "bd-migration-owned-dolt-server.pid" || return 1
+    dolt_bin=$(command -v dolt) || return 1
+    dolt_bin=$(readlink -f -- "$dolt_bin") || return 1
+    [ -f "$dolt_bin" ] && [ -x "$dolt_bin" ] || return 1
+    migration_subprocess_environment "$ws" clean_env || return 1
+    "${clean_env[@]}" timeout --kill-after="$BD_OP_KILL_AFTER" \
+        "$BD_OP_TIMEOUT" "$dolt_bin" \
+        --host 127.0.0.1 --port "$port" --no-tls --use-db "$database" \
+        sql -r json -q "$query"
+}
+
+start_owned_migration_dolt_server() {
+    local ws="$1"
+    local git_dir="$ws/.git"
+    local beads_dir="$ws/.beads"
+    local dolt_root="$beads_dir/dolt"
+    local port_file="$git_dir/bd-migration-server-port"
+    local pid_file="$git_dir/bd-migration-owned-dolt-server.pid"
+    local identity_file="$git_dir/bd-migration-owned-dolt-server.identity"
+    local prestarted_file="$git_dir/bd-migration-prestarted-server"
+    local log_file="$git_dir/bd-migration-owned-dolt-server.log"
+    local dolt_bin port pid="" existing_pid="" marker_port="" status attempt
+    local provisional_start=""
+    local marker_tmp="$prestarted_file.tmp.$BASHPID.$RANDOM"
+    local remove_prestarted_marker=true captured=false
+    local -a clean_env owned_identity
+
+    migration_validate_operation_timeouts || return 1
+    migration_workspace_owned_by_harness "$ws" || return 1
+    [ -f "$port_file" ] && [ ! -L "$port_file" ] || return 1
+    port=$(cat "$port_file") || return 1
+    [[ "$port" =~ ^2[0-9]{4}$ ]] || return 1
+
+    if [ -e "$prestarted_file" ] || [ -L "$prestarted_file" ]; then
+        [ -f "$prestarted_file" ] && [ ! -L "$prestarted_file" ] || return 1
+        marker_port=$(cat "$prestarted_file") || return 1
+        [ "$marker_port" = "$port" ] || return 1
+        remove_prestarted_marker=false
+    fi
+    dolt_bin=$(command -v dolt) || return 1
+    dolt_bin=$(readlink -f -- "$dolt_bin") || return 1
+    [ -f "$dolt_bin" ] && [ -x "$dolt_bin" ] || return 1
+    if [ -e "$pid_file" ] || [ -L "$pid_file" ] ||
+        [ -e "$identity_file" ] || [ -L "$identity_file" ]; then
+        [ -f "$pid_file" ] && [ ! -L "$pid_file" ] || return 1
+        [ -f "$identity_file" ] && [ ! -L "$identity_file" ] || return 1
+        existing_pid=$(cat "$pid_file") || return 1
+        migration_pid_belongs_to_workspace \
+            "$existing_pid" "$ws" "bd-migration-owned-dolt-server.pid" || return 1
+        owned_migration_dolt_server_ready "$ws" "$dolt_bin" "$port" "$existing_pid" ||
+            return 1
+        if [ ! -e "$prestarted_file" ]; then
+            (set -o noclobber; umask 077; printf '%s\n' "$port" > "$marker_tmp") \
+                2>/dev/null || return 1
+            mv --no-target-directory --no-clobber -- "$marker_tmp" "$prestarted_file" || {
+                rm -f -- "$marker_tmp"
+                return 1
+            }
+        fi
+        [ -f "$prestarted_file" ] && [ ! -L "$prestarted_file" ] &&
+            [ "$(cat "$prestarted_file")" = "$port" ] &&
+            migration_pid_belongs_to_workspace \
+                "$existing_pid" "$ws" "bd-migration-owned-dolt-server.pid"
+        return
+    fi
+
+    if [ -e "$beads_dir" ] || [ -L "$beads_dir" ]; then
+        [ -d "$beads_dir" ] && [ ! -L "$beads_dir" ] || return 1
+        [ "$(stat -c '%u' -- "$beads_dir")" = "$(id -u)" ] || return 1
+    else
+        mkdir -m 700 -- "$beads_dir" || return 1
+    fi
+    if [ -e "$dolt_root" ] || [ -L "$dolt_root" ]; then
+        [ -d "$dolt_root" ] && [ ! -L "$dolt_root" ] || return 1
+        [ "$(stat -c '%u' -- "$dolt_root")" = "$(id -u)" ] || return 1
+    else
+        mkdir -m 700 -- "$dolt_root" || return 1
+    fi
+    migration_subprocess_environment "$ws" clean_env || return 1
+    if [ -e "$dolt_root/.dolt" ] || [ -L "$dolt_root/.dolt" ]; then
+        [ -d "$dolt_root/.dolt" ] && [ ! -L "$dolt_root/.dolt" ] || return 1
+        [ "$(stat -c '%u' -- "$dolt_root/.dolt")" = "$(id -u)" ] || return 1
+    elif ! (
+        cd -P -- "$dolt_root" &&
+            "${clean_env[@]}" timeout --kill-after="$BD_OP_KILL_AFTER" \
+                "$BD_OP_TIMEOUT" "$dolt_bin" init \
+                --name migration-test --email test@beads.test --initial-branch main
+    ) >/dev/null 2>&1; then
+        return 1
+    fi
+    [ -d "$dolt_root/.dolt" ] && [ ! -L "$dolt_root/.dolt" ] || return 1
+
+    if migration_server_port_in_use "$port"; then
+        return 1
+    else
+        status=$?
+        [ "$status" -eq 1 ] || return 1
+    fi
+    if [ -e "$log_file" ] || [ -L "$log_file" ]; then
+        [ -f "$log_file" ] && [ ! -L "$log_file" ] || return 1
+        [ "$(stat -c '%u' -- "$log_file")" = "$(id -u)" ] || return 1
+    fi
+    : >> "$log_file" || return 1
+    (
+        cd -P -- "$dolt_root" || exit 1
+        exec "${clean_env[@]}" "$dolt_bin" sql-server \
+            --host 127.0.0.1 --port "$port"
+    ) >> "$log_file" 2>&1 < /dev/null &
+    pid=$!
+    provisional_start=$(migration_process_start_time "$pid") || {
+        wait "$pid" 2>/dev/null || true
+        return 1
+    }
+    migration_begin_provisional_owned_process "$ws" "$pid" "$provisional_start"
+
+    for ((attempt = 0; attempt < 100; attempt++)); do
+        if migration_capture_owned_process_identity \
+            "$pid" "$ws" "$dolt_bin" "$port" owned_identity; then
+            captured=true
+            break
+        fi
+        [ -e "/proc/$pid" ] || break
+        sleep 0.02
+    done
+    if ! $captured; then
+        migration_rollback_provisional_owned_process "$ws" || true
+        return 1
+    fi
+    MIGRATION_PROVISIONAL_OWNED_IDENTITY=("${owned_identity[@]}")
+    if ! migration_publish_owned_process_identity "$ws" owned_identity; then
+        if migration_owned_identity_files_match "$ws" owned_identity; then
+            migration_rollback_started_server \
+                "$ws" owned_identity "$remove_prestarted_marker" || true
+        else
+            migration_rollback_provisional_owned_process "$ws" || true
+        fi
+        return 1
+    fi
+    if ! owned_migration_dolt_server_ready "$ws" "$dolt_bin" "$port" "$pid"; then
+        migration_rollback_started_server \
+            "$ws" owned_identity "$remove_prestarted_marker" || true
+        return 1
+    fi
+    if [ ! -e "$prestarted_file" ]; then
+        if ! (set -o noclobber; umask 077; printf '%s\n' "$port" > "$marker_tmp") \
+                2>/dev/null ||
+            ! mv --no-target-directory --no-clobber -- "$marker_tmp" "$prestarted_file"; then
+            rm -f -- "$marker_tmp"
+            migration_rollback_started_server \
+                "$ws" owned_identity "$remove_prestarted_marker" || true
+            return 1
+        fi
+    fi
+    if [ -f "$pid_file" ] && [ ! -L "$pid_file" ] &&
+        [ "$(cat "$pid_file")" = "$pid" ] &&
+        [ -f "$identity_file" ] && [ ! -L "$identity_file" ] &&
+        [ -f "$prestarted_file" ] && [ ! -L "$prestarted_file" ] &&
+        [ "$(cat "$prestarted_file")" = "$port" ] &&
+        migration_pid_belongs_to_workspace \
+            "$pid" "$ws" "bd-migration-owned-dolt-server.pid"; then
+        migration_clear_provisional_owned_process "$ws"
+        return 0
+    fi
+    migration_rollback_started_server \
+        "$ws" owned_identity "$remove_prestarted_marker" || true
+    return 1
+}
+
 stop_dolt_server() {
     local ws="$1"
-    local pid="" pidfile_name="" port="" status=0
+    local pid="" pidfile_name=""
+    local owned_pid="" owned_state=""
+    local owned_pid_file="$ws/.git/bd-migration-owned-dolt-server.pid"
+    local owned_identity_file="$ws/.git/bd-migration-owned-dolt-server.identity"
+    local -a owned_identity
     migration_workspace_owned_by_harness "$ws" || return 1
+    if [ "$MIGRATION_PROVISIONAL_OWNED_WS" = "$ws" ] &&
+        { [ ! -f "$owned_pid_file" ] || [ -L "$owned_pid_file" ] ||
+            [ ! -f "$owned_identity_file" ] || [ -L "$owned_identity_file" ]; }; then
+        migration_rollback_provisional_owned_process "$ws" || return 1
+    fi
+    if [ -e "$owned_pid_file" ] || [ -L "$owned_pid_file" ] ||
+        [ -e "$owned_identity_file" ] || [ -L "$owned_identity_file" ]; then
+        [ -f "$owned_pid_file" ] && [ ! -L "$owned_pid_file" ] || return 1
+        [ -f "$owned_identity_file" ] && [ ! -L "$owned_identity_file" ] || return 1
+        owned_pid=$(cat "$owned_pid_file") || return 1
+        [[ "$owned_pid" =~ ^[0-9]+$ ]] && [ "$owned_pid" -gt 1 ] || return 1
+        migration_read_owned_process_identity "$ws" owned_identity || return 1
+        [ "${owned_identity[0]}" = "$owned_pid" ] || return 1
+        if [ -e "/proc/$owned_pid" ]; then
+            owned_state=$(migration_process_state "$owned_pid" 2>/dev/null) || {
+                [ -e "/proc/$owned_pid" ] && return 1
+                owned_state=""
+            }
+            case "$owned_state" in
+                ""|Z|X|x) ;;
+                *)
+                    migration_owned_process_matches_identity \
+                        "$owned_pid" "$ws" owned_identity || return 1
+                    migration_terminate_owned_process \
+                        "$owned_pid" "$ws" owned_identity || return 1
+                    ;;
+            esac
+            wait "$owned_pid" 2>/dev/null || true
+        fi
+    fi
     for pidfile in "$ws/.beads/dolt-monitor.pid" "$ws/.beads/daemon.pid" "$ws/.beads/dolt-server.pid"; do
         if [ -f "$pidfile" ] && [ ! -L "$pidfile" ]; then
             pid=$(cat "$pidfile" 2>/dev/null) || true
@@ -411,13 +1185,10 @@ stop_dolt_server() {
             fi
         fi
     done
-    sleep 1
-    port=$(cat "$ws/.git/bd-migration-server-port") || return 1
-    if migration_server_port_in_use "$port"; then
-        return 1
-    else
-        status=$?
-        [ "$status" -eq 1 ] || return 1
+    migration_wait_server_port_free "$ws" || return 1
+    if [ -n "$owned_pid" ]; then
+        migration_remove_owned_identity_files "$ws" owned_identity || return 1
+        migration_clear_provisional_owned_process "$ws"
     fi
     rm -f "$ws/.beads/bd.sock" "$ws/.beads/dolt-server.lock" 2>/dev/null || true
 }

--- a/scripts/migration-test/public-v062-bridge-test.sh
+++ b/scripts/migration-test/public-v062-bridge-test.sh
@@ -1,0 +1,644 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+BRIDGE="$REPO_ROOT/scripts/migrate-v062-server-to-current.sh"
+
+fail() {
+    printf 'public-v062-bridge-test: %s\n' "$*" >&2
+    exit 1
+}
+
+[ -x "$BRIDGE" ] || fail "missing executable public bridge: $BRIDGE"
+command -v jq >/dev/null || fail "jq is required"
+command -v script >/dev/null || fail "script is required"
+
+if [ -n "${PUBLIC_V062_REAL_TARGET_BD:-}" ]; then
+    REAL_TARGET_BD=$(realpath -e -- "$PUBLIC_V062_REAL_TARGET_BD") ||
+        fail "PUBLIC_V062_REAL_TARGET_BD cannot be resolved"
+else
+    (cd "$REPO_ROOT" && make build >/dev/null) ||
+        fail "could not build the real current bd target"
+    REAL_TARGET_BD="$REPO_ROOT/bd"
+fi
+[ -f "$REAL_TARGET_BD" ] && [ -x "$REAL_TARGET_BD" ] ||
+    fail "real current bd target is not executable: $REAL_TARGET_BD"
+
+tmp=$(mktemp -d "${TMPDIR:-/tmp}/bd-public-v062-bridge.XXXXXX")
+trap 'rm -rf -- "$tmp"' EXIT
+mkdir -p "$tmp/home"
+
+TARGET_BD="$tmp/fake-bd-current"
+TARGET_LOG="$tmp/fake-target.log"
+OLD_TARGET_BD="$tmp/fake-bd-old-target"
+OLD_TARGET_LOG="$tmp/fake-old-target.log"
+INCAPABLE_TARGET_BD="$tmp/fake-bd-incapable-target"
+INCAPABLE_TARGET_LOG="$tmp/fake-incapable-target.log"
+TIMEOUT_TARGET_BD="$tmp/fake-bd-timeout-target"
+TIMEOUT_TARGET_LOG="$tmp/fake-timeout-target.log"
+
+make_fake_bd() {
+    local path="$1" version="$2" capability="$3" log="$4"
+    cat > "$path" <<EOF
+#!/usr/bin/env bash
+{
+    printf 'argv=%q' "\$0"
+    printf ' %q' "\$@"
+    printf '\n'
+    env | LC_ALL=C sort
+} >> '$log'
+case "\${1:-}" in
+    version)
+        [ "\${2:-}" = --json ] || exit 2
+        printf '{"version":"%s","build":"test"}\n' '$version'
+        ;;
+    __migration-v062-inspect)
+        if [ '$capability' = timeout ]; then
+            printf '%s\n' "\$\$" > '${log}.pid'
+            exec /usr/bin/sleep 30
+        fi
+        [ '$capability' = embedded ] || exit 2
+        [ "\$#" -eq 4 ] && [ "\$2" = --workspace ] &&
+            [[ "\$3" = /* ]] && [ "\$4" = --json ] || exit 2
+        inspection_code=
+        inspection_retryable=false
+        inspection_exit=1
+        qualified_workspace="\$3"
+        qualified_digest_scope=admission_observation
+        qualified_exit=0
+        repeat_qualified=false
+        case "\${3##*/}" in
+            wrong-witness) inspection_code=source_version_mismatch ;;
+            missing-witness) inspection_code=source_version_missing ;;
+            ambiguous-witness) inspection_code=source_version_ambiguous ;;
+            wrong-metadata) inspection_code=source_metadata_mismatch ;;
+            symlink-layout) inspection_code=unsafe_source_symlink ;;
+            mixed-target) inspection_code=mixed_storage_layout ;;
+            rollback-collision) inspection_code=rollback_collision ;;
+            lying-workspace)
+                qualified_workspace=/not/the/requested/workspace
+                ;;
+            wrong-digest-scope) qualified_digest_scope=lifetime_authority ;;
+            multiple-json) repeat_qualified=true ;;
+            qualified-wrong-exit) qualified_exit=1 ;;
+            refused-wrong-exit)
+                inspection_code=source_version_mismatch
+                inspection_exit=0
+                ;;
+            unknown-refusal-code) inspection_code=unrecognized_private_code ;;
+            wrong-retryability-stable)
+                inspection_code=source_version_mismatch
+                inspection_retryable=true
+                ;;
+            wrong-retryability-transient)
+                inspection_code=source_changed
+                inspection_retryable=false
+                ;;
+            retryable-source-changed)
+                inspection_code=source_changed
+                inspection_retryable=true
+                ;;
+        esac
+        if [ -n "\$inspection_code" ]; then
+            printf '{"schema_version":1,"operation":"v062_source_inspection","status":"refused","retryable":%s,"effect":"none","code":"%s"}\n' "\$inspection_retryable" "\$inspection_code"
+            exit "\$inspection_exit"
+        fi
+        printf '{"schema_version":1,"operation":"v062_source_inspection","status":"qualified","retryable":false,"effect":"none","source":{"workspace":"%s","version":"0.62.0","backend":"dolt-server","tree_sha256":"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef","digest_scope":"%s"},"target":{"version":"%s","backend":"dolt-embedded","embedded_capable":true}}\n' "\$qualified_workspace" "\$qualified_digest_scope" '$version'
+        if \$repeat_qualified; then
+            printf '{"schema_version":1,"operation":"v062_source_inspection","status":"qualified","retryable":false,"effect":"none","source":{"workspace":"%s","version":"0.62.0","backend":"dolt-server","tree_sha256":"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef","digest_scope":"%s"},"target":{"version":"%s","backend":"dolt-embedded","embedded_capable":true}}\n' "\$qualified_workspace" "\$qualified_digest_scope" '$version'
+        fi
+        exit "\$qualified_exit"
+        ;;
+    *) exit 2 ;;
+esac
+EOF
+    chmod +x "$path"
+}
+
+make_fake_bd "$TARGET_BD" 1.1.0 embedded "$TARGET_LOG"
+make_fake_bd "$OLD_TARGET_BD" 0.62.0 embedded "$OLD_TARGET_LOG"
+make_fake_bd "$INCAPABLE_TARGET_BD" 1.1.0 unavailable "$INCAPABLE_TARGET_LOG"
+make_fake_bd "$TIMEOUT_TARGET_BD" 1.1.0 timeout "$TIMEOUT_TARGET_LOG"
+
+new_v062_workspace() {
+    local ws="$1"
+    mkdir -p "$ws"
+    GIT_CONFIG_NOSYSTEM=1 GIT_CONFIG_GLOBAL=/dev/null \
+        git -C "$ws" init --quiet
+    git -C "$ws" config core.hooksPath .git/hooks
+    mkdir -p \
+        "$ws/.beads/dolt/.dolt" \
+        "$ws/.beads/dolt/smoke/.dolt"
+    cat > "$ws/.beads/metadata.json" <<'EOF'
+{
+  "database": "dolt",
+  "backend": "dolt",
+  "dolt_mode": "server",
+  "dolt_server_host": "127.0.0.1",
+  "dolt_server_port": 3307,
+  "dolt_database": "smoke",
+  "project_id": "7ef372b4-4c3c-4e2c-a6cc-29dd2d0a28c6"
+}
+EOF
+    printf '0.62.0\n' > "$ws/.beads/.local_version"
+    printf '{}\n' > "$ws/.beads/dolt/.dolt/config.json"
+    printf '{"head":"refs/heads/main"}\n' > "$ws/.beads/dolt/.dolt/repo_state.json"
+    printf '{}\n' > "$ws/.beads/dolt/smoke/.dolt/config.json"
+    printf '{"head":"refs/heads/main"}\n' > "$ws/.beads/dolt/smoke/.dolt/repo_state.json"
+    printf 'listener:\n  host: 127.0.0.1\n  port: 3307\n' \
+        > "$ws/.beads/dolt/config.yaml"
+}
+
+tree_fingerprint() {
+    local root="$1"
+    (
+        cd "$root"
+        find -P . -mindepth 1 \
+            -printf '%y %m %D %i %n %u %g %s %T@ %C@ %p %l\n' |
+            LC_ALL=C sort
+        find -P . -type f -print0 | LC_ALL=C sort -z | xargs -0 -r sha256sum
+    ) | sha256sum | awk '{print $1}'
+}
+
+RUN_STATUS=0
+RUN_STDOUT=""
+RUN_STDERR=""
+run_bridge() {
+    local label="$1" cwd="$2"
+    shift 2
+    local out="$tmp/$label.stdout" err="$tmp/$label.stderr"
+    local target="${BRIDGE_TEST_TARGET:-$TARGET_BD}"
+    set +e
+    (
+        cd "$cwd"
+        env -i \
+            "PATH=$PATH" "HOME=$tmp/home" "TMPDIR=$tmp" \
+            LANG=C LC_ALL=C TZ=UTC TERM=dumb \
+            BD_BACKEND=postgres BD_DATABASE_BACKEND=mysql \
+            BEADS_DB='postgres://poison.invalid/beads' \
+            BD_DB='mysql://poison.invalid/beads' \
+            BEADS_DIR="$tmp/poison-beads" \
+            BEADS_SQLITE_PATH="$tmp/poison.sqlite" \
+            BEADS_DOLT_SERVER_MODE=1 BEADS_DOLT_SHARED_SERVER=1 \
+            BEADS_DOLT_DATA_DIR="$tmp/poison-dolt" \
+            BEADS_DOLT_SERVER_HOST=poison.invalid \
+            BEADS_DOLT_SERVER_PORT=29999 \
+            "BD_V062_INSPECT_TIMEOUT_SECONDS=${BRIDGE_TEST_INSPECT_TIMEOUT_SECONDS:-600}" \
+            "$BRIDGE" --target-bd "$target" --json "$@" \
+            </dev/null >"$out" 2>"$err"
+    )
+    RUN_STATUS=$?
+    set -e
+    RUN_STDOUT=$(<"$out")
+    RUN_STDERR=$(<"$err")
+}
+
+run_apply_without_yes_on_tty() {
+    local ws="$1" command
+    printf -v command '%q ' env -i "PATH=$PATH" "HOME=$tmp/home" \
+        LANG=C LC_ALL=C TZ=UTC TERM=dumb "$BRIDGE" \
+        --target-bd "$TARGET_BD" --apply --workspace "$ws" --json
+    set +e
+    (cd "$ws" && script -q -e -c "$command" /dev/null >/dev/null 2>&1)
+    RUN_STATUS=$?
+    set -e
+}
+
+assert_common_json() {
+    local mode="$1" status="$2" effect="$3"
+    jq -se --arg mode "$mode" --arg status "$status" --arg effect "$effect" '
+        length == 1 and (.[0] |
+            type == "object" and
+            .schema_version == 1 and
+            .operation == "v062_server_to_current" and
+            .mode == $mode and .status == $status and
+            (.retryable | type) == "boolean" and .effect == $effect and
+            (keys - ["schema_version", "operation", "mode", "status",
+                     "retryable", "effect", "code", "source", "target",
+                     "rollback", "verification"] | length) == 0
+        )
+    ' <<< "$RUN_STDOUT" >/dev/null ||
+        fail "invalid JSON contract for $mode/$status: $RUN_STDOUT $RUN_STDERR"
+}
+
+assert_unchanged() {
+    local ws="$1" before="$2" context="$3"
+    [ "$(tree_fingerprint "$ws")" = "$before" ] ||
+        fail "$context mutated the workspace"
+}
+
+# Default mode is inspect. It can report the target-qualified source plan but
+# must not claim the bridge is ready until the public apply path exists.
+inspect_ws="$tmp/inspect-default"
+new_v062_workspace "$inspect_ws"
+inspect_before=$(tree_fingerprint "$inspect_ws")
+run_bridge inspect-default "$inspect_ws"
+[ "$RUN_STATUS" -eq 1 ] || fail "default inspect exit=$RUN_STATUS, want 1"
+assert_common_json inspect failed none
+jq -e '
+    .retryable == false and .code == "apply_not_available" and
+    .source.version == "0.62.0" and .source.backend == "dolt-server" and
+    .source.digest_scope == "admission_observation" and
+    (.source.tree_sha256 | test("^[0-9a-f]{64}$")) and
+    .target.backend == "dolt-embedded" and .target.embedded_capable == true and
+    (.rollback | type) == "object" and
+    .verification.source_digest_scope == "admission_observation" and
+    .verification.apply_reinspection_required == true and
+    .verification.apply_available == false and
+    .verification.workspace_effects == false
+' <<< "$RUN_STDOUT" >/dev/null || fail "default inspect omitted its qualified plan"
+default_json=$(jq -Sc . <<< "$RUN_STDOUT")
+assert_unchanged "$inspect_ws" "$inspect_before" "default inspect"
+
+run_bridge inspect-explicit "$inspect_ws" --inspect --workspace "$inspect_ws"
+[ "$RUN_STATUS" -eq 1 ] || fail "explicit inspect exit=$RUN_STATUS, want 1"
+assert_common_json inspect failed none
+[ "$(jq -Sc . <<< "$RUN_STDOUT")" = "$default_json" ] ||
+    fail "default and explicit inspect returned different JSON contracts"
+assert_unchanged "$inspect_ws" "$inspect_before" "explicit inspect"
+
+# Provider and database selectors inherited from the caller may not reach the
+# target binary, which owns both version and hidden migration inspection.
+[ -s "$TARGET_LOG" ] || fail "inspect did not validate the target binary"
+grep -F -- '__migration-v062-inspect' "$TARGET_LOG" >/dev/null ||
+    fail "public inspect did not use the target hidden inspection command"
+grep -F -- "--workspace $inspect_ws --json" "$TARGET_LOG" >/dev/null ||
+    fail "target hidden inspection did not receive the physical workspace"
+for poison in \
+    'BD_BACKEND=postgres' 'BD_DATABASE_BACKEND=mysql' \
+    'postgres://poison.invalid/beads' 'mysql://poison.invalid/beads' \
+    "$tmp/poison-beads" "$tmp/poison.sqlite" "$tmp/poison-dolt" \
+    'BEADS_DOLT_SERVER_MODE=1' 'BEADS_DOLT_SHARED_SERVER=1' \
+    'poison.invalid' 'BEADS_DOLT_SERVER_PORT=29999'; do
+    if grep -F -- "$poison" "$TARGET_LOG" >/dev/null; then
+        fail "ambient provider selector reached the target binary: $poison"
+    fi
+done
+
+# Treat the hidden command as an untrusted protocol peer. A response is
+# admissible only when its payload and process exit form one exact tuple.
+protocol_rejection_failures=()
+check_protocol_rejected() {
+    local label="$1" ws="$tmp/$1" before
+    new_v062_workspace "$ws"
+    before=$(tree_fingerprint "$ws")
+    run_bridge "$label" "$ws" --inspect --workspace "$ws"
+    if [ "$RUN_STATUS" -ne 1 ]; then
+        printf '%s: exit=%s, want 1\n' "$label" "$RUN_STATUS" >&2
+        return 1
+    fi
+    if ! jq -se '
+        length == 1 and .[0] == {
+            schema_version: 1,
+            operation: "v062_server_to_current",
+            mode: "inspect",
+            status: "refused",
+            retryable: false,
+            effect: "none",
+            code: "target_capability_missing"
+        }
+    ' <<< "$RUN_STDOUT" >/dev/null 2>&1; then
+        printf '%s: wrapper trusted invalid inspector tuple: %s %s\n' \
+            "$label" "$RUN_STDOUT" "$RUN_STDERR" >&2
+        return 1
+    fi
+    if [ "$(tree_fingerprint "$ws")" != "$before" ]; then
+        printf '%s: protocol rejection mutated the workspace\n' "$label" >&2
+        return 1
+    fi
+}
+
+for protocol_case in \
+    lying-workspace \
+    wrong-digest-scope \
+    multiple-json \
+    qualified-wrong-exit \
+    refused-wrong-exit \
+    unknown-refusal-code \
+    wrong-retryability-stable \
+    wrong-retryability-transient; do
+    if ! check_protocol_rejected "$protocol_case"; then
+        protocol_rejection_failures+=("$protocol_case")
+    fi
+done
+if [ "${#protocol_rejection_failures[@]}" -ne 0 ]; then
+    fail "inspector protocol regressions: ${protocol_rejection_failures[*]}"
+fi
+
+assert_refused() {
+    local label="$1" ws="$2" code="$3"
+    local before
+    before=$(tree_fingerprint "$ws")
+    run_bridge "$label" "$ws" --inspect --workspace "$ws"
+    [ "$RUN_STATUS" -eq 1 ] || fail "$label exit=$RUN_STATUS, want refusal exit 1"
+    assert_common_json inspect refused none
+    jq -e --arg code "$code" '.retryable == false and .code == $code' \
+        <<< "$RUN_STDOUT" >/dev/null || fail "$label returned the wrong refusal code"
+    assert_unchanged "$ws" "$before" "$label refusal"
+}
+
+wrong_ws="$tmp/wrong-witness"; new_v062_workspace "$wrong_ws"
+printf '0.61.0\n' > "$wrong_ws/.beads/.local_version"
+assert_refused wrong-witness "$wrong_ws" source_version_mismatch
+
+missing_ws="$tmp/missing-witness"; new_v062_workspace "$missing_ws"
+rm -f -- "$missing_ws/.beads/.local_version"
+assert_refused missing-witness "$missing_ws" source_version_missing
+
+ambiguous_ws="$tmp/ambiguous-witness"; new_v062_workspace "$ambiguous_ws"
+mv -f -- "$ambiguous_ws/.beads/.local_version" "$ambiguous_ws/version-target"
+ln -s ../version-target "$ambiguous_ws/.beads/.local_version"
+assert_refused ambiguous-witness "$ambiguous_ws" source_version_ambiguous
+
+metadata_ws="$tmp/wrong-metadata"; new_v062_workspace "$metadata_ws"
+jq '.backend = "postgres"' "$metadata_ws/.beads/metadata.json" \
+    > "$metadata_ws/.beads/metadata.json.tmp"
+mv -f -- "$metadata_ws/.beads/metadata.json.tmp" "$metadata_ws/.beads/metadata.json"
+assert_refused wrong-metadata "$metadata_ws" source_metadata_mismatch
+
+symlink_ws="$tmp/symlink-layout"; new_v062_workspace "$symlink_ws"
+mv -f -- "$symlink_ws/.beads/dolt" "$symlink_ws/.beads/dolt-real"
+ln -s dolt-real "$symlink_ws/.beads/dolt"
+assert_refused symlink-layout "$symlink_ws" unsafe_source_symlink
+
+mixed_ws="$tmp/mixed-target"; new_v062_workspace "$mixed_ws"
+mkdir -p "$mixed_ws/.beads/embeddeddolt"
+assert_refused mixed-target "$mixed_ws" mixed_storage_layout
+
+collision_ws="$tmp/rollback-collision"; new_v062_workspace "$collision_ws"
+mkdir -p "$collision_ws/.beads-v0.62.0-rollback"
+printf 'unrelated retained data\n' > "$collision_ws/.beads-v0.62.0-rollback/sentinel"
+assert_refused rollback-collision "$collision_ws" rollback_collision
+
+changed_ws="$tmp/retryable-source-changed"; new_v062_workspace "$changed_ws"
+changed_before=$(tree_fingerprint "$changed_ws")
+run_bridge retryable-source-changed "$changed_ws" \
+    --inspect --workspace "$changed_ws"
+[ "$RUN_STATUS" -eq 1 ] ||
+    fail "retryable source change exit=$RUN_STATUS, want refusal exit 1"
+assert_common_json inspect refused none
+jq -e '
+    .retryable == true and .code == "source_changed"
+' <<< "$RUN_STDOUT" >/dev/null ||
+    fail "valid retryable source change was not forwarded unchanged"
+assert_unchanged "$changed_ws" "$changed_before" \
+    "retryable source change refusal"
+
+assert_target_refused() {
+    local label="$1" target="$2" code="$3" ws="$tmp/$1"
+    local before
+    new_v062_workspace "$ws"
+    before=$(tree_fingerprint "$ws")
+    BRIDGE_TEST_TARGET="$target" run_bridge "$label" "$ws" --inspect --workspace "$ws"
+    [ "$RUN_STATUS" -eq 1 ] || fail "$label exit=$RUN_STATUS, want refusal exit 1"
+    assert_common_json inspect refused none
+    jq -e --arg code "$code" '.retryable == false and .code == $code' \
+        <<< "$RUN_STDOUT" >/dev/null || fail "$label returned the wrong refusal code"
+    assert_unchanged "$ws" "$before" "$label refusal"
+}
+
+assert_target_refused old-target "$OLD_TARGET_BD" target_binary_invalid
+grep -F -- '__migration-v062-inspect' "$OLD_TARGET_LOG" >/dev/null ||
+    fail "historical target was rejected without validating its hidden response"
+assert_target_refused incapable-target "$INCAPABLE_TARGET_BD" target_capability_missing
+grep -F -- '__migration-v062-inspect' "$INCAPABLE_TARGET_LOG" >/dev/null ||
+    fail "embedded-incapable target was rejected without a capability probe"
+
+timeout_ws="$tmp/timeout-target"
+new_v062_workspace "$timeout_ws"
+timeout_before=$(tree_fingerprint "$timeout_ws")
+timeout_started=$SECONDS
+BRIDGE_TEST_INSPECT_TIMEOUT_SECONDS=1 \
+BRIDGE_TEST_TARGET="$TIMEOUT_TARGET_BD" \
+    run_bridge timeout-target "$timeout_ws" --inspect --workspace "$timeout_ws"
+timeout_elapsed=$((SECONDS - timeout_started))
+[ "$RUN_STATUS" -eq 1 ] ||
+    fail "timeout target exit=$RUN_STATUS, want refusal exit 1"
+[ "$timeout_elapsed" -le 5 ] ||
+    fail "timeout target exceeded its wall-clock bound (${timeout_elapsed}s)"
+assert_common_json inspect refused none
+jq -e '
+    .retryable == true and .code == "target_inspection_timeout"
+' <<< "$RUN_STDOUT" >/dev/null ||
+    fail "target timeout was not reported as a retryable refusal"
+[ -s "${TIMEOUT_TARGET_LOG}.pid" ] ||
+    fail "timeout target did not record its process identity"
+timeout_target_pid=$(<"${TIMEOUT_TARGET_LOG}.pid")
+if kill -0 "$timeout_target_pid" 2>/dev/null; then
+    fail "timed-out target process $timeout_target_pid leaked"
+fi
+assert_unchanged "$timeout_ws" "$timeout_before" "target timeout refusal"
+
+# Apply always requires explicit consent, even on a terminal, and every
+# currently admitted apply remains truthfully unavailable and non-mutating.
+apply_ws="$tmp/apply-without-consent"; new_v062_workspace "$apply_ws"
+apply_before=$(tree_fingerprint "$apply_ws")
+run_bridge apply-without-consent "$apply_ws" --apply --workspace "$apply_ws"
+[ "$RUN_STATUS" -eq 2 ] || fail "apply without --yes exit=$RUN_STATUS, want 2"
+assert_common_json apply usage_error none
+jq -e '.retryable == false and .code == "confirmation_required"' \
+    <<< "$RUN_STDOUT" >/dev/null || fail "apply without --yes lacked stable JSON"
+assert_unchanged "$apply_ws" "$apply_before" "apply without --yes"
+
+run_apply_without_yes_on_tty "$apply_ws"
+[ "$RUN_STATUS" -eq 2 ] || fail "TTY apply without --yes exit=$RUN_STATUS, want 2"
+assert_unchanged "$apply_ws" "$apply_before" "TTY apply without --yes"
+
+run_bridge apply-unavailable "$apply_ws" --apply --yes --workspace "$apply_ws"
+[ "$RUN_STATUS" -eq 1 ] || fail "apply --yes exit=$RUN_STATUS, want 1"
+assert_common_json apply failed none
+jq -e '.retryable == false and .code == "apply_not_available"' \
+    <<< "$RUN_STDOUT" >/dev/null || fail "apply --yes overstated bridge availability"
+jq -e '
+    .verification.source_digest_scope == "admission_observation" and
+    .verification.apply_reinspection_required == true
+' <<< "$RUN_STDOUT" >/dev/null ||
+    fail "apply --yes omitted its mandatory source reinspection contract"
+assert_unchanged "$apply_ws" "$apply_before" "unavailable apply"
+
+# JSON is bootstrapped before ordinary parsing: even when --json follows an
+# invalid flag, the result is one structured usage error and no effects.
+run_bridge invalid-usage "$inspect_ws" --definitely-not-a-real-option
+[ "$RUN_STATUS" -eq 2 ] || fail "invalid usage exit=$RUN_STATUS, want 2"
+assert_common_json inspect usage_error none
+jq -e '.retryable == false and .code == "invalid_usage"' \
+    <<< "$RUN_STDOUT" >/dev/null || fail "invalid usage lacked stable JSON"
+assert_unchanged "$inspect_ws" "$inspect_before" "invalid usage"
+
+assert_usage_error() {
+    local label="$1" code="$2"
+    shift 2
+    run_bridge "$label" "$inspect_ws" "$@"
+    [ "$RUN_STATUS" -eq 2 ] ||
+        fail "$label exit=$RUN_STATUS, want usage exit 2"
+    assert_common_json inspect usage_error none
+    jq -e --arg code "$code" '.retryable == false and .code == $code' \
+        <<< "$RUN_STDOUT" >/dev/null ||
+        fail "$label lacked its stable usage code"
+    assert_unchanged "$inspect_ws" "$inspect_before" "$label"
+}
+
+assert_usage_error conflicting-modes invalid_usage --inspect --apply
+assert_usage_error inspect-with-yes invalid_usage --inspect --yes
+assert_usage_error workspace-missing-value invalid_usage --workspace
+assert_usage_error target-missing-value invalid_usage --target-bd
+
+for invalid_timeout in \
+    0 \
+    3601 \
+    999999999999999999999999999999999999999999999999999999999999 \
+    not-a-number; do
+    BRIDGE_TEST_INSPECT_TIMEOUT_SECONDS="$invalid_timeout" \
+        run_bridge "invalid-timeout-$invalid_timeout" "$inspect_ws" --inspect
+    [ "$RUN_STATUS" -eq 2 ] ||
+        fail "invalid timeout $invalid_timeout exit=$RUN_STATUS, want 2"
+    assert_common_json inspect usage_error none
+    jq -e '
+        .retryable == false and .code == "invalid_environment"
+    ' <<< "$RUN_STDOUT" >/dev/null ||
+        fail "invalid timeout $invalid_timeout lacked its stable usage code"
+    assert_unchanged "$inspect_ws" "$inspect_before" \
+        "invalid timeout $invalid_timeout"
+done
+
+# Close the test-double gap: exercise the actual built current bd through the
+# public shell entrypoint, hidden Cobra protocol, and descriptor-relative Go
+# inspector. This is the admission slice's real process-boundary E2E path.
+real_ws="$tmp/real-current-target"
+new_v062_workspace "$real_ws"
+# Fresh v0.62.0 workspaces using the default server endpoint omit these
+# optional metadata fields; exercise that authentic shape through the real
+# current binary rather than only the explicitly configured CI fixture.
+jq 'del(.dolt_server_host, .dolt_server_port)' \
+    "$real_ws/.beads/metadata.json" > "$real_ws/.beads/metadata.json.tmp"
+mv -f -- "$real_ws/.beads/metadata.json.tmp" \
+    "$real_ws/.beads/metadata.json"
+real_before=$(tree_fingerprint "$real_ws")
+
+hostile_cwd="$tmp/hostile-cwd"
+hostile_home="$tmp/hostile-home-real"
+mkdir -p \
+    "$hostile_cwd/.beads" \
+    "$hostile_home/.config/bd" \
+    "$hostile_home/.cache" \
+    "$hostile_home/.local/share" \
+    "$hostile_home/.local/state"
+printf '%s\n' '{"backend":"postgres","database":"postgres"}' \
+    > "$hostile_cwd/.beads/metadata.json"
+printf '%s\n' 'backend: postgres' > "$hostile_cwd/.beads/config.yaml"
+printf '%s\n' 'BD_BACKEND=postgres' > "$hostile_cwd/.beads/.env"
+printf '%s\n' 'metrics.disabled: false' \
+    > "$hostile_home/.config/bd/config.yaml"
+hostile_cwd_before=$(tree_fingerprint "$hostile_cwd")
+hostile_home_before=$(tree_fingerprint "$hostile_home")
+hidden_real_stdout="$tmp/hidden-real.stdout"
+hidden_real_stderr="$tmp/hidden-real.stderr"
+set +e
+(
+    cd "$hostile_cwd"
+    env \
+        HOME="$hostile_home" \
+        XDG_CONFIG_HOME="$hostile_home/.config" \
+        XDG_CACHE_HOME="$hostile_home/.cache" \
+        XDG_DATA_HOME="$hostile_home/.local/share" \
+        XDG_STATE_HOME="$hostile_home/.local/state" \
+        BD_BACKEND=postgres BD_DATABASE_BACKEND=mysql \
+        BEADS_DB='postgres://poison.invalid/beads' \
+        BD_DB='mysql://poison.invalid/beads' \
+        BEADS_DIR="$hostile_cwd/.beads" \
+        "$REAL_TARGET_BD" __migration-v062-inspect \
+            --workspace "$real_ws" --json \
+            > "$hidden_real_stdout" 2> "$hidden_real_stderr"
+)
+hidden_real_status=$?
+set -e
+[ "$hidden_real_status" -eq 0 ] ||
+    fail "real hidden command exit=$hidden_real_status, want 0"
+[ ! -s "$hidden_real_stderr" ] ||
+    fail "real hidden command emitted stderr: $(<"$hidden_real_stderr")"
+jq -e --arg workspace "$real_ws" '
+    keys == ["effect", "operation", "retryable", "schema_version",
+             "source", "status", "target"] and
+    .schema_version == 1 and .operation == "v062_source_inspection" and
+    .status == "qualified" and .retryable == false and .effect == "none" and
+    .source.workspace == $workspace and .source.version == "0.62.0" and
+    .source.backend == "dolt-server" and
+    .source.digest_scope == "admission_observation" and
+    (.source.tree_sha256 | test("^[0-9a-f]{64}$")) and
+    .target.backend == "dolt-embedded" and
+    .target.embedded_capable == true
+' "$hidden_real_stdout" >/dev/null ||
+    fail "real hidden command did not emit the exact qualified protocol"
+assert_unchanged "$real_ws" "$real_before" "real hidden command"
+assert_unchanged "$hostile_cwd" "$hostile_cwd_before" \
+    "real hidden command hostile cwd"
+assert_unchanged "$hostile_home" "$hostile_home_before" \
+    "real hidden command hostile home"
+hidden_real_digest=$(jq -r '.source.tree_sha256' "$hidden_real_stdout")
+
+BRIDGE_TEST_TARGET="$REAL_TARGET_BD" \
+    run_bridge real-current-target "$real_ws" \
+        --inspect --workspace "$real_ws"
+[ "$RUN_STATUS" -eq 1 ] ||
+    fail "real current target exit=$RUN_STATUS, want fail-closed exit 1"
+assert_common_json inspect failed none
+jq -e --arg workspace "$real_ws" --arg digest "$hidden_real_digest" '
+    .retryable == false and .code == "apply_not_available" and
+    .source.workspace == $workspace and .source.version == "0.62.0" and
+    .source.backend == "dolt-server" and
+    .source.digest_scope == "admission_observation" and
+    .source.tree_sha256 == $digest and
+    .target.backend == "dolt-embedded" and
+    .target.embedded_capable == true and
+    .verification.source_digest_scope == "admission_observation" and
+    .verification.apply_reinspection_required == true
+' <<< "$RUN_STDOUT" >/dev/null ||
+    fail "real current target did not return the qualified admission plan"
+assert_unchanged "$real_ws" "$real_before" "real current target inspection"
+
+real_negative_ws="$tmp/real-current-negative"
+new_v062_workspace "$real_negative_ws"
+printf '0.61.0\n' > "$real_negative_ws/.beads/.local_version"
+real_negative_before=$(tree_fingerprint "$real_negative_ws")
+BRIDGE_TEST_TARGET="$REAL_TARGET_BD" \
+    run_bridge real-current-negative "$real_negative_ws" \
+        --inspect --workspace "$real_negative_ws"
+[ "$RUN_STATUS" -eq 1 ] ||
+    fail "real negative source exit=$RUN_STATUS, want refusal exit 1"
+assert_common_json inspect refused none
+jq -e '
+    .retryable == false and .code == "source_version_mismatch"
+' <<< "$RUN_STDOUT" >/dev/null ||
+    fail "real negative source did not preserve its typed refusal"
+assert_unchanged "$real_negative_ws" "$real_negative_before" \
+    "real negative source refusal"
+
+# The version gate above is not a safety refusal. Prove that the real inspector
+# also fails closed on the safety-critical shapes end to end, through the public
+# wrapper and the descriptor-relative Go walk, not only the fake target.
+assert_real_target_refused() {
+    local label="$1" ws="$2" code="$3" before
+    before=$(tree_fingerprint "$ws")
+    BRIDGE_TEST_TARGET="$REAL_TARGET_BD" \
+        run_bridge "$label" "$ws" --inspect --workspace "$ws"
+    [ "$RUN_STATUS" -eq 1 ] ||
+        fail "$label exit=$RUN_STATUS, want fail-closed refusal exit 1"
+    assert_common_json inspect refused none
+    jq -e --arg code "$code" '.retryable == false and .code == $code' \
+        <<< "$RUN_STDOUT" >/dev/null ||
+        fail "$label did not preserve its typed safety refusal"
+    assert_unchanged "$ws" "$before" "$label refusal"
+}
+
+real_symlink_ws="$tmp/real-current-symlink"
+new_v062_workspace "$real_symlink_ws"
+mv -f -- "$real_symlink_ws/.beads/dolt" "$real_symlink_ws/.beads/dolt-real"
+ln -s dolt-real "$real_symlink_ws/.beads/dolt"
+assert_real_target_refused real-current-symlink "$real_symlink_ws" unsafe_source_symlink
+
+real_mixed_ws="$tmp/real-current-mixed"
+new_v062_workspace "$real_mixed_ws"
+printf 'sqlite-like bytes\n' > "$real_mixed_ws/.beads/beads.db"
+assert_real_target_refused real-current-mixed "$real_mixed_ws" mixed_storage_layout
+
+printf 'public-v062-bridge-test: PASS\n'

--- a/scripts/migration-test/public-v062-bridge-test.sh
+++ b/scripts/migration-test/public-v062-bridge-test.sh
@@ -67,6 +67,8 @@ case "\${1:-}" in
         qualified_digest_scope=admission_observation
         qualified_exit=0
         repeat_qualified=false
+        qualified_source_extra=
+        qualified_target_extra=
         case "\${3##*/}" in
             wrong-witness) inspection_code=source_version_mismatch ;;
             missing-witness) inspection_code=source_version_missing ;;
@@ -98,12 +100,18 @@ case "\${1:-}" in
                 inspection_code=source_changed
                 inspection_retryable=true
                 ;;
+            smuggle-source-field)
+                qualified_source_extra=',"injected":"evil"'
+                ;;
+            smuggle-target-field)
+                qualified_target_extra=',"injected":"evil"'
+                ;;
         esac
         if [ -n "\$inspection_code" ]; then
             printf '{"schema_version":1,"operation":"v062_source_inspection","status":"refused","retryable":%s,"effect":"none","code":"%s"}\n' "\$inspection_retryable" "\$inspection_code"
             exit "\$inspection_exit"
         fi
-        printf '{"schema_version":1,"operation":"v062_source_inspection","status":"qualified","retryable":false,"effect":"none","source":{"workspace":"%s","version":"0.62.0","backend":"dolt-server","tree_sha256":"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef","digest_scope":"%s"},"target":{"version":"%s","backend":"dolt-embedded","embedded_capable":true}}\n' "\$qualified_workspace" "\$qualified_digest_scope" '$version'
+        printf '{"schema_version":1,"operation":"v062_source_inspection","status":"qualified","retryable":false,"effect":"none","source":{"workspace":"%s","version":"0.62.0","backend":"dolt-server","tree_sha256":"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef","digest_scope":"%s"%s},"target":{"version":"%s","backend":"dolt-embedded","embedded_capable":true%s}}\n' "\$qualified_workspace" "\$qualified_digest_scope" "\$qualified_source_extra" '$version' "\$qualified_target_extra"
         if \$repeat_qualified; then
             printf '{"schema_version":1,"operation":"v062_source_inspection","status":"qualified","retryable":false,"effect":"none","source":{"workspace":"%s","version":"0.62.0","backend":"dolt-server","tree_sha256":"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef","digest_scope":"%s"},"target":{"version":"%s","backend":"dolt-embedded","embedded_capable":true}}\n' "\$qualified_workspace" "\$qualified_digest_scope" '$version'
         fi
@@ -316,7 +324,9 @@ for protocol_case in \
     refused-wrong-exit \
     unknown-refusal-code \
     wrong-retryability-stable \
-    wrong-retryability-transient; do
+    wrong-retryability-transient \
+    smuggle-source-field \
+    smuggle-target-field; do
     if ! check_protocol_rejected "$protocol_case"; then
         protocol_rejection_failures+=("$protocol_case")
     fi

--- a/scripts/migration-test/recipes/server_to_embedded.sh
+++ b/scripts/migration-test/recipes/server_to_embedded.sh
@@ -3,8 +3,10 @@
 #
 # Each server-era release needs an explicit extraction strategy. v0.55.4 has
 # a lossless native export for the qualified fixture. v0.57.0 needs its native
-# export enriched with comment bodies from one-item show queries. v0.56.1 and
-# v0.58.0 remain unqualified.
+# export enriched with comment bodies from one-item show queries. v0.62.0 uses
+# the same bridge after normalizing the three derived epic counters that its
+# show command adds but its export command omits. v0.56.1 and v0.58.0 remain
+# unqualified.
 #
 # Strategy:
 #   1. Stop any running Dolt server
@@ -13,9 +15,10 @@
 #   4. If candidate DB is empty, reimport from JSONL export
 #
 # User-facing instructions:
-#   Use the pinned migration harness for qualified v0.55.4 and v0.57.0 core
-#   fixtures. It stops the historical server, retains a byte-verified rollback
-#   tree, extracts and validates JSONL, and only then initializes the candidate.
+#   Use the pinned migration harness for qualified v0.55.4, v0.57.0, and
+#   v0.62.0 core fixtures. It stops the historical server, retains a
+#   byte-verified rollback tree, extracts and validates JSONL, and only then
+#   initializes the candidate.
 
 publish_legacy_dolt_rollback() {
     mv --no-target-directory --no-clobber --no-copy -- "$1" "$2"
@@ -102,12 +105,19 @@ migration_jsonl_is_snapshot_subset() {
 v057_export_matches_snapshot() {
     local export_path="$1"
     local before_snapshot="$2"
+    local version="$3"
 
     jq -en \
         --slurpfile exports "$export_path" \
-        --slurpfile before "$before_snapshot" '
+        --slurpfile before "$before_snapshot" \
+        --arg version "$version" '
         def by_id: map({key: .id, value: .}) | from_entries;
+        def normalize_version_derived_fields:
+            if $version == "v0.62.0" then
+                del(.epic_closeable, .epic_closed_children, .epic_total_children)
+            else . end;
         def core:
+            normalize_version_derived_fields |
             del(
                 .labels,
                 .dependencies,
@@ -179,12 +189,18 @@ v057_export_and_show_comments_agree() {
     local export_path="$1"
     local show_path="$2"
     local before_snapshot="$3"
+    local version="$4"
 
     jq -en \
         --slurpfile exports "$export_path" \
         --slurpfile shows "$show_path" \
-        --slurpfile before "$before_snapshot" '
+        --slurpfile before "$before_snapshot" \
+        --arg version "$version" '
         def by_id: map({key: .id, value: .}) | from_entries;
+        def normalize_version_derived_fields:
+            if $version == "v0.62.0" then
+                del(.epic_closeable, .epic_closed_children, .epic_total_children)
+            else . end;
         ($exports | by_id) as $export |
         ($shows | by_id) as $show |
         ($before[0] | by_id) as $expected |
@@ -200,7 +216,8 @@ v057_export_and_show_comments_agree() {
             (($comments | type) == "array") and
             ($count == ($comments | length)) and
             ($comments == $expected_comments) and
-            ($show[$id] == $expected[$id])
+            (($show[$id] | normalize_version_derived_fields) ==
+                ($expected[$id] | normalize_version_derived_fields))
         ] | all)
     ' >/dev/null 2>&1
 }
@@ -211,6 +228,7 @@ enrich_v057_export_comments() {
     local export_path="$3"
     local before_snapshot="$4"
     local enriched_path="$5"
+    local version="$6"
     local show_path ids encoded_id id show_json show_record
     local extraction_ok=true
 
@@ -218,7 +236,7 @@ enrich_v057_export_comments() {
     [ -f "$before_snapshot" ] && [ ! -L "$before_snapshot" ] || return 1
     [ -f "$enriched_path" ] && [ ! -L "$enriched_path" ] || return 1
     migration_jsonl_matches_snapshot "$export_path" "$before_snapshot" || return 1
-    v057_export_matches_snapshot "$export_path" "$before_snapshot" || return 1
+    v057_export_matches_snapshot "$export_path" "$before_snapshot" "$version" || return 1
 
     show_path=$(mktemp "$ws/.beads/.issues.jsonl.show.tmp.XXXXXX") || return 1
     ids=$(jq -ce '.[] | .id' "$before_snapshot" 2>/dev/null) || extraction_ok=false
@@ -257,7 +275,7 @@ enrich_v057_export_comments() {
     if $extraction_ok && \
         migration_jsonl_matches_snapshot "$show_path" "$before_snapshot" && \
         v057_export_and_show_comments_agree \
-            "$export_path" "$show_path" "$before_snapshot"; then
+            "$export_path" "$show_path" "$before_snapshot" "$version"; then
         if ! jq -cn \
             --slurpfile exports "$export_path" \
             --slurpfile shows "$show_path" '
@@ -411,6 +429,25 @@ recipe_server_to_embedded() {
     }
     preserve_legacy_dolt_source "$ws" "$rollback_manifest" || return 1
 
+    # v0.62 cannot reliably auto-start its historical server on a loaded host.
+    # Its workspace marker keeps auto-start disabled, so restart the qualified,
+    # harness-owned server against the still-active source before extraction.
+    local bootstrap_strategy=""
+    bootstrap_strategy=$(server_bootstrap_strategy "$version" 2>/dev/null) || true
+    case "$bootstrap_strategy" in
+        "") ;;
+        prestarted_server)
+            if ! start_owned_migration_dolt_server "$ws"; then
+                echo "  FAILED: could not restart the qualified historical Dolt server"
+                return 1
+            fi
+            ;;
+        *)
+            echo "  FAILED: unsupported server bootstrap strategy for $version"
+            return 1
+            ;;
+    esac
+
     # Step 2: Export data via old binary BEFORE clearing metadata.
     # The old binary needs metadata.json to know it's in server mode and
     # to auto-start its Dolt server. Removing metadata first (as was done
@@ -437,7 +474,7 @@ recipe_server_to_embedded() {
                 if [ -n "$enriched_tmp" ] && \
                     enrich_v057_export_comments \
                         "$ws" "$old_bin" "$export_tmp" \
-                        "$before_snapshot" "$enriched_tmp"; then
+                        "$before_snapshot" "$enriched_tmp" "$version"; then
                     export_publish_source="$enriched_tmp"
                     historical_export_ok=true
                 fi

--- a/scripts/migration-test/run.sh
+++ b/scripts/migration-test/run.sh
@@ -39,7 +39,7 @@ set -uo pipefail
 #   1  A path is BLOCKED, or strict qualification fails
 # =============================================================================
 
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 
 # Source library modules
@@ -77,12 +77,150 @@ verify_strict_retained_source() {
     esac
 }
 
+verify_v062_prestarted_source() {
+    local ws="$1"
+    local reserved_port="$2"
+    local metadata="$ws/.beads/metadata.json"
+    local local_version="$ws/.beads/.local_version"
+    local schema_json=""
+
+    [[ "$reserved_port" =~ ^2[0-9]{4}$ ]] || {
+        echo "reserved server port is invalid"
+        return 1
+    }
+    if [ ! -f "$metadata" ] || [ -L "$metadata" ]; then
+        echo "v0.62.0 init did not create authentic metadata"
+        return 1
+    fi
+    if ! jq -e --argjson reserved_port "$reserved_port" '
+        type == "object" and
+        .backend == "dolt" and
+        .database == "dolt" and
+        .dolt_mode == "server" and
+        .dolt_server_host == "127.0.0.1" and
+        (.dolt_server_port | type == "number") and
+        .dolt_server_port == $reserved_port and
+        .dolt_database == "smoke" and
+        (.project_id | type == "string" and length > 0)
+    ' "$metadata" >/dev/null; then
+        echo "v0.62.0 init metadata does not match the server fixture contract"
+        return 1
+    fi
+    if [ ! -f "$local_version" ] || [ -L "$local_version" ] ||
+        ! printf '0.62.0\n' | cmp -s - "$local_version"; then
+        echo "v0.62.0 init did not write the exact historical version marker"
+        return 1
+    fi
+    if [ ! -d "$ws/.beads/dolt" ] || [ -L "$ws/.beads/dolt" ] ||
+        [ ! -d "$ws/.beads/dolt/.dolt" ] || [ -L "$ws/.beads/dolt/.dolt" ] ||
+        [ ! -d "$ws/.beads/dolt/smoke" ] || [ -L "$ws/.beads/dolt/smoke" ] ||
+        [ ! -d "$ws/.beads/dolt/smoke/.dolt" ] || [ -L "$ws/.beads/dolt/smoke/.dolt" ]; then
+        echo "v0.62.0 init did not create the local Dolt catalog and smoke database"
+        return 1
+    fi
+    schema_json=$(migration_owned_dolt_sql \
+        "$ws" smoke \
+        "SELECT value AS schema_version FROM config WHERE \`key\` = 'schema_version'") || {
+        echo "could not query the v0.62.0 source schema"
+        return 1
+    }
+    if ! jq -e '
+        type == "object" and
+        (.rows | type == "array" and length == 1) and
+        (.rows[0] |
+            type == "object" and
+            (.schema_version | type == "string") and
+            .schema_version == "9")
+    ' <<< "$schema_json" >/dev/null; then
+        echo "v0.62.0 source schema version is not exactly string 9"
+        return 1
+    fi
+}
+
+block_source_initialization() {
+    local ws="$1"
+    local snapshots_dir="$2"
+    local path_label="$3"
+    local detail="$4"
+
+    migration_run_record_result_after_cleanup \
+        "$ws" "$snapshots_dir" "$path_label" "BLOCKED" "$detail" || true
+    echo -e "  ${RED}BLOCKED: ${RESULT_DETAILS[-1]}${NC}"
+}
+
+MIGRATION_RUN_ACTIVE_WORKSPACE=""
+MIGRATION_RUN_ACTIVE_SNAPSHOTS=""
+
+migration_run_activate_workspace() {
+    MIGRATION_RUN_ACTIVE_WORKSPACE="$1"
+    MIGRATION_RUN_ACTIVE_SNAPSHOTS="${2:-}"
+}
+
+migration_run_forget_workspace() {
+    local ws="$1"
+
+    if [ "$MIGRATION_RUN_ACTIVE_WORKSPACE" = "$ws" ]; then
+        MIGRATION_RUN_ACTIVE_WORKSPACE=""
+        MIGRATION_RUN_ACTIVE_SNAPSHOTS=""
+    fi
+}
+
+migration_run_cleanup_active_workspace() {
+    local ws="$MIGRATION_RUN_ACTIVE_WORKSPACE"
+    local snapshots="$MIGRATION_RUN_ACTIVE_SNAPSHOTS"
+
+    [ -n "$ws" ] || return 0
+    migration_run_forget_workspace "$ws"
+    if [ ! -e "$ws" ] && [ ! -L "$ws" ]; then
+        [ -z "$snapshots" ] || rm -rf -- "$snapshots"
+        return 0
+    fi
+    if cleanup_workspace "$ws"; then
+        [ -z "$snapshots" ] || rm -rf -- "$snapshots"
+        return 0
+    fi
+    echo "could not prove isolated workspace cleanup; preserved at $ws" >&2
+    return 1
+}
+
+migration_run_install_cleanup_traps() {
+    trap 'migration_run_cleanup_active_workspace' EXIT
+    trap 'exit 129' HUP
+    trap 'exit 130' INT
+    trap 'exit 143' TERM
+}
+
+migration_run_record_result_after_cleanup() {
+    local ws="$1"
+    local snapshots="$2"
+    local path="$3"
+    local status="$4"
+    local detail="$5"
+    local recipe="${6:-}"
+    local violations="${7:-0}"
+
+    if ! cleanup_workspace "$ws"; then
+        migration_run_forget_workspace "$ws"
+        record_result "$path" "BLOCKED" \
+            "could not prove isolated workspace cleanup; preserved at $ws" "" "$violations"
+        return 1
+    fi
+    migration_run_forget_workspace "$ws"
+    [ -z "$snapshots" ] || rm -rf -- "$snapshots"
+    record_result "$path" "$status" "$detail" "$recipe" "$violations"
+}
+
+if [ "${MIGRATION_TEST_RUN_LIBRARY_ONLY:-0}" = "1" ]; then
+    return 0 2>/dev/null || exit 0
+fi
+
 # Ensure jq is available
 if ! command -v jq >/dev/null 2>&1; then
     echo -e "${RED}ERROR: jq is required but not installed.${NC}"
     echo "Install with: sudo apt install jq / brew install jq"
     exit 1
 fi
+migration_run_install_cleanup_traps
 
 # ---------------------------------------------------------------------------
 # Test a direct upgrade path: source_version → candidate
@@ -127,68 +265,125 @@ test_direct_path() {
         echo -e "  ${RED}BLOCKED: could not create isolated workspace${NC}"
         return 0
     fi
+    migration_run_activate_workspace "$WS" ""
     local SNAPSHOTS_DIR=""
     if ! SNAPSHOTS_DIR=$(mktemp -d /tmp/bd-snapshots-XXXXXX); then
-        record_result_after_workspace_cleanup \
-            "$WS" "$path_label" "BLOCKED" "could not create isolated snapshot directory" || true
+        migration_run_record_result_after_cleanup \
+            "$WS" "" "$path_label" "BLOCKED" \
+            "could not create isolated snapshot directory" || true
         echo -e "  ${RED}BLOCKED: ${RESULT_DETAILS[-1]}${NC}"
         return 0
     fi
+    migration_run_activate_workspace "$WS" "$SNAPSHOTS_DIR"
 
     # Step 1: Init with source binary
     local init_ok=false
-    if bd_in "$WS" "$src_bin" init --quiet --non-interactive --prefix smoke </dev/null >/dev/null 2>&1; then
-        init_ok=true
-    elif bd_in "$WS" "$src_bin" init --quiet --prefix smoke </dev/null >/dev/null 2>&1; then
-        init_ok=true
-    fi
+    if [ "$version" = "v0.62.0" ]; then
+        local bootstrap_strategy=""
+        local init_output=""
+        local init_port=""
+        local verification_detail=""
 
-    if ! $init_ok; then
-        local init_err init_status init_detail
-        init_err=$(bd_in "$WS" "$src_bin" init --quiet --prefix smoke </dev/null 2>&1 | head -1 || true)
+        bootstrap_strategy=$(server_bootstrap_strategy "$version" 2>/dev/null) || true
+        if [ "$bootstrap_strategy" != "prestarted_server" ]; then
+            block_source_initialization \
+                "$WS" "$SNAPSHOTS_DIR" "$path_label" \
+                "v0.62.0 server bootstrap contract is unavailable"
+            return 0
+        fi
+        if ! start_owned_migration_dolt_server "$WS"; then
+            block_source_initialization \
+                "$WS" "$SNAPSHOTS_DIR" "$path_label" \
+                "could not start the owned v0.62.0 Dolt server"
+            return 0
+        fi
+        if [ ! -f "$WS/.git/bd-migration-server-port" ] ||
+            [ -L "$WS/.git/bd-migration-server-port" ]; then
+            block_source_initialization \
+                "$WS" "$SNAPSHOTS_DIR" "$path_label" \
+                "owned v0.62.0 Dolt server has no reserved port"
+            return 0
+        fi
+        init_port=$(cat "$WS/.git/bd-migration-server-port") || init_port=""
+        if ! [[ "$init_port" =~ ^2[0-9]{4}$ ]]; then
+            block_source_initialization \
+                "$WS" "$SNAPSHOTS_DIR" "$path_label" \
+                "owned v0.62.0 Dolt server has an invalid reserved port"
+            return 0
+        fi
 
-        if echo "$init_err" | grep -qi "CGO"; then
-            init_status="SKIP"
-            init_detail="binary built without CGO"
-        elif echo "$init_err" | grep -qi "dolt.*server\|unreachable\|auto-start"; then
-            init_status="SKIP"
-            init_detail="needs dolt server"
+        if init_output=$(bd_in "$WS" "$src_bin" init \
+            --quiet \
+            --server-host 127.0.0.1 --server-port "$init_port" \
+            --database smoke --prefix smoke </dev/null 2>&1); then
+            init_ok=true
         else
-            init_status="BLOCKED"
-            init_detail="init failed: ${init_err}"
+            local init_first_line=""
+            init_first_line=$(head -1 <<< "$init_output")
+            block_source_initialization \
+                "$WS" "$SNAPSHOTS_DIR" "$path_label" \
+                "v0.62.0 one-shot init failed: ${init_first_line:-no error output}"
+            return 0
         fi
-        if record_result_after_workspace_cleanup \
-            "$WS" "$path_label" "$init_status" "$init_detail"; then
-            rm -rf "$SNAPSHOTS_DIR"
+
+        verification_detail=$(verify_v062_prestarted_source "$WS" "$init_port") || {
+            block_source_initialization \
+                "$WS" "$SNAPSHOTS_DIR" "$path_label" "$verification_detail"
+            return 0
+        }
+    else
+        if bd_in "$WS" "$src_bin" init --quiet --non-interactive --prefix smoke </dev/null >/dev/null 2>&1; then
+            init_ok=true
+        elif bd_in "$WS" "$src_bin" init --quiet --prefix smoke </dev/null >/dev/null 2>&1; then
+            init_ok=true
         fi
-        echo -e "  ${RESULT_STATUSES[-1]}: ${RESULT_DETAILS[-1]}"
-        return 0
+
+        if ! $init_ok; then
+            local init_err init_status init_detail
+            init_err=$(bd_in "$WS" "$src_bin" init --quiet --prefix smoke </dev/null 2>&1 | head -1 || true)
+
+            if echo "$init_err" | grep -qi "CGO"; then
+                init_status="SKIP"
+                init_detail="binary built without CGO"
+            elif echo "$init_err" | grep -qi "dolt.*server\|unreachable\|auto-start"; then
+                init_status="SKIP"
+                init_detail="needs dolt server"
+            else
+                init_status="BLOCKED"
+                init_detail="init failed: ${init_err}"
+            fi
+            migration_run_record_result_after_cleanup \
+                "$WS" "$SNAPSHOTS_DIR" "$path_label" \
+                "$init_status" "$init_detail" || true
+            echo -e "  ${RESULT_STATUSES[-1]}: ${RESULT_DETAILS[-1]}"
+            return 0
+        fi
     fi
     git -C "$WS" config beads.role maintainer 2>/dev/null || true
 
     # Step 2: Create rich dataset with source binary
     if ! create_dataset "$WS" "$src_bin" "$version"; then
-        cleanup_workspace "$WS"
-        rm -rf "$SNAPSHOTS_DIR"
-        record_result "$path_label" "BLOCKED" "could not create test data"
-        echo -e "  ${RED}BLOCKED: could not create test data${NC}"
+        migration_run_record_result_after_cleanup \
+            "$WS" "$SNAPSHOTS_DIR" "$path_label" "BLOCKED" \
+            "could not create test data" || true
+        echo -e "  ${RED}BLOCKED: ${RESULT_DETAILS[-1]}${NC}"
         return 0
     fi
     if $STRICT_MODE && ! strict_fixture_has_expected_features "$version" "${DATASET_FEATURES[@]}"; then
-        cleanup_workspace "$WS"
-        rm -rf "$SNAPSHOTS_DIR"
-        record_result "$path_label" "BLOCKED" "source fixture is missing required features"
-        echo -e "  ${RED}BLOCKED: source fixture is missing required features${NC}"
+        migration_run_record_result_after_cleanup \
+            "$WS" "$SNAPSHOTS_DIR" "$path_label" "BLOCKED" \
+            "source fixture is missing required features" || true
+        echo -e "  ${RED}BLOCKED: ${RESULT_DETAILS[-1]}${NC}"
         return 0
     fi
 
     # Step 3: Capture before-snapshot
     if ! capture_snapshot "$WS" "$src_bin" > "$SNAPSHOTS_DIR/before.json"; then
         if $STRICT_MODE; then
-            cleanup_workspace "$WS"
-            rm -rf "$SNAPSHOTS_DIR"
-            record_result "$path_label" "BLOCKED" "could not capture the complete source snapshot"
-            echo -e "  ${RED}BLOCKED: could not capture the complete source snapshot${NC}"
+            migration_run_record_result_after_cleanup \
+                "$WS" "$SNAPSHOTS_DIR" "$path_label" "BLOCKED" \
+                "could not capture the complete source snapshot" || true
+            echo -e "  ${RED}BLOCKED: ${RESULT_DETAILS[-1]}${NC}"
             return 0
         fi
     fi
@@ -196,22 +391,23 @@ test_direct_path() {
     before_count=$(jq 'length' "$SNAPSHOTS_DIR/before.json" 2>/dev/null) || before_count=0
     echo "  before-snapshot: $before_count items"
     if $STRICT_MODE && [ "$before_count" -eq 0 ]; then
-        cleanup_workspace "$WS"
-        rm -rf "$SNAPSHOTS_DIR"
-        record_result "$path_label" "BLOCKED" "source snapshot is empty"
-        echo -e "  ${RED}BLOCKED: source snapshot is empty${NC}"
+        migration_run_record_result_after_cleanup \
+            "$WS" "$SNAPSHOTS_DIR" "$path_label" "BLOCKED" \
+            "source snapshot is empty" || true
+        echo -e "  ${RED}BLOCKED: ${RESULT_DETAILS[-1]}${NC}"
         return 0
     fi
     if $STRICT_MODE && ! strict_snapshot_has_expected_fixture "$version" "$SNAPSHOTS_DIR/before.json"; then
-        cleanup_workspace "$WS"
-        rm -rf "$SNAPSHOTS_DIR"
-        record_result "$path_label" "BLOCKED" "source snapshot does not match the exact fixture contract"
-        echo -e "  ${RED}BLOCKED: source snapshot does not match the exact fixture contract${NC}"
+        migration_run_record_result_after_cleanup \
+            "$WS" "$SNAPSHOTS_DIR" "$path_label" "BLOCKED" \
+            "source snapshot does not match the exact fixture contract" || true
+        echo -e "  ${RED}BLOCKED: ${RESULT_DETAILS[-1]}${NC}"
         return 0
     fi
 
     # Stop source server before upgrade
     if ! stop_dolt_server "$WS"; then
+        migration_run_forget_workspace "$WS"
         record_result "$path_label" "BLOCKED" \
             "could not prove the historical server stopped before upgrade; preserved at $WS"
         echo -e "  ${RED}BLOCKED: could not prove the historical server stopped before upgrade${NC}"
@@ -225,25 +421,25 @@ test_direct_path() {
     local source_legacy_dolt_manifest=""
     if $STRICT_MODE; then
         source_fingerprint=$(source_artifact_fingerprint "$WS/.beads") || {
-            cleanup_workspace "$WS"
-            rm -rf "$SNAPSHOTS_DIR"
-            record_result "$path_label" "BLOCKED" "could not fingerprint historical source tree"
+            migration_run_record_result_after_cleanup \
+                "$WS" "$SNAPSHOTS_DIR" "$path_label" "BLOCKED" \
+                "could not fingerprint historical source tree" || true
             return 0
         }
         case "$source_era" in
             sqlite)
                 source_sqlite_manifest=$(classic_sqlite_artifact_manifest "$WS/.beads") || {
-                    cleanup_workspace "$WS"
-                    rm -rf "$SNAPSHOTS_DIR"
-                    record_result "$path_label" "BLOCKED" "could not inventory classic SQLite rollback source"
+                    migration_run_record_result_after_cleanup \
+                        "$WS" "$SNAPSHOTS_DIR" "$path_label" "BLOCKED" \
+                        "could not inventory classic SQLite rollback source" || true
                     return 0
                 }
                 ;;
             dolt_server)
                 source_legacy_dolt_manifest=$(legacy_dolt_artifact_manifest "$WS/.beads") || {
-                    cleanup_workspace "$WS"
-                    rm -rf "$SNAPSHOTS_DIR"
-                    record_result "$path_label" "BLOCKED" "could not inventory legacy Dolt rollback source"
+                    migration_run_record_result_after_cleanup \
+                        "$WS" "$SNAPSHOTS_DIR" "$path_label" "BLOCKED" \
+                        "could not inventory legacy Dolt rollback source" || true
                     return 0
                 }
                 ;;
@@ -261,10 +457,10 @@ test_direct_path() {
     fi
 
     if [ "$probe_status" -eq 2 ]; then
-        cleanup_workspace "$WS"
-        rm -rf "$SNAPSHOTS_DIR"
-        record_result "$path_label" "BLOCKED" "$DIRECT_PROBE_FAILURE_DETAIL"
-        echo -e "  ${RED}BLOCKED: $DIRECT_PROBE_FAILURE_DETAIL${NC}"
+        migration_run_record_result_after_cleanup \
+            "$WS" "$SNAPSHOTS_DIR" "$path_label" "BLOCKED" \
+            "$DIRECT_PROBE_FAILURE_DETAIL" || true
+        echo -e "  ${RED}BLOCKED: ${RESULT_DETAILS[-1]}${NC}"
         return 0
     fi
     if $STRICT_MODE && ! $upgrade_ok; then
@@ -274,10 +470,10 @@ test_direct_path() {
     if $upgrade_ok; then
         # Capture after-snapshot and check fidelity
         if ! capture_snapshot "$WS" "$cand_bin" > "$SNAPSHOTS_DIR/after.json"; then
-            cleanup_workspace "$WS"
-            rm -rf "$SNAPSHOTS_DIR"
-            record_result "$path_label" "BLOCKED" "could not capture the complete candidate snapshot"
-            echo -e "  ${RED}BLOCKED: could not capture the complete candidate snapshot${NC}"
+            migration_run_record_result_after_cleanup \
+                "$WS" "$SNAPSHOTS_DIR" "$path_label" "BLOCKED" \
+                "could not capture the complete candidate snapshot" || true
+            echo -e "  ${RED}BLOCKED: ${RESULT_DETAILS[-1]}${NC}"
             return 0
         fi
         local after_count
@@ -299,10 +495,9 @@ test_direct_path() {
             direct_status="AUTO"
             direct_detail="direct upgrade, $violations fidelity violations"
         fi
-        if record_result_after_workspace_cleanup \
-            "$WS" "$path_label" "$direct_status" "$direct_detail" "" "$violations"; then
-            rm -rf "$SNAPSHOTS_DIR"
-        else
+        if ! migration_run_record_result_after_cleanup \
+            "$WS" "$SNAPSHOTS_DIR" "$path_label" \
+            "$direct_status" "$direct_detail" "" "$violations"; then
             echo -e "  ${RED}BLOCKED: could not prove isolated workspace cleanup${NC}"
         fi
         return 0
@@ -310,6 +505,7 @@ test_direct_path() {
 
     # Step 5: Direct upgrade failed — try recipes
     if ! stop_dolt_server "$WS"; then
+        migration_run_forget_workspace "$WS"
         record_result "$path_label" "BLOCKED" \
             "could not prove the direct-probe server stopped before migration recipes; preserved at $WS"
         echo -e "  ${RED}BLOCKED: could not prove the direct-probe server stopped before migration recipes${NC}"
@@ -354,19 +550,19 @@ test_direct_path() {
     if $recipe_worked; then
         if $STRICT_MODE && ! verify_strict_retained_source \
             "$WS" "$era" "$source_sqlite_manifest" "$source_legacy_dolt_manifest"; then
-            cleanup_workspace "$WS"
-            rm -rf "$SNAPSHOTS_DIR"
-            record_result "$path_label" "BLOCKED" "manual bridge mutated the retained historical rollback source"
-            echo -e "  ${RED}BLOCKED: manual bridge mutated the retained historical rollback source${NC}"
+            migration_run_record_result_after_cleanup \
+                "$WS" "$SNAPSHOTS_DIR" "$path_label" "BLOCKED" \
+                "manual bridge mutated the retained historical rollback source" || true
+            echo -e "  ${RED}BLOCKED: ${RESULT_DETAILS[-1]}${NC}"
             return 0
         fi
 
         # Re-capture and check fidelity after recipe
         if ! capture_snapshot "$WS" "$cand_bin" > "$SNAPSHOTS_DIR/after.json"; then
-            cleanup_workspace "$WS"
-            rm -rf "$SNAPSHOTS_DIR"
-            record_result "$path_label" "BLOCKED" "could not capture the complete candidate snapshot after recipe"
-            echo -e "  ${RED}BLOCKED: could not capture the complete candidate snapshot after recipe${NC}"
+            migration_run_record_result_after_cleanup \
+                "$WS" "$SNAPSHOTS_DIR" "$path_label" "BLOCKED" \
+                "could not capture the complete candidate snapshot after recipe" || true
+            echo -e "  ${RED}BLOCKED: ${RESULT_DETAILS[-1]}${NC}"
             return 0
         fi
         local after_count
@@ -381,6 +577,7 @@ test_direct_path() {
         violations=$((violations + blocker_violations))
 
         if ! stop_dolt_server "$WS"; then
+            migration_run_forget_workspace "$WS"
             record_result "$path_label" "BLOCKED" \
                 "could not prove the candidate server stopped before rollback verification; preserved at $WS"
             echo -e "  ${RED}BLOCKED: could not prove the candidate server stopped before rollback verification${NC}"
@@ -389,10 +586,10 @@ test_direct_path() {
 
         if $STRICT_MODE && ! verify_strict_retained_source \
             "$WS" "$era" "$source_sqlite_manifest" "$source_legacy_dolt_manifest"; then
-            cleanup_workspace "$WS"
-            rm -rf "$SNAPSHOTS_DIR"
-            record_result "$path_label" "BLOCKED" "post-upgrade commands mutated the retained historical rollback source"
-            echo -e "  ${RED}BLOCKED: post-upgrade commands mutated the retained historical rollback source${NC}"
+            migration_run_record_result_after_cleanup \
+                "$WS" "$SNAPSHOTS_DIR" "$path_label" "BLOCKED" \
+                "post-upgrade commands mutated the retained historical rollback source" || true
+            echo -e "  ${RED}BLOCKED: ${RESULT_DETAILS[-1]}${NC}"
             return 0
         fi
 
@@ -404,21 +601,19 @@ test_direct_path() {
             recipe_status="MANUAL"
             recipe_detail="recipe: $recipe_name, $violations fidelity violations"
         fi
-        if record_result_after_workspace_cleanup \
-            "$WS" "$path_label" "$recipe_status" "$recipe_detail" "$recipe_name" "$violations"; then
-            rm -rf "$SNAPSHOTS_DIR"
-        else
+        if ! migration_run_record_result_after_cleanup \
+            "$WS" "$SNAPSHOTS_DIR" "$path_label" \
+            "$recipe_status" "$recipe_detail" "$recipe_name" "$violations"; then
             echo -e "  ${RED}BLOCKED: could not prove isolated workspace cleanup${NC}"
         fi
         return 0
     fi
 
     # All recipes failed
-    if cleanup_workspace "$WS"; then
-        rm -rf "$SNAPSHOTS_DIR"
-    fi
-    record_result "$path_label" "BLOCKED" "no working upgrade path found"
-    echo -e "  ${RED}BLOCKED: no working upgrade path${NC}"
+    migration_run_record_result_after_cleanup \
+        "$WS" "$SNAPSHOTS_DIR" "$path_label" "BLOCKED" \
+        "no working upgrade path found" || true
+    echo -e "  ${RED}BLOCKED: ${RESULT_DETAILS[-1]}${NC}"
 }
 
 # ---------------------------------------------------------------------------
@@ -455,13 +650,16 @@ test_stepping_stone_path() {
         echo -e "  ${RED}BLOCKED: could not create isolated workspace${NC}"
         return 0
     fi
+    migration_run_activate_workspace "$WS" ""
     local SNAPSHOTS_DIR=""
     if ! SNAPSHOTS_DIR=$(mktemp -d /tmp/bd-snapshots-XXXXXX); then
-        record_result_after_workspace_cleanup \
-            "$WS" "$path_label" "BLOCKED" "could not create isolated snapshot directory" || true
+        migration_run_record_result_after_cleanup \
+            "$WS" "" "$path_label" "BLOCKED" \
+            "could not create isolated snapshot directory" || true
         echo -e "  ${RED}BLOCKED: ${RESULT_DETAILS[-1]}${NC}"
         return 0
     fi
+    migration_run_activate_workspace "$WS" "$SNAPSHOTS_DIR"
 
     # Init with first version
     local first_bin="${bins[0]}"
@@ -475,10 +673,9 @@ test_stepping_stone_path() {
     fi
 
     if ! $init_ok; then
-        if record_result_after_workspace_cleanup \
-            "$WS" "$path_label" "SKIP" "could not init with $first_ver"; then
-            rm -rf "$SNAPSHOTS_DIR"
-        fi
+        migration_run_record_result_after_cleanup \
+            "$WS" "$SNAPSHOTS_DIR" "$path_label" "SKIP" \
+            "could not init with $first_ver" || true
         echo -e "  ${RESULT_STATUSES[-1]}: ${RESULT_DETAILS[-1]}"
         return 0
     fi
@@ -486,15 +683,16 @@ test_stepping_stone_path() {
 
     # Create dataset with first version
     if ! create_dataset "$WS" "$first_bin" "$first_ver"; then
-        cleanup_workspace "$WS"
-        rm -rf "$SNAPSHOTS_DIR"
-        record_result "$path_label" "BLOCKED" "could not create test data with $first_ver"
+        migration_run_record_result_after_cleanup \
+            "$WS" "$SNAPSHOTS_DIR" "$path_label" "BLOCKED" \
+            "could not create test data with $first_ver" || true
         return 0
     fi
 
     # Capture initial snapshot
     capture_snapshot "$WS" "$first_bin" > "$SNAPSHOTS_DIR/before.json"
     if ! stop_dolt_server "$WS"; then
+        migration_run_forget_workspace "$WS"
         record_result "$path_label" "BLOCKED" \
             "could not prove the first historical server stopped before stepping; preserved at $WS"
         echo -e "  ${RED}BLOCKED: could not prove the first historical server stopped before stepping${NC}"
@@ -525,9 +723,11 @@ test_stepping_stone_path() {
         fi
 
         if ! stop_dolt_server "$WS"; then
-            step_failed=true
-            failed_at="$step_ver (server stop unverified)"
-            break
+            migration_run_forget_workspace "$WS"
+            record_result "$path_label" "BLOCKED" \
+                "could not prove the $step_ver server stopped; preserved at $WS"
+            echo -e "  ${RED}BLOCKED: $step_ver server stop unverified${NC}"
+            return 0
         fi
 
         if ! $step_ok; then
@@ -539,9 +739,9 @@ test_stepping_stone_path() {
     done
 
     if $step_failed; then
-        cleanup_workspace "$WS"
-        rm -rf "$SNAPSHOTS_DIR"
-        record_result "$path_label" "BLOCKED" "failed at step $failed_at"
+        migration_run_record_result_after_cleanup \
+            "$WS" "$SNAPSHOTS_DIR" "$path_label" "BLOCKED" \
+            "failed at step $failed_at" || true
         echo -e "  ${RED}BLOCKED at $failed_at${NC}"
         return 0
     fi
@@ -563,9 +763,9 @@ test_stepping_stone_path() {
     fi
 
     if ! $upgrade_ok; then
-        cleanup_workspace "$WS"
-        rm -rf "$SNAPSHOTS_DIR"
-        record_result "$path_label" "BLOCKED" "final step to candidate failed"
+        migration_run_record_result_after_cleanup \
+            "$WS" "$SNAPSHOTS_DIR" "$path_label" "BLOCKED" \
+            "final step to candidate failed" || true
         echo -e "  ${RED}BLOCKED at final step${NC}"
         return 0
     fi
@@ -587,10 +787,9 @@ test_stepping_stone_path() {
         step_status="AUTO"
         step_detail="all steps passed, $violations fidelity violations"
     fi
-    if record_result_after_workspace_cleanup \
-        "$WS" "$path_label" "$step_status" "$step_detail" "" "$violations"; then
-        rm -rf "$SNAPSHOTS_DIR"
-    else
+    if ! migration_run_record_result_after_cleanup \
+        "$WS" "$SNAPSHOTS_DIR" "$path_label" \
+        "$step_status" "$step_detail" "" "$violations"; then
         echo -e "  ${RED}BLOCKED: could not prove isolated workspace cleanup${NC}"
     fi
 }
@@ -695,20 +894,24 @@ if $SELF_TEST; then
         echo -e "  ${RED}BLOCKED: could not create isolated workspace${NC}"
         record_result "candidate → candidate" "BLOCKED" "could not create isolated workspace"
     else
+        migration_run_activate_workspace "$WS" ""
         SNAPSHOTS_DIR=""
         if ! SNAPSHOTS_DIR=$(mktemp -d /tmp/bd-snapshots-XXXXXX); then
-            record_result_after_workspace_cleanup \
-                "$WS" "candidate → candidate" "BLOCKED" \
+            migration_run_record_result_after_cleanup \
+                "$WS" "" "candidate → candidate" "BLOCKED" \
                 "could not create isolated snapshot directory" || true
             echo -e "  ${RED}BLOCKED: ${RESULT_DETAILS[-1]}${NC}"
         # Init with candidate
-        elif ! bd_in "$WS" "$CAND_BIN" init --quiet --non-interactive --prefix smoke </dev/null >/dev/null 2>&1; then
-            if record_result_after_workspace_cleanup \
-                "$WS" "candidate → candidate" "BLOCKED" "init failed"; then
-                rm -rf "$SNAPSHOTS_DIR"
-            fi
-            echo -e "  ${RED}BLOCKED: ${RESULT_DETAILS[-1]}${NC}"
         else
+            migration_run_activate_workspace "$WS" "$SNAPSHOTS_DIR"
+        fi
+        if [ -n "$SNAPSHOTS_DIR" ] &&
+            ! bd_in "$WS" "$CAND_BIN" init --quiet --non-interactive --prefix smoke </dev/null >/dev/null 2>&1; then
+            migration_run_record_result_after_cleanup \
+                "$WS" "$SNAPSHOTS_DIR" "candidate → candidate" \
+                "BLOCKED" "init failed" || true
+            echo -e "  ${RED}BLOCKED: ${RESULT_DETAILS[-1]}${NC}"
+        elif [ -n "$SNAPSHOTS_DIR" ]; then
             git -C "$WS" config beads.role maintainer 2>/dev/null || true
             self_status="BLOCKED"
             self_detail="could not create test data"
@@ -739,10 +942,9 @@ if $SELF_TEST; then
                     self_detail="self-test, $violations fidelity violations"
                 fi
             fi
-            if record_result_after_workspace_cleanup \
-                "$WS" "candidate → candidate" "$self_status" "$self_detail" "" "$self_violations"; then
-                rm -rf "$SNAPSHOTS_DIR"
-            else
+            if ! migration_run_record_result_after_cleanup \
+                "$WS" "$SNAPSHOTS_DIR" "candidate → candidate" \
+                "$self_status" "$self_detail" "" "$self_violations"; then
                 echo -e "  ${RED}BLOCKED: could not prove isolated workspace cleanup${NC}"
             fi
         fi

--- a/scripts/migration-test/strict-mode-test.sh
+++ b/scripts/migration-test/strict-mode-test.sh
@@ -6,6 +6,7 @@ source "$SCRIPT_DIR/lib/report.sh"
 source "$SCRIPT_DIR/lib/versions.sh"
 source "$SCRIPT_DIR/lib/binary.sh"
 source "$SCRIPT_DIR/lib/workspace.sh"
+source "$SCRIPT_DIR/lib/features.sh"
 source "$SCRIPT_DIR/lib/snapshot.sh"
 source "$SCRIPT_DIR/lib/direct_probe.sh"
 source "$SCRIPT_DIR/recipes/sqlite_to_current.sh"
@@ -45,6 +46,26 @@ sha=$(strict_release_sha256 v0.57.0 linux amd64) || fail "missing v0.57.0 releas
 [ "$(strict_required_dolt_sha256 v0.57.0 linux amd64)" = \
     "f66318f08ed66e409fc39363ae0fff8ce6fbf6dba9f5bac632b91527b9632a74" ] ||
     fail "unexpected v0.57.0 Dolt runtime checksum"
+
+asset=$(strict_release_asset v0.62.0 linux amd64) || fail "missing v0.62.0 release asset"
+[ "$asset" = "beads_0.62.0_linux_amd64.tar.gz" ] || fail "unexpected v0.62.0 release asset"
+sha=$(strict_release_sha256 v0.62.0 linux amd64) || fail "missing v0.62.0 release checksum"
+[ "$sha" = "4cca7265b22e5c3ca8d62ab0b9752bec31f68b7f5fa636282a4c7e5454c35535" ] ||
+    fail "unexpected v0.62.0 release checksum"
+[ "$(strict_expected_status v0.62.0)" = "MANUAL" ] || fail "unexpected v0.62.0 status"
+[ "$(strict_expected_recipe v0.62.0)" = "server_to_embedded" ] || fail "unexpected v0.62.0 recipe"
+[ "$(strict_expected_features v0.62.0)" = "epic task bug dependency standalone closed label comment" ] ||
+    fail "unexpected v0.62.0 source features"
+[ "$(server_bridge_strategy v0.62.0)" = "native_export_show_comments" ] ||
+    fail "unexpected v0.62.0 bridge strategy"
+[ "$(server_bootstrap_strategy v0.62.0)" = "prestarted_server" ] ||
+    fail "unexpected v0.62.0 server bootstrap strategy"
+[ "$(strict_required_dolt_version v0.62.0)" = "1.84.0" ] ||
+    fail "unexpected v0.62.0 Dolt runtime version"
+[ "$(strict_required_dolt_sha256 v0.62.0 linux amd64)" = \
+    "afcdaa9530ae0b4f317ed6041a41d20096e156b2556eb0e03c7c57a624ccc0b3" ] ||
+    fail "unexpected v0.62.0 Dolt runtime checksum"
+[ "$(get_era v0.62.0)" = "dolt_server" ] || fail "v0.62.0 was not classified as server mode"
 
 asset=$(strict_release_asset v0.63.3 linux amd64) || fail "missing v0.63.3 release asset"
 [ "$asset" = "beads_0.63.3_linux_amd64.tar.gz" ] || fail "unexpected v0.63.3 release asset"
@@ -234,6 +255,27 @@ kill -9 -- "$guard_server_pid" 2>/dev/null || true
 wait "$guard_server_pid" 2>/dev/null || true
 guard_server_pid=""
 
+legacy_child_dolt_cwd="$pid_guard_workspace/.beads/dolt/legacy-child"
+mkdir -p "$legacy_child_dolt_cwd"
+(
+    cd "$legacy_child_dolt_cwd"
+    exec -a 'dolt sql-server' sleep 600
+) &
+guard_server_pid=$!
+for _ in $(seq 1 50); do
+    if [ "$(readlink "/proc/$guard_server_pid/cwd" 2>/dev/null || true)" = \
+        "$legacy_child_dolt_cwd" ]; then
+        break
+    fi
+    sleep 0.02
+done
+migration_pid_belongs_to_workspace \
+    "$guard_server_pid" "$pid_guard_workspace" "dolt-server.pid" ||
+    fail "legacy Dolt cleanup lost its established child-cwd compatibility"
+kill -9 -- "$guard_server_pid" 2>/dev/null || true
+wait "$guard_server_pid" 2>/dev/null || true
+guard_server_pid=""
+
 fake_dolt_cwd="$pid_guard_workspace/.beads/dolt"
 mkdir -p "$fake_dolt_cwd"
 (
@@ -332,12 +374,583 @@ grep -Fqx 'BEADS_NO_DAEMON=1' <<< "$poisoned_env_output" ||
 grep -Fqx 'BEADS_DOLT_AUTO_START=1' <<< "$poisoned_env_output" ||
     fail "bd_in did not force the intended historical server auto-start behavior"
 
+timeout_probe_bin_dir="$tmp/timeout-probe-bin"
+mkdir -p "$timeout_probe_bin_dir"
+if ! migration_validate_operation_timeouts; then
+    fail "default migration operation timeouts were rejected"
+fi
+if BD_OP_TIMEOUT=0 migration_validate_operation_timeouts; then
+    fail "zero migration operation timeout was accepted"
+fi
+if BD_OP_TIMEOUT=301 migration_validate_operation_timeouts; then
+    fail "unbounded migration operation timeout was accepted"
+fi
+if BD_OP_KILL_AFTER=0s migration_validate_operation_timeouts; then
+    fail "zero migration kill-after timeout was accepted"
+fi
+if BD_OP_KILL_AFTER=61s migration_validate_operation_timeouts; then
+    fail "unbounded migration kill-after timeout was accepted"
+fi
+if ! migration_validate_readiness_settings 100 0.1 30; then
+    fail "default owned-server readiness settings were rejected"
+fi
+for invalid_readiness in '0 0.1 30' '201 0.1 30' '100 1.1 30' '100 0.1 0' '100 0.1 121'; do
+    read -r ready_attempts ready_delay ready_timeout <<< "$invalid_readiness"
+    if migration_validate_readiness_settings \
+        "$ready_attempts" "$ready_delay" "$ready_timeout"; then
+        fail "unsafe owned-server readiness settings were accepted: $invalid_readiness"
+    fi
+done
+cat > "$timeout_probe_bin_dir/timeout" <<'EOF'
+#!/bin/bash
+printf ' <%s>' "$@"
+printf '\n'
+EOF
+chmod +x "$timeout_probe_bin_dir/timeout"
+timeout_probe_output=$(PATH="$timeout_probe_bin_dir:$PATH" bd_in "$port_ws_one" /bin/true)
+[ "$timeout_probe_output" = \
+    " <--kill-after=$BD_OP_KILL_AFTER> <$BD_OP_TIMEOUT> </bin/true>" ] ||
+    fail "bd_in did not bound a stubborn historical command with timeout --kill-after"
+
 release_migration_server_port "$port_ws_one" ||
     fail "could not release the first isolated historical server port"
 release_migration_server_port "$port_ws_two" ||
     fail "could not release the second isolated historical server port"
 [ ! -e "$port_lock_one" ] && [ ! -e "$port_lock_two" ] ||
     fail "historical server port reservation leaked after release"
+
+if ! (
+    transition_pid=""
+    transition_state="$tmp/owned-exit-transition.state"
+    cleanup_transition_probe() {
+        [ -z "$transition_pid" ] || kill -9 -- "$transition_pid" 2>/dev/null || true
+        [ -z "$transition_pid" ] || wait "$transition_pid" 2>/dev/null || true
+    }
+    trap cleanup_transition_probe EXIT
+    rm -f -- "$transition_state"
+    (
+        trap 'printf "term\n" > "$transition_state"; sleep 0.2; exit 0' TERM
+        while :; do
+            sleep 0.05 &
+            wait "$!" || true
+        done
+    ) &
+    transition_pid=$!
+    transition_start=$(migration_process_start_time "$transition_pid")
+    transition_identity=(
+        "$transition_pid" "$transition_start" ignored-exe ignored-launch
+        ignored-launch-id binary ignored-cwd
+    )
+    kill -TERM -- "$transition_pid"
+    for ((attempt = 0; attempt < 50; attempt++)); do
+        [ -s "$transition_state" ] && break
+        sleep 0.01
+    done
+    [ -s "$transition_state" ]
+    migration_owned_process_matches_identity() { return 1; }
+    migration_wait_owned_process_exit \
+        "$transition_pid" "$tmp" transition_identity 40
+); then
+    fail "owned-process wait rejected a valid graceful-exit transition"
+fi
+
+owned_server_bin_dir="$tmp/owned-server-bin"
+owned_server_calls="$owned_server_bin_dir/calls"
+owned_server_env="$owned_server_bin_dir/environments"
+mkdir -p "$owned_server_bin_dir"
+cat > "$owned_server_bin_dir/dolt" <<'EOF'
+#!/bin/bash
+set -euo pipefail
+bin_dir="$(cd "$(dirname "$0")" && pwd)"
+{
+    printf 'cwd=%s args=' "$PWD"
+    printf ' <%s>' "$@"
+    printf '\n'
+} >> "$bin_dir/calls"
+{
+    printf '%s\n' '---'
+    env | sort
+} >> "$bin_dir/environments"
+case "${1:-}" in
+    init)
+        mkdir -p .dolt
+        printf '{}\n' > .dolt/repo_state.json
+        ;;
+    sql-server)
+        [ ! -e "$bin_dir/fail-server" ] || exit 42
+        printf '%s\n' "$BASHPID" > "$bin_dir/last-server-pid"
+        if [ -e "$bin_dir/ignore-term" ]; then
+            trap '' TERM
+        else
+            trap 'exit 0' TERM
+        fi
+        while :; do
+            sleep 0.1 &
+            wait "$!" || true
+        done
+        ;;
+    --host)
+        [ ! -e "$bin_dir/fail-sql" ] || exit 43
+        [ "$2" = "127.0.0.1" ] && [ "$3" = "--port" ] &&
+            [[ "$4" =~ ^2[0-9]{4}$ ]] || exit 45
+        if [ "$#" -eq 8 ]; then
+            [ "$5" = "--no-tls" ] && [ "$6" = "sql" ] &&
+                [ "$7" = "-q" ] && [ "$8" = "SELECT 1" ]
+            if [ -e "$bin_dir/fail-final-validation" ]; then
+                git_dir="${XDG_RUNTIME_DIR%/bd-migration-runtime}"
+                printf '29999\n' > "$git_dir/bd-migration-prestarted-server"
+            fi
+        elif [ "$#" -eq 12 ]; then
+            [ "$5" = "--no-tls" ] && [ "$6" = "--use-db" ] &&
+                [ "$7" = "smoke" ] && [ "$8" = "sql" ] &&
+                [ "$9" = "-r" ] && [ "${10}" = "json" ] &&
+                [ "${11}" = "-q" ] &&
+                [ "${12}" = "SELECT value AS schema_version FROM config WHERE \`key\` = 'schema_version'" ]
+            printf '{"rows":[{"schema_version":"9"}]}\n'
+        else
+            exit 46
+        fi
+        ;;
+    *)
+        exit 44
+        ;;
+esac
+EOF
+chmod +x "$owned_server_bin_dir/dolt"
+
+owned_server_workspace=$(new_workspace) ||
+    fail "could not create an owned-server helper workspace"
+owned_server_port=$(cat "$owned_server_workspace/.git/bd-migration-server-port")
+if ! PATH="$owned_server_bin_dir:$PATH" \
+    HOME=/production/home \
+    XDG_CONFIG_HOME=/production/config \
+    DOLT_ROOT_PATH=/production/dolt-root \
+    start_owned_migration_dolt_server "$owned_server_workspace"; then
+    fail "owned historical Dolt server did not start"
+fi
+owned_server_pid_file="$owned_server_workspace/.git/bd-migration-owned-dolt-server.pid"
+owned_server_identity_file="$owned_server_workspace/.git/bd-migration-owned-dolt-server.identity"
+owned_server_mode_file="$owned_server_workspace/.git/bd-migration-prestarted-server"
+[ -f "$owned_server_pid_file" ] && [ ! -L "$owned_server_pid_file" ] ||
+    fail "owned historical Dolt server PID was not recorded safely"
+[ -f "$owned_server_identity_file" ] && [ ! -L "$owned_server_identity_file" ] ||
+    fail "owned historical Dolt server launch identity was not recorded safely"
+mapfile -t owned_server_recorded_identity < "$owned_server_identity_file"
+[ "${#owned_server_recorded_identity[@]}" -eq 7 ] ||
+    fail "owned historical Dolt server recorded redundant or incomplete identity fields"
+guard_server_pid=$(cat "$owned_server_pid_file")
+migration_pid_belongs_to_workspace \
+    "$guard_server_pid" "$owned_server_workspace" "bd-migration-owned-dolt-server.pid" ||
+    fail "recorded historical Dolt server PID failed ownership validation"
+declare -F migration_owned_process_matches_launch >/dev/null ||
+    fail "owned historical Dolt server has no exact argv validator"
+
+owned_identity_original="$tmp/owned-server.identity.original"
+owned_identity_tampered="$tmp/owned-server.identity.tampered"
+/bin/cp -f -- "$owned_server_identity_file" "$owned_identity_original"
+awk 'NR == 2 { $0 = $0 + 1 } { print }' \
+    "$owned_identity_original" > "$owned_identity_tampered"
+mv -f -- "$owned_identity_tampered" "$owned_server_identity_file"
+if migration_pid_belongs_to_workspace \
+    "$guard_server_pid" "$owned_server_workspace" "bd-migration-owned-dolt-server.pid"; then
+    fail "owned historical Dolt server trusted a mismatched process start time"
+fi
+/bin/cp -f -- "$owned_identity_original" "$owned_server_identity_file"
+migration_pid_belongs_to_workspace \
+    "$guard_server_pid" "$owned_server_workspace" "bd-migration-owned-dolt-server.pid" ||
+    fail "restored owned historical Dolt identity was rejected"
+
+(
+    cd "$owned_server_workspace/.beads/dolt"
+    exec -a "dolt sql-server --host 127.0.0.1 --port $owned_server_port" sleep 600
+) &
+spoof_server_pid=$!
+for _ in $(seq 1 50); do
+    [ "$(readlink "/proc/$spoof_server_pid/cwd" 2>/dev/null || true)" = \
+        "$owned_server_workspace/.beads/dolt" ] && break
+    sleep 0.02
+done
+spoof_server_accepted=false
+if migration_owned_process_matches_launch \
+    "$spoof_server_pid" "$owned_server_workspace" \
+    "$owned_server_bin_dir/dolt" "$owned_server_port"; then
+    spoof_server_accepted=true
+fi
+kill -9 -- "$spoof_server_pid" 2>/dev/null || true
+wait "$spoof_server_pid" 2>/dev/null || true
+$spoof_server_accepted &&
+    fail "owned historical Dolt server accepted substring-spoofed argv"
+[ "$(cat "$owned_server_mode_file")" = "$owned_server_port" ] ||
+    fail "prestarted-server marker did not bind to the reserved workspace port"
+[ -d "$owned_server_workspace/.beads/dolt/.dolt" ] ||
+    fail "owned historical Dolt server did not initialize its data root"
+grep -Fq "cwd=$owned_server_workspace/.beads/dolt args= <sql-server> <--host> <127.0.0.1> <--port> <$owned_server_port>" \
+    "$owned_server_calls" || fail "owned historical Dolt server used an unsafe command or cwd"
+grep -Fq "args= <--host> <127.0.0.1> <--port> <$owned_server_port> <--no-tls> <sql> <-q> <SELECT 1>" \
+    "$owned_server_calls" || fail "owned historical Dolt readiness did not execute a SQL query"
+if grep -Eq '^(HOME|XDG_CONFIG_HOME|DOLT_ROOT_PATH)=/production' "$owned_server_env"; then
+    fail "owned historical Dolt server inherited a poisoned host environment"
+fi
+grep -Fq "HOME=$owned_server_workspace/.git/bd-migration-home" "$owned_server_env" ||
+    fail "owned historical Dolt server did not use the isolated workspace HOME"
+for expected_server_env in \
+    "XDG_CONFIG_HOME=$owned_server_workspace/.git/bd-migration-home/.config" \
+    "XDG_CACHE_HOME=$owned_server_workspace/.git/bd-migration-home/.cache" \
+    "XDG_DATA_HOME=$owned_server_workspace/.git/bd-migration-home/.local/share" \
+    "XDG_STATE_HOME=$owned_server_workspace/.git/bd-migration-home/.local/state" \
+    "XDG_RUNTIME_DIR=$owned_server_workspace/.git/bd-migration-runtime" \
+    "TMPDIR=$owned_server_workspace/.git/bd-migration-tmp"; do
+    grep -Fq "$expected_server_env" "$owned_server_env" ||
+        fail "owned historical Dolt server did not isolate $expected_server_env"
+done
+owned_schema_json=$(PATH="$owned_server_bin_dir:$PATH" \
+    migration_owned_dolt_sql \
+        "$owned_server_workspace" smoke \
+        "SELECT value AS schema_version FROM config WHERE \`key\` = 'schema_version'") ||
+    fail "read-only owned-server SQL query failed"
+[ "$(jq -r '.rows[0].schema_version' <<< "$owned_schema_json")" = "9" ] ||
+    fail "read-only owned-server SQL query did not preserve JSON output"
+if PATH="$owned_server_bin_dir:$PATH" migration_owned_dolt_sql \
+    "$owned_server_workspace" smoke 'SELECT DOLT_COMMIT()' >/dev/null 2>&1; then
+    fail "read-only owned-server SQL helper accepted a mutating statement"
+fi
+grep -Fq "args= <--host> <127.0.0.1> <--port> <$owned_server_port> <--no-tls> <--use-db> <smoke> <sql> <-r> <json> <-q> <SELECT value AS schema_version FROM config WHERE \`key\` = 'schema_version'>" \
+    "$owned_server_calls" || fail "read-only owned-server SQL used an unsafe connection shape"
+
+owned_server_bd_env=$(bd_in "$owned_server_workspace" "$env_probe_bin")
+grep -Fqx 'BEADS_DOLT_AUTO_START=0' <<< "$owned_server_bd_env" ||
+    fail "bd_in did not disable auto-start for the prestarted historical server"
+if ! stop_dolt_server "$owned_server_workspace"; then
+    fail "could not stop the owned historical Dolt server"
+fi
+guard_server_pid=""
+[ ! -e "$owned_server_pid_file" ] && [ ! -L "$owned_server_pid_file" ] ||
+    fail "owned historical Dolt server PID marker survived shutdown"
+[ ! -e "$owned_server_identity_file" ] && [ ! -L "$owned_server_identity_file" ] ||
+    fail "owned historical Dolt server identity marker survived shutdown"
+[ "$(cat "$owned_server_mode_file")" = "$owned_server_port" ] ||
+    fail "prestarted-server mode was lost across a deliberate server stop"
+grep -Fqx 'BEADS_DOLT_AUTO_START=0' \
+    <<< "$(bd_in "$owned_server_workspace" "$env_probe_bin")" ||
+    fail "bd_in re-enabled auto-start after a prestarted server stopped"
+if PATH="$owned_server_bin_dir:$PATH" migration_owned_dolt_sql \
+    "$owned_server_workspace" smoke \
+    "SELECT value AS schema_version FROM config WHERE \`key\` = 'schema_version'" \
+    >/dev/null 2>&1; then
+    fail "read-only owned-server SQL trusted a stopped server"
+fi
+if ! PATH="$owned_server_bin_dir:$PATH" \
+    start_owned_migration_dolt_server "$owned_server_workspace"; then
+    fail "owned historical Dolt server did not restart"
+fi
+guard_server_pid=$(cat "$owned_server_pid_file")
+[ "$(grep -c 'args= <init>' "$owned_server_calls")" -eq 1 ] ||
+    fail "owned historical Dolt restart reinitialized an existing data root"
+cleanup_workspace "$owned_server_workspace" ||
+    fail "could not clean up the owned historical Dolt server workspace"
+guard_server_pid=""
+[ ! -e "$owned_server_workspace" ] ||
+    fail "owned historical Dolt server workspace survived verified cleanup"
+
+owned_server_final_failure_workspace=$(new_workspace) ||
+    fail "could not create an owned-server final-validation workspace"
+touch "$owned_server_bin_dir/fail-final-validation"
+final_validation_succeeded=false
+if PATH="$owned_server_bin_dir:$PATH" \
+    start_owned_migration_dolt_server "$owned_server_final_failure_workspace"; then
+    final_validation_succeeded=true
+fi
+rm -f "$owned_server_bin_dir/fail-final-validation"
+final_validation_pid=$(cat "$owned_server_bin_dir/last-server-pid")
+final_validation_live=false
+kill -0 "$final_validation_pid" 2>/dev/null && final_validation_live=true
+final_validation_markers=false
+for final_marker in \
+    "$owned_server_final_failure_workspace/.git/bd-migration-owned-dolt-server.pid" \
+    "$owned_server_final_failure_workspace/.git/bd-migration-owned-dolt-server.identity" \
+    "$owned_server_final_failure_workspace/.git/bd-migration-prestarted-server"; do
+    if [ -e "$final_marker" ] || [ -L "$final_marker" ]; then
+        final_validation_markers=true
+    fi
+done
+cleanup_workspace "$owned_server_final_failure_workspace" ||
+    fail "could not clean up the final-validation failure workspace"
+$final_validation_succeeded &&
+    fail "owned historical Dolt server accepted failed final validation"
+$final_validation_live &&
+    fail "failed final validation left an owned historical Dolt server live"
+$final_validation_markers &&
+    fail "failed final validation left owned-server trust markers"
+
+owned_server_capture_failure_workspace=$(new_workspace) ||
+    fail "could not create an owned-server capture-failure workspace"
+capture_failure_succeeded=false
+if (
+    PATH="$owned_server_bin_dir:$PATH"
+    migration_capture_owned_process_identity() { return 1; }
+    start_owned_migration_dolt_server "$owned_server_capture_failure_workspace"
+) >/dev/null 2>&1; then
+    capture_failure_succeeded=true
+fi
+capture_failure_pid=$(cat "$owned_server_bin_dir/last-server-pid")
+capture_failure_live=false
+if kill -0 "$capture_failure_pid" 2>/dev/null; then
+    capture_failure_live=true
+    kill -9 -- "$capture_failure_pid" 2>/dev/null || true
+fi
+capture_failure_markers=false
+for capture_failure_marker in \
+    "$owned_server_capture_failure_workspace/.git/bd-migration-owned-dolt-server.pid" \
+    "$owned_server_capture_failure_workspace/.git/bd-migration-owned-dolt-server.identity"; do
+    if [ -e "$capture_failure_marker" ] || [ -L "$capture_failure_marker" ]; then
+        capture_failure_markers=true
+    fi
+done
+cleanup_workspace "$owned_server_capture_failure_workspace" ||
+    fail "could not clean up the owned-server capture-failure workspace"
+$capture_failure_succeeded &&
+    fail "owned-server launch succeeded without a durable full identity"
+$capture_failure_live &&
+    fail "failed owned-server identity capture orphaned the launched process"
+$capture_failure_markers &&
+    fail "failed owned-server identity capture published trust markers"
+
+owned_server_publish_failure_workspace=$(new_workspace) ||
+    fail "could not create an owned-server publication-failure workspace"
+publication_failure_succeeded=false
+if (
+    PATH="$owned_server_bin_dir:$PATH"
+    migration_publish_owned_process_identity() {
+        local ws="$1"
+        local identity_name="$2"
+        local -n identity_ref="$identity_name"
+        printf '%s\n' "${identity_ref[@]}" > \
+            "$ws/.git/bd-migration-owned-dolt-server.identity"
+        printf '%s\n' "${identity_ref[0]}" > \
+            "$ws/.git/bd-migration-owned-dolt-server.pid"
+        return 1
+    }
+    start_owned_migration_dolt_server "$owned_server_publish_failure_workspace"
+) >/dev/null 2>&1; then
+    publication_failure_succeeded=true
+fi
+publication_failure_pid=$(cat "$owned_server_bin_dir/last-server-pid")
+publication_failure_live=false
+kill -0 "$publication_failure_pid" 2>/dev/null && publication_failure_live=true
+publication_failure_markers=false
+for publication_failure_marker in \
+    "$owned_server_publish_failure_workspace/.git/bd-migration-owned-dolt-server.pid" \
+    "$owned_server_publish_failure_workspace/.git/bd-migration-owned-dolt-server.identity"; do
+    if [ -e "$publication_failure_marker" ] || [ -L "$publication_failure_marker" ]; then
+        publication_failure_markers=true
+    fi
+done
+cleanup_workspace "$owned_server_publish_failure_workspace" ||
+    fail "could not clean up the owned-server publication-failure workspace"
+$publication_failure_succeeded &&
+    fail "owned-server launch accepted a failed identity publication"
+$publication_failure_live &&
+    fail "failed owned-server identity publication orphaned the launched process"
+$publication_failure_markers &&
+    fail "failed owned-server identity publication retained committed trust markers"
+
+owned_server_rollback_failure_workspace=$(new_workspace) ||
+    fail "could not create an owned-server rollback-failure workspace"
+touch "$owned_server_bin_dir/fail-final-validation"
+rollback_failure_output=$(
+    {
+        PATH="$owned_server_bin_dir:$PATH"
+        migration_signal_owned_process() { return 1; }
+        start_owned_migration_dolt_server "$owned_server_rollback_failure_workspace"
+    } 2>&1
+) && fail "owned-server rollback failure unexpectedly reported success"
+rm -f "$owned_server_bin_dir/fail-final-validation"
+rollback_failure_pid=$(cat \
+    "$owned_server_rollback_failure_workspace/.git/bd-migration-owned-dolt-server.pid")
+guard_server_pid="$rollback_failure_pid"
+kill -0 "$rollback_failure_pid" 2>/dev/null ||
+    fail "rollback cleanup failure lost the accounted owned server"
+[ -f "$owned_server_rollback_failure_workspace/.git/bd-migration-owned-dolt-server.identity" ] ||
+    fail "rollback cleanup failure lost the owned-server identity marker"
+migration_pid_belongs_to_workspace \
+    "$rollback_failure_pid" "$owned_server_rollback_failure_workspace" \
+    "bd-migration-owned-dolt-server.pid" ||
+    fail "rollback cleanup failure left an unverifiable owned server"
+grep -Fq 'rollback failed' <<< "$rollback_failure_output" ||
+    fail "owned-server rollback cleanup failure was not reported"
+cleanup_workspace "$owned_server_rollback_failure_workspace" ||
+    fail "could not clean up the accounted rollback-failure workspace"
+guard_server_pid=""
+
+ignored_cleanup_workspace=$(new_workspace) ||
+    fail "could not create an ignored-cleanup reporting workspace"
+ignored_cleanup_snapshots=$(mktemp -d /tmp/bd-snapshots-XXXXXX) ||
+    fail "could not create ignored-cleanup snapshot evidence"
+printf 'snapshot evidence\n' > "$ignored_cleanup_snapshots/before.json"
+ignored_cleanup_result=$(bash -c '
+    set -euo pipefail
+    export MIGRATION_TEST_RUN_LIBRARY_ONLY=1
+    source "$1"
+    migration_run_activate_workspace "$2" "$3"
+    cleanup_workspace() { return 1; }
+    if migration_run_record_result_after_cleanup \
+        "$2" "$3" "v0.62.0 → candidate" "BLOCKED" "earlier failure"; then
+        exit 1
+    fi
+    printf "%s\n%s\n%s\n" \
+        "${RESULT_STATUSES[-1]}" "${RESULT_DETAILS[-1]}" \
+        "$MIGRATION_RUN_ACTIVE_WORKSPACE"
+' migration-report-probe "$SCRIPT_DIR/run.sh" \
+    "$ignored_cleanup_workspace" "$ignored_cleanup_snapshots") ||
+    fail "cleanup refusal did not override the earlier result and retain evidence"
+mapfile -t ignored_cleanup_lines <<< "$ignored_cleanup_result"
+[ "${ignored_cleanup_lines[0]}" = "BLOCKED" ] &&
+    [[ "${ignored_cleanup_lines[1]}" == \
+        "could not prove isolated workspace cleanup; preserved at "* ]] &&
+    [ -z "${ignored_cleanup_lines[2]:-}" ] &&
+    [ -f "$ignored_cleanup_snapshots/before.json" ] ||
+    fail "cleanup refusal did not override the earlier result and retain evidence"
+cleanup_workspace "$ignored_cleanup_workspace" ||
+    fail "could not clean up the ignored-cleanup reporting workspace"
+rm -rf -- "$ignored_cleanup_snapshots"
+
+signal_cleanup_state="$tmp/signal-cleanup.state"
+(
+    exec bash -c '
+        set -euo pipefail
+        export MIGRATION_TEST_RUN_LIBRARY_ONLY=1
+        export PATH="$2:$PATH"
+        source "$1"
+        migration_run_install_cleanup_traps
+        ws=$(new_workspace)
+        snapshots=$(mktemp -d /tmp/bd-snapshots-XXXXXX)
+        migration_run_activate_workspace "$ws" "$snapshots"
+        start_owned_migration_dolt_server "$ws"
+        pid=$(cat "$ws/.git/bd-migration-owned-dolt-server.pid")
+        printf "%s\n%s\n" "$ws" "$pid" > "$3.tmp"
+        mv -f -- "$3.tmp" "$3"
+        while :; do sleep 1; done
+    ' migration-signal-probe "$SCRIPT_DIR/run.sh" \
+        "$owned_server_bin_dir" "$signal_cleanup_state"
+) &
+signal_cleanup_runner=$!
+for _ in $(seq 1 200); do
+    [ -s "$signal_cleanup_state" ] && break
+    kill -0 "$signal_cleanup_runner" 2>/dev/null || break
+    sleep 0.02
+done
+[ -s "$signal_cleanup_state" ] || {
+    kill -9 -- "$signal_cleanup_runner" 2>/dev/null || true
+    wait "$signal_cleanup_runner" 2>/dev/null || true
+    fail "signal-cleanup subprocess did not become ready"
+}
+mapfile -t signal_cleanup_identity < "$signal_cleanup_state"
+signal_cleanup_workspace="${signal_cleanup_identity[0]}"
+signal_cleanup_server_pid="${signal_cleanup_identity[1]}"
+kill -TERM -- "$signal_cleanup_runner"
+signal_cleanup_status=0
+wait "$signal_cleanup_runner" || signal_cleanup_status=$?
+[ "$signal_cleanup_status" -eq 143 ] ||
+    fail "signal-cleanup subprocess returned $signal_cleanup_status, want 143"
+kill -0 "$signal_cleanup_server_pid" 2>/dev/null &&
+    fail "signal cleanup left the owned historical Dolt server running"
+[ ! -e "$signal_cleanup_workspace" ] ||
+    fail "signal cleanup left the active migration workspace behind"
+
+owned_server_failure_workspace=$(new_workspace) ||
+    fail "could not create an owned-server failure workspace"
+touch "$owned_server_bin_dir/fail-sql"
+if PATH="$owned_server_bin_dir:$PATH" \
+    MIGRATION_DOLT_READY_ATTEMPTS=2 MIGRATION_DOLT_READY_DELAY=0 \
+    start_owned_migration_dolt_server "$owned_server_failure_workspace"; then
+    fail "owned historical Dolt server accepted failed SQL readiness"
+fi
+rm -f "$owned_server_bin_dir/fail-sql"
+[ ! -e "$owned_server_failure_workspace/.git/bd-migration-owned-dolt-server.pid" ] &&
+    [ ! -e "$owned_server_failure_workspace/.git/bd-migration-prestarted-server" ] ||
+    fail "failed SQL readiness left owned-server trust markers"
+cleanup_workspace "$owned_server_failure_workspace" ||
+    fail "could not clean up the failed owned-server workspace"
+
+owned_server_exit_workspace=$(new_workspace) ||
+    fail "could not create an owned-server early-exit workspace"
+touch "$owned_server_bin_dir/fail-server"
+if PATH="$owned_server_bin_dir:$PATH" \
+    start_owned_migration_dolt_server "$owned_server_exit_workspace"; then
+    fail "owned historical Dolt server accepted an exited sql-server process"
+fi
+rm -f "$owned_server_bin_dir/fail-server"
+[ ! -e "$owned_server_exit_workspace/.git/bd-migration-owned-dolt-server.pid" ] &&
+    [ ! -e "$owned_server_exit_workspace/.git/bd-migration-prestarted-server" ] ||
+    fail "early sql-server exit left owned-server trust markers"
+cleanup_workspace "$owned_server_exit_workspace" ||
+    fail "could not clean up the early-exit owned-server workspace"
+
+owned_server_crash_workspace=$(new_workspace) ||
+    fail "could not create an owned-server crash workspace"
+if ! PATH="$owned_server_bin_dir:$PATH" \
+    start_owned_migration_dolt_server "$owned_server_crash_workspace"; then
+    fail "could not start the owned historical Dolt crash fixture"
+fi
+guard_server_pid=$(cat \
+    "$owned_server_crash_workspace/.git/bd-migration-owned-dolt-server.pid")
+kill -9 -- "$guard_server_pid" 2>/dev/null || true
+wait "$guard_server_pid" 2>/dev/null || true
+guard_server_pid=""
+cleanup_workspace "$owned_server_crash_workspace" ||
+    fail "cleanup stranded a workspace after its owned Dolt server exited"
+[ ! -e "$owned_server_crash_workspace" ] ||
+    fail "crashed owned-server workspace survived port-verified cleanup"
+
+tampered_mode_workspace=$(new_workspace) ||
+    fail "could not create a prestarted-marker tamper workspace"
+printf '29999\n' > "$tampered_mode_workspace/.git/bd-migration-prestarted-server"
+if bd_in "$tampered_mode_workspace" /bin/true; then
+    fail "bd_in trusted a prestarted-server marker for another port"
+fi
+rm -f "$tampered_mode_workspace/.git/bd-migration-prestarted-server"
+ln -s /dev/null "$tampered_mode_workspace/.git/bd-migration-prestarted-server"
+if bd_in "$tampered_mode_workspace" /bin/true; then
+    fail "bd_in followed a prestarted-server marker symlink"
+fi
+rm -f "$tampered_mode_workspace/.git/bd-migration-prestarted-server"
+cleanup_workspace "$tampered_mode_workspace" ||
+    fail "could not clean up the prestarted-marker tamper workspace"
+
+tampered_pid_workspace=$(new_workspace) ||
+    fail "could not create an owned-PID tamper workspace"
+tampered_pid_external_cwd="$tmp/owned-pid-external-cwd"
+mkdir -p "$tampered_pid_workspace/.beads/dolt" "$tampered_pid_external_cwd"
+tampered_pid_port=$(cat "$tampered_pid_workspace/.git/bd-migration-server-port")
+(
+    cd "$tampered_pid_external_cwd"
+    exec -a "dolt sql-server --host 127.0.0.1 --port $tampered_pid_port" sleep 600
+) &
+guard_server_pid=$!
+for _ in $(seq 1 50); do
+    if [ "$(readlink "/proc/$guard_server_pid/cwd" 2>/dev/null || true)" = \
+        "$tampered_pid_external_cwd" ]; then
+        break
+    fi
+    sleep 0.02
+done
+printf '%s\n' "$guard_server_pid" > \
+    "$tampered_pid_workspace/.git/bd-migration-owned-dolt-server.pid"
+if cleanup_workspace "$tampered_pid_workspace"; then
+    fail "cleanup trusted an owned-server PID rooted outside its workspace"
+fi
+[ -d "$tampered_pid_workspace" ] ||
+    fail "cleanup deleted a workspace after owned-server PID validation failed"
+kill -0 "$guard_server_pid" 2>/dev/null || {
+    guard_server_pid=""
+    fail "cleanup killed a process after owned-server PID validation failed"
+}
+kill -9 -- "$guard_server_pid" 2>/dev/null || true
+wait "$guard_server_pid" 2>/dev/null || true
+guard_server_pid=""
+rm -f "$tampered_pid_workspace/.git/bd-migration-owned-dolt-server.pid"
+cleanup_workspace "$tampered_pid_workspace" ||
+    fail "could not clean up the rejected owned-PID workspace safely"
 
 port_unknown_ws="$tmp/port-workspace-unknown-occupancy"
 mkdir -p "$port_unknown_ws/.git"
@@ -366,6 +979,14 @@ if PATH="$runtime_bin_dir:$PATH" FAKE_DOLT_VERSION=2.1.9 \
     verify_strict_historical_runtime v0.57.0 >/dev/null 2>&1; then
     fail "unqualified v0.57.0 Dolt runtime was accepted"
 fi
+if ! PATH="$runtime_bin_dir:$PATH" FAKE_DOLT_VERSION=1.84.0 \
+    verify_strict_historical_runtime v0.62.0; then
+    fail "qualified v0.62.0 Dolt runtime was rejected"
+fi
+if PATH="$runtime_bin_dir:$PATH" FAKE_DOLT_VERSION=1.84.1 \
+    verify_strict_historical_runtime v0.62.0 >/dev/null 2>&1; then
+    fail "unqualified v0.62.0 Dolt runtime was accepted"
+fi
 verify_strict_historical_runtime v0.49.6 ||
     fail "a release without an external Dolt requirement was rejected"
 
@@ -379,6 +1000,9 @@ fi
 if OS=linux ARCH=amd64 verify_release_archive v0.57.0 "$tmp/archive.tar.gz" >/dev/null 2>&1; then
     fail "tampered v0.57.0 release archive was accepted"
 fi
+if OS=linux ARCH=amd64 verify_release_archive v0.62.0 "$tmp/archive.tar.gz" >/dev/null 2>&1; then
+    fail "tampered v0.62.0 release archive was accepted"
+fi
 if OS=linux ARCH=amd64 verify_release_archive v0.63.3 "$tmp/archive.tar.gz" >/dev/null 2>&1; then
     fail "tampered v0.63.3 release archive was accepted"
 fi
@@ -389,6 +1013,8 @@ strict_fixture_has_expected_features v0.55.4 epic task bug dependency standalone
     fail "complete v0.55.4 source fixture was rejected"
 strict_fixture_has_expected_features v0.57.0 epic task bug dependency standalone closed label comment ||
     fail "complete v0.57.0 source fixture was rejected"
+strict_fixture_has_expected_features v0.62.0 epic task bug dependency standalone closed label comment ||
+    fail "complete v0.62.0 source fixture was rejected"
 strict_fixture_has_expected_features v0.63.3 epic task bug dependency standalone closed label comment ||
     fail "complete v0.63.3 source fixture was rejected"
 if strict_fixture_has_expected_features v0.49.6 epic task bug standalone closed label >/dev/null 2>&1; then
@@ -397,6 +1023,90 @@ fi
 if strict_fixture_has_expected_features v0.49.6 epic task bug dependency standalone closed label >/dev/null 2>&1; then
     fail "source fixture without comment was accepted"
 fi
+if strict_fixture_has_expected_features v0.62.0 epic task bug standalone closed label comment >/dev/null 2>&1; then
+    fail "v0.62.0 source fixture without dependency was accepted"
+fi
+if strict_fixture_has_expected_features v0.62.0 epic task bug dependency standalone closed label >/dev/null 2>&1; then
+    fail "v0.62.0 source fixture without comment was accepted"
+fi
+
+# A strict fixture must construct its canonical parent relationship directly.
+# Keep this hermetic: a fake bd proves a clean cache cannot introduce a probe,
+# and that a qualified release which rejects --parent blocks fixture creation.
+(
+    strict_fixture_ws="$tmp/strict-fixture-workspace"
+    strict_fixture_bin_dir="$tmp/strict-fixture-bin"
+    strict_fixture_bin="$strict_fixture_bin_dir/bd"
+    strict_fixture_calls="$strict_fixture_bin_dir/calls"
+    GATES_CACHE="$tmp/strict-fixture-cache/feature-gates.cache"
+    mkdir -p "$strict_fixture_ws" "$strict_fixture_bin_dir" "$(dirname "$GATES_CACHE")"
+    cat > "$strict_fixture_bin" <<'EOF'
+#!/bin/bash
+set -euo pipefail
+bin_dir="$(cd "$(dirname "$0")" && pwd)"
+printf ' <%s>' "$@" >> "$bin_dir/calls"
+printf '\n' >> "$bin_dir/calls"
+
+case "${1:-}" in
+    create)
+        if [ -e "$bin_dir/reject-parent" ] && [[ " $* " == *" --parent "* ]]; then
+            exit 71
+        fi
+        case "$*" in
+            *"__probe__"*) printf '%s\n' 'strict-probe' ;;
+            *"Migration epic"*) printf '%s\n' 'strict-epic' ;;
+            *"Migration task alpha"*) printf '%s\n' 'strict-task' ;;
+            *"Migration bug beta"*) printf '%s\n' 'strict-bug' ;;
+            *"Standalone detailed task"*) printf '%s\n' 'strict-standalone' ;;
+            *"Already closed issue"*) printf '%s\n' 'strict-closed' ;;
+            *) exit 72 ;;
+        esac
+        ;;
+    dep|close|label|comments)
+        ;;
+    *)
+        exit 73
+        ;;
+esac
+EOF
+    chmod +x "$strict_fixture_bin"
+
+    STRICT_MODE=true
+    create_dataset "$strict_fixture_ws" "$strict_fixture_bin" v0.62.0 >/dev/null ||
+        fail "strict fixture construction rejected direct parent creation"
+    [ "${DATASET_FEATURES[*]}" = "epic task bug dependency standalone closed label comment" ] ||
+        fail "strict fixture construction changed the public eight-feature manifest"
+    [ ! -e "$GATES_CACHE" ] ||
+        fail "strict fixture construction consulted or populated the feature-gate cache"
+    if grep -Fq '__probe__' "$strict_fixture_calls"; then
+        fail "strict fixture construction created a parent-support probe"
+    fi
+    grep -Fq '<create> <--silent> <--title> <Migration task alpha> <--type> <task> <--priority> <1> <--parent> <strict-epic>' \
+        "$strict_fixture_calls" ||
+        fail "strict fixture did not construct its canonical task with --parent directly"
+
+    printf '%s\n' 'v0.62.0:parent_child=no' > "$GATES_CACHE"
+    : > "$strict_fixture_calls"
+    create_dataset "$strict_fixture_ws" "$strict_fixture_bin" v0.62.0 >/dev/null ||
+        fail "strict fixture construction trusted a negative feature-cache entry"
+    grep -Fq '<create> <--silent> <--title> <Migration task alpha> <--type> <task> <--priority> <1> <--parent> <strict-epic>' \
+        "$strict_fixture_calls" ||
+        fail "strict fixture omitted --parent after a negative feature-cache entry"
+    if grep -Fq '__probe__' "$strict_fixture_calls"; then
+        fail "strict fixture probed after a negative feature-cache entry"
+    fi
+    [ "$(cat "$GATES_CACHE")" = 'v0.62.0:parent_child=no' ] ||
+        fail "strict fixture construction rewrote the feature-gate cache"
+
+    : > "$strict_fixture_calls"
+    touch "$strict_fixture_bin_dir/reject-parent"
+    if create_dataset "$strict_fixture_ws" "$strict_fixture_bin" v0.62.0 >/dev/null 2>&1; then
+        fail "strict fixture ignored a qualified release rejecting --parent"
+    fi
+    if grep -Fq '__probe__' "$strict_fixture_calls"; then
+        fail "strict unsupported-parent failure ran a feature probe"
+    fi
+)
 
 declare -gA DATASET_IDS=(
     [epic]="old-epic"
@@ -409,8 +1119,8 @@ printf '%s\n' '[
   {"id":"old-epic","title":"Migration epic","description":"Epic for migration testing","priority":2,"issue_type":"epic","status":"open"},
   {"id":"old-standalone","title":"Standalone detailed task","description":"This task has a detailed description for fidelity testing.","notes":"Historical notes must survive the upgrade.","design":"Historical design must survive the upgrade.","acceptance_criteria":"Historical acceptance criteria must survive the upgrade.","external_ref":"legacy-upgrade-42","status":"open"},
   {"id":"old-closed","title":"Already closed issue","status":"closed"},
-  {"id":"old-task","title":"Implement core feature","status":"open","labels":["urgent"],"comments":[{"author":"legacy-author","text":"Historical comment must survive the upgrade."}]},
-  {"id":"old-bug","title":"Fix migration blocker","status":"open","dependencies":[{"id":"old-task"}]}
+  {"id":"old-task","title":"Implement core feature","status":"open","parent":"old-epic","dependencies":[{"id":"old-epic","dependency_type":"parent-child"}],"labels":["urgent"],"comments":[{"author":"legacy-author","text":"Historical comment must survive the upgrade."}]},
+  {"id":"old-bug","title":"Fix migration blocker","status":"open","dependencies":[{"id":"old-task","dependency_type":"blocks"}]}
 ]' > "$tmp/fixture.json"
 strict_snapshot_has_expected_fixture v0.49.6 "$tmp/fixture.json" ||
     fail "exact v0.49.6 source fixture was rejected"
@@ -418,24 +1128,69 @@ strict_snapshot_has_expected_fixture v0.55.4 "$tmp/fixture.json" ||
     fail "exact v0.55.4 source fixture was rejected"
 strict_snapshot_has_expected_fixture v0.57.0 "$tmp/fixture.json" ||
     fail "exact v0.57.0 source fixture was rejected"
+strict_snapshot_has_expected_fixture v0.62.0 "$tmp/fixture.json" ||
+    fail "exact v0.62.0 source fixture was rejected"
 strict_snapshot_has_expected_fixture v0.63.3 "$tmp/fixture.json" ||
     fail "exact v0.63.3 source fixture was rejected"
+jq 'map(if .id == "old-task" then del(.parent) else . end)' \
+    "$tmp/fixture.json" > "$tmp/fixture-parentless-task.json"
+if strict_snapshot_has_expected_fixture v0.62.0 "$tmp/fixture-parentless-task.json" >/dev/null 2>&1; then
+    fail "v0.62.0 source fixture with a parentless canonical task was accepted"
+fi
+jq 'map(if .id == "old-task" then
+        .dependencies[0].dependency_type = "blocks"
+    else . end)' \
+    "$tmp/fixture.json" > "$tmp/fixture-wrong-parent-child-type.json"
+if strict_snapshot_has_expected_fixture v0.62.0 "$tmp/fixture-wrong-parent-child-type.json" >/dev/null 2>&1; then
+    fail "v0.62.0 source fixture with the wrong parent-child dependency type was accepted"
+fi
+jq 'map(if .id == "old-bug" then
+        .dependencies[0].dependency_type = "related"
+    else . end)' \
+    "$tmp/fixture.json" > "$tmp/fixture-wrong-blocks-type.json"
+if strict_snapshot_has_expected_fixture v0.62.0 "$tmp/fixture-wrong-blocks-type.json" >/dev/null 2>&1; then
+    fail "v0.62.0 source fixture with the wrong blocks dependency type was accepted"
+fi
+jq 'map(if .id == "old-task" then
+        .dependencies += [{"id":"old-closed","dependency_type":"related"}]
+    else . end)' \
+    "$tmp/fixture.json" > "$tmp/fixture-extra-task-dependency.json"
+if strict_snapshot_has_expected_fixture v0.62.0 "$tmp/fixture-extra-task-dependency.json" >/dev/null 2>&1; then
+    fail "v0.62.0 source fixture with an extra task dependency was accepted"
+fi
+jq 'map(if .id == "old-bug" then
+        .dependencies += [{"id":"old-closed","dependency_type":"related"}]
+    else . end)' \
+    "$tmp/fixture.json" > "$tmp/fixture-extra-bug-dependency.json"
+if strict_snapshot_has_expected_fixture v0.62.0 "$tmp/fixture-extra-bug-dependency.json" >/dev/null 2>&1; then
+    fail "v0.62.0 source fixture with an extra bug dependency was accepted"
+fi
+for issue_id in old-epic old-standalone old-closed; do
+    jq --arg id "$issue_id" 'map(if .id == $id then
+            .dependencies = [{"id":"old-task","dependency_type":"related"}]
+        else . end)' \
+        "$tmp/fixture.json" > "$tmp/fixture-unexpected-$issue_id-dependency.json"
+    if strict_snapshot_has_expected_fixture \
+        v0.62.0 "$tmp/fixture-unexpected-$issue_id-dependency.json" >/dev/null 2>&1; then
+        fail "v0.62.0 source fixture accepted an unexpected dependency on $issue_id"
+    fi
+done
 jq 'map(select(.id != "old-epic"))' "$tmp/fixture.json" > "$tmp/fixture-four-items.json"
-for version in v0.49.6 v0.55.4 v0.57.0 v0.63.3; do
+for version in v0.49.6 v0.55.4 v0.57.0 v0.62.0 v0.63.3; do
     if strict_snapshot_has_expected_fixture "$version" "$tmp/fixture-four-items.json" >/dev/null 2>&1; then
         fail "$version source fixture with four items was accepted"
     fi
 done
 jq '. + [{"id":"old-extra","title":"Unexpected extra issue"}]' \
     "$tmp/fixture.json" > "$tmp/fixture-six-items.json"
-for version in v0.49.6 v0.55.4 v0.57.0 v0.63.3; do
+for version in v0.49.6 v0.55.4 v0.57.0 v0.62.0 v0.63.3; do
     if strict_snapshot_has_expected_fixture "$version" "$tmp/fixture-six-items.json" >/dev/null 2>&1; then
         fail "$version source fixture with six items was accepted"
     fi
 done
 jq 'map(if .id == "old-epic" then .issue_type = "task" else . end)' \
     "$tmp/fixture.json" > "$tmp/fixture-wrong-epic.json"
-for version in v0.49.6 v0.55.4 v0.57.0 v0.63.3; do
+for version in v0.49.6 v0.55.4 v0.57.0 v0.62.0 v0.63.3; do
     if strict_snapshot_has_expected_fixture "$version" "$tmp/fixture-wrong-epic.json" >/dev/null 2>&1; then
         fail "$version source fixture with an inexact epic was accepted"
     fi
@@ -451,6 +1206,9 @@ fi
 if strict_snapshot_has_expected_fixture v0.57.0 "$tmp/fixture-missing-rich-field.json" >/dev/null 2>&1; then
     fail "v0.57.0 source fixture without the exact rich fields was accepted"
 fi
+if strict_snapshot_has_expected_fixture v0.62.0 "$tmp/fixture-missing-rich-field.json" >/dev/null 2>&1; then
+    fail "v0.62.0 source fixture without the exact rich fields was accepted"
+fi
 if strict_snapshot_has_expected_fixture v0.63.3 "$tmp/fixture-missing-rich-field.json" >/dev/null 2>&1; then
     fail "v0.63.3 source fixture without the exact rich fields was accepted"
 fi
@@ -465,6 +1223,9 @@ fi
 if strict_snapshot_has_expected_fixture v0.57.0 "$tmp/fixture-missing-label.json" >/dev/null 2>&1; then
     fail "v0.57.0 source fixture without the exact label was accepted"
 fi
+if strict_snapshot_has_expected_fixture v0.62.0 "$tmp/fixture-missing-label.json" >/dev/null 2>&1; then
+    fail "v0.62.0 source fixture without the exact label was accepted"
+fi
 if strict_snapshot_has_expected_fixture v0.63.3 "$tmp/fixture-missing-label.json" >/dev/null 2>&1; then
     fail "v0.63.3 source fixture without the exact label was accepted"
 fi
@@ -478,6 +1239,9 @@ if strict_snapshot_has_expected_fixture v0.55.4 "$tmp/fixture-missing-dependency
 fi
 if strict_snapshot_has_expected_fixture v0.57.0 "$tmp/fixture-missing-dependency.json" >/dev/null 2>&1; then
     fail "v0.57.0 source fixture without the exact dependency was accepted"
+fi
+if strict_snapshot_has_expected_fixture v0.62.0 "$tmp/fixture-missing-dependency.json" >/dev/null 2>&1; then
+    fail "v0.62.0 source fixture without the exact dependency was accepted"
 fi
 if strict_snapshot_has_expected_fixture v0.63.3 "$tmp/fixture-missing-dependency.json" >/dev/null 2>&1; then
     fail "v0.63.3 source fixture without the exact dependency was accepted"
@@ -718,6 +1482,39 @@ fi
 [ ! -e "$stop_refusal_ws/.beads/legacy-dolt.pre-migration" ] ||
     fail "server-stop verification failure created a rollback tree"
 
+restart_refusal_ws="$tmp/restart-refusal-workspace"
+restart_refusal_calls="$tmp/restart-refusal.calls"
+restart_refusal_binary_calls="$tmp/restart-refusal-binary.calls"
+mkdir -p "$restart_refusal_ws/.beads/dolt"
+printf 'active restart-refusal data' > "$restart_refusal_ws/.beads/dolt/table.dat"
+printf 'active restart-refusal metadata' > "$restart_refusal_ws/.beads/metadata.json"
+restart_refusal_manifest=$(legacy_dolt_artifact_manifest "$restart_refusal_ws/.beads")
+export LEGACY_RACE_CALLS="$restart_refusal_binary_calls"
+: > "$restart_refusal_calls"
+: > "$restart_refusal_binary_calls"
+if (
+    stop_dolt_server() { :; }
+    start_owned_migration_dolt_server() {
+        printf '%s\n' "$1" >> "$restart_refusal_calls"
+        return 1
+    }
+    recipe_server_to_embedded \
+        "$restart_refusal_ws" "$legacy_race_old_bin" "$legacy_race_candidate_bin" \
+        v0.62.0 "$legacy_race_before"
+) >/dev/null 2>&1; then
+    fail "v0.62.0 server bridge continued after owned-server restart failed"
+fi
+[ "$(cat "$restart_refusal_calls")" = "$restart_refusal_ws" ] ||
+    fail "v0.62.0 server bridge did not attempt exactly one owned-server restart"
+[ ! -s "$restart_refusal_binary_calls" ] ||
+    fail "owned-server restart failure invoked a historical or candidate binary"
+[ "$(legacy_dolt_artifact_manifest "$restart_refusal_ws/.beads")" = \
+    "$restart_refusal_manifest" ] ||
+    fail "owned-server restart failure mutated the active historical source"
+verify_retained_legacy_dolt_source \
+    "$restart_refusal_ws/.beads" "$restart_refusal_manifest" ||
+    fail "owned-server restart failure did not retain an exact rollback source"
+
 [ "$(server_bridge_strategy v0.55.4)" = "native_export" ] ||
     fail "v0.55.4 did not select its pinned server bridge strategy"
 [ "$(server_bridge_strategy v0.57.0)" = "native_export_show_comments" ] ||
@@ -804,6 +1601,34 @@ printf '%s\n' \
 if check_fidelity v0.49.6 "$tmp/before-comment.json" "$tmp/after-comment.json" >/dev/null 2>&1; then
     fail "strict fidelity accepted changed comment text"
 fi
+printf '%s\n' \
+    '[{"id":"old-task","title":"Child","description":"","priority":2,"issue_type":"task","status":"open","parent":"old-epic","dependencies":[{"id":"old-epic","dependency_type":"parent-child"}],"labels":[],"comments":[]}]' \
+    > "$tmp/before-relationships.json"
+printf '%s\n' \
+    '[{"id":"old-task","title":"Child","description":"","priority":2,"issue_type":"task","status":"open","dependencies":[{"depends_on_id":"old-epic","type":"parent-child"}],"labels":[],"comments":[]}]' \
+    > "$tmp/after-parent-lost.json"
+if check_fidelity v0.62.0 "$tmp/before-relationships.json" "$tmp/after-parent-lost.json" >/dev/null 2>&1; then
+    fail "strict fidelity accepted post-upgrade parent loss"
+fi
+printf '%s\n' \
+    '[{"id":"old-task","title":"Child","description":"","priority":2,"issue_type":"task","status":"open","parent":"old-epic","dependencies":[{"depends_on_id":"old-epic","type":"blocks"}],"labels":[],"comments":[]}]' \
+    > "$tmp/after-dependency-type-drift.json"
+if check_fidelity v0.62.0 "$tmp/before-relationships.json" "$tmp/after-dependency-type-drift.json" >/dev/null 2>&1; then
+    fail "strict fidelity accepted dependency-type drift"
+fi
+printf '%s\n' \
+    '[{"id":"old-task","title":"Child","description":"","priority":2,"issue_type":"task","status":"open","parent":"old-epic","dependencies":[{"depends_on_id":"old-epic","type":"parent-child"}],"labels":[],"comments":[]}]' \
+    > "$tmp/after-normalized-relationships.json"
+check_fidelity v0.62.0 "$tmp/before-relationships.json" "$tmp/after-normalized-relationships.json" >/dev/null ||
+    fail "strict fidelity rejected equivalent historical dependency shapes"
+
+printf '%s\n' \
+    '[{"id":"old-task","title":"Child","description":"","priority":2,"issue_type":"task","status":"open","dependencies":[{"id":"old-epic","dependency_type":"blocks"}],"labels":[],"comments":[]}]' \
+    > "$tmp/after-nonstrict-relationship-drift.json"
+STRICT_MODE=false
+check_fidelity v0.62.0 "$tmp/before-relationships.json" "$tmp/after-nonstrict-relationship-drift.json" >/dev/null ||
+    fail "non-strict fidelity started enforcing parent or dependency types"
+STRICT_MODE=true
 
 snapshot_contract_ws="$tmp/snapshot-contract-workspace"
 snapshot_contract_bin="$tmp/fake-snapshot-contract-bd"
@@ -926,6 +1751,52 @@ printf '%s\n' '{"id":"jsonl-1"} {"id":"jsonl-2"}' > "$jsonl_contract_file"
 if migration_jsonl_matches_snapshot \
     "$jsonl_contract_file" "$jsonl_contract_snapshot" >/dev/null 2>&1; then
     fail "historical JSONL contract accepted two records on one line"
+fi
+
+v062_derived_before="$tmp/v062-derived-before.json"
+v062_derived_export="$tmp/v062-derived-export.jsonl"
+v062_derived_show="$tmp/v062-derived-show.jsonl"
+v062_changed_export="$tmp/v062-changed-export.jsonl"
+v062_changed_show="$tmp/v062-changed-show.jsonl"
+printf '%s\n' '[
+  {"id":"v62-epic","title":"Legacy epic","issue_type":"epic","epic_closeable":true,"epic_closed_children":1,"epic_total_children":2,"comments":[]}
+]' > "$v062_derived_before"
+printf '%s\n' \
+    '{"id":"v62-epic","title":"Legacy epic","issue_type":"epic","dependency_count":0,"comment_count":0}' \
+    > "$v062_derived_export"
+printf '%s\n' \
+    '{"id":"v62-epic","title":"Legacy epic","issue_type":"epic","epic_closeable":false,"epic_closed_children":0,"epic_total_children":3,"comments":[]}' \
+    > "$v062_derived_show"
+
+v057_export_matches_snapshot \
+    "$v062_derived_export" "$v062_derived_before" v0.62.0 ||
+    fail "v0.62.0 export comparison rejected differences limited to derived epic fields"
+if v057_export_matches_snapshot \
+    "$v062_derived_export" "$v062_derived_before" v0.57.0 >/dev/null 2>&1; then
+    fail "v0.57.0 export comparison normalized v0.62.0-only derived epic fields"
+fi
+v057_export_and_show_comments_agree \
+    "$v062_derived_export" "$v062_derived_show" \
+    "$v062_derived_before" v0.62.0 ||
+    fail "v0.62.0 show comparison rejected differences limited to derived epic fields"
+if v057_export_and_show_comments_agree \
+    "$v062_derived_export" "$v062_derived_show" \
+    "$v062_derived_before" v0.57.0 >/dev/null 2>&1; then
+    fail "v0.57.0 show comparison normalized v0.62.0-only derived epic fields"
+fi
+
+jq -c '.title = "Changed epic"' \
+    "$v062_derived_export" > "$v062_changed_export"
+if v057_export_matches_snapshot \
+    "$v062_changed_export" "$v062_derived_before" v0.62.0 >/dev/null 2>&1; then
+    fail "v0.62.0 export comparison normalized a non-derived title change"
+fi
+jq -c '.title = "Changed epic"' \
+    "$v062_derived_show" > "$v062_changed_show"
+if v057_export_and_show_comments_agree \
+    "$v062_derived_export" "$v062_changed_show" \
+    "$v062_derived_before" v0.62.0 >/dev/null 2>&1; then
+    fail "v0.62.0 show comparison normalized a non-derived title change"
 fi
 
 # v0.57.0's native export preserves issue/label/dependency records and a


### PR DESCRIPTION
## What

Add a checksum-pinned strict CI qualification for the official v0.62.0 Dolt-server release and its explicit server-to-embedded migration bridge. The lane creates an authentic schema-version-9 server workspace, verifies an exact five-issue relationship-rich fixture, proves the current candidate refuses a direct open before mutation, then migrates with zero fidelity violations.

This also extends the pre-store product guard to the project-identity server shape used by v0.59-v0.62. Stable historical witnesses are refused with migration guidance; raced, replaced, unreadable, or otherwise ambiguous witnesses fail closed before version tracking or store open.

The cross-era upgrading guide now routes by observed storage layout, removes the false promise that v0.62 converts automatically, and replaces the destructive server-era fallback with backup-before-extraction guidance. It explicitly distinguishes the qualified CI recipe from a supported user-facing migration command.

This is stacked on PR #4812 and tracked under upgrade-hardening epic `bd-ldt0f.3`.

## Why

v0.62 is the last historical server-mode era before embedded Dolt. Users upgrading from it need deterministic proof that ordinary current commands cannot mutate their source and that the qualified manual bridge preserves issue state and graph semantics.

The prior harness could also leak or misidentify owned Dolt server processes during startup and teardown. This change binds ownership to the exact PID, start time, executable, argv, and cwd; signals only after revalidation; bounds TERM/KILL waits; rolls back provisional startup; and fails on process, port, reservation, or workspace leaks.

## Qualification boundary

The official v0.62.0 source must create and preserve exactly:

- 5 issues: epic, child task, blocking bug, standalone issue, and closed issue
- the task's sole `parent-child` edge to the epic
- the bug's sole `blocks` edge to the task
- no unexpected dependency edges
- the exact rich fields, label, and comment used by the historical fixture
- correct `blocked`, `ready`, and `close` behavior after migration
- 0 fidelity and blocker violations

The expected result is `MANUAL(server_to_embedded)`, not an automatic in-place migration. The bridge retains and revalidates the rollback source before candidate import.

## Artifact and CI determinism

- v0.62.0 archive: `beads_0.62.0_linux_amd64.tar.gz`
- v0.62.0 archive SHA-256: `4cca7265b22e5c3ca8d62ab0b9752bec31f68b7f5fa636282a4c7e5454c35535`
- required Dolt runtime: `1.84.0`
- Dolt archive SHA-256: `afcdaa9530ae0b4f317ed6041a41d20096e156b2556eb0e03c7c57a624ccc0b3`
- strict workflow requests run only the owned pinned lanes; ad-hoc/latest-Dolt provisioning is skipped unless supplemental work is actually requested
- strict fixtures bypass feature probes and do not create feature-gate cache artifacts

## Safety and rollback

- Stable v0.59-v0.62 project-identity server witnesses are rejected before any store open or version-marker write.
- Missing markers remain accepted for legitimate current remote-server clones; stable current markers and non-Dolt/non-server providers remain accepted.
- Path replacement, in-place rewrite, read errors, special files, and unstable metadata are classified as ambiguous and refused.
- The harness records exact owned-process identity before signaling and revalidates immediately before TERM or KILL.
- Post-signal waiting observes immutable PID/start-time state and handles disappearance or zombie exit without signaling a replacement process.
- Startup, signal, EXIT, port, reservation, and workspace cleanup paths are bounded and regression-tested.
- This touches migration and destructive-process paths, requires substantive human review, and must not be self-merged.

## Verification

- Fresh rebuilt-candidate v0.62.0 qualification: `MANUAL(server_to_embedded)`, 5/5 issues, exact relationships, 0 fidelity violations, blocker/ready/close checks correct
- `./scripts/migration-test/strict-mode-test.sh`: PASS
- Guard/current-provider/legacy-boundary focused suite: PASS
- Same-size path-replacement and in-place-rewrite guard regressions with `-count=20`: PASS
- `make build`: PASS
- `bash -n` across migration harness scripts: PASS
- `actionlint .github/workflows/migration-test.yml`: PASS
- ShellCheck error-level gate: PASS
- `make check-docs`: PASS
- `git diff --check`: PASS
- Exact stacked diff SHA-256: `bebba9b4e4e46f77df76dd59e477de0721938eb8fea90a0fe2998fc43f346622`
- Multi-agent correctness, safety, compatibility, relationship-fidelity, process-ownership, workflow-determinism, and maintainability council: APPROVE

The full repository suite was attempted with `TEST_TIMEOUT=5m make test` on a shared host at load average ~110. It reached the five-minute `cmd/bd` package timeout in unrelated `TestPrime_HookJSON_LocalPrimeOverride`; that exact test passed alone in 16.8 seconds (28.4 seconds including container lifecycle), and every other reported package passed. PR CI on a normally provisioned runner is the authoritative full-suite gate.

_codex-unknown-model-unknown-reasoning on behalf of Test User_