### PR TITLE
feat(setup): redirect beads block to AGENTS.md when CLAUDE.md is a stub

### DIFF
--- a/cmd/bd/setup/claude.go
+++ b/cmd/bd/setup/claude.go
@@ -138,10 +138,13 @@ func stripStaleClaudeBlock(env claudeEnv) error {
 // the file is a thin stub that imports shared agent instructions from the
 // agents file rather than carrying its own content.
 func isAgentsImportStub(content, agentsFile string) bool {
-	directive := "@" + agentsFile
+	directives := []string{"@" + agentsFile, "@./" + agentsFile}
 	for _, line := range strings.Split(content, "\n") {
-		if strings.TrimSpace(line) == directive {
-			return true
+		trimmed := strings.TrimSpace(line)
+		for _, directive := range directives {
+			if trimmed == directive {
+				return true
+			}
 		}
 	}
 	return false
@@ -277,7 +280,11 @@ func installClaude(env claudeEnv, global bool, stealth bool) error {
 		_, _ = fmt.Fprintf(env.stderr, "Warning: failed to update %s: %v\n", claudeInstructionsFile, err)
 	}
 
-	if redirected {
+	// Only strip the stale CLAUDE.md block once the redirect has actually
+	// written the replacement to AGENTS.md. If installAgents skipped injection
+	// (e.g. AGENTS.md is a symlink), stripping here would delete-before-write
+	// and leave the project with no beads section anywhere.
+	if redirected && !agentsSkipped {
 		if err := stripStaleClaudeBlock(env); err != nil {
 			// Non-fatal: the redirect itself already succeeded above
 			_, _ = fmt.Fprintf(env.stderr, "Warning: failed to clean stale beads block from %s: %v\n", claudeInstructionsFile, err)
@@ -458,14 +465,19 @@ func removeClaude(env claudeEnv, global bool) error {
 	}
 
 	agentsEnv, redirected := claudeAgentsEnvRedirect(env)
-	if err := removeAgents(agentsEnv, claudeAgentsIntegration); err != nil {
-		// Non-fatal
-		_, _ = fmt.Fprintf(env.stderr, "Warning: failed to update %s: %v\n", claudeInstructionsFile, err)
-	}
-
 	if redirected {
+		// When redirected, AGENTS.md carries the project-authoritative shared
+		// beads section (created by `bd init` or another agent's setup), not a
+		// Claude-specific one. Removing Claude integration must not delete it;
+		// only clean up any stale block left directly in CLAUDE.md.
+		_, _ = fmt.Fprintf(env.stdout, "  Leaving shared beads section in %s untouched (project-authoritative, not Claude-specific)\n", config.SafeAgentsFile())
 		if err := stripStaleClaudeBlock(env); err != nil {
 			_, _ = fmt.Fprintf(env.stderr, "Warning: failed to clean stale beads block from %s: %v\n", claudeInstructionsFile, err)
+		}
+	} else {
+		if err := removeAgents(agentsEnv, claudeAgentsIntegration); err != nil {
+			// Non-fatal
+			_, _ = fmt.Fprintf(env.stderr, "Warning: failed to update %s: %v\n", claudeInstructionsFile, err)
 		}
 	}
 

--- a/cmd/bd/setup/claude.go
+++ b/cmd/bd/setup/claude.go
@@ -71,6 +71,15 @@ func globalSettingsPath(home string) string {
 }
 
 func claudeAgentsEnv(env claudeEnv) agentsEnv {
+	ae, _ := claudeAgentsEnvRedirect(env)
+	return ae
+}
+
+// claudeAgentsEnvRedirect is claudeAgentsEnv plus a bool reporting whether the
+// AGENTS.md redirect activated, so callers that need to clean up a stale
+// CLAUDE.md block (installClaude, removeClaude) can tell the redirected case
+// apart from the plain CLAUDE.md-is-authoritative case.
+func claudeAgentsEnvRedirect(env claudeEnv) (agentsEnv, bool) {
 	claudePath := filepath.Join(env.projectDir, claudeInstructionsFile)
 
 	// If CLAUDE.md is a thin stub that imports AGENTS.md via the @-include
@@ -87,7 +96,7 @@ func claudeAgentsEnv(env claudeEnv) agentsEnv {
 					agentsPath: agentsPath,
 					stdout:     env.stdout,
 					stderr:     env.stderr,
-				}
+				}, true
 			}
 		}
 	}
@@ -96,7 +105,32 @@ func claudeAgentsEnv(env claudeEnv) agentsEnv {
 		agentsPath: claudePath,
 		stdout:     env.stdout,
 		stderr:     env.stderr,
+	}, false
+}
+
+// stripStaleClaudeBlock removes a beads-managed block left behind in CLAUDE.md
+// by an older bd version, once the AGENTS.md redirect is active. Older bd
+// releases wrote the managed block directly into CLAUDE.md; a project that has
+// since adopted the "@AGENTS.md" import-stub pattern would otherwise carry a
+// stale duplicate of that block alongside the one now maintained in AGENTS.md.
+func stripStaleClaudeBlock(env claudeEnv) error {
+	claudePath := filepath.Join(env.projectDir, claudeInstructionsFile)
+	data, err := env.readFile(claudePath)
+	if err != nil {
+		return nil
 	}
+
+	content := string(data)
+	if !containsBeadsMarker(content) {
+		return nil
+	}
+
+	newContent := removeBeadsSection(content)
+	if err := env.writeFile(claudePath, []byte(newContent)); err != nil {
+		return err
+	}
+	_, _ = fmt.Fprintf(env.stdout, "✓ Removed stale beads block from %s (now redirected to %s)\n", claudeInstructionsFile, config.SafeAgentsFile())
+	return nil
 }
 
 // isAgentsImportStub reports whether content contains an @-include directive
@@ -235,12 +269,19 @@ func installClaude(env claudeEnv, global bool, stealth bool) error {
 
 	// Install minimal beads section in CLAUDE.md.
 	// Hooks handle the heavy lifting via bd prime; CLAUDE.md just needs a pointer.
-	agentsEnv := claudeAgentsEnv(env)
+	agentsEnv, redirected := claudeAgentsEnvRedirect(env)
 	agentsSkipped := false
 	agentsEnv.skipped = &agentsSkipped
 	if err := installAgents(agentsEnv, claudeAgentsIntegration); err != nil {
 		// Non-fatal: hooks are already installed
 		_, _ = fmt.Fprintf(env.stderr, "Warning: failed to update %s: %v\n", claudeInstructionsFile, err)
+	}
+
+	if redirected {
+		if err := stripStaleClaudeBlock(env); err != nil {
+			// Non-fatal: the redirect itself already succeeded above
+			_, _ = fmt.Fprintf(env.stderr, "Warning: failed to clean stale beads block from %s: %v\n", claudeInstructionsFile, err)
+		}
 	}
 
 	if agentsSkipped {
@@ -416,9 +457,16 @@ func removeClaude(env claudeEnv, global bool) error {
 		}
 	}
 
-	if err := removeAgents(claudeAgentsEnv(env), claudeAgentsIntegration); err != nil {
+	agentsEnv, redirected := claudeAgentsEnvRedirect(env)
+	if err := removeAgents(agentsEnv, claudeAgentsIntegration); err != nil {
 		// Non-fatal
 		_, _ = fmt.Fprintf(env.stderr, "Warning: failed to update %s: %v\n", claudeInstructionsFile, err)
+	}
+
+	if redirected {
+		if err := stripStaleClaudeBlock(env); err != nil {
+			_, _ = fmt.Fprintf(env.stderr, "Warning: failed to clean stale beads block from %s: %v\n", claudeInstructionsFile, err)
+		}
 	}
 
 	_, _ = fmt.Fprintln(env.stdout, "✓ Claude hooks removed")

--- a/cmd/bd/setup/claude.go
+++ b/cmd/bd/setup/claude.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/steveyegge/beads/internal/config"
 	"github.com/steveyegge/beads/internal/templates/agents"
 )
 
@@ -70,11 +71,46 @@ func globalSettingsPath(home string) string {
 }
 
 func claudeAgentsEnv(env claudeEnv) agentsEnv {
+	claudePath := filepath.Join(env.projectDir, claudeInstructionsFile)
+
+	// If CLAUDE.md is a thin stub that imports AGENTS.md via the @-include
+	// convention (Claude Code expands @-imports), redirect the managed beads
+	// section to AGENTS.md instead of duplicating it in the stub. This matches
+	// the shared-authoritative-file pattern used by repos that keep AGENTS.md
+	// as the single source of agent instructions.
+	agentsFile := config.SafeAgentsFile()
+	agentsPath := filepath.Join(env.projectDir, agentsFile)
+	if data, err := env.readFile(claudePath); err == nil {
+		if isAgentsImportStub(string(data), agentsFile) {
+			if _, err := env.readFile(agentsPath); err == nil {
+				return agentsEnv{
+					agentsPath: agentsPath,
+					stdout:     env.stdout,
+					stderr:     env.stderr,
+				}
+			}
+		}
+	}
+
 	return agentsEnv{
-		agentsPath: filepath.Join(env.projectDir, claudeInstructionsFile),
+		agentsPath: claudePath,
 		stdout:     env.stdout,
 		stderr:     env.stderr,
 	}
+}
+
+// isAgentsImportStub reports whether content contains an @-include directive
+// for the given agents file (e.g. "@AGENTS.md" on its own line), indicating
+// the file is a thin stub that imports shared agent instructions from the
+// agents file rather than carrying its own content.
+func isAgentsImportStub(content, agentsFile string) bool {
+	directive := "@" + agentsFile
+	for _, line := range strings.Split(content, "\n") {
+		if strings.TrimSpace(line) == directive {
+			return true
+		}
+	}
+	return false
 }
 
 func InstallClaude(global bool, stealth bool) error {

--- a/cmd/bd/setup/claude_test.go
+++ b/cmd/bd/setup/claude_test.go
@@ -1195,6 +1195,12 @@ func TestIsAgentsImportStub(t *testing.T) {
 			want:       true,
 		},
 		{
+			name:       "relative @./AGENTS.md directive",
+			content:    "# Claude Code\n\n@./AGENTS.md\n",
+			agentsFile: "AGENTS.md",
+			want:       true,
+		},
+		{
 			name:       "empty content",
 			content:    "",
 			agentsFile: "AGENTS.md",
@@ -1313,13 +1319,15 @@ func TestRemoveClaudeRedirectsToAgentsMD(t *testing.T) {
 		t.Fatalf("removeClaude: %v", err)
 	}
 
-	// AGENTS.md should no longer have a beads section
+	// AGENTS.md's beads section is project-authoritative (shared with other
+	// agents), not Claude-specific — removing Claude integration must leave
+	// it intact.
 	agentsData, err := os.ReadFile(agentsPath)
 	if err != nil {
 		t.Fatalf("read AGENTS.md: %v", err)
 	}
-	if strings.Contains(string(agentsData), "BEGIN BEADS INTEGRATION") {
-		t.Fatalf("AGENTS.md should not contain beads section after remove:\n%s", agentsData)
+	if !strings.Contains(string(agentsData), "BEGIN BEADS INTEGRATION") {
+		t.Fatalf("AGENTS.md should still contain the shared beads section after removing Claude:\n%s", agentsData)
 	}
 
 	// CLAUDE.md should be untouched (still a stub)
@@ -1329,6 +1337,41 @@ func TestRemoveClaudeRedirectsToAgentsMD(t *testing.T) {
 	}
 	if !strings.Contains(string(claudeData), "@AGENTS.md") {
 		t.Fatalf("CLAUDE.md should still contain @AGENTS.md import:\n%s", claudeData)
+	}
+
+	if !strings.Contains(stdout.String(), "AGENTS.md") {
+		t.Fatalf("expected output to reference AGENTS.md, got: %s", stdout.String())
+	}
+}
+
+// TestRemoveClaudeRedirectPreservesFullProfileSharedBlock covers the case
+// where AGENTS.md carries a full-profile shared beads block (e.g. created by
+// `bd init` or `bd setup codex`). Removing Claude integration must not touch
+// it — other agents still depend on it.
+func TestRemoveClaudeRedirectPreservesFullProfileSharedBlock(t *testing.T) {
+	env, stdout, _ := newClaudeTestEnv(t)
+
+	claudePath := filepath.Join(env.projectDir, claudeInstructionsFile)
+	if err := os.WriteFile(claudePath, []byte("# Claude Code\n\n@AGENTS.md\n"), 0o644); err != nil {
+		t.Fatalf("write CLAUDE.md: %v", err)
+	}
+
+	agentsPath := filepath.Join(env.projectDir, "AGENTS.md")
+	fullBlock := "# Agent Instructions\n\n" + agents.RenderSection(agents.ProfileFull)
+	if err := os.WriteFile(agentsPath, []byte(fullBlock), 0o644); err != nil {
+		t.Fatalf("write AGENTS.md: %v", err)
+	}
+
+	if err := removeClaude(env, false); err != nil {
+		t.Fatalf("removeClaude: %v", err)
+	}
+
+	agentsData, err := os.ReadFile(agentsPath)
+	if err != nil {
+		t.Fatalf("read AGENTS.md: %v", err)
+	}
+	if string(agentsData) != fullBlock {
+		t.Fatalf("AGENTS.md full-profile shared block should be byte-for-byte unchanged:\ngot:\n%s\nwant:\n%s", agentsData, fullBlock)
 	}
 
 	if !strings.Contains(stdout.String(), "AGENTS.md") {
@@ -1416,6 +1459,62 @@ func TestInstallClaudeRedirectCleansStaleClaudeBlock(t *testing.T) {
 	}
 }
 
+// TestInstallClaudeRedirectSkipsStripWhenAgentsSymlink is a regression test
+// for the delete-before-write gap: when the redirect target (AGENTS.md) is a
+// symlink, installAgents skips injection (agents.go markSkipped) without
+// writing the beads block anywhere. In that case installClaude must NOT
+// strip the stale block already present in CLAUDE.md, or the project is left
+// with no beads section at all.
+func TestInstallClaudeRedirectSkipsStripWhenAgentsSymlink(t *testing.T) {
+	stubDetectRenderOpts(t)
+	env, _, stderr := newClaudeTestEnv(t)
+
+	// CLAUDE.md is a stub that imports AGENTS.md but still carries a stale
+	// beads block from an older bd install.
+	claudePath := filepath.Join(env.projectDir, claudeInstructionsFile)
+	if err := os.WriteFile(claudePath, []byte(staleClaudeStubWithBlock()), 0o644); err != nil {
+		t.Fatalf("write CLAUDE.md: %v", err)
+	}
+
+	// AGENTS.md is a symlink to a separate target file.
+	target := filepath.Join(env.projectDir, "AGENTS_target.md")
+	if err := os.WriteFile(target, []byte("# Shared instructions\n"), 0o644); err != nil {
+		t.Fatalf("write AGENTS.md target: %v", err)
+	}
+	agentsPath := filepath.Join(env.projectDir, "AGENTS.md")
+	if err := os.Symlink(target, agentsPath); err != nil {
+		t.Fatalf("symlink AGENTS.md: %v", err)
+	}
+
+	if err := installClaude(env, false, false); err != nil {
+		t.Fatalf("installClaude: %v", err)
+	}
+
+	// installAgents should have warned and skipped injection.
+	if !strings.Contains(stderr.String(), "AGENTS.md is a symlink") {
+		t.Fatalf("expected symlink warning on stderr, got:\n%s", stderr.String())
+	}
+
+	// The stale beads block in CLAUDE.md must be preserved: the redirect
+	// never wrote a replacement, so stripping it would delete-before-write.
+	claudeData, err := os.ReadFile(claudePath)
+	if err != nil {
+		t.Fatalf("read CLAUDE.md: %v", err)
+	}
+	if !strings.Contains(string(claudeData), "BEGIN BEADS INTEGRATION") {
+		t.Fatalf("CLAUDE.md should keep its beads block when the AGENTS.md redirect is skipped:\n%s", claudeData)
+	}
+
+	// The symlink target must remain untouched.
+	targetData, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("read AGENTS.md target: %v", err)
+	}
+	if strings.Contains(string(targetData), "BEGIN BEADS INTEGRATION") {
+		t.Fatalf("AGENTS.md symlink target should remain untouched:\n%s", targetData)
+	}
+}
+
 func TestRemoveClaudeRedirectCleansStaleClaudeBlock(t *testing.T) {
 	env, _, _ := newClaudeTestEnv(t)
 
@@ -1441,11 +1540,14 @@ func TestRemoveClaudeRedirectCleansStaleClaudeBlock(t *testing.T) {
 		t.Fatalf("CLAUDE.md should not contain a beads block after remove:\n%s", claudeData)
 	}
 
+	// AGENTS.md's own beads section is project-authoritative and shared with
+	// other agents — removing Claude integration must not delete it, only the
+	// stale duplicate left in CLAUDE.md.
 	agentsData, err := os.ReadFile(agentsPath)
 	if err != nil {
 		t.Fatalf("read AGENTS.md: %v", err)
 	}
-	if strings.Contains(string(agentsData), "BEGIN BEADS INTEGRATION") {
-		t.Fatalf("AGENTS.md should not contain a beads block after remove:\n%s", agentsData)
+	if !strings.Contains(string(agentsData), "BEGIN BEADS INTEGRATION") {
+		t.Fatalf("AGENTS.md should still contain its beads block after remove:\n%s", agentsData)
 	}
 }

--- a/cmd/bd/setup/claude_test.go
+++ b/cmd/bd/setup/claude_test.go
@@ -1156,3 +1156,206 @@ func TestCheckClaudePluginManaged(t *testing.T) {
 		t.Errorf("expected plugin-managed message, got: %s", out)
 	}
 }
+
+func TestIsAgentsImportStub(t *testing.T) {
+	tests := []struct {
+		name       string
+		content    string
+		agentsFile string
+		want       bool
+	}{
+		{
+			name:       "standalone @AGENTS.md directive",
+			content:    "# Claude Code\n\n@AGENTS.md\n\nSome text.\n",
+			agentsFile: "AGENTS.md",
+			want:       true,
+		},
+		{
+			name:       "directive with surrounding whitespace",
+			content:    "# Claude Code\n\n  @AGENTS.md  \n",
+			agentsFile: "AGENTS.md",
+			want:       true,
+		},
+		{
+			name:       "directive inline in prose",
+			content:    "See @AGENTS.md for details.\n",
+			agentsFile: "AGENTS.md",
+			want:       false,
+		},
+		{
+			name:       "no directive",
+			content:    "# Claude Code\n\nFull instructions here.\n",
+			agentsFile: "AGENTS.md",
+			want:       false,
+		},
+		{
+			name:       "custom agents file name",
+			content:    "# Claude Code\n\n@INSTRUCTIONS.md\n",
+			agentsFile: "INSTRUCTIONS.md",
+			want:       true,
+		},
+		{
+			name:       "empty content",
+			content:    "",
+			agentsFile: "AGENTS.md",
+			want:       false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isAgentsImportStub(tt.content, tt.agentsFile); got != tt.want {
+				t.Errorf("isAgentsImportStub() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestInstallClaudeRedirectsToAgentsMD(t *testing.T) {
+	stubDetectRenderOpts(t)
+	env, _, _ := newClaudeTestEnv(t)
+
+	// Create CLAUDE.md as a thin stub that imports AGENTS.md
+	claudePath := filepath.Join(env.projectDir, claudeInstructionsFile)
+	stubContent := "# Claude Code\n\n@AGENTS.md\n\nShared instructions live in AGENTS.md.\n"
+	if err := os.WriteFile(claudePath, []byte(stubContent), 0o644); err != nil {
+		t.Fatalf("write CLAUDE.md: %v", err)
+	}
+
+	// Create AGENTS.md with existing content (no beads block yet)
+	agentsPath := filepath.Join(env.projectDir, "AGENTS.md")
+	if err := os.WriteFile(agentsPath, []byte("# Agent Instructions\n\nSome content.\n"), 0o644); err != nil {
+		t.Fatalf("write AGENTS.md: %v", err)
+	}
+
+	if err := installClaude(env, false, false); err != nil {
+		t.Fatalf("installClaude: %v", err)
+	}
+
+	// CLAUDE.md should NOT have a beads section
+	claudeData, err := os.ReadFile(claudePath)
+	if err != nil {
+		t.Fatalf("read CLAUDE.md: %v", err)
+	}
+	if strings.Contains(string(claudeData), "BEGIN BEADS INTEGRATION") {
+		t.Fatalf("CLAUDE.md should not contain beads section when it imports AGENTS.md:\n%s", claudeData)
+	}
+
+	// AGENTS.md SHOULD have a beads section
+	agentsData, err := os.ReadFile(agentsPath)
+	if err != nil {
+		t.Fatalf("read AGENTS.md: %v", err)
+	}
+	if !strings.Contains(string(agentsData), "BEGIN BEADS INTEGRATION") {
+		t.Fatalf("AGENTS.md should contain beads section:\n%s", agentsData)
+	}
+	if !strings.Contains(string(agentsData), "profile:minimal") {
+		t.Fatalf("AGENTS.md should have minimal profile:\n%s", agentsData)
+	}
+}
+
+func TestCheckClaudeRedirectsToAgentsMD(t *testing.T) {
+	stubDetectRenderOpts(t)
+	env, stdout, _ := newClaudeTestEnv(t)
+
+	// Create CLAUDE.md as a thin stub
+	claudePath := filepath.Join(env.projectDir, claudeInstructionsFile)
+	if err := os.WriteFile(claudePath, []byte("# Claude Code\n\n@AGENTS.md\n"), 0o644); err != nil {
+		t.Fatalf("write CLAUDE.md: %v", err)
+	}
+
+	// Create AGENTS.md with a beads section
+	agentsPath := filepath.Join(env.projectDir, "AGENTS.md")
+	if err := os.WriteFile(agentsPath, []byte("# Agent Instructions\n\n"+agents.RenderSection(agents.ProfileMinimal)), 0o644); err != nil {
+		t.Fatalf("write AGENTS.md: %v", err)
+	}
+
+	// Install hooks so check passes the hooks stage
+	writeSettings(t, projectSettingsPath(env.projectDir), map[string]interface{}{
+		"hooks": map[string]interface{}{
+			"SessionStart": []interface{}{
+				map[string]interface{}{
+					"matcher": "",
+					"hooks": []interface{}{
+						map[string]interface{}{"type": "command", "command": "bd prime --hook-json"},
+					},
+				},
+			},
+		},
+	})
+
+	if err := checkClaude(env); err != nil {
+		t.Fatalf("checkClaude: %v", err)
+	}
+
+	// Should report AGENTS.md as the integration file, not CLAUDE.md
+	out := stdout.String()
+	if !strings.Contains(out, "AGENTS.md") {
+		t.Fatalf("expected output to reference AGENTS.md, got: %s", out)
+	}
+}
+
+func TestRemoveClaudeRedirectsToAgentsMD(t *testing.T) {
+	env, stdout, _ := newClaudeTestEnv(t)
+
+	// Create CLAUDE.md as a thin stub
+	claudePath := filepath.Join(env.projectDir, claudeInstructionsFile)
+	if err := os.WriteFile(claudePath, []byte("# Claude Code\n\n@AGENTS.md\n"), 0o644); err != nil {
+		t.Fatalf("write CLAUDE.md: %v", err)
+	}
+
+	// Create AGENTS.md with a beads section
+	agentsPath := filepath.Join(env.projectDir, "AGENTS.md")
+	if err := os.WriteFile(agentsPath, []byte("# Agent Instructions\n\n"+agents.RenderSection(agents.ProfileMinimal)), 0o644); err != nil {
+		t.Fatalf("write AGENTS.md: %v", err)
+	}
+
+	if err := removeClaude(env, false); err != nil {
+		t.Fatalf("removeClaude: %v", err)
+	}
+
+	// AGENTS.md should no longer have a beads section
+	agentsData, err := os.ReadFile(agentsPath)
+	if err != nil {
+		t.Fatalf("read AGENTS.md: %v", err)
+	}
+	if strings.Contains(string(agentsData), "BEGIN BEADS INTEGRATION") {
+		t.Fatalf("AGENTS.md should not contain beads section after remove:\n%s", agentsData)
+	}
+
+	// CLAUDE.md should be untouched (still a stub)
+	claudeData, err := os.ReadFile(claudePath)
+	if err != nil {
+		t.Fatalf("read CLAUDE.md: %v", err)
+	}
+	if !strings.Contains(string(claudeData), "@AGENTS.md") {
+		t.Fatalf("CLAUDE.md should still contain @AGENTS.md import:\n%s", claudeData)
+	}
+
+	if !strings.Contains(stdout.String(), "AGENTS.md") {
+		t.Fatalf("expected output to reference AGENTS.md, got: %s", stdout.String())
+	}
+}
+
+func TestInstallClaudeNoRedirectWhenAGENTSMDMissing(t *testing.T) {
+	stubDetectRenderOpts(t)
+	env, _, _ := newClaudeTestEnv(t)
+
+	// Create CLAUDE.md as a thin stub, but do NOT create AGENTS.md
+	claudePath := filepath.Join(env.projectDir, claudeInstructionsFile)
+	if err := os.WriteFile(claudePath, []byte("# Claude Code\n\n@AGENTS.md\n"), 0o644); err != nil {
+		t.Fatalf("write CLAUDE.md: %v", err)
+	}
+
+	if err := installClaude(env, false, false); err != nil {
+		t.Fatalf("installClaude: %v", err)
+	}
+
+	// CLAUDE.md should get the beads section (fallback: no AGENTS.md to redirect to)
+	claudeData, err := os.ReadFile(claudePath)
+	if err != nil {
+		t.Fatalf("read CLAUDE.md: %v", err)
+	}
+	if !strings.Contains(string(claudeData), "BEGIN BEADS INTEGRATION") {
+		t.Fatalf("CLAUDE.md should contain beads section when AGENTS.md is missing:\n%s", claudeData)
+	}
+}

--- a/cmd/bd/setup/claude_test.go
+++ b/cmd/bd/setup/claude_test.go
@@ -1359,3 +1359,93 @@ func TestInstallClaudeNoRedirectWhenAGENTSMDMissing(t *testing.T) {
 		t.Fatalf("CLAUDE.md should contain beads section when AGENTS.md is missing:\n%s", claudeData)
 	}
 }
+
+// staleClaudeStubWithBlock builds a CLAUDE.md stub that carries BOTH the
+// @AGENTS.md import line (redirect trigger) and a beads block written by an
+// older bd, simulating a project that adopted the AGENTS.md-import pattern
+// after a beads block was already installed directly into CLAUDE.md.
+func staleClaudeStubWithBlock() string {
+	return "# Claude Code\n\n@AGENTS.md\n\n" +
+		agents.RenderSection(agents.ProfileMinimal) +
+		"\nShared instructions live in AGENTS.md.\n"
+}
+
+func TestInstallClaudeRedirectCleansStaleClaudeBlock(t *testing.T) {
+	stubDetectRenderOpts(t)
+	env, _, _ := newClaudeTestEnv(t)
+
+	// CLAUDE.md is a stub that imports AGENTS.md but still carries a stale
+	// beads block from an older bd install.
+	claudePath := filepath.Join(env.projectDir, claudeInstructionsFile)
+	if err := os.WriteFile(claudePath, []byte(staleClaudeStubWithBlock()), 0o644); err != nil {
+		t.Fatalf("write CLAUDE.md: %v", err)
+	}
+
+	// AGENTS.md already exists (without a beads block yet).
+	agentsPath := filepath.Join(env.projectDir, "AGENTS.md")
+	if err := os.WriteFile(agentsPath, []byte("# Agent Instructions\n\nSome content.\n"), 0o644); err != nil {
+		t.Fatalf("write AGENTS.md: %v", err)
+	}
+
+	if err := installClaude(env, false, false); err != nil {
+		t.Fatalf("installClaude: %v", err)
+	}
+
+	claudeData, err := os.ReadFile(claudePath)
+	if err != nil {
+		t.Fatalf("read CLAUDE.md: %v", err)
+	}
+	claudeContent := string(claudeData)
+	if strings.Contains(claudeContent, "BEGIN BEADS INTEGRATION") {
+		t.Fatalf("CLAUDE.md should have the stale beads block stripped:\n%s", claudeContent)
+	}
+	if !strings.Contains(claudeContent, "@AGENTS.md") {
+		t.Fatalf("CLAUDE.md should still contain the @AGENTS.md import line:\n%s", claudeContent)
+	}
+	if !strings.Contains(claudeContent, "Shared instructions live in AGENTS.md.") {
+		t.Fatalf("CLAUDE.md should keep its other stub content:\n%s", claudeContent)
+	}
+
+	agentsData, err := os.ReadFile(agentsPath)
+	if err != nil {
+		t.Fatalf("read AGENTS.md: %v", err)
+	}
+	agentsContent := string(agentsData)
+	if got := strings.Count(agentsContent, "BEGIN BEADS INTEGRATION"); got != 1 {
+		t.Fatalf("AGENTS.md should contain exactly one beads block, got %d:\n%s", got, agentsContent)
+	}
+}
+
+func TestRemoveClaudeRedirectCleansStaleClaudeBlock(t *testing.T) {
+	env, _, _ := newClaudeTestEnv(t)
+
+	claudePath := filepath.Join(env.projectDir, claudeInstructionsFile)
+	if err := os.WriteFile(claudePath, []byte(staleClaudeStubWithBlock()), 0o644); err != nil {
+		t.Fatalf("write CLAUDE.md: %v", err)
+	}
+
+	agentsPath := filepath.Join(env.projectDir, "AGENTS.md")
+	if err := os.WriteFile(agentsPath, []byte("# Agent Instructions\n\n"+agents.RenderSection(agents.ProfileMinimal)), 0o644); err != nil {
+		t.Fatalf("write AGENTS.md: %v", err)
+	}
+
+	if err := removeClaude(env, false); err != nil {
+		t.Fatalf("removeClaude: %v", err)
+	}
+
+	claudeData, err := os.ReadFile(claudePath)
+	if err != nil {
+		t.Fatalf("read CLAUDE.md: %v", err)
+	}
+	if strings.Contains(string(claudeData), "BEGIN BEADS INTEGRATION") {
+		t.Fatalf("CLAUDE.md should not contain a beads block after remove:\n%s", claudeData)
+	}
+
+	agentsData, err := os.ReadFile(agentsPath)
+	if err != nil {
+		t.Fatalf("read AGENTS.md: %v", err)
+	}
+	if strings.Contains(string(agentsData), "BEGIN BEADS INTEGRATION") {
+		t.Fatalf("AGENTS.md should not contain a beads block after remove:\n%s", agentsData)
+	}
+}


### PR DESCRIPTION
## What

When `CLAUDE.md` is a thin stub that imports `AGENTS.md` via the `@-include` convention (e.g. `@AGENTS.md` on its own line), `bd setup claude` now writes the managed `BEADS INTEGRATION` block to `AGENTS.md` instead of duplicating it in the stub.

## Why

Some repos keep `AGENTS.md` as the single authoritative agent-instruction file and reduce `CLAUDE.md` to a short stub that imports it (`@AGENTS.md`). Claude Code expands `@`-imports, so the `AGENTS.md` content is already in context. Previously, `bd setup claude` wrote its managed block into `CLAUDE.md`, which fought this pattern: re-running setup re-inserted the block into the stub, duplicating content already present in `AGENTS.md` via `bd setup codex` or other recipes.

## How

`claudeAgentsEnv()` now checks whether `CLAUDE.md` contains a standalone `@AGENTS.md` directive (the configured agents file name) and whether that agents file exists. If both are true, it redirects the beads section target to the agents file. The redirect applies to install, check, and remove operations. If the agents file does not exist, the fallback behavior (writing to `CLAUDE.md`) is preserved.

The detection is conservative: only a standalone `@AGENTS.md` line (after trimming whitespace) triggers the redirect. Inline references in prose (e.g. "See @AGENTS.md for details") do not.

Closes beads issue mybd-xq68.
