### PR TITLE
Add a fail-closed public v0.62 migration inspector

### DIFF
--- a/.github/workflows/migration-test.yml
+++ b/.github/workflows/migration-test.yml
@@ -244,6 +244,12 @@ jobs:
         if: steps.selection.outputs.selected == 'true'
         run: make build
 
+      - name: Verify public v0.62 migration bridge
+        if: steps.selection.outputs.selected == 'true' && matrix.version == 'v0.62.0'
+        env:
+          PUBLIC_V062_REAL_TARGET_BD: ./bd
+        run: ./scripts/migration-test/public-v062-bridge-test.sh
+
       - name: Verify strict harness guards
         if: steps.selection.outputs.selected == 'true'
         run: ./scripts/migration-test/strict-mode-test.sh

--- a/cmd/bd/main.go
+++ b/cmd/bd/main.go
@@ -585,10 +585,18 @@ func getOwner() string {
 	return ""
 }
 
+func isMigrationV062InspectRawEntrypoint(args []string) bool {
+	return len(args) > 1 && args[1] == "__migration-v062-inspect"
+}
+
 func init() {
-	// Initialize viper configuration
-	if err := config.Initialize(); err != nil {
-		fmt.Fprintf(os.Stderr, "Warning: failed to initialize config: %v\n", err)
+	// The private v0.62 inspector's supported grammar requires its command token
+	// to be argv[1]. Skip ambient config (and its git-backed discovery) before
+	// Cobra starts; the leaf and root lifecycle bypasses remain defense in depth.
+	if !isMigrationV062InspectRawEntrypoint(os.Args) {
+		if err := config.Initialize(); err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: failed to initialize config: %v\n", err)
+		}
 	}
 
 	// Register persistent flags
@@ -694,6 +702,12 @@ var rootCmd = &cobra.Command{
 		_ = cmd.Help() // Help() always returns nil for cobra commands
 	},
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) (returnErr error) {
+		// Private migration admission must not discover ambient workspaces, load
+		// project configuration, initialize metrics, or select a store before its
+		// descriptor-relative inspector runs.
+		if cmd == migrationV062InspectCmd {
+			return nil
+		}
 		defer func() {
 			if cmd == initCmd {
 				clearInitBackendPreflightAfterError(cmd, &returnErr)
@@ -855,8 +869,9 @@ var rootCmd = &cobra.Command{
 		// to avoid spawning git subprocesses for simple commands
 		// like "bd version" that don't need database access.
 		noDbCommands := []string{
-			"__complete",       // Cobra's internal completion command (shell completions work without db)
-			"__completeNoDesc", // Cobra's completion without descriptions (used by fish)
+			"__migration-v062-inspect", // private, descriptor-relative source admission
+			"__complete",               // Cobra's internal completion command (shell completions work without db)
+			"__completeNoDesc",         // Cobra's completion without descriptions (used by fish)
 			"bash",
 			"bootstrap",
 			"completion",
@@ -1392,6 +1407,9 @@ var rootCmd = &cobra.Command{
 		return nil
 	},
 	PersistentPostRunE: func(cmd *cobra.Command, args []string) error {
+		if cmd == migrationV062InspectCmd {
+			return nil
+		}
 		defer restoreChangeDirSelection()
 
 		if proxiedServerMode {

--- a/cmd/bd/migration_v062_inspect.go
+++ b/cmd/bd/migration_v062_inspect.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/steveyegge/beads/internal/v062migration"
+)
+
+// newMigrationV062InspectCmd builds the private, read-only protocol endpoint
+// used by scripts/migrate-v062-server-to-current.sh. It deliberately owns
+// no product-facing command surface. Its supported argv grammar begins with
+// the hidden command token; root flags placed before that token are outside the
+// protocol because the public bridge never emits them.
+func newMigrationV062InspectCmd() *cobra.Command {
+	var workspace string
+	emitUsageError := func() error {
+		if err := outputJSONRaw(v062migration.UsageErrorResult()); err != nil {
+			return err
+		}
+		return &exitError{Code: 2}
+	}
+	cmd := &cobra.Command{
+		Use:           "__migration-v062-inspect",
+		Hidden:        true,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		Args: func(_ *cobra.Command, args []string) error {
+			if len(args) != 0 {
+				return emitUsageError()
+			}
+			return nil
+		},
+
+		// The root lifecycle discovers ambient workspaces, loads configuration,
+		// and initializes metrics before its normal no-store classification.
+		// Suppress it so the descriptor-relative inspector is the only code that
+		// observes the explicitly named source. main.go carries matching early
+		// bypasses as defense in depth if Cobra traversal semantics ever change.
+		PersistentPreRunE: func(*cobra.Command, []string) error {
+			if workspace == "" {
+				return emitUsageError()
+			}
+			return nil
+		},
+		PersistentPostRunE: func(*cobra.Command, []string) error { return nil },
+
+		RunE: func(*cobra.Command, []string) error {
+			result, err := v062migration.Inspect(workspace, Version)
+			if err == nil {
+				return outputJSONRaw(result)
+			}
+
+			refusal, ok := v062migration.AsRefusal(err)
+			if !ok {
+				refusal = &v062migration.Refusal{
+					Code:      v062migration.CodeSourceUnverifiable,
+					Retryable: true,
+					Effect:    v062migration.EffectNone,
+				}
+			}
+			if err := outputJSONRaw(v062migration.RefusedResult(refusal.Code, refusal.Retryable)); err != nil {
+				return err
+			}
+			return SilentExit()
+		},
+	}
+	cmd.Flags().StringVar(&workspace, "workspace", "", "absolute canonical project path")
+	cmd.SetFlagErrorFunc(func(*cobra.Command, error) error {
+		return emitUsageError()
+	})
+	return cmd
+}
+
+var migrationV062InspectCmd = newMigrationV062InspectCmd()
+
+func init() {
+	rootCmd.AddCommand(migrationV062InspectCmd)
+}

--- a/cmd/bd/migration_v062_inspect_test.go
+++ b/cmd/bd/migration_v062_inspect_test.go
@@ -1,0 +1,405 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/steveyegge/beads/internal/v062migration"
+)
+
+func TestMigrationV062InspectRawEntrypointGrammar(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want bool
+	}{
+		{name: "no argv", args: nil, want: false},
+		{name: "binary only", args: []string{"bd"}, want: false},
+		{name: "exact token first", args: []string{"bd", "__migration-v062-inspect"}, want: true},
+		{name: "root flag before token", args: []string{"bd", "--json", "__migration-v062-inspect"}, want: false},
+		{name: "similar token", args: []string{"bd", "__migration-v062-inspect-extra"}, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isMigrationV062InspectRawEntrypoint(tt.args); got != tt.want {
+				t.Fatalf("isMigrationV062InspectRawEntrypoint(%q) = %v, want %v", tt.args, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMigrationV062InspectRawEntrypointDoesNotInitializeAmbientConfig(t *testing.T) {
+	bd := buildMigrationV062LifecycleBinary(t)
+	fixture := newMigrationV062AmbientConfigFixture(t)
+	missingWorkspace := filepath.Join(fixture.root, "missing-v062-workspace")
+
+	t.Run("hidden token first ignores ambient config", func(t *testing.T) {
+		stdout, stderr, err := runMigrationV062LifecycleProcess(
+			t,
+			bd,
+			fixture.cwd,
+			fixture.env,
+			"__migration-v062-inspect",
+			"--workspace", missingWorkspace,
+		)
+		if code := migrationV062ProcessExitCode(err); code != 1 {
+			t.Fatalf("exit code = %d, want 1\nstdout:\n%s\nstderr:\n%s", code, stdout, stderr)
+		}
+		if stderr != "" {
+			t.Fatalf("private migration entrypoint observed ambient initialization:\n%s", stderr)
+		}
+		var result v062migration.Result
+		if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+			t.Fatalf("decode protocol output: %v\nstdout: %s", err, stdout)
+		}
+		if result.Status != v062migration.StatusRefused || result.Effect != v062migration.EffectNone {
+			t.Fatalf("unexpected refusal envelope: %#v", result)
+		}
+	})
+
+	t.Run("normal command still initializes ambient config", func(t *testing.T) {
+		stdout, stderr, err := runMigrationV062LifecycleProcess(t, bd, fixture.cwd, fixture.env, "version")
+		if code := migrationV062ProcessExitCode(err); code != 0 {
+			t.Fatalf("exit code = %d, want 0\nstdout:\n%s\nstderr:\n%s", code, stdout, stderr)
+		}
+		if !strings.Contains(stderr, "Warning: failed to initialize config:") {
+			t.Fatalf("normal command did not observe hostile ambient config:\n%s", stderr)
+		}
+	})
+
+	t.Run("hidden token not first still initializes ambient config", func(t *testing.T) {
+		stdout, stderr, err := runMigrationV062LifecycleProcess(
+			t,
+			bd,
+			fixture.cwd,
+			fixture.env,
+			"--json",
+			"__migration-v062-inspect",
+			"--workspace", missingWorkspace,
+		)
+		if code := migrationV062ProcessExitCode(err); code != 1 {
+			t.Fatalf("exit code = %d, want 1\nstdout:\n%s\nstderr:\n%s", code, stdout, stderr)
+		}
+		if !strings.Contains(stderr, "Warning: failed to initialize config:") {
+			t.Fatalf("token-not-first invocation incorrectly bypassed ambient config:\n%s", stderr)
+		}
+	})
+}
+
+func TestMigrationV062InspectRawEntrypointDoesNotInvokeGitDuringInitialization(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake executable probe uses a POSIX shell")
+	}
+
+	bd := buildMigrationV062LifecycleBinary(t)
+	root := t.TempDir()
+	cwd := filepath.Join(root, "caller")
+	binDir := filepath.Join(root, "bin")
+	marker := filepath.Join(root, "git-was-invoked")
+	for _, dir := range []string{cwd, binDir} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+	gitProbe := filepath.Join(binDir, "git")
+	if err := os.WriteFile(gitProbe, []byte("#!/bin/sh\n: > \"$BD_V062_GIT_PROBE\"\nexit 1\n"), 0o755); err != nil {
+		t.Fatalf("write git probe: %v", err)
+	}
+	env := migrationV062LifecycleEnv(
+		filepath.Join(root, "home"),
+		filepath.Join(root, "xdg"),
+		"PATH="+binDir,
+		"BD_V062_GIT_PROBE="+marker,
+	)
+
+	stdout, stderr, err := runMigrationV062LifecycleProcess(
+		t,
+		bd,
+		cwd,
+		env,
+		"__migration-v062-inspect",
+		"--workspace", filepath.Join(root, "missing-v062-workspace"),
+	)
+	if code := migrationV062ProcessExitCode(err); code != 1 {
+		t.Fatalf("exit code = %d, want 1\nstdout:\n%s\nstderr:\n%s", code, stdout, stderr)
+	}
+	if _, err := os.Stat(marker); !os.IsNotExist(err) {
+		t.Fatalf("private migration entrypoint invoked ambient git probe: %v", err)
+	}
+
+	// Root help does not run Cobra's command lifecycle, so this marker can only
+	// come from the eager configuration initialization performed by init().
+	stdout, stderr, err = runMigrationV062LifecycleProcess(t, bd, cwd, env, "--help")
+	if code := migrationV062ProcessExitCode(err); code != 0 {
+		t.Fatalf("control exit code = %d, want 0\nstdout:\n%s\nstderr:\n%s", code, stdout, stderr)
+	}
+	if _, err := os.Stat(marker); err != nil {
+		t.Fatalf("control command did not invoke git during config initialization: %v", err)
+	}
+}
+
+func TestMigrationV062InspectCommandBypassesParentLifecycle(t *testing.T) {
+	t.Setenv("BD_BACKEND", "postgres")
+	t.Setenv("BD_DATABASE_BACKEND", "mysql")
+
+	parentPreRun := false
+	parentPostRun := false
+	root := &cobra.Command{
+		Use: "bd",
+		PersistentPreRunE: func(*cobra.Command, []string) error {
+			parentPreRun = true
+			return nil
+		},
+		PersistentPostRunE: func(*cobra.Command, []string) error {
+			parentPostRun = true
+			return nil
+		},
+	}
+	command := newMigrationV062InspectCmd()
+	root.AddCommand(command)
+	root.SetArgs([]string{
+		"__migration-v062-inspect",
+		"--workspace", "/definitely/not/a/v062/workspace",
+	})
+
+	stdout, executeErr := captureMigrationV062Stdout(t, root.Execute)
+	if code, ok := exitCodeFromError(executeErr); !ok || code != 1 {
+		t.Fatalf("Execute() error = %T %v, want exit code 1", executeErr, executeErr)
+	}
+	if parentPreRun || parentPostRun {
+		t.Fatalf("hidden protocol ran parent lifecycle: pre=%v post=%v", parentPreRun, parentPostRun)
+	}
+	if !command.Hidden {
+		t.Fatal("migration inspection plumbing must remain hidden")
+	}
+
+	var result v062migration.Result
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("decode protocol output: %v\nstdout: %s", err, stdout)
+	}
+	if result.SchemaVersion != v062migration.SchemaVersion ||
+		result.Operation != v062migration.Operation ||
+		result.Status != v062migration.StatusRefused ||
+		result.Effect != v062migration.EffectNone ||
+		result.Code == "" {
+		t.Fatalf("unexpected refusal envelope: %#v", result)
+	}
+}
+
+func TestMigrationV062InspectCommandUsageContract(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{name: "missing workspace", args: nil},
+		{name: "empty workspace", args: []string{"--workspace", ""}},
+		{name: "unexpected argument", args: []string{"--workspace", "/tmp", "extra"}},
+		{name: "unknown flag", args: []string{"--unknown"}},
+		{name: "missing flag value", args: []string{"--workspace"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := &cobra.Command{Use: "bd"}
+			root.AddCommand(newMigrationV062InspectCmd())
+			root.SetArgs(append([]string{"__migration-v062-inspect"}, tt.args...))
+
+			stdout, executeErr := captureMigrationV062Stdout(t, root.Execute)
+			if code, ok := exitCodeFromError(executeErr); !ok || code != 2 {
+				t.Fatalf("Execute() error = %T %v, want exit code 2", executeErr, executeErr)
+			}
+			var result v062migration.Result
+			if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+				t.Fatalf("decode protocol output: %v\nstdout: %s", err, stdout)
+			}
+			if result != v062migration.UsageErrorResult() {
+				t.Fatalf("usage result = %#v, want %#v", result, v062migration.UsageErrorResult())
+			}
+		})
+	}
+}
+
+func TestMigrationV062InspectCommandIsAbsentFromHelp(t *testing.T) {
+	root := &cobra.Command{Use: "bd"}
+	root.AddCommand(newMigrationV062InspectCmd())
+	var output bytes.Buffer
+	root.SetOut(&output)
+	root.SetErr(&output)
+	if err := root.Help(); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(output.String(), "__migration-v062-inspect") {
+		t.Fatalf("hidden protocol leaked into help:\n%s", output.String())
+	}
+}
+
+func captureMigrationV062Stdout(t *testing.T, fn func() error) (string, error) {
+	t.Helper()
+
+	stdioMutex.Lock()
+	defer stdioMutex.Unlock()
+
+	previous := os.Stdout
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = writer
+
+	executeErr := fn()
+	_ = writer.Close()
+	os.Stdout = previous
+
+	data, readErr := io.ReadAll(reader)
+	_ = reader.Close()
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	return string(data), executeErr
+}
+
+type migrationV062AmbientConfigFixture struct {
+	root string
+	cwd  string
+	env  []string
+}
+
+func newMigrationV062AmbientConfigFixture(t *testing.T) migrationV062AmbientConfigFixture {
+	t.Helper()
+
+	root := t.TempDir()
+	home := filepath.Join(root, "home")
+	xdg := filepath.Join(root, "xdg")
+	cwd := filepath.Join(root, "caller", "nested")
+	configPaths := []string{
+		filepath.Join(home, ".beads", "config.yaml"),
+		filepath.Join(xdg, "bd", "config.yaml"),
+		filepath.Join(root, "caller", ".beads", "config.yaml"),
+	}
+	if err := os.MkdirAll(cwd, 0o755); err != nil {
+		t.Fatalf("mkdir caller: %v", err)
+	}
+	for _, path := range configPaths {
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("mkdir config parent: %v", err)
+		}
+		if err := os.WriteFile(path, []byte("json: [unterminated\n"), 0o600); err != nil {
+			t.Fatalf("write hostile config: %v", err)
+		}
+	}
+
+	return migrationV062AmbientConfigFixture{
+		root: root,
+		cwd:  cwd,
+		env:  migrationV062LifecycleEnv(home, xdg),
+	}
+}
+
+var (
+	migrationV062LifecycleBuildOnce sync.Once
+	migrationV062LifecycleBD        string
+	migrationV062LifecycleBuildErr  string
+)
+
+func buildMigrationV062LifecycleBinary(t *testing.T) string {
+	t.Helper()
+
+	migrationV062LifecycleBuildOnce.Do(func() {
+		packageDir, err := os.Getwd()
+		if err != nil {
+			migrationV062LifecycleBuildErr = "get package directory: " + err.Error()
+			return
+		}
+		buildDir, err := testTempDir("bd-v062-lifecycle-*")
+		if err != nil {
+			migrationV062LifecycleBuildErr = "create build directory: " + err.Error()
+			return
+		}
+		name := "bd"
+		if runtime.GOOS == "windows" {
+			name = "bd.exe"
+		}
+		migrationV062LifecycleBD = filepath.Join(buildDir, name)
+		cmd := exec.Command("go", "build", "-tags", "gms_pure_go", "-o", migrationV062LifecycleBD, ".")
+		cmd.Dir = packageDir
+		if output, err := cmd.CombinedOutput(); err != nil {
+			migrationV062LifecycleBuildErr = "build bd: " + err.Error() + "\n" + string(output)
+		}
+	})
+	if migrationV062LifecycleBuildErr != "" {
+		t.Fatal(migrationV062LifecycleBuildErr)
+	}
+	return migrationV062LifecycleBD
+}
+
+func migrationV062LifecycleEnv(home, xdg string, extra ...string) []string {
+	blocked := map[string]bool{
+		"HOME":                true,
+		"USERPROFILE":         true,
+		"XDG_CONFIG_HOME":     true,
+		"GIT_CONFIG_GLOBAL":   true,
+		"GIT_CONFIG_NOSYSTEM": true,
+		"PATH":                true,
+	}
+	env := make([]string, 0, len(os.Environ())+len(extra)+9)
+	for _, entry := range os.Environ() {
+		name, _, _ := strings.Cut(entry, "=")
+		if blocked[name] || strings.HasPrefix(name, "BD_") || strings.HasPrefix(name, "BEADS_") {
+			continue
+		}
+		env = append(env, entry)
+	}
+	env = append(env,
+		"HOME="+home,
+		"USERPROFILE="+home,
+		"XDG_CONFIG_HOME="+xdg,
+		"GIT_CONFIG_GLOBAL="+filepath.Join(home, "gitconfig"),
+		"GIT_CONFIG_NOSYSTEM=1",
+		"PATH="+os.Getenv("PATH"),
+		"BEADS_DOLT_AUTO_START=0",
+		"BEADS_NO_DAEMON=1",
+		"BD_DISABLE_METRICS=1",
+		"BD_DISABLE_EVENT_FLUSH=1",
+	)
+	return append(env, extra...)
+}
+
+func runMigrationV062LifecycleProcess(
+	t *testing.T,
+	bd string,
+	dir string,
+	env []string,
+	args ...string,
+) (stdout, stderr string, runErr error) {
+	t.Helper()
+
+	cmd := exec.Command(bd, args...)
+	cmd.Dir = dir
+	cmd.Env = env
+	var stdoutBuffer bytes.Buffer
+	var stderrBuffer bytes.Buffer
+	cmd.Stdout = &stdoutBuffer
+	cmd.Stderr = &stderrBuffer
+	runErr = cmd.Run()
+	return stdoutBuffer.String(), stderrBuffer.String(), runErr
+}
+
+func migrationV062ProcessExitCode(err error) int {
+	if err == nil {
+		return 0
+	}
+	if exitErr, ok := err.(*exec.ExitError); ok {
+		return exitErr.ExitCode()
+	}
+	return -1
+}

--- a/internal/v062migration/embedded_build_cgo.go
+++ b/internal/v062migration/embedded_build_cgo.go
@@ -1,0 +1,5 @@
+//go:build cgo
+
+package v062migration
+
+const embeddedBuildCapable = true

--- a/internal/v062migration/embedded_build_nocgo.go
+++ b/internal/v062migration/embedded_build_nocgo.go
@@ -1,0 +1,5 @@
+//go:build !cgo
+
+package v062migration
+
+const embeddedBuildCapable = false

--- a/internal/v062migration/inspect_linux.go
+++ b/internal/v062migration/inspect_linux.go
@@ -95,24 +95,8 @@ func Inspect(project, targetVersion string) (result Result, returnErr error) {
 }
 
 func inspectWithHooks(project, targetVersion string, hooks inspectHooks) (result Result, returnErr error) {
-	if runtime.GOARCH != "amd64" {
-		return Result{}, refuse(CodePlatformUnsupported, false, nil)
-	}
-	wsl, err := runningUnderWSL()
-	if err != nil {
-		return Result{}, refuse(CodeSourceUnverifiable, true, err)
-	}
-	if wsl {
-		return Result{}, refuse(CodePlatformUnsupported, false, nil)
-	}
-	if !embeddedBuildCapable {
-		return Result{}, refuse(CodeEmbeddedTargetUnavailable, false, nil)
-	}
-	if project == "" || !filepath.IsAbs(project) {
-		return Result{}, refuse(CodeWorkspaceInvalid, false, nil)
-	}
-	if filepath.Clean(project) != project {
-		return Result{}, refuse(CodeWorkspaceNotCanonical, false, nil)
+	if err := checkInspectPreconditions(project); err != nil {
+		return Result{}, err
 	}
 
 	readMountID := hooks.mountIDAt
@@ -136,33 +120,19 @@ func inspectWithHooks(project, targetVersion string, hooks inspectHooks) (result
 		return Result{}, err
 	}
 
-	versionFile, versionStat, err := fs.openWitnessAt(beadsFile, ".local_version", CodeSourceVersionMissing, CodeSourceVersionAmbiguous)
+	versionFile, versionStat, version, err := fs.readBoundedWitness(beadsFile, ".local_version", CodeSourceVersionMissing, CodeSourceVersionAmbiguous, maxVersionBytes, CodeSourceVersionMismatch)
+	defer closeForInspection(&result, &returnErr, versionFile)
 	if err != nil {
 		return Result{}, err
-	}
-	defer closeForInspection(&result, &returnErr, versionFile)
-	version, err := readStableBounded(versionFile, versionStat, maxVersionBytes)
-	if err != nil {
-		if errors.Is(err, errWitnessOutsideBound) {
-			return Result{}, refuse(CodeSourceVersionMismatch, false, err)
-		}
-		return Result{}, classifyWitnessReadFailure(err)
 	}
 	if !bytes.Equal(version, []byte(versionWitness)) {
 		return Result{}, refuse(CodeSourceVersionMismatch, false, nil)
 	}
 
-	metadataFile, metadataStat, err := fs.openWitnessAt(beadsFile, "metadata.json", CodeSourceMetadataMissing, CodeUnsafeSourceSymlink)
+	metadataFile, metadataStat, metadata, err := fs.readBoundedWitness(beadsFile, "metadata.json", CodeSourceMetadataMissing, CodeUnsafeSourceSymlink, maxMetadataBytes, CodeSourceMetadataMismatch)
+	defer closeForInspection(&result, &returnErr, metadataFile)
 	if err != nil {
 		return Result{}, err
-	}
-	defer closeForInspection(&result, &returnErr, metadataFile)
-	metadata, err := readStableBounded(metadataFile, metadataStat, maxMetadataBytes)
-	if err != nil {
-		if errors.Is(err, errWitnessOutsideBound) {
-			return Result{}, refuse(CodeSourceMetadataMismatch, false, err)
-		}
-		return Result{}, classifyWitnessReadFailure(err)
 	}
 	shape, err := parseMetadata(metadata)
 	if err != nil {
@@ -195,6 +165,31 @@ func inspectWithHooks(project, targetVersion string, hooks inspectHooks) (result
 	}
 
 	return QualifiedResult(project, targetVersion, first.treeSHA256), nil
+}
+
+// checkInspectPreconditions rejects environments and workspace arguments that
+// the descriptor-bound inspector cannot admit before any source is opened.
+func checkInspectPreconditions(project string) error {
+	if runtime.GOARCH != "amd64" {
+		return refuse(CodePlatformUnsupported, false, nil)
+	}
+	wsl, err := runningUnderWSL()
+	if err != nil {
+		return refuse(CodeSourceUnverifiable, true, err)
+	}
+	if wsl {
+		return refuse(CodePlatformUnsupported, false, nil)
+	}
+	if !embeddedBuildCapable {
+		return refuse(CodeEmbeddedTargetUnavailable, false, nil)
+	}
+	if project == "" || !filepath.IsAbs(project) {
+		return refuse(CodeWorkspaceInvalid, false, nil)
+	}
+	if filepath.Clean(project) != project {
+		return refuse(CodeWorkspaceNotCanonical, false, nil)
+	}
+	return nil
 }
 
 func runningUnderWSL() (bool, error) {
@@ -392,6 +387,26 @@ func (fs sourceFS) openWitnessAt(parent *os.File, name string, missingCode, syml
 	return file, opened, nil
 }
 
+// readBoundedWitness opens a required regular-file witness under the retained
+// beads descriptor and reads it under the stable-size contract. An oversized
+// but stable witness is a non-retryable mismatch. The file is returned even on
+// a read failure so the caller can register its deferred close; it is nil only
+// when the open itself failed.
+func (fs sourceFS) readBoundedWitness(beads *os.File, name string, missingCode, symlinkCode Code, limit int64, mismatchCode Code) (*os.File, unix.Stat_t, []byte, error) {
+	file, stat, err := fs.openWitnessAt(beads, name, missingCode, symlinkCode)
+	if err != nil {
+		return nil, unix.Stat_t{}, nil, err
+	}
+	data, err := readStableBounded(file, stat, limit)
+	if err != nil {
+		if errors.Is(err, errWitnessOutsideBound) {
+			return file, stat, nil, refuse(mismatchCode, false, err)
+		}
+		return file, stat, nil, classifyWitnessReadFailure(err)
+	}
+	return file, stat, data, nil
+}
+
 func classifyBeadsOpen(err error) error {
 	if _, ok := AsRefusal(err); ok {
 		return err
@@ -460,55 +475,68 @@ func parseMetadata(data []byte) (metadataShape, error) {
 	if err != nil {
 		return metadataShape{}, err
 	}
-	backend, ok := requiredString(values, "backend")
-	if !ok || backend != "dolt" {
-		return metadataShape{}, errors.New("backend")
+	database, err := requiredMetadataShape(values)
+	if err != nil {
+		return metadataShape{}, err
 	}
-	databaseKind, ok := requiredString(values, "database")
-	if !ok || databaseKind != "dolt" {
-		return metadataShape{}, errors.New("database")
+	if err := rejectDisallowedMetadataFields(values); err != nil {
+		return metadataShape{}, err
 	}
-	mode, ok := requiredString(values, "dolt_mode")
-	if !ok || mode != "server" {
-		return metadataShape{}, errors.New("dolt_mode")
+	return metadataShape{database: database}, nil
+}
+
+// requiredMetadataShape enforces the exact scalar contract of a v0.62 local
+// Dolt-server metadata document and returns the validated dolt database name.
+func requiredMetadataShape(values map[string]json.RawMessage) (string, error) {
+	for _, field := range []struct{ key, want string }{
+		{"backend", "dolt"},
+		{"database", "dolt"},
+		{"dolt_mode", "server"},
+	} {
+		if got, ok := requiredString(values, field.key); !ok || got != field.want {
+			return "", errors.New(field.key)
+		}
 	}
 	if _, present := values["dolt_server_host"]; present {
-		host, ok := requiredString(values, "dolt_server_host")
-		if !ok || host != "127.0.0.1" {
-			return metadataShape{}, errors.New("dolt_server_host")
+		if host, ok := requiredString(values, "dolt_server_host"); !ok || host != "127.0.0.1" {
+			return "", errors.New("dolt_server_host")
 		}
 	}
 	database, ok := requiredString(values, "dolt_database")
 	if !ok || !databaseNamePattern.MatchString(database) {
-		return metadataShape{}, errors.New("dolt_database")
+		return "", errors.New("dolt_database")
 	}
-	projectID, ok := requiredString(values, "project_id")
-	if !ok || !projectIDPattern.MatchString(projectID) {
-		return metadataShape{}, errors.New("project_id")
+	if projectID, ok := requiredString(values, "project_id"); !ok || !projectIDPattern.MatchString(projectID) {
+		return "", errors.New("project_id")
 	}
 	if _, present := values["dolt_server_port"]; present {
-		port, ok := requiredInteger(values, "dolt_server_port")
-		if !ok || port < 1 || port > 65535 {
-			return metadataShape{}, errors.New("dolt_server_port")
+		if port, ok := requiredInteger(values, "dolt_server_port"); !ok || port < 1 || port > 65535 {
+			return "", errors.New("dolt_server_port")
 		}
 	}
+	return database, nil
+}
+
+// rejectDisallowedMetadataFields fails closed on any field outside the allowed
+// v0.62 set, any foreign-provider metadata, and any non-empty custom data dir.
+func rejectDisallowedMetadataFields(values map[string]json.RawMessage) error {
 	for key, raw := range values {
 		if _, allowed := allowedV062MetadataFields[key]; !allowed {
-			return metadataShape{}, errors.New("unknown v0.62 metadata field")
+			return errors.New("unknown v0.62 metadata field")
 		}
 		lower := strings.ToLower(key)
 		if strings.HasPrefix(lower, "postgres") || strings.HasPrefix(lower, "mysql") ||
 			strings.HasPrefix(lower, "sqlite") || strings.HasPrefix(lower, "proxied") {
-			return metadataShape{}, errors.New("foreign provider metadata")
+			return errors.New("foreign provider metadata")
 		}
-		if key == "dolt_data_dir" || key == "dolt_server_socket" {
+		if key == "dolt_data_dir" {
 			var value string
 			if err := json.Unmarshal(raw, &value); err != nil || value != "" {
-				return metadataShape{}, errors.New("custom server path")
+				return errors.New("custom server path")
 			}
 		}
 	}
-	return metadataShape{database: database}, nil
+	return nil
 }
 
 func decodeUniqueObject(data []byte) (map[string]json.RawMessage, error) {
@@ -602,80 +630,111 @@ func (fs sourceFS) inspectDirectory(dir *os.File, relative string, includeConten
 	}
 	sort.Strings(names)
 	for _, name := range names {
-		path := name
-		if relative != "" {
-			path = relative + "/" + name
-		}
-		var named unix.Stat_t
-		if err := unix.Fstatat(int(dir.Fd()), name, &named, unix.AT_SYMLINK_NOFOLLOW); err != nil {
-			if errors.Is(err, unix.ENOENT) || errors.Is(err, unix.ESTALE) {
-				return refuse(CodeSourceChanged, true, err)
-			}
-			return refuse(CodeSourceUnverifiable, true, err)
-		}
-		if err := checkDevice(named.Dev, fs.device); err != nil {
-			return err
-		}
-		if err := fs.checkMountAt(int(dir.Fd()), name, unix.AT_SYMLINK_NOFOLLOW); err != nil {
+		path := joinRelative(relative, name)
+		named, err := fs.statTreeEntry(dir, name)
+		if err != nil {
 			return err
 		}
 		switch named.Mode & unix.S_IFMT {
 		case unix.S_IFLNK:
 			return refuse(CodeUnsafeSourceSymlink, false, nil)
 		case unix.S_IFDIR:
-			child, opened, err := fs.openDirectoryAt(dir, name)
-			if err != nil {
-				return classifyTreeOpen(err)
-			}
-			kinds[path] = 'd'
-			writeTreeRecord(treeHash, 'd', path, opened, nil)
-			writeStructureRecord(structureHash, 'd', path, opened)
-			err = fs.inspectDirectory(child, path, includeContent, treeHash, structureHash, kinds)
-			closeErr := child.Close()
-			if err != nil {
+			if err := fs.inspectSubdirectory(dir, name, path, includeContent, treeHash, structureHash, kinds); err != nil {
 				return err
-			}
-			if closeErr != nil {
-				return refuse(CodeSourceUnverifiable, true, closeErr)
 			}
 		case unix.S_IFREG:
-			if named.Nlink != 1 {
-				return refuse(CodeUnsafeSourceHardlink, false, nil)
-			}
-			file, opened, err := fs.openRegularTreeFile(dir, name, named)
-			if err != nil {
+			if err := fs.hashRegularTreeEntry(dir, name, path, named, includeContent, treeHash, structureHash, kinds); err != nil {
 				return err
 			}
-			var contentDigest []byte
-			if includeContent {
-				contentHash := sha256.New()
-				if _, err := io.Copy(contentHash, file); err != nil {
-					_ = file.Close()
-					return refuse(CodeSourceUnverifiable, true, err)
-				}
-				contentDigest = contentHash.Sum(nil)
-			}
-			var after unix.Stat_t
-			statErr := unix.Fstat(int(file.Fd()), &after)
-			closeErr := file.Close()
-			if statErr != nil {
-				return refuse(CodeSourceUnverifiable, true, statErr)
-			}
-			if !sameStat(opened, after) {
-				return refuse(CodeSourceChanged, true, nil)
-			}
-			if closeErr != nil {
-				return refuse(CodeSourceUnverifiable, true, closeErr)
-			}
-			kinds[path] = 'f'
-			if includeContent {
-				writeTreeRecord(treeHash, 'f', path, opened, contentDigest)
-			}
-			writeStructureRecord(structureHash, 'f', path, opened)
 		default:
 			return refuse(CodeUnsafeSourceObject, false, nil)
 		}
 	}
+	return nil
+}
+
+func joinRelative(relative, name string) string {
+	if relative == "" {
+		return name
+	}
+	return relative + "/" + name
+}
+
+// statTreeEntry stats a directory entry without following symlinks and binds it
+// to the retained source device and mount before the caller inspects its kind.
+func (fs sourceFS) statTreeEntry(dir *os.File, name string) (unix.Stat_t, error) {
+	var named unix.Stat_t
+	if err := unix.Fstatat(int(dir.Fd()), name, &named, unix.AT_SYMLINK_NOFOLLOW); err != nil {
+		if errors.Is(err, unix.ENOENT) || errors.Is(err, unix.ESTALE) {
+			return unix.Stat_t{}, refuse(CodeSourceChanged, true, err)
+		}
+		return unix.Stat_t{}, refuse(CodeSourceUnverifiable, true, err)
+	}
+	if err := checkDevice(named.Dev, fs.device); err != nil {
+		return unix.Stat_t{}, err
+	}
+	if err := fs.checkMountAt(int(dir.Fd()), name, unix.AT_SYMLINK_NOFOLLOW); err != nil {
+		return unix.Stat_t{}, err
+	}
+	return named, nil
+}
+
+func (fs sourceFS) inspectSubdirectory(dir *os.File, name, path string, includeContent bool, treeHash, structureHash hash.Hash, kinds map[string]byte) error {
+	child, opened, err := fs.openDirectoryAt(dir, name)
+	if err != nil {
+		return classifyTreeOpen(err)
+	}
+	kinds[path] = 'd'
+	writeTreeRecord(treeHash, 'd', path, opened, nil)
+	writeStructureRecord(structureHash, 'd', path, opened)
+	err = fs.inspectDirectory(child, path, includeContent, treeHash, structureHash, kinds)
+	closeErr := child.Close()
+	if err != nil {
+		return err
+	}
+	if closeErr != nil {
+		return refuse(CodeSourceUnverifiable, true, closeErr)
+	}
+	return nil
+}
+
+// hashRegularTreeEntry opens a regular tree file under its retained descriptor,
+// folds its content and structure into the running digests, and re-stats it to
+// prove it did not change during the read.
+func (fs sourceFS) hashRegularTreeEntry(dir *os.File, name, path string, named unix.Stat_t, includeContent bool, treeHash, structureHash hash.Hash, kinds map[string]byte) error {
+	if named.Nlink != 1 {
+		return refuse(CodeUnsafeSourceHardlink, false, nil)
+	}
+	file, opened, err := fs.openRegularTreeFile(dir, name, named)
+	if err != nil {
+		return err
+	}
+	var contentDigest []byte
+	if includeContent {
+		contentHash := sha256.New()
+		if _, err := io.Copy(contentHash, file); err != nil {
+			_ = file.Close()
+			return refuse(CodeSourceUnverifiable, true, err)
+		}
+		contentDigest = contentHash.Sum(nil)
+	}
+	var after unix.Stat_t
+	statErr := unix.Fstat(int(file.Fd()), &after)
+	closeErr := file.Close()
+	if statErr != nil {
+		return refuse(CodeSourceUnverifiable, true, statErr)
+	}
+	if !sameStat(opened, after) {
+		return refuse(CodeSourceChanged, true, nil)
+	}
+	if closeErr != nil {
+		return refuse(CodeSourceUnverifiable, true, closeErr)
+	}
+	kinds[path] = 'f'
+	if includeContent {
+		writeTreeRecord(treeHash, 'f', path, opened, contentDigest)
+	}
+	writeStructureRecord(structureHash, 'f', path, opened)
 	return nil
 }
 
@@ -856,6 +915,13 @@ func (fs sourceFS) revalidateSource(projectPath string, project *os.File, projec
 	if canonical != projectPath {
 		return refuse(CodeSourceChanged, true, nil)
 	}
+	return fs.reverifyProjectIdentity(projectPath, projectStat)
+}
+
+// reverifyProjectIdentity reopens the canonical project path and proves the
+// fresh descriptor still names the same inode on the same source mount, closing
+// the residual window between the retained descriptor and a path-based reopen.
+func (fs sourceFS) reverifyProjectIdentity(projectPath string, projectStat unix.Stat_t) error {
 	reopened, reopenedStat, reopenedMountID, err := openProject(projectPath, fs.readMountID)
 	if err != nil {
 		if refusal, ok := AsRefusal(err); ok && refusal.Code == CodeSourceUnverifiable {

--- a/internal/v062migration/inspect_linux.go
+++ b/internal/v062migration/inspect_linux.go
@@ -1,0 +1,946 @@
+//go:build linux
+
+package v062migration
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"hash"
+	"io"
+	"os"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"sort"
+	"strconv"
+	"strings"
+
+	"golang.org/x/sys/unix"
+)
+
+const (
+	versionWitness       = "0.62.0\n"
+	maxVersionBytes      = 64
+	maxMetadataBytes     = 1 << 20
+	rollbackDirectory    = ".beads-v0.62.0-rollback"
+	directoryOpenFlags   = unix.O_RDONLY | unix.O_DIRECTORY | unix.O_CLOEXEC | unix.O_NOFOLLOW | unix.O_NOATIME
+	regularFileOpenFlags = unix.O_RDONLY | unix.O_CLOEXEC | unix.O_NOFOLLOW | unix.O_NOATIME | unix.O_NONBLOCK
+)
+
+var (
+	databaseNamePattern       = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_-]{0,63}$`)
+	projectIDPattern          = regexp.MustCompile(`^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$`)
+	errWitnessOutsideBound    = errors.New("witness outside size bound")
+	errWitnessChanged         = errors.New("witness changed while read")
+	allowedV062MetadataFields = map[string]struct{}{
+		"backend":                  {},
+		"database":                 {},
+		"deletions_retention_days": {},
+		"dolt_data_dir":            {},
+		"dolt_database":            {},
+		"dolt_mode":                {},
+		"dolt_remotesapi_port":     {},
+		"dolt_server_host":         {},
+		"dolt_server_port":         {},
+		"dolt_server_tls":          {},
+		"dolt_server_user":         {},
+		"last_bd_version":          {},
+		"project_id":               {},
+		"stale_closed_issues_days": {},
+	}
+)
+
+type metadataShape struct {
+	database string
+}
+
+type treeSnapshot struct {
+	treeSHA256      string
+	structureSHA256 string
+	kinds           map[string]byte
+}
+
+type mountIDReader func(dirfd int, path string, flags int) (uint64, error)
+
+type pathOpener func(path string, flags int, mode uint32) (int, error)
+
+// sourceFS binds every traversal observation to both the source filesystem
+// device and the Linux mount that contained the retained project descriptor.
+// st_dev alone cannot distinguish bind mounts on the same filesystem.
+type sourceFS struct {
+	device      uint64
+	mountID     uint64
+	readMountID mountIDReader
+}
+
+type inspectHooks struct {
+	afterFirstTree func()
+	mountIDAt      mountIDReader
+}
+
+func sameAdmissionObservation(first, second treeSnapshot) bool {
+	return first.structureSHA256 == second.structureSHA256 && first.treeSHA256 == second.treeSHA256
+}
+
+// Inspect admits only an exact, physical v0.62.0 local Dolt-server source.
+// Every source read is rooted at retained O_NOFOLLOW descriptors and no source
+// path is opened for writing.
+func Inspect(project, targetVersion string) (result Result, returnErr error) {
+	return inspectWithHooks(project, targetVersion, inspectHooks{})
+}
+
+func inspectWithHooks(project, targetVersion string, hooks inspectHooks) (result Result, returnErr error) {
+	if runtime.GOARCH != "amd64" {
+		return Result{}, refuse(CodePlatformUnsupported, false, nil)
+	}
+	wsl, err := runningUnderWSL()
+	if err != nil {
+		return Result{}, refuse(CodeSourceUnverifiable, true, err)
+	}
+	if wsl {
+		return Result{}, refuse(CodePlatformUnsupported, false, nil)
+	}
+	if !embeddedBuildCapable {
+		return Result{}, refuse(CodeEmbeddedTargetUnavailable, false, nil)
+	}
+	if project == "" || !filepath.IsAbs(project) {
+		return Result{}, refuse(CodeWorkspaceInvalid, false, nil)
+	}
+	if filepath.Clean(project) != project {
+		return Result{}, refuse(CodeWorkspaceNotCanonical, false, nil)
+	}
+
+	readMountID := hooks.mountIDAt
+	if readMountID == nil {
+		readMountID = readMountIDAt
+	}
+	projectFile, projectStat, projectMountID, err := openProject(project, readMountID)
+	if err != nil {
+		return Result{}, err
+	}
+	defer closeForInspection(&result, &returnErr, projectFile)
+	fs := sourceFS{device: projectStat.Dev, mountID: projectMountID, readMountID: readMountID}
+
+	beadsFile, beadsStat, err := fs.openDirectoryAt(projectFile, ".beads")
+	if err != nil {
+		return Result{}, classifyBeadsOpen(err)
+	}
+	defer closeForInspection(&result, &returnErr, beadsFile)
+
+	if err := rejectRollbackCollision(projectFile); err != nil {
+		return Result{}, err
+	}
+
+	versionFile, versionStat, err := fs.openWitnessAt(beadsFile, ".local_version", CodeSourceVersionMissing, CodeSourceVersionAmbiguous)
+	if err != nil {
+		return Result{}, err
+	}
+	defer closeForInspection(&result, &returnErr, versionFile)
+	version, err := readStableBounded(versionFile, versionStat, maxVersionBytes)
+	if err != nil {
+		if errors.Is(err, errWitnessOutsideBound) {
+			return Result{}, refuse(CodeSourceVersionMismatch, false, err)
+		}
+		return Result{}, classifyWitnessReadFailure(err)
+	}
+	if !bytes.Equal(version, []byte(versionWitness)) {
+		return Result{}, refuse(CodeSourceVersionMismatch, false, nil)
+	}
+
+	metadataFile, metadataStat, err := fs.openWitnessAt(beadsFile, "metadata.json", CodeSourceMetadataMissing, CodeUnsafeSourceSymlink)
+	if err != nil {
+		return Result{}, err
+	}
+	defer closeForInspection(&result, &returnErr, metadataFile)
+	metadata, err := readStableBounded(metadataFile, metadataStat, maxMetadataBytes)
+	if err != nil {
+		if errors.Is(err, errWitnessOutsideBound) {
+			return Result{}, refuse(CodeSourceMetadataMismatch, false, err)
+		}
+		return Result{}, classifyWitnessReadFailure(err)
+	}
+	shape, err := parseMetadata(metadata)
+	if err != nil {
+		return Result{}, refuse(CodeSourceMetadataMismatch, false, err)
+	}
+
+	first, err := fs.inspectTree(beadsFile, beadsStat, true)
+	if err != nil {
+		return Result{}, err
+	}
+	if err := validateRequiredLayout(first.kinds, shape.database); err != nil {
+		return Result{}, err
+	}
+	if hooks.afterFirstTree != nil {
+		hooks.afterFirstTree()
+	}
+	if err := fs.revalidateSource(project, projectFile, projectStat, beadsFile, beadsStat, versionFile, versionStat, metadataFile, metadataStat, version, metadata); err != nil {
+		return Result{}, err
+	}
+
+	second, err := fs.inspectTree(beadsFile, beadsStat, true)
+	if err != nil {
+		return Result{}, err
+	}
+	if !sameAdmissionObservation(first, second) {
+		return Result{}, refuse(CodeSourceChanged, true, nil)
+	}
+	if err := fs.revalidateSource(project, projectFile, projectStat, beadsFile, beadsStat, versionFile, versionStat, metadataFile, metadataStat, version, metadata); err != nil {
+		return Result{}, err
+	}
+
+	return QualifiedResult(project, targetVersion, first.treeSHA256), nil
+}
+
+func runningUnderWSL() (bool, error) {
+	var name unix.Utsname
+	if err := unix.Uname(&name); err != nil {
+		return false, err
+	}
+	return isWSLRelease(utsnameString(name.Release[:])), nil
+}
+
+func isWSLRelease(release string) bool {
+	lower := strings.ToLower(release)
+	return strings.Contains(lower, "microsoft") || strings.Contains(lower, "wsl")
+}
+
+func utsnameString(raw []byte) string {
+	for index, value := range raw {
+		if value == 0 {
+			return string(raw[:index])
+		}
+	}
+	return string(raw)
+}
+
+func openProject(project string, readMountID mountIDReader) (*os.File, unix.Stat_t, uint64, error) {
+	return openProjectWith(project, readMountID, unix.Open)
+}
+
+func openProjectWith(project string, readMountID mountIDReader, open pathOpener) (*os.File, unix.Stat_t, uint64, error) {
+	fd, err := open(project, directoryOpenFlags, 0)
+	if err != nil {
+		if errors.Is(err, unix.ELOOP) {
+			return nil, unix.Stat_t{}, 0, refuse(CodeWorkspaceNotCanonical, false, err)
+		}
+		if errors.Is(err, unix.EPERM) || errors.Is(err, unix.EACCES) {
+			// O_NOATIME is mandatory: retrying without it would mutate atime and
+			// violate the inspector's effect:none contract.
+			return nil, unix.Stat_t{}, 0, refuse(CodeSourceUnverifiable, true, err)
+		}
+		return nil, unix.Stat_t{}, 0, refuse(CodeWorkspaceInvalid, false, err)
+	}
+	file := os.NewFile(uintptr(fd), project)
+	if file == nil {
+		_ = unix.Close(fd)
+		return nil, unix.Stat_t{}, 0, refuse(CodeSourceUnverifiable, true, nil)
+	}
+	var stat unix.Stat_t
+	if err := unix.Fstat(fd, &stat); err != nil {
+		_ = file.Close()
+		return nil, unix.Stat_t{}, 0, refuse(CodeSourceUnverifiable, true, err)
+	}
+	mountID, err := readMountID(fd, "", unix.AT_EMPTY_PATH|unix.AT_SYMLINK_NOFOLLOW)
+	if err != nil {
+		_ = file.Close()
+		return nil, unix.Stat_t{}, 0, refuse(CodeSourceUnverifiable, true, err)
+	}
+	canonical, err := os.Readlink(fmt.Sprintf("/proc/self/fd/%d", fd))
+	if err != nil {
+		_ = file.Close()
+		return nil, unix.Stat_t{}, 0, refuse(CodeSourceUnverifiable, true, err)
+	}
+	if canonical != project {
+		_ = file.Close()
+		return nil, unix.Stat_t{}, 0, refuse(CodeWorkspaceNotCanonical, false, nil)
+	}
+	return file, stat, mountID, nil
+}
+
+func readMountIDAt(dirfd int, path string, flags int) (uint64, error) {
+	var stat unix.Statx_t
+	if err := unix.Statx(dirfd, path, flags, unix.STATX_MNT_ID, &stat); err != nil {
+		return 0, err
+	}
+	if stat.Mask&unix.STATX_MNT_ID == 0 {
+		return 0, unix.EOPNOTSUPP
+	}
+	return stat.Mnt_id, nil
+}
+
+func (fs sourceFS) checkMountAt(dirfd int, path string, flags int) error {
+	mountID, err := fs.readMountID(dirfd, path, flags)
+	if err != nil {
+		return refuse(CodeSourceUnverifiable, true, err)
+	}
+	return checkMountID(mountID, fs.mountID)
+}
+
+func checkMountID(actual, expected uint64) error {
+	if actual != expected {
+		return refuse(CodeCrossDeviceSource, false, nil)
+	}
+	return nil
+}
+
+func (fs sourceFS) openDirectoryAt(parent *os.File, name string) (*os.File, unix.Stat_t, error) {
+	var named unix.Stat_t
+	if err := unix.Fstatat(int(parent.Fd()), name, &named, unix.AT_SYMLINK_NOFOLLOW); err != nil {
+		return nil, unix.Stat_t{}, err
+	}
+	if named.Mode&unix.S_IFMT == unix.S_IFLNK {
+		return nil, unix.Stat_t{}, unix.ELOOP
+	}
+	if named.Mode&unix.S_IFMT != unix.S_IFDIR {
+		return nil, unix.Stat_t{}, unix.ENOTDIR
+	}
+	if err := checkDevice(named.Dev, fs.device); err != nil {
+		return nil, unix.Stat_t{}, err
+	}
+	if err := fs.checkMountAt(int(parent.Fd()), name, unix.AT_SYMLINK_NOFOLLOW); err != nil {
+		return nil, unix.Stat_t{}, err
+	}
+	fd, err := unix.Openat(int(parent.Fd()), name, directoryOpenFlags, 0)
+	if err != nil {
+		return nil, unix.Stat_t{}, err
+	}
+	file := os.NewFile(uintptr(fd), name)
+	if file == nil {
+		_ = unix.Close(fd)
+		return nil, unix.Stat_t{}, unix.EBADF
+	}
+	var opened unix.Stat_t
+	if err := unix.Fstat(fd, &opened); err != nil {
+		_ = file.Close()
+		return nil, unix.Stat_t{}, err
+	}
+	if err := checkDevice(opened.Dev, fs.device); err != nil {
+		_ = file.Close()
+		return nil, unix.Stat_t{}, err
+	}
+	if err := fs.checkMountAt(fd, "", unix.AT_EMPTY_PATH|unix.AT_SYMLINK_NOFOLLOW); err != nil {
+		_ = file.Close()
+		return nil, unix.Stat_t{}, err
+	}
+	if !sameStat(named, opened) {
+		_ = file.Close()
+		return nil, unix.Stat_t{}, unix.ESTALE
+	}
+	return file, opened, nil
+}
+
+func (fs sourceFS) openWitnessAt(parent *os.File, name string, missingCode, symlinkCode Code) (*os.File, unix.Stat_t, error) {
+	var named unix.Stat_t
+	if err := unix.Fstatat(int(parent.Fd()), name, &named, unix.AT_SYMLINK_NOFOLLOW); err != nil {
+		if errors.Is(err, unix.ENOENT) {
+			return nil, unix.Stat_t{}, refuse(missingCode, false, err)
+		}
+		return nil, unix.Stat_t{}, refuse(CodeSourceUnverifiable, true, err)
+	}
+	switch named.Mode & unix.S_IFMT {
+	case unix.S_IFLNK:
+		return nil, unix.Stat_t{}, refuse(symlinkCode, false, nil)
+	case unix.S_IFREG:
+		// Continue below.
+	default:
+		return nil, unix.Stat_t{}, refuse(CodeUnsafeSourceObject, false, nil)
+	}
+	if err := checkDevice(named.Dev, fs.device); err != nil {
+		return nil, unix.Stat_t{}, err
+	}
+	if err := fs.checkMountAt(int(parent.Fd()), name, unix.AT_SYMLINK_NOFOLLOW); err != nil {
+		return nil, unix.Stat_t{}, err
+	}
+	if named.Nlink != 1 {
+		return nil, unix.Stat_t{}, refuse(CodeUnsafeSourceHardlink, false, nil)
+	}
+	fd, err := unix.Openat(int(parent.Fd()), name, regularFileOpenFlags, 0)
+	if err != nil {
+		if errors.Is(err, unix.ELOOP) {
+			return nil, unix.Stat_t{}, refuse(symlinkCode, false, err)
+		}
+		return nil, unix.Stat_t{}, refuse(CodeSourceUnverifiable, true, err)
+	}
+	file := os.NewFile(uintptr(fd), name)
+	if file == nil {
+		_ = unix.Close(fd)
+		return nil, unix.Stat_t{}, refuse(CodeSourceUnverifiable, true, nil)
+	}
+	var opened unix.Stat_t
+	if err := unix.Fstat(fd, &opened); err != nil {
+		_ = file.Close()
+		return nil, unix.Stat_t{}, refuse(CodeSourceUnverifiable, true, err)
+	}
+	if err := checkDevice(opened.Dev, fs.device); err != nil {
+		_ = file.Close()
+		return nil, unix.Stat_t{}, err
+	}
+	if err := fs.checkMountAt(fd, "", unix.AT_EMPTY_PATH|unix.AT_SYMLINK_NOFOLLOW); err != nil {
+		_ = file.Close()
+		return nil, unix.Stat_t{}, err
+	}
+	if !sameStat(named, opened) {
+		_ = file.Close()
+		return nil, unix.Stat_t{}, refuse(CodeSourceChanged, true, nil)
+	}
+	return file, opened, nil
+}
+
+func classifyBeadsOpen(err error) error {
+	if _, ok := AsRefusal(err); ok {
+		return err
+	}
+	switch {
+	case errors.Is(err, unix.ENOENT), errors.Is(err, unix.ENOTDIR):
+		return refuse(CodeSourceLayoutMissing, false, err)
+	case errors.Is(err, unix.ELOOP):
+		return refuse(CodeUnsafeSourceSymlink, false, err)
+	case errors.Is(err, unix.EXDEV):
+		return refuse(CodeCrossDeviceSource, false, err)
+	default:
+		return refuse(CodeSourceUnverifiable, true, err)
+	}
+}
+
+func rejectRollbackCollision(project *os.File) error {
+	var stat unix.Stat_t
+	err := unix.Fstatat(int(project.Fd()), rollbackDirectory, &stat, unix.AT_SYMLINK_NOFOLLOW)
+	if err == nil {
+		return refuse(CodeRollbackCollision, false, nil)
+	}
+	if errors.Is(err, unix.ENOENT) {
+		return nil
+	}
+	return refuse(CodeSourceUnverifiable, true, err)
+}
+
+func readStableBounded(file *os.File, expected unix.Stat_t, limit int64) ([]byte, error) {
+	if expected.Size < 0 || expected.Size > limit {
+		var after unix.Stat_t
+		if err := unix.Fstat(int(file.Fd()), &after); err != nil {
+			return nil, err
+		}
+		if !sameStat(expected, after) {
+			return nil, errWitnessChanged
+		}
+		return nil, errWitnessOutsideBound
+	}
+	data, err := io.ReadAll(io.NewSectionReader(file, 0, limit+1))
+	if err != nil {
+		return nil, err
+	}
+	var after unix.Stat_t
+	if err := unix.Fstat(int(file.Fd()), &after); err != nil {
+		return nil, err
+	}
+	if !sameStat(expected, after) || int64(len(data)) != after.Size {
+		return nil, errWitnessChanged
+	}
+	if int64(len(data)) > limit {
+		return nil, errWitnessOutsideBound
+	}
+	return data, nil
+}
+
+func classifyWitnessReadFailure(err error) error {
+	if errors.Is(err, errWitnessChanged) {
+		return refuse(CodeSourceChanged, true, err)
+	}
+	return refuse(CodeSourceUnverifiable, true, err)
+}
+
+func parseMetadata(data []byte) (metadataShape, error) {
+	values, err := decodeUniqueObject(data)
+	if err != nil {
+		return metadataShape{}, err
+	}
+	backend, ok := requiredString(values, "backend")
+	if !ok || backend != "dolt" {
+		return metadataShape{}, errors.New("backend")
+	}
+	databaseKind, ok := requiredString(values, "database")
+	if !ok || databaseKind != "dolt" {
+		return metadataShape{}, errors.New("database")
+	}
+	mode, ok := requiredString(values, "dolt_mode")
+	if !ok || mode != "server" {
+		return metadataShape{}, errors.New("dolt_mode")
+	}
+	if _, present := values["dolt_server_host"]; present {
+		host, ok := requiredString(values, "dolt_server_host")
+		if !ok || host != "127.0.0.1" {
+			return metadataShape{}, errors.New("dolt_server_host")
+		}
+	}
+	database, ok := requiredString(values, "dolt_database")
+	if !ok || !databaseNamePattern.MatchString(database) {
+		return metadataShape{}, errors.New("dolt_database")
+	}
+	projectID, ok := requiredString(values, "project_id")
+	if !ok || !projectIDPattern.MatchString(projectID) {
+		return metadataShape{}, errors.New("project_id")
+	}
+	if _, present := values["dolt_server_port"]; present {
+		port, ok := requiredInteger(values, "dolt_server_port")
+		if !ok || port < 1 || port > 65535 {
+			return metadataShape{}, errors.New("dolt_server_port")
+		}
+	}
+	for key, raw := range values {
+		if _, allowed := allowedV062MetadataFields[key]; !allowed {
+			return metadataShape{}, errors.New("unknown v0.62 metadata field")
+		}
+		lower := strings.ToLower(key)
+		if strings.HasPrefix(lower, "postgres") || strings.HasPrefix(lower, "mysql") ||
+			strings.HasPrefix(lower, "sqlite") || strings.HasPrefix(lower, "proxied") {
+			return metadataShape{}, errors.New("foreign provider metadata")
+		}
+		if key == "dolt_data_dir" || key == "dolt_server_socket" {
+			var value string
+			if err := json.Unmarshal(raw, &value); err != nil || value != "" {
+				return metadataShape{}, errors.New("custom server path")
+			}
+		}
+	}
+	return metadataShape{database: database}, nil
+}
+
+func decodeUniqueObject(data []byte) (map[string]json.RawMessage, error) {
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	token, err := decoder.Token()
+	if err != nil || token != json.Delim('{') {
+		return nil, errors.New("metadata is not an object")
+	}
+	values := make(map[string]json.RawMessage)
+	for decoder.More() {
+		token, err := decoder.Token()
+		if err != nil {
+			return nil, err
+		}
+		key, ok := token.(string)
+		if !ok {
+			return nil, errors.New("metadata key is not a string")
+		}
+		if _, duplicate := values[key]; duplicate {
+			return nil, errors.New("duplicate metadata key")
+		}
+		var raw json.RawMessage
+		if err := decoder.Decode(&raw); err != nil {
+			return nil, err
+		}
+		values[key] = raw
+	}
+	if token, err = decoder.Token(); err != nil || token != json.Delim('}') {
+		return nil, errors.New("unterminated metadata object")
+	}
+	if token, err = decoder.Token(); !errors.Is(err, io.EOF) || token != nil {
+		return nil, errors.New("trailing metadata content")
+	}
+	return values, nil
+}
+
+func requiredString(values map[string]json.RawMessage, key string) (string, bool) {
+	raw, ok := values[key]
+	if !ok {
+		return "", false
+	}
+	var value string
+	if err := json.Unmarshal(raw, &value); err != nil {
+		return "", false
+	}
+	return value, true
+}
+
+func requiredInteger(values map[string]json.RawMessage, key string) (int64, bool) {
+	raw, ok := values[key]
+	if !ok {
+		return 0, false
+	}
+	value, err := strconv.ParseInt(string(raw), 10, 64)
+	return value, err == nil
+}
+
+func (fs sourceFS) inspectTree(root *os.File, rootStat unix.Stat_t, includeContent bool) (treeSnapshot, error) {
+	rootCopy, opened, err := fs.openDirectoryAt(root, ".")
+	if err != nil {
+		return treeSnapshot{}, classifyTreeOpen(err)
+	}
+	if !sameStat(rootStat, opened) {
+		_ = rootCopy.Close()
+		return treeSnapshot{}, refuse(CodeSourceChanged, true, nil)
+	}
+	treeHash := sha256.New()
+	structureHash := sha256.New()
+	kinds := make(map[string]byte)
+	writeTreeRecord(treeHash, 'd', ".", opened, nil)
+	writeStructureRecord(structureHash, 'd', ".", opened)
+	inspectErr := fs.inspectDirectory(rootCopy, "", includeContent, treeHash, structureHash, kinds)
+	closeErr := rootCopy.Close()
+	if inspectErr != nil {
+		return treeSnapshot{}, inspectErr
+	}
+	if closeErr != nil {
+		return treeSnapshot{}, refuse(CodeSourceUnverifiable, true, closeErr)
+	}
+	return treeSnapshot{
+		treeSHA256:      hex.EncodeToString(treeHash.Sum(nil)),
+		structureSHA256: hex.EncodeToString(structureHash.Sum(nil)),
+		kinds:           kinds,
+	}, nil
+}
+
+func (fs sourceFS) inspectDirectory(dir *os.File, relative string, includeContent bool, treeHash, structureHash hash.Hash, kinds map[string]byte) error {
+	names, err := dir.Readdirnames(-1)
+	if err != nil {
+		return refuse(CodeSourceUnverifiable, true, err)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		path := name
+		if relative != "" {
+			path = relative + "/" + name
+		}
+		var named unix.Stat_t
+		if err := unix.Fstatat(int(dir.Fd()), name, &named, unix.AT_SYMLINK_NOFOLLOW); err != nil {
+			if errors.Is(err, unix.ENOENT) || errors.Is(err, unix.ESTALE) {
+				return refuse(CodeSourceChanged, true, err)
+			}
+			return refuse(CodeSourceUnverifiable, true, err)
+		}
+		if err := checkDevice(named.Dev, fs.device); err != nil {
+			return err
+		}
+		if err := fs.checkMountAt(int(dir.Fd()), name, unix.AT_SYMLINK_NOFOLLOW); err != nil {
+			return err
+		}
+		switch named.Mode & unix.S_IFMT {
+		case unix.S_IFLNK:
+			return refuse(CodeUnsafeSourceSymlink, false, nil)
+		case unix.S_IFDIR:
+			child, opened, err := fs.openDirectoryAt(dir, name)
+			if err != nil {
+				return classifyTreeOpen(err)
+			}
+			kinds[path] = 'd'
+			writeTreeRecord(treeHash, 'd', path, opened, nil)
+			writeStructureRecord(structureHash, 'd', path, opened)
+			err = fs.inspectDirectory(child, path, includeContent, treeHash, structureHash, kinds)
+			closeErr := child.Close()
+			if err != nil {
+				return err
+			}
+			if closeErr != nil {
+				return refuse(CodeSourceUnverifiable, true, closeErr)
+			}
+		case unix.S_IFREG:
+			if named.Nlink != 1 {
+				return refuse(CodeUnsafeSourceHardlink, false, nil)
+			}
+			file, opened, err := fs.openRegularTreeFile(dir, name, named)
+			if err != nil {
+				return err
+			}
+			var contentDigest []byte
+			if includeContent {
+				contentHash := sha256.New()
+				if _, err := io.Copy(contentHash, file); err != nil {
+					_ = file.Close()
+					return refuse(CodeSourceUnverifiable, true, err)
+				}
+				contentDigest = contentHash.Sum(nil)
+			}
+			var after unix.Stat_t
+			statErr := unix.Fstat(int(file.Fd()), &after)
+			closeErr := file.Close()
+			if statErr != nil {
+				return refuse(CodeSourceUnverifiable, true, statErr)
+			}
+			if !sameStat(opened, after) {
+				return refuse(CodeSourceChanged, true, nil)
+			}
+			if closeErr != nil {
+				return refuse(CodeSourceUnverifiable, true, closeErr)
+			}
+			kinds[path] = 'f'
+			if includeContent {
+				writeTreeRecord(treeHash, 'f', path, opened, contentDigest)
+			}
+			writeStructureRecord(structureHash, 'f', path, opened)
+		default:
+			return refuse(CodeUnsafeSourceObject, false, nil)
+		}
+	}
+	return nil
+}
+
+func (fs sourceFS) openRegularTreeFile(parent *os.File, name string, named unix.Stat_t) (*os.File, unix.Stat_t, error) {
+	fd, err := unix.Openat(int(parent.Fd()), name, regularFileOpenFlags, 0)
+	if err != nil {
+		return nil, unix.Stat_t{}, classifyTreeOpen(err)
+	}
+	file := os.NewFile(uintptr(fd), name)
+	if file == nil {
+		_ = unix.Close(fd)
+		return nil, unix.Stat_t{}, refuse(CodeSourceUnverifiable, true, nil)
+	}
+	var opened unix.Stat_t
+	if err := unix.Fstat(fd, &opened); err != nil {
+		_ = file.Close()
+		return nil, unix.Stat_t{}, refuse(CodeSourceUnverifiable, true, err)
+	}
+	if err := checkDevice(opened.Dev, fs.device); err != nil {
+		_ = file.Close()
+		return nil, unix.Stat_t{}, err
+	}
+	if err := fs.checkMountAt(fd, "", unix.AT_EMPTY_PATH|unix.AT_SYMLINK_NOFOLLOW); err != nil {
+		_ = file.Close()
+		return nil, unix.Stat_t{}, err
+	}
+	if opened.Mode&unix.S_IFMT != unix.S_IFREG || opened.Nlink != 1 {
+		_ = file.Close()
+		return nil, unix.Stat_t{}, refuse(CodeUnsafeSourceObject, false, nil)
+	}
+	if !sameStat(named, opened) {
+		_ = file.Close()
+		return nil, unix.Stat_t{}, refuse(CodeSourceChanged, true, nil)
+	}
+	return file, opened, nil
+}
+
+func classifyTreeOpen(err error) error {
+	if _, ok := AsRefusal(err); ok {
+		return err
+	}
+	switch {
+	case errors.Is(err, unix.ELOOP):
+		return refuse(CodeUnsafeSourceSymlink, false, err)
+	case errors.Is(err, unix.EXDEV):
+		return refuse(CodeCrossDeviceSource, false, err)
+	case errors.Is(err, unix.ENOENT), errors.Is(err, unix.ESTALE):
+		return refuse(CodeSourceChanged, true, err)
+	default:
+		return refuse(CodeSourceUnverifiable, true, err)
+	}
+}
+
+func checkDevice(actual, expected uint64) error {
+	if actual != expected {
+		return refuse(CodeCrossDeviceSource, false, nil)
+	}
+	return nil
+}
+
+func validateRequiredLayout(kinds map[string]byte, database string) error {
+	for _, mixed := range []string{"embeddeddolt", "beads.db", "proxieddb", "sqlite.db"} {
+		if _, exists := kinds[mixed]; exists {
+			return refuse(CodeMixedStorageLayout, false, nil)
+		}
+	}
+	for path, kind := range kinds {
+		if kind == 'f' && isRootSQLiteArtifact(path) {
+			return refuse(CodeMixedStorageLayout, false, nil)
+		}
+		parts := strings.Split(path, "/")
+		if kind == 'd' && len(parts) == 3 && parts[0] == "dolt" && parts[2] == ".dolt" && parts[1] != database {
+			// An immediate dolt/<name>/.dolt is another database root. Nested
+			// stats repositories such as dolt/.dolt/stats/.dolt and
+			// dolt/<database>/.dolt/stats/.dolt are authentic Dolt layout.
+			return refuse(CodeMixedStorageLayout, false, nil)
+		}
+	}
+	required := map[string]byte{
+		".local_version":                              'f',
+		"metadata.json":                               'f',
+		"dolt":                                        'd',
+		"dolt/config.yaml":                            'f',
+		"dolt/.dolt":                                  'd',
+		"dolt/.dolt/config.json":                      'f',
+		"dolt/.dolt/repo_state.json":                  'f',
+		"dolt/" + database:                            'd',
+		"dolt/" + database + "/.dolt":                 'd',
+		"dolt/" + database + "/.dolt/config.json":     'f',
+		"dolt/" + database + "/.dolt/repo_state.json": 'f',
+	}
+	for path, kind := range required {
+		if kinds[path] != kind {
+			return refuse(CodeSourceLayoutMissing, false, nil)
+		}
+	}
+	return nil
+}
+
+func isRootSQLiteArtifact(path string) bool {
+	if strings.Contains(path, "/") {
+		return false
+	}
+	name := strings.ToLower(path)
+	for _, ancillary := range []string{
+		"ephemeral.sqlite3",
+		"ephemeral.sqlite3-journal",
+		"ephemeral.sqlite3-wal",
+		"ephemeral.sqlite3-shm",
+	} {
+		if name == ancillary {
+			return false
+		}
+	}
+	for _, suffix := range []string{
+		".db", ".db-journal", ".db-wal", ".db-shm",
+		".sqlite", ".sqlite-journal", ".sqlite-wal", ".sqlite-shm",
+		".sqlite3", ".sqlite3-journal", ".sqlite3-wal", ".sqlite3-shm",
+	} {
+		if strings.HasSuffix(name, suffix) {
+			return true
+		}
+	}
+	return strings.Contains(name, ".db?")
+}
+
+func (fs sourceFS) revalidateSource(projectPath string, project *os.File, projectStat unix.Stat_t, beads *os.File, beadsStat unix.Stat_t, version *os.File, versionStat unix.Stat_t, metadata *os.File, metadataStat unix.Stat_t, expectedVersion, expectedMetadata []byte) error {
+	for _, item := range []struct {
+		file *os.File
+		want unix.Stat_t
+	}{
+		{project, projectStat},
+		{beads, beadsStat},
+		{version, versionStat},
+		{metadata, metadataStat},
+	} {
+		var current unix.Stat_t
+		if err := unix.Fstat(int(item.file.Fd()), &current); err != nil {
+			return refuse(CodeSourceUnverifiable, true, err)
+		}
+		if !sameStat(item.want, current) {
+			return refuse(CodeSourceChanged, true, nil)
+		}
+		if err := checkDevice(current.Dev, fs.device); err != nil {
+			return err
+		}
+		if err := fs.checkMountAt(int(item.file.Fd()), "", unix.AT_EMPTY_PATH|unix.AT_SYMLINK_NOFOLLOW); err != nil {
+			return err
+		}
+	}
+	if err := fs.entryStillNames(project, ".beads", beadsStat); err != nil {
+		return err
+	}
+	if err := fs.entryStillNames(beads, ".local_version", versionStat); err != nil {
+		return err
+	}
+	if err := fs.entryStillNames(beads, "metadata.json", metadataStat); err != nil {
+		return err
+	}
+	versionBytes, err := readStableBounded(version, versionStat, maxVersionBytes)
+	if err != nil {
+		return classifyWitnessReadFailure(err)
+	}
+	if !bytes.Equal(versionBytes, expectedVersion) {
+		return refuse(CodeSourceChanged, true, nil)
+	}
+	metadataBytes, err := readStableBounded(metadata, metadataStat, maxMetadataBytes)
+	if err != nil {
+		return classifyWitnessReadFailure(err)
+	}
+	if !bytes.Equal(metadataBytes, expectedMetadata) {
+		return refuse(CodeSourceChanged, true, nil)
+	}
+	canonical, err := os.Readlink(fmt.Sprintf("/proc/self/fd/%d", project.Fd()))
+	if err != nil {
+		return refuse(CodeSourceUnverifiable, true, err)
+	}
+	if canonical != projectPath {
+		return refuse(CodeSourceChanged, true, nil)
+	}
+	reopened, reopenedStat, reopenedMountID, err := openProject(projectPath, fs.readMountID)
+	if err != nil {
+		if refusal, ok := AsRefusal(err); ok && refusal.Code == CodeSourceUnverifiable {
+			return err
+		}
+		return refuse(CodeSourceChanged, true, err)
+	}
+	closeErr := reopened.Close()
+	if !sameStat(projectStat, reopenedStat) {
+		return refuse(CodeSourceChanged, true, nil)
+	}
+	if err := checkMountID(reopenedMountID, fs.mountID); err != nil {
+		return err
+	}
+	if closeErr != nil {
+		return refuse(CodeSourceUnverifiable, true, closeErr)
+	}
+	return nil
+}
+
+func (fs sourceFS) entryStillNames(parent *os.File, name string, expected unix.Stat_t) error {
+	var current unix.Stat_t
+	if err := unix.Fstatat(int(parent.Fd()), name, &current, unix.AT_SYMLINK_NOFOLLOW); err != nil {
+		if errors.Is(err, unix.ENOENT) || errors.Is(err, unix.ESTALE) {
+			return refuse(CodeSourceChanged, true, err)
+		}
+		return refuse(CodeSourceUnverifiable, true, err)
+	}
+	if !sameStat(expected, current) {
+		return refuse(CodeSourceChanged, true, nil)
+	}
+	if err := checkDevice(current.Dev, fs.device); err != nil {
+		return err
+	}
+	if err := fs.checkMountAt(int(parent.Fd()), name, unix.AT_SYMLINK_NOFOLLOW); err != nil {
+		return err
+	}
+	return nil
+}
+
+func sameStat(left, right unix.Stat_t) bool {
+	return left.Dev == right.Dev && left.Ino == right.Ino && left.Mode == right.Mode &&
+		left.Nlink == right.Nlink && left.Rdev == right.Rdev && left.Size == right.Size &&
+		left.Mtim == right.Mtim && left.Ctim == right.Ctim
+}
+
+func writeTreeRecord(writer hash.Hash, kind byte, path string, stat unix.Stat_t, contentDigest []byte) {
+	writeField(writer, []byte{kind})
+	writeField(writer, []byte(path))
+	var numeric [16]byte
+	binary.BigEndian.PutUint64(numeric[:8], uint64(stat.Mode&0o7777))
+	if kind == 'f' {
+		binary.BigEndian.PutUint64(numeric[8:], uint64(stat.Size))
+	}
+	writeField(writer, numeric[:])
+	writeField(writer, contentDigest)
+}
+
+func writeStructureRecord(writer hash.Hash, kind byte, path string, stat unix.Stat_t) {
+	writeField(writer, []byte{kind})
+	writeField(writer, []byte(path))
+	values := []uint64{
+		stat.Dev, stat.Ino, uint64(stat.Mode), stat.Nlink, stat.Rdev, uint64(stat.Size),
+		uint64(stat.Mtim.Sec), uint64(stat.Mtim.Nsec), uint64(stat.Ctim.Sec), uint64(stat.Ctim.Nsec),
+	}
+	var numeric [8]byte
+	for _, value := range values {
+		binary.BigEndian.PutUint64(numeric[:], value)
+		writeField(writer, numeric[:])
+	}
+}
+
+func writeField(writer hash.Hash, value []byte) {
+	var size [8]byte
+	binary.BigEndian.PutUint64(size[:], uint64(len(value)))
+	_, _ = writer.Write(size[:])
+	_, _ = writer.Write(value)
+}
+
+func closeForInspection(result *Result, returnErr *error, file *os.File) {
+	if file == nil {
+		return
+	}
+	if err := file.Close(); err != nil {
+		*result = Result{}
+		*returnErr = refuse(CodeSourceUnverifiable, true, err)
+	}
+}

--- a/internal/v062migration/inspect_linux_nocgo_test.go
+++ b/internal/v062migration/inspect_linux_nocgo_test.go
@@ -1,0 +1,16 @@
+//go:build linux && !cgo
+
+package v062migration
+
+import "testing"
+
+func TestInspectWithoutCGORefusesBeforeSourceAccess(t *testing.T) {
+	_, err := Inspect("/definitely/not/a/source", "1.1.0")
+	refusal, ok := AsRefusal(err)
+	if !ok {
+		t.Fatalf("Inspect() error = %T %v, want Refusal", err, err)
+	}
+	if refusal.Code != CodeEmbeddedTargetUnavailable || refusal.Retryable || refusal.Effect != EffectNone {
+		t.Fatalf("refusal = %#v", refusal)
+	}
+}

--- a/internal/v062migration/inspect_linux_test.go
+++ b/internal/v062migration/inspect_linux_test.go
@@ -1,0 +1,689 @@
+//go:build linux && cgo
+
+package v062migration
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+func TestInspectQualifiesExactV062ServerTreeWithoutMutation(t *testing.T) {
+	project := newV062Project(t)
+	before := snapshotTree(t, project)
+
+	result, err := Inspect(project, "1.1.0")
+	if err != nil {
+		t.Fatalf("Inspect() error = %v", err)
+	}
+	if result.SchemaVersion != 1 || result.Operation != Operation || result.Status != StatusQualified {
+		t.Fatalf("unexpected envelope: %#v", result)
+	}
+	if result.Retryable || result.Effect != EffectNone {
+		t.Fatalf("qualified retryable/effect = %v/%q", result.Retryable, result.Effect)
+	}
+	if result.Source.Workspace != project || result.Source.Version != "0.62.0" || result.Source.Backend != "dolt-server" {
+		t.Fatalf("unexpected source: %#v", result.Source)
+	}
+	if result.Source.DigestScope != DigestScopeAdmissionObservation {
+		t.Fatalf("digest scope = %q, want %q", result.Source.DigestScope, DigestScopeAdmissionObservation)
+	}
+	if len(result.Source.TreeSHA256) != 64 {
+		t.Fatalf("tree digest = %q", result.Source.TreeSHA256)
+	}
+	if result.Target.Version != "1.1.0" || result.Target.Backend != "dolt-embedded" || !result.Target.EmbeddedCapable {
+		t.Fatalf("unexpected target: %#v", result.Target)
+	}
+	if after := snapshotTree(t, project); after != before {
+		t.Fatalf("inspection mutated source tree\nbefore: %s\nafter:  %s", before, after)
+	}
+}
+
+func TestInspectAdmitsAuthenticV062DoltAncillaryLayout(t *testing.T) {
+	project := newV062Project(t)
+	for _, dir := range []string{
+		filepath.Join(project, ".beads", "dolt", ".doltcfg"),
+		filepath.Join(project, ".beads", "dolt", ".dolt", "stats", ".dolt"),
+		filepath.Join(project, ".beads", "dolt", "smoke", ".dolt", "stats", ".dolt"),
+	} {
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for path, content := range map[string]string{
+		filepath.Join(project, ".beads", ".gitignore"):                                              "dolt/\n*.db\n",
+		filepath.Join(project, ".beads", ".beads-credential-key"):                                   "fixture-key\n",
+		filepath.Join(project, ".beads", "config.yaml"):                                             "dolt:\n  auto-start: true\n",
+		filepath.Join(project, ".beads", "dolt-server.port"):                                        "3307\n",
+		filepath.Join(project, ".beads", "ephemeral.sqlite3"):                                       "known v0.62 ephemeral store\n",
+		filepath.Join(project, ".beads", "interactions.jsonl"):                                      "",
+		filepath.Join(project, ".beads", "last-touched"):                                            "0\n",
+		filepath.Join(project, ".beads", "dolt", ".doltcfg", "privileges.db"):                       "dolt-owned ancillary database\n",
+		filepath.Join(project, ".beads", "dolt", ".dolt", "stats", ".dolt", "config.json"):          "{}\n",
+		filepath.Join(project, ".beads", "dolt", ".dolt", "stats", ".dolt", "repo_state.json"):      "{\"head\":\"refs/heads/main\"}\n",
+		filepath.Join(project, ".beads", "dolt", "smoke", ".dolt", "stats", ".dolt", "config.json"): "{}\n",
+	} {
+		mustWrite(t, path, content)
+	}
+
+	if _, err := Inspect(project, "1.1.0"); err != nil {
+		t.Fatalf("Inspect() rejected authentic v0.62 ancillary layout: %v", err)
+	}
+}
+
+func TestInspectAdmitsDefaultV062MetadataWithoutPersistedServerEndpoint(t *testing.T) {
+	project := newV062Project(t)
+	mustWrite(t, filepath.Join(project, ".beads", "metadata.json"), `{
+  "database": "dolt",
+  "backend": "dolt",
+  "dolt_mode": "server",
+  "dolt_database": "smoke",
+  "project_id": "7ef372b4-4c3c-4e2c-a6cc-29dd2d0a28c6"
+}
+`)
+	before := snapshotTree(t, project)
+
+	if _, err := Inspect(project, "1.1.0"); err != nil {
+		t.Fatalf("Inspect() rejected default v0.62 metadata: %v", err)
+	}
+	if after := snapshotTree(t, project); after != before {
+		t.Fatalf("inspection mutated source tree\nbefore: %s\nafter:  %s", before, after)
+	}
+}
+
+func TestInspectTreeDigestChangesWithRegularFileContent(t *testing.T) {
+	first := newV062Project(t)
+	second := newV062Project(t)
+	if err := os.WriteFile(filepath.Join(second, ".beads", "dolt", "smoke", ".dolt", "repo_state.json"), []byte("{\"head\":\"other\"}\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	left, err := Inspect(first, "1.1.0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	right, err := Inspect(second, "1.1.0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if left.Source.TreeSHA256 == right.Source.TreeSHA256 {
+		t.Fatalf("different trees produced digest %q", left.Source.TreeSHA256)
+	}
+}
+
+func TestInspectTreeDigestIsStableAcrossRepeatedAndEquivalentTrees(t *testing.T) {
+	first := newV062Project(t)
+	second := newV062Project(t)
+
+	firstResult, err := Inspect(first, "1.1.0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	repeatedResult, err := Inspect(first, "1.1.0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	secondResult, err := Inspect(second, "1.1.0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if firstResult.Source.TreeSHA256 != repeatedResult.Source.TreeSHA256 {
+		t.Fatalf("repeated inspection changed digest: %q != %q", firstResult.Source.TreeSHA256, repeatedResult.Source.TreeSHA256)
+	}
+	if firstResult.Source.TreeSHA256 != secondResult.Source.TreeSHA256 {
+		t.Fatalf("equivalent trees changed digest: %q != %q", firstResult.Source.TreeSHA256, secondResult.Source.TreeSHA256)
+	}
+}
+
+func TestInspectRefusesUnsafeAndMixedSourceShapes(t *testing.T) {
+	tests := []struct {
+		name string
+		want Code
+		edit func(*testing.T, string)
+	}{
+		{
+			name: "version missing",
+			want: CodeSourceVersionMissing,
+			edit: func(t *testing.T, project string) {
+				t.Helper()
+				if err := os.Remove(filepath.Join(project, ".beads", ".local_version")); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			name: "version mismatch",
+			want: CodeSourceVersionMismatch,
+			edit: func(t *testing.T, project string) {
+				t.Helper()
+				mustWrite(t, filepath.Join(project, ".beads", ".local_version"), "0.61.0\n")
+			},
+		},
+		{
+			name: "version symlink",
+			want: CodeSourceVersionAmbiguous,
+			edit: func(t *testing.T, project string) {
+				t.Helper()
+				version := filepath.Join(project, ".beads", ".local_version")
+				if err := os.Rename(version, version+".real"); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.Symlink(".local_version.real", version); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			name: "version fifo is an unsafe object, not an ambiguous symlink",
+			want: CodeUnsafeSourceObject,
+			edit: func(t *testing.T, project string) {
+				t.Helper()
+				version := filepath.Join(project, ".beads", ".local_version")
+				if err := os.Remove(version); err != nil {
+					t.Fatal(err)
+				}
+				if err := unix.Mkfifo(version, 0o600); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			name: "metadata mismatch",
+			want: CodeSourceMetadataMismatch,
+			edit: func(t *testing.T, project string) {
+				t.Helper()
+				setV062MetadataField(t, project, "backend", "postgres")
+			},
+		},
+		{
+			name: "current global Dolt database selector",
+			want: CodeSourceMetadataMismatch,
+			edit: func(t *testing.T, project string) {
+				t.Helper()
+				setV062MetadataField(t, project, "global_dolt_database", "other")
+			},
+		},
+		{
+			name: "current global project selector",
+			want: CodeSourceMetadataMismatch,
+			edit: func(t *testing.T, project string) {
+				t.Helper()
+				setV062MetadataField(t, project, "global_project_id", "other")
+			},
+		},
+		{
+			name: "metadata symlink",
+			want: CodeUnsafeSourceSymlink,
+			edit: func(t *testing.T, project string) {
+				t.Helper()
+				metadata := filepath.Join(project, ".beads", "metadata.json")
+				if err := os.Rename(metadata, metadata+".real"); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.Symlink("metadata.json.real", metadata); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			name: "metadata fifo is an unsafe object, not a symlink",
+			want: CodeUnsafeSourceObject,
+			edit: func(t *testing.T, project string) {
+				t.Helper()
+				metadata := filepath.Join(project, ".beads", "metadata.json")
+				if err := os.Remove(metadata); err != nil {
+					t.Fatal(err)
+				}
+				if err := unix.Mkfifo(metadata, 0o600); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			name: "symlinked dolt root",
+			want: CodeUnsafeSourceSymlink,
+			edit: func(t *testing.T, project string) {
+				t.Helper()
+				dolt := filepath.Join(project, ".beads", "dolt")
+				if err := os.Rename(dolt, dolt+".real"); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.Symlink("dolt.real", dolt); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			name: "mixed provider",
+			want: CodeMixedStorageLayout,
+			edit: func(t *testing.T, project string) {
+				t.Helper()
+				if err := os.Mkdir(filepath.Join(project, ".beads", "embeddeddolt"), 0o700); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			name: "arbitrary root db artifact",
+			want: CodeMixedStorageLayout,
+			edit: func(t *testing.T, project string) {
+				t.Helper()
+				mustWrite(t, filepath.Join(project, ".beads", "unrecognized.DB"), "sqlite-like bytes")
+			},
+		},
+		{
+			name: "arbitrary root sqlite artifact",
+			want: CodeMixedStorageLayout,
+			edit: func(t *testing.T, project string) {
+				t.Helper()
+				mustWrite(t, filepath.Join(project, ".beads", "unrecognized.sqlite3"), "sqlite-like bytes")
+			},
+		},
+		{
+			name: "unexpected additional dolt database root",
+			want: CodeMixedStorageLayout,
+			edit: func(t *testing.T, project string) {
+				t.Helper()
+				other := filepath.Join(project, ".beads", "dolt", "other", ".dolt")
+				if err := os.MkdirAll(other, 0o700); err != nil {
+					t.Fatal(err)
+				}
+				mustWrite(t, filepath.Join(other, "config.json"), "{}\n")
+				mustWrite(t, filepath.Join(other, "repo_state.json"), "{\"head\":\"refs/heads/main\"}\n")
+			},
+		},
+		{
+			name: "rollback collision",
+			want: CodeRollbackCollision,
+			edit: func(t *testing.T, project string) {
+				t.Helper()
+				if err := os.Mkdir(filepath.Join(project, ".beads-v0.62.0-rollback"), 0o700); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			name: "hard link",
+			want: CodeUnsafeSourceHardlink,
+			edit: func(t *testing.T, project string) {
+				t.Helper()
+				source := filepath.Join(project, ".beads", "dolt", "config.yaml")
+				if err := os.Link(source, filepath.Join(project, ".beads", "hardlink")); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			name: "fifo",
+			want: CodeUnsafeSourceObject,
+			edit: func(t *testing.T, project string) {
+				t.Helper()
+				if err := unix.Mkfifo(filepath.Join(project, ".beads", "pipe"), 0o600); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			project := newV062Project(t)
+			tt.edit(t, project)
+			before := snapshotTree(t, project)
+			_, err := Inspect(project, "1.1.0")
+			assertRefusalCode(t, err, tt.want)
+			if after := snapshotTree(t, project); after != before {
+				t.Fatalf("refusal mutated source tree")
+			}
+		})
+	}
+}
+
+func TestInspectClassifiesStableOversizedWitnessesAsNonRetryableMismatch(t *testing.T) {
+	tests := []struct {
+		name    string
+		path    string
+		content string
+		want    Code
+	}{
+		{
+			name:    "version",
+			path:    ".local_version",
+			content: strings.Repeat("0", maxVersionBytes+1),
+			want:    CodeSourceVersionMismatch,
+		},
+		{
+			name:    "metadata",
+			path:    "metadata.json",
+			content: strings.Repeat("{", maxMetadataBytes+1),
+			want:    CodeSourceMetadataMismatch,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			project := newV062Project(t)
+			mustWrite(t, filepath.Join(project, ".beads", tt.path), tt.content)
+			_, err := Inspect(project, "1.1.0")
+			refusal, ok := AsRefusal(err)
+			if !ok {
+				t.Fatalf("Inspect() error = %T %v, want Refusal", err, err)
+			}
+			if refusal.Code != tt.want || refusal.Retryable || refusal.Effect != EffectNone {
+				t.Fatalf("refusal = %#v, want code %q/nonretryable/effect none", refusal, tt.want)
+			}
+		})
+	}
+}
+
+func TestWitnessReadFailureClassificationDistinguishesDriftFromUnverifiableIO(t *testing.T) {
+	changed, ok := AsRefusal(classifyWitnessReadFailure(errWitnessChanged))
+	if !ok || changed.Code != CodeSourceChanged || !changed.Retryable || changed.Effect != EffectNone {
+		t.Fatalf("changed witness classified as %#v", changed)
+	}
+	unverifiable, ok := AsRefusal(classifyWitnessReadFailure(unix.EIO))
+	if !ok || unverifiable.Code != CodeSourceUnverifiable || !unverifiable.Retryable || unverifiable.Effect != EffectNone {
+		t.Fatalf("witness I/O failure classified as %#v", unverifiable)
+	}
+}
+
+func TestInspectRequiresAbsoluteCanonicalProject(t *testing.T) {
+	project := newV062Project(t)
+	_, err := Inspect(project+string(os.PathSeparator)+".", "1.1.0")
+	assertRefusalCode(t, err, CodeWorkspaceNotCanonical)
+
+	_, err = Inspect("relative/project", "1.1.0")
+	assertRefusalCode(t, err, CodeWorkspaceInvalid)
+}
+
+func TestInspectRefusesInjectedCrossDeviceObservation(t *testing.T) {
+	err := checkDevice(2, 1)
+	assertRefusalCode(t, err, CodeCrossDeviceSource)
+}
+
+func TestInspectRefusesDifferentNamedAndOpenedMountIdentityInsideTree(t *testing.T) {
+	tests := []struct {
+		name   string
+		target func(int, string) bool
+	}{
+		{
+			name: "named entry",
+			target: func(dirfd int, path string) bool {
+				return path == "repo_state.json" && descriptorPathHasSuffix(dirfd, "/dolt/smoke/.dolt")
+			},
+		},
+		{
+			name: "opened descriptor after safe named lookup",
+			target: func(dirfd int, path string) bool {
+				return path == "" && descriptorPathHasSuffix(dirfd, "/dolt/smoke/.dolt/repo_state.json")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			project := newV062Project(t)
+			injected := false
+			_, err := inspectWithHooks(project, "1.1.0", inspectHooks{
+				mountIDAt: func(dirfd int, path string, flags int) (uint64, error) {
+					mountID, readErr := readMountIDAt(dirfd, path, flags)
+					if readErr != nil {
+						return 0, readErr
+					}
+					if tt.target(dirfd, path) {
+						injected = true
+						return mountID + 1, nil
+					}
+					return mountID, nil
+				},
+			})
+			if !injected {
+				t.Fatal("mount identity seam did not observe the nested Dolt witness")
+			}
+			assertRefusalCode(t, err, CodeCrossDeviceSource)
+		})
+	}
+}
+
+func TestInspectFailsClosedWhenMountIdentityCannotBeRead(t *testing.T) {
+	project := newV062Project(t)
+	injected := false
+	_, err := inspectWithHooks(project, "1.1.0", inspectHooks{
+		mountIDAt: func(dirfd int, path string, flags int) (uint64, error) {
+			if path == "config.yaml" && descriptorPathHasSuffix(dirfd, "/.beads/dolt") {
+				injected = true
+				return 0, unix.ENOSYS
+			}
+			return readMountIDAt(dirfd, path, flags)
+		},
+	})
+	if !injected {
+		t.Fatal("mount identity seam did not observe the nested config")
+	}
+	refusal, ok := AsRefusal(err)
+	if !ok || refusal.Code != CodeSourceUnverifiable || !refusal.Retryable || refusal.Effect != EffectNone {
+		t.Fatalf("refusal = %#v (%v), want source_unverifiable/retryable/effect none", refusal, err)
+	}
+}
+
+func TestProjectNoAtimePermissionFailureIsUnverifiableWithoutRetryOpen(t *testing.T) {
+	for _, openErr := range []error{unix.EPERM, unix.EACCES} {
+		attempts := 0
+		_, _, _, err := openProjectWith("/absolute/project", readMountIDAt, func(_ string, flags int, _ uint32) (int, error) {
+			attempts++
+			if flags&unix.O_NOATIME == 0 {
+				t.Fatalf("open flags %#x omitted O_NOATIME", flags)
+			}
+			return -1, openErr
+		})
+		if attempts != 1 {
+			t.Fatalf("open attempts = %d, want exactly one O_NOATIME attempt", attempts)
+		}
+		refusal, ok := AsRefusal(err)
+		if !ok || refusal.Code != CodeSourceUnverifiable || !refusal.Retryable || refusal.Effect != EffectNone {
+			t.Fatalf("open error %v classified as %#v (%v)", openErr, refusal, err)
+		}
+	}
+}
+
+func TestAdmissionObservationsCompareBothStructureAndContent(t *testing.T) {
+	first := treeSnapshot{treeSHA256: "first-content", structureSHA256: "same-structure"}
+	second := treeSnapshot{treeSHA256: "second-content", structureSHA256: "same-structure"}
+	if sameAdmissionObservation(first, second) {
+		t.Fatal("equal structure with different content digest was accepted")
+	}
+	second.treeSHA256 = first.treeSHA256
+	if !sameAdmissionObservation(first, second) {
+		t.Fatal("identical admission observations were rejected")
+	}
+}
+
+func TestInspectRefusesDeterministicRevalidationDrift(t *testing.T) {
+	project := newV062Project(t)
+	changed := filepath.Join(project, ".beads", "dolt", "smoke", ".dolt", "repo_state.json")
+	result, err := inspectWithHooks(project, "1.1.0", inspectHooks{
+		afterFirstTree: func() {
+			if writeErr := os.WriteFile(changed, []byte("{\"head\":\"changed\"}\n"), 0o600); writeErr != nil {
+				t.Fatalf("inject drift: %v", writeErr)
+			}
+		},
+	})
+	if result.Status != "" {
+		t.Fatalf("drift returned result %#v", result)
+	}
+	assertRefusalCode(t, err, CodeSourceChanged)
+}
+
+func TestInspectReleasesDescriptorsOnSuccessAndRefusal(t *testing.T) {
+	project := newV062Project(t)
+	before := openDescriptorCount(t)
+	for range 20 {
+		if _, err := Inspect(project, "1.1.0"); err != nil {
+			t.Fatalf("qualified Inspect() error = %v", err)
+		}
+	}
+	mustWrite(t, filepath.Join(project, ".beads", ".local_version"), "0.61.0\n")
+	for range 20 {
+		_, err := Inspect(project, "1.1.0")
+		assertRefusalCode(t, err, CodeSourceVersionMismatch)
+	}
+	if after := openDescriptorCount(t); after != before {
+		t.Fatalf("descriptor count changed from %d to %d", before, after)
+	}
+}
+
+func TestWSLReleaseDetection(t *testing.T) {
+	for _, release := range []string{"5.15.90.1-microsoft-standard-WSL2", "4.4.0-Microsoft", "6.1.0-wsl"} {
+		if !isWSLRelease(release) {
+			t.Errorf("isWSLRelease(%q) = false", release)
+		}
+	}
+	if isWSLRelease("6.8.0-1018-azure") {
+		t.Fatal("native Linux release classified as WSL")
+	}
+}
+
+func assertRefusalCode(t *testing.T, err error, want Code) {
+	t.Helper()
+	refusal, ok := AsRefusal(err)
+	if !ok {
+		t.Fatalf("error %T %v is not a Refusal", err, err)
+	}
+	if refusal.Code != want || refusal.Effect != EffectNone {
+		t.Fatalf("refusal = %#v, want code %q/effect none", refusal, want)
+	}
+}
+
+func newV062Project(t *testing.T) string {
+	t.Helper()
+	project := filepath.Join(t.TempDir(), "project")
+	for _, dir := range []string{
+		filepath.Join(project, ".beads", "dolt", ".dolt"),
+		filepath.Join(project, ".beads", "dolt", "smoke", ".dolt"),
+	} {
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	mustWrite(t, filepath.Join(project, ".beads", ".local_version"), "0.62.0\n")
+	mustWrite(t, filepath.Join(project, ".beads", "metadata.json"), `{
+  "database": "dolt",
+  "backend": "dolt",
+  "dolt_mode": "server",
+  "dolt_server_host": "127.0.0.1",
+  "dolt_server_port": 3307,
+  "dolt_database": "smoke",
+  "project_id": "7ef372b4-4c3c-4e2c-a6cc-29dd2d0a28c6"
+}
+`)
+	mustWrite(t, filepath.Join(project, ".beads", "dolt", "config.yaml"), "listener:\n  host: 127.0.0.1\n  port: 3307\n")
+	mustWrite(t, filepath.Join(project, ".beads", "dolt", ".dolt", "config.json"), "{}\n")
+	mustWrite(t, filepath.Join(project, ".beads", "dolt", ".dolt", "repo_state.json"), "{\"head\":\"refs/heads/main\"}\n")
+	mustWrite(t, filepath.Join(project, ".beads", "dolt", "smoke", ".dolt", "config.json"), "{}\n")
+	mustWrite(t, filepath.Join(project, ".beads", "dolt", "smoke", ".dolt", "repo_state.json"), "{\"head\":\"refs/heads/main\"}\n")
+	return project
+}
+
+func mustWrite(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func setV062MetadataField(t *testing.T, project, key string, fieldValue any) {
+	t.Helper()
+	metadata := filepath.Join(project, ".beads", "metadata.json")
+	var value map[string]any
+	data, err := os.ReadFile(metadata)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(data, &value); err != nil {
+		t.Fatal(err)
+	}
+	value[key] = fieldValue
+	updated, err := json.Marshal(value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(metadata, updated, 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func snapshotTree(t *testing.T, root string) string {
+	t.Helper()
+	var records []string
+	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		record := rel + "|" + info.Mode().String() + "|" + info.ModTime().UTC().String()
+		if info.Mode().IsRegular() {
+			stat, ok := info.Sys().(*syscall.Stat_t)
+			if !ok {
+				return errors.New("file stat is not syscall.Stat_t")
+			}
+			record += "|atime=" + strconv.FormatInt(stat.Atim.Sec, 10) + "." + strconv.FormatInt(stat.Atim.Nsec, 10)
+			fd, err := unix.Open(path, unix.O_RDONLY|unix.O_CLOEXEC|unix.O_NOFOLLOW|unix.O_NOATIME, 0)
+			if err != nil {
+				return err
+			}
+			file := os.NewFile(uintptr(fd), path)
+			if file == nil {
+				_ = unix.Close(fd)
+				return errors.New("could not wrap snapshot descriptor")
+			}
+			data, readErr := io.ReadAll(file)
+			closeErr := file.Close()
+			if readErr != nil {
+				return readErr
+			}
+			if closeErr != nil {
+				return closeErr
+			}
+			record += "|" + string(data)
+		} else if info.Mode()&os.ModeSymlink != 0 {
+			target, err := os.Readlink(path)
+			if err != nil {
+				return err
+			}
+			record += "|" + target
+		}
+		records = append(records, record)
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	sort.Strings(records)
+	return strings.Join(records, "\n")
+}
+
+func openDescriptorCount(t *testing.T) int {
+	t.Helper()
+	entries, err := os.ReadDir("/proc/self/fd")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return len(entries)
+}
+
+func descriptorPathHasSuffix(fd int, suffix string) bool {
+	path, err := os.Readlink("/proc/self/fd/" + strconv.Itoa(fd))
+	return err == nil && strings.HasSuffix(path, suffix)
+}

--- a/internal/v062migration/inspect_linux_test.go
+++ b/internal/v062migration/inspect_linux_test.go
@@ -348,6 +348,139 @@ func TestInspectRefusesUnsafeAndMixedSourceShapes(t *testing.T) {
 	}
 }
 
+func TestInspectRefusesMissingRequiredLayoutEntries(t *testing.T) {
+	// The required-layout gate is one of the two central admission decisions.
+	// Deleting any required layout entry must fail closed with a stable
+	// source_layout_missing code, never admit a partial Dolt-server tree.
+	tests := []struct {
+		name   string
+		remove string
+		want   Code
+	}{
+		{"beads directory", ".beads", CodeSourceLayoutMissing},
+		{"dolt root", ".beads/dolt", CodeSourceLayoutMissing},
+		{"dolt config", ".beads/dolt/config.yaml", CodeSourceLayoutMissing},
+		{"server dolt directory", ".beads/dolt/.dolt", CodeSourceLayoutMissing},
+		{"server config", ".beads/dolt/.dolt/config.json", CodeSourceLayoutMissing},
+		{"server repo state", ".beads/dolt/.dolt/repo_state.json", CodeSourceLayoutMissing},
+		{"database dolt directory", ".beads/dolt/smoke/.dolt", CodeSourceLayoutMissing},
+		{"database config", ".beads/dolt/smoke/.dolt/config.json", CodeSourceLayoutMissing},
+		{"database repo state", ".beads/dolt/smoke/.dolt/repo_state.json", CodeSourceLayoutMissing},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			project := newV062Project(t)
+			if err := os.RemoveAll(filepath.Join(project, filepath.FromSlash(tt.remove))); err != nil {
+				t.Fatal(err)
+			}
+			before := snapshotTree(t, project)
+			_, err := Inspect(project, "1.1.0")
+			assertRefusalCode(t, err, tt.want)
+			if after := snapshotTree(t, project); after != before {
+				t.Fatalf("refusal mutated source tree")
+			}
+		})
+	}
+}
+
+func TestInspectRefusesMissingMetadata(t *testing.T) {
+	project := newV062Project(t)
+	if err := os.Remove(filepath.Join(project, ".beads", "metadata.json")); err != nil {
+		t.Fatal(err)
+	}
+	before := snapshotTree(t, project)
+	_, err := Inspect(project, "1.1.0")
+	assertRefusalCode(t, err, CodeSourceMetadataMissing)
+	if after := snapshotTree(t, project); after != before {
+		t.Fatalf("refusal mutated source tree")
+	}
+}
+
+func TestInspectRefusesMalformedV062Metadata(t *testing.T) {
+	// parseMetadata is the second central admission gate. Every rejected field,
+	// pattern, and JSON-shape branch must collapse to a non-retryable
+	// source_metadata_mismatch rather than admit a foreign or ambiguous source.
+	tests := []struct {
+		name string
+		edit func(*testing.T, string)
+	}{
+		{
+			name: "backend not dolt",
+			edit: func(t *testing.T, project string) { setV062MetadataField(t, project, "backend", "sqlite") },
+		},
+		{
+			name: "database not dolt",
+			edit: func(t *testing.T, project string) { setV062MetadataField(t, project, "database", "sqlite") },
+		},
+		{
+			name: "dolt mode not server",
+			edit: func(t *testing.T, project string) { setV062MetadataField(t, project, "dolt_mode", "embedded") },
+		},
+		{
+			name: "non-loopback server host",
+			edit: func(t *testing.T, project string) { setV062MetadataField(t, project, "dolt_server_host", "10.0.0.5") },
+		},
+		{
+			name: "invalid dolt database name",
+			edit: func(t *testing.T, project string) { setV062MetadataField(t, project, "dolt_database", "smoke;drop") },
+		},
+		{
+			name: "non-uuid project id",
+			edit: func(t *testing.T, project string) { setV062MetadataField(t, project, "project_id", "not-a-uuid") },
+		},
+		{
+			name: "server port below range",
+			edit: func(t *testing.T, project string) { setV062MetadataField(t, project, "dolt_server_port", 0) },
+		},
+		{
+			name: "server port above range",
+			edit: func(t *testing.T, project string) { setV062MetadataField(t, project, "dolt_server_port", 70000) },
+		},
+		{
+			name: "non-empty custom data dir",
+			edit: func(t *testing.T, project string) { setV062MetadataField(t, project, "dolt_data_dir", "/srv/dolt") },
+		},
+		{
+			name: "unknown metadata field",
+			edit: func(t *testing.T, project string) { setV062MetadataField(t, project, "shared_server", "true") },
+		},
+		{
+			name: "duplicate metadata key",
+			edit: func(t *testing.T, project string) {
+				mustWrite(t, filepath.Join(project, ".beads", "metadata.json"),
+					`{"backend":"dolt","backend":"dolt","database":"dolt","dolt_mode":"server","dolt_database":"smoke","project_id":"7ef372b4-4c3c-4e2c-a6cc-29dd2d0a28c6"}`)
+			},
+		},
+		{
+			name: "trailing content after object",
+			edit: func(t *testing.T, project string) {
+				mustWrite(t, filepath.Join(project, ".beads", "metadata.json"),
+					`{"backend":"dolt","database":"dolt","dolt_mode":"server","dolt_database":"smoke","project_id":"7ef372b4-4c3c-4e2c-a6cc-29dd2d0a28c6"}{}`)
+			},
+		},
+		{
+			name: "not a json object",
+			edit: func(t *testing.T, project string) {
+				mustWrite(t, filepath.Join(project, ".beads", "metadata.json"), `["dolt"]`)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			project := newV062Project(t)
+			tt.edit(t, project)
+			before := snapshotTree(t, project)
+			_, err := Inspect(project, "1.1.0")
+			assertRefusalCode(t, err, CodeSourceMetadataMismatch)
+			if after := snapshotTree(t, project); after != before {
+				t.Fatalf("refusal mutated source tree")
+			}
+		})
+	}
+}
+
 func TestInspectClassifiesStableOversizedWitnessesAsNonRetryableMismatch(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/internal/v062migration/inspect_unsupported.go
+++ b/internal/v062migration/inspect_unsupported.go
@@ -1,0 +1,9 @@
+//go:build !linux
+
+package v062migration
+
+// Inspect fails before touching the source on platforms outside the single
+// qualified Linux/amd64 migration environment.
+func Inspect(_ string, _ string) (Result, error) {
+	return Result{}, refuse(CodePlatformUnsupported, false, nil)
+}

--- a/internal/v062migration/types.go
+++ b/internal/v062migration/types.go
@@ -1,0 +1,148 @@
+// Package v062migration performs the private, read-only admission inspection
+// used by the v0.62.0 server-to-embedded migration bridge.
+package v062migration
+
+import "errors"
+
+const (
+	SchemaVersion = 1
+	Operation     = "v062_source_inspection"
+	EffectNone    = "none"
+
+	// DigestScopeAdmissionObservation means the digest describes the two
+	// consecutive descriptor-bound reads performed by admission. It is not a
+	// lifetime lease on the source. Any future effectful apply must rebind and
+	// reinspect the source while holding its own operation fence.
+	DigestScopeAdmissionObservation = "admission_observation"
+
+	StatusQualified  = "qualified"
+	StatusRefused    = "refused"
+	StatusUsageError = "usage_error"
+)
+
+// Code is a stable machine-readable admission outcome.
+type Code string
+
+const (
+	CodeInvalidUsage              Code = "invalid_usage"
+	CodePlatformUnsupported       Code = "platform_unsupported"
+	CodeEmbeddedTargetUnavailable Code = "embedded_target_unavailable"
+	CodeWorkspaceInvalid          Code = "workspace_invalid"
+	CodeWorkspaceNotCanonical     Code = "workspace_not_canonical"
+	CodeSourceVersionMissing      Code = "source_version_missing"
+	CodeSourceVersionMismatch     Code = "source_version_mismatch"
+	CodeSourceVersionAmbiguous    Code = "source_version_ambiguous"
+	CodeSourceMetadataMissing     Code = "source_metadata_missing"
+	CodeSourceMetadataMismatch    Code = "source_metadata_mismatch"
+	CodeSourceLayoutMissing       Code = "source_layout_missing"
+	CodeUnsafeSourceSymlink       Code = "unsafe_source_symlink"
+	CodeUnsafeSourceHardlink      Code = "unsafe_source_hardlink"
+	CodeUnsafeSourceObject        Code = "unsafe_source_object"
+	CodeCrossDeviceSource         Code = "cross_device_source"
+	CodeMixedStorageLayout        Code = "mixed_storage_layout"
+	CodeRollbackCollision         Code = "rollback_collision"
+	CodeSourceChanged             Code = "source_changed"
+	CodeSourceUnverifiable        Code = "source_unverifiable"
+)
+
+// Result is the versioned JSON protocol shared by the hidden inspector and
+// its shell bridge. Qualified results include Source and Target.
+type Result struct {
+	SchemaVersion int     `json:"schema_version"`
+	Operation     string  `json:"operation"`
+	Status        string  `json:"status"`
+	Retryable     bool    `json:"retryable"`
+	Effect        string  `json:"effect"`
+	Code          Code    `json:"code,omitempty"`
+	Source        *Source `json:"source,omitempty"`
+	Target        *Target `json:"target,omitempty"`
+}
+
+type Source struct {
+	Workspace string `json:"workspace"`
+	Version   string `json:"version"`
+	Backend   string `json:"backend"`
+	// TreeSHA256 is admission evidence with the lifetime explicitly bounded
+	// by DigestScope; it must never authorize a later effectful operation.
+	TreeSHA256 string `json:"tree_sha256"`
+	// DigestScope requires a future apply to rebind/reinspect under its fence.
+	DigestScope string `json:"digest_scope"`
+}
+
+type Target struct {
+	Version         string `json:"version"`
+	Backend         string `json:"backend"`
+	EmbeddedCapable bool   `json:"embedded_capable"`
+}
+
+// Refusal is the sole typed negative admission outcome. Error deliberately
+// exposes only the stable code; OS paths and values never cross the protocol.
+type Refusal struct {
+	Code      Code   `json:"code"`
+	Retryable bool   `json:"retryable"`
+	Effect    string `json:"effect"`
+	cause     error
+}
+
+func (r *Refusal) Error() string {
+	if r == nil {
+		return ""
+	}
+	return string(r.Code)
+}
+
+func (r *Refusal) Unwrap() error {
+	if r == nil {
+		return nil
+	}
+	return r.cause
+}
+
+func AsRefusal(err error) (*Refusal, bool) {
+	var refusal *Refusal
+	ok := errors.As(err, &refusal)
+	return refusal, ok
+}
+
+func refuse(code Code, retryable bool, cause error) error {
+	return &Refusal{Code: code, Retryable: retryable, Effect: EffectNone, cause: cause}
+}
+
+func QualifiedResult(workspace, targetVersion, treeSHA256 string) Result {
+	return Result{
+		SchemaVersion: SchemaVersion,
+		Operation:     Operation,
+		Status:        StatusQualified,
+		Retryable:     false,
+		Effect:        EffectNone,
+		Source: &Source{
+			Workspace:   workspace,
+			Version:     "0.62.0",
+			Backend:     "dolt-server",
+			TreeSHA256:  treeSHA256,
+			DigestScope: DigestScopeAdmissionObservation,
+		},
+		Target: &Target{
+			Version:         targetVersion,
+			Backend:         "dolt-embedded",
+			EmbeddedCapable: true,
+		},
+	}
+}
+
+func RefusedResult(code Code, retryable bool) Result {
+	return Result{
+		SchemaVersion: SchemaVersion,
+		Operation:     Operation,
+		Status:        StatusRefused,
+		Retryable:     retryable,
+		Effect:        EffectNone,
+		Code:          code,
+	}
+}
+
+func UsageErrorResult() Result {
+	result := RefusedResult(CodeInvalidUsage, false)
+	result.Status = StatusUsageError
+	return result
+}

--- a/scripts/migrate-v062-server-to-current.sh
+++ b/scripts/migrate-v062-server-to-current.sh
@@ -1,0 +1,312 @@
+#!/usr/bin/env bash
+# Qualified public bridge for v0.62.0 Dolt-server workspaces.
+# Source admission is delegated to hidden no-follow plumbing in current bd.
+
+set -uo pipefail
+umask 077
+
+readonly OPERATION=v062_server_to_current
+readonly ENV_BIN=/usr/bin/env
+readonly JQ_BIN=/usr/bin/jq
+readonly READLINK_BIN=/usr/bin/readlink
+readonly REALPATH_BIN=/usr/bin/realpath
+readonly TIMEOUT_BIN=/usr/bin/timeout
+
+MODE=inspect
+MODE_SET=false
+JSON_OUTPUT=false
+YES=false
+WORKSPACE_ARG=
+TARGET_BD_ARG=
+
+# Honor --json even when a preceding argument is invalid.
+for argument in "$@"; do
+    [ "$argument" = --json ] && JSON_OUTPUT=true
+done
+
+usage() {
+    cat >&2 <<'EOF'
+Usage: migrate-v062-server-to-current.sh [options]
+
+  --workspace PROJECT  Project containing the v0.62.0 .beads directory
+  --target-bd PATH     Absolute path to the current embedded-capable bd
+  --inspect            Inspect only (default; no workspace effects)
+  --apply              Perform the migration
+  --yes                Required confirmation for --apply
+  --json               Emit exactly one JSON result on stdout
+  -h, --help           Show this help
+EOF
+}
+
+bootstrap_json() {
+    local status="$1" code="$2" retryable="$3" effect="$4"
+    printf '{"schema_version":1,"operation":"%s",' "$OPERATION"
+    printf '"mode":"%s","status":"%s","retryable":%s,' \
+        "$MODE" "$status" "$retryable"
+    printf '"effect":"%s","code":"%s"}\n' "$effect" "$code"
+}
+
+emit_base_json() {
+    "$JQ_BIN" -cn \
+        --arg operation "$OPERATION" --arg mode "$MODE" \
+        --arg status "$1" --arg code "$2" \
+        --argjson retryable "$3" --arg effect "$4" '
+        {
+            schema_version: 1, operation: $operation, mode: $mode,
+            status: $status, retryable: $retryable, effect: $effect
+        } + if $code == "" then {} else {code: $code} end
+    '
+}
+
+finish_error() {
+    local exit_status="$1" status="$2" code="$3"
+    local retryable="$4" effect="$5" message="$6"
+    printf '%s: %s\n' "$OPERATION" "$message" >&2
+    if $JSON_OUTPUT; then
+        if [ -x "$JQ_BIN" ]; then
+            emit_base_json "$status" "$code" "$retryable" "$effect"
+        else
+            bootstrap_json "$status" "$code" "$retryable" "$effect"
+        fi
+    fi
+    exit "$exit_status"
+}
+
+invalid_usage() {
+    finish_error 2 usage_error "$1" false none "$2"
+}
+
+refuse() {
+    finish_error 1 refused "$1" "$2" none "$3"
+}
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --workspace)
+            [ "$#" -ge 2 ] ||
+                invalid_usage invalid_usage "--workspace requires a value"
+            WORKSPACE_ARG="$2"
+            shift 2
+            ;;
+        --target-bd)
+            [ "$#" -ge 2 ] ||
+                invalid_usage invalid_usage "--target-bd requires a value"
+            TARGET_BD_ARG="$2"
+            shift 2
+            ;;
+        --inspect|--apply)
+            requested_mode="${1#--}"
+            if $MODE_SET && [ "$MODE" != "$requested_mode" ]; then
+                invalid_usage invalid_usage \
+                    "--inspect and --apply are mutually exclusive"
+            fi
+            MODE="$requested_mode"
+            MODE_SET=true
+            shift
+            ;;
+        --yes)
+            YES=true
+            shift
+            ;;
+        --json)
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        --*)
+            invalid_usage invalid_usage "unknown option: $1"
+            ;;
+        *)
+            invalid_usage invalid_usage "unexpected argument: $1"
+            ;;
+    esac
+done
+
+if [ "$MODE" = apply ] && ! $YES; then
+    invalid_usage confirmation_required \
+        "--apply requires explicit --yes confirmation"
+fi
+if $YES && [ "$MODE" != apply ]; then
+    invalid_usage invalid_usage "--yes is valid only with --apply"
+fi
+
+INSPECT_TIMEOUT_SECONDS=${BD_V062_INSPECT_TIMEOUT_SECONDS:-600}
+if [[ ! "$INSPECT_TIMEOUT_SECONDS" =~ ^[1-9][0-9]*$ ]] ||
+    [ "${#INSPECT_TIMEOUT_SECONDS}" -gt 4 ] ||
+    [ "$INSPECT_TIMEOUT_SECONDS" -gt 3600 ]; then
+    invalid_usage invalid_environment \
+        "BD_V062_INSPECT_TIMEOUT_SECONDS must be an integer from 1 to 3600"
+fi
+
+for helper in \
+    "$ENV_BIN" "$JQ_BIN" "$READLINK_BIN" "$REALPATH_BIN" "$TIMEOUT_BIN"; do
+    [ -f "$helper" ] && [ -x "$helper" ] && [ ! -L "$helper" ] ||
+        refuse missing_requirement true \
+            "required fixed helper is unavailable: $helper"
+done
+
+[ -n "$WORKSPACE_ARG" ] || WORKSPACE_ARG="$PWD"
+WORKSPACE=$("$REALPATH_BIN" -e -- "$WORKSPACE_ARG" 2>/dev/null) ||
+    refuse workspace_invalid true "workspace cannot be resolved"
+[ -d "$WORKSPACE" ] && [ ! -L "$WORKSPACE" ] ||
+    refuse workspace_invalid true \
+        "workspace must be a physical project directory"
+
+if [ -z "$TARGET_BD_ARG" ]; then
+    TARGET_BD_ARG=$(type -P bd 2>/dev/null) ||
+        refuse target_binary_missing true "no current bd binary was found"
+elif [[ "$TARGET_BD_ARG" != /* ]]; then
+    refuse target_binary_invalid false \
+        "--target-bd must be an absolute path"
+fi
+TARGET_BD=$("$READLINK_BIN" -f -- "$TARGET_BD_ARG" 2>/dev/null) ||
+    refuse target_binary_invalid false \
+        "the target bd path cannot be resolved"
+[ -f "$TARGET_BD" ] && [ -x "$TARGET_BD" ] ||
+    refuse target_binary_invalid false \
+        "the target bd path is not an executable regular file"
+
+inspection_stdout=$(
+    "$ENV_BIN" -i \
+        PATH=/usr/bin:/bin HOME=/nonexistent \
+        XDG_CONFIG_HOME=/nonexistent XDG_CACHE_HOME=/nonexistent \
+        XDG_DATA_HOME=/nonexistent XDG_STATE_HOME=/nonexistent \
+        GIT_CONFIG_NOSYSTEM=1 GIT_CONFIG_GLOBAL=/dev/null \
+        GIT_TERMINAL_PROMPT=0 BD_DISABLE_METRICS=1 \
+        BD_DISABLE_EVENT_FLUSH=1 BD_NON_INTERACTIVE=1 \
+        NO_COLOR=1 CI=1 LANG=C.UTF-8 LC_ALL=C.UTF-8 TZ=UTC TERM=dumb \
+        "$TIMEOUT_BIN" --kill-after=5s "${INSPECT_TIMEOUT_SECONDS}s" \
+        "$TARGET_BD" __migration-v062-inspect \
+            --workspace "$WORKSPACE" --json 2>/dev/null
+)
+inspection_status=$?
+
+if [ "$inspection_status" -eq 124 ] || [ "$inspection_status" -eq 137 ]; then
+    refuse target_inspection_timeout true \
+        "target bd inspection exceeded its bounded runtime"
+fi
+
+if ! inspection_json=$("$JQ_BIN" -cse \
+    --argjson process_status "$inspection_status" '
+    def has_code($codes):
+        .code as $code | $codes | index($code) != null;
+    def nonretryable_refusal:
+        .retryable == false and has_code([
+            "platform_unsupported",
+            "embedded_target_unavailable",
+            "workspace_invalid",
+            "workspace_not_canonical",
+            "source_version_missing",
+            "source_version_mismatch",
+            "source_version_ambiguous",
+            "source_metadata_missing",
+            "source_metadata_mismatch",
+            "source_layout_missing",
+            "unsafe_source_symlink",
+            "unsafe_source_hardlink",
+            "unsafe_source_object",
+            "cross_device_source",
+            "mixed_storage_layout",
+            "rollback_collision"
+        ]);
+    def retryable_refusal:
+        .retryable == true and has_code([
+            "source_changed",
+            "source_unverifiable"
+        ]);
+    if length != 1 then empty else .[0] end |
+    select(
+        type == "object" and .schema_version == 1 and
+        .operation == "v062_source_inspection" and .effect == "none" and
+        (
+            (
+                .status == "qualified" and $process_status == 0 and
+                .retryable == false and
+                keys == [
+                    "effect", "operation", "retryable", "schema_version",
+                    "source", "status", "target"
+                ]
+            ) or
+            (
+                .status == "refused" and $process_status == 1 and
+                keys == [
+                    "code", "effect", "operation", "retryable",
+                    "schema_version", "status"
+                ] and
+                (nonretryable_refusal or retryable_refusal)
+            )
+        )
+    )
+' 2>/dev/null <<< "$inspection_stdout"); then
+    refuse target_capability_missing false \
+        "target bd does not implement the qualified inspection protocol"
+fi
+
+inspection_result_status=$("$JQ_BIN" -r '.status' <<< "$inspection_json")
+if [ "$inspection_result_status" = refused ]; then
+    inspection_code=$("$JQ_BIN" -r '.code' <<< "$inspection_json")
+    inspection_retryable=$("$JQ_BIN" -r '.retryable' <<< "$inspection_json")
+    finish_error 1 refused "$inspection_code" \
+        "$inspection_retryable" none \
+        "the no-follow source inspector refused this workspace"
+fi
+
+if [ "$inspection_status" -ne 0 ] ||
+    ! "$JQ_BIN" -e --arg workspace "$WORKSPACE" '
+        .status == "qualified" and
+        .source.workspace == $workspace and
+        .source.version == "0.62.0" and
+        .source.backend == "dolt-server" and
+        .source.digest_scope == "admission_observation" and
+        (.source.tree_sha256 | type) == "string" and
+        (.source.tree_sha256 | test("^[0-9a-f]{64}$")) and
+        .target.backend == "dolt-embedded" and
+        .target.embedded_capable == true and
+        (.target.version | type) == "string" and
+        (.target.version |
+            test("^[0-9]+[.][0-9]+[.][0-9]+([+-].*)?$")) and
+        ((.target.version | split(".")[0] | tonumber) >= 1)
+    ' >/dev/null 2>&1 <<< "$inspection_json"; then
+    reported_target_version=$(
+        "$JQ_BIN" -r '.target.version // ""' <<< "$inspection_json" \
+            2>/dev/null
+    ) || reported_target_version=
+    if [ "$reported_target_version" = 0.62.0 ]; then
+        refuse target_binary_invalid false \
+            "the historical bd binary cannot be the migration target"
+    fi
+    refuse target_capability_missing false \
+        "target bd is not a qualified embedded-capable migration target"
+fi
+
+rollback_path="$WORKSPACE/.beads-v0.62.0-rollback"
+
+# Be truthful while this stack contains admission but not the effectful bridge.
+if $JSON_OUTPUT; then
+    "$JQ_BIN" -cn \
+        --argjson inspection "$inspection_json" \
+        --arg operation "$OPERATION" --arg mode "$MODE" \
+        --arg rollback "$rollback_path" '
+        {
+            schema_version: 1, operation: $operation, mode: $mode,
+            status: "failed", code: "apply_not_available",
+            retryable: false, effect: "none",
+            source: $inspection.source, target: $inspection.target,
+            rollback: {path: $rollback, policy: "retain"},
+            verification: {
+                source_shape: "qualified",
+                source_tree_sha256: $inspection.source.tree_sha256,
+                source_digest_scope: $inspection.source.digest_scope,
+                apply_reinspection_required: true,
+                apply_available: false,
+                workspace_effects: false
+            }
+        }
+    '
+else
+    printf '%s\n' \
+        'Qualified v0.62.0 source; apply is not available in this build.' >&2
+fi
+exit 1

--- a/scripts/migration-test/public-v062-bridge-test.sh
+++ b/scripts/migration-test/public-v062-bridge-test.sh
@@ -613,4 +613,32 @@ jq -e '
 assert_unchanged "$real_negative_ws" "$real_negative_before" \
     "real negative source refusal"
 
+# The version gate above is not a safety refusal. Prove that the real inspector
+# also fails closed on the safety-critical shapes end to end, through the public
+# wrapper and the descriptor-relative Go walk, not only the fake target.
+assert_real_target_refused() {
+    local label="$1" ws="$2" code="$3" before
+    before=$(tree_fingerprint "$ws")
+    BRIDGE_TEST_TARGET="$REAL_TARGET_BD" \
+        run_bridge "$label" "$ws" --inspect --workspace "$ws"
+    [ "$RUN_STATUS" -eq 1 ] ||
+        fail "$label exit=$RUN_STATUS, want fail-closed refusal exit 1"
+    assert_common_json inspect refused none
+    jq -e --arg code "$code" '.retryable == false and .code == $code' \
+        <<< "$RUN_STDOUT" >/dev/null ||
+        fail "$label did not preserve its typed safety refusal"
+    assert_unchanged "$ws" "$before" "$label refusal"
+}
+
+real_symlink_ws="$tmp/real-current-symlink"
+new_v062_workspace "$real_symlink_ws"
+mv -f -- "$real_symlink_ws/.beads/dolt" "$real_symlink_ws/.beads/dolt-real"
+ln -s dolt-real "$real_symlink_ws/.beads/dolt"
+assert_real_target_refused real-current-symlink "$real_symlink_ws" unsafe_source_symlink
+
+real_mixed_ws="$tmp/real-current-mixed"
+new_v062_workspace "$real_mixed_ws"
+printf 'sqlite-like bytes\n' > "$real_mixed_ws/.beads/beads.db"
+assert_real_target_refused real-current-mixed "$real_mixed_ws" mixed_storage_layout
+
 printf 'public-v062-bridge-test: PASS\n'

--- a/scripts/migration-test/public-v062-bridge-test.sh
+++ b/scripts/migration-test/public-v062-bridge-test.sh
@@ -1,0 +1,616 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+BRIDGE="$REPO_ROOT/scripts/migrate-v062-server-to-current.sh"
+
+fail() {
+    printf 'public-v062-bridge-test: %s\n' "$*" >&2
+    exit 1
+}
+
+[ -x "$BRIDGE" ] || fail "missing executable public bridge: $BRIDGE"
+command -v jq >/dev/null || fail "jq is required"
+command -v script >/dev/null || fail "script is required"
+
+if [ -n "${PUBLIC_V062_REAL_TARGET_BD:-}" ]; then
+    REAL_TARGET_BD=$(realpath -e -- "$PUBLIC_V062_REAL_TARGET_BD") ||
+        fail "PUBLIC_V062_REAL_TARGET_BD cannot be resolved"
+else
+    (cd "$REPO_ROOT" && make build >/dev/null) ||
+        fail "could not build the real current bd target"
+    REAL_TARGET_BD="$REPO_ROOT/bd"
+fi
+[ -f "$REAL_TARGET_BD" ] && [ -x "$REAL_TARGET_BD" ] ||
+    fail "real current bd target is not executable: $REAL_TARGET_BD"
+
+tmp=$(mktemp -d "${TMPDIR:-/tmp}/bd-public-v062-bridge.XXXXXX")
+trap 'rm -rf -- "$tmp"' EXIT
+mkdir -p "$tmp/home"
+
+TARGET_BD="$tmp/fake-bd-current"
+TARGET_LOG="$tmp/fake-target.log"
+OLD_TARGET_BD="$tmp/fake-bd-old-target"
+OLD_TARGET_LOG="$tmp/fake-old-target.log"
+INCAPABLE_TARGET_BD="$tmp/fake-bd-incapable-target"
+INCAPABLE_TARGET_LOG="$tmp/fake-incapable-target.log"
+TIMEOUT_TARGET_BD="$tmp/fake-bd-timeout-target"
+TIMEOUT_TARGET_LOG="$tmp/fake-timeout-target.log"
+
+make_fake_bd() {
+    local path="$1" version="$2" capability="$3" log="$4"
+    cat > "$path" <<EOF
+#!/usr/bin/env bash
+{
+    printf 'argv=%q' "\$0"
+    printf ' %q' "\$@"
+    printf '\n'
+    env | LC_ALL=C sort
+} >> '$log'
+case "\${1:-}" in
+    version)
+        [ "\${2:-}" = --json ] || exit 2
+        printf '{"version":"%s","build":"test"}\n' '$version'
+        ;;
+    __migration-v062-inspect)
+        if [ '$capability' = timeout ]; then
+            printf '%s\n' "\$\$" > '${log}.pid'
+            exec /usr/bin/sleep 30
+        fi
+        [ '$capability' = embedded ] || exit 2
+        [ "\$#" -eq 4 ] && [ "\$2" = --workspace ] &&
+            [[ "\$3" = /* ]] && [ "\$4" = --json ] || exit 2
+        inspection_code=
+        inspection_retryable=false
+        inspection_exit=1
+        qualified_workspace="\$3"
+        qualified_digest_scope=admission_observation
+        qualified_exit=0
+        repeat_qualified=false
+        case "\${3##*/}" in
+            wrong-witness) inspection_code=source_version_mismatch ;;
+            missing-witness) inspection_code=source_version_missing ;;
+            ambiguous-witness) inspection_code=source_version_ambiguous ;;
+            wrong-metadata) inspection_code=source_metadata_mismatch ;;
+            symlink-layout) inspection_code=unsafe_source_symlink ;;
+            mixed-target) inspection_code=mixed_storage_layout ;;
+            rollback-collision) inspection_code=rollback_collision ;;
+            lying-workspace)
+                qualified_workspace=/not/the/requested/workspace
+                ;;
+            wrong-digest-scope) qualified_digest_scope=lifetime_authority ;;
+            multiple-json) repeat_qualified=true ;;
+            qualified-wrong-exit) qualified_exit=1 ;;
+            refused-wrong-exit)
+                inspection_code=source_version_mismatch
+                inspection_exit=0
+                ;;
+            unknown-refusal-code) inspection_code=unrecognized_private_code ;;
+            wrong-retryability-stable)
+                inspection_code=source_version_mismatch
+                inspection_retryable=true
+                ;;
+            wrong-retryability-transient)
+                inspection_code=source_changed
+                inspection_retryable=false
+                ;;
+            retryable-source-changed)
+                inspection_code=source_changed
+                inspection_retryable=true
+                ;;
+        esac
+        if [ -n "\$inspection_code" ]; then
+            printf '{"schema_version":1,"operation":"v062_source_inspection","status":"refused","retryable":%s,"effect":"none","code":"%s"}\n' "\$inspection_retryable" "\$inspection_code"
+            exit "\$inspection_exit"
+        fi
+        printf '{"schema_version":1,"operation":"v062_source_inspection","status":"qualified","retryable":false,"effect":"none","source":{"workspace":"%s","version":"0.62.0","backend":"dolt-server","tree_sha256":"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef","digest_scope":"%s"},"target":{"version":"%s","backend":"dolt-embedded","embedded_capable":true}}\n' "\$qualified_workspace" "\$qualified_digest_scope" '$version'
+        if \$repeat_qualified; then
+            printf '{"schema_version":1,"operation":"v062_source_inspection","status":"qualified","retryable":false,"effect":"none","source":{"workspace":"%s","version":"0.62.0","backend":"dolt-server","tree_sha256":"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef","digest_scope":"%s"},"target":{"version":"%s","backend":"dolt-embedded","embedded_capable":true}}\n' "\$qualified_workspace" "\$qualified_digest_scope" '$version'
+        fi
+        exit "\$qualified_exit"
+        ;;
+    *) exit 2 ;;
+esac
+EOF
+    chmod +x "$path"
+}
+
+make_fake_bd "$TARGET_BD" 1.1.0 embedded "$TARGET_LOG"
+make_fake_bd "$OLD_TARGET_BD" 0.62.0 embedded "$OLD_TARGET_LOG"
+make_fake_bd "$INCAPABLE_TARGET_BD" 1.1.0 unavailable "$INCAPABLE_TARGET_LOG"
+make_fake_bd "$TIMEOUT_TARGET_BD" 1.1.0 timeout "$TIMEOUT_TARGET_LOG"
+
+new_v062_workspace() {
+    local ws="$1"
+    mkdir -p "$ws"
+    GIT_CONFIG_NOSYSTEM=1 GIT_CONFIG_GLOBAL=/dev/null \
+        git -C "$ws" init --quiet
+    git -C "$ws" config core.hooksPath .git/hooks
+    mkdir -p \
+        "$ws/.beads/dolt/.dolt" \
+        "$ws/.beads/dolt/smoke/.dolt"
+    cat > "$ws/.beads/metadata.json" <<'EOF'
+{
+  "database": "dolt",
+  "backend": "dolt",
+  "dolt_mode": "server",
+  "dolt_server_host": "127.0.0.1",
+  "dolt_server_port": 3307,
+  "dolt_database": "smoke",
+  "project_id": "7ef372b4-4c3c-4e2c-a6cc-29dd2d0a28c6"
+}
+EOF
+    printf '0.62.0\n' > "$ws/.beads/.local_version"
+    printf '{}\n' > "$ws/.beads/dolt/.dolt/config.json"
+    printf '{"head":"refs/heads/main"}\n' > "$ws/.beads/dolt/.dolt/repo_state.json"
+    printf '{}\n' > "$ws/.beads/dolt/smoke/.dolt/config.json"
+    printf '{"head":"refs/heads/main"}\n' > "$ws/.beads/dolt/smoke/.dolt/repo_state.json"
+    printf 'listener:\n  host: 127.0.0.1\n  port: 3307\n' \
+        > "$ws/.beads/dolt/config.yaml"
+}
+
+tree_fingerprint() {
+    local root="$1"
+    (
+        cd "$root"
+        find -P . -mindepth 1 \
+            -printf '%y %m %D %i %n %u %g %s %T@ %C@ %p %l\n' |
+            LC_ALL=C sort
+        find -P . -type f -print0 | LC_ALL=C sort -z | xargs -0 -r sha256sum
+    ) | sha256sum | awk '{print $1}'
+}
+
+RUN_STATUS=0
+RUN_STDOUT=""
+RUN_STDERR=""
+run_bridge() {
+    local label="$1" cwd="$2"
+    shift 2
+    local out="$tmp/$label.stdout" err="$tmp/$label.stderr"
+    local target="${BRIDGE_TEST_TARGET:-$TARGET_BD}"
+    set +e
+    (
+        cd "$cwd"
+        env -i \
+            "PATH=$PATH" "HOME=$tmp/home" "TMPDIR=$tmp" \
+            LANG=C LC_ALL=C TZ=UTC TERM=dumb \
+            BD_BACKEND=postgres BD_DATABASE_BACKEND=mysql \
+            BEADS_DB='postgres://poison.invalid/beads' \
+            BD_DB='mysql://poison.invalid/beads' \
+            BEADS_DIR="$tmp/poison-beads" \
+            BEADS_SQLITE_PATH="$tmp/poison.sqlite" \
+            BEADS_DOLT_SERVER_MODE=1 BEADS_DOLT_SHARED_SERVER=1 \
+            BEADS_DOLT_DATA_DIR="$tmp/poison-dolt" \
+            BEADS_DOLT_SERVER_HOST=poison.invalid \
+            BEADS_DOLT_SERVER_PORT=29999 \
+            "BD_V062_INSPECT_TIMEOUT_SECONDS=${BRIDGE_TEST_INSPECT_TIMEOUT_SECONDS:-600}" \
+            "$BRIDGE" --target-bd "$target" --json "$@" \
+            </dev/null >"$out" 2>"$err"
+    )
+    RUN_STATUS=$?
+    set -e
+    RUN_STDOUT=$(<"$out")
+    RUN_STDERR=$(<"$err")
+}
+
+run_apply_without_yes_on_tty() {
+    local ws="$1" command
+    printf -v command '%q ' env -i "PATH=$PATH" "HOME=$tmp/home" \
+        LANG=C LC_ALL=C TZ=UTC TERM=dumb "$BRIDGE" \
+        --target-bd "$TARGET_BD" --apply --workspace "$ws" --json
+    set +e
+    (cd "$ws" && script -q -e -c "$command" /dev/null >/dev/null 2>&1)
+    RUN_STATUS=$?
+    set -e
+}
+
+assert_common_json() {
+    local mode="$1" status="$2" effect="$3"
+    jq -se --arg mode "$mode" --arg status "$status" --arg effect "$effect" '
+        length == 1 and (.[0] |
+            type == "object" and
+            .schema_version == 1 and
+            .operation == "v062_server_to_current" and
+            .mode == $mode and .status == $status and
+            (.retryable | type) == "boolean" and .effect == $effect and
+            (keys - ["schema_version", "operation", "mode", "status",
+                     "retryable", "effect", "code", "source", "target",
+                     "rollback", "verification"] | length) == 0
+        )
+    ' <<< "$RUN_STDOUT" >/dev/null ||
+        fail "invalid JSON contract for $mode/$status: $RUN_STDOUT $RUN_STDERR"
+}
+
+assert_unchanged() {
+    local ws="$1" before="$2" context="$3"
+    [ "$(tree_fingerprint "$ws")" = "$before" ] ||
+        fail "$context mutated the workspace"
+}
+
+# Default mode is inspect. It can report the target-qualified source plan but
+# must not claim the bridge is ready until the public apply path exists.
+inspect_ws="$tmp/inspect-default"
+new_v062_workspace "$inspect_ws"
+inspect_before=$(tree_fingerprint "$inspect_ws")
+run_bridge inspect-default "$inspect_ws"
+[ "$RUN_STATUS" -eq 1 ] || fail "default inspect exit=$RUN_STATUS, want 1"
+assert_common_json inspect failed none
+jq -e '
+    .retryable == false and .code == "apply_not_available" and
+    .source.version == "0.62.0" and .source.backend == "dolt-server" and
+    .source.digest_scope == "admission_observation" and
+    (.source.tree_sha256 | test("^[0-9a-f]{64}$")) and
+    .target.backend == "dolt-embedded" and .target.embedded_capable == true and
+    (.rollback | type) == "object" and
+    .verification.source_digest_scope == "admission_observation" and
+    .verification.apply_reinspection_required == true and
+    .verification.apply_available == false and
+    .verification.workspace_effects == false
+' <<< "$RUN_STDOUT" >/dev/null || fail "default inspect omitted its qualified plan"
+default_json=$(jq -Sc . <<< "$RUN_STDOUT")
+assert_unchanged "$inspect_ws" "$inspect_before" "default inspect"
+
+run_bridge inspect-explicit "$inspect_ws" --inspect --workspace "$inspect_ws"
+[ "$RUN_STATUS" -eq 1 ] || fail "explicit inspect exit=$RUN_STATUS, want 1"
+assert_common_json inspect failed none
+[ "$(jq -Sc . <<< "$RUN_STDOUT")" = "$default_json" ] ||
+    fail "default and explicit inspect returned different JSON contracts"
+assert_unchanged "$inspect_ws" "$inspect_before" "explicit inspect"
+
+# Provider and database selectors inherited from the caller may not reach the
+# target binary, which owns both version and hidden migration inspection.
+[ -s "$TARGET_LOG" ] || fail "inspect did not validate the target binary"
+grep -F -- '__migration-v062-inspect' "$TARGET_LOG" >/dev/null ||
+    fail "public inspect did not use the target hidden inspection command"
+grep -F -- "--workspace $inspect_ws --json" "$TARGET_LOG" >/dev/null ||
+    fail "target hidden inspection did not receive the physical workspace"
+for poison in \
+    'BD_BACKEND=postgres' 'BD_DATABASE_BACKEND=mysql' \
+    'postgres://poison.invalid/beads' 'mysql://poison.invalid/beads' \
+    "$tmp/poison-beads" "$tmp/poison.sqlite" "$tmp/poison-dolt" \
+    'BEADS_DOLT_SERVER_MODE=1' 'BEADS_DOLT_SHARED_SERVER=1' \
+    'poison.invalid' 'BEADS_DOLT_SERVER_PORT=29999'; do
+    if grep -F -- "$poison" "$TARGET_LOG" >/dev/null; then
+        fail "ambient provider selector reached the target binary: $poison"
+    fi
+done
+
+# Treat the hidden command as an untrusted protocol peer. A response is
+# admissible only when its payload and process exit form one exact tuple.
+protocol_rejection_failures=()
+check_protocol_rejected() {
+    local label="$1" ws="$tmp/$1" before
+    new_v062_workspace "$ws"
+    before=$(tree_fingerprint "$ws")
+    run_bridge "$label" "$ws" --inspect --workspace "$ws"
+    if [ "$RUN_STATUS" -ne 1 ]; then
+        printf '%s: exit=%s, want 1\n' "$label" "$RUN_STATUS" >&2
+        return 1
+    fi
+    if ! jq -se '
+        length == 1 and .[0] == {
+            schema_version: 1,
+            operation: "v062_server_to_current",
+            mode: "inspect",
+            status: "refused",
+            retryable: false,
+            effect: "none",
+            code: "target_capability_missing"
+        }
+    ' <<< "$RUN_STDOUT" >/dev/null 2>&1; then
+        printf '%s: wrapper trusted invalid inspector tuple: %s %s\n' \
+            "$label" "$RUN_STDOUT" "$RUN_STDERR" >&2
+        return 1
+    fi
+    if [ "$(tree_fingerprint "$ws")" != "$before" ]; then
+        printf '%s: protocol rejection mutated the workspace\n' "$label" >&2
+        return 1
+    fi
+}
+
+for protocol_case in \
+    lying-workspace \
+    wrong-digest-scope \
+    multiple-json \
+    qualified-wrong-exit \
+    refused-wrong-exit \
+    unknown-refusal-code \
+    wrong-retryability-stable \
+    wrong-retryability-transient; do
+    if ! check_protocol_rejected "$protocol_case"; then
+        protocol_rejection_failures+=("$protocol_case")
+    fi
+done
+if [ "${#protocol_rejection_failures[@]}" -ne 0 ]; then
+    fail "inspector protocol regressions: ${protocol_rejection_failures[*]}"
+fi
+
+assert_refused() {
+    local label="$1" ws="$2" code="$3"
+    local before
+    before=$(tree_fingerprint "$ws")
+    run_bridge "$label" "$ws" --inspect --workspace "$ws"
+    [ "$RUN_STATUS" -eq 1 ] || fail "$label exit=$RUN_STATUS, want refusal exit 1"
+    assert_common_json inspect refused none
+    jq -e --arg code "$code" '.retryable == false and .code == $code' \
+        <<< "$RUN_STDOUT" >/dev/null || fail "$label returned the wrong refusal code"
+    assert_unchanged "$ws" "$before" "$label refusal"
+}
+
+wrong_ws="$tmp/wrong-witness"; new_v062_workspace "$wrong_ws"
+printf '0.61.0\n' > "$wrong_ws/.beads/.local_version"
+assert_refused wrong-witness "$wrong_ws" source_version_mismatch
+
+missing_ws="$tmp/missing-witness"; new_v062_workspace "$missing_ws"
+rm -f -- "$missing_ws/.beads/.local_version"
+assert_refused missing-witness "$missing_ws" source_version_missing
+
+ambiguous_ws="$tmp/ambiguous-witness"; new_v062_workspace "$ambiguous_ws"
+mv -f -- "$ambiguous_ws/.beads/.local_version" "$ambiguous_ws/version-target"
+ln -s ../version-target "$ambiguous_ws/.beads/.local_version"
+assert_refused ambiguous-witness "$ambiguous_ws" source_version_ambiguous
+
+metadata_ws="$tmp/wrong-metadata"; new_v062_workspace "$metadata_ws"
+jq '.backend = "postgres"' "$metadata_ws/.beads/metadata.json" \
+    > "$metadata_ws/.beads/metadata.json.tmp"
+mv -f -- "$metadata_ws/.beads/metadata.json.tmp" "$metadata_ws/.beads/metadata.json"
+assert_refused wrong-metadata "$metadata_ws" source_metadata_mismatch
+
+symlink_ws="$tmp/symlink-layout"; new_v062_workspace "$symlink_ws"
+mv -f -- "$symlink_ws/.beads/dolt" "$symlink_ws/.beads/dolt-real"
+ln -s dolt-real "$symlink_ws/.beads/dolt"
+assert_refused symlink-layout "$symlink_ws" unsafe_source_symlink
+
+mixed_ws="$tmp/mixed-target"; new_v062_workspace "$mixed_ws"
+mkdir -p "$mixed_ws/.beads/embeddeddolt"
+assert_refused mixed-target "$mixed_ws" mixed_storage_layout
+
+collision_ws="$tmp/rollback-collision"; new_v062_workspace "$collision_ws"
+mkdir -p "$collision_ws/.beads-v0.62.0-rollback"
+printf 'unrelated retained data\n' > "$collision_ws/.beads-v0.62.0-rollback/sentinel"
+assert_refused rollback-collision "$collision_ws" rollback_collision
+
+changed_ws="$tmp/retryable-source-changed"; new_v062_workspace "$changed_ws"
+changed_before=$(tree_fingerprint "$changed_ws")
+run_bridge retryable-source-changed "$changed_ws" \
+    --inspect --workspace "$changed_ws"
+[ "$RUN_STATUS" -eq 1 ] ||
+    fail "retryable source change exit=$RUN_STATUS, want refusal exit 1"
+assert_common_json inspect refused none
+jq -e '
+    .retryable == true and .code == "source_changed"
+' <<< "$RUN_STDOUT" >/dev/null ||
+    fail "valid retryable source change was not forwarded unchanged"
+assert_unchanged "$changed_ws" "$changed_before" \
+    "retryable source change refusal"
+
+assert_target_refused() {
+    local label="$1" target="$2" code="$3" ws="$tmp/$1"
+    local before
+    new_v062_workspace "$ws"
+    before=$(tree_fingerprint "$ws")
+    BRIDGE_TEST_TARGET="$target" run_bridge "$label" "$ws" --inspect --workspace "$ws"
+    [ "$RUN_STATUS" -eq 1 ] || fail "$label exit=$RUN_STATUS, want refusal exit 1"
+    assert_common_json inspect refused none
+    jq -e --arg code "$code" '.retryable == false and .code == $code' \
+        <<< "$RUN_STDOUT" >/dev/null || fail "$label returned the wrong refusal code"
+    assert_unchanged "$ws" "$before" "$label refusal"
+}
+
+assert_target_refused old-target "$OLD_TARGET_BD" target_binary_invalid
+grep -F -- '__migration-v062-inspect' "$OLD_TARGET_LOG" >/dev/null ||
+    fail "historical target was rejected without validating its hidden response"
+assert_target_refused incapable-target "$INCAPABLE_TARGET_BD" target_capability_missing
+grep -F -- '__migration-v062-inspect' "$INCAPABLE_TARGET_LOG" >/dev/null ||
+    fail "embedded-incapable target was rejected without a capability probe"
+
+timeout_ws="$tmp/timeout-target"
+new_v062_workspace "$timeout_ws"
+timeout_before=$(tree_fingerprint "$timeout_ws")
+timeout_started=$SECONDS
+BRIDGE_TEST_INSPECT_TIMEOUT_SECONDS=1 \
+BRIDGE_TEST_TARGET="$TIMEOUT_TARGET_BD" \
+    run_bridge timeout-target "$timeout_ws" --inspect --workspace "$timeout_ws"
+timeout_elapsed=$((SECONDS - timeout_started))
+[ "$RUN_STATUS" -eq 1 ] ||
+    fail "timeout target exit=$RUN_STATUS, want refusal exit 1"
+[ "$timeout_elapsed" -le 5 ] ||
+    fail "timeout target exceeded its wall-clock bound (${timeout_elapsed}s)"
+assert_common_json inspect refused none
+jq -e '
+    .retryable == true and .code == "target_inspection_timeout"
+' <<< "$RUN_STDOUT" >/dev/null ||
+    fail "target timeout was not reported as a retryable refusal"
+[ -s "${TIMEOUT_TARGET_LOG}.pid" ] ||
+    fail "timeout target did not record its process identity"
+timeout_target_pid=$(<"${TIMEOUT_TARGET_LOG}.pid")
+if kill -0 "$timeout_target_pid" 2>/dev/null; then
+    fail "timed-out target process $timeout_target_pid leaked"
+fi
+assert_unchanged "$timeout_ws" "$timeout_before" "target timeout refusal"
+
+# Apply always requires explicit consent, even on a terminal, and every
+# currently admitted apply remains truthfully unavailable and non-mutating.
+apply_ws="$tmp/apply-without-consent"; new_v062_workspace "$apply_ws"
+apply_before=$(tree_fingerprint "$apply_ws")
+run_bridge apply-without-consent "$apply_ws" --apply --workspace "$apply_ws"
+[ "$RUN_STATUS" -eq 2 ] || fail "apply without --yes exit=$RUN_STATUS, want 2"
+assert_common_json apply usage_error none
+jq -e '.retryable == false and .code == "confirmation_required"' \
+    <<< "$RUN_STDOUT" >/dev/null || fail "apply without --yes lacked stable JSON"
+assert_unchanged "$apply_ws" "$apply_before" "apply without --yes"
+
+run_apply_without_yes_on_tty "$apply_ws"
+[ "$RUN_STATUS" -eq 2 ] || fail "TTY apply without --yes exit=$RUN_STATUS, want 2"
+assert_unchanged "$apply_ws" "$apply_before" "TTY apply without --yes"
+
+run_bridge apply-unavailable "$apply_ws" --apply --yes --workspace "$apply_ws"
+[ "$RUN_STATUS" -eq 1 ] || fail "apply --yes exit=$RUN_STATUS, want 1"
+assert_common_json apply failed none
+jq -e '.retryable == false and .code == "apply_not_available"' \
+    <<< "$RUN_STDOUT" >/dev/null || fail "apply --yes overstated bridge availability"
+jq -e '
+    .verification.source_digest_scope == "admission_observation" and
+    .verification.apply_reinspection_required == true
+' <<< "$RUN_STDOUT" >/dev/null ||
+    fail "apply --yes omitted its mandatory source reinspection contract"
+assert_unchanged "$apply_ws" "$apply_before" "unavailable apply"
+
+# JSON is bootstrapped before ordinary parsing: even when --json follows an
+# invalid flag, the result is one structured usage error and no effects.
+run_bridge invalid-usage "$inspect_ws" --definitely-not-a-real-option
+[ "$RUN_STATUS" -eq 2 ] || fail "invalid usage exit=$RUN_STATUS, want 2"
+assert_common_json inspect usage_error none
+jq -e '.retryable == false and .code == "invalid_usage"' \
+    <<< "$RUN_STDOUT" >/dev/null || fail "invalid usage lacked stable JSON"
+assert_unchanged "$inspect_ws" "$inspect_before" "invalid usage"
+
+assert_usage_error() {
+    local label="$1" code="$2"
+    shift 2
+    run_bridge "$label" "$inspect_ws" "$@"
+    [ "$RUN_STATUS" -eq 2 ] ||
+        fail "$label exit=$RUN_STATUS, want usage exit 2"
+    assert_common_json inspect usage_error none
+    jq -e --arg code "$code" '.retryable == false and .code == $code' \
+        <<< "$RUN_STDOUT" >/dev/null ||
+        fail "$label lacked its stable usage code"
+    assert_unchanged "$inspect_ws" "$inspect_before" "$label"
+}
+
+assert_usage_error conflicting-modes invalid_usage --inspect --apply
+assert_usage_error inspect-with-yes invalid_usage --inspect --yes
+assert_usage_error workspace-missing-value invalid_usage --workspace
+assert_usage_error target-missing-value invalid_usage --target-bd
+
+for invalid_timeout in \
+    0 \
+    3601 \
+    999999999999999999999999999999999999999999999999999999999999 \
+    not-a-number; do
+    BRIDGE_TEST_INSPECT_TIMEOUT_SECONDS="$invalid_timeout" \
+        run_bridge "invalid-timeout-$invalid_timeout" "$inspect_ws" --inspect
+    [ "$RUN_STATUS" -eq 2 ] ||
+        fail "invalid timeout $invalid_timeout exit=$RUN_STATUS, want 2"
+    assert_common_json inspect usage_error none
+    jq -e '
+        .retryable == false and .code == "invalid_environment"
+    ' <<< "$RUN_STDOUT" >/dev/null ||
+        fail "invalid timeout $invalid_timeout lacked its stable usage code"
+    assert_unchanged "$inspect_ws" "$inspect_before" \
+        "invalid timeout $invalid_timeout"
+done
+
+# Close the test-double gap: exercise the actual built current bd through the
+# public shell entrypoint, hidden Cobra protocol, and descriptor-relative Go
+# inspector. This is the admission slice's real process-boundary E2E path.
+real_ws="$tmp/real-current-target"
+new_v062_workspace "$real_ws"
+# Fresh v0.62.0 workspaces using the default server endpoint omit these
+# optional metadata fields; exercise that authentic shape through the real
+# current binary rather than only the explicitly configured CI fixture.
+jq 'del(.dolt_server_host, .dolt_server_port)' \
+    "$real_ws/.beads/metadata.json" > "$real_ws/.beads/metadata.json.tmp"
+mv -f -- "$real_ws/.beads/metadata.json.tmp" \
+    "$real_ws/.beads/metadata.json"
+real_before=$(tree_fingerprint "$real_ws")
+
+hostile_cwd="$tmp/hostile-cwd"
+hostile_home="$tmp/hostile-home-real"
+mkdir -p \
+    "$hostile_cwd/.beads" \
+    "$hostile_home/.config/bd" \
+    "$hostile_home/.cache" \
+    "$hostile_home/.local/share" \
+    "$hostile_home/.local/state"
+printf '%s\n' '{"backend":"postgres","database":"postgres"}' \
+    > "$hostile_cwd/.beads/metadata.json"
+printf '%s\n' 'backend: postgres' > "$hostile_cwd/.beads/config.yaml"
+printf '%s\n' 'BD_BACKEND=postgres' > "$hostile_cwd/.beads/.env"
+printf '%s\n' 'metrics.disabled: false' \
+    > "$hostile_home/.config/bd/config.yaml"
+hostile_cwd_before=$(tree_fingerprint "$hostile_cwd")
+hostile_home_before=$(tree_fingerprint "$hostile_home")
+hidden_real_stdout="$tmp/hidden-real.stdout"
+hidden_real_stderr="$tmp/hidden-real.stderr"
+set +e
+(
+    cd "$hostile_cwd"
+    env \
+        HOME="$hostile_home" \
+        XDG_CONFIG_HOME="$hostile_home/.config" \
+        XDG_CACHE_HOME="$hostile_home/.cache" \
+        XDG_DATA_HOME="$hostile_home/.local/share" \
+        XDG_STATE_HOME="$hostile_home/.local/state" \
+        BD_BACKEND=postgres BD_DATABASE_BACKEND=mysql \
+        BEADS_DB='postgres://poison.invalid/beads' \
+        BD_DB='mysql://poison.invalid/beads' \
+        BEADS_DIR="$hostile_cwd/.beads" \
+        "$REAL_TARGET_BD" __migration-v062-inspect \
+            --workspace "$real_ws" --json \
+            > "$hidden_real_stdout" 2> "$hidden_real_stderr"
+)
+hidden_real_status=$?
+set -e
+[ "$hidden_real_status" -eq 0 ] ||
+    fail "real hidden command exit=$hidden_real_status, want 0"
+[ ! -s "$hidden_real_stderr" ] ||
+    fail "real hidden command emitted stderr: $(<"$hidden_real_stderr")"
+jq -e --arg workspace "$real_ws" '
+    keys == ["effect", "operation", "retryable", "schema_version",
+             "source", "status", "target"] and
+    .schema_version == 1 and .operation == "v062_source_inspection" and
+    .status == "qualified" and .retryable == false and .effect == "none" and
+    .source.workspace == $workspace and .source.version == "0.62.0" and
+    .source.backend == "dolt-server" and
+    .source.digest_scope == "admission_observation" and
+    (.source.tree_sha256 | test("^[0-9a-f]{64}$")) and
+    .target.backend == "dolt-embedded" and
+    .target.embedded_capable == true
+' "$hidden_real_stdout" >/dev/null ||
+    fail "real hidden command did not emit the exact qualified protocol"
+assert_unchanged "$real_ws" "$real_before" "real hidden command"
+assert_unchanged "$hostile_cwd" "$hostile_cwd_before" \
+    "real hidden command hostile cwd"
+assert_unchanged "$hostile_home" "$hostile_home_before" \
+    "real hidden command hostile home"
+hidden_real_digest=$(jq -r '.source.tree_sha256' "$hidden_real_stdout")
+
+BRIDGE_TEST_TARGET="$REAL_TARGET_BD" \
+    run_bridge real-current-target "$real_ws" \
+        --inspect --workspace "$real_ws"
+[ "$RUN_STATUS" -eq 1 ] ||
+    fail "real current target exit=$RUN_STATUS, want fail-closed exit 1"
+assert_common_json inspect failed none
+jq -e --arg workspace "$real_ws" --arg digest "$hidden_real_digest" '
+    .retryable == false and .code == "apply_not_available" and
+    .source.workspace == $workspace and .source.version == "0.62.0" and
+    .source.backend == "dolt-server" and
+    .source.digest_scope == "admission_observation" and
+    .source.tree_sha256 == $digest and
+    .target.backend == "dolt-embedded" and
+    .target.embedded_capable == true and
+    .verification.source_digest_scope == "admission_observation" and
+    .verification.apply_reinspection_required == true
+' <<< "$RUN_STDOUT" >/dev/null ||
+    fail "real current target did not return the qualified admission plan"
+assert_unchanged "$real_ws" "$real_before" "real current target inspection"
+
+real_negative_ws="$tmp/real-current-negative"
+new_v062_workspace "$real_negative_ws"
+printf '0.61.0\n' > "$real_negative_ws/.beads/.local_version"
+real_negative_before=$(tree_fingerprint "$real_negative_ws")
+BRIDGE_TEST_TARGET="$REAL_TARGET_BD" \
+    run_bridge real-current-negative "$real_negative_ws" \
+        --inspect --workspace "$real_negative_ws"
+[ "$RUN_STATUS" -eq 1 ] ||
+    fail "real negative source exit=$RUN_STATUS, want refusal exit 1"
+assert_common_json inspect refused none
+jq -e '
+    .retryable == false and .code == "source_version_mismatch"
+' <<< "$RUN_STDOUT" >/dev/null ||
+    fail "real negative source did not preserve its typed refusal"
+assert_unchanged "$real_negative_ws" "$real_negative_before" \
+    "real negative source refusal"
+
+printf 'public-v062-bridge-test: PASS\n'


### PR DESCRIPTION
## What

Add the public `scripts/migrate-v062-server-to-current.sh` entrypoint and a hidden, lifecycle-free `bd` inspection protocol for official v0.62.0 local Dolt-server workspaces.

This stacked slice is deliberately admission-only: inspect is the default, source effects are always `none`, and `--apply --yes` truthfully returns `apply_not_available` until rollback, import, and fidelity verification are wired through this exact public path.

## Why

The existing official v0.62 qualification lane proves an internal test recipe, but users need a stable public boundary that fails before ambient configuration, provider selection, store initialization, or source mutation. This establishes that boundary on the multi-provider stack without overstating that effectful migration is ready.

Parent: #4835

## Safety and scope

- Uses descriptor-relative, no-follow, no-atime Linux inspection with same-device and Linux mount-ID checks.
- Compares two complete structure/content observations and revalidates retained descriptors and witnesses.
- Accepts exact v0.62 metadata fields, including authentic default metadata that omits persisted host/port; rejects current-only global selectors and foreign/mixed provider layouts.
- Treats the inspection digest as admission evidence only; a future apply must rebind and reinspect under its own fence.
- Scrubs ambient PostgreSQL, MySQL, SQLite, and Dolt selectors from target subprocesses.
- Enforces exact single-object JSON plus process-exit tuples, bounded timeout, and process cleanup.
- Adds no schema, provider DDL, storage-engine recovery logic, automatic migration, or user-visible `bd` command.

## Verification

- `GOFLAGS=-mod=readonly make build`
- Public shell → real built `bd` → hidden command → Go inspector E2E
- Official checksum-pinned v0.62.0 binary + checksum-pinned Dolt 1.84.0 real lane: 5 issues, 8 features, 0 fidelity violations; blocker/ready/close and rollback/source preservation pass
- Strict migration harness guards
- Focused `cmd/bd` lifecycle suite
- Internal package, race, no-CGO, Darwin/Windows compile, vet, golangci-lint, Bash syntax, ShellCheck, actionlint, gofmt, and diff checks
- Repository-wide `make test` passed every package except the aggregate `cmd/bd` package, which hit its 3-minute package timeout in an existing init-metrics subprocess test; that exact test passes alone in 42.4s and all changed focused tests pass

Exact staged binary-diff SHA-256: `2ede9a461cc36096529709af82019b2c371662b63a2ae20bf6a045441d172537`.

Independent exact-hash council reviews: 0 Critical, 0 Important in both lanes. Anthropic and local Codex OAuth pools returned 401, so the recorded fallbacks were the Claude Code harness with `deepseek-v4-flash:cloud` and an independent platform Codex subagent.

Human review is required before merge because this is a protected migration path.

_codex-unknown-model-unknown-reasoning on behalf of Test User_
