### PR TITLE
fix(claim): stop the refusal copy from teaching claim eviction (bd-at6rc)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   entirely. A task gated on an epic becomes ready when the epic itself is
   closed, consistent with `bd ready`/`bd blocked`.
 
+- **Claim/unclaim refusals now steer toward the holder instead of teaching
+  eviction** (bd-at6rc, wyvern wy-zs5s2). The `--claim` refusal for an issue
+  assigned to someone else suggested `bd unclaim <id>` — in a multi-agent
+  fleet that copy taught an unclaim-then-claim steamroller that evicted a
+  live, heartbeated claim mid-review. The refusal now says to coordinate
+  with the holder, and unclaim's ownership rejection frames `--force` as an
+  abandoned-claim escape hatch rather than a routine override. (The
+  ownership check itself — foreign unclaim requires `--force` — landed in
+  [#4675](https://github.com/gastownhall/beads/pull/4675).)
+
 ### Added
 
 - **Work leases: claim-TTL, heartbeat, and reclaim for dead-worker recovery**

--- a/cmd/bd/unclaim.go
+++ b/cmd/bd/unclaim.go
@@ -20,6 +20,11 @@ var unclaimCmd = &cobra.Command{
 Use this when an agent crashes mid-work or you need to abandon a claimed task.
 The issue becomes available for re-claiming by other agents.
 
+Only the current assignee can release its own claim. Releasing another
+actor's claim requires --force and should be coordinated with the holder
+first — their claim may be live even if the issue looks idle. Prefer
+letting lease expiry reclaim genuinely abandoned work.
+
 Examples:
   bd unclaim bd-123
   bd unclaim bd-123 --reason "Agent crashed"

--- a/cmd/bd/unclaim_embedded_test.go
+++ b/cmd/bd/unclaim_embedded_test.go
@@ -188,6 +188,11 @@ func TestEmbeddedUnclaim(t *testing.T) {
 		if !strings.Contains(out, "held by alice") && !strings.Contains(out, "claimed by a different actor") {
 			t.Errorf("expected ownership-rejection error, got: %s", out)
 		}
+		// The rejection should frame --force as an abandoned-claim escape
+		// hatch, not a routine override (bd-at6rc / wy-zs5s2).
+		if !strings.Contains(out, "coordinate with the holder") {
+			t.Errorf("rejection should say coordinate-with-holder, got: %s", out)
+		}
 
 		// The claim must be untouched after the rejected release.
 		got := bdShow(t, bd, dir, issue.ID)

--- a/cmd/bd/update_embedded_test.go
+++ b/cmd/bd/update_embedded_test.go
@@ -676,6 +676,13 @@ func TestEmbeddedUpdate(t *testing.T) {
 		if strings.Contains(out, "to release it before re-claiming") {
 			t.Errorf("refusal must not suggest plain unclaim of a foreign claim, got: %s", out)
 		}
+		// Nor may it name unclaim or --force at all: copy that names an
+		// eviction command gets pattern-matched by batch agents into
+		// `unclaim --force; claim` — a stronger steamroller than the one
+		// this fix removed (wy-yuclk).
+		if strings.Contains(out, "unclaim") || strings.Contains(out, "--force") {
+			t.Errorf("claim refusal must not name an eviction command, got: %s", out)
+		}
 	})
 
 	// A batch where one claim is lost and another is won must exit non-zero, so

--- a/cmd/bd/update_embedded_test.go
+++ b/cmd/bd/update_embedded_test.go
@@ -668,6 +668,14 @@ func TestEmbeddedUpdate(t *testing.T) {
 		if !strings.Contains(out, "already assigned to") {
 			t.Errorf("expected 'already assigned to' error, got: %s", out)
 		}
+		// The refusal must steer toward the holder, not teach an
+		// unclaim-then-claim eviction of a live claim (bd-at6rc / wy-zs5s2).
+		if !strings.Contains(out, "coordinate with the holder") {
+			t.Errorf("refusal should say coordinate-with-holder, got: %s", out)
+		}
+		if strings.Contains(out, "to release it before re-claiming") {
+			t.Errorf("refusal must not suggest plain unclaim of a foreign claim, got: %s", out)
+		}
 	})
 
 	// A batch where one claim is lost and another is won must exit non-zero, so

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -1535,6 +1535,11 @@ Release a claimed issue by clearing the assignee and resetting status to 'open'.
 Use this when an agent crashes mid-work or you need to abandon a claimed task.
 The issue becomes available for re-claiming by other agents.
 
+Only the current assignee can release its own claim. Releasing another
+actor's claim requires --force and should be coordinated with the holder
+first — their claim may be live even if the issue looks idle. Prefer
+letting lease expiry reclaim genuinely abandoned work.
+
 Examples:
   bd unclaim bd-123
   bd unclaim bd-123 --reason "Agent crashed"
@@ -2357,6 +2362,16 @@ Commands:
 DoltHub is recommended for cloud backup:
   bd backup init https://doltremoteapi.dolthub.com/&lt;user&gt;/&lt;repo&gt;
   Set DOLT_REMOTE_USER and DOLT_REMOTE_PASSWORD for authentication.
+
+Auto-backup default:
+  When backup.enabled is unset, auto-backup turns ON in embedded mode if a
+  git remote exists, and stays OFF in sql-server / shared-server mode. In
+  server mode many bd clients share one Dolt server, and each would register
+  a server-side backup remote under the same name pointing at its own local
+  dir and full-sync the whole database — a self-amplifying storm. To back up
+  a shared server, run 'bd backup' explicitly (or set backup.enabled=true and
+  coordinate destinations). 'bd config get backup.enabled' shows the effective
+  value and its source.
 
 ```
 bd backup [command]

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -639,9 +639,11 @@ Gate types:
   timer   - Expires after timeout (Phase 2)
   gh:run  - Waits for GitHub workflow (Phase 3)
   gh:pr   - Waits for PR merge (Phase 3)
-  bead    - Waits for cross-rig bead to close (Phase 4)
+  bead    - Waits for another bead to close (Phase 4)
 
-For bead gates, await_id format is &lt;rig&gt;:&lt;bead-id&gt; (e.g., "other-project:op-abc123").
+For bead gates, await_id is a bead ID in this rig's database (e.g., "bd-abc123").
+The historical cross-rig form &lt;rig&gt;:&lt;bead-id&gt; can no longer be evaluated
+(multi-rig routing removed) and stays pending until resolved manually.
 
 Examples:
   bd gate list           # Show all open gates

--- a/docs/cli-reference/backup.md
+++ b/docs/cli-reference/backup.md
@@ -25,6 +25,16 @@ DoltHub is recommended for cloud backup:
   bd backup init https://doltremoteapi.dolthub.com/&lt;user&gt;/&lt;repo&gt;
   Set DOLT_REMOTE_USER and DOLT_REMOTE_PASSWORD for authentication.
 
+Auto-backup default:
+  When backup.enabled is unset, auto-backup turns ON in embedded mode if a
+  git remote exists, and stays OFF in sql-server / shared-server mode. In
+  server mode many bd clients share one Dolt server, and each would register
+  a server-side backup remote under the same name pointing at its own local
+  dir and full-sync the whole database — a self-amplifying storm. To back up
+  a shared server, run 'bd backup' explicitly (or set backup.enabled=true and
+  coordinate destinations). 'bd config get backup.enabled' shows the effective
+  value and its source.
+
 ```
 bd backup [command]
 ```

--- a/docs/cli-reference/gate.md
+++ b/docs/cli-reference/gate.md
@@ -17,9 +17,11 @@ Gate types:
   timer   - Expires after timeout (Phase 2)
   gh:run  - Waits for GitHub workflow (Phase 3)
   gh:pr   - Waits for PR merge (Phase 3)
-  bead    - Waits for cross-rig bead to close (Phase 4)
+  bead    - Waits for another bead to close (Phase 4)
 
-For bead gates, await_id format is &lt;rig&gt;:&lt;bead-id&gt; (e.g., "other-project:op-abc123").
+For bead gates, await_id is a bead ID in this rig's database (e.g., "bd-abc123").
+The historical cross-rig form &lt;rig&gt;:&lt;bead-id&gt; can no longer be evaluated
+(multi-rig routing removed) and stays pending until resolved manually.
 
 Examples:
   bd gate list           # Show all open gates

--- a/docs/cli-reference/unclaim.md
+++ b/docs/cli-reference/unclaim.md
@@ -12,6 +12,11 @@ Release a claimed issue by clearing the assignee and resetting status to 'open'.
 Use this when an agent crashes mid-work or you need to abandon a claimed task.
 The issue becomes available for re-claiming by other agents.
 
+Only the current assignee can release its own claim. Releasing another
+actor's claim requires --force and should be coordinated with the holder
+first — their claim may be live even if the issue looks idle. Prefer
+letting lease expiry reclaim genuinely abandoned work.
+
 Examples:
   bd unclaim bd-123
   bd unclaim bd-123 --reason "Agent crashed"

--- a/internal/storage/issueops/claim.go
+++ b/internal/storage/issueops/claim.go
@@ -114,7 +114,10 @@ func ClaimIssueInTx(ctx context.Context, tx DBTX, id string, actor string) (*Cla
 		}
 		if assignee != "" && assignee != actor {
 			if currentStatus == types.StatusOpen {
-				return nil, fmt.Errorf("issue already assigned to %q. Use `bd unclaim %s` to release it before re-claiming", assignee, id)
+				// Do not suggest `bd unclaim` here: that copy taught agents to
+				// evict each other's live claims (an unclaim+claim steamroller
+				// observed in multi-agent fleets). Point at the holder instead.
+				return nil, fmt.Errorf("issue already assigned to %q — coordinate with the holder instead of releasing their claim (releasing another actor's claim requires bd unclaim --force)", assignee)
 			}
 			return nil, fmt.Errorf("%w by %s", storage.ErrAlreadyClaimed, assignee)
 		}

--- a/internal/storage/issueops/claim.go
+++ b/internal/storage/issueops/claim.go
@@ -114,10 +114,13 @@ func ClaimIssueInTx(ctx context.Context, tx DBTX, id string, actor string) (*Cla
 		}
 		if assignee != "" && assignee != actor {
 			if currentStatus == types.StatusOpen {
-				// Do not suggest `bd unclaim` here: that copy taught agents to
-				// evict each other's live claims (an unclaim+claim steamroller
-				// observed in multi-agent fleets). Point at the holder instead.
-				return nil, fmt.Errorf("issue already assigned to %q — coordinate with the holder instead of releasing their claim (releasing another actor's claim requires bd unclaim --force)", assignee)
+				// Do not name a release command here — not `bd unclaim`, not
+				// `bd unclaim --force`. Refusal copy that names one gets
+				// pattern-matched by batch agents into an unclaim+claim
+				// steamroller of live claims (wy-yuclk). Point at the holder;
+				// bd reclaim is safe to name because it only recovers claims
+				// whose lease has already expired.
+				return nil, fmt.Errorf("issue already assigned to %q — coordinate with the holder; if their claim is abandoned (crashed agent), lease expiry will surface it for bd reclaim", assignee)
 			}
 			return nil, fmt.Errorf("%w by %s", storage.ErrAlreadyClaimed, assignee)
 		}

--- a/internal/storage/issueops/unclaim.go
+++ b/internal/storage/issueops/unclaim.go
@@ -54,7 +54,7 @@ func UnclaimIssueInTx(ctx context.Context, tx *sql.Tx, id string, actor string, 
 	// Validate ownership unless the caller forced the release. Without force, a
 	// process may only release its own claim.
 	if !force && oldIssue.Assignee != actor {
-		return fmt.Errorf("%w: %s is held by %s (use --force to override)",
+		return fmt.Errorf("%w: %s is held by %s; coordinate with the holder — pass --force only if their claim is abandoned (crashed agent, expired lease)",
 			storage.ErrNotOwner, id, oldIssue.Assignee)
 	}
 
@@ -97,7 +97,7 @@ func UnclaimIssueInTx(ctx context.Context, tx *sql.Tx, id string, actor string, 
 			return fmt.Errorf("failed to unclaim issue %s: no matching row", id)
 		}
 		if !force && current.Assignee != actor {
-			return fmt.Errorf("%w: %s is held by %s (use --force to override)",
+			return fmt.Errorf("%w: %s is held by %s; coordinate with the holder — pass --force only if their claim is abandoned (crashed agent, expired lease)",
 				storage.ErrNotOwner, id, current.Assignee)
 		}
 		return fmt.Errorf("failed to unclaim issue %s: no matching row", id)


### PR DESCRIPTION
## Summary

From a real wyvern multi-agent incident (forensics `wy-yuclk`, ask `wy-zs5s2`): the `--claim` refusal for an issue assigned to another actor said *"Use `bd unclaim <id>` to release it before re-claiming"*. That copy taught agents an eviction steamroller — a silenced `unclaim; claim` batch loop yanked another agent's **live, heartbeated** claim mid-review.

The ownership check itself (foreign unclaim requires `--force`) already landed in #4675 and ships with the next release. This PR completes the wyvern ask by fixing the guidance around it:

- The open-but-assigned `--claim` refusal now says **coordinate with the holder** and points at lease expiry / `bd reclaim` for abandoned claims. It deliberately names **no** release command: an adversarial review pass caught that the first cut of this copy said "requires `bd unclaim --force`" — handing the same literal-minded batch agents an even stronger steamroller. `bd reclaim` is safe to name because it only recovers already-expired leases.
- Unclaim's `ErrNotOwner` rejection frames `--force` as an abandoned-claim escape hatch (crashed agent, expired lease), not a routine override.
- `bd unclaim --help` documents the ownership rule and points at lease expiry for genuinely abandoned work.

## Testing

- Extended `TestEmbeddedUpdate/update_claim_already_claimed` and `TestEmbeddedUnclaim/unclaim_non_owner_rejected` to pin the coordinate-with-holder copy and assert the old release-before-reclaiming suggestion stays gone.
- The claim-refusal test additionally pins that the copy names neither `unclaim` nor `--force`.
- `TestEmbeddedUnclaim`, `TestEmbeddedUpdate`, and the storage `Claim|Unclaim` suites pass; `gofmt` clean.

## Notes

- CLI reference regenerated; includes the same pre-existing auto-backup help-drift hunk as #4839 (identical content, merges cleanly in either order).
- Tracked as bd-at6rc (P1); requested by the wyvern rig. Sibling PR: #4839 (no-ID last-touched fallback guard, bd-m00pb).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
