### PR TITLE
feat(claim): pool-aware claiming via the claim.pools config key (bd-bguz6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Pool-aware claiming via the `claim.pools` config key** (bd-bguz6).
+  Dispatcher fleets pre-assign issues to a pool pseudo-assignee (e.g.
+  `fable-crew`); `--claim` previously refused those ("already assigned"),
+  forcing a two-step `--assignee <me> -s in_progress` per issue. Aliases
+  listed in `bd config set claim.pools "fable-crew,night-crew"` are now
+  claimable by any actor through the same atomic compare-and-swap — the
+  claim stamps the normal lease, and issues assigned to a real actor (or
+  to an alias not in the config) keep their anti-steal protection.
+  Off by default: with no `claim.pools` configured, behavior is unchanged.
+
 - **Work leases: claim-TTL, heartbeat, and reclaim for dead-worker recovery**
   (schema v54, migration `0054`)
   ([#4537](https://github.com/gastownhall/beads/pull/4537)). A claim was

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   claimable by any actor through the same atomic compare-and-swap — the
   claim stamps the normal lease, and issues assigned to a real actor (or
   to an alias not in the config) keep their anti-steal protection.
+  Pool-aware claiming works in every dolt mode — the proxied-server claim
+  path applies the same predicate — and `claim.*` is a recognized config
+  namespace (documented in `bd config --help`). Note: if a pool take's
+  lease expires, `bd reclaim` returns the issue to the unassigned pool,
+  not to the pool alias it was dispatched to.
   Off by default: with no `claim.pools` configured, behavior is unchanged.
 
 - **Work leases: claim-TTL, heartbeat, and reclaim for dead-worker recovery**

--- a/cmd/bd/claim_pools_embedded_test.go
+++ b/cmd/bd/claim_pools_embedded_test.go
@@ -31,6 +31,11 @@ func TestEmbeddedClaimPools(t *testing.T) {
 	cfgCmd.Env = bdEnv(dir)
 	if out, err := cfgCmd.CombinedOutput(); err != nil {
 		t.Fatalf("bd config set claim.pools failed: %v\n%s", err, out)
+	} else if strings.Contains(string(out), "not a recognized config key") {
+		// The exit code alone missed this once: claim.* must be a
+		// recognized namespace so the feature's setup command doesn't
+		// warn every adopter.
+		t.Fatalf("bd config set claim.pools warned about an unrecognized key:\n%s", out)
 	}
 
 	t.Run("claim_from_pool_succeeds", func(t *testing.T) {

--- a/cmd/bd/claim_pools_embedded_test.go
+++ b/cmd/bd/claim_pools_embedded_test.go
@@ -1,0 +1,106 @@
+//go:build cgo
+
+package main
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// TestEmbeddedClaimPools covers pool-aware claiming (bd-bguz6): issues
+// pre-assigned to a pool alias listed in the claim.pools config are
+// claimable by any actor through the normal --claim CAS, while issues
+// assigned to a real actor (or to an unconfigured alias) keep their
+// anti-steal protection. Mirrors the wyvern dispatcher pattern that
+// pre-assigns review beads to "fable-crew".
+func TestEmbeddedClaimPools(t *testing.T) {
+	if os.Getenv("BEADS_TEST_EMBEDDED_DOLT") != "1" {
+		t.Skip("set BEADS_TEST_EMBEDDED_DOLT=1 to run embedded dolt integration tests")
+	}
+	t.Parallel()
+
+	bd := buildEmbeddedBD(t)
+	dir, _, _ := bdInit(t, bd, "--prefix", "tp")
+
+	cfgCmd := exec.Command(bd, "config", "set", "claim.pools", "fable-crew, night-crew")
+	cfgCmd.Dir = dir
+	cfgCmd.Env = bdEnv(dir)
+	if out, err := cfgCmd.CombinedOutput(); err != nil {
+		t.Fatalf("bd config set claim.pools failed: %v\n%s", err, out)
+	}
+
+	t.Run("claim_from_pool_succeeds", func(t *testing.T) {
+		issue := bdCreate(t, bd, dir, "Pool-dispatched review", "--type", "task")
+		bdUpdate(t, bd, dir, issue.ID, "--assignee", "fable-crew")
+
+		bdUpdate(t, bd, dir, issue.ID, "--claim", "--actor", "tortoise")
+
+		got := bdShow(t, bd, dir, issue.ID)
+		if got.Assignee != "tortoise" {
+			t.Errorf("assignee after pool claim = %q, want tortoise", got.Assignee)
+		}
+		if got.Status != types.StatusInProgress {
+			t.Errorf("status after pool claim = %s, want in_progress", got.Status)
+		}
+
+		// The full dispatcher flow: claim from pool, work, close — no
+		// reassign-then-close two-step (the friction reported in bd-bguz6).
+		bdClose(t, bd, dir, issue.ID, "--reason", "reviewed", "--actor", "tortoise")
+		gotClosed := bdShow(t, bd, dir, issue.ID)
+		if gotClosed.Status != types.StatusClosed {
+			t.Errorf("status after close = %s, want closed", gotClosed.Status)
+		}
+	})
+
+	t.Run("second_pool_alias_also_claimable", func(t *testing.T) {
+		issue := bdCreate(t, bd, dir, "Night shift item", "--type", "task")
+		bdUpdate(t, bd, dir, issue.ID, "--assignee", "night-crew")
+		bdUpdate(t, bd, dir, issue.ID, "--claim", "--actor", "owl")
+		got := bdShow(t, bd, dir, issue.ID)
+		if got.Assignee != "owl" {
+			t.Errorf("assignee = %q, want owl", got.Assignee)
+		}
+	})
+
+	t.Run("real_actor_assignment_still_protected", func(t *testing.T) {
+		issue := bdCreate(t, bd, dir, "Alice's work", "--type", "task")
+		bdUpdate(t, bd, dir, issue.ID, "--assignee", "alice")
+
+		out := bdUpdateFail(t, bd, dir, issue.ID, "--claim", "--actor", "tortoise")
+		if !strings.Contains(out, "already assigned to") {
+			t.Errorf("expected anti-steal refusal, got: %s", out)
+		}
+
+		got := bdShow(t, bd, dir, issue.ID)
+		if got.Assignee != "alice" {
+			t.Errorf("assignee after refused claim = %q, want alice (unchanged)", got.Assignee)
+		}
+	})
+
+	t.Run("unconfigured_alias_still_protected", func(t *testing.T) {
+		issue := bdCreate(t, bd, dir, "Other crew's work", "--type", "task")
+		bdUpdate(t, bd, dir, issue.ID, "--assignee", "other-crew")
+
+		out := bdUpdateFail(t, bd, dir, issue.ID, "--claim", "--actor", "tortoise")
+		if !strings.Contains(out, "already assigned to") {
+			t.Errorf("expected refusal for unconfigured alias, got: %s", out)
+		}
+	})
+
+	t.Run("pool_claim_stamps_lease", func(t *testing.T) {
+		// A pool take is a normal claim: it must carry a lease so the
+		// reclaim machinery can recover it if the taker dies.
+		issue := bdCreate(t, bd, dir, "Leased pool item", "--type", "task")
+		bdUpdate(t, bd, dir, issue.ID, "--assignee", "fable-crew")
+		bdUpdate(t, bd, dir, issue.ID, "--claim", "--actor", "tortoise")
+
+		raw := bdShowJSON(t, bd, dir, issue.ID)
+		if !strings.Contains(raw, "lease_expires_at") {
+			t.Errorf("pool claim should stamp a lease; show --json: %s", raw)
+		}
+	})
+}

--- a/cmd/bd/config.go
+++ b/cmd/bd/config.go
@@ -39,6 +39,7 @@ Common namespaces:
   - notion.*          Notion integration settings
   - custom.*          Custom integration settings
   - status.*          Issue status configuration
+  - claim.*           Claim arbitration settings (pool-aware claiming)
   - doctor.suppress.* Suppress specific bd doctor warnings (GH#1095)
 
 Auto-Export (config.yaml):
@@ -72,6 +73,18 @@ Custom Status States:
   This enables issues to use statuses like 'awaiting_review' in addition to
   the built-in statuses (open, in_progress, blocked, deferred, closed).
 
+Claim Pools:
+  A dispatcher can pre-assign issues to a pool pseudo-assignee (e.g.
+  "fable-crew") and let any actor take them with --claim. List the pool
+  aliases in the claim.pools config key, comma-separated:
+
+    bd config set claim.pools "fable-crew,night-crew"
+
+  Issues assigned to a real actor (or to an alias not in the list) keep
+  their anti-steal protection. Pool takes carry the normal lease; note
+  that if a taker's lease expires, bd reclaim returns the issue to the
+  unassigned pool, not to the pool alias it was dispatched to.
+
 Suppressing Doctor Warnings:
   Suppress specific bd doctor warnings by check name slug:
     bd config set doctor.suppress.pending-migrations true
@@ -88,6 +101,7 @@ Examples:
   bd config set jira.url "https://company.atlassian.net"
   bd config set jira.project "PROJ"
   bd config set status.custom "awaiting_review,awaiting_testing"
+  bd config set claim.pools "fable-crew,night-crew"    # Pool aliases claimable by any actor
   bd config set doctor.suppress.pending-migrations true
   bd config set dolt.debug true                        # Enable Dolt sql-server debug mode (loglevel=debug, --prof cpu)
   bd config set dolt.local-only true                   # Skip wiring a Dolt sync remote during bd init
@@ -926,6 +940,7 @@ var recognizedConfigPrefixes = []string{
 	"status.", "types.", "doctor.suppress.", "routing.", "sync.", "git.",
 	"directory.", "repos.", "external_projects.", "validation.",
 	"hierarchy.", "ai.", "backup.", "federation.", "metrics.", "agent.",
+	"claim.",
 }
 
 // allRecognizedConfigPrefixes returns the static namespaces plus the prefix of

--- a/cmd/bd/config_validate_key_test.go
+++ b/cmd/bd/config_validate_key_test.go
@@ -13,6 +13,7 @@ func TestIsRecognizedConfigKey(t *testing.T) {
 		"doctor.suppress.git-hooks", "no-git-ops", "beads.role",
 		"status.custom", "types.custom", "types.infra", "ai.model",
 		"backup.enabled", "import.path", "dolt.local-only", "agent.profile",
+		"claim.pools",
 		// Tracker namespaces are derived from the registry (GH#4427); cover
 		// ado (the original bug) plus the others removed from the static list.
 		"ado.org", "ado.project", "github.token", "linear.api-key",

--- a/cmd/bd/update.go
+++ b/cmd/bd/update.go
@@ -666,7 +666,7 @@ func init() {
 	updateCmd.Flags().StringSlice("remove-label", nil, "Remove labels (repeatable)")
 	updateCmd.Flags().StringSlice("set-labels", nil, "Set labels, replacing all existing (repeatable)")
 	updateCmd.Flags().String("parent", "", "New parent issue ID (reparents the issue, use empty string to remove parent)")
-	updateCmd.Flags().Bool("claim", false, "Atomically claim the issue (sets assignee to you, status to in_progress; idempotent if already claimed by you)")
+	updateCmd.Flags().Bool("claim", false, "Atomically claim the issue (sets assignee to you, status to in_progress; idempotent if already claimed by you; issues assigned to a pool alias listed in the claim.pools config are claimable too)")
 	updateCmd.Flags().String("session", "", "Claude Code session ID for status=closed (or set CLAUDE_SESSION_ID env var)")
 	// Time-based scheduling flags (GH#820)
 	// Examples:

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -2769,6 +2769,7 @@ Common namespaces:
   - notion.*          Notion integration settings
   - custom.*          Custom integration settings
   - status.*          Issue status configuration
+  - claim.*           Claim arbitration settings (pool-aware claiming)
   - doctor.suppress.* Suppress specific bd doctor warnings (GH#1095)
 
 Auto-Export (config.yaml):
@@ -2802,6 +2803,18 @@ Custom Status States:
   This enables issues to use statuses like 'awaiting_review' in addition to
   the built-in statuses (open, in_progress, blocked, deferred, closed).
 
+Claim Pools:
+  A dispatcher can pre-assign issues to a pool pseudo-assignee (e.g.
+  "fable-crew") and let any actor take them with --claim. List the pool
+  aliases in the claim.pools config key, comma-separated:
+
+    bd config set claim.pools "fable-crew,night-crew"
+
+  Issues assigned to a real actor (or to an alias not in the list) keep
+  their anti-steal protection. Pool takes carry the normal lease; note
+  that if a taker's lease expires, bd reclaim returns the issue to the
+  unassigned pool, not to the pool alias it was dispatched to.
+
 Suppressing Doctor Warnings:
   Suppress specific bd doctor warnings by check name slug:
     bd config set doctor.suppress.pending-migrations true
@@ -2818,6 +2831,7 @@ Examples:
   bd config set jira.url "https://company.atlassian.net"
   bd config set jira.project "PROJ"
   bd config set status.custom "awaiting_review,awaiting_testing"
+  bd config set claim.pools "fable-crew,night-crew"    # Pool aliases claimable by any actor
   bd config set doctor.suppress.pending-migrations true
   bd config set dolt.debug true                        # Enable Dolt sql-server debug mode (loglevel=debug, --prof cpu)
   bd config set dolt.local-only true                   # Skip wiring a Dolt sync remote during bd init

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -1579,7 +1579,7 @@ bd update [id...] [flags]
   -a, --assignee string              Assignee
       --await-id string              Set gate await_id (e.g., GitHub run ID for gh:run gates)
       --body-file string             Read description from file (use - for stdin)
-      --claim                        Atomically claim the issue (sets assignee to you, status to in_progress; idempotent if already claimed by you)
+      --claim                        Atomically claim the issue (sets assignee to you, status to in_progress; idempotent if already claimed by you; issues assigned to a pool alias listed in the claim.pools config are claimable too)
       --defer string                 Defer until date (empty to clear). Issue hidden from bd ready until then
   -d, --description string           Issue description
       --design string                Design notes

--- a/docs/cli-reference/config.md
+++ b/docs/cli-reference/config.md
@@ -22,6 +22,7 @@ Common namespaces:
   - notion.*          Notion integration settings
   - custom.*          Custom integration settings
   - status.*          Issue status configuration
+  - claim.*           Claim arbitration settings (pool-aware claiming)
   - doctor.suppress.* Suppress specific bd doctor warnings (GH#1095)
 
 Auto-Export (config.yaml):
@@ -55,6 +56,18 @@ Custom Status States:
   This enables issues to use statuses like 'awaiting_review' in addition to
   the built-in statuses (open, in_progress, blocked, deferred, closed).
 
+Claim Pools:
+  A dispatcher can pre-assign issues to a pool pseudo-assignee (e.g.
+  "fable-crew") and let any actor take them with --claim. List the pool
+  aliases in the claim.pools config key, comma-separated:
+
+    bd config set claim.pools "fable-crew,night-crew"
+
+  Issues assigned to a real actor (or to an alias not in the list) keep
+  their anti-steal protection. Pool takes carry the normal lease; note
+  that if a taker's lease expires, bd reclaim returns the issue to the
+  unassigned pool, not to the pool alias it was dispatched to.
+
 Suppressing Doctor Warnings:
   Suppress specific bd doctor warnings by check name slug:
     bd config set doctor.suppress.pending-migrations true
@@ -71,6 +84,7 @@ Examples:
   bd config set jira.url "https://company.atlassian.net"
   bd config set jira.project "PROJ"
   bd config set status.custom "awaiting_review,awaiting_testing"
+  bd config set claim.pools "fable-crew,night-crew"    # Pool aliases claimable by any actor
   bd config set doctor.suppress.pending-migrations true
   bd config set dolt.debug true                        # Enable Dolt sql-server debug mode (loglevel=debug, --prof cpu)
   bd config set dolt.local-only true                   # Skip wiring a Dolt sync remote during bd init

--- a/docs/cli-reference/update.md
+++ b/docs/cli-reference/update.md
@@ -26,7 +26,7 @@ bd update [id...] [flags]
   -a, --assignee string              Assignee
       --await-id string              Set gate await_id (e.g., GitHub run ID for gh:run gates)
       --body-file string             Read description from file (use - for stdin)
-      --claim                        Atomically claim the issue (sets assignee to you, status to in_progress; idempotent if already claimed by you)
+      --claim                        Atomically claim the issue (sets assignee to you, status to in_progress; idempotent if already claimed by you; issues assigned to a pool alias listed in the claim.pools config are claimable too)
       --defer string                 Defer until date (empty to clear). Issue hidden from bd ready until then
   -d, --description string           Issue description
       --design string                Design notes

--- a/internal/storage/domain/db/issue.go
+++ b/internal/storage/domain/db/issue.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -225,25 +226,44 @@ func (r *issueSQLRepositoryImpl) Claim(ctx context.Context, id, actor string, op
 	// row_lock invariant guards against (see issueops/lease.go).
 	leaseClause, leaseArgs := issueops.LeaseSetClause(now, issueops.LeaseTTL(ctx))
 
+	// Mirror the primary path's pool-aware predicate (bd-bguz6): aliases in
+	// the claim.pools config are claimable by any actor. This dual must stay
+	// in lockstep with issueops.ClaimIssueInTx — the lease comment above is
+	// the scar from the last time it drifted. (Known remaining drift: this
+	// path claims from status = 'open' only, not the custom active statuses
+	// of ClaimableSourceStatusesInTx.)
+	pools, err := issueops.ClaimPoolAliasesInTx(ctx, r.runner)
+	if err != nil {
+		return domain.ClaimRowResult{}, fmt.Errorf("db: Claim %s: resolve claim pools: %w", id, err)
+	}
+	assigneePredicate := "assignee = '' OR assignee IS NULL OR assignee = ?"
+	assigneeArgs := []any{actor}
+	for _, pool := range pools {
+		assigneePredicate += " OR assignee = ?"
+		assigneeArgs = append(assigneeArgs, pool)
+	}
+
 	var res sql.Result
 	if startedWasZero {
 		args := append([]any{actor, now, now}, leaseArgs...)
-		args = append(args, id, actor)
+		args = append(args, id)
+		args = append(args, assigneeArgs...)
 		//nolint:gosec // G201: table is one of two hardcoded constants
 		res, err = r.runner.ExecContext(ctx, fmt.Sprintf(`
 			UPDATE %s
 			SET assignee = ?, status = 'in_progress', updated_at = ?, started_at = ?, %s
-			WHERE id = ? AND status = 'open' AND (assignee = '' OR assignee IS NULL OR assignee = ?)
-		`, table, leaseClause), args...)
+			WHERE id = ? AND status = 'open' AND (%s)
+		`, table, leaseClause, assigneePredicate), args...)
 	} else {
 		args := append([]any{actor, now}, leaseArgs...)
-		args = append(args, id, actor)
+		args = append(args, id)
+		args = append(args, assigneeArgs...)
 		//nolint:gosec // G201: table is one of two hardcoded constants
 		res, err = r.runner.ExecContext(ctx, fmt.Sprintf(`
 			UPDATE %s
 			SET assignee = ?, status = 'in_progress', updated_at = ?, %s
-			WHERE id = ? AND status = 'open' AND (assignee = '' OR assignee IS NULL OR assignee = ?)
-		`, table, leaseClause), args...)
+			WHERE id = ? AND status = 'open' AND (%s)
+		`, table, leaseClause, assigneePredicate), args...)
 	}
 	if err != nil {
 		return domain.ClaimRowResult{}, fmt.Errorf("db: Claim %s: %w", id, err)
@@ -267,11 +287,12 @@ func (r *issueSQLRepositoryImpl) Claim(ctx context.Context, id, actor string, op
 			assignee = currentAssignee.String
 		}
 		return domain.ClaimRowResult{
-			Updated:          false,
-			CurrentAssignee:  assignee,
-			CurrentStatus:    currentStatus,
-			StartedAtWasZero: startedWasZero,
-			OldIssue:         oldIssue,
+			Updated:               false,
+			CurrentAssignee:       assignee,
+			CurrentAssigneeIsPool: slices.Contains(pools, assignee),
+			CurrentStatus:         currentStatus,
+			StartedAtWasZero:      startedWasZero,
+			OldIssue:              oldIssue,
 		}, nil
 	}
 

--- a/internal/storage/domain/db/issue.go
+++ b/internal/storage/domain/db/issue.go
@@ -229,9 +229,7 @@ func (r *issueSQLRepositoryImpl) Claim(ctx context.Context, id, actor string, op
 	// Mirror the primary path's pool-aware predicate (bd-bguz6): aliases in
 	// the claim.pools config are claimable by any actor. This dual must stay
 	// in lockstep with issueops.ClaimIssueInTx — the lease comment above is
-	// the scar from the last time it drifted. (Known remaining drift: this
-	// path claims from status = 'open' only, not the custom active statuses
-	// of ClaimableSourceStatusesInTx.)
+	// the scar from the last time it drifted.
 	pools, err := issueops.ClaimPoolAliasesInTx(ctx, r.runner)
 	if err != nil {
 		return domain.ClaimRowResult{}, fmt.Errorf("db: Claim %s: resolve claim pools: %w", id, err)
@@ -243,27 +241,43 @@ func (r *issueSQLRepositoryImpl) Claim(ctx context.Context, id, actor string, op
 		assigneeArgs = append(assigneeArgs, pool)
 	}
 
+	// Same lockstep for the source statuses (bd-pq7m2): claimable from "open"
+	// plus custom active-category statuses, like the primary path — not a
+	// hardcoded status = 'open'.
+	claimableStatuses, err := issueops.ClaimableSourceStatusesInTx(ctx, r.runner)
+	if err != nil {
+		return domain.ClaimRowResult{}, fmt.Errorf("db: Claim %s: resolve claimable statuses: %w", id, err)
+	}
+	statusPredicate := "status = ?"
+	statusArgs := []any{claimableStatuses[0]}
+	for _, st := range claimableStatuses[1:] {
+		statusPredicate += " OR status = ?"
+		statusArgs = append(statusArgs, st)
+	}
+
 	var res sql.Result
 	if startedWasZero {
 		args := append([]any{actor, now, now}, leaseArgs...)
 		args = append(args, id)
+		args = append(args, statusArgs...)
 		args = append(args, assigneeArgs...)
 		//nolint:gosec // G201: table is one of two hardcoded constants
 		res, err = r.runner.ExecContext(ctx, fmt.Sprintf(`
 			UPDATE %s
 			SET assignee = ?, status = 'in_progress', updated_at = ?, started_at = ?, %s
-			WHERE id = ? AND status = 'open' AND (%s)
-		`, table, leaseClause, assigneePredicate), args...)
+			WHERE id = ? AND (%s) AND (%s)
+		`, table, leaseClause, statusPredicate, assigneePredicate), args...)
 	} else {
 		args := append([]any{actor, now}, leaseArgs...)
 		args = append(args, id)
+		args = append(args, statusArgs...)
 		args = append(args, assigneeArgs...)
 		//nolint:gosec // G201: table is one of two hardcoded constants
 		res, err = r.runner.ExecContext(ctx, fmt.Sprintf(`
 			UPDATE %s
 			SET assignee = ?, status = 'in_progress', updated_at = ?, %s
-			WHERE id = ? AND status = 'open' AND (%s)
-		`, table, leaseClause, assigneePredicate), args...)
+			WHERE id = ? AND (%s) AND (%s)
+		`, table, leaseClause, statusPredicate, assigneePredicate), args...)
 	}
 	if err != nil {
 		return domain.ClaimRowResult{}, fmt.Errorf("db: Claim %s: %w", id, err)

--- a/internal/storage/domain/db/issue_test.go
+++ b/internal/storage/domain/db/issue_test.go
@@ -41,6 +41,9 @@ func (s *testSuite) TestIssueSQLRepository() {
 		s.Run("EmptyIDReturnsError", s.issueClaimEmptyID)
 		s.Run("RecordsClaimedEvent", s.issueClaimRecordsEvent)
 		s.Run("StampsLeaseAndIsReclaimable", s.issueClaimStampsLease)
+		s.Run("PoolAliasClaimableByAnyActor", s.issueClaimPoolAlias)
+		s.Run("UnconfiguredAliasStillProtected", s.issueClaimPoolUnconfiguredAlias)
+		s.Run("PoolStatusConflictFlagsPoolAssignee", s.issueClaimPoolStatusConflict)
 	})
 	s.Run("Get", func() {
 		s.Run("MissingIDReturnsErrNoRows", s.issueGetMissing)
@@ -690,6 +693,83 @@ func (s *testSuite) issueClaimStampsLease() {
 	s.Require().NoError(err)
 	s.Equal(types.StatusOpen, out.Status, "reclaim reverts the proxied claim to open")
 	s.Equal("", out.Assignee)
+}
+
+// setClaimPools configures claim.pools for a subtest and returns a cleanup
+// func. Sibling subtests share this database (SetupTest resets per suite
+// method, not per s.Run), so the key must not leak past the subtest.
+func (s *testSuite) setClaimPools(value string) func() {
+	s.Require().NoError(issueops.SetConfigInTx(s.Ctx(), s.Runner(), "claim.pools", value))
+	return func() {
+		_, err := s.db.ExecContext(s.Ctx(), "DELETE FROM config WHERE `key` = 'claim.pools'")
+		s.Require().NoError(err)
+	}
+}
+
+// issueClaimPoolAlias asserts the proxied-server (uow) claim path honors
+// claim.pools (bd-bguz6): an issue pre-assigned to a configured pool alias is
+// claimable by any actor, exactly like the primary issueops.ClaimIssueInTx
+// path.
+func (s *testSuite) issueClaimPoolAlias() {
+	cleanup := s.setClaimPools("fable-crew, night-crew")
+	defer cleanup()
+
+	r := s.issueRepo()
+	in := newTestIssue("bd-claim-pool", "pool-dispatched item")
+	in.Assignee = "fable-crew"
+	s.Require().NoError(r.Insert(s.Ctx(), in, "dispatcher", domain.InsertIssueOpts{}))
+
+	res, err := r.Claim(s.Ctx(), "bd-claim-pool", "bob", domain.IssueTableOpts{})
+	s.Require().NoError(err)
+	s.Require().True(res.Updated, "pool-assigned issue must be claimable by any actor through the proxied path")
+
+	out, err := r.Get(s.Ctx(), "bd-claim-pool", domain.IssueTableOpts{})
+	s.Require().NoError(err)
+	s.Equal("bob", out.Assignee)
+	s.Equal(types.StatusInProgress, out.Status)
+
+	var leaseExpires sql.NullTime
+	s.Require().NoError(s.Runner().QueryRowContext(s.Ctx(),
+		"SELECT lease_expires_at FROM issues WHERE id = ?", "bd-claim-pool").Scan(&leaseExpires))
+	s.Require().True(leaseExpires.Valid, "a pool take is a normal claim and must stamp a lease")
+}
+
+// issueClaimPoolUnconfiguredAlias asserts an alias absent from claim.pools
+// keeps the anti-steal protection on this path too.
+func (s *testSuite) issueClaimPoolUnconfiguredAlias() {
+	cleanup := s.setClaimPools("fable-crew")
+	defer cleanup()
+
+	r := s.issueRepo()
+	in := newTestIssue("bd-claim-pool-other", "other crew's work")
+	in.Assignee = "other-crew"
+	s.Require().NoError(r.Insert(s.Ctx(), in, "dispatcher", domain.InsertIssueOpts{}))
+
+	res, err := r.Claim(s.Ctx(), "bd-claim-pool-other", "bob", domain.IssueTableOpts{})
+	s.Require().NoError(err)
+	s.False(res.Updated, "unconfigured alias must not be claimable")
+	s.Equal("other-crew", res.CurrentAssignee)
+	s.False(res.CurrentAssigneeIsPool, "unconfigured alias is not a pool")
+}
+
+// issueClaimPoolStatusConflict asserts a pool-assigned issue that loses the
+// CAS on status is flagged CurrentAssigneeIsPool, so the use-case layer
+// reports a status conflict instead of a held-by-pseudo-assignee refusal.
+func (s *testSuite) issueClaimPoolStatusConflict() {
+	cleanup := s.setClaimPools("fable-crew")
+	defer cleanup()
+
+	r := s.issueRepo()
+	in := newTestIssue("bd-claim-pool-blocked", "blocked pool item")
+	in.Assignee = "fable-crew"
+	in.Status = types.StatusBlocked
+	s.Require().NoError(r.Insert(s.Ctx(), in, "dispatcher", domain.InsertIssueOpts{}))
+
+	res, err := r.Claim(s.Ctx(), "bd-claim-pool-blocked", "bob", domain.IssueTableOpts{})
+	s.Require().NoError(err)
+	s.False(res.Updated)
+	s.True(res.CurrentAssigneeIsPool, "pool assignee must be flagged for status-conflict error mapping")
+	s.Equal(types.StatusBlocked, res.CurrentStatus)
 }
 
 func (s *testSuite) issueClaimRecordsEvent() {

--- a/internal/storage/domain/db/issue_test.go
+++ b/internal/storage/domain/db/issue_test.go
@@ -44,6 +44,7 @@ func (s *testSuite) TestIssueSQLRepository() {
 		s.Run("PoolAliasClaimableByAnyActor", s.issueClaimPoolAlias)
 		s.Run("UnconfiguredAliasStillProtected", s.issueClaimPoolUnconfiguredAlias)
 		s.Run("PoolStatusConflictFlagsPoolAssignee", s.issueClaimPoolStatusConflict)
+		s.Run("CustomActiveStatusClaimable", s.issueClaimCustomActiveStatus)
 	})
 	s.Run("Get", func() {
 		s.Run("MissingIDReturnsErrNoRows", s.issueGetMissing)
@@ -770,6 +771,46 @@ func (s *testSuite) issueClaimPoolStatusConflict() {
 	s.False(res.Updated)
 	s.True(res.CurrentAssigneeIsPool, "pool assignee must be flagged for status-conflict error mapping")
 	s.Equal(types.StatusBlocked, res.CurrentStatus)
+}
+
+// issueClaimCustomActiveStatus asserts the proxied-server claim path claims
+// from custom active-category statuses like the primary path's
+// ClaimableSourceStatusesInTx (bd-pq7m2), not from a hardcoded
+// status = 'open' — and that non-active customs keep their anti-steal
+// protection (GH-3570 parity).
+func (s *testSuite) issueClaimCustomActiveStatus() {
+	_, err := s.db.ExecContext(s.Ctx(),
+		"INSERT INTO custom_statuses (name, category) VALUES ('triaged', 'active'), ('polishing', 'wip')")
+	s.Require().NoError(err)
+	defer func() {
+		_, err := s.db.ExecContext(s.Ctx(),
+			"DELETE FROM custom_statuses WHERE name IN ('triaged', 'polishing')")
+		s.Require().NoError(err)
+	}()
+
+	r := s.issueRepo()
+	in := newTestIssue("bd-claim-custom-active", "triaged item")
+	in.Status = types.Status("triaged")
+	s.Require().NoError(r.Insert(s.Ctx(), in, "tester", domain.InsertIssueOpts{}))
+
+	res, err := r.Claim(s.Ctx(), "bd-claim-custom-active", "alice", domain.IssueTableOpts{})
+	s.Require().NoError(err)
+	s.Require().True(res.Updated, "custom active-category status must be claimable through the proxied path (bd-pq7m2)")
+
+	out, err := r.Get(s.Ctx(), "bd-claim-custom-active", domain.IssueTableOpts{})
+	s.Require().NoError(err)
+	s.Equal("alice", out.Assignee)
+	s.Equal(types.StatusInProgress, out.Status)
+
+	// A wip-category custom status stays unclaimable (anti-steal parity).
+	wip := newTestIssue("bd-claim-custom-wip", "being polished")
+	wip.Status = types.Status("polishing")
+	s.Require().NoError(r.Insert(s.Ctx(), wip, "tester", domain.InsertIssueOpts{}))
+
+	res, err = r.Claim(s.Ctx(), "bd-claim-custom-wip", "alice", domain.IssueTableOpts{})
+	s.Require().NoError(err)
+	s.False(res.Updated, "wip-category custom status must not be claimable")
+	s.Equal(types.Status("polishing"), res.CurrentStatus)
 }
 
 func (s *testSuite) issueClaimRecordsEvent() {

--- a/internal/storage/domain/db/issue_usecase_apply_update_test.go
+++ b/internal/storage/domain/db/issue_usecase_apply_update_test.go
@@ -12,6 +12,7 @@ func (s *testSuite) TestIssueUseCase_Claim() {
 	s.Run("SuccessReturnsEmptyResult", s.iucClaimSuccess)
 	s.Run("IdempotentReclaimMarksAlreadyClaimed", s.iucClaimIdempotent)
 	s.Run("ConflictWrapsErrAlreadyClaimed", s.iucClaimConflict)
+	s.Run("OpenAssignedRefusalSteersToHolder", s.iucClaimOpenAssignedCopy)
 	s.Run("ClosedWrapsErrNotClaimable", s.iucClaimClosed)
 	s.Run("EmptyIDReturnsError", s.iucClaimEmptyID)
 	s.Run("EmptyActorReturnsError", s.iucClaimEmptyActor)
@@ -67,6 +68,25 @@ func (s *testSuite) iucClaimConflict() {
 	s.Require().Error(err)
 	s.True(errors.Is(err, storage.ErrAlreadyClaimed), "expected ErrAlreadyClaimed, got %v", err)
 	s.Contains(err.Error(), "alice")
+}
+
+// iucClaimOpenAssignedCopy pins the proxied-path refusal copy for an OPEN
+// issue assigned to another real actor (bd-at6rc parity, found by review):
+// it must steer toward the holder like issueops.ClaimIssueInTx, keep the
+// ErrAlreadyClaimed wrap (the proxied batch exit code keys on errors.Is),
+// and never name an eviction command.
+func (s *testSuite) iucClaimOpenAssignedCopy() {
+	s.seedOpenIssue("bd-iuc-cl-openassigned")
+	r := s.issueRepo()
+	s.Require().NoError(r.Update(s.Ctx(), "bd-iuc-cl-openassigned",
+		map[string]any{"assignee": "alice"}, "seeder", domain.IssueTableOpts{}))
+
+	_, err := s.issueUseCase().ClaimIssue(s.Ctx(), "bd-iuc-cl-openassigned", "bob")
+	s.Require().Error(err)
+	s.True(errors.Is(err, storage.ErrAlreadyClaimed), "expected ErrAlreadyClaimed wrap, got %v", err)
+	s.Contains(err.Error(), "coordinate with the holder")
+	s.NotContains(err.Error(), "unclaim")
+	s.NotContains(err.Error(), "--force")
 }
 
 func (s *testSuite) iucClaimClosed() {

--- a/internal/storage/domain/issue.go
+++ b/internal/storage/domain/issue.go
@@ -427,6 +427,13 @@ func (u *issueUseCaseImpl) claim(ctx context.Context, id, actor string, useWisp 
 		if row.CurrentAssigneeIsPool {
 			return ClaimResult{}, fmt.Errorf("%w: status %s", storage.ErrNotClaimable, row.CurrentStatus)
 		}
+		if row.CurrentStatus == types.StatusOpen {
+			// Same guidance as issueops.ClaimIssueInTx's open-but-assigned
+			// refusal (bd-at6rc): steer toward the holder, never name an
+			// eviction command. Keep the %w wrap — the proxied batch exit
+			// code keys on errors.Is(err, ErrAlreadyClaimed).
+			return ClaimResult{}, fmt.Errorf("%w: already assigned to %q — coordinate with the holder; if their claim is abandoned (crashed agent), lease expiry will surface it for bd reclaim", storage.ErrAlreadyClaimed, row.CurrentAssignee)
+		}
 		return ClaimResult{}, fmt.Errorf("%w by %s", storage.ErrAlreadyClaimed, row.CurrentAssignee)
 	}
 	return ClaimResult{}, fmt.Errorf("%w: status %s", storage.ErrNotClaimable, row.CurrentStatus)

--- a/internal/storage/domain/issue.go
+++ b/internal/storage/domain/issue.go
@@ -22,11 +22,16 @@ type IssueTableOpts struct {
 }
 
 type ClaimRowResult struct {
-	Updated          bool
-	CurrentAssignee  string
-	CurrentStatus    types.Status
-	StartedAtWasZero bool
-	OldIssue         *types.Issue
+	Updated bool
+	// CurrentAssignee is the assignee found on the 0-row disambiguation
+	// read; CurrentAssigneeIsPool marks it as a claim.pools alias, so the
+	// caller reports a status conflict instead of a held-by-someone
+	// refusal (a pool alias never "holds" a claim).
+	CurrentAssignee       string
+	CurrentAssigneeIsPool bool
+	CurrentStatus         types.Status
+	StartedAtWasZero      bool
+	OldIssue              *types.Issue
 }
 
 type IssueSQLRepository interface {
@@ -416,6 +421,12 @@ func (u *issueUseCaseImpl) claim(ctx context.Context, id, actor string, useWisp 
 		return ClaimResult{AlreadyClaimed: true, PriorAssignee: actor}, nil
 	}
 	if row.CurrentAssignee != "" && row.CurrentAssignee != actor {
+		// A pool-assigned issue only loses the CAS for a non-assignee
+		// reason (status changed underneath us): report the status, not a
+		// misleading held-by refusal (mirrors issueops.ClaimIssueInTx).
+		if row.CurrentAssigneeIsPool {
+			return ClaimResult{}, fmt.Errorf("%w: status %s", storage.ErrNotClaimable, row.CurrentStatus)
+		}
 		return ClaimResult{}, fmt.Errorf("%w by %s", storage.ErrAlreadyClaimed, row.CurrentAssignee)
 	}
 	return ClaimResult{}, fmt.Errorf("%w: status %s", storage.ErrNotClaimable, row.CurrentStatus)

--- a/internal/storage/issueops/claim.go
+++ b/internal/storage/issueops/claim.go
@@ -6,6 +6,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"slices"
+	"strings"
 	"time"
 
 	"github.com/steveyegge/beads/internal/storage"
@@ -20,7 +22,9 @@ type ClaimResult struct {
 
 // ClaimIssueInTx atomically claims an issue using compare-and-swap semantics.
 // It sets the assignee to actor and status to "in_progress" only if the issue
-// is currently open and unassigned or already assigned to the same actor.
+// is currently open and unassigned, already assigned to the same actor, or
+// assigned to a pool alias listed in the claim.pools config (see
+// ClaimPoolAliasesInTx).
 // Returns storage.ErrAlreadyClaimed if already claimed by a different user.
 // Idempotent: re-claiming an in_progress issue by the same actor is a no-op
 // success (supports agent retry workflows).
@@ -57,6 +61,22 @@ func ClaimIssueInTx(ctx context.Context, tx DBTX, id string, actor string) (*Cla
 	}
 	statusPlaceholders, statusArgs := buildSQLInClause(claimableStatuses)
 
+	// Pool-aware claim (bd-bguz6): a dispatcher may pre-assign issues to a
+	// pool pseudo-assignee (e.g. "fable-crew"). Aliases listed in the
+	// claim.pools config are claimable by any actor through the same CAS;
+	// issues assigned to a real actor keep their anti-steal protection.
+	pools, err := ClaimPoolAliasesInTx(ctx, tx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve claim pools: %w", err)
+	}
+	assigneePredicate := "assignee = '' OR assignee IS NULL OR assignee = ?"
+	assigneeArgs := []interface{}{actor}
+	if len(pools) > 0 {
+		poolPlaceholders, poolArgs := buildSQLInClause(pools)
+		assigneePredicate += " OR assignee IN (" + poolPlaceholders + ")"
+		assigneeArgs = append(assigneeArgs, poolArgs...)
+	}
+
 	// Conditional UPDATE: only succeeds while the issue is still claimable.
 	// Also set started_at on first transition to in_progress (GH#2796); preserve
 	// any existing value so re-claims don't overwrite the original start time.
@@ -67,22 +87,22 @@ func ClaimIssueInTx(ctx context.Context, tx DBTX, id string, actor string) (*Cla
 		args := append([]interface{}{actor, now, now}, leaseArgs...)
 		args = append(args, id)
 		args = append(args, statusArgs...)
-		args = append(args, actor)
+		args = append(args, assigneeArgs...)
 		result, err = tx.ExecContext(ctx, fmt.Sprintf(`
 			UPDATE %s
 			SET assignee = ?, status = 'in_progress', updated_at = ?, started_at = ?, %s
-			WHERE id = ? AND status IN (%s) AND (assignee = '' OR assignee IS NULL OR assignee = ?)
-		`, issueTable, leaseClause, statusPlaceholders), args...)
+			WHERE id = ? AND status IN (%s) AND (%s)
+		`, issueTable, leaseClause, statusPlaceholders, assigneePredicate), args...)
 	} else {
 		args := append([]interface{}{actor, now}, leaseArgs...)
 		args = append(args, id)
 		args = append(args, statusArgs...)
-		args = append(args, actor)
+		args = append(args, assigneeArgs...)
 		result, err = tx.ExecContext(ctx, fmt.Sprintf(`
 			UPDATE %s
 			SET assignee = ?, status = 'in_progress', updated_at = ?, %s
-			WHERE id = ? AND status IN (%s) AND (assignee = '' OR assignee IS NULL OR assignee = ?)
-		`, issueTable, leaseClause, statusPlaceholders), args...)
+			WHERE id = ? AND status IN (%s) AND (%s)
+		`, issueTable, leaseClause, statusPlaceholders, assigneePredicate), args...)
 	}
 	if err != nil {
 		return nil, fmt.Errorf("failed to claim issue: %w", err)
@@ -113,6 +133,12 @@ func ClaimIssueInTx(ctx context.Context, tx DBTX, id string, actor string) (*Cla
 			return &ClaimResult{OldIssue: oldIssue, IsWisp: isWisp}, nil
 		}
 		if assignee != "" && assignee != actor {
+			// A pool-assigned issue reaches here only when the CAS lost for a
+			// non-assignee reason (status changed underneath us): report the
+			// status rather than a misleading held-by-someone refusal.
+			if slices.Contains(pools, assignee) {
+				return nil, fmt.Errorf("%w: status %s", storage.ErrNotClaimable, currentStatus)
+			}
 			if currentStatus == types.StatusOpen {
 				// Do not name a release command here — not `bd unclaim`, not
 				// `bd unclaim --force`. Refusal copy that names one gets
@@ -175,6 +201,27 @@ func ClaimReadyIssueInTx(
 		return claimed, nil
 	}
 	return nil, nil
+}
+
+// ClaimPoolAliasesInTx returns the pool pseudo-assignee aliases from the
+// claim.pools config key (comma-separated, whitespace-trimmed). An issue
+// assigned to one of these aliases is claimable by ANY actor through the
+// normal claim CAS — the pattern where a dispatcher pre-assigns work to a
+// group alias (e.g. "fable-crew") and members take items from the pool.
+// Issues assigned to a real actor are unaffected. Missing/empty config (the
+// default) disables pool-aware claiming entirely.
+func ClaimPoolAliasesInTx(ctx context.Context, tx DBTX) ([]string, error) {
+	raw, err := GetConfigInTx(ctx, tx, "claim.pools")
+	if err != nil {
+		return nil, err
+	}
+	var pools []string
+	for _, p := range strings.Split(raw, ",") {
+		if p = strings.TrimSpace(p); p != "" {
+			pools = append(pools, p)
+		}
+	}
+	return pools, nil
 }
 
 // ClaimableSourceStatusesInTx returns the set of statuses an issue may be


### PR DESCRIPTION
## Summary

**Stacked on #4841** (same `claim.go` region; GitHub will retarget to `main` when it merges — only the last commit is new here).

From the wyvern rig's review-fleet session (their #1 friction, hit on all 10 beads): their dispatcher pre-assigns issues to a pool pseudo-assignee (`fable-crew`), and `--claim` refuses pre-assigned issues, forcing a two-step `--assignee <me> -s in_progress` per issue — and a reassign-then-close at the end.

This makes `--claim` pool-aware, driven by config:

```
bd config set claim.pools "fable-crew,night-crew"
```

- Aliases in `claim.pools` are claimable by **any actor** through the same atomic CAS — the assignee predicate gains `OR assignee IN (<pools>)`, resolved in-transaction via `GetConfigInTx`. No storage-interface change, no new flag.
- **Both claim duals get the predicate**: an adversarial review pass caught that the proxied-server (uow) path has its own CAS (`issueSQLRepositoryImpl.Claim`) that would have silently refused pool takes in `dolt.mode=proxied-server`. It now resolves the same config in lockstep, and `ClaimRowResult.CurrentAssigneeIsPool` keeps the 0-row disambiguation honest there too.
- The same dual also gets its **third known drift** fixed (bd-pq7m2): it hardcoded `status = 'open'`, so custom active-category statuses (claimable everywhere else via `ClaimableSourceStatusesInTx`) weren't claimable in proxied-server mode. Now resolved in lockstep; wip/done/frozen customs stay excluded (GH-3570 anti-steal parity).
- `claim.*` is a recognized config namespace (the setup command previously warned "not a recognized config key"), and `bd config --help` documents the key — including the reclaim caveat: an expired pool take returns to the *unassigned* pool, not to the pool alias it was dispatched to.
- A pool take stamps the normal lease, so the reclaim machinery covers it.
- Issues assigned to a **real actor** — or to an alias not in the config — keep their anti-steal protection (deliberately composing with #4675/#4841: take-from-pool must not become an eviction path).
- Off by default: no `claim.pools` config → byte-identical behavior.

Charter note: this stays a claim-arbitration primitive — one config key, no schema change, no orchestration policy beyond "these assignee strings are pools."

Scope choice: `bd close`'s actor≠assignee refusal is untouched — with pool-aware claim the dispatcher flow is claim → work → close, and close sees assignee = you. Keeping the close guard intact preserves its protection.

## Testing

New `TestEmbeddedClaimPools` (embedded Dolt, `BEADS_TEST_EMBEDDED_DOLT=1`) covers: the full dispatcher flow (pool assign → claim → close with no two-step), a second configured alias, lease stamping on pool takes, and both protection boundaries (real-actor assignee refused, unconfigured alias refused) — plus an assertion that the setup command emits no unrecognized-key warning. Three new subtests in the domain/db container suite cover the proxied-path dual (pool take + lease, unconfigured alias protected, status-conflict flagging). Full embedded `TestEmbeddedUpdate`/`TestEmbeddedUnclaim` suites and the domain/db `Claim` suite pass alongside; docsync guard, `gofmt`, `go vet` clean.

## Notes

- Tracked as bd-bguz6 (P2); requested by tortoise (wyvern). Siblings: #4839 (bd-m00pb), #4841 (bd-at6rc).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
