### PR TITLE
Enable verified public v0.62 migration apply

### DIFF
--- a/cmd/bd/init.go
+++ b/cmd/bd/init.go
@@ -90,6 +90,14 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 				restoreChangeDirSelection()
 			}
 		}()
+		migrationProjectID, err := migrationV062InitProjectID(cmd, admission)
+		if err != nil {
+			return err
+		}
+		migrationRepositoryRoot, err := migrationV062InitRepositoryRoot(cmd, migrationProjectID)
+		if err != nil {
+			return err
+		}
 		if err := prepareInitContextAfterBackendPreflight(cmd, admission); err != nil {
 			return err
 		}
@@ -1191,25 +1199,49 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 		}
 
 		// Compute and store repository fingerprint (FR-015)
-		repoID, err := beads.ComputeRepoID()
+		var repoID string
+		if migrationRepositoryRoot != "" {
+			repoID, err = beads.ComputeRepoIDForPath(migrationRepositoryRoot)
+		} else {
+			repoID, err = beads.ComputeRepoID()
+		}
 		if err != nil {
+			if migrationRepositoryRoot != "" {
+				return fmt.Errorf("failed to compute authenticated migration repository ID: %v", err)
+			}
 			if !quiet {
 				fmt.Fprintf(os.Stderr, "Warning: could not compute repository ID: %v\n", err)
 			}
 		} else {
-			if verifyMetadata(ctx, store, "repo_id", repoID) && !quiet {
+			persisted := verifyMetadata(ctx, store, "repo_id", repoID)
+			if migrationRepositoryRoot != "" && !persisted {
+				return fmt.Errorf("authenticated migration repository ID did not persist")
+			}
+			if persisted && !quiet {
 				fmt.Printf("  Repository ID: %s\n", repoID[:8])
 			}
 		}
 
 		// Compute and store clone-specific ID (FR-016: skip on failure)
-		cloneID, err := beads.GetCloneID()
+		var cloneID string
+		if migrationRepositoryRoot != "" {
+			cloneID, err = beads.GetCloneIDForPath(migrationRepositoryRoot)
+		} else {
+			cloneID, err = beads.GetCloneID()
+		}
 		if err != nil {
+			if migrationRepositoryRoot != "" {
+				return fmt.Errorf("failed to compute authenticated migration clone ID: %v", err)
+			}
 			if !quiet {
 				fmt.Fprintf(os.Stderr, "Warning: could not compute clone ID: %v\n", err)
 			}
 		} else {
-			if verifyMetadata(ctx, store, "clone_id", cloneID) && !quiet {
+			persisted := verifyMetadata(ctx, store, "clone_id", cloneID)
+			if migrationRepositoryRoot != "" && !persisted {
+				return fmt.Errorf("authenticated migration clone ID did not persist")
+			}
+			if persisted && !quiet {
 				fmt.Printf("  Clone ID: %s\n", cloneID)
 			}
 		}
@@ -1243,8 +1275,19 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 			// minting a new one and writing it back would overwrite the
 			// source identity and cause cross-project verification to
 			// fail on subsequent pulls.
+			if migrationProjectID != "" && cfg.ProjectID != "" && cfg.ProjectID != migrationProjectID {
+				return fmt.Errorf("--%s conflicts with an existing project identity", migrationV062ProjectIDFlag)
+			}
 			if cfg.ProjectID == "" {
-				if store != nil && (database != "" || bootstrappedFromRemote) {
+				if migrationProjectID != "" {
+					if store != nil {
+						existingID, readErr := store.GetMetadata(ctx, "_project_id")
+						if readErr == nil && existingID != "" && existingID != migrationProjectID {
+							return fmt.Errorf("--%s conflicts with the target database identity", migrationV062ProjectIDFlag)
+						}
+					}
+					cfg.ProjectID = migrationProjectID
+				} else if store != nil && (database != "" || bootstrappedFromRemote) {
 					if existingID, err := store.GetMetadata(ctx, "_project_id"); err == nil && existingID != "" {
 						cfg.ProjectID = existingID
 						if !quiet {
@@ -1316,6 +1359,9 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 			}
 
 			if err := cfg.Save(beadsDir); err != nil {
+				if migrationProjectID != "" {
+					return fmt.Errorf("failed to persist authenticated v0.62 project identity: %v", err)
+				}
 				fmt.Fprintf(os.Stderr, "Warning: failed to create metadata.json: %v\n", err)
 				// Non-fatal - continue anyway
 			}
@@ -1323,7 +1369,15 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 			// Write project identity to database for cross-project verification (GH#2372)
 			if cfg.ProjectID != "" && store != nil {
 				if err := store.SetMetadata(ctx, "_project_id", cfg.ProjectID); err != nil {
+					if migrationProjectID != "" {
+						return fmt.Errorf("failed to persist authenticated v0.62 database identity: %v", err)
+					}
 					fmt.Fprintf(os.Stderr, "Warning: failed to write project ID to database: %v\n", err)
+				} else if migrationProjectID != "" {
+					persisted, readErr := store.GetMetadata(ctx, "_project_id")
+					if readErr != nil || persisted != migrationProjectID {
+						return fmt.Errorf("authenticated v0.62 database identity did not persist")
+					}
 				}
 			}
 
@@ -2164,6 +2218,10 @@ func init() {
 	initCmd.Flags().String("mysql-url", "", "MySQL server DSN (with --backend=mysql), e.g. user:pass@tcp(host:3306)/ . A password may be included for init but is never persisted; set BEADS_MYSQL_PASSWORD for later commands. Falls back to BEADS_MYSQL_URL.")
 	initCmd.Flags().String("mysql-database", "", "MySQL database for this workspace (with --backend=mysql; MySQL's isolation unit)")
 	initCmd.Flags().String("sqlite-path", "", "SQLite database file (with --backend=sqlite; relative to the beads dir, default beads.db)")
+	initCmd.Flags().String(migrationV062ProjectIDFlag, "", "Authenticated project identity for the v0.62 migration bridge")
+	_ = initCmd.Flags().MarkHidden(migrationV062ProjectIDFlag)
+	initCmd.Flags().String(migrationV062RepositoryRootFlag, "", "Final repository root for the v0.62 migration bridge")
+	_ = initCmd.Flags().MarkHidden(migrationV062RepositoryRootFlag)
 
 	// Dolt server connection flags
 	initCmd.Flags().Bool("server", false, "Use external dolt sql-server instead of embedded engine")

--- a/cmd/bd/migration_v062_init.go
+++ b/cmd/bd/migration_v062_init.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+
+	"github.com/spf13/cobra"
+	"github.com/steveyegge/beads/internal/beads"
+	"github.com/steveyegge/beads/internal/configfile"
+)
+
+const migrationV062ProjectIDFlag = "migration-v062-project-id"
+const migrationV062RepositoryRootFlag = "migration-v062-repository-root"
+
+var migrationV062ProjectIDPattern = regexp.MustCompile(
+	`^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$`,
+)
+
+// migrationV062InitProjectID admits the authenticated historical project ID
+// only on a fresh, explicitly selected embedded-Dolt initialization. Keeping
+// this as a creation-time input lets normal init persist metadata.json and the
+// database _project_id together; a post-init rewrite could strand them in a
+// mismatched state after a crash.
+func migrationV062InitProjectID(cmd *cobra.Command, admission initBackendAdmission) (string, error) {
+	flags := cmd.Flags()
+	if flags.Lookup(migrationV062ProjectIDFlag) == nil {
+		return "", nil
+	}
+	projectID, err := flags.GetString(migrationV062ProjectIDFlag)
+	if err != nil || projectID == "" {
+		return "", err
+	}
+	refuse := func(reason string) (string, error) {
+		return "", fmt.Errorf("--%s %s", migrationV062ProjectIDFlag, reason)
+	}
+
+	if !cmd.Flags().Changed("backend") || admission.backend != configfile.BackendDolt {
+		return refuse("requires explicit --backend=dolt")
+	}
+	if !migrationV062ProjectIDPattern.MatchString(projectID) {
+		return refuse("requires a canonical UUID")
+	}
+	if admission.initialized {
+		return refuse("requires a fresh, uninitialized target")
+	}
+
+	for _, flag := range []string{
+		"force", "reinit-local", "discard-remote", "from-jsonl", "init-if-missing",
+		"remote", "server", "shared-server", "external", "proxied-server",
+		"server-host", "server-port", "server-socket", "server-user",
+	} {
+		if cmd.Flags().Changed(flag) {
+			return refuse("cannot be combined with --" + flag)
+		}
+	}
+	proxied, _ := cmd.Flags().GetBool("proxied-server")
+	shared, _ := cmd.Flags().GetBool("shared-server")
+	server, _ := cmd.Flags().GetBool("server")
+	if mode := resolveInitDoltMode(proxied, shared, server); mode != "embedded" {
+		return refuse("requires embedded Dolt mode")
+	}
+
+	return projectID, nil
+}
+
+// migrationV062InitRepositoryRoot admits the final physical Git workspace whose
+// tracking identity must be persisted into a side-by-side migration target.
+// The target itself is initialized under a temporary staging path, so deriving
+// repo_id and clone_id from its current working directory would publish the
+// staging repository's identity after the .beads directory is moved.
+func migrationV062InitRepositoryRoot(cmd *cobra.Command, projectID string) (string, error) {
+	flags := cmd.Flags()
+	if flags.Lookup(migrationV062RepositoryRootFlag) == nil {
+		return "", nil
+	}
+	if !flags.Changed(migrationV062RepositoryRootFlag) {
+		return "", nil
+	}
+	root, err := flags.GetString(migrationV062RepositoryRootFlag)
+	if err != nil {
+		return "", err
+	}
+	refuse := func(reason string) (string, error) {
+		return "", fmt.Errorf("--%s %s", migrationV062RepositoryRootFlag, reason)
+	}
+	if projectID == "" {
+		return refuse("requires --" + migrationV062ProjectIDFlag)
+	}
+	if root == "" || !filepath.IsAbs(root) {
+		return refuse("requires an absolute physical Git workspace")
+	}
+	physical, err := filepath.EvalSymlinks(root)
+	if err != nil || physical != filepath.Clean(root) {
+		return refuse("requires an existing canonical physical Git workspace")
+	}
+	info, err := os.Stat(physical)
+	if err != nil || !info.IsDir() {
+		return refuse("requires an existing canonical physical Git workspace")
+	}
+	if _, err := beads.ComputeRepoIDForPath(physical); err != nil {
+		return refuse("requires an existing canonical physical Git workspace")
+	}
+	if _, err := beads.GetCloneIDForPath(physical); err != nil {
+		return refuse("requires an existing canonical physical Git workspace")
+	}
+	return physical, nil
+}

--- a/cmd/bd/migration_v062_init_embedded_test.go
+++ b/cmd/bd/migration_v062_init_embedded_test.go
@@ -1,0 +1,387 @@
+//go:build cgo
+
+package main
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/beads"
+	"github.com/steveyegge/beads/internal/configfile"
+)
+
+const migrationV062ProjectIDFlagNameForTest = "migration-v062-project-id"
+const migrationV062RepositoryRootFlagNameForTest = "migration-v062-repository-root"
+
+func TestMigrationV062ProjectIDInitFlagIsHidden(t *testing.T) {
+	for _, name := range []string{
+		migrationV062ProjectIDFlagNameForTest,
+		migrationV062RepositoryRootFlagNameForTest,
+	} {
+		flag := initCmd.Flags().Lookup(name)
+		if flag == nil {
+			t.Fatalf("init command does not register hidden --%s", name)
+		}
+		if !flag.Hidden {
+			t.Fatalf("--%s must be hidden from init help", name)
+		}
+	}
+}
+
+func TestMigrationV062ProjectIDInitEmbedded(t *testing.T) {
+	bd := buildEmbeddedBD(t)
+
+	t.Run("preserves_authenticated_identity", func(t *testing.T) {
+		const projectID = "7ef372b4-4c3c-4e2c-a6cc-29dd2d0a28c6"
+		dir := t.TempDir()
+		initGitRepoAt(t, dir)
+
+		cmd := exec.Command(bd,
+			"init",
+			"--quiet",
+			"--non-interactive",
+			"--skip-hooks",
+			"--skip-agents",
+			"--prefix", "legacy",
+			"--database", "smoke",
+			"--backend=dolt",
+			"--"+migrationV062ProjectIDFlagNameForTest, projectID,
+		)
+		cmd.Dir = dir
+		cmd.Env = bdEnv(dir)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("migration identity init failed: %v\n%s", err, out)
+		}
+
+		beadsDir := filepath.Join(dir, ".beads")
+		cfg, err := configfile.Load(beadsDir)
+		if err != nil {
+			t.Fatalf("load metadata.json: %v", err)
+		}
+		if cfg == nil {
+			t.Fatal("metadata.json was not created")
+		}
+		if cfg.Backend != configfile.BackendDolt {
+			t.Fatalf("metadata backend = %q, want %q", cfg.Backend, configfile.BackendDolt)
+		}
+		if cfg.DoltMode != configfile.DoltModeEmbedded {
+			t.Fatalf("metadata Dolt mode = %q, want %q", cfg.DoltMode, configfile.DoltModeEmbedded)
+		}
+		if cfg.DoltDatabase != "smoke" {
+			t.Fatalf("metadata Dolt database = %q, want authenticated source database %q", cfg.DoltDatabase, "smoke")
+		}
+		if cfg.ProjectID != projectID {
+			t.Fatalf("metadata project_id = %q, want authenticated v0.62 identity %q", cfg.ProjectID, projectID)
+		}
+		if got := readBack(t, beadsDir, "smoke", "_project_id", true); got != projectID {
+			t.Fatalf("database _project_id = %q, want authenticated v0.62 identity %q", got, projectID)
+		}
+		if got := readBack(t, beadsDir, "smoke", "issue_prefix", false); got != "legacy" {
+			t.Fatalf("database issue_prefix = %q, want authenticated source prefix %q", got, "legacy")
+		}
+	})
+
+	tests := []struct {
+		name       string
+		args       []string
+		wantErrors []string
+		untouched  []string
+	}{
+		{
+			name:       "rejects_invalid_uuid",
+			args:       []string{"--backend=dolt", "--" + migrationV062ProjectIDFlagNameForTest, "not-a-uuid"},
+			wantErrors: []string{"uuid"},
+		},
+		{
+			name:       "requires_explicit_dolt_backend",
+			args:       []string{"--" + migrationV062ProjectIDFlagNameForTest, "7ef372b4-4c3c-4e2c-a6cc-29dd2d0a28c6"},
+			wantErrors: []string{"explicit", "backend=dolt"},
+		},
+		{
+			name:       "rejects_server_selector",
+			args:       []string{"--backend=dolt", "--server", "--" + migrationV062ProjectIDFlagNameForTest, "7ef372b4-4c3c-4e2c-a6cc-29dd2d0a28c6"},
+			wantErrors: []string{"--server"},
+		},
+		{
+			name:       "rejects_non_dolt_backend",
+			args:       []string{"--backend=sqlite", "--sqlite-path", "provider.db", "--" + migrationV062ProjectIDFlagNameForTest, "7ef372b4-4c3c-4e2c-a6cc-29dd2d0a28c6"},
+			wantErrors: []string{"backend=dolt"},
+			untouched:  []string{"provider.db"},
+		},
+		{
+			name:       "rejects_reinit",
+			args:       []string{"--backend=dolt", "--reinit-local", "--" + migrationV062ProjectIDFlagNameForTest, "7ef372b4-4c3c-4e2c-a6cc-29dd2d0a28c6"},
+			wantErrors: []string{"--reinit-local"},
+		},
+		{
+			name:       "rejects_from_jsonl",
+			args:       []string{"--backend=dolt", "--from-jsonl", "--" + migrationV062ProjectIDFlagNameForTest, "7ef372b4-4c3c-4e2c-a6cc-29dd2d0a28c6"},
+			wantErrors: []string{"--from-jsonl"},
+		},
+		{
+			name:       "rejects_remote",
+			args:       []string{"--backend=dolt", "--remote", "https://example.invalid/legacy.git", "--" + migrationV062ProjectIDFlagNameForTest, "7ef372b4-4c3c-4e2c-a6cc-29dd2d0a28c6"},
+			wantErrors: []string{"--remote"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			initGitRepoAt(t, dir)
+			args := append([]string{
+				"init",
+				"--quiet",
+				"--non-interactive",
+				"--skip-hooks",
+				"--skip-agents",
+				"--prefix", "legacy",
+			}, tt.args...)
+			cmd := exec.Command(bd, args...)
+			cmd.Dir = dir
+			cmd.Env = bdEnv(dir)
+			out, err := cmd.CombinedOutput()
+			if err == nil {
+				t.Fatalf("unsafe migration identity init unexpectedly succeeded:\n%s", out)
+			}
+
+			message := strings.ToLower(string(out))
+			if strings.Contains(message, "unknown flag") {
+				t.Fatalf("migration identity flag is not implemented; wanted an admission refusal:\n%s", out)
+			}
+			if !strings.Contains(message, "--"+migrationV062ProjectIDFlagNameForTest) {
+				t.Fatalf("refusal does not identify --%s:\n%s", migrationV062ProjectIDFlagNameForTest, out)
+			}
+			for _, want := range tt.wantErrors {
+				if !strings.Contains(message, strings.ToLower(want)) {
+					t.Fatalf("refusal does not mention %q:\n%s", want, out)
+				}
+			}
+
+			assertMigrationV062InitUntouched(t, dir, tt.untouched...)
+		})
+	}
+}
+
+func TestMigrationV062StagedInitPublishesFinalRepositoryIdentity(t *testing.T) {
+	bd := buildEmbeddedBD(t)
+	finalWorkspace := t.TempDir()
+	initGitRepoAt(t, finalWorkspace)
+
+	stagedTarget := filepath.Join(
+		finalWorkspace, ".beads-v0.62.0-staging", "target",
+	)
+	if err := os.MkdirAll(stagedTarget, 0o700); err != nil {
+		t.Fatalf("create staged target: %v", err)
+	}
+	initGitRepoAt(t, stagedTarget)
+	runBDInit(t, bd, stagedTarget,
+		"--non-interactive",
+		"--skip-hooks",
+		"--skip-agents",
+		"--prefix", "legacy",
+		"--database", "smoke",
+		"--backend=dolt",
+		"--"+migrationV062ProjectIDFlagNameForTest,
+		"7ef372b4-4c3c-4e2c-a6cc-29dd2d0a28c6",
+		"--"+migrationV062RepositoryRootFlagNameForTest,
+		finalWorkspace,
+	)
+
+	publishedBeads := filepath.Join(finalWorkspace, ".beads")
+	if err := os.Rename(filepath.Join(stagedTarget, ".beads"), publishedBeads); err != nil {
+		t.Fatalf("publish staged .beads: %v", err)
+	}
+
+	wantRepoID, err := beads.ComputeRepoIDForPath(finalWorkspace)
+	if err != nil {
+		t.Fatalf("compute final workspace repo_id: %v", err)
+	}
+	wantCloneID, err := beads.GetCloneIDForPath(finalWorkspace)
+	if err != nil {
+		t.Fatalf("compute final workspace clone_id: %v", err)
+	}
+	if got := readBack(t, publishedBeads, "smoke", "repo_id", true); got != wantRepoID {
+		t.Errorf("published repo_id = %q, want final workspace identity %q", got, wantRepoID)
+	}
+	if got := readBack(t, publishedBeads, "smoke", "clone_id", true); got != wantCloneID {
+		t.Errorf("published clone_id = %q, want final workspace identity %q", got, wantCloneID)
+	}
+}
+
+func TestMigrationV062RepositoryRootAdmission(t *testing.T) {
+	bd := buildEmbeddedBD(t)
+	const projectID = "7ef372b4-4c3c-4e2c-a6cc-29dd2d0a28c6"
+
+	tests := []struct {
+		name      string
+		rootArg   func(t *testing.T, target string) string
+		projectID bool
+		wantError string
+	}{
+		{
+			name:      "requires_project_id",
+			rootArg:   func(_ *testing.T, target string) string { return target },
+			wantError: "Error: --migration-v062-repository-root requires --migration-v062-project-id\n",
+		},
+		{
+			name:      "rejects_explicit_empty_root",
+			rootArg:   func(_ *testing.T, _ string) string { return "" },
+			projectID: true,
+			wantError: "Error: --migration-v062-repository-root requires an absolute physical Git workspace\n",
+		},
+		{
+			name:      "rejects_relative_root",
+			rootArg:   func(_ *testing.T, _ string) string { return "." },
+			projectID: true,
+			wantError: "Error: --migration-v062-repository-root requires an absolute physical Git workspace\n",
+		},
+		{
+			name: "rejects_symlink_root",
+			rootArg: func(t *testing.T, target string) string {
+				symlink := filepath.Join(t.TempDir(), "workspace-link")
+				if err := os.Symlink(target, symlink); err != nil {
+					t.Fatalf("create repository-root symlink: %v", err)
+				}
+				return symlink
+			},
+			projectID: true,
+			wantError: "Error: --migration-v062-repository-root requires an existing canonical physical Git workspace\n",
+		},
+		{
+			name:      "rejects_non_git_root_before_init",
+			rootArg:   func(t *testing.T, _ string) string { return t.TempDir() },
+			projectID: true,
+			wantError: "Error: --migration-v062-repository-root requires an existing canonical physical Git workspace\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			target := t.TempDir()
+			initGitRepoAt(t, target)
+			args := []string{
+				"init", "--quiet", "--non-interactive", "--skip-hooks",
+				"--skip-agents", "--prefix", "legacy", "--database", "smoke",
+				"--backend=dolt",
+			}
+			if tt.projectID {
+				args = append(args,
+					"--"+migrationV062ProjectIDFlagNameForTest, projectID,
+				)
+			}
+			root := tt.rootArg(t, target)
+			args = append(args,
+				"--"+migrationV062RepositoryRootFlagNameForTest+"="+root,
+			)
+			snapshotPaths := []string{target}
+			if root != "" {
+				rootPath := root
+				if !filepath.IsAbs(rootPath) {
+					rootPath = filepath.Join(target, rootPath)
+				}
+				if info, err := os.Lstat(rootPath); err == nil && info.Mode()&os.ModeSymlink != 0 {
+					rootPath = filepath.Dir(rootPath)
+				}
+				if filepath.Clean(rootPath) != filepath.Clean(target) {
+					snapshotPaths = append(snapshotPaths, rootPath)
+				}
+			}
+			before := make(map[string][sha256.Size]byte, len(snapshotPaths))
+			for _, path := range snapshotPaths {
+				before[path] = snapshotMigrationV062Tree(t, path)
+			}
+
+			cmd := exec.Command(bd, args...)
+			cmd.Dir = target
+			cmd.Env = bdEnv(target)
+			out, err := cmd.CombinedOutput()
+			if err == nil {
+				t.Fatalf("unsafe migration repository root unexpectedly succeeded:\n%s", out)
+			}
+			if !strings.Contains(string(out), tt.wantError) {
+				t.Fatalf("refusal = %q, want exact line %q", out, tt.wantError)
+			}
+			for _, path := range snapshotPaths {
+				if after := snapshotMigrationV062Tree(t, path); after != before[path] {
+					t.Errorf("rejected migration init changed tree %s", path)
+				}
+			}
+			assertMigrationV062InitUntouched(t, target)
+		})
+	}
+}
+
+func snapshotMigrationV062Tree(t *testing.T, root string) [sha256.Size]byte {
+	t.Helper()
+	hash := sha256.New()
+	err := filepath.WalkDir(root, func(path string, _ os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		info, err := os.Lstat(path)
+		if err != nil {
+			return err
+		}
+		_, _ = fmt.Fprintf(hash, "%s\x00%s\x00", rel, info.Mode())
+		switch {
+		case info.Mode()&os.ModeSymlink != 0:
+			target, err := os.Readlink(path)
+			if err != nil {
+				return err
+			}
+			_, _ = fmt.Fprintf(hash, "%s\x00", target)
+		case info.Mode().IsRegular():
+			file, err := os.Open(path)
+			if err != nil {
+				return err
+			}
+			_, copyErr := io.Copy(hash, file)
+			closeErr := file.Close()
+			if copyErr != nil {
+				return copyErr
+			}
+			if closeErr != nil {
+				return closeErr
+			}
+			_, _ = hash.Write([]byte{0})
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("snapshot tree %s: %v", root, err)
+	}
+	var digest [sha256.Size]byte
+	copy(digest[:], hash.Sum(nil))
+	return digest
+}
+
+func assertMigrationV062InitUntouched(t *testing.T, dir string, extra ...string) {
+	t.Helper()
+	paths := append([]string{
+		".beads",
+		".dolt",
+		".gitignore",
+		"AGENTS.md",
+		".agents",
+		".codex",
+	}, extra...)
+	for _, rel := range paths {
+		path := filepath.Join(dir, rel)
+		if _, err := os.Lstat(path); err == nil {
+			t.Errorf("rejected migration identity init changed %s", path)
+		} else if !os.IsNotExist(err) {
+			t.Errorf("stat rejected-init path %s: %v", path, err)
+		}
+	}
+}

--- a/docs/getting-started/upgrading.md
+++ b/docs/getting-started/upgrading.md
@@ -305,13 +305,60 @@ Before changing binaries:
 5. Revalidate the sealed rollback copy, and retain it until issue counts,
    fields, comments, labels, and dependency edges have been verified.
 
-The repository's migration CI contains release-specific bridges for its pinned
-historical fixtures, but those recipes are test infrastructure, not a supported
-command for arbitrary user databases. A generic `list --json` export is not a
-lossless substitute: historical release shapes can omit comments, labels, or
-dependency details. Until a user-facing bridge is published, keep using the
-matching historical binary rather than applying the old destructive conversion
-steps.
+#### Qualified v0.62.0 bridge (Linux)
+
+The repository now includes a user-facing bridge for one deliberately narrow
+v0.62.0 shape. It accepts exactly the five-record qualification corpus covering
+eight features: epic, task, bug, dependency, standalone rich fields, closed
+state, label, and comment. A different record count, an unsupported top-level
+or nested field, a different historical release, or an unsafe layout is refused
+before cutover. This is not yet a general converter for arbitrary v0.62 data.
+
+Stop the historical server and every writer first. Keep checksum-verified copies
+of the exact v0.62.0 `bd` binary and Dolt 1.84.0 runtime, then inspect without
+workspace effects:
+
+```bash
+workspace=$(realpath /path/to/project)
+target_bd=$(realpath /path/to/current/bd)
+source_bd=$(realpath /path/to/bd-v0.62.0)
+source_dolt=$(realpath /path/to/dolt-1.84.0)
+
+./scripts/migrate-v062-server-to-current.sh \
+  --inspect --json \
+  --workspace "$workspace" \
+  --target-bd "$target_bd" \
+  --source-bd "$source_bd" \
+  --source-dolt "$source_dolt" \
+  > /tmp/beads-v062-plan.json
+
+plan=$(jq -er '.plan.digest' /tmp/beads-v062-plan.json)
+```
+
+Review the plan, keep the historical server stopped, and explicitly apply that
+exact digest:
+
+```bash
+./scripts/migrate-v062-server-to-current.sh \
+  --apply --yes --json --expect-plan "$plan" \
+  --workspace "$workspace" \
+  --target-bd "$target_bd" \
+  --source-bd "$source_bd" \
+  --source-dolt "$source_dolt"
+```
+
+Apply retains the complete historical source at
+`.beads-v0.62.0-rollback` and publishes the verified embedded target at
+`.beads`. It is never automatic. Re-running the same consent-bound plan after
+success verifies the receipt-backed target and returns a no-op; an authenticated
+interrupted cutover is recovered on retry, while ambiguous state is preserved
+for manual recovery.
+
+For other v0.50.x-v0.62.x shapes, keep using the matching historical binary.
+The migration CI recipes are qualification infrastructure, not supported
+commands for arbitrary databases. A generic `list --json` export is not a
+lossless substitute because historical release shapes can omit comments,
+labels, or dependency details.
 
 ### From v0.30.x-v0.50.x SQLite workspaces
 

--- a/internal/v062migration/inspect_linux.go
+++ b/internal/v062migration/inspect_linux.go
@@ -56,7 +56,8 @@ var (
 )
 
 type metadataShape struct {
-	database string
+	database  string
+	projectID string
 }
 
 type treeSnapshot struct {
@@ -164,7 +165,7 @@ func inspectWithHooks(project, targetVersion string, hooks inspectHooks) (result
 		return Result{}, err
 	}
 
-	return QualifiedResult(project, targetVersion, first.treeSHA256), nil
+	return QualifiedResult(project, targetVersion, shape.database, shape.projectID, first.treeSHA256), nil
 }
 
 // checkInspectPreconditions rejects environments and workspace arguments that
@@ -475,46 +476,48 @@ func parseMetadata(data []byte) (metadataShape, error) {
 	if err != nil {
 		return metadataShape{}, err
 	}
-	database, err := requiredMetadataShape(values)
+	database, projectID, err := requiredMetadataShape(values)
 	if err != nil {
 		return metadataShape{}, err
 	}
 	if err := rejectDisallowedMetadataFields(values); err != nil {
 		return metadataShape{}, err
 	}
-	return metadataShape{database: database}, nil
+	return metadataShape{database: database, projectID: projectID}, nil
 }
 
 // requiredMetadataShape enforces the exact scalar contract of a v0.62 local
-// Dolt-server metadata document and returns the validated dolt database name.
-func requiredMetadataShape(values map[string]json.RawMessage) (string, error) {
+// Dolt-server metadata document and returns the validated dolt database name
+// and project id.
+func requiredMetadataShape(values map[string]json.RawMessage) (string, string, error) {
 	for _, field := range []struct{ key, want string }{
 		{"backend", "dolt"},
 		{"database", "dolt"},
 		{"dolt_mode", "server"},
 	} {
 		if got, ok := requiredString(values, field.key); !ok || got != field.want {
-			return "", errors.New(field.key)
+			return "", "", errors.New(field.key)
 		}
 	}
 	if _, present := values["dolt_server_host"]; present {
 		if host, ok := requiredString(values, "dolt_server_host"); !ok || host != "127.0.0.1" {
-			return "", errors.New("dolt_server_host")
+			return "", "", errors.New("dolt_server_host")
 		}
 	}
 	database, ok := requiredString(values, "dolt_database")
 	if !ok || !databaseNamePattern.MatchString(database) {
-		return "", errors.New("dolt_database")
+		return "", "", errors.New("dolt_database")
 	}
-	if projectID, ok := requiredString(values, "project_id"); !ok || !projectIDPattern.MatchString(projectID) {
-		return "", errors.New("project_id")
+	projectID, ok := requiredString(values, "project_id")
+	if !ok || !projectIDPattern.MatchString(projectID) {
+		return "", "", errors.New("project_id")
 	}
 	if _, present := values["dolt_server_port"]; present {
 		if port, ok := requiredInteger(values, "dolt_server_port"); !ok || port < 1 || port > 65535 {
-			return "", errors.New("dolt_server_port")
+			return "", "", errors.New("dolt_server_port")
 		}
 	}
-	return database, nil
+	return database, projectID, nil
 }
 
 // rejectDisallowedMetadataFields fails closed on any field outside the allowed
@@ -796,6 +799,11 @@ func checkDevice(actual, expected uint64) error {
 }
 
 func validateRequiredLayout(kinds map[string]byte, database string) error {
+	for _, routingArtifact := range []string{".env", "redirect"} {
+		if _, exists := kinds[routingArtifact]; exists {
+			return refuse(CodeSourceRoutingUnsupported, false, nil)
+		}
+	}
 	for _, mixed := range []string{"embeddeddolt", "beads.db", "proxieddb", "sqlite.db"} {
 		if _, exists := kinds[mixed]; exists {
 			return refuse(CodeMixedStorageLayout, false, nil)

--- a/internal/v062migration/inspect_linux_test.go
+++ b/internal/v062migration/inspect_linux_test.go
@@ -34,6 +34,12 @@ func TestInspectQualifiesExactV062ServerTreeWithoutMutation(t *testing.T) {
 	if result.Source.Workspace != project || result.Source.Version != "0.62.0" || result.Source.Backend != "dolt-server" {
 		t.Fatalf("unexpected source: %#v", result.Source)
 	}
+	if result.Source.Database != "smoke" {
+		t.Fatalf("source database = %q, want %q", result.Source.Database, "smoke")
+	}
+	if result.Source.ProjectID != "7ef372b4-4c3c-4e2c-a6cc-29dd2d0a28c6" {
+		t.Fatalf("source project ID = %q", result.Source.ProjectID)
+	}
 	if result.Source.DigestScope != DigestScopeAdmissionObservation {
 		t.Fatalf("digest scope = %q, want %q", result.Source.DigestScope, DigestScopeAdmissionObservation)
 	}
@@ -270,6 +276,22 @@ func TestInspectRefusesUnsafeAndMixedSourceShapes(t *testing.T) {
 				if err := os.Mkdir(filepath.Join(project, ".beads", "embeddeddolt"), 0o700); err != nil {
 					t.Fatal(err)
 				}
+			},
+		},
+		{
+			name: "project env routing override",
+			want: Code("source_routing_unsupported"),
+			edit: func(t *testing.T, project string) {
+				t.Helper()
+				mustWrite(t, filepath.Join(project, ".beads", ".env"), "BEADS_DOLT_SERVER_HOST=poison.invalid\n")
+			},
+		},
+		{
+			name: "project redirect routing override",
+			want: Code("source_routing_unsupported"),
+			edit: func(t *testing.T, project string) {
+				t.Helper()
+				mustWrite(t, filepath.Join(project, ".beads", "redirect"), "../other/.beads\n")
 			},
 		},
 		{

--- a/internal/v062migration/types.go
+++ b/internal/v062migration/types.go
@@ -35,6 +35,7 @@ const (
 	CodeSourceMetadataMissing     Code = "source_metadata_missing"
 	CodeSourceMetadataMismatch    Code = "source_metadata_mismatch"
 	CodeSourceLayoutMissing       Code = "source_layout_missing"
+	CodeSourceRoutingUnsupported  Code = "source_routing_unsupported"
 	CodeUnsafeSourceSymlink       Code = "unsafe_source_symlink"
 	CodeUnsafeSourceHardlink      Code = "unsafe_source_hardlink"
 	CodeUnsafeSourceObject        Code = "unsafe_source_object"
@@ -62,6 +63,8 @@ type Source struct {
 	Workspace string `json:"workspace"`
 	Version   string `json:"version"`
 	Backend   string `json:"backend"`
+	Database  string `json:"database"`
+	ProjectID string `json:"project_id"`
 	// TreeSHA256 is admission evidence with the lifetime explicitly bounded
 	// by DigestScope; it must never authorize a later effectful operation.
 	TreeSHA256 string `json:"tree_sha256"`
@@ -108,7 +111,7 @@ func refuse(code Code, retryable bool, cause error) error {
 	return &Refusal{Code: code, Retryable: retryable, Effect: EffectNone, cause: cause}
 }
 
-func QualifiedResult(workspace, targetVersion, treeSHA256 string) Result {
+func QualifiedResult(workspace, targetVersion, database, projectID, treeSHA256 string) Result {
 	return Result{
 		SchemaVersion: SchemaVersion,
 		Operation:     Operation,
@@ -119,6 +122,8 @@ func QualifiedResult(workspace, targetVersion, treeSHA256 string) Result {
 			Workspace:   workspace,
 			Version:     "0.62.0",
 			Backend:     "dolt-server",
+			Database:    database,
+			ProjectID:   projectID,
 			TreeSHA256:  treeSHA256,
 			DigestScope: DigestScopeAdmissionObservation,
 		},

--- a/scripts/migrate-v062-server-to-current.sh
+++ b/scripts/migrate-v062-server-to-current.sh
@@ -1,6 +1,8 @@
-#!/usr/bin/env bash
+#!/bin/bash -p
 # Qualified public bridge for v0.62.0 Dolt-server workspaces.
 # Source admission is delegated to hidden no-follow plumbing in current bd.
+# Transaction recovery covers process interruption on a live filesystem. This
+# bridge does not claim to implement storage-engine power-loss durability.
 
 set -uo pipefail
 umask 077
@@ -11,6 +13,26 @@ readonly JQ_BIN=/usr/bin/jq
 readonly READLINK_BIN=/usr/bin/readlink
 readonly REALPATH_BIN=/usr/bin/realpath
 readonly TIMEOUT_BIN=/usr/bin/timeout
+readonly SHA256SUM_BIN=/usr/bin/sha256sum
+readonly CP_BIN=/usr/bin/cp
+readonly GIT_BIN=/usr/bin/git
+readonly MKTEMP_BIN=/usr/bin/mktemp
+readonly MKDIR_BIN=/usr/bin/mkdir
+readonly RM_BIN=/usr/bin/rm
+readonly RMDIR_BIN=/usr/bin/rmdir
+readonly SLEEP_BIN=/usr/bin/sleep
+readonly FIND_BIN=/usr/bin/find
+readonly SORT_BIN=/usr/bin/sort
+readonly XARGS_BIN=/usr/bin/xargs
+readonly MV_BIN=/usr/bin/mv
+readonly CHMOD_BIN=/usr/bin/chmod
+readonly STAT_BIN=/usr/bin/stat
+readonly CAT_BIN=/usr/bin/cat
+readonly GREP_BIN=/usr/bin/grep
+readonly FLOCK_BIN=/usr/bin/flock
+readonly BOOT_ID_PATH=/proc/sys/kernel/random/boot_id
+readonly SEMANTIC_SCOPE=v062_lossless_core_v1
+readonly PLAN_SCHEMA=bd.v062.bridge-plan.v1
 
 MODE=inspect
 MODE_SET=false
@@ -18,6 +40,76 @@ JSON_OUTPUT=false
 YES=false
 WORKSPACE_ARG=
 TARGET_BD_ARG=
+SOURCE_BD_ARG=
+SOURCE_DOLT_ARG=
+EXPECT_PLAN=
+SOURCE_BD=
+SOURCE_DOLT=
+SOURCE_BD_EXEC=
+SOURCE_DOLT_EXEC=
+SOURCE_BD_SHA256=
+SOURCE_DOLT_SHA256=
+SOURCE_ISSUE_PREFIX=
+SOURCE_DATABASE=
+SOURCE_PROJECT_ID=
+SOURCE_SERVER_PORT=
+TARGET_BD_SHA256=
+TARGET_BD_EXEC=
+PLAN_JSON=
+PLAN_DIGEST=
+SEMANTIC_PROBE=
+RUNTIME_SCRATCH=
+RUNTIME_SCRATCH_ID=
+RUNTIME_GUARD_PID=
+RUNTIME_GUARD_START_TIME=
+SOURCE_SCRATCH=
+SOURCE_SERVER_PID=
+SOURCE_SERVER_START_TIME=
+SOURCE_SERVER_LOG=
+CLEAN_HOME=
+QUALIFICATION_CODE=
+QUALIFIED_SOURCE_TREE=
+ROLLBACK_PATH=
+CANONICAL_STAGING_PATH=
+CANONICAL_LOCK_PATH=
+STAGING_PATH=
+LOCK_PATH=
+LOCK_JOURNAL_PATH=
+TRANSACTION_ROOT=
+TRANSACTION_ROOT_ID=
+TRANSACTION_LOCK_PATH=
+TRANSACTION_STAGING_PATH=
+TRANSACTION_GUARD_PID=
+TRANSACTION_GUARD_START_TIME=
+STAGING_ID=
+LOCK_ID=
+LOCK_PHASE=
+LOCK_STAGING_ID=
+LOCK_SOURCE_ID=
+LOCK_OWNER_PID=
+LOCK_OWNER_START_TIME=
+LOCK_BOOT_ID=
+WORKSPACE_LOCK_FD=
+WORKSPACE_LOCK_HOLDER_PID=
+WORKSPACE_LOCK_HOLDER_START_TIME=
+WORKSPACE_LOCK_READY=
+WORKSPACE_LOCK_RELEASE=
+WORKSPACE_ID=
+AUTHENTICATED_SOURCE_CONTENT=
+STAGING_OWNED=false
+LOCK_OWNED=false
+LOCK_PUBLISHED=false
+SOURCE_RENAMED=false
+SOURCE_MOVE_ATTEMPTED=false
+SOURCE_ORIGINAL_ID=
+TRANSACTION_COMMITTED=false
+TEST_PHASE_DIR=${BD_V062_TEST_PHASE_DIR:-}
+TEST_FINGERPRINT_FAILURE=${BD_V062_TEST_FINGERPRINT_FAILURE:-}
+TEST_MV_MODE=${BD_V062_TEST_MV_MODE:-}
+TEST_RUNTIME_UNKNOWN_ENTRY=${BD_V062_TEST_RUNTIME_UNKNOWN_ENTRY:-}
+TEST_IDENTITY_PROBE_FAILURE=${BD_V062_TEST_IDENTITY_PROBE_FAILURE:-}
+TEST_GUARDIAN_START_FAILURE=${BD_V062_TEST_GUARDIAN_START_FAILURE:-}
+UNSAFE_TEST_MV_BIN=${BD_V062_TEST_MV_BIN:-}
 
 # Honor --json even when a preceding argument is invalid.
 for argument in "$@"; do
@@ -25,14 +117,17 @@ for argument in "$@"; do
 done
 
 usage() {
-    cat >&2 <<'EOF'
+    "$CAT_BIN" >&2 <<'EOF'
 Usage: migrate-v062-server-to-current.sh [options]
 
   --workspace PROJECT  Project containing the v0.62.0 .beads directory
   --target-bd PATH     Absolute path to the current embedded-capable bd
+  --source-bd PATH     Absolute path to the pinned v0.62.0 bd
+  --source-dolt PATH   Absolute path to the pinned Dolt 1.84.0 runtime
   --inspect            Inspect only (default; no workspace effects)
   --apply              Perform the migration
   --yes                Required confirmation for --apply
+  --expect-plan SHA256 Required inspect plan digest for --apply
   --json               Emit exactly one JSON result on stdout
   -h, --help           Show this help
 EOF
@@ -80,6 +175,2739 @@ refuse() {
     finish_error 1 refused "$1" "$2" none "$3"
 }
 
+sha256_file() {
+    local digest
+    read -r digest _ < <("$SHA256SUM_BIN" -- "$1") || return 1
+    [[ "$digest" =~ ^[0-9a-f]{64}$ ]] || return 1
+    printf '%s\n' "$digest"
+}
+
+ensure_runtime_scratch() {
+    local owner_start
+
+    if [ -n "$RUNTIME_SCRATCH" ]; then
+        return 0
+    fi
+    RUNTIME_SCRATCH=$("$MKTEMP_BIN" -d /tmp/bd-v062-runtime.XXXXXX) ||
+        return 1
+    RUNTIME_SCRATCH_ID=$(directory_identity "$RUNTIME_SCRATCH") || {
+        RUNTIME_SCRATCH=
+        return 1
+    }
+    if ! "$CHMOD_BIN" 700 -- "$RUNTIME_SCRATCH" ||
+        ! owner_start=$(source_server_start_time "$$"); then
+        remove_authenticated_directory \
+            "$RUNTIME_SCRATCH" "$RUNTIME_SCRATCH_ID" runtime \
+            2>/dev/null || true
+        RUNTIME_SCRATCH=
+        RUNTIME_SCRATCH_ID=
+        return 1
+    fi
+    (
+        trap - EXIT
+        close_workspace_lock_in_child
+        runtime_scratch_guardian \
+            "$$" "$owner_start" "$RUNTIME_SCRATCH" "$RUNTIME_SCRATCH_ID"
+    ) </dev/null >/dev/null 2>&1 &
+    RUNTIME_GUARD_PID=$!
+    RUNTIME_GUARD_START_TIME=$(bounded_process_start_time_builtin \
+        "$RUNTIME_GUARD_PID" runtime_guardian_start) || return 1
+    if [ "$TEST_RUNTIME_UNKNOWN_ENTRY" = inject ]; then
+        printf '%s\n' 'test-only unknown runtime bytes' \
+            > "$RUNTIME_SCRATCH/unexpected-runtime-entry" || return 1
+    fi
+}
+
+pin_executable() {
+    local source="$1" destination="$2"
+    [ -f "$source" ] && [ -x "$source" ] && [ ! -L "$source" ] || return 1
+    [ ! -e "$destination" ] && [ ! -L "$destination" ] || return 1
+    "$CP_BIN" -f -- "$source" "$destination" || return 1
+    "$CHMOD_BIN" 700 -- "$destination" || return 1
+    [ -f "$destination" ] && [ -x "$destination" ] &&
+        [ ! -L "$destination" ] || return 1
+}
+
+clean_capture() {
+    [ -n "$CLEAN_HOME" ] && [ -d "$CLEAN_HOME" ] &&
+        [ ! -L "$CLEAN_HOME" ] || return 1
+    "$ENV_BIN" -i \
+        PATH=/usr/bin:/bin HOME="$CLEAN_HOME" TMPDIR="$CLEAN_HOME/tmp" \
+        XDG_CONFIG_HOME="$CLEAN_HOME/config" \
+        XDG_CACHE_HOME="$CLEAN_HOME/cache" \
+        XDG_DATA_HOME="$CLEAN_HOME/data" \
+        XDG_STATE_HOME="$CLEAN_HOME/state" \
+        GIT_CONFIG_NOSYSTEM=1 GIT_CONFIG_GLOBAL=/dev/null \
+        GIT_TERMINAL_PROMPT=0 BD_DISABLE_METRICS=1 \
+        BD_DISABLE_EVENT_FLUSH=1 BD_NON_INTERACTIVE=1 \
+        BEADS_NO_DAEMON=1 BEADS_DOLT_AUTO_START=0 \
+        NO_COLOR=1 CI=1 LANG=C.UTF-8 LC_ALL=C.UTF-8 TZ=UTC TERM=dumb \
+        "$TIMEOUT_BIN" --kill-after=5s "${INSPECT_TIMEOUT_SECONDS}s" "$@"
+}
+
+resolve_source_tools() {
+    local version_json version_text
+
+    if [ -z "$SOURCE_BD_ARG" ]; then
+        refuse source_binary_missing false \
+            "an explicit pinned v0.62.0 source bd is required"
+    fi
+    if [[ "$SOURCE_BD_ARG" != /* ]]; then
+        refuse source_binary_invalid false \
+            "--source-bd must be an absolute path"
+    fi
+    if [ ! -e "$SOURCE_BD_ARG" ] && [ ! -L "$SOURCE_BD_ARG" ]; then
+        refuse source_binary_missing false \
+            "the pinned v0.62.0 source bd is unavailable"
+    fi
+    [ ! -L "$SOURCE_BD_ARG" ] ||
+        refuse source_binary_invalid false \
+            "the source bd path must not be a symbolic link"
+    SOURCE_BD=$("$READLINK_BIN" -f -- "$SOURCE_BD_ARG" 2>/dev/null) ||
+        refuse source_binary_invalid false \
+            "the source bd path cannot be resolved"
+    [ -f "$SOURCE_BD" ] && [ -x "$SOURCE_BD" ] ||
+        refuse source_binary_invalid false \
+            "the source bd path is not an executable regular file"
+    ensure_runtime_scratch ||
+        refuse source_binary_invalid false \
+            "a private source runtime directory cannot be created"
+    SOURCE_BD_EXEC="$RUNTIME_SCRATCH/source-bd"
+    pin_executable "$SOURCE_BD" "$SOURCE_BD_EXEC" ||
+        refuse source_binary_invalid false \
+            "the source bd executable cannot be pinned"
+    ensure_clean_home ||
+        refuse source_binary_invalid false \
+            "an isolated runtime home could not be created"
+    version_json=$(clean_capture "$SOURCE_BD_EXEC" version --json 2>/dev/null) ||
+        refuse source_binary_invalid false \
+            "the source bd version cannot be verified"
+    version_text=$("$JQ_BIN" -er '.version | select(type == "string")' \
+        <<< "$version_json" 2>/dev/null) ||
+        refuse source_binary_invalid false \
+            "the source bd version response is invalid"
+    [ "$version_text" = 0.62.0 ] ||
+        refuse source_binary_invalid false \
+            "the source bd must be exactly v0.62.0"
+    SOURCE_BD_SHA256=$(sha256_file "$SOURCE_BD_EXEC") ||
+        refuse source_binary_invalid false \
+            "the source bd identity cannot be hashed"
+
+    if [ -z "$SOURCE_DOLT_ARG" ]; then
+        refuse source_runtime_missing false \
+            "an explicit pinned Dolt 1.84.0 runtime is required"
+    fi
+    if [[ "$SOURCE_DOLT_ARG" != /* ]]; then
+        refuse source_runtime_invalid false \
+            "--source-dolt must be an absolute path"
+    fi
+    if [ ! -e "$SOURCE_DOLT_ARG" ] && [ ! -L "$SOURCE_DOLT_ARG" ]; then
+        refuse source_runtime_missing false \
+            "the pinned Dolt 1.84.0 runtime is unavailable"
+    fi
+    [ ! -L "$SOURCE_DOLT_ARG" ] ||
+        refuse source_runtime_invalid false \
+            "the source Dolt path must not be a symbolic link"
+    SOURCE_DOLT=$("$READLINK_BIN" -f -- "$SOURCE_DOLT_ARG" 2>/dev/null) ||
+        refuse source_runtime_invalid false \
+            "the source Dolt path cannot be resolved"
+    [ -f "$SOURCE_DOLT" ] && [ -x "$SOURCE_DOLT" ] ||
+        refuse source_runtime_invalid false \
+            "the source Dolt path is not an executable regular file"
+    SOURCE_DOLT_EXEC="$RUNTIME_SCRATCH/source-dolt"
+    pin_executable "$SOURCE_DOLT" "$SOURCE_DOLT_EXEC" ||
+        refuse source_runtime_invalid false \
+            "the source Dolt executable cannot be pinned"
+    version_text=$(clean_capture "$SOURCE_DOLT_EXEC" version 2>/dev/null) ||
+        refuse source_runtime_invalid false \
+            "the source Dolt version cannot be verified"
+    "$GREP_BIN" -Eq '^dolt version 1[.]84[.]0([[:space:]]|$)' \
+        <<< "$version_text" ||
+        refuse source_runtime_invalid false \
+            "the source Dolt runtime must be exactly 1.84.0"
+    SOURCE_DOLT_SHA256=$(sha256_file "$SOURCE_DOLT_EXEC") ||
+        refuse source_runtime_invalid false \
+            "the source Dolt identity cannot be hashed"
+}
+
+semantic_issue_ids() {
+    "$JQ_BIN" -cse '
+        select(
+            length == 5 and
+            all(.[];
+                type == "object" and
+                ((.id? | type) == "string") and
+                (.id | test("^[A-Za-z0-9._-]{1,128}$"))) and
+            (([.[].id] | unique | length) == 5)
+        ) |
+        [.[].id] | sort
+    ' "$1" 2>/dev/null
+}
+
+build_bound_plan() {
+    local inspection="$1" semantic_file="$2" source_content="$3"
+    local plan_without_digest target_version source_tree
+    local baseline_ids baseline_digest
+
+    target_version=$("$JQ_BIN" -er '.target.version' <<< "$inspection") ||
+        return 1
+    source_tree=$("$JQ_BIN" -er '.source.tree_sha256' <<< "$inspection") ||
+        return 1
+    [[ "$source_content" =~ ^[0-9a-f]{64}$ ]] || return 1
+    baseline_ids=$(semantic_issue_ids "$semantic_file") || return 1
+    baseline_digest=$(semantic_sha256 "$semantic_file") || return 1
+    [[ "$TARGET_BD_SHA256" =~ ^[0-9a-f]{64}$ ]] || return 1
+    plan_without_digest=$("$JQ_BIN" -cnS \
+        --arg schema "$PLAN_SCHEMA" --arg workspace "$WORKSPACE" \
+        --arg semantic_scope "$SEMANTIC_SCOPE" \
+        --arg tree "$source_tree" \
+        --arg source_content "$source_content" \
+        --arg source_bd "$SOURCE_BD" --arg source_bd_sha "$SOURCE_BD_SHA256" \
+        --arg source_dolt "$SOURCE_DOLT" --arg source_dolt_sha "$SOURCE_DOLT_SHA256" \
+        --arg source_prefix "$SOURCE_ISSUE_PREFIX" \
+        --arg source_database "$SOURCE_DATABASE" \
+        --arg source_project_id "$SOURCE_PROJECT_ID" \
+        --argjson baseline_ids "$baseline_ids" \
+        --arg baseline_digest "$baseline_digest" \
+        --arg target_bd "$TARGET_BD" --arg target_version "$target_version" \
+        --arg target_sha "$TARGET_BD_SHA256" '
+        {
+            schema: $schema,
+            workspace: $workspace,
+            semantic_scope: $semantic_scope,
+            target_backend: "dolt-embedded",
+            source_observation: {
+                tree_sha256: $tree,
+                digest_scope: "admission_observation",
+                content_sha256: $source_content,
+                content_digest_scope: "complete_source_tree"
+            },
+            source_identity: {
+                issue_prefix: $source_prefix,
+                database: $source_database,
+                project_id: $source_project_id
+            },
+            semantic_baseline: {
+                issue_ids: $baseline_ids,
+                sha256: $baseline_digest
+            },
+            source_binary: {
+                path: $source_bd, version: "0.62.0", sha256: $source_bd_sha
+            },
+            source_runtime: {
+                kind: "dolt", path: $source_dolt,
+                version: "1.84.0", sha256: $source_dolt_sha
+            },
+            target_binary: {
+                path: $target_bd, version: $target_version, sha256: $target_sha
+            },
+            strategy: {
+                export: "native_export_show_comments_v1",
+                import: "jsonl_v1",
+                verification: "id_keyed_canonical_v1",
+                cutover: "side_by_side_atomic_publish_v1",
+                rollback: "retain"
+            }
+        }
+    ') || return 1
+    PLAN_DIGEST=$(printf '%s' "$plan_without_digest" | "$SHA256SUM_BIN" |
+        { read -r digest _; printf '%s\n' "$digest"; }) || return 1
+    [[ "$PLAN_DIGEST" =~ ^[0-9a-f]{64}$ ]] || return 1
+    PLAN_JSON=$("$JQ_BIN" -cS --arg digest "$PLAN_DIGEST" \
+        '. + {digest: $digest}' <<< "$plan_without_digest") || return 1
+}
+
+ensure_clean_home() {
+    if [ -n "$CLEAN_HOME" ]; then
+        [ "$CLEAN_HOME" = "$RUNTIME_SCRATCH/home" ] &&
+            [ -d "$CLEAN_HOME" ] && [ ! -L "$CLEAN_HOME" ]
+        return
+    fi
+    ensure_runtime_scratch || return 1
+    CLEAN_HOME="$RUNTIME_SCRATCH/home"
+    path_absent "$CLEAN_HOME" || return 1
+    "$MKDIR_BIN" -m 700 -- "$CLEAN_HOME" || return 1
+    "$MKDIR_BIN" -m 700 -- \
+        "$CLEAN_HOME/config" "$CLEAN_HOME/cache" "$CLEAN_HOME/data" \
+        "$CLEAN_HOME/state" "$CLEAN_HOME/tmp" || return 1
+}
+
+close_workspace_lock_in_child() {
+    [ -z "$WORKSPACE_LOCK_FD" ] || exec {WORKSPACE_LOCK_FD}>&-
+}
+
+clean_at() {
+    local cwd="$1"
+    shift
+    (
+        close_workspace_lock_in_child
+        cd -P -- "$cwd" || exit 1
+        "$ENV_BIN" -i \
+            PATH=/usr/bin:/bin HOME="$CLEAN_HOME" TMPDIR="$CLEAN_HOME/tmp" \
+            XDG_CONFIG_HOME="$CLEAN_HOME/config" \
+            XDG_CACHE_HOME="$CLEAN_HOME/cache" \
+            XDG_DATA_HOME="$CLEAN_HOME/data" \
+            XDG_STATE_HOME="$CLEAN_HOME/state" \
+            GIT_CONFIG_NOSYSTEM=1 GIT_CONFIG_GLOBAL=/dev/null \
+            GIT_TERMINAL_PROMPT=0 BD_DISABLE_METRICS=1 \
+            BD_DISABLE_EVENT_FLUSH=1 BD_NON_INTERACTIVE=1 \
+            BD_NO_PAGER=1 BEADS_NO_DAEMON=1 BEADS_DOLT_AUTO_START=0 \
+            NO_COLOR=1 CI=1 LANG=C.UTF-8 LC_ALL=C.UTF-8 TZ=UTC TERM=dumb \
+            "$TIMEOUT_BIN" --kill-after=5s "${INSPECT_TIMEOUT_SECONDS}s" "$@"
+    )
+}
+
+target_at() {
+    local cwd="$1"
+    shift
+    [ ! -e "$cwd/.beads/.env" ] && [ ! -L "$cwd/.beads/.env" ] &&
+        [ ! -e "$cwd/.beads/redirect" ] &&
+        [ ! -L "$cwd/.beads/redirect" ] || return 1
+    ensure_clean_home || return 1
+    (
+        close_workspace_lock_in_child
+        cd -P -- "$cwd" || exit 1
+        "$ENV_BIN" -i \
+            PATH=/usr/bin:/bin HOME="$CLEAN_HOME" TMPDIR="$CLEAN_HOME/tmp" \
+            XDG_CONFIG_HOME="$CLEAN_HOME/config" \
+            XDG_CACHE_HOME="$CLEAN_HOME/cache" \
+            XDG_DATA_HOME="$CLEAN_HOME/data" \
+            XDG_STATE_HOME="$CLEAN_HOME/state" \
+            BEADS_DIR="$cwd/.beads" USER=beads-migration \
+            GIT_CONFIG_NOSYSTEM=1 GIT_CONFIG_GLOBAL=/dev/null \
+            GIT_TERMINAL_PROMPT=0 BD_DISABLE_METRICS=1 \
+            BD_DISABLE_EVENT_FLUSH=1 BD_NON_INTERACTIVE=1 \
+            BD_NO_PAGER=1 BEADS_NO_DAEMON=1 BEADS_DOLT_AUTO_START=0 \
+            NO_COLOR=1 CI=1 LANG=C.UTF-8 LC_ALL=C.UTF-8 TZ=UTC TERM=dumb \
+            "$TIMEOUT_BIN" --kill-after=5s "${INSPECT_TIMEOUT_SECONDS}s" "$@"
+    )
+}
+
+source_at() {
+    local cwd="$1"
+    shift
+    [[ "$SOURCE_SERVER_PORT" =~ ^[1-9][0-9]*$ ]] &&
+        [ "$SOURCE_SERVER_PORT" -le 65535 ] || return 1
+    [[ "$SOURCE_DATABASE" =~ ^[A-Za-z_][A-Za-z0-9_-]{0,63}$ ]] || return 1
+    ensure_clean_home || return 1
+    (
+        close_workspace_lock_in_child
+        cd -P -- "$cwd" || exit 1
+        "$ENV_BIN" -i \
+            PATH=/usr/bin:/bin HOME="$CLEAN_HOME" TMPDIR="$CLEAN_HOME/tmp" \
+            XDG_CONFIG_HOME="$CLEAN_HOME/config" \
+            XDG_CACHE_HOME="$CLEAN_HOME/cache" \
+            XDG_DATA_HOME="$CLEAN_HOME/data" \
+            XDG_STATE_HOME="$CLEAN_HOME/state" \
+            BEADS_DOLT_SERVER_HOST=127.0.0.1 \
+            BEADS_DOLT_SERVER_PORT="$SOURCE_SERVER_PORT" \
+            BEADS_DOLT_SERVER_DATABASE="$SOURCE_DATABASE" \
+            GIT_CONFIG_NOSYSTEM=1 GIT_CONFIG_GLOBAL=/dev/null \
+            GIT_TERMINAL_PROMPT=0 BD_DISABLE_METRICS=1 \
+            BD_DISABLE_EVENT_FLUSH=1 BD_NON_INTERACTIVE=1 \
+            BD_NO_PAGER=1 BEADS_NO_DAEMON=1 BEADS_DOLT_AUTO_START=0 \
+            NO_COLOR=1 CI=1 LANG=C.UTF-8 LC_ALL=C.UTF-8 TZ=UTC TERM=dumb \
+            "$TIMEOUT_BIN" --kill-after=5s "${INSPECT_TIMEOUT_SECONDS}s" "$@"
+    )
+}
+
+inspect_admission_source() {
+    local workspace="$1" output process_status
+    ensure_clean_home || return 1
+    output=$(clean_at "$workspace" "$TARGET_BD_EXEC" \
+        __migration-v062-inspect --workspace "$workspace" --json 2>/dev/null)
+    process_status=$?
+    [ "$process_status" -eq 0 ] || return 1
+    "$JQ_BIN" -crse --arg workspace "$workspace" '
+        if length == 1 then .[0] else empty end |
+        select(
+            type == "object" and .schema_version == 1 and
+            .operation == "v062_source_inspection" and
+            .status == "qualified" and .retryable == false and
+            .effect == "none" and
+            .source.workspace == $workspace and
+            .source.version == "0.62.0" and
+            .source.backend == "dolt-server" and
+            (.source | keys) == [
+                "backend", "database", "digest_scope", "project_id",
+                "tree_sha256", "version", "workspace"
+            ] and
+            (.source.database | type) == "string" and
+            (.source.database |
+                test("^[A-Za-z_][A-Za-z0-9_-]{0,63}$")) and
+            (.source.project_id | type) == "string" and
+            (.source.project_id | test(
+                "^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$"
+            )) and
+            .source.digest_scope == "admission_observation" and
+            (.source.tree_sha256 | type) == "string" and
+            (.source.tree_sha256 | test("^[0-9a-f]{64}$")) and
+            .target.backend == "dolt-embedded" and
+            .target.embedded_capable == true
+        ) |
+        .source
+    ' 2>/dev/null <<< "$output"
+}
+
+inspect_admission_tree() {
+    local source
+    source=$(inspect_admission_source "$1") || return 1
+    "$JQ_BIN" -er '.tree_sha256' <<< "$source" 2>/dev/null
+}
+
+content_fingerprint() {
+    local root="$1" digest hold_pid hold_start owner_pid owner_start
+    local output temporary unsafe
+    [ -d "$root" ] && [ ! -L "$root" ] || return 1
+    if [ "$TEST_FINGERPRINT_FAILURE" = hold ]; then
+        [ -n "$TEST_PHASE_DIR" ] && [[ "$TEST_PHASE_DIR" = /* ]] &&
+            [ -d "$TEST_PHASE_DIR" ] && [ ! -L "$TEST_PHASE_DIR" ] ||
+            return 1
+        path_absent "$TEST_PHASE_DIR/workspace-lock-child.identities" ||
+            return 1
+        temporary="$TEST_PHASE_DIR/workspace-lock-child.identities.next"
+        path_absent "$temporary" || return 1
+        "$SLEEP_BIN" 600 &
+        hold_pid=$!
+        owner_pid=$BASHPID
+        owner_start=$(source_server_start_time "$owner_pid") || {
+            kill -TERM "$hold_pid" 2>/dev/null || true
+            wait "$hold_pid" 2>/dev/null || true
+            return 1
+        }
+        hold_start=$(source_server_start_time "$hold_pid") || {
+            kill -TERM "$hold_pid" 2>/dev/null || true
+            wait "$hold_pid" 2>/dev/null || true
+            return 1
+        }
+        printf '%s %s\n%s %s\n' \
+            "$owner_pid" "$owner_start" "$hold_pid" "$hold_start" \
+            > "$temporary" || {
+            kill -TERM "$hold_pid" 2>/dev/null || true
+            wait "$hold_pid" 2>/dev/null || true
+            return 1
+        }
+        move_no_clobber_verified file "$temporary" \
+            "$TEST_PHASE_DIR/workspace-lock-child.identities" || return 1
+        wait "$hold_pid" || return 1
+    fi
+    unsafe=$(
+        cd -P -- "$root" &&
+            "$FIND_BIN" -P . -mindepth 1 \
+                ! \( -type d -o -type f \) -print -quit
+    ) || return 1
+    [ -z "$unsafe" ] || return 1
+    unsafe=$(
+        cd -P -- "$root" &&
+            "$FIND_BIN" -P . -type f -links +1 -print -quit
+    ) || return 1
+    [ -z "$unsafe" ] || return 1
+    output=$(
+        (
+            cd -P -- "$root" || exit 1
+            "$FIND_BIN" -P . -maxdepth 0 -printf '%y %m %p %l\n' ||
+                exit 1
+            "$FIND_BIN" -P . -mindepth 1 -printf '%y %m %p %l\n' |
+                LC_ALL=C "$SORT_BIN" || exit 1
+            {
+                "$FIND_BIN" -P . -type f -print0 || exit 1
+                if [ "$TEST_FINGERPRINT_FAILURE" = hash ]; then
+                    [ ! -e .bd-v062-intentional-missing-hash-input ] &&
+                        [ ! -L .bd-v062-intentional-missing-hash-input ] ||
+                        exit 1
+                    printf '%s\0' ./.bd-v062-intentional-missing-hash-input
+                fi
+            } | LC_ALL=C "$SORT_BIN" -z |
+                "$XARGS_BIN" -0 -r "$SHA256SUM_BIN" || exit 1
+        ) | "$SHA256SUM_BIN"
+    ) || return 1
+    read -r digest _ <<< "$output" || return 1
+    [[ "$digest" =~ ^[0-9a-f]{64}$ ]] || return 1
+    printf '%s\n' "$digest"
+}
+
+directory_identity() {
+    [ -d "$1" ] && [ ! -L "$1" ] || return 1
+    "$STAT_BIN" -Lc '%d:%i' -- "$1" 2>/dev/null
+}
+
+regular_file_identity() {
+    [ -f "$1" ] && [ ! -L "$1" ] || return 1
+    "$STAT_BIN" -Lc '%d:%i' -- "$1" 2>/dev/null
+}
+
+path_absent() {
+    [ ! -e "$1" ] && [ ! -L "$1" ]
+}
+
+close_workspace_lock() {
+    local attempt probe_status=2 status=0 temporary
+
+    if [ -n "$WORKSPACE_LOCK_FD" ]; then
+        exec {WORKSPACE_LOCK_FD}>&- || status=1
+        WORKSPACE_LOCK_FD=
+    fi
+    if [ -n "$WORKSPACE_LOCK_HOLDER_PID" ]; then
+        [ -n "$WORKSPACE_LOCK_HOLDER_START_TIME" ] || return 1
+        owned_directory_matches "$RUNTIME_SCRATCH" "$RUNTIME_SCRATCH_ID" ||
+            return 1
+        temporary="${WORKSPACE_LOCK_RELEASE}.next"
+        path_absent "$WORKSPACE_LOCK_RELEASE" && path_absent "$temporary" ||
+            return 1
+        printf '%s %s\n' "$WORKSPACE_LOCK_HOLDER_PID" \
+            "$WORKSPACE_LOCK_HOLDER_START_TIME" > "$temporary" || return 1
+        move_no_clobber_verified file \
+            "$temporary" "$WORKSPACE_LOCK_RELEASE" || return 1
+        for ((attempt = 0; attempt < 200; attempt++)); do
+            probe_process_identity_builtin \
+                "$WORKSPACE_LOCK_HOLDER_PID" \
+                "$WORKSPACE_LOCK_HOLDER_START_TIME"
+            probe_status=$?
+            [ "$probe_status" -ne 1 ] || break
+            "$SLEEP_BIN" 0.005
+        done
+        [ "$probe_status" -eq 1 ] || return 1
+        wait "$WORKSPACE_LOCK_HOLDER_PID" 2>/dev/null || return 1
+        WORKSPACE_LOCK_HOLDER_PID=
+        WORKSPACE_LOCK_HOLDER_START_TIME=
+        remove_known_regular_file "$WORKSPACE_LOCK_READY" || status=1
+        remove_known_regular_file "$WORKSPACE_LOCK_RELEASE" || status=1
+        WORKSPACE_LOCK_READY=
+        WORKSPACE_LOCK_RELEASE=
+    fi
+    return "$status"
+}
+
+probe_process_identity_builtin() {
+    local pid="$1" expected_start="$2" role="${3:-}" stat rest
+    local -a fields
+
+    [[ "$pid" =~ ^[1-9][0-9]*$ ]] &&
+        [[ "$expected_start" =~ ^[0-9]+$ ]] || return 2
+    if [ "$TEST_IDENTITY_PROBE_FAILURE" = owner_unverifiable ] &&
+        [ "$role" = owner ] && kill -0 "$pid" 2>/dev/null; then
+        return 2
+    fi
+    if ! IFS= read -r stat 2>/dev/null < "/proc/$pid/stat"; then
+        kill -0 "$pid" 2>/dev/null && return 2
+        return 1
+    fi
+    rest=${stat##*) }
+    read -r -a fields <<< "$rest" || return 2
+    [ "${#fields[@]}" -ge 20 ] || return 2
+    [ "${fields[0]}" != Z ] || return 1
+    [ "${fields[19]}" = "$expected_start" ] && return 0
+    return 1
+}
+
+process_start_time_builtin() {
+    local pid="$1" stat rest
+    local -a fields
+
+    IFS= read -r stat 2>/dev/null < "/proc/$pid/stat" || return 1
+    rest=${stat##*) }
+    read -r -a fields <<< "$rest" || return 1
+    [ "${#fields[@]}" -ge 20 ] && [ "${fields[0]}" != Z ] || return 1
+    printf '%s\n' "${fields[19]}"
+}
+
+bounded_process_start_time_builtin() {
+    local pid="$1" role="$2" attempt start
+
+    for ((attempt = 0; attempt < 200; attempt++)); do
+        if [ "$TEST_GUARDIAN_START_FAILURE" != "$role" ]; then
+            start=$(process_start_time_builtin "$pid") && {
+                printf '%s\n' "$start"
+                return 0
+            }
+        fi
+        kill -0 "$pid" 2>/dev/null || return 1
+        "$SLEEP_BIN" 0.005
+    done
+    return 2
+}
+
+workspace_lock_holder() {
+    local owner_pid="$1" owner_start="$2" runtime="$3" runtime_id="$4"
+    local ready="$5" release="$6" current_id release_pid release_start
+    local self_pid="$BASHPID" self_start temporary="${ready}.next"
+    local owner_status release_enabled=true
+
+    trap '' HUP INT TERM
+    self_start=$(process_start_time_builtin "$self_pid") || return 1
+    path_absent "$ready" && path_absent "$temporary" || return 1
+    printf '%s %s\n' "$self_pid" "$self_start" > "$temporary" || return 1
+    (
+        close_workspace_lock_in_child
+        move_no_clobber_verified file "$temporary" "$ready"
+    ) || return 1
+    while :; do
+        probe_process_identity_builtin "$owner_pid" "$owner_start" owner
+        owner_status=$?
+        [ "$owner_status" -ne 1 ] || break
+        if [ "$owner_status" -eq 2 ]; then
+            (
+                close_workspace_lock_in_child
+                exec "$SLEEP_BIN" 0.05
+            )
+            continue
+        fi
+        if $release_enabled; then
+            current_id=$(
+                close_workspace_lock_in_child
+                directory_identity "$runtime"
+            ) || release_enabled=false
+            [ "$current_id" = "$runtime_id" ] || release_enabled=false
+        fi
+        if $release_enabled && [ -f "$release" ] && [ ! -L "$release" ]; then
+            IFS=' ' read -r release_pid release_start < "$release" || {
+                release_pid=
+                release_start=
+            }
+            [ "$release_pid" = "$self_pid" ] &&
+                [ "$release_start" = "$self_start" ] && break
+        fi
+        (
+            close_workspace_lock_in_child
+            exec "$SLEEP_BIN" 0.05
+        )
+    done
+    close_workspace_lock_in_child
+}
+
+acquire_workspace_lock() {
+    local attempt held_identity holder_pid holder_start owner_start
+    local probe_status status
+
+    WORKSPACE_ID=$(directory_identity "$WORKSPACE") || return 1
+    owned_directory_matches "$RUNTIME_SCRATCH" "$RUNTIME_SCRATCH_ID" ||
+        return 1
+    owner_start=$(source_server_start_time "$$") || return 1
+    exec {WORKSPACE_LOCK_FD}<"$WORKSPACE" || return 1
+    held_identity=$("$STAT_BIN" -Lc '%d:%i' -- \
+        "/proc/$$/fd/$WORKSPACE_LOCK_FD" 2>/dev/null) || {
+        close_workspace_lock
+        return 1
+    }
+    if [ "$held_identity" != "$WORKSPACE_ID" ] ||
+        [ "$(directory_identity "$WORKSPACE" 2>/dev/null)" != \
+            "$WORKSPACE_ID" ]; then
+        close_workspace_lock
+        return 1
+    fi
+    "$FLOCK_BIN" -x -n -E 75 "$WORKSPACE_LOCK_FD"
+    status=$?
+    if [ "$status" -ne 0 ]; then
+        close_workspace_lock
+        return "$status"
+    fi
+    WORKSPACE_LOCK_READY="$RUNTIME_SCRATCH/.workspace-lock-ready"
+    WORKSPACE_LOCK_RELEASE="$RUNTIME_SCRATCH/.workspace-lock-release"
+    path_absent "$WORKSPACE_LOCK_READY" &&
+        path_absent "$WORKSPACE_LOCK_RELEASE" || {
+        close_workspace_lock
+        return 1
+    }
+    (
+        trap - EXIT
+        workspace_lock_holder "$$" "$owner_start" \
+            "$RUNTIME_SCRATCH" "$RUNTIME_SCRATCH_ID" \
+            "$WORKSPACE_LOCK_READY" "$WORKSPACE_LOCK_RELEASE"
+    ) </dev/null >/dev/null 2>&1 &
+    WORKSPACE_LOCK_HOLDER_PID=$!
+    exec {WORKSPACE_LOCK_FD}>&- || return 1
+    WORKSPACE_LOCK_FD=
+    for ((attempt = 0; attempt < 200; attempt++)); do
+        if [ -s "$WORKSPACE_LOCK_READY" ]; then
+            IFS=' ' read -r holder_pid holder_start \
+                < "$WORKSPACE_LOCK_READY" || {
+                holder_pid=
+                holder_start=
+            }
+            if [ "$holder_pid" = "$WORKSPACE_LOCK_HOLDER_PID" ] &&
+                [[ "$holder_start" =~ ^[0-9]+$ ]]; then
+                probe_process_identity_builtin "$holder_pid" "$holder_start"
+                probe_status=$?
+                if [ "$probe_status" -eq 0 ]; then
+                    WORKSPACE_LOCK_HOLDER_START_TIME="$holder_start"
+                    return 0
+                fi
+                [ "$probe_status" -ne 1 ] || break
+            fi
+        fi
+        kill -0 "$WORKSPACE_LOCK_HOLDER_PID" 2>/dev/null || break
+        "$SLEEP_BIN" 0.005
+    done
+    # Do not wait on a holder that may still be live. Returning failure makes
+    # this owner exit; the holder then releases by authenticated owner identity.
+    return 1
+}
+
+move_no_clobber_verified() {
+    local kind="$1" source="$2" destination="$3" before after
+    case "$kind" in
+        directory) before=$(directory_identity "$source") || return 1 ;;
+        file) before=$(regular_file_identity "$source") || return 1 ;;
+        *) return 1 ;;
+    esac
+
+    if [ "$TEST_MV_MODE" = false_success_on_collision ] &&
+        { [ -e "$destination" ] || [ -L "$destination" ]; }; then
+        :
+    else
+        "$MV_BIN" -T --no-clobber -- "$source" "$destination" || return 1
+    fi
+    [ ! -e "$source" ] && [ ! -L "$source" ] || return 1
+
+    case "$kind" in
+        directory) after=$(directory_identity "$destination") || return 1 ;;
+        file) after=$(regular_file_identity "$destination") || return 1 ;;
+    esac
+    [ "$after" = "$before" ] || return 1
+    if [ "$TEST_MV_MODE" = fail_after_source_rename ] &&
+        [ "$kind" = directory ] &&
+        [ "$source" = "$WORKSPACE/.beads" ] &&
+        [ "$destination" = "$ROLLBACK_PATH" ]; then
+        return 1
+    fi
+}
+
+owned_directory_matches() {
+    local path="$1" expected="$2" actual
+    [ -n "$expected" ] || return 1
+    actual=$(directory_identity "$path") || return 1
+    [ "$actual" = "$expected" ]
+}
+
+test_phase() {
+    local phase="$1" attempt
+    [ -n "$TEST_PHASE_DIR" ] || return 0
+    [[ "$TEST_PHASE_DIR" = /* ]] &&
+        [ -d "$TEST_PHASE_DIR" ] && [ ! -L "$TEST_PHASE_DIR" ] || return 1
+    : > "$TEST_PHASE_DIR/$phase.reached" || return 1
+    for ((attempt = 0; attempt < 600; attempt++)); do
+        [ -f "$TEST_PHASE_DIR/$phase.continue" ] && return 0
+        (
+            close_workspace_lock_in_child
+            exec "$SLEEP_BIN" 0.05
+        )
+    done
+    return 1
+}
+
+source_server_start_time() {
+    local pid="$1" stat rest
+    local -a fields
+    stat=$("$CAT_BIN" -- "/proc/$pid/stat" 2>/dev/null) || return 1
+    rest=${stat##*) }
+    read -r -a fields <<< "$rest" || return 1
+    [ "${#fields[@]}" -ge 20 ] || return 1
+    printf '%s\n' "${fields[19]}"
+}
+
+process_state() {
+    local pid="$1" stat rest
+    local -a fields
+    stat=$("$CAT_BIN" -- "/proc/$pid/stat" 2>/dev/null) || return 1
+    rest=${stat##*) }
+    read -r -a fields <<< "$rest" || return 1
+    [ "${#fields[@]}" -ge 20 ] || return 1
+    printf '%s\n' "${fields[0]}"
+}
+
+guardian_test_marker() {
+    local guardian="$1" event="$2"
+    guardian_test_enabled || return 0
+    : > "$TEST_PHASE_DIR/$guardian-guardian.$event"
+}
+
+guardian_test_enabled() {
+    [ -n "$TEST_PHASE_DIR" ] || return 1
+    [[ "$TEST_PHASE_DIR" = /* ]] && [ -d "$TEST_PHASE_DIR" ] &&
+        [ ! -L "$TEST_PHASE_DIR" ] &&
+        [ -f "$TEST_PHASE_DIR/guardian-cooperative-shutdown.enabled" ] &&
+        [ ! -L "$TEST_PHASE_DIR/guardian-cooperative-shutdown.enabled" ]
+}
+
+guardian_test_checkpoint() {
+    local guardian="$1"
+    guardian_test_enabled || return 0
+    test_phase "${guardian}_guardian_resource_removed"
+}
+
+runtime_scratch_guardian() {
+    local owner_pid="$1" owner_start="$2" scratch="$3" expected_id="$4"
+    local current_id owner_status
+
+    # The guardian must survive loss of its owner, but normal cleanup can stop
+    # and reap it explicitly.
+    trap '' HUP INT
+    if guardian_test_enabled; then
+        trap 'guardian_test_marker runtime term || true; exit 97' TERM
+    else
+        trap '' TERM
+    fi
+    trap 'guardian_test_marker runtime done || true' EXIT
+    guardian_test_marker runtime started || true
+    while :; do
+        current_id=$(directory_identity "$scratch" 2>/dev/null) || {
+            if path_absent "$scratch"; then
+                guardian_test_checkpoint runtime || return 1
+                return 0
+            fi
+            break
+        }
+        [ "$current_id" = "$expected_id" ] || return 0
+        probe_process_identity_builtin "$owner_pid" "$owner_start" owner
+        owner_status=$?
+        [ "$owner_status" -ne 1 ] || break
+        "$SLEEP_BIN" 0.05
+    done
+
+    remove_authenticated_directory "$scratch" "$expected_id" runtime || true
+}
+
+transaction_root_guardian() {
+    local owner_pid="$1" owner_start="$2" root="$3" root_id="$4"
+    local canonical_lock="$5" private_lock="$6" lock_id="$7"
+    local canonical_staging="$8" current_id owner_status
+
+    # A canonical fence is the recovery authority. The guardian removes the
+    # private bundle only before that fence is published, or after the same
+    # lock inode has been retired back into the authenticated private root.
+    trap '' HUP INT
+    if guardian_test_enabled; then
+        trap 'guardian_test_marker transaction term || true; exit 97' TERM
+    else
+        trap '' TERM
+    fi
+    trap 'guardian_test_marker transaction done || true' EXIT
+    guardian_test_marker transaction started || true
+    while :; do
+        current_id=$(directory_identity "$root" 2>/dev/null) || {
+            if path_absent "$root"; then
+                guardian_test_checkpoint transaction || return 1
+                return 0
+            fi
+            break
+        }
+        [ "$current_id" = "$root_id" ] || return 0
+        probe_process_identity_builtin "$owner_pid" "$owner_start" owner
+        owner_status=$?
+        [ "$owner_status" -ne 1 ] || break
+        "$SLEEP_BIN" 0.05
+    done
+
+    path_absent "$canonical_lock" || return 0
+    path_absent "$canonical_staging" || return 0
+    if ! owned_directory_matches "$private_lock" "$lock_id"; then
+        path_absent "$private_lock" || return 0
+    fi
+    remove_authenticated_directory "$root" "$root_id" transaction || true
+}
+
+start_transaction_guardian() {
+    local owner_start private_id canonical_id
+
+    if [ -n "$TRANSACTION_GUARD_PID" ]; then
+        [ -n "$TRANSACTION_GUARD_START_TIME" ] && return 0
+        return 1
+    fi
+    owned_directory_matches "$TRANSACTION_ROOT" "$TRANSACTION_ROOT_ID" ||
+        return 1
+    private_id=$(directory_identity "$TRANSACTION_LOCK_PATH" 2>/dev/null) ||
+        private_id=
+    canonical_id=$(directory_identity "$CANONICAL_LOCK_PATH" 2>/dev/null) ||
+        canonical_id=
+    if [ "$private_id" = "$LOCK_ID" ] && [ -z "$canonical_id" ]; then
+        :
+    elif [ "$canonical_id" = "$LOCK_ID" ] && [ -z "$private_id" ]; then
+        :
+    else
+        return 1
+    fi
+    owner_start=$(source_server_start_time "$$") || return 1
+    (
+        trap - EXIT
+        close_workspace_lock_in_child
+        transaction_root_guardian \
+            "$$" "$owner_start" "$TRANSACTION_ROOT" "$TRANSACTION_ROOT_ID" \
+            "$CANONICAL_LOCK_PATH" "$TRANSACTION_LOCK_PATH" "$LOCK_ID" \
+            "$CANONICAL_STAGING_PATH"
+    ) </dev/null >/dev/null 2>&1 &
+    TRANSACTION_GUARD_PID=$!
+    TRANSACTION_GUARD_START_TIME=$(bounded_process_start_time_builtin \
+        "$TRANSACTION_GUARD_PID" transaction_guardian_start) || return 1
+}
+
+stop_transaction_guardian() {
+    local attempt probe_status=2
+    [ -n "$TRANSACTION_GUARD_PID" ] || return 0
+    [ -n "$TRANSACTION_GUARD_START_TIME" ] || return 1
+    guardian_test_marker transaction stop-waiting || true
+    for ((attempt = 0; attempt < 200; attempt++)); do
+        probe_process_identity_builtin "$TRANSACTION_GUARD_PID" \
+            "$TRANSACTION_GUARD_START_TIME"
+        probe_status=$?
+        [ "$probe_status" -ne 1 ] || break
+        "$SLEEP_BIN" 0.005
+    done
+    [ "$probe_status" -eq 1 ] || return 1
+    wait "$TRANSACTION_GUARD_PID" 2>/dev/null || return 1
+    TRANSACTION_GUARD_PID=
+    TRANSACTION_GUARD_START_TIME=
+}
+
+staging_directory_has_only_known_entries() (
+    local root="$1" path entry
+    local -a paths
+    [ -d "$root" ] && [ ! -L "$root" ] || return 1
+    shopt -s dotglob nullglob
+    paths=("$root"/*)
+    for path in "${paths[@]}"; do
+        entry=${path##*/}
+        case "$entry" in
+            target)
+                [ -d "$path" ] && [ ! -L "$path" ] ||
+                    return 1
+                ;;
+            target-semantics.jsonl|reopen-semantics.jsonl)
+                [ -f "$path" ] && [ ! -L "$path" ] ||
+                    return 1
+                ;;
+            *) return 1 ;;
+        esac
+    done
+)
+
+runtime_directory_has_only_known_entries() (
+    local root="$1" path entry
+    local -a paths
+    shopt -s dotglob nullglob
+    paths=("$root"/*)
+    for path in "${paths[@]}"; do
+        entry=${path##*/}
+        case "$entry" in
+            home|source)
+                [ -d "$path" ] && [ ! -L "$path" ] ||
+                    return 1
+                ;;
+            source-bd|source-dolt|target-bd|target-export.jsonl|qualified.jsonl|\
+            .workspace-lock-ready|.workspace-lock-ready.next|\
+            .workspace-lock-release|.workspace-lock-release.next)
+                [ -f "$path" ] && [ ! -L "$path" ] ||
+                    return 1
+                ;;
+            *) return 1 ;;
+        esac
+    done
+)
+
+transaction_directory_has_only_known_entries() (
+    local root="$1" path entry
+    local -a paths
+    shopt -s dotglob nullglob
+    paths=("$root"/*)
+    for path in "${paths[@]}"; do
+        entry=${path##*/}
+        case "$entry" in
+            lock)
+                [ -d "$path" ] && [ ! -L "$path" ] &&
+                    lock_directory_has_only_known_files "$path" ||
+                    return 1
+                ;;
+            staging)
+                staging_directory_has_only_known_entries "$path" ||
+                    return 1
+                ;;
+            *) return 1 ;;
+        esac
+    done
+)
+
+cleanup_tree_is_safe() {
+    # This rejects pre-existing corruption before recursive cleanup. The
+    # workspace flock coordinates supported callers; an actively adversarial
+    # same-UID process racing this private 0700 tree is outside this bridge's
+    # process-interruption guarantee.
+    case "$2" in
+        runtime) runtime_directory_has_only_known_entries "$1" ;;
+        transaction) transaction_directory_has_only_known_entries "$1" ;;
+        *) return 1 ;;
+    esac
+}
+
+remove_authenticated_directory() {
+    local path="$1" expected_id="$2" policy="$3"
+    local test_phase_name="${4:-}"
+    local directory_fd held_id current_id root_fd
+    local owner_pid=$BASHPID
+
+    [ -n "$expected_id" ] || return 1
+    case "$policy" in
+        runtime|transaction) ;;
+        *) return 1 ;;
+    esac
+    exec {directory_fd}<"$path" || return 1
+    root_fd="/proc/$owner_pid/fd/$directory_fd"
+    held_id=$("$STAT_BIN" -Lc '%d:%i' -- \
+        "$root_fd" 2>/dev/null) || {
+        exec {directory_fd}>&-
+        return 1
+    }
+    [ "$held_id" = "$expected_id" ] || {
+        exec {directory_fd}>&-
+        return 1
+    }
+    current_id=$(directory_identity "$path") || {
+        exec {directory_fd}>&-
+        return 1
+    }
+    [ "$current_id" = "$expected_id" ] || {
+        exec {directory_fd}>&-
+        return 1
+    }
+    cleanup_tree_is_safe "$root_fd" "$policy" || {
+        exec {directory_fd}>&-
+        return 1
+    }
+    (
+        cd -P -- "$root_fd" || exit 1
+        "$FIND_BIN" -P . -xdev -mindepth 1 -depth -delete
+    ) || {
+        exec {directory_fd}>&-
+        return 1
+    }
+    if [ -n "$test_phase_name" ] &&
+        [ "${BD_V062_TEST_FAILPOINT:-}" = "$test_phase_name" ] &&
+        ! test_phase "$test_phase_name"; then
+        exec {directory_fd}>&-
+        return 1
+    fi
+    current_id=$(directory_identity "$path") || {
+        exec {directory_fd}>&-
+        return 1
+    }
+    [ "$current_id" = "$expected_id" ] || {
+        exec {directory_fd}>&-
+        return 1
+    }
+    "$RMDIR_BIN" -- "$path" || {
+        exec {directory_fd}>&-
+        return 1
+    }
+    exec {directory_fd}>&-
+    path_absent "$path"
+}
+
+stop_runtime_guardian() {
+    local attempt probe_status=2
+    [ -n "$RUNTIME_GUARD_PID" ] || return 0
+    [ -n "$RUNTIME_GUARD_START_TIME" ] || return 1
+    guardian_test_marker runtime stop-waiting || true
+    for ((attempt = 0; attempt < 200; attempt++)); do
+        probe_process_identity_builtin "$RUNTIME_GUARD_PID" \
+            "$RUNTIME_GUARD_START_TIME"
+        probe_status=$?
+        [ "$probe_status" -ne 1 ] || break
+        "$SLEEP_BIN" 0.005
+    done
+    [ "$probe_status" -eq 1 ] || return 1
+    wait "$RUNTIME_GUARD_PID" 2>/dev/null || return 1
+    RUNTIME_GUARD_PID=
+    RUNTIME_GUARD_START_TIME=
+}
+
+cleanup_runtime_scratch() {
+    local status=0
+
+    if [ -n "$RUNTIME_SCRATCH" ]; then
+        if path_absent "$RUNTIME_SCRATCH"; then
+            stop_runtime_guardian || status=1
+        elif remove_authenticated_directory \
+            "$RUNTIME_SCRATCH" "$RUNTIME_SCRATCH_ID" runtime; then
+            stop_runtime_guardian || status=1
+        else
+            # Preserve both renamed evidence and any replacement pathname.
+            status=1
+        fi
+    fi
+    if [ "$status" -eq 0 ]; then
+        RUNTIME_SCRATCH=
+        RUNTIME_SCRATCH_ID=
+        SOURCE_SCRATCH=
+        CLEAN_HOME=
+        SEMANTIC_PROBE=
+    fi
+    return "$status"
+}
+
+owned_source_server_alive() {
+    local current
+    [ -n "$SOURCE_SERVER_PID" ] && [ -n "$SOURCE_SERVER_START_TIME" ] ||
+        return 1
+    kill -0 "$SOURCE_SERVER_PID" 2>/dev/null || return 1
+    current=$(source_server_start_time "$SOURCE_SERVER_PID") || return 1
+    [ "$current" = "$SOURCE_SERVER_START_TIME" ]
+}
+
+stop_owned_source_server() {
+    local attempt
+    if [ -z "$SOURCE_SERVER_PID" ]; then
+        return 0
+    fi
+    if owned_source_server_alive; then
+        kill -TERM "$SOURCE_SERVER_PID" 2>/dev/null || true
+        for ((attempt = 0; attempt < 100; attempt++)); do
+            owned_source_server_alive || break
+            "$SLEEP_BIN" 0.05
+        done
+        if owned_source_server_alive; then
+            kill -KILL "$SOURCE_SERVER_PID" 2>/dev/null || true
+        fi
+    fi
+    wait "$SOURCE_SERVER_PID" 2>/dev/null || true
+    SOURCE_SERVER_PID=
+    SOURCE_SERVER_START_TIME=
+}
+
+cleanup_owned_paths() {
+    stop_owned_source_server
+}
+
+canonical_semantic_corpus() {
+    "$JQ_BIN" -se '
+        def deps:
+            (.dependencies // []) |
+            map({
+                id: (.id // .depends_on_id),
+                type: (.dependency_type // .type)
+            }) | sort_by(.id, .type);
+        def parent:
+            .parent //
+            ([deps[] | select(.type == "parent-child") | .id] |
+                if length == 1 then .[0] else "" end);
+        def unsupported:
+            has("assignee") or has("estimated_minutes") or
+            has("due_at") or has("defer_until") or has("source_system") or
+            has("metadata") or has("spec_id") or
+            has("compaction_level") or has("compacted_at") or
+            has("compacted_at_commit") or has("original_size") or
+            has("sender") or has("ephemeral") or has("no_history") or
+            has("wisp_type") or has("pinned") or has("is_template") or
+            has("bonded_from") or has("await_type") or has("await_id") or
+            has("timeout") or has("waiters") or has("source_formula") or
+            has("source_location") or has("mol_type") or has("work_type") or
+            has("event_kind") or has("actor") or has("target") or
+            has("payload") or has("crystallizes") or has("creator") or
+            has("quality_score") or has("validations") or
+            has("hook_bead") or has("role_bead") or
+            has("agent_state") or has("last_activity") or
+            has("role_type") or has("rig") or has("holder") or
+            has("closed_by_session");
+        ([.[] | select(.title == "Migration epic") | .id][0]) as $epic |
+        ([.[] | select(.title == "Migration task alpha") | .id][0]) as $task |
+        length == 5 and
+        all(.[];
+            type == "object" and
+            ((.id? | type) == "string") and
+            (.id | test("^[A-Za-z0-9._-]{1,128}$")) and
+            (unsupported | not)) and
+        (([.[].id] | length) == ([.[].id] | unique | length)) and
+        any(.[];
+            .title == "Migration epic" and
+            .description == "Epic for migration testing" and
+            .priority == 2 and .issue_type == "epic" and
+            .status == "open" and (deps | length) == 0) and
+        any(.[];
+            .title == "Standalone detailed task" and
+            .description == "This task has a detailed description for fidelity testing." and
+            .notes == "Historical notes must survive the upgrade." and
+            .design == "Historical design must survive the upgrade." and
+            .acceptance_criteria == "Historical acceptance criteria must survive the upgrade." and
+            .external_ref == "legacy-upgrade-42" and
+            .priority == 2 and .issue_type == "task" and
+            .status == "open" and (deps | length) == 0) and
+        any(.[];
+            .title == "Already closed issue" and
+            .priority == 3 and .issue_type == "task" and
+            .status == "closed" and (deps | length) == 0) and
+        ([.[] | select(.title == "Migration epic") | .id] | length == 1) and
+        ([.[] | select(.title == "Migration task alpha")] | length == 1) and
+        ([.[] | select(.title == "Migration bug beta")] | length == 1) and
+        any(.[];
+            .id == $task and .priority == 1 and
+            .issue_type == "task" and .status == "open" and
+            parent == $epic and
+            deps == [{id: $epic, type: "parent-child"}] and
+            ((.labels // []) | sort) == ["urgent"] and
+            ((.comments // [] | map({author, text})) |
+                index({
+                    author: "legacy-author",
+                    text: "Historical comment must survive the upgrade."
+                }) != null)) and
+        any(.[];
+            .title == "Migration bug beta" and
+            .priority == 3 and .issue_type == "bug" and
+            .status == "open" and
+            deps == [{id: $task, type: "blocks"}])
+    ' "$1" >/dev/null 2>&1
+}
+
+qualified_source_semantic_corpus() {
+    canonical_semantic_corpus "$1" || return 1
+    "$JQ_BIN" -se '
+        def allowed_keys: [
+            "id", "title", "description", "design",
+            "acceptance_criteria", "notes", "status", "priority",
+            "issue_type", "created_at", "created_by", "updated_at",
+            "closed_at", "close_reason", "owner", "external_ref", "parent",
+            "labels", "dependencies", "comments", "dependency_count",
+            "dependent_count", "comment_count"
+        ];
+        def allowed_dependency_keys: [
+            "issue_id", "depends_on_id", "type", "created_at",
+            "created_by", "metadata", "thread_id"
+        ];
+        def allowed_comment_keys: [
+            "id", "issue_id", "author", "text", "created_at"
+        ];
+        all(.[];
+            . as $issue |
+            (($issue | keys - allowed_keys) | length) == 0 and
+            all(($issue.dependencies // [])[];
+                type == "object" and
+                ((keys - allowed_dependency_keys) | length) == 0 and
+                .issue_id == $issue.id and
+                ((.depends_on_id? | type) == "string") and
+                ((.depends_on_id? | length) > 0) and
+                ((.type? | type) == "string") and
+                ((.type? | length) > 0) and
+                ((.created_at? | type) == "string") and
+                ((.created_at? | length) > 0) and
+                ((.created_by? | type) == "string") and
+                ((.created_by? | length) > 0) and
+                ((.metadata? // "{}") as $metadata |
+                    ($metadata | type) == "string" and
+                    ((try ($metadata | fromjson) catch null) == {})) and
+                ((.thread_id? // "") == "")) and
+            all(($issue.comments // [])[];
+                type == "object" and
+                ((keys - allowed_comment_keys) | length) == 0 and
+                ((.id? | type) == "string") and
+                ((.id? | length) > 0) and
+                (.issue_id == $issue.id) and
+                ((.author? | type) == "string") and
+                ((.text? | type) == "string") and
+                ((.created_at? | type) == "string") and
+                ((.created_at? | length) > 0)))
+    ' "$1" >/dev/null 2>&1
+}
+
+canonical_semantic_json() {
+    "$JQ_BIN" -csS '
+        def deps:
+            (.dependencies // []) |
+            map({
+                issue_id,
+                depends_on_id,
+                type,
+                created_at,
+                created_by,
+                metadata: ((.metadata // "{}") | fromjson),
+                thread_id: (.thread_id // "")
+            }) |
+            sort_by(
+                .issue_id, .depends_on_id, .type, .created_at, .created_by,
+                (.metadata | tojson), .thread_id
+            );
+        def parent:
+            .parent //
+            ([deps[] |
+                select(.type == "parent-child") | .depends_on_id] |
+                if length == 1 then .[0] else "" end);
+        map({
+            id,
+            title,
+            description: (.description // ""),
+            notes: (.notes // ""),
+            design: (.design // ""),
+            acceptance_criteria: (.acceptance_criteria // ""),
+            external_ref: (.external_ref // ""),
+            owner: (.owner // ""),
+            created_at: (.created_at // ""),
+            created_by: (.created_by // ""),
+            updated_at: (.updated_at // ""),
+            closed_at: (.closed_at // ""),
+            close_reason: (.close_reason // ""),
+            priority,
+            issue_type,
+            status,
+            parent: parent,
+            labels: ((.labels // []) | sort),
+            dependencies: deps,
+            comments: ((.comments // []) |
+                map({id, issue_id, author, text, created_at}) |
+                sort_by(.id, .issue_id, .author, .text, .created_at))
+        }) | sort_by(.id)
+    ' "$1" 2>/dev/null
+}
+
+verify_embedded_layout() {
+    local root="$1" metadata database config database_root grep_status
+    [ -d "$root/.beads" ] && [ ! -L "$root/.beads" ] || return 1
+    [ ! -e "$root/.beads/.env" ] && [ ! -L "$root/.beads/.env" ] &&
+        [ ! -e "$root/.beads/redirect" ] &&
+        [ ! -L "$root/.beads/redirect" ] || return 1
+    config="$root/.beads/config.yaml"
+    if [ -e "$config" ] || [ -L "$config" ]; then
+        [ -f "$config" ] && [ ! -L "$config" ] || return 1
+        if "$GREP_BIN" -Eq '^[[:space:]]*[^#[:space:]]' -- "$config" \
+            2>/dev/null; then
+            return 1
+        else
+            grep_status=$?
+            [ "$grep_status" -eq 1 ] || return 1
+        fi
+    fi
+    metadata="$root/.beads/metadata.json"
+    [ -f "$metadata" ] && [ ! -L "$metadata" ] || return 1
+    database=$("$JQ_BIN" -er '
+        select(.backend == "dolt" and .dolt_mode == "embedded") |
+        (.dolt_database // .database) |
+        select(type == "string" and test("^[A-Za-z_][A-Za-z0-9_-]{0,63}$"))
+    ' "$metadata" 2>/dev/null) || return 1
+    database_root="$root/.beads/embeddeddolt/$database"
+    [ -d "$root/.beads/embeddeddolt" ] &&
+        [ ! -L "$root/.beads/embeddeddolt" ] &&
+        [ -d "$database_root" ] && [ ! -L "$database_root" ] &&
+        [ -d "$database_root/.dolt" ] && [ ! -L "$database_root/.dolt" ] &&
+        [ ! -e "$root/.beads/dolt" ] && [ ! -L "$root/.beads/dolt" ]
+}
+
+verify_target_identity() {
+    local root="$1" metadata prefix_json
+    metadata="$root/.beads/metadata.json"
+    [ -f "$metadata" ] && [ ! -L "$metadata" ] || return 1
+    "$JQ_BIN" -e \
+        --arg database "$SOURCE_DATABASE" \
+        --arg project_id "$SOURCE_PROJECT_ID" '
+        .backend == "dolt" and .dolt_mode == "embedded" and
+        (.dolt_database // .database) == $database and
+        .project_id == $project_id
+    ' "$metadata" >/dev/null 2>&1 || return 1
+    prefix_json=$(target_at "$root" "$TARGET_BD_EXEC" \
+        config get issue_prefix --json 2>/dev/null) || return 1
+    "$JQ_BIN" -cse --arg issue_prefix "$SOURCE_ISSUE_PREFIX" '
+        if length == 1 then .[0] else empty end |
+        select(
+            type == "object" and
+            keys == ["key", "schema_version", "value"] and
+            .schema_version == 1 and
+            .key == "issue_prefix" and .value == $issue_prefix
+        )
+    ' >/dev/null 2>&1 <<< "$prefix_json"
+}
+
+collect_target_semantics() {
+    local root="$1" destination="$2" expected_ids="${3:-}"
+    local inventory ids selected_ids raw_export
+
+    inventory=$(target_at "$root" "$TARGET_BD_EXEC" list --json --all -n 0 \
+        2>/dev/null) || return 1
+    if [ -n "$expected_ids" ]; then
+        ids=$("$JQ_BIN" -cer --argjson expected "$expected_ids" '
+            select(type == "array") |
+            ([.[].id]) as $actual |
+            if
+                ($expected | type) == "array" and
+                ($expected | length) == 5 and
+                all($expected[];
+                    type == "string" and
+                    test("^[A-Za-z0-9._-]{1,128}$")) and
+                $expected == ($expected | sort | unique) and
+                all(.[];
+                    type == "object" and
+                    ((.id? | type) == "string") and
+                    (.id | test("^[A-Za-z0-9._-]{1,128}$"))) and
+                ($actual | length) == ($actual | unique | length) and
+                (($expected - $actual) | length) == 0
+            then $expected[] | @json
+            else error("invalid target baseline")
+            end
+        ' <<< "$inventory" 2>/dev/null) || return 1
+    else
+        ids=$("$JQ_BIN" -cer '
+            select(type == "array") |
+            if length == 5 and
+               all(.[];
+                   type == "object" and
+                   ((.id? | type) == "string") and
+                   (.id | test("^[A-Za-z0-9._-]{1,128}$"))) and
+               (([.[].id] | unique | length) == 5)
+            then .[].id | @json
+            else error("invalid target inventory")
+            end
+        ' <<< "$inventory" 2>/dev/null) || return 1
+    fi
+    selected_ids=$("$JQ_BIN" -cs 'select(length > 0)' <<< "$ids" \
+        2>/dev/null) || return 1
+    raw_export="$RUNTIME_SCRATCH/target-export.jsonl"
+    path_absent "$raw_export" || return 1
+    if ! target_at "$root" "$TARGET_BD_EXEC" export --no-memories \
+        -o "$raw_export" >/dev/null 2>&1; then
+        "$RM_BIN" -f -- "$raw_export" >/dev/null 2>&1 || true
+        return 1
+    fi
+    if ! "$JQ_BIN" -ce -s --argjson selected "$selected_ids" '
+        . as $records |
+        ([$records[] |
+            select(.id as $id | $selected | index($id) != null)]) as $matches |
+        if
+            ($matches | length) == ($selected | length) and
+            (($matches | map(.id) | sort) == ($selected | sort))
+        then $matches[]
+        else error("target export does not contain the selected IDs exactly once")
+        end
+    ' "$raw_export" > "$destination" 2>/dev/null; then
+        "$RM_BIN" -f -- "$raw_export" >/dev/null 2>&1 || true
+        return 1
+    fi
+    "$RM_BIN" -f -- "$raw_export" || return 1
+    canonical_semantic_corpus "$destination"
+}
+
+semantics_match() {
+    local source="$1" target="$2" source_json target_json
+    source_json=$(canonical_semantic_json "$source") || return 1
+    target_json=$(canonical_semantic_json "$target") || return 1
+    [ "$source_json" = "$target_json" ]
+}
+
+semantic_sha256() {
+    local semantic_json digest
+    semantic_json=$(canonical_semantic_json "$1") || return 1
+    read -r digest _ < <(printf '%s' "$semantic_json" | "$SHA256SUM_BIN") ||
+        return 1
+    [[ "$digest" =~ ^[0-9a-f]{64}$ ]] || return 1
+    printf '%s\n' "$digest"
+}
+
+transaction_root_path_is_valid() {
+    local prefix="$WORKSPACE/.beads-v0.62.0-migration.runtime."
+    local suffix=${TRANSACTION_ROOT#"$prefix"}
+
+    [ "$suffix" != "$TRANSACTION_ROOT" ] && [ "${#suffix}" -eq 6 ] &&
+        [[ "$suffix" =~ ^[A-Za-z0-9]+$ ]] &&
+        [ "$TRANSACTION_LOCK_PATH" = "$TRANSACTION_ROOT/lock" ] &&
+        [ "$TRANSACTION_STAGING_PATH" = "$TRANSACTION_ROOT/staging" ]
+}
+
+clear_operation_state() {
+    STAGING_OWNED=false
+    LOCK_OWNED=false
+    LOCK_PUBLISHED=false
+    STAGING_ID=
+    LOCK_ID=
+    LOCK_PHASE=
+    LOCK_STAGING_ID=
+    LOCK_SOURCE_ID=
+    LOCK_OWNER_PID=
+    LOCK_OWNER_START_TIME=
+    LOCK_BOOT_ID=
+    TRANSACTION_ROOT=
+    TRANSACTION_ROOT_ID=
+    TRANSACTION_LOCK_PATH=
+    TRANSACTION_STAGING_PATH=
+    STAGING_PATH="$CANONICAL_STAGING_PATH"
+    LOCK_PATH="$CANONICAL_LOCK_PATH"
+    LOCK_JOURNAL_PATH="$LOCK_PATH/journal.json"
+}
+
+create_operation_bundle() {
+    local lock_id staging_id source_id owner_start boot_id
+
+    path_absent "$CANONICAL_LOCK_PATH" &&
+        path_absent "$CANONICAL_STAGING_PATH" || return 1
+    TRANSACTION_ROOT=$(
+        "$MKTEMP_BIN" -d \
+            "$WORKSPACE/.beads-v0.62.0-migration.runtime.XXXXXX"
+    ) || return 1
+    TRANSACTION_ROOT_ID=$(directory_identity "$TRANSACTION_ROOT") || {
+        TRANSACTION_ROOT=
+        clear_operation_state
+        return 1
+    }
+    if ! "$CHMOD_BIN" 700 -- "$TRANSACTION_ROOT"; then
+        remove_authenticated_directory \
+            "$TRANSACTION_ROOT" "$TRANSACTION_ROOT_ID" transaction \
+            2>/dev/null || true
+        clear_operation_state
+        return 1
+    fi
+    TRANSACTION_LOCK_PATH="$TRANSACTION_ROOT/lock"
+    TRANSACTION_STAGING_PATH="$TRANSACTION_ROOT/staging"
+    if ! transaction_root_path_is_valid ||
+        ! "$MKDIR_BIN" -m 700 -- \
+            "$TRANSACTION_LOCK_PATH" "$TRANSACTION_STAGING_PATH"; then
+        remove_authenticated_directory \
+            "$TRANSACTION_ROOT" "$TRANSACTION_ROOT_ID" transaction \
+            2>/dev/null || true
+        clear_operation_state
+        return 1
+    fi
+
+    LOCK_PATH="$TRANSACTION_LOCK_PATH"
+    LOCK_JOURNAL_PATH="$LOCK_PATH/journal.json"
+    STAGING_PATH="$TRANSACTION_STAGING_PATH"
+    if ! lock_id=$(directory_identity "$LOCK_PATH") ||
+        ! staging_id=$(directory_identity "$STAGING_PATH") ||
+        ! source_id=$(directory_identity "$WORKSPACE/.beads") ||
+        ! owner_start=$(source_server_start_time "$$") ||
+        ! boot_id=$("$CAT_BIN" -- "$BOOT_ID_PATH" 2>/dev/null); then
+        remove_authenticated_directory \
+            "$TRANSACTION_ROOT" "$TRANSACTION_ROOT_ID" transaction \
+            2>/dev/null || true
+        clear_operation_state
+        return 1
+    fi
+    LOCK_ID="$lock_id"
+    STAGING_ID="$staging_id"
+    LOCK_OWNED=true
+    STAGING_OWNED=true
+    LOCK_PUBLISHED=false
+    LOCK_STAGING_ID="$STAGING_ID"
+    LOCK_SOURCE_ID="$source_id"
+    LOCK_OWNER_PID=$$
+    LOCK_OWNER_START_TIME="$owner_start"
+    LOCK_BOOT_ID="$boot_id"
+    write_lock_journal fenced || return 1
+    start_transaction_guardian
+}
+
+publish_operation_lock() {
+    $LOCK_OWNED && ! $LOCK_PUBLISHED || return 1
+    [ "$LOCK_PATH" = "$TRANSACTION_LOCK_PATH" ] || return 1
+    owned_directory_matches "$LOCK_PATH" "$LOCK_ID" || return 1
+    path_absent "$CANONICAL_LOCK_PATH" || return 1
+    move_no_clobber_verified directory \
+        "$LOCK_PATH" "$CANONICAL_LOCK_PATH" || return 1
+    LOCK_PATH="$CANONICAL_LOCK_PATH"
+    LOCK_JOURNAL_PATH="$LOCK_PATH/journal.json"
+    LOCK_PUBLISHED=true
+}
+
+publish_operation_staging() {
+    $STAGING_OWNED && $LOCK_PUBLISHED || return 1
+    [ "$STAGING_PATH" = "$TRANSACTION_STAGING_PATH" ] || return 1
+    owned_directory_matches "$STAGING_PATH" "$STAGING_ID" || return 1
+    path_absent "$CANONICAL_STAGING_PATH" || return 1
+    move_no_clobber_verified directory \
+        "$STAGING_PATH" "$CANONICAL_STAGING_PATH" || return 1
+    STAGING_PATH="$CANONICAL_STAGING_PATH"
+}
+
+remove_owned_staging() {
+    $STAGING_OWNED || return 0
+    transaction_root_path_is_valid || return 1
+    owned_directory_matches "$TRANSACTION_ROOT" "$TRANSACTION_ROOT_ID" ||
+        return 1
+    [ "$STAGING_ID" = "$LOCK_STAGING_ID" ] || return 1
+    staging_directory_has_only_known_entries "$STAGING_PATH" || return 1
+    if [ "$STAGING_PATH" = "$CANONICAL_STAGING_PATH" ]; then
+        owned_directory_matches "$STAGING_PATH" "$STAGING_ID" || return 1
+        path_absent "$TRANSACTION_STAGING_PATH" || return 1
+        move_no_clobber_verified directory \
+            "$STAGING_PATH" "$TRANSACTION_STAGING_PATH" || return 1
+        STAGING_PATH="$TRANSACTION_STAGING_PATH"
+    fi
+    [ "$STAGING_PATH" = "$TRANSACTION_STAGING_PATH" ] || return 1
+    owned_directory_matches "$STAGING_PATH" "$STAGING_ID"
+}
+
+lock_directory_has_only_known_files() (
+    local root="${1:-$LOCK_PATH}" path entry
+    local -a paths
+    [ -d "$root" ] && [ ! -L "$root" ] || return 1
+    shopt -s dotglob nullglob
+    paths=("$root"/*)
+    for path in "${paths[@]}"; do
+        entry=${path##*/}
+        case "$entry" in
+            journal.json|.journal.next)
+                [ -f "$path" ] && [ ! -L "$path" ] ||
+                    return 1
+                ;;
+            *) return 1 ;;
+        esac
+    done
+)
+
+known_lock_file_is_safe() {
+    local path="$1"
+    path_absent "$path" && return 0
+    [ -f "$path" ] && [ ! -L "$path" ]
+}
+
+remove_known_lock_file() {
+    local path="$1"
+    path_absent "$path" && return 0
+    known_lock_file_is_safe "$path" || return 1
+    "$RM_BIN" -f -- "$path" || return 1
+    path_absent "$path"
+}
+
+remove_known_regular_file() {
+    local path="$1"
+    path_absent "$path" && return 0
+    [ -f "$path" ] && [ ! -L "$path" ] || return 1
+    "$RM_BIN" -f -- "$path" || return 1
+    path_absent "$path"
+}
+
+write_lock_journal() {
+    local phase="$1" temporary="$LOCK_PATH/.journal.next"
+    case "$phase" in
+        fenced|staging|source-move-pending|source-retained|committed) ;;
+        *) return 1 ;;
+    esac
+    $LOCK_OWNED || return 1
+    transaction_root_path_is_valid || return 1
+    owned_directory_matches "$TRANSACTION_ROOT" "$TRANSACTION_ROOT_ID" ||
+        return 1
+    owned_directory_matches "$LOCK_PATH" "$LOCK_ID" || return 1
+    owned_directory_matches "$STAGING_PATH" "$STAGING_ID" || return 1
+    [ "$STAGING_ID" = "$LOCK_STAGING_ID" ] || return 1
+    [[ "$TRANSACTION_ROOT_ID" =~ ^[0-9]+:[0-9]+$ ]] || return 1
+    [[ "$LOCK_SOURCE_ID" =~ ^[0-9]+:[0-9]+$ ]] || return 1
+    [[ "$LOCK_OWNER_PID" =~ ^[1-9][0-9]*$ ]] || return 1
+    [[ "$LOCK_OWNER_START_TIME" =~ ^[0-9]+$ ]] || return 1
+    [[ "$LOCK_BOOT_ID" =~ ^[0-9a-fA-F-]{36}$ ]] || return 1
+    path_absent "$temporary" || return 1
+    "$JQ_BIN" -cn \
+        --arg operation "$OPERATION" --arg workspace "$WORKSPACE" \
+        --arg expected_plan "$EXPECT_PLAN" --arg phase "$phase" \
+        --argjson owner_pid "$LOCK_OWNER_PID" \
+        --arg owner_start_time "$LOCK_OWNER_START_TIME" \
+        --arg boot_id "$LOCK_BOOT_ID" \
+        --arg transaction_root "$TRANSACTION_ROOT" \
+        --arg lock_path "$CANONICAL_LOCK_PATH" \
+        --arg staging_path "$CANONICAL_STAGING_PATH" \
+        --arg source_path "$WORKSPACE/.beads" \
+        --arg rollback_path "$ROLLBACK_PATH" \
+        --arg transaction_root_id "$TRANSACTION_ROOT_ID" \
+        --arg lock_id "$LOCK_ID" --arg source_id "$LOCK_SOURCE_ID" \
+        --arg staging_id "$LOCK_STAGING_ID" '
+        {
+            schema_version: 1,
+            operation: $operation,
+            workspace: $workspace,
+            expected_plan: $expected_plan,
+            phase: $phase,
+            owner: {
+                pid: $owner_pid,
+                start_time: $owner_start_time,
+                boot_id: $boot_id
+            },
+            paths: {
+                transaction_root: $transaction_root,
+                lock: $lock_path,
+                staging: $staging_path,
+                source: $source_path,
+                rollback: $rollback_path
+            },
+            identities: {
+                transaction_root: $transaction_root_id,
+                lock: $lock_id,
+                staging: $staging_id,
+                source: $source_id
+            }
+        }
+    ' > "$temporary" || return 1
+    "$CHMOD_BIN" 600 -- "$temporary" || return 1
+    "$MV_BIN" -T -f -- "$temporary" "$LOCK_JOURNAL_PATH" || return 1
+    [ -f "$LOCK_JOURNAL_PATH" ] && [ ! -L "$LOCK_JOURNAL_PATH" ] ||
+        return 1
+    LOCK_PHASE="$phase"
+}
+
+load_lock_journal() {
+    local journal private_present=0 canonical_present=0 actual
+    local transaction_prefix="$WORKSPACE/.beads-v0.62.0-migration.runtime."
+    lock_directory_has_only_known_files || return 1
+    [ -f "$LOCK_JOURNAL_PATH" ] && [ ! -L "$LOCK_JOURNAL_PATH" ] ||
+        return 1
+    known_lock_file_is_safe "$LOCK_PATH/.journal.next" || return 1
+    journal=$("$JQ_BIN" -cse \
+        --arg operation "$OPERATION" --arg workspace "$WORKSPACE" \
+        --arg expected_plan "$EXPECT_PLAN" \
+        --arg transaction_prefix "$transaction_prefix" \
+        --arg lock_path "$CANONICAL_LOCK_PATH" \
+        --arg staging_path "$CANONICAL_STAGING_PATH" \
+        --arg source_path "$WORKSPACE/.beads" \
+        --arg rollback_path "$ROLLBACK_PATH" --arg lock_id "$LOCK_ID" '
+        if length == 1 then .[0] else empty end |
+        select(
+            type == "object" and
+            keys == [
+                "expected_plan", "identities", "operation", "owner",
+                "paths", "phase", "schema_version", "workspace"
+            ] and
+            .schema_version == 1 and .operation == $operation and
+            .workspace == $workspace and .expected_plan == $expected_plan and
+            (.expected_plan | test("^[0-9a-f]{64}$")) and
+            (.phase | IN(
+                "fenced", "staging", "source-move-pending",
+                "source-retained", "committed"
+            )) and
+            (.owner | keys) == ["boot_id", "pid", "start_time"] and
+            (.owner.pid | type) == "number" and
+            (.owner.pid | floor) == .owner.pid and .owner.pid > 0 and
+            (.owner.start_time | type) == "string" and
+            (.owner.start_time | test("^[0-9]+$")) and
+            (.owner.boot_id | type) == "string" and
+            (.owner.boot_id | test(
+                "^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$"
+            )) and
+            (.paths | keys) == [
+                "lock", "rollback", "source", "staging", "transaction_root"
+            ] and
+            (.paths.transaction_root | type) == "string" and
+            (.paths.transaction_root | startswith($transaction_prefix)) and
+            .paths.lock == $lock_path and .paths.staging == $staging_path and
+            .paths.source == $source_path and .paths.rollback == $rollback_path and
+            (.identities | keys) == [
+                "lock", "source", "staging", "transaction_root"
+            ] and
+            (.identities.transaction_root | type) == "string" and
+            (.identities.transaction_root | test("^[0-9]+:[0-9]+$")) and
+            .identities.lock == $lock_id and
+            (.identities.source | type) == "string" and
+            (.identities.source | test("^[0-9]+:[0-9]+$")) and
+            (.identities.staging | type) == "string" and
+            (.identities.staging | test("^[0-9]+:[0-9]+$"))
+        )
+    ' "$LOCK_JOURNAL_PATH" 2>/dev/null) || return 1
+    LOCK_PHASE=$("$JQ_BIN" -er '.phase' <<< "$journal") || return 1
+    LOCK_STAGING_ID=$("$JQ_BIN" -er '.identities.staging // ""' \
+        <<< "$journal") || return 1
+    TRANSACTION_ROOT=$("$JQ_BIN" -er '.paths.transaction_root' \
+        <<< "$journal") || return 1
+    TRANSACTION_ROOT_ID=$("$JQ_BIN" -er '.identities.transaction_root' \
+        <<< "$journal") || return 1
+    TRANSACTION_LOCK_PATH="$TRANSACTION_ROOT/lock"
+    TRANSACTION_STAGING_PATH="$TRANSACTION_ROOT/staging"
+    LOCK_SOURCE_ID=$("$JQ_BIN" -er '.identities.source' <<< "$journal") ||
+        return 1
+    LOCK_OWNER_PID=$("$JQ_BIN" -er '.owner.pid | tostring' <<< "$journal") ||
+        return 1
+    LOCK_OWNER_START_TIME=$("$JQ_BIN" -er '.owner.start_time' \
+        <<< "$journal") || return 1
+    LOCK_BOOT_ID=$("$JQ_BIN" -er '.owner.boot_id' <<< "$journal") || return 1
+    transaction_root_path_is_valid || return 1
+    owned_directory_matches "$TRANSACTION_ROOT" "$TRANSACTION_ROOT_ID" ||
+        return 1
+    path_absent "$TRANSACTION_LOCK_PATH" || return 1
+    if [ -e "$TRANSACTION_STAGING_PATH" ] ||
+        [ -L "$TRANSACTION_STAGING_PATH" ]; then
+        private_present=1
+    fi
+    if [ -e "$CANONICAL_STAGING_PATH" ] ||
+        [ -L "$CANONICAL_STAGING_PATH" ]; then
+        canonical_present=1
+    fi
+    [ "$((private_present + canonical_present))" -eq 1 ] || return 1
+    if [ "$private_present" -eq 1 ]; then
+        STAGING_PATH="$TRANSACTION_STAGING_PATH"
+    else
+        STAGING_PATH="$CANONICAL_STAGING_PATH"
+    fi
+    actual=$(directory_identity "$STAGING_PATH") || return 1
+    [ "$actual" = "$LOCK_STAGING_ID" ] || return 1
+    STAGING_ID="$LOCK_STAGING_ID"
+}
+
+release_operation_lock() {
+    local retired=false
+
+    $LOCK_OWNED || return 0
+    $STAGING_OWNED || return 1
+    remove_owned_staging || return 1
+    transaction_root_path_is_valid || return 1
+    owned_directory_matches "$TRANSACTION_ROOT" "$TRANSACTION_ROOT_ID" ||
+        return 1
+    owned_directory_matches "$LOCK_PATH" "$LOCK_ID" || return 1
+    lock_directory_has_only_known_files || return 1
+    known_lock_file_is_safe "$LOCK_PATH/.journal.next" || return 1
+
+    if [ "$LOCK_PATH" = "$CANONICAL_LOCK_PATH" ]; then
+        [ -f "$LOCK_JOURNAL_PATH" ] && [ ! -L "$LOCK_JOURNAL_PATH" ] ||
+            return 1
+        path_absent "$TRANSACTION_LOCK_PATH" || return 1
+        start_transaction_guardian || return 1
+        move_no_clobber_verified directory \
+            "$LOCK_PATH" "$TRANSACTION_LOCK_PATH" || return 1
+        LOCK_PATH="$TRANSACTION_LOCK_PATH"
+        LOCK_JOURNAL_PATH="$LOCK_PATH/journal.json"
+        LOCK_PUBLISHED=false
+        retired=true
+    elif [ "$LOCK_PATH" = "$TRANSACTION_LOCK_PATH" ]; then
+        owned_directory_matches "$LOCK_PATH" "$LOCK_ID" || return 1
+        known_lock_file_is_safe "$LOCK_JOURNAL_PATH" || return 1
+    else
+        return 1
+    fi
+
+    path_absent "$CANONICAL_STAGING_PATH" &&
+        path_absent "$CANONICAL_LOCK_PATH" || return 1
+    if $retired; then
+        test_phase after_operation_fence_retired_before_private_cleanup ||
+            return 1
+    fi
+    remove_authenticated_directory \
+        "$TRANSACTION_ROOT" "$TRANSACTION_ROOT_ID" transaction \
+        after_private_children_deleted_before_root_rmdir || return 1
+    stop_transaction_guardian || return 1
+    clear_operation_state
+}
+
+authenticate_recovery_receipt() {
+    local receipt="$1" receipt_json plan_without_digest computed_digest
+    [ -f "$receipt" ] && [ ! -L "$receipt" ] || return 1
+    receipt_json=$("$JQ_BIN" -cse \
+        --arg operation "$OPERATION" --arg schema "$PLAN_SCHEMA" \
+        --arg workspace "$WORKSPACE" --arg expected "$EXPECT_PLAN" \
+        --arg semantic_scope "$SEMANTIC_SCOPE" \
+        --arg rollback "$ROLLBACK_PATH" '
+        if length == 1 then .[0] else empty end |
+        select(
+            type == "object" and
+            keys == [
+                "operation", "plan", "plan_digest", "rollback",
+                "schema_version", "semantic_scope",
+                "semantic_scope_verified", "semantic_sha256", "state",
+                "target_backend"
+            ] and
+            .schema_version == 1 and .operation == $operation and
+            .state == "committed" and .plan_digest == $expected and
+            .semantic_scope == $semantic_scope and
+            .semantic_scope_verified == true and
+            (.semantic_sha256 | type) == "string" and
+            (.semantic_sha256 | test("^[0-9a-f]{64}$")) and
+            .target_backend == "dolt-embedded" and
+            (.plan | type) == "object" and .plan.schema == $schema and
+            .plan.digest == $expected and .plan.workspace == $workspace and
+            .plan.semantic_scope == $semantic_scope and
+            .plan.target_backend == "dolt-embedded" and
+            (.plan.source_observation.content_sha256 | type) == "string" and
+            (.plan.source_observation.content_sha256 |
+                test("^[0-9a-f]{64}$")) and
+            .plan.source_observation.content_digest_scope ==
+                "complete_source_tree" and
+            .rollback.path == $rollback and .rollback.policy == "retain" and
+            .rollback.verified == true and
+            .rollback.tree_sha256 ==
+                .plan.source_observation.content_sha256
+        )
+    ' "$receipt" 2>/dev/null) || return 1
+    plan_without_digest=$("$JQ_BIN" -cS '.plan | del(.digest)' \
+        <<< "$receipt_json" 2>/dev/null) || return 1
+    computed_digest=$(printf '%s' "$plan_without_digest" | "$SHA256SUM_BIN" |
+        { read -r digest _; printf '%s\n' "$digest"; }) || return 1
+    [ "$computed_digest" = "$EXPECT_PLAN" ] || return 1
+    AUTHENTICATED_SOURCE_CONTENT=$("$JQ_BIN" -er \
+        '.plan.source_observation.content_sha256' <<< "$receipt_json") ||
+        return 1
+}
+
+journal_owner_is_alive() {
+    local current_boot current_start current_state
+    current_boot=$("$CAT_BIN" -- "$BOOT_ID_PATH" 2>/dev/null) || return 1
+    [ "$current_boot" = "$LOCK_BOOT_ID" ] || return 1
+    kill -0 "$LOCK_OWNER_PID" 2>/dev/null || return 1
+    current_state=$(process_state "$LOCK_OWNER_PID") || return 1
+    [ "$current_state" != Z ] || return 1
+    current_start=$(source_server_start_time "$LOCK_OWNER_PID") || return 1
+    [ "$current_start" = "$LOCK_OWNER_START_TIME" ]
+}
+
+reset_stale_lock_state() {
+    clear_operation_state
+    AUTHENTICATED_SOURCE_CONTENT=
+}
+
+finalize_stale_operation() {
+    LOCK_OWNED=true
+    STAGING_OWNED=true
+    LOCK_PUBLISHED=true
+    STAGING_ID="$LOCK_STAGING_ID"
+    if remove_owned_staging && release_operation_lock; then
+        AUTHENTICATED_SOURCE_CONTENT=
+        return 0
+    fi
+
+    # The canonical fence, or the guardian after a completed retirement,
+    # remains the recovery authority. Do not let EXIT retry a failed cleanup.
+    LOCK_OWNED=false
+    STAGING_OWNED=false
+    return 1
+}
+
+recover_stale_operation() {
+    local active_id rollback_id restored_id rollback_digest
+    local active_receipt="$WORKSPACE/.beads/v062-migration-receipt.json"
+    local staged_root="$STAGING_PATH/target"
+    local staged_receipt="$staged_root/.beads/v062-migration-receipt.json"
+
+    [ -d "$LOCK_PATH" ] && [ ! -L "$LOCK_PATH" ] || return 1
+    LOCK_ID=$(directory_identity "$LOCK_PATH") || return 1
+    load_lock_journal || return 1
+    journal_owner_is_alive && return 1
+
+    staged_root="$STAGING_PATH/target"
+    staged_receipt="$staged_root/.beads/v062-migration-receipt.json"
+
+    active_id=$(directory_identity "$WORKSPACE/.beads" 2>/dev/null) ||
+        active_id=
+    rollback_id=$(directory_identity "$ROLLBACK_PATH" 2>/dev/null) ||
+        rollback_id=
+
+    # A receipt-backed active target is authoritative. It can contain ordinary
+    # writes made after publication, so recovery removes only transaction
+    # artifacts and leaves final verification to the normal no-op path.
+    if [ -n "$active_id" ] &&
+        { [ -e "$active_receipt" ] || [ -L "$active_receipt" ] ||
+          looks_like_completed_target; }; then
+        [ -n "$rollback_id" ] || return 1
+        [ -d "$WORKSPACE/.beads" ] && [ ! -L "$WORKSPACE/.beads" ] ||
+            return 1
+        authenticate_recovery_receipt "$active_receipt" || return 1
+        rollback_digest=$(content_fingerprint "$ROLLBACK_PATH") || return 1
+        [ "$rollback_digest" = "$AUTHENTICATED_SOURCE_CONTENT" ] || return 1
+        case "$LOCK_PHASE" in
+            fenced|staging)
+                [ "$active_id" = "$LOCK_SOURCE_ID" ] || return 1
+                ;;
+            source-retained|committed)
+                [ "$rollback_id" = "$LOCK_SOURCE_ID" ] || return 1
+                ;;
+            *) return 1 ;;
+        esac
+        finalize_stale_operation
+        return
+    fi
+
+    # Before target publication, the exact original inode may be sitting at
+    # the retained rollback path. Authenticate the staged receipt before its
+    # content digest is allowed to authorize restoration.
+    if [ -z "$active_id" ] && path_absent "$WORKSPACE/.beads" &&
+        [ -n "$rollback_id" ]; then
+        [ "$rollback_id" = "$LOCK_SOURCE_ID" ] || return 1
+        [ -n "$LOCK_STAGING_ID" ] || return 1
+        [ -d "$staged_root" ] && [ ! -L "$staged_root" ] &&
+            [ -d "$staged_root/.beads" ] &&
+            [ ! -L "$staged_root/.beads" ] || return 1
+        authenticate_recovery_receipt "$staged_receipt" || return 1
+        rollback_digest=$(content_fingerprint "$ROLLBACK_PATH") || return 1
+        [ "$rollback_digest" = "$AUTHENTICATED_SOURCE_CONTENT" ] || return 1
+        case "$LOCK_PHASE" in
+            source-move-pending|source-retained) ;;
+            *) return 1 ;;
+        esac
+        move_no_clobber_verified directory \
+            "$ROLLBACK_PATH" "$WORKSPACE/.beads" || return 1
+        restored_id=$(directory_identity "$WORKSPACE/.beads") || return 1
+        [ "$restored_id" = "$LOCK_SOURCE_ID" ] || return 1
+        finalize_stale_operation
+        return
+    fi
+
+    # If the original inode never left (or was already restored), deleting an
+    # inode-matched staging tree and the authenticated journal is effect-free.
+    if [ "$active_id" = "$LOCK_SOURCE_ID" ] &&
+        path_absent "$ROLLBACK_PATH" && [ "$LOCK_PHASE" != committed ]; then
+        finalize_stale_operation
+        return
+    fi
+
+    return 1
+}
+
+recover_cutover() {
+    local active_id rollback_id
+    $TRANSACTION_COMMITTED && return 0
+
+    if $SOURCE_MOVE_ATTEMPTED; then
+        [ -n "$SOURCE_ORIGINAL_ID" ] || return 1
+        active_id=$(directory_identity "$WORKSPACE/.beads" 2>/dev/null) ||
+            active_id=
+        if [ "$active_id" = "$SOURCE_ORIGINAL_ID" ]; then
+            SOURCE_MOVE_ATTEMPTED=false
+            SOURCE_RENAMED=false
+            SOURCE_ORIGINAL_ID=
+            return 0
+        fi
+        [ -z "$active_id" ] &&
+            [ ! -e "$WORKSPACE/.beads" ] &&
+            [ ! -L "$WORKSPACE/.beads" ] || return 1
+        rollback_id=$(directory_identity "$ROLLBACK_PATH" 2>/dev/null) ||
+            rollback_id=
+        [ "$rollback_id" = "$SOURCE_ORIGINAL_ID" ] || return 1
+        move_no_clobber_verified directory \
+            "$ROLLBACK_PATH" "$WORKSPACE/.beads" ||
+            return 1
+        active_id=$(directory_identity "$WORKSPACE/.beads") || return 1
+        [ "$active_id" = "$SOURCE_ORIGINAL_ID" ] || return 1
+        SOURCE_MOVE_ATTEMPTED=false
+        SOURCE_RENAMED=false
+        SOURCE_ORIGINAL_ID=
+    fi
+}
+
+cleanup_all() {
+    if ! $TRANSACTION_COMMITTED; then
+        recover_cutover 2>/dev/null || true
+    fi
+    remove_owned_staging 2>/dev/null || true
+    release_operation_lock 2>/dev/null || true
+    cleanup_owned_paths
+    close_workspace_lock 2>/dev/null || true
+    cleanup_runtime_scratch 2>/dev/null || true
+}
+
+transaction_failure() {
+    local code="$1" retryable="$2" message="$3"
+    if $TRANSACTION_COMMITTED; then
+        if ! remove_owned_staging || ! release_operation_lock; then
+            finish_error 1 failed cleanup_failed false workspace_migrated \
+                "migration committed but its transaction artifacts could not be removed"
+        fi
+        finish_error 1 failed "$code" "$retryable" workspace_migrated \
+            "$message"
+    fi
+    if ! recover_cutover || ! remove_owned_staging || ! release_operation_lock; then
+        finish_error 1 failed recovery_failed false workspace_requires_recovery \
+            "migration failed and the original workspace could not be restored"
+    fi
+    finish_error 1 failed "$code" "$retryable" none "$message"
+}
+
+injected_failure() {
+    local failpoint="$1" effect=none
+    if $TRANSACTION_COMMITTED; then
+        effect=workspace_migrated
+        if ! remove_owned_staging || ! release_operation_lock; then
+            finish_error 1 failed cleanup_failed false workspace_migrated \
+                "migration committed but injected-failure cleanup did not complete"
+        fi
+    elif ! recover_cutover || ! remove_owned_staging || ! release_operation_lock; then
+        finish_error 1 failed recovery_failed false workspace_requires_recovery \
+            "injected failure recovery could not restore the original workspace"
+    fi
+    printf '%s: injected failure at %s\n' "$OPERATION" "$failpoint" >&2
+    if $JSON_OUTPUT; then
+        "$JQ_BIN" -cn --arg operation "$OPERATION" --arg failpoint "$failpoint" \
+            --arg effect "$effect" '
+            {
+                schema_version: 1, operation: $operation, mode: "apply",
+                status: "failed", retryable: true, effect: $effect,
+                code: "injected_failure",
+                verification: {failpoint: $failpoint, phase_reached: true}
+            }
+        '
+    fi
+    exit 1
+}
+
+completion_receipt_path() {
+    printf '%s\n' "$WORKSPACE/.beads/v062-migration-receipt.json"
+}
+
+looks_like_completed_target() {
+    local metadata="$WORKSPACE/.beads/metadata.json"
+    [ -f "$metadata" ] && [ ! -L "$metadata" ] || return 1
+    "$JQ_BIN" -e '.backend == "dolt" and .dolt_mode == "embedded"' \
+        "$metadata" >/dev/null 2>&1
+}
+
+emit_verified_no_op() {
+    local receipt_path receipt_json rollback_digest target_semantics
+    local target_semantic_digest plan_without_digest computed_digest
+    local baseline_ids baseline_digest
+    receipt_path=$(completion_receipt_path)
+    [ -f "$receipt_path" ] && [ ! -L "$receipt_path" ] ||
+        refuse completion_state_invalid false \
+            "the completed migration receipt is missing or unsafe"
+    receipt_json=$("$JQ_BIN" -cse \
+        --arg operation "$OPERATION" --arg schema "$PLAN_SCHEMA" \
+        --arg workspace "$WORKSPACE" --arg expected "$EXPECT_PLAN" \
+        --arg semantic_scope "$SEMANTIC_SCOPE" \
+        --arg source_bd "$SOURCE_BD" --arg source_bd_sha "$SOURCE_BD_SHA256" \
+        --arg source_dolt "$SOURCE_DOLT" \
+        --arg source_dolt_sha "$SOURCE_DOLT_SHA256" \
+        --arg target_bd "$TARGET_BD" --arg target_sha "$TARGET_BD_SHA256" \
+        --arg rollback "$ROLLBACK_PATH" '
+        if length == 1 then .[0] else empty end |
+        select(
+            type == "object" and .schema_version == 1 and
+            .operation == $operation and .state == "committed" and
+            .plan_digest == $expected and
+            .semantic_scope == $semantic_scope and
+            .semantic_scope_verified == true and
+            (.semantic_sha256 | type) == "string" and
+            (.semantic_sha256 | test("^[0-9a-f]{64}$")) and
+            .target_backend == "dolt-embedded" and
+            .plan.schema == $schema and .plan.digest == $expected and
+            .plan.workspace == $workspace and
+            .plan.semantic_scope == $semantic_scope and
+            .plan.target_backend == "dolt-embedded" and
+            (.plan.semantic_baseline | type) == "object" and
+            (.plan.semantic_baseline | keys) == ["issue_ids", "sha256"] and
+            (.plan.semantic_baseline.issue_ids | type) == "array" and
+            (.plan.semantic_baseline.issue_ids | length) == 5 and
+            all(.plan.semantic_baseline.issue_ids[];
+                type == "string" and
+                test("^[A-Za-z0-9._-]{1,128}$")) and
+            .plan.semantic_baseline.issue_ids ==
+                (.plan.semantic_baseline.issue_ids | sort | unique) and
+            (.plan.semantic_baseline.sha256 | type) == "string" and
+            (.plan.semantic_baseline.sha256 | test("^[0-9a-f]{64}$")) and
+            .semantic_sha256 == .plan.semantic_baseline.sha256 and
+            (.plan.source_observation.content_sha256 | type) == "string" and
+            (.plan.source_observation.content_sha256 |
+                test("^[0-9a-f]{64}$")) and
+            .plan.source_observation.content_digest_scope ==
+                "complete_source_tree" and
+            (.plan.source_identity | type) == "object" and
+            (.plan.source_identity | keys) == [
+                "database", "issue_prefix", "project_id"
+            ] and
+            (.plan.source_identity.issue_prefix | type) == "string" and
+            (.plan.source_identity.issue_prefix |
+                test("^[A-Za-z][A-Za-z0-9_-]{0,63}$")) and
+            (.plan.source_identity.issue_prefix | endswith("-") | not) and
+            (.plan.source_identity.database | type) == "string" and
+            (.plan.source_identity.database |
+                test("^[A-Za-z_][A-Za-z0-9_]{0,63}$")) and
+            (.plan.source_identity.project_id | type) == "string" and
+            (.plan.source_identity.project_id | test(
+                "^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$"
+            )) and
+            .plan.source_binary.path == $source_bd and
+            .plan.source_binary.sha256 == $source_bd_sha and
+            .plan.source_runtime.path == $source_dolt and
+            .plan.source_runtime.sha256 == $source_dolt_sha and
+            .plan.target_binary.path == $target_bd and
+            .plan.target_binary.sha256 == $target_sha and
+            .rollback.path == $rollback and
+            .rollback.policy == "retain" and
+            .rollback.verified == true and
+            (.rollback.tree_sha256 | type) == "string" and
+            (.rollback.tree_sha256 | test("^[0-9a-f]{64}$")) and
+            .rollback.tree_sha256 ==
+                .plan.source_observation.content_sha256
+        )
+    ' "$receipt_path" 2>/dev/null) ||
+        refuse completion_state_invalid false \
+            "the completed migration receipt does not match this invocation"
+    plan_without_digest=$("$JQ_BIN" -cS '.plan | del(.digest)' \
+        <<< "$receipt_json" 2>/dev/null) ||
+        refuse completion_state_invalid false \
+            "the completed migration plan cannot be authenticated"
+    computed_digest=$(printf '%s' "$plan_without_digest" | "$SHA256SUM_BIN" |
+        { read -r digest _; printf '%s\n' "$digest"; }) ||
+        refuse completion_state_invalid false \
+            "the completed migration plan cannot be authenticated"
+    [ "$computed_digest" = "$EXPECT_PLAN" ] ||
+        refuse completion_state_invalid false \
+            "the completed migration plan digest is invalid"
+    baseline_ids=$("$JQ_BIN" -cer '.plan.semantic_baseline.issue_ids' \
+        <<< "$receipt_json") ||
+        refuse completion_state_invalid false \
+            "the completed semantic baseline cannot be recovered"
+    baseline_digest=$("$JQ_BIN" -er '.plan.semantic_baseline.sha256' \
+        <<< "$receipt_json") ||
+        refuse completion_state_invalid false \
+            "the completed semantic baseline cannot be recovered"
+    SOURCE_ISSUE_PREFIX=$("$JQ_BIN" -er \
+        '.plan.source_identity.issue_prefix' <<< "$receipt_json") ||
+        refuse completion_state_invalid false \
+            "the completed source prefix cannot be recovered"
+    SOURCE_DATABASE=$("$JQ_BIN" -er \
+        '.plan.source_identity.database' <<< "$receipt_json") ||
+        refuse completion_state_invalid false \
+            "the completed source database cannot be recovered"
+    SOURCE_PROJECT_ID=$("$JQ_BIN" -er \
+        '.plan.source_identity.project_id' <<< "$receipt_json") ||
+        refuse completion_state_invalid false \
+            "the completed source project identity cannot be recovered"
+    [ -d "$ROLLBACK_PATH" ] && [ ! -L "$ROLLBACK_PATH" ] ||
+        refuse completion_state_invalid false \
+            "the retained rollback is missing or unsafe"
+    rollback_digest=$(content_fingerprint "$ROLLBACK_PATH") ||
+        refuse completion_state_invalid false \
+            "the retained rollback cannot be verified"
+    [ "$rollback_digest" = \
+        "$("$JQ_BIN" -r '.rollback.tree_sha256' <<< "$receipt_json")" ] ||
+        refuse completion_state_invalid false \
+            "the retained rollback no longer matches its receipt"
+    verify_embedded_layout "$WORKSPACE" ||
+        refuse completion_state_invalid false \
+            "the active target is not the committed embedded layout"
+    verify_target_identity "$WORKSPACE" ||
+        refuse completion_state_invalid false \
+            "the active target no longer has the committed source identity"
+    target_semantics="$CLEAN_HOME/tmp/no-op-target.jsonl"
+    collect_target_semantics \
+        "$WORKSPACE" "$target_semantics" "$baseline_ids" ||
+        refuse completion_state_invalid false \
+            "the active target no longer has the committed semantic corpus"
+    target_semantic_digest=$(semantic_sha256 "$target_semantics") ||
+        refuse completion_state_invalid false \
+            "the active target semantic digest cannot be computed"
+    [ "$target_semantic_digest" = "$baseline_digest" ] ||
+        refuse completion_state_invalid false \
+            "the active target no longer matches the committed semantic digest"
+    verify_embedded_layout "$WORKSPACE" ||
+        refuse completion_state_invalid false \
+            "the active target routing or layout changed during verification"
+
+    PLAN_JSON=$("$JQ_BIN" -c '.plan' <<< "$receipt_json") ||
+        refuse completion_state_invalid false \
+            "the completed plan cannot be recovered from its receipt"
+    PLAN_DIGEST="$EXPECT_PLAN"
+    if ! remove_owned_staging || ! release_operation_lock; then
+        finish_error 1 failed cleanup_failed false none \
+            "the verified no-op operation fence could not be released"
+    fi
+    if $JSON_OUTPUT; then
+        "$JQ_BIN" -cn \
+            --arg operation "$OPERATION" --argjson receipt "$receipt_json" '
+            {
+                schema_version: 1, operation: $operation, mode: "apply",
+                status: "succeeded", retryable: false, effect: "none",
+                no_op: true, plan: $receipt.plan,
+                target: {
+                    version: $receipt.plan.target_binary.version,
+                    backend: "dolt-embedded", embedded_capable: true
+                },
+                rollback: $receipt.rollback,
+                verification: {
+                    semantic_scope: $receipt.semantic_scope,
+                    semantic_scope_verified: true,
+                    issue_count: 5,
+                    target_backend_verified: true,
+                    separate_process_reopen: true
+                }
+            }
+        '
+    else
+        printf 'Migration already committed and verified: %s\n' "$PLAN_DIGEST"
+    fi
+    exit 0
+}
+
+write_completion_receipt() {
+    local target_root="$1" source_tree="$2" semantic_digest="$3"
+    local receipt="$target_root/.beads/v062-migration-receipt.json"
+    local temporary="$target_root/.beads/.v062-migration-receipt.tmp"
+    local baseline_digest
+    baseline_digest=$("$JQ_BIN" -er \
+        '.semantic_baseline.sha256 | select(type == "string")' \
+        <<< "$PLAN_JSON") || return 1
+    [ "$semantic_digest" = "$baseline_digest" ] || return 1
+    [ ! -e "$receipt" ] && [ ! -L "$receipt" ] || return 1
+    "$JQ_BIN" -cn \
+        --arg operation "$OPERATION" --arg semantic_scope "$SEMANTIC_SCOPE" \
+        --arg plan_digest "$PLAN_DIGEST" --argjson plan "$PLAN_JSON" \
+        --arg semantic_digest "$semantic_digest" \
+        --arg rollback "$ROLLBACK_PATH" --arg source_tree "$source_tree" '
+        {
+            schema_version: 1,
+            operation: $operation,
+            state: "committed",
+            plan_digest: $plan_digest,
+            plan: $plan,
+            semantic_scope: $semantic_scope,
+            semantic_scope_verified: true,
+            semantic_sha256: $semantic_digest,
+            target_backend: "dolt-embedded",
+            rollback: {
+                path: $rollback,
+                policy: "retain",
+                verified: true,
+                tree_sha256: $source_tree
+            }
+        }
+    ' > "$temporary" || return 1
+    "$CHMOD_BIN" 600 -- "$temporary" || return 1
+    test_phase before_receipt_publish || return 1
+    move_no_clobber_verified file "$temporary" "$receipt"
+}
+
+initialize_staged_target() {
+    local target_root="$1" source_semantics="$2" target_semantics="$3"
+    "$MKDIR_BIN" -m 700 -- "$target_root" || return 1
+    ensure_clean_home || return 1
+    clean_at "$target_root" "$GIT_BIN" init --quiet || return 1
+    clean_at "$target_root" "$GIT_BIN" \
+        config core.hooksPath .git/hooks || return 1
+    target_at "$target_root" "$TARGET_BD_EXEC" init \
+        --quiet --non-interactive --backend=dolt \
+        --prefix "$SOURCE_ISSUE_PREFIX" --database "$SOURCE_DATABASE" \
+        --migration-v062-project-id "$SOURCE_PROJECT_ID" \
+        --migration-v062-repository-root "$WORKSPACE" \
+        --role maintainer --skip-agents --skip-hooks \
+        >/dev/null 2>&1 || return 1
+    verify_embedded_layout "$target_root" || return 1
+    verify_target_identity "$target_root" || return 1
+    target_at "$target_root" "$TARGET_BD_EXEC" import \
+        -i "$source_semantics" --json >/dev/null 2>&1 || return 1
+    collect_target_semantics "$target_root" "$target_semantics" || return 1
+    semantics_match "$source_semantics" "$target_semantics" || return 1
+    verify_embedded_layout "$target_root"
+}
+
+emit_apply_success() {
+    local source_tree="$1"
+    if $JSON_OUTPUT; then
+        "$JQ_BIN" -cn \
+            --arg operation "$OPERATION" \
+            --argjson inspection "$inspection_json" \
+            --argjson plan "$PLAN_JSON" \
+            --arg rollback "$ROLLBACK_PATH" \
+            --arg semantic_scope "$SEMANTIC_SCOPE" \
+            --arg source_tree "$source_tree" '
+            {
+                schema_version: 1, operation: $operation, mode: "apply",
+                status: "succeeded", retryable: false,
+                effect: "workspace_migrated",
+                source: $inspection.source,
+                target: $inspection.target,
+                plan: $plan,
+                rollback: {
+                    path: $rollback, policy: "retain",
+                    verified: true, tree_sha256: $source_tree
+                },
+                verification: {
+                    semantic_scope: $semantic_scope,
+                    semantic_scope_verified: true,
+                    issue_count: 5,
+                    target_backend_verified: true,
+                    separate_process_reopen: true
+                }
+            }
+        '
+    else
+        printf 'Migrated v0.62.0 workspace; rollback retained at %s\n' \
+            "$ROLLBACK_PATH"
+    fi
+}
+
+perform_apply() {
+    local source_semantics="$1" target_root target_semantics reopen_semantics
+    local planned_tree planned_content current_admission source_tree current_content
+    local rollback_tree semantic_digest failpoint
+
+    [ ! -e "$ROLLBACK_PATH" ] && [ ! -L "$ROLLBACK_PATH" ] ||
+        refuse rollback_collision false \
+            "the retained rollback destination already exists"
+    $LOCK_OWNED && $STAGING_OWNED && $LOCK_PUBLISHED &&
+        [ "$LOCK_PHASE" = staging ] &&
+        [ "$STAGING_PATH" = "$CANONICAL_STAGING_PATH" ] &&
+        owned_directory_matches "$STAGING_PATH" "$STAGING_ID" ||
+        transaction_failure staging_unavailable true \
+            "the published staging transaction could not be authenticated"
+
+    target_root="$STAGING_PATH/target"
+    target_semantics="$STAGING_PATH/target-semantics.jsonl"
+    reopen_semantics="$STAGING_PATH/reopen-semantics.jsonl"
+    planned_tree=$("$JQ_BIN" -er '.source_observation.tree_sha256' \
+        <<< "$PLAN_JSON") ||
+        transaction_failure plan_invalid false \
+            "the authorized source observation is invalid"
+    planned_content=$("$JQ_BIN" -er \
+        '.source_observation.content_sha256 |
+            select(type == "string" and test("^[0-9a-f]{64}$"))' \
+        <<< "$PLAN_JSON") ||
+        transaction_failure plan_invalid false \
+            "the authorized source content identity is invalid"
+
+    [ "$QUALIFIED_SOURCE_TREE" = "$planned_tree" ] || {
+        remove_owned_staging ||
+            transaction_failure cleanup_failed false \
+                "the changed-source staging tree could not be removed"
+        refuse plan_mismatch false \
+            "the source changed while the authorized plan was being applied"
+    }
+    source_tree=$(content_fingerprint "$WORKSPACE/.beads") ||
+        transaction_failure source_unverifiable true \
+            "the active source cannot be reverified"
+    [ "$source_tree" = "$planned_content" ] || {
+        remove_owned_staging ||
+            transaction_failure cleanup_failed false \
+                "the changed-source staging tree could not be removed"
+        refuse plan_mismatch false \
+            "the source content changed while the authorized plan was being applied"
+    }
+
+    initialize_staged_target \
+        "$target_root" "$source_semantics" "$target_semantics" ||
+        transaction_failure target_verification_failed false \
+            "the staged embedded target could not be initialized and verified"
+    semantic_digest=$(semantic_sha256 "$source_semantics") ||
+        transaction_failure target_verification_failed false \
+            "the verified source semantic digest could not be computed"
+    write_completion_receipt \
+        "$target_root" "$source_tree" "$semantic_digest" ||
+        transaction_failure receipt_write_failed false \
+            "the completion receipt could not be staged"
+
+    current_admission=$(inspect_admission_tree "$WORKSPACE") ||
+        transaction_failure source_unverifiable true \
+            "the active source admission state cannot be reinspected"
+    [ "$current_admission" = "$planned_tree" ] || {
+        remove_owned_staging ||
+            transaction_failure cleanup_failed false \
+                "the changed-source staging tree could not be removed"
+        refuse plan_mismatch false \
+            "the source admission state changed before cutover"
+    }
+    current_content=$(content_fingerprint "$WORKSPACE/.beads") ||
+        transaction_failure source_unverifiable true \
+            "the active source cannot be verified before cutover"
+    [ "$current_content" = "$source_tree" ] || {
+        remove_owned_staging ||
+            transaction_failure cleanup_failed false \
+                "the changed-source staging tree could not be removed"
+        refuse plan_mismatch false \
+            "the source changed before cutover"
+    }
+
+    test_phase before_source_rename ||
+        transaction_failure test_phase_failed true \
+            "the test phase handshake did not complete"
+    failpoint=${BD_V062_TEST_FAILPOINT:-}
+    [ "$failpoint" != before_source_rename ] ||
+        injected_failure before_source_rename
+
+    SOURCE_ORIGINAL_ID=$(directory_identity "$WORKSPACE/.beads") ||
+        transaction_failure source_rename_failed true \
+            "the source identity could not be captured before retention"
+    [ "$SOURCE_ORIGINAL_ID" = "$LOCK_SOURCE_ID" ] ||
+        transaction_failure source_rename_failed true \
+            "the source directory identity changed before retention"
+    write_lock_journal source-move-pending ||
+        transaction_failure journal_write_failed false \
+            "the pending source move could not be journaled"
+    SOURCE_MOVE_ATTEMPTED=true
+    move_no_clobber_verified directory \
+        "$WORKSPACE/.beads" "$ROLLBACK_PATH" ||
+        transaction_failure source_rename_failed true \
+            "the source could not be atomically retained as rollback"
+    SOURCE_RENAMED=true
+    write_lock_journal source-retained ||
+        transaction_failure journal_write_failed false \
+            "the retained source state could not be journaled"
+    rollback_tree=$(content_fingerprint "$ROLLBACK_PATH") ||
+        transaction_failure rollback_verification_failed false \
+            "the retained rollback could not be verified"
+    [ "$rollback_tree" = "$source_tree" ] ||
+        transaction_failure rollback_verification_failed false \
+            "the retained rollback differs from the authorized source"
+
+    test_phase after_source_rename_before_target_publish ||
+        transaction_failure test_phase_failed true \
+            "the post-rename test phase handshake did not complete"
+    [ "$failpoint" != after_source_rename_before_target_publish ] ||
+        injected_failure after_source_rename_before_target_publish
+
+    move_no_clobber_verified directory \
+        "$target_root/.beads" "$WORKSPACE/.beads" ||
+        transaction_failure target_publish_failed true \
+            "the verified target could not be atomically published"
+    # Atomic publication is the commit point. From here onward the target may
+    # accept ordinary bd writes, so no failure path may restore the old source
+    # over it or delete the published target.
+    TRANSACTION_COMMITTED=true
+    SOURCE_MOVE_ATTEMPTED=false
+    SOURCE_RENAMED=false
+    SOURCE_ORIGINAL_ID=
+    write_lock_journal committed ||
+        transaction_failure journal_write_failed false \
+            "the committed target state could not be journaled"
+    verify_embedded_layout "$WORKSPACE" ||
+        transaction_failure target_reopen_failed false \
+            "the published target layout could not be reopened"
+    verify_target_identity "$WORKSPACE" ||
+        transaction_failure target_reopen_failed false \
+            "the published target failed source identity reopen"
+    collect_target_semantics "$WORKSPACE" "$reopen_semantics" &&
+        semantics_match "$source_semantics" "$reopen_semantics" ||
+        transaction_failure target_reopen_failed false \
+            "the published target failed separate-process semantic reopen"
+    verify_embedded_layout "$WORKSPACE" ||
+        transaction_failure target_reopen_failed false \
+            "the published target routing or layout changed during reopen"
+
+    test_phase after_target_publish ||
+        transaction_failure test_phase_failed true \
+            "the post-publish test phase handshake did not complete"
+    [ "$failpoint" != after_target_publish ] ||
+        injected_failure after_target_publish
+
+    remove_owned_staging ||
+        finish_error 1 failed cleanup_failed false workspace_migrated \
+            "migration committed but its owned staging tree remains"
+    release_operation_lock ||
+        finish_error 1 failed cleanup_failed false workspace_migrated \
+            "migration committed but its operation fence remains"
+    emit_apply_success "$source_tree"
+    exit 0
+}
+
+qualify_source_semantics() {
+    local destination="$1"
+    local expected_tree="$2" expected_database="$3" expected_project_id="$4"
+    local metadata port database raw shows enriched ids encoded_id id
+    local qualified_source qualified_database qualified_project_id prefix_json
+    local db_project_json db_project_id project_query
+    local show_json show_record attempt ready=false
+
+    QUALIFICATION_CODE=source_semantic_scope_unverifiable
+    QUALIFIED_SOURCE_TREE=
+    ensure_clean_home || return 1
+    SOURCE_SCRATCH="$RUNTIME_SCRATCH/source"
+    path_absent "$SOURCE_SCRATCH" || return 1
+    "$MKDIR_BIN" -m 700 -- "$SOURCE_SCRATCH" || return 1
+    if ! clean_at "$SOURCE_SCRATCH" "$GIT_BIN" init --quiet ||
+        ! clean_at "$SOURCE_SCRATCH" "$GIT_BIN" \
+            config core.hooksPath .git/hooks ||
+        ! "$CP_BIN" -a -- "$WORKSPACE/.beads" "$SOURCE_SCRATCH/.beads"; then
+        cleanup_owned_paths
+        return 1
+    fi
+    qualified_source=$(inspect_admission_source "$SOURCE_SCRATCH") || {
+        cleanup_owned_paths
+        return 1
+    }
+    QUALIFIED_SOURCE_TREE=$("$JQ_BIN" -er '.tree_sha256' \
+        <<< "$qualified_source" 2>/dev/null) || {
+        cleanup_owned_paths
+        return 1
+    }
+    qualified_database=$("$JQ_BIN" -er '.database' \
+        <<< "$qualified_source" 2>/dev/null) || {
+        cleanup_owned_paths
+        return 1
+    }
+    qualified_project_id=$("$JQ_BIN" -er '.project_id' \
+        <<< "$qualified_source" 2>/dev/null) || {
+        cleanup_owned_paths
+        return 1
+    }
+    if [ "$QUALIFIED_SOURCE_TREE" != "$expected_tree" ] ||
+        [ "$qualified_database" != "$expected_database" ] ||
+        [ "$qualified_project_id" != "$expected_project_id" ]; then
+        QUALIFICATION_CODE=source_changed
+        cleanup_owned_paths
+        return 1
+    fi
+
+    metadata="$SOURCE_SCRATCH/.beads/metadata.json"
+    port=$("$JQ_BIN" -er '
+        (.dolt_server_port // 3307) |
+        select(type == "number" and floor == . and . >= 1 and . <= 65535)
+    ' "$metadata" 2>/dev/null) || {
+        cleanup_owned_paths
+        return 1
+    }
+    SOURCE_SERVER_PORT="$port"
+    database=$("$JQ_BIN" -er '
+        (.dolt_database // .database) |
+        select(type == "string" and test("^[A-Za-z_][A-Za-z0-9_-]{0,63}$"))
+    ' "$metadata" 2>/dev/null) || {
+        cleanup_owned_paths
+        return 1
+    }
+    [ "$database" = "$qualified_database" ] || {
+        cleanup_owned_paths
+        return 1
+    }
+    SOURCE_SERVER_LOG="$SOURCE_SCRATCH/source-dolt.log"
+    (
+        close_workspace_lock_in_child
+        cd -P -- "$SOURCE_SCRATCH/.beads/dolt" || exit 1
+        exec "$ENV_BIN" -i \
+            PATH=/usr/bin:/bin HOME="$CLEAN_HOME" TMPDIR="$CLEAN_HOME/tmp" \
+            XDG_CONFIG_HOME="$CLEAN_HOME/config" \
+            XDG_CACHE_HOME="$CLEAN_HOME/cache" \
+            XDG_DATA_HOME="$CLEAN_HOME/data" XDG_STATE_HOME="$CLEAN_HOME/state" \
+            NO_COLOR=1 LANG=C.UTF-8 LC_ALL=C.UTF-8 TZ=UTC TERM=dumb \
+            "$SOURCE_DOLT_EXEC" sql-server --host 127.0.0.1 --port "$port"
+    ) >> "$SOURCE_SERVER_LOG" 2>&1 < /dev/null &
+    SOURCE_SERVER_PID=$!
+    SOURCE_SERVER_START_TIME=$(source_server_start_time "$SOURCE_SERVER_PID") || {
+        wait "$SOURCE_SERVER_PID" 2>/dev/null || true
+        SOURCE_SERVER_PID=
+        cleanup_owned_paths
+        return 1
+    }
+    for ((attempt = 0; attempt < 100; attempt++)); do
+        if clean_at "$SOURCE_SCRATCH" "$SOURCE_DOLT_EXEC" \
+            --host 127.0.0.1 --port "$port" --no-tls \
+            --use-db "$database" sql -r json -q 'SELECT 1' \
+            >/dev/null 2>&1 && owned_source_server_alive; then
+            ready=true
+            break
+        fi
+        owned_source_server_alive || break
+        "$SLEEP_BIN" 0.05
+    done
+    if ! $ready; then
+        cleanup_owned_paths
+        return 1
+    fi
+
+    project_query="SELECT value AS project_id FROM metadata WHERE \`key\` = '_project_id'"
+    db_project_json=$(clean_at "$SOURCE_SCRATCH" "$SOURCE_DOLT_EXEC" \
+        --host 127.0.0.1 --port "$port" --no-tls \
+        --use-db "$database" sql -r json -q "$project_query" \
+        2>/dev/null) || {
+        cleanup_owned_paths
+        return 1
+    }
+    owned_source_server_alive || {
+        cleanup_owned_paths
+        return 1
+    }
+    db_project_id=$("$JQ_BIN" -crse '
+        if length == 1 then .[0] else empty end |
+        select(
+            type == "object" and keys == ["rows"] and
+            (.rows | type) == "array" and (.rows | length) == 1 and
+            (.rows[0] | type) == "object" and
+            (.rows[0] | keys) == ["project_id"] and
+            (.rows[0].project_id | type) == "string" and
+            (.rows[0].project_id | test(
+                "^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$"
+            ))
+        ) |
+        .rows[0].project_id
+    ' 2>/dev/null <<< "$db_project_json") || {
+        cleanup_owned_paths
+        return 1
+    }
+    if [ "$db_project_id" != "$qualified_project_id" ]; then
+        QUALIFICATION_CODE=source_identity_mismatch
+        cleanup_owned_paths
+        return 1
+    fi
+
+    prefix_json=$(source_at "$SOURCE_SCRATCH" "$SOURCE_BD_EXEC" \
+        config get issue_prefix --json 2>/dev/null) || {
+        cleanup_owned_paths
+        return 1
+    }
+    SOURCE_ISSUE_PREFIX=$("$JQ_BIN" -crse '
+        if length == 1 then .[0] else empty end |
+        select(
+            type == "object" and keys == ["key", "value"] and
+            .key == "issue_prefix" and
+            (.value | type) == "string" and
+            (.value | test("^[A-Za-z][A-Za-z0-9._-]{0,63}$"))
+        ) |
+        .value
+    ' 2>/dev/null <<< "$prefix_json") || {
+        cleanup_owned_paths
+        return 1
+    }
+    if [[ ! "$SOURCE_ISSUE_PREFIX" =~ ^[A-Za-z][A-Za-z0-9_-]{0,63}$ ]] ||
+        [[ "$SOURCE_ISSUE_PREFIX" == *- ]] ||
+        [[ ! "$qualified_database" =~ ^[A-Za-z_][A-Za-z0-9_]{0,63}$ ]]; then
+        QUALIFICATION_CODE=source_identity_unsupported
+        cleanup_owned_paths
+        return 1
+    fi
+
+    raw="$SOURCE_SCRATCH/source-export.jsonl"
+    shows="$SOURCE_SCRATCH/source-shows.jsonl"
+    enriched="$SOURCE_SCRATCH/source-enriched.jsonl"
+    if ! source_at "$SOURCE_SCRATCH" "$SOURCE_BD_EXEC" export -o "$raw" \
+        >/dev/null 2>&1 ||
+        ! ids=$("$JQ_BIN" -cer -s '
+            if length > 0 and all(.[];
+                type == "object" and
+                ((.id? | type) == "string") and
+                (.id | test("^[A-Za-z0-9._-]{1,128}$")))
+            then .[].id | @json
+            else error("invalid source export")
+            end
+        ' "$raw" 2>/dev/null); then
+        cleanup_owned_paths
+        return 1
+    fi
+    : > "$shows" || {
+        cleanup_owned_paths
+        return 1
+    }
+    while IFS= read -r encoded_id; do
+        id=$("$JQ_BIN" -er 'select(type == "string" and length > 0)' \
+            <<< "$encoded_id" 2>/dev/null) || {
+            cleanup_owned_paths
+            return 1
+        }
+        show_json=$(source_at "$SOURCE_SCRATCH" "$SOURCE_BD_EXEC" \
+            show --id="$id" --json 2>/dev/null) || {
+            cleanup_owned_paths
+            return 1
+        }
+        show_record=$("$JQ_BIN" -ce --arg id "$id" '
+            select(type == "array" and length == 1) | .[0] |
+            select(type == "object" and .id == $id and
+                   ((.comments // []) | type) == "array")
+        ' <<< "$show_json" 2>/dev/null) || {
+            cleanup_owned_paths
+            return 1
+        }
+        printf '%s\n' "$show_record" >> "$shows" || {
+            cleanup_owned_paths
+            return 1
+        }
+    done <<< "$ids"
+    stop_owned_source_server
+
+    if ! "$JQ_BIN" -cn \
+        --slurpfile exports "$raw" --slurpfile shows "$shows" '
+        def by_id: map({key: .id, value: .}) | from_entries;
+        ($shows | by_id) as $show |
+        $exports[] |
+        ($show[.id].parent // null) as $parent |
+        ($show[.id].comments // []) as $comments |
+        if $parent != null
+        then .parent = $parent
+        else del(.parent)
+        end |
+        if ($comments | length) > 0
+        then .comments = $comments
+        else del(.comments)
+        end
+    ' > "$enriched" || ! qualified_source_semantic_corpus "$enriched"; then
+        QUALIFICATION_CODE=source_semantic_scope_unqualified
+        cleanup_owned_paths
+        return 1
+    fi
+    if ! "$CP_BIN" -f -- "$enriched" "$destination"; then
+        cleanup_owned_paths
+        return 1
+    fi
+    cleanup_owned_paths
+    QUALIFICATION_CODE=
+    return 0
+}
+
+trap cleanup_all EXIT
+
 while [ "$#" -gt 0 ]; do
     case "$1" in
         --workspace)
@@ -92,6 +2920,24 @@ while [ "$#" -gt 0 ]; do
             [ "$#" -ge 2 ] ||
                 invalid_usage invalid_usage "--target-bd requires a value"
             TARGET_BD_ARG="$2"
+            shift 2
+            ;;
+        --source-bd)
+            [ "$#" -ge 2 ] ||
+                invalid_usage invalid_usage "--source-bd requires a value"
+            SOURCE_BD_ARG="$2"
+            shift 2
+            ;;
+        --source-dolt)
+            [ "$#" -ge 2 ] ||
+                invalid_usage invalid_usage "--source-dolt requires a value"
+            SOURCE_DOLT_ARG="$2"
+            shift 2
+            ;;
+        --expect-plan)
+            [ "$#" -ge 2 ] ||
+                invalid_usage invalid_usage "--expect-plan requires a value"
+            EXPECT_PLAN="$2"
             shift 2
             ;;
         --inspect|--apply)
@@ -128,8 +2974,18 @@ if [ "$MODE" = apply ] && ! $YES; then
     invalid_usage confirmation_required \
         "--apply requires explicit --yes confirmation"
 fi
+if [ "$MODE" = apply ] && [ -z "$EXPECT_PLAN" ]; then
+    invalid_usage plan_required \
+        "--apply requires the exact --expect-plan digest from inspect"
+fi
 if $YES && [ "$MODE" != apply ]; then
     invalid_usage invalid_usage "--yes is valid only with --apply"
+fi
+if [ -n "$EXPECT_PLAN" ] && [ "$MODE" != apply ]; then
+    invalid_usage invalid_usage "--expect-plan is valid only with --apply"
+fi
+if [ -n "$EXPECT_PLAN" ] && [[ ! "$EXPECT_PLAN" =~ ^[0-9a-f]{64}$ ]]; then
+    invalid_usage invalid_plan "--expect-plan must be 64 lowercase hex characters"
 fi
 
 INSPECT_TIMEOUT_SECONDS=${BD_V062_INSPECT_TIMEOUT_SECONDS:-600}
@@ -139,9 +2995,51 @@ if [[ ! "$INSPECT_TIMEOUT_SECONDS" =~ ^[1-9][0-9]*$ ]] ||
     invalid_usage invalid_environment \
         "BD_V062_INSPECT_TIMEOUT_SECONDS must be an integer from 1 to 3600"
 fi
-
+case "$TEST_FINGERPRINT_FAILURE" in
+    ""|hash|hold) ;;
+    *)
+        invalid_usage invalid_environment \
+            "BD_V062_TEST_FINGERPRINT_FAILURE has an unsupported value"
+        ;;
+esac
+if [ -n "$UNSAFE_TEST_MV_BIN" ]; then
+    invalid_usage invalid_environment \
+        "BD_V062_TEST_MV_BIN is not a supported executable override"
+fi
+case "$TEST_MV_MODE" in
+    ""|false_success_on_collision|fail_after_source_rename) ;;
+    *)
+        invalid_usage invalid_environment \
+            "BD_V062_TEST_MV_MODE has an unsupported value"
+        ;;
+esac
+case "$TEST_RUNTIME_UNKNOWN_ENTRY" in
+    ""|inject) ;;
+    *)
+        invalid_usage invalid_environment \
+            "BD_V062_TEST_RUNTIME_UNKNOWN_ENTRY has an unsupported value"
+        ;;
+esac
+case "$TEST_IDENTITY_PROBE_FAILURE" in
+    ""|owner_unverifiable) ;;
+    *)
+        invalid_usage invalid_environment \
+            "BD_V062_TEST_IDENTITY_PROBE_FAILURE has an unsupported value"
+        ;;
+esac
+case "$TEST_GUARDIAN_START_FAILURE" in
+    ""|runtime_guardian_start|transaction_guardian_start) ;;
+    *)
+        invalid_usage invalid_environment \
+            "BD_V062_TEST_GUARDIAN_START_FAILURE has an unsupported value"
+        ;;
+esac
 for helper in \
-    "$ENV_BIN" "$JQ_BIN" "$READLINK_BIN" "$REALPATH_BIN" "$TIMEOUT_BIN"; do
+    "$ENV_BIN" "$JQ_BIN" "$READLINK_BIN" "$REALPATH_BIN" "$TIMEOUT_BIN" \
+    "$SHA256SUM_BIN" "$CP_BIN" "$GIT_BIN" "$MKTEMP_BIN" \
+    "$MKDIR_BIN" "$RM_BIN" "$RMDIR_BIN" "$SLEEP_BIN" \
+    "$FIND_BIN" "$SORT_BIN" "$XARGS_BIN" "$MV_BIN" \
+    "$CHMOD_BIN" "$STAT_BIN" "$CAT_BIN" "$GREP_BIN" "$FLOCK_BIN"; do
     [ -f "$helper" ] && [ -x "$helper" ] && [ ! -L "$helper" ] ||
         refuse missing_requirement true \
             "required fixed helper is unavailable: $helper"
@@ -167,20 +3065,85 @@ TARGET_BD=$("$READLINK_BIN" -f -- "$TARGET_BD_ARG" 2>/dev/null) ||
 [ -f "$TARGET_BD" ] && [ -x "$TARGET_BD" ] ||
     refuse target_binary_invalid false \
         "the target bd path is not an executable regular file"
+ensure_runtime_scratch ||
+    refuse target_binary_invalid false \
+        "a private target runtime directory cannot be created"
+TARGET_BD_EXEC="$RUNTIME_SCRATCH/target-bd"
+pin_executable "$TARGET_BD" "$TARGET_BD_EXEC" ||
+    refuse target_binary_invalid false \
+        "the target bd executable cannot be pinned"
+TARGET_BD_SHA256=$(sha256_file "$TARGET_BD_EXEC") ||
+    refuse target_binary_invalid false \
+        "the target bd identity cannot be hashed"
 
-inspection_stdout=$(
-    "$ENV_BIN" -i \
-        PATH=/usr/bin:/bin HOME=/nonexistent \
-        XDG_CONFIG_HOME=/nonexistent XDG_CACHE_HOME=/nonexistent \
-        XDG_DATA_HOME=/nonexistent XDG_STATE_HOME=/nonexistent \
-        GIT_CONFIG_NOSYSTEM=1 GIT_CONFIG_GLOBAL=/dev/null \
-        GIT_TERMINAL_PROMPT=0 BD_DISABLE_METRICS=1 \
-        BD_DISABLE_EVENT_FLUSH=1 BD_NON_INTERACTIVE=1 \
-        NO_COLOR=1 CI=1 LANG=C.UTF-8 LC_ALL=C.UTF-8 TZ=UTC TERM=dumb \
-        "$TIMEOUT_BIN" --kill-after=5s "${INSPECT_TIMEOUT_SECONDS}s" \
-        "$TARGET_BD" __migration-v062-inspect \
-            --workspace "$WORKSPACE" --json 2>/dev/null
-)
+SOURCE_TOOLS_REQUESTED=false
+if [ -n "$SOURCE_BD_ARG" ] || [ -n "$SOURCE_DOLT_ARG" ] || \
+    [ "$MODE" = apply ]; then
+    SOURCE_TOOLS_REQUESTED=true
+    resolve_source_tools
+fi
+
+ROLLBACK_PATH="$WORKSPACE/.beads-v0.62.0-rollback"
+CANONICAL_STAGING_PATH="$WORKSPACE/.beads-v0.62.0-staging"
+CANONICAL_LOCK_PATH="$WORKSPACE/.beads-v0.62.0-migration.lock"
+STAGING_PATH="$CANONICAL_STAGING_PATH"
+LOCK_PATH="$CANONICAL_LOCK_PATH"
+LOCK_JOURNAL_PATH="$LOCK_PATH/journal.json"
+rollback_path="$ROLLBACK_PATH"
+
+if [ "$MODE" = apply ]; then
+    acquire_workspace_lock
+    workspace_lock_status=$?
+    if [ "$workspace_lock_status" -eq 75 ]; then
+        refuse operation_in_progress true \
+            "another v0.62 migration operation owns the workspace lock"
+    fi
+    if [ "$workspace_lock_status" -ne 0 ]; then
+        refuse operation_fence_unverifiable true \
+            "the workspace migration lock could not be acquired"
+    fi
+    if [ -e "$LOCK_PATH" ] || [ -L "$LOCK_PATH" ]; then
+        recover_stale_operation ||
+            finish_error 1 failed recovery_failed false \
+                workspace_requires_recovery \
+                "stale migration state could not be authenticated and recovered"
+    fi
+    path_absent "$CANONICAL_STAGING_PATH" ||
+        refuse staging_collision false \
+            "the side-by-side staging destination already exists"
+    create_operation_bundle ||
+        transaction_failure operation_fence_unverifiable true \
+            "the private migration operation bundle could not be prepared"
+    test_phase after_operation_bundle_prepared_before_fence_publish ||
+        transaction_failure test_phase_failed true \
+            "the prepared-operation test phase handshake did not complete"
+    publish_operation_lock ||
+        transaction_failure operation_fence_unverifiable true \
+            "the migration operation fence could not be published"
+    test_phase after_operation_fence_before_reinspect ||
+        transaction_failure test_phase_failed true \
+            "the operation-fence test phase handshake did not complete"
+    publish_operation_staging ||
+        transaction_failure staging_unavailable true \
+            "the prepared staging inode could not be published"
+    test_phase after_staging_publish_before_journal_update ||
+        transaction_failure test_phase_failed true \
+            "the staging-publication test phase handshake did not complete"
+    write_lock_journal staging ||
+        transaction_failure journal_write_failed false \
+            "the staging transaction state could not be journaled"
+    receipt_path=$(completion_receipt_path)
+    if [ -e "$receipt_path" ] || [ -L "$receipt_path" ] ||
+        looks_like_completed_target; then
+        emit_verified_no_op
+    fi
+fi
+
+ensure_clean_home ||
+    refuse missing_requirement true \
+        "an isolated runtime home could not be created"
+inspection_stdout=$(clean_at "$WORKSPACE" "$TARGET_BD_EXEC" \
+    __migration-v062-inspect --workspace "$WORKSPACE" --json 2>/dev/null)
 inspection_status=$?
 
 if [ "$inspection_status" -eq 124 ] || [ "$inspection_status" -eq 137 ]; then
@@ -204,6 +3167,7 @@ if ! inspection_json=$("$JQ_BIN" -cse \
             "source_metadata_missing",
             "source_metadata_mismatch",
             "source_layout_missing",
+            "source_routing_unsupported",
             "unsafe_source_symlink",
             "unsafe_source_hardlink",
             "unsafe_source_object",
@@ -259,6 +3223,17 @@ if [ "$inspection_status" -ne 0 ] ||
         .source.workspace == $workspace and
         .source.version == "0.62.0" and
         .source.backend == "dolt-server" and
+        (.source | keys) == [
+            "backend", "database", "digest_scope", "project_id",
+            "tree_sha256", "version", "workspace"
+        ] and
+        (.source.database | type) == "string" and
+        (.source.database |
+            test("^[A-Za-z_][A-Za-z0-9_-]{0,63}$")) and
+        (.source.project_id | type) == "string" and
+        (.source.project_id | test(
+            "^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$"
+        )) and
         .source.digest_scope == "admission_observation" and
         (.source.tree_sha256 | type) == "string" and
         (.source.tree_sha256 | test("^[0-9a-f]{64}$")) and
@@ -281,9 +3256,100 @@ if [ "$inspection_status" -ne 0 ] ||
         "target bd is not a qualified embedded-capable migration target"
 fi
 
-rollback_path="$WORKSPACE/.beads-v0.62.0-rollback"
+SOURCE_DATABASE=$("$JQ_BIN" -er '.source.database' <<< "$inspection_json") ||
+    refuse target_capability_missing false \
+        "the qualified source database identity is invalid"
+SOURCE_PROJECT_ID=$("$JQ_BIN" -er '.source.project_id' <<< "$inspection_json") ||
+    refuse target_capability_missing false \
+        "the qualified source project identity is invalid"
 
-# Be truthful while this stack contains admission but not the effectful bridge.
+if $SOURCE_TOOLS_REQUESTED; then
+    source_observation=$("$JQ_BIN" -er '.source.tree_sha256' \
+        <<< "$inspection_json") ||
+        refuse target_capability_missing false \
+            "the qualified source observation is invalid"
+    SEMANTIC_PROBE="$RUNTIME_SCRATCH/qualified.jsonl"
+    path_absent "$SEMANTIC_PROBE" &&
+        : > "$SEMANTIC_PROBE" &&
+        "$CHMOD_BIN" 600 -- "$SEMANTIC_PROBE" ||
+            refuse source_semantic_scope_unverifiable true \
+                "a bounded semantic qualification file could not be created"
+    if ! qualify_source_semantics "$SEMANTIC_PROBE" \
+        "$source_observation" "$SOURCE_DATABASE" "$SOURCE_PROJECT_ID"; then
+        if [ "$QUALIFICATION_CODE" = source_semantic_scope_unqualified ]; then
+            refuse source_semantic_scope_unqualified false \
+                "the source is outside the currently qualified semantic corpus"
+        fi
+        if [ "$QUALIFICATION_CODE" = source_changed ]; then
+            refuse source_changed true \
+                "the source identity changed while it was being qualified"
+        fi
+        if [ "$QUALIFICATION_CODE" = source_identity_mismatch ]; then
+            refuse source_identity_mismatch false \
+                "metadata.json and the v0.62 database have different project identities"
+        fi
+        if [ "$QUALIFICATION_CODE" = source_identity_unsupported ]; then
+            refuse source_identity_unsupported false \
+                "the v0.62 source identity cannot be preserved by the embedded target"
+        fi
+        refuse source_semantic_scope_unverifiable true \
+            "the source semantic corpus could not be verified"
+    fi
+    [ "$QUALIFIED_SOURCE_TREE" = "$source_observation" ] ||
+        refuse source_changed true \
+            "the source changed while its semantic corpus was inspected"
+    source_content_sha256=$(content_fingerprint "$WORKSPACE/.beads") ||
+        refuse source_unverifiable true \
+            "the complete source tree could not be fingerprinted"
+    build_bound_plan \
+        "$inspection_json" "$SEMANTIC_PROBE" "$source_content_sha256" ||
+        refuse target_capability_missing false \
+            "the bound migration plan could not be constructed"
+
+    if [ "$MODE" = apply ] && [ "$EXPECT_PLAN" != "$PLAN_DIGEST" ]; then
+        refuse plan_mismatch false \
+            "the source, runtime, target, or workspace changed after inspect"
+    fi
+
+    if [ "$MODE" = inspect ]; then
+        "$RM_BIN" -f -- "$SEMANTIC_PROBE" ||
+            refuse source_semantic_scope_unverifiable true \
+                "the semantic qualification scratch file could not be removed"
+        SEMANTIC_PROBE=
+        if $JSON_OUTPUT; then
+            "$JQ_BIN" -cn \
+                --argjson inspection "$inspection_json" \
+                --argjson plan "$PLAN_JSON" \
+                --arg operation "$OPERATION" --arg rollback "$rollback_path" \
+                --arg semantic_scope "$SEMANTIC_SCOPE" '
+                {
+                    schema_version: 1, operation: $operation,
+                    mode: "inspect", status: "planned",
+                    retryable: false, effect: "none",
+                    source: $inspection.source, target: $inspection.target,
+                    plan: $plan,
+                    rollback: {path: $rollback, policy: "retain"},
+                    verification: {
+                        source_shape: "qualified",
+                        source_digest_scope: $inspection.source.digest_scope,
+                        apply_reinspection_required: true,
+                        semantic_scope: $semantic_scope,
+                        semantic_scope_verified: true,
+                        workspace_effects: false
+                    }
+                }
+            '
+        else
+            printf 'Planned canonical v0.62.0 server-to-embedded migration: %s\n' \
+                "$PLAN_DIGEST"
+        fi
+        exit 0
+    fi
+    perform_apply "$SEMANTIC_PROBE"
+fi
+
+# Layout admission alone cannot produce a consent-bound plan. Historical
+# source tools are explicit inputs because their exact bytes become plan data.
 if $JSON_OUTPUT; then
     "$JQ_BIN" -cn \
         --argjson inspection "$inspection_json" \
@@ -291,7 +3357,7 @@ if $JSON_OUTPUT; then
         --arg rollback "$rollback_path" '
         {
             schema_version: 1, operation: $operation, mode: $mode,
-            status: "failed", code: "apply_not_available",
+            status: "refused", code: "source_tools_required",
             retryable: false, effect: "none",
             source: $inspection.source, target: $inspection.target,
             rollback: {path: $rollback, policy: "retain"},
@@ -300,13 +3366,14 @@ if $JSON_OUTPUT; then
                 source_tree_sha256: $inspection.source.tree_sha256,
                 source_digest_scope: $inspection.source.digest_scope,
                 apply_reinspection_required: true,
-                apply_available: false,
+                apply_available: true,
+                apply_requires_pinned_source_tools: true,
                 workspace_effects: false
             }
         }
     '
 else
     printf '%s\n' \
-        'Qualified v0.62.0 source; apply is not available in this build.' >&2
+        'Qualified v0.62.0 source; rerun inspect with --source-bd and --source-dolt to bind an apply plan.' >&2
 fi
 exit 1

--- a/scripts/migrate-v062-server-to-current.sh
+++ b/scripts/migrate-v062-server-to-current.sh
@@ -1485,6 +1485,16 @@ verify_embedded_layout() {
         [ ! -e "$root/.beads/dolt" ] && [ ! -L "$root/.beads/dolt" ]
 }
 
+# Post-init identity re-check (belt-and-suspenders): re-verify backend,
+# dolt_mode, database, project_id, and issue_prefix directly from the published
+# target. repo_id/clone_id are intentionally NOT re-checked here even though
+# --migration-v062-repository-root exists to get them right: they are computed
+# by the target binary's init from that flag, their persistence is
+# fatal-on-failure (cmd/bd/init.go), and it is proven end to end in Go by
+# TestMigrationV062StagedInitPublishesFinalRepositoryIdentity. Re-deriving them
+# in shell would duplicate the Go identity logic (ComputeRepoIDForPath /
+# GetCloneIDForPath) this bridge deliberately reuses rather than reimplements,
+# so those two guarantees are delegated to init's fatal contract.
 verify_target_identity() {
     local root="$1" metadata prefix_json
     metadata="$root/.beads/metadata.json"

--- a/scripts/migration-test/lib/versions.sh
+++ b/scripts/migration-test/lib/versions.sh
@@ -146,6 +146,15 @@ strict_required_dolt_sha256() {
     printf '%s\n' "$value"
 }
 
+# Local strict-runtime gate. This is deliberately version-string-only: it
+# confirms the resolved dolt reports the pinned historical version, nothing
+# more. Authoritative binary-integrity enforcement (sha256 of the downloaded
+# release archive against strict_required_dolt_sha256) is CI-side, in
+# .github/workflows/migration-test.yml. We do not checksum the local dolt here
+# because a developer's installed dolt 1.84.0 can be a legitimately different
+# build (package manager, `go install`, other arch) with a different hash, so
+# enforcing the release-archive SHA against an arbitrary local binary would
+# reject authentic runtimes. CI owns integrity; this only pins the version.
 verify_strict_historical_runtime() {
     local version="$1"
     local expected output

--- a/scripts/migration-test/lib/versions.sh
+++ b/scripts/migration-test/lib/versions.sh
@@ -66,7 +66,7 @@ declare -Ar STRICT_EXPECTED_RECIPES=(
     ["v0.49.6"]="sqlite_to_current"
     ["v0.55.4"]="server_to_embedded"
     ["v0.57.0"]="server_to_embedded"
-    ["v0.62.0"]="server_to_embedded"
+    ["v0.62.0"]="public_v062_bridge"
     ["v0.63.3"]=""
 )
 declare -Ar STRICT_EXPECTED_FEATURES=(
@@ -79,7 +79,6 @@ declare -Ar STRICT_EXPECTED_FEATURES=(
 declare -Ar SERVER_BRIDGE_STRATEGIES=(
     ["v0.55.4"]="native_export"
     ["v0.57.0"]="native_export_show_comments"
-    ["v0.62.0"]="native_export_show_comments"
 )
 declare -Ar SERVER_BOOTSTRAP_STRATEGIES=(
     ["v0.62.0"]="prestarted_server"

--- a/scripts/migration-test/public-v062-bridge-test.sh
+++ b/scripts/migration-test/public-v062-bridge-test.sh
@@ -13,6 +13,27 @@ fail() {
 command -v jq >/dev/null || fail "jq is required"
 command -v script >/dev/null || fail "script is required"
 
+if grep -Fq '"$RM_BIN" -rf -- "$RUNTIME_SCRATCH"' "$BRIDGE" ||
+    grep -Fq '"$RM_BIN" -rf -- "$TRANSACTION_ROOT"' "$BRIDGE"; then
+    fail "private runtime cleanup must not recursively delete an unauthenticated pathname"
+fi
+
+assert_function_has_no_signal_command() {
+    local function_name="$1" body
+    body=$(awk -v signature="$function_name() {" '
+        $0 == signature { capture = 1 }
+        capture { print }
+        capture && $0 == "}" { exit }
+    ' "$BRIDGE") || fail "could not inspect $function_name"
+    [ -n "$body" ] || fail "could not find $function_name"
+    if grep -Eq '(^|[^[:alnum:]_])kill([[:space:]]|$)' <<< "$body"; then
+        fail "$function_name must use identity-aware cooperative waiting, not process signals"
+    fi
+}
+
+assert_function_has_no_signal_command stop_runtime_guardian
+assert_function_has_no_signal_command stop_transaction_guardian
+
 if [ -n "${PUBLIC_V062_REAL_TARGET_BD:-}" ]; then
     REAL_TARGET_BD=$(realpath -e -- "$PUBLIC_V062_REAL_TARGET_BD") ||
         fail "PUBLIC_V062_REAL_TARGET_BD cannot be resolved"
@@ -25,8 +46,149 @@ fi
     fail "real current bd target is not executable: $REAL_TARGET_BD"
 
 tmp=$(mktemp -d "${TMPDIR:-/tmp}/bd-public-v062-bridge.XXXXXX")
-trap 'rm -rf -- "$tmp"' EXIT
+
+pid_is_running() {
+    local pid="$1" stat rest state
+    [[ "$pid" =~ ^[1-9][0-9]*$ ]] || return 1
+    kill -0 "$pid" 2>/dev/null || return 1
+    stat=$(/usr/bin/cat -- "/proc/$pid/stat" 2>/dev/null) || return 1
+    rest=${stat#*) }
+    state=${rest%% *}
+    [ "$state" != Z ]
+}
+
+pid_start_time() {
+    local pid="$1" stat rest
+    local -a fields
+    stat=$(/usr/bin/cat -- "/proc/$pid/stat" 2>/dev/null) || return 1
+    rest=${stat##*) }
+    read -r -a fields <<< "$rest" || return 1
+    [ "${#fields[@]}" -ge 20 ] && [ "${fields[0]}" != Z ] || return 1
+    printf '%s\n' "${fields[19]}"
+}
+
+pid_identity_is_running() {
+    local pid="$1" expected_start="$2" actual_start
+    pid_is_running "$pid" || return 1
+    actual_start=$(pid_start_time "$pid") || return 1
+    [ "$actual_start" = "$expected_start" ]
+}
+
+terminate_pid_bounded() {
+    local pid="$1" attempt
+    if ! pid_is_running "$pid"; then
+        wait "$pid" 2>/dev/null || true
+        return 0
+    fi
+    kill -TERM -- "$pid" 2>/dev/null || true
+    for ((attempt = 0; attempt < 100; attempt++)); do
+        pid_is_running "$pid" || break
+        sleep 0.025
+    done
+    if pid_is_running "$pid"; then
+        kill -KILL -- "$pid" 2>/dev/null || true
+        for ((attempt = 0; attempt < 100; attempt++)); do
+            pid_is_running "$pid" || break
+            sleep 0.025
+        done
+    fi
+    pid_is_running "$pid" && return 1
+    wait "$pid" 2>/dev/null || true
+}
+
+terminate_pid_identity_bounded() {
+    local pid="$1" start="$2" attempt
+    pid_identity_is_running "$pid" "$start" || return 0
+    kill -TERM -- "$pid" 2>/dev/null || true
+    for ((attempt = 0; attempt < 100; attempt++)); do
+        pid_identity_is_running "$pid" "$start" || break
+        sleep 0.025
+    done
+    if pid_identity_is_running "$pid" "$start"; then
+        kill -KILL -- "$pid" 2>/dev/null || true
+    fi
+    pid_identity_is_running "$pid" "$start" && return 1
+    wait "$pid" 2>/dev/null || true
+}
+
+cleanup() {
+    local pids_file identity_file pid start command_line
+    if [ -n "${GUARDIAN_TEST_PHASE_DIR:-}" ] &&
+        [ -d "$GUARDIAN_TEST_PHASE_DIR" ]; then
+        touch \
+            "$GUARDIAN_TEST_PHASE_DIR/transaction_guardian_resource_removed.continue" \
+            "$GUARDIAN_TEST_PHASE_DIR/runtime_guardian_resource_removed.continue" \
+            2>/dev/null || true
+    fi
+    while IFS= read -r identity_file; do
+        while IFS=' ' read -r pid start; do
+            [[ "$pid" =~ ^[1-9][0-9]*$ ]] &&
+                [[ "$start" =~ ^[0-9]+$ ]] || continue
+            terminate_pid_identity_bounded "$pid" "$start" || true
+        done < "$identity_file"
+    done < <(find -P "$tmp" -type f \
+        -name 'workspace-lock-child.identities*' -print 2>/dev/null)
+    if [ -n "${JOURNAL_ZOMBIE_HOLDER_PID:-}" ]; then
+        kill -TERM -- "$JOURNAL_ZOMBIE_HOLDER_PID" 2>/dev/null || true
+        wait "$JOURNAL_ZOMBIE_HOLDER_PID" 2>/dev/null || true
+        JOURNAL_ZOMBIE_HOLDER_PID=""
+    fi
+    if [ -n "${ASYNC_BRIDGE_PID:-}" ]; then
+        terminate_pid_bounded "$ASYNC_BRIDGE_PID" || true
+    fi
+    for pids_file in "$tmp"/*.pid "$tmp"/*.pids; do
+        [ -s "$pids_file" ] || continue
+        while IFS= read -r pid; do
+            [[ "$pid" =~ ^[1-9][0-9]*$ ]] || continue
+            command_line=$(
+                /usr/bin/cat -- "/proc/$pid/cmdline" 2>/dev/null |
+                    tr '\0' ' ' || true
+            )
+            if { [[ "$command_line" == *"$tmp/fake-dolt-"* ]] &&
+                    [[ "$command_line" == *sql-server* ]]; } ||
+                { [[ "$command_line" == /tmp/bd-v062-runtime.*/source-dolt* ]] &&
+                    [[ "$command_line" == *sql-server* ]]; } ||
+                { [[ "$command_line" == "$tmp"/*/source-dolt* ]] &&
+                    [[ "$command_line" == *sql-server* ]]; } ||
+                [[ "$command_line" == *"$tmp/fake-bd-timeout-target"* ]]; then
+                terminate_pid_bounded "$pid" || true
+            fi
+        done < "$pids_file"
+    done
+    rm -rf -- "$tmp"
+}
+trap cleanup EXIT
 mkdir -p "$tmp/home"
+
+POISON_BIN="$tmp/poison-bin"
+POISON_BASH_MARKER="$tmp/poison-bash-invoked"
+POISON_BASH_ENV_MARKER="$tmp/poison-bash-env-invoked"
+POISON_PATH_MARKER="$tmp/poison-path-command-invoked"
+POISON_BASH_ENV="$tmp/poison-bash-env"
+POISON_GIT_DIR="$tmp/poison-git-dir"
+POISON_GIT_WORK_TREE="$tmp/poison-git-work-tree"
+POISON_GIT_TEMPLATE="$tmp/poison-git-template"
+mkdir -m 700 "$POISON_BIN" "$POISON_GIT_TEMPLATE"
+printf -v poison_bash_marker_q '%q' "$POISON_BASH_MARKER"
+printf -v poison_bash_env_marker_q '%q' "$POISON_BASH_ENV_MARKER"
+printf -v poison_path_marker_q '%q' "$POISON_PATH_MARKER"
+cat > "$POISON_BIN/bash" <<EOF
+#!/bin/bash
+printf '%s\n' invoked >> $poison_bash_marker_q
+exec /bin/bash "\$@"
+EOF
+chmod +x "$POISON_BIN/bash"
+cat > "$POISON_BIN/grep" <<EOF
+#!/bin/bash
+printf '%s\n' invoked >> $poison_path_marker_q
+exit 97
+EOF
+chmod +x "$POISON_BIN/grep"
+cat > "$POISON_BASH_ENV" <<EOF
+printf '%s\n' invoked >> $poison_bash_env_marker_q
+exit 97
+EOF
+printf '%s\n' poison-template > "$POISON_GIT_TEMPLATE/poison-template-marker"
 
 TARGET_BD="$tmp/fake-bd-current"
 TARGET_LOG="$tmp/fake-target.log"
@@ -36,28 +198,193 @@ INCAPABLE_TARGET_BD="$tmp/fake-bd-incapable-target"
 INCAPABLE_TARGET_LOG="$tmp/fake-incapable-target.log"
 TIMEOUT_TARGET_BD="$tmp/fake-bd-timeout-target"
 TIMEOUT_TARGET_LOG="$tmp/fake-timeout-target.log"
+LOSSY_TARGET_LOG="$tmp/fake-lossy-audit-target.log"
+ROUTED_TARGET_BD="$tmp/fake-bd-routed-target"
+ROUTED_TARGET_LOG="$tmp/fake-routed-target.log"
+LATE_ROUTED_TARGET_BD="$tmp/fake-bd-late-routed-target"
+LATE_ROUTED_TARGET_LOG="$tmp/fake-late-routed-target.log"
+SYMLINK_DOLT_TARGET_BD="$tmp/fake-bd-symlink-dolt-target"
+SYMLINK_DOLT_TARGET_LOG="$tmp/fake-symlink-dolt-target.log"
+SYMLINK_DATABASE_TARGET_BD="$tmp/fake-bd-symlink-database-target"
+SYMLINK_DATABASE_TARGET_LOG="$tmp/fake-symlink-database-target.log"
+SOURCE_BD="$tmp/fake-bd-v0.62.0"
+SOURCE_LOG="$tmp/fake-source.log"
+SOURCE_DOLT="$tmp/fake-dolt-1.84.0"
+SOURCE_DOLT_LOG="$tmp/fake-source-dolt.log"
+OLD_NO_CLOBBER_MV="$tmp/fake-old-no-clobber-mv"
+BAD_SOURCE_BD="$tmp/fake-bd-v0.61.0"
+BAD_SOURCE_LOG="$tmp/fake-bad-source.log"
+BAD_SOURCE_DOLT="$tmp/fake-dolt-1.83.0"
+BAD_SOURCE_DOLT_LOG="$tmp/fake-bad-source-dolt.log"
+CANONICAL_EXPORT="$tmp/canonical-v062-export.jsonl"
+CANONICAL_SHOW="$tmp/canonical-v062-show.json"
+UNQUALIFIED_EXPORT="$tmp/unqualified-v062-export.jsonl"
+UNQUALIFIED_SHOW="$tmp/unqualified-v062-show.json"
+UNSUPPORTED_EXPORT="$tmp/unsupported-v062-export.jsonl"
+UNSUPPORTED_SHOW="$tmp/unsupported-v062-show.json"
+NESTED_DEPENDENCY_EXPORT="$tmp/nested-dependency-v062-export.jsonl"
+NESTED_COMMENT_SHOW="$tmp/nested-comment-v062-show.json"
+SOURCE_AUDIT_FIXTURE_DIR="$tmp/source-audit-fixtures"
+SOURCE_ISSUE_PREFIX=legacy
+SOURCE_DATABASE=smoke
+SOURCE_PROJECT_ID=7ef372b4-4c3c-4e2c-a6cc-29dd2d0a28c6
+
+# Model coreutils releases where mv --no-clobber exits zero after skipping a
+# move because the destination appeared. The bridge must trust postconditions,
+# not that historically inconsistent exit status.
+cat > "$OLD_NO_CLOBBER_MV" <<'EOF'
+#!/bin/bash
+arguments=("$@")
+count=${#arguments[@]}
+if ((count >= 2)); then
+    source=${arguments[count - 2]}
+    destination=${arguments[count - 1]}
+    if { [ -e "$source" ] || [ -L "$source" ]; } &&
+        { [ -e "$destination" ] || [ -L "$destination" ]; }; then
+        exit 0
+    fi
+fi
+exec /usr/bin/mv "$@"
+EOF
+chmod +x "$OLD_NO_CLOBBER_MV"
+
+# The first public apply path is deliberately bounded to the exact strict-lane
+# v0.62 corpus: five issues carrying eight semantic features. The historical
+# export omits comment bodies; one-item show calls are required to enrich it.
+cat > "$CANONICAL_EXPORT" <<'EOF'
+{"id":"old-epic","title":"Migration epic","description":"Epic for migration testing","priority":2,"issue_type":"epic","status":"open","dependency_count":0,"comment_count":0}
+{"id":"old-standalone","title":"Standalone detailed task","description":"This task has a detailed description for fidelity testing.","notes":"Historical notes must survive the upgrade.","design":"Historical design must survive the upgrade.","acceptance_criteria":"Historical acceptance criteria must survive the upgrade.","external_ref":"legacy-upgrade-42","priority":2,"issue_type":"task","status":"open","dependency_count":0,"comment_count":0}
+{"id":"old-closed","title":"Already closed issue","priority":3,"issue_type":"task","status":"closed","dependency_count":0,"comment_count":0}
+{"id":"old-task","title":"Migration task alpha","priority":1,"issue_type":"task","status":"open","labels":["urgent"],"dependencies":[{"issue_id":"old-task","depends_on_id":"old-epic","type":"parent-child","created_at":"2025-01-02T03:04:05Z","created_by":"legacy-parent-author","metadata":"{}","thread_id":""}],"dependency_count":0,"comment_count":1}
+{"id":"old-bug","title":"Migration bug beta","priority":3,"issue_type":"bug","status":"open","dependencies":[{"issue_id":"old-bug","depends_on_id":"old-task","type":"blocks","created_at":"2025-01-03T04:05:06Z","created_by":"legacy-block-author","metadata":"{}","thread_id":""}],"dependency_count":1,"comment_count":0}
+EOF
+cat > "$CANONICAL_SHOW" <<'EOF'
+[
+  {"id":"old-epic","title":"Migration epic","description":"Epic for migration testing","priority":2,"issue_type":"epic","status":"open","dependencies":[],"comments":[]},
+  {"id":"old-standalone","title":"Standalone detailed task","description":"This task has a detailed description for fidelity testing.","notes":"Historical notes must survive the upgrade.","design":"Historical design must survive the upgrade.","acceptance_criteria":"Historical acceptance criteria must survive the upgrade.","external_ref":"legacy-upgrade-42","priority":2,"issue_type":"task","status":"open","dependencies":[],"comments":[]},
+  {"id":"old-closed","title":"Already closed issue","priority":3,"issue_type":"task","status":"closed","dependencies":[],"comments":[]},
+  {"id":"old-task","title":"Migration task alpha","priority":1,"issue_type":"task","status":"open","parent":"old-epic","labels":["urgent"],"dependencies":[{"id":"old-epic","dependency_type":"parent-child"}],"comments":[{"id":"7dbef7d8-c3af-42e3-9b59-9f30e81e2647","issue_id":"old-task","author":"legacy-author","text":"Historical comment must survive the upgrade.","created_at":"2025-01-04T05:06:07Z"}]},
+  {"id":"old-bug","title":"Migration bug beta","priority":3,"issue_type":"bug","status":"open","dependencies":[{"id":"old-task","dependency_type":"blocks"}],"comments":[]}
+]
+EOF
+# A sixth record is valid JSONL but outside the currently proven semantic
+# envelope. It must be rejected before any workspace effect.
+cp -f -- "$CANONICAL_EXPORT" "$UNQUALIFIED_EXPORT"
+printf '%s\n' '{"id":"old-extra","title":"Unqualified extra issue","priority":2,"issue_type":"task","status":"open","dependency_count":0,"comment_count":0}' \
+    >> "$UNQUALIFIED_EXPORT"
+jq '. + [{
+    id: "old-extra", title: "Unqualified extra issue", priority: 2,
+    issue_type: "task", status: "open", dependencies: [], comments: []
+}]' "$CANONICAL_SHOW" > "$UNQUALIFIED_SHOW"
+
+# Record count alone cannot qualify a semantic envelope. Keep the canonical
+# five IDs and values but add a v0.62 field that this first bridge has not
+# independently proven through import/reopen fidelity.
+jq -c '
+    if .id == "old-standalone"
+    then . + {creator: "unqualified-creator"}
+    else .
+    end
+' "$CANONICAL_EXPORT" > "$UNSUPPORTED_EXPORT"
+jq '
+    map(
+        if .id == "old-standalone"
+        then . + {creator: "unqualified-creator"}
+        else .
+        end
+    )
+' "$CANONICAL_SHOW" > "$UNSUPPORTED_SHOW"
+
+# Nested values that the canonical projection drops are outside the qualified
+# scope even when the same five records still carry all eight proven features.
+jq -c '
+    if .id == "old-task"
+    then .dependencies = (.dependencies | map(
+        .metadata = "{\"legacy\":\"value\"}" |
+        .thread_id = "legacy-dependency-thread"
+    ))
+    else .
+    end
+' "$CANONICAL_EXPORT" > "$NESTED_DEPENDENCY_EXPORT"
+jq '
+    map(
+        if .id == "old-task"
+        then .comments = (.comments | map(
+            . + {legacy_thread_id: "legacy-comment-thread"}
+        ))
+        else .
+        end
+    )
+' "$CANONICAL_SHOW" > "$NESTED_COMMENT_SHOW"
+
+# Each admitted audit field is independently required. Empty historical values
+# must be refused before a plan is offered, not normalized away during import.
+mkdir -m 700 "$SOURCE_AUDIT_FIXTURE_DIR"
+for source_audit_field in created-at created-by; do
+    jq -c --arg field "${source_audit_field//-/_}" '
+        if .id == "old-task"
+        then .dependencies = (.dependencies | map(.[$field] = ""))
+        else .
+        end
+    ' "$CANONICAL_EXPORT" \
+        > "$SOURCE_AUDIT_FIXTURE_DIR/dependency-$source_audit_field.jsonl"
+done
+for source_audit_field in id issue-id created-at; do
+    jq --arg field "${source_audit_field//-/_}" '
+        map(
+            if .id == "old-task"
+            then .comments = (.comments | map(.[$field] = ""))
+            else .
+            end
+        )
+    ' "$CANONICAL_SHOW" \
+        > "$SOURCE_AUDIT_FIXTURE_DIR/comment-$source_audit_field.json"
+done
 
 make_fake_bd() {
     local path="$1" version="$2" capability="$3" log="$4"
+    local log_q version_q capability_q log_pid_q log_pids_q
+    local injection_marker_q export_marker_q
+    printf -v log_q '%q' "$log"
+    printf -v version_q '%q' "$version"
+    printf -v capability_q '%q' "$capability"
+    printf -v log_pid_q '%q' "${log}.pid"
+    printf -v log_pids_q '%q' "${log}.pids"
+    printf -v injection_marker_q '%q' "${path}.injected"
+    printf -v export_marker_q '%q' "${path}.exported"
     cat > "$path" <<EOF
 #!/usr/bin/env bash
 {
     printf 'argv=%q' "\$0"
     printf ' %q' "\$@"
     printf '\n'
+    printf 'cwd=%q\n' "\$PWD"
     env | LC_ALL=C sort
-} >> '$log'
+} >> $log_q
 case "\${1:-}" in
     version)
-        [ "\${2:-}" = --json ] || exit 2
-        printf '{"version":"%s","build":"test"}\n' '$version'
+        if [ "\${2:-}" = --json ]; then
+            printf '{"version":"%s","build":"test"}\n' $version_q
+        elif [ "\$#" -eq 1 ]; then
+            printf 'bd version %s\n' $version_q
+        else
+            exit 2
+        fi
         ;;
     __migration-v062-inspect)
-        if [ '$capability' = timeout ]; then
-            printf '%s\n' "\$\$" > '${log}.pid'
-            exec /usr/bin/sleep 30
+        if [ $capability_q = timeout ]; then
+            printf '%s\n' "\$BASHPID" > $log_pid_q
+            printf '%s\n' "\$BASHPID" >> $log_pids_q
+            trap 'exit 0' TERM INT
+            while :; do
+                /usr/bin/sleep 0.05 &
+                wait "\$!" || true
+            done
         fi
-        [ '$capability' = embedded ] || exit 2
+        case $capability_q in
+            embedded|lossy-*|active-config|late-active-config|symlink-dolt|symlink-database) ;;
+            *) exit 2 ;;
+        esac
         [ "\$#" -eq 4 ] && [ "\$2" = --workspace ] &&
             [[ "\$3" = /* ]] && [ "\$4" = --json ] || exit 2
         inspection_code=
@@ -74,6 +401,9 @@ case "\${1:-}" in
             wrong-metadata) inspection_code=source_metadata_mismatch ;;
             symlink-layout) inspection_code=unsafe_source_symlink ;;
             mixed-target) inspection_code=mixed_storage_layout ;;
+            routing-env|routing-redirect)
+                inspection_code=source_routing_unsupported
+                ;;
             rollback-collision) inspection_code=rollback_collision ;;
             lying-workspace)
                 qualified_workspace=/not/the/requested/workspace
@@ -103,11 +433,279 @@ case "\${1:-}" in
             printf '{"schema_version":1,"operation":"v062_source_inspection","status":"refused","retryable":%s,"effect":"none","code":"%s"}\n' "\$inspection_retryable" "\$inspection_code"
             exit "\$inspection_exit"
         fi
-        printf '{"schema_version":1,"operation":"v062_source_inspection","status":"qualified","retryable":false,"effect":"none","source":{"workspace":"%s","version":"0.62.0","backend":"dolt-server","tree_sha256":"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef","digest_scope":"%s"},"target":{"version":"%s","backend":"dolt-embedded","embedded_capable":true}}\n' "\$qualified_workspace" "\$qualified_digest_scope" '$version'
+        qualified_digest=\$(
+            cd "\$3/.beads" &&
+                {
+                    find -P . -maxdepth 0 -printf '%y %m %p %l\n'
+                    find -P . -mindepth 1 -printf '%y %m %p %l\n' |
+                        LC_ALL=C sort
+                    find -P . -type f -print0 | LC_ALL=C sort -z |
+                        xargs -0 -r sha256sum
+                } | sha256sum | awk '{print \$1}'
+        ) || exit 2
+        printf '{"schema_version":1,"operation":"v062_source_inspection","status":"qualified","retryable":false,"effect":"none","source":{"workspace":"%s","version":"0.62.0","backend":"dolt-server","database":"smoke","project_id":"7ef372b4-4c3c-4e2c-a6cc-29dd2d0a28c6","tree_sha256":"%s","digest_scope":"%s"},"target":{"version":"%s","backend":"dolt-embedded","embedded_capable":true}}\n' "\$qualified_workspace" "\$qualified_digest" "\$qualified_digest_scope" $version_q
         if \$repeat_qualified; then
-            printf '{"schema_version":1,"operation":"v062_source_inspection","status":"qualified","retryable":false,"effect":"none","source":{"workspace":"%s","version":"0.62.0","backend":"dolt-server","tree_sha256":"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef","digest_scope":"%s"},"target":{"version":"%s","backend":"dolt-embedded","embedded_capable":true}}\n' "\$qualified_workspace" "\$qualified_digest_scope" '$version'
+            printf '{"schema_version":1,"operation":"v062_source_inspection","status":"qualified","retryable":false,"effect":"none","source":{"workspace":"%s","version":"0.62.0","backend":"dolt-server","database":"smoke","project_id":"7ef372b4-4c3c-4e2c-a6cc-29dd2d0a28c6","tree_sha256":"%s","digest_scope":"%s"},"target":{"version":"%s","backend":"dolt-embedded","embedded_capable":true}}\n' "\$qualified_workspace" "\$qualified_digest" "\$qualified_digest_scope" $version_q
         fi
         exit "\$qualified_exit"
+        ;;
+    init)
+        case $capability_q in
+            embedded|lossy-*|active-config|late-active-config|symlink-dolt|symlink-database) ;;
+            *) exit 2 ;;
+        esac
+        # The fake must not manufacture an embedded target unless production
+        # explicitly selected it. A permissive init fake would let ambient or
+        # server-provider routing pass while the test still observed Dolt. It
+        # also requires the authenticated source identity to be explicit: a
+        # default prefix, database, or newly minted project ID is data drift.
+        backend_count=0
+        prefix_count=0
+        database_count=0
+        project_id_count=0
+        repository_root_count=0
+        prefix=
+        database=
+        project_id=
+        repository_root=
+        shift
+        while [ "\$#" -gt 0 ]; do
+            case "\$1" in
+                --backend=dolt)
+                    backend_count=\$((backend_count + 1))
+                    shift
+                    ;;
+                --backend|--backend=*) exit 2 ;;
+                --server|--shared-server|--external|--server-*) exit 2 ;;
+                --prefix)
+                    [ "\$#" -ge 2 ] || exit 2
+                    prefix_count=\$((prefix_count + 1))
+                    prefix="\$2"
+                    shift 2
+                    ;;
+                --prefix=*) exit 2 ;;
+                --database)
+                    [ "\$#" -ge 2 ] || exit 2
+                    database_count=\$((database_count + 1))
+                    database="\$2"
+                    shift 2
+                    ;;
+                --database=*) exit 2 ;;
+                --migration-v062-project-id)
+                    [ "\$#" -ge 2 ] || exit 2
+                    project_id_count=\$((project_id_count + 1))
+                    project_id="\$2"
+                    shift 2
+                    ;;
+                --migration-v062-project-id=*) exit 2 ;;
+                --migration-v062-repository-root)
+                    [ "\$#" -ge 2 ] || exit 2
+                    repository_root_count=\$((repository_root_count + 1))
+                    repository_root="\$2"
+                    shift 2
+                    ;;
+                --migration-v062-repository-root=*) exit 2 ;;
+                --role)
+                    [ "\$#" -ge 2 ] && [ "\$2" = maintainer ] || exit 2
+                    shift 2
+                    ;;
+                --quiet|--non-interactive|--skip-agents|--skip-hooks)
+                    shift
+                    ;;
+                *) exit 2 ;;
+            esac
+        done
+        [ "\$backend_count" -eq 1 ] &&
+            [ "\$prefix_count" -eq 1 ] && [ "\$prefix" = legacy ] &&
+            [ "\$database_count" -eq 1 ] && [ "\$database" = smoke ] &&
+            [ "\$project_id_count" -eq 1 ] &&
+            [ "\$project_id" = 7ef372b4-4c3c-4e2c-a6cc-29dd2d0a28c6 ] &&
+            [ "\$repository_root_count" -eq 1 ] &&
+            [[ "\$repository_root" = /* ]] &&
+            [ -d "\$repository_root/.git" ] || exit 2
+        mkdir -p "\$PWD/.beads/embeddeddolt/\$database/.dolt"
+        printf '%s\n' \
+            '{"database":"dolt","backend":"dolt","dolt_mode":"embedded","dolt_database":"smoke","project_id":"7ef372b4-4c3c-4e2c-a6cc-29dd2d0a28c6"}' \
+            > "\$PWD/.beads/metadata.json"
+        printf '%s\n' \
+            '{"issue_prefix":"legacy","_project_id":"7ef372b4-4c3c-4e2c-a6cc-29dd2d0a28c6"}' \
+            > "\$PWD/.beads/fake-target-config.json"
+        if [ $capability_q = embedded ]; then
+            printf '%s\n' '# comment-only target config is inert' '' \
+                > "\$PWD/.beads/config.yaml"
+        elif [ $capability_q = active-config ]; then
+            printf '%s\n' 'dolt:' '  host: poison.invalid' '  port: 29998' \
+                > "\$PWD/.beads/config.yaml" || exit 2
+            printf '%s\n' $capability_q > $injection_marker_q || exit 2
+        elif [ $capability_q = symlink-dolt ]; then
+            mv -f -- "\$PWD/.beads/embeddeddolt/\$database/.dolt" \
+                "\$PWD/.beads/embeddeddolt/\$database/.dolt-real" || exit 2
+            ln -s .dolt-real \
+                "\$PWD/.beads/embeddeddolt/\$database/.dolt" || exit 2
+            printf '%s\n' $capability_q > $injection_marker_q || exit 2
+        elif [ $capability_q = symlink-database ]; then
+            mv -f -- "\$PWD/.beads/embeddeddolt/\$database" \
+                "\$PWD/.beads/embeddeddolt/\${database}-authentic" || exit 2
+            ln -s "\${database}-authentic" \
+                "\$PWD/.beads/embeddeddolt/\$database" || exit 2
+            printf '%s\n' $capability_q > $injection_marker_q || exit 2
+        fi
+        ;;
+    import)
+        case $capability_q in
+            embedded|lossy-*|active-config|late-active-config|symlink-dolt|symlink-database) ;;
+            *) exit 2 ;;
+        esac
+        input=
+        shift
+        while [ "\$#" -gt 0 ]; do
+            case "\$1" in
+                -i|--input)
+                    [ "\$#" -ge 2 ] || exit 2
+                    input="\$2"
+                    shift 2
+                    ;;
+                --input=*) input="\${1#*=}"; shift ;;
+                --*) shift ;;
+                *)
+                    [ -n "\$input" ] || input="\$1"
+                    shift
+                    ;;
+            esac
+        done
+        [ -n "\$input" ] && [ -f "\$input" ] || exit 2
+        case $capability_q in
+            lossy-dependency-created-at)
+                filter='.dependencies = ((.dependencies // []) | map(del(.created_at)))'
+                ;;
+            lossy-dependency-created-by)
+                filter='.dependencies = ((.dependencies // []) | map(del(.created_by)))'
+                ;;
+            lossy-comment-id)
+                filter='.comments = ((.comments // []) | map(del(.id)))'
+                ;;
+            lossy-comment-issue-id)
+                filter='.comments = ((.comments // []) | map(del(.issue_id)))'
+                ;;
+            lossy-comment-created-at)
+                filter='.comments = ((.comments // []) | map(del(.created_at)))'
+                ;;
+            *) filter= ;;
+        esac
+        if [ -n "\$filter" ]; then
+            /usr/bin/jq -c "\$filter" "\$input" \
+                > "\$PWD/.beads/fake-target-state.jsonl" || exit 2
+            printf '%s\n' $capability_q > $injection_marker_q || exit 2
+        else
+            cp -f -- "\$input" "\$PWD/.beads/fake-target-state.jsonl" ||
+                exit 2
+        fi
+        ;;
+    export)
+        case $capability_q in
+            embedded|lossy-*|active-config|late-active-config|symlink-dolt|symlink-database) ;;
+            *) exit 2 ;;
+        esac
+        output=
+        no_memories=false
+        shift
+        while [ "\$#" -gt 0 ]; do
+            case "\$1" in
+                -o|--output)
+                    [ "\$#" -ge 2 ] || exit 2
+                    output="\$2"
+                    shift 2
+                    ;;
+                --output=*) output="\${1#*=}"; shift ;;
+                --no-memories) no_memories=true; shift ;;
+                --*) shift ;;
+                *) shift ;;
+            esac
+        done
+        \$no_memories && [ -n "\$output" ] &&
+            [ -f "\$PWD/.beads/fake-target-state.jsonl" ] || exit 2
+        # Current bd export encodes parenthood through the parent-child
+        # dependency and does not repeat it in the legacy top-level parent
+        # projection. Model that real output shape so the bridge cannot pass
+        # only because its fake copied the import record byte-for-byte.
+        /usr/bin/jq -c 'del(.parent)' \
+            "\$PWD/.beads/fake-target-state.jsonl" > "\$output" || exit 2
+        if [ $capability_q = late-active-config ]; then
+            printf '%s\n' 'dolt:' '  host: poison.invalid' '  port: 29998' \
+                > "\$PWD/.beads/config.yaml" || exit 2
+            printf '%s\n' $capability_q > $injection_marker_q || exit 2
+        fi
+        printf '%s\n' $capability_q > $export_marker_q || exit 2
+        ;;
+    list)
+        case $capability_q in
+            embedded|lossy-*|active-config|late-active-config|symlink-dolt|symlink-database) ;;
+            *) exit 2 ;;
+        esac
+        [ "\$#" -eq 5 ] && [ "\$2" = --json ] &&
+            [ "\$3" = --all ] && [ "\$4" = -n ] &&
+            [ "\$5" = 0 ] || exit 2
+        [ -f "\$PWD/.beads/fake-target-state.jsonl" ] || exit 1
+        /usr/bin/jq -s '.' "\$PWD/.beads/fake-target-state.jsonl"
+        ;;
+    show)
+        case $capability_q in
+            embedded|lossy-*|active-config|late-active-config|symlink-dolt|symlink-database) ;;
+            *) exit 2 ;;
+        esac
+        [ "\$#" -eq 4 ] && [[ "\$2" == --id=* ]] &&
+            [ "\$3" = --json ] && [ "\$4" = --include-comments ] || exit 2
+        [ -f "\$PWD/.beads/fake-target-state.jsonl" ] || exit 1
+        wanted="\${2#*=}"
+        [ -n "\$wanted" ] || exit 2
+        /usr/bin/jq -s --arg id "\$wanted" \
+            '[.[] | select(.id == \$id)]' \
+            "\$PWD/.beads/fake-target-state.jsonl"
+        ;;
+    config)
+        case $capability_q in
+            embedded|lossy-*|active-config|late-active-config|symlink-dolt|symlink-database) ;;
+            *) exit 2 ;;
+        esac
+        [ "\$#" -eq 4 ] && [ "\$2" = get ] &&
+            [ "\$3" = issue_prefix ] && [ "\$4" = --json ] || exit 2
+        if [ -f "\$PWD/.beads/force-noop-lock-cleanup-failure" ] &&
+            [ -f "\$PWD/.beads/v062-migration-receipt.json" ] &&
+            [ -d "\$PWD/.beads-v0.62.0-migration.lock" ]; then
+            printf '%s\n' 'injected cleanup obstruction' \
+                > "\$PWD/.beads-v0.62.0-migration.lock/unexpected-entry"
+        fi
+        prefix=\$(/usr/bin/jq -er \
+            '.issue_prefix | select(type == "string" and length > 0)' \
+            "\$PWD/.beads/fake-target-config.json") || exit 1
+        /usr/bin/jq -cn --arg value "\$prefix" \
+            '{schema_version:1, key:"issue_prefix", value:\$value}'
+        ;;
+    create)
+        case $capability_q in
+            embedded|lossy-*|active-config|late-active-config|symlink-dolt|symlink-database) ;;
+            *) exit 2 ;;
+        esac
+        [ "\$#" -eq 3 ] && [ "\$2" = "Post-migration identity probe" ] &&
+            [ "\$3" = --json ] || exit 2
+        [ -f "\$PWD/.beads/metadata.json" ] &&
+            [ -f "\$PWD/.beads/fake-target-state.jsonl" ] || exit 1
+        prefix=\$(/usr/bin/jq -er \
+            '.issue_prefix | select(type == "string" and length > 0)' \
+            "\$PWD/.beads/fake-target-config.json") || exit 1
+        issue_id="\${prefix}-post-migration-1"
+        /usr/bin/jq -e --arg id "\$issue_id" \
+            'select(.id == \$id)' "\$PWD/.beads/fake-target-state.jsonl" \
+            >/dev/null 2>&1 && exit 1
+        record=\$(/usr/bin/jq -cn --arg id "\$issue_id" '
+            {
+                id: \$id, title: "Post-migration identity probe",
+                priority: 2, issue_type: "task", status: "open",
+                dependencies: [], comments: []
+            }
+        ') || exit 1
+        printf '%s\n' "\$record" >> "\$PWD/.beads/fake-target-state.jsonl"
+        printf '%s\n' "\$record"
         ;;
     *) exit 2 ;;
 esac
@@ -119,6 +717,240 @@ make_fake_bd "$TARGET_BD" 1.1.0 embedded "$TARGET_LOG"
 make_fake_bd "$OLD_TARGET_BD" 0.62.0 embedded "$OLD_TARGET_LOG"
 make_fake_bd "$INCAPABLE_TARGET_BD" 1.1.0 unavailable "$INCAPABLE_TARGET_LOG"
 make_fake_bd "$TIMEOUT_TARGET_BD" 1.1.0 timeout "$TIMEOUT_TARGET_LOG"
+for lossy_audit_field in \
+    dependency-created-at dependency-created-by \
+    comment-id comment-issue-id comment-created-at; do
+    make_fake_bd "$tmp/fake-bd-lossy-$lossy_audit_field-target" 1.1.0 \
+        "lossy-$lossy_audit_field" "$LOSSY_TARGET_LOG"
+done
+make_fake_bd "$ROUTED_TARGET_BD" 1.1.0 active-config "$ROUTED_TARGET_LOG"
+make_fake_bd "$LATE_ROUTED_TARGET_BD" 1.1.0 late-active-config \
+    "$LATE_ROUTED_TARGET_LOG"
+make_fake_bd "$SYMLINK_DOLT_TARGET_BD" 1.1.0 symlink-dolt \
+    "$SYMLINK_DOLT_TARGET_LOG"
+make_fake_bd "$SYMLINK_DATABASE_TARGET_BD" 1.1.0 symlink-database \
+    "$SYMLINK_DATABASE_TARGET_LOG"
+
+make_fake_source_bd() {
+    local path="$1" version="$2" log="$3"
+    local log_q version_q canonical_export_q unqualified_export_q
+    local unsupported_export_q nested_dependency_export_q canonical_show_q
+    local unqualified_show_q unsupported_show_q nested_comment_show_q
+    local source_audit_fixture_dir_q
+    printf -v log_q '%q' "$log"
+    printf -v version_q '%q' "$version"
+    printf -v canonical_export_q '%q' "$CANONICAL_EXPORT"
+    printf -v unqualified_export_q '%q' "$UNQUALIFIED_EXPORT"
+    printf -v unsupported_export_q '%q' "$UNSUPPORTED_EXPORT"
+    printf -v nested_dependency_export_q '%q' "$NESTED_DEPENDENCY_EXPORT"
+    printf -v canonical_show_q '%q' "$CANONICAL_SHOW"
+    printf -v unqualified_show_q '%q' "$UNQUALIFIED_SHOW"
+    printf -v unsupported_show_q '%q' "$UNSUPPORTED_SHOW"
+    printf -v nested_comment_show_q '%q' "$NESTED_COMMENT_SHOW"
+    printf -v source_audit_fixture_dir_q '%q' "$SOURCE_AUDIT_FIXTURE_DIR"
+    cat > "$path" <<EOF
+#!/usr/bin/env bash
+{
+    printf 'argv=%q' "\$0"
+    printf ' %q' "\$@"
+    printf '\n'
+    printf 'cwd=%q\n' "\$PWD"
+    env | LC_ALL=C sort
+} >> $log_q
+case "\${1:-}" in
+    version|--version)
+        if [ "\${2:-}" = --json ]; then
+            printf '{"version":"%s","build":"historical-test"}\n' $version_q
+        else
+            printf 'bd version %s\n' $version_q
+        fi
+        ;;
+    config)
+        [ "\$#" -eq 4 ] && [ "\$2" = get ] &&
+            [ "\$3" = issue_prefix ] && [ "\$4" = --json ] || exit 2
+        if [ -f "\$PWD/.beads/require-owned-source-route" ]; then
+            [ "\${BEADS_DOLT_SERVER_HOST:-}" = 127.0.0.1 ] &&
+                [ "\${BEADS_DOLT_SERVER_PORT:-}" = 3307 ] &&
+                [ "\${BEADS_DOLT_SERVER_DATABASE:-}" = smoke ] || exit 86
+        fi
+        source_prefix=legacy
+        if [ -f "\$PWD/.beads/source-prefix-dotted" ]; then
+            source_prefix=legacy.alpha
+        elif [ -f "\$PWD/.beads/source-prefix-trailing-hyphen" ]; then
+            source_prefix=legacy-
+        fi
+        printf '{"key":"issue_prefix","value":"%s"}\n' "\$source_prefix"
+        ;;
+    export)
+        if [ -f "\$PWD/.beads/require-owned-source-route" ]; then
+            [ "\${BEADS_DOLT_SERVER_HOST:-}" = 127.0.0.1 ] &&
+                [ "\${BEADS_DOLT_SERVER_PORT:-}" = 3307 ] &&
+                [ "\${BEADS_DOLT_SERVER_DATABASE:-}" = smoke ] || exit 86
+        fi
+        output=
+        shift
+        while [ "\$#" -gt 0 ]; do
+            case "\$1" in
+                -o|--output)
+                    [ "\$#" -ge 2 ] || exit 2
+                    output="\$2"
+                    shift 2
+                    ;;
+                --output=*) output="\${1#*=}"; shift ;;
+                *) shift ;;
+            esac
+        done
+        [ -n "\$output" ] || exit 2
+        if [ -f "\$PWD/.beads/unqualified-semantic-scope" ]; then
+            cp -f -- $unqualified_export_q "\$output"
+        elif [ -f "\$PWD/.beads/unsupported-semantic-scope" ]; then
+            cp -f -- $unsupported_export_q "\$output"
+        elif [ -f "\$PWD/.beads/nested-dependency-semantic-scope" ]; then
+            cp -f -- $nested_dependency_export_q "\$output"
+        elif [ -f "\$PWD/.beads/audit-source-dependency-created-at" ]; then
+            cp -f -- \
+                $source_audit_fixture_dir_q/dependency-created-at.jsonl \
+                "\$output"
+        elif [ -f "\$PWD/.beads/audit-source-dependency-created-by" ]; then
+            cp -f -- \
+                $source_audit_fixture_dir_q/dependency-created-by.jsonl \
+                "\$output"
+        else
+            cp -f -- $canonical_export_q "\$output"
+        fi
+        ;;
+    list)
+        if [ -f "\$PWD/.beads/unqualified-semantic-scope" ]; then
+            /usr/bin/jq -s '.' $unqualified_export_q
+        elif [ -f "\$PWD/.beads/unsupported-semantic-scope" ]; then
+            /usr/bin/jq -s '.' $unsupported_export_q
+        elif [ -f "\$PWD/.beads/nested-dependency-semantic-scope" ]; then
+            /usr/bin/jq -s '.' $nested_dependency_export_q
+        else
+            /usr/bin/jq -s '.' $canonical_export_q
+        fi
+        ;;
+    show)
+        if [ -f "\$PWD/.beads/require-owned-source-route" ]; then
+            [ "\${BEADS_DOLT_SERVER_HOST:-}" = 127.0.0.1 ] &&
+                [ "\${BEADS_DOLT_SERVER_PORT:-}" = 3307 ] &&
+                [ "\${BEADS_DOLT_SERVER_DATABASE:-}" = smoke ] || exit 86
+        fi
+        wanted=
+        show_fixture=$canonical_show_q
+        if [ -f "\$PWD/.beads/unqualified-semantic-scope" ]; then
+            show_fixture=$unqualified_show_q
+        elif [ -f "\$PWD/.beads/unsupported-semantic-scope" ]; then
+            show_fixture=$unsupported_show_q
+        elif [ -f "\$PWD/.beads/nested-comment-semantic-scope" ]; then
+            show_fixture=$nested_comment_show_q
+        elif [ -f "\$PWD/.beads/audit-source-comment-id" ]; then
+            show_fixture=$source_audit_fixture_dir_q/comment-id.json
+        elif [ -f "\$PWD/.beads/audit-source-comment-issue-id" ]; then
+            show_fixture=$source_audit_fixture_dir_q/comment-issue-id.json
+        elif [ -f "\$PWD/.beads/audit-source-comment-created-at" ]; then
+            show_fixture=$source_audit_fixture_dir_q/comment-created-at.json
+        fi
+        shift
+        while [ "\$#" -gt 0 ]; do
+            case "\$1" in
+                --id=*) wanted="\${1#*=}" ;;
+                --id) shift; wanted="\${1:-}" ;;
+                --json) ;;
+                --*) ;;
+                *) [ -n "\$wanted" ] || wanted="\$1" ;;
+            esac
+            shift
+        done
+        [ -n "\$wanted" ] || exit 2
+        /usr/bin/jq --arg id "\$wanted" \
+            '[.[] | select(.id == \$id)]' "\$show_fixture"
+        ;;
+    dolt)
+        [ "\${2:-}" = stop ] || exit 2
+        ;;
+    *) exit 2 ;;
+esac
+EOF
+    chmod +x "$path"
+}
+
+make_fake_source_dolt() {
+    local path="$1" version="$2" log="$3"
+    local log_q version_q log_pid_q log_pids_q
+    printf -v log_q '%q' "$log"
+    printf -v version_q '%q' "$version"
+    printf -v log_pid_q '%q' "${log}.pid"
+    printf -v log_pids_q '%q' "${log}.pids"
+    cat > "$path" <<EOF
+#!/usr/bin/env bash
+{
+    printf 'argv=%q' "\$0"
+    printf ' %q' "\$@"
+    printf '\n'
+    printf 'cwd=%q\n' "\$PWD"
+    env | LC_ALL=C sort
+} >> $log_q
+case "\${1:-}" in
+    init)
+        mkdir -p .dolt
+        printf '%s\n' '{"head":"refs/heads/main"}' > .dolt/repo_state.json
+        ;;
+    sql-server)
+        printf '%s\n' "\$BASHPID" > $log_pid_q
+        printf '%s\n' "\$BASHPID" >> $log_pids_q
+        trap 'exit 0' TERM INT
+        while :; do
+            /usr/bin/sleep 0.05 &
+            wait "\$!" || true
+        done
+        ;;
+    --host)
+        # Fake-only readiness transport: the bridge must still launch and own
+        # the sql-server child, then probe it through the pinned runtime. The
+        # official lane supplies the real checksum-pinned Dolt listener.
+        server_pid=\$(< $log_pid_q)
+        kill -0 "\$server_pid" 2>/dev/null || exit 2
+        [[ " \$* " == *" sql "* ]] || exit 2
+        if [[ " \$* " == *" SELECT value AS project_id FROM metadata"* ]] &&
+            [[ " \$* " == *"_project_id"* ]]; then
+            project_id=7ef372b4-4c3c-4e2c-a6cc-29dd2d0a28c6
+            if [ -f "\$PWD/.beads/database-project-id-mismatch" ]; then
+                project_id=00000000-0000-0000-0000-000000000000
+            fi
+            printf '{"rows":[{"project_id":"%s"}]}\n' "\$project_id"
+        else
+            [[ " \$* " == *" SELECT 1"* ]] || exit 2
+            printf '%s\n' '{"rows":[{"1":1}]}'
+        fi
+        ;;
+    version|--version)
+        printf 'dolt version %s\n' $version_q
+        ;;
+    *) exit 2 ;;
+esac
+EOF
+    chmod +x "$path"
+}
+
+make_fake_source_bd "$SOURCE_BD" 0.62.0 "$SOURCE_LOG"
+make_fake_source_bd "$BAD_SOURCE_BD" 0.61.0 "$BAD_SOURCE_LOG"
+make_fake_source_dolt "$SOURCE_DOLT" 1.84.0 "$SOURCE_DOLT_LOG"
+make_fake_source_dolt "$BAD_SOURCE_DOLT" 1.83.0 "$BAD_SOURCE_DOLT_LOG"
+
+make_executable_tripwire() {
+    local path="$1" label="$2" marker="$3"
+    local label_q marker_q replacement="${path}.replacement"
+    printf -v label_q '%q' "$label"
+    printf -v marker_q '%q' "$marker"
+    cat > "$replacement" <<EOF
+#!/usr/bin/env bash
+printf '%s\n' $label_q >> $marker_q
+exit 97
+EOF
+    chmod +x "$replacement"
+    mv -f -- "$replacement" "$path"
+}
 
 new_v062_workspace() {
     local ws="$1"
@@ -160,6 +992,34 @@ tree_fingerprint() {
     ) | sha256sum | awk '{print $1}'
 }
 
+# Content-only identity is used across the atomic source rename: inode and
+# ctime changes are irrelevant, but every file byte, mode, and symlink target
+# in the retained rollback must remain identical.
+content_fingerprint() {
+    local root="$1"
+    (
+        cd "$root"
+        find -P . -maxdepth 0 -printf '%y %m %p %l\n'
+        find -P . -mindepth 1 -printf '%y %m %p %l\n' | LC_ALL=C sort
+        find -P . -type f -print0 | LC_ALL=C sort -z | xargs -0 -r sha256sum
+    ) | sha256sum | awk '{print $1}'
+}
+
+assert_log_unpoisoned() {
+    local log="$1" peer="$2" poison
+    [ -s "$log" ] || fail "$peer was never invoked"
+    for poison in \
+        'BD_BACKEND=postgres' 'BD_DATABASE_BACKEND=mysql' \
+        'postgres://poison.invalid/beads' 'mysql://poison.invalid/beads' \
+        "$tmp/poison-beads" "$tmp/poison.sqlite" "$tmp/poison-dolt" \
+        'BEADS_DOLT_SERVER_MODE=1' 'BEADS_DOLT_SHARED_SERVER=1' \
+        'poison.invalid' 'BEADS_DOLT_SERVER_PORT=29999'; do
+        if grep -F -- "$poison" "$log" >/dev/null; then
+            fail "ambient provider selector reached $peer: $poison"
+        fi
+    done
+}
+
 RUN_STATUS=0
 RUN_STDOUT=""
 RUN_STDERR=""
@@ -172,7 +1032,11 @@ run_bridge() {
     (
         cd "$cwd"
         env -i \
-            "PATH=$PATH" "HOME=$tmp/home" "TMPDIR=$tmp" \
+            "PATH=$POISON_BIN:$PATH" "HOME=$tmp/home" "TMPDIR=$tmp" \
+            "BASH_ENV=$POISON_BASH_ENV" SHELLOPTS=xtrace \
+            "GIT_DIR=$POISON_GIT_DIR" \
+            "GIT_WORK_TREE=$POISON_GIT_WORK_TREE" \
+            "GIT_TEMPLATE_DIR=$POISON_GIT_TEMPLATE" \
             LANG=C LC_ALL=C TZ=UTC TERM=dumb \
             BD_BACKEND=postgres BD_DATABASE_BACKEND=mysql \
             BEADS_DB='postgres://poison.invalid/beads' \
@@ -184,6 +1048,15 @@ run_bridge() {
             BEADS_DOLT_SERVER_HOST=poison.invalid \
             BEADS_DOLT_SERVER_PORT=29999 \
             "BD_V062_INSPECT_TIMEOUT_SECONDS=${BRIDGE_TEST_INSPECT_TIMEOUT_SECONDS:-600}" \
+            "BD_V062_TEST_FAILPOINT=${BRIDGE_TEST_FAILPOINT:-}" \
+            "BD_V062_TEST_PHASE_DIR=${BRIDGE_TEST_PHASE_DIR:-}" \
+            "BD_V062_TEST_FINGERPRINT_FAILURE=${BRIDGE_TEST_FINGERPRINT_FAILURE:-}" \
+            "BD_V062_TEST_MV_MODE=${BRIDGE_TEST_MV_MODE:-}" \
+            "BD_V062_TEST_RUNTIME_UNKNOWN_ENTRY=${BRIDGE_TEST_RUNTIME_UNKNOWN_ENTRY:-}" \
+            "BD_V062_TEST_IDENTITY_PROBE_FAILURE=${BRIDGE_TEST_IDENTITY_PROBE_FAILURE:-}" \
+            "BD_V062_TEST_GUARDIAN_START_FAILURE=${BRIDGE_TEST_GUARDIAN_START_FAILURE:-}" \
+            "BD_V062_TEST_MV_BIN=${BRIDGE_TEST_MV_BIN:-}" \
+            /usr/bin/timeout --kill-after=5s 180s \
             "$BRIDGE" --target-bd "$target" --json "$@" \
             </dev/null >"$out" 2>"$err"
     )
@@ -191,6 +1064,293 @@ run_bridge() {
     set -e
     RUN_STDOUT=$(<"$out")
     RUN_STDERR=$(<"$err")
+}
+
+ASYNC_BRIDGE_PID=""
+ASYNC_BRIDGE_OUT=""
+ASYNC_BRIDGE_ERR=""
+JOURNAL_ZOMBIE_HOLDER_PID=""
+JOURNAL_ZOMBIE_OWNER_PID=""
+WORKSPACE_LOCK_TEST_IDENTITY_FILE=""
+GUARDIAN_TEST_PHASE_DIR=""
+
+capture_async_bridge_output() {
+    if [ -f "$ASYNC_BRIDGE_OUT" ]; then
+        RUN_STDOUT=$(<"$ASYNC_BRIDGE_OUT")
+    else
+        RUN_STDOUT=""
+    fi
+    if [ -f "$ASYNC_BRIDGE_ERR" ]; then
+        RUN_STDERR=$(<"$ASYNC_BRIDGE_ERR")
+    else
+        RUN_STDERR=""
+    fi
+}
+
+start_bridge_at_phase() {
+    local label="$1" cwd="$2"
+    shift 2
+    local target="${BRIDGE_TEST_TARGET:-$TARGET_BD}"
+    [ -n "${BRIDGE_TEST_PHASE_DIR:-}" ] ||
+        fail "$label has no phase-handshake directory"
+    ASYNC_BRIDGE_OUT="$tmp/$label.stdout"
+    ASYNC_BRIDGE_ERR="$tmp/$label.stderr"
+    RUN_STATUS=0
+    RUN_STDOUT=""
+    RUN_STDERR=""
+    (
+        cd "$cwd"
+        exec env -i \
+            "PATH=$POISON_BIN:$PATH" "HOME=$tmp/home" "TMPDIR=$tmp" \
+            "BASH_ENV=$POISON_BASH_ENV" SHELLOPTS=xtrace \
+            "GIT_DIR=$POISON_GIT_DIR" \
+            "GIT_WORK_TREE=$POISON_GIT_WORK_TREE" \
+            "GIT_TEMPLATE_DIR=$POISON_GIT_TEMPLATE" \
+            LANG=C LC_ALL=C TZ=UTC TERM=dumb \
+            BD_BACKEND=postgres BD_DATABASE_BACKEND=mysql \
+            BEADS_DB='postgres://poison.invalid/beads' \
+            BD_DB='mysql://poison.invalid/beads' \
+            BEADS_DIR="$tmp/poison-beads" \
+            BEADS_SQLITE_PATH="$tmp/poison.sqlite" \
+            BEADS_DOLT_SERVER_MODE=1 BEADS_DOLT_SHARED_SERVER=1 \
+            BEADS_DOLT_DATA_DIR="$tmp/poison-dolt" \
+            BEADS_DOLT_SERVER_HOST=poison.invalid \
+            BEADS_DOLT_SERVER_PORT=29999 \
+            "BD_V062_INSPECT_TIMEOUT_SECONDS=${BRIDGE_TEST_INSPECT_TIMEOUT_SECONDS:-600}" \
+            "BD_V062_TEST_FAILPOINT=${BRIDGE_TEST_FAILPOINT:-}" \
+            "BD_V062_TEST_PHASE_DIR=$BRIDGE_TEST_PHASE_DIR" \
+            "BD_V062_TEST_FINGERPRINT_FAILURE=${BRIDGE_TEST_FINGERPRINT_FAILURE:-}" \
+            "BD_V062_TEST_MV_MODE=${BRIDGE_TEST_MV_MODE:-}" \
+            "BD_V062_TEST_RUNTIME_UNKNOWN_ENTRY=${BRIDGE_TEST_RUNTIME_UNKNOWN_ENTRY:-}" \
+            "BD_V062_TEST_IDENTITY_PROBE_FAILURE=${BRIDGE_TEST_IDENTITY_PROBE_FAILURE:-}" \
+            "BD_V062_TEST_GUARDIAN_START_FAILURE=${BRIDGE_TEST_GUARDIAN_START_FAILURE:-}" \
+            "BD_V062_TEST_MV_BIN=${BRIDGE_TEST_MV_BIN:-}" \
+            "$BRIDGE" --target-bd "$target" --json "$@" \
+            </dev/null >"$ASYNC_BRIDGE_OUT" 2>"$ASYNC_BRIDGE_ERR"
+    ) &
+    ASYNC_BRIDGE_PID=$!
+}
+
+finish_phase_bridge() {
+    local context="${1:-phase bridge}" pid attempt
+    [ -n "$ASYNC_BRIDGE_PID" ] || fail "no phase bridge is running"
+    pid="$ASYNC_BRIDGE_PID"
+    for ((attempt = 0; attempt < 1200; attempt++)); do
+        pid_is_running "$pid" || break
+        sleep 0.025
+    done
+    if pid_is_running "$pid"; then
+        terminate_pid_bounded "$pid" || true
+        capture_async_bridge_output
+        ASYNC_BRIDGE_PID=""
+        fail "$context did not exit within 30 seconds after phase release: stdout=$RUN_STDOUT stderr=$RUN_STDERR"
+    fi
+    set +e
+    wait "$pid"
+    RUN_STATUS=$?
+    set -e
+    ASYNC_BRIDGE_PID=""
+    capture_async_bridge_output
+}
+
+abort_phase_bridge() {
+    if [ -n "$ASYNC_BRIDGE_PID" ]; then
+        terminate_pid_bounded "$ASYNC_BRIDGE_PID" || true
+        ASYNC_BRIDGE_PID=""
+        capture_async_bridge_output
+    fi
+}
+
+hard_kill_phase_bridge() {
+    local context="${1:-phase bridge}" pid
+    [ -n "$ASYNC_BRIDGE_PID" ] || fail "no phase bridge is running"
+    pid="$ASYNC_BRIDGE_PID"
+    kill -KILL -- "$pid" 2>/dev/null || true
+    set +e
+    wait "$pid" 2>/dev/null
+    RUN_STATUS=$?
+    set -e
+    ASYNC_BRIDGE_PID=""
+    capture_async_bridge_output
+    [ "$RUN_STATUS" -eq 137 ] ||
+        fail "$context exit=$RUN_STATUS after SIGKILL, want 137: $RUN_STDOUT $RUN_STDERR"
+}
+
+replace_journal_owner_with_zombie() {
+    local journal="$1" pid_file="$tmp/journal-zombie-owner.pid"
+    local attempt stat rest state="" start_time boot_id temporary
+    command -v perl >/dev/null || fail "perl is required for zombie-owner coverage"
+    rm -f -- "$pid_file"
+    /usr/bin/perl -e '
+        my ($pid_file) = @ARGV;
+        my $child = fork();
+        die "fork failed" unless defined $child;
+        exit 0 unless $child;
+        open my $fh, ">", $pid_file or die "open pid file: $!";
+        print {$fh} "$child\n";
+        close $fh or die "close pid file: $!";
+        $SIG{TERM} = sub { exit 0 };
+        sleep 600;
+    ' "$pid_file" &
+    JOURNAL_ZOMBIE_HOLDER_PID=$!
+    for ((attempt = 0; attempt < 400; attempt++)); do
+        if [ -s "$pid_file" ]; then
+            JOURNAL_ZOMBIE_OWNER_PID=$(<"$pid_file")
+            stat=$(/usr/bin/cat -- "/proc/$JOURNAL_ZOMBIE_OWNER_PID/stat" \
+                2>/dev/null) || stat=""
+            if [ -n "$stat" ]; then
+                rest=${stat##*) }
+                read -r -a fields <<< "$rest"
+                state=${fields[0]:-}
+                start_time=${fields[19]:-}
+                [ "$state" = Z ] && [ -n "$start_time" ] && break
+            fi
+        fi
+        sleep 0.025
+    done
+    [ "$state" = Z ] && [[ "$start_time" =~ ^[0-9]+$ ]] ||
+        fail "could not create an unreaped journal-owner zombie"
+    boot_id=$(/usr/bin/cat -- /proc/sys/kernel/random/boot_id) ||
+        fail "could not read boot ID for zombie-owner coverage"
+    temporary="${journal}.zombie-owner"
+    jq --argjson pid "$JOURNAL_ZOMBIE_OWNER_PID" \
+        --arg start_time "$start_time" --arg boot_id "$boot_id" '
+        .owner.pid = $pid |
+        .owner.start_time = $start_time |
+        .owner.boot_id = $boot_id
+    ' "$journal" > "$temporary" || fail "could not stage zombie owner journal"
+    chmod 600 "$temporary"
+    mv -f -- "$temporary" "$journal"
+}
+
+stop_journal_owner_zombie() {
+    if [ -n "$JOURNAL_ZOMBIE_HOLDER_PID" ]; then
+        kill -TERM -- "$JOURNAL_ZOMBIE_HOLDER_PID" 2>/dev/null || true
+        wait "$JOURNAL_ZOMBIE_HOLDER_PID" 2>/dev/null || true
+        JOURNAL_ZOMBIE_HOLDER_PID=""
+        JOURNAL_ZOMBIE_OWNER_PID=""
+    fi
+}
+
+last_private_runtime_from_log() {
+    local log="$1" runtime
+    runtime=$(sed -n \
+        's|^argv=\(.*\)/source-bd version --json$|\1|p' \
+        "$log" 2>/dev/null | tail -1) || runtime=""
+    [ -n "$runtime" ] || return 1
+    [[ "$runtime" = /* ]] || return 1
+    printf '%s\n' "$runtime"
+}
+
+last_clean_home_from_log() {
+    local log="$1" home
+    home=$(sed -n 's|^HOME=\(/[^[:space:]]*\)$|\1|p' \
+        "$log" 2>/dev/null | tail -1) || home=""
+    [ -n "$home" ] || return 1
+    printf '%s\n' "$home"
+}
+
+last_source_copy_from_log() {
+    local log="$1" source_copy
+    source_copy=$(sed -n 's|^cwd=\(/[^[:space:]]*\)$|\1|p' \
+        "$log" 2>/dev/null | tail -1) || source_copy=""
+    [ -n "$source_copy" ] || return 1
+    printf '%s\n' "$source_copy"
+}
+
+last_semantic_probe_from_log() {
+    local log="$1" probe
+    probe=$(sed -n \
+        's|^argv=.* import -i \(/[^[:space:]]*\) --json$|\1|p' \
+        "$log" 2>/dev/null | tail -1) || probe=""
+    [ -n "$probe" ] || return 1
+    printf '%s\n' "$probe"
+}
+
+wait_for_path_absence() {
+    local path="$1" context="$2" attempt
+    for ((attempt = 0; attempt < 400; attempt++)); do
+        if [ ! -e "$path" ] && [ ! -L "$path" ]; then
+            return 0
+        fi
+        sleep 0.025
+    done
+    fail "$context was not removed within 10 seconds: $path"
+}
+
+assert_last_private_runtime_removed() {
+    local log="$1" context="$2" runtime
+    runtime=$(last_private_runtime_from_log "$log") ||
+        fail "$context did not expose its authenticated runtime root"
+    wait_for_path_absence "$runtime" "$context runtime root"
+}
+
+assert_no_workspace_runtime_artifacts() {
+    local ws="$1" context="$2" artifact attempt
+    for ((attempt = 0; attempt < 400; attempt++)); do
+        artifact=$(find -P "$ws" -mindepth 1 -maxdepth 1 \
+            -name '.beads-v0.62.0-migration.runtime.*' -print -quit) ||
+            fail "$context runtime-artifact scan failed"
+        [ -n "$artifact" ] || return 0
+        sleep 0.025
+    done
+    fail "$context left a workspace runtime artifact: $artifact"
+}
+
+assert_scratch_is_beneath_runtime() {
+    local runtime="$1" path="$2" label="$3"
+    case "$path" in
+        "$runtime"/*) ;;
+        *) fail "$label escaped the authenticated runtime root: $path" ;;
+    esac
+}
+
+release_transaction_gap_phases() {
+    local phase_dir="$1"
+    touch \
+        "$phase_dir/after_operation_bundle_prepared_before_fence_publish.continue" \
+        "$phase_dir/after_staging_publish_before_journal_update.continue" \
+        "$phase_dir/after_operation_fence_retired_before_private_cleanup.continue"
+}
+
+phase_marker_state() {
+    local phase_dir="$1" marker state=""
+    for marker in "$phase_dir"/*; do
+        [ -f "$marker" ] || continue
+        state+="${state:+,}${marker##*/}"
+    done
+    printf '%s\n' "${state:-none}"
+}
+
+wait_for_phase() {
+    local phase_dir="$1" phase="$2" context="$3" attempt markers
+    for ((attempt = 0; attempt < 400; attempt++)); do
+        [ -f "$phase_dir/$phase.reached" ] && return 0
+        if ! pid_is_running "$ASYNC_BRIDGE_PID" ||
+            [ -s "$ASYNC_BRIDGE_OUT" ]; then
+            finish_phase_bridge "$context"
+            fail "$context exited before phase $phase: $RUN_STDOUT $RUN_STDERR"
+        fi
+        sleep 0.025
+    done
+    markers=$(phase_marker_state "$phase_dir")
+    abort_phase_bridge
+    fail "$context did not reach phase $phase within 10 seconds: markers=$markers stdout=$RUN_STDOUT stderr=$RUN_STDERR"
+}
+
+wait_for_guardian_marker() {
+    local phase_dir="$1" marker="$2" context="$3" attempt markers
+    for ((attempt = 0; attempt < 400; attempt++)); do
+        [ -f "$phase_dir/$marker" ] && return 0
+        if ! pid_is_running "$ASYNC_BRIDGE_PID"; then
+            finish_phase_bridge "$context"
+            fail "$context exited before guardian marker $marker: $RUN_STDOUT $RUN_STDERR"
+        fi
+        sleep 0.025
+    done
+    markers=$(phase_marker_state "$phase_dir")
+    abort_phase_bridge
+    fail "$context did not emit guardian marker $marker within 10 seconds: markers=$markers stdout=$RUN_STDOUT stderr=$RUN_STDERR"
 }
 
 run_apply_without_yes_on_tty() {
@@ -215,7 +1375,8 @@ assert_common_json() {
             (.retryable | type) == "boolean" and .effect == $effect and
             (keys - ["schema_version", "operation", "mode", "status",
                      "retryable", "effect", "code", "source", "target",
-                     "rollback", "verification"] | length) == 0
+                     "plan", "rollback", "verification", "no_op"] |
+                length) == 0
         )
     ' <<< "$RUN_STDOUT" >/dev/null ||
         fail "invalid JSON contract for $mode/$status: $RUN_STDOUT $RUN_STDERR"
@@ -227,16 +1388,16 @@ assert_unchanged() {
         fail "$context mutated the workspace"
 }
 
-# Default mode is inspect. It can report the target-qualified source plan but
-# must not claim the bridge is ready until the public apply path exists.
+# Default mode can qualify the source layout without executing historical
+# tools, but it must accurately explain what is required for a bindable plan.
 inspect_ws="$tmp/inspect-default"
 new_v062_workspace "$inspect_ws"
 inspect_before=$(tree_fingerprint "$inspect_ws")
 run_bridge inspect-default "$inspect_ws"
 [ "$RUN_STATUS" -eq 1 ] || fail "default inspect exit=$RUN_STATUS, want 1"
-assert_common_json inspect failed none
+assert_common_json inspect refused none
 jq -e '
-    .retryable == false and .code == "apply_not_available" and
+    .retryable == false and .code == "source_tools_required" and
     .source.version == "0.62.0" and .source.backend == "dolt-server" and
     .source.digest_scope == "admission_observation" and
     (.source.tree_sha256 | test("^[0-9a-f]{64}$")) and
@@ -244,7 +1405,8 @@ jq -e '
     (.rollback | type) == "object" and
     .verification.source_digest_scope == "admission_observation" and
     .verification.apply_reinspection_required == true and
-    .verification.apply_available == false and
+    .verification.apply_available == true and
+    .verification.apply_requires_pinned_source_tools == true and
     .verification.workspace_effects == false
 ' <<< "$RUN_STDOUT" >/dev/null || fail "default inspect omitted its qualified plan"
 default_json=$(jq -Sc . <<< "$RUN_STDOUT")
@@ -252,7 +1414,7 @@ assert_unchanged "$inspect_ws" "$inspect_before" "default inspect"
 
 run_bridge inspect-explicit "$inspect_ws" --inspect --workspace "$inspect_ws"
 [ "$RUN_STATUS" -eq 1 ] || fail "explicit inspect exit=$RUN_STATUS, want 1"
-assert_common_json inspect failed none
+assert_common_json inspect refused none
 [ "$(jq -Sc . <<< "$RUN_STDOUT")" = "$default_json" ] ||
     fail "default and explicit inspect returned different JSON contracts"
 assert_unchanged "$inspect_ws" "$inspect_before" "explicit inspect"
@@ -262,7 +1424,8 @@ assert_unchanged "$inspect_ws" "$inspect_before" "explicit inspect"
 [ -s "$TARGET_LOG" ] || fail "inspect did not validate the target binary"
 grep -F -- '__migration-v062-inspect' "$TARGET_LOG" >/dev/null ||
     fail "public inspect did not use the target hidden inspection command"
-grep -F -- "--workspace $inspect_ws --json" "$TARGET_LOG" >/dev/null ||
+printf -v inspect_ws_log_q '%q' "$inspect_ws"
+grep -F -- "--workspace $inspect_ws_log_q --json" "$TARGET_LOG" >/dev/null ||
     fail "target hidden inspection did not receive the physical workspace"
 for poison in \
     'BD_BACKEND=postgres' 'BD_DATABASE_BACKEND=mysql' \
@@ -365,6 +1528,18 @@ mixed_ws="$tmp/mixed-target"; new_v062_workspace "$mixed_ws"
 mkdir -p "$mixed_ws/.beads/embeddeddolt"
 assert_refused mixed-target "$mixed_ws" mixed_storage_layout
 
+routing_env_ws="$tmp/routing-env"; new_v062_workspace "$routing_env_ws"
+printf '%s\n' 'BEADS_DOLT_SERVER_HOST=poison.invalid' \
+    > "$routing_env_ws/.beads/.env"
+assert_refused routing-env "$routing_env_ws" source_routing_unsupported
+
+routing_redirect_ws="$tmp/routing-redirect"
+new_v062_workspace "$routing_redirect_ws"
+printf '%s\n' '../poison-routing/.beads' \
+    > "$routing_redirect_ws/.beads/redirect"
+assert_refused routing-redirect "$routing_redirect_ws" \
+    source_routing_unsupported
+
 collision_ws="$tmp/rollback-collision"; new_v062_workspace "$collision_ws"
 mkdir -p "$collision_ws/.beads-v0.62.0-rollback"
 printf 'unrelated retained data\n' > "$collision_ws/.beads-v0.62.0-rollback/sentinel"
@@ -429,8 +1604,9 @@ if kill -0 "$timeout_target_pid" 2>/dev/null; then
 fi
 assert_unchanged "$timeout_ws" "$timeout_before" "target timeout refusal"
 
-# Apply always requires explicit consent, even on a terminal, and every
-# currently admitted apply remains truthfully unavailable and non-mutating.
+# Apply always requires explicit consent, even on a terminal. Once consent is
+# present, a blocking apply still requires the exact inspect-generated plan
+# before source/runtime validation or any workspace effect.
 apply_ws="$tmp/apply-without-consent"; new_v062_workspace "$apply_ws"
 apply_before=$(tree_fingerprint "$apply_ws")
 run_bridge apply-without-consent "$apply_ws" --apply --workspace "$apply_ws"
@@ -444,17 +1620,14 @@ run_apply_without_yes_on_tty "$apply_ws"
 [ "$RUN_STATUS" -eq 2 ] || fail "TTY apply without --yes exit=$RUN_STATUS, want 2"
 assert_unchanged "$apply_ws" "$apply_before" "TTY apply without --yes"
 
-run_bridge apply-unavailable "$apply_ws" --apply --yes --workspace "$apply_ws"
-[ "$RUN_STATUS" -eq 1 ] || fail "apply --yes exit=$RUN_STATUS, want 1"
-assert_common_json apply failed none
-jq -e '.retryable == false and .code == "apply_not_available"' \
-    <<< "$RUN_STDOUT" >/dev/null || fail "apply --yes overstated bridge availability"
-jq -e '
-    .verification.source_digest_scope == "admission_observation" and
-    .verification.apply_reinspection_required == true
-' <<< "$RUN_STDOUT" >/dev/null ||
-    fail "apply --yes omitted its mandatory source reinspection contract"
-assert_unchanged "$apply_ws" "$apply_before" "unavailable apply"
+run_bridge apply-plan-required "$apply_ws" --apply --yes --workspace "$apply_ws"
+[ "$RUN_STATUS" -eq 2 ] ||
+    fail "apply --yes without plan exit=$RUN_STATUS, want usage exit 2: $RUN_STDOUT"
+assert_common_json apply usage_error none
+jq -e '.retryable == false and .code == "plan_required"' \
+    <<< "$RUN_STDOUT" >/dev/null ||
+    fail "apply --yes without --expect-plan lacked plan_required: $RUN_STDOUT"
+assert_unchanged "$apply_ws" "$apply_before" "apply without expected plan"
 
 # JSON is bootstrapped before ordinary parsing: even when --json follows an
 # invalid flag, the result is one structured usage error and no effects.
@@ -482,6 +1655,9 @@ assert_usage_error conflicting-modes invalid_usage --inspect --apply
 assert_usage_error inspect-with-yes invalid_usage --inspect --yes
 assert_usage_error workspace-missing-value invalid_usage --workspace
 assert_usage_error target-missing-value invalid_usage --target-bd
+assert_usage_error source-bd-missing-value invalid_usage --source-bd
+assert_usage_error source-dolt-missing-value invalid_usage --source-dolt
+assert_usage_error expect-plan-missing-value invalid_usage --expect-plan
 
 for invalid_timeout in \
     0 \
@@ -581,9 +1757,9 @@ BRIDGE_TEST_TARGET="$REAL_TARGET_BD" \
         --inspect --workspace "$real_ws"
 [ "$RUN_STATUS" -eq 1 ] ||
     fail "real current target exit=$RUN_STATUS, want fail-closed exit 1"
-assert_common_json inspect failed none
+assert_common_json inspect refused none
 jq -e --arg workspace "$real_ws" --arg digest "$hidden_real_digest" '
-    .retryable == false and .code == "apply_not_available" and
+    .retryable == false and .code == "source_tools_required" and
     .source.workspace == $workspace and .source.version == "0.62.0" and
     .source.backend == "dolt-server" and
     .source.digest_scope == "admission_observation" and
@@ -640,5 +1816,2288 @@ real_mixed_ws="$tmp/real-current-mixed"
 new_v062_workspace "$real_mixed_ws"
 printf 'sqlite-like bytes\n' > "$real_mixed_ws/.beads/beads.db"
 assert_real_target_refused real-current-mixed "$real_mixed_ws" mixed_storage_layout
+
+for routing_artifact in env redirect; do
+    routing_label="real-routing-$routing_artifact"
+    routing_ws="$tmp/$routing_label"
+    new_v062_workspace "$routing_ws"
+    case "$routing_artifact" in
+        env)
+            printf '%s\n' \
+                'BEADS_DOLT_SERVER_HOST=poison.invalid' \
+                'BEADS_DOLT_SERVER_PORT=29999' \
+                > "$routing_ws/.beads/.env"
+            ;;
+        redirect)
+            printf '%s\n' '../poison-routing/.beads' \
+                > "$routing_ws/.beads/redirect"
+            ;;
+    esac
+    routing_before=$(tree_fingerprint "$routing_ws")
+    BRIDGE_TEST_TARGET="$REAL_TARGET_BD" \
+        run_bridge "$routing_label" "$routing_ws" \
+            --inspect --workspace "$routing_ws"
+    [ "$RUN_STATUS" -eq 1 ] ||
+        fail "$routing_label exit=$RUN_STATUS, want refusal exit 1"
+    assert_common_json inspect refused none
+    jq -e '
+        .retryable == false and .code == "source_routing_unsupported"
+    ' <<< "$RUN_STDOUT" >/dev/null ||
+        fail "$routing_label did not reject project-local routing state"
+    assert_unchanged "$routing_ws" "$routing_before" "$routing_label refusal"
+done
+
+# Effectful walking-skeleton contract. Admission-only inspect above remains
+# fail-closed for callers that have not supplied pinned historical tools. A
+# bindable plan is available only when the exact source bd and Dolt runtime are
+# explicit inputs; apply repeats those identities and the plan digest.
+EFFECTFUL_PLAN=""
+inspect_effectful_plan() {
+    local label="$1" ws="$2" source_bd="$3" source_dolt="$4" target_bd="$5"
+    local before source_sha runtime_sha target_sha
+    before=$(tree_fingerprint "$ws")
+    BRIDGE_TEST_TARGET="$target_bd" \
+        run_bridge "$label" "$ws" \
+            --inspect --workspace "$ws" \
+            --source-bd "$source_bd" --source-dolt "$source_dolt"
+    [ "$RUN_STATUS" -eq 0 ] ||
+        fail "$label exit=$RUN_STATUS, want planned exit 0: $RUN_STDOUT $RUN_STDERR"
+    [ -z "$RUN_STDERR" ] ||
+        fail "$label emitted stderr in JSON mode: $RUN_STDERR"
+    assert_common_json inspect planned none
+    source_sha=$(sha256sum "$source_bd" | awk '{print $1}')
+    runtime_sha=$(sha256sum "$source_dolt" | awk '{print $1}')
+    target_sha=$(sha256sum "$target_bd" | awk '{print $1}')
+    jq -e \
+        --arg workspace "$ws" \
+        --arg issue_prefix "$SOURCE_ISSUE_PREFIX" \
+        --arg database "$SOURCE_DATABASE" \
+        --arg project_id "$SOURCE_PROJECT_ID" \
+        --arg source_bd "$source_bd" --arg source_sha "$source_sha" \
+        --arg source_dolt "$source_dolt" --arg runtime_sha "$runtime_sha" \
+        --arg target_bd "$target_bd" --arg target_sha "$target_sha" '
+        .retryable == false and
+        .source.workspace == $workspace and
+        .source.version == "0.62.0" and
+        .source.backend == "dolt-server" and
+        .source.digest_scope == "admission_observation" and
+        (.source.tree_sha256 | test("^[0-9a-f]{64}$")) and
+        .target.backend == "dolt-embedded" and
+        .target.embedded_capable == true and
+        .plan.schema == "bd.v062.bridge-plan.v1" and
+        (.plan.digest | test("^[0-9a-f]{64}$")) and
+        .plan.semantic_scope == "v062_lossless_core_v1" and
+        .plan.semantic_baseline.issue_ids == [
+            "old-bug", "old-closed", "old-epic", "old-standalone", "old-task"
+        ] and
+        (.plan.semantic_baseline.sha256 | test("^[0-9a-f]{64}$")) and
+        .plan.target_backend == "dolt-embedded" and
+        .plan.source_observation.tree_sha256 == .source.tree_sha256 and
+        .plan.source_observation.digest_scope == "admission_observation" and
+        .plan.source_identity == {
+            issue_prefix: $issue_prefix,
+            database: $database,
+            project_id: $project_id
+        } and
+        .plan.source_binary == {
+            path: $source_bd, version: "0.62.0", sha256: $source_sha
+        } and
+        .plan.source_runtime == {
+            kind: "dolt", path: $source_dolt,
+            version: "1.84.0", sha256: $runtime_sha
+        } and
+        .plan.target_binary == {
+            path: $target_bd, version: "1.1.0", sha256: $target_sha
+        }
+    ' <<< "$RUN_STDOUT" >/dev/null ||
+        fail "$label omitted a fully bound effectful plan: $RUN_STDOUT"
+    EFFECTFUL_PLAN=$(jq -er '.plan.digest' <<< "$RUN_STDOUT") ||
+        fail "$label did not expose a plan digest"
+    assert_unchanged "$ws" "$before" "$label"
+}
+
+assert_bridge_error() {
+    local label="$1" ws="$2" expected_exit="$3" mode="$4"
+    local status="$5" code="$6" before
+    shift 6
+    before=$(tree_fingerprint "$ws")
+    run_bridge "$label" "$ws" "$@"
+    [ "$RUN_STATUS" -eq "$expected_exit" ] ||
+        fail "$label exit=$RUN_STATUS, want $expected_exit: $RUN_STDOUT $RUN_STDERR"
+    assert_common_json "$mode" "$status" none
+    jq -e --arg code "$code" \
+        '.retryable == false and .code == $code' \
+        <<< "$RUN_STDOUT" >/dev/null ||
+        fail "$label lacked stable $code refusal: $RUN_STDOUT"
+    assert_unchanged "$ws" "$before" "$label"
+}
+
+call_count() {
+    local log="$1" command="$2" count
+    count=$(grep -Ec "^argv=.* ${command}( |$)" "$log" 2>/dev/null) || true
+    printf '%s\n' "${count:-0}"
+}
+
+# Production must never select an inherited helper executable for destructive
+# publication. The only supported test seam is a validated, fail-only mode.
+unsafe_mv_override_ws="$tmp/unsafe-mv-helper-override"
+new_v062_workspace "$unsafe_mv_override_ws"
+unsafe_mv_override_before=$(tree_fingerprint "$unsafe_mv_override_ws")
+BRIDGE_TEST_MV_BIN="$OLD_NO_CLOBBER_MV" \
+    run_bridge unsafe-mv-helper-override "$unsafe_mv_override_ws" \
+        --inspect --source-bd "$SOURCE_BD" --source-dolt "$SOURCE_DOLT" \
+        --workspace "$unsafe_mv_override_ws"
+[ "$RUN_STATUS" -eq 2 ] ||
+    fail "unsafe mv helper override exit=$RUN_STATUS, want usage refusal: $RUN_STDOUT $RUN_STDERR"
+assert_common_json inspect usage_error none
+jq -e '
+    .retryable == false and .code == "invalid_environment"
+' <<< "$RUN_STDOUT" >/dev/null ||
+    fail "unsafe mv helper override was accepted: $RUN_STDOUT"
+assert_unchanged "$unsafe_mv_override_ws" "$unsafe_mv_override_before" \
+    "unsafe mv helper override"
+
+# A failed file hash inside the complete-source fingerprint must propagate to
+# inspection. A digest over the successfully read prefix is not authorization.
+fingerprint_failure_ws="$tmp/effectful-fingerprint-hash-failure"
+new_v062_workspace "$fingerprint_failure_ws"
+fingerprint_failure_before=$(tree_fingerprint "$fingerprint_failure_ws")
+BRIDGE_TEST_FINGERPRINT_FAILURE=hash \
+    run_bridge effectful-fingerprint-hash-failure "$fingerprint_failure_ws" \
+        --inspect --source-bd "$SOURCE_BD" --source-dolt "$SOURCE_DOLT" \
+        --workspace "$fingerprint_failure_ws"
+[ "$RUN_STATUS" -eq 1 ] ||
+    fail "fingerprint hash failure exit=$RUN_STATUS, want refusal: $RUN_STDOUT $RUN_STDERR"
+assert_common_json inspect refused none
+jq -e '
+    .retryable == true and .code == "source_unverifiable"
+' <<< "$RUN_STDOUT" >/dev/null ||
+    fail "fingerprint hash failure was not propagated: $RUN_STDOUT"
+assert_unchanged "$fingerprint_failure_ws" "$fingerprint_failure_before" \
+    "fingerprint hash failure"
+
+effect_ws="$tmp/effectful-canonical"
+new_v062_workspace "$effect_ws"
+effect_before=$(tree_fingerprint "$effect_ws")
+inspect_effectful_plan effectful-inspect "$effect_ws" \
+    "$SOURCE_BD" "$SOURCE_DOLT" "$TARGET_BD"
+canonical_plan="$EFFECTFUL_PLAN"
+canonical_plan_json=$(jq -Sc '.plan' <<< "$RUN_STDOUT")
+canonical_source_tree=$(jq -er '.plan.source_observation.tree_sha256' \
+    <<< "$RUN_STDOUT")
+grep -E '^argv=.* config get issue_prefix --json$' "$SOURCE_LOG" >/dev/null ||
+    fail "effectful inspect did not read the authenticated v0.62 issue prefix"
+grep -E '^argv=.* --host .*project_id.*_project_id' \
+    "$SOURCE_DOLT_LOG" >/dev/null ||
+    fail "effectful inspect did not authenticate the v0.62 database project ID"
+
+# Identical inspection is deterministic, while every executable identity is
+# bound by bytes and therefore changes the consent digest when it changes.
+inspect_effectful_plan effectful-inspect-repeat "$effect_ws" \
+    "$SOURCE_BD" "$SOURCE_DOLT" "$TARGET_BD"
+[ "$EFFECTFUL_PLAN" = "$canonical_plan" ] ||
+    fail "identical effectful inspect produced a different plan digest"
+[ "$(jq -Sc '.plan' <<< "$RUN_STDOUT")" = "$canonical_plan_json" ] ||
+    fail "identical effectful inspect produced a different plan"
+
+# Unknown bytes in the authenticated /tmp runtime are preserved even after
+# the owner exits; the real guardian must observe that exit and finish without
+# receiving TERM.
+runtime_unknown_phase_dir="$tmp/effectful-runtime-unknown-phase"
+mkdir -m 700 "$runtime_unknown_phase_dir"
+touch "$runtime_unknown_phase_dir/guardian-cooperative-shutdown.enabled"
+runtime_unknown_before=$(tree_fingerprint "$effect_ws")
+BRIDGE_TEST_RUNTIME_UNKNOWN_ENTRY=inject \
+BRIDGE_TEST_PHASE_DIR="$runtime_unknown_phase_dir" \
+    run_bridge effectful-runtime-unknown "$effect_ws" \
+        --inspect --source-bd "$SOURCE_BD" --source-dolt "$SOURCE_DOLT" \
+        --workspace "$effect_ws"
+[ "$RUN_STATUS" -eq 0 ] ||
+    fail "runtime unknown-entry inspect failed: $RUN_STDOUT $RUN_STDERR"
+assert_common_json inspect planned none
+runtime_unknown_root=$(last_private_runtime_from_log "$SOURCE_LOG") ||
+    fail "runtime unknown-entry case did not expose its private root"
+[ -f "$runtime_unknown_root/unexpected-runtime-entry" ] ||
+    fail "runtime cleanup deleted an unexpected entry"
+for ((attempt = 0; attempt < 400; attempt++)); do
+    [ -f "$runtime_unknown_phase_dir/runtime-guardian.done" ] && break
+    sleep 0.025
+done
+[ -f "$runtime_unknown_phase_dir/runtime-guardian.started" ] &&
+    [ -f "$runtime_unknown_phase_dir/runtime-guardian.done" ] ||
+    fail "runtime guardian did not observe owner exit after cleanup refusal"
+[ ! -e "$runtime_unknown_phase_dir/runtime-guardian.term" ] ||
+    fail "runtime guardian received TERM during cleanup refusal"
+[ "$(tree_fingerprint "$effect_ws")" = "$runtime_unknown_before" ] ||
+    fail "runtime unknown-entry inspect mutated the workspace"
+rm -rf -- "$runtime_unknown_root"
+
+# Historical config/export/show must be pinned to the private server owned by
+# this bridge. A stale runtime port file and active config.yaml are data-routing
+# inputs, not authority to contact another server during semantic extraction.
+source_route_ws="$tmp/effectful-source-route-override"
+new_v062_workspace "$source_route_ws"
+printf '%s\n' 29998 > "$source_route_ws/.beads/dolt-server.port"
+cat > "$source_route_ws/.beads/config.yaml" <<'EOF'
+dolt:
+  host: poison.invalid
+  port: 29998
+  database: poison_database
+EOF
+printf '%s\n' 'require explicit private source route' \
+    > "$source_route_ws/.beads/require-owned-source-route"
+inspect_effectful_plan source-route-override-plan "$source_route_ws" \
+    "$SOURCE_BD" "$SOURCE_DOLT" "$TARGET_BD"
+
+SOURCE_BD_ALT="$tmp/fake-bd-v0.62.0-byte-variant"
+SOURCE_DOLT_ALT="$tmp/fake-dolt-1.84.0-byte-variant"
+TARGET_BD_ALT="$tmp/fake-bd-current-byte-variant"
+cp -f -- "$SOURCE_BD" "$SOURCE_BD_ALT"
+cp -f -- "$SOURCE_DOLT" "$SOURCE_DOLT_ALT"
+cp -f -- "$TARGET_BD" "$TARGET_BD_ALT"
+printf '\n# source identity variant\n' >> "$SOURCE_BD_ALT"
+printf '\n# runtime identity variant\n' >> "$SOURCE_DOLT_ALT"
+printf '\n# target identity variant\n' >> "$TARGET_BD_ALT"
+chmod +x "$SOURCE_BD_ALT" "$SOURCE_DOLT_ALT" "$TARGET_BD_ALT"
+SOURCE_BD_LINK="$tmp/fake-bd-v0.62.0-link"
+SOURCE_DOLT_LINK="$tmp/fake-dolt-1.84.0-link"
+ln -s "$SOURCE_BD" "$SOURCE_BD_LINK"
+ln -s "$SOURCE_DOLT" "$SOURCE_DOLT_LINK"
+
+inspect_effectful_plan source-identity-plan "$effect_ws" \
+    "$SOURCE_BD_ALT" "$SOURCE_DOLT" "$TARGET_BD"
+[ "$EFFECTFUL_PLAN" != "$canonical_plan" ] ||
+    fail "source binary identity was not bound into the plan"
+inspect_effectful_plan runtime-identity-plan "$effect_ws" \
+    "$SOURCE_BD" "$SOURCE_DOLT_ALT" "$TARGET_BD"
+[ "$EFFECTFUL_PLAN" != "$canonical_plan" ] ||
+    fail "source runtime identity was not bound into the plan"
+inspect_effectful_plan target-identity-plan "$effect_ws" \
+    "$SOURCE_BD" "$SOURCE_DOLT" "$TARGET_BD_ALT"
+[ "$EFFECTFUL_PLAN" != "$canonical_plan" ] ||
+    fail "target binary identity was not bound into the plan"
+assert_unchanged "$effect_ws" "$effect_before" "all effectful planning"
+
+# Source and runtime paths are explicit, absolute, release-qualified inputs.
+# A syntactically valid expected digest is supplied so these refusals prove the
+# input check rather than merely falling into plan parsing.
+assert_bridge_error source-binary-omitted "$effect_ws" 1 apply refused \
+    source_binary_missing \
+    --apply --yes --expect-plan "$canonical_plan" \
+    --source-dolt "$SOURCE_DOLT" --workspace "$effect_ws"
+assert_bridge_error source-binary-absent "$effect_ws" 1 apply refused \
+    source_binary_missing \
+    --apply --yes --expect-plan "$canonical_plan" \
+    --source-bd "$tmp/does-not-exist-bd" \
+    --source-dolt "$SOURCE_DOLT" --workspace "$effect_ws"
+assert_bridge_error source-binary-relative "$effect_ws" 1 apply refused \
+    source_binary_invalid \
+    --apply --yes --expect-plan "$canonical_plan" \
+    --source-bd fake-bd-v0.62.0 \
+    --source-dolt "$SOURCE_DOLT" --workspace "$effect_ws"
+assert_bridge_error source-binary-wrong-version "$effect_ws" 1 apply refused \
+    source_binary_invalid \
+    --apply --yes --expect-plan "$canonical_plan" \
+    --source-bd "$BAD_SOURCE_BD" \
+    --source-dolt "$SOURCE_DOLT" --workspace "$effect_ws"
+assert_bridge_error source-binary-symlink "$effect_ws" 1 apply refused \
+    source_binary_invalid \
+    --apply --yes --expect-plan "$canonical_plan" \
+    --source-bd "$SOURCE_BD_LINK" \
+    --source-dolt "$SOURCE_DOLT" --workspace "$effect_ws"
+assert_bridge_error source-runtime-omitted "$effect_ws" 1 apply refused \
+    source_runtime_missing \
+    --apply --yes --expect-plan "$canonical_plan" \
+    --source-bd "$SOURCE_BD" --workspace "$effect_ws"
+assert_bridge_error source-runtime-absent "$effect_ws" 1 apply refused \
+    source_runtime_missing \
+    --apply --yes --expect-plan "$canonical_plan" \
+    --source-bd "$SOURCE_BD" \
+    --source-dolt "$tmp/does-not-exist-dolt" --workspace "$effect_ws"
+assert_bridge_error source-runtime-relative "$effect_ws" 1 apply refused \
+    source_runtime_invalid \
+    --apply --yes --expect-plan "$canonical_plan" \
+    --source-bd "$SOURCE_BD" \
+    --source-dolt fake-dolt-1.84.0 --workspace "$effect_ws"
+assert_bridge_error source-runtime-wrong-version "$effect_ws" 1 apply refused \
+    source_runtime_invalid \
+    --apply --yes --expect-plan "$canonical_plan" \
+    --source-bd "$SOURCE_BD" \
+    --source-dolt "$BAD_SOURCE_DOLT" --workspace "$effect_ws"
+assert_bridge_error source-runtime-symlink "$effect_ws" 1 apply refused \
+    source_runtime_invalid \
+    --apply --yes --expect-plan "$canonical_plan" \
+    --source-bd "$SOURCE_BD" \
+    --source-dolt "$SOURCE_DOLT_LINK" --workspace "$effect_ws"
+BRIDGE_TEST_GUARDIAN_START_FAILURE=runtime_guardian_start \
+    assert_bridge_error runtime-guardian-start-unverifiable \
+        "$effect_ws" 1 apply refused target_binary_invalid \
+        --apply --yes --expect-plan "$canonical_plan" \
+        --source-bd "$SOURCE_BD" --source-dolt "$SOURCE_DOLT" \
+        --workspace "$effect_ws"
+
+wrong_plan=$(printf 'f%.0s' {1..64})
+[ "$wrong_plan" != "$canonical_plan" ] ||
+    wrong_plan=$(printf 'e%.0s' {1..64})
+assert_bridge_error wrong-plan "$effect_ws" 1 apply refused plan_mismatch \
+    --apply --yes --expect-plan "$wrong_plan" \
+    --source-bd "$SOURCE_BD" --source-dolt "$SOURCE_DOLT" \
+    --workspace "$effect_ws"
+assert_bridge_error changed-source-binary "$effect_ws" 1 apply refused \
+    plan_mismatch \
+    --apply --yes --expect-plan "$canonical_plan" \
+    --source-bd "$SOURCE_BD_ALT" --source-dolt "$SOURCE_DOLT" \
+    --workspace "$effect_ws"
+assert_bridge_error changed-source-runtime "$effect_ws" 1 apply refused \
+    plan_mismatch \
+    --apply --yes --expect-plan "$canonical_plan" \
+    --source-bd "$SOURCE_BD" --source-dolt "$SOURCE_DOLT_ALT" \
+    --workspace "$effect_ws"
+BRIDGE_TEST_TARGET="$TARGET_BD_ALT" \
+    assert_bridge_error changed-target-binary "$effect_ws" 1 apply refused \
+        plan_mismatch \
+        --apply --yes --expect-plan "$canonical_plan" \
+        --source-bd "$SOURCE_BD" --source-dolt "$SOURCE_DOLT" \
+        --workspace "$effect_ws"
+
+# Apply must re-observe the original under its operation fence. A source byte
+# changed after planning invalidates consent and is never imported.
+drift_ws="$tmp/effectful-source-drift"
+new_v062_workspace "$drift_ws"
+inspect_effectful_plan source-drift-plan "$drift_ws" \
+    "$SOURCE_BD" "$SOURCE_DOLT" "$TARGET_BD"
+drift_plan="$EFFECTFUL_PLAN"
+printf '%s\n' '{"drift":true}' \
+    > "$drift_ws/.beads/dolt/smoke/.dolt/config.json"
+assert_bridge_error source-drift-apply "$drift_ws" 1 apply refused \
+    plan_mismatch \
+    --apply --yes --expect-plan "$drift_plan" \
+    --source-bd "$SOURCE_BD" --source-dolt "$SOURCE_DOLT" \
+    --workspace "$drift_ws"
+
+# Hold the first apply immediately after it owns the operation fence but before
+# its mandatory reinspection. A concurrent apply must observe the fence, and a
+# source write in this overlap window must invalidate the first consent digest.
+overlap_ws="$tmp/effectful-overlap-before-reinspect"
+new_v062_workspace "$overlap_ws"
+inspect_effectful_plan overlap-plan "$overlap_ws" \
+    "$SOURCE_BD" "$SOURCE_DOLT" "$TARGET_BD"
+overlap_plan="$EFFECTFUL_PLAN"
+overlap_phase_dir="$tmp/effectful-overlap-phase"
+mkdir -m 700 "$overlap_phase_dir"
+release_transaction_gap_phases "$overlap_phase_dir"
+BRIDGE_TEST_PHASE_DIR="$overlap_phase_dir" \
+    start_bridge_at_phase overlap-first "$overlap_ws" \
+        --apply --yes --expect-plan "$overlap_plan" \
+        --source-bd "$SOURCE_BD" --source-dolt "$SOURCE_DOLT" \
+        --workspace "$overlap_ws"
+wait_for_phase "$overlap_phase_dir" after_operation_fence_before_reinspect \
+    "first overlapping apply"
+[ -d "$overlap_ws/.beads-v0.62.0-migration.lock" ] &&
+    [ ! -L "$overlap_ws/.beads-v0.62.0-migration.lock" ] ||
+    fail "first overlapping apply did not publish its physical operation fence"
+[ -d "$overlap_ws/.beads" ] &&
+    [ ! -e "$overlap_ws/.beads-v0.62.0-staging" ] &&
+    [ ! -e "$overlap_ws/.beads-v0.62.0-rollback" ] ||
+    fail "operation-fence phase exposed an impossible pre-reinspection layout"
+overlap_fenced_before=$(content_fingerprint "$overlap_ws")
+run_bridge overlap-second "$overlap_ws" \
+    --apply --yes --expect-plan "$overlap_plan" \
+    --source-bd "$SOURCE_BD" --source-dolt "$SOURCE_DOLT" \
+    --workspace "$overlap_ws"
+[ "$RUN_STATUS" -eq 1 ] ||
+    fail "second overlapping apply exit=$RUN_STATUS, want refusal exit 1"
+assert_common_json apply refused none
+jq -e '
+    .retryable == true and .code == "operation_in_progress"
+' <<< "$RUN_STDOUT" >/dev/null ||
+    fail "second overlapping apply did not observe the operation fence"
+[ "$(content_fingerprint "$overlap_ws")" = "$overlap_fenced_before" ] ||
+    fail "second overlapping apply changed the fenced workspace"
+printf '%s\n' '{"overlap_drift":true}' \
+    > "$overlap_ws/.beads/dolt/smoke/.dolt/config.json"
+overlap_drifted_source=$(content_fingerprint "$overlap_ws/.beads")
+touch "$overlap_phase_dir/after_operation_fence_before_reinspect.continue"
+finish_phase_bridge "drifted first apply"
+[ "$RUN_STATUS" -eq 1 ] ||
+    fail "drifted first apply exit=$RUN_STATUS, want refusal exit 1: $RUN_STDOUT $RUN_STDERR"
+assert_common_json apply refused none
+jq -e '
+    .retryable == false and .code == "plan_mismatch"
+' <<< "$RUN_STDOUT" >/dev/null ||
+    fail "fenced reinspection did not reject overlapping source drift"
+[ "$(content_fingerprint "$overlap_ws/.beads")" = "$overlap_drifted_source" ] ||
+    fail "drift refusal did not preserve the externally changed source"
+[ ! -e "$overlap_ws/.beads-v0.62.0-migration.lock" ] &&
+    [ ! -e "$overlap_ws/.beads-v0.62.0-staging" ] &&
+    [ ! -e "$overlap_ws/.beads-v0.62.0-rollback" ] ||
+    fail "drift refusal leaked a transaction artifact"
+
+identity_mismatch_ws="$tmp/source-project-id-mismatch"
+new_v062_workspace "$identity_mismatch_ws"
+touch "$identity_mismatch_ws/.beads/database-project-id-mismatch"
+identity_mismatch_before=$(tree_fingerprint "$identity_mismatch_ws")
+run_bridge source-project-id-mismatch "$identity_mismatch_ws" \
+    --inspect --source-bd "$SOURCE_BD" --source-dolt "$SOURCE_DOLT" \
+    --workspace "$identity_mismatch_ws"
+[ "$RUN_STATUS" -eq 1 ] ||
+    fail "source project-ID mismatch exit=$RUN_STATUS, want refusal exit 1"
+assert_common_json inspect refused none
+jq -e '
+    .retryable == false and .code == "source_identity_mismatch"
+' <<< "$RUN_STDOUT" >/dev/null ||
+    fail "source project-ID mismatch lacked a stable refusal: $RUN_STDOUT"
+assert_unchanged "$identity_mismatch_ws" "$identity_mismatch_before" \
+    "source project-ID mismatch"
+
+# Executable identity is authenticated before the operation fence and then
+# executed only through private copies. Replacing every caller-supplied path
+# after the fence cannot redirect the already-authorized in-flight apply.
+pinning_ws="$tmp/effectful-executable-pinning"
+new_v062_workspace "$pinning_ws"
+pinning_source_bd="$tmp/pinning-source-bd"
+pinning_source_dolt="$tmp/pinning-source-dolt"
+pinning_target_bd="$tmp/pinning-target-bd"
+pinning_source_log="$tmp/pinning-source-bd.log"
+pinning_source_dolt_log="$tmp/pinning-source-dolt.log"
+pinning_target_log="$tmp/pinning-target-bd.log"
+make_fake_source_bd "$pinning_source_bd" 0.62.0 "$pinning_source_log"
+make_fake_source_dolt "$pinning_source_dolt" 1.84.0 \
+    "$pinning_source_dolt_log"
+make_fake_bd "$pinning_target_bd" 1.1.0 embedded "$pinning_target_log"
+inspect_effectful_plan executable-pinning-plan "$pinning_ws" \
+    "$pinning_source_bd" "$pinning_source_dolt" "$pinning_target_bd"
+pinning_plan="$EFFECTFUL_PLAN"
+pinning_source_sha=$(sha256sum "$pinning_source_bd" | awk '{print $1}')
+pinning_source_dolt_sha=$(sha256sum "$pinning_source_dolt" | awk '{print $1}')
+pinning_target_sha=$(sha256sum "$pinning_target_bd" | awk '{print $1}')
+pinning_phase_dir="$tmp/effectful-executable-pinning-phase"
+pinning_tripwire_log="$tmp/effectful-executable-pinning-tripwire.log"
+mkdir -m 700 "$pinning_phase_dir"
+release_transaction_gap_phases "$pinning_phase_dir"
+touch "$pinning_phase_dir/before_source_rename.continue"
+touch "$pinning_phase_dir/after_source_rename_before_target_publish.continue"
+touch "$pinning_phase_dir/after_target_publish.continue"
+BRIDGE_TEST_PHASE_DIR="$pinning_phase_dir" \
+BRIDGE_TEST_TARGET="$pinning_target_bd" \
+    start_bridge_at_phase executable-pinning-apply "$pinning_ws" \
+        --apply --yes --expect-plan "$pinning_plan" \
+        --source-bd "$pinning_source_bd" \
+        --source-dolt "$pinning_source_dolt" \
+        --workspace "$pinning_ws"
+wait_for_phase "$pinning_phase_dir" after_operation_fence_before_reinspect \
+    "executable-pinning apply"
+pinning_runtime_dir=$(last_private_runtime_from_log "$pinning_source_log") ||
+    fail "executable-pinning apply did not expose its private runtime"
+[ -d "$pinning_runtime_dir" ] && [ ! -L "$pinning_runtime_dir" ] &&
+    [ "$(stat -c '%a' "$pinning_runtime_dir")" = 700 ] &&
+    [ "$(stat -c '%d' "$pinning_runtime_dir")" = \
+        "$(stat -c '%d' "$pinning_ws")" ] ||
+    fail "private runtime is not an owner-only directory on the workspace filesystem"
+pinning_initial_home=$(last_clean_home_from_log "$pinning_source_log") ||
+    fail "executable-pinning apply did not expose its isolated home"
+assert_scratch_is_beneath_runtime "$pinning_runtime_dir" \
+    "$pinning_initial_home" "initial clean home"
+[ "$(sha256sum "$pinning_runtime_dir/source-bd" | awk '{print $1}')" = \
+    "$pinning_source_sha" ] &&
+    [ "$(sha256sum "$pinning_runtime_dir/source-dolt" | awk '{print $1}')" = \
+        "$pinning_source_dolt_sha" ] &&
+    [ "$(sha256sum "$pinning_runtime_dir/target-bd" | awk '{print $1}')" = \
+        "$pinning_target_sha" ] ||
+    fail "private runtime bytes differ from the authorized executables"
+: > "$pinning_source_log"
+: > "$pinning_source_dolt_log"
+: > "$pinning_target_log"
+make_executable_tripwire \
+    "$pinning_source_bd" source-bd "$pinning_tripwire_log"
+make_executable_tripwire \
+    "$pinning_source_dolt" source-dolt "$pinning_tripwire_log"
+make_executable_tripwire \
+    "$pinning_target_bd" target-bd "$pinning_tripwire_log"
+[ "$(sha256sum "$pinning_source_bd" | awk '{print $1}')" != \
+    "$pinning_source_sha" ] &&
+    [ "$(sha256sum "$pinning_source_dolt" | awk '{print $1}')" != \
+        "$pinning_source_dolt_sha" ] &&
+    [ "$(sha256sum "$pinning_target_bd" | awk '{print $1}')" != \
+        "$pinning_target_sha" ] ||
+    fail "executable-pinning tripwires did not replace every original path"
+touch "$pinning_phase_dir/after_operation_fence_before_reinspect.continue"
+wait_for_phase "$pinning_phase_dir" before_receipt_publish \
+    "executable-pinning apply scratch consolidation"
+pinning_active_home=$(last_clean_home_from_log "$pinning_source_log") ||
+    fail "post-fence source reads did not expose their isolated home"
+pinning_source_copy=$(last_source_copy_from_log "$pinning_source_log") ||
+    fail "post-fence source reads did not expose their expendable source copy"
+pinning_semantic_probe=$(last_semantic_probe_from_log "$pinning_target_log") ||
+    fail "staged import did not expose its semantic probe"
+[ "$pinning_active_home" = "$pinning_initial_home" ] ||
+    fail "clean home changed across pinned subprocess calls"
+assert_scratch_is_beneath_runtime "$pinning_runtime_dir" \
+    "$pinning_active_home" "active clean home"
+assert_scratch_is_beneath_runtime "$pinning_runtime_dir" \
+    "$pinning_source_copy" "expendable source copy"
+assert_scratch_is_beneath_runtime "$pinning_runtime_dir" \
+    "$pinning_semantic_probe" "semantic probe"
+touch "$pinning_phase_dir/before_receipt_publish.continue"
+finish_phase_bridge "executable-pinning apply"
+[ "$RUN_STATUS" -eq 0 ] ||
+    fail "executable-pinning apply followed a replaced path: $RUN_STDOUT $RUN_STDERR"
+[ ! -e "$pinning_tripwire_log" ] ||
+    fail "in-flight apply invoked a replaced executable: $(<"$pinning_tripwire_log")"
+wait_for_path_absence "$pinning_runtime_dir" \
+    "successful executable-pinning apply runtime root"
+for pinning_scratch in \
+    "$pinning_initial_home" "$pinning_active_home" \
+    "$pinning_source_copy" "$pinning_semantic_probe"; do
+    [ ! -e "$pinning_scratch" ] && [ ! -L "$pinning_scratch" ] ||
+        fail "successful executable-pinning apply leaked scratch: $pinning_scratch"
+done
+grep -F "argv=$pinning_runtime_dir/source-bd config get issue_prefix --json" \
+    "$pinning_source_log" >/dev/null &&
+    grep -F "argv=$pinning_runtime_dir/source-bd export" \
+        "$pinning_source_log" >/dev/null &&
+    grep -F "argv=$pinning_runtime_dir/source-bd show" \
+        "$pinning_source_log" >/dev/null ||
+    fail "post-fence source reads did not use the private source bd"
+grep -F "argv=$pinning_runtime_dir/source-dolt sql-server" \
+    "$pinning_source_dolt_log" >/dev/null &&
+    grep -F "argv=$pinning_runtime_dir/source-dolt --host" \
+        "$pinning_source_dolt_log" >/dev/null ||
+    fail "post-fence source runtime calls did not use the private Dolt"
+for target_command in \
+    __migration-v062-inspect init import export config; do
+    grep -F "argv=$pinning_runtime_dir/target-bd $target_command" \
+        "$pinning_target_log" >/dev/null ||
+        fail "post-fence target $target_command did not use the private target bd"
+done
+assert_common_json apply succeeded workspace_migrated
+jq -e --arg plan "$pinning_plan" '
+    .retryable == false and .plan.digest == $plan and
+    .verification.semantic_scope_verified == true and
+    .verification.separate_process_reopen == true
+' <<< "$RUN_STDOUT" >/dev/null ||
+    fail "executable-pinning apply overstated verification: $RUN_STDOUT"
+[ ! -e "$pinning_ws/.beads-v0.62.0-migration.lock" ] &&
+    [ ! -e "$pinning_ws/.beads-v0.62.0-staging" ] &&
+    [ -d "$pinning_ws/.beads-v0.62.0-rollback" ] ||
+    fail "executable-pinning apply leaked transaction artifacts"
+while IFS= read -r pinning_source_dolt_pid; do
+    pid_is_running "$pinning_source_dolt_pid" &&
+        fail "private source Dolt child $pinning_source_dolt_pid leaked"
+done < "${pinning_source_dolt_log}.pids"
+
+# General v0.62 data is intentionally not qualified yet. The negative marker
+# lives inside .beads so it survives the mandatory expendable source copy.
+semantic_ws="$tmp/semantic-unqualified"
+new_v062_workspace "$semantic_ws"
+printf '%s\n' 'six-record corpus is outside v062_lossless_core_v1' \
+    > "$semantic_ws/.beads/unqualified-semantic-scope"
+assert_bridge_error semantic-scope "$semantic_ws" 1 inspect refused \
+    source_semantic_scope_unqualified \
+    --inspect --source-bd "$SOURCE_BD" --source-dolt "$SOURCE_DOLT" \
+    --workspace "$semantic_ws"
+
+# Preserve the canonical count and IDs while introducing one unsupported
+# historical field. Qualification must be an exact semantic allowlist rather
+# than a five-row heuristic.
+unsupported_ws="$tmp/semantic-unsupported-same-count"
+new_v062_workspace "$unsupported_ws"
+printf '%s\n' 'five-record corpus contains an unsupported field' \
+    > "$unsupported_ws/.beads/unsupported-semantic-scope"
+assert_bridge_error semantic-unsupported-same-count "$unsupported_ws" \
+    1 inspect refused source_semantic_scope_unqualified \
+    --inspect --source-bd "$SOURCE_BD" --source-dolt "$SOURCE_DOLT" \
+    --workspace "$unsupported_ws"
+
+# Top-level allowlisting is insufficient: dependency metadata/thread IDs and
+# unqualified comment fields would be silently discarded by canonicalization.
+nested_dependency_ws="$tmp/semantic-nested-dependency"
+new_v062_workspace "$nested_dependency_ws"
+printf '%s\n' 'five-record corpus contains nested dependency state' \
+    > "$nested_dependency_ws/.beads/nested-dependency-semantic-scope"
+assert_bridge_error semantic-nested-dependency "$nested_dependency_ws" \
+    1 inspect refused source_semantic_scope_unqualified \
+    --inspect --source-bd "$SOURCE_BD" --source-dolt "$SOURCE_DOLT" \
+    --workspace "$nested_dependency_ws"
+
+nested_comment_ws="$tmp/semantic-nested-comment"
+new_v062_workspace "$nested_comment_ws"
+printf '%s\n' 'five-record corpus contains an unqualified nested comment field' \
+    > "$nested_comment_ws/.beads/nested-comment-semantic-scope"
+assert_bridge_error semantic-nested-comment "$nested_comment_ws" \
+    1 inspect refused source_semantic_scope_unqualified \
+    --inspect --source-bd "$SOURCE_BD" --source-dolt "$SOURCE_DOLT" \
+    --workspace "$nested_comment_ws"
+
+for source_audit_field in \
+    dependency-created-at dependency-created-by \
+    comment-id comment-issue-id comment-created-at; do
+    source_audit_ws="$tmp/semantic-audit-source-$source_audit_field"
+    new_v062_workspace "$source_audit_ws"
+    printf '%s\n' "$source_audit_field is empty" \
+        > "$source_audit_ws/.beads/audit-source-$source_audit_field"
+    assert_bridge_error "semantic-audit-source-$source_audit_field" \
+        "$source_audit_ws" 1 inspect refused \
+        source_semantic_scope_unqualified \
+        --inspect --source-bd "$SOURCE_BD" --source-dolt "$SOURCE_DOLT" \
+        --workspace "$source_audit_ws"
+done
+
+assert_unsafe_target_candidate_rejected() {
+    local label="$1" target_bd="$2" expected_injection="$3"
+    local ws plan source_before
+    ws="$tmp/$label"
+    new_v062_workspace "$ws"
+    inspect_effectful_plan "$label-plan" "$ws" \
+        "$SOURCE_BD" "$SOURCE_DOLT" "$target_bd"
+    plan="$EFFECTFUL_PLAN"
+    source_before=$(content_fingerprint "$ws/.beads")
+    BRIDGE_TEST_TARGET="$target_bd" \
+        run_bridge "$label-apply" "$ws" \
+            --apply --yes --expect-plan "$plan" \
+            --source-bd "$SOURCE_BD" --source-dolt "$SOURCE_DOLT" \
+            --workspace "$ws"
+    [ "$RUN_STATUS" -eq 1 ] ||
+        fail "$label exit=$RUN_STATUS, want target-verification failure: $RUN_STDOUT $RUN_STDERR"
+    assert_common_json apply failed none
+    jq -e '
+        .retryable == false and .code == "target_verification_failed"
+    ' <<< "$RUN_STDOUT" >/dev/null ||
+        fail "$label did not reject the unsafe staged target: $RUN_STDOUT"
+    [ -f "${target_bd}.injected" ] &&
+        grep -Fqx -- "$expected_injection" "${target_bd}.injected" ||
+        fail "$label refused before injecting $expected_injection"
+    case "$expected_injection" in
+        lossy-*)
+            [ -f "${target_bd}.exported" ] &&
+                grep -Fqx -- "$expected_injection" \
+                    "${target_bd}.exported" ||
+                fail "$label refused before exporting the lossy target"
+            ;;
+    esac
+    [ "$(content_fingerprint "$ws/.beads")" = "$source_before" ] &&
+        [ ! -e "$ws/.beads-v0.62.0-rollback" ] &&
+        [ ! -e "$ws/.beads-v0.62.0-staging" ] &&
+        [ ! -e "$ws/.beads-v0.62.0-migration.lock" ] ||
+        fail "$label changed the source or leaked transaction artifacts"
+}
+
+# The admitted audit fields are part of the lossless contract. Verification
+# must compare them through current export, not a show projection that can omit
+# dependency provenance or regenerate comment identity.
+for lossy_audit_field in \
+    dependency-created-at dependency-created-by \
+    comment-id comment-issue-id comment-created-at; do
+    assert_unsafe_target_candidate_rejected \
+        "effectful-lossy-$lossy_audit_field-target" \
+        "$tmp/fake-bd-lossy-$lossy_audit_field-target" \
+        "lossy-$lossy_audit_field"
+done
+
+# Neither active provider routing nor a symlinked embedded repository is a
+# publishable target, even if all five issue records otherwise reopen.
+assert_unsafe_target_candidate_rejected \
+    effectful-active-target-config "$ROUTED_TARGET_BD" active-config
+assert_unsafe_target_candidate_rejected \
+    effectful-late-active-target-config "$LATE_ROUTED_TARGET_BD" \
+    late-active-config
+assert_unsafe_target_candidate_rejected \
+    effectful-symlink-target-dolt "$SYMLINK_DOLT_TARGET_BD" symlink-dolt
+assert_unsafe_target_candidate_rejected \
+    effectful-symlink-target-database "$SYMLINK_DATABASE_TARGET_BD" \
+    symlink-database
+
+target_inits_before_identity_refusal=$(call_count "$TARGET_LOG" init)
+target_imports_before_identity_refusal=$(call_count "$TARGET_LOG" import)
+for incompatible_prefix in dotted trailing-hyphen; do
+    identity_ws="$tmp/identity-prefix-$incompatible_prefix"
+    new_v062_workspace "$identity_ws"
+    printf '%s\n' "$incompatible_prefix prefix cannot round-trip" \
+        > "$identity_ws/.beads/source-prefix-$incompatible_prefix"
+    BRIDGE_TEST_TARGET="$REAL_TARGET_BD" \
+        assert_bridge_error "identity-prefix-$incompatible_prefix" \
+            "$identity_ws" 1 inspect refused source_identity_unsupported \
+            --inspect --source-bd "$SOURCE_BD" \
+            --source-dolt "$SOURCE_DOLT" --workspace "$identity_ws"
+done
+
+identity_database_ws="$tmp/identity-database-hyphen"
+new_v062_workspace "$identity_database_ws"
+mv -f -- "$identity_database_ws/.beads/dolt/smoke" \
+    "$identity_database_ws/.beads/dolt/smoke-db"
+jq '.dolt_database = "smoke-db"' \
+    "$identity_database_ws/.beads/metadata.json" \
+    > "$identity_database_ws/.beads/metadata.json.tmp"
+mv -f -- "$identity_database_ws/.beads/metadata.json.tmp" \
+    "$identity_database_ws/.beads/metadata.json"
+BRIDGE_TEST_TARGET="$REAL_TARGET_BD" \
+    assert_bridge_error identity-database-hyphen "$identity_database_ws" \
+        1 inspect refused source_identity_unsupported \
+        --inspect --source-bd "$SOURCE_BD" --source-dolt "$SOURCE_DOLT" \
+        --workspace "$identity_database_ws"
+[ "$(call_count "$TARGET_LOG" init)" -eq \
+    "$target_inits_before_identity_refusal" ] &&
+    [ "$(call_count "$TARGET_LOG" import)" -eq \
+        "$target_imports_before_identity_refusal" ] ||
+    fail "identity refusal reached target init or import"
+
+# Rollback and side-by-side staging destinations are never adopted, replaced,
+# or cleaned when they pre-exist, even when their contents look plausible.
+rollback_collision_ws="$tmp/effectful-rollback-destination"
+new_v062_workspace "$rollback_collision_ws"
+inspect_effectful_plan effectful-rollback-plan "$rollback_collision_ws" \
+    "$SOURCE_BD" "$SOURCE_DOLT" "$TARGET_BD"
+rollback_collision_plan="$EFFECTFUL_PLAN"
+mkdir -p "$rollback_collision_ws/.beads-v0.62.0-rollback"
+printf '%s\n' 'unrelated retained data' \
+    > "$rollback_collision_ws/.beads-v0.62.0-rollback/sentinel"
+assert_bridge_error effectful-rollback-collision "$rollback_collision_ws" \
+    1 apply refused rollback_collision \
+    --apply --yes --expect-plan "$rollback_collision_plan" \
+    --source-bd "$SOURCE_BD" --source-dolt "$SOURCE_DOLT" \
+    --workspace "$rollback_collision_ws"
+
+staging_collision_ws="$tmp/effectful-staging-destination"
+new_v062_workspace "$staging_collision_ws"
+inspect_effectful_plan effectful-staging-plan "$staging_collision_ws" \
+    "$SOURCE_BD" "$SOURCE_DOLT" "$TARGET_BD"
+staging_collision_plan="$EFFECTFUL_PLAN"
+mkdir -p "$staging_collision_ws/.beads-v0.62.0-staging"
+printf '%s\n' 'unrelated staging data' \
+    > "$staging_collision_ws/.beads-v0.62.0-staging/sentinel"
+assert_bridge_error effectful-staging-collision "$staging_collision_ws" \
+    1 apply refused staging_collision \
+    --apply --yes --expect-plan "$staging_collision_plan" \
+    --source-bd "$SOURCE_BD" --source-dolt "$SOURCE_DOLT" \
+    --workspace "$staging_collision_ws"
+
+# Cleanup authority is limited to the bridge's known staging entries. An
+# unexpected descendant survives for inspection after the target commit and
+# converts success into a typed cleanup failure.
+unknown_staging_ws="$tmp/effectful-unknown-staging-entry"
+new_v062_workspace "$unknown_staging_ws"
+inspect_effectful_plan effectful-unknown-staging-plan "$unknown_staging_ws" \
+    "$SOURCE_BD" "$SOURCE_DOLT" "$TARGET_BD"
+unknown_staging_plan="$EFFECTFUL_PLAN"
+unknown_staging_phase_dir="$tmp/effectful-unknown-staging-phase"
+mkdir -m 700 "$unknown_staging_phase_dir"
+touch \
+    "$unknown_staging_phase_dir/after_operation_bundle_prepared_before_fence_publish.continue" \
+    "$unknown_staging_phase_dir/after_operation_fence_before_reinspect.continue" \
+    "$unknown_staging_phase_dir/before_receipt_publish.continue" \
+    "$unknown_staging_phase_dir/before_source_rename.continue" \
+    "$unknown_staging_phase_dir/after_source_rename_before_target_publish.continue" \
+    "$unknown_staging_phase_dir/after_target_publish.continue"
+BRIDGE_TEST_PHASE_DIR="$unknown_staging_phase_dir" \
+    start_bridge_at_phase effectful-unknown-staging "$unknown_staging_ws" \
+        --apply --yes --expect-plan "$unknown_staging_plan" \
+        --source-bd "$SOURCE_BD" --source-dolt "$SOURCE_DOLT" \
+        --workspace "$unknown_staging_ws"
+wait_for_phase "$unknown_staging_phase_dir" \
+    after_staging_publish_before_journal_update \
+    "effectful unknown staging entry"
+printf '%s\n' 'unowned staging bytes' \
+    > "$unknown_staging_ws/.beads-v0.62.0-staging/unexpected-entry"
+touch \
+    "$unknown_staging_phase_dir/after_staging_publish_before_journal_update.continue"
+finish_phase_bridge "effectful unknown staging entry"
+[ "$RUN_STATUS" -eq 1 ] ||
+    fail "unknown staging cleanup exit=$RUN_STATUS, want failure: $RUN_STDOUT $RUN_STDERR"
+assert_common_json apply failed workspace_migrated
+jq -e '.retryable == false and .code == "cleanup_failed"' \
+    <<< "$RUN_STDOUT" >/dev/null ||
+    fail "unknown staging cleanup was misclassified: $RUN_STDOUT"
+[ -f "$unknown_staging_ws/.beads-v0.62.0-staging/unexpected-entry" ] ||
+    fail "cleanup deleted an unexpected staging entry"
+
+# A rename can complete before a later postcondition reports failure. Recovery
+# must reconcile the original inode and restore it before claiming effect:none.
+source_rename_false_failure_ws="$tmp/effectful-source-rename-false-failure"
+new_v062_workspace "$source_rename_false_failure_ws"
+inspect_effectful_plan effectful-source-rename-false-failure-plan \
+    "$source_rename_false_failure_ws" "$SOURCE_BD" "$SOURCE_DOLT" "$TARGET_BD"
+source_rename_false_failure_plan="$EFFECTFUL_PLAN"
+source_rename_false_failure_digest=$(content_fingerprint \
+    "$source_rename_false_failure_ws/.beads")
+BRIDGE_TEST_MV_MODE=fail_after_source_rename \
+    run_bridge effectful-source-rename-false-failure \
+        "$source_rename_false_failure_ws" \
+        --apply --yes --expect-plan "$source_rename_false_failure_plan" \
+        --source-bd "$SOURCE_BD" --source-dolt "$SOURCE_DOLT" \
+        --workspace "$source_rename_false_failure_ws"
+[ "$RUN_STATUS" -eq 1 ] ||
+    fail "source rename false failure exit=$RUN_STATUS, want failure: $RUN_STDOUT $RUN_STDERR"
+assert_common_json apply failed none
+jq -e '
+    .retryable == true and .code == "source_rename_failed"
+' <<< "$RUN_STDOUT" >/dev/null ||
+    fail "source rename false failure was misclassified: $RUN_STDOUT"
+[ -d "$source_rename_false_failure_ws/.beads" ] &&
+    [ "$(content_fingerprint "$source_rename_false_failure_ws/.beads")" = \
+        "$source_rename_false_failure_digest" ] &&
+    [ ! -e "$source_rename_false_failure_ws/.beads-v0.62.0-rollback" ] &&
+    [ ! -e "$source_rename_false_failure_ws/.beads-v0.62.0-staging" ] &&
+    [ ! -e "$source_rename_false_failure_ws/.beads-v0.62.0-migration.lock" ] ||
+    fail "source rename false failure did not restore the exact source"
+run_bridge effectful-source-rename-false-failure-retry \
+    "$source_rename_false_failure_ws" \
+    --apply --yes --expect-plan "$source_rename_false_failure_plan" \
+    --source-bd "$SOURCE_BD" --source-dolt "$SOURCE_DOLT" \
+    --workspace "$source_rename_false_failure_ws"
+[ "$RUN_STATUS" -eq 0 ] ||
+    fail "source rename false-failure retry did not succeed: $RUN_STDOUT $RUN_STDERR"
+assert_common_json apply succeeded workspace_migrated
+
+# The workspace flock belongs only to a dedicated holder. A direct child that
+# outlives a SIGKILLed bridge must not inherit the lock or delay exact-plan
+# recovery.
+lock_handoff_ws="$tmp/effectful-workspace-lock-handoff"
+new_v062_workspace "$lock_handoff_ws"
+inspect_effectful_plan effectful-workspace-lock-handoff-plan \
+    "$lock_handoff_ws" "$SOURCE_BD" "$SOURCE_DOLT" "$TARGET_BD"
+lock_handoff_plan="$EFFECTFUL_PLAN"
+lock_handoff_phase_dir="$tmp/effectful-workspace-lock-handoff-phase"
+mkdir -m 700 "$lock_handoff_phase_dir"
+release_transaction_gap_phases "$lock_handoff_phase_dir"
+touch "$lock_handoff_phase_dir/after_operation_fence_before_reinspect.continue"
+BRIDGE_TEST_FINGERPRINT_FAILURE=hold \
+BRIDGE_TEST_IDENTITY_PROBE_FAILURE=owner_unverifiable \
+BRIDGE_TEST_PHASE_DIR="$lock_handoff_phase_dir" \
+    start_bridge_at_phase effectful-workspace-lock-handoff \
+        "$lock_handoff_ws" \
+        --apply --yes --expect-plan "$lock_handoff_plan" \
+        --source-bd "$SOURCE_BD" --source-dolt "$SOURCE_DOLT" \
+        --workspace "$lock_handoff_ws"
+for ((attempt = 0; attempt < 400; attempt++)); do
+    [ -s "$lock_handoff_phase_dir/workspace-lock-child.identities" ] && break
+    pid_is_running "$ASYNC_BRIDGE_PID" ||
+        fail "workspace-lock handoff bridge exited before its child started"
+    sleep 0.025
+done
+[ -s "$lock_handoff_phase_dir/workspace-lock-child.identities" ] ||
+    fail "workspace-lock handoff child did not start"
+WORKSPACE_LOCK_TEST_IDENTITY_FILE=\
+"$lock_handoff_phase_dir/workspace-lock-child.identities"
+while IFS=' ' read -r pid start; do
+    [[ "$pid" =~ ^[1-9][0-9]*$ ]] && [[ "$start" =~ ^[0-9]+$ ]] &&
+        pid_identity_is_running "$pid" "$start" ||
+        fail "workspace-lock test child identity is not alive: $pid/$start"
+done < "$WORKSPACE_LOCK_TEST_IDENTITY_FILE"
+lock_handoff_runtime=$(last_private_runtime_from_log "$SOURCE_LOG") ||
+    fail "workspace-lock handoff did not expose its private runtime"
+IFS=' ' read -r lock_holder_pid lock_holder_start \
+    < "$lock_handoff_runtime/.workspace-lock-ready" ||
+    fail "workspace-lock holder readiness record is unreadable"
+pid_identity_is_running "$lock_holder_pid" "$lock_holder_start" ||
+    fail "workspace-lock holder identity is not live"
+kill -TERM -- "$lock_holder_pid" 2>/dev/null ||
+    fail "workspace-lock holder could not receive the TERM robustness probe"
+sleep 0.1
+pid_identity_is_running "$lock_holder_pid" "$lock_holder_start" ||
+    fail "workspace-lock holder released on TERM while its owner was live"
+if /usr/bin/flock -x -n "$lock_handoff_ws" /usr/bin/true; then
+    fail "competing workspace flock succeeded while the bridge was alive"
+fi
+hard_kill_phase_bridge "effectful workspace-lock handoff"
+while IFS=' ' read -r pid start; do
+    pid_identity_is_running "$pid" "$start" ||
+        fail "workspace-lock test child $pid did not outlive the bridge"
+done < "$WORKSPACE_LOCK_TEST_IDENTITY_FILE"
+lock_handoff_released=false
+for ((attempt = 0; attempt < 400; attempt++)); do
+    if /usr/bin/flock -x -n "$lock_handoff_ws" /usr/bin/true; then
+        lock_handoff_released=true
+        break
+    fi
+    sleep 0.025
+done
+$lock_handoff_released ||
+    fail "an orphan child retained the workspace flock after bridge SIGKILL"
+run_bridge effectful-workspace-lock-handoff-retry "$lock_handoff_ws" \
+    --apply --yes --expect-plan "$lock_handoff_plan" \
+    --source-bd "$SOURCE_BD" --source-dolt "$SOURCE_DOLT" \
+    --workspace "$lock_handoff_ws"
+[ "$RUN_STATUS" -eq 0 ] ||
+    fail "workspace-lock handoff retry failed: $RUN_STDOUT $RUN_STDERR"
+assert_common_json apply succeeded workspace_migrated
+while IFS=' ' read -r pid start; do
+    terminate_pid_identity_bounded "$pid" "$start" ||
+        fail "workspace-lock test child $pid could not be terminated"
+done < "$WORKSPACE_LOCK_TEST_IDENTITY_FILE"
+WORKSPACE_LOCK_TEST_IDENTITY_FILE=""
+
+# The operation fence and staging inode are published from one fully journaled
+# bundle. SIGKILL in each rename gap must leave either no canonical transaction
+# state or an authenticated stale state that the exact-plan retry can recover.
+kill_bundle_ws="$tmp/effectful-kill-prepared-operation-bundle"
+new_v062_workspace "$kill_bundle_ws"
+inspect_effectful_plan effectful-kill-prepared-bundle-plan "$kill_bundle_ws" \
+    "$SOURCE_BD" "$SOURCE_DOLT" "$TARGET_BD"
+kill_bundle_plan="$EFFECTFUL_PLAN"
+kill_bundle_source=$(content_fingerprint "$kill_bundle_ws/.beads")
+kill_bundle_phase_dir="$tmp/effectful-kill-prepared-bundle-phase"
+mkdir -m 700 "$kill_bundle_phase_dir"
+BRIDGE_TEST_PHASE_DIR="$kill_bundle_phase_dir" \
+    start_bridge_at_phase effectful-kill-prepared-bundle "$kill_bundle_ws" \
+        --apply --yes --expect-plan "$kill_bundle_plan" \
+        --source-bd "$SOURCE_BD" --source-dolt "$SOURCE_DOLT" \
+        --workspace "$kill_bundle_ws"
+wait_for_phase "$kill_bundle_phase_dir" \
+    after_operation_bundle_prepared_before_fence_publish \
+    "SIGKILL after prepared operation bundle"
+kill_bundle_runtime=$(last_private_runtime_from_log "$SOURCE_LOG") ||
+    fail "prepared-bundle operation did not expose its runtime root"
+[ -d "$kill_bundle_ws/.beads" ] &&
+    [ ! -e "$kill_bundle_ws/.beads-v0.62.0-migration.lock" ] &&
+    [ ! -e "$kill_bundle_ws/.beads-v0.62.0-staging" ] &&
+    [ ! -e "$kill_bundle_ws/.beads-v0.62.0-rollback" ] ||
+    fail "prepared operation bundle escaped into canonical workspace state"
+hard_kill_phase_bridge "SIGKILL after prepared operation bundle"
+wait_for_path_absence "$kill_bundle_runtime" \
+    "SIGKILL prepared-bundle runtime root"
+assert_no_workspace_runtime_artifacts "$kill_bundle_ws" \
+    "SIGKILL after prepared operation bundle"
+[ "$(content_fingerprint "$kill_bundle_ws/.beads")" = \
+    "$kill_bundle_source" ] &&
+    [ ! -e "$kill_bundle_ws/.beads-v0.62.0-migration.lock" ] &&
+    [ ! -e "$kill_bundle_ws/.beads-v0.62.0-staging" ] &&
+    [ ! -e "$kill_bundle_ws/.beads-v0.62.0-rollback" ] ||
+    fail "SIGKILL after prepared bundle changed canonical workspace state"
+run_bridge effectful-kill-prepared-bundle-retry "$kill_bundle_ws" \
+    --apply --yes --expect-plan "$kill_bundle_plan" \
+    --source-bd "$SOURCE_BD" --source-dolt "$SOURCE_DOLT" \
+    --workspace "$kill_bundle_ws"
+[ "$RUN_STATUS" -eq 0 ] ||
+    fail "retry after prepared-bundle SIGKILL failed: $RUN_STDOUT $RUN_STDERR"
+assert_common_json apply succeeded workspace_migrated
+
+kill_staging_gap_ws="$tmp/effectful-kill-staging-publication-gap"
+new_v062_workspace "$kill_staging_gap_ws"
+inspect_effectful_plan effectful-kill-staging-gap-plan "$kill_staging_gap_ws" \
+    "$SOURCE_BD" "$SOURCE_DOLT" "$TARGET_BD"
+kill_staging_gap_plan="$EFFECTFUL_PLAN"
+kill_staging_gap_source=$(content_fingerprint "$kill_staging_gap_ws/.beads")
+kill_staging_gap_phase_dir="$tmp/effectful-kill-staging-gap-phase"
+mkdir -m 700 "$kill_staging_gap_phase_dir"
+touch \
+    "$kill_staging_gap_phase_dir/after_operation_bundle_prepared_before_fence_publish.continue" \
+    "$kill_staging_gap_phase_dir/after_operation_fence_before_reinspect.continue"
+BRIDGE_TEST_PHASE_DIR="$kill_staging_gap_phase_dir" \
+    start_bridge_at_phase effectful-kill-staging-gap "$kill_staging_gap_ws" \
+        --apply --yes --expect-plan "$kill_staging_gap_plan" \
+        --source-bd "$SOURCE_BD" --source-dolt "$SOURCE_DOLT" \
+        --workspace "$kill_staging_gap_ws"
+wait_for_phase "$kill_staging_gap_phase_dir" \
+    after_staging_publish_before_journal_update \
+    "SIGKILL after staging publication"
+kill_staging_gap_runtime=$(last_private_runtime_from_log "$SOURCE_LOG") ||
+    fail "staging-gap operation did not expose its runtime root"
+[ "$(content_fingerprint "$kill_staging_gap_ws/.beads")" = \
+    "$kill_staging_gap_source" ] &&
+    [ -f "$kill_staging_gap_ws/.beads-v0.62.0-migration.lock/journal.json" ] &&
+    [ -d "$kill_staging_gap_ws/.beads-v0.62.0-staging" ] &&
+    [ ! -e "$kill_staging_gap_ws/.beads-v0.62.0-rollback" ] ||
+    fail "staging publication gap was not completely journaled"
+hard_kill_phase_bridge "SIGKILL after staging publication"
+wait_for_path_absence "$kill_staging_gap_runtime" \
+    "SIGKILL staging-publication runtime root"
+run_bridge effectful-kill-staging-gap-retry "$kill_staging_gap_ws" \
+    --apply --yes --expect-plan "$kill_staging_gap_plan" \
+    --source-bd "$SOURCE_BD" --source-dolt "$SOURCE_DOLT" \
+    --workspace "$kill_staging_gap_ws"
+[ "$RUN_STATUS" -eq 0 ] ||
+    fail "retry after staging-publication SIGKILL failed: $RUN_STDOUT $RUN_STDERR"
+assert_common_json apply succeeded workspace_migrated
+[ ! -e "$kill_staging_gap_ws/.beads-v0.62.0-migration.lock" ] &&
+    [ ! -e "$kill_staging_gap_ws/.beads-v0.62.0-staging" ] ||
+    fail "staging-gap recovery left transaction artifacts"
+
+kill_retired_fence_ws="$tmp/effectful-kill-retired-operation-fence"
+new_v062_workspace "$kill_retired_fence_ws"
+inspect_effectful_plan effectful-kill-retired-fence-plan \
+    "$kill_retired_fence_ws" "$SOURCE_BD" "$SOURCE_DOLT" "$TARGET_BD"
+kill_retired_fence_plan="$EFFECTFUL_PLAN"
+kill_retired_fence_phase_dir="$tmp/effectful-kill-retired-fence-phase"
+mkdir -m 700 "$kill_retired_fence_phase_dir"
+touch \
+    "$kill_retired_fence_phase_dir/after_operation_bundle_prepared_before_fence_publish.continue" \
+    "$kill_retired_fence_phase_dir/after_operation_fence_before_reinspect.continue" \
+    "$kill_retired_fence_phase_dir/after_staging_publish_before_journal_update.continue" \
+    "$kill_retired_fence_phase_dir/before_receipt_publish.continue" \
+    "$kill_retired_fence_phase_dir/before_source_rename.continue" \
+    "$kill_retired_fence_phase_dir/after_source_rename_before_target_publish.continue" \
+    "$kill_retired_fence_phase_dir/after_target_publish.continue" \
+    "$kill_retired_fence_phase_dir/after_operation_fence_retired_before_private_cleanup.continue"
+BRIDGE_TEST_FAILPOINT=after_private_children_deleted_before_root_rmdir \
+BRIDGE_TEST_IDENTITY_PROBE_FAILURE=owner_unverifiable \
+BRIDGE_TEST_PHASE_DIR="$kill_retired_fence_phase_dir" \
+    start_bridge_at_phase effectful-kill-retired-fence \
+        "$kill_retired_fence_ws" \
+        --apply --yes --expect-plan "$kill_retired_fence_plan" \
+        --source-bd "$SOURCE_BD" --source-dolt "$SOURCE_DOLT" \
+        --workspace "$kill_retired_fence_ws"
+wait_for_phase "$kill_retired_fence_phase_dir" \
+    after_private_children_deleted_before_root_rmdir \
+    "SIGKILL during retired-fence cleanup"
+kill_retired_fence_runtime=$(last_private_runtime_from_log "$SOURCE_LOG") ||
+    fail "retired-fence operation did not expose its runtime root"
+kill_retired_fence_transaction=$(find -P "$kill_retired_fence_ws" \
+    -mindepth 1 -maxdepth 1 -type d \
+    -name '.beads-v0.62.0-migration.runtime.*' -print -quit)
+[ -n "$kill_retired_fence_transaction" ] &&
+    [ ! -e "$kill_retired_fence_transaction/lock" ] &&
+    [ ! -L "$kill_retired_fence_transaction/lock" ] &&
+    [ ! -e "$kill_retired_fence_transaction/staging" ] &&
+    [ ! -L "$kill_retired_fence_transaction/staging" ] ||
+    fail "retired-fence cleanup did not reach the empty-root crash window"
+[ -f "$kill_retired_fence_ws/.beads/v062-migration-receipt.json" ] &&
+    [ -d "$kill_retired_fence_ws/.beads-v0.62.0-rollback" ] &&
+    [ ! -e "$kill_retired_fence_ws/.beads-v0.62.0-migration.lock" ] &&
+    [ ! -e "$kill_retired_fence_ws/.beads-v0.62.0-staging" ] ||
+    fail "retired operation fence remained canonical or lost committed state"
+hard_kill_phase_bridge "SIGKILL during retired-fence cleanup"
+wait_for_path_absence "$kill_retired_fence_runtime" \
+    "SIGKILL retired-fence runtime root"
+assert_no_workspace_runtime_artifacts "$kill_retired_fence_ws" \
+    "SIGKILL during retired-fence cleanup"
+kill_retired_fence_create=$(cd "$kill_retired_fence_ws" &&
+    env -i PATH="$PATH" HOME="$tmp/home" LANG=C LC_ALL=C TZ=UTC TERM=dumb \
+        "$TARGET_BD" create "Post-migration identity probe" --json) ||
+    fail "ordinary write after retired-fence SIGKILL failed"
+kill_retired_fence_create_id=$(jq -er '.id' \
+    <<< "$kill_retired_fence_create") ||
+    fail "ordinary write after retired-fence SIGKILL returned invalid JSON"
+run_bridge effectful-kill-retired-fence-retry "$kill_retired_fence_ws" \
+    --apply --yes --expect-plan "$kill_retired_fence_plan" \
+    --source-bd "$SOURCE_BD" --source-dolt "$SOURCE_DOLT" \
+    --workspace "$kill_retired_fence_ws"
+[ "$RUN_STATUS" -eq 0 ] ||
+    fail "retry after retired-fence SIGKILL failed: $RUN_STDOUT $RUN_STDERR"
+assert_common_json apply succeeded none
+jq -e '.no_op == true' <<< "$RUN_STDOUT" >/dev/null ||
+    fail "retry after retired-fence SIGKILL did not verify a no-op"
+jq -e --arg id "$kill_retired_fence_create_id" \
+    'select(.id == $id)' \
+    "$kill_retired_fence_ws/.beads/fake-target-state.jsonl" >/dev/null ||
+    fail "retired-fence retry lost the post-publication issue"
+
+# Replacing the runtime pathname cannot trick the detached guardian into
+# deleting attacker-owned bytes or ambiguous renamed evidence. A pathname
+# identity mismatch preserves both roots for explicit recovery.
+runtime_replacement_ws="$tmp/effectful-runtime-replacement-race"
+new_v062_workspace "$runtime_replacement_ws"
+inspect_effectful_plan effectful-runtime-replacement-plan \
+    "$runtime_replacement_ws" "$SOURCE_BD" "$SOURCE_DOLT" "$TARGET_BD"
+runtime_replacement_plan="$EFFECTFUL_PLAN"
+runtime_replacement_phase_dir="$tmp/effectful-runtime-replacement-phase"
+mkdir -m 700 "$runtime_replacement_phase_dir"
+touch \
+    "$runtime_replacement_phase_dir/after_operation_bundle_prepared_before_fence_publish.continue"
+BRIDGE_TEST_PHASE_DIR="$runtime_replacement_phase_dir" \
+    start_bridge_at_phase effectful-runtime-replacement \
+        "$runtime_replacement_ws" \
+        --apply --yes --expect-plan "$runtime_replacement_plan" \
+        --source-bd "$SOURCE_BD" --source-dolt "$SOURCE_DOLT" \
+        --workspace "$runtime_replacement_ws"
+wait_for_phase "$runtime_replacement_phase_dir" \
+    after_operation_fence_before_reinspect \
+    "runtime-root replacement race"
+runtime_replacement_root=$(last_private_runtime_from_log "$SOURCE_LOG") ||
+    fail "runtime replacement race did not expose its runtime root"
+runtime_authenticated_root="${runtime_replacement_root}.authenticated"
+runtime_authenticated_source_sha=$(sha256sum \
+    "$runtime_replacement_root/source-bd" | awk '{print $1}')
+mv -fT -- "$runtime_replacement_root" "$runtime_authenticated_root"
+mkdir -m 700 -- "$runtime_replacement_root"
+printf '%s\n' 'replacement must survive guardian cleanup' \
+    > "$runtime_replacement_root/sentinel"
+hard_kill_phase_bridge "runtime-root replacement race"
+# Give the detached guardian a bounded window to observe the dead owner. A
+# pathname-identity mismatch is fail-closed: neither inode is safe to delete.
+for ((runtime_guardian_attempt = 0; \
+    runtime_guardian_attempt < 40; runtime_guardian_attempt++)); do
+    sleep 0.025
+done
+[ -f "$runtime_replacement_root/sentinel" ] &&
+    grep -Fqx 'replacement must survive guardian cleanup' \
+        "$runtime_replacement_root/sentinel" ||
+    fail "guardian deleted or changed the replacement runtime path"
+[ -f "$runtime_authenticated_root/source-bd" ] &&
+    [ "$(sha256sum "$runtime_authenticated_root/source-bd" | awk '{print $1}')" = \
+        "$runtime_authenticated_source_sha" ] ||
+    fail "guardian deleted or changed renamed authenticated runtime evidence"
+rm -rf -- "$runtime_replacement_root" "$runtime_authenticated_root"
+run_bridge effectful-runtime-replacement-retry "$runtime_replacement_ws" \
+    --apply --yes --expect-plan "$runtime_replacement_plan" \
+    --source-bd "$SOURCE_BD" --source-dolt "$SOURCE_DOLT" \
+    --workspace "$runtime_replacement_ws"
+[ "$RUN_STATUS" -eq 0 ] ||
+    fail "retry after runtime replacement SIGKILL failed: $RUN_STDOUT $RUN_STDERR"
+assert_common_json apply succeeded workspace_migrated
+
+# A process death cannot run EXIT traps. The authenticated fence distinguishes a
+# live operation from these three authenticated stale transaction layouts.
+kill_fence_ws="$tmp/effectful-kill-after-fence"
+new_v062_workspace "$kill_fence_ws"
+inspect_effectful_plan effectful-kill-after-fence-plan "$kill_fence_ws" \
+    "$SOURCE_BD" "$SOURCE_DOLT" "$TARGET_BD"
+kill_fence_plan="$EFFECTFUL_PLAN"
+kill_fence_source=$(content_fingerprint "$kill_fence_ws/.beads")
+kill_fence_phase_dir="$tmp/effectful-kill-after-fence-phase"
+mkdir -m 700 "$kill_fence_phase_dir"
+release_transaction_gap_phases "$kill_fence_phase_dir"
+BRIDGE_TEST_PHASE_DIR="$kill_fence_phase_dir" \
+    start_bridge_at_phase effectful-kill-after-fence "$kill_fence_ws" \
+        --apply --yes --expect-plan "$kill_fence_plan" \
+        --source-bd "$SOURCE_BD" --source-dolt "$SOURCE_DOLT" \
+        --workspace "$kill_fence_ws"
+wait_for_phase "$kill_fence_phase_dir" \
+    after_operation_fence_before_reinspect "SIGKILL after operation fence"
+hard_kill_phase_bridge "SIGKILL after operation fence"
+assert_last_private_runtime_removed "$SOURCE_LOG" \
+    "SIGKILL after operation fence"
+[ -f "$kill_fence_ws/.beads-v0.62.0-migration.lock/journal.json" ] ||
+    fail "SIGKILL after fence did not retain its recovery journal"
+replace_journal_owner_with_zombie \
+    "$kill_fence_ws/.beads-v0.62.0-migration.lock/journal.json"
+[ "$(content_fingerprint "$kill_fence_ws/.beads")" = "$kill_fence_source" ] &&
+    [ -d "$kill_fence_ws/.beads-v0.62.0-migration.lock" ] &&
+    [ ! -e "$kill_fence_ws/.beads-v0.62.0-staging" ] &&
+    [ ! -e "$kill_fence_ws/.beads-v0.62.0-rollback" ] ||
+    fail "SIGKILL after fence produced an unrecognized transaction layout"
+run_bridge effectful-kill-after-fence-retry "$kill_fence_ws" \
+    --apply --yes --expect-plan "$kill_fence_plan" \
+    --source-bd "$SOURCE_BD" --source-dolt "$SOURCE_DOLT" \
+    --workspace "$kill_fence_ws"
+stop_journal_owner_zombie
+[ "$RUN_STATUS" -eq 0 ] ||
+    fail "retry after fence SIGKILL failed: $RUN_STDOUT $RUN_STDERR"
+assert_common_json apply succeeded workspace_migrated
+[ ! -e "$kill_fence_ws/.beads-v0.62.0-migration.lock" ] &&
+    [ ! -e "$kill_fence_ws/.beads-v0.62.0-staging" ] ||
+    fail "retry after fence SIGKILL left transaction artifacts"
+
+kill_source_ws="$tmp/effectful-kill-after-source-rename"
+new_v062_workspace "$kill_source_ws"
+inspect_effectful_plan effectful-kill-after-source-plan "$kill_source_ws" \
+    "$SOURCE_BD" "$SOURCE_DOLT" "$TARGET_BD"
+kill_source_plan="$EFFECTFUL_PLAN"
+kill_source_digest=$(content_fingerprint "$kill_source_ws/.beads")
+kill_source_phase_dir="$tmp/effectful-kill-after-source-phase"
+mkdir -m 700 "$kill_source_phase_dir"
+release_transaction_gap_phases "$kill_source_phase_dir"
+touch "$kill_source_phase_dir/after_operation_fence_before_reinspect.continue"
+touch "$kill_source_phase_dir/before_receipt_publish.continue"
+touch "$kill_source_phase_dir/before_source_rename.continue"
+BRIDGE_TEST_PHASE_DIR="$kill_source_phase_dir" \
+    start_bridge_at_phase effectful-kill-after-source "$kill_source_ws" \
+        --apply --yes --expect-plan "$kill_source_plan" \
+        --source-bd "$SOURCE_BD" --source-dolt "$SOURCE_DOLT" \
+        --workspace "$kill_source_ws"
+wait_for_phase "$kill_source_phase_dir" \
+    after_source_rename_before_target_publish "SIGKILL after source rename"
+hard_kill_phase_bridge "SIGKILL after source rename"
+assert_last_private_runtime_removed "$SOURCE_LOG" \
+    "SIGKILL after source rename"
+[ ! -e "$kill_source_ws/.beads" ] &&
+    [ "$(content_fingerprint "$kill_source_ws/.beads-v0.62.0-rollback")" = \
+        "$kill_source_digest" ] &&
+    [ -d "$kill_source_ws/.beads-v0.62.0-staging" ] &&
+    [ -d "$kill_source_ws/.beads-v0.62.0-migration.lock" ] ||
+    fail "SIGKILL after source rename produced an unrecognized transaction layout"
+run_bridge effectful-kill-after-source-retry "$kill_source_ws" \
+    --apply --yes --expect-plan "$kill_source_plan" \
+    --source-bd "$SOURCE_BD" --source-dolt "$SOURCE_DOLT" \
+    --workspace "$kill_source_ws"
+[ "$RUN_STATUS" -eq 0 ] ||
+    fail "retry after source-rename SIGKILL failed: $RUN_STDOUT $RUN_STDERR"
+assert_common_json apply succeeded workspace_migrated
+[ "$(content_fingerprint "$kill_source_ws/.beads-v0.62.0-rollback")" = \
+    "$kill_source_digest" ] &&
+    [ ! -e "$kill_source_ws/.beads-v0.62.0-migration.lock" ] &&
+    [ ! -e "$kill_source_ws/.beads-v0.62.0-staging" ] ||
+    fail "retry after source-rename SIGKILL lost rollback or left artifacts"
+
+# Recovery may restore the retained source only after the staged receipt binds
+# it to the caller's exact consent plan. Preserve every artifact when that
+# receipt is malformed or has been replaced after process death.
+kill_tamper_ws="$tmp/effectful-kill-tampered-staged-receipt"
+new_v062_workspace "$kill_tamper_ws"
+inspect_effectful_plan effectful-kill-tamper-plan "$kill_tamper_ws" \
+    "$SOURCE_BD" "$SOURCE_DOLT" "$TARGET_BD"
+kill_tamper_plan="$EFFECTFUL_PLAN"
+kill_tamper_source=$(content_fingerprint "$kill_tamper_ws/.beads")
+kill_tamper_phase_dir="$tmp/effectful-kill-tamper-phase"
+mkdir -m 700 "$kill_tamper_phase_dir"
+release_transaction_gap_phases "$kill_tamper_phase_dir"
+touch "$kill_tamper_phase_dir/after_operation_fence_before_reinspect.continue"
+touch "$kill_tamper_phase_dir/before_receipt_publish.continue"
+touch "$kill_tamper_phase_dir/before_source_rename.continue"
+BRIDGE_TEST_PHASE_DIR="$kill_tamper_phase_dir" \
+    start_bridge_at_phase effectful-kill-tamper "$kill_tamper_ws" \
+        --apply --yes --expect-plan "$kill_tamper_plan" \
+        --source-bd "$SOURCE_BD" --source-dolt "$SOURCE_DOLT" \
+        --workspace "$kill_tamper_ws"
+wait_for_phase "$kill_tamper_phase_dir" \
+    after_source_rename_before_target_publish \
+    "SIGKILL before staged-receipt tamper"
+hard_kill_phase_bridge "SIGKILL before staged-receipt tamper"
+assert_last_private_runtime_removed "$SOURCE_LOG" \
+    "SIGKILL before staged-receipt tamper"
+kill_tamper_receipt="$kill_tamper_ws/.beads-v0.62.0-staging/target/.beads/v062-migration-receipt.json"
+jq '.plan_digest = "0000000000000000000000000000000000000000000000000000000000000000"' \
+    "$kill_tamper_receipt" > "${kill_tamper_receipt}.tampered"
+chmod 600 "${kill_tamper_receipt}.tampered"
+mv -f -- "${kill_tamper_receipt}.tampered" "$kill_tamper_receipt"
+kill_tamper_rollback_before=$(content_fingerprint \
+    "$kill_tamper_ws/.beads-v0.62.0-rollback")
+kill_tamper_staging_before=$(content_fingerprint \
+    "$kill_tamper_ws/.beads-v0.62.0-staging")
+kill_tamper_lock_before=$(content_fingerprint \
+    "$kill_tamper_ws/.beads-v0.62.0-migration.lock")
+run_bridge effectful-kill-tamper-retry "$kill_tamper_ws" \
+    --apply --yes --expect-plan "$kill_tamper_plan" \
+    --source-bd "$SOURCE_BD" --source-dolt "$SOURCE_DOLT" \
+    --workspace "$kill_tamper_ws"
+[ "$RUN_STATUS" -eq 1 ] ||
+    fail "tampered stale receipt retry exit=$RUN_STATUS, want failure"
+assert_common_json apply failed workspace_requires_recovery
+jq -e '.retryable == false and .code == "recovery_failed"' \
+    <<< "$RUN_STDOUT" >/dev/null ||
+    fail "tampered stale receipt was not refused: $RUN_STDOUT"
+[ ! -e "$kill_tamper_ws/.beads" ] &&
+    [ "$(content_fingerprint "$kill_tamper_ws/.beads-v0.62.0-rollback")" = \
+        "$kill_tamper_rollback_before" ] &&
+    [ "$kill_tamper_rollback_before" = "$kill_tamper_source" ] &&
+    [ "$(content_fingerprint "$kill_tamper_ws/.beads-v0.62.0-staging")" = \
+        "$kill_tamper_staging_before" ] &&
+    [ "$(content_fingerprint "$kill_tamper_ws/.beads-v0.62.0-migration.lock")" = \
+        "$kill_tamper_lock_before" ] ||
+    fail "tampered stale recovery changed or discarded transaction evidence"
+
+kill_publish_ws="$tmp/effectful-kill-after-target-publish"
+new_v062_workspace "$kill_publish_ws"
+inspect_effectful_plan effectful-kill-after-publish-plan "$kill_publish_ws" \
+    "$SOURCE_BD" "$SOURCE_DOLT" "$TARGET_BD"
+kill_publish_plan="$EFFECTFUL_PLAN"
+kill_publish_phase_dir="$tmp/effectful-kill-after-publish-phase"
+mkdir -m 700 "$kill_publish_phase_dir"
+release_transaction_gap_phases "$kill_publish_phase_dir"
+touch "$kill_publish_phase_dir/after_operation_fence_before_reinspect.continue"
+touch "$kill_publish_phase_dir/before_receipt_publish.continue"
+touch "$kill_publish_phase_dir/before_source_rename.continue"
+touch "$kill_publish_phase_dir/after_source_rename_before_target_publish.continue"
+BRIDGE_TEST_PHASE_DIR="$kill_publish_phase_dir" \
+    start_bridge_at_phase effectful-kill-after-publish "$kill_publish_ws" \
+        --apply --yes --expect-plan "$kill_publish_plan" \
+        --source-bd "$SOURCE_BD" --source-dolt "$SOURCE_DOLT" \
+        --workspace "$kill_publish_ws"
+wait_for_phase "$kill_publish_phase_dir" after_target_publish \
+    "SIGKILL after target publication"
+hard_kill_phase_bridge "SIGKILL after target publication"
+assert_last_private_runtime_removed "$SOURCE_LOG" \
+    "SIGKILL after target publication"
+[ -f "$kill_publish_ws/.beads/v062-migration-receipt.json" ] &&
+    [ -d "$kill_publish_ws/.beads-v0.62.0-rollback" ] &&
+    [ -d "$kill_publish_ws/.beads-v0.62.0-staging" ] &&
+    [ -d "$kill_publish_ws/.beads-v0.62.0-migration.lock" ] ||
+    fail "SIGKILL after target publication produced an unrecognized layout"
+kill_publish_create=$(cd "$kill_publish_ws" &&
+    env -i PATH="$PATH" HOME="$tmp/home" LANG=C LC_ALL=C TZ=UTC TERM=dumb \
+        "$TARGET_BD" create "Post-migration identity probe" --json) ||
+    fail "ordinary write after killed publication failed"
+kill_publish_create_id=$(jq -er '.id' <<< "$kill_publish_create") ||
+    fail "ordinary write after killed publication returned invalid JSON"
+run_bridge effectful-kill-after-publish-retry "$kill_publish_ws" \
+    --apply --yes --expect-plan "$kill_publish_plan" \
+    --source-bd "$SOURCE_BD" --source-dolt "$SOURCE_DOLT" \
+    --workspace "$kill_publish_ws"
+[ "$RUN_STATUS" -eq 0 ] ||
+    fail "retry after target-publication SIGKILL failed: $RUN_STDOUT $RUN_STDERR"
+assert_common_json apply succeeded none
+jq -e '.no_op == true' <<< "$RUN_STDOUT" >/dev/null ||
+    fail "retry after killed publication did not verify a no-op"
+jq -e --arg id "$kill_publish_create_id" 'select(.id == $id)' \
+    "$kill_publish_ws/.beads/fake-target-state.jsonl" >/dev/null ||
+    fail "retry after killed publication lost the additive issue"
+[ ! -e "$kill_publish_ws/.beads-v0.62.0-migration.lock" ] &&
+    [ ! -e "$kill_publish_ws/.beads-v0.62.0-staging" ] ||
+    fail "retry after target-publication SIGKILL left transaction artifacts"
+
+# GNU mv --no-clobber can report success when it skipped a rename. Exercise
+# each transaction publication point with a byte-identical destination so
+# content checks cannot be mistaken for proof that the owned source moved.
+receipt_race_ws="$tmp/effectful-receipt-publish-race"
+new_v062_workspace "$receipt_race_ws"
+inspect_effectful_plan effectful-receipt-race-plan "$receipt_race_ws" \
+    "$SOURCE_BD" "$SOURCE_DOLT" "$TARGET_BD"
+receipt_race_plan="$EFFECTFUL_PLAN"
+receipt_race_source=$(content_fingerprint "$receipt_race_ws/.beads")
+receipt_race_phase_dir="$tmp/effectful-receipt-race-phase"
+mkdir -m 700 "$receipt_race_phase_dir"
+release_transaction_gap_phases "$receipt_race_phase_dir"
+touch "$receipt_race_phase_dir/after_operation_fence_before_reinspect.continue"
+touch "$receipt_race_phase_dir/before_source_rename.continue"
+touch "$receipt_race_phase_dir/after_source_rename_before_target_publish.continue"
+touch "$receipt_race_phase_dir/after_target_publish.continue"
+BRIDGE_TEST_MV_MODE=false_success_on_collision \
+BRIDGE_TEST_PHASE_DIR="$receipt_race_phase_dir" \
+    start_bridge_at_phase effectful-receipt-race "$receipt_race_ws" \
+        --apply --yes --expect-plan "$receipt_race_plan" \
+        --source-bd "$SOURCE_BD" --source-dolt "$SOURCE_DOLT" \
+        --workspace "$receipt_race_ws"
+wait_for_phase "$receipt_race_phase_dir" before_receipt_publish \
+    "effectful receipt publication race"
+receipt_race_staged="$receipt_race_ws/.beads-v0.62.0-staging/target/.beads"
+/usr/bin/cp -a -- \
+    "$receipt_race_staged/.v062-migration-receipt.tmp" \
+    "$receipt_race_staged/v062-migration-receipt.json"
+touch "$receipt_race_phase_dir/before_receipt_publish.continue"
+finish_phase_bridge "effectful receipt publication race"
+[ "$RUN_STATUS" -eq 1 ] ||
+    fail "receipt publication race exit=$RUN_STATUS, want failure: $RUN_STDOUT $RUN_STDERR"
+assert_common_json apply failed none
+jq -e '.retryable == false and .code == "receipt_write_failed"' \
+    <<< "$RUN_STDOUT" >/dev/null ||
+    fail "receipt publication race was accepted: $RUN_STDOUT"
+[ "$(content_fingerprint "$receipt_race_ws/.beads")" = \
+    "$receipt_race_source" ] &&
+    [ ! -e "$receipt_race_ws/.beads-v0.62.0-rollback" ] &&
+    [ ! -e "$receipt_race_ws/.beads-v0.62.0-staging" ] &&
+    [ ! -e "$receipt_race_ws/.beads-v0.62.0-migration.lock" ] ||
+    fail "receipt publication race changed the source or leaked transaction state"
+
+source_rename_race_ws="$tmp/effectful-source-rename-race"
+new_v062_workspace "$source_rename_race_ws"
+inspect_effectful_plan effectful-source-rename-race-plan \
+    "$source_rename_race_ws" "$SOURCE_BD" "$SOURCE_DOLT" "$TARGET_BD"
+source_rename_race_plan="$EFFECTFUL_PLAN"
+source_rename_race_digest=$(content_fingerprint \
+    "$source_rename_race_ws/.beads")
+source_rename_race_phase_dir="$tmp/effectful-source-rename-race-phase"
+mkdir -m 700 "$source_rename_race_phase_dir"
+release_transaction_gap_phases "$source_rename_race_phase_dir"
+touch "$source_rename_race_phase_dir/after_operation_fence_before_reinspect.continue"
+touch "$source_rename_race_phase_dir/before_receipt_publish.continue"
+touch "$source_rename_race_phase_dir/after_source_rename_before_target_publish.continue"
+BRIDGE_TEST_MV_MODE=false_success_on_collision \
+BRIDGE_TEST_PHASE_DIR="$source_rename_race_phase_dir" \
+    start_bridge_at_phase effectful-source-rename-race \
+        "$source_rename_race_ws" \
+        --apply --yes --expect-plan "$source_rename_race_plan" \
+        --source-bd "$SOURCE_BD" --source-dolt "$SOURCE_DOLT" \
+        --workspace "$source_rename_race_ws"
+wait_for_phase "$source_rename_race_phase_dir" before_source_rename \
+    "effectful source rename race"
+/usr/bin/cp -a -- "$source_rename_race_ws/.beads" \
+    "$source_rename_race_ws/.beads-v0.62.0-rollback"
+touch "$source_rename_race_phase_dir/before_source_rename.continue"
+finish_phase_bridge "effectful source rename race"
+[ "$RUN_STATUS" -eq 1 ] ||
+    fail "source rename race exit=$RUN_STATUS, want failure: $RUN_STDOUT $RUN_STDERR"
+assert_common_json apply failed none
+jq -e '.retryable == true and .code == "source_rename_failed"' \
+    <<< "$RUN_STDOUT" >/dev/null ||
+    fail "source rename race advanced transaction state: $RUN_STDOUT"
+[ "$(content_fingerprint "$source_rename_race_ws/.beads")" = \
+    "$source_rename_race_digest" ] &&
+    [ "$(content_fingerprint \
+        "$source_rename_race_ws/.beads-v0.62.0-rollback")" = \
+        "$source_rename_race_digest" ] ||
+    fail "source rename race changed the active or colliding source bytes"
+
+target_publish_race_ws="$tmp/effectful-target-publish-race"
+new_v062_workspace "$target_publish_race_ws"
+inspect_effectful_plan effectful-target-publish-race-plan \
+    "$target_publish_race_ws" "$SOURCE_BD" "$SOURCE_DOLT" "$TARGET_BD"
+target_publish_race_plan="$EFFECTFUL_PLAN"
+target_publish_race_source=$(content_fingerprint \
+    "$target_publish_race_ws/.beads")
+target_publish_race_phase_dir="$tmp/effectful-target-publish-race-phase"
+mkdir -m 700 "$target_publish_race_phase_dir"
+release_transaction_gap_phases "$target_publish_race_phase_dir"
+touch "$target_publish_race_phase_dir/after_operation_fence_before_reinspect.continue"
+touch "$target_publish_race_phase_dir/before_receipt_publish.continue"
+touch "$target_publish_race_phase_dir/before_source_rename.continue"
+touch "$target_publish_race_phase_dir/after_target_publish.continue"
+BRIDGE_TEST_MV_MODE=false_success_on_collision \
+BRIDGE_TEST_PHASE_DIR="$target_publish_race_phase_dir" \
+    start_bridge_at_phase effectful-target-publish-race \
+        "$target_publish_race_ws" \
+        --apply --yes --expect-plan "$target_publish_race_plan" \
+        --source-bd "$SOURCE_BD" --source-dolt "$SOURCE_DOLT" \
+        --workspace "$target_publish_race_ws"
+wait_for_phase "$target_publish_race_phase_dir" \
+    after_source_rename_before_target_publish \
+    "effectful target publication race"
+/usr/bin/cp -a -- \
+    "$target_publish_race_ws/.beads-v0.62.0-staging/target/.beads" \
+    "$target_publish_race_ws/.beads"
+touch "$target_publish_race_phase_dir/after_source_rename_before_target_publish.continue"
+finish_phase_bridge "effectful target publication race"
+[ "$RUN_STATUS" -eq 1 ] ||
+    fail "target publication race exit=$RUN_STATUS, want failure: $RUN_STDOUT $RUN_STDERR"
+assert_common_json apply failed workspace_requires_recovery
+jq -e '.retryable == false and .code == "recovery_failed"' \
+    <<< "$RUN_STDOUT" >/dev/null ||
+    fail "target publication race claimed a committed migration: $RUN_STDOUT"
+[ "$(content_fingerprint \
+    "$target_publish_race_ws/.beads-v0.62.0-rollback")" = \
+    "$target_publish_race_source" ] ||
+    fail "target publication race lost the authoritative rollback"
+
+recovery_race_ws="$tmp/effectful-recovery-race"
+new_v062_workspace "$recovery_race_ws"
+inspect_effectful_plan effectful-recovery-race-plan "$recovery_race_ws" \
+    "$SOURCE_BD" "$SOURCE_DOLT" "$TARGET_BD"
+recovery_race_plan="$EFFECTFUL_PLAN"
+recovery_race_source=$(content_fingerprint "$recovery_race_ws/.beads")
+recovery_race_phase_dir="$tmp/effectful-recovery-race-phase"
+mkdir -m 700 "$recovery_race_phase_dir"
+release_transaction_gap_phases "$recovery_race_phase_dir"
+touch "$recovery_race_phase_dir/after_operation_fence_before_reinspect.continue"
+touch "$recovery_race_phase_dir/before_receipt_publish.continue"
+touch "$recovery_race_phase_dir/before_source_rename.continue"
+BRIDGE_TEST_FAILPOINT=after_source_rename_before_target_publish \
+BRIDGE_TEST_MV_MODE=false_success_on_collision \
+BRIDGE_TEST_PHASE_DIR="$recovery_race_phase_dir" \
+    start_bridge_at_phase effectful-recovery-race "$recovery_race_ws" \
+        --apply --yes --expect-plan "$recovery_race_plan" \
+        --source-bd "$SOURCE_BD" --source-dolt "$SOURCE_DOLT" \
+        --workspace "$recovery_race_ws"
+wait_for_phase "$recovery_race_phase_dir" \
+    after_source_rename_before_target_publish \
+    "effectful recovery race"
+/usr/bin/cp -a -- \
+    "$recovery_race_ws/.beads-v0.62.0-staging/target/.beads" \
+    "$recovery_race_ws/.beads"
+touch "$recovery_race_phase_dir/after_source_rename_before_target_publish.continue"
+finish_phase_bridge "effectful recovery race"
+[ "$RUN_STATUS" -eq 1 ] ||
+    fail "recovery race exit=$RUN_STATUS, want failure: $RUN_STDOUT $RUN_STDERR"
+assert_common_json apply failed workspace_requires_recovery
+jq -e '.retryable == false and .code == "recovery_failed"' \
+    <<< "$RUN_STDOUT" >/dev/null ||
+    fail "recovery race claimed that rollback restoration succeeded: $RUN_STDOUT"
+[ "$(content_fingerprint \
+    "$recovery_race_ws/.beads-v0.62.0-rollback")" = \
+    "$recovery_race_source" ] ||
+    fail "recovery race lost the authoritative rollback"
+
+assert_failpoint_preserves_source() {
+    local label="$1" ws="$2" plan="$3" failpoint="$4"
+    local source_before workspace_before phase_dir
+    source_before=$(content_fingerprint "$ws/.beads")
+    workspace_before=$(content_fingerprint "$ws")
+    phase_dir="$tmp/$label-phase"
+    mkdir -m 700 "$phase_dir"
+    release_transaction_gap_phases "$phase_dir"
+    # This helper observes a later cutover phase. Release the earlier
+    # operation-fence hook up front so the bridge can reach that phase.
+    touch "$phase_dir/after_operation_fence_before_reinspect.continue"
+    touch "$phase_dir/before_receipt_publish.continue"
+    case "$failpoint" in
+        after_source_rename_before_target_publish)
+            touch "$phase_dir/before_source_rename.continue"
+            ;;
+    esac
+    BRIDGE_TEST_FAILPOINT="$failpoint" \
+    BRIDGE_TEST_PHASE_DIR="$phase_dir" \
+        start_bridge_at_phase "$label" "$ws" \
+            --apply --yes --expect-plan "$plan" \
+            --source-bd "$SOURCE_BD" --source-dolt "$SOURCE_DOLT" \
+            --workspace "$ws"
+    wait_for_phase "$phase_dir" "$failpoint" "$label"
+    [ -d "$ws/.beads-v0.62.0-migration.lock" ] &&
+        [ ! -L "$ws/.beads-v0.62.0-migration.lock" ] &&
+        [ -d "$ws/.beads-v0.62.0-staging" ] &&
+        [ ! -L "$ws/.beads-v0.62.0-staging" ] ||
+        fail "$label did not reach cutover with a fenced verified candidate"
+    case "$failpoint" in
+        before_source_rename)
+            [ -d "$ws/.beads" ] && [ ! -L "$ws/.beads" ] &&
+                [ ! -e "$ws/.beads-v0.62.0-rollback" ] &&
+                [ -f "$ws/.beads-v0.62.0-staging/target/.beads/v062-migration-receipt.json" ] ||
+                fail "$label exposed an invalid pre-rename layout"
+            [ ! -e "$POISON_BASH_MARKER" ] &&
+                [ ! -e "$POISON_BASH_ENV_MARKER" ] &&
+                [ ! -e "$POISON_PATH_MARKER" ] &&
+                [ ! -e "$POISON_GIT_DIR" ] &&
+                [ ! -e "$POISON_GIT_WORK_TREE" ] &&
+                [ -d "$ws/.beads-v0.62.0-staging/target/.git" ] &&
+                [ ! -e "$ws/.beads-v0.62.0-staging/target/.git/poison-template-marker" ] &&
+                ! grep -F "$POISON_GIT_WORK_TREE" \
+                    "$ws/.beads-v0.62.0-staging/target/.git/config" \
+                    >/dev/null ||
+                fail "$label allowed hostile shell or Git environment state"
+            ;;
+        after_source_rename_before_target_publish)
+            [ ! -e "$ws/.beads" ] && [ ! -L "$ws/.beads" ] &&
+                [ -d "$ws/.beads-v0.62.0-rollback" ] &&
+                [ ! -L "$ws/.beads-v0.62.0-rollback" ] &&
+                [ -f "$ws/.beads-v0.62.0-staging/target/.beads/v062-migration-receipt.json" ] &&
+                [ "$(content_fingerprint "$ws/.beads-v0.62.0-rollback")" = \
+                    "$source_before" ] ||
+                fail "$label exposed an invalid post-rename layout"
+            ;;
+        *) fail "$label requested an unknown observed failpoint: $failpoint" ;;
+    esac
+    touch "$phase_dir/$failpoint.continue"
+    finish_phase_bridge "$label"
+    [ "$RUN_STATUS" -eq 1 ] ||
+        fail "$label exit=$RUN_STATUS, want injected failure exit 1: $RUN_STDOUT $RUN_STDERR"
+    assert_common_json apply failed none
+    jq -e --arg failpoint "$failpoint" '
+        .retryable == true and .code == "injected_failure" and
+        .verification.failpoint == $failpoint and
+        .verification.phase_reached == true
+    ' <<< "$RUN_STDOUT" >/dev/null ||
+        fail "$label lacked stable injected-failure evidence: $RUN_STDOUT"
+    [ -d "$ws/.beads" ] && [ ! -L "$ws/.beads" ] ||
+        fail "$label did not restore the active source directory"
+    [ "$(content_fingerprint "$ws/.beads")" = "$source_before" ] ||
+        fail "$label changed original source bytes"
+    [ "$(content_fingerprint "$ws")" = "$workspace_before" ] ||
+        fail "$label left a workspace artifact after recovery"
+    [ ! -e "$ws/.beads-v0.62.0-rollback" ] &&
+        [ ! -L "$ws/.beads-v0.62.0-rollback" ] ||
+        fail "$label left a rollback publication after failed cutover"
+    [ ! -e "$ws/.beads-v0.62.0-staging" ] &&
+        [ ! -L "$ws/.beads-v0.62.0-staging" ] ||
+        fail "$label left a staging publication after recovery"
+}
+
+before_rename_ws="$tmp/fail-before-source-rename"
+new_v062_workspace "$before_rename_ws"
+inspect_effectful_plan fail-before-source-rename-plan "$before_rename_ws" \
+    "$SOURCE_BD" "$SOURCE_DOLT" "$TARGET_BD"
+before_rename_plan="$EFFECTFUL_PLAN"
+assert_failpoint_preserves_source fail-before-source-rename \
+    "$before_rename_ws" "$before_rename_plan" before_source_rename
+
+# Exercise the harder cutover window on the canonical success workspace, then
+# retry the exact authorized plan. A restored source must remain resumable.
+assert_failpoint_preserves_source fail-after-source-rename \
+    "$effect_ws" "$canonical_plan" \
+    after_source_rename_before_target_publish
+
+# Atomic publication is the irreversible commit point. Once normal commands
+# can see the target, even an injected bridge failure must retain their writes.
+post_publish_ws="$tmp/write-after-target-publish"
+new_v062_workspace "$post_publish_ws"
+inspect_effectful_plan write-after-publish-plan "$post_publish_ws" \
+    "$SOURCE_BD" "$SOURCE_DOLT" "$TARGET_BD"
+post_publish_plan="$EFFECTFUL_PLAN"
+post_publish_phase_dir="$tmp/write-after-publish-phase"
+mkdir -m 700 "$post_publish_phase_dir"
+release_transaction_gap_phases "$post_publish_phase_dir"
+touch "$post_publish_phase_dir/after_operation_fence_before_reinspect.continue"
+touch "$post_publish_phase_dir/before_receipt_publish.continue"
+touch "$post_publish_phase_dir/before_source_rename.continue"
+touch "$post_publish_phase_dir/after_source_rename_before_target_publish.continue"
+BRIDGE_TEST_FAILPOINT=after_target_publish \
+BRIDGE_TEST_PHASE_DIR="$post_publish_phase_dir" \
+    start_bridge_at_phase write-after-publish "$post_publish_ws" \
+        --apply --yes --expect-plan "$post_publish_plan" \
+        --source-bd "$SOURCE_BD" --source-dolt "$SOURCE_DOLT" \
+        --workspace "$post_publish_ws"
+wait_for_phase "$post_publish_phase_dir" after_target_publish \
+    "write-after-publish apply"
+[ -d "$post_publish_ws/.beads-v0.62.0-migration.lock" ] &&
+    [ -f "$post_publish_ws/.beads/v062-migration-receipt.json" ] &&
+    [ -d "$post_publish_ws/.beads-v0.62.0-rollback" ] ||
+    fail "write-after-publish apply did not expose its committed target"
+post_publish_create="$tmp/write-after-publish-create.json"
+(
+    cd "$post_publish_ws"
+    env -i PATH="$PATH" HOME="$tmp/home" LANG=C LC_ALL=C TZ=UTC TERM=dumb \
+        "$TARGET_BD" create "Post-migration identity probe" --json \
+        > "$post_publish_create"
+) || fail "ordinary target write failed after atomic publication"
+post_publish_id=$(jq -er '.id' "$post_publish_create") ||
+    fail "ordinary target write returned invalid JSON"
+touch "$post_publish_phase_dir/after_target_publish.continue"
+finish_phase_bridge "write-after-publish apply"
+[ "$RUN_STATUS" -eq 1 ] ||
+    fail "post-publish failpoint exit=$RUN_STATUS, want injected failure"
+assert_common_json apply failed workspace_migrated
+jq -e '
+    .retryable == true and .code == "injected_failure" and
+    .verification.failpoint == "after_target_publish"
+' <<< "$RUN_STDOUT" >/dev/null ||
+    fail "post-publish failure did not report committed effects: $RUN_STDOUT"
+jq -e --arg id "$post_publish_id" 'select(.id == $id)' \
+    "$post_publish_ws/.beads/fake-target-state.jsonl" >/dev/null ||
+    fail "post-publish recovery discarded an ordinary target write"
+[ ! -e "$post_publish_ws/.beads-v0.62.0-migration.lock" ] &&
+    [ ! -e "$post_publish_ws/.beads-v0.62.0-staging" ] &&
+    [ -d "$post_publish_ws/.beads-v0.62.0-rollback" ] ||
+    fail "post-publish failure leaked committed transaction artifacts"
+
+# A receipt-backed retry verifies the migrated five-record baseline without
+# rejecting ordinary issues written after publication or repeating migration.
+post_publish_retry_before=$(tree_fingerprint "$post_publish_ws")
+post_publish_receipt="$post_publish_ws/.beads/v062-migration-receipt.json"
+post_publish_receipt_before=$(sha256sum "$post_publish_receipt" | awk '{print $1}')
+post_publish_source_exports=$(call_count "$SOURCE_LOG" export)
+post_publish_source_shows=$(call_count "$SOURCE_LOG" show)
+post_publish_target_inits=$(call_count "$TARGET_LOG" init)
+post_publish_target_imports=$(call_count "$TARGET_LOG" import)
+run_bridge write-after-publish-no-op "$post_publish_ws" \
+    --apply --yes --expect-plan "$post_publish_plan" \
+    --source-bd "$SOURCE_BD" --source-dolt "$SOURCE_DOLT" \
+    --workspace "$post_publish_ws"
+[ "$RUN_STATUS" -eq 0 ] ||
+    fail "post-publish retry exit=$RUN_STATUS, want no-op exit 0: $RUN_STDOUT $RUN_STDERR"
+[ -z "$RUN_STDERR" ] ||
+    fail "post-publish retry emitted stderr in JSON mode: $RUN_STDERR"
+assert_common_json apply succeeded none
+jq -e --arg plan "$post_publish_plan" '
+    .retryable == false and .no_op == true and (.code | not) and
+    .plan.digest == $plan and .verification.issue_count == 5 and
+    .verification.semantic_scope_verified == true and
+    .verification.separate_process_reopen == true
+' <<< "$RUN_STDOUT" >/dev/null ||
+    fail "post-publish retry did not report a verified no-op: $RUN_STDOUT"
+assert_unchanged "$post_publish_ws" "$post_publish_retry_before" \
+    "post-publish retry"
+[ "$(sha256sum "$post_publish_receipt" | awk '{print $1}')" = \
+    "$post_publish_receipt_before" ] ||
+    fail "post-publish retry rewrote its completion receipt"
+jq -e --arg id "$post_publish_id" 'select(.id == $id)' \
+    "$post_publish_ws/.beads/fake-target-state.jsonl" >/dev/null ||
+    fail "post-publish retry discarded the ordinary target write"
+[ "$(call_count "$SOURCE_LOG" export)" -eq "$post_publish_source_exports" ] &&
+    [ "$(call_count "$SOURCE_LOG" show)" -eq "$post_publish_source_shows" ] &&
+    [ "$(call_count "$TARGET_LOG" init)" -eq "$post_publish_target_inits" ] &&
+    [ "$(call_count "$TARGET_LOG" import)" -eq "$post_publish_target_imports" ] ||
+    fail "post-publish retry repeated a mutating migration phase"
+
+# Failure to authenticate a newly spawned transaction guardian is bounded.
+# The source remains unchanged while the detached guardian removes the private
+# pre-publication bundle after its owner exits.
+guardian_start_ws="$tmp/effectful-transaction-guardian-start"
+new_v062_workspace "$guardian_start_ws"
+inspect_effectful_plan transaction-guardian-start-plan "$guardian_start_ws" \
+    "$SOURCE_BD" "$SOURCE_DOLT" "$TARGET_BD"
+guardian_start_plan="$EFFECTFUL_PLAN"
+guardian_start_source=$(content_fingerprint "$guardian_start_ws/.beads")
+BRIDGE_TEST_GUARDIAN_START_FAILURE=transaction_guardian_start \
+    run_bridge transaction-guardian-start-unverifiable "$guardian_start_ws" \
+        --apply --yes --expect-plan "$guardian_start_plan" \
+        --source-bd "$SOURCE_BD" --source-dolt "$SOURCE_DOLT" \
+        --workspace "$guardian_start_ws"
+[ "$RUN_STATUS" -eq 1 ] ||
+    fail "transaction guardian start failure exit=$RUN_STATUS, want 1: $RUN_STDOUT $RUN_STDERR"
+assert_common_json apply failed workspace_requires_recovery
+jq -e '.retryable == false and .code == "recovery_failed"' \
+    <<< "$RUN_STDOUT" >/dev/null ||
+    fail "transaction guardian start failure was misclassified: $RUN_STDOUT"
+[ "$(content_fingerprint "$guardian_start_ws/.beads")" = \
+    "$guardian_start_source" ] &&
+    [ ! -e "$guardian_start_ws/.beads-v0.62.0-migration.lock" ] &&
+    [ ! -e "$guardian_start_ws/.beads-v0.62.0-staging" ] ||
+    fail "transaction guardian start failure changed canonical source state"
+assert_no_workspace_runtime_artifacts "$guardian_start_ws" \
+    "transaction guardian start failure"
+run_bridge transaction-guardian-start-retry "$guardian_start_ws" \
+    --apply --yes --expect-plan "$guardian_start_plan" \
+    --source-bd "$SOURCE_BD" --source-dolt "$SOURCE_DOLT" \
+    --workspace "$guardian_start_ws"
+[ "$RUN_STATUS" -eq 0 ] ||
+    fail "transaction guardian start retry failed: $RUN_STDOUT $RUN_STDERR"
+assert_common_json apply succeeded workspace_migrated
+assert_no_workspace_runtime_artifacts "$guardian_start_ws" \
+    "transaction guardian start retry"
+
+source_content_before=$(content_fingerprint "$effect_ws/.beads")
+[ "$source_content_before" = "$canonical_source_tree" ] ||
+    fail "test source manifest disagrees with the inspect-bound observation"
+source_export_before=$(call_count "$SOURCE_LOG" export)
+source_show_before=$(call_count "$SOURCE_LOG" show)
+target_init_before=$(call_count "$TARGET_LOG" init)
+target_import_before=$(call_count "$TARGET_LOG" import)
+target_export_before=$(call_count "$TARGET_LOG" export)
+guardian_success_phase_dir="$tmp/effectful-guardian-success-phase"
+mkdir -m 700 "$guardian_success_phase_dir"
+touch \
+    "$guardian_success_phase_dir/guardian-cooperative-shutdown.enabled" \
+    "$guardian_success_phase_dir/after_operation_bundle_prepared_before_fence_publish.continue" \
+    "$guardian_success_phase_dir/after_operation_fence_before_reinspect.continue" \
+    "$guardian_success_phase_dir/after_staging_publish_before_journal_update.continue" \
+    "$guardian_success_phase_dir/before_receipt_publish.continue" \
+    "$guardian_success_phase_dir/before_source_rename.continue" \
+    "$guardian_success_phase_dir/after_source_rename_before_target_publish.continue" \
+    "$guardian_success_phase_dir/after_target_publish.continue" \
+    "$guardian_success_phase_dir/after_operation_fence_retired_before_private_cleanup.continue"
+GUARDIAN_TEST_PHASE_DIR="$guardian_success_phase_dir"
+BRIDGE_TEST_PHASE_DIR="$guardian_success_phase_dir" \
+    start_bridge_at_phase effectful-apply "$effect_ws" \
+        --apply --yes --expect-plan "$canonical_plan" \
+        --source-bd "$SOURCE_BD" --source-dolt "$SOURCE_DOLT" \
+        --workspace "$effect_ws"
+wait_for_phase "$guardian_success_phase_dir" \
+    transaction_guardian_resource_removed \
+    "transaction guardian cooperative shutdown"
+wait_for_guardian_marker "$guardian_success_phase_dir" \
+    transaction-guardian.stop-waiting \
+    "transaction guardian cooperative shutdown"
+pid_is_running "$ASYNC_BRIDGE_PID" &&
+    [ -f "$guardian_success_phase_dir/transaction-guardian.started" ] &&
+    [ ! -e "$guardian_success_phase_dir/transaction-guardian.done" ] &&
+    [ ! -e "$guardian_success_phase_dir/transaction-guardian.term" ] ||
+    fail "transaction guardian was not live during cooperative shutdown"
+touch "$guardian_success_phase_dir/transaction_guardian_resource_removed.continue"
+wait_for_guardian_marker "$guardian_success_phase_dir" \
+    runtime_guardian_resource_removed.reached \
+    "runtime guardian cooperative shutdown"
+wait_for_guardian_marker "$guardian_success_phase_dir" \
+    runtime-guardian.stop-waiting \
+    "runtime guardian cooperative shutdown"
+pid_is_running "$ASYNC_BRIDGE_PID" &&
+    [ -f "$guardian_success_phase_dir/runtime-guardian.started" ] &&
+    [ ! -e "$guardian_success_phase_dir/runtime-guardian.done" ] &&
+    [ ! -e "$guardian_success_phase_dir/runtime-guardian.term" ] ||
+    fail "runtime guardian was not live during cooperative shutdown"
+touch "$guardian_success_phase_dir/runtime_guardian_resource_removed.continue"
+finish_phase_bridge "effectful apply guardian shutdown"
+GUARDIAN_TEST_PHASE_DIR=""
+[ "$RUN_STATUS" -eq 0 ] ||
+    fail "effectful apply exit=$RUN_STATUS, want 0: $RUN_STDOUT $RUN_STDERR"
+[ -z "$RUN_STDERR" ] ||
+    fail "effectful apply emitted stderr in JSON mode: $RUN_STDERR"
+for guardian in runtime transaction; do
+    [ -f "$guardian_success_phase_dir/$guardian-guardian.started" ] &&
+        [ -f "$guardian_success_phase_dir/$guardian-guardian.done" ] ||
+        fail "$guardian guardian did not complete cooperative cleanup"
+    [ ! -e "$guardian_success_phase_dir/$guardian-guardian.term" ] ||
+        fail "$guardian guardian was stopped by a TERM signal"
+done
+assert_common_json apply succeeded workspace_migrated
+jq -e \
+    --arg plan "$canonical_plan" \
+    --arg rollback "$effect_ws/.beads-v0.62.0-rollback" \
+    --arg source_content "$source_content_before" \
+    --arg issue_prefix "$SOURCE_ISSUE_PREFIX" \
+    --arg database "$SOURCE_DATABASE" \
+    --arg project_id "$SOURCE_PROJECT_ID" '
+    .retryable == false and (.code | not) and
+    .plan.digest == $plan and
+    .plan.semantic_scope == "v062_lossless_core_v1" and
+    .plan.source_identity == {
+        issue_prefix: $issue_prefix,
+        database: $database,
+        project_id: $project_id
+    } and
+    .target.backend == "dolt-embedded" and
+    .rollback.path == $rollback and
+    .rollback.policy == "retain" and
+    .rollback.verified == true and
+    .rollback.tree_sha256 == $source_content and
+    .verification.semantic_scope == "v062_lossless_core_v1" and
+    .verification.semantic_scope_verified == true and
+    .verification.issue_count == 5 and
+    .verification.target_backend_verified == true and
+    .verification.separate_process_reopen == true
+' <<< "$RUN_STDOUT" >/dev/null ||
+    fail "effectful apply overstated or omitted verification: $RUN_STDOUT"
+
+rollback_path="$effect_ws/.beads-v0.62.0-rollback"
+receipt_path="$effect_ws/.beads/v062-migration-receipt.json"
+[ -d "$rollback_path" ] && [ ! -L "$rollback_path" ] ||
+    fail "effectful apply did not retain a physical rollback"
+[ "$(content_fingerprint "$rollback_path")" = "$source_content_before" ] ||
+    fail "retained rollback differs from the admitted source bytes"
+[ -d "$rollback_path/dolt" ] && [ ! -e "$effect_ws/.beads/dolt" ] ||
+    fail "effectful apply left the historical source selected"
+[ -d "$effect_ws/.beads/embeddeddolt/$SOURCE_DATABASE/.dolt" ] &&
+    [ ! -L "$effect_ws/.beads/embeddeddolt" ] ||
+    fail "effectful apply did not publish embedded Dolt"
+jq -e \
+    --arg issue_prefix "$SOURCE_ISSUE_PREFIX" \
+    --arg database "$SOURCE_DATABASE" \
+    --arg project_id "$SOURCE_PROJECT_ID" '
+    .database == "dolt" and .backend == "dolt" and
+    .dolt_mode == "embedded" and .dolt_database == $database and
+    .project_id == $project_id
+' \
+    "$effect_ws/.beads/metadata.json" >/dev/null ||
+    fail "effectful apply did not preserve source identity in embedded metadata"
+[ ! -e "$effect_ws/.beads-v0.62.0-staging" ] &&
+    [ ! -L "$effect_ws/.beads-v0.62.0-staging" ] ||
+    fail "effectful apply leaked its side-by-side staging tree"
+[ -f "$receipt_path" ] && [ ! -L "$receipt_path" ] ||
+    fail "effectful apply did not publish its completion receipt"
+[ "$(stat -c '%a' "$receipt_path")" = 600 ] ||
+    fail "completion receipt is not owner-only"
+jq -e \
+    --arg plan "$canonical_plan" \
+    --arg rollback "$rollback_path" \
+    --arg source_content "$source_content_before" \
+    --arg issue_prefix "$SOURCE_ISSUE_PREFIX" \
+    --arg database "$SOURCE_DATABASE" \
+    --arg project_id "$SOURCE_PROJECT_ID" '
+    .schema_version == 1 and
+    .operation == "v062_server_to_current" and
+    .state == "committed" and .plan_digest == $plan and
+    .semantic_scope == "v062_lossless_core_v1" and
+    .semantic_scope_verified == true and
+    (.semantic_sha256 | type == "string" and
+        test("^[0-9a-f]{64}$")) and
+    .semantic_sha256 == .plan.semantic_baseline.sha256 and
+    .target_backend == "dolt-embedded" and
+    .plan.digest == $plan and
+    .plan.source_identity == {
+        issue_prefix: $issue_prefix,
+        database: $database,
+        project_id: $project_id
+    } and
+    .rollback.path == $rollback and .rollback.verified == true and
+    .rollback.tree_sha256 == $source_content
+' "$receipt_path" >/dev/null ||
+    fail "completion receipt cannot authorize safe idempotent re-entry"
+
+[ "$(call_count "$SOURCE_LOG" export)" -gt "$source_export_before" ] ||
+    fail "effectful apply did not export through the pinned source bd"
+[ "$(call_count "$SOURCE_LOG" show)" -gt "$source_show_before" ] ||
+    fail "effectful apply did not enrich export through source show"
+[ "$(call_count "$TARGET_LOG" init)" -gt "$target_init_before" ] ||
+    fail "effectful apply did not initialize a side-by-side target"
+[ "$(call_count "$TARGET_LOG" import)" -gt "$target_import_before" ] ||
+    fail "effectful apply did not import into the side-by-side target"
+[ "$(call_count "$TARGET_LOG" export)" -gt "$target_export_before" ] ||
+    fail "effectful apply did not verify target audit fields through current export"
+grep -E '^argv=.* export --no-memories -o (.*)$' \
+    "$TARGET_LOG" >/dev/null ||
+    fail "target audit verification omitted export --no-memories"
+[ "$(call_count "$TARGET_LOG" show)" -eq 0 ] ||
+    fail "target audit verification fell back to a lossy show projection"
+grep -E '^argv=.* init --quiet --non-interactive --backend=dolt( |$)' \
+    "$TARGET_LOG" >/dev/null ||
+    fail "effectful apply did not explicitly force the staged Dolt backend"
+if ! grep -E '^argv=.* init .*--prefix legacy( |$)' \
+    "$TARGET_LOG" >/dev/null ||
+    ! grep -E '^argv=.* init .*--database smoke( |$)' \
+        "$TARGET_LOG" >/dev/null ||
+    ! grep -E '^argv=.* init .*--migration-v062-project-id 7ef372b4-4c3c-4e2c-a6cc-29dd2d0a28c6( |$)' \
+        "$TARGET_LOG" >/dev/null; then
+    fail "effectful apply did not initialize with the bound source identity"
+fi
+if grep -E '^argv=.* init .*--(server|shared-server|external)( |$)' \
+    "$TARGET_LOG" >/dev/null; then
+    fail "effectful apply selected a server-mode target during staged init"
+fi
+grep -E '^argv=.* (version|--version)( |$)' "$SOURCE_DOLT_LOG" >/dev/null ||
+    fail "effectful apply did not validate the pinned Dolt runtime"
+grep -E '^argv=.* sql-server( |$)' "$SOURCE_DOLT_LOG" >/dev/null ||
+    fail "effectful apply did not launch the pinned historical Dolt runtime"
+grep -E '^argv=.* --host( |$)' "$SOURCE_DOLT_LOG" >/dev/null ||
+    fail "effectful apply did not probe historical Dolt readiness"
+printf -v original_source_cwd_log_q '%q' "$effect_ws/.beads/dolt"
+grep -F "cwd=$original_source_cwd_log_q" "$SOURCE_DOLT_LOG" >/dev/null &&
+    fail "historical Dolt was started against the original source"
+
+# Reopen the published target in a separate clean process and independently
+# assert the complete five-issue/eight-feature semantic result.
+reopen_stdout="$tmp/effectful-reopen.stdout"
+reopen_stderr="$tmp/effectful-reopen.stderr"
+set +e
+(
+    cd "$effect_ws"
+    env -i PATH="$PATH" HOME="$tmp/home" LANG=C LC_ALL=C TZ=UTC TERM=dumb \
+        "$TARGET_BD" list --json --all -n 0 \
+        > "$reopen_stdout" 2> "$reopen_stderr"
+)
+reopen_status=$?
+set -e
+[ "$reopen_status" -eq 0 ] ||
+    fail "separate-process target reopen exit=$reopen_status"
+[ ! -s "$reopen_stderr" ] ||
+    fail "separate-process target reopen emitted stderr"
+jq -e '
+    def deps:
+        (.dependencies // []) |
+        map({
+            issue_id,
+            depends_on_id,
+            type,
+            created_at,
+            created_by,
+            metadata: ((.metadata // "{}") | fromjson),
+            thread_id: (.thread_id // "")
+        }) | sort_by(.issue_id, .depends_on_id, .type);
+    length == 5 and
+    ([.[].id] | sort) ==
+        ["old-bug", "old-closed", "old-epic", "old-standalone", "old-task"] and
+    any(.[];
+        .id == "old-epic" and .title == "Migration epic" and
+        .description == "Epic for migration testing" and
+        .priority == 2 and .issue_type == "epic" and .status == "open") and
+    any(.[];
+        .id == "old-standalone" and
+        .description == "This task has a detailed description for fidelity testing." and
+        .notes == "Historical notes must survive the upgrade." and
+        .design == "Historical design must survive the upgrade." and
+        .acceptance_criteria == "Historical acceptance criteria must survive the upgrade." and
+        .external_ref == "legacy-upgrade-42") and
+    any(.[]; .id == "old-closed" and .status == "closed") and
+    any(.[];
+        .id == "old-task" and .parent == "old-epic" and
+        (deps == [{
+            issue_id: "old-task",
+            depends_on_id: "old-epic",
+            type: "parent-child",
+            created_at: "2025-01-02T03:04:05Z",
+            created_by: "legacy-parent-author",
+            metadata: {},
+            thread_id: ""
+        }]) and
+        ((.labels // []) | index("urgent") != null) and
+        ((.comments // [] | map({id, issue_id, author, text, created_at})) |
+            index({
+                id: "7dbef7d8-c3af-42e3-9b59-9f30e81e2647",
+                issue_id: "old-task",
+                author: "legacy-author",
+                text: "Historical comment must survive the upgrade.",
+                created_at: "2025-01-04T05:06:07Z"
+            }) != null)) and
+    any(.[];
+        .id == "old-bug" and
+        (deps == [{
+            issue_id: "old-bug",
+            depends_on_id: "old-task",
+            type: "blocks",
+            created_at: "2025-01-03T04:05:06Z",
+            created_by: "legacy-block-author",
+            metadata: {},
+            thread_id: ""
+        }]))
+' "$reopen_stdout" >/dev/null ||
+    fail "separate-process target lost the canonical semantic corpus"
+
+# The retired private bundle is also an authority boundary. If an unknown
+# top-level entry appears after the canonical fence is retired, the bridge
+# preserves it and reports cleanup failure instead of recursively deleting it.
+unknown_root_phase_dir="$tmp/effectful-unknown-transaction-root-phase"
+mkdir -m 700 "$unknown_root_phase_dir"
+touch \
+    "$unknown_root_phase_dir/after_operation_bundle_prepared_before_fence_publish.continue" \
+    "$unknown_root_phase_dir/after_operation_fence_before_reinspect.continue" \
+    "$unknown_root_phase_dir/after_staging_publish_before_journal_update.continue"
+BRIDGE_TEST_PHASE_DIR="$unknown_root_phase_dir" \
+    start_bridge_at_phase effectful-unknown-transaction-root "$effect_ws" \
+        --apply --yes --expect-plan "$canonical_plan" \
+        --source-bd "$SOURCE_BD" --source-dolt "$SOURCE_DOLT" \
+        --workspace "$effect_ws"
+wait_for_phase "$unknown_root_phase_dir" \
+    after_operation_fence_retired_before_private_cleanup \
+    "effectful unknown transaction root"
+unknown_transaction_root=$(find -P "$effect_ws" -mindepth 1 -maxdepth 1 \
+    -type d -name '.beads-v0.62.0-migration.runtime.*' -print -quit)
+[ -n "$unknown_transaction_root" ] ||
+    fail "retired transaction root was not discoverable"
+unknown_transaction_entry=$'lock\nstaging'
+printf '%s\n' 'unowned transaction bytes' \
+    > "$unknown_transaction_root/$unknown_transaction_entry"
+touch \
+    "$unknown_root_phase_dir/after_operation_fence_retired_before_private_cleanup.continue"
+finish_phase_bridge "effectful unknown transaction root"
+[ "$RUN_STATUS" -eq 1 ] ||
+    fail "unknown transaction cleanup exit=$RUN_STATUS, want failure: $RUN_STDOUT $RUN_STDERR"
+assert_common_json apply failed none
+jq -e '.retryable == false and .code == "cleanup_failed"' \
+    <<< "$RUN_STDOUT" >/dev/null ||
+    fail "unknown transaction cleanup was misclassified: $RUN_STDOUT"
+[ -f "$unknown_transaction_root/$unknown_transaction_entry" ] ||
+    fail "cleanup deleted an unexpected transaction-root entry"
+sleep 0.1
+rm -rf -- "$unknown_transaction_root"
+
+# Allowed cleanup names do not authorize a different object type. Replacing
+# journal.json with a directory must preserve its contents just like an
+# entirely unknown entry.
+wrong_lock_type_phase_dir="$tmp/effectful-wrong-lock-type-phase"
+mkdir -m 700 "$wrong_lock_type_phase_dir"
+touch \
+    "$wrong_lock_type_phase_dir/after_operation_bundle_prepared_before_fence_publish.continue" \
+    "$wrong_lock_type_phase_dir/after_operation_fence_before_reinspect.continue" \
+    "$wrong_lock_type_phase_dir/after_staging_publish_before_journal_update.continue"
+BRIDGE_TEST_PHASE_DIR="$wrong_lock_type_phase_dir" \
+    start_bridge_at_phase effectful-wrong-lock-type "$effect_ws" \
+        --apply --yes --expect-plan "$canonical_plan" \
+        --source-bd "$SOURCE_BD" --source-dolt "$SOURCE_DOLT" \
+        --workspace "$effect_ws"
+wait_for_phase "$wrong_lock_type_phase_dir" \
+    after_operation_fence_retired_before_private_cleanup \
+    "effectful wrong lock entry type"
+wrong_lock_type_root=$(find -P "$effect_ws" -mindepth 1 -maxdepth 1 \
+    -type d -name '.beads-v0.62.0-migration.runtime.*' -print -quit)
+[ -n "$wrong_lock_type_root" ] ||
+    fail "wrong-type transaction root was not discoverable"
+mv -f -- "$wrong_lock_type_root/lock/journal.json" \
+    "$tmp/wrong-lock-type-journal.json"
+mkdir -m 700 "$wrong_lock_type_root/lock/journal.json"
+printf '%s\n' 'unowned allowed-name bytes' \
+    > "$wrong_lock_type_root/lock/journal.json/sentinel"
+touch \
+    "$wrong_lock_type_phase_dir/after_operation_fence_retired_before_private_cleanup.continue"
+finish_phase_bridge "effectful wrong lock entry type"
+[ "$RUN_STATUS" -eq 1 ] ||
+    fail "wrong lock type exit=$RUN_STATUS, want failure: $RUN_STDOUT $RUN_STDERR"
+assert_common_json apply failed none
+jq -e '.retryable == false and .code == "cleanup_failed"' \
+    <<< "$RUN_STDOUT" >/dev/null ||
+    fail "wrong lock type cleanup was misclassified: $RUN_STDOUT"
+[ -f "$wrong_lock_type_root/lock/journal.json/sentinel" ] ||
+    fail "cleanup recursively deleted an allowed-name replacement"
+sleep 0.1
+rm -rf -- "$wrong_lock_type_root"
+
+# A second byte-for-byte identical invocation is authorized only by the
+# committed receipt and verified retained rollback. It performs no extraction,
+# initialization, import, publication, or workspace write.
+second_before=$(tree_fingerprint "$effect_ws")
+receipt_before=$(sha256sum "$receipt_path" | awk '{print $1}')
+second_source_exports=$(call_count "$SOURCE_LOG" export)
+second_source_shows=$(call_count "$SOURCE_LOG" show)
+second_target_inits=$(call_count "$TARGET_LOG" init)
+second_target_imports=$(call_count "$TARGET_LOG" import)
+run_bridge effectful-no-op "$effect_ws" \
+    --apply --yes --expect-plan "$canonical_plan" \
+    --source-bd "$SOURCE_BD" --source-dolt "$SOURCE_DOLT" \
+    --workspace "$effect_ws"
+[ "$RUN_STATUS" -eq 0 ] ||
+    fail "second effectful apply exit=$RUN_STATUS, want no-op exit 0"
+[ -z "$RUN_STDERR" ] ||
+    fail "second effectful apply emitted stderr in JSON mode: $RUN_STDERR"
+assert_common_json apply succeeded none
+jq -e \
+    --arg plan "$canonical_plan" --arg rollback "$rollback_path" \
+    --arg issue_prefix "$SOURCE_ISSUE_PREFIX" \
+    --arg database "$SOURCE_DATABASE" \
+    --arg project_id "$SOURCE_PROJECT_ID" '
+    .retryable == false and .no_op == true and (.code | not) and
+    .plan.digest == $plan and .target.backend == "dolt-embedded" and
+    .plan.source_identity == {
+        issue_prefix: $issue_prefix,
+        database: $database,
+        project_id: $project_id
+    } and
+    .rollback.path == $rollback and .rollback.policy == "retain" and
+    .rollback.verified == true and
+    .verification.semantic_scope_verified == true and
+    .verification.separate_process_reopen == true
+' <<< "$RUN_STDOUT" >/dev/null ||
+    fail "second effectful apply did not report a verified no-op: $RUN_STDOUT"
+assert_unchanged "$effect_ws" "$second_before" "second effectful apply"
+[ "$(sha256sum "$receipt_path" | awk '{print $1}')" = "$receipt_before" ] ||
+    fail "no-op invocation rewrote its completion receipt"
+[ "$(call_count "$SOURCE_LOG" export)" -eq "$second_source_exports" ] &&
+    [ "$(call_count "$SOURCE_LOG" show)" -eq "$second_source_shows" ] &&
+[ "$(call_count "$TARGET_LOG" init)" -eq "$second_target_inits" ] &&
+    [ "$(call_count "$TARGET_LOG" import)" -eq "$second_target_imports" ] ||
+    fail "no-op invocation repeated a mutating migration phase"
+
+assert_tampered_completion_refused() {
+    local label="$1" before
+    local exports_before shows_before inits_before imports_before
+    before=$(tree_fingerprint "$effect_ws")
+    exports_before=$(call_count "$SOURCE_LOG" export)
+    shows_before=$(call_count "$SOURCE_LOG" show)
+    inits_before=$(call_count "$TARGET_LOG" init)
+    imports_before=$(call_count "$TARGET_LOG" import)
+    run_bridge "$label" "$effect_ws" \
+        --apply --yes --expect-plan "$canonical_plan" \
+        --source-bd "$SOURCE_BD" --source-dolt "$SOURCE_DOLT" \
+        --workspace "$effect_ws"
+    [ "$RUN_STATUS" -eq 1 ] ||
+        fail "$label exit=$RUN_STATUS, want completion refusal exit 1"
+    assert_common_json apply refused none
+    jq -e '
+        .retryable == false and .code == "completion_state_invalid"
+    ' <<< "$RUN_STDOUT" >/dev/null ||
+        fail "$label did not fail closed on tampered completion state"
+    assert_unchanged "$effect_ws" "$before" "$label"
+    [ "$(call_count "$SOURCE_LOG" export)" -eq "$exports_before" ] &&
+        [ "$(call_count "$SOURCE_LOG" show)" -eq "$shows_before" ] &&
+        [ "$(call_count "$TARGET_LOG" init)" -eq "$inits_before" ] &&
+        [ "$(call_count "$TARGET_LOG" import)" -eq "$imports_before" ] ||
+        fail "$label restarted an effectful migration while refusing tampering"
+}
+
+# A completion claim is authority only while its receipt, retained source, and
+# active target independently agree. Exercise each trust root separately and
+# restore the fixture only after proving that the invocation made no changes.
+receipt_backup="$tmp/effectful-receipt.valid.json"
+cp -p -- "$receipt_path" "$receipt_backup"
+jq '.state = "prepared"' "$receipt_backup" \
+    > "$effect_ws/.beads/.tampered-receipt.json"
+chmod 600 "$effect_ws/.beads/.tampered-receipt.json"
+mv -f -- "$effect_ws/.beads/.tampered-receipt.json" "$receipt_path"
+assert_tampered_completion_refused tampered-completion-receipt
+cp -p -- "$receipt_backup" "$receipt_path"
+
+jq '.plan.strategy.rollback = "delete"' "$receipt_backup" \
+    > "$effect_ws/.beads/.tampered-receipt.json"
+chmod 600 "$effect_ws/.beads/.tampered-receipt.json"
+mv -f -- "$effect_ws/.beads/.tampered-receipt.json" "$receipt_path"
+assert_tampered_completion_refused tampered-completion-plan-digest
+cp -p -- "$receipt_backup" "$receipt_path"
+
+printf '%s\n' 'rollback bytes changed after commit' \
+    > "$rollback_path/.tampered-completion-state"
+assert_tampered_completion_refused tampered-completion-rollback
+rm -f -- "$rollback_path/.tampered-completion-state"
+
+rollback_root_mode=$(stat -c '%a' "$rollback_path")
+case "$rollback_root_mode" in
+    700) rollback_tampered_mode=755 ;;
+    *) rollback_tampered_mode=700 ;;
+esac
+chmod "$rollback_tampered_mode" "$rollback_path"
+assert_tampered_completion_refused tampered-completion-rollback-root-mode
+chmod "$rollback_root_mode" "$rollback_path"
+
+# The receipt cannot redefine which source tree the authenticated plan bound.
+# Even matching rollback bytes and receipt digest must fail when both diverge
+# from the source observation committed in the plan.
+printf '%s\n' 'rollback and receipt changed together after commit' \
+    > "$rollback_path/.paired-tampered-completion-state"
+paired_rollback_digest=$(content_fingerprint "$rollback_path")
+jq --arg digest "$paired_rollback_digest" \
+    '.rollback.tree_sha256 = $digest' "$receipt_backup" \
+    > "$effect_ws/.beads/.tampered-receipt.json"
+chmod 600 "$effect_ws/.beads/.tampered-receipt.json"
+mv -f -- "$effect_ws/.beads/.tampered-receipt.json" "$receipt_path"
+assert_tampered_completion_refused tampered-completion-rollback-receipt-pair
+rm -f -- "$rollback_path/.paired-tampered-completion-state"
+cp -p -- "$receipt_backup" "$receipt_path"
+
+# Project-local routing state is unsafe even after publication; a receipt must
+# not let retry bypass the same routing-artifact refusal enforced at admission.
+printf '%s\n' '../redirected-after-completion' > "$effect_ws/.beads/redirect"
+assert_tampered_completion_refused tampered-completion-routing-redirect
+rm -f -- "$effect_ws/.beads/redirect"
+
+printf '%s\n' 'dolt:' '  host: poison.invalid' '  port: 29998' \
+    > "$effect_ws/.beads/config.yaml"
+assert_tampered_completion_refused tampered-completion-active-config
+rm -f -- "$effect_ws/.beads/config.yaml"
+
+target_dolt="$effect_ws/.beads/embeddeddolt/$SOURCE_DATABASE/.dolt"
+target_dolt_backup="$effect_ws/.beads/embeddeddolt/$SOURCE_DATABASE/.dolt-authentic"
+mv -f -- "$target_dolt" "$target_dolt_backup"
+ln -s .dolt-authentic "$target_dolt"
+assert_tampered_completion_refused tampered-completion-symlink-dolt
+rm -f -- "$target_dolt"
+mv -f -- "$target_dolt_backup" "$target_dolt"
+
+target_metadata="$effect_ws/.beads/metadata.json"
+target_metadata_backup="$tmp/effectful-target-metadata.valid.json"
+cp -p -- "$target_metadata" "$target_metadata_backup"
+jq '.project_id = "00000000-0000-0000-0000-000000000000"' \
+    "$target_metadata_backup" > "$effect_ws/.beads/.tampered-metadata.json"
+mv -f -- "$effect_ws/.beads/.tampered-metadata.json" "$target_metadata"
+assert_tampered_completion_refused tampered-completion-identity
+cp -p -- "$target_metadata_backup" "$target_metadata"
+
+target_config="$effect_ws/.beads/fake-target-config.json"
+target_config_backup="$tmp/effectful-target-config.valid.json"
+cp -p -- "$target_config" "$target_config_backup"
+jq '.issue_prefix = "tampered"' \
+    "$target_config_backup" > "$effect_ws/.beads/.tampered-config.json"
+mv -f -- "$effect_ws/.beads/.tampered-config.json" "$target_config"
+assert_tampered_completion_refused tampered-completion-prefix
+cp -p -- "$target_config_backup" "$target_config"
+
+target_state="$effect_ws/.beads/fake-target-state.jsonl"
+target_state_backup="$tmp/effectful-target-state.valid.jsonl"
+cp -p -- "$target_state" "$target_state_backup"
+jq -c '
+    if .id == "old-standalone"
+    then .title = "Tampered after completion"
+    else .
+    end
+' "$target_state_backup" > "$effect_ws/.beads/.tampered-target.jsonl"
+mv -f -- "$effect_ws/.beads/.tampered-target.jsonl" "$target_state"
+assert_tampered_completion_refused tampered-completion-target
+cp -p -- "$target_state_backup" "$target_state"
+
+# A verified retry is not successful until its operation fence is gone. The
+# target fake adds an unknown lock entry during identity verification so lock
+# retirement fails deterministically without relying on permissions as root.
+touch "$effect_ws/.beads/force-noop-lock-cleanup-failure"
+run_bridge forced-noop-lock-cleanup-failure "$effect_ws" \
+    --apply --yes --expect-plan "$canonical_plan" \
+    --source-bd "$SOURCE_BD" --source-dolt "$SOURCE_DOLT" \
+    --workspace "$effect_ws"
+[ "$RUN_STATUS" -eq 1 ] ||
+    fail "forced no-op cleanup failure exit=$RUN_STATUS, want failure: $RUN_STDOUT $RUN_STDERR"
+assert_common_json apply failed none
+jq -e '.retryable == false and .code == "cleanup_failed"' \
+    <<< "$RUN_STDOUT" >/dev/null ||
+    fail "no-op cleanup failure emitted success before releasing its fence"
+[ -f "$effect_ws/.beads-v0.62.0-migration.lock/unexpected-entry" ] ||
+    fail "no-op cleanup seam did not retain its obstruction evidence"
+rm -f -- \
+    "$effect_ws/.beads/force-noop-lock-cleanup-failure" \
+    "$effect_ws/.beads-v0.62.0-migration.lock/unexpected-entry"
+run_bridge forced-noop-lock-cleanup-recovery "$effect_ws" \
+    --apply --yes --expect-plan "$canonical_plan" \
+    --source-bd "$SOURCE_BD" --source-dolt "$SOURCE_DOLT" \
+    --workspace "$effect_ws"
+[ "$RUN_STATUS" -eq 0 ] ||
+    fail "recovery after forced no-op cleanup failure failed: $RUN_STDOUT $RUN_STDERR"
+assert_common_json apply succeeded none
+jq -e '.no_op == true' <<< "$RUN_STDOUT" >/dev/null ||
+    fail "cleanup recovery did not return a verified no-op"
+[ ! -e "$effect_ws/.beads-v0.62.0-migration.lock" ] ||
+    fail "cleanup recovery left the operation fence"
+
+# Creating new work after migration must continue the source project's ID
+# namespace. The fake persists the record so this cannot pass by printing a
+# canned ID disconnected from the published target metadata.
+post_create_stdout="$tmp/effectful-post-create.stdout"
+post_create_stderr="$tmp/effectful-post-create.stderr"
+set +e
+(
+    cd "$effect_ws"
+    env -i PATH="$PATH" HOME="$tmp/home" LANG=C LC_ALL=C TZ=UTC TERM=dumb \
+        "$TARGET_BD" create "Post-migration identity probe" --json \
+        > "$post_create_stdout" 2> "$post_create_stderr"
+)
+post_create_status=$?
+set -e
+[ "$post_create_status" -eq 0 ] ||
+    fail "post-migration create exit=$post_create_status"
+[ ! -s "$post_create_stderr" ] ||
+    fail "post-migration create emitted stderr"
+jq -e --arg prefix "$SOURCE_ISSUE_PREFIX" '
+    (.id | startswith($prefix + "-")) and
+    .title == "Post-migration identity probe"
+' "$post_create_stdout" >/dev/null ||
+    fail "post-migration create did not use the preserved issue prefix"
+post_create_id=$(jq -er '.id' "$post_create_stdout")
+jq -e --arg id "$post_create_id" \
+    'select(.id == $id and .title == "Post-migration identity probe")' \
+    "$target_state" >/dev/null ||
+    fail "post-migration create did not persist its prefixed issue"
+
+# Every subprocess boundary is provider-hostile by construction. None of the
+# PostgreSQL, MySQL, SQLite, external-Dolt, or path selectors may survive.
+assert_log_unpoisoned "$TARGET_LOG" "target bd"
+assert_log_unpoisoned "$SOURCE_LOG" "source bd"
+assert_log_unpoisoned "$SOURCE_DOLT_LOG" "source Dolt runtime"
+assert_log_unpoisoned "$BAD_SOURCE_LOG" "invalid source bd"
+assert_log_unpoisoned "$BAD_SOURCE_DOLT_LOG" "invalid source Dolt runtime"
+if [ -s "${SOURCE_DOLT_LOG}.pids" ]; then
+    while IFS= read -r source_dolt_pid; do
+        [[ "$source_dolt_pid" =~ ^[1-9][0-9]*$ ]] ||
+            fail "historical Dolt fake recorded an invalid process ID"
+        if kill -0 "$source_dolt_pid" 2>/dev/null; then
+            fail "historical Dolt child $source_dolt_pid leaked after bridge completion"
+        fi
+    done < <(LC_ALL=C sort -u "${SOURCE_DOLT_LOG}.pids")
+fi
 
 printf 'public-v062-bridge-test: PASS\n'

--- a/scripts/migration-test/public-v062-bridge-test.sh
+++ b/scripts/migration-test/public-v062-bridge-test.sh
@@ -1,6 +1,30 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Test coverage scope
+# -------------------
+# This harness drives the public v0.62 bridge's apply / crash-injection /
+# rollback / idempotency / losslessness matrix against deterministic bash+jq
+# fakes (make_fake_bd, make_fake_source_bd, make_fake_source_dolt) that stand in
+# for source-bd, source-dolt, and the target-bd. Because the fakes emit real
+# ".beads" layouts, the matrix genuinely exercises the bridge's control flow,
+# refusal codes, and, most importantly, its filesystem transaction (atomic
+# ".beads" renames + inode journal) and crash-recovery behavior. It does NOT
+# run a real Dolt import, so a real-Dolt losslessness regression (a dropped
+# field, or a mid-cutover real-engine crash) would not turn this matrix red.
+#
+# Real-Dolt import losslessness is guarded elsewhere, not by this suite:
+#   - run.sh's server->embedded strict lane (run_public_v062_bridge) drives the
+#     bridge end to end against the real current bd and a real pinned dolt. That
+#     lane is happy-path only (no failpoint/SIGKILL injection) and is SKIP-gated
+#     when a real dolt runtime is unavailable.
+#   - The production bridge fails closed on a lossy real import at runtime: after
+#     importing into the embedded target it runs semantics_match against the
+#     source and rolls back on mismatch (see migrate-v062-server-to-current.sh),
+#     so end users are protected regardless of this suite's mock realism.
+#
+# Do not read the fake-target assertions below as real-Dolt coverage.
+
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 BRIDGE="$REPO_ROOT/scripts/migrate-v062-server-to-current.sh"
 

--- a/scripts/migration-test/recipes/server_to_embedded.sh
+++ b/scripts/migration-test/recipes/server_to_embedded.sh
@@ -3,10 +3,9 @@
 #
 # Each server-era release needs an explicit extraction strategy. v0.55.4 has
 # a lossless native export for the qualified fixture. v0.57.0 needs its native
-# export enriched with comment bodies from one-item show queries. v0.62.0 uses
-# the same bridge after normalizing the three derived epic counters that its
-# show command adds but its export command omits. v0.56.1 and v0.58.0 remain
-# unqualified.
+# export enriched with comment bodies from one-item show queries. v0.56.1 and
+# v0.58.0 remain unqualified. v0.62.0 must use the public bridge instead of
+# this harness-private recipe.
 #
 # Strategy:
 #   1. Stop any running Dolt server
@@ -15,10 +14,9 @@
 #   4. If candidate DB is empty, reimport from JSONL export
 #
 # User-facing instructions:
-#   Use the pinned migration harness for qualified v0.55.4, v0.57.0, and
-#   v0.62.0 core fixtures. It stops the historical server, retains a
-#   byte-verified rollback tree, extracts and validates JSONL, and only then
-#   initializes the candidate.
+#   Use the pinned migration harness for qualified v0.55.4 and v0.57.0 core
+#   fixtures. It stops the historical server, retains a byte-verified rollback
+#   tree, extracts and validates JSONL, and only then initializes the candidate.
 
 publish_legacy_dolt_rollback() {
     mv --no-target-directory --no-clobber --no-copy -- "$1" "$2"
@@ -387,6 +385,11 @@ recipe_server_to_embedded() {
     local export_path="$ws/.beads/issues.jsonl"
     local existing_export_state="absent"
     local existing_export_checksum=""
+
+    if [ "$version" = "v0.62.0" ]; then
+        echo "  FAILED: v0.62.0 must use the public migration bridge"
+        return 1
+    fi
 
     echo "  Trying server→embedded recipe..."
     strategy=$(server_bridge_strategy "$version") || {

--- a/scripts/migration-test/run.sh
+++ b/scripts/migration-test/run.sh
@@ -61,6 +61,8 @@ verify_strict_retained_source() {
     local era="$2"
     local sqlite_manifest="$3"
     local legacy_dolt_manifest="$4"
+    local version="${5:-}"
+    local source_fingerprint="${6:-}"
 
     case "$era" in
         sqlite)
@@ -68,13 +70,186 @@ verify_strict_retained_source() {
                 verify_retained_sqlite_source "$ws/.beads" "$sqlite_manifest"
             ;;
         dolt_server)
-            [ -n "$legacy_dolt_manifest" ] && \
-                verify_retained_legacy_dolt_source "$ws/.beads" "$legacy_dolt_manifest"
+            if [ "$version" = "v0.62.0" ]; then
+                local retained_fingerprint=""
+                [ -n "$source_fingerprint" ] || return 1
+                retained_fingerprint=$(source_artifact_fingerprint \
+                    "$ws/.beads-v0.62.0-rollback") || return 1
+                if [ "$retained_fingerprint" != "$source_fingerprint" ]; then
+                    echo "  FIDELITY: retained public v0.62.0 rollback source changed" >&2
+                    return 1
+                fi
+            else
+                [ -n "$legacy_dolt_manifest" ] && \
+                    verify_retained_legacy_dolt_source \
+                        "$ws/.beads" "$legacy_dolt_manifest"
+            fi
             ;;
         *)
             return 0
             ;;
     esac
+}
+
+PUBLIC_V062_BRIDGE_FAILURE_DETAIL=""
+
+run_public_v062_bridge() {
+    local ws="$1"
+    local source_bd="$2"
+    local target_bd="$3"
+    local source_identity="$4"
+    local bridge="$PROJECT_ROOT/scripts/migrate-v062-server-to-current.sh"
+    local source_dolt=""
+    local inspect_output=""
+    local inspect_json=""
+    local inspect_status=0
+    local inspect_code=""
+    local plan_digest=""
+    local apply_output=""
+    local apply_json=""
+    local apply_status=0
+    local apply_code=""
+    local no_op_output=""
+    local no_op_json=""
+    local no_op_status=0
+    local no_op_code=""
+
+    PUBLIC_V062_BRIDGE_FAILURE_DETAIL=""
+    if [ ! -f "$bridge" ] || [ -L "$bridge" ] || [ ! -x "$bridge" ]; then
+        PUBLIC_V062_BRIDGE_FAILURE_DETAIL="public v0.62 bridge is unavailable"
+        echo "  FAILED: $PUBLIC_V062_BRIDGE_FAILURE_DETAIL"
+        return 1
+    fi
+
+    source_dolt=$(type -P dolt 2>/dev/null) || source_dolt=""
+    if [ -n "$source_dolt" ]; then
+        source_dolt=$(readlink -f -- "$source_dolt" 2>/dev/null) || source_dolt=""
+    fi
+    if [ -z "$source_dolt" ] || [ ! -f "$source_dolt" ] || \
+        [ ! -x "$source_dolt" ]; then
+        PUBLIC_V062_BRIDGE_FAILURE_DETAIL="pinned v0.62 Dolt runtime is unavailable"
+        echo "  FAILED: $PUBLIC_V062_BRIDGE_FAILURE_DETAIL"
+        return 1
+    fi
+
+    inspect_output=$("$bridge" \
+        --inspect --source-bd "$source_bd" --source-dolt "$source_dolt" \
+        --workspace "$ws" --target-bd "$target_bd" --json) || \
+        inspect_status=$?
+    inspect_json=$(jq -cse '
+        if length == 1 and (.[0] | type) == "object"
+        then .[0]
+        else empty
+        end
+    ' <<< "$inspect_output") || inspect_json=""
+
+    if [ "$inspect_status" -ne 0 ]; then
+        if [ -n "$inspect_json" ]; then
+            inspect_code=$(jq -r '.code // empty' <<< "$inspect_json" 2>/dev/null) || \
+                inspect_code=""
+        fi
+        PUBLIC_V062_BRIDGE_FAILURE_DETAIL="public v0.62 bridge inspect failed: ${inspect_code:-exit $inspect_status}"
+        echo "  FAILED: $PUBLIC_V062_BRIDGE_FAILURE_DETAIL"
+        return 1
+    fi
+    if [ -z "$inspect_json" ]; then
+        PUBLIC_V062_BRIDGE_FAILURE_DETAIL="public v0.62 bridge inspect returned invalid JSON"
+        echo "  FAILED: $PUBLIC_V062_BRIDGE_FAILURE_DETAIL"
+        return 1
+    fi
+
+    plan_digest=$(jq -er --argjson source_identity "$source_identity" '
+        select(
+            .schema_version == 1 and
+            .operation == "v062_server_to_current" and
+            .mode == "inspect" and
+            .status == "planned" and
+            .effect == "none" and
+            .source.database == $source_identity.database and
+            .source.project_id == $source_identity.project_id and
+            .plan.source_identity == $source_identity
+        ) |
+        .plan.digest |
+        select(type == "string" and test("^[0-9a-f]{64}$"))
+    ' <<< "$inspect_json" 2>/dev/null) || plan_digest=""
+    if [ -z "$plan_digest" ]; then
+        PUBLIC_V062_BRIDGE_FAILURE_DETAIL="public v0.62 bridge inspect returned no bindable plan"
+        echo "  FAILED: $PUBLIC_V062_BRIDGE_FAILURE_DETAIL"
+        return 1
+    fi
+
+    apply_output=$("$bridge" \
+        --apply --yes --expect-plan "$plan_digest" \
+        --source-bd "$source_bd" --source-dolt "$source_dolt" \
+        --workspace "$ws" --target-bd "$target_bd" --json) || \
+        apply_status=$?
+    apply_json=$(jq -cse '
+        if length == 1 and (.[0] | type) == "object"
+        then .[0]
+        else empty
+        end
+    ' <<< "$apply_output") || apply_json=""
+
+    if [ "$apply_status" -ne 0 ]; then
+        if [ -n "$apply_json" ]; then
+            apply_code=$(jq -r '.code // empty' <<< "$apply_json" 2>/dev/null) || \
+                apply_code=""
+        fi
+        PUBLIC_V062_BRIDGE_FAILURE_DETAIL="public v0.62 bridge apply failed: ${apply_code:-exit $apply_status}"
+        echo "  FAILED: $PUBLIC_V062_BRIDGE_FAILURE_DETAIL"
+        return 1
+    fi
+    if ! jq -e --arg plan_digest "$plan_digest" \
+        --argjson source_identity "$source_identity" '
+        .schema_version == 1 and
+        .operation == "v062_server_to_current" and
+        .mode == "apply" and
+        .status == "succeeded" and
+        .effect == "workspace_migrated" and
+        .plan.digest == $plan_digest and
+        .plan.source_identity == $source_identity and
+        .target.backend == "dolt-embedded"
+    ' >/dev/null 2>&1 <<< "$apply_json"; then
+        PUBLIC_V062_BRIDGE_FAILURE_DETAIL="public v0.62 bridge apply returned an invalid success result"
+        echo "  FAILED: $PUBLIC_V062_BRIDGE_FAILURE_DETAIL"
+        return 1
+    fi
+
+    no_op_output=$("$bridge" \
+        --apply --yes --expect-plan "$plan_digest" \
+        --source-bd "$source_bd" --source-dolt "$source_dolt" \
+        --workspace "$ws" --target-bd "$target_bd" --json) || \
+        no_op_status=$?
+    no_op_json=$(jq -cse '
+        if length == 1 and (.[0] | type) == "object"
+        then .[0]
+        else empty
+        end
+    ' <<< "$no_op_output") || no_op_json=""
+    if [ "$no_op_status" -ne 0 ]; then
+        if [ -n "$no_op_json" ]; then
+            no_op_code=$(jq -r '.code // empty' <<< "$no_op_json" 2>/dev/null) ||
+                no_op_code=""
+        fi
+        PUBLIC_V062_BRIDGE_FAILURE_DETAIL="public v0.62 bridge no-op verification failed: ${no_op_code:-exit $no_op_status}"
+        echo "  FAILED: $PUBLIC_V062_BRIDGE_FAILURE_DETAIL"
+        return 1
+    fi
+    if ! jq -e --arg plan_digest "$plan_digest" \
+        --argjson source_identity "$source_identity" '
+        .schema_version == 1 and
+        .operation == "v062_server_to_current" and
+        .mode == "apply" and .status == "succeeded" and
+        .effect == "none" and .no_op == true and
+        .plan.digest == $plan_digest and
+        .plan.source_identity == $source_identity and
+        .target.backend == "dolt-embedded" and
+        .verification.separate_process_reopen == true
+    ' >/dev/null 2>&1 <<< "$no_op_json"; then
+        PUBLIC_V062_BRIDGE_FAILURE_DETAIL="public v0.62 bridge returned an invalid receipt-backed no-op"
+        echo "  FAILED: $PUBLIC_V062_BRIDGE_FAILURE_DETAIL"
+        return 1
+    fi
 }
 
 verify_v062_prestarted_source() {
@@ -133,6 +308,150 @@ verify_v062_prestarted_source() {
             .schema_version == "9")
     ' <<< "$schema_json" >/dev/null; then
         echo "v0.62.0 source schema version is not exactly string 9"
+        return 1
+    fi
+}
+
+capture_v062_source_identity() {
+    local ws="$1" source_bd="$2"
+    local metadata="$ws/.beads/metadata.json"
+    local context_output database project_id prefix_output issue_prefix
+
+    context_output=$(bd_in "$ws" "$source_bd" context --json 2>/dev/null) || {
+        echo "could not read the v0.62.0 source context" >&2
+        return 1
+    }
+    database=$(jq -crse '
+        if length == 1 then .[0] else empty end |
+        select(
+            type == "object" and .backend == "dolt" and
+            .dolt_mode == "server" and
+            (.database | type) == "string" and
+            (.database | test("^[A-Za-z_][A-Za-z0-9_-]{0,63}$")) and
+            (.project_id | type) == "string" and
+            (.project_id | test(
+                "^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$"
+            ))
+        ) |
+        .database
+    ' 2>/dev/null <<< "$context_output") || {
+        echo "v0.62.0 returned an invalid source context" >&2
+        return 1
+    }
+    project_id=$(jq -er '.project_id' <<< "$context_output" 2>/dev/null) ||
+        return 1
+    if ! jq -e --arg database "$database" --arg project_id "$project_id" '
+        .backend == "dolt" and .dolt_mode == "server" and
+        .dolt_database == $database and .project_id == $project_id
+    ' "$metadata" >/dev/null 2>&1; then
+        echo "v0.62.0 context and metadata identities disagree" >&2
+        return 1
+    fi
+    prefix_output=$(bd_in "$ws" "$source_bd" \
+        config get issue_prefix --json 2>/dev/null) || {
+        echo "could not read the v0.62.0 source issue prefix" >&2
+        return 1
+    }
+    issue_prefix=$(jq -crse '
+        if length == 1 then .[0] else empty end |
+        select(
+            type == "object" and keys == ["key", "value"] and
+            .key == "issue_prefix" and
+            (.value | type) == "string" and
+            (.value | test("^[A-Za-z][A-Za-z0-9._-]{0,63}$"))
+        ) |
+        .value
+    ' 2>/dev/null <<< "$prefix_output") || {
+        echo "v0.62.0 returned an invalid issue-prefix identity" >&2
+        return 1
+    }
+    jq -cn \
+        --arg issue_prefix "$issue_prefix" --arg database "$database" \
+        --arg project_id "$project_id" '
+        {
+            issue_prefix: $issue_prefix,
+            database: $database,
+            project_id: $project_id
+        }
+    '
+}
+
+verify_v062_migrated_identity() {
+    local ws="$1" candidate_bd="$2" source_identity="$3"
+    local metadata="$ws/.beads/metadata.json"
+    local context_output prefix_output create_output created_id show_output
+
+    if [ ! -f "$metadata" ] || [ -L "$metadata" ] ||
+        ! jq -e --argjson source_identity "$source_identity" '
+            .backend == "dolt" and .dolt_mode == "embedded" and
+            (.dolt_database // .database) == $source_identity.database and
+            .project_id == $source_identity.project_id
+        ' "$metadata" >/dev/null 2>&1; then
+        echo "migrated metadata does not preserve the v0.62.0 source identity"
+        return 1
+    fi
+    context_output=$(bd_in "$ws" "$candidate_bd" context --json 2>/dev/null) || {
+        echo "could not read the migrated backend context"
+        return 1
+    }
+    if ! jq -cse --argjson source_identity "$source_identity" '
+        if length == 1 then .[0] else empty end |
+        select(
+            type == "object" and .schema_version == 1 and
+            .backend == "dolt" and .dolt_mode == "embedded" and
+            .database == $source_identity.database and
+            .project_id == $source_identity.project_id and
+            (has("server_host") | not) and (has("server_port") | not)
+        )
+    ' >/dev/null 2>&1 <<< "$context_output"; then
+        echo "migrated context does not preserve the embedded source identity"
+        return 1
+    fi
+    prefix_output=$(bd_in "$ws" "$candidate_bd" \
+        config get issue_prefix --json 2>/dev/null) || {
+        echo "could not read the migrated database-backed issue prefix"
+        return 1
+    }
+    if ! jq -cse --argjson source_identity "$source_identity" '
+        if length == 1 then .[0] else empty end |
+        select(
+            type == "object" and
+            keys == ["key", "schema_version", "value"] and
+            .schema_version == 1 and
+            .key == "issue_prefix" and
+            .value == $source_identity.issue_prefix
+        )
+    ' >/dev/null 2>&1 <<< "$prefix_output"; then
+        echo "migrated database does not preserve the v0.62.0 issue prefix"
+        return 1
+    fi
+    create_output=$(bd_in "$ws" "$candidate_bd" \
+        create "Post-upgrade identity probe" --json 2>/dev/null) || {
+        echo "could not create a post-upgrade identity probe"
+        return 1
+    }
+    created_id=$(jq -crse --argjson source_identity "$source_identity" '
+        if length == 1 then .[0] else empty end |
+        select(
+            type == "object" and .schema_version == 1 and
+            (.id | type) == "string" and
+            (.id | startswith($source_identity.issue_prefix + "-"))
+        ) |
+        .id
+    ' 2>/dev/null <<< "$create_output") || {
+        echo "post-upgrade issue creation did not retain the v0.62.0 prefix"
+        return 1
+    }
+    show_output=$(bd_in "$ws" "$candidate_bd" \
+        show --id="$created_id" --json 2>/dev/null) || {
+        echo "could not reopen the post-upgrade identity probe"
+        return 1
+    }
+    if ! jq -cse --arg id "$created_id" '
+        if length == 1 then .[0] else empty end |
+        select(type == "array" and length == 1 and .[0].id == $id)
+    ' >/dev/null 2>&1 <<< "$show_output"; then
+        echo "post-upgrade identity probe was not persisted"
         return 1
     fi
 }
@@ -275,6 +594,7 @@ test_direct_path() {
         return 0
     fi
     migration_run_activate_workspace "$WS" "$SNAPSHOTS_DIR"
+    local source_identity_json=""
 
     # Step 1: Init with source binary
     local init_ok=false
@@ -315,7 +635,7 @@ test_direct_path() {
         if init_output=$(bd_in "$WS" "$src_bin" init \
             --quiet \
             --server-host 127.0.0.1 --server-port "$init_port" \
-            --database smoke --prefix smoke </dev/null 2>&1); then
+            --database smoke --prefix legacy </dev/null 2>&1); then
             init_ok=true
         else
             local init_first_line=""
@@ -404,6 +724,28 @@ test_direct_path() {
         echo -e "  ${RED}BLOCKED: ${RESULT_DETAILS[-1]}${NC}"
         return 0
     fi
+    if [ "$version" = "v0.62.0" ]; then
+        if ! capture_v062_source_identity "$WS" "$src_bin" \
+            > "$SNAPSHOTS_DIR/source-identity.json"; then
+            migration_run_record_result_after_cleanup \
+                "$WS" "$SNAPSHOTS_DIR" "$path_label" "BLOCKED" \
+                "could not capture the authenticated v0.62.0 source identity" || true
+            echo -e "  ${RED}BLOCKED: ${RESULT_DETAILS[-1]}${NC}"
+            return 0
+        fi
+        source_identity_json=$(jq -ce '
+            select(
+                type == "object" and
+                keys == ["database", "issue_prefix", "project_id"]
+            )
+        ' "$SNAPSHOTS_DIR/source-identity.json" 2>/dev/null) || {
+            migration_run_record_result_after_cleanup \
+                "$WS" "$SNAPSHOTS_DIR" "$path_label" "BLOCKED" \
+                "captured v0.62.0 source identity is invalid" || true
+            echo -e "  ${RED}BLOCKED: ${RESULT_DETAILS[-1]}${NC}"
+            return 0
+        }
+    fi
 
     # Stop source server before upgrade
     if ! stop_dolt_server "$WS"; then
@@ -412,6 +754,38 @@ test_direct_path() {
             "could not prove the historical server stopped before upgrade; preserved at $WS"
         echo -e "  ${RED}BLOCKED: could not prove the historical server stopped before upgrade${NC}"
         return 0
+    fi
+
+    # Exercise the public bridge against authentic v0.62 routing conflicts.
+    # Historical bd must not follow either source when the bridge binds its
+    # private server explicitly by host, port, and database.
+    if $STRICT_MODE && [ "$version" = "v0.62.0" ]; then
+        local routing_conflict_port=1
+        local routing_conflict_status=0
+        if migration_server_port_in_use "$routing_conflict_port"; then
+            migration_run_record_result_after_cleanup \
+                "$WS" "$SNAPSHOTS_DIR" "$path_label" "BLOCKED" \
+                "reserved routing-conflict port is unexpectedly occupied" || true
+            echo -e "  ${RED}BLOCKED: ${RESULT_DETAILS[-1]}${NC}"
+            return 0
+        else
+            routing_conflict_status=$?
+        fi
+        if [ "$routing_conflict_status" -ne 1 ] || \
+            [ ! -f "$WS/.beads/config.yaml" ] || \
+            [ -L "$WS/.beads/config.yaml" ] || \
+            [ -L "$WS/.beads/dolt-server.port" ] || \
+            ! printf '%s\n' "$routing_conflict_port" \
+                > "$WS/.beads/dolt-server.port" || \
+            ! printf '\ndolt.shared-server: true\ndolt.host: 127.0.0.1\ndolt.port: %s\ndolt.database: migration_routing_conflict\n' \
+                "$routing_conflict_port" >> "$WS/.beads/config.yaml"; then
+            migration_run_record_result_after_cleanup \
+                "$WS" "$SNAPSHOTS_DIR" "$path_label" "BLOCKED" \
+                "could not install isolated v0.62 source-routing conflicts" || true
+            echo -e "  ${RED}BLOCKED: ${RESULT_DETAILS[-1]}${NC}"
+            return 0
+        fi
+        echo "  source-routing-conflicts: port file and config.yaml active"
     fi
 
     local source_era
@@ -487,6 +861,18 @@ test_direct_path() {
         check_blocker_paths "$WS" "$cand_bin" || blocker_violations=$?
         violations=$((violations + blocker_violations))
 
+        if [ "$version" = "v0.62.0" ]; then
+            local identity_detail=""
+            if ! identity_detail=$(verify_v062_migrated_identity \
+                "$WS" "$cand_bin" "$source_identity_json" 2>&1); then
+                migration_run_record_result_after_cleanup \
+                    "$WS" "$SNAPSHOTS_DIR" "$path_label" "BLOCKED" \
+                    "${identity_detail:-migrated v0.62.0 identity verification failed}" || true
+                echo -e "  ${RED}BLOCKED: ${RESULT_DETAILS[-1]}${NC}"
+                return 0
+            fi
+        fi
+
         local direct_status direct_detail
         if [ "$blocker_violations" -gt 0 ]; then
             direct_status="BLOCKED"
@@ -525,7 +911,19 @@ test_direct_path() {
             fi
             ;;
         dolt_server)
-            if recipe_server_to_embedded \
+            if [ "$version" = "v0.62.0" ]; then
+                if run_public_v062_bridge \
+                    "$WS" "$src_bin" "$cand_bin" "$source_identity_json"; then
+                    recipe_worked=true
+                    recipe_name="public_v062_bridge"
+                else
+                    migration_run_record_result_after_cleanup \
+                        "$WS" "$SNAPSHOTS_DIR" "$path_label" "BLOCKED" \
+                        "${PUBLIC_V062_BRIDGE_FAILURE_DETAIL:-public v0.62 bridge failed}" || true
+                    echo -e "  ${RED}BLOCKED: ${RESULT_DETAILS[-1]}${NC}"
+                    return 0
+                fi
+            elif recipe_server_to_embedded \
                 "$WS" "$src_bin" "$cand_bin" "$version" "$SNAPSHOTS_DIR/before.json"; then
                 recipe_worked=true
                 recipe_name="server_to_embedded"
@@ -549,7 +947,8 @@ test_direct_path() {
 
     if $recipe_worked; then
         if $STRICT_MODE && ! verify_strict_retained_source \
-            "$WS" "$era" "$source_sqlite_manifest" "$source_legacy_dolt_manifest"; then
+            "$WS" "$era" "$source_sqlite_manifest" "$source_legacy_dolt_manifest" \
+            "$version" "$source_fingerprint"; then
             migration_run_record_result_after_cleanup \
                 "$WS" "$SNAPSHOTS_DIR" "$path_label" "BLOCKED" \
                 "manual bridge mutated the retained historical rollback source" || true
@@ -576,6 +975,18 @@ test_direct_path() {
         check_blocker_paths "$WS" "$cand_bin" || blocker_violations=$?
         violations=$((violations + blocker_violations))
 
+        if [ "$version" = "v0.62.0" ]; then
+            local identity_detail=""
+            if ! identity_detail=$(verify_v062_migrated_identity \
+                "$WS" "$cand_bin" "$source_identity_json" 2>&1); then
+                migration_run_record_result_after_cleanup \
+                    "$WS" "$SNAPSHOTS_DIR" "$path_label" "BLOCKED" \
+                    "${identity_detail:-migrated v0.62.0 identity verification failed}" || true
+                echo -e "  ${RED}BLOCKED: ${RESULT_DETAILS[-1]}${NC}"
+                return 0
+            fi
+        fi
+
         if ! stop_dolt_server "$WS"; then
             migration_run_forget_workspace "$WS"
             record_result "$path_label" "BLOCKED" \
@@ -585,7 +996,8 @@ test_direct_path() {
         fi
 
         if $STRICT_MODE && ! verify_strict_retained_source \
-            "$WS" "$era" "$source_sqlite_manifest" "$source_legacy_dolt_manifest"; then
+            "$WS" "$era" "$source_sqlite_manifest" "$source_legacy_dolt_manifest" \
+            "$version" "$source_fingerprint"; then
             migration_run_record_result_after_cleanup \
                 "$WS" "$SNAPSHOTS_DIR" "$path_label" "BLOCKED" \
                 "post-upgrade commands mutated the retained historical rollback source" || true

--- a/scripts/migration-test/strict-mode-test.sh
+++ b/scripts/migration-test/strict-mode-test.sh
@@ -53,11 +53,15 @@ sha=$(strict_release_sha256 v0.62.0 linux amd64) || fail "missing v0.62.0 releas
 [ "$sha" = "4cca7265b22e5c3ca8d62ab0b9752bec31f68b7f5fa636282a4c7e5454c35535" ] ||
     fail "unexpected v0.62.0 release checksum"
 [ "$(strict_expected_status v0.62.0)" = "MANUAL" ] || fail "unexpected v0.62.0 status"
-[ "$(strict_expected_recipe v0.62.0)" = "server_to_embedded" ] || fail "unexpected v0.62.0 recipe"
+[ "$(strict_expected_recipe v0.62.0)" = "public_v062_bridge" ] ||
+    fail "unexpected v0.62.0 recipe"
 [ "$(strict_expected_features v0.62.0)" = "epic task bug dependency standalone closed label comment" ] ||
     fail "unexpected v0.62.0 source features"
-[ "$(server_bridge_strategy v0.62.0)" = "native_export_show_comments" ] ||
-    fail "unexpected v0.62.0 bridge strategy"
+[[ ${SERVER_BRIDGE_STRATEGIES["v0.62.0"]+present} != present ]] ||
+    fail "v0.62.0 remained in the private server bridge strategy map"
+if server_bridge_strategy v0.62.0 >/dev/null 2>&1; then
+    fail "v0.62.0 unexpectedly selected a private server bridge strategy"
+fi
 [ "$(server_bootstrap_strategy v0.62.0)" = "prestarted_server" ] ||
     fail "unexpected v0.62.0 server bootstrap strategy"
 [ "$(strict_required_dolt_version v0.62.0)" = "1.84.0" ] ||
@@ -98,6 +102,123 @@ done
 tmp=$(mktemp -d)
 guard_server_pid=""
 trap '[ -z "${guard_server_pid:-}" ] || kill -9 -- "$guard_server_pid" 2>/dev/null || true; rm -rf "$tmp"' EXIT
+
+server_recipe_route=$(awk '
+    /# Step 5: Direct upgrade failed/ { in_recipe_section = 1 }
+    in_recipe_section && /^[[:space:]]*case "\$era" in$/ { in_era_case = 1 }
+    in_era_case && /^[[:space:]]*dolt_server\)$/ { in_server_route = 1 }
+    in_server_route {
+        print
+        if ($0 ~ /^[[:space:]]*;;[[:space:]]*$/) exit
+    }
+' "$SCRIPT_DIR/run.sh")
+[ -n "$server_recipe_route" ] || fail "could not locate the Dolt-server recipe route"
+public_v062_route=$(awk '
+    /if \[ "\$version" = "v0\.62\.0" \]; then/ { in_public_route = 1 }
+    in_public_route && /^[[:space:]]*elif recipe_server_to_embedded/ { exit }
+    in_public_route { print }
+' <<< "$server_recipe_route")
+grep -Fq 'run_public_v062_bridge' \
+    <<< "$public_v062_route" || fail "v0.62.0 did not route through the public bridge"
+grep -Fq '"$source_identity_json"' <<< "$public_v062_route" ||
+    fail "v0.62.0 public bridge route omitted authenticated source identity"
+grep -Fq 'recipe_name="public_v062_bridge"' <<< "$public_v062_route" ||
+    fail "v0.62.0 did not report the public bridge recipe"
+if grep -Fq 'recipe_server_to_embedded' <<< "$public_v062_route"; then
+    fail "v0.62.0 public route retained a private server bridge fallback"
+fi
+grep -Fq 'elif recipe_server_to_embedded' <<< "$server_recipe_route" ||
+    fail "legacy Dolt-server versions lost the private v0.55/v0.57 recipe route"
+
+public_route_root="$tmp/public-route-project"
+public_route_bin_dir="$tmp/public-route-bin"
+public_route_bridge="$public_route_root/scripts/migrate-v062-server-to-current.sh"
+public_route_source_bd="$tmp/public-route-source-bd"
+public_route_target_bd="$tmp/public-route-target-bd"
+public_route_dolt="$public_route_bin_dir/dolt"
+public_route_ws="$tmp/public-route-workspace"
+public_route_calls="$tmp/public-route.calls"
+public_route_private_calls="$tmp/public-route-private.calls"
+public_route_plan=0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+public_route_identity='{"issue_prefix":"legacy","database":"smoke","project_id":"7ef372b4-4c3c-4e2c-a6cc-29dd2d0a28c6"}'
+mkdir -p "$public_route_root/scripts" "$public_route_bin_dir" "$public_route_ws"
+cat > "$public_route_bridge" <<'EOF'
+#!/bin/bash
+set -euo pipefail
+{
+    for arg in "$@"; do
+        printf '<%s>' "$arg"
+    done
+    printf '\n'
+} >> "${PUBLIC_ROUTE_CALLS:?}"
+case "${1:-}" in
+    --inspect)
+        printf '{"schema_version":1,"operation":"v062_server_to_current","mode":"inspect","status":"planned","effect":"none","source":{"database":"smoke","project_id":"7ef372b4-4c3c-4e2c-a6cc-29dd2d0a28c6"},"plan":{"digest":"%s","source_identity":{"issue_prefix":"legacy","database":"smoke","project_id":"7ef372b4-4c3c-4e2c-a6cc-29dd2d0a28c6"}}}\n' \
+            "${PUBLIC_ROUTE_PLAN:?}"
+        ;;
+    --apply)
+        args=("$@")
+        expected_plan=""
+        for ((i = 0; i < ${#args[@]}; i++)); do
+            if [ "${args[$i]}" = "--expect-plan" ] && [ $((i + 1)) -lt ${#args[@]} ]; then
+                expected_plan="${args[$((i + 1))]}"
+            fi
+        done
+        [ -n "$expected_plan" ] || exit 2
+        apply_count=$(grep -c '^<--apply>' "${PUBLIC_ROUTE_CALLS:?}")
+        if [ "$apply_count" -eq 1 ]; then
+            printf '{"schema_version":1,"operation":"v062_server_to_current","mode":"apply","status":"succeeded","effect":"workspace_migrated","plan":{"digest":"%s","source_identity":{"issue_prefix":"legacy","database":"smoke","project_id":"7ef372b4-4c3c-4e2c-a6cc-29dd2d0a28c6"}},"target":{"backend":"dolt-embedded"}}\n' \
+                "$expected_plan"
+        else
+            printf '{"schema_version":1,"operation":"v062_server_to_current","mode":"apply","status":"succeeded","effect":"none","no_op":true,"plan":{"digest":"%s","source_identity":{"issue_prefix":"legacy","database":"smoke","project_id":"7ef372b4-4c3c-4e2c-a6cc-29dd2d0a28c6"}},"target":{"backend":"dolt-embedded"},"verification":{"separate_process_reopen":true}}\n' \
+                "$expected_plan"
+        fi
+        ;;
+    *) exit 2 ;;
+esac
+EOF
+printf '%s\n' '#!/bin/bash' 'exit 0' > "$public_route_source_bd"
+printf '%s\n' '#!/bin/bash' 'exit 0' > "$public_route_target_bd"
+printf '%s\n' '#!/bin/bash' 'exit 0' > "$public_route_dolt"
+chmod +x \
+    "$public_route_bridge" "$public_route_source_bd" \
+    "$public_route_target_bd" "$public_route_dolt"
+if [[ "$public_route_source_bd" != /* ]] || [[ "$public_route_dolt" != /* ]]; then
+    fail "public-route probe binaries were not absolute"
+fi
+if ! PATH="$public_route_bin_dir:$PATH" \
+    PUBLIC_ROUTE_CALLS="$public_route_calls" \
+    PUBLIC_ROUTE_PLAN="$public_route_plan" \
+    bash -c '
+    set -euo pipefail
+    export MIGRATION_TEST_RUN_LIBRARY_ONLY=1
+    source "$1"
+    PROJECT_ROOT="$2"
+    private_calls="$3"
+    recipe_server_to_embedded() {
+        printf "private fallback\n" >> "$private_calls"
+        return 1
+    }
+    run_public_v062_bridge "$4" "$5" "$6" "$7"
+' public-route-probe "$SCRIPT_DIR/run.sh" "$public_route_root" \
+        "$public_route_private_calls" "$public_route_ws" \
+        "$public_route_source_bd" "$public_route_target_bd" \
+        "$public_route_identity"; then
+    fail "run.sh public v0.62.0 inspect/apply route failed"
+fi
+[ ! -e "$public_route_private_calls" ] ||
+    fail "run.sh public v0.62.0 route invoked the private recipe fallback"
+mapfile -t public_route_argv < "$public_route_calls"
+[ "${#public_route_argv[@]}" -eq 3 ] ||
+    fail "public v0.62.0 route did not make one inspect and two apply calls"
+expected_public_inspect="<--inspect><--source-bd><$public_route_source_bd><--source-dolt><$public_route_dolt><--workspace><$public_route_ws><--target-bd><$public_route_target_bd><--json>"
+expected_public_apply="<--apply><--yes><--expect-plan><$public_route_plan><--source-bd><$public_route_source_bd><--source-dolt><$public_route_dolt><--workspace><$public_route_ws><--target-bd><$public_route_target_bd><--json>"
+[ "${public_route_argv[0]}" = "$expected_public_inspect" ] ||
+    fail "public v0.62.0 inspect did not receive exact absolute source inputs"
+[ "${public_route_argv[1]}" = "$expected_public_apply" ] ||
+    fail "public v0.62.0 apply was not bound to the exact value-bearing inspect plan"
+[ "${public_route_argv[2]}" = "$expected_public_apply" ] ||
+    fail "public v0.62.0 no-op did not repeat the exact value-bearing inspect plan"
 
 unsafe_cleanup_calls="$tmp/unsafe-cleanup.calls"
 if (
@@ -1482,44 +1603,48 @@ fi
 [ ! -e "$stop_refusal_ws/.beads/legacy-dolt.pre-migration" ] ||
     fail "server-stop verification failure created a rollback tree"
 
-restart_refusal_ws="$tmp/restart-refusal-workspace"
-restart_refusal_calls="$tmp/restart-refusal.calls"
-restart_refusal_binary_calls="$tmp/restart-refusal-binary.calls"
-mkdir -p "$restart_refusal_ws/.beads/dolt"
-printf 'active restart-refusal data' > "$restart_refusal_ws/.beads/dolt/table.dat"
-printf 'active restart-refusal metadata' > "$restart_refusal_ws/.beads/metadata.json"
-restart_refusal_manifest=$(legacy_dolt_artifact_manifest "$restart_refusal_ws/.beads")
-export LEGACY_RACE_CALLS="$restart_refusal_binary_calls"
-: > "$restart_refusal_calls"
-: > "$restart_refusal_binary_calls"
-if (
-    stop_dolt_server() { :; }
+private_v062_ws="$tmp/private-v062-refusal-workspace"
+private_v062_effect_calls="$tmp/private-v062-refusal.effects"
+private_v062_binary_calls="$tmp/private-v062-refusal.binaries"
+mkdir -p "$private_v062_ws/.beads/dolt"
+printf 'active private-route data' > "$private_v062_ws/.beads/dolt/table.dat"
+printf 'active private-route metadata' > "$private_v062_ws/.beads/metadata.json"
+private_v062_fingerprint=$(source_artifact_fingerprint "$private_v062_ws/.beads")
+export LEGACY_RACE_CALLS="$private_v062_binary_calls"
+: > "$private_v062_effect_calls"
+: > "$private_v062_binary_calls"
+private_v062_output=""
+if private_v062_output=$(
+    stop_dolt_server() { printf 'stop\n' >> "$private_v062_effect_calls"; }
     start_owned_migration_dolt_server() {
-        printf '%s\n' "$1" >> "$restart_refusal_calls"
-        return 1
+        printf 'start\n' >> "$private_v062_effect_calls"
+    }
+    preserve_legacy_dolt_source() {
+        printf 'preserve\n' >> "$private_v062_effect_calls"
     }
     recipe_server_to_embedded \
-        "$restart_refusal_ws" "$legacy_race_old_bin" "$legacy_race_candidate_bin" \
+        "$private_v062_ws" "$legacy_race_old_bin" "$legacy_race_candidate_bin" \
         v0.62.0 "$legacy_race_before"
-) >/dev/null 2>&1; then
-    fail "v0.62.0 server bridge continued after owned-server restart failed"
+); then
+    fail "private server-to-embedded recipe accepted v0.62.0"
 fi
-[ "$(cat "$restart_refusal_calls")" = "$restart_refusal_ws" ] ||
-    fail "v0.62.0 server bridge did not attempt exactly one owned-server restart"
-[ ! -s "$restart_refusal_binary_calls" ] ||
-    fail "owned-server restart failure invoked a historical or candidate binary"
-[ "$(legacy_dolt_artifact_manifest "$restart_refusal_ws/.beads")" = \
-    "$restart_refusal_manifest" ] ||
-    fail "owned-server restart failure mutated the active historical source"
-verify_retained_legacy_dolt_source \
-    "$restart_refusal_ws/.beads" "$restart_refusal_manifest" ||
-    fail "owned-server restart failure did not retain an exact rollback source"
+grep -Fq 'v0.62.0 must use the public migration bridge' <<< "$private_v062_output" ||
+    fail "private server-to-embedded recipe did not explain the v0.62.0 refusal"
+[ ! -s "$private_v062_effect_calls" ] ||
+    fail "private v0.62.0 recipe refusal reached a migration effect"
+[ ! -s "$private_v062_binary_calls" ] ||
+    fail "private v0.62.0 recipe refusal invoked a historical or candidate binary"
+[ "$(source_artifact_fingerprint "$private_v062_ws/.beads")" = \
+    "$private_v062_fingerprint" ] ||
+    fail "private v0.62.0 recipe refusal mutated the historical source"
+[ ! -e "$private_v062_ws/.beads/legacy-dolt.pre-migration" ] ||
+    fail "private v0.62.0 recipe refusal created a rollback tree"
 
 [ "$(server_bridge_strategy v0.55.4)" = "native_export" ] ||
     fail "v0.55.4 did not select its pinned server bridge strategy"
 [ "$(server_bridge_strategy v0.57.0)" = "native_export_show_comments" ] ||
     fail "v0.57.0 did not select its lossless export+show server bridge strategy"
-for unsupported_version in v0.56.1 v0.58.0 v9.9.9; do
+for unsupported_version in v0.56.1 v0.58.0 v0.62.0 v9.9.9; do
     if server_bridge_strategy "$unsupported_version" >/dev/null 2>&1; then
         fail "$unsupported_version unexpectedly selected a server bridge strategy"
     fi


### PR DESCRIPTION
## What

Enable the public v0.62 migration bridge to perform an explicit, plan-bound server-to-embedded upgrade. `--inspect` remains the default and returns an immutable plan digest; effectful work requires `--apply --yes --expect-plan <digest>` plus explicit checksum-pinned v0.62.0 `bd` and Dolt 1.84.0 executables.

The bridge copies and requalifies the historical source, exports and enriches the exact supported core corpus, initializes a side-by-side embedded-Dolt target, imports and independently reopens it, compares canonical issue and relationship data, retains the original `.beads` tree as `.beads-v0.62.0-rollback`, and atomically publishes the verified target. Hidden init-only plumbing preserves the authenticated project, repository, clone, database, and issue-prefix identities without exposing a new user-facing `bd` command.

This remains opt-in and manual. Ordinary current commands continue to refuse the historical workspace; there is no automatic upgrade.

Parent: #4840

## Why

The official v0.62 lane previously proved only an internal test recipe, while the public bridge could inspect but truthfully returned `apply_not_available`. Users on v0.62 need a deterministic path that either completes with verified fidelity and a retained rollback or fails closed before publishing a target.

The authentic lane also caught a fake/real discrepancy during this slice: current `bd export` represents parenthood through the `parent-child` dependency and omits the redundant legacy top-level `parent` projection. The focused fake now reproduces that shape, and the bridge derives the projection only when exactly one matching dependency exists. Missing, conflicting, malformed, or multiple parent edges remain rejected.

## Qualification boundary

The first public apply path is deliberately bounded to the checksum-pinned official v0.62.0 source and its qualified five-issue/eight-feature corpus:

- epic, child task, blocking bug, standalone issue, and closed issue
- exact `parent-child` and `blocks` edges, including supported dependency audit fields
- rich description, notes, design, acceptance criteria, external reference, label, and comment fields
- authenticated issue prefix, Dolt database, and project identity
- correct `blocked`, `ready`, `close`, reopen, and post-migration create behavior

Sources outside that proven semantic envelope are refused rather than migrated speculatively.

## Safety, rollback, and provider boundary

- Binds inspect and apply to source-tree/content hashes, source/target executable hashes, source identity, semantic baseline, and the exact plan digest.
- Reinspects under an authenticated workspace operation fence before cutover.
- Forces the staged target through explicit `--backend=dolt` and runs source, target, Git, and Dolt subprocesses in scrubbed environments so PostgreSQL, MySQL, SQLite, remote-Dolt, and ambient routing selectors cannot leak across the provider boundary.
- Retains and byte-verifies the complete historical source as rollback before target publication.
- Uses receipt-backed, separately reopened verification for deterministic no-op retries.
- Recovers authenticated private staging/fence resources after process interruption on a live filesystem. It does not claim storage-engine power-loss durability, and active malicious same-UID races remain outside the supported boundary.
- Adds no schema or provider DDL and does not introspect or patch storage-engine internals.

This touches a protected migration path. It requires substantive human review and must not be self-merged or auto-merged.

## Verification

- `./scripts/migration-test/public-v062-bridge-test.sh`: PASS
- `./scripts/migration-test/strict-mode-test.sh`: PASS
- Authentic pinned lane:
  `PATH=/home/ubuntu/.cache/beads-regression/runtimes/dolt-1.84.0-afcdaa9530ae/bin:$PATH CANDIDATE_BIN=./bd ./scripts/migration-test/run.sh --strict --expect MANUAL v0.62.0`
  returned `MANUAL(public_v062_bridge)`, migrated all 5 items, preserved all 8 features, reported 0 fidelity violations, and passed blocker/ready/close checks.
- `TEST_TIMEOUT=5m make test`: PASS, all packages; total coverage 37.9%
- `make ci-pr-core`: PASS
- `make ci-pr-policy`: PASS
- `make ci-pr-lint`: PASS, 0 issues
- Bash syntax, ShellCheck error-level, and `git diff --check`: PASS
- Three-agent correctness, fidelity, and scope/safety council: APPROVE with 0 Critical and 0 Important findings
- Exact stacked binary diff SHA-256: `a4603cebaa0d2dbfa1bf71ce1529c3371923107d03ecd39e8085eb743fbaa067`
- Exact reviewed bridge/E2E diff SHA-256: `af4c4e6d821f1ac9f85b274aa22e24344fd8b74d533cd7dfafd3658c2433e182`

_codex-gpt-5-unknown-reasoning on behalf of Test User_
