### PR TITLE
fix(proxy): TLS support for proxied external dolt server

### DIFF
--- a/cmd/bd/db_proxy_child.go
+++ b/cmd/bd/db_proxy_child.go
@@ -15,21 +15,18 @@ import (
 )
 
 var (
-	dbProxyChildRoot                string
-	dbProxyChildPort                int
-	dbProxyChildIdleTimeout         time.Duration
-	dbProxyChildBackend             string
-	dbProxyChildConfig              string
-	dbProxyChildLogPath             string
-	dbProxyChildDoltBin             string
-	dbProxyChildDatabase            string
-	dbProxyChildExternalHost        string
-	dbProxyChildExternalPort        int
-	dbProxyChildExternalSocketPath  string
-	dbProxyChildExternalTLS         bool
-	dbProxyChildExternalTLSCertPath string
-	dbProxyChildExternalTLSKeyPath  string
-	dbProxyChildExternalKeepAlive   time.Duration
+	dbProxyChildRoot               string
+	dbProxyChildPort               int
+	dbProxyChildIdleTimeout        time.Duration
+	dbProxyChildBackend            string
+	dbProxyChildConfig             string
+	dbProxyChildLogPath            string
+	dbProxyChildDoltBin            string
+	dbProxyChildDatabase           string
+	dbProxyChildExternalHost       string
+	dbProxyChildExternalPort       int
+	dbProxyChildExternalSocketPath string
+	dbProxyChildExternalKeepAlive  time.Duration
 )
 
 var dbProxyChildCmd = &cobra.Command{
@@ -53,9 +50,6 @@ not intended to be invoked directly by users.`,
 			Host:            dbProxyChildExternalHost,
 			Port:            dbProxyChildExternalPort,
 			Socket:          dbProxyChildExternalSocketPath,
-			TLSRequired:     dbProxyChildExternalTLS,
-			TLSCert:         dbProxyChildExternalTLSCertPath,
-			TLSKey:          dbProxyChildExternalTLSKeyPath,
 			KeepAlivePeriod: dbProxyChildExternalKeepAlive,
 		}
 
@@ -106,9 +100,6 @@ func init() {
 	dbProxyChildCmd.Flags().StringVar(&dbProxyChildExternalHost, "external-host", "", "external backend: hostname or IP of the dolt sql-server")
 	dbProxyChildCmd.Flags().IntVar(&dbProxyChildExternalPort, "external-port", 0, "external backend: TCP port of the dolt sql-server")
 	dbProxyChildCmd.Flags().StringVar(&dbProxyChildExternalSocketPath, "external-socket-path", "", "external backend: absolute path to a unix domain socket (overrides host/port)")
-	dbProxyChildCmd.Flags().BoolVar(&dbProxyChildExternalTLS, "external-tls", false, "external backend: require TLS in the MySQL handshake")
-	dbProxyChildCmd.Flags().StringVar(&dbProxyChildExternalTLSCertPath, "external-tls-cert-path", "", "external backend: absolute path to client TLS certificate (mTLS)")
-	dbProxyChildCmd.Flags().StringVar(&dbProxyChildExternalTLSKeyPath, "external-tls-key-path", "", "external backend: absolute path to client TLS private key (mTLS)")
 	dbProxyChildCmd.Flags().DurationVar(&dbProxyChildExternalKeepAlive, "external-keep-alive", 0, "external backend: TCP keepalive period (default 30s)")
 	_ = dbProxyChildCmd.MarkFlagRequired("root")
 	_ = dbProxyChildCmd.MarkFlagRequired("port")

--- a/cmd/bd/db_proxy_child_test.go
+++ b/cmd/bd/db_proxy_child_test.go
@@ -74,9 +74,6 @@ func TestDbProxyChildRegistersExternalFlags(t *testing.T) {
 		{"external-host", ""},
 		{"external-port", "0"},
 		{"external-socket-path", ""},
-		{"external-tls", "false"},
-		{"external-tls-cert-path", ""},
-		{"external-tls-key-path", ""},
 		{"external-keep-alive", "0s"},
 	}
 	for _, tc := range cases {

--- a/cmd/bd/init.go
+++ b/cmd/bd/init.go
@@ -136,8 +136,11 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 		externalSocketPath, _ := cmd.Flags().GetString("proxied-server-external-socket-path")
 		externalUser, _ := cmd.Flags().GetString("proxied-server-external-user")
 		externalTLS, _ := cmd.Flags().GetBool("proxied-server-external-tls")
+		externalTLSCACertPath, _ := cmd.Flags().GetString("proxied-server-external-tls-ca-cert-path")
 		externalTLSCertPath, _ := cmd.Flags().GetString("proxied-server-external-tls-cert-path")
 		externalTLSKeyPath, _ := cmd.Flags().GetString("proxied-server-external-tls-key-path")
+		externalTLSServerName, _ := cmd.Flags().GetString("proxied-server-external-tls-server-name")
+		externalTLSSkipVerify, _ := cmd.Flags().GetBool("proxied-server-external-tls-skip-verify")
 		externalKeepAlive, _ := cmd.Flags().GetDuration("proxied-server-external-keep-alive")
 		if os.Getenv("BEADS_DOLT_PROXIED_SERVER") == "1" {
 			initProxiedServer = true
@@ -214,7 +217,8 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 
 		externalProvided := externalHost != "" || externalPort != 0 || externalSocketPath != "" ||
 			externalUser != "" ||
-			externalTLS || externalTLSCertPath != "" || externalTLSKeyPath != "" || externalKeepAlive != 0
+			externalTLS || externalTLSCACertPath != "" || externalTLSCertPath != "" || externalTLSKeyPath != "" ||
+			externalTLSServerName != "" || externalTLSSkipVerify || externalKeepAlive != 0
 		if externalProvided && !initProxiedServer {
 			return fmt.Errorf("--proxied-server-external-* flags require --proxied-server")
 		}
@@ -232,8 +236,11 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 				Socket:          externalSocketPath,
 				User:            externalUser,
 				TLSRequired:     externalTLS,
+				TLSCACert:       externalTLSCACertPath,
 				TLSCert:         externalTLSCertPath,
 				TLSKey:          externalTLSKeyPath,
+				TLSServerName:   externalTLSServerName,
+				TLSSkipVerify:   externalTLSSkipVerify,
 				KeepAlivePeriod: externalKeepAlive,
 			}
 			if err := cfg.Validate(); err != nil {
@@ -2162,8 +2169,11 @@ func init() {
 	initCmd.Flags().String("proxied-server-external-socket-path", "", "[EXPERIMENTAL] Absolute unix socket path of the externally-managed dolt sql-server (proxied-server mode only). Mutually exclusive with --proxied-server-external-host. Relative paths are rejected.")
 	initCmd.Flags().String("proxied-server-external-user", "", "[EXPERIMENTAL] MySQL user for the externally-managed dolt sql-server (proxied-server mode only). Defaults to \"root\" when empty. Password is read at runtime from $BEADS_PROXIED_SERVER_EXTERNAL_PASSWORD and is never persisted to disk.")
 	initCmd.Flags().Bool("proxied-server-external-tls", false, "[EXPERIMENTAL] Require TLS when connecting to the externally-managed dolt sql-server (proxied-server mode only).")
+	initCmd.Flags().String("proxied-server-external-tls-ca-cert-path", "", "[EXPERIMENTAL] Absolute path to a CA certificate (PEM) used to verify the externally-managed dolt sql-server. Empty uses the system trust store. Relative paths are rejected.")
 	initCmd.Flags().String("proxied-server-external-tls-cert-path", "", "[EXPERIMENTAL] Absolute path to a client TLS certificate (for mTLS to the externally-managed dolt sql-server). Must be paired with --proxied-server-external-tls-key-path. Relative paths are rejected.")
 	initCmd.Flags().String("proxied-server-external-tls-key-path", "", "[EXPERIMENTAL] Absolute path to the client TLS private key (for mTLS to the externally-managed dolt sql-server). Must be paired with --proxied-server-external-tls-cert-path. Relative paths are rejected.")
+	initCmd.Flags().String("proxied-server-external-tls-server-name", "", "[EXPERIMENTAL] Server name to verify in the external dolt sql-server's TLS certificate. Defaults to the external host. Required with a unix socket unless --proxied-server-external-tls-skip-verify is set.")
+	initCmd.Flags().Bool("proxied-server-external-tls-skip-verify", false, "[EXPERIMENTAL] Skip TLS certificate verification for the external dolt sql-server. Insecure; testing only.")
 	initCmd.Flags().Duration("proxied-server-external-keep-alive", 0, "[EXPERIMENTAL] TCP keepalive period for the proxy→external connection. Zero uses the package default (30s).")
 
 	rootCmd.AddCommand(initCmd)

--- a/cmd/bd/proxied_server_test.go
+++ b/cmd/bd/proxied_server_test.go
@@ -508,8 +508,11 @@ func TestInitCommandRegistersProxiedServerExternalFlags(t *testing.T) {
 		{"proxied-server-external-socket-path", ""},
 		{"proxied-server-external-user", ""},
 		{"proxied-server-external-tls", "false"},
+		{"proxied-server-external-tls-ca-cert-path", ""},
 		{"proxied-server-external-tls-cert-path", ""},
 		{"proxied-server-external-tls-key-path", ""},
+		{"proxied-server-external-tls-server-name", ""},
+		{"proxied-server-external-tls-skip-verify", "false"},
 		{"proxied-server-external-keep-alive", "0s"},
 	}
 	for _, tc := range cases {

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -3581,55 +3581,58 @@ bd init [flags]
 **Flags:**
 
 ```
-      --agents-file string                             Custom filename for agent instructions (default: AGENTS.md)
-      --agents-profile string                          AGENTS.md profile: 'minimal' (default, pointer to bd prime) or 'full' (complete command reference)
-      --agents-template string                         Path to custom AGENTS.md template (overrides embedded default)
-      --backend string                                 Storage backend: dolt (default), postgres, mysql, or sqlite. See docs/architecture/storage-backends.md.
-      --contributor                                    Run OSS contributor setup wizard
-      --database string                                Use existing server database name (overrides prefix-based naming)
-      --debug                                          Run the managed Dolt sql-server with --loglevel=debug and CPU profiling (--prof cpu). Persisted to config.yaml as dolt.debug. No effect on externally-managed servers.
-      --destroy-token string                           Explicit confirmation token for destructive re-init in non-interactive mode (format: 'DESTROY-<prefix>')
-      --discard-remote                                 Authorize discarding the configured remote's Dolt history when re-initializing. Requires --destroy-token in non-interactive mode; see 'bd help init-safety'.
-      --external                                       Server is externally managed (skip server startup); use with --shared-server or --server
-      --force                                          Deprecated alias for --reinit-local. Bypasses only the LOCAL data-safety guard; does NOT authorize remote divergence (see 'bd help init-safety').
-      --from-jsonl                                     Import issues from configured import.path; refuses remote history unless --discard-remote authorizes replacement
-      --init-if-missing                                If the workspace is already initialized, skip init and exit 0 instead of failing (idempotent init for scaffolds)
-      --mysql-database string                          MySQL database for this workspace (with --backend=mysql; MySQL's isolation unit)
-      --mysql-url string                               MySQL server DSN (with --backend=mysql), e.g. user:pass@tcp(host:3306)/ . A password may be included for init but is never persisted; set BEADS_MYSQL_PASSWORD for later commands. Falls back to BEADS_MYSQL_URL.
-      --non-interactive                                Skip all interactive prompts (auto-detected in CI or non-TTY environments)
-      --pg-schema string                               Postgres schema for this workspace's tables (with --backend=postgres; provides search_path isolation)
-      --pg-url string                                  Postgres connection URL (with --backend=postgres). A password may be included for init but is never persisted; set BEADS_PG_PASSWORD for later commands. Falls back to BEADS_POSTGRES_URL.
-  -p, --prefix string                                  Issue prefix (default: current directory name)
-      --proxied-server                                 [EXPERIMENTAL] Use a per-workspace proxied dolt sql-server (proxy + child dolt) rooted at .beads/dolt
-      --proxied-server-config-path string              [EXPERIMENTAL] Absolute path to an existing dolt sql-server YAML config (proxied-server mode only). When set, bd uses this file instead of auto-generating one. Relative paths are rejected.
-      --proxied-server-external-host string            [EXPERIMENTAL] Hostname or IP of an externally-managed dolt sql-server the proxy should front (proxied-server mode only). Mutually exclusive with --proxied-server-external-socket-path.
-      --proxied-server-external-keep-alive duration    [EXPERIMENTAL] TCP keepalive period for the proxy→external connection. Zero uses the package default (30s).
-      --proxied-server-external-port int               [EXPERIMENTAL] TCP port of the externally-managed dolt sql-server (proxied-server mode only). Required when --proxied-server-external-host is set.
-      --proxied-server-external-socket-path string     [EXPERIMENTAL] Absolute unix socket path of the externally-managed dolt sql-server (proxied-server mode only). Mutually exclusive with --proxied-server-external-host. Relative paths are rejected.
-      --proxied-server-external-tls                    [EXPERIMENTAL] Require TLS when connecting to the externally-managed dolt sql-server (proxied-server mode only).
-      --proxied-server-external-tls-cert-path string   [EXPERIMENTAL] Absolute path to a client TLS certificate (for mTLS to the externally-managed dolt sql-server). Must be paired with --proxied-server-external-tls-key-path. Relative paths are rejected.
-      --proxied-server-external-tls-key-path string    [EXPERIMENTAL] Absolute path to the client TLS private key (for mTLS to the externally-managed dolt sql-server). Must be paired with --proxied-server-external-tls-cert-path. Relative paths are rejected.
-      --proxied-server-external-user string            [EXPERIMENTAL] MySQL user for the externally-managed dolt sql-server (proxied-server mode only). Defaults to "root" when empty. Password is read at runtime from $BEADS_PROXIED_SERVER_EXTERNAL_PASSWORD and is never persisted to disk.
-      --proxied-server-idle-timeout duration           [EXPERIMENTAL] Idle duration after which the proxy shuts down its loopback listener and backend (proxied-server mode only). Omit for the built-in default (30s); 0 keeps the proxy and backend alive indefinitely; a positive value sets the window.
-      --proxied-server-log-path string                 [EXPERIMENTAL] Absolute path to the proxied dolt sql-server log file (proxied-server mode only). Default: <beadsDir>/dolt/server.log. Relative paths are rejected.
-      --proxied-server-port int                        [EXPERIMENTAL] Fixed TCP port for the proxy's loopback listener (proxied-server mode only). Default 0 = an OS-assigned free port. Startup fails if the port is already in use.
-      --proxied-server-root-path string                [EXPERIMENTAL] Absolute directory holding the proxied dolt sql-server's lockfiles, pidfiles, and child .dolt repository (proxied-server mode only). Default: <beadsDir>/dolt. May not exist yet — bd will create it. Relative paths are rejected.
-  -q, --quiet                                          Suppress output (quiet mode)
-      --reinit-local                                   Re-initialize local .beads/ over existing local data. Does NOT authorize remote divergence; see --discard-remote.
-      --remote string                                  Dolt remote URL to clone from and persist as sync.remote
-      --role string                                    Set beads role without prompting: "maintainer" or "contributor"
-      --server                                         Use external dolt sql-server instead of embedded engine
-      --server-host string                             Dolt server host (default: 127.0.0.1)
-      --server-port int                                Dolt server port (default: 3307)
-      --server-socket string                           Unix domain socket path (overrides host/port)
-      --server-user string                             Dolt server MySQL user (default: root)
-      --setup-exclude                                  Configure .git/info/exclude to keep beads files local (for forks)
-      --shared-server                                  Enable shared Dolt server mode (all projects share one server at ~/.beads/shared-server/)
-      --skip-agents                                    Skip AGENTS.md and Claude/Codex/Cursor setup generation
-      --skip-hooks                                     Skip git hooks installation
-      --sqlite-path string                             SQLite database file (with --backend=sqlite; relative to the beads dir, default beads.db)
-      --stealth                                        Enable stealth mode: global gitattributes and gitignore, no local repo tracking
-      --team                                           Run team workflow setup wizard
+      --agents-file string                                Custom filename for agent instructions (default: AGENTS.md)
+      --agents-profile string                             AGENTS.md profile: 'minimal' (default, pointer to bd prime) or 'full' (complete command reference)
+      --agents-template string                            Path to custom AGENTS.md template (overrides embedded default)
+      --backend string                                    Storage backend: dolt (default), postgres, mysql, or sqlite. See docs/architecture/storage-backends.md.
+      --contributor                                       Run OSS contributor setup wizard
+      --database string                                   Use existing server database name (overrides prefix-based naming)
+      --debug                                             Run the managed Dolt sql-server with --loglevel=debug and CPU profiling (--prof cpu). Persisted to config.yaml as dolt.debug. No effect on externally-managed servers.
+      --destroy-token string                              Explicit confirmation token for destructive re-init in non-interactive mode (format: 'DESTROY-<prefix>')
+      --discard-remote                                    Authorize discarding the configured remote's Dolt history when re-initializing. Requires --destroy-token in non-interactive mode; see 'bd help init-safety'.
+      --external                                          Server is externally managed (skip server startup); use with --shared-server or --server
+      --force                                             Deprecated alias for --reinit-local. Bypasses only the LOCAL data-safety guard; does NOT authorize remote divergence (see 'bd help init-safety').
+      --from-jsonl                                        Import issues from configured import.path; refuses remote history unless --discard-remote authorizes replacement
+      --init-if-missing                                   If the workspace is already initialized, skip init and exit 0 instead of failing (idempotent init for scaffolds)
+      --mysql-database string                             MySQL database for this workspace (with --backend=mysql; MySQL's isolation unit)
+      --mysql-url string                                  MySQL server DSN (with --backend=mysql), e.g. user:pass@tcp(host:3306)/ . A password may be included for init but is never persisted; set BEADS_MYSQL_PASSWORD for later commands. Falls back to BEADS_MYSQL_URL.
+      --non-interactive                                   Skip all interactive prompts (auto-detected in CI or non-TTY environments)
+      --pg-schema string                                  Postgres schema for this workspace's tables (with --backend=postgres; provides search_path isolation)
+      --pg-url string                                     Postgres connection URL (with --backend=postgres). A password may be included for init but is never persisted; set BEADS_PG_PASSWORD for later commands. Falls back to BEADS_POSTGRES_URL.
+  -p, --prefix string                                     Issue prefix (default: current directory name)
+      --proxied-server                                    [EXPERIMENTAL] Use a per-workspace proxied dolt sql-server (proxy + child dolt) rooted at .beads/dolt
+      --proxied-server-config-path string                 [EXPERIMENTAL] Absolute path to an existing dolt sql-server YAML config (proxied-server mode only). When set, bd uses this file instead of auto-generating one. Relative paths are rejected.
+      --proxied-server-external-host string               [EXPERIMENTAL] Hostname or IP of an externally-managed dolt sql-server the proxy should front (proxied-server mode only). Mutually exclusive with --proxied-server-external-socket-path.
+      --proxied-server-external-keep-alive duration       [EXPERIMENTAL] TCP keepalive period for the proxy→external connection. Zero uses the package default (30s).
+      --proxied-server-external-port int                  [EXPERIMENTAL] TCP port of the externally-managed dolt sql-server (proxied-server mode only). Required when --proxied-server-external-host is set.
+      --proxied-server-external-socket-path string        [EXPERIMENTAL] Absolute unix socket path of the externally-managed dolt sql-server (proxied-server mode only). Mutually exclusive with --proxied-server-external-host. Relative paths are rejected.
+      --proxied-server-external-tls                       [EXPERIMENTAL] Require TLS when connecting to the externally-managed dolt sql-server (proxied-server mode only).
+      --proxied-server-external-tls-ca-cert-path string   [EXPERIMENTAL] Absolute path to a CA certificate (PEM) used to verify the externally-managed dolt sql-server. Empty uses the system trust store. Relative paths are rejected.
+      --proxied-server-external-tls-cert-path string      [EXPERIMENTAL] Absolute path to a client TLS certificate (for mTLS to the externally-managed dolt sql-server). Must be paired with --proxied-server-external-tls-key-path. Relative paths are rejected.
+      --proxied-server-external-tls-key-path string       [EXPERIMENTAL] Absolute path to the client TLS private key (for mTLS to the externally-managed dolt sql-server). Must be paired with --proxied-server-external-tls-cert-path. Relative paths are rejected.
+      --proxied-server-external-tls-server-name string    [EXPERIMENTAL] Server name to verify in the external dolt sql-server's TLS certificate. Defaults to the external host. Required with a unix socket unless --proxied-server-external-tls-skip-verify is set.
+      --proxied-server-external-tls-skip-verify           [EXPERIMENTAL] Skip TLS certificate verification for the external dolt sql-server. Insecure; testing only.
+      --proxied-server-external-user string               [EXPERIMENTAL] MySQL user for the externally-managed dolt sql-server (proxied-server mode only). Defaults to "root" when empty. Password is read at runtime from $BEADS_PROXIED_SERVER_EXTERNAL_PASSWORD and is never persisted to disk.
+      --proxied-server-idle-timeout duration              [EXPERIMENTAL] Idle duration after which the proxy shuts down its loopback listener and backend (proxied-server mode only). Omit for the built-in default (30s); 0 keeps the proxy and backend alive indefinitely; a positive value sets the window.
+      --proxied-server-log-path string                    [EXPERIMENTAL] Absolute path to the proxied dolt sql-server log file (proxied-server mode only). Default: <beadsDir>/dolt/server.log. Relative paths are rejected.
+      --proxied-server-port int                           [EXPERIMENTAL] Fixed TCP port for the proxy's loopback listener (proxied-server mode only). Default 0 = an OS-assigned free port. Startup fails if the port is already in use.
+      --proxied-server-root-path string                   [EXPERIMENTAL] Absolute directory holding the proxied dolt sql-server's lockfiles, pidfiles, and child .dolt repository (proxied-server mode only). Default: <beadsDir>/dolt. May not exist yet — bd will create it. Relative paths are rejected.
+  -q, --quiet                                             Suppress output (quiet mode)
+      --reinit-local                                      Re-initialize local .beads/ over existing local data. Does NOT authorize remote divergence; see --discard-remote.
+      --remote string                                     Dolt remote URL to clone from and persist as sync.remote
+      --role string                                       Set beads role without prompting: "maintainer" or "contributor"
+      --server                                            Use external dolt sql-server instead of embedded engine
+      --server-host string                                Dolt server host (default: 127.0.0.1)
+      --server-port int                                   Dolt server port (default: 3307)
+      --server-socket string                              Unix domain socket path (overrides host/port)
+      --server-user string                                Dolt server MySQL user (default: root)
+      --setup-exclude                                     Configure .git/info/exclude to keep beads files local (for forks)
+      --shared-server                                     Enable shared Dolt server mode (all projects share one server at ~/.beads/shared-server/)
+      --skip-agents                                       Skip AGENTS.md and Claude/Codex/Cursor setup generation
+      --skip-hooks                                        Skip git hooks installation
+      --sqlite-path string                                SQLite database file (with --backend=sqlite; relative to the beads dir, default beads.db)
+      --stealth                                           Enable stealth mode: global gitattributes and gitignore, no local repo tracking
+      --team                                              Run team workflow setup wizard
 ```
 
 ### bd kv

--- a/docs/cli-reference/init.md
+++ b/docs/cli-reference/init.md
@@ -49,53 +49,56 @@ bd init [flags]
 **Flags:**
 
 ```
-      --agents-file string                             Custom filename for agent instructions (default: AGENTS.md)
-      --agents-profile string                          AGENTS.md profile: 'minimal' (default, pointer to bd prime) or 'full' (complete command reference)
-      --agents-template string                         Path to custom AGENTS.md template (overrides embedded default)
-      --backend string                                 Storage backend: dolt (default), postgres, mysql, or sqlite. See docs/architecture/storage-backends.md.
-      --contributor                                    Run OSS contributor setup wizard
-      --database string                                Use existing server database name (overrides prefix-based naming)
-      --debug                                          Run the managed Dolt sql-server with --loglevel=debug and CPU profiling (--prof cpu). Persisted to config.yaml as dolt.debug. No effect on externally-managed servers.
-      --destroy-token string                           Explicit confirmation token for destructive re-init in non-interactive mode (format: 'DESTROY-<prefix>')
-      --discard-remote                                 Authorize discarding the configured remote's Dolt history when re-initializing. Requires --destroy-token in non-interactive mode; see 'bd help init-safety'.
-      --external                                       Server is externally managed (skip server startup); use with --shared-server or --server
-      --force                                          Deprecated alias for --reinit-local. Bypasses only the LOCAL data-safety guard; does NOT authorize remote divergence (see 'bd help init-safety').
-      --from-jsonl                                     Import issues from configured import.path; refuses remote history unless --discard-remote authorizes replacement
-      --init-if-missing                                If the workspace is already initialized, skip init and exit 0 instead of failing (idempotent init for scaffolds)
-      --mysql-database string                          MySQL database for this workspace (with --backend=mysql; MySQL's isolation unit)
-      --mysql-url string                               MySQL server DSN (with --backend=mysql), e.g. user:pass@tcp(host:3306)/ . A password may be included for init but is never persisted; set BEADS_MYSQL_PASSWORD for later commands. Falls back to BEADS_MYSQL_URL.
-      --non-interactive                                Skip all interactive prompts (auto-detected in CI or non-TTY environments)
-      --pg-schema string                               Postgres schema for this workspace's tables (with --backend=postgres; provides search_path isolation)
-      --pg-url string                                  Postgres connection URL (with --backend=postgres). A password may be included for init but is never persisted; set BEADS_PG_PASSWORD for later commands. Falls back to BEADS_POSTGRES_URL.
-  -p, --prefix string                                  Issue prefix (default: current directory name)
-      --proxied-server                                 [EXPERIMENTAL] Use a per-workspace proxied dolt sql-server (proxy + child dolt) rooted at .beads/dolt
-      --proxied-server-config-path string              [EXPERIMENTAL] Absolute path to an existing dolt sql-server YAML config (proxied-server mode only). When set, bd uses this file instead of auto-generating one. Relative paths are rejected.
-      --proxied-server-external-host string            [EXPERIMENTAL] Hostname or IP of an externally-managed dolt sql-server the proxy should front (proxied-server mode only). Mutually exclusive with --proxied-server-external-socket-path.
-      --proxied-server-external-keep-alive duration    [EXPERIMENTAL] TCP keepalive period for the proxy→external connection. Zero uses the package default (30s).
-      --proxied-server-external-port int               [EXPERIMENTAL] TCP port of the externally-managed dolt sql-server (proxied-server mode only). Required when --proxied-server-external-host is set.
-      --proxied-server-external-socket-path string     [EXPERIMENTAL] Absolute unix socket path of the externally-managed dolt sql-server (proxied-server mode only). Mutually exclusive with --proxied-server-external-host. Relative paths are rejected.
-      --proxied-server-external-tls                    [EXPERIMENTAL] Require TLS when connecting to the externally-managed dolt sql-server (proxied-server mode only).
-      --proxied-server-external-tls-cert-path string   [EXPERIMENTAL] Absolute path to a client TLS certificate (for mTLS to the externally-managed dolt sql-server). Must be paired with --proxied-server-external-tls-key-path. Relative paths are rejected.
-      --proxied-server-external-tls-key-path string    [EXPERIMENTAL] Absolute path to the client TLS private key (for mTLS to the externally-managed dolt sql-server). Must be paired with --proxied-server-external-tls-cert-path. Relative paths are rejected.
-      --proxied-server-external-user string            [EXPERIMENTAL] MySQL user for the externally-managed dolt sql-server (proxied-server mode only). Defaults to "root" when empty. Password is read at runtime from $BEADS_PROXIED_SERVER_EXTERNAL_PASSWORD and is never persisted to disk.
-      --proxied-server-idle-timeout duration           [EXPERIMENTAL] Idle duration after which the proxy shuts down its loopback listener and backend (proxied-server mode only). Omit for the built-in default (30s); 0 keeps the proxy and backend alive indefinitely; a positive value sets the window.
-      --proxied-server-log-path string                 [EXPERIMENTAL] Absolute path to the proxied dolt sql-server log file (proxied-server mode only). Default: <beadsDir>/dolt/server.log. Relative paths are rejected.
-      --proxied-server-port int                        [EXPERIMENTAL] Fixed TCP port for the proxy's loopback listener (proxied-server mode only). Default 0 = an OS-assigned free port. Startup fails if the port is already in use.
-      --proxied-server-root-path string                [EXPERIMENTAL] Absolute directory holding the proxied dolt sql-server's lockfiles, pidfiles, and child .dolt repository (proxied-server mode only). Default: <beadsDir>/dolt. May not exist yet — bd will create it. Relative paths are rejected.
-  -q, --quiet                                          Suppress output (quiet mode)
-      --reinit-local                                   Re-initialize local .beads/ over existing local data. Does NOT authorize remote divergence; see --discard-remote.
-      --remote string                                  Dolt remote URL to clone from and persist as sync.remote
-      --role string                                    Set beads role without prompting: "maintainer" or "contributor"
-      --server                                         Use external dolt sql-server instead of embedded engine
-      --server-host string                             Dolt server host (default: 127.0.0.1)
-      --server-port int                                Dolt server port (default: 3307)
-      --server-socket string                           Unix domain socket path (overrides host/port)
-      --server-user string                             Dolt server MySQL user (default: root)
-      --setup-exclude                                  Configure .git/info/exclude to keep beads files local (for forks)
-      --shared-server                                  Enable shared Dolt server mode (all projects share one server at ~/.beads/shared-server/)
-      --skip-agents                                    Skip AGENTS.md and Claude/Codex/Cursor setup generation
-      --skip-hooks                                     Skip git hooks installation
-      --sqlite-path string                             SQLite database file (with --backend=sqlite; relative to the beads dir, default beads.db)
-      --stealth                                        Enable stealth mode: global gitattributes and gitignore, no local repo tracking
-      --team                                           Run team workflow setup wizard
+      --agents-file string                                Custom filename for agent instructions (default: AGENTS.md)
+      --agents-profile string                             AGENTS.md profile: 'minimal' (default, pointer to bd prime) or 'full' (complete command reference)
+      --agents-template string                            Path to custom AGENTS.md template (overrides embedded default)
+      --backend string                                    Storage backend: dolt (default), postgres, mysql, or sqlite. See docs/architecture/storage-backends.md.
+      --contributor                                       Run OSS contributor setup wizard
+      --database string                                   Use existing server database name (overrides prefix-based naming)
+      --debug                                             Run the managed Dolt sql-server with --loglevel=debug and CPU profiling (--prof cpu). Persisted to config.yaml as dolt.debug. No effect on externally-managed servers.
+      --destroy-token string                              Explicit confirmation token for destructive re-init in non-interactive mode (format: 'DESTROY-<prefix>')
+      --discard-remote                                    Authorize discarding the configured remote's Dolt history when re-initializing. Requires --destroy-token in non-interactive mode; see 'bd help init-safety'.
+      --external                                          Server is externally managed (skip server startup); use with --shared-server or --server
+      --force                                             Deprecated alias for --reinit-local. Bypasses only the LOCAL data-safety guard; does NOT authorize remote divergence (see 'bd help init-safety').
+      --from-jsonl                                        Import issues from configured import.path; refuses remote history unless --discard-remote authorizes replacement
+      --init-if-missing                                   If the workspace is already initialized, skip init and exit 0 instead of failing (idempotent init for scaffolds)
+      --mysql-database string                             MySQL database for this workspace (with --backend=mysql; MySQL's isolation unit)
+      --mysql-url string                                  MySQL server DSN (with --backend=mysql), e.g. user:pass@tcp(host:3306)/ . A password may be included for init but is never persisted; set BEADS_MYSQL_PASSWORD for later commands. Falls back to BEADS_MYSQL_URL.
+      --non-interactive                                   Skip all interactive prompts (auto-detected in CI or non-TTY environments)
+      --pg-schema string                                  Postgres schema for this workspace's tables (with --backend=postgres; provides search_path isolation)
+      --pg-url string                                     Postgres connection URL (with --backend=postgres). A password may be included for init but is never persisted; set BEADS_PG_PASSWORD for later commands. Falls back to BEADS_POSTGRES_URL.
+  -p, --prefix string                                     Issue prefix (default: current directory name)
+      --proxied-server                                    [EXPERIMENTAL] Use a per-workspace proxied dolt sql-server (proxy + child dolt) rooted at .beads/dolt
+      --proxied-server-config-path string                 [EXPERIMENTAL] Absolute path to an existing dolt sql-server YAML config (proxied-server mode only). When set, bd uses this file instead of auto-generating one. Relative paths are rejected.
+      --proxied-server-external-host string               [EXPERIMENTAL] Hostname or IP of an externally-managed dolt sql-server the proxy should front (proxied-server mode only). Mutually exclusive with --proxied-server-external-socket-path.
+      --proxied-server-external-keep-alive duration       [EXPERIMENTAL] TCP keepalive period for the proxy→external connection. Zero uses the package default (30s).
+      --proxied-server-external-port int                  [EXPERIMENTAL] TCP port of the externally-managed dolt sql-server (proxied-server mode only). Required when --proxied-server-external-host is set.
+      --proxied-server-external-socket-path string        [EXPERIMENTAL] Absolute unix socket path of the externally-managed dolt sql-server (proxied-server mode only). Mutually exclusive with --proxied-server-external-host. Relative paths are rejected.
+      --proxied-server-external-tls                       [EXPERIMENTAL] Require TLS when connecting to the externally-managed dolt sql-server (proxied-server mode only).
+      --proxied-server-external-tls-ca-cert-path string   [EXPERIMENTAL] Absolute path to a CA certificate (PEM) used to verify the externally-managed dolt sql-server. Empty uses the system trust store. Relative paths are rejected.
+      --proxied-server-external-tls-cert-path string      [EXPERIMENTAL] Absolute path to a client TLS certificate (for mTLS to the externally-managed dolt sql-server). Must be paired with --proxied-server-external-tls-key-path. Relative paths are rejected.
+      --proxied-server-external-tls-key-path string       [EXPERIMENTAL] Absolute path to the client TLS private key (for mTLS to the externally-managed dolt sql-server). Must be paired with --proxied-server-external-tls-cert-path. Relative paths are rejected.
+      --proxied-server-external-tls-server-name string    [EXPERIMENTAL] Server name to verify in the external dolt sql-server's TLS certificate. Defaults to the external host. Required with a unix socket unless --proxied-server-external-tls-skip-verify is set.
+      --proxied-server-external-tls-skip-verify           [EXPERIMENTAL] Skip TLS certificate verification for the external dolt sql-server. Insecure; testing only.
+      --proxied-server-external-user string               [EXPERIMENTAL] MySQL user for the externally-managed dolt sql-server (proxied-server mode only). Defaults to "root" when empty. Password is read at runtime from $BEADS_PROXIED_SERVER_EXTERNAL_PASSWORD and is never persisted to disk.
+      --proxied-server-idle-timeout duration              [EXPERIMENTAL] Idle duration after which the proxy shuts down its loopback listener and backend (proxied-server mode only). Omit for the built-in default (30s); 0 keeps the proxy and backend alive indefinitely; a positive value sets the window.
+      --proxied-server-log-path string                    [EXPERIMENTAL] Absolute path to the proxied dolt sql-server log file (proxied-server mode only). Default: <beadsDir>/dolt/server.log. Relative paths are rejected.
+      --proxied-server-port int                           [EXPERIMENTAL] Fixed TCP port for the proxy's loopback listener (proxied-server mode only). Default 0 = an OS-assigned free port. Startup fails if the port is already in use.
+      --proxied-server-root-path string                   [EXPERIMENTAL] Absolute directory holding the proxied dolt sql-server's lockfiles, pidfiles, and child .dolt repository (proxied-server mode only). Default: <beadsDir>/dolt. May not exist yet — bd will create it. Relative paths are rejected.
+  -q, --quiet                                             Suppress output (quiet mode)
+      --reinit-local                                      Re-initialize local .beads/ over existing local data. Does NOT authorize remote divergence; see --discard-remote.
+      --remote string                                     Dolt remote URL to clone from and persist as sync.remote
+      --role string                                       Set beads role without prompting: "maintainer" or "contributor"
+      --server                                            Use external dolt sql-server instead of embedded engine
+      --server-host string                                Dolt server host (default: 127.0.0.1)
+      --server-port int                                   Dolt server port (default: 3307)
+      --server-socket string                              Unix domain socket path (overrides host/port)
+      --server-user string                                Dolt server MySQL user (default: root)
+      --setup-exclude                                     Configure .git/info/exclude to keep beads files local (for forks)
+      --shared-server                                     Enable shared Dolt server mode (all projects share one server at ~/.beads/shared-server/)
+      --skip-agents                                       Skip AGENTS.md and Claude/Codex/Cursor setup generation
+      --skip-hooks                                        Skip git hooks installation
+      --sqlite-path string                                SQLite database file (with --backend=sqlite; relative to the beads dir, default beads.db)
+      --stealth                                           Enable stealth mode: global gitattributes and gitignore, no local repo tracking
+      --team                                              Run team workflow setup wizard
 ```

--- a/internal/configfile/external_dolt_config.go
+++ b/internal/configfile/external_dolt_config.go
@@ -1,8 +1,11 @@
 package configfile
 
 import (
+	"crypto/tls"
+	"crypto/x509"
 	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 	"time"
 )
@@ -18,8 +21,11 @@ type ExternalDoltConfig struct {
 	Socket          string        `json:"socket,omitempty"`
 	User            string        `json:"user,omitempty"`
 	TLSRequired     bool          `json:"tls_required,omitempty"`
+	TLSCACert       string        `json:"tls_ca_cert,omitempty"`
 	TLSCert         string        `json:"tls_cert,omitempty"`
 	TLSKey          string        `json:"tls_key,omitempty"`
+	TLSServerName   string        `json:"tls_server_name,omitempty"`
+	TLSSkipVerify   bool          `json:"tls_skip_verify,omitempty"`
 	KeepAlivePeriod time.Duration `json:"keep_alive_period,omitempty"`
 }
 
@@ -67,10 +73,57 @@ func (c ExternalDoltConfig) Validate() error {
 	if c.TLSKey != "" && !filepath.IsAbs(c.TLSKey) {
 		return fmt.Errorf("ExternalDoltConfig: TLSKey %q is not absolute", c.TLSKey)
 	}
+	if c.TLSCACert != "" && !filepath.IsAbs(c.TLSCACert) {
+		return fmt.Errorf("ExternalDoltConfig: TLSCACert %q is not absolute", c.TLSCACert)
+	}
+
+	if c.TLSRequired && hasSocket && c.TLSServerName == "" && !c.TLSSkipVerify {
+		return errors.New("ExternalDoltConfig: TLSRequired over Socket needs TLSServerName or TLSSkipVerify")
+	}
 
 	if c.KeepAlivePeriod < 0 {
 		return fmt.Errorf("ExternalDoltConfig: KeepAlivePeriod %s is negative", c.KeepAlivePeriod)
 	}
 
 	return nil
+}
+
+func (c ExternalDoltConfig) TLSClientConfig() (*tls.Config, error) {
+	if !c.TLSRequired {
+		return nil, nil
+	}
+
+	cfg := &tls.Config{MinVersion: tls.VersionTLS12}
+
+	if c.TLSSkipVerify {
+		cfg.InsecureSkipVerify = true
+	} else {
+		name := c.TLSServerName
+		if name == "" {
+			name = c.Host
+		}
+		cfg.ServerName = name
+	}
+
+	if c.TLSCACert != "" {
+		pem, err := os.ReadFile(c.TLSCACert)
+		if err != nil {
+			return nil, fmt.Errorf("ExternalDoltConfig: read TLSCACert: %w", err)
+		}
+		pool := x509.NewCertPool()
+		if !pool.AppendCertsFromPEM(pem) {
+			return nil, fmt.Errorf("ExternalDoltConfig: TLSCACert %q: no certificates parsed", c.TLSCACert)
+		}
+		cfg.RootCAs = pool
+	}
+
+	if c.TLSCert != "" {
+		crt, err := tls.LoadX509KeyPair(c.TLSCert, c.TLSKey)
+		if err != nil {
+			return nil, fmt.Errorf("ExternalDoltConfig: load client cert/key: %w", err)
+		}
+		cfg.Certificates = []tls.Certificate{crt}
+	}
+
+	return cfg, nil
 }

--- a/internal/configfile/external_dolt_config.go
+++ b/internal/configfile/external_dolt_config.go
@@ -77,6 +77,19 @@ func (c ExternalDoltConfig) Validate() error {
 		return fmt.Errorf("ExternalDoltConfig: TLSCACert %q is not absolute", c.TLSCACert)
 	}
 
+	if !c.TLSRequired {
+		switch {
+		case c.TLSCACert != "":
+			return errors.New("ExternalDoltConfig: TLSCACert set without TLSRequired")
+		case c.TLSCert != "" || c.TLSKey != "":
+			return errors.New("ExternalDoltConfig: TLSCert/TLSKey set without TLSRequired")
+		case c.TLSServerName != "":
+			return errors.New("ExternalDoltConfig: TLSServerName set without TLSRequired")
+		case c.TLSSkipVerify:
+			return errors.New("ExternalDoltConfig: TLSSkipVerify set without TLSRequired")
+		}
+	}
+
 	if c.TLSRequired && hasSocket && c.TLSServerName == "" && !c.TLSSkipVerify {
 		return errors.New("ExternalDoltConfig: TLSRequired over Socket needs TLSServerName or TLSSkipVerify")
 	}
@@ -96,7 +109,7 @@ func (c ExternalDoltConfig) TLSClientConfig() (*tls.Config, error) {
 	cfg := &tls.Config{MinVersion: tls.VersionTLS12}
 
 	if c.TLSSkipVerify {
-		cfg.InsecureSkipVerify = true
+		cfg.InsecureSkipVerify = true //nolint:gosec // G402: opt-in insecure transport via the TLSSkipVerify testing flag
 	} else {
 		name := c.TLSServerName
 		if name == "" {

--- a/internal/configfile/external_dolt_config_test.go
+++ b/internal/configfile/external_dolt_config_test.go
@@ -1,6 +1,18 @@
 package configfile
 
-import "testing"
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
 
 func TestExternalDoltConfig_ResolvedUser(t *testing.T) {
 	t.Run("empty falls back to default", func(t *testing.T) {
@@ -14,4 +26,169 @@ func TestExternalDoltConfig_ResolvedUser(t *testing.T) {
 			t.Errorf("got %q, want %q", got, "beads")
 		}
 	})
+}
+
+func TestExternalDoltConfig_Validate_TLS(t *testing.T) {
+	certPath, keyPath := writeSelfSignedPair(t)
+
+	t.Run("ca cert must be absolute", func(t *testing.T) {
+		err := ExternalDoltConfig{Host: "db", Port: 3306, TLSRequired: true, TLSCACert: "relative/ca.pem"}.Validate()
+		if err == nil {
+			t.Fatal("expected error for relative TLSCACert")
+		}
+	})
+
+	t.Run("absolute ca cert accepted", func(t *testing.T) {
+		if err := (ExternalDoltConfig{Host: "db", Port: 3306, TLSRequired: true, TLSCACert: certPath}).Validate(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("socket with tls needs server name", func(t *testing.T) {
+		err := ExternalDoltConfig{Socket: "/var/run/dolt.sock", TLSRequired: true}.Validate()
+		if err == nil {
+			t.Fatal("expected error for socket+tls without server name")
+		}
+	})
+
+	t.Run("socket with tls and server name ok", func(t *testing.T) {
+		if err := (ExternalDoltConfig{Socket: "/var/run/dolt.sock", TLSRequired: true, TLSServerName: "db"}).Validate(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("socket with tls and skip verify ok", func(t *testing.T) {
+		if err := (ExternalDoltConfig{Socket: "/var/run/dolt.sock", TLSRequired: true, TLSSkipVerify: true}).Validate(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	_ = keyPath
+}
+
+func TestExternalDoltConfig_TLSClientConfig(t *testing.T) {
+	certPath, keyPath := writeSelfSignedPair(t)
+
+	t.Run("not required returns nil", func(t *testing.T) {
+		cfg, err := ExternalDoltConfig{Host: "db", Port: 3306}.TLSClientConfig()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if cfg != nil {
+			t.Fatalf("expected nil config, got %+v", cfg)
+		}
+	})
+
+	t.Run("server name defaults to host", func(t *testing.T) {
+		cfg, err := ExternalDoltConfig{Host: "db.example.com", Port: 3306, TLSRequired: true}.TLSClientConfig()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if cfg.ServerName != "db.example.com" {
+			t.Fatalf("ServerName = %q, want db.example.com", cfg.ServerName)
+		}
+		if cfg.MinVersion == 0 {
+			t.Fatal("MinVersion not set")
+		}
+	})
+
+	t.Run("server name override wins", func(t *testing.T) {
+		cfg, err := ExternalDoltConfig{Host: "127.0.0.1", Port: 3306, TLSRequired: true, TLSServerName: "real.host"}.TLSClientConfig()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if cfg.ServerName != "real.host" {
+			t.Fatalf("ServerName = %q, want real.host", cfg.ServerName)
+		}
+	})
+
+	t.Run("skip verify sets insecure and clears server name", func(t *testing.T) {
+		cfg, err := ExternalDoltConfig{Host: "db", Port: 3306, TLSRequired: true, TLSSkipVerify: true, TLSServerName: "db"}.TLSClientConfig()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !cfg.InsecureSkipVerify {
+			t.Fatal("InsecureSkipVerify not set")
+		}
+		if cfg.ServerName != "" {
+			t.Fatalf("ServerName = %q, want empty under skip-verify", cfg.ServerName)
+		}
+	})
+
+	t.Run("ca cert loaded into root pool", func(t *testing.T) {
+		cfg, err := ExternalDoltConfig{Host: "db", Port: 3306, TLSRequired: true, TLSCACert: certPath}.TLSClientConfig()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if cfg.RootCAs == nil {
+			t.Fatal("RootCAs not set from CA cert")
+		}
+	})
+
+	t.Run("empty ca cert uses system roots", func(t *testing.T) {
+		cfg, err := ExternalDoltConfig{Host: "db", Port: 3306, TLSRequired: true}.TLSClientConfig()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if cfg.RootCAs != nil {
+			t.Fatal("RootCAs should be nil to use system roots")
+		}
+	})
+
+	t.Run("unparseable ca cert errors", func(t *testing.T) {
+		bad := filepath.Join(t.TempDir(), "bad.pem")
+		if err := os.WriteFile(bad, []byte("not a pem"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		_, err := ExternalDoltConfig{Host: "db", Port: 3306, TLSRequired: true, TLSCACert: bad}.TLSClientConfig()
+		if err == nil {
+			t.Fatal("expected error for unparseable CA cert")
+		}
+	})
+
+	t.Run("client cert loaded for mtls", func(t *testing.T) {
+		cfg, err := ExternalDoltConfig{Host: "db", Port: 3306, TLSRequired: true, TLSCert: certPath, TLSKey: keyPath}.TLSClientConfig()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(cfg.Certificates) != 1 {
+			t.Fatalf("Certificates len = %d, want 1", len(cfg.Certificates))
+		}
+	})
+}
+
+func writeSelfSignedPair(t *testing.T) (certPath, keyPath string) {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmpl := x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "test"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, &tmpl, &tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dir := t.TempDir()
+	certPath = filepath.Join(dir, "cert.pem")
+	keyPath = filepath.Join(dir, "key.pem")
+	if err := os.WriteFile(certPath, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(keyPath, pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER}), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return certPath, keyPath
 }

--- a/internal/configfile/external_dolt_config_test.go
+++ b/internal/configfile/external_dolt_config_test.go
@@ -63,7 +63,19 @@ func TestExternalDoltConfig_Validate_TLS(t *testing.T) {
 		}
 	})
 
-	_ = keyPath
+	t.Run("tls material without tls required is rejected", func(t *testing.T) {
+		cases := []ExternalDoltConfig{
+			{Host: "db", Port: 3306, TLSCACert: certPath},
+			{Host: "db", Port: 3306, TLSCert: certPath, TLSKey: keyPath},
+			{Host: "db", Port: 3306, TLSServerName: "db"},
+			{Host: "db", Port: 3306, TLSSkipVerify: true},
+		}
+		for _, c := range cases {
+			if err := c.Validate(); err == nil {
+				t.Fatalf("expected error for TLS material without TLSRequired: %+v", c)
+			}
+		}
+	})
 }
 
 func TestExternalDoltConfig_TLSClientConfig(t *testing.T) {

--- a/internal/storage/dbproxy/proxy/endpoint.go
+++ b/internal/storage/dbproxy/proxy/endpoint.go
@@ -260,15 +260,6 @@ func forkExecChild(rootDir string, opts OpenOpts, port int, lock *util.Lock) (*e
 		if ext.Socket != "" {
 			args = append(args, "--external-socket-path", ext.Socket)
 		}
-		if ext.TLSRequired {
-			args = append(args, "--external-tls")
-		}
-		if ext.TLSCert != "" {
-			args = append(args, "--external-tls-cert-path", ext.TLSCert)
-		}
-		if ext.TLSKey != "" {
-			args = append(args, "--external-tls-key-path", ext.TLSKey)
-		}
 		if ext.KeepAlivePeriod != 0 {
 			args = append(args, "--external-keep-alive", ext.KeepAlivePeriod.String())
 		}

--- a/internal/storage/dbproxy/server/external_dolt_server.go
+++ b/internal/storage/dbproxy/server/external_dolt_server.go
@@ -20,9 +20,6 @@ type ExternalDoltServer struct {
 	host            string
 	port            int
 	socket          string
-	tlsRequired     bool
-	tlsCert         string
-	tlsKey          string
 	keepAlivePeriod time.Duration
 
 	started atomic.Bool
@@ -43,9 +40,6 @@ func NewExternalDoltServer(cfg configfile.ExternalDoltConfig) (*ExternalDoltServ
 		host:            cfg.Host,
 		port:            cfg.Port,
 		socket:          cfg.Socket,
-		tlsRequired:     cfg.TLSRequired,
-		tlsCert:         cfg.TLSCert,
-		tlsKey:          cfg.TLSKey,
 		keepAlivePeriod: keepAlive,
 	}, nil
 }
@@ -68,12 +62,9 @@ func (s *ExternalDoltServer) ID(_ context.Context) string {
 
 func (s *ExternalDoltServer) DSN(_ context.Context, database, user, password string) string {
 	dsn := util.DoltServerDSN{
-		User:        user,
-		Password:    password,
-		Database:    database,
-		TLSRequired: s.tlsRequired,
-		TLSCert:     s.tlsCert,
-		TLSKey:      s.tlsKey,
+		User:     user,
+		Password: password,
+		Database: database,
 	}
 	if s.socket != "" {
 		dsn.Socket = s.socket

--- a/internal/storage/dbproxy/server/external_dolt_server_test.go
+++ b/internal/storage/dbproxy/server/external_dolt_server_test.go
@@ -213,11 +213,11 @@ func TestExternalDoltServer_DSN(t *testing.T) {
 		assert.Contains(t, dsn, "tls=false")
 	})
 
-	t.Run("tcp with tls required", func(t *testing.T) {
+	t.Run("tls terminates client-side, not in this dsn", func(t *testing.T) {
 		s, err := NewExternalDoltServer(configfile.ExternalDoltConfig{Host: "db", Port: 3306, TLSRequired: true})
 		require.NoError(t, err)
 		dsn := s.DSN(context.Background(), "beads", "root", "")
-		assert.Contains(t, dsn, "tls=true")
+		assert.Contains(t, dsn, "tls=false")
 	})
 
 	t.Run("unix socket", func(t *testing.T) {

--- a/internal/storage/dbproxy/util/dsn.go
+++ b/internal/storage/dbproxy/util/dsn.go
@@ -8,16 +8,17 @@ import (
 )
 
 type DoltServerDSN struct {
-	Socket      string
-	Host        string
-	Port        int
-	User        string
-	Password    string //nolint:gosec // G117: MySQL DSN password field; required by the connection-string builder, not serialized as JSON
-	Database    string
-	Timeout     time.Duration
-	TLSRequired bool
-	TLSCert     string
-	TLSKey      string
+	Socket        string
+	Host          string
+	Port          int
+	User          string
+	Password      string //nolint:gosec // G117: MySQL DSN password field; required by the connection-string builder, not serialized as JSON
+	Database      string
+	Timeout       time.Duration
+	TLSRequired   bool
+	TLSCert       string
+	TLSKey        string
+	TLSConfigName string
 }
 
 func (d DoltServerDSN) String() string {
@@ -44,9 +45,12 @@ func (d DoltServerDSN) String() string {
 		Timeout:              timeout,
 		AllowNativePasswords: true,
 	}
-	if d.TLSRequired {
+	switch {
+	case d.TLSConfigName != "":
+		cfg.TLSConfig = d.TLSConfigName
+	case d.TLSRequired:
 		cfg.TLSConfig = "true"
-	} else {
+	default:
 		cfg.TLSConfig = "false"
 	}
 

--- a/internal/storage/dbproxy/util/dsn_test.go
+++ b/internal/storage/dbproxy/util/dsn_test.go
@@ -1,0 +1,36 @@
+package util
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestDoltServerDSN_TLS(t *testing.T) {
+	t.Run("config name takes precedence", func(t *testing.T) {
+		dsn := DoltServerDSN{Host: "127.0.0.1", Port: 3306, User: "root", TLSConfigName: "beads-external-abc", TLSRequired: true}.String()
+		if !strings.Contains(dsn, "tls=beads-external-abc") {
+			t.Fatalf("dsn %q missing tls=beads-external-abc", dsn)
+		}
+	})
+
+	t.Run("required without name emits tls=true", func(t *testing.T) {
+		dsn := DoltServerDSN{Host: "127.0.0.1", Port: 3306, User: "root", TLSRequired: true}.String()
+		if !strings.Contains(dsn, "tls=true") {
+			t.Fatalf("dsn %q missing tls=true", dsn)
+		}
+	})
+
+	t.Run("default disables tls", func(t *testing.T) {
+		dsn := DoltServerDSN{Host: "127.0.0.1", Port: 3306, User: "root"}.String()
+		if !strings.Contains(dsn, "tls=false") {
+			t.Fatalf("dsn %q missing tls=false", dsn)
+		}
+	})
+
+	t.Run("socket uses unix network", func(t *testing.T) {
+		dsn := DoltServerDSN{Socket: "/var/run/dolt.sock", User: "root"}.String()
+		if !strings.Contains(dsn, "unix(/var/run/dolt.sock)") {
+			t.Fatalf("dsn %q missing unix socket", dsn)
+		}
+	})
+}

--- a/internal/storage/uow/dolt_sql_provider.go
+++ b/internal/storage/uow/dolt_sql_provider.go
@@ -93,13 +93,14 @@ func (p *doltSQLProvider) initSchema(ctx context.Context, database string) error
 	}, backoff.WithContext(bo, ctx))
 }
 
-func buildDSN(ep proxy.Endpoint, database, user, password string) string {
+func buildDSN(ep proxy.Endpoint, database, user, password, tlsConfigName string) string {
 	return util.DoltServerDSN{
-		Host:     ep.Host,
-		Port:     ep.Port,
-		User:     user,
-		Password: password,
-		Database: database,
+		Host:          ep.Host,
+		Port:          ep.Port,
+		User:          user,
+		Password:      password,
+		Database:      database,
+		TLSConfigName: tlsConfigName,
 	}.String()
 }
 
@@ -114,8 +115,8 @@ func openDB(ctx context.Context, dsn string) (*sql.DB, error) {
 	return conn, nil
 }
 
-func openAndInitSchema(ctx context.Context, ep proxy.Endpoint, database, rootUser, rootPassword string) (UnitOfWorkProvider, error) {
-	initDB, err := openDB(ctx, buildDSN(ep, "", rootUser, rootPassword))
+func openAndInitSchema(ctx context.Context, ep proxy.Endpoint, database, rootUser, rootPassword, tlsConfigName string) (UnitOfWorkProvider, error) {
+	initDB, err := openDB(ctx, buildDSN(ep, "", rootUser, rootPassword, tlsConfigName))
 	if err != nil {
 		return nil, err
 	}
@@ -134,7 +135,7 @@ func openAndInitSchema(ctx context.Context, ep proxy.Endpoint, database, rootUse
 		return nil, fmt.Errorf("uow: close init db: %w", err)
 	}
 
-	dbConn, err := openDB(ctx, buildDSN(ep, database, rootUser, rootPassword))
+	dbConn, err := openDB(ctx, buildDSN(ep, database, rootUser, rootPassword, tlsConfigName))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/storage/uow/doltserver_provider.go
+++ b/internal/storage/uow/doltserver_provider.go
@@ -68,5 +68,5 @@ func NewDoltServerUOWProvider(
 		return nil, fmt.Errorf("uow: get proxy endpoint: %w", err)
 	}
 
-	return openAndInitSchema(ctx, ep, database, rootUser, rootPassword)
+	return openAndInitSchema(ctx, ep, database, rootUser, rootPassword, "")
 }

--- a/internal/storage/uow/external_doltserver_provider.go
+++ b/internal/storage/uow/external_doltserver_provider.go
@@ -7,11 +7,12 @@ import (
 	"path/filepath"
 	"time"
 
-	_ "github.com/go-sql-driver/mysql"
+	mysql "github.com/go-sql-driver/mysql"
 
 	"github.com/steveyegge/beads/internal/config"
 	"github.com/steveyegge/beads/internal/configfile"
 	"github.com/steveyegge/beads/internal/storage/dbproxy/proxy"
+	"github.com/steveyegge/beads/internal/storage/dbproxy/server"
 )
 
 func NewExternalDoltServerUOWProvider(
@@ -47,6 +48,11 @@ func NewExternalDoltServerUOWProvider(
 		return nil, fmt.Errorf("uow: creating server root directory: %w", err)
 	}
 
+	tlsConfigName, err := registerExternalTLSConfig(external)
+	if err != nil {
+		return nil, fmt.Errorf("uow: external TLS: %w", err)
+	}
+
 	ep, err := proxy.GetCreateDatabaseProxyServerEndpoint(absServerRootDir, proxy.OpenOpts{
 		Backend:     proxy.BackendExternal,
 		LogFilePath: serverLogFilePath,
@@ -58,5 +64,20 @@ func NewExternalDoltServerUOWProvider(
 		return nil, fmt.Errorf("uow: get proxy endpoint: %w", err)
 	}
 
-	return openAndInitSchema(ctx, ep, database, rootUser, rootPassword)
+	return openAndInitSchema(ctx, ep, database, rootUser, rootPassword, tlsConfigName)
+}
+
+func registerExternalTLSConfig(external configfile.ExternalDoltConfig) (string, error) {
+	if !external.TLSRequired {
+		return "", nil
+	}
+	tc, err := external.TLSClientConfig()
+	if err != nil {
+		return "", err
+	}
+	name := "beads-external-" + server.ExternalDoltServerID(external)
+	if err := mysql.RegisterTLSConfig(name, tc); err != nil {
+		return "", fmt.Errorf("register TLS config: %w", err)
+	}
+	return name, nil
 }


### PR DESCRIPTION
## What

Makes the proxied-server **external** backend actually work against a remote dolt sql-server that requires TLS. Before this change, TLS config flowed from the config file → fork/exec flags → `ExternalDoltServer` fields → a `DSN()` method that is never called on the external path, so no code ever opened a TLS socket. The client DSN (`buildDSN`) dropped TLS entirely and connected in plaintext, which a `require_secure_transport=ON` server rejects.

## Approach

TLS terminates **end-to-end at the bd client**, tunneled through the proxy's byte-pipe. The client already authenticates end-to-end (it holds the password and sends the MySQL handshake through the pipe), so the client is the true MySQL endpoint and is where TLS belongs. The proxy stays a plaintext L4 relay — no MySQL-protocol awareness, no keys, not a trust boundary. This avoids turning the byte-pipe into a stateful MySQL protocol proxy, which in-band MySQL TLS negotiation would otherwise require.

## Changes

- `ExternalDoltConfig`: add `TLSCACert`, `TLSServerName`, `TLSSkipVerify`; validate absolute CA path and require a server name (or skip-verify) when TLS is used over a unix socket.
- New `ExternalDoltConfig.TLSClientConfig()` builds the `*tls.Config` (MinVersion 1.2, ServerName defaulting to host, RootCAs from CA file or system roots, client cert/key for mTLS, optional skip-verify).
- `DoltServerDSN` gains `TLSConfigName`; the external UOW provider registers the config via `mysql.RegisterTLSConfig` (keyed by the stable server ID) and threads the name through `buildDSN` / `openAndInitSchema`. `ServerName` is pinned to the real external host so verification survives the loopback address rewrite.
- Remove the now-dead TLS plumbing from the child/proxy path (`endpoint.go` fork args, `db-proxy-child` flags, `ExternalDoltServer` TLS fields, the dead `DSN()` TLS branch).
- Wire the three new fields into `bd init` as `--proxied-server-external-tls-ca-cert-path`, `--proxied-server-external-tls-server-name`, `--proxied-server-external-tls-skip-verify`.

## Tests

- Unit: DSN builder emits `tls=<name>`; `TLSClientConfig` across system-roots / CA-file / mTLS / skip-verify / socket cases; new config validation; updated flag-registration and external-DSN tests.
- `go build ./...`, `go vet`, and the config / proxy / uow / `cmd/bd` proxied-server suites pass.
- Not yet run: live end-to-end against a real TLS-requiring dolt server (the wrong-CA negative check included).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
