### PR TITLE
docs: add emBEADings to community tools

### DIFF
--- a/docs/community-tools.md
+++ b/docs/community-tools.md
@@ -59,6 +59,8 @@ A curated list of community-built UIs, extensions, and integrations for Beads. R
 
 Install with `uv tool install git+https://github.com/jklenk/thread`. Built by [@jklenk](https://github.com/jklenk). (Python/DuckDB)
 
+- **[emBEADings](https://github.com/DyrtyJax/embeadings)** - Technical-preview, read-only coordination CLI that turns typed Beads relationships, local semantic retrieval, and active Git worktree changes into bounded, deterministic review leads. Reads the live tracker through allowlisted `bd --readonly ... --json` commands, embeds issue text locally, and has no tracker-write operations. Install the [v0.4.1 wheel](https://github.com/DyrtyJax/embeadings/releases/tag/v0.4.1). Built by [@DyrtyJax](https://github.com/DyrtyJax). (Python)
+
 ## SDKs & Libraries
 
 - **[beads-sdk](https://github.com/HerbCaudill/beads-sdk)** - Typed TypeScript SDK with zero runtime dependencies. High-level `BeadsClient` for CRUD, filtering, search, labels, dependencies, comments, epics, and sync. Install with `pnpm add @herbcaudill/beads-sdk`. Built by [@HerbCaudill](https://github.com/HerbCaudill). (TypeScript)

--- a/docs/community-tools.md
+++ b/docs/community-tools.md
@@ -59,7 +59,7 @@ A curated list of community-built UIs, extensions, and integrations for Beads. R
 
 Install with `uv tool install git+https://github.com/jklenk/thread`. Built by [@jklenk](https://github.com/jklenk). (Python/DuckDB)
 
-- **[emBEADings](https://github.com/DyrtyJax/embeadings)** - Technical-preview, read-only coordination CLI that turns typed Beads relationships, local semantic retrieval, and active Git worktree changes into bounded, deterministic review leads. Reads the live tracker through allowlisted `bd --readonly ... --json` commands, embeds issue text locally, and has no tracker-write operations. Install the [v0.4.1 wheel](https://github.com/DyrtyJax/embeadings/releases/tag/v0.4.1). Built by [@DyrtyJax](https://github.com/DyrtyJax). (Python)
+- **[emBEADings](https://github.com/DyrtyJax/embeadings)** - Technical-preview, read-only coordination CLI that turns typed Beads relationships, local semantic retrieval, and active Git worktree changes into bounded, deterministic review leads. Reads the live tracker through allowlisted `bd --readonly ... --json` commands, embeds issue text locally, and has no tracker-write operations. Install from [PyPI](https://pypi.org/project/embeadings/) with `pipx install embeadings` or `uv tool install embeadings`. Built by [@DyrtyJax](https://github.com/DyrtyJax). (Python)
 
 ## SDKs & Libraries
 


### PR DESCRIPTION
## What

Add emBEADings to **Analytics & Observability** as a technical-preview Beads companion. This is one catalog entry; it changes no Beads code, schema, or storage behavior.

## Why

emBEADings provides an optional, local-first review layer for semantic neighbors and concurrent code-surface leads while keeping Beads authoritative. Its Beads adapter allowlists only these live CLI reads:

```console
bd --readonly context --json
bd --readonly version --json
bd --readonly list --all --limit 0 --json
```

It has no tracker-write operations, and the default embedding model runs locally after its model artifacts are downloaded. Related to the embedding/search question in #4144; this does not add vector search, compression, or summarization to Beads itself.

## Verification

- `scripts/pr-preflight.sh --search 'embeadings semantic embeddings community tools analytics observability' --repo gastownhall/beads` — no matching open PR.
- Reviewed #4735, the open Community Tools contribution; it adds a different tool under Native Apps and is not superseded by this Analytics entry.
- `git diff --check`
- `.github/scripts/docs-render-check.sh origin/main`
- `make test`
- Fresh-installed [PyPI v0.4.2](https://pypi.org/project/embeadings/0.4.2/) independently with `pipx install embeadings==0.4.2` and `uv tool install embeadings==0.4.2`; both reported `embead 0.4.2`, and `embead capabilities --json` included `read-only-review`.
- PyPI provenance for both distributions names `DyrtyJax/embeadings`, `release.yml`, and the protected `pypi` environment; `pypi-attestations verify pypi` passed for the wheel and source archive.
- GitHub and PyPI SHA-256 digests match the published `SHA256SUMS` from the [immutable v0.4.2 release](https://github.com/DyrtyJax/embeadings/releases/tag/v0.4.2).
- Product claims and boundaries are documented in the [README evidence table](https://github.com/DyrtyJax/embeadings#why-trust-it).
- The [four-worktree dogfood story](https://github.com/DyrtyJax/embeadings/blob/v0.4.2/docs/articles/dogfooding-v040-worktree-gate.md) and [aggregate gate](https://github.com/DyrtyJax/embeadings/blob/v0.4.2/docs/research/code-surface-v040-release-gate.md) state the one-repository limit and avoid general precision or recall claims.
