### PR TITLE
refactor(storage): name-keyed backend registry for storage backend selection

### DIFF
--- a/cmd/bd/backend_registry_contract_test.go
+++ b/cmd/bd/backend_registry_contract_test.go
@@ -1,0 +1,106 @@
+package main
+
+// Extension-contract tests for the backend registry: registering a backend
+// by name (one additive registrant file in a real extension) is enough for
+// the metadata-driven store factories to dispatch to it, wins over the
+// removed-backend tombstones, and leaves unregistered names failing closed
+// exactly as before.
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/configfile"
+	"github.com/steveyegge/beads/internal/storage"
+	"github.com/steveyegge/beads/internal/storage/backends"
+)
+
+var (
+	errContractOpen         = errors.New("contract backend: read-write open")
+	errContractOpenReadOnly = errors.New("contract backend: read-only open")
+)
+
+// registerContractBackend registers a fixture backend whose open functions
+// fail with recognizable sentinels, proving dispatch reached the registrant
+// without standing up a real store.
+func registerContractBackend(t *testing.T, name string) {
+	t.Helper()
+	backends.Register(name, backends.Backend{
+		Open: func(context.Context, string) (storage.DoltStorage, error) {
+			return nil, errContractOpen
+		},
+		OpenReadOnly: func(context.Context, string) (storage.DoltStorage, error) {
+			return nil, errContractOpenReadOnly
+		},
+	})
+	t.Cleanup(func() { backends.Deregister(name) })
+}
+
+func writeBackendWorkspace(t *testing.T, backend string) string {
+	t.Helper()
+	beadsDir := t.TempDir()
+	if err := (&configfile.Config{Backend: backend}).Save(beadsDir); err != nil {
+		t.Fatalf("save metadata.json: %v", err)
+	}
+	return beadsDir
+}
+
+func TestRegisteredBackendDispatchesThroughStoreFactories(t *testing.T) {
+	const name = "contractkv"
+	registerContractBackend(t, name)
+	beadsDir := writeBackendWorkspace(t, name)
+
+	if _, err := newDoltStoreFromConfig(t.Context(), beadsDir); !errors.Is(err, errContractOpen) {
+		t.Errorf("newDoltStoreFromConfig dispatched wrong: err = %v, want %v", err, errContractOpen)
+	}
+	if _, err := newReadOnlyStoreFromConfig(t.Context(), beadsDir); !errors.Is(err, errContractOpenReadOnly) {
+		t.Errorf("newReadOnlyStoreFromConfig dispatched wrong: err = %v, want %v", err, errContractOpenReadOnly)
+	}
+	if err := validateConfiguredBackend(&configfile.Config{Backend: name}); err != nil {
+		t.Errorf("validateConfiguredBackend rejected registered backend: %v", err)
+	}
+}
+
+func TestRegisteredNameBeatsTombstoneInStoreFactory(t *testing.T) {
+	registerContractBackend(t, configfile.BackendPostgres)
+	beadsDir := writeBackendWorkspace(t, configfile.BackendPostgres)
+
+	// Registry wins over the removed-name tombstone: the factory dispatches
+	// to the registered backend instead of failing with the removal error.
+	if _, err := newDoltStoreFromConfig(t.Context(), beadsDir); !errors.Is(err, errContractOpen) {
+		t.Errorf("registered removed name did not dispatch: err = %v, want %v", err, errContractOpen)
+	}
+	if err := validateConfiguredBackend(&configfile.Config{Backend: configfile.BackendPostgres}); err != nil {
+		t.Errorf("validateConfiguredBackend rejected registered removed name: %v", err)
+	}
+}
+
+func TestUnregisteredRemovedNamesStillTombstoned(t *testing.T) {
+	// No registration here: the tombstones must keep failing closed with the
+	// standard removed-backend error surface.
+	for _, backend := range []string{configfile.BackendPostgres, configfile.BackendMySQL} {
+		beadsDir := writeBackendWorkspace(t, backend)
+		_, err := newDoltStoreFromConfig(t.Context(), beadsDir)
+		if err == nil || !strings.Contains(err.Error(), "no longer supported") {
+			t.Errorf("unregistered removed name %q: err = %v, want RemovedBackendError", backend, err)
+		}
+		wantErr := configfile.RemovedBackendError(backend)
+		if got := validateConfiguredBackend(&configfile.Config{Backend: backend}); got == nil || got.Error() != wantErr.Error() {
+			t.Errorf("validateConfiguredBackend(%q) = %v, want %v", backend, got, wantErr)
+		}
+	}
+}
+
+func TestUnregisteredUnknownNameStillRejected(t *testing.T) {
+	const name = "contract-unregistered"
+	wantErr := configfile.UnknownBackendError(name)
+	if got := validateConfiguredBackend(&configfile.Config{Backend: name}); got == nil || got.Error() != wantErr.Error() {
+		t.Errorf("validateConfiguredBackend(%q) = %v, want %v", name, got, wantErr)
+	}
+	beadsDir := writeBackendWorkspace(t, name)
+	if _, err := newDoltStoreFromConfig(t.Context(), beadsDir); err == nil || !strings.Contains(err.Error(), "not recognized") {
+		t.Errorf("unknown backend factory error = %v, want UnknownBackendError", err)
+	}
+}

--- a/cmd/bd/backend_registry_contract_test.go
+++ b/cmd/bd/backend_registry_contract_test.go
@@ -9,12 +9,14 @@ package main
 import (
 	"context"
 	"errors"
+	"maps"
 	"strings"
 	"testing"
 
 	"github.com/steveyegge/beads/internal/configfile"
 	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/storage/backends"
+	"github.com/steveyegge/beads/internal/storage/sqlite"
 )
 
 var (
@@ -45,6 +47,82 @@ func writeBackendWorkspace(t *testing.T, backend string) string {
 		t.Fatalf("save metadata.json: %v", err)
 	}
 	return beadsDir
+}
+
+// TestRegisteredBackendProvisionOptionsAndPersistRoundTrip pins the generic
+// provisioning contract: options reach the registrant's Provision hook via
+// ProvisionRequest untouched, and the persist entries it returns land in
+// metadata.json's backend_config map and survive a reload.
+func TestRegisteredBackendProvisionOptionsAndPersistRoundTrip(t *testing.T) {
+	const name = "contractkv-provision"
+	wantPersist := map[string]string{"dsn": "contract://server/db", "schema": "beads_ws"}
+	var got backends.ProvisionRequest
+	b := backends.Backend{
+		Open: func(context.Context, string) (storage.DoltStorage, error) {
+			return nil, errContractOpen
+		},
+		OpenReadOnly: func(context.Context, string) (storage.DoltStorage, error) {
+			return nil, errContractOpenReadOnly
+		},
+		Provision: func(_ context.Context, req backends.ProvisionRequest) (map[string]string, error) {
+			got = req
+			return wantPersist, nil
+		},
+	}
+	backends.Register(name, b)
+	t.Cleanup(func() { backends.Deregister(name) })
+
+	beadsDir := t.TempDir()
+	options := map[string]string{"dsn": "contract://server/db", "schema": "beads_ws"}
+
+	reg, ok := backends.Lookup(name)
+	if !ok || reg.Provision == nil {
+		t.Fatalf("Lookup(%q) lost the Provision hook", name)
+	}
+	persist, err := reg.Provision(t.Context(), backends.ProvisionRequest{BeadsDir: beadsDir, Options: options})
+	if err != nil {
+		t.Fatalf("Provision: %v", err)
+	}
+	if got.BeadsDir != beadsDir {
+		t.Errorf("ProvisionRequest.BeadsDir = %q, want %q", got.BeadsDir, beadsDir)
+	}
+	if !maps.Equal(got.Options, options) {
+		t.Errorf("ProvisionRequest.Options = %v, want %v", got.Options, options)
+	}
+
+	// Persist plumbing: init records the returned entries via
+	// applyBackendPersist; they must round-trip through metadata.json.
+	cfg := configfile.DefaultConfig()
+	cfg.Backend = name
+	applyBackendPersist(cfg, name, persist)
+	if err := cfg.Save(beadsDir); err != nil {
+		t.Fatalf("save metadata.json: %v", err)
+	}
+	loaded, err := configfile.Load(beadsDir)
+	if err != nil {
+		t.Fatalf("reload metadata.json: %v", err)
+	}
+	if !maps.Equal(loaded.GetBackendConfig(), wantPersist) {
+		t.Errorf("backend_config round-trip = %v, want %v", loaded.GetBackendConfig(), wantPersist)
+	}
+	if loaded.SQLitePath != "" {
+		t.Errorf("non-sqlite persist leaked into legacy sqlite_path: %q", loaded.SQLitePath)
+	}
+}
+
+// TestApplyBackendPersistSQLiteLegacyPath pins the compatibility mapping: the
+// sqlite backend's path entry is persisted in the legacy sqlite_path field
+// (not backend_config) so existing workspaces and older bd versions keep
+// reading the same location.
+func TestApplyBackendPersistSQLiteLegacyPath(t *testing.T) {
+	cfg := configfile.DefaultConfig()
+	applyBackendPersist(cfg, configfile.BackendSQLite, map[string]string{sqlite.ProvisionOptionPath: "custom.db"})
+	if cfg.SQLitePath != "custom.db" {
+		t.Errorf("SQLitePath = %q, want %q", cfg.SQLitePath, "custom.db")
+	}
+	if len(cfg.BackendConfig) != 0 {
+		t.Errorf("sqlite path entry leaked into backend_config: %v", cfg.BackendConfig)
+	}
 }
 
 func TestRegisteredBackendDispatchesThroughStoreFactories(t *testing.T) {

--- a/cmd/bd/backend_support.go
+++ b/cmd/bd/backend_support.go
@@ -21,11 +21,15 @@ func validateConfiguredBackend(cfg *configfile.Config) error {
 	if cfg == nil {
 		return nil
 	}
+	// Supported means built-in or registered; the registry consult wins over
+	// the removed-name tombstones (see configfile.IsSupportedBackend). The
+	// tombstone rejection below fires only for names nobody registered.
+	if configfile.IsSupportedBackend(cfg.Backend) {
+		return nil
+	}
 	switch cfg.Backend {
 	case configfile.BackendPostgres, configfile.BackendMySQL:
 		return configfile.RemovedBackendError(cfg.Backend)
-	case "", configfile.BackendDolt, configfile.BackendSQLite:
-		return nil
 	default:
 		return configfile.UnknownBackendError(cfg.Backend)
 	}

--- a/cmd/bd/backend_support.go
+++ b/cmd/bd/backend_support.go
@@ -4,7 +4,18 @@ import (
 	"fmt"
 
 	"github.com/steveyegge/beads/internal/configfile"
+	"github.com/steveyegge/beads/internal/storage/backends"
 )
+
+// registeredBackendWorkspaceIsBeadsDir reports whether metadata selects a
+// registered backend whose workspace IS the .beads directory itself (no
+// separately discoverable database directory) — the WorkspaceIsBeadsDir
+// discovery capability. Unregistered names, including the Dolt family,
+// report false.
+func registeredBackendWorkspaceIsBeadsDir(cfg *configfile.Config) bool {
+	b, ok := backends.Lookup(cfg.GetBackend())
+	return ok && b.WorkspaceIsBeadsDir
+}
 
 func validateConfiguredBackend(cfg *configfile.Config) error {
 	if cfg == nil {

--- a/cmd/bd/backends_builtin.go
+++ b/cmd/bd/backends_builtin.go
@@ -1,0 +1,13 @@
+package main
+
+// Built-in registry-dispatched storage backends. Each blank import runs the
+// package's init(), which registers the backend by name in
+// internal/storage/backends. To add a backend, add its registrant package
+// here (or in an equivalent file) — no other shared files change.
+//
+// The Dolt family (embedded, server, proxied-server) is not registered; it
+// stays on the hand-written dispatch in store_factory*.go and main.go.
+import (
+	// SQLite: pure-Go, file-based local backend.
+	_ "github.com/steveyegge/beads/internal/storage/sqlite"
+)

--- a/cmd/bd/init.go
+++ b/cmd/bd/init.go
@@ -26,10 +26,10 @@ import (
 	"github.com/steveyegge/beads/internal/git"
 	"github.com/steveyegge/beads/internal/metrics"
 	"github.com/steveyegge/beads/internal/storage"
+	"github.com/steveyegge/beads/internal/storage/backends"
 	"github.com/steveyegge/beads/internal/storage/dbproxy/proxy"
 	"github.com/steveyegge/beads/internal/storage/dolt"
 	"github.com/steveyegge/beads/internal/storage/schema"
-	beadssqlite "github.com/steveyegge/beads/internal/storage/sqlite"
 	"github.com/steveyegge/beads/internal/templates/agents"
 	"github.com/steveyegge/beads/internal/ui"
 	"github.com/steveyegge/beads/internal/utils"
@@ -1806,9 +1806,9 @@ type initSQLiteInput struct {
 }
 
 // runInitSQLite finalizes a SQLite-backed workspace: it provisions the database file
-// (default beads.db inside the beads dir), seeds the issue prefix and project identity,
-// and writes metadata.json. SQLite is file-based and embedded (pure-Go), so there is no
-// server, DSN, or password.
+// (default beads.db inside the beads dir) through the backend registry's provision
+// hook, seeds the issue prefix and project identity, and writes metadata.json. SQLite
+// is file-based and embedded (pure-Go), so there is no server, DSN, or password.
 func runInitSQLite(ctx context.Context, in initSQLiteInput) error {
 	relPath := in.sqlitePath
 	if relPath == "" {
@@ -1819,7 +1819,11 @@ func runInitSQLite(ctx context.Context, in initSQLiteInput) error {
 		dbPath = filepath.Join(in.beadsDir, dbPath)
 	}
 
-	store, err := beadssqlite.Provision(ctx, dbPath)
+	backend, ok := backends.Lookup(configfile.BackendSQLite)
+	if !ok || backend.Provision == nil {
+		return fmt.Errorf("SQLite backend is not registered in this build (see cmd/bd/backends_builtin.go)")
+	}
+	store, err := backend.Provision(ctx, dbPath)
 	if err != nil {
 		return fmt.Errorf("failed to initialize SQLite workspace: %w", err)
 	}

--- a/cmd/bd/init.go
+++ b/cmd/bd/init.go
@@ -248,6 +248,14 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 			}
 			return fmt.Errorf("unknown backend %q: supported backends are \"dolt\" (default) and \"sqlite\"", backendFlag)
 		}
+		if backendFlag != "" && backendFlag != configfile.BackendDolt && !isSQLite {
+			// The name passed IsSupportedBackend above, so it is a backend
+			// registered at runtime — openable, but bd init's provisioning
+			// arms are per-backend and this build has none for it. Refuse
+			// rather than silently provisioning a Dolt workspace under a
+			// non-Dolt backend name.
+			return fmt.Errorf("bd init cannot provision storage backend %q in this build; provision the workspace with the tooling that registers %q, or use --backend=dolt or --backend=sqlite", backendFlag, backendFlag)
+		}
 		for _, legacyFlag := range removedServerBackendInitFlags {
 			if cmd.Flags().Changed(legacyFlag.name) {
 				return fmt.Errorf("--%s belonged to the removed PostgreSQL/MySQL initialization paths: %s; use --backend=dolt or --backend=sqlite", legacyFlag.name, configfile.RemovedBackendRationale)

--- a/cmd/bd/init.go
+++ b/cmd/bd/init.go
@@ -30,6 +30,7 @@ import (
 	"github.com/steveyegge/beads/internal/storage/dbproxy/proxy"
 	"github.com/steveyegge/beads/internal/storage/dolt"
 	"github.com/steveyegge/beads/internal/storage/schema"
+	"github.com/steveyegge/beads/internal/storage/sqlite"
 	"github.com/steveyegge/beads/internal/templates/agents"
 	"github.com/steveyegge/beads/internal/ui"
 	"github.com/steveyegge/beads/internal/utils"
@@ -103,6 +104,7 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 		database, _ := cmd.Flags().GetString("database")
 		destroyToken, _ := cmd.Flags().GetString("destroy-token")
 		sqlitePath, _ := cmd.Flags().GetString("sqlite-path")
+		backendOptEntries, _ := cmd.Flags().GetStringArray("backend-opt")
 
 		// --force is a deprecated alias for --reinit-local. They share
 		// semantics for the local data-safety guard; both refuse remote
@@ -261,6 +263,16 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 				return fmt.Errorf("--%s belonged to the removed PostgreSQL/MySQL initialization paths: %s; use --backend=dolt or --backend=sqlite", legacyFlag.name, configfile.RemovedBackendRationale)
 			}
 		}
+		// --backend-opt is the generic provisioning-option surface for any
+		// backend provisioned through the backend registry: parsed here, the
+		// options flow into the backend's ProvisionRequest untouched.
+		backendOpts, optErr := parseBackendOpts(backendOptEntries)
+		if optErr != nil {
+			return optErr
+		}
+		if len(backendOpts) > 0 && !isSQLite {
+			return fmt.Errorf("--backend-opt passes provisioning options to a backend provisioned through the backend registry and requires selecting one (this build: --backend=sqlite); the default Dolt backend takes no backend options")
+		}
 		if isSQLite {
 			// SQLite is a plain local workspace: only a small set of init-local flags
 			// apply. Reject any other init-local flag by ALLOWLIST — a
@@ -270,6 +282,7 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 			sqliteAllowedFlags := map[string]bool{
 				"backend":     true,
 				"sqlite-path": true,
+				"backend-opt": true,
 				"prefix":      true, "quiet": true,
 				"skip-hooks": true, "skip-agents": true,
 				"reinit-local": true, "force": true, "init-if-missing": true,
@@ -290,6 +303,19 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 			if len(rejected) > 0 {
 				sort.Strings(rejected)
 				return fmt.Errorf("bd init --backend=%s does not support %s (SQLite is a plain local workspace: no Dolt server, sync, remote, or wizard)", backendFlag, strings.Join(rejected, ", "))
+			}
+
+			// --sqlite-path is sugar for the sqlite backend's generic "path"
+			// option. Both spellings stay supported; passing both with
+			// different values is an explicit conflict, not a precedence rule.
+			if sqlitePath != "" {
+				if prior, ok := backendOpts[sqlite.ProvisionOptionPath]; ok && prior != sqlitePath {
+					return fmt.Errorf("--sqlite-path %q conflicts with --backend-opt %s=%q; pass one of them (or the same value in both)", sqlitePath, sqlite.ProvisionOptionPath, prior)
+				}
+				if backendOpts == nil {
+					backendOpts = make(map[string]string, 1)
+				}
+				backendOpts[sqlite.ProvisionOptionPath] = sqlitePath
 			}
 		}
 
@@ -819,7 +845,7 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 			return runInitSQLite(ctx, initSQLiteInput{
 				beadsDir:   beadsDir,
 				prefix:     prefix,
-				sqlitePath: sqlitePath,
+				options:    backendOpts,
 				quiet:      quiet,
 				jsonOutput: jsonOutput,
 			})
@@ -1808,39 +1834,91 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 type initSQLiteInput struct {
 	beadsDir   string
 	prefix     string
-	sqlitePath string
+	options    map[string]string // backend provisioning options (--backend-opt / --sqlite-path sugar)
 	quiet      bool
 	jsonOutput bool
 }
 
+// parseBackendOpts parses repeated --backend-opt key=value entries into an
+// options map for the backend's ProvisionRequest. Each entry splits at its
+// first '=': the key must be non-empty and unique, while the value may
+// itself contain '=' (DSNs with query parameters, for one). Returns nil for
+// no entries.
+func parseBackendOpts(entries []string) (map[string]string, error) {
+	if len(entries) == 0 {
+		return nil, nil
+	}
+	opts := make(map[string]string, len(entries))
+	for _, entry := range entries {
+		key, value, found := strings.Cut(entry, "=")
+		if !found {
+			return nil, fmt.Errorf("invalid --backend-opt %q: expected key=value", entry)
+		}
+		if key == "" {
+			return nil, fmt.Errorf("invalid --backend-opt %q: key must be non-empty", entry)
+		}
+		if _, dup := opts[key]; dup {
+			return nil, fmt.Errorf("duplicate --backend-opt key %q", key)
+		}
+		opts[key] = value
+	}
+	return opts, nil
+}
+
+// applyBackendPersist records onto cfg the config entries a backend's
+// Provision hook returned for persistence. Entries land in the generic
+// backend_config map in metadata.json; the SQLite backend's path entry maps
+// onto the legacy sqlite_path field instead, so existing workspaces and
+// older bd versions keep reading the database location from the same place.
+func applyBackendPersist(cfg *configfile.Config, backendName string, persist map[string]string) {
+	for key, value := range persist {
+		if backendName == configfile.BackendSQLite && key == sqlite.ProvisionOptionPath {
+			cfg.SQLitePath = value
+			continue
+		}
+		if cfg.BackendConfig == nil {
+			cfg.BackendConfig = make(map[string]string, len(persist))
+		}
+		cfg.BackendConfig[key] = value
+	}
+}
+
 // runInitSQLite finalizes a SQLite-backed workspace: it provisions the database file
 // (default beads.db inside the beads dir) through the backend registry's provision
-// hook, seeds the issue prefix and project identity, and writes metadata.json. SQLite
-// is file-based and embedded (pure-Go), so there is no server, DSN, or password.
+// hook, persists the returned backend config in metadata.json, and seeds the issue
+// prefix and project identity. SQLite is file-based and embedded (pure-Go), so there
+// is no server, DSN, or password.
 func runInitSQLite(ctx context.Context, in initSQLiteInput) error {
-	relPath := in.sqlitePath
-	if relPath == "" {
-		relPath = "beads.db"
-	}
-	dbPath := relPath
-	if !filepath.IsAbs(dbPath) {
-		dbPath = filepath.Join(in.beadsDir, dbPath)
-	}
-
 	backend, ok := backends.Lookup(configfile.BackendSQLite)
 	if !ok || backend.Provision == nil {
 		return fmt.Errorf("SQLite backend is not registered in this build (see cmd/bd/backends_builtin.go)")
 	}
-	store, err := backend.Provision(ctx, dbPath)
+	persist, err := backend.Provision(ctx, backends.ProvisionRequest{
+		BeadsDir: in.beadsDir,
+		Options:  in.options,
+	})
 	if err != nil {
 		return fmt.Errorf("failed to initialize SQLite workspace: %w", err)
 	}
-	defer func() { _ = store.Close() }()
 
 	cfg, _ := configfile.Load(in.beadsDir)
 	if cfg == nil {
 		cfg = configfile.DefaultConfig()
 	}
+	cfg.Backend = configfile.BackendSQLite
+	applyBackendPersist(cfg, configfile.BackendSQLite, persist)
+	// The registry open below resolves the database location from
+	// metadata.json, so the backend selection and provisioning results must
+	// be persisted before opening.
+	if err := cfg.Save(in.beadsDir); err != nil {
+		return fmt.Errorf("failed to write metadata.json: %w", err)
+	}
+
+	store, err := backend.Open(ctx, in.beadsDir)
+	if err != nil {
+		return fmt.Errorf("failed to open SQLite workspace: %w", err)
+	}
+	defer func() { _ = store.Close() }()
 
 	if in.prefix != "" {
 		if existing, _ := store.GetConfig(ctx, "issue_prefix"); existing == "" {
@@ -1863,12 +1941,11 @@ func runInitSQLite(ctx context.Context, in initSQLiteInput) error {
 		}
 	}
 
-	cfg.Backend = configfile.BackendSQLite
-	cfg.SQLitePath = relPath
 	cfg.ProjectID = projectID
 	if err := cfg.Save(in.beadsDir); err != nil {
 		return fmt.Errorf("failed to write metadata.json: %w", err)
 	}
+	relPath := cfg.GetSQLitePath()
 
 	switch {
 	case in.jsonOutput:
@@ -1918,6 +1995,7 @@ func init() {
 	// Backend selection: Dolt (default) or embedded SQLite.
 	initCmd.Flags().String("backend", "", "Storage backend: dolt (default) or sqlite. See docs/architecture/storage-backends.md.")
 	initCmd.Flags().String("sqlite-path", "", "SQLite database file (with --backend=sqlite; relative to the beads dir, default beads.db)")
+	initCmd.Flags().StringArray("backend-opt", nil, "Backend-specific provisioning option as key=value (repeatable; interpreted by the backend selected with --backend)")
 	// Keep the short-lived server-backend flags as hidden parser tombstones. A
 	// legacy invocation can then reach the backend rollback guidance instead of
 	// failing early with an opaque "unknown flag" error. Current backends reject

--- a/cmd/bd/init_test.go
+++ b/cmd/bd/init_test.go
@@ -2490,7 +2490,9 @@ func TestInitBackendFlag(t *testing.T) {
 	})
 
 	t.Run("backend_opt_malformed", func(t *testing.T) {
-		for _, opt := range []string{"path", "=x.db", "path=a=b"} {
+		// "path=a=b" is NOT malformed: values may contain '=' (DSNs with
+		// query parameters); parsing splits at the first '=' only.
+		for _, opt := range []string{"path", "=x.db"} {
 			_, _, out, err := initSQLite(t, "--backend-opt", opt)
 			if err == nil || !strings.Contains(string(out), "--backend-opt") {
 				t.Errorf("malformed --backend-opt %q: err = %v, want parse error, got: %s", opt, err, out)

--- a/cmd/bd/init_test.go
+++ b/cmd/bd/init_test.go
@@ -2366,6 +2366,46 @@ func initBackendTestEnv(beadsDir string) []string {
 	return append(env, "BEADS_DIR="+beadsDir)
 }
 
+func TestParseBackendOpts(t *testing.T) {
+	t.Run("valid", func(t *testing.T) {
+		opts, err := parseBackendOpts([]string{"path=custom.db", "schema=beads_ws", "empty=", "dsn=postgres://h/db?sslmode=require"})
+		if err != nil {
+			t.Fatalf("parseBackendOpts: %v", err)
+		}
+		want := map[string]string{"path": "custom.db", "schema": "beads_ws", "empty": "", "dsn": "postgres://h/db?sslmode=require"}
+		if len(opts) != len(want) {
+			t.Fatalf("opts = %v, want %v", opts, want)
+		}
+		for k, v := range want {
+			if opts[k] != v {
+				t.Errorf("opts[%q] = %q, want %q", k, opts[k], v)
+			}
+		}
+	})
+
+	t.Run("empty input is nil", func(t *testing.T) {
+		if opts, err := parseBackendOpts(nil); err != nil || opts != nil {
+			t.Errorf("parseBackendOpts(nil) = %v, %v; want nil, nil", opts, err)
+		}
+	})
+
+	t.Run("rejected", func(t *testing.T) {
+		for _, tc := range []struct {
+			entries []string
+			wantErr string
+		}{
+			{[]string{"path"}, "expected key=value"},
+			{[]string{"=x"}, "key must be non-empty"},
+			{[]string{"path=a", "path=b"}, "duplicate"},
+		} {
+			_, err := parseBackendOpts(tc.entries)
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Errorf("parseBackendOpts(%v) err = %v, want containing %q", tc.entries, err, tc.wantErr)
+			}
+		}
+	})
+}
+
 func TestInitBackendFlag(t *testing.T) {
 	bd := buildBDForInitTests(t)
 
@@ -2393,6 +2433,94 @@ func TestInitBackendFlag(t *testing.T) {
 		}
 		if cfg.Backend != configfile.BackendSQLite {
 			t.Errorf("Expected backend %q, got %q", configfile.BackendSQLite, cfg.Backend)
+		}
+	})
+
+	// --backend-opt is the generic provisioning-option surface for registered
+	// backends; for sqlite, path is the same option --sqlite-path sugars.
+	initSQLite := func(t *testing.T, args ...string) (*configfile.Config, string, []byte, error) {
+		t.Helper()
+		tmpDir := t.TempDir()
+		beadsDir := filepath.Join(tmpDir, ".beads")
+		cmd := exec.Command(bd, append([]string{"init", "--backend", "sqlite", "--quiet"}, args...)...)
+		cmd.Dir = tmpDir
+		cmd.Env = initBackendTestEnv(beadsDir)
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			return nil, beadsDir, out, err
+		}
+		cfg, cfgErr := configfile.Load(beadsDir)
+		if cfgErr != nil || cfg == nil {
+			t.Fatalf("failed to load metadata.json: %v", cfgErr)
+		}
+		return cfg, beadsDir, out, nil
+	}
+
+	t.Run("sqlite_backend_opt_path", func(t *testing.T) {
+		cfg, beadsDir, out, err := initSQLite(t, "--backend-opt", "path=custom.db")
+		if err != nil {
+			t.Fatalf("init with --backend-opt path= should succeed: %v\n%s", err, out)
+		}
+		if cfg.SQLitePath != "custom.db" {
+			t.Errorf("sqlite_path = %q, want %q", cfg.SQLitePath, "custom.db")
+		}
+		if len(cfg.BackendConfig) != 0 {
+			t.Errorf("sqlite path leaked into backend_config: %v", cfg.BackendConfig)
+		}
+		if _, err := os.Stat(filepath.Join(beadsDir, "custom.db")); err != nil {
+			t.Errorf("database file not created at option path: %v", err)
+		}
+	})
+
+	t.Run("sqlite_path_and_backend_opt_conflict", func(t *testing.T) {
+		_, _, out, err := initSQLite(t, "--sqlite-path", "a.db", "--backend-opt", "path=b.db")
+		if err == nil || !strings.Contains(string(out), "conflicts") {
+			t.Errorf("conflicting path spellings: err = %v, want conflict error, got: %s", err, out)
+		}
+	})
+
+	t.Run("sqlite_path_and_backend_opt_agree", func(t *testing.T) {
+		cfg, _, out, err := initSQLite(t, "--sqlite-path", "same.db", "--backend-opt", "path=same.db")
+		if err != nil {
+			t.Fatalf("matching path spellings should succeed: %v\n%s", err, out)
+		}
+		if cfg.SQLitePath != "same.db" {
+			t.Errorf("sqlite_path = %q, want %q", cfg.SQLitePath, "same.db")
+		}
+	})
+
+	t.Run("backend_opt_malformed", func(t *testing.T) {
+		for _, opt := range []string{"path", "=x.db", "path=a=b"} {
+			_, _, out, err := initSQLite(t, "--backend-opt", opt)
+			if err == nil || !strings.Contains(string(out), "--backend-opt") {
+				t.Errorf("malformed --backend-opt %q: err = %v, want parse error, got: %s", opt, err, out)
+			}
+		}
+	})
+
+	t.Run("backend_opt_duplicate_key", func(t *testing.T) {
+		_, _, out, err := initSQLite(t, "--backend-opt", "path=a.db", "--backend-opt", "path=b.db")
+		if err == nil || !strings.Contains(string(out), "duplicate") {
+			t.Errorf("duplicate --backend-opt key: err = %v, want duplicate error, got: %s", err, out)
+		}
+	})
+
+	t.Run("backend_opt_unknown_key", func(t *testing.T) {
+		_, _, out, err := initSQLite(t, "--backend-opt", "nope=x")
+		if err == nil || !strings.Contains(string(out), "unknown provisioning option") {
+			t.Errorf("unknown option key: err = %v, want backend rejection, got: %s", err, out)
+		}
+	})
+
+	t.Run("backend_opt_requires_registry_backend", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		beadsDir := filepath.Join(tmpDir, ".beads")
+		cmd := exec.Command(bd, "init", "--quiet", "--backend-opt", "path=x.db")
+		cmd.Dir = tmpDir
+		cmd.Env = initBackendTestEnv(beadsDir)
+		out, err := cmd.CombinedOutput()
+		if err == nil || !strings.Contains(string(out), "--backend-opt") {
+			t.Errorf("--backend-opt on the default Dolt backend: err = %v, want rejection, got: %s", err, out)
 		}
 	})
 

--- a/cmd/bd/main.go
+++ b/cmd/bd/main.go
@@ -32,9 +32,9 @@ import (
 	"github.com/steveyegge/beads/internal/remotecache"
 	"github.com/steveyegge/beads/internal/routing"
 	"github.com/steveyegge/beads/internal/storage"
+	"github.com/steveyegge/beads/internal/storage/backends"
 	"github.com/steveyegge/beads/internal/storage/dolt"
 	"github.com/steveyegge/beads/internal/storage/schema"
-	sqlitestore "github.com/steveyegge/beads/internal/storage/sqlite"
 	"github.com/steveyegge/beads/internal/storage/uow"
 	"github.com/steveyegge/beads/internal/telemetry"
 	"github.com/steveyegge/beads/internal/ui"
@@ -990,12 +990,14 @@ var rootCmd = &cobra.Command{
 		if dbPath == "" {
 			if bd := beads.FindBeadsDir(); bd != "" {
 				cfg, cfgErr := configfile.Load(bd)
-				if cfgErr != nil || cfg != nil && (cfg.IsDoltProxiedServerMode() || cfg.GetBackend() == configfile.BackendSQLite || !configfile.IsSupportedBackend(cfg.Backend)) {
-					// SQLite, proxied-server, and removed-backend workspaces may have no
-					// local Dolt database file. Invalid or unknown metadata likewise must
-					// reach config validation instead of becoming a generic "no database"
-					// result. metadata.json identifies the workspace so store selection can
-					// route or reject it explicitly.
+				if cfgErr != nil || cfg != nil && (cfg.IsDoltProxiedServerMode() || registeredBackendWorkspaceIsBeadsDir(cfg) || !configfile.IsSupportedBackend(cfg.Backend)) {
+					// Registered backends whose workspace IS the .beads directory
+					// (e.g. SQLite), proxied-server, and removed-backend workspaces
+					// may have no local Dolt database file. Invalid or unknown
+					// metadata likewise must reach config validation instead of
+					// becoming a generic "no database" result. metadata.json
+					// identifies the workspace so store selection can route or
+					// reject it explicitly.
 					dbPath = bd
 				}
 			}
@@ -1282,9 +1284,17 @@ var rootCmd = &cobra.Command{
 		// Removing them WILL cause unrecoverable data corruption and data loss.
 		// Dolt manages these files itself; external interference is never safe.
 
-		if cfg != nil && cfg.GetBackend() == configfile.BackendSQLite {
-			// SQLite backend: pure-Go file-based SQL-family bundle.
-			store, err = sqlitestore.NewFromConfig(rootCtx, beadsDir)
+		if backend, ok := backends.Lookup(cfg.GetBackend()); ok {
+			// Registered backend (e.g. SQLite): the registry owns this open.
+			// The Dolt family stays literal — embedded and server modes go
+			// through newDoltStore below, and proxied-server already
+			// short-circuited to the UOW provider above — because the
+			// registry is for storage.DoltStorage-returning backends only.
+			if useReadOnly {
+				store, err = backend.OpenReadOnly(rootCtx, beadsDir)
+			} else {
+				store, err = backend.Open(rootCtx, beadsDir)
+			}
 		} else {
 			store, err = newDoltStore(rootCtx, doltCfg)
 		}

--- a/cmd/bd/store_factory.go
+++ b/cmd/bd/store_factory.go
@@ -15,7 +15,6 @@ import (
 	"github.com/steveyegge/beads/internal/storage/dbproxy/util"
 	"github.com/steveyegge/beads/internal/storage/dolt"
 	"github.com/steveyegge/beads/internal/storage/embeddeddolt"
-	beadssqlite "github.com/steveyegge/beads/internal/storage/sqlite"
 )
 
 func usesSQLServer() bool {
@@ -92,40 +91,12 @@ func acquireEmbeddedLock(beadsDir string, serverMode bool) (util.Unlocker, error
 	return lock, nil
 }
 
-// newDoltStoreFromConfig creates a storage backend from the beads directory's
-// persisted metadata.json configuration. Uses embedded Dolt by default;
-// connects to dolt sql-server when dolt_mode is "server".
+// openEmbeddedStoreFromConfig opens the embedded Dolt database selected by
+// the metadata-driven ladder in store_factory_config.go.
 //
-// For embedded mode, legacy hyphenated database names (pre-GH#2142) are
-// auto-sanitized to underscores and the fix is persisted to metadata.json.
-func newDoltStoreFromConfig(ctx context.Context, beadsDir string) (storage.DoltStorage, error) {
-	cfg, err := configfile.Load(beadsDir)
-	if err != nil {
-		// A present-but-unloadable metadata.json must not degrade to the
-		// embedded default: on server-mode deployments the embedded
-		// directory is an empty relic, and opening it silently turns every
-		// query into an empty result set with exit 0 (false-empty). Absent
-		// metadata.json (cfg == nil, err == nil) keeps the embedded default.
-		return nil, fmt.Errorf("load %s: %w (refusing to fall back to the embedded store)", configfile.ConfigPath(beadsDir), err)
-	}
-	if err := validateConfiguredBackend(cfg); err != nil {
-		return nil, err
-	}
-	if cfg != nil && cfg.GetBackend() == configfile.BackendSQLite {
-		return beadssqlite.NewFromConfig(ctx, beadsDir)
-	}
-	if cfg != nil && cfg.IsDoltProxiedServerMode() {
-		// TODO: this needs to be uow provider
-		return nil, fmt.Errorf("proxy server store should be uow provider")
-		// 	return newProxiedServerStore(ctx, &dolt.Config{
-		// 		BeadsDir:      beadsDir,
-		// 		Database:      cfg.GetDoltDatabase(),
-		// 		ProxiedServer: true,
-		// 	})
-	}
-	if cfg != nil && cfg.IsDoltServerMode() {
-		return dolt.NewFromConfig(ctx, beadsDir)
-	}
+// Legacy hyphenated database names (pre-GH#2142) are auto-sanitized to
+// underscores and the fix is persisted to metadata.json.
+func openEmbeddedStoreFromConfig(ctx context.Context, beadsDir string, cfg *configfile.Config) (storage.DoltStorage, error) {
 	database := configfile.DefaultDoltDatabase
 	if cfg != nil {
 		database = cfg.GetDoltDatabase()
@@ -179,40 +150,13 @@ func migrateHyphenatedDB(beadsDir string, cfg *configfile.Config, oldName, newNa
 	return nil
 }
 
-// newReadOnlyStoreFromConfig creates a read-only storage backend from the beads
-// directory's persisted metadata.json configuration.
+// openEmbeddedReadOnlyStoreFromConfig opens the embedded Dolt database for a
+// read-only command.
 //
-// For embedded mode, invalid characters (hyphens, dots) are sanitized in-memory
-// only — no directory renames or metadata.json writes. This prevents cross-repo
+// Invalid characters (hyphens, dots) are sanitized in-memory only — no
+// directory renames or metadata.json writes. This prevents cross-repo
 // hydration from mutating foreign projects (GH#3231).
-func newReadOnlyStoreFromConfig(ctx context.Context, beadsDir string) (storage.DoltStorage, error) {
-	cfg, err := configfile.Load(beadsDir)
-	if err != nil {
-		// Same contract as newDoltStoreFromConfig: a present-but-unloadable
-		// metadata.json is a hard error, not a silent embedded fallback —
-		// and the error must name the real cause rather than the downstream
-		// "database not found" the embedded open would produce.
-		return nil, fmt.Errorf("load %s: %w (refusing to fall back to the embedded store)", configfile.ConfigPath(beadsDir), err)
-	}
-	if err := validateConfiguredBackend(cfg); err != nil {
-		return nil, err
-	}
-	if cfg != nil && cfg.GetBackend() == configfile.BackendSQLite {
-		return beadssqlite.NewFromConfig(ctx, beadsDir)
-	}
-	if cfg != nil && cfg.IsDoltProxiedServerMode() {
-		// TODO: this needs to be uow provider
-		return nil, fmt.Errorf("proxy server store needs to be uow provider")
-		// return newProxiedServerStore(ctx, &dolt.Config{
-		// 	BeadsDir:      beadsDir,
-		// 	Database:      cfg.GetDoltDatabase(),
-		// 	ProxiedServer: true,
-		// 	ReadOnly:      true,
-		// })
-	}
-	if cfg != nil && cfg.IsDoltServerMode() {
-		return dolt.NewFromConfigWithOptions(ctx, beadsDir, &dolt.Config{ReadOnly: true})
-	}
+func openEmbeddedReadOnlyStoreFromConfig(ctx context.Context, beadsDir string, cfg *configfile.Config) (storage.DoltStorage, error) {
 	database := configfile.DefaultDoltDatabase
 	if cfg != nil {
 		database = cfg.GetDoltDatabase()

--- a/cmd/bd/store_factory_config.go
+++ b/cmd/bd/store_factory_config.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/steveyegge/beads/internal/configfile"
+	"github.com/steveyegge/beads/internal/storage"
+	"github.com/steveyegge/beads/internal/storage/backends"
+	"github.com/steveyegge/beads/internal/storage/dolt"
+)
+
+// This file holds the build-agnostic metadata-driven store selection shared
+// by CGO and non-CGO builds. Registered backends (e.g. SQLite) dispatch
+// through the backend registry; the Dolt family stays literal below. The
+// proxied-server arm is special-cased because it must produce a unit-of-work
+// provider (newProxiedServerUOWProvider), not a store — the registry is for
+// storage.DoltStorage-returning backends only. Only the embedded-Dolt open
+// differs per build: see openEmbeddedStoreFromConfig /
+// openEmbeddedReadOnlyStoreFromConfig in store_factory.go (CGO) and
+// store_factory_nocgo.go (non-CGO).
+
+// newDoltStoreFromConfig creates a storage backend from the beads directory's
+// persisted metadata.json configuration. Uses embedded Dolt by default;
+// connects to dolt sql-server when dolt_mode is "server".
+func newDoltStoreFromConfig(ctx context.Context, beadsDir string) (storage.DoltStorage, error) {
+	cfg, err := configfile.Load(beadsDir)
+	if err != nil {
+		// A present-but-unloadable metadata.json must not degrade to the
+		// embedded default: on server-mode deployments the embedded
+		// directory is an empty relic, and opening it silently turns every
+		// query into an empty result set with exit 0 (false-empty). Absent
+		// metadata.json (cfg == nil, err == nil) keeps the embedded default.
+		return nil, fmt.Errorf("load %s: %w (refusing to fall back to the embedded store)", configfile.ConfigPath(beadsDir), err)
+	}
+	if err := validateConfiguredBackend(cfg); err != nil {
+		return nil, err
+	}
+	if b, ok := backends.Lookup(cfg.GetBackend()); ok {
+		return b.Open(ctx, beadsDir)
+	}
+	if cfg != nil && cfg.IsDoltProxiedServerMode() {
+		// TODO: this needs to be uow provider
+		return nil, fmt.Errorf("proxy server store should be uow provider")
+	}
+	if cfg != nil && cfg.IsDoltServerMode() {
+		return dolt.NewFromConfig(ctx, beadsDir)
+	}
+	return openEmbeddedStoreFromConfig(ctx, beadsDir, cfg)
+}
+
+// newReadOnlyStoreFromConfig creates a read-only storage backend from the beads
+// directory's persisted metadata.json configuration.
+func newReadOnlyStoreFromConfig(ctx context.Context, beadsDir string) (storage.DoltStorage, error) {
+	cfg, err := configfile.Load(beadsDir)
+	if err != nil {
+		// Same contract as newDoltStoreFromConfig: a present-but-unloadable
+		// metadata.json is a hard error, not a silent embedded fallback —
+		// and the error must name the real cause rather than the downstream
+		// "database not found" the embedded open would produce.
+		return nil, fmt.Errorf("load %s: %w (refusing to fall back to the embedded store)", configfile.ConfigPath(beadsDir), err)
+	}
+	if err := validateConfiguredBackend(cfg); err != nil {
+		return nil, err
+	}
+	if b, ok := backends.Lookup(cfg.GetBackend()); ok {
+		return b.OpenReadOnly(ctx, beadsDir)
+	}
+	if cfg != nil && cfg.IsDoltProxiedServerMode() {
+		// TODO: this needs to be uow provider
+		return nil, fmt.Errorf("proxy server store needs to be uow provider")
+	}
+	if cfg != nil && cfg.IsDoltServerMode() {
+		return dolt.NewFromConfigWithOptions(ctx, beadsDir, &dolt.Config{ReadOnly: true})
+	}
+	return openEmbeddedReadOnlyStoreFromConfig(ctx, beadsDir, cfg)
+}

--- a/cmd/bd/store_factory_nocgo.go
+++ b/cmd/bd/store_factory_nocgo.go
@@ -10,7 +10,6 @@ import (
 	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/storage/dbproxy/util"
 	"github.com/steveyegge/beads/internal/storage/dolt"
-	beadssqlite "github.com/steveyegge/beads/internal/storage/sqlite"
 )
 
 func usesSQLServer() bool {
@@ -46,62 +45,16 @@ func acquireEmbeddedLock(_ string, _ bool) (util.Unlocker, error) {
 	return util.NoopLock{}, nil
 }
 
-// newDoltStoreFromConfig creates a SQL-server-backed storage backend from config.
-func newDoltStoreFromConfig(ctx context.Context, beadsDir string) (storage.DoltStorage, error) {
-	cfg, err := configfile.Load(beadsDir)
-	if err != nil {
-		// Name the real cause: without this, a present-but-unloadable
-		// metadata.json surfaces as the misleading "embedded requires CGO"
-		// message below.
-		return nil, fmt.Errorf("load %s: %w", configfile.ConfigPath(beadsDir), err)
-	}
-	if err := validateConfiguredBackend(cfg); err != nil {
-		return nil, err
-	}
-	if cfg != nil && cfg.GetBackend() == configfile.BackendSQLite {
-		// SQLite (modernc.org/sqlite) is pure-Go; no CGO.
-		return beadssqlite.NewFromConfig(ctx, beadsDir)
-	}
-	if cfg != nil && cfg.IsDoltProxiedServerMode() {
-		// TODO: this needs to be uow provider
-		return nil, fmt.Errorf("proxy server store should be uow provider")
-		// 	return newProxiedServerStore(ctx, &dolt.Config{
-		// 		BeadsDir:      beadsDir,
-		// 		Database:      cfg.GetDoltDatabase(),
-		// 		ProxiedServer: true,
-		// 	})
-	}
-	if cfg != nil && cfg.IsDoltServerMode() {
-		return dolt.NewFromConfig(ctx, beadsDir)
-	}
+// openEmbeddedStoreFromConfig is the non-CGO arm of the metadata-driven
+// ladder in store_factory_config.go: embedded Dolt requires CGO, so it can
+// only report how to proceed.
+func openEmbeddedStoreFromConfig(_ context.Context, _ string, _ *configfile.Config) (storage.DoltStorage, error) {
 	return nil, fmt.Errorf("%s", nocgoEmbeddedErrMsg)
 }
 
-// newReadOnlyStoreFromConfig creates a read-only SQL-server-backed storage backend.
-func newReadOnlyStoreFromConfig(ctx context.Context, beadsDir string) (storage.DoltStorage, error) {
-	cfg, err := configfile.Load(beadsDir)
-	if err != nil {
-		return nil, fmt.Errorf("load %s: %w", configfile.ConfigPath(beadsDir), err)
-	}
-	if err := validateConfiguredBackend(cfg); err != nil {
-		return nil, err
-	}
-	if cfg != nil && cfg.GetBackend() == configfile.BackendSQLite {
-		return beadssqlite.NewFromConfig(ctx, beadsDir)
-	}
-	if cfg != nil && cfg.IsDoltProxiedServerMode() {
-		// TODO: this needs to be uow provider
-		return nil, fmt.Errorf("proxy server store needs to be uow provider")
-		// return newProxiedServerStore(ctx, &dolt.Config{
-		// 	BeadsDir:      beadsDir,
-		// 	Database:      cfg.GetDoltDatabase(),
-		// 	ProxiedServer: true,
-		// 	ReadOnly:      true,
-		// })
-	}
-	if cfg != nil && cfg.IsDoltServerMode() {
-		return dolt.NewFromConfigWithOptions(ctx, beadsDir, &dolt.Config{ReadOnly: true})
-	}
+// openEmbeddedReadOnlyStoreFromConfig mirrors openEmbeddedStoreFromConfig for
+// read-only commands.
+func openEmbeddedReadOnlyStoreFromConfig(_ context.Context, _ string, _ *configfile.Config) (storage.DoltStorage, error) {
 	return nil, fmt.Errorf("%s", nocgoEmbeddedErrMsg)
 }
 

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -3585,6 +3585,7 @@ bd init [flags]
       --agents-profile string                          AGENTS.md profile: 'minimal' (default, pointer to bd prime) or 'full' (complete command reference)
       --agents-template string                         Path to custom AGENTS.md template (overrides embedded default)
       --backend string                                 Storage backend: dolt (default) or sqlite. See docs/architecture/storage-backends.md.
+      --backend-opt stringArray                        Backend-specific provisioning option as key=value (repeatable; interpreted by the backend selected with --backend)
       --contributor                                    Run OSS contributor setup wizard
       --database string                                Use existing server database name (overrides prefix-based naming)
       --debug                                          Run the managed Dolt sql-server with --loglevel=debug and CPU profiling (--prof cpu). Persisted to config.yaml as dolt.debug. No effect on externally-managed servers.

--- a/docs/cli-reference/init.md
+++ b/docs/cli-reference/init.md
@@ -53,6 +53,7 @@ bd init [flags]
       --agents-profile string                          AGENTS.md profile: 'minimal' (default, pointer to bd prime) or 'full' (complete command reference)
       --agents-template string                         Path to custom AGENTS.md template (overrides embedded default)
       --backend string                                 Storage backend: dolt (default) or sqlite. See docs/architecture/storage-backends.md.
+      --backend-opt stringArray                        Backend-specific provisioning option as key=value (repeatable; interpreted by the backend selected with --backend)
       --contributor                                    Run OSS contributor setup wizard
       --database string                                Use existing server database name (overrides prefix-based naming)
       --debug                                          Run the managed Dolt sql-server with --loglevel=debug and CPU profiling (--prof cpu). Persisted to config.yaml as dolt.debug. No effect on externally-managed servers.

--- a/internal/configfile/configfile.go
+++ b/internal/configfile/configfile.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/steveyegge/beads/internal/config"
+	"github.com/steveyegge/beads/internal/storage/backends"
 )
 
 const ConfigFileName = "metadata.json"
@@ -247,18 +248,27 @@ func (c *Config) GetCapabilities() BackendCapabilities {
 	return CapabilitiesForBackend(backend)
 }
 
-// IsSupportedBackend reports whether backend selects an implementation shipped by
-// beads. The empty value is the legacy/default spelling of Dolt.
+// IsSupportedBackend reports whether backend selects an implementation this
+// process can open: a built-in name, or any backend registered in
+// internal/storage/backends (additional backends register themselves at init
+// time). The empty value is the legacy/default spelling of Dolt.
+//
+// The registry consult deliberately wins over the removed-backend tombstones:
+// a name on the removed list that some backend registered at runtime is
+// supported; the tombstone rejections fire only for names nobody registered.
 func IsSupportedBackend(backend string) bool {
-	return backend == "" || backend == BackendDolt || backend == BackendSQLite
+	return backend == "" || backend == BackendDolt || backend == BackendSQLite ||
+		backends.Registered(backend)
 }
 
 // GetBackend returns the configured storage backend. PostgreSQL and MySQL remain
 // recognizable here so workspaces created by earlier releases can fail loudly at
 // store selection instead of silently falling back to an empty Dolt database.
-// Empty and explicit Dolt retain the established Dolt behavior. GetBackend keeps
-// the historical Dolt fallback for unknown values, so storage-selection callers
-// must check IsSupportedBackend(c.Backend) before opening or creating storage.
+// Empty and explicit Dolt retain the established Dolt behavior. Names registered
+// in internal/storage/backends are returned as-is so store selection can
+// dispatch to them. GetBackend keeps the historical Dolt fallback for unknown
+// values, so storage-selection callers must check IsSupportedBackend(c.Backend)
+// before opening or creating storage.
 func (c *Config) GetBackend() string {
 	if c != nil {
 		switch c.Backend {
@@ -268,6 +278,9 @@ func (c *Config) GetBackend() string {
 			return BackendMySQL
 		case BackendSQLite:
 			return BackendSQLite
+		}
+		if backends.Registered(c.Backend) {
+			return c.Backend
 		}
 	}
 	return BackendDolt

--- a/internal/configfile/configfile.go
+++ b/internal/configfile/configfile.go
@@ -48,6 +48,13 @@ type Config struct {
 	// SQLite backend (backend="sqlite"). File-based, embedded; no credentials.
 	SQLitePath string `json:"sqlite_path,omitempty"` // database file, relative to the beads dir (default beads.db)
 
+	// BackendConfig carries backend-specific config entries recorded by a
+	// registered backend's Provision hook at bd init time (see
+	// internal/storage/backends). Keys and meanings are owned by the backend
+	// that wrote them; bd core only round-trips the map. The SQLite database
+	// path stays in the legacy sqlite_path field above for compatibility.
+	BackendConfig map[string]string `json:"backend_config,omitempty"`
+
 	// Project identity — unique ID generated at bd init time.
 	// Used to detect cross-project data leakage when a client connects
 	// to the wrong Dolt server (GH#2372).
@@ -293,6 +300,16 @@ func (c *Config) GetSQLitePath() string {
 		return ""
 	}
 	return c.SQLitePath
+}
+
+// GetBackendConfig returns the backend-specific config entries recorded at
+// bd init time by the configured backend's Provision hook. May be nil;
+// callers may index it directly.
+func (c *Config) GetBackendConfig() map[string]string {
+	if c == nil {
+		return nil
+	}
+	return c.BackendConfig
 }
 
 // Dolt mode constants

--- a/internal/configfile/configfile_test.go
+++ b/internal/configfile/configfile_test.go
@@ -45,6 +45,47 @@ func TestLoadSaveRoundtrip(t *testing.T) {
 	}
 }
 
+func TestBackendConfigRoundtrip(t *testing.T) {
+	beadsDir := t.TempDir()
+
+	cfg := DefaultConfig()
+	cfg.Backend = "contractkv"
+	cfg.BackendConfig = map[string]string{"dsn": "contract://server/db", "schema": "beads_ws"}
+	if err := cfg.Save(beadsDir); err != nil {
+		t.Fatalf("Save() failed: %v", err)
+	}
+
+	loaded, err := Load(beadsDir)
+	if err != nil {
+		t.Fatalf("Load() failed: %v", err)
+	}
+	got := loaded.GetBackendConfig()
+	if len(got) != 2 || got["dsn"] != "contract://server/db" || got["schema"] != "beads_ws" {
+		t.Errorf("BackendConfig round-trip = %v, want %v", got, cfg.BackendConfig)
+	}
+}
+
+func TestBackendConfigOmittedWhenEmpty(t *testing.T) {
+	beadsDir := t.TempDir()
+	if err := DefaultConfig().Save(beadsDir); err != nil {
+		t.Fatalf("Save() failed: %v", err)
+	}
+	data, err := os.ReadFile(ConfigPath(beadsDir))
+	if err != nil {
+		t.Fatalf("read metadata.json: %v", err)
+	}
+	if strings.Contains(string(data), "backend_config") {
+		t.Errorf("empty backend_config serialized into metadata.json: %s", data)
+	}
+	if (&Config{}).GetBackendConfig() != nil {
+		t.Error("GetBackendConfig() on zero config should be nil")
+	}
+	var nilCfg *Config
+	if nilCfg.GetBackendConfig() != nil {
+		t.Error("GetBackendConfig() on nil config should be nil")
+	}
+}
+
 func TestLoadNonexistent(t *testing.T) {
 	tmpDir := t.TempDir()
 

--- a/internal/storage/backends/backends.go
+++ b/internal/storage/backends/backends.go
@@ -1,0 +1,109 @@
+// Package backends provides a name-keyed registry of storage backends.
+//
+// Additional backends register themselves at init time from their own
+// package — one additive registrant file plus a blank import in cmd/bd
+// (see cmd/bd/backends_builtin.go) — so adding a backend requires no edits
+// to shared dispatch code.
+//
+// The registry covers backends whose open returns a storage.DoltStorage
+// directly (e.g. SQLite). The Dolt family (embedded, server, proxied-server)
+// is deliberately not registered: its dispatch involves connection modes,
+// credentials, and — for proxied-server — a unit-of-work provider rather
+// than a store, so it stays hand-written in cmd/bd.
+//
+// This package must stay import-light (internal/storage and stdlib only):
+// internal/configfile consults the registry for backend classification, and
+// registrants typically import internal/configfile, so any heavier imports
+// here would create cycles.
+package backends
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/steveyegge/beads/internal/storage"
+)
+
+// Backend describes a registered storage backend. All paths receive the
+// workspace's .beads directory and resolve backend-specific configuration
+// themselves (typically from metadata.json).
+type Backend struct {
+	// Open opens the workspace's store read-write.
+	Open func(ctx context.Context, beadsDir string) (storage.DoltStorage, error)
+
+	// OpenReadOnly opens the workspace's store for read-only commands.
+	// File-based backends without a distinct read-only open path may use
+	// the same function as Open.
+	OpenReadOnly func(ctx context.Context, beadsDir string) (storage.DoltStorage, error)
+
+	// Provision creates and initializes the backend's database for bd init.
+	// dbPath is the resolved absolute database location. May be nil for
+	// backends that bd init cannot provision.
+	Provision func(ctx context.Context, dbPath string) (storage.DoltStorage, error)
+
+	// WorkspaceIsBeadsDir reports that the .beads directory itself is the
+	// workspace: there is no separately discoverable database directory, so
+	// workspace discovery must treat the .beads directory as the database
+	// path instead of searching for one.
+	WorkspaceIsBeadsDir bool
+}
+
+// doltName is the backend name reserved for the hand-written Dolt dispatch
+// in cmd/bd. Registering it would hijack the primary open path.
+const doltName = "dolt"
+
+var (
+	mu       sync.RWMutex
+	registry = make(map[string]Backend)
+)
+
+// Register adds a backend under name. It is intended to be called from a
+// registrant package's init(). It panics on an empty or reserved name, a
+// duplicate registration, or a backend missing its open functions — all of
+// which are wiring bugs that must fail at process start, not at first use.
+func Register(name string, b Backend) {
+	if name == "" {
+		panic("backends: Register called with empty backend name")
+	}
+	if name == doltName {
+		panic(fmt.Sprintf("backends: backend name %q is reserved for the built-in Dolt dispatch", name))
+	}
+	if b.Open == nil || b.OpenReadOnly == nil {
+		panic(fmt.Sprintf("backends: backend %q registered without Open/OpenReadOnly", name))
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if _, dup := registry[name]; dup {
+		panic(fmt.Sprintf("backends: backend %q registered twice", name))
+	}
+	registry[name] = b
+}
+
+// Deregister removes name from the registry, reporting whether it was
+// present. It exists so tests can restore registry state after registering
+// fixture backends; production registrants register once from init() and
+// never deregister.
+func Deregister(name string) bool {
+	mu.Lock()
+	defer mu.Unlock()
+	_, ok := registry[name]
+	delete(registry, name)
+	return ok
+}
+
+// Lookup returns the backend registered under name.
+func Lookup(name string) (Backend, bool) {
+	mu.RLock()
+	defer mu.RUnlock()
+	b, ok := registry[name]
+	return b, ok
+}
+
+// Registered reports whether a backend is registered under name.
+func Registered(name string) bool {
+	mu.RLock()
+	defer mu.RUnlock()
+	_, ok := registry[name]
+	return ok
+}

--- a/internal/storage/backends/backends.go
+++ b/internal/storage/backends/backends.go
@@ -25,6 +25,19 @@ import (
 	"github.com/steveyegge/beads/internal/storage"
 )
 
+// ProvisionRequest carries the inputs to a backend's Provision hook. It is
+// deliberately backend-agnostic: whatever a backend needs beyond the
+// workspace location (a file path, a DSN, a schema name, …) arrives as
+// options, and their keys and meanings are owned by the backend.
+type ProvisionRequest struct {
+	// BeadsDir is the workspace's .beads directory.
+	BeadsDir string
+
+	// Options are backend-specific provisioning options, typically from
+	// repeated `bd init --backend-opt key=value` flags. May be nil.
+	Options map[string]string
+}
+
 // Backend describes a registered storage backend. All paths receive the
 // workspace's .beads directory and resolve backend-specific configuration
 // themselves (typically from metadata.json).
@@ -37,10 +50,12 @@ type Backend struct {
 	// the same function as Open.
 	OpenReadOnly func(ctx context.Context, beadsDir string) (storage.DoltStorage, error)
 
-	// Provision creates and initializes the backend's database for bd init.
-	// dbPath is the resolved absolute database location. May be nil for
+	// Provision creates and initializes the backend's database for bd init,
+	// resolving whatever it needs from the request options. persist is the
+	// set of backend-specific config entries the backend wants recorded in
+	// metadata.json for later opens; empty/nil is fine. May be nil for
 	// backends that bd init cannot provision.
-	Provision func(ctx context.Context, dbPath string) (storage.DoltStorage, error)
+	Provision func(ctx context.Context, req ProvisionRequest) (persist map[string]string, err error)
 
 	// WorkspaceIsBeadsDir reports that the .beads directory itself is the
 	// workspace: there is no separately discoverable database directory, so

--- a/internal/storage/backends/backends_test.go
+++ b/internal/storage/backends/backends_test.go
@@ -1,0 +1,92 @@
+package backends_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/storage"
+	"github.com/steveyegge/beads/internal/storage/backends"
+)
+
+var errFakeOpen = errors.New("fake backend open")
+
+// fakeBackend returns a minimal registrable backend whose open functions
+// fail with a recognizable sentinel, proving dispatch without a real store.
+func fakeBackend() backends.Backend {
+	open := func(ctx context.Context, beadsDir string) (storage.DoltStorage, error) {
+		return nil, errFakeOpen
+	}
+	return backends.Backend{Open: open, OpenReadOnly: open}
+}
+
+func TestRegisterAndLookup(t *testing.T) {
+	const name = "lookup-fixture"
+	backends.Register(name, fakeBackend())
+	t.Cleanup(func() { backends.Deregister(name) })
+
+	b, ok := backends.Lookup(name)
+	if !ok {
+		t.Fatalf("Lookup(%q) = _, false; want registered backend", name)
+	}
+	if _, err := b.Open(context.Background(), t.TempDir()); !errors.Is(err, errFakeOpen) {
+		t.Fatalf("Open dispatched to wrong backend: err = %v, want %v", err, errFakeOpen)
+	}
+	if !backends.Registered(name) {
+		t.Fatalf("Registered(%q) = false, want true", name)
+	}
+}
+
+func TestLookupUnknownName(t *testing.T) {
+	if _, ok := backends.Lookup("no-such-backend"); ok {
+		t.Fatal("Lookup of unregistered name unexpectedly succeeded")
+	}
+	if backends.Registered("no-such-backend") {
+		t.Fatal("Registered() reported an unregistered name")
+	}
+}
+
+func TestDeregister(t *testing.T) {
+	const name = "deregister-fixture"
+	backends.Register(name, fakeBackend())
+	if !backends.Deregister(name) {
+		t.Fatalf("Deregister(%q) = false, want true", name)
+	}
+	if backends.Registered(name) {
+		t.Fatalf("backend %q still registered after Deregister", name)
+	}
+	if backends.Deregister(name) {
+		t.Fatalf("second Deregister(%q) = true, want false", name)
+	}
+}
+
+func TestRegisterPanics(t *testing.T) {
+	mustPanic := func(t *testing.T, register func()) {
+		t.Helper()
+		defer func() {
+			if recover() == nil {
+				t.Fatal("Register did not panic")
+			}
+		}()
+		register()
+	}
+
+	t.Run("duplicate name", func(t *testing.T) {
+		const name = "duplicate-fixture"
+		backends.Register(name, fakeBackend())
+		t.Cleanup(func() { backends.Deregister(name) })
+		mustPanic(t, func() { backends.Register(name, fakeBackend()) })
+	})
+
+	t.Run("empty name", func(t *testing.T) {
+		mustPanic(t, func() { backends.Register("", fakeBackend()) })
+	})
+
+	t.Run("reserved dolt name", func(t *testing.T) {
+		mustPanic(t, func() { backends.Register("dolt", fakeBackend()) })
+	})
+
+	t.Run("missing open functions", func(t *testing.T) {
+		mustPanic(t, func() { backends.Register("nil-open-fixture", backends.Backend{}) })
+	})
+}

--- a/internal/storage/backends/backends_test.go
+++ b/internal/storage/backends/backends_test.go
@@ -3,6 +3,7 @@ package backends_test
 import (
 	"context"
 	"errors"
+	"maps"
 	"testing"
 
 	"github.com/steveyegge/beads/internal/storage"
@@ -34,6 +35,41 @@ func TestRegisterAndLookup(t *testing.T) {
 	}
 	if !backends.Registered(name) {
 		t.Fatalf("Registered(%q) = false, want true", name)
+	}
+}
+
+func TestProvisionContract(t *testing.T) {
+	const name = "provision-fixture"
+	wantPersist := map[string]string{"dsn": "fixture://server/db", "schema": "beads_ws"}
+	var got backends.ProvisionRequest
+	b := fakeBackend()
+	b.Provision = func(_ context.Context, req backends.ProvisionRequest) (map[string]string, error) {
+		got = req
+		return wantPersist, nil
+	}
+	backends.Register(name, b)
+	t.Cleanup(func() { backends.Deregister(name) })
+
+	reg, ok := backends.Lookup(name)
+	if !ok || reg.Provision == nil {
+		t.Fatalf("Lookup(%q) lost the Provision hook", name)
+	}
+	req := backends.ProvisionRequest{
+		BeadsDir: "/ws/.beads",
+		Options:  map[string]string{"schema": "beads_ws"},
+	}
+	persist, err := reg.Provision(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Provision: %v", err)
+	}
+	if got.BeadsDir != req.BeadsDir {
+		t.Errorf("ProvisionRequest.BeadsDir = %q, want %q", got.BeadsDir, req.BeadsDir)
+	}
+	if !maps.Equal(got.Options, req.Options) {
+		t.Errorf("ProvisionRequest.Options = %v, want %v", got.Options, req.Options)
+	}
+	if !maps.Equal(persist, wantPersist) {
+		t.Errorf("persist = %v, want %v", persist, wantPersist)
 	}
 }
 

--- a/internal/storage/backends/precedence_test.go
+++ b/internal/storage/backends/precedence_test.go
@@ -1,0 +1,68 @@
+package backends_test
+
+import (
+	"testing"
+
+	"github.com/steveyegge/beads/internal/configfile"
+	"github.com/steveyegge/beads/internal/storage/backends"
+)
+
+// These tests pin the classification precedence contract: a name registered
+// in the backend registry is supported even when it appears on the
+// removed-backend tombstone list, and the tombstones apply only to names
+// nobody registered. This is what lets an out-of-tree backend revive a
+// removed name without editing shared files.
+
+func TestRegisteredNameBeatsRemovedTombstone(t *testing.T) {
+	if configfile.IsSupportedBackend(configfile.BackendPostgres) {
+		t.Fatal("precondition: unregistered removed name must be unsupported")
+	}
+
+	backends.Register(configfile.BackendPostgres, fakeBackend())
+	t.Cleanup(func() { backends.Deregister(configfile.BackendPostgres) })
+
+	if !configfile.IsSupportedBackend(configfile.BackendPostgres) {
+		t.Error("registered removed name must be supported (registry wins over the tombstone)")
+	}
+	cfg := &configfile.Config{Backend: configfile.BackendPostgres}
+	if got := cfg.GetBackend(); got != configfile.BackendPostgres {
+		t.Errorf("GetBackend() = %q, want %q", got, configfile.BackendPostgres)
+	}
+	// Registration revives only the registered name; the sibling tombstone
+	// still applies.
+	if configfile.IsSupportedBackend(configfile.BackendMySQL) {
+		t.Error("unregistered removed name must remain unsupported")
+	}
+}
+
+func TestRegisteredCustomNameIsSupported(t *testing.T) {
+	const name = "customkv"
+	if configfile.IsSupportedBackend(name) {
+		t.Fatalf("precondition: %q must be unsupported before registration", name)
+	}
+	cfg := &configfile.Config{Backend: name}
+	if got := cfg.GetBackend(); got != configfile.BackendDolt {
+		t.Fatalf("unregistered custom name should keep the historical Dolt fallback, got %q", got)
+	}
+
+	backends.Register(name, fakeBackend())
+	t.Cleanup(func() { backends.Deregister(name) })
+
+	if !configfile.IsSupportedBackend(name) {
+		t.Error("registered custom name must be supported")
+	}
+	if got := cfg.GetBackend(); got != name {
+		t.Errorf("GetBackend() = %q, want registered name %q", got, name)
+	}
+}
+
+func TestDeregisteredNameRevertsToTombstone(t *testing.T) {
+	backends.Register(configfile.BackendMySQL, fakeBackend())
+	if !configfile.IsSupportedBackend(configfile.BackendMySQL) {
+		t.Fatal("registered removed name must be supported")
+	}
+	backends.Deregister(configfile.BackendMySQL)
+	if configfile.IsSupportedBackend(configfile.BackendMySQL) {
+		t.Error("tombstone must apply again once the name is no longer registered")
+	}
+}

--- a/internal/storage/dolt/open.go
+++ b/internal/storage/dolt/open.go
@@ -52,12 +52,18 @@ func ApplyCLIAutoStart(beadsDir string, cfg *Config) {
 // factory and interpreting another backend's workspace as Dolt. Removed backend
 // identifiers deliberately remain recognizable in metadata so this check can fail
 // closed instead of opening a new, empty Dolt database.
+//
+// Supported non-Dolt backends — built-in or registered at runtime — are
+// rejected below as well: a Dolt open of another backend's workspace is
+// always wrong. The supported-name check runs first so that a registered
+// name gets the plain non-Dolt rejection rather than a stale removed-name
+// tombstone (registration wins over the tombstone list).
 func requireDoltBackend(fileCfg *configfile.Config) error {
-	switch fileCfg.Backend {
-	case configfile.BackendPostgres, configfile.BackendMySQL:
-		return fmt.Errorf("configured storage backend %q is no longer supported and cannot be opened as Dolt: %s", fileCfg.Backend, configfile.RemovedBackendDetail(fileCfg.Backend))
-	}
 	if !configfile.IsSupportedBackend(fileCfg.Backend) {
+		switch fileCfg.Backend {
+		case configfile.BackendPostgres, configfile.BackendMySQL:
+			return fmt.Errorf("configured storage backend %q is no longer supported and cannot be opened as Dolt: %s", fileCfg.Backend, configfile.RemovedBackendDetail(fileCfg.Backend))
+		}
 		return fmt.Errorf("configured storage backend %q in metadata.json is not recognized and cannot be opened as Dolt; %s", fileCfg.Backend, configfile.BackendNotOpenedGuarantee)
 	}
 	backend := fileCfg.GetBackend()

--- a/internal/storage/dolt/open_backend_guard_test.go
+++ b/internal/storage/dolt/open_backend_guard_test.go
@@ -1,0 +1,77 @@
+package dolt
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/configfile"
+	"github.com/steveyegge/beads/internal/storage"
+	"github.com/steveyegge/beads/internal/storage/backends"
+)
+
+// TestRequireDoltBackendGuard pins the defense-in-depth backstop: metadata
+// that selects any non-Dolt backend — built-in, registered at runtime, or
+// unknown — must never be opened as Dolt, and the error surface for
+// pre-existing names must not change.
+func TestRequireDoltBackendGuard(t *testing.T) {
+	fakeOpen := func(context.Context, string) (storage.DoltStorage, error) {
+		return nil, errors.New("fake open")
+	}
+
+	t.Run("dolt and empty accepted", func(t *testing.T) {
+		for _, cfg := range []*configfile.Config{{}, {Backend: configfile.BackendDolt}} {
+			if err := requireDoltBackend(cfg); err != nil {
+				t.Errorf("requireDoltBackend(%+v) = %v, want nil", cfg, err)
+			}
+		}
+	})
+
+	t.Run("sqlite rejected as non-dolt", func(t *testing.T) {
+		err := requireDoltBackend(&configfile.Config{Backend: configfile.BackendSQLite})
+		if err == nil || !strings.Contains(err.Error(), "cannot be opened as Dolt") {
+			t.Errorf("sqlite guard error = %v, want non-Dolt rejection", err)
+		}
+	})
+
+	t.Run("unregistered removed names keep the tombstone error", func(t *testing.T) {
+		for _, backend := range []string{configfile.BackendPostgres, configfile.BackendMySQL} {
+			err := requireDoltBackend(&configfile.Config{Backend: backend})
+			if err == nil || !strings.Contains(err.Error(), "no longer supported") {
+				t.Errorf("removed backend %q error = %v, want removal guidance", backend, err)
+			}
+		}
+	})
+
+	t.Run("unknown name rejected as unrecognized", func(t *testing.T) {
+		err := requireDoltBackend(&configfile.Config{Backend: "mystery"})
+		if err == nil || !strings.Contains(err.Error(), "not recognized") {
+			t.Errorf("unknown backend error = %v, want unrecognized rejection", err)
+		}
+	})
+
+	t.Run("registered custom name still rejected", func(t *testing.T) {
+		const name = "guardkv-fixture"
+		backends.Register(name, backends.Backend{Open: fakeOpen, OpenReadOnly: fakeOpen})
+		t.Cleanup(func() { backends.Deregister(name) })
+
+		err := requireDoltBackend(&configfile.Config{Backend: name})
+		if err == nil || !strings.Contains(err.Error(), "cannot be opened as Dolt") {
+			t.Errorf("registered non-Dolt backend error = %v, want non-Dolt rejection", err)
+		}
+	})
+
+	t.Run("registered removed name gets non-dolt rejection not tombstone", func(t *testing.T) {
+		backends.Register(configfile.BackendPostgres, backends.Backend{Open: fakeOpen, OpenReadOnly: fakeOpen})
+		t.Cleanup(func() { backends.Deregister(configfile.BackendPostgres) })
+
+		err := requireDoltBackend(&configfile.Config{Backend: configfile.BackendPostgres})
+		if err == nil || !strings.Contains(err.Error(), "cannot be opened as Dolt") {
+			t.Errorf("registered removed name error = %v, want non-Dolt rejection", err)
+		}
+		if err != nil && strings.Contains(err.Error(), "no longer supported") {
+			t.Errorf("registered removed name hit the tombstone error: %v", err)
+		}
+	})
+}

--- a/internal/storage/sqlite/fromconfig.go
+++ b/internal/storage/sqlite/fromconfig.go
@@ -11,14 +11,19 @@ import (
 )
 
 // NewFromConfig opens the SQLite backend for a workspace, reading the database file
-// path from .beads/metadata.json (default beads.db, relative to the beads dir). SQLite
-// is file-based, so there is no DSN password to manage.
+// path from .beads/metadata.json (default beads.db, relative to the beads dir). The
+// legacy sqlite_path field wins so existing workspaces keep opening unchanged; the
+// generic backend_config "path" entry is the fallback spelling. SQLite is file-based,
+// so there is no DSN password to manage.
 func NewFromConfig(ctx context.Context, beadsDir string) (storage.DoltStorage, error) {
 	cfg, err := configfile.Load(beadsDir)
 	if err != nil {
 		return nil, fmt.Errorf("sqlite: load config: %w", err)
 	}
 	path := cfg.GetSQLitePath()
+	if path == "" {
+		path = cfg.GetBackendConfig()[ProvisionOptionPath]
+	}
 	if path == "" {
 		path = "beads.db"
 	}

--- a/internal/storage/sqlite/register.go
+++ b/internal/storage/sqlite/register.go
@@ -1,9 +1,18 @@
 package sqlite
 
 import (
+	"context"
+	"fmt"
+	"path/filepath"
+
 	"github.com/steveyegge/beads/internal/configfile"
 	"github.com/steveyegge/beads/internal/storage/backends"
 )
+
+// ProvisionOptionPath is this backend's provisioning option (and persist key)
+// for the database file location: relative paths are anchored at the beads
+// dir, absolute paths are used as-is. Empty means the default (beads.db).
+const ProvisionOptionPath = "path"
 
 // The SQLite backend registers itself at init time. Additional backends
 // follow the same pattern: one registrant file like this one, plus a blank
@@ -14,10 +23,40 @@ func init() {
 		// SQLite is file-based with no distinct read-only open path; the
 		// same config-driven open serves read-only commands.
 		OpenReadOnly: NewFromConfig,
-		Provision:    Provision,
+		Provision:    provisionWorkspace,
 		// The SQLite database lives directly in the .beads directory
 		// (default beads.db): the workspace IS the .beads dir, with no
 		// separately discoverable Dolt database directory.
 		WorkspaceIsBeadsDir: true,
 	})
+}
+
+// provisionWorkspace is the backend registry's Provision hook. It resolves
+// the database file from the request options (default beads.db; relative
+// paths anchored at the beads dir — the same defaulting bd init applied
+// before the options contract existed), creates and initializes the
+// database, and returns the config entries to persist for later opens.
+func provisionWorkspace(ctx context.Context, req backends.ProvisionRequest) (map[string]string, error) {
+	relPath := "beads.db"
+	for key, value := range req.Options {
+		switch key {
+		case ProvisionOptionPath:
+			if value == "" {
+				return nil, fmt.Errorf("sqlite: provisioning option %q must not be empty", key)
+			}
+			relPath = value
+		default:
+			return nil, fmt.Errorf("sqlite: unknown provisioning option %q (supported: %s)", key, ProvisionOptionPath)
+		}
+	}
+	dbPath := relPath
+	if !filepath.IsAbs(dbPath) {
+		dbPath = filepath.Join(req.BeadsDir, dbPath)
+	}
+	store, err := Provision(ctx, dbPath)
+	if err != nil {
+		return nil, err
+	}
+	_ = store.Close()
+	return map[string]string{ProvisionOptionPath: relPath}, nil
 }

--- a/internal/storage/sqlite/register.go
+++ b/internal/storage/sqlite/register.go
@@ -1,0 +1,23 @@
+package sqlite
+
+import (
+	"github.com/steveyegge/beads/internal/configfile"
+	"github.com/steveyegge/beads/internal/storage/backends"
+)
+
+// The SQLite backend registers itself at init time. Additional backends
+// follow the same pattern: one registrant file like this one, plus a blank
+// import in cmd/bd/backends_builtin.go — no shared dispatch code changes.
+func init() {
+	backends.Register(configfile.BackendSQLite, backends.Backend{
+		Open: NewFromConfig,
+		// SQLite is file-based with no distinct read-only open path; the
+		// same config-driven open serves read-only commands.
+		OpenReadOnly: NewFromConfig,
+		Provision:    Provision,
+		// The SQLite database lives directly in the .beads directory
+		// (default beads.db): the workspace IS the .beads dir, with no
+		// separately discoverable Dolt database directory.
+		WorkspaceIsBeadsDir: true,
+	})
+}

--- a/internal/storage/sqlite/register_test.go
+++ b/internal/storage/sqlite/register_test.go
@@ -1,0 +1,139 @@
+package sqlite
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/configfile"
+	"github.com/steveyegge/beads/internal/storage/backends"
+)
+
+// The registrant's Provision hook resolves the database file from the generic
+// options contract (default beads.db, relative paths anchored at the beads
+// dir) and returns the persist entries bd init records in metadata.json.
+func TestProvisionWorkspaceOptions(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("default path", func(t *testing.T) {
+		beadsDir := t.TempDir()
+		persist, err := provisionWorkspace(ctx, backends.ProvisionRequest{BeadsDir: beadsDir})
+		if err != nil {
+			t.Fatalf("provisionWorkspace: %v", err)
+		}
+		if got := persist[ProvisionOptionPath]; got != "beads.db" {
+			t.Errorf("persist[%q] = %q, want %q", ProvisionOptionPath, got, "beads.db")
+		}
+		if _, err := os.Stat(filepath.Join(beadsDir, "beads.db")); err != nil {
+			t.Errorf("default database file not created: %v", err)
+		}
+	})
+
+	t.Run("relative path option", func(t *testing.T) {
+		beadsDir := t.TempDir()
+		persist, err := provisionWorkspace(ctx, backends.ProvisionRequest{
+			BeadsDir: beadsDir,
+			Options:  map[string]string{ProvisionOptionPath: "custom.db"},
+		})
+		if err != nil {
+			t.Fatalf("provisionWorkspace: %v", err)
+		}
+		if got := persist[ProvisionOptionPath]; got != "custom.db" {
+			t.Errorf("persist[%q] = %q, want %q (relative spelling preserved)", ProvisionOptionPath, got, "custom.db")
+		}
+		if _, err := os.Stat(filepath.Join(beadsDir, "custom.db")); err != nil {
+			t.Errorf("database file not created at option path: %v", err)
+		}
+	})
+
+	t.Run("absolute path option", func(t *testing.T) {
+		abs := filepath.Join(t.TempDir(), "abs.db")
+		persist, err := provisionWorkspace(ctx, backends.ProvisionRequest{
+			BeadsDir: t.TempDir(),
+			Options:  map[string]string{ProvisionOptionPath: abs},
+		})
+		if err != nil {
+			t.Fatalf("provisionWorkspace: %v", err)
+		}
+		if got := persist[ProvisionOptionPath]; got != abs {
+			t.Errorf("persist[%q] = %q, want %q", ProvisionOptionPath, got, abs)
+		}
+		if _, err := os.Stat(abs); err != nil {
+			t.Errorf("database file not created at absolute path: %v", err)
+		}
+	})
+
+	t.Run("empty path rejected", func(t *testing.T) {
+		_, err := provisionWorkspace(ctx, backends.ProvisionRequest{
+			BeadsDir: t.TempDir(),
+			Options:  map[string]string{ProvisionOptionPath: ""},
+		})
+		if err == nil || !strings.Contains(err.Error(), "must not be empty") {
+			t.Errorf("empty path option: err = %v, want non-empty rejection", err)
+		}
+	})
+
+	t.Run("unknown option rejected", func(t *testing.T) {
+		_, err := provisionWorkspace(ctx, backends.ProvisionRequest{
+			BeadsDir: t.TempDir(),
+			Options:  map[string]string{"paht": "typo.db"},
+		})
+		if err == nil || !strings.Contains(err.Error(), "unknown provisioning option") {
+			t.Errorf("unknown option: err = %v, want unknown-option rejection", err)
+		}
+	})
+}
+
+// NewFromConfig resolves the database file from the legacy sqlite_path field
+// first (existing workspaces), then the generic backend_config path entry.
+func TestNewFromConfigBackendConfigFallback(t *testing.T) {
+	ctx := context.Background()
+
+	open := func(t *testing.T, cfg *configfile.Config) (string, error) {
+		t.Helper()
+		beadsDir := t.TempDir()
+		if err := cfg.Save(beadsDir); err != nil {
+			t.Fatalf("save metadata.json: %v", err)
+		}
+		st, err := NewFromConfig(ctx, beadsDir)
+		if err != nil {
+			return beadsDir, err
+		}
+		if err := st.Close(); err != nil {
+			t.Errorf("close store: %v", err)
+		}
+		return beadsDir, nil
+	}
+
+	t.Run("backend_config path used when legacy field empty", func(t *testing.T) {
+		beadsDir, err := open(t, &configfile.Config{
+			Backend:       configfile.BackendSQLite,
+			BackendConfig: map[string]string{ProvisionOptionPath: "fromgeneric.db"},
+		})
+		if err != nil {
+			t.Fatalf("NewFromConfig: %v", err)
+		}
+		if _, err := os.Stat(filepath.Join(beadsDir, "fromgeneric.db")); err != nil {
+			t.Errorf("database not opened at backend_config path: %v", err)
+		}
+	})
+
+	t.Run("legacy sqlite_path wins over backend_config", func(t *testing.T) {
+		beadsDir, err := open(t, &configfile.Config{
+			Backend:       configfile.BackendSQLite,
+			SQLitePath:    "legacy.db",
+			BackendConfig: map[string]string{ProvisionOptionPath: "ignored.db"},
+		})
+		if err != nil {
+			t.Fatalf("NewFromConfig: %v", err)
+		}
+		if _, err := os.Stat(filepath.Join(beadsDir, "legacy.db")); err != nil {
+			t.Errorf("database not opened at legacy sqlite_path: %v", err)
+		}
+		if _, err := os.Stat(filepath.Join(beadsDir, "ignored.db")); !os.IsNotExist(err) {
+			t.Errorf("backend_config path used despite legacy field: stat err = %v", err)
+		}
+	})
+}


### PR DESCRIPTION
Follow-up to #4847: convert backend selection from hardcoded dispatch to a name-keyed registry.

Today adding (or removing) a backend means touching every dispatch site: the `store_factory*.go` if-chains, the primary open ladder in `main.go`, workspace discovery, and the `configfile` backend enum. This PR replaces all of that with a small registry (`internal/storage/backends`): a backend is one registrant file that calls `backends.Register` from `init()`, plus a blank import in `cmd/bd/backends_builtin.go`. No shared dispatch code changes.

**What's in the registry contract:**
- `Open` / `OpenReadOnly` — open a workspace from `.beads` config
- `Provision` — `bd init` provisioning, taking a backend-agnostic `ProvisionRequest{BeadsDir, Options}` and returning config entries to persist in `metadata.json` (`backend_config` map)
- `WorkspaceIsBeadsDir` — workspace-discovery predicate

**CLI surface:**
- New generic `bd init --backend-opt key=value` (repeatable) passes provisioning options to the selected backend; values may contain `=` (DSNs etc.). Option keys are owned by the backend.
- `--sqlite-path` stays as sugar for the sqlite backend's `path` option (conflicting values in both spellings are rejected explicitly).
- Existing workspaces are untouched: sqlite keeps reading/writing the legacy `sqlite_path` field so older `bd` versions and current workspaces interoperate.

**Behavior guarantees, tested:**
- SQLite converts to the registry with byte-identical behavior; the dispatch conversion is covered by contract tests in `cmd/bd` plus registry unit tests.
- Precedence is pinned: a *registered* backend name is classified as supported ahead of the removed-backend tombstones from #4847, so a backend can be reintroduced additively by registration alone — while unregistered removed names keep failing closed with the migration guidance.
- Dolt paths are unchanged (defense-in-depth guard test included).

This keeps the core simple while making backend membership a build-time composition decision — local-first backends (e.g. the flat-file backend proposed in #4415) can plug into the storage seam and the conformance oracle (`internal/storage/conformance`) without touching shared dispatch code.
