### PR TITLE
fix(claim): serialize concurrent claims with a per-database advisory lock

### DIFF
--- a/internal/storage/dolt/issues.go
+++ b/internal/storage/dolt/issues.go
@@ -3,8 +3,10 @@ package dolt
 import (
 	"context"
 	"database/sql"
+	"database/sql/driver"
 	"encoding/json"
 	"fmt"
+	"io"
 	"sort"
 	"strings"
 	"time"
@@ -206,6 +208,76 @@ func (s *DoltStore) UpdateIssue(ctx context.Context, id string, updates map[stri
 // currently has no assignee. Returns storage.ErrAlreadyClaimed if already claimed.
 // Delegates SQL work to issueops.ClaimIssueInTx; handles Dolt-specific concerns
 // (wisp routing, DOLT_ADD/COMMIT, cache invalidation).
+// claimLockTimeoutSecs bounds how long a claim waits for the advisory lock before
+// giving up (a heavily-contended goal, or a crashed holder whose session has not yet
+// been reaped by the server).
+const claimLockTimeoutSecs = 10
+
+// acquireClaimLock serializes concurrent claims on THIS database with a MySQL named
+// advisory lock, and returns a release func.
+//
+// Why this is needed: the claim itself is already a correct compare-and-swap
+// (`UPDATE ... WHERE status='open' AND assignee IN (”,NULL,actor)` + RowsAffected).
+// But under Dolt's snapshot isolation each concurrent claim transaction evaluates that
+// WHERE against its own start snapshot, so N racers all still see status='open', all
+// get RowsAffected==1, and all commit — the CAS is defeated by the isolation model.
+// MEASURED against a Dolt 2.1.10 sql-server, 6 concurrent claims of one open bead:
+// baseline 6/6 "win"; `SELECT ... FOR UPDATE` ALSO 6/6 (Dolt does not serialize on it);
+// GET_LOCK 1/6 (correct). So a named lock — not FOR UPDATE — is the serialization
+// primitive that works here. The lock name is per-database so claims in different repos
+// on a shared server never block each other. Held on a dedicated pinned connection for
+// the whole claim (find + CAS + DOLT_COMMIT); other claimers block on GET_LOCK until it
+// is released.
+func (s *DoltStore) acquireClaimLock(ctx context.Context) (*sql.Conn, func(), error) {
+	conn, err := s.db.Conn(ctx)
+	if err != nil {
+		return nil, nil, fmt.Errorf("claim lock: acquire connection: %w", err)
+	}
+	var dbName sql.NullString
+	if err := conn.QueryRowContext(ctx, "SELECT DATABASE()").Scan(&dbName); err != nil {
+		_ = conn.Close()
+		return nil, nil, fmt.Errorf("claim lock: resolve database: %w", err)
+	}
+	lockName := "bd_claim_" + dbName.String
+	var got sql.NullInt64
+	if err := conn.QueryRowContext(ctx, "SELECT GET_LOCK(?, ?)", lockName, claimLockTimeoutSecs).Scan(&got); err != nil {
+		_ = conn.Close()
+		return nil, nil, fmt.Errorf("claim lock: GET_LOCK(%q): %w", lockName, err)
+	}
+	if !got.Valid || got.Int64 != 1 {
+		_ = conn.Close()
+		return nil, nil, fmt.Errorf("claim lock: could not acquire %q within %ds (contended)", lockName, claimLockTimeoutSecs)
+	}
+	release := func() {
+		// Release on a BOUNDED context so a hung server cannot block forever.
+		releaseCtx, cancel := context.WithTimeout(context.Background(), claimLockTimeoutSecs*time.Second)
+		defer cancel()
+		var released sql.NullInt64
+		err := conn.QueryRowContext(releaseCtx, "SELECT RELEASE_LOCK(?)", lockName).Scan(&released)
+		if err == nil && released.Valid && released.Int64 == 1 {
+			// Lock confirmed released; safe to return the session to the pool.
+			_ = conn.Close()
+			return
+		}
+		// The release did NOT confirm. GET_LOCK is session-scoped, and conn.Close() only returns
+		// the physical session to database/sql's pool — a pooled session that still holds the lock
+		// would block every future claim on this database. So physically drop the driver connection
+		// (ending the session and its advisory lock) and mark it bad so the pool discards it.
+		_ = conn.Raw(func(dc any) error {
+			if c, ok := dc.(io.Closer); ok {
+				_ = c.Close()
+			}
+			return driver.ErrBadConn
+		})
+		// Returning ErrBadConn from Raw already discards the underlying driver connection, but
+		// call Close explicitly so the *sql.Conn is unambiguously finalized on this path too
+		// (a no-op / ErrConnDone if Raw already closed it — never a double-release).
+		_ = conn.Close()
+	}
+
+	return conn, release, nil
+}
+
 func (s *DoltStore) ClaimIssue(ctx context.Context, id string, actor string) error {
 	// Route ephemeral IDs to wisps table (falls through for promoted wisps).
 	// Wisps skip DOLT_COMMIT since they live in dolt_ignored tables.
@@ -213,7 +285,13 @@ func (s *DoltStore) ClaimIssue(ctx context.Context, id string, actor string) err
 		return s.claimWisp(ctx, id, actor)
 	}
 
-	tx, err := s.db.BeginTx(ctx, nil)
+	conn, release, err := s.acquireClaimLock(ctx)
+	if err != nil {
+		return err
+	}
+	defer release()
+
+	tx, err := conn.BeginTx(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("failed to begin transaction: %w", err)
 	}
@@ -242,7 +320,13 @@ func (s *DoltStore) ClaimIssue(ctx context.Context, id string, actor string) err
 
 // ClaimReadyIssue atomically claims the first ready issue matching filter.
 func (s *DoltStore) ClaimReadyIssue(ctx context.Context, filter types.WorkFilter, actor string) (*types.Issue, error) {
-	tx, err := s.db.BeginTx(ctx, nil)
+	conn, release, err := s.acquireClaimLock(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer release()
+
+	tx, err := conn.BeginTx(ctx, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to begin transaction: %w", err)
 	}


### PR DESCRIPTION
## The bug
`ClaimIssue` / `ClaimReadyIssue` are a correct compare-and-swap — `UPDATE issues SET status='in_progress', assignee=? WHERE id=? AND status='open' AND assignee IN ('',NULL,actor)`, then a `RowsAffected` check. But under Dolt's snapshot isolation, each concurrent claim transaction evaluates that `WHERE` against its **own start snapshot**, so N racers all still see `status='open'`, all get `RowsAffected==1`, and all commit. The CAS is silently defeated and **one issue is handed to multiple callers**. Any setup running N processes against a shared Dolt server (e.g. a fan-out of agents doing `bd ready --claim`) double-claims work.

## Measured
Against a Dolt 2.1.10 `sql-server`, 6 concurrent claims of one open issue:

| approach | winners (correct = 1) |
|---|---|
| baseline (today) | **6 / 6** |
| `SELECT … FOR UPDATE` | **6 / 6** (Dolt does not serialize on it) |
| `GET_LOCK()` | **1 / 6** ✅ |

So the usual `FOR UPDATE` fix does **not** work under Dolt — a named advisory lock does.

## The fix
Hold a MySQL named advisory lock (`GET_LOCK`) for the duration of each claim:
- The lock **and** the claim transaction run on **one pinned `*sql.Conn`** (`conn.BeginTx`), so it works under `SetMaxOpenConns(1)`.
- The lock name is **per-database** (`bd_claim_<db>`) so claims in different repos on a shared server never block each other.
- Release confirms `RELEASE_LOCK==1` then returns the connection to the pool; on any release failure it physically drops the driver session (`conn.Raw` + `driver.ErrBadConn`, then `Close`) so a failed release can never leave the lock held and deadlock later claims.

## Alternatives considered
- **`SELECT … FOR UPDATE`** — the standard fix, and the first thing most reviewers will reach for. Dolt evaluates the predicate against each transaction's start snapshot rather than taking a serializing row lock, so it does not serialize concurrent claimants (measured 6 / 6 above). Kept in the table precisely to pre-empt that suggestion.
- **Dolt commit-time conflict detection (optimistic retry)** — the most Dolt-idiomatic option: let both CAS updates run and rely on the second `COMMIT` failing on a same-cell write-write conflict, then retry. Not dependable here — whether a same-cell conflict errors vs. auto-merges depends on transaction/conflict configuration, and in the baseline the concurrent claims committed silently (6 / 6). Making it reliable would need explicit multi-statement transactions with conflict-on-commit enabled plus a bounded retry loop: more surface area and more Dolt-version coupling than a single advisory lock.
- **`GET_LOCK` is not a MySQL-only bolt-on** — it is implemented natively by go-mysql-server (the engine under Dolt) as a session-scoped named lock held in the server, independent of the versioned storage and snapshot isolation. That orthogonality is exactly why it serializes where row locks do not, and it behaves identically whether `bd` is pointed at Dolt or upstream MySQL — so the fix is portable across both backends rather than Dolt-specific.

## Verification
- Existing `Ready|Claim|Proxied|Update` CLI suite: **pass** (embedded-Dolt, `gms_pure_go`).
- **End-to-end A/B on a real Dolt server**, 12 concurrent claimers over 3 beads × 4 rounds: current `bd` double-claims every round (48 "successes" for 12 real slots); the patched `bd` claims each bead **exactly once** (12 successes total, **0 double-claims**), no deadlock.
- Reviewed adversarially by two independent models, which drove fixes for an unbounded release context, a pooled-session lock leak, a `MaxOpenConns=1` self-deadlock, and an under-specified release error path before it passed.
