### PR TITLE
feat(leases): ephemeral dolt_ignored leases table — heartbeats mint zero commits (bd-lrgn1)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -838,9 +838,10 @@ jobs:
           BEADS_TEST_EMBEDDED_DOLT: "1"
           BEADS_TEST_EMBEDDED_TEST_BINARY: /tmp/embeddeddolt-test
         # Conformance runs in the dedicated test-embedded-conformance job
-        # below (mirrors pr-risk.yml); skip it here so this job stays inside
-        # its 20m envelope as the base embedded suite grows.
-        run: /tmp/embeddeddolt-test -test.v -test.count=1 -test.timeout=20m -test.skip '^TestConformance$'
+        # below (mirrors pr-risk.yml); skip it here. The budget must cover
+        # every store-open re-running the full migration chain, which grows
+        # with each migration (bd-lrgn1 pushed a slow runner past 20m).
+        run: /tmp/embeddeddolt-test -test.v -test.count=1 -test.timeout=30m -test.skip '^TestConformance$'
 
   test-embedded-conformance:
     name: Test (Embedded Dolt Conformance)

--- a/.github/workflows/pr-risk.yml
+++ b/.github/workflows/pr-risk.yml
@@ -169,9 +169,10 @@ jobs:
           BEADS_TEST_EMBEDDED_DOLT: "1"
           BEADS_TEST_EMBEDDED_TEST_BINARY: /tmp/embeddeddolt-test
         # Conformance runs in the dedicated test-embedded-conformance job; skip
-        # it here. Keeps upstream's 20m bump (base embedded tests grew) while
-        # this job stays inside its envelope without the conformance suite.
-        run: /tmp/embeddeddolt-test -test.v -test.count=1 -test.timeout=20m -test.skip '^TestConformance$'
+        # it here. The budget must cover every store-open re-running the full
+        # migration chain, which grows with each migration (bd-lrgn1 pushed a
+        # slow runner past the old 20m).
+        run: /tmp/embeddeddolt-test -test.v -test.count=1 -test.timeout=30m -test.skip '^TestConformance$'
 
   test-embedded-conformance:
     name: Test (Embedded Dolt Conformance)

--- a/cmd/bd/doctor/dolt.go
+++ b/cmd/bd/doctor/dolt.go
@@ -288,7 +288,7 @@ func checkSchemaWithDB(conn *doltConn) DoctorCheck {
 	// Check dolt_ignore'd tables — these only exist in the working set and
 	// must be recreated each server session. (GH#2271)
 	ignoredTables := []string{
-		"local_metadata", "repo_mtimes",
+		"leases", "local_metadata", "repo_mtimes",
 		"wisps", "wisp_labels", "wisp_dependencies", "wisp_events", "wisp_comments",
 	}
 	var missingIgnoredTables []string
@@ -411,7 +411,7 @@ func CheckDoltIssueCount(path string) DoctorCheck {
 // produces self-fulfilling warnings that can never be cleared.
 func isIgnoredTable(tableName string) bool {
 	switch tableName {
-	case "wisps", "local_metadata", "repo_mtimes":
+	case "wisps", "leases", "local_metadata", "repo_mtimes":
 		return true
 	}
 	return strings.HasPrefix(tableName, "wisp_")

--- a/cmd/bd/heartbeat.go
+++ b/cmd/bd/heartbeat.go
@@ -24,8 +24,10 @@ it up. Heartbeat pushes lease_expires_at forward and stamps heartbeat_at = now.
 Only the current owner may heartbeat. If the lease has already been reclaimed or
 the issue closed, heartbeat fails so the worker learns to stop.
 
-Heartbeat writes a Dolt commit, so heartbeat well below the TTL but not so fast
-it bloats history — cadence should be a small fraction of the TTL, not per-op.
+Leases live in an ephemeral, node-local table: heartbeats write no Dolt commit
+and no history, so any cadence comfortably below the TTL is fine. Leases are
+only enforceable on the node that granted them; cross-machine claim visibility
+rides the issue's status and assignee, which do commit.
 
 Examples:
   bd heartbeat bd-123

--- a/cmd/bd/protocol/lease_claim_test.go
+++ b/cmd/bd/protocol/lease_claim_test.go
@@ -235,12 +235,14 @@ func TestProtocol_LeaseFieldsExportToJSONL(t *testing.T) {
 // lease fields must survive the round trip, not just the export. bd import once
 // dropped them (wy-urlct: the sole issue INSERT path, issueops.InsertIssueIntoTable,
 // listed no lease columns), so an issue exported while claimed was imported as
-// in_progress with a NULL lease. Reclaim's stale predicate (L5.1) requires
-// lease_expires_at IS NOT NULL, which made such an issue unreclaimable by any
+// in_progress with a NULL lease. Reclaim only recovers leased claims (L5.1),
+// which made such an issue unreclaimable by any
 // reaper: stranded forever under a worker that may be long dead — exactly the
-// recoverability the lease exists to provide. The lease columns now ride the
-// upsert's stale-guard alongside status/assignee (see issueUpsertColumns), so
-// an import can restore a lease but a stale snapshot can never clobber a live one.
+// recoverability the lease exists to provide. Leases now live in the ephemeral
+// leases table (bd-lrgn1) and import restores them via
+// issueops.RestoreLeaseOnImportInTx, so an import can restore a lease but
+// snapshot data can never clobber a live (unexpired) local lease — pinned by
+// TestProtocol_ImportNeverClobbersLiveLocalLease.
 func TestProtocol_LeaseFieldsRoundTripJSONL(t *testing.T) {
 	t.Parallel()
 	w := newWorkspace(t)
@@ -264,6 +266,60 @@ func TestProtocol_LeaseFieldsRoundTripJSONL(t *testing.T) {
 	if restored["assignee"] != "alice" || restored["status"] != "in_progress" {
 		t.Errorf("L1.2: lease owner did not round-trip: assignee=%v status=%v, want alice/in_progress",
 			restored["assignee"], restored["status"])
+	}
+}
+
+// TestProtocol_ImportNeverClobbersLiveLocalLease pins the lease-restore guard
+// of clause L1.2 under the ephemeral leases table (bd-lrgn1): leases are
+// node-local — only enforceable on the node that granted them — so a snapshot
+// imported over a LIVE (unexpired) local lease must leave the local lease
+// untouched, even when the snapshot's issue row is strictly newer and its
+// other fields win the stale-guard merge. Only an expired (or absent) local
+// lease may be replaced by snapshot lease data.
+func TestProtocol_ImportNeverClobbersLiveLocalLease(t *testing.T) {
+	t.Parallel()
+	w := newWorkspace(t)
+
+	leased := w.create("--title", "Locally claimed", "--type", "task")
+	w.runEnv([]string{"BEADS_ACTOR=alice"}, "update", leased, "--claim")
+	local := w.showJSON(leased)
+	localExpiry := requireRFC3339(t, local, "lease_expires_at", leased)
+	if !localExpiry.After(time.Now()) {
+		t.Fatalf("precondition: local lease already expired (%v)", localExpiry)
+	}
+
+	// Craft a snapshot of the same issue that is strictly NEWER by updated_at
+	// and carries different (also-live) lease timestamps — as if exported from
+	// another node that also believes it holds the claim.
+	snapshot := map[string]any{}
+	for k, v := range local {
+		snapshot[k] = v
+	}
+	delete(snapshot, "labels")
+	snapshot["updated_at"] = time.Now().UTC().Add(2 * time.Hour).Format(time.RFC3339)
+	snapshot["lease_expires_at"] = time.Now().UTC().Add(30 * time.Hour).Format(time.RFC3339)
+	snapshot["heartbeat_at"] = time.Now().UTC().Add(29 * time.Hour).Format(time.RFC3339)
+	snapshot["notes"] = "remote edit that must land"
+
+	line, err := json.Marshal(snapshot)
+	if err != nil {
+		t.Fatalf("marshal snapshot: %v", err)
+	}
+	path := filepath.Join(w.dir, "remote.jsonl")
+	if err := os.WriteFile(path, append(line, '\n'), 0o644); err != nil {
+		t.Fatalf("write snapshot: %v", err)
+	}
+	w.run("import", path)
+
+	restored := w.showJSON(leased)
+	// The newer snapshot's row fields won the merge...
+	if restored["notes"] != "remote edit that must land" {
+		t.Errorf("newer snapshot's field edit did not land: notes=%v", restored["notes"])
+	}
+	// ...but the live local lease was NOT clobbered by the snapshot's lease.
+	if back := requireRFC3339(t, restored, "lease_expires_at", leased); !back.Equal(localExpiry) {
+		t.Errorf("import clobbered a live local lease: expiry was %v, now %v (snapshot's was ~30h out)",
+			localExpiry, back)
 	}
 }
 

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -843,8 +843,10 @@ it up. Heartbeat pushes lease_expires_at forward and stamps heartbeat_at = now.
 Only the current owner may heartbeat. If the lease has already been reclaimed or
 the issue closed, heartbeat fails so the worker learns to stop.
 
-Heartbeat writes a Dolt commit, so heartbeat well below the TTL but not so fast
-it bloats history — cadence should be a small fraction of the TTL, not per-op.
+Leases live in an ephemeral, node-local table: heartbeats write no Dolt commit
+and no history, so any cadence comfortably below the TTL is fine. Leases are
+only enforceable on the node that granted them; cross-machine claim visibility
+rides the issue's status and assignee, which do commit.
 
 Examples:
   bd heartbeat bd-123

--- a/docs/cli-reference/heartbeat.md
+++ b/docs/cli-reference/heartbeat.md
@@ -17,8 +17,10 @@ it up. Heartbeat pushes lease_expires_at forward and stamps heartbeat_at = now.
 Only the current owner may heartbeat. If the lease has already been reclaimed or
 the issue closed, heartbeat fails so the worker learns to stop.
 
-Heartbeat writes a Dolt commit, so heartbeat well below the TTL but not so fast
-it bloats history — cadence should be a small fraction of the TTL, not per-op.
+Leases live in an ephemeral, node-local table: heartbeats write no Dolt commit
+and no history, so any cadence comfortably below the TTL is fine. Leases are
+only enforceable on the node that granted them; cross-machine claim visibility
+rides the issue's status and assignee, which do commit.
 
 Examples:
   bd heartbeat bd-123

--- a/internal/storage/dolt/dolt_test.go
+++ b/internal/storage/dolt/dolt_test.go
@@ -22,7 +22,12 @@ import (
 // The embedded Dolt driver can be slow, especially for complex JOIN queries.
 // If tests are timing out, it may indicate an issue with the embedded Dolt
 // driver's async operations rather than with the DoltStore implementation.
-const testTimeout = 30 * time.Second
+// testTimeout bounds each test's context. It must cover a cold store setup —
+// container-assisted connect plus the FULL migration chain (every versioned +
+// ignored migration, each Dolt-committed), which grows as migrations
+// accumulate — with headroom for a loaded machine; some tests set up two
+// stores under one context.
+const testTimeout = 45 * time.Second
 
 // testSem limits concurrent database-touching tests to avoid overwhelming the
 // shared Dolt testcontainer. Without this, 200+ parallel tests cause a

--- a/internal/storage/dolt/ephemeral_routing.go
+++ b/internal/storage/dolt/ephemeral_routing.go
@@ -273,6 +273,10 @@ func (s *DoltStore) DemoteToWisp(ctx context.Context, id string, updates map[str
 		if _, err := tx.ExecContext(ctx, "DELETE FROM issues WHERE id = ?", id); err != nil {
 			return fmt.Errorf("failed to delete issue from issues: %w", err)
 		}
+		// Wisps are never leased: drop any lease the issue held.
+		if err := issueops.DeleteLeaseInTx(ctx, tx, id); err != nil {
+			return err
+		}
 
 		affectedIssues, affectedWisps, aerr := issueops.AffectedByStatusChangeForWispInTx(ctx, tx, id)
 		if aerr != nil {

--- a/internal/storage/dolt/issues.go
+++ b/internal/storage/dolt/issues.go
@@ -273,29 +273,20 @@ func (s *DoltStore) ClaimReadyIssue(ctx context.Context, filter types.WorkFilter
 }
 
 // HeartbeatIssue refreshes the lease on an issue actor holds in_progress,
-// pushing lease_expires_at forward and rewriting row_lock (see issueops.lease).
-// Wrapped in withRetryTx so a heartbeat that loses Dolt's optimistic merge to a
-// concurrent reclaim/close on the same row is replayed against a fresh snapshot
-// rather than surfaced — the row_lock collision is what forces that retry.
+// pushing lease_expires_at forward on its row in the ephemeral leases table
+// (see issueops.lease). Deliberately NO DOLT_ADD/DOLT_COMMIT: the leases
+// table is dolt_ignored, so a heartbeat mints no commit and no history — this
+// is the whole point of bd-lrgn1 (fleet heartbeats were the dominant source
+// of unbounded reachable history). Wrapped in withRetryTx so a heartbeat that
+// loses Dolt's optimistic merge to a concurrent reclaim/close on the same
+// lease row is replayed against a fresh snapshot rather than surfaced.
 func (s *DoltStore) HeartbeatIssue(ctx context.Context, id, actor string) error {
 	if s.isActiveWisp(ctx, id) {
 		// Wisps are ephemeral and never leased; nothing to heartbeat.
 		return fmt.Errorf("%w: %s is ephemeral", storage.ErrNotClaimable, id)
 	}
 	return s.withRetryTx(ctx, func(tx *sql.Tx) error {
-		if err := issueops.HeartbeatIssueInTx(ctx, tx, id, actor); err != nil {
-			return err
-		}
-		// GH#2455: stage only the tables we touched, then commit without -A.
-		for _, table := range []string{"issues"} {
-			_, _ = tx.ExecContext(ctx, "CALL DOLT_ADD(?)", table)
-		}
-		commitMsg := fmt.Sprintf("bd: heartbeat %s", id)
-		if _, err := tx.ExecContext(ctx, "CALL DOLT_COMMIT('-m', ?, '--author', ?)",
-			commitMsg, s.commitAuthorString()); err != nil && !isDoltNothingToCommit(err) {
-			return fmt.Errorf("dolt commit: %w", err)
-		}
-		return nil
+		return issueops.HeartbeatIssueInTx(ctx, tx, id, actor)
 	})
 }
 
@@ -332,7 +323,7 @@ func (s *DoltStore) ReclaimExpiredLeases(ctx context.Context, olderThan time.Dur
 }
 
 // UnclaimIssue atomically unclaims an issue by clearing the assignee, resetting
-// status to "open", clearing the lease columns and rewriting row_lock. Records
+// status to "open", deleting its lease row and rewriting row_lock. Records
 // an "unclaimed" event. Only the current assignee may release its own claim
 // unless force is set (admin/reaper override). Delegates SQL work to
 // issueops.UnclaimIssueInTx; handles Dolt-specific concerns (DOLT_ADD/COMMIT).

--- a/internal/storage/dolt/iter_dependents.go
+++ b/internal/storage/dolt/iter_dependents.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/storage/issueops"
+	"github.com/steveyegge/beads/internal/storage/sqlbuild"
 	"github.com/steveyegge/beads/internal/types"
 )
 
@@ -49,14 +50,17 @@ func (s *DoltStore) IterDependentsWithMetadata(ctx context.Context, issueID stri
 		SELECT %s, d.type
 		FROM issues i
 		JOIN dependencies d ON d.issue_id = i.id
+		%s
 		WHERE %s = ?
 		UNION ALL
 		SELECT %s, d.type
 		FROM wisps w
 		JOIN wisp_dependencies d ON d.issue_id = w.id
+		%s
 		WHERE %s = ?
 		ORDER BY created_at ASC
-	`, prefixedIssueColumns("i"), depTargetExprWithAlias("d"), prefixedIssueColumns("w"), depTargetExprWithAlias("d"))
+	`, prefixedIssueColumns("i"), sqlbuild.LeaseJoin("i"), depTargetExprWithAlias("d"),
+		prefixedIssueColumns("w"), sqlbuild.LeaseJoin("w"), depTargetExprWithAlias("d"))
 	return s.iterIssuesWithDepType(ctx, q, issueID, issueID)
 }
 
@@ -142,16 +146,16 @@ func (it *doltDependentsIter) Close() error {
 	return nil
 }
 
-// prefixedIssueColumns returns IssueSelectColumns with each column prefixed
-// by the given table alias (e.g. "i") so it can be used in JOIN queries.
-// The columns string is a comma-separated list with newlines/whitespace;
-// we split on commas and prepend the alias.
+// prefixedIssueColumns returns IssueSelectColumns with each issues-row column
+// prefixed by the given table alias (e.g. "i") so it can be used in JOIN
+// queries. The lease overlay columns keep their own leases. qualifier — the
+// caller's FROM must include sqlbuild.LeaseJoin(alias).
 func prefixedIssueColumns(alias string) string {
-	cols := splitCommaList(issueops.IssueSelectColumns)
+	cols := splitCommaList(sqlbuild.IssueBaseColumns)
 	for i, c := range cols {
 		cols[i] = alias + "." + c
 	}
-	return joinCommaList(cols)
+	return joinCommaList(cols) + ", " + sqlbuild.LeaseSelectColumns
 }
 
 // splitCommaList splits a multi-line comma-separated column list into

--- a/internal/storage/dolt/iter_issues.go
+++ b/internal/storage/dolt/iter_issues.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/storage/issueops"
+	"github.com/steveyegge/beads/internal/storage/sqlbuild"
 	"github.com/steveyegge/beads/internal/types"
 )
 
@@ -53,8 +54,8 @@ func (s *DoltStore) IterIssues(ctx context.Context, query string, filter types.I
 	}
 
 	//nolint:gosec // G201: whereSQL contains column comparisons with ?, limitSQL is a safe integer
-	q := fmt.Sprintf(`SELECT %s FROM issues %s ORDER BY priority ASC, created_at DESC, id ASC%s`,
-		issueops.IssueSelectColumns, whereSQL, limitSQL)
+	q := fmt.Sprintf(`SELECT %s FROM issues %s %s ORDER BY priority ASC, created_at DESC, id ASC%s`,
+		issueops.IssueSelectColumns, sqlbuild.LeaseJoin("issues"), whereSQL, limitSQL)
 
 	var issues []*types.Issue
 	txErr := s.withReadTx(ctx, func(tx *sql.Tx) error {

--- a/internal/storage/dolt/lease_migration_test.go
+++ b/internal/storage/dolt/lease_migration_test.go
@@ -1,0 +1,167 @@
+package dolt
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/steveyegge/beads/internal/storage/doltutil"
+	"github.com/steveyegge/beads/internal/storage/issueops"
+	"github.com/steveyegge/beads/internal/storage/schema"
+)
+
+// preLeaseMoveVersion is the last schema version where leases were columns on
+// the issues table (0054 added them; 0055 moved them to the ephemeral leases
+// table, bd-lrgn1).
+const preLeaseMoveVersion = 54
+
+// TestMigration0055MovesLiveLeases is acceptance criterion (3) of bd-lrgn1:
+// upgrading a workspace from the column schema moves live lease values into
+// the leases table (so in-flight claims stay reclaimable across the upgrade)
+// and drops the issues lease columns. row_lock stays — it is the general
+// write-serialization cell, not a lease column.
+func TestMigration0055MovesLiveLeases(t *testing.T) {
+	skipIfNoDolt(t)
+	acquireTestSlot()
+	t.Cleanup(releaseTestSlot)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Minute)
+	t.Cleanup(cancel)
+
+	dbName := uniqueTestDBName(t)
+	admin, err := sql.Open("mysql", doltutil.ServerDSN{
+		Host: "127.0.0.1", Port: testServerPort, User: "root", Timeout: 10 * time.Second,
+	}.String())
+	if err != nil {
+		t.Fatalf("open admin connection: %v", err)
+	}
+	t.Cleanup(func() { admin.Close() })
+	if _, err := admin.ExecContext(ctx, "CREATE DATABASE `"+dbName+"`"); err != nil {
+		t.Fatalf("create database: %v", err)
+	}
+
+	db, err := sql.Open("mysql", doltutil.ServerDSN{
+		Host: "127.0.0.1", Port: testServerPort, User: "root", Database: dbName, Timeout: 10 * time.Second,
+	}.String())
+	if err != nil {
+		t.Fatalf("open test database: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		t.Fatalf("pin connection: %v", err)
+	}
+	t.Cleanup(func() { conn.Close() })
+
+	exec := func(query string, args ...any) {
+		t.Helper()
+		if _, err := conn.ExecContext(ctx, query, args...); err != nil {
+			t.Fatalf("exec %q: %v", query, err)
+		}
+	}
+
+	if _, err := schema.MigrateUpTo(ctx, conn, preLeaseMoveVersion); err != nil {
+		t.Fatalf("migrate to %04d: %v", preLeaseMoveVersion, err)
+	}
+
+	// Seed the column-schema claim states an upgrading workspace can hold:
+	// a live claim (future lease), a dead worker's claim (expired lease),
+	// and an idle open issue (no lease).
+	liveExpiry := time.Now().UTC().Add(45 * time.Minute).Truncate(time.Second)
+	liveHeartbeat := time.Now().UTC().Truncate(time.Second)
+	deadExpiry := time.Now().UTC().Add(-2 * time.Hour).Truncate(time.Second)
+	exec("INSERT INTO issues (id, title, description, design, acceptance_criteria, notes, status, priority, issue_type, assignee, lease_expires_at, heartbeat_at, row_lock) "+
+		"VALUES ('mig-live', 'live claim', '', '', '', '', 'in_progress', 2, 'task', 'alice', ?, ?, 42)",
+		liveExpiry, liveHeartbeat)
+	exec("INSERT INTO issues (id, title, description, design, acceptance_criteria, notes, status, priority, issue_type, assignee, lease_expires_at, heartbeat_at, row_lock) "+
+		"VALUES ('mig-dead', 'dead claim', '', '', '', '', 'in_progress', 2, 'task', 'ghost', ?, ?, 43)",
+		deadExpiry, deadExpiry.Add(-5*time.Minute))
+	exec("INSERT INTO issues (id, title, description, design, acceptance_criteria, notes, status, priority, issue_type) " +
+		"VALUES ('mig-idle', 'idle', '', '', '', '', 'open', 2, 'task')")
+	exec("CALL DOLT_COMMIT('-Am', 'column-schema workspace with live leases')")
+
+	// The production upgrade.
+	if _, err := schema.MigrateUp(ctx, conn); err != nil {
+		t.Fatalf("MigrateUp to HEAD: %v", err)
+	}
+
+	// The issues lease columns are gone; row_lock survives.
+	var colCount int
+	if err := conn.QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'issues' AND COLUMN_NAME IN ('lease_expires_at', 'heartbeat_at')",
+	).Scan(&colCount); err != nil {
+		t.Fatalf("check dropped columns: %v", err)
+	}
+	if colCount != 0 {
+		t.Errorf("issues still carries %d lease column(s), want 0 after 0055", colCount)
+	}
+	if err := conn.QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'issues' AND COLUMN_NAME = 'row_lock'",
+	).Scan(&colCount); err != nil {
+		t.Fatalf("check row_lock survives: %v", err)
+	}
+	if colCount != 1 {
+		t.Errorf("issues.row_lock missing after 0055 — it must stay (general write-serialization cell)")
+	}
+
+	// Both claims' lease values moved into the leases table intact.
+	type leaseRow struct {
+		holder    string
+		expires   time.Time
+		heartbeat time.Time
+	}
+	readLease := func(id string) (leaseRow, bool) {
+		var lr leaseRow
+		err := conn.QueryRowContext(ctx,
+			"SELECT holder, lease_expires_at, heartbeat_at FROM leases WHERE issue_id = ?", id,
+		).Scan(&lr.holder, &lr.expires, &lr.heartbeat)
+		if err == sql.ErrNoRows {
+			return lr, false
+		}
+		if err != nil {
+			t.Fatalf("read lease row %s: %v", id, err)
+		}
+		return lr, true
+	}
+
+	live, ok := readLease("mig-live")
+	if !ok {
+		t.Fatal("live claim's lease was not moved into the leases table")
+	}
+	if live.holder != "alice" || !live.expires.Equal(liveExpiry) {
+		t.Errorf("live lease moved wrong: holder=%q expires=%v, want alice/%v", live.holder, live.expires, liveExpiry)
+	}
+	dead, ok := readLease("mig-dead")
+	if !ok {
+		t.Fatal("expired claim's lease was not moved — it must stay reclaimable across the upgrade")
+	}
+	if dead.holder != "ghost" || !dead.expires.Equal(deadExpiry) {
+		t.Errorf("dead lease moved wrong: holder=%q expires=%v, want ghost/%v", dead.holder, dead.expires, deadExpiry)
+	}
+	if _, ok := readLease("mig-idle"); ok {
+		t.Error("idle issue grew a lease row during migration")
+	}
+
+	// The dead worker's claim is reclaimable through the normal path.
+	reclaimed, err := issueops.ReclaimExpiredLeasesInTx(ctx, conn, time.Now().UTC(), "reaper")
+	if err != nil {
+		t.Fatalf("reclaim after migration: %v", err)
+	}
+	if len(reclaimed) != 1 || reclaimed[0].ID != "mig-dead" || reclaimed[0].PreviousOwner != "ghost" {
+		t.Fatalf("reclaimed = %+v, want [{mig-dead ghost}]", reclaimed)
+	}
+	var status string
+	if err := conn.QueryRowContext(ctx, "SELECT status FROM issues WHERE id = 'mig-dead'").Scan(&status); err != nil {
+		t.Fatalf("read reclaimed status: %v", err)
+	}
+	if status != "open" {
+		t.Errorf("reclaimed issue status = %q, want open", status)
+	}
+	if _, still := readLease("mig-dead"); still {
+		t.Error("reclaim left the dead lease row behind")
+	}
+	if _, ok := readLease("mig-live"); !ok {
+		t.Error("reclaim touched the live lease")
+	}
+}

--- a/internal/storage/dolt/lease_test.go
+++ b/internal/storage/dolt/lease_test.go
@@ -15,7 +15,9 @@ import (
 	"github.com/steveyegge/beads/internal/types"
 )
 
-// leaseState reads the lease columns for an issue directly, for assertions.
+// leaseState reads an issue's claim state plus its lease-row overlay (the
+// ephemeral leases table, bd-lrgn1) directly, for assertions. leaseExpires/
+// heartbeatAt are NULL when the issue has no lease row.
 type leaseState struct {
 	status        string
 	assignee      sql.NullString
@@ -30,8 +32,9 @@ func readLeaseState(t *testing.T, ctx context.Context, store *DoltStore, id stri
 	var ls leaseState
 	var startedAt sql.NullTime
 	err := store.db.QueryRowContext(ctx, `
-		SELECT status, assignee, lease_expires_at, heartbeat_at, row_lock, started_at
-		FROM issues WHERE id = ?
+		SELECT i.status, i.assignee, l.lease_expires_at, l.heartbeat_at, i.row_lock, i.started_at
+		FROM issues i LEFT JOIN leases l ON l.issue_id = i.id
+		WHERE i.id = ?
 	`, id).Scan(&ls.status, &ls.assignee, &ls.leaseExpires, &ls.heartbeatAt, &ls.rowLock, &startedAt)
 	if err != nil {
 		t.Fatalf("read lease state for %s: %v", id, err)
@@ -106,8 +109,8 @@ func TestHeartbeatExtendsLeaseAndGuardsOwnership(t *testing.T) {
 	if !after.leaseExpires.Time.After(before.leaseExpires.Time) {
 		t.Errorf("heartbeat did not extend lease: before=%v after=%v", before.leaseExpires.Time, after.leaseExpires.Time)
 	}
-	if after.rowLock == before.rowLock {
-		t.Error("heartbeat did not rewrite row_lock")
+	if after.rowLock != before.rowLock {
+		t.Error("heartbeat touched the issues row (row_lock changed) — heartbeats must write only the leases table (bd-lrgn1)")
 	}
 
 	// A non-owner cannot heartbeat.
@@ -388,15 +391,17 @@ func TestReclaimRevertsExpiredOnly(t *testing.T) {
 
 // TestRowLockForcesConflictOnDisjointCellWrites is the regression guard for the
 // row_lock trick. It shows, against real Dolt, that two concurrent transactions
-// writing DISJOINT cells of the same issue row silently cell-merge into a
-// corrupt "zombie" state — UNLESS both also rewrite the shared row_lock cell,
-// which forces the second commit to conflict (1213) so withRetryTx can replay.
+// writing DISJOINT cells of the same issue row silently cell-merge — UNLESS
+// both also rewrite the shared row_lock cell, which forces the second commit
+// to conflict (1213) so withRetryTx can replay.
 //
-// The dangerous pair: a worker's heartbeat (writes heartbeat_at) racing a reaper
-// reverting the row to ready (writes status/assignee). Without a shared lock
-// cell Dolt merges them, producing an open+unassigned issue that still carries
-// the worker's fresh heartbeat — the worker believes it owns work that another
-// worker can now also claim.
+// Since bd-lrgn1 heartbeats no longer touch the issues row (they live on the
+// leases table, where a racing reclaim contends on the SAME row — see
+// TestHeartbeatReclaimContendOnLeaseRow). The disjoint-cell pair guarded here
+// is a worker-side field edit (e.g. priority, via updateIssueInTx) racing a
+// reaper reverting the row to ready (status/assignee): without the shared
+// lock cell Dolt merges them silently, so the edit path never learns its row
+// was reverted underneath it.
 func TestRowLockForcesConflictOnDisjointCellWrites(t *testing.T) {
 	store, cleanup := setupConcurrentTestStore(t)
 	defer cleanup()
@@ -417,44 +422,48 @@ func TestRowLockForcesConflictOnDisjointCellWrites(t *testing.T) {
 			t.Fatalf("begin tx2: %v", err)
 		}
 
-		hbSQL := "UPDATE issues SET heartbeat_at = ? WHERE id = ?"
+		editSQL := "UPDATE issues SET priority = 0 WHERE id = ?"
 		reclaimSQL := "UPDATE issues SET status = 'open', assignee = NULL WHERE id = ?"
-		hbArgs := []any{time.Now().UTC(), id}
+		editArgs := []any{id}
 		reclaimArgs := []any{id}
 		if withLock {
-			hbSQL = "UPDATE issues SET heartbeat_at = ?, row_lock = ? WHERE id = ?"
-			hbArgs = []any{time.Now().UTC(), int64(111111), id}
+			editSQL = "UPDATE issues SET priority = 0, row_lock = ? WHERE id = ?"
+			editArgs = []any{int64(111111), id}
 			reclaimSQL = "UPDATE issues SET status = 'open', assignee = NULL, row_lock = ? WHERE id = ?"
 			reclaimArgs = []any{int64(222222), id}
 		}
 
-		if _, err := tx1.ExecContext(ctx, hbSQL, hbArgs...); err != nil {
-			t.Fatalf("tx1 heartbeat exec: %v", err)
+		if _, err := tx1.ExecContext(ctx, editSQL, editArgs...); err != nil {
+			t.Fatalf("tx1 edit exec: %v", err)
 		}
 		if _, err := tx2.ExecContext(ctx, reclaimSQL, reclaimArgs...); err != nil {
 			t.Fatalf("tx2 reclaim exec: %v", err)
 		}
-		// Commit the heartbeat first, then the reclaim. The reclaim is the loser
+		// Commit the edit first, then the reclaim. The reclaim is the loser
 		// that must conflict when both touch row_lock.
 		if err := tx1.Commit(); err != nil {
-			t.Fatalf("tx1 commit (heartbeat): %v", err)
+			t.Fatalf("tx1 commit (edit): %v", err)
 		}
 		return tx2.Commit()
 	}
 
-	// WITHOUT row_lock: the disjoint writes merge with no error, leaving a zombie.
+	// WITHOUT row_lock: the disjoint writes merge with no error.
 	if err := runRace("zombie-norowlock", false); err != nil {
 		// A conflict here would also be acceptable (still safe), but the point of
 		// the test is to demonstrate the silent merge, so surface if Dolt's
 		// behavior changed.
 		t.Skipf("expected silent merge without row_lock, got conflict %v (Dolt merge semantics changed)", err)
 	}
-	z := readLeaseState(t, ctx, store, "zombie-norowlock")
-	zombie := z.status == "open" && z.heartbeatAt.Valid && (!z.assignee.Valid || z.assignee.String == "")
-	if !zombie {
-		t.Fatalf("without row_lock expected a merged zombie (open+unassigned+heartbeat), got %+v", z)
+	var priority int
+	var status string
+	if err := store.db.QueryRowContext(ctx,
+		"SELECT priority, status FROM issues WHERE id = ?", "zombie-norowlock").Scan(&priority, &status); err != nil {
+		t.Fatalf("read merged row: %v", err)
 	}
-	t.Logf("without row_lock: cell-merge produced zombie state %+v", z)
+	if priority != 0 || status != "open" {
+		t.Fatalf("without row_lock expected a silent merge (priority=0 AND status=open), got priority=%d status=%s", priority, status)
+	}
+	t.Logf("without row_lock: cell-merge landed both writes (priority=%d, status=%s)", priority, status)
 
 	// WITH row_lock: both writers touch the shared cell, so the second commit
 	// conflicts (1213/1205) instead of silently merging.
@@ -466,6 +475,99 @@ func TestRowLockForcesConflictOnDisjointCellWrites(t *testing.T) {
 		t.Fatalf("with row_lock got err %v, want a serialization conflict (1213/1205)", err)
 	}
 	t.Logf("with row_lock: second commit correctly conflicted: %v", err)
+}
+
+// TestHeartbeatReclaimContendOnLeaseRow pins the property that replaced the
+// old heartbeat-vs-reaper row_lock guard (bd-lrgn1): a heartbeat (UPDATE of
+// the lease row) and a reclaim (DELETE of the same lease row) contend on the
+// SAME leases row, so Dolt's commit-time merge forces the second committer to
+// conflict — no shared lock cell needed. The loser's withRetryTx replay then
+// sees the winner's state: a replayed heartbeat finds its lease gone (worker
+// learns it lost the claim), a replayed reclaim finds a fresh expiry and
+// leaves the rescued claim alone.
+func TestHeartbeatReclaimContendOnLeaseRow(t *testing.T) {
+	store, cleanup := setupConcurrentTestStore(t)
+	defer cleanup()
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	seedClaimedIssue(t, ctx, store, "lease-contend", "owner", time.Hour)
+
+	tx1, err := store.db.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatalf("begin tx1: %v", err)
+	}
+	tx2, err := store.db.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatalf("begin tx2: %v", err)
+	}
+
+	// tx1: heartbeat pushes the expiry forward. tx2: reclaim deletes the row.
+	if _, err := tx1.ExecContext(ctx,
+		"UPDATE leases SET lease_expires_at = ?, heartbeat_at = ? WHERE issue_id = ?",
+		time.Now().UTC().Add(2*time.Hour), time.Now().UTC(), "lease-contend"); err != nil {
+		t.Fatalf("tx1 heartbeat exec: %v", err)
+	}
+	if _, err := tx2.ExecContext(ctx,
+		"DELETE FROM leases WHERE issue_id = ?", "lease-contend"); err != nil {
+		t.Fatalf("tx2 reclaim exec: %v", err)
+	}
+	if err := tx1.Commit(); err != nil {
+		t.Fatalf("tx1 commit (heartbeat): %v", err)
+	}
+	err = tx2.Commit()
+	if err == nil {
+		t.Fatal("update-vs-delete of the same lease row did not conflict — the heartbeat/reclaim race guard is gone")
+	}
+	if !isSerializationError(err) {
+		t.Fatalf("lease-row contention err = %v, want a serialization conflict (1213/1205)", err)
+	}
+	t.Logf("lease-row update-vs-delete correctly conflicted: %v", err)
+}
+
+// TestHeartbeatMintsNoDoltCommits is acceptance criterion (1) of bd-lrgn1: a
+// claim followed by N heartbeats produces exactly the claim's own commit and
+// ZERO further commits — heartbeats write only the dolt_ignored leases table.
+// Status/assignee transitions (claim, close) still commit (criterion 2).
+func TestHeartbeatMintsNoDoltCommits(t *testing.T) {
+	store, cleanup := setupConcurrentTestStore(t)
+	defer cleanup()
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	commitCount := func() int {
+		var n int
+		if err := store.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM dolt_log").Scan(&n); err != nil {
+			t.Fatalf("count dolt_log: %v", err)
+		}
+		return n
+	}
+
+	seedClaimedIssue(t, ctx, store, "lease-nocommit", "alice", time.Hour)
+	afterClaim := commitCount()
+
+	for i := 0; i < 5; i++ {
+		if err := store.HeartbeatIssue(ctx, "lease-nocommit", "alice"); err != nil {
+			t.Fatalf("heartbeat %d: %v", i, err)
+		}
+	}
+	if got := commitCount(); got != afterClaim {
+		t.Errorf("heartbeats minted %d dolt commit(s) — want zero (leases are dolt_ignored)", got-afterClaim)
+	}
+
+	// The lease is genuinely renewed even though nothing committed.
+	ls := readLeaseState(t, ctx, store, "lease-nocommit")
+	if !ls.leaseExpires.Valid || !ls.leaseExpires.Time.After(time.Now()) {
+		t.Errorf("lease not renewed after heartbeats: %+v", ls)
+	}
+
+	// A status transition still commits: close mints a commit.
+	if err := store.CloseIssue(ctx, "lease-nocommit", "done", "alice", ""); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	if got := commitCount(); got <= afterClaim {
+		t.Errorf("close minted no dolt commit: count %d, want > %d", got, afterClaim)
+	}
 }
 
 // TestConcurrentHeartbeatReclaimClose is the integration race (the lease analog

--- a/internal/storage/dolt/wisps.go
+++ b/internal/storage/dolt/wisps.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/storage/issueops"
+	"github.com/steveyegge/beads/internal/storage/sqlbuild"
 	"github.com/steveyegge/beads/internal/types"
 )
 
@@ -27,9 +28,9 @@ func insertIssueIntoTable(ctx context.Context, tx *sql.Tx, table string, issue *
 func scanIssueFromTable(ctx context.Context, db *sql.DB, table, id string) (*types.Issue, error) {
 	row := db.QueryRowContext(ctx, fmt.Sprintf(`
 		SELECT %s
-		FROM %s
+		FROM %s %s
 		WHERE id = ?
-	`, issueSelectColumns, table), id)
+	`, issueSelectColumns, table, sqlbuild.LeaseJoin(table)), id)
 
 	issue, err := scanIssueFrom(row)
 	if err == sql.ErrNoRows {
@@ -117,8 +118,8 @@ func insertIssueTxIntoTable(ctx context.Context, tx *sql.Tx, table string, issue
 //nolint:gosec // G201: table is a hardcoded constant ("issues" or "wisps")
 func scanIssueTxFromTable(ctx context.Context, tx *sql.Tx, table, id string) (*types.Issue, error) {
 	row := tx.QueryRowContext(ctx, fmt.Sprintf(`
-		SELECT %s FROM %s WHERE id = ?
-	`, issueSelectColumns, table), id)
+		SELECT %s FROM %s %s WHERE id = ?
+	`, issueSelectColumns, table, sqlbuild.LeaseJoin(table)), id)
 
 	issue, err := scanIssueFrom(row)
 	if err == sql.ErrNoRows {
@@ -432,9 +433,9 @@ func (s *DoltStore) getWispsByIDs(ctx context.Context, ids []string) ([]*types.I
 		//nolint:gosec // G201: placeholders contains only ? markers
 		querySQL := fmt.Sprintf(`
 			SELECT %s
-			FROM wisps
+			FROM wisps %s
 			WHERE id IN (%s)
-		`, issueSelectColumns, placeholders)
+		`, issueSelectColumns, sqlbuild.LeaseJoin("wisps"), placeholders)
 
 		queryRows, err := s.queryContext(ctx, querySQL, args...)
 		if err != nil {

--- a/internal/storage/domain/db/issue.go
+++ b/internal/storage/domain/db/issue.go
@@ -219,12 +219,12 @@ func (r *issueSQLRepositoryImpl) Claim(ctx context.Context, id, actor string, op
 	now := time.Now().UTC()
 	startedWasZero := oldIssue.StartedAt == nil
 
-	// Stamp the same lease + row_lock the primary claim path (issueops.
-	// ClaimIssueInTx) writes. Without this, a claim made through the proxied-
-	// server (uow) path leaves lease_expires_at/heartbeat_at NULL and row_lock
-	// unchanged — invisible to bd reclaim and open to the cell-merge bug the
-	// row_lock invariant guards against (see issueops/lease.go).
-	leaseClause, leaseArgs := issueops.LeaseSetClause(now, issueops.LeaseTTL(ctx))
+	// Rewrite row_lock exactly like the primary claim path (issueops.
+	// ClaimIssueInTx). Without this, a claim made through the proxied-server
+	// (uow) path leaves row_lock unchanged — open to the cell-merge bug the
+	// row_lock invariant guards against (see issueops/lease.go). The lease
+	// itself is granted into the ephemeral leases table below, after the CAS.
+	rowLockClause, rowLockArgs := issueops.RowLockClause()
 
 	// Mirror the primary path's pool-aware predicate (bd-bguz6): aliases in
 	// the claim.pools config are claimable by any actor. This dual must stay
@@ -257,7 +257,7 @@ func (r *issueSQLRepositoryImpl) Claim(ctx context.Context, id, actor string, op
 
 	var res sql.Result
 	if startedWasZero {
-		args := append([]any{actor, now, now}, leaseArgs...)
+		args := append([]any{actor, now, now}, rowLockArgs...)
 		args = append(args, id)
 		args = append(args, statusArgs...)
 		args = append(args, assigneeArgs...)
@@ -266,9 +266,9 @@ func (r *issueSQLRepositoryImpl) Claim(ctx context.Context, id, actor string, op
 			UPDATE %s
 			SET assignee = ?, status = 'in_progress', updated_at = ?, started_at = ?, %s
 			WHERE id = ? AND (%s) AND (%s)
-		`, table, leaseClause, statusPredicate, assigneePredicate), args...)
+		`, table, rowLockClause, statusPredicate, assigneePredicate), args...)
 	} else {
-		args := append([]any{actor, now}, leaseArgs...)
+		args := append([]any{actor, now}, rowLockArgs...)
 		args = append(args, id)
 		args = append(args, statusArgs...)
 		args = append(args, assigneeArgs...)
@@ -277,7 +277,7 @@ func (r *issueSQLRepositoryImpl) Claim(ctx context.Context, id, actor string, op
 			UPDATE %s
 			SET assignee = ?, status = 'in_progress', updated_at = ?, %s
 			WHERE id = ? AND (%s) AND (%s)
-		`, table, leaseClause, statusPredicate, assigneePredicate), args...)
+		`, table, rowLockClause, statusPredicate, assigneePredicate), args...)
 	}
 	if err != nil {
 		return domain.ClaimRowResult{}, fmt.Errorf("db: Claim %s: %w", id, err)
@@ -310,6 +310,15 @@ func (r *issueSQLRepositoryImpl) Claim(ctx context.Context, id, actor string, op
 		}, nil
 	}
 
+	// Grant the lease in the ephemeral leases table, mirroring
+	// issueops.ClaimIssueInTx. Wisps are never leased. This dual must stay in
+	// lockstep with the primary path (see the row_lock comment above).
+	if !opts.UseWispsTable {
+		if err := issueops.UpsertLeaseInTx(ctx, r.runner, id, actor, now, issueops.LeaseTTL(ctx)); err != nil {
+			return domain.ClaimRowResult{}, fmt.Errorf("db: Claim %s: %w", id, err)
+		}
+	}
+
 	oldData, _ := json.Marshal(oldIssue)
 	newData, _ := json.Marshal(map[string]any{"assignee": actor, "status": "in_progress"})
 	if err := r.events.Record(ctx, domain.Event{
@@ -337,7 +346,8 @@ func (r *issueSQLRepositoryImpl) Get(ctx context.Context, id string, opts domain
 	}
 	table := pickIssueTable(opts.UseWispsTable)
 	//nolint:gosec // G201: table is one of two hardcoded constants
-	row := r.runner.QueryRowContext(ctx, fmt.Sprintf("SELECT %s FROM %s WHERE id = ?", issueSelectColumns, table), id)
+	row := r.runner.QueryRowContext(ctx, fmt.Sprintf("SELECT %s FROM %s %s WHERE id = ?",
+		issueSelectColumns, table, sqlbuild.LeaseJoin(table)), id)
 	issue, err := scanIssue(row)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, sql.ErrNoRows
@@ -360,7 +370,8 @@ func (r *issueSQLRepositoryImpl) GetByIDs(ctx context.Context, ids []string, opt
 	}
 	table := pickIssueTable(opts.UseWispsTable)
 	//nolint:gosec // G201: table is one of two hardcoded constants
-	q := fmt.Sprintf("SELECT %s FROM %s WHERE id IN (%s)", issueSelectColumns, table, strings.Join(placeholders, ","))
+	q := fmt.Sprintf("SELECT %s FROM %s %s WHERE id IN (%s)",
+		issueSelectColumns, table, sqlbuild.LeaseJoin(table), strings.Join(placeholders, ","))
 	rows, err := r.runner.QueryContext(ctx, q, args...)
 	if err != nil {
 		return nil, fmt.Errorf("db: GetByIDs: %w", err)
@@ -712,6 +723,10 @@ func (r *issueSQLRepositoryImpl) Delete(ctx context.Context, id string, opts dom
 	if rows == 0 {
 		return fmt.Errorf("issue not found: %s", id)
 	}
+	// A deleted issue holds no lease (no-op for wisps, which are never leased).
+	if err := issueops.DeleteLeaseInTx(ctx, r.runner, id); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -748,6 +763,15 @@ func (r *issueSQLRepositoryImpl) DeleteByIDs(ctx context.Context, ids []string, 
 			return total, fmt.Errorf("db: IssueSQLRepository.DeleteByIDs rows affected: %w", err)
 		}
 		total += int(n)
+		if !opts.UseWispsTable {
+			// Deleted issues hold no leases.
+			//nolint:gosec // G201: placeholders are ?.
+			if _, err := r.runner.ExecContext(ctx,
+				fmt.Sprintf("DELETE FROM leases WHERE issue_id IN (%s)", strings.Join(placeholders, ",")),
+				args...); err != nil {
+				return total, fmt.Errorf("db: IssueSQLRepository.DeleteByIDs leases: %w", err)
+			}
+		}
 	}
 	return total, nil
 }

--- a/internal/storage/domain/db/issue_search.go
+++ b/internal/storage/domain/db/issue_search.go
@@ -131,8 +131,8 @@ func (r *issueSQLRepositoryImpl) fetchIssuesByIDs(ctx context.Context, ids []str
 	placeholders, args := buildInPlaceholders(ids)
 
 	//nolint:gosec // G201: tables.Main is "issues" or "wisps"; placeholders are ?.
-	fetchSQL := fmt.Sprintf(`SELECT %s FROM %s WHERE id IN (%s)`,
-		issueSelectColumns, tables.Main, placeholders)
+	fetchSQL := fmt.Sprintf(`SELECT %s FROM %s %s WHERE id IN (%s)`,
+		issueSelectColumns, tables.Main, sqlbuild.LeaseJoin(tables.Main), placeholders)
 	rows, err := r.runner.QueryContext(ctx, fetchSQL, args...)
 	if err != nil {
 		return nil, err
@@ -198,8 +198,8 @@ func (r *issueSQLRepositoryImpl) searchTable(ctx context.Context, query string, 
 	limitSQL := limitOffsetSQL(filter.Limit, filter.Offset)
 
 	//nolint:gosec // G201: SQL fragments from fixed table names and parameterized filters.
-	querySQL := fmt.Sprintf(`%s%s FROM %s %s %s %s`,
-		selectKw, issueSelectColumns, plan.FromSQL, whereSQL, orderBy, limitSQL)
+	querySQL := fmt.Sprintf(`%s%s FROM %s %s %s %s %s`,
+		selectKw, issueSelectColumns, plan.FromSQL, sqlbuild.LeaseJoin(tables.Main), whereSQL, orderBy, limitSQL)
 
 	rows, err := r.runner.QueryContext(ctx, querySQL, args...)
 	if err != nil {

--- a/internal/storage/domain/db/issue_test.go
+++ b/internal/storage/domain/db/issue_test.go
@@ -644,8 +644,8 @@ func (s *testSuite) issueClaimEmptyID() {
 	s.Contains(err.Error(), "id must not be empty")
 }
 
-// issueClaimStampsLease asserts the proxied-server (uow) claim path stamps the
-// lease columns and rewrites row_lock, so a claim made through this path is
+// issueClaimStampsLease asserts the proxied-server (uow) claim path grants a
+// lease row and rewrites row_lock, so a claim made through this path is
 // visible to bd reclaim rather than stranded (the C2 gap).
 func (s *testSuite) issueClaimStampsLease() {
 	r := s.issueRepo()
@@ -662,10 +662,11 @@ func (s *testSuite) issueClaimStampsLease() {
 		rowLock      int64
 	)
 	s.Require().NoError(s.Runner().QueryRowContext(s.Ctx(),
-		"SELECT lease_expires_at, heartbeat_at, row_lock FROM issues WHERE id = ?", "bd-claim-lease").
+		"SELECT l.lease_expires_at, l.heartbeat_at, i.row_lock FROM issues i "+
+			"LEFT JOIN leases l ON l.issue_id = i.id WHERE i.id = ?", "bd-claim-lease").
 		Scan(&leaseExpires, &heartbeatAt, &rowLock))
-	s.Require().True(leaseExpires.Valid, "proxied claim must stamp lease_expires_at")
-	s.Require().True(heartbeatAt.Valid, "proxied claim must stamp heartbeat_at")
+	s.Require().True(leaseExpires.Valid, "proxied claim must grant a lease row")
+	s.Require().True(heartbeatAt.Valid, "proxied claim must stamp heartbeat_at on the lease row")
 	s.NotZero(rowLock, "proxied claim must rewrite row_lock")
 
 	// The stamped lease must be recoverable. A cutoff in the future makes the
@@ -731,8 +732,8 @@ func (s *testSuite) issueClaimPoolAlias() {
 
 	var leaseExpires sql.NullTime
 	s.Require().NoError(s.Runner().QueryRowContext(s.Ctx(),
-		"SELECT lease_expires_at FROM issues WHERE id = ?", "bd-claim-pool").Scan(&leaseExpires))
-	s.Require().True(leaseExpires.Valid, "a pool take is a normal claim and must stamp a lease")
+		"SELECT lease_expires_at FROM leases WHERE issue_id = ?", "bd-claim-pool").Scan(&leaseExpires))
+	s.Require().True(leaseExpires.Valid, "a pool take is a normal claim and must grant a lease")
 }
 
 // issueClaimPoolUnconfiguredAlias asserts an alias absent from claim.pools

--- a/internal/storage/embeddeddolt/lease_test.go
+++ b/internal/storage/embeddeddolt/lease_test.go
@@ -120,12 +120,10 @@ func TestReclaimExpiredLeaseSurvivesRestartEmbedded(t *testing.T) {
 		t.Fatalf("ClaimIssue: %v", err)
 	}
 
-	// Restart: close the engine, let the lease expire while it is down, reopen.
+	// Restart: close the engine, reopen from disk.
 	if err := store.Close(); err != nil {
 		t.Fatalf("Close: %v", err)
 	}
-	time.Sleep(1500 * time.Millisecond)
-
 	store2, err := embeddeddolt.Open(ctx, beadsDir, prefix, "main")
 	if err != nil {
 		t.Fatalf("reopen: %v", err)
@@ -136,10 +134,29 @@ func TestReclaimExpiredLeaseSurvivesRestartEmbedded(t *testing.T) {
 	// against a vacuous pass below, since reclaim JOINs on the leases table and
 	// would return nothing if restart had dropped the row.
 	te := &testEnv{store: store2, dataDir: filepath.Join(beadsDir, "embeddeddolt"), database: prefix}
-	var holder string
-	te.queryScalar(t, ctx, "SELECT holder FROM leases WHERE issue_id = ?", []any{"lease-restart-1"}, &holder)
+	var holder, statusBefore, expiresStr string
+	te.queryScalar(t, ctx,
+		"SELECT l.holder, i.status, CAST(l.lease_expires_at AS CHAR) FROM leases l JOIN issues i ON i.id = l.issue_id WHERE l.issue_id = ?",
+		[]any{"lease-restart-1"}, &holder, &statusBefore, &expiresStr)
 	if holder != "alice" {
 		t.Fatalf("lease holder after restart = %q, want alice", holder)
+	}
+	if statusBefore != "in_progress" {
+		t.Fatalf("issue status after restart = %q, want in_progress", statusBefore)
+	}
+
+	// Wait until the wall clock is unambiguously past the STORED expiry:
+	// DATETIME is second-granular and may round the claim's now+TTL up, so
+	// racing a fixed sleep against it flakes (reclaim compares with strict <).
+	expires, err := time.Parse("2006-01-02 15:04:05", expiresStr)
+	if err != nil {
+		t.Fatalf("parse stored lease_expires_at %q: %v", expiresStr, err)
+	}
+	if wait := time.Until(expires.Add(1500 * time.Millisecond)); wait > 0 {
+		if wait > 10*time.Second {
+			t.Fatalf("stored lease_expires_at %s is unexpectedly far in the future", expiresStr)
+		}
+		time.Sleep(wait)
 	}
 
 	reclaimed, err := store2.ReclaimExpiredLeases(ctx, 0, "reaper")

--- a/internal/storage/embeddeddolt/lease_test.go
+++ b/internal/storage/embeddeddolt/lease_test.go
@@ -4,10 +4,12 @@ package embeddeddolt_test
 
 import (
 	"errors"
+	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/steveyegge/beads/internal/storage"
+	"github.com/steveyegge/beads/internal/storage/embeddeddolt"
 	"github.com/steveyegge/beads/internal/storage/issueops"
 	"github.com/steveyegge/beads/internal/types"
 )
@@ -73,6 +75,95 @@ func TestLeaseLifecycleEmbedded(t *testing.T) {
 	}
 	if got.Assignee != "" {
 		t.Errorf("assignee = %q after reclaim, want empty", got.Assignee)
+	}
+}
+
+// TestReclaimExpiredLeaseSurvivesRestartEmbedded pins bd-lrgn1 acceptance (5):
+// the leases table is dolt_ignored (unversioned, node-local) but still durable,
+// so a lease granted before a server restart is visible after it and an expired
+// lease can be reclaimed by the restarted server. Closing and reopening the
+// embedded store is a real engine restart from disk.
+func TestReclaimExpiredLeaseSurvivesRestartEmbedded(t *testing.T) {
+	skipUnlessEmbeddedDolt(t)
+
+	ctx := t.Context()
+	beadsDir := filepath.Join(t.TempDir(), ".beads")
+	const prefix = "lease_restart"
+
+	store, err := embeddeddolt.Open(ctx, beadsDir, prefix, "main")
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	if err := store.SetConfig(ctx, "issue_prefix", prefix); err != nil {
+		store.Close()
+		t.Fatalf("SetConfig(issue_prefix): %v", err)
+	}
+	if err := store.Commit(ctx, "bd init"); err != nil {
+		store.Close()
+		t.Fatalf("Commit: %v", err)
+	}
+
+	issue := &types.Issue{
+		ID:        "lease-restart-1",
+		Title:     "lease across restart",
+		Status:    types.StatusOpen,
+		Priority:  2,
+		IssueType: types.TypeTask,
+	}
+	if err := store.CreateIssue(ctx, issue, "seeder"); err != nil {
+		store.Close()
+		t.Fatalf("CreateIssue: %v", err)
+	}
+	claimCtx := issueops.WithLeaseTTL(ctx, time.Second)
+	if err := store.ClaimIssue(claimCtx, "lease-restart-1", "alice"); err != nil {
+		store.Close()
+		t.Fatalf("ClaimIssue: %v", err)
+	}
+
+	// Restart: close the engine, let the lease expire while it is down, reopen.
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	time.Sleep(1500 * time.Millisecond)
+
+	store2, err := embeddeddolt.Open(ctx, beadsDir, prefix, "main")
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	defer store2.Close()
+
+	// The lease row survived the restart with its holder intact — this guards
+	// against a vacuous pass below, since reclaim JOINs on the leases table and
+	// would return nothing if restart had dropped the row.
+	te := &testEnv{store: store2, dataDir: filepath.Join(beadsDir, "embeddeddolt"), database: prefix}
+	var holder string
+	te.queryScalar(t, ctx, "SELECT holder FROM leases WHERE issue_id = ?", []any{"lease-restart-1"}, &holder)
+	if holder != "alice" {
+		t.Fatalf("lease holder after restart = %q, want alice", holder)
+	}
+
+	reclaimed, err := store2.ReclaimExpiredLeases(ctx, 0, "reaper")
+	if err != nil {
+		t.Fatalf("ReclaimExpiredLeases after restart: %v", err)
+	}
+	if len(reclaimed) != 1 || reclaimed[0].ID != "lease-restart-1" || reclaimed[0].PreviousOwner != "alice" {
+		t.Fatalf("reclaimed = %+v, want [{lease-restart-1 alice}]", reclaimed)
+	}
+
+	got, err := store2.GetIssue(ctx, "lease-restart-1")
+	if err != nil {
+		t.Fatalf("GetIssue: %v", err)
+	}
+	if got.Status != types.StatusOpen {
+		t.Errorf("status = %q after restart reclaim, want open", got.Status)
+	}
+	if got.Assignee != "" {
+		t.Errorf("assignee = %q after restart reclaim, want empty", got.Assignee)
+	}
+	var leaseRows int
+	te.queryScalar(t, ctx, "SELECT COUNT(*) FROM leases WHERE issue_id = ?", []any{"lease-restart-1"}, &leaseRows)
+	if leaseRows != 0 {
+		t.Errorf("lease rows after reclaim = %d, want 0", leaseRows)
 	}
 }
 

--- a/internal/storage/embeddeddolt/migrate_selfheal_test.go
+++ b/internal/storage/embeddeddolt/migrate_selfheal_test.go
@@ -180,15 +180,17 @@ func TestEmbeddedMigrateConvergesUnderConcurrentInterruptedRetries_4566(t *testi
 	}
 
 	// Install the fault hook only AFTER seeding, so the baseline builds cleanly.
-	// It fires on a random ~55% of numbered main-source steps (versions > the
-	// ignored source's max of 11, so only the killed 49..latest jump is
-	// affected, never the dolt-ignored tail). A thread-safe RNG keeps it safe
-	// for the concurrent workers. Progress is monotonic post-fix: a step that
-	// faults was already committed, so each attempt advances.
+	// It fires on a random ~55% of numbered main-source steps (versions above
+	// the ignored source's max, so only the killed 49..latest jump is
+	// affected, never the dolt-ignored tail — the hook cannot tell sources
+	// apart, and a kill inside the ignored tail strands the pass's backfill
+	// dirt, which only the end-of-pass commit stages). A thread-safe RNG keeps
+	// it safe for the concurrent workers. Progress is monotonic post-fix: a
+	// step that faults was already committed, so each attempt advances.
 	var rngMu sync.Mutex
 	rng := rand.New(rand.NewSource(1))
 	restore := schema.SetMigrateStepFaultHookForTest(func(_ context.Context, _ schema.DBConn, version int) error {
-		if version <= 11 {
+		if version <= schema.LatestIgnoredVersion() {
 			return nil
 		}
 		rngMu.Lock()

--- a/internal/storage/issueops/bulk_ops.go
+++ b/internal/storage/issueops/bulk_ops.go
@@ -197,6 +197,13 @@ func DeleteIssuesBySourceRepoInTx(ctx context.Context, tx *sql.Tx, sourceRepo st
 		return 0, fmt.Errorf("affected by source-repo delete: %w", aerr)
 	}
 
+	// Deleted issues hold no leases: clear them while the id set is still
+	// joinable (before the issues rows go away).
+	if _, err := tx.ExecContext(ctx,
+		`DELETE FROM leases WHERE issue_id IN (SELECT id FROM issues WHERE source_repo = ?)`, sourceRepo); err != nil {
+		return 0, fmt.Errorf("delete leases: %w", err)
+	}
+
 	result, err := tx.ExecContext(ctx, `DELETE FROM issues WHERE source_repo = ?`, sourceRepo)
 	if err != nil {
 		return 0, fmt.Errorf("delete issues: %w", err)
@@ -238,6 +245,12 @@ func updateIssueIDInTx(ctx context.Context, tx *sql.Tx, oldID, newID string, iss
 
 	if err := UpdateIssueIDInDependenciesInTx(ctx, tx, oldID, newID); err != nil {
 		return err
+	}
+
+	// A live lease follows its issue across the rename.
+	if _, err := tx.ExecContext(ctx,
+		`UPDATE leases SET issue_id = ? WHERE issue_id = ?`, newID, oldID); err != nil {
+		return fmt.Errorf("rename lease row: %w", err)
 	}
 
 	_, err = tx.ExecContext(ctx, `

--- a/internal/storage/issueops/claim.go
+++ b/internal/storage/issueops/claim.go
@@ -44,12 +44,12 @@ func ClaimIssueInTx(ctx context.Context, tx DBTX, id string, actor string) (*Cla
 
 	now := time.Now().UTC()
 
-	// Stamp a lease on the claim: lease_expires_at = now + TTL, heartbeat_at =
-	// now, and a fresh row_lock (see lease.go). The lease is what makes a claim
-	// recoverable — a worker that dies stops heartbeating and bd reclaim later
-	// reverts the issue. row_lock here also forces a concurrent reclaim/heartbeat
-	// to conflict rather than silently cell-merge.
-	leaseClause, leaseArgs := leaseSetClause(now, leaseTTL(ctx))
+	// Rewrite row_lock with the claim (see lease.go): a concurrent reclaim or
+	// close on the same row is forced to conflict rather than silently
+	// cell-merge. The lease itself is granted separately below, in the
+	// ephemeral leases table — claims commit (status/assignee are
+	// history-worthy) but lease grants and heartbeats do not (bd-lrgn1).
+	rowLockClause, rowLockArgs := RowLockClause()
 
 	// An issue is claimable from "open" plus any configured custom status whose
 	// category is "active" (e.g. a draft->ready->in_progress lifecycle where
@@ -84,7 +84,7 @@ func ClaimIssueInTx(ctx context.Context, tx DBTX, id string, actor string) (*Cla
 		result sql.Result
 	)
 	if oldIssue.StartedAt == nil {
-		args := append([]interface{}{actor, now, now}, leaseArgs...)
+		args := append([]interface{}{actor, now, now}, rowLockArgs...)
 		args = append(args, id)
 		args = append(args, statusArgs...)
 		args = append(args, assigneeArgs...)
@@ -92,9 +92,9 @@ func ClaimIssueInTx(ctx context.Context, tx DBTX, id string, actor string) (*Cla
 			UPDATE %s
 			SET assignee = ?, status = 'in_progress', updated_at = ?, started_at = ?, %s
 			WHERE id = ? AND status IN (%s) AND (%s)
-		`, issueTable, leaseClause, statusPlaceholders, assigneePredicate), args...)
+		`, issueTable, rowLockClause, statusPlaceholders, assigneePredicate), args...)
 	} else {
-		args := append([]interface{}{actor, now}, leaseArgs...)
+		args := append([]interface{}{actor, now}, rowLockArgs...)
 		args = append(args, id)
 		args = append(args, statusArgs...)
 		args = append(args, assigneeArgs...)
@@ -102,7 +102,7 @@ func ClaimIssueInTx(ctx context.Context, tx DBTX, id string, actor string) (*Cla
 			UPDATE %s
 			SET assignee = ?, status = 'in_progress', updated_at = ?, %s
 			WHERE id = ? AND status IN (%s) AND (%s)
-		`, issueTable, leaseClause, statusPlaceholders, assigneePredicate), args...)
+		`, issueTable, rowLockClause, statusPlaceholders, assigneePredicate), args...)
 	}
 	if err != nil {
 		return nil, fmt.Errorf("failed to claim issue: %w", err)
@@ -151,6 +151,16 @@ func ClaimIssueInTx(ctx context.Context, tx DBTX, id string, actor string) (*Cla
 			return nil, fmt.Errorf("%w by %s", storage.ErrAlreadyClaimed, assignee)
 		}
 		return nil, fmt.Errorf("%w: status %s", storage.ErrNotClaimable, currentStatus)
+	}
+
+	// Grant the lease: what makes the claim recoverable — a worker that dies
+	// stops heartbeating and bd reclaim later reverts the issue. Lease rows
+	// live in the ephemeral leases table (no Dolt commit, node-local). Wisps
+	// are never leased (they are ephemeral, not reclaimable work).
+	if !isWisp {
+		if err := UpsertLeaseInTx(ctx, tx, id, actor, now, leaseTTL(ctx)); err != nil {
+			return nil, err
+		}
 	}
 
 	// Record the claim event.

--- a/internal/storage/issueops/close.go
+++ b/internal/storage/issueops/close.go
@@ -48,11 +48,10 @@ func closeIssueInTx(ctx context.Context, tx DBTX, id string, reason, actor, sess
 	// row_lock is rewritten on close so a concurrent reclaim (which also rewrites
 	// row_lock) collides on this cell and is forced to conflict-and-retry rather
 	// than silently cell-merging a revert-to-ready over a completed close (see
-	// lease.go). lease_expires_at/heartbeat_at are cleared: a closed issue holds
-	// no lease.
+	// lease.go). The lease row is deleted below: a closed issue holds no lease.
 	result, err := tx.ExecContext(ctx, fmt.Sprintf(`
 		UPDATE %s SET status = ?, closed_at = ?, updated_at = ?, close_reason = ?, closed_by_session = ?,
-			lease_expires_at = NULL, heartbeat_at = NULL, row_lock = ?
+			row_lock = ?
 		WHERE id = ? AND status != ?
 	`, issueTable), types.StatusClosed, now, now, reason, session, freshRowLock(), id, types.StatusClosed)
 	if err != nil {
@@ -78,6 +77,11 @@ func closeIssueInTx(ctx context.Context, tx DBTX, id string, reason, actor, sess
 			return &CloseResult{IsWisp: isWisp, AlreadyClosed: true}, nil
 		}
 		return nil, fmt.Errorf("failed to close issue: %s", id)
+	}
+
+	// A closed issue holds no lease (no-op for wisps, which are never leased).
+	if err := DeleteLeaseInTx(ctx, tx, id); err != nil {
+		return nil, err
 	}
 
 	if recordEvent {

--- a/internal/storage/issueops/create.go
+++ b/internal/storage/issueops/create.go
@@ -138,6 +138,16 @@ func CreateIssueInTxWithResult(ctx context.Context, tx *sql.Tx, bc *BatchContext
 	}
 	result.markChanged(issueTable)
 
+	// Reconcile the ephemeral lease row with the accepted issue state
+	// (restore an imported lease / drop an orphaned one — see
+	// RestoreLeaseOnImportInTx). Wisps are never leased. The leases table is
+	// dolt_ignored, so this is deliberately not marked as a changed table.
+	if issueTable == "issues" {
+		if err := RestoreLeaseOnImportInTx(ctx, tx, issue, isNew); err != nil {
+			return result, err
+		}
+	}
+
 	if isNew {
 		if err := RecordEventInTable(ctx, tx, eventTable, issue.ID, types.EventCreated, actor, ""); err != nil {
 			return result, fmt.Errorf("failed to record event for %s: %w", issue.ID, err)

--- a/internal/storage/issueops/delete.go
+++ b/internal/storage/issueops/delete.go
@@ -64,6 +64,9 @@ func deleteIssueRowInTx(ctx context.Context, tx *sql.Tx, id string, isWisp bool)
 		if err := DeleteWispFromDependenciesInTx(ctx, tx, id); err != nil {
 			return err
 		}
+	} else if err := DeleteLeaseInTx(ctx, tx, id); err != nil {
+		// A deleted issue holds no lease.
+		return err
 	}
 	return nil
 }
@@ -262,6 +265,13 @@ func DeleteIssuesInTx(ctx context.Context, tx *sql.Tx, ids []string, cascade boo
 		}
 		rowsAffected, _ := deleteResult.RowsAffected()
 		totalRegularsDeleted += int(rowsAffected)
+
+		// Deleted issues hold no leases.
+		if _, err := tx.ExecContext(ctx,
+			fmt.Sprintf(`DELETE FROM leases WHERE issue_id IN (%s)`, batchInClause),
+			batchArgs...); err != nil {
+			return nil, fmt.Errorf("delete leases: %w", err)
+		}
 	}
 	result.DeletedCount = totalRegularsDeleted + len(allWispIDs)
 

--- a/internal/storage/issueops/dependencies.go
+++ b/internal/storage/issueops/dependencies.go
@@ -882,8 +882,8 @@ func GetIssuesByIDsInTx(ctx context.Context, tx DBTX, ids []string, wispSet map[
 			inClause := strings.Join(placeholders, ",")
 
 			rows, err := tx.QueryContext(ctx, fmt.Sprintf(
-				`SELECT %s FROM %s WHERE id IN (%s)`,
-				IssueSelectColumns, pair.table, inClause), args...)
+				`SELECT %s FROM %s %s WHERE id IN (%s)`,
+				IssueSelectColumns, pair.table, sqlbuild.LeaseJoin(pair.table), inClause), args...)
 			if err != nil {
 				return nil, fmt.Errorf("get issues by IDs from %s: %w", pair.table, err)
 			}

--- a/internal/storage/issueops/dependency_tree_test.go
+++ b/internal/storage/issueops/dependency_tree_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/steveyegge/beads/internal/storage/sqlbuild"
 	"github.com/steveyegge/beads/internal/types"
 )
 
@@ -100,7 +101,7 @@ type dependencyRow struct {
 }
 
 func expectIssue(mock sqlmock.Sqlmock, id, title string) {
-	mock.ExpectQuery(regexp.QuoteMeta("SELECT " + IssueSelectColumns + " FROM issues WHERE id = ?")).
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT " + IssueSelectColumns + " FROM issues " + sqlbuild.LeaseJoin("issues") + " WHERE id = ?")).
 		WithArgs(id).
 		WillReturnRows(issueRows().AddRow(issueRowValues(id, title)...))
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT label FROM labels WHERE issue_id = ? ORDER BY label")).
@@ -129,7 +130,7 @@ func expectIssueBatch(mock sqlmock.Sqlmock, ids []string) {
 	for _, id := range ids {
 		rows.AddRow(issueRowValues(id, id)...)
 	}
-	mock.ExpectQuery(regexp.QuoteMeta("SELECT "+IssueSelectColumns+" FROM issues WHERE id IN (?,?)")).
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT "+IssueSelectColumns+" FROM issues "+sqlbuild.LeaseJoin("issues")+" WHERE id IN (?,?)")).
 		WithArgs(ids[0], ids[1]).
 		WillReturnRows(rows)
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT issue_id, label FROM labels WHERE issue_id IN (?,?) ORDER BY issue_id, label")).

--- a/internal/storage/issueops/get_issue.go
+++ b/internal/storage/issueops/get_issue.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"github.com/steveyegge/beads/internal/storage"
+	"github.com/steveyegge/beads/internal/storage/sqlbuild"
 	"github.com/steveyegge/beads/internal/types"
 )
 
@@ -35,7 +36,8 @@ func GetIssueInTx(ctx context.Context, tx DBTX, id string) (*types.Issue, error)
 
 func getIssueFromTableInTx(ctx context.Context, tx DBTX, issueTable, labelTable, id string) (*types.Issue, error) {
 	//nolint:gosec // G201: issueTable is a hardcoded literal supplied by GetIssueInTx ("issues" or "wisps")
-	row := tx.QueryRowContext(ctx, fmt.Sprintf(`SELECT %s FROM %s WHERE id = ?`, IssueSelectColumns, issueTable), id)
+	row := tx.QueryRowContext(ctx, fmt.Sprintf(`SELECT %s FROM %s %s WHERE id = ?`,
+		IssueSelectColumns, issueTable, sqlbuild.LeaseJoin(issueTable)), id)
 	issue, err := ScanIssueFrom(row)
 	if err == sql.ErrNoRows || isTableNotExistError(err) {
 		return nil, storage.ErrNotFound

--- a/internal/storage/issueops/helpers.go
+++ b/internal/storage/issueops/helpers.go
@@ -59,19 +59,18 @@ func TableRouting(issue *types.Issue) (issueTable, eventTable string) {
 // evaluated in order, so the comparison column must not be reassigned until
 // all other columns have been decided.
 //
-// The lease columns ride the same rule as status/assignee (protocol L1.2:
-// lease fields MUST round-trip the JSONL interchange, wy-urlct): a stale
-// snapshot can never clobber a live lease because claim and heartbeat both
-// stamp updated_at, so a live claim is always strictly newer than any
-// pre-claim export. row_lock rides along because any write that can change
-// status/assignee/lease must rewrite it to collide with a concurrent
-// heartbeat/reclaim/close on the same row (see freshRowLock in lease.go).
+// Leases are NOT issues columns (bd-lrgn1): they live in the ephemeral
+// leases table and are restored by RestoreLeaseOnImportInTx, which enforces
+// the never-clobber-a-live-local-lease rule (protocol L1.2: lease fields MUST
+// round-trip the JSONL interchange, wy-urlct). row_lock rides along because
+// any write that can change status/assignee must rewrite it to collide with a
+// concurrent reclaim/close on the same row (see freshRowLock in lease.go).
 var issueUpsertColumns = []string{
 	"content_hash", "title", "description", "design", "acceptance_criteria",
 	"notes", "status", "priority", "issue_type", "assignee",
 	"estimated_minutes", "started_at", "closed_at", "external_ref",
 	"source_repo", "close_reason", "metadata",
-	"lease_expires_at", "heartbeat_at", "row_lock", "updated_at",
+	"row_lock", "updated_at",
 }
 
 // issueUpsertAssignments renders the ON DUPLICATE KEY UPDATE clause. With
@@ -122,7 +121,7 @@ func insertIssueIntoTable(ctx context.Context, tx *sql.Tx, table string, issue *
 			event_kind, actor, target, payload,
 			await_type, await_id, timeout_ns, waiters,
 			due_at, defer_until, metadata,
-			lease_expires_at, heartbeat_at, row_lock
+			row_lock
 		) VALUES (
 			?, ?, ?, ?, ?, ?, ?,
 			?, ?, ?, ?, ?,
@@ -133,7 +132,7 @@ func insertIssueIntoTable(ctx context.Context, tx *sql.Tx, table string, issue *
 			?, ?, ?, ?,
 			?, ?, ?, ?,
 			?, ?, ?,
-			?, ?, ?
+			?
 		)
 		ON DUPLICATE KEY UPDATE
 			%s
@@ -147,7 +146,7 @@ func insertIssueIntoTable(ctx context.Context, tx *sql.Tx, table string, issue *
 		issue.EventKind, issue.Actor, issue.Target, issue.Payload,
 		issue.AwaitType, issue.AwaitID, issue.Timeout.Nanoseconds(), FormatJSONStringArray(issue.Waiters),
 		issue.DueAt, issue.DeferUntil, JSONMetadata(issue.Metadata),
-		issue.LeaseExpiresAt, issue.HeartbeatAt, freshRowLock(),
+		freshRowLock(),
 	)
 	if err != nil {
 		return fmt.Errorf("insert issue into %s: %w", table, err)

--- a/internal/storage/issueops/lease.go
+++ b/internal/storage/issueops/lease.go
@@ -41,25 +41,28 @@ func leaseTTL(ctx context.Context) time.Duration {
 //
 // row_lock is the keystone of dead-worker recovery on Dolt. Dolt has no real
 // row locking and merges concurrent commits cell-by-cell, so two transactions
-// that touch DIFFERENT cells of the same issue row (a heartbeat writing
-// heartbeat_at, a close writing status) merge silently instead of conflicting —
-// which would let a reclaim quietly revert an issue the owner just closed. By
-// having every status/ownership/lease-mutating path rewrite this one shared cell
-// to a fresh random value, those writers always collide on row_lock, surfacing
-// the 1213/1205 serialization conflict that withRetryTx replays. The value's
-// only job is to differ from whatever a concurrent writer wrote, so any source
-// of entropy works; we use crypto/rand to avoid seeding concerns. Never 0 (the
+// that touch DIFFERENT cells of the same issue row (a reclaim writing status,
+// a close writing closed_at) merge silently instead of conflicting — which
+// would let a reclaim quietly revert an issue the owner just closed. By having
+// every status/ownership-mutating path rewrite this one shared cell to a fresh
+// random value, those writers always collide on row_lock, surfacing the
+// 1213/1205 serialization conflict that withRetryTx replays. The value's only
+// job is to differ from whatever a concurrent writer wrote, so any source of
+// entropy works; we use crypto/rand to avoid seeding concerns. Never 0 (the
 // column default) so a freshly-claimed row is always distinguishable from a
 // never-touched one.
 //
-// INVARIANT: any path that mutates status, assignee, started_at, or the lease
-// columns on an in_progress issue MUST rewrite row_lock — that is the set the
-// reclaim/heartbeat races care about (claim, close, updateIssueInTx, heartbeat,
-// reclaim all do). Paths that touch only orthogonal cells (is_blocked,
-// compaction_level, dependency metadata, rename, or reopen — which acts on
-// closed rows) are safe to merge with a reclaim and intentionally do NOT rewrite
-// it. Adding a new path that sets status/assignee/lease outside updateIssueInTx
-// without rewriting row_lock would silently reintroduce the zombie-merge bug.
+// INVARIANT: any path that mutates status, assignee, or started_at on an
+// in_progress issue MUST rewrite row_lock — that is the set the reclaim/close
+// races care about (claim, close, updateIssueInTx, reclaim, unclaim all do).
+// Paths that touch only orthogonal cells (is_blocked, compaction_level,
+// dependency metadata, rename, or reopen — which acts on closed rows) are safe
+// to merge with a reclaim and intentionally do NOT rewrite it. Heartbeats no
+// longer touch the issues row at all (bd-lrgn1): the lease lives in the
+// ephemeral leases table, where a racing heartbeat and reclaim contend on the
+// SAME lease row and conflict without any help. Adding a new path that sets
+// status/assignee outside updateIssueInTx without rewriting row_lock would
+// silently reintroduce the zombie-merge bug.
 func freshRowLock() int64 {
 	var b [8]byte
 	if _, err := rand.Read(b[:]); err != nil {
@@ -74,21 +77,13 @@ func freshRowLock() int64 {
 	return v
 }
 
-// leaseSetClause returns the SET-clause fragment and args that stamp a fresh
-// lease onto a row being claimed or heartbeated: a future expiry, a now
-// heartbeat, and a fresh row_lock. Append to an existing UPDATE's SET list.
-func leaseSetClause(now time.Time, ttl time.Duration) (string, []interface{}) {
-	return "lease_expires_at = ?, heartbeat_at = ?, row_lock = ?",
-		[]interface{}{now.Add(ttl), now, freshRowLock()}
-}
-
-// LeaseSetClause is the exported form of leaseSetClause, for the proxied-server
-// (uow) claim path in internal/storage/domain/db, which builds its own claim
-// UPDATE rather than calling ClaimIssueInTx. Keeping both paths on this one
-// helper is what stops the proxied path from reintroducing the missing-lease /
-// cell-merge bug the row_lock invariant guards against.
-func LeaseSetClause(now time.Time, ttl time.Duration) (string, []interface{}) {
-	return leaseSetClause(now, ttl)
+// RowLockClause returns the SET-clause fragment and arg that rewrite row_lock
+// to a fresh value. Append to any UPDATE that mutates status/assignee/
+// started_at on an issues row (see the freshRowLock invariant). Exported for
+// the proxied-server (uow) claim path in internal/storage/domain/db, which
+// builds its own claim UPDATE rather than calling ClaimIssueInTx.
+func RowLockClause() (string, []interface{}) {
+	return "row_lock = ?", []interface{}{freshRowLock()}
 }
 
 // LeaseTTL is the exported form of leaseTTL: it resolves the lease TTL for the
@@ -98,36 +93,139 @@ func LeaseTTL(ctx context.Context) time.Duration {
 	return leaseTTL(ctx)
 }
 
-// HeartbeatIssueInTx proves the lease owner is still alive: it pushes
-// lease_expires_at forward by the TTL, stamps heartbeat_at = now, and rewrites
-// row_lock so the heartbeat conflicts with any concurrent reclaim/close on the
-// same row (see freshRowLock). Only the current owner of an in_progress issue
-// may heartbeat — a heartbeat from anyone else, or on an issue that is no longer
-// in_progress (already closed or already reclaimed), affects no rows and returns
-// storage.ErrNotClaimable so the caller learns its lease is gone.
+// UpsertLeaseInTx grants or re-grants the lease on an issue to holder: a
+// future expiry, a now heartbeat. The lease row lives in the ephemeral leases
+// table (dolt_ignored on the Dolt backend, bd-lrgn1), NOT on the issues row,
+// so granting or renewing it mints no Dolt commit and no history. Leases are
+// deliberately node-local: they are only enforceable on the replica that
+// granted them; cross-machine claim VISIBILITY rides status/assignee on the
+// issues row, which still commits.
 //
-// Routes to the correct table (issues/wisps). The caller owns Dolt versioning.
+// INVARIANT: a leases row exists if and only if its issue is a live claim
+// (in_progress with the row's holder as assignee) on this node. Every path
+// that ends or transfers a claim — close, unclaim, reclaim, delete, a generic
+// update that changes status/assignee, an import that accepts a newer
+// non-claimed snapshot — must delete the lease row (DeleteLeaseInTx). Wisps
+// are never leased (see testHeartbeatWisp) and never get a row here.
+func UpsertLeaseInTx(ctx context.Context, tx DBTX, id, holder string, now time.Time, ttl time.Duration) error {
+	_, err := tx.ExecContext(ctx, `
+		INSERT INTO leases (issue_id, holder, granted_at, lease_expires_at, heartbeat_at)
+		VALUES (?, ?, ?, ?, ?)
+		ON DUPLICATE KEY UPDATE
+			holder = VALUES(holder),
+			granted_at = VALUES(granted_at),
+			lease_expires_at = VALUES(lease_expires_at),
+			heartbeat_at = VALUES(heartbeat_at)
+	`, id, holder, now, now.Add(ttl), now)
+	if err != nil {
+		return fmt.Errorf("upsert lease for %s: %w", id, err)
+	}
+	return nil
+}
+
+// DeleteLeaseInTx removes the lease row for an issue, if any. Call from every
+// path that ends or transfers a claim (see the UpsertLeaseInTx invariant).
+// Deleting a lease that does not exist is a no-op, so callers may invoke it
+// unconditionally — including for wisp IDs, which never have lease rows.
+func DeleteLeaseInTx(ctx context.Context, tx DBTX, id string) error {
+	if _, err := tx.ExecContext(ctx, `DELETE FROM leases WHERE issue_id = ?`, id); err != nil {
+		return fmt.Errorf("delete lease for %s: %w", id, err)
+	}
+	return nil
+}
+
+// RestoreLeaseOnImportInTx reconciles an issue's lease row after an
+// import/upsert wrote the issue row (protocol L1.2: lease fields round-trip
+// the JSONL interchange, wy-urlct — bd-lrgn1 moved them from issues columns
+// to the ephemeral leases table).
+//
+// Two duties, both keyed off the STORED row (the winner after any stale-guard
+// merge), never the snapshot alone:
+//
+//   - restore: when the snapshot carried a lease and the stored row is a live
+//     claim, upsert the lease row — but NEVER clobber a live (unexpired) local
+//     lease with snapshot data. Leases are node-local; the local grant is
+//     always more authoritative than a replicated timestamp.
+//   - reconcile: when the accepted state ended or transferred the claim, drop
+//     any now-orphaned local lease row so the UpsertLeaseInTx invariant
+//     (lease row ⇔ live claim) holds.
+//
+// Wisps are never leased; callers route them away before calling this.
+func RestoreLeaseOnImportInTx(ctx context.Context, tx DBTX, issue *types.Issue, isNew bool) error {
+	now := time.Now().UTC()
+
+	if issue.LeaseExpiresAt != nil {
+		var status, assignee string
+		err := tx.QueryRowContext(ctx,
+			"SELECT status, COALESCE(assignee, '') FROM issues WHERE id = ?", issue.ID,
+		).Scan(&status, &assignee)
+		if err != nil {
+			return fmt.Errorf("read stored row for lease restore of %s: %w", issue.ID, err)
+		}
+		if status == string(types.StatusInProgress) && assignee != "" {
+			grantedAt := now
+			heartbeatAt := now
+			if issue.HeartbeatAt != nil {
+				grantedAt = *issue.HeartbeatAt
+				heartbeatAt = *issue.HeartbeatAt
+			}
+			// Assignment order matters: lease_expires_at is the liveness
+			// comparison column and ON DUPLICATE KEY UPDATE assignments are
+			// evaluated in order, so it must be reassigned LAST.
+			_, err := tx.ExecContext(ctx, `
+				INSERT INTO leases (issue_id, holder, granted_at, lease_expires_at, heartbeat_at)
+				VALUES (?, ?, ?, ?, ?)
+				ON DUPLICATE KEY UPDATE
+					holder = IF(leases.lease_expires_at >= ?, leases.holder, VALUES(holder)),
+					granted_at = IF(leases.lease_expires_at >= ?, leases.granted_at, VALUES(granted_at)),
+					heartbeat_at = IF(leases.lease_expires_at >= ?, leases.heartbeat_at, VALUES(heartbeat_at)),
+					lease_expires_at = IF(leases.lease_expires_at >= ?, leases.lease_expires_at, VALUES(lease_expires_at))
+			`, issue.ID, assignee, grantedAt, *issue.LeaseExpiresAt, heartbeatAt,
+				now, now, now, now)
+			if err != nil {
+				return fmt.Errorf("restore lease for %s: %w", issue.ID, err)
+			}
+		}
+	}
+
+	// An upsert over an existing row may have ended or transferred the claim
+	// (e.g. a newer snapshot closed the issue): drop a lease row that no
+	// longer matches a live claim by its holder.
+	if !isNew {
+		_, err := tx.ExecContext(ctx, `
+			DELETE FROM leases WHERE issue_id = ?
+			  AND NOT EXISTS (
+				SELECT 1 FROM issues i
+				WHERE i.id = ? AND i.status = 'in_progress' AND i.assignee = leases.holder
+			  )
+		`, issue.ID, issue.ID)
+		if err != nil {
+			return fmt.Errorf("reconcile lease for %s: %w", issue.ID, err)
+		}
+	}
+	return nil
+}
+
+// HeartbeatIssueInTx proves the lease owner is still alive: it pushes
+// lease_expires_at forward by the TTL and stamps heartbeat_at = now on the
+// issue's lease row. Only the current holder may heartbeat — a heartbeat from
+// anyone else, or on an issue whose lease is gone (closed, unclaimed,
+// reclaimed, or never leased — wisps), affects no rows and returns
+// storage.ErrNotClaimable / ErrAlreadyClaimed so the caller learns its lease
+// is gone.
+//
+// The write touches ONLY the leases table (ephemeral, dolt_ignored): a
+// heartbeat mints no Dolt commit and no history, and deliberately does NOT
+// stamp issues.updated_at — updated_at keeps its merge/LWW meaning and bd
+// stale consults leases.heartbeat_at for in_progress rows instead (bd-lrgn1).
 //
 //nolint:gosec // G201: table names come from WispTableRouting (hardcoded constants)
 func HeartbeatIssueInTx(ctx context.Context, tx DBTX, id, actor string) error {
-	isWisp := IsActiveWispInTx(ctx, tx, id)
-	issueTable, _, _, _ := WispTableRouting(isWisp)
-
 	now := time.Now().UTC()
-	leaseClause, leaseArgs := leaseSetClause(now, leaseTTL(ctx))
-
-	// Stamp updated_at = now on the heartbeat. On Dolt/MySQL the issues/wisps
-	// ON UPDATE CURRENT_TIMESTAMP trigger bumps updated_at on every heartbeat;
-	// Postgres and SQLite have no such trigger, so without an explicit stamp an
-	// actively-heartbeated issue keeps a stale updated_at and bd stale (which
-	// filters in_progress rows on updated_at < cutoff) diverges from the Dolt
-	// oracle. Claim already stamps updated_at explicitly, so this is heartbeat-only.
-	args := append([]interface{}{}, leaseArgs...)
-	args = append(args, now, id, actor)
-	result, err := tx.ExecContext(ctx, fmt.Sprintf(`
-		UPDATE %s SET %s, updated_at = ?
-		WHERE id = ? AND status = 'in_progress' AND assignee = ?
-	`, issueTable, leaseClause), args...)
+	result, err := tx.ExecContext(ctx, `
+		UPDATE leases SET lease_expires_at = ?, heartbeat_at = ?
+		WHERE issue_id = ? AND holder = ?
+	`, now.Add(leaseTTL(ctx)), now, id, actor)
 	if err != nil {
 		return fmt.Errorf("failed to heartbeat issue: %w", err)
 	}
@@ -136,8 +234,11 @@ func HeartbeatIssueInTx(ctx context.Context, tx DBTX, id, actor string) error {
 		return fmt.Errorf("failed to get rows affected: %w", err)
 	}
 	if rows == 0 {
-		// Disambiguate for the caller: gone (closed/reopened/reclaimed),
-		// not-found, or owned by someone else.
+		// No lease row. Disambiguate from the issue row: gone
+		// (closed/reopened/reclaimed), not-found, owned by someone else, or a
+		// wisp (never leased).
+		isWisp := IsActiveWispInTx(ctx, tx, id)
+		issueTable, _, _, _ := WispTableRouting(isWisp)
 		var assignee, status string
 		qerr := tx.QueryRowContext(ctx,
 			fmt.Sprintf("SELECT COALESCE(assignee, ''), status FROM %s WHERE id = ?", issueTable), id,
@@ -148,18 +249,30 @@ func HeartbeatIssueInTx(ctx context.Context, tx DBTX, id, actor string) error {
 		if assignee != "" && assignee != actor {
 			return fmt.Errorf("%w by %s", storage.ErrAlreadyClaimed, assignee)
 		}
+		if !isWisp && assignee == actor && status == string(types.StatusInProgress) {
+			// The caller genuinely holds the claim but has no lease row — e.g.
+			// the claim was hand-doled through a generic update (which never
+			// arms a lease, bd-9hpgf) and the worker is now opting into lease
+			// semantics. A real worker's heartbeat re-arms recovery.
+			return UpsertLeaseInTx(ctx, tx, id, actor, now, leaseTTL(ctx))
+		}
 		return fmt.Errorf("%w: %s status %s", storage.ErrNotClaimable, id, status)
 	}
 	return nil
 }
 
 // ReclaimExpiredLeasesInTx reverts in_progress issues whose lease has gone stale
-// back to ready: status → open, assignee cleared, started_at cleared, and a
-// fresh row_lock so the reclaim conflicts with a racing heartbeat/close on the
-// same row (see freshRowLock). An issue is stale when its lease_expires_at is
-// non-null and strictly before cutoff. Callers pass cutoff = now - graceWindow
-// (the supervisor uses graceWindow = 2×TTL) so only leases that expired a safe
-// margin ago — i.e. workers that are almost certainly dead — are reclaimed.
+// back to ready: the lease row is deleted, then status → open, assignee cleared,
+// started_at cleared, and a fresh row_lock so the reclaim conflicts with a
+// racing close/update on the same issues row (see freshRowLock). An issue is
+// stale when its lease row's lease_expires_at is strictly before cutoff.
+// Callers pass cutoff = now - graceWindow (the supervisor uses graceWindow =
+// 2×TTL) so only leases that expired a safe margin ago — i.e. workers that are
+// almost certainly dead — are reclaimed.
+//
+// Leases are node-local (the leases table is dolt_ignored and does not
+// replicate), so a reclaim can only recover claims granted through this node —
+// which is the only place the lease was ever enforceable anyway.
 //
 // Reclaim only ever touches the permanent issues table: wisps are ephemeral and
 // are never leased work. Returns the issues it reverted (id + the owner it took
@@ -167,15 +280,15 @@ func HeartbeatIssueInTx(ctx context.Context, tx DBTX, id, actor string) error {
 // Dolt versioning.
 func ReclaimExpiredLeasesInTx(ctx context.Context, tx DBTX, cutoff time.Time, actor string) ([]types.ReclaimedLease, error) {
 	// Snapshot the stale set first so we can report exactly which issues we
-	// reverted and record per-issue recovery events. The UPDATE below repeats
-	// the predicate, so an issue that a concurrent heartbeat rescued between the
-	// SELECT and the UPDATE is simply skipped (0 rows) — it never appears as
-	// reclaimed.
+	// reverted and record per-issue recovery events. The DELETE below repeats
+	// the expiry predicate, so an issue that a concurrent heartbeat rescued
+	// between the SELECT and the DELETE is simply skipped (0 rows) — it never
+	// appears as reclaimed.
 	rows, err := tx.QueryContext(ctx, `
-		SELECT id, COALESCE(assignee, '') FROM issues
-		WHERE status = 'in_progress'
-		  AND lease_expires_at IS NOT NULL
-		  AND lease_expires_at < ?
+		SELECT l.issue_id, COALESCE(i.assignee, '') FROM leases l
+		JOIN issues i ON i.id = l.issue_id
+		WHERE i.status = 'in_progress'
+		  AND l.lease_expires_at < ?
 	`, cutoff)
 	if err != nil {
 		return nil, fmt.Errorf("scan for stale leases: %w", err)
@@ -202,18 +315,14 @@ func ReclaimExpiredLeasesInTx(ctx context.Context, tx DBTX, cutoff time.Time, ac
 
 	var reclaimed []types.ReclaimedLease
 	for _, r := range stale {
-		// Re-check the predicate inside the UPDATE so a heartbeat that landed
-		// after the snapshot (pushing lease_expires_at back into the future, or
-		// the row already closed) cannot be clobbered. row_lock makes the racing
-		// writer conflict; this WHERE makes a winning racer's rescue stick.
+		// Re-check the expiry inside the DELETE so a heartbeat that landed
+		// after the snapshot (pushing lease_expires_at back into the future)
+		// cannot be clobbered: heartbeat and reclaim contend on this same lease
+		// row, so one of a racing pair is forced to retry, and a winning
+		// rescuer's pushed-out expiry makes this DELETE match nothing.
 		res, err := tx.ExecContext(ctx, `
-			UPDATE issues
-			SET status = 'open', assignee = NULL, started_at = NULL,
-			    lease_expires_at = NULL, heartbeat_at = NULL,
-			    updated_at = ?, row_lock = ?
-			WHERE id = ? AND status = 'in_progress'
-			  AND lease_expires_at IS NOT NULL AND lease_expires_at < ?
-		`, time.Now().UTC(), freshRowLock(), r.ID, cutoff)
+			DELETE FROM leases WHERE issue_id = ? AND lease_expires_at < ?
+		`, r.ID, cutoff)
 		if err != nil {
 			return nil, fmt.Errorf("reclaim %s: %w", r.ID, err)
 		}
@@ -222,7 +331,27 @@ func ReclaimExpiredLeasesInTx(ctx context.Context, tx DBTX, cutoff time.Time, ac
 			return nil, fmt.Errorf("reclaim %s rows affected: %w", r.ID, err)
 		}
 		if n == 0 {
-			continue // rescued by a concurrent heartbeat/close — leave it be
+			continue // rescued by a concurrent heartbeat — leave it be
+		}
+		// Revert the issue itself. status is re-checked so a row that stopped
+		// being in_progress under us (closed) is left alone; row_lock makes a
+		// concurrent close/update conflict at commit time rather than
+		// cell-merge with this write.
+		res, err = tx.ExecContext(ctx, `
+			UPDATE issues
+			SET status = 'open', assignee = NULL, started_at = NULL,
+			    updated_at = ?, row_lock = ?
+			WHERE id = ? AND status = 'in_progress'
+		`, time.Now().UTC(), freshRowLock(), r.ID)
+		if err != nil {
+			return nil, fmt.Errorf("reclaim %s: %w", r.ID, err)
+		}
+		n, err = res.RowsAffected()
+		if err != nil {
+			return nil, fmt.Errorf("reclaim %s rows affected: %w", r.ID, err)
+		}
+		if n == 0 {
+			continue // no longer in_progress — its lease row was stale anyway
 		}
 		if err := RecordFullEventInTable(ctx, tx, "events", r.ID, types.EventLeaseReclaimed, actor,
 			r.PreviousOwner, ""); err != nil {

--- a/internal/storage/issueops/search.go
+++ b/internal/storage/issueops/search.go
@@ -47,14 +47,18 @@ type searchProjection[T any] struct {
 	// limited queries. Worth it only for wide projections; the id projection
 	// already scans id-only with no hydration, so it leaves this false.
 	idShrink bool
+	// joinLeases adds the leases LEFT JOIN to the FROM clause; required by
+	// any projection whose columns include sqlbuild.LeaseSelectColumns.
+	joinLeases bool
 }
 
 var issueProjection = searchProjection[*types.Issue]{
-	columns:  func(_ FilterTables) string { return IssueSelectColumns },
-	scan:     func(rows *sql.Rows) (*types.Issue, error) { return ScanIssueFrom(rows) },
-	id:       func(issue *types.Issue) string { return issue.ID },
-	hydrate:  hydrateIssueLabelsAndDeps,
-	idShrink: true,
+	columns:    func(_ FilterTables) string { return IssueSelectColumns },
+	scan:       func(rows *sql.Rows) (*types.Issue, error) { return ScanIssueFrom(rows) },
+	id:         func(issue *types.Issue) string { return issue.ID },
+	hydrate:    hydrateIssueLabelsAndDeps,
+	idShrink:   true,
+	joinLeases: true,
 }
 
 var idProjection = searchProjection[string]{
@@ -211,9 +215,14 @@ func searchTableInTxT[T any](ctx context.Context, tx DBTX, query string, filter 
 	if plan.Distinct {
 		selectKeyword = "SELECT DISTINCT "
 	}
+	fromSQL := plan.FromSQL
+	if proj.joinLeases {
+		fromSQL += " " + sqlbuild.LeaseJoin(tables.Main)
+	}
+
 	//nolint:gosec // G201: SQL fragments are built from fixed table/column names and parameterized filters.
 	querySQL := fmt.Sprintf(`%s%s FROM %s %s %s %s`,
-		selectKeyword, proj.columns(tables), plan.FromSQL, whereSQL, sqlbuild.OrderBy(filter.SortBy, filter.SortDesc, ""), limitSQL)
+		selectKeyword, proj.columns(tables), fromSQL, whereSQL, sqlbuild.OrderBy(filter.SortBy, filter.SortDesc, ""), limitSQL)
 
 	rows, err := tx.QueryContext(ctx, querySQL, args...)
 	if err != nil {
@@ -272,9 +281,13 @@ func searchTablePatternBT[T any](ctx context.Context, tx DBTX, query string, fil
 		placeholders[i] = "?"
 		fetchArgs[i] = id
 	}
+	fetchFrom := tables.Main
+	if proj.joinLeases {
+		fetchFrom += " " + sqlbuild.LeaseJoin(tables.Main)
+	}
 	//nolint:gosec // G201: column expression and table name are fixed; ids are parameterized.
 	fetchSQL := fmt.Sprintf(`SELECT %s FROM %s WHERE id IN (%s)`,
-		proj.columns(tables), tables.Main, strings.Join(placeholders, ","))
+		proj.columns(tables), fetchFrom, strings.Join(placeholders, ","))
 
 	fetchRows, err := tx.QueryContext(ctx, fetchSQL, fetchArgs...)
 	if err != nil {

--- a/internal/storage/issueops/stale.go
+++ b/internal/storage/issueops/stale.go
@@ -23,17 +23,24 @@ func GetStaleIssuesInTx(ctx context.Context, tx *sql.Tx, filter types.StaleFilte
 		statusClause = "status = ?"
 	}
 
+	// Heartbeats live in the ephemeral leases table and no longer stamp
+	// issues.updated_at (bd-lrgn1), so an actively-worked claim can carry an
+	// old updated_at: an issue with a heartbeat since the cutoff is not stale.
 	query := fmt.Sprintf(`
 		SELECT id FROM issues
 		WHERE updated_at < ?
 		  AND %s
 		  AND (ephemeral = 0 OR ephemeral IS NULL)
+		  AND NOT EXISTS (
+			SELECT 1 FROM leases WHERE leases.issue_id = issues.id AND leases.heartbeat_at >= ?
+		  )
 		ORDER BY updated_at ASC
 	`, statusClause)
 	args := []interface{}{cutoff}
 	if filter.Status != "" {
 		args = append(args, filter.Status)
 	}
+	args = append(args, cutoff) // NOT EXISTS heartbeat cutoff, after any status arg
 
 	if filter.Limit > 0 {
 		query += fmt.Sprintf(" LIMIT %d", filter.Limit)

--- a/internal/storage/issueops/unclaim.go
+++ b/internal/storage/issueops/unclaim.go
@@ -12,9 +12,9 @@ import (
 )
 
 // UnclaimIssueInTx atomically releases a claimed issue: it clears the assignee,
-// resets status to "open", clears the lease columns (lease_expires_at,
-// heartbeat_at, started_at) and rewrites row_lock so a concurrent heartbeat or
-// reclaim on the same row conflicts rather than silently cell-merging (see the
+// resets status to "open", clears started_at, deletes the issue's lease row
+// (see UpsertLeaseInTx) and rewrites row_lock so a concurrent reclaim or close
+// on the same row conflicts rather than silently cell-merging (see the
 // row_lock invariant in lease.go). Records an "unclaimed" event.
 //
 // Ownership: only the current assignee may release its own claim. A mismatched
@@ -60,11 +60,11 @@ func UnclaimIssueInTx(ctx context.Context, tx *sql.Tx, id string, actor string, 
 
 	now := time.Now().UTC()
 
-	// Atomic UPDATE: clear assignee, reset status to open, clear the lease
-	// columns, and rewrite row_lock. The predicate re-checks ownership (unless
-	// forced) so a claim that changed hands between the read above and this
-	// write is not clobbered. row_lock forces a racing heartbeat/reclaim on the
-	// same row to conflict rather than silently merge (see lease.go invariant).
+	// Atomic UPDATE: clear assignee, reset status to open, clear started_at,
+	// and rewrite row_lock. The predicate re-checks ownership (unless forced)
+	// so a claim that changed hands between the read above and this write is
+	// not clobbered. row_lock forces a racing reclaim/close on the same row to
+	// conflict rather than silently merge (see lease.go invariant).
 	ownerPredicate := "AND assignee = ?"
 	args := []interface{}{now, freshRowLock(), id, actor}
 	if force {
@@ -75,8 +75,7 @@ func UnclaimIssueInTx(ctx context.Context, tx *sql.Tx, id string, actor string, 
 	result, err := tx.ExecContext(ctx, fmt.Sprintf(`
 		UPDATE %s
 		SET assignee = '', status = 'open', updated_at = ?,
-		    lease_expires_at = NULL, heartbeat_at = NULL, started_at = NULL,
-		    row_lock = ?
+		    started_at = NULL, row_lock = ?
 		WHERE id = ? AND status IN ('open', 'in_progress') %s
 	`, issueTable, ownerPredicate), args...)
 	if err != nil {
@@ -101,6 +100,12 @@ func UnclaimIssueInTx(ctx context.Context, tx *sql.Tx, id string, actor string, 
 				storage.ErrNotOwner, id, current.Assignee)
 		}
 		return fmt.Errorf("failed to unclaim issue %s: no matching row", id)
+	}
+
+	// The claim is over: drop its lease row (no-op when none exists, e.g. a
+	// wisp or an open-but-assigned issue that was never leased).
+	if err := DeleteLeaseInTx(ctx, tx, id); err != nil {
+		return err
 	}
 
 	// Record the unclaim event

--- a/internal/storage/issueops/update.go
+++ b/internal/storage/issueops/update.go
@@ -102,13 +102,16 @@ func ManageStartedAt(oldIssue *types.Issue, updates map[string]interface{}, setC
 //     down against the new holder — clear it. The new holder gets a lease only
 //     via the claim verb; a real worker's next heartbeat re-arms one.
 //   - the update leaves the same claim in place (already in_progress, same
-//     assignee): leave the lease columns untouched, so a worker's live lease
-//     survives unrelated edits to its issue.
-func ManageLeaseOnUpdate(oldIssue *types.Issue, updates map[string]interface{}, setClauses []string, args []interface{}) ([]string, []interface{}) {
+//     assignee): leave the lease untouched, so a worker's live lease survives
+//     unrelated edits to its issue.
+//
+// Returns true when the update ends/transfers the claim and the issue's lease
+// row must be deleted (DeleteLeaseInTx) after the row update.
+func ManageLeaseOnUpdate(oldIssue *types.Issue, updates map[string]interface{}) bool {
 	rawStatus, hasStatus := updates["status"]
 	rawAssignee, hasAssignee := updates["assignee"]
 	if !hasStatus && !hasAssignee {
-		return setClauses, args
+		return false
 	}
 
 	newStatus := string(oldIssue.Status)
@@ -119,7 +122,7 @@ func ManageLeaseOnUpdate(oldIssue *types.Issue, updates map[string]interface{}, 
 		case types.Status:
 			newStatus = string(v)
 		default:
-			return setClauses, args
+			return false
 		}
 	}
 
@@ -137,12 +140,7 @@ func ManageLeaseOnUpdate(oldIssue *types.Issue, updates map[string]interface{}, 
 
 	sameClaim := newStatus == string(types.StatusInProgress) && newAssignee != "" &&
 		oldIssue.Status == types.StatusInProgress && newAssignee == oldIssue.Assignee
-	if sameClaim {
-		return setClauses, args
-	}
-
-	setClauses = append(setClauses, "lease_expires_at = NULL", "heartbeat_at = NULL")
-	return setClauses, args
+	return !sameClaim
 }
 
 // DetermineEventType returns the appropriate event type for an update.
@@ -275,13 +273,13 @@ func updateIssueInTx(ctx context.Context, tx DBTX, id string, updates map[string
 
 	// Auto-manage leases when direct updates change status or assignee.
 	// Clears stale leases only; arming is reserved for claim/heartbeat.
-	setClauses, args = ManageLeaseOnUpdate(oldIssue, updates, setClauses, args)
+	clearLease := ManageLeaseOnUpdate(oldIssue, updates)
 
-	// Rewrite row_lock on every update so a concurrent lease mutation (heartbeat/
-	// reclaim) collides on this shared cell and is forced to conflict-and-retry
-	// rather than silently cell-merging two writes to different columns of the
-	// same row (see lease.go). This is the "every mutating path writes row_lock"
-	// invariant the lease scheme depends on.
+	// Rewrite row_lock on every update so a concurrent status/ownership
+	// mutation (reclaim/close) collides on this shared cell and is forced to
+	// conflict-and-retry rather than silently cell-merging two writes to
+	// different columns of the same row (see lease.go). This is the "every
+	// mutating path writes row_lock" invariant the lease scheme depends on.
 	setClauses = append(setClauses, "row_lock = ?")
 	args = append(args, freshRowLock())
 
@@ -291,6 +289,12 @@ func updateIssueInTx(ctx context.Context, tx DBTX, id string, updates map[string
 	query := fmt.Sprintf("UPDATE %s SET %s WHERE id = ?", issueTable, strings.Join(setClauses, ", "))
 	if _, err := tx.ExecContext(ctx, query, args...); err != nil {
 		return nil, fmt.Errorf("failed to update issue: %w", err)
+	}
+
+	if clearLease {
+		if err := DeleteLeaseInTx(ctx, tx, id); err != nil {
+			return nil, err
+		}
 	}
 
 	if recordEvent {

--- a/internal/storage/issueops/update_test.go
+++ b/internal/storage/issueops/update_test.go
@@ -1,7 +1,6 @@
 package issueops
 
 import (
-	"reflect"
 	"testing"
 
 	"github.com/steveyegge/beads/internal/types"
@@ -9,12 +8,10 @@ import (
 
 // TestManageLeaseOnUpdate pins the clear-only contract (bd-9hpgf, GH#4716):
 // generic updates never arm a lease — arming belongs to claim/heartbeat. The
-// helper clears the lease columns whenever the update leaves the claimed state
-// or changes who holds the claim, and leaves them untouched when the same
-// claim stays in place.
+// helper reports that the lease row must be dropped (DeleteLeaseInTx) whenever
+// the update leaves the claimed state or changes who holds the claim, and
+// leaves the lease untouched when the same claim stays in place.
 func TestManageLeaseOnUpdate(t *testing.T) {
-	const clearClause = "lease_expires_at = NULL"
-
 	tests := []struct {
 		name      string
 		oldStatus types.Status
@@ -82,29 +79,9 @@ func TestManageLeaseOnUpdate(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			oldIssue := &types.Issue{Status: tt.oldStatus, Assignee: tt.oldOwner}
-			inClauses := []string{"updated_at = ?"}
-			inArgs := []interface{}{"now"}
 
-			gotClauses, gotArgs := ManageLeaseOnUpdate(oldIssue, tt.updates, inClauses, inArgs)
-
-			cleared := false
-			for _, c := range gotClauses {
-				if c == clearClause {
-					cleared = true
-				}
-			}
-			if cleared != tt.wantClear {
-				t.Errorf("clear = %v, want %v (clauses: %v)", cleared, tt.wantClear, gotClauses)
-			}
-			// The helper must never arm: no new args beyond what came in, and no
-			// parameterized lease clause.
-			if !reflect.DeepEqual(gotArgs, inArgs) {
-				t.Errorf("args changed — generic update must never stamp lease values: %v", gotArgs)
-			}
-			for _, c := range gotClauses {
-				if c == "lease_expires_at = ?" || c == "heartbeat_at = ?" {
-					t.Errorf("generic update armed a lease via clause %q", c)
-				}
+			if cleared := ManageLeaseOnUpdate(oldIssue, tt.updates); cleared != tt.wantClear {
+				t.Errorf("clear = %v, want %v", cleared, tt.wantClear)
 			}
 		})
 	}

--- a/internal/storage/mysql/schema.sql
+++ b/internal/storage/mysql/schema.sql
@@ -53,8 +53,6 @@ CREATE TABLE IF NOT EXISTS `issues` (
   `no_history` tinyint(1) DEFAULT '0',
   `started_at` datetime,
   `is_blocked` tinyint(1) NOT NULL DEFAULT '0',
-  `lease_expires_at` datetime,
-  `heartbeat_at` datetime,
   `row_lock` bigint NOT NULL DEFAULT 0,
   PRIMARY KEY (`id`),
   KEY `idx_issues_assignee` (`assignee`),
@@ -65,8 +63,19 @@ CREATE TABLE IF NOT EXISTS `issues` (
   KEY `idx_issues_issue_type` (`issue_type`),
   KEY `idx_issues_priority` (`priority`),
   KEY `idx_issues_spec_id` (`spec_id`(191)),
-  KEY `idx_issues_status_updated_at` (`status`,`updated_at`),
-  KEY `idx_issues_lease` (`status`,`lease_expires_at`)
+  KEY `idx_issues_status_updated_at` (`status`,`updated_at`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;
+
+-- Ephemeral claim leases (bd-lrgn1): node-local, never exported by backup.
+-- One row per live claim; see issueops.UpsertLeaseInTx for the invariant.
+CREATE TABLE IF NOT EXISTS `leases` (
+  `issue_id` varchar(255) NOT NULL,
+  `holder` varchar(255) NOT NULL,
+  `granted_at` datetime NOT NULL,
+  `lease_expires_at` datetime NOT NULL,
+  `heartbeat_at` datetime NOT NULL,
+  PRIMARY KEY (`issue_id`),
+  KEY `idx_leases_expires` (`lease_expires_at`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;
 
 
@@ -125,8 +134,6 @@ CREATE TABLE IF NOT EXISTS `wisps` (
   `no_history` tinyint(1) DEFAULT '0',
   `started_at` datetime,
   `is_blocked` tinyint(1) NOT NULL DEFAULT '0',
-  `lease_expires_at` datetime,
-  `heartbeat_at` datetime,
   `row_lock` bigint NOT NULL DEFAULT 0,
   PRIMARY KEY (`id`),
   KEY `idx_wisps_assignee` (`assignee`),

--- a/internal/storage/mysql/schema.sql
+++ b/internal/storage/mysql/schema.sql
@@ -67,7 +67,7 @@ CREATE TABLE IF NOT EXISTS `issues` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin;
 
 -- Ephemeral claim leases (bd-lrgn1): node-local, never exported by backup.
--- One row per live claim; see issueops.UpsertLeaseInTx for the invariant.
+-- One row per live claim. See issueops.UpsertLeaseInTx for the invariant.
 CREATE TABLE IF NOT EXISTS `leases` (
   `issue_id` varchar(255) NOT NULL,
   `holder` varchar(255) NOT NULL,

--- a/internal/storage/pgdialect/corpus_test.go
+++ b/internal/storage/pgdialect/corpus_test.go
@@ -60,8 +60,8 @@ func searchSelectSQL(tables sqlbuild.FilterTables, query string, filter types.Is
 	if plan.Distinct {
 		selectKw = "SELECT DISTINCT "
 	}
-	return fmt.Sprintf("%s%s FROM %s %s %s",
-		selectKw, sqlbuild.IssueSelectColumns, plan.FromSQL, whereSQL,
+	return fmt.Sprintf("%s%s FROM %s %s %s %s",
+		selectKw, sqlbuild.IssueSelectColumns, plan.FromSQL, sqlbuild.LeaseJoin(tables.Main), whereSQL,
 		sqlbuild.OrderBy(filter.SortBy, filter.SortDesc, "")), nil
 }
 
@@ -262,6 +262,8 @@ func createScratchSchema(ctx context.Context, db *sql.DB, schema string) error {
 		fmt.Sprintf(`CREATE SCHEMA IF NOT EXISTS %q`, schema),
 		issueTableDDL("issues"),
 		issueTableDDL("wisps"),
+		`CREATE TABLE leases (issue_id text, holder text, granted_at timestamp(0),
+			lease_expires_at timestamp(0), heartbeat_at timestamp(0))`,
 		`CREATE TABLE labels (issue_id text, label text)`,
 		`CREATE TABLE wisp_labels (issue_id text, label text)`,
 		depTableDDL("dependencies"),
@@ -281,11 +283,13 @@ func createScratchSchema(ctx context.Context, db *sql.DB, schema string) error {
 }
 
 // issueTableDDL renders a CREATE TABLE for the issues/wisps family from
-// IssueSelectColumns plus the derived is_blocked column the ready-work WHERE
-// reads. Column types are faithful where an operator depends on them.
+// IssueBaseColumns plus the derived is_blocked column the ready-work WHERE
+// reads. The lease overlay columns live in the separate leases table
+// (bd-lrgn1), created explicitly in createScratchSchema. Column types are
+// faithful where an operator depends on them.
 func issueTableDDL(table string) string {
 	var defs []string
-	for _, name := range splitColumnList(sqlbuild.IssueSelectColumns) {
+	for _, name := range splitColumnList(sqlbuild.IssueBaseColumns) {
 		defs = append(defs, name+" "+pgColumnType(name))
 	}
 	defs = append(defs, "is_blocked smallint NOT NULL DEFAULT 0")

--- a/internal/storage/pgdialect/translate.go
+++ b/internal/storage/pgdialect/translate.go
@@ -526,6 +526,7 @@ var onConflictTargets = map[string]string{
 	"wisp_child_counters": "parent_id",
 	"repo_mtimes":         "repo_path",
 	"federation_peers":    "name",
+	"leases":              "issue_id",
 }
 
 // rewriteOnDuplicateKey converts `… ON DUPLICATE KEY UPDATE <body>` into

--- a/internal/storage/pgdialect/translate_test.go
+++ b/internal/storage/pgdialect/translate_test.go
@@ -44,6 +44,16 @@ func TestTranslate(t *testing.T) {
 			want: `INSERT INTO issues (id, title, updated_at) VALUES ($1, $2, $3) ON CONFLICT (id) DO UPDATE SET title = CASE WHEN EXCLUDED.updated_at > updated_at THEN EXCLUDED.title ELSE title END`,
 		},
 		{
+			name: "lease upsert with (issue_id) target (bd-lrgn1)",
+			in:   `INSERT INTO leases (issue_id, holder, granted_at, lease_expires_at, heartbeat_at) VALUES (?, ?, ?, ?, ?) ON DUPLICATE KEY UPDATE holder = VALUES(holder), lease_expires_at = VALUES(lease_expires_at)`,
+			want: `INSERT INTO leases (issue_id, holder, granted_at, lease_expires_at, heartbeat_at) VALUES ($1, $2, $3, $4, $5) ON CONFLICT (issue_id) DO UPDATE SET holder = EXCLUDED.holder, lease_expires_at = EXCLUDED.lease_expires_at`,
+		},
+		{
+			name: "lease import-restore never-clobber-live guard (bd-lrgn1)",
+			in:   `INSERT INTO leases (issue_id, holder) VALUES (?, ?) ON DUPLICATE KEY UPDATE holder = IF(leases.lease_expires_at >= ?, leases.holder, VALUES(holder))`,
+			want: `INSERT INTO leases (issue_id, holder) VALUES ($1, $2) ON CONFLICT (issue_id) DO UPDATE SET holder = CASE WHEN leases.lease_expires_at >= $3 THEN leases.holder ELSE EXCLUDED.holder END`,
+		},
+		{
 			name: "child counter GREATEST upsert with (parent_id) target",
 			in:   `INSERT INTO child_counters (parent_id, last_child) VALUES (?, ?) ON DUPLICATE KEY UPDATE last_child = GREATEST(last_child, ?)`,
 			want: `INSERT INTO child_counters (parent_id, last_child) VALUES ($1, $2) ON CONFLICT (parent_id) DO UPDATE SET last_child = GREATEST(last_child, $3)`,

--- a/internal/storage/postgres/schema.go
+++ b/internal/storage/postgres/schema.go
@@ -107,8 +107,6 @@ CREATE TABLE IF NOT EXISTS issues (
     no_history          smallint DEFAULT 0,
     started_at          timestamp(0),
     is_blocked          smallint NOT NULL DEFAULT 0,
-    lease_expires_at    timestamp(0),
-    heartbeat_at        timestamp(0),
     row_lock            bigint NOT NULL DEFAULT 0,
     PRIMARY KEY (id)
 );
@@ -122,7 +120,21 @@ CREATE INDEX IF NOT EXISTS idx_issues_issue_type        ON issues (issue_type);
 CREATE INDEX IF NOT EXISTS idx_issues_priority          ON issues (priority);
 CREATE INDEX IF NOT EXISTS idx_issues_spec_id           ON issues (spec_id);
 CREATE INDEX IF NOT EXISTS idx_issues_status_updated_at ON issues (status, updated_at);
-CREATE INDEX IF NOT EXISTS idx_issues_lease             ON issues (status, lease_expires_at);
+
+-- ============================================================ leases
+-- Ephemeral claim leases (bd-lrgn1): node-local, never exported by backup.
+-- One row per live claim; see issueops.UpsertLeaseInTx for the invariant.
+
+CREATE TABLE IF NOT EXISTS leases (
+    issue_id            text NOT NULL,
+    holder              text NOT NULL,
+    granted_at          timestamp(0) NOT NULL,
+    lease_expires_at    timestamp(0) NOT NULL,
+    heartbeat_at        timestamp(0) NOT NULL,
+    PRIMARY KEY (issue_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_leases_expires ON leases (lease_expires_at);
 
 -- ============================================================ wisps
 
@@ -181,8 +193,6 @@ CREATE TABLE IF NOT EXISTS wisps (
     no_history          smallint DEFAULT 0,
     started_at          timestamp(0),
     is_blocked          smallint NOT NULL DEFAULT 0,
-    lease_expires_at    timestamp(0),
-    heartbeat_at        timestamp(0),
     row_lock            bigint NOT NULL DEFAULT 0,
     PRIMARY KEY (id)
 );

--- a/internal/storage/schema/cli_migrations.go
+++ b/internal/storage/schema/cli_migrations.go
@@ -54,6 +54,12 @@ func cliCompatibleMigrationSQL(name, sqlText string) string {
 		// apply the prepared ALTER TABLE statements the runtime migration uses
 		// for idempotent re-runs on upgraded databases.
 		return cliMigration0054AddLeaseColumns
+	case "0055_move_leases_to_table.up.sql":
+		// Direct DDL for the same reason as 0054. A fresh bundle has no live
+		// leases to copy (0054 just added empty columns), so this is pure
+		// schema delta: create the ephemeral leases table, drop the issues/
+		// wisps lease columns 0054 added. row_lock stays (see the migration).
+		return cliMigration0055MoveLeasesToTable
 	default:
 		return sqlText
 	}
@@ -80,6 +86,20 @@ CREATE INDEX idx_issues_lease ON issues (status, lease_expires_at);
 ALTER TABLE wisps ADD COLUMN lease_expires_at DATETIME;
 ALTER TABLE wisps ADD COLUMN heartbeat_at DATETIME;
 ALTER TABLE wisps ADD COLUMN row_lock BIGINT NOT NULL DEFAULT 0;`
+
+const cliMigration0055MoveLeasesToTable = `CREATE TABLE leases (
+    issue_id VARCHAR(255) PRIMARY KEY,
+    holder VARCHAR(255) NOT NULL,
+    granted_at DATETIME NOT NULL,
+    lease_expires_at DATETIME NOT NULL,
+    heartbeat_at DATETIME NOT NULL,
+    INDEX idx_leases_expires (lease_expires_at)
+);
+ALTER TABLE issues DROP INDEX idx_issues_lease;
+ALTER TABLE issues DROP COLUMN lease_expires_at;
+ALTER TABLE issues DROP COLUMN heartbeat_at;
+ALTER TABLE wisps DROP COLUMN lease_expires_at;
+ALTER TABLE wisps DROP COLUMN heartbeat_at;`
 
 const cliMigration0041SplitDependenciesTarget = `DELETE FROM dolt_nonlocal_tables;
 CALL DOLT_COMMIT('-Am', 'disable nonlocal tables for fk migrations');

--- a/internal/storage/schema/migrations/0055_move_leases_to_table.down.sql
+++ b/internal/storage/schema/migrations/0055_move_leases_to_table.down.sql
@@ -1,0 +1,69 @@
+-- Roll back the lease move (bd-lrgn1): re-add the issues/wisps lease columns,
+-- copy live leases back onto their issue rows, and drop the leases table.
+-- Guarded statement-by-statement like the up migration.
+
+SET @sql = IF(
+  (SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = 'issues'
+      AND COLUMN_NAME = 'lease_expires_at') = 0,
+  'ALTER TABLE issues ADD COLUMN lease_expires_at DATETIME',
+  'SELECT 1'
+);
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @sql = IF(
+  (SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = 'issues'
+      AND COLUMN_NAME = 'heartbeat_at') = 0,
+  'ALTER TABLE issues ADD COLUMN heartbeat_at DATETIME',
+  'SELECT 1'
+);
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @has_idx = (
+    SELECT COUNT(*) FROM INFORMATION_SCHEMA.STATISTICS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = 'issues'
+      AND INDEX_NAME = 'idx_issues_lease'
+);
+SET @sql = IF(@has_idx = 0,
+    'CREATE INDEX idx_issues_lease ON issues (status, lease_expires_at)',
+    'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @has_leases = (
+    SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES
+    WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'leases'
+);
+SET @sql = IF(@has_leases > 0,
+    'UPDATE issues i JOIN leases l ON l.issue_id = i.id
+     SET i.lease_expires_at = l.lease_expires_at, i.heartbeat_at = l.heartbeat_at
+     WHERE i.status = ''in_progress''',
+    'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @has_wisps = (
+    SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES
+    WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'wisps'
+);
+SET @sql = IF(@has_wisps > 0 AND
+    (SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
+        WHERE TABLE_SCHEMA = DATABASE()
+          AND TABLE_NAME = 'wisps'
+          AND COLUMN_NAME = 'lease_expires_at') = 0,
+    'ALTER TABLE wisps ADD COLUMN lease_expires_at DATETIME',
+    'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @sql = IF(@has_wisps > 0 AND
+    (SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
+        WHERE TABLE_SCHEMA = DATABASE()
+          AND TABLE_NAME = 'wisps'
+          AND COLUMN_NAME = 'heartbeat_at') = 0,
+    'ALTER TABLE wisps ADD COLUMN heartbeat_at DATETIME',
+    'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+DROP TABLE IF EXISTS leases;

--- a/internal/storage/schema/migrations/0055_move_leases_to_table.up.sql
+++ b/internal/storage/schema/migrations/0055_move_leases_to_table.up.sql
@@ -58,38 +58,33 @@ SET @sql = IF(@has_col > 0,
     'SELECT 1');
 PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
 
--- 3. Drop the lease index and columns from issues.
+-- 3. Drop the lease index and columns from issues. One combined ALTER (each
+-- ALTER is a table rewrite; fresh chains run 0054 add + 0055 drop, so keep
+-- this cheap). Clauses are guarded individually so a partially-applied
+-- earlier run re-runs as a no-op.
 SET @has_index = (
     SELECT COUNT(*) FROM INFORMATION_SCHEMA.STATISTICS
     WHERE TABLE_SCHEMA = DATABASE()
       AND TABLE_NAME = 'issues'
       AND INDEX_NAME = 'idx_issues_lease'
 );
-SET @sql = IF(@has_index > 0,
-    'ALTER TABLE issues DROP INDEX idx_issues_lease',
-    'SELECT 1');
-PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
-
-SET @has_col = (
+SET @has_lease_col = (
     SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
     WHERE TABLE_SCHEMA = DATABASE()
       AND TABLE_NAME = 'issues'
       AND COLUMN_NAME = 'lease_expires_at'
 );
-SET @sql = IF(@has_col > 0,
-    'ALTER TABLE issues DROP COLUMN lease_expires_at',
-    'SELECT 1');
-PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
-
-SET @has_col = (
+SET @has_hb_col = (
     SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
     WHERE TABLE_SCHEMA = DATABASE()
       AND TABLE_NAME = 'issues'
       AND COLUMN_NAME = 'heartbeat_at'
 );
-SET @sql = IF(@has_col > 0,
-    'ALTER TABLE issues DROP COLUMN heartbeat_at',
-    'SELECT 1');
+SET @clauses = CONCAT_WS(', ',
+    IF(@has_index > 0, 'DROP INDEX idx_issues_lease', NULL),
+    IF(@has_lease_col > 0, 'DROP COLUMN lease_expires_at', NULL),
+    IF(@has_hb_col > 0, 'DROP COLUMN heartbeat_at', NULL));
+SET @sql = IF(@clauses = '', 'SELECT 1', CONCAT('ALTER TABLE issues ', @clauses));
 PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
 
 -- 4. Drop the (never-reclaimed, now entirely unread) lease columns from wisps.
@@ -102,24 +97,20 @@ SET @has_wisps = (
     WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'wisps'
 );
 
-SET @has_col = IF(@has_wisps > 0,
+SET @has_lease_col = IF(@has_wisps > 0,
     (SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
         WHERE TABLE_SCHEMA = DATABASE()
           AND TABLE_NAME = 'wisps'
           AND COLUMN_NAME = 'lease_expires_at'),
     0);
-SET @sql = IF(@has_col > 0,
-    'ALTER TABLE wisps DROP COLUMN lease_expires_at',
-    'SELECT 1');
-PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
-
-SET @has_col = IF(@has_wisps > 0,
+SET @has_hb_col = IF(@has_wisps > 0,
     (SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
         WHERE TABLE_SCHEMA = DATABASE()
           AND TABLE_NAME = 'wisps'
           AND COLUMN_NAME = 'heartbeat_at'),
     0);
-SET @sql = IF(@has_col > 0,
-    'ALTER TABLE wisps DROP COLUMN heartbeat_at',
-    'SELECT 1');
+SET @clauses = CONCAT_WS(', ',
+    IF(@has_lease_col > 0, 'DROP COLUMN lease_expires_at', NULL),
+    IF(@has_hb_col > 0, 'DROP COLUMN heartbeat_at', NULL));
+SET @sql = IF(@clauses = '', 'SELECT 1', CONCAT('ALTER TABLE wisps ', @clauses));
 PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;

--- a/internal/storage/schema/migrations/0055_move_leases_to_table.up.sql
+++ b/internal/storage/schema/migrations/0055_move_leases_to_table.up.sql
@@ -1,0 +1,125 @@
+-- Move claim leases out of the versioned issues table into an ephemeral
+-- leases table (bd-lrgn1).
+--
+-- lease_expires_at / heartbeat_at as issues columns meant every claim and
+-- every heartbeat was an issues-row UPDATE -> a Dolt commit. At fleet scale
+-- that coordination chatter was the dominant source of unbounded reachable
+-- history and of the constant write traffic that starves large catch-up
+-- merges. The new leases table is registered dolt_ignored (seeded by
+-- MigrateUp's doltIgnorePatterns before this migration runs), so claims mint
+-- exactly one commit (the status/assignee transition — history-worthy) and
+-- heartbeats mint none.
+--
+-- Leases are deliberately node-local: dolt_ignored tables do not replicate,
+-- which matches what leases already were in reality — only enforceable on the
+-- replica that granted them. Cross-machine claim VISIBILITY still rides
+-- status/assignee on issues. row_lock STAYS on issues/wisps: it is the
+-- general write-serialization cell for status/ownership races, not a lease
+-- column (see issueops/lease.go freshRowLock).
+--
+-- Fresh clones never run this migration (the schema_migrations cursor arrives
+-- at-latest); they materialize the leases table via ignored migration 0012.
+-- Everything here is guarded so a re-run, or a run against a workspace in any
+-- intermediate state, is a no-op (see 0052/0046 precedent).
+
+-- 1. Create the leases table if this workspace does not have one yet. The
+-- __temp__ + conditional RENAME dance (see ignored/0001) keeps the CREATE
+-- idempotent; __temp__leases never survives this migration step.
+DROP TABLE IF EXISTS __temp__leases;
+CREATE TABLE __temp__leases (
+    issue_id VARCHAR(255) PRIMARY KEY,
+    holder VARCHAR(255) NOT NULL,
+    granted_at DATETIME NOT NULL,
+    lease_expires_at DATETIME NOT NULL,
+    heartbeat_at DATETIME NOT NULL,
+    INDEX idx_leases_expires (lease_expires_at)
+);
+SET @exists = (SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'leases');
+SET @sql = IF(@exists = 0, 'RENAME TABLE __temp__leases TO leases', 'DROP TABLE __temp__leases');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+-- 2. Move live lease values out of the issues columns. Only rows that are an
+-- actual live claim carry a lease; granted_at/heartbeat_at fall back to
+-- updated_at when heartbeat_at was never stamped. INSERT IGNORE: an existing
+-- lease row (e.g. from a partially-applied earlier run) wins.
+SET @has_col = (
+    SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = 'issues'
+      AND COLUMN_NAME = 'lease_expires_at'
+);
+SET @sql = IF(@has_col > 0,
+    'INSERT IGNORE INTO leases (issue_id, holder, granted_at, lease_expires_at, heartbeat_at)
+     SELECT id, assignee, COALESCE(heartbeat_at, updated_at), lease_expires_at, COALESCE(heartbeat_at, updated_at)
+     FROM issues
+     WHERE lease_expires_at IS NOT NULL
+       AND status = ''in_progress''
+       AND COALESCE(assignee, '''') != ''''',
+    'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+-- 3. Drop the lease index and columns from issues.
+SET @has_index = (
+    SELECT COUNT(*) FROM INFORMATION_SCHEMA.STATISTICS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = 'issues'
+      AND INDEX_NAME = 'idx_issues_lease'
+);
+SET @sql = IF(@has_index > 0,
+    'ALTER TABLE issues DROP INDEX idx_issues_lease',
+    'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @has_col = (
+    SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = 'issues'
+      AND COLUMN_NAME = 'lease_expires_at'
+);
+SET @sql = IF(@has_col > 0,
+    'ALTER TABLE issues DROP COLUMN lease_expires_at',
+    'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @has_col = (
+    SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = 'issues'
+      AND COLUMN_NAME = 'heartbeat_at'
+);
+SET @sql = IF(@has_col > 0,
+    'ALTER TABLE issues DROP COLUMN heartbeat_at',
+    'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+-- 4. Drop the (never-reclaimed, now entirely unread) lease columns from wisps.
+-- Wisps are never leased work; their claims get no lease row. row_lock stays:
+-- the shared claim/close/update SQL still rewrites it on wisps rows. Guarded
+-- on the wisps table existing AND carrying the columns — fresh clones build
+-- wisps from ignored/0001, which never had them.
+SET @has_wisps = (
+    SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES
+    WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'wisps'
+);
+
+SET @has_col = IF(@has_wisps > 0,
+    (SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
+        WHERE TABLE_SCHEMA = DATABASE()
+          AND TABLE_NAME = 'wisps'
+          AND COLUMN_NAME = 'lease_expires_at'),
+    0);
+SET @sql = IF(@has_col > 0,
+    'ALTER TABLE wisps DROP COLUMN lease_expires_at',
+    'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @has_col = IF(@has_wisps > 0,
+    (SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
+        WHERE TABLE_SCHEMA = DATABASE()
+          AND TABLE_NAME = 'wisps'
+          AND COLUMN_NAME = 'heartbeat_at'),
+    0);
+SET @sql = IF(@has_col > 0,
+    'ALTER TABLE wisps DROP COLUMN heartbeat_at',
+    'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;

--- a/internal/storage/schema/migrations/ignored/0012_create_leases.up.sql
+++ b/internal/storage/schema/migrations/ignored/0012_create_leases.up.sql
@@ -1,0 +1,22 @@
+-- Materialize the ephemeral leases table (bd-lrgn1) on clones that never ran
+-- main migration 0055. The leases table is dolt_ignored, so it lives only in
+-- the working set and is never part of committed history: a fresh clone
+-- arrives with the schema_migrations cursor at-latest (0055 already recorded)
+-- but WITHOUT the table, exactly like the wisp/local-state tables from
+-- ignored/0001. Same __temp__ + conditional RENAME pattern: create only when
+-- absent, never touch an existing table.
+--
+-- One row per live claim granted through this node; see
+-- issueops.UpsertLeaseInTx for the lease-row invariant.
+DROP TABLE IF EXISTS __temp__leases;
+CREATE TABLE __temp__leases (
+    issue_id VARCHAR(255) PRIMARY KEY,
+    holder VARCHAR(255) NOT NULL,
+    granted_at DATETIME NOT NULL,
+    lease_expires_at DATETIME NOT NULL,
+    heartbeat_at DATETIME NOT NULL,
+    INDEX idx_leases_expires (lease_expires_at)
+);
+SET @exists = (SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'leases');
+SET @sql = IF(@exists = 0, 'RENAME TABLE __temp__leases TO leases', 'DROP TABLE __temp__leases');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;

--- a/internal/storage/schema/schema.go
+++ b/internal/storage/schema/schema.go
@@ -221,6 +221,7 @@ var (
 // re-asserts the full set idempotently at the top of every write-mode open.
 var doltIgnorePatterns = []string{
 	"ignored_schema_migrations",
+	"leases",
 	"local_metadata",
 	"repo_mtimes",
 	"wisp_%",

--- a/internal/storage/sqlbuild/counts.go
+++ b/internal/storage/sqlbuild/counts.go
@@ -3,8 +3,9 @@ package sqlbuild
 import "fmt"
 
 // ReadyWorkIssueColumns is IssueSelectColumns qualified with the "i." alias
-// used by the counts mega-query.
-var ReadyWorkIssueColumns = QualifyColumns(IssueSelectColumns, "i.")
+// used by the counts mega-query. The lease overlay columns keep their own
+// leases. qualifier (the mega-query FROM includes LeaseJoin("i")).
+var ReadyWorkIssueColumns = QualifyColumns(IssueBaseColumns, "i.") + ", " + LeaseSelectColumns
 
 // DepJSONObject renders one dependency row as JSON for JSON_ARRAYAGG
 // aggregation in the counts mega-query. Field names must match the JSON tags
@@ -109,6 +110,7 @@ func SearchCountsSQL(tables FilterTables, ids []string, whereSQL, orderBySQL, li
 			d.deps_json      AS deps_json
 		FROM %s i
 		%s
+		%s
 		LEFT JOIN (
 			SELECT issue_id, COUNT(*) AS cnt
 			FROM %s
@@ -144,6 +146,7 @@ func SearchCountsSQL(tables FilterTables, ids []string, whereSQL, orderBySQL, li
 		ReadyWorkIssueColumns,
 		labelsSelect,
 		tables.Main,
+		LeaseJoin("i"),
 		labelsJoin,
 		tables.Dependencies, depBlocksExtra,
 		reverseBlockerSelect,

--- a/internal/storage/sqlbuild/sqlbuild.go
+++ b/internal/storage/sqlbuild/sqlbuild.go
@@ -31,11 +31,11 @@ var (
 // mutually-exclusive target columns.
 const DepTargetExpr = "COALESCE(depends_on_issue_id, depends_on_wisp_id, depends_on_external)"
 
-// IssueSelectColumns is the canonical column list for full issue hydration.
-// Every query that reads a complete types.Issue should use this constant;
-// the scan side is issueops.ScanIssueFrom, which scans positionally and
-// must stay in column-for-column agreement with this list.
-const IssueSelectColumns = `id, content_hash, title, description, design, acceptance_criteria, notes,
+// IssueBaseColumns is the column list for the issues/wisps row itself,
+// without the lease overlay. Use IssueSelectColumns for full hydration;
+// this split exists so callers that alias the main table (QualifyColumns)
+// can qualify the row columns without mangling the leases.* references.
+const IssueBaseColumns = `id, content_hash, title, description, design, acceptance_criteria, notes,
 	       status, priority, issue_type, assignee, estimated_minutes,
 	       created_at, created_by, owner, updated_at, started_at, closed_at, external_ref, spec_id,
 	       compaction_level, compacted_at, compacted_at_commit, original_size, source_repo, close_reason,
@@ -44,8 +44,29 @@ const IssueSelectColumns = `id, content_hash, title, description, design, accept
 	       mol_type,
 	       event_kind, actor, target, payload,
 	       due_at, defer_until,
-	       work_type, source_system, metadata,
-	       lease_expires_at, heartbeat_at`
+	       work_type, source_system, metadata`
+
+// LeaseSelectColumns is the lease overlay for full issue hydration. Leases
+// live in the ephemeral leases table (bd-lrgn1), not on the issues row, so
+// every query selecting these must also add LeaseJoin to its FROM clause —
+// a query that forgets the join fails loudly on the leases.* reference.
+const LeaseSelectColumns = `leases.lease_expires_at, leases.heartbeat_at`
+
+// IssueSelectColumns is the canonical column list for full issue hydration.
+// Every query that reads a complete types.Issue should use this constant
+// and include LeaseJoin(table) in its FROM clause; the scan side is
+// issueops.ScanIssueFrom, which scans positionally and must stay in
+// column-for-column agreement with this list.
+const IssueSelectColumns = IssueBaseColumns + `,
+	       ` + LeaseSelectColumns
+
+// LeaseJoin returns the FROM-clause fragment that overlays the ephemeral
+// leases table onto the given issues/wisps table reference (a table name or
+// alias). LEFT JOIN: rows without a live claim have no lease row and hydrate
+// nil lease fields.
+func LeaseJoin(tableRef string) string {
+	return "LEFT JOIN leases ON leases.issue_id = " + tableRef + ".id"
+}
 
 // QueryBatchSize bounds IN-clause sizes when long ID lists are folded into
 // WHERE fragments.

--- a/internal/storage/sqlite/schema.sql
+++ b/internal/storage/sqlite/schema.sql
@@ -53,10 +53,19 @@ CREATE TABLE IF NOT EXISTS `issues` (
   `no_history` tinyint(1) DEFAULT '0',
   `started_at` datetime,
   `is_blocked` tinyint(1) NOT NULL DEFAULT '0',
-  `lease_expires_at` datetime,
-  `heartbeat_at` datetime,
   `row_lock` bigint NOT NULL DEFAULT 0,
   PRIMARY KEY (`id`)
+);
+
+-- Ephemeral claim leases (bd-lrgn1): node-local, never exported by backup.
+-- One row per live claim; see issueops.UpsertLeaseInTx for the invariant.
+CREATE TABLE IF NOT EXISTS `leases` (
+  `issue_id` varchar(255) NOT NULL,
+  `holder` varchar(255) NOT NULL,
+  `granted_at` datetime NOT NULL,
+  `lease_expires_at` datetime NOT NULL,
+  `heartbeat_at` datetime NOT NULL,
+  PRIMARY KEY (`issue_id`)
 );
 
 CREATE TABLE IF NOT EXISTS `wisps` (
@@ -114,8 +123,6 @@ CREATE TABLE IF NOT EXISTS `wisps` (
   `no_history` tinyint(1) DEFAULT '0',
   `started_at` datetime,
   `is_blocked` tinyint(1) NOT NULL DEFAULT '0',
-  `lease_expires_at` datetime,
-  `heartbeat_at` datetime,
   `row_lock` bigint NOT NULL DEFAULT 0,
   PRIMARY KEY (`id`)
 );
@@ -279,7 +286,7 @@ CREATE INDEX IF NOT EXISTS idx_issues_issue_type ON `issues` (`issue_type`);
 CREATE INDEX IF NOT EXISTS idx_issues_priority ON `issues` (`priority`);
 CREATE INDEX IF NOT EXISTS idx_issues_spec_id ON `issues` (`spec_id`);
 CREATE INDEX IF NOT EXISTS idx_issues_status_updated_at ON `issues` (`status`,`updated_at`);
-CREATE INDEX IF NOT EXISTS idx_issues_lease ON `issues` (`status`,`lease_expires_at`);
+CREATE INDEX IF NOT EXISTS idx_leases_expires ON `leases` (`lease_expires_at`);
 CREATE INDEX IF NOT EXISTS idx_wisps_assignee ON `wisps` (`assignee`);
 CREATE INDEX IF NOT EXISTS idx_wisps_created_at ON `wisps` (`created_at`);
 CREATE INDEX IF NOT EXISTS idx_wisps_external_ref ON `wisps` (`external_ref`);

--- a/internal/storage/sqlite/schema.sql
+++ b/internal/storage/sqlite/schema.sql
@@ -58,7 +58,7 @@ CREATE TABLE IF NOT EXISTS `issues` (
 );
 
 -- Ephemeral claim leases (bd-lrgn1): node-local, never exported by backup.
--- One row per live claim; see issueops.UpsertLeaseInTx for the invariant.
+-- One row per live claim. See issueops.UpsertLeaseInTx for the invariant.
 CREATE TABLE IF NOT EXISTS `leases` (
   `issue_id` varchar(255) NOT NULL,
   `holder` varchar(255) NOT NULL,

--- a/internal/storage/sqlitedialect/translate.go
+++ b/internal/storage/sqlitedialect/translate.go
@@ -105,6 +105,7 @@ var onConflictTargets = map[string]string{
 	"wisp_child_counters": "parent_id",
 	"repo_mtimes":         "repo_path",
 	"federation_peers":    "name",
+	"leases":              "issue_id",
 }
 
 func rewriteOnDuplicateKey(sql string) string {

--- a/internal/storage/sqlitedialect/translate_test.go
+++ b/internal/storage/sqlitedialect/translate_test.go
@@ -28,6 +28,10 @@ func TestTranslate(t *testing.T) {
 		// rewritten to SQLite's scalar max even inside the ON DUPLICATE KEY envelope,
 		// otherwise hierarchical dotted child IDs fail on SQLite.
 		{"child counter upsert", "INSERT INTO child_counters (parent_id, last_child) VALUES (?, ?) ON DUPLICATE KEY UPDATE last_child = GREATEST(last_child, ?)", "ON CONFLICT (parent_id) DO UPDATE SET last_child = max(last_child, ?)", "GREATEST"},
+		// The lease upsert from issueops/lease.go (bd-lrgn1): leases keys on
+		// issue_id, so the arbiter map must know it or the upsert fails at PREPARE.
+		{"lease upsert", "INSERT INTO leases (issue_id, holder) VALUES (?, ?) ON DUPLICATE KEY UPDATE holder = VALUES(holder)", "ON CONFLICT (issue_id) DO UPDATE SET holder = excluded.holder", "DUPLICATE"},
+		{"lease import-restore live guard", "INSERT INTO leases (issue_id, holder) VALUES (?, ?) ON DUPLICATE KEY UPDATE holder = IF(leases.lease_expires_at >= ?, leases.holder, VALUES(holder))", "ON CONFLICT (issue_id) DO UPDATE SET holder = CASE WHEN leases.lease_expires_at >= ? THEN leases.holder ELSE excluded.holder END", "IF("},
 		{"passthrough select", "SELECT * FROM issues WHERE id = ?", "SELECT * FROM issues WHERE id = ?", ""},
 	}
 	for _, tc := range cases {

--- a/internal/storage/sqlkit/iter.go
+++ b/internal/storage/sqlkit/iter.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/storage/issueops"
+	"github.com/steveyegge/beads/internal/storage/sqlbuild"
 	"github.com/steveyegge/beads/internal/types"
 )
 
@@ -33,8 +34,8 @@ func (s *Store) IterIssues(ctx context.Context, query string, filter types.Issue
 	}
 
 	//nolint:gosec // G201: whereSQL contains column comparisons with ?, limitSQL is a safe integer
-	q := fmt.Sprintf(`SELECT %s FROM issues %s ORDER BY priority ASC, created_at DESC, id ASC%s`,
-		issueops.IssueSelectColumns, whereSQL, limitSQL)
+	q := fmt.Sprintf(`SELECT %s FROM issues %s %s ORDER BY priority ASC, created_at DESC, id ASC%s`,
+		issueops.IssueSelectColumns, sqlbuild.LeaseJoin("issues"), whereSQL, limitSQL)
 
 	var issues []*types.Issue
 	txErr := s.withReadTx(ctx, func(tx *sql.Tx) error {

--- a/internal/storage/uow/dolt_sql_provider.go
+++ b/internal/storage/uow/dolt_sql_provider.go
@@ -64,7 +64,10 @@ func (p *doltSQLProvider) BeginTx(ctx context.Context) (Tx, error) {
 func (p *doltSQLProvider) initSchema(ctx context.Context, database string) error {
 	bo := backoff.NewExponentialBackOff()
 	bo.InitialInterval = 25 * time.Millisecond
-	bo.MaxElapsedTime = 15 * time.Second
+	// This budget must outwait a peer holding the migration lock through a
+	// full cold-start migration pass (every migration + a Dolt commit each),
+	// not just a transient blip — it grows as migrations accumulate.
+	bo.MaxElapsedTime = 60 * time.Second
 	return backoff.Retry(func() error {
 		conn, err := p.db.Conn(ctx)
 		if err != nil {

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -45,9 +45,11 @@ type Issue struct {
 	CloseReason     string     `json:"close_reason,omitempty"`      // Reason provided when closing
 	ClosedBySession string     `json:"closed_by_session,omitempty"` // Claude Code session that closed this issue
 
-	// ===== Leasing (claim TTL + heartbeat; migration 0054) =====
-	// NULL when there is no active lease. row_lock is an internal serialization
-	// mechanism and is intentionally NOT surfaced here.
+	// ===== Leasing (claim TTL + heartbeat; migrations 0054/0055) =====
+	// Hydrated from the ephemeral, node-local leases table (bd-lrgn1), not
+	// from issues columns. NULL when there is no active lease on this node.
+	// row_lock is an internal serialization mechanism (an issues column) and
+	// is intentionally NOT surfaced here.
 	LeaseExpiresAt *time.Time `json:"lease_expires_at,omitempty"` // When the current claim's lease expires
 	HeartbeatAt    *time.Time `json:"heartbeat_at,omitempty"`     // Last heartbeat from the lease owner
 

--- a/test/conformance/roundtrip_test.go
+++ b/test/conformance/roundtrip_test.go
@@ -157,11 +157,14 @@ func runSteps(t *testing.T, bin, dir string, env []string, backend string, steps
 	}
 }
 
-// ephemeralExportKeys are runtime claim/lease fields that `bd export` serializes but
-// `bd import` deliberately does not restore: a restored backup must not carry a dead
-// worker's stale lease. They are not part of the durable backup contract, so the
-// round-trip legitimately drops them on EVERY backend (the Dolt reference included), and
-// canonicalRecords strips them before the fidelity comparison.
+// ephemeralExportKeys are runtime claim/lease fields that `bd export`
+// serializes but that are not part of the durable backup contract. Leases
+// live in the ephemeral, node-local leases table (bd-lrgn1): import restores
+// a snapshot lease only when the stored row is a live claim and no unexpired
+// local lease exists (issueops.RestoreLeaseOnImportInTx), so whether they
+// survive a round trip is timing- and node-dependent. canonicalRecords strips
+// them before the fidelity comparison. The exact restore semantics are pinned
+// separately by cmd/bd/protocol/lease_claim_test.go (L1.2).
 var ephemeralExportKeys = []string{"lease_expires_at", "heartbeat_at", "row_lock"}
 
 // canonicalRecords normalizes a JSONL export for the round-trip fidelity comparison:


### PR DESCRIPTION
## Summary

Moves claim leases (`holder`, `granted_at`, `lease_expires_at`, `heartbeat_at`) off the versioned `issues` table into a new `leases` table registered in `dolt_ignore` (precedent: `wisps`). Claims and heartbeats no longer mint Dolt commits or history: a claim commits exactly once (the history-worthy status/assignee transition) and heartbeats commit nothing. At fleet scale this removes ~13k coordination commits/day of pure chatter — the dominant source of unbounded reachable history and of the write pressure that starves large catch-up merges (bd-lrgn1; evidence from the wyvern deployment).

Leases are deliberately node-local (dolt_ignored tables don't replicate) — matching what leases already were in reality: only enforceable on the replica that granted them. Cross-machine claim visibility still rides `status`/`assignee` on `issues`. Bonus: heartbeats stop stamping `issues.updated_at`, so `updated_at` regains its merge/LWW meaning.

## Design

- `leases` table on all five backends: dolt via migration 0055 + ignored/0012 (fresh clones), sqlite/mysql `schema.sql`, postgres `schema.go`. Always-on, not a config mode (no dual query paths).
- Invariant: a lease row exists iff its issue is a live claim on this node. Every path ending or transferring a claim (close, unclaim, reclaim, delete, status/assignee update, import accepting a newer non-claimed snapshot) deletes the row.
- All full-issue query sites hydrate via `sqlbuild.LeaseJoin` (LEFT JOIN); a missed site fails loudly at PREPARE.
- `row_lock` STAYS on issues — it is the general write-serialization cell, not lease state. Wisps are never leased.
- Protocol L1.2 preserved: lease fields still round-trip JSONL via export-time JOIN; import restores into `leases` but never clobbers a live (unexpired) local lease (`RestoreLeaseOnImportInTx` + new test).
- Migration 0055 moves live lease values from the old columns, then drops them (single combined ALTER per table); guarded for re-runs and partial states. Old binaries against a migrated DB fail loudly (columns gone), never corrupt.

## Fixes surfaced while validating

- Both `pgdialect` and `sqlitedialect` needed the `leases → issue_id` ON CONFLICT arbiter entry — without it every claim upsert on sqlite/postgres failed at PREPARE (translator tests added for both upsert forms).
- sqlite/mysql schema loaders split DDL on `;` before stripping comments — the leases DDL comment contained one and broke every subsequent statement.
- uow `initSchema` waiter budget 15s → 60s: it must outwait a peer's full cold-start migration pass (grows with every migration), not a transient blip. Same reasoning for the dolt package's `testTimeout` 30s → 45s.

## Acceptance (from bd-lrgn1)

1. ✅ Claim + N heartbeats → zero new dolt commits (`TestHeartbeatMintsNoDoltCommits`, asserts via dolt_log count)
2. ✅ status/assignee transitions still commit
3. ✅ Migration test from the column schema with live leases preserved (`TestMigration0055MovesLiveLeases`)
4. ✅ Lease protocol tests green in updated form (`cmd/bd/protocol`, incl. new never-clobber-live-lease test)
5. ✅ Reclaim of an expired lease across a server restart (`TestReclaimExpiredLeaseSurvivesRestartEmbedded` — real embedded-engine close/reopen; lease row durability asserted explicitly)
6. ✅ `./scripts/conformance.sh` fully green (both tiers); `make test` green except two failures reproduced identically on main (internal/audit hang and cmd/bd 3m package timeout — environmental, see below)

## Testing notes

Full local `internal/storage/dolt` package runs crawl on the dev machine for **both this branch and origin/main** with the identical failure signature (store init deadline; long-lived shared test container degradation, consistent with the dolt GC connection-slot leak dolthub/dolt#11196) — all lease/claim/migration tests pass in isolated and targeted runs; CI is the arbiter for the full package. Rebased onto current main (post backend-revert + TLS proxy changes); build/vet/lint clean (one pre-existing gosec finding untouched by this branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)