### PR TITLE
docs(recovery): history-squash runbook (bd-okqpv / wy-7lmdp)

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -271,6 +271,7 @@
           "recovery/merge-conflicts",
           "recovery/circular-dependencies",
           "recovery/sync-failures",
+          "recovery/history-squash",
           "recovery/uninstalling"
         ]
       },

--- a/docs/recovery/history-squash.md
+++ b/docs/recovery/history-squash.md
@@ -95,6 +95,16 @@ bd backup remove && bd backup init <path>   # fresh destination, then:
 bd backup sync
 ```
 
+<Warning>
+A Dolt remote accumulates chunks monotonically: the force-push re-points the
+remote's refs at the squashed chain but deletes nothing, so the *remote's*
+storage does not shrink. To reclaim the published side too, replace the
+remote — clear its storage (or pick a fresh path/prefix) before the push:
+`bd dolt remote remove <name>`, `bd dolt remote add <name> <fresh-url>`,
+then `bd dolt push --force`. Every other clone must re-clone after a squash
+regardless, so replacing the remote costs nothing extra.
+</Warning>
+
 **Step 5:** Verify, then re-clone everywhere else. On this machine:
 
 ```bash

--- a/docs/recovery/history-squash.md
+++ b/docs/recovery/history-squash.md
@@ -1,0 +1,103 @@
+---
+title: History Bloat
+description: Shed reachable Dolt history that dolt gc cannot reclaim
+---
+
+Every bead write mints a Dolt commit, and Dolt keeps every byte a reachable
+commit references — `dolt gc` only reclaims what nothing points to. A
+workspace that has accumulated months of high-frequency writes can grow far
+past its live data (gigabytes of storage for a few thousand beads) while
+`dolt gc` reclaims nothing, because the entire chain is still reachable from
+your branch. This runbook squashes that chain to a single baseline commit so
+the old history becomes collectable, without touching your live data.
+
+<Warning>
+This procedure rewrites history. Every other clone of the database becomes
+unmergeable and must re-clone, and remotes and backups must be re-pointed.
+Run it in a fenced window: all writers stopped, backup verified first.
+</Warning>
+
+## Symptoms
+
+- The Dolt data directory (or its remote/backup) is large and growing while
+  `bd stats` shows a modest number of beads
+- `dolt gc` and `dolt gc --full` reclaim little or nothing
+- Cloning or pulling the database is slow far out of proportion to its content
+
+## Diagnosis
+
+Run these inside the Dolt data directory — `.beads/embeddeddolt/<database>/`
+in embedded mode, `.beads/dolt/<database>/` in server mode:
+
+```bash
+# How big is the store?
+du -sh .
+
+# How deep is the history? Thousands of commits with a small live
+# dataset means the history, not the data, is the bloat.
+dolt log --oneline | wc -l
+
+# Confirm gc has nothing unreachable to collect
+dolt gc --full
+```
+
+If `dolt gc --full` frees the space, you are done — no squash needed.
+
+## Solution
+
+**Step 1:** Fence and back up. Stop every writer (agents, background
+services); in server mode also stop the server after backing up. The backup
+is dolt-native and keeps the full history, so it remains your rollback.
+
+```bash
+bd backup sync
+bd dolt stop
+```
+
+**Step 2:** Squash to a single baseline. From the Dolt data directory,
+re-commit the current tree directly on top of the root commit:
+
+```bash
+root=$(dolt log --oneline | tail -1 | cut -d' ' -f1)
+dolt reset --soft "$root"
+dolt add -A
+dolt commit -m "history squash: baseline $(date +%F)"
+```
+
+**Step 3:** Drop the other refs and collect. Anything still pointing at the
+old chain keeps it alive:
+
+```bash
+dolt branch          # delete stale branches: dolt branch -D <name>
+dolt tag             # delete stale tags:     dolt tag -d <name>
+dolt gc --full
+```
+
+**Step 4:** Re-point remotes and backups. The new history is unrelated to
+the old, so the first publish must replace it:
+
+```bash
+bd dolt push --force
+bd backup remove && bd backup init <path>   # fresh destination, then:
+bd backup sync
+```
+
+**Step 5:** Verify, then re-clone everywhere else. On this machine:
+
+```bash
+bd doctor
+bd list -n 5
+```
+
+Every other clone of this database must be re-created from the squashed
+remote (old clones can no longer pull — the histories no longer share a
+root). Only then unfence your writers.
+
+## Prevention
+
+High-frequency coordination state (claim leases, wisps) lives in unversioned
+tables precisely so routine agent traffic does not mint history; bloat at
+this scale usually means something is writing versioned tables in a tight
+loop. Find and fix that writer, watch data-directory growth over time, and
+run `dolt gc` periodically so unreachable garbage never accumulates on top
+of reachable history.

--- a/docs/recovery/history-squash.md
+++ b/docs/recovery/history-squash.md
@@ -55,7 +55,9 @@ bd dolt stop
 ```
 
 **Step 2:** Squash to a single baseline. From the Dolt data directory,
-re-commit the current tree directly on top of the root commit:
+re-commit the current tree directly on top of the root commit. Keeping the
+root as the sole ancestor preserves a valid chain — do not try to "simplify"
+further by starting an orphan branch:
 
 ```bash
 root=$(dolt log --oneline | tail -1 | cut -d' ' -f1)
@@ -65,13 +67,24 @@ dolt commit -m "history squash: baseline $(date +%F)"
 ```
 
 **Step 3:** Drop the other refs and collect. Anything still pointing at the
-old chain keeps it alive:
+old chain keeps it alive — stale local branches and tags, and also the
+*remote-tracking refs* left behind by every past push and fetch, which any
+long-lived synced workspace has. Delete them all before collecting; Step 4's
+force-push recreates the remote-tracking refs on the new chain:
 
 ```bash
-dolt branch          # delete stale branches: dolt branch -D <name>
-dolt tag             # delete stale tags:     dolt tag -d <name>
+dolt branch          # delete stale branches:       dolt branch -D <name>
+dolt branch -r       # delete remote-tracking refs: dolt branch -rd <remote>/<branch>
+dolt tag             # delete stale tags:           dolt tag -d <name>
 dolt gc --full
+du -sh .             # verify: the store should now be a fraction of its old size
 ```
+
+If the size barely moved, a ref still anchors the old chain — re-check
+`dolt branch`, `dolt branch -r`, and `dolt tag` for survivors and collect
+again. (A failed collection does not endanger Step 4 — the push sends only
+what the new baseline references — but this machine keeps the bloat until
+the gc succeeds.)
 
 **Step 4:** Re-point remotes and backups. The new history is unrelated to
 the old, so the first publish must replace it:
@@ -95,9 +108,10 @@ root). Only then unfence your writers.
 
 ## Prevention
 
-High-frequency coordination state (claim leases, wisps) lives in unversioned
-tables precisely so routine agent traffic does not mint history; bloat at
-this scale usually means something is writing versioned tables in a tight
-loop. Find and fix that writer, watch data-directory growth over time, and
+High-frequency coordination state lives in unversioned tables precisely so
+routine agent traffic does not mint history — claim leases (see
+[bd heartbeat](/cli-reference/heartbeat)) and [wisps](/workflows/wisps) —
+so bloat at this scale usually means something is writing versioned tables
+in a tight loop. Find and fix that writer, watch data-directory growth over time, and
 run `dolt gc` periodically so unreachable garbage never accumulates on top
 of reachable history.

--- a/docs/recovery/history-squash.md
+++ b/docs/recovery/history-squash.md
@@ -113,8 +113,10 @@ bd list -n 5
 ```
 
 Every other clone of this database must be re-created from the squashed
-remote (old clones can no longer pull — the histories no longer share a
-root). Only then unfence your writers.
+remote. Old clones must not pull: the two chains still share the root, so a
+pull can "succeed" as a cross-merge that re-anchors the entire old history —
+and a later push resurrects the bloat on the squashed remote. Only then
+unfence your writers.
 
 ## Prevention
 

--- a/docs/recovery/index.md
+++ b/docs/recovery/index.md
@@ -14,6 +14,7 @@ This section provides step-by-step recovery procedures for common Beads issues. 
 | Merge Conflicts | Dolt conflicts during sync | [Merge Conflicts](/recovery/merge-conflicts) |
 | Circular Dependencies | Cycle detection errors | [Circular Dependencies](/recovery/circular-dependencies) |
 | Sync Failures | `bd dolt push`/`bd dolt pull` errors | [Sync Failures](/recovery/sync-failures) |
+| History Bloat | Store grows unbounded; `dolt gc` reclaims nothing | [History Bloat](/recovery/history-squash) |
 | Removing beads | Uninstall bd or strip beads from a repo | [Uninstalling](/recovery/uninstalling) |
 
 ## Quick Diagnostic


### PR DESCRIPTION
New recovery runbook: shedding reachable Dolt history that `dolt gc` cannot reclaim, via a fenced-window squash (backup → soft-reset squash to a baseline commit → drop stale refs → `gc --full` → force re-publish → re-clone everywhere else). Follows the house runbook format (Symptoms / Diagnosis / Solution ≤5 steps / Prevention); nav + recovery index updated.

Motivated by the wyvern deployment's 3.6G of reachable lease-churn history (wy-7lmdp); generic to any workspace with high-frequency-write history bloat. Companion to PR #4863, which removes the churn source going forward.

Docs-only. Gates: `go test ./test/docsync` and `check-doc-freshness.sh` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)