### PR TITLE
docs: fix mermaid diagram rendering on GitHub (reserved node id)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,12 @@ Beads provides a persistent, structured memory for coding agents. It replaces me
 
 ```mermaid
 flowchart LR
-    create["bd create<br/>new bead"] --> graph["dependency<br/>graph"]
-    graph --> ready["bd ready<br/>claimable work"]
+    create["bd create<br/>new bead"] --> deps["dependency<br/>graph"]
+    deps --> ready["bd ready<br/>claimable work"]
     ready --> claim["bd update --claim<br/>agent takes it"]
     claim --> close["bd close<br/>work done"]
     close -->|blockers released| ready
-    graph <-->|"bd dolt push / pull"| remote[("other machines<br/>and agents")]
+    deps <-->|"bd dolt push / pull"| remote[("other machines<br/>and agents")]
 ```
 
 ## ⚡ Quick Start

--- a/docs/core-concepts/index.md
+++ b/docs/core-concepts/index.md
@@ -12,8 +12,8 @@ Work survives the agent; the next session picks up where the last one died.
 
 ```mermaid
 flowchart LR
-    create["bd create<br/>new bead"] --> graph["dependency<br/>graph"]
-    graph --> ready["bd ready<br/>claimable work"]
+    create["bd create<br/>new bead"] --> deps["dependency<br/>graph"]
+    deps --> ready["bd ready<br/>claimable work"]
     ready --> claim["bd update --claim<br/>agent takes it"]
     claim --> close["bd close<br/>work done"]
     close -->|blockers released| ready


### PR DESCRIPTION
The README diagram was failing to render on GitHub because one of the flowchart nodes was named `graph`, which is a reserved Mermaid keyword. Renamed the node id to `deps` (the visible label is unchanged), here and in the copy in `docs/core-concepts/index.md`.

Thanks Steve for making beads, it's a great tool!