### PR TITLE
feat: export DependencyAddOptions from the root package

### DIFF
--- a/beads.go
+++ b/beads.go
@@ -23,6 +23,15 @@ type Storage = beads.Storage
 // Use Storage.RunInTransaction() to obtain a Transaction instance.
 type Transaction = beads.Transaction
 
+// DependencyAddOptions controls transaction-scoped dependency insertion for
+// Transaction.AddDependencyWithOptions. Exported so embedders' bulk graph
+// writers can set SkipCycleCheck per edge and run one whole-graph
+// Transaction.CycleThroughEdges pass before commit (bd-6dnrw.8) instead of
+// paying the recursive per-edge cycle query — which cannot finish inside a
+// per-command budget on molecule-sized graphs (observed: a 67-node/100-edge
+// batch blowing a 120s deadline mid-transaction, gascity 2026-07-17).
+type DependencyAddOptions = storage.DependencyAddOptions
+
 // RemoteStore provides dolt remote management and replication operations.
 // Use type assertion on a Storage value to access these methods:
 //

--- a/beads.go
+++ b/beads.go
@@ -30,6 +30,11 @@ type Transaction = beads.Transaction
 // paying the recursive per-edge cycle query — which cannot finish inside a
 // per-command budget on molecule-sized graphs (observed: a 67-node/100-edge
 // batch blowing a 120s deadline mid-transaction, gascity 2026-07-17).
+//
+// Callers that set SkipCycleCheck MUST run Transaction.CycleThroughEdges before
+// commit and fail on new blocks/conditional-blocks/parent-child cycles
+// (waits-for is excluded); skipping the per-edge check trades per-edge cost for
+// one whole-graph check, never graph integrity.
 type DependencyAddOptions = storage.DependencyAddOptions
 
 // RemoteStore provides dolt remote management and replication operations.

--- a/export_dependency_add_options_test.go
+++ b/export_dependency_add_options_test.go
@@ -1,0 +1,25 @@
+package beads
+
+import (
+	"context"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// Compile-time proof that the exported alias is accepted by the Transaction
+// interface's AddDependencyWithOptions. Embedders' bulk graph writers need to
+// name this type to set SkipCycleCheck per edge and run one whole-graph
+// Transaction.CycleThroughEdges pass before commit (bd-6dnrw.8); before this
+// alias it lived only in internal/storage, so the designed batch path was
+// uncallable from outside the module (a 67-node/100-edge molecule batch blew
+// a 120s deadline on per-edge cycle queries, gascity 2026-07-17).
+var _ = func(tx Transaction, dep *types.Dependency) error {
+	return tx.AddDependencyWithOptions(context.Background(), dep, "actor", DependencyAddOptions{SkipCycleCheck: true})
+}
+
+func TestDependencyAddOptionsIsExported(t *testing.T) {
+	if !(DependencyAddOptions{SkipCycleCheck: true}).SkipCycleCheck {
+		t.Fatal("SkipCycleCheck must round-trip through the exported alias")
+	}
+}


### PR DESCRIPTION
## Summary
`Transaction.AddDependencyWithOptions` and `Transaction.CycleThroughEdges` are both on the public `Transaction` interface, but `DependencyAddOptions` lived only in `internal/storage` — so the designed bulk-write path (`SkipCycleCheck` per edge + one whole-graph `CycleThroughEdges` pass before commit, bd-6dnrw.8) was **uncallable by embedders**.

## Why now
Gas City's native graph-apply pours molecule-sized batches (67 nodes / ~100 blocking edges). Each edge pays the recursive cycle-reachability query, which cannot finish inside a 120s per-command budget: reproduced 2026-07-17, the batch died at the deadline mid-edges twice (`failed to check for dependency cycle: context deadline exceeded`), then fell back to per-bead creates — a 9-minute pour. Gas City has an interim deadline-scaling fix (gastownhall/gascity#4391); this export is the prerequisite for the real fix (skip per-edge, one batch check).

Gas City will pick this up at the next version pin bump (go.mod + deps.env lockstep).

## Change
One root alias in `beads.go` + a compile-time proof that the alias satisfies the `Transaction` method signature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)