### PR TITLE
docs(recovery): restore RECOVERY.md as a forwarding stub for shipped v1.1.0 links

### DIFF
--- a/docs/RECOVERY.md
+++ b/docs/RECOVERY.md
@@ -1,30 +1,13 @@
 # Recovery Playbooks
 
-This playbook moved to [docs/recovery/](recovery/index.md), rendered on the
-docs site at [https://beads.gascity.com/recovery/](https://beads.gascity.com/recovery/). Everything that lived on
-this page is now in [recovery/init-safety.md](recovery/init-safety.md)
-([https://beads.gascity.com/recovery/init-safety](https://beads.gascity.com/recovery/init-safety)).
+The recovery playbooks moved to [docs/recovery/](recovery/index.md), rendered
+on the docs site at
+[https://beads.gascity.com/recovery/](https://beads.gascity.com/recovery/).
 
 > **Why this file exists:** released `bd` binaries print URLs into this file —
 > v1.1.0's Dolt merge-refusal guidance (`printAncestorPKMismatchGuidance`,
-> `cmd/bd/dolt.go` at tag `v1.1.0`) prints
-> `docs/RECOVERY.md#pk-fork-refused`. This stub keeps those printed links
-> landing on a working page with the same anchors. Do not delete it while
-> released binaries still print it; it is deliberately exempt from the
-> no-pointer-stubs rule (see `test/docsync`).
-
-## init-force-refused
-
-Moved: [recovery/init-safety.md § init-force-refused](recovery/init-safety.md#init-force-refused) · [https://beads.gascity.com/recovery/init-safety#init-force-refused](https://beads.gascity.com/recovery/init-safety#init-force-refused)
-
-## init-token-missing
-
-Moved: [recovery/init-safety.md § init-token-missing](recovery/init-safety.md#init-token-missing) · [https://beads.gascity.com/recovery/init-safety#init-token-missing](https://beads.gascity.com/recovery/init-safety#init-token-missing)
-
-## init-local-exists
-
-Moved: [recovery/init-safety.md § init-local-exists](recovery/init-safety.md#init-local-exists) · [https://beads.gascity.com/recovery/init-safety#init-local-exists](https://beads.gascity.com/recovery/init-safety#init-local-exists)
-
-## pk-fork-refused
-
-Moved: [recovery/init-safety.md § pk-fork-refused](recovery/init-safety.md#pk-fork-refused) · [https://beads.gascity.com/recovery/init-safety#pk-fork-refused](https://beads.gascity.com/recovery/init-safety#pk-fork-refused)
+> `cmd/bd/dolt.go` at tag `v1.1.0`) prints `docs/RECOVERY.md#pk-fork-refused`.
+> This stub keeps those printed links landing on a page that points at the
+> live playbooks. Do not delete it while released binaries still print it; it
+> is a deliberate exception to the no-pointer-stubs rule, registered in
+> `test/docsync`.

--- a/docs/RECOVERY.md
+++ b/docs/RECOVERY.md
@@ -1,0 +1,30 @@
+# Recovery Playbooks
+
+This playbook moved to [docs/recovery/](recovery/index.md), rendered on the
+docs site at [https://beads.gascity.com/recovery/](https://beads.gascity.com/recovery/). Everything that lived on
+this page is now in [recovery/init-safety.md](recovery/init-safety.md)
+([https://beads.gascity.com/recovery/init-safety](https://beads.gascity.com/recovery/init-safety)).
+
+> **Why this file exists:** released `bd` binaries print URLs into this file —
+> v1.1.0's Dolt merge-refusal guidance (`printAncestorPKMismatchGuidance`,
+> `cmd/bd/dolt.go` at tag `v1.1.0`) prints
+> `docs/RECOVERY.md#pk-fork-refused`. This stub keeps those printed links
+> landing on a working page with the same anchors. Do not delete it while
+> released binaries still print it; it is deliberately exempt from the
+> no-pointer-stubs rule (see `test/docsync`).
+
+## init-force-refused
+
+Moved: [recovery/init-safety.md § init-force-refused](recovery/init-safety.md#init-force-refused) · [https://beads.gascity.com/recovery/init-safety#init-force-refused](https://beads.gascity.com/recovery/init-safety#init-force-refused)
+
+## init-token-missing
+
+Moved: [recovery/init-safety.md § init-token-missing](recovery/init-safety.md#init-token-missing) · [https://beads.gascity.com/recovery/init-safety#init-token-missing](https://beads.gascity.com/recovery/init-safety#init-token-missing)
+
+## init-local-exists
+
+Moved: [recovery/init-safety.md § init-local-exists](recovery/init-safety.md#init-local-exists) · [https://beads.gascity.com/recovery/init-safety#init-local-exists](https://beads.gascity.com/recovery/init-safety#init-local-exists)
+
+## pk-fork-refused
+
+Moved: [recovery/init-safety.md § pk-fork-refused](recovery/init-safety.md#pk-fork-refused) · [https://beads.gascity.com/recovery/init-safety#pk-fork-refused](https://beads.gascity.com/recovery/init-safety#pk-fork-refused)

--- a/test/docsync/docsync_test.go
+++ b/test/docsync/docsync_test.go
@@ -34,6 +34,11 @@ var markdownLinkRE = regexp.MustCompile(`\[[^][]*\]\(([^)]+)\)`)
 // (engdocs/decisions/2026-07-10-mintlify-docs-overhaul.md, decision 6).
 var docsPublishExemptions = map[string]bool{
 	"CLI_REFERENCE.md": true, // generated single-file reference (bd help --all)
+	// Deliberate exception to decision 6: released bd binaries print this
+	// path (v1.1.0 printAncestorPKMismatchGuidance emits
+	// docs/RECOVERY.md#pk-fork-refused), and github.com blob URLs cannot be
+	// redirected. Keep until no supported release prints it.
+	"RECOVERY.md": true,
 }
 
 // rootDocFiles are the curated root-level markdown files whose local links


### PR DESCRIPTION
## Why

Released v1.1.0 binaries print this in the Dolt ancestor-PK merge-refusal guidance (`printAncestorPKMismatchGuidance`, `cmd/bd/dolt.go` at the tag):

```
Full playbook:
  https://github.com/gastownhall/beads/blob/main/docs/RECOVERY.md#pk-fork-refused
```

`docs/RECOVERY.md` was removed in the docs restructure, so every v1.1.0 binary in the wild prints a 404 — at exactly the moment a user is mid-incident. GitHub blob paths cannot be redirected by anything (Mintlify redirects only govern beads.gascity.com), so the only fix for already-shipped binaries is the file existing again at that path. main's binary already prints the corrected URL, so this is purely for binaries in the wild; no Go code is touched.

## What

- **`docs/RECOVERY.md`** — a pure pointer stub: one link to the live playbooks (`docs/recovery/` in-repo, `beads.gascity.com/recovery/` rendered) plus a blockquote explaining the file exists deliberately for shipped-binary link stability. Nothing in it mirrors the live docs' structure, so there is nothing to keep in sync and nothing to drift. Deep anchors from printed URLs (`#pk-fork-refused`) land at the top of the page, where the pointer is the first thing a reader sees.
- **`test/docsync/docsync_test.go`** — registers `RECOVERY.md` in `docsPublishExemptions`, the designed mechanism for this: it exempts the file from the no-orphan nav check and switches link validation to GitHub-stub mode (relative link targets must exist on disk, so a future `docs/recovery/` rename fails CI until the stub is updated). The comment scopes the exception: a deliberate exit from decision 6 (no pointer stubs), kept only while supported releases print the path.

## Verification

- `go test ./test/docsync` — pass (orphan check and stub-mode link validation)
- `https://beads.gascity.com/recovery/` curl-verified 200
- Angle-bracket autolinks avoided (Mintlify builds hidden pages as MDX, where they parse as JSX)
- The definitive proof — `https://github.com/gastownhall/beads/blob/main/docs/RECOVERY.md#pk-fork-refused` resolving — lands only after this merges.