### PR TITLE
docs(upgrading): document BD_ALLOW_REMOTE_MIGRATE; fix the dead heartbeat link breaking main's docsync guard

### DIFF
--- a/docs/getting-started/upgrading.md
+++ b/docs/getting-started/upgrading.md
@@ -204,6 +204,12 @@ migrating here as the designated migrator, adopting the remote's already-migrate
 database, or recovering a fork — and asks for an explicit operator decision.
 Follow the guidance it prints.
 
+For scripted or CI upgrades where nobody reads the prompt,
+`BD_ALLOW_REMOTE_MIGRATE=1 bd migrate` (any boolean true value works) declares
+this clone the designated migrator and bypasses the gate entirely — including
+its already-forked checks — so wire it into exactly one clone's upgrade job,
+never all of them.
+
 **Multiple clones sharing one remote:**
 
 ```bash

--- a/docs/recovery/history-squash.md
+++ b/docs/recovery/history-squash.md
@@ -121,8 +121,8 @@ unfence your writers.
 ## Prevention
 
 High-frequency coordination state lives in unversioned tables precisely so
-routine agent traffic does not mint history — claim leases (see
-[bd heartbeat](/cli-reference/heartbeat)) and [wisps](/workflows/wisps) —
+routine agent traffic does not mint history — claim leases and
+[wisps](/workflows/wisps) —
 so bloat at this scale usually means something is writing versioned tables
 in a tight loop. Find and fix that writer, watch data-directory growth over time, and
 run `dolt gc` periodically so unreachable garbage never accumulates on top


### PR DESCRIPTION
## Why

Two small docs fixes, one of which un-breaks main's CI:

1. **Document `BD_ALLOW_REMOTE_MIGRATE` in the upgrade guide.** The v1.1.0 release notes tell the designated migrator to run `BD_ALLOW_REMOTE_MIGRATE=1 bd migrate`, but the docs never name the variable — the escape-hatch scrub (#4874) removed it from seven places where recipes taught it as a routine step. One honest mention belongs in the upgrade guide, where a blocked or CI-scripting reader actually looks. This is a deliberate, scoped refinement of the no-escape-hatches stance, not a return to sprinkling it through recipes.

2. **Fix the dead link failing the docsync guard on main.** The history-squash runbook (#4864) and the release-pinned CLI reference (#4876) crossed mid-flight: the runbook's prevention section links `/cli-reference/heartbeat`, a page the pin removed because `bd heartbeat` is not in v1.1.0. `TestDocsSiteLinks` fails on main and on every branch cut from it until this lands. The fix keeps the prose ("claim leases and wisps") and drops only the link.

## The added paragraph

Inserted after the "follow the guidance it prints" paragraph in the designated-migrator section of `getting-started/upgrading.md`:

> For scripted or CI upgrades where nobody reads the prompt, `BD_ALLOW_REMOTE_MIGRATE=1 bd migrate` (any boolean true value works) declares this clone the designated migrator and bypasses the gate entirely — including its already-forked checks — so wire it into exactly one clone's upgrade job, never all of them.

Every claim is derived from the v1.1.0 source rather than the release notes: boolean parsing and fire-only consultation (`internal/storage/schema/remote_migrate_gate.go:14-18`, `:299-314`), and the bypass-everything semantics (the env check returns before `routeSmartGate` runs, so the adopt/fork-skew lanes never execute — hence the explicit warning that it can push past an already-forked state). No phantom `bd migrate --force` reintroduced.

## Verification

- `go test ./test/docsync` — pass on this branch (fails on main today via the heartbeat link)
- `./scripts/check-doc-freshness.sh` — pass
- Two single-concern commits so the runbook fix is independently cherry-pickable