### PR TITLE
fix(storage): wire --label-regex into the query pipeline; register on bd ready

### DIFF
--- a/cmd/bd/ready.go
+++ b/cmd/bd/ready.go
@@ -89,6 +89,7 @@ This is useful for agents executing molecules to see which steps can run next.`,
 		labels, _ := cmd.Flags().GetStringSlice("label")
 		labelsAny, _ := cmd.Flags().GetStringSlice("label-any")
 		excludeLabels, _ := cmd.Flags().GetStringSlice("exclude-label")
+		labelRegex, _ := cmd.Flags().GetString("label-regex")
 		issueType, _ := cmd.Flags().GetString("type")
 		issueType = utils.NormalizeIssueType(issueType) // Expand aliases (mr→merge-request, etc.)
 		parentID, _ := cmd.Flags().GetString("parent")
@@ -141,6 +142,7 @@ This is useful for agents executing molecules to see which steps can run next.`,
 			Labels:           labels,
 			LabelsAny:        labelsAny,
 			ExcludeLabels:    excludeLabels,
+			LabelRegex:       labelRegex,
 			IncludeDeferred:  includeDeferred,  // GH#820: respect --include-deferred flag
 			IncludeEphemeral: includeEphemeral, // bd-i5k5x: allow ephemeral issues (e.g., merge-requests)
 			ExcludeTypes:     excludeTypes,
@@ -754,6 +756,12 @@ func init() {
 	readyCmd.Flags().StringSliceP("label", "l", []string{}, "Filter by labels (AND: must have ALL). Can combine with --label-any")
 	readyCmd.Flags().StringSlice("label-any", []string{}, "Filter by labels (OR: must have AT LEAST ONE). Can combine with --label")
 	readyCmd.Flags().StringSlice("exclude-label", []string{}, "Exclude issues that have ANY of these labels")
+	readyCmd.Flags().String("label-regex", "", "Filter by label regex pattern (e.g., 'tech-(debt|legacy)')")
+	// --label-pattern (glob) is intentionally NOT registered here yet: unlike
+	// --label-regex, BuildReadyWorkWhere doesn't read WorkFilter.LabelPattern
+	// until #4882 lands (ga-hqchm's SQL LIKE wiring), so exposing it on this
+	// command now would silently no-op — the exact dead-flag bug ga-7r884
+	// exists to eliminate, just on a third callsite. Add it once #4882 merges.
 	readyCmd.Flags().StringP("type", "t", "", "Filter by issue type (task, bug, feature, epic, decision, merge-request). Aliases: mr→merge-request, feat→feature, mol→molecule, dec/adr→decision")
 	readyCmd.Flags().String("mol", "", "Filter to steps within a specific molecule")
 	readyCmd.Flags().String("parent", "", "Filter to descendants of this bead/epic")

--- a/internal/storage/issueops/count.go
+++ b/internal/storage/issueops/count.go
@@ -14,6 +14,12 @@ import (
 // only the count: ephemeral-only filters route to the wisps table,
 // SkipWisps=true counts the durable issues table only, and otherwise the
 // wisps count is merged in (GH#4387).
+//
+// Known gap (ga-7r884): a set filter.LabelRegex is NOT reflected in this
+// count. LabelRegex is a Go-side, post-fetch filter (see compileLabelRegex)
+// — applying it here would require fetching and hydrating every candidate
+// row just to discard most of them, defeating the SELECT COUNT(*) this
+// function exists to provide cheaply. The returned count is pre-regex.
 func CountIssuesInTx(ctx context.Context, tx *sql.Tx, query string, filter types.IssueFilter) (int, error) {
 	if filter.Ephemeral != nil && *filter.Ephemeral {
 		wispCount, err := countTableInTx(ctx, tx, query, filter, WispsFilterTables)

--- a/internal/storage/issueops/label_regex.go
+++ b/internal/storage/issueops/label_regex.go
@@ -1,0 +1,73 @@
+package issueops
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// compileLabelRegex compiles pattern for use as a Go-side, post-fetch label
+// filter. Unlike LabelPattern, which BuildIssueFilterClauses/
+// BuildReadyWorkWhere push down as a SQL LIKE clause, LabelRegex can't be
+// evaluated in the WHERE clause: bd does not use SQL REGEXP functions
+// (engdocs/ICU-POLICY.md — that's the explicit justification for shipping
+// without libicu). Callers fetch candidates first, bound by every other
+// filter field (all SQL-pushed), and apply this afterward.
+func compileLabelRegex(pattern string) (*regexp.Regexp, error) {
+	re, err := regexp.Compile(pattern)
+	if err != nil {
+		return nil, fmt.Errorf("invalid --label-regex pattern %q: %w", pattern, err)
+	}
+	return re, nil
+}
+
+// labelsMatchRegex reports whether any label matches re.
+func labelsMatchRegex(labels []string, re *regexp.Regexp) bool {
+	for _, label := range labels {
+		if re.MatchString(label) {
+			return true
+		}
+	}
+	return false
+}
+
+// filterIssuesByLabelRegex returns the subset of issues with at least one
+// label matching re. issues must already be hydrated (Labels populated).
+func filterIssuesByLabelRegex(issues []*types.Issue, re *regexp.Regexp) []*types.Issue {
+	filtered := make([]*types.Issue, 0, len(issues))
+	for _, issue := range issues {
+		if labelsMatchRegex(issue.Labels, re) {
+			filtered = append(filtered, issue)
+		}
+	}
+	return filtered
+}
+
+// filterIssuesWithCountsByLabelRegex is filterIssuesByLabelRegex for the
+// counts-projection result type (SearchIssuesWithCountsInTx,
+// GetReadyWorkWithCountsInTx — the `bd ... --json` paths, which hydrate rows
+// through a separate scan/orchestration layer from the plain-Issue paths and
+// so need their own copy of this post-fetch filter).
+func filterIssuesWithCountsByLabelRegex(items []*types.IssueWithCounts, re *regexp.Regexp) []*types.IssueWithCounts {
+	filtered := make([]*types.IssueWithCounts, 0, len(items))
+	for _, item := range items {
+		if item != nil && item.Issue != nil && labelsMatchRegex(item.Issue.Labels, re) {
+			filtered = append(filtered, item)
+		}
+	}
+	return filtered
+}
+
+// truncateIssuesWithCounts applies filter.Limit in Go. Used after a
+// LabelRegex post-fetch filter has run, since the SQL-level LIMIT that
+// normally bounds these results is suppressed whenever LabelRegex is set
+// (see buildReadyWorkPredicates and runFilterSearchQueryInTx) — otherwise it
+// would cap the pre-regex candidate set and could drop real matches. When
+// LabelRegex is unset this is a no-op: the SQL LIMIT already bounded items.
+func truncateIssuesWithCounts(items []*types.IssueWithCounts, limit int) []*types.IssueWithCounts {
+	if limit > 0 && len(items) > limit {
+		return items[:limit]
+	}
+	return items
+}

--- a/internal/storage/issueops/label_regex_test.go
+++ b/internal/storage/issueops/label_regex_test.go
@@ -1,0 +1,143 @@
+package issueops
+
+import (
+	"testing"
+
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// ga-7r884: LabelRegex was parsed from --label-regex and stored on
+// IssueFilter/WorkFilter, but neither BuildIssueFilterClauses nor
+// BuildReadyWorkWhere ever read it — same dead-code shape ga-hqchm found in
+// LabelPattern (#4882), except LabelRegex can't be pushed into the WHERE
+// clause at all (bd does not use SQL REGEXP functions, engdocs/ICU-POLICY.md),
+// so the fix is this Go-side post-fetch filter instead of a SQL clause.
+
+func TestCompileLabelRegex(t *testing.T) {
+	t.Parallel()
+
+	t.Run("valid pattern compiles", func(t *testing.T) {
+		t.Parallel()
+		re, err := compileLabelRegex("tech-(debt|legacy)")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !re.MatchString("tech-debt") {
+			t.Error("expected compiled regex to match \"tech-debt\"")
+		}
+	})
+
+	t.Run("invalid pattern returns wrapped error", func(t *testing.T) {
+		t.Parallel()
+		_, err := compileLabelRegex("tech-(debt")
+		if err == nil {
+			t.Fatal("expected error for unbalanced group, got nil")
+		}
+		if got, want := err.Error(), `invalid --label-regex pattern "tech-(debt"`; !containsSubstring(got, want) {
+			t.Errorf("error = %q, want substring %q", got, want)
+		}
+	})
+
+	t.Run("empty pattern compiles (matches everything)", func(t *testing.T) {
+		t.Parallel()
+		re, err := compileLabelRegex("")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !re.MatchString("anything") {
+			t.Error("empty pattern should match any string")
+		}
+	})
+}
+
+func TestLabelsMatchRegex(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		labels []string
+		re     string
+		want   bool
+	}{
+		{"single label matches", []string{"tech-debt"}, "tech-.*", true},
+		{"no labels", nil, "tech-.*", false},
+		{"no matching label", []string{"frontend", "urgent"}, "^tech-", false},
+		{"one of several labels matches", []string{"frontend", "tech-legacy"}, "^tech-", true},
+		{"anchored pattern excludes partial match", []string{"biotech-debt"}, "^tech-", false},
+		{"alternation matches second branch", []string{"tech-legacy"}, "tech-(debt|legacy)", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			re, err := compileLabelRegex(tc.re)
+			if err != nil {
+				t.Fatalf("compileLabelRegex(%q): %v", tc.re, err)
+			}
+			if got := labelsMatchRegex(tc.labels, re); got != tc.want {
+				t.Errorf("labelsMatchRegex(%v, %q) = %v, want %v", tc.labels, tc.re, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestFilterIssuesByLabelRegex(t *testing.T) {
+	t.Parallel()
+
+	issues := []*types.Issue{
+		{ID: "a", Labels: []string{"tech-debt"}},
+		{ID: "b", Labels: []string{"frontend"}},
+		{ID: "c", Labels: []string{"tech-legacy", "urgent"}},
+		{ID: "d", Labels: nil},
+	}
+
+	re, err := compileLabelRegex("^tech-")
+	if err != nil {
+		t.Fatalf("compileLabelRegex: %v", err)
+	}
+
+	got := filterIssuesByLabelRegex(issues, re)
+
+	gotIDs := make([]string, len(got))
+	for i, issue := range got {
+		gotIDs[i] = issue.ID
+	}
+	want := []string{"a", "c"}
+	if len(gotIDs) != len(want) {
+		t.Fatalf("filterIssuesByLabelRegex ids = %v, want %v", gotIDs, want)
+	}
+	for i := range want {
+		if gotIDs[i] != want[i] {
+			t.Errorf("filterIssuesByLabelRegex ids = %v, want %v", gotIDs, want)
+			break
+		}
+	}
+
+	// ga-hqchm-class regression guard: a non-matching pattern must return an
+	// empty slice, not silently pass every issue through (the original bug's
+	// exact failure mode for LabelPattern).
+	noneRe, err := compileLabelRegex("nonexistent-.*")
+	if err != nil {
+		t.Fatalf("compileLabelRegex: %v", err)
+	}
+	if got := filterIssuesByLabelRegex(issues, noneRe); len(got) != 0 {
+		t.Errorf("expected empty result for non-matching pattern, got %d issues: %v", len(got), got)
+	}
+
+	// Must not mutate the input slice's backing array.
+	if len(issues) != 4 {
+		t.Errorf("filterIssuesByLabelRegex mutated input slice length: %d, want 4", len(issues))
+	}
+}
+
+func containsSubstring(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || indexOf(s, substr) >= 0)
+}
+
+func indexOf(s, substr string) int {
+	for i := 0; i+len(substr) <= len(s); i++ {
+		if s[i:i+len(substr)] == substr {
+			return i
+		}
+	}
+	return -1
+}

--- a/internal/storage/issueops/ready_work.go
+++ b/internal/storage/issueops/ready_work.go
@@ -74,8 +74,13 @@ func buildReadyWorkPredicates(ctx context.Context, tx DBTX, filter types.WorkFil
 	args = append(args, whereArgs...)
 	args = append(args, orderBy.Args...)
 
+	// LabelRegex can't be pushed into whereSQL (see compileLabelRegex), so
+	// GetReadyWorkInTx applies it in Go after fetching. Suppress the SQL
+	// LIMIT in that case — otherwise it would cap the pre-regex candidate
+	// set and could drop real matches — and let GetReadyWorkInTx apply
+	// filter.Limit itself once the regex filter has run.
 	var limitSQL string
-	if filter.Limit > 0 {
+	if filter.Limit > 0 && filter.LabelRegex == "" {
 		limitSQL = fmt.Sprintf("LIMIT %d", filter.Limit)
 	}
 
@@ -128,12 +133,26 @@ func GetReadyWorkInTx(
 		}
 	}
 
+	if filter.LabelRegex != "" {
+		re, reErr := compileLabelRegex(filter.LabelRegex)
+		if reErr != nil {
+			return nil, reErr
+		}
+		ordered = filterIssuesByLabelRegex(ordered, re)
+	}
+
 	wisps, wErr := getReadyWispsInTx(ctx, tx, filter, preds.deferredChildIDs)
 	if wErr != nil {
 		return nil, wErr
 	}
 	if len(wisps) > 0 {
+		// mergeReadyWisps applies filter.Limit itself after merging.
 		ordered = mergeReadyWisps(ordered, wisps, filter)
+	} else if filter.LabelRegex != "" && filter.Limit > 0 && len(ordered) > filter.Limit {
+		// No wisps to merge, so mergeReadyWisps' truncate never runs. The SQL
+		// LIMIT was suppressed above (LabelRegex set), so ordered can still
+		// exceed filter.Limit here — apply it now that the regex filter has run.
+		ordered = ordered[:filter.Limit]
 	}
 
 	return ordered, nil

--- a/internal/storage/issueops/ready_work_counts.go
+++ b/internal/storage/issueops/ready_work_counts.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"regexp"
 	"sort"
 
 	"github.com/steveyegge/beads/internal/storage/sqlbuild"
@@ -12,6 +13,20 @@ import (
 )
 
 func GetReadyWorkWithCountsInTx(ctx context.Context, tx *sql.Tx, filter types.WorkFilter) ([]*types.IssueWithCounts, error) {
+	// LabelRegex can't be pushed into whereSQL (see compileLabelRegex), so
+	// it's applied in Go below, to both the issues and wisps result sets.
+	// buildReadyWorkPredicates already suppresses the SQL LIMIT whenever
+	// LabelRegex is set (avoids capping the pre-regex candidate set); this
+	// function applies filter.Limit itself once filtering has run.
+	var labelRe *regexp.Regexp
+	if filter.LabelRegex != "" {
+		var reErr error
+		labelRe, reErr = compileLabelRegex(filter.LabelRegex)
+		if reErr != nil {
+			return nil, reErr
+		}
+	}
+
 	wispDepsExist, err := optionalTableExistsInTx(ctx, tx, "wisp_dependencies")
 	if err != nil {
 		return nil, fmt.Errorf("get ready work with counts: wisp dependency probe: %w", err)
@@ -25,16 +40,19 @@ func GetReadyWorkWithCountsInTx(ctx context.Context, tx *sql.Tx, filter types.Wo
 	if err != nil {
 		return nil, err
 	}
+	if labelRe != nil {
+		out = filterIssuesWithCountsByLabelRegex(out, labelRe)
+	}
 
 	empty, probeErr := wispsTableEmptyOrMissingInTx(ctx, tx)
 	if probeErr != nil {
 		return nil, fmt.Errorf("get ready work with counts: wisp probe: %w", probeErr)
 	}
 	if empty {
-		return out, nil
+		return truncateIssuesWithCounts(out, filter.Limit), nil
 	}
 	if !wispDepsExist {
-		return out, nil
+		return truncateIssuesWithCounts(out, filter.Limit), nil
 	}
 
 	wispPreds, err := buildReadyWorkPredicates(ctx, tx, filter, WispsFilterTables)
@@ -44,12 +62,15 @@ func GetReadyWorkWithCountsInTx(ctx context.Context, tx *sql.Tx, filter types.Wo
 	wisps, err := runReadyCountsInTx(ctx, tx, WispsFilterTables, filter.Limit, wispPreds, true, false)
 	if err != nil {
 		if isTableNotExistError(err) {
-			return out, nil
+			return truncateIssuesWithCounts(out, filter.Limit), nil
 		}
 		return nil, err
 	}
+	if labelRe != nil {
+		wisps = filterIssuesWithCountsByLabelRegex(wisps, labelRe)
+	}
 	if len(wisps) == 0 {
-		return out, nil
+		return truncateIssuesWithCounts(out, filter.Limit), nil
 	}
 
 	// Prefer the canonical wisp record when an ID exists in both tables (be-iabdi).
@@ -148,7 +169,18 @@ func runReadyCountsInTx(ctx context.Context, tx *sql.Tx, tables FilterTables, li
 
 // CountReadyWorkInTx returns the number of ready-work items — identical to
 // len(GetReadyWorkWithCountsInTx(filter with Limit=0)) — without materializing
-// the counts mega-query. The ready set is a union of the issues and wisps that
+// the counts mega-query.
+//
+// Known gap (ga-7r884): this identity does NOT hold when filter.LabelRegex is
+// set. LabelRegex is a Go-side, post-fetch filter (see compileLabelRegex) —
+// applying it here would mean fetching and hydrating every candidate row just
+// to discard most of them, defeating the SELECT COUNT(*) this function exists
+// to avoid. The count returned counts pre-regex matches, so any caller using
+// it as a "Showing X of N" total while LabelRegex is also set will see an N
+// that overcounts. Not fixed here: same "count-only path can't apply a
+// Go-side filter" shape as CountIssuesInTx.
+//
+// The ready set is a union of the issues and wisps that
 // match the ready predicate, so it sizes each family with a single indexed
 // COUNT(*) over that predicate and subtracts the overlap (IDs present in both
 // ready sets, which GetReadyWorkWithCountsInTx dedupes wisp-wins). It never

--- a/internal/storage/issueops/ready_work_test.go
+++ b/internal/storage/issueops/ready_work_test.go
@@ -122,6 +122,45 @@ func TestGetReadyWorkInTx_PropagatesDeferredParentChildError(t *testing.T) {
 	}
 }
 
+// ga-7r884: LabelRegex can't be pushed into whereSQL (bd does not use SQL
+// REGEXP functions), so GetReadyWorkInTx applies it in Go after fetching.
+// buildReadyWorkPredicates must suppress the SQL LIMIT whenever LabelRegex is
+// set — otherwise the LIMIT would cap the pre-regex candidate set and
+// GetReadyWorkInTx's post-filter could silently drop real matches beyond the
+// first filter.Limit unfiltered rows (the same "wrong result, no error"
+// shape ga-hqchm hit with LabelPattern, just via a different mechanism).
+// IncludeDeferred:true and ParentID:nil keep this a pure predicate-building
+// call with no SQL round-trips, so no sqlmock expectations are needed beyond
+// the transaction sqlmock.New() itself always requires.
+func TestBuildReadyWorkPredicates_SuppressesLimitSQLWhenLabelRegexSet(t *testing.T) {
+	t.Parallel()
+
+	_, _, tx := beginMockTx(t)
+
+	withRegex, err := buildReadyWorkPredicates(context.Background(), tx, types.WorkFilter{
+		IncludeDeferred: true,
+		Limit:           10,
+		LabelRegex:      "tech-.*",
+	}, IssuesFilterTables)
+	if err != nil {
+		t.Fatalf("buildReadyWorkPredicates (LabelRegex set): %v", err)
+	}
+	if withRegex.limitSQL != "" {
+		t.Errorf("limitSQL = %q, want empty when LabelRegex is set (regex filter runs post-fetch in Go)", withRegex.limitSQL)
+	}
+
+	withoutRegex, err := buildReadyWorkPredicates(context.Background(), tx, types.WorkFilter{
+		IncludeDeferred: true,
+		Limit:           10,
+	}, IssuesFilterTables)
+	if err != nil {
+		t.Fatalf("buildReadyWorkPredicates (no LabelRegex): %v", err)
+	}
+	if want := "LIMIT 10"; withoutRegex.limitSQL != want {
+		t.Errorf("limitSQL = %q, want %q when LabelRegex is unset (existing SQL-pushdown behavior preserved)", withoutRegex.limitSQL, want)
+	}
+}
+
 func TestLoadStatusByIDInTxPrefersWispOnCollision(t *testing.T) {
 	t.Parallel()
 

--- a/internal/storage/issueops/search.go
+++ b/internal/storage/issueops/search.go
@@ -43,6 +43,12 @@ type searchProjection[T any] struct {
 	// set is closed (so we don't hold multiple active result sets on the same
 	// connection). nil for projections that don't need post-scan loading.
 	hydrate func(ctx context.Context, tx DBTX, tables FilterTables, items []T, filter types.IssueFilter) error
+	// labelsOf extracts an item's labels for the Go-side LabelRegex filter
+	// (see compileLabelRegex — LabelRegex can't be pushed into the WHERE
+	// clause the way LabelPattern is). nil for projections that never
+	// hydrate labels; searchTableInTxT errors rather than silently ignoring
+	// LabelRegex if one reaches it.
+	labelsOf func(T) []string
 	// idShrink enables Pattern B (cheap SELECT id scan → batch hydrate) for
 	// limited queries. Worth it only for wide projections; the id projection
 	// already scans id-only with no hydration, so it leaves this false.
@@ -57,6 +63,7 @@ var issueProjection = searchProjection[*types.Issue]{
 	scan:       func(rows *sql.Rows) (*types.Issue, error) { return ScanIssueFrom(rows) },
 	id:         func(issue *types.Issue) string { return issue.ID },
 	hydrate:    hydrateIssueLabelsAndDeps,
+	labelsOf:   func(issue *types.Issue) []string { return issue.Labels },
 	idShrink:   true,
 	joinLeases: true,
 }
@@ -190,7 +197,13 @@ func searchTableInTxT[T any](ctx context.Context, tx DBTX, query string, filter 
 	// (mirrors GetStaleIssuesInTx). The id projection itself leaves idShrink
 	// false: it *is* the id-only scan, so it falls straight through to the
 	// direct path below — one query, no second fetch, no hydration.
-	if proj.idShrink && filter.Limit > 0 && !filter.NoIDShrink {
+	//
+	// LabelRegex can't be pushed into the id-only scan's WHERE clause (see
+	// compileLabelRegex), so a LIMIT-bound id-shrink would apply the SQL
+	// LIMIT to candidates the regex hasn't filtered yet and could drop real
+	// matches. Fall through to the direct path instead, which fetches every
+	// WHERE-matching row, regex-filters, then applies filter.Limit last.
+	if proj.idShrink && filter.Limit > 0 && !filter.NoIDShrink && filter.LabelRegex == "" {
 		return searchTablePatternBT(ctx, tx, query, filter, tables, proj)
 	}
 
@@ -207,9 +220,12 @@ func searchTableInTxT[T any](ctx context.Context, tx DBTX, query string, filter 
 	}
 
 	limitSQL := ""
-	if filter.Limit > 0 {
+	if filter.Limit > 0 && filter.LabelRegex == "" {
 		limitSQL = fmt.Sprintf(" LIMIT %d", filter.Limit)
 	}
+	// When LabelRegex is set, filter.Limit is applied in Go after the regex
+	// filter runs (below) instead of here — otherwise a real match beyond
+	// the first filter.Limit pre-regex rows would be silently dropped.
 
 	selectKeyword := "SELECT "
 	if plan.Distinct {
@@ -252,6 +268,26 @@ func searchTableInTxT[T any](ctx context.Context, tx DBTX, query string, filter 
 	if proj.hydrate != nil && len(results) > 0 {
 		if err := proj.hydrate(ctx, tx, tables, results, filter); err != nil {
 			return nil, fmt.Errorf("search %s: %w", tables.Main, err)
+		}
+	}
+
+	if filter.LabelRegex != "" {
+		if proj.labelsOf == nil {
+			return nil, fmt.Errorf("search %s: --label-regex requires a projection that hydrates labels", tables.Main)
+		}
+		re, reErr := compileLabelRegex(filter.LabelRegex)
+		if reErr != nil {
+			return nil, reErr
+		}
+		filteredResults := make([]T, 0, len(results))
+		for _, item := range results {
+			if labelsMatchRegex(proj.labelsOf(item), re) {
+				filteredResults = append(filteredResults, item)
+			}
+		}
+		results = filteredResults
+		if filter.Limit > 0 && len(results) > filter.Limit {
+			results = results[:filter.Limit]
 		}
 	}
 

--- a/internal/storage/issueops/search_counts.go
+++ b/internal/storage/issueops/search_counts.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"regexp"
 	"sort"
 
 	"github.com/steveyegge/beads/internal/storage/sqlbuild"
@@ -11,6 +12,18 @@ import (
 )
 
 func SearchIssuesWithCountsInTx(ctx context.Context, tx *sql.Tx, query string, filter types.IssueFilter) ([]*types.IssueWithCounts, error) {
+	// LabelRegex can't be pushed into whereSQL (see compileLabelRegex), so it's
+	// applied in Go via finishSearchIssuesWithCounts below. Compile once up
+	// front: every return path in this function funnels through that helper.
+	var labelRe *regexp.Regexp
+	if filter.LabelRegex != "" {
+		var reErr error
+		labelRe, reErr = compileLabelRegex(filter.LabelRegex)
+		if reErr != nil {
+			return nil, reErr
+		}
+	}
+
 	wispDepsExist, err := optionalTableExistsInTx(ctx, tx, "wisp_dependencies")
 	if err != nil {
 		return nil, fmt.Errorf("search issues with counts: wisp dependency probe: %w", err)
@@ -27,7 +40,7 @@ func SearchIssuesWithCountsInTx(ctx context.Context, tx *sql.Tx, query string, f
 				return nil, err
 			}
 			if len(wisps) > 0 {
-				return finishSearchIssuesWithCounts(wisps, filter), nil
+				return finishSearchIssuesWithCounts(wisps, filter, labelRe), nil
 			}
 		}
 		// Fall through: the wisps tier is missing/empty or matched no rows.
@@ -40,7 +53,7 @@ func SearchIssuesWithCountsInTx(ctx context.Context, tx *sql.Tx, query string, f
 		if err != nil {
 			return nil, err
 		}
-		return finishSearchIssuesWithCounts(out, filter), nil
+		return finishSearchIssuesWithCounts(out, filter, labelRe), nil
 	}
 
 	out, err := runFilterSearchQueryInTx(ctx, tx, query, filter, IssuesFilterTables, wispDepsExist)
@@ -50,7 +63,7 @@ func SearchIssuesWithCountsInTx(ctx context.Context, tx *sql.Tx, query string, f
 
 	// Skip wisps merge entirely when caller opts out (Q2: perf escape hatch).
 	if filter.SkipWisps {
-		return finishSearchIssuesWithCounts(out, filter), nil
+		return finishSearchIssuesWithCounts(out, filter, labelRe), nil
 	}
 
 	empty, probeErr := wispsTableEmptyOrMissingInTx(ctx, tx)
@@ -58,21 +71,21 @@ func SearchIssuesWithCountsInTx(ctx context.Context, tx *sql.Tx, query string, f
 		return nil, fmt.Errorf("search issues with counts: wisp probe: %w", probeErr)
 	}
 	if empty {
-		return finishSearchIssuesWithCounts(out, filter), nil
+		return finishSearchIssuesWithCounts(out, filter, labelRe), nil
 	}
 	if !wispDepsExist {
-		return finishSearchIssuesWithCounts(out, filter), nil
+		return finishSearchIssuesWithCounts(out, filter, labelRe), nil
 	}
 
 	wisps, err := runFilterSearchQueryInTx(ctx, tx, query, filter, WispsFilterTables, true)
 	if err != nil {
 		if isTableNotExistError(err) {
-			return finishSearchIssuesWithCounts(out, filter), nil
+			return finishSearchIssuesWithCounts(out, filter, labelRe), nil
 		}
 		return nil, err
 	}
 	if len(wisps) == 0 {
-		return finishSearchIssuesWithCounts(out, filter), nil
+		return finishSearchIssuesWithCounts(out, filter, labelRe), nil
 	}
 
 	// Prefer the canonical wisp record when an ID exists in both tables (be-iabdi).
@@ -93,7 +106,7 @@ func SearchIssuesWithCountsInTx(ctx context.Context, tx *sql.Tx, query string, f
 		}
 	}
 	kept = append(kept, wisps...)
-	return finishSearchIssuesWithCounts(kept, filter), nil
+	return finishSearchIssuesWithCounts(kept, filter, labelRe), nil
 }
 
 func runFilterSearchQueryInTx(ctx context.Context, tx *sql.Tx, query string, filter types.IssueFilter, tables FilterTables, includeWispReverseDeps bool) ([]*types.IssueWithCounts, error) {
@@ -105,8 +118,12 @@ func runFilterSearchQueryInTx(ctx context.Context, tx *sql.Tx, query string, fil
 	if len(whereClauses) > 0 {
 		whereSQL = "WHERE " + joinAnd(whereClauses)
 	}
+	// See SearchIssuesWithCountsInTx: LabelRegex is applied in Go after
+	// fetching, so the SQL LIMIT is suppressed here to avoid capping the
+	// pre-regex candidate set. finishSearchIssuesWithCounts applies
+	// filter.Limit itself once the regex filter (if any) has run.
 	limitSQL := ""
-	if filter.Limit > 0 {
+	if filter.Limit > 0 && filter.LabelRegex == "" {
 		limitSQL = fmt.Sprintf("LIMIT %d", filter.Limit)
 	}
 	orderBy := sqlbuild.OrderBy(filter.SortBy, filter.SortDesc, "i")
@@ -154,7 +171,14 @@ func scanCountsRowsInTx(ctx context.Context, tx *sql.Tx, mainTable, query string
 	return out, nil
 }
 
-func finishSearchIssuesWithCounts(items []*types.IssueWithCounts, filter types.IssueFilter) []*types.IssueWithCounts {
+// finishSearchIssuesWithCounts applies the LabelRegex post-fetch filter (see
+// compileLabelRegex), sorts, and truncates to filter.Limit. labelRe is nil
+// when filter.LabelRegex is unset, in which case items is already
+// SQL-LIMIT-bound and the truncate below is a no-op.
+func finishSearchIssuesWithCounts(items []*types.IssueWithCounts, filter types.IssueFilter, labelRe *regexp.Regexp) []*types.IssueWithCounts {
+	if labelRe != nil {
+		items = filterIssuesWithCountsByLabelRegex(items, labelRe)
+	}
 	sortSearchIssuesWithCounts(items, filter.SortBy, filter.SortDesc)
 	if filter.Limit > 0 && len(items) > filter.Limit {
 		return items[:filter.Limit]

--- a/internal/storage/issueops/search_counts_test.go
+++ b/internal/storage/issueops/search_counts_test.go
@@ -104,7 +104,7 @@ func TestFinishSearchIssuesWithCountsTruncatesByRequestedSort(t *testing.T) {
 		iwc("bd-newest-p4", 4, at(10)),
 	}
 
-	got := finishSearchIssuesWithCounts(items, types.IssueFilter{SortBy: "created", Limit: 2})
+	got := finishSearchIssuesWithCounts(items, types.IssueFilter{SortBy: "created", Limit: 2}, nil)
 	if len(got) != 2 || got[0].Issue.ID != "bd-newest-p4" || got[1].Issue.ID != "bd-new-p3" {
 		ids := make([]string, len(got))
 		for i, g := range got {
@@ -114,7 +114,7 @@ func TestFinishSearchIssuesWithCountsTruncatesByRequestedSort(t *testing.T) {
 	}
 
 	// SortDesc flips the per-key default direction: created becomes ASC.
-	got = finishSearchIssuesWithCounts(items, types.IssueFilter{SortBy: "created", SortDesc: true, Limit: 2})
+	got = finishSearchIssuesWithCounts(items, types.IssueFilter{SortBy: "created", SortDesc: true, Limit: 2}, nil)
 	if len(got) != 2 || got[0].Issue.ID != "bd-old-p0" || got[1].Issue.ID != "bd-mid-p2" {
 		ids := make([]string, len(got))
 		for i, g := range got {
@@ -124,7 +124,7 @@ func TestFinishSearchIssuesWithCountsTruncatesByRequestedSort(t *testing.T) {
 	}
 
 	// Default (no SortBy) keeps the historical priority/created/id order.
-	got = finishSearchIssuesWithCounts(items, types.IssueFilter{Limit: 2})
+	got = finishSearchIssuesWithCounts(items, types.IssueFilter{Limit: 2}, nil)
 	if len(got) != 2 || got[0].Issue.ID != "bd-old-p0" || got[1].Issue.ID != "bd-mid-p2" {
 		ids := make([]string, len(got))
 		for i, g := range got {
@@ -132,4 +132,56 @@ func TestFinishSearchIssuesWithCountsTruncatesByRequestedSort(t *testing.T) {
 		}
 		t.Fatalf("default sort limit=2 kept %v, want [bd-old-p0 bd-mid-p2]", ids)
 	}
+}
+
+// ga-7r884: bd list --json goes through SearchIssuesWithCountsInTx, a
+// separate implementation from SearchIssuesInTx (search.go) with its own
+// row-fetch/hydrate/sort/truncate pipeline — LabelRegex needs its own
+// post-fetch filter applied here too, not just in the plain (non-json) path.
+func TestFinishSearchIssuesWithCountsAppliesLabelRegex(t *testing.T) {
+	t.Parallel()
+
+	iwc := func(id string, labels ...string) *types.IssueWithCounts {
+		return &types.IssueWithCounts{Issue: &types.Issue{ID: id, Labels: labels}}
+	}
+	items := []*types.IssueWithCounts{
+		iwc("a", "tech-debt"),
+		iwc("b", "frontend"),
+		iwc("c", "tech-legacy"),
+	}
+
+	re, err := compileLabelRegex("^tech-")
+	if err != nil {
+		t.Fatalf("compileLabelRegex: %v", err)
+	}
+
+	got := finishSearchIssuesWithCounts(items, types.IssueFilter{}, re)
+	if len(got) != 2 {
+		t.Fatalf("len(got) = %d, want 2 (a, c); got ids: %v", len(got), issueWithCountsIDs(got))
+	}
+	for _, want := range []string{"a", "c"} {
+		found := false
+		for _, g := range got {
+			if g.Issue.ID == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected %q in filtered result, got ids: %v", want, issueWithCountsIDs(got))
+		}
+	}
+
+	// nil labelRe (the LabelRegex-unset case) must not filter anything.
+	if got := finishSearchIssuesWithCounts(items, types.IssueFilter{}, nil); len(got) != len(items) {
+		t.Errorf("nil labelRe: len(got) = %d, want %d (unfiltered)", len(got), len(items))
+	}
+}
+
+func issueWithCountsIDs(items []*types.IssueWithCounts) []string {
+	ids := make([]string, len(items))
+	for i, item := range items {
+		ids[i] = item.Issue.ID
+	}
+	return ids
 }


### PR DESCRIPTION
## What

- Fixes `--label-regex` being silently ignored (parsed but never applied) across every `bd list`/`bd ready` row-fetch path — the `LabelRegex` analog of ga-hqchm/#4882's `LabelPattern` fix, implemented as a Go-side post-fetch filter since SQL `REGEXP` isn't available here (see Design below).
- Adds `--label-regex` flag registration to the standalone `bd ready` subcommand, which didn't expose it (or `--label-pattern`) at all.

## Why

Follow-up from ga-hqchm/#4882, split out per `CONTRIBUTING.md`'s one-issue-per-PR rule — both #4882's own scope note and this bug's description call this out explicitly. Two adjacent gaps:

1. `IssueFilter.LabelRegex`/`WorkFilter.LabelRegex` were parsed from `--label-regex` and stored on the filter structs, but no query builder ever read them — a non-matching pattern silently returned every issue, the exact shape #4882 fixed for `LabelPattern`.
2. The standalone `bd ready` subcommand doesn't register `--label-pattern`/`--label-regex` as flags at all (confirmed via `bd ready --help`), separate from the dead-filter bug above.

## Design: Go-side filter, not SQL

Unlike `LabelPattern` (which #4882 pushes down as a SQL `LIKE` clause), `LabelRegex` can't be pushed into the WHERE clause: `bd` does not use SQL `REGEXP` functions (`engdocs/ICU-POLICY.md` — the explicit justification for shipping without libicu). So this fix applies `regexp.MatchString` as a post-fetch, in-Go filter over already-hydrated issue labels.

That has one real architectural consequence, handled explicitly: filtering *after* the SQL layer means the SQL-level `LIMIT` can't run before the regex filter without risking dropping real matches that happen to sort after the first `--limit` *unfiltered* rows — silently wrong, no error, the exact bug class this whole chain exists to eliminate. So wherever `LabelRegex` is set, this PR suppresses the SQL `LIMIT`, fetches every row matching every *other* (SQL-pushed) filter, regex-filters in Go, then applies `--limit` itself. Verified end-to-end below that `--label-regex X --limit 1` returns a real match, not an empty/wrong result.

## Scope: which paths are fixed

Fixed, both the plain and `--json`/counts variants — `bd list --json` and `bd ready --json` turned out to route through entirely separate row-fetch/hydrate/sort/truncate implementations from the non-json path, which the first pass of this PR missed until manual end-to-end testing caught it returning unfiltered results under `--json`:

- `bd list --label-regex` (`SearchIssuesInTx` / `searchTableInTxT`)
- `bd list --label-regex --json` (`SearchIssuesWithCountsInTx`)
- `bd ready --label-regex` / `bd list --ready --label-regex` (`GetReadyWorkInTx`)
- `bd ready --label-regex --json` / `bd list --ready --label-regex --json` (`GetReadyWorkWithCountsInTx`)

Explicitly **not** fixed, documented inline at each site:

- `CountIssuesInTx` / `CountReadyWorkInTx` — `SELECT COUNT(*)`-only paths that never fetch or hydrate rows. Applying `LabelRegex` here would mean fetching every candidate just to discard most of it, defeating the point of a cheap count. A "Showing X of N" hint combined with `--label-regex` will overcount N (it counts pre-regex matches). This does **not** affect the correctness of the issues actually returned — only that informational total.
- `IterIssues`/`IterWisps` (`internal/storage/dolt`) — Go library API surface (`storage.Iter[T]`), not reachable from any `bd` CLI command.
- `--label-pattern` (glob) on `bd ready` — deliberately **not** registered as a flag yet. Unlike `--label-regex`, `WorkFilter.LabelPattern` still isn't read by `BuildReadyWorkWhere` until #4882 lands; registering it now would silently no-op — reproducing the exact dead-flag bug this PR exists to eliminate, just on a third callsite. Trivial follow-up once #4882 merges (mirrors this PR's `--label-regex` registration in shape).

## Testing

```
go test ./internal/storage/sqlbuild/... ./internal/storage/issueops/...   # all pass
go build -tags gms_pure_go ./...                                          # clean
go vet -tags gms_pure_go ./...                                            # clean
otool -L bd | grep -i icu                                                 # empty — binary stays ICU-free
```

New coverage: table-driven unit tests for the regex-matching primitives (`label_regex_test.go`, mirrors `TestGlobToSQLLike`'s style), a focused test proving `buildReadyWorkPredicates` suppresses the SQL `LIMIT` exactly when `LabelRegex` is set (`TestBuildReadyWorkPredicates_SuppressesLimitSQLWhenLabelRegexSet`), and a `finishSearchIssuesWithCounts` test covering the `--json` path directly (`TestFinishSearchIssuesWithCountsAppliesLabelRegex`).

Also verified end-to-end against a real built binary, against a scratch workspace (issues labeled `tech-debt`, `tech-legacy`, `frontend`, `biotech-debt`):

```
$ bd list --label-regex '^tech-' --json
{"id":"e2e-djm","labels":["tech-debt"]}
{"id":"e2e-g39","labels":["tech-legacy"]}
$ bd list --label-regex 'nonexistent-.*' --json
[]
$ bd list --label-regex '[invalid' --json
Error: invalid --label-regex pattern "[invalid": error parsing regexp: missing closing ]: `[invalid`

$ bd ready --label-regex '^tech-' --plain
📋 Ready work (2 issues with no active blockers):
1. [● P2] [task] e2e-djm: Tech debt issue
2. [● P2] [task] e2e-g39: Legacy tech issue

$ bd ready --label-pattern 'tech-*' --plain
Error: unknown flag: --label-pattern

$ bd ready --label-regex '^tech-' --json --limit 1
{"id":"e2e-djm","labels":["tech-debt"]}   # a real match — proves limit-then-filter isn't silently dropping matches
```
