### PR TITLE
fix(dolt): stop misreporting an interrupted fsck as dangling-chunk corruption (bd-f2b15)

### DIFF
--- a/internal/storage/dolt/fsck_test.go
+++ b/internal/storage/dolt/fsck_test.go
@@ -200,7 +200,59 @@ func TestClassifyFSCKFailure(t *testing.T) {
 			wantIsNot:    []error{ErrDanglingReference},
 			wantContains: "BEADS_FSCK_TIMEOUT",
 		},
-		// (e) Generic non-zero exit, empty output, no context error → ErrDanglingReference.
+		// (e) Cancellation phrasing in output with no context error (bd-f2b15
+		//     pin): a killed process group leaves "context canceled" in the
+		//     output while both contexts look healthy. Must NOT be reported
+		//     as corruption.
+		{
+			name:         "output 'context canceled' + nil ctx errors → interrupted, not ErrDanglingReference",
+			parentErr:    nil,
+			fsckErr:      nil,
+			output:       "context canceled",
+			wantIs:       context.Canceled,
+			wantIsNot:    []error{ErrDanglingReference, ErrFSCKTimeout},
+			wantContains: "interrupted",
+		},
+		{
+			name:         "output 'signal: killed' + nil ctx errors → interrupted, not ErrDanglingReference",
+			parentErr:    nil,
+			fsckErr:      nil,
+			output:       "signal: killed",
+			wantIs:       context.Canceled,
+			wantIsNot:    []error{ErrDanglingReference, ErrFSCKTimeout},
+			wantContains: "interrupted",
+		},
+		// (a→b) Cancellation phrasing falls through to the parent-canceled branch.
+		{
+			name:      "output 'context canceled' + parent Canceled → cancellation, not dangling",
+			parentErr: context.Canceled,
+			fsckErr:   context.Canceled,
+			output:    "context canceled",
+			wantIs:    context.Canceled,
+			wantIsNot: []error{ErrDanglingReference, ErrFSCKTimeout},
+		},
+		// (a→d) Cancellation phrasing + fsck's own deadline → timeout guidance,
+		//       not a corruption report.
+		{
+			name:         "output 'context deadline exceeded' + own fsck timeout → ErrFSCKTimeout, not dangling",
+			parentErr:    nil,
+			fsckErr:      context.DeadlineExceeded,
+			output:       "context deadline exceeded",
+			wantIs:       ErrFSCKTimeout,
+			wantIsNot:    []error{ErrDanglingReference},
+			wantContains: "BEADS_FSCK_TIMEOUT",
+		},
+		// Negative sentinel: real corruption output without cancellation
+		// phrasing must still abort.
+		{
+			name:      "real corruption output stays ErrDanglingReference despite nil ctx errors",
+			parentErr: nil,
+			fsckErr:   nil,
+			output:    "dangling chunk reference: hash abc123 not found",
+			wantIs:    ErrDanglingReference,
+			wantIsNot: []error{ErrFSCKTimeout},
+		},
+		// (f) Generic non-zero exit, empty output, no context error → ErrDanglingReference.
 		{
 			name:      "generic failure (empty output, no ctx error) → ErrDanglingReference",
 			parentErr: nil,
@@ -240,6 +292,58 @@ func TestClassifyFSCKFailure(t *testing.T) {
 			}
 			if tc.wantAbsent != "" && strings.Contains(err.Error(), tc.wantAbsent) {
 				t.Errorf("error message %q must not contain %q", err.Error(), tc.wantAbsent)
+			}
+		})
+	}
+}
+
+// TestFsckOutputInterrupted verifies the helper recognizes the cancellation
+// phrasings an interrupted fsck prints, and does not classify integrity
+// findings or unrelated output as interrupts.
+func TestFsckOutputInterrupted(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name   string
+		output string
+		want   bool
+	}{
+		{
+			name:   "context canceled (observed: killed background bd dolt push, bd-f2b15)",
+			output: "context canceled",
+			want:   true,
+		},
+		{
+			name:   "context deadline exceeded",
+			output: "error: context deadline exceeded",
+			want:   true,
+		},
+		{
+			name:   "signal killed",
+			output: "signal: killed",
+			want:   true,
+		},
+		{
+			name:   "signal terminated",
+			output: "signal: terminated",
+			want:   true,
+		},
+		{
+			name:   "real dangling reference is not an interrupt",
+			output: "dangling chunk reference: hash abc123 referenced but not present",
+			want:   false,
+		},
+		{
+			name:   "empty output",
+			output: "",
+			want:   false,
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := fsckOutputInterrupted(tc.output); got != tc.want {
+				t.Errorf("fsckOutputInterrupted(%q) = %v, want %v", tc.output, got, tc.want)
 			}
 		})
 	}

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -2420,12 +2420,13 @@ func (s *DoltStore) credentialsForRemote(remote string) *remoteCredentials {
 // re-pushes that remote faithfully propagates the dangling reference.
 //
 // If CLIDir is empty or .dolt/noms does not exist, the check is skipped.
-// Five outcomes are possible when fsck exits non-zero (see classifyFSCKFailure):
+// Six outcomes are possible when fsck exits non-zero (see classifyFSCKFailure):
 //   - non-empty output, could-not-open: skipped with a log warning.
 //   - non-empty output, other: ErrDanglingReference — push aborted.
 //   - parent context canceled: cancellation error — push aborted.
 //   - parent context deadline exceeded: ErrFSCKTimeout (caller timeout) — push aborted.
 //   - fsck own timeout: ErrFSCKTimeout (raise BEADS_FSCK_TIMEOUT) — push aborted.
+//   - cancellation phrasing in output, no context error: cancellation error — push aborted.
 func (s *DoltStore) prePushFSCK(ctx context.Context) error {
 	dir := s.CLIDir()
 	if dir == "" {
@@ -2450,15 +2451,18 @@ func (s *DoltStore) prePushFSCK(ctx context.Context) error {
 	return nil
 }
 
-// classifyFSCKFailure maps a failed dolt fsck exit into one of five outcomes,
+// classifyFSCKFailure maps a failed dolt fsck exit into one of six outcomes,
 // evaluated in priority order:
 //
 //	(a) Non-empty output → route by content: could-not-open → nil (caller logs
-//	    and skips); any other content → ErrDanglingReference abort. Non-empty
-//	    output means fsck actually ran and said something (--quiet fsck is
-//	    silent until it finds a problem), so content wins over context state.
-//	    This also closes the race where real corruption arrives at the deadline
-//	    instant and would otherwise be masked as a timeout.
+//	    and skips); cancellation phrasing (fsckOutputInterrupted) → fall
+//	    through to the context-state branches below, because an interrupted
+//	    fsck prints e.g. "context canceled" before dying and that text is not
+//	    an integrity finding; any other content → ErrDanglingReference abort.
+//	    Non-empty output means fsck actually ran and said something (--quiet
+//	    fsck is silent until it finds a problem), so content wins over context
+//	    state. This also closes the race where real corruption arrives at the
+//	    deadline instant and would otherwise be masked as a timeout.
 //
 //	(b) Parent context canceled (Ctrl-C, caller abort) → plain cancellation
 //	    error wrapping context.Canceled; neither ErrDanglingReference nor
@@ -2474,19 +2478,30 @@ func (s *DoltStore) prePushFSCK(ctx context.Context) error {
 //	(d) fsck's own deadline exceeded, parent still running → ErrFSCKTimeout
 //	    with dolt gc / CALL DOLT_GC() / BEADS_FSCK_TIMEOUT guidance.
 //
-//	(e) Generic non-zero exit, empty output → ErrDanglingReference abort.
+//	(e) Cancellation phrasing in output but no recognized context error — the
+//	    bd process (group) was killed out from under fsck, so neither context
+//	    carries the reason. Plain cancellation error wrapping context.Canceled;
+//	    the store is not implicated.
+//
+//	(f) Generic non-zero exit, empty output → ErrDanglingReference abort.
 //
 // Returning nil for the could-not-open case (branch a) distinguishes "fsck
 // couldn't run at all" from "fsck ran and found a problem". Wrapping an
-// open-failure as ErrDanglingReference misleads users (dolthub/dolt#10915).
+// open-failure as ErrDanglingReference misleads users (dolthub/dolt#10915);
+// so does wrapping an interrupt's "context canceled" noise as corruption
+// (same genus, observed when a background push's process group was killed).
 func classifyFSCKFailure(parentErr, fsckErr error, output string) error {
 	// (a) Non-empty output: fsck actually reported something; route by content.
 	if output != "" {
 		if fsckCouldNotOpen(output) {
 			return nil
 		}
-		return fmt.Errorf("%w: aborting push to prevent propagating corrupt chunks: %s",
-			ErrDanglingReference, output)
+		if !fsckOutputInterrupted(output) {
+			return fmt.Errorf("%w: aborting push to prevent propagating corrupt chunks: %s",
+				ErrDanglingReference, output)
+		}
+		// Cancellation phrasing: not an integrity finding — classify by
+		// context state below.
 	}
 	// (b) Parent context canceled — user interrupt or caller abort.
 	if errors.Is(parentErr, context.Canceled) {
@@ -2509,7 +2524,13 @@ func classifyFSCKFailure(parentErr, fsckErr error, output string) error {
 			"the timeout can be raised via the BEADS_FSCK_TIMEOUT environment variable",
 			ErrFSCKTimeout)
 	}
-	// (e) Generic failure with no output and no recognized context error.
+	// (e) Interrupted fsck whose cancellation reason lives only in the output
+	// (process group killed: both contexts look healthy from here).
+	if fsckOutputInterrupted(output) {
+		return fmt.Errorf("pre-push integrity check interrupted: %w: %s",
+			context.Canceled, output)
+	}
+	// (f) Generic failure with no output and no recognized context error.
 	return fmt.Errorf("%w: aborting push to prevent propagating corrupt chunks",
 		ErrDanglingReference)
 }
@@ -2526,6 +2547,26 @@ func fsckCouldNotOpen(output string) bool {
 	default:
 		return false
 	}
+}
+
+// fsckOutputInterrupted reports whether dolt fsck output is cancellation
+// noise from a dying process rather than an integrity finding. An fsck
+// interrupted mid-run (Ctrl-C, killed process group, expired deadline)
+// prints the literal cancellation text to its combined output before
+// exiting; treating that as a dangling-reference finding produces a false
+// corruption report for a plain interrupt (bd-f2b15).
+func fsckOutputInterrupted(output string) bool {
+	for _, phrase := range []string{
+		"context canceled",
+		"context deadline exceeded",
+		"signal: killed",
+		"signal: terminated",
+	} {
+		if strings.Contains(output, phrase) {
+			return true
+		}
+	}
+	return false
 }
 
 // doltCLIPush shells out to `dolt push` from the database directory.


### PR DESCRIPTION
## Summary

`classifyFSCKFailure` (internal/storage/dolt/store.go) routed **any** non-empty fsck output that wasn't a could-not-open phrasing to `ErrDanglingReference`. When the bd process group is killed mid-fsck (observed: a background `bd dolt push` stopped during the bd-lrgn1 cutover), `dolt fsck` prints the literal text `context canceled` to its combined output before dying — so the user saw:

    Error: dangling chunk reference: aborting push to prevent propagating corrupt chunks: context canceled

a false corruption report for a plain interrupt. Same genus as the dolthub/dolt#10915 could-not-open misclassification that branch (a) already guards against. The store was fine (the remote pushed clean minutes later).

## Fix

- New `fsckOutputInterrupted` helper recognizes cancellation phrasings in fsck output: `context canceled`, `context deadline exceeded`, `signal: killed`, `signal: terminated`.
- Branch (a) now falls through to the context-state branches for such output instead of declaring corruption — so parent-cancel still maps to plain cancellation (b), caller deadline to caller-timeout guidance (c), fsck's own timeout to `BEADS_FSCK_TIMEOUT` guidance (d).
- New branch (e): cancellation phrasing with **no** live context error (process group killed out from under fsck — both contexts look healthy from the classifier's view) returns a plain cancellation error wrapping `context.Canceled`, not `ErrDanglingReference`.
- Real corruption output (no cancellation phrasing) still aborts the push exactly as before.

## Tests

- bd-f2b15's required pin: `output='context canceled'` + `parentErr=nil` must NOT map to `ErrDanglingReference` — plus `signal: killed`, fall-through-to-(b), fall-through-to-(d), and a negative sentinel that real dangling-reference output still aborts.
- `TestFsckOutputInterrupted` table covering all four phrasings and non-interrupt output.
- Full `./internal/storage/dolt/` package green locally; `go vet` + `go build ./...` clean.

Closes bd-f2b15.

🤖 Generated with [Claude Code](https://claude.com/claude-code)