### PR TITLE
fix(gc): prune remote-tracking refs before post-squash GC so flatten/compact actually reclaim (bd-agctw)

### DIFF
--- a/cmd/bd/compact_dolt.go
+++ b/cmd/bd/compact_dolt.go
@@ -33,7 +33,9 @@ How it works:
   2. Creates a squashed base commit from all old history
   3. Cherry-picks recent commits on top
   4. Swaps main branch to the compacted version
-  5. Runs Dolt GC to reclaim space
+  5. Prunes remote-tracking refs (they would keep the old history alive;
+     the next push or fetch re-creates them at the new tip)
+  6. Runs Dolt GC to reclaim space
 
 Examples:
   bd compact --dry-run               # Preview: show commit breakdown
@@ -175,29 +177,46 @@ Examples:
 			return HandleError("compact failed: %v", err)
 		}
 
+		// Prune remote-tracking refs before GC: they still anchor the
+		// pre-compact chain, and with them in place GC reclaims nothing on any
+		// workspace that has ever pushed or fetched (bd-agctw).
+		sizeBefore := storeSizeBytes()
+		pruned, tags := pruneRemoteRefsForGC(ctx)
+		if !jsonOutput {
+			printPruneReport(pruned, tags)
+		}
+
 		// Reclaim disk space from orphaned old history
 		if gc, ok := storage.UnwrapStore(store).(storage.GarbageCollector); ok {
 			if err := gc.DoltGC(ctx); err != nil {
 				WarnError("dolt gc after compact failed: %v", err)
 			}
 		}
+		sizeAfter := storeSizeBytes()
 
 		elapsed := time.Since(start)
 		resultCommits := len(recentHashes) + 1
 
 		if jsonOutput {
-			return outputJSON(map[string]interface{}{
-				"success":        true,
-				"commits_before": totalCommits,
-				"commits_after":  resultCommits,
-				"old_squashed":   oldCommits,
-				"recent_kept":    len(recentHashes),
-				"elapsed_ms":     elapsed.Milliseconds(),
-			})
+			result := map[string]interface{}{
+				"success":            true,
+				"commits_before":     totalCommits,
+				"commits_after":      resultCommits,
+				"old_squashed":       oldCommits,
+				"recent_kept":        len(recentHashes),
+				"remote_refs_pruned": pruned,
+				"tags_anchoring":     tags,
+				"elapsed_ms":         elapsed.Milliseconds(),
+			}
+			addGCSizeJSON(result, sizeBefore, sizeAfter)
+			return outputJSON(result)
 		}
 		fmt.Printf("✓ Compacted %d commits → %d\n", totalCommits, resultCommits)
 		fmt.Printf("  Squashed: %d old commits → 1 base\n", oldCommits)
 		fmt.Printf("  Preserved: %d recent commits\n", len(recentHashes))
+		if line := gcSizeLine(sizeBefore, sizeAfter); line != "" {
+			fmt.Printf("  Store: %s\n", line)
+		}
 		fmt.Printf("  Time: %v\n", elapsed.Round(time.Millisecond))
 		return nil
 	},

--- a/cmd/bd/flatten.go
+++ b/cmd/bd/flatten.go
@@ -25,7 +25,9 @@ This uses the Tim Sehn recipe:
   2. Soft-reset to the initial commit (preserving all data)
   3. Commit everything as a single snapshot
   4. Swap main branch to the new flattened branch
-  5. Run Dolt GC to reclaim space from old history
+  5. Prune remote-tracking refs (they would keep the old history alive;
+     the next push or fetch re-creates them at the new tip)
+  6. Run Dolt GC to reclaim space from old history
 
 This is irreversible — all commit history is lost. The resulting database
 has exactly one commit containing all current data.
@@ -75,17 +77,27 @@ Examples:
 		}
 
 		if flattenDryRun {
+			remoteRefs, tags := listRemoteRefsAndTags(ctx)
 			if jsonOutput {
 				return outputJSON(map[string]interface{}{
-					"dry_run":       true,
-					"commit_count":  commitCount,
-					"initial_hash":  initialHash,
-					"would_flatten": commitCount > 1,
+					"dry_run":           true,
+					"commit_count":      commitCount,
+					"initial_hash":      initialHash,
+					"would_flatten":     commitCount > 1,
+					"remote_refs":       remoteRefs,
+					"tags":              tags,
+					"size_before_bytes": storeSizeBytes(),
 				})
 			}
 			fmt.Printf("DRY RUN — Flatten preview\n\n")
 			fmt.Printf("  Commits:        %d\n", commitCount)
 			fmt.Printf("  Initial commit: %s\n", initialHash)
+			if len(remoteRefs) > 0 {
+				fmt.Printf("  Remote refs:    %d (pruned before GC so old history is reclaimable)\n", len(remoteRefs))
+			}
+			if len(tags) > 0 {
+				fmt.Printf("  Tags:           %d (anchor old history; GC cannot reclaim past them)\n", len(tags))
+			}
 			if commitCount <= 1 {
 				fmt.Printf("\n  Already flat (1 commit). Nothing to do.\n")
 			} else {
@@ -121,23 +133,40 @@ Examples:
 			return HandleErrorRespectJSON("flatten failed: %v", err)
 		}
 
+		// Prune remote-tracking refs before GC: they still anchor the entire
+		// pre-flatten chain, and with them in place GC reclaims nothing on any
+		// workspace that has ever pushed or fetched (bd-agctw).
+		sizeBefore := storeSizeBytes()
+		pruned, tags := pruneRemoteRefsForGC(ctx)
+		if !jsonOutput {
+			printPruneReport(pruned, tags)
+		}
+
 		if gc, ok := storage.UnwrapStore(store).(storage.GarbageCollector); ok {
 			if err := gc.DoltGC(ctx); err != nil {
 				WarnError("dolt gc after flatten failed: %v", err)
 			}
 		}
+		sizeAfter := storeSizeBytes()
 
 		elapsed := time.Since(start)
 
 		if jsonOutput {
-			return outputJSON(map[string]interface{}{
-				"success":        true,
-				"commits_before": commitCount,
-				"commits_after":  1,
-				"elapsed_ms":     elapsed.Milliseconds(),
-			})
+			result := map[string]interface{}{
+				"success":            true,
+				"commits_before":     commitCount,
+				"commits_after":      1,
+				"remote_refs_pruned": pruned,
+				"tags_anchoring":     tags,
+				"elapsed_ms":         elapsed.Milliseconds(),
+			}
+			addGCSizeJSON(result, sizeBefore, sizeAfter)
+			return outputJSON(result)
 		}
 		fmt.Printf("✓ Flattened %d commits → 1\n", commitCount)
+		if line := gcSizeLine(sizeBefore, sizeAfter); line != "" {
+			fmt.Printf("  Store: %s\n", line)
+		}
 		fmt.Printf("  Time: %v\n", elapsed.Round(time.Millisecond))
 		return nil
 	},

--- a/cmd/bd/gc.go
+++ b/cmd/bd/gc.go
@@ -170,6 +170,7 @@ Examples:
 			}
 		}
 
+		var gcSizeInfo map[string]interface{}
 		if gcSkipDolt {
 			results = append(results, phaseResult{name: "Dolt GC", skipped: true})
 		} else {
@@ -189,14 +190,34 @@ Examples:
 				}
 				results = append(results, phaseResult{name: "Dolt GC", detail: "dry-run"})
 			} else {
+				// bd gc runs without a preceding squash, so remote-tracking
+				// refs are left alone here (they cache the remote tip for the
+				// migrate gate); flatten/compact prune them before their GC
+				// (bd-agctw). Sizes are reported so a no-op reclaim is visible.
+				sizeBefore := storeSizeBytes()
+				remoteRefs, tags := listRemoteRefsAndTags(ctx)
 				if err := gc.DoltGC(ctx); err != nil {
 					WarnError("dolt gc failed: %v", err)
 					results = append(results, phaseResult{name: "Dolt GC", detail: "failed"})
 				} else {
-					if !jsonOutput {
-						fmt.Println("  Done")
+					sizeAfter := storeSizeBytes()
+					detail := "complete"
+					if line := gcSizeLine(sizeBefore, sizeAfter); line != "" {
+						detail = "complete: " + line
 					}
-					results = append(results, phaseResult{name: "Dolt GC", detail: "complete"})
+					if !jsonOutput {
+						fmt.Printf("  Done (%s)\n", detail)
+						if len(remoteRefs)+len(tags) > 0 {
+							fmt.Printf("  Note: %d remote-tracking ref(s) and %d tag(s) anchor history;\n", len(remoteRefs), len(tags))
+							fmt.Printf("  after a history squash, use bd flatten / bd compact so they are pruned first.\n")
+						}
+					}
+					results = append(results, phaseResult{name: "Dolt GC", detail: detail})
+					gcSizeInfo = map[string]interface{}{
+						"remote_refs": len(remoteRefs),
+						"tags":        len(tags),
+					}
+					addGCSizeJSON(gcSizeInfo, sizeBefore, sizeAfter)
 				}
 			}
 			if !jsonOutput {
@@ -222,6 +243,9 @@ Examples:
 				phases = append(phases, p)
 			}
 			summaryMap["phases"] = phases
+			if gcSizeInfo != nil {
+				summaryMap["dolt_gc"] = gcSizeInfo
+			}
 			return outputJSON(summaryMap)
 		}
 

--- a/cmd/bd/gc_prune.go
+++ b/cmd/bd/gc_prune.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/steveyegge/beads/internal/storage"
+)
+
+// storeSizeBytes returns the on-disk size of the store's data directory, or
+// -1 when it cannot be determined (no local path, walk error). Measured
+// around DOLT_GC so a no-op reclaim is visible to the operator (bd-agctw).
+func storeSizeBytes() int64 {
+	loc, ok := storage.UnwrapStore(store).(storage.StoreLocator)
+	if !ok || loc.Path() == "" {
+		return -1
+	}
+	size, err := getDirSize(loc.Path())
+	if err != nil {
+		return -1
+	}
+	return size
+}
+
+// pruneRemoteRefsForGC deletes cached remote-tracking refs ahead of a
+// post-squash GC — they anchor the pre-squash chain, and with them in place
+// DOLT_GC reclaims nothing on any workspace that has ever pushed or fetched
+// (bd-agctw). Also returns tags, which anchor history the same way but are
+// user-created and therefore only warned about. Failures are warnings: GC
+// still runs, it just reclaims less.
+func pruneRemoteRefsForGC(ctx context.Context) (pruned, tags []string) {
+	pruner, ok := storage.UnwrapStore(store).(storage.RemoteRefPruner)
+	if !ok {
+		return nil, nil
+	}
+	var err error
+	pruned, err = pruner.PruneRemoteRefs(ctx)
+	if err != nil {
+		WarnError("pruning remote-tracking refs before GC: %v (GC may reclaim little)", err)
+	}
+	tags, err = pruner.ListTags(ctx)
+	if err != nil {
+		WarnError("listing tags before GC: %v", err)
+	}
+	return pruned, tags
+}
+
+// listRemoteRefsAndTags is the read-only companion for dry runs and bd gc.
+func listRemoteRefsAndTags(ctx context.Context) (refs, tags []string) {
+	pruner, ok := storage.UnwrapStore(store).(storage.RemoteRefPruner)
+	if !ok {
+		return nil, nil
+	}
+	refs, _ = pruner.ListRemoteRefs(ctx)
+	tags, _ = pruner.ListTags(ctx)
+	return refs, tags
+}
+
+// printPruneReport prints the outcome of pruneRemoteRefsForGC (text mode only).
+func printPruneReport(pruned, tags []string) {
+	if len(pruned) > 0 {
+		fmt.Printf("  Pruned %d remote-tracking ref(s): %s\n", len(pruned), strings.Join(pruned, ", "))
+		fmt.Printf("  (local cache only — the next push/fetch re-creates them at the new tip)\n")
+	}
+	if len(tags) > 0 {
+		fmt.Printf("  Warning: %d tag(s) still anchor old history: %s\n", len(tags), strings.Join(tags, ", "))
+		fmt.Printf("  GC cannot reclaim commits reachable from tags; delete unwanted tags and re-run GC.\n")
+	}
+}
+
+// gcSizeLine formats a before/after size pair as "X → Y (freed Z)", or ""
+// when either measurement failed.
+func gcSizeLine(before, after int64) string {
+	if before < 0 || after < 0 {
+		return ""
+	}
+	freed := before - after
+	if freed < 0 {
+		freed = 0
+	}
+	return fmt.Sprintf("%s → %s (freed %s)", formatBytes(before), formatBytes(after), formatBytes(freed))
+}
+
+// addGCSizeJSON adds size measurements to a JSON output map (fields omitted
+// when a measurement failed).
+func addGCSizeJSON(m map[string]interface{}, before, after int64) {
+	if before >= 0 {
+		m["size_before_bytes"] = before
+	}
+	if after >= 0 {
+		m["size_after_bytes"] = after
+	}
+	if before >= 0 && after >= 0 {
+		freed := before - after
+		if freed < 0 {
+			freed = 0
+		}
+		m["freed_bytes"] = freed
+	}
+}

--- a/internal/storage/dolt/prune_remote_refs_test.go
+++ b/internal/storage/dolt/prune_remote_refs_test.go
@@ -1,0 +1,143 @@
+package dolt
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"testing"
+)
+
+// TestDoltNew_PruneRemoteRefs_RealDolt is the regression test for bd-agctw:
+// on a workspace with a registered remote and a pushed ref, a post-flatten GC
+// is a silent no-op because the cached remote-tracking ref still anchors the
+// entire pre-flatten chain. The fix is PruneRemoteRefs between the squash and
+// the GC. The test proves the anchor exists after Flatten (the old chain is
+// still readable through the remote ref), prunes it, and verifies the anchor
+// is gone and GC runs clean. Tags are asserted list-only: they anchor history
+// the same way but must never be deleted by the prune.
+func TestDoltNew_PruneRemoteRefs_RealDolt(t *testing.T) {
+	skipIfNoDolt(t)
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	tmpDir := t.TempDir()
+	dbName := uniqueTestDBName(t)
+
+	store, err := New(ctx, &Config{
+		Path:            tmpDir,
+		CommitterName:   "test",
+		CommitterEmail:  "test@example.com",
+		Database:        dbName,
+		CreateIfMissing: true,
+		MaxOpenConns:    1,
+	})
+	if err != nil {
+		t.Fatalf("New (create): %v", err)
+	}
+	db := store.db
+	defer func() {
+		dropCtx, dropCancel := context.WithTimeout(context.Background(), testTimeout)
+		defer dropCancel()
+		_, _ = db.ExecContext(dropCtx, fmt.Sprintf("DROP DATABASE IF EXISTS `%s`", dbName))
+		store.Close()
+	}()
+
+	mustExec := func(stage, q string, args ...any) {
+		t.Helper()
+		if _, err := db.ExecContext(ctx, q, args...); err != nil {
+			t.Fatalf("%s: %v", stage, err)
+		}
+	}
+
+	// Register a remote and push, caching remotes/origin/main; then grow local
+	// history past the pushed tip so the remote ref anchors an old chain.
+	mustExec("add remote", "CALL DOLT_REMOTE('add', 'origin', ?)", "file://"+filepath.Join(tmpDir, "remote"))
+	mustExec("commit 1", "CALL DOLT_COMMIT('--allow-empty', '-m', 'test: commit 1')")
+	mustExec("push", "CALL DOLT_PUSH('origin', 'main')")
+	mustExec("commit 2", "CALL DOLT_COMMIT('--allow-empty', '-m', 'test: commit 2')")
+	mustExec("tag", "CALL DOLT_TAG('prune-test-tag')")
+
+	refs, err := store.ListRemoteRefs(ctx)
+	if err != nil {
+		t.Fatalf("ListRemoteRefs: %v", err)
+	}
+	if len(refs) != 1 || refs[0] != "remotes/origin/main" {
+		t.Fatalf("ListRemoteRefs = %v, want [remotes/origin/main]", refs)
+	}
+
+	tags, err := store.ListTags(ctx)
+	if err != nil {
+		t.Fatalf("ListTags: %v", err)
+	}
+	if len(tags) != 1 || tags[0] != "prune-test-tag" {
+		t.Fatalf("ListTags = %v, want [prune-test-tag]", tags)
+	}
+
+	if err := store.Flatten(ctx); err != nil {
+		t.Fatalf("Flatten: %v", err)
+	}
+
+	// The bug precondition: after the squash, local main is just the initial
+	// commit plus the flattened snapshot, but the pre-flatten chain is still
+	// fully reachable through the cached remote-tracking ref — exactly what
+	// makes the follow-up GC a no-op.
+	var localCommits, anchoredCommits int
+	if err := db.QueryRowContext(ctx, "SELECT COUNT(*) FROM dolt_log").Scan(&localCommits); err != nil {
+		t.Fatalf("count local commits: %v", err)
+	}
+	if localCommits != 2 {
+		t.Fatalf("local commits after flatten = %d, want 2 (init + snapshot)", localCommits)
+	}
+	if err := db.QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM dolt_log('remotes/origin/main')").Scan(&anchoredCommits); err != nil {
+		t.Fatalf("count commits anchored by remote ref: %v", err)
+	}
+	if anchoredCommits < 2 {
+		t.Fatalf("commits anchored by remote ref = %d, want >= 2 (old chain)", anchoredCommits)
+	}
+
+	pruned, err := store.PruneRemoteRefs(ctx)
+	if err != nil {
+		t.Fatalf("PruneRemoteRefs: %v", err)
+	}
+	if len(pruned) != 1 || pruned[0] != "remotes/origin/main" {
+		t.Fatalf("PruneRemoteRefs = %v, want [remotes/origin/main]", pruned)
+	}
+
+	refs, err = store.ListRemoteRefs(ctx)
+	if err != nil {
+		t.Fatalf("ListRemoteRefs after prune: %v", err)
+	}
+	if len(refs) != 0 {
+		t.Fatalf("ListRemoteRefs after prune = %v, want empty", refs)
+	}
+
+	// The anchor must actually be gone, not just hidden from the listing.
+	if err := db.QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM dolt_log('remotes/origin/main')").Scan(&anchoredCommits); err == nil {
+		t.Fatalf("dolt_log('remotes/origin/main') still resolves after prune (%d commits)", anchoredCommits)
+	}
+
+	// Prune must not touch tags.
+	tags, err = store.ListTags(ctx)
+	if err != nil {
+		t.Fatalf("ListTags after prune: %v", err)
+	}
+	if len(tags) != 1 || tags[0] != "prune-test-tag" {
+		t.Fatalf("ListTags after prune = %v, want [prune-test-tag]", tags)
+	}
+
+	if err := store.DoltGC(ctx); err != nil {
+		t.Fatalf("DoltGC after prune: %v", err)
+	}
+
+	// Idempotence: pruning an already-clean workspace is a quiet no-op.
+	pruned, err = store.PruneRemoteRefs(ctx)
+	if err != nil {
+		t.Fatalf("PruneRemoteRefs (second run): %v", err)
+	}
+	if len(pruned) != 0 {
+		t.Fatalf("PruneRemoteRefs second run = %v, want empty", pruned)
+	}
+}

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -1860,6 +1860,27 @@ func (s *DoltStore) DoltGC(ctx context.Context) error {
 	return versioncontrolops.DoltGC(ctx, conn)
 }
 
+// ListRemoteRefs returns the names of all cached remote-tracking refs.
+func (s *DoltStore) ListRemoteRefs(ctx context.Context) ([]string, error) {
+	return versioncontrolops.ListRemoteRefs(ctx, s.db)
+}
+
+// PruneRemoteRefs deletes all cached remote-tracking refs so a post-squash GC
+// can reclaim the history they anchor (bd-agctw). Returns the deleted names.
+func (s *DoltStore) PruneRemoteRefs(ctx context.Context) ([]string, error) {
+	conn, err := s.db.Conn(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("acquire connection for remote-ref prune: %w", err)
+	}
+	defer conn.Close()
+	return versioncontrolops.PruneRemoteRefs(ctx, conn)
+}
+
+// ListTags returns the names of all Dolt tags.
+func (s *DoltStore) ListTags(ctx context.Context) ([]string, error) {
+	return versioncontrolops.ListTags(ctx, s.db)
+}
+
 // Flatten squashes all Dolt commit history into a single commit.
 // Pins a single connection because the stored procedures (DOLT_CHECKOUT,
 // DOLT_RESET, etc.) rely on session-scoped state that would be lost if

--- a/internal/storage/embeddeddolt/store.go
+++ b/internal/storage/embeddeddolt/store.go
@@ -583,6 +583,40 @@ func (s *EmbeddedDoltStore) DoltGC(ctx context.Context) error {
 	})
 }
 
+// ListRemoteRefs returns the names of all cached remote-tracking refs.
+func (s *EmbeddedDoltStore) ListRemoteRefs(ctx context.Context) ([]string, error) {
+	var refs []string
+	err := s.withDBConn(ctx, func(db versioncontrolops.DBConn) error {
+		var err error
+		refs, err = versioncontrolops.ListRemoteRefs(ctx, db)
+		return err
+	})
+	return refs, err
+}
+
+// PruneRemoteRefs deletes all cached remote-tracking refs so a post-squash GC
+// can reclaim the history they anchor (bd-agctw). Returns the deleted names.
+func (s *EmbeddedDoltStore) PruneRemoteRefs(ctx context.Context) ([]string, error) {
+	var pruned []string
+	err := s.withMutatingDBConn(ctx, func(db versioncontrolops.DBConn) error {
+		var err error
+		pruned, err = versioncontrolops.PruneRemoteRefs(ctx, db)
+		return err
+	})
+	return pruned, err
+}
+
+// ListTags returns the names of all Dolt tags.
+func (s *EmbeddedDoltStore) ListTags(ctx context.Context) ([]string, error) {
+	var tags []string
+	err := s.withDBConn(ctx, func(db versioncontrolops.DBConn) error {
+		var err error
+		tags, err = versioncontrolops.ListTags(ctx, db)
+		return err
+	})
+	return tags, err
+}
+
 // ImportJSONLData atomically checks if the database is empty and, if so,
 // imports parsed issues and config key/value pairs in a single transaction.
 // Returns the count of issues imported, or 0 if the database was not empty.

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -259,6 +259,19 @@ type Flattener interface {
 	Flatten(ctx context.Context) error
 }
 
+// RemoteRefPruner manages the cached remote-tracking refs that anchor Dolt
+// history. After a squash (Flatten/Compact) those refs still point at the
+// pre-squash chain, making the follow-up GC a silent no-op on any workspace
+// that has ever pushed or fetched (bd-agctw) — callers must prune them before
+// GC. Pruning only touches the local cache; the next push/fetch re-creates
+// the refs at the new tip. Tags anchor history the same way but are
+// user-created, so they are listed for warning rather than deleted.
+type RemoteRefPruner interface {
+	ListRemoteRefs(ctx context.Context) ([]string, error)
+	PruneRemoteRefs(ctx context.Context) ([]string, error)
+	ListTags(ctx context.Context) ([]string, error)
+}
+
 type SchemaMigrator interface {
 	ApplySchemaMigrations(ctx context.Context) (applied int, err error)
 }

--- a/internal/storage/versioncontrolops/compact.go
+++ b/internal/storage/versioncontrolops/compact.go
@@ -15,7 +15,9 @@ import (
 //  6. Checkout main, hard-reset to temp branch
 //  7. Delete temp branch
 //
-// Callers should run DoltGC afterward to reclaim disk space.
+// Callers should run PruneRemoteRefs and then DoltGC afterward to reclaim disk
+// space — remote-tracking refs still anchor the pre-compact chain, and GC
+// alone reclaims nothing while they exist (bd-agctw).
 //
 // conn must be a single database connection (not a pooled *sql.DB) since the
 // stored procedures rely on session-scoped state (current branch, working set).

--- a/internal/storage/versioncontrolops/flatten.go
+++ b/internal/storage/versioncontrolops/flatten.go
@@ -15,7 +15,9 @@ import (
 //  6. Hard-reset main to the flattened branch
 //  7. Delete temp branch
 //
-// Callers should run DoltGC afterward to reclaim disk space from orphaned history.
+// Callers should run PruneRemoteRefs and then DoltGC afterward to reclaim disk
+// space from orphaned history — remote-tracking refs still anchor the
+// pre-flatten chain, and GC alone reclaims nothing while they exist (bd-agctw).
 //
 // conn must be a single database connection (not a pooled *sql.DB) since the
 // stored procedures rely on session-scoped state (current branch, working set).

--- a/internal/storage/versioncontrolops/remoterefs.go
+++ b/internal/storage/versioncontrolops/remoterefs.go
@@ -1,0 +1,70 @@
+package versioncontrolops
+
+import (
+	"context"
+	"fmt"
+)
+
+// ListRemoteRefs returns the names of all cached remote-tracking refs
+// (e.g. "remotes/origin/main"), sorted by name.
+func ListRemoteRefs(ctx context.Context, db DBConn) ([]string, error) {
+	rows, err := db.QueryContext(ctx, "SELECT name FROM dolt_remote_branches ORDER BY name")
+	if err != nil {
+		return nil, fmt.Errorf("list remote-tracking refs: %w", err)
+	}
+	defer rows.Close()
+
+	var refs []string
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return nil, fmt.Errorf("scan remote-tracking ref: %w", err)
+		}
+		refs = append(refs, name)
+	}
+	return refs, rows.Err()
+}
+
+// PruneRemoteRefs deletes every cached remote-tracking ref and returns the
+// names deleted. After a history squash (Flatten/Compact) these refs still
+// anchor the pre-squash commit chain, so DOLT_GC treats the entire old history
+// as reachable and reclaims nothing (bd-agctw). Pruning is safe on a squashed
+// workspace: the refs are local caches only — nothing is deleted on the remote
+// itself — and the next push or fetch re-creates them at the new tip.
+//
+// On error, the returned slice holds the refs deleted before the failure.
+func PruneRemoteRefs(ctx context.Context, db DBConn) ([]string, error) {
+	refs, err := ListRemoteRefs(ctx, db)
+	if err != nil {
+		return nil, err
+	}
+	var pruned []string
+	for _, name := range refs {
+		if _, err := db.ExecContext(ctx, "CALL DOLT_BRANCH('-D', '-r', ?)", name); err != nil {
+			return pruned, fmt.Errorf("delete remote-tracking ref %s: %w", name, err)
+		}
+		pruned = append(pruned, name)
+	}
+	return pruned, nil
+}
+
+// ListTags returns the names of all Dolt tags, sorted by name. Tags anchor
+// history the same way remote-tracking refs do, but they are user-created, so
+// callers should surface them rather than delete them.
+func ListTags(ctx context.Context, db DBConn) ([]string, error) {
+	rows, err := db.QueryContext(ctx, "SELECT tag_name FROM dolt_tags ORDER BY tag_name")
+	if err != nil {
+		return nil, fmt.Errorf("list tags: %w", err)
+	}
+	defer rows.Close()
+
+	var tags []string
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return nil, fmt.Errorf("scan tag: %w", err)
+		}
+		tags = append(tags, name)
+	}
+	return tags, rows.Err()
+}


### PR DESCRIPTION
## Problem (bd-agctw, P1)

`bd flatten` and `bd compact` squash history and then run `DOLT_GC` — but neither deletes remote-tracking refs first, and any workspace that has ever pushed or fetched has them. GC treats those refs as live roots, so on exactly the workspaces these commands target (big, long-lived, synced) the GC reclaims ~nothing and the operator gets no cue. Observed in prod: the wyvern store stayed ~10G through a compression attempt (2026-07-17); lion independently diagnosed the same hole for the manual runbook path in #4864.

## Fix

- **versioncontrolops**: new `ListRemoteRefs` / `PruneRemoteRefs` / `ListTags` (`dolt_remote_branches` + `CALL DOLT_BRANCH('-D','-r', ...)`; tags list-only). `Flatten`/`Compact` doc comments now name the required prune so future callers don't reintroduce the bug.
- **storage**: optional `RemoteRefPruner` interface, implemented on `DoltStore` and `EmbeddedDoltStore` (same conn-pinning discipline as `DoltGC`).
- **`bd flatten` / `bd compact`**: prune between the squash and the GC; report store size before → after (freed bytes) so a no-op reclaim is visible; warn about tags (they anchor history the same way but are user-created and never deleted); surface refs/tags in `--dry-run` and JSON (`remote_refs_pruned`, `tags_anchoring`, `size_*_bytes`).
- **`bd gc` (audited, deliberately not pruning)**: `bd gc` never squashes — its Compact phase is informational only — and its remote-tracking refs double as the smart migrate gate's cached remote tip (`AS OF 'remotes/origin/main'`, #4516). Pruning there would weaken the gate for zero reclaim. It now reports size before → after and notes anchoring refs/tags with a pointer to flatten/compact.

Pruning touches only the local ref cache: nothing is deleted on the remote, and the next push/fetch re-creates the refs at the new tip.

## Testing

- New real-Dolt regression test `TestDoltNew_PruneRemoteRefs_RealDolt`: proves the pre-flatten chain stays reachable through `remotes/origin/main` after `Flatten` (the bug precondition), that prune removes the anchor (listing empty, `AS OF` read fails), tags survive, GC runs clean, and prune is idempotent.
- E2E on a scratch workspace: `bd flatten --force` printed `Pruned 1 remote-tracking ref(s): remotes/origin/main` and `Store: 1.7 MB → 42.3 KB (freed 1.6 MB)` — space previously retained silently. `bd gc` now shows `freed 0 B` when there is nothing to reclaim.
- `versioncontrolops`, `embeddeddolt` suites green locally; `golangci-lint` 0 issues. Full `internal/storage/dolt` and `cmd/bd` suites exceed the local 10m `go test` default (hence the sharded CI lanes); 30m solo runs in progress locally, CI is authoritative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)