### PR TITLE
fix(schema): carry wisps.row_lock on the ignored migration track — fresh bootstraps since 0054 can't insert wisps (bd-rotq2)

### DIFF
--- a/internal/storage/dolt/wisp_row_lock_heal_test.go
+++ b/internal/storage/dolt/wisp_row_lock_heal_test.go
@@ -1,0 +1,113 @@
+package dolt
+
+import (
+	"context"
+	"fmt"
+	"testing"
+)
+
+// TestDoltNew_WispRowLockSelfHeal_RealDolt is the regression test for
+// bd-rotq2: wisps is dolt-ignored, so its schema is clone-local, and a
+// workspace that bootstraps from a remote whose synced cursor is already
+// >= 0054 never executes the synced migration that added wisps.row_lock —
+// leaving a wisps table the post-0054 binary cannot insert into (Error 1054,
+// observed in prod on claude-code-vm). The fix carries the column on the
+// ignored track (ignored/0013), which runs at store open, so an affected
+// workspace self-heals on its next connect. The test reproduces the broken
+// state directly (drop the column, rewind the ignored cursor past 0013 —
+// the synced cursor stays at latest, exactly like a bootstrap) and asserts
+// a reopen restores the column.
+func TestDoltNew_WispRowLockSelfHeal_RealDolt(t *testing.T) {
+	skipIfNoDolt(t)
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	tmpDir := t.TempDir()
+	dbName := uniqueTestDBName(t)
+
+	cfg := &Config{
+		Path:            tmpDir,
+		CommitterName:   "test",
+		CommitterEmail:  "test@example.com",
+		Database:        dbName,
+		CreateIfMissing: true,
+		MaxOpenConns:    1,
+	}
+
+	store, err := New(ctx, cfg)
+	if err != nil {
+		t.Fatalf("New (create): %v", err)
+	}
+	defer func() {
+		dropCtx, dropCancel := context.WithTimeout(context.Background(), testTimeout)
+		defer dropCancel()
+		_, _ = store.db.ExecContext(dropCtx, fmt.Sprintf("DROP DATABASE IF EXISTS `%s`", dbName))
+		store.Close()
+	}()
+
+	hasRowLock := func(stage string) bool {
+		t.Helper()
+		// wisps is dolt-ignored, so its schema lives in the working set and a
+		// pooled connection can hold a read view predating the migration's
+		// ALTER. Close the view first so the probe sees current state.
+		_, _ = store.db.ExecContext(ctx, "COMMIT")
+		var n int
+		if err := store.db.QueryRowContext(ctx,
+			`SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
+			   WHERE TABLE_SCHEMA = DATABASE()
+			     AND TABLE_NAME = 'wisps' AND COLUMN_NAME = 'row_lock'`).Scan(&n); err != nil {
+			t.Fatalf("%s: probe wisps.row_lock: %v", stage, err)
+		}
+		return n > 0
+	}
+
+	// A fresh workspace must come out of migrations with the column.
+	if !hasRowLock("fresh workspace") {
+		t.Fatal("fresh workspace: wisps.row_lock missing after full migration run")
+	}
+
+	// Reproduce the bootstrap-from-remote state: local wisps predates 0054
+	// (no row_lock) while the SYNCED cursor stays at latest, and the ignored
+	// cursor predates the healing migration.
+	if _, err := store.db.ExecContext(ctx, "ALTER TABLE wisps DROP COLUMN row_lock"); err != nil {
+		t.Fatalf("drop row_lock: %v", err)
+	}
+	if _, err := store.db.ExecContext(ctx,
+		"DELETE FROM ignored_schema_migrations WHERE version >= 13"); err != nil {
+		t.Fatalf("rewind ignored cursor: %v", err)
+	}
+	if hasRowLock("after break") {
+		t.Fatal("test setup failed to remove wisps.row_lock")
+	}
+	store.Close()
+
+	// Reopen: the ignored track runs at store open and must restore the column.
+	store, err = New(ctx, cfg)
+	if err != nil {
+		t.Fatalf("New (reopen): %v", err)
+	}
+	if !hasRowLock("after reopen") {
+		t.Fatal("wisps.row_lock not restored by ignored/0013 on reopen — bootstrap-broken workspaces stay broken")
+	}
+
+	// The heal must be usable, not just present: a wisp-shaped insert that
+	// names row_lock (what the post-0054 binary does) succeeds.
+	if _, err := store.db.ExecContext(ctx,
+		`INSERT INTO wisps (id, title, description, row_lock) VALUES ('wisp-rotq2-heal', 't', '', 1)`); err != nil {
+		t.Fatalf("wisp insert naming row_lock after heal: %v", err)
+	}
+	if _, err := store.db.ExecContext(ctx, "DELETE FROM wisps WHERE id = 'wisp-rotq2-heal'"); err != nil {
+		t.Fatalf("cleanup wisp row: %v", err)
+	}
+
+	// Idempotence: another reopen with the column present must not error.
+	store.Close()
+	store, err = New(ctx, cfg)
+	if err != nil {
+		t.Fatalf("New (third open, idempotence): %v", err)
+	}
+	if !hasRowLock("after third open") {
+		t.Fatal("wisps.row_lock lost on subsequent open")
+	}
+}

--- a/internal/storage/schema/migrations/ignored/0013_add_wisp_row_lock.up.sql
+++ b/internal/storage/schema/migrations/ignored/0013_add_wisp_row_lock.up.sql
@@ -1,0 +1,30 @@
+-- Ignored migration 0013: ensure wisps.row_lock exists on every clone
+-- (bd-rotq2).
+--
+-- Synced migration 0054 added row_lock to wisps — but wisps is dolt-ignored
+-- (migration 0019), so its schema is clone-local, and a workspace that
+-- bootstraps or re-clones from a remote whose schema_migrations cursor is
+-- already >= 0054 adopts the cursor without ever executing 0054. Its wisps
+-- table (materialized by ignored/0001, which predates row_lock) then
+-- permanently lacks the column, and every wisp INSERT from a post-0054 binary
+-- soft-fails with Error 1054 (observed in prod on claude-code-vm, wy-pt82l).
+--
+-- Carrying the column on the ignored track fixes both fronts: fresh
+-- bootstraps get it right after ignored/0001 runs, and already-affected
+-- workspaces self-heal on their next store open. The guard makes this a
+-- no-op on in-place-upgraded workspaces where synced 0054 already added the
+-- column, and on workspaces with no local wisps table yet.
+SET @needs_add = IF(
+    (SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES
+        WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'wisps') > 0
+    AND
+    (SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
+        WHERE TABLE_SCHEMA = DATABASE()
+          AND TABLE_NAME = 'wisps'
+          AND COLUMN_NAME = 'row_lock') = 0,
+    1, 0
+);
+SET @sql = IF(@needs_add = 1,
+    'ALTER TABLE wisps ADD COLUMN row_lock BIGINT NOT NULL DEFAULT 0',
+    'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;

--- a/internal/storage/schema/migrations/ignored/0013_add_wisp_row_lock.up.sql
+++ b/internal/storage/schema/migrations/ignored/0013_add_wisp_row_lock.up.sql
@@ -14,6 +14,13 @@
 -- workspaces self-heal on their next store open. The guard makes this a
 -- no-op on in-place-upgraded workspaces where synced 0054 already added the
 -- column, and on workspaces with no local wisps table yet.
+--
+-- Deliberately NOT healed: 0054's other two wisps columns
+-- (lease_expires_at, heartbeat_at). 0055 moved leases to their own table
+-- and dropped those columns from issues/wisps — wisps are never leased, and
+-- nothing post-cutover reads or writes them on wisps — so bootstrapped
+-- workspaces that never had them are already in the correct final shape.
+-- row_lock is the only 0054 wisps column that survives 0055.
 SET @needs_add = IF(
     (SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES
         WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'wisps') > 0


### PR DESCRIPTION
## Problem (bd-rotq2, P1 — live in prod)

`wisps` is dolt-ignored (migration 0019), so its schema is clone-local, materialized by `ignored/0001`. But `row_lock` was added only by **synced** migration 0054. A workspace that bootstraps or re-clones from a remote whose `schema_migrations` cursor is already ≥ 0054 adopts the cursor without ever executing 0054 — leaving a wisps table the post-0054 binary cannot insert into (`Error 1054: Unknown column 'row_lock' in 'wisps'`).

Live occurrence: claude-code-vm's Gargoyle lane soft-failed 54 wisp inserts after its post-squash re-clone (wy-pt82l, reported by lion), silently dropping its wisp trail while the lane stayed green. **Every fresh synced bootstrap since the 0054/0055 cutover is affected**, including new community clones; in-place upgrades are not (0054 executed locally there), which is why it went unnoticed.

## Fix

New guarded `ignored/0013_add_wisp_row_lock` (same INFORMATION_SCHEMA + PREPARE pattern as `ignored/0006`): adds the column iff wisps exists and lacks it. Because the ignored track runs at store open, already-broken workspaces **self-heal on their next connect**; upgraded workspaces where 0054 already added the column no-op. Nothing edits shipped migrations (content hashes untouched).

## Testing

- New real-Dolt regression test `TestDoltNew_WispRowLockSelfHeal_RealDolt`: fresh workspace has the column; then reproduces the bootstrap-broken state exactly (drop column, rewind ignored cursor, synced cursor stays at latest) and proves a reopen restores it, an insert naming `row_lock` succeeds, and further opens are no-ops. Includes a probe subtlety worth knowing: ignored-table schema lives in the working set, so a pooled connection can hold a pre-ALTER read view — probes force a fresh view first.
- `internal/storage/schema` suite, `embeddeddolt` suite, `test/docsync`, `check-migration-hygiene.sh`, and lint all green locally.

## Process note

Future synced migrations must not alter dolt-ignored tables without a paired ignored/ migration; a doctor check comparing local-table shape to binary expectation is a candidate follow-up (tracked on the bead).

🤖 Generated with [Claude Code](https://claude.com/claude-code)