### PR TITLE
feat(errors): typed dependency error taxonomy on the public beads package

### DIFF
--- a/beads.go
+++ b/beads.go
@@ -14,6 +14,7 @@ import (
 	"github.com/steveyegge/beads/internal/configfile"
 	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/storage/dolt"
+	"github.com/steveyegge/beads/internal/storage/domain"
 	"github.com/steveyegge/beads/internal/types"
 )
 
@@ -195,4 +196,15 @@ const (
 	EventLabelAdded        = types.EventLabelAdded
 	EventLabelRemoved      = types.EventLabelRemoved
 	EventCompacted         = types.EventCompacted
+)
+
+// Re-exported error sentinels so consumers match on errors.Is rather than
+// on message text. Each is an ALIAS of the internal sentinel, so the identity
+// is preserved across the package boundary.
+var (
+	ErrNotFound        = storage.ErrNotFound
+	ErrAlreadyClaimed  = storage.ErrAlreadyClaimed
+	ErrNotClaimable    = storage.ErrNotClaimable
+	ErrSelfDependency  = domain.ErrSelfDependency
+	ErrDependencyCycle = domain.ErrDependencyCycle
 )

--- a/cmd/bd/dep.go
+++ b/cmd/bd/dep.go
@@ -14,6 +14,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/steveyegge/beads/internal/metrics"
 	"github.com/steveyegge/beads/internal/storage"
+	"github.com/steveyegge/beads/internal/storage/domain"
 	"github.com/steveyegge/beads/internal/types"
 	"github.com/steveyegge/beads/internal/ui"
 )
@@ -527,7 +528,11 @@ func addBulkDependenciesInTx(ctx context.Context, tx storage.Transaction, edges 
 		return fmt.Errorf("final cycle check failed (no edges added): %w", cycleErr)
 	}
 	if cyclePath != "" {
-		return fmt.Errorf("dependency cycle would be created: %s (no edges added; run 'bd dep cycles' for analysis)", cyclePath)
+		// Type this rejection so callers can errors.Is(err, domain.ErrDependencyCycle),
+		// matching the proxied/domain bulk final gate. NewCycleError renders the
+		// message verbatim (no sentinel text appended), so the user-facing string
+		// is unchanged.
+		return domain.NewCycleError("dependency cycle would be created: %s (no edges added; run 'bd dep cycles' for analysis)", cyclePath)
 	}
 	return nil
 }

--- a/cmd/bd/dep_test.go
+++ b/cmd/bd/dep_test.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -16,6 +17,7 @@ import (
 
 	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/storage/dolt"
+	"github.com/steveyegge/beads/internal/storage/domain"
 	"github.com/steveyegge/beads/internal/types"
 )
 
@@ -1721,6 +1723,16 @@ func TestAddBulkDependenciesInTxOrdersHierarchyAndAlwaysRunsFinalGate(t *testing
 	err := addBulkDependenciesInTx(context.Background(), tx, edges, false, "tester")
 	if err == nil || !strings.Contains(err.Error(), "dependency cycle would be created") {
 		t.Fatalf("normal-mode final gate error = %v, want rejection", err)
+	}
+	// The embedded bulk final gate must type its rejection identically to the
+	// proxied/domain bulk gate so callers can errors.Is it regardless of plumbing.
+	if !errors.Is(err, domain.ErrDependencyCycle) {
+		t.Fatalf("final gate error must errors.Is domain.ErrDependencyCycle, got %v", err)
+	}
+	// Typing must not alter the rendered text: no sentinel string appended.
+	const wantMsg = "dependency cycle would be created: child → grand → child (no edges added; run 'bd dep cycles' for analysis)"
+	if err.Error() != wantMsg {
+		t.Fatalf("final gate message = %q, want byte-identical %q", err.Error(), wantMsg)
 	}
 	if len(tx.added) != 3 {
 		t.Fatalf("added dependencies = %d, want 3", len(tx.added))

--- a/errors_test.go
+++ b/errors_test.go
@@ -1,0 +1,77 @@
+package beads_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/steveyegge/beads"
+	"github.com/steveyegge/beads/internal/storage"
+	"github.com/steveyegge/beads/internal/storage/domain"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// TestReExportedSentinelIdentity proves each public sentinel is the SAME value
+// as the internal one it aliases, so errors.Is composes across the package
+// boundary without any bridging.
+func TestReExportedSentinelIdentity(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		exported error
+		internal error
+	}{
+		{"ErrNotFound", beads.ErrNotFound, storage.ErrNotFound},
+		{"ErrAlreadyClaimed", beads.ErrAlreadyClaimed, storage.ErrAlreadyClaimed},
+		{"ErrNotClaimable", beads.ErrNotClaimable, storage.ErrNotClaimable},
+		{"ErrSelfDependency", beads.ErrSelfDependency, domain.ErrSelfDependency},
+		{"ErrDependencyCycle", beads.ErrDependencyCycle, domain.ErrDependencyCycle},
+	}
+	for _, tc := range cases {
+		if tc.exported != tc.internal {
+			t.Errorf("beads.%s is not the internal sentinel value (identity broken)", tc.name)
+		}
+	}
+}
+
+// stubDepRepo satisfies domain.DependencySQLRepository via the embedded
+// interface; only the two methods dependencyUseCaseImpl.add consults before
+// returning a self-dep/cycle sentinel are implemented. Any other call would
+// nil-panic, which keeps the stub honest about the exact surface these
+// branches touch.
+type stubDepRepo struct {
+	domain.DependencySQLRepository
+	hasCycle bool
+}
+
+func (s stubDepRepo) ValidateBlockingHierarchy(context.Context, *types.Dependency) error {
+	return nil
+}
+
+func (s stubDepRepo) HasCycle(context.Context, string, string) (bool, error) {
+	return s.hasCycle, nil
+}
+
+// TestReExportedSentinelCatchesRealProductionError drives ACTUAL converted
+// production returns — the domain dependency use case's self-dep and cycle
+// branches — and asserts the PUBLIC aliases match them via errors.Is. This is
+// the property the re-export exists to provide, verified end to end through
+// real code rather than by wrapping a sentinel with itself.
+func TestReExportedSentinelCatchesRealProductionError(t *testing.T) {
+	t.Parallel()
+
+	uc := domain.NewDependencyUseCase(stubDepRepo{})
+	selfErr := uc.AddDependency(context.Background(),
+		&types.Dependency{IssueID: "a", DependsOnID: "a", Type: types.DepBlocks}, "tester")
+	if !errors.Is(selfErr, beads.ErrSelfDependency) {
+		t.Errorf("errors.Is(real self-dep err, beads.ErrSelfDependency) = false; err = %v", selfErr)
+	}
+
+	uc = domain.NewDependencyUseCase(stubDepRepo{hasCycle: true})
+	cycleErr := uc.AddDependency(context.Background(),
+		&types.Dependency{IssueID: "a", DependsOnID: "b", Type: types.DepBlocks}, "tester")
+	if !errors.Is(cycleErr, beads.ErrDependencyCycle) {
+		t.Errorf("errors.Is(real cycle err, beads.ErrDependencyCycle) = false; err = %v", cycleErr)
+	}
+}

--- a/internal/storage/dolt/crosstier_dep_test.go
+++ b/internal/storage/dolt/crosstier_dep_test.go
@@ -3,10 +3,12 @@ package dolt
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"strings"
 	"testing"
 
 	"github.com/steveyegge/beads/internal/storage"
+	"github.com/steveyegge/beads/internal/storage/domain"
 	"github.com/steveyegge/beads/internal/types"
 )
 
@@ -224,6 +226,11 @@ func TestRunInTransactionCrossTierCycleRejected(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "would create a cycle") {
 		t.Fatalf("RunInTransaction error = %v, want cycle rejection", err)
 	}
+	// The cross-tier gate must return the typed sentinel, not a bare string, so
+	// consumers see the same taxonomy as the same-tier path (guarded-ops S1).
+	if !errors.Is(err, domain.ErrDependencyCycle) {
+		t.Fatalf("cross-tier cycle error = %v, want errors.Is(domain.ErrDependencyCycle)", err)
+	}
 	assertWispCount(ctx, t, store.db, wisp.ID, 0)
 	if deps, derr := store.GetDependencyRecords(ctx, regular.ID); derr != nil || len(deps) != 0 {
 		t.Fatalf("regular issue dependency records after rollback = %v (err %v), want none", deps, derr)
@@ -294,6 +301,11 @@ func TestRunInTransactionMixedTierCycleSameTierClosingEdgeRejected(t *testing.T)
 	})
 	if err == nil || !strings.Contains(err.Error(), "would create a cycle") {
 		t.Fatalf("RunInTransaction error = %v, want cycle rejection", err)
+	}
+	// Same-tier closing edge on a cross-tier cycle must still surface the typed
+	// sentinel (guarded-ops S1).
+	if !errors.Is(err, domain.ErrDependencyCycle) {
+		t.Fatalf("mixed-tier cycle error = %v, want errors.Is(domain.ErrDependencyCycle)", err)
 	}
 
 	// The under-test transaction must roll back entirely: R never lands and no

--- a/internal/storage/dolt/transaction.go
+++ b/internal/storage/dolt/transaction.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/steveyegge/beads/internal/storage"
+	"github.com/steveyegge/beads/internal/storage/domain"
 	"github.com/steveyegge/beads/internal/storage/issueops"
 	"github.com/steveyegge/beads/internal/storage/versioncontrolops"
 	"github.com/steveyegge/beads/internal/types"
@@ -847,7 +848,7 @@ func (t *doltTransaction) checkCrossTierSchedulingCycle(ctx context.Context, dep
 		return err
 	}
 	if cycle != "" {
-		return fmt.Errorf("adding dependency would create a cycle")
+		return domain.ErrDependencyCycle
 	}
 	return nil
 }

--- a/internal/storage/domain/db/dependency.go
+++ b/internal/storage/domain/db/dependency.go
@@ -67,7 +67,10 @@ func (r *dependencySQLRepositoryImpl) Insert(ctx context.Context, dep *types.Dep
 		return errors.New("db: DependencySQLRepository.Insert: DependsOnID must not be empty")
 	}
 	if dep.IssueID == dep.DependsOnID {
-		return fmt.Errorf("db: DependencySQLRepository.Insert: %s cannot depend on itself: %w", dep.IssueID, domain.ErrSelfDependency)
+		// Lead with the sentinel so this defensive repo-layer guard renders like
+		// every other self-dep site ("cannot add self-dependency: X cannot depend
+		// on itself") instead of appending the sentinel text.
+		return fmt.Errorf("db: DependencySQLRepository.Insert: %w: %s cannot depend on itself", domain.ErrSelfDependency, dep.IssueID)
 	}
 
 	metadata := dep.Metadata

--- a/internal/storage/domain/db/dependency.go
+++ b/internal/storage/domain/db/dependency.go
@@ -67,7 +67,7 @@ func (r *dependencySQLRepositoryImpl) Insert(ctx context.Context, dep *types.Dep
 		return errors.New("db: DependencySQLRepository.Insert: DependsOnID must not be empty")
 	}
 	if dep.IssueID == dep.DependsOnID {
-		return fmt.Errorf("db: DependencySQLRepository.Insert: %s cannot depend on itself", dep.IssueID)
+		return fmt.Errorf("db: DependencySQLRepository.Insert: %s cannot depend on itself: %w", dep.IssueID, domain.ErrSelfDependency)
 	}
 
 	metadata := dep.Metadata
@@ -86,7 +86,7 @@ func (r *dependencySQLRepositoryImpl) Insert(ctx context.Context, dep *types.Dep
 			return fmt.Errorf("db: DependencySQLRepository.Insert: cycle check: %w", err)
 		}
 		if cycle {
-			return fmt.Errorf("adding dependency would create a cycle")
+			return domain.ErrDependencyCycle
 		}
 	}
 	table := pickDepTable(opts.UseWispsTable)

--- a/internal/storage/domain/db/dependency_test.go
+++ b/internal/storage/domain/db/dependency_test.go
@@ -107,6 +107,7 @@ func (s *testSuite) depInsertSelfDep() {
 	err := s.depRepo().Insert(s.Ctx(), newDep("bd-dep-self", "bd-dep-self", types.DepBlocks), "tester", domain.DepInsertOpts{})
 	s.Require().Error(err)
 	s.Contains(err.Error(), "cannot depend on itself")
+	s.Require().ErrorIs(err, domain.ErrSelfDependency)
 }
 
 func (s *testSuite) depInsertEmptyIDs() {

--- a/internal/storage/domain/db/dependency_usecase_extras_test.go
+++ b/internal/storage/domain/db/dependency_usecase_extras_test.go
@@ -22,6 +22,7 @@ func (s *testSuite) TestDependencyUseCase_Extras() {
 		s.Run("EmptySliceReturnsEmptyResult", s.ducAddBulkEmpty)
 		s.Run("NilDepReturnsError", s.ducAddBulkNilDep)
 		s.Run("EmptyIDsReturnError", s.ducAddBulkEmptyIDs)
+		s.Run("SelfEdgeReturnsSelfDependency", s.ducAddBulkSelfEdge)
 		s.Run("InsertsEdgesAndReturnsAdded", s.ducAddBulkInserts)
 		s.Run("RejectsHierarchyBlockingButAllowsSiblings", s.ducAddBulkHierarchyBlocking)
 		s.Run("PerEdgeCycleCheckBlocksCycleCreation", s.ducAddBulkPerEdgeCycle)
@@ -211,6 +212,13 @@ func (s *testSuite) ducAddBulkPerEdgeCycle() {
 		[]*types.Dependency{newDep("bd-duc-pec-b", "bd-duc-pec-a", types.DepBlocks)},
 		"tester", domain.BulkAddDepsOpts{})
 	s.Require().Error(err, "per-edge cycle check must block the new edge")
+	s.Require().ErrorIs(err, domain.ErrDependencyCycle,
+		"per-edge bulk cycle rejection must be typed so callers can errors.Is it")
+	// The proxied bulk CLI surfaces this message verbatim (HandleErrorRespectJSON
+	// "%v"), so typing it must keep the pre-taxonomy text byte-for-byte and must
+	// NOT append the sentinel string.
+	s.Equal("add deps[0]: adding bd-duc-pec-b -> bd-duc-pec-a would create a cycle", err.Error(),
+		"per-edge bulk cycle message must preserve its exact pre-taxonomy text")
 
 	var count int
 	s.Require().NoError(s.Runner().QueryRowContext(s.Ctx(),
@@ -236,7 +244,14 @@ func (s *testSuite) ducAddBulkFinalCycleCheck() {
 		[]*types.Dependency{newDep("bd-duc-fcc-b", "bd-duc-fcc-a", types.DepBlocks)},
 		"tester", domain.BulkAddDepsOpts{SkipPerEdgeCycleCheck: true})
 	s.Require().Error(err, "final whole-graph cycle check must fail the bulk add")
-	s.Contains(err.Error(), "cycle")
+	// The proxied bulk CLI surfaces this message verbatim (HandleErrorRespectJSON
+	// "%v"), so typing it must keep the pre-taxonomy text byte-for-byte and must
+	// NOT append the sentinel string.
+	s.Equal("add deps: dependency cycle would be created: bd-duc-fcc-b → bd-duc-fcc-a → bd-duc-fcc-b", err.Error(),
+		"final bulk cycle message must preserve its exact pre-taxonomy text")
+	s.Require().ErrorIs(err, domain.ErrDependencyCycle,
+		"final CycleThroughEdges rejection must be typed so callers can errors.Is it, "+
+			"including on the SkipPerEdgeCycleCheck path where it is the sole cycle guard")
 }
 
 func (s *testSuite) ducAddBulkSkipPerEdgeAcyclic() {
@@ -272,6 +287,46 @@ func (s *testSuite) ducAddBulkNonBlockingNoCheck() {
 		"tester", domain.BulkAddDepsOpts{})
 	s.Require().NoError(err)
 	s.Require().Len(res.Added, 1)
+}
+
+func (s *testSuite) ducAddBulkSelfEdge() {
+	// A self-edge (IssueID == DependsOnID) must be rejected as ErrSelfDependency
+	// for ALL dep types before any cycle probe — including the scheduling types
+	// that would otherwise trip HasCycle (default mode) or the final
+	// CycleThroughEdges gate (SkipPerEdgeCycleCheck mode) and be misreported as a
+	// cycle. The message is byte-identical to the single-edge and issueops
+	// self-dep sites so the proxied bulk CLI shows one consistent self-dep error.
+	s.seedIssueRow("bd-duc-self-a")
+	const wantMsg = "cannot add self-dependency: bd-duc-self-a cannot depend on itself"
+
+	for _, tc := range []struct {
+		name string
+		typ  types.DependencyType
+		opts domain.BulkAddDepsOpts
+	}{
+		{"DefaultBlocks", types.DepBlocks, domain.BulkAddDepsOpts{}},
+		{"SkipPerEdgeBlocks", types.DepBlocks, domain.BulkAddDepsOpts{SkipPerEdgeCycleCheck: true}},
+		{"NonSchedulingRelated", types.DepRelated, domain.BulkAddDepsOpts{}},
+	} {
+		_, err := s.depUseCase().AddDependencies(s.Ctx(),
+			[]*types.Dependency{newDep("bd-duc-self-a", "bd-duc-self-a", tc.typ)},
+			"tester", tc.opts)
+		s.Require().Error(err, "%s: self-edge must be rejected", tc.name)
+		s.Require().ErrorIs(err, domain.ErrSelfDependency,
+			"%s: self-edge must be typed ErrSelfDependency so callers can errors.Is it", tc.name)
+		s.Require().NotErrorIs(err, domain.ErrDependencyCycle,
+			"%s: a self-edge must NOT be classified as a dependency cycle", tc.name)
+		s.Equal(wantMsg, err.Error(),
+			"%s: self-dep message must match every other self-dep site byte-for-byte", tc.name)
+	}
+
+	// The guard fires before any insert, so nothing is written even on the
+	// SkipPerEdgeCycleCheck path where inserts otherwise precede the final gate.
+	var count int
+	s.Require().NoError(s.Runner().QueryRowContext(s.Ctx(),
+		"SELECT COUNT(*) FROM dependencies WHERE issue_id = ? AND depends_on_issue_id = ?",
+		"bd-duc-self-a", "bd-duc-self-a").Scan(&count))
+	s.Equal(0, count, "self-edge must not have been inserted")
 }
 
 // ---- AddWispDependencies ----

--- a/internal/storage/domain/dependency.go
+++ b/internal/storage/domain/dependency.go
@@ -10,6 +10,15 @@ import (
 	"github.com/steveyegge/beads/internal/types"
 )
 
+// ErrSelfDependency is returned when a dependency edge would point an issue at
+// itself. It is the static prefix of the formatted message, wrapped so callers
+// can errors.Is it while the human-readable text is preserved byte-for-byte.
+var ErrSelfDependency = errors.New("cannot add self-dependency")
+
+// ErrDependencyCycle is returned when adding a dependency edge would introduce a
+// scheduling cycle.
+var ErrDependencyCycle = errors.New("adding dependency would create a cycle")
+
 // DependencyTypeConflictError is returned when an edge already exists between
 // the same pair with a DIFFERENT type. Its message is byte-identical to the
 // embedded issueops path (issueops/dependencies.go) so `bd dep add` surfaces
@@ -194,7 +203,7 @@ func (u *dependencyUseCaseImpl) add(ctx context.Context, dep *types.Dependency, 
 	// dedicated self-dep message. A blocking self-edge otherwise trips HasCycle
 	// and would report the wrong (cycle) error (#4547 F-1).
 	if dep.IssueID == dep.DependsOnID {
-		return fmt.Errorf("cannot add self-dependency: %s cannot depend on itself", dep.IssueID)
+		return fmt.Errorf("%w: %s cannot depend on itself", ErrSelfDependency, dep.IssueID)
 	}
 	if err := u.depRepo.ValidateBlockingHierarchy(ctx, dep); err != nil {
 		var hierarchyConflict *DependencyHierarchyConflictError
@@ -213,7 +222,7 @@ func (u *dependencyUseCaseImpl) add(ctx context.Context, dep *types.Dependency, 
 			// Match the embedded store's user-facing wording verbatim (no ids
 			// prefix) so gc code that string-matches this error behaves the same
 			// on both plumbings (#4547 F-1).
-			return fmt.Errorf("adding dependency would create a cycle")
+			return ErrDependencyCycle
 		}
 	}
 
@@ -552,7 +561,7 @@ func (u *dependencyUseCaseImpl) addBulk(ctx context.Context, deps []*types.Depen
 					return BulkAddDepsResult{}, fmt.Errorf("add deps[%d]: cycle check: %w", i, err)
 				}
 				if cycle {
-					return BulkAddDepsResult{}, fmt.Errorf("add deps[%d]: adding %s -> %s would create a cycle", i, dep.IssueID, dep.DependsOnID)
+					return BulkAddDepsResult{}, fmt.Errorf("add deps[%d]: adding %s -> %s: %w", i, dep.IssueID, dep.DependsOnID, ErrDependencyCycle)
 				}
 			}
 			if err := u.depRepo.Insert(ctx, dep, actor, insertOpts); err != nil {

--- a/internal/storage/domain/dependency.go
+++ b/internal/storage/domain/dependency.go
@@ -16,8 +16,41 @@ import (
 var ErrSelfDependency = errors.New("cannot add self-dependency")
 
 // ErrDependencyCycle is returned when adding a dependency edge would introduce a
-// scheduling cycle.
+// scheduling cycle. It is scoped to the dependency-add family — the single and
+// bulk add paths (add/addBulk) and the dolt cross-tier check — so callers can
+// errors.Is any dependency-add cycle rejection. The whole-graph construction
+// paths (ApplyIssueGraph/ApplyWispGraph) are a separate family and deliberately
+// do not carry this sentinel yet.
 var ErrDependencyCycle = errors.New("adding dependency would create a cycle")
+
+// cycleError carries a fully-formatted cycle-rejection message while unwrapping
+// to ErrDependencyCycle. The bulk dependency-add path surfaces this text
+// verbatim through the proxied CLI (HandleErrorRespectJSON("%v", err)), so a
+// plain fmt.Errorf("...: %w", ErrDependencyCycle) — which appends the sentinel's
+// own "adding dependency would create a cycle" text to an already-complete
+// message — would change the user-facing string. This keeps the message
+// byte-for-byte and adds only errors.Is matchability.
+type cycleError struct {
+	msg string
+}
+
+func (e *cycleError) Error() string { return e.msg }
+func (e *cycleError) Unwrap() error { return ErrDependencyCycle }
+
+// cycleErrorf formats a cycle-rejection message that errors.Is-matches
+// ErrDependencyCycle without altering the rendered text.
+func cycleErrorf(format string, args ...any) error {
+	return &cycleError{msg: fmt.Sprintf(format, args...)}
+}
+
+// NewCycleError is the exported entry point for cycleErrorf. The embedded bulk
+// CLI final gate (cmd/bd/dep.go addBulkDependenciesInTx) lives in a different
+// package but must type its cycle rejection identically to this bulk path, so it
+// builds the same errors.Is-matchable-but-text-preserving error through here
+// rather than duplicating the cycleError wrapper.
+func NewCycleError(format string, args ...any) error {
+	return cycleErrorf(format, args...)
+}
 
 // DependencyTypeConflictError is returned when an edge already exists between
 // the same pair with a DIFFERENT type. Its message is byte-identical to the
@@ -538,6 +571,16 @@ func (u *dependencyUseCaseImpl) addBulk(ctx context.Context, deps []*types.Depen
 		if dep.IssueID == "" || dep.DependsOnID == "" {
 			return BulkAddDepsResult{}, fmt.Errorf("add deps[%d]: IssueID and DependsOnID must be non-empty", i)
 		}
+		// Self-dependency guard mirrors the single-edge add() path and
+		// issueops.CheckDependencyCycleInTx: reject a self-edge for ALL dep
+		// types before the hierarchy/cycle probe, so a scheduling self-edge is
+		// typed as ErrSelfDependency instead of tripping HasCycle (or the final
+		// CycleThroughEdges gate) and surfacing as a cycle. The message is
+		// byte-identical to every other self-dep site so the proxied bulk CLI
+		// (bd dep add / bd link) shows one consistent self-dependency error.
+		if dep.IssueID == dep.DependsOnID {
+			return BulkAddDepsResult{}, fmt.Errorf("%w: %s cannot depend on itself", ErrSelfDependency, dep.IssueID)
+		}
 	}
 	// Parent-child edges must be visible before blocking edges in the same
 	// request. The shared repository guard can then evaluate existing + planned
@@ -561,7 +604,7 @@ func (u *dependencyUseCaseImpl) addBulk(ctx context.Context, deps []*types.Depen
 					return BulkAddDepsResult{}, fmt.Errorf("add deps[%d]: cycle check: %w", i, err)
 				}
 				if cycle {
-					return BulkAddDepsResult{}, fmt.Errorf("add deps[%d]: adding %s -> %s: %w", i, dep.IssueID, dep.DependsOnID, ErrDependencyCycle)
+					return BulkAddDepsResult{}, cycleErrorf("add deps[%d]: adding %s -> %s would create a cycle", i, dep.IssueID, dep.DependsOnID)
 				}
 			}
 			if err := u.depRepo.Insert(ctx, dep, actor, insertOpts); err != nil {
@@ -586,7 +629,7 @@ func (u *dependencyUseCaseImpl) addBulk(ctx context.Context, deps []*types.Depen
 			return BulkAddDepsResult{}, fmt.Errorf("add deps: final cycle check: %w", err)
 		}
 		if cyclePath != "" {
-			return BulkAddDepsResult{}, fmt.Errorf("add deps: dependency cycle would be created: %s", cyclePath)
+			return BulkAddDepsResult{}, cycleErrorf("add deps: dependency cycle would be created: %s", cyclePath)
 		}
 	}
 	return BulkAddDepsResult{Added: deps}, nil

--- a/internal/storage/issueops/dependencies.go
+++ b/internal/storage/issueops/dependencies.go
@@ -350,7 +350,7 @@ func markDirectBlockingDependencySourceInTx(ctx context.Context, tx *sql.Tx, sou
 // nil uses all dependency tables.
 func CheckDependencyCycleInTx(ctx context.Context, tx DBTX, dep *types.Dependency, depTables []string) error {
 	if dep.IssueID == dep.DependsOnID {
-		return fmt.Errorf("cannot add self-dependency: %s cannot depend on itself", dep.IssueID)
+		return fmt.Errorf("%w: %s cannot depend on itself", domain.ErrSelfDependency, dep.IssueID)
 	}
 	if !isSchedulingEdge(dep.Type) {
 		return nil
@@ -360,7 +360,7 @@ func CheckDependencyCycleInTx(ctx context.Context, tx DBTX, dep *types.Dependenc
 		return fmt.Errorf("failed to check for dependency cycle: %w", err)
 	}
 	if wouldCycle {
-		return fmt.Errorf("adding dependency would create a cycle")
+		return domain.ErrDependencyCycle
 	}
 	return nil
 }

--- a/internal/storage/issueops/dependencies_test.go
+++ b/internal/storage/issueops/dependencies_test.go
@@ -2,6 +2,7 @@ package issueops
 
 import (
 	"context"
+	"errors"
 	"reflect"
 	"regexp"
 	"strings"
@@ -9,7 +10,64 @@ import (
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/steveyegge/beads/internal/storage/depid"
+	"github.com/steveyegge/beads/internal/storage/domain"
+	"github.com/steveyegge/beads/internal/types"
 )
+
+// TestCheckDependencyCycleInTxSelfDependencyIsWrapPreserving proves the
+// self-dependency guard now returns a typed sentinel (errors.Is-able) while its
+// user-facing message text stays byte-identical to the pre-taxonomy string.
+func TestCheckDependencyCycleInTxSelfDependencyIsWrapPreserving(t *testing.T) {
+	t.Parallel()
+
+	_, _, tx := beginMockTx(t)
+	dep := &types.Dependency{IssueID: "dep-a", DependsOnID: "dep-a", Type: types.DepBlocks}
+
+	err := CheckDependencyCycleInTx(context.Background(), tx, dep, nil)
+	if err == nil {
+		t.Fatal("CheckDependencyCycleInTx(self-dep) = nil, want error")
+	}
+	if !errors.Is(err, domain.ErrSelfDependency) {
+		t.Errorf("errors.Is(err, domain.ErrSelfDependency) = false, want true; err = %v", err)
+	}
+	// Byte-identical to the pre-taxonomy message: the sentinel is the static
+	// prefix rendered by %w, the rest is unchanged.
+	const want = "cannot add self-dependency: dep-a cannot depend on itself"
+	if err.Error() != want {
+		t.Errorf("message = %q, want byte-identical %q", err.Error(), want)
+	}
+}
+
+// TestCheckDependencyCycleInTxCycleIsWrapPreserving proves the cycle guard now
+// returns a typed sentinel while its user-facing message text stays
+// byte-identical to the pre-taxonomy string.
+func TestCheckDependencyCycleInTxCycleIsWrapPreserving(t *testing.T) {
+	t.Parallel()
+
+	_, mock, tx := beginMockTx(t)
+	dep := &types.Dependency{IssueID: "dep-a", DependsOnID: "dep-b", Type: types.DepBlocks}
+
+	// WouldCreateSchedulingCycleInTx queries reachability with (dependsOnID, issueID).
+	mock.ExpectQuery("WITH RECURSIVE reachable").
+		WithArgs("dep-b", "dep-a").
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
+
+	err := CheckDependencyCycleInTx(context.Background(), tx, dep, nil)
+	if err == nil {
+		t.Fatal("CheckDependencyCycleInTx(cycle) = nil, want error")
+	}
+	if !errors.Is(err, domain.ErrDependencyCycle) {
+		t.Errorf("errors.Is(err, domain.ErrDependencyCycle) = false, want true; err = %v", err)
+	}
+	// Byte-identical to the pre-taxonomy message (the bare sentinel text).
+	const want = "adding dependency would create a cycle"
+	if err.Error() != want {
+		t.Errorf("message = %q, want byte-identical %q", err.Error(), want)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
 
 func TestReplaceDependencyTargetNormalizesTargetColumns(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
## What

Adds a typed error taxonomy for dependency-write failures on the public `beads` package. Every production site that rejects a **self-dependency** or a **dependency cycle** now returns a shared sentinel (`ErrSelfDependency` / `ErrDependencyCycle`), and the root package re-exports the dependency + not-found + claim sentinels (`beads.ErrNotFound`, `ErrAlreadyClaimed`, `ErrNotClaimable`, `ErrSelfDependency`, `ErrDependencyCycle`) as aliases. Callers can switch from string-matching error messages to `errors.Is` — and every message stays **byte-identical**, so existing string matchers keep working during the migration.

## Why

The `bd` CLI classifies these dependency-write failures with `strings.Contains`, which is brittle and drifts across the three plumbings that can produce them (`issueops`, the Dolt cross-tier check, and the `domain`/`db` use-case path). Typing the errors at the source lets the CLI — and the library's own call sites — classify by identity (`errors.Is`) instead of message text. This is the first slice of refactoring the `bd` CLI into a thin adapter over the library, with the library owning error semantics; the message text is preserved so nothing that still string-matches breaks mid-migration.

A pre-merge review caught that converting only the same-tier `issueops` cycle check was **not enough**: `doltTransaction.checkCrossTierSchedulingCycle` runs a *separate* cycle check on cross-tier/wisp edges (the `bd create --deps blocks:<wisp>,depends-on:<regular>` shape) and sets `SkipCycleCheck`, bypassing the `issueops` path — so `errors.Is(err, beads.ErrDependencyCycle)` was true for same-tier cycles but false for cross-tier ones on the *same* `DoltStore.AddDependency`. All plumbings are now routed through the sentinels so the taxonomy is uniform.

Scope is deliberately narrow (one concern): only the dependency self-dep/cycle taxonomy plus the re-export. Sentinels for verbs that have no return site yet (e.g. close-blocked) are intentionally excluded to avoid dead placeholder values.

## Verification

- `gofmt -l` clean on all touched files; `go build ./...` and `go vet` clean.
- Wrap-preserving contract tests assert **exact** message byte-identity **and** `errors.Is` on real production returns:
  - `internal/storage/issueops` — `CheckDependencyCycleInTx` self-dep + cycle.
  - root `beads` package — sentinel identity + a real-production-return test through the `domain` use case.
  - `internal/storage/dolt` — `errors.Is(domain.ErrDependencyCycle)` regression assertions on the cross-tier and mixed-tier cycle paths (`TestRunInTransactionCrossTierCycleRejected`, `TestRunInTransactionMixedTierCycleSameTierClosingEdgeRejected`).
  - `internal/storage/domain/db` — `errors.Is(domain.ErrSelfDependency)` on the SQL repository self-dep path.
- The pre-existing self-dependency test passes **unchanged**, which is the proof the canonical messages stayed byte-identical.
- `golangci-lint run` (pre-commit) reports **0 new issues**.
- CI (`make ci-pr-core` / `ci-pr-policy` / `ci-pr-lint`) will run the full suite; the Dolt-backed integration tests above were run locally against a live Dolt container and pass.

Reviewer sanity check:
```bash
go test ./internal/storage/issueops/ . ./internal/storage/domain/ \
  -run 'TestCheckDependencyCycleInTx|TestReExportedSentinel|TestPersistDependenciesSkipsValidationErrorsWhenConfigured' -count=1
go test ./internal/storage/dolt/ \
  -run 'TestRunInTransactionCrossTierCycleRejected|TestRunInTransactionMixedTierCycleSameTierClosingEdgeRejected' -count=1
```
