### PR TITLE
feat(close): CloseIssueChecked — atomic guarded close in the engine

### DIFF
--- a/beads.go
+++ b/beads.go
@@ -48,6 +48,16 @@ type Transaction = beads.Transaction
 // one whole-graph check, never graph integrity.
 type DependencyAddOptions = storage.DependencyAddOptions
 
+// CloseIssueOptions carries the optional inputs to Storage.CloseIssueChecked —
+// an atomic, guarded close that refuses a still-blocked issue with
+// ErrCloseBlocked unless Force is set. Exported so consumers can name it without
+// importing internal/storage.
+type CloseIssueOptions = storage.CloseIssueOptions
+
+// CloseIssueResult reports the outcome of Storage.CloseIssueChecked. Unchanged
+// is true when the issue was already closed (idempotent no-op).
+type CloseIssueResult = storage.CloseIssueResult
+
 // RemoteStore provides dolt remote management and replication operations.
 // Use type assertion on a Storage value to access these methods:
 //
@@ -205,6 +215,7 @@ var (
 	ErrNotFound        = storage.ErrNotFound
 	ErrAlreadyClaimed  = storage.ErrAlreadyClaimed
 	ErrNotClaimable    = storage.ErrNotClaimable
+	ErrCloseBlocked    = storage.ErrCloseBlocked
 	ErrSelfDependency  = domain.ErrSelfDependency
 	ErrDependencyCycle = domain.ErrDependencyCycle
 )

--- a/errors_test.go
+++ b/errors_test.go
@@ -3,6 +3,7 @@ package beads_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/steveyegge/beads"
@@ -10,6 +11,22 @@ import (
 	"github.com/steveyegge/beads/internal/storage/domain"
 	"github.com/steveyegge/beads/internal/types"
 )
+
+// TestReExportCloseBlocked proves the public beads.ErrCloseBlocked alias is the
+// same value as the internal sentinel and composes through errors.Is when
+// wrapped — the property CloseIssueChecked callers rely on to detect a guard
+// refusal without importing internal/storage.
+func TestReExportCloseBlocked(t *testing.T) {
+	t.Parallel()
+
+	if beads.ErrCloseBlocked != storage.ErrCloseBlocked {
+		t.Error("beads.ErrCloseBlocked is not the internal sentinel value (identity broken)")
+	}
+	wrapped := fmt.Errorf("x: %w", beads.ErrCloseBlocked)
+	if !errors.Is(wrapped, beads.ErrCloseBlocked) {
+		t.Errorf("errors.Is(wrapped, beads.ErrCloseBlocked) = false; err = %v", wrapped)
+	}
+}
 
 // TestReExportedSentinelIdentity proves each public sentinel is the SAME value
 // as the internal one it aliases, so errors.Is composes across the package

--- a/internal/jira/tracker_test.go
+++ b/internal/jira/tracker_test.go
@@ -653,7 +653,10 @@ func (s *configStore) UpdateIssue(_ context.Context, _ string, _ map[string]inte
 func (s *configStore) ReopenIssue(_ context.Context, _, _, _ string) error     { return nil }
 func (s *configStore) UpdateIssueType(_ context.Context, _, _, _ string) error { return nil }
 func (s *configStore) CloseIssue(_ context.Context, _, _, _, _ string) error   { return nil }
-func (s *configStore) DeleteIssue(_ context.Context, _ string) error           { return nil }
+func (s *configStore) CloseIssueChecked(_ context.Context, _, _ string, _ storage.CloseIssueOptions) (storage.CloseIssueResult, error) {
+	return storage.CloseIssueResult{}, nil
+}
+func (s *configStore) DeleteIssue(_ context.Context, _ string) error { return nil }
 func (s *configStore) SearchIssuesWithCounts(_ context.Context, _ string, _ types.IssueFilter) ([]*types.IssueWithCounts, error) {
 	return nil, nil
 }

--- a/internal/storage/dolt/close_issue_checked_test.go
+++ b/internal/storage/dolt/close_issue_checked_test.go
@@ -96,6 +96,41 @@ func TestCloseIssueChecked(t *testing.T) {
 		return id
 	}
 
+	// mkClosedBlockedStale creates a closed issue and then forces is_blocked=1
+	// back onto the closed row via direct SQL + DOLT_COMMIT. This reproduces the
+	// stale denormalization a cross-clone Dolt merge can leave: the schema
+	// explicitly models closed+is_blocked=1 rows (GetStatistics filters
+	// `is_blocked = 1 AND status <> 'closed'`), and a hand-resolved merge conflict
+	// can leave the flag stale indefinitely. No single-clone store API path can
+	// otherwise reach this state, because every in-process close recomputes and
+	// clears is_blocked for the closed row — so it is seeded the same way
+	// blocked_merge_test.go seeds merged state.
+	mkClosedBlockedStale := func(t *testing.T, id string) string {
+		t.Helper()
+		createPerm(t, ctx, store, id)
+		if _, err := store.CloseIssueChecked(ctx, id, "tester",
+			storage.CloseIssueOptions{Reason: "done"}); err != nil {
+			t.Fatalf("initial CloseIssueChecked(%s): %v", id, err)
+		}
+		if _, err := store.db.ExecContext(ctx,
+			"UPDATE issues SET is_blocked = 1 WHERE id = ?", id); err != nil {
+			t.Fatalf("force stale is_blocked=1 on %s: %v", id, err)
+		}
+		if _, err := store.db.ExecContext(ctx,
+			"CALL DOLT_COMMIT('-Am', 'simulate merged stale is_blocked')"); err != nil && !isDoltNothingToCommit(err) {
+			t.Fatalf("commit stale is_blocked for %s: %v", id, err)
+		}
+		// Guard the fixture itself: the row must be closed AND carry the stale
+		// is_blocked=1 the regression depends on.
+		if got := getStatus(t, id); got != types.StatusClosed {
+			t.Fatalf("%s should be closed for the regression fixture, got %q", id, got)
+		}
+		if !getIsBlocked(t, ctx, store, "issues", id) {
+			t.Fatalf("%s should carry stale is_blocked=1 for the regression fixture", id)
+		}
+		return id
+	}
+
 	tests := []struct {
 		name  string
 		setup func(t *testing.T) string
@@ -161,6 +196,31 @@ func TestCloseIssueChecked(t *testing.T) {
 			setup: func(t *testing.T) string { return mkClosed(t, "cic-idem") },
 			opts:  storage.CloseIssueOptions{Reason: "again"},
 			check: func(t *testing.T, id string, res storage.CloseIssueResult, err error) {
+				if err != nil {
+					t.Fatalf("re-close err = %v, want nil", err)
+				}
+				if !res.Unchanged {
+					t.Fatalf("res.Unchanged = false, want true (already closed)")
+				}
+				if got := getStatus(t, id); got != types.StatusClosed {
+					t.Fatalf("issue %s status = %q, want closed", id, got)
+				}
+			},
+		},
+		{
+			// Regression: a non-force re-close of an ALREADY-CLOSED row that still
+			// carries a stale is_blocked=1 must stay idempotent (Unchanged=true).
+			// The guard only has meaning for an open→closed transition, so it must
+			// not fire on a row that is already closed — otherwise the documented
+			// idempotency contract breaks once bd close is wired to this primitive.
+			name:  "already closed with stale is_blocked=1 is idempotent, not refused",
+			setup: func(t *testing.T) string { return mkClosedBlockedStale(t, "cic-idem-stale") },
+			opts:  storage.CloseIssueOptions{Reason: "again"},
+			check: func(t *testing.T, id string, res storage.CloseIssueResult, err error) {
+				if errors.Is(err, storage.ErrCloseBlocked) {
+					t.Fatalf("re-close of already-closed %s refused with ErrCloseBlocked; "+
+						"the guard must not fire on an already-closed row (stale is_blocked=1)", id)
+				}
 				if err != nil {
 					t.Fatalf("re-close err = %v, want nil", err)
 				}

--- a/internal/storage/dolt/close_issue_checked_test.go
+++ b/internal/storage/dolt/close_issue_checked_test.go
@@ -1,0 +1,272 @@
+package dolt
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/storage"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// TestCloseIssueChecked exercises the atomic, guarded close. The guard
+// (is_blocked) and the close share ONE transaction, so a blocked issue is
+// refused with storage.ErrCloseBlocked and — critically — the transaction rolls
+// back leaving the issue open with no `closed` event recorded (the atomic-refuse
+// property). Force bypasses the guard, and already-closed is an idempotent
+// success (Unchanged=true).
+func TestCloseIssueChecked(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	// mkBlocked creates a blocker and a target with a `blocks` dependency so the
+	// target's is_blocked is 1, mirroring the fixtures in is_blocked_test.go.
+	mkBlocked := func(t *testing.T, prefix string) string {
+		t.Helper()
+		blocker, target := prefix+"-blocker", prefix+"-target"
+		createPerm(t, ctx, store, blocker)
+		createPerm(t, ctx, store, target)
+		if err := store.AddDependency(ctx, &types.Dependency{
+			IssueID: target, DependsOnID: blocker, Type: types.DepBlocks,
+		}, "tester"); err != nil {
+			t.Fatalf("AddDependency: %v", err)
+		}
+		if !getIsBlocked(t, ctx, store, "issues", target) {
+			t.Fatalf("%s should be is_blocked = 1 after adding blocks dep", target)
+		}
+		return target
+	}
+
+	// mkBlockedWisp is mkBlocked's ephemeral twin: the target is a wisp, so the
+	// close routes through closeWispChecked (its own rollback wrapper, no
+	// DOLT_COMMIT) rather than the permanent withRetryTx path.
+	mkBlockedWisp := func(t *testing.T, prefix string) string {
+		t.Helper()
+		blocker, target := prefix+"-blocker", prefix+"-target"
+		createPerm(t, ctx, store, blocker)
+		createWisp(t, ctx, store, target)
+		if err := store.AddDependency(ctx, &types.Dependency{
+			IssueID: target, DependsOnID: blocker, Type: types.DepBlocks,
+		}, "tester"); err != nil {
+			t.Fatalf("AddDependency: %v", err)
+		}
+		if !getIsBlocked(t, ctx, store, "wisps", target) {
+			t.Fatalf("wisp %s should be is_blocked = 1 after adding blocks dep", target)
+		}
+		return target
+	}
+
+	getStatus := func(t *testing.T, id string) types.Status {
+		t.Helper()
+		iss, err := store.GetIssue(ctx, id)
+		if err != nil {
+			t.Fatalf("GetIssue(%s): %v", id, err)
+		}
+		if iss == nil {
+			t.Fatalf("GetIssue(%s) returned nil issue", id)
+		}
+		return iss.Status
+	}
+
+	countClosedEvents := func(t *testing.T, id string) int {
+		t.Helper()
+		events, err := store.GetEvents(ctx, id, 0)
+		if err != nil {
+			t.Fatalf("GetEvents(%s): %v", id, err)
+		}
+		n := 0
+		for _, e := range events {
+			if e.EventType == types.EventClosed {
+				n++
+			}
+		}
+		return n
+	}
+
+	// mkClosed creates a plain issue and closes it via the guarded path so the
+	// already-closed case can re-close it.
+	mkClosed := func(t *testing.T, id string) string {
+		t.Helper()
+		createPerm(t, ctx, store, id)
+		if _, err := store.CloseIssueChecked(ctx, id, "tester",
+			storage.CloseIssueOptions{Reason: "done"}); err != nil {
+			t.Fatalf("initial CloseIssueChecked(%s): %v", id, err)
+		}
+		return id
+	}
+
+	tests := []struct {
+		name  string
+		setup func(t *testing.T) string
+		opts  storage.CloseIssueOptions
+		check func(t *testing.T, id string, res storage.CloseIssueResult, err error)
+	}{
+		{
+			name:  "blocked without force refuses and rolls back",
+			setup: func(t *testing.T) string { return mkBlocked(t, "cic-noforce") },
+			opts:  storage.CloseIssueOptions{Reason: "done"},
+			check: func(t *testing.T, id string, res storage.CloseIssueResult, err error) {
+				if !errors.Is(err, storage.ErrCloseBlocked) {
+					t.Fatalf("err = %v, want errors.Is(_, ErrCloseBlocked)", err)
+				}
+				// Atomic refuse: the issue must still be open (not closed) and
+				// no closed event may have been written — the guard aborted the
+				// tx before the close ran.
+				if got := getStatus(t, id); got == types.StatusClosed {
+					t.Fatalf("issue %s status = closed after refused close; guard did not abort", id)
+				}
+				if n := countClosedEvents(t, id); n != 0 {
+					t.Fatalf("closed event count for %s = %d, want 0 (tx must have rolled back)", id, n)
+				}
+			},
+		},
+		{
+			name:  "blocked with force closes",
+			setup: func(t *testing.T) string { return mkBlocked(t, "cic-force") },
+			opts:  storage.CloseIssueOptions{Reason: "done", Force: true},
+			check: func(t *testing.T, id string, res storage.CloseIssueResult, err error) {
+				if err != nil {
+					t.Fatalf("Force close err = %v, want nil", err)
+				}
+				if res.Unchanged {
+					t.Fatalf("res.Unchanged = true, want false (a real close)")
+				}
+				if got := getStatus(t, id); got != types.StatusClosed {
+					t.Fatalf("issue %s status = %q, want closed", id, got)
+				}
+			},
+		},
+		{
+			name: "not blocked closes",
+			setup: func(t *testing.T) string {
+				createPerm(t, ctx, store, "cic-plain")
+				return "cic-plain"
+			},
+			opts: storage.CloseIssueOptions{Reason: "done"},
+			check: func(t *testing.T, id string, res storage.CloseIssueResult, err error) {
+				if err != nil {
+					t.Fatalf("close err = %v, want nil", err)
+				}
+				if res.Unchanged {
+					t.Fatalf("res.Unchanged = true, want false (a real close)")
+				}
+				if got := getStatus(t, id); got != types.StatusClosed {
+					t.Fatalf("issue %s status = %q, want closed", id, got)
+				}
+			},
+		},
+		{
+			name:  "already closed is idempotent",
+			setup: func(t *testing.T) string { return mkClosed(t, "cic-idem") },
+			opts:  storage.CloseIssueOptions{Reason: "again"},
+			check: func(t *testing.T, id string, res storage.CloseIssueResult, err error) {
+				if err != nil {
+					t.Fatalf("re-close err = %v, want nil", err)
+				}
+				if !res.Unchanged {
+					t.Fatalf("res.Unchanged = false, want true (already closed)")
+				}
+				if got := getStatus(t, id); got != types.StatusClosed {
+					t.Fatalf("issue %s status = %q, want closed", id, got)
+				}
+			},
+		},
+		{
+			name:  "force on already closed is unchanged",
+			setup: func(t *testing.T) string { return mkClosed(t, "cic-force-idem") },
+			opts:  storage.CloseIssueOptions{Reason: "again", Force: true},
+			check: func(t *testing.T, id string, res storage.CloseIssueResult, err error) {
+				if err != nil {
+					t.Fatalf("force re-close err = %v, want nil", err)
+				}
+				if !res.Unchanged {
+					t.Fatalf("res.Unchanged = false, want true (already closed, even with Force)")
+				}
+				if got := getStatus(t, id); got != types.StatusClosed {
+					t.Fatalf("issue %s status = %q, want closed", id, got)
+				}
+			},
+		},
+		{
+			name: "non-blocking dep does not trip guard",
+			setup: func(t *testing.T) string {
+				createPerm(t, ctx, store, "cic-rel-other")
+				createPerm(t, ctx, store, "cic-rel-target")
+				if err := store.AddDependency(ctx, &types.Dependency{
+					IssueID: "cic-rel-target", DependsOnID: "cic-rel-other", Type: types.DepRelated,
+				}, "tester"); err != nil {
+					t.Fatalf("AddDependency(related): %v", err)
+				}
+				if getIsBlocked(t, ctx, store, "issues", "cic-rel-target") {
+					t.Fatalf("cic-rel-target should NOT be is_blocked with only a related dep")
+				}
+				return "cic-rel-target"
+			},
+			opts: storage.CloseIssueOptions{Reason: "done"},
+			check: func(t *testing.T, id string, res storage.CloseIssueResult, err error) {
+				if err != nil {
+					t.Fatalf("close with non-blocking dep err = %v, want nil", err)
+				}
+				if res.Unchanged {
+					t.Fatalf("res.Unchanged = true, want false (a real close)")
+				}
+				if got := getStatus(t, id); got != types.StatusClosed {
+					t.Fatalf("issue %s status = %q, want closed", id, got)
+				}
+			},
+		},
+		{
+			name:  "wisp blocked without force refuses and rolls back",
+			setup: func(t *testing.T) string { return mkBlockedWisp(t, "cic-wisp-noforce") },
+			opts:  storage.CloseIssueOptions{Reason: "done"},
+			check: func(t *testing.T, id string, res storage.CloseIssueResult, err error) {
+				if !errors.Is(err, storage.ErrCloseBlocked) {
+					t.Fatalf("err = %v, want errors.Is(_, ErrCloseBlocked)", err)
+				}
+				// closeWispChecked's deferred Rollback must discard the tx: the
+				// wisp stays open with no closed event.
+				if got := getStatus(t, id); got == types.StatusClosed {
+					t.Fatalf("wisp %s status = closed after refused close; guard did not abort", id)
+				}
+				if n := countClosedEvents(t, id); n != 0 {
+					t.Fatalf("closed event count for wisp %s = %d, want 0 (tx must have rolled back)", id, n)
+				}
+			},
+		},
+		{
+			name:  "wisp blocked with force closes",
+			setup: func(t *testing.T) string { return mkBlockedWisp(t, "cic-wisp-force") },
+			opts:  storage.CloseIssueOptions{Reason: "done", Force: true},
+			check: func(t *testing.T, id string, res storage.CloseIssueResult, err error) {
+				if err != nil {
+					t.Fatalf("Force close wisp err = %v, want nil", err)
+				}
+				if res.Unchanged {
+					t.Fatalf("res.Unchanged = true, want false (a real close)")
+				}
+				if got := getStatus(t, id); got != types.StatusClosed {
+					t.Fatalf("wisp %s status = %q, want closed", id, got)
+				}
+			},
+		},
+		{
+			name:  "missing id returns ErrNotFound",
+			setup: func(t *testing.T) string { return "cic-does-not-exist" },
+			opts:  storage.CloseIssueOptions{Reason: "done"},
+			check: func(t *testing.T, id string, res storage.CloseIssueResult, err error) {
+				if !errors.Is(err, storage.ErrNotFound) {
+					t.Fatalf("err = %v, want errors.Is(_, ErrNotFound)", err)
+				}
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			id := tc.setup(t)
+			res, err := store.CloseIssueChecked(ctx, id, "tester", tc.opts)
+			tc.check(t, id, res, err)
+		})
+	}
+}

--- a/internal/storage/dolt/issues.go
+++ b/internal/storage/dolt/issues.go
@@ -436,6 +436,48 @@ func (s *DoltStore) CloseIssue(ctx context.Context, id string, reason string, ac
 	})
 }
 
+// CloseIssueChecked closes an issue but refuses with storage.ErrCloseBlocked
+// when it is still blocked (is_blocked=1) unless opts.Force is set. The guard
+// and the close share one transaction, so the check is atomic (no TOCTOU).
+// Mirrors CloseIssue's Dolt-specific concerns (wisp routing, DOLT_ADD/COMMIT).
+func (s *DoltStore) CloseIssueChecked(ctx context.Context, id string, actor string, opts storage.CloseIssueOptions) (storage.CloseIssueResult, error) {
+	// Route ephemeral IDs to wisps table (falls through for promoted wisps).
+	// Wisps skip DOLT_COMMIT since they live in dolt_ignored tables.
+	if s.isActiveWisp(ctx, id) {
+		return s.closeWispChecked(ctx, id, actor, opts)
+	}
+
+	// Wrap in withRetryTx exactly like CloseIssue so a concurrent writer that
+	// loses Dolt's optimistic commit-time merge (MySQL 1213/1205, guaranteed
+	// server-side rollback) is retried. A blocked-guard rejection
+	// (storage.ErrCloseBlocked) is NOT a serialization error, so withRetryTx
+	// surfaces it permanently and the transaction rolls back — no close and no
+	// event are written (the atomic-refuse property).
+	var result storage.CloseIssueResult
+	if err := s.withRetryTx(ctx, func(tx *sql.Tx) error {
+		res, err := issueops.CloseIssueCheckedInTx(ctx, tx, id, opts.Reason, actor, opts.Session, opts.Force)
+		if err != nil {
+			return err
+		}
+		result = storage.CloseIssueResult{Unchanged: res.AlreadyClosed}
+
+		// Dolt versioning for permanent issues.
+		// GH#2455: Stage only the tables we modified, then commit without -A.
+		for _, table := range []string{"issues", "events"} {
+			_, _ = tx.ExecContext(ctx, "CALL DOLT_ADD(?)", table)
+		}
+		commitMsg := fmt.Sprintf("bd: close %s", id)
+		if _, err := tx.ExecContext(ctx, "CALL DOLT_COMMIT('-m', ?, '--author', ?)",
+			commitMsg, s.commitAuthorString()); err != nil && !isDoltNothingToCommit(err) {
+			return fmt.Errorf("dolt commit: %w", err)
+		}
+		return nil
+	}); err != nil {
+		return storage.CloseIssueResult{}, err
+	}
+	return result, nil
+}
+
 // DeleteIssue permanently removes an issue
 func (s *DoltStore) DeleteIssue(ctx context.Context, id string) error {
 	// Route ephemeral IDs to wisps table (falls through for promoted wisps)

--- a/internal/storage/dolt/wisps.go
+++ b/internal/storage/dolt/wisps.go
@@ -216,6 +216,30 @@ func (s *DoltStore) closeWisp(ctx context.Context, id string, reason string, act
 	return wrapTransactionError("commit close wisp", tx.Commit())
 }
 
+// closeWispChecked closes a wisp with the is_blocked guard, mirroring closeWisp
+// but refusing with storage.ErrCloseBlocked when the wisp is still blocked
+// unless opts.Force is set. The guard and the close share the same transaction;
+// wisps live in dolt_ignored tables, so there is no DOLT_COMMIT. On a guard
+// rejection the deferred Rollback discards the transaction — no close or event
+// is written.
+func (s *DoltStore) closeWispChecked(ctx context.Context, id string, actor string, opts storage.CloseIssueOptions) (storage.CloseIssueResult, error) {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return storage.CloseIssueResult{}, fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	res, err := issueops.CloseIssueCheckedInTx(ctx, tx, id, opts.Reason, actor, opts.Session, opts.Force)
+	if err != nil {
+		return storage.CloseIssueResult{}, err
+	}
+
+	if err := wrapTransactionError("commit close wisp", tx.Commit()); err != nil {
+		return storage.CloseIssueResult{}, err
+	}
+	return storage.CloseIssueResult{Unchanged: res.AlreadyClosed}, nil
+}
+
 // deleteWisp permanently removes a wisp and its related data.
 func (s *DoltStore) deleteWisp(ctx context.Context, id string) error {
 	tx, err := s.db.BeginTx(ctx, nil)

--- a/internal/storage/embeddeddolt/close_issue_checked_test.go
+++ b/internal/storage/embeddeddolt/close_issue_checked_test.go
@@ -1,0 +1,80 @@
+//go:build cgo
+
+package embeddeddolt_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/storage"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// TestEmbeddedCloseIssueChecked exercises the guarded close through the
+// EmbeddedDoltStore's withConn wrapper: a blocked issue is refused with
+// storage.ErrCloseBlocked and the transaction rolls back (issue stays open, no
+// closed event), while Force bypasses the guard and closes. The SQL guard/close
+// core is the shared issueops.CloseIssueCheckedInTx already covered against a
+// real engine by the dolt package; this test proves the embedded wrapper wires
+// it up and rolls back correctly.
+func TestEmbeddedCloseIssueChecked(t *testing.T) {
+	skipUnlessEmbeddedDolt(t)
+	te := newTestEnv(t, "cic")
+	ctx := t.Context()
+
+	for _, id := range []string{"cic-blocker", "cic-target"} {
+		iss := &types.Issue{ID: id, Title: id, Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask}
+		if err := te.store.CreateIssue(ctx, iss, "tester"); err != nil {
+			t.Fatalf("create %s: %v", id, err)
+		}
+	}
+	if err := te.store.AddDependency(ctx, &types.Dependency{
+		IssueID: "cic-target", DependsOnID: "cic-blocker", Type: types.DepBlocks,
+	}, "tester"); err != nil {
+		t.Fatalf("AddDependency: %v", err)
+	}
+	if blocked, _, err := te.store.IsBlocked(ctx, "cic-target"); err != nil || !blocked {
+		t.Fatalf("cic-target should be blocked (blocked=%v err=%v)", blocked, err)
+	}
+
+	// Blocked without force: refuse atomically — no close, no closed event.
+	res, err := te.store.CloseIssueChecked(ctx, "cic-target", "tester", storage.CloseIssueOptions{Reason: "done"})
+	if !errors.Is(err, storage.ErrCloseBlocked) {
+		t.Fatalf("blocked close err = %v, want errors.Is(_, ErrCloseBlocked)", err)
+	}
+	if res.Unchanged {
+		t.Fatalf("res.Unchanged = true on refusal, want false")
+	}
+	iss, err := te.store.GetIssue(ctx, "cic-target")
+	if err != nil {
+		t.Fatalf("GetIssue: %v", err)
+	}
+	if iss.Status == types.StatusClosed {
+		t.Fatalf("cic-target closed after refusal; withConn did not roll back")
+	}
+	events, err := te.store.GetEvents(ctx, "cic-target", 0)
+	if err != nil {
+		t.Fatalf("GetEvents: %v", err)
+	}
+	for _, e := range events {
+		if e.EventType == types.EventClosed {
+			t.Fatalf("closed event recorded despite refusal (tx must roll back)")
+		}
+	}
+
+	// Force bypasses the guard and closes.
+	res, err = te.store.CloseIssueChecked(ctx, "cic-target", "tester", storage.CloseIssueOptions{Reason: "done", Force: true})
+	if err != nil {
+		t.Fatalf("force close err = %v, want nil", err)
+	}
+	if res.Unchanged {
+		t.Fatalf("res.Unchanged = true on force close of open issue, want false")
+	}
+	iss, err = te.store.GetIssue(ctx, "cic-target")
+	if err != nil {
+		t.Fatalf("GetIssue after force: %v", err)
+	}
+	if iss.Status != types.StatusClosed {
+		t.Fatalf("cic-target status = %q after force, want closed", iss.Status)
+	}
+}

--- a/internal/storage/embeddeddolt/issues.go
+++ b/internal/storage/embeddeddolt/issues.go
@@ -133,6 +133,26 @@ func (s *EmbeddedDoltStore) CloseIssue(ctx context.Context, id string, reason st
 	})
 }
 
+// CloseIssueChecked closes an issue but refuses with storage.ErrCloseBlocked
+// when it is still blocked (is_blocked=1) unless opts.Force is set. The guard
+// and the close share one transaction, so the check is atomic (no TOCTOU).
+// Delegates SQL work to issueops; EmbeddedDolt auto-commits the transaction.
+func (s *EmbeddedDoltStore) CloseIssueChecked(ctx context.Context, id string, actor string, opts storage.CloseIssueOptions) (storage.CloseIssueResult, error) {
+	var result storage.CloseIssueResult
+	err := s.withConn(ctx, true, func(tx *sql.Tx) error {
+		res, err := issueops.CloseIssueCheckedInTx(ctx, tx, id, opts.Reason, actor, opts.Session, opts.Force)
+		if err != nil {
+			return err
+		}
+		result = storage.CloseIssueResult{Unchanged: res.AlreadyClosed}
+		return nil
+	})
+	if err != nil {
+		return storage.CloseIssueResult{}, err
+	}
+	return result, nil
+}
+
 // IsBlocked checks if an issue is blocked by active dependencies.
 func (s *EmbeddedDoltStore) IsBlocked(ctx context.Context, issueID string) (bool, []string, error) {
 	var blocked bool

--- a/internal/storage/hook_decorator.go
+++ b/internal/storage/hook_decorator.go
@@ -143,6 +143,19 @@ func (h *HookFiringStore) CloseIssue(ctx context.Context, id string, reason stri
 	return nil
 }
 
+// CloseIssueChecked closes an issue under the is_blocked guard and fires
+// on_close on success — mirroring CloseIssue, this includes the idempotent
+// no-op when the issue was already closed (res.Unchanged). A guard rejection
+// (ErrCloseBlocked) or any other error returns without firing.
+func (h *HookFiringStore) CloseIssueChecked(ctx context.Context, id string, actor string, opts CloseIssueOptions) (CloseIssueResult, error) {
+	res, err := h.inner.CloseIssueChecked(ctx, id, actor, opts)
+	if err != nil {
+		return res, err
+	}
+	h.fireHookByID(ctx, hooks.EventClose, id)
+	return res, nil
+}
+
 // ── Dependency mutations ────────────────────────────────────────────
 
 // AddDependency adds a dependency and fires on_update for the issue.

--- a/internal/storage/issueops/close.go
+++ b/internal/storage/issueops/close.go
@@ -3,6 +3,7 @@ package issueops
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"time"
 
@@ -33,22 +34,62 @@ func CloseIssueWithoutEventInTx(ctx context.Context, tx DBTX, id string, reason,
 // SAME transaction, so no blocker can clear between the check and the close.
 func CloseIssueCheckedInTx(ctx context.Context, tx DBTX, id, reason, actor, session string, force bool) (*CloseResult, error) {
 	if !force {
-		blocked, blockers, err := IsBlockedInTx(ctx, tx, id)
+		// The blocked guard only has meaning for an open→closed transition. An
+		// already-closed row is an idempotent no-op (Unchanged=true per the
+		// Storage.CloseIssueChecked contract), so detect that first. A closed
+		// row can still carry a stale is_blocked=1 — e.g. after a cross-clone
+		// Dolt merge, a state the schema explicitly models (GetStatistics
+		// filters `is_blocked = 1 AND status <> 'closed'`). Guarding such a row
+		// would refuse the idempotent re-close with ErrCloseBlocked. Only guard
+		// rows that are not already closed; CloseIssueInTx below is the sole
+		// detector of the already-closed no-op (and matches the Force path,
+		// which already reaches Unchanged=true by skipping the guard).
+		closed, err := isClosedInTx(ctx, tx, id)
 		if err != nil {
 			return nil, err
 		}
-		if blocked {
-			// A purely transitive block (e.g. an active parent-child chain)
-			// sets is_blocked=1 without any direct blocks/waits-for/
-			// conditional-blocks edge, so blockers is empty — omit the "blocked
-			// by" clause rather than render "blocked by []".
-			if len(blockers) > 0 {
-				return nil, fmt.Errorf("%w: %s is blocked by %v", storage.ErrCloseBlocked, id, blockers)
+		if !closed {
+			blocked, blockers, err := IsBlockedInTx(ctx, tx, id)
+			if err != nil {
+				return nil, err
 			}
-			return nil, fmt.Errorf("%w: %s", storage.ErrCloseBlocked, id)
+			if blocked {
+				// A purely transitive block (e.g. an active parent-child chain)
+				// sets is_blocked=1 without any direct blocks/waits-for/
+				// conditional-blocks edge, so blockers is empty — omit the "blocked
+				// by" clause rather than render "blocked by []".
+				if len(blockers) > 0 {
+					return nil, fmt.Errorf("%w: %s is blocked by %v", storage.ErrCloseBlocked, id, blockers)
+				}
+				return nil, fmt.Errorf("%w: %s", storage.ErrCloseBlocked, id)
+			}
 		}
 	}
 	return CloseIssueInTx(ctx, tx, id, reason, actor, session)
+}
+
+// isClosedInTx reports whether the issue (or wisp) identified by id is already
+// in the closed status. It probes the issues table then the optional wisps
+// table, mirroring IsBlockedInTx's table order. A missing row reports false so
+// the caller falls through to CloseIssueInTx, which returns ErrNotFound.
+//
+//nolint:gosec // G201: table is a hardcoded "issues" or "wisps".
+func isClosedInTx(ctx context.Context, tx DBTX, id string) (bool, error) {
+	for _, table := range []string{"issues", "wisps"} {
+		var status string
+		err := tx.QueryRowContext(ctx, "SELECT status FROM "+table+" WHERE id = ?", id).Scan(&status)
+		if err == nil {
+			return types.Status(status) == types.StatusClosed, nil
+		}
+		if errors.Is(err, sql.ErrNoRows) {
+			continue
+		}
+		if optionalBlockedTable(table) && isTableNotExistError(err) {
+			continue
+		}
+		return false, fmt.Errorf("read status from %s: %w", table, err)
+	}
+	return false, nil
 }
 
 //nolint:gosec // G201: table names come from WispTableRouting (hardcoded constants)

--- a/internal/storage/issueops/close.go
+++ b/internal/storage/issueops/close.go
@@ -27,6 +27,30 @@ func CloseIssueWithoutEventInTx(ctx context.Context, tx DBTX, id string, reason,
 	return closeIssueInTx(ctx, tx, id, reason, actor, session, false)
 }
 
+// CloseIssueCheckedInTx closes an issue within a transaction, refusing with
+// storage.ErrCloseBlocked when it is still blocked (is_blocked=1) unless force
+// is set. The guard (IsBlockedInTx) and the close (CloseIssueInTx) share the
+// SAME transaction, so no blocker can clear between the check and the close.
+func CloseIssueCheckedInTx(ctx context.Context, tx DBTX, id, reason, actor, session string, force bool) (*CloseResult, error) {
+	if !force {
+		blocked, blockers, err := IsBlockedInTx(ctx, tx, id)
+		if err != nil {
+			return nil, err
+		}
+		if blocked {
+			// A purely transitive block (e.g. an active parent-child chain)
+			// sets is_blocked=1 without any direct blocks/waits-for/
+			// conditional-blocks edge, so blockers is empty — omit the "blocked
+			// by" clause rather than render "blocked by []".
+			if len(blockers) > 0 {
+				return nil, fmt.Errorf("%w: %s is blocked by %v", storage.ErrCloseBlocked, id, blockers)
+			}
+			return nil, fmt.Errorf("%w: %s", storage.ErrCloseBlocked, id)
+		}
+	}
+	return CloseIssueInTx(ctx, tx, id, reason, actor, session)
+}
+
 //nolint:gosec // G201: table names come from WispTableRouting (hardcoded constants)
 func closeIssueInTx(ctx context.Context, tx DBTX, id string, reason, actor, session string, recordEvent bool) (*CloseResult, error) {
 	isWisp := IsActiveWispInTx(ctx, tx, id)

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -44,6 +44,11 @@ var ErrNotInitialized = errors.New("database not initialized")
 // ErrPrefixMismatch is returned when an issue ID does not match the configured prefix.
 var ErrPrefixMismatch = errors.New("prefix mismatch")
 
+// ErrCloseBlocked is returned by CloseIssueChecked when an issue cannot be
+// closed because it is still blocked (is_blocked=1: an open blocking dependency
+// or an open blocking gate). Bypass with CloseIssueOptions.Force.
+var ErrCloseBlocked = errors.New("cannot close blocked issue")
+
 // Storage is the interface satisfied by *dolt.DoltStore.
 // Consumers depend on this interface rather than on the concrete type so that
 // alternative implementations (mocks, proxies, etc.) can be substituted.
@@ -64,6 +69,12 @@ type Storage interface {
 	UnclaimIssueIfAssignee(ctx context.Context, id string, actor string, expectedAssignee string) error
 	UpdateIssueType(ctx context.Context, id string, issueType string, actor string) error
 	CloseIssue(ctx context.Context, id string, reason string, actor string, session string) error
+	// CloseIssueChecked closes an issue, but refuses with ErrCloseBlocked when
+	// the issue is still blocked (is_blocked=1) unless opts.Force is set. The
+	// blocked-check and the close run in ONE transaction, so the guard is atomic
+	// (no TOCTOU). Already-closed is an idempotent success with Unchanged=true; a
+	// missing issue returns ErrNotFound.
+	CloseIssueChecked(ctx context.Context, id string, actor string, opts CloseIssueOptions) (CloseIssueResult, error)
 	DeleteIssue(ctx context.Context, id string) error
 	SearchIssues(ctx context.Context, query string, filter types.IssueFilter) ([]*types.Issue, error)
 	SearchIssuesWithCounts(ctx context.Context, query string, filter types.IssueFilter) ([]*types.IssueWithCounts, error)
@@ -188,6 +199,18 @@ type Storage interface {
 
 	// Lifecycle
 	Close() error
+}
+
+// CloseIssueOptions carries the optional inputs to CloseIssueChecked.
+type CloseIssueOptions struct {
+	Reason  string
+	Session string
+	Force   bool // bypass the is_blocked guard (mirrors `bd close --force`)
+}
+
+// CloseIssueResult reports the outcome of CloseIssueChecked.
+type CloseIssueResult struct {
+	Unchanged bool // true when the issue was ALREADY closed (idempotent no-op)
 }
 
 // MergeSlotStatus is returned by MergeSlotCheck and describes the current

--- a/internal/telemetry/storage.go
+++ b/internal/telemetry/storage.go
@@ -210,6 +210,17 @@ func (s *InstrumentedStorage) CloseIssue(ctx context.Context, id string, reason 
 	return err
 }
 
+func (s *InstrumentedStorage) CloseIssueChecked(ctx context.Context, id string, actor string, opts storage.CloseIssueOptions) (storage.CloseIssueResult, error) {
+	attrs := []attribute.KeyValue{
+		attribute.String("bd.issue.id", id),
+		attribute.String("bd.actor", actor),
+	}
+	ctx, span, t := s.op(ctx, "CloseIssueChecked", attrs...)
+	res, err := s.inner.CloseIssueChecked(ctx, id, actor, opts)
+	s.done(ctx, span, t, err, attrs...)
+	return res, err
+}
+
 func (s *InstrumentedStorage) DeleteIssue(ctx context.Context, id string) error {
 	attrs := []attribute.KeyValue{attribute.String("bd.issue.id", id)}
 	ctx, span, t := s.op(ctx, "DeleteIssue", attrs...)


### PR DESCRIPTION
> Stacked on #4892 (S1 typed error taxonomy). Base is `feat/guarded-ops-s1-error-taxonomy`; retarget to `main` once #4892 merges. The diff below is S2 only.

## What

Adds `CloseIssueChecked` — a close that runs the `is_blocked` guard **and** the close inside **one transaction**, so the guard is atomic. A `Force` option bypasses it (mirrors `bd close --force`). New `storage.ErrCloseBlocked` sentinel (re-exported as `beads.ErrCloseBlocked`), plus `CloseIssueOptions{Reason,Session,Force}` and `CloseIssueResult{Unchanged}`.

## Why

`bd close` today reads blockers (`store.IsBlocked`) and then calls `store.CloseIssue` in a **separate** transaction — a TOCTOU: a blocker can clear, or the bead can be closed by someone else, between the check and the close. Moving the guard into a single engine transaction removes that window and lets the `bd` CLI delegate its close guard to the engine instead of hand-rolling the check-then-close dance. This is a step in making the library the single enforcement layer with the CLI as a thin adapter.

Scope is one concern. Category-aware reopen (reopening custom done-category statuses) and folding the open-children close guard (GH#3681) into the same op are deliberately split into follow-up PRs.

## Verification

- Guard semantics: `IsBlockedInTx` reads the denormalized transitive `is_blocked` column — an open blocking dependency or an open blocking gate. On a blocked refusal, `CloseIssueChecked` returns `ErrCloseBlocked` and the transaction **rolls back**: no close, no `closed` event.
- Implemented on the `Storage` interface across `DoltStore` (perm + wisp paths, mirroring `CloseIssue`'s DOLT_COMMIT / wisp handling), `EmbeddedDoltStore`, `HookFiringStore` (fires `on_close` on success, like `CloseIssue`), and `InstrumentedStorage`; both cgo and `CGO_ENABLED=0` builds compile.
- Integration tests assert the **atomic-refuse** property (blocked → refused, still open, **zero** closed events recorded) on the perm, wisp, and embeddeddolt paths, plus: Force closes a blocked bead; a non-blocking dep type does not trip the guard; already-closed → `Unchanged=true`; missing id → `ErrNotFound`.
- `gofmt`/`go vet` clean; `golangci-lint` (pre-commit) 0 issues.

```bash
go test ./internal/storage/dolt/ -run TestCloseIssueChecked -count=1 -v
BEADS_TEST_EMBEDDED_DOLT=1 go test ./internal/storage/embeddeddolt/ -run TestEmbeddedCloseIssueChecked -v
```
