### PR TITLE
feat(validate): typed length bounds for assignee, owner, and label

### DIFF
--- a/beads.go
+++ b/beads.go
@@ -208,6 +208,10 @@ const (
 	EventCompacted         = types.EventCompacted
 )
 
+// MaxFieldLen re-exports the maximum length (in characters) of the assignee,
+// owner, and label fields, paired with the ErrFieldTooLong sentinel below.
+const MaxFieldLen = types.MaxFieldLen
+
 // Re-exported error sentinels so consumers match on errors.Is rather than
 // on message text. Each is an ALIAS of the internal sentinel, so the identity
 // is preserved across the package boundary.
@@ -218,4 +222,5 @@ var (
 	ErrCloseBlocked    = storage.ErrCloseBlocked
 	ErrSelfDependency  = domain.ErrSelfDependency
 	ErrDependencyCycle = domain.ErrDependencyCycle
+	ErrFieldTooLong    = types.ErrFieldTooLong
 )

--- a/errors_test.go
+++ b/errors_test.go
@@ -44,6 +44,7 @@ func TestReExportedSentinelIdentity(t *testing.T) {
 		{"ErrNotClaimable", beads.ErrNotClaimable, storage.ErrNotClaimable},
 		{"ErrSelfDependency", beads.ErrSelfDependency, domain.ErrSelfDependency},
 		{"ErrDependencyCycle", beads.ErrDependencyCycle, domain.ErrDependencyCycle},
+		{"ErrFieldTooLong", beads.ErrFieldTooLong, types.ErrFieldTooLong},
 	}
 	for _, tc := range cases {
 		if tc.exported != tc.internal {
@@ -90,5 +91,25 @@ func TestReExportedSentinelCatchesRealProductionError(t *testing.T) {
 		&types.Dependency{IssueID: "a", DependsOnID: "b", Type: types.DepBlocks}, "tester")
 	if !errors.Is(cycleErr, beads.ErrDependencyCycle) {
 		t.Errorf("errors.Is(real cycle err, beads.ErrDependencyCycle) = false; err = %v", cycleErr)
+	}
+}
+
+// TestReExportFieldTooLong proves the public beads.ErrFieldTooLong alias is the
+// same value as the internal types sentinel and composes through errors.Is when
+// wrapped — the property length-validation callers rely on to detect an
+// over-length assignee/owner/label without importing internal/types. It also
+// checks the MaxFieldLen constant re-export tracks the source of truth.
+func TestReExportFieldTooLong(t *testing.T) {
+	t.Parallel()
+
+	if beads.ErrFieldTooLong != types.ErrFieldTooLong {
+		t.Error("beads.ErrFieldTooLong is not the internal sentinel value (identity broken)")
+	}
+	wrapped := fmt.Errorf("x: %w", beads.ErrFieldTooLong)
+	if !errors.Is(wrapped, beads.ErrFieldTooLong) {
+		t.Errorf("errors.Is(wrapped, beads.ErrFieldTooLong) = false; err = %v", wrapped)
+	}
+	if beads.MaxFieldLen != types.MaxFieldLen {
+		t.Errorf("beads.MaxFieldLen = %d, want types.MaxFieldLen = %d", beads.MaxFieldLen, types.MaxFieldLen)
 	}
 }

--- a/internal/storage/dolt/field_length_test.go
+++ b/internal/storage/dolt/field_length_test.go
@@ -1,0 +1,177 @@
+package dolt
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// TestFieldLengthValidation drives the assignee/owner/label VARCHAR(255) bounds
+// through the real DoltStore. Over-length values are rejected up front with a
+// typed types.ErrFieldTooLong — instead of a raw backend "data too long" error
+// for assignee/owner, or (critically) a SILENT INSERT IGNORE truncation for
+// labels — and nothing is persisted. Values at exactly the 255-character limit
+// still succeed.
+func TestFieldLengthValidation(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	over := strings.Repeat("x", 300)                  // 300 runes > MaxFieldLen (255)
+	atLimit := strings.Repeat("y", types.MaxFieldLen) // exactly 255 runes
+
+	baseIssue := func(id string) *types.Issue {
+		return &types.Issue{
+			ID:        id,
+			Title:     "field-length " + id,
+			Status:    types.StatusOpen,
+			Priority:  2,
+			IssueType: types.TypeTask,
+		}
+	}
+
+	t.Run("create with over-length label is rejected and not stored", func(t *testing.T) {
+		iss := baseIssue("fl-label-over")
+		iss.Labels = []string{over}
+		err := store.CreateIssue(ctx, iss, "tester")
+		if !errors.Is(err, types.ErrFieldTooLong) {
+			t.Fatalf("CreateIssue with 300-char label: err = %v, want errors.Is(ErrFieldTooLong)", err)
+		}
+		// The whole create ran in one transaction, so it rolled back: no label
+		// row exists (not a silently truncated one) and the issue is absent.
+		labels, err := store.GetLabels(ctx, "fl-label-over")
+		if err != nil {
+			t.Fatalf("GetLabels: %v", err)
+		}
+		if len(labels) != 0 {
+			t.Errorf("expected no labels stored after failed create, got %v", labels)
+		}
+		if got, _ := store.GetIssue(ctx, "fl-label-over"); got != nil {
+			t.Errorf("expected issue to be absent after rejected create, got %+v", got)
+		}
+	})
+
+	t.Run("create with over-length assignee is rejected and not stored", func(t *testing.T) {
+		iss := baseIssue("fl-assignee-over")
+		iss.Assignee = over
+		err := store.CreateIssue(ctx, iss, "tester")
+		if !errors.Is(err, types.ErrFieldTooLong) {
+			t.Fatalf("CreateIssue with 300-char assignee: err = %v, want errors.Is(ErrFieldTooLong)", err)
+		}
+		if got, _ := store.GetIssue(ctx, "fl-assignee-over"); got != nil {
+			t.Errorf("expected issue to be absent after rejected create, got %+v", got)
+		}
+	})
+
+	t.Run("create with over-length owner is rejected and not stored", func(t *testing.T) {
+		iss := baseIssue("fl-owner-over")
+		iss.Owner = over
+		err := store.CreateIssue(ctx, iss, "tester")
+		if !errors.Is(err, types.ErrFieldTooLong) {
+			t.Fatalf("CreateIssue with 300-char owner: err = %v, want errors.Is(ErrFieldTooLong)", err)
+		}
+		if got, _ := store.GetIssue(ctx, "fl-owner-over"); got != nil {
+			t.Errorf("expected issue to be absent after rejected create, got %+v", got)
+		}
+	})
+
+	t.Run("255-rune multibyte assignee round-trips (rune-count, not byte-count)", func(t *testing.T) {
+		// "é" is 2 bytes, so 255 of them is 255 runes / 510 bytes: fits the
+		// VARCHAR(255) column by character count and must survive unchanged.
+		multibyte := strings.Repeat("é", types.MaxFieldLen)
+		iss := baseIssue("fl-multibyte-ok")
+		iss.Assignee = multibyte
+		if err := store.CreateIssue(ctx, iss, "tester"); err != nil {
+			t.Fatalf("CreateIssue with 255-rune multibyte assignee (%d bytes): %v", len(multibyte), err)
+		}
+		got, err := store.GetIssue(ctx, "fl-multibyte-ok")
+		if err != nil {
+			t.Fatalf("GetIssue: %v", err)
+		}
+		if got == nil || got.Assignee != multibyte {
+			t.Errorf("expected the 255-rune multibyte assignee stored intact, got %+v", got)
+		}
+	})
+
+	t.Run("256-rune multibyte assignee is rejected", func(t *testing.T) {
+		iss := baseIssue("fl-multibyte-over")
+		iss.Assignee = strings.Repeat("é", types.MaxFieldLen+1)
+		err := store.CreateIssue(ctx, iss, "tester")
+		if !errors.Is(err, types.ErrFieldTooLong) {
+			t.Fatalf("CreateIssue with 256-rune multibyte assignee: err = %v, want errors.Is(ErrFieldTooLong)", err)
+		}
+	})
+
+	t.Run("bulk create with one over-length field is rejected and nothing persisted", func(t *testing.T) {
+		// The bulk path enforces the configured "test" ID prefix, so use it here.
+		good := baseIssue("test-fl-bulk-good")
+		bad := baseIssue("test-fl-bulk-bad")
+		bad.Assignee = over
+		err := store.CreateIssues(ctx, []*types.Issue{good, bad}, "tester")
+		if !errors.Is(err, types.ErrFieldTooLong) {
+			t.Fatalf("CreateIssues with a 300-char assignee: err = %v, want errors.Is(ErrFieldTooLong)", err)
+		}
+		// The batch runs in one transaction, so a mid-batch rejection rolls back
+		// the whole batch — neither issue is persisted.
+		for _, id := range []string{"test-fl-bulk-good", "test-fl-bulk-bad"} {
+			if got, _ := store.GetIssue(ctx, id); got != nil {
+				t.Errorf("expected %s absent after rejected bulk create, got %+v", id, got)
+			}
+		}
+	})
+
+	t.Run("update assignee to over-length is rejected", func(t *testing.T) {
+		iss := baseIssue("fl-update-assignee")
+		if err := store.CreateIssue(ctx, iss, "tester"); err != nil {
+			t.Fatalf("CreateIssue: %v", err)
+		}
+		err := store.UpdateIssue(ctx, "fl-update-assignee", map[string]interface{}{"assignee": over}, "tester")
+		if !errors.Is(err, types.ErrFieldTooLong) {
+			t.Fatalf("UpdateIssue assignee=300 chars: err = %v, want errors.Is(ErrFieldTooLong)", err)
+		}
+	})
+
+	t.Run("add-label with over-length label is rejected", func(t *testing.T) {
+		iss := baseIssue("fl-addlabel")
+		if err := store.CreateIssue(ctx, iss, "tester"); err != nil {
+			t.Fatalf("CreateIssue: %v", err)
+		}
+		err := store.AddLabel(ctx, "fl-addlabel", over, "tester")
+		if !errors.Is(err, types.ErrFieldTooLong) {
+			t.Fatalf("AddLabel with 300-char label: err = %v, want errors.Is(ErrFieldTooLong)", err)
+		}
+		labels, err := store.GetLabels(ctx, "fl-addlabel")
+		if err != nil {
+			t.Fatalf("GetLabels: %v", err)
+		}
+		if len(labels) != 0 {
+			t.Errorf("expected no labels stored after rejected AddLabel, got %v", labels)
+		}
+	})
+
+	t.Run("values at the 255-char limit succeed", func(t *testing.T) {
+		iss := baseIssue("fl-atlimit")
+		iss.Assignee = atLimit
+		iss.Labels = []string{atLimit}
+		if err := store.CreateIssue(ctx, iss, "tester"); err != nil {
+			t.Fatalf("CreateIssue with 255-char assignee+label: %v", err)
+		}
+		labels, err := store.GetLabels(ctx, "fl-atlimit")
+		if err != nil {
+			t.Fatalf("GetLabels: %v", err)
+		}
+		if len(labels) != 1 || labels[0] != atLimit {
+			t.Errorf("expected the 255-char label stored intact, got %v", labels)
+		}
+		got, err := store.GetIssue(ctx, "fl-atlimit")
+		if err != nil {
+			t.Fatalf("GetIssue: %v", err)
+		}
+		if got == nil || got.Assignee != atLimit {
+			t.Errorf("expected the 255-char assignee stored intact, got %+v", got)
+		}
+	})
+}

--- a/internal/storage/domain/db/field_length_test.go
+++ b/internal/storage/domain/db/field_length_test.go
@@ -1,0 +1,81 @@
+package db
+
+import (
+	"strings"
+
+	"github.com/steveyegge/beads/internal/storage/domain"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// TestFieldLengthGuards proves the proxied-server (uow) write stack enforces the
+// assignee/owner/label VARCHAR(255) bounds — the gap the S3 embedded-path fix
+// alone left open. Over-length values are rejected with a typed
+// types.ErrFieldTooLong (not a raw backend "data too long" error, and not a
+// silent label truncation), nothing is persisted, and values at the 255-char
+// limit still round-trip.
+func (s *testSuite) TestFieldLengthGuards() {
+	over := strings.Repeat("x", 300)                  // 300 runes > MaxFieldLen (255)
+	atLimit := strings.Repeat("y", types.MaxFieldLen) // exactly 255 runes
+
+	s.Run("LabelInsertOverLengthRejectedNoRow", func() {
+		s.seedIssueRow("bd-fl-label")
+		r := s.labelRepo()
+		err := r.Insert(s.Ctx(), "bd-fl-label", over, "tester", domain.LabelOpts{})
+		s.Require().ErrorIs(err, types.ErrFieldTooLong)
+
+		out, err := r.List(s.Ctx(), "bd-fl-label", domain.LabelOpts{})
+		s.Require().NoError(err)
+		s.Empty(out, "over-length label must not be stored (not even truncated)")
+	})
+
+	s.Run("CreateOverLengthAssigneeRejectedNotPersisted", func() {
+		r := s.issueRepo()
+		in := newTestIssue("bd-fl-assignee", "over-length assignee")
+		in.Assignee = over
+		err := r.Insert(s.Ctx(), in, "tester", domain.InsertIssueOpts{})
+		s.Require().ErrorIs(err, types.ErrFieldTooLong)
+
+		exists, err := r.Exists(s.Ctx(), "bd-fl-assignee", domain.IssueTableOpts{})
+		s.Require().NoError(err)
+		s.False(exists, "issue must not be persisted when assignee is rejected")
+	})
+
+	s.Run("CreateOverLengthOwnerRejected", func() {
+		r := s.issueRepo()
+		in := newTestIssue("bd-fl-owner", "over-length owner")
+		in.Owner = over
+		err := r.Insert(s.Ctx(), in, "tester", domain.InsertIssueOpts{})
+		s.Require().ErrorIs(err, types.ErrFieldTooLong)
+	})
+
+	s.Run("UpdateOverLengthAssigneeRejected", func() {
+		r := s.issueRepo()
+		s.Require().NoError(r.Insert(s.Ctx(), newTestIssue("bd-fl-upd", "x"), "tester", domain.InsertIssueOpts{}))
+		err := r.Update(s.Ctx(), "bd-fl-upd", map[string]any{"assignee": over}, "tester", domain.IssueTableOpts{})
+		s.Require().ErrorIs(err, types.ErrFieldTooLong)
+	})
+
+	s.Run("ClaimOverLengthActorRejected", func() {
+		r := s.issueRepo()
+		s.Require().NoError(r.Insert(s.Ctx(), newTestIssue("bd-fl-claim", "x"), "tester", domain.InsertIssueOpts{}))
+		_, err := r.Claim(s.Ctx(), "bd-fl-claim", over, domain.IssueTableOpts{})
+		s.Require().ErrorIs(err, types.ErrFieldTooLong)
+	})
+
+	s.Run("AtLimitAssigneeAndLabelRoundTrip", func() {
+		r := s.issueRepo()
+		in := newTestIssue("bd-fl-ok", "at limit")
+		in.Assignee = atLimit
+		s.Require().NoError(r.Insert(s.Ctx(), in, "tester", domain.InsertIssueOpts{}))
+
+		out, err := r.Get(s.Ctx(), "bd-fl-ok", domain.IssueTableOpts{})
+		s.Require().NoError(err)
+		s.Equal(atLimit, out.Assignee, "255-char assignee must round-trip unchanged")
+
+		lr := s.labelRepo()
+		s.Require().NoError(lr.Insert(s.Ctx(), "bd-fl-ok", atLimit, "tester", domain.LabelOpts{}))
+		labels, err := lr.List(s.Ctx(), "bd-fl-ok", domain.LabelOpts{})
+		s.Require().NoError(err)
+		s.Equal([]string{atLimit}, labels, "255-char label must be stored intact")
+	})
+}

--- a/internal/storage/domain/db/issue.go
+++ b/internal/storage/domain/db/issue.go
@@ -92,6 +92,19 @@ func (r *issueSQLRepositoryImpl) Update(ctx context.Context, id string, updates 
 		return nil
 	}
 
+	// Bound the VARCHAR(255) assignment columns before touching SQL, mirroring
+	// issueops.updateIssueInTx: an over-length assignee/owner aborts with a typed
+	// ErrFieldTooLong instead of a raw backend "data too long" error.
+	for _, field := range []string{"assignee", "owner"} {
+		if raw, ok := updates[field]; ok {
+			if val, ok := raw.(string); ok {
+				if err := types.CheckFieldLen(field, val); err != nil {
+					return err
+				}
+			}
+		}
+	}
+
 	table := pickIssueTable(opts.UseWispsTable)
 
 	_, statusChanging := updates["status"]
@@ -229,6 +242,12 @@ func coerceStatus(v any) types.Status {
 func (r *issueSQLRepositoryImpl) Claim(ctx context.Context, id, actor string, opts domain.IssueTableOpts) (domain.ClaimRowResult, error) {
 	if id == "" {
 		return domain.ClaimRowResult{}, errors.New("db: Claim: id must not be empty")
+	}
+	// The CAS below writes assignee = actor. actor is user-settable (--actor /
+	// BEADS_ACTOR), so bound it against the VARCHAR(255) assignee column up front
+	// and return a typed ErrFieldTooLong rather than a raw backend error.
+	if err := types.CheckFieldLen("actor", actor); err != nil {
+		return domain.ClaimRowResult{}, err
 	}
 
 	oldIssue, err := r.Get(ctx, id, opts)
@@ -556,6 +575,17 @@ func pickIssueTable(useWisps bool) string {
 
 //nolint:gosec // G201: table is a hardcoded constant ("issues" or "wisps")
 func insertIssueRow(ctx context.Context, runner Runner, table string, issue *types.Issue) error {
+	// Bound the VARCHAR(255) assignment columns at the raw-SQL chokepoint, so
+	// every proxied-server (uow) create — single, batch, and import — rejects an
+	// over-length assignee/owner with a typed ErrFieldTooLong instead of a raw
+	// backend "data too long" error. Mirrors ValidateWithCustom on the embedded
+	// create path.
+	if err := types.CheckFieldLen("assignee", issue.Assignee); err != nil {
+		return err
+	}
+	if err := types.CheckFieldLen("owner", issue.Owner); err != nil {
+		return err
+	}
 	_, err := runner.ExecContext(ctx, fmt.Sprintf(`
 		INSERT INTO %s (
 			id, content_hash, title, description, design, acceptance_criteria, notes,

--- a/internal/storage/domain/db/label.go
+++ b/internal/storage/domain/db/label.go
@@ -39,6 +39,13 @@ func (r *labelSQLRepositoryImpl) Insert(ctx context.Context, issueID, label, act
 	if label == "" {
 		return fmt.Errorf("db: LabelSQLRepository.Insert: label must not be empty")
 	}
+	// Reject an over-length label before the INSERT IGNORE, which would otherwise
+	// silently truncate it to the VARCHAR(255) column. This is the proxied-server
+	// (uow) analog of issueops.AddLabelInTx's guard, so both write stacks return a
+	// typed ErrFieldTooLong instead of storing a label the caller never sent.
+	if err := types.CheckFieldLen("label", label); err != nil {
+		return err
+	}
 	table := pickLabelTable(opts.UseWispsTable)
 	//nolint:gosec // G201: table is one of two hardcoded constants
 	if _, err := r.runner.ExecContext(ctx,

--- a/internal/storage/issueops/claim.go
+++ b/internal/storage/issueops/claim.go
@@ -33,6 +33,12 @@ type ClaimResult struct {
 //
 //nolint:gosec // G201: table names come from WispTableRouting (hardcoded constants)
 func ClaimIssueInTx(ctx context.Context, tx DBTX, id string, actor string) (*ClaimResult, error) {
+	// The CAS below writes assignee = actor. actor is user-settable (--actor /
+	// BEADS_ACTOR), so bound it against the VARCHAR(255) assignee column up front
+	// and return a typed ErrFieldTooLong rather than a raw backend error.
+	if err := types.CheckFieldLen("actor", actor); err != nil {
+		return nil, err
+	}
 	isWisp := IsActiveWispInTx(ctx, tx, id)
 	issueTable, _, eventTable, _ := WispTableRouting(isWisp)
 

--- a/internal/storage/issueops/create.go
+++ b/internal/storage/issueops/create.go
@@ -644,6 +644,14 @@ func PersistLabels(ctx context.Context, tx *sql.Tx, issue *types.Issue, actor, e
 			continue
 		}
 		seen[label] = struct{}{}
+		// Reject an over-length label before the INSERT IGNORE, which would
+		// otherwise silently truncate it to VARCHAR(255). This is the create and
+		// import chokepoint (AddLabelInTx guards the bd label-add path). The whole
+		// create runs in one transaction, so returning here rolls it back — the
+		// issue and its labels are not persisted.
+		if err := types.CheckFieldLen("label", label); err != nil {
+			return result, err
+		}
 		//nolint:gosec // G201: table is determined by ephemeral flag
 		sqlResult, err := tx.ExecContext(ctx, fmt.Sprintf(`
 			INSERT IGNORE INTO %s (issue_id, label)

--- a/internal/storage/issueops/labels.go
+++ b/internal/storage/issueops/labels.go
@@ -132,6 +132,12 @@ func getLabelsIntoFromTable(ctx context.Context, tx DBTX, labelTable string, ids
 // transaction. Automatically routes to wisp tables if the ID is an active wisp.
 // Uses INSERT IGNORE for idempotency.
 func AddLabelInTx(ctx context.Context, tx DBTX, labelTable, eventTable, issueID, label, actor string) error {
+	// Reject an over-length label up front. The INSERT IGNORE below would
+	// otherwise silently truncate it to the VARCHAR(255) column, storing a label
+	// the caller never sent; a typed ErrFieldTooLong is the clean rejection.
+	if err := types.CheckFieldLen("label", label); err != nil {
+		return err
+	}
 	if labelTable == "" || eventTable == "" {
 		isWisp := IsActiveWispInTx(ctx, tx, issueID)
 		_, lt, et, _ := WispTableRouting(isWisp)

--- a/internal/storage/issueops/update.go
+++ b/internal/storage/issueops/update.go
@@ -227,6 +227,20 @@ func updateIssueInTx(ctx context.Context, tx DBTX, id string, updates map[string
 		}
 	}
 
+	// Bound the VARCHAR(255) assignment columns before touching SQL, so an
+	// over-length assignee/owner aborts with a typed ErrFieldTooLong instead of
+	// a raw backend "data too long" error. Create validates these via
+	// ValidateWithCustom; the generic update path does not, so guard it here.
+	for _, field := range []string{"assignee", "owner"} {
+		if raw, ok := updates[field]; ok {
+			if val, ok := raw.(string); ok {
+				if err := types.CheckFieldLen(field, val); err != nil {
+					return nil, err
+				}
+			}
+		}
+	}
+
 	// Build SET clauses.
 	setClauses := []string{"updated_at = ?"}
 	args := []interface{}{time.Now().UTC()}

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -4,11 +4,13 @@ package types
 import (
 	"crypto/sha256"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"hash"
 	"regexp"
 	"strings"
 	"time"
+	"unicode/utf8"
 )
 
 // Issue represents a trackable work item.
@@ -213,6 +215,26 @@ func (w hashFieldWriter) flag(b bool, label string) {
 	w.h.Write([]byte{0})
 }
 
+// MaxFieldLen is the maximum length (in characters) of the assignee, owner, and
+// label fields, matching their VARCHAR(255) columns.
+const MaxFieldLen = 255
+
+// ErrFieldTooLong is returned when assignee, owner, or a label exceeds
+// MaxFieldLen characters. Callers can errors.Is it instead of matching a raw
+// backend "data too long" string.
+var ErrFieldTooLong = errors.New("field exceeds maximum length")
+
+// CheckFieldLen returns ErrFieldTooLong (wrapped with context) when val exceeds
+// MaxFieldLen characters. name is the field label used in the message. Length is
+// counted in runes, not bytes, so a multibyte value up to MaxFieldLen characters
+// fits the VARCHAR(255) column and passes.
+func CheckFieldLen(name, val string) error {
+	if n := utf8.RuneCountInString(val); n > MaxFieldLen {
+		return fmt.Errorf("%w: %s is %d characters (max %d)", ErrFieldTooLong, name, n, MaxFieldLen)
+	}
+	return nil
+}
+
 // Validate checks if the issue has valid field values (built-in statuses only)
 func (i *Issue) Validate() error {
 	return i.ValidateWithCustomStatuses(nil)
@@ -262,6 +284,14 @@ func (i *Issue) ValidateWithCustom(customStatuses, customTypes []string) error {
 	if i.Ephemeral && i.NoHistory {
 		return fmt.Errorf("ephemeral and no_history are mutually exclusive")
 	}
+	// Bound the VARCHAR(255) assignment columns up front so callers get a typed
+	// ErrFieldTooLong rejection instead of a raw backend "data too long" error.
+	if err := CheckFieldLen("assignee", i.Assignee); err != nil {
+		return err
+	}
+	if err := CheckFieldLen("owner", i.Owner); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -305,6 +335,14 @@ func (i *Issue) ValidateForImport(customStatuses []string) error {
 		if !json.Valid(i.Metadata) {
 			return fmt.Errorf("metadata must be valid JSON")
 		}
+	}
+	// Bound the VARCHAR(255) assignment columns on the import path too, so an
+	// over-length assignee/owner is rejected here instead of by the backend.
+	if err := CheckFieldLen("assignee", i.Assignee); err != nil {
+		return err
+	}
+	if err := CheckFieldLen("owner", i.Owner); err != nil {
+		return err
 	}
 	return nil
 }

--- a/internal/types/types_test.go
+++ b/internal/types/types_test.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
@@ -1677,5 +1678,125 @@ func TestBondRefUnmarshalJSON(t *testing.T) {
 				t.Errorf("BondType = %q, want %q", b.BondType, tt.wantBondType)
 			}
 		})
+	}
+}
+
+// validIssue returns a minimal issue that passes ValidateWithCustom, so
+// field-length tests below isolate the assignee/owner bound.
+func validIssue() Issue {
+	return Issue{
+		Title:     "Test Issue",
+		Status:    StatusOpen,
+		Priority:  1,
+		IssueType: TypeTask,
+	}
+}
+
+// TestValidateFieldLength proves ValidateWithCustom bounds assignee and owner at
+// MaxFieldLen and that the bound is measured in runes, not bytes: a 255-rune
+// multibyte value (~510 bytes) fits the VARCHAR(255) column and passes, while a
+// 256-rune value is rejected with a typed ErrFieldTooLong.
+func TestValidateFieldLength(t *testing.T) {
+	// "é" (U+00E9) encodes as 2 bytes, so 255 of them is 255 runes / 510 bytes.
+	const multibyte = "é"
+
+	tests := []struct {
+		name    string
+		mutate  func(*Issue)
+		wantErr bool
+	}{
+		{
+			name:    "255-rune assignee passes",
+			mutate:  func(i *Issue) { i.Assignee = strings.Repeat("a", MaxFieldLen) },
+			wantErr: false,
+		},
+		{
+			name:    "256-rune assignee fails",
+			mutate:  func(i *Issue) { i.Assignee = strings.Repeat("a", MaxFieldLen+1) },
+			wantErr: true,
+		},
+		{
+			name:    "255-rune owner passes",
+			mutate:  func(i *Issue) { i.Owner = strings.Repeat("o", MaxFieldLen) },
+			wantErr: false,
+		},
+		{
+			name:    "256-rune owner fails",
+			mutate:  func(i *Issue) { i.Owner = strings.Repeat("o", MaxFieldLen+1) },
+			wantErr: true,
+		},
+		{
+			name:    "255-rune multibyte assignee passes (rune-count, not byte-count)",
+			mutate:  func(i *Issue) { i.Assignee = strings.Repeat(multibyte, MaxFieldLen) },
+			wantErr: false,
+		},
+		{
+			name:    "256-rune multibyte assignee fails",
+			mutate:  func(i *Issue) { i.Assignee = strings.Repeat(multibyte, MaxFieldLen+1) },
+			wantErr: true,
+		},
+		{
+			name:    "255-rune multibyte owner passes (rune-count, not byte-count)",
+			mutate:  func(i *Issue) { i.Owner = strings.Repeat(multibyte, MaxFieldLen) },
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			issue := validIssue()
+			tt.mutate(&issue)
+			err := issue.ValidateWithCustom(nil, nil)
+			if tt.wantErr {
+				if !errors.Is(err, ErrFieldTooLong) {
+					t.Errorf("ValidateWithCustom() error = %v, want errors.Is(ErrFieldTooLong)", err)
+				}
+			} else if err != nil {
+				t.Errorf("ValidateWithCustom() error = %v, want nil", err)
+			}
+		})
+	}
+}
+
+// TestValidateForImportFieldLength proves the import path bounds assignee and
+// owner too, so a federated import can't smuggle in an over-length value that
+// the backend would otherwise reject with a raw "data too long" error.
+func TestValidateForImportFieldLength(t *testing.T) {
+	t.Run("256-rune assignee fails", func(t *testing.T) {
+		issue := validIssue()
+		issue.Assignee = strings.Repeat("a", MaxFieldLen+1)
+		if err := issue.ValidateForImport(nil); !errors.Is(err, ErrFieldTooLong) {
+			t.Errorf("ValidateForImport() error = %v, want errors.Is(ErrFieldTooLong)", err)
+		}
+	})
+	t.Run("256-rune owner fails", func(t *testing.T) {
+		issue := validIssue()
+		issue.Owner = strings.Repeat("o", MaxFieldLen+1)
+		if err := issue.ValidateForImport(nil); !errors.Is(err, ErrFieldTooLong) {
+			t.Errorf("ValidateForImport() error = %v, want errors.Is(ErrFieldTooLong)", err)
+		}
+	})
+	t.Run("255-rune multibyte assignee passes", func(t *testing.T) {
+		issue := validIssue()
+		issue.Assignee = strings.Repeat("é", MaxFieldLen)
+		if err := issue.ValidateForImport(nil); err != nil {
+			t.Errorf("ValidateForImport() error = %v, want nil", err)
+		}
+	})
+}
+
+// TestCheckFieldLen unit-tests the helper directly, including the rune vs byte
+// boundary and the wrapped, typed error it returns.
+func TestCheckFieldLen(t *testing.T) {
+	if err := CheckFieldLen("assignee", strings.Repeat("a", MaxFieldLen)); err != nil {
+		t.Errorf("CheckFieldLen(255 runes) = %v, want nil", err)
+	}
+	if err := CheckFieldLen("assignee", strings.Repeat("é", MaxFieldLen)); err != nil {
+		t.Errorf("CheckFieldLen(255 multibyte runes / %d bytes) = %v, want nil",
+			len(strings.Repeat("é", MaxFieldLen)), err)
+	}
+	err := CheckFieldLen("assignee", strings.Repeat("é", MaxFieldLen+1))
+	if !errors.Is(err, ErrFieldTooLong) {
+		t.Errorf("CheckFieldLen(256 runes) = %v, want errors.Is(ErrFieldTooLong)", err)
 	}
 }


### PR DESCRIPTION
> Stacked on #4893 (S2) → #4892 (S1). Base is `feat/guarded-ops-s2-checked-close`; retarget down the stack as each lands. The diff below is S3 only.

## What

Adds typed length validation for the `assignee`, `owner`, and `label` fields (all `VARCHAR(255)` columns). Over-length values now return a typed `beads.ErrFieldTooLong` (`errors.Is`-able) instead of a raw backend "data too long" error (assignee/owner) or a silent `INSERT IGNORE` truncation (labels). Length is counted in **runes** to match the column's character semantics.

## Why

`bd create -a <long>`, `bd assign`, `bd label add <long>`, and imports could feed the engine an over-255 field. Today `bd` surfaces either a raw SQL error the CLI can't classify, or — for labels — silently stores a truncated value the user never typed (a full-array label PATCH then never converges). Validating up front with a typed error lets `bd` (and the library's own call sites) reject cleanly and consistently. Part of making the library the single enforcement layer with the CLI as a thin adapter.

A pre-merge review caught that the engine has **two** write stacks — the embedded `issueops`/`DoltStore` path and the proxied-server `domain/db` (uow) path — and a first pass only guarded the first, so the silent-truncation bug persisted in proxied-server mode. All raw assignee/owner/label write sites on **both** stacks (create, update, label insert, and the claim CAS that writes `assignee = actor`) are now guarded through the shared `types.CheckFieldLen`.

Scope is one concern (field bounds). The closed-boundary-as-category status guard is split into a follow-up.

## Verification

- `types.CheckFieldLen` uses `utf8.RuneCountInString` vs `MaxFieldLen = 255`; a 255-rune multibyte value (`é`×255, ~510 bytes) round-trips **unchanged** through the real store, a 256-rune one is rejected — proving rune-count, not byte-count, end to end.
- Guarded on both stacks; tests reject over-length create/update/label/claim with `ErrFieldTooLong` and assert **nothing is persisted** (single and bulk create), on the `dolt` and the `domain/db` (proxied) harnesses.
- `gofmt`/`go vet` clean; `go build ./...` under cgo and `CGO_ENABLED=0`; `golangci-lint` (pre-commit) 0 issues.

```bash
go test ./internal/storage/dolt/ -run TestFieldLengthValidation -v
go test ./internal/storage/domain/db/ -run TestDomainDB/TestFieldLengthGuards -v
go test ./internal/types/ . -count=1
```
