### PR TITLE
feat(metadata): MergeMetadata — atomic single-key metadata merge

### DIFF
--- a/internal/jira/tracker_test.go
+++ b/internal/jira/tracker_test.go
@@ -735,6 +735,9 @@ func (s *configStore) MergeSlotAcquire(_ context.Context, _, _ string, _ bool) (
 }
 func (s *configStore) MergeSlotRelease(_ context.Context, _, _ string) error { return nil }
 func (s *configStore) SlotSet(_ context.Context, _, _, _, _ string) error    { return nil }
+func (s *configStore) MergeMetadata(_ context.Context, _, _ string, _ json.RawMessage, _ string) error {
+	return nil
+}
 func (s *configStore) SlotGet(_ context.Context, _, _ string) (string, error) {
 	return "", nil
 }

--- a/internal/storage/conformance/portable.go
+++ b/internal/storage/conformance/portable.go
@@ -1,6 +1,7 @@
 package conformance
 
 import (
+	"encoding/json"
 	"errors"
 	"slices"
 	"sort"
@@ -705,6 +706,80 @@ func testSlots(t *testing.T, f Factory) {
 	if err := s.SlotSet(c, "test-missing", "k", "v", "a"); err == nil {
 		t.Error("SlotSet on a missing issue: want error, got nil")
 	}
+
+	// MergeMetadata stores a raw JSON value, so nested objects/arrays are
+	// preserved rather than stringified, and independent keys coexist. (At this
+	// point "test-sl" metadata is {"k2":"other"}.) Backends canonicalize JSON
+	// whitespace differently (compact vs. spaced), so assert values semantically.
+	must(t, s.MergeMetadata(c, "test-sl", "nested", json.RawMessage(`{"pr":7}`), "a"))
+	must(t, s.MergeMetadata(c, "test-sl", "flag", json.RawMessage(`true`), "a"))
+	meta := readMetadata(t, s, "test-sl")
+	if pr := nestedField(t, meta, "nested"); pr != 7 {
+		t.Errorf("MergeMetadata nested value pr = %v, want 7 (nested object round-trip)", pr)
+	}
+	if string(meta["flag"]) != `true` {
+		t.Errorf("MergeMetadata flag value = %s, want true", meta["flag"])
+	}
+	if v := jsonString(t, meta["k2"]); v != "other" {
+		t.Errorf("pre-existing k2 clobbered by MergeMetadata: %q", v)
+	}
+
+	// SlotClear removes only its key; the other merged key survives (the atomic
+	// single-key delete every backend must honor).
+	must(t, s.SlotClear(c, "test-sl", "nested", "a"))
+	meta = readMetadata(t, s, "test-sl")
+	if _, ok := meta["nested"]; ok {
+		t.Error("nested key still present after SlotClear")
+	}
+	if string(meta["flag"]) != `true` {
+		t.Errorf("flag wrongly affected by clearing nested: %s", meta["flag"])
+	}
+
+	// MergeMetadata on a non-existent issue is an error.
+	if err := s.MergeMetadata(c, "test-missing", "k", json.RawMessage(`"v"`), "a"); err == nil {
+		t.Error("MergeMetadata on a missing issue: want error, got nil")
+	}
+}
+
+// readMetadata reads an issue's metadata JSON back as a raw-value map for slot
+// assertions.
+func readMetadata(t *testing.T, s storage.DoltStorage, id string) map[string]json.RawMessage {
+	t.Helper()
+	iss, err := s.GetIssue(ctx(), id)
+	if err != nil {
+		t.Fatalf("GetIssue(%s): %v", id, err)
+	}
+	m := make(map[string]json.RawMessage)
+	if len(iss.Metadata) > 0 {
+		if err := json.Unmarshal(iss.Metadata, &m); err != nil {
+			t.Fatalf("unmarshal metadata for %s (%s): %v", id, iss.Metadata, err)
+		}
+	}
+	return m
+}
+
+// nestedField parses meta[key] as a JSON object and returns its "pr" field,
+// proving the value round-tripped as a nested object (not a stringified blob)
+// regardless of a backend's JSON whitespace canonicalization.
+func nestedField(t *testing.T, meta map[string]json.RawMessage, key string) float64 {
+	t.Helper()
+	var obj struct {
+		PR float64 `json:"pr"`
+	}
+	if err := json.Unmarshal(meta[key], &obj); err != nil {
+		t.Fatalf("metadata[%q]=%s did not round-trip as an object: %v", key, meta[key], err)
+	}
+	return obj.PR
+}
+
+// jsonString parses a raw JSON string value.
+func jsonString(t *testing.T, raw json.RawMessage) string {
+	t.Helper()
+	var s string
+	if err := json.Unmarshal(raw, &s); err != nil {
+		t.Fatalf("value %s is not a JSON string: %v", raw, err)
+	}
+	return s
 }
 
 func commentTexts(cs []*types.Comment) []string {

--- a/internal/storage/dolt/metadata_merge_test.go
+++ b/internal/storage/dolt/metadata_merge_test.go
@@ -1,0 +1,416 @@
+package dolt
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"slices"
+	"sync"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/storage"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// getMetadataMap reads an issue's metadata JSON back as a raw-value map.
+func getMetadataMap(t *testing.T, ctx context.Context, store *DoltStore, id string) map[string]json.RawMessage {
+	t.Helper()
+	issue, err := store.GetIssue(ctx, id)
+	if err != nil {
+		t.Fatalf("GetIssue(%s): %v", id, err)
+	}
+	m := make(map[string]json.RawMessage)
+	if len(issue.Metadata) > 0 {
+		if err := json.Unmarshal(issue.Metadata, &m); err != nil {
+			t.Fatalf("unmarshal metadata for %s (%s): %v", id, issue.Metadata, err)
+		}
+	}
+	return m
+}
+
+// updatedEventActors returns the actors of every EventUpdated recorded for id.
+func updatedEventActors(t *testing.T, ctx context.Context, store *DoltStore, id string) []string {
+	t.Helper()
+	events, err := store.GetEvents(ctx, id, 0)
+	if err != nil {
+		t.Fatalf("GetEvents(%s): %v", id, err)
+	}
+	var actors []string
+	for _, e := range events {
+		if e.EventType == types.EventUpdated {
+			actors = append(actors, e.Actor)
+		}
+	}
+	return actors
+}
+
+// TestMergeMetadataConcurrentNoClobber is the money test for B1: many goroutines
+// merge DISTINCT keys into the SAME issue at once. The old cross-transaction
+// SlotSet (GetIssue in tx1, UpdateIssue in tx2) let each writer clobber the
+// others because every writer wrote back a whole-metadata blob computed from a
+// stale read. MergeMetadata does the read-modify-write inside one withRetryTx,
+// so Dolt's optimistic-commit conflict on the shared metadata cell forces the
+// loser to retry and re-read the now-committed metadata — every key must survive.
+func TestMergeMetadataConcurrentNoClobber(t *testing.T) {
+	store, cleanup := setupConcurrentTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := concurrentTestContext(t)
+	defer cancel()
+
+	const id = "mm-concurrent"
+	createPerm(t, ctx, store, id)
+
+	// A pre-existing key must survive the concurrent merges untouched.
+	if err := store.MergeMetadata(ctx, id, "seed", json.RawMessage(`"original"`), "tester"); err != nil {
+		t.Fatalf("seed MergeMetadata: %v", err)
+	}
+
+	const numGoroutines = 8
+	var wg sync.WaitGroup
+	errs := make(chan error, numGoroutines)
+
+	for n := range numGoroutines {
+		wg.Go(func() {
+			key := fmt.Sprintf("key-%d", n)
+			val := json.RawMessage(fmt.Sprintf(`%d`, n))
+			if err := store.MergeMetadata(ctx, id, key, val, fmt.Sprintf("worker-%d", n)); err != nil {
+				errs <- fmt.Errorf("goroutine %d MergeMetadata(%q): %w", n, key, err)
+			}
+		})
+	}
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		t.Errorf("merge error: %v", err)
+	}
+	if t.Failed() {
+		t.Fatal("concurrent MergeMetadata failed — withRetryTx should have retried serialization conflicts")
+	}
+
+	m := getMetadataMap(t, ctx, store, id)
+	if got := string(m["seed"]); got != `"original"` {
+		t.Errorf("pre-existing key clobbered: metadata[seed] = %s, want \"original\"", got)
+	}
+	for n := range numGoroutines {
+		key := fmt.Sprintf("key-%d", n)
+		want := fmt.Sprintf("%d", n)
+		if got, ok := m[key]; !ok {
+			t.Errorf("key %q missing after concurrent merge — CLOBBERED (B1 regression)", key)
+		} else if string(got) != want {
+			t.Errorf("metadata[%q] = %s, want %s", key, got, want)
+		}
+	}
+}
+
+// TestMergeMetadataSequential covers the simple ordering: merge A, then B, and a
+// pre-existing unrelated key is preserved across both.
+func TestMergeMetadataSequential(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	const id = "mm-seq"
+	createPerm(t, ctx, store, id)
+
+	if err := store.MergeMetadata(ctx, id, "pre", json.RawMessage(`"kept"`), "tester"); err != nil {
+		t.Fatalf("merge pre: %v", err)
+	}
+	if err := store.MergeMetadata(ctx, id, "a", json.RawMessage(`"A"`), "tester"); err != nil {
+		t.Fatalf("merge a: %v", err)
+	}
+	if err := store.MergeMetadata(ctx, id, "b", json.RawMessage(`"B"`), "tester"); err != nil {
+		t.Fatalf("merge b: %v", err)
+	}
+
+	m := getMetadataMap(t, ctx, store, id)
+	for key, want := range map[string]string{"pre": `"kept"`, "a": `"A"`, "b": `"B"`} {
+		if got := string(m[key]); got != want {
+			t.Errorf("metadata[%q] = %s, want %s", key, got, want)
+		}
+	}
+}
+
+// TestMergeMetadataNestedJSON proves a nested object value round-trips as a
+// nested object, not a stringified blob — the reason MergeMetadata takes a
+// json.RawMessage instead of a string.
+func TestMergeMetadataNestedJSON(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	const id = "mm-nested"
+	createPerm(t, ctx, store, id)
+
+	nested := json.RawMessage(`{"commit":"abc","pr":7}`)
+	if err := store.MergeMetadata(ctx, id, "merge", nested, "tester"); err != nil {
+		t.Fatalf("MergeMetadata nested: %v", err)
+	}
+
+	m := getMetadataMap(t, ctx, store, id)
+	var got struct {
+		Commit string `json:"commit"`
+		PR     int    `json:"pr"`
+	}
+	if err := json.Unmarshal(m["merge"], &got); err != nil {
+		t.Fatalf("nested value did not round-trip as an object: %s (%v)", m["merge"], err)
+	}
+	if got.Commit != "abc" || got.PR != 7 {
+		t.Errorf("nested round-trip = %+v, want {commit:abc pr:7}", got)
+	}
+}
+
+// TestMergeMetadataWisp merges a metadata key on a wisp (ephemeral) id, exercising
+// the dolt_ignored wisp path (no DOLT_COMMIT).
+func TestMergeMetadataWisp(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	const id = "mm-wisp"
+	createWisp(t, ctx, store, id)
+
+	if err := store.MergeMetadata(ctx, id, "phase", json.RawMessage(`"done"`), "tester"); err != nil {
+		t.Fatalf("MergeMetadata on wisp: %v", err)
+	}
+	m := getMetadataMap(t, ctx, store, id)
+	if got := string(m["phase"]); got != `"done"` {
+		t.Errorf("wisp metadata[phase] = %s, want \"done\"", got)
+	}
+}
+
+// TestMergeMetadataNotFound returns storage.ErrNotFound for a missing id.
+func TestMergeMetadataNotFound(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	err := store.MergeMetadata(ctx, "mm-missing", "k", json.RawMessage(`"v"`), "tester")
+	if !errors.Is(err, storage.ErrNotFound) {
+		t.Fatalf("err = %v, want errors.Is(_, storage.ErrNotFound)", err)
+	}
+}
+
+// TestMergeMetadataInvalidJSON rejects a value that is not valid JSON up front.
+func TestMergeMetadataInvalidJSON(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	const id = "mm-badjson"
+	createPerm(t, ctx, store, id)
+
+	if err := store.MergeMetadata(ctx, id, "k", json.RawMessage(`{not json`), "tester"); err == nil {
+		t.Fatal("MergeMetadata with invalid JSON value: want error, got nil")
+	}
+}
+
+// TestSlotSetByteCompat locks in that the MergeMetadata-backed SlotSet stores the
+// exact same metadata JSON as the historical whole-metadata rewrite: a string
+// value is stored as a JSON string, so a single SlotSet yields {"key":"value"}.
+func TestSlotSetByteCompat(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	const id = "mm-slotcompat"
+	createPerm(t, ctx, store, id)
+
+	if err := store.SlotSet(ctx, id, "key", "value", "tester"); err != nil {
+		t.Fatalf("SlotSet: %v", err)
+	}
+
+	issue, err := store.GetIssue(ctx, id)
+	if err != nil {
+		t.Fatalf("GetIssue: %v", err)
+	}
+	if got := string(issue.Metadata); got != `{"key":"value"}` {
+		t.Errorf("SlotSet metadata = %s, want {\"key\":\"value\"} (byte-compat with old SlotSet)", got)
+	}
+
+	// SlotGet still reads the string back verbatim.
+	if v, err := store.SlotGet(ctx, id, "key"); err != nil || v != "value" {
+		t.Errorf("SlotGet after SlotSet = (%q, %v), want (value, nil)", v, err)
+	}
+}
+
+// TestMergeMetadataRecordsEvent proves the audit trail is not dropped: routing
+// through UpdateIssueInTx means MergeMetadata (and SlotSet built on it) each
+// record an EventUpdated attributed to the caller's actor, exactly as the old
+// SlotSet did via UpdateIssue.
+func TestMergeMetadataRecordsEvent(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	const id = "mm-event"
+	createPerm(t, ctx, store, id)
+
+	if err := store.MergeMetadata(ctx, id, "k", json.RawMessage(`"v"`), "merger"); err != nil {
+		t.Fatalf("MergeMetadata: %v", err)
+	}
+	if err := store.SlotSet(ctx, id, "k2", "v2", "setter"); err != nil {
+		t.Fatalf("SlotSet: %v", err)
+	}
+
+	actors := updatedEventActors(t, ctx, store, id)
+	if !slices.Contains(actors, "merger") {
+		t.Errorf("no EventUpdated attributed to \"merger\"; updated-event actors = %v", actors)
+	}
+	if !slices.Contains(actors, "setter") {
+		t.Errorf("no EventUpdated attributed to \"setter\"; updated-event actors = %v", actors)
+	}
+}
+
+// TestMergeMetadataOverwrite: merging the same key twice takes the last value and
+// leaves other keys intact.
+func TestMergeMetadataOverwrite(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	const id = "mm-overwrite"
+	createPerm(t, ctx, store, id)
+
+	if err := store.MergeMetadata(ctx, id, "other", json.RawMessage(`"keep"`), "tester"); err != nil {
+		t.Fatalf("merge other: %v", err)
+	}
+	if err := store.MergeMetadata(ctx, id, "a", json.RawMessage(`1`), "tester"); err != nil {
+		t.Fatalf("merge a=1: %v", err)
+	}
+	if err := store.MergeMetadata(ctx, id, "a", json.RawMessage(`2`), "tester"); err != nil {
+		t.Fatalf("merge a=2: %v", err)
+	}
+
+	m := getMetadataMap(t, ctx, store, id)
+	if got := string(m["a"]); got != "2" {
+		t.Errorf("metadata[a] = %s, want 2 (overwrite)", got)
+	}
+	if got := string(m["other"]); got != `"keep"` {
+		t.Errorf("metadata[other] = %s, want \"keep\" (untouched)", got)
+	}
+}
+
+// TestMergeMetadataSlotGetInterop: a value merged via MergeMetadata is readable
+// through SlotGet.
+func TestMergeMetadataSlotGetInterop(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	const id = "mm-interop"
+	createPerm(t, ctx, store, id)
+
+	if err := store.MergeMetadata(ctx, id, "s", json.RawMessage(`"hello"`), "tester"); err != nil {
+		t.Fatalf("MergeMetadata: %v", err)
+	}
+	if v, err := store.SlotGet(ctx, id, "s"); err != nil || v != "hello" {
+		t.Errorf("SlotGet after MergeMetadata = (%q, %v), want (hello, nil)", v, err)
+	}
+}
+
+// TestSlotClearRemovesKeyPreservesOthers: clearing one key leaves the rest, and
+// clearing an absent key is a silent no-op (behavior parity with the old
+// cross-tx SlotClear, now atomic).
+func TestSlotClearRemovesKeyPreservesOthers(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	const id = "sc-basic"
+	createPerm(t, ctx, store, id)
+
+	if err := store.SlotSet(ctx, id, "a", "1", "tester"); err != nil {
+		t.Fatalf("SlotSet a: %v", err)
+	}
+	if err := store.SlotSet(ctx, id, "b", "2", "tester"); err != nil {
+		t.Fatalf("SlotSet b: %v", err)
+	}
+	if err := store.SlotClear(ctx, id, "a", "tester"); err != nil {
+		t.Fatalf("SlotClear a: %v", err)
+	}
+
+	m := getMetadataMap(t, ctx, store, id)
+	if _, ok := m["a"]; ok {
+		t.Errorf("key a still present after SlotClear")
+	}
+	if got := string(m["b"]); got != `"2"` {
+		t.Errorf("metadata[b] = %s, want \"2\" (untouched by clearing a)", got)
+	}
+	if err := store.SlotClear(ctx, id, "nonexistent", "tester"); err != nil {
+		t.Errorf("SlotClear absent key: want nil, got %v", err)
+	}
+}
+
+// TestSlotClearConcurrentNoClobber is the money test for the clear path: pre-set
+// keys are cleared concurrently while distinct new keys are set. The old cross-tx
+// SlotClear read a stale whole-metadata blob and wrote it back, so a concurrent
+// SlotSet's key vanished. With DeleteMetadataInTx sharing one transaction, every
+// set key that was never cleared must survive, and every cleared key is gone.
+func TestSlotClearConcurrentNoClobber(t *testing.T) {
+	store, cleanup := setupConcurrentTestStore(t)
+	defer cleanup()
+	ctx, cancel := concurrentTestContext(t)
+	defer cancel()
+
+	const id = "sc-concurrent"
+	createPerm(t, ctx, store, id)
+
+	const n = 6
+	for i := range n {
+		if err := store.SlotSet(ctx, id, fmt.Sprintf("clear-%d", i), "x", "seed"); err != nil {
+			t.Fatalf("seed clear-%d: %v", i, err)
+		}
+	}
+
+	var wg sync.WaitGroup
+	errs := make(chan error, 2*n)
+	for i := range n {
+		wg.Go(func() {
+			if err := store.SlotSet(ctx, id, fmt.Sprintf("set-%d", i), fmt.Sprintf("v%d", i), "setter"); err != nil {
+				errs <- fmt.Errorf("SlotSet set-%d: %w", i, err)
+			}
+		})
+		wg.Go(func() {
+			if err := store.SlotClear(ctx, id, fmt.Sprintf("clear-%d", i), "clearer"); err != nil {
+				errs <- fmt.Errorf("SlotClear clear-%d: %w", i, err)
+			}
+		})
+	}
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		t.Errorf("%v", err)
+	}
+	if t.Failed() {
+		t.Fatal("concurrent SlotSet/SlotClear errored — withRetryTx should have retried conflicts")
+	}
+
+	m := getMetadataMap(t, ctx, store, id)
+	for i := range n {
+		setKey := fmt.Sprintf("set-%d", i)
+		want := fmt.Sprintf("%q", fmt.Sprintf("v%d", i))
+		if got, ok := m[setKey]; !ok {
+			t.Errorf("set key %q missing — a concurrent SlotClear CLOBBERED it (B1 regression)", setKey)
+		} else if string(got) != want {
+			t.Errorf("metadata[%q] = %s, want %s", setKey, got, want)
+		}
+		clearKey := fmt.Sprintf("clear-%d", i)
+		if _, ok := m[clearKey]; ok {
+			t.Errorf("clear key %q still present — concurrent SlotClear did not take effect", clearKey)
+		}
+	}
+}

--- a/internal/storage/dolt/slots.go
+++ b/internal/storage/dolt/slots.go
@@ -2,37 +2,86 @@ package dolt
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"fmt"
+
+	"github.com/steveyegge/beads/internal/storage/issueops"
 )
+
+// MergeMetadata merges a single key into an issue's metadata JSON atomically.
+// value is a raw JSON value, so nested objects/arrays are preserved (not
+// stringified). Unlike the old read-then-write SlotSet, the read and write share
+// ONE transaction: on a Dolt optimistic-commit conflict (MySQL 1213/1205,
+// guaranteed server-side rollback) withRetryTx re-runs the whole body and
+// re-reads the now-committed metadata, so a concurrent merge of a DIFFERENT key
+// is preserved rather than clobbered. Dolt has no real row locking — FOR UPDATE
+// / SKIP LOCKED are parse-only no-ops — so retry is the only safety net. The
+// write routes through UpdateIssueInTx, so the merge records an EventUpdated
+// history event (attributed to actor) and runs the configured metadata-schema
+// validation, exactly as the old SlotSet did — now atomic. SlotSet is built on
+// this. Routes ephemeral IDs to the wisps table (no DOLT_COMMIT); permanent
+// issues get a Dolt commit.
+func (s *DoltStore) MergeMetadata(ctx context.Context, issueID, key string, value json.RawMessage, actor string) error {
+	// Route ephemeral IDs to wisps table (falls through for promoted wisps).
+	// Wisps skip DOLT_COMMIT since they live in dolt_ignored tables.
+	if s.isActiveWisp(ctx, issueID) {
+		return s.mergeMetadataWisp(ctx, issueID, key, value, actor)
+	}
+
+	// withRetryTx owns BeginTx and the final Commit. The read+merge+write inside
+	// the fn is a single transaction; the retry is what fixes the cross-tx
+	// clobber the old SlotSet suffered from.
+	return s.withRetryTx(ctx, func(tx *sql.Tx) error {
+		if err := issueops.MergeMetadataInTx(ctx, tx, issueID, key, value, actor); err != nil {
+			return err
+		}
+
+		// Dolt versioning for permanent issues. The merge routes through
+		// UpdateIssueInTx, which also writes an EventUpdated row into events, so
+		// stage both tables before committing (mirrors CloseIssue).
+		for _, table := range []string{"issues", "events"} {
+			_, _ = tx.ExecContext(ctx, "CALL DOLT_ADD(?)", table)
+		}
+		commitMsg := fmt.Sprintf("bd: merge metadata %s.%s", issueID, key)
+		if _, err := tx.ExecContext(ctx, "CALL DOLT_COMMIT('-m', ?, '--author', ?)",
+			commitMsg, s.commitAuthorString()); err != nil && !isDoltNothingToCommit(err) {
+			return fmt.Errorf("dolt commit: %w", err)
+		}
+		return nil
+	})
+}
+
+// mergeMetadataWisp merges a metadata key on a wisp. Mirrors closeWisp: no Dolt
+// versioning since wisps live in dolt_ignored tables. The read and write still
+// share the one transaction, so the atomic-merge property holds.
+func (s *DoltStore) mergeMetadataWisp(ctx context.Context, issueID, key string, value json.RawMessage, actor string) error {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	if err := issueops.MergeMetadataInTx(ctx, tx, issueID, key, value, actor); err != nil {
+		return err
+	}
+	return wrapTransactionError("commit merge metadata wisp", tx.Commit())
+}
 
 // SlotSet sets a key-value pair in the issue's metadata JSON.
 // If the issue has no metadata, a new JSON object is created.
 // If the key already exists, its value is overwritten.
+//
+// Built on MergeMetadata so the read-modify-write is atomic: two concurrent
+// SlotSet calls on different keys both survive. The string value is stored as a
+// JSON string (json.Marshal(value) yields "value"), keeping the stored metadata
+// byte-compatible with the historical whole-metadata rewrite.
 func (s *DoltStore) SlotSet(ctx context.Context, issueID, key, value, actor string) error {
-	issue, err := s.GetIssue(ctx, issueID)
+	raw, err := json.Marshal(value)
 	if err != nil {
-		return fmt.Errorf("getting issue %s: %w", issueID, err)
+		return fmt.Errorf("marshaling slot value for %s.%s: %w", issueID, key, err)
 	}
-
-	metadata := make(map[string]interface{})
-	if len(issue.Metadata) > 0 {
-		if err := json.Unmarshal(issue.Metadata, &metadata); err != nil {
-			return fmt.Errorf("parsing metadata for %s: %w", issueID, err)
-		}
-	}
-
-	metadata[key] = value
-
-	raw, err := json.Marshal(metadata)
-	if err != nil {
-		return fmt.Errorf("marshaling metadata for %s: %w", issueID, err)
-	}
-
-	updates := map[string]interface{}{
-		"metadata": string(raw),
-	}
-	return s.UpdateIssue(ctx, issueID, updates, actor)
+	return s.MergeMetadata(ctx, issueID, key, raw, actor)
 }
 
 // SlotGet retrieves the value of a metadata key from an issue.
@@ -72,34 +121,49 @@ func (s *DoltStore) SlotGet(ctx context.Context, issueID, key string) (string, e
 
 // SlotClear removes a metadata key from an issue.
 // It is not an error to clear a key that doesn't exist.
+//
+// Built on DeleteMetadataInTx so the read-modify-write is atomic, exactly like
+// MergeMetadata: a concurrent SlotClear (or SlotSet of a different key) can no
+// longer clobber this write between the read and the write. Clearing an absent
+// key is a no-op that writes nothing.
 func (s *DoltStore) SlotClear(ctx context.Context, issueID, key, actor string) error {
-	issue, err := s.GetIssue(ctx, issueID)
+	// Route ephemeral IDs to wisps table (falls through for promoted wisps).
+	// Wisps skip DOLT_COMMIT since they live in dolt_ignored tables.
+	if s.isActiveWisp(ctx, issueID) {
+		return s.clearMetadataWisp(ctx, issueID, key, actor)
+	}
+
+	return s.withRetryTx(ctx, func(tx *sql.Tx) error {
+		if err := issueops.DeleteMetadataInTx(ctx, tx, issueID, key, actor); err != nil {
+			return err
+		}
+
+		// DeleteMetadataInTx routes through UpdateIssueInTx (issues + events),
+		// so stage both before committing. A no-op clear writes nothing, which
+		// DOLT_COMMIT reports as nothing-to-commit (handled below).
+		for _, table := range []string{"issues", "events"} {
+			_, _ = tx.ExecContext(ctx, "CALL DOLT_ADD(?)", table)
+		}
+		commitMsg := fmt.Sprintf("bd: clear metadata %s.%s", issueID, key)
+		if _, err := tx.ExecContext(ctx, "CALL DOLT_COMMIT('-m', ?, '--author', ?)",
+			commitMsg, s.commitAuthorString()); err != nil && !isDoltNothingToCommit(err) {
+			return fmt.Errorf("dolt commit: %w", err)
+		}
+		return nil
+	})
+}
+
+// clearMetadataWisp clears a metadata key on a wisp. Mirrors mergeMetadataWisp /
+// closeWisp: no Dolt versioning since wisps live in dolt_ignored tables.
+func (s *DoltStore) clearMetadataWisp(ctx context.Context, issueID, key, actor string) error {
+	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
-		return fmt.Errorf("getting issue %s: %w", issueID, err)
+		return fmt.Errorf("failed to begin transaction: %w", err)
 	}
+	defer func() { _ = tx.Rollback() }()
 
-	if len(issue.Metadata) == 0 {
-		return nil // No metadata, nothing to clear
+	if err := issueops.DeleteMetadataInTx(ctx, tx, issueID, key, actor); err != nil {
+		return err
 	}
-
-	metadata := make(map[string]interface{})
-	if err := json.Unmarshal(issue.Metadata, &metadata); err != nil {
-		return fmt.Errorf("parsing metadata for %s: %w", issueID, err)
-	}
-
-	if _, ok := metadata[key]; !ok {
-		return nil // Key doesn't exist, nothing to clear
-	}
-
-	delete(metadata, key)
-
-	raw, err := json.Marshal(metadata)
-	if err != nil {
-		return fmt.Errorf("marshaling metadata for %s: %w", issueID, err)
-	}
-
-	updates := map[string]interface{}{
-		"metadata": string(raw),
-	}
-	return s.UpdateIssue(ctx, issueID, updates, actor)
+	return wrapTransactionError("commit clear metadata wisp", tx.Commit())
 }

--- a/internal/storage/embeddeddolt/slots.go
+++ b/internal/storage/embeddeddolt/slots.go
@@ -4,32 +4,39 @@ package embeddeddolt
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"fmt"
+
+	"github.com/steveyegge/beads/internal/storage/issueops"
 )
 
+// MergeMetadata merges a single key into an issue's metadata JSON atomically.
+// value is a raw JSON value, so nested objects/arrays are preserved. The read
+// and write share ONE transaction (withConn commit=true), so a concurrent merge
+// of a DIFFERENT key cannot clobber this one between the read and the write. The
+// write routes through UpdateIssueInTx, so the merge records an EventUpdated
+// history event (attributed to actor) and runs the configured metadata-schema
+// validation, exactly as the old SlotSet did. Routes to the issues or wisps
+// table automatically. SlotSet is built on this.
+func (s *EmbeddedDoltStore) MergeMetadata(ctx context.Context, issueID, key string, value json.RawMessage, actor string) error {
+	return s.withConn(ctx, true, func(tx *sql.Tx) error {
+		return issueops.MergeMetadataInTx(ctx, tx, issueID, key, value, actor)
+	})
+}
+
 // SlotSet sets a key-value pair in the issue's metadata JSON.
+//
+// Built on MergeMetadata so the read-modify-write is atomic: two concurrent
+// SlotSet calls on different keys both survive. The string value is stored as a
+// JSON string (json.Marshal(value) yields "value"), keeping the stored metadata
+// byte-compatible with the historical whole-metadata rewrite.
 func (s *EmbeddedDoltStore) SlotSet(ctx context.Context, issueID, key, value, actor string) error {
-	issue, err := s.GetIssue(ctx, issueID)
+	raw, err := json.Marshal(value)
 	if err != nil {
-		return fmt.Errorf("getting issue %s: %w", issueID, err)
+		return fmt.Errorf("marshaling slot value for %s.%s: %w", issueID, key, err)
 	}
-
-	metadata := make(map[string]interface{})
-	if len(issue.Metadata) > 0 {
-		if err := json.Unmarshal(issue.Metadata, &metadata); err != nil {
-			return fmt.Errorf("parsing metadata for %s: %w", issueID, err)
-		}
-	}
-	metadata[key] = value
-
-	raw, err := json.Marshal(metadata)
-	if err != nil {
-		return fmt.Errorf("marshaling metadata for %s: %w", issueID, err)
-	}
-
-	updates := map[string]interface{}{"metadata": string(raw)}
-	return s.UpdateIssue(ctx, issueID, updates, actor)
+	return s.MergeMetadata(ctx, issueID, key, raw, actor)
 }
 
 // SlotGet retrieves the value of a metadata key from an issue.
@@ -66,31 +73,13 @@ func (s *EmbeddedDoltStore) SlotGet(ctx context.Context, issueID, key string) (s
 }
 
 // SlotClear removes a metadata key from an issue.
+//
+// Built on DeleteMetadataInTx so the read-modify-write is atomic (withConn
+// commit=true), exactly like MergeMetadata: a concurrent SlotClear or SlotSet of
+// a different key can no longer clobber this write. Clearing an absent key is a
+// no-op that writes nothing.
 func (s *EmbeddedDoltStore) SlotClear(ctx context.Context, issueID, key, actor string) error {
-	issue, err := s.GetIssue(ctx, issueID)
-	if err != nil {
-		return fmt.Errorf("getting issue %s: %w", issueID, err)
-	}
-
-	if len(issue.Metadata) == 0 {
-		return nil
-	}
-
-	metadata := make(map[string]interface{})
-	if err := json.Unmarshal(issue.Metadata, &metadata); err != nil {
-		return fmt.Errorf("parsing metadata for %s: %w", issueID, err)
-	}
-
-	if _, ok := metadata[key]; !ok {
-		return nil
-	}
-	delete(metadata, key)
-
-	raw, err := json.Marshal(metadata)
-	if err != nil {
-		return fmt.Errorf("marshaling metadata for %s: %w", issueID, err)
-	}
-
-	updates := map[string]interface{}{"metadata": string(raw)}
-	return s.UpdateIssue(ctx, issueID, updates, actor)
+	return s.withConn(ctx, true, func(tx *sql.Tx) error {
+		return issueops.DeleteMetadataInTx(ctx, tx, issueID, key, actor)
+	})
 }

--- a/internal/storage/issueops/metadata.go
+++ b/internal/storage/issueops/metadata.go
@@ -1,0 +1,104 @@
+package issueops
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+
+	"github.com/steveyegge/beads/internal/storage"
+)
+
+// MergeMetadataInTx merges a single key into an issue's metadata JSON within an
+// existing transaction: it reads the current metadata, sets metadata[key]=value
+// (a raw JSON value, so nested objects/arrays are preserved), and writes the
+// whole object back — all on the SAME tx, so a concurrent writer cannot clobber
+// a different key between the read and the write (the caller's withRetryTx/commit
+// re-runs this on a serialization conflict, re-reading the latest metadata).
+// Routes to the issues or wisps table automatically. value must be valid JSON.
+//
+// The write goes through UpdateIssueInTx, so the merge inherits everything a
+// metadata update does — NormalizeMetadataValue, the configured metadata-schema
+// validation, the EventUpdated history event with actor attribution, and
+// updated_at — behavior-identical to the old cross-tx SlotSet, now atomic.
+func MergeMetadataInTx(ctx context.Context, tx DBTX, issueID, key string, value json.RawMessage, actor string) error {
+	if !json.Valid(value) {
+		return fmt.Errorf("metadata value for key %q on %s is not valid JSON", key, issueID)
+	}
+
+	m, err := readMetadataMapInTx(ctx, tx, issueID)
+	if err != nil {
+		return err
+	}
+	m[key] = value
+	return writeMergedMetadataInTx(ctx, tx, issueID, m, actor)
+}
+
+// DeleteMetadataInTx removes a single key from an issue's metadata JSON within an
+// existing transaction, reading and writing on the SAME tx so a concurrent merge
+// of a different key cannot be clobbered by the delete. Clearing a key that is
+// absent (or an issue with no metadata) is a no-op that writes nothing and
+// records no event, matching the historical SlotClear. Routes to the issues or
+// wisps table automatically. The write goes through UpdateIssueInTx, inheriting
+// the same event/validation/normalization the generic update path applies.
+func DeleteMetadataInTx(ctx context.Context, tx DBTX, issueID, key, actor string) error {
+	m, err := readMetadataMapInTx(ctx, tx, issueID)
+	if err != nil {
+		return err
+	}
+	if _, ok := m[key]; !ok {
+		return nil // key absent (or no metadata) — nothing to clear
+	}
+	delete(m, key)
+	return writeMergedMetadataInTx(ctx, tx, issueID, m, actor)
+}
+
+// readMetadataMapInTx reads an issue's metadata column (routed to issues/wisps)
+// and unmarshals it into a raw-value map. Existing values are kept as raw JSON so
+// they round-trip byte-for-byte. An empty or null metadata column yields a fresh
+// map; a missing issue returns a wrapped storage.ErrNotFound (mirroring
+// CloseIssueInTx).
+//
+//nolint:gosec // G201: table name comes from WispTableRouting (hardcoded constants)
+func readMetadataMapInTx(ctx context.Context, tx DBTX, issueID string) (map[string]json.RawMessage, error) {
+	isWisp := IsActiveWispInTx(ctx, tx, issueID)
+	issueTable, _, _, _ := WispTableRouting(isWisp)
+
+	var raw sql.NullString
+	err := tx.QueryRowContext(ctx,
+		fmt.Sprintf("SELECT metadata FROM %s WHERE id = ?", issueTable), issueID,
+	).Scan(&raw)
+	if err == sql.ErrNoRows {
+		return nil, fmt.Errorf("%w: issue %s", storage.ErrNotFound, issueID)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("read metadata for %s: %w", issueID, err)
+	}
+
+	m := make(map[string]json.RawMessage)
+	if raw.Valid && raw.String != "" && raw.String != "null" {
+		if err := json.Unmarshal([]byte(raw.String), &m); err != nil {
+			return nil, fmt.Errorf("parse metadata for %s: %w", issueID, err)
+		}
+	}
+	return m, nil
+}
+
+// writeMergedMetadataInTx validates the fully-merged metadata blob against the
+// configured schema (preserving the check the generic update path runs in the
+// store wrapper) and then writes it via UpdateIssueInTx, which records the
+// EventUpdated history event, normalizes the value, and bumps updated_at — all
+// on the caller's transaction.
+func writeMergedMetadataInTx(ctx context.Context, tx DBTX, issueID string, m map[string]json.RawMessage, actor string) error {
+	merged, err := json.Marshal(m)
+	if err != nil {
+		return fmt.Errorf("marshal metadata for %s: %w", issueID, err)
+	}
+	if err := ValidateMetadataIfConfigured(json.RawMessage(merged)); err != nil {
+		return err
+	}
+	if _, err := UpdateIssueInTx(ctx, tx, issueID, map[string]interface{}{"metadata": string(merged)}, actor); err != nil {
+		return err
+	}
+	return nil
+}

--- a/internal/storage/issueops/metadata_test.go
+++ b/internal/storage/issueops/metadata_test.go
@@ -1,0 +1,122 @@
+package issueops
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/steveyegge/beads/internal/config"
+	"github.com/steveyegge/beads/internal/storage"
+)
+
+// expectNonWisp makes IsActiveWispInTx report "not a wisp" (empty result set).
+func expectNonWisp(mock sqlmock.Sqlmock, id string) {
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT 1 FROM wisps WHERE id = ? LIMIT 1")).
+		WithArgs(id).WillReturnRows(sqlmock.NewRows([]string{"1"}))
+}
+
+// TestMergeMetadataInTx exercises the cheap, deterministic branches of the merge
+// primitive hermetically via sqlmock: the invalid-JSON guard (no query) and the
+// not-found path (routed SELECT → sql.ErrNoRows → wrapped storage.ErrNotFound).
+// The happy path routes through UpdateIssueInTx (event + validation + full
+// update SQL) and is covered end-to-end against real Dolt in the dolt package.
+func TestMergeMetadataInTx(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("invalid json is rejected before any query", func(t *testing.T) {
+		_, _, tx := beginMockTx(t)
+		if err := MergeMetadataInTx(ctx, tx, "iss-1", "k", json.RawMessage(`{bad`), "actor"); err == nil {
+			t.Fatal("want error for invalid JSON value, got nil")
+		}
+	})
+
+	t.Run("missing issue returns ErrNotFound", func(t *testing.T) {
+		_, mock, tx := beginMockTx(t)
+		expectNonWisp(mock, "iss-missing")
+		mock.ExpectQuery(regexp.QuoteMeta("SELECT metadata FROM issues WHERE id = ?")).
+			WithArgs("iss-missing").WillReturnError(sql.ErrNoRows)
+
+		err := MergeMetadataInTx(ctx, tx, "iss-missing", "k", json.RawMessage(`"v"`), "actor")
+		if !errors.Is(err, storage.ErrNotFound) {
+			t.Fatalf("err = %v, want errors.Is(_, storage.ErrNotFound)", err)
+		}
+		if err := mock.ExpectationsWereMet(); err != nil {
+			t.Fatalf("unmet expectations: %v", err)
+		}
+	})
+}
+
+// TestMergeMetadataInTxSchemaValidation proves the merge routes through the
+// configured metadata-schema validation before it writes — the check the old
+// SlotSet inherited from the generic update path. With error-mode validation and
+// a required field, a merged blob that lacks the required field is rejected and
+// UpdateIssueInTx is never reached (no UPDATE/event is mocked or executed).
+func TestMergeMetadataInTxSchemaValidation(t *testing.T) {
+	// t.Setenv forces non-parallel; ignore the repo's tracked config so only the
+	// schema we inject below is in effect.
+	t.Setenv("BEADS_TEST_IGNORE_REPO_CONFIG", "1")
+	if err := config.Initialize(); err != nil {
+		t.Fatalf("config.Initialize: %v", err)
+	}
+	defer config.ResetForTesting()
+	config.Set("validation.metadata.mode", "error")
+	config.Set("validation.metadata.fields", map[string]interface{}{
+		"required_field": map[string]interface{}{"type": "string", "required": true},
+	})
+
+	_, mock, tx := beginMockTx(t)
+	expectNonWisp(mock, "iss-1")
+	// Existing metadata has no required_field; the merge adds an unrelated key.
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT metadata FROM issues WHERE id = ?")).
+		WithArgs("iss-1").WillReturnRows(sqlmock.NewRows([]string{"metadata"}).AddRow(`{}`))
+
+	err := MergeMetadataInTx(context.Background(), tx, "iss-1", "other", json.RawMessage(`"x"`), "actor")
+	if err == nil || !strings.Contains(err.Error(), "schema violation") {
+		t.Fatalf("err = %v, want a metadata schema violation", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations (validation should have stopped before the update): %v", err)
+	}
+}
+
+// TestDeleteMetadataInTx covers the clear primitive's cheap branches: a missing
+// issue is ErrNotFound, and clearing a key that is absent is a no-op that issues
+// no write (and therefore records no event), matching the historical SlotClear.
+func TestDeleteMetadataInTx(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("missing issue returns ErrNotFound", func(t *testing.T) {
+		_, mock, tx := beginMockTx(t)
+		expectNonWisp(mock, "iss-missing")
+		mock.ExpectQuery(regexp.QuoteMeta("SELECT metadata FROM issues WHERE id = ?")).
+			WithArgs("iss-missing").WillReturnError(sql.ErrNoRows)
+
+		err := DeleteMetadataInTx(ctx, tx, "iss-missing", "k", "actor")
+		if !errors.Is(err, storage.ErrNotFound) {
+			t.Fatalf("err = %v, want errors.Is(_, storage.ErrNotFound)", err)
+		}
+		if err := mock.ExpectationsWereMet(); err != nil {
+			t.Fatalf("unmet expectations: %v", err)
+		}
+	})
+
+	t.Run("clearing an absent key is a no-op with no write", func(t *testing.T) {
+		_, mock, tx := beginMockTx(t)
+		expectNonWisp(mock, "iss-1")
+		mock.ExpectQuery(regexp.QuoteMeta("SELECT metadata FROM issues WHERE id = ?")).
+			WithArgs("iss-1").WillReturnRows(sqlmock.NewRows([]string{"metadata"}).AddRow(`{"other":"y"}`))
+		// No ExpectExec: the absent-key clear must not issue an UPDATE.
+
+		if err := DeleteMetadataInTx(ctx, tx, "iss-1", "gone", "actor"); err != nil {
+			t.Fatalf("DeleteMetadataInTx (absent key): %v", err)
+		}
+		if err := mock.ExpectationsWereMet(); err != nil {
+			t.Fatalf("unmet expectations: %v", err)
+		}
+	})
+}

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -8,6 +8,7 @@ package storage
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"time"
 
@@ -196,6 +197,12 @@ type Storage interface {
 	SlotSet(ctx context.Context, issueID, key, value, actor string) error
 	SlotGet(ctx context.Context, issueID, key string) (string, error)
 	SlotClear(ctx context.Context, issueID, key, actor string) error
+
+	// MergeMetadata merges a single key into an issue's metadata JSON as a raw
+	// JSON value (nested objects/arrays are preserved). The read-modify-write
+	// runs in a single transaction, so two concurrent merges of DIFFERENT keys
+	// both survive rather than clobbering each other. SlotSet is built on it.
+	MergeMetadata(ctx context.Context, issueID, key string, value json.RawMessage, actor string) error
 
 	// Lifecycle
 	Close() error

--- a/internal/telemetry/storage.go
+++ b/internal/telemetry/storage.go
@@ -2,6 +2,7 @@ package telemetry
 
 import (
 	"context"
+	"encoding/json"
 	"time"
 
 	"go.opentelemetry.io/otel/attribute"
@@ -693,6 +694,13 @@ func (s *InstrumentedStorage) SlotGet(ctx context.Context, issueID, key string) 
 func (s *InstrumentedStorage) SlotClear(ctx context.Context, issueID, key, actor string) error {
 	ctx, span, t := s.op(ctx, "SlotClear", attribute.String("slot.key", key))
 	err := s.inner.SlotClear(ctx, issueID, key, actor)
+	s.done(ctx, span, t, err)
+	return err
+}
+
+func (s *InstrumentedStorage) MergeMetadata(ctx context.Context, issueID, key string, value json.RawMessage, actor string) error {
+	ctx, span, t := s.op(ctx, "MergeMetadata", attribute.String("slot.key", key))
+	err := s.inner.MergeMetadata(ctx, issueID, key, value, actor)
 	s.done(ctx, span, t, err)
 	return err
 }


### PR DESCRIPTION
> Stacked on #4894 (S3) → #4893 (S2) → #4892 (S1). Base is `feat/guarded-ops-s3-field-validation`; retarget down the stack as each lands. The diff below is S4 only.

## What

Adds `MergeMetadata` — an **atomic** single-key merge into an issue's metadata JSON — and reimplements `SlotSet`/`SlotClear` on top of it. The value is stored as raw JSON, so nested objects/arrays are preserved (not stringified).

## Why

`SlotSet` (and `SlotClear`) did a read-modify-write across **two** transactions: `GetIssue`, then `UpdateIssue`. Two concurrent calls — even on **different** keys — each read the same base metadata and wrote back the whole blob, so the second silently clobbered the first's key. Doing the read and the write in **one** transaction closes that window: on a Dolt optimistic-commit conflict the write is retried and re-reads the latest metadata, so a concurrent merge of a different key survives. This is the engine primitive the `bd` CLI (and the library's own metadata call sites) should use instead of hand-rolling a fragile read-then-write.

A pre-merge review caught that reimplementing `SlotSet` on a **bare** metadata `UPDATE` would silently drop what the old `UpdateIssue` path did — the `EventUpdated` history event (with actor attribution) and the configured metadata-schema validation — and would leave `SlotClear` on the old clobber. The fix routes the merge/delete **through `UpdateIssueInTx`** in the one transaction, so every side effect is preserved (behavior-identical to the old `SlotSet`, now clobber-free), and `SlotClear` is rebuilt on the same atomic path.

## Verification

- **B1 no-clobber**: an 8-goroutine test merges distinct keys concurrently on one issue and asserts every key (plus a pre-seeded one) survives — the property the old cross-tx `SlotSet` violated; a matching test interleaves concurrent `SlotSet`/`SlotClear`.
- **Behavior preserved**: tests assert the `EventUpdated` history event (actor-attributed) is recorded and the metadata-schema validation still rejects a violating value; `SlotSet` stays byte-compatible; nested JSON round-trips as an object.
- Cross-backend **conformance** covers `MergeMetadata` + atomic `SlotClear` on both server and embedded Dolt.
- `gofmt`/`go vet` clean; `go build ./...` under cgo and `CGO_ENABLED=0`; `golangci-lint` (pre-commit) 0 issues.

```bash
go test ./internal/storage/dolt/ -run 'TestMergeMetadata|TestSlotSet|TestSlotClear' -v
go test ./internal/storage/conformance/ -run 'TestConformance/.*/Slots' -v
```
