### PR TITLE
feat(concurrency): expose a per-row version on Issue reads (RowVersion)

### DIFF
--- a/internal/storage/dolt/row_version_test.go
+++ b/internal/storage/dolt/row_version_test.go
@@ -1,0 +1,135 @@
+package dolt
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/steveyegge/beads/internal/storage"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// TestRowVersion exercises the read-only RowVersion token — the issues/wisps
+// row_lock cell surfaced on types.Issue. RowVersion is stable across reads with
+// no intervening write, changes on every status/ownership-mutating write, is
+// hydrated by the list path as well as the point read, and — the reason the
+// token exists — distinguishes two writes that land in the same wall-clock
+// second, where updated_at (DATETIME, second granularity) is identical.
+func TestRowVersion(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	get := func(t *testing.T, id string) *types.Issue {
+		t.Helper()
+		iss, err := store.GetIssue(ctx, id)
+		if err != nil {
+			t.Fatalf("GetIssue(%s): %v", id, err)
+		}
+		if iss == nil {
+			t.Fatalf("GetIssue(%s) returned nil", id)
+		}
+		return iss
+	}
+
+	t.Run("create stamps a nonzero version and reads are stable", func(t *testing.T) {
+		createPerm(t, ctx, store, "rv-stable")
+		first := get(t, "rv-stable")
+		// The issueops create path writes freshRowLock(), so a freshly created
+		// issue already carries a nonzero version.
+		if first.RowVersion == 0 {
+			t.Fatalf("RowVersion after create = 0, want nonzero (create stamps row_lock)")
+		}
+		// Two reads with no write between must return the identical version.
+		second := get(t, "rv-stable")
+		if second.RowVersion != first.RowVersion {
+			t.Fatalf("RowVersion changed across reads with no write: %d -> %d", first.RowVersion, second.RowVersion)
+		}
+	})
+
+	t.Run("mutating write changes the version", func(t *testing.T) {
+		createPerm(t, ctx, store, "rv-mutate")
+		before := get(t, "rv-mutate").RowVersion
+		if _, err := store.CloseIssueChecked(ctx, "rv-mutate", "tester",
+			storage.CloseIssueOptions{Reason: "done"}); err != nil {
+			t.Fatalf("CloseIssueChecked: %v", err)
+		}
+		after := get(t, "rv-mutate").RowVersion
+		if after == before {
+			t.Fatalf("RowVersion unchanged after a mutating write: still %d", before)
+		}
+	})
+
+	t.Run("SearchIssues hydrates the version", func(t *testing.T) {
+		createPerm(t, ctx, store, "rv-search")
+		want := get(t, "rv-search").RowVersion
+
+		results, err := store.SearchIssues(ctx, "", types.IssueFilter{})
+		if err != nil {
+			t.Fatalf("SearchIssues: %v", err)
+		}
+		var got int64
+		found := false
+		for _, iss := range results {
+			if iss.ID == "rv-search" {
+				got = iss.RowVersion
+				found = true
+			}
+		}
+		if !found {
+			t.Fatalf("SearchIssues did not return rv-search")
+		}
+		if got == 0 {
+			t.Fatalf("SearchIssues hydrated RowVersion = 0; the list path did not scan row_lock")
+		}
+		if got != want {
+			t.Fatalf("SearchIssues RowVersion = %d, GetIssue RowVersion = %d; list and point reads disagree", got, want)
+		}
+	})
+
+	// The B4 property: two mutating writes in the same wall-clock second yield
+	// identical updated_at (DATETIME truncates to the second) but DIFFERENT
+	// RowVersions. A caller holding only updated_at could not tell the two writes
+	// apart; RowVersion can. This is the whole reason for the slice.
+	t.Run("same-second writes get distinct versions", func(t *testing.T) {
+		createPerm(t, ctx, store, "rv-b4")
+
+		mutate := func(rev int) *types.Issue {
+			t.Helper()
+			updates := map[string]interface{}{"title": fmt.Sprintf("rv-b4 rev %d", rev)}
+			if err := store.UpdateIssue(ctx, "rv-b4", updates, "tester"); err != nil {
+				t.Fatalf("UpdateIssue rev %d: %v", rev, err)
+			}
+			return get(t, "rv-b4")
+		}
+
+		// Two back-to-back writes almost always land in one second; retry only to
+		// absorb the rare wall-clock second boundary between the pair.
+		const attempts = 8
+		sameSecondSeen := false
+		for i := 0; i < attempts && !sameSecondSeen; i++ {
+			a := mutate(2 * i)
+			b := mutate(2*i + 1)
+
+			// RowVersion must always distinguish two distinct writes.
+			if a.RowVersion == b.RowVersion {
+				t.Fatalf("two mutating writes shared RowVersion %d", a.RowVersion)
+			}
+
+			if a.UpdatedAt.Unix() == b.UpdatedAt.Unix() {
+				// updated_at is byte-identical at second granularity here, yet the
+				// versions differ — exactly the indistinguishability the token fixes.
+				if !a.UpdatedAt.Truncate(time.Second).Equal(b.UpdatedAt.Truncate(time.Second)) {
+					t.Fatalf("same Unix second but truncated updated_at differ: %v vs %v", a.UpdatedAt, b.UpdatedAt)
+				}
+				t.Logf("same-second writes: updated_at=%v identical; RowVersion %d != %d",
+					a.UpdatedAt.Truncate(time.Second), a.RowVersion, b.RowVersion)
+				sameSecondSeen = true
+			}
+		}
+		if !sameSecondSeen {
+			t.Fatalf("no write pair landed in the same wall-clock second across %d attempts; cannot demonstrate the B4 property", attempts)
+		}
+	})
+}

--- a/internal/storage/domain/db/issue_scan_parity_test.go
+++ b/internal/storage/domain/db/issue_scan_parity_test.go
@@ -42,7 +42,7 @@ func TestScanIssue_StringTimestamps(t *testing.T) {
 	for i := range cols {
 		cols[i] = strings.TrimSpace(cols[i])
 	}
-	require.Len(t, cols, 48)
+	require.Len(t, cols, 49)
 
 	row := []driver.Value{
 		"bd-test.1", nil, "title", "desc", "", "", "", // id..notes
@@ -55,9 +55,10 @@ func TestScanIssue_StringTimestamps(t *testing.T) {
 		nil, nil, nil, nil, // event_kind..payload
 		nil, nil, // due_at, defer_until
 		nil, nil, nil, // work_type, source_system, metadata
-		nil, nil, // lease_expires_at, heartbeat_at
+		int64(12345), // row_lock
+		nil, nil,     // lease_expires_at, heartbeat_at
 	}
-	require.Len(t, row, 48)
+	require.Len(t, row, 49)
 
 	mock.ExpectQuery("SELECT").WillReturnRows(sqlmock.NewRows(cols).AddRow(row...))
 
@@ -70,4 +71,6 @@ func TestScanIssue_StringTimestamps(t *testing.T) {
 	require.NoError(t, err, "string timestamps must scan via the shared classic parse")
 	assert.Equal(t, time.Date(2026, 6, 12, 10, 0, 0, 0, time.UTC), issue.CreatedAt)
 	assert.Equal(t, time.Date(2026, 6, 12, 10, 0, 1, 0, time.UTC), issue.UpdatedAt)
+	// row_lock hydrates into the opaque RowVersion token at its positional slot.
+	assert.Equal(t, int64(12345), issue.RowVersion)
 }

--- a/internal/storage/issueops/scan.go
+++ b/internal/storage/issueops/scan.go
@@ -40,6 +40,7 @@ func ScanIssueFrom(s IssueScanner, extra ...any) (*types.Issue, error) {
 	var awaitType, awaitID, waiters sql.NullString
 	var ephemeral, noHistory, pinned, isTemplate sql.NullInt64
 	var metadata sql.NullString
+	var rowLock sql.NullInt64 // row_lock column (NOT NULL DEFAULT 0); scanned defensively so NULL maps to 0
 
 	dests := []any{
 		&issue.ID, &contentHash, &issue.Title, &issue.Description, &issue.Design,
@@ -52,7 +53,7 @@ func ScanIssueFrom(s IssueScanner, extra ...any) (*types.Issue, error) {
 		&molType,
 		&eventKind, &actor, &target, &payload,
 		&dueAt, &deferUntil,
-		&workType, &sourceSystem, &metadata,
+		&workType, &sourceSystem, &metadata, &rowLock,
 		&leaseExpiresAt, &heartbeatAt,
 	}
 	dests = append(dests, extra...)
@@ -173,6 +174,9 @@ func ScanIssueFrom(s IssueScanner, extra ...any) (*types.Issue, error) {
 	if metadata.Valid && metadata.String != "" && metadata.String != "{}" {
 		issue.Metadata = []byte(metadata.String)
 	}
+	// row_lock surfaced as the opaque RowVersion token. NOT NULL DEFAULT 0, so
+	// this is normally valid; a NULL (defensive) maps to 0.
+	issue.RowVersion = rowLock.Int64
 	// Lease columns (migration 0054); NULL when no active lease.
 	if leaseExpiresAt.Valid {
 		issue.LeaseExpiresAt = &leaseExpiresAt.Time

--- a/internal/storage/sqlbuild/sqlbuild.go
+++ b/internal/storage/sqlbuild/sqlbuild.go
@@ -44,7 +44,7 @@ const IssueBaseColumns = `id, content_hash, title, description, design, acceptan
 	       mol_type,
 	       event_kind, actor, target, payload,
 	       due_at, defer_until,
-	       work_type, source_system, metadata`
+	       work_type, source_system, metadata, row_lock`
 
 // LeaseSelectColumns is the lease overlay for full issue hydration. Leases
 // live in the ephemeral leases table (bd-lrgn1), not on the issues row, so

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -50,10 +50,33 @@ type Issue struct {
 	// ===== Leasing (claim TTL + heartbeat; migrations 0054/0055) =====
 	// Hydrated from the ephemeral, node-local leases table (bd-lrgn1), not
 	// from issues columns. NULL when there is no active lease on this node.
-	// row_lock is an internal serialization mechanism (an issues column) and
-	// is intentionally NOT surfaced here.
+	// row_lock is an internal serialization mechanism (an issues column); it is
+	// surfaced read-only to Go callers as RowVersion in the Concurrency group
+	// below (json:"-", never serialized).
 	LeaseExpiresAt *time.Time `json:"lease_expires_at,omitempty"` // When the current claim's lease expires
 	HeartbeatAt    *time.Time `json:"heartbeat_at,omitempty"`     // Last heartbeat from the lease owner
+
+	// ===== Concurrency (Go-only; never serialized) =====
+	// RowVersion is an opaque optimistic-concurrency token for the library's own
+	// Go call sites: the issues/wisps row_lock cell, a random non-zero value the
+	// engine rewrites on every status/ownership-mutating write. It is
+	// EQUALITY-ONLY — compare it, never order or interpret it — and a change
+	// signals the row was mutated since you read it. It is json:"-" on purpose:
+	// row_lock is random per write, so serializing it would break stable bd
+	// --json goldens and bd export round-trips; a Go consumer reads
+	// issue.RowVersion directly instead.
+	//
+	// Coverage is deliberately partial: it changes on claim/close/unclaim and the
+	// generic update path, but NOT on direct-UPDATE paths that rewrite text
+	// without touching row_lock (RestoreFromSnapshotInTx, the compaction
+	// text-truncation path). For a complete change-detection key, combine it with
+	// updated_at (which those paths DO bump), status, and the label set
+	// (label-only and reopen writes change those, not row_lock).
+	//
+	// 0 appears only on legacy rows backfilled by migration 0054 (DEFAULT 0) that
+	// have not been mutated since; any issue created by the current code path is
+	// non-zero (create stamps freshRowLock()).
+	RowVersion int64 `json:"-"`
 
 	// ===== Time-Based Scheduling (GH#820) =====
 	DueAt      *time.Time `json:"due_at,omitempty"`      // When this issue should be completed

--- a/internal/types/types_test.go
+++ b/internal/types/types_test.go
@@ -939,6 +939,43 @@ func TestIssueLeaseJSONSerialization(t *testing.T) {
 	}
 }
 
+// TestRowVersionNeverSerialized locks in the Go-only decision for RowVersion:
+// it is a live Go field (library call sites build an optimistic-concurrency
+// token from it) but json:"-", so its random-per-write value never reaches any
+// bd --json surface or bd export. Serializing it would break stable protocol
+// goldens and export round-trips because the value is regenerated on every
+// write. The value must be absent from the bare Issue and from the two
+// embedding wrappers that back show/list/ready (IssueDetails, IssueWithCounts).
+func TestRowVersionNeverSerialized(t *testing.T) {
+	iss := Issue{ID: "test-1", Title: "Versioned", Status: StatusOpen, RowVersion: 123456789}
+
+	// The Go field stays populated — this is what library call sites read.
+	if iss.RowVersion != 123456789 {
+		t.Fatalf("RowVersion Go field = %d, want 123456789", iss.RowVersion)
+	}
+
+	surfaces := []struct {
+		name string
+		v    any
+	}{
+		{"Issue", iss},
+		{"IssueDetails", IssueDetails{Issue: iss}},
+		{"IssueWithCounts", IssueWithCounts{Issue: &iss}},
+	}
+	for _, tc := range surfaces {
+		b, err := json.Marshal(tc.v)
+		if err != nil {
+			t.Fatalf("marshal %s: %v", tc.name, err)
+		}
+		s := string(b)
+		for _, forbidden := range []string{"row_version", "RowVersion", "row_lock", "123456789"} {
+			if strings.Contains(s, forbidden) {
+				t.Errorf("%s JSON must not contain %q, got: %s", tc.name, forbidden, s)
+			}
+		}
+	}
+}
+
 func TestReclaimedLeaseJSONSerialization(t *testing.T) {
 	b, err := json.Marshal(ReclaimedLease{ID: "bd-1", PreviousOwner: "worker-a"})
 	if err != nil {


### PR DESCRIPTION
> Stacked on #4898 (S4) → #4894 (S3) → #4893 (S2) → #4892 (S1). Base is `feat/guarded-ops-s4-merge-metadata`; retarget down the stack as each lands. The diff below is S5 only.

## What

Surfaces the engine's internal `row_lock` column read-only as `types.Issue.RowVersion` — an opaque, equality-only optimistic-concurrency token. It is a **Go-only** field (`json:"-"`); it never appears on any `bd --json` or `bd export` surface.

## Why

`row_lock` is a random non-zero int64 the engine rewrites on every status/ownership-mutating write (claim, close, unclaim) and on the generic update path, but it was not surfaced on `types.Issue`. A caller that wants a fine-grained change token had only `updated_at`, which is stored at **second granularity** — so two writes in the same second are indistinguishable. Exposing `RowVersion` lets a caller tell same-second writes apart (the concrete gap: a change token built from `updated_at` + status + labels can't detect a second same-second edit to the same field; `RowVersion` can). This is the read-side foundation the `bd` CLI and the library's own call sites need; an optional in-transaction CAS on the guarded ops is a follow-up.

A pre-merge review caught that serializing the token onto the JSON wire (`json:"row_version,omitempty"`) broke the pinned `TestCorpusGolden` and the export round-trip test — and couldn't be regenerated stably because the value is random per write. The fix makes it Go-only (`json:"-"`): callers read the field directly, and no golden or export output changes.

## Verification

- Single-point change: `row_lock` added to the canonical `sqlbuild.IssueBaseColumns` and a matching dest in `issueops.ScanIssueFrom` (verified 49-column/49-dest positional alignment). Both write stacks, wisps, and the counts/dependents parallel scans derive from those, so hydration propagates once; broad issue-read tests (GetIssue/Search/Create/counts/dependents) confirm no read is corrupted.
- `RowVersion` hydrates on read and the list path, changes on a mutating write, and distinguishes two same-second writes (identical `updated_at`, distinct `RowVersion`) — the B4 property.
- `RowVersion` never appears on any JSON surface (`TestRowVersionNeverSerialized`); `TestCorpusGolden` and the export round-trip are green with **no** golden/testdata changes.
- Content hash is unaffected (`RowVersion` is not folded into `ComputeContentHash`). `gofmt`/`go vet` clean; `go build ./...` under cgo and `CGO_ENABLED=0`; `golangci-lint` 0 issues.

```bash
go test ./internal/storage/dolt/ -run TestRowVersion -v
go test ./internal/types/ -run RowVersion
go test ./cmd/bd/protocol/ -run TestCorpusGolden
```
