### PR TITLE
feat(deps): return a typed error on dependency type-conflict

### DIFF
--- a/beads.go
+++ b/beads.go
@@ -224,3 +224,13 @@ var (
 	ErrDependencyCycle = domain.ErrDependencyCycle
 	ErrFieldTooLong    = types.ErrFieldTooLong
 )
+
+// DependencyTypeConflictError is returned by AddDependency when an edge of a
+// different type already exists between the pair; callers errors.As it to read
+// the existing/requested types instead of parsing the message.
+type DependencyTypeConflictError = domain.DependencyTypeConflictError
+
+// DependencyHierarchyConflictError is returned by AddDependency when a blocking
+// edge would gate an issue on its own ancestor/descendant (a gate that can
+// never clear).
+type DependencyHierarchyConflictError = domain.DependencyHierarchyConflictError

--- a/errors_test.go
+++ b/errors_test.go
@@ -94,6 +94,70 @@ func TestReExportedSentinelCatchesRealProductionError(t *testing.T) {
 	}
 }
 
+// insertErrDepRepo returns preset errors from the two methods the domain
+// dependency use-case consults before its typed-conflict passthrough branches:
+// ValidateBlockingHierarchy (hierarchy conflict) and Insert (type conflict). Any
+// other call nil-panics through the embedded interface, keeping the stub honest
+// about the surface these branches touch.
+type insertErrDepRepo struct {
+	domain.DependencySQLRepository
+	hierarchyErr error
+	insertErr    error
+}
+
+func (r insertErrDepRepo) ValidateBlockingHierarchy(context.Context, *types.Dependency) error {
+	return r.hierarchyErr
+}
+
+func (r insertErrDepRepo) HasCycle(context.Context, string, string) (bool, error) {
+	return false, nil
+}
+
+func (r insertErrDepRepo) Insert(context.Context, *types.Dependency, string, domain.DepInsertOpts) error {
+	return r.insertErr
+}
+
+// TestReExportedDependencyConflictTypes proves the public
+// beads.DependencyTypeConflictError and beads.DependencyHierarchyConflictError
+// aliases are the SAME struct types the engine returns: driving ACTUAL domain
+// use-case passthrough returns (the conflict is passed through unwrapped, the
+// property both write stacks now share), errors.As classifies each through the
+// public alias and reads its fields — no message parsing.
+func TestReExportedDependencyConflictTypes(t *testing.T) {
+	t.Parallel()
+
+	// Type conflict: a different-type edge already exists between the pair.
+	typeConflict := &domain.DependencyTypeConflictError{
+		IssueID: "a", DependsOnID: "b", ExistingType: "blocks", RequestedType: "related",
+	}
+	uc := domain.NewDependencyUseCase(insertErrDepRepo{insertErr: typeConflict})
+	err := uc.AddDependency(context.Background(),
+		&types.Dependency{IssueID: "a", DependsOnID: "b", Type: types.DepRelated}, "tester")
+	var gotType *beads.DependencyTypeConflictError
+	if !errors.As(err, &gotType) {
+		t.Fatalf("errors.As(real type-conflict err, *beads.DependencyTypeConflictError) = false; err = %v", err)
+	}
+	if gotType.IssueID != "a" || gotType.DependsOnID != "b" ||
+		gotType.ExistingType != "blocks" || gotType.RequestedType != "related" {
+		t.Errorf("extracted type-conflict fields = %+v, want {a b blocks related}", gotType)
+	}
+
+	// Hierarchy conflict: a blocking edge would gate an issue on its ancestor.
+	hierConflict := &domain.DependencyHierarchyConflictError{
+		IssueID: "child", BlockerID: "ancestor", BlockerIsAncestor: true,
+	}
+	uc = domain.NewDependencyUseCase(insertErrDepRepo{hierarchyErr: hierConflict})
+	err = uc.AddDependency(context.Background(),
+		&types.Dependency{IssueID: "child", DependsOnID: "ancestor", Type: types.DepBlocks}, "tester")
+	var gotHier *beads.DependencyHierarchyConflictError
+	if !errors.As(err, &gotHier) {
+		t.Fatalf("errors.As(real hierarchy-conflict err, *beads.DependencyHierarchyConflictError) = false; err = %v", err)
+	}
+	if gotHier.IssueID != "child" || gotHier.BlockerID != "ancestor" || !gotHier.BlockerIsAncestor {
+		t.Errorf("extracted hierarchy-conflict fields = %+v, want {child ancestor true}", gotHier)
+	}
+}
+
 // TestReExportFieldTooLong proves the public beads.ErrFieldTooLong alias is the
 // same value as the internal types sentinel and composes through errors.Is when
 // wrapped — the property length-validation callers rely on to detect an

--- a/internal/storage/dolt/dependencies_type_conflict_test.go
+++ b/internal/storage/dolt/dependencies_type_conflict_test.go
@@ -1,0 +1,92 @@
+package dolt
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/storage/domain"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// TestAddDependencyTypeConflictReturnsTypedError proves the embedded
+// issueops/DoltStore write stack returns the SAME typed conflict as the
+// domain/db (proxied-server) stack when an edge of a different type already
+// exists between a pair: a *domain.DependencyTypeConflictError, errors.As-able
+// with the existing/requested types readable off it, whose message is still
+// byte-identical to the historical fmt.Errorf string so callers that string-match
+// the old wording keep working.
+//
+// It asserts against domain.DependencyTypeConflictError rather than the public
+// beads.DependencyTypeConflictError alias only because package dolt cannot import
+// the root beads package (root beads imports dolt); the two are the same type via
+// the alias, and the public-alias errors.As is locked separately in the root
+// errors_test.
+//
+// Both DoltStore.AddDependency write seams funnel through the single typed-conflict
+// return at issueops/dependencies.go, but wrap it differently, so both are covered:
+//   - issues source: commits via withRetryTx (backoff-permanent, no retry loop).
+//   - wisp source: addWispDependency (dolt/wisps.go) uses its own BeginTx/Commit,
+//     returning the conflict before it reaches Commit — a distinct wrapping point.
+//
+// The external/cross-prefix route shares the same issueops/dependencies.go return
+// and is not separately exercised here.
+func TestAddDependencyTypeConflictReturnsTypedError(t *testing.T) {
+	t.Run("issues_source", func(t *testing.T) {
+		store, cleanup := setupTestStore(t)
+		defer cleanup()
+		ctx, cancel := testContext(t)
+		defer cancel()
+
+		createPerm(t, ctx, store, "tc-a")
+		createPerm(t, ctx, store, "tc-b")
+		assertTypeConflict(t, ctx, store, "tc-a", "tc-b")
+	})
+
+	t.Run("wisp_source", func(t *testing.T) {
+		store, cleanup := setupTestStore(t)
+		defer cleanup()
+		ctx, cancel := testContext(t)
+		defer cancel()
+
+		createWisp(t, ctx, store, "tc-w")
+		createPerm(t, ctx, store, "tc-wt")
+		assertTypeConflict(t, ctx, store, "tc-w", "tc-wt")
+	})
+}
+
+// assertTypeConflict adds a blocks edge source -> target, then adds a related
+// edge over the same pair and asserts the second add returns the typed conflict
+// with correct fields and a byte-identical message.
+func assertTypeConflict(t *testing.T, ctx context.Context, store *DoltStore, source, target string) {
+	t.Helper()
+
+	if err := store.AddDependency(ctx, &types.Dependency{
+		IssueID: source, DependsOnID: target, Type: types.DepBlocks,
+	}, "tester"); err != nil {
+		t.Fatalf("AddDependency blocks %s -> %s: %v", source, target, err)
+	}
+
+	err := store.AddDependency(ctx, &types.Dependency{
+		IssueID: source, DependsOnID: target, Type: types.DepRelated,
+	}, "tester")
+	if err == nil {
+		t.Fatalf("AddDependency(related) over existing blocks edge %s -> %s = nil, want type-conflict error", source, target)
+	}
+
+	var conflict *domain.DependencyTypeConflictError
+	if !errors.As(err, &conflict) {
+		t.Fatalf("errors.As(err, *domain.DependencyTypeConflictError) = false; err = %v", err)
+	}
+	if conflict.IssueID != source || conflict.DependsOnID != target ||
+		conflict.ExistingType != "blocks" || conflict.RequestedType != "related" {
+		t.Errorf("conflict fields = %+v, want {IssueID:%s DependsOnID:%s ExistingType:blocks RequestedType:related}", conflict, source, target)
+	}
+
+	// Byte-identical to the pre-taxonomy fmt.Errorf message.
+	want := fmt.Sprintf(`dependency %s -> %s already exists with type "blocks" (requested "related"); remove it first with 'bd dep remove' then re-add`, source, target)
+	if err.Error() != want {
+		t.Errorf("message = %q, want byte-identical %q", err.Error(), want)
+	}
+}

--- a/internal/storage/domain/db/dependency_test.go
+++ b/internal/storage/domain/db/dependency_test.go
@@ -144,6 +144,16 @@ func (s *testSuite) depInsertConflictingType() {
 	err := r.Insert(s.Ctx(), newDep("bd-dep-conf-1", "bd-dep-conf-2", types.DepRelated), "tester", domain.DepInsertOpts{})
 	s.Require().Error(err)
 	s.Contains(err.Error(), "already exists with type")
+
+	// Parity with the embedded issueops/DoltStore stack: the conflict is a typed
+	// *domain.DependencyTypeConflictError, errors.As-able with the existing and
+	// requested types readable off it.
+	var conflict *domain.DependencyTypeConflictError
+	s.Require().ErrorAs(err, &conflict)
+	s.Equal("bd-dep-conf-1", conflict.IssueID)
+	s.Equal("bd-dep-conf-2", conflict.DependsOnID)
+	s.Equal("blocks", conflict.ExistingType)
+	s.Equal("related", conflict.RequestedType)
 }
 
 func (s *testSuite) depInsertFKViolation() {

--- a/internal/storage/issueops/dependencies.go
+++ b/internal/storage/issueops/dependencies.go
@@ -219,8 +219,12 @@ func AddDependencyInTx(ctx context.Context, tx *sql.Tx, dep *types.Dependency, a
 			}
 			return nil
 		}
-		return fmt.Errorf("dependency %s -> %s already exists with type %q (requested %q); remove it first with 'bd dep remove' then re-add",
-			dep.IssueID, dep.DependsOnID, existingType, dep.Type)
+		return &domain.DependencyTypeConflictError{
+			IssueID:       dep.IssueID,
+			DependsOnID:   dep.DependsOnID,
+			ExistingType:  existingType,
+			RequestedType: string(dep.Type),
+		}
 	} else if !errors.Is(err, sql.ErrNoRows) {
 		return fmt.Errorf("failed to check existing dependency: %w", err)
 	}


### PR DESCRIPTION
> Stacked on #4899 (S5) → #4898 (S4) → #4894 (S3) → #4893 (S2) → #4892 (S1). Base is `feat/guarded-ops-s5-row-version`; retarget down the stack as each lands. The diff below is S6 only.

## What

Makes the dependency type-conflict error typed on **both** engine write paths and re-exports the two dependency-conflict types on the public `beads` package, so a caller classifies an `AddDependency` rejection with `errors.As` instead of matching the message text.

## Why

Adding a dependency between a pair that already has an edge of a *different* type is a deterministic rejection. One write path returned a typed `*DependencyTypeConflictError`; the other returned a plain `fmt.Errorf` string — so `errors.As` worked on one path and not the other, and `bd` had to fall back to string-matching (or treat the deterministic rejection as a retryable fault). Typing it consistently lets the `bd` CLI (and the library's own call sites) map it to a clean, deterministic outcome. Completes the dependency-write error taxonomy: self-dependency and cycle are already typed sentinels, and the hierarchy/cross-type error was already typed on both paths — type-conflict was the last formatted-string gap.

The message is **byte-identical** (`DependencyTypeConflictError.Error()` is the exact former string), so no string-matcher changes.

## Verification

- `errors.As(err, &beads.DependencyTypeConflictError{})` matches at the public `AddDependency` boundary on both write paths (verified against a real Dolt server and the alternate stack), with the four fields readable; the re-exports are `=` type aliases so the public type is the engine type.
- Covered on the permanent `issues→issues` route **and** the wisp-source `BeginTx`/`Commit` seam; `err.Error()` asserted byte-identical to the historical string; the deterministic conflict is returned immediately (not retried as a transient serialization error).
- Existing dependency string-match tests still pass (message unchanged). `gofmt`/`go vet` clean; `go build ./...` under cgo and `CGO_ENABLED=0`; `golangci-lint` 0 issues.

```bash
go test ./internal/storage/dolt/ -run TestAddDependencyTypeConflict -v
go test ./internal/storage/domain/db/ -run TestDependencySQLRepository -count=1
go test . -run TestReExportedDependencyConflictTypes
```
