### PR TITLE
feat(deps): emit dependency_added / dependency_removed events

### DIFF
--- a/internal/storage/dolt/dependencies.go
+++ b/internal/storage/dolt/dependencies.go
@@ -52,7 +52,10 @@ func (s *DoltStore) AddDependency(ctx context.Context, dep *types.Dependency, ac
 		return err
 	}
 	// GH#2455: Use explicit DOLT_ADD to avoid sweeping up stale config changes.
-	return s.doltAddAndCommit(ctx, []string{"dependencies"}, "dependency: add "+string(dep.Type)+" "+dep.IssueID+" -> "+dep.DependsOnID)
+	// Stage events alongside dependencies: AddDependencyInTx now records a
+	// dependency_added event, and DOLT_COMMIT only commits explicitly staged
+	// tables — omitting events would leave the event row in the working set.
+	return s.doltAddAndCommit(ctx, []string{"dependencies", "events"}, "dependency: add "+string(dep.Type)+" "+dep.IssueID+" -> "+dep.DependsOnID)
 }
 
 // RemoveDependency removes a dependency between two issues.
@@ -65,7 +68,7 @@ func (s *DoltStore) RemoveDependency(ctx context.Context, issueID, dependsOnID s
 			return fmt.Errorf("failed to begin transaction: %w", err)
 		}
 		defer func() { _ = tx.Rollback() }()
-		if err := issueops.RemoveDependencyInTx(ctx, tx, issueID, dependsOnID); err != nil {
+		if err := issueops.RemoveDependencyInTx(ctx, tx, issueID, dependsOnID, actor); err != nil {
 			return err
 		}
 		return wrapTransactionError("commit remove wisp dependency", tx.Commit())
@@ -77,7 +80,7 @@ func (s *DoltStore) RemoveDependency(ctx context.Context, issueID, dependsOnID s
 	}
 	defer func() { _ = tx.Rollback() }()
 
-	if err := issueops.RemoveDependencyInTx(ctx, tx, issueID, dependsOnID); err != nil {
+	if err := issueops.RemoveDependencyInTx(ctx, tx, issueID, dependsOnID, actor); err != nil {
 		return err
 	}
 
@@ -85,7 +88,9 @@ func (s *DoltStore) RemoveDependency(ctx context.Context, issueID, dependsOnID s
 		return fmt.Errorf("sql commit: %w", err)
 	}
 	// GH#2455: Use explicit DOLT_ADD to avoid sweeping up stale config changes.
-	if err := s.doltAddAndCommit(ctx, []string{"dependencies"}, "dependency: remove "+issueID+" -> "+dependsOnID); err != nil {
+	// Stage events alongside dependencies: RemoveDependencyInTx now records a
+	// dependency_removed event that DOLT_COMMIT would otherwise leave uncommitted.
+	if err := s.doltAddAndCommit(ctx, []string{"dependencies", "events"}, "dependency: remove "+issueID+" -> "+dependsOnID); err != nil {
 		return err
 	}
 	return nil

--- a/internal/storage/dolt/dependency_events_test.go
+++ b/internal/storage/dolt/dependency_events_test.go
@@ -1,0 +1,289 @@
+package dolt
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/storage"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// depEventsOfType returns the events on issue id whose type matches et, as read
+// back through the store (working-set view, the same view bd and library
+// callers see).
+func depEventsOfType(t *testing.T, ctx context.Context, store *DoltStore, id string, et types.EventType) []*types.Event {
+	t.Helper()
+	events, err := store.GetEvents(ctx, id, 0)
+	if err != nil {
+		t.Fatalf("GetEvents(%s): %v", id, err)
+	}
+	var out []*types.Event
+	for _, e := range events {
+		if e.EventType == et {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+func newValueOf(t *testing.T, e *types.Event) string {
+	t.Helper()
+	if e.NewValue == nil {
+		t.Fatalf("event %s has nil new_value", e.EventType)
+	}
+	return *e.NewValue
+}
+
+// TestDependencyEventEmission ports the SQLite-era dependency_added /
+// dependency_removed event emission onto the Dolt engine: a real add or remove
+// records a descriptive event on the source's event table, an idempotent re-add
+// does not double-emit, and the added event is DOLT_COMMITted (staged), not left
+// dangling in the working set.
+func TestDependencyEventEmission(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	t.Run("AddEmitsDependencyAdded", func(t *testing.T) {
+		src, tgt := "de-add-a", "de-add-b"
+		createPerm(t, ctx, store, src)
+		createPerm(t, ctx, store, tgt)
+		if err := store.AddDependency(ctx, &types.Dependency{
+			IssueID: src, DependsOnID: tgt, Type: types.DepBlocks,
+		}, "tester"); err != nil {
+			t.Fatalf("AddDependency: %v", err)
+		}
+
+		added := depEventsOfType(t, ctx, store, src, types.EventDependencyAdded)
+		if len(added) != 1 {
+			t.Fatalf("dependency_added event count on %s = %d, want 1", src, len(added))
+		}
+		if added[0].Actor != "tester" {
+			t.Fatalf("dependency_added actor = %q, want %q", added[0].Actor, "tester")
+		}
+		if got, want := newValueOf(t, added[0]), "Added dependency: de-add-a blocks de-add-b"; got != want {
+			t.Fatalf("dependency_added new_value = %q, want %q", got, want)
+		}
+		// No event should land on the target (the source owns the edge history).
+		if n := len(depEventsOfType(t, ctx, store, tgt, types.EventDependencyAdded)); n != 0 {
+			t.Fatalf("target %s must carry no dependency_added event, got %d", tgt, n)
+		}
+	})
+
+	t.Run("AddCommitsEventRow", func(t *testing.T) {
+		src, tgt := "de-commit-a", "de-commit-b"
+		createPerm(t, ctx, store, src)
+		createPerm(t, ctx, store, tgt)
+		if err := store.AddDependency(ctx, &types.Dependency{
+			IssueID: src, DependsOnID: tgt, Type: types.DepBlocks,
+		}, "tester"); err != nil {
+			t.Fatalf("AddDependency: %v", err)
+		}
+
+		// AS OF 'HEAD' reads the committed tree only: a non-zero count proves the
+		// event row was staged and committed, not merely written to the working set.
+		var committed int
+		if err := store.db.QueryRowContext(ctx,
+			"SELECT COUNT(*) FROM events AS OF 'HEAD' WHERE issue_id = ? AND event_type = ?",
+			src, string(types.EventDependencyAdded),
+		).Scan(&committed); err != nil {
+			t.Fatalf("count committed dependency_added events: %v", err)
+		}
+		if committed != 1 {
+			t.Fatalf("committed dependency_added count = %d, want 1 (events must be staged before DOLT_COMMIT)", committed)
+		}
+		// The events table must be clean afterward — the row is in the commit, not
+		// left dirty in the working set where a later DOLT_RESET could drop it.
+		var dirtyEvents int
+		if err := store.db.QueryRowContext(ctx,
+			"SELECT COUNT(*) FROM dolt_status WHERE table_name = 'events'",
+		).Scan(&dirtyEvents); err != nil {
+			t.Fatalf("query dolt_status for events: %v", err)
+		}
+		if dirtyEvents != 0 {
+			t.Fatalf("events table dirty after AddDependency (count=%d); staging is not committing the event", dirtyEvents)
+		}
+	})
+
+	t.Run("RemoveEmitsDependencyRemoved", func(t *testing.T) {
+		src, tgt := "de-rm-a", "de-rm-b"
+		createPerm(t, ctx, store, src)
+		createPerm(t, ctx, store, tgt)
+		if err := store.AddDependency(ctx, &types.Dependency{
+			IssueID: src, DependsOnID: tgt, Type: types.DepBlocks,
+		}, "tester"); err != nil {
+			t.Fatalf("AddDependency: %v", err)
+		}
+		if err := store.RemoveDependency(ctx, src, tgt, "remover"); err != nil {
+			t.Fatalf("RemoveDependency: %v", err)
+		}
+
+		removed := depEventsOfType(t, ctx, store, src, types.EventDependencyRemoved)
+		if len(removed) != 1 {
+			t.Fatalf("dependency_removed event count on %s = %d, want 1", src, len(removed))
+		}
+		if removed[0].Actor != "remover" {
+			t.Fatalf("dependency_removed actor = %q, want %q", removed[0].Actor, "remover")
+		}
+		if got, want := newValueOf(t, removed[0]), "Removed dependency on de-rm-b"; got != want {
+			t.Fatalf("dependency_removed new_value = %q, want %q", got, want)
+		}
+		// The removed event is committed too.
+		var committed int
+		if err := store.db.QueryRowContext(ctx,
+			"SELECT COUNT(*) FROM events AS OF 'HEAD' WHERE issue_id = ? AND event_type = ?",
+			src, string(types.EventDependencyRemoved),
+		).Scan(&committed); err != nil {
+			t.Fatalf("count committed dependency_removed events: %v", err)
+		}
+		if committed != 1 {
+			t.Fatalf("committed dependency_removed count = %d, want 1", committed)
+		}
+	})
+
+	t.Run("RemoveMissingEdgeEmitsNothing", func(t *testing.T) {
+		src, tgt := "de-noop-a", "de-noop-b"
+		createPerm(t, ctx, store, src)
+		createPerm(t, ctx, store, tgt)
+		// No edge was ever added; a no-op remove must not record an event.
+		if err := store.RemoveDependency(ctx, src, tgt, "remover"); err != nil {
+			t.Fatalf("RemoveDependency (no-op): %v", err)
+		}
+		if n := len(depEventsOfType(t, ctx, store, src, types.EventDependencyRemoved)); n != 0 {
+			t.Fatalf("no-op remove must emit no dependency_removed event, got %d", n)
+		}
+	})
+
+	t.Run("IdempotentReAddDoesNotDoubleEmit", func(t *testing.T) {
+		src, tgt := "de-idem-a", "de-idem-b"
+		createPerm(t, ctx, store, src)
+		createPerm(t, ctx, store, tgt)
+		dep := &types.Dependency{IssueID: src, DependsOnID: tgt, Type: types.DepBlocks}
+		if err := store.AddDependency(ctx, dep, "tester"); err != nil {
+			t.Fatalf("AddDependency (first): %v", err)
+		}
+		// Second add of the same edge/type is an idempotent metadata-only update
+		// that returns before the INSERT — it must not record a second event.
+		if err := store.AddDependency(ctx, dep, "tester"); err != nil {
+			t.Fatalf("AddDependency (idempotent re-add): %v", err)
+		}
+		if n := len(depEventsOfType(t, ctx, store, src, types.EventDependencyAdded)); n != 1 {
+			t.Fatalf("idempotent re-add must not double-emit: dependency_added count = %d, want 1", n)
+		}
+	})
+
+	t.Run("WispSourceEmitsIntoWispEventTable", func(t *testing.T) {
+		src, tgt := "de-wisp-a", "de-wisp-b"
+		createWisp(t, ctx, store, src)
+		createPerm(t, ctx, store, tgt)
+		if err := store.AddDependency(ctx, &types.Dependency{
+			IssueID: src, DependsOnID: tgt, Type: types.DepBlocks,
+		}, "tester"); err != nil {
+			t.Fatalf("AddDependency (wisp source): %v", err)
+		}
+
+		// GetEvents routes a wisp source to wisp_events, so the event is visible
+		// there and nowhere in the permanent events table.
+		added := depEventsOfType(t, ctx, store, src, types.EventDependencyAdded)
+		if len(added) != 1 {
+			t.Fatalf("wisp dependency_added event count on %s = %d, want 1", src, len(added))
+		}
+		if got, want := newValueOf(t, added[0]), "Added dependency: de-wisp-a blocks de-wisp-b"; got != want {
+			t.Fatalf("wisp dependency_added new_value = %q, want %q", got, want)
+		}
+		var permCount int
+		if err := store.db.QueryRowContext(ctx,
+			"SELECT COUNT(*) FROM events WHERE issue_id = ?", src,
+		).Scan(&permCount); err != nil {
+			t.Fatalf("count permanent events for wisp source: %v", err)
+		}
+		if permCount != 0 {
+			t.Fatalf("wisp-source event leaked into permanent events table (count=%d)", permCount)
+		}
+	})
+}
+
+// TestRunInTransactionAddRemoveDependencyCommitsEvents is the FIX-1 regression
+// guard for the transaction-path plumbing: doltTransaction.AddDependency /
+// RemoveDependency emit dep events through issueops, and StageAndCommit commits
+// only the dirty set — so the source's event table MUST be staged or the event is
+// a torn write (written to the working set but never committed, dropped on
+// reset/reconcile). A permanent source commits the event; AS OF 'HEAD' reads the
+// committed tree only, so a count of 1 proves the event was staged and committed.
+func TestRunInTransactionAddRemoveDependencyCommitsEvents(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	src, tgt := "tx-dep-a", "tx-dep-b"
+	createPerm(t, ctx, store, src)
+	createPerm(t, ctx, store, tgt)
+
+	if err := store.RunInTransaction(ctx, "test: tx add dependency emits event", func(tx storage.Transaction) error {
+		return tx.AddDependency(ctx, &types.Dependency{IssueID: src, DependsOnID: tgt, Type: types.DepBlocks}, "tester")
+	}); err != nil {
+		t.Fatalf("RunInTransaction AddDependency: %v", err)
+	}
+	assertCommittedEventCount(ctx, t, store.db, src, types.EventDependencyAdded, 1)
+
+	if err := store.RunInTransaction(ctx, "test: tx remove dependency emits event", func(tx storage.Transaction) error {
+		return tx.RemoveDependency(ctx, src, tgt, "remover")
+	}); err != nil {
+		t.Fatalf("RunInTransaction RemoveDependency: %v", err)
+	}
+	assertCommittedEventCount(ctx, t, store.db, src, types.EventDependencyRemoved, 1)
+}
+
+// TestRunInTransactionWispSourceDependencyRoutesToWispEvents proves the tx-path
+// stages the SOURCE's event table wisp-aware: a wisp-source dep records its event
+// in wisp_events (the wisp's branch-local home), never in the permanent events
+// table. Wisp tables are dolt-ignored, so "persisted" here means readable in the
+// working set, which is where all wisp data lives.
+func TestRunInTransactionWispSourceDependencyRoutesToWispEvents(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	src, tgt := "tx-wdep-a", "tx-wdep-b"
+	createWisp(t, ctx, store, src)
+	createWisp(t, ctx, store, tgt)
+
+	if err := store.RunInTransaction(ctx, "test: tx wisp add dependency", func(tx storage.Transaction) error {
+		return tx.AddDependency(ctx, &types.Dependency{IssueID: src, DependsOnID: tgt, Type: types.DepBlocks}, "tester")
+	}); err != nil {
+		t.Fatalf("RunInTransaction wisp AddDependency: %v", err)
+	}
+	assertEventCountInTable(ctx, t, store.db, "wisp_events", src, types.EventDependencyAdded, 1)
+	assertEventCountInTable(ctx, t, store.db, "events", src, types.EventDependencyAdded, 0)
+
+	if err := store.RunInTransaction(ctx, "test: tx wisp remove dependency", func(tx storage.Transaction) error {
+		return tx.RemoveDependency(ctx, src, tgt, "remover")
+	}); err != nil {
+		t.Fatalf("RunInTransaction wisp RemoveDependency: %v", err)
+	}
+	assertEventCountInTable(ctx, t, store.db, "wisp_events", src, types.EventDependencyRemoved, 1)
+	assertEventCountInTable(ctx, t, store.db, "events", src, types.EventDependencyRemoved, 0)
+}
+
+// assertEventCountInTable counts working-set rows for issueID/eventType in the
+// named event table (events or wisp_events). Used for wisp assertions, where the
+// dolt-ignored wisp_events table is never committed to HEAD.
+//
+//nolint:gosec // G201: table is a test-supplied constant ("events" or "wisp_events").
+func assertEventCountInTable(ctx context.Context, t *testing.T, db *sql.DB, table, issueID string, eventType types.EventType, want int) {
+	t.Helper()
+	var got int
+	if err := db.QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM "+table+" WHERE issue_id = ? AND event_type = ?",
+		issueID, eventType,
+	).Scan(&got); err != nil {
+		t.Fatalf("count %s.%s for %s: %v", table, eventType, issueID, err)
+	}
+	if got != want {
+		t.Fatalf("%s.%s count for %s = %d, want %d", table, eventType, issueID, got, want)
+	}
+}

--- a/internal/storage/dolt/transaction.go
+++ b/internal/storage/dolt/transaction.go
@@ -699,9 +699,11 @@ func (t *doltTransaction) AddDependency(ctx context.Context, dep *types.Dependen
 func (t *doltTransaction) AddDependencyWithOptions(ctx context.Context, dep *types.Dependency, actor string, addOpts storage.DependencyAddOptions) error {
 	table := "dependencies"
 	sourceTable := "issues"
+	eventTable := "events"
 	if t.isActiveWisp(ctx, dep.IssueID) {
 		table = "wisp_dependencies"
 		sourceTable = "wisps"
+		eventTable = "wisp_events"
 	}
 
 	isCrossPrefix := isCrossPrefixDep(dep.IssueID, dep.DependsOnID)
@@ -766,6 +768,10 @@ func (t *doltTransaction) AddDependencyWithOptions(ctx context.Context, dep *typ
 		return addErr
 	}
 	t.dirty.MarkDirty(table)
+	// AddDependencyInTx records a dependency_added event on the source's event
+	// table; stage it so StageAndCommit commits the event with the edge (a torn
+	// write otherwise leaves the event in the working set, dropped on reset).
+	t.dirty.MarkDirty(eventTable)
 	t.recordDepTierWrite(table)
 	return nil
 }
@@ -907,13 +913,18 @@ func (t *doltTransaction) GetDependencyRecords(ctx context.Context, issueID stri
 
 func (t *doltTransaction) RemoveDependency(ctx context.Context, issueID, dependsOnID string, actor string) error {
 	table := "dependencies"
+	eventTable := "events"
 	if t.isActiveWisp(ctx, issueID) {
 		table = "wisp_dependencies"
+		eventTable = "wisp_events"
 	}
-	if err := issueops.RemoveDependencyInTx(ctx, t.txFor(table), issueID, dependsOnID); err != nil {
+	if err := issueops.RemoveDependencyInTx(ctx, t.txFor(table), issueID, dependsOnID, actor); err != nil {
 		return wrapExecError("remove dependency in tx", err)
 	}
 	t.dirty.MarkDirty(table)
+	// RemoveDependencyInTx records a dependency_removed event on the source's
+	// event table when a row is deleted; stage it so it commits with the edge.
+	t.dirty.MarkDirty(eventTable)
 	return nil
 }
 

--- a/internal/storage/domain/db/dependency.go
+++ b/internal/storage/domain/db/dependency.go
@@ -18,11 +18,15 @@ import (
 )
 
 func NewDependencySQLRepository(runner Runner) domain.DependencySQLRepository {
-	return &dependencySQLRepositoryImpl{runner: runner}
+	return &dependencySQLRepositoryImpl{
+		runner: runner,
+		events: NewEventsSQLRepository(runner),
+	}
 }
 
 type dependencySQLRepositoryImpl struct {
 	runner Runner
+	events domain.EventsSQLRepository
 }
 
 var _ domain.DependencySQLRepository = (*dependencySQLRepositoryImpl)(nil)
@@ -142,6 +146,24 @@ func (r *dependencySQLRepositoryImpl) Insert(ctx context.Context, dep *types.Dep
 		return fmt.Errorf("db: DependencySQLRepository.Insert: %w", err)
 	}
 
+	// Record the dependency_added event on the source's event table, matching the
+	// embedded/issueops AddDependencyInTx path so the bd CLI and library callers
+	// observe the same history from either write plumbing. Reached only on the
+	// genuine new-edge path; the idempotent same-type refresh returned earlier.
+	// Gated on EmitEvent so only the explicit dep verbs emit: create-with-deps
+	// calls Insert directly without it, so an implicit parent-child / --deps /
+	// waits-for edge produces no event (parity with embedded PersistDependencies).
+	if opts.EmitEvent {
+		if err := r.events.Record(ctx, domain.Event{
+			IssueID:  dep.IssueID,
+			Type:     types.EventDependencyAdded,
+			Actor:    actor,
+			NewValue: fmt.Sprintf("Added dependency: %s %s %s", dep.IssueID, dep.Type, dep.DependsOnID),
+		}, domain.RecordEventOpts{UseWispsTable: opts.UseWispsTable}); err != nil {
+			return fmt.Errorf("db: DependencySQLRepository.Insert: record dependency_added event: %w", err)
+		}
+	}
+
 	// is_blocked maintenance mirrors the classic AddDependencyInTx flow
 	// (issueops/dependencies.go): the affected set expands the source by its
 	// parent-child descendants (plus, for parent-child edges, waiters on the
@@ -251,6 +273,21 @@ func (r *dependencySQLRepositoryImpl) Delete(ctx context.Context, issueID, depen
 		issueID, dependsOnID,
 	); err != nil {
 		return domain.DepDeleteResult{}, fmt.Errorf("db: DependencySQLRepository.Delete: %s -> %s: %w", issueID, dependsOnID, err)
+	}
+
+	// The type lookup above returned Found:false when no edge existed, so reaching
+	// here means a row was deleted — record the dependency_removed event on the
+	// source's event table, matching the embedded/issueops RemoveDependencyInTx path.
+	// Gated on EmitEvent so only the explicit `bd dep remove` verb emits.
+	if opts.EmitEvent {
+		if err := r.events.Record(ctx, domain.Event{
+			IssueID:  issueID,
+			Type:     types.EventDependencyRemoved,
+			Actor:    actor,
+			NewValue: fmt.Sprintf("Removed dependency on %s", dependsOnID),
+		}, domain.RecordEventOpts{UseWispsTable: opts.UseWispsTable}); err != nil {
+			return domain.DepDeleteResult{}, fmt.Errorf("db: DependencySQLRepository.Delete: record dependency_removed event: %w", err)
+		}
 	}
 
 	dt := types.DependencyType(depType)

--- a/internal/storage/domain/db/dependency_event_consistency_test.go
+++ b/internal/storage/domain/db/dependency_event_consistency_test.go
@@ -1,0 +1,122 @@
+package db
+
+import (
+	"github.com/steveyegge/beads/internal/storage/domain"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// TestDependencyEventConsistency locks in the explicit-verb boundary: the
+// proxied plumbing records a dependency_added / dependency_removed event ONLY on
+// the explicit dep verb (through the DependencyUseCase), never on create-with-deps
+// (which calls depRepo.Insert directly). So `bd create --parent` / `--deps`
+// produces the same empty dep history on the proxied backend as on the embedded
+// backend, where create routes through issueops PersistDependencies (no emit).
+func (s *testSuite) TestDependencyEventConsistency() {
+	s.Run("ExplicitAddDependenciesEmits", s.consistencyExplicitAddEmits)
+	s.Run("ExplicitRemoveDependencyEmits", s.consistencyExplicitRemoveEmits)
+	s.Run("CreateWithParentDoesNotEmit", s.consistencyCreateParentNoEmit)
+	s.Run("CreateWithDepsDoesNotEmit", s.consistencyCreateDepsNoEmit)
+}
+
+// consistencyExplicitAddEmits proves the real proxied `bd dep add` / `bd link`
+// verb — which routes through DependencyUseCase.AddDependencies (bulk) — emits.
+func (s *testSuite) consistencyExplicitAddEmits() {
+	s.seedIssueRow("bd-cons-add-a")
+	s.seedIssueRow("bd-cons-add-b")
+	_, err := s.depUseCase().AddDependencies(s.Ctx(),
+		[]*types.Dependency{newDep("bd-cons-add-a", "bd-cons-add-b", types.DepBlocks)},
+		"tester", domain.BulkAddDepsOpts{})
+	s.Require().NoError(err)
+
+	var count int
+	s.Require().NoError(s.Runner().QueryRowContext(s.Ctx(),
+		"SELECT COUNT(*) FROM events WHERE issue_id = ? AND event_type = ?",
+		"bd-cons-add-a", string(types.EventDependencyAdded)).Scan(&count))
+	s.Equal(1, count, "explicit AddDependencies (bd dep add / bd link) must emit one dependency_added")
+
+	var newValue string
+	s.Require().NoError(s.Runner().QueryRowContext(s.Ctx(),
+		"SELECT new_value FROM events WHERE issue_id = ? AND event_type = ?",
+		"bd-cons-add-a", string(types.EventDependencyAdded)).Scan(&newValue))
+	s.Equal("Added dependency: bd-cons-add-a blocks bd-cons-add-b", newValue)
+}
+
+// consistencyExplicitRemoveEmits proves the explicit `bd dep remove` verb —
+// DependencyUseCase.RemoveDependency — emits a dependency_removed event.
+func (s *testSuite) consistencyExplicitRemoveEmits() {
+	s.seedIssueRow("bd-cons-rm-a")
+	s.seedIssueRow("bd-cons-rm-b")
+	_, err := s.depUseCase().AddDependencies(s.Ctx(),
+		[]*types.Dependency{newDep("bd-cons-rm-a", "bd-cons-rm-b", types.DepBlocks)},
+		"tester", domain.BulkAddDepsOpts{})
+	s.Require().NoError(err)
+	s.Require().NoError(s.depUseCase().RemoveDependency(s.Ctx(), "bd-cons-rm-a", "bd-cons-rm-b", "remover"))
+
+	var count int
+	s.Require().NoError(s.Runner().QueryRowContext(s.Ctx(),
+		"SELECT COUNT(*) FROM events WHERE issue_id = ? AND event_type = ?",
+		"bd-cons-rm-a", string(types.EventDependencyRemoved)).Scan(&count))
+	s.Equal(1, count, "explicit RemoveDependency (bd dep remove) must emit one dependency_removed")
+}
+
+// consistencyCreateParentNoEmit proves `bd create --parent` on the proxied path
+// creates the implicit parent-child edge but records NO dependency_added event,
+// matching the embedded backend.
+func (s *testSuite) consistencyCreateParentNoEmit() {
+	s.resetMintConfig("cparent", "")
+	uc := s.issueUseCase()
+	parent, err := uc.CreateIssue(s.Ctx(), domain.CreateIssueParams{
+		Issue: &types.Issue{Title: "parent", IssueType: types.TypeEpic, Priority: 2},
+	}, "tester")
+	s.Require().NoError(err)
+	child, err := uc.CreateIssue(s.Ctx(), domain.CreateIssueParams{
+		Issue:    &types.Issue{Title: "child", IssueType: types.TypeTask, Priority: 2},
+		ParentID: parent.Issue.ID,
+	}, "tester")
+	s.Require().NoError(err)
+
+	// The implicit parent-child edge must exist ...
+	var edgeCount int
+	s.Require().NoError(s.Runner().QueryRowContext(s.Ctx(),
+		"SELECT COUNT(*) FROM dependencies WHERE issue_id = ? AND depends_on_issue_id = ? AND type = 'parent-child'",
+		child.Issue.ID, parent.Issue.ID).Scan(&edgeCount))
+	s.Equal(1, edgeCount, "create --parent must create the parent-child edge")
+
+	// ... but must NOT record a dependency_added event (parity with embedded).
+	var eventCount int
+	s.Require().NoError(s.Runner().QueryRowContext(s.Ctx(),
+		"SELECT COUNT(*) FROM events WHERE issue_id = ? AND event_type = ?",
+		child.Issue.ID, string(types.EventDependencyAdded)).Scan(&eventCount))
+	s.Equal(0, eventCount, "create --parent must NOT emit dependency_added (matches embedded PersistDependencies)")
+}
+
+// consistencyCreateDepsNoEmit proves `bd create --deps` on the proxied path
+// creates the edge but records NO dependency_added event, matching the embedded
+// backend.
+func (s *testSuite) consistencyCreateDepsNoEmit() {
+	s.resetMintConfig("cdeps", "")
+	uc := s.issueUseCase()
+	target, err := uc.CreateIssue(s.Ctx(), domain.CreateIssueParams{
+		Issue: &types.Issue{Title: "target", IssueType: types.TypeTask, Priority: 2},
+	}, "tester")
+	s.Require().NoError(err)
+	src, err := uc.CreateIssue(s.Ctx(), domain.CreateIssueParams{
+		Issue: &types.Issue{Title: "source", IssueType: types.TypeTask, Priority: 2},
+		Dependencies: []domain.DependencySpec{
+			{Type: types.DepBlocks, TargetID: target.Issue.ID},
+		},
+	}, "tester")
+	s.Require().NoError(err)
+
+	var edgeCount int
+	s.Require().NoError(s.Runner().QueryRowContext(s.Ctx(),
+		"SELECT COUNT(*) FROM dependencies WHERE issue_id = ? AND depends_on_issue_id = ?",
+		src.Issue.ID, target.Issue.ID).Scan(&edgeCount))
+	s.Equal(1, edgeCount, "create --deps must create the dependency edge")
+
+	var eventCount int
+	s.Require().NoError(s.Runner().QueryRowContext(s.Ctx(),
+		"SELECT COUNT(*) FROM events WHERE issue_id = ? AND event_type = ?",
+		src.Issue.ID, string(types.EventDependencyAdded)).Scan(&eventCount))
+	s.Equal(0, eventCount, "create --deps must NOT emit dependency_added (matches embedded)")
+}

--- a/internal/storage/domain/db/dependency_test.go
+++ b/internal/storage/domain/db/dependency_test.go
@@ -16,6 +16,9 @@ func (s *testSuite) TestDependencySQLRepository() {
 		s.Run("DifferentTypeIsRejected", s.depInsertConflictingType)
 		s.Run("MissingTargetIssueFailsFK", s.depInsertFKViolation)
 		s.Run("ThreadIDPersists", s.depInsertThreadID)
+		s.Run("EmitsDependencyAddedEventWhenEmitEventSet", s.depInsertEmitsAddedEvent)
+		s.Run("RecordsNoEventWithoutEmitEvent", s.depInsertWithoutEmitEventRecordsNoEvent)
+		s.Run("IdempotentReAddEmitsNoSecondEvent", s.depInsertIdempotentNoDoubleEvent)
 	})
 	s.Run("Delete", func() {
 		s.Run("ReturnsFoundFalseOnMissingEdge", s.depDeleteMissingEdge)
@@ -23,6 +26,8 @@ func (s *testSuite) TestDependencySQLRepository() {
 		s.Run("RemovesRow", s.depDeleteRemovesRow)
 		s.Run("RejectsEmptyIDs", s.depDeleteEmptyIDs)
 		s.Run("WispRoutesToWispDependencies", s.depDeleteWispRouting)
+		s.Run("EmitsDependencyRemovedEvent", s.depDeleteEmitsRemovedEvent)
+		s.Run("MissingEdgeEmitsNoEvent", s.depDeleteMissingEdgeEmitsNoEvent)
 	})
 	s.Run("HasCycle", func() {
 		s.Run("StraightLineIsAcyclic", s.depCycleAcyclic)
@@ -175,6 +180,116 @@ func (s *testSuite) depInsertThreadID() {
 	s.Require().NoError(err)
 	s.Require().Len(out.Outgoing["bd-dep-th-1"], 1)
 	s.Equal("thread-xyz", out.Outgoing["bd-dep-th-1"][0].ThreadID)
+}
+
+// depInsertEmitsAddedEvent proves the repo records a dependency_added event for
+// a genuine new edge when the caller sets EmitEvent (the explicit dep verb). The
+// descriptive string matches the embedded/issueops AddDependencyInTx path.
+func (s *testSuite) depInsertEmitsAddedEvent() {
+	s.seedIssueRow("bd-dep-evt-a")
+	s.seedIssueRow("bd-dep-evt-b")
+	s.Require().NoError(s.depRepo().Insert(s.Ctx(),
+		newDep("bd-dep-evt-a", "bd-dep-evt-b", types.DepBlocks), "tester", domain.DepInsertOpts{EmitEvent: true}))
+
+	var count int
+	s.Require().NoError(s.Runner().QueryRowContext(s.Ctx(),
+		"SELECT COUNT(*) FROM events WHERE issue_id = ? AND event_type = ?",
+		"bd-dep-evt-a", string(types.EventDependencyAdded)).Scan(&count))
+	s.Equal(1, count, "one dependency_added event expected on the source")
+
+	var actor, newValue string
+	s.Require().NoError(s.Runner().QueryRowContext(s.Ctx(),
+		"SELECT actor, new_value FROM events WHERE issue_id = ? AND event_type = ?",
+		"bd-dep-evt-a", string(types.EventDependencyAdded)).Scan(&actor, &newValue))
+	s.Equal("tester", actor)
+	s.Equal("Added dependency: bd-dep-evt-a blocks bd-dep-evt-b", newValue)
+}
+
+// depInsertWithoutEmitEventRecordsNoEvent proves the create-with-deps path (which
+// calls Insert directly with EmitEvent unset) records no event, matching the
+// embedded PersistDependencies behavior — the edge is created but has no history.
+func (s *testSuite) depInsertWithoutEmitEventRecordsNoEvent() {
+	s.seedIssueRow("bd-dep-evt-noemit-a")
+	s.seedIssueRow("bd-dep-evt-noemit-b")
+	r := s.depRepo()
+	s.Require().NoError(r.Insert(s.Ctx(),
+		newDep("bd-dep-evt-noemit-a", "bd-dep-evt-noemit-b", types.DepBlocks), "tester", domain.DepInsertOpts{}))
+
+	var eventCount int
+	s.Require().NoError(s.Runner().QueryRowContext(s.Ctx(),
+		"SELECT COUNT(*) FROM events WHERE issue_id = ? AND event_type = ?",
+		"bd-dep-evt-noemit-a", string(types.EventDependencyAdded)).Scan(&eventCount))
+	s.Equal(0, eventCount, "Insert without EmitEvent must record no dependency_added event")
+
+	// The edge itself must still exist — only the event is suppressed.
+	var edgeCount int
+	s.Require().NoError(s.Runner().QueryRowContext(s.Ctx(),
+		"SELECT COUNT(*) FROM dependencies WHERE issue_id = ? AND depends_on_issue_id = ?",
+		"bd-dep-evt-noemit-a", "bd-dep-evt-noemit-b").Scan(&edgeCount))
+	s.Equal(1, edgeCount, "the dependency edge must be created even with EmitEvent unset")
+}
+
+// depInsertIdempotentNoDoubleEvent proves the idempotent same-type re-add (a
+// metadata-only refresh that returns before the INSERT) records no second event
+// even with EmitEvent set on both calls.
+func (s *testSuite) depInsertIdempotentNoDoubleEvent() {
+	s.seedIssueRow("bd-dep-evt-idem-a")
+	s.seedIssueRow("bd-dep-evt-idem-b")
+	r := s.depRepo()
+	dep := newDep("bd-dep-evt-idem-a", "bd-dep-evt-idem-b", types.DepBlocks)
+	s.Require().NoError(r.Insert(s.Ctx(), dep, "tester", domain.DepInsertOpts{EmitEvent: true}))
+	dep.Metadata = `{"v":2}`
+	s.Require().NoError(r.Insert(s.Ctx(), dep, "tester", domain.DepInsertOpts{EmitEvent: true}))
+
+	var count int
+	s.Require().NoError(s.Runner().QueryRowContext(s.Ctx(),
+		"SELECT COUNT(*) FROM events WHERE issue_id = ? AND event_type = ?",
+		"bd-dep-evt-idem-a", string(types.EventDependencyAdded)).Scan(&count))
+	s.Equal(1, count, "idempotent same-type re-add must not emit a second dependency_added event")
+}
+
+// depDeleteEmitsRemovedEvent proves the repo records a dependency_removed event
+// when a real edge is deleted with EmitEvent set (the explicit dep remove verb).
+func (s *testSuite) depDeleteEmitsRemovedEvent() {
+	s.seedIssueRow("bd-dep-evt-rm-a")
+	s.seedIssueRow("bd-dep-evt-rm-b")
+	r := s.depRepo()
+	s.Require().NoError(r.Insert(s.Ctx(),
+		newDep("bd-dep-evt-rm-a", "bd-dep-evt-rm-b", types.DepBlocks), "tester", domain.DepInsertOpts{}))
+
+	res, err := r.Delete(s.Ctx(), "bd-dep-evt-rm-a", "bd-dep-evt-rm-b", "remover", domain.DepInsertOpts{EmitEvent: true})
+	s.Require().NoError(err)
+	s.True(res.Found)
+
+	var count int
+	s.Require().NoError(s.Runner().QueryRowContext(s.Ctx(),
+		"SELECT COUNT(*) FROM events WHERE issue_id = ? AND event_type = ?",
+		"bd-dep-evt-rm-a", string(types.EventDependencyRemoved)).Scan(&count))
+	s.Equal(1, count, "one dependency_removed event expected on the source")
+
+	var actor, newValue string
+	s.Require().NoError(s.Runner().QueryRowContext(s.Ctx(),
+		"SELECT actor, new_value FROM events WHERE issue_id = ? AND event_type = ?",
+		"bd-dep-evt-rm-a", string(types.EventDependencyRemoved)).Scan(&actor, &newValue))
+	s.Equal("remover", actor)
+	s.Equal("Removed dependency on bd-dep-evt-rm-b", newValue)
+}
+
+// depDeleteMissingEdgeEmitsNoEvent proves a no-op delete of a non-existent edge
+// records nothing (the type lookup short-circuits before the emission), even
+// with EmitEvent set.
+func (s *testSuite) depDeleteMissingEdgeEmitsNoEvent() {
+	s.seedIssueRow("bd-dep-evt-noop-a")
+	s.seedIssueRow("bd-dep-evt-noop-b")
+	res, err := s.depRepo().Delete(s.Ctx(), "bd-dep-evt-noop-a", "bd-dep-evt-noop-b", "remover", domain.DepInsertOpts{EmitEvent: true})
+	s.Require().NoError(err)
+	s.False(res.Found)
+
+	var count int
+	s.Require().NoError(s.Runner().QueryRowContext(s.Ctx(),
+		"SELECT COUNT(*) FROM events WHERE issue_id = ? AND event_type = ?",
+		"bd-dep-evt-noop-a", string(types.EventDependencyRemoved)).Scan(&count))
+	s.Equal(0, count, "no-op delete must not emit a dependency_removed event")
 }
 
 func (s *testSuite) depCycleAcyclic() {

--- a/internal/storage/domain/dependency.go
+++ b/internal/storage/domain/dependency.go
@@ -100,6 +100,13 @@ type DepInsertOpts struct {
 	UseWispsTable      bool
 	HierarchyValidated bool // Set only after ValidateBlockingHierarchy on the same repository/UOW.
 	CycleValidated     bool // Set only after HasCycle or a whole-graph check on the same repository/UOW.
+	// EmitEvent records a dependency_added / dependency_removed event on the
+	// source's event table for a genuine edge add/remove. Only the explicit dep
+	// verbs (AddDependency/AddDependencies/RemoveDependency and their wisp twins)
+	// set it; create-with-deps calls Insert directly with it unset so an implicit
+	// parent-child / --deps / waits-for edge produces no event, matching the
+	// embedded plumbing (issueops PersistDependencies emits nothing on create).
+	EmitEvent bool
 }
 
 type DepListOpts struct {
@@ -259,7 +266,7 @@ func (u *dependencyUseCaseImpl) add(ctx context.Context, dep *types.Dependency, 
 		}
 	}
 
-	if err := u.depRepo.Insert(ctx, dep, actor, DepInsertOpts{UseWispsTable: useWisp, HierarchyValidated: true, CycleValidated: true}); err != nil {
+	if err := u.depRepo.Insert(ctx, dep, actor, DepInsertOpts{UseWispsTable: useWisp, HierarchyValidated: true, CycleValidated: true, EmitEvent: true}); err != nil {
 		// The retype conflict is a user-facing error whose message already
 		// matches embedded verbatim; pass it through unwrapped so the CLI does
 		// not prepend "add dep: insert:" (#4547 F-1).
@@ -288,7 +295,7 @@ func (u *dependencyUseCaseImpl) removeDep(ctx context.Context, sourceID, depends
 	if sourceID == "" || dependsOnID == "" {
 		return fmt.Errorf("remove dep: sourceID and dependsOnID must not be empty")
 	}
-	if _, err := u.depRepo.Delete(ctx, sourceID, dependsOnID, actor, DepInsertOpts{UseWispsTable: useWisp}); err != nil {
+	if _, err := u.depRepo.Delete(ctx, sourceID, dependsOnID, actor, DepInsertOpts{UseWispsTable: useWisp, EmitEvent: true}); err != nil {
 		return fmt.Errorf("remove dep %s -> %s: %w", sourceID, dependsOnID, err)
 	}
 	return nil
@@ -560,7 +567,11 @@ func (u *dependencyUseCaseImpl) addBulk(ctx context.Context, deps []*types.Depen
 	if len(deps) == 0 {
 		return BulkAddDepsResult{Added: []*types.Dependency{}}, nil
 	}
-	insertOpts := DepInsertOpts{UseWispsTable: useWisp, HierarchyValidated: true, CycleValidated: true}
+	// AddDependencies is the explicit `bd dep add` / `bd link` verb on the
+	// proxied server (cmd/bd/dep_proxied_server.go, link_proxied_server.go), so
+	// each genuine new edge records a dependency_added event — unlike
+	// create-with-deps, which calls depRepo.Insert directly without EmitEvent.
+	insertOpts := DepInsertOpts{UseWispsTable: useWisp, HierarchyValidated: true, CycleValidated: true, EmitEvent: true}
 	// Validate the entire input shape before the first write. Multi-edge callers
 	// run in a UOW, but this also avoids an avoidable partial prefix for direct
 	// use-case consumers.

--- a/internal/storage/embeddeddolt/dependencies.go
+++ b/internal/storage/embeddeddolt/dependencies.go
@@ -21,7 +21,7 @@ func (s *EmbeddedDoltStore) AddDependency(ctx context.Context, dep *types.Depend
 // RemoveDependency removes a dependency between two issues.
 func (s *EmbeddedDoltStore) RemoveDependency(ctx context.Context, issueID, dependsOnID string, actor string) error {
 	return s.withConn(ctx, true, func(tx *sql.Tx) error {
-		return issueops.RemoveDependencyInTx(ctx, tx, issueID, dependsOnID)
+		return issueops.RemoveDependencyInTx(ctx, tx, issueID, dependsOnID, actor)
 	})
 }
 

--- a/internal/storage/embeddeddolt/transaction.go
+++ b/internal/storage/embeddeddolt/transaction.go
@@ -110,7 +110,7 @@ func (t *embeddedTransaction) AddDependency(ctx context.Context, dep *types.Depe
 }
 
 func (t *embeddedTransaction) AddDependencyWithOptions(ctx context.Context, dep *types.Dependency, actor string, addOpts storage.DependencyAddOptions) error {
-	_, _, _, depTable := issueops.WispTableRouting(issueops.IsActiveWispInTx(ctx, t.tx, dep.IssueID))
+	_, _, eventTable, depTable := issueops.WispTableRouting(issueops.IsActiveWispInTx(ctx, t.tx, dep.IssueID))
 	if err := issueops.AddDependencyInTx(ctx, t.tx, dep, actor, issueops.AddDependencyOpts{
 		IsCrossPrefix:  types.ExtractPrefix(dep.IssueID) != types.ExtractPrefix(dep.DependsOnID),
 		SkipCycleCheck: addOpts.SkipCycleCheck,
@@ -118,6 +118,9 @@ func (t *embeddedTransaction) AddDependencyWithOptions(ctx context.Context, dep 
 		return err
 	}
 	t.dirty.MarkDirty(depTable)
+	// AddDependencyInTx records a dependency_added event on the source's event
+	// table; stage it so the event commits with the edge.
+	t.dirty.MarkDirty(eventTable)
 	return nil
 }
 
@@ -133,8 +136,14 @@ func (t *embeddedTransaction) CycleThroughEdges(ctx context.Context, edges [][2]
 }
 
 func (t *embeddedTransaction) RemoveDependency(ctx context.Context, issueID, dependsOnID string, actor string) error {
-	t.dirty.MarkDirty("dependencies")
-	return issueops.RemoveDependencyInTx(ctx, t.tx, issueID, dependsOnID)
+	// Route dirty marking on the source's wisp status: a wisp-source remove
+	// stages wisp_dependencies/wisp_events, a permanent one dependencies/events.
+	// RemoveDependencyInTx records a dependency_removed event on the source's
+	// event table when a row is deleted; stage it so it commits with the edge.
+	_, _, eventTable, depTable := issueops.WispTableRouting(issueops.IsActiveWispInTx(ctx, t.tx, issueID))
+	t.dirty.MarkDirty(depTable)
+	t.dirty.MarkDirty(eventTable)
+	return issueops.RemoveDependencyInTx(ctx, t.tx, issueID, dependsOnID, actor)
 }
 
 func (t *embeddedTransaction) GetDependencyRecords(ctx context.Context, issueID string) ([]*types.Dependency, error) {

--- a/internal/storage/issueops/dependencies.go
+++ b/internal/storage/issueops/dependencies.go
@@ -242,6 +242,18 @@ func AddDependencyInTx(ctx context.Context, tx *sql.Tx, dep *types.Dependency, a
 	}
 
 	srcIsWisp := writeTable == "wisp_dependencies"
+
+	// Record the dependency_added event on the source issue's event table so the
+	// bd CLI and library callers observing an issue's history see the new edge.
+	// The source's event table routes the same way as its dependency write table
+	// (wisp_dependencies -> wisp_events). This runs only on the genuine new-edge
+	// path: the idempotent same-type re-add returned earlier without emitting.
+	_, _, eventTable, _ := WispTableRouting(srcIsWisp)
+	if err := RecordEventInTable(ctx, tx, eventTable, dep.IssueID, types.EventDependencyAdded, actor,
+		fmt.Sprintf("Added dependency: %s %s %s", dep.IssueID, dep.Type, dep.DependsOnID)); err != nil {
+		return fmt.Errorf("record dependency_added event: %w", err)
+	}
+
 	var affectedIssues, affectedWisps []string
 	var aerr error
 	if srcIsWisp {
@@ -828,12 +840,14 @@ func checkRenameTargetCollision(ctx context.Context, tx *sql.Tx, table, typedCol
 
 // RemoveDependencyInTx removes a dependency between two issues within an
 // existing transaction. Automatically routes to wisp_dependencies if the
-// source issue is an active wisp.
+// source issue is an active wisp. When a row is actually removed it records a
+// dependency_removed event (attributed to actor) on the source's event table;
+// a no-op remove of a missing edge records nothing.
 //
 //nolint:gosec // G201: depTable from WispTableRouting (hardcoded constants)
-func RemoveDependencyInTx(ctx context.Context, tx *sql.Tx, issueID, dependsOnID string) error {
+func RemoveDependencyInTx(ctx context.Context, tx *sql.Tx, issueID, dependsOnID, actor string) error {
 	isWisp := IsActiveWispInTx(ctx, tx, issueID)
-	_, _, _, depTable := WispTableRouting(isWisp)
+	_, _, eventTable, depTable := WispTableRouting(isWisp)
 
 	// Capture the row's type before deleting so we can dispatch the right
 	// affected-set helper. If no row matches, treat as a no-op.
@@ -852,6 +866,14 @@ func RemoveDependencyInTx(ctx context.Context, tx *sql.Tx, issueID, dependsOnID 
 		`DELETE FROM %s WHERE issue_id = ? AND %s = ?`, depTable, DepTargetExpr),
 		issueID, dependsOnID); err != nil {
 		return fmt.Errorf("remove dependency: %w", err)
+	}
+
+	// The lookup above returned early when no row matched, so reaching here means
+	// an edge was actually deleted — record the dependency_removed event on the
+	// source issue's event table for bd CLI / library history observers.
+	if err := RecordEventInTable(ctx, tx, eventTable, issueID, types.EventDependencyRemoved, actor,
+		fmt.Sprintf("Removed dependency on %s", dependsOnID)); err != nil {
+		return fmt.Errorf("record dependency_removed event: %w", err)
 	}
 
 	var affectedIssues, affectedWisps []string


### PR DESCRIPTION
> Stacked on #4900 (S6) → #4899 (S5) → … → #4892 (S1). Base is `feat/guarded-ops-s6-dep-errors`; retarget down the stack as each lands. The diff below is S6b only.

## What

Restores `dependency_added` / `dependency_removed` event emission on `bd dep add` / `bd dep remove`, so the events feed surfaces dependency changes. Emitted on both Dolt write paths, committed atomically with the edge, gated to the explicit dep verb.

## Why

The event types have existed since the original SQLite backend, which emitted them on every add/remove — but the emission was dropped when that backend was removed for the Dolt-only migration and never ported. The constants (and their re-exports) survived with no writer, so `bd dep add`/`remove` recorded nothing and the history/activity view silently omitted dependency changes. This restores the original behavior on the current `bd` write paths (an events row on the source issue with the original descriptive text).

Two correctness details the restore has to get right (both caught pre-merge):
- **Committed with the edge.** The store-level add/remove and the transaction-path (`RunInTransaction` / batch / graph-apply) methods now stage the source's event table (`events` or `wisp_events`) before commit — otherwise the event row dangles in the working set and is lost on the next reset/reconcile.
- **Explicit verb only, consistently.** Only the explicit `bd dep add`/`bd dep remove` verb emits. Create-with-deps (implicit parent-child, `--deps`, waits-for) creates the edge without an event on both backends, so `bd create --parent X` yields identical history regardless of storage backend.

## Verification

- Add/remove emit exactly one event and **commit** it (asserted via `events AS OF 'HEAD'` + clean `dolt_status`); idempotent re-add and no-op remove of a missing edge emit nothing; wisp sources route to `wisp_events`, never `events`.
- Consistency proof: explicit `dep add`/`remove` emit; `bd create --parent`/`--deps` create the edge but emit no `dependency_added` — on both write plumbings.
- `gofmt`/`go vet` clean; `go build ./...` under cgo and `CGO_ENABLED=0`; `golangci-lint` 0 issues.

```bash
go test ./internal/storage/dolt/ -run 'TestDependencyEvent|TestRunInTransaction.*Dependency' -v
go test ./internal/storage/domain/db/ -run 'TestDependencyEventConsistency|TestDependencySQLRepository' -count=1
```
