### PR TITLE
feat(close): optional ExpectedVersion CAS on CloseIssueChecked

### DIFF
--- a/beads.go
+++ b/beads.go
@@ -220,6 +220,7 @@ var (
 	ErrAlreadyClaimed  = storage.ErrAlreadyClaimed
 	ErrNotClaimable    = storage.ErrNotClaimable
 	ErrCloseBlocked    = storage.ErrCloseBlocked
+	ErrVersionMismatch = storage.ErrVersionMismatch
 	ErrSelfDependency  = domain.ErrSelfDependency
 	ErrDependencyCycle = domain.ErrDependencyCycle
 	ErrFieldTooLong    = types.ErrFieldTooLong

--- a/errors_test.go
+++ b/errors_test.go
@@ -28,6 +28,22 @@ func TestReExportCloseBlocked(t *testing.T) {
 	}
 }
 
+// TestReExportVersionMismatch proves the public beads.ErrVersionMismatch alias
+// is the same value as the internal sentinel and composes through errors.Is when
+// wrapped — the property a CloseIssueChecked caller relies on to detect an
+// optimistic-concurrency refusal without importing internal/storage.
+func TestReExportVersionMismatch(t *testing.T) {
+	t.Parallel()
+
+	if beads.ErrVersionMismatch != storage.ErrVersionMismatch {
+		t.Error("beads.ErrVersionMismatch is not the internal sentinel value (identity broken)")
+	}
+	wrapped := fmt.Errorf("x: %w", beads.ErrVersionMismatch)
+	if !errors.Is(wrapped, beads.ErrVersionMismatch) {
+		t.Errorf("errors.Is(wrapped, beads.ErrVersionMismatch) = false; err = %v", wrapped)
+	}
+}
+
 // TestReExportedSentinelIdentity proves each public sentinel is the SAME value
 // as the internal one it aliases, so errors.Is composes across the package
 // boundary without any bridging.
@@ -42,6 +58,7 @@ func TestReExportedSentinelIdentity(t *testing.T) {
 		{"ErrNotFound", beads.ErrNotFound, storage.ErrNotFound},
 		{"ErrAlreadyClaimed", beads.ErrAlreadyClaimed, storage.ErrAlreadyClaimed},
 		{"ErrNotClaimable", beads.ErrNotClaimable, storage.ErrNotClaimable},
+		{"ErrVersionMismatch", beads.ErrVersionMismatch, storage.ErrVersionMismatch},
 		{"ErrSelfDependency", beads.ErrSelfDependency, domain.ErrSelfDependency},
 		{"ErrDependencyCycle", beads.ErrDependencyCycle, domain.ErrDependencyCycle},
 		{"ErrFieldTooLong", beads.ErrFieldTooLong, types.ErrFieldTooLong},

--- a/internal/storage/dolt/close_issue_checked_test.go
+++ b/internal/storage/dolt/close_issue_checked_test.go
@@ -330,3 +330,228 @@ func TestCloseIssueChecked(t *testing.T) {
 		})
 	}
 }
+
+// TestCloseIssueCheckedVersionCAS exercises the optional ExpectedVersion
+// optimistic-concurrency check layered onto the guarded close. The version read
+// and the close share ONE transaction, so a stale version is refused with
+// storage.ErrVersionMismatch and — critically — the transaction rolls back
+// leaving the issue open with no `closed` event (the atomic-refuse property,
+// mirroring the is_blocked guard). The CAS is orthogonal to Force: a stale
+// version is refused even with Force set. A nil ExpectedVersion disables the
+// check, so behavior is unchanged from S2.
+func TestCloseIssueCheckedVersionCAS(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	rowVersion := func(t *testing.T, id string) int64 {
+		t.Helper()
+		iss, err := store.GetIssue(ctx, id)
+		if err != nil {
+			t.Fatalf("GetIssue(%s): %v", id, err)
+		}
+		if iss == nil {
+			t.Fatalf("GetIssue(%s) returned nil issue", id)
+		}
+		return iss.RowVersion
+	}
+	getStatus := func(t *testing.T, id string) types.Status {
+		t.Helper()
+		iss, err := store.GetIssue(ctx, id)
+		if err != nil {
+			t.Fatalf("GetIssue(%s): %v", id, err)
+		}
+		return iss.Status
+	}
+	countClosedEvents := func(t *testing.T, id string) int {
+		t.Helper()
+		events, err := store.GetEvents(ctx, id, 0)
+		if err != nil {
+			t.Fatalf("GetEvents(%s): %v", id, err)
+		}
+		n := 0
+		for _, e := range events {
+			if e.EventType == types.EventClosed {
+				n++
+			}
+		}
+		return n
+	}
+	ptr := func(v int64) *int64 { return &v }
+
+	t.Run("matching version closes", func(t *testing.T) {
+		createPerm(t, ctx, store, "cas-match")
+		v := rowVersion(t, "cas-match")
+		res, err := store.CloseIssueChecked(ctx, "cas-match", "tester",
+			storage.CloseIssueOptions{Reason: "done", ExpectedVersion: ptr(v)})
+		if err != nil {
+			t.Fatalf("close with matching version err = %v, want nil", err)
+		}
+		if res.Unchanged {
+			t.Fatalf("res.Unchanged = true, want false (a real close)")
+		}
+		if got := getStatus(t, "cas-match"); got != types.StatusClosed {
+			t.Fatalf("cas-match status = %q, want closed", got)
+		}
+	})
+
+	t.Run("stale version refuses atomically", func(t *testing.T) {
+		createPerm(t, ctx, store, "cas-stale")
+		v := rowVersion(t, "cas-stale")
+		// v+1 is a version the row provably does not hold.
+		res, err := store.CloseIssueChecked(ctx, "cas-stale", "tester",
+			storage.CloseIssueOptions{Reason: "done", ExpectedVersion: ptr(v + 1)})
+		if !errors.Is(err, storage.ErrVersionMismatch) {
+			t.Fatalf("err = %v, want errors.Is(_, ErrVersionMismatch)", err)
+		}
+		if res.Unchanged {
+			t.Fatalf("res.Unchanged = true on mismatch, want false")
+		}
+		// Atomic refuse: still open, no closed event — the CAS aborted the tx
+		// before the close ran.
+		if got := getStatus(t, "cas-stale"); got == types.StatusClosed {
+			t.Fatalf("cas-stale status = closed after refused close; CAS did not abort")
+		}
+		if n := countClosedEvents(t, "cas-stale"); n != 0 {
+			t.Fatalf("closed event count for cas-stale = %d, want 0 (tx must have rolled back)", n)
+		}
+	})
+
+	t.Run("concurrent write invalidates captured version", func(t *testing.T) {
+		createPerm(t, ctx, store, "cas-concurrent")
+		v1 := rowVersion(t, "cas-concurrent")
+		// A mutating write rewrites row_lock, so the captured v1 is now stale.
+		if err := store.UpdateIssue(ctx, "cas-concurrent",
+			map[string]interface{}{"priority": 1}, "tester"); err != nil {
+			t.Fatalf("UpdateIssue: %v", err)
+		}
+		if v2 := rowVersion(t, "cas-concurrent"); v2 == v1 {
+			t.Fatalf("RowVersion unchanged after UpdateIssue (%d); CAS could not detect the write", v2)
+		}
+		res, err := store.CloseIssueChecked(ctx, "cas-concurrent", "tester",
+			storage.CloseIssueOptions{Reason: "done", ExpectedVersion: ptr(v1)})
+		if !errors.Is(err, storage.ErrVersionMismatch) {
+			t.Fatalf("err = %v, want errors.Is(_, ErrVersionMismatch)", err)
+		}
+		if res.Unchanged {
+			t.Fatalf("res.Unchanged = true on stale close, want false")
+		}
+		if got := getStatus(t, "cas-concurrent"); got == types.StatusClosed {
+			t.Fatalf("cas-concurrent closed despite stale version")
+		}
+	})
+
+	t.Run("nil ExpectedVersion skips the check", func(t *testing.T) {
+		createPerm(t, ctx, store, "cas-nil")
+		res, err := store.CloseIssueChecked(ctx, "cas-nil", "tester",
+			storage.CloseIssueOptions{Reason: "done", ExpectedVersion: nil})
+		if err != nil {
+			t.Fatalf("nil ExpectedVersion close err = %v, want nil (back-compat)", err)
+		}
+		if res.Unchanged {
+			t.Fatalf("res.Unchanged = true, want false (a real close)")
+		}
+		if got := getStatus(t, "cas-nil"); got != types.StatusClosed {
+			t.Fatalf("cas-nil status = %q, want closed", got)
+		}
+	})
+
+	t.Run("Force does not bypass the version check", func(t *testing.T) {
+		createPerm(t, ctx, store, "cas-force")
+		v := rowVersion(t, "cas-force")
+		res, err := store.CloseIssueChecked(ctx, "cas-force", "tester",
+			storage.CloseIssueOptions{Reason: "done", Force: true, ExpectedVersion: ptr(v + 1)})
+		if !errors.Is(err, storage.ErrVersionMismatch) {
+			t.Fatalf("err = %v, want errors.Is(_, ErrVersionMismatch) even with Force", err)
+		}
+		if res.Unchanged {
+			t.Fatalf("res.Unchanged = true on mismatch+Force, want false")
+		}
+		if got := getStatus(t, "cas-force"); got == types.StatusClosed {
+			t.Fatalf("cas-force closed under Force despite stale version; CAS is not orthogonal to Force")
+		}
+	})
+
+	t.Run("missing id returns ErrNotFound", func(t *testing.T) {
+		res, err := store.CloseIssueChecked(ctx, "cas-missing", "tester",
+			storage.CloseIssueOptions{Reason: "done", ExpectedVersion: ptr(1)})
+		if !errors.Is(err, storage.ErrNotFound) {
+			t.Fatalf("err = %v, want errors.Is(_, ErrNotFound) for absent row", err)
+		}
+		if res.Unchanged {
+			t.Fatalf("res.Unchanged = true for missing id, want false")
+		}
+	})
+
+	// The wisp subtests exercise CheckVersionInTx's wisp routing (SELECT row_lock
+	// FROM wisps) and the wisp atomic-refuse seam: closeWispChecked uses a bare
+	// BeginTx with a deferred Rollback (no withRetryTx, matching the package-wide
+	// wisp write pattern), so a stale version must leave the wisp untouched.
+	t.Run("wisp matching version closes", func(t *testing.T) {
+		createWisp(t, ctx, store, "cas-wisp-match")
+		// Reading the version at all requires the wisp route: a read against the
+		// issues table for this id would miss, so a successful close here proves
+		// CheckVersionInTx routed to the wisps table.
+		v := rowVersion(t, "cas-wisp-match")
+		res, err := store.CloseIssueChecked(ctx, "cas-wisp-match", "tester",
+			storage.CloseIssueOptions{Reason: "done", ExpectedVersion: ptr(v)})
+		if err != nil {
+			t.Fatalf("wisp close with matching version err = %v, want nil", err)
+		}
+		if res.Unchanged {
+			t.Fatalf("res.Unchanged = true, want false (a real wisp close)")
+		}
+		if got := getStatus(t, "cas-wisp-match"); got != types.StatusClosed {
+			t.Fatalf("cas-wisp-match status = %q, want closed", got)
+		}
+	})
+
+	t.Run("wisp stale version refuses atomically", func(t *testing.T) {
+		createWisp(t, ctx, store, "cas-wisp-stale")
+		v := rowVersion(t, "cas-wisp-stale")
+		res, err := store.CloseIssueChecked(ctx, "cas-wisp-stale", "tester",
+			storage.CloseIssueOptions{Reason: "done", ExpectedVersion: ptr(v + 1)})
+		if !errors.Is(err, storage.ErrVersionMismatch) {
+			t.Fatalf("wisp err = %v, want errors.Is(_, ErrVersionMismatch)", err)
+		}
+		if res.Unchanged {
+			t.Fatalf("res.Unchanged = true on wisp mismatch, want false")
+		}
+		// closeWispChecked's deferred Rollback must discard the tx: the wisp stays
+		// open with no closed event (atomic-refuse on the wisp path).
+		if got := getStatus(t, "cas-wisp-stale"); got == types.StatusClosed {
+			t.Fatalf("cas-wisp-stale status = closed after refused close; wisp CAS did not abort")
+		}
+		if n := countClosedEvents(t, "cas-wisp-stale"); n != 0 {
+			t.Fatalf("closed event count for cas-wisp-stale = %d, want 0 (wisp tx must have rolled back)", n)
+		}
+	})
+
+	// Idempotency composes with the CAS: re-closing an already-closed issue with
+	// its CURRENT (post-close) version passes the version check and short-circuits
+	// to the idempotent Unchanged result — not a spurious mismatch and not a
+	// second close event.
+	t.Run("already closed re-close with post-close version is idempotent", func(t *testing.T) {
+		createPerm(t, ctx, store, "cas-idem")
+		if _, err := store.CloseIssueChecked(ctx, "cas-idem", "tester",
+			storage.CloseIssueOptions{Reason: "done"}); err != nil {
+			t.Fatalf("initial close err = %v, want nil", err)
+		}
+		postClose := rowVersion(t, "cas-idem")
+		if n := countClosedEvents(t, "cas-idem"); n != 1 {
+			t.Fatalf("closed event count after first close = %d, want 1", n)
+		}
+		res, err := store.CloseIssueChecked(ctx, "cas-idem", "tester",
+			storage.CloseIssueOptions{Reason: "again", ExpectedVersion: ptr(postClose)})
+		if err != nil {
+			t.Fatalf("re-close with post-close version err = %v, want nil (CAS passes, idempotent)", err)
+		}
+		if !res.Unchanged {
+			t.Fatalf("res.Unchanged = false, want true (already closed)")
+		}
+		if n := countClosedEvents(t, "cas-idem"); n != 1 {
+			t.Fatalf("closed event count after idempotent re-close = %d, want 1 (no second close)", n)
+		}
+	})
+}

--- a/internal/storage/dolt/issues.go
+++ b/internal/storage/dolt/issues.go
@@ -437,9 +437,12 @@ func (s *DoltStore) CloseIssue(ctx context.Context, id string, reason string, ac
 }
 
 // CloseIssueChecked closes an issue but refuses with storage.ErrCloseBlocked
-// when it is still blocked (is_blocked=1) unless opts.Force is set. The guard
-// and the close share one transaction, so the check is atomic (no TOCTOU).
-// Mirrors CloseIssue's Dolt-specific concerns (wisp routing, DOLT_ADD/COMMIT).
+// when it is still blocked (is_blocked=1) unless opts.Force is set, and — when
+// opts.ExpectedVersion is non-nil — with storage.ErrVersionMismatch when the
+// row's current RowVersion no longer matches (an orthogonal CAS that Force does
+// not bypass). Both checks and the close share one transaction, so they are
+// atomic (no TOCTOU). Mirrors CloseIssue's Dolt-specific concerns (wisp routing,
+// DOLT_ADD/COMMIT).
 func (s *DoltStore) CloseIssueChecked(ctx context.Context, id string, actor string, opts storage.CloseIssueOptions) (storage.CloseIssueResult, error) {
 	// Route ephemeral IDs to wisps table (falls through for promoted wisps).
 	// Wisps skip DOLT_COMMIT since they live in dolt_ignored tables.
@@ -455,7 +458,7 @@ func (s *DoltStore) CloseIssueChecked(ctx context.Context, id string, actor stri
 	// event are written (the atomic-refuse property).
 	var result storage.CloseIssueResult
 	if err := s.withRetryTx(ctx, func(tx *sql.Tx) error {
-		res, err := issueops.CloseIssueCheckedInTx(ctx, tx, id, opts.Reason, actor, opts.Session, opts.Force)
+		res, err := issueops.CloseIssueCheckedInTx(ctx, tx, id, opts.Reason, actor, opts.Session, opts.Force, opts.ExpectedVersion)
 		if err != nil {
 			return err
 		}

--- a/internal/storage/dolt/wisps.go
+++ b/internal/storage/dolt/wisps.go
@@ -218,10 +218,20 @@ func (s *DoltStore) closeWisp(ctx context.Context, id string, reason string, act
 
 // closeWispChecked closes a wisp with the is_blocked guard, mirroring closeWisp
 // but refusing with storage.ErrCloseBlocked when the wisp is still blocked
-// unless opts.Force is set. The guard and the close share the same transaction;
-// wisps live in dolt_ignored tables, so there is no DOLT_COMMIT. On a guard
-// rejection the deferred Rollback discards the transaction — no close or event
-// is written.
+// unless opts.Force is set — and, when opts.ExpectedVersion is non-nil, with
+// storage.ErrVersionMismatch when the row's RowVersion no longer matches (an
+// orthogonal CAS that Force does not bypass). The checks and the close share the
+// same transaction; wisps live in dolt_ignored tables, so there is no
+// DOLT_COMMIT. On any rejection the deferred Rollback discards the transaction —
+// no close or event is written.
+//
+// Unlike the permanent path, the wisp close uses a bare BeginTx/Commit with no
+// withRetryTx (consistent with the rest of the wisp write path — do not add one
+// here). So the CAS's read-side limb still returns ErrVersionMismatch for a
+// writer that committed before this tx began, but a CONCURRENT wisp mutation
+// that loses the race at commit surfaces as a transaction/serialization error
+// rather than ErrVersionMismatch. Either way atomicity holds: no lost update and
+// no stale close.
 func (s *DoltStore) closeWispChecked(ctx context.Context, id string, actor string, opts storage.CloseIssueOptions) (storage.CloseIssueResult, error) {
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
@@ -229,7 +239,7 @@ func (s *DoltStore) closeWispChecked(ctx context.Context, id string, actor strin
 	}
 	defer func() { _ = tx.Rollback() }()
 
-	res, err := issueops.CloseIssueCheckedInTx(ctx, tx, id, opts.Reason, actor, opts.Session, opts.Force)
+	res, err := issueops.CloseIssueCheckedInTx(ctx, tx, id, opts.Reason, actor, opts.Session, opts.Force, opts.ExpectedVersion)
 	if err != nil {
 		return storage.CloseIssueResult{}, err
 	}

--- a/internal/storage/embeddeddolt/close_issue_checked_test.go
+++ b/internal/storage/embeddeddolt/close_issue_checked_test.go
@@ -78,3 +78,87 @@ func TestEmbeddedCloseIssueChecked(t *testing.T) {
 		t.Fatalf("cic-target status = %q after force, want closed", iss.Status)
 	}
 }
+
+// TestEmbeddedCloseIssueCheckedVersionCAS proves the ExpectedVersion CAS wires
+// through the EmbeddedDoltStore's withConn wrapper: a matching version closes, a
+// stale version is refused atomically with storage.ErrVersionMismatch (issue
+// stays open, no closed event) even under Force, and a nil ExpectedVersion is
+// unchanged behavior. The compare-and-swap core is the shared
+// issueops.CloseIssueCheckedInTx/CheckVersionInTx already covered against a real
+// engine by the dolt package; this test proves the embedded wrapper threads it
+// and rolls back.
+func TestEmbeddedCloseIssueCheckedVersionCAS(t *testing.T) {
+	skipUnlessEmbeddedDolt(t)
+	te := newTestEnv(t, "casv")
+	ctx := t.Context()
+	ptr := func(v int64) *int64 { return &v }
+
+	create := func(id string) {
+		iss := &types.Issue{ID: id, Title: id, Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask}
+		if err := te.store.CreateIssue(ctx, iss, "tester"); err != nil {
+			t.Fatalf("create %s: %v", id, err)
+		}
+	}
+	rowVersion := func(id string) int64 {
+		iss, err := te.store.GetIssue(ctx, id)
+		if err != nil {
+			t.Fatalf("GetIssue(%s): %v", id, err)
+		}
+		return iss.RowVersion
+	}
+
+	// Matching version closes.
+	create("casv-match")
+	res, err := te.store.CloseIssueChecked(ctx, "casv-match", "tester",
+		storage.CloseIssueOptions{Reason: "done", ExpectedVersion: ptr(rowVersion("casv-match"))})
+	if err != nil {
+		t.Fatalf("matching-version close err = %v, want nil", err)
+	}
+	if res.Unchanged {
+		t.Fatalf("res.Unchanged = true, want false (a real close)")
+	}
+	if iss, _ := te.store.GetIssue(ctx, "casv-match"); iss.Status != types.StatusClosed {
+		t.Fatalf("casv-match status = %q, want closed", iss.Status)
+	}
+
+	// Stale version refuses atomically, even with Force.
+	create("casv-stale")
+	stale := rowVersion("casv-stale") + 1
+	res, err = te.store.CloseIssueChecked(ctx, "casv-stale", "tester",
+		storage.CloseIssueOptions{Reason: "done", Force: true, ExpectedVersion: ptr(stale)})
+	if !errors.Is(err, storage.ErrVersionMismatch) {
+		t.Fatalf("stale close err = %v, want errors.Is(_, ErrVersionMismatch) even with Force", err)
+	}
+	if res.Unchanged {
+		t.Fatalf("res.Unchanged = true on mismatch, want false")
+	}
+	iss, err := te.store.GetIssue(ctx, "casv-stale")
+	if err != nil {
+		t.Fatalf("GetIssue: %v", err)
+	}
+	if iss.Status == types.StatusClosed {
+		t.Fatalf("casv-stale closed after refusal; withConn did not roll back")
+	}
+	events, err := te.store.GetEvents(ctx, "casv-stale", 0)
+	if err != nil {
+		t.Fatalf("GetEvents: %v", err)
+	}
+	for _, e := range events {
+		if e.EventType == types.EventClosed {
+			t.Fatalf("closed event recorded despite version mismatch (tx must roll back)")
+		}
+	}
+
+	// nil ExpectedVersion is unchanged behavior.
+	res, err = te.store.CloseIssueChecked(ctx, "casv-stale", "tester",
+		storage.CloseIssueOptions{Reason: "done", ExpectedVersion: nil})
+	if err != nil {
+		t.Fatalf("nil-version close err = %v, want nil (back-compat)", err)
+	}
+	if res.Unchanged {
+		t.Fatalf("res.Unchanged = true on nil-version close of open issue, want false")
+	}
+	if iss, _ := te.store.GetIssue(ctx, "casv-stale"); iss.Status != types.StatusClosed {
+		t.Fatalf("casv-stale status = %q after nil-version close, want closed", iss.Status)
+	}
+}

--- a/internal/storage/embeddeddolt/issues.go
+++ b/internal/storage/embeddeddolt/issues.go
@@ -134,13 +134,16 @@ func (s *EmbeddedDoltStore) CloseIssue(ctx context.Context, id string, reason st
 }
 
 // CloseIssueChecked closes an issue but refuses with storage.ErrCloseBlocked
-// when it is still blocked (is_blocked=1) unless opts.Force is set. The guard
-// and the close share one transaction, so the check is atomic (no TOCTOU).
-// Delegates SQL work to issueops; EmbeddedDolt auto-commits the transaction.
+// when it is still blocked (is_blocked=1) unless opts.Force is set, and — when
+// opts.ExpectedVersion is non-nil — with storage.ErrVersionMismatch when the
+// row's current RowVersion no longer matches (an orthogonal CAS that Force does
+// not bypass). Both checks and the close share one transaction, so they are
+// atomic (no TOCTOU). Delegates SQL work to issueops; EmbeddedDolt auto-commits
+// the transaction.
 func (s *EmbeddedDoltStore) CloseIssueChecked(ctx context.Context, id string, actor string, opts storage.CloseIssueOptions) (storage.CloseIssueResult, error) {
 	var result storage.CloseIssueResult
 	err := s.withConn(ctx, true, func(tx *sql.Tx) error {
-		res, err := issueops.CloseIssueCheckedInTx(ctx, tx, id, opts.Reason, actor, opts.Session, opts.Force)
+		res, err := issueops.CloseIssueCheckedInTx(ctx, tx, id, opts.Reason, actor, opts.Session, opts.Force, opts.ExpectedVersion)
 		if err != nil {
 			return err
 		}

--- a/internal/storage/issueops/close.go
+++ b/internal/storage/issueops/close.go
@@ -32,7 +32,20 @@ func CloseIssueWithoutEventInTx(ctx context.Context, tx DBTX, id string, reason,
 // storage.ErrCloseBlocked when it is still blocked (is_blocked=1) unless force
 // is set. The guard (IsBlockedInTx) and the close (CloseIssueInTx) share the
 // SAME transaction, so no blocker can clear between the check and the close.
-func CloseIssueCheckedInTx(ctx context.Context, tx DBTX, id, reason, actor, session string, force bool) (*CloseResult, error) {
+//
+// When expectedVersion is non-nil it adds an ORTHOGONAL optimistic-concurrency
+// precondition: the row's current RowVersion (row_lock) must still equal
+// *expectedVersion or the close refuses with storage.ErrVersionMismatch. This
+// runs first — before the is_blocked guard and before force short-circuits it —
+// so force bypasses only the is_blocked guard, never the version check. Because
+// the read shares this transaction, a mismatch returns before any write and the
+// transaction rolls back with the issue unchanged (a true compare-and-swap).
+func CloseIssueCheckedInTx(ctx context.Context, tx DBTX, id, reason, actor, session string, force bool, expectedVersion *int64) (*CloseResult, error) {
+	if expectedVersion != nil {
+		if err := CheckVersionInTx(ctx, tx, id, *expectedVersion); err != nil {
+			return nil, err
+		}
+	}
 	if !force {
 		// The blocked guard only has meaning for an open→closed transition. An
 		// already-closed row is an idempotent no-op (Unchanged=true per the

--- a/internal/storage/issueops/close.go
+++ b/internal/storage/issueops/close.go
@@ -40,6 +40,10 @@ func CloseIssueWithoutEventInTx(ctx context.Context, tx DBTX, id string, reason,
 // so force bypasses only the is_blocked guard, never the version check. Because
 // the read shares this transaction, a mismatch returns before any write and the
 // transaction rolls back with the issue unchanged (a true compare-and-swap).
+// row_lock only tracks lifecycle/ownership writes (status, assignee, started_at),
+// so this guards against a concurrent lifecycle change — not against concurrent
+// label, dependency, rename, or is_blocked writes that leave row_lock untouched
+// (see the freshRowLock invariant in lease.go).
 func CloseIssueCheckedInTx(ctx context.Context, tx DBTX, id, reason, actor, session string, force bool, expectedVersion *int64) (*CloseResult, error) {
 	if expectedVersion != nil {
 		if err := CheckVersionInTx(ctx, tx, id, *expectedVersion); err != nil {

--- a/internal/storage/issueops/version.go
+++ b/internal/storage/issueops/version.go
@@ -1,0 +1,48 @@
+package issueops
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+
+	"github.com/steveyegge/beads/internal/storage"
+)
+
+// CheckVersionInTx reads the current row_lock (the RowVersion token) for id and
+// returns ErrVersionMismatch (wrapped with both values) when it differs from
+// expected. Routes to the issues or wisps table. Returns ErrNotFound when the
+// row is absent. The read shares the caller's transaction, so pairing it with a
+// mutation in the same tx yields a true compare-and-swap.
+//
+// The CAS has two limbs, and the read-side check here is the first: it refuses
+// any writer that committed a row_lock change BEFORE the close's transaction
+// began (the version it reads is already stale). The second limb lives on the
+// retry-wrapped permanent close path — a writer that commits DURING the close's
+// transaction collides on this same row_lock cell at commit time, which
+// withRetryTx replays; the replayed attempt then re-reads the new version here
+// and refuses. Together they close the read-then-write window that a bare
+// read-then-write would leave open.
+//
+//nolint:gosec // G201: table name comes from WispTableRouting (hardcoded constants)
+func CheckVersionInTx(ctx context.Context, tx DBTX, id string, expected int64) error {
+	isWisp := IsActiveWispInTx(ctx, tx, id)
+	issueTable, _, _, _ := WispTableRouting(isWisp)
+
+	// row_lock is NOT NULL DEFAULT 0, but scan defensively so a NULL maps to 0
+	// rather than erroring (mirrors scan.go's RowVersion handling).
+	var current sql.NullInt64
+	err := tx.QueryRowContext(ctx,
+		fmt.Sprintf("SELECT row_lock FROM %s WHERE id = ?", issueTable), id,
+	).Scan(&current)
+	if errors.Is(err, sql.ErrNoRows) {
+		return fmt.Errorf("%w: issue %s", storage.ErrNotFound, id)
+	}
+	if err != nil {
+		return fmt.Errorf("failed to read row version for %s: %w", id, err)
+	}
+	if current.Int64 != expected {
+		return fmt.Errorf("%w: expected %d, got %d", storage.ErrVersionMismatch, expected, current.Int64)
+	}
+	return nil
+}

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -231,6 +231,14 @@ type CloseIssueOptions struct {
 	// pointer, not an int64, so nil ("no check") is distinct from a caller that
 	// requires version 0. Force bypasses only the is_blocked guard, not this
 	// version check.
+	//
+	// RowVersion tracks lifecycle/ownership writes only — it is rewritten by
+	// status, assignee, and started_at changes (claim, close, reclaim, unclaim,
+	// updateIssueInTx). So this is a "close only if the issue's lifecycle state
+	// is unchanged" guard, NOT an all-columns check: concurrent label, dependency,
+	// rename, is_blocked, or compaction-only writes intentionally do not bump
+	// row_lock and are not caught here (see the freshRowLock invariant in
+	// internal/storage/issueops/lease.go).
 	ExpectedVersion *int64
 }
 

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -50,6 +50,12 @@ var ErrPrefixMismatch = errors.New("prefix mismatch")
 // or an open blocking gate). Bypass with CloseIssueOptions.Force.
 var ErrCloseBlocked = errors.New("cannot close blocked issue")
 
+// ErrVersionMismatch is returned by a *Checked op given an ExpectedVersion that
+// no longer matches the row's current version (row_lock) — an optimistic
+// concurrency failure. Callers errors.Is it to distinguish a lost-update
+// precondition from other errors.
+var ErrVersionMismatch = errors.New("version mismatch")
+
 // Storage is the interface satisfied by *dolt.DoltStore.
 // Consumers depend on this interface rather than on the concrete type so that
 // alternative implementations (mocks, proxies, etc.) can be substituted.
@@ -73,8 +79,12 @@ type Storage interface {
 	// CloseIssueChecked closes an issue, but refuses with ErrCloseBlocked when
 	// the issue is still blocked (is_blocked=1) unless opts.Force is set. The
 	// blocked-check and the close run in ONE transaction, so the guard is atomic
-	// (no TOCTOU). Already-closed is an idempotent success with Unchanged=true; a
-	// missing issue returns ErrNotFound.
+	// (no TOCTOU). When opts.ExpectedVersion is non-nil it adds an orthogonal
+	// optimistic-concurrency precondition: the close proceeds only if the issue's
+	// current RowVersion still equals *opts.ExpectedVersion, else it refuses with
+	// ErrVersionMismatch atomically (Force does NOT bypass this check). Already-
+	// closed is an idempotent success with Unchanged=true; a missing issue returns
+	// ErrNotFound.
 	CloseIssueChecked(ctx context.Context, id string, actor string, opts CloseIssueOptions) (CloseIssueResult, error)
 	DeleteIssue(ctx context.Context, id string) error
 	SearchIssues(ctx context.Context, query string, filter types.IssueFilter) ([]*types.Issue, error)
@@ -213,6 +223,15 @@ type CloseIssueOptions struct {
 	Reason  string
 	Session string
 	Force   bool // bypass the is_blocked guard (mirrors `bd close --force`)
+	// ExpectedVersion, when non-nil, gates the close on an optimistic-concurrency
+	// check: the close proceeds only if the issue's current RowVersion (the
+	// row_lock token) equals *ExpectedVersion, otherwise it refuses with
+	// ErrVersionMismatch atomically (the version read and the close share one
+	// transaction). nil disables the check, leaving behavior unchanged. It is a
+	// pointer, not an int64, so nil ("no check") is distinct from a caller that
+	// requires version 0. Force bypasses only the is_blocked guard, not this
+	// version check.
+	ExpectedVersion *int64
 }
 
 // CloseIssueResult reports the outcome of CloseIssueChecked.


### PR DESCRIPTION
> Stacked on #4902 (S6b) → #4900 (S6) → … → #4892 (S1). Base is `feat/guarded-ops-s6b-dep-events`; retarget down the stack as each lands. The diff below is S5b only.

## What

Adds an optional compare-and-swap to `CloseIssueChecked`: the caller may pass the row's expected version (the `RowVersion` / `row_lock` token), and the close proceeds only if the row still has that version — otherwise it refuses with a typed `beads.ErrVersionMismatch`, atomically. When no version is supplied, behavior is unchanged.

## Why

`CloseIssueChecked` already guards a close on `is_blocked` in one transaction. But a caller that reads an issue and then closes it can't express "only if it hasn't changed since I read it" — a lost-update window. The optional `ExpectedVersion` closes that: the version read and the close share one transaction, so it's a true compare-and-swap with no read-then-write gap. This is the engine primitive the `bd` CLI (and the library's own call sites) need for optimistic concurrency on close.

`Force` bypasses only the `is_blocked` guard, never the version check — the CAS is an orthogonal precondition. The check has two limbs: the read-side comparison catches a writer that committed before the close began, and on the retry-wrapped path a commit-time `row_lock` conflict is replayed so the re-read refuses.

## Verification

- Match closes; stale version refuses atomically — `errors.Is(err, ErrVersionMismatch)`, issue still open, zero `closed` events (the tx rolled back); a committed concurrent write invalidates a captured version; nil `ExpectedVersion` is unchanged behavior; `Force: true` with a stale version still refuses; missing id → `ErrNotFound`.
- Wisp sources route to the `wisps` table; an already-closed re-close with the post-close version stays idempotent (`Unchanged`), not a spurious mismatch. Covered on both DoltStore and EmbeddedDoltStore.
- `gofmt`/`go vet` clean; `go build ./...` under cgo and `CGO_ENABLED=0`; `golangci-lint` 0 issues.

```bash
go test ./internal/storage/dolt/ -run TestCloseIssueCheckedVersionCAS -v
go test . -run TestReExportVersionMismatch
```
