### PR TITLE
refactor(cli): bd close delegates to the engine's guarded close

### DIFF
--- a/cmd/bd/close.go
+++ b/cmd/bd/close.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -106,6 +107,7 @@ the flags appear in the command line.`,
 		// Direct mode
 		closedIssues := []*types.Issue{}
 		closedCount := 0
+		alreadyClosed := 0
 		firstClosedID := ""
 
 		for i, id := range resolvedIDs {
@@ -143,42 +145,58 @@ the flags appear in the command line.`,
 				}
 			}
 
-			// Check if issue has open blockers (GH#962)
-			if !force {
-				blocked, blockers, err := activeStore.IsBlocked(ctx, id)
-				if err != nil {
-					fmt.Fprintf(os.Stderr, "Error checking blockers for %s: %v\n", id, err)
-					continue
+			// Delegate the is_blocked guard to the engine (GH#962). CloseIssueChecked
+			// runs the guard and the close in ONE transaction, so there is no
+			// read-then-write TOCTOU window between the check and the close. --force
+			// bypasses the guard; ExpectedVersion is unused on this path.
+			res, err := activeStore.CloseIssueChecked(ctx, id, actor, storage.CloseIssueOptions{
+				Reason:  reason,
+				Session: session,
+				Force:   force,
+			})
+			if err != nil {
+				if errors.Is(err, storage.ErrCloseBlocked) {
+					// The guard refused atomically; ErrCloseBlocked's message names the
+					// blockers. Preserve the actionable hint.
+					fmt.Fprintf(os.Stderr, "%v (use --force to override)\n", err)
+				} else {
+					fmt.Fprintf(os.Stderr, "Error closing %s: %v\n", id, err)
 				}
-				if blocked && len(blockers) > 0 {
-					fmt.Fprintf(os.Stderr, "cannot close %s: blocked by open issues %v (use --force to override)\n", id, blockers)
-					continue
-				}
-			}
-
-			if err := activeStore.CloseIssue(ctx, id, reason, actor, session); err != nil {
-				fmt.Fprintf(os.Stderr, "Error closing %s: %v\n", id, err)
 				continue
 			}
-			mutatedStores[activeStore] = append(mutatedStores[activeStore], id)
+			if res.Unchanged {
+				// Already closed: an idempotent no-op. The old CloseIssue path also
+				// returned nil here and still reported the (already-closed) issue, so
+				// keep OUTPUT parity via the shared display block below — the issue
+				// stays in --json output and the text report exactly as before. But
+				// skip every real-state-change side effect: the audit entry (no
+				// spurious closed→closed), the pending-commit tracking (nothing to
+				// commit), molecule auto-close, and the suggest-next/newly-unblocked/
+				// claim-next paths (all gated on closedCount). Exit stays 0 via
+				// alreadyClosed.
+				alreadyClosed++
+			} else {
+				mutatedStores[activeStore] = append(mutatedStores[activeStore], id)
 
-			// Audit log the close (survives Dolt GC flatten)
-			oldStatus := "open"
-			if issue != nil {
-				oldStatus = string(issue.Status)
+				// Audit log the close (survives Dolt GC flatten)
+				oldStatus := "open"
+				if issue != nil {
+					oldStatus = string(issue.Status)
+				}
+				audit.LogFieldChange(id, "status", oldStatus, "closed", actor, reason)
+
+				closedCount++
+				if firstClosedID == "" {
+					firstClosedID = id
+				}
+
+				// Auto-close parent molecule if all steps are now complete.
+				// Runs against the same store the step was closed in.
+				autoCloseCompletedMolecule(ctx, activeStore, id, actor, session)
 			}
-			audit.LogFieldChange(id, "status", oldStatus, "closed", actor, reason)
 
-			closedCount++
-			if firstClosedID == "" {
-				firstClosedID = id
-			}
-
-			// Auto-close parent molecule if all steps are now complete.
-			// Runs against the same store the step was closed in.
-			autoCloseCompletedMolecule(ctx, activeStore, id, actor, session)
-
-			// Re-fetch for display
+			// Re-fetch for display. A real close and an idempotent no-op both report
+			// the closed issue here, matching the historical output shape.
 			closedIssue, _ := activeStore.GetIssue(ctx, id)
 
 			if jsonOutput {
@@ -308,7 +326,7 @@ the flags appear in the command line.`,
 		}
 
 		totalAttempted := len(resolvedIDs)
-		if totalAttempted > 0 && closedCount == 0 {
+		if totalAttempted > 0 && closedCount == 0 && alreadyClosed == 0 {
 			return SilentExit()
 		}
 		return nil

--- a/cmd/bd/close_embedded_test.go
+++ b/cmd/bd/close_embedded_test.go
@@ -204,6 +204,84 @@ func TestEmbeddedClose(t *testing.T) {
 		cmd.CombinedOutput() // Don't check error — behavior varies.
 	})
 
+	// The delegated close (CloseIssueChecked) reports Unchanged for an already-
+	// closed issue. Re-closing must stay an idempotent success (exit 0, issue
+	// stays closed) — matching the old CloseIssue path, which returned nil for an
+	// already-closed issue. bdClose t.Fatalf's on non-zero exit, so this asserts
+	// the exit code.
+	t.Run("close_already_closed_is_idempotent_success", func(t *testing.T) {
+		issue := bdCreate(t, bd, dir, "Idempotent close", "--type", "task")
+		bdClose(t, bd, dir, issue.ID)
+		bdClose(t, bd, dir, issue.ID) // second close: idempotent no-op, exit 0
+		got := bdShow(t, bd, dir, issue.ID)
+		if got.Status != types.StatusClosed {
+			t.Errorf("expected issue to remain closed after idempotent re-close, got %s", got.Status)
+		}
+	})
+
+	// Output parity: `bd close --json` on an already-closed bead must still emit
+	// the issue in the JSON array (the old CloseIssue path re-fetched and reported
+	// it). The Unchanged branch skips the real-close side effects but keeps the
+	// display, so the shape is unchanged.
+	t.Run("close_json_already_closed_emits_issue", func(t *testing.T) {
+		issue := bdCreate(t, bd, dir, "JSON idempotent", "--type", "task")
+		bdClose(t, bd, dir, issue.ID) // first close
+		cmd := exec.Command(bd, "close", issue.ID, "--json")
+		cmd.Dir = dir
+		cmd.Env = bdEnv(dir)
+		stdout, stderr, err := runCommandBuffers(t, cmd)
+		if err != nil {
+			t.Fatalf("bd close --json (already closed) failed: %v\nstdout:\n%s\nstderr:\n%s", err, stdout.String(), stderr.String())
+		}
+		s := stdout.String()
+		start := strings.Index(s, "[")
+		if start < 0 {
+			t.Fatalf("expected a JSON array for already-closed --json re-close, got: %s", s)
+		}
+		var issues []json.RawMessage
+		if jsonErr := json.Unmarshal([]byte(s[start:]), &issues); jsonErr != nil {
+			t.Fatalf("expected valid JSON array, got: %s (%v)", s[start:], jsonErr)
+		}
+		if len(issues) != 1 {
+			t.Fatalf("expected 1 issue in JSON for already-closed re-close (parity), got %d: %s", len(issues), s[start:])
+		}
+		if !strings.Contains(s, issue.ID) {
+			t.Errorf("expected already-closed issue %s in JSON output, got: %s", issue.ID, s)
+		}
+	})
+
+	// Mixed batch: one already-closed bead + one live bead. Both must appear in
+	// the JSON array — the already-closed one for output parity, the live one as a
+	// real close.
+	t.Run("close_json_mixed_batch_includes_already_closed", func(t *testing.T) {
+		already := bdCreate(t, bd, dir, "Mixed already", "--type", "task")
+		fresh := bdCreate(t, bd, dir, "Mixed fresh", "--type", "task")
+		bdClose(t, bd, dir, already.ID) // pre-close one
+
+		cmd := exec.Command(bd, "close", already.ID, fresh.ID, "--json")
+		cmd.Dir = dir
+		cmd.Env = bdEnv(dir)
+		stdout, stderr, err := runCommandBuffers(t, cmd)
+		if err != nil {
+			t.Fatalf("bd close --json (mixed batch) failed: %v\nstdout:\n%s\nstderr:\n%s", err, stdout.String(), stderr.String())
+		}
+		s := stdout.String()
+		start := strings.Index(s, "[")
+		if start < 0 {
+			t.Fatalf("expected a JSON array for mixed-batch --json close, got: %s", s)
+		}
+		var issues []json.RawMessage
+		if jsonErr := json.Unmarshal([]byte(s[start:]), &issues); jsonErr != nil {
+			t.Fatalf("expected valid JSON array, got: %s (%v)", s[start:], jsonErr)
+		}
+		if len(issues) != 2 {
+			t.Fatalf("expected both issues in JSON (real close + already-closed parity), got %d: %s", len(issues), s[start:])
+		}
+		if !strings.Contains(s, already.ID) || !strings.Contains(s, fresh.ID) {
+			t.Errorf("expected both %s and %s in JSON output, got: %s", already.ID, fresh.ID, s)
+		}
+	})
+
 	t.Run("close_nonexistent_id", func(t *testing.T) {
 		bdCloseFail(t, bd, dir, "tc-nonexistent999")
 	})
@@ -232,6 +310,61 @@ func TestEmbeddedClose(t *testing.T) {
 		got := bdShow(t, bd, dir, blocked.ID)
 		if got.Status != types.StatusClosed {
 			t.Errorf("expected closed with --force, got %s", got.Status)
+		}
+	})
+
+	// Proves the S7 delegation: `bd close` on a blocked issue now surfaces the
+	// engine's atomic guard (storage.ErrCloseBlocked) rather than a duplicated
+	// CLI pre-check. The refusal must be atomic — the issue stays open because the
+	// guard and the close share one transaction — and the message must name the
+	// blocker and the --force hint. --force then bypasses the engine guard.
+	t.Run("close_blocked_delegated_guard", func(t *testing.T) {
+		blocker := bdCreate(t, bd, dir, "Deleg blocker", "--type", "task")
+		blocked := bdCreate(t, bd, dir, "Deleg blocked", "--type", "task")
+		bdDepAdd(t, bd, dir, blocked.ID, blocker.ID)
+
+		out := bdCloseFail(t, bd, dir, blocked.ID)
+		if !strings.Contains(out, "cannot close") {
+			t.Errorf("expected engine guard message ('cannot close'), got: %s", out)
+		}
+		if !strings.Contains(out, blocker.ID) {
+			t.Errorf("expected guard message to name blocker %s, got: %s", blocker.ID, out)
+		}
+		if !strings.Contains(out, "--force") {
+			t.Errorf("expected guard message to mention --force, got: %s", out)
+		}
+
+		// Atomic refuse: the guard ran in-transaction, so the issue must remain open.
+		got := bdShow(t, bd, dir, blocked.ID)
+		if got.Status == types.StatusClosed {
+			t.Error("expected blocked issue to remain open after the guard refused (atomic)")
+		}
+
+		// --force bypasses the engine guard.
+		bdClose(t, bd, dir, blocked.ID, "--force")
+		got = bdShow(t, bd, dir, blocked.ID)
+		if got.Status != types.StatusClosed {
+			t.Errorf("expected closed with --force, got %s", got.Status)
+		}
+	})
+
+	// The delegated guard refuses only on a LIVE direct blocker, matching the
+	// historical `bd close` predicate. A transitively-blocked child (parent-child
+	// of a blocked parent) has is_blocked=1 but no direct blocker of its own, so it
+	// must close WITHOUT --force — the historical behavior.
+	t.Run("close_transitively_blocked_closes_without_force", func(t *testing.T) {
+		blocker := bdCreate(t, bd, dir, "Trans blocker", "--type", "task")
+		parent := bdCreate(t, bd, dir, "Trans parent", "--type", "task")
+		child := bdCreate(t, bd, dir, "Trans child", "--type", "task")
+		// parent is blocked by an open blocker; child is a parent-child of parent,
+		// so child inherits is_blocked=1 transitively with no direct blocker.
+		bdDepAdd(t, bd, dir, parent.ID, blocker.ID)
+		bdDepAdd(t, bd, dir, child.ID, parent.ID, "--type", "parent-child")
+
+		bdClose(t, bd, dir, child.ID) // no --force
+		got := bdShow(t, bd, dir, child.ID)
+		if got.Status != types.StatusClosed {
+			t.Errorf("expected transitively-blocked child to close without --force, got %s", got.Status)
 		}
 	})
 

--- a/internal/storage/dolt/close_issue_checked_test.go
+++ b/internal/storage/dolt/close_issue_checked_test.go
@@ -192,6 +192,91 @@ func TestCloseIssueChecked(t *testing.T) {
 			},
 		},
 		{
+			// The guard refuses only on a LIVE direct blocker, matching the
+			// historical `bd close` predicate (blocked && len(blockers) > 0). A
+			// transitively-blocked child (parent-child of a blocked parent) has
+			// is_blocked=1 but NO direct blocker of its own, so it must close
+			// without Force.
+			name: "transitively blocked child closes without force",
+			setup: func(t *testing.T) string {
+				blocker, parent, child := "cic-trans-blocker", "cic-trans-parent", "cic-trans-child"
+				createPerm(t, ctx, store, blocker)
+				createPerm(t, ctx, store, parent)
+				createPerm(t, ctx, store, child)
+				if err := store.AddDependency(ctx, &types.Dependency{
+					IssueID: parent, DependsOnID: blocker, Type: types.DepBlocks,
+				}, "tester"); err != nil {
+					t.Fatalf("AddDependency(parent blocks blocker): %v", err)
+				}
+				if err := store.AddDependency(ctx, &types.Dependency{
+					IssueID: child, DependsOnID: parent, Type: types.DepParentChild,
+				}, "tester"); err != nil {
+					t.Fatalf("AddDependency(parent-child): %v", err)
+				}
+				// Precondition: the child inherits is_blocked=1 from its blocked
+				// parent, with no direct blocker edge of its own.
+				if !getIsBlocked(t, ctx, store, "issues", child) {
+					t.Fatalf("%s should inherit is_blocked=1 from blocked parent %s", child, parent)
+				}
+				return child
+			},
+			opts: storage.CloseIssueOptions{Reason: "done"},
+			check: func(t *testing.T, id string, res storage.CloseIssueResult, err error) {
+				if err != nil {
+					t.Fatalf("transitive-blocked close err = %v, want nil (no live direct blocker)", err)
+				}
+				if res.Unchanged {
+					t.Fatalf("res.Unchanged = true, want false (a real close)")
+				}
+				if got := getStatus(t, id); got != types.StatusClosed {
+					t.Fatalf("issue %s status = %q, want closed", id, got)
+				}
+			},
+		},
+		{
+			// A stale is_blocked=1 (its only direct blocker has since closed, but
+			// the denormalized column was not recomputed) must NOT refuse: the
+			// guard reads the LIVE blocker list — empty because the blocker is
+			// closed — and self-heals by closing.
+			name: "stale is_blocked with closed direct blocker closes",
+			setup: func(t *testing.T) string {
+				blocker, target := "cic-stale-blocker", "cic-stale-target"
+				createPerm(t, ctx, store, blocker)
+				createPerm(t, ctx, store, target)
+				if err := store.AddDependency(ctx, &types.Dependency{
+					IssueID: target, DependsOnID: blocker, Type: types.DepBlocks,
+				}, "tester"); err != nil {
+					t.Fatalf("AddDependency(blocks): %v", err)
+				}
+				if !getIsBlocked(t, ctx, store, "issues", target) {
+					t.Fatalf("%s should be is_blocked=1 after adding blocks dep", target)
+				}
+				// Close the blocker via a raw UPDATE that skips the is_blocked
+				// recompute, leaving target.is_blocked stale at 1 while its only
+				// direct blocker is now closed.
+				if _, err := store.db.ExecContext(ctx,
+					"UPDATE issues SET status = 'closed' WHERE id = ?", blocker); err != nil {
+					t.Fatalf("raw-close blocker: %v", err)
+				}
+				if !getIsBlocked(t, ctx, store, "issues", target) {
+					t.Fatalf("%s is_blocked column should still read stale-1", target)
+				}
+				return target
+			},
+			opts: storage.CloseIssueOptions{Reason: "done"},
+			check: func(t *testing.T, id string, res storage.CloseIssueResult, err error) {
+				if err != nil {
+					t.Fatalf("stale-blocked close err = %v, want nil (live blocker is closed; self-heals)", err)
+				}
+				if res.Unchanged {
+					t.Fatalf("res.Unchanged = true, want false (a real close)")
+				}
+				if got := getStatus(t, id); got != types.StatusClosed {
+					t.Fatalf("issue %s status = %q, want closed", id, got)
+				}
+			},
+		},
+		{
 			name:  "already closed is idempotent",
 			setup: func(t *testing.T) string { return mkClosed(t, "cic-idem") },
 			opts:  storage.CloseIssueOptions{Reason: "again"},

--- a/internal/storage/dolt/issues.go
+++ b/internal/storage/dolt/issues.go
@@ -437,7 +437,7 @@ func (s *DoltStore) CloseIssue(ctx context.Context, id string, reason string, ac
 }
 
 // CloseIssueChecked closes an issue but refuses with storage.ErrCloseBlocked
-// when it is still blocked (is_blocked=1) unless opts.Force is set, and — when
+// when it has a live direct blocker unless opts.Force is set, and — when
 // opts.ExpectedVersion is non-nil — with storage.ErrVersionMismatch when the
 // row's current RowVersion no longer matches (an orthogonal CAS that Force does
 // not bypass). Both checks and the close share one transaction, so they are

--- a/internal/storage/embeddeddolt/close_issue_checked_test.go
+++ b/internal/storage/embeddeddolt/close_issue_checked_test.go
@@ -79,6 +79,57 @@ func TestEmbeddedCloseIssueChecked(t *testing.T) {
 	}
 }
 
+// TestEmbeddedCloseIssueCheckedTransitiveBlockedCloses proves the guard refuses
+// only on a LIVE direct blocker (blocked && len(blockers) > 0): a transitively-
+// blocked child (parent-child of a blocked parent) has is_blocked=1 but no direct
+// blocker of its own, so it closes without Force — the historical `bd close`
+// behavior, threaded through the embedded wrapper.
+func TestEmbeddedCloseIssueCheckedTransitiveBlockedCloses(t *testing.T) {
+	skipUnlessEmbeddedDolt(t)
+	te := newTestEnv(t, "cictr")
+	ctx := t.Context()
+
+	for _, id := range []string{"cictr-blocker", "cictr-parent", "cictr-child"} {
+		iss := &types.Issue{ID: id, Title: id, Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask}
+		if err := te.store.CreateIssue(ctx, iss, "tester"); err != nil {
+			t.Fatalf("create %s: %v", id, err)
+		}
+	}
+	if err := te.store.AddDependency(ctx, &types.Dependency{
+		IssueID: "cictr-parent", DependsOnID: "cictr-blocker", Type: types.DepBlocks,
+	}, "tester"); err != nil {
+		t.Fatalf("AddDependency(parent blocks blocker): %v", err)
+	}
+	if err := te.store.AddDependency(ctx, &types.Dependency{
+		IssueID: "cictr-child", DependsOnID: "cictr-parent", Type: types.DepParentChild,
+	}, "tester"); err != nil {
+		t.Fatalf("AddDependency(parent-child): %v", err)
+	}
+	// The child inherits is_blocked=1 transitively, with NO direct blocker.
+	blocked, blockers, err := te.store.IsBlocked(ctx, "cictr-child")
+	if err != nil {
+		t.Fatalf("IsBlocked(child): %v", err)
+	}
+	if !blocked {
+		t.Fatal("cictr-child should inherit is_blocked=1 from its blocked parent")
+	}
+	if len(blockers) != 0 {
+		t.Fatalf("cictr-child should have NO direct blocker, got %v", blockers)
+	}
+
+	// No Force: the guard sees no live direct blocker and closes.
+	res, err := te.store.CloseIssueChecked(ctx, "cictr-child", "tester", storage.CloseIssueOptions{Reason: "done"})
+	if err != nil {
+		t.Fatalf("transitive-blocked close err = %v, want nil (no live direct blocker)", err)
+	}
+	if res.Unchanged {
+		t.Fatalf("res.Unchanged = true, want false (a real close)")
+	}
+	if iss, _ := te.store.GetIssue(ctx, "cictr-child"); iss.Status != types.StatusClosed {
+		t.Fatalf("cictr-child status = %q, want closed", iss.Status)
+	}
+}
+
 // TestEmbeddedCloseIssueCheckedVersionCAS proves the ExpectedVersion CAS wires
 // through the EmbeddedDoltStore's withConn wrapper: a matching version closes, a
 // stale version is refused atomically with storage.ErrVersionMismatch (issue

--- a/internal/storage/embeddeddolt/issues.go
+++ b/internal/storage/embeddeddolt/issues.go
@@ -134,7 +134,7 @@ func (s *EmbeddedDoltStore) CloseIssue(ctx context.Context, id string, reason st
 }
 
 // CloseIssueChecked closes an issue but refuses with storage.ErrCloseBlocked
-// when it is still blocked (is_blocked=1) unless opts.Force is set, and — when
+// when it has a live direct blocker unless opts.Force is set, and — when
 // opts.ExpectedVersion is non-nil — with storage.ErrVersionMismatch when the
 // row's current RowVersion no longer matches (an orthogonal CAS that Force does
 // not bypass). Both checks and the close share one transaction, so they are

--- a/internal/storage/issueops/close.go
+++ b/internal/storage/issueops/close.go
@@ -29,9 +29,18 @@ func CloseIssueWithoutEventInTx(ctx context.Context, tx DBTX, id string, reason,
 }
 
 // CloseIssueCheckedInTx closes an issue within a transaction, refusing with
-// storage.ErrCloseBlocked when it is still blocked (is_blocked=1) unless force
-// is set. The guard (IsBlockedInTx) and the close (CloseIssueInTx) share the
-// SAME transaction, so no blocker can clear between the check and the close.
+// storage.ErrCloseBlocked when it has a LIVE direct blocker unless force is set.
+// The guard (IsBlockedInTx) and the close (CloseIssueInTx) share the SAME
+// transaction, so no blocker can clear between the check and the close.
+//
+// The refuse predicate is the exact historical `bd close` guard:
+// blocked && len(blockers) > 0 — refuse only when the denormalized is_blocked
+// column is set AND there is at least one live, open direct blocker
+// (blocks/waits-for/conditional-blocks). A bare is_blocked=1 with no live direct
+// blocker is deliberately NOT refused: it is either a purely transitive block
+// (a parent-child child of a blocked parent — historically closable) or a stale
+// is_blocked column whose direct blockers have since closed. Reading the live
+// blocker list self-heals against a stale column instead of acting on it.
 //
 // When expectedVersion is non-nil it adds an ORTHOGONAL optimistic-concurrency
 // precondition: the row's current RowVersion (row_lock) must still equal
@@ -70,15 +79,8 @@ func CloseIssueCheckedInTx(ctx context.Context, tx DBTX, id, reason, actor, sess
 			if err != nil {
 				return nil, err
 			}
-			if blocked {
-				// A purely transitive block (e.g. an active parent-child chain)
-				// sets is_blocked=1 without any direct blocks/waits-for/
-				// conditional-blocks edge, so blockers is empty — omit the "blocked
-				// by" clause rather than render "blocked by []".
-				if len(blockers) > 0 {
-					return nil, fmt.Errorf("%w: %s is blocked by %v", storage.ErrCloseBlocked, id, blockers)
-				}
-				return nil, fmt.Errorf("%w: %s", storage.ErrCloseBlocked, id)
+			if blocked && len(blockers) > 0 {
+				return nil, fmt.Errorf("%w: %s is blocked by %v", storage.ErrCloseBlocked, id, blockers)
 			}
 		}
 	}

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -77,7 +77,10 @@ type Storage interface {
 	UpdateIssueType(ctx context.Context, id string, issueType string, actor string) error
 	CloseIssue(ctx context.Context, id string, reason string, actor string, session string) error
 	// CloseIssueChecked closes an issue, but refuses with ErrCloseBlocked when
-	// the issue is still blocked (is_blocked=1) unless opts.Force is set. The
+	// the issue has a live direct blocker (an open blocks/waits-for/
+	// conditional-blocks edge) unless opts.Force is set — the historical
+	// `bd close` guard. A bare is_blocked=1 with no live direct blocker (a purely
+	// transitive parent-child block, or a stale column) is not refused. The
 	// blocked-check and the close run in ONE transaction, so the guard is atomic
 	// (no TOCTOU). When opts.ExpectedVersion is non-nil it adds an orthogonal
 	// optimistic-concurrency precondition: the close proceeds only if the issue's

--- a/tests/regression/discovery_test.go
+++ b/tests/regression/discovery_test.go
@@ -293,7 +293,11 @@ func TestProtocol_CloseGuardRespectDepTypes(t *testing.T) {
 		w.run("dep", "add", a, b, "--type", "blocks")
 
 		out, _ := w.tryRun("close", a)
-		if !strings.Contains(out, "blocked by open issues") {
+		// The embedded close path delegates to the engine's guarded close (S7),
+		// which surfaces storage.ErrCloseBlocked ("cannot close blocked issue:
+		// <id> is blocked by [...]"). The proxied path still uses the older
+		// "blocked by open issues" wording — accept either.
+		if !strings.Contains(out, "blocked by open issues") && !strings.Contains(out, "cannot close") {
 			t.Errorf("close of blocked issue should be rejected, got: %s", out)
 		}
 


### PR DESCRIPTION
> Stacked on #4903 (S5b) → #4902 (S6b) → … → #4892 (S1). Base is `feat/guarded-ops-s5b-version-cas`; retarget down the stack as each lands. The diff below is S7 only.

## What

`bd close` (embedded path) now delegates to the engine's `CloseIssueChecked` instead of running its own is_blocked pre-check and closing in a separate call. The verb builds `CloseIssueOptions{Reason, Session, Force}` and calls the op; the duplicated CLI guard is deleted.

## Why

The CLI's check-then-close was a read-then-write TOCTOU: an issue could become blocked between the `IsBlocked` read and the `CloseIssue` write. `CloseIssueChecked` runs the guard and the close in one transaction, so the refusal is atomic (still open, no `closed` event). This is the delegation pattern for the `bd` verbs: argument parsing in the CLI, enforcement in the library.

**Behavior-preserving, deliberately.** A pre-merge review compared old-vs-new binaries and caught two deltas, both fixed before merge:
- The engine guard originally refused on the bare denormalized `is_blocked` column, which would have refused transitively-blocked children (blocked parent, zero direct blockers) and stale `is_blocked` rows that the old CLI closed. The guard now uses the exact historical predicate — refuse only on a **live direct blocker** — so the delegation changes no close semantics. (Whether transitive blocks *should* refuse a close is a real question, but it belongs to a deliberate semantics change, not a refactor.)
- An already-closed issue still appears in the `--json` array and text report (idempotent success, exit 0) — but no longer emits a spurious `closed→closed` audit entry or the real-close side effects.

## Verification

- Direct blocker: refuses atomically (issue stays open, blockers named, `--force` hint), closes with `--force`. Transitively-blocked and stale-`is_blocked` beads close without `--force` (old-binary parity). Already-closed: in `--json` output alone and in mixed batches, exit 0, no spurious audit.
- Covered at the engine level (both stores, incl. new transitive/stale cases) and through the built `bd` binary.
- `gofmt`/`go vet` clean; `go build ./...` under cgo and `CGO_ENABLED=0`; `golangci-lint` 0 issues.

```bash
go test ./internal/storage/dolt/ -run TestCloseIssueChecked -v
BEADS_TEST_EMBEDDED_DOLT=1 go test ./cmd/bd/ -run Close -count=1
```
