### PR TITLE
feat(update): UpdateIssueChecked — optional ExpectedVersion CAS on the update

### DIFF
--- a/beads.go
+++ b/beads.go
@@ -58,6 +58,12 @@ type CloseIssueOptions = storage.CloseIssueOptions
 // is true when the issue was already closed (idempotent no-op).
 type CloseIssueResult = storage.CloseIssueResult
 
+// UpdateIssueOptions carries the optional inputs to Storage.UpdateIssueChecked —
+// an update with an optional ExpectedVersion compare-and-swap that refuses a
+// concurrently-modified issue with ErrVersionMismatch. Exported so consumers can
+// name it without importing internal/storage.
+type UpdateIssueOptions = storage.UpdateIssueOptions
+
 // RemoteStore provides dolt remote management and replication operations.
 // Use type assertion on a Storage value to access these methods:
 //

--- a/errors_test.go
+++ b/errors_test.go
@@ -44,6 +44,24 @@ func TestReExportVersionMismatch(t *testing.T) {
 	}
 }
 
+// TestUpdateIssueOptionsIsExported proves the public beads.UpdateIssueOptions
+// alias is usable from outside the module and its ExpectedVersion compare-and-
+// swap field round-trips — the type a caller names to opt a
+// Storage.UpdateIssueChecked into optimistic concurrency without importing
+// internal/storage. The zero value must leave ExpectedVersion nil (no check).
+func TestUpdateIssueOptionsIsExported(t *testing.T) {
+	t.Parallel()
+
+	v := int64(7)
+	opts := beads.UpdateIssueOptions{ExpectedVersion: &v}
+	if opts.ExpectedVersion == nil || *opts.ExpectedVersion != 7 {
+		t.Fatalf("ExpectedVersion did not round-trip through the exported alias: %+v", opts)
+	}
+	if (beads.UpdateIssueOptions{}).ExpectedVersion != nil {
+		t.Fatal("zero-value UpdateIssueOptions must have a nil ExpectedVersion (no check)")
+	}
+}
+
 // TestReExportedSentinelIdentity proves each public sentinel is the SAME value
 // as the internal one it aliases, so errors.Is composes across the package
 // boundary without any bridging.

--- a/internal/jira/tracker_test.go
+++ b/internal/jira/tracker_test.go
@@ -650,6 +650,9 @@ func (s *configStore) GetIssuesByIDs(_ context.Context, _ []string) ([]*types.Is
 func (s *configStore) UpdateIssue(_ context.Context, _ string, _ map[string]interface{}, _ string) error {
 	return nil
 }
+func (s *configStore) UpdateIssueChecked(_ context.Context, _ string, _ map[string]interface{}, _ string, _ storage.UpdateIssueOptions) error {
+	return nil
+}
 func (s *configStore) ReopenIssue(_ context.Context, _, _, _ string) error     { return nil }
 func (s *configStore) UpdateIssueType(_ context.Context, _, _, _ string) error { return nil }
 func (s *configStore) CloseIssue(_ context.Context, _, _, _, _ string) error   { return nil }

--- a/internal/storage/dolt/ephemeral_routing.go
+++ b/internal/storage/dolt/ephemeral_routing.go
@@ -198,99 +198,106 @@ func (s *DoltStore) PromoteFromEphemeral(ctx context.Context, id string, actor s
 //
 // Called by UpdateIssue when no_history=true or wisp=true is set on a regular issue.
 func (s *DoltStore) DemoteToWisp(ctx context.Context, id string, updates map[string]interface{}, actor string) error {
-	if err := s.withRetryTx(ctx, func(tx *sql.Tx) error {
-		if _, err := issueops.UpdateIssueWithoutEventInTx(ctx, tx, id, updates, actor); err != nil {
-			return fmt.Errorf("update issue before demotion: %w", err)
-		}
+	return s.withRetryTx(ctx, func(tx *sql.Tx) error {
+		return s.demoteToWispInTx(ctx, tx, id, updates, actor)
+	})
+}
 
-		issue, err := scanIssueTxFromTable(ctx, tx, "issues", id)
-		if err != nil {
-			return fmt.Errorf("failed to get updated issue for demotion: %w", err)
-		}
+// demoteToWispInTx is DemoteToWisp's transaction body: it applies the field
+// update without an intermediate event, then migrates the issue to the wisps
+// table (insert into wisps, copy auxiliary rows, delete from issues) and stages
+// the demotion commit. Extracted so UpdateIssueChecked can wrap it with an
+// atomic version precondition in the same transaction; DemoteToWisp's behavior
+// is unchanged.
+func (s *DoltStore) demoteToWispInTx(ctx context.Context, tx *sql.Tx, id string, updates map[string]interface{}, actor string) error {
+	if _, err := issueops.UpdateIssueWithoutEventInTx(ctx, tx, id, updates, actor); err != nil {
+		return fmt.Errorf("update issue before demotion: %w", err)
+	}
 
-		if err := insertIssueTxIntoTable(ctx, tx, "wisps", issue); err != nil {
-			return fmt.Errorf("failed to insert issue into wisps: %w", err)
-		}
+	issue, err := scanIssueTxFromTable(ctx, tx, "issues", id)
+	if err != nil {
+		return fmt.Errorf("failed to get updated issue for demotion: %w", err)
+	}
 
-		if _, err := tx.ExecContext(ctx, `
+	if err := insertIssueTxIntoTable(ctx, tx, "wisps", issue); err != nil {
+		return fmt.Errorf("failed to insert issue into wisps: %w", err)
+	}
+
+	if _, err := tx.ExecContext(ctx, `
 		INSERT IGNORE INTO wisp_labels (issue_id, label)
 		SELECT issue_id, label FROM labels WHERE issue_id = ?
 	`, id); err != nil {
-			return fmt.Errorf("copy labels for demoted issue %s: %w", id, err)
-		}
-		if _, err := tx.ExecContext(ctx, `DELETE FROM labels WHERE issue_id = ?`, id); err != nil {
-			return fmt.Errorf("delete copied labels for demoted issue %s: %w", id, err)
-		}
+		return fmt.Errorf("copy labels for demoted issue %s: %w", id, err)
+	}
+	if _, err := tx.ExecContext(ctx, `DELETE FROM labels WHERE issue_id = ?`, id); err != nil {
+		return fmt.Errorf("delete copied labels for demoted issue %s: %w", id, err)
+	}
 
-		// Demotion is the inverse of promotion: carry id across so the wisp edge
-		// keeps the deterministic key its dependency had. Both tables key id on
-		// (issue_id, target), and wisp_dependencies.id also has no DEFAULT now, so
-		// the copy is both consistent and required (#4259).
-		if _, err := tx.ExecContext(ctx, `
+	// Demotion is the inverse of promotion: carry id across so the wisp edge
+	// keeps the deterministic key its dependency had. Both tables key id on
+	// (issue_id, target), and wisp_dependencies.id also has no DEFAULT now, so
+	// the copy is both consistent and required (#4259).
+	if _, err := tx.ExecContext(ctx, `
 		INSERT IGNORE INTO wisp_dependencies (id, issue_id, depends_on_issue_id, depends_on_wisp_id, depends_on_external, type, created_at, created_by, metadata, thread_id)
 		SELECT id, issue_id, depends_on_issue_id, depends_on_wisp_id, depends_on_external, type, created_at, created_by, metadata, thread_id
 		FROM dependencies WHERE issue_id = ?
 	`, id); err != nil {
-			return fmt.Errorf("copy dependencies for demoted issue %s: %w", id, err)
-		}
-		if _, err := tx.ExecContext(ctx, `DELETE FROM dependencies WHERE issue_id = ?`, id); err != nil {
-			return fmt.Errorf("delete copied dependencies for demoted issue %s: %w", id, err)
-		}
+		return fmt.Errorf("copy dependencies for demoted issue %s: %w", id, err)
+	}
+	if _, err := tx.ExecContext(ctx, `DELETE FROM dependencies WHERE issue_id = ?`, id); err != nil {
+		return fmt.Errorf("delete copied dependencies for demoted issue %s: %w", id, err)
+	}
 
-		if _, err := tx.ExecContext(ctx, `
+	if _, err := tx.ExecContext(ctx, `
 		INSERT IGNORE INTO wisp_events (id, issue_id, event_type, actor, old_value, new_value, comment, created_at)
 		SELECT id, issue_id, event_type, actor, old_value, new_value, comment, created_at
 		FROM events WHERE issue_id = ?
 	`, id); err != nil {
-			return fmt.Errorf("copy events for demoted issue %s: %w", id, err)
-		}
-		if _, err := tx.ExecContext(ctx, `DELETE FROM events WHERE issue_id = ?`, id); err != nil {
-			return fmt.Errorf("delete copied events for demoted issue %s: %w", id, err)
-		}
+		return fmt.Errorf("copy events for demoted issue %s: %w", id, err)
+	}
+	if _, err := tx.ExecContext(ctx, `DELETE FROM events WHERE issue_id = ?`, id); err != nil {
+		return fmt.Errorf("delete copied events for demoted issue %s: %w", id, err)
+	}
 
-		if _, err := tx.ExecContext(ctx, `
+	if _, err := tx.ExecContext(ctx, `
 		INSERT IGNORE INTO wisp_comments (id, issue_id, author, text, created_at)
 		SELECT id, issue_id, author, text, created_at
 		FROM comments WHERE issue_id = ?
 	`, id); err != nil {
-			return fmt.Errorf("copy comments for demoted issue %s: %w", id, err)
-		}
-		if _, err := tx.ExecContext(ctx, `DELETE FROM comments WHERE issue_id = ?`, id); err != nil {
-			return fmt.Errorf("delete copied comments for demoted issue %s: %w", id, err)
-		}
+		return fmt.Errorf("copy comments for demoted issue %s: %w", id, err)
+	}
+	if _, err := tx.ExecContext(ctx, `DELETE FROM comments WHERE issue_id = ?`, id); err != nil {
+		return fmt.Errorf("delete copied comments for demoted issue %s: %w", id, err)
+	}
 
-		if _, err := tx.ExecContext(ctx, `
+	if _, err := tx.ExecContext(ctx, `
 		INSERT INTO wisp_events (id, issue_id, event_type, actor, old_value, new_value)
 		VALUES (?, ?, ?, ?, ?, ?)
 	`, issueops.NewEventID(), id, types.EventUpdated, actor, "", "demoted to wisp"); err != nil {
-			return fmt.Errorf("record demotion event for demoted issue %s: %w", id, err)
-		}
+		return fmt.Errorf("record demotion event for demoted issue %s: %w", id, err)
+	}
 
-		if err := issueops.RetargetInboundDependenciesToWispInTx(ctx, tx, id); err != nil {
-			return err
-		}
-
-		if _, err := tx.ExecContext(ctx, "DELETE FROM issues WHERE id = ?", id); err != nil {
-			return fmt.Errorf("failed to delete issue from issues: %w", err)
-		}
-		// Wisps are never leased: drop any lease the issue held.
-		if err := issueops.DeleteLeaseInTx(ctx, tx, id); err != nil {
-			return err
-		}
-
-		affectedIssues, affectedWisps, aerr := issueops.AffectedByStatusChangeForWispInTx(ctx, tx, id)
-		if aerr != nil {
-			return fmt.Errorf("affected by demote for %s: %w", id, aerr)
-		}
-		if err := issueops.RecomputeIsBlockedInTx(ctx, tx, affectedIssues, affectedWisps); err != nil {
-			return fmt.Errorf("recompute is_blocked after demote for %s: %w", id, err)
-		}
-
-		return s.doltAddAndCommitInTx(ctx, tx, permanentIssueAuxTables, fmt.Sprintf("bd: demote %s to wisp", id))
-	}); err != nil {
+	if err := issueops.RetargetInboundDependenciesToWispInTx(ctx, tx, id); err != nil {
 		return err
 	}
-	return nil
+
+	if _, err := tx.ExecContext(ctx, "DELETE FROM issues WHERE id = ?", id); err != nil {
+		return fmt.Errorf("failed to delete issue from issues: %w", err)
+	}
+	// Wisps are never leased: drop any lease the issue held.
+	if err := issueops.DeleteLeaseInTx(ctx, tx, id); err != nil {
+		return err
+	}
+
+	affectedIssues, affectedWisps, aerr := issueops.AffectedByStatusChangeForWispInTx(ctx, tx, id)
+	if aerr != nil {
+		return fmt.Errorf("affected by demote for %s: %w", id, aerr)
+	}
+	if err := issueops.RecomputeIsBlockedInTx(ctx, tx, affectedIssues, affectedWisps); err != nil {
+		return fmt.Errorf("recompute is_blocked after demote for %s: %w", id, err)
+	}
+
+	return s.doltAddAndCommitInTx(ctx, tx, permanentIssueAuxTables, fmt.Sprintf("bd: demote %s to wisp", id))
 }
 
 func (s *DoltStore) doltAddAndCommitInTx(ctx context.Context, tx *sql.Tx, tables []string, commitMsg string) error {

--- a/internal/storage/dolt/issues.go
+++ b/internal/storage/dolt/issues.go
@@ -198,6 +198,81 @@ func (s *DoltStore) UpdateIssue(ctx context.Context, id string, updates map[stri
 	})
 }
 
+// UpdateIssueChecked applies the update like UpdateIssue, adding an optional
+// optimistic-concurrency precondition: when opts.ExpectedVersion is non-nil the
+// update proceeds only if the issue's current RowVersion (row_lock) still equals
+// *opts.ExpectedVersion, else it refuses with storage.ErrVersionMismatch. The
+// version read and the update share ONE transaction, so a mismatch returns
+// before any write and the transaction rolls back with the issue unchanged (a
+// true compare-and-swap). nil disables the check, leaving behavior identical to
+// UpdateIssue. Mirrors UpdateIssue's Dolt-specific concerns (metadata
+// validation, wisp routing, DemoteToWisp, DOLT_ADD/COMMIT); UpdateIssue is the
+// hot path and is left untouched.
+func (s *DoltStore) UpdateIssueChecked(ctx context.Context, id string, updates map[string]interface{}, actor string, opts storage.UpdateIssueOptions) error {
+	// Validate metadata against schema before wisp routing (GH#1416 Phase 2).
+	if rawMeta, ok := updates["metadata"]; ok {
+		metadataStr, err := storage.NormalizeMetadataValue(rawMeta)
+		if err != nil {
+			return fmt.Errorf("invalid metadata: %w", err)
+		}
+		if err := validateMetadataIfConfigured(json.RawMessage(metadataStr)); err != nil {
+			return err
+		}
+	}
+
+	// Route ephemeral IDs to wisps table (falls through for promoted wisps).
+	// Wisps skip DOLT_COMMIT since they live in dolt_ignored tables.
+	if s.isActiveWisp(ctx, id) {
+		return s.updateWispChecked(ctx, id, updates, actor, opts.ExpectedVersion)
+	}
+
+	// If updating a regular issue to no-history or ephemeral, migrate it to the
+	// wisps table instead of updating in-place (mirrors UpdateIssue). The version
+	// check shares the demotion transaction so the CAS stays atomic on this path.
+	_, settingNoHistory := updates["no_history"]
+	_, settingWisp := updates["wisp"]
+	if settingNoHistory || settingWisp {
+		return s.withRetryTx(ctx, func(tx *sql.Tx) error {
+			if opts.ExpectedVersion != nil {
+				if err := issueops.CheckVersionInTx(ctx, tx, id, *opts.ExpectedVersion); err != nil {
+					return err
+				}
+			}
+			return s.demoteToWispInTx(ctx, tx, id, updates, actor)
+		})
+	}
+
+	// Wrap in withRetryTx exactly like UpdateIssue so a concurrent writer that
+	// loses Dolt's optimistic commit-time merge (MySQL 1213/1205, guaranteed
+	// server-side rollback) is retried rather than surfaced as a hard failure.
+	// A version mismatch (storage.ErrVersionMismatch) is NOT a serialization
+	// error, so withRetryTx surfaces it permanently and the transaction rolls
+	// back — no update and no event are written (the atomic-refuse property). A
+	// concurrent write that commits DURING this tx collides on the row_lock cell
+	// and is replayed by withRetryTx, which re-reads the new version here and
+	// refuses. withRetryTx owns BeginTx and the final Commit.
+	return s.withRetryTx(ctx, func(tx *sql.Tx) error {
+		if opts.ExpectedVersion != nil {
+			if err := issueops.CheckVersionInTx(ctx, tx, id, *opts.ExpectedVersion); err != nil {
+				return err
+			}
+		}
+		if _, err := issueops.UpdateIssueInTx(ctx, tx, id, updates, actor); err != nil {
+			return err
+		}
+
+		for _, table := range []string{"issues", "events"} {
+			_, _ = tx.ExecContext(ctx, "CALL DOLT_ADD(?)", table)
+		}
+		commitMsg := fmt.Sprintf("bd: update %s", id)
+		if _, err := tx.ExecContext(ctx, "CALL DOLT_COMMIT('-m', ?, '--author', ?)",
+			commitMsg, s.commitAuthorString()); err != nil && !isDoltNothingToCommit(err) {
+			return fmt.Errorf("dolt commit: %w", err)
+		}
+		return nil
+	})
+}
+
 // ClaimIssue atomically claims an issue using compare-and-swap semantics.
 // It sets the assignee to actor and status to "in_progress" only if the issue
 // currently has no assignee. Returns storage.ErrAlreadyClaimed if already claimed.

--- a/internal/storage/dolt/update_issue_checked_test.go
+++ b/internal/storage/dolt/update_issue_checked_test.go
@@ -1,0 +1,239 @@
+package dolt
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/storage"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// TestUpdateIssueCheckedVersionCAS exercises the optional ExpectedVersion
+// optimistic-concurrency check layered onto the generic update. The version read
+// and the update share ONE transaction, so a stale version is refused with
+// storage.ErrVersionMismatch and — critically — the transaction rolls back
+// leaving the field UNCHANGED with no `updated` event recorded (the atomic-
+// refuse property, mirroring CloseIssueChecked). A nil ExpectedVersion disables
+// the check, so behavior is byte-identical to UpdateIssue.
+func TestUpdateIssueCheckedVersionCAS(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	get := func(t *testing.T, id string) *types.Issue {
+		t.Helper()
+		iss, err := store.GetIssue(ctx, id)
+		if err != nil {
+			t.Fatalf("GetIssue(%s): %v", id, err)
+		}
+		if iss == nil {
+			t.Fatalf("GetIssue(%s) returned nil issue", id)
+		}
+		return iss
+	}
+	rowVersion := func(t *testing.T, id string) int64 {
+		t.Helper()
+		return get(t, id).RowVersion
+	}
+	title := func(t *testing.T, id string) string {
+		t.Helper()
+		return get(t, id).Title
+	}
+	countUpdatedEvents := func(t *testing.T, id string) int {
+		t.Helper()
+		events, err := store.GetEvents(ctx, id, 0)
+		if err != nil {
+			t.Fatalf("GetEvents(%s): %v", id, err)
+		}
+		n := 0
+		for _, e := range events {
+			if e.EventType == types.EventUpdated {
+				n++
+			}
+		}
+		return n
+	}
+	ptr := func(v int64) *int64 { return &v }
+
+	t.Run("matching version updates", func(t *testing.T) {
+		createPerm(t, ctx, store, "uc-match")
+		v := rowVersion(t, "uc-match")
+		if err := store.UpdateIssueChecked(ctx, "uc-match",
+			map[string]interface{}{"title": "matched"}, "tester",
+			storage.UpdateIssueOptions{ExpectedVersion: ptr(v)}); err != nil {
+			t.Fatalf("update with matching version err = %v, want nil", err)
+		}
+		if got := title(t, "uc-match"); got != "matched" {
+			t.Fatalf("uc-match title = %q, want %q (update did not apply)", got, "matched")
+		}
+		if after := rowVersion(t, "uc-match"); after == v {
+			t.Fatalf("RowVersion unchanged after a checked update: still %d", v)
+		}
+	})
+
+	t.Run("stale version refuses atomically", func(t *testing.T) {
+		createPerm(t, ctx, store, "uc-stale")
+		v := rowVersion(t, "uc-stale")
+		before := title(t, "uc-stale")
+		eventsBefore := countUpdatedEvents(t, "uc-stale")
+		// v+1 is a version the row provably does not hold.
+		err := store.UpdateIssueChecked(ctx, "uc-stale",
+			map[string]interface{}{"title": "should-not-apply"}, "tester",
+			storage.UpdateIssueOptions{ExpectedVersion: ptr(v + 1)})
+		if !errors.Is(err, storage.ErrVersionMismatch) {
+			t.Fatalf("err = %v, want errors.Is(_, ErrVersionMismatch)", err)
+		}
+		// Atomic refuse: field unchanged and no `updated` event — the CAS aborted
+		// the tx before the update ran.
+		if got := title(t, "uc-stale"); got != before {
+			t.Fatalf("uc-stale title = %q after refused update, want unchanged %q", got, before)
+		}
+		if n := countUpdatedEvents(t, "uc-stale"); n != eventsBefore {
+			t.Fatalf("updated event count for uc-stale = %d, want %d (tx must have rolled back)", n, eventsBefore)
+		}
+	})
+
+	t.Run("concurrent write invalidates captured version", func(t *testing.T) {
+		createPerm(t, ctx, store, "uc-concurrent")
+		v1 := rowVersion(t, "uc-concurrent")
+		// A mutating write rewrites row_lock, so the captured v1 is now stale.
+		if err := store.UpdateIssue(ctx, "uc-concurrent",
+			map[string]interface{}{"priority": 1}, "tester"); err != nil {
+			t.Fatalf("UpdateIssue: %v", err)
+		}
+		if v2 := rowVersion(t, "uc-concurrent"); v2 == v1 {
+			t.Fatalf("RowVersion unchanged after UpdateIssue (%d); CAS could not detect the write", v2)
+		}
+		before := title(t, "uc-concurrent")
+		err := store.UpdateIssueChecked(ctx, "uc-concurrent",
+			map[string]interface{}{"title": "should-not-apply"}, "tester",
+			storage.UpdateIssueOptions{ExpectedVersion: ptr(v1)})
+		if !errors.Is(err, storage.ErrVersionMismatch) {
+			t.Fatalf("err = %v, want errors.Is(_, ErrVersionMismatch)", err)
+		}
+		if got := title(t, "uc-concurrent"); got != before {
+			t.Fatalf("uc-concurrent title = %q after stale update, want unchanged %q", got, before)
+		}
+	})
+
+	t.Run("nil ExpectedVersion is unchanged behavior", func(t *testing.T) {
+		createPerm(t, ctx, store, "uc-nil")
+		if err := store.UpdateIssueChecked(ctx, "uc-nil",
+			map[string]interface{}{"title": "nil-check"}, "tester",
+			storage.UpdateIssueOptions{}); err != nil {
+			t.Fatalf("nil ExpectedVersion update err = %v, want nil (back-compat)", err)
+		}
+		if got := title(t, "uc-nil"); got != "nil-check" {
+			t.Fatalf("uc-nil title = %q, want %q (update did not apply)", got, "nil-check")
+		}
+	})
+
+	t.Run("missing id returns ErrNotFound", func(t *testing.T) {
+		err := store.UpdateIssueChecked(ctx, "uc-missing",
+			map[string]interface{}{"title": "x"}, "tester",
+			storage.UpdateIssueOptions{ExpectedVersion: ptr(1)})
+		if !errors.Is(err, storage.ErrNotFound) {
+			t.Fatalf("err = %v, want errors.Is(_, ErrNotFound) for absent row", err)
+		}
+	})
+
+	// The wisp subtests exercise CheckVersionInTx's wisp routing (SELECT row_lock
+	// FROM wisps) and updateWispChecked's atomic-refuse seam: it uses a bare
+	// BeginTx with a deferred Rollback (no withRetryTx, matching the package-wide
+	// wisp write pattern), so a stale version must leave the wisp untouched.
+	t.Run("wisp matching version updates", func(t *testing.T) {
+		createWisp(t, ctx, store, "uc-wisp-match")
+		// Reading the version at all requires the wisp route: a read against the
+		// issues table for this id would miss, so a successful update here proves
+		// CheckVersionInTx routed to the wisps table.
+		v := rowVersion(t, "uc-wisp-match")
+		if err := store.UpdateIssueChecked(ctx, "uc-wisp-match",
+			map[string]interface{}{"title": "wisp-matched"}, "tester",
+			storage.UpdateIssueOptions{ExpectedVersion: ptr(v)}); err != nil {
+			t.Fatalf("wisp update with matching version err = %v, want nil", err)
+		}
+		if got := title(t, "uc-wisp-match"); got != "wisp-matched" {
+			t.Fatalf("uc-wisp-match title = %q, want %q", got, "wisp-matched")
+		}
+	})
+
+	t.Run("wisp stale version refuses atomically", func(t *testing.T) {
+		createWisp(t, ctx, store, "uc-wisp-stale")
+		v := rowVersion(t, "uc-wisp-stale")
+		before := title(t, "uc-wisp-stale")
+		err := store.UpdateIssueChecked(ctx, "uc-wisp-stale",
+			map[string]interface{}{"title": "should-not-apply"}, "tester",
+			storage.UpdateIssueOptions{ExpectedVersion: ptr(v + 1)})
+		if !errors.Is(err, storage.ErrVersionMismatch) {
+			t.Fatalf("wisp err = %v, want errors.Is(_, ErrVersionMismatch)", err)
+		}
+		// updateWispChecked's deferred Rollback must discard the tx: the wisp's
+		// field stays unchanged.
+		if got := title(t, "uc-wisp-stale"); got != before {
+			t.Fatalf("uc-wisp-stale title = %q after refused update, want unchanged %q", got, before)
+		}
+	})
+
+	// The demote subtests exercise the no_history/wisp branch of UpdateIssueChecked
+	// (CheckVersionInTx + demoteToWispInTx in ONE withRetryTx). A future refactor
+	// that re-split the check and the demotion into separate transactions would
+	// still pass the plain-update subtests above but break these — the seam the
+	// demoteToWispInTx extraction exists to keep atomic.
+	inIssuesTable := func(t *testing.T, id string) bool {
+		t.Helper()
+		var count int
+		if err := store.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM issues WHERE id = ?", id).Scan(&count); err != nil {
+			t.Fatalf("query issues table for %s: %v", id, err)
+		}
+		return count > 0
+	}
+
+	t.Run("demote matching version migrates and applies the update", func(t *testing.T) {
+		createPerm(t, ctx, store, "uc-demote-match")
+		v := rowVersion(t, "uc-demote-match")
+		// no_history=true is the demote trigger (mirrors demote_to_wisp_test.go);
+		// the title change rides along so "update applied" is unambiguous.
+		if err := store.UpdateIssueChecked(ctx, "uc-demote-match",
+			map[string]interface{}{"no_history": true, "title": "demoted-match"}, "tester",
+			storage.UpdateIssueOptions{ExpectedVersion: ptr(v)}); err != nil {
+			t.Fatalf("demote update with matching version err = %v, want nil", err)
+		}
+		if !store.isActiveWisp(ctx, "uc-demote-match") {
+			t.Fatalf("uc-demote-match should be in the wisps table after demotion")
+		}
+		if inIssuesTable(t, "uc-demote-match") {
+			t.Fatalf("uc-demote-match still present in the issues table after demotion")
+		}
+		iss := get(t, "uc-demote-match")
+		if iss.Title != "demoted-match" {
+			t.Fatalf("uc-demote-match title = %q, want %q (update did not apply)", iss.Title, "demoted-match")
+		}
+		if !iss.NoHistory {
+			t.Fatalf("uc-demote-match NoHistory = false after demotion, want true")
+		}
+	})
+
+	t.Run("demote stale version refuses atomically", func(t *testing.T) {
+		createPerm(t, ctx, store, "uc-demote-stale")
+		v := rowVersion(t, "uc-demote-stale")
+		before := title(t, "uc-demote-stale")
+		err := store.UpdateIssueChecked(ctx, "uc-demote-stale",
+			map[string]interface{}{"no_history": true, "title": "should-not-apply"}, "tester",
+			storage.UpdateIssueOptions{ExpectedVersion: ptr(v + 1)})
+		if !errors.Is(err, storage.ErrVersionMismatch) {
+			t.Fatalf("err = %v, want errors.Is(_, ErrVersionMismatch)", err)
+		}
+		// Atomic refuse: the demotion tx rolled back, so the issue is NOT a wisp,
+		// still lives in the issues table, and its field is unchanged.
+		if store.isActiveWisp(ctx, "uc-demote-stale") {
+			t.Fatalf("uc-demote-stale demoted to a wisp despite stale version; CAS did not abort")
+		}
+		if !inIssuesTable(t, "uc-demote-stale") {
+			t.Fatalf("uc-demote-stale missing from the issues table after refused demote (tx must roll back)")
+		}
+		if got := title(t, "uc-demote-stale"); got != before {
+			t.Fatalf("uc-demote-stale title = %q after refused demote, want unchanged %q", got, before)
+		}
+	})
+}

--- a/internal/storage/dolt/wisps.go
+++ b/internal/storage/dolt/wisps.go
@@ -199,6 +199,33 @@ func (s *DoltStore) updateWisp(ctx context.Context, id string, updates map[strin
 	return wrapTransactionError("commit update wisp", tx.Commit())
 }
 
+// updateWispChecked updates a wisp with an optional atomic version precondition,
+// mirroring updateWisp but — when expectedVersion is non-nil — first calling
+// issueops.CheckVersionInTx in the SAME transaction, so a stale version refuses
+// with storage.ErrVersionMismatch before any write and the deferred Rollback
+// discards the transaction (a true compare-and-swap). Like updateWisp it uses a
+// bare BeginTx/Commit with no withRetryTx (consistent with the rest of the wisp
+// write path — do not add one here); wisps live in dolt_ignored tables, so there
+// is no DOLT_COMMIT.
+func (s *DoltStore) updateWispChecked(ctx context.Context, id string, updates map[string]interface{}, actor string, expectedVersion *int64) error {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	if expectedVersion != nil {
+		if err := issueops.CheckVersionInTx(ctx, tx, id, *expectedVersion); err != nil {
+			return err
+		}
+	}
+	if _, err := issueops.UpdateIssueInTx(ctx, tx, id, updates, actor); err != nil {
+		return err
+	}
+
+	return wrapTransactionError("commit update wisp", tx.Commit())
+}
+
 // closeWisp closes a wisp in the wisps table.
 // Delegates SQL work to issueops.CloseIssueInTx; no Dolt versioning needed
 // since wisps live in dolt_ignored tables.

--- a/internal/storage/embeddeddolt/issues.go
+++ b/internal/storage/embeddeddolt/issues.go
@@ -74,6 +74,38 @@ func (s *EmbeddedDoltStore) UpdateIssue(ctx context.Context, id string, updates 
 	})
 }
 
+// UpdateIssueChecked applies the update like UpdateIssue, adding an optional
+// optimistic-concurrency precondition: when opts.ExpectedVersion is non-nil the
+// update proceeds only if the issue's current RowVersion (row_lock) still equals
+// *opts.ExpectedVersion, else it refuses with storage.ErrVersionMismatch. The
+// version read and the update share ONE transaction, so a mismatch returns
+// before any write and the transaction rolls back with the issue unchanged (a
+// true compare-and-swap). nil disables the check, leaving behavior identical to
+// UpdateIssue. Delegates SQL work to issueops; EmbeddedDolt auto-commits the
+// transaction.
+func (s *EmbeddedDoltStore) UpdateIssueChecked(ctx context.Context, id string, updates map[string]interface{}, actor string, opts storage.UpdateIssueOptions) error {
+	// Validate metadata against schema before routing.
+	if rawMeta, ok := updates["metadata"]; ok {
+		metadataStr, err := storage.NormalizeMetadataValue(rawMeta)
+		if err != nil {
+			return fmt.Errorf("invalid metadata: %w", err)
+		}
+		if err := issueops.ValidateMetadataIfConfigured(json.RawMessage(metadataStr)); err != nil {
+			return err
+		}
+	}
+
+	return s.withConn(ctx, true, func(tx *sql.Tx) error {
+		if opts.ExpectedVersion != nil {
+			if err := issueops.CheckVersionInTx(ctx, tx, id, *opts.ExpectedVersion); err != nil {
+				return err
+			}
+		}
+		_, err := issueops.UpdateIssueInTx(ctx, tx, id, updates, actor)
+		return err
+	})
+}
+
 // HeartbeatIssue refreshes the lease on an issue actor holds in_progress.
 // Delegates SQL work to issueops; EmbeddedDolt auto-commits the transaction.
 func (s *EmbeddedDoltStore) HeartbeatIssue(ctx context.Context, id, actor string) error {

--- a/internal/storage/embeddeddolt/update_issue_checked_test.go
+++ b/internal/storage/embeddeddolt/update_issue_checked_test.go
@@ -1,0 +1,97 @@
+//go:build cgo
+
+package embeddeddolt_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/storage"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// TestEmbeddedUpdateIssueCheckedVersionCAS proves the ExpectedVersion CAS wires
+// through the EmbeddedDoltStore's withConn wrapper: a matching version updates, a
+// stale version is refused atomically with storage.ErrVersionMismatch (field
+// unchanged, no updated event), a concurrent write invalidates a captured
+// version, and a nil ExpectedVersion is unchanged behavior. The compare-and-swap
+// core is the shared issueops.UpdateIssueInTx/CheckVersionInTx already covered
+// against a real engine by the dolt package; this test proves the embedded
+// wrapper threads it and rolls back.
+func TestEmbeddedUpdateIssueCheckedVersionCAS(t *testing.T) {
+	skipUnlessEmbeddedDolt(t)
+	te := newTestEnv(t, "ucv")
+	ctx := t.Context()
+	ptr := func(v int64) *int64 { return &v }
+
+	create := func(id string) {
+		iss := &types.Issue{ID: id, Title: id, Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask}
+		if err := te.store.CreateIssue(ctx, iss, "tester"); err != nil {
+			t.Fatalf("create %s: %v", id, err)
+		}
+	}
+	get := func(id string) *types.Issue {
+		iss, err := te.store.GetIssue(ctx, id)
+		if err != nil {
+			t.Fatalf("GetIssue(%s): %v", id, err)
+		}
+		return iss
+	}
+
+	// Matching version updates.
+	create("ucv-match")
+	if err := te.store.UpdateIssueChecked(ctx, "ucv-match",
+		map[string]interface{}{"title": "matched"}, "tester",
+		storage.UpdateIssueOptions{ExpectedVersion: ptr(get("ucv-match").RowVersion)}); err != nil {
+		t.Fatalf("matching-version update err = %v, want nil", err)
+	}
+	if got := get("ucv-match").Title; got != "matched" {
+		t.Fatalf("ucv-match title = %q, want %q", got, "matched")
+	}
+
+	// Stale version refuses atomically: field unchanged, no updated event.
+	create("ucv-stale")
+	before := get("ucv-stale").Title
+	stale := get("ucv-stale").RowVersion + 1
+	err := te.store.UpdateIssueChecked(ctx, "ucv-stale",
+		map[string]interface{}{"title": "should-not-apply"}, "tester",
+		storage.UpdateIssueOptions{ExpectedVersion: ptr(stale)})
+	if !errors.Is(err, storage.ErrVersionMismatch) {
+		t.Fatalf("stale update err = %v, want errors.Is(_, ErrVersionMismatch)", err)
+	}
+	if got := get("ucv-stale").Title; got != before {
+		t.Fatalf("ucv-stale title = %q after refusal, want unchanged %q (withConn did not roll back)", got, before)
+	}
+	events, err := te.store.GetEvents(ctx, "ucv-stale", 0)
+	if err != nil {
+		t.Fatalf("GetEvents: %v", err)
+	}
+	for _, e := range events {
+		if e.EventType == types.EventUpdated {
+			t.Fatalf("updated event recorded despite version mismatch (tx must roll back)")
+		}
+	}
+
+	// A concurrent plain UpdateIssue invalidates a captured version.
+	create("ucv-concurrent")
+	v1 := get("ucv-concurrent").RowVersion
+	if err := te.store.UpdateIssue(ctx, "ucv-concurrent",
+		map[string]interface{}{"priority": 1}, "tester"); err != nil {
+		t.Fatalf("UpdateIssue: %v", err)
+	}
+	if err := te.store.UpdateIssueChecked(ctx, "ucv-concurrent",
+		map[string]interface{}{"title": "should-not-apply"}, "tester",
+		storage.UpdateIssueOptions{ExpectedVersion: ptr(v1)}); !errors.Is(err, storage.ErrVersionMismatch) {
+		t.Fatalf("stale-after-concurrent update err = %v, want errors.Is(_, ErrVersionMismatch)", err)
+	}
+
+	// nil ExpectedVersion is unchanged behavior.
+	if err := te.store.UpdateIssueChecked(ctx, "ucv-stale",
+		map[string]interface{}{"title": "nil-check"}, "tester",
+		storage.UpdateIssueOptions{}); err != nil {
+		t.Fatalf("nil-version update err = %v, want nil (back-compat)", err)
+	}
+	if got := get("ucv-stale").Title; got != "nil-check" {
+		t.Fatalf("ucv-stale title = %q after nil-version update, want %q", got, "nil-check")
+	}
+}

--- a/internal/storage/hook_decorator.go
+++ b/internal/storage/hook_decorator.go
@@ -116,6 +116,17 @@ func (h *HookFiringStore) UpdateIssue(ctx context.Context, id string, updates ma
 	return nil
 }
 
+// UpdateIssueChecked applies the guarded update (optional ExpectedVersion CAS)
+// and fires on_update on success — mirroring UpdateIssue. A version mismatch
+// (ErrVersionMismatch) or any other error returns without firing.
+func (h *HookFiringStore) UpdateIssueChecked(ctx context.Context, id string, updates map[string]interface{}, actor string, opts UpdateIssueOptions) error {
+	if err := h.inner.UpdateIssueChecked(ctx, id, updates, actor, opts); err != nil {
+		return err
+	}
+	h.fireHookByID(ctx, hooks.EventUpdate, id)
+	return nil
+}
+
 // ReopenIssue reopens an issue and fires on_update.
 func (h *HookFiringStore) ReopenIssue(ctx context.Context, id string, reason string, actor string) error {
 	if err := h.inner.ReopenIssue(ctx, id, reason, actor); err != nil {
@@ -566,6 +577,9 @@ var (
 	} = (*HookFiringStore)(nil)
 	_ interface {
 		UpdateIssue(context.Context, string, map[string]interface{}, string) error
+	} = (*HookFiringStore)(nil)
+	_ interface {
+		UpdateIssueChecked(context.Context, string, map[string]interface{}, string, UpdateIssueOptions) error
 	} = (*HookFiringStore)(nil)
 	_ interface {
 		CloseIssue(context.Context, string, string, string, string) error

--- a/internal/storage/hook_decorator_internal_test.go
+++ b/internal/storage/hook_decorator_internal_test.go
@@ -25,6 +25,9 @@ type fakeHookStore struct {
 	DoltStorage
 	issues           map[string]*types.Issue
 	dropDependencies bool
+	// updateCheckedErr, when non-nil, is returned by UpdateIssueChecked so a test
+	// can simulate an inner refusal (e.g. ErrVersionMismatch). nil = success.
+	updateCheckedErr error
 }
 
 func (s fakeHookStore) CreateIssue(_ context.Context, issue *types.Issue, _ string) error {
@@ -60,6 +63,10 @@ func (s fakeHookStore) GetDependencyRecords(_ context.Context, id string) ([]*ty
 		return nil, nil
 	}
 	return cloneDependenciesForHook(issue.Dependencies), nil
+}
+
+func (s fakeHookStore) UpdateIssueChecked(_ context.Context, _ string, _ map[string]interface{}, _ string, _ UpdateIssueOptions) error {
+	return s.updateCheckedErr
 }
 
 func (s fakeHookStore) RunInTransaction(ctx context.Context, _ string, fn func(tx Transaction) error) error {
@@ -451,4 +458,50 @@ func TestNewHookFiringStoreNilRunnerSkipsCreateHooks(t *testing.T) {
 	if err := store.CreateIssue(context.Background(), issue, "tester"); err != nil {
 		t.Fatalf("CreateIssue: %v", err)
 	}
+}
+
+// TestHookFiringStoreUpdateIssueCheckedFiresOnSuccessOnly locks in the
+// HookFiringStore.UpdateIssueChecked override: it fires exactly one on_update
+// hook when the inner update succeeds, and fires NO hook when the inner update
+// refuses (ErrVersionMismatch). Because HookFiringStore embeds DoltStorage, a
+// deleted override would silently passthrough and skip the hook (the success
+// case would fail) — and a refusal must not look like a successful update to
+// hook consumers (the error case).
+func TestHookFiringStoreUpdateIssueCheckedFiresOnSuccessOnly(t *testing.T) {
+	t.Run("success fires one on_update", func(t *testing.T) {
+		runner := &recordingHookRunner{}
+		inner := fakeHookStore{issues: map[string]*types.Issue{
+			"uc-hook": {ID: "uc-hook", Title: "updated"},
+		}}
+		store := &HookFiringStore{DoltStorage: inner, inner: inner, runner: runner}
+
+		if err := store.UpdateIssueChecked(context.Background(), "uc-hook",
+			map[string]interface{}{"title": "updated"}, "tester", UpdateIssueOptions{}); err != nil {
+			t.Fatalf("UpdateIssueChecked: %v", err)
+		}
+		wantEvents := []string{hooks.EventUpdate}
+		if !reflect.DeepEqual(runner.events, wantEvents) {
+			t.Fatalf("events = %v, want %v", runner.events, wantEvents)
+		}
+	})
+
+	t.Run("version-mismatch refusal fires no hook", func(t *testing.T) {
+		runner := &recordingHookRunner{}
+		inner := fakeHookStore{
+			issues:           map[string]*types.Issue{"uc-hook": {ID: "uc-hook"}},
+			updateCheckedErr: ErrVersionMismatch,
+		}
+		store := &HookFiringStore{DoltStorage: inner, inner: inner, runner: runner}
+
+		v := int64(1)
+		err := store.UpdateIssueChecked(context.Background(), "uc-hook",
+			map[string]interface{}{"title": "nope"}, "tester",
+			UpdateIssueOptions{ExpectedVersion: &v})
+		if !errors.Is(err, ErrVersionMismatch) {
+			t.Fatalf("err = %v, want errors.Is(_, ErrVersionMismatch)", err)
+		}
+		if len(runner.events) != 0 {
+			t.Fatalf("events = %v, want none (a refused update must not fire on_update)", runner.events)
+		}
+	})
 }

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -67,6 +67,10 @@ type Storage interface {
 	GetIssueByExternalRef(ctx context.Context, externalRef string) (*types.Issue, error)
 	GetIssuesByIDs(ctx context.Context, ids []string) ([]*types.Issue, error)
 	UpdateIssue(ctx context.Context, id string, updates map[string]interface{}, actor string) error
+	// UpdateIssueChecked applies the update like UpdateIssue, with an optional
+	// optimistic-concurrency precondition: see UpdateIssueOptions.ExpectedVersion.
+	// The version read and the update share one transaction (a true CAS).
+	UpdateIssueChecked(ctx context.Context, id string, updates map[string]interface{}, actor string, opts UpdateIssueOptions) error
 	ReopenIssue(ctx context.Context, id string, reason string, actor string) error
 	UnclaimIssue(ctx context.Context, id string, actor string, force bool) error
 	// UnclaimIssueIfAssignee releases a claim only while the issue is still
@@ -248,6 +252,16 @@ type CloseIssueOptions struct {
 // CloseIssueResult reports the outcome of CloseIssueChecked.
 type CloseIssueResult struct {
 	Unchanged bool // true when the issue was ALREADY closed (idempotent no-op)
+}
+
+// UpdateIssueOptions carries the optional inputs to UpdateIssueChecked.
+type UpdateIssueOptions struct {
+	// ExpectedVersion, when non-nil, makes the update a compare-and-swap: it
+	// proceeds only if the issue's current RowVersion (row_lock) equals
+	// *ExpectedVersion, else it refuses with ErrVersionMismatch atomically.
+	// nil disables the check. A pointer so nil is distinct from requiring a
+	// legacy version of 0.
+	ExpectedVersion *int64
 }
 
 // MergeSlotStatus is returned by MergeSlotCheck and describes the current

--- a/internal/telemetry/storage.go
+++ b/internal/telemetry/storage.go
@@ -153,6 +153,18 @@ func (s *InstrumentedStorage) UpdateIssue(ctx context.Context, id string, update
 	return err
 }
 
+func (s *InstrumentedStorage) UpdateIssueChecked(ctx context.Context, id string, updates map[string]interface{}, actor string, opts storage.UpdateIssueOptions) error {
+	attrs := []attribute.KeyValue{
+		attribute.String("bd.issue.id", id),
+		attribute.String("bd.actor", actor),
+		attribute.Int("bd.update.count", len(updates)),
+	}
+	ctx, span, t := s.op(ctx, "UpdateIssueChecked", attrs...)
+	err := s.inner.UpdateIssueChecked(ctx, id, updates, actor, opts)
+	s.done(ctx, span, t, err, attrs...)
+	return err
+}
+
 func (s *InstrumentedStorage) ReopenIssue(ctx context.Context, id string, reason string, actor string) error {
 	attrs := []attribute.KeyValue{
 		attribute.String("bd.issue.id", id),


### PR DESCRIPTION
> Stacked on #4904 (S7) → #4903 (S5b) → … → #4892 (S1). Base is `feat/guarded-ops-s7-cli-delegation`; retarget down the stack as each lands. The diff below is S5c only.

## What

Adds `UpdateIssueChecked` — the generic field-map update with an optional compare-and-swap on the row's version (`RowVersion` / `row_lock`), mirroring the `CloseIssueChecked` CAS. When `ExpectedVersion` is supplied, the version read and the update share one transaction and a moved row refuses with the typed `beads.ErrVersionMismatch`. Nil disables the check; `UpdateIssue` itself is untouched.

## Why

A caller that reads an issue and then updates it couldn't express "only if it hasn't changed since I read it" — the read and the write were separate calls, a lost-update window. This closes it at the engine, the same way the checked close did, so `bd` (and the library's own call sites) get optimistic concurrency on the update verb without hand-rolling a read-then-write.

One route needed real care: an update carrying `no_history`/`wisp` routes through the demote-to-wisp flow (a multi-table row move). A pure extraction (`demoteToWispInTx`, verified byte-identical to the old body under `git diff -w`) lets the version check compose atomically with the demote in the same transaction — and tests now lock that seam.

## Verification

- CAS match updates and bumps `RowVersion`; stale refuses atomically (`errors.Is(ErrVersionMismatch)`, field unchanged, zero `updated` events); a committed concurrent write invalidates a captured version; nil is byte-identical to `UpdateIssue` (line-by-line parity: same validation, routing, commit); missing id → `ErrNotFound`.
- All routes covered on both stores: permanent, wisp (match + stale), and the demote route (match migrates + applies; stale leaves the row in `issues`, unchanged). The hook decorator fires `on_update` exactly once on success and never on a refused update.
- `gofmt`/`go vet` clean; `go build ./...` under cgo and `CGO_ENABLED=0`; `golangci-lint` 0 issues; `UpdateIssue`/`DemoteToWisp` regression suites green.

```bash
go test ./internal/storage/dolt/ -run TestUpdateIssueCheckedVersionCAS -v
go test ./internal/storage/ -run TestHookFiringStoreUpdateIssueChecked -v
```
