### PR TITLE
docs(async-gates): fix nonexistent gate subcommands in skill resource

### DIFF
--- a/plugins/beads/skills/beads/resources/ASYNC_GATES.md
+++ b/plugins/beads/skills/beads/resources/ASYNC_GATES.md
@@ -14,7 +14,7 @@
 | CI | `gh:run` | GitHub Actions run ID | Wait for GitHub Actions completion |
 | PR | `gh:pr` | PR number | Wait for PR merge |
 | Timer | `timer` | — | Deployment propagation delay |
-| Bead | `bead` | `<rig>:<bead-id>` | Wait for a cross-rig bead to close |
+| Bead | `bead` | `<bead-id>` (local) | Wait for another local bead to close |
 
 ---
 
@@ -37,10 +37,14 @@ bd gate create --type gh:pr --blocks bd-abc \
 bd gate create --type timer --blocks bd-abc \
   --timeout 15m
 
-# Cross-rig bead gate
+# Bead gate (waits for a local bead to close)
 bd gate create --type bead --blocks bd-abc \
-  --await-id other-project:op-abc123
+  --await-id bd-xyz
 ```
+
+> Note: cross-rig await IDs (`<rig>:<bead-id>`) are accepted at create time
+> but are not currently evaluable — the gate stays pending forever. Use a
+> local bead ID.
 
 **Required options**:
 - `--blocks <issue-id>` — Issue that stays blocked until the gate resolves

--- a/plugins/beads/skills/beads/resources/ASYNC_GATES.md
+++ b/plugins/beads/skills/beads/resources/ASYNC_GATES.md
@@ -12,42 +12,44 @@
 |------|-----------------|--------------|----------|
 | Human | `human` (default) | — | Cross-session human approval |
 | CI | `gh:run` | GitHub Actions run ID | Wait for GitHub Actions completion |
-| PR | `gh:pr` | PR number | Wait for PR merge/close |
+| PR | `gh:pr` | PR number | Wait for PR merge |
 | Timer | `timer` | — | Deployment propagation delay |
+| Bead | `bead` | `<rig>:<bead-id>` | Wait for a cross-rig bead to close |
 
 ---
 
 ## Creating Gates
 
 ```bash
-# Human approval gate
+# Human approval gate (timeout is stored but not enforced by check)
 bd gate create --type human --blocks bd-abc \
-  --reason "Approve production deploy" \
-  --timeout 4h
+  --reason "Approve production deploy"
 
 # CI gate (GitHub Actions)
 bd gate create --type gh:run --blocks bd-abc \
-  --await-id 123456789 \
-  --timeout 30m
+  --await-id 123456789
 
 # PR merge gate
 bd gate create --type gh:pr --blocks bd-abc \
-  --await-id 42 \
-  --timeout 24h
+  --await-id 42
 
-# Timer gate (deployment propagation)
+# Timer gate (deployment propagation) — --timeout is enforced by check
 bd gate create --type timer --blocks bd-abc \
   --timeout 15m
+
+# Cross-rig bead gate
+bd gate create --type bead --blocks bd-abc \
+  --await-id other-project:op-abc123
 ```
 
 **Required options**:
 - `--blocks <issue-id>` — Issue that stays blocked until the gate resolves
 
 **Optional**:
-- `--type <type>` — Gate type: `human`, `timer`, `gh:run`, `gh:pr` (default `human`)
-- `--await-id <id>` — Condition identifier (run ID, PR number, etc.)
-- `--reason <text>` — Human-readable description of what's being gated
-- `--timeout <duration>` — Recommended: prevents forever-open gates
+- `--type <type>` — Gate type: `human`, `timer`, `gh:run`, `gh:pr`, `bead` (default `human`)
+- `--await-id <id>` — Condition identifier (run ID, PR number, `rig:bead-id`, etc.)
+- `--reason <text>` — Stored on the gate as its description (what is being gated)
+- `--timeout <duration>` — **Only timer gates enforce this** via `bd gate check`. You can set it on other types for documentation, but `check` does not auto-resolve/escalate human or GitHub gates based on timeout.
 
 ---
 
@@ -57,15 +59,22 @@ bd gate create --type timer --blocks bd-abc \
 bd gate list              # All open gates
 bd gate list --all        # Include closed
 bd gate show <gate-id>    # Details for specific gate
-bd gate check             # Evaluate open gates, close resolved ones
-bd gate check --dry-run   # Preview what would close
+bd gate check             # Evaluate open gates (resolve / escalate / pending)
+bd gate check --dry-run   # Preview without closing or escalating
+bd gate check --escalate  # Also fire escalations for failed/closed-unmerged gates
 ```
 
-**Auto-close behavior** (`bd gate check`):
-- `timer` — Closes when duration elapsed
-- `gh:run` — Checks GitHub API (`gh run view`), closes on success/failure
-- `gh:pr` — Checks GitHub API (`gh pr view`), closes on merge/close
-- `human` — Never auto-closes; requires explicit `bd gate resolve`
+**What `bd gate check` does** (by type):
+
+| Type | Resolves (closes gate) when | Escalates (gate stays open) when |
+|------|-----------------------------|----------------------------------|
+| `timer` | `now > created_at + timeout` | never (timers only resolve or stay pending) |
+| `gh:run` | run `status=completed` **and** `conclusion=success` (also `skipped`) | run completed with `failure` / `canceled` |
+| `gh:pr` | PR `state=MERGED` | PR `state=CLOSED` without merge |
+| `bead` | target bead `status=closed` | — |
+| `human` | **never** via `check` — use `bd gate resolve` | — |
+
+Only **resolved** gates are closed. Escalated gates remain open; use `--escalate` to notify, then decide whether to `bd gate resolve` manually.
 
 ---
 
@@ -76,11 +85,11 @@ bd gate check --dry-run   # Preview what would close
 bd gate resolve <gate-id>
 bd gate resolve <gate-id> --reason "Reviewed and approved by Steve"
 
-# Manual close (any gate) — there's no separate "close" subcommand,
+# Manual close (any gate) — there is no separate "close" subcommand;
 # resolve works on gates of any type
 bd gate resolve <gate-id> --reason "No longer needed"
 
-# Auto-close via evaluation
+# Auto-resolve via evaluation (success/merge/timer only)
 bd gate check
 ```
 
@@ -88,29 +97,29 @@ bd gate check
 
 ## Best Practices
 
-1. **Always set timeouts**: Prevents forever-open gates
+1. **Timeouts only protect timer gates**: `bd gate check` evaluates `Timeout` for `timer` only. For human/GitHub forever-open protection, schedule a manual review or resolve yourself — do not rely on `--timeout` alone.
    ```bash
-   bd gate create --type human --blocks bd-abc --timeout 24h
+   bd gate create --type timer --blocks bd-abc --timeout 15m
    ```
 
-2. **Clear reasons**: The `--reason` text should indicate what's being gated
+2. **Clear reasons**: `--reason` is stored as the gate description (what is being gated).
    ```bash
    --reason "Approve Phase 2: Core Implementation"
    ```
 
-3. **Check periodically**: Run at session start to close elapsed gates
+3. **Check periodically**: Run at session start to resolve elapsed timers / successful CI / merged PRs.
    ```bash
    bd gate check
    ```
 
-4. **Clean up obsolete gates**: Close gates that are no longer needed
+4. **Clean up obsolete gates**: Resolve gates that are no longer needed.
    ```bash
    bd gate resolve <id> --reason "superseded by new approach"
    ```
 
-5. **Check before creating**: Avoid duplicate gates
+5. **Find a gate by reason/description**: plain `bd gate list` prints id + await type/id only (not title/description). Filter JSON instead:
    ```bash
-   bd gate list | grep "spec-myfeature"
+   bd gate list --json | jq -r '.[] | select((.description // .title // "") | test("Phase 2"; "i")) | .id'
    ```
 
 ---
@@ -121,11 +130,11 @@ bd gate check
 |--------|--------------|--------|
 | Persistence | Ephemeral (not synced) | Permanent (synced to git) |
 | Purpose | Block on external condition | Track work items |
-| Lifecycle | Auto-close when condition met | Manual close |
+| Lifecycle | Resolve on success/merge/timer; escalate on failure | Manual close |
 | Visibility | `bd gate list` | `bd list` |
-| Use case | CI, approval, timers | Tasks, bugs, features |
+| Use case | CI, approval, timers, cross-rig | Tasks, bugs, features |
 
-Gates are designed to be temporary coordination primitives—they exist only until their condition is satisfied.
+Gates are designed to be temporary coordination primitives—they exist only until their condition is satisfied (or you resolve them by hand).
 
 ---
 
@@ -140,8 +149,9 @@ bd gate show <gate-id>
 # For gh:run gates, verify the run exists
 gh run view <run-id>
 
-# Force close if stuck
-bd gate resolve <gate-id> --reason "manual override"
+# Failed CI / closed-unmerged PR escalate — they do NOT auto-resolve.
+# Resolve manually when you have handled the failure:
+bd gate resolve <gate-id> --reason "handled failure / no longer blocking"
 ```
 
 ### Can't find gate ID
@@ -150,8 +160,8 @@ bd gate resolve <gate-id> --reason "manual override"
 # List all gates (including closed)
 bd gate list --all
 
-# Search by title pattern
-bd gate list | grep "Phase 2"
+# Search by description/reason (list text output has neither)
+bd gate list --json | jq -r '.[] | select((.description // .title // "") | test("Phase 2"; "i")) | "\(.id) \(.await_type // .awaitType) \(.description // .title)"'
 ```
 
 ### CI run ID detection fails

--- a/plugins/beads/skills/beads/resources/ASYNC_GATES.md
+++ b/plugins/beads/skills/beads/resources/ASYNC_GATES.md
@@ -8,13 +8,12 @@
 
 ## Gate Types
 
-| Type | Await Syntax | Use Case |
-|------|--------------|----------|
-| Human | `human:<prompt>` | Cross-session human approval |
-| CI | `gh:run:<id>` | Wait for GitHub Actions completion |
-| PR | `gh:pr:<id>` | Wait for PR merge/close |
-| Timer | `timer:<duration>` | Deployment propagation delay |
-| Mail | `mail:<pattern>` | Wait for matching email |
+| Type | `--type` value | `--await-id` | Use Case |
+|------|-----------------|--------------|----------|
+| Human | `human` (default) | — | Cross-session human approval |
+| CI | `gh:run` | GitHub Actions run ID | Wait for GitHub Actions completion |
+| PR | `gh:pr` | PR number | Wait for PR merge/close |
+| Timer | `timer` | — | Deployment propagation delay |
 
 ---
 
@@ -22,32 +21,33 @@
 
 ```bash
 # Human approval gate
-bd gate create --await human:deploy-approval \
-  --title "Approve production deploy" \
+bd gate create --type human --blocks bd-abc \
+  --reason "Approve production deploy" \
   --timeout 4h
 
 # CI gate (GitHub Actions)
-bd gate create --await gh:run:123456789 \
-  --title "Wait for CI" \
+bd gate create --type gh:run --blocks bd-abc \
+  --await-id 123456789 \
   --timeout 30m
 
 # PR merge gate
-bd gate create --await gh:pr:42 \
-  --title "Wait for PR approval" \
+bd gate create --type gh:pr --blocks bd-abc \
+  --await-id 42 \
   --timeout 24h
 
 # Timer gate (deployment propagation)
-bd gate create --await timer:15m \
-  --title "Wait for deployment propagation"
+bd gate create --type timer --blocks bd-abc \
+  --timeout 15m
 ```
 
 **Required options**:
-- `--await <spec>` — Gate condition (see types above)
-- `--timeout <duration>` — Recommended: prevents forever-open gates
+- `--blocks <issue-id>` — Issue that stays blocked until the gate resolves
 
 **Optional**:
-- `--title <text>` — Human-readable description
-- `--notify <recipients>` — Email/beads addresses to notify
+- `--type <type>` — Gate type: `human`, `timer`, `gh:run`, `gh:pr` (default `human`)
+- `--await-id <id>` — Condition identifier (run ID, PR number, etc.)
+- `--reason <text>` — Human-readable description of what's being gated
+- `--timeout <duration>` — Recommended: prevents forever-open gates
 
 ---
 
@@ -57,31 +57,31 @@ bd gate create --await timer:15m \
 bd gate list              # All open gates
 bd gate list --all        # Include closed
 bd gate show <gate-id>    # Details for specific gate
-bd gate eval              # Auto-close elapsed/completed gates
-bd gate eval --dry-run    # Preview what would close
+bd gate check             # Evaluate open gates, close resolved ones
+bd gate check --dry-run   # Preview what would close
 ```
 
-**Auto-close behavior** (`bd gate eval`):
-- `timer:*` — Closes when duration elapsed
-- `gh:run:*` — Checks GitHub API, closes on success/failure
-- `gh:pr:*` — Checks GitHub API, closes on merge/close
-- `human:*` — Requires explicit `bd gate approve`
+**Auto-close behavior** (`bd gate check`):
+- `timer` — Closes when duration elapsed
+- `gh:run` — Checks GitHub API (`gh run view`), closes on success/failure
+- `gh:pr` — Checks GitHub API (`gh pr view`), closes on merge/close
+- `human` — Never auto-closes; requires explicit `bd gate resolve`
 
 ---
 
 ## Closing Gates
 
 ```bash
-# Human gates require explicit approval
-bd gate approve <gate-id>
-bd gate approve <gate-id> --comment "Reviewed and approved by Steve"
+# Human gates require explicit resolution
+bd gate resolve <gate-id>
+bd gate resolve <gate-id> --reason "Reviewed and approved by Steve"
 
-# Manual close (any gate)
-bd gate close <gate-id>
-bd gate close <gate-id> --reason "No longer needed"
+# Manual close (any gate) — there's no separate "close" subcommand,
+# resolve works on gates of any type
+bd gate resolve <gate-id> --reason "No longer needed"
 
 # Auto-close via evaluation
-bd gate eval
+bd gate check
 ```
 
 ---
@@ -90,22 +90,22 @@ bd gate eval
 
 1. **Always set timeouts**: Prevents forever-open gates
    ```bash
-   bd gate create --await human:... --timeout 24h
+   bd gate create --type human --blocks bd-abc --timeout 24h
    ```
 
-2. **Clear titles**: Title should indicate what's being gated
+2. **Clear reasons**: The `--reason` text should indicate what's being gated
    ```bash
-   --title "Approve Phase 2: Core Implementation"
+   --reason "Approve Phase 2: Core Implementation"
    ```
 
-3. **Eval periodically**: Run at session start to close elapsed gates
+3. **Check periodically**: Run at session start to close elapsed gates
    ```bash
-   bd gate eval
+   bd gate check
    ```
 
 4. **Clean up obsolete gates**: Close gates that are no longer needed
    ```bash
-   bd gate close <id> --reason "superseded by new approach"
+   bd gate resolve <id> --reason "superseded by new approach"
    ```
 
 5. **Check before creating**: Avoid duplicate gates
@@ -141,7 +141,7 @@ bd gate show <gate-id>
 gh run view <run-id>
 
 # Force close if stuck
-bd gate close <gate-id> --reason "manual override"
+bd gate resolve <gate-id> --reason "manual override"
 ```
 
 ### Can't find gate ID


### PR DESCRIPTION

## What

`plugins/beads/skills/beads/resources/ASYNC_GATES.md` documents `bd gate eval`, `bd gate approve`, `bd gate close`, and a combined `--await <type>:<id>` flag. None of these exist on `main` — cobra falls through to parent help for all of them. This PR corrects every command in the doc to match the real subcommand tree (`create`, `list`, `show`, `check`, `resolve`, `add-waiter`, `discover`) and its actual flags.

## Why

Discovered this while building a community skill against `bd` 1.0.4 (`bd gate --help` there lists `add-waiter/check/create/discover/list/resolve/show`, no `eval`/`approve`/`close`) and confirmed the same surface is current on `main`. An agent following this doc verbatim gets a cobra usage error on the very first `bd gate create --await ...` example.

## How each replacement was verified

Ground truth is `cmd/bd/gate.go` on `main` (cross-checked against the auto-generated `docs/cli-reference/gate.md`):

- `bd gate eval` → `bd gate check` — `gateCheckCmd` (`cmd/bd/gate.go:523`, `Use: "check"`, `Short: "Evaluate gates and close resolved ones"`); `--dry-run` flag registered at `cmd/bd/gate.go:1015`.
- `bd gate approve <id>` → `bd gate resolve <id>` — `gateResolveCmd` (`cmd/bd/gate.go:469`, `Short: "Manually resolve (close) a gate"`); doc-comment explicitly says human gates require `bd gate resolve` (`cmd/bd/gate.go:290-296`). No `approve` command or `--comment` flag exists; `resolve` takes `--reason` (`cmd/bd/gate.go:1011`).
- `bd gate close <id>` → `bd gate resolve <id>` — there is no standalone `close` subcommand; `resolve` is documented as "equivalent to `bd close <gate-id>` but with a more explicit name" (`cmd/bd/gate.go:471-473`), so it also covers the doc's "manual close (any gate)" and "force close if stuck" cases.
- `--await <type>:<id>` → `--type <type> --await-id <id>` — `gateCreateCmd` has no `--await` flag; it registers `--type` (default `human`; allowed values `human`, `timer`, `gh:run`, `gh:pr`) and `--await-id` separately (`cmd/bd/gate.go:1024-1029`).
- `--title` / `--notify` → dropped, replaced with `--reason` where a description was implied — neither flag exists on `gate create`; the closest real equivalent is `--reason string` (`cmd/bd/gate.go:1027`).
- "Mail" gate type row → removed — grepped `cmd/bd/gate.go` and `internal/` for any `mail:` await-type handling; none exists. The only `mail` command in the codebase (`cmd/bd/mail.go`) is unrelated to gates.

## Scope

Deliberately minimal — no restructuring, no new sections, no touching the sibling resources. Every code block that referenced a nonexistent command/flag was corrected in place; everything else (tables like "Gates vs Issues", the troubleshooting flow, prose) is untouched.

Note for maintainers: `plugins/beads/skills/beads/CLAUDE.md` flags CLI-syntax duplication in resources as a staleness risk ("CLI command syntax ❌ No — Use `bd <cmd> --help`") — which is exactly what happened here. Out of scope for this PR, but might be worth a follow-up to trim the hardcoded flag lists in `ASYNC_GATES.md` down to conceptual guidance + a pointer to `bd gate --help`, the way `SKILL.md` already does for the resource index entry.

## Testing

Docs-only change to a plugin resource (not part of the Mintlify `docs/` tree, so `docs-render-check` doesn't cover it). Verified by reading `cmd/bd/gate.go` directly rather than running the CLI, since every replacement command's existence and flags are visible in the source.
