### PR TITLE
feat(comments): keyset-paged comments read (GetIssueCommentsPage)

### DIFF
--- a/beads.go
+++ b/beads.go
@@ -64,6 +64,12 @@ type CloseIssueResult = storage.CloseIssueResult
 // name it without importing internal/storage.
 type UpdateIssueOptions = storage.UpdateIssueOptions
 
+// CommentPageCursor is the resume position for Storage.GetIssueCommentsPage — the
+// (created_at, id) of the last comment already returned, with the zero value
+// starting a walk from the beginning of the thread. Exported so consumers can
+// name it without importing internal/storage.
+type CommentPageCursor = storage.CommentPageCursor
+
 // RemoteStore provides dolt remote management and replication operations.
 // Use type assertion on a Storage value to access these methods:
 //

--- a/internal/jira/tracker_test.go
+++ b/internal/jira/tracker_test.go
@@ -714,6 +714,10 @@ func (s *configStore) AddIssueComment(_ context.Context, _, _, _ string) (*types
 func (s *configStore) GetIssueComments(_ context.Context, _ string) ([]*types.Comment, error) {
 	return nil, nil
 }
+
+func (s *configStore) GetIssueCommentsPage(_ context.Context, _ string, _ storage.CommentPageCursor, _ int) ([]*types.Comment, error) {
+	return nil, nil
+}
 func (s *configStore) GetEvents(_ context.Context, _ string, _ int) ([]*types.Event, error) {
 	return nil, nil
 }

--- a/internal/storage/dolt/comments_page_test.go
+++ b/internal/storage/dolt/comments_page_test.go
@@ -1,0 +1,346 @@
+package dolt
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/steveyegge/beads/internal/storage"
+	"github.com/steveyegge/beads/internal/storage/issueops"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// cmtIDs projects comment IDs in result order.
+func cmtIDs(cs []*types.Comment) []string {
+	out := make([]string, len(cs))
+	for i, c := range cs {
+		out[i] = c.ID
+	}
+	return out
+}
+
+func cmtEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// seedGroupedComments inserts n comments on issueID with ids that sort lexically
+// by index and created_at bucketed into same-second groups of groupSize (forcing
+// the (created_at, id) tie-break). It returns the whole-second base time. Raw
+// INSERTs give the test full control of both id and created_at.
+func seedGroupedComments(t *testing.T, ctx context.Context, db *sql.DB, issueID string, n, groupSize int) time.Time {
+	t.Helper()
+	base := time.Date(2024, 1, 2, 3, 4, 5, 0, time.UTC)
+	for i := 0; i < n; i++ {
+		id := fmt.Sprintf("00000000-0000-0000-0000-%012d", i)
+		at := base.Add(time.Duration(i/groupSize) * time.Second)
+		if _, err := db.ExecContext(ctx,
+			"INSERT INTO comments (id, issue_id, author, text, created_at) VALUES (?, ?, ?, ?, ?)",
+			id, issueID, "tester", fmt.Sprintf("c%d", i), at); err != nil {
+			t.Fatalf("insert comment %d: %v", i, err)
+		}
+	}
+	return base
+}
+
+// walkCommentsPage pages the whole thread with the given limit, feeding each
+// page's last (created_at, id) back in as the cursor, and returns the collected
+// ids. It fails on any duplicate id or an over-long page.
+func walkCommentsPage(t *testing.T, ctx context.Context, s *DoltStore, issueID string, limit int) []string {
+	t.Helper()
+	var collected []string
+	seen := map[string]bool{}
+	var after storage.CommentPageCursor
+	for i := 0; i < 1000; i++ {
+		page, err := s.GetIssueCommentsPage(ctx, issueID, after, limit)
+		if err != nil {
+			t.Fatalf("GetIssueCommentsPage(page %d): %v", i, err)
+		}
+		if len(page) == 0 {
+			break
+		}
+		if len(page) > limit {
+			t.Fatalf("page %d size = %d, want <= %d", i, len(page), limit)
+		}
+		for _, c := range page {
+			if seen[c.ID] {
+				t.Fatalf("duplicate id %q across pages — same-second overflow was lost", c.ID)
+			}
+			seen[c.ID] = true
+			collected = append(collected, c.ID)
+		}
+		last := page[len(page)-1]
+		after = storage.CommentPageCursor{CreatedAt: last.CreatedAt, ID: last.ID}
+	}
+	return collected
+}
+
+// TestGetIssueCommentsPageWalkEqualsFullRead is the money property: a keyset walk
+// with a page size smaller than a same-second group reproduces GetIssueComments
+// exactly — same order, no dropped or duplicated comment, no gap — even across
+// same-second collisions where a created_at-only cursor would lose the overflow.
+func TestGetIssueCommentsPageWalkEqualsFullRead(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	iss := &types.Issue{ID: "cm-page", Title: "cm", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask}
+	if err := store.CreateIssue(ctx, iss, "tester"); err != nil {
+		t.Fatalf("create issue: %v", err)
+	}
+	// 25 comments in 5 same-second groups of 5 (groupSize 5 > page size 4).
+	const n, groupSize, pageSize = 25, 5, 4
+	seedGroupedComments(t, ctx, store.db, iss.ID, n, groupSize)
+
+	full, err := store.GetIssueComments(ctx, iss.ID)
+	if err != nil {
+		t.Fatalf("GetIssueComments: %v", err)
+	}
+	if len(full) != n {
+		t.Fatalf("full read = %d comments, want %d", len(full), n)
+	}
+
+	// Same-second tie-break, explicit: the first group shares one created_at and
+	// is returned in strictly ascending id order (the secondary sort key).
+	for i := 1; i < groupSize; i++ {
+		if !full[i].CreatedAt.Equal(full[0].CreatedAt) {
+			t.Fatalf("group 0 not same-second: full[%d].CreatedAt=%v != full[0]=%v", i, full[i].CreatedAt, full[0].CreatedAt)
+		}
+		if full[i].ID <= full[i-1].ID {
+			t.Fatalf("same-second group not id-ascending at %d: %q <= %q", i, full[i].ID, full[i-1].ID)
+		}
+	}
+
+	// The walk (page size < group size) equals the full read exactly.
+	walked := walkCommentsPage(t, ctx, store, iss.ID, pageSize)
+	if want := cmtIDs(full); !cmtEqual(walked, want) {
+		t.Fatalf("keyset walk = %v,\nwant full read %v", walked, want)
+	}
+
+	// First page (zero cursor) is exactly the first pageSize in order.
+	first, err := store.GetIssueCommentsPage(ctx, iss.ID, storage.CommentPageCursor{}, pageSize)
+	if err != nil {
+		t.Fatalf("GetIssueCommentsPage(first): %v", err)
+	}
+	if got, want := cmtIDs(first), cmtIDs(full)[:pageSize]; !cmtEqual(got, want) {
+		t.Fatalf("first page = %v, want %v", got, want)
+	}
+
+	// A cursor planted on the last comment (past-the-end) yields an empty page.
+	lastC := full[len(full)-1]
+	end, err := store.GetIssueCommentsPage(ctx, iss.ID, storage.CommentPageCursor{CreatedAt: lastC.CreatedAt, ID: lastC.ID}, pageSize)
+	if err != nil {
+		t.Fatalf("GetIssueCommentsPage(past-the-end): %v", err)
+	}
+	if len(end) != 0 {
+		t.Fatalf("past-the-end page = %v, want empty", cmtIDs(end))
+	}
+
+	// limit <= 0 falls back to the store default (>= n here), returning the whole
+	// thread in one page identical to the full read.
+	def, err := store.GetIssueCommentsPage(ctx, iss.ID, storage.CommentPageCursor{}, 0)
+	if err != nil {
+		t.Fatalf("GetIssueCommentsPage(limit=0): %v", err)
+	}
+	if got, want := cmtIDs(def), cmtIDs(full); !cmtEqual(got, want) {
+		t.Fatalf("default-limit page = %v, want full read %v", got, want)
+	}
+}
+
+// TestGetIssueCommentsPageEmptyThread pins the empty-thread and missing-issue
+// semantics: both return an empty page with no error, matching GetIssueComments.
+func TestGetIssueCommentsPageEmptyThread(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	iss := &types.Issue{ID: "cm-empty", Title: "cm", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask}
+	if err := store.CreateIssue(ctx, iss, "tester"); err != nil {
+		t.Fatalf("create issue: %v", err)
+	}
+
+	empty, err := store.GetIssueCommentsPage(ctx, iss.ID, storage.CommentPageCursor{}, 10)
+	if err != nil {
+		t.Fatalf("GetIssueCommentsPage(empty thread): %v", err)
+	}
+	if len(empty) != 0 {
+		t.Fatalf("empty thread page = %v, want empty", cmtIDs(empty))
+	}
+
+	missing, err := store.GetIssueCommentsPage(ctx, "does-not-exist", storage.CommentPageCursor{}, 10)
+	if err != nil {
+		t.Fatalf("GetIssueCommentsPage(missing issue): %v", err)
+	}
+	if len(missing) != 0 {
+		t.Fatalf("missing-issue page = %v, want empty", cmtIDs(missing))
+	}
+}
+
+// TestGetIssueCommentsPageWisp verifies the wisp route: a page on an active wisp
+// reads wisp_comments (not comments) and matches GetIssueComments for that wisp.
+func TestGetIssueCommentsPageWisp(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	wisp := &types.Issue{ID: "cm-wisp", Title: "wisp", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask, Ephemeral: true}
+	if err := store.CreateIssue(ctx, wisp, "tester"); err != nil {
+		t.Fatalf("create wisp: %v", err)
+	}
+	base := time.Date(2024, 5, 6, 7, 8, 9, 0, time.UTC)
+	for i := 0; i < 6; i++ {
+		if _, err := store.ImportIssueComment(ctx, wisp.ID, "tester", fmt.Sprintf("w%d", i), base.Add(time.Duration(i)*time.Second)); err != nil {
+			t.Fatalf("import wisp comment %d: %v", i, err)
+		}
+	}
+
+	// Nothing landed in the durable comments table — routing hit wisp_comments.
+	var durable int
+	if err := store.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM comments WHERE issue_id = ?", wisp.ID).Scan(&durable); err != nil {
+		t.Fatalf("count durable comments: %v", err)
+	}
+	if durable != 0 {
+		t.Fatalf("wisp comments leaked into durable table: %d rows", durable)
+	}
+
+	full, err := store.GetIssueComments(ctx, wisp.ID)
+	if err != nil {
+		t.Fatalf("GetIssueComments(wisp): %v", err)
+	}
+	if len(full) != 6 {
+		t.Fatalf("wisp full read = %d, want 6", len(full))
+	}
+	walked := walkCommentsPage(t, ctx, store, wisp.ID, 2)
+	if want := cmtIDs(full); !cmtEqual(walked, want) {
+		t.Fatalf("wisp keyset walk = %v, want %v", walked, want)
+	}
+}
+
+// TestGetIssueCommentsPagePlanIsIndexed is the sargability regression guard: the
+// keyset page predicate must seek the (issue_id, created_at, id) index
+// (IndexedTableAccess), not full-scan-and-filter the issue's comments. The
+// redundant `created_at >= ?` lower bound in CommentsKeysetPredicate is what keeps
+// the Dolt planner on the index. It single-sources the guarded SQL from
+// production (issueops.CommentsPageQuery, which embeds CommentsKeysetPredicate)
+// and skips rather than fails if the EXPLAIN format is unrecognizable.
+func TestGetIssueCommentsPagePlanIsIndexed(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	iss := &types.Issue{ID: "cm-plan", Title: "cm", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask}
+	if err := store.CreateIssue(ctx, iss, "tester"); err != nil {
+		t.Fatalf("create issue: %v", err)
+	}
+	seedGroupedComments(t, ctx, store.db, iss.ID, 10, 2)
+
+	// Single-source: the production query string must embed the exported
+	// predicate, so a drift in CommentsKeysetPredicate breaks both.
+	prod := issueops.CommentsPageQuery("comments", true, 100)
+	if !strings.Contains(prod, issueops.CommentsKeysetPredicate) {
+		t.Fatalf("production page query does not embed CommentsKeysetPredicate:\n%s", prod)
+	}
+
+	const cur = "2024-01-02 03:04:05"
+	// Four ? placeholders: issue_id, created_at (lower bound), created_at
+	// (strict), id (tie-break).
+	plan := explainPlan(t, ctx, store.db, literalizeParams(prod, "'"+iss.ID+"'", "'"+cur+"'", "'"+cur+"'", "''"))
+
+	if !looksLikeDoltPlan(plan) {
+		t.Skipf("EXPLAIN output not in a recognized Dolt plan format, skipping sargability assertion; plan=\n%s", plan)
+	}
+	// Pin the COMPOSITE index specifically, not merely "some index". Dolt's
+	// EXPLAIN identifies an index by its column list rather than its name, so the
+	// composite idx_comments_issue_created_id shows as
+	// [comments.issue_id,comments.created_at,comments.id]. The single-column
+	// idx_comments_issue shows only [comments.issue_id] (verified by a
+	// drop-index probe during authoring) — so this exact signature fails if the
+	// planner regresses to the issue-only index (leaving the created_at range +
+	// id tie-break to a filter+sort) or to a full scan.
+	const compositeIndexCols = "[comments.issue_id,comments.created_at,comments.id]"
+	if !strings.Contains(plan, "IndexedTableAccess") || !strings.Contains(plan, compositeIndexCols) {
+		t.Fatalf("comment page predicate does not seek the composite index (want IndexedTableAccess on %s) — regressed to the issue-only index or a full Table scan.\nplan:\n%s", compositeIndexCols, plan)
+	}
+}
+
+// literalizeParams replaces each ? placeholder in query, in order, with the
+// corresponding literal — for EXPLAINing a production ?-bound SQL string whose
+// planner shape is under test. It panics on an arity mismatch so a drifted
+// placeholder count fails loudly rather than EXPLAINing malformed SQL.
+func literalizeParams(query string, literals ...string) string {
+	for _, lit := range literals {
+		if !strings.Contains(query, "?") {
+			panic("literalizeParams: more literals than ? placeholders in query")
+		}
+		query = strings.Replace(query, "?", lit, 1)
+	}
+	if strings.Contains(query, "?") {
+		panic("literalizeParams: unbound ? placeholder(s) remain in query")
+	}
+	return query
+}
+
+// explainPlan runs EXPLAIN FORMAT=TREE <query> and joins the plan tree into one
+// string. FORMAT=TREE yields the go-mysql-server node tree in a single "plan"
+// column (IndexedTableAccess / Filter / TopN); the default tabular EXPLAIN is
+// avoided because its numeric columns break the MySQL driver's row decode.
+func explainPlan(t *testing.T, ctx context.Context, db *sql.DB, query string) string {
+	t.Helper()
+	rows, err := db.QueryContext(ctx, "EXPLAIN FORMAT=TREE "+query)
+	if err != nil {
+		t.Fatalf("EXPLAIN: %v", err)
+	}
+	defer rows.Close()
+	cols, err := rows.Columns()
+	if err != nil {
+		t.Fatalf("EXPLAIN columns: %v", err)
+	}
+	var out strings.Builder
+	for rows.Next() {
+		// RawBytes bypasses the driver's per-column type coercion (Dolt's EXPLAIN
+		// can carry numeric columns that arrive as the literal text "NULL").
+		cells := make([]any, len(cols))
+		holders := make([]sql.RawBytes, len(cols))
+		for i := range cells {
+			cells[i] = &holders[i]
+		}
+		if err := rows.Scan(cells...); err != nil {
+			t.Fatalf("EXPLAIN scan: %v", err)
+		}
+		for _, h := range holders {
+			if len(h) > 0 {
+				out.Write(h)
+				out.WriteString("\n")
+			}
+		}
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("EXPLAIN rows: %v", err)
+	}
+	return out.String()
+}
+
+// looksLikeDoltPlan reports whether s resembles a go-mysql-server / Dolt EXPLAIN
+// plan tree, so the sargability assertion can skip cleanly if the format shifts.
+func looksLikeDoltPlan(s string) bool {
+	for _, tok := range []string{"TableAccess", "Table", "Project", "Filter", "Sort", "Limit", "TopN"} {
+		if strings.Contains(s, tok) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/storage/dolt/events.go
+++ b/internal/storage/dolt/events.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/storage/issueops"
 	"github.com/steveyegge/beads/internal/types"
 )
@@ -101,6 +102,20 @@ func (s *DoltStore) GetIssueComments(ctx context.Context, issueID string) ([]*ty
 	defer rows.Close()
 
 	return scanComments(rows)
+}
+
+// GetIssueCommentsPage returns one keyset page of an issue's comments in
+// (created_at ASC, id ASC) order, resuming strictly after the cursor. See the
+// storage.Storage doc for the ordering, sargability, and page-walk-equals-full-
+// read contract.
+func (s *DoltStore) GetIssueCommentsPage(ctx context.Context, issueID string, after storage.CommentPageCursor, limit int) ([]*types.Comment, error) {
+	var result []*types.Comment
+	err := s.withReadTx(ctx, func(tx *sql.Tx) error {
+		var err error
+		result, err = issueops.GetIssueCommentsPageInTx(ctx, tx, issueID, after, limit)
+		return err
+	})
+	return result, err
 }
 
 // GetCommentsForIssues retrieves comments for multiple issues

--- a/internal/storage/embeddeddolt/comments_page_test.go
+++ b/internal/storage/embeddeddolt/comments_page_test.go
@@ -1,0 +1,181 @@
+//go:build cgo
+
+package embeddeddolt_test
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/steveyegge/beads/internal/storage"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// cpIDs projects comment IDs in result order.
+func cpIDs(cs []*types.Comment) []string {
+	out := make([]string, len(cs))
+	for i, c := range cs {
+		out[i] = c.ID
+	}
+	return out
+}
+
+func cpEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// TestGetIssueCommentsPageEmbedded is the embedded-backend twin of the dolt
+// suite's page-walk property: a keyset walk with a page size smaller than a
+// same-second group reproduces GetIssueComments exactly (order + content, no
+// drop/dup), and the wisp route pages wisp_comments. Comments are seeded through
+// the public ImportIssueComment with a controlled created_at so several share a
+// second, exercising the (created_at, id) tie-break; the external test package
+// shares no connection with the store, so writes go through store ops.
+func TestGetIssueCommentsPageEmbedded(t *testing.T) {
+	skipUnlessEmbeddedDolt(t)
+
+	te := newTestEnv(t, "cp")
+	ctx := t.Context()
+
+	iss := &types.Issue{ID: "cp-1", Title: "cp", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask}
+	if err := te.store.CreateIssue(ctx, iss, "tester"); err != nil {
+		t.Fatalf("CreateIssue: %v", err)
+	}
+
+	// 25 comments in 5 same-second groups of 5 (group size > page size 4).
+	const n, groupSize, pageSize = 25, 5, 4
+	base := time.Date(2024, 1, 2, 3, 4, 5, 0, time.UTC)
+	for i := 0; i < n; i++ {
+		at := base.Add(time.Duration(i/groupSize) * time.Second)
+		if _, err := te.store.ImportIssueComment(ctx, iss.ID, "tester", fmt.Sprintf("c%d", i), at); err != nil {
+			t.Fatalf("ImportIssueComment %d: %v", i, err)
+		}
+	}
+
+	full, err := te.store.GetIssueComments(ctx, iss.ID)
+	if err != nil {
+		t.Fatalf("GetIssueComments: %v", err)
+	}
+	if len(full) != n {
+		t.Fatalf("full read = %d comments, want %d", len(full), n)
+	}
+
+	// A same-second collision was actually exercised (adjacent equal created_at).
+	sawCollision := false
+	for i := 1; i < len(full); i++ {
+		if full[i].CreatedAt.Equal(full[i-1].CreatedAt) {
+			sawCollision = true
+			if full[i].ID <= full[i-1].ID {
+				t.Fatalf("same-second group not id-ascending at %d: %q <= %q", i, full[i].ID, full[i-1].ID)
+			}
+		}
+	}
+	if !sawCollision {
+		t.Fatalf("no same-second created_at collision in the seeded thread — tie-break not exercised")
+	}
+
+	// Keyset walk (page size < group size) equals the full read exactly.
+	var collected []string
+	seen := map[string]bool{}
+	var after storage.CommentPageCursor
+	for i := 0; i < 1000; i++ {
+		page, err := te.store.GetIssueCommentsPage(ctx, iss.ID, after, pageSize)
+		if err != nil {
+			t.Fatalf("GetIssueCommentsPage(page %d): %v", i, err)
+		}
+		if len(page) == 0 {
+			break
+		}
+		if len(page) > pageSize {
+			t.Fatalf("page %d size = %d, want <= %d", i, len(page), pageSize)
+		}
+		for _, c := range page {
+			if seen[c.ID] {
+				t.Fatalf("duplicate id %q across pages", c.ID)
+			}
+			seen[c.ID] = true
+			collected = append(collected, c.ID)
+		}
+		last := page[len(page)-1]
+		after = storage.CommentPageCursor{CreatedAt: last.CreatedAt, ID: last.ID}
+	}
+	if want := cpIDs(full); !cpEqual(collected, want) {
+		t.Fatalf("keyset walk = %v,\nwant full read %v", collected, want)
+	}
+
+	// First page (zero cursor) is the first pageSize in order; a cursor on the
+	// last comment yields an empty page.
+	first, err := te.store.GetIssueCommentsPage(ctx, iss.ID, storage.CommentPageCursor{}, pageSize)
+	if err != nil {
+		t.Fatalf("GetIssueCommentsPage(first): %v", err)
+	}
+	if got, want := cpIDs(first), cpIDs(full)[:pageSize]; !cpEqual(got, want) {
+		t.Fatalf("first page = %v, want %v", got, want)
+	}
+	lastC := full[len(full)-1]
+	end, err := te.store.GetIssueCommentsPage(ctx, iss.ID, storage.CommentPageCursor{CreatedAt: lastC.CreatedAt, ID: lastC.ID}, pageSize)
+	if err != nil {
+		t.Fatalf("GetIssueCommentsPage(past-the-end): %v", err)
+	}
+	if len(end) != 0 {
+		t.Fatalf("past-the-end page = %v, want empty", cpIDs(end))
+	}
+
+	// Empty thread -> empty page.
+	empty := &types.Issue{ID: "cp-empty", Title: "cp", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask}
+	if err := te.store.CreateIssue(ctx, empty, "tester"); err != nil {
+		t.Fatalf("CreateIssue(empty): %v", err)
+	}
+	emptyPage, err := te.store.GetIssueCommentsPage(ctx, empty.ID, storage.CommentPageCursor{}, 10)
+	if err != nil {
+		t.Fatalf("GetIssueCommentsPage(empty): %v", err)
+	}
+	if len(emptyPage) != 0 {
+		t.Fatalf("empty thread page = %v, want empty", cpIDs(emptyPage))
+	}
+
+	// Wisp route: an active wisp pages wisp_comments and matches its full read.
+	wisp := &types.Issue{ID: "cp-wisp", Title: "wisp", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask, Ephemeral: true}
+	if err := te.store.CreateIssue(ctx, wisp, "tester"); err != nil {
+		t.Fatalf("CreateIssue(wisp): %v", err)
+	}
+	for i := 0; i < 6; i++ {
+		if _, err := te.store.ImportIssueComment(ctx, wisp.ID, "tester", fmt.Sprintf("w%d", i), base.Add(time.Duration(i)*time.Second)); err != nil {
+			t.Fatalf("ImportIssueComment(wisp) %d: %v", i, err)
+		}
+	}
+	wispFull, err := te.store.GetIssueComments(ctx, wisp.ID)
+	if err != nil {
+		t.Fatalf("GetIssueComments(wisp): %v", err)
+	}
+	if len(wispFull) != 6 {
+		t.Fatalf("wisp full read = %d, want 6", len(wispFull))
+	}
+	var wispWalk []string
+	after = storage.CommentPageCursor{}
+	for i := 0; i < 1000; i++ {
+		page, err := te.store.GetIssueCommentsPage(ctx, wisp.ID, after, 2)
+		if err != nil {
+			t.Fatalf("GetIssueCommentsPage(wisp page %d): %v", i, err)
+		}
+		if len(page) == 0 {
+			break
+		}
+		for _, c := range page {
+			wispWalk = append(wispWalk, c.ID)
+		}
+		last := page[len(page)-1]
+		after = storage.CommentPageCursor{CreatedAt: last.CreatedAt, ID: last.ID}
+	}
+	if want := cpIDs(wispFull); !cpEqual(wispWalk, want) {
+		t.Fatalf("wisp keyset walk = %v, want %v", wispWalk, want)
+	}
+}

--- a/internal/storage/embeddeddolt/store.go
+++ b/internal/storage/embeddeddolt/store.go
@@ -537,6 +537,20 @@ func (s *EmbeddedDoltStore) GetIssueComments(ctx context.Context, issueID string
 	return result, err
 }
 
+// GetIssueCommentsPage returns one keyset page of an issue's comments in
+// (created_at ASC, id ASC) order, resuming strictly after the cursor. See the
+// storage.Storage doc for the ordering, sargability, and page-walk-equals-full-
+// read contract.
+func (s *EmbeddedDoltStore) GetIssueCommentsPage(ctx context.Context, issueID string, after storage.CommentPageCursor, limit int) ([]*types.Comment, error) {
+	var result []*types.Comment
+	err := s.withConn(ctx, false, func(tx *sql.Tx) error {
+		var err error
+		result, err = issueops.GetIssueCommentsPageInTx(ctx, tx, issueID, after, limit)
+		return err
+	})
+	return result, err
+}
+
 func (s *EmbeddedDoltStore) GetEvents(ctx context.Context, issueID string, limit int) ([]*types.Event, error) {
 	var result []*types.Event
 	err := s.withConn(ctx, false, func(tx *sql.Tx) error {

--- a/internal/storage/issueops/comments.go
+++ b/internal/storage/issueops/comments.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/types"
 )
 
@@ -37,6 +38,114 @@ func GetIssueCommentsInTx(ctx context.Context, tx *sql.Tx, issueID string) ([]*t
 		var c types.Comment
 		if err := rows.Scan(&c.ID, &c.IssueID, &c.Author, &c.Text, &c.CreatedAt); err != nil {
 			return nil, fmt.Errorf("get issue comments: scan: %w", err)
+		}
+		comments = append(comments, &c)
+	}
+	return comments, rows.Err()
+}
+
+// Comment page-read tuning. Mirrors the EventsSince keyset clamp: an unbounded
+// page defeats the purpose of paging a long thread, so a non-positive limit
+// falls back to the default and any larger request is capped.
+const (
+	defaultCommentsPageLimit = 100
+	maxCommentsPageLimit     = 500
+)
+
+// CommentsKeysetPredicate is the SARGABLE (created_at ASC, id ASC) keyset resume
+// predicate GetIssueCommentsPageInTx ANDs in once a page cursor is set. Its three
+// ? placeholders bind, in order: created_at (the sargable lower bound),
+// created_at (strict), and id (the same-second tie-break).
+//
+// It is logically "(created_at, id) is strictly after the cursor" under
+// created_at ASC, id ASC — i.e. (created_at > ?) OR (created_at = ? AND id > ?)
+// — but rewritten with a redundant `created_at >= ?` leading bound so the
+// planner seeks the (issue_id, created_at, id) index (an IndexedTableAccess
+// range on Dolt) instead of scanning the issue's comments and filtering. The two
+// forms select the same rows: created_at >= C is true whenever the OR is, and
+// prunes only created_at < C, which the OR already excludes. It is exported so
+// the backend sargability guard EXPLAINs this exact string rather than a
+// hand-copied literal — a change here then breaks the guard.
+const CommentsKeysetPredicate = `created_at >= ? AND ((created_at > ?) OR (id > ?))`
+
+// CommentsPageQuery returns the exact SQL GetIssueCommentsPageInTx executes for
+// the given comment table (comments or wisp_comments), cursor presence, and
+// already-clamped limit. The ? placeholders bind in order: issue_id, then — when
+// hasCursor — the three CommentsKeysetPredicate binds (created_at, created_at,
+// id). It is exported so the sargability guard EXPLAINs this production string
+// (with CommentsKeysetPredicate embedded) rather than a copy — a drift in either
+// the surrounding query or the predicate then breaks the guard.
+//
+//nolint:gosec // G201: table is a hardcoded routing constant and limit is an int the caller clamps; every runtime value is a bound parameter.
+func CommentsPageQuery(table string, hasCursor bool, limit int) string {
+	query := fmt.Sprintf(`
+		SELECT id, issue_id, author, text, created_at
+		FROM %s
+		WHERE issue_id = ?`, table)
+	if hasCursor {
+		query += " AND " + CommentsKeysetPredicate
+	}
+	query += fmt.Sprintf(" ORDER BY created_at ASC, id ASC LIMIT %d", limit)
+	return query
+}
+
+// GetIssueCommentsPageInTx returns one keyset page of an issue's comments within
+// an existing transaction, ordered by (created_at ASC, id ASC). It routes to
+// wisp_comments when issueID is an active wisp, exactly like GetIssueCommentsInTx.
+//
+// after is the resume position — the (created_at, id) of the last comment already
+// seen. The zero cursor starts from the beginning of the thread. Walking the
+// pages, feeding each page's last (created_at, id) back in as after, yields
+// exactly the same comments in the same order as GetIssueCommentsInTx, with no
+// dropped or duplicated comment even when several comments share a created_at
+// second, because id (the primary key) is a total tie-break.
+//
+// The cursor must come from a previously returned comment: created_at is a
+// DATETIME(0) column, so a sub-second cursor CreatedAt sorts after same-second
+// rows stored at the truncated second and skips them on resume (AddIssueCommentInTx
+// truncates its returned CreatedAt to avoid exactly this). And like an audit
+// feed, a comment inserted with a backdated created_at behind an in-progress
+// cursor is not seen by that forward-only walk.
+//
+// limit <= 0 falls back to defaultCommentsPageLimit (100); a larger limit is
+// capped at maxCommentsPageLimit (500), so a caller that pages until
+// len(page) < limit must keep limit <= 500 or terminate on an empty page
+// instead. A missing issue routes to comments and returns an empty page with no
+// error, matching GetIssueCommentsInTx.
+func GetIssueCommentsPageInTx(ctx context.Context, tx *sql.Tx, issueID string, after storage.CommentPageCursor, limit int) ([]*types.Comment, error) {
+	if limit <= 0 {
+		limit = defaultCommentsPageLimit
+	}
+	if limit > maxCommentsPageLimit {
+		limit = maxCommentsPageLimit
+	}
+
+	table := "comments"
+	if IsActiveWispInTx(ctx, tx, issueID) {
+		table = "wisp_comments"
+	}
+
+	hasCursor := !after.CreatedAt.IsZero() || after.ID != ""
+	args := []any{issueID}
+	if hasCursor {
+		// Bind the cursor time as time.Time, not a formatted string: created_at
+		// is a DATETIME column, so a time.Time value compares correctly on every
+		// backend while an RFC3339 string can mis-compare. Bound twice (the
+		// sargable lower bound and the strict bound), then the id tie-break.
+		args = append(args, after.CreatedAt, after.CreatedAt, after.ID)
+	}
+
+	rows, err := tx.QueryContext(ctx, CommentsPageQuery(table, hasCursor, limit), args...)
+	if err != nil {
+		return nil, fmt.Errorf("get issue comments page from %s (after %v/%q): %w", table, after.CreatedAt, after.ID, err)
+	}
+	defer rows.Close()
+
+	var comments []*types.Comment
+	for rows.Next() {
+		var c types.Comment
+		if err := rows.Scan(&c.ID, &c.IssueID, &c.Author, &c.Text, &c.CreatedAt); err != nil {
+			return nil, fmt.Errorf("get issue comments page: scan: %w", err)
 		}
 		comments = append(comments, &c)
 	}
@@ -109,9 +218,15 @@ func GetCommentCountsInTx(ctx context.Context, tx *sql.Tx, issueIDs []string) (m
 // AddIssueCommentInTx adds a structured comment to an issue within a transaction.
 // Routes to comments or wisp_comments based on wisp status.
 //
+// The insert timestamp is truncated to whole seconds to match the created_at
+// column's DATETIME(0) precision, so the returned Comment.CreatedAt equals the
+// stored value. That makes the returned comment safe to use directly as a
+// GetIssueCommentsPage cursor: an un-truncated sub-second CreatedAt would sort
+// after same-second rows stored at the truncated second and skip them on resume.
+//
 //nolint:gosec // G201: table names come from hardcoded constants
 func AddIssueCommentInTx(ctx context.Context, tx *sql.Tx, issueID, author, text string) (*types.Comment, error) {
-	return ImportIssueCommentInTx(ctx, tx, issueID, author, text, time.Now().UTC())
+	return ImportIssueCommentInTx(ctx, tx, issueID, author, text, time.Now().UTC().Truncate(time.Second))
 }
 
 // ImportIssueCommentInTx adds a comment preserving the original timestamp.

--- a/internal/storage/schema/migrations/0056_add_comments_keyset_index.down.sql
+++ b/internal/storage/schema/migrations/0056_add_comments_keyset_index.down.sql
@@ -1,0 +1,25 @@
+-- Reverse 0056: drop the (issue_id, created_at, id) composite indexes on
+-- comments and wisp_comments. Guarded for the same idempotency reason as up so
+-- it must not error when the index is already absent. The "index present" guard
+-- also covers a missing wisp_comments table (an absent table has no index), so
+-- the wisp half is a no-op on a fresh clone too.
+
+SET @has_c = (
+    SELECT IF(COUNT(*) > 0, 1, 0)
+    FROM INFORMATION_SCHEMA.STATISTICS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = 'comments'
+      AND INDEX_NAME = 'idx_comments_issue_created_id'
+);
+SET @sql = IF(@has_c = 1, 'DROP INDEX idx_comments_issue_created_id ON comments', 'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @has_w = (
+    SELECT IF(COUNT(*) > 0, 1, 0)
+    FROM INFORMATION_SCHEMA.STATISTICS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = 'wisp_comments'
+      AND INDEX_NAME = 'idx_wisp_comments_issue_created_id'
+);
+SET @sql = IF(@has_w = 1, 'DROP INDEX idx_wisp_comments_issue_created_id ON wisp_comments', 'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;

--- a/internal/storage/schema/migrations/0056_add_comments_keyset_index.up.sql
+++ b/internal/storage/schema/migrations/0056_add_comments_keyset_index.up.sql
@@ -1,0 +1,58 @@
+-- Add a (issue_id, created_at, id) composite index to comments and wisp_comments
+-- so the keyset comment-page read (GetIssueCommentsPage) seeks the index for a
+-- single issue's thread in (created_at, id) order instead of scanning the issue's
+-- comments and sorting. The pre-existing single-column idx_comments_issue /
+-- idx_wisp_comments_issue indexes can seek issue_id but leave the created_at
+-- range and the id tie-break to a filter+sort.
+--
+-- Numbered 0056: the next contiguous version after main's 0055 (the migration
+-- loader requires gap-free versions — COUNT == MAX, enforced by
+-- TestAllMigrationsSQLAppliesThroughDoltCLIAndRecordsLatestVersion — so we
+-- cannot pre-emptively skip to 0057). Several in-flight branches (claim-fence,
+-- holder-token, revision) also add an 0056 on their own 0055 base; the loader
+-- panics on a duplicate version (schema.go checkNoDuplicateVersions), so
+-- whichever lands second rebases onto the new main and bumps to the next free
+-- number. That collision is resolved loudly at merge, never silently.
+--
+-- Guarded against the current schema so the migration is idempotent (a clone may
+-- re-apply it; see 0052) — it must not error when the index is already present.
+--
+-- The wisp half is additionally guarded on the wisp_comments table EXISTING:
+-- wisp_% tables are dolt-ignored clone-local state that the ignored-migration
+-- chain materializes AFTER the main migrations run, so on a fresh clone's first
+-- writable open wisp_comments does not yet exist when this migration runs.
+-- Treat that as a no-op (exactly like 0035/0037/0053) — the fresh wisp_comments
+-- is created with this composite index directly by the canonical wisp schema in
+-- ignored/0001_create_local_state_tables.up.sql, while this migration upgrades
+-- the wisp_comments of already-materialized (existing) workspaces.
+
+-- comments is a durable table present in every workspace once 0004 has run, so
+-- it needs only the index-missing guard.
+SET @needs_c = (
+    SELECT IF(COUNT(*) = 0, 1, 0)
+    FROM INFORMATION_SCHEMA.STATISTICS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = 'comments'
+      AND INDEX_NAME = 'idx_comments_issue_created_id'
+);
+SET @sql = IF(@needs_c = 1, 'CREATE INDEX idx_comments_issue_created_id ON comments (issue_id, created_at, id)', 'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+-- wisp_comments may not exist yet on a fresh clone: guard on table existence AND
+-- index-missing so the CREATE INDEX (and its PREPARE) is skipped entirely when
+-- the table is absent.
+SET @has_wisp_comments = (
+    SELECT COUNT(*)
+    FROM INFORMATION_SCHEMA.TABLES
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = 'wisp_comments'
+);
+SET @has_wisp_index = (
+    SELECT COUNT(*)
+    FROM INFORMATION_SCHEMA.STATISTICS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = 'wisp_comments'
+      AND INDEX_NAME = 'idx_wisp_comments_issue_created_id'
+);
+SET @sql = IF(@has_wisp_comments > 0 AND @has_wisp_index = 0, 'CREATE INDEX idx_wisp_comments_issue_created_id ON wisp_comments (issue_id, created_at, id)', 'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;

--- a/internal/storage/schema/migrations/ignored/0001_create_local_state_tables.up.sql
+++ b/internal/storage/schema/migrations/ignored/0001_create_local_state_tables.up.sql
@@ -106,7 +106,13 @@ CREATE TABLE __temp__wisp_comments (
     author VARCHAR(255) DEFAULT '',
     text TEXT NOT NULL,
     created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
-    INDEX idx_wisp_comments_issue (issue_id)
+    INDEX idx_wisp_comments_issue (issue_id),
+    -- Keyset comment-page index (issue_id, created_at, id), the wisp twin of
+    -- migration 0056's addition to durable comments. Baked into the canonical
+    -- wisp schema so fresh clones — which materialize wisp_comments here, after
+    -- the main migrations have already run — get the indexed page-read plan;
+    -- 0056 upgrades already-materialized workspaces.
+    INDEX idx_wisp_comments_issue_created_id (issue_id, created_at, id)
 );
 
 DROP TABLE IF EXISTS __temp__repo_mtimes;

--- a/internal/storage/schema/schema_test.go
+++ b/internal/storage/schema/schema_test.go
@@ -425,6 +425,44 @@ DELETE FROM schema_migrations WHERE version = %d;
 		`SELECT COUNT(*) AS c FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'wisps'`, "0")
 }
 
+// TestMigration0056NoopsWithoutWispCommentsThroughDoltCLI pins the fresh-clone
+// guard for the comments-keyset index: main migrations run before the ignored
+// chain materializes the clone-local wisp_% tables, so migration 0056 must
+// no-op its wisp half when wisp_comments is absent. A bare
+// CREATE INDEX ... ON wisp_comments would fail at PREPARE ("table not found")
+// and brick the first writable open. The durable comments half still runs.
+// AllMigrationsSQL is main-source only (it never creates wisp_comments), so
+// applying it already runs 0056 against an absent wisp_comments; the isolated
+// re-apply then asserts the no-op explicitly.
+func TestMigration0056NoopsWithoutWispCommentsThroughDoltCLI(t *testing.T) {
+	testutil.RequireDoltBinary(t)
+
+	dir := filepath.Join(t.TempDir(), "comments-keyset-no-wisps")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("create no-wisps dir: %v", err)
+	}
+	runDoltCommand(t, dir, "init", "--name", "test", "--email", "test@example.com")
+	runDoltSQL(t, dir, AllMigrationsSQL())
+
+	seedSQL := fmt.Sprintf(`
+DROP TABLE IF EXISTS wisp_comments;
+DELETE FROM schema_migrations WHERE version = %d;
+`, LatestVersion())
+	migrationSQL, err := mainSource.files.ReadFile("migrations/0056_add_comments_keyset_index.up.sql")
+	if err != nil {
+		t.Fatalf("read 0056 migration: %v", err)
+	}
+	runDoltSQL(t, dir, seedSQL+"\n"+string(migrationSQL))
+
+	// Wisp half no-oped: no wisp_comments table was created, no error raised.
+	requireDoltCount(t, dir,
+		`SELECT COUNT(*) AS c FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'wisp_comments'`, "0")
+	// Comments half ran: the durable composite index is present (one distinct
+	// index name; a composite spans three STATISTICS rows).
+	requireDoltCount(t, dir,
+		`SELECT COUNT(DISTINCT INDEX_NAME) AS c FROM INFORMATION_SCHEMA.STATISTICS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'comments' AND INDEX_NAME = 'idx_comments_issue_created_id'`, "1")
+}
+
 func TestMigration0053RepairsRigWispsThroughDoltCLI(t *testing.T) {
 	testutil.RequireDoltBinary(t)
 

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -56,6 +56,18 @@ var ErrCloseBlocked = errors.New("cannot close blocked issue")
 // precondition from other errors.
 var ErrVersionMismatch = errors.New("version mismatch")
 
+// CommentPageCursor is the resume position for a keyset page of an issue's
+// comments: the (created_at, id) of the last comment already returned. The zero
+// value starts a walk from the beginning of the thread.
+//
+// It lives in the storage package (rather than issueops) because issueops
+// imports storage — the reverse would be an import cycle — so the shared cursor
+// type is defined here and referenced from the issueops query layer.
+type CommentPageCursor struct {
+	CreatedAt time.Time
+	ID        string
+}
+
 // Storage is the interface satisfied by *dolt.DoltStore.
 // Consumers depend on this interface rather than on the concrete type so that
 // alternative implementations (mocks, proxies, etc.) can be substituted.
@@ -130,6 +142,32 @@ type Storage interface {
 	// Comments and events
 	AddIssueComment(ctx context.Context, issueID, author, text string) (*types.Comment, error)
 	GetIssueComments(ctx context.Context, issueID string) ([]*types.Comment, error)
+	// GetIssueCommentsPage returns one keyset page of an issue's comments in the
+	// stable (created_at ASC, id ASC) total order, resuming strictly after the
+	// after cursor (the zero cursor starts from the beginning of the thread).
+	// id is the primary key, so the same-second tie-break is total: a thread
+	// with several comments in the same created_at second still pages
+	// completely, and concatenating every page of a full walk yields exactly the
+	// same comments in the same order as GetIssueComments — no dropped or
+	// duplicated comment. The resume predicate is sargable: it seeks the
+	// (issue_id, created_at, id) index rather than scanning the whole thread.
+	//
+	// The after cursor MUST come from a comment previously returned by a read
+	// (this method or GetIssueComments), whose CreatedAt matches the stored
+	// DATETIME second. Feeding a cursor with a sub-second CreatedAt can skip
+	// same-second rows (AddIssueComment already truncates its returned CreatedAt
+	// for this reason).
+	//
+	// Keyset semantics, like an audit feed: a comment inserted with a backdated
+	// created_at that lands behind an in-progress cursor is not seen by that
+	// walk — the walk only moves forward. A whole-thread read or a fresh walk
+	// still returns it.
+	//
+	// limit <= 0 uses a store default (100); a larger limit is capped at 500. A
+	// caller that pages until len(page) < limit must therefore keep limit <= 500
+	// or use empty-page termination instead: a request for limit > 500 always
+	// returns at most 500 rows and would stop a len-based loop one page early.
+	GetIssueCommentsPage(ctx context.Context, issueID string, after CommentPageCursor, limit int) ([]*types.Comment, error)
 	GetEvents(ctx context.Context, issueID string, limit int) ([]*types.Event, error)
 	GetAllEventsSince(ctx context.Context, since time.Time) ([]*types.Event, error)
 

--- a/internal/telemetry/storage.go
+++ b/internal/telemetry/storage.go
@@ -443,6 +443,14 @@ func (s *InstrumentedStorage) GetIssueComments(ctx context.Context, issueID stri
 	return v, err
 }
 
+func (s *InstrumentedStorage) GetIssueCommentsPage(ctx context.Context, issueID string, after storage.CommentPageCursor, limit int) ([]*types.Comment, error) {
+	attrs := []attribute.KeyValue{attribute.String("bd.issue.id", issueID)}
+	ctx, span, t := s.op(ctx, "GetIssueCommentsPage", attrs...)
+	v, err := s.inner.GetIssueCommentsPage(ctx, issueID, after, limit)
+	s.done(ctx, span, t, err, attrs...)
+	return v, err
+}
+
 func (s *InstrumentedStorage) GetEvents(ctx context.Context, issueID string, limit int) ([]*types.Event, error) {
 	attrs := []attribute.KeyValue{attribute.String("bd.issue.id", issueID)}
 	ctx, span, t := s.op(ctx, "GetEvents", attrs...)


### PR DESCRIPTION
> Stacked on #4911 (S7b) → #4906 (S5c) → … → #4892 (S1). Base is `feat/guarded-ops-s7b-proxied-close`; retarget down the stack as each lands. The diff below is S10 only.

## What

Adds `GetIssueCommentsPage` — a keyset-paged comments read (`(created_at, id)` ascending, index-backed resume predicate, limit default 100 / cap 500) — plus the composite index migration it needs, on both stores. The whole-thread `GetIssueComments` is untouched.

## Why

The comments surface was whole-thread only: any consumer wanting a page of a long thread had to materialize the entire thread and page in memory — with a cap, long threads get served incomplete. A keyset page read makes paging a bounded engine call: stable order, exact resume, `O(page)` per request. The pattern (sargable `created_at >= ? AND ((created_at > ?) OR (id > ?))`, same-second `id` tie-break, page-walk-equals-full-read) mirrors the engine's existing keyset reads.

Three non-obvious correctness points, all caught by pre-merge review and covered by tests:
- **Clone-safe migration.** Wisp tables are clone-local, and main migrations run before the clone-local chain materializes them — so the wisp half of the index migration is table-guarded (the 0035/0037/0053 precedent, with a matching no-op pin test), and fresh clones get the wisp index from the canonical clone-local schema instead. A bare `CREATE INDEX` would have broken every fresh clone's first writable open.
- **Cursor round-trip.** `AddIssueCommentInTx` returned an un-truncated Go time while the column stores `DATETIME(0)`; using that as a cursor could skip same-second rows. The returned `CreatedAt` is now truncated to match storage (stored value unchanged).
- **Honest plan guard.** The EXPLAIN test pins the composite index by its column-list signature (single-sourced from the exported production query) — it fails if the index is dropped, not just if the query errors.

Note on the migration number: 0056 is the only contiguous slot on this base (a gap-free version invariant is test-enforced). Other in-flight branches also carry an 0056; the loader panics loudly on duplicates, so whichever lands second renumbers on rebase — documented in the migration header.

## Verification

- Page-walk equals the full read exactly (5 same-second groups of 5, page size 4 — no dupes, no gaps); same-second tie-break asserted; first/past-end/empty/default-limit; wisp comments route to `wisp_comments`; migration no-ops cleanly on a DB without wisp tables (pin test through the dolt CLI); EXPLAIN shows an index seek on `(issue_id, created_at, id)`.
- Both stores covered; existing comments tests and the full schema suite green. `gofmt`/`go vet` clean; `go build ./...` under cgo and `CGO_ENABLED=0`; `golangci-lint` 0 issues.

```bash
go test ./internal/storage/dolt/ -run 'CommentsPage' -v
go test ./internal/storage/schema/ -run 'TestMigration0056|TestAllMigrationsSQL' -v
```
