### PR TITLE
feat(storage): (created_at, id) keyset issue-list predicate on IssueFilter

### DIFF
--- a/internal/storage/dolt/keyset_search_test.go
+++ b/internal/storage/dolt/keyset_search_test.go
@@ -1,0 +1,163 @@
+package dolt
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/steveyegge/beads/internal/storage/sqlbuild"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// ksIDs projects issue IDs in result order.
+func ksIDs(issues []*types.Issue) []string {
+	out := make([]string, len(issues))
+	for i, iss := range issues {
+		out[i] = iss.ID
+	}
+	return out
+}
+
+func ksEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// TestSearchIssuesKeysetSameSecondOverflow is the same-second-overflow keyset regression: a same-second
+// group LARGER than one page must page completely under the (created_at DESC,
+// id ASC) keyset with no dropped or duplicated row — the exact case a
+// created_at-only cursor loses. It also pins the cross-second DESC + id-ASC order
+// and that the keyset resumes exactly at the boundary. Exercised through the
+// public SearchIssues (SLICE stack), which routes the new IssueFilter keyset
+// fields into the shared sqlbuild predicate.
+func TestSearchIssuesKeysetSameSecondOverflow(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	// A 5-row same-second group at T, one row a second newer, one a second older.
+	// Under created_at DESC, id ASC the total order is: newer, a1..a5, older.
+	base := time.Date(2024, 1, 2, 3, 4, 5, 0, time.UTC)
+	seeds := []struct {
+		id string
+		at time.Time
+	}{
+		{"k-newer", base.Add(time.Second)},
+		{"k-a1", base}, {"k-a2", base}, {"k-a3", base}, {"k-a4", base}, {"k-a5", base},
+		{"k-older", base.Add(-time.Second)},
+	}
+	for _, s := range seeds {
+		iss := &types.Issue{ID: s.id, Title: s.id, Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask, CreatedAt: s.at}
+		if err := store.CreateIssue(ctx, iss, "tester"); err != nil {
+			t.Fatalf("create %s: %v", s.id, err)
+		}
+	}
+
+	wantOrder := []string{"k-newer", "k-a1", "k-a2", "k-a3", "k-a4", "k-a5", "k-older"}
+
+	// One-shot ordered read (no keyset): pins created_at DESC, id ASC.
+	full, err := store.SearchIssues(ctx, "", types.IssueFilter{
+		IDPrefix: "k-", SkipWisps: true, SortBy: "created", Limit: 100,
+	})
+	if err != nil {
+		t.Fatalf("SearchIssues(full): %v", err)
+	}
+	if got := ksIDs(full); !ksEqual(got, wantOrder) {
+		t.Fatalf("full order = %v, want %v", got, wantOrder)
+	}
+
+	// Keyset walk, page size 2 (< the 5-row same-second group). The union across
+	// pages must be exactly wantOrder in order, with no id seen twice.
+	const pageSize = 2
+	var collected []string
+	seen := map[string]bool{}
+	var afterCreatedAt *time.Time
+	afterID := ""
+	for i := 0; i < 100; i++ {
+		f := types.IssueFilter{
+			IDPrefix: "k-", SkipWisps: true, SortBy: "created", Limit: pageSize,
+			AfterCreatedAt: afterCreatedAt, AfterID: afterID,
+		}
+		page, err := store.SearchIssues(ctx, "", f)
+		if err != nil {
+			t.Fatalf("SearchIssues(page %d): %v", i, err)
+		}
+		if len(page) == 0 {
+			break
+		}
+		if len(page) > pageSize {
+			t.Fatalf("page %d size = %d, want <= %d", i, len(page), pageSize)
+		}
+		for _, iss := range page {
+			if seen[iss.ID] {
+				t.Fatalf("duplicate id %q across pages — same-second overflow was lost", iss.ID)
+			}
+			seen[iss.ID] = true
+			collected = append(collected, iss.ID)
+		}
+		last := page[len(page)-1]
+		at := last.CreatedAt.UTC()
+		afterCreatedAt = &at
+		afterID = last.ID
+	}
+	if !ksEqual(collected, wantOrder) {
+		t.Fatalf("keyset paged order = %v, want %v (no drop/dup)", collected, wantOrder)
+	}
+
+	// Resume-at-boundary: a cursor planted in the middle of the same-second group
+	// (after k-a3) yields exactly the strictly-later tail (a4, a5, older).
+	afterA3 := base.UTC()
+	tail, err := store.SearchIssues(ctx, "", types.IssueFilter{
+		IDPrefix: "k-", SkipWisps: true, SortBy: "created", Limit: 100,
+		AfterCreatedAt: &afterA3, AfterID: "k-a3",
+	})
+	if err != nil {
+		t.Fatalf("SearchIssues(after k-a3): %v", err)
+	}
+	if got := ksIDs(tail); !ksEqual(got, []string{"k-a4", "k-a5", "k-older"}) {
+		t.Fatalf("resume after k-a3 = %v, want [k-a4 k-a5 k-older]", got)
+	}
+}
+
+// TestSearchIssuesKeysetPlanIsIndexed is the sargability regression guard: the
+// keyset predicate must seek idx_issues_created_at (IndexedTableAccess), not
+// full-scan-and-filter. The redundant `created_at <= ?` leading bound is what
+// keeps the Dolt planner on the index. It EXPLAINs the exact production predicate
+// (single-sourced from sqlbuild.KeysetCreatedAtIDPredicate) with literals, and
+// skips rather than fails if the EXPLAIN format is unrecognizable.
+func TestSearchIssuesKeysetPlanIsIndexed(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	base := time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC)
+	for i := 0; i < 5; i++ {
+		iss := &types.Issue{ID: "kp-" + string(rune('a'+i)), Title: "kp", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask, CreatedAt: base.Add(time.Duration(i) * time.Second)}
+		if err := store.CreateIssue(ctx, iss, "tester"); err != nil {
+			t.Fatalf("create seed: %v", err)
+		}
+	}
+
+	const cur = "2023-01-01 00:00:00"
+	// Single-source the guarded SQL from production: the three placeholders bind
+	// created_at (sargable upper bound), created_at (strict), id (tie-break).
+	pred := literalizeParams(sqlbuild.KeysetCreatedAtIDPredicate, "'"+cur+"'", "'"+cur+"'", "''")
+	//nolint:gosec // G202: pred is a literalized production constant, no user input.
+	plan := explainPlan(t, ctx, store.db, "SELECT id FROM issues WHERE "+pred+" ORDER BY created_at DESC, id ASC LIMIT 100")
+
+	if !looksLikeDoltPlan(plan) {
+		t.Skipf("EXPLAIN output not in a recognized Dolt plan format, skipping sargability assertion; plan=\n%s", plan)
+	}
+	if !strings.Contains(plan, "IndexedTableAccess") || !strings.Contains(plan, "issues.created_at") {
+		t.Fatalf("keyset predicate does not seek idx_issues_created_at (want IndexedTableAccess on [issues.created_at]) — the sargable upper bound regressed to a full Table scan.\nplan:\n%s", plan)
+	}
+}

--- a/internal/storage/embeddeddolt/keyset_search_test.go
+++ b/internal/storage/embeddeddolt/keyset_search_test.go
@@ -1,0 +1,95 @@
+//go:build cgo
+
+package embeddeddolt_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// TestSearchIssuesKeysetEmbedded is the same-second-overflow keyset regression
+// on the embedded Dolt backend: a same-second group larger than a page pages completely under the
+// (created_at DESC, id ASC) keyset with no drop/dup, routed through the public
+// SearchIssues.
+func TestSearchIssuesKeysetEmbedded(t *testing.T) {
+	te := newTestEnv(t, "ks")
+	ctx := t.Context()
+
+	base := time.Date(2024, 1, 2, 3, 4, 5, 0, time.UTC)
+	seeds := []struct {
+		id string
+		at time.Time
+	}{
+		{"k-newer", base.Add(time.Second)},
+		{"k-a1", base}, {"k-a2", base}, {"k-a3", base}, {"k-a4", base}, {"k-a5", base},
+		{"k-older", base.Add(-time.Second)},
+	}
+	for _, s := range seeds {
+		iss := &types.Issue{ID: s.id, Title: s.id, Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask, CreatedAt: s.at}
+		if err := te.store.CreateIssue(ctx, iss, "tester"); err != nil {
+			t.Fatalf("create %s: %v", s.id, err)
+		}
+	}
+
+	want := []string{"k-newer", "k-a1", "k-a2", "k-a3", "k-a4", "k-a5", "k-older"}
+	ids := func(issues []*types.Issue) []string {
+		out := make([]string, len(issues))
+		for i, iss := range issues {
+			out[i] = iss.ID
+		}
+		return out
+	}
+	eq := func(got, exp []string) bool {
+		if len(got) != len(exp) {
+			return false
+		}
+		for i := range exp {
+			if got[i] != exp[i] {
+				return false
+			}
+		}
+		return true
+	}
+
+	full, err := te.store.SearchIssues(ctx, "", types.IssueFilter{IDPrefix: "k-", SkipWisps: true, SortBy: "created", Limit: 100})
+	if err != nil {
+		t.Fatalf("SearchIssues(full): %v", err)
+	}
+	if got := ids(full); !eq(got, want) {
+		t.Fatalf("full order = %v, want %v", got, want)
+	}
+
+	const pageSize = 2
+	var collected []string
+	seen := map[string]bool{}
+	var afterCreatedAt *time.Time
+	afterID := ""
+	for i := 0; i < 100; i++ {
+		page, err := te.store.SearchIssues(ctx, "", types.IssueFilter{
+			IDPrefix: "k-", SkipWisps: true, SortBy: "created", Limit: pageSize,
+			AfterCreatedAt: afterCreatedAt, AfterID: afterID,
+		})
+		if err != nil {
+			t.Fatalf("SearchIssues(page %d): %v", i, err)
+		}
+		if len(page) == 0 {
+			break
+		}
+		for _, iss := range page {
+			if seen[iss.ID] {
+				t.Fatalf("duplicate id %q across pages — same-second overflow lost", iss.ID)
+			}
+			seen[iss.ID] = true
+			collected = append(collected, iss.ID)
+		}
+		last := page[len(page)-1]
+		at := last.CreatedAt.UTC()
+		afterCreatedAt = &at
+		afterID = last.ID
+	}
+	if !eq(collected, want) {
+		t.Fatalf("keyset paged order = %v, want %v (no drop/dup)", collected, want)
+	}
+}

--- a/internal/storage/sqlbuild/filter.go
+++ b/internal/storage/sqlbuild/filter.go
@@ -10,6 +10,23 @@ import (
 	"github.com/steveyegge/beads/internal/types"
 )
 
+// KeysetCreatedAtIDPredicate is the SARGABLE (created_at DESC, id ASC) keyset
+// predicate emitted for IssueFilter.AfterCreatedAt/AfterID. Its three ?
+// placeholders bind, in order: created_at (the sargable upper bound), created_at
+// (strict, drops the same-second rows already returned), and id (the same-second
+// tie-break).
+//
+// It is logically "(created_at, id) is strictly after (cursor)" under
+// created_at DESC, id ASC — i.e. (created_at < ?) OR (created_at = ? AND id > ?)
+// — but rewritten with a redundant `created_at <= ?` leading bound so the planner
+// seeks idx_issues_created_at (an IndexedTableAccess range on Dolt, an index/
+// BitmapOr scan on Postgres) instead of full-scanning and filtering. The two
+// forms select the same rows: created_at <= C is true whenever the OR is, and
+// prunes only created_at > C, which the OR already excludes. It is exported so
+// the backend sargability guards EXPLAIN this exact string rather than a copy —
+// a change here then breaks the guard.
+const KeysetCreatedAtIDPredicate = "(created_at <= ? AND ((created_at < ?) OR (id > ?)))"
+
 // BuildIssueFilterClauses builds WHERE clause fragments and args from a query
 // string and IssueFilter. The tables parameter controls which table names are
 // referenced in subqueries (issues vs wisps).
@@ -221,6 +238,18 @@ func BuildIssueFilterClauses(query string, filter types.IssueFilter, tables Filt
 			whereClauses = append(whereClauses, fmt.Sprintf("%s %s ?", tc.col, tc.op))
 			args = append(args, tc.v.Format(time.RFC3339))
 		}
+	}
+
+	if filter.AfterCreatedAt != nil {
+		// Bind the cursor time as time.Time, not a formatted string: the issues/
+		// wisps created_at columns are DATETIME (NUMERIC affinity), so an RFC3339
+		// string parameter mis-compares on the SQLite backend, while a time.Time
+		// value compares correctly on every backend — the same binding EventsSince
+		// uses. Bound twice (the sargable upper bound and the strict bound), then
+		// the id tie-break.
+		ac := *filter.AfterCreatedAt
+		whereClauses = append(whereClauses, KeysetCreatedAtIDPredicate)
+		args = append(args, ac, ac, filter.AfterID)
 	}
 
 	if filter.Deferred {

--- a/internal/storage/sqlbuild/keyset_test.go
+++ b/internal/storage/sqlbuild/keyset_test.go
@@ -1,0 +1,92 @@
+package sqlbuild
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// TestKeysetPredicateEmission pins the (created_at DESC, id ASC) keyset predicate
+// BuildIssueFilterClauses emits for IssueFilter.AfterCreatedAt/AfterID: the exact
+// sargable SQL fragment (single-sourced from KeysetCreatedAtIDPredicate) and its
+// three bound args in order (created_at, created_at, id).
+func TestKeysetPredicateEmission(t *testing.T) {
+	t.Parallel()
+
+	cur := time.Date(2024, 3, 2, 1, 0, 0, 0, time.UTC)
+
+	// No keyset set: predicate absent.
+	clauses, args, err := BuildIssueFilterClauses("", types.IssueFilter{}, IssuesFilterTables)
+	if err != nil {
+		t.Fatalf("BuildIssueFilterClauses (no keyset): %v", err)
+	}
+	for _, c := range clauses {
+		if strings.Contains(c, KeysetCreatedAtIDPredicate) {
+			t.Fatalf("keyset predicate emitted with no AfterCreatedAt set: %v", clauses)
+		}
+	}
+	_ = args
+
+	// Keyset set: exactly one predicate clause equal to the single-sourced
+	// constant, with three args in bind order.
+	clauses, args, err = BuildIssueFilterClauses("", types.IssueFilter{
+		AfterCreatedAt: &cur,
+		AfterID:        "bd-42",
+	}, IssuesFilterTables)
+	if err != nil {
+		t.Fatalf("BuildIssueFilterClauses (keyset): %v", err)
+	}
+	found := 0
+	for _, c := range clauses {
+		if c == KeysetCreatedAtIDPredicate {
+			found++
+		}
+	}
+	if found != 1 {
+		t.Fatalf("keyset predicate clause count = %d, want 1; clauses=%v", found, clauses)
+	}
+	// The cursor time binds as time.Time (twice: sargable + strict bound), then
+	// the id — bound as a value, not a formatted string, so the DATETIME columns
+	// compare correctly on every backend.
+	want := []any{cur, cur, "bd-42"}
+	if len(args) != len(want) {
+		t.Fatalf("args = %v, want %v", args, want)
+	}
+	for i := range want {
+		if args[i] != want[i] {
+			t.Fatalf("arg[%d] = %v (%T), want %v (%T)", i, args[i], args[i], want[i], want[i])
+		}
+	}
+}
+
+// TestKeysetComposesWithCreatedBefore proves the new keyset field does not
+// displace CreatedBefore: both predicates are emitted, and the keyset upper
+// bound (created_at <=) is distinct from CreatedBefore's (created_at <).
+func TestKeysetComposesWithCreatedBefore(t *testing.T) {
+	t.Parallel()
+
+	cur := time.Date(2024, 3, 2, 1, 0, 0, 0, time.UTC)
+	before := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	clauses, args, err := BuildIssueFilterClauses("", types.IssueFilter{
+		CreatedBefore:  &before,
+		AfterCreatedAt: &cur,
+		AfterID:        "bd-7",
+	}, IssuesFilterTables)
+	if err != nil {
+		t.Fatalf("BuildIssueFilterClauses: %v", err)
+	}
+	joined := strings.Join(clauses, " AND ")
+	if !strings.Contains(joined, KeysetCreatedAtIDPredicate) {
+		t.Fatalf("keyset predicate missing when composed with CreatedBefore: %v", clauses)
+	}
+	if !strings.Contains(joined, "created_at < ?") {
+		t.Fatalf("CreatedBefore predicate (created_at < ?) missing: %v", clauses)
+	}
+	// CreatedBefore contributes one arg, keyset contributes three.
+	if len(args) != 4 {
+		t.Fatalf("arg count = %d, want 4 (1 CreatedBefore + 3 keyset)", len(args))
+	}
+}

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -1298,6 +1298,23 @@ type IssueFilter struct {
 	StartedAfter  *time.Time
 	StartedBefore *time.Time
 
+	// Keyset pagination over the (created_at DESC, id ASC) total order.
+	//
+	// When AfterCreatedAt != nil the query is restricted to rows strictly after
+	// the keyset position (AfterCreatedAt, AfterID) under that order — i.e.
+	// (created_at < AfterCreatedAt) OR (created_at = AfterCreatedAt AND id > AfterID).
+	// id is the primary key, so the tie-break is total: a same-second group
+	// larger than one page still pages completely with no dropped or duplicated
+	// row (unlike a created_at-only cursor, which loses same-second overflow).
+	// AfterID is meaningful only when AfterCreatedAt is set; "" starts the
+	// same-second group from its first id.
+	//
+	// This composes with every other filter (including CreatedBefore, which it
+	// does not replace). Pair it with SortBy="created", SortDesc=false so the
+	// ORDER BY is created_at DESC, id ASC — the order the predicate assumes.
+	AfterCreatedAt *time.Time
+	AfterID        string
+
 	// Empty/null checks
 	EmptyDescription bool
 	NoAssignee       bool


### PR DESCRIPTION
> Stacked on #4915 (S10) → … → #4892 (S1). Base is `feat/guarded-ops-s10-comments-keyset`; retarget down the stack as each lands. The diff below is S11 only. Per the chain's review model, the label is added only when this PR becomes head-of-chain.

## What

Ports the proven `(created_at, id)` keyset issue-list predicate onto the stack: `IssueFilter` gains `AfterCreatedAt *time.Time` + `AfterID string`, emitted through the shared `sqlbuild.BuildIssueFilterClauses` path as the single-sourced sargable `KeysetCreatedAtIDPredicate`, honored by `SearchIssues`/`SearchIssuesWithCounts` on both backends. Authorship preserved (cherry-pick).

## Why

`bd list` and the library's own callers had only `CreatedBefore + Limit` — with second-granularity timestamps, a same-second group larger than one page cannot page without dropping or duplicating its overflow. The `(created_at DESC, id ASC)` tuple cursor (id = primary key, total tie-break) closes that, matching the keyset pattern the engine already uses for the comments page read.

## Verification

- Same-second-overflow paging regressions through the public `SearchIssues` on **both** server and embedded Dolt; a dolt EXPLAIN guard pins the plan against the exact production predicate constant; a sqlbuild unit test pins clause/arg emission.
- Composes with every existing filter; no interaction with the stack's column-list changes (WHERE-only). `gofmt`/`go vet`/builds clean; `golangci-lint` 0 issues.

```bash
go test ./internal/storage/dolt/ -run 'TestSearchIssuesKeyset' -v
BEADS_TEST_EMBEDDED_DOLT=1 go test ./internal/storage/embeddeddolt/ -run TestSearchIssuesKeysetEmbedded -v
```
