### PR TITLE
feat(storage): durable events reads — EventsSince keyset feed with per-bead scope

### DIFF
--- a/internal/storage/dependency_queries.go
+++ b/internal/storage/dependency_queries.go
@@ -10,6 +10,14 @@ import (
 type DependencyQueryStore interface {
 	GetDependencyRecords(ctx context.Context, issueID string) ([]*types.Dependency, error)
 	GetDependencyRecordsForIssues(ctx context.Context, issueIDs []string) (map[string][]*types.Dependency, error)
+	// GetDependentRecords returns raw dependency rows whose target is targetID
+	// (the inbound edges), without hydrating the source issues. depType filters
+	// by dependency type ("" = all); results are ordered by source issue_id ASC,
+	// bounded by limit (0 = a store default, capped), and paged with afterID as
+	// a keyset continuation ("" = start). Mirrors the source-keyed
+	// GetDependencyRecords but in the target direction; unblocks target-side
+	// group membership reads that must see dangling children.
+	GetDependentRecords(ctx context.Context, targetID string, depType string, limit int, afterID string) ([]*types.Dependency, error)
 	GetAllDependencyRecords(ctx context.Context) (map[string][]*types.Dependency, error)
 	GetDependencyCounts(ctx context.Context, issueIDs []string) (map[string]*types.DependencyCounts, error)
 	GetBlockingInfoForIssues(ctx context.Context, issueIDs []string) (blockedByMap map[string][]string, blocksMap map[string][]string, parentMap map[string]string, err error)

--- a/internal/storage/dolt/dependencies.go
+++ b/internal/storage/dolt/dependencies.go
@@ -219,6 +219,19 @@ func (s *DoltStore) GetDependencyRecords(ctx context.Context, issueID string) ([
 	return scanDependencyRows(rows)
 }
 
+// GetDependentRecords returns raw dependency rows whose target is issueID,
+// without hydrating the source issues. Delegates to
+// issueops.GetDependentRecordsInTx for shared query logic.
+func (s *DoltStore) GetDependentRecords(ctx context.Context, targetID string, depType string, limit int, afterID string) ([]*types.Dependency, error) {
+	var result []*types.Dependency
+	err := s.withReadTx(ctx, func(tx *sql.Tx) error {
+		var err error
+		result, err = issueops.GetDependentRecordsInTx(ctx, tx, targetID, depType, limit, afterID)
+		return err
+	})
+	return result, err
+}
+
 // GetAllDependencyRecords returns all dependency records.
 // Delegates to issueops.GetAllDependencyRecordsInTx for shared query logic.
 func (s *DoltStore) GetAllDependencyRecords(ctx context.Context) (map[string][]*types.Dependency, error) {

--- a/internal/storage/dolt/dependents_records_test.go
+++ b/internal/storage/dolt/dependents_records_test.go
@@ -1,0 +1,131 @@
+package dolt
+
+import (
+	"testing"
+
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// TestGetDependentRecords verifies the target-keyed raw dependents read:
+// direction correctness (rows whose target is X, not whose source is X), the
+// dep-type filter, deterministic issue_id ordering, keyset paging, and that it
+// does not drop rows based on source status (raw, no source hydration).
+func TestGetDependentRecords(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	// Target X (the "epic"/group), the sources pointing AT it, and a decoy that
+	// X itself points at (to prove direction). ids are chosen so issue_id ASC is
+	// [s1, s2, s3, s4].
+	mk := func(id string) *types.Issue {
+		iss := &types.Issue{ID: id, Title: id, Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask}
+		if err := store.CreateIssue(ctx, iss, "tester"); err != nil {
+			t.Fatalf("create %s: %v", id, err)
+		}
+		return iss
+	}
+	target := mk("dr-target")
+	block := mk("dr-s1-block")   // blocks -> X
+	childA := mk("dr-s2-childa") // parent-child -> X
+	childB := mk("dr-s3-childb") // parent-child -> X
+	closed := mk("dr-s4-closed") // parent-child -> X, then closed
+	other := mk("dr-other")      // X -> other (decoy: source is X)
+
+	addDep := func(src, tgt string, typ types.DependencyType) {
+		if err := store.AddDependency(ctx, &types.Dependency{IssueID: src, DependsOnID: tgt, Type: typ}, "tester"); err != nil {
+			t.Fatalf("add dep %s -> %s (%s): %v", src, tgt, typ, err)
+		}
+	}
+	addDep(block.ID, target.ID, types.DepBlocks)
+	addDep(childA.ID, target.ID, types.DepParentChild)
+	addDep(childB.ID, target.ID, types.DepParentChild)
+	addDep(closed.ID, target.ID, types.DepParentChild)
+	addDep(target.ID, other.ID, types.DepBlocks) // decoy: target is the SOURCE here
+	if err := store.CloseIssue(ctx, closed.ID, "done", "tester", ""); err != nil {
+		t.Fatalf("close %s: %v", closed.ID, err)
+	}
+
+	srcIDs := func(deps []*types.Dependency) []string {
+		out := make([]string, len(deps))
+		for i, d := range deps {
+			out[i] = d.IssueID
+		}
+		return out
+	}
+
+	// Direction + raw: all inbound edges of X, regardless of source status. The
+	// decoy (target-is-X-as-source) must not appear; the closed source must.
+	all, err := store.GetDependentRecords(ctx, target.ID, "", 100, "")
+	if err != nil {
+		t.Fatalf("GetDependentRecords(all): %v", err)
+	}
+	wantAll := []string{block.ID, childA.ID, childB.ID, closed.ID}
+	if got := srcIDs(all); !sameOrderedIDs(got, wantAll) {
+		t.Fatalf("inbound sources = %v, want %v (ordered issue_id ASC)", got, wantAll)
+	}
+	for _, d := range all {
+		if d.DependsOnID != target.ID {
+			t.Fatalf("row %s has target %s, want %s", d.IssueID, d.DependsOnID, target.ID)
+		}
+		if d.IssueID == target.ID {
+			t.Fatalf("direction violation: returned a row whose SOURCE is the target")
+		}
+	}
+
+	// The decoy edge is discoverable from the OTHER direction (target=other).
+	fromOther, err := store.GetDependentRecords(ctx, other.ID, "", 100, "")
+	if err != nil {
+		t.Fatalf("GetDependentRecords(other): %v", err)
+	}
+	if got := srcIDs(fromOther); !sameOrderedIDs(got, []string{target.ID}) {
+		t.Fatalf("inbound sources of other = %v, want %v", got, []string{target.ID})
+	}
+
+	// Type filter: only parent-child edges.
+	pc, err := store.GetDependentRecords(ctx, target.ID, string(types.DepParentChild), 100, "")
+	if err != nil {
+		t.Fatalf("GetDependentRecords(parent-child): %v", err)
+	}
+	if got := srcIDs(pc); !sameOrderedIDs(got, []string{childA.ID, childB.ID, closed.ID}) {
+		t.Fatalf("parent-child sources = %v, want %v", got, []string{childA.ID, childB.ID, closed.ID})
+	}
+
+	// Keyset paging: page size 1 walks all four inbound sources in issue_id
+	// order with no gaps or duplicates.
+	var paged []string
+	after := ""
+	for {
+		page, err := store.GetDependentRecords(ctx, target.ID, "", 1, after)
+		if err != nil {
+			t.Fatalf("GetDependentRecords(page after %q): %v", after, err)
+		}
+		if len(page) == 0 {
+			break
+		}
+		if len(page) != 1 {
+			t.Fatalf("page size = %d, want 1", len(page))
+		}
+		paged = append(paged, page[0].IssueID)
+		after = page[0].IssueID
+	}
+	if !sameOrderedIDs(paged, wantAll) {
+		t.Fatalf("paged sources = %v, want %v", paged, wantAll)
+	}
+}
+
+// sameOrderedIDs compares two string slices positionally (order-sensitive), since
+// GetDependentRecords returns rows in issue_id ASC order.
+func sameOrderedIDs(got, want []string) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/storage/dolt/events.go
+++ b/internal/storage/dolt/events.go
@@ -57,11 +57,12 @@ func (s *DoltStore) GetAllEventsSince(ctx context.Context, since time.Time) ([]*
 
 // EventsSince returns durable events strictly after the keyset cursor, ordered
 // by (created_at ASC, id ASC) and bounded by limit. Durable events table only.
-func (s *DoltStore) EventsSince(ctx context.Context, cursor storage.EventCursor, limit int) ([]*types.Event, error) {
+// issueID != "" scopes the feed to one bead's history.
+func (s *DoltStore) EventsSince(ctx context.Context, cursor storage.EventCursor, issueID string, limit int) ([]*types.Event, error) {
 	var result []*types.Event
 	err := s.withReadTx(ctx, func(tx *sql.Tx) error {
 		var err error
-		result, err = issueops.EventsSinceInTx(ctx, tx, cursor.CreatedAt, cursor.ID, limit)
+		result, err = issueops.EventsSinceInTx(ctx, tx, cursor.CreatedAt, cursor.ID, issueID, limit)
 		return err
 	})
 	return result, err

--- a/internal/storage/dolt/events.go
+++ b/internal/storage/dolt/events.go
@@ -55,6 +55,18 @@ func (s *DoltStore) GetAllEventsSince(ctx context.Context, since time.Time) ([]*
 	return result, err
 }
 
+// EventsSince returns durable events strictly after the keyset cursor, ordered
+// by (created_at ASC, id ASC) and bounded by limit. Durable events table only.
+func (s *DoltStore) EventsSince(ctx context.Context, cursor storage.EventCursor, limit int) ([]*types.Event, error) {
+	var result []*types.Event
+	err := s.withReadTx(ctx, func(tx *sql.Tx) error {
+		var err error
+		result, err = issueops.EventsSinceInTx(ctx, tx, cursor.CreatedAt, cursor.ID, limit)
+		return err
+	})
+	return result, err
+}
+
 // AddIssueComment adds a comment to an issue (structured comment)
 func (s *DoltStore) AddIssueComment(ctx context.Context, issueID, author, text string) (*types.Comment, error) {
 	return s.ImportIssueComment(ctx, issueID, author, text, time.Now().UTC())

--- a/internal/storage/dolt/events_since_test.go
+++ b/internal/storage/dolt/events_since_test.go
@@ -1,0 +1,143 @@
+package dolt
+
+import (
+	"testing"
+	"time"
+
+	"github.com/steveyegge/beads/internal/storage"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// TestEventsSince verifies the durable keyset event read: (created_at, id)
+// ordering, same-second id tie-break, cursor exclusivity, limit clamping, and
+// durable-only scope (wisp events excluded).
+func TestEventsSince(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	// A durable issue to anchor events (events.issue_id → issues.id FK).
+	durable := &types.Issue{ID: "es-durable", Title: "Durable", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask}
+	if err := store.CreateIssue(ctx, durable, "tester"); err != nil {
+		t.Fatalf("create durable issue: %v", err)
+	}
+	// A wisp issue whose "created" event lands in wisp_events, which the
+	// durable-only feed must never surface.
+	wisp := &types.Issue{ID: "es-wisp", Title: "Wisp", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask, Ephemeral: true}
+	if err := store.CreateIssue(ctx, wisp, "tester"); err != nil {
+		t.Fatalf("create wisp issue: %v", err)
+	}
+
+	// Clear the auto-generated "created" event so the seeded rows are the only
+	// durable events, giving a fully deterministic ordering.
+	if _, err := store.db.ExecContext(ctx, "DELETE FROM events WHERE issue_id = ?", durable.ID); err != nil {
+		t.Fatalf("clear auto events: %v", err)
+	}
+
+	base := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
+	type seed struct {
+		id string
+		at time.Time
+	}
+	// e1 and e2 share a second (tie broken by id ASC); e3 is one second later.
+	seeds := []seed{
+		{id: "00000000-0000-0000-0000-000000000001", at: base},
+		{id: "00000000-0000-0000-0000-000000000002", at: base},
+		{id: "00000000-0000-0000-0000-000000000003", at: base.Add(time.Second)},
+	}
+	for _, s := range seeds {
+		if _, err := store.db.ExecContext(ctx,
+			"INSERT INTO events (id, issue_id, event_type, actor, created_at) VALUES (?, ?, ?, ?, ?)",
+			s.id, durable.ID, string(types.EventUpdated), "tester", s.at); err != nil {
+			t.Fatalf("insert seed event %s: %v", s.id, err)
+		}
+	}
+
+	ids := func(evs []*types.Event) []string {
+		out := make([]string, len(evs))
+		for i, e := range evs {
+			out[i] = e.ID
+		}
+		return out
+	}
+	eq := func(t *testing.T, got, want []string) {
+		t.Helper()
+		if len(got) != len(want) {
+			t.Fatalf("event ids = %v, want %v", got, want)
+		}
+		for i := range want {
+			if got[i] != want[i] {
+				t.Fatalf("event ids = %v, want %v", got, want)
+			}
+		}
+	}
+
+	// Empty cursor = from epoch; ordered by (created_at ASC, id ASC), durable only.
+	all, err := store.EventsSince(ctx, storage.EventCursor{}, 10)
+	if err != nil {
+		t.Fatalf("EventsSince(epoch): %v", err)
+	}
+	eq(t, ids(all), []string{seeds[0].id, seeds[1].id, seeds[2].id})
+	for _, e := range all {
+		if e.IssueID == wisp.ID {
+			t.Fatalf("durable-only feed returned wisp event for %s", wisp.ID)
+		}
+	}
+
+	// Limit honored.
+	page, err := store.EventsSince(ctx, storage.EventCursor{}, 2)
+	if err != nil {
+		t.Fatalf("EventsSince(limit=2): %v", err)
+	}
+	eq(t, ids(page), []string{seeds[0].id, seeds[1].id})
+
+	// Cursor excludes its own row and orders the same-second tie by id: starting
+	// at e1's (created_at, id) yields e2 then e3.
+	afterE1, err := store.EventsSince(ctx, storage.EventCursor{CreatedAt: seeds[0].at, ID: seeds[0].id}, 10)
+	if err != nil {
+		t.Fatalf("EventsSince(after e1): %v", err)
+	}
+	eq(t, ids(afterE1), []string{seeds[1].id, seeds[2].id})
+
+	// Exhausting the shared second advances to the next second's row.
+	afterE2, err := store.EventsSince(ctx, storage.EventCursor{CreatedAt: seeds[1].at, ID: seeds[1].id}, 10)
+	if err != nil {
+		t.Fatalf("EventsSince(after e2): %v", err)
+	}
+	eq(t, ids(afterE2), []string{seeds[2].id})
+}
+
+// TestEventsSinceClaimedConstant verifies the real claim path writes an event
+// whose type is the extracted EventClaimed constant ("claimed"), reachable
+// through the durable keyset read.
+func TestEventsSinceClaimedConstant(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	issue := &types.Issue{ID: "es-claim", Title: "Claimable", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask}
+	if err := store.CreateIssue(ctx, issue, "tester"); err != nil {
+		t.Fatalf("create issue: %v", err)
+	}
+	if err := store.ClaimIssue(ctx, issue.ID, "worker"); err != nil {
+		t.Fatalf("claim issue: %v", err)
+	}
+
+	evs, err := store.EventsSince(ctx, storage.EventCursor{}, 100)
+	if err != nil {
+		t.Fatalf("EventsSince: %v", err)
+	}
+	found := false
+	for _, e := range evs {
+		if e.IssueID == issue.ID && e.EventType == types.EventClaimed {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("no %q event found for claimed issue %s", types.EventClaimed, issue.ID)
+	}
+}

--- a/internal/storage/dolt/events_since_test.go
+++ b/internal/storage/dolt/events_since_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/steveyegge/beads/internal/storage"
+	"github.com/steveyegge/beads/internal/storage/issueops"
 	"github.com/steveyegge/beads/internal/types"
 )
 
@@ -296,13 +297,13 @@ func TestEventsSincePlanIsIndexed(t *testing.T) {
 	}
 
 	const cur = "2023-01-01 00:00:00"
-	// Mirror EventsSinceInTx's SARGABLE predicate with literals.
-	plan := explainPlan(t, ctx, store.db, `
-		SELECT id, issue_id, event_type, actor, old_value, new_value, comment, created_at
-		FROM events
-		WHERE created_at >= '`+cur+`' AND ((created_at > '`+cur+`') OR (id > ''))
-		ORDER BY created_at ASC, id ASC
-		LIMIT 100`)
+	// Single-source the guarded SQL from production: EXPLAIN the exact string
+	// EventsSinceInTx runs (issueID="" => three ? placeholders: the created_at
+	// lower bound, the strict created_at, and the id tie-break), with the
+	// placeholders replaced by literals for the plan. A change to the SARGABLE
+	// predicate in issueops.EventsSinceQuery then breaks this guard.
+	prod := issueops.EventsSinceQuery("", 100)
+	plan := explainPlan(t, ctx, store.db, literalizeParams(prod, "'"+cur+"'", "'"+cur+"'", "''"))
 
 	if !looksLikeDoltPlan(plan) {
 		t.Skipf("EXPLAIN output not in a recognized Dolt plan format, skipping sargability assertion; plan=\n%s", plan)

--- a/internal/storage/dolt/events_since_test.go
+++ b/internal/storage/dolt/events_since_test.go
@@ -1,6 +1,8 @@
 package dolt
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -75,7 +77,7 @@ func TestEventsSince(t *testing.T) {
 	}
 
 	// Empty cursor = from epoch; ordered by (created_at ASC, id ASC), durable only.
-	all, err := store.EventsSince(ctx, storage.EventCursor{}, 10)
+	all, err := store.EventsSince(ctx, storage.EventCursor{}, "", 10)
 	if err != nil {
 		t.Fatalf("EventsSince(epoch): %v", err)
 	}
@@ -87,7 +89,7 @@ func TestEventsSince(t *testing.T) {
 	}
 
 	// Limit honored.
-	page, err := store.EventsSince(ctx, storage.EventCursor{}, 2)
+	page, err := store.EventsSince(ctx, storage.EventCursor{}, "", 2)
 	if err != nil {
 		t.Fatalf("EventsSince(limit=2): %v", err)
 	}
@@ -95,14 +97,14 @@ func TestEventsSince(t *testing.T) {
 
 	// Cursor excludes its own row and orders the same-second tie by id: starting
 	// at e1's (created_at, id) yields e2 then e3.
-	afterE1, err := store.EventsSince(ctx, storage.EventCursor{CreatedAt: seeds[0].at, ID: seeds[0].id}, 10)
+	afterE1, err := store.EventsSince(ctx, storage.EventCursor{CreatedAt: seeds[0].at, ID: seeds[0].id}, "", 10)
 	if err != nil {
 		t.Fatalf("EventsSince(after e1): %v", err)
 	}
 	eq(t, ids(afterE1), []string{seeds[1].id, seeds[2].id})
 
 	// Exhausting the shared second advances to the next second's row.
-	afterE2, err := store.EventsSince(ctx, storage.EventCursor{CreatedAt: seeds[1].at, ID: seeds[1].id}, 10)
+	afterE2, err := store.EventsSince(ctx, storage.EventCursor{CreatedAt: seeds[1].at, ID: seeds[1].id}, "", 10)
 	if err != nil {
 		t.Fatalf("EventsSince(after e2): %v", err)
 	}
@@ -127,7 +129,7 @@ func TestEventsSinceClaimedConstant(t *testing.T) {
 		t.Fatalf("claim issue: %v", err)
 	}
 
-	evs, err := store.EventsSince(ctx, storage.EventCursor{}, 100)
+	evs, err := store.EventsSince(ctx, storage.EventCursor{}, "", 100)
 	if err != nil {
 		t.Fatalf("EventsSince: %v", err)
 	}
@@ -139,5 +141,173 @@ func TestEventsSinceClaimedConstant(t *testing.T) {
 	}
 	if !found {
 		t.Fatalf("no %q event found for claimed issue %s", types.EventClaimed, issue.ID)
+	}
+}
+
+// TestEventsSinceIssueFilter verifies the optional per-bead scope: a non-empty
+// issueID restricts the durable feed to that issue's events, while "" returns
+// every issue's events. This is the primitive behind `bd show`'s per-bead
+// event history.
+func TestEventsSinceIssueFilter(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	mk := func(id string) {
+		iss := &types.Issue{ID: id, Title: id, Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask}
+		if err := store.CreateIssue(ctx, iss, "tester"); err != nil {
+			t.Fatalf("create %s: %v", id, err)
+		}
+		if _, err := store.db.ExecContext(ctx, "DELETE FROM events WHERE issue_id = ?", id); err != nil {
+			t.Fatalf("clear auto events for %s: %v", id, err)
+		}
+	}
+	mk("ef-a")
+	mk("ef-b")
+
+	base := time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC)
+	seed := func(id, issueID string, at time.Time) {
+		if _, err := store.db.ExecContext(ctx,
+			"INSERT INTO events (id, issue_id, event_type, actor, created_at) VALUES (?, ?, ?, ?, ?)",
+			id, issueID, string(types.EventUpdated), "tester", at); err != nil {
+			t.Fatalf("insert seed event %s: %v", id, err)
+		}
+	}
+	seed("00000000-0000-0000-0000-0000000000a1", "ef-a", base)
+	seed("00000000-0000-0000-0000-0000000000a2", "ef-a", base.Add(time.Second))
+	seed("00000000-0000-0000-0000-0000000000b1", "ef-b", base.Add(2*time.Second))
+
+	issueIDsOf := func(evs []*types.Event) map[string]int {
+		m := map[string]int{}
+		for _, e := range evs {
+			m[e.IssueID]++
+		}
+		return m
+	}
+
+	onlyA, err := store.EventsSince(ctx, storage.EventCursor{}, "ef-a", 100)
+	if err != nil {
+		t.Fatalf("EventsSince(issue=ef-a): %v", err)
+	}
+	if got := issueIDsOf(onlyA); got["ef-a"] != 2 || got["ef-b"] != 0 {
+		t.Fatalf("filtered ef-a feed = %v, want {ef-a:2}", got)
+	}
+
+	onlyB, err := store.EventsSince(ctx, storage.EventCursor{}, "ef-b", 100)
+	if err != nil {
+		t.Fatalf("EventsSince(issue=ef-b): %v", err)
+	}
+	if got := issueIDsOf(onlyB); got["ef-b"] != 1 || got["ef-a"] != 0 {
+		t.Fatalf("filtered ef-b feed = %v, want {ef-b:1}", got)
+	}
+
+	unfiltered, err := store.EventsSince(ctx, storage.EventCursor{}, "", 100)
+	if err != nil {
+		t.Fatalf("EventsSince(all): %v", err)
+	}
+	if got := issueIDsOf(unfiltered); got["ef-a"] != 2 || got["ef-b"] != 1 {
+		t.Fatalf("unfiltered feed = %v, want {ef-a:2, ef-b:1}", got)
+	}
+}
+
+// TestEventsSinceLimitClamp verifies the self-clamp: limit <= 0 falls back to
+// the store default (100) and any limit above the hard cap is clamped to 500.
+func TestEventsSinceLimitClamp(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	iss := &types.Issue{ID: "clamp", Title: "clamp", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask}
+	if err := store.CreateIssue(ctx, iss, "tester"); err != nil {
+		t.Fatalf("create issue: %v", err)
+	}
+	if _, err := store.db.ExecContext(ctx, "DELETE FROM events WHERE issue_id = ?", iss.ID); err != nil {
+		t.Fatalf("clear auto events: %v", err)
+	}
+
+	// Seed 501 durable events in one multi-row insert (cheaper than 501 round
+	// trips). ids sort lexically in numeric order, so (created_at, id) ordering
+	// is the seed order.
+	const n = 501
+	base := time.Date(2022, 1, 1, 0, 0, 0, 0, time.UTC)
+	var b strings.Builder
+	b.WriteString("INSERT INTO events (id, issue_id, event_type, actor, created_at) VALUES ")
+	args := make([]any, 0, n*5)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			b.WriteString(",")
+		}
+		b.WriteString("(?, ?, ?, ?, ?)")
+		args = append(args,
+			fmt.Sprintf("clamp-%05d", i), iss.ID, string(types.EventUpdated), "tester", base.Add(time.Duration(i)*time.Second))
+	}
+	if _, err := store.db.ExecContext(ctx, b.String(), args...); err != nil {
+		t.Fatalf("bulk insert seed events: %v", err)
+	}
+
+	// limit <= 0 => issueops.defaultEventsSinceLimit (100).
+	const wantDefault, wantCap = 100, 500
+	def, err := store.EventsSince(ctx, storage.EventCursor{}, "", 0)
+	if err != nil {
+		t.Fatalf("EventsSince(limit=0): %v", err)
+	}
+	if len(def) != wantDefault {
+		t.Fatalf("default clamp: got %d rows, want %d", len(def), wantDefault)
+	}
+
+	// limit above the cap => issueops.maxEventsSinceLimit (500).
+	capped, err := store.EventsSince(ctx, storage.EventCursor{}, "", 100000)
+	if err != nil {
+		t.Fatalf("EventsSince(limit=100000): %v", err)
+	}
+	if len(capped) != wantCap {
+		t.Fatalf("cap clamp: got %d rows, want %d", len(capped), wantCap)
+	}
+}
+
+// TestEventsSincePlanIsIndexed is the sargability regression guard: the
+// EventsSince cursor predicate must seek idx_events_created_at
+// (IndexedTableAccess), not full-scan-and-filter. The redundant `created_at >= ?`
+// lower bound is what flips the Dolt planner from Table+Filter+TopN to an
+// indexed range. It EXPLAINs the exact predicate shape with literals and skips
+// (rather than fails) if the EXPLAIN output format is unrecognizable.
+func TestEventsSincePlanIsIndexed(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	iss := &types.Issue{ID: "plan", Title: "plan", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask}
+	if err := store.CreateIssue(ctx, iss, "tester"); err != nil {
+		t.Fatalf("create issue: %v", err)
+	}
+	base := time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC)
+	for i := 0; i < 5; i++ {
+		if _, err := store.db.ExecContext(ctx,
+			"INSERT INTO events (id, issue_id, event_type, actor, created_at) VALUES (?, ?, ?, ?, ?)",
+			fmt.Sprintf("plan-%02d", i), iss.ID, string(types.EventUpdated), "tester", base.Add(time.Duration(i)*time.Second)); err != nil {
+			t.Fatalf("insert seed event: %v", err)
+		}
+	}
+
+	const cur = "2023-01-01 00:00:00"
+	// Mirror EventsSinceInTx's SARGABLE predicate with literals.
+	plan := explainPlan(t, ctx, store.db, `
+		SELECT id, issue_id, event_type, actor, old_value, new_value, comment, created_at
+		FROM events
+		WHERE created_at >= '`+cur+`' AND ((created_at > '`+cur+`') OR (id > ''))
+		ORDER BY created_at ASC, id ASC
+		LIMIT 100`)
+
+	if !looksLikeDoltPlan(plan) {
+		t.Skipf("EXPLAIN output not in a recognized Dolt plan format, skipping sargability assertion; plan=\n%s", plan)
+	}
+	if !strings.Contains(plan, "IndexedTableAccess") || !strings.Contains(plan, "events.created_at") {
+		t.Fatalf("EventsSince predicate does not seek idx_events_created_at (want IndexedTableAccess on [events.created_at]) — the sargable lower bound regressed to a full Table scan.\nplan:\n%s", plan)
 	}
 }

--- a/internal/storage/embeddeddolt/events_since_test.go
+++ b/internal/storage/embeddeddolt/events_since_test.go
@@ -1,0 +1,75 @@
+//go:build cgo
+
+package embeddeddolt_test
+
+import (
+	"testing"
+
+	"github.com/steveyegge/beads/internal/storage"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// TestEventsSinceEmbedded mirrors the dolt-suite EventsSince coverage on the
+// embedded backend: the durable keyset feed returns durable events in
+// (created_at, id) order, excludes wisp events, and honors the per-issue filter.
+// Events are driven through store operations (CreateIssue/ClaimIssue) rather than
+// raw INSERTs, since the external test package shares no connection with the
+// store's working set.
+func TestEventsSinceEmbedded(t *testing.T) {
+	skipUnlessEmbeddedDolt(t)
+
+	te := newTestEnv(t, "es")
+	ctx := t.Context()
+
+	for _, issue := range []*types.Issue{
+		{ID: "es-a", Title: "durable a", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask},
+		{ID: "es-b", Title: "durable b", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask},
+		{ID: "es-w", Title: "wisp", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask, Ephemeral: true},
+	} {
+		if err := te.store.CreateIssue(ctx, issue, "tester"); err != nil {
+			t.Fatalf("CreateIssue %s: %v", issue.ID, err)
+		}
+	}
+	// A durable claim adds a second durable event on es-a.
+	if err := te.store.ClaimIssue(ctx, "es-a", "worker"); err != nil {
+		t.Fatalf("ClaimIssue es-a: %v", err)
+	}
+
+	// Unfiltered durable feed: es-a and es-b events present, wisp excluded,
+	// created_at non-decreasing.
+	all, err := te.store.EventsSince(ctx, storage.EventCursor{}, "", 500)
+	if err != nil {
+		t.Fatalf("EventsSince(all): %v", err)
+	}
+	var sawA, sawB bool
+	for i, e := range all {
+		switch e.IssueID {
+		case "es-a":
+			sawA = true
+		case "es-b":
+			sawB = true
+		case "es-w":
+			t.Fatalf("durable-only feed returned a wisp event for es-w")
+		}
+		if i > 0 && e.CreatedAt.Before(all[i-1].CreatedAt) {
+			t.Fatalf("feed not ordered by created_at ASC at index %d", i)
+		}
+	}
+	if !sawA || !sawB {
+		t.Fatalf("durable feed missing events: sawA=%v sawB=%v", sawA, sawB)
+	}
+
+	// Per-issue filter: only es-a's events.
+	onlyA, err := te.store.EventsSince(ctx, storage.EventCursor{}, "es-a", 500)
+	if err != nil {
+		t.Fatalf("EventsSince(issue=es-a): %v", err)
+	}
+	if len(onlyA) == 0 {
+		t.Fatalf("filtered es-a feed is empty")
+	}
+	for _, e := range onlyA {
+		if e.IssueID != "es-a" {
+			t.Fatalf("filtered es-a feed returned event for %s", e.IssueID)
+		}
+	}
+}

--- a/internal/storage/embeddeddolt/store.go
+++ b/internal/storage/embeddeddolt/store.go
@@ -573,11 +573,12 @@ func (s *EmbeddedDoltStore) GetAllEventsSince(ctx context.Context, since time.Ti
 
 // EventsSince returns durable events strictly after the keyset cursor, ordered
 // by (created_at ASC, id ASC) and bounded by limit. Durable events table only.
-func (s *EmbeddedDoltStore) EventsSince(ctx context.Context, cursor storage.EventCursor, limit int) ([]*types.Event, error) {
+// issueID != "" scopes the feed to one bead's history.
+func (s *EmbeddedDoltStore) EventsSince(ctx context.Context, cursor storage.EventCursor, issueID string, limit int) ([]*types.Event, error) {
 	var result []*types.Event
 	err := s.withConn(ctx, false, func(tx *sql.Tx) error {
 		var err error
-		result, err = issueops.EventsSinceInTx(ctx, tx, cursor.CreatedAt, cursor.ID, limit)
+		result, err = issueops.EventsSinceInTx(ctx, tx, cursor.CreatedAt, cursor.ID, issueID, limit)
 		return err
 	})
 	return result, err

--- a/internal/storage/embeddeddolt/store.go
+++ b/internal/storage/embeddeddolt/store.go
@@ -571,6 +571,18 @@ func (s *EmbeddedDoltStore) GetAllEventsSince(ctx context.Context, since time.Ti
 	return result, err
 }
 
+// EventsSince returns durable events strictly after the keyset cursor, ordered
+// by (created_at ASC, id ASC) and bounded by limit. Durable events table only.
+func (s *EmbeddedDoltStore) EventsSince(ctx context.Context, cursor storage.EventCursor, limit int) ([]*types.Event, error) {
+	var result []*types.Event
+	err := s.withConn(ctx, false, func(tx *sql.Tx) error {
+		var err error
+		result, err = issueops.EventsSinceInTx(ctx, tx, cursor.CreatedAt, cursor.ID, limit)
+		return err
+	})
+	return result, err
+}
+
 // RunInTransaction is implemented in transaction.go.
 
 // Close decrements the reference count if this store was opened via Open (the
@@ -896,6 +908,18 @@ func (s *EmbeddedDoltStore) GetDependencyRecords(ctx context.Context, issueID st
 		}
 		result = m[issueID]
 		return nil
+	})
+	return result, err
+}
+
+// GetDependentRecords returns raw dependency rows whose target is targetID,
+// without hydrating the source issues. Delegates to shared query logic.
+func (s *EmbeddedDoltStore) GetDependentRecords(ctx context.Context, targetID string, depType string, limit int, afterID string) ([]*types.Dependency, error) {
+	var result []*types.Dependency
+	err := s.withConn(ctx, false, func(tx *sql.Tx) error {
+		var err error
+		result, err = issueops.GetDependentRecordsInTx(ctx, tx, targetID, depType, limit, afterID)
+		return err
 	})
 	return result, err
 }

--- a/internal/storage/event_queries.go
+++ b/internal/storage/event_queries.go
@@ -1,0 +1,27 @@
+package storage
+
+import (
+	"context"
+	"time"
+
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// EventCursor is a keyset position in the durable events stream, ordered by
+// (created_at, id). The zero value (zero time, empty id) means "from the
+// beginning".
+type EventCursor struct {
+	CreatedAt time.Time
+	ID        string
+}
+
+// EventQueryStore provides keyset paging over the durable event log, beyond
+// the base Storage interface's time-only GetAllEventsSince. Callers that need
+// it type-assert to this interface.
+type EventQueryStore interface {
+	// EventsSince returns durable events strictly after cursor, ordered by
+	// (created_at ASC, id ASC) and bounded by limit (0 = a store default,
+	// capped). It reads the durable events table only — wisp events are not
+	// included — so a change feed built on it stays durable-only.
+	EventsSince(ctx context.Context, cursor EventCursor, limit int) ([]*types.Event, error)
+}

--- a/internal/storage/event_queries.go
+++ b/internal/storage/event_queries.go
@@ -23,5 +23,19 @@ type EventQueryStore interface {
 	// (created_at ASC, id ASC) and bounded by limit (0 = a store default,
 	// capped). It reads the durable events table only — wisp events are not
 	// included — so a change feed built on it stays durable-only.
-	EventsSince(ctx context.Context, cursor EventCursor, limit int) ([]*types.Event, error)
+	//
+	// issueID scopes the feed to a single bead's history ("" = all issues),
+	// serving a per-bead drawer read off the same keyset primitive. The scan
+	// seeks idx_events_created_at on the created_at lower bound; with issueID
+	// set the planner may instead seek idx_events_issue and filter on the
+	// cursor (a composite (issue_id, created_at, id) index does not exist).
+	//
+	// COMMIT-VISIBILITY-LAG CAVEAT: created_at is the event's logical timestamp,
+	// but on a version-controlled backend a committed row can become visible to
+	// readers slightly after its created_at. A feed that resumes from the last
+	// row's cursor must therefore re-scan a slack window behind it (a resuming
+	// consumer should overlap ~45s) and de-duplicate by id, or it can skip an
+	// event whose created_at preceded the cursor but which committed after the
+	// previous read.
+	EventsSince(ctx context.Context, cursor EventCursor, issueID string, limit int) ([]*types.Event, error)
 }

--- a/internal/storage/issueops/claim.go
+++ b/internal/storage/issueops/claim.go
@@ -177,7 +177,7 @@ func ClaimIssueInTx(ctx context.Context, tx DBTX, id string, actor string) (*Cla
 	}
 	newData, _ := json.Marshal(newUpdates)
 
-	if err := RecordFullEventInTable(ctx, tx, eventTable, id, "claimed", actor, string(oldData), string(newData)); err != nil {
+	if err := RecordFullEventInTable(ctx, tx, eventTable, id, types.EventClaimed, actor, string(oldData), string(newData)); err != nil {
 		return nil, fmt.Errorf("failed to record claim event: %w", err)
 	}
 

--- a/internal/storage/issueops/dependency_queries.go
+++ b/internal/storage/issueops/dependency_queries.go
@@ -131,6 +131,97 @@ func getDependencyRecordsIntoFromTable(ctx context.Context, tx DBTX, depTable st
 	return nil
 }
 
+// Target-keyed dependents-read bounds. A raw read has no consumer to apply a
+// page size, so it clamps its own (default when limit <= 0, hard cap otherwise).
+const (
+	defaultDependentRecordsLimit = 100
+	maxDependentRecordsLimit     = 500
+)
+
+// GetDependentRecordsInTx returns raw dependency rows whose TARGET is targetID
+// — the edges pointing AT targetID — from both the permanent and wisp
+// dependency tables. Unlike GetDependents/GetDependentsWithMetadata it does
+// NOT join or hydrate the source issues, so edges from dangling, cross-project,
+// or wisp sources are returned as raw rows rather than dropped. Rows are keyed
+// by their source issue_id (Dependency.IssueID); target resolution COALESCEs
+// the three typed target columns exactly like the source-keyed sibling reads.
+//
+// When depType is non-empty only rows of that dependency type are returned
+// ("" = all types). Results are ordered by source issue_id ASC and bounded by
+// limit (see the clamp constants). afterID is a keyset continuation over that
+// order: "" starts at the beginning, otherwise only rows with issue_id > afterID
+// are returned. The (issue_id, typed-target) unique keys make issue_id unique
+// among rows sharing a fixed target, so paging on it drops no rows.
+func GetDependentRecordsInTx(ctx context.Context, tx DBTX, targetID, depType string, limit int, afterID string) ([]*types.Dependency, error) {
+	if limit <= 0 {
+		limit = defaultDependentRecordsLimit
+	}
+	if limit > maxDependentRecordsLimit {
+		limit = maxDependentRecordsLimit
+	}
+
+	var all []*types.Dependency
+	for _, depTable := range []string{"dependencies", "wisp_dependencies"} {
+		rows, err := queryDependentRecordsFromTable(ctx, tx, depTable, targetID, depType, limit, afterID)
+		if err != nil {
+			if optionalBlockedTable(depTable) && isTableNotExistError(err) {
+				continue
+			}
+			return nil, err
+		}
+		all = append(all, rows...)
+	}
+
+	// Merge the two per-table pages into one deterministic order. issue_id is
+	// unique per fixed target across both tables (durable vs wisp sources have
+	// disjoint ids), so ordering by (issue_id, type) is total; type is only a
+	// tie-break for the pathological same-source/same-target-string edge.
+	sort.Slice(all, func(i, j int) bool {
+		if all[i].IssueID != all[j].IssueID {
+			return all[i].IssueID < all[j].IssueID
+		}
+		return all[i].Type < all[j].Type
+	})
+	if len(all) > limit {
+		all = all[:limit]
+	}
+	return all, nil
+}
+
+//nolint:gosec // G201: depTable is a hardcoded constant; targetID/depType/afterID are bound as parameters.
+func queryDependentRecordsFromTable(ctx context.Context, tx DBTX, depTable, targetID, depType string, limit int, afterID string) ([]*types.Dependency, error) {
+	query := fmt.Sprintf(`
+		SELECT issue_id, %s AS depends_on_id, type, created_at, created_by, metadata, thread_id
+		FROM %s
+		WHERE %s`, DepTargetExpr, depTable, depTargetEquals(""))
+	args := []any{targetID}
+	if depType != "" {
+		query += " AND type = ?"
+		args = append(args, depType)
+	}
+	if afterID != "" {
+		query += " AND issue_id > ?"
+		args = append(args, afterID)
+	}
+	query += fmt.Sprintf(" ORDER BY issue_id ASC LIMIT %d", limit)
+
+	rows, err := tx.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("get dependent records from %s: %w", depTable, err)
+	}
+	defer rows.Close()
+
+	var deps []*types.Dependency
+	for rows.Next() {
+		dep, scanErr := scanDependencyRow(rows)
+		if scanErr != nil {
+			return nil, fmt.Errorf("get dependent records: scan: %w", scanErr)
+		}
+		deps = append(deps, dep)
+	}
+	return deps, rows.Err()
+}
+
 func GetDependencyCountsInTx(ctx context.Context, tx DBTX, issueIDs []string) (map[string]*types.DependencyCounts, error) {
 	if len(issueIDs) == 0 {
 		return make(map[string]*types.DependencyCounts), nil

--- a/internal/storage/issueops/events.go
+++ b/internal/storage/issueops/events.go
@@ -96,17 +96,11 @@ func EventsSinceInTx(ctx context.Context, tx DBTX, cursorCreatedAt time.Time, cu
 		limit = maxEventsSinceLimit
 	}
 
-	query := `
-		SELECT id, issue_id, event_type, actor, old_value, new_value, comment, created_at
-		FROM events
-		WHERE created_at >= ? AND ((created_at > ?) OR (id > ?))`
+	query := EventsSinceQuery(issueID, limit)
 	args := []any{cursorCreatedAt, cursorCreatedAt, cursorID}
 	if issueID != "" {
-		query += " AND issue_id = ?"
 		args = append(args, issueID)
 	}
-	//nolint:gosec // G201: limit is an int clamped above; all values are bound parameters.
-	query += fmt.Sprintf(" ORDER BY created_at ASC, id ASC LIMIT %d", limit)
 
 	rows, err := tx.QueryContext(ctx, query, args...)
 	if err != nil {
@@ -115,6 +109,27 @@ func EventsSinceInTx(ctx context.Context, tx DBTX, cursorCreatedAt time.Time, cu
 	defer rows.Close()
 
 	return scanEvents(rows)
+}
+
+// EventsSinceQuery returns the exact SQL EventsSinceInTx executes for the given
+// issueID scope and already-clamped limit, with ? placeholders bound in order by
+// the caller: created_at (sargable lower bound), created_at (strict), id
+// (same-second tie-break), and issue_id when issueID != "". It is exported so
+// the backend sargability guard EXPLAINs this production string rather than a
+// hand-copied literal — a change to the SARGABLE predicate here then breaks the
+// guard.
+//
+//nolint:gosec // G201: limit is an int the caller clamps; every runtime value is a bound parameter.
+func EventsSinceQuery(issueID string, limit int) string {
+	query := `
+		SELECT id, issue_id, event_type, actor, old_value, new_value, comment, created_at
+		FROM events
+		WHERE created_at >= ? AND ((created_at > ?) OR (id > ?))`
+	if issueID != "" {
+		query += " AND issue_id = ?"
+	}
+	query += fmt.Sprintf(" ORDER BY created_at ASC, id ASC LIMIT %d", limit)
+	return query
 }
 
 func scanEvents(rows *sql.Rows) ([]*types.Event, error) {

--- a/internal/storage/issueops/events.go
+++ b/internal/storage/issueops/events.go
@@ -67,15 +67,28 @@ const (
 
 // EventsSinceInTx returns durable events strictly after the (createdAt, id)
 // keyset cursor, ordered by (created_at ASC, id ASC) and bounded by limit.
+// issueID != "" scopes the feed to one bead's history; "" returns all issues'.
 //
-// The cursor predicate `(created_at > ?) OR (created_at = ? AND id > ?)`
-// excludes the cursor row itself and orders same-second ties by id, so a
-// caller can page forward by feeding the last returned event's CreatedAt/ID
-// back in. The zero cursor (zero time, empty id) starts from the epoch.
+// The cursor predicate is written as
+//
+//	created_at >= ? AND ((created_at > ?) OR (id > ?))
+//
+// which is logically the keyset "(created_at, id) > (cursor)" but SARGABLE: the
+// redundant `created_at >= ?` lower bound lets the planner seek
+// idx_events_created_at (an IndexedTableAccess range) instead of full-scanning
+// and filtering — the bare OR form plans as Table+Filter+TopN on Dolt. The
+// nested OR then re-applies strict exclusion (drop the cursor row) and the
+// same-second id tie-break. All three placeholders bind the cursor: the time
+// twice, then the id. The zero cursor (zero time, empty id) starts from epoch.
+//
+// With issueID set an additional `issue_id = ?` is ANDed in. There is no
+// composite (issue_id, created_at, id) index, so that arm is a single-column
+// index seek (idx_events_issue) plus a filter; acceptable for a per-bead drawer,
+// which is small.
 //
 // Scope is the durable `events` table only — wisp_events are deliberately not
 // unioned in, unlike GetAllEventsSince, so the feed stays durable-only.
-func EventsSinceInTx(ctx context.Context, tx *sql.Tx, cursorCreatedAt time.Time, cursorID string, limit int) ([]*types.Event, error) {
+func EventsSinceInTx(ctx context.Context, tx DBTX, cursorCreatedAt time.Time, cursorID, issueID string, limit int) ([]*types.Event, error) {
 	if limit <= 0 {
 		limit = defaultEventsSinceLimit
 	}
@@ -83,15 +96,21 @@ func EventsSinceInTx(ctx context.Context, tx *sql.Tx, cursorCreatedAt time.Time,
 		limit = maxEventsSinceLimit
 	}
 
-	rows, err := tx.QueryContext(ctx, fmt.Sprintf(`
+	query := `
 		SELECT id, issue_id, event_type, actor, old_value, new_value, comment, created_at
 		FROM events
-		WHERE (created_at > ?) OR (created_at = ? AND id > ?)
-		ORDER BY created_at ASC, id ASC
-		LIMIT %d
-	`, limit), cursorCreatedAt, cursorCreatedAt, cursorID)
+		WHERE created_at >= ? AND ((created_at > ?) OR (id > ?))`
+	args := []any{cursorCreatedAt, cursorCreatedAt, cursorID}
+	if issueID != "" {
+		query += " AND issue_id = ?"
+		args = append(args, issueID)
+	}
+	//nolint:gosec // G201: limit is an int clamped above; all values are bound parameters.
+	query += fmt.Sprintf(" ORDER BY created_at ASC, id ASC LIMIT %d", limit)
+
+	rows, err := tx.QueryContext(ctx, query, args...)
 	if err != nil {
-		return nil, fmt.Errorf("events since cursor (%v, %q): %w", cursorCreatedAt, cursorID, err)
+		return nil, fmt.Errorf("events since cursor (%v, %q) issue %q: %w", cursorCreatedAt, cursorID, issueID, err)
 	}
 	defer rows.Close()
 

--- a/internal/storage/issueops/events.go
+++ b/internal/storage/issueops/events.go
@@ -57,6 +57,47 @@ func GetAllEventsSinceInTx(ctx context.Context, tx *sql.Tx, since time.Time) ([]
 	return scanEvents(rows)
 }
 
+// Event keyset-read bounds. The API's change feed pages the durable events
+// table with a bounded limit (default when the caller passes <= 0, hard cap
+// otherwise).
+const (
+	defaultEventsSinceLimit = 100
+	maxEventsSinceLimit     = 500
+)
+
+// EventsSinceInTx returns durable events strictly after the (createdAt, id)
+// keyset cursor, ordered by (created_at ASC, id ASC) and bounded by limit.
+//
+// The cursor predicate `(created_at > ?) OR (created_at = ? AND id > ?)`
+// excludes the cursor row itself and orders same-second ties by id, so a
+// caller can page forward by feeding the last returned event's CreatedAt/ID
+// back in. The zero cursor (zero time, empty id) starts from the epoch.
+//
+// Scope is the durable `events` table only — wisp_events are deliberately not
+// unioned in, unlike GetAllEventsSince, so the feed stays durable-only.
+func EventsSinceInTx(ctx context.Context, tx *sql.Tx, cursorCreatedAt time.Time, cursorID string, limit int) ([]*types.Event, error) {
+	if limit <= 0 {
+		limit = defaultEventsSinceLimit
+	}
+	if limit > maxEventsSinceLimit {
+		limit = maxEventsSinceLimit
+	}
+
+	rows, err := tx.QueryContext(ctx, fmt.Sprintf(`
+		SELECT id, issue_id, event_type, actor, old_value, new_value, comment, created_at
+		FROM events
+		WHERE (created_at > ?) OR (created_at = ? AND id > ?)
+		ORDER BY created_at ASC, id ASC
+		LIMIT %d
+	`, limit), cursorCreatedAt, cursorCreatedAt, cursorID)
+	if err != nil {
+		return nil, fmt.Errorf("events since cursor (%v, %q): %w", cursorCreatedAt, cursorID, err)
+	}
+	defer rows.Close()
+
+	return scanEvents(rows)
+}
+
 func scanEvents(rows *sql.Rows) ([]*types.Event, error) {
 	var events []*types.Event
 	for rows.Next() {

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -339,6 +339,7 @@ type DoltStorage interface {
 	FederationStore
 	BulkIssueStore
 	DependencyQueryStore
+	EventQueryStore
 	AnnotationStore
 	ConfigMetadataStore
 	CompactionStore

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -1066,6 +1066,7 @@ type EventType string
 const (
 	EventCreated           EventType = "created"
 	EventUpdated           EventType = "updated"
+	EventClaimed           EventType = "claimed"
 	EventStatusChanged     EventType = "status_changed"
 	EventCommented         EventType = "commented"
 	EventClosed            EventType = "closed"


### PR DESCRIPTION
> Stacked on #4922 (S12) → … → #4892 (S1); base `feat/guarded-ops-s12-isblocked-filter`. Diff below is this slice only. Per the chain's review model, the label arrives when this PR becomes head-of-chain.

## What
Ports the durable events read surface: `EventsSince` — a keyset `(created_at, id)` feed over the events table with an optional per-bead scope — plus `EventCursor`, the `EventClaimed` constant, and `GetDependentRecords`. Sargable predicate, single-sourced into the EXPLAIN guard. Authorship preserved (cherry-picks).

## Why
`bd` verbs that render event history (`bd show`'s per-bead history, activity views) and library callers had only limit-bound newest-first reads or a timestamp watermark — no stable resumable cursor. The keyset feed gives exact resume with same-second correctness, matching the engine's established keyset pattern.

## Verification
Events keyset tests + EXPLAIN plan guard (single-sourced from production SQL) on real Dolt; embedded feed test; `Event` regression sweep; builds cgo+nocgo, vet, lint 0 issues.
```bash
go test ./internal/storage/dolt/ -run 'TestEventsSince' -v
```
