### PR TITLE
feat(storage): bounded dependents reads + batched transitive-blocked read

### DIFF
--- a/internal/storage/dependency_queries.go
+++ b/internal/storage/dependency_queries.go
@@ -20,6 +20,14 @@ type DependencyQueryStore interface {
 	// group membership reads that must see dangling children. RAW: applies no
 	// visibility policy — the caller filters at hydration.
 	GetDependentRecords(ctx context.Context, targetID string, depType string, limit int, afterID string) ([]*types.Dependency, error)
+	// GetDependentRecordsForIssues returns raw dependency rows keyed by TARGET id:
+	// for each id in targetIDs, the rows whose target is that id (its inbound edges
+	// = its dependents), across both the durable and wisp dependency tables, ALL
+	// dep types (the caller filters), de-duped by row id. It is the batched,
+	// target-keyed mirror of GetDependencyRecordsForIssues — the whole-page read
+	// that answers "what does each of these ids block/gate" without a per-id
+	// fan-out. RAW: applies no visibility policy — the caller filters at hydration.
+	GetDependentRecordsForIssues(ctx context.Context, targetIDs []string) (map[string][]*types.Dependency, error)
 	// CountDependentRecords returns the total number of inbound edges of targetID
 	// (same predicate/scope as GetDependentRecords, depType "" = all), across
 	// both dependency tables, without paging. Callers that want a true total

--- a/internal/storage/dependency_queries.go
+++ b/internal/storage/dependency_queries.go
@@ -11,13 +11,21 @@ type DependencyQueryStore interface {
 	GetDependencyRecords(ctx context.Context, issueID string) ([]*types.Dependency, error)
 	GetDependencyRecordsForIssues(ctx context.Context, issueIDs []string) (map[string][]*types.Dependency, error)
 	// GetDependentRecords returns raw dependency rows whose target is targetID
-	// (the inbound edges), without hydrating the source issues. depType filters
-	// by dependency type ("" = all); results are ordered by source issue_id ASC,
-	// bounded by limit (0 = a store default, capped), and paged with afterID as
-	// a keyset continuation ("" = start). Mirrors the source-keyed
+	// (the inbound edges), without hydrating the source issues, spanning both the
+	// durable and wisp dependency tables. depType filters by dependency type
+	// ("" = all); results are ordered by the dependency row's primary id ASC,
+	// bounded by limit (0 = a store default, capped), and paged with afterID as a
+	// keyset continuation over that id ("" = start). Mirrors the source-keyed
 	// GetDependencyRecords but in the target direction; unblocks target-side
-	// group membership reads that must see dangling children.
+	// group membership reads that must see dangling children. RAW: applies no
+	// visibility policy — the caller filters at hydration.
 	GetDependentRecords(ctx context.Context, targetID string, depType string, limit int, afterID string) ([]*types.Dependency, error)
+	// CountDependentRecords returns the total number of inbound edges of targetID
+	// (same predicate/scope as GetDependentRecords, depType "" = all), across
+	// both dependency tables, without paging. Callers that want a true total
+	// membership count need it without walking every page. RAW count — no
+	// visibility policy.
+	CountDependentRecords(ctx context.Context, targetID string, depType string) (int, error)
 	GetAllDependencyRecords(ctx context.Context) (map[string][]*types.Dependency, error)
 	GetDependencyCounts(ctx context.Context, issueIDs []string) (map[string]*types.DependencyCounts, error)
 	GetBlockingInfoForIssues(ctx context.Context, issueIDs []string) (blockedByMap map[string][]string, blocksMap map[string][]string, parentMap map[string]string, err error)

--- a/internal/storage/dependency_queries.go
+++ b/internal/storage/dependency_queries.go
@@ -38,6 +38,14 @@ type DependencyQueryStore interface {
 	GetDependencyCounts(ctx context.Context, issueIDs []string) (map[string]*types.DependencyCounts, error)
 	GetBlockingInfoForIssues(ctx context.Context, issueIDs []string) (blockedByMap map[string][]string, blocksMap map[string][]string, parentMap map[string]string, err error)
 	IsBlocked(ctx context.Context, issueID string) (bool, []string, error)
+	// IsBlockedBatch returns the denormalized, TRANSITIVE is_blocked flag for a
+	// page of ids in one batched read (SELECT id, is_blocked FROM {issues,wisps}
+	// WHERE id IN (...), batched at queryBatchSize) — the same value IsBlocked
+	// returns per id, without an N-call fan-out or a per-row blocker recompute.
+	// It reflects inherited/ancestor blockedness (a child of a blocked parent is
+	// blocked with no direct blocking edge). ids present in neither table are
+	// absent from the map; callers treat absent as not-blocked.
+	IsBlockedBatch(ctx context.Context, ids []string) (map[string]bool, error)
 	GetNewlyUnblockedByClose(ctx context.Context, closedIssueID string) ([]*types.Issue, error)
 	DetectCycles(ctx context.Context) ([][]*types.Issue, error)
 	FindWispDependentsRecursive(ctx context.Context, ids []string) (map[string]bool, error)

--- a/internal/storage/dolt/dependencies.go
+++ b/internal/storage/dolt/dependencies.go
@@ -232,6 +232,18 @@ func (s *DoltStore) GetDependentRecords(ctx context.Context, targetID string, de
 	return result, err
 }
 
+// CountDependentRecords returns the total inbound-edge count of targetID across
+// both dependency tables. Delegates to issueops.CountDependentRecordsInTx.
+func (s *DoltStore) CountDependentRecords(ctx context.Context, targetID string, depType string) (int, error) {
+	var n int
+	err := s.withReadTx(ctx, func(tx *sql.Tx) error {
+		var err error
+		n, err = issueops.CountDependentRecordsInTx(ctx, tx, targetID, depType)
+		return err
+	})
+	return n, err
+}
+
 // GetAllDependencyRecords returns all dependency records.
 // Delegates to issueops.GetAllDependencyRecordsInTx for shared query logic.
 func (s *DoltStore) GetAllDependencyRecords(ctx context.Context) (map[string][]*types.Dependency, error) {

--- a/internal/storage/dolt/dependencies.go
+++ b/internal/storage/dolt/dependencies.go
@@ -347,6 +347,21 @@ func (s *DoltStore) IsBlocked(ctx context.Context, issueID string) (bool, []stri
 	return blocked, blockers, nil
 }
 
+// IsBlockedBatch returns the denormalized transitive is_blocked flag for each id
+// in one batched read. Delegates to issueops.IsBlockedBatchInTx.
+func (s *DoltStore) IsBlockedBatch(ctx context.Context, ids []string) (map[string]bool, error) {
+	var result map[string]bool
+	err := s.withReadTx(ctx, func(tx *sql.Tx) error {
+		var err error
+		result, err = issueops.IsBlockedBatchInTx(ctx, tx, ids)
+		return err
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to batch-check blockers: %w", err)
+	}
+	return result, nil
+}
+
 // GetNewlyUnblockedByClose finds issues that become unblocked when an issue is closed.
 func (s *DoltStore) GetNewlyUnblockedByClose(ctx context.Context, closedIssueID string) ([]*types.Issue, error) {
 	var result []*types.Issue

--- a/internal/storage/dolt/dependencies.go
+++ b/internal/storage/dolt/dependencies.go
@@ -244,6 +244,19 @@ func (s *DoltStore) CountDependentRecords(ctx context.Context, targetID string, 
 	return n, err
 }
 
+// GetDependentRecordsForIssues returns the raw inbound dependency rows for a SET
+// of target ids in one batched read, keyed by target id. Delegates to
+// issueops.GetDependentRecordsForIssuesInTx for shared query logic.
+func (s *DoltStore) GetDependentRecordsForIssues(ctx context.Context, targetIDs []string) (map[string][]*types.Dependency, error) {
+	var result map[string][]*types.Dependency
+	err := s.withReadTx(ctx, func(tx *sql.Tx) error {
+		var err error
+		result, err = issueops.GetDependentRecordsForIssuesInTx(ctx, tx, targetIDs)
+		return err
+	})
+	return result, err
+}
+
 // GetAllDependencyRecords returns all dependency records.
 // Delegates to issueops.GetAllDependencyRecordsInTx for shared query logic.
 func (s *DoltStore) GetAllDependencyRecords(ctx context.Context) (map[string][]*types.Dependency, error) {

--- a/internal/storage/dolt/dependents_records_test.go
+++ b/internal/storage/dolt/dependents_records_test.go
@@ -3,6 +3,7 @@ package dolt
 import (
 	"testing"
 
+	"github.com/steveyegge/beads/internal/storage/depid"
 	"github.com/steveyegge/beads/internal/types"
 )
 
@@ -175,6 +176,111 @@ func TestCountDependentRecords(t *testing.T) {
 		t.Fatalf("CountDependentRecords(leaf): %v", err)
 	} else if n != 0 {
 		t.Fatalf("CountDependentRecords(leaf) = %d, want 0", n)
+	}
+}
+
+// TestDependentRecordsCrossTableCollision seeds the SAME logical edge in BOTH
+// the durable and wisp dependency tables — they share one depid-derived id
+// because depid.New keys on (issue_id, target) and omits the table — and proves
+// the target-keyed reads treat it as a single inbound edge: GetDependentRecords
+// returns one row per id (the durable copy), CountDependentRecords equals the
+// distinct total (not the sum of two per-table COUNTs), and keyset paging is
+// stable across the collision (no dup, no drop). A collision like this arises
+// from a wisp promoted to durable or two Dolt clones merged.
+func TestDependentRecordsCrossTableCollision(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	mk := func(id string, ephemeral bool) {
+		iss := &types.Issue{ID: id, Title: id, Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask, Ephemeral: ephemeral}
+		if err := store.CreateIssue(ctx, iss, "tester"); err != nil {
+			t.Fatalf("create %s: %v", id, err)
+		}
+	}
+	mk("cc-target", false)
+	mk("cc-a", false) // durable source of the collision edge
+	mk("cc-c", false) // durable-only dependent
+	mk("cc-w", true)  // genuine wisp-only dependent
+
+	add := func(src string) {
+		if err := store.AddDependency(ctx, &types.Dependency{IssueID: src, DependsOnID: "cc-target", Type: types.DepBlocks}, "tester"); err != nil {
+			t.Fatalf("add dep %s: %v", src, err)
+		}
+	}
+	add("cc-a") // -> dependencies, id = depid.New("cc-a", "cc-target")
+	add("cc-c") // -> dependencies
+	add("cc-w") // wisp source -> wisp_dependencies
+
+	// Force the collision: the SAME (cc-a, cc-target) edge into wisp_dependencies
+	// with the same depid. FK checks are relaxed because cc-a is not a wisp — the
+	// point is to reproduce the post-merge/promotion state where one edge exists
+	// in both tables under one id.
+	collisionID := depid.New("cc-a", "cc-target")
+	if _, err := store.db.ExecContext(ctx, "SET FOREIGN_KEY_CHECKS = 0"); err != nil {
+		t.Fatalf("disable FK checks: %v", err)
+	}
+	if _, err := store.db.ExecContext(ctx,
+		"INSERT INTO wisp_dependencies (id, issue_id, depends_on_issue_id, type, created_by) VALUES (?, ?, ?, 'blocks', 'tester')",
+		collisionID, "cc-a", "cc-target"); err != nil {
+		t.Fatalf("seed collision row: %v", err)
+	}
+	if _, err := store.db.ExecContext(ctx, "SET FOREIGN_KEY_CHECKS = 1"); err != nil {
+		t.Fatalf("re-enable FK checks: %v", err)
+	}
+
+	// One row per id: cc-a appears once (its durable copy), never twice.
+	all, err := store.GetDependentRecords(ctx, "cc-target", "", 100, "")
+	if err != nil {
+		t.Fatalf("GetDependentRecords: %v", err)
+	}
+	ids := map[string]int{}
+	srcs := map[string]bool{}
+	for _, d := range all {
+		ids[d.ID]++
+		srcs[d.IssueID] = true
+	}
+	for id, n := range ids {
+		if n != 1 {
+			t.Fatalf("id %s appears %d times in one page; want exactly 1 (collision not de-duped)", id, n)
+		}
+	}
+	if len(srcs) != 3 || !srcs["cc-a"] || !srcs["cc-c"] || !srcs["cc-w"] {
+		t.Fatalf("dependent sources = %v, want {cc-a, cc-c, cc-w}", srcs)
+	}
+
+	// Count equals the distinct total (3), not the sum of two per-table COUNTs (4).
+	if n, err := store.CountDependentRecords(ctx, "cc-target", ""); err != nil {
+		t.Fatalf("CountDependentRecords: %v", err)
+	} else if n != 3 {
+		t.Fatalf("CountDependentRecords = %d, want 3 (distinct); a sum-of-counts would report 4", n)
+	}
+
+	// Keyset paging (size 1) is stable across the collision: 3 distinct sources,
+	// each once, no drop.
+	seen := map[string]bool{}
+	after := ""
+	for i := 0; i < 10; i++ {
+		page, err := store.GetDependentRecords(ctx, "cc-target", "", 1, after)
+		if err != nil {
+			t.Fatalf("page after %q: %v", after, err)
+		}
+		if len(page) == 0 {
+			break
+		}
+		if len(page) != 1 {
+			t.Fatalf("page size = %d, want 1", len(page))
+		}
+		if seen[page[0].IssueID] {
+			t.Fatalf("duplicate source %q across pages (collision drop/dup)", page[0].IssueID)
+		}
+		seen[page[0].IssueID] = true
+		after = page[0].ID
+	}
+	if len(seen) != 3 || !seen["cc-a"] || !seen["cc-c"] || !seen["cc-w"] {
+		t.Fatalf("paged sources = %v, want 3 distinct {cc-a, cc-c, cc-w}", seen)
 	}
 }
 

--- a/internal/storage/dolt/dependents_records_test.go
+++ b/internal/storage/dolt/dependents_records_test.go
@@ -326,6 +326,105 @@ func TestGetDependentRecordsLimitClamp(t *testing.T) {
 	}
 }
 
+// TestGetDependentRecordsForIssues verifies the BATCHED target-keyed dependents
+// read: it keys inbound edges by target across a SET of targets in ONE call,
+// spans both dependency tables (durable + wisp sources), returns the FULL dep-type
+// set (blocks, waits-for, conditional-blocks, parent-child — no type is dropped,
+// unlike GetBlockingInfoForIssues which restricts to blocks/parent-child), keeps
+// each row's real dep_type, and never surfaces an edge whose target is not the
+// key (a decoy where the id is the SOURCE stays out).
+func TestGetDependentRecordsForIssues(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	mk := func(id string, ephemeral bool) {
+		iss := &types.Issue{ID: id, Title: id, Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask, Ephemeral: ephemeral}
+		if err := store.CreateIssue(ctx, iss, "tester"); err != nil {
+			t.Fatalf("create %s: %v", id, err)
+		}
+	}
+	mk("bt-x", false)     // target X
+	mk("bt-y", false)     // target Y
+	mk("bt-blk", false)   // blocks -> X (durable)
+	mk("bt-wait", false)  // waits-for -> X (durable)
+	mk("bt-cond", true)   // conditional-blocks -> X from a WISP source (wisp_dependencies)
+	mk("bt-child", false) // parent-child -> X (durable)
+	mk("bt-yblk", false)  // blocks -> Y (durable)
+	mk("bt-z", false)     // decoy target: X -> Z (X is the SOURCE)
+
+	addDep := func(src, tgt string, typ types.DependencyType) {
+		if err := store.AddDependency(ctx, &types.Dependency{IssueID: src, DependsOnID: tgt, Type: typ}, "tester"); err != nil {
+			t.Fatalf("add dep %s -> %s (%s): %v", src, tgt, typ, err)
+		}
+	}
+	addDep("bt-blk", "bt-x", types.DepBlocks)
+	addDep("bt-wait", "bt-x", types.DepWaitsFor)
+	addDep("bt-cond", "bt-x", types.DepConditionalBlocks) // wisp source -> wisp_dependencies
+	addDep("bt-child", "bt-x", types.DepParentChild)
+	addDep("bt-yblk", "bt-y", types.DepBlocks)
+	addDep("bt-x", "bt-z", types.DepBlocks) // decoy: X is the SOURCE here
+
+	typesBySrc := func(deps []*types.Dependency, target string) map[string]types.DependencyType {
+		out := map[string]types.DependencyType{}
+		for _, d := range deps {
+			if d.DependsOnID != target {
+				t.Fatalf("row keyed under %s has target %s (must equal the key)", target, d.DependsOnID)
+			}
+			if d.ID == "" {
+				t.Fatalf("dependent row has empty ID (the row primary key): %+v", d)
+			}
+			out[d.IssueID] = d.Type
+		}
+		return out
+	}
+
+	byTarget, err := store.GetDependentRecordsForIssues(ctx, []string{"bt-x", "bt-y"})
+	if err != nil {
+		t.Fatalf("GetDependentRecordsForIssues: %v", err)
+	}
+
+	// X: all four inbound edges, keyed by target, spanning both tables, with the
+	// FULL type set and real dep_type preserved (no drop of waits-for/conditional-
+	// blocks, no drop of the wisp-source or the parent-child edge).
+	x := typesBySrc(byTarget["bt-x"], "bt-x")
+	if len(x) != 4 {
+		t.Fatalf("X dependents = %v, want 4 (blocks, waits-for, conditional-blocks[wisp], parent-child)", x)
+	}
+	if x["bt-blk"] != types.DepBlocks || x["bt-wait"] != types.DepWaitsFor ||
+		x["bt-cond"] != types.DepConditionalBlocks || x["bt-child"] != types.DepParentChild {
+		t.Fatalf("X dependents lost a real dep_type or dropped a wisp/blocking edge: %v", x)
+	}
+	if _, bad := x["bt-z"]; bad {
+		t.Fatalf("decoy edge X->Z surfaced as an inbound edge of X: %v", x)
+	}
+
+	// Y: its single inbound blocks edge, keyed separately in the same batch.
+	y := typesBySrc(byTarget["bt-y"], "bt-y")
+	if len(y) != 1 || y["bt-yblk"] != types.DepBlocks {
+		t.Fatalf("Y dependents = %v, want {bt-yblk: blocks}", y)
+	}
+
+	// A batch element with no inbound edges is simply absent from the map (bt-blk
+	// only has an OUTGOING edge), never an error or a phantom key.
+	leaf, err := store.GetDependentRecordsForIssues(ctx, []string{"bt-blk"})
+	if err != nil {
+		t.Fatalf("GetDependentRecordsForIssues(leaf): %v", err)
+	}
+	if got, present := leaf["bt-blk"]; present {
+		t.Fatalf("source-only node bt-blk has inbound edges %v, want absent", got)
+	}
+
+	// Empty input is a valid empty map, not an error.
+	if got, err := store.GetDependentRecordsForIssues(ctx, nil); err != nil {
+		t.Fatalf("GetDependentRecordsForIssues(nil): %v", err)
+	} else if len(got) != 0 {
+		t.Fatalf("GetDependentRecordsForIssues(nil) = %v, want empty", got)
+	}
+}
+
 // pad renders i as a zero-padded 4-digit string for stable id construction.
 func pad(i int) string {
 	s := ""

--- a/internal/storage/dolt/dependents_records_test.go
+++ b/internal/storage/dolt/dependents_records_test.go
@@ -8,8 +8,10 @@ import (
 
 // TestGetDependentRecords verifies the target-keyed raw dependents read:
 // direction correctness (rows whose target is X, not whose source is X), the
-// dep-type filter, deterministic issue_id ordering, keyset paging, and that it
-// does not drop rows based on source status (raw, no source hydration).
+// dep-type filter, that rows span BOTH the durable and wisp dependency tables,
+// row-id keyset paging with no drop/dup across the two-table boundary, and that
+// it does not drop rows on source status (raw, no source hydration). Ordering is
+// by the dependency row's primary id (a UUIDv5), so assertions are set-based.
 func TestGetDependentRecords(t *testing.T) {
 	store, cleanup := setupTestStore(t)
 	defer cleanup()
@@ -17,22 +19,19 @@ func TestGetDependentRecords(t *testing.T) {
 	ctx, cancel := testContext(t)
 	defer cancel()
 
-	// Target X (the "epic"/group), the sources pointing AT it, and a decoy that
-	// X itself points at (to prove direction). ids are chosen so issue_id ASC is
-	// [s1, s2, s3, s4].
-	mk := func(id string) *types.Issue {
-		iss := &types.Issue{ID: id, Title: id, Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask}
+	mk := func(id string, ephemeral bool) *types.Issue {
+		iss := &types.Issue{ID: id, Title: id, Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask, Ephemeral: ephemeral}
 		if err := store.CreateIssue(ctx, iss, "tester"); err != nil {
 			t.Fatalf("create %s: %v", id, err)
 		}
 		return iss
 	}
-	target := mk("dr-target")
-	block := mk("dr-s1-block")   // blocks -> X
-	childA := mk("dr-s2-childa") // parent-child -> X
-	childB := mk("dr-s3-childb") // parent-child -> X
-	closed := mk("dr-s4-closed") // parent-child -> X, then closed
-	other := mk("dr-other")      // X -> other (decoy: source is X)
+	target := mk("dr-target", false)
+	block := mk("dr-s1-block", false)   // blocks -> X (durable, `dependencies`)
+	childA := mk("dr-s2-childa", false) // parent-child -> X (durable)
+	closed := mk("dr-s3-closed", false) // parent-child -> X, then closed (durable)
+	wispDep := mk("dr-s4-wisp", true)   // blocks -> X from a WISP source (`wisp_dependencies`)
+	other := mk("dr-other", false)      // X -> other (decoy: source is X)
 
 	addDep := func(src, tgt string, typ types.DependencyType) {
 		if err := store.AddDependency(ctx, &types.Dependency{IssueID: src, DependsOnID: tgt, Type: typ}, "tester"); err != nil {
@@ -41,32 +40,43 @@ func TestGetDependentRecords(t *testing.T) {
 	}
 	addDep(block.ID, target.ID, types.DepBlocks)
 	addDep(childA.ID, target.ID, types.DepParentChild)
-	addDep(childB.ID, target.ID, types.DepParentChild)
 	addDep(closed.ID, target.ID, types.DepParentChild)
-	addDep(target.ID, other.ID, types.DepBlocks) // decoy: target is the SOURCE here
+	addDep(wispDep.ID, target.ID, types.DepBlocks) // wisp source -> durable target (wisp_dependencies)
+	addDep(target.ID, other.ID, types.DepBlocks)   // decoy: target is the SOURCE here
 	if err := store.CloseIssue(ctx, closed.ID, "done", "tester", ""); err != nil {
 		t.Fatalf("close %s: %v", closed.ID, err)
 	}
 
-	srcIDs := func(deps []*types.Dependency) []string {
-		out := make([]string, len(deps))
-		for i, d := range deps {
-			out[i] = d.IssueID
+	srcSet := func(deps []*types.Dependency) map[string]bool {
+		out := map[string]bool{}
+		for _, d := range deps {
+			out[d.IssueID] = true
 		}
 		return out
 	}
+	eqSet := func(t *testing.T, got map[string]bool, want ...string) {
+		t.Helper()
+		if len(got) != len(want) {
+			t.Fatalf("dependent sources = %v, want %v", got, want)
+		}
+		for _, w := range want {
+			if !got[w] {
+				t.Fatalf("dependent sources = %v, missing %q", got, w)
+			}
+		}
+	}
 
-	// Direction + raw: all inbound edges of X, regardless of source status. The
-	// decoy (target-is-X-as-source) must not appear; the closed source must.
+	// Direction + raw + two-table span: all inbound edges of X regardless of
+	// source status, INCLUDING the wisp source; the decoy must not appear.
 	all, err := store.GetDependentRecords(ctx, target.ID, "", 100, "")
 	if err != nil {
 		t.Fatalf("GetDependentRecords(all): %v", err)
 	}
-	wantAll := []string{block.ID, childA.ID, childB.ID, closed.ID}
-	if got := srcIDs(all); !sameOrderedIDs(got, wantAll) {
-		t.Fatalf("inbound sources = %v, want %v (ordered issue_id ASC)", got, wantAll)
-	}
+	eqSet(t, srcSet(all), block.ID, childA.ID, closed.ID, wispDep.ID)
 	for _, d := range all {
+		if d.ID == "" {
+			t.Fatalf("dependent row has empty ID (the keyset cursor): %+v", d)
+		}
 		if d.DependsOnID != target.ID {
 			t.Fatalf("row %s has target %s, want %s", d.IssueID, d.DependsOnID, target.ID)
 		}
@@ -80,22 +90,19 @@ func TestGetDependentRecords(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetDependentRecords(other): %v", err)
 	}
-	if got := srcIDs(fromOther); !sameOrderedIDs(got, []string{target.ID}) {
-		t.Fatalf("inbound sources of other = %v, want %v", got, []string{target.ID})
-	}
+	eqSet(t, srcSet(fromOther), target.ID)
 
-	// Type filter: only parent-child edges.
+	// Type filter: only parent-child edges (the wisp edge is 'blocks', excluded).
 	pc, err := store.GetDependentRecords(ctx, target.ID, string(types.DepParentChild), 100, "")
 	if err != nil {
 		t.Fatalf("GetDependentRecords(parent-child): %v", err)
 	}
-	if got := srcIDs(pc); !sameOrderedIDs(got, []string{childA.ID, childB.ID, closed.ID}) {
-		t.Fatalf("parent-child sources = %v, want %v", got, []string{childA.ID, childB.ID, closed.ID})
-	}
+	eqSet(t, srcSet(pc), childA.ID, closed.ID)
 
-	// Keyset paging: page size 1 walks all four inbound sources in issue_id
-	// order with no gaps or duplicates.
-	var paged []string
+	// Row-id keyset paging across the two-table boundary: page size 1 walks all
+	// four inbound sources (three durable + one wisp) with no gaps or duplicates.
+	seen := map[string]bool{}
+	var pages int
 	after := ""
 	for {
 		page, err := store.GetDependentRecords(ctx, target.ID, "", 1, after)
@@ -108,24 +115,116 @@ func TestGetDependentRecords(t *testing.T) {
 		if len(page) != 1 {
 			t.Fatalf("page size = %d, want 1", len(page))
 		}
-		paged = append(paged, page[0].IssueID)
-		after = page[0].IssueID
+		if seen[page[0].IssueID] {
+			t.Fatalf("duplicate source %q across pages (keyset drop/dup)", page[0].IssueID)
+		}
+		seen[page[0].IssueID] = true
+		after = page[0].ID
+		if pages++; pages > 10 {
+			t.Fatalf("paging did not terminate")
+		}
 	}
-	if !sameOrderedIDs(paged, wantAll) {
-		t.Fatalf("paged sources = %v, want %v", paged, wantAll)
+	eqSet(t, seen, block.ID, childA.ID, closed.ID, wispDep.ID)
+}
+
+// TestCountDependentRecords verifies the un-paged total matches the paged read's
+// membership, spans both tables, and honors the type filter.
+func TestCountDependentRecords(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	mk := func(id string, ephemeral bool) {
+		iss := &types.Issue{ID: id, Title: id, Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask, Ephemeral: ephemeral}
+		if err := store.CreateIssue(ctx, iss, "tester"); err != nil {
+			t.Fatalf("create %s: %v", id, err)
+		}
+	}
+	mk("cd-target", false)
+	mk("cd-s1", false)
+	mk("cd-s2", false)
+	mk("cd-w", true)
+	add := func(src string, typ types.DependencyType) {
+		if err := store.AddDependency(ctx, &types.Dependency{IssueID: src, DependsOnID: "cd-target", Type: typ}, "tester"); err != nil {
+			t.Fatalf("add dep %s: %v", src, err)
+		}
+	}
+	add("cd-s1", types.DepBlocks)
+	add("cd-s2", types.DepParentChild)
+	add("cd-w", types.DepBlocks) // wisp source (wisp_dependencies)
+
+	if n, err := store.CountDependentRecords(ctx, "cd-target", ""); err != nil {
+		t.Fatalf("CountDependentRecords: %v", err)
+	} else if n != 3 {
+		t.Fatalf("CountDependentRecords(all) = %d, want 3 (2 durable + 1 wisp)", n)
+	}
+	if n, err := store.CountDependentRecords(ctx, "cd-target", string(types.DepBlocks)); err != nil {
+		t.Fatalf("CountDependentRecords(blocks): %v", err)
+	} else if n != 2 {
+		t.Fatalf("CountDependentRecords(blocks) = %d, want 2 (cd-s1 durable + cd-w wisp)", n)
+	}
+	if n, err := store.CountDependentRecords(ctx, "cd-target", string(types.DepParentChild)); err != nil {
+		t.Fatalf("CountDependentRecords(parent-child): %v", err)
+	} else if n != 1 {
+		t.Fatalf("CountDependentRecords(parent-child) = %d, want 1", n)
+	}
+	// A target with no dependents counts zero, not an error.
+	if n, err := store.CountDependentRecords(ctx, "cd-s1", ""); err != nil {
+		t.Fatalf("CountDependentRecords(leaf): %v", err)
+	} else if n != 0 {
+		t.Fatalf("CountDependentRecords(leaf) = %d, want 0", n)
 	}
 }
 
-// sameOrderedIDs compares two string slices positionally (order-sensitive), since
-// GetDependentRecords returns rows in issue_id ASC order.
-func sameOrderedIDs(got, want []string) bool {
-	if len(got) != len(want) {
-		return false
+// TestGetDependentRecordsLimitClamp verifies the self-clamp (default 100, cap 500).
+func TestGetDependentRecordsLimitClamp(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	if err := store.CreateIssue(ctx, &types.Issue{ID: "lc-target", Title: "t", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask}, "tester"); err != nil {
+		t.Fatalf("create target: %v", err)
 	}
-	for i := range want {
-		if got[i] != want[i] {
-			return false
+	// 120 durable dependents -> more than the default clamp (100), fewer than
+	// the cap (500), so we can observe the default kick in without seeding 500.
+	const n = 120
+	for i := 0; i < n; i++ {
+		id := "lc-s" + pad(i)
+		if err := store.CreateIssue(ctx, &types.Issue{ID: id, Title: id, Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask}, "tester"); err != nil {
+			t.Fatalf("create %s: %v", id, err)
+		}
+		if err := store.AddDependency(ctx, &types.Dependency{IssueID: id, DependsOnID: "lc-target", Type: types.DepBlocks}, "tester"); err != nil {
+			t.Fatalf("add dep %s: %v", id, err)
 		}
 	}
-	return true
+
+	// limit <= 0 => issueops.defaultDependentRecordsLimit (100).
+	def, err := store.GetDependentRecords(ctx, "lc-target", "", 0, "")
+	if err != nil {
+		t.Fatalf("GetDependentRecords(limit=0): %v", err)
+	}
+	if len(def) != 100 {
+		t.Fatalf("default clamp: got %d rows, want 100", len(def))
+	}
+	// A limit above the total returns the total (and is under the 500 cap).
+	full, err := store.GetDependentRecords(ctx, "lc-target", "", 100000, "")
+	if err != nil {
+		t.Fatalf("GetDependentRecords(limit=100000): %v", err)
+	}
+	if len(full) != n {
+		t.Fatalf("clamp with limit>total: got %d rows, want %d", len(full), n)
+	}
+}
+
+// pad renders i as a zero-padded 4-digit string for stable id construction.
+func pad(i int) string {
+	s := ""
+	for _, d := range []int{1000, 100, 10, 1} {
+		s += string(rune('0' + (i/d)%10))
+	}
+	return s
 }

--- a/internal/storage/dolt/is_blocked_batch_test.go
+++ b/internal/storage/dolt/is_blocked_batch_test.go
@@ -1,0 +1,81 @@
+package dolt
+
+import (
+	"testing"
+
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// TestIsBlockedBatch is the batch-is_blocked regression on the reference Dolt
+// backend: the batch transitive is_blocked read agrees with per-row IsBlocked
+// for every id (direct blocker, inherited parent-child block, unblocked control), and
+// reflects inherited blockedness with an EMPTY direct-blocker set — the same
+// denormalized column IsBlocked reads, in one round-trip, with no recompute.
+func TestIsBlockedBatch(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	mk := func(id string) {
+		iss := &types.Issue{ID: id, Title: id, Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask}
+		if err := store.CreateIssue(ctx, iss, "tester"); err != nil {
+			t.Fatalf("create %s: %v", id, err)
+		}
+	}
+	add := func(src, tgt string, typ types.DependencyType) {
+		if err := store.AddDependency(ctx, &types.Dependency{IssueID: src, DependsOnID: tgt, Type: typ}, "tester"); err != nil {
+			t.Fatalf("add dep %s->%s: %v", src, tgt, err)
+		}
+	}
+	// ib-blk (open) blocks ib-parent; ib-child is a parent-child of ib-parent so
+	// it inherits is_blocked with no direct blocking edge; ib-free is unblocked.
+	mk("ib-blk")
+	mk("ib-parent")
+	add("ib-parent", "ib-blk", types.DepBlocks)
+	mk("ib-child")
+	add("ib-child", "ib-parent", types.DepParentChild)
+	mk("ib-free")
+
+	ids := []string{"ib-blk", "ib-parent", "ib-child", "ib-free"}
+	batch, err := store.IsBlockedBatch(ctx, ids)
+	if err != nil {
+		t.Fatalf("IsBlockedBatch: %v", err)
+	}
+
+	// Batch value must equal per-row IsBlocked for every id.
+	for _, id := range ids {
+		want, _, err := store.IsBlocked(ctx, id)
+		if err != nil {
+			t.Fatalf("IsBlocked(%s): %v", id, err)
+		}
+		if batch[id] != want {
+			t.Fatalf("IsBlockedBatch[%s] = %v, want %v (per-row IsBlocked)", id, batch[id], want)
+		}
+	}
+
+	// Inherited block: the child is transitively blocked with an EMPTY direct
+	// blocker set, and the batch reflects it.
+	blocked, blockers, err := store.IsBlocked(ctx, "ib-child")
+	if err != nil {
+		t.Fatalf("IsBlocked(ib-child): %v", err)
+	}
+	if !blocked || len(blockers) != 0 {
+		t.Fatalf("ib-child IsBlocked = (%v, %v), want (true, []) — inherited block, empty direct blockers", blocked, blockers)
+	}
+	if !batch["ib-child"] || !batch["ib-parent"] {
+		t.Fatalf("IsBlockedBatch child=%v parent=%v, want both true", batch["ib-child"], batch["ib-parent"])
+	}
+	if batch["ib-free"] {
+		t.Fatalf("IsBlockedBatch[ib-free] = true, want false")
+	}
+
+	// Missing id is absent from the map (callers treat absent as not-blocked).
+	miss, err := store.IsBlockedBatch(ctx, []string{"ib-nope"})
+	if err != nil {
+		t.Fatalf("IsBlockedBatch(missing): %v", err)
+	}
+	if _, ok := miss["ib-nope"]; ok {
+		t.Fatalf("IsBlockedBatch returned an entry for a missing id: %v", miss)
+	}
+}

--- a/internal/storage/dolt/is_blocked_batch_test.go
+++ b/internal/storage/dolt/is_blocked_batch_test.go
@@ -79,3 +79,53 @@ func TestIsBlockedBatch(t *testing.T) {
 		t.Fatalf("IsBlockedBatch returned an entry for a missing id: %v", miss)
 	}
 }
+
+// TestIsBlockedBatchCrossTableCollisionMatchesSingle locks in the single/batch
+// resolution parity: when the SAME id lives in BOTH the issues and wisps tables
+// with DIFFERENT is_blocked values (a data anomaly), the batch read
+// (IsBlockedBatch) must resolve the shared is_blocked field the same
+// way the per-row read (IsBlocked) does. IsBlockedInTx scans
+// issues→wisps and breaks on the first table that has the id, so ISSUES wins;
+// the batch must agree. Before the fix the batch preferred the wisps row and the
+// two reads disagreed on the same stored flag.
+func TestIsBlockedBatchCrossTableCollisionMatchesSingle(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	const id = "ib-collide"
+
+	// issues row: is_blocked = 1 (blocked).
+	createPerm(t, ctx, store, id)
+	if _, err := store.execContext(ctx, "UPDATE issues SET is_blocked = 1 WHERE id = ?", id); err != nil {
+		t.Fatalf("set issues.is_blocked: %v", err)
+	}
+
+	// wisps row with the SAME id but is_blocked = 0 (not blocked) — the collision.
+	if _, err := store.execContext(ctx, `
+		INSERT INTO wisps (id, title, description, design, acceptance_criteria, notes, status, priority, issue_type, ephemeral, is_blocked)
+		VALUES (?, ?, '', '', '', '', ?, ?, ?, ?, ?)
+	`, id, "wisp collide", types.StatusOpen, 2, types.TypeTask, true, 0); err != nil {
+		t.Fatalf("insert colliding wisp row: %v", err)
+	}
+
+	single, _, err := store.IsBlocked(ctx, id)
+	if err != nil {
+		t.Fatalf("IsBlocked(%s): %v", id, err)
+	}
+	batch, err := store.IsBlockedBatch(ctx, []string{id})
+	if err != nil {
+		t.Fatalf("IsBlockedBatch(%s): %v", id, err)
+	}
+
+	// The two reads must agree on the shared is_blocked field.
+	if single != batch[id] {
+		t.Fatalf("collision divergence: IsBlocked(%s) = %v, IsBlockedBatch[%s] = %v — must agree", id, single, id, batch[id])
+	}
+	// And the agreed value must be the ISSUES-table value (issues-wins), matching
+	// IsBlockedInTx's issues→wisps break order.
+	if !single {
+		t.Fatalf("IsBlocked(%s) = false, want true (issues-wins: issues.is_blocked = 1)", id)
+	}
+}

--- a/internal/storage/embeddeddolt/dependents_records_test.go
+++ b/internal/storage/embeddeddolt/dependents_records_test.go
@@ -91,3 +91,73 @@ func TestGetDependentRecordsEmbedded(t *testing.T) {
 		t.Fatalf("CountDependentRecords(blocks) = %d, want 2 (dr-s1 + dr-w)", n)
 	}
 }
+
+// TestGetDependentRecordsForIssuesEmbedded mirrors the dolt-suite batched
+// target-keyed coverage on the embedded backend: inbound edges keyed by target
+// across a SET of targets in one call, spanning both tables (durable + wisp
+// sources), with the FULL dep-type set (blocks, waits-for, conditional-blocks,
+// parent-child) and real dep_type preserved, and a decoy (source==id) excluded.
+func TestGetDependentRecordsForIssuesEmbedded(t *testing.T) {
+	skipUnlessEmbeddedDolt(t)
+
+	te := newTestEnv(t, "bt")
+	ctx := t.Context()
+
+	for _, issue := range []*types.Issue{
+		{ID: "bt-x", Title: "x", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask},
+		{ID: "bt-y", Title: "y", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask},
+		{ID: "bt-blk", Title: "blk", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask},
+		{ID: "bt-wait", Title: "wait", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask},
+		{ID: "bt-cond", Title: "cond", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask, Ephemeral: true},
+		{ID: "bt-child", Title: "child", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask},
+		{ID: "bt-yblk", Title: "yblk", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask},
+		{ID: "bt-z", Title: "z", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask},
+	} {
+		if err := te.store.CreateIssue(ctx, issue, "tester"); err != nil {
+			t.Fatalf("CreateIssue %s: %v", issue.ID, err)
+		}
+	}
+	for _, dep := range []*types.Dependency{
+		{IssueID: "bt-blk", DependsOnID: "bt-x", Type: types.DepBlocks},
+		{IssueID: "bt-wait", DependsOnID: "bt-x", Type: types.DepWaitsFor},
+		{IssueID: "bt-cond", DependsOnID: "bt-x", Type: types.DepConditionalBlocks}, // wisp source
+		{IssueID: "bt-child", DependsOnID: "bt-x", Type: types.DepParentChild},
+		{IssueID: "bt-yblk", DependsOnID: "bt-y", Type: types.DepBlocks},
+		{IssueID: "bt-x", DependsOnID: "bt-z", Type: types.DepBlocks}, // decoy: bt-x is the SOURCE
+	} {
+		if err := te.store.AddDependency(ctx, dep, "tester"); err != nil {
+			t.Fatalf("AddDependency %s->%s: %v", dep.IssueID, dep.DependsOnID, err)
+		}
+	}
+
+	typesBySrc := func(deps []*types.Dependency, target string) map[string]types.DependencyType {
+		out := map[string]types.DependencyType{}
+		for _, d := range deps {
+			if d.DependsOnID != target {
+				t.Fatalf("row keyed under %s has target %s", target, d.DependsOnID)
+			}
+			if d.ID == "" {
+				t.Fatalf("dependent row missing ID: %+v", d)
+			}
+			out[d.IssueID] = d.Type
+		}
+		return out
+	}
+
+	byTarget, err := te.store.GetDependentRecordsForIssues(ctx, []string{"bt-x", "bt-y"})
+	if err != nil {
+		t.Fatalf("GetDependentRecordsForIssues: %v", err)
+	}
+	x := typesBySrc(byTarget["bt-x"], "bt-x")
+	if len(x) != 4 || x["bt-blk"] != types.DepBlocks || x["bt-wait"] != types.DepWaitsFor ||
+		x["bt-cond"] != types.DepConditionalBlocks || x["bt-child"] != types.DepParentChild {
+		t.Fatalf("X dependents = %v, want the full 4-type set with real dep_type", x)
+	}
+	if _, bad := x["bt-z"]; bad {
+		t.Fatalf("decoy edge X->Z surfaced as an inbound edge of X: %v", x)
+	}
+	y := typesBySrc(byTarget["bt-y"], "bt-y")
+	if len(y) != 1 || y["bt-yblk"] != types.DepBlocks {
+		t.Fatalf("Y dependents = %v, want {bt-yblk: blocks}", y)
+	}
+}

--- a/internal/storage/embeddeddolt/dependents_records_test.go
+++ b/internal/storage/embeddeddolt/dependents_records_test.go
@@ -1,0 +1,93 @@
+//go:build cgo
+
+package embeddeddolt_test
+
+import (
+	"testing"
+
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// TestGetDependentRecordsEmbedded mirrors the dolt-suite target-keyed dependents
+// coverage on the embedded backend: direction, two-table span (durable + wisp
+// sources), the type filter, row-id keyset paging with no drop/dup, and
+// CountDependentRecords totals.
+func TestGetDependentRecordsEmbedded(t *testing.T) {
+	skipUnlessEmbeddedDolt(t)
+
+	te := newTestEnv(t, "dr")
+	ctx := t.Context()
+
+	for _, issue := range []*types.Issue{
+		{ID: "dr-target", Title: "target", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask},
+		{ID: "dr-s1", Title: "s1", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask},
+		{ID: "dr-s2", Title: "s2", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask},
+		{ID: "dr-w", Title: "wisp", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask, Ephemeral: true},
+	} {
+		if err := te.store.CreateIssue(ctx, issue, "tester"); err != nil {
+			t.Fatalf("CreateIssue %s: %v", issue.ID, err)
+		}
+	}
+	for _, dep := range []*types.Dependency{
+		{IssueID: "dr-s1", DependsOnID: "dr-target", Type: types.DepBlocks},
+		{IssueID: "dr-s2", DependsOnID: "dr-target", Type: types.DepParentChild},
+		{IssueID: "dr-w", DependsOnID: "dr-target", Type: types.DepBlocks}, // wisp source -> wisp_dependencies
+	} {
+		if err := te.store.AddDependency(ctx, dep, "tester"); err != nil {
+			t.Fatalf("AddDependency %s->%s: %v", dep.IssueID, dep.DependsOnID, err)
+		}
+	}
+
+	set := func(deps []*types.Dependency) map[string]bool {
+		m := map[string]bool{}
+		for _, d := range deps {
+			if d.ID == "" {
+				t.Fatalf("dependent row missing ID (keyset cursor): %+v", d)
+			}
+			m[d.IssueID] = true
+		}
+		return m
+	}
+
+	all, err := te.store.GetDependentRecords(ctx, "dr-target", "", 100, "")
+	if err != nil {
+		t.Fatalf("GetDependentRecords: %v", err)
+	}
+	got := set(all)
+	if len(got) != 3 || !got["dr-s1"] || !got["dr-s2"] || !got["dr-w"] {
+		t.Fatalf("dependents = %v, want {dr-s1, dr-s2, dr-w} (spanning both tables)", got)
+	}
+
+	// Row-id keyset paging across the two-table boundary.
+	seen := map[string]bool{}
+	after := ""
+	for i := 0; i < 10; i++ {
+		page, err := te.store.GetDependentRecords(ctx, "dr-target", "", 1, after)
+		if err != nil {
+			t.Fatalf("page after %q: %v", after, err)
+		}
+		if len(page) == 0 {
+			break
+		}
+		if seen[page[0].IssueID] {
+			t.Fatalf("duplicate source %q across pages", page[0].IssueID)
+		}
+		seen[page[0].IssueID] = true
+		after = page[0].ID
+	}
+	if len(seen) != 3 {
+		t.Fatalf("paged sources = %v, want 3 distinct", seen)
+	}
+
+	// CountDependentRecords totals span both tables and honor the type filter.
+	if n, err := te.store.CountDependentRecords(ctx, "dr-target", ""); err != nil {
+		t.Fatalf("CountDependentRecords: %v", err)
+	} else if n != 3 {
+		t.Fatalf("CountDependentRecords(all) = %d, want 3", n)
+	}
+	if n, err := te.store.CountDependentRecords(ctx, "dr-target", string(types.DepBlocks)); err != nil {
+		t.Fatalf("CountDependentRecords(blocks): %v", err)
+	} else if n != 2 {
+		t.Fatalf("CountDependentRecords(blocks) = %d, want 2 (dr-s1 + dr-w)", n)
+	}
+}

--- a/internal/storage/embeddeddolt/is_blocked_batch_test.go
+++ b/internal/storage/embeddeddolt/is_blocked_batch_test.go
@@ -1,0 +1,63 @@
+//go:build cgo
+
+package embeddeddolt_test
+
+import (
+	"testing"
+
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// TestIsBlockedBatchEmbedded is the batch-is_blocked regression on the embedded
+// Dolt backend: IsBlockedBatch agrees with per-row IsBlocked for every id and
+// reflects an inherited parent-child block (transitive is_blocked with an empty
+// direct-blocker set), through the same store surface.
+func TestIsBlockedBatchEmbedded(t *testing.T) {
+	skipUnlessEmbeddedDolt(t)
+
+	te := newTestEnv(t, "ib")
+	ctx := t.Context()
+
+	mk := func(id string) {
+		iss := &types.Issue{ID: id, Title: id, Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask}
+		if err := te.store.CreateIssue(ctx, iss, "tester"); err != nil {
+			t.Fatalf("create %s: %v", id, err)
+		}
+	}
+	add := func(src, tgt string, typ types.DependencyType) {
+		if err := te.store.AddDependency(ctx, &types.Dependency{IssueID: src, DependsOnID: tgt, Type: typ}, "tester"); err != nil {
+			t.Fatalf("add dep %s->%s: %v", src, tgt, err)
+		}
+	}
+	mk("ib-blk")
+	mk("ib-parent")
+	add("ib-parent", "ib-blk", types.DepBlocks)
+	mk("ib-child")
+	add("ib-child", "ib-parent", types.DepParentChild)
+	mk("ib-free")
+
+	ids := []string{"ib-blk", "ib-parent", "ib-child", "ib-free"}
+	batch, err := te.store.IsBlockedBatch(ctx, ids)
+	if err != nil {
+		t.Fatalf("IsBlockedBatch: %v", err)
+	}
+	for _, id := range ids {
+		want, _, err := te.store.IsBlocked(ctx, id)
+		if err != nil {
+			t.Fatalf("IsBlocked(%s): %v", id, err)
+		}
+		if batch[id] != want {
+			t.Fatalf("IsBlockedBatch[%s] = %v, want %v (per-row IsBlocked)", id, batch[id], want)
+		}
+	}
+	blocked, blockers, err := te.store.IsBlocked(ctx, "ib-child")
+	if err != nil {
+		t.Fatalf("IsBlocked(ib-child): %v", err)
+	}
+	if !blocked || len(blockers) != 0 {
+		t.Fatalf("ib-child IsBlocked = (%v, %v), want (true, []) — inherited block, empty direct blockers", blocked, blockers)
+	}
+	if !batch["ib-child"] || !batch["ib-parent"] || batch["ib-free"] {
+		t.Fatalf("IsBlockedBatch = %v, want child+parent true, free false", batch)
+	}
+}

--- a/internal/storage/embeddeddolt/issues.go
+++ b/internal/storage/embeddeddolt/issues.go
@@ -200,6 +200,18 @@ func (s *EmbeddedDoltStore) IsBlocked(ctx context.Context, issueID string) (bool
 	return blocked, blockers, err
 }
 
+// IsBlockedBatch returns the denormalized transitive is_blocked flag for each id
+// in one batched read. Delegates to issueops.IsBlockedBatchInTx.
+func (s *EmbeddedDoltStore) IsBlockedBatch(ctx context.Context, ids []string) (map[string]bool, error) {
+	var result map[string]bool
+	err := s.withConn(ctx, false, func(tx *sql.Tx) error {
+		var err error
+		result, err = issueops.IsBlockedBatchInTx(ctx, tx, ids)
+		return err
+	})
+	return result, err
+}
+
 // GetNewlyUnblockedByClose finds issues that become unblocked when closedIssueID is closed.
 func (s *EmbeddedDoltStore) GetNewlyUnblockedByClose(ctx context.Context, closedIssueID string) ([]*types.Issue, error) {
 	var result []*types.Issue

--- a/internal/storage/embeddeddolt/list_queries.go
+++ b/internal/storage/embeddeddolt/list_queries.go
@@ -92,6 +92,19 @@ func (s *EmbeddedDoltStore) GetDependencyRecordsForIssues(ctx context.Context, i
 	return result, err
 }
 
+// GetDependentRecordsForIssues returns the raw inbound dependency rows for a SET
+// of target ids in one batched read, keyed by target id. Delegates to
+// issueops.GetDependentRecordsForIssuesInTx for shared query logic.
+func (s *EmbeddedDoltStore) GetDependentRecordsForIssues(ctx context.Context, targetIDs []string) (map[string][]*types.Dependency, error) {
+	var result map[string][]*types.Dependency
+	err := s.withConn(ctx, false, func(tx *sql.Tx) error {
+		var err error
+		result, err = issueops.GetDependentRecordsForIssuesInTx(ctx, tx, targetIDs)
+		return err
+	})
+	return result, err
+}
+
 func (s *EmbeddedDoltStore) GetDependencyCounts(ctx context.Context, issueIDs []string) (map[string]*types.DependencyCounts, error) {
 	var result map[string]*types.DependencyCounts
 	err := s.withConn(ctx, false, func(tx *sql.Tx) error {

--- a/internal/storage/embeddeddolt/store.go
+++ b/internal/storage/embeddeddolt/store.go
@@ -925,6 +925,18 @@ func (s *EmbeddedDoltStore) GetDependentRecords(ctx context.Context, targetID st
 	return result, err
 }
 
+// CountDependentRecords returns the total inbound-edge count of targetID across
+// both dependency tables. Delegates to issueops.CountDependentRecordsInTx.
+func (s *EmbeddedDoltStore) CountDependentRecords(ctx context.Context, targetID string, depType string) (int, error) {
+	var n int
+	err := s.withConn(ctx, false, func(tx *sql.Tx) error {
+		var err error
+		n, err = issueops.CountDependentRecordsInTx(ctx, tx, targetID, depType)
+		return err
+	})
+	return n, err
+}
+
 // IsBlocked is implemented in issues.go.
 
 // GetNewlyUnblockedByClose is implemented in issues.go.

--- a/internal/storage/issueops/dependencies.go
+++ b/internal/storage/issueops/dependencies.go
@@ -49,6 +49,28 @@ func depTargetEquals(alias string) string {
 	return depTargetExpr(alias) + " = ?"
 }
 
+// depTargetEqualsOr returns a SARGABLE target-equality predicate as an explicit
+// per-column OR — `(depends_on_issue_id = ? OR depends_on_wisp_id = ? OR
+// depends_on_external = ?)` — binding the target id once per typed column (three
+// args, in that column order). Unlike depTargetEquals's COALESCE wrapper (which
+// wraps the columns in an expression no index can match), each disjunct is a
+// bare indexed column.
+//
+// On an index-merging planner (e.g. Postgres) this plans as a BitmapOr
+// index-merge over idx_dep_{issue,wisp,external}_target (a Bitmap Heap Scan,
+// cost ~36 on a 5k-row table) where the COALESCE form is a Seq Scan (cost
+// ~104). On Dolt
+// (go-mysql-server) the optimizer does not index-merge an OR of distinct columns,
+// so the un-ordered COUNT still scans, but the COALESCE form never had any index
+// path either; the type-filtered path seeks the (type, target) composite on both.
+// Use it for target-keyed reads of a single fixed target.
+func depTargetEqualsOr(alias string) string {
+	if alias == "" {
+		return "(depends_on_issue_id = ? OR depends_on_wisp_id = ? OR depends_on_external = ?)"
+	}
+	return fmt.Sprintf("(%s.depends_on_issue_id = ? OR %s.depends_on_wisp_id = ? OR %s.depends_on_external = ?)", alias, alias, alias)
+}
+
 func depTargetIn(alias, placeholders string) string {
 	return depTargetExpr(alias) + " IN (" + placeholders + ")"
 }

--- a/internal/storage/issueops/dependency_queries.go
+++ b/internal/storage/issueops/dependency_queries.go
@@ -989,8 +989,12 @@ func IsBlockedInTx(ctx context.Context, tx DBTX, issueID string) (bool, []string
 // at queryBatchSize, so it reflects inherited/ancestor blockedness (a child of a
 // blocked parent has is_blocked=1 with no direct blocking edge of its own) with
 // no graph walk. ids missing from both tables are absent from the map (callers
-// treat absent as not-blocked). On a cross-table id collision the wisps row wins,
-// matching loadStatusByIDInTx and the search wisp-merge.
+// treat absent as not-blocked). On a cross-table id collision the ISSUES row wins,
+// matching IsBlockedInTx exactly: the single read scans issues→wisps and breaks on
+// the first table that has the id, so the batch keeps the first-seen (issues) value
+// and skips any later (wisps) duplicate. The two reads share the is_blocked field,
+// so they must resolve a collision identically — this is a data anomaly, but the
+// single and batch reads would otherwise disagree on the same stored flag.
 //
 //nolint:gosec // G201: table is a hardcoded "issues" or "wisps".
 func IsBlockedBatchInTx(ctx context.Context, tx DBTX, ids []string) (map[string]bool, error) {
@@ -1022,9 +1026,12 @@ func IsBlockedBatchInTx(ctx context.Context, tx DBTX, ids []string) (map[string]
 					_ = rows.Close()
 					return nil, fmt.Errorf("scan is_blocked from %s: %w", table, err)
 				}
-				// Tables iterate issues→wisps, so a second encounter is the
-				// wisps row, which is canonical on a cross-table dup (be-iabdi).
-				if _, dup := seen[id]; dup && table != "wisps" {
+				// Tables iterate issues→wisps and IsBlockedInTx breaks on the
+				// first table that has the id (issues first) — so ISSUES wins on
+				// a cross-table id collision. Keep the first-seen value and skip
+				// any later (wisps) duplicate, so the batch is_blocked matches
+				// per-row IsBlocked exactly on the shared field.
+				if _, dup := seen[id]; dup {
 					continue
 				}
 				seen[id] = table

--- a/internal/storage/issueops/dependency_queries.go
+++ b/internal/storage/issueops/dependency_queries.go
@@ -131,6 +131,87 @@ func getDependencyRecordsIntoFromTable(ctx context.Context, tx DBTX, depTable st
 	return nil
 }
 
+// GetDependentRecordsForIssuesInTx returns raw dependency rows keyed by TARGET
+// id: for each id in targetIDs, the rows whose target is that id — its INCOMING
+// edges, i.e. its dependents — spanning BOTH the durable and wisp dependency
+// tables and applying NO type filter or visibility policy (the caller filters
+// at hydration). It is the batched, target-keyed mirror of the source-keyed
+// GetDependencyRecordsForIssuesInTx: one query per table per batch of
+// queryBatchSize target ids, so cost is O(1 + N/queryBatchSize) round-trips per
+// table rather than O(N) — the whole-page read that lets a caller render every
+// id's inbound `blocks` edges without a per-id fan-out.
+//
+// A target is matched by the coalesced target expression (DepTargetExpr) — the
+// same predicate the batched source-keyed blocks/counts reads use — so an id
+// that appears in any of the three typed target columns resolves; each returned
+// row's DependsOnID is that resolved target, which is the map key. Rows are
+// de-duped by their primary id across the two tables exactly as
+// GetDependentRecordsInTx does: a wisp promoted to durable carries ONE depid in
+// both tables, so the durable table is scanned first and a repeat id from the
+// wisp table is skipped — the edge is returned once, as its authoritative
+// durable row.
+func GetDependentRecordsForIssuesInTx(ctx context.Context, tx DBTX, targetIDs []string) (map[string][]*types.Dependency, error) {
+	result := make(map[string][]*types.Dependency)
+	if len(targetIDs) == 0 {
+		return result, nil
+	}
+	// De-dup by row id across the two tables, preferring the durable copy scanned
+	// first — same cross-table collision handling as GetDependentRecordsInTx.
+	seen := make(map[string]bool)
+	for _, depTable := range []string{"dependencies", "wisp_dependencies"} {
+		if err := getDependentRecordsIntoFromTable(ctx, tx, depTable, targetIDs, seen, result); err != nil {
+			if optionalBlockedTable(depTable) && isTableNotExistError(err) {
+				continue
+			}
+			return nil, err
+		}
+	}
+	return result, nil
+}
+
+//nolint:gosec // G201: depTable is "dependencies" or "wisp_dependencies" (hardcoded by caller); placeholders are ? only.
+func getDependentRecordsIntoFromTable(ctx context.Context, tx DBTX, depTable string, targetIDs []string, seen map[string]bool, result map[string][]*types.Dependency) error {
+	for start := 0; start < len(targetIDs); start += queryBatchSize {
+		end := start + queryBatchSize
+		if end > len(targetIDs) {
+			end = len(targetIDs)
+		}
+		batch := targetIDs[start:end]
+		placeholders := make([]string, len(batch))
+		args := make([]any, len(batch))
+		for i, id := range batch {
+			placeholders[i] = "?"
+			args[i] = id
+		}
+		rows, err := tx.QueryContext(ctx, fmt.Sprintf(
+			`SELECT id, issue_id, %s AS depends_on_id, type, created_at, created_by, metadata, thread_id
+			 FROM %s WHERE %s ORDER BY %s`,
+			DepTargetExpr, depTable, depTargetIn("", strings.Join(placeholders, ",")), DepTargetExpr), args...)
+		if err != nil {
+			return fmt.Errorf("get dependent records from %s: %w", depTable, err)
+		}
+		for rows.Next() {
+			dep, scanErr := scanDependentRow(rows)
+			if scanErr != nil {
+				_ = rows.Close()
+				return fmt.Errorf("get dependent records: scan: %w", scanErr)
+			}
+			// De-dup by row id (depid): the wisp copy of a promoted edge carries
+			// the same id as the durable copy scanned first, so skip the repeat.
+			if seen[dep.ID] {
+				continue
+			}
+			seen[dep.ID] = true
+			result[dep.DependsOnID] = append(result[dep.DependsOnID], dep)
+		}
+		_ = rows.Close()
+		if err := rows.Err(); err != nil {
+			return fmt.Errorf("get dependent records: rows: %w", err)
+		}
+	}
+	return nil
+}
+
 // Target-keyed dependents-read bounds. A raw read has no consumer to apply a
 // page size, so it clamps its own (default when limit <= 0, hard cap otherwise).
 const (

--- a/internal/storage/issueops/dependency_queries.go
+++ b/internal/storage/issueops/dependency_queries.go
@@ -170,6 +170,7 @@ func GetDependentRecordsInTx(ctx context.Context, tx DBTX, targetID, depType str
 	}
 
 	var all []*types.Dependency
+	seen := make(map[string]bool)
 	for _, depTable := range []string{"dependencies", "wisp_dependencies"} {
 		rows, err := queryDependentRecordsFromTable(ctx, tx, depTable, targetID, depType, limit, afterID)
 		if err != nil {
@@ -178,13 +179,29 @@ func GetDependentRecordsInTx(ctx context.Context, tx DBTX, targetID, depType str
 			}
 			return nil, err
 		}
-		all = append(all, rows...)
+		// De-dup by row id across the two tables. depid.New keys the id on
+		// (issue_id, target) and deliberately omits the table, so the SAME edge
+		// that lands in BOTH tables — a wisp promoted to durable, or two clones
+		// merged — carries ONE id in both. Appending the wisp copy would put a
+		// duplicate id in the page and, at a page boundary, drop it on the next
+		// `id > afterID`. We iterate durable first and skip an already-seen id,
+		// so a colliding edge is returned exactly once as its DURABLE row (the
+		// authoritative, non-ephemeral copy). Within a single table id is a
+		// PRIMARY KEY, so intra-table rows never collide.
+		for _, r := range rows {
+			if seen[r.ID] {
+				continue
+			}
+			seen[r.ID] = true
+			all = append(all, r)
+		}
 	}
 
-	// Merge the two per-table pages into one total order by row id. Each table
-	// returned its first `limit` rows with id > afterID, so the global first
-	// `limit` rows with id > afterID are all present; sorting by the globally
-	// unique id and truncating yields exactly that page with no drop and no dup.
+	// Merge the de-duped per-table pages into one total order by row id. Each
+	// table returned its first `limit` rows with id > afterID, so the global
+	// first `limit` DISTINCT ids > afterID are all present; sorting by the
+	// globally unique id and truncating yields exactly that page — no drop, no
+	// dup, and stable across a cross-table id collision.
 	sort.Slice(all, func(i, j int) bool { return all[i].ID < all[j].ID })
 	if len(all) > limit {
 		all = all[:limit]
@@ -250,25 +267,64 @@ func scanDependentRow(rows *sql.Rows) (*types.Dependency, error) {
 	return &dep, nil
 }
 
-// CountDependentRecordsInTx returns the total number of inbound edges of
-// targetID across both dependency tables, applying the same sargable target
-// predicate and optional depType filter as GetDependentRecordsInTx but no
-// keyset/limit. Callers that want a true total membership count need it without
-// paging to exhaustion. Like the paged read it is a RAW count spanning both
-// tables; the caller applies any visibility policy separately.
+// CountDependentRecordsInTx returns the number of DISTINCT inbound edges of
+// targetID, applying the same sargable target predicate and optional depType
+// filter as GetDependentRecordsInTx but no keyset/limit. Callers that want a
+// true total membership count need it without paging to exhaustion. Like the
+// paged read it is a RAW count spanning both tables; the caller applies any
+// visibility policy separately.
+//
+// It must agree with GetDependentRecordsInTx's durable-preferred de-dup: an edge
+// present in BOTH tables (same depid) is ONE row in the page, so the count is
+// every durable row PLUS every wisp row whose depid is not already a durable row
+// for the same target/type. Summing two raw COUNT(*)s would over-count that edge
+// and exceed the distinct keyset row count.
 func CountDependentRecordsInTx(ctx context.Context, tx DBTX, targetID, depType string) (int, error) {
-	total := 0
-	for _, depTable := range []string{"dependencies", "wisp_dependencies"} {
-		n, err := countDependentRecordsFromTable(ctx, tx, depTable, targetID, depType)
-		if err != nil {
-			if optionalBlockedTable(depTable) && isTableNotExistError(err) {
-				continue
-			}
-			return 0, err
-		}
-		total += n
+	durable, err := countDependentRecordsFromTable(ctx, tx, "dependencies", targetID, depType)
+	if err != nil {
+		return 0, err
 	}
-	return total, nil
+	wispExtra, err := countWispDependentsNotInDurableInTx(ctx, tx, targetID, depType)
+	if err != nil {
+		// wisp_dependencies absent: the durable count is the whole answer.
+		if isTableNotExistError(err) {
+			return durable, nil
+		}
+		return 0, err
+	}
+	return durable + wispExtra, nil
+}
+
+// countWispDependentsNotInDurableInTx counts wisp_dependencies rows whose target
+// is targetID (optional depType) but whose depid is NOT present in the durable
+// dependencies table for the same target/type — the wisp-ONLY inbound edges.
+// Colliding edges (present in both tables) are counted on the durable side, so
+// this is the exact complement that makes the total distinct-by-id. The NOT IN
+// subquery is uncorrelated and bounded by the target's durable inbound-edge
+// count; both arms use the sargable per-column OR target predicate.
+//
+//nolint:gosec // G201: table names are hardcoded constants; targetID/depType are bound as parameters.
+func countWispDependentsNotInDurableInTx(ctx context.Context, tx DBTX, targetID, depType string) (int, error) {
+	wispWhere := depTargetEqualsOr("")
+	durableWhere := depTargetEqualsOr("")
+	args := []any{targetID, targetID, targetID}
+	if depType != "" {
+		wispWhere += " AND type = ?"
+		args = append(args, depType)
+	}
+	args = append(args, targetID, targetID, targetID)
+	if depType != "" {
+		durableWhere += " AND type = ?"
+		args = append(args, depType)
+	}
+	query := fmt.Sprintf(
+		"SELECT COUNT(*) FROM wisp_dependencies WHERE %s AND id NOT IN (SELECT id FROM dependencies WHERE %s)",
+		wispWhere, durableWhere)
+	var n int
+	if err := tx.QueryRowContext(ctx, query, args...).Scan(&n); err != nil {
+		return 0, fmt.Errorf("count wisp-only dependent records: %w", err)
+	}
+	return n, nil
 }
 
 //nolint:gosec // G201: depTable is a hardcoded constant; targetID/depType are bound as parameters.

--- a/internal/storage/issueops/dependency_queries.go
+++ b/internal/storage/issueops/dependency_queries.go
@@ -982,6 +982,63 @@ func IsBlockedInTx(ctx context.Context, tx DBTX, issueID string) (bool, []string
 	return true, blockers, nil
 }
 
+// IsBlockedBatchInTx returns the denormalized, TRANSITIVE is_blocked flag for
+// each of ids in one batched read — the same value IsBlockedInTx returns per id,
+// without the per-row blocker-list recompute. It reads the stored is_blocked
+// column (SELECT id, is_blocked FROM {issues,wisps} WHERE id IN (...)), batched
+// at queryBatchSize, so it reflects inherited/ancestor blockedness (a child of a
+// blocked parent has is_blocked=1 with no direct blocking edge of its own) with
+// no graph walk. ids missing from both tables are absent from the map (callers
+// treat absent as not-blocked). On a cross-table id collision the wisps row wins,
+// matching loadStatusByIDInTx and the search wisp-merge.
+//
+//nolint:gosec // G201: table is a hardcoded "issues" or "wisps".
+func IsBlockedBatchInTx(ctx context.Context, tx DBTX, ids []string) (map[string]bool, error) {
+	blocked := make(map[string]bool, len(ids))
+	if len(ids) == 0 {
+		return blocked, nil
+	}
+
+	seen := make(map[string]string, len(ids))
+	for _, table := range []string{"issues", "wisps"} {
+		for start := 0; start < len(ids); start += queryBatchSize {
+			end := start + queryBatchSize
+			if end > len(ids) {
+				end = len(ids)
+			}
+			placeholders, args := buildSQLInClause(ids[start:end])
+			rows, err := tx.QueryContext(ctx, fmt.Sprintf(
+				"SELECT id, is_blocked FROM %s WHERE id IN (%s)", table, placeholders), args...)
+			if err != nil {
+				if optionalBlockedTable(table) && isTableNotExistError(err) {
+					break
+				}
+				return nil, fmt.Errorf("read is_blocked from %s: %w", table, err)
+			}
+			for rows.Next() {
+				var id string
+				var b int
+				if err := rows.Scan(&id, &b); err != nil {
+					_ = rows.Close()
+					return nil, fmt.Errorf("scan is_blocked from %s: %w", table, err)
+				}
+				// Tables iterate issues→wisps, so a second encounter is the
+				// wisps row, which is canonical on a cross-table dup (be-iabdi).
+				if _, dup := seen[id]; dup && table != "wisps" {
+					continue
+				}
+				seen[id] = table
+				blocked[id] = b != 0
+			}
+			_ = rows.Close()
+			if err := rows.Err(); err != nil {
+				return nil, fmt.Errorf("is_blocked rows from %s: %w", table, err)
+			}
+		}
+	}
+	return blocked, nil
+}
+
 // scanDependencyRow scans a single dependency row from a *sql.Rows.
 func scanDependencyRow(rows *sql.Rows) (*types.Dependency, error) {
 	var dep types.Dependency

--- a/internal/storage/issueops/dependency_queries.go
+++ b/internal/storage/issueops/dependency_queries.go
@@ -142,16 +142,25 @@ const (
 // — the edges pointing AT targetID — from both the permanent and wisp
 // dependency tables. Unlike GetDependents/GetDependentsWithMetadata it does
 // NOT join or hydrate the source issues, so edges from dangling, cross-project,
-// or wisp sources are returned as raw rows rather than dropped. Rows are keyed
-// by their source issue_id (Dependency.IssueID); target resolution COALESCEs
-// the three typed target columns exactly like the source-keyed sibling reads.
+// or wisp sources are returned as raw rows rather than dropped. RAW READ: it
+// spans BOTH the `dependencies` and `wisp_dependencies` tables and applies no
+// visibility policy — filtering (e.g. a group-membership visibility rule) is
+// the caller's job, applied at hydration.
 //
 // When depType is non-empty only rows of that dependency type are returned
-// ("" = all types). Results are ordered by source issue_id ASC and bounded by
-// limit (see the clamp constants). afterID is a keyset continuation over that
-// order: "" starts at the beginning, otherwise only rows with issue_id > afterID
-// are returned. The (issue_id, typed-target) unique keys make issue_id unique
-// among rows sharing a fixed target, so paging on it drops no rows.
+// ("" = all types). Results are ordered by the dependency row's primary id ASC
+// and bounded by limit (see the clamp constants). afterID is a keyset
+// continuation over that id order: "" starts at the beginning, otherwise only
+// rows with id > afterID are returned.
+//
+// CURSOR KEY: the dependency row's own id (depid.New(issue_id, target), a
+// UUIDv5 that is stable and globally unique across both tables) — NOT the source
+// issue_id. issue_id is not a total key for a fixed target: a source can appear
+// across the two scanned tables, so paging on it could drop or duplicate rows.
+// Paging on the unique row id is total, so each source's inbound edge is
+// returned exactly once. The target match is a sargable per-column OR over the
+// three typed columns (seeks idx_dep_*_target / the type composites) rather than
+// a COALESCE wrapper.
 func GetDependentRecordsInTx(ctx context.Context, tx DBTX, targetID, depType string, limit int, afterID string) ([]*types.Dependency, error) {
 	if limit <= 0 {
 		limit = defaultDependentRecordsLimit
@@ -172,16 +181,11 @@ func GetDependentRecordsInTx(ctx context.Context, tx DBTX, targetID, depType str
 		all = append(all, rows...)
 	}
 
-	// Merge the two per-table pages into one deterministic order. issue_id is
-	// unique per fixed target across both tables (durable vs wisp sources have
-	// disjoint ids), so ordering by (issue_id, type) is total; type is only a
-	// tie-break for the pathological same-source/same-target-string edge.
-	sort.Slice(all, func(i, j int) bool {
-		if all[i].IssueID != all[j].IssueID {
-			return all[i].IssueID < all[j].IssueID
-		}
-		return all[i].Type < all[j].Type
-	})
+	// Merge the two per-table pages into one total order by row id. Each table
+	// returned its first `limit` rows with id > afterID, so the global first
+	// `limit` rows with id > afterID are all present; sorting by the globally
+	// unique id and truncating yields exactly that page with no drop and no dup.
+	sort.Slice(all, func(i, j int) bool { return all[i].ID < all[j].ID })
 	if len(all) > limit {
 		all = all[:limit]
 	}
@@ -191,19 +195,19 @@ func GetDependentRecordsInTx(ctx context.Context, tx DBTX, targetID, depType str
 //nolint:gosec // G201: depTable is a hardcoded constant; targetID/depType/afterID are bound as parameters.
 func queryDependentRecordsFromTable(ctx context.Context, tx DBTX, depTable, targetID, depType string, limit int, afterID string) ([]*types.Dependency, error) {
 	query := fmt.Sprintf(`
-		SELECT issue_id, %s AS depends_on_id, type, created_at, created_by, metadata, thread_id
+		SELECT id, issue_id, %s AS depends_on_id, type, created_at, created_by, metadata, thread_id
 		FROM %s
-		WHERE %s`, DepTargetExpr, depTable, depTargetEquals(""))
-	args := []any{targetID}
+		WHERE %s`, DepTargetExpr, depTable, depTargetEqualsOr(""))
+	args := []any{targetID, targetID, targetID}
 	if depType != "" {
 		query += " AND type = ?"
 		args = append(args, depType)
 	}
 	if afterID != "" {
-		query += " AND issue_id > ?"
+		query += " AND id > ?"
 		args = append(args, afterID)
 	}
-	query += fmt.Sprintf(" ORDER BY issue_id ASC LIMIT %d", limit)
+	query += fmt.Sprintf(" ORDER BY id ASC LIMIT %d", limit)
 
 	rows, err := tx.QueryContext(ctx, query, args...)
 	if err != nil {
@@ -213,13 +217,73 @@ func queryDependentRecordsFromTable(ctx context.Context, tx DBTX, depTable, targ
 
 	var deps []*types.Dependency
 	for rows.Next() {
-		dep, scanErr := scanDependencyRow(rows)
+		dep, scanErr := scanDependentRow(rows)
 		if scanErr != nil {
 			return nil, fmt.Errorf("get dependent records: scan: %w", scanErr)
 		}
 		deps = append(deps, dep)
 	}
 	return deps, rows.Err()
+}
+
+// scanDependentRow scans a dependents row that INCLUDES the row id (the keyset
+// cursor). The shared scanDependencyRow does not select id, and adding it there
+// would ripple through every source-keyed read, so the target-keyed read owns
+// this variant.
+func scanDependentRow(rows *sql.Rows) (*types.Dependency, error) {
+	var dep types.Dependency
+	var createdAt sql.NullTime
+	var metadata, threadID sql.NullString
+
+	if err := rows.Scan(&dep.ID, &dep.IssueID, &dep.DependsOnID, &dep.Type, &createdAt, &dep.CreatedBy, &metadata, &threadID); err != nil {
+		return nil, fmt.Errorf("scan dependent: %w", err)
+	}
+	if createdAt.Valid {
+		dep.CreatedAt = createdAt.Time
+	}
+	if metadata.Valid {
+		dep.Metadata = metadata.String
+	}
+	if threadID.Valid {
+		dep.ThreadID = threadID.String
+	}
+	return &dep, nil
+}
+
+// CountDependentRecordsInTx returns the total number of inbound edges of
+// targetID across both dependency tables, applying the same sargable target
+// predicate and optional depType filter as GetDependentRecordsInTx but no
+// keyset/limit. Callers that want a true total membership count need it without
+// paging to exhaustion. Like the paged read it is a RAW count spanning both
+// tables; the caller applies any visibility policy separately.
+func CountDependentRecordsInTx(ctx context.Context, tx DBTX, targetID, depType string) (int, error) {
+	total := 0
+	for _, depTable := range []string{"dependencies", "wisp_dependencies"} {
+		n, err := countDependentRecordsFromTable(ctx, tx, depTable, targetID, depType)
+		if err != nil {
+			if optionalBlockedTable(depTable) && isTableNotExistError(err) {
+				continue
+			}
+			return 0, err
+		}
+		total += n
+	}
+	return total, nil
+}
+
+//nolint:gosec // G201: depTable is a hardcoded constant; targetID/depType are bound as parameters.
+func countDependentRecordsFromTable(ctx context.Context, tx DBTX, depTable, targetID, depType string) (int, error) {
+	query := fmt.Sprintf("SELECT COUNT(*) FROM %s WHERE %s", depTable, depTargetEqualsOr(""))
+	args := []any{targetID, targetID, targetID}
+	if depType != "" {
+		query += " AND type = ?"
+		args = append(args, depType)
+	}
+	var n int
+	if err := tx.QueryRowContext(ctx, query, args...).Scan(&n); err != nil {
+		return 0, fmt.Errorf("count dependent records from %s: %w", depTable, err)
+	}
+	return n, nil
 }
 
 func GetDependencyCountsInTx(ctx context.Context, tx DBTX, issueIDs []string) (map[string]*types.DependencyCounts, error) {

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -783,6 +783,12 @@ func (w WorkType) IsValid() bool {
 
 // Dependency represents a relationship between issues
 type Dependency struct {
+	// ID is the dependency row's deterministic surrogate primary key,
+	// depid.New(issue_id, target) — a UUIDv5 that is stable and globally unique
+	// across the durable and wisp dependency tables. Populated only by reads
+	// that select it (e.g. GetDependentRecords, which keysets on it); left empty
+	// by the source-keyed reads that never needed it.
+	ID          string         `json:"id,omitempty"`
 	IssueID     string         `json:"issue_id"`
 	DependsOnID string         `json:"depends_on_id"`
 	Type        DependencyType `json:"type"`


### PR DESCRIPTION
> Stacked on the S13 events PR → … → #4892. Diff below is this slice only. Per the chain's review model, the label arrives when this PR becomes head-of-chain.

## What
Ports the bounded dependents read family — `GetDependentRecords` id-cursor paging + `CountDependentRecords` + batched `GetDependentRecordsForIssues` (with the cross-table depid dedup fix) — and `IsBlockedBatch` (one batched read of the transitive is_blocked column, issues-wins on id collision, matching single-row `IsBlocked`). Storage layer only; the root re-exports land in the next slice with the interfaces they extend. Authorship preserved.

## Why
`bd dep list`/dependents views and library callers materialized unbounded dependent sets and did N per-row `IsBlocked` calls for a page of beads. Bounded, batched, index-backed reads close both.

## Verification
Dependents cursor/count/batch + collision-dedup + IsBlockedBatch parity tests on real Dolt and embedded; regression sweep; builds/vet/lint clean.
```bash
go test ./internal/storage/dolt/ -run 'TestGetDependentRecords|TestIsBlockedBatch|TestCountDependentRecords' -v
```
