### PR TITLE
feat(storage): events + dependents reads, batched blocked, public claim surface

### DIFF
--- a/beads.go
+++ b/beads.go
@@ -88,6 +88,55 @@ type RemoteStore = storage.RemoteStore
 // SyncStore provides high-level sync operations with peers.
 type SyncStore = storage.SyncStore
 
+// DependencyQueryStore provides extended dependency queries beyond the base
+// Storage interface (raw source-keyed and target-keyed dependency records,
+// blocking info, counts). Type-assert a Storage value to reach it:
+//
+//	if dq, ok := store.(beads.DependencyQueryStore); ok {
+//	    rows, err := dq.GetDependentRecords(ctx, targetID, "", 100, "")
+//	}
+type DependencyQueryStore = storage.DependencyQueryStore
+
+// EventQueryStore provides keyset paging over the durable event log
+// (EventsSince). Type-assert a Storage value to reach it.
+type EventQueryStore = storage.EventQueryStore
+
+// EventCursor is a keyset position in the durable events stream, ordered by
+// (created_at, id). The zero value means "from the beginning".
+type EventCursor = storage.EventCursor
+
+// ErrCircuitOpen is re-exported (aliased, so errors.Is works across the package
+// boundary) from the Dolt storage layer: a read or write rejected because the
+// Dolt circuit breaker is open wraps it. The claim sentinels ErrAlreadyClaimed
+// and ErrNotClaimable — the ones ParseClaimConflict recovers assignee/status
+// detail from — are re-exported with the other error sentinels below.
+var (
+	ErrCircuitOpen = dolt.ErrCircuitOpen
+)
+
+// IssueClaimer is the atomic-claim surface of a Storage. ClaimIssue and
+// ClaimReadyIssue live on the storage.BulkIssueStore extension rather than the
+// base Storage interface, so callers reach them by type-assertion via
+// AsIssueClaimer rather than off the Storage value directly.
+type IssueClaimer interface {
+	// ClaimIssue atomically claims id for actor using compare-and-swap
+	// semantics (open ∧ unassigned-or-same-actor). Returns a wrapped
+	// ErrAlreadyClaimed or ErrNotClaimable on conflict.
+	ClaimIssue(ctx context.Context, id string, actor string) error
+	// ClaimReadyIssue atomically claims the first ready issue matching filter,
+	// or returns (nil, nil) when none is claimable.
+	ClaimReadyIssue(ctx context.Context, filter WorkFilter, actor string) (*Issue, error)
+}
+
+// AsIssueClaimer returns the IssueClaimer view of s when the backing store
+// supports atomic claim (Dolt-backed stores do), and (nil, false) otherwise.
+// Assert once at startup and fail loud: a Storage decorator that does not
+// forward the claim surface makes this return false.
+func AsIssueClaimer(s Storage) (IssueClaimer, bool) {
+	c, ok := s.(IssueClaimer)
+	return c, ok
+}
+
 // VersionControlReader provides read-only version control operations.
 // Write operations (Branch, Checkout, Merge, DeleteBranch) are not yet
 // part of the public API. If you need them, please open an issue.
@@ -216,6 +265,7 @@ const (
 const (
 	EventCreated           = types.EventCreated
 	EventUpdated           = types.EventUpdated
+	EventClaimed           = types.EventClaimed
 	EventStatusChanged     = types.EventStatusChanged
 	EventCommented         = types.EventCommented
 	EventClosed            = types.EventClosed

--- a/beads.go
+++ b/beads.go
@@ -119,12 +119,37 @@ type DependentQuerier interface {
 	CountDependentRecords(ctx context.Context, targetID string, depType string) (int, error)
 }
 
+// BlockedQuerier is the transitive-blocked surface of a Storage: the
+// denormalized is_blocked flag, single or batched. Like EventQuerier it is a
+// NARROW hand-declared root interface (not an alias of DependencyQueryStore),
+// exposing only the reads consumers use. IsBlockedBatch returns the is_blocked
+// column for a whole page in one round-trip — the same transitive value
+// IsBlocked returns per id, with no N-call fan-out. Reach it via AsBlockedQuerier.
+type BlockedQuerier interface {
+	// IsBlocked reports whether issueID is blocked (its denormalized transitive
+	// is_blocked flag) and the open direct blockers for display.
+	IsBlocked(ctx context.Context, issueID string) (bool, []string, error)
+	// IsBlockedBatch returns the denormalized transitive is_blocked flag for each
+	// of ids in one batched read. ids present in neither the issues nor wisps
+	// table are absent from the map; callers treat absent as not-blocked.
+	IsBlockedBatch(ctx context.Context, ids []string) (map[string]bool, error)
+}
+
 // AsEventQuerier returns the EventQuerier view of s, or (nil, false) when the
 // backing store does not expose the durable-event feed. Assert once and fail
 // loud. A single direct assertion is sufficient — see the decorator contract on
 // AsIssueClaimer.
 func AsEventQuerier(s Storage) (EventQuerier, bool) {
 	q, ok := s.(EventQuerier)
+	return q, ok
+}
+
+// AsBlockedQuerier returns the BlockedQuerier view of s, or (nil, false) when the
+// backing store does not expose the transitive-blocked reads. Assert once and
+// fail loud. A single direct assertion is sufficient — see the decorator
+// contract on AsIssueClaimer.
+func AsBlockedQuerier(s Storage) (BlockedQuerier, bool) {
+	q, ok := s.(BlockedQuerier)
 	return q, ok
 }
 
@@ -190,6 +215,7 @@ var (
 	_ IssueClaimer     = (storage.DoltStorage)(nil)
 	_ EventQuerier     = (storage.DoltStorage)(nil)
 	_ DependentQuerier = (storage.DoltStorage)(nil)
+	_ BlockedQuerier   = (storage.DoltStorage)(nil)
 )
 
 // VersionControlReader provides read-only version control operations.

--- a/beads.go
+++ b/beads.go
@@ -88,22 +88,66 @@ type RemoteStore = storage.RemoteStore
 // SyncStore provides high-level sync operations with peers.
 type SyncStore = storage.SyncStore
 
-// DependencyQueryStore provides extended dependency queries beyond the base
-// Storage interface (raw source-keyed and target-keyed dependency records,
-// blocking info, counts). Type-assert a Storage value to reach it:
-//
-//	if dq, ok := store.(beads.DependencyQueryStore); ok {
-//	    rows, err := dq.GetDependentRecords(ctx, targetID, "", 100, "")
-//	}
-type DependencyQueryStore = storage.DependencyQueryStore
-
-// EventQueryStore provides keyset paging over the durable event log
-// (EventsSince). Type-assert a Storage value to reach it.
-type EventQueryStore = storage.EventQueryStore
-
 // EventCursor is a keyset position in the durable events stream, ordered by
 // (created_at, id). The zero value means "from the beginning".
 type EventCursor = storage.EventCursor
+
+// EventQuerier is the durable-event-feed surface of a Storage: keyset paging
+// over the durable event log, beyond the base Storage's time-only
+// GetAllEventsSince. It is a NARROW, hand-declared root interface exposing
+// exactly what consumers need — not an alias of the internal EventQueryStore —
+// so the published surface stays small and independent of the engine interface.
+// Reach it via AsEventQuerier.
+type EventQuerier interface {
+	// EventsSince returns durable events strictly after cursor, ordered by
+	// (created_at ASC, id ASC), bounded by limit (0 = a store default, capped).
+	// issueID scopes the feed to one bead's history ("" = all).
+	EventsSince(ctx context.Context, cursor EventCursor, issueID string, limit int) ([]*Event, error)
+}
+
+// DependentQuerier is the target-keyed dependents surface of a Storage: the raw
+// inbound-edge reads that back group-membership. Like EventQuerier it is a
+// NARROW hand-declared root interface (not an alias of DependencyQueryStore),
+// exposing only the two calls consumers use. Reach it via AsDependentQuerier.
+type DependentQuerier interface {
+	// GetDependentRecords returns raw dependency rows whose target is targetID,
+	// paged by the dependency row id (afterID, "" = start). See the engine doc
+	// for the two-table span and raw-read/policy-at-hydration contract.
+	GetDependentRecords(ctx context.Context, targetID string, depType string, limit int, afterID string) ([]*Dependency, error)
+	// CountDependentRecords returns the true total inbound-edge count of targetID
+	// (depType "" = all) without paging.
+	CountDependentRecords(ctx context.Context, targetID string, depType string) (int, error)
+}
+
+// AsEventQuerier returns the EventQuerier view of s, unwrapping a HookFiringStore
+// decorator so a decorated store keeps the capability. Assert once and fail
+// loud. Mirrors AsIssueClaimer.
+func AsEventQuerier(s Storage) (EventQuerier, bool) {
+	if q, ok := s.(EventQuerier); ok {
+		return q, true
+	}
+	if ds, ok := s.(storage.DoltStorage); ok {
+		if q, ok := storage.UnwrapStore(ds).(EventQuerier); ok {
+			return q, true
+		}
+	}
+	return nil, false
+}
+
+// AsDependentQuerier returns the DependentQuerier view of s, unwrapping a
+// HookFiringStore decorator so a decorated store keeps the capability. Assert
+// once and fail loud. Mirrors AsIssueClaimer.
+func AsDependentQuerier(s Storage) (DependentQuerier, bool) {
+	if q, ok := s.(DependentQuerier); ok {
+		return q, true
+	}
+	if ds, ok := s.(storage.DoltStorage); ok {
+		if q, ok := storage.UnwrapStore(ds).(DependentQuerier); ok {
+			return q, true
+		}
+	}
+	return nil, false
+}
 
 // ErrCircuitOpen is re-exported (aliased, so errors.Is works across the package
 // boundary) from the Dolt storage layer: a read or write rejected because the
@@ -130,12 +174,30 @@ type IssueClaimer interface {
 
 // AsIssueClaimer returns the IssueClaimer view of s when the backing store
 // supports atomic claim (Dolt-backed stores do), and (nil, false) otherwise.
-// Assert once at startup and fail loud: a Storage decorator that does not
-// forward the claim surface makes this return false.
+// Assert once at startup and fail loud. It unwraps a HookFiringStore decorator
+// so a decorated store keeps the claim surface.
 func AsIssueClaimer(s Storage) (IssueClaimer, bool) {
-	c, ok := s.(IssueClaimer)
-	return c, ok
+	if c, ok := s.(IssueClaimer); ok {
+		return c, true
+	}
+	if ds, ok := s.(storage.DoltStorage); ok {
+		if c, ok := storage.UnwrapStore(ds).(IssueClaimer); ok {
+			return c, true
+		}
+	}
+	return nil, false
 }
+
+// Compile-time drift guards: the full engine interface storage.DoltStorage must
+// satisfy each narrow public surface, so a signature change to the claim / event
+// / dependents methods on the engine breaks the build here instead of silently
+// making As* return false at runtime. Concrete-store conformance is asserted in
+// the tests (both Dolt stores).
+var (
+	_ IssueClaimer     = (storage.DoltStorage)(nil)
+	_ EventQuerier     = (storage.DoltStorage)(nil)
+	_ DependentQuerier = (storage.DoltStorage)(nil)
+)
 
 // VersionControlReader provides read-only version control operations.
 // Write operations (Branch, Checkout, Merge, DeleteBranch) are not yet

--- a/beads.go
+++ b/beads.go
@@ -119,34 +119,22 @@ type DependentQuerier interface {
 	CountDependentRecords(ctx context.Context, targetID string, depType string) (int, error)
 }
 
-// AsEventQuerier returns the EventQuerier view of s, unwrapping a HookFiringStore
-// decorator so a decorated store keeps the capability. Assert once and fail
-// loud. Mirrors AsIssueClaimer.
+// AsEventQuerier returns the EventQuerier view of s, or (nil, false) when the
+// backing store does not expose the durable-event feed. Assert once and fail
+// loud. A single direct assertion is sufficient — see the decorator contract on
+// AsIssueClaimer.
 func AsEventQuerier(s Storage) (EventQuerier, bool) {
-	if q, ok := s.(EventQuerier); ok {
-		return q, true
-	}
-	if ds, ok := s.(storage.DoltStorage); ok {
-		if q, ok := storage.UnwrapStore(ds).(EventQuerier); ok {
-			return q, true
-		}
-	}
-	return nil, false
+	q, ok := s.(EventQuerier)
+	return q, ok
 }
 
-// AsDependentQuerier returns the DependentQuerier view of s, unwrapping a
-// HookFiringStore decorator so a decorated store keeps the capability. Assert
-// once and fail loud. Mirrors AsIssueClaimer.
+// AsDependentQuerier returns the DependentQuerier view of s, or (nil, false) when
+// the backing store does not expose the target-keyed dependents reads. Assert
+// once and fail loud. A single direct assertion is sufficient — see the
+// decorator contract on AsIssueClaimer.
 func AsDependentQuerier(s Storage) (DependentQuerier, bool) {
-	if q, ok := s.(DependentQuerier); ok {
-		return q, true
-	}
-	if ds, ok := s.(storage.DoltStorage); ok {
-		if q, ok := storage.UnwrapStore(ds).(DependentQuerier); ok {
-			return q, true
-		}
-	}
-	return nil, false
+	q, ok := s.(DependentQuerier)
+	return q, ok
 }
 
 // ErrCircuitOpen is re-exported (aliased, so errors.Is works across the package
@@ -174,18 +162,23 @@ type IssueClaimer interface {
 
 // AsIssueClaimer returns the IssueClaimer view of s when the backing store
 // supports atomic claim (Dolt-backed stores do), and (nil, false) otherwise.
-// Assert once at startup and fail loud. It unwraps a HookFiringStore decorator
-// so a decorated store keeps the claim surface.
+// Assert once at startup and fail loud.
+//
+// DECORATOR CONTRACT: a single direct type-assertion is sufficient — no unwrap.
+// ClaimIssue/ClaimReadyIssue (like EventsSince and the dependents reads) live on
+// the engine interface storage.DoltStorage, and the compile-time drift guards
+// below prove storage.DoltStorage satisfies each narrow surface. A store
+// decorator therefore MUST embed storage.DoltStorage — as HookFiringStore does —
+// which promotes these methods so the assertion reaches them THROUGH the
+// decorator. (This is unlike the cmd/bd optional interfaces — StoreLocator,
+// BackupStore, Flattener, … — which are NOT part of DoltStorage, do not promote,
+// and so genuinely need storage.UnwrapStore.) A former storage.UnwrapStore
+// fallback here was provably dead: whenever s satisfies storage.DoltStorage it
+// already satisfies the narrow surface (drift guard), so the direct assertion
+// always wins; and the only decorator, HookFiringStore, forwards by promotion.
 func AsIssueClaimer(s Storage) (IssueClaimer, bool) {
-	if c, ok := s.(IssueClaimer); ok {
-		return c, true
-	}
-	if ds, ok := s.(storage.DoltStorage); ok {
-		if c, ok := storage.UnwrapStore(ds).(IssueClaimer); ok {
-			return c, true
-		}
-	}
-	return nil, false
+	c, ok := s.(IssueClaimer)
+	return c, ok
 }
 
 // Compile-time drift guards: the full engine interface storage.DoltStorage must

--- a/beads.go
+++ b/beads.go
@@ -108,12 +108,19 @@ type EventQuerier interface {
 // DependentQuerier is the target-keyed dependents surface of a Storage: the raw
 // inbound-edge reads that back group-membership. Like EventQuerier it is a
 // NARROW hand-declared root interface (not an alias of DependencyQueryStore),
-// exposing only the two calls consumers use. Reach it via AsDependentQuerier.
+// exposing only the calls consumers use. Reach it via AsDependentQuerier.
 type DependentQuerier interface {
 	// GetDependentRecords returns raw dependency rows whose target is targetID,
 	// paged by the dependency row id (afterID, "" = start). See the engine doc
 	// for the two-table span and raw-read/policy-at-hydration contract.
 	GetDependentRecords(ctx context.Context, targetID string, depType string, limit int, afterID string) ([]*Dependency, error)
+	// GetDependentRecordsForIssues returns raw dependency rows keyed by TARGET id
+	// — for a SET of target ids in one batched read, each id's inbound edges (its
+	// dependents), across both dependency tables, ALL dep types, de-duped by row
+	// id. The batched, target-keyed mirror of GetDependencyRecordsForIssues; same
+	// two-table span and raw-read/policy-at-hydration contract as
+	// GetDependentRecords, without paging.
+	GetDependentRecordsForIssues(ctx context.Context, targetIDs []string) (map[string][]*Dependency, error)
 	// CountDependentRecords returns the true total inbound-edge count of targetID
 	// (depType "" = all) without paging.
 	CountDependentRecords(ctx context.Context, targetID string, depType string) (int, error)

--- a/claim.go
+++ b/claim.go
@@ -56,23 +56,28 @@ func ParseClaimConflict(err error) (ClaimConflict, bool) {
 	}
 }
 
-// tailAfter returns the substring following the last occurrence of marker in s,
-// or "" when marker is absent.
+// tailAfter returns the bounded token following the last occurrence of marker in
+// s, or "" when marker is absent or the token cannot be recovered unambiguously.
 //
-// The recovered token (assignee/status) is the message's trailing run BY REPO
-// CONVENTION: claim-error wraps PREPEND context ("caller ctx: %w"), never append
-// it, so the fragment appears once near the end and its tail is the bare token.
-// As a guard against a future appended wrap corrupting the token, if the tail
-// still contains a known claim marker we treat it as ambiguous and return "" —
-// a recovered-empty field is the documented best-effort failure mode, and the
-// round-trip test would go red before any garbage token could reach a caller.
+// The recovered token (assignee/status) is a single whitespace-free run by the
+// producer's construction: the fragment is the last thing before the bare token,
+// and claim-error wraps PREPEND context ("caller ctx: %w"), never append it, so
+// in the well-formed case the tail is exactly the token. If the tail carries
+// trailing content — whitespace, an appended "(...)" wrap, or a further embedded
+// marker (all of which contain a space or a paren) — we cannot separate the
+// token from the wrap, so we return "". A recovered-empty field is the
+// documented best-effort failure mode (ParseClaimConflict still reports ok=true
+// on the errors.Is match); a status never contains whitespace and an assignee is
+// an actor id that by convention does not either, so a clean conflict is
+// unaffected. This bound also stops a plain appended suffix — which the old
+// "contains another full marker" guard missed — from leaking a garbage token.
 func tailAfter(s, marker string) string {
 	i := strings.LastIndex(s, marker)
 	if i < 0 {
 		return ""
 	}
 	tail := s[i+len(marker):]
-	if strings.Contains(tail, alreadyClaimedMarker) || strings.Contains(tail, notClaimableMarker) {
+	if strings.ContainsAny(tail, " \t\r\n(") {
 		return ""
 	}
 	return tail

--- a/claim.go
+++ b/claim.go
@@ -3,6 +3,8 @@ package beads
 import (
 	"errors"
 	"strings"
+
+	"github.com/steveyegge/beads/internal/storage"
 )
 
 // ClaimConflict describes why a claim failed, recovered from the claim error.
@@ -23,9 +25,16 @@ type ClaimConflict struct {
 	CurrentStatus string
 }
 
-const (
-	alreadyClaimedMarker = "issue already claimed by "
-	notClaimableMarker   = "issue not claimable: status "
+// alreadyClaimedMarker and notClaimableMarker are derived at package-init time
+// from the storage layer's sentinel + format fragment, NOT hardcoded literals,
+// so the producer (issueops/claim.go) and this parser cannot drift: both spell
+// the conflict message as "<sentinel><fragment><token>". A change to either the
+// sentinel text or the fragment moves both ends in lockstep, and the producer-
+// tied round-trip test (claim_roundtrip_test.go / the dolt suite) is the
+// tripwire if the producer stops using the fragment at all.
+var (
+	alreadyClaimedMarker = storage.ErrAlreadyClaimed.Error() + storage.ClaimedByFragment
+	notClaimableMarker   = storage.ErrNotClaimable.Error() + storage.NotClaimableStatusFragment
 )
 
 // ParseClaimConflict inspects a claim error and, when it wraps ErrAlreadyClaimed
@@ -49,9 +58,22 @@ func ParseClaimConflict(err error) (ClaimConflict, bool) {
 
 // tailAfter returns the substring following the last occurrence of marker in s,
 // or "" when marker is absent.
+//
+// The recovered token (assignee/status) is the message's trailing run BY REPO
+// CONVENTION: claim-error wraps PREPEND context ("caller ctx: %w"), never append
+// it, so the fragment appears once near the end and its tail is the bare token.
+// As a guard against a future appended wrap corrupting the token, if the tail
+// still contains a known claim marker we treat it as ambiguous and return "" —
+// a recovered-empty field is the documented best-effort failure mode, and the
+// round-trip test would go red before any garbage token could reach a caller.
 func tailAfter(s, marker string) string {
-	if i := strings.LastIndex(s, marker); i >= 0 {
-		return s[i+len(marker):]
+	i := strings.LastIndex(s, marker)
+	if i < 0 {
+		return ""
 	}
-	return ""
+	tail := s[i+len(marker):]
+	if strings.Contains(tail, alreadyClaimedMarker) || strings.Contains(tail, notClaimableMarker) {
+		return ""
+	}
+	return tail
 }

--- a/claim.go
+++ b/claim.go
@@ -1,0 +1,57 @@
+package beads
+
+import (
+	"errors"
+	"strings"
+)
+
+// ClaimConflict describes why a claim failed, recovered from the claim error.
+//
+// The engine's conditional-UPDATE claim path returns no typed conflict result:
+// on ErrAlreadyClaimed it embeds the current assignee in the message
+// ("issue already claimed by <assignee>"), and on ErrNotClaimable it embeds the
+// current status ("issue not claimable: status <status>"). ClaimConflict
+// carries whichever of those was recoverable; the other stays empty. This is a
+// deliberately string-coupled shim — a typed conflict result would require
+// changing the internal claim signature, which this surface deliberately avoids.
+type ClaimConflict struct {
+	// CurrentAssignee is the actor currently holding the issue. Set when the
+	// error wraps ErrAlreadyClaimed and the assignee was parseable.
+	CurrentAssignee string
+	// CurrentStatus is the issue's status that made it unclaimable. Set when
+	// the error wraps ErrNotClaimable and the status was parseable.
+	CurrentStatus string
+}
+
+const (
+	alreadyClaimedMarker = "issue already claimed by "
+	notClaimableMarker   = "issue not claimable: status "
+)
+
+// ParseClaimConflict inspects a claim error and, when it wraps ErrAlreadyClaimed
+// or ErrNotClaimable, returns the recovered conflict detail and true. For any
+// other error (including nil) it returns the zero ClaimConflict and false.
+//
+// Parsing keys on the message fragment the engine appends after the sentinel,
+// located with LastIndex so that outer "context: %w" wrapping (which prepends)
+// does not defeat it. Fields are best-effort: an Is-match with an unparseable
+// message still returns true with the corresponding field empty.
+func ParseClaimConflict(err error) (ClaimConflict, bool) {
+	switch {
+	case errors.Is(err, ErrAlreadyClaimed):
+		return ClaimConflict{CurrentAssignee: tailAfter(err.Error(), alreadyClaimedMarker)}, true
+	case errors.Is(err, ErrNotClaimable):
+		return ClaimConflict{CurrentStatus: tailAfter(err.Error(), notClaimableMarker)}, true
+	default:
+		return ClaimConflict{}, false
+	}
+}
+
+// tailAfter returns the substring following the last occurrence of marker in s,
+// or "" when marker is absent.
+func tailAfter(s, marker string) string {
+	if i := strings.LastIndex(s, marker); i >= 0 {
+		return s[i+len(marker):]
+	}
+	return ""
+}

--- a/claim_roundtrip_test.go
+++ b/claim_roundtrip_test.go
@@ -1,0 +1,80 @@
+package beads_test
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+
+	"github.com/steveyegge/beads"
+)
+
+// TestParseClaimConflictAgainstRealDolt is the end-to-end producer→parser proof
+// for the string-coupled claim shim: it drives a REAL Dolt-backed claim into
+// both conflict branches through the public surface and asserts
+// beads.ParseClaimConflict recovers the embedded assignee/status. It doubles as
+// the AsIssueClaimer drift exercise (finding: assert the claim surface resolves
+// off a live Storage), so a decorator that dropped ClaimIssue would fail here.
+func TestParseClaimConflictAgainstRealDolt(t *testing.T) {
+	skipIfNoDoltServer(t)
+
+	ctx := context.Background()
+	store, err := beads.Open(ctx, filepath.Join(t.TempDir(), "rt-dolt"))
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer store.Close()
+
+	if err := store.SetConfig(ctx, "issue_prefix", "rt"); err != nil {
+		t.Fatalf("SetConfig(issue_prefix): %v", err)
+	}
+
+	claimer, ok := beads.AsIssueClaimer(store)
+	if !ok {
+		t.Fatalf("AsIssueClaimer returned ok=false for a live Dolt Storage")
+	}
+
+	mk := func(id string) {
+		iss := &beads.Issue{ID: id, Title: id, Status: beads.StatusOpen, Priority: 2, IssueType: beads.TypeTask}
+		if err := store.CreateIssue(ctx, iss, "tester"); err != nil {
+			t.Fatalf("CreateIssue %s: %v", id, err)
+		}
+	}
+
+	// Already-claimed: alice holds rt-1; bob's claim must recover assignee="alice".
+	mk("rt-1")
+	if err := claimer.ClaimIssue(ctx, "rt-1", "alice"); err != nil {
+		t.Fatalf("claim rt-1 as alice: %v", err)
+	}
+	err = claimer.ClaimIssue(ctx, "rt-1", "bob")
+	if !errors.Is(err, beads.ErrAlreadyClaimed) {
+		t.Fatalf("bob's claim error does not wrap ErrAlreadyClaimed: %v", err)
+	}
+	cc, ok := beads.ParseClaimConflict(err)
+	if !ok {
+		t.Fatalf("ParseClaimConflict returned ok=false for an ErrAlreadyClaimed error")
+	}
+	if cc.CurrentAssignee != "alice" {
+		t.Fatalf("CurrentAssignee = %q, want %q (from %v)", cc.CurrentAssignee, "alice", err)
+	}
+	if cc.CurrentStatus != "" {
+		t.Fatalf("CurrentStatus = %q, want empty on an already-claimed conflict", cc.CurrentStatus)
+	}
+
+	// Not-claimable: a closed issue's claim must recover status="closed".
+	mk("rt-2")
+	if err := store.CloseIssue(ctx, "rt-2", "done", "tester", ""); err != nil {
+		t.Fatalf("close rt-2: %v", err)
+	}
+	err = claimer.ClaimIssue(ctx, "rt-2", "carol")
+	if !errors.Is(err, beads.ErrNotClaimable) {
+		t.Fatalf("closed-issue claim error does not wrap ErrNotClaimable: %v", err)
+	}
+	cc, ok = beads.ParseClaimConflict(err)
+	if !ok {
+		t.Fatalf("ParseClaimConflict returned ok=false for an ErrNotClaimable error")
+	}
+	if cc.CurrentStatus != string(beads.StatusClosed) {
+		t.Fatalf("CurrentStatus = %q, want %q (from %v)", cc.CurrentStatus, beads.StatusClosed, err)
+	}
+}

--- a/claim_test.go
+++ b/claim_test.go
@@ -95,4 +95,42 @@ func TestParseClaimConflict(t *testing.T) {
 			t.Errorf("CurrentAssignee = %q, want empty for unparseable message", got.CurrentAssignee)
 		}
 	})
+
+	t.Run("appended wrap yields empty field but still ok", func(t *testing.T) {
+		t.Parallel()
+		// A wrap APPENDED after the assignee (not the repo-convention prepend) is
+		// ambiguous, so the field comes back empty — best-effort — while ok stays
+		// true because it is still an ErrAlreadyClaimed match.
+		err := fmt.Errorf("%w (context appended)", fmt.Errorf("%w by %s", storage.ErrAlreadyClaimed, "alice"))
+		got, ok := ParseClaimConflict(err)
+		if !ok {
+			t.Fatalf("ParseClaimConflict returned ok=false for an appended-wrap ErrAlreadyClaimed")
+		}
+		if got.CurrentAssignee != "" {
+			t.Errorf("CurrentAssignee = %q, want empty on an appended-wrap message", got.CurrentAssignee)
+		}
+	})
+}
+
+// TestTailAfterBoundsTheToken pins the token-recovery boundary directly: a clean
+// token and a prepended wrap recover the bare token; an appended suffix (space or
+// "(...)" wrap) is rejected to "" rather than leaking a corrupted token.
+func TestTailAfterBoundsTheToken(t *testing.T) {
+	t.Parallel()
+	m := alreadyClaimedMarker // "issue already claimed by "
+	cases := []struct {
+		name, in, want string
+	}{
+		{"clean token", m + "alice", "alice"},
+		{"prepended wrap", "claim dr-1: " + m + "alice", "alice"},
+		{"appended paren wrap", m + "alice (from ctx)", ""},
+		{"appended space suffix", m + "alice then boom", ""},
+		{"marker absent", "unrelated error", ""},
+		{"empty token", m, ""},
+	}
+	for _, c := range cases {
+		if got := tailAfter(c.in, m); got != c.want {
+			t.Errorf("%s: tailAfter(%q) = %q, want %q", c.name, c.in, got, c.want)
+		}
+	}
 }

--- a/claim_test.go
+++ b/claim_test.go
@@ -1,0 +1,98 @@
+package beads
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/storage"
+	"github.com/steveyegge/beads/internal/storage/dolt"
+)
+
+// TestClaimSentinelsWrapPreservation proves that errors produced the way the
+// engine's claim/circuit paths produce them still satisfy errors.Is against the
+// ROOT package's re-exported sentinels — i.e. the alias re-export preserves the
+// wrap chain across the package boundary. The wrapped forms mirror
+// issueops/claim.go and storage/dolt/circuit.go exactly.
+func TestClaimSentinelsWrapPreservation(t *testing.T) {
+	t.Parallel()
+
+	// Mirrors issueops.ClaimIssueInTx: fmt.Errorf("%w by %s", ErrAlreadyClaimed, assignee),
+	// then an outer context wrap as a real caller would add.
+	alreadyClaimed := fmt.Errorf("claim dr-1: %w", fmt.Errorf("%w by %s", storage.ErrAlreadyClaimed, "alice"))
+	if !errors.Is(alreadyClaimed, ErrAlreadyClaimed) {
+		t.Errorf("wrapped already-claimed error does not match root beads.ErrAlreadyClaimed")
+	}
+
+	notClaimable := fmt.Errorf("claim dr-1: %w", fmt.Errorf("%w: status %s", storage.ErrNotClaimable, "closed"))
+	if !errors.Is(notClaimable, ErrNotClaimable) {
+		t.Errorf("wrapped not-claimable error does not match root beads.ErrNotClaimable")
+	}
+
+	circuit := fmt.Errorf("read issue: %w", dolt.ErrCircuitOpen)
+	if !errors.Is(circuit, ErrCircuitOpen) {
+		t.Errorf("wrapped circuit error does not match root beads.ErrCircuitOpen")
+	}
+
+	// A conflict must not cross-match the wrong sentinel.
+	if errors.Is(alreadyClaimed, ErrNotClaimable) {
+		t.Errorf("already-claimed error unexpectedly matched ErrNotClaimable")
+	}
+}
+
+func TestParseClaimConflict(t *testing.T) {
+	t.Parallel()
+
+	t.Run("already claimed recovers assignee", func(t *testing.T) {
+		t.Parallel()
+		err := fmt.Errorf("claim dr-1: %w", fmt.Errorf("%w by %s", storage.ErrAlreadyClaimed, "alice"))
+		got, ok := ParseClaimConflict(err)
+		if !ok {
+			t.Fatalf("ParseClaimConflict returned ok=false for an ErrAlreadyClaimed error")
+		}
+		if got.CurrentAssignee != "alice" {
+			t.Errorf("CurrentAssignee = %q, want %q", got.CurrentAssignee, "alice")
+		}
+		if got.CurrentStatus != "" {
+			t.Errorf("CurrentStatus = %q, want empty", got.CurrentStatus)
+		}
+	})
+
+	t.Run("not claimable recovers status", func(t *testing.T) {
+		t.Parallel()
+		err := fmt.Errorf("%w: status %s", storage.ErrNotClaimable, "in_progress")
+		got, ok := ParseClaimConflict(err)
+		if !ok {
+			t.Fatalf("ParseClaimConflict returned ok=false for an ErrNotClaimable error")
+		}
+		if got.CurrentStatus != "in_progress" {
+			t.Errorf("CurrentStatus = %q, want %q", got.CurrentStatus, "in_progress")
+		}
+		if got.CurrentAssignee != "" {
+			t.Errorf("CurrentAssignee = %q, want empty", got.CurrentAssignee)
+		}
+	})
+
+	t.Run("unrelated error returns false", func(t *testing.T) {
+		t.Parallel()
+		if got, ok := ParseClaimConflict(errors.New("boom")); ok {
+			t.Errorf("ParseClaimConflict(unrelated) = (%+v, true), want ok=false", got)
+		}
+		if got, ok := ParseClaimConflict(nil); ok {
+			t.Errorf("ParseClaimConflict(nil) = (%+v, true), want ok=false", got)
+		}
+	})
+
+	t.Run("is-match with unparseable message still ok", func(t *testing.T) {
+		t.Parallel()
+		// Wraps the sentinel without the " by <assignee>" tail.
+		err := fmt.Errorf("weird wrap: %w", storage.ErrAlreadyClaimed)
+		got, ok := ParseClaimConflict(err)
+		if !ok {
+			t.Fatalf("ParseClaimConflict returned ok=false for a wrapped ErrAlreadyClaimed")
+		}
+		if got.CurrentAssignee != "" {
+			t.Errorf("CurrentAssignee = %q, want empty for unparseable message", got.CurrentAssignee)
+		}
+	})
+}

--- a/claim_test.go
+++ b/claim_test.go
@@ -58,6 +58,25 @@ func TestParseClaimConflict(t *testing.T) {
 		}
 	})
 
+	t.Run("open pre-assigned conflict classifies, assignee best-effort", func(t *testing.T) {
+		t.Parallel()
+		// Mirrors issueops.ClaimIssueInTx's open-but-assigned branch: the
+		// sentinel is wrapped (so errors.Is classification holds) but the
+		// holder-focused message does not end in the " by <assignee>" tail, so
+		// the assignee comes back empty — best-effort — while ok stays true.
+		err := fmt.Errorf("claim cl-fa1: %w", fmt.Errorf("%w: already assigned to %q — coordinate with the holder; if their claim is abandoned (crashed agent), lease expiry will surface it for bd reclaim", storage.ErrAlreadyClaimed, "alice"))
+		got, ok := ParseClaimConflict(err)
+		if !ok {
+			t.Fatalf("ParseClaimConflict returned ok=false for a wrapped open-assigned ErrAlreadyClaimed")
+		}
+		if got.CurrentAssignee != "" {
+			t.Errorf("CurrentAssignee = %q, want empty (holder-focused message has no parseable tail)", got.CurrentAssignee)
+		}
+		if got.CurrentStatus != "" {
+			t.Errorf("CurrentStatus = %q, want empty", got.CurrentStatus)
+		}
+	})
+
 	t.Run("not claimable recovers status", func(t *testing.T) {
 		t.Parallel()
 		err := fmt.Errorf("%w: status %s", storage.ErrNotClaimable, "in_progress")

--- a/internal/storage/conformance/claim.go
+++ b/internal/storage/conformance/claim.go
@@ -65,6 +65,26 @@ func testClaimAlreadyClaimed(t *testing.T, f Factory) {
 	}
 }
 
+// testClaimOpenForeignAssignee: an OPEN issue pre-assigned to a different real
+// actor (a dispatcher set the assignee but nobody claimed it, so status stays
+// open) is still an ErrAlreadyClaimed conflict when another actor tries to claim
+// it. The open-but-assigned refusal branch wraps the sentinel so the public
+// IssueClaimer contract (errors.Is / ParseClaimConflict) holds identically on
+// both backends, matching the already-claimed (in_progress) path above.
+func testClaimOpenForeignAssignee(t *testing.T, f Factory) {
+	s := f(t)
+	must(t, s.CreateIssue(ctx(), withDefaults(&types.Issue{ID: "cl-fa1", Title: "T", Assignee: "alice", Status: types.StatusOpen}), "dispatcher"))
+	pre, err := s.GetIssue(ctx(), "cl-fa1")
+	must(t, err)
+	if pre.Status != types.StatusOpen || pre.Assignee != "alice" {
+		t.Fatalf("precondition: want open+assigned-to-alice, got status=%q assignee=%q", pre.Status, pre.Assignee)
+	}
+	err = s.ClaimIssue(ctx(), "cl-fa1", "bob")
+	if !errors.Is(err, storage.ErrAlreadyClaimed) {
+		t.Errorf("claim of open issue pre-assigned to another actor: err = %v, want ErrAlreadyClaimed", err)
+	}
+}
+
 // testClaimNotClaimable: claiming a closed issue is ErrNotClaimable.
 func testClaimNotClaimable(t *testing.T, f Factory) {
 	s := f(t)

--- a/internal/storage/conformance/conformance.go
+++ b/internal/storage/conformance/conformance.go
@@ -191,6 +191,8 @@ func RunAll(t *testing.T, factory Factory) {
 
 	// Transaction
 	t.Run("Transaction", func(t *testing.T) { testTransaction(t, factory) })
+	t.Run("TransactionSnapshotReads", func(t *testing.T) { testTransactionSnapshotReads(t, factory) })
+	t.Run("TransactionReadYourWrites", func(t *testing.T) { testTransactionReadYourWrites(t, factory) })
 }
 
 // RunDeferredReads runs the subset of the suite covering SQLite's shared
@@ -926,6 +928,282 @@ func testTransaction(t *testing.T, f Factory) {
 	}
 	if !found {
 		t.Errorf("label 'from-tx' not found, got %v", labels)
+	}
+}
+
+// sumCounts totals a CountIssuesByGroup result.
+func sumCounts(m map[string]int) int {
+	total := 0
+	for _, n := range m {
+		total += n
+	}
+	return total
+}
+
+// testTransactionSnapshotReads proves the new reads run on the transaction's
+// live snapshot rather than a fresh (committed-only) connection: it reads a
+// composite view off the opening snapshot, mutates INSIDE the transaction, and
+// re-reads — asserting every read reflects the in-transaction mutation. A
+// non-transactional implementation would return the pre-mutation state on the
+// second read and fail every delta. It keeps the cross-read arithmetic checks so
+// a torn read (values drawn from different points) is also caught.
+//
+// The fixture includes a committed wisp so the count-vs-search wisp asymmetry is
+// exercised rather than silently avoided (CountIssuesByGroup merges wisps;
+// SearchIssues reads the issues table only). External-connection mutation (the
+// classic snapshot-isolation probe) is not used because the Dolt store pins a
+// single connection per transaction (MaxOpenConns=1), so a second op would
+// deadlock; the in-transaction mutation is the deterministic equivalent.
+func testTransactionSnapshotReads(t *testing.T, f Factory) {
+	s := f(t)
+	c := ctx()
+
+	must(t, s.CreateIssue(c, withDefaults(&types.Issue{ID: "snap-1", Title: "Root", Status: types.StatusOpen, IssueType: "bug", Priority: 0}), "a"))
+	must(t, s.CreateIssue(c, withDefaults(&types.Issue{ID: "snap-2", Title: "Child", Status: types.StatusOpen, IssueType: "task", Priority: 1}), "a"))
+	must(t, s.CreateIssue(c, withDefaults(&types.Issue{ID: "snap-3", Title: "Other", Status: types.StatusInProgress, IssueType: "task", Priority: 1}), "a"))
+	// A committed wisp: counted by CountIssuesByGroup but not by SearchIssues.
+	must(t, s.CreateIssue(c, withDefaults(&types.Issue{ID: "snap-wisp", Title: "Wisp", Status: types.StatusOpen, Ephemeral: true}), "a"))
+	const committedWisps = 1
+	// snap-2 depends on (is blocked by) snap-1.
+	must(t, s.AddDependency(c, &types.Dependency{IssueID: "snap-2", DependsOnID: "snap-1", Type: types.DepBlocks}, "a"))
+	// Two comments on snap-1.
+	if _, err := s.AddIssueComment(c, "snap-1", "a", "first"); err != nil {
+		t.Fatalf("AddIssueComment: %v", err)
+	}
+	if _, err := s.AddIssueComment(c, "snap-1", "a", "second"); err != nil {
+		t.Fatalf("AddIssueComment: %v", err)
+	}
+
+	err := s.RunInTransaction(c, "bd: snapshot", func(tx storage.Transaction) error {
+		// --- Baseline reads off the opening snapshot. ---
+		issues0, err := tx.SearchIssues(c, "", types.IssueFilter{})
+		if err != nil {
+			return err
+		}
+		counts0, err := tx.CountIssuesByGroup(c, types.IssueFilter{}, "status")
+		if err != nil {
+			return err
+		}
+		dep0, err := tx.GetDependentRecords(c, "snap-1", "", 0, "")
+		if err != nil {
+			return err
+		}
+		nDep0, err := tx.CountDependentRecords(c, "snap-1", "")
+		if err != nil {
+			return err
+		}
+		comments0, err := tx.GetIssueCommentsPage(c, "snap-1", storage.CommentPageCursor{}, 0)
+		if err != nil {
+			return err
+		}
+		events0, err := tx.EventsSince(c, storage.EventCursor{}, "", 1000)
+		if err != nil {
+			return err
+		}
+		scoped0, err := tx.EventsSince(c, storage.EventCursor{}, "snap-1", 1000)
+		if err != nil {
+			return err
+		}
+
+		// CountIssuesByGroup merges wisps on every backend, so its buckets sum to
+		// the 3 durable issues + the committed wisp. Whether SearchIssues also
+		// counts that committed wisp is backend-specific (the classic Dolt tx reads
+		// the issues table only; the embedded tx merges both), so we assert the
+		// durable issues are all present rather than a wisp-free equality — see the
+		// count-vs-search wisp-scoping asymmetry noted on storage.Transaction.
+		const durableSeeded = 3
+		if got := sumCounts(counts0); got != durableSeeded+committedWisps {
+			t.Errorf("baseline sum(CountIssuesByGroup)=%d, want %d (durable + committed wisp)", got, durableSeeded+committedWisps)
+		}
+		for _, id := range []string{"snap-1", "snap-2", "snap-3"} {
+			if !containsIssueID(issues0, id) {
+				t.Errorf("baseline SearchIssues missing durable issue %s", id)
+			}
+		}
+		if len(dep0) != 1 || dep0[0].IssueID != "snap-2" {
+			t.Errorf("baseline GetDependentRecords(snap-1)=%v, want one edge from snap-2", dep0)
+		}
+		if nDep0 != len(dep0) {
+			t.Errorf("baseline CountDependentRecords=%d != len(GetDependentRecords)=%d", nDep0, len(dep0))
+		}
+		if len(comments0) != 2 {
+			t.Errorf("baseline GetIssueCommentsPage(snap-1)=%d comments, want 2", len(comments0))
+		}
+		if len(events0) == 0 {
+			t.Errorf("baseline EventsSince(all) returned no events")
+		}
+		for _, e := range scoped0 {
+			if e.IssueID != "snap-1" {
+				t.Errorf("EventsSince(snap-1) leaked event for %s", e.IssueID)
+			}
+		}
+
+		// --- Mutate INSIDE the transaction, then re-read the same view. ---
+		if err := tx.CreateIssue(c, withDefaults(&types.Issue{ID: "snap-4", Title: "InTx", Status: types.StatusOpen, IssueType: "task", Priority: 1}), "a"); err != nil {
+			return err
+		}
+		if err := tx.AddDependency(c, &types.Dependency{IssueID: "snap-4", DependsOnID: "snap-1", Type: types.DepBlocks}, "a"); err != nil {
+			return err
+		}
+
+		issues1, err := tx.SearchIssues(c, "", types.IssueFilter{})
+		if err != nil {
+			return err
+		}
+		counts1, err := tx.CountIssuesByGroup(c, types.IssueFilter{}, "status")
+		if err != nil {
+			return err
+		}
+		dep1, err := tx.GetDependentRecords(c, "snap-1", "", 0, "")
+		if err != nil {
+			return err
+		}
+		nDep1, err := tx.CountDependentRecords(c, "snap-1", "")
+		if err != nil {
+			return err
+		}
+		blocked1, err := tx.IsBlockedBatch(c, []string{"snap-1", "snap-2", "snap-3", "snap-4"})
+		if err != nil {
+			return err
+		}
+		events1, err := tx.EventsSince(c, storage.EventCursor{}, "", 1000)
+		if err != nil {
+			return err
+		}
+
+		// Every read must reflect the in-transaction mutation — the delta is
+		// exactly the new issue + edge, nothing torn.
+		if len(issues1) != len(issues0)+1 {
+			t.Errorf("SearchIssues after in-tx create = %d, want %d", len(issues1), len(issues0)+1)
+		}
+		if sumCounts(counts1) != sumCounts(counts0)+1 {
+			t.Errorf("CountIssuesByGroup total after in-tx create = %d, want %d", sumCounts(counts1), sumCounts(counts0)+1)
+		}
+		if len(dep1) != len(dep0)+1 {
+			t.Errorf("GetDependentRecords(snap-1) after in-tx edge = %d, want %d", len(dep1), len(dep0)+1)
+		}
+		if !containsDependentFrom(dep1, "snap-4") {
+			t.Errorf("GetDependentRecords(snap-1) missing in-tx edge from snap-4: %v", dep1)
+		}
+		if nDep1 != nDep0+1 {
+			t.Errorf("CountDependentRecords(snap-1) after in-tx edge = %d, want %d", nDep1, nDep0+1)
+		}
+		if !blocked1["snap-4"] {
+			t.Errorf("snap-4 should read blocked after its in-tx dependency")
+		}
+		if !blocked1["snap-2"] {
+			t.Errorf("snap-2 should still read blocked")
+		}
+		if blocked1["snap-1"] || blocked1["snap-3"] {
+			t.Errorf("snap-1/snap-3 should read not-blocked, got %v", blocked1)
+		}
+		if len(events1) <= len(events0) {
+			t.Errorf("EventsSince(all) did not grow after in-tx writes: %d <= %d", len(events1), len(events0))
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("RunInTransaction: %v", err)
+	}
+}
+
+// containsDependentFrom reports whether deps contains an inbound edge sourced at
+// sourceID.
+func containsDependentFrom(deps []*types.Dependency, sourceID string) bool {
+	for _, d := range deps {
+		if d.IssueID == sourceID {
+			return true
+		}
+	}
+	return false
+}
+
+// containsIssueID reports whether issues contains an issue with the given id.
+func containsIssueID(issues []*types.Issue, id string) bool {
+	for _, i := range issues {
+		if i.ID == id {
+			return true
+		}
+	}
+	return false
+}
+
+// testTransactionReadYourWrites creates an issue graph inside a transaction and
+// reads it back through the new composite-view methods BEFORE commit, proving
+// the transaction sees its own uncommitted writes — including through the
+// grouped-count and event-feed reads.
+func testTransactionReadYourWrites(t *testing.T, f Factory) {
+	s := f(t)
+	c := ctx()
+
+	err := s.RunInTransaction(c, "bd: ryw", func(tx storage.Transaction) error {
+		if err := tx.CreateIssue(c, withDefaults(&types.Issue{ID: "ryw-1", Title: "Blocker", Status: types.StatusOpen}), "a"); err != nil {
+			return err
+		}
+		if err := tx.CreateIssue(c, withDefaults(&types.Issue{ID: "ryw-2", Title: "Blocked", Status: types.StatusOpen}), "a"); err != nil {
+			return err
+		}
+		if err := tx.AddDependency(c, &types.Dependency{IssueID: "ryw-2", DependsOnID: "ryw-1", Type: types.DepBlocks}, "a"); err != nil {
+			return err
+		}
+
+		dependents, err := tx.GetDependentRecords(c, "ryw-1", "", 0, "")
+		if err != nil {
+			return err
+		}
+		if len(dependents) != 1 || dependents[0].IssueID != "ryw-2" {
+			t.Errorf("in-tx GetDependentRecords(ryw-1) = %v, want one edge from ryw-2", dependents)
+		}
+		byTarget, err := tx.GetDependentRecordsForIssues(c, []string{"ryw-1"})
+		if err != nil {
+			return err
+		}
+		if len(byTarget["ryw-1"]) != 1 {
+			t.Errorf("in-tx GetDependentRecordsForIssues[ryw-1] = %d, want 1", len(byTarget["ryw-1"]))
+		}
+		nDep, err := tx.CountDependentRecords(c, "ryw-1", "")
+		if err != nil {
+			return err
+		}
+		if nDep != 1 {
+			t.Errorf("in-tx CountDependentRecords(ryw-1) = %d, want 1", nDep)
+		}
+		batch, err := tx.IsBlockedBatch(c, []string{"ryw-1", "ryw-2"})
+		if err != nil {
+			return err
+		}
+		if !batch["ryw-2"] || batch["ryw-1"] {
+			t.Errorf("in-tx IsBlockedBatch = %v, want ryw-2 blocked, ryw-1 not", batch)
+		}
+		isBlocked, blockers, err := tx.IsBlocked(c, "ryw-2")
+		if err != nil {
+			return err
+		}
+		if !isBlocked || len(blockers) != 1 || blockers[0] != "ryw-1" {
+			t.Errorf("in-tx IsBlocked(ryw-2) = %v, %v, want true, [ryw-1]", isBlocked, blockers)
+		}
+
+		// The two in-tx durable issues are visible through the grouped counts.
+		counts, err := tx.CountIssuesByGroup(c, types.IssueFilter{}, "status")
+		if err != nil {
+			return err
+		}
+		if sumCounts(counts) != 2 {
+			t.Errorf("in-tx CountIssuesByGroup total = %d, want 2 (both uncommitted issues)", sumCounts(counts))
+		}
+
+		// The in-tx create event is visible through the durable event feed.
+		evs, err := tx.EventsSince(c, storage.EventCursor{}, "ryw-1", 100)
+		if err != nil {
+			return err
+		}
+		if len(evs) == 0 {
+			t.Errorf("in-tx EventsSince(ryw-1) returned no events for the uncommitted create")
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("RunInTransaction: %v", err)
 	}
 }
 

--- a/internal/storage/conformance/conformance.go
+++ b/internal/storage/conformance/conformance.go
@@ -147,6 +147,7 @@ func RunAll(t *testing.T, factory Factory) {
 	t.Run("Claim", func(t *testing.T) { testClaim(t, factory) })
 	t.Run("ClaimIdempotent", func(t *testing.T) { testClaimIdempotent(t, factory) })
 	t.Run("ClaimAlreadyClaimed", func(t *testing.T) { testClaimAlreadyClaimed(t, factory) })
+	t.Run("ClaimOpenForeignAssignee", func(t *testing.T) { testClaimOpenForeignAssignee(t, factory) })
 	t.Run("ClaimNotClaimable", func(t *testing.T) { testClaimNotClaimable(t, factory) })
 	t.Run("ClaimReadyIssue", func(t *testing.T) { testClaimReadyIssue(t, factory) })
 	t.Run("ClaimReadyIssueLabelFilters", func(t *testing.T) { testClaimReadyIssueLabelFilters(t, factory) })
@@ -940,6 +941,42 @@ func sumCounts(m map[string]int) int {
 	return total
 }
 
+// snapView bundles the composite-view reads taken at a single point inside a
+// transaction so the baseline and post-mutation snapshots can be compared as
+// plain data instead of a wall of inline reads. Both snapshots share these five
+// reads; point-specific extras (comments, the snap-1-scoped event feed, and the
+// batch blocked flags) are read separately by the caller.
+type snapView struct {
+	issues []*types.Issue
+	counts map[string]int
+	deps   []*types.Dependency
+	nDep   int
+	events []*types.Event
+}
+
+// readSnapView captures the five composite-view reads shared by the baseline and
+// post-mutation snapshots in testTransactionSnapshotReads.
+func readSnapView(c context.Context, tx storage.Transaction) (snapView, error) {
+	var v snapView
+	var err error
+	if v.issues, err = tx.SearchIssues(c, "", types.IssueFilter{}); err != nil {
+		return v, err
+	}
+	if v.counts, err = tx.CountIssuesByGroup(c, types.IssueFilter{}, "status"); err != nil {
+		return v, err
+	}
+	if v.deps, err = tx.GetDependentRecords(c, "snap-1", "", 0, ""); err != nil {
+		return v, err
+	}
+	if v.nDep, err = tx.CountDependentRecords(c, "snap-1", ""); err != nil {
+		return v, err
+	}
+	if v.events, err = tx.EventsSince(c, storage.EventCursor{}, "", 1000); err != nil {
+		return v, err
+	}
+	return v, nil
+}
+
 // testTransactionSnapshotReads proves the new reads run on the transaction's
 // live snapshot rather than a fresh (committed-only) connection: it reads a
 // composite view off the opening snapshot, mutates INSIDE the transaction, and
@@ -976,19 +1013,7 @@ func testTransactionSnapshotReads(t *testing.T, f Factory) {
 
 	err := s.RunInTransaction(c, "bd: snapshot", func(tx storage.Transaction) error {
 		// --- Baseline reads off the opening snapshot. ---
-		issues0, err := tx.SearchIssues(c, "", types.IssueFilter{})
-		if err != nil {
-			return err
-		}
-		counts0, err := tx.CountIssuesByGroup(c, types.IssueFilter{}, "status")
-		if err != nil {
-			return err
-		}
-		dep0, err := tx.GetDependentRecords(c, "snap-1", "", 0, "")
-		if err != nil {
-			return err
-		}
-		nDep0, err := tx.CountDependentRecords(c, "snap-1", "")
+		base, err := readSnapView(c, tx)
 		if err != nil {
 			return err
 		}
@@ -996,47 +1021,11 @@ func testTransactionSnapshotReads(t *testing.T, f Factory) {
 		if err != nil {
 			return err
 		}
-		events0, err := tx.EventsSince(c, storage.EventCursor{}, "", 1000)
-		if err != nil {
-			return err
-		}
 		scoped0, err := tx.EventsSince(c, storage.EventCursor{}, "snap-1", 1000)
 		if err != nil {
 			return err
 		}
-
-		// CountIssuesByGroup merges wisps on every backend, so its buckets sum to
-		// the 3 durable issues + the committed wisp. Whether SearchIssues also
-		// counts that committed wisp is backend-specific (the classic Dolt tx reads
-		// the issues table only; the embedded tx merges both), so we assert the
-		// durable issues are all present rather than a wisp-free equality — see the
-		// count-vs-search wisp-scoping asymmetry noted on storage.Transaction.
-		const durableSeeded = 3
-		if got := sumCounts(counts0); got != durableSeeded+committedWisps {
-			t.Errorf("baseline sum(CountIssuesByGroup)=%d, want %d (durable + committed wisp)", got, durableSeeded+committedWisps)
-		}
-		for _, id := range []string{"snap-1", "snap-2", "snap-3"} {
-			if !containsIssueID(issues0, id) {
-				t.Errorf("baseline SearchIssues missing durable issue %s", id)
-			}
-		}
-		if len(dep0) != 1 || dep0[0].IssueID != "snap-2" {
-			t.Errorf("baseline GetDependentRecords(snap-1)=%v, want one edge from snap-2", dep0)
-		}
-		if nDep0 != len(dep0) {
-			t.Errorf("baseline CountDependentRecords=%d != len(GetDependentRecords)=%d", nDep0, len(dep0))
-		}
-		if len(comments0) != 2 {
-			t.Errorf("baseline GetIssueCommentsPage(snap-1)=%d comments, want 2", len(comments0))
-		}
-		if len(events0) == 0 {
-			t.Errorf("baseline EventsSince(all) returned no events")
-		}
-		for _, e := range scoped0 {
-			if e.IssueID != "snap-1" {
-				t.Errorf("EventsSince(snap-1) leaked event for %s", e.IssueID)
-			}
-		}
+		assertSnapBaseline(t, base, comments0, scoped0, committedWisps)
 
 		// --- Mutate INSIDE the transaction, then re-read the same view. ---
 		if err := tx.CreateIssue(c, withDefaults(&types.Issue{ID: "snap-4", Title: "InTx", Status: types.StatusOpen, IssueType: "task", Priority: 1}), "a"); err != nil {
@@ -1046,19 +1035,7 @@ func testTransactionSnapshotReads(t *testing.T, f Factory) {
 			return err
 		}
 
-		issues1, err := tx.SearchIssues(c, "", types.IssueFilter{})
-		if err != nil {
-			return err
-		}
-		counts1, err := tx.CountIssuesByGroup(c, types.IssueFilter{}, "status")
-		if err != nil {
-			return err
-		}
-		dep1, err := tx.GetDependentRecords(c, "snap-1", "", 0, "")
-		if err != nil {
-			return err
-		}
-		nDep1, err := tx.CountDependentRecords(c, "snap-1", "")
+		after, err := readSnapView(c, tx)
 		if err != nil {
 			return err
 		}
@@ -1066,40 +1043,7 @@ func testTransactionSnapshotReads(t *testing.T, f Factory) {
 		if err != nil {
 			return err
 		}
-		events1, err := tx.EventsSince(c, storage.EventCursor{}, "", 1000)
-		if err != nil {
-			return err
-		}
-
-		// Every read must reflect the in-transaction mutation — the delta is
-		// exactly the new issue + edge, nothing torn.
-		if len(issues1) != len(issues0)+1 {
-			t.Errorf("SearchIssues after in-tx create = %d, want %d", len(issues1), len(issues0)+1)
-		}
-		if sumCounts(counts1) != sumCounts(counts0)+1 {
-			t.Errorf("CountIssuesByGroup total after in-tx create = %d, want %d", sumCounts(counts1), sumCounts(counts0)+1)
-		}
-		if len(dep1) != len(dep0)+1 {
-			t.Errorf("GetDependentRecords(snap-1) after in-tx edge = %d, want %d", len(dep1), len(dep0)+1)
-		}
-		if !containsDependentFrom(dep1, "snap-4") {
-			t.Errorf("GetDependentRecords(snap-1) missing in-tx edge from snap-4: %v", dep1)
-		}
-		if nDep1 != nDep0+1 {
-			t.Errorf("CountDependentRecords(snap-1) after in-tx edge = %d, want %d", nDep1, nDep0+1)
-		}
-		if !blocked1["snap-4"] {
-			t.Errorf("snap-4 should read blocked after its in-tx dependency")
-		}
-		if !blocked1["snap-2"] {
-			t.Errorf("snap-2 should still read blocked")
-		}
-		if blocked1["snap-1"] || blocked1["snap-3"] {
-			t.Errorf("snap-1/snap-3 should read not-blocked, got %v", blocked1)
-		}
-		if len(events1) <= len(events0) {
-			t.Errorf("EventsSince(all) did not grow after in-tx writes: %d <= %d", len(events1), len(events0))
-		}
+		assertSnapDelta(t, base, after, blocked1)
 		return nil
 	})
 	if err != nil {
@@ -1128,6 +1072,80 @@ func containsIssueID(issues []*types.Issue, id string) bool {
 	return false
 }
 
+// assertSnapBaseline checks the opening-snapshot reads: the durable+wisp count
+// sum, presence of every durable issue, the single inbound edge on snap-1 (with
+// list/count agreement), the two comments, a non-empty event feed, and that the
+// snap-1-scoped feed never leaks another issue's events.
+func assertSnapBaseline(t *testing.T, v snapView, comments []*types.Comment, scoped []*types.Event, committedWisps int) {
+	t.Helper()
+	// CountIssuesByGroup merges wisps on every backend, so its buckets sum to the
+	// 3 durable issues + the committed wisp. Whether SearchIssues also counts that
+	// committed wisp is backend-specific (the classic Dolt tx reads the issues
+	// table only; the embedded tx merges both), so we assert the durable issues
+	// are all present rather than a wisp-free equality — see the count-vs-search
+	// wisp-scoping asymmetry noted on storage.Transaction.
+	const durableSeeded = 3
+	if got := sumCounts(v.counts); got != durableSeeded+committedWisps {
+		t.Errorf("baseline sum(CountIssuesByGroup)=%d, want %d (durable + committed wisp)", got, durableSeeded+committedWisps)
+	}
+	for _, id := range []string{"snap-1", "snap-2", "snap-3"} {
+		if !containsIssueID(v.issues, id) {
+			t.Errorf("baseline SearchIssues missing durable issue %s", id)
+		}
+	}
+	if len(v.deps) != 1 || v.deps[0].IssueID != "snap-2" {
+		t.Errorf("baseline GetDependentRecords(snap-1)=%v, want one edge from snap-2", v.deps)
+	}
+	if v.nDep != len(v.deps) {
+		t.Errorf("baseline CountDependentRecords=%d != len(GetDependentRecords)=%d", v.nDep, len(v.deps))
+	}
+	if len(comments) != 2 {
+		t.Errorf("baseline GetIssueCommentsPage(snap-1)=%d comments, want 2", len(comments))
+	}
+	if len(v.events) == 0 {
+		t.Errorf("baseline EventsSince(all) returned no events")
+	}
+	for _, e := range scoped {
+		if e.IssueID != "snap-1" {
+			t.Errorf("EventsSince(snap-1) leaked event for %s", e.IssueID)
+		}
+	}
+}
+
+// assertSnapDelta checks that every composite-view read reflects exactly the
+// in-transaction create + edge (one new issue, one new inbound edge on snap-1
+// from snap-4 with snap-4 reading blocked) with no torn or missing rows.
+func assertSnapDelta(t *testing.T, base, after snapView, blocked map[string]bool) {
+	t.Helper()
+	if len(after.issues) != len(base.issues)+1 {
+		t.Errorf("SearchIssues after in-tx create = %d, want %d", len(after.issues), len(base.issues)+1)
+	}
+	if sumCounts(after.counts) != sumCounts(base.counts)+1 {
+		t.Errorf("CountIssuesByGroup total after in-tx create = %d, want %d", sumCounts(after.counts), sumCounts(base.counts)+1)
+	}
+	if len(after.deps) != len(base.deps)+1 {
+		t.Errorf("GetDependentRecords(snap-1) after in-tx edge = %d, want %d", len(after.deps), len(base.deps)+1)
+	}
+	if !containsDependentFrom(after.deps, "snap-4") {
+		t.Errorf("GetDependentRecords(snap-1) missing in-tx edge from snap-4: %v", after.deps)
+	}
+	if after.nDep != base.nDep+1 {
+		t.Errorf("CountDependentRecords(snap-1) after in-tx edge = %d, want %d", after.nDep, base.nDep+1)
+	}
+	if !blocked["snap-4"] {
+		t.Errorf("snap-4 should read blocked after its in-tx dependency")
+	}
+	if !blocked["snap-2"] {
+		t.Errorf("snap-2 should still read blocked")
+	}
+	if blocked["snap-1"] || blocked["snap-3"] {
+		t.Errorf("snap-1/snap-3 should read not-blocked, got %v", blocked)
+	}
+	if len(after.events) <= len(base.events) {
+		t.Errorf("EventsSince(all) did not grow after in-tx writes: %d <= %d", len(after.events), len(base.events))
+	}
+}
+
 // testTransactionReadYourWrites creates an issue graph inside a transaction and
 // reads it back through the new composite-view methods BEFORE commit, proving
 // the transaction sees its own uncommitted writes — including through the
@@ -1137,74 +1155,96 @@ func testTransactionReadYourWrites(t *testing.T, f Factory) {
 	c := ctx()
 
 	err := s.RunInTransaction(c, "bd: ryw", func(tx storage.Transaction) error {
-		if err := tx.CreateIssue(c, withDefaults(&types.Issue{ID: "ryw-1", Title: "Blocker", Status: types.StatusOpen}), "a"); err != nil {
+		if err := seedReadYourWritesGraph(c, tx); err != nil {
 			return err
 		}
-		if err := tx.CreateIssue(c, withDefaults(&types.Issue{ID: "ryw-2", Title: "Blocked", Status: types.StatusOpen}), "a"); err != nil {
+		if err := assertInTxDependentReads(t, c, tx); err != nil {
 			return err
 		}
-		if err := tx.AddDependency(c, &types.Dependency{IssueID: "ryw-2", DependsOnID: "ryw-1", Type: types.DepBlocks}, "a"); err != nil {
-			return err
-		}
-
-		dependents, err := tx.GetDependentRecords(c, "ryw-1", "", 0, "")
-		if err != nil {
-			return err
-		}
-		if len(dependents) != 1 || dependents[0].IssueID != "ryw-2" {
-			t.Errorf("in-tx GetDependentRecords(ryw-1) = %v, want one edge from ryw-2", dependents)
-		}
-		byTarget, err := tx.GetDependentRecordsForIssues(c, []string{"ryw-1"})
-		if err != nil {
-			return err
-		}
-		if len(byTarget["ryw-1"]) != 1 {
-			t.Errorf("in-tx GetDependentRecordsForIssues[ryw-1] = %d, want 1", len(byTarget["ryw-1"]))
-		}
-		nDep, err := tx.CountDependentRecords(c, "ryw-1", "")
-		if err != nil {
-			return err
-		}
-		if nDep != 1 {
-			t.Errorf("in-tx CountDependentRecords(ryw-1) = %d, want 1", nDep)
-		}
-		batch, err := tx.IsBlockedBatch(c, []string{"ryw-1", "ryw-2"})
-		if err != nil {
-			return err
-		}
-		if !batch["ryw-2"] || batch["ryw-1"] {
-			t.Errorf("in-tx IsBlockedBatch = %v, want ryw-2 blocked, ryw-1 not", batch)
-		}
-		isBlocked, blockers, err := tx.IsBlocked(c, "ryw-2")
-		if err != nil {
-			return err
-		}
-		if !isBlocked || len(blockers) != 1 || blockers[0] != "ryw-1" {
-			t.Errorf("in-tx IsBlocked(ryw-2) = %v, %v, want true, [ryw-1]", isBlocked, blockers)
-		}
-
-		// The two in-tx durable issues are visible through the grouped counts.
-		counts, err := tx.CountIssuesByGroup(c, types.IssueFilter{}, "status")
-		if err != nil {
-			return err
-		}
-		if sumCounts(counts) != 2 {
-			t.Errorf("in-tx CountIssuesByGroup total = %d, want 2 (both uncommitted issues)", sumCounts(counts))
-		}
-
-		// The in-tx create event is visible through the durable event feed.
-		evs, err := tx.EventsSince(c, storage.EventCursor{}, "ryw-1", 100)
-		if err != nil {
-			return err
-		}
-		if len(evs) == 0 {
-			t.Errorf("in-tx EventsSince(ryw-1) returned no events for the uncommitted create")
-		}
-		return nil
+		return assertInTxCountsAndEvents(t, c, tx)
 	})
 	if err != nil {
 		t.Fatalf("RunInTransaction: %v", err)
 	}
+}
+
+// seedReadYourWritesGraph creates the ryw-1 <- ryw-2 (blocked-by) graph inside
+// the transaction that reads it back.
+func seedReadYourWritesGraph(c context.Context, tx storage.Transaction) error {
+	if err := tx.CreateIssue(c, withDefaults(&types.Issue{ID: "ryw-1", Title: "Blocker", Status: types.StatusOpen}), "a"); err != nil {
+		return err
+	}
+	if err := tx.CreateIssue(c, withDefaults(&types.Issue{ID: "ryw-2", Title: "Blocked", Status: types.StatusOpen}), "a"); err != nil {
+		return err
+	}
+	return tx.AddDependency(c, &types.Dependency{IssueID: "ryw-2", DependsOnID: "ryw-1", Type: types.DepBlocks}, "a")
+}
+
+// assertInTxDependentReads proves the dependents/blocked family reads the graph's
+// own uncommitted writes: the single inbound edge on ryw-1 (list, by-target map,
+// and count all agree) and the blocked flags (ryw-2 blocked, ryw-1 not) through
+// both IsBlockedBatch and IsBlocked.
+func assertInTxDependentReads(t *testing.T, c context.Context, tx storage.Transaction) error {
+	t.Helper()
+	dependents, err := tx.GetDependentRecords(c, "ryw-1", "", 0, "")
+	if err != nil {
+		return err
+	}
+	if len(dependents) != 1 || dependents[0].IssueID != "ryw-2" {
+		t.Errorf("in-tx GetDependentRecords(ryw-1) = %v, want one edge from ryw-2", dependents)
+	}
+	byTarget, err := tx.GetDependentRecordsForIssues(c, []string{"ryw-1"})
+	if err != nil {
+		return err
+	}
+	if len(byTarget["ryw-1"]) != 1 {
+		t.Errorf("in-tx GetDependentRecordsForIssues[ryw-1] = %d, want 1", len(byTarget["ryw-1"]))
+	}
+	nDep, err := tx.CountDependentRecords(c, "ryw-1", "")
+	if err != nil {
+		return err
+	}
+	if nDep != 1 {
+		t.Errorf("in-tx CountDependentRecords(ryw-1) = %d, want 1", nDep)
+	}
+	batch, err := tx.IsBlockedBatch(c, []string{"ryw-1", "ryw-2"})
+	if err != nil {
+		return err
+	}
+	if !batch["ryw-2"] || batch["ryw-1"] {
+		t.Errorf("in-tx IsBlockedBatch = %v, want ryw-2 blocked, ryw-1 not", batch)
+	}
+	isBlocked, blockers, err := tx.IsBlocked(c, "ryw-2")
+	if err != nil {
+		return err
+	}
+	if !isBlocked || len(blockers) != 1 || blockers[0] != "ryw-1" {
+		t.Errorf("in-tx IsBlocked(ryw-2) = %v, %v, want true, [ryw-1]", isBlocked, blockers)
+	}
+	return nil
+}
+
+// assertInTxCountsAndEvents proves the grouped counts and durable event feed also
+// reflect the transaction's own uncommitted writes.
+func assertInTxCountsAndEvents(t *testing.T, c context.Context, tx storage.Transaction) error {
+	t.Helper()
+	// The two in-tx durable issues are visible through the grouped counts.
+	counts, err := tx.CountIssuesByGroup(c, types.IssueFilter{}, "status")
+	if err != nil {
+		return err
+	}
+	if sumCounts(counts) != 2 {
+		t.Errorf("in-tx CountIssuesByGroup total = %d, want 2 (both uncommitted issues)", sumCounts(counts))
+	}
+	// The in-tx create event is visible through the durable event feed.
+	evs, err := tx.EventsSince(c, storage.EventCursor{}, "ryw-1", 100)
+	if err != nil {
+		return err
+	}
+	if len(evs) == 0 {
+		t.Errorf("in-tx EventsSince(ryw-1) returned no events for the uncommitted create")
+	}
+	return nil
 }
 
 // --- Ready-work counts equivalence (perf/ready-counts) ---

--- a/internal/storage/dependency_queries.go
+++ b/internal/storage/dependency_queries.go
@@ -10,6 +10,14 @@ import (
 type DependencyQueryStore interface {
 	GetDependencyRecords(ctx context.Context, issueID string) ([]*types.Dependency, error)
 	GetDependencyRecordsForIssues(ctx context.Context, issueIDs []string) (map[string][]*types.Dependency, error)
+	// GetDependentRecords returns raw dependency rows whose target is targetID
+	// (the inbound edges), without hydrating the source issues. depType filters
+	// by dependency type ("" = all); results are ordered by source issue_id ASC,
+	// bounded by limit (0 = a store default, capped), and paged with afterID as
+	// a keyset continuation ("" = start). Mirrors the source-keyed
+	// GetDependencyRecords but in the target direction; unblocks target-side
+	// group membership reads that must see dangling children.
+	GetDependentRecords(ctx context.Context, targetID string, depType string, limit int, afterID string) ([]*types.Dependency, error)
 	GetAllDependencyRecords(ctx context.Context) (map[string][]*types.Dependency, error)
 	GetDependencyCounts(ctx context.Context, issueIDs []string) (map[string]*types.DependencyCounts, error)
 	GetBlockingInfoForIssues(ctx context.Context, issueIDs []string) (blockedByMap map[string][]string, blocksMap map[string][]string, parentMap map[string]string, err error)

--- a/internal/storage/dependency_queries.go
+++ b/internal/storage/dependency_queries.go
@@ -20,6 +20,14 @@ type DependencyQueryStore interface {
 	// group membership reads that must see dangling children. RAW: applies no
 	// visibility policy — the caller filters at hydration.
 	GetDependentRecords(ctx context.Context, targetID string, depType string, limit int, afterID string) ([]*types.Dependency, error)
+	// GetDependentRecordsForIssues returns raw dependency rows keyed by TARGET id:
+	// for each id in targetIDs, the rows whose target is that id (its inbound edges
+	// = its dependents), across both the durable and wisp dependency tables, ALL
+	// dep types (the caller filters), de-duped by row id. It is the batched,
+	// target-keyed mirror of GetDependencyRecordsForIssues — the whole-page read
+	// that answers "what does each of these ids block/gate" without a per-id
+	// fan-out. RAW: applies no visibility policy — the caller filters at hydration.
+	GetDependentRecordsForIssues(ctx context.Context, targetIDs []string) (map[string][]*types.Dependency, error)
 	// CountDependentRecords returns the total number of inbound edges of targetID
 	// (same predicate/scope as GetDependentRecords, depType "" = all), across
 	// both dependency tables, without paging. Callers that want a true total

--- a/internal/storage/dependency_queries.go
+++ b/internal/storage/dependency_queries.go
@@ -11,13 +11,21 @@ type DependencyQueryStore interface {
 	GetDependencyRecords(ctx context.Context, issueID string) ([]*types.Dependency, error)
 	GetDependencyRecordsForIssues(ctx context.Context, issueIDs []string) (map[string][]*types.Dependency, error)
 	// GetDependentRecords returns raw dependency rows whose target is targetID
-	// (the inbound edges), without hydrating the source issues. depType filters
-	// by dependency type ("" = all); results are ordered by source issue_id ASC,
-	// bounded by limit (0 = a store default, capped), and paged with afterID as
-	// a keyset continuation ("" = start). Mirrors the source-keyed
+	// (the inbound edges), without hydrating the source issues, spanning both the
+	// durable and wisp dependency tables. depType filters by dependency type
+	// ("" = all); results are ordered by the dependency row's primary id ASC,
+	// bounded by limit (0 = a store default, capped), and paged with afterID as a
+	// keyset continuation over that id ("" = start). Mirrors the source-keyed
 	// GetDependencyRecords but in the target direction; unblocks target-side
-	// group membership reads that must see dangling children.
+	// group membership reads that must see dangling children. RAW: applies no
+	// visibility policy — the caller filters at hydration.
 	GetDependentRecords(ctx context.Context, targetID string, depType string, limit int, afterID string) ([]*types.Dependency, error)
+	// CountDependentRecords returns the total number of inbound edges of targetID
+	// (same predicate/scope as GetDependentRecords, depType "" = all), across
+	// both dependency tables, without paging. Callers that want a true total
+	// membership count need it without walking every page. RAW count — no
+	// visibility policy.
+	CountDependentRecords(ctx context.Context, targetID string, depType string) (int, error)
 	GetAllDependencyRecords(ctx context.Context) (map[string][]*types.Dependency, error)
 	GetDependencyCounts(ctx context.Context, issueIDs []string) (map[string]*types.DependencyCounts, error)
 	GetBlockingInfoForIssues(ctx context.Context, issueIDs []string) (blockedByMap map[string][]string, blocksMap map[string][]string, parentMap map[string]string, err error)

--- a/internal/storage/dependency_queries.go
+++ b/internal/storage/dependency_queries.go
@@ -38,6 +38,14 @@ type DependencyQueryStore interface {
 	GetDependencyCounts(ctx context.Context, issueIDs []string) (map[string]*types.DependencyCounts, error)
 	GetBlockingInfoForIssues(ctx context.Context, issueIDs []string) (blockedByMap map[string][]string, blocksMap map[string][]string, parentMap map[string]string, err error)
 	IsBlocked(ctx context.Context, issueID string) (bool, []string, error)
+	// IsBlockedBatch returns the denormalized, TRANSITIVE is_blocked flag for a
+	// page of ids in one batched read (SELECT id, is_blocked FROM {issues,wisps}
+	// WHERE id IN (...), batched at queryBatchSize) — the same value IsBlocked
+	// returns per id, without an N-call fan-out or a per-row blocker recompute.
+	// It reflects inherited/ancestor blockedness (a child of a blocked parent is
+	// blocked with no direct blocking edge). ids present in neither table are
+	// absent from the map; callers treat absent as not-blocked.
+	IsBlockedBatch(ctx context.Context, ids []string) (map[string]bool, error)
 	GetNewlyUnblockedByClose(ctx context.Context, closedIssueID string) ([]*types.Issue, error)
 	DetectCycles(ctx context.Context) ([][]*types.Issue, error)
 	FindWispDependentsRecursive(ctx context.Context, ids []string) (map[string]bool, error)

--- a/internal/storage/dolt/claim_conflict_test.go
+++ b/internal/storage/dolt/claim_conflict_test.go
@@ -1,0 +1,78 @@
+package dolt
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/storage"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// recoverTail mirrors beads.ParseClaimConflict's extraction: it reconstructs the
+// marker from the storage sentinel + fragment (the single source of truth) and
+// returns the trailing token. Kept local because internal/storage/dolt cannot
+// import the root beads package (import cycle); the root package's own
+// claim_roundtrip_test.go exercises the real ParseClaimConflict end to end.
+func recoverTail(msg string, sentinel error, fragment string) string {
+	marker := sentinel.Error() + fragment
+	if i := strings.LastIndex(msg, marker); i >= 0 {
+		return msg[i+len(marker):]
+	}
+	return ""
+}
+
+// TestClaimConflictFormatRoundTrip is the producer-tied tripwire for the claim
+// string coupling: it drives the REAL claim path (issueops.ClaimIssueInTx via
+// DoltStore.ClaimIssue) into both conflict branches and proves the emitted error
+// (a) satisfies errors.Is against the storage sentinel and (b) still carries the
+// assignee/status recoverable via the exported storage fragments that
+// beads.ParseClaimConflict keys on. If the producer stops wrapping with the
+// fragment, this test goes red instead of ParseClaimConflict silently returning
+// an empty field to a caller.
+func TestClaimConflictFormatRoundTrip(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	mk := func(id string) {
+		iss := &types.Issue{ID: id, Title: id, Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask}
+		if err := store.CreateIssue(ctx, iss, "tester"); err != nil {
+			t.Fatalf("create %s: %v", id, err)
+		}
+	}
+
+	// Already-claimed branch: alice holds it, bob's claim conflicts.
+	mk("cc-held")
+	if err := store.ClaimIssue(ctx, "cc-held", "alice"); err != nil {
+		t.Fatalf("claim as alice: %v", err)
+	}
+	err := store.ClaimIssue(ctx, "cc-held", "bob")
+	if err == nil {
+		t.Fatalf("bob's claim of alice's issue unexpectedly succeeded")
+	}
+	if !errors.Is(err, storage.ErrAlreadyClaimed) {
+		t.Fatalf("claim conflict does not wrap ErrAlreadyClaimed: %v", err)
+	}
+	if got := recoverTail(err.Error(), storage.ErrAlreadyClaimed, storage.ClaimedByFragment); got != "alice" {
+		t.Fatalf("recovered assignee = %q, want %q (from %q)", got, "alice", err.Error())
+	}
+
+	// Not-claimable branch: a closed issue is unclaimable, status embedded.
+	mk("cc-closed")
+	if err := store.CloseIssue(ctx, "cc-closed", "done", "tester", ""); err != nil {
+		t.Fatalf("close cc-closed: %v", err)
+	}
+	err = store.ClaimIssue(ctx, "cc-closed", "carol")
+	if err == nil {
+		t.Fatalf("claim of a closed issue unexpectedly succeeded")
+	}
+	if !errors.Is(err, storage.ErrNotClaimable) {
+		t.Fatalf("closed-claim error does not wrap ErrNotClaimable: %v", err)
+	}
+	if got := recoverTail(err.Error(), storage.ErrNotClaimable, storage.NotClaimableStatusFragment); got != string(types.StatusClosed) {
+		t.Fatalf("recovered status = %q, want %q (from %q)", got, types.StatusClosed, err.Error())
+	}
+}

--- a/internal/storage/dolt/dependencies.go
+++ b/internal/storage/dolt/dependencies.go
@@ -381,6 +381,21 @@ func (s *DoltStore) IsBlocked(ctx context.Context, issueID string) (bool, []stri
 	return blocked, blockers, nil
 }
 
+// IsBlockedBatch returns the denormalized transitive is_blocked flag for each id
+// in one batched read. Delegates to issueops.IsBlockedBatchInTx.
+func (s *DoltStore) IsBlockedBatch(ctx context.Context, ids []string) (map[string]bool, error) {
+	var result map[string]bool
+	err := s.withReadTx(ctx, func(tx *sql.Tx) error {
+		var err error
+		result, err = issueops.IsBlockedBatchInTx(ctx, tx, ids)
+		return err
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to batch-check blockers: %w", err)
+	}
+	return result, nil
+}
+
 // GetNewlyUnblockedByClose finds issues that become unblocked when an issue is closed.
 func (s *DoltStore) GetNewlyUnblockedByClose(ctx context.Context, closedIssueID string) ([]*types.Issue, error) {
 	var result []*types.Issue

--- a/internal/storage/dolt/dependencies.go
+++ b/internal/storage/dolt/dependencies.go
@@ -266,6 +266,18 @@ func (s *DoltStore) GetDependentRecords(ctx context.Context, targetID string, de
 	return result, err
 }
 
+// CountDependentRecords returns the total inbound-edge count of targetID across
+// both dependency tables. Delegates to issueops.CountDependentRecordsInTx.
+func (s *DoltStore) CountDependentRecords(ctx context.Context, targetID string, depType string) (int, error) {
+	var n int
+	err := s.withReadTx(ctx, func(tx *sql.Tx) error {
+		var err error
+		n, err = issueops.CountDependentRecordsInTx(ctx, tx, targetID, depType)
+		return err
+	})
+	return n, err
+}
+
 // GetAllDependencyRecords returns all dependency records.
 // Delegates to issueops.GetAllDependencyRecordsInTx for shared query logic.
 func (s *DoltStore) GetAllDependencyRecords(ctx context.Context) (map[string][]*types.Dependency, error) {

--- a/internal/storage/dolt/dependencies.go
+++ b/internal/storage/dolt/dependencies.go
@@ -278,6 +278,19 @@ func (s *DoltStore) CountDependentRecords(ctx context.Context, targetID string, 
 	return n, err
 }
 
+// GetDependentRecordsForIssues returns the raw inbound dependency rows for a SET
+// of target ids in one batched read, keyed by target id. Delegates to
+// issueops.GetDependentRecordsForIssuesInTx for shared query logic.
+func (s *DoltStore) GetDependentRecordsForIssues(ctx context.Context, targetIDs []string) (map[string][]*types.Dependency, error) {
+	var result map[string][]*types.Dependency
+	err := s.withReadTx(ctx, func(tx *sql.Tx) error {
+		var err error
+		result, err = issueops.GetDependentRecordsForIssuesInTx(ctx, tx, targetIDs)
+		return err
+	})
+	return result, err
+}
+
 // GetAllDependencyRecords returns all dependency records.
 // Delegates to issueops.GetAllDependencyRecordsInTx for shared query logic.
 func (s *DoltStore) GetAllDependencyRecords(ctx context.Context) (map[string][]*types.Dependency, error) {

--- a/internal/storage/dolt/dependencies.go
+++ b/internal/storage/dolt/dependencies.go
@@ -253,6 +253,19 @@ func (s *DoltStore) GetDependencyRecords(ctx context.Context, issueID string) ([
 	return scanDependencyRows(rows)
 }
 
+// GetDependentRecords returns raw dependency rows whose target is issueID,
+// without hydrating the source issues. Delegates to
+// issueops.GetDependentRecordsInTx for shared query logic.
+func (s *DoltStore) GetDependentRecords(ctx context.Context, targetID string, depType string, limit int, afterID string) ([]*types.Dependency, error) {
+	var result []*types.Dependency
+	err := s.withReadTx(ctx, func(tx *sql.Tx) error {
+		var err error
+		result, err = issueops.GetDependentRecordsInTx(ctx, tx, targetID, depType, limit, afterID)
+		return err
+	})
+	return result, err
+}
+
 // GetAllDependencyRecords returns all dependency records.
 // Delegates to issueops.GetAllDependencyRecordsInTx for shared query logic.
 func (s *DoltStore) GetAllDependencyRecords(ctx context.Context) (map[string][]*types.Dependency, error) {

--- a/internal/storage/dolt/dependents_records_test.go
+++ b/internal/storage/dolt/dependents_records_test.go
@@ -3,6 +3,7 @@ package dolt
 import (
 	"testing"
 
+	"github.com/steveyegge/beads/internal/storage/depid"
 	"github.com/steveyegge/beads/internal/types"
 )
 
@@ -175,6 +176,111 @@ func TestCountDependentRecords(t *testing.T) {
 		t.Fatalf("CountDependentRecords(leaf): %v", err)
 	} else if n != 0 {
 		t.Fatalf("CountDependentRecords(leaf) = %d, want 0", n)
+	}
+}
+
+// TestDependentRecordsCrossTableCollision seeds the SAME logical edge in BOTH
+// the durable and wisp dependency tables — they share one depid-derived id
+// because depid.New keys on (issue_id, target) and omits the table — and proves
+// the target-keyed reads treat it as a single inbound edge: GetDependentRecords
+// returns one row per id (the durable copy), CountDependentRecords equals the
+// distinct total (not the sum of two per-table COUNTs), and keyset paging is
+// stable across the collision (no dup, no drop). A collision like this arises
+// from a wisp promoted to durable or two Dolt clones merged.
+func TestDependentRecordsCrossTableCollision(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	mk := func(id string, ephemeral bool) {
+		iss := &types.Issue{ID: id, Title: id, Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask, Ephemeral: ephemeral}
+		if err := store.CreateIssue(ctx, iss, "tester"); err != nil {
+			t.Fatalf("create %s: %v", id, err)
+		}
+	}
+	mk("cc-target", false)
+	mk("cc-a", false) // durable source of the collision edge
+	mk("cc-c", false) // durable-only dependent
+	mk("cc-w", true)  // genuine wisp-only dependent
+
+	add := func(src string) {
+		if err := store.AddDependency(ctx, &types.Dependency{IssueID: src, DependsOnID: "cc-target", Type: types.DepBlocks}, "tester"); err != nil {
+			t.Fatalf("add dep %s: %v", src, err)
+		}
+	}
+	add("cc-a") // -> dependencies, id = depid.New("cc-a", "cc-target")
+	add("cc-c") // -> dependencies
+	add("cc-w") // wisp source -> wisp_dependencies
+
+	// Force the collision: the SAME (cc-a, cc-target) edge into wisp_dependencies
+	// with the same depid. FK checks are relaxed because cc-a is not a wisp — the
+	// point is to reproduce the post-merge/promotion state where one edge exists
+	// in both tables under one id.
+	collisionID := depid.New("cc-a", "cc-target")
+	if _, err := store.db.ExecContext(ctx, "SET FOREIGN_KEY_CHECKS = 0"); err != nil {
+		t.Fatalf("disable FK checks: %v", err)
+	}
+	if _, err := store.db.ExecContext(ctx,
+		"INSERT INTO wisp_dependencies (id, issue_id, depends_on_issue_id, type, created_by) VALUES (?, ?, ?, 'blocks', 'tester')",
+		collisionID, "cc-a", "cc-target"); err != nil {
+		t.Fatalf("seed collision row: %v", err)
+	}
+	if _, err := store.db.ExecContext(ctx, "SET FOREIGN_KEY_CHECKS = 1"); err != nil {
+		t.Fatalf("re-enable FK checks: %v", err)
+	}
+
+	// One row per id: cc-a appears once (its durable copy), never twice.
+	all, err := store.GetDependentRecords(ctx, "cc-target", "", 100, "")
+	if err != nil {
+		t.Fatalf("GetDependentRecords: %v", err)
+	}
+	ids := map[string]int{}
+	srcs := map[string]bool{}
+	for _, d := range all {
+		ids[d.ID]++
+		srcs[d.IssueID] = true
+	}
+	for id, n := range ids {
+		if n != 1 {
+			t.Fatalf("id %s appears %d times in one page; want exactly 1 (collision not de-duped)", id, n)
+		}
+	}
+	if len(srcs) != 3 || !srcs["cc-a"] || !srcs["cc-c"] || !srcs["cc-w"] {
+		t.Fatalf("dependent sources = %v, want {cc-a, cc-c, cc-w}", srcs)
+	}
+
+	// Count equals the distinct total (3), not the sum of two per-table COUNTs (4).
+	if n, err := store.CountDependentRecords(ctx, "cc-target", ""); err != nil {
+		t.Fatalf("CountDependentRecords: %v", err)
+	} else if n != 3 {
+		t.Fatalf("CountDependentRecords = %d, want 3 (distinct); a sum-of-counts would report 4", n)
+	}
+
+	// Keyset paging (size 1) is stable across the collision: 3 distinct sources,
+	// each once, no drop.
+	seen := map[string]bool{}
+	after := ""
+	for i := 0; i < 10; i++ {
+		page, err := store.GetDependentRecords(ctx, "cc-target", "", 1, after)
+		if err != nil {
+			t.Fatalf("page after %q: %v", after, err)
+		}
+		if len(page) == 0 {
+			break
+		}
+		if len(page) != 1 {
+			t.Fatalf("page size = %d, want 1", len(page))
+		}
+		if seen[page[0].IssueID] {
+			t.Fatalf("duplicate source %q across pages (collision drop/dup)", page[0].IssueID)
+		}
+		seen[page[0].IssueID] = true
+		after = page[0].ID
+	}
+	if len(seen) != 3 || !seen["cc-a"] || !seen["cc-c"] || !seen["cc-w"] {
+		t.Fatalf("paged sources = %v, want 3 distinct {cc-a, cc-c, cc-w}", seen)
 	}
 }
 

--- a/internal/storage/dolt/dependents_records_test.go
+++ b/internal/storage/dolt/dependents_records_test.go
@@ -326,6 +326,105 @@ func TestGetDependentRecordsLimitClamp(t *testing.T) {
 	}
 }
 
+// TestGetDependentRecordsForIssues verifies the BATCHED target-keyed dependents
+// read: it keys inbound edges by target across a SET of targets in ONE call,
+// spans both dependency tables (durable + wisp sources), returns the FULL dep-type
+// set (blocks, waits-for, conditional-blocks, parent-child — no type is dropped,
+// unlike GetBlockingInfoForIssues which restricts to blocks/parent-child), keeps
+// each row's real dep_type, and never surfaces an edge whose target is not the
+// key (a decoy where the id is the SOURCE stays out).
+func TestGetDependentRecordsForIssues(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	mk := func(id string, ephemeral bool) {
+		iss := &types.Issue{ID: id, Title: id, Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask, Ephemeral: ephemeral}
+		if err := store.CreateIssue(ctx, iss, "tester"); err != nil {
+			t.Fatalf("create %s: %v", id, err)
+		}
+	}
+	mk("bt-x", false)     // target X
+	mk("bt-y", false)     // target Y
+	mk("bt-blk", false)   // blocks -> X (durable)
+	mk("bt-wait", false)  // waits-for -> X (durable)
+	mk("bt-cond", true)   // conditional-blocks -> X from a WISP source (wisp_dependencies)
+	mk("bt-child", false) // parent-child -> X (durable)
+	mk("bt-yblk", false)  // blocks -> Y (durable)
+	mk("bt-z", false)     // decoy target: X -> Z (X is the SOURCE)
+
+	addDep := func(src, tgt string, typ types.DependencyType) {
+		if err := store.AddDependency(ctx, &types.Dependency{IssueID: src, DependsOnID: tgt, Type: typ}, "tester"); err != nil {
+			t.Fatalf("add dep %s -> %s (%s): %v", src, tgt, typ, err)
+		}
+	}
+	addDep("bt-blk", "bt-x", types.DepBlocks)
+	addDep("bt-wait", "bt-x", types.DepWaitsFor)
+	addDep("bt-cond", "bt-x", types.DepConditionalBlocks) // wisp source -> wisp_dependencies
+	addDep("bt-child", "bt-x", types.DepParentChild)
+	addDep("bt-yblk", "bt-y", types.DepBlocks)
+	addDep("bt-x", "bt-z", types.DepBlocks) // decoy: X is the SOURCE here
+
+	typesBySrc := func(deps []*types.Dependency, target string) map[string]types.DependencyType {
+		out := map[string]types.DependencyType{}
+		for _, d := range deps {
+			if d.DependsOnID != target {
+				t.Fatalf("row keyed under %s has target %s (must equal the key)", target, d.DependsOnID)
+			}
+			if d.ID == "" {
+				t.Fatalf("dependent row has empty ID (the row primary key): %+v", d)
+			}
+			out[d.IssueID] = d.Type
+		}
+		return out
+	}
+
+	byTarget, err := store.GetDependentRecordsForIssues(ctx, []string{"bt-x", "bt-y"})
+	if err != nil {
+		t.Fatalf("GetDependentRecordsForIssues: %v", err)
+	}
+
+	// X: all four inbound edges, keyed by target, spanning both tables, with the
+	// FULL type set and real dep_type preserved (no drop of waits-for/conditional-
+	// blocks, no drop of the wisp-source or the parent-child edge).
+	x := typesBySrc(byTarget["bt-x"], "bt-x")
+	if len(x) != 4 {
+		t.Fatalf("X dependents = %v, want 4 (blocks, waits-for, conditional-blocks[wisp], parent-child)", x)
+	}
+	if x["bt-blk"] != types.DepBlocks || x["bt-wait"] != types.DepWaitsFor ||
+		x["bt-cond"] != types.DepConditionalBlocks || x["bt-child"] != types.DepParentChild {
+		t.Fatalf("X dependents lost a real dep_type or dropped a wisp/blocking edge: %v", x)
+	}
+	if _, bad := x["bt-z"]; bad {
+		t.Fatalf("decoy edge X->Z surfaced as an inbound edge of X: %v", x)
+	}
+
+	// Y: its single inbound blocks edge, keyed separately in the same batch.
+	y := typesBySrc(byTarget["bt-y"], "bt-y")
+	if len(y) != 1 || y["bt-yblk"] != types.DepBlocks {
+		t.Fatalf("Y dependents = %v, want {bt-yblk: blocks}", y)
+	}
+
+	// A batch element with no inbound edges is simply absent from the map (bt-blk
+	// only has an OUTGOING edge), never an error or a phantom key.
+	leaf, err := store.GetDependentRecordsForIssues(ctx, []string{"bt-blk"})
+	if err != nil {
+		t.Fatalf("GetDependentRecordsForIssues(leaf): %v", err)
+	}
+	if got, present := leaf["bt-blk"]; present {
+		t.Fatalf("source-only node bt-blk has inbound edges %v, want absent", got)
+	}
+
+	// Empty input is a valid empty map, not an error.
+	if got, err := store.GetDependentRecordsForIssues(ctx, nil); err != nil {
+		t.Fatalf("GetDependentRecordsForIssues(nil): %v", err)
+	} else if len(got) != 0 {
+		t.Fatalf("GetDependentRecordsForIssues(nil) = %v, want empty", got)
+	}
+}
+
 // pad renders i as a zero-padded 4-digit string for stable id construction.
 func pad(i int) string {
 	s := ""

--- a/internal/storage/dolt/dependents_records_test.go
+++ b/internal/storage/dolt/dependents_records_test.go
@@ -1,0 +1,131 @@
+package dolt
+
+import (
+	"testing"
+
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// TestGetDependentRecords verifies the target-keyed raw dependents read:
+// direction correctness (rows whose target is X, not whose source is X), the
+// dep-type filter, deterministic issue_id ordering, keyset paging, and that it
+// does not drop rows based on source status (raw, no source hydration).
+func TestGetDependentRecords(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	// Target X (the "epic"/group), the sources pointing AT it, and a decoy that
+	// X itself points at (to prove direction). ids are chosen so issue_id ASC is
+	// [s1, s2, s3, s4].
+	mk := func(id string) *types.Issue {
+		iss := &types.Issue{ID: id, Title: id, Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask}
+		if err := store.CreateIssue(ctx, iss, "tester"); err != nil {
+			t.Fatalf("create %s: %v", id, err)
+		}
+		return iss
+	}
+	target := mk("dr-target")
+	block := mk("dr-s1-block")   // blocks -> X
+	childA := mk("dr-s2-childa") // parent-child -> X
+	childB := mk("dr-s3-childb") // parent-child -> X
+	closed := mk("dr-s4-closed") // parent-child -> X, then closed
+	other := mk("dr-other")      // X -> other (decoy: source is X)
+
+	addDep := func(src, tgt string, typ types.DependencyType) {
+		if err := store.AddDependency(ctx, &types.Dependency{IssueID: src, DependsOnID: tgt, Type: typ}, "tester"); err != nil {
+			t.Fatalf("add dep %s -> %s (%s): %v", src, tgt, typ, err)
+		}
+	}
+	addDep(block.ID, target.ID, types.DepBlocks)
+	addDep(childA.ID, target.ID, types.DepParentChild)
+	addDep(childB.ID, target.ID, types.DepParentChild)
+	addDep(closed.ID, target.ID, types.DepParentChild)
+	addDep(target.ID, other.ID, types.DepBlocks) // decoy: target is the SOURCE here
+	if err := store.CloseIssue(ctx, closed.ID, "done", "tester", ""); err != nil {
+		t.Fatalf("close %s: %v", closed.ID, err)
+	}
+
+	srcIDs := func(deps []*types.Dependency) []string {
+		out := make([]string, len(deps))
+		for i, d := range deps {
+			out[i] = d.IssueID
+		}
+		return out
+	}
+
+	// Direction + raw: all inbound edges of X, regardless of source status. The
+	// decoy (target-is-X-as-source) must not appear; the closed source must.
+	all, err := store.GetDependentRecords(ctx, target.ID, "", 100, "")
+	if err != nil {
+		t.Fatalf("GetDependentRecords(all): %v", err)
+	}
+	wantAll := []string{block.ID, childA.ID, childB.ID, closed.ID}
+	if got := srcIDs(all); !sameOrderedIDs(got, wantAll) {
+		t.Fatalf("inbound sources = %v, want %v (ordered issue_id ASC)", got, wantAll)
+	}
+	for _, d := range all {
+		if d.DependsOnID != target.ID {
+			t.Fatalf("row %s has target %s, want %s", d.IssueID, d.DependsOnID, target.ID)
+		}
+		if d.IssueID == target.ID {
+			t.Fatalf("direction violation: returned a row whose SOURCE is the target")
+		}
+	}
+
+	// The decoy edge is discoverable from the OTHER direction (target=other).
+	fromOther, err := store.GetDependentRecords(ctx, other.ID, "", 100, "")
+	if err != nil {
+		t.Fatalf("GetDependentRecords(other): %v", err)
+	}
+	if got := srcIDs(fromOther); !sameOrderedIDs(got, []string{target.ID}) {
+		t.Fatalf("inbound sources of other = %v, want %v", got, []string{target.ID})
+	}
+
+	// Type filter: only parent-child edges.
+	pc, err := store.GetDependentRecords(ctx, target.ID, string(types.DepParentChild), 100, "")
+	if err != nil {
+		t.Fatalf("GetDependentRecords(parent-child): %v", err)
+	}
+	if got := srcIDs(pc); !sameOrderedIDs(got, []string{childA.ID, childB.ID, closed.ID}) {
+		t.Fatalf("parent-child sources = %v, want %v", got, []string{childA.ID, childB.ID, closed.ID})
+	}
+
+	// Keyset paging: page size 1 walks all four inbound sources in issue_id
+	// order with no gaps or duplicates.
+	var paged []string
+	after := ""
+	for {
+		page, err := store.GetDependentRecords(ctx, target.ID, "", 1, after)
+		if err != nil {
+			t.Fatalf("GetDependentRecords(page after %q): %v", after, err)
+		}
+		if len(page) == 0 {
+			break
+		}
+		if len(page) != 1 {
+			t.Fatalf("page size = %d, want 1", len(page))
+		}
+		paged = append(paged, page[0].IssueID)
+		after = page[0].IssueID
+	}
+	if !sameOrderedIDs(paged, wantAll) {
+		t.Fatalf("paged sources = %v, want %v", paged, wantAll)
+	}
+}
+
+// sameOrderedIDs compares two string slices positionally (order-sensitive), since
+// GetDependentRecords returns rows in issue_id ASC order.
+func sameOrderedIDs(got, want []string) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/storage/dolt/dependents_records_test.go
+++ b/internal/storage/dolt/dependents_records_test.go
@@ -8,8 +8,10 @@ import (
 
 // TestGetDependentRecords verifies the target-keyed raw dependents read:
 // direction correctness (rows whose target is X, not whose source is X), the
-// dep-type filter, deterministic issue_id ordering, keyset paging, and that it
-// does not drop rows based on source status (raw, no source hydration).
+// dep-type filter, that rows span BOTH the durable and wisp dependency tables,
+// row-id keyset paging with no drop/dup across the two-table boundary, and that
+// it does not drop rows on source status (raw, no source hydration). Ordering is
+// by the dependency row's primary id (a UUIDv5), so assertions are set-based.
 func TestGetDependentRecords(t *testing.T) {
 	store, cleanup := setupTestStore(t)
 	defer cleanup()
@@ -17,22 +19,19 @@ func TestGetDependentRecords(t *testing.T) {
 	ctx, cancel := testContext(t)
 	defer cancel()
 
-	// Target X (the "epic"/group), the sources pointing AT it, and a decoy that
-	// X itself points at (to prove direction). ids are chosen so issue_id ASC is
-	// [s1, s2, s3, s4].
-	mk := func(id string) *types.Issue {
-		iss := &types.Issue{ID: id, Title: id, Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask}
+	mk := func(id string, ephemeral bool) *types.Issue {
+		iss := &types.Issue{ID: id, Title: id, Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask, Ephemeral: ephemeral}
 		if err := store.CreateIssue(ctx, iss, "tester"); err != nil {
 			t.Fatalf("create %s: %v", id, err)
 		}
 		return iss
 	}
-	target := mk("dr-target")
-	block := mk("dr-s1-block")   // blocks -> X
-	childA := mk("dr-s2-childa") // parent-child -> X
-	childB := mk("dr-s3-childb") // parent-child -> X
-	closed := mk("dr-s4-closed") // parent-child -> X, then closed
-	other := mk("dr-other")      // X -> other (decoy: source is X)
+	target := mk("dr-target", false)
+	block := mk("dr-s1-block", false)   // blocks -> X (durable, `dependencies`)
+	childA := mk("dr-s2-childa", false) // parent-child -> X (durable)
+	closed := mk("dr-s3-closed", false) // parent-child -> X, then closed (durable)
+	wispDep := mk("dr-s4-wisp", true)   // blocks -> X from a WISP source (`wisp_dependencies`)
+	other := mk("dr-other", false)      // X -> other (decoy: source is X)
 
 	addDep := func(src, tgt string, typ types.DependencyType) {
 		if err := store.AddDependency(ctx, &types.Dependency{IssueID: src, DependsOnID: tgt, Type: typ}, "tester"); err != nil {
@@ -41,32 +40,43 @@ func TestGetDependentRecords(t *testing.T) {
 	}
 	addDep(block.ID, target.ID, types.DepBlocks)
 	addDep(childA.ID, target.ID, types.DepParentChild)
-	addDep(childB.ID, target.ID, types.DepParentChild)
 	addDep(closed.ID, target.ID, types.DepParentChild)
-	addDep(target.ID, other.ID, types.DepBlocks) // decoy: target is the SOURCE here
+	addDep(wispDep.ID, target.ID, types.DepBlocks) // wisp source -> durable target (wisp_dependencies)
+	addDep(target.ID, other.ID, types.DepBlocks)   // decoy: target is the SOURCE here
 	if err := store.CloseIssue(ctx, closed.ID, "done", "tester", ""); err != nil {
 		t.Fatalf("close %s: %v", closed.ID, err)
 	}
 
-	srcIDs := func(deps []*types.Dependency) []string {
-		out := make([]string, len(deps))
-		for i, d := range deps {
-			out[i] = d.IssueID
+	srcSet := func(deps []*types.Dependency) map[string]bool {
+		out := map[string]bool{}
+		for _, d := range deps {
+			out[d.IssueID] = true
 		}
 		return out
 	}
+	eqSet := func(t *testing.T, got map[string]bool, want ...string) {
+		t.Helper()
+		if len(got) != len(want) {
+			t.Fatalf("dependent sources = %v, want %v", got, want)
+		}
+		for _, w := range want {
+			if !got[w] {
+				t.Fatalf("dependent sources = %v, missing %q", got, w)
+			}
+		}
+	}
 
-	// Direction + raw: all inbound edges of X, regardless of source status. The
-	// decoy (target-is-X-as-source) must not appear; the closed source must.
+	// Direction + raw + two-table span: all inbound edges of X regardless of
+	// source status, INCLUDING the wisp source; the decoy must not appear.
 	all, err := store.GetDependentRecords(ctx, target.ID, "", 100, "")
 	if err != nil {
 		t.Fatalf("GetDependentRecords(all): %v", err)
 	}
-	wantAll := []string{block.ID, childA.ID, childB.ID, closed.ID}
-	if got := srcIDs(all); !sameOrderedIDs(got, wantAll) {
-		t.Fatalf("inbound sources = %v, want %v (ordered issue_id ASC)", got, wantAll)
-	}
+	eqSet(t, srcSet(all), block.ID, childA.ID, closed.ID, wispDep.ID)
 	for _, d := range all {
+		if d.ID == "" {
+			t.Fatalf("dependent row has empty ID (the keyset cursor): %+v", d)
+		}
 		if d.DependsOnID != target.ID {
 			t.Fatalf("row %s has target %s, want %s", d.IssueID, d.DependsOnID, target.ID)
 		}
@@ -80,22 +90,19 @@ func TestGetDependentRecords(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetDependentRecords(other): %v", err)
 	}
-	if got := srcIDs(fromOther); !sameOrderedIDs(got, []string{target.ID}) {
-		t.Fatalf("inbound sources of other = %v, want %v", got, []string{target.ID})
-	}
+	eqSet(t, srcSet(fromOther), target.ID)
 
-	// Type filter: only parent-child edges.
+	// Type filter: only parent-child edges (the wisp edge is 'blocks', excluded).
 	pc, err := store.GetDependentRecords(ctx, target.ID, string(types.DepParentChild), 100, "")
 	if err != nil {
 		t.Fatalf("GetDependentRecords(parent-child): %v", err)
 	}
-	if got := srcIDs(pc); !sameOrderedIDs(got, []string{childA.ID, childB.ID, closed.ID}) {
-		t.Fatalf("parent-child sources = %v, want %v", got, []string{childA.ID, childB.ID, closed.ID})
-	}
+	eqSet(t, srcSet(pc), childA.ID, closed.ID)
 
-	// Keyset paging: page size 1 walks all four inbound sources in issue_id
-	// order with no gaps or duplicates.
-	var paged []string
+	// Row-id keyset paging across the two-table boundary: page size 1 walks all
+	// four inbound sources (three durable + one wisp) with no gaps or duplicates.
+	seen := map[string]bool{}
+	var pages int
 	after := ""
 	for {
 		page, err := store.GetDependentRecords(ctx, target.ID, "", 1, after)
@@ -108,24 +115,116 @@ func TestGetDependentRecords(t *testing.T) {
 		if len(page) != 1 {
 			t.Fatalf("page size = %d, want 1", len(page))
 		}
-		paged = append(paged, page[0].IssueID)
-		after = page[0].IssueID
+		if seen[page[0].IssueID] {
+			t.Fatalf("duplicate source %q across pages (keyset drop/dup)", page[0].IssueID)
+		}
+		seen[page[0].IssueID] = true
+		after = page[0].ID
+		if pages++; pages > 10 {
+			t.Fatalf("paging did not terminate")
+		}
 	}
-	if !sameOrderedIDs(paged, wantAll) {
-		t.Fatalf("paged sources = %v, want %v", paged, wantAll)
+	eqSet(t, seen, block.ID, childA.ID, closed.ID, wispDep.ID)
+}
+
+// TestCountDependentRecords verifies the un-paged total matches the paged read's
+// membership, spans both tables, and honors the type filter.
+func TestCountDependentRecords(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	mk := func(id string, ephemeral bool) {
+		iss := &types.Issue{ID: id, Title: id, Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask, Ephemeral: ephemeral}
+		if err := store.CreateIssue(ctx, iss, "tester"); err != nil {
+			t.Fatalf("create %s: %v", id, err)
+		}
+	}
+	mk("cd-target", false)
+	mk("cd-s1", false)
+	mk("cd-s2", false)
+	mk("cd-w", true)
+	add := func(src string, typ types.DependencyType) {
+		if err := store.AddDependency(ctx, &types.Dependency{IssueID: src, DependsOnID: "cd-target", Type: typ}, "tester"); err != nil {
+			t.Fatalf("add dep %s: %v", src, err)
+		}
+	}
+	add("cd-s1", types.DepBlocks)
+	add("cd-s2", types.DepParentChild)
+	add("cd-w", types.DepBlocks) // wisp source (wisp_dependencies)
+
+	if n, err := store.CountDependentRecords(ctx, "cd-target", ""); err != nil {
+		t.Fatalf("CountDependentRecords: %v", err)
+	} else if n != 3 {
+		t.Fatalf("CountDependentRecords(all) = %d, want 3 (2 durable + 1 wisp)", n)
+	}
+	if n, err := store.CountDependentRecords(ctx, "cd-target", string(types.DepBlocks)); err != nil {
+		t.Fatalf("CountDependentRecords(blocks): %v", err)
+	} else if n != 2 {
+		t.Fatalf("CountDependentRecords(blocks) = %d, want 2 (cd-s1 durable + cd-w wisp)", n)
+	}
+	if n, err := store.CountDependentRecords(ctx, "cd-target", string(types.DepParentChild)); err != nil {
+		t.Fatalf("CountDependentRecords(parent-child): %v", err)
+	} else if n != 1 {
+		t.Fatalf("CountDependentRecords(parent-child) = %d, want 1", n)
+	}
+	// A target with no dependents counts zero, not an error.
+	if n, err := store.CountDependentRecords(ctx, "cd-s1", ""); err != nil {
+		t.Fatalf("CountDependentRecords(leaf): %v", err)
+	} else if n != 0 {
+		t.Fatalf("CountDependentRecords(leaf) = %d, want 0", n)
 	}
 }
 
-// sameOrderedIDs compares two string slices positionally (order-sensitive), since
-// GetDependentRecords returns rows in issue_id ASC order.
-func sameOrderedIDs(got, want []string) bool {
-	if len(got) != len(want) {
-		return false
+// TestGetDependentRecordsLimitClamp verifies the self-clamp (default 100, cap 500).
+func TestGetDependentRecordsLimitClamp(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	if err := store.CreateIssue(ctx, &types.Issue{ID: "lc-target", Title: "t", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask}, "tester"); err != nil {
+		t.Fatalf("create target: %v", err)
 	}
-	for i := range want {
-		if got[i] != want[i] {
-			return false
+	// 120 durable dependents -> more than the default clamp (100), fewer than
+	// the cap (500), so we can observe the default kick in without seeding 500.
+	const n = 120
+	for i := 0; i < n; i++ {
+		id := "lc-s" + pad(i)
+		if err := store.CreateIssue(ctx, &types.Issue{ID: id, Title: id, Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask}, "tester"); err != nil {
+			t.Fatalf("create %s: %v", id, err)
+		}
+		if err := store.AddDependency(ctx, &types.Dependency{IssueID: id, DependsOnID: "lc-target", Type: types.DepBlocks}, "tester"); err != nil {
+			t.Fatalf("add dep %s: %v", id, err)
 		}
 	}
-	return true
+
+	// limit <= 0 => issueops.defaultDependentRecordsLimit (100).
+	def, err := store.GetDependentRecords(ctx, "lc-target", "", 0, "")
+	if err != nil {
+		t.Fatalf("GetDependentRecords(limit=0): %v", err)
+	}
+	if len(def) != 100 {
+		t.Fatalf("default clamp: got %d rows, want 100", len(def))
+	}
+	// A limit above the total returns the total (and is under the 500 cap).
+	full, err := store.GetDependentRecords(ctx, "lc-target", "", 100000, "")
+	if err != nil {
+		t.Fatalf("GetDependentRecords(limit=100000): %v", err)
+	}
+	if len(full) != n {
+		t.Fatalf("clamp with limit>total: got %d rows, want %d", len(full), n)
+	}
+}
+
+// pad renders i as a zero-padded 4-digit string for stable id construction.
+func pad(i int) string {
+	s := ""
+	for _, d := range []int{1000, 100, 10, 1} {
+		s += string(rune('0' + (i/d)%10))
+	}
+	return s
 }

--- a/internal/storage/dolt/events.go
+++ b/internal/storage/dolt/events.go
@@ -57,11 +57,12 @@ func (s *DoltStore) GetAllEventsSince(ctx context.Context, since time.Time) ([]*
 
 // EventsSince returns durable events strictly after the keyset cursor, ordered
 // by (created_at ASC, id ASC) and bounded by limit. Durable events table only.
-func (s *DoltStore) EventsSince(ctx context.Context, cursor storage.EventCursor, limit int) ([]*types.Event, error) {
+// issueID != "" scopes the feed to one bead's history.
+func (s *DoltStore) EventsSince(ctx context.Context, cursor storage.EventCursor, issueID string, limit int) ([]*types.Event, error) {
 	var result []*types.Event
 	err := s.withReadTx(ctx, func(tx *sql.Tx) error {
 		var err error
-		result, err = issueops.EventsSinceInTx(ctx, tx, cursor.CreatedAt, cursor.ID, limit)
+		result, err = issueops.EventsSinceInTx(ctx, tx, cursor.CreatedAt, cursor.ID, issueID, limit)
 		return err
 	})
 	return result, err

--- a/internal/storage/dolt/events.go
+++ b/internal/storage/dolt/events.go
@@ -55,6 +55,18 @@ func (s *DoltStore) GetAllEventsSince(ctx context.Context, since time.Time) ([]*
 	return result, err
 }
 
+// EventsSince returns durable events strictly after the keyset cursor, ordered
+// by (created_at ASC, id ASC) and bounded by limit. Durable events table only.
+func (s *DoltStore) EventsSince(ctx context.Context, cursor storage.EventCursor, limit int) ([]*types.Event, error) {
+	var result []*types.Event
+	err := s.withReadTx(ctx, func(tx *sql.Tx) error {
+		var err error
+		result, err = issueops.EventsSinceInTx(ctx, tx, cursor.CreatedAt, cursor.ID, limit)
+		return err
+	})
+	return result, err
+}
+
 // AddIssueComment adds a comment to an issue (structured comment)
 func (s *DoltStore) AddIssueComment(ctx context.Context, issueID, author, text string) (*types.Comment, error) {
 	return s.ImportIssueComment(ctx, issueID, author, text, time.Now().UTC())

--- a/internal/storage/dolt/events_since_test.go
+++ b/internal/storage/dolt/events_since_test.go
@@ -1,0 +1,143 @@
+package dolt
+
+import (
+	"testing"
+	"time"
+
+	"github.com/steveyegge/beads/internal/storage"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// TestEventsSince verifies the durable keyset event read: (created_at, id)
+// ordering, same-second id tie-break, cursor exclusivity, limit clamping, and
+// durable-only scope (wisp events excluded).
+func TestEventsSince(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	// A durable issue to anchor events (events.issue_id → issues.id FK).
+	durable := &types.Issue{ID: "es-durable", Title: "Durable", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask}
+	if err := store.CreateIssue(ctx, durable, "tester"); err != nil {
+		t.Fatalf("create durable issue: %v", err)
+	}
+	// A wisp issue whose "created" event lands in wisp_events, which the
+	// durable-only feed must never surface.
+	wisp := &types.Issue{ID: "es-wisp", Title: "Wisp", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask, Ephemeral: true}
+	if err := store.CreateIssue(ctx, wisp, "tester"); err != nil {
+		t.Fatalf("create wisp issue: %v", err)
+	}
+
+	// Clear the auto-generated "created" event so the seeded rows are the only
+	// durable events, giving a fully deterministic ordering.
+	if _, err := store.db.ExecContext(ctx, "DELETE FROM events WHERE issue_id = ?", durable.ID); err != nil {
+		t.Fatalf("clear auto events: %v", err)
+	}
+
+	base := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
+	type seed struct {
+		id string
+		at time.Time
+	}
+	// e1 and e2 share a second (tie broken by id ASC); e3 is one second later.
+	seeds := []seed{
+		{id: "00000000-0000-0000-0000-000000000001", at: base},
+		{id: "00000000-0000-0000-0000-000000000002", at: base},
+		{id: "00000000-0000-0000-0000-000000000003", at: base.Add(time.Second)},
+	}
+	for _, s := range seeds {
+		if _, err := store.db.ExecContext(ctx,
+			"INSERT INTO events (id, issue_id, event_type, actor, created_at) VALUES (?, ?, ?, ?, ?)",
+			s.id, durable.ID, string(types.EventUpdated), "tester", s.at); err != nil {
+			t.Fatalf("insert seed event %s: %v", s.id, err)
+		}
+	}
+
+	ids := func(evs []*types.Event) []string {
+		out := make([]string, len(evs))
+		for i, e := range evs {
+			out[i] = e.ID
+		}
+		return out
+	}
+	eq := func(t *testing.T, got, want []string) {
+		t.Helper()
+		if len(got) != len(want) {
+			t.Fatalf("event ids = %v, want %v", got, want)
+		}
+		for i := range want {
+			if got[i] != want[i] {
+				t.Fatalf("event ids = %v, want %v", got, want)
+			}
+		}
+	}
+
+	// Empty cursor = from epoch; ordered by (created_at ASC, id ASC), durable only.
+	all, err := store.EventsSince(ctx, storage.EventCursor{}, 10)
+	if err != nil {
+		t.Fatalf("EventsSince(epoch): %v", err)
+	}
+	eq(t, ids(all), []string{seeds[0].id, seeds[1].id, seeds[2].id})
+	for _, e := range all {
+		if e.IssueID == wisp.ID {
+			t.Fatalf("durable-only feed returned wisp event for %s", wisp.ID)
+		}
+	}
+
+	// Limit honored.
+	page, err := store.EventsSince(ctx, storage.EventCursor{}, 2)
+	if err != nil {
+		t.Fatalf("EventsSince(limit=2): %v", err)
+	}
+	eq(t, ids(page), []string{seeds[0].id, seeds[1].id})
+
+	// Cursor excludes its own row and orders the same-second tie by id: starting
+	// at e1's (created_at, id) yields e2 then e3.
+	afterE1, err := store.EventsSince(ctx, storage.EventCursor{CreatedAt: seeds[0].at, ID: seeds[0].id}, 10)
+	if err != nil {
+		t.Fatalf("EventsSince(after e1): %v", err)
+	}
+	eq(t, ids(afterE1), []string{seeds[1].id, seeds[2].id})
+
+	// Exhausting the shared second advances to the next second's row.
+	afterE2, err := store.EventsSince(ctx, storage.EventCursor{CreatedAt: seeds[1].at, ID: seeds[1].id}, 10)
+	if err != nil {
+		t.Fatalf("EventsSince(after e2): %v", err)
+	}
+	eq(t, ids(afterE2), []string{seeds[2].id})
+}
+
+// TestEventsSinceClaimedConstant verifies the real claim path writes an event
+// whose type is the extracted EventClaimed constant ("claimed"), reachable
+// through the durable keyset read.
+func TestEventsSinceClaimedConstant(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	issue := &types.Issue{ID: "es-claim", Title: "Claimable", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask}
+	if err := store.CreateIssue(ctx, issue, "tester"); err != nil {
+		t.Fatalf("create issue: %v", err)
+	}
+	if err := store.ClaimIssue(ctx, issue.ID, "worker"); err != nil {
+		t.Fatalf("claim issue: %v", err)
+	}
+
+	evs, err := store.EventsSince(ctx, storage.EventCursor{}, 100)
+	if err != nil {
+		t.Fatalf("EventsSince: %v", err)
+	}
+	found := false
+	for _, e := range evs {
+		if e.IssueID == issue.ID && e.EventType == types.EventClaimed {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("no %q event found for claimed issue %s", types.EventClaimed, issue.ID)
+	}
+}

--- a/internal/storage/dolt/events_since_test.go
+++ b/internal/storage/dolt/events_since_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/steveyegge/beads/internal/storage"
+	"github.com/steveyegge/beads/internal/storage/issueops"
 	"github.com/steveyegge/beads/internal/types"
 )
 
@@ -296,13 +297,13 @@ func TestEventsSincePlanIsIndexed(t *testing.T) {
 	}
 
 	const cur = "2023-01-01 00:00:00"
-	// Mirror EventsSinceInTx's SARGABLE predicate with literals.
-	plan := explainPlan(t, ctx, store.db, `
-		SELECT id, issue_id, event_type, actor, old_value, new_value, comment, created_at
-		FROM events
-		WHERE created_at >= '`+cur+`' AND ((created_at > '`+cur+`') OR (id > ''))
-		ORDER BY created_at ASC, id ASC
-		LIMIT 100`)
+	// Single-source the guarded SQL from production: EXPLAIN the exact string
+	// EventsSinceInTx runs (issueID="" => three ? placeholders: the created_at
+	// lower bound, the strict created_at, and the id tie-break), with the
+	// placeholders replaced by literals for the plan. A change to the SARGABLE
+	// predicate in issueops.EventsSinceQuery then breaks this guard.
+	prod := issueops.EventsSinceQuery("", 100)
+	plan := explainPlan(t, ctx, store.db, literalizeParams(prod, "'"+cur+"'", "'"+cur+"'", "''"))
 
 	if !looksLikeDoltPlan(plan) {
 		t.Skipf("EXPLAIN output not in a recognized Dolt plan format, skipping sargability assertion; plan=\n%s", plan)

--- a/internal/storage/dolt/events_since_test.go
+++ b/internal/storage/dolt/events_since_test.go
@@ -1,6 +1,8 @@
 package dolt
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -75,7 +77,7 @@ func TestEventsSince(t *testing.T) {
 	}
 
 	// Empty cursor = from epoch; ordered by (created_at ASC, id ASC), durable only.
-	all, err := store.EventsSince(ctx, storage.EventCursor{}, 10)
+	all, err := store.EventsSince(ctx, storage.EventCursor{}, "", 10)
 	if err != nil {
 		t.Fatalf("EventsSince(epoch): %v", err)
 	}
@@ -87,7 +89,7 @@ func TestEventsSince(t *testing.T) {
 	}
 
 	// Limit honored.
-	page, err := store.EventsSince(ctx, storage.EventCursor{}, 2)
+	page, err := store.EventsSince(ctx, storage.EventCursor{}, "", 2)
 	if err != nil {
 		t.Fatalf("EventsSince(limit=2): %v", err)
 	}
@@ -95,14 +97,14 @@ func TestEventsSince(t *testing.T) {
 
 	// Cursor excludes its own row and orders the same-second tie by id: starting
 	// at e1's (created_at, id) yields e2 then e3.
-	afterE1, err := store.EventsSince(ctx, storage.EventCursor{CreatedAt: seeds[0].at, ID: seeds[0].id}, 10)
+	afterE1, err := store.EventsSince(ctx, storage.EventCursor{CreatedAt: seeds[0].at, ID: seeds[0].id}, "", 10)
 	if err != nil {
 		t.Fatalf("EventsSince(after e1): %v", err)
 	}
 	eq(t, ids(afterE1), []string{seeds[1].id, seeds[2].id})
 
 	// Exhausting the shared second advances to the next second's row.
-	afterE2, err := store.EventsSince(ctx, storage.EventCursor{CreatedAt: seeds[1].at, ID: seeds[1].id}, 10)
+	afterE2, err := store.EventsSince(ctx, storage.EventCursor{CreatedAt: seeds[1].at, ID: seeds[1].id}, "", 10)
 	if err != nil {
 		t.Fatalf("EventsSince(after e2): %v", err)
 	}
@@ -127,7 +129,7 @@ func TestEventsSinceClaimedConstant(t *testing.T) {
 		t.Fatalf("claim issue: %v", err)
 	}
 
-	evs, err := store.EventsSince(ctx, storage.EventCursor{}, 100)
+	evs, err := store.EventsSince(ctx, storage.EventCursor{}, "", 100)
 	if err != nil {
 		t.Fatalf("EventsSince: %v", err)
 	}
@@ -139,5 +141,173 @@ func TestEventsSinceClaimedConstant(t *testing.T) {
 	}
 	if !found {
 		t.Fatalf("no %q event found for claimed issue %s", types.EventClaimed, issue.ID)
+	}
+}
+
+// TestEventsSinceIssueFilter verifies the optional per-bead scope: a non-empty
+// issueID restricts the durable feed to that issue's events, while "" returns
+// every issue's events. This is the primitive behind `bd show`'s per-bead
+// event history.
+func TestEventsSinceIssueFilter(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	mk := func(id string) {
+		iss := &types.Issue{ID: id, Title: id, Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask}
+		if err := store.CreateIssue(ctx, iss, "tester"); err != nil {
+			t.Fatalf("create %s: %v", id, err)
+		}
+		if _, err := store.db.ExecContext(ctx, "DELETE FROM events WHERE issue_id = ?", id); err != nil {
+			t.Fatalf("clear auto events for %s: %v", id, err)
+		}
+	}
+	mk("ef-a")
+	mk("ef-b")
+
+	base := time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC)
+	seed := func(id, issueID string, at time.Time) {
+		if _, err := store.db.ExecContext(ctx,
+			"INSERT INTO events (id, issue_id, event_type, actor, created_at) VALUES (?, ?, ?, ?, ?)",
+			id, issueID, string(types.EventUpdated), "tester", at); err != nil {
+			t.Fatalf("insert seed event %s: %v", id, err)
+		}
+	}
+	seed("00000000-0000-0000-0000-0000000000a1", "ef-a", base)
+	seed("00000000-0000-0000-0000-0000000000a2", "ef-a", base.Add(time.Second))
+	seed("00000000-0000-0000-0000-0000000000b1", "ef-b", base.Add(2*time.Second))
+
+	issueIDsOf := func(evs []*types.Event) map[string]int {
+		m := map[string]int{}
+		for _, e := range evs {
+			m[e.IssueID]++
+		}
+		return m
+	}
+
+	onlyA, err := store.EventsSince(ctx, storage.EventCursor{}, "ef-a", 100)
+	if err != nil {
+		t.Fatalf("EventsSince(issue=ef-a): %v", err)
+	}
+	if got := issueIDsOf(onlyA); got["ef-a"] != 2 || got["ef-b"] != 0 {
+		t.Fatalf("filtered ef-a feed = %v, want {ef-a:2}", got)
+	}
+
+	onlyB, err := store.EventsSince(ctx, storage.EventCursor{}, "ef-b", 100)
+	if err != nil {
+		t.Fatalf("EventsSince(issue=ef-b): %v", err)
+	}
+	if got := issueIDsOf(onlyB); got["ef-b"] != 1 || got["ef-a"] != 0 {
+		t.Fatalf("filtered ef-b feed = %v, want {ef-b:1}", got)
+	}
+
+	unfiltered, err := store.EventsSince(ctx, storage.EventCursor{}, "", 100)
+	if err != nil {
+		t.Fatalf("EventsSince(all): %v", err)
+	}
+	if got := issueIDsOf(unfiltered); got["ef-a"] != 2 || got["ef-b"] != 1 {
+		t.Fatalf("unfiltered feed = %v, want {ef-a:2, ef-b:1}", got)
+	}
+}
+
+// TestEventsSinceLimitClamp verifies the self-clamp: limit <= 0 falls back to
+// the store default (100) and any limit above the hard cap is clamped to 500.
+func TestEventsSinceLimitClamp(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	iss := &types.Issue{ID: "clamp", Title: "clamp", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask}
+	if err := store.CreateIssue(ctx, iss, "tester"); err != nil {
+		t.Fatalf("create issue: %v", err)
+	}
+	if _, err := store.db.ExecContext(ctx, "DELETE FROM events WHERE issue_id = ?", iss.ID); err != nil {
+		t.Fatalf("clear auto events: %v", err)
+	}
+
+	// Seed 501 durable events in one multi-row insert (cheaper than 501 round
+	// trips). ids sort lexically in numeric order, so (created_at, id) ordering
+	// is the seed order.
+	const n = 501
+	base := time.Date(2022, 1, 1, 0, 0, 0, 0, time.UTC)
+	var b strings.Builder
+	b.WriteString("INSERT INTO events (id, issue_id, event_type, actor, created_at) VALUES ")
+	args := make([]any, 0, n*5)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			b.WriteString(",")
+		}
+		b.WriteString("(?, ?, ?, ?, ?)")
+		args = append(args,
+			fmt.Sprintf("clamp-%05d", i), iss.ID, string(types.EventUpdated), "tester", base.Add(time.Duration(i)*time.Second))
+	}
+	if _, err := store.db.ExecContext(ctx, b.String(), args...); err != nil {
+		t.Fatalf("bulk insert seed events: %v", err)
+	}
+
+	// limit <= 0 => issueops.defaultEventsSinceLimit (100).
+	const wantDefault, wantCap = 100, 500
+	def, err := store.EventsSince(ctx, storage.EventCursor{}, "", 0)
+	if err != nil {
+		t.Fatalf("EventsSince(limit=0): %v", err)
+	}
+	if len(def) != wantDefault {
+		t.Fatalf("default clamp: got %d rows, want %d", len(def), wantDefault)
+	}
+
+	// limit above the cap => issueops.maxEventsSinceLimit (500).
+	capped, err := store.EventsSince(ctx, storage.EventCursor{}, "", 100000)
+	if err != nil {
+		t.Fatalf("EventsSince(limit=100000): %v", err)
+	}
+	if len(capped) != wantCap {
+		t.Fatalf("cap clamp: got %d rows, want %d", len(capped), wantCap)
+	}
+}
+
+// TestEventsSincePlanIsIndexed is the sargability regression guard: the
+// EventsSince cursor predicate must seek idx_events_created_at
+// (IndexedTableAccess), not full-scan-and-filter. The redundant `created_at >= ?`
+// lower bound is what flips the Dolt planner from Table+Filter+TopN to an
+// indexed range. It EXPLAINs the exact predicate shape with literals and skips
+// (rather than fails) if the EXPLAIN output format is unrecognizable.
+func TestEventsSincePlanIsIndexed(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	iss := &types.Issue{ID: "plan", Title: "plan", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask}
+	if err := store.CreateIssue(ctx, iss, "tester"); err != nil {
+		t.Fatalf("create issue: %v", err)
+	}
+	base := time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC)
+	for i := 0; i < 5; i++ {
+		if _, err := store.db.ExecContext(ctx,
+			"INSERT INTO events (id, issue_id, event_type, actor, created_at) VALUES (?, ?, ?, ?, ?)",
+			fmt.Sprintf("plan-%02d", i), iss.ID, string(types.EventUpdated), "tester", base.Add(time.Duration(i)*time.Second)); err != nil {
+			t.Fatalf("insert seed event: %v", err)
+		}
+	}
+
+	const cur = "2023-01-01 00:00:00"
+	// Mirror EventsSinceInTx's SARGABLE predicate with literals.
+	plan := explainPlan(t, ctx, store.db, `
+		SELECT id, issue_id, event_type, actor, old_value, new_value, comment, created_at
+		FROM events
+		WHERE created_at >= '`+cur+`' AND ((created_at > '`+cur+`') OR (id > ''))
+		ORDER BY created_at ASC, id ASC
+		LIMIT 100`)
+
+	if !looksLikeDoltPlan(plan) {
+		t.Skipf("EXPLAIN output not in a recognized Dolt plan format, skipping sargability assertion; plan=\n%s", plan)
+	}
+	if !strings.Contains(plan, "IndexedTableAccess") || !strings.Contains(plan, "events.created_at") {
+		t.Fatalf("EventsSince predicate does not seek idx_events_created_at (want IndexedTableAccess on [events.created_at]) — the sargable lower bound regressed to a full Table scan.\nplan:\n%s", plan)
 	}
 }

--- a/internal/storage/dolt/is_blocked_batch_test.go
+++ b/internal/storage/dolt/is_blocked_batch_test.go
@@ -1,0 +1,81 @@
+package dolt
+
+import (
+	"testing"
+
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// TestIsBlockedBatch is the batch-is_blocked regression on the reference Dolt
+// backend: the batch transitive is_blocked read agrees with per-row IsBlocked
+// for every id (direct blocker, inherited parent-child block, unblocked control), and
+// reflects inherited blockedness with an EMPTY direct-blocker set — the same
+// denormalized column IsBlocked reads, in one round-trip, with no recompute.
+func TestIsBlockedBatch(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	mk := func(id string) {
+		iss := &types.Issue{ID: id, Title: id, Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask}
+		if err := store.CreateIssue(ctx, iss, "tester"); err != nil {
+			t.Fatalf("create %s: %v", id, err)
+		}
+	}
+	add := func(src, tgt string, typ types.DependencyType) {
+		if err := store.AddDependency(ctx, &types.Dependency{IssueID: src, DependsOnID: tgt, Type: typ}, "tester"); err != nil {
+			t.Fatalf("add dep %s->%s: %v", src, tgt, err)
+		}
+	}
+	// ib-blk (open) blocks ib-parent; ib-child is a parent-child of ib-parent so
+	// it inherits is_blocked with no direct blocking edge; ib-free is unblocked.
+	mk("ib-blk")
+	mk("ib-parent")
+	add("ib-parent", "ib-blk", types.DepBlocks)
+	mk("ib-child")
+	add("ib-child", "ib-parent", types.DepParentChild)
+	mk("ib-free")
+
+	ids := []string{"ib-blk", "ib-parent", "ib-child", "ib-free"}
+	batch, err := store.IsBlockedBatch(ctx, ids)
+	if err != nil {
+		t.Fatalf("IsBlockedBatch: %v", err)
+	}
+
+	// Batch value must equal per-row IsBlocked for every id.
+	for _, id := range ids {
+		want, _, err := store.IsBlocked(ctx, id)
+		if err != nil {
+			t.Fatalf("IsBlocked(%s): %v", id, err)
+		}
+		if batch[id] != want {
+			t.Fatalf("IsBlockedBatch[%s] = %v, want %v (per-row IsBlocked)", id, batch[id], want)
+		}
+	}
+
+	// Inherited block: the child is transitively blocked with an EMPTY direct
+	// blocker set, and the batch reflects it.
+	blocked, blockers, err := store.IsBlocked(ctx, "ib-child")
+	if err != nil {
+		t.Fatalf("IsBlocked(ib-child): %v", err)
+	}
+	if !blocked || len(blockers) != 0 {
+		t.Fatalf("ib-child IsBlocked = (%v, %v), want (true, []) — inherited block, empty direct blockers", blocked, blockers)
+	}
+	if !batch["ib-child"] || !batch["ib-parent"] {
+		t.Fatalf("IsBlockedBatch child=%v parent=%v, want both true", batch["ib-child"], batch["ib-parent"])
+	}
+	if batch["ib-free"] {
+		t.Fatalf("IsBlockedBatch[ib-free] = true, want false")
+	}
+
+	// Missing id is absent from the map (callers treat absent as not-blocked).
+	miss, err := store.IsBlockedBatch(ctx, []string{"ib-nope"})
+	if err != nil {
+		t.Fatalf("IsBlockedBatch(missing): %v", err)
+	}
+	if _, ok := miss["ib-nope"]; ok {
+		t.Fatalf("IsBlockedBatch returned an entry for a missing id: %v", miss)
+	}
+}

--- a/internal/storage/dolt/is_blocked_batch_test.go
+++ b/internal/storage/dolt/is_blocked_batch_test.go
@@ -79,3 +79,53 @@ func TestIsBlockedBatch(t *testing.T) {
 		t.Fatalf("IsBlockedBatch returned an entry for a missing id: %v", miss)
 	}
 }
+
+// TestIsBlockedBatchCrossTableCollisionMatchesSingle locks in the single/batch
+// resolution parity: when the SAME id lives in BOTH the issues and wisps tables
+// with DIFFERENT is_blocked values (a data anomaly), the batch read
+// (IsBlockedBatch) must resolve the shared is_blocked field the same
+// way the per-row read (IsBlocked) does. IsBlockedInTx scans
+// issues→wisps and breaks on the first table that has the id, so ISSUES wins;
+// the batch must agree. Before the fix the batch preferred the wisps row and the
+// two reads disagreed on the same stored flag.
+func TestIsBlockedBatchCrossTableCollisionMatchesSingle(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	const id = "ib-collide"
+
+	// issues row: is_blocked = 1 (blocked).
+	createPerm(t, ctx, store, id)
+	if _, err := store.execContext(ctx, "UPDATE issues SET is_blocked = 1 WHERE id = ?", id); err != nil {
+		t.Fatalf("set issues.is_blocked: %v", err)
+	}
+
+	// wisps row with the SAME id but is_blocked = 0 (not blocked) — the collision.
+	if _, err := store.execContext(ctx, `
+		INSERT INTO wisps (id, title, description, design, acceptance_criteria, notes, status, priority, issue_type, ephemeral, is_blocked)
+		VALUES (?, ?, '', '', '', '', ?, ?, ?, ?, ?)
+	`, id, "wisp collide", types.StatusOpen, 2, types.TypeTask, true, 0); err != nil {
+		t.Fatalf("insert colliding wisp row: %v", err)
+	}
+
+	single, _, err := store.IsBlocked(ctx, id)
+	if err != nil {
+		t.Fatalf("IsBlocked(%s): %v", id, err)
+	}
+	batch, err := store.IsBlockedBatch(ctx, []string{id})
+	if err != nil {
+		t.Fatalf("IsBlockedBatch(%s): %v", id, err)
+	}
+
+	// The two reads must agree on the shared is_blocked field.
+	if single != batch[id] {
+		t.Fatalf("collision divergence: IsBlocked(%s) = %v, IsBlockedBatch[%s] = %v — must agree", id, single, id, batch[id])
+	}
+	// And the agreed value must be the ISSUES-table value (issues-wins), matching
+	// IsBlockedInTx's issues→wisps break order.
+	if !single {
+		t.Fatalf("IsBlocked(%s) = false, want true (issues-wins: issues.is_blocked = 1)", id)
+	}
+}

--- a/internal/storage/dolt/transaction.go
+++ b/internal/storage/dolt/transaction.go
@@ -1131,3 +1131,123 @@ func (t *doltTransaction) AddComment(ctx context.Context, issueID, actor, commen
 	}
 	return wrapExecError("add comment in tx", err)
 }
+
+// GetIssueCommentsPage returns one keyset page of an issue's comments within the
+// transaction. Like the OLD GetIssueComments/GetDependencyRecords tx methods, it
+// pre-resolves wispness on the ignored session and hands the InTx read the
+// handle that owns issueID's tier, so a comment written on either tier earlier in
+// THIS uncommitted transaction is visible (durable rows live on regularTx, wisp
+// rows on ignoredTx — see the struct comment on the two-session split).
+func (t *doltTransaction) GetIssueCommentsPage(ctx context.Context, issueID string, after storage.CommentPageCursor, limit int) ([]*types.Comment, error) {
+	tx := t.regularTx
+	if t.isActiveWisp(ctx, issueID) {
+		tx = t.ignoredTx
+	}
+	return issueops.GetIssueCommentsPageInTx(ctx, tx, issueID, after, limit)
+}
+
+// CountIssuesByGroup returns per-group issue counts within the transaction.
+//
+// TWO-SESSION SCOPING: the count runs on regularTx, so it reflects this tx's own
+// uncommitted DURABLE issues plus all COMMITTED issues and wisps, but NOT wisps
+// created in this same uncommitted transaction (those live on the separate
+// ignored session). This matches doltTransaction.SearchIssues, which is likewise
+// durable-tier for the tx's own writes. Note the pre-existing count-vs-search
+// asymmetry: CountIssuesByGroupInTx merges committed wisps into the buckets while
+// SearchIssues reads the issues table only, so the two need not agree when
+// committed wisps exist. The embedded backend has no session split and sees
+// in-tx wisps here.
+func (t *doltTransaction) CountIssuesByGroup(ctx context.Context, filter types.IssueFilter, groupBy string) (map[string]int, error) {
+	return issueops.CountIssuesByGroupInTx(ctx, t.regularTx, filter, groupBy)
+}
+
+// GetDependentRecords returns the raw inbound dependency rows of targetID within
+// the transaction.
+//
+// TWO-SESSION SCOPING: a target's inbound edges genuinely span BOTH dependency
+// tables (a wisp source points at a durable target), and the InTx read unions
+// them with an in-query, cross-table de-dup that must run on a single handle.
+// Run on regularTx, it sees this tx's own uncommitted DURABLE edges plus all
+// COMMITTED edges, but NOT wisp edges written in this same uncommitted
+// transaction (those live on the ignored session and become visible after
+// commit). The embedded backend has no session split and sees in-tx wisp edges.
+func (t *doltTransaction) GetDependentRecords(ctx context.Context, targetID string, depType string, limit int, afterID string) ([]*types.Dependency, error) {
+	return issueops.GetDependentRecordsInTx(ctx, t.regularTx, targetID, depType, limit, afterID)
+}
+
+// GetDependentRecordsForIssues returns the raw inbound dependency rows for a set
+// of target ids within the transaction, keyed by target id. Same TWO-SESSION
+// SCOPING as GetDependentRecords: uncommitted-durable plus committed edges on the
+// server backend; wisp edges written in this same transaction are visible after
+// commit. The embedded backend sees in-tx wisp edges.
+func (t *doltTransaction) GetDependentRecordsForIssues(ctx context.Context, targetIDs []string) (map[string][]*types.Dependency, error) {
+	return issueops.GetDependentRecordsForIssuesInTx(ctx, t.regularTx, targetIDs)
+}
+
+// CountDependentRecords returns the total inbound-edge count of targetID within
+// the transaction. Same TWO-SESSION SCOPING as GetDependentRecords — the count
+// uses a cross-table NOT-IN subquery that must run on one handle, so on the
+// server backend it excludes wisp edges written in this same uncommitted
+// transaction (visible after commit). The embedded backend sees them.
+func (t *doltTransaction) CountDependentRecords(ctx context.Context, targetID string, depType string) (int, error) {
+	return issueops.CountDependentRecordsInTx(ctx, t.regularTx, targetID, depType)
+}
+
+// IsBlocked reports the denormalized transitive is_blocked flag and direct
+// blockers of issueID within the transaction. Like GetIssueCommentsPage, it
+// pre-resolves wispness and reads on the session that owns issueID's tier, so the
+// is_blocked flag and blocker edges written for issueID earlier in THIS
+// uncommitted transaction are visible on either tier.
+func (t *doltTransaction) IsBlocked(ctx context.Context, issueID string) (bool, []string, error) {
+	tx := t.regularTx
+	if t.isActiveWisp(ctx, issueID) {
+		tx = t.ignoredTx
+	}
+	return issueops.IsBlockedInTx(ctx, tx, issueID)
+}
+
+// IsBlockedBatch reports the denormalized transitive is_blocked flag for a page
+// of ids within the transaction. A batch can mix durable and wisp ids whose
+// is_blocked columns live on different sessions, so — unlike a single-handle
+// delegation — it partitions the ids by wispness (resolved on the ignored
+// session so this tx's own uncommitted wisps count) and reads each tier's
+// is_blocked on its owning session, then merges. Every id therefore reflects the
+// flag written earlier in THIS uncommitted transaction, on either tier.
+func (t *doltTransaction) IsBlockedBatch(ctx context.Context, ids []string) (map[string]bool, error) {
+	if len(ids) == 0 {
+		return map[string]bool{}, nil
+	}
+	wispIDs, permIDs, err := issueops.PartitionWispIDsInTx(ctx, t.ignoredTx, ids)
+	if err != nil {
+		return nil, err
+	}
+	result := make(map[string]bool, len(ids))
+	if len(permIDs) > 0 {
+		durable, err := issueops.IsBlockedBatchInTx(ctx, t.regularTx, permIDs)
+		if err != nil {
+			return nil, err
+		}
+		for id, blocked := range durable {
+			result[id] = blocked
+		}
+	}
+	if len(wispIDs) > 0 {
+		wisp, err := issueops.IsBlockedBatchInTx(ctx, t.ignoredTx, wispIDs)
+		if err != nil {
+			return nil, err
+		}
+		for id, blocked := range wisp {
+			result[id] = blocked
+		}
+	}
+	return result, nil
+}
+
+// EventsSince returns durable events strictly after the keyset cursor within the
+// transaction. Mirrors DoltStore.EventsSince's issueops delegation. The feed is
+// durable-only by contract (wisp events are excluded), and durable event writes
+// land on regularTx, so an event recorded earlier in THIS uncommitted
+// transaction is visible.
+func (t *doltTransaction) EventsSince(ctx context.Context, cursor storage.EventCursor, issueID string, limit int) ([]*types.Event, error) {
+	return issueops.EventsSinceInTx(ctx, t.regularTx, cursor.CreatedAt, cursor.ID, issueID, limit)
+}

--- a/internal/storage/dolt/tx_reads_test.go
+++ b/internal/storage/dolt/tx_reads_test.go
@@ -1,0 +1,207 @@
+package dolt
+
+import (
+	"testing"
+	"time"
+
+	"github.com/steveyegge/beads/internal/storage"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// TestTxReadYourWritesWithComment exercises the full composite-view
+// read-your-writes cycle on real Dolt: an issue graph plus a comment created
+// inside one transaction, read back through the new snapshot-read methods
+// BEFORE commit. The comment leg is Dolt-specific because it writes through
+// doltTransaction.ImportIssueComment (the embedded transaction stubs it), so it
+// lives here rather than in the backend-agnostic conformance suite.
+func TestTxReadYourWritesWithComment(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	err := store.RunInTransaction(ctx, "bd: tx read-your-writes", func(tx storage.Transaction) error {
+		if err := tx.CreateIssue(ctx, &types.Issue{ID: "txr-1", Title: "Blocker", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask}, "tester"); err != nil {
+			return err
+		}
+		if err := tx.CreateIssue(ctx, &types.Issue{ID: "txr-2", Title: "Blocked", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask}, "tester"); err != nil {
+			return err
+		}
+		if err := tx.AddDependency(ctx, &types.Dependency{IssueID: "txr-2", DependsOnID: "txr-1", Type: types.DepBlocks}, "tester"); err != nil {
+			return err
+		}
+		if _, err := tx.ImportIssueComment(ctx, "txr-1", "tester", "note", time.Now().UTC()); err != nil {
+			return err
+		}
+
+		// Dependent-edge read-your-writes.
+		dependents, err := tx.GetDependentRecords(ctx, "txr-1", "", 0, "")
+		if err != nil {
+			return err
+		}
+		if len(dependents) != 1 || dependents[0].IssueID != "txr-2" {
+			t.Errorf("in-tx GetDependentRecords(txr-1) = %v, want one edge from txr-2", dependents)
+		}
+		nDep, err := tx.CountDependentRecords(ctx, "txr-1", "")
+		if err != nil {
+			return err
+		}
+		if nDep != 1 {
+			t.Errorf("in-tx CountDependentRecords(txr-1) = %d, want 1", nDep)
+		}
+
+		// Blocked read-your-writes.
+		batch, err := tx.IsBlockedBatch(ctx, []string{"txr-1", "txr-2"})
+		if err != nil {
+			return err
+		}
+		if !batch["txr-2"] || batch["txr-1"] {
+			t.Errorf("in-tx IsBlockedBatch = %v, want txr-2 blocked, txr-1 not", batch)
+		}
+
+		// Comment read-your-writes through the new page method.
+		page, err := tx.GetIssueCommentsPage(ctx, "txr-1", storage.CommentPageCursor{}, 0)
+		if err != nil {
+			return err
+		}
+		if len(page) != 1 || page[0].Text != "note" {
+			t.Errorf("in-tx GetIssueCommentsPage(txr-1) = %v, want one comment 'note'", page)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("RunInTransaction: %v", err)
+	}
+}
+
+// TestTxReadYourWritesWispTier pins the two-session wisp behavior of the new
+// reads on the classic Dolt store (wisp rows live on ignoredTx, durable on
+// regularTx). It proves:
+//   - Single-tier reads route to the owning session and ARE read-your-writes for
+//     an uncommitted wisp (GetIssueCommentsPage, IsBlocked, IsBlockedBatch).
+//   - Both-tiers-spanning reads run on regularTx and, per the documented
+//     two-session caveat, do NOT yet see a wisp edge written in the same open
+//     transaction (GetDependentRecords/CountDependentRecords) — and DO see it
+//     once the transaction commits.
+func TestTxReadYourWritesWispTier(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	// Committed durable blocker (its open status must be visible cross-session).
+	blocker := crossTierRegularIssue("txw-block", "committed durable blocker")
+	if err := store.CreateIssue(ctx, blocker, "tester"); err != nil {
+		t.Fatalf("CreateIssue blocker: %v", err)
+	}
+	// Committed wisp: pins the classic-Dolt count-vs-search asymmetry — the tx's
+	// SearchIssues is durable-tier, while CountIssuesByGroup merges wisps.
+	committedWisp := crossTierWispIssue("txw-cwisp", "committed wisp")
+	if err := store.CreateIssue(ctx, committedWisp, "tester"); err != nil {
+		t.Fatalf("CreateIssue committed wisp: %v", err)
+	}
+
+	err := store.RunInTransaction(ctx, "bd: wisp read-your-writes", func(tx storage.Transaction) error {
+		// Count-vs-search asymmetry on the classic Dolt tx (committed data only,
+		// before this tx mutates anything): SearchIssues sees the durable blocker
+		// but not the committed wisp; CountIssuesByGroup counts both.
+		search, err := tx.SearchIssues(ctx, "", types.IssueFilter{})
+		if err != nil {
+			return err
+		}
+		if len(search) != 1 || search[0].ID != "txw-block" {
+			t.Errorf("tx.SearchIssues = %v, want [txw-block] only (durable-tier; committed wisp excluded)", search)
+		}
+		groupCounts, err := tx.CountIssuesByGroup(ctx, types.IssueFilter{}, "status")
+		if err != nil {
+			return err
+		}
+		total := 0
+		for _, n := range groupCounts {
+			total += n
+		}
+		if total != 2 {
+			t.Errorf("tx.CountIssuesByGroup total = %d, want 2 (durable blocker + committed wisp merged)", total)
+		}
+
+		wisp := crossTierWispIssue("txw-wisp", "wisp created in tx")
+		if err := tx.CreateIssue(ctx, wisp, "tester"); err != nil {
+			return err
+		}
+		// Wisp-sourced blocks edge → wisp_dependencies (ignoredTx); wisp blocked.
+		if err := tx.AddDependency(ctx, &types.Dependency{IssueID: "txw-wisp", DependsOnID: "txw-block", Type: types.DepBlocks}, "tester"); err != nil {
+			return err
+		}
+		if _, err := tx.ImportIssueComment(ctx, "txw-wisp", "tester", "wisp note", time.Now().UTC()); err != nil {
+			return err
+		}
+
+		// Single-tier reads ARE read-your-writes on the wisp tier.
+		page, err := tx.GetIssueCommentsPage(ctx, "txw-wisp", storage.CommentPageCursor{}, 0)
+		if err != nil {
+			return err
+		}
+		if len(page) != 1 || page[0].Text != "wisp note" {
+			t.Errorf("in-tx GetIssueCommentsPage(txw-wisp) = %v, want one comment 'wisp note'", page)
+		}
+		isBlocked, blockers, err := tx.IsBlocked(ctx, "txw-wisp")
+		if err != nil {
+			return err
+		}
+		if !isBlocked || len(blockers) != 1 || blockers[0] != "txw-block" {
+			t.Errorf("in-tx IsBlocked(txw-wisp) = %v, %v, want true, [txw-block]", isBlocked, blockers)
+		}
+		batch, err := tx.IsBlockedBatch(ctx, []string{"txw-wisp", "txw-block"})
+		if err != nil {
+			return err
+		}
+		if !batch["txw-wisp"] || batch["txw-block"] {
+			t.Errorf("in-tx IsBlockedBatch = %v, want txw-wisp blocked, txw-block not", batch)
+		}
+
+		// Both-tiers-spanning reads do NOT yet see the uncommitted wisp edge
+		// (documented two-session caveat): txw-block's only inbound edge is the
+		// wisp edge, uncommitted on the ignored session.
+		dependents, err := tx.GetDependentRecords(ctx, "txw-block", "", 0, "")
+		if err != nil {
+			return err
+		}
+		if len(dependents) != 0 {
+			t.Errorf("in-tx GetDependentRecords(txw-block) = %v, want empty (uncommitted wisp edge not visible on regularTx)", dependents)
+		}
+		nDep, err := tx.CountDependentRecords(ctx, "txw-block", "")
+		if err != nil {
+			return err
+		}
+		if nDep != 0 {
+			t.Errorf("in-tx CountDependentRecords(txw-block) = %d, want 0 (documented caveat)", nDep)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("RunInTransaction: %v", err)
+	}
+
+	// After commit, the wisp edge and comment are visible through the store.
+	dependents, err := store.GetDependentRecords(ctx, "txw-block", "", 0, "")
+	if err != nil {
+		t.Fatalf("post-commit GetDependentRecords: %v", err)
+	}
+	if len(dependents) != 1 || dependents[0].IssueID != "txw-wisp" {
+		t.Errorf("post-commit GetDependentRecords(txw-block) = %v, want one edge from txw-wisp", dependents)
+	}
+	nDep, err := store.CountDependentRecords(ctx, "txw-block", "")
+	if err != nil {
+		t.Fatalf("post-commit CountDependentRecords: %v", err)
+	}
+	if nDep != 1 {
+		t.Errorf("post-commit CountDependentRecords(txw-block) = %d, want 1", nDep)
+	}
+	page, err := store.GetIssueCommentsPage(ctx, "txw-wisp", storage.CommentPageCursor{}, 0)
+	if err != nil {
+		t.Fatalf("post-commit GetIssueCommentsPage: %v", err)
+	}
+	if len(page) != 1 || page[0].Text != "wisp note" {
+		t.Errorf("post-commit GetIssueCommentsPage(txw-wisp) = %v, want one comment 'wisp note'", page)
+	}
+}

--- a/internal/storage/embeddeddolt/dependents_records_test.go
+++ b/internal/storage/embeddeddolt/dependents_records_test.go
@@ -91,3 +91,73 @@ func TestGetDependentRecordsEmbedded(t *testing.T) {
 		t.Fatalf("CountDependentRecords(blocks) = %d, want 2 (dr-s1 + dr-w)", n)
 	}
 }
+
+// TestGetDependentRecordsForIssuesEmbedded mirrors the dolt-suite batched
+// target-keyed coverage on the embedded backend: inbound edges keyed by target
+// across a SET of targets in one call, spanning both tables (durable + wisp
+// sources), with the FULL dep-type set (blocks, waits-for, conditional-blocks,
+// parent-child) and real dep_type preserved, and a decoy (source==id) excluded.
+func TestGetDependentRecordsForIssuesEmbedded(t *testing.T) {
+	skipUnlessEmbeddedDolt(t)
+
+	te := newTestEnv(t, "bt")
+	ctx := t.Context()
+
+	for _, issue := range []*types.Issue{
+		{ID: "bt-x", Title: "x", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask},
+		{ID: "bt-y", Title: "y", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask},
+		{ID: "bt-blk", Title: "blk", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask},
+		{ID: "bt-wait", Title: "wait", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask},
+		{ID: "bt-cond", Title: "cond", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask, Ephemeral: true},
+		{ID: "bt-child", Title: "child", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask},
+		{ID: "bt-yblk", Title: "yblk", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask},
+		{ID: "bt-z", Title: "z", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask},
+	} {
+		if err := te.store.CreateIssue(ctx, issue, "tester"); err != nil {
+			t.Fatalf("CreateIssue %s: %v", issue.ID, err)
+		}
+	}
+	for _, dep := range []*types.Dependency{
+		{IssueID: "bt-blk", DependsOnID: "bt-x", Type: types.DepBlocks},
+		{IssueID: "bt-wait", DependsOnID: "bt-x", Type: types.DepWaitsFor},
+		{IssueID: "bt-cond", DependsOnID: "bt-x", Type: types.DepConditionalBlocks}, // wisp source
+		{IssueID: "bt-child", DependsOnID: "bt-x", Type: types.DepParentChild},
+		{IssueID: "bt-yblk", DependsOnID: "bt-y", Type: types.DepBlocks},
+		{IssueID: "bt-x", DependsOnID: "bt-z", Type: types.DepBlocks}, // decoy: bt-x is the SOURCE
+	} {
+		if err := te.store.AddDependency(ctx, dep, "tester"); err != nil {
+			t.Fatalf("AddDependency %s->%s: %v", dep.IssueID, dep.DependsOnID, err)
+		}
+	}
+
+	typesBySrc := func(deps []*types.Dependency, target string) map[string]types.DependencyType {
+		out := map[string]types.DependencyType{}
+		for _, d := range deps {
+			if d.DependsOnID != target {
+				t.Fatalf("row keyed under %s has target %s", target, d.DependsOnID)
+			}
+			if d.ID == "" {
+				t.Fatalf("dependent row missing ID: %+v", d)
+			}
+			out[d.IssueID] = d.Type
+		}
+		return out
+	}
+
+	byTarget, err := te.store.GetDependentRecordsForIssues(ctx, []string{"bt-x", "bt-y"})
+	if err != nil {
+		t.Fatalf("GetDependentRecordsForIssues: %v", err)
+	}
+	x := typesBySrc(byTarget["bt-x"], "bt-x")
+	if len(x) != 4 || x["bt-blk"] != types.DepBlocks || x["bt-wait"] != types.DepWaitsFor ||
+		x["bt-cond"] != types.DepConditionalBlocks || x["bt-child"] != types.DepParentChild {
+		t.Fatalf("X dependents = %v, want the full 4-type set with real dep_type", x)
+	}
+	if _, bad := x["bt-z"]; bad {
+		t.Fatalf("decoy edge X->Z surfaced as an inbound edge of X: %v", x)
+	}
+	y := typesBySrc(byTarget["bt-y"], "bt-y")
+	if len(y) != 1 || y["bt-yblk"] != types.DepBlocks {
+		t.Fatalf("Y dependents = %v, want {bt-yblk: blocks}", y)
+	}
+}

--- a/internal/storage/embeddeddolt/dependents_records_test.go
+++ b/internal/storage/embeddeddolt/dependents_records_test.go
@@ -1,0 +1,93 @@
+//go:build cgo
+
+package embeddeddolt_test
+
+import (
+	"testing"
+
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// TestGetDependentRecordsEmbedded mirrors the dolt-suite target-keyed dependents
+// coverage on the embedded backend: direction, two-table span (durable + wisp
+// sources), the type filter, row-id keyset paging with no drop/dup, and
+// CountDependentRecords totals.
+func TestGetDependentRecordsEmbedded(t *testing.T) {
+	skipUnlessEmbeddedDolt(t)
+
+	te := newTestEnv(t, "dr")
+	ctx := t.Context()
+
+	for _, issue := range []*types.Issue{
+		{ID: "dr-target", Title: "target", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask},
+		{ID: "dr-s1", Title: "s1", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask},
+		{ID: "dr-s2", Title: "s2", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask},
+		{ID: "dr-w", Title: "wisp", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask, Ephemeral: true},
+	} {
+		if err := te.store.CreateIssue(ctx, issue, "tester"); err != nil {
+			t.Fatalf("CreateIssue %s: %v", issue.ID, err)
+		}
+	}
+	for _, dep := range []*types.Dependency{
+		{IssueID: "dr-s1", DependsOnID: "dr-target", Type: types.DepBlocks},
+		{IssueID: "dr-s2", DependsOnID: "dr-target", Type: types.DepParentChild},
+		{IssueID: "dr-w", DependsOnID: "dr-target", Type: types.DepBlocks}, // wisp source -> wisp_dependencies
+	} {
+		if err := te.store.AddDependency(ctx, dep, "tester"); err != nil {
+			t.Fatalf("AddDependency %s->%s: %v", dep.IssueID, dep.DependsOnID, err)
+		}
+	}
+
+	set := func(deps []*types.Dependency) map[string]bool {
+		m := map[string]bool{}
+		for _, d := range deps {
+			if d.ID == "" {
+				t.Fatalf("dependent row missing ID (keyset cursor): %+v", d)
+			}
+			m[d.IssueID] = true
+		}
+		return m
+	}
+
+	all, err := te.store.GetDependentRecords(ctx, "dr-target", "", 100, "")
+	if err != nil {
+		t.Fatalf("GetDependentRecords: %v", err)
+	}
+	got := set(all)
+	if len(got) != 3 || !got["dr-s1"] || !got["dr-s2"] || !got["dr-w"] {
+		t.Fatalf("dependents = %v, want {dr-s1, dr-s2, dr-w} (spanning both tables)", got)
+	}
+
+	// Row-id keyset paging across the two-table boundary.
+	seen := map[string]bool{}
+	after := ""
+	for i := 0; i < 10; i++ {
+		page, err := te.store.GetDependentRecords(ctx, "dr-target", "", 1, after)
+		if err != nil {
+			t.Fatalf("page after %q: %v", after, err)
+		}
+		if len(page) == 0 {
+			break
+		}
+		if seen[page[0].IssueID] {
+			t.Fatalf("duplicate source %q across pages", page[0].IssueID)
+		}
+		seen[page[0].IssueID] = true
+		after = page[0].ID
+	}
+	if len(seen) != 3 {
+		t.Fatalf("paged sources = %v, want 3 distinct", seen)
+	}
+
+	// CountDependentRecords totals span both tables and honor the type filter.
+	if n, err := te.store.CountDependentRecords(ctx, "dr-target", ""); err != nil {
+		t.Fatalf("CountDependentRecords: %v", err)
+	} else if n != 3 {
+		t.Fatalf("CountDependentRecords(all) = %d, want 3", n)
+	}
+	if n, err := te.store.CountDependentRecords(ctx, "dr-target", string(types.DepBlocks)); err != nil {
+		t.Fatalf("CountDependentRecords(blocks): %v", err)
+	} else if n != 2 {
+		t.Fatalf("CountDependentRecords(blocks) = %d, want 2 (dr-s1 + dr-w)", n)
+	}
+}

--- a/internal/storage/embeddeddolt/events_since_test.go
+++ b/internal/storage/embeddeddolt/events_since_test.go
@@ -1,0 +1,75 @@
+//go:build cgo
+
+package embeddeddolt_test
+
+import (
+	"testing"
+
+	"github.com/steveyegge/beads/internal/storage"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// TestEventsSinceEmbedded mirrors the dolt-suite EventsSince coverage on the
+// embedded backend: the durable keyset feed returns durable events in
+// (created_at, id) order, excludes wisp events, and honors the per-issue filter.
+// Events are driven through store operations (CreateIssue/ClaimIssue) rather than
+// raw INSERTs, since the external test package shares no connection with the
+// store's working set.
+func TestEventsSinceEmbedded(t *testing.T) {
+	skipUnlessEmbeddedDolt(t)
+
+	te := newTestEnv(t, "es")
+	ctx := t.Context()
+
+	for _, issue := range []*types.Issue{
+		{ID: "es-a", Title: "durable a", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask},
+		{ID: "es-b", Title: "durable b", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask},
+		{ID: "es-w", Title: "wisp", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask, Ephemeral: true},
+	} {
+		if err := te.store.CreateIssue(ctx, issue, "tester"); err != nil {
+			t.Fatalf("CreateIssue %s: %v", issue.ID, err)
+		}
+	}
+	// A durable claim adds a second durable event on es-a.
+	if err := te.store.ClaimIssue(ctx, "es-a", "worker"); err != nil {
+		t.Fatalf("ClaimIssue es-a: %v", err)
+	}
+
+	// Unfiltered durable feed: es-a and es-b events present, wisp excluded,
+	// created_at non-decreasing.
+	all, err := te.store.EventsSince(ctx, storage.EventCursor{}, "", 500)
+	if err != nil {
+		t.Fatalf("EventsSince(all): %v", err)
+	}
+	var sawA, sawB bool
+	for i, e := range all {
+		switch e.IssueID {
+		case "es-a":
+			sawA = true
+		case "es-b":
+			sawB = true
+		case "es-w":
+			t.Fatalf("durable-only feed returned a wisp event for es-w")
+		}
+		if i > 0 && e.CreatedAt.Before(all[i-1].CreatedAt) {
+			t.Fatalf("feed not ordered by created_at ASC at index %d", i)
+		}
+	}
+	if !sawA || !sawB {
+		t.Fatalf("durable feed missing events: sawA=%v sawB=%v", sawA, sawB)
+	}
+
+	// Per-issue filter: only es-a's events.
+	onlyA, err := te.store.EventsSince(ctx, storage.EventCursor{}, "es-a", 500)
+	if err != nil {
+		t.Fatalf("EventsSince(issue=es-a): %v", err)
+	}
+	if len(onlyA) == 0 {
+		t.Fatalf("filtered es-a feed is empty")
+	}
+	for _, e := range onlyA {
+		if e.IssueID != "es-a" {
+			t.Fatalf("filtered es-a feed returned event for %s", e.IssueID)
+		}
+	}
+}

--- a/internal/storage/embeddeddolt/is_blocked_batch_test.go
+++ b/internal/storage/embeddeddolt/is_blocked_batch_test.go
@@ -1,0 +1,63 @@
+//go:build cgo
+
+package embeddeddolt_test
+
+import (
+	"testing"
+
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// TestIsBlockedBatchEmbedded is the batch-is_blocked regression on the embedded
+// Dolt backend: IsBlockedBatch agrees with per-row IsBlocked for every id and
+// reflects an inherited parent-child block (transitive is_blocked with an empty
+// direct-blocker set), through the same store surface.
+func TestIsBlockedBatchEmbedded(t *testing.T) {
+	skipUnlessEmbeddedDolt(t)
+
+	te := newTestEnv(t, "ib")
+	ctx := t.Context()
+
+	mk := func(id string) {
+		iss := &types.Issue{ID: id, Title: id, Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask}
+		if err := te.store.CreateIssue(ctx, iss, "tester"); err != nil {
+			t.Fatalf("create %s: %v", id, err)
+		}
+	}
+	add := func(src, tgt string, typ types.DependencyType) {
+		if err := te.store.AddDependency(ctx, &types.Dependency{IssueID: src, DependsOnID: tgt, Type: typ}, "tester"); err != nil {
+			t.Fatalf("add dep %s->%s: %v", src, tgt, err)
+		}
+	}
+	mk("ib-blk")
+	mk("ib-parent")
+	add("ib-parent", "ib-blk", types.DepBlocks)
+	mk("ib-child")
+	add("ib-child", "ib-parent", types.DepParentChild)
+	mk("ib-free")
+
+	ids := []string{"ib-blk", "ib-parent", "ib-child", "ib-free"}
+	batch, err := te.store.IsBlockedBatch(ctx, ids)
+	if err != nil {
+		t.Fatalf("IsBlockedBatch: %v", err)
+	}
+	for _, id := range ids {
+		want, _, err := te.store.IsBlocked(ctx, id)
+		if err != nil {
+			t.Fatalf("IsBlocked(%s): %v", id, err)
+		}
+		if batch[id] != want {
+			t.Fatalf("IsBlockedBatch[%s] = %v, want %v (per-row IsBlocked)", id, batch[id], want)
+		}
+	}
+	blocked, blockers, err := te.store.IsBlocked(ctx, "ib-child")
+	if err != nil {
+		t.Fatalf("IsBlocked(ib-child): %v", err)
+	}
+	if !blocked || len(blockers) != 0 {
+		t.Fatalf("ib-child IsBlocked = (%v, %v), want (true, []) — inherited block, empty direct blockers", blocked, blockers)
+	}
+	if !batch["ib-child"] || !batch["ib-parent"] || batch["ib-free"] {
+		t.Fatalf("IsBlockedBatch = %v, want child+parent true, free false", batch)
+	}
+}

--- a/internal/storage/embeddeddolt/issues.go
+++ b/internal/storage/embeddeddolt/issues.go
@@ -200,6 +200,18 @@ func (s *EmbeddedDoltStore) IsBlocked(ctx context.Context, issueID string) (bool
 	return blocked, blockers, err
 }
 
+// IsBlockedBatch returns the denormalized transitive is_blocked flag for each id
+// in one batched read. Delegates to issueops.IsBlockedBatchInTx.
+func (s *EmbeddedDoltStore) IsBlockedBatch(ctx context.Context, ids []string) (map[string]bool, error) {
+	var result map[string]bool
+	err := s.withConn(ctx, false, func(tx *sql.Tx) error {
+		var err error
+		result, err = issueops.IsBlockedBatchInTx(ctx, tx, ids)
+		return err
+	})
+	return result, err
+}
+
 // GetNewlyUnblockedByClose finds issues that become unblocked when closedIssueID is closed.
 func (s *EmbeddedDoltStore) GetNewlyUnblockedByClose(ctx context.Context, closedIssueID string) ([]*types.Issue, error) {
 	var result []*types.Issue

--- a/internal/storage/embeddeddolt/list_queries.go
+++ b/internal/storage/embeddeddolt/list_queries.go
@@ -92,6 +92,19 @@ func (s *EmbeddedDoltStore) GetDependencyRecordsForIssues(ctx context.Context, i
 	return result, err
 }
 
+// GetDependentRecordsForIssues returns the raw inbound dependency rows for a SET
+// of target ids in one batched read, keyed by target id. Delegates to
+// issueops.GetDependentRecordsForIssuesInTx for shared query logic.
+func (s *EmbeddedDoltStore) GetDependentRecordsForIssues(ctx context.Context, targetIDs []string) (map[string][]*types.Dependency, error) {
+	var result map[string][]*types.Dependency
+	err := s.withConn(ctx, false, func(tx *sql.Tx) error {
+		var err error
+		result, err = issueops.GetDependentRecordsForIssuesInTx(ctx, tx, targetIDs)
+		return err
+	})
+	return result, err
+}
+
 func (s *EmbeddedDoltStore) GetDependencyCounts(ctx context.Context, issueIDs []string) (map[string]*types.DependencyCounts, error) {
 	var result map[string]*types.DependencyCounts
 	err := s.withConn(ctx, false, func(tx *sql.Tx) error {

--- a/internal/storage/embeddeddolt/store.go
+++ b/internal/storage/embeddeddolt/store.go
@@ -573,11 +573,12 @@ func (s *EmbeddedDoltStore) GetAllEventsSince(ctx context.Context, since time.Ti
 
 // EventsSince returns durable events strictly after the keyset cursor, ordered
 // by (created_at ASC, id ASC) and bounded by limit. Durable events table only.
-func (s *EmbeddedDoltStore) EventsSince(ctx context.Context, cursor storage.EventCursor, limit int) ([]*types.Event, error) {
+// issueID != "" scopes the feed to one bead's history.
+func (s *EmbeddedDoltStore) EventsSince(ctx context.Context, cursor storage.EventCursor, issueID string, limit int) ([]*types.Event, error) {
 	var result []*types.Event
 	err := s.withConn(ctx, false, func(tx *sql.Tx) error {
 		var err error
-		result, err = issueops.EventsSinceInTx(ctx, tx, cursor.CreatedAt, cursor.ID, limit)
+		result, err = issueops.EventsSinceInTx(ctx, tx, cursor.CreatedAt, cursor.ID, issueID, limit)
 		return err
 	})
 	return result, err

--- a/internal/storage/embeddeddolt/store.go
+++ b/internal/storage/embeddeddolt/store.go
@@ -571,6 +571,18 @@ func (s *EmbeddedDoltStore) GetAllEventsSince(ctx context.Context, since time.Ti
 	return result, err
 }
 
+// EventsSince returns durable events strictly after the keyset cursor, ordered
+// by (created_at ASC, id ASC) and bounded by limit. Durable events table only.
+func (s *EmbeddedDoltStore) EventsSince(ctx context.Context, cursor storage.EventCursor, limit int) ([]*types.Event, error) {
+	var result []*types.Event
+	err := s.withConn(ctx, false, func(tx *sql.Tx) error {
+		var err error
+		result, err = issueops.EventsSinceInTx(ctx, tx, cursor.CreatedAt, cursor.ID, limit)
+		return err
+	})
+	return result, err
+}
+
 // RunInTransaction is implemented in transaction.go.
 
 // Close decrements the reference count if this store was opened via Open (the
@@ -896,6 +908,18 @@ func (s *EmbeddedDoltStore) GetDependencyRecords(ctx context.Context, issueID st
 		}
 		result = m[issueID]
 		return nil
+	})
+	return result, err
+}
+
+// GetDependentRecords returns raw dependency rows whose target is targetID,
+// without hydrating the source issues. Delegates to shared query logic.
+func (s *EmbeddedDoltStore) GetDependentRecords(ctx context.Context, targetID string, depType string, limit int, afterID string) ([]*types.Dependency, error) {
+	var result []*types.Dependency
+	err := s.withConn(ctx, false, func(tx *sql.Tx) error {
+		var err error
+		result, err = issueops.GetDependentRecordsInTx(ctx, tx, targetID, depType, limit, afterID)
+		return err
 	})
 	return result, err
 }

--- a/internal/storage/embeddeddolt/store.go
+++ b/internal/storage/embeddeddolt/store.go
@@ -925,6 +925,18 @@ func (s *EmbeddedDoltStore) GetDependentRecords(ctx context.Context, targetID st
 	return result, err
 }
 
+// CountDependentRecords returns the total inbound-edge count of targetID across
+// both dependency tables. Delegates to issueops.CountDependentRecordsInTx.
+func (s *EmbeddedDoltStore) CountDependentRecords(ctx context.Context, targetID string, depType string) (int, error) {
+	var n int
+	err := s.withConn(ctx, false, func(tx *sql.Tx) error {
+		var err error
+		n, err = issueops.CountDependentRecordsInTx(ctx, tx, targetID, depType)
+		return err
+	})
+	return n, err
+}
+
 // IsBlocked is implemented in issues.go.
 
 // GetNewlyUnblockedByClose is implemented in issues.go.

--- a/internal/storage/embeddeddolt/transaction.go
+++ b/internal/storage/embeddeddolt/transaction.go
@@ -253,3 +253,63 @@ func (t *embeddedTransaction) CreateIssueImport(ctx context.Context, issue *type
 	}
 	return nil
 }
+
+// The composite-view reads below all run on the single embedded transaction
+// handle. Unlike the classic Dolt store, the embedded store has no durable/wisp
+// session split, so every read here — including the both-tiers-spanning ones —
+// is read-your-writes on both tiers; the InTx functions do their own wisp
+// routing on the one handle. The two-session wisp caveat in the
+// storage.Transaction doc applies only to the server (Dolt) backend.
+
+// GetIssueCommentsPage returns one keyset page of an issue's comments within the
+// transaction. Mirrors EmbeddedDoltStore.GetIssueCommentsPage's issueops
+// delegation.
+func (t *embeddedTransaction) GetIssueCommentsPage(ctx context.Context, issueID string, after storage.CommentPageCursor, limit int) ([]*types.Comment, error) {
+	return issueops.GetIssueCommentsPageInTx(ctx, t.tx, issueID, after, limit)
+}
+
+// CountIssuesByGroup returns per-group issue counts within the transaction.
+// Mirrors EmbeddedDoltStore.CountIssuesByGroup's issueops delegation.
+func (t *embeddedTransaction) CountIssuesByGroup(ctx context.Context, filter types.IssueFilter, groupBy string) (map[string]int, error) {
+	return issueops.CountIssuesByGroupInTx(ctx, t.tx, filter, groupBy)
+}
+
+// GetDependentRecords returns the raw inbound dependency rows of targetID within
+// the transaction. Mirrors EmbeddedDoltStore.GetDependentRecords; the InTx
+// function spans both dependency tables itself.
+func (t *embeddedTransaction) GetDependentRecords(ctx context.Context, targetID string, depType string, limit int, afterID string) ([]*types.Dependency, error) {
+	return issueops.GetDependentRecordsInTx(ctx, t.tx, targetID, depType, limit, afterID)
+}
+
+// GetDependentRecordsForIssues returns the raw inbound dependency rows for a set
+// of target ids within the transaction, keyed by target id. Mirrors
+// EmbeddedDoltStore.GetDependentRecordsForIssues.
+func (t *embeddedTransaction) GetDependentRecordsForIssues(ctx context.Context, targetIDs []string) (map[string][]*types.Dependency, error) {
+	return issueops.GetDependentRecordsForIssuesInTx(ctx, t.tx, targetIDs)
+}
+
+// CountDependentRecords returns the total inbound-edge count of targetID within
+// the transaction. Mirrors EmbeddedDoltStore.CountDependentRecords.
+func (t *embeddedTransaction) CountDependentRecords(ctx context.Context, targetID string, depType string) (int, error) {
+	return issueops.CountDependentRecordsInTx(ctx, t.tx, targetID, depType)
+}
+
+// IsBlocked reports the denormalized transitive is_blocked flag and direct
+// blockers of issueID within the transaction. Mirrors
+// EmbeddedDoltStore.IsBlocked's issueops delegation.
+func (t *embeddedTransaction) IsBlocked(ctx context.Context, issueID string) (bool, []string, error) {
+	return issueops.IsBlockedInTx(ctx, t.tx, issueID)
+}
+
+// IsBlockedBatch reports the denormalized transitive is_blocked flag for a page
+// of ids within the transaction. Mirrors EmbeddedDoltStore.IsBlockedBatch; the
+// InTx function batches over both the issues and wisps tables itself.
+func (t *embeddedTransaction) IsBlockedBatch(ctx context.Context, ids []string) (map[string]bool, error) {
+	return issueops.IsBlockedBatchInTx(ctx, t.tx, ids)
+}
+
+// EventsSince returns durable events strictly after the keyset cursor within the
+// transaction. Mirrors EmbeddedDoltStore.EventsSince's issueops delegation.
+func (t *embeddedTransaction) EventsSince(ctx context.Context, cursor storage.EventCursor, issueID string, limit int) ([]*types.Event, error) {
+	return issueops.EventsSinceInTx(ctx, t.tx, cursor.CreatedAt, cursor.ID, issueID, limit)
+}

--- a/internal/storage/event_queries.go
+++ b/internal/storage/event_queries.go
@@ -1,0 +1,27 @@
+package storage
+
+import (
+	"context"
+	"time"
+
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// EventCursor is a keyset position in the durable events stream, ordered by
+// (created_at, id). The zero value (zero time, empty id) means "from the
+// beginning".
+type EventCursor struct {
+	CreatedAt time.Time
+	ID        string
+}
+
+// EventQueryStore provides keyset paging over the durable event log, beyond
+// the base Storage interface's time-only GetAllEventsSince. Callers that need
+// it type-assert to this interface.
+type EventQueryStore interface {
+	// EventsSince returns durable events strictly after cursor, ordered by
+	// (created_at ASC, id ASC) and bounded by limit (0 = a store default,
+	// capped). It reads the durable events table only — wisp events are not
+	// included — so a change feed built on it stays durable-only.
+	EventsSince(ctx context.Context, cursor EventCursor, limit int) ([]*types.Event, error)
+}

--- a/internal/storage/event_queries.go
+++ b/internal/storage/event_queries.go
@@ -23,5 +23,19 @@ type EventQueryStore interface {
 	// (created_at ASC, id ASC) and bounded by limit (0 = a store default,
 	// capped). It reads the durable events table only — wisp events are not
 	// included — so a change feed built on it stays durable-only.
-	EventsSince(ctx context.Context, cursor EventCursor, limit int) ([]*types.Event, error)
+	//
+	// issueID scopes the feed to a single bead's history ("" = all issues),
+	// serving a per-bead drawer read off the same keyset primitive. The scan
+	// seeks idx_events_created_at on the created_at lower bound; with issueID
+	// set the planner may instead seek idx_events_issue and filter on the
+	// cursor (a composite (issue_id, created_at, id) index does not exist).
+	//
+	// COMMIT-VISIBILITY-LAG CAVEAT: created_at is the event's logical timestamp,
+	// but on a version-controlled backend a committed row can become visible to
+	// readers slightly after its created_at. A feed that resumes from the last
+	// row's cursor must therefore re-scan a slack window behind it (a resuming
+	// consumer should overlap ~45s) and de-duplicate by id, or it can skip an
+	// event whose created_at preceded the cursor but which committed after the
+	// previous read.
+	EventsSince(ctx context.Context, cursor EventCursor, issueID string, limit int) ([]*types.Event, error)
 }

--- a/internal/storage/issueops/claim.go
+++ b/internal/storage/issueops/claim.go
@@ -151,8 +151,14 @@ func ClaimIssueInTx(ctx context.Context, tx DBTX, id string, actor string) (*Cla
 				// pattern-matched by batch agents into an unclaim+claim
 				// steamroller of live claims (wy-yuclk). Point at the holder;
 				// bd reclaim is safe to name because it only recovers claims
-				// whose lease has already expired.
-				return nil, fmt.Errorf("issue already assigned to %q — coordinate with the holder; if their claim is abandoned (crashed agent), lease expiry will surface it for bd reclaim", assignee)
+				// whose lease has already expired. Keep the %w wrap so this
+				// open-but-assigned refusal is still a classifiable claim
+				// conflict: the public IssueClaimer contract promises wrapped
+				// ErrAlreadyClaimed, and errors.Is / ParseClaimConflict (and the
+				// proxied batch exit code) key on it. This mirrors the
+				// domain-stack twin (domain.issueUseCaseImpl.claim, bd-at6rc),
+				// which already wraps the same message.
+				return nil, fmt.Errorf("%w: already assigned to %q — coordinate with the holder; if their claim is abandoned (crashed agent), lease expiry will surface it for bd reclaim", storage.ErrAlreadyClaimed, assignee)
 			}
 			return nil, fmt.Errorf("%w%s%s", storage.ErrAlreadyClaimed, storage.ClaimedByFragment, assignee)
 		}

--- a/internal/storage/issueops/claim.go
+++ b/internal/storage/issueops/claim.go
@@ -177,7 +177,7 @@ func ClaimIssueInTx(ctx context.Context, tx DBTX, id string, actor string) (*Cla
 	}
 	newData, _ := json.Marshal(newUpdates)
 
-	if err := RecordFullEventInTable(ctx, tx, eventTable, id, "claimed", actor, string(oldData), string(newData)); err != nil {
+	if err := RecordFullEventInTable(ctx, tx, eventTable, id, types.EventClaimed, actor, string(oldData), string(newData)); err != nil {
 		return nil, fmt.Errorf("failed to record claim event: %w", err)
 	}
 

--- a/internal/storage/issueops/claim.go
+++ b/internal/storage/issueops/claim.go
@@ -143,7 +143,7 @@ func ClaimIssueInTx(ctx context.Context, tx DBTX, id string, actor string) (*Cla
 			// non-assignee reason (status changed underneath us): report the
 			// status rather than a misleading held-by-someone refusal.
 			if slices.Contains(pools, assignee) {
-				return nil, fmt.Errorf("%w: status %s", storage.ErrNotClaimable, currentStatus)
+				return nil, fmt.Errorf("%w%s%s", storage.ErrNotClaimable, storage.NotClaimableStatusFragment, currentStatus)
 			}
 			if currentStatus == types.StatusOpen {
 				// Do not name a release command here — not `bd unclaim`, not
@@ -154,9 +154,9 @@ func ClaimIssueInTx(ctx context.Context, tx DBTX, id string, actor string) (*Cla
 				// whose lease has already expired.
 				return nil, fmt.Errorf("issue already assigned to %q — coordinate with the holder; if their claim is abandoned (crashed agent), lease expiry will surface it for bd reclaim", assignee)
 			}
-			return nil, fmt.Errorf("%w by %s", storage.ErrAlreadyClaimed, assignee)
+			return nil, fmt.Errorf("%w%s%s", storage.ErrAlreadyClaimed, storage.ClaimedByFragment, assignee)
 		}
-		return nil, fmt.Errorf("%w: status %s", storage.ErrNotClaimable, currentStatus)
+		return nil, fmt.Errorf("%w%s%s", storage.ErrNotClaimable, storage.NotClaimableStatusFragment, currentStatus)
 	}
 
 	// Grant the lease: what makes the claim recoverable — a worker that dies

--- a/internal/storage/issueops/dependencies.go
+++ b/internal/storage/issueops/dependencies.go
@@ -64,11 +64,8 @@ func depTargetEquals(alias string) string {
 // so the un-ordered COUNT still scans, but the COALESCE form never had any index
 // path either; the type-filtered path seeks the (type, target) composite on both.
 // Use it for target-keyed reads of a single fixed target.
-func depTargetEqualsOr(alias string) string {
-	if alias == "" {
-		return "(depends_on_issue_id = ? OR depends_on_wisp_id = ? OR depends_on_external = ?)"
-	}
-	return fmt.Sprintf("(%s.depends_on_issue_id = ? OR %s.depends_on_wisp_id = ? OR %s.depends_on_external = ?)", alias, alias, alias)
+func depTargetEqualsOr() string {
+	return "(depends_on_issue_id = ? OR depends_on_wisp_id = ? OR depends_on_external = ?)"
 }
 
 func depTargetIn(alias, placeholders string) string {

--- a/internal/storage/issueops/dependencies.go
+++ b/internal/storage/issueops/dependencies.go
@@ -49,6 +49,28 @@ func depTargetEquals(alias string) string {
 	return depTargetExpr(alias) + " = ?"
 }
 
+// depTargetEqualsOr returns a SARGABLE target-equality predicate as an explicit
+// per-column OR — `(depends_on_issue_id = ? OR depends_on_wisp_id = ? OR
+// depends_on_external = ?)` — binding the target id once per typed column (three
+// args, in that column order). Unlike depTargetEquals's COALESCE wrapper (which
+// wraps the columns in an expression no index can match), each disjunct is a
+// bare indexed column.
+//
+// On an index-merging planner (e.g. Postgres) this plans as a BitmapOr
+// index-merge over idx_dep_{issue,wisp,external}_target (a Bitmap Heap Scan,
+// cost ~36 on a 5k-row table) where the COALESCE form is a Seq Scan (cost
+// ~104). On Dolt
+// (go-mysql-server) the optimizer does not index-merge an OR of distinct columns,
+// so the un-ordered COUNT still scans, but the COALESCE form never had any index
+// path either; the type-filtered path seeks the (type, target) composite on both.
+// Use it for target-keyed reads of a single fixed target.
+func depTargetEqualsOr(alias string) string {
+	if alias == "" {
+		return "(depends_on_issue_id = ? OR depends_on_wisp_id = ? OR depends_on_external = ?)"
+	}
+	return fmt.Sprintf("(%s.depends_on_issue_id = ? OR %s.depends_on_wisp_id = ? OR %s.depends_on_external = ?)", alias, alias, alias)
+}
+
 func depTargetIn(alias, placeholders string) string {
 	return depTargetExpr(alias) + " IN (" + placeholders + ")"
 }

--- a/internal/storage/issueops/dependency_queries.go
+++ b/internal/storage/issueops/dependency_queries.go
@@ -131,6 +131,97 @@ func getDependencyRecordsIntoFromTable(ctx context.Context, tx DBTX, depTable st
 	return nil
 }
 
+// Target-keyed dependents-read bounds. A raw read has no consumer to apply a
+// page size, so it clamps its own (default when limit <= 0, hard cap otherwise).
+const (
+	defaultDependentRecordsLimit = 100
+	maxDependentRecordsLimit     = 500
+)
+
+// GetDependentRecordsInTx returns raw dependency rows whose TARGET is targetID
+// — the edges pointing AT targetID — from both the permanent and wisp
+// dependency tables. Unlike GetDependents/GetDependentsWithMetadata it does
+// NOT join or hydrate the source issues, so edges from dangling, cross-project,
+// or wisp sources are returned as raw rows rather than dropped. Rows are keyed
+// by their source issue_id (Dependency.IssueID); target resolution COALESCEs
+// the three typed target columns exactly like the source-keyed sibling reads.
+//
+// When depType is non-empty only rows of that dependency type are returned
+// ("" = all types). Results are ordered by source issue_id ASC and bounded by
+// limit (see the clamp constants). afterID is a keyset continuation over that
+// order: "" starts at the beginning, otherwise only rows with issue_id > afterID
+// are returned. The (issue_id, typed-target) unique keys make issue_id unique
+// among rows sharing a fixed target, so paging on it drops no rows.
+func GetDependentRecordsInTx(ctx context.Context, tx DBTX, targetID, depType string, limit int, afterID string) ([]*types.Dependency, error) {
+	if limit <= 0 {
+		limit = defaultDependentRecordsLimit
+	}
+	if limit > maxDependentRecordsLimit {
+		limit = maxDependentRecordsLimit
+	}
+
+	var all []*types.Dependency
+	for _, depTable := range []string{"dependencies", "wisp_dependencies"} {
+		rows, err := queryDependentRecordsFromTable(ctx, tx, depTable, targetID, depType, limit, afterID)
+		if err != nil {
+			if optionalBlockedTable(depTable) && isTableNotExistError(err) {
+				continue
+			}
+			return nil, err
+		}
+		all = append(all, rows...)
+	}
+
+	// Merge the two per-table pages into one deterministic order. issue_id is
+	// unique per fixed target across both tables (durable vs wisp sources have
+	// disjoint ids), so ordering by (issue_id, type) is total; type is only a
+	// tie-break for the pathological same-source/same-target-string edge.
+	sort.Slice(all, func(i, j int) bool {
+		if all[i].IssueID != all[j].IssueID {
+			return all[i].IssueID < all[j].IssueID
+		}
+		return all[i].Type < all[j].Type
+	})
+	if len(all) > limit {
+		all = all[:limit]
+	}
+	return all, nil
+}
+
+//nolint:gosec // G201: depTable is a hardcoded constant; targetID/depType/afterID are bound as parameters.
+func queryDependentRecordsFromTable(ctx context.Context, tx DBTX, depTable, targetID, depType string, limit int, afterID string) ([]*types.Dependency, error) {
+	query := fmt.Sprintf(`
+		SELECT issue_id, %s AS depends_on_id, type, created_at, created_by, metadata, thread_id
+		FROM %s
+		WHERE %s`, DepTargetExpr, depTable, depTargetEquals(""))
+	args := []any{targetID}
+	if depType != "" {
+		query += " AND type = ?"
+		args = append(args, depType)
+	}
+	if afterID != "" {
+		query += " AND issue_id > ?"
+		args = append(args, afterID)
+	}
+	query += fmt.Sprintf(" ORDER BY issue_id ASC LIMIT %d", limit)
+
+	rows, err := tx.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("get dependent records from %s: %w", depTable, err)
+	}
+	defer rows.Close()
+
+	var deps []*types.Dependency
+	for rows.Next() {
+		dep, scanErr := scanDependencyRow(rows)
+		if scanErr != nil {
+			return nil, fmt.Errorf("get dependent records: scan: %w", scanErr)
+		}
+		deps = append(deps, dep)
+	}
+	return deps, rows.Err()
+}
+
 func GetDependencyCountsInTx(ctx context.Context, tx DBTX, issueIDs []string) (map[string]*types.DependencyCounts, error) {
 	if len(issueIDs) == 0 {
 		return make(map[string]*types.DependencyCounts), nil

--- a/internal/storage/issueops/dependency_queries.go
+++ b/internal/storage/issueops/dependency_queries.go
@@ -995,55 +995,61 @@ func IsBlockedInTx(ctx context.Context, tx DBTX, issueID string) (bool, []string
 // and skips any later (wisps) duplicate. The two reads share the is_blocked field,
 // so they must resolve a collision identically — this is a data anomaly, but the
 // single and batch reads would otherwise disagree on the same stored flag.
-//
-//nolint:gosec // G201: table is a hardcoded "issues" or "wisps".
 func IsBlockedBatchInTx(ctx context.Context, tx DBTX, ids []string) (map[string]bool, error) {
 	blocked := make(map[string]bool, len(ids))
 	if len(ids) == 0 {
 		return blocked, nil
 	}
-
-	seen := make(map[string]string, len(ids))
+	// De-dup by id across the two tables, keeping the first-seen (issues) value so
+	// a cross-table collision resolves ISSUES-win, exactly as IsBlockedInTx does
+	// (see above). The wisps table is optional, so a missing one is skipped —
+	// same two-table read shape as GetDependentRecordsForIssuesInTx.
+	seen := make(map[string]bool, len(ids))
 	for _, table := range []string{"issues", "wisps"} {
-		for start := 0; start < len(ids); start += queryBatchSize {
-			end := start + queryBatchSize
-			if end > len(ids) {
-				end = len(ids)
+		if err := readIsBlockedIntoFromTable(ctx, tx, table, ids, seen, blocked); err != nil {
+			if optionalBlockedTable(table) && isTableNotExistError(err) {
+				continue
 			}
-			placeholders, args := buildSQLInClause(ids[start:end])
-			rows, err := tx.QueryContext(ctx, fmt.Sprintf(
-				"SELECT id, is_blocked FROM %s WHERE id IN (%s)", table, placeholders), args...)
-			if err != nil {
-				if optionalBlockedTable(table) && isTableNotExistError(err) {
-					break
-				}
-				return nil, fmt.Errorf("read is_blocked from %s: %w", table, err)
-			}
-			for rows.Next() {
-				var id string
-				var b int
-				if err := rows.Scan(&id, &b); err != nil {
-					_ = rows.Close()
-					return nil, fmt.Errorf("scan is_blocked from %s: %w", table, err)
-				}
-				// Tables iterate issues→wisps and IsBlockedInTx breaks on the
-				// first table that has the id (issues first) — so ISSUES wins on
-				// a cross-table id collision. Keep the first-seen value and skip
-				// any later (wisps) duplicate, so the batch is_blocked matches
-				// per-row IsBlocked exactly on the shared field.
-				if _, dup := seen[id]; dup {
-					continue
-				}
-				seen[id] = table
-				blocked[id] = b != 0
-			}
-			_ = rows.Close()
-			if err := rows.Err(); err != nil {
-				return nil, fmt.Errorf("is_blocked rows from %s: %w", table, err)
-			}
+			return nil, err
 		}
 	}
 	return blocked, nil
+}
+
+//nolint:gosec // G201: table is a hardcoded "issues" or "wisps"; placeholders are ? only.
+func readIsBlockedIntoFromTable(ctx context.Context, tx DBTX, table string, ids []string, seen, blocked map[string]bool) error {
+	for start := 0; start < len(ids); start += queryBatchSize {
+		end := start + queryBatchSize
+		if end > len(ids) {
+			end = len(ids)
+		}
+		placeholders, args := buildSQLInClause(ids[start:end])
+		rows, err := tx.QueryContext(ctx, fmt.Sprintf(
+			"SELECT id, is_blocked FROM %s WHERE id IN (%s)", table, placeholders), args...)
+		if err != nil {
+			return fmt.Errorf("read is_blocked from %s: %w", table, err)
+		}
+		for rows.Next() {
+			var id string
+			var b int
+			if err := rows.Scan(&id, &b); err != nil {
+				_ = rows.Close()
+				return fmt.Errorf("scan is_blocked from %s: %w", table, err)
+			}
+			// Keep the first-seen (issues) value and skip any later (wisps)
+			// duplicate, so the batch is_blocked matches per-row IsBlocked.
+			if seen[id] {
+				continue
+			}
+			seen[id] = true
+			blocked[id] = b != 0
+		}
+		_ = rows.Close()
+		if err := rows.Err(); err != nil {
+			return fmt.Errorf("is_blocked rows from %s: %w", table, err)
+		}
+	}
+	return nil
 }
 
 // scanDependencyRow scans a single dependency row from a *sql.Rows.

--- a/internal/storage/issueops/dependency_queries.go
+++ b/internal/storage/issueops/dependency_queries.go
@@ -989,8 +989,12 @@ func IsBlockedInTx(ctx context.Context, tx DBTX, issueID string) (bool, []string
 // at queryBatchSize, so it reflects inherited/ancestor blockedness (a child of a
 // blocked parent has is_blocked=1 with no direct blocking edge of its own) with
 // no graph walk. ids missing from both tables are absent from the map (callers
-// treat absent as not-blocked). On a cross-table id collision the wisps row wins,
-// matching loadStatusByIDInTx and the search wisp-merge.
+// treat absent as not-blocked). On a cross-table id collision the ISSUES row wins,
+// matching IsBlockedInTx exactly: the single read scans issues→wisps and breaks on
+// the first table that has the id, so the batch keeps the first-seen (issues) value
+// and skips any later (wisps) duplicate. The two reads share the is_blocked field,
+// so they must resolve a collision identically — this is a data anomaly, but the
+// single and batch reads would otherwise disagree on the same stored flag.
 //
 //nolint:gosec // G201: table is a hardcoded "issues" or "wisps".
 func IsBlockedBatchInTx(ctx context.Context, tx DBTX, ids []string) (map[string]bool, error) {
@@ -1022,9 +1026,12 @@ func IsBlockedBatchInTx(ctx context.Context, tx DBTX, ids []string) (map[string]
 					_ = rows.Close()
 					return nil, fmt.Errorf("scan is_blocked from %s: %w", table, err)
 				}
-				// Tables iterate issues→wisps, so a second encounter is the
-				// wisps row, which is canonical on a cross-table dup (be-iabdi).
-				if _, dup := seen[id]; dup && table != "wisps" {
+				// Tables iterate issues→wisps and IsBlockedInTx breaks on the
+				// first table that has the id (issues first) — so ISSUES wins on
+				// a cross-table id collision. Keep the first-seen value and skip
+				// any later (wisps) duplicate, so the batch is_blocked matches
+				// per-row IsBlocked exactly on the shared field.
+				if _, dup := seen[id]; dup {
 					continue
 				}
 				seen[id] = table

--- a/internal/storage/issueops/dependency_queries.go
+++ b/internal/storage/issueops/dependency_queries.go
@@ -131,6 +131,87 @@ func getDependencyRecordsIntoFromTable(ctx context.Context, tx DBTX, depTable st
 	return nil
 }
 
+// GetDependentRecordsForIssuesInTx returns raw dependency rows keyed by TARGET
+// id: for each id in targetIDs, the rows whose target is that id — its INCOMING
+// edges, i.e. its dependents — spanning BOTH the durable and wisp dependency
+// tables and applying NO type filter or visibility policy (the caller filters
+// at hydration). It is the batched, target-keyed mirror of the source-keyed
+// GetDependencyRecordsForIssuesInTx: one query per table per batch of
+// queryBatchSize target ids, so cost is O(1 + N/queryBatchSize) round-trips per
+// table rather than O(N) — the whole-page read that lets a caller render every
+// id's inbound `blocks` edges without a per-id fan-out.
+//
+// A target is matched by the coalesced target expression (DepTargetExpr) — the
+// same predicate the batched source-keyed blocks/counts reads use — so an id
+// that appears in any of the three typed target columns resolves; each returned
+// row's DependsOnID is that resolved target, which is the map key. Rows are
+// de-duped by their primary id across the two tables exactly as
+// GetDependentRecordsInTx does: a wisp promoted to durable carries ONE depid in
+// both tables, so the durable table is scanned first and a repeat id from the
+// wisp table is skipped — the edge is returned once, as its authoritative
+// durable row.
+func GetDependentRecordsForIssuesInTx(ctx context.Context, tx DBTX, targetIDs []string) (map[string][]*types.Dependency, error) {
+	result := make(map[string][]*types.Dependency)
+	if len(targetIDs) == 0 {
+		return result, nil
+	}
+	// De-dup by row id across the two tables, preferring the durable copy scanned
+	// first — same cross-table collision handling as GetDependentRecordsInTx.
+	seen := make(map[string]bool)
+	for _, depTable := range []string{"dependencies", "wisp_dependencies"} {
+		if err := getDependentRecordsIntoFromTable(ctx, tx, depTable, targetIDs, seen, result); err != nil {
+			if optionalBlockedTable(depTable) && isTableNotExistError(err) {
+				continue
+			}
+			return nil, err
+		}
+	}
+	return result, nil
+}
+
+//nolint:gosec // G201: depTable is "dependencies" or "wisp_dependencies" (hardcoded by caller); placeholders are ? only.
+func getDependentRecordsIntoFromTable(ctx context.Context, tx DBTX, depTable string, targetIDs []string, seen map[string]bool, result map[string][]*types.Dependency) error {
+	for start := 0; start < len(targetIDs); start += queryBatchSize {
+		end := start + queryBatchSize
+		if end > len(targetIDs) {
+			end = len(targetIDs)
+		}
+		batch := targetIDs[start:end]
+		placeholders := make([]string, len(batch))
+		args := make([]any, len(batch))
+		for i, id := range batch {
+			placeholders[i] = "?"
+			args[i] = id
+		}
+		rows, err := tx.QueryContext(ctx, fmt.Sprintf(
+			`SELECT id, issue_id, %s AS depends_on_id, type, created_at, created_by, metadata, thread_id
+			 FROM %s WHERE %s ORDER BY %s`,
+			DepTargetExpr, depTable, depTargetIn("", strings.Join(placeholders, ",")), DepTargetExpr), args...)
+		if err != nil {
+			return fmt.Errorf("get dependent records from %s: %w", depTable, err)
+		}
+		for rows.Next() {
+			dep, scanErr := scanDependentRow(rows)
+			if scanErr != nil {
+				_ = rows.Close()
+				return fmt.Errorf("get dependent records: scan: %w", scanErr)
+			}
+			// De-dup by row id (depid): the wisp copy of a promoted edge carries
+			// the same id as the durable copy scanned first, so skip the repeat.
+			if seen[dep.ID] {
+				continue
+			}
+			seen[dep.ID] = true
+			result[dep.DependsOnID] = append(result[dep.DependsOnID], dep)
+		}
+		_ = rows.Close()
+		if err := rows.Err(); err != nil {
+			return fmt.Errorf("get dependent records: rows: %w", err)
+		}
+	}
+	return nil
+}
+
 // Target-keyed dependents-read bounds. A raw read has no consumer to apply a
 // page size, so it clamps its own (default when limit <= 0, hard cap otherwise).
 const (

--- a/internal/storage/issueops/dependency_queries.go
+++ b/internal/storage/issueops/dependency_queries.go
@@ -170,6 +170,7 @@ func GetDependentRecordsInTx(ctx context.Context, tx DBTX, targetID, depType str
 	}
 
 	var all []*types.Dependency
+	seen := make(map[string]bool)
 	for _, depTable := range []string{"dependencies", "wisp_dependencies"} {
 		rows, err := queryDependentRecordsFromTable(ctx, tx, depTable, targetID, depType, limit, afterID)
 		if err != nil {
@@ -178,13 +179,29 @@ func GetDependentRecordsInTx(ctx context.Context, tx DBTX, targetID, depType str
 			}
 			return nil, err
 		}
-		all = append(all, rows...)
+		// De-dup by row id across the two tables. depid.New keys the id on
+		// (issue_id, target) and deliberately omits the table, so the SAME edge
+		// that lands in BOTH tables — a wisp promoted to durable, or two clones
+		// merged — carries ONE id in both. Appending the wisp copy would put a
+		// duplicate id in the page and, at a page boundary, drop it on the next
+		// `id > afterID`. We iterate durable first and skip an already-seen id,
+		// so a colliding edge is returned exactly once as its DURABLE row (the
+		// authoritative, non-ephemeral copy). Within a single table id is a
+		// PRIMARY KEY, so intra-table rows never collide.
+		for _, r := range rows {
+			if seen[r.ID] {
+				continue
+			}
+			seen[r.ID] = true
+			all = append(all, r)
+		}
 	}
 
-	// Merge the two per-table pages into one total order by row id. Each table
-	// returned its first `limit` rows with id > afterID, so the global first
-	// `limit` rows with id > afterID are all present; sorting by the globally
-	// unique id and truncating yields exactly that page with no drop and no dup.
+	// Merge the de-duped per-table pages into one total order by row id. Each
+	// table returned its first `limit` rows with id > afterID, so the global
+	// first `limit` DISTINCT ids > afterID are all present; sorting by the
+	// globally unique id and truncating yields exactly that page — no drop, no
+	// dup, and stable across a cross-table id collision.
 	sort.Slice(all, func(i, j int) bool { return all[i].ID < all[j].ID })
 	if len(all) > limit {
 		all = all[:limit]
@@ -250,25 +267,64 @@ func scanDependentRow(rows *sql.Rows) (*types.Dependency, error) {
 	return &dep, nil
 }
 
-// CountDependentRecordsInTx returns the total number of inbound edges of
-// targetID across both dependency tables, applying the same sargable target
-// predicate and optional depType filter as GetDependentRecordsInTx but no
-// keyset/limit. Callers that want a true total membership count need it without
-// paging to exhaustion. Like the paged read it is a RAW count spanning both
-// tables; the caller applies any visibility policy separately.
+// CountDependentRecordsInTx returns the number of DISTINCT inbound edges of
+// targetID, applying the same sargable target predicate and optional depType
+// filter as GetDependentRecordsInTx but no keyset/limit. Callers that want a
+// true total membership count need it without paging to exhaustion. Like the
+// paged read it is a RAW count spanning both tables; the caller applies any
+// visibility policy separately.
+//
+// It must agree with GetDependentRecordsInTx's durable-preferred de-dup: an edge
+// present in BOTH tables (same depid) is ONE row in the page, so the count is
+// every durable row PLUS every wisp row whose depid is not already a durable row
+// for the same target/type. Summing two raw COUNT(*)s would over-count that edge
+// and exceed the distinct keyset row count.
 func CountDependentRecordsInTx(ctx context.Context, tx DBTX, targetID, depType string) (int, error) {
-	total := 0
-	for _, depTable := range []string{"dependencies", "wisp_dependencies"} {
-		n, err := countDependentRecordsFromTable(ctx, tx, depTable, targetID, depType)
-		if err != nil {
-			if optionalBlockedTable(depTable) && isTableNotExistError(err) {
-				continue
-			}
-			return 0, err
-		}
-		total += n
+	durable, err := countDependentRecordsFromTable(ctx, tx, "dependencies", targetID, depType)
+	if err != nil {
+		return 0, err
 	}
-	return total, nil
+	wispExtra, err := countWispDependentsNotInDurableInTx(ctx, tx, targetID, depType)
+	if err != nil {
+		// wisp_dependencies absent: the durable count is the whole answer.
+		if isTableNotExistError(err) {
+			return durable, nil
+		}
+		return 0, err
+	}
+	return durable + wispExtra, nil
+}
+
+// countWispDependentsNotInDurableInTx counts wisp_dependencies rows whose target
+// is targetID (optional depType) but whose depid is NOT present in the durable
+// dependencies table for the same target/type — the wisp-ONLY inbound edges.
+// Colliding edges (present in both tables) are counted on the durable side, so
+// this is the exact complement that makes the total distinct-by-id. The NOT IN
+// subquery is uncorrelated and bounded by the target's durable inbound-edge
+// count; both arms use the sargable per-column OR target predicate.
+//
+//nolint:gosec // G201: table names are hardcoded constants; targetID/depType are bound as parameters.
+func countWispDependentsNotInDurableInTx(ctx context.Context, tx DBTX, targetID, depType string) (int, error) {
+	wispWhere := depTargetEqualsOr("")
+	durableWhere := depTargetEqualsOr("")
+	args := []any{targetID, targetID, targetID}
+	if depType != "" {
+		wispWhere += " AND type = ?"
+		args = append(args, depType)
+	}
+	args = append(args, targetID, targetID, targetID)
+	if depType != "" {
+		durableWhere += " AND type = ?"
+		args = append(args, depType)
+	}
+	query := fmt.Sprintf(
+		"SELECT COUNT(*) FROM wisp_dependencies WHERE %s AND id NOT IN (SELECT id FROM dependencies WHERE %s)",
+		wispWhere, durableWhere)
+	var n int
+	if err := tx.QueryRowContext(ctx, query, args...).Scan(&n); err != nil {
+		return 0, fmt.Errorf("count wisp-only dependent records: %w", err)
+	}
+	return n, nil
 }
 
 //nolint:gosec // G201: depTable is a hardcoded constant; targetID/depType are bound as parameters.

--- a/internal/storage/issueops/dependency_queries.go
+++ b/internal/storage/issueops/dependency_queries.go
@@ -982,6 +982,63 @@ func IsBlockedInTx(ctx context.Context, tx DBTX, issueID string) (bool, []string
 	return true, blockers, nil
 }
 
+// IsBlockedBatchInTx returns the denormalized, TRANSITIVE is_blocked flag for
+// each of ids in one batched read — the same value IsBlockedInTx returns per id,
+// without the per-row blocker-list recompute. It reads the stored is_blocked
+// column (SELECT id, is_blocked FROM {issues,wisps} WHERE id IN (...)), batched
+// at queryBatchSize, so it reflects inherited/ancestor blockedness (a child of a
+// blocked parent has is_blocked=1 with no direct blocking edge of its own) with
+// no graph walk. ids missing from both tables are absent from the map (callers
+// treat absent as not-blocked). On a cross-table id collision the wisps row wins,
+// matching loadStatusByIDInTx and the search wisp-merge.
+//
+//nolint:gosec // G201: table is a hardcoded "issues" or "wisps".
+func IsBlockedBatchInTx(ctx context.Context, tx DBTX, ids []string) (map[string]bool, error) {
+	blocked := make(map[string]bool, len(ids))
+	if len(ids) == 0 {
+		return blocked, nil
+	}
+
+	seen := make(map[string]string, len(ids))
+	for _, table := range []string{"issues", "wisps"} {
+		for start := 0; start < len(ids); start += queryBatchSize {
+			end := start + queryBatchSize
+			if end > len(ids) {
+				end = len(ids)
+			}
+			placeholders, args := buildSQLInClause(ids[start:end])
+			rows, err := tx.QueryContext(ctx, fmt.Sprintf(
+				"SELECT id, is_blocked FROM %s WHERE id IN (%s)", table, placeholders), args...)
+			if err != nil {
+				if optionalBlockedTable(table) && isTableNotExistError(err) {
+					break
+				}
+				return nil, fmt.Errorf("read is_blocked from %s: %w", table, err)
+			}
+			for rows.Next() {
+				var id string
+				var b int
+				if err := rows.Scan(&id, &b); err != nil {
+					_ = rows.Close()
+					return nil, fmt.Errorf("scan is_blocked from %s: %w", table, err)
+				}
+				// Tables iterate issues→wisps, so a second encounter is the
+				// wisps row, which is canonical on a cross-table dup (be-iabdi).
+				if _, dup := seen[id]; dup && table != "wisps" {
+					continue
+				}
+				seen[id] = table
+				blocked[id] = b != 0
+			}
+			_ = rows.Close()
+			if err := rows.Err(); err != nil {
+				return nil, fmt.Errorf("is_blocked rows from %s: %w", table, err)
+			}
+		}
+	}
+	return blocked, nil
+}
+
 // scanDependencyRow scans a single dependency row from a *sql.Rows.
 func scanDependencyRow(rows *sql.Rows) (*types.Dependency, error) {
 	var dep types.Dependency

--- a/internal/storage/issueops/dependency_queries.go
+++ b/internal/storage/issueops/dependency_queries.go
@@ -295,7 +295,7 @@ func queryDependentRecordsFromTable(ctx context.Context, tx DBTX, depTable, targ
 	query := fmt.Sprintf(`
 		SELECT id, issue_id, %s AS depends_on_id, type, created_at, created_by, metadata, thread_id
 		FROM %s
-		WHERE %s`, DepTargetExpr, depTable, depTargetEqualsOr(""))
+		WHERE %s`, DepTargetExpr, depTable, depTargetEqualsOr())
 	args := []any{targetID, targetID, targetID}
 	if depType != "" {
 		query += " AND type = ?"
@@ -386,8 +386,8 @@ func CountDependentRecordsInTx(ctx context.Context, tx DBTX, targetID, depType s
 //
 //nolint:gosec // G201: table names are hardcoded constants; targetID/depType are bound as parameters.
 func countWispDependentsNotInDurableInTx(ctx context.Context, tx DBTX, targetID, depType string) (int, error) {
-	wispWhere := depTargetEqualsOr("")
-	durableWhere := depTargetEqualsOr("")
+	wispWhere := depTargetEqualsOr()
+	durableWhere := depTargetEqualsOr()
 	args := []any{targetID, targetID, targetID}
 	if depType != "" {
 		wispWhere += " AND type = ?"
@@ -410,7 +410,7 @@ func countWispDependentsNotInDurableInTx(ctx context.Context, tx DBTX, targetID,
 
 //nolint:gosec // G201: depTable is a hardcoded constant; targetID/depType are bound as parameters.
 func countDependentRecordsFromTable(ctx context.Context, tx DBTX, depTable, targetID, depType string) (int, error) {
-	query := fmt.Sprintf("SELECT COUNT(*) FROM %s WHERE %s", depTable, depTargetEqualsOr(""))
+	query := fmt.Sprintf("SELECT COUNT(*) FROM %s WHERE %s", depTable, depTargetEqualsOr())
 	args := []any{targetID, targetID, targetID}
 	if depType != "" {
 		query += " AND type = ?"

--- a/internal/storage/issueops/dependency_queries.go
+++ b/internal/storage/issueops/dependency_queries.go
@@ -142,16 +142,25 @@ const (
 // — the edges pointing AT targetID — from both the permanent and wisp
 // dependency tables. Unlike GetDependents/GetDependentsWithMetadata it does
 // NOT join or hydrate the source issues, so edges from dangling, cross-project,
-// or wisp sources are returned as raw rows rather than dropped. Rows are keyed
-// by their source issue_id (Dependency.IssueID); target resolution COALESCEs
-// the three typed target columns exactly like the source-keyed sibling reads.
+// or wisp sources are returned as raw rows rather than dropped. RAW READ: it
+// spans BOTH the `dependencies` and `wisp_dependencies` tables and applies no
+// visibility policy — filtering (e.g. a group-membership visibility rule) is
+// the caller's job, applied at hydration.
 //
 // When depType is non-empty only rows of that dependency type are returned
-// ("" = all types). Results are ordered by source issue_id ASC and bounded by
-// limit (see the clamp constants). afterID is a keyset continuation over that
-// order: "" starts at the beginning, otherwise only rows with issue_id > afterID
-// are returned. The (issue_id, typed-target) unique keys make issue_id unique
-// among rows sharing a fixed target, so paging on it drops no rows.
+// ("" = all types). Results are ordered by the dependency row's primary id ASC
+// and bounded by limit (see the clamp constants). afterID is a keyset
+// continuation over that id order: "" starts at the beginning, otherwise only
+// rows with id > afterID are returned.
+//
+// CURSOR KEY: the dependency row's own id (depid.New(issue_id, target), a
+// UUIDv5 that is stable and globally unique across both tables) — NOT the source
+// issue_id. issue_id is not a total key for a fixed target: a source can appear
+// across the two scanned tables, so paging on it could drop or duplicate rows.
+// Paging on the unique row id is total, so each source's inbound edge is
+// returned exactly once. The target match is a sargable per-column OR over the
+// three typed columns (seeks idx_dep_*_target / the type composites) rather than
+// a COALESCE wrapper.
 func GetDependentRecordsInTx(ctx context.Context, tx DBTX, targetID, depType string, limit int, afterID string) ([]*types.Dependency, error) {
 	if limit <= 0 {
 		limit = defaultDependentRecordsLimit
@@ -172,16 +181,11 @@ func GetDependentRecordsInTx(ctx context.Context, tx DBTX, targetID, depType str
 		all = append(all, rows...)
 	}
 
-	// Merge the two per-table pages into one deterministic order. issue_id is
-	// unique per fixed target across both tables (durable vs wisp sources have
-	// disjoint ids), so ordering by (issue_id, type) is total; type is only a
-	// tie-break for the pathological same-source/same-target-string edge.
-	sort.Slice(all, func(i, j int) bool {
-		if all[i].IssueID != all[j].IssueID {
-			return all[i].IssueID < all[j].IssueID
-		}
-		return all[i].Type < all[j].Type
-	})
+	// Merge the two per-table pages into one total order by row id. Each table
+	// returned its first `limit` rows with id > afterID, so the global first
+	// `limit` rows with id > afterID are all present; sorting by the globally
+	// unique id and truncating yields exactly that page with no drop and no dup.
+	sort.Slice(all, func(i, j int) bool { return all[i].ID < all[j].ID })
 	if len(all) > limit {
 		all = all[:limit]
 	}
@@ -191,19 +195,19 @@ func GetDependentRecordsInTx(ctx context.Context, tx DBTX, targetID, depType str
 //nolint:gosec // G201: depTable is a hardcoded constant; targetID/depType/afterID are bound as parameters.
 func queryDependentRecordsFromTable(ctx context.Context, tx DBTX, depTable, targetID, depType string, limit int, afterID string) ([]*types.Dependency, error) {
 	query := fmt.Sprintf(`
-		SELECT issue_id, %s AS depends_on_id, type, created_at, created_by, metadata, thread_id
+		SELECT id, issue_id, %s AS depends_on_id, type, created_at, created_by, metadata, thread_id
 		FROM %s
-		WHERE %s`, DepTargetExpr, depTable, depTargetEquals(""))
-	args := []any{targetID}
+		WHERE %s`, DepTargetExpr, depTable, depTargetEqualsOr(""))
+	args := []any{targetID, targetID, targetID}
 	if depType != "" {
 		query += " AND type = ?"
 		args = append(args, depType)
 	}
 	if afterID != "" {
-		query += " AND issue_id > ?"
+		query += " AND id > ?"
 		args = append(args, afterID)
 	}
-	query += fmt.Sprintf(" ORDER BY issue_id ASC LIMIT %d", limit)
+	query += fmt.Sprintf(" ORDER BY id ASC LIMIT %d", limit)
 
 	rows, err := tx.QueryContext(ctx, query, args...)
 	if err != nil {
@@ -213,13 +217,73 @@ func queryDependentRecordsFromTable(ctx context.Context, tx DBTX, depTable, targ
 
 	var deps []*types.Dependency
 	for rows.Next() {
-		dep, scanErr := scanDependencyRow(rows)
+		dep, scanErr := scanDependentRow(rows)
 		if scanErr != nil {
 			return nil, fmt.Errorf("get dependent records: scan: %w", scanErr)
 		}
 		deps = append(deps, dep)
 	}
 	return deps, rows.Err()
+}
+
+// scanDependentRow scans a dependents row that INCLUDES the row id (the keyset
+// cursor). The shared scanDependencyRow does not select id, and adding it there
+// would ripple through every source-keyed read, so the target-keyed read owns
+// this variant.
+func scanDependentRow(rows *sql.Rows) (*types.Dependency, error) {
+	var dep types.Dependency
+	var createdAt sql.NullTime
+	var metadata, threadID sql.NullString
+
+	if err := rows.Scan(&dep.ID, &dep.IssueID, &dep.DependsOnID, &dep.Type, &createdAt, &dep.CreatedBy, &metadata, &threadID); err != nil {
+		return nil, fmt.Errorf("scan dependent: %w", err)
+	}
+	if createdAt.Valid {
+		dep.CreatedAt = createdAt.Time
+	}
+	if metadata.Valid {
+		dep.Metadata = metadata.String
+	}
+	if threadID.Valid {
+		dep.ThreadID = threadID.String
+	}
+	return &dep, nil
+}
+
+// CountDependentRecordsInTx returns the total number of inbound edges of
+// targetID across both dependency tables, applying the same sargable target
+// predicate and optional depType filter as GetDependentRecordsInTx but no
+// keyset/limit. Callers that want a true total membership count need it without
+// paging to exhaustion. Like the paged read it is a RAW count spanning both
+// tables; the caller applies any visibility policy separately.
+func CountDependentRecordsInTx(ctx context.Context, tx DBTX, targetID, depType string) (int, error) {
+	total := 0
+	for _, depTable := range []string{"dependencies", "wisp_dependencies"} {
+		n, err := countDependentRecordsFromTable(ctx, tx, depTable, targetID, depType)
+		if err != nil {
+			if optionalBlockedTable(depTable) && isTableNotExistError(err) {
+				continue
+			}
+			return 0, err
+		}
+		total += n
+	}
+	return total, nil
+}
+
+//nolint:gosec // G201: depTable is a hardcoded constant; targetID/depType are bound as parameters.
+func countDependentRecordsFromTable(ctx context.Context, tx DBTX, depTable, targetID, depType string) (int, error) {
+	query := fmt.Sprintf("SELECT COUNT(*) FROM %s WHERE %s", depTable, depTargetEqualsOr(""))
+	args := []any{targetID, targetID, targetID}
+	if depType != "" {
+		query += " AND type = ?"
+		args = append(args, depType)
+	}
+	var n int
+	if err := tx.QueryRowContext(ctx, query, args...).Scan(&n); err != nil {
+		return 0, fmt.Errorf("count dependent records from %s: %w", depTable, err)
+	}
+	return n, nil
 }
 
 func GetDependencyCountsInTx(ctx context.Context, tx DBTX, issueIDs []string) (map[string]*types.DependencyCounts, error) {

--- a/internal/storage/issueops/events.go
+++ b/internal/storage/issueops/events.go
@@ -96,17 +96,11 @@ func EventsSinceInTx(ctx context.Context, tx DBTX, cursorCreatedAt time.Time, cu
 		limit = maxEventsSinceLimit
 	}
 
-	query := `
-		SELECT id, issue_id, event_type, actor, old_value, new_value, comment, created_at
-		FROM events
-		WHERE created_at >= ? AND ((created_at > ?) OR (id > ?))`
+	query := EventsSinceQuery(issueID, limit)
 	args := []any{cursorCreatedAt, cursorCreatedAt, cursorID}
 	if issueID != "" {
-		query += " AND issue_id = ?"
 		args = append(args, issueID)
 	}
-	//nolint:gosec // G201: limit is an int clamped above; all values are bound parameters.
-	query += fmt.Sprintf(" ORDER BY created_at ASC, id ASC LIMIT %d", limit)
 
 	rows, err := tx.QueryContext(ctx, query, args...)
 	if err != nil {
@@ -115,6 +109,27 @@ func EventsSinceInTx(ctx context.Context, tx DBTX, cursorCreatedAt time.Time, cu
 	defer rows.Close()
 
 	return scanEvents(rows)
+}
+
+// EventsSinceQuery returns the exact SQL EventsSinceInTx executes for the given
+// issueID scope and already-clamped limit, with ? placeholders bound in order by
+// the caller: created_at (sargable lower bound), created_at (strict), id
+// (same-second tie-break), and issue_id when issueID != "". It is exported so
+// the backend sargability guard EXPLAINs this production string rather than a
+// hand-copied literal — a change to the SARGABLE predicate here then breaks the
+// guard.
+//
+//nolint:gosec // G201: limit is an int the caller clamps; every runtime value is a bound parameter.
+func EventsSinceQuery(issueID string, limit int) string {
+	query := `
+		SELECT id, issue_id, event_type, actor, old_value, new_value, comment, created_at
+		FROM events
+		WHERE created_at >= ? AND ((created_at > ?) OR (id > ?))`
+	if issueID != "" {
+		query += " AND issue_id = ?"
+	}
+	query += fmt.Sprintf(" ORDER BY created_at ASC, id ASC LIMIT %d", limit)
+	return query
 }
 
 func scanEvents(rows *sql.Rows) ([]*types.Event, error) {

--- a/internal/storage/issueops/events.go
+++ b/internal/storage/issueops/events.go
@@ -67,15 +67,28 @@ const (
 
 // EventsSinceInTx returns durable events strictly after the (createdAt, id)
 // keyset cursor, ordered by (created_at ASC, id ASC) and bounded by limit.
+// issueID != "" scopes the feed to one bead's history; "" returns all issues'.
 //
-// The cursor predicate `(created_at > ?) OR (created_at = ? AND id > ?)`
-// excludes the cursor row itself and orders same-second ties by id, so a
-// caller can page forward by feeding the last returned event's CreatedAt/ID
-// back in. The zero cursor (zero time, empty id) starts from the epoch.
+// The cursor predicate is written as
+//
+//	created_at >= ? AND ((created_at > ?) OR (id > ?))
+//
+// which is logically the keyset "(created_at, id) > (cursor)" but SARGABLE: the
+// redundant `created_at >= ?` lower bound lets the planner seek
+// idx_events_created_at (an IndexedTableAccess range) instead of full-scanning
+// and filtering — the bare OR form plans as Table+Filter+TopN on Dolt. The
+// nested OR then re-applies strict exclusion (drop the cursor row) and the
+// same-second id tie-break. All three placeholders bind the cursor: the time
+// twice, then the id. The zero cursor (zero time, empty id) starts from epoch.
+//
+// With issueID set an additional `issue_id = ?` is ANDed in. There is no
+// composite (issue_id, created_at, id) index, so that arm is a single-column
+// index seek (idx_events_issue) plus a filter; acceptable for a per-bead drawer,
+// which is small.
 //
 // Scope is the durable `events` table only — wisp_events are deliberately not
 // unioned in, unlike GetAllEventsSince, so the feed stays durable-only.
-func EventsSinceInTx(ctx context.Context, tx *sql.Tx, cursorCreatedAt time.Time, cursorID string, limit int) ([]*types.Event, error) {
+func EventsSinceInTx(ctx context.Context, tx DBTX, cursorCreatedAt time.Time, cursorID, issueID string, limit int) ([]*types.Event, error) {
 	if limit <= 0 {
 		limit = defaultEventsSinceLimit
 	}
@@ -83,15 +96,21 @@ func EventsSinceInTx(ctx context.Context, tx *sql.Tx, cursorCreatedAt time.Time,
 		limit = maxEventsSinceLimit
 	}
 
-	rows, err := tx.QueryContext(ctx, fmt.Sprintf(`
+	query := `
 		SELECT id, issue_id, event_type, actor, old_value, new_value, comment, created_at
 		FROM events
-		WHERE (created_at > ?) OR (created_at = ? AND id > ?)
-		ORDER BY created_at ASC, id ASC
-		LIMIT %d
-	`, limit), cursorCreatedAt, cursorCreatedAt, cursorID)
+		WHERE created_at >= ? AND ((created_at > ?) OR (id > ?))`
+	args := []any{cursorCreatedAt, cursorCreatedAt, cursorID}
+	if issueID != "" {
+		query += " AND issue_id = ?"
+		args = append(args, issueID)
+	}
+	//nolint:gosec // G201: limit is an int clamped above; all values are bound parameters.
+	query += fmt.Sprintf(" ORDER BY created_at ASC, id ASC LIMIT %d", limit)
+
+	rows, err := tx.QueryContext(ctx, query, args...)
 	if err != nil {
-		return nil, fmt.Errorf("events since cursor (%v, %q): %w", cursorCreatedAt, cursorID, err)
+		return nil, fmt.Errorf("events since cursor (%v, %q) issue %q: %w", cursorCreatedAt, cursorID, issueID, err)
 	}
 	defer rows.Close()
 

--- a/internal/storage/issueops/events.go
+++ b/internal/storage/issueops/events.go
@@ -57,6 +57,47 @@ func GetAllEventsSinceInTx(ctx context.Context, tx *sql.Tx, since time.Time) ([]
 	return scanEvents(rows)
 }
 
+// Event keyset-read bounds. The API's change feed pages the durable events
+// table with a bounded limit (default when the caller passes <= 0, hard cap
+// otherwise).
+const (
+	defaultEventsSinceLimit = 100
+	maxEventsSinceLimit     = 500
+)
+
+// EventsSinceInTx returns durable events strictly after the (createdAt, id)
+// keyset cursor, ordered by (created_at ASC, id ASC) and bounded by limit.
+//
+// The cursor predicate `(created_at > ?) OR (created_at = ? AND id > ?)`
+// excludes the cursor row itself and orders same-second ties by id, so a
+// caller can page forward by feeding the last returned event's CreatedAt/ID
+// back in. The zero cursor (zero time, empty id) starts from the epoch.
+//
+// Scope is the durable `events` table only — wisp_events are deliberately not
+// unioned in, unlike GetAllEventsSince, so the feed stays durable-only.
+func EventsSinceInTx(ctx context.Context, tx *sql.Tx, cursorCreatedAt time.Time, cursorID string, limit int) ([]*types.Event, error) {
+	if limit <= 0 {
+		limit = defaultEventsSinceLimit
+	}
+	if limit > maxEventsSinceLimit {
+		limit = maxEventsSinceLimit
+	}
+
+	rows, err := tx.QueryContext(ctx, fmt.Sprintf(`
+		SELECT id, issue_id, event_type, actor, old_value, new_value, comment, created_at
+		FROM events
+		WHERE (created_at > ?) OR (created_at = ? AND id > ?)
+		ORDER BY created_at ASC, id ASC
+		LIMIT %d
+	`, limit), cursorCreatedAt, cursorCreatedAt, cursorID)
+	if err != nil {
+		return nil, fmt.Errorf("events since cursor (%v, %q): %w", cursorCreatedAt, cursorID, err)
+	}
+	defer rows.Close()
+
+	return scanEvents(rows)
+}
+
 func scanEvents(rows *sql.Rows) ([]*types.Event, error) {
 	var events []*types.Event
 	for rows.Next() {

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -355,6 +355,7 @@ type DoltStorage interface {
 	FederationStore
 	BulkIssueStore
 	DependencyQueryStore
+	EventQueryStore
 	AnnotationStore
 	ConfigMetadataStore
 	CompactionStore

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -35,6 +35,19 @@ var ErrNotOwner = errors.New("issue claimed by a different actor")
 // stale; the issue is left untouched.
 var ErrAssigneeMismatch = errors.New("assignee mismatch")
 
+// ClaimedByFragment and NotClaimableStatusFragment are the exact message
+// fragments the claim path (issueops/claim.go) appends after the sentinel to
+// carry the conflicting assignee/status: ErrAlreadyClaimed is wrapped as
+// "<sentinel> by <assignee>" and ErrNotClaimable as "<sentinel>: status
+// <status>". They are the single source of truth for that format so producer
+// (claim.go) and consumer (beads.ParseClaimConflict) cannot drift: the consumer
+// reconstructs its marker as ErrAlreadyClaimed.Error()+ClaimedByFragment rather
+// than hardcoding the literal.
+const (
+	ClaimedByFragment          = " by "
+	NotClaimableStatusFragment = ": status "
+)
+
 // ErrNotFound is returned when a requested entity does not exist in the database.
 var ErrNotFound = errors.New("not found")
 

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -498,6 +498,29 @@ type ReadyWorkCounter interface {
 //   - If the callback function panics, the transaction is rolled back
 //   - On successful return from the callback, the transaction is committed
 //
+// # Compose surface (classic path)
+//
+// The transaction methods are implemented by the classic Dolt and
+// embedded-Dolt stores. The domain/uow plumbing (internal/storage/domain) is a
+// separate compose surface that does not implement storage.Transaction today;
+// that asymmetry is pre-existing and out of scope for this surface.
+//
+// The read methods below let a caller assemble a whole composite view — a
+// bd show-style assembly of counts and relations — inside ONE transaction, so
+// everything it stitches together is read from a single snapshot and cannot
+// tear across separate engine reads.
+//
+// TWO-SESSION WISP CAVEAT (server/Dolt backend only): the classic Dolt store
+// runs durable tables and dolt-ignored wisp tables on two separate SQL sessions
+// within one logical transaction. Reads that span both tiers in a single query
+// (the ones flagged below) therefore see this transaction's own uncommitted
+// DURABLE writes and all COMMITTED wisps, but NOT wisps written in the same
+// still-open transaction — those become visible after commit. Single-tier reads
+// (GetIssue, GetIssueComments, GetIssueCommentsPage, GetDependencyRecords,
+// IsBlocked, IsBlockedBatch, GetLabels) route to the owning session and are
+// read-your-writes on both tiers. The embedded-Dolt store has no session split,
+// so every read there is read-your-writes on both tiers.
+//
 // # Example Usage
 //
 //	err := store.RunInTransaction(ctx, "bd: create parent and child", func(tx storage.Transaction) error {
@@ -567,7 +590,61 @@ type Transaction interface {
 	// Comment operations
 	AddComment(ctx context.Context, issueID, actor, comment string) error
 	ImportIssueComment(ctx context.Context, issueID, author, text string, createdAt time.Time) (*types.Comment, error)
-	GetIssueComments(ctx context.Context, issueID string) ([]*types.Comment, error)
+	GetIssueComments(ctx context.Context, issueID string) ([]*types.Comment, error) // For read-your-writes within transaction
+	// GetIssueCommentsPage returns one keyset page of an issue's comments in the
+	// stable (created_at ASC, id ASC) order, resuming strictly after the cursor
+	// (the zero cursor starts at the beginning of the thread). Lets a composite
+	// view page a comment thread off the same snapshot as its other reads. See
+	// storage.Storage.GetIssueCommentsPage for the full ordering and
+	// page-walk-equals-full-read contract.
+	GetIssueCommentsPage(ctx context.Context, issueID string, after CommentPageCursor, limit int) ([]*types.Comment, error)
+
+	// Composite-view reads.
+	//
+	// Each mirrors the Storage-level method of the same name; they add no new
+	// query shape, only the ability to run the existing read on the
+	// transaction's snapshot, so a bd show-style assembly can gather every count
+	// and relation it needs inside one transaction. All see this transaction's
+	// own uncommitted DURABLE writes; the wisp-tier visibility of the
+	// both-tiers-spanning reads is governed by the TWO-SESSION WISP CAVEAT above.
+
+	// CountIssuesByGroup returns per-group issue counts. groupBy is one of:
+	// status, priority, type, assignee, label. SPANS BOTH TIERS (merges wisps):
+	// subject to the two-session wisp caveat on the server backend. Note it merges
+	// committed wisps into the buckets while the transaction's SearchIssues reads
+	// the issues table only, so their totals need not agree when committed wisps
+	// exist — a pre-existing count-vs-search wisp-scoping asymmetry, not a tear.
+	CountIssuesByGroup(ctx context.Context, filter types.IssueFilter, groupBy string) (map[string]int, error)
+
+	// GetDependentRecords returns the raw inbound dependency rows whose target is
+	// targetID (its dependents), spanning the durable and wisp dependency tables,
+	// filtered by depType ("" = all), bounded by limit and paged by afterID.
+	// SPANS BOTH TIERS: subject to the two-session wisp caveat on the server backend.
+	GetDependentRecords(ctx context.Context, targetID string, depType string, limit int, afterID string) ([]*types.Dependency, error)
+	// GetDependentRecordsForIssues returns the raw inbound dependency rows for a
+	// SET of target ids in one batched read, keyed by target id. SPANS BOTH TIERS:
+	// subject to the two-session wisp caveat on the server backend.
+	GetDependentRecordsForIssues(ctx context.Context, targetIDs []string) (map[string][]*types.Dependency, error)
+	// CountDependentRecords returns the total inbound-edge count of targetID
+	// across both dependency tables (same predicate/scope as GetDependentRecords).
+	// SPANS BOTH TIERS: subject to the two-session wisp caveat on the server backend.
+	CountDependentRecords(ctx context.Context, targetID string, depType string) (int, error)
+
+	// IsBlocked reports the denormalized transitive is_blocked flag for one issue
+	// plus its direct blocker ids. Single-tier (routes to the issue's own tier):
+	// read-your-writes on both tiers.
+	IsBlocked(ctx context.Context, issueID string) (bool, []string, error)
+	// IsBlockedBatch reports the denormalized transitive is_blocked flag for a
+	// page of ids in one batched read. ids present in neither the issues nor the
+	// wisps table are absent from the map; callers treat absent as not-blocked.
+	// Partitions ids by tier and reads each on its owning session, so it is
+	// read-your-writes on both tiers even for a mixed durable/wisp batch.
+	IsBlockedBatch(ctx context.Context, ids []string) (map[string]bool, error)
+
+	// EventsSince returns durable events strictly after cursor, ordered by
+	// (created_at ASC, id ASC) and bounded by limit; issueID scopes the feed to
+	// one issue's history ("" = all issues). Durable events table only.
+	EventsSince(ctx context.Context, cursor EventCursor, issueID string, limit int) ([]*types.Event, error)
 }
 
 // DependencyAddOptions controls dependency insertion for both the store-level

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -783,6 +783,12 @@ func (w WorkType) IsValid() bool {
 
 // Dependency represents a relationship between issues
 type Dependency struct {
+	// ID is the dependency row's deterministic surrogate primary key,
+	// depid.New(issue_id, target) — a UUIDv5 that is stable and globally unique
+	// across the durable and wisp dependency tables. Populated only by reads
+	// that select it (e.g. GetDependentRecords, which keysets on it); left empty
+	// by the source-keyed reads that never needed it.
+	ID          string         `json:"id,omitempty"`
 	IssueID     string         `json:"issue_id"`
 	DependsOnID string         `json:"depends_on_id"`
 	Type        DependencyType `json:"type"`

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -1066,6 +1066,7 @@ type EventType string
 const (
 	EventCreated           EventType = "created"
 	EventUpdated           EventType = "updated"
+	EventClaimed           EventType = "claimed"
 	EventStatusChanged     EventType = "status_changed"
 	EventCommented         EventType = "commented"
 	EventClosed            EventType = "closed"

--- a/query_interfaces_cgo_test.go
+++ b/query_interfaces_cgo_test.go
@@ -1,0 +1,16 @@
+//go:build cgo
+
+package beads_test
+
+import (
+	"github.com/steveyegge/beads"
+	"github.com/steveyegge/beads/internal/storage/embeddeddolt"
+)
+
+// Compile-time proof that the embedded Dolt store also satisfies each narrow
+// public interface (the server Dolt store is asserted in query_interfaces_test.go).
+var (
+	_ beads.IssueClaimer     = (*embeddeddolt.EmbeddedDoltStore)(nil)
+	_ beads.EventQuerier     = (*embeddeddolt.EmbeddedDoltStore)(nil)
+	_ beads.DependentQuerier = (*embeddeddolt.EmbeddedDoltStore)(nil)
+)

--- a/query_interfaces_cgo_test.go
+++ b/query_interfaces_cgo_test.go
@@ -13,4 +13,5 @@ var (
 	_ beads.IssueClaimer     = (*embeddeddolt.EmbeddedDoltStore)(nil)
 	_ beads.EventQuerier     = (*embeddeddolt.EmbeddedDoltStore)(nil)
 	_ beads.DependentQuerier = (*embeddeddolt.EmbeddedDoltStore)(nil)
+	_ beads.BlockedQuerier   = (*embeddeddolt.EmbeddedDoltStore)(nil)
 )

--- a/query_interfaces_test.go
+++ b/query_interfaces_test.go
@@ -1,0 +1,78 @@
+package beads_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/steveyegge/beads"
+	"github.com/steveyegge/beads/internal/storage/dolt"
+)
+
+// Compile-time proof that the concrete Dolt store satisfies each narrow public
+// interface (the embedded Dolt store is asserted in query_interfaces_cgo_test.go).
+// These pin the interfaces to a real implementation, complementing the
+// engine-interface guards in beads.go.
+var (
+	_ beads.IssueClaimer     = (*dolt.DoltStore)(nil)
+	_ beads.EventQuerier     = (*dolt.DoltStore)(nil)
+	_ beads.DependentQuerier = (*dolt.DoltStore)(nil)
+)
+
+// TestQueryInterfacesAgainstRealDolt exercises AsEventQuerier / AsDependentQuerier
+// (and their methods) against a live Dolt Storage through the public surface,
+// the runtime complement to the compile-time guards.
+func TestQueryInterfacesAgainstRealDolt(t *testing.T) {
+	skipIfNoDoltServer(t)
+
+	ctx := context.Background()
+	store, err := beads.Open(ctx, filepath.Join(t.TempDir(), "qi-dolt"))
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer store.Close()
+	if err := store.SetConfig(ctx, "issue_prefix", "qi"); err != nil {
+		t.Fatalf("SetConfig: %v", err)
+	}
+
+	mk := func(id string) {
+		iss := &beads.Issue{ID: id, Title: id, Status: beads.StatusOpen, Priority: 2, IssueType: beads.TypeTask}
+		if err := store.CreateIssue(ctx, iss, "tester"); err != nil {
+			t.Fatalf("CreateIssue %s: %v", id, err)
+		}
+	}
+	mk("qi-target")
+	mk("qi-src")
+	if err := store.AddDependency(ctx, &beads.Dependency{IssueID: "qi-src", DependsOnID: "qi-target", Type: beads.DepBlocks}, "tester"); err != nil {
+		t.Fatalf("AddDependency: %v", err)
+	}
+
+	dq, ok := beads.AsDependentQuerier(store)
+	if !ok {
+		t.Fatalf("AsDependentQuerier returned ok=false for a live Dolt Storage")
+	}
+	deps, err := dq.GetDependentRecords(ctx, "qi-target", "", 100, "")
+	if err != nil {
+		t.Fatalf("GetDependentRecords: %v", err)
+	}
+	if len(deps) != 1 || deps[0].IssueID != "qi-src" {
+		t.Fatalf("GetDependentRecords = %v, want [qi-src]", deps)
+	}
+	if n, err := dq.CountDependentRecords(ctx, "qi-target", ""); err != nil {
+		t.Fatalf("CountDependentRecords: %v", err)
+	} else if n != 1 {
+		t.Fatalf("CountDependentRecords = %d, want 1", n)
+	}
+
+	eq, ok := beads.AsEventQuerier(store)
+	if !ok {
+		t.Fatalf("AsEventQuerier returned ok=false for a live Dolt Storage")
+	}
+	evs, err := eq.EventsSince(ctx, beads.EventCursor{}, "", 100)
+	if err != nil {
+		t.Fatalf("EventsSince: %v", err)
+	}
+	if len(evs) == 0 {
+		t.Fatalf("EventsSince returned no durable events after creates")
+	}
+}

--- a/query_interfaces_test.go
+++ b/query_interfaces_test.go
@@ -18,6 +18,7 @@ var (
 	_ beads.IssueClaimer     = (*dolt.DoltStore)(nil)
 	_ beads.EventQuerier     = (*dolt.DoltStore)(nil)
 	_ beads.DependentQuerier = (*dolt.DoltStore)(nil)
+	_ beads.BlockedQuerier   = (*dolt.DoltStore)(nil)
 )
 
 // TestQueryInterfacesAgainstRealDolt exercises AsEventQuerier / AsDependentQuerier
@@ -76,6 +77,29 @@ func TestQueryInterfacesAgainstRealDolt(t *testing.T) {
 	if len(evs) == 0 {
 		t.Fatalf("EventsSince returned no durable events after creates")
 	}
+
+	bq, ok := beads.AsBlockedQuerier(store)
+	if !ok {
+		t.Fatalf("AsBlockedQuerier returned ok=false for a live Dolt Storage")
+	}
+	batch, err := bq.IsBlockedBatch(ctx, []string{"qi-src", "qi-target"})
+	if err != nil {
+		t.Fatalf("IsBlockedBatch: %v", err)
+	}
+	// qi-src blocks-depends on the open qi-target, so it is blocked; qi-target
+	// has no open blocker. The batch value must match per-row IsBlocked.
+	for _, id := range []string{"qi-src", "qi-target"} {
+		want, _, err := bq.IsBlocked(ctx, id)
+		if err != nil {
+			t.Fatalf("IsBlocked(%s): %v", id, err)
+		}
+		if batch[id] != want {
+			t.Fatalf("IsBlockedBatch[%s] = %v, want %v (per-row IsBlocked)", id, batch[id], want)
+		}
+	}
+	if !batch["qi-src"] {
+		t.Fatalf("IsBlockedBatch[qi-src] = false, want true (blocked by open qi-target)")
+	}
 }
 
 // TestAsAccessorsResolveThroughHookDecorator proves the decorator contract that
@@ -111,5 +135,8 @@ func TestAsAccessorsResolveThroughHookDecorator(t *testing.T) {
 	}
 	if _, ok := beads.AsDependentQuerier(decorated); !ok {
 		t.Errorf("AsDependentQuerier returned ok=false through a HookFiringStore decorator")
+	}
+	if _, ok := beads.AsBlockedQuerier(decorated); !ok {
+		t.Errorf("AsBlockedQuerier returned ok=false through a HookFiringStore decorator")
 	}
 }

--- a/query_interfaces_test.go
+++ b/query_interfaces_test.go
@@ -65,6 +65,13 @@ func TestQueryInterfacesAgainstRealDolt(t *testing.T) {
 	} else if n != 1 {
 		t.Fatalf("CountDependentRecords = %d, want 1", n)
 	}
+	byTarget, err := dq.GetDependentRecordsForIssues(ctx, []string{"qi-target"})
+	if err != nil {
+		t.Fatalf("GetDependentRecordsForIssues: %v", err)
+	}
+	if got := byTarget["qi-target"]; len(got) != 1 || got[0].IssueID != "qi-src" || got[0].DependsOnID != "qi-target" {
+		t.Fatalf("GetDependentRecordsForIssues[qi-target] = %v, want one row {src=qi-src, target=qi-target}", got)
+	}
 
 	eq, ok := beads.AsEventQuerier(store)
 	if !ok {

--- a/query_interfaces_test.go
+++ b/query_interfaces_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/steveyegge/beads"
+	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/storage/dolt"
 )
 
@@ -74,5 +75,41 @@ func TestQueryInterfacesAgainstRealDolt(t *testing.T) {
 	}
 	if len(evs) == 0 {
 		t.Fatalf("EventsSince returned no durable events after creates")
+	}
+}
+
+// TestAsAccessorsResolveThroughHookDecorator proves the decorator contract that
+// lets the As* accessors use a single direct assertion (no UnwrapStore): a
+// HookFiringStore embeds storage.DoltStorage, so the engine-interface narrow
+// surfaces (claim / event feed / dependents) promote through it and resolve
+// without unwrapping. This is the test that would go red if a future decorator
+// stopped forwarding one of them — i.e. the reason the removed fallback was dead
+// rather than load-bearing.
+func TestAsAccessorsResolveThroughHookDecorator(t *testing.T) {
+	skipIfNoDoltServer(t)
+
+	ctx := context.Background()
+	store, err := beads.Open(ctx, filepath.Join(t.TempDir(), "deco-dolt"))
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer store.Close()
+
+	ds, ok := store.(storage.DoltStorage)
+	if !ok {
+		t.Fatalf("live Dolt store is not a storage.DoltStorage")
+	}
+	// nil runner => passthrough decorator; the narrow surfaces are promoted from
+	// the embedded engine interface, not overridden.
+	decorated := storage.NewHookFiringStore(ds, nil)
+
+	if _, ok := beads.AsIssueClaimer(decorated); !ok {
+		t.Errorf("AsIssueClaimer returned ok=false through a HookFiringStore decorator")
+	}
+	if _, ok := beads.AsEventQuerier(decorated); !ok {
+		t.Errorf("AsEventQuerier returned ok=false through a HookFiringStore decorator")
+	}
+	if _, ok := beads.AsDependentQuerier(decorated); !ok {
+		t.Errorf("AsDependentQuerier returned ok=false through a HookFiringStore decorator")
 	}
 }


### PR DESCRIPTION
> **Consolidated PR** — replaces #4924, #4925 (closed, unmerged; their commits are in this branch). Stacks on the keyset-reads group #4922; retarget as the chain drains. The diff vs its base is the complete events/dependents/claim group.

## What

The remaining read + recovery surface, as one unit (commit history preserves the slices; authorship preserved via cherry-picks):

- **Durable events reads** (was #4924) — `EventsSince` keyset feed with per-bead scope, `EventCursor`, single-sourced EXPLAIN sargability guard
- **Bounded dependents reads + batched blocked** (was #4925) — `GetDependentRecords` id-cursor paging, `CountDependentRecords`, batched `GetDependentRecordsForIssues` with cross-table dedup, `IsBlockedBatch` (issues-wins collision semantics matching single-row `IsBlocked`)
- **Public claim surface** (this branch's tip slices) — `ClaimConflict`/`ParseClaimConflict` (markers single-sourced from the producer, token bounded), narrow `IssueClaimer`/`EventQuerier`/`DependentQuerier`/`BlockedQuerier` interfaces with `As*` accessors and compile-time drift guards
- **Transactional snapshot reads** (this branch's tip slice) — `storage.Transaction` gains the composite-view read subset (grouped counts, comments page, dependents family, blocked checks, events feed) so a caller assembles a whole view inside one transaction; single-tier reads are read-your-writes on both tiers, spanning reads document their clone-local limitation per method, and the conformance snapshot test asserts exact in-transaction deltas

## Why

Event history, dependents views, and claim-conflict recovery previously required unbounded reads, N+1 per-row calls, or free-form error-text parsing. This closes all three with bounded, typed, index-backed surfaces.

## Verification

Events/dependents keyset + EXPLAIN guards on real Dolt and embedded; IsBlockedBatch parity tests; claim round-trip/wrap-preservation/token-bounding tests unit + producer-tied against real Dolt; drift-guard and query-interface tests. Builds/vet/lint clean.

