### PR TITLE
fix(readonly): prevent validation side effects

### DIFF
--- a/cmd/bd/doctor/config_values.go
+++ b/cmd/bd/doctor/config_values.go
@@ -406,7 +406,7 @@ func checkDatabaseConfigValues(repoPath string) []string {
 
 	// Open Dolt store in read-only mode
 	ctx := context.Background()
-	store, err := dolt.NewFromConfigWithCLIOptions(ctx, beadsDir, &dolt.Config{ReadOnly: true})
+	store, err := dolt.NewFromConfigWithCLIOptions(ctx, beadsDir, configValidationStoreOptions())
 	if err != nil {
 		issues = append(issues, fmt.Sprintf("database: failed to open Dolt store: %v", err))
 		return issues
@@ -414,6 +414,10 @@ func checkDatabaseConfigValues(repoPath string) []string {
 	defer func() { _ = store.Close() }()
 
 	return checkDatabaseConfigValuesWithStore(store)
+}
+
+func configValidationStoreOptions() *dolt.Config {
+	return &dolt.Config{ReadOnly: true, DisableAutoStart: true}
 }
 
 func checkDatabaseConfigValuesWithStore(store *dolt.DoltStore) []string {

--- a/cmd/bd/doctor/config_values_test.go
+++ b/cmd/bd/doctor/config_values_test.go
@@ -7,6 +7,16 @@ import (
 	"testing"
 )
 
+func TestConfigValidationStoreOptionsAreStrictReadOnly(t *testing.T) {
+	cfg := configValidationStoreOptions()
+	if !cfg.ReadOnly {
+		t.Fatal("config validation store must be read-only")
+	}
+	if !cfg.DisableAutoStart {
+		t.Fatal("config validation store must disable auto-start")
+	}
+}
+
 func setupDoctorSharedWorktree(t *testing.T) (mainRepoDir, worktreeDir string) {
 	t.Helper()
 

--- a/cmd/bd/main.go
+++ b/cmd/bd/main.go
@@ -151,6 +151,37 @@ func isReadOnlyCommand(cmdName string) bool {
 	return readOnlyCommands[cmdName]
 }
 
+type rootStorePolicy struct {
+	readOnly         bool
+	disableAutoStart bool
+	runMaintenance   bool
+}
+
+// effectiveRootStorePolicy separates strict --readonly/config policy from
+// command classification. Classified reads retain their compatibility
+// maintenance and auto-start behavior; strict readonly is mutation-free.
+func effectiveRootStorePolicy(cmdName string, strictReadonly bool) rootStorePolicy {
+	return rootStorePolicy{
+		readOnly:         strictReadonly || isReadOnlyCommand(cmdName),
+		disableAutoStart: strictReadonly,
+		runMaintenance:   !strictReadonly,
+	}
+}
+
+// backendSupportsStrictReadonly reports whether the live backend path can open
+// without provisioning or lifecycle changes. Unsupported SQL backends are
+// rejected earlier by validateConfiguredBackend; proxied Dolt remains writable-only.
+func backendSupportsStrictReadonly(cfg *configfile.Config) bool {
+	return cfg == nil || !cfg.IsDoltProxiedServerMode()
+}
+
+var (
+	runPostRunAutoCommit = maybeAutoCommit
+	runPostRunAutoBackup = maybeAutoBackup
+	runPostRunAutoExport = maybeAutoExport
+	runPostRunAutoPush   = maybeAutoPush
+)
+
 // isWorkingSetReconcileCommand reports whether cmd's whole purpose is to
 // reconcile the Dolt working set: "bd dolt commit" or "bd vc commit". These
 // commands are the documented recovery from a pending-migration dirty-table
@@ -1090,6 +1121,9 @@ var rootCmd = &cobra.Command{
 		if backendErr := validateConfiguredBackend(cfg); backendErr != nil {
 			return HandleError("%v", backendErr)
 		}
+		if readonlyMode && !backendSupportsStrictReadonly(cfg) {
+			return HandleError("strict readonly is unavailable for dolt proxied-server backend; refusing to open a store that cannot guarantee mutation-free access")
+		}
 
 		// Set actor for audit trail
 		actor = getActorWithGit()
@@ -1098,14 +1132,18 @@ var rootCmd = &cobra.Command{
 			commandSpan.SetAttributes(attribute.String("bd.actor", actor))
 		}
 
-		// Track bd version changes
-		// Best-effort tracking - failures are silent
-		trackBdVersion()
+		policy := effectiveRootStorePolicy(cmd.Name(), readonlyMode)
+
+		// Track bd version changes unless strict readonly forbids repository mutation.
+		// Best-effort tracking - failures are silent.
+		if policy.runMaintenance {
+			trackBdVersion()
+		}
 
 		// Check if this is a read-only command (GH#804)
 		// Read-only commands open the store in read-only mode to avoid modifying
 		// the database (which breaks file watchers).
-		useReadOnly := isReadOnlyCommand(cmd.Name())
+		useReadOnly := policy.readOnly
 
 		// If the operator passed --force on `bd migrate` or `bd migrate schema`,
 		// set the programmatic gate override before both autoMigrateOnVersionBump
@@ -1127,7 +1165,9 @@ var rootCmd = &cobra.Command{
 		// and closes BEFORE the main store is opened. This ensures bd doctor and
 		// read-only commands see the correct version after a CLI upgrade.
 
-		autoMigrateOnVersionBump(beadsDir)
+		if policy.runMaintenance {
+			autoMigrateOnVersionBump(beadsDir)
+		}
 
 		// Initialize direct storage access
 		var err error
@@ -1136,9 +1176,10 @@ var rootCmd = &cobra.Command{
 		// on a different filesystem (e.g., ext4 for performance on WSL).
 		doltPath := doltserver.ResolveDoltDir(beadsDir)
 		doltCfg := &dolt.Config{
-			ReadOnly:    useReadOnly,
-			BeadsDir:    beadsDir,
-			LenientOpen: isWorkingSetReconcileCommand(cmd),
+			ReadOnly:         useReadOnly,
+			DisableAutoStart: policy.disableAutoStart,
+			BeadsDir:         beadsDir,
+			LenientOpen:      isWorkingSetReconcileCommand(cmd),
 		}
 
 		// Load config to get database name and server connection settings.
@@ -1391,58 +1432,60 @@ var rootCmd = &cobra.Command{
 				uowProvider = nil
 			}
 		} else {
-			// Dolt auto-commit: after a successful write command (and after final flush),
-			// create a Dolt commit so changes don't remain only in the working set.
-			if commandDidWrite.Load() && !commandDidExplicitDoltCommit {
-				if err := maybeAutoCommit(rootCtx, doltAutoCommitParams{Command: cmd.Name()}); err != nil {
-					return HandleError("dolt auto-commit failed: %v", err)
+			if effectiveRootStorePolicy(cmd.Name(), readonlyMode).runMaintenance {
+				// Dolt auto-commit: after a successful write command (and after final flush),
+				// create a Dolt commit so changes don't remain only in the working set.
+				if commandDidWrite.Load() && !commandDidExplicitDoltCommit {
+					if err := runPostRunAutoCommit(rootCtx, doltAutoCommitParams{Command: cmd.Name()}); err != nil {
+						return HandleError("dolt auto-commit failed: %v", err)
+					}
 				}
-			}
 
-			// Tip metadata auto-commit: if a tip was shown, create a separate Dolt commit for the
-			// tip_*_last_shown metadata updates. This may happen even for otherwise read-only commands.
-			if commandDidWriteTipMetadata && len(commandTipIDsShown) > 0 {
-				// Only applies when dolt auto-commit is enabled and backend is versioned (Dolt).
-				if mode, err := getDoltAutoCommitMode(); err != nil {
-					return HandleError("dolt tip auto-commit failed: %v", err)
-				} else if mode == doltAutoCommitOn {
-					// Apply tip metadata writes now (deferred in recordTipShown for Dolt).
-					for tipID := range commandTipIDsShown {
-						key := fmt.Sprintf("tip_%s_last_shown", tipID)
-						value := time.Now().Format(time.RFC3339)
-						if err := store.SetLocalMetadata(rootCtx, key, value); err != nil {
+				// Tip metadata auto-commit: if a tip was shown, create a separate Dolt commit for the
+				// tip_*_last_shown metadata updates. This may happen even for otherwise read-only commands.
+				if commandDidWriteTipMetadata && len(commandTipIDsShown) > 0 {
+					// Only applies when dolt auto-commit is enabled and backend is versioned (Dolt).
+					if mode, err := getDoltAutoCommitMode(); err != nil {
+						return HandleError("dolt tip auto-commit failed: %v", err)
+					} else if mode == doltAutoCommitOn {
+						// Apply tip metadata writes now (deferred in recordTipShown for Dolt).
+						for tipID := range commandTipIDsShown {
+							key := fmt.Sprintf("tip_%s_last_shown", tipID)
+							value := time.Now().Format(time.RFC3339)
+							if err := store.SetLocalMetadata(rootCtx, key, value); err != nil {
+								return HandleError("dolt tip auto-commit failed: %v", err)
+							}
+						}
+
+						ids := make([]string, 0, len(commandTipIDsShown))
+						for tipID := range commandTipIDsShown {
+							ids = append(ids, tipID)
+						}
+						msg := formatDoltAutoCommitMessage("tip", getActor(), ids)
+						if err := runPostRunAutoCommit(rootCtx, doltAutoCommitParams{Command: "tip", MessageOverride: msg}); err != nil {
 							return HandleError("dolt tip auto-commit failed: %v", err)
 						}
 					}
+				}
 
-					ids := make([]string, 0, len(commandTipIDsShown))
-					for tipID := range commandTipIDsShown {
-						ids = append(ids, tipID)
-					}
-					msg := formatDoltAutoCommitMessage("tip", getActor(), ids)
-					if err := maybeAutoCommit(rootCtx, doltAutoCommitParams{Command: "tip", MessageOverride: msg}); err != nil {
-						return HandleError("dolt tip auto-commit failed: %v", err)
+				// Auto-backup: sync a Dolt-native backup if enabled and due
+				runPostRunAutoBackup(rootCtx)
+
+				// Auto-export: write git-tracked JSONL for portability if enabled and due.
+				// Read-only commands must not perform post-run maintenance writes or emit
+				// sync guidance after machine-readable output.
+				if shouldRunPostCommandAutoExport(cmd) {
+					if err := runPostRunAutoExport(rootCtx, commandAllowsEmptyAutoExport(cmd)); err != nil {
+						return HandleError("%v", err)
 					}
 				}
-			}
 
-			// Auto-backup: sync a Dolt-native backup if enabled and due
-			maybeAutoBackup(rootCtx)
-
-			// Auto-export: write git-tracked JSONL for portability if enabled and due.
-			// Read-only commands must not perform post-run maintenance writes or emit
-			// sync guidance after machine-readable output.
-			if shouldRunPostCommandAutoExport(cmd) {
-				if err := maybeAutoExport(rootCtx, commandAllowsEmptyAutoExport(cmd)); err != nil {
-					return HandleError("%v", err)
+				// Auto-push: push to Dolt remote if enabled and due.
+				// Skip for read-only commands to avoid unnecessary network operations
+				// and metadata writes on commands like bd list/show/ready (GH#2191).
+				if !isReadOnlyCommand(cmd.Name()) {
+					runPostRunAutoPush(rootCtx)
 				}
-			}
-
-			// Auto-push: push to Dolt remote if enabled and due.
-			// Skip for read-only commands to avoid unnecessary network operations
-			// and metadata writes on commands like bd list/show/ready (GH#2191).
-			if !isReadOnlyCommand(cmd.Name()) {
-				maybeAutoPush(rootCtx)
 			}
 
 			// Signal that store is closing (prevents background flush from accessing closed store)

--- a/cmd/bd/readonly_policy_test.go
+++ b/cmd/bd/readonly_policy_test.go
@@ -1,0 +1,369 @@
+package main
+
+import (
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"fmt"
+	"io/fs"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/steveyegge/beads/internal/configfile"
+	"github.com/steveyegge/beads/internal/storage"
+	"github.com/steveyegge/beads/internal/storage/dolt"
+	"github.com/steveyegge/beads/internal/storage/doltutil"
+)
+
+func TestEffectiveRootStorePolicy(t *testing.T) {
+	tests := []struct {
+		name             string
+		command          string
+		strictReadonly   bool
+		wantReadOnly     bool
+		wantDisableStart bool
+		wantMaintenance  bool
+	}{
+		{
+			name:            "ordinary write command",
+			command:         "create",
+			wantMaintenance: true,
+		},
+		{
+			name:            "classified read keeps compatibility maintenance",
+			command:         "search",
+			wantReadOnly:    true,
+			wantMaintenance: true,
+		},
+		{
+			name:             "strict readonly governs unclassified command",
+			command:          "create",
+			strictReadonly:   true,
+			wantReadOnly:     true,
+			wantDisableStart: true,
+			wantMaintenance:  false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			policy := effectiveRootStorePolicy(tc.command, tc.strictReadonly)
+			if policy.readOnly != tc.wantReadOnly {
+				t.Fatalf("readOnly = %v, want %v", policy.readOnly, tc.wantReadOnly)
+			}
+			if policy.disableAutoStart != tc.wantDisableStart {
+				t.Fatalf("disableAutoStart = %v, want %v", policy.disableAutoStart, tc.wantDisableStart)
+			}
+			if policy.runMaintenance != tc.wantMaintenance {
+				t.Fatalf("runMaintenance = %v, want %v", policy.runMaintenance, tc.wantMaintenance)
+			}
+		})
+	}
+}
+
+func TestStrictReadonlyBackendSupport(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  *configfile.Config
+		want bool
+	}{
+		{name: "fresh embedded default", cfg: nil, want: true},
+		{name: "dolt server", cfg: &configfile.Config{Backend: configfile.BackendDolt, DoltMode: configfile.DoltModeServer}, want: true},
+		{name: "proxied server", cfg: &configfile.Config{Backend: configfile.BackendDolt, DoltMode: configfile.DoltModeProxiedServer}, want: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := backendSupportsStrictReadonly(tc.cfg); got != tc.want {
+				t.Fatalf("backendSupportsStrictReadonly() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+type strictReadonlyPostRunStore struct {
+	storage.DoltStorage
+	metadataWrites int
+	closeCalls     int
+}
+
+func (s *strictReadonlyPostRunStore) SetLocalMetadata(context.Context, string, string) error {
+	s.metadataWrites++
+	return nil
+}
+
+func (s *strictReadonlyPostRunStore) Close() error {
+	s.closeCalls++
+	return nil
+}
+
+func TestPersistentPostRunStrictReadonlySuppressesMaintenance(t *testing.T) {
+	originalStore := store
+	originalReadonly := readonlyMode
+	originalProxied := proxiedServerMode
+	originalRootCtx := rootCtx
+	originalRootCancel := rootCancel
+	originalCommandSpan := commandSpan
+	originalProfileFile := profileFile
+	originalTraceFile := traceFile
+	storeMutex.Lock()
+	originalStoreActive := storeActive
+	storeMutex.Unlock()
+	originalDoltAutoCommit := doltAutoCommit
+	originalDidWrite := commandDidWrite.Load()
+	originalDidExplicitCommit := commandDidExplicitDoltCommit
+	originalDidWriteTipMetadata := commandDidWriteTipMetadata
+	originalTipIDsWereNil := commandTipIDsShown == nil
+	originalTipIDsShown := make(map[string]struct{}, len(commandTipIDsShown))
+	for id := range commandTipIDsShown {
+		originalTipIDsShown[id] = struct{}{}
+	}
+	originalCommit := runPostRunAutoCommit
+	originalBackup := runPostRunAutoBackup
+	originalExport := runPostRunAutoExport
+	originalPush := runPostRunAutoPush
+	t.Cleanup(func() {
+		store = originalStore
+		readonlyMode = originalReadonly
+		proxiedServerMode = originalProxied
+		rootCtx = originalRootCtx
+		rootCancel = originalRootCancel
+		commandSpan = originalCommandSpan
+		profileFile = originalProfileFile
+		traceFile = originalTraceFile
+		storeMutex.Lock()
+		storeActive = originalStoreActive
+		storeMutex.Unlock()
+		doltAutoCommit = originalDoltAutoCommit
+		commandDidWrite.Store(originalDidWrite)
+		commandDidExplicitDoltCommit = originalDidExplicitCommit
+		commandDidWriteTipMetadata = originalDidWriteTipMetadata
+		if originalTipIDsWereNil {
+			commandTipIDsShown = nil
+		} else {
+			commandTipIDsShown = originalTipIDsShown
+		}
+		runPostRunAutoCommit = originalCommit
+		runPostRunAutoBackup = originalBackup
+		runPostRunAutoExport = originalExport
+		runPostRunAutoPush = originalPush
+	})
+
+	maintenanceCalls := 0
+	runPostRunAutoCommit = func(context.Context, doltAutoCommitParams) error { maintenanceCalls++; return nil }
+	runPostRunAutoBackup = func(context.Context) { maintenanceCalls++ }
+	runPostRunAutoExport = func(context.Context, bool) error { maintenanceCalls++; return nil }
+	runPostRunAutoPush = func(context.Context) { maintenanceCalls++ }
+
+	fake := &strictReadonlyPostRunStore{}
+	store = fake
+	readonlyMode = true
+	proxiedServerMode = false
+	rootCtx = context.Background()
+	rootCancel = nil
+	commandSpan = nil
+	profileFile = nil
+	traceFile = nil
+	commandDidWrite.Store(true)
+	commandDidExplicitDoltCommit = false
+	commandDidWriteTipMetadata = true
+	commandTipIDsShown = map[string]struct{}{"strict-readonly": {}}
+	doltAutoCommit = string(doltAutoCommitOn)
+
+	if err := rootCmd.PersistentPostRunE(&cobra.Command{Use: "create"}, nil); err != nil {
+		t.Fatalf("PersistentPostRunE: %v", err)
+	}
+	if maintenanceCalls != 0 {
+		t.Fatalf("strict readonly ran %d automatic commit/backup/export/push operation(s)", maintenanceCalls)
+	}
+	if fake.metadataWrites != 0 {
+		t.Fatalf("strict readonly wrote %d tip metadata value(s)", fake.metadataWrites)
+	}
+	if fake.closeCalls != 1 {
+		t.Fatalf("store close calls = %d, want 1", fake.closeCalls)
+	}
+}
+
+type readonlyTreeEntry struct {
+	Mode   fs.FileMode
+	SHA256 string
+}
+
+type readonlyTreeSnapshot struct {
+	Exists  bool
+	Entries map[string]readonlyTreeEntry
+}
+
+func snapshotReadonlyTree(t *testing.T, root string) readonlyTreeSnapshot {
+	t.Helper()
+	if _, err := os.Lstat(root); os.IsNotExist(err) {
+		return readonlyTreeSnapshot{}
+	} else if err != nil {
+		t.Fatalf("stat snapshot root %s: %v", root, err)
+	}
+
+	snapshot := readonlyTreeSnapshot{Exists: true, Entries: make(map[string]readonlyTreeEntry)}
+	if err := filepath.WalkDir(root, func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		info, err := os.Lstat(path)
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		item := readonlyTreeEntry{Mode: info.Mode()}
+		switch {
+		case info.Mode().IsRegular():
+			data, err := os.ReadFile(path)
+			if err != nil {
+				return err
+			}
+			item.SHA256 = fmt.Sprintf("%x", sha256.Sum256(data))
+		case info.Mode()&os.ModeSymlink != 0:
+			target, err := os.Readlink(path)
+			if err != nil {
+				return err
+			}
+			item.SHA256 = fmt.Sprintf("%x", sha256.Sum256([]byte(target)))
+		}
+		snapshot.Entries[rel] = item
+		return nil
+	}); err != nil {
+		t.Fatalf("snapshot %s: %v", root, err)
+	}
+	return snapshot
+}
+
+func readonlyCanaryEnv(home, beadsDir, circuitDir string, port int) []string {
+	replace := map[string]bool{
+		"HOME": true, "XDG_CONFIG_HOME": true,
+		"BEADS_DIR": true, "BEADS_DB": true, "BD_DB": true,
+		"BEADS_DOLT_PORT": true, "BEADS_DOLT_SERVER_PORT": true, "BEADS_DOLT_AUTO_START": true,
+		"BEADS_TEST_MODE": true, "BEADS_TEST_CIRCUIT_DIR": true,
+		"BD_DISABLE_METRICS": true, "BD_DISABLE_EVENT_FLUSH": true,
+		"BD_OTEL_METRICS_URL": true, "BD_OTEL_LOGS_URL": true, "BD_OTEL_STDOUT": true,
+	}
+	env := make([]string, 0, len(os.Environ())+16)
+	for _, value := range os.Environ() {
+		key, _, _ := strings.Cut(value, "=")
+		if !replace[key] {
+			env = append(env, value)
+		}
+	}
+	return append(env,
+		"HOME="+home,
+		"XDG_CONFIG_HOME="+filepath.Join(home, "xdg"),
+		"BEADS_DIR="+beadsDir,
+		"BEADS_DB=", "BD_DB=",
+		"BEADS_DOLT_SERVER_PORT="+strconv.Itoa(port),
+		"BEADS_DOLT_PORT="+strconv.Itoa(port),
+		"BEADS_DOLT_AUTO_START=0",
+		"BEADS_TEST_MODE=1",
+		"BEADS_TEST_CIRCUIT_DIR="+circuitDir,
+		"BD_DISABLE_METRICS=1",
+		"BD_DISABLE_EVENT_FLUSH=1",
+		"BD_OTEL_METRICS_URL=", "BD_OTEL_LOGS_URL=", "BD_OTEL_STDOUT=false",
+		"BEADS_TEST_IGNORE_REPO_CONFIG=1",
+	)
+}
+
+func TestConfigValidateReadOnlyIsHermetic(t *testing.T) {
+	port, err := strconv.Atoi(os.Getenv("BEADS_DOLT_PORT"))
+	if err != nil || port <= 0 {
+		t.Skip("shared Dolt test server is unavailable")
+	}
+	circuitDir := os.Getenv("BEADS_TEST_CIRCUIT_DIR")
+	if !filepath.IsAbs(circuitDir) {
+		t.Fatalf("suite circuit directory is not isolated: %q", circuitDir)
+	}
+
+	repoDir := t.TempDir()
+	beadsDir := filepath.Join(repoDir, ".beads")
+	doltPath := filepath.Join(beadsDir, "dolt")
+	if err := os.MkdirAll(doltPath, 0o755); err != nil {
+		t.Fatalf("create isolated Dolt path: %v", err)
+	}
+	database := fmt.Sprintf("readonly_canary_%d_%d", os.Getpid(), time.Now().UnixNano())
+	cfg := &configfile.Config{
+		Database:       "dolt",
+		Backend:        configfile.BackendDolt,
+		DoltMode:       configfile.DoltModeServer,
+		DoltDatabase:   database,
+		DoltServerHost: "127.0.0.1",
+		DoltServerPort: port,
+	}
+	if err := cfg.Save(beadsDir); err != nil {
+		t.Fatalf("save isolated metadata: %v", err)
+	}
+	store, err := dolt.New(context.Background(), &dolt.Config{
+		Path:            doltPath,
+		BeadsDir:        beadsDir,
+		ServerHost:      "127.0.0.1",
+		ServerPort:      port,
+		Database:        database,
+		CreateIfMissing: true,
+	})
+	if err != nil {
+		t.Fatalf("create isolated database: %v", err)
+	}
+	if err := store.SetConfig(context.Background(), "issue_prefix", "readonly"); err != nil {
+		_ = store.Close()
+		t.Fatalf("seed isolated database config: %v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("close isolated database: %v", err)
+	}
+	t.Cleanup(func() {
+		db, openErr := sql.Open("mysql", doltutil.ServerDSN{Host: "127.0.0.1", Port: port, User: "root"}.String())
+		if openErr == nil {
+			defer db.Close()
+			_, _ = db.ExecContext(context.Background(), fmt.Sprintf("DROP DATABASE IF EXISTS `%s`", database)) //nolint:gosec // generated test name
+		}
+	})
+	if err := os.WriteFile(filepath.Join(beadsDir, "config.yaml"), []byte("issue-prefix: readonly\ndolt.auto-start: false\n"), 0o644); err != nil {
+		t.Fatalf("write isolated config: %v", err)
+	}
+
+	beforeBeads := snapshotReadonlyTree(t, beadsDir)
+	beforeCircuit := snapshotReadonlyTree(t, circuitDir)
+	home := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(home, "xdg"), 0o755); err != nil {
+		t.Fatalf("create isolated XDG home: %v", err)
+	}
+	// The canary must execute the current worktree source, never a caller-provided
+	// prebuilt binary that may predate this candidate.
+	t.Setenv("BEADS_TEST_BD_BINARY", "")
+	bd := buildBDForTest(t)
+	cmd := exec.Command(bd, "config", "validate", "--readonly")
+	cmd.Dir = repoDir
+	cmd.Env = readonlyCanaryEnv(home, beadsDir, circuitDir, port)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("bd config validate --readonly: %v\n%s", err, output)
+	}
+
+	afterBeads := snapshotReadonlyTree(t, beadsDir)
+	if !reflect.DeepEqual(afterBeads, beforeBeads) {
+		t.Fatalf("target .beads changed\nbefore: %#v\nafter:  %#v\noutput: %s", beforeBeads, afterBeads, output)
+	}
+	afterCircuit := snapshotReadonlyTree(t, circuitDir)
+	if !reflect.DeepEqual(afterCircuit, beforeCircuit) {
+		t.Fatalf("test circuit state changed\nbefore: %#v\nafter:  %#v", beforeCircuit, afterCircuit)
+	}
+	for _, artifact := range []string{".local_version", "dolt-server.port", "dolt-server.pid", "dolt-server.log"} {
+		if _, err := os.Lstat(filepath.Join(beadsDir, artifact)); !os.IsNotExist(err) {
+			t.Fatalf("strict readonly created server/version artifact %s (stat error: %v)", artifact, err)
+		}
+	}
+}

--- a/cmd/bd/readonly_policy_test.go
+++ b/cmd/bd/readonly_policy_test.go
@@ -331,7 +331,10 @@ func TestConfigValidateReadOnlyIsHermetic(t *testing.T) {
 			_, _ = db.ExecContext(context.Background(), fmt.Sprintf("DROP DATABASE IF EXISTS `%s`", database)) //nolint:gosec // generated test name
 		}
 	})
-	if err := os.WriteFile(filepath.Join(beadsDir, "config.yaml"), []byte("issue-prefix: readonly\ndolt.auto-start: false\n"), 0o644); err != nil {
+	// federation.remote is required for `bd config validate` to pass since
+	// the JSONL-removal change; without it the canary fails on validation
+	// rather than exercising the hermeticity contract.
+	if err := os.WriteFile(filepath.Join(beadsDir, "config.yaml"), []byte("issue-prefix: readonly\ndolt.auto-start: false\nfederation:\n  remote: https://github.com/example/beads-remote\n"), 0o644); err != nil {
 		t.Fatalf("write isolated config: %v", err)
 	}
 

--- a/cmd/bd/store_factory.go
+++ b/cmd/bd/store_factory.go
@@ -55,9 +55,20 @@ func newDoltStore(ctx context.Context, cfg *dolt.Config) (storage.DoltStorage, e
 		return dolt.New(ctx, cfg)
 	}
 	if cfg.ReadOnly {
-		// Read-only commands must not be bricked by the #4259
-		// remote-migrate gate (bd-578h9.5); server mode's ReadOnly opens
-		// already skip migration entirely.
+		if cfg.DisableAutoStart {
+			// Strict --readonly (cfg.DisableAutoStart is the strict-only
+			// signal threaded from policy.disableAutoStart): the command
+			// must not write anything, not even incidentally (schema
+			// init, migrations, the post-command autocommit net). Use the
+			// genuinely write-refusing open — same one used for cross-repo
+			// hydration of foreign projects (GH#3231, bd-6dnrw.32) — instead
+			// of OpenForReadOnlyCommand, which is "otherwise a normal
+			// writable store".
+			return embeddeddolt.OpenReadOnly(ctx, cfg.BeadsDir, cfg.Database, "main")
+		}
+		// Ordinary classified-read commands (bd show, bd list, ...) must
+		// not be bricked by the #4259 remote-migrate gate (bd-578h9.5);
+		// server mode's ReadOnly opens already skip migration entirely.
 		return embeddeddolt.OpenForReadOnlyCommand(ctx, cfg.BeadsDir, cfg.Database, "main")
 	}
 	if cfg.LenientOpen {

--- a/cmd/bd/store_factory_test.go
+++ b/cmd/bd/store_factory_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/steveyegge/beads/internal/configfile"
+	"github.com/steveyegge/beads/internal/storage/dolt"
 	"github.com/steveyegge/beads/internal/storage/embeddeddolt"
 )
 
@@ -243,5 +244,54 @@ func TestNewDoltStoreFromConfig_DottedDBName(t *testing.T) {
 	}
 	if reloaded.DoltDatabase != "my_project" {
 		t.Errorf("expected dolt_database %q, got %q", "my_project", reloaded.DoltDatabase)
+	}
+}
+
+// TestNewDoltStore_StrictReadOnlyRefusesWritesOnFreshDatabase covers Blocker 2
+// of the 2026-07-23 maintainer review on gastownhall/beads#4930: cfg.ReadOnly
+// alone (an ordinary classified-read command) must route through
+// OpenForReadOnlyCommand, which creates the embedded data directory on first
+// use — but cfg.ReadOnly combined with cfg.DisableAutoStart (the strict
+// --readonly signal) must route through the genuinely write-refusing
+// OpenReadOnly instead, which fails rather than create anything for a fresh
+// database.
+func TestNewDoltStore_StrictReadOnlyRefusesWritesOnFreshDatabase(t *testing.T) {
+	if os.Getenv("BEADS_TEST_EMBEDDED_DOLT") != "1" {
+		t.Skip("set BEADS_TEST_EMBEDDED_DOLT=1 to run embedded dolt tests")
+	}
+
+	// Strict --readonly: must fail on a fresh database and must not create
+	// the embeddeddolt data directory.
+	strictBeadsDir := t.TempDir()
+	strictDataDir := filepath.Join(strictBeadsDir, "embeddeddolt")
+	_, err := newDoltStore(t.Context(), &dolt.Config{
+		ReadOnly:         true,
+		DisableAutoStart: true,
+		BeadsDir:         strictBeadsDir,
+		Database:         "testdb",
+	})
+	if err == nil {
+		t.Fatal("newDoltStore(ReadOnly, DisableAutoStart) on a fresh database = nil error, want refusal")
+	}
+	if _, statErr := os.Stat(strictDataDir); !os.IsNotExist(statErr) {
+		t.Fatalf("strict read-only open created %s (stat error: %v)", strictDataDir, statErr)
+	}
+
+	// Ordinary classified read (ReadOnly without DisableAutoStart): must
+	// still succeed and initialize the embedded database on first use, per
+	// the #4259 remote-migrate-gate exemption this backend relies on.
+	classifiedBeadsDir := t.TempDir()
+	classifiedDataDir := filepath.Join(classifiedBeadsDir, "embeddeddolt")
+	store, err := newDoltStore(t.Context(), &dolt.Config{
+		ReadOnly: true,
+		BeadsDir: classifiedBeadsDir,
+		Database: "testdb",
+	})
+	if err != nil {
+		t.Fatalf("newDoltStore(ReadOnly) on a fresh database: %v", err)
+	}
+	defer store.Close()
+	if _, statErr := os.Stat(classifiedDataDir); statErr != nil {
+		t.Fatalf("classified-read open did not initialize %s: %v", classifiedDataDir, statErr)
 	}
 }

--- a/cmd/bd/test_repo_beads_guard_test.go
+++ b/cmd/bd/test_repo_beads_guard_test.go
@@ -115,6 +115,8 @@ func testMainInner(m *testing.M) int {
 	// test-server lane so dolt.New's database-name firewall allows
 	// testdb_*, benchdb_*, etc. on the spawned test container.
 	_ = os.Setenv("BEADS_TEST_SERVER", "1")
+	_ = os.Setenv("BEADS_TEST_CIRCUIT_DIR", filepath.Join(tmp, "circuit"))
+	defer os.Unsetenv("BEADS_TEST_CIRCUIT_DIR")
 
 	// Clear BEADS_DIR to prevent tests from accidentally picking up the project's
 	// .beads directory via git repo detection when there's a redirect file.

--- a/internal/storage/dolt/circuit.go
+++ b/internal/storage/dolt/circuit.go
@@ -82,10 +82,25 @@ func maybeNewCircuitBreaker(host string, port int, database string) *circuitBrea
 	return newCircuitBreaker(host, port, database)
 }
 
-// circuitBreakerDir is the dedicated directory for circuit breaker state files.
+// circuitBreakerDir is the production directory for circuit breaker state files.
 // Using a subdirectory avoids scanning all of /tmp (which may contain millions
 // of entries) when cleaning up stale breaker files on startup.
 const circuitBreakerDir = "/tmp/beads-circuit"
+
+const (
+	legacyCircuitBreakerFile = "/tmp/beads-dolt-circuit-0.json"
+	testCircuitBreakerDirEnv = "BEADS_TEST_CIRCUIT_DIR"
+)
+
+// circuitBreakerPaths returns production paths unless the test harness provides
+// a suite-owned circuit directory. The override redirects both current and
+// legacy state even when an individual test temporarily unsets BEADS_TEST_MODE.
+func circuitBreakerPaths() (dir, legacyFile string) {
+	if testDir := filepath.Clean(os.Getenv(testCircuitBreakerDirEnv)); filepath.IsAbs(testDir) {
+		return testDir, filepath.Join(testDir, "beads-dolt-circuit-0.json")
+	}
+	return circuitBreakerDir, legacyCircuitBreakerFile
+}
 
 // newCircuitBreaker creates a circuit breaker for the given Dolt server
 // host:port:database. The database name is included in the file path so each
@@ -107,12 +122,13 @@ func newCircuitBreaker(host string, port int, database string) *circuitBreaker {
 		filename = fmt.Sprintf("beads-dolt-circuit-%s-%d.json", safeHost, port)
 	}
 
-	_ = os.MkdirAll(circuitBreakerDir, 0755)
+	dir, _ := circuitBreakerPaths()
+	_ = os.MkdirAll(dir, 0755)
 	return &circuitBreaker{
 		host:     host,
 		port:     port,
 		database: database,
-		filePath: filepath.Join(circuitBreakerDir, filename),
+		filePath: filepath.Join(dir, filename),
 	}
 }
 
@@ -324,13 +340,14 @@ func (cb *circuitBreaker) writeState(state circuitState) {
 //
 // Called during init to ensure a clean starting state (GH#2598).
 func CleanStaleCircuitBreakerFiles() {
+	dir, legacyFile := circuitBreakerPaths()
 	// Remove legacy files that lived directly in /tmp (before the subdirectory move).
 	// Direct path removal — no directory scan needed.
-	_ = os.Remove("/tmp/beads-dolt-circuit-0.json")
+	_ = os.Remove(legacyFile)
 
 	// Clean stale files in the dedicated subdirectory (fast — typically 0-2 files).
-	_ = os.MkdirAll(circuitBreakerDir, 0755)
-	cleanStaleCircuitBreakerFilesIn(circuitBreakerDir)
+	_ = os.MkdirAll(dir, 0755)
+	cleanStaleCircuitBreakerFilesIn(dir)
 }
 
 // cleanStaleCircuitBreakerFilesIn is the testable implementation of

--- a/internal/storage/dolt/circuit_test.go
+++ b/internal/storage/dolt/circuit_test.go
@@ -417,15 +417,61 @@ func TestCircuitBreakerDir_UsesSubdirectory(t *testing.T) {
 	cb := newCircuitBreaker("127.0.0.1", 44444, "")
 	t.Cleanup(func() { os.Remove(cb.filePath) })
 
-	if filepath.Dir(cb.filePath) != filepath.Clean(circuitBreakerDir) {
+	wantDir, _ := circuitBreakerPaths()
+	if filepath.Dir(cb.filePath) != wantDir {
 		t.Errorf("circuit breaker file should be in %s, got dir %s",
-			circuitBreakerDir, filepath.Dir(cb.filePath))
+			wantDir, filepath.Dir(cb.filePath))
 	}
 
 	// Write state and verify file lands in the subdirectory
 	cb.writeState(circuitState{State: circuitClosed})
 	if _, err := os.Stat(cb.filePath); err != nil {
 		t.Errorf("circuit breaker file should exist at %s: %v", cb.filePath, err)
+	}
+}
+
+func TestCircuitBreakerPathsTestOverrideIsolatesCurrentAndLegacyState(t *testing.T) {
+	testDir := t.TempDir()
+	t.Setenv(testCircuitBreakerDirEnv, testDir)
+	t.Setenv("BEADS_TEST_MODE", "")
+
+	dir, legacy := circuitBreakerPaths()
+	if dir != testDir {
+		t.Fatalf("circuit directory = %q, want %q", dir, testDir)
+	}
+	wantLegacy := filepath.Join(testDir, "beads-dolt-circuit-0.json")
+	if legacy != wantLegacy {
+		t.Fatalf("legacy circuit file = %q, want %q", legacy, wantLegacy)
+	}
+	cb := newCircuitBreaker("127.0.0.1", 44444, "isolated")
+	if filepath.Dir(cb.filePath) != testDir {
+		t.Fatalf("breaker path = %q, want directory %q", cb.filePath, testDir)
+	}
+	if err := os.WriteFile(wantLegacy, []byte("legacy"), 0o600); err != nil {
+		t.Fatalf("write isolated legacy state: %v", err)
+	}
+	CleanStaleCircuitBreakerFiles()
+	if _, err := os.Stat(wantLegacy); !os.IsNotExist(err) {
+		t.Fatalf("isolated legacy cleanup error = %v, want not-exist", err)
+	}
+}
+
+func TestCircuitBreakerPathsProductionDefaultsUnchanged(t *testing.T) {
+	t.Setenv(testCircuitBreakerDirEnv, "")
+	dir, legacy := circuitBreakerPaths()
+	if dir != "/tmp/beads-circuit" {
+		t.Fatalf("production circuit directory = %q", dir)
+	}
+	if legacy != "/tmp/beads-dolt-circuit-0.json" {
+		t.Fatalf("production legacy circuit file = %q", legacy)
+	}
+}
+
+func TestCircuitBreakerPathsRejectsRelativeOverride(t *testing.T) {
+	t.Setenv(testCircuitBreakerDirEnv, "relative-test-dir")
+	dir, legacy := circuitBreakerPaths()
+	if dir != circuitBreakerDir || legacy != legacyCircuitBreakerFile {
+		t.Fatalf("relative override selected paths dir=%q legacy=%q", dir, legacy)
 	}
 }
 

--- a/internal/storage/dolt/readonly_server_policy_test.go
+++ b/internal/storage/dolt/readonly_server_policy_test.go
@@ -1,0 +1,106 @@
+package dolt
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestInitializeServerCircuitBreakerHonorsReadOnly(t *testing.T) {
+	t.Setenv("BEADS_TEST_MODE", "")
+	originalClean := cleanServerCircuitState
+	originalNew := newServerCircuitBreaker
+	t.Cleanup(func() {
+		cleanServerCircuitState = originalClean
+		newServerCircuitBreaker = originalNew
+	})
+
+	cleanCalls := 0
+	newCalls := 0
+	cleanServerCircuitState = func() { cleanCalls++ }
+	newServerCircuitBreaker = func(host string, port int, database string) *circuitBreaker {
+		newCalls++
+		return &circuitBreaker{filePath: filepath.Join(t.TempDir(), "circuit.json")}
+	}
+
+	if got := initializeServerCircuitBreaker(&Config{ReadOnly: true, ServerPort: 3307}); got != nil {
+		t.Fatal("read-only server open created a circuit breaker")
+	}
+	if cleanCalls != 0 || newCalls != 0 {
+		t.Fatalf("read-only server open mutated circuit state: clean=%d new=%d", cleanCalls, newCalls)
+	}
+
+	if got := initializeServerCircuitBreaker(&Config{ServerPort: 3307}); got == nil {
+		t.Fatal("writable server open must retain circuit breaker behavior")
+	}
+	if cleanCalls != 1 || newCalls != 1 {
+		t.Fatalf("writable server open circuit calls: clean=%d new=%d, want 1 each", cleanCalls, newCalls)
+	}
+}
+
+func TestInitializeServerCircuitBreakerSkipsTestMode(t *testing.T) {
+	originalClean := cleanServerCircuitState
+	originalNew := newServerCircuitBreaker
+	t.Cleanup(func() {
+		cleanServerCircuitState = originalClean
+		newServerCircuitBreaker = originalNew
+	})
+	t.Setenv("BEADS_TEST_MODE", "1")
+
+	cleanCalls := 0
+	newCalls := 0
+	cleanServerCircuitState = func() { cleanCalls++ }
+	newServerCircuitBreaker = func(string, int, string) *circuitBreaker {
+		newCalls++
+		return &circuitBreaker{}
+	}
+
+	if got := initializeServerCircuitBreaker(&Config{ServerPort: 3307}); got != nil {
+		t.Fatal("test-mode server open created a circuit breaker")
+	}
+	if cleanCalls != 0 || newCalls != 0 {
+		t.Fatalf("test-mode server open touched circuit state: clean=%d new=%d", cleanCalls, newCalls)
+	}
+}
+
+func TestPersistResolvedPortFileHonorsReadOnly(t *testing.T) {
+	originalEnsure := ensureResolvedPortFile
+	t.Cleanup(func() { ensureResolvedPortFile = originalEnsure })
+	t.Setenv("BEADS_DOLT_SERVER_PORT", "")
+	t.Setenv("BEADS_DOLT_PORT", "")
+
+	calls := 0
+	var gotDir string
+	var gotPort int
+	ensureResolvedPortFile = func(beadsDir string, port int) error {
+		calls++
+		gotDir, gotPort = beadsDir, port
+		return nil
+	}
+
+	beadsDir := t.TempDir()
+	if err := persistResolvedPortFile(&Config{ReadOnly: true, ServerHost: "127.0.0.1", ServerPort: 3307}, beadsDir); err != nil {
+		t.Fatalf("read-only persist policy: %v", err)
+	}
+	if calls != 0 {
+		t.Fatalf("read-only server open repaired port file %d time(s)", calls)
+	}
+
+	if err := persistResolvedPortFile(&Config{ServerHost: "127.0.0.1", ServerPort: 3308}, beadsDir); err != nil {
+		t.Fatalf("writable persist policy: %v", err)
+	}
+	if calls != 1 || gotDir != beadsDir || gotPort != 3308 {
+		t.Fatalf("writable port persistence = calls:%d dir:%q port:%d", calls, gotDir, gotPort)
+	}
+}
+
+func TestServerOpenCanAutoStartHonorsReadOnly(t *testing.T) {
+	readonly := &Config{ReadOnly: true, AutoStart: true, Path: "/unused", ServerHost: "127.0.0.1"}
+	if serverOpenCanAutoStart(readonly) {
+		t.Fatal("read-only server open must never auto-start a server")
+	}
+
+	writable := &Config{AutoStart: true, Path: "/unused", ServerHost: "127.0.0.1"}
+	if !serverOpenCanAutoStart(writable) {
+		t.Fatal("writable server open must retain auto-start behavior")
+	}
+}

--- a/internal/storage/dolt/readonly_server_policy_test.go
+++ b/internal/storage/dolt/readonly_server_policy_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 )
 
-func TestInitializeServerCircuitBreakerHonorsReadOnly(t *testing.T) {
+func TestInitializeServerCircuitBreakerHonorsDisableAutoStart(t *testing.T) {
 	t.Setenv("BEADS_TEST_MODE", "")
 	originalClean := cleanServerCircuitState
 	originalNew := newServerCircuitBreaker
@@ -22,11 +22,11 @@ func TestInitializeServerCircuitBreakerHonorsReadOnly(t *testing.T) {
 		return &circuitBreaker{filePath: filepath.Join(t.TempDir(), "circuit.json")}
 	}
 
-	if got := initializeServerCircuitBreaker(&Config{ReadOnly: true, ServerPort: 3307}); got != nil {
-		t.Fatal("read-only server open created a circuit breaker")
+	if got := initializeServerCircuitBreaker(&Config{DisableAutoStart: true, ServerPort: 3307}); got != nil {
+		t.Fatal("strict read-only (DisableAutoStart) server open created a circuit breaker")
 	}
 	if cleanCalls != 0 || newCalls != 0 {
-		t.Fatalf("read-only server open mutated circuit state: clean=%d new=%d", cleanCalls, newCalls)
+		t.Fatalf("strict read-only server open mutated circuit state: clean=%d new=%d", cleanCalls, newCalls)
 	}
 
 	if got := initializeServerCircuitBreaker(&Config{ServerPort: 3307}); got == nil {
@@ -34,6 +34,17 @@ func TestInitializeServerCircuitBreakerHonorsReadOnly(t *testing.T) {
 	}
 	if cleanCalls != 1 || newCalls != 1 {
 		t.Fatalf("writable server open circuit calls: clean=%d new=%d, want 1 each", cleanCalls, newCalls)
+	}
+
+	// An ordinary classified-read command sets ReadOnly but not
+	// DisableAutoStart, and must retain the writable-open circuit breaker
+	// behavior (regression guard for the ReadOnly/DisableAutoStart
+	// conflation fixed in this change).
+	if got := initializeServerCircuitBreaker(&Config{ReadOnly: true, ServerPort: 3307}); got == nil {
+		t.Fatal("ordinary classified-read (ReadOnly without DisableAutoStart) must retain circuit breaker behavior")
+	}
+	if cleanCalls != 2 || newCalls != 2 {
+		t.Fatalf("classified-read server open circuit calls: clean=%d new=%d, want 2 each", cleanCalls, newCalls)
 	}
 }
 
@@ -62,7 +73,7 @@ func TestInitializeServerCircuitBreakerSkipsTestMode(t *testing.T) {
 	}
 }
 
-func TestPersistResolvedPortFileHonorsReadOnly(t *testing.T) {
+func TestPersistResolvedPortFileHonorsDisableAutoStart(t *testing.T) {
 	originalEnsure := ensureResolvedPortFile
 	t.Cleanup(func() { ensureResolvedPortFile = originalEnsure })
 	t.Setenv("BEADS_DOLT_SERVER_PORT", "")
@@ -78,11 +89,11 @@ func TestPersistResolvedPortFileHonorsReadOnly(t *testing.T) {
 	}
 
 	beadsDir := t.TempDir()
-	if err := persistResolvedPortFile(&Config{ReadOnly: true, ServerHost: "127.0.0.1", ServerPort: 3307}, beadsDir); err != nil {
-		t.Fatalf("read-only persist policy: %v", err)
+	if err := persistResolvedPortFile(&Config{DisableAutoStart: true, ServerHost: "127.0.0.1", ServerPort: 3307}, beadsDir); err != nil {
+		t.Fatalf("strict read-only persist policy: %v", err)
 	}
 	if calls != 0 {
-		t.Fatalf("read-only server open repaired port file %d time(s)", calls)
+		t.Fatalf("strict read-only server open repaired port file %d time(s)", calls)
 	}
 
 	if err := persistResolvedPortFile(&Config{ServerHost: "127.0.0.1", ServerPort: 3308}, beadsDir); err != nil {
@@ -91,16 +102,35 @@ func TestPersistResolvedPortFileHonorsReadOnly(t *testing.T) {
 	if calls != 1 || gotDir != beadsDir || gotPort != 3308 {
 		t.Fatalf("writable port persistence = calls:%d dir:%q port:%d", calls, gotDir, gotPort)
 	}
+
+	// An ordinary classified-read command sets ReadOnly but not
+	// DisableAutoStart, and must retain port-file repair.
+	if err := persistResolvedPortFile(&Config{ReadOnly: true, ServerHost: "127.0.0.1", ServerPort: 3309}, beadsDir); err != nil {
+		t.Fatalf("classified-read persist policy: %v", err)
+	}
+	if calls != 2 || gotDir != beadsDir || gotPort != 3309 {
+		t.Fatalf("classified-read port persistence = calls:%d dir:%q port:%d", calls, gotDir, gotPort)
+	}
 }
 
-func TestServerOpenCanAutoStartHonorsReadOnly(t *testing.T) {
-	readonly := &Config{ReadOnly: true, AutoStart: true, Path: "/unused", ServerHost: "127.0.0.1"}
-	if serverOpenCanAutoStart(readonly) {
-		t.Fatal("read-only server open must never auto-start a server")
+func TestServerOpenCanAutoStartHonorsDisableAutoStart(t *testing.T) {
+	strictReadOnly := &Config{DisableAutoStart: true, AutoStart: true, Path: "/unused", ServerHost: "127.0.0.1"}
+	if serverOpenCanAutoStart(strictReadOnly) {
+		t.Fatal("strict read-only (DisableAutoStart) server open must never auto-start a server")
 	}
 
 	writable := &Config{AutoStart: true, Path: "/unused", ServerHost: "127.0.0.1"}
 	if !serverOpenCanAutoStart(writable) {
 		t.Fatal("writable server open must retain auto-start behavior")
+	}
+
+	// An ordinary classified-read command (bd show, bd list, ...) sets
+	// ReadOnly but not DisableAutoStart, and must still be able to
+	// auto-start a stopped managed server (regression guard for the
+	// ReadOnly/DisableAutoStart conflation; see
+	// dolt_autostart_lifecycle_integration_test.go).
+	classifiedRead := &Config{ReadOnly: true, AutoStart: true, Path: "/unused", ServerHost: "127.0.0.1"}
+	if !serverOpenCanAutoStart(classifiedRead) {
+		t.Fatal("ordinary classified-read (ReadOnly without DisableAutoStart) must retain auto-start behavior")
 	}
 }

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -1465,7 +1465,7 @@ var (
 )
 
 func initializeServerCircuitBreaker(cfg *Config) *circuitBreaker {
-	if cfg.ReadOnly || os.Getenv("BEADS_TEST_MODE") == "1" {
+	if cfg.DisableAutoStart || os.Getenv("BEADS_TEST_MODE") == "1" {
 		return nil
 	}
 	// Clean stale circuit breaker files before checking — prevents leftover
@@ -1474,13 +1474,19 @@ func initializeServerCircuitBreaker(cfg *Config) *circuitBreaker {
 	return newServerCircuitBreaker(cfg.ServerHost, cfg.ServerPort, cfg.Database)
 }
 
+// serverOpenCanAutoStart reports whether a stopped managed dolt server may be
+// auto-started for this open. This is keyed off DisableAutoStart (the strict
+// --readonly signal threaded from policy.disableAutoStart in cmd/bd/main.go),
+// not cfg.ReadOnly: ordinary classified-read commands (bd show, bd list, ...)
+// also set cfg.ReadOnly but must still be able to auto-start a stopped
+// managed server, per dolt_autostart_lifecycle_integration_test.go.
 func serverOpenCanAutoStart(cfg *Config) bool {
-	return !cfg.ReadOnly && cfg.AutoStart && cfg.Path != "" &&
+	return !cfg.DisableAutoStart && cfg.AutoStart && cfg.Path != "" &&
 		cfg.ServerSocket == "" && isLocalHost(cfg.ServerHost)
 }
 
 func persistResolvedPortFile(cfg *Config, beadsDir string) error {
-	if cfg.ReadOnly || !shouldPersistResolvedPortFile() {
+	if cfg.DisableAutoStart || !shouldPersistResolvedPortFile() {
 		return nil
 	}
 	return ensureResolvedPortFile(beadsDir, cfg.ServerPort)

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -1253,11 +1253,7 @@ func buildTestModeProductionPortPanic(cfg *Config) string {
 // newServerMode creates a DoltStore connected to a running dolt sql-server.
 // This path is pure Go and does not require CGO.
 func newServerMode(ctx context.Context, cfg *Config) (*DoltStore, error) {
-	// Clean stale circuit breaker files before checking — prevents leftover
-	// state from previous sessions poisoning fresh inits (GH#2598).
-	CleanStaleCircuitBreakerFiles()
-
-	breaker := maybeNewCircuitBreaker(cfg.ServerHost, cfg.ServerPort, cfg.Database)
+	breaker := initializeServerCircuitBreaker(cfg)
 
 	// Circuit breaker: fail-fast if the server is known to be down.
 	if breaker != nil && !breaker.Allow() {
@@ -1267,7 +1263,7 @@ func newServerMode(ctx context.Context, cfg *Config) (*DoltStore, error) {
 
 	// Tracks server dir if we auto-started a server (for cleanup in Close, GH#2542).
 	var autoStartedDir string
-	trackAutoStartedServer := shouldStopAutoStartedServerOnClose(cfg)
+	trackAutoStartedServer := !cfg.ReadOnly && shouldStopAutoStartedServerOnClose(cfg)
 	resolvedBeadsDir := cfg.BeadsDir
 	if resolvedBeadsDir == "" {
 		resolvedBeadsDir = filepath.Dir(cfg.Path) // fallback: cfg.Path is .beads/dolt → parent is .beads/
@@ -1292,8 +1288,7 @@ func newServerMode(ctx context.Context, cfg *Config) (*DoltStore, error) {
 		// Socket mode is excluded — auto-start creates a TCP listener, not a
 		// unix socket, so the DSN would still fail. Socket users are expected
 		// to manage their own server lifecycle.
-		canAutoStart := cfg.AutoStart && cfg.Path != "" &&
-			cfg.ServerSocket == "" && isLocalHost(cfg.ServerHost)
+		canAutoStart := serverOpenCanAutoStart(cfg)
 		if canAutoStart {
 			port, startedByUs, startErr := doltserver.EnsureRunningDetailed(resolvedBeadsDir)
 			if startErr != nil {
@@ -1441,12 +1436,12 @@ func newServerMode(ctx context.Context, cfg *Config) (*DoltStore, error) {
 		}
 	}
 
-	if isLocalHost(cfg.ServerHost) && shouldPersistResolvedPortFile() {
+	if isLocalHost(cfg.ServerHost) {
 		beadsDir := cfg.BeadsDir
 		if beadsDir == "" && cfg.Path != "" {
 			beadsDir = filepath.Dir(cfg.Path)
 		}
-		_ = doltserver.EnsurePortFile(beadsDir, cfg.ServerPort)
+		_ = persistResolvedPortFile(cfg, beadsDir)
 	}
 
 	// All writers operate on main — transaction isolation via RunInTransaction
@@ -1461,6 +1456,34 @@ func newServerMode(ctx context.Context, cfg *Config) (*DoltStore, error) {
 	// close above. Must be the last thing before the success return.
 	storeReady = true
 	return store, nil
+}
+
+var (
+	cleanServerCircuitState = CleanStaleCircuitBreakerFiles
+	newServerCircuitBreaker = maybeNewCircuitBreaker
+	ensureResolvedPortFile  = doltserver.EnsurePortFile
+)
+
+func initializeServerCircuitBreaker(cfg *Config) *circuitBreaker {
+	if cfg.ReadOnly || os.Getenv("BEADS_TEST_MODE") == "1" {
+		return nil
+	}
+	// Clean stale circuit breaker files before checking — prevents leftover
+	// state from previous sessions poisoning fresh writable opens (GH#2598).
+	cleanServerCircuitState()
+	return newServerCircuitBreaker(cfg.ServerHost, cfg.ServerPort, cfg.Database)
+}
+
+func serverOpenCanAutoStart(cfg *Config) bool {
+	return !cfg.ReadOnly && cfg.AutoStart && cfg.Path != "" &&
+		cfg.ServerSocket == "" && isLocalHost(cfg.ServerHost)
+}
+
+func persistResolvedPortFile(cfg *Config, beadsDir string) error {
+	if cfg.ReadOnly || !shouldPersistResolvedPortFile() {
+		return nil
+	}
+	return ensureResolvedPortFile(beadsDir, cfg.ServerPort)
 }
 
 func shouldPersistResolvedPortFile() bool {

--- a/internal/storage/dolt/testmain_test.go
+++ b/internal/storage/dolt/testmain_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"fmt"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/steveyegge/beads/internal/doltserver"
@@ -41,9 +42,15 @@ func testMainInner(m *testing.M) int {
 	// unique to this test run and removed when it exits.
 	suiteTempRoot, tempRootErr := os.MkdirTemp("", "beads-storage-dolt-tests-*")
 	if tempRootErr != nil {
-		fmt.Fprintf(os.Stderr, "WARN: failed to create suite temp root: %v\n", tempRootErr)
+		fmt.Fprintf(os.Stderr, "FATAL: failed to create suite temp root: %v\n", tempRootErr)
+		return 1
 	} else {
 		defer os.RemoveAll(suiteTempRoot)
+		if err := os.Setenv(testCircuitBreakerDirEnv, filepath.Join(suiteTempRoot, "circuit")); err != nil {
+			fmt.Fprintf(os.Stderr, "FATAL: failed to isolate circuit state: %v\n", err)
+			return 1
+		}
+		defer os.Unsetenv(testCircuitBreakerDirEnv)
 	}
 
 	// AD-01 (be-c5p): the test/bench harness opens a process-local dolt

--- a/internal/storage/embeddeddolt/cache_cleanup.go
+++ b/internal/storage/embeddeddolt/cache_cleanup.go
@@ -24,6 +24,11 @@ import (
 // This function is safe to call concurrently and is rate-limited to avoid
 // unnecessary filesystem walks on hot paths.
 func (s *EmbeddedDoltStore) cleanGitRemoteCacheGarbage() {
+	// Strict read-only opens must not touch the filesystem, even to delete
+	// leaked temp files — observational purity is the contract.
+	if s.readOnly {
+		return
+	}
 	if !cacheCleanupThrottle.shouldRun() {
 		return
 	}

--- a/internal/storage/embeddeddolt/remote_migrate_gate_test.go
+++ b/internal/storage/embeddeddolt/remote_migrate_gate_test.go
@@ -186,6 +186,35 @@ func TestEmbeddedOpenReadOnly_SkipsGateAndMigrations(t *testing.T) {
 	ro2.Close()
 }
 
+// TestEmbeddedOpenReadOnly_FreshDatabaseNoWrites covers the fresh-database
+// half of the strict --readonly hermeticity contract (gastownhall/beads#4930
+// maintainer review, 2026-07-23): OpenReadOnly against a beadsDir that has no
+// embeddeddolt/ data directory yet must fail rather than create one — unlike
+// Open/OpenForReadOnlyCommand, which create the data directory and initialize
+// the schema on first use.
+func TestEmbeddedOpenReadOnly_FreshDatabaseNoWrites(t *testing.T) {
+	ctx := t.Context()
+	beadsDir := filepath.Join(t.TempDir(), ".beads")
+	dataDir := filepath.Join(beadsDir, "embeddeddolt")
+
+	if _, err := os.Stat(beadsDir); !os.IsNotExist(err) {
+		t.Fatalf("beadsDir must not pre-exist: stat error = %v", err)
+	}
+
+	ro, err := embeddeddolt.OpenReadOnly(ctx, beadsDir, "testdb", "main")
+	if err == nil {
+		ro.Close()
+		t.Fatal("OpenReadOnly on a fresh (nonexistent) database = nil error, want refusal")
+	}
+
+	if _, statErr := os.Stat(dataDir); !os.IsNotExist(statErr) {
+		t.Fatalf("OpenReadOnly on a fresh database created %s (stat error: %v)", dataDir, statErr)
+	}
+	if _, statErr := os.Stat(beadsDir); !os.IsNotExist(statErr) {
+		t.Fatalf("OpenReadOnly on a fresh database created %s (stat error: %v)", beadsDir, statErr)
+	}
+}
+
 // TestEmbeddedOpenForReadOnlyCommand_LenientGate covers bd-578h9.5: a
 // read-only command's open of a behind, remote-backed embedded database must
 // not be bricked by the remote-migrate gate. The open succeeds WITHOUT


### PR DESCRIPTION
## What

Make strict `--readonly` validation observationally pure across root initialization, validator-owned stores, Dolt server lifecycle state, circuit-breaker files, port-file repair, and post-run maintenance.

Strict readonly now fails closed for proxied Dolt, whose current provider bypasses the direct store's readonly config. Current upstream already rejects removed PostgreSQL/MySQL/SQLite backend tombstones before maintenance or store startup; this patch preserves that architecture. Ordinary command-classified reads retain their existing maintenance and auto-start compatibility.

The patch also isolates circuit state for package tests and child `bd` processes under suite-owned temporary roots while preserving the exact production defaults.

## Why

`bd config validate --readonly` could still open the main store writable, track CLI version changes, auto-migrate metadata, start a server, clean or record circuit-breaker state, repair the resolved port file, and run post-command backup/export/push work. A read-only audit observed stale circuit state being deleted.

This is distinct from #4367, which addresses routed writable-store behavior, and it does not modify `version_tracking.go` from #3710.

## Verification

- Fresh focused strict-policy and post-run tests: pass.
- Fresh validator-owned store-options test: pass.
- Fresh circuit isolation, readonly server-open, port-file, auto-start, and writable-companion tests: pass.
- `git diff --cached --check`: pass.
- `make ci-pr-core`: changed storage package passed; two `cmd/bd` failures reproduce unchanged on the exact base.
- `make test`: changed storage package passed; the same exact-base failures and a contention timeout remain named local blockers.
- `gofmt`: pass.
- Hermetic child-process canary: compiles but SKIPs locally because Docker-backed Dolt test infrastructure is unavailable; CI must produce an explicit PASS.
- Local policy/lint scripts are blocked by missing Bash `mapfile` and missing `golangci-lint`; no local tool workaround was installed.

Separate-source exact-candidate review receipt and full local proof are recorded in the handoff packet. Producer will not self-merge.
