### PR TITLE
test(backup): use a platform-native absolute path in TestResolveDoltBackupURL (GH#4923)

### DIFF
--- a/cmd/bd/backup_dolt_test.go
+++ b/cmd/bd/backup_dolt_test.go
@@ -11,6 +11,13 @@ import (
 func TestResolveDoltBackupURL(t *testing.T) {
 	t.Parallel()
 
+	// Build the absolute-path fixture with platform-native semantics.
+	// A hard-coded POSIX literal like "/mnt/usb/beads-backup" is not absolute
+	// on Windows (no volume name), so resolveDoltBackupURL would resolve it
+	// against the current drive and return "file://C:\\mnt\\usb\\...".
+	// t.TempDir() is absolute and already cleaned on every platform.
+	absBackup := filepath.Join(t.TempDir(), "beads-backup")
+
 	tests := []struct {
 		name      string
 		input     string
@@ -43,9 +50,9 @@ func TestResolveDoltBackupURL(t *testing.T) {
 			wantExact: "gs://bucket/path",
 		},
 		{
-			name:    "absolute path gets file:// prefix",
-			input:   "/mnt/usb/beads-backup",
-			wantPfx: "file:///mnt/usb/beads-backup",
+			name:      "absolute path gets file:// prefix",
+			input:     absBackup,
+			wantExact: "file://" + absBackup,
 		},
 		{
 			name:    "relative path gets resolved and prefixed",


### PR DESCRIPTION
## What

Makes the `absolute path gets file:// prefix` case in `TestResolveDoltBackupURL`
build its fixture with platform-native path semantics instead of a hard-coded
POSIX literal.

Test-only change. `resolveDoltBackupURL` is untouched, so there is no
production behavior change.

## Why

The case used the literal `/mnt/usb/beads-backup` as its "absolute path" input
and asserted the result carried the prefix `file:///mnt/usb/beads-backup`.

On Windows that string is not absolute — `filepath.IsAbs` returns false because
it has no volume name. `resolveDoltBackupURL` therefore falls through to
`filepath.Abs`, which resolves it against the current drive, and the function
returns `file://C:\mnt\usb\beads-backup`. The assertion fails, so the focused
`cmd/bd` package suite cannot run clean on Windows:

```
--- FAIL: TestResolveDoltBackupURL/absolute_path_gets_file://_prefix
    backup_dolt_test.go:67: resolveDoltBackupURL("/mnt/usb/beads-backup") =
        "file://C:\\mnt\\usb\\beads-backup", want prefix "file:///mnt/usb/beads-backup"
```

This is a test portability defect, not a production regression.

The fixture is now `filepath.Join(t.TempDir(), "beads-backup")`. `t.TempDir()`
is absolute and already `filepath.Clean`-ed on every platform, so it satisfies
the "absolute path" precondition the old literal failed to meet on Windows. The
path is never created on disk — only the string transform is exercised — so no
filesystem coupling is added.

The assertion also moves from `wantPfx` to `wantExact`. For an already-absolute,
clean input `filepath.Abs` is an identity, so the expected value is
deterministic and the stricter check is safe. On POSIX the expectation still
resolves to a triple-slash `file:///...` URL, preserving the original intent.

The six sibling cases (`https`/`http`/`file`/`aws`/`gs` pass-through and the
relative-path case) are already platform-agnostic and are left untouched.

Refs #4923

## Verification

Run on darwin/arm64, Go 1.26.2 toolchain, `gms_pure_go` build tag:

```bash
go test -tags gms_pure_go ./cmd/bd -run '^TestResolveDoltBackupURL' -count=1   # PASS (7/7 subtests)
go test -tags gms_pure_go ./cmd/bd -run 'Backup' -count=1                      # ok
go vet -tags gms_pure_go ./cmd/bd                                              # clean
make fmt-check                                                                 # all files properly formatted
```

**Windows confirmation.** @ecuthiell, who reported #4923, re-ran the original
repro command against this PR's head commit `ea3a48d` on the same environment
that produced the failure — Windows 11 Pro build 26200, Go 1.26.5
windows/amd64, `gms_pure_go` — and all seven subtests pass. The `t.TempDir()`
fixture used here is the approach proposed in the issue.

I have no Windows machine and did not run it myself; the confirmation is
theirs.

Not in scope: the broader Windows portability sweep tracked in #4638 (NTFS exec
bit, `Signal(0)`, `USERPROFILE` vs `HOME`, worktree walk-up boundary). Kept
separate per the one-issue-per-PR rule.

---

