### PR TITLE
feat: add public schema package re-exporting the migration API

### DIFF
--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1,0 +1,44 @@
+// Package schema is the public wrapper around bd's schema migration engine,
+// re-exporting the minimal surface external tools need to create or upgrade a
+// beads database over a standard database/sql connection.
+package schema
+
+import (
+	"context"
+	"database/sql"
+
+	ischema "github.com/steveyegge/beads/internal/storage/schema"
+)
+
+// DBConn is the minimal query interface satisfied by *sql.DB, *sql.Tx, and
+// *sql.Conn.
+type DBConn = ischema.DBConn
+
+// SchemaSkewError is returned when the database's schema version is ahead of
+// the version this module was built against (forward drift).
+type SchemaSkewError = ischema.SchemaSkewError
+
+// IsSchemaSkewError reports whether err (or any error it wraps) is a
+// *SchemaSkewError.
+func IsSchemaSkewError(err error) bool {
+	return ischema.IsSchemaSkewError(err)
+}
+
+// LatestVersion returns the schema version this module was built against.
+func LatestVersion() int {
+	return ischema.LatestVersion()
+}
+
+// CurrentVersion returns the database's current schema version. A database
+// with no schema_migrations table (never migrated) reports version 0.
+func CurrentVersion(ctx context.Context, db DBConn) (int, error) {
+	return ischema.CurrentVersion(ctx, db)
+}
+
+// MigrateUpWithLock applies all pending migrations up to LatestVersion,
+// serialized across processes by a per-database Dolt/MySQL named lock. conn
+// must be a pinned *sql.Conn because named locks are session-scoped. Returns
+// the number of migrations applied (0 when already current).
+func MigrateUpWithLock(ctx context.Context, conn *sql.Conn, databaseName string) (applied int, err error) {
+	return ischema.MigrateUpWithLock(ctx, conn, databaseName)
+}

--- a/schema/schema_test.go
+++ b/schema/schema_test.go
@@ -1,0 +1,34 @@
+package schema_test
+
+import (
+	"database/sql"
+	"fmt"
+	"testing"
+
+	"github.com/steveyegge/beads/schema"
+)
+
+func TestLatestVersionIsPositive(t *testing.T) {
+	if v := schema.LatestVersion(); v <= 0 {
+		t.Fatalf("LatestVersion() = %d, want > 0", v)
+	}
+}
+
+func TestIsSchemaSkewErrorDetectsWrappedError(t *testing.T) {
+	skew := &schema.SchemaSkewError{DBVersion: 9, BinaryVersion: 3}
+	wrapped := fmt.Errorf("connect: %w", skew)
+	if !schema.IsSchemaSkewError(wrapped) {
+		t.Fatal("IsSchemaSkewError(wrapped SchemaSkewError) = false, want true")
+	}
+	if schema.IsSchemaSkewError(fmt.Errorf("plain error")) {
+		t.Fatal("IsSchemaSkewError(plain error) = true, want false")
+	}
+}
+
+func TestDBConnSatisfiedByStdlibTypes(t *testing.T) {
+	var (
+		_ schema.DBConn = (*sql.DB)(nil)
+		_ schema.DBConn = (*sql.Tx)(nil)
+		_ schema.DBConn = (*sql.Conn)(nil)
+	)
+}


### PR DESCRIPTION
Adds a public schema package                                                                                                                                                                 
                                                                                                                                                                                              
Exposes bd's schema migration API to external Go modules. The migration engine lives under internal/storage/schema, so a separate module can't import it. This adds a thin wrapper at github.com/steveyegge/beads/schema re-exporting the minimal surface needed to create or upgrade a beads database over a standard database/sql connection 