### PR TITLE
test(git): isolate hook-dir home lookup on Windows

### DIFF
--- a/internal/git/gitdir_test.go
+++ b/internal/git/gitdir_test.go
@@ -41,8 +41,8 @@ func setupTestRepo(t *testing.T) (repoPath string, cleanup func()) {
 }
 
 func TestGetGitHooksDirTildeExpansion(t *testing.T) {
-	// Use an explicit temporary HOME so tilde expansion is deterministic
-	// regardless of the environment (CI, containers, overridden HOME, etc.).
+	// Use an explicit temporary home so tilde expansion is deterministic
+	// regardless of the environment (CI, containers, overridden homes, etc.).
 	fakeHome := t.TempDir()
 
 	tests := []struct {
@@ -88,17 +88,10 @@ func TestGetGitHooksDirTildeExpansion(t *testing.T) {
 			subRepoPath, subCleanup := setupTestRepo(t)
 			defer subCleanup()
 
-			// Override HOME after repo setup so tilde expansion resolves
-			// to fakeHome deterministically for the code under test.
-			origHome := os.Getenv("HOME")
-			os.Setenv("HOME", fakeHome)
-			t.Cleanup(func() {
-				if origHome != "" {
-					os.Setenv("HOME", origHome)
-				} else {
-					os.Unsetenv("HOME")
-				}
-			})
+			// Override both home variables after repo setup so Git and
+			// os.UserHomeDir resolve to fakeHome on every platform.
+			t.Setenv("HOME", fakeHome)
+			t.Setenv("USERPROFILE", fakeHome)
 
 			ResetCaches()
 


### PR DESCRIPTION
## What

Set both `HOME` and `USERPROFILE` to the disposable home in `TestGetGitHooksDirTildeExpansion`, after the temporary Git repository has been initialized.

## Why

Fixes #4944.

Git expands the slash forms of `~` through `HOME`, while the production fallback for a literal `~` uses `os.UserHomeDir()`, which reads `USERPROFILE` on Windows. The test previously isolated only `HOME`, so its `bare_tilde` row read the contributor's real profile and failed even though production behavior was correct.

The change is test-only and makes both lookup paths resolve to the same disposable directory on every platform.

## Verification

```powershell
go test -tags gms_pure_go ./internal/git -run '^TestGetGitHooksDirTildeExpansion$' -count=5
```

All five focused repetitions pass on Windows 11 with Go 1.26.5 and Git 2.54. `gofmt` and `git diff --check` are clean.

The complete `internal/git` package still reaches the pre-existing Jujutsu `t.TempDir` cleanup failures tracked by #4935 and PR #4936; this patch does not touch those cases.

Related fixture work: #4638 and PR #4809.

---

_codex-tui-gpt-5.6-sol-ultra on behalf of Ewen Cuthiell_
