### PR TITLE
test(backup): split embedded effective-value cases

### DIFF
--- a/cmd/bd/config_get_backup_enabled_embedded_test.go
+++ b/cmd/bd/config_get_backup_enabled_embedded_test.go
@@ -1,0 +1,24 @@
+//go:build cgo
+
+package main
+
+import "testing"
+
+func TestConfigGetBackupEnabled_EffectiveValue_Embedded(t *testing.T) {
+	runConfigGetBackupEnabledEffectiveValueCases(t, []backupEnabledEffectiveValueCase{
+		{
+			name:         "unset + no remote → off (no git remote)",
+			envVal:       "\x00",
+			hasRemote:    false,
+			wantPrefix:   "false ",
+			wantContains: "no git remote",
+		},
+		{
+			name:         "unset + remote → on (git remote)",
+			envVal:       "\x00",
+			hasRemote:    true,
+			wantPrefix:   "true ",
+			wantContains: "git remote detected",
+		},
+	})
+}

--- a/cmd/bd/config_get_backup_enabled_test.go
+++ b/cmd/bd/config_get_backup_enabled_test.go
@@ -8,34 +8,22 @@ import (
 	"github.com/steveyegge/beads/internal/config"
 )
 
+type backupEnabledEffectiveValueCase struct {
+	name         string
+	envVal       string // "\x00" = unset
+	hasRemote    bool
+	sharedServer bool
+	wantPrefix   string // leading "true "/"false "
+	wantContains string // source annotation substring
+}
+
 // TestConfigGetBackupEnabled_EffectiveValue pins wy-zrmqr fix #3: `bd config
 // get backup.enabled` must report the EFFECTIVE value (what isBackupAutoEnabled
 // actually returns) plus its source, not the raw stored value. Before the fix
 // it printed "false"/"not set" even while auto-backup was running via
 // primeHasGitRemote — the mismatch that hid the storm from operators.
 func TestConfigGetBackupEnabled_EffectiveValue(t *testing.T) {
-	tests := []struct {
-		name         string
-		envVal       string // "\x00" = unset
-		hasRemote    bool
-		sharedServer bool
-		wantPrefix   string // leading "true "/"false "
-		wantContains string // source annotation substring
-	}{
-		{
-			name:         "unset + no remote → off (no git remote)",
-			envVal:       "\x00",
-			hasRemote:    false,
-			wantPrefix:   "false ",
-			wantContains: "no git remote",
-		},
-		{
-			name:         "unset + remote → on (git remote)",
-			envVal:       "\x00",
-			hasRemote:    true,
-			wantPrefix:   "true ",
-			wantContains: "git remote detected",
-		},
+	runConfigGetBackupEnabledEffectiveValueCases(t, []backupEnabledEffectiveValueCase{
 		{
 			name:         "unset + remote + sql-server → off (server mode)",
 			envVal:       "\x00",
@@ -59,8 +47,11 @@ func TestConfigGetBackupEnabled_EffectiveValue(t *testing.T) {
 			wantPrefix:   "false ",
 			wantContains: "env var",
 		},
-	}
+	})
+}
 
+func runConfigGetBackupEnabledEffectiveValueCases(t *testing.T, tests []backupEnabledEffectiveValueCase) {
+	t.Helper()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			orig := primeHasGitRemote


### PR DESCRIPTION
## What

Split the backup effective-value table by the storage mode each case actually requires:

- keep SQL-server default and explicit true/false cases in the untagged test;
- move only the two embedded Git-remote auto-detection cases into a `cgo`-tagged companion; and
- share one setup/assertion helper across both files.

## Why

Fixes #4946.

The two embedded-default cases cannot be valid in a non-CGO build: embedded Dolt is unavailable there, and `store_factory_nocgo.go` intentionally reports SQL-server mode. Their unconditional selection made correct non-CGO behavior look like a backup-effective-value regression.

Gating the whole file would also discard three valid non-CGO assertions. The split keeps those portable cases active while aligning only the embedded cases with `backup_auto_test.go` and the other embedded suites. No production or user-visible behavior changes.

## Verification

```powershell
$env:CGO_ENABLED = "1"
go test -tags gms_pure_go ./cmd/bd -run '^TestConfigGetBackupEnabled_EffectiveValue' -count=1 -v

$env:CGO_ENABLED = "0"
go test -tags gms_pure_go ./cmd/bd -run '^TestConfigGetBackupEnabled_EffectiveValue' -count=1 -v
```

The CGO run selects and passes all five existing cases. The non-CGO run selects and passes the three portable cases without compiling the embedded companion. `gofmt` and `git diff --check` are clean.

---

_codex-tui-gpt-5.6-sol-ultra on behalf of Ewen Cuthiell_
