### PR TITLE
test(windows): isolate multi-ID update subprocess home

### DIFF
--- a/cmd/bd/update_multi_id_exit_test.go
+++ b/cmd/bd/update_multi_id_exit_test.go
@@ -28,8 +28,8 @@ import (
 )
 
 // multiIDUpdateEnv returns a hermetic environment for bd subprocess runs:
-// no inherited BEADS_* variables, HOME pinned to the test dir, metrics and
-// daemons disabled.
+// no inherited BEADS_* variables, HOME and USERPROFILE pinned to the test dir,
+// metrics and daemons disabled.
 func multiIDUpdateEnv(dir string) []string {
 	var env []string
 	for _, e := range os.Environ() {
@@ -40,6 +40,7 @@ func multiIDUpdateEnv(dir string) []string {
 	}
 	return append(env,
 		"HOME="+dir,
+		"USERPROFILE="+dir,
 		"BD_NON_INTERACTIVE=1",
 		"BD_DISABLE_METRICS=1",
 		"BD_DISABLE_EVENT_FLUSH=1",
@@ -75,6 +76,8 @@ func setupMultiIDUpdateDB(t *testing.T) (bd, dir string) {
 	t.Helper()
 	bd = buildBDForInitTests(t)
 	dir = t.TempDir()
+	runGitForBootstrapTest(t, dir, "init", "-q")
+	runGitForBootstrapTest(t, dir, "config", "core.hooksPath", ".git/hooks")
 	stdout, stderr, code := runBDMultiID(t, bd, dir,
 		"init", "--prefix", "test", "--quiet", "--non-interactive", "--skip-hooks", "--skip-agents")
 	if code != 0 {


### PR DESCRIPTION
## What

- Pin both `HOME` and `USERPROFILE` for multi-ID update subprocess tests.
- Initialize each test directory as a Git repository with repo-local hooks before running `bd init`.

## Why

The multi-ID update contract tests added in #4726 were not hermetic on Windows. `t.TempDir()` lives under the real user profile, and without a temporary Git boundary Beads repository discovery could walk upward and find the user's global `.beads` directory. The test then aborted after reporting the existing database instead of exercising the intended isolated workspace.

This keeps the tests inside their temporary directory on every platform and prevents them from consulting real user state.

## Validation

- `go test -tags gms_pure_go ./cmd/bd -run '^TestMultiIDUpdateAllGoodPathUnchanged$' -count=1`
- `go test -tags gms_pure_go ./cmd/bd -run '^TestMultiIDUpdate' -count=1`
- `git diff --check`
