### PR TITLE
fix(search): validate and combine status filters

### DIFF
--- a/cmd/bd/list_filter.go
+++ b/cmd/bd/list_filter.go
@@ -128,22 +128,8 @@ func buildListFilter(in listInput, cfg listFilterConfig) (types.IssueFilter, err
 		s := types.StatusOpen
 		filter.Status = &s
 	} else if in.status != "" && in.status != "all" {
-		names := cfg.customStatusNames()
-		statusParts := strings.Split(in.status, ",")
-		if len(statusParts) == 1 {
-			s := types.Status(strings.TrimSpace(statusParts[0]))
-			if !s.IsValidWithCustom(names) {
-				return filter, fmt.Errorf("invalid status %q (valid: %s)", in.status, validStatusList(names))
-			}
-			filter.Status = &s
-		} else {
-			for _, part := range statusParts {
-				s := types.Status(strings.TrimSpace(part))
-				if !s.IsValidWithCustom(names) {
-					return filter, fmt.Errorf("invalid status %q in multi-status filter (valid: %s)", strings.TrimSpace(part), validStatusList(names))
-				}
-				filter.Statuses = append(filter.Statuses, s)
-			}
+		if err := applyStatusFilter(&filter, in.status, cfg.customStatusNames()); err != nil {
+			return filter, err
 		}
 	}
 
@@ -333,4 +319,25 @@ func validStatusList(customStatusNames []string) string {
 		validList += ", " + strings.Join(customStatusNames, ", ")
 	}
 	return validList
+}
+
+func applyStatusFilter(filter *types.IssueFilter, status string, customStatusNames []string) error {
+	statusParts := strings.Split(status, ",")
+	if len(statusParts) == 1 {
+		s := types.Status(strings.TrimSpace(statusParts[0]))
+		if !s.IsValidWithCustom(customStatusNames) {
+			return fmt.Errorf("invalid status %q (valid: %s)", status, validStatusList(customStatusNames))
+		}
+		filter.Status = &s
+		return nil
+	}
+
+	for _, part := range statusParts {
+		s := types.Status(strings.TrimSpace(part))
+		if !s.IsValidWithCustom(customStatusNames) {
+			return fmt.Errorf("invalid status %q in multi-status filter (valid: %s)", strings.TrimSpace(part), validStatusList(customStatusNames))
+		}
+		filter.Statuses = append(filter.Statuses, s)
+	}
+	return nil
 }

--- a/cmd/bd/list_filter_status_test.go
+++ b/cmd/bd/list_filter_status_test.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/types"
+)
+
+func TestApplyStatusFilter(t *testing.T) {
+	t.Run("single built-in trims spaces", func(t *testing.T) {
+		var filter types.IssueFilter
+		if err := applyStatusFilter(&filter, " open ", nil); err != nil {
+			t.Fatalf("applyStatusFilter: %v", err)
+		}
+		if filter.Status == nil || *filter.Status != types.StatusOpen {
+			t.Fatalf("Status = %v, want %q", filter.Status, types.StatusOpen)
+		}
+	})
+
+	t.Run("multiple statuses use OR filter", func(t *testing.T) {
+		var filter types.IssueFilter
+		if err := applyStatusFilter(&filter, "open, closed", nil); err != nil {
+			t.Fatalf("applyStatusFilter: %v", err)
+		}
+		want := []types.Status{types.StatusOpen, types.StatusClosed}
+		if !reflect.DeepEqual(filter.Statuses, want) {
+			t.Fatalf("Statuses = %v, want %v", filter.Statuses, want)
+		}
+	})
+
+	t.Run("configured custom status", func(t *testing.T) {
+		var filter types.IssueFilter
+		if err := applyStatusFilter(&filter, "in_review", []string{"in_review"}); err != nil {
+			t.Fatalf("applyStatusFilter: %v", err)
+		}
+		if filter.Status == nil || *filter.Status != types.Status("in_review") {
+			t.Fatalf("Status = %v, want %q", filter.Status, "in_review")
+		}
+	})
+
+	t.Run("invalid status errors", func(t *testing.T) {
+		var filter types.IssueFilter
+		err := applyStatusFilter(&filter, "open,not-a-status", nil)
+		if err == nil {
+			t.Fatal("applyStatusFilter unexpectedly succeeded")
+		}
+		if !strings.Contains(err.Error(), "invalid status") || !strings.Contains(err.Error(), "not-a-status") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+}

--- a/cmd/bd/search.go
+++ b/cmd/bd/search.go
@@ -108,8 +108,13 @@ Examples:
 		}
 
 		if status != "" && status != "all" {
-			s := types.Status(status)
-			filter.Status = &s
+			cfg, err := loadDirectListFilterConfig(rootCtx, store)
+			if err != nil {
+				return HandleError("loading status configuration: %v", err)
+			}
+			if err := applyStatusFilter(&filter, status, cfg.customStatusNames()); err != nil {
+				return HandleError("%v", err)
+			}
 		} else if status != "all" {
 			// Default: exclude closed issues to reduce scan scope (hq-319).
 			// With 12K+ issues, ~60-70% are closed — excluding them lets the
@@ -349,7 +354,7 @@ func outputSearchResults(issues []*types.Issue, query string, longFormat bool) {
 
 func init() {
 	searchCmd.Flags().String("query", "", "Search query (alternative to positional argument)")
-	searchCmd.Flags().StringP("status", "s", "", "Filter by stored status (open, in_progress, blocked, deferred, closed, all). Default excludes closed; use 'all' to include closed. Note: dependency-blocked issues use 'bd blocked'")
+	searchCmd.Flags().StringP("status", "s", "", "Filter by stored status (comma-separated for OR; open, in_progress, blocked, deferred, closed, all). Default excludes closed; use 'all' to include closed. Note: dependency-blocked issues use 'bd blocked'")
 	searchCmd.Flags().StringP("assignee", "a", "", "Filter by assignee")
 	searchCmd.Flags().StringP("type", "t", "", "Filter by type (bug, feature, task, epic, chore, decision, merge-request, molecule, gate)")
 	searchCmd.Flags().StringSliceP("label", "l", []string{}, "Filter by labels (AND: must have ALL)")

--- a/cmd/bd/search_embedded_test.go
+++ b/cmd/bd/search_embedded_test.go
@@ -26,6 +26,20 @@ func bdSearch(t *testing.T, bd, dir string, args ...string) string {
 	return stdout.String()
 }
 
+// bdSearchFail runs "bd search" and returns combined output from an expected failure.
+func bdSearchFail(t *testing.T, bd, dir string, args ...string) string {
+	t.Helper()
+	fullArgs := append([]string{"search"}, args...)
+	cmd := exec.Command(bd, fullArgs...)
+	cmd.Dir = dir
+	cmd.Env = bdEnv(dir)
+	stdout, stderr, err := runCommandBuffers(t, cmd)
+	if err == nil {
+		t.Fatalf("expected bd search %s to fail, got:\nstdout:\n%s\nstderr:\n%s", strings.Join(args, " "), stdout.String(), stderr.String())
+	}
+	return stdout.String() + stderr.String()
+}
+
 // bdSearchJSON runs "bd search --json" and returns parsed results.
 func bdSearchJSON(t *testing.T, bd, dir string, args ...string) []map[string]interface{} {
 	t.Helper()
@@ -135,6 +149,24 @@ func TestEmbeddedSearch(t *testing.T) {
 		}
 		if !ids[taskA.ID] || !ids[closedTask.ID] {
 			t.Error("expected both open and closed issues with --status all")
+		}
+	})
+
+	t.Run("search_status_comma_separated", func(t *testing.T) {
+		results := bdSearchJSON(t, bd, dir, "sr-", "--status", "open,closed")
+		ids := map[string]bool{}
+		for _, r := range results {
+			ids[r["id"].(string)] = true
+		}
+		if !ids[taskA.ID] || !ids[closedTask.ID] {
+			t.Error("expected both open and closed issues with --status open,closed")
+		}
+	})
+
+	t.Run("search_status_invalid", func(t *testing.T) {
+		out := bdSearchFail(t, bd, dir, "sr-", "--status", "not-a-status")
+		if !strings.Contains(out, "invalid status") || !strings.Contains(out, "not-a-status") {
+			t.Errorf("expected useful invalid status error, got: %s", out)
 		}
 	})
 

--- a/cmd/bd/search_proxied_server.go
+++ b/cmd/bd/search_proxied_server.go
@@ -64,10 +64,7 @@ func runSearchProxiedServer(cmd *cobra.Command, ctx context.Context, args []stri
 		Limit: limit,
 	}
 
-	if status != "" && status != "all" {
-		s := types.Status(status)
-		filter.Status = &s
-	} else if status != "all" {
+	if status == "" {
 		filter.ExcludeStatus = []types.Status{types.StatusClosed}
 	}
 
@@ -193,6 +190,16 @@ func runSearchProxiedServer(cmd *cobra.Command, ctx context.Context, args []stri
 		return HandleErrorRespectJSON("%v", err)
 	}
 	defer uw.Close(ctx)
+
+	if status != "" && status != "all" {
+		cfg, err := loadProxiedListFilterConfig(ctx, uw)
+		if err != nil {
+			return HandleErrorRespectJSON("loading status configuration: %v", err)
+		}
+		if err := applyStatusFilter(&filter, status, cfg.customStatusNames()); err != nil {
+			return HandleErrorRespectJSON("%v", err)
+		}
+	}
 
 	if jsonOutput {
 		page, err := uw.IssueUseCase().SearchIssuesWithCounts(ctx, query, filter)


### PR DESCRIPTION
## Why

`bd search --status` treated a comma-separated value as one unknown status and silently returned no matches. It also accepted arbitrary invalid values with exit code 0, unlike `bd list --status`. That inconsistency makes typos look like legitimate empty searches and forces callers to filter results themselves.

## What changed

- share `bd list`'s validated status parser with direct and proxied search
- support comma-separated OR filters, including configured custom statuses
- return a useful error for invalid status values
- document comma-separated search statuses
- cover parser semantics and embedded CLI behavior

## Validation

- `BEADS_TEST_EMBEDDED_DOLT=1 CGO_ENABLED=0 go test -tags gms_pure_go ./cmd/bd -run '^(TestEmbeddedSearch|TestApplyStatusFilter|TestListCommandSuite|TestListQueryCapabilitiesSuite)$' -count=1`
- `git diff --check`

Fixes #4834
