### PR TITLE
fix(config): read shared server PID for drift

### DIFF
--- a/cmd/bd/config_drift.go
+++ b/cmd/bd/config_drift.go
@@ -262,10 +262,24 @@ func checkServerDrift() []DriftItem {
 		}}
 	}
 
-	sharedServerEnabled := config.GetString("dolt.shared-server")
-	wantServer := strings.EqualFold(sharedServerEnabled, "true")
+	wantServer := doltserver.IsSharedServerMode()
 
-	serverRunning := isServerProbablyRunning(beadsDir)
+	serverDir := beadsDir
+	if wantServer {
+		var err error
+		serverDir, err = doltserver.SharedServerPath()
+		if err != nil {
+			return []DriftItem{{
+				Check:    "server",
+				Status:   driftStatusDrift,
+				Message:  fmt.Sprintf("dolt.shared-server is enabled but its state directory cannot be resolved: %v", err),
+				Expected: "resolvable shared server state directory",
+				Actual:   "unavailable",
+			}}
+		}
+	}
+
+	serverRunning := isServerProbablyRunning(serverDir)
 
 	if wantServer && !serverRunning {
 		return []DriftItem{{

--- a/cmd/bd/config_drift_test.go
+++ b/cmd/bd/config_drift_test.go
@@ -4,8 +4,10 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
+	"github.com/steveyegge/beads/internal/doltserver"
 	"github.com/steveyegge/beads/internal/git"
 )
 
@@ -104,6 +106,96 @@ func TestIsServerProbablyRunningOwnPID(t *testing.T) {
 	}
 	if !isServerProbablyRunning(tmpDir) {
 		t.Error("expected true for own PID")
+	}
+}
+
+func setupServerDriftTest(t *testing.T, sharedServer bool) (beadsDir, sharedDir string) {
+	t.Helper()
+	root := t.TempDir()
+	beadsDir = filepath.Join(root, ".beads")
+	if err := os.MkdirAll(beadsDir, 0o755); err != nil {
+		t.Fatalf("create project beads dir: %v", err)
+	}
+	configBody := fmt.Sprintf("dolt:\n  shared-server: %t\n", sharedServer)
+	if err := os.WriteFile(filepath.Join(beadsDir, "config.yaml"), []byte(configBody), 0o600); err != nil {
+		t.Fatalf("write config.yaml: %v", err)
+	}
+	sharedDir = filepath.Join(root, "shared-server")
+	t.Setenv("BEADS_DIR", beadsDir)
+	t.Setenv("BEADS_SHARED_SERVER_DIR", sharedDir)
+	initConfigForTest(t)
+	return beadsDir, sharedDir
+}
+
+func writeLiveServerPID(t *testing.T, dir string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("create server state dir: %v", err)
+	}
+	pidFile := filepath.Join(dir, doltserver.PIDFileName)
+	if err := os.WriteFile(pidFile, []byte(fmt.Sprintf("%d\n", os.Getpid())), 0o600); err != nil {
+		t.Fatalf("write live PID file: %v", err)
+	}
+}
+
+func requireServerPIDLivenessForDriftTest(t *testing.T) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("signal-0 PID liveness is not supported on Windows; covered by #4808")
+	}
+}
+
+func TestCheckServerDriftSharedServerHealthyWithoutProjectPID(t *testing.T) {
+	requireServerPIDLivenessForDriftTest(t)
+	beadsDir, sharedDir := setupServerDriftTest(t, true)
+	writeLiveServerPID(t, sharedDir)
+
+	items := checkServerDrift()
+	if len(items) != 1 || items[0].Status != driftStatusOK {
+		t.Fatalf("checkServerDrift = %+v, want one ok item", items)
+	}
+	if _, err := os.Stat(filepath.Join(beadsDir, doltserver.PIDFileName)); !os.IsNotExist(err) {
+		t.Fatalf("project PID file unexpectedly exists: %v", err)
+	}
+}
+
+func TestCheckServerDriftSharedServerEnvOverride(t *testing.T) {
+	requireServerPIDLivenessForDriftTest(t)
+	beadsDir, sharedDir := setupServerDriftTest(t, false)
+	t.Setenv("BEADS_DOLT_SHARED_SERVER", "1")
+	writeLiveServerPID(t, sharedDir)
+
+	items := checkServerDrift()
+	if len(items) != 1 || items[0].Status != driftStatusOK {
+		t.Fatalf("checkServerDrift = %+v, want one ok item", items)
+	}
+	if _, err := os.Stat(filepath.Join(beadsDir, doltserver.PIDFileName)); !os.IsNotExist(err) {
+		t.Fatalf("project PID file unexpectedly exists: %v", err)
+	}
+}
+
+func TestCheckServerDriftSharedServerMissingIgnoresProjectPID(t *testing.T) {
+	requireServerPIDLivenessForDriftTest(t)
+	beadsDir, sharedDir := setupServerDriftTest(t, true)
+	writeLiveServerPID(t, beadsDir)
+
+	items := checkServerDrift()
+	if len(items) != 1 || items[0].Status != driftStatusDrift {
+		t.Fatalf("checkServerDrift = %+v, want one drift item", items)
+	}
+	if _, err := os.Stat(sharedDir); !os.IsNotExist(err) {
+		t.Fatalf("read-only drift check created or touched shared dir %q: %v", sharedDir, err)
+	}
+}
+
+func TestCheckServerDriftStandaloneRunningPreservesInfo(t *testing.T) {
+	requireServerPIDLivenessForDriftTest(t)
+	beadsDir, _ := setupServerDriftTest(t, false)
+	writeLiveServerPID(t, beadsDir)
+
+	items := checkServerDrift()
+	if len(items) != 1 || items[0].Status != driftStatusInfo {
+		t.Fatalf("checkServerDrift = %+v, want one info item", items)
 	}
 }
 

--- a/internal/doltserver/doltserver.go
+++ b/internal/doltserver/doltserver.go
@@ -205,19 +205,27 @@ func readyTimeout() time.Duration {
 	return time.Duration(secs) * time.Second
 }
 
+// SharedServerPath returns the directory for shared server state files without
+// creating it. Override with BEADS_SHARED_SERVER_DIR for testing or custom
+// layouts; otherwise it resolves to ~/.beads/shared-server/.
+func SharedServerPath() (string, error) {
+	if d := os.Getenv("BEADS_SHARED_SERVER_DIR"); d != "" {
+		return d, nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("cannot determine home directory: %w", err)
+	}
+	return filepath.Join(home, ".beads", "shared-server"), nil
+}
+
 // SharedServerDir returns the directory for shared server state files.
 // Returns ~/.beads/shared-server/ (created on first use).
 // Override with BEADS_SHARED_SERVER_DIR env var for testing or custom layouts.
 func SharedServerDir() (string, error) {
-	var dir string
-	if d := os.Getenv("BEADS_SHARED_SERVER_DIR"); d != "" {
-		dir = d
-	} else {
-		home, err := os.UserHomeDir()
-		if err != nil {
-			return "", fmt.Errorf("cannot determine home directory: %w", err)
-		}
-		dir = filepath.Join(home, ".beads", "shared-server")
+	dir, err := SharedServerPath()
+	if err != nil {
+		return "", err
 	}
 	if err := os.MkdirAll(dir, config.BeadsDirPerm); err != nil {
 		return "", fmt.Errorf("cannot create shared server directory %s: %w", dir, err)

--- a/internal/doltserver/doltserver_test.go
+++ b/internal/doltserver/doltserver_test.go
@@ -1428,6 +1428,22 @@ func TestSharedServerDir_EnvOverride(t *testing.T) {
 	}
 }
 
+func TestSharedServerPath_EnvOverrideDoesNotCreateDirectory(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "not-created")
+	t.Setenv("BEADS_SHARED_SERVER_DIR", dir)
+
+	got, err := SharedServerPath()
+	if err != nil {
+		t.Fatalf("SharedServerPath: %v", err)
+	}
+	if got != dir {
+		t.Fatalf("SharedServerPath = %q, want %q", got, dir)
+	}
+	if _, err := os.Stat(dir); !os.IsNotExist(err) {
+		t.Fatalf("SharedServerPath created or touched %q: stat error = %v", dir, err)
+	}
+}
+
 func TestSharedDoltDir_EnvOverride(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("BEADS_SHARED_SERVER_DIR", tmp)


### PR DESCRIPTION
## Why

`bd config drift` always read the project-local `dolt-server.pid`, even when the effective configuration selected the managed shared server under `~/.beads/shared-server`. That produced false negatives when the shared server was healthy and could produce false positives from an unrelated project PID.

## What changed

- add a canonical, non-creating shared-server path resolver
- retain the existing create-on-use lifecycle helper behavior
- select the shared PID directory from the effective shared-mode predicate, including `BEADS_DOLT_SHARED_SERVER`
- keep standalone server checks project-local
- cover healthy shared state, ignored project PIDs, env-only shared mode, standalone behavior, and the read-only guarantee

## Validation

- `CGO_ENABLED=0 go test -tags gms_pure_go ./internal/doltserver -run '^TestSharedServer(Path|Dir)' -count=1`
- Linux/WSL: `CGO_ENABLED=0 go test -tags gms_pure_go ./cmd/bd -run '^TestCheckServerDrift(SharedServerHealthyWithoutProjectPID|SharedServerEnvOverride|SharedServerMissingIgnoresProjectPID|StandaloneRunningPreservesInfo)$' -count=1`
- `git diff --check`

Windows PID liveness remains tracked separately by #4808; this PR deliberately does not overlap its platform helper changes.

Fixes #4836
