### PR TITLE
fix(init): use server-aware diagnostics

### DIFF
--- a/cmd/bd/doctor.go
+++ b/cmd/bd/doctor.go
@@ -996,22 +996,28 @@ func runInitDiagnostics(path string) doctorResult {
 		result.OverallOK = false
 	}
 
+	// Open one shared store for the database-backed init checks. Server-mode
+	// workspaces may not have a local .beads/dolt directory, so the path-only
+	// checks would otherwise report a false missing database.
+	sharedStore := doctor.NewSharedStore(path)
+	defer sharedStore.Close()
+
 	// Check 2: Database version
-	dbCheck := convertWithCategory(doctor.CheckDatabaseVersion(path, Version), doctor.CategoryCore)
+	dbCheck := convertWithCategory(doctor.CheckDatabaseVersionWithStore(sharedStore, Version), doctor.CategoryCore)
 	result.Checks = append(result.Checks, dbCheck)
 	if dbCheck.Status == statusError {
 		result.OverallOK = false
 	}
 
 	// Check 3: Schema compatibility
-	schemaCheck := convertWithCategory(doctor.CheckSchemaCompatibility(path), doctor.CategoryCore)
+	schemaCheck := convertWithCategory(doctor.CheckSchemaCompatibilityWithStore(sharedStore), doctor.CategoryCore)
 	result.Checks = append(result.Checks, schemaCheck)
 	if schemaCheck.Status == statusError {
 		result.OverallOK = false
 	}
 
 	// Check 4: Permissions
-	permCheck := convertWithCategory(doctor.CheckPermissions(path), doctor.CategoryCore)
+	permCheck := convertWithCategory(doctor.CheckPermissionsWithStore(path, sharedStore), doctor.CategoryCore)
 	result.Checks = append(result.Checks, permCheck)
 	if permCheck.Status == statusError {
 		result.OverallOK = false

--- a/cmd/bd/doctor_init_diagnostics_cgo_test.go
+++ b/cmd/bd/doctor_init_diagnostics_cgo_test.go
@@ -1,0 +1,32 @@
+//go:build cgo
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestRunInitDiagnosticsServerModeWithoutLocalDoltDir(t *testing.T) {
+	projectDir := t.TempDir()
+	doltPath := filepath.Join(projectDir, ".beads", "dolt")
+	store := newTestStoreIsolatedDB(t, doltPath, "initdiag")
+	if err := store.Close(); err != nil {
+		t.Fatalf("close setup store: %v", err)
+	}
+
+	if info, err := os.Stat(doltPath); err == nil || !os.IsNotExist(err) {
+		t.Fatalf("expected no local .beads/dolt directory, got info=%v err=%v", info, err)
+	}
+
+	result := runInitDiagnostics(projectDir)
+	for _, check := range result.Checks {
+		if check.Message == "No dolt database found" {
+			t.Fatalf("runInitDiagnostics reported false missing database: %+v", check)
+		}
+	}
+	if !result.OverallOK {
+		t.Fatalf("runInitDiagnostics OverallOK=false: %+v", result.Checks)
+	}
+}


### PR DESCRIPTION
## Why

`bd init --server` successfully creates and connects to a server database, but its final diagnostics still used path-only checks that require a local `.beads/dolt` directory. Healthy server-mode setups therefore ended with a false "No dolt database found" failure and advice to repair an already-working board.

Fixes #4553.

## What changed

- Open one shared, server-aware doctor store for init-time database checks.
- Route version, schema compatibility, and permissions checks through their existing `WithStore` variants.
- Add a server-backed regression proving init diagnostics succeed when `.beads/dolt` is intentionally absent.

The installation, Dolt-format, connection, and schema-health checks retain their existing behavior.

## Validation

- `CGO_ENABLED=0 go test -tags gms_pure_go ./cmd/bd -run '^$' -count=1`
- `go test -tags gms_pure_go ./cmd/bd -run '^TestRunInitDiagnosticsServerModeWithoutLocalDoltDir$' -count=1` (compiles locally; assertions require the Docker-backed CI Dolt server and skip when unavailable)
- `git diff --check upstream/main...HEAD`
- Independent correctness review: no blocking findings

_codex-gpt-5.6-sol-high on behalf of matt wilkie_
