### PR TITLE
fix(config): honor disabled Dolt auto-start

### DIFF
--- a/cmd/bd/config_apply.go
+++ b/cmd/bd/config_apply.go
@@ -394,6 +394,18 @@ func applyServer(drifted bool, dryRun bool) ApplyResult {
 		}
 	}
 
+	// Reconciliation must honor the same auto-start policy as implicit storage
+	// opens. A disabled auto-start means the server is externally managed; keep
+	// Action="start" to describe the skipped reconciliation action consistently.
+	if doltserver.IsAutoStartDisabled() {
+		return ApplyResult{
+			Check:   "server",
+			Action:  "start",
+			Status:  applyStatusSkipped,
+			Message: "Dolt shared server not started because auto-start is disabled; the server is externally managed",
+		}
+	}
+
 	serverDir := doltserver.ResolveServerDir(beadsDir)
 
 	if dryRun {

--- a/cmd/bd/config_apply_test.go
+++ b/cmd/bd/config_apply_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -124,6 +126,66 @@ func TestApplyServerDryRun(t *testing.T) {
 	// Without beads dir, should skip even in dry-run
 	if result.Status != applyStatusSkipped {
 		t.Errorf("expected status %q, got %q", applyStatusSkipped, result.Status)
+	}
+}
+
+func TestApplyServerSkipsWhenAutoStartDisabled(t *testing.T) {
+	tests := []struct {
+		name         string
+		autoStartEnv string
+		autoStartYML string
+	}{
+		{
+			name:         "environment disables auto-start",
+			autoStartEnv: "0",
+			autoStartYML: "true",
+		},
+		{
+			name:         "workspace config disables auto-start",
+			autoStartEnv: "",
+			autoStartYML: "false",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := t.TempDir()
+			beadsDir := filepath.Join(root, ".beads")
+			if err := os.MkdirAll(beadsDir, 0o755); err != nil {
+				t.Fatalf("create .beads: %v", err)
+			}
+			configYAML := "dolt:\n  shared-server: true\n  auto-start: " + tt.autoStartYML + "\n"
+			if err := os.WriteFile(filepath.Join(beadsDir, "config.yaml"), []byte(configYAML), 0o600); err != nil {
+				t.Fatalf("write config.yaml: %v", err)
+			}
+			sharedDir := filepath.Join(root, "shared-server")
+			t.Setenv("BEADS_DIR", beadsDir)
+			t.Setenv("BEADS_SHARED_SERVER_DIR", sharedDir)
+			t.Setenv("BEADS_DOLT_AUTO_START", tt.autoStartEnv)
+			initConfigForTest(t)
+
+			for _, dryRun := range []bool{false, true} {
+				name := "apply"
+				if dryRun {
+					name = "dry-run"
+				}
+				t.Run(name, func(t *testing.T) {
+					result := applyServer(true, dryRun)
+					if result.Status != applyStatusSkipped {
+						t.Fatalf("status = %q, want %q: %+v", result.Status, applyStatusSkipped, result)
+					}
+					if result.Action != "start" {
+						t.Fatalf("action = %q, want %q", result.Action, "start")
+					}
+					if !strings.Contains(result.Message, "auto-start is disabled") || !strings.Contains(result.Message, "externally managed") {
+						t.Fatalf("message does not explain skip policy: %q", result.Message)
+					}
+					if _, err := os.Stat(sharedDir); !os.IsNotExist(err) {
+						t.Fatalf("applyServer created shared server state despite disabled auto-start: %v", err)
+					}
+				})
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Why

`BEADS_DOLT_AUTO_START=0` and `dolt.auto-start: false` mark a Dolt server as externally managed. Most implicit lifecycle paths honor that fence, but `bd config apply` could silently bypass it and start a duplicate shared server during drift reconciliation.

Fixes #4509.

## What changed

- Skip shared-server reconciliation before dry-run or startup when either auto-start policy source disables management.
- Keep explicit `bd dolt start` and server initialization behavior unchanged.
- Cover environment- and workspace-config disable sources independently in both apply and dry-run modes.
- Assert the skipped path creates no shared-server state directory.

## Validation

- `CGO_ENABLED=0 go test -tags gms_pure_go ./cmd/bd -run '^TestApplyServer' -count=1 -v`
- `git diff --check upstream/main...HEAD`
- Independent correctness review: no blocking findings; repeated focused runs passed

_codex-gpt-5.6-sol-high on behalf of matt wilkie_
