### PR TITLE
fix(dep): allow matching explicit parent edges

### DIFF
--- a/cmd/bd/dep.go
+++ b/cmd/bd/dep.go
@@ -65,18 +65,36 @@ func resolveIDForMutation(ctx context.Context, localStore storage.DoltStorage, i
 // isChildOf returns true if childID is a hierarchical child of parentID.
 // For example, "bd-abc.1" is a child of "bd-abc", and "bd-abc.1.2" is a child of "bd-abc.1".
 func isChildOf(childID, parentID string) bool {
+	_, isAncestor := hierarchicalParentRelation(childID, parentID)
+	return isAncestor
+}
+
+func hierarchicalParentRelation(childID, targetID string) (immediateParent string, isAncestor bool) {
 	// A child ID has the format "parentID.N" or "parentID.N.M" etc.
 	// Use ParseHierarchicalID to get the actual parent
 	_, actualParentID, depth := types.ParseHierarchicalID(childID)
 	if depth == 0 {
-		return false // Not a hierarchical ID
+		return "", false // Not a hierarchical ID
 	}
 	// Check if the immediate parent matches
-	if actualParentID == parentID {
-		return true
+	if actualParentID == targetID {
+		return actualParentID, true
 	}
-	// Also check if parentID is an ancestor (e.g., "bd-abc" is parent of "bd-abc.1.2")
-	return strings.HasPrefix(childID, parentID+".")
+	// Also check if targetID is an ancestor (e.g., "bd-abc" is an ancestor of "bd-abc.1.2")
+	return actualParentID, strings.HasPrefix(childID, targetID+".")
+}
+
+// isDisallowedHierarchicalDependency reports whether an explicit dependency
+// conflicts with hierarchy encoded in a dotted issue ID. The one allowed match
+// is a parent-child edge to the immediate dotted-ID parent; blocking and other
+// edge types to any parent/ancestor, plus parent-child edges to higher ancestors,
+// remain rejected.
+func isDisallowedHierarchicalDependency(fromID, toID string, depType types.DependencyType) bool {
+	immediateParent, isAncestor := hierarchicalParentRelation(fromID, toID)
+	if !isAncestor {
+		return false
+	}
+	return depType != types.DepParentChild || toID != immediateParent
 }
 
 // warnIfCyclesExist checks for dependency cycles and prints a warning if found.
@@ -175,7 +193,7 @@ Examples:
 			}
 			defer toCleanup()
 
-			if isChildOf(fromID, toID) {
+			if isDisallowedHierarchicalDependency(fromID, toID, types.DepBlocks) {
 				return HandleErrorRespectJSON("cannot add dependency: %s is already a child of %s. Children inherit dependency on parent completion via hierarchy. Adding an explicit dependency would create a deadlock", fromID, toID)
 			}
 
@@ -359,11 +377,11 @@ Examples:
 			}
 		}
 
-		if isChildOf(fromID, toID) {
+		dt := types.DependencyType(depType)
+		if isDisallowedHierarchicalDependency(fromID, toID, dt) {
 			return HandleErrorRespectJSON("cannot add dependency: %s is already a child of %s. Children inherit dependency on parent completion via hierarchy. Adding an explicit dependency would create a deadlock", fromID, toID)
 		}
 
-		dt := types.DependencyType(depType)
 		if !dt.IsValid() {
 			return HandleErrorRespectJSON("invalid dependency type %q: must be non-empty and at most 50 characters", depType)
 		}
@@ -657,7 +675,7 @@ func validateBulkDepEdges(ctx context.Context, edges []bulkDepEdge) ([]bulkDepEd
 			current.DependsOnID = toID
 		}
 
-		if isChildOf(current.IssueID, current.DependsOnID) {
+		if isDisallowedHierarchicalDependency(current.IssueID, current.DependsOnID, current.Type) {
 			errs = append(errs, fmt.Sprintf("line %d: cannot add dependency: %s is already a child of %s", edge.Line, current.IssueID, current.DependsOnID))
 			resolved = append(resolved, current)
 			continue

--- a/cmd/bd/dep_proxied_server.go
+++ b/cmd/bd/dep_proxied_server.go
@@ -66,7 +66,7 @@ func printCycleWarnings(cycles [][]*types.Issue) {
 }
 
 func runDepBlocksProxiedServer(cmd *cobra.Command, ctx context.Context, blockerID, blockedID string) error {
-	if isChildOf(blockedID, blockerID) {
+	if isDisallowedHierarchicalDependency(blockedID, blockerID, types.DepBlocks) {
 		return HandleErrorRespectJSON("cannot add dependency: %s is already a child of %s. Children inherit dependency on parent completion via hierarchy. Adding an explicit dependency would create a deadlock", blockedID, blockerID)
 	}
 
@@ -155,11 +155,11 @@ func runDepAddProxiedServer(cmd *cobra.Command, ctx context.Context, args []stri
 		toID = dependsOnArg
 	}
 
-	if isChildOf(fromID, toID) {
+	dt := types.DependencyType(depType)
+	if isDisallowedHierarchicalDependency(fromID, toID, dt) {
 		return HandleErrorRespectJSON("cannot add dependency: %s is already a child of %s. Children inherit dependency on parent completion via hierarchy. Adding an explicit dependency would create a deadlock", fromID, toID)
 	}
 
-	dt := types.DependencyType(depType)
 	if !dt.IsValid() {
 		return HandleErrorRespectJSON("invalid dependency type %q: must be non-empty and at most 50 characters", depType)
 	}
@@ -225,7 +225,7 @@ func runDepAddBulkProxied(cmd *cobra.Command, ctx context.Context, file, default
 
 	deps := make([]*types.Dependency, 0, len(edges))
 	for _, edge := range edges {
-		if isChildOf(edge.IssueID, edge.DependsOnID) {
+		if isDisallowedHierarchicalDependency(edge.IssueID, edge.DependsOnID, edge.Type) {
 			return HandleErrorRespectJSON("line %d: cannot add dependency: %s is already a child of %s", edge.Line, edge.IssueID, edge.DependsOnID)
 		}
 		if strings.HasPrefix(edge.DependsOnID, "external:") {

--- a/cmd/bd/dependency_hierarchy_embedded_test.go
+++ b/cmd/bd/dependency_hierarchy_embedded_test.go
@@ -1,0 +1,96 @@
+//go:build cgo
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func bdLinkForHierarchyTest(t *testing.T, bd, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command(bd, append([]string{"link"}, args...)...)
+	cmd.Dir = dir
+	cmd.Env = bdEnv(dir)
+	stdout, stderr, err := runCommandBuffers(t, cmd)
+	if err != nil {
+		t.Fatalf("bd link %s failed: %v\nstdout:\n%s\nstderr:\n%s", strings.Join(args, " "), err, stdout.String(), stderr.String())
+	}
+	return stdout.String()
+}
+
+func TestEmbeddedExplicitHierarchicalParentEdges(t *testing.T) {
+	if os.Getenv("BEADS_TEST_EMBEDDED_DOLT") != "1" {
+		t.Skip("set BEADS_TEST_EMBEDDED_DOLT=1 to run embedded dolt integration tests")
+	}
+
+	bd := buildEmbeddedBD(t)
+	dir, _, _ := bdInit(t, bd, "--prefix", "hg")
+	grandparent := bdCreate(t, bd, dir, "Hierarchy grandparent", "--type", "epic")
+	parent := bdCreate(t, bd, dir, "Hierarchy parent", "--id", grandparent.ID+".1", "--type", "task")
+
+	t.Run("dep add immediate parent-child succeeds", func(t *testing.T) {
+		child := bdCreate(t, bd, dir, "Dep child", "--id", parent.ID+".1", "--type", "task")
+		out := bdDep(t, bd, dir, "add", child.ID, parent.ID, "--type", "parent-child")
+		if !strings.Contains(out, "Added dependency") {
+			t.Fatalf("unexpected dep add output: %s", out)
+		}
+	})
+
+	t.Run("link immediate parent-child succeeds", func(t *testing.T) {
+		child := bdCreate(t, bd, dir, "Link child", "--id", parent.ID+".2", "--type", "task")
+		out := bdLinkForHierarchyTest(t, bd, dir, child.ID, parent.ID, "--type", "parent-child")
+		if !strings.Contains(out, "Linked") {
+			t.Fatalf("unexpected link output: %s", out)
+		}
+	})
+
+	t.Run("blocking immediate parent rejected", func(t *testing.T) {
+		child := bdCreate(t, bd, dir, "Blocked child", "--id", parent.ID+".3", "--type", "task")
+		out := bdDepFail(t, bd, dir, "add", child.ID, parent.ID, "--type", "blocks")
+		if !strings.Contains(out, "already a child") {
+			t.Fatalf("expected hierarchy rejection, got: %s", out)
+		}
+	})
+
+	t.Run("blocks flag immediate parent rejected", func(t *testing.T) {
+		child := bdCreate(t, bd, dir, "Blocks flag child", "--id", parent.ID+".4", "--type", "task")
+		out := bdDepFail(t, bd, dir, parent.ID, "--blocks", child.ID)
+		if !strings.Contains(out, "already a child") {
+			t.Fatalf("expected hierarchy rejection, got: %s", out)
+		}
+	})
+
+	t.Run("parent-child to grandparent rejected", func(t *testing.T) {
+		child := bdCreate(t, bd, dir, "Grandparent child", "--id", parent.ID+".5", "--type", "task")
+		out := bdDepFail(t, bd, dir, "add", child.ID, grandparent.ID, "--type", "parent-child")
+		if !strings.Contains(out, "already a child") {
+			t.Fatalf("expected ancestor rejection, got: %s", out)
+		}
+	})
+
+	t.Run("bulk immediate parent-child succeeds and grandparent rejects", func(t *testing.T) {
+		allowed := bdCreate(t, bd, dir, "Bulk child", "--id", parent.ID+".6", "--type", "task")
+		allowedPath := filepath.Join(t.TempDir(), "allowed.jsonl")
+		allowedBody := fmt.Sprintf("{\"from\":%q,\"to\":%q,\"type\":\"parent-child\"}\n", allowed.ID, parent.ID)
+		if err := os.WriteFile(allowedPath, []byte(allowedBody), 0o600); err != nil {
+			t.Fatalf("write allowed bulk file: %v", err)
+		}
+		bdDep(t, bd, dir, "add", "--file", allowedPath)
+
+		rejected := bdCreate(t, bd, dir, "Bulk grandparent child", "--id", parent.ID+".7", "--type", "task")
+		rejectedPath := filepath.Join(t.TempDir(), "rejected.jsonl")
+		rejectedBody := fmt.Sprintf("{\"from\":%q,\"to\":%q,\"type\":\"parent-child\"}\n", rejected.ID, grandparent.ID)
+		if err := os.WriteFile(rejectedPath, []byte(rejectedBody), 0o600); err != nil {
+			t.Fatalf("write rejected bulk file: %v", err)
+		}
+		out := bdDepFail(t, bd, dir, "add", "--file", rejectedPath)
+		if !strings.Contains(out, "already a child") {
+			t.Fatalf("expected bulk ancestor rejection, got: %s", out)
+		}
+	})
+}

--- a/cmd/bd/dependency_hierarchy_test.go
+++ b/cmd/bd/dependency_hierarchy_test.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/steveyegge/beads/internal/types"
+)
+
+func TestIsDisallowedHierarchicalDependency(t *testing.T) {
+	tests := []struct {
+		name    string
+		fromID  string
+		toID    string
+		depType types.DependencyType
+		want    bool
+	}{
+		{
+			name:    "immediate parent-child allowed",
+			fromID:  "bd-root.1.2",
+			toID:    "bd-root.1",
+			depType: types.DepParentChild,
+			want:    false,
+		},
+		{
+			name:    "immediate parent blocks rejected",
+			fromID:  "bd-root.1.2",
+			toID:    "bd-root.1",
+			depType: types.DepBlocks,
+			want:    true,
+		},
+		{
+			name:    "grandparent parent-child rejected",
+			fromID:  "bd-root.1.2",
+			toID:    "bd-root",
+			depType: types.DepParentChild,
+			want:    true,
+		},
+		{
+			name:    "unrelated target allowed",
+			fromID:  "bd-root.1.2",
+			toID:    "bd-other",
+			depType: types.DepBlocks,
+			want:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isDisallowedHierarchicalDependency(tt.fromID, tt.toID, tt.depType)
+			if got != tt.want {
+				t.Fatalf("isDisallowedHierarchicalDependency(%q, %q, %q) = %v, want %v", tt.fromID, tt.toID, tt.depType, got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/bd/link.go
+++ b/cmd/bd/link.go
@@ -62,11 +62,11 @@ Examples:
 		}
 		defer toCleanup()
 
-		if isChildOf(fromID, toID) {
+		dt := types.DependencyType(depType)
+		if isDisallowedHierarchicalDependency(fromID, toID, dt) {
 			return HandleErrorRespectJSON("cannot add dependency: %s is already a child of %s. Children inherit dependency on parent completion via hierarchy. Adding an explicit dependency would create a deadlock", fromID, toID)
 		}
 
-		dt := types.DependencyType(depType)
 		if !dt.IsValid() {
 			return HandleErrorRespectJSON("invalid dependency type %q: must be non-empty and at most 50 characters", depType)
 		}

--- a/cmd/bd/link_proxied_server.go
+++ b/cmd/bd/link_proxied_server.go
@@ -17,11 +17,11 @@ func runLinkProxiedServer(cmd *cobra.Command, ctx context.Context, args []string
 	id2 := args[1]
 	depType, _ := cmd.Flags().GetString("type")
 
-	if isChildOf(id1, id2) {
+	dt := types.DependencyType(depType)
+	if isDisallowedHierarchicalDependency(id1, id2, dt) {
 		return HandleErrorRespectJSON("cannot add dependency: %s is already a child of %s. Children inherit dependency on parent completion via hierarchy. Adding an explicit dependency would create a deadlock", id1, id2)
 	}
 
-	dt := types.DependencyType(depType)
 	if !dt.IsValid() {
 		return HandleErrorRespectJSON("invalid dependency type %q: must be non-empty and at most 50 characters", depType)
 	}


### PR DESCRIPTION
## Why

The CLI rejected every dependency from a dotted child to its parent as a deadlock, even when the requested edge was the matching structural `parent-child` relationship. Storage already supports materializing that edge idempotently, so `bd dep add` and `bd link` contradicted the underlying model and the `bd update --parent` path.

Fixes #4398.

## What changed

- Centralize hierarchy conflict detection for dependency commands.
- Allow only `parent-child` to the dotted ID's immediate parent.
- Continue rejecting blocking/other edge types to any parent or ancestor.
- Continue rejecting `parent-child` links to a grandparent or higher ancestor.
- Apply the shared rule to direct, bulk, link, and proxied-server paths.

## Validation

- `CGO_ENABLED=0 go test -tags gms_pure_go ./cmd/bd -run '^TestIsDisallowedHierarchicalDependency$' -count=1 -v`
- `BEADS_TEST_EMBEDDED_DOLT=1 CGO_ENABLED=1 go test -tags gms_pure_go ./cmd/bd -run '^TestEmbeddedExplicitHierarchicalParentEdges$' -count=1 -v`
  - six subtests passed: direct add, link, bulk, blocking guards, and grandparent rejection
- `git diff --check upstream/main...HEAD`
- Independent correctness review: no blocking findings

_codex-gpt-5.6-sol-high on behalf of matt wilkie_
