### PR TITLE
fix(create): validate global IDs against global prefix

### DIFF
--- a/cmd/bd/create.go
+++ b/cmd/bd/create.go
@@ -483,12 +483,9 @@ var createCmd = &cobra.Command{
 
 			ctx := createCtx
 
-			var dbPrefix, allowedPrefixes string
-			if yamlPrefix := config.GetString("issue-prefix"); yamlPrefix != "" {
-				dbPrefix = yamlPrefix
-			} else {
-				dbPrefix, _ = store.GetConfig(ctx, "issue_prefix")
-			}
+			storePrefix, _ := store.GetConfig(ctx, "issue_prefix")
+			dbPrefix := selectCreateIDPrefix(globalFlag, config.GetString("issue-prefix"), storePrefix)
+			var allowedPrefixes string
 			allowedPrefixes, _ = store.GetConfig(ctx, "allowed_prefixes")
 
 			if err := validation.ValidateIDPrefixAllowed(explicitID, dbPrefix, allowedPrefixes, forceCreate); err != nil {
@@ -698,6 +695,16 @@ func mergeCreateLabels(labels, inheritedLabels []string) []string {
 		return nil
 	}
 	return merged
+}
+
+func selectCreateIDPrefix(global bool, yamlPrefix, storePrefix string) string {
+	if global {
+		return storePrefix
+	}
+	if yamlPrefix != "" {
+		return yamlPrefix
+	}
+	return storePrefix
 }
 
 func renderCreateDryRunPreview(issue *types.Issue, labels, deps []string) {

--- a/cmd/bd/create_prefix_test.go
+++ b/cmd/bd/create_prefix_test.go
@@ -1,0 +1,41 @@
+package main
+
+import "testing"
+
+func TestSelectCreateIDPrefix(t *testing.T) {
+	tests := []struct {
+		name        string
+		global      bool
+		yamlPrefix  string
+		storePrefix string
+		want        string
+	}{
+		{
+			name:        "global ignores YAML",
+			global:      true,
+			yamlPrefix:  "proj0",
+			storePrefix: "global",
+			want:        "global",
+		},
+		{
+			name:        "ordinary prefers YAML",
+			yamlPrefix:  "proj0",
+			storePrefix: "store",
+			want:        "proj0",
+		},
+		{
+			name:        "ordinary falls back to store",
+			storePrefix: "store",
+			want:        "store",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := selectCreateIDPrefix(tt.global, tt.yamlPrefix, tt.storePrefix); got != tt.want {
+				t.Fatalf("selectCreateIDPrefix(%t, %q, %q) = %q, want %q",
+					tt.global, tt.yamlPrefix, tt.storePrefix, got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/bd/global_identity_integration_test.go
+++ b/cmd/bd/global_identity_integration_test.go
@@ -104,11 +104,23 @@ func TestGlobalDBIdentityCheck(t *testing.T) {
 		t.Errorf("metadata.json global_project_id = %q, want %q",
 			cfg.GlobalProjectID, doltserver.GlobalProjectID)
 	}
+	// bd init (non-no-db) stores the prefix in the DB, not config.yaml
+	// (the generated file only carries a commented `# issue-prefix: ""`).
+	// Write the project prefix into config.yaml explicitly so that the
+	// create/show steps below exercise the YAML-first prefix-selection
+	// path exactly as bd-4646 regressed it: unpatched selectCreateIDPrefix
+	// would then incorrectly prefer this "proj0" YAML prefix over the
+	// global store's prefix even in --global mode, and the ID validation
+	// below would fail. See cmd/bd/init_embedded_test.go for the same
+	// pattern.
+	if err := os.WriteFile(filepath.Join(beadsDir, "config.yaml"), []byte("issue-prefix: proj0\n"), 0o644); err != nil {
+		t.Fatalf("write config.yaml issue-prefix: %v", err)
+	}
 	if yamlPrefix := config.GetStringFromDir(beadsDir, "issue-prefix"); yamlPrefix != "proj0" {
 		t.Fatalf("project YAML issue-prefix = %q, want %q", yamlPrefix, "proj0")
 	}
 
-	explicitGlobalID := "global-explicit"
+	explicitGlobalID := doltserver.GlobalIssuePrefix + "-explicit"
 	out, err := ssExec(ctx, bdBinary, projectDir, env,
 		"create", "Global explicit ID", "--global", "--id", explicitGlobalID, "--silent")
 	if err != nil {

--- a/cmd/bd/global_identity_integration_test.go
+++ b/cmd/bd/global_identity_integration_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/steveyegge/beads/internal/config"
 	"github.com/steveyegge/beads/internal/configfile"
 	"github.com/steveyegge/beads/internal/doltserver"
 	"github.com/steveyegge/beads/internal/testutil"
@@ -103,8 +104,30 @@ func TestGlobalDBIdentityCheck(t *testing.T) {
 		t.Errorf("metadata.json global_project_id = %q, want %q",
 			cfg.GlobalProjectID, doltserver.GlobalProjectID)
 	}
+	if yamlPrefix := config.GetStringFromDir(beadsDir, "issue-prefix"); yamlPrefix != "proj0" {
+		t.Fatalf("project YAML issue-prefix = %q, want %q", yamlPrefix, "proj0")
+	}
 
-	out, err := ssExec(ctx, bdBinary, projectDir, env, "list", "--global")
+	explicitGlobalID := "global-explicit"
+	out, err := ssExec(ctx, bdBinary, projectDir, env,
+		"create", "Global explicit ID", "--global", "--id", explicitGlobalID, "--silent")
+	if err != nil {
+		t.Fatalf("bd create --global --id %s failed: %v\noutput:\n%s", explicitGlobalID, err, out)
+	}
+	if got := strings.TrimSpace(out); got != explicitGlobalID {
+		t.Fatalf("bd create --global --id returned %q, want %q", got, explicitGlobalID)
+	}
+
+	out, err = ssExec(ctx, bdBinary, projectDir, env, "show", "--global", explicitGlobalID)
+	if err != nil {
+		t.Fatalf("bd show --global %s failed: %v\noutput:\n%s", explicitGlobalID, err, out)
+	}
+	if !strings.Contains(out, explicitGlobalID) {
+		t.Fatalf("bd show --global did not return %s from %s:\n%s",
+			explicitGlobalID, doltserver.GlobalDatabaseName, out)
+	}
+
+	out, err = ssExec(ctx, bdBinary, projectDir, env, "list", "--global")
 	if err != nil {
 		t.Fatalf("bd list --global failed: %v\noutput:\n%s", err, out)
 	}


### PR DESCRIPTION
## Why

`--global` switches the opened store to `beads_global`, but explicit-ID validation still preferred the current project's YAML prefix. From a project using `proj0`, `bd create --global --id global-...` was therefore rejected before it could write to the correctly selected global database.

This addresses the create-prefix portion of #4646. The separate `where --global` output contract remains intentionally unresolved.

## What changed

- In global mode, validate explicit IDs against the selected store's `issue_prefix`.
- In ordinary project mode, preserve YAML-first then store-fallback precedence from #2469.
- Add pure precedence tests and a shared-server integration regression with differing project/global prefixes.

## Validation

- `CGO_ENABLED=0 go test -tags gms_pure_go ./cmd/bd -run '^TestSelectCreateIDPrefix$' -count=1 -v`
- `CGO_ENABLED=1 go test -tags gms_pure_go ./cmd/bd -run '^TestGlobalDBIdentityCheck$' -count=1 -v` (compiles locally; existing Windows guard skips the Linux/container assertion)
- `git diff --check upstream/main...HEAD`
- Independent correctness review: no blocking findings

_codex-gpt-5.6-sol-high on behalf of matt wilkie_
