### PR TITLE
Fix mermaid diagrams: "graph" is a reserved node id

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,12 @@ Beads provides a persistent, structured memory for coding agents. It replaces me
 
 ```mermaid
 flowchart LR
-    create["bd create<br/>new bead"] --> graph["dependency<br/>graph"]
-    graph --> ready["bd ready<br/>claimable work"]
+    create["bd create<br/>new bead"] --> depgraph["dependency<br/>graph"]
+    depgraph --> ready["bd ready<br/>claimable work"]
     ready --> claim["bd update --claim<br/>agent takes it"]
     claim --> close["bd close<br/>work done"]
     close -->|blockers released| ready
-    graph <-->|"bd dolt push / pull"| remote[("other machines<br/>and agents")]
+    depgraph <-->|"bd dolt push / pull"| remote[("other machines<br/>and agents")]
 ```
 
 ## ⚡ Quick Start

--- a/docs/core-concepts/index.md
+++ b/docs/core-concepts/index.md
@@ -12,8 +12,8 @@ Work survives the agent; the next session picks up where the last one died.
 
 ```mermaid
 flowchart LR
-    create["bd create<br/>new bead"] --> graph["dependency<br/>graph"]
-    graph --> ready["bd ready<br/>claimable work"]
+    create["bd create<br/>new bead"] --> depgraph["dependency<br/>graph"]
+    depgraph --> ready["bd ready<br/>claimable work"]
     ready --> claim["bd update --claim<br/>agent takes it"]
     claim --> close["bd close<br/>work done"]
     close -->|blockers released| ready


### PR DESCRIPTION
Closes #4846.

The mermaid diagram at the top of the README doesn't render on GitHub ("Unable to render rich display", parse error, "got 'GRAPH'"), because `graph` is a reserved keyword in mermaid's flowchart syntax and can't be used as a node id.

This renames the node id to `depgraph` (the visible "dependency graph" label is unchanged). The same diagram lives in `docs/core-concepts/index.md`, so it's fixed there too.

Verified with mermaid-cli: the original block fails to parse, and every mermaid block in both files renders after the change.

Note: #4773 and #4869 already propose the same fix but seem to have slipped through triage, so hopefully a newer PR catches someone's eye. Happy to close this one in favor of either of them.

### Before

![README showing the mermaid parse error](https://github.com/pvinis/beads/blob/assets-mermaid-fix/before.png?raw=true)

### After

![Fixed diagram rendering correctly](https://github.com/pvinis/beads/blob/assets-mermaid-fix/after.png?raw=true)
