### PR TITLE
fix: drop incorrect issues.jsonl note from proxied-server init warning

### DIFF
--- a/cmd/bd/init.go
+++ b/cmd/bd/init.go
@@ -1911,7 +1911,7 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 				fmt.Fprintf(os.Stderr, "  %s\n\n", ui.RenderAccent("git remote add upstream <repo-url>"))
 			}
 			if !stealth && !initRemoteChanged && !shouldWireInitRemote(syncURL, syncFromRemote, syncURLFromConfig, syncURLFromGitOrigin) {
-				printInitNoDoltRemoteWarning()
+				printInitNoDoltRemoteWarning(true)
 			}
 		}
 
@@ -2702,10 +2702,12 @@ func configureInitDoltRemote(ctx context.Context, store storage.DoltStorage, syn
 	}
 }
 
-func printInitNoDoltRemoteWarning() {
+func printInitNoDoltRemoteWarning(withExportNote bool) {
 	fmt.Fprintf(os.Stderr, "\n%s No Dolt remote configured\n", ui.RenderWarn("⚠"))
-	fmt.Fprintln(os.Stderr, "  Issues are stored in local Dolt. .beads/issues.jsonl is an export,")
-	fmt.Fprintln(os.Stderr, "  not cross-machine sync or the source of truth.")
+	if withExportNote {
+		fmt.Fprintln(os.Stderr, "  Issues are stored in local Dolt. .beads/issues.jsonl is an export,")
+		fmt.Fprintln(os.Stderr, "  not cross-machine sync or the source of truth.")
+	}
 	if originURL, err := gitOriginGetURL(); err == nil && originURL != "" {
 		fmt.Fprintln(os.Stderr, "  To use your git origin for durable sync, run:")
 		fmt.Fprintf(os.Stderr, "    %s\n", ui.RenderAccent("bd dolt remote add origin "+normalizeRemoteURL(originURL)))

--- a/cmd/bd/init_proxied_server.go
+++ b/cmd/bd/init_proxied_server.go
@@ -448,7 +448,7 @@ func runInitProxiedServerTail(cmd *cobra.Command, ctx context.Context, in initPr
 			fmt.Fprintf(os.Stderr, "  %s\n\n", ui.RenderAccent("git remote add upstream <repo-url>"))
 		}
 		if !in.stealth && !in.initRemoteChanged && t.remoteURL == "" {
-			printInitNoDoltRemoteWarning()
+			printInitNoDoltRemoteWarning(false)
 		}
 	}
 


### PR DESCRIPTION
## What

In `bd init --proxied-server` mode, the "No Dolt remote configured" warning printed two lines claiming that issues are stored in local Dolt and that `.beads/issues.jsonl` is an export of them:

```
⚠ No Dolt remote configured
  Issues are stored in local Dolt. .beads/issues.jsonl is an export,
  not cross-machine sync or the source of truth.
```

This is incorrect for proxied-server mode: issues live in a Dolt SQL server and no `.beads/issues.jsonl` export is written on that path.

## Change

`printInitNoDoltRemoteWarning` now takes a `withExportNote bool` that gates the two jsonl lines. The embedded init path passes `true` (unchanged — the export is real there); the proxied-server path passes `false`, so it now prints only the heading plus the remediation:

```
⚠ No Dolt remote configured
  To use your git origin for durable sync, run:
    bd dolt remote add origin <url>
    bd dolt push
```

The `bd dolt remote add` / `bd dolt push` remediation is valid in proxied-server mode, so it is kept.

🤖 Generated with [Claude Code](https://claude.com/claude-code)