### PR TITLE
fix(import): preserve bare cross-prefix dependencies

### DIFF
--- a/cmd/bd/export_test.go
+++ b/cmd/bd/export_test.go
@@ -344,6 +344,13 @@ func TestExportImportRoundTrip(t *testing.T) {
 		"exp-6", "Round Trip", "round trip test", "", "", "", "open", 1, "feature"); err != nil {
 		t.Fatalf("insert issue: %v", err)
 	}
+	if err := s.AddDependency(ctx, &types.Dependency{
+		IssueID:     "exp-6",
+		DependsOnID: "mkt-456",
+		Type:        types.DepRelated,
+	}, "test"); err != nil {
+		t.Fatalf("add cross-prefix dependency: %v", err)
+	}
 
 	// Export
 	exportFile := filepath.Join(tmpDir, "roundtrip.jsonl")
@@ -382,6 +389,32 @@ func TestExportImportRoundTrip(t *testing.T) {
 	}
 	if count != 1 {
 		t.Errorf("expected 1 issue, got %d", count)
+	}
+
+	// Import the exact export into a fresh database. Bare cross-prefix targets
+	// are emitted unchanged (without an "external:" marker), so the bulk import
+	// path must classify the target by its prefix instead of treating it as a
+	// missing local issue and silently skipping the edge.
+	importDir := t.TempDir()
+	baseImportStore := newTestStoreWithPrefix(t, filepath.Join(importDir, "dolt"), "exp")
+	importStore := &dependencySkipCapturingStore{DoltStorage: baseImportStore}
+	imported, err := importFromLocalJSONL(ctx, importStore, exportFile)
+	if err != nil {
+		t.Fatalf("import exported JSONL: %v", err)
+	}
+	if imported != 1 {
+		t.Fatalf("imported count = %d, want 1", imported)
+	}
+	if len(importStore.skippedDependencies) != 0 {
+		t.Fatalf("skipped dependencies = %#v, want none", importStore.skippedDependencies)
+	}
+
+	deps, err := baseImportStore.GetDependencyRecords(ctx, "exp-6")
+	if err != nil {
+		t.Fatalf("GetDependencyRecords(exp-6): %v", err)
+	}
+	if len(deps) != 1 || deps[0].DependsOnID != "mkt-456" || deps[0].Type != types.DepRelated {
+		t.Fatalf("exp-6 deps = %#v, want one related dependency on mkt-456", deps)
 	}
 }
 

--- a/cmd/bd/import_from_jsonl_test.go
+++ b/cmd/bd/import_from_jsonl_test.go
@@ -10,8 +10,25 @@ import (
 	"testing"
 	"time"
 
+	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/types"
 )
+
+type dependencySkipCapturingStore struct {
+	storage.DoltStorage
+	skippedDependencies []string
+}
+
+func (s *dependencySkipCapturingStore) CreateIssuesWithFullOptions(ctx context.Context, issues []*types.Issue, actor string, opts storage.BatchCreateOptions) error {
+	onSkipped := opts.OnSkippedDependency
+	opts.OnSkippedDependency = func(issueID, dependsOnID, reason string) {
+		s.skippedDependencies = append(s.skippedDependencies, issueID+" -> "+dependsOnID+": "+reason)
+		if onSkipped != nil {
+			onSkipped(issueID, dependsOnID, reason)
+		}
+	}
+	return s.DoltStorage.CreateIssuesWithFullOptions(ctx, issues, actor, opts)
+}
 
 func TestImportFromLocalJSONL(t *testing.T) {
 	skipIfNoDolt(t)
@@ -473,6 +490,40 @@ func TestImportFromLocalJSONL(t *testing.T) {
 		}
 		if deps[0].CreatedBy != "someone.else" {
 			t.Fatalf("dependency created_by = %q, want someone.else", deps[0].CreatedBy)
+		}
+	})
+
+	t.Run("preserves bare cross-prefix dependency", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		dbPath := filepath.Join(tmpDir, "dolt")
+		baseStore := newTestStoreWithPrefix(t, dbPath, "sym")
+		store := &dependencySkipCapturingStore{DoltStorage: baseStore}
+
+		jsonlContent := `{"id":"sym-3su","title":"Cross-project source","status":"open","priority":2,"issue_type":"task","dependencies":[{"depends_on_id":"mkt-456","type":"related"}],"created_at":"2025-01-01T00:00:00Z","updated_at":"2025-01-01T00:00:00Z"}
+`
+		jsonlPath := filepath.Join(tmpDir, "issues.jsonl")
+		if err := os.WriteFile(jsonlPath, []byte(jsonlContent), 0644); err != nil {
+			t.Fatalf("Failed to write JSONL file: %v", err)
+		}
+
+		ctx := context.Background()
+		count, err := importFromLocalJSONL(ctx, store, jsonlPath)
+		if err != nil {
+			t.Fatalf("importFromLocalJSONL failed: %v", err)
+		}
+		if count != 1 {
+			t.Fatalf("imported count = %d, want 1", count)
+		}
+		if len(store.skippedDependencies) != 0 {
+			t.Fatalf("skipped dependencies = %#v, want none", store.skippedDependencies)
+		}
+
+		deps, err := baseStore.GetDependencyRecords(ctx, "sym-3su")
+		if err != nil {
+			t.Fatalf("GetDependencyRecords(sym-3su): %v", err)
+		}
+		if len(deps) != 1 || deps[0].DependsOnID != "mkt-456" || deps[0].Type != types.DepRelated {
+			t.Fatalf("sym-3su deps = %#v, want one related dependency on mkt-456", deps)
 		}
 	})
 

--- a/internal/storage/issueops/create.go
+++ b/internal/storage/issueops/create.go
@@ -771,7 +771,8 @@ func PersistDependenciesWithOptionsResult(ctx context.Context, tx *sql.Tx, issue
 			if (dep.Type == types.DepParentChild) != parentPhase {
 				continue
 			}
-			kind := ClassifyDepTarget(ctx, tx, dep, false)
+			isCrossPrefix := types.ExtractPrefix(dep.IssueID) != types.ExtractPrefix(dep.DependsOnID)
+			kind := ClassifyDepTarget(ctx, tx, dep, isCrossPrefix)
 
 			if kind != DepTargetExternal {
 				lookupTable := "issues"

--- a/internal/storage/issueops/create_test.go
+++ b/internal/storage/issueops/create_test.go
@@ -233,6 +233,51 @@ func TestPersistDependenciesDefaultsCreatedByToActor(t *testing.T) {
 	}
 }
 
+func TestPersistDependenciesClassifiesBareCrossPrefixTargetAsExternal(t *testing.T) {
+	ctx := context.Background()
+	db, mock, tx := beginMockTx(t)
+	defer db.Close()
+
+	source := &types.Issue{
+		ID:        "sym-3su",
+		IssueType: types.TypeTask,
+		Dependencies: []*types.Dependency{{
+			DependsOnID: "mkt-456",
+			Type:        types.DepRelated,
+		}},
+	}
+	var skipped []string
+
+	// A bare target with a different issue prefix is external. In particular,
+	// persistence must not probe either local target table before this insert.
+	mock.ExpectExec("INSERT INTO dependencies \\(id, issue_id, depends_on_external").
+		WithArgs(depid.New("sym-3su", "mkt-456"), "sym-3su", "mkt-456", types.DepRelated, "tester", sqlmock.AnyArg()).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	result, err := PersistDependenciesWithOptionsResult(ctx, tx, []*types.Issue{source}, "tester", storage.BatchCreateOptions{
+		OnSkippedDependency: func(issueID, dependsOnID, reason string) {
+			skipped = append(skipped, issueID+" -> "+dependsOnID+": "+reason)
+		},
+	})
+	if err != nil {
+		t.Fatalf("PersistDependenciesWithOptionsResult error = %v, want nil", err)
+	}
+	if len(skipped) != 0 {
+		t.Fatalf("skipped = %#v, want none", skipped)
+	}
+	if !result.ChangedTables["dependencies"] {
+		t.Fatalf("ChangedTables = %#v, want dependencies changed", result.ChangedTables)
+	}
+
+	mock.ExpectRollback()
+	if err := tx.Rollback(); err != nil {
+		t.Fatalf("rollback: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
 func TestPersistDependenciesReturnsTargetLookupErrors(t *testing.T) {
 	ctx := context.Background()
 	db, mock, tx := beginMockTx(t)
@@ -424,17 +469,12 @@ func TestPersistDependenciesSkipsHierarchyValidationAcrossPrefixes(t *testing.T)
 		}},
 	}
 
-	mock.ExpectQuery("SELECT 1 FROM wisps WHERE id = \\? LIMIT 1").
-		WithArgs("bb-target").
-		WillReturnError(sql.ErrNoRows)
-	mock.ExpectQuery("SELECT 1 FROM issues WHERE id = \\?").
-		WithArgs("bb-target").
-		WillReturnRows(sqlmock.NewRows([]string{"1"}).AddRow(1))
-	// No ancestors query: hierarchy cannot cross rig prefixes.
+	// No target or ancestors query: target existence and hierarchy cannot be
+	// validated locally across rig prefixes.
 	mock.ExpectQuery("WITH RECURSIVE reachable").
 		WithArgs("bb-target", "aa-source").
 		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
-	mock.ExpectExec("INSERT INTO dependencies").
+	mock.ExpectExec("INSERT INTO dependencies \\(id, issue_id, depends_on_external").
 		WithArgs(depid.New("aa-source", "bb-target"), "aa-source", "bb-target", types.DepBlocks, "tester", sqlmock.AnyArg()).
 		WillReturnResult(sqlmock.NewResult(0, 1))
 


### PR DESCRIPTION
## Why

JSONL export preserves cross-project dependency IDs such as `mkt-456` without adding an `external:` marker. The two-phase bulk import path nevertheless classified every bare ID as local, so a valid exported edge like `sym-3su -> mkt-456` was treated as a missing local target and silently skipped.

This is a data-fidelity bug: the issue survives a round trip while part of its dependency graph disappears.

## What changed

- classify bulk-persisted dependency targets as cross-prefix before looking for a local issue or wisp
- store those targets in `depends_on_external`, matching the interactive dependency path
- cover the storage helper, direct JSONL import, and a literal export→fresh-import round trip

Same-prefix missing targets and explicit `external:` targets retain their existing behavior.

## Validation

- `CGO_ENABLED=0 go test -tags gms_pure_go ./internal/storage/issueops`
- `CGO_ENABLED=1 BEADS_TEST_EMBEDDED_DOLT=1 go test -tags gms_pure_go ./cmd/bd -run 'TestImportFromLocalJSONL/preserves_bare_cross-prefix_dependency|TestExportImportRoundTrip' -count=1 -timeout=8m`
- `git diff --check`
- repository commit hook: `0 issues`
- independent read-only review: no blockers

## Scope and overlap

This is the first independent acceptance-criterion leaf of #4640. It does not supersede #4286: that larger, currently conflicting dependency-table rewrite still leaves this bulk classifier call unchanged. Keeping this fix small and current-schema-compatible makes the round-trip correction reviewable and portable if that broader work later lands.

_codex-gpt-5.6-sol-high on behalf of matt wilkie_
