### PR TITLE
fix(import): allow children of deleted parents

### DIFF
--- a/cmd/bd/import_orphan_embedded_test.go
+++ b/cmd/bd/import_orphan_embedded_test.go
@@ -1,0 +1,102 @@
+//go:build cgo
+
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/steveyegge/beads/internal/storage/embeddeddolt"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+func TestEmbeddedImportClosedChildWhoseParentWasDeleted(t *testing.T) {
+	if os.Getenv("BEADS_TEST_EMBEDDED_DOLT") != "1" {
+		t.Skip("set BEADS_TEST_EMBEDDED_DOLT=1 to run embedded dolt import tests")
+	}
+
+	ctx := context.Background()
+	beadsDir := t.TempDir()
+	store, err := embeddeddolt.Open(ctx, beadsDir, "beads", "main")
+	if err != nil {
+		t.Fatalf("open embedded Dolt store: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	if err := store.SetConfig(ctx, "issue_prefix", "test"); err != nil {
+		t.Fatalf("set issue prefix: %v", err)
+	}
+
+	// A valid export can retain a closed child after its parent was deleted.
+	// The unrelated row proves a counter reconciliation failure does not roll
+	// back the rest of the import batch.
+	jsonlContent := `{"id":"test-ordinary","title":"Ordinary issue","type":"task","status":"open","priority":2,"created_at":"2025-01-01T00:00:00Z","updated_at":"2025-01-01T00:00:00Z"}
+{"id":"test-deleted-parent.7","title":"Closed orphan child","type":"task","status":"closed","priority":2,"created_at":"2025-01-01T00:00:00Z","updated_at":"2025-01-02T00:00:00Z","closed_at":"2025-01-02T00:00:00Z"}
+`
+	jsonlPath := filepath.Join(t.TempDir(), "issues.jsonl")
+	if err := os.WriteFile(jsonlPath, []byte(jsonlContent), 0o644); err != nil {
+		t.Fatalf("write JSONL file: %v", err)
+	}
+
+	count, err := importFromLocalJSONL(ctx, store, jsonlPath)
+	if err != nil {
+		t.Fatalf("importFromLocalJSONL: %v", err)
+	}
+	if count != 2 {
+		t.Fatalf("imported issues = %d, want 2", count)
+	}
+	if _, err := store.GetIssue(ctx, "test-ordinary"); err != nil {
+		t.Fatalf("ordinary issue missing after import: %v", err)
+	}
+	child, err := store.GetIssue(ctx, "test-deleted-parent.7")
+	if err != nil {
+		t.Fatalf("closed orphan child missing after import: %v", err)
+	}
+	if child.Status != types.StatusClosed {
+		t.Fatalf("orphan child status = %q, want %q", child.Status, types.StatusClosed)
+	}
+
+	dataDir := filepath.Join(beadsDir, "embeddeddolt")
+	db, cleanup, err := embeddeddolt.OpenSQL(ctx, dataDir, "beads", "main")
+	if err != nil {
+		t.Fatalf("open embedded SQL connection: %v", err)
+	}
+	var counterRows int
+	queryErr := db.QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM child_counters WHERE parent_id = ?",
+		"test-deleted-parent").Scan(&counterRows)
+	cleanupErr := cleanup()
+	if queryErr != nil {
+		t.Fatalf("query orphan child counter: %v", queryErr)
+	}
+	if cleanupErr != nil {
+		t.Fatalf("close embedded SQL connection: %v", cleanupErr)
+	}
+	if counterRows != 0 {
+		t.Fatalf("orphan child counter rows = %d, want 0", counterRows)
+	}
+
+	// Recreating the parent remains allocation-safe without an orphaned
+	// counter because GetNextChildID scans existing direct child IDs.
+	now := time.Now().UTC()
+	if err := store.CreateIssue(ctx, &types.Issue{
+		ID:        "test-deleted-parent",
+		Title:     "Recreated parent",
+		Status:    types.StatusOpen,
+		Priority:  1,
+		IssueType: types.TypeEpic,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}, "tester"); err != nil {
+		t.Fatalf("recreate parent: %v", err)
+	}
+	nextID, err := store.GetNextChildID(ctx, "test-deleted-parent")
+	if err != nil {
+		t.Fatalf("GetNextChildID after recreating parent: %v", err)
+	}
+	if nextID != "test-deleted-parent.8" {
+		t.Fatalf("next child ID = %q, want %q", nextID, "test-deleted-parent.8")
+	}
+}

--- a/internal/storage/conformance/audit_molecule_wisp_batch_iter.go
+++ b/internal/storage/conformance/audit_molecule_wisp_batch_iter.go
@@ -33,7 +33,7 @@ func RunAudit_molecule_wisp_batch_iter(t *testing.T, f Factory) {
 	t.Run("CreateRejectStaleUpserts", func(t *testing.T) { testAuditCreateRejectStaleUpserts(t, f) })
 	t.Run("CreateAllWispsFastPath", func(t *testing.T) { testAuditCreateAllWispsFastPath(t, f) })
 	t.Run("CreateAllWispsInlineDependencies", func(t *testing.T) { testAuditCreateAllWispsInlineDependencies(t, f) })
-	t.Run("CreateOrphanStrict", func(t *testing.T) { testAuditCreateOrphanStrict(t, f) })
+	t.Run("CreateOrphanHandling", func(t *testing.T) { testAuditCreateOrphanHandling(t, f) })
 	t.Run("CreateCrossBucketDependency", func(t *testing.T) { testAuditCreateCrossBucketDependency(t, f) })
 	t.Run("CreateInBatchCycle", func(t *testing.T) { testAuditCreateInBatchCycle(t, f) })
 	t.Run("ListWisps", func(t *testing.T) { testAuditListWisps(t, f) })
@@ -504,15 +504,11 @@ func testAuditCreateAllWispsInlineDependencies(t *testing.T, f Factory) {
 }
 
 // OrphanStrict rejects an issue whose hierarchical parent is missing
-// (create.go:490-515), inserting nothing.
-//
-// NOTE: the finding's companion claim — that OrphanSkip *silently* drops the
-// same orphan — does NOT hold in the batch path on the Dolt reference: the
-// skipped orphan is still handed to ReconcileChildCounters, which FK-violates
-// on the missing parent (child_counters.fk_counter_parent). So a single
-// missing-parent orphan under OrphanSkip errors on Dolt, not skips; only the
-// Strict branch is a stable, reproducible contract here.
-func testAuditCreateOrphanStrict(t *testing.T, f Factory) {
+// (create.go:490-515), inserting nothing. OrphanSkip accepts the batch but
+// inserts neither the orphan nor an ownerless child-counter row: counter
+// reconciliation now verifies that the routed parent exists before touching
+// its auxiliary counter table.
+func testAuditCreateOrphanHandling(t *testing.T, f Factory) {
 	s := f(t)
 	c := ctx()
 	if err := s.CreateIssuesWithFullOptions(c, []*types.Issue{
@@ -522,6 +518,15 @@ func testAuditCreateOrphanStrict(t *testing.T, f Factory) {
 	}
 	if _, err := s.GetIssue(c, "test-p.2"); !errors.Is(err, storage.ErrNotFound) {
 		t.Errorf("OrphanStrict inserted the orphan: %v", err)
+	}
+
+	if err := s.CreateIssuesWithFullOptions(c, []*types.Issue{
+		withDefaults(&types.Issue{ID: "test-p.3", Title: "Orphan3"}),
+	}, "a", storage.BatchCreateOptions{OrphanHandling: storage.OrphanSkip, SkipPrefixValidation: true}); err != nil {
+		t.Errorf("OrphanSkip: unexpected error: %v", err)
+	}
+	if _, err := s.GetIssue(c, "test-p.3"); !errors.Is(err, storage.ErrNotFound) {
+		t.Errorf("OrphanSkip inserted the orphan: %v", err)
 	}
 }
 

--- a/internal/storage/issueops/create.go
+++ b/internal/storage/issueops/create.go
@@ -902,20 +902,47 @@ func ReconcileChildCounters(ctx context.Context, tx *sql.Tx, issues []*types.Iss
 		}
 	}
 
+	unknownParentIDs := make([]string, 0, len(parents))
+	for parentID, b := range parents {
+		if b.maxChild > 0 && !b.known {
+			unknownParentIDs = append(unknownParentIDs, parentID)
+		}
+	}
+	wispParents, err := WispIDSetInTx(ctx, tx, unknownParentIDs)
+	if err != nil {
+		return nil, fmt.Errorf("failed to route child counter parents: %w", err)
+	}
+	for _, parentID := range unknownParentIDs {
+		_, parents[parentID].isWisp = wispParents[parentID]
+	}
+
 	for parentID, b := range parents {
 		if b.maxChild == 0 {
 			continue
 		}
-		if !b.known {
-			b.isWisp = IsActiveWispInTx(ctx, tx, parentID)
-		}
 		table := "child_counters"
+		parentTable := "issues"
 		if b.isWisp {
 			table = "wisp_child_counters"
+			parentTable = "wisps"
+		}
+		var parentExists int
+		// Orphaned hierarchical IDs are valid import input when the parent was
+		// deleted before export. Their auxiliary counter has no owner and must
+		// not be inserted: both counter tables enforce a parent foreign key.
+		//nolint:gosec // G201: parentTable is one of two hardcoded constants.
+		err := tx.QueryRowContext(ctx, fmt.Sprintf(`
+			SELECT 1 FROM %s WHERE id = ?
+		`, parentTable), parentID).Scan(&parentExists)
+		if err == sql.ErrNoRows {
+			continue
+		}
+		if err != nil {
+			return nil, fmt.Errorf("failed to check child counter parent %s: %w", parentID, err)
 		}
 		var current int
 		//nolint:gosec // G201: table is one of two hardcoded constants.
-		err := tx.QueryRowContext(ctx, fmt.Sprintf(`
+		err = tx.QueryRowContext(ctx, fmt.Sprintf(`
 			SELECT last_child FROM %s WHERE parent_id = ?
 		`, table), parentID).Scan(&current)
 		if err != nil && err != sql.ErrNoRows {

--- a/internal/storage/issueops/create_test.go
+++ b/internal/storage/issueops/create_test.go
@@ -451,3 +451,96 @@ func TestPersistDependenciesSkipsHierarchyValidationAcrossPrefixes(t *testing.T)
 		t.Fatalf("unmet expectations: %v", err)
 	}
 }
+
+func TestReconcileChildCountersSkipsMissingParent(t *testing.T) {
+	ctx := context.Background()
+	db, mock, tx := beginMockTx(t)
+	defer db.Close()
+
+	mock.ExpectQuery("SELECT 1 FROM wisps LIMIT 1").
+		WillReturnError(sql.ErrNoRows)
+	mock.ExpectQuery("SELECT 1 FROM issues WHERE id = \\?").
+		WithArgs("test-deleted-parent").
+		WillReturnError(sql.ErrNoRows)
+
+	changed, err := ReconcileChildCounters(ctx, tx, []*types.Issue{{
+		ID:        "test-deleted-parent.7",
+		IssueType: types.TypeTask,
+	}})
+	if err != nil {
+		t.Fatalf("ReconcileChildCounters error = %v, want nil", err)
+	}
+	if len(changed) != 0 {
+		t.Fatalf("changed tables = %#v, want none", changed)
+	}
+
+	// No counter SELECT or upsert is expected after the missing-parent lookup.
+	mock.ExpectRollback()
+	if err := tx.Rollback(); err != nil {
+		t.Fatalf("rollback: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestReconcileChildCountersReturnsParentLookupError(t *testing.T) {
+	ctx := context.Background()
+	db, mock, tx := beginMockTx(t)
+	defer db.Close()
+	lookupErr := errors.New("parent lookup failed")
+
+	mock.ExpectQuery("SELECT 1 FROM wisps LIMIT 1").
+		WillReturnError(sql.ErrNoRows)
+	mock.ExpectQuery("SELECT 1 FROM issues WHERE id = \\?").
+		WithArgs("test-parent").
+		WillReturnError(lookupErr)
+
+	_, err := ReconcileChildCounters(ctx, tx, []*types.Issue{{
+		ID:        "test-parent.1",
+		IssueType: types.TypeTask,
+	}})
+	if err == nil || !strings.Contains(err.Error(), "failed to check child counter parent test-parent") || !errors.Is(err, lookupErr) {
+		t.Fatalf("error = %v, want contextual parent lookup error", err)
+	}
+
+	// A lookup failure must not be mistaken for an absent parent or reach the
+	// counter table.
+	mock.ExpectRollback()
+	if err := tx.Rollback(); err != nil {
+		t.Fatalf("rollback: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestReconcileChildCountersReturnsWispLookupError(t *testing.T) {
+	ctx := context.Background()
+	db, mock, tx := beginMockTx(t)
+	defer db.Close()
+	lookupErr := errors.New("wisp lookup failed")
+
+	mock.ExpectQuery("SELECT 1 FROM wisps LIMIT 1").
+		WillReturnRows(sqlmock.NewRows([]string{"1"}).AddRow(1))
+	mock.ExpectQuery("SELECT id FROM wisps WHERE id IN \\(\\?\\)").
+		WithArgs("test-parent").
+		WillReturnError(lookupErr)
+
+	_, err := ReconcileChildCounters(ctx, tx, []*types.Issue{{
+		ID:        "test-parent.1",
+		IssueType: types.TypeTask,
+	}})
+	if err == nil || !strings.Contains(err.Error(), "failed to route child counter parents") || !errors.Is(err, lookupErr) {
+		t.Fatalf("error = %v, want contextual wisp lookup error", err)
+	}
+
+	// A failed wisp lookup must stop routing before any issues or counter query.
+	mock.ExpectRollback()
+	if err := tx.Rollback(); err != nil {
+		t.Fatalf("rollback: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}


### PR DESCRIPTION
## Why

A valid export can contain a closed hierarchical child after its parent was deleted. Bulk import persists that child, then unconditionally tries to create an auxiliary `child_counters` row whose foreign key points at the absent parent. That counter write rolls back the entire transaction, including unrelated issues in the same import batch.

The child is durable history; the ownerless counter is disposable derived state. Import should preserve the former without inventing the latter.

## What changed

- route unknown hierarchy parents through the existing error-aware batched wisp lookup
- verify the routed parent row exists before reading or upserting its counter
- skip counter reconciliation only for a genuinely absent owner
- propagate wisp-routing and owner-lookup errors instead of confusing them with absence
- update the storage conformance contract for Strict and Skip orphan handling

Foreign-key checks remain enabled. Existing issue and wisp parent paths are unchanged.

## Validation

- `CGO_ENABLED=0 go test -tags gms_pure_go ./internal/storage/issueops -count=1`
- `CGO_ENABLED=1 BEADS_TEST_EMBEDDED_DOLT=1 go test -tags gms_pure_go ./cmd/bd -run '^TestEmbeddedImportClosedChildWhoseParentWasDeleted$' -count=1`
- existing durable and mixed durable/wisp child-counter tests
- exact embedded-Dolt `CreateOrphanHandling` conformance case
- `git diff --check`
- repository commit hook: `0 issues`
- independent review found and verified the fix for a swallowed wisp-lookup error; final re-review found no blockers

The embedded regression imports an ordinary row and a closed orphan `.7`, proves the batch commits with no ownerless counter, recreates the parent, and verifies the next child allocation is `.8`.

## Scope and overlap

This is the third independent acceptance-criterion leaf of #4640. It is distinct from #4538: that merged migration repairs counter rows already present in a database, while this patch prevents a fresh import from attempting an invalid counter insert. Exact-topic preflight and branch searches found no active implementation.

_codex-gpt-5.6-sol-high on behalf of matt wilkie_
