### PR TITLE
fix(docs): pin generated CLI artifacts to LF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -14,3 +14,10 @@ internal/templates/agents/defaults/*.md text eol=lf
 # Windows checkouts (core.autocrlf=true) hash identically to release builds
 # instead of reporting false migration-content skew.
 internal/storage/schema/migrations/**/*.sql text eol=lf
+
+# CLI docs freshness compares committed artifacts byte-for-byte with an LF-only
+# scratch tree. Pin every generated surface so core.autocrlf cannot create false
+# drift on Windows.
+docs/CLI_REFERENCE.md text eol=lf
+docs/cli-reference/*.md text eol=lf
+docs/docs.json text eol=lf


### PR DESCRIPTION
## What

Pin all generated CLI documentation surfaces to LF in `.gitattributes`:

- `docs/CLI_REFERENCE.md`
- `docs/cli-reference/*.md`
- `docs/docs.json`

The committed artifacts are already LF, so the patch changes only `.gitattributes`; it introduces no generated-document content churn.

## Why

Fixes #4965.

The CLI docs freshness gate byte-compares the checked-out artifacts with generated output. On Windows, a system or user `core.autocrlf=true` setting currently materializes those same blobs as CRLF because the generated files have no explicit checkout policy. A clean, current checkout consequently fails every freshness entry point with a whole-file line-ending diff.

Path-specific `eol=lf` rules make the repository own the byte-level invariant required by its generator, independent of workstation Git configuration.

## Verification

Before the patch, on Windows with system `core.autocrlf=true`:

```bash
./scripts/generate-cli-docs.sh --check
```

failed with `docs/CLI_REFERENCE.md is out of sync`, and `git ls-files --eol` reported `i/lf w/crlf` across all 111 generated artifacts.

In a fresh detached worktree at the patched commit, under the same Git configuration, all 111 artifacts report `w/lf`, and all three checks pass:

```bash
./scripts/generate-cli-docs.sh --check
./scripts/check-cli-docs-drift.sh
./scripts/check-doc-flags.sh
```

`git add --renormalize` staged no generated files, confirming that the patch does not alter their committed content.

---

_codex-tui-gpt-5.6-sol-ultra on behalf of Ewen Cuthiell_
