### PR TITLE
fix(plugin): make command argument hints strings

### DIFF
--- a/cmd/bd/setup/plugin_layout_test.go
+++ b/cmd/bd/setup/plugin_layout_test.go
@@ -1,10 +1,13 @@
 package setup
 
 import (
+	"bytes"
 	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"gopkg.in/yaml.v3"
 )
 
 func TestPluginLayoutUsesSharedBeadsRoot(t *testing.T) {
@@ -57,6 +60,54 @@ func TestPluginLayoutUsesSharedBeadsRoot(t *testing.T) {
 	requireRepoFile(t, root, "plugins", "beads", "skills", "beads", "commands", "ready.md")
 	requireRepoFile(t, root, "plugins", "beads", ".codex-plugin", "hooks", "hooks.json")
 	requireNoRepoPath(t, root, "plugins", "beads", "hooks", "hooks.json")
+}
+
+func TestPluginCommandArgumentHintsAreStrings(t *testing.T) {
+	root := filepath.Join("..", "..", "..")
+	commandsDir := filepath.Join(root, "plugins", "beads", "skills", "beads", "commands")
+	entries, err := os.ReadDir(commandsDir)
+	if err != nil {
+		t.Fatalf("read commands directory %s: %v", commandsDir, err)
+	}
+
+	const expectedArgumentHints = 23
+	checkedArgumentHints := 0
+	for _, entry := range entries {
+		if entry.IsDir() || filepath.Ext(entry.Name()) != ".md" {
+			continue
+		}
+
+		path := filepath.Join(commandsDir, entry.Name())
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read %s: %v", path, err)
+		}
+		data = bytes.ReplaceAll(data, []byte("\r\n"), []byte("\n"))
+		if !bytes.HasPrefix(data, []byte("---\n")) {
+			continue
+		}
+
+		frontmatter, _, ok := bytes.Cut(data[len("---\n"):], []byte("\n---\n"))
+		if !ok {
+			t.Fatalf("parse frontmatter in %s: missing closing delimiter", path)
+		}
+
+		var metadata map[string]interface{}
+		if err := yaml.Unmarshal(frontmatter, &metadata); err != nil {
+			t.Fatalf("parse frontmatter in %s: %v", path, err)
+		}
+		argumentHint, ok := metadata["argument-hint"]
+		if !ok {
+			continue
+		}
+		checkedArgumentHints++
+		if _, ok := argumentHint.(string); !ok {
+			t.Errorf("argument-hint in %s decoded as %T, want string", path, argumentHint)
+		}
+	}
+	if checkedArgumentHints != expectedArgumentHints {
+		t.Errorf("checked %d command argument-hint fields, want %d", checkedArgumentHints, expectedArgumentHints)
+	}
 }
 
 func readJSONFile(t *testing.T, path string, dest interface{}) {

--- a/plugins/beads/skills/beads/commands/audit.md
+++ b/plugins/beads/skills/beads/commands/audit.md
@@ -1,6 +1,6 @@
 ---
 description: Log and label agent interactions (append-only JSONL)
-argument-hint: record|label
+argument-hint: "record|label"
 ---
 
 Append-only audit logging for agent interactions (prompts, responses, tool calls) in `.beads/interactions.jsonl`.
@@ -24,5 +24,4 @@ Each line is one event. Labeling is done by appending a new `"label"` event refe
 
 - Audit entries are **append-only** (no in-place edits).
 - `bd dolt push` includes `.beads/interactions.jsonl` in the commit allowlist.
-
 

--- a/plugins/beads/skills/beads/commands/blocked.md
+++ b/plugins/beads/skills/beads/commands/blocked.md
@@ -1,6 +1,6 @@
 ---
 description: Show blocked issues
-argument-hint: []
+argument-hint: ""
 ---
 
 Show all issues that are blocked by dependencies.

--- a/plugins/beads/skills/beads/commands/close.md
+++ b/plugins/beads/skills/beads/commands/close.md
@@ -1,6 +1,6 @@
 ---
 description: Close a completed issue
-argument-hint: [issue-id] [reason]
+argument-hint: "[issue-id] [reason]"
 ---
 
 Close a beads issue that's been completed.

--- a/plugins/beads/skills/beads/commands/comments.md
+++ b/plugins/beads/skills/beads/commands/comments.md
@@ -1,6 +1,6 @@
 ---
 description: View or manage comments on an issue
-argument-hint: [issue-id]
+argument-hint: "[issue-id]"
 ---
 
 View or add comments to a beads issue.

--- a/plugins/beads/skills/beads/commands/compact.md
+++ b/plugins/beads/skills/beads/commands/compact.md
@@ -1,6 +1,6 @@
 ---
 description: Compact old closed issues using semantic summarization
-argument-hint: [--all] [--id issue-id] [--dry-run]
+argument-hint: "[--all] [--id issue-id] [--dry-run]"
 ---
 
 Reduce database size by summarizing closed issues no longer actively referenced.

--- a/plugins/beads/skills/beads/commands/create.md
+++ b/plugins/beads/skills/beads/commands/create.md
@@ -1,6 +1,6 @@
 ---
 description: Create a new issue interactively
-argument-hint: [title] [type] [priority]
+argument-hint: "[title] [type] [priority]"
 ---
 
 Create a new beads issue. If arguments are provided:

--- a/plugins/beads/skills/beads/commands/decision.md
+++ b/plugins/beads/skills/beads/commands/decision.md
@@ -1,6 +1,6 @@
 ---
 description: Record, list, and manage project decisions with rationale tracking
-argument-hint: record|list|show|supersede
+argument-hint: "record|list|show|supersede"
 ---
 
 Record and track project decisions as beads issues with structured rationale, alternatives considered, and links to affected work.

--- a/plugins/beads/skills/beads/commands/delete.md
+++ b/plugins/beads/skills/beads/commands/delete.md
@@ -1,6 +1,6 @@
 ---
 description: Delete issues and clean up references
-argument-hint: [issue-ids...] [--force]
+argument-hint: "[issue-ids...] [--force]"
 ---
 
 Delete one or more issues and clean up all references.

--- a/plugins/beads/skills/beads/commands/dep.md
+++ b/plugins/beads/skills/beads/commands/dep.md
@@ -1,6 +1,6 @@
 ---
 description: Manage dependencies between issues
-argument-hint: [command] [from-id] [to-id]
+argument-hint: "[command] [from-id] [to-id]"
 ---
 
 Manage dependencies between beads issues.

--- a/plugins/beads/skills/beads/commands/epic.md
+++ b/plugins/beads/skills/beads/commands/epic.md
@@ -1,6 +1,6 @@
 ---
 description: Epic management commands
-argument-hint: [command]
+argument-hint: "[command]"
 ---
 
 Manage epics (large features composed of multiple issues).

--- a/plugins/beads/skills/beads/commands/export.md
+++ b/plugins/beads/skills/beads/commands/export.md
@@ -1,6 +1,6 @@
 ---
 description: Export issues to JSONL format
-argument-hint: [-o output-file]
+argument-hint: "[-o output-file]"
 ---
 
 Export all issues to JSON Lines format (one JSON object per line).

--- a/plugins/beads/skills/beads/commands/init.md
+++ b/plugins/beads/skills/beads/commands/init.md
@@ -1,6 +1,6 @@
 ---
 description: Initialize beads in the current project
-argument-hint: [prefix]
+argument-hint: "[prefix]"
 ---
 
 Initialize beads issue tracking in the current directory.

--- a/plugins/beads/skills/beads/commands/label.md
+++ b/plugins/beads/skills/beads/commands/label.md
@@ -1,6 +1,6 @@
 ---
 description: Manage issue labels
-argument-hint: [command] [issue-id] [label]
+argument-hint: "[command] [issue-id] [label]"
 ---
 
 Manage labels on beads issues. Labels provide flexible cross-cutting metadata beyond structured fields (status, priority, type).

--- a/plugins/beads/skills/beads/commands/list.md
+++ b/plugins/beads/skills/beads/commands/list.md
@@ -1,6 +1,6 @@
 ---
 description: List issues with optional filters
-argument-hint: [--status] [--priority] [--type] [--assignee] [--label]
+argument-hint: "[--status] [--priority] [--type] [--assignee] [--label]"
 ---
 
 List beads issues with optional filtering.

--- a/plugins/beads/skills/beads/commands/quickstart.md
+++ b/plugins/beads/skills/beads/commands/quickstart.md
@@ -1,6 +1,6 @@
 ---
 description: Quick start guide for bd workflows (deprecated)
-argument-hint: []
+argument-hint: ""
 ---
 
 **Note:** The `bd quickstart` command is deprecated. See the [Quick Start](https://beads.gascity.com/getting-started/quickstart) on the documentation site, or the in-repo source [docs/getting-started/quickstart.md](https://github.com/gastownhall/beads/blob/main/docs/getting-started/quickstart.md).

--- a/plugins/beads/skills/beads/commands/rename-prefix.md
+++ b/plugins/beads/skills/beads/commands/rename-prefix.md
@@ -1,6 +1,6 @@
 ---
 description: Rename the issue prefix for all issues
-argument-hint: <new-prefix> [--dry-run]
+argument-hint: "<new-prefix> [--dry-run]"
 ---
 
 Rename the issue prefix for all issues in the database.

--- a/plugins/beads/skills/beads/commands/reopen.md
+++ b/plugins/beads/skills/beads/commands/reopen.md
@@ -1,6 +1,6 @@
 ---
 description: Reopen closed issues
-argument-hint: [issue-ids...] [--reason]
+argument-hint: "[issue-ids...] [--reason]"
 ---
 
 Reopen one or more closed issues.

--- a/plugins/beads/skills/beads/commands/restore.md
+++ b/plugins/beads/skills/beads/commands/restore.md
@@ -1,6 +1,6 @@
 ---
 description: Restore full history of compacted issue from git
-argument-hint: <issue-id>
+argument-hint: "<issue-id>"
 ---
 
 Restore full history of a compacted issue from git version control.

--- a/plugins/beads/skills/beads/commands/search.md
+++ b/plugins/beads/skills/beads/commands/search.md
@@ -1,6 +1,6 @@
 ---
 description: Search issues by text query
-argument-hint: <query> [--status] [--label] [--assignee]
+argument-hint: "<query> [--status] [--label] [--assignee]"
 ---
 
 Search issues across title, description, and ID with a simple text query.

--- a/plugins/beads/skills/beads/commands/show.md
+++ b/plugins/beads/skills/beads/commands/show.md
@@ -1,6 +1,6 @@
 ---
 description: Show detailed information about an issue
-argument-hint: [issue-id]
+argument-hint: "[issue-id]"
 ---
 
 Display detailed information about a beads issue.

--- a/plugins/beads/skills/beads/commands/update.md
+++ b/plugins/beads/skills/beads/commands/update.md
@@ -1,6 +1,6 @@
 ---
 description: Update an issue's status, priority, or other fields
-argument-hint: [issue-id] [status]
+argument-hint: "[issue-id] [status]"
 ---
 
 Update a beads issue.


### PR DESCRIPTION
## Why

Copilot loads the shared plugin command frontmatter as YAML and requires `argument-hint` to be a string. Seven commands currently decode a bracketed value as a sequence, so those skills fail to load. Several other multi-bracket hints are not valid yaml.v3 scalars at all, leaving the same schema vulnerable to future consumers and refreshes.

## What changed

- normalize all 23 shared command `argument-hint` fields to explicit YAML strings
- preserve each displayed hint, except the two no-argument commands whose reported `[]` values correctly become empty strings
- scan every shared command Markdown file in a regression test and assert all 23 hints decode as strings
- normalize CRLF before parsing so the test cannot silently skip a normal Windows checkout

The cleanup expands mechanically beyond the seven reported files because a truthful scan-all test exposed invalid legacy multi-bracket YAML in the remaining command set.

## Validation

- `go test ./cmd/bd/setup -run 'TestPlugin(CommandArgumentHintsAreStrings|LayoutUsesSharedBeadsRoot)' -count=1`
- `go test ./cmd/bd/setup -skip '^TestInstallAgentsInspectError$' -count=1`
- `git diff --check`
- repository commit hook: `0 issues`
- independent read-only review: no remaining blockers

The complete setup package has one pre-existing Windows-only failure in `TestInstallAgentsInspectError`: its expected inspect-error wording is replaced by a temp-file path error. That exact failure reproduces on a separate upstream-main-derived worktree and is unrelated to these frontmatter changes.

Closes #4494.

_codex-gpt-5.6-sol-high on behalf of matt wilkie_
