### PR TITLE
docs(plugin): replace unsupported export status example

### DIFF
--- a/plugins/beads/skills/beads/commands/export.md
+++ b/plugins/beads/skills/beads/commands/export.md
@@ -9,7 +9,7 @@ Export all issues to JSON Lines format (one JSON object per line).
 
 - **To stdout**: `bd export`
 - **To file**: `bd export -o issues.jsonl`
-- **Filter by status**: `bd export --status open`
+- **Include all records**: `bd export --all -o full.jsonl`
 
 Issues are sorted by ID for consistent diffs, making git diffs readable.
 


### PR DESCRIPTION
## Why

The bundled plugin told agents to run `bd export --status open`, but `export` has no `--status` flag. Following the skill therefore fails immediately instead of producing JSONL.

## What changed

- replace the unsupported status-filter example with the command's supported `--all -o full.jsonl` example

## Validation

- confirmed `--all` and `-o` against `cmd/bd/export.go`
- confirmed the exact example matches the command's own long help
- `git diff --check`
- independent read-only review: no blockers

Related active PR #4969 touches only this file's frontmatter; its hunk is separate from this usage correction.

Closes #4853.

_codex-gpt-5.6-sol-high on behalf of matt wilkie_
