### PR TITLE
docs(plugin): align worktree guidance with Dolt

### DIFF
--- a/plugins/beads/skills/beads/resources/WORKTREES.md
+++ b/plugins/beads/skills/beads/resources/WORKTREES.md
@@ -13,35 +13,45 @@
 | Quick branch switch | No | `git switch` is simpler |
 | PR review isolation | Yes | Review without disturbing main work |
 
-## Why `bd worktree` over `git worktree`
+## Creating Worktrees
 
-**Always use `bd worktree`** instead of raw `git worktree` commands.
+Normal Git worktrees work with beads. Use `bd worktree` when its convenience
+features are useful:
 
 ```bash
+# Beads convenience command: creates the Git worktree and adds an in-repo path
+# to .gitignore.
 bd worktree create .worktrees/{name} --branch feature/{name}
 bd worktree remove .worktrees/{name}
+
+# Standard Git commands are also supported.
+git worktree add -b feature/{name} .worktrees/{name}
+git worktree remove .worktrees/{name}
 ```
 
-**Why?** `bd worktree` auto-configures:
-- Beads database redirect files
-- Proper gitignore entries
-- Embedded mode for worktree operations
+`bd worktree remove` adds safety checks for uncommitted changes and unpushed
+commits. By default, both creation paths use the same shared beads workspace.
 
 ## Architecture
 
-All worktrees share one `.beads/` database via redirect files:
+By default, linked worktrees share the repository's `.beads/` workspace through
+Git common directory discovery. They do not need per-worktree redirect files:
 
 ```
 main-repo/
-├── .beads/              ← Single source of truth
+├── .git/                ← Shared Git directory
+├── .beads/              ← Shared beads config and local Dolt data
 └── .worktrees/
     ├── feature-a/
-    │   └── .beads       ← Redirect file (not directory)
     └── feature-b/
-        └── .beads       ← Redirect file
 ```
 
-**Key insight**: Wisp operations in worktrees use embedded mode automatically.
+`bd` uses the workspace's configured storage mode from every linked worktree;
+worktree use does not force embedded mode.
+
+Set `BEADS_DIR` to use an external beads workspace instead. A worktree can also
+use its own `.beads/` database explicitly; otherwise discovery falls back to
+the shared workspace.
 
 ## Commands
 
@@ -52,8 +62,9 @@ bd worktree create .worktrees/my-feature --branch feature/my-feature
 # List worktrees
 bd worktree list
 
-# Show worktree info
-bd worktree info .worktrees/my-feature
+# Show info for the current worktree
+cd .worktrees/my-feature
+bd worktree info
 
 # Remove worktree cleanly
 bd worktree remove .worktrees/my-feature
@@ -64,31 +75,39 @@ bd worktree remove .worktrees/my-feature
 When beads commands behave unexpectedly in a worktree:
 
 ```bash
-bd where              # Shows actual .beads location (follows redirects)
-bd doctor --deep      # Validates graph integrity across all refs
+bd where              # Shows the effective .beads workspace location
+bd doctor --deep      # Validates full graph integrity
 ```
 
 ## Protected Branch Workflows
 
-For repos with protected `main` branch:
+Protected Git branches need no special beads branch because issue data is
+stored in Dolt under `refs/dolt/data`, separate from code branches:
 
 ```bash
-bd init --branch beads-metadata    # Use separate branch for beads data
-bd init --contributor              # Auto-configure sync.remote=upstream for forks
+# Choose one initialization path:
+bd init                            # Standard repository setup
+# OR
+bd init --contributor              # OSS fork setup with contributor routing
+
+bd dolt pull                       # Pull shared issue data
+bd dolt push                       # Push shared issue data
 ```
 
-This creates `.git/beads-worktrees/` for internal management.
+No `--branch` flag or `.git/beads-worktrees/` directory is used. Keep using
+your normal Git feature branches and worktrees for code changes.
 
 ## Multi-Clone Support
 
 Multi-clone, multi-branch workflows:
 
 - Hash-based IDs (`bd-abc`) eliminate collision across clones
-- Each clone syncs independently via git
+- Each clone syncs through the configured Dolt remote with `bd dolt pull` and
+  `bd dolt push`
 - See [WORKTREES.md](https://github.com/gastownhall/beads/blob/main/docs/reference/worktrees.md) for comprehensive guide
 
 ## External References
 
 - **Official Docs**: [github.com/gastownhall/beads/docs](https://github.com/gastownhall/beads/tree/main/docs)
-- **Sync Branch**: [PROTECTED_BRANCHES.md](https://github.com/gastownhall/beads/blob/main/docs/reference/protected-branches.md)
+- **Protected Branches**: [PROTECTED_BRANCHES.md](https://github.com/gastownhall/beads/blob/main/docs/reference/protected-branches.md)
 - **Worktrees**: [WORKTREES.md](https://github.com/gastownhall/beads/blob/main/docs/reference/worktrees.md)


### PR DESCRIPTION
## Why

The bundled worktree guide attributes `--branch` to `bd init`, but that flag belongs to `bd worktree create`. The same section still described the removed sync-branch/redirect-file model, which could lead agents to unsupported commands and incorrect issue-sync assumptions.

## What changed

- replace `bd init --branch beads-metadata` with current initialization choices
- document normal Git worktrees and Git common-directory discovery
- correct `bd worktree info` to its no-argument form
- describe `bd worktree` as a safety/convenience wrapper, not a requirement
- clarify that cross-clone issue sync uses `bd dolt pull` and `bd dolt push`
- remove legacy redirect-file, forced-embedded, and `.git/beads-worktrees/` claims

## Validation

- checked worktree command syntax and safety behavior against `cmd/bd/worktree_cmd.go`
- checked sync/storage claims against the canonical worktree and protected-branch references
- stale-command and stale-architecture scans
- Markdown fence balance and `git diff --check`
- two review passes plus final main-agent diff inspection

Closes #4855.

_codex-gpt-5.6-sol-high on behalf of matt wilkie_
