### PR TITLE
docs(plugin): replace removed sync command guidance

### DIFF
--- a/plugins/beads/skills/beads/commands/sync.md
+++ b/plugins/beads/skills/beads/commands/sync.md
@@ -1,17 +1,50 @@
 ---
-description: Synchronize issues (deprecated — use bd dolt push/pull)
-argument-hint: (deprecated)
+description: Synchronize issues with a configured Dolt remote
+argument-hint: ""
 ---
 
-`bd sync` is **deprecated** and is now a no-op.
+The top-level `bd sync` command has been removed. Running it returns an
+unknown-command error; it is not a compatibility no-op. Nested commands such
+as `bd backup sync` and tracker-specific sync commands are separate commands
+and remain supported.
 
-## Use Dolt commands instead
+## Supported workflow
 
-- **Push to remote**: `bd dolt push`
-- **Pull from remote**: `bd dolt pull`
-- **Commit pending changes**: `bd dolt commit`
-- **Check connection**: `bd dolt show`
+```bash
+# Before starting work or consuming changes from another clone
+bd dolt pull
+
+# After local issue updates and before handoff: commit, integrate, then publish
+bd dolt commit
+bd dolt pull
+bd dolt push
+```
+
+`bd dolt commit` creates an explicit commit boundary when auto-commit is off or
+in batch mode; it is a safe no-op when there is nothing pending. The following
+pull integrates remote changes before the final push. The pull steps require a
+configured remote; use the one-time setup below first when needed.
+
+Inspect the configured Dolt remotes with:
+
+```bash
+bd dolt remote list
+```
+
+If no Dolt remote exists, the project has a Git origin, and remote sync is
+enabled, `bd dolt push` automatically adopts that origin; do not add the
+matching URL manually. To use a distinct custom Dolt remote, first confirm that
+the chosen name is absent, then add it explicitly:
+
+```bash
+bd dolt remote add origin <distinct-dolt-remote-url>
+```
 
 ## Note
 
-Most users should rely on the Dolt server's automatic sync (with `dolt.auto-commit` enabled) instead of running manual sync commands.
+When enabled, `dolt.auto-commit` records successful writes in local Dolt
+history; it does not push them to a remote. Remote auto-push is a separate,
+opt-in setting and is disabled by default. Auto-push publishes committed HEAD
+only; it does not commit pending working-set writes when auto-commit is off or
+in batch mode. Keep an explicit commit boundary before handoff unless the
+project has a coordinated policy that provides one.


### PR DESCRIPTION
## Why

The bundled plugin described top-level `bd sync` as a harmless no-op. The command has been removed, so agents following that guidance fail with an unknown-command error. The old replacement advice also did not guarantee that pending off/batch/server working-set changes reached the remote.

## What changed

- state that top-level `bd sync` is removed while unrelated nested sync commands remain
- document pull-before-work and commit→pull→push before handoff
- explain safe automatic Git-origin adoption when no Dolt remote exists
- reserve manual remote setup for a distinct, absent custom remote
- clarify that auto-commit is local and opt-in auto-push publishes committed HEAD only

## Validation

- checked root and nested command registration against current Cobra definitions
- checked commit/pull/push behavior in embedded and server modes
- checked remote adoption, collision guard, and auto-push behavior against source/tests
- Markdown fence and stale-command scans; `git diff --check`
- independent final review: no blockers

Related active PR #4969 touches only this file's frontmatter quoting; its hunk is separate.

Closes #4856.

_codex-gpt-5.6-sol-high on behalf of matt wilkie_
