### PR TITLE
fix(windows): detect exited processes in liveness helpers

### DIFF
--- a/internal/doltserver/doltserver_windows.go
+++ b/internal/doltserver/doltserver_windows.go
@@ -98,16 +98,19 @@ func isProcessInDir(pid int, dir string) bool {
 	return false
 }
 
-// isProcessAlive checks if a process with the given PID is running.
-// Uses OpenProcess with PROCESS_QUERY_LIMITED_INFORMATION — returns error if
-// the process doesn't exist.
+// isProcessAlive checks if a process with the given PID is running. Opening a
+// process is not sufficient: an exited process remains openable while another
+// handle refers to it. A zero-timeout wait distinguishes that signaled process
+// from a running process.
 func isProcessAlive(pid int) bool {
-	h, err := windows.OpenProcess(windows.PROCESS_QUERY_LIMITED_INFORMATION, false, uint32(pid))
+	h, err := windows.OpenProcess(windows.SYNCHRONIZE, false, uint32(pid))
 	if err != nil {
 		return false
 	}
-	windows.CloseHandle(h)
-	return true
+	defer func() { _ = windows.CloseHandle(h) }()
+
+	status, err := windows.WaitForSingleObject(h, 0)
+	return err == nil && status == uint32(windows.WAIT_TIMEOUT)
 }
 
 // gracefulStop terminates a process on Windows. Uses TerminateProcess (hard kill)

--- a/internal/doltserver/doltserver_windows_test.go
+++ b/internal/doltserver/doltserver_windows_test.go
@@ -1,0 +1,45 @@
+//go:build windows
+
+package doltserver
+
+import (
+	"os/exec"
+	"testing"
+
+	"golang.org/x/sys/windows"
+)
+
+// Keep the parent-owned process handle open after exit to reproduce the state
+// where OpenProcess succeeds for a process that is no longer running.
+func TestIsProcessAliveReportsExitedProcessWithLingeringHandleAsDead(t *testing.T) {
+	cmd := exec.Command("cmd.exe", "/c", "exit", "0")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start child process: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := cmd.Wait(); err != nil {
+			t.Errorf("reap child process: %v", err)
+		}
+	})
+
+	pid := cmd.Process.Pid
+	probe, err := windows.OpenProcess(windows.SYNCHRONIZE, false, uint32(pid))
+	if err != nil {
+		t.Fatalf("open probe handle for process %d: %v", pid, err)
+	}
+	status, waitErr := windows.WaitForSingleObject(probe, 5000)
+	closeErr := windows.CloseHandle(probe)
+	if waitErr != nil {
+		t.Fatalf("wait for process %d to exit: %v", pid, waitErr)
+	}
+	if closeErr != nil {
+		t.Fatalf("close probe handle for process %d: %v", pid, closeErr)
+	}
+	if status != windows.WAIT_OBJECT_0 {
+		t.Fatalf("wait for process %d returned status %#x, want WAIT_OBJECT_0", pid, status)
+	}
+
+	if isProcessAlive(pid) {
+		t.Fatalf("exited process %d reported alive while its parent handle remained open", pid)
+	}
+}

--- a/internal/linear/synclock_windows.go
+++ b/internal/linear/synclock_windows.go
@@ -7,10 +7,12 @@ import (
 )
 
 func isProcessAlive(pid int) bool {
-	h, err := windows.OpenProcess(windows.PROCESS_QUERY_LIMITED_INFORMATION, false, uint32(pid))
+	h, err := windows.OpenProcess(windows.SYNCHRONIZE, false, uint32(pid))
 	if err != nil {
 		return false
 	}
-	windows.CloseHandle(h)
-	return true
+	defer func() { _ = windows.CloseHandle(h) }()
+
+	status, err := windows.WaitForSingleObject(h, 0)
+	return err == nil && status == uint32(windows.WAIT_TIMEOUT)
 }

--- a/internal/linear/synclock_windows_test.go
+++ b/internal/linear/synclock_windows_test.go
@@ -1,0 +1,45 @@
+//go:build windows
+
+package linear
+
+import (
+	"os/exec"
+	"testing"
+
+	"golang.org/x/sys/windows"
+)
+
+// Keep the parent-owned process handle open after exit to reproduce the state
+// where OpenProcess succeeds for a process that is no longer running.
+func TestIsProcessAliveReportsExitedProcessWithLingeringHandleAsDead(t *testing.T) {
+	cmd := exec.Command("cmd.exe", "/c", "exit", "0")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start child process: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := cmd.Wait(); err != nil {
+			t.Errorf("reap child process: %v", err)
+		}
+	})
+
+	pid := cmd.Process.Pid
+	probe, err := windows.OpenProcess(windows.SYNCHRONIZE, false, uint32(pid))
+	if err != nil {
+		t.Fatalf("open probe handle for process %d: %v", pid, err)
+	}
+	status, waitErr := windows.WaitForSingleObject(probe, 5000)
+	closeErr := windows.CloseHandle(probe)
+	if waitErr != nil {
+		t.Fatalf("wait for process %d to exit: %v", pid, waitErr)
+	}
+	if closeErr != nil {
+		t.Fatalf("close probe handle for process %d: %v", pid, closeErr)
+	}
+	if status != windows.WAIT_OBJECT_0 {
+		t.Fatalf("wait for process %d returned status %#x, want WAIT_OBJECT_0", pid, status)
+	}
+
+	if IsProcessAlive(pid) {
+		t.Fatalf("exited process %d reported alive while its parent handle remained open", pid)
+	}
+}


### PR DESCRIPTION
## Summary

Fix the Windows process-liveness helpers in `internal/doltserver` and `internal/linear` so an exited process is not reported alive merely because its process object remains openable.

The Dolt-server helper has production callers. The matching Linear helper currently has no production caller; this patch corrects and regression-pins that existing helper without claiming a current Linear runtime effect.

Closes #4980.

## Changes

- request only the `SYNCHRONIZE` process right;
- use `WaitForSingleObject(handle, 0)` to distinguish running (`WAIT_TIMEOUT`) from exited (`WAIT_OBJECT_0`) processes;
- close every probe handle explicitly;
- add a Windows regression test in each affected package using an exited child whose parent handle deliberately remains open.

## Why `OpenProcess` success is insufficient

Windows retains a terminated process object until its final handle closes. A parent that has not called `Wait`, or another observer such as a debugger or security tool, can therefore keep a dead process openable. The previous implementation returned `true` in that state.

## Verification

The new tests first failed against `02e38d0b` in both packages with the exited PID reported alive. After the fix:

```text
go test -tags gms_pure_go ./internal/linear -run '^TestIsProcessAlive' -count=5
ok

go test -tags gms_pure_go ./internal/doltserver -run '^TestIsProcessAliveReportsExitedProcessWithLingeringHandleAsDead$' -count=5
ok

go vet -tags gms_pure_go ./internal/linear ./internal/doltserver
clean
```

The full `internal/doltserver` package passes. The full `internal/linear` package still exposes a separate, pre-existing Windows diagnostic-read failure in `TestAcquireSyncLock/second_acquire_detects_lock_held`; it is unrelated to these liveness changes and is being documented separately.

## Attribution

The wait-based design and lingering-parent-handle regression strategy build on Marco Del Pin's contributor work in #4808. That PR remains separate and untouched.

---

_codex-tui-gpt-5.6-sol-ultra on behalf of Ewen Cuthiell_
