### PR TITLE
fix(create): reject caller input that would be discarded

### DIFF
--- a/cmd/bd/create.go
+++ b/cmd/bd/create.go
@@ -46,7 +46,7 @@ var createCmd = &cobra.Command{
 	GroupID:       "issues",
 	Aliases:       []string{"new"},
 	Short:         "Create a new issue (or batch from markdown/graph JSON)",
-	Args:          validateCreateArgs,
+	Args:          cobra.MatchAll(cobra.MaximumNArgs(1), validateCreateArgs),
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -124,9 +124,12 @@ var createCmd = &cobra.Command{
 			}
 		}
 
-		description, _, err := getDescriptionFlag(cmd)
+		description, descriptionChanged, err := getDescriptionFlag(cmd)
 		if err != nil {
 			return err
+		}
+		if err := validateDescriptionUpdate(cmd, description, descriptionChanged); err != nil {
+			return HandleError("%v", err)
 		}
 
 		skills, _ := cmd.Flags().GetString("skills")
@@ -782,6 +785,7 @@ func init() {
 	createCmd.Flags().String("mol-type", "", "Molecule type: swarm (multi-agent), patrol (recurring ops), work (default)")
 	createCmd.Flags().String("wisp-type", "", "Wisp type for TTL-based compaction: heartbeat, ping, patrol, gc_report, recovery, error, escalation")
 	createCmd.Flags().Bool("validate", false, "Validate description contains required sections for issue type")
+	createCmd.Flags().Bool("allow-empty-description", false, "Allow empty description input from stdin or file")
 	// Event-specific flags (only valid when --type=event)
 	createCmd.Flags().String("event-category", "", "Event category (e.g., patrol.muted, agent.started) (requires --type=event)")
 	createCmd.Flags().String("event-actor", "", "Entity URI who caused this event (requires --type=event)")

--- a/cmd/bd/create_dispatch_test.go
+++ b/cmd/bd/create_dispatch_test.go
@@ -1,0 +1,173 @@
+//go:build cgo
+
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// TestCreateDirectModeRejectsAllowEmptyDescriptionWithFile is a regression
+// test for the 2026-07-23 CHANGES_REQUESTED review on gastownhall/beads#4984:
+// direct-mode (non-proxied) --file dispatch returned from RunE before the
+// validateDescriptionUpdate/--allow-empty-description check ever ran, so the
+// flag was silently accepted-and-ignored with --file. This asserts the guard
+// added in create.go now rejects it before createIssuesFromMarkdown runs.
+func TestCreateDirectModeRejectsAllowEmptyDescriptionWithFile(t *testing.T) {
+	saveAndRestoreGlobals(t)
+	ensureCleanGlobalState(t)
+
+	readonlyMode = false
+	t.Cleanup(func() { readonlyMode = false })
+
+	fileFlag := createCmd.Flags().Lookup("file")
+	allowEmptyFlag := createCmd.Flags().Lookup("allow-empty-description")
+	t.Cleanup(func() {
+		_ = fileFlag.Value.Set("")
+		fileFlag.Changed = false
+		_ = allowEmptyFlag.Value.Set("false")
+		allowEmptyFlag.Changed = false
+	})
+
+	tmpDir := t.TempDir()
+	mdPath := filepath.Join(tmpDir, "plan.md")
+	if err := os.WriteFile(mdPath, []byte("# Issue\n\nBody\n"), 0644); err != nil {
+		t.Fatalf("write markdown fixture: %v", err)
+	}
+
+	if err := createCmd.Flags().Set("file", mdPath); err != nil {
+		t.Fatalf("set --file: %v", err)
+	}
+	if err := createCmd.Flags().Set("allow-empty-description", "true"); err != nil {
+		t.Fatalf("set --allow-empty-description: %v", err)
+	}
+
+	var err error
+	stderr := captureStderr(t, func() {
+		err = createCmd.RunE(createCmd, nil)
+	})
+	if err == nil {
+		t.Fatal("expected direct-mode --file dispatch to reject --allow-empty-description")
+	}
+	if !strings.Contains(stderr, "--allow-empty-description is not valid with --file") {
+		t.Fatalf("expected --file rejection message on stderr, got: %v (err: %v)", stderr, err)
+	}
+}
+
+// TestCreateDirectModeRejectsAllowEmptyDescriptionWithGraph mirrors the --file
+// case above for the --graph dispatch path.
+func TestCreateDirectModeRejectsAllowEmptyDescriptionWithGraph(t *testing.T) {
+	saveAndRestoreGlobals(t)
+	ensureCleanGlobalState(t)
+
+	readonlyMode = false
+	t.Cleanup(func() { readonlyMode = false })
+
+	graphFlag := createCmd.Flags().Lookup("graph")
+	allowEmptyFlag := createCmd.Flags().Lookup("allow-empty-description")
+	t.Cleanup(func() {
+		_ = graphFlag.Value.Set("")
+		graphFlag.Changed = false
+		_ = allowEmptyFlag.Value.Set("false")
+		allowEmptyFlag.Changed = false
+	})
+
+	// The guard fires before createIssuesFromGraph reads the file, so the
+	// path need not exist or contain a valid plan.
+	graphPath := filepath.Join(t.TempDir(), "plan.json")
+
+	if err := createCmd.Flags().Set("graph", graphPath); err != nil {
+		t.Fatalf("set --graph: %v", err)
+	}
+	if err := createCmd.Flags().Set("allow-empty-description", "true"); err != nil {
+		t.Fatalf("set --allow-empty-description: %v", err)
+	}
+
+	var err error
+	stderr := captureStderr(t, func() {
+		err = createCmd.RunE(createCmd, nil)
+	})
+	if err == nil {
+		t.Fatal("expected direct-mode --graph dispatch to reject --allow-empty-description")
+	}
+	if !strings.Contains(stderr, "--allow-empty-description is not valid with --graph") {
+		t.Fatalf("expected --graph rejection message on stderr, got: %v (err: %v)", stderr, err)
+	}
+}
+
+// TestCreateSingleIssueAllowEmptyDescriptionRoundTrip exercises the opt-in
+// success path end to end: a single-issue (non --file/--graph) create with an
+// empty description read from an external source (--body-file pointing at an
+// empty file) plus --allow-empty-description should actually create the
+// issue, not merely register the flag (the review's should-fix #2: thin
+// coverage of the opt-in path).
+func TestCreateSingleIssueAllowEmptyDescriptionRoundTrip(t *testing.T) {
+	saveAndRestoreGlobals(t)
+	ensureCleanGlobalState(t)
+
+	// saveAndRestoreGlobals doesn't cover these three; restore them
+	// explicitly so this test can't contaminate the package run.
+	savedRootCtx, savedJSONOutput, savedActor := rootCtx, jsonOutput, actor
+	t.Cleanup(func() {
+		rootCtx, jsonOutput, actor = savedRootCtx, savedJSONOutput, savedActor
+	})
+
+	tmpDir := t.TempDir()
+	testDB := filepath.Join(tmpDir, ".beads", "beads.db")
+	s := newTestStore(t, testDB)
+
+	store = s
+	rootCtx = context.Background()
+	jsonOutput = false
+	readonlyMode = false
+	actor = "test-actor"
+	t.Cleanup(func() { readonlyMode = false })
+
+	bodyFilePath := filepath.Join(tmpDir, "empty-body.md")
+	if err := os.WriteFile(bodyFilePath, nil, 0644); err != nil {
+		t.Fatalf("write empty body file: %v", err)
+	}
+
+	bodyFileFlag := createCmd.Flags().Lookup("body-file")
+	allowEmptyFlag := createCmd.Flags().Lookup("allow-empty-description")
+	t.Cleanup(func() {
+		_ = bodyFileFlag.Value.Set("")
+		bodyFileFlag.Changed = false
+		_ = allowEmptyFlag.Value.Set("false")
+		allowEmptyFlag.Changed = false
+	})
+
+	if err := createCmd.Flags().Set("body-file", bodyFilePath); err != nil {
+		t.Fatalf("set --body-file: %v", err)
+	}
+	if err := createCmd.Flags().Set("allow-empty-description", "true"); err != nil {
+		t.Fatalf("set --allow-empty-description: %v", err)
+	}
+
+	title := "Allow empty description round trip"
+	if err := createCmd.RunE(createCmd, []string{title}); err != nil {
+		t.Fatalf("expected --allow-empty-description opt-in to succeed, got: %v", err)
+	}
+
+	issues, err := s.SearchIssues(rootCtx, "", types.IssueFilter{})
+	if err != nil {
+		t.Fatalf("search issues: %v", err)
+	}
+	var created bool
+	for _, iss := range issues {
+		if iss.Title == title {
+			created = true
+			if iss.Description != "" {
+				t.Fatalf("expected empty description, got %q", iss.Description)
+			}
+		}
+	}
+	if !created {
+		t.Fatalf("expected issue %q to be created via --allow-empty-description opt-in", title)
+	}
+}

--- a/cmd/bd/create_input.go
+++ b/cmd/bd/create_input.go
@@ -130,9 +130,12 @@ func gatherCreateInput(cmd *cobra.Command, args []string) (createInput, error) {
 	}
 	in.title = title
 
-	desc, _, err := getDescriptionFlag(cmd)
+	desc, descChanged, err := getDescriptionFlag(cmd)
 	if err != nil {
 		return in, err
+	}
+	if err := validateDescriptionUpdate(cmd, desc, descChanged); err != nil {
+		return in, HandleError("%v", err)
 	}
 	in.description = desc
 	skills, _ := cmd.Flags().GetString("skills")
@@ -293,6 +296,7 @@ var singleIssueOnlyFlags = []string{
 	"status",
 	"description", "body", "message", "body-file", "description-file", "stdin",
 	"design", "design-file", "acceptance", "notes", "append-notes",
+	"allow-empty-description",
 	"labels", "label", "skills", "context",
 	"event-category", "event-actor", "event-target", "event-payload",
 	"due", "defer",

--- a/cmd/bd/create_input_test.go
+++ b/cmd/bd/create_input_test.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestCreateCommandRejectsExtraPositionalArguments(t *testing.T) {
+	err := createCmd.Args(createCmd, []string{"bug", "real title"})
+	if err == nil {
+		t.Fatal("expected create to reject a second positional argument")
+	}
+	if !strings.Contains(err.Error(), "at most 1 arg") {
+		t.Fatalf("expected actionable maximum-argument error, got: %v", err)
+	}
+}
+
+func TestCreateCommandAllowsOnePositionalArgument(t *testing.T) {
+	if err := createCmd.Args(createCmd, []string{"title"}); err != nil {
+		t.Fatalf("expected create to accept a single title argument, got: %v", err)
+	}
+	// Zero args with no --file/--graph/--title fails title resolution at
+	// Args time (upstream moved title validation into Args via
+	// validateCreateArgs), not with an arg-count error.
+	if err := createCmd.Args(createCmd, nil); err == nil {
+		t.Fatal("expected title-resolution error for zero args")
+	}
+}
+
+func TestCreateCommandRegistersEmptyDescriptionOptIn(t *testing.T) {
+	if createCmd.Flags().Lookup("allow-empty-description") == nil {
+		t.Fatal("expected create to register --allow-empty-description")
+	}
+}
+
+func TestGatherCreateInputRejectsEmptyBodyFile(t *testing.T) {
+	filePath := filepath.Join(t.TempDir(), "empty.md")
+	if err := os.WriteFile(filePath, nil, 0644); err != nil {
+		t.Fatalf("write empty body file: %v", err)
+	}
+
+	cmd := &cobra.Command{Use: "create [title]"}
+	registerCommonIssueFlags(cmd)
+	cmd.Flags().Bool("allow-empty-description", false, "Allow empty description input from stdin or file")
+	if err := cmd.ParseFlags([]string{"--body-file", filePath}); err != nil {
+		t.Fatalf("parse create flags: %v", err)
+	}
+
+	_, err := gatherCreateInput(cmd, []string{"title"})
+	if err == nil {
+		t.Fatal("expected create input gathering to reject an empty body file")
+	}
+}


### PR DESCRIPTION
## What

Make create fail closed when caller-supplied input would otherwise be silently discarded:

- reject more than one positional title before RunE
- reject explicit empty stdin or file descriptions by default in both normal and proxied create paths
- preserve intentional empty external input behind --allow-empty-description
- preserve zero-title flag usage, one positional title, and intentionally omitted descriptions

## Why

Today bd create bug REAL_TITLE silently keeps bug as the title and discards REAL_TITLE. Explicit empty --body-file input similarly succeeds as though no description input was supplied. Both produce success-looking automation after data loss.

Fixes #4983.

## Verification

```text
go test -tags gms_pure_go ./cmd/bd -run Test(CreateCommand|GatherCreateInputRejectsEmptyBodyFile|ValidateDescriptionUpdate) -count=1
ok github.com/steveyegge/beads/cmd/bd
```

Isolated proxied-store CLI proof:

- extra positional: exit 1, accepts at most 1 arg
- empty body file: exit 1 with --allow-empty-description guidance
- empty body with opt-in: exit 0
- omitted description: exit 0
- persisted issue count after all dry runs: 0
