### PR TITLE
docs: fix README Mermaid diagram (rename reserved `graph` node id)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,12 @@ Beads provides a persistent, structured memory for coding agents. It replaces me
 
 ```mermaid
 flowchart LR
-    create["bd create<br/>new bead"] --> graph["dependency<br/>graph"]
-    graph --> ready["bd ready<br/>claimable work"]
+    create["bd create<br/>new bead"] --> depgraph["dependency<br/>graph"]
+    depgraph --> ready["bd ready<br/>claimable work"]
     ready --> claim["bd update --claim<br/>agent takes it"]
     claim --> close["bd close<br/>work done"]
     close -->|blockers released| ready
-    graph <-->|"bd dolt push / pull"| remote[("other machines<br/>and agents")]
+    depgraph <-->|"bd dolt push / pull"| remote[("other machines<br/>and agents")]
 ```
 
 ## ⚡ Quick Start


### PR DESCRIPTION
The README Mermaid flowchart currently fails to render on GitHub with:

```
Parse error on line 2:
...<br/>new bead"] --> graph["dependency<br
-----------------------^
Expecting ..., got 'GRAPH'
```

**Cause:** the diagram uses `graph` as a **node id**, which collides with Mermaid's reserved `graph` keyword (the legacy name for `flowchart`). The parser tokenizes the id as the `GRAPH` keyword and bails.

**Fix:** rename the node id `graph` → `depgraph` (3 references). The visible label text (`dependency<br/>graph`) and every edge are unchanged, so the rendered diagram looks identical — it just parses now.

No other content touched.