### PR TITLE
feat(gate): support bd gate check in proxied-server mode

### DIFF
--- a/cmd/bd/close.go
+++ b/cmd/bd/close.go
@@ -548,7 +548,7 @@ func checkGateSatisfaction(issue *types.Issue) error {
 
 	switch {
 	case strings.HasPrefix(issue.AwaitType, "gh:run"):
-		resolved, escalated, reason, err = checkGHRun(issue, true)
+		resolved, escalated, reason, err = checkGHRun(issue, func(gateID, runID string) error { return updateGateAwaitIDFunc(nil, gateID, runID) })
 	case strings.HasPrefix(issue.AwaitType, "gh:pr"):
 		resolved, escalated, reason, err = checkGHPR(issue)
 	case issue.AwaitType == "timer":

--- a/cmd/bd/gate.go
+++ b/cmd/bd/gate.go
@@ -561,7 +561,7 @@ Examples:
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if usesProxiedServer() {
-			return HandleErrorRespectJSON("gate check is not supported in proxied-server mode")
+			return runGateCheckProxiedServer(cmd, rootCtx)
 		}
 		CheckReadonly("gate check")
 
@@ -585,128 +585,159 @@ Examples:
 		}
 
 		ctx := rootCtx
-		var gates []*types.Issue
-		var err error
 
-		gates, err = store.SearchIssues(ctx, "", filter)
+		gates, err := store.SearchIssues(ctx, "", filter)
 		if err != nil {
 			return HandleErrorRespectJSON("%v", err)
 		}
 
-		var filteredGates []*types.Issue
-		for _, gate := range gates {
-			if shouldCheckGate(gate, gateTypeFilter) {
-				filteredGates = append(filteredGates, gate)
-			}
-		}
-
+		filteredGates := filterCheckableGates(gates, gateTypeFilter)
 		if len(filteredGates) == 0 {
-			if gateTypeFilter != "" {
-				fmt.Printf("No open gates of type '%s' found.\n", gateTypeFilter)
-			} else {
-				fmt.Println("No open gates found.")
-			}
+			printNoOpenGates(gateTypeFilter)
 			return nil
 		}
 
-		// Results tracking
-		type checkResult struct {
-			gate      *types.Issue
-			resolved  bool
-			escalated bool
-			reason    string
-			err       error
-		}
-		results := make([]checkResult, 0, len(filteredGates))
-
-		// Check each gate
-		now := time.Now()
-		for _, gate := range filteredGates {
-			result := checkResult{gate: gate}
-
-			switch {
-			case strings.HasPrefix(gate.AwaitType, "gh:run"):
-				result.resolved, result.escalated, result.reason, result.err = checkGHRun(gate, !dryRun)
-			case strings.HasPrefix(gate.AwaitType, "gh:pr"):
-				result.resolved, result.escalated, result.reason, result.err = checkGHPR(gate)
-			case gate.AwaitType == "timer":
-				result.resolved, result.escalated, result.reason, result.err = checkTimer(gate, now)
-			case gate.AwaitType == "bead":
-				result.resolved, result.reason = checkBeadGate(ctx, store, gate.AwaitID)
-			default:
-				// Skip unsupported gate types (human gates need manual resolution)
-				continue
-			}
-
-			results = append(results, result)
-		}
-
-		// Process results
-		resolvedCount := 0
-		escalatedCount := 0
-		errorCount := 0
-
-		for _, r := range results {
-			if r.err != nil {
-				errorCount++
-				fmt.Fprintf(os.Stderr, "%s %s: error checking - %v\n",
-					ui.RenderFail("✗"), r.gate.ID, r.err)
-				continue
-			}
-
-			if r.resolved {
-				resolvedCount++
-				if dryRun {
-					fmt.Printf("%s %s: would resolve - %s\n",
-						ui.RenderPass("✓"), r.gate.ID, r.reason)
-				} else {
-					// Close the gate
-					closeErr := closeGate(ctx, r.gate.ID, r.reason)
-					if closeErr != nil {
-						fmt.Fprintf(os.Stderr, "%s %s: error closing - %v\n",
-							ui.RenderFail("✗"), r.gate.ID, closeErr)
-						errorCount++
-					} else {
-						fmt.Printf("%s %s: resolved - %s\n",
-							ui.RenderPass("✓"), r.gate.ID, r.reason)
-					}
-				}
-			} else if r.escalated {
-				escalatedCount++
-				if dryRun {
-					fmt.Printf("%s %s: would escalate - %s\n",
-						ui.RenderWarn("⚠"), r.gate.ID, r.reason)
-				} else {
-					fmt.Printf("%s %s: ESCALATE - %s\n",
-						ui.RenderWarn("⚠"), r.gate.ID, r.reason)
-					// Actually escalate if flag is set
-					if escalateFlag {
-						escalateGate(r.gate, r.reason)
-					}
-				}
-			} else {
-				// Still pending
-				fmt.Printf("%s %s: pending - %s\n",
-					ui.RenderAccent("○"), r.gate.ID, r.reason)
+		var persistAwaitID func(gateID, runID string) error
+		if !dryRun {
+			persistAwaitID = func(gateID, runID string) error {
+				return updateGateAwaitIDFunc(nil, gateID, runID)
 			}
 		}
 
-		// Summary
-		fmt.Println()
-		fmt.Printf("Checked %d gates: %d resolved, %d escalated, %d errors\n",
-			len(results), resolvedCount, escalatedCount, errorCount)
+		results := evaluateGates(ctx, filteredGates, time.Now(), store, persistAwaitID)
 
-		if jsonOutput {
-			return outputJSON(map[string]interface{}{
-				"checked":   len(results),
-				"resolved":  resolvedCount,
-				"escalated": escalatedCount,
-				"errors":    errorCount,
-				"dry_run":   dryRun,
-			})
-		}
-		return nil
+		resolvedCount, escalatedCount, errorCount := applyGateCheckResults(
+			results, dryRun, escalateFlag,
+			func(gate *types.Issue, reason string) error {
+				return closeGate(ctx, gate.ID, reason)
+			},
+		)
+
+		return printGateCheckSummary(len(results), resolvedCount, escalatedCount, errorCount, dryRun)
 	},
+}
+
+// gateCheckResult is one gate's evaluation outcome, independent of the storage
+// backend that produced or will act on it.
+type gateCheckResult struct {
+	gate      *types.Issue
+	resolved  bool
+	escalated bool
+	reason    string
+	err       error
+}
+
+// filterCheckableGates keeps the gates matching the --type filter.
+func filterCheckableGates(gates []*types.Issue, typeFilter string) []*types.Issue {
+	var out []*types.Issue
+	for _, gate := range gates {
+		if shouldCheckGate(gate, typeFilter) {
+			out = append(out, gate)
+		}
+	}
+	return out
+}
+
+func printNoOpenGates(typeFilter string) {
+	if typeFilter != "" {
+		fmt.Printf("No open gates of type '%s' found.\n", typeFilter)
+	} else {
+		fmt.Println("No open gates found.")
+	}
+}
+
+// evaluateGates checks each gate's await condition. Bead gates read through
+// getter; a gh:run gate whose await_id is a workflow-name hint persists the
+// discovered numeric run id through persistAwaitID (nil under --dry-run). now is
+// passed in so timer evaluation is deterministic under test. Evaluation performs
+// no gate writes beyond persistAwaitID, so callers may run it outside a
+// transaction.
+func evaluateGates(ctx context.Context, gates []*types.Issue, now time.Time, getter issueGetter, persistAwaitID func(gateID, runID string) error) []gateCheckResult {
+	results := make([]gateCheckResult, 0, len(gates))
+	for _, gate := range gates {
+		r := gateCheckResult{gate: gate}
+		switch {
+		case strings.HasPrefix(gate.AwaitType, "gh:run"):
+			r.resolved, r.escalated, r.reason, r.err = checkGHRun(gate, persistAwaitID)
+		case strings.HasPrefix(gate.AwaitType, "gh:pr"):
+			r.resolved, r.escalated, r.reason, r.err = checkGHPR(gate)
+		case gate.AwaitType == "timer":
+			r.resolved, r.escalated, r.reason, r.err = checkTimer(gate, now)
+		case gate.AwaitType == "bead":
+			r.resolved, r.reason = checkBeadGate(ctx, getter, gate.AwaitID)
+		default:
+			// Skip unsupported gate types (human gates need manual resolution).
+			continue
+		}
+		results = append(results, r)
+	}
+	return results
+}
+
+// applyGateCheckResults renders each outcome and, unless dryRun, closes resolved
+// gates via closeResolved and escalates escalated ones when escalate is set. It
+// is storage-agnostic: closeResolved performs (or reports) the actual close.
+// Returns the resolved/escalated/error counts for the summary line.
+func applyGateCheckResults(results []gateCheckResult, dryRun, escalate bool, closeResolved func(gate *types.Issue, reason string) error) (resolvedCount, escalatedCount, errorCount int) {
+	for _, r := range results {
+		if r.err != nil {
+			errorCount++
+			fmt.Fprintf(os.Stderr, "%s %s: error checking - %v\n",
+				ui.RenderFail("✗"), r.gate.ID, r.err)
+			continue
+		}
+
+		switch {
+		case r.resolved:
+			resolvedCount++
+			if dryRun {
+				fmt.Printf("%s %s: would resolve - %s\n",
+					ui.RenderPass("✓"), r.gate.ID, r.reason)
+				continue
+			}
+			if closeErr := closeResolved(r.gate, r.reason); closeErr != nil {
+				fmt.Fprintf(os.Stderr, "%s %s: error closing - %v\n",
+					ui.RenderFail("✗"), r.gate.ID, closeErr)
+				errorCount++
+			} else {
+				fmt.Printf("%s %s: resolved - %s\n",
+					ui.RenderPass("✓"), r.gate.ID, r.reason)
+			}
+		case r.escalated:
+			escalatedCount++
+			if dryRun {
+				fmt.Printf("%s %s: would escalate - %s\n",
+					ui.RenderWarn("⚠"), r.gate.ID, r.reason)
+				continue
+			}
+			fmt.Printf("%s %s: ESCALATE - %s\n",
+				ui.RenderWarn("⚠"), r.gate.ID, r.reason)
+			if escalate {
+				escalateGate(r.gate, r.reason)
+			}
+		default:
+			fmt.Printf("%s %s: pending - %s\n",
+				ui.RenderAccent("○"), r.gate.ID, r.reason)
+		}
+	}
+	return resolvedCount, escalatedCount, errorCount
+}
+
+func printGateCheckSummary(checked, resolvedCount, escalatedCount, errorCount int, dryRun bool) error {
+	fmt.Println()
+	fmt.Printf("Checked %d gates: %d resolved, %d escalated, %d errors\n",
+		checked, resolvedCount, escalatedCount, errorCount)
+
+	if jsonOutput {
+		return outputJSON(map[string]interface{}{
+			"checked":   checked,
+			"resolved":  resolvedCount,
+			"escalated": escalatedCount,
+			"errors":    errorCount,
+			"dry_run":   dryRun,
+		})
+	}
+	return nil
 }
 
 // shouldCheckGate returns true if the gate matches the type filter
@@ -803,7 +834,7 @@ func discoverRunIDByWorkflowName(workflowHint string) (string, error) {
 
 // checkGHRun checks a GitHub Actions workflow run gate.
 // When persistDiscoveredRunID is false, workflow-name discovery stays in-memory only.
-func checkGHRun(gate *types.Issue, persistDiscoveredRunID bool) (resolved, escalated bool, reason string, err error) {
+func checkGHRun(gate *types.Issue, persistAwaitID func(gateID, runID string) error) (resolved, escalated bool, reason string, err error) {
 	if gate.AwaitID == "" {
 		return false, false, "no run ID specified - set await_id or use workflow name hint", nil
 	}
@@ -817,9 +848,9 @@ func checkGHRun(gate *types.Issue, persistDiscoveredRunID bool) (resolved, escal
 			return false, false, fmt.Sprintf("workflow hint '%s': %v", gate.AwaitID, discoverErr), nil
 		}
 
-		if persistDiscoveredRunID {
+		if persistAwaitID != nil {
 			// Non-dry-run flows persist the numeric run ID for future checks.
-			if updateErr := updateGateAwaitIDFunc(nil, gate.ID, discoveredID); updateErr != nil {
+			if updateErr := persistAwaitID(gate.ID, discoveredID); updateErr != nil {
 				return false, false, "", fmt.Errorf("failed to update gate with discovered run ID: %w", updateErr)
 			}
 		}

--- a/cmd/bd/gate.go
+++ b/cmd/bd/gate.go
@@ -617,8 +617,6 @@ Examples:
 	},
 }
 
-// gateCheckResult is one gate's evaluation outcome, independent of the storage
-// backend that produced or will act on it.
 type gateCheckResult struct {
 	gate      *types.Issue
 	resolved  bool
@@ -627,7 +625,6 @@ type gateCheckResult struct {
 	err       error
 }
 
-// filterCheckableGates keeps the gates matching the --type filter.
 func filterCheckableGates(gates []*types.Issue, typeFilter string) []*types.Issue {
 	var out []*types.Issue
 	for _, gate := range gates {
@@ -646,12 +643,6 @@ func printNoOpenGates(typeFilter string) {
 	}
 }
 
-// evaluateGates checks each gate's await condition. Bead gates read through
-// getter; a gh:run gate whose await_id is a workflow-name hint persists the
-// discovered numeric run id through persistAwaitID (nil under --dry-run). now is
-// passed in so timer evaluation is deterministic under test. Evaluation performs
-// no gate writes beyond persistAwaitID, so callers may run it outside a
-// transaction.
 func evaluateGates(ctx context.Context, gates []*types.Issue, now time.Time, getter issueGetter, persistAwaitID func(gateID, runID string) error) []gateCheckResult {
 	results := make([]gateCheckResult, 0, len(gates))
 	for _, gate := range gates {
@@ -666,7 +657,6 @@ func evaluateGates(ctx context.Context, gates []*types.Issue, now time.Time, get
 		case gate.AwaitType == "bead":
 			r.resolved, r.reason = checkBeadGate(ctx, getter, gate.AwaitID)
 		default:
-			// Skip unsupported gate types (human gates need manual resolution).
 			continue
 		}
 		results = append(results, r)
@@ -674,10 +664,6 @@ func evaluateGates(ctx context.Context, gates []*types.Issue, now time.Time, get
 	return results
 }
 
-// applyGateCheckResults renders each outcome and, unless dryRun, closes resolved
-// gates via closeResolved and escalates escalated ones when escalate is set. It
-// is storage-agnostic: closeResolved performs (or reports) the actual close.
-// Returns the resolved/escalated/error counts for the summary line.
 func applyGateCheckResults(results []gateCheckResult, dryRun, escalate bool, closeResolved func(gate *types.Issue, reason string) error) (resolvedCount, escalatedCount, errorCount int) {
 	for _, r := range results {
 		if r.err != nil {

--- a/cmd/bd/gate.go
+++ b/cmd/bd/gate.go
@@ -818,8 +818,6 @@ func discoverRunIDByWorkflowName(workflowHint string) (string, error) {
 	return fmt.Sprintf("%d", runs[0].DatabaseID), nil
 }
 
-// checkGHRun checks a GitHub Actions workflow run gate.
-// When persistDiscoveredRunID is false, workflow-name discovery stays in-memory only.
 func checkGHRun(gate *types.Issue, persistAwaitID func(gateID, runID string) error) (resolved, escalated bool, reason string, err error) {
 	if gate.AwaitID == "" {
 		return false, false, "no run ID specified - set await_id or use workflow name hint", nil

--- a/cmd/bd/gate_check_proxied_integration_test.go
+++ b/cmd/bd/gate_check_proxied_integration_test.go
@@ -1,0 +1,208 @@
+//go:build cgo
+
+package main
+
+import (
+	"context"
+	"database/sql"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// seedGateAwait rewrites a gate issue's await columns directly on the shared
+// Dolt server so proxied gate check has something to evaluate. bd gate create is
+// not available in proxied-server mode, so timer/bead/gh gates are seeded here
+// instead. createdAt/timeout only matter for timer gates; pass zero values
+// otherwise.
+func seedGateAwait(t *testing.T, db *sql.DB, id, awaitType, awaitID string, createdAt time.Time, timeout time.Duration) {
+	t.Helper()
+	if _, err := db.ExecContext(context.Background(),
+		"UPDATE issues SET await_type=?, await_id=?, timeout_ns=?, created_at=? WHERE id=?",
+		awaitType, awaitID, int64(timeout), createdAt.UTC(), id); err != nil {
+		t.Fatalf("seed await columns for %s: %v", id, err)
+	}
+}
+
+// TestProxiedServerGateCheck mirrors the embedded gate check coverage
+// (gate_check_* subtests in gate_embedded_test.go) for proxied-server mode, and
+// asserts the actual resolution behavior end-to-end rather than just that the
+// command runs.
+func TestProxiedServerGateCheck(t *testing.T) {
+	requireSharedProxiedServer(t)
+	t.Parallel()
+	bd := buildEmbeddedBD(t)
+
+	// far past / far future margins large enough that any server/client timezone
+	// skew cannot flip an expired gate into a pending one or vice versa.
+	const expiredTimeout = time.Hour
+	longAgo := func() time.Time { return time.Now().UTC().Add(-48 * time.Hour) }
+	longFuture := time.Hour * 1000
+
+	t.Run("no_gates", func(t *testing.T) {
+		t.Parallel()
+		p := newSharedProxiedProject(t, bd, "gcn")
+		out, stderr, err := bdProxiedRunBuffers(t, bd, p.dir, "gate", "check")
+		if err != nil {
+			t.Fatalf("gate check failed: %v\nstderr:\n%s", err, stderr)
+		}
+		if !strings.Contains(out, "No open gates") {
+			t.Errorf("expected 'No open gates' message, got:\n%s", out)
+		}
+	})
+
+	t.Run("timer_expired_resolves", func(t *testing.T) {
+		t.Parallel()
+		p := newSharedProxiedProject(t, bd, "gce")
+		gate := bdProxiedCreate(t, bd, p.dir, "Expired timer gate", "--type", "gate")
+		db := openProxiedDB(t, p)
+		seedGateAwait(t, db, gate.ID, "timer", "", longAgo(), expiredTimeout)
+
+		out, stderr, err := bdProxiedRunBuffers(t, bd, p.dir, "gate", "check", "--type", "timer")
+		if err != nil {
+			t.Fatalf("gate check failed: %v\nstderr:\n%s", err, stderr)
+		}
+		if got := readStatus(t, db, gate.ID); got != types.StatusClosed {
+			t.Errorf("expired timer gate should be closed, got %q", got)
+		}
+		if !strings.Contains(out, "Checked 1 gates: 1 resolved") {
+			t.Errorf("expected summary with 1 resolved, got:\n%s", out)
+		}
+	})
+
+	t.Run("timer_pending_stays_open", func(t *testing.T) {
+		t.Parallel()
+		p := newSharedProxiedProject(t, bd, "gcp")
+		gate := bdProxiedCreate(t, bd, p.dir, "Pending timer gate", "--type", "gate")
+		db := openProxiedDB(t, p)
+		seedGateAwait(t, db, gate.ID, "timer", "", time.Now().UTC(), longFuture)
+
+		out, stderr, err := bdProxiedRunBuffers(t, bd, p.dir, "gate", "check", "--type", "timer")
+		if err != nil {
+			t.Fatalf("gate check failed: %v\nstderr:\n%s", err, stderr)
+		}
+		if got := readStatus(t, db, gate.ID); got == types.StatusClosed {
+			t.Error("pending timer gate should stay open")
+		}
+		if !strings.Contains(out, "0 resolved") {
+			t.Errorf("expected 0 resolved for pending timer, got:\n%s", out)
+		}
+	})
+
+	t.Run("dry_run_does_not_close", func(t *testing.T) {
+		t.Parallel()
+		p := newSharedProxiedProject(t, bd, "gcd")
+		gate := bdProxiedCreate(t, bd, p.dir, "Dry run timer gate", "--type", "gate")
+		db := openProxiedDB(t, p)
+		seedGateAwait(t, db, gate.ID, "timer", "", longAgo(), expiredTimeout)
+
+		out, stderr, err := bdProxiedRunBuffers(t, bd, p.dir, "gate", "check", "--type", "timer", "--dry-run")
+		if err != nil {
+			t.Fatalf("gate check --dry-run failed: %v\nstderr:\n%s", err, stderr)
+		}
+		if got := readStatus(t, db, gate.ID); got == types.StatusClosed {
+			t.Error("dry-run must not close the gate")
+		}
+		if !strings.Contains(out, "would resolve") {
+			t.Errorf("expected 'would resolve' in dry-run output, got:\n%s", out)
+		}
+	})
+
+	t.Run("bead_gate_resolves_when_target_closes", func(t *testing.T) {
+		t.Parallel()
+		p := newSharedProxiedProject(t, bd, "gcb")
+		target := bdProxiedCreate(t, bd, p.dir, "Bead gate target")
+		gate := bdProxiedCreate(t, bd, p.dir, "Bead gate", "--type", "gate")
+		db := openProxiedDB(t, p)
+		seedGateAwait(t, db, gate.ID, "bead", target.ID, time.Now().UTC(), 0)
+
+		// Target still open: gate stays pending.
+		if _, stderr, err := bdProxiedRunBuffers(t, bd, p.dir, "gate", "check", "--type", "bead"); err != nil {
+			t.Fatalf("gate check (target open) failed: %v\nstderr:\n%s", err, stderr)
+		}
+		if got := readStatus(t, db, gate.ID); got == types.StatusClosed {
+			t.Error("bead gate should stay pending while target is open")
+		}
+
+		// Close the target, then the gate resolves.
+		bdProxiedClose(t, bd, p.dir, target.ID)
+		out, stderr, err := bdProxiedRunBuffers(t, bd, p.dir, "gate", "check", "--type", "bead")
+		if err != nil {
+			t.Fatalf("gate check (target closed) failed: %v\nstderr:\n%s", err, stderr)
+		}
+		if got := readStatus(t, db, gate.ID); got != types.StatusClosed {
+			t.Errorf("bead gate should resolve after target closes, got %q", got)
+		}
+		if !strings.Contains(out, "1 resolved") {
+			t.Errorf("expected 1 resolved after target close, got:\n%s", out)
+		}
+	})
+
+	t.Run("type_filter_scopes_evaluation", func(t *testing.T) {
+		t.Parallel()
+		p := newSharedProxiedProject(t, bd, "gcf")
+		timerGate := bdProxiedCreate(t, bd, p.dir, "Timer gate", "--type", "gate")
+		prGate := bdProxiedCreate(t, bd, p.dir, "PR gate", "--type", "gate")
+		db := openProxiedDB(t, p)
+		seedGateAwait(t, db, timerGate.ID, "timer", "", longAgo(), expiredTimeout)
+		seedGateAwait(t, db, prGate.ID, "gh:pr", "1", time.Now().UTC(), 0)
+
+		// --type timer must not touch the gh:pr gate (its evaluation would shell
+		// out to gh, which is unavailable here; the filter keeps it untouched).
+		if _, stderr, err := bdProxiedRunBuffers(t, bd, p.dir, "gate", "check", "--type", "timer"); err != nil {
+			t.Fatalf("gate check --type timer failed: %v\nstderr:\n%s", err, stderr)
+		}
+		if got := readStatus(t, db, timerGate.ID); got != types.StatusClosed {
+			t.Errorf("timer gate should be closed under --type timer, got %q", got)
+		}
+		if got := readStatus(t, db, prGate.ID); got == types.StatusClosed {
+			t.Error("gh:pr gate must be untouched under --type timer")
+		}
+	})
+
+	t.Run("limit_bounds_gates_checked", func(t *testing.T) {
+		t.Parallel()
+		p := newSharedProxiedProject(t, bd, "gcl")
+		db := openProxiedDB(t, p)
+		var ids []string
+		for i := 0; i < 3; i++ {
+			g := bdProxiedCreate(t, bd, p.dir, "Limit timer gate", "--type", "gate")
+			seedGateAwait(t, db, g.ID, "timer", "", longAgo(), expiredTimeout)
+			ids = append(ids, g.ID)
+		}
+
+		if _, stderr, err := bdProxiedRunBuffers(t, bd, p.dir, "gate", "check", "--type", "timer", "--limit", "1"); err != nil {
+			t.Fatalf("gate check --limit 1 failed: %v\nstderr:\n%s", err, stderr)
+		}
+		closed := 0
+		for _, id := range ids {
+			if readStatus(t, db, id) == types.StatusClosed {
+				closed++
+			}
+		}
+		if closed > 1 {
+			t.Errorf("--limit 1 should close at most 1 gate, closed %d", closed)
+		}
+	})
+
+	t.Run("timer_escalate_is_noop_and_resolves", func(t *testing.T) {
+		t.Parallel()
+		p := newSharedProxiedProject(t, bd, "gcx")
+		gate := bdProxiedCreate(t, bd, p.dir, "Escalate timer gate", "--type", "gate")
+		db := openProxiedDB(t, p)
+		seedGateAwait(t, db, gate.ID, "timer", "", longAgo(), expiredTimeout)
+
+		out, stderr, err := bdProxiedRunBuffers(t, bd, p.dir, "gate", "check", "--type", "timer", "--escalate")
+		if err != nil {
+			t.Fatalf("gate check --escalate failed: %v\nstderr:\n%s", err, stderr)
+		}
+		if got := readStatus(t, db, gate.ID); got != types.StatusClosed {
+			t.Errorf("expired timer gate should resolve with --escalate, got %q", got)
+		}
+		if strings.Contains(out, "ESCALATE") {
+			t.Errorf("timer gates never escalate; --escalate should be a no-op, got:\n%s", out)
+		}
+	})
+}

--- a/cmd/bd/gate_check_proxied_integration_test.go
+++ b/cmd/bd/gate_check_proxied_integration_test.go
@@ -12,11 +12,6 @@ import (
 	"github.com/steveyegge/beads/internal/types"
 )
 
-// seedGateAwait rewrites a gate issue's await columns directly on the shared
-// Dolt server so proxied gate check has something to evaluate. bd gate create is
-// not available in proxied-server mode, so timer/bead/gh gates are seeded here
-// instead. createdAt/timeout only matter for timer gates; pass zero values
-// otherwise.
 func seedGateAwait(t *testing.T, db *sql.DB, id, awaitType, awaitID string, createdAt time.Time, timeout time.Duration) {
 	t.Helper()
 	if _, err := db.ExecContext(context.Background(),
@@ -26,17 +21,11 @@ func seedGateAwait(t *testing.T, db *sql.DB, id, awaitType, awaitID string, crea
 	}
 }
 
-// TestProxiedServerGateCheck mirrors the embedded gate check coverage
-// (gate_check_* subtests in gate_embedded_test.go) for proxied-server mode, and
-// asserts the actual resolution behavior end-to-end rather than just that the
-// command runs.
 func TestProxiedServerGateCheck(t *testing.T) {
 	requireSharedProxiedServer(t)
 	t.Parallel()
 	bd := buildEmbeddedBD(t)
 
-	// far past / far future margins large enough that any server/client timezone
-	// skew cannot flip an expired gate into a pending one or vice versa.
 	const expiredTimeout = time.Hour
 	longAgo := func() time.Time { return time.Now().UTC().Add(-48 * time.Hour) }
 	longFuture := time.Hour * 1000
@@ -118,7 +107,6 @@ func TestProxiedServerGateCheck(t *testing.T) {
 		db := openProxiedDB(t, p)
 		seedGateAwait(t, db, gate.ID, "bead", target.ID, time.Now().UTC(), 0)
 
-		// Target still open: gate stays pending.
 		if _, stderr, err := bdProxiedRunBuffers(t, bd, p.dir, "gate", "check", "--type", "bead"); err != nil {
 			t.Fatalf("gate check (target open) failed: %v\nstderr:\n%s", err, stderr)
 		}
@@ -126,7 +114,6 @@ func TestProxiedServerGateCheck(t *testing.T) {
 			t.Error("bead gate should stay pending while target is open")
 		}
 
-		// Close the target, then the gate resolves.
 		bdProxiedClose(t, bd, p.dir, target.ID)
 		out, stderr, err := bdProxiedRunBuffers(t, bd, p.dir, "gate", "check", "--type", "bead")
 		if err != nil {
@@ -149,8 +136,6 @@ func TestProxiedServerGateCheck(t *testing.T) {
 		seedGateAwait(t, db, timerGate.ID, "timer", "", longAgo(), expiredTimeout)
 		seedGateAwait(t, db, prGate.ID, "gh:pr", "1", time.Now().UTC(), 0)
 
-		// --type timer must not touch the gh:pr gate (its evaluation would shell
-		// out to gh, which is unavailable here; the filter keeps it untouched).
 		if _, stderr, err := bdProxiedRunBuffers(t, bd, p.dir, "gate", "check", "--type", "timer"); err != nil {
 			t.Fatalf("gate check --type timer failed: %v\nstderr:\n%s", err, stderr)
 		}

--- a/cmd/bd/gate_proxied_server.go
+++ b/cmd/bd/gate_proxied_server.go
@@ -9,32 +9,38 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/steveyegge/beads/internal/audit"
+	"github.com/steveyegge/beads/internal/hooks"
 	"github.com/steveyegge/beads/internal/metrics"
 	"github.com/steveyegge/beads/internal/storage/domain"
 	"github.com/steveyegge/beads/internal/storage/uow"
 	"github.com/steveyegge/beads/internal/types"
 )
 
-// proxiedGateClose captures a resolved gate's before/after state so on_update
-// and on_close hooks can fire once, after the transaction commits.
 type proxiedGateClose struct {
-	before *types.Issue
-	after  *types.Issue
+	before    *types.Issue
+	after     *types.Issue
+	oldStatus string
+	reason    string
 }
 
-// gateCheckApply is the outcome of the write transaction, built fresh on each
-// RunTx attempt so a serialization retry never doubles it.
 type gateCheckApply struct {
 	closed    []proxiedGateClose
+	updated   []*types.Issue
 	closeErrs map[string]error
 	awaitErrs map[string]error
 }
 
-// runGateCheckProxiedServer is the proxied-server dual of the embedded gate
-// check flow. It evaluates gates outside the transaction (gate evaluation shells
-// out to `gh` and must not run under a retryable tx), then applies await-id
-// updates and gate closes inside a single uow.RunTx, and fires hooks and renders
-// output after the commit.
+type proxiedFreshReadGetter struct{}
+
+func (proxiedFreshReadGetter) GetIssue(ctx context.Context, id string) (*types.Issue, error) {
+	uw, err := proxiedOpenReadUOW(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer uw.Close(ctx)
+	return uw.IssueUseCase().GetIssue(ctx, id)
+}
+
 func runGateCheckProxiedServer(cmd *cobra.Command, ctx context.Context) error {
 	CheckReadonly("gate check")
 
@@ -61,10 +67,6 @@ func runGateCheckProxiedServer(cmd *cobra.Command, ctx context.Context) error {
 		Limit:         limit,
 	}
 
-	// Read + evaluate under a read-only unit of work. A gh:run gate that names a
-	// workflow hint records its discovered run id here for a deferred write; the
-	// callback never writes so evaluation stays side-effect free (dry runs pass
-	// nil and skip discovery persistence entirely).
 	discovered := map[string]string{}
 	var persistAwaitID func(gateID, runID string) error
 	if !dryRun {
@@ -84,15 +86,14 @@ func runGateCheckProxiedServer(cmd *cobra.Command, ctx context.Context) error {
 		return HandleErrorRespectJSON("%v", err)
 	}
 	filteredGates := filterCheckableGates(page.Items, gateTypeFilter)
+	readUW.Close(ctx)
+
 	if len(filteredGates) == 0 {
-		readUW.Close(ctx)
 		printNoOpenGates(gateTypeFilter)
 		return nil
 	}
-	results := evaluateGates(ctx, filteredGates, time.Now(), readUW.IssueUseCase(), persistAwaitID)
-	readUW.Close(ctx)
+	results := evaluateGates(ctx, filteredGates, time.Now(), proxiedFreshReadGetter{}, persistAwaitID)
 
-	// Dry run performs no writes; render straight from the evaluation.
 	if dryRun {
 		resolved, escalated, errCount := applyGateCheckResults(results, true, escalateFlag, nil)
 		return printGateCheckSummary(len(results), resolved, escalated, errCount, dryRun)
@@ -107,6 +108,10 @@ func runGateCheckProxiedServer(cmd *cobra.Command, ctx context.Context) error {
 		for gateID, runID := range discovered {
 			if err := uw.IssueUseCase().UpdateIssue(ctx, gateID, map[string]any{"await_id": runID}, actor); err != nil {
 				out.awaitErrs[gateID] = fmt.Errorf("failed to update gate with discovered run ID: %w", err)
+				continue
+			}
+			if after, getErr := uw.IssueUseCase().GetIssue(ctx, gateID); getErr == nil && after != nil {
+				out.updated = append(out.updated, after)
 			}
 		}
 
@@ -118,13 +123,20 @@ func runGateCheckProxiedServer(cmd *cobra.Command, ctx context.Context) error {
 				continue
 			}
 			before, _ := uw.IssueUseCase().GetIssue(ctx, r.gate.ID)
+			if before != nil && before.Status == types.StatusClosed {
+				continue
+			}
 			res, closeErr := uw.IssueUseCase().CloseIssue(ctx, r.gate.ID, domain.CloseIssueParams{Reason: r.reason}, actor)
 			if closeErr != nil {
 				out.closeErrs[r.gate.ID] = closeErr
 				continue
 			}
-			audit.LogFieldChange(r.gate.ID, "status", string(r.gate.Status), "closed", actor, r.reason)
-			out.closed = append(out.closed, proxiedGateClose{before: before, after: res.Issue})
+			out.closed = append(out.closed, proxiedGateClose{
+				before:    before,
+				after:     res.Issue,
+				oldStatus: string(r.gate.Status),
+				reason:    r.reason,
+			})
 		}
 
 		return out, "bd: gate check", nil
@@ -133,19 +145,21 @@ func runGateCheckProxiedServer(cmd *cobra.Command, ctx context.Context) error {
 		return HandleErrorRespectJSON("%v", err)
 	}
 
-	// Fire hooks and mark the command as a writer only after the commit lands.
+	for _, after := range applied.updated {
+		if err := fireProxiedUpdateHook(ctx, after); err != nil {
+			fmt.Fprintf(os.Stderr, "warning: %s: %v\n", after.ID, err)
+		}
+	}
 	for _, c := range applied.closed {
+		audit.LogFieldChange(c.after.ID, "status", c.oldStatus, "closed", actor, c.reason)
 		if err := fireProxiedCloseHooks(ctx, c.before, c.after); err != nil {
 			fmt.Fprintf(os.Stderr, "warning: %s: %v\n", c.after.ID, err)
 		}
 	}
-	if len(applied.closed) > 0 || len(discovered) > len(applied.awaitErrs) {
+	if len(applied.closed) > 0 || len(applied.updated) > 0 {
 		commandDidWrite.Store(true)
 	}
 
-	// Overlay transaction-time await-id write failures onto evaluation so they
-	// render as check errors, matching the embedded flow where a persistence
-	// failure supersedes the gate's resolution.
 	for i := range results {
 		if awaitErr, failed := applied.awaitErrs[results[i].gate.ID]; failed {
 			results[i].resolved = false
@@ -159,6 +173,23 @@ func runGateCheckProxiedServer(cmd *cobra.Command, ctx context.Context) error {
 			return applied.closeErrs[gate.ID]
 		})
 	return printGateCheckSummary(len(results), resolved, escalated, errCount, dryRun)
+}
+
+func fireProxiedUpdateHook(ctx context.Context, after *types.Issue) error {
+	if after == nil {
+		return nil
+	}
+	runner, err := proxiedHookRunner(ctx)
+	if err != nil {
+		return fmt.Errorf("hook runner: %w", err)
+	}
+	if runner == nil {
+		return nil
+	}
+	if err := runner.RunSync(hooks.EventUpdate, after); err != nil {
+		return fmt.Errorf("on_update hook: %w", err)
+	}
+	return nil
 }
 
 func runGateListProxiedServer(cmd *cobra.Command, ctx context.Context, args []string) error {

--- a/cmd/bd/gate_proxied_server.go
+++ b/cmd/bd/gate_proxied_server.go
@@ -2,12 +2,164 @@ package main
 
 import (
 	"context"
+	"fmt"
+	"os"
+	"time"
 
 	"github.com/spf13/cobra"
 
+	"github.com/steveyegge/beads/internal/audit"
+	"github.com/steveyegge/beads/internal/metrics"
 	"github.com/steveyegge/beads/internal/storage/domain"
+	"github.com/steveyegge/beads/internal/storage/uow"
 	"github.com/steveyegge/beads/internal/types"
 )
+
+// proxiedGateClose captures a resolved gate's before/after state so on_update
+// and on_close hooks can fire once, after the transaction commits.
+type proxiedGateClose struct {
+	before *types.Issue
+	after  *types.Issue
+}
+
+// gateCheckApply is the outcome of the write transaction, built fresh on each
+// RunTx attempt so a serialization retry never doubles it.
+type gateCheckApply struct {
+	closed    []proxiedGateClose
+	closeErrs map[string]error
+	awaitErrs map[string]error
+}
+
+// runGateCheckProxiedServer is the proxied-server dual of the embedded gate
+// check flow. It evaluates gates outside the transaction (gate evaluation shells
+// out to `gh` and must not run under a retryable tx), then applies await-id
+// updates and gate closes inside a single uow.RunTx, and fires hooks and renders
+// output after the commit.
+func runGateCheckProxiedServer(cmd *cobra.Command, ctx context.Context) error {
+	CheckReadonly("gate check")
+
+	evt := metrics.NewCommandEvent("gate-check")
+	defer func() {
+		if c := metrics.Global(); c != nil {
+			c.CloseEventAndAdd(evt)
+		}
+	}()
+
+	gateTypeFilter, _ := cmd.Flags().GetString("type")
+	dryRun, _ := cmd.Flags().GetBool("dry-run")
+	escalateFlag, _ := cmd.Flags().GetBool("escalate")
+	limit, _ := cmd.Flags().GetInt("limit")
+
+	if uowProvider == nil {
+		return HandleErrorRespectJSON("proxied-server UOW provider not initialized")
+	}
+
+	gateType := types.IssueType("gate")
+	filter := types.IssueFilter{
+		IssueType:     &gateType,
+		ExcludeStatus: []types.Status{types.StatusClosed},
+		Limit:         limit,
+	}
+
+	// Read + evaluate under a read-only unit of work. A gh:run gate that names a
+	// workflow hint records its discovered run id here for a deferred write; the
+	// callback never writes so evaluation stays side-effect free (dry runs pass
+	// nil and skip discovery persistence entirely).
+	discovered := map[string]string{}
+	var persistAwaitID func(gateID, runID string) error
+	if !dryRun {
+		persistAwaitID = func(gateID, runID string) error {
+			discovered[gateID] = runID
+			return nil
+		}
+	}
+
+	readUW, err := proxiedOpenReadUOW(ctx)
+	if err != nil {
+		return err
+	}
+	page, err := readUW.IssueUseCase().SearchIssues(ctx, "", filter)
+	if err != nil {
+		readUW.Close(ctx)
+		return HandleErrorRespectJSON("%v", err)
+	}
+	filteredGates := filterCheckableGates(page.Items, gateTypeFilter)
+	if len(filteredGates) == 0 {
+		readUW.Close(ctx)
+		printNoOpenGates(gateTypeFilter)
+		return nil
+	}
+	results := evaluateGates(ctx, filteredGates, time.Now(), readUW.IssueUseCase(), persistAwaitID)
+	readUW.Close(ctx)
+
+	// Dry run performs no writes; render straight from the evaluation.
+	if dryRun {
+		resolved, escalated, errCount := applyGateCheckResults(results, true, escalateFlag, nil)
+		return printGateCheckSummary(len(results), resolved, escalated, errCount, dryRun)
+	}
+
+	applied, err := uow.RunTxResult(ctx, uowProvider, func(ctx context.Context, uw uow.UnitOfWork) (gateCheckApply, string, error) {
+		out := gateCheckApply{
+			closeErrs: map[string]error{},
+			awaitErrs: map[string]error{},
+		}
+
+		for gateID, runID := range discovered {
+			if err := uw.IssueUseCase().UpdateIssue(ctx, gateID, map[string]any{"await_id": runID}, actor); err != nil {
+				out.awaitErrs[gateID] = fmt.Errorf("failed to update gate with discovered run ID: %w", err)
+			}
+		}
+
+		for _, r := range results {
+			if r.err != nil || !r.resolved {
+				continue
+			}
+			if _, awaitFailed := out.awaitErrs[r.gate.ID]; awaitFailed {
+				continue
+			}
+			before, _ := uw.IssueUseCase().GetIssue(ctx, r.gate.ID)
+			res, closeErr := uw.IssueUseCase().CloseIssue(ctx, r.gate.ID, domain.CloseIssueParams{Reason: r.reason}, actor)
+			if closeErr != nil {
+				out.closeErrs[r.gate.ID] = closeErr
+				continue
+			}
+			audit.LogFieldChange(r.gate.ID, "status", string(r.gate.Status), "closed", actor, r.reason)
+			out.closed = append(out.closed, proxiedGateClose{before: before, after: res.Issue})
+		}
+
+		return out, "bd: gate check", nil
+	})
+	if err != nil {
+		return HandleErrorRespectJSON("%v", err)
+	}
+
+	// Fire hooks and mark the command as a writer only after the commit lands.
+	for _, c := range applied.closed {
+		if err := fireProxiedCloseHooks(ctx, c.before, c.after); err != nil {
+			fmt.Fprintf(os.Stderr, "warning: %s: %v\n", c.after.ID, err)
+		}
+	}
+	if len(applied.closed) > 0 || len(discovered) > len(applied.awaitErrs) {
+		commandDidWrite.Store(true)
+	}
+
+	// Overlay transaction-time await-id write failures onto evaluation so they
+	// render as check errors, matching the embedded flow where a persistence
+	// failure supersedes the gate's resolution.
+	for i := range results {
+		if awaitErr, failed := applied.awaitErrs[results[i].gate.ID]; failed {
+			results[i].resolved = false
+			results[i].escalated = false
+			results[i].err = awaitErr
+		}
+	}
+
+	resolved, escalated, errCount := applyGateCheckResults(results, false, escalateFlag,
+		func(gate *types.Issue, reason string) error {
+			return applied.closeErrs[gate.ID]
+		})
+	return printGateCheckSummary(len(results), resolved, escalated, errCount, dryRun)
+}
 
 func runGateListProxiedServer(cmd *cobra.Command, ctx context.Context, args []string) error {
 	allFlag, _ := cmd.Flags().GetBool("all")

--- a/cmd/bd/gate_proxied_server.go
+++ b/cmd/bd/gate_proxied_server.go
@@ -131,10 +131,14 @@ func runGateCheckProxiedServer(cmd *cobra.Command, ctx context.Context) error {
 				out.closeErrs[r.gate.ID] = closeErr
 				continue
 			}
+			oldStatus := "open"
+			if before != nil && before.Status != "" {
+				oldStatus = string(before.Status)
+			}
 			out.closed = append(out.closed, proxiedGateClose{
 				before:    before,
 				after:     res.Issue,
-				oldStatus: string(r.gate.Status),
+				oldStatus: oldStatus,
 				reason:    r.reason,
 			})
 		}

--- a/cmd/bd/gate_test.go
+++ b/cmd/bd/gate_test.go
@@ -427,7 +427,7 @@ func TestCheckGHRun_DryRunDoesNotPersistDiscoveredRunID(t *testing.T) {
 	resolved, escalated, reason, err := checkGHRun(&types.Issue{
 		ID:      "bd-gate",
 		AwaitID: "release.yml",
-	}, false)
+	}, nil)
 	if err != nil {
 		t.Fatalf("checkGHRun returned error: %v", err)
 	}
@@ -482,7 +482,7 @@ func TestCheckGHRun_PersistsDiscoveredRunIDOutsideDryRun(t *testing.T) {
 	resolved, escalated, reason, err := checkGHRun(&types.Issue{
 		ID:      "bd-gate",
 		AwaitID: "release.yml",
-	}, true)
+	}, func(gateID, runID string) error { return updateGateAwaitIDFunc(nil, gateID, runID) })
 	if err != nil {
 		t.Fatalf("checkGHRun returned error: %v", err)
 	}
@@ -533,7 +533,7 @@ func TestCheckGHRun_ReturnsErrorWhenPersistingDiscoveredRunIDFails(t *testing.T)
 	resolved, escalated, reason, err := checkGHRun(&types.Issue{
 		ID:      "bd-gate",
 		AwaitID: "release.yml",
-	}, true)
+	}, func(gateID, runID string) error { return updateGateAwaitIDFunc(nil, gateID, runID) })
 	if err == nil {
 		t.Fatal("expected checkGHRun to return an error when await_id persistence fails")
 	}


### PR DESCRIPTION
## Summary

Adds proxied-server support for `bd gate check`, which previously errored out with `gate check is not supported in proxied-server mode`. It now has behavioral and integration-test parity with embedded mode.

No new domain/use-case methods were needed — the flow maps onto the existing `IssueUseCase` surface (`SearchIssues`, `GetIssue`, `CloseIssue`, `UpdateIssue`).

## Changes

**`cmd/bd/gate.go` — shared, storage-agnostic plumbing**
- `checkGHRun` now takes a `persistAwaitID func(gateID, runID string) error` callback instead of a `bool` (nil = dry-run / no persistence), so the embedded path can write through `store` and the proxied path can defer the write into a transaction.
- Extracted helpers reused by both modes: `filterCheckableGates`, `printNoOpenGates`, `evaluateGates` (the gh/timer/bead switch, keyed off the `issueGetter` interface both `store` and `uw.IssueUseCase()` satisfy), `applyGateCheckResults` (render + close via a callback + escalate), and `printGateCheckSummary`. The embedded `RunE` collapsed to call these.

**`cmd/bd/gate_proxied_server.go` — the proxied dual**
- `runGateCheckProxiedServer`: evaluates gates under a read UOW *outside* any transaction (gate evaluation shells out to `gh` and must not run inside a retryable `RunTx`), then applies await-id updates and gate closes inside a single `uow.RunTxResult` returning `bd: gate check` as the commit message. Hooks fire (`fireProxiedCloseHooks`) and output renders after the commit, mirroring `close_proxied_server.go`; sets `commandDidWrite`.

**Dispatch + callers**
- `gate check` dispatches to the dual instead of erroring; updated the four `checkGHRun` call sites (`close.go` + three in `gate_test.go`) for the new signature, preserving the `updateGateAwaitIDFunc` test seam.

## Tests

New `cmd/bd/gate_check_proxied_integration_test.go` — `TestProxiedServerGateCheck`, 8 parallel subtests with parity to the embedded `gate_check_*` scenarios, asserting real resolution behavior (not just that the command runs):

- `no_gates`, `timer_expired_resolves`, `timer_pending_stays_open`, `dry_run_does_not_close`, `bead_gate_resolves_when_target_closes`, `type_filter_scopes_evaluation`, `limit_bounds_gates_checked`, `timer_escalate_is_noop_and_resolves`.

Uses the shared proxied harness (`requireSharedProxiedServer` / `newSharedProxiedProject` / `bdProxiedRunBuffers` / `openProxiedDB`). Timer/bead/gh gates are seeded by writing the `await_*` columns directly through `openProxiedDB` (the `lint_stale_proxied_integration_test.go` pattern), since `bd gate create` is not available in proxied mode. `//go:build cgo` and the `TestProxiedServer` name prefix mean the shard script discovers it and it hash-distributes into one CI shard automatically.

## Verification

- `go build`, `go vet`, `golangci-lint run ./cmd/bd/` — clean.
- `BEADS_TEST_PROXIED_SERVER=1 go test -run '^TestProxiedServerGateCheck$'` — all 8 subtests pass end-to-end against a real proxied Dolt server, in parallel.
- Existing gate unit tests (`GateCheck|CheckGHRun|CheckBeadGate|Gate`) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
