### PR TITLE
test(doltserver): fix TestResolveCfgDir macOS failures — build expectations from the physical temp root

### DIFF
--- a/internal/doltserver/doltserver_test.go
+++ b/internal/doltserver/doltserver_test.go
@@ -1969,12 +1969,26 @@ func TestBuildDoltServerYAMLConfig_DebugLogLevel(t *testing.T) {
 	}
 }
 
+// physicalTempDir returns t.TempDir() with symlinks resolved. resolveCfgDir
+// deliberately normalizes doltDir via filepath.EvalSymlinks, and on macOS
+// t.TempDir() lives under /var/folders which is a symlink to
+// /private/var/folders — expected paths must be built from the physical
+// root or the comparison fails on that platform alone.
+func physicalTempDir(t *testing.T) string {
+	t.Helper()
+	dir, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatalf("EvalSymlinks(t.TempDir()): %v", err)
+	}
+	return dir
+}
+
 // TestResolveCfgDir_NeitherExists is the common case: no parent or
 // data-dir .doltcfg found on disk, so resolveCfgDir must default to
 // dataDir/.doltcfg — matching Dolt's own flag-mode default ("Assign the one
 // that exists, defaults to current if neither exist" in setupDoltConfig).
 func TestResolveCfgDir_NeitherExists(t *testing.T) {
-	doltDir := filepath.Join(t.TempDir(), "dolt")
+	doltDir := filepath.Join(physicalTempDir(t), "dolt")
 	if err := os.MkdirAll(doltDir, 0o755); err != nil {
 		t.Fatalf("mkdir doltDir: %v", err)
 	}
@@ -1998,7 +2012,7 @@ func TestResolveCfgDir_NeitherExists(t *testing.T) {
 // would otherwise silently ignore it; resolveCfgDir must find it and point
 // cfg_dir there instead of a fresh dataDir/.doltcfg.
 func TestResolveCfgDir_ParentExists(t *testing.T) {
-	root := t.TempDir()
+	root := physicalTempDir(t)
 	doltDir := filepath.Join(root, "dolt")
 	if err := os.MkdirAll(doltDir, 0o755); err != nil {
 		t.Fatalf("mkdir doltDir: %v", err)
@@ -2029,7 +2043,7 @@ func TestResolveCfgDir_ParentExists(t *testing.T) {
 // one) resolves to itself, matching flag-mode's "look in data directory"
 // branch.
 func TestResolveCfgDir_CurrentExists(t *testing.T) {
-	root := t.TempDir()
+	root := physicalTempDir(t)
 	doltDir := filepath.Join(root, "dolt")
 	if err := os.MkdirAll(doltDir, 0o755); err != nil {
 		t.Fatalf("mkdir doltDir: %v", err)
@@ -2083,7 +2097,7 @@ func TestResolveCfgDir_BothExistIsAmbiguous(t *testing.T) {
 // (not a directory) is not mistaken for a real .doltcfg dir — matches
 // Dolt's own dEnv.FS.Exists(...) check, which also requires isDir.
 func TestResolveCfgDir_FileNotDirIgnored(t *testing.T) {
-	root := t.TempDir()
+	root := physicalTempDir(t)
 	doltDir := filepath.Join(root, "dolt")
 	if err := os.MkdirAll(doltDir, 0o755); err != nil {
 		t.Fatalf("mkdir doltDir: %v", err)


### PR DESCRIPTION
## Why

Main is red: `Test (macos-latest)` fails at d7b9f4fc5 (#4986) and again at d076e6346 (a docs-only merge), so the failure is deterministic, not flake. The four `TestResolveCfgDir_*` path-comparison tests added by #4986 fail only on macOS.

## Root cause

On macOS `t.TempDir()` returns a path under `/var/folders`, which is a symlink to `/private/var/folders`. `resolveCfgDir` deliberately resolves its input through `filepath.EvalSymlinks` (parity with the dolt child process's physically tracked cwd — the #4986 round-3 review rationale documented on the function), so it returns the `/private/var/...` physical path while the tests build `want` with plain `filepath.Abs`, keeping the lexical `/var/...` form.

The implementation is behaving as specified; the tests were constructing expectations from the symlinked root. Linux PR CI could not catch this because `/tmp` is not a symlink there.

## Fix

Test-only: `physicalTempDir(t)` resolves `t.TempDir()` through `EvalSymlinks` once, and the four comparing tests build all paths from that physical root. `TestResolveCfgDir_BothExistIsAmbiguous` is untouched (it asserts only the error, no path comparison). No production code changed.

## Verification

Reproduced the macOS shape on Linux by pointing `TMPDIR` through a symlink:

- unpatched + symlinked `TMPDIR`: the exact four CI failures (`NeitherExists`, `ParentExists`, `CurrentExists`, `FileNotDirIgnored`)
- patched: green under both normal and symlinked `TMPDIR`, `-count=1`, `-tags gms_pure_go`

Stop-the-line per Base-Branch Health: while main is red this fix is the only mergeable PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

_claude-fable-5-high on behalf of matt wilkie_
