### PR TITLE
feat: support compact/gc/ping/dolt clean-databases in proxied-server mode

### DIFF
--- a/cmd/bd/compact.go
+++ b/cmd/bd/compact.go
@@ -83,7 +83,10 @@ Examples:
 `,
 	RunE: func(_ *cobra.Command, _ []string) error {
 		if usesProxiedServer() {
-			return HandleErrorRespectJSON("admin compact is not supported in proxied-server mode")
+			if compactDolt {
+				return runCompactDoltProxiedServer(rootCtx)
+			}
+			return HandleErrorRespectJSON("only 'compact --dolt' is supported in proxied-server mode")
 		}
 		// Block mutating operations in embedded mode; allow --stats, --analyze, --dry-run read-only paths.
 		if !compactStats && !compactAnalyze && !compactDryRun {

--- a/cmd/bd/compact_dolt.go
+++ b/cmd/bd/compact_dolt.go
@@ -46,7 +46,7 @@ Examples:
 	SilenceErrors: true,
 	RunE: func(_ *cobra.Command, _ []string) error {
 		if usesProxiedServer() {
-			return HandleErrorRespectJSON("compact is not supported in proxied-server mode")
+			return runCompactProxiedServer(rootCtx)
 		}
 		evt := metrics.NewCommandEvent("compact")
 		defer func() {

--- a/cmd/bd/compact_dolt_proxied_server.go
+++ b/cmd/bd/compact_dolt_proxied_server.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/steveyegge/beads/internal/storage/versioncontrolops"
+)
+
+func runCompactDoltProxiedServer(ctx context.Context) error {
+	start := time.Now()
+
+	if compactDryRun {
+		if jsonOutput {
+			return outputJSON(map[string]interface{}{
+				"dry_run": true,
+			})
+		}
+		fmt.Printf("DRY RUN - Dolt garbage collection\n\n")
+		fmt.Printf("Run without --dry-run to perform garbage collection.\n")
+		return nil
+	}
+
+	if !jsonOutput {
+		fmt.Printf("Running Dolt garbage collection...\n")
+	}
+
+	err := runProxiedNonTx(ctx, func(ctx context.Context, conn *sql.Conn) error {
+		return versioncontrolops.DoltGC(ctx, conn)
+	})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: dolt gc failed: %v\n", err)
+		return SilentExit()
+	}
+
+	elapsed := time.Since(start)
+
+	if jsonOutput {
+		return outputJSON(map[string]interface{}{
+			"success":    true,
+			"elapsed_ms": elapsed.Milliseconds(),
+		})
+	}
+
+	fmt.Printf("✓ Dolt garbage collection complete\n")
+	fmt.Printf("  Time: %v\n", elapsed)
+	return nil
+}

--- a/cmd/bd/compact_proxied_server.go
+++ b/cmd/bd/compact_proxied_server.go
@@ -1,0 +1,179 @@
+package main
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+
+	"github.com/steveyegge/beads/internal/metrics"
+	"github.com/steveyegge/beads/internal/storage"
+	"github.com/steveyegge/beads/internal/storage/versioncontrolops"
+)
+
+func runCompactProxiedServer(ctx context.Context) error {
+	evt := metrics.NewCommandEvent("compact")
+	defer func() {
+		if c := metrics.Global(); c != nil {
+			c.CloseEventAndAdd(evt)
+		}
+	}()
+
+	if !compactDoltDryRun {
+		CheckReadonly("compact")
+	}
+	start := time.Now()
+
+	if compactDoltDays < 0 {
+		return HandleError("--days must be non-negative")
+	}
+
+	var logEntries []storage.CommitInfo
+	if err := runProxiedNonTx(ctx, func(ctx context.Context, conn *sql.Conn) error {
+		var err error
+		logEntries, err = versioncontrolops.Log(ctx, conn, 0)
+		return err
+	}); err != nil {
+		return HandleError("failed to read commit log: %v", err)
+	}
+
+	totalCommits := len(logEntries)
+	if totalCommits <= 1 {
+		if jsonOutput {
+			return outputJSON(map[string]interface{}{
+				"success":       true,
+				"message":       "nothing to compact",
+				"total_commits": totalCommits,
+			})
+		}
+		fmt.Printf("Only %d commit(s). Nothing to compact.\n", totalCommits)
+		return nil
+	}
+
+	cutoff := time.Now().AddDate(0, 0, -compactDoltDays)
+
+	var oldCommits int
+	var recentHashes []string
+	for _, entry := range logEntries {
+		if entry.Date.Before(cutoff) {
+			oldCommits++
+		} else {
+			recentHashes = append(recentHashes, entry.Hash)
+		}
+	}
+	initialHash := logEntries[totalCommits-1].Hash
+	boundaryHash := ""
+	for _, entry := range logEntries {
+		if entry.Date.Before(cutoff) {
+			boundaryHash = entry.Hash
+			break
+		}
+	}
+
+	for i, j := 0, len(recentHashes)-1; i < j; i, j = i+1, j-1 {
+		recentHashes[i], recentHashes[j] = recentHashes[j], recentHashes[i]
+	}
+	recentCommits := len(recentHashes)
+
+	if compactDoltDryRun {
+		if jsonOutput {
+			return outputJSON(map[string]interface{}{
+				"dry_run":        true,
+				"total_commits":  totalCommits,
+				"old_commits":    oldCommits,
+				"recent_commits": recentCommits,
+				"cutoff_days":    compactDoltDays,
+				"cutoff_date":    cutoff.Format("2006-01-02"),
+				"initial_hash":   initialHash,
+				"boundary_hash":  boundaryHash,
+			})
+		}
+		fmt.Printf("DRY RUN — Compact preview\n\n")
+		fmt.Printf("  Total commits:  %d\n", totalCommits)
+		fmt.Printf("  Old (>%d days): %d (would be squashed into 1)\n", compactDoltDays, oldCommits)
+		fmt.Printf("  Recent:         %d (preserved)\n", recentCommits)
+		fmt.Printf("  Cutoff date:    %s\n", cutoff.Format("2006-01-02"))
+		if oldCommits <= 1 {
+			fmt.Printf("\n  Nothing to compact (0-1 old commits).\n")
+		} else {
+			fmt.Printf("\n  Result: %d commits → %d commits\n", totalCommits, recentCommits+1)
+			fmt.Printf("  Run with --force to proceed.\n")
+		}
+		return nil
+	}
+
+	if oldCommits <= 1 {
+		if jsonOutput {
+			return outputJSON(map[string]interface{}{
+				"success":       true,
+				"message":       "nothing to compact",
+				"total_commits": totalCommits,
+				"old_commits":   oldCommits,
+			})
+		}
+		fmt.Printf("Only %d old commit(s). Nothing to compact.\n", oldCommits)
+		return nil
+	}
+
+	if boundaryHash == "" {
+		return HandleError("could not find boundary commit for compaction")
+	}
+
+	if !compactDoltForce {
+		return HandleErrorWithHint(
+			fmt.Sprintf("would squash %d old commits into 1, preserving %d recent commits",
+				oldCommits, recentCommits),
+			"Use --force to confirm or --dry-run to preview.")
+	}
+
+	if !jsonOutput {
+		fmt.Printf("Compacting: %d old commits → 1, preserving %d recent\n",
+			oldCommits, recentCommits)
+	}
+
+	var pruned, tags []string
+	if err := runProxiedNonTx(ctx, func(ctx context.Context, conn *sql.Conn) error {
+		if err := versioncontrolops.Compact(ctx, conn, initialHash, boundaryHash, oldCommits, recentHashes); err != nil {
+			return err
+		}
+		var perr error
+		if pruned, perr = versioncontrolops.PruneRemoteRefs(ctx, conn); perr != nil {
+			WarnError("pruning remote-tracking refs before GC: %v (GC may reclaim little)", perr)
+		}
+		if tags, perr = versioncontrolops.ListTags(ctx, conn); perr != nil {
+			WarnError("listing tags before GC: %v", perr)
+		}
+		if perr := versioncontrolops.DoltGC(ctx, conn); perr != nil {
+			WarnError("dolt gc after compact failed: %v", perr)
+		}
+		return nil
+	}); err != nil {
+		return HandleError("compact failed: %v", err)
+	}
+
+	elapsed := time.Since(start)
+	resultCommits := recentCommits + 1
+
+	if !jsonOutput {
+		printPruneReport(pruned, tags)
+	}
+
+	if jsonOutput {
+		return outputJSON(map[string]interface{}{
+			"success":            true,
+			"commits_before":     totalCommits,
+			"commits_after":      resultCommits,
+			"old_squashed":       oldCommits,
+			"recent_kept":        recentCommits,
+			"remote_refs_pruned": len(pruned),
+			"tags_anchoring":     len(tags),
+			"elapsed_ms":         elapsed.Milliseconds(),
+		})
+	}
+
+	fmt.Printf("✓ Compacted %d commits → %d\n", totalCommits, resultCommits)
+	fmt.Printf("  Squashed: %d old commits → 1 base\n", oldCommits)
+	fmt.Printf("  Preserved: %d recent commits\n", recentCommits)
+	fmt.Printf("  Time: %v\n", elapsed.Round(time.Millisecond))
+	return nil
+}

--- a/cmd/bd/dolt.go
+++ b/cmd/bd/dolt.go
@@ -1018,6 +1018,10 @@ Use --dry-run to see what would be dropped without actually dropping.`,
 		}
 		dryRun, _ := cmd.Flags().GetBool("dry-run")
 
+		if usesProxiedServer() {
+			return runDoltCleanDatabasesProxied(rootCtx, beadsDir, dryRun)
+		}
+
 		// Connect directly to the Dolt server via config instead of getStore(),
 		// which isn't initialized for dolt subcommands (beads-9vt).
 		db, cleanup, err := openDoltServerConnection()

--- a/cmd/bd/dolt_clean_databases_proxied_server.go
+++ b/cmd/bd/dolt_clean_databases_proxied_server.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/steveyegge/beads/internal/storage/uow"
+)
+
+func runDoltCleanDatabasesProxied(ctx context.Context, beadsDir string, dryRun bool) error {
+	provider, err := newProxiedServerUOWProvider(ctx, beadsDir)
+	if err != nil {
+		return HandleError("failed to open uow provider: %v", err)
+	}
+	defer func() { _ = provider.Close(ctx) }()
+
+	mp, ok := provider.(uow.MaintenanceProvider)
+	if !ok {
+		return HandleError("proxied-server provider does not support maintenance operations")
+	}
+
+	return mp.RunNonTx(ctx, func(ctx context.Context, conn *sql.Conn) error {
+		listCtx, listCancel := context.WithTimeout(ctx, 30*time.Second)
+		defer listCancel()
+
+		rows, err := conn.QueryContext(listCtx, "SHOW DATABASES")
+		if err != nil {
+			return HandleError("listing databases: %v", err)
+		}
+		defer rows.Close()
+
+		var stale []string
+		for rows.Next() {
+			var dbName string
+			if err := rows.Scan(&dbName); err != nil {
+				continue
+			}
+			for _, prefix := range staleDatabasePrefixes {
+				if strings.HasPrefix(dbName, prefix) {
+					stale = append(stale, dbName)
+					break
+				}
+			}
+		}
+		if err := rows.Err(); err != nil {
+			return HandleError("listing databases: %v", err)
+		}
+
+		if len(stale) == 0 {
+			fmt.Println("No stale databases found.")
+			return nil
+		}
+
+		fmt.Printf("Found %d stale databases:\n", len(stale))
+		for _, name := range stale {
+			fmt.Printf("  %s\n", name)
+		}
+
+		if dryRun {
+			fmt.Println("\n(dry run — no databases dropped)")
+			return nil
+		}
+
+		fmt.Println()
+		dropped := 0
+		for _, name := range stale {
+			dropCtx, dropCancel := context.WithTimeout(ctx, 30*time.Second)
+			safeName := strings.ReplaceAll(name, "`", "``")
+			_, err := conn.ExecContext(dropCtx, fmt.Sprintf("DROP DATABASE `%s`", safeName)) //nolint:gosec // G201: identifier-escaped
+			dropCancel()
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "  FAIL: %s: %v\n", name, err)
+			} else {
+				fmt.Printf("  Dropped: %s\n", name)
+				dropped++
+			}
+		}
+		fmt.Printf("\nDropped %d/%d stale databases.\n", dropped, len(stale))
+		return nil
+	})
+}

--- a/cmd/bd/dolt_clean_databases_proxied_server.go
+++ b/cmd/bd/dolt_clean_databases_proxied_server.go
@@ -37,7 +37,7 @@ func runDoltCleanDatabasesProxied(ctx context.Context, beadsDir string, dryRun b
 		for rows.Next() {
 			var dbName string
 			if err := rows.Scan(&dbName); err != nil {
-				continue
+				return HandleError("scanning database name: %v", err)
 			}
 			for _, prefix := range staleDatabasePrefixes {
 				if strings.HasPrefix(dbName, prefix) {

--- a/cmd/bd/gc.go
+++ b/cmd/bd/gc.go
@@ -43,7 +43,7 @@ Examples:
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, _ []string) error {
 		if usesProxiedServer() {
-			return HandleErrorRespectJSON("gc is not supported in proxied-server mode")
+			return runGCProxiedServer(rootCtx)
 		}
 		evt := metrics.NewCommandEvent("gc")
 		defer func() {

--- a/cmd/bd/gc_proxied_server.go
+++ b/cmd/bd/gc_proxied_server.go
@@ -40,6 +40,7 @@ func runGCProxiedServer(ctx context.Context) error {
 		detail  string
 	}
 	var results []phaseResult
+	var gcFailed bool
 
 	if gcSkipDecay {
 		results = append(results, phaseResult{name: "Decay", skipped: true})
@@ -170,6 +171,7 @@ func runGCProxiedServer(ctx context.Context) error {
 			if err != nil {
 				WarnError("dolt gc failed: %v", err)
 				results = append(results, phaseResult{name: "Dolt GC", detail: "failed"})
+				gcFailed = true
 			} else {
 				if !jsonOutput {
 					fmt.Println("  Done (complete)")
@@ -187,6 +189,7 @@ func runGCProxiedServer(ctx context.Context) error {
 	if jsonOutput {
 		summaryMap := make(map[string]interface{})
 		summaryMap["dry_run"] = gcDryRun
+		summaryMap["success"] = !gcFailed
 		summaryMap["elapsed_ms"] = elapsed.Milliseconds()
 		phases := make([]map[string]interface{}, 0, len(results))
 		for _, r := range results {
@@ -200,12 +203,21 @@ func runGCProxiedServer(ctx context.Context) error {
 			phases = append(phases, p)
 		}
 		summaryMap["phases"] = phases
-		return outputJSON(summaryMap)
+		if err := outputJSON(summaryMap); err != nil {
+			return err
+		}
+		if gcFailed {
+			return SilentExit()
+		}
+		return nil
 	}
 
 	mode := "✓ GC complete"
-	if gcDryRun {
+	switch {
+	case gcDryRun:
 		mode = "DRY RUN complete"
+	case gcFailed:
+		mode = "⚠ GC completed with errors"
 	}
 	fmt.Printf("%s (%v)\n", mode, elapsed.Round(time.Millisecond))
 	for _, r := range results {
@@ -214,6 +226,9 @@ func runGCProxiedServer(ctx context.Context) error {
 		} else {
 			fmt.Printf("  %s: %s\n", r.name, r.detail)
 		}
+	}
+	if gcFailed {
+		return SilentExit()
 	}
 	return nil
 }
@@ -227,6 +242,13 @@ func scalarCount(res *domain.RawSQLResult) int {
 		return int(v)
 	case int:
 		return v
+	case uint64:
+		return int(v)
+	case float64:
+		return int(v)
+	case []byte:
+		n, _ := strconv.Atoi(string(v))
+		return n
 	case string:
 		n, _ := strconv.Atoi(v)
 		return n

--- a/cmd/bd/gc_proxied_server.go
+++ b/cmd/bd/gc_proxied_server.go
@@ -1,0 +1,236 @@
+package main
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/steveyegge/beads/internal/metrics"
+	"github.com/steveyegge/beads/internal/storage/domain"
+	"github.com/steveyegge/beads/internal/storage/uow"
+	"github.com/steveyegge/beads/internal/storage/versioncontrolops"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+func runGCProxiedServer(ctx context.Context) error {
+	evt := metrics.NewCommandEvent("gc")
+	defer func() {
+		if c := metrics.Global(); c != nil {
+			c.CloseEventAndAdd(evt)
+		}
+	}()
+
+	if !gcDryRun {
+		CheckReadonly("gc")
+	}
+	if uowProvider == nil {
+		return HandleErrorRespectJSON("proxied-server UOW provider not initialized")
+	}
+	start := time.Now()
+
+	if gcOlderThan < 0 {
+		return HandleErrorRespectJSON("--older-than must be non-negative")
+	}
+
+	type phaseResult struct {
+		name    string
+		skipped bool
+		detail  string
+	}
+	var results []phaseResult
+
+	if gcSkipDecay {
+		results = append(results, phaseResult{name: "Decay", skipped: true})
+	} else {
+		if !jsonOutput {
+			fmt.Println("Phase 1/3: Decay (delete old closed issues)")
+		}
+
+		cutoffDays := gcOlderThan
+		cutoffTime := time.Now().UTC().AddDate(0, 0, -cutoffDays)
+		statusClosed := types.StatusClosed
+		filter := types.IssueFilter{
+			Status:       &statusClosed,
+			ClosedBefore: &cutoffTime,
+		}
+
+		closedIssues, err := uow.RunTxRead(ctx, uowProvider, func(ctx context.Context, uw uow.UnitOfWork) ([]*types.Issue, error) {
+			page, err := uw.IssueUseCase().SearchIssues(ctx, "", filter)
+			if err != nil {
+				return nil, err
+			}
+			return page.Items, nil
+		})
+		if err != nil {
+			return HandleErrorRespectJSON("searching closed issues: %v", err)
+		}
+
+		var stats closedDeletionCandidateStats
+		closedIssues, stats = filterClosedDeletionCandidates(closedIssues, &cutoffTime)
+		warnClosedDeletionSafetySkips(stats)
+
+		switch {
+		case len(closedIssues) == 0:
+			if !jsonOutput {
+				fmt.Printf("  No closed issues older than %d days\n", cutoffDays)
+			}
+			results = append(results, phaseResult{name: "Decay", detail: "0 issues deleted"})
+		case gcDryRun:
+			if !jsonOutput {
+				fmt.Printf("  Would delete %d closed issue(s)\n", len(closedIssues))
+			}
+			results = append(results, phaseResult{name: "Decay", detail: fmt.Sprintf("%d issues (dry-run)", len(closedIssues))})
+		case !gcForce:
+			return HandleErrorWithHintRespectJSON(
+				fmt.Sprintf("would delete %d closed issue(s) older than %d days", len(closedIssues), cutoffDays),
+				"Use --force to confirm or --dry-run to preview.")
+		default:
+			ids := make([]string, len(closedIssues))
+			for i, issue := range closedIssues {
+				ids[i] = issue.ID
+			}
+			deleteResult, err := uow.RunTxResult(ctx, uowProvider, func(ctx context.Context, uw uow.UnitOfWork) (domain.DeleteIssuesResult, string, error) {
+				res, err := uw.IssueUseCase().DeleteIssues(ctx, domain.DeleteIssuesParams{IDs: ids}, actor)
+				if err != nil {
+					return domain.DeleteIssuesResult{}, "", err
+				}
+				return res, fmt.Sprintf("bd: gc decay %d issue(s)", res.DeletedCount), nil
+			})
+			if err != nil {
+				return HandleErrorRespectJSON("deleting closed issues: %v", err)
+			}
+			commandDidWrite.Store(true)
+			if !jsonOutput {
+				fmt.Printf("  Deleted %d issue(s)\n", deleteResult.DeletedCount)
+			}
+			results = append(results, phaseResult{name: "Decay", detail: fmt.Sprintf("%d issues deleted", deleteResult.DeletedCount)})
+		}
+		if !jsonOutput {
+			fmt.Println()
+		}
+	}
+
+	if !jsonOutput {
+		fmt.Println("Phase 2/3: Compact (Dolt commit history info)")
+	}
+
+	commitCount, logErr := uow.RunTxRead(ctx, uowProvider, func(ctx context.Context, uw uow.UnitOfWork) (int, error) {
+		res, err := uw.RawSQLUseCase().Query(ctx, "SELECT COUNT(*) FROM dolt_log")
+		if err != nil {
+			return 0, err
+		}
+		return scalarCount(res), nil
+	})
+	if logErr != nil {
+		WarnError("could not read Dolt commit log: %v", logErr)
+		commitCount = 0
+	}
+
+	if commitCount <= 1 {
+		if !jsonOutput {
+			fmt.Printf("  Only %d commit(s), nothing to compact\n\n", commitCount)
+		}
+		results = append(results, phaseResult{name: "Compact", detail: "nothing to compact"})
+	} else if gcDryRun {
+		if !jsonOutput {
+			fmt.Printf("  %d commits in history (use bd flatten to squash)\n\n", commitCount)
+		}
+		results = append(results, phaseResult{name: "Compact", detail: fmt.Sprintf("%d commits (dry-run)", commitCount)})
+	} else {
+		if !jsonOutput {
+			fmt.Printf("  %d commits in history\n", commitCount)
+			fmt.Printf("  Tip: use 'bd flatten' to squash all history to one commit\n\n")
+		}
+		results = append(results, phaseResult{name: "Compact", detail: fmt.Sprintf("%d commits", commitCount)})
+	}
+
+	if gcSkipDolt {
+		results = append(results, phaseResult{name: "Dolt GC", skipped: true})
+	} else {
+		if !jsonOutput {
+			fmt.Println("Phase 3/3: Dolt GC (reclaim disk space)")
+		}
+		if gcDryRun {
+			if !jsonOutput {
+				fmt.Println("  Would run DOLT_GC() and DOLT_STATS_GC()")
+			}
+			results = append(results, phaseResult{name: "Dolt GC", detail: "dry-run"})
+		} else {
+			err := runProxiedNonTx(ctx, func(ctx context.Context, conn *sql.Conn) error {
+				if err := versioncontrolops.DoltGC(ctx, conn); err != nil {
+					return err
+				}
+				if _, err := conn.ExecContext(ctx, "CALL DOLT_STATS_GC()"); err != nil {
+					return fmt.Errorf("dolt_stats_gc: %w", err)
+				}
+				return nil
+			})
+			if err != nil {
+				WarnError("dolt gc failed: %v", err)
+				results = append(results, phaseResult{name: "Dolt GC", detail: "failed"})
+			} else {
+				if !jsonOutput {
+					fmt.Println("  Done (complete)")
+				}
+				results = append(results, phaseResult{name: "Dolt GC", detail: "complete"})
+			}
+		}
+		if !jsonOutput {
+			fmt.Println()
+		}
+	}
+
+	elapsed := time.Since(start)
+
+	if jsonOutput {
+		summaryMap := make(map[string]interface{})
+		summaryMap["dry_run"] = gcDryRun
+		summaryMap["elapsed_ms"] = elapsed.Milliseconds()
+		phases := make([]map[string]interface{}, 0, len(results))
+		for _, r := range results {
+			p := map[string]interface{}{
+				"name":    r.name,
+				"skipped": r.skipped,
+			}
+			if r.detail != "" {
+				p["detail"] = r.detail
+			}
+			phases = append(phases, p)
+		}
+		summaryMap["phases"] = phases
+		return outputJSON(summaryMap)
+	}
+
+	mode := "✓ GC complete"
+	if gcDryRun {
+		mode = "DRY RUN complete"
+	}
+	fmt.Printf("%s (%v)\n", mode, elapsed.Round(time.Millisecond))
+	for _, r := range results {
+		if r.skipped {
+			fmt.Printf("  %s: skipped\n", r.name)
+		} else {
+			fmt.Printf("  %s: %s\n", r.name, r.detail)
+		}
+	}
+	return nil
+}
+
+func scalarCount(res *domain.RawSQLResult) int {
+	if res == nil || len(res.Rows) == 0 || len(res.Rows[0]) == 0 {
+		return 0
+	}
+	switch v := res.Rows[0][0].(type) {
+	case int64:
+		return int(v)
+	case int:
+		return v
+	case string:
+		n, _ := strconv.Atoi(v)
+		return n
+	default:
+		return 0
+	}
+}

--- a/cmd/bd/maintenance_commands_proxied_integration_test.go
+++ b/cmd/bd/maintenance_commands_proxied_integration_test.go
@@ -3,10 +3,24 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 	"testing"
 )
+
+func parseProxiedJSONObject(t *testing.T, stdout string) map[string]interface{} {
+	t.Helper()
+	start := strings.Index(stdout, "{")
+	if start < 0 {
+		t.Fatalf("no JSON object found in output:\n%s", stdout)
+	}
+	var m map[string]interface{}
+	if err := json.Unmarshal([]byte(stdout[start:]), &m); err != nil {
+		t.Fatalf("failed to parse JSON object: %v\nraw: %s", err, stdout[start:])
+	}
+	return m
+}
 
 func TestProxiedServerPing(t *testing.T) {
 	requireSharedProxiedServer(t)
@@ -90,6 +104,52 @@ func TestProxiedServerGC(t *testing.T) {
 			t.Errorf("expected --force hint in refusal, got:\n%s\n%s", stdout, stderr)
 		}
 	})
+
+	t.Run("skip_decay", func(t *testing.T) {
+		stdout, stderr, err := bdProxiedRunBuffers(t, bd, p.dir, "gc", "--dry-run", "--skip-decay")
+		if err != nil {
+			t.Fatalf("bd gc --skip-decay failed: %v\nstdout:\n%s\nstderr:\n%s", err, stdout, stderr)
+		}
+		if !strings.Contains(stdout, "Decay: skipped") {
+			t.Errorf("expected 'Decay: skipped', got: %s", stdout)
+		}
+	})
+
+	t.Run("skip_dolt", func(t *testing.T) {
+		stdout, stderr, err := bdProxiedRunBuffers(t, bd, p.dir, "gc", "--dry-run", "--skip-dolt")
+		if err != nil {
+			t.Fatalf("bd gc --skip-dolt failed: %v\nstdout:\n%s\nstderr:\n%s", err, stdout, stderr)
+		}
+		if !strings.Contains(stdout, "Dolt GC: skipped") {
+			t.Errorf("expected 'Dolt GC: skipped', got: %s", stdout)
+		}
+	})
+
+	t.Run("json_summary", func(t *testing.T) {
+		stdout, stderr, err := bdProxiedRunBuffers(t, bd, p.dir, "gc", "--dry-run", "--json")
+		if err != nil {
+			t.Fatalf("bd gc --json failed: %v\nstdout:\n%s\nstderr:\n%s", err, stdout, stderr)
+		}
+		m := parseProxiedJSONObject(t, stdout)
+		if m["dry_run"] != true {
+			t.Errorf("expected dry_run=true, got: %v", m["dry_run"])
+		}
+		phases, ok := m["phases"].([]interface{})
+		if !ok || len(phases) != 3 {
+			t.Fatalf("expected 3 phases in JSON, got: %v", m["phases"])
+		}
+		names := map[string]bool{}
+		for _, ph := range phases {
+			if pm, ok := ph.(map[string]interface{}); ok {
+				names[fmt.Sprintf("%v", pm["name"])] = true
+			}
+		}
+		for _, want := range []string{"Decay", "Compact", "Dolt GC"} {
+			if !names[want] {
+				t.Errorf("expected phase %q in JSON, got: %v", want, names)
+			}
+		}
+	})
 }
 
 func TestProxiedServerCompactDolt(t *testing.T) {
@@ -144,6 +204,20 @@ func TestProxiedServerCompactHistory(t *testing.T) {
 		}
 	})
 
+	t.Run("json_dry_run", func(t *testing.T) {
+		stdout, stderr, err := bdProxiedRunBuffers(t, bd, p.dir, "compact", "--days", "0", "--dry-run", "--json")
+		if err != nil {
+			t.Fatalf("compact --dry-run --json failed: %v\nstdout:\n%s\nstderr:\n%s", err, stdout, stderr)
+		}
+		m := parseProxiedJSONObject(t, stdout)
+		if m["dry_run"] != true {
+			t.Errorf("expected dry_run=true, got: %v", m["dry_run"])
+		}
+		if _, ok := m["total_commits"]; !ok {
+			t.Errorf("expected total_commits field, got: %v", m)
+		}
+	})
+
 	t.Run("refuses_without_force", func(t *testing.T) {
 		stdout, stderr, err := bdProxiedRunBuffers(t, bd, p.dir, "compact", "--days", "0")
 		if err == nil {
@@ -178,6 +252,16 @@ func TestProxiedServerCompactHistory(t *testing.T) {
 			}
 		}
 	})
+
+	t.Run("nothing_to_compact_when_all_recent", func(t *testing.T) {
+		stdout, stderr, err := bdProxiedRunBuffers(t, bd, p.dir, "compact", "--days", "3650", "--force")
+		if err != nil {
+			t.Fatalf("compact --days 3650 failed: %v\nstdout:\n%s\nstderr:\n%s", err, stdout, stderr)
+		}
+		if !strings.Contains(stdout, "Nothing to compact") {
+			t.Errorf("expected 'Nothing to compact', got: %s", stdout)
+		}
+	})
 }
 
 func proxiedCommitCount(t *testing.T, bd string, p proxiedProject) int {
@@ -205,8 +289,20 @@ func TestProxiedServerCleanDatabases(t *testing.T) {
 	bd := buildEmbeddedBD(t)
 	p := newSharedProxiedProject(t, bd, "clean")
 
-	staleDB := fmt.Sprintf("testdb_clean_probe_%s", strings.ReplaceAll(p.database, "bdtest_", ""))
+	suffix := strings.ReplaceAll(p.database, "bdtest_", "")
+	staleDB := fmt.Sprintf("testdb_clean_probe_%s", suffix)
+	keepDB := fmt.Sprintf("keepdb_clean_probe_%s", suffix)
 	bdProxiedSQL(t, bd, p.dir, "CREATE DATABASE "+staleDB)
+	bdProxiedSQL(t, bd, p.dir, "CREATE DATABASE "+keepDB)
+	t.Cleanup(func() {
+		_, _, _ = bdProxiedRunBuffers(t, bd, p.dir, "sql", "DROP DATABASE IF EXISTS `"+keepDB+"`")
+	})
+
+	databaseExists := func(name string) bool {
+		rows := bdProxiedSQLJSON(t, bd, p.dir,
+			"SELECT COUNT(*) as count FROM information_schema.schemata WHERE schema_name = '"+name+"'")
+		return len(rows) == 1 && sqlValueEquals(rows[0]["count"], 1)
+	}
 
 	t.Run("dry_run_lists_without_dropping", func(t *testing.T) {
 		stdout, stderr, err := bdProxiedRunBuffers(t, bd, p.dir, "dolt", "clean-databases", "--dry-run")
@@ -216,9 +312,15 @@ func TestProxiedServerCleanDatabases(t *testing.T) {
 		if !strings.Contains(stdout, staleDB) || !strings.Contains(stdout, "dry run") {
 			t.Errorf("expected dry-run to list %s, got: %s", staleDB, stdout)
 		}
+		if strings.Contains(stdout, keepDB) {
+			t.Errorf("dry-run should not list non-stale %s, got: %s", keepDB, stdout)
+		}
+		if !databaseExists(staleDB) {
+			t.Errorf("dry-run must not drop %s", staleDB)
+		}
 	})
 
-	t.Run("drops_stale_database", func(t *testing.T) {
+	t.Run("drops_stale_leaves_non_stale", func(t *testing.T) {
 		stdout, stderr, err := bdProxiedRunBuffers(t, bd, p.dir, "dolt", "clean-databases")
 		if err != nil {
 			t.Fatalf("clean-databases failed: %v\nstdout:\n%s\nstderr:\n%s", err, stdout, stderr)
@@ -226,11 +328,27 @@ func TestProxiedServerCleanDatabases(t *testing.T) {
 		if !strings.Contains(stdout, "Dropped: "+staleDB) {
 			t.Errorf("expected %s dropped, got: %s", staleDB, stdout)
 		}
+		if strings.Contains(stdout, keepDB) {
+			t.Errorf("clean-databases must not touch non-stale %s, got: %s", keepDB, stdout)
+		}
+		if databaseExists(staleDB) {
+			t.Errorf("expected %s gone", staleDB)
+		}
+		if !databaseExists(keepDB) {
+			t.Errorf("expected non-stale %s to survive", keepDB)
+		}
+	})
 
-		rows := bdProxiedSQLJSON(t, bd, p.dir,
-			"SELECT COUNT(*) as count FROM information_schema.schemata WHERE schema_name = '"+staleDB+"'")
-		if len(rows) != 1 || !sqlValueEquals(rows[0]["count"], 0) {
-			t.Errorf("expected %s gone, got: %v", staleDB, rows)
+	t.Run("empty_case_reports_none", func(t *testing.T) {
+		stdout, stderr, err := bdProxiedRunBuffers(t, bd, p.dir, "dolt", "clean-databases")
+		if err != nil {
+			t.Fatalf("clean-databases (empty) failed: %v\nstdout:\n%s\nstderr:\n%s", err, stdout, stderr)
+		}
+		if !strings.Contains(stdout, "No stale databases found") {
+			t.Errorf("expected 'No stale databases found', got: %s", stdout)
+		}
+		if !databaseExists(keepDB) {
+			t.Errorf("expected non-stale %s to survive empty run", keepDB)
 		}
 	})
 }

--- a/cmd/bd/maintenance_commands_proxied_integration_test.go
+++ b/cmd/bd/maintenance_commands_proxied_integration_test.go
@@ -1,0 +1,156 @@
+//go:build cgo
+
+package main
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestProxiedServerPing(t *testing.T) {
+	requireSharedProxiedServer(t)
+	t.Parallel()
+	bd := buildEmbeddedBD(t)
+	p := newSharedProxiedProject(t, bd, "ping")
+
+	t.Run("human", func(t *testing.T) {
+		stdout, stderr, err := bdProxiedRunBuffers(t, bd, p.dir, "ping")
+		if err != nil {
+			t.Fatalf("bd ping failed: %v\nstdout:\n%s\nstderr:\n%s", err, stdout, stderr)
+		}
+		if !strings.Contains(stdout, "bd ping: ok") {
+			t.Errorf("expected 'bd ping: ok' in output, got: %s", stdout)
+		}
+	})
+
+	t.Run("json", func(t *testing.T) {
+		stdout, stderr, err := bdProxiedRunBuffers(t, bd, p.dir, "ping", "--json")
+		if err != nil {
+			t.Fatalf("bd ping --json failed: %v\nstdout:\n%s\nstderr:\n%s", err, stdout, stderr)
+		}
+		if !strings.Contains(stdout, `"status": "ok"`) {
+			t.Errorf("expected status ok in JSON, got: %s", stdout)
+		}
+	})
+}
+
+func TestProxiedServerGC(t *testing.T) {
+	requireSharedProxiedServer(t)
+	t.Parallel()
+	bd := buildEmbeddedBD(t)
+	p := newSharedProxiedProject(t, bd, "gc")
+
+	t.Run("dry_run_all_phases", func(t *testing.T) {
+		stdout, stderr, err := bdProxiedRunBuffers(t, bd, p.dir, "gc", "--dry-run")
+		if err != nil {
+			t.Fatalf("bd gc --dry-run failed: %v\nstdout:\n%s\nstderr:\n%s", err, stdout, stderr)
+		}
+		for _, want := range []string{"Phase 1/3", "Phase 2/3", "Phase 3/3", "DRY RUN complete"} {
+			if !strings.Contains(stdout, want) {
+				t.Errorf("expected %q in gc --dry-run output, got: %s", want, stdout)
+			}
+		}
+	})
+
+	t.Run("decay_deletes_closed_issue", func(t *testing.T) {
+		issue := bdProxiedCreate(t, bd, p.dir, "decay me", "--type", "task")
+		bdProxiedClose(t, bd, p.dir, issue.ID)
+		bdProxiedSQL(t, bd, p.dir,
+			"UPDATE issues SET closed_at = '2000-01-01 00:00:00' WHERE id = '"+issue.ID+"'")
+
+		stdout, stderr, err := bdProxiedRunBuffers(t, bd, p.dir,
+			"gc", "--older-than", "1", "--skip-dolt", "--force")
+		if err != nil {
+			t.Fatalf("bd gc decay failed: %v\nstdout:\n%s\nstderr:\n%s", err, stdout, stderr)
+		}
+		if !strings.Contains(stdout, "Deleted 1 issue") {
+			t.Errorf("expected 'Deleted 1 issue' in output, got: %s", stdout)
+		}
+
+		rows := bdProxiedSQLJSON(t, bd, p.dir,
+			"SELECT COUNT(*) as count FROM issues WHERE id = '"+issue.ID+"'")
+		if len(rows) != 1 || !sqlValueEquals(rows[0]["count"], 0) {
+			t.Errorf("expected deleted issue gone, got: %v", rows)
+		}
+	})
+
+	t.Run("refuses_without_force", func(t *testing.T) {
+		issue := bdProxiedCreate(t, bd, p.dir, "keep me", "--type", "task")
+		bdProxiedClose(t, bd, p.dir, issue.ID)
+		bdProxiedSQL(t, bd, p.dir,
+			"UPDATE issues SET closed_at = '2000-01-01 00:00:00' WHERE id = '"+issue.ID+"'")
+
+		stdout, stderr, err := bdProxiedRunBuffers(t, bd, p.dir,
+			"gc", "--older-than", "1", "--skip-dolt")
+		if err == nil {
+			t.Fatalf("bd gc without --force should have failed\nstdout:\n%s", stdout)
+		}
+		if !strings.Contains(stdout+stderr, "--force") {
+			t.Errorf("expected --force hint in refusal, got:\n%s\n%s", stdout, stderr)
+		}
+	})
+}
+
+func TestProxiedServerCompactDolt(t *testing.T) {
+	requireSharedProxiedServer(t)
+	t.Parallel()
+	bd := buildEmbeddedBD(t)
+	p := newSharedProxiedProject(t, bd, "compact")
+
+	t.Run("dolt_dry_run", func(t *testing.T) {
+		stdout, stderr, err := bdProxiedRunBuffers(t, bd, p.dir, "admin", "compact", "--dolt", "--dry-run")
+		if err != nil {
+			t.Fatalf("bd admin compact --dolt --dry-run failed: %v\nstdout:\n%s\nstderr:\n%s", err, stdout, stderr)
+		}
+		if !strings.Contains(stdout, "Dolt garbage collection") {
+			t.Errorf("expected dry-run GC message, got: %s", stdout)
+		}
+	})
+
+	t.Run("non_dolt_mode_rejected", func(t *testing.T) {
+		stdout, stderr, err := bdProxiedRunBuffers(t, bd, p.dir, "admin", "compact", "--stats")
+		if err == nil {
+			t.Fatalf("bd admin compact --stats should be rejected in proxied mode\nstdout:\n%s", stdout)
+		}
+		if !strings.Contains(stdout+stderr, "only 'compact --dolt' is supported") {
+			t.Errorf("expected scoped rejection message, got:\n%s\n%s", stdout, stderr)
+		}
+	})
+}
+
+func TestProxiedServerCleanDatabases(t *testing.T) {
+	requireSharedProxiedServer(t)
+	t.Parallel()
+	bd := buildEmbeddedBD(t)
+	p := newSharedProxiedProject(t, bd, "clean")
+
+	staleDB := fmt.Sprintf("testdb_clean_probe_%s", strings.ReplaceAll(p.database, "bdtest_", ""))
+	bdProxiedSQL(t, bd, p.dir, "CREATE DATABASE "+staleDB)
+
+	t.Run("dry_run_lists_without_dropping", func(t *testing.T) {
+		stdout, stderr, err := bdProxiedRunBuffers(t, bd, p.dir, "dolt", "clean-databases", "--dry-run")
+		if err != nil {
+			t.Fatalf("clean-databases --dry-run failed: %v\nstdout:\n%s\nstderr:\n%s", err, stdout, stderr)
+		}
+		if !strings.Contains(stdout, staleDB) || !strings.Contains(stdout, "dry run") {
+			t.Errorf("expected dry-run to list %s, got: %s", staleDB, stdout)
+		}
+	})
+
+	t.Run("drops_stale_database", func(t *testing.T) {
+		stdout, stderr, err := bdProxiedRunBuffers(t, bd, p.dir, "dolt", "clean-databases")
+		if err != nil {
+			t.Fatalf("clean-databases failed: %v\nstdout:\n%s\nstderr:\n%s", err, stdout, stderr)
+		}
+		if !strings.Contains(stdout, "Dropped: "+staleDB) {
+			t.Errorf("expected %s dropped, got: %s", staleDB, stdout)
+		}
+
+		rows := bdProxiedSQLJSON(t, bd, p.dir,
+			"SELECT COUNT(*) as count FROM information_schema.schemata WHERE schema_name = '"+staleDB+"'")
+		if len(rows) != 1 || !sqlValueEquals(rows[0]["count"], 0) {
+			t.Errorf("expected %s gone, got: %v", staleDB, rows)
+		}
+	})
+}

--- a/cmd/bd/maintenance_commands_proxied_integration_test.go
+++ b/cmd/bd/maintenance_commands_proxied_integration_test.go
@@ -275,7 +275,9 @@ func proxiedCommitCount(t *testing.T, bd string, p proxiedProject) int {
 		return int(v)
 	case string:
 		n := 0
-		fmt.Sscanf(v, "%d", &n)
+		if _, err := fmt.Sscanf(v, "%d", &n); err != nil {
+			t.Fatalf("failed to parse commit count %q: %v", v, err)
+		}
 		return n
 	default:
 		t.Fatalf("unexpected count type %T: %v", v, v)

--- a/cmd/bd/maintenance_commands_proxied_integration_test.go
+++ b/cmd/bd/maintenance_commands_proxied_integration_test.go
@@ -119,6 +119,86 @@ func TestProxiedServerCompactDolt(t *testing.T) {
 	})
 }
 
+func TestProxiedServerCompactHistory(t *testing.T) {
+	requireSharedProxiedServer(t)
+	t.Parallel()
+	bd := buildEmbeddedBD(t)
+	p := newSharedProxiedProject(t, bd, "cphist")
+
+	for _, title := range []string{"keep-alpha", "keep-beta", "keep-gamma"} {
+		bdProxiedCreate(t, bd, p.dir, title, "--type", "task")
+	}
+
+	commitsBefore := proxiedCommitCount(t, bd, p)
+	if commitsBefore <= 1 {
+		t.Fatalf("expected multiple commits before compaction, got %d", commitsBefore)
+	}
+
+	t.Run("dry_run_previews", func(t *testing.T) {
+		stdout, stderr, err := bdProxiedRunBuffers(t, bd, p.dir, "compact", "--days", "0", "--dry-run")
+		if err != nil {
+			t.Fatalf("compact --dry-run failed: %v\nstdout:\n%s\nstderr:\n%s", err, stdout, stderr)
+		}
+		if !strings.Contains(stdout, "DRY RUN") || !strings.Contains(stdout, "Run with --force") {
+			t.Errorf("expected dry-run preview, got: %s", stdout)
+		}
+	})
+
+	t.Run("refuses_without_force", func(t *testing.T) {
+		stdout, stderr, err := bdProxiedRunBuffers(t, bd, p.dir, "compact", "--days", "0")
+		if err == nil {
+			t.Fatalf("compact without --force should have failed\nstdout:\n%s", stdout)
+		}
+		if !strings.Contains(stdout+stderr, "--force") {
+			t.Errorf("expected --force hint, got:\n%s\n%s", stdout, stderr)
+		}
+	})
+
+	t.Run("squashes_and_preserves_data", func(t *testing.T) {
+		stdout, stderr, err := bdProxiedRunBuffers(t, bd, p.dir, "compact", "--days", "0", "--force")
+		if err != nil {
+			t.Fatalf("compact --force failed: %v\nstdout:\n%s\nstderr:\n%s", err, stdout, stderr)
+		}
+		if !strings.Contains(stdout, "Compacted") {
+			t.Errorf("expected 'Compacted' summary, got: %s", stdout)
+		}
+
+		commitsAfter := proxiedCommitCount(t, bd, p)
+		if commitsAfter >= commitsBefore {
+			t.Errorf("expected fewer commits after compaction: before=%d after=%d", commitsBefore, commitsAfter)
+		}
+
+		rows := bdProxiedSQLJSON(t, bd, p.dir, "SELECT title FROM issues ORDER BY title")
+		if len(rows) != 3 {
+			t.Fatalf("expected 3 issues to survive compaction, got %d: %v", len(rows), rows)
+		}
+		for i, want := range []string{"keep-alpha", "keep-beta", "keep-gamma"} {
+			if rows[i]["title"] != want {
+				t.Errorf("issue %d: expected %q, got %q", i, want, rows[i]["title"])
+			}
+		}
+	})
+}
+
+func proxiedCommitCount(t *testing.T, bd string, p proxiedProject) int {
+	t.Helper()
+	rows := bdProxiedSQLJSON(t, bd, p.dir, "SELECT COUNT(*) as count FROM dolt_log")
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 row from dolt_log count, got %d", len(rows))
+	}
+	switch v := rows[0]["count"].(type) {
+	case float64:
+		return int(v)
+	case string:
+		n := 0
+		fmt.Sscanf(v, "%d", &n)
+		return n
+	default:
+		t.Fatalf("unexpected count type %T: %v", v, v)
+		return 0
+	}
+}
+
 func TestProxiedServerCleanDatabases(t *testing.T) {
 	requireSharedProxiedServer(t)
 	t.Parallel()

--- a/cmd/bd/ping.go
+++ b/cmd/bd/ping.go
@@ -34,7 +34,7 @@ Examples:
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if usesProxiedServer() {
-			return HandleErrorRespectJSON("ping is not supported in proxied-server mode")
+			return runPingProxiedServer(rootCtx)
 		}
 		evt := metrics.NewCommandEvent("ping")
 		defer func() {

--- a/cmd/bd/ping_proxied_server.go
+++ b/cmd/bd/ping_proxied_server.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/steveyegge/beads/internal/beads"
+	"github.com/steveyegge/beads/internal/metrics"
+	"github.com/steveyegge/beads/internal/storage/domain"
+	"github.com/steveyegge/beads/internal/storage/uow"
+	"github.com/steveyegge/beads/internal/ui"
+)
+
+func runPingProxiedServer(ctx context.Context) error {
+	evt := metrics.NewCommandEvent("ping")
+	defer func() {
+		if c := metrics.Global(); c != nil {
+			c.CloseEventAndAdd(evt)
+		}
+	}()
+
+	start := time.Now()
+
+	beadsDir := beads.FindBeadsDir()
+	if beadsDir == "" {
+		return pingFail(start, "no .beads directory found")
+	}
+	resolveMs := time.Since(start).Milliseconds()
+
+	if uowProvider == nil {
+		return pingFail(start, "proxied-server UOW provider not initialized")
+	}
+	storeMs := time.Since(start).Milliseconds()
+
+	_, err := uow.RunTxRead(ctx, uowProvider, func(ctx context.Context, uw uow.UnitOfWork) (*domain.RawSQLResult, error) {
+		return uw.RawSQLUseCase().Query(ctx, "SELECT 1")
+	})
+	if err != nil {
+		return pingFail(start, fmt.Sprintf("query failed: %v", err))
+	}
+	totalMs := time.Since(start).Milliseconds()
+	queryMs := totalMs - storeMs
+
+	if jsonOutput {
+		return outputJSON(map[string]interface{}{
+			"status":     "ok",
+			"resolve_ms": resolveMs,
+			"store_ms":   storeMs - resolveMs,
+			"query_ms":   queryMs,
+			"total_ms":   totalMs,
+		})
+	}
+
+	fmt.Fprintf(os.Stdout, "%s bd ping: ok (%dms)\n", ui.RenderPass("✓"), totalMs)
+	return nil
+}

--- a/cmd/bd/proxied_maintenance.go
+++ b/cmd/bd/proxied_maintenance.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/steveyegge/beads/internal/storage/uow"
+)
+
+func runProxiedNonTx(ctx context.Context, fn func(ctx context.Context, conn *sql.Conn) error) error {
+	if uowProvider == nil {
+		return HandleError("proxied-server UOW provider not initialized")
+	}
+	mp, ok := uowProvider.(uow.MaintenanceProvider)
+	if !ok {
+		return HandleError("proxied-server provider does not support maintenance operations")
+	}
+	return mp.RunNonTx(ctx, fn)
+}

--- a/cmd/bd/proxied_maintenance.go
+++ b/cmd/bd/proxied_maintenance.go
@@ -9,11 +9,11 @@ import (
 
 func runProxiedNonTx(ctx context.Context, fn func(ctx context.Context, conn *sql.Conn) error) error {
 	if uowProvider == nil {
-		return HandleError("proxied-server UOW provider not initialized")
+		return HandleErrorRespectJSON("proxied-server UOW provider not initialized")
 	}
 	mp, ok := uowProvider.(uow.MaintenanceProvider)
 	if !ok {
-		return HandleError("proxied-server provider does not support maintenance operations")
+		return HandleErrorRespectJSON("proxied-server provider does not support maintenance operations")
 	}
 	return mp.RunNonTx(ctx, fn)
 }

--- a/internal/storage/uow/maintenance.go
+++ b/internal/storage/uow/maintenance.go
@@ -1,0 +1,22 @@
+package uow
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+)
+
+type MaintenanceProvider interface {
+	RunNonTx(ctx context.Context, fn func(ctx context.Context, conn *sql.Conn) error) error
+}
+
+var _ MaintenanceProvider = (*doltSQLProvider)(nil)
+
+func (p *doltSQLProvider) RunNonTx(ctx context.Context, fn func(ctx context.Context, conn *sql.Conn) error) error {
+	conn, err := p.db.Conn(ctx)
+	if err != nil {
+		return fmt.Errorf("uow: pin connection: %w", err)
+	}
+	defer func() { _ = conn.Close() }()
+	return fn(ctx, conn)
+}


### PR DESCRIPTION
## Summary

Adds proxied-server-mode support for four maintenance commands that previously hard-rejected (or silently mishandled) proxied mode: **`bd ping`**, **`bd gc`**, **`bd compact`** (both the top-level history-squash and `bd admin compact --dolt`), and **`bd dolt clean-databases`**.

In proxied mode the CLI talks to a per-workspace TCP proxy fronting a Dolt SQL server and runs everything through the `uowProvider` rather than the legacy `storage.Store`. Each command now follows the established `if usesProxiedServer() { return runXProxiedServer(...) }` dual pattern.

## Core infrastructure

Several of these operations (`CALL DOLT_GC`, `CALL DOLT_STATS_GC`, `DROP DATABASE`, and the `DOLT_BRANCH`/`DOLT_RESET`/`DOLT_CHERRY_PICK` squash sequence) **cannot run inside an explicit transaction**, but the proxied `uowProvider` opens `START TRANSACTION` eagerly. So we add a non-transactional path:

- `internal/storage/uow/maintenance.go` — `MaintenanceProvider` interface + `doltSQLProvider.RunNonTx`, which pins a raw `*sql.Conn` (no `START TRANSACTION`).
- `cmd/bd/proxied_maintenance.go` — `runProxiedNonTx` command-layer helper.

A `*sql.Conn` satisfies `versioncontrolops.DBConn`, so the existing SQL-based version-control ops (`Compact`, `Log`, `DoltGC`, `PruneRemoteRefs`, `ListTags`) are reused directly — no duplicated logic.

## Per-command

| Command | Behavior in proxied mode |
|---|---|
| `bd ping` | Trivial `SELECT 1` round-trip via `RunTxRead`; human + JSON output |
| `bd gc` | All 3 phases: decay (`IssueUseCase` search+delete), compact-info (`SELECT COUNT(*) FROM dolt_log`), Dolt GC (`DOLT_GC` + `DOLT_STATS_GC` on a non-tx conn) |
| `bd compact` (top-level) | Full commit-history squash via `versioncontrolops.Compact` on one pinned conn, then prune remote refs + Dolt GC |
| `bd admin compact --dolt` | Dolt GC via SQL; other modes return a clear scoped rejection |
| `bd dolt clean-databases` | `SHOW DATABASES` / `DROP DATABASE` on a non-tx conn (builds its own provider, since `bd dolt` subcommands skip provider init) |

## Testing

New gated integration suite `maintenance_commands_proxied_integration_test.go` (runs with `BEADS_TEST_PROXIED_SERVER=1`) covering, per command: dry-run, real mutation with data-preservation/idempotence checks, refuse-without-force, skip flags, JSON output, and the clean-databases non-stale-DB safety guarantee. This brings proxied coverage to meet-or-exceed the (weaker/absent) embedded tests for these commands.

Verified end-to-end on a real managed proxied workspace. `go build`, `go vet`, `gofmt`, and `golangci-lint` (0 issues) all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
