### PR TITLE
bd sql (proxied-server): multi-statement batches and --database flag

### DIFF
--- a/cmd/bd/sql.go
+++ b/cmd/bd/sql.go
@@ -29,6 +29,11 @@ The query is passed directly to the database. SELECT queries return results as a
 table (or JSON/CSV with --json/--csv). Non-SELECT queries (INSERT, UPDATE, DELETE)
 report the number of rows affected.
 
+Multiple statements separated by ';' run as a single committed batch and report
+"OK". In proxied-server mode, --database runs the query against a different
+server database (equivalent to a session USE) without changing the project's
+configured database.
+
 WARNING: Direct database access bypasses the storage layer. Use with caution.`,
 	Args:          cobra.ExactArgs(1),
 	SilenceUsage:  true,
@@ -46,9 +51,14 @@ WARNING: Direct database access bypasses the storage layer. Use with caution.`,
 		}
 		query := args[0]
 		csvOutput, _ := cmd.Flags().GetBool("csv")
+		database, _ := cmd.Flags().GetString("database")
 
 		if usesProxiedServer() {
-			return runSQLProxiedServer(rootCtx, query, csvOutput)
+			return runSQLProxiedServer(rootCtx, query, csvOutput, database)
+		}
+
+		if database != "" {
+			return HandleErrorRespectJSON("--database is only supported in proxied-server mode")
 		}
 
 		if store == nil {
@@ -223,6 +233,7 @@ WARNING: Direct database access bypasses the storage layer. Use with caution.`,
 
 func init() {
 	sqlCmd.Flags().Bool("csv", false, "Output results in CSV format")
+	sqlCmd.Flags().String("database", "", "Run the query against a different server database (proxied-server mode only)")
 
 	// Register as a read-only command for SELECT queries.
 	// Write queries will be caught by CheckReadonly.

--- a/cmd/bd/sql_multistatement_proxied_integration_test.go
+++ b/cmd/bd/sql_multistatement_proxied_integration_test.go
@@ -68,3 +68,59 @@ func TestProxiedServerMultiStatementSQL(t *testing.T) {
 		t.Fatalf("multi-statement --json should not include rows_affected: %q", s)
 	}
 }
+
+func TestProxiedServerSQLDatabaseFlag(t *testing.T) {
+	requireProxiedServerEnv(t)
+
+	bd := buildEmbeddedBD(t)
+	p := bdProxiedInit(t, bd, "df")
+
+	// Stand up a second database with a table, alongside the project database.
+	db := openProxiedDB(t, p)
+	for _, q := range []string{
+		"CREATE DATABASE IF NOT EXISTS df_other",
+		"USE df_other; CREATE TABLE widgets (id INT PRIMARY KEY, name VARCHAR(32))",
+	} {
+		if _, err := db.ExecContext(context.Background(), q); err != nil {
+			t.Fatalf("setup %q: %v", q, err)
+		}
+	}
+
+	// A single write routed to the other database with --database.
+	out, err := bdProxiedRun(t, bd, p.dir, "sql", "--database", "df_other",
+		"INSERT INTO widgets VALUES (1, 'gear')")
+	if err != nil {
+		t.Fatalf("bd sql --database write failed: %v\n%s", err, out)
+	}
+	if got := strings.TrimSpace(string(out)); got != "OK, 1 rows affected" {
+		t.Fatalf("--database write output = %q, want %q", got, "OK, 1 rows affected")
+	}
+
+	// The write must have committed in df_other, not the project database.
+	var n int
+	if err := db.QueryRowContext(context.Background(),
+		"SELECT COUNT(*) FROM df_other.widgets WHERE name = 'gear'").Scan(&n); err != nil {
+		t.Fatalf("count df_other.widgets: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("df_other.widgets rows = %d, want 1 (--database write not committed there)", n)
+	}
+
+	// A read routed with --database against an unqualified table name resolves
+	// in the switched database and renders results.
+	out, err = bdProxiedRun(t, bd, p.dir, "sql", "--database", "df_other",
+		"SELECT name FROM widgets WHERE id = 1")
+	if err != nil {
+		t.Fatalf("bd sql --database read failed: %v\n%s", err, out)
+	}
+	if s := string(out); !strings.Contains(s, "gear") {
+		t.Fatalf("--database read output missing 'gear':\n%s", s)
+	}
+
+	// An invalid database identifier is rejected, not interpolated.
+	out, err = bdProxiedRun(t, bd, p.dir, "sql", "--database", "bad;name",
+		"SELECT 1")
+	if err == nil {
+		t.Fatalf("expected --database with invalid identifier to fail; got:\n%s", out)
+	}
+}

--- a/cmd/bd/sql_multistatement_proxied_integration_test.go
+++ b/cmd/bd/sql_multistatement_proxied_integration_test.go
@@ -1,0 +1,70 @@
+//go:build cgo
+
+package main
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestProxiedServerMultiStatementSQL(t *testing.T) {
+	requireProxiedServerEnv(t)
+
+	bd := buildEmbeddedBD(t)
+	p := bdProxiedInit(t, bd, "ms")
+
+	// A multi-statement batch is treated as a write: it executes and commits
+	// atomically, and reports "OK" with no rows-affected count.
+	batch := "CREATE TABLE ms_t (id INT PRIMARY KEY); INSERT INTO ms_t VALUES (1); INSERT INTO ms_t VALUES (2)"
+	out, err := bdProxiedRun(t, bd, p.dir, "sql", batch)
+	if err != nil {
+		t.Fatalf("bd sql multi-statement failed: %v\n%s", err, out)
+	}
+	got := strings.TrimSpace(string(out))
+	if got != "OK" {
+		t.Fatalf("multi-statement output = %q, want %q", got, "OK")
+	}
+
+	// Both inserts must have committed.
+	db := openProxiedDB(t, p)
+	var n int
+	if err := db.QueryRowContext(context.Background(), "SELECT COUNT(*) FROM ms_t").Scan(&n); err != nil {
+		t.Fatalf("count ms_t: %v", err)
+	}
+	if n != 2 {
+		t.Fatalf("ms_t row count = %d, want 2 (multi-statement writes not committed)", n)
+	}
+
+	// A single write still reports the affected-row count.
+	out, err = bdProxiedRun(t, bd, p.dir, "sql", "INSERT INTO ms_t VALUES (3)")
+	if err != nil {
+		t.Fatalf("bd sql single write failed: %v\n%s", err, out)
+	}
+	if got := strings.TrimSpace(string(out)); got != "OK, 1 rows affected" {
+		t.Fatalf("single-write output = %q, want %q", got, "OK, 1 rows affected")
+	}
+
+	// A single read still renders a result table.
+	out, err = bdProxiedRun(t, bd, p.dir, "sql", "SELECT COUNT(*) AS c FROM ms_t")
+	if err != nil {
+		t.Fatalf("bd sql single read failed: %v\n%s", err, out)
+	}
+	if s := string(out); !strings.Contains(s, "c") || !strings.Contains(s, "3") {
+		t.Fatalf("single-read output missing rendered result:\n%s", s)
+	}
+
+	// Multi-statement with --json reports a status object, not rows_affected.
+	out, err = bdProxiedRun(t, bd, p.dir, "sql", "--json",
+		"INSERT INTO ms_t VALUES (4); INSERT INTO ms_t VALUES (5)")
+	if err != nil {
+		t.Fatalf("bd sql --json multi-statement failed: %v\n%s", err, out)
+	}
+	s := string(out)
+	if !strings.Contains(s, "\"status\"") || !strings.Contains(s, "ok") {
+		t.Fatalf("multi-statement --json output = %q, want a status:ok object", s)
+	}
+	if strings.Contains(s, "rows_affected") {
+		t.Fatalf("multi-statement --json should not include rows_affected: %q", s)
+	}
+}

--- a/cmd/bd/sql_multistatement_test.go
+++ b/cmd/bd/sql_multistatement_test.go
@@ -1,0 +1,56 @@
+package main
+
+import "testing"
+
+func TestTopLevelStatementCount(t *testing.T) {
+	cases := []struct {
+		name  string
+		query string
+		want  int
+	}{
+		{"single", "SELECT 1", 1},
+		{"single_trailing_semicolon", "SELECT 1;", 1},
+		{"single_multiline", "SELECT id, title\nFROM issues\nWHERE status = 'open'", 1},
+		{"two", "SELECT 1; SELECT 2", 2},
+		{"two_trailing", "SELECT 1; SELECT 2;", 2},
+		{"three_writes", "INSERT INTO t VALUES (1); INSERT INTO t VALUES (2); UPDATE t SET id=3;", 3},
+		{"semicolon_in_single_quote", "SELECT ';'", 1},
+		{"semicolon_in_double_quote", "SELECT \";;;\" AS x", 1},
+		{"semicolon_in_backtick", "SELECT 1 AS `a;b`", 1},
+		{"escaped_quote", "SELECT 'it\\'s; fine'", 1},
+		{"doubled_quote", "SELECT 'it''s; fine'", 1},
+		{"line_comment_dashes", "SELECT 1 -- a; b\n", 1},
+		{"hash_comment", "SELECT 1 # a; b\n", 1},
+		{"block_comment", "SELECT 1 /* a; b; c */", 1},
+		{"block_comment_then_stmt", "SELECT 1 /* ; */; SELECT 2", 2},
+		{"empty", "", 0},
+		{"only_semicolons", ";;;", 0},
+		{"whitespace_between", "  SELECT 1 ;  SELECT 2  ", 2},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := topLevelStatementCount(tc.query); got != tc.want {
+				t.Errorf("topLevelStatementCount(%q) = %d, want %d", tc.query, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestIsMultiStatementSQL(t *testing.T) {
+	cases := []struct {
+		query string
+		want  bool
+	}{
+		{"SELECT 1", false},
+		{"SELECT 1;", false},
+		{"SELECT id\nFROM issues", false},
+		{"SELECT 1; SELECT 2", true},
+		{"DELETE FROM t; DELETE FROM u", true},
+		{"SELECT ';'", false},
+	}
+	for _, tc := range cases {
+		if got := isMultiStatementSQL(tc.query); got != tc.want {
+			t.Errorf("isMultiStatementSQL(%q) = %v, want %v", tc.query, got, tc.want)
+		}
+	}
+}

--- a/cmd/bd/sql_proxied_server.go
+++ b/cmd/bd/sql_proxied_server.go
@@ -16,7 +16,9 @@ func runSQLProxiedServer(ctx context.Context, query string, csvOutput bool) erro
 		return HandleError("proxied-server UOW provider not initialized")
 	}
 
-	if sqlQueryIsRead(query) {
+	multiStatement := isMultiStatementSQL(query)
+
+	if !multiStatement && sqlQueryIsRead(query) {
 		result, err := uow.RunTxRead(ctx, uowProvider, func(ctx context.Context, uw uow.UnitOfWork) (*domain.RawSQLResult, error) {
 			return uw.RawSQLUseCase().Query(ctx, query)
 		})
@@ -39,6 +41,16 @@ func runSQLProxiedServer(ctx context.Context, query string, csvOutput bool) erro
 		return HandleErrorRespectJSON("exec error: %v", err)
 	}
 
+	if multiStatement {
+		if jsonOutput {
+			return outputJSON(map[string]interface{}{
+				"status": "ok",
+			})
+		}
+		fmt.Println("OK")
+		return nil
+	}
+
 	if jsonOutput {
 		return outputJSON(map[string]interface{}{
 			"rows_affected": affected,
@@ -47,6 +59,79 @@ func runSQLProxiedServer(ctx context.Context, query string, csvOutput bool) erro
 
 	fmt.Printf("OK, %d rows affected\n", affected)
 	return nil
+}
+
+func isMultiStatementSQL(query string) bool {
+	return topLevelStatementCount(query) > 1
+}
+
+func topLevelStatementCount(query string) int {
+	count := 0
+	hasContent := false
+	n := len(query)
+	for i := 0; i < n; {
+		c := query[i]
+		switch c {
+		case '\'', '"', '`':
+			quote := c
+			i++
+			for i < n {
+				if query[i] == '\\' && quote != '`' {
+					i += 2
+					continue
+				}
+				if query[i] == quote {
+					if i+1 < n && query[i+1] == quote {
+						i += 2
+						continue
+					}
+					i++
+					break
+				}
+				i++
+			}
+			hasContent = true
+		case '-':
+			if i+1 < n && query[i+1] == '-' && (i+2 >= n || query[i+2] == ' ' || query[i+2] == '\t' || query[i+2] == '\n' || query[i+2] == '\r') {
+				for i < n && query[i] != '\n' {
+					i++
+				}
+			} else {
+				hasContent = true
+				i++
+			}
+		case '#':
+			for i < n && query[i] != '\n' {
+				i++
+			}
+		case '/':
+			if i+1 < n && query[i+1] == '*' {
+				i += 2
+				for i+1 < n && !(query[i] == '*' && query[i+1] == '/') {
+					i++
+				}
+				i += 2
+			} else {
+				hasContent = true
+				i++
+			}
+		case ';':
+			if hasContent {
+				count++
+				hasContent = false
+			}
+			i++
+		case ' ', '\t', '\n', '\r':
+			i++
+		default:
+			hasContent = true
+			i++
+		}
+	}
+	if hasContent {
+		count++
+	}
+	return count
 }
 
 func sqlQueryIsRead(query string) bool {

--- a/cmd/bd/sql_proxied_server.go
+++ b/cmd/bd/sql_proxied_server.go
@@ -11,7 +11,7 @@ import (
 	"github.com/steveyegge/beads/internal/storage/uow"
 )
 
-func runSQLProxiedServer(ctx context.Context, query string, csvOutput bool) error {
+func runSQLProxiedServer(ctx context.Context, query string, csvOutput bool, database string) error {
 	if uowProvider == nil {
 		return HandleError("proxied-server UOW provider not initialized")
 	}
@@ -20,6 +20,11 @@ func runSQLProxiedServer(ctx context.Context, query string, csvOutput bool) erro
 
 	if !multiStatement && sqlQueryIsRead(query) {
 		result, err := uow.RunTxRead(ctx, uowProvider, func(ctx context.Context, uw uow.UnitOfWork) (*domain.RawSQLResult, error) {
+			if database != "" {
+				if err := uw.SwitchDatabase(ctx, database); err != nil {
+					return nil, err
+				}
+			}
 			return uw.RawSQLUseCase().Query(ctx, query)
 		})
 		if err != nil {
@@ -31,6 +36,11 @@ func runSQLProxiedServer(ctx context.Context, query string, csvOutput bool) erro
 	CheckReadonly("sql")
 
 	affected, err := uow.RunTxResult(ctx, uowProvider, func(ctx context.Context, uw uow.UnitOfWork) (int64, string, error) {
+		if database != "" {
+			if err := uw.SwitchDatabase(ctx, database); err != nil {
+				return 0, "", err
+			}
+		}
 		affected, err := uw.RawSQLUseCase().Exec(ctx, query)
 		if err != nil {
 			return 0, "", err

--- a/cmd/bd/update_proxied_server_test.go
+++ b/cmd/bd/update_proxied_server_test.go
@@ -113,16 +113,17 @@ type fakeUOW struct {
 	commit  func() error
 }
 
-func (f *fakeUOW) Close(ctx context.Context)                        {}
-func (f *fakeUOW) Commit(ctx context.Context, message string) error { return f.commit() }
-func (f *fakeUOW) ConfigUseCase() domain.ConfigUseCase              { return nil }
-func (f *fakeUOW) DoltRemoteUseCase() domain.DoltRemoteUseCase      { return nil }
-func (f *fakeUOW) BootstrapUseCase() domain.BootstrapUseCase        { return nil }
-func (f *fakeUOW) IssueUseCase() domain.IssueUseCase                { return f.issueUC }
-func (f *fakeUOW) DependencyUseCase() domain.DependencyUseCase      { return nil }
-func (f *fakeUOW) LabelUseCase() domain.LabelUseCase                { return nil }
-func (f *fakeUOW) CommentUseCase() domain.CommentUseCase            { return nil }
-func (f *fakeUOW) RawSQLUseCase() domain.RawSQLUseCase              { return nil }
+func (f *fakeUOW) Close(ctx context.Context)                                 {}
+func (f *fakeUOW) Commit(ctx context.Context, message string) error          { return f.commit() }
+func (f *fakeUOW) SwitchDatabase(ctx context.Context, database string) error { return nil }
+func (f *fakeUOW) ConfigUseCase() domain.ConfigUseCase                       { return nil }
+func (f *fakeUOW) DoltRemoteUseCase() domain.DoltRemoteUseCase               { return nil }
+func (f *fakeUOW) BootstrapUseCase() domain.BootstrapUseCase                 { return nil }
+func (f *fakeUOW) IssueUseCase() domain.IssueUseCase                         { return f.issueUC }
+func (f *fakeUOW) DependencyUseCase() domain.DependencyUseCase               { return nil }
+func (f *fakeUOW) LabelUseCase() domain.LabelUseCase                         { return nil }
+func (f *fakeUOW) CommentUseCase() domain.CommentUseCase                     { return nil }
+func (f *fakeUOW) RawSQLUseCase() domain.RawSQLUseCase                       { return nil }
 
 type fakeUOWProvider struct {
 	uows   atomic.Int64

--- a/internal/storage/uow/tx_test.go
+++ b/internal/storage/uow/tx_test.go
@@ -27,6 +27,8 @@ func (m *mockUnitOfWork) Commit(ctx context.Context, message string) error {
 	return m.commitErr
 }
 
+func (m *mockUnitOfWork) SwitchDatabase(ctx context.Context, database string) error { return nil }
+
 func (m *mockUnitOfWork) ConfigUseCase() domain.ConfigUseCase         { return nil }
 func (m *mockUnitOfWork) DoltRemoteUseCase() domain.DoltRemoteUseCase { return nil }
 func (m *mockUnitOfWork) BootstrapUseCase() domain.BootstrapUseCase   { return nil }

--- a/internal/storage/uow/uow.go
+++ b/internal/storage/uow/uow.go
@@ -11,6 +11,8 @@ type UnitOfWork interface {
 	Close(ctx context.Context)
 	Commit(ctx context.Context, message string) error
 
+	SwitchDatabase(ctx context.Context, database string) error
+
 	ConfigUseCase() domain.ConfigUseCase
 	DoltRemoteUseCase() domain.DoltRemoteUseCase
 	BootstrapUseCase() domain.BootstrapUseCase
@@ -55,6 +57,10 @@ func (u *baseUOW) Commit(ctx context.Context, message string) error {
 
 func (u *baseUOW) Close(ctx context.Context) {
 	u.tx.RollbackUnlessCommitted(ctx)
+}
+
+func (u *baseUOW) SwitchDatabase(ctx context.Context, database string) error {
+	return db.NewDDLSQLRepository(u.tx.Runner()).UseDatabase(ctx, database)
 }
 
 func (u *baseUOW) ConfigUseCase() domain.ConfigUseCase {


### PR DESCRIPTION
## Summary

Two related improvements to `bd sql` in proxied-server mode, both landing entirely on the client side (the transparent proxy and Dolt server already support the wire behavior):

### 1. Multi-statement SQL

`bd sql` now accepts a `;`-separated batch of statements. Any multi-statement input is treated as a write: it executes atomically in a single unit-of-work transaction, commits via `DOLT_COMMIT`, and reports `OK` (JSON `{"status":"ok"}`). Single statements are unchanged — reads render a table, single writes still report `OK, N rows affected`.

Multi-statement detection is a lightweight top-level `;` scan that ignores semicolons inside `'…'`, `"…"`, `` `…` ``, `-- `, `#`, and `/* … */`. A single multi-line `SELECT` stays a single-statement read.

This routing was chosen after verifying `go-sql-driver/mysql` behavior against a real proxied Dolt server: `ExecContext` reports only the *last* statement's `RowsAffected` (not a sum), and `QueryContext` never surfaces write counts — so an honest per-batch row count isn't available, hence the plain `OK`.

### 2. `--database` flag

`bd sql --database <name> '<query>'` runs the query against a different database on the same proxied server — the equivalent of a session `USE <name>` — without changing the project's configured database. Implemented by switching the database on the pinned UOW connection before executing (verified that `USE` inside `START TRANSACTION` works and that a subsequent `DOLT_COMMIT` targets the switched database, leaving the default database untouched).

- Works for single reads, single writes, and multi-statement batches.
- The database name is validated (`^[a-zA-Z_][a-zA-Z0-9_]*$`) before interpolation — no injection via the flag.
- Only supported in proxied-server mode; direct-server mode returns a clear error rather than silently ignoring it.

## Implementation notes

- `internal/storage/uow/uow.go`: added `SwitchDatabase(ctx, database)` to the `UnitOfWork` interface / `baseUOW`, delegating to the existing identifier-validated `DDLSQLRepository.UseDatabase`.
- `cmd/bd/sql_proxied_server.go`: multi-statement detection + routing; both read and write paths switch database on the same pinned session.
- `cmd/bd/sql.go`: registered `--database`, help text, non-proxied guard.

## Testing

- `TestTopLevelStatementCount` / `TestIsMultiStatementSQL` — statement-counter unit tests (quotes, comments, escapes, multi-line).
- `TestProxiedServerMultiStatementSQL` — end-to-end: multi-statement batch commits atomically and prints `OK`; single write keeps its count; single read still renders; `--json` multi-statement omits `rows_affected`.
- `TestProxiedServerSQLDatabaseFlag` — end-to-end: `--database` write commits to the other database, unqualified read resolves there, invalid identifier rejected.

All pass against a real proxied Dolt server (`BEADS_TEST_PROXIED_SERVER=1`); `go vet`, `gofmt`, and full build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
