### PR TITLE
fix(nix): update vendorHash for the Go 1.26.5 module set

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -19,7 +19,7 @@ buildGoModule {
   # proxyVendor avoids vendor/modules.txt consistency checks when the vendored
   # tree lags go.mod/go.sum.
   proxyVendor = true;
-  vendorHash = "sha256-j+KnR2/0AxVkSfwO/C6/Zo2FjIC7iQs8RlZlrBt/8wc=";
+  vendorHash = "sha256-g3VILiRj/vRA04ahiPDEkUYZmjYp7X393tYEaM0TPbs=";
 
   # Match go.mod to the selected Nix Go toolchain. buildGoModule also builds
   # vendored dependencies in the Nix sandbox, where toolchain downloads are not


### PR DESCRIPTION
## Why

Main is red at 4f0df4e6a: `Test Nix Flake` fails with a fixed-output hash mismatch in `beads-1.1.0-go-modules.drv`. #4942 (Bump Go to 1.26.5) changed `go.mod`/`go.sum`, which invalidates `default.nix`'s `vendorHash` — the same class the dependabot automation patches on bot branches, but #4942 landed without it.

## What

One line: `vendorHash` in `default.nix` updated to the correct value reported by the failing derivation itself (`got: sha256-g3VILiRj/vRA04ahiPDEkUYZmjYp7X393tYEaM0TPbs=` in run 30061122769). No other changes.

Stop-the-line per Base-Branch Health: while main is red this fix is the only mergeable PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

_claude-fable-5-high on behalf of matt wilkie_
