### PR TITLE
feat(update): conditional compare-and-set guards --if-assignee/--if-status (bd-wsqvw)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,7 +111,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   still equals the expected value — one atomic transaction, nothing written on
   a mismatch, and a loud non-zero exit naming actual vs expected (typed as
   `storage.ErrAssigneeMismatch` / new `ErrStatusMismatch`). `--if-assignee ''`
-  means "expected unassigned". This closes the two coordination transitions no
+  means "expected unassigned". A guard mismatch is machine-distinguishable
+  from infra failure: exit code **13** when every failure in the run was a
+  stale guard (a racer won — skip gracefully) vs 1 for anything else
+  (retry/abort); in `--json` mode each entry in the failure report's `failed`
+  array additionally carries `"guard_mismatch": true`, and the stderr text
+  always contains the sentinel token `assignee mismatch` / `status mismatch`. This closes the two coordination transitions no
   existing verb could express: reassign X→Y only while X still holds it
   (`bd update <id> --if-assignee worker -a mayor`), and claim-on-behalf with a
   status guard (`bd update <id> --if-assignee '' --if-status open -a owner -s

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Conditional (compare-and-set) updates: `bd update --if-assignee` /
+  `--if-status`** (bd-wsqvw, from wyvern's wheelhouse hostile-review epic
+  wy-mdi5h; design in `PROPOSAL-cas-conditional-update.md`). When either guard
+  is present the update applies only if the issue's current assignee/status
+  still equals the expected value — one atomic transaction, nothing written on
+  a mismatch, and a loud non-zero exit naming actual vs expected (typed as
+  `storage.ErrAssigneeMismatch` / new `ErrStatusMismatch`). `--if-assignee ''`
+  means "expected unassigned". This closes the two coordination transitions no
+  existing verb could express: reassign X→Y only while X still holds it
+  (`bd update <id> --if-assignee worker -a mayor`), and claim-on-behalf with a
+  status guard (`bd update <id> --if-assignee '' --if-status open -a owner -s
+  in_progress`). Guards require a field update to ride on, are mutually
+  exclusive with `--claim` (its own CAS), compose with each other and with the
+  engine's `ExpectedVersion` row CAS, and work in every dolt mode. In Dolt
+  server mode a guarded update that writes assignee/status is claim-family and
+  is resolved by the bd-zccb9 verify-by-re-read protocol, so its exit code
+  stays truthful under a degraded server. Library consumers get the same
+  guards via new `UpdateIssueOptions.ExpectedAssignee`/`ExpectedStatus` fields
+  on the existing `UpdateIssueChecked` — no interface change; out-of-tree
+  `Storage` implementations that ignore the new fields simply do not enforce
+  them and should add support before advertising guard semantics.
+
 - **Pool-aware claiming via the `claim.pools` config key** (bd-bguz6).
   Dispatcher fleets pre-assign issues to a pool pseudo-assignee (e.g.
   `fable-crew`); `--claim` previously refused those ("already assigned"),

--- a/cmd/bd/prime.go
+++ b/cmd/bd/prime.go
@@ -868,6 +868,7 @@ git status                  # Check changed files
 - ` + "`bd update <id> --claim`" + ` - Claim work
 - ` + "`bd unclaim <id>`" + ` - Release stuck issue (agent crashed)
 - ` + "`bd update <id> --assignee=username`" + ` - Assign to someone
+- ` + "`bd update <id> --if-assignee=<expected> --assignee=<new>`" + ` - Atomic reassign: applies only if the assignee still matches (--if-status=<expected> guards status; --if-assignee='' requires unassigned). Mismatch exits non-zero with nothing written — never retry blindly
 - ` + "`bd update <id> --title/--description/--notes/--design`" + ` - Update fields inline
 - ` + "`bd close <id>`" + ` - Mark complete
 - ` + "`bd close <id1> <id2> ...`" + ` - Close multiple issues at once (more efficient)

--- a/cmd/bd/update.go
+++ b/cmd/bd/update.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -31,7 +32,12 @@ create, update, show, or close operation).
 
 Updates are applied per issue ID, not atomically across IDs: when some IDs
 fail, the remaining issues are still updated, every failed ID is reported on
-stderr, and the command exits nonzero.`,
+stderr, and the command exits nonzero.
+
+Exit codes: 1 for general failures; 13 when every failure is a stale
+--if-assignee/--if-status guard (the precondition no longer held, nothing was
+written — another actor won the race, so retrying the same guard is
+pointless).`,
 	Args:          cobra.MinimumNArgs(0),
 	SilenceUsage:  true,
 	SilenceErrors: true,
@@ -441,7 +447,11 @@ stderr, and the command exits nonzero.`,
 				}
 				if updateErr != nil {
 					fmt.Fprintf(os.Stderr, "Error updating %s: %v\n", id, updateErr)
-					recordFailure(id, fmt.Sprintf("updating issue: %v", updateErr))
+					failures = append(failures, updateIDFailure{
+						ID:            id,
+						Error:         fmt.Sprintf("updating issue: %v", updateErr),
+						GuardMismatch: isGuardMismatch(updateErr),
+					})
 					closeIfUnmutated(result)
 					continue
 				}
@@ -621,18 +631,39 @@ func warnNotesReplacement(id string) {
 	fmt.Fprintf(os.Stderr, "warning: %s: --notes replaced existing notes (use --append-notes to preserve history)\n", id) //nolint:gosec // G705: stderr, not a browser context
 }
 
+// ExitGuardMismatch is the exit code when a `bd update` run failed solely
+// because --if-assignee/--if-status guards did not match: the precondition no
+// longer held, nothing was written, and retrying is pointless — another actor
+// won the race. Scripts branch on it to tell "racer won, skip gracefully"
+// (13) from infra failure (1, retry/abort). Mixed batches — any failure that
+// is NOT a guard mismatch — exit 1, the conservative "something needs a
+// retry" verdict. The stderr line carries the machine-greppable sentinel
+// text ("assignee mismatch" / "status mismatch") either way.
+const ExitGuardMismatch = 13
+
+// isGuardMismatch reports whether err is a bd-wsqvw conditional-update guard
+// refusal (stale --if-assignee/--if-status), the failure class that exits
+// ExitGuardMismatch instead of 1.
+func isGuardMismatch(err error) bool {
+	return errors.Is(err, storage.ErrAssigneeMismatch) || errors.Is(err, storage.ErrStatusMismatch)
+}
+
 // updateIDFailure records one issue ID that could not be updated and why.
+// GuardMismatch marks a --if-assignee/--if-status refusal so JSON consumers
+// can distinguish it without parsing the error text.
 type updateIDFailure struct {
-	ID    string `json:"id"`
-	Error string `json:"error"`
+	ID            string `json:"id"`
+	Error         string `json:"error"`
+	GuardMismatch bool   `json:"guard_mismatch,omitempty"`
 }
 
 // reportUpdateFailures emits a per-ID failure report on stderr and returns a
-// nonzero exit error. In --json mode the report is a single compact JSON
-// line — the last line on stderr — so callers can parse which IDs failed
-// while stdout keeps the plain array-of-updated-issues success shape. In
-// text mode the individual errors were already printed inline; this adds a
-// summary naming every failed ID.
+// nonzero exit error — ExitGuardMismatch when every failure is a
+// --if-assignee/--if-status guard refusal, 1 otherwise. In --json mode the
+// report is a single compact JSON line — the last line on stderr — so
+// callers can parse which IDs failed while stdout keeps the plain
+// array-of-updated-issues success shape. In text mode the individual errors
+// were already printed inline; this adds a summary naming every failed ID.
 func reportUpdateFailures(failures []updateIDFailure, total int) error {
 	msg := fmt.Sprintf("%d of %d issues failed to update", len(failures), total)
 	if jsonOutput {
@@ -663,6 +694,16 @@ func reportUpdateFailures(failures []updateIDFailure, total int) error {
 		for _, f := range failures {
 			fmt.Fprintf(os.Stderr, "  %s: %s\n", f.ID, f.Error)
 		}
+	}
+	allGuard := len(failures) > 0
+	for _, f := range failures {
+		if !f.GuardMismatch {
+			allGuard = false
+			break
+		}
+	}
+	if allGuard {
+		return &exitError{Code: ExitGuardMismatch}
 	}
 	return &exitError{Code: 1}
 }
@@ -753,8 +794,8 @@ func init() {
 	updateCmd.Flags().String("parent", "", "New parent issue ID (reparents the issue, use empty string to remove parent)")
 	updateCmd.Flags().Bool("claim", false, "Atomically claim the issue (sets assignee to you, status to in_progress; idempotent if already claimed by you; issues assigned to a pool alias listed in the claim.pools config are claimable too)")
 	// Conditional (compare-and-set) update guards (bd-wsqvw)
-	updateCmd.Flags().String("if-assignee", "", "Apply the update only if the current assignee equals this value (--if-assignee '' requires unassigned); a mismatch writes nothing and exits non-zero. Requires a field update; cannot combine with --claim")
-	updateCmd.Flags().String("if-status", "", "Apply the update only if the current status equals this value; a mismatch writes nothing and exits non-zero. Requires a field update; cannot combine with --claim")
+	updateCmd.Flags().String("if-assignee", "", "Apply the update only if the current assignee equals this value (--if-assignee '' requires unassigned); a mismatch writes nothing and exits 13 (vs 1 for other failures). Requires a field update; cannot combine with --claim")
+	updateCmd.Flags().String("if-status", "", "Apply the update only if the current status equals this value; a mismatch writes nothing and exits 13 (vs 1 for other failures). Requires a field update; cannot combine with --claim")
 	updateCmd.Flags().String("session", "", "Claude Code session ID for status=closed (or set CLAUDE_SESSION_ID env var)")
 	// Time-based scheduling flags (GH#820)
 	// Examples:

--- a/cmd/bd/update.go
+++ b/cmd/bd/update.go
@@ -320,6 +320,15 @@ stderr, and the command exits nonzero.`,
 			return nil
 		}
 
+		// Conditional-update guards (bd-wsqvw): validated against the same
+		// status set as --status, mutually exclusive with --claim (which is
+		// its own compare-and-set), and only meaningful with a field update
+		// to ride on.
+		ifAssignee, ifStatus, err := updateGuardsFromFlags(cmd, claimFlag, updates)
+		if err != nil {
+			return err
+		}
+
 		ctx := rootCtx
 
 		updatedIssues := []*types.Issue{}
@@ -419,9 +428,20 @@ stderr, and the command exits nonzero.`,
 			notesOverwritten := replacesExistingNotes(issue.Notes, updates)
 
 			if len(regularUpdates) > 0 {
-				if err := issueStore.UpdateIssue(ctx, result.ResolvedID, regularUpdates, actor); err != nil {
-					fmt.Fprintf(os.Stderr, "Error updating %s: %v\n", id, err)
-					recordFailure(id, fmt.Sprintf("updating issue: %v", err))
+				// With guards present, route through the checked (CAS) path: a
+				// stale assignee/status refuses atomically with a typed
+				// mismatch error and MUST surface as a non-zero exit — never
+				// collapse it to success (finding #10).
+				var updateErr error
+				if ifAssignee != nil || ifStatus != nil {
+					updateErr = issueStore.UpdateIssueChecked(ctx, result.ResolvedID, regularUpdates, actor,
+						storage.UpdateIssueOptions{ExpectedAssignee: ifAssignee, ExpectedStatus: ifStatus})
+				} else {
+					updateErr = issueStore.UpdateIssue(ctx, result.ResolvedID, regularUpdates, actor)
+				}
+				if updateErr != nil {
+					fmt.Fprintf(os.Stderr, "Error updating %s: %v\n", id, updateErr)
+					recordFailure(id, fmt.Sprintf("updating issue: %v", updateErr))
 					closeIfUnmutated(result)
 					continue
 				}
@@ -667,6 +687,54 @@ func toJSONValue(s string) json.RawMessage {
 	return storage.MetadataEditValue(s)
 }
 
+// updateGuardsFromFlags reads the bd-wsqvw conditional-update guards
+// (--if-assignee/--if-status) with presence detected via Changed(), so
+// `--if-assignee ""` is a real guard meaning "expected unassigned" rather than
+// "no guard" (the unclaim.go idiom). It rejects combining guards with --claim
+// (--claim is its own compare-and-set with claim-pool semantics; the guards
+// would silently duplicate or contradict it) and guards with no regular field
+// update to ride on (the CAS applies to the issues-row UPDATE; label and
+// parent edits run outside it and would not be guarded). An --if-status value
+// is validated against the same built-in + custom status set as --status, so a
+// typo fails fast instead of mismatching forever.
+func updateGuardsFromFlags(cmd *cobra.Command, claimFlag bool, updates map[string]interface{}) (ifAssignee, ifStatus *string, err error) {
+	if cmd.Flags().Changed("if-assignee") {
+		v, _ := cmd.Flags().GetString("if-assignee")
+		ifAssignee = &v
+	}
+	if cmd.Flags().Changed("if-status") {
+		v, _ := cmd.Flags().GetString("if-status")
+		var customStatuses []string
+		if store != nil {
+			if cs, csErr := store.GetCustomStatuses(rootCtx); csErr == nil {
+				customStatuses = cs
+			}
+		}
+		if !types.Status(v).IsValidWithCustom(customStatuses) {
+			return nil, nil, HandleErrorRespectJSON("invalid --if-status %q (built-in: open, in_progress, blocked, deferred, closed, pinned, hooked; or configure custom statuses via 'bd config set status.custom')", v)
+		}
+		ifStatus = &v
+	}
+	if ifAssignee == nil && ifStatus == nil {
+		return nil, nil, nil
+	}
+	if claimFlag {
+		return nil, nil, HandleErrorRespectJSON("cannot combine --if-assignee/--if-status with --claim (--claim is already an atomic compare-and-set)")
+	}
+	hasFieldUpdate := false
+	for k := range updates {
+		switch k {
+		case "add_labels", "remove_labels", "set_labels", "parent":
+		default:
+			hasFieldUpdate = true
+		}
+	}
+	if !hasFieldUpdate {
+		return nil, nil, HandleErrorRespectJSON("--if-assignee/--if-status require at least one field update (e.g. -a, -s); label and parent edits are not covered by the guard")
+	}
+	return ifAssignee, ifStatus, nil
+}
+
 func init() {
 	updateCmd.Flags().StringP("status", "s", "", "New status")
 	registerPriorityFlag(updateCmd, "")
@@ -684,6 +752,9 @@ func init() {
 	updateCmd.Flags().StringSlice("set-labels", nil, "Set labels, replacing all existing (repeatable)")
 	updateCmd.Flags().String("parent", "", "New parent issue ID (reparents the issue, use empty string to remove parent)")
 	updateCmd.Flags().Bool("claim", false, "Atomically claim the issue (sets assignee to you, status to in_progress; idempotent if already claimed by you; issues assigned to a pool alias listed in the claim.pools config are claimable too)")
+	// Conditional (compare-and-set) update guards (bd-wsqvw)
+	updateCmd.Flags().String("if-assignee", "", "Apply the update only if the current assignee equals this value (--if-assignee '' requires unassigned); a mismatch writes nothing and exits non-zero. Requires a field update; cannot combine with --claim")
+	updateCmd.Flags().String("if-status", "", "Apply the update only if the current status equals this value; a mismatch writes nothing and exits non-zero. Requires a field update; cannot combine with --claim")
 	updateCmd.Flags().String("session", "", "Claude Code session ID for status=closed (or set CLAUDE_SESSION_ID env var)")
 	// Time-based scheduling flags (GH#820)
 	// Examples:

--- a/cmd/bd/update_conditional_embedded_test.go
+++ b/cmd/bd/update_conditional_embedded_test.go
@@ -1,0 +1,134 @@
+//go:build cgo
+
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// TestUpdateIfGuardsCLI drives the bd-wsqvw conditional-update guards
+// (`bd update --if-assignee/--if-status`) end-to-end against the embedded Dolt
+// backend. The guarded update must be a compare-and-set, not a
+// read-then-clobber: a stale guard exits nonzero naming the actual state and
+// writes nothing; a matching guard applies; and `--if-assignee ""` is a real
+// "expected unassigned" guard, not "no guard". Covers the two wheelhouse
+// transitions no other verb expresses: reassign X→Y (park) and claim-on-behalf
+// with a status guard (restore).
+func TestUpdateIfGuardsCLI(t *testing.T) {
+	if os.Getenv("BEADS_TEST_EMBEDDED_DOLT") != "1" {
+		t.Skip("set BEADS_TEST_EMBEDDED_DOLT=1 to run embedded dolt integration tests")
+	}
+	t.Parallel()
+
+	bd := buildEmbeddedBD(t)
+	dir, _, _ := bdInit(t, bd, "--prefix", "ug")
+
+	t.Run("reassign_only_if_still_held", func(t *testing.T) {
+		issue := bdCreate(t, bd, dir, "Park transition", "--type", "task")
+		bdUpdate(t, bd, dir, issue.ID, "--assignee", "worker", "--status", "in_progress")
+
+		// Stale guard: exits nonzero, names the actual holder, writes nothing.
+		out := bdUpdateFail(t, bd, dir, issue.ID, "--if-assignee", "bob", "--assignee", "mayor")
+		if !strings.Contains(out, "worker") {
+			t.Errorf("mismatch error should name the current holder worker, got:\n%s", out)
+		}
+		got := bdShow(t, bd, dir, issue.ID)
+		if got.Assignee != "worker" {
+			t.Errorf("stale --if-assignee clobbered the row: assignee = %q, want worker", got.Assignee)
+		}
+
+		// Matching guard: the park reassign applies.
+		bdUpdate(t, bd, dir, issue.ID, "--if-assignee", "worker", "--assignee", "mayor")
+		got = bdShow(t, bd, dir, issue.ID)
+		if got.Assignee != "mayor" {
+			t.Errorf("after matching --if-assignee: assignee = %q, want mayor", got.Assignee)
+		}
+
+		// The guard is exactly-once: re-running the same conditional reassign
+		// now fails (worker no longer holds it), it does not silently succeed.
+		_ = bdUpdateFail(t, bd, dir, issue.ID, "--if-assignee", "worker", "--assignee", "mayor")
+	})
+
+	t.Run("claim_on_behalf_only_while_open", func(t *testing.T) {
+		issue := bdCreate(t, bd, dir, "Restore transition", "--type", "task")
+
+		// --if-assignee "" is a real guard: claim-on-behalf applies only while
+		// unassigned and open.
+		bdUpdate(t, bd, dir, issue.ID, "--if-assignee", "", "--if-status", "open",
+			"--assignee", "owner", "--status", "in_progress")
+		got := bdShow(t, bd, dir, issue.ID)
+		if got.Assignee != "owner" || got.Status != types.StatusInProgress {
+			t.Errorf("claim-on-behalf: got assignee=%q status=%q, want owner/in_progress", got.Assignee, got.Status)
+		}
+
+		// A second restore attempt must lose: the bead is no longer unassigned.
+		out := bdUpdateFail(t, bd, dir, issue.ID, "--if-assignee", "", "--if-status", "open",
+			"--assignee", "other", "--status", "in_progress")
+		if !strings.Contains(out, "owner") {
+			t.Errorf("mismatch error should name the current holder owner, got:\n%s", out)
+		}
+		got = bdShow(t, bd, dir, issue.ID)
+		if got.Assignee != "owner" {
+			t.Errorf("lost restore clobbered the row: assignee = %q, want owner", got.Assignee)
+		}
+	})
+
+	t.Run("status_guard_mismatch_is_loud", func(t *testing.T) {
+		issue := bdCreate(t, bd, dir, "Status guard", "--type", "task")
+		bdUpdate(t, bd, dir, issue.ID, "--status", "in_progress")
+
+		out := bdUpdateFail(t, bd, dir, issue.ID, "--if-status", "open", "--priority", "1")
+		if !strings.Contains(out, "in_progress") {
+			t.Errorf("mismatch error should name the actual status in_progress, got:\n%s", out)
+		}
+		if got := bdShow(t, bd, dir, issue.ID); got.Priority != issue.Priority {
+			t.Errorf("refused guard changed priority to %d, want unchanged %d", got.Priority, issue.Priority)
+		}
+	})
+}
+
+// TestUpdateIfGuardsFlagValidation drives the CLI-surface rules that keep the
+// guard contract unambiguous: guards cannot combine with --claim (which is its
+// own compare-and-set), guards require a field update to ride on (label-only
+// edits run outside the guarded transaction), and an --if-status typo is
+// rejected up front instead of mismatching forever. Every rejection must write
+// nothing.
+func TestUpdateIfGuardsFlagValidation(t *testing.T) {
+	if os.Getenv("BEADS_TEST_EMBEDDED_DOLT") != "1" {
+		t.Skip("set BEADS_TEST_EMBEDDED_DOLT=1 to run embedded dolt integration tests")
+	}
+	t.Parallel()
+
+	bd := buildEmbeddedBD(t)
+	dir, _, _ := bdInit(t, bd, "--prefix", "uf")
+
+	issue := bdCreate(t, bd, dir, "Flag validation", "--type", "task")
+
+	t.Run("claim_and_guards_mutually_exclusive", func(t *testing.T) {
+		out := bdUpdateFail(t, bd, dir, issue.ID, "--if-assignee", "", "--claim")
+		if !strings.Contains(out, "--claim") {
+			t.Errorf("expected the --claim exclusion in the error, got:\n%s", out)
+		}
+		if got := bdShow(t, bd, dir, issue.ID); got.Assignee != "" {
+			t.Errorf("rejected flag combo still claimed the issue: assignee = %q", got.Assignee)
+		}
+	})
+
+	t.Run("guards_require_a_field_update", func(t *testing.T) {
+		out := bdUpdateFail(t, bd, dir, issue.ID, "--if-assignee", "", "--add-label", "x")
+		if !strings.Contains(out, "field update") {
+			t.Errorf("expected the field-update requirement in the error, got:\n%s", out)
+		}
+	})
+
+	t.Run("invalid_if_status_rejected_up_front", func(t *testing.T) {
+		out := bdUpdateFail(t, bd, dir, issue.ID, "--if-status", "opne", "--priority", "1")
+		if !strings.Contains(out, "opne") {
+			t.Errorf("expected the invalid status named in the error, got:\n%s", out)
+		}
+	})
+}

--- a/cmd/bd/update_conditional_embedded_test.go
+++ b/cmd/bd/update_conditional_embedded_test.go
@@ -3,12 +3,34 @@
 package main
 
 import (
+	"errors"
 	"os"
+	"os/exec"
 	"strings"
 	"testing"
 
 	"github.com/steveyegge/beads/internal/types"
 )
+
+// bdUpdateFailCode runs "bd update" expecting failure and returns the combined
+// output plus the process exit code, so guard tests can assert the
+// ExitGuardMismatch contract (13 = stale guard, 1 = everything else).
+func bdUpdateFailCode(t *testing.T, bd, dir string, args ...string) (string, int) {
+	t.Helper()
+	fullArgs := append([]string{"update"}, args...)
+	cmd := exec.Command(bd, fullArgs...)
+	cmd.Dir = dir
+	cmd.Env = bdEnv(dir)
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected bd update %s to fail, but it succeeded:\n%s", strings.Join(args, " "), out)
+	}
+	var ee *exec.ExitError
+	if !errors.As(err, &ee) {
+		t.Fatalf("bd update %s failed without an exit code: %v\n%s", strings.Join(args, " "), err, out)
+	}
+	return string(out), ee.ExitCode()
+}
 
 // TestUpdateIfGuardsCLI drives the bd-wsqvw conditional-update guards
 // (`bd update --if-assignee/--if-status`) end-to-end against the embedded Dolt
@@ -31,8 +53,12 @@ func TestUpdateIfGuardsCLI(t *testing.T) {
 		issue := bdCreate(t, bd, dir, "Park transition", "--type", "task")
 		bdUpdate(t, bd, dir, issue.ID, "--assignee", "worker", "--status", "in_progress")
 
-		// Stale guard: exits nonzero, names the actual holder, writes nothing.
-		out := bdUpdateFail(t, bd, dir, issue.ID, "--if-assignee", "bob", "--assignee", "mayor")
+		// Stale guard: exits ExitGuardMismatch (so scripts can tell "a racer
+		// won" from infra failure), names the actual holder, writes nothing.
+		out, code := bdUpdateFailCode(t, bd, dir, issue.ID, "--if-assignee", "bob", "--assignee", "mayor")
+		if code != ExitGuardMismatch {
+			t.Errorf("stale guard exit code = %d, want %d\n%s", code, ExitGuardMismatch, out)
+		}
 		if !strings.Contains(out, "worker") {
 			t.Errorf("mismatch error should name the current holder worker, got:\n%s", out)
 		}
@@ -66,8 +92,11 @@ func TestUpdateIfGuardsCLI(t *testing.T) {
 		}
 
 		// A second restore attempt must lose: the bead is no longer unassigned.
-		out := bdUpdateFail(t, bd, dir, issue.ID, "--if-assignee", "", "--if-status", "open",
+		out, code := bdUpdateFailCode(t, bd, dir, issue.ID, "--if-assignee", "", "--if-status", "open",
 			"--assignee", "other", "--status", "in_progress")
+		if code != ExitGuardMismatch {
+			t.Errorf("lost restore exit code = %d, want %d\n%s", code, ExitGuardMismatch, out)
+		}
 		if !strings.Contains(out, "owner") {
 			t.Errorf("mismatch error should name the current holder owner, got:\n%s", out)
 		}
@@ -81,12 +110,30 @@ func TestUpdateIfGuardsCLI(t *testing.T) {
 		issue := bdCreate(t, bd, dir, "Status guard", "--type", "task")
 		bdUpdate(t, bd, dir, issue.ID, "--status", "in_progress")
 
-		out := bdUpdateFail(t, bd, dir, issue.ID, "--if-status", "open", "--priority", "1")
+		out, code := bdUpdateFailCode(t, bd, dir, issue.ID, "--if-status", "open", "--priority", "1")
+		if code != ExitGuardMismatch {
+			t.Errorf("status guard exit code = %d, want %d\n%s", code, ExitGuardMismatch, out)
+		}
 		if !strings.Contains(out, "in_progress") {
 			t.Errorf("mismatch error should name the actual status in_progress, got:\n%s", out)
 		}
 		if got := bdShow(t, bd, dir, issue.ID); got.Priority != issue.Priority {
 			t.Errorf("refused guard changed priority to %d, want unchanged %d", got.Priority, issue.Priority)
+		}
+	})
+
+	t.Run("mixed_batch_failure_exits_1_not_13", func(t *testing.T) {
+		// ExitGuardMismatch means "every failure was a stale guard — a racer
+		// won, don't retry". A batch that ALSO hit a non-guard failure (here a
+		// nonexistent ID) must keep the conservative exit 1 so callers still
+		// treat the run as retry-worthy.
+		issue := bdCreate(t, bd, dir, "Mixed batch", "--type", "task")
+		bdUpdate(t, bd, dir, issue.ID, "--assignee", "worker")
+
+		out, code := bdUpdateFailCode(t, bd, dir, issue.ID, "ug-nope99",
+			"--if-assignee", "bob", "--priority", "1")
+		if code != 1 {
+			t.Errorf("mixed guard+lookup failure exit code = %d, want 1\n%s", code, out)
 		}
 	})
 }
@@ -109,7 +156,10 @@ func TestUpdateIfGuardsFlagValidation(t *testing.T) {
 	issue := bdCreate(t, bd, dir, "Flag validation", "--type", "task")
 
 	t.Run("claim_and_guards_mutually_exclusive", func(t *testing.T) {
-		out := bdUpdateFail(t, bd, dir, issue.ID, "--if-assignee", "", "--claim")
+		out, code := bdUpdateFailCode(t, bd, dir, issue.ID, "--if-assignee", "", "--claim")
+		if code != 1 {
+			t.Errorf("flag-validation exit code = %d, want 1 (13 is reserved for real guard mismatches)\n%s", code, out)
+		}
 		if !strings.Contains(out, "--claim") {
 			t.Errorf("expected the --claim exclusion in the error, got:\n%s", out)
 		}

--- a/cmd/bd/update_conditional_proxied_test.go
+++ b/cmd/bd/update_conditional_proxied_test.go
@@ -3,9 +3,28 @@
 package main
 
 import (
+	"errors"
+	"os/exec"
 	"strings"
 	"testing"
 )
+
+// bdProxiedUpdateFailCode runs a proxied "bd update" expecting failure and
+// returns combined output plus the exit code, for asserting the
+// ExitGuardMismatch contract on the proxied path.
+func bdProxiedUpdateFailCode(t *testing.T, bd, dir string, args ...string) (string, int) {
+	t.Helper()
+	stdout, stderr, err := bdProxiedUpdateRaw(t, bd, dir, args...)
+	if err == nil {
+		t.Fatalf("bd update %s should have failed; got:\nstdout:\n%s\nstderr:\n%s",
+			strings.Join(args, " "), stdout, stderr)
+	}
+	var ee *exec.ExitError
+	if !errors.As(err, &ee) {
+		t.Fatalf("bd update %s failed without an exit code: %v", strings.Join(args, " "), err)
+	}
+	return stdout + stderr, ee.ExitCode()
+}
 
 // TestProxiedServerUpdateIfGuards proves the bd-wsqvw conditional-update
 // guards hold on the proxied-server path: the guards ride domain.UpdateSpec
@@ -35,8 +54,12 @@ func TestProxiedServerUpdateIfGuards(t *testing.T) {
 			t.Fatalf("assignee = %q after guarded reassign, want mayor", got.Assignee)
 		}
 
-		// The same guard now loses, names the actual holder, and writes nothing.
-		out := bdProxiedUpdateFail(t, bd, p.dir, issue.ID, "--if-assignee", "worker", "--assignee", "thief")
+		// The same guard now loses with the distinct guard-mismatch exit code,
+		// names the actual holder, and writes nothing.
+		out, code := bdProxiedUpdateFailCode(t, bd, p.dir, issue.ID, "--if-assignee", "worker", "--assignee", "thief")
+		if code != ExitGuardMismatch {
+			t.Errorf("stale guard exit code = %d, want %d\n%s", code, ExitGuardMismatch, out)
+		}
 		if !strings.Contains(out, "mayor") {
 			t.Errorf("mismatch error should name the current holder mayor, got:\n%s", out)
 		}
@@ -61,8 +84,11 @@ func TestProxiedServerUpdateIfGuards(t *testing.T) {
 		}
 
 		// Second restore loses: no longer unassigned.
-		out := bdProxiedUpdateFail(t, bd, p.dir, issue.ID,
+		out, code := bdProxiedUpdateFailCode(t, bd, p.dir, issue.ID,
 			"--if-assignee", "", "--if-status", "open", "--assignee", "other", "--status", "in_progress")
+		if code != ExitGuardMismatch {
+			t.Errorf("lost restore exit code = %d, want %d\n%s", code, ExitGuardMismatch, out)
+		}
 		if !strings.Contains(out, "owner") {
 			t.Errorf("mismatch error should name the holder owner, got:\n%s", out)
 		}

--- a/cmd/bd/update_conditional_proxied_test.go
+++ b/cmd/bd/update_conditional_proxied_test.go
@@ -1,0 +1,80 @@
+//go:build cgo
+
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestProxiedServerUpdateIfGuards proves the bd-wsqvw conditional-update
+// guards hold on the proxied-server path: the guards ride domain.UpdateSpec
+// into ApplyUpdate, where the guard read shares the unit of work's
+// transaction. A stale guard is a terminal per-issue failure (loud, non-zero,
+// nothing written — the finding-#10 exit contract), a matching guard applies,
+// and `--if-assignee ""` guards on unassigned.
+func TestProxiedServerUpdateIfGuards(t *testing.T) {
+	requireSharedProxiedServer(t)
+	t.Parallel()
+	bd := buildEmbeddedBD(t)
+
+	t.Run("guarded_reassign_wins_and_then_loses", func(t *testing.T) {
+		t.Parallel()
+		p := newSharedProxiedProject(t, bd, "ugp")
+		issue := bdProxiedCreate(t, bd, p.dir, "Park via proxy")
+		if out, err := bdProxiedRun(t, bd, p.dir, "update", issue.ID, "--assignee", "worker", "--status", "in_progress"); err != nil {
+			t.Fatalf("seed assign failed: %v\n%s", err, out)
+		}
+
+		// Matching guard applies.
+		if out, err := bdProxiedRun(t, bd, p.dir, "update", issue.ID, "--if-assignee", "worker", "--assignee", "mayor"); err != nil {
+			t.Fatalf("guarded reassign failed: %v\n%s", err, out)
+		}
+		got := bdProxiedShow(t, bd, p.dir, issue.ID)
+		if got.Assignee != "mayor" {
+			t.Fatalf("assignee = %q after guarded reassign, want mayor", got.Assignee)
+		}
+
+		// The same guard now loses, names the actual holder, and writes nothing.
+		out := bdProxiedUpdateFail(t, bd, p.dir, issue.ID, "--if-assignee", "worker", "--assignee", "thief")
+		if !strings.Contains(out, "mayor") {
+			t.Errorf("mismatch error should name the current holder mayor, got:\n%s", out)
+		}
+		got = bdProxiedShow(t, bd, p.dir, issue.ID)
+		if got.Assignee != "mayor" {
+			t.Errorf("lost guard clobbered the row: assignee = %q, want mayor", got.Assignee)
+		}
+	})
+
+	t.Run("claim_on_behalf_guards_on_unassigned", func(t *testing.T) {
+		t.Parallel()
+		p := newSharedProxiedProject(t, bd, "ugr")
+		issue := bdProxiedCreate(t, bd, p.dir, "Restore via proxy")
+
+		if out, err := bdProxiedRun(t, bd, p.dir, "update", issue.ID,
+			"--if-assignee", "", "--if-status", "open", "--assignee", "owner", "--status", "in_progress"); err != nil {
+			t.Fatalf("claim-on-behalf failed: %v\n%s", err, out)
+		}
+		got := bdProxiedShow(t, bd, p.dir, issue.ID)
+		if got.Assignee != "owner" {
+			t.Fatalf("assignee = %q after claim-on-behalf, want owner", got.Assignee)
+		}
+
+		// Second restore loses: no longer unassigned.
+		out := bdProxiedUpdateFail(t, bd, p.dir, issue.ID,
+			"--if-assignee", "", "--if-status", "open", "--assignee", "other", "--status", "in_progress")
+		if !strings.Contains(out, "owner") {
+			t.Errorf("mismatch error should name the holder owner, got:\n%s", out)
+		}
+	})
+
+	t.Run("guards_with_claim_rejected", func(t *testing.T) {
+		t.Parallel()
+		p := newSharedProxiedProject(t, bd, "ugx")
+		issue := bdProxiedCreate(t, bd, p.dir, "Flag combo via proxy")
+		out := bdProxiedUpdateFail(t, bd, p.dir, issue.ID, "--if-assignee", "", "--claim")
+		if !strings.Contains(out, "--claim") {
+			t.Errorf("expected the --claim exclusion in the error, got:\n%s", out)
+		}
+	})
+}

--- a/cmd/bd/update_input.go
+++ b/cmd/bd/update_input.go
@@ -30,6 +30,11 @@ type updateInput struct {
 	unsetMetadata    []string
 	mergeMetadataIn  json.RawMessage
 	clearDeferStatus bool
+	// bd-wsqvw conditional-update guards; non-nil only when the flag was
+	// explicitly passed (a pointer to "" is the real "expected unassigned"
+	// guard).
+	ifAssignee *string
+	ifStatus   *string
 }
 
 func gatherUpdateInput(ctx context.Context, cmd *cobra.Command) (*updateInput, error) {
@@ -238,6 +243,31 @@ func gatherUpdateInput(ctx context.Context, cmd *cobra.Command) (*updateInput, e
 	in.unsetMetadata = unsetMetadataFlags
 
 	in.claim, _ = cmd.Flags().GetBool("claim")
+
+	// bd-wsqvw conditional-update guards, mirroring the non-proxied path's
+	// updateGuardsFromFlags rules: Changed()-detected presence (so
+	// `--if-assignee ""` guards on unassigned), --if-status validated against
+	// the live status set, mutually exclusive with --claim, and requiring a
+	// field update to ride on.
+	if cmd.Flags().Changed("if-assignee") {
+		v, _ := cmd.Flags().GetString("if-assignee")
+		in.ifAssignee = &v
+	}
+	if cmd.Flags().Changed("if-status") {
+		v, _ := cmd.Flags().GetString("if-status")
+		if err := validateUpdateStatus(ctx, v); err != nil {
+			return nil, err
+		}
+		in.ifStatus = &v
+	}
+	if in.ifAssignee != nil || in.ifStatus != nil {
+		if in.claim {
+			return nil, HandleErrorRespectJSON("cannot combine --if-assignee/--if-status with --claim (--claim is already an atomic compare-and-set)")
+		}
+		if len(in.fields) == 0 && !in.hasAppendNotes && len(in.mergeMetadataIn) == 0 && len(in.setMetadata) == 0 && len(in.unsetMetadata) == 0 {
+			return nil, HandleErrorRespectJSON("--if-assignee/--if-status require at least one field update (e.g. -a, -s); label and parent edits are not covered by the guard")
+		}
+	}
 	return in, nil
 }
 

--- a/cmd/bd/update_proxied_server.go
+++ b/cmd/bd/update_proxied_server.go
@@ -54,12 +54,12 @@ func runUpdateProxiedServer(cmd *cobra.Command, ctx context.Context, args []stri
 	var failures []updateIDFailure
 
 	for _, id := range args {
-		issue, failReason, err := applyUpdateProxiedOne(ctx, id, in)
+		issue, fail, err := applyUpdateProxiedOne(ctx, id, in)
 		if err != nil {
 			return err
 		}
-		if failReason != "" {
-			failures = append(failures, updateIDFailure{ID: id, Error: failReason})
+		if fail != nil {
+			failures = append(failures, *fail)
 			continue
 		}
 		if jsonOut {
@@ -90,20 +90,20 @@ func runUpdateProxiedServer(cmd *cobra.Command, ctx context.Context, args []stri
 // Redoing the attempt re-reads the winner's committed row, so merge
 // operations (metadata edits, note appends) resolve against authoritative
 // state instead of erasing it.
-func applyUpdateProxiedOne(ctx context.Context, id string, in *updateInput) (*types.Issue, string, error) {
+func applyUpdateProxiedOne(ctx context.Context, id string, in *updateInput) (*types.Issue, *updateIDFailure, error) {
 	if uowProvider == nil {
-		return nil, "", HandleError("proxied-server UOW provider not initialized")
+		return nil, nil, HandleError("proxied-server UOW provider not initialized")
 	}
 
 	var issue *types.Issue
-	var failReason string
+	var fail *updateIDFailure
 	bo := backoff.NewExponentialBackOff()
 	bo.InitialInterval = 25 * time.Millisecond
 	bo.MaxElapsedTime = proxiedUpdateRetryMaxElapsed
 	err := backoff.Retry(func() error {
 		var retryable bool
 		var attemptErr error
-		issue, failReason, retryable, attemptErr = applyUpdateProxiedAttempt(ctx, id, in)
+		issue, fail, retryable, attemptErr = applyUpdateProxiedAttempt(ctx, id, in)
 		if attemptErr == nil {
 			return nil
 		}
@@ -117,25 +117,26 @@ func applyUpdateProxiedOne(ctx context.Context, id string, in *updateInput) (*ty
 			// Retries exhausted while losing Dolt's commit-time merge. The
 			// write did NOT land; fail loudly instead of exiting 0.
 			fmt.Fprintf(os.Stderr, "Error updating %s: retries exhausted on write conflicts: %v\n", id, err)
-			return nil, fmt.Sprintf("retries exhausted on write conflicts: %v", err), nil
+			return nil, &updateIDFailure{ID: id, Error: fmt.Sprintf("retries exhausted on write conflicts: %v", err)}, nil
 		}
-		return nil, "", err
+		return nil, nil, err
 	}
-	return issue, failReason, nil
+	return issue, fail, nil
 }
 
 // applyUpdateProxiedAttempt runs one full read-merge-write attempt in a fresh
 // unit of work. retryable is true only for serialization failures, where the
 // server-side rollback guarantees nothing landed and the whole attempt is safe
 // to redo. Terminal per-issue failures (not found, claim conflicts, commit
-// errors) print to stderr and return a non-empty failReason with no error, so
-// the multi-ID loop records the failed ID, keeps going, and still exits
-// non-zero — matching the non-proxied path.
-func applyUpdateProxiedAttempt(ctx context.Context, id string, in *updateInput) (issue *types.Issue, failReason string, retryable bool, err error) {
+// errors) print to stderr and return a non-nil fail with no error, so the
+// multi-ID loop records the failed ID, keeps going, and still exits non-zero
+// — matching the non-proxied path. A guard refusal sets fail.GuardMismatch so
+// the exit code distinguishes it (ExitGuardMismatch vs 1).
+func applyUpdateProxiedAttempt(ctx context.Context, id string, in *updateInput) (issue *types.Issue, fail *updateIDFailure, retryable bool, err error) {
 	uw, err := uowProvider.NewUOW(ctx)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error opening unit of work for %s: %v\n", id, err)
-		return nil, fmt.Sprintf("opening unit of work: %v", err), false, nil
+		return nil, &updateIDFailure{ID: id, Error: fmt.Sprintf("opening unit of work: %v", err)}, false, nil
 	}
 	defer uw.Close(ctx)
 
@@ -147,15 +148,15 @@ func applyUpdateProxiedAttempt(ctx context.Context, id string, in *updateInput) 
 			current = wispCurrent
 		} else if err != nil {
 			fmt.Fprintf(os.Stderr, "Error resolving %s: %v\n", id, err)
-			return nil, fmt.Sprintf("resolving issue: %v", err), false, nil
+			return nil, &updateIDFailure{ID: id, Error: fmt.Sprintf("resolving issue: %v", err)}, false, nil
 		} else {
 			fmt.Fprintf(os.Stderr, "Issue %s not found\n", id)
-			return nil, "issue not found", false, nil
+			return nil, &updateIDFailure{ID: id, Error: "issue not found"}, false, nil
 		}
 	}
 	if err := validateIssueUpdatable(id, current); err != nil {
 		fmt.Fprintf(os.Stderr, "%s\n", err)
-		return nil, err.Error(), false, nil
+		return nil, &updateIDFailure{ID: id, Error: err.Error()}, false, nil
 	}
 
 	spec := buildUpdateSpecForIssue(current, in)
@@ -164,31 +165,32 @@ func applyUpdateProxiedAttempt(ctx context.Context, id string, in *updateInput) 
 	updated, err := issueUC.ApplyUpdate(ctx, id, spec, actor)
 	if err != nil {
 		if uow.IsSerializationError(err) {
-			return nil, "", true, err
+			return nil, nil, true, err
 		}
 		if errors.Is(err, storage.ErrAlreadyClaimed) || errors.Is(err, storage.ErrNotClaimable) {
 			fmt.Fprintf(os.Stderr, "Error claiming %s: %v\n", id, err)
-			return nil, fmt.Sprintf("claiming issue: %v", err), false, nil
+			return nil, &updateIDFailure{ID: id, Error: fmt.Sprintf("claiming issue: %v", err)}, false, nil
 		}
-		if errors.Is(err, storage.ErrAssigneeMismatch) || errors.Is(err, storage.ErrStatusMismatch) {
+		if isGuardMismatch(err) {
 			// bd-wsqvw guard verdict: the precondition no longer holds, nothing
-			// was written. Loud and non-zero, never collapsed to success.
+			// was written. Loud and non-zero, never collapsed to success —
+			// GuardMismatch routes the batch to ExitGuardMismatch.
 			fmt.Fprintf(os.Stderr, "Error updating %s: %v\n", id, err)
-			return nil, fmt.Sprintf("precondition failed: %v", err), false, nil
+			return nil, &updateIDFailure{ID: id, Error: fmt.Sprintf("precondition failed: %v", err), GuardMismatch: true}, false, nil
 		}
 		fmt.Fprintf(os.Stderr, "Error updating %s: %v\n", id, err)
-		return nil, fmt.Sprintf("updating: %v", err), false, nil
+		return nil, &updateIDFailure{ID: id, Error: fmt.Sprintf("updating: %v", err)}, false, nil
 	}
 
 	if err := uw.Commit(ctx, fmt.Sprintf("bd: update %s", id)); err != nil {
 		if uow.IsSerializationError(err) {
 			// Dolt rolled the whole transaction back server-side; nothing
 			// landed. Signal the caller to redo the read-merge-write.
-			return nil, "", true, err
+			return nil, nil, true, err
 		}
 		if !isDoltNothingToCommit(err) {
 			fmt.Fprintf(os.Stderr, "Error committing %s: %v\n", id, err)
-			return nil, fmt.Sprintf("committing: %v", err), false, nil
+			return nil, &updateIDFailure{ID: id, Error: fmt.Sprintf("committing: %v", err)}, false, nil
 		}
 		// "Nothing to commit" here is the legitimately-empty working set:
 		// wisp-only updates live in dolt_ignored tables, so a successful
@@ -204,7 +206,7 @@ func applyUpdateProxiedAttempt(ctx context.Context, id string, in *updateInput) 
 	if err := fireProxiedUpdateHooks(ctx, current, updated); err != nil {
 		fmt.Fprintf(os.Stderr, "warning: %s: %v\n", id, err)
 	}
-	return updated, "", false, nil
+	return updated, nil, false, nil
 }
 
 func fireProxiedUpdateHooks(ctx context.Context, before, after *types.Issue) error {

--- a/cmd/bd/update_proxied_server.go
+++ b/cmd/bd/update_proxied_server.go
@@ -170,6 +170,12 @@ func applyUpdateProxiedAttempt(ctx context.Context, id string, in *updateInput) 
 			fmt.Fprintf(os.Stderr, "Error claiming %s: %v\n", id, err)
 			return nil, fmt.Sprintf("claiming issue: %v", err), false, nil
 		}
+		if errors.Is(err, storage.ErrAssigneeMismatch) || errors.Is(err, storage.ErrStatusMismatch) {
+			// bd-wsqvw guard verdict: the precondition no longer holds, nothing
+			// was written. Loud and non-zero, never collapsed to success.
+			fmt.Fprintf(os.Stderr, "Error updating %s: %v\n", id, err)
+			return nil, fmt.Sprintf("precondition failed: %v", err), false, nil
+		}
 		fmt.Fprintf(os.Stderr, "Error updating %s: %v\n", id, err)
 		return nil, fmt.Sprintf("updating: %v", err), false, nil
 	}
@@ -274,11 +280,13 @@ func buildUpdateSpecForIssue(current *types.Issue, in *updateInput) domain.Updat
 	}
 
 	return domain.UpdateSpec{
-		Fields:       fields,
-		Claim:        in.claim,
-		AddLabels:    in.addLabels,
-		RemoveLabels: in.removeLabels,
-		SetLabels:    in.setLabels,
-		Reparent:     in.reparent,
+		Fields:           fields,
+		Claim:            in.claim,
+		AddLabels:        in.addLabels,
+		RemoveLabels:     in.removeLabels,
+		SetLabels:        in.setLabels,
+		Reparent:         in.reparent,
+		ExpectedAssignee: in.ifAssignee,
+		ExpectedStatus:   in.ifStatus,
 	}
 }

--- a/cmd/bd/update_proxied_server_test.go
+++ b/cmd/bd/update_proxied_server_test.go
@@ -198,12 +198,12 @@ func TestApplyUpdateProxiedOne_RetriesWholeAttemptOnConflict(t *testing.T) {
 	withFakeProxiedUpdateEnv(t, provider)
 
 	in := &updateInput{fields: map[string]any{"title": "renamed"}}
-	got, failReason, err := applyUpdateProxiedOne(context.Background(), "bd-retry-1", in)
+	got, fail, err := applyUpdateProxiedOne(context.Background(), "bd-retry-1", in)
 	if err != nil {
 		t.Fatalf("applyUpdateProxiedOne: %v", err)
 	}
-	if failReason != "" {
-		t.Fatalf("expected update to succeed after conflict retries, got failure: %s", failReason)
+	if fail != nil {
+		t.Fatalf("expected update to succeed after conflict retries, got failure: %s", fail.Error)
 	}
 	if got == nil || got.ID != "bd-retry-1" {
 		t.Fatalf("updated issue = %v, want bd-retry-1", got)
@@ -231,17 +231,20 @@ func TestApplyUpdateProxiedOne_ExhaustedConflictsFailLoudly(t *testing.T) {
 	withFakeProxiedUpdateEnv(t, provider)
 
 	var got *types.Issue
-	var failReason string
+	var fail *updateIDFailure
 	var err error
 	stderr := captureStderrDuring(t, func() {
 		in := &updateInput{fields: map[string]any{"title": "never lands"}}
-		got, failReason, err = applyUpdateProxiedOne(context.Background(), "bd-retry-2", in)
+		got, fail, err = applyUpdateProxiedOne(context.Background(), "bd-retry-2", in)
 	})
 	if err != nil {
 		t.Fatalf("applyUpdateProxiedOne returned hard error: %v", err)
 	}
-	if failReason == "" || got != nil {
-		t.Fatalf("failReason=%q issue=%v: a write that never landed must be reported as a failure", failReason, got)
+	if fail == nil || got != nil {
+		t.Fatalf("fail=%v issue=%v: a write that never landed must be reported as a failure", fail, got)
+	}
+	if fail.GuardMismatch {
+		t.Errorf("exhausted conflicts must not masquerade as a guard mismatch (that would exit 13 and tell scripts not to retry)")
 	}
 	if !strings.Contains(stderr, "retries exhausted") {
 		t.Errorf("stderr = %q, want a loud retries-exhausted failure", stderr)
@@ -265,12 +268,12 @@ func TestApplyUpdateProxiedOne_NothingToCommitWithoutConflictSucceeds(t *testing
 	withFakeProxiedUpdateEnv(t, provider)
 
 	in := &updateInput{fields: map[string]any{"title": "wisp-shaped"}}
-	got, failReason, err := applyUpdateProxiedOne(context.Background(), "bd-retry-3", in)
+	got, fail, err := applyUpdateProxiedOne(context.Background(), "bd-retry-3", in)
 	if err != nil {
 		t.Fatalf("applyUpdateProxiedOne: %v", err)
 	}
-	if failReason != "" || got == nil {
-		t.Fatalf("failReason=%q issue=%v: empty-working-set commit on an unconflicted attempt is a success", failReason, got)
+	if fail != nil || got == nil {
+		t.Fatalf("fail=%v issue=%v: empty-working-set commit on an unconflicted attempt is a success", fail, got)
 	}
 	if n := provider.uows.Load(); n != 1 {
 		t.Errorf("unit-of-work attempts = %d, want 1 (nothing-to-commit must not trigger retries)", n)

--- a/internal/storage/dolt/claim_verify.go
+++ b/internal/storage/dolt/claim_verify.go
@@ -75,6 +75,16 @@ func unclaimed() claimPostcondition {
 // an annoyance, not a phantom claim). The postcondition checks only the
 // coordination fields the update actually sets, since the others may be
 // legitimately touched by concurrent writers.
+//
+// Attribution narrowness (lion review, PR #5008): because only the SET
+// coordination fields are checked, a commit-phase loss whose transaction
+// verifiably rolled back can still verify as "applied" when a racing actor
+// landed the SAME target values inside the verify window. The coordination
+// state is then correct but it is the racer's write, not ours: any ordinary
+// fields riding the same update (title, notes, …) and our event row are
+// silently gone despite the reported success. Mitigation is usage-side, not
+// machinery: keep guarded coordination writes single-purpose (assignee/status
+// only), which is how the wheelhouse park/restore consumers use them.
 func guardedUpdatePostcondition(opts storage.UpdateIssueOptions, updates map[string]interface{}) (claimPostcondition, bool) {
 	if opts.ExpectedAssignee == nil && opts.ExpectedStatus == nil {
 		return claimPostcondition{}, false

--- a/internal/storage/dolt/claim_verify.go
+++ b/internal/storage/dolt/claim_verify.go
@@ -9,6 +9,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 
+	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/types"
 )
 
@@ -64,6 +65,47 @@ func unclaimed() claimPostcondition {
 		},
 		desc: fmt.Sprintf("assignee=%q status=%q", "", types.StatusOpen),
 	}
+}
+
+// guardedUpdatePostcondition derives the postcondition for a guarded update
+// (bd-wsqvw: UpdateIssueOptions.ExpectedAssignee/ExpectedStatus) that writes
+// the coordination fields. ok is false — no verification — when the update
+// carries no guard, or when it guards but writes neither assignee nor status
+// (a guarded edit of ordinary fields is not claim-family: a lost notes edit is
+// an annoyance, not a phantom claim). The postcondition checks only the
+// coordination fields the update actually sets, since the others may be
+// legitimately touched by concurrent writers.
+func guardedUpdatePostcondition(opts storage.UpdateIssueOptions, updates map[string]interface{}) (claimPostcondition, bool) {
+	if opts.ExpectedAssignee == nil && opts.ExpectedStatus == nil {
+		return claimPostcondition{}, false
+	}
+	newAssignee, setsAssignee := updates["assignee"].(string)
+	newStatus, setsStatus := updates["status"].(string)
+	if !setsAssignee && !setsStatus {
+		return claimPostcondition{}, false
+	}
+	var desc string
+	switch {
+	case setsAssignee && setsStatus:
+		desc = fmt.Sprintf("assignee=%q status=%q", newAssignee, newStatus)
+	case setsAssignee:
+		desc = fmt.Sprintf("assignee=%q", newAssignee)
+	default:
+		desc = fmt.Sprintf("status=%q", newStatus)
+	}
+	return claimPostcondition{
+		op: "guarded-update",
+		want: func(assignee string, status types.Status) bool {
+			if setsAssignee && assignee != newAssignee {
+				return false
+			}
+			if setsStatus && status != types.Status(newStatus) {
+				return false
+			}
+			return true
+		},
+		desc: desc,
+	}, true
 }
 
 // readClaimState re-reads an issue's assignee and status on a fresh

--- a/internal/storage/dolt/issues.go
+++ b/internal/storage/dolt/issues.go
@@ -243,17 +243,21 @@ func (s *DoltStore) UpdateIssueChecked(ctx context.Context, id string, updates m
 	// Route ephemeral IDs to wisps table (falls through for promoted wisps).
 	// Wisps skip DOLT_COMMIT since they live in dolt_ignored tables.
 	if s.isActiveWisp(ctx, id) {
-		return s.updateWispChecked(ctx, id, updates, actor, opts.ExpectedVersion)
+		return s.updateWispChecked(ctx, id, updates, actor, opts)
 	}
 
 	// If updating a regular issue to no-history or ephemeral, migrate it to the
-	// wisps table instead of updating in-place (mirrors UpdateIssue). The version
-	// check shares the demotion transaction so the CAS stays atomic on this path.
+	// wisps table instead of updating in-place (mirrors UpdateIssue). The
+	// precondition checks share the demotion transaction so the CAS stays
+	// atomic on this path.
 	_, settingNoHistory := updates["no_history"]
 	_, settingWisp := updates["wisp"]
 	if settingNoHistory || settingWisp {
 		return s.withRetryTx(ctx, func(tx *sql.Tx) error {
 			if err := checkExpectedVersionInTx(ctx, tx, id, opts.ExpectedVersion); err != nil {
+				return err
+			}
+			if err := issueops.CheckExpectedFieldsInTx(ctx, tx, id, opts.ExpectedAssignee, opts.ExpectedStatus); err != nil {
 				return err
 			}
 			return s.demoteToWispInTx(ctx, tx, id, updates, actor)
@@ -263,30 +267,47 @@ func (s *DoltStore) UpdateIssueChecked(ctx context.Context, id string, updates m
 	// Wrap in withRetryTx exactly like UpdateIssue so a concurrent writer that
 	// loses Dolt's optimistic commit-time merge (MySQL 1213/1205, guaranteed
 	// server-side rollback) is retried rather than surfaced as a hard failure.
-	// A version mismatch (storage.ErrVersionMismatch) is NOT a serialization
-	// error, so withRetryTx surfaces it permanently and the transaction rolls
-	// back — no update and no event are written (the atomic-refuse property). A
+	// A precondition mismatch (storage.ErrVersionMismatch /
+	// ErrAssigneeMismatch / ErrStatusMismatch) is NOT a serialization error, so
+	// withRetryTx surfaces it permanently and the transaction rolls back — no
+	// update and no event are written (the atomic-refuse property). A
 	// concurrent write that commits DURING this tx collides on the row_lock cell
-	// and is replayed by withRetryTx, which re-reads the new version here and
+	// and is replayed by withRetryTx, which re-reads the preconditions here and
 	// refuses. withRetryTx owns BeginTx and the final Commit.
-	return s.withRetryTx(ctx, func(tx *sql.Tx) error {
-		if err := checkExpectedVersionInTx(ctx, tx, id, opts.ExpectedVersion); err != nil {
-			return err
-		}
-		if _, err := issueops.UpdateIssueInTx(ctx, tx, id, updates, actor); err != nil {
-			return err
-		}
+	write := func() error {
+		return s.withRetryTx(ctx, func(tx *sql.Tx) error {
+			if err := checkExpectedVersionInTx(ctx, tx, id, opts.ExpectedVersion); err != nil {
+				return err
+			}
+			if err := issueops.CheckExpectedFieldsInTx(ctx, tx, id, opts.ExpectedAssignee, opts.ExpectedStatus); err != nil {
+				return err
+			}
+			if _, err := issueops.UpdateIssueInTx(ctx, tx, id, updates, actor); err != nil {
+				return err
+			}
 
-		for _, table := range []string{"issues", "events"} {
-			_, _ = tx.ExecContext(ctx, "CALL DOLT_ADD(?)", table)
-		}
-		commitMsg := fmt.Sprintf("bd: update %s", id)
-		if _, err := tx.ExecContext(ctx, "CALL DOLT_COMMIT('-m', ?, '--author', ?)",
-			commitMsg, s.commitAuthorString()); err != nil && !isDoltNothingToCommit(err) {
-			return fmt.Errorf("dolt commit: %w", err)
-		}
-		return nil
-	})
+			for _, table := range []string{"issues", "events"} {
+				_, _ = tx.ExecContext(ctx, "CALL DOLT_ADD(?)", table)
+			}
+			commitMsg := fmt.Sprintf("bd: update %s", id)
+			if _, err := tx.ExecContext(ctx, "CALL DOLT_COMMIT('-m', ?, '--author', ?)",
+				commitMsg, s.commitAuthorString()); err != nil && !isDoltNothingToCommit(err) {
+				return fmt.Errorf("dolt commit: %w", err)
+			}
+			return nil
+		})
+	}
+
+	// A guarded update that writes the coordination fields (a reassign or a
+	// claim-on-behalf, bd-wsqvw) is claim-family: resolve it by verify-by-re-read
+	// (bd-zccb9) instead of trusting the exit status. Safe to replay after a
+	// verified rollback — the guards are re-checked inside the replayed
+	// transaction, so a racing writer makes the replay refuse rather than
+	// clobber. Unguarded or non-coordination updates keep their exit status.
+	if post, ok := guardedUpdatePostcondition(opts, updates); ok {
+		return s.verifiedClaimWrite(ctx, id, post, write)
+	}
+	return write()
 }
 
 // ClaimIssue atomically claims an issue using compare-and-swap semantics.

--- a/internal/storage/dolt/update_guards_test.go
+++ b/internal/storage/dolt/update_guards_test.go
@@ -1,0 +1,222 @@
+package dolt
+
+import (
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/storage"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// TestUpdateIssueCheckedFieldGuards exercises the bd-wsqvw semantic-field
+// compare-and-set guards (UpdateIssueOptions.ExpectedAssignee/ExpectedStatus)
+// layered onto UpdateIssueChecked: the guard read and the update share ONE
+// transaction, so a stale guard refuses with the typed mismatch error and the
+// transaction rolls back leaving the row untouched (the atomic-refuse property
+// of the version CAS, extended to the coordination fields). The two motivating
+// transitions are covered explicitly: reassign X→Y (park) and claim-on-behalf
+// with a status guard (restore) — the transitions neither --claim nor
+// unclaim --if-assignee can express.
+func TestUpdateIssueCheckedFieldGuards(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	get := func(t *testing.T, id string) *types.Issue {
+		t.Helper()
+		iss, err := store.GetIssue(ctx, id)
+		if err != nil {
+			t.Fatalf("GetIssue(%s): %v", id, err)
+		}
+		if iss == nil {
+			t.Fatalf("GetIssue(%s) returned nil issue", id)
+		}
+		return iss
+	}
+	sptr := func(v string) *string { return &v }
+
+	t.Run("reassign X to Y with matching assignee guard", func(t *testing.T) {
+		createPerm(t, ctx, store, "ug-park")
+		if err := store.ClaimIssue(ctx, "ug-park", "worker"); err != nil {
+			t.Fatalf("seed claim: %v", err)
+		}
+		// The park transition: hand the bead to the parking assignee only while
+		// the reclaimed worker still holds it.
+		if err := store.UpdateIssueChecked(ctx, "ug-park",
+			map[string]interface{}{"assignee": "mayor"}, "tester",
+			storage.UpdateIssueOptions{ExpectedAssignee: sptr("worker")}); err != nil {
+			t.Fatalf("guarded reassign err = %v, want nil", err)
+		}
+		if got := get(t, "ug-park").Assignee; got != "mayor" {
+			t.Fatalf("assignee = %q after guarded reassign, want %q", got, "mayor")
+		}
+	})
+
+	t.Run("stale assignee guard refuses atomically", func(t *testing.T) {
+		createPerm(t, ctx, store, "ug-stale")
+		if err := store.ClaimIssue(ctx, "ug-stale", "thief"); err != nil {
+			t.Fatalf("seed claim: %v", err)
+		}
+		err := store.UpdateIssueChecked(ctx, "ug-stale",
+			map[string]interface{}{"assignee": "mayor", "title": "should-not-apply"}, "tester",
+			storage.UpdateIssueOptions{ExpectedAssignee: sptr("worker")})
+		if !errors.Is(err, storage.ErrAssigneeMismatch) {
+			t.Fatalf("err = %v, want errors.Is(_, ErrAssigneeMismatch)", err)
+		}
+		iss := get(t, "ug-stale")
+		if iss.Assignee != "thief" {
+			t.Fatalf("assignee = %q after refused reassign, want unchanged %q", iss.Assignee, "thief")
+		}
+		if iss.Title == "should-not-apply" {
+			t.Fatalf("title applied despite refused guard; tx must roll back atomically")
+		}
+	})
+
+	t.Run("claim-on-behalf with empty assignee and status guards", func(t *testing.T) {
+		createPerm(t, ctx, store, "ug-restore")
+		// The restore transition: assign to the crew owner and start it, only
+		// while still open and unassigned. --if-assignee '' is a real guard.
+		if err := store.UpdateIssueChecked(ctx, "ug-restore",
+			map[string]interface{}{"assignee": "owner", "status": "in_progress"}, "tester",
+			storage.UpdateIssueOptions{ExpectedAssignee: sptr(""), ExpectedStatus: sptr("open")}); err != nil {
+			t.Fatalf("claim-on-behalf err = %v, want nil", err)
+		}
+		iss := get(t, "ug-restore")
+		if iss.Assignee != "owner" || iss.Status != types.StatusInProgress {
+			t.Fatalf("got assignee=%q status=%q, want owner/in_progress", iss.Assignee, iss.Status)
+		}
+	})
+
+	t.Run("empty assignee guard refuses when assigned", func(t *testing.T) {
+		createPerm(t, ctx, store, "ug-taken")
+		if err := store.ClaimIssue(ctx, "ug-taken", "worker"); err != nil {
+			t.Fatalf("seed claim: %v", err)
+		}
+		err := store.UpdateIssueChecked(ctx, "ug-taken",
+			map[string]interface{}{"assignee": "owner"}, "tester",
+			storage.UpdateIssueOptions{ExpectedAssignee: sptr("")})
+		if !errors.Is(err, storage.ErrAssigneeMismatch) {
+			t.Fatalf("err = %v, want errors.Is(_, ErrAssigneeMismatch) for assigned row", err)
+		}
+		if got := get(t, "ug-taken").Assignee; got != "worker" {
+			t.Fatalf("assignee = %q, want unchanged %q", got, "worker")
+		}
+	})
+
+	t.Run("status guard mismatch is typed and atomic", func(t *testing.T) {
+		createPerm(t, ctx, store, "ug-status")
+		if err := store.ClaimIssue(ctx, "ug-status", "worker"); err != nil {
+			t.Fatalf("seed claim: %v", err)
+		}
+		// Conjunction: the assignee guard holds but the status guard does not —
+		// the whole precondition must fail with the status verdict.
+		err := store.UpdateIssueChecked(ctx, "ug-status",
+			map[string]interface{}{"assignee": "owner"}, "tester",
+			storage.UpdateIssueOptions{ExpectedAssignee: sptr("worker"), ExpectedStatus: sptr("open")})
+		if !errors.Is(err, storage.ErrStatusMismatch) {
+			t.Fatalf("err = %v, want errors.Is(_, ErrStatusMismatch)", err)
+		}
+		if got := get(t, "ug-status").Assignee; got != "worker" {
+			t.Fatalf("assignee = %q after refused update, want unchanged %q", got, "worker")
+		}
+	})
+
+	t.Run("guards compose with ExpectedVersion", func(t *testing.T) {
+		createPerm(t, ctx, store, "ug-both")
+		v := get(t, "ug-both").RowVersion
+		iptr := func(v int64) *int64 { return &v }
+		// Field guards hold, version stale: the version verdict wins.
+		err := store.UpdateIssueChecked(ctx, "ug-both",
+			map[string]interface{}{"title": "should-not-apply"}, "tester",
+			storage.UpdateIssueOptions{ExpectedVersion: iptr(v + 1), ExpectedAssignee: sptr("")})
+		if !errors.Is(err, storage.ErrVersionMismatch) {
+			t.Fatalf("err = %v, want errors.Is(_, ErrVersionMismatch)", err)
+		}
+		// Both hold: applies.
+		if err := store.UpdateIssueChecked(ctx, "ug-both",
+			map[string]interface{}{"title": "both-held"}, "tester",
+			storage.UpdateIssueOptions{ExpectedVersion: iptr(v), ExpectedAssignee: sptr("")}); err != nil {
+			t.Fatalf("update with both preconditions held err = %v, want nil", err)
+		}
+		if got := get(t, "ug-both").Title; got != "both-held" {
+			t.Fatalf("title = %q, want %q", got, "both-held")
+		}
+	})
+
+	t.Run("wisp guard routes to wisps table", func(t *testing.T) {
+		createWisp(t, ctx, store, "ug-wisp")
+		// A matching guard proves CheckExpectedFieldsInTx read the wisps table
+		// (an issues-table read for this id would miss and refuse).
+		if err := store.UpdateIssueChecked(ctx, "ug-wisp",
+			map[string]interface{}{"title": "wisp-guarded"}, "tester",
+			storage.UpdateIssueOptions{ExpectedAssignee: sptr("")}); err != nil {
+			t.Fatalf("guarded wisp update err = %v, want nil", err)
+		}
+		if got := get(t, "ug-wisp").Title; got != "wisp-guarded" {
+			t.Fatalf("wisp title = %q, want %q", got, "wisp-guarded")
+		}
+		err := store.UpdateIssueChecked(ctx, "ug-wisp",
+			map[string]interface{}{"title": "should-not-apply"}, "tester",
+			storage.UpdateIssueOptions{ExpectedAssignee: sptr("someone")})
+		if !errors.Is(err, storage.ErrAssigneeMismatch) {
+			t.Fatalf("wisp err = %v, want errors.Is(_, ErrAssigneeMismatch)", err)
+		}
+	})
+}
+
+// TestGuardedReassignConcurrent races two guarded reassigns of the same row —
+// both conditioned on the same expected assignee — and requires exactly one
+// winner: the loser must observe the winner's write (via the shared-tx guard
+// re-check after withRetryTx replays the commit-time row_lock collision) and
+// refuse with ErrAssigneeMismatch, never silently clobber. This is the CAS
+// property the blind `bd update -a` check-then-act pattern lacks.
+func TestGuardedReassignConcurrent(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	createPerm(t, ctx, store, "ug-race")
+	if err := store.ClaimIssue(ctx, "ug-race", "worker"); err != nil {
+		t.Fatalf("seed claim: %v", err)
+	}
+
+	expected := "worker"
+	errs := make([]error, 2)
+	var wg sync.WaitGroup
+	for i, newAssignee := range []string{"alpha", "beta"} {
+		wg.Add(1)
+		go func(i int, newAssignee string) {
+			defer wg.Done()
+			errs[i] = store.UpdateIssueChecked(ctx, "ug-race",
+				map[string]interface{}{"assignee": newAssignee}, newAssignee,
+				storage.UpdateIssueOptions{ExpectedAssignee: &expected})
+		}(i, newAssignee)
+	}
+	wg.Wait()
+
+	winners := 0
+	for i, err := range errs {
+		switch {
+		case err == nil:
+			winners++
+		case errors.Is(err, storage.ErrAssigneeMismatch):
+			// the loser's verdict
+		default:
+			t.Fatalf("racer %d unexpected error: %v", i, err)
+		}
+	}
+	if winners != 1 {
+		t.Fatalf("winners = %d, want exactly 1 (errs: %v)", winners, errs)
+	}
+
+	iss, err := store.GetIssue(ctx, "ug-race")
+	if err != nil {
+		t.Fatalf("GetIssue: %v", err)
+	}
+	if iss.Assignee != "alpha" && iss.Assignee != "beta" {
+		t.Fatalf("final assignee = %q, want the winner's value", iss.Assignee)
+	}
+}

--- a/internal/storage/dolt/wisps.go
+++ b/internal/storage/dolt/wisps.go
@@ -199,25 +199,30 @@ func (s *DoltStore) updateWisp(ctx context.Context, id string, updates map[strin
 	return wrapTransactionError("commit update wisp", tx.Commit())
 }
 
-// updateWispChecked updates a wisp with an optional atomic version precondition,
-// mirroring updateWisp but — when expectedVersion is non-nil — first calling
-// issueops.CheckVersionInTx in the SAME transaction, so a stale version refuses
-// with storage.ErrVersionMismatch before any write and the deferred Rollback
-// discards the transaction (a true compare-and-swap). Like updateWisp it uses a
-// bare BeginTx/Commit with no withRetryTx (consistent with the rest of the wisp
-// write path — do not add one here); wisps live in dolt_ignored tables, so there
-// is no DOLT_COMMIT.
-func (s *DoltStore) updateWispChecked(ctx context.Context, id string, updates map[string]interface{}, actor string, expectedVersion *int64) error {
+// updateWispChecked updates a wisp with the optional atomic preconditions of
+// UpdateIssueChecked, mirroring updateWisp but first enforcing — in the SAME
+// transaction — opts.ExpectedVersion (issueops.CheckVersionInTx →
+// storage.ErrVersionMismatch) and the opts.ExpectedAssignee/ExpectedStatus
+// field guards (issueops.CheckExpectedFieldsInTx → ErrAssigneeMismatch/
+// ErrStatusMismatch), so a stale precondition refuses before any write and the
+// deferred Rollback discards the transaction (a true compare-and-swap). Like
+// updateWisp it uses a bare BeginTx/Commit with no withRetryTx (consistent with
+// the rest of the wisp write path — do not add one here); wisps live in
+// dolt_ignored tables, so there is no DOLT_COMMIT.
+func (s *DoltStore) updateWispChecked(ctx context.Context, id string, updates map[string]interface{}, actor string, opts storage.UpdateIssueOptions) error {
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("failed to begin transaction: %w", err)
 	}
 	defer func() { _ = tx.Rollback() }()
 
-	if expectedVersion != nil {
-		if err := issueops.CheckVersionInTx(ctx, tx, id, *expectedVersion); err != nil {
+	if opts.ExpectedVersion != nil {
+		if err := issueops.CheckVersionInTx(ctx, tx, id, *opts.ExpectedVersion); err != nil {
 			return err
 		}
+	}
+	if err := issueops.CheckExpectedFieldsInTx(ctx, tx, id, opts.ExpectedAssignee, opts.ExpectedStatus); err != nil {
+		return err
 	}
 	if _, err := issueops.UpdateIssueInTx(ctx, tx, id, updates, actor); err != nil {
 		return err

--- a/internal/storage/domain/issue.go
+++ b/internal/storage/domain/issue.go
@@ -220,6 +220,18 @@ type UpdateSpec struct {
 	RemoveLabels []string
 	SetLabels    *[]string
 	Reparent     *string
+
+	// ExpectedAssignee and ExpectedStatus are the bd-wsqvw compare-and-set
+	// guards (`bd update --if-assignee/--if-status`): when non-nil, the whole
+	// update applies only if the issue's current assignee/status equals the
+	// expected value, else ApplyUpdate refuses with
+	// storage.ErrAssigneeMismatch/ErrStatusMismatch and nothing is written. A
+	// non-nil pointer to "" means "expected unassigned". The guard read shares
+	// the unit of work's transaction; a writer that commits mid-flight
+	// collides on the row_lock rewrite at commit time and the caller's
+	// whole-attempt retry re-checks the guards on the redo.
+	ExpectedAssignee *string
+	ExpectedStatus   *string
 }
 
 type IssueUseCase interface {
@@ -465,6 +477,35 @@ func (u *issueUseCaseImpl) ApplyUpdate(ctx context.Context, id string, spec Upda
 	useWisp, err := u.isWispID(ctx, id)
 	if err != nil {
 		return nil, fmt.Errorf("ApplyUpdate %s: %w", id, err)
+	}
+
+	// bd-wsqvw field guards: refuse the whole spec atomically on a stale
+	// assignee/status. The read shares this unit of work's transaction, and
+	// every field update rewrites row_lock, so a writer that commits during
+	// the attempt collides at commit time and the caller's whole-attempt
+	// retry re-checks here on the redo — same CAS invariant as the store-level
+	// UpdateIssueChecked path.
+	if spec.ExpectedAssignee != nil || spec.ExpectedStatus != nil {
+		var current *types.Issue
+		if useWisp {
+			current, err = u.GetWisp(ctx, id)
+		} else {
+			current, err = u.GetIssue(ctx, id)
+		}
+		if err != nil {
+			return nil, fmt.Errorf("ApplyUpdate: read %s for guards: %w", id, err)
+		}
+		if current == nil {
+			return nil, fmt.Errorf("%w: issue %s", storage.ErrNotFound, id)
+		}
+		if spec.ExpectedAssignee != nil && current.Assignee != *spec.ExpectedAssignee {
+			return nil, fmt.Errorf("%w: %s is held by %q, expected %q",
+				storage.ErrAssigneeMismatch, id, current.Assignee, *spec.ExpectedAssignee)
+		}
+		if spec.ExpectedStatus != nil && string(current.Status) != *spec.ExpectedStatus {
+			return nil, fmt.Errorf("%w: %s has status %q, expected %q",
+				storage.ErrStatusMismatch, id, current.Status, *spec.ExpectedStatus)
+		}
 	}
 
 	if spec.Claim {

--- a/internal/storage/embeddeddolt/issues.go
+++ b/internal/storage/embeddeddolt/issues.go
@@ -74,15 +74,18 @@ func (s *EmbeddedDoltStore) UpdateIssue(ctx context.Context, id string, updates 
 	})
 }
 
-// UpdateIssueChecked applies the update like UpdateIssue, adding an optional
-// optimistic-concurrency precondition: when opts.ExpectedVersion is non-nil the
-// update proceeds only if the issue's current RowVersion (row_lock) still equals
-// *opts.ExpectedVersion, else it refuses with storage.ErrVersionMismatch. The
-// version read and the update share ONE transaction, so a mismatch returns
-// before any write and the transaction rolls back with the issue unchanged (a
-// true compare-and-swap). nil disables the check, leaving behavior identical to
-// UpdateIssue. Delegates SQL work to issueops; EmbeddedDolt auto-commits the
-// transaction.
+// UpdateIssueChecked applies the update like UpdateIssue, adding optional
+// atomic preconditions: when opts.ExpectedVersion is non-nil the update
+// proceeds only if the issue's current RowVersion (row_lock) still equals
+// *opts.ExpectedVersion, else it refuses with storage.ErrVersionMismatch; when
+// opts.ExpectedAssignee/ExpectedStatus are non-nil the update proceeds only if
+// the issue's current assignee/status match, else it refuses with
+// storage.ErrAssigneeMismatch/ErrStatusMismatch (bd-wsqvw field guards; a
+// pointer to "" means "expected unassigned"). The precondition reads and the
+// update share ONE transaction, so a mismatch returns before any write and the
+// transaction rolls back with the issue unchanged (a true compare-and-swap).
+// nil disables a check, leaving behavior identical to UpdateIssue. Delegates
+// SQL work to issueops; EmbeddedDolt auto-commits the transaction.
 func (s *EmbeddedDoltStore) UpdateIssueChecked(ctx context.Context, id string, updates map[string]interface{}, actor string, opts storage.UpdateIssueOptions) error {
 	// Validate metadata against schema before routing.
 	if rawMeta, ok := updates["metadata"]; ok {
@@ -100,6 +103,9 @@ func (s *EmbeddedDoltStore) UpdateIssueChecked(ctx context.Context, id string, u
 			if err := issueops.CheckVersionInTx(ctx, tx, id, *opts.ExpectedVersion); err != nil {
 				return err
 			}
+		}
+		if err := issueops.CheckExpectedFieldsInTx(ctx, tx, id, opts.ExpectedAssignee, opts.ExpectedStatus); err != nil {
+			return err
 		}
 		_, err := issueops.UpdateIssueInTx(ctx, tx, id, updates, actor)
 		return err

--- a/internal/storage/embeddeddolt/update_guards_test.go
+++ b/internal/storage/embeddeddolt/update_guards_test.go
@@ -1,0 +1,91 @@
+//go:build cgo
+
+package embeddeddolt_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/storage"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// TestEmbeddedUpdateIssueCheckedFieldGuards proves the bd-wsqvw
+// ExpectedAssignee/ExpectedStatus guards wire through the EmbeddedDoltStore's
+// withConn wrapper: a matching guard applies, a stale guard refuses atomically
+// with the typed mismatch error and the row untouched, and a pointer to "" is
+// a real "expected unassigned" guard. The compare-and-swap core is the shared
+// issueops.CheckExpectedFieldsInTx already covered against a real engine by
+// the dolt package; this test proves the embedded wrapper threads it and rolls
+// back.
+func TestEmbeddedUpdateIssueCheckedFieldGuards(t *testing.T) {
+	skipUnlessEmbeddedDolt(t)
+	te := newTestEnv(t, "ugd")
+	ctx := t.Context()
+	sptr := func(v string) *string { return &v }
+
+	create := func(id string) {
+		iss := &types.Issue{ID: id, Title: id, Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask}
+		if err := te.store.CreateIssue(ctx, iss, "tester"); err != nil {
+			t.Fatalf("create %s: %v", id, err)
+		}
+	}
+	get := func(id string) *types.Issue {
+		iss, err := te.store.GetIssue(ctx, id)
+		if err != nil {
+			t.Fatalf("GetIssue(%s): %v", id, err)
+		}
+		return iss
+	}
+
+	// Reassign X→Y with a matching assignee guard (the park transition).
+	create("ugd-park")
+	if err := te.store.ClaimIssue(ctx, "ugd-park", "worker"); err != nil {
+		t.Fatalf("seed claim: %v", err)
+	}
+	if err := te.store.UpdateIssueChecked(ctx, "ugd-park",
+		map[string]interface{}{"assignee": "mayor"}, "tester",
+		storage.UpdateIssueOptions{ExpectedAssignee: sptr("worker")}); err != nil {
+		t.Fatalf("guarded reassign err = %v, want nil", err)
+	}
+	if got := get("ugd-park").Assignee; got != "mayor" {
+		t.Fatalf("assignee = %q after guarded reassign, want %q", got, "mayor")
+	}
+
+	// Stale assignee guard refuses atomically: typed error, row untouched.
+	create("ugd-stale")
+	if err := te.store.ClaimIssue(ctx, "ugd-stale", "thief"); err != nil {
+		t.Fatalf("seed claim: %v", err)
+	}
+	err := te.store.UpdateIssueChecked(ctx, "ugd-stale",
+		map[string]interface{}{"assignee": "mayor", "title": "should-not-apply"}, "tester",
+		storage.UpdateIssueOptions{ExpectedAssignee: sptr("worker")})
+	if !errors.Is(err, storage.ErrAssigneeMismatch) {
+		t.Fatalf("err = %v, want errors.Is(_, ErrAssigneeMismatch)", err)
+	}
+	if iss := get("ugd-stale"); iss.Assignee != "thief" || iss.Title == "should-not-apply" {
+		t.Fatalf("row changed after refused guard (assignee=%q title=%q); tx must roll back", iss.Assignee, iss.Title)
+	}
+
+	// Claim-on-behalf: --if-assignee '' --if-status open (the restore transition).
+	create("ugd-restore")
+	if err := te.store.UpdateIssueChecked(ctx, "ugd-restore",
+		map[string]interface{}{"assignee": "owner", "status": "in_progress"}, "tester",
+		storage.UpdateIssueOptions{ExpectedAssignee: sptr(""), ExpectedStatus: sptr("open")}); err != nil {
+		t.Fatalf("claim-on-behalf err = %v, want nil", err)
+	}
+	if iss := get("ugd-restore"); iss.Assignee != "owner" || iss.Status != types.StatusInProgress {
+		t.Fatalf("got assignee=%q status=%q, want owner/in_progress", iss.Assignee, iss.Status)
+	}
+
+	// Status guard mismatch is typed.
+	err = te.store.UpdateIssueChecked(ctx, "ugd-restore",
+		map[string]interface{}{"assignee": "other"}, "tester",
+		storage.UpdateIssueOptions{ExpectedAssignee: sptr("owner"), ExpectedStatus: sptr("open")})
+	if !errors.Is(err, storage.ErrStatusMismatch) {
+		t.Fatalf("err = %v, want errors.Is(_, ErrStatusMismatch)", err)
+	}
+	if got := get("ugd-restore").Assignee; got != "owner" {
+		t.Fatalf("assignee = %q after refused update, want unchanged %q", got, "owner")
+	}
+}

--- a/internal/storage/issueops/update_cas.go
+++ b/internal/storage/issueops/update_cas.go
@@ -1,0 +1,53 @@
+package issueops
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+
+	"github.com/steveyegge/beads/internal/storage"
+)
+
+// CheckExpectedFieldsInTx reads the current assignee and status for id and
+// returns ErrAssigneeMismatch/ErrStatusMismatch (wrapped with actual vs
+// expected) when a non-nil guard differs — the semantic-field compare-and-swap
+// behind `bd update --if-assignee/--if-status` (bd-wsqvw). A non-nil pointer to
+// "" is a real guard meaning "expected unassigned"; nil disables that check.
+// Routes to the issues or wisps table. Returns ErrNotFound when the row is
+// absent.
+//
+// The CAS has the same two limbs as CheckVersionInTx: this read-side check
+// refuses a writer that committed before the caller's transaction began, and a
+// writer that commits DURING the transaction collides at commit time on the
+// row_lock cell (every mutating path rewrites row_lock), which the caller's
+// retry loop replays — the replayed attempt re-reads here and refuses.
+// Together they close the read-then-write window.
+//
+//nolint:gosec // G201: table name comes from WispTableRouting (hardcoded constants)
+func CheckExpectedFieldsInTx(ctx context.Context, tx DBTX, id string, expectedAssignee, expectedStatus *string) error {
+	if expectedAssignee == nil && expectedStatus == nil {
+		return nil
+	}
+	isWisp := IsActiveWispInTx(ctx, tx, id)
+	issueTable, _, _, _ := WispTableRouting(isWisp)
+
+	var assignee sql.NullString
+	var status string
+	err := tx.QueryRowContext(ctx,
+		fmt.Sprintf("SELECT assignee, status FROM %s WHERE id = ?", issueTable), id,
+	).Scan(&assignee, &status)
+	if errors.Is(err, sql.ErrNoRows) {
+		return fmt.Errorf("%w: issue %s", storage.ErrNotFound, id)
+	}
+	if err != nil {
+		return fmt.Errorf("failed to read assignee/status for %s: %w", id, err)
+	}
+	if expectedAssignee != nil && assignee.String != *expectedAssignee {
+		return fmt.Errorf("%w: %s is held by %q, expected %q", storage.ErrAssigneeMismatch, id, assignee.String, *expectedAssignee)
+	}
+	if expectedStatus != nil && status != *expectedStatus {
+		return fmt.Errorf("%w: %s has status %q, expected %q", storage.ErrStatusMismatch, id, status, *expectedStatus)
+	}
+	return nil
+}

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -69,6 +69,12 @@ var ErrCloseBlocked = errors.New("cannot close blocked issue")
 // precondition from other errors.
 var ErrVersionMismatch = errors.New("version mismatch")
 
+// ErrStatusMismatch is returned by UpdateIssueChecked given an ExpectedStatus
+// that no longer matches the issue's current status. The caller's view of the
+// issue was stale; the issue is left untouched. The assignee analog is
+// ErrAssigneeMismatch, shared with UnclaimIssueIfAssignee.
+var ErrStatusMismatch = errors.New("status mismatch")
+
 // CommentPageCursor is the resume position for a keyset page of an issue's
 // comments: the (created_at, id) of the last comment already returned. The zero
 // value starts a walk from the beginning of the thread.
@@ -329,6 +335,21 @@ type UpdateIssueOptions struct {
 	// nil disables the check. A pointer so nil is distinct from requiring a
 	// legacy version of 0.
 	ExpectedVersion *int64
+
+	// ExpectedAssignee and ExpectedStatus are semantic-field compare-and-swap
+	// guards (bd-wsqvw, `bd update --if-assignee/--if-status`): when non-nil,
+	// the update proceeds only if the issue's current assignee/status equals
+	// the expected value, else it refuses atomically with
+	// ErrAssigneeMismatch/ErrStatusMismatch naming the actual state. A non-nil
+	// pointer to "" is a real guard meaning "expected unassigned" — nil, not
+	// the empty string, disables a check. Guards present together must ALL
+	// hold (conjunction), and compose with ExpectedVersion. The guard read and
+	// the update share one transaction, so there is no internal TOCTOU; a
+	// concurrent writer that commits mid-transaction collides on the row_lock
+	// cell rewrite and is replayed by the store's retry loop, which re-reads
+	// and refuses (the same invariant as ExpectedVersion).
+	ExpectedAssignee *string
+	ExpectedStatus   *string
 }
 
 // MergeSlotStatus is returned by MergeSlotCheck and describes the current


### PR DESCRIPTION
## Summary

Implements bd-wsqvw: general conditional (compare-and-set) update — `bd update --if-assignee <expected> [--if-status <expected>]`. Design: `PROPOSAL-cas-conditional-update.md` (fly's handoff from wyvern's wheelhouse hostile-review, epic wy-mdi5h), committed in the base PR #5006.

**Stacked on #5006** (bd-zccb9 verify-after-write) — the guarded coordination writes route through its `verifiedClaimWrite`. Merge #5006 first; this PR's base is `bd-zccb9-claim-verify`.

The wheelhouse fleet's most common bug class is check-then-act on assignee/status: read state, decide, then issue a blind `bd update -a X` — and lose to a racing writer in the gap. Two transitions had no atomic primitive:

- **Reassign X→Y** (park, wy-mdi5h.3): `bd update <id> --if-assignee worker -a mayor`
- **Claim-on-behalf with a status guard** (restore, wy-mdi5h.6): `bd update <id> --if-assignee '' --if-status open -a owner -s in_progress`

When a guard is present the mutation applies only if the current value still matches — one atomic transaction, nothing written on a mismatch, loud non-zero exit naming actual vs expected. `--if-assignee ''` is a real guard meaning "expected unassigned" (`Changed()`-detected, the unclaim idiom).

## Design: reconciled with #4911

The proposal predates #4911 (`UpdateIssueChecked` + `ExpectedVersion` row CAS). Rather than the proposal's new `UpdateIssueIfMatch` interface method, the guards extend the **existing** `UpdateIssueOptions` (`ExpectedAssignee`/`ExpectedStatus` pointer fields, conjunction semantics, composing with `ExpectedVersion`):

- No `Storage` interface break; decorators (`HookFiringStore`, `InstrumentedStorage`) pass through unchanged.
- One shared guard primitive: `issueops.CheckExpectedFieldsInTx` beside `CheckVersionInTx`, typed `storage.ErrStatusMismatch` beside the existing `ErrAssigneeMismatch`.
- Same two-limb atomicity as the version CAS (reviewed in #4911): the guard read shares the mutation's transaction, and a writer that commits mid-flight collides on the row_lock cell rewrite at commit time — the retry loop replays, re-reads the guard, and refuses.

Wired through **all three write stacks**: `DoltStore` (server mode, incl. the wisp and demote-to-wisp branches), `EmbeddedDoltStore`, and the proxied-server path (`domain.UpdateSpec` → `ApplyUpdate`, guard failures flowing through the finding-#10 non-zero exit contract).

**bd-zccb9 integration:** in Dolt server mode a guarded update that writes assignee/status is claim-family — it resolves through `verifiedClaimWrite` with a `guardedUpdatePostcondition` (checks only the coordination fields the update actually sets), so its exit code stays truthful under a degraded server. Replay after a verified rollback re-checks the guards inside the replayed transaction, so a racing writer makes the replay refuse rather than clobber.

CLI rules: guards are mutually exclusive with `--claim` (its own CAS with pool semantics), require a regular field update to ride on (label/parent edits run outside the guarded transaction), and `--if-status` is validated against the live status set so a typo fails fast instead of mismatching forever.

## Testing

All against real engines; suites green:

- `internal/storage/dolt/update_guards_test.go` (Dolt container): park reassign, atomic refuse (typed error, row untouched, no event), claim-on-behalf, `--if-assignee ''` semantics, guard conjunction, composition with `ExpectedVersion`, wisp routing, and `TestGuardedReassignConcurrent` — two racing guarded reassigns, exactly one winner, loser gets `ErrAssigneeMismatch`.
- `internal/storage/embeddeddolt/update_guards_test.go`: same core through the embedded wrapper.
- `cmd/bd/update_conditional_embedded_test.go` (CLI e2e): guarded transitions, exactly-once semantics, mismatch names actual state, flag-validation rejections write nothing.
- `cmd/bd/update_conditional_proxied_test.go` (proxied server e2e): guarded reassign win/lose, claim-on-behalf, `--claim` exclusion.
- Regressions: dolt + embedded `UpdateIssueChecked` version-CAS suites, claim-verify suite, `domain`, `issueops` — all pass. Build/vet/gofmt/golangci-lint clean.

Docs note: per the 2026-07-17 docs-release-pin decision, no `docs/` changes — the generated CLI reference documents the pinned release; the flags are documented in `bd prime` output and CHANGELOG.

The wheelhouse *adoption* patches (queue-take wy-mdi5h.7, bulldog wy-mdi5h.4 switching to pool-aware `--claim`) are wyvern-side follow-ups, not part of this PR.

Closes bd-wsqvw.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


**CI note:** the pr workflow triggers only on PRs targeting main (`pull_request: branches: [main]`), so checks appear on this PR when it retargets main after #5006 merges. All four local suite layers are green (details above). Main itself has a red Test Nix Flake from the #4942 go.mod bump — fix in #5009.
