### PR TITLE
fix(nix): update vendorHash for the Go 1.26.5 dependency bump (bd-tub5q)

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -19,7 +19,7 @@ buildGoModule {
   # proxyVendor avoids vendor/modules.txt consistency checks when the vendored
   # tree lags go.mod/go.sum.
   proxyVendor = true;
-  vendorHash = "sha256-j+KnR2/0AxVkSfwO/C6/Zo2FjIC7iQs8RlZlrBt/8wc=";
+  vendorHash = "sha256-g3VILiRj/vRA04ahiPDEkUYZmjYp7X393tYEaM0TPbs=";
 
   # Match go.mod to the selected Nix Go toolchain. buildGoModule also builds
   # vendored dependencies in the Nix sandbox, where toolchain downloads are not


### PR DESCRIPTION
## Summary

Commit 4e2eeecc0 (#4942, Bump Go to 1.26.5) changed `go.mod` — Go version plus the x/text v0.39.0 bump for GO-2026-5970 — without regenerating `default.nix`'s `vendorHash`. The **Test Nix Flake** job has been red on main since, and every PR built atop it inherits the failure (first observed on #5006).

One line: `vendorHash` updated to the value the CI job's own mismatch report names (`use "sha256-g3VILiRj/vRA04ahiPDEkUYZmjYp7X393tYEaM0TPbs="`). This PR's own Test Nix Flake run is the verification.

Closes bd-tub5q.

🤖 Generated with [Claude Code](https://claude.com/claude-code)