### PR TITLE
fix(lint): replace reclaim_scope eq closure with slices.Equal (gosec G602)

### DIFF
--- a/internal/storage/conformance/reclaim_scope.go
+++ b/internal/storage/conformance/reclaim_scope.go
@@ -1,6 +1,7 @@
 package conformance
 
 import (
+	"slices"
 	"sort"
 	"testing"
 	"time"
@@ -53,17 +54,7 @@ func testReclaimScoped(t *testing.T, f Factory) {
 		must(t, err)
 		return got.Status == types.StatusInProgress
 	}
-	eq := func(got, want []string) bool {
-		if len(got) != len(want) {
-			return false
-		}
-		for i := range got {
-			if got[i] != want[i] {
-				return false
-			}
-		}
-		return true
-	}
+	eq := slices.Equal[[]string]
 
 	// --label (AND-set): only lane-b's stale lease is reverted; the lane-a and
 	// unlabeled claims are untouched even though a global reaper would take them.


### PR DESCRIPTION
## Why

Main is red at c38582b7e: the Lint gate fails with `internal/storage/conformance/reclaim_scope.go:61:21: G602: slice index out of range (gosec)`. The `eq` closure ranges over `got` while indexing `want`; the `len(got) != len(want)` guard on the line above makes it safe, but gosec can't prove that across the loop.

## What

Replace the closure body with `slices.Equal` — behaviorally identical (length check + elementwise compare), and the flagged indexing disappears entirely rather than being nolint-ed.

## Verification

`CGO_ENABLED=0 go build -tags gms_pure_go`, `go vet`, `gofmt -l`, and `golangci-lint run --build-tags gms_pure_go ./internal/storage/conformance/...` → 0 issues.

Stop-the-line per Base-Branch Health: while main is red this fix is the only mergeable PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

_claude-fable-5-high on behalf of matt wilkie_
