### PR TITLE
fix(dbproxy): verified identity for the managed proxied-server lifecycle (adoption, cleanup, kills)

### DIFF
--- a/.github/workflows/proxied-local-smoke.yml
+++ b/.github/workflows/proxied-local-smoke.yml
@@ -1,16 +1,17 @@
-# Managed-local proxied smoke lane.
+# Managed-local proxied lifecycle lane.
 #
 # The proxied shards in main.yml exercise command behavior against an
 # EXTERNALLY managed Dolt testcontainer. This lane covers the production
 # local-first path those shards cannot: bd launches its own loopback proxy,
 # the proxy launches a locally installed `dolt sql-server`, and the whole
 # lifecycle (create/read, loopback-only listeners, idle shutdown,
-# transparent restart with persistence) runs INSIDE a network namespace
-# with only loopback up — proving no outbound network is needed once the
-# binaries are installed. Linux first; Windows/macOS parity is tracked
-# separately.
+# transparent restart with persistence), identity failures, orphan recovery,
+# and start/stop convergence run INSIDE a network namespace with only
+# loopback up — proving no outbound network is needed once the binaries are
+# installed. Linux first; the test lane defines Windows/macOS parity but does
+# not implement those OS-specific observation helpers yet.
 
-name: Proxied Local Smoke
+name: Proxied Local Lifecycle
 
 on:
   workflow_dispatch:
@@ -86,20 +87,30 @@ jobs:
           go build -tags gms_pure_go -o /tmp/bd-under-test ./cmd/bd
           go test -tags gms_pure_go -c -o /tmp/proxied-local-smoke.test ./cmd/bd
 
-      - name: Assert the managed-local smoke test is compiled in
+      - name: Assert the managed-local lifecycle tests are compiled in
         run: |
           listed="$(
             BEADS_TEST_PROXIED_LOCAL=1 \
             BEADS_TEST_SKIP=dolt \
             /tmp/proxied-local-smoke.test \
-              -test.list '^TestManagedLocalProxiedLifecycleSmoke$'
+              -test.list '^TestManagedLocalProxied'
           )"
-          if [[ "$listed" != 'TestManagedLocalProxiedLifecycleSmoke' ]]; then
-            echo "managed-local smoke test missing or ambiguous; got: '$listed'" >&2
-            exit 1
-          fi
+          for test_name in \
+            TestManagedLocalProxiedLifecycleSmoke \
+            TestManagedLocalProxiedForeignListenerNotAdopted \
+            TestManagedLocalProxiedReusedPidNeverKilled \
+            TestManagedLocalProxiedLegacyRecordFailClosed \
+            TestManagedLocalProxiedOrphanBackendReaped \
+            TestManagedLocalProxiedNProcessColdStartConvergence \
+            TestManagedLocalProxiedStopStartInterleave
+          do
+            if ! grep -qx "$test_name" <<<"$listed"; then
+              echo "managed-local lifecycle test $test_name is missing; got: '$listed'" >&2
+              exit 1
+            fi
+          done
 
-      - name: Run managed-local lifecycle smoke offline (loopback-only netns)
+      - name: Run managed-local lifecycle lane offline (loopback-only netns)
         run: |
           sudo env \
             "PATH=$PATH" \
@@ -116,6 +127,6 @@ jobs:
               fi
               cd cmd/bd
               /tmp/proxied-local-smoke.test \
-                -test.run "^TestManagedLocalProxiedLifecycleSmoke$" \
+                -test.run "^TestManagedLocalProxied" \
                 -test.v -test.timeout 15m
             '

--- a/cmd/bd/dolt.go
+++ b/cmd/bd/dolt.go
@@ -597,7 +597,12 @@ var doltStopCmd = &cobra.Command{
 	Long: `Stop the dolt sql-server managed by beads for the current project.
 
 This sends a graceful shutdown signal. The server will restart automatically
-on the next bd command unless auto-start is disabled.`,
+on the next bd command unless auto-start is disabled.
+
+For a managed proxied server, --force can recover an unverifiable or legacy
+process record only after its live process executable is matched to bd or dolt.
+In that recovery path, force still refuses to signal a process whose executable
+identity cannot be matched to bd or dolt.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		beadsDir := selectedDoltBeadsDir()
 		if beadsDir == "" {
@@ -609,28 +614,159 @@ on the next bd command unless auto-start is disabled.`,
 		if !usesSQLServer() {
 			return HandleError("'bd dolt stop' is not supported in embedded mode (no Dolt server)")
 		}
+		force, _ := cmd.Flags().GetBool("force")
 
 		if usesProxiedServer() {
 			rootDir, err := resolveProxiedServerRootPath(beadsDir)
 			if err != nil {
 				return HandleError("%v", err)
 			}
-			if err := proxy.Shutdown(rootDir); err != nil {
-				return HandleError("%v", err)
+			shutdownErr := proxy.Shutdown(rootDir)
+			if shutdownErr == nil {
+				return renderDoltStopResult(doltStopResult{
+					Stopped:  true,
+					Force:    force,
+					Verified: boolPointer(true),
+				})
 			}
-			fmt.Println("Dolt server stopped.")
-			return nil
+			if !force || !proxy.CanForceStopUnverified(shutdownErr) {
+				return HandleErrorRespectJSON("%v", shutdownErr)
+			}
+
+			report, forceErr := proxy.ForceStopUnverified(rootDir)
+			return renderDoltStopResult(newForcedDoltStopResult(shutdownErr, report, forceErr))
 		}
 
 		serverDir := doltserver.ResolveServerDir(beadsDir)
-		force, _ := cmd.Flags().GetBool("force")
 
 		if err := doltserver.StopWithForce(serverDir, force); err != nil {
 			return HandleError("%v", err)
 		}
+		return renderDoltStopResult(doltStopResult{
+			Stopped: true,
+			Force:   force,
+		})
+	},
+}
+
+// doltStopResult is the shared JSON object for successful and refused stop
+// operations. Force-stop recovery deliberately exposes each irreversible
+// action so automation can distinguish a matched executable from a signaled
+// process and a quarantined record from one left in place.
+type doltStopResult struct {
+	Stopped               bool   `json:"stopped"`
+	Force                 bool   `json:"force"`
+	ForcedRecovery        bool   `json:"forced_recovery,omitempty"`
+	Verified              *bool  `json:"verified,omitempty"`
+	VerifiedShutdownError string `json:"verified_shutdown_error,omitempty"`
+	RecordFound           bool   `json:"record_found,omitempty"`
+	RecordPath            string `json:"record_path,omitempty"`
+	RecordLeftAlone       bool   `json:"record_left_alone,omitempty"`
+	LockWasHeld           bool   `json:"lock_was_held,omitempty"`
+	PID                   int    `json:"pid,omitempty"`
+	Executable            string `json:"executable,omitempty"`
+	ExecutableVerified    *bool  `json:"executable_verified,omitempty"`
+	ProcessWasGone        bool   `json:"process_was_gone,omitempty"`
+	SignalSent            bool   `json:"signal_sent,omitempty"`
+	ProcessLeftAlone      bool   `json:"process_left_alone,omitempty"`
+	QuarantinedPath       string `json:"quarantined_path,omitempty"`
+	Error                 string `json:"error,omitempty"`
+}
+
+func newForcedDoltStopResult(
+	shutdownErr error,
+	report proxy.ForceStopReport,
+	forceErr error,
+) doltStopResult {
+	result := doltStopResult{
+		Stopped:               forceErr == nil,
+		Force:                 true,
+		ForcedRecovery:        true,
+		Verified:              boolPointer(false),
+		VerifiedShutdownError: shutdownErr.Error(),
+		RecordFound:           report.RecordFound,
+		RecordPath:            report.RecordPath,
+		LockWasHeld:           report.LockWasHeld,
+		PID:                   report.PID,
+		Executable:            report.Executable,
+		ProcessWasGone:        report.ProcessWasGone,
+		SignalSent:            report.SignalSent,
+		QuarantinedPath:       report.QuarantinedPath,
+	}
+	if report.Executable != "" {
+		result.ExecutableVerified = boolPointer(
+			report.Executable == "bd" || report.Executable == "dolt",
+		)
+	}
+	result.ProcessLeftAlone = report.RecordFound &&
+		!report.ProcessWasGone &&
+		!report.SignalSent
+	result.RecordLeftAlone = report.RecordFound && report.QuarantinedPath == ""
+	if forceErr != nil {
+		result.Error = forceErr.Error()
+	}
+	return result
+}
+
+func boolPointer(value bool) *bool {
+	return &value
+}
+
+func renderDoltStopResult(result doltStopResult) error {
+	if jsonOutput {
+		if err := outputJSON(result); err != nil {
+			return HandleError("encode dolt stop result: %v", err)
+		}
+		if result.Error != "" {
+			return SilentExit()
+		}
+		return nil
+	}
+
+	if !result.ForcedRecovery {
 		fmt.Println("Dolt server stopped.")
 		return nil
-	},
+	}
+
+	fmt.Printf("Verified shutdown refused: %s\n", result.VerifiedShutdownError)
+	if result.Error == "" {
+		fmt.Println("Dolt server stopped with --force.")
+	} else if result.ProcessLeftAlone {
+		fmt.Println("Force stop refused; the recorded process was left alone.")
+	} else {
+		fmt.Println("Force stop incomplete; completed actions are reported below.")
+	}
+	if result.RecordFound {
+		fmt.Printf("  Record: %s\n", result.RecordPath)
+	}
+	if result.PID != 0 {
+		fmt.Printf("  PID: %d\n", result.PID)
+	}
+	if result.Executable != "" {
+		if result.ExecutableVerified != nil && *result.ExecutableVerified {
+			fmt.Printf("  Executable: %s (matched bd/dolt)\n", result.Executable)
+		} else {
+			fmt.Printf("  Executable: %s (not bd/dolt)\n", result.Executable)
+		}
+	}
+	switch {
+	case result.SignalSent:
+		fmt.Println("  Process: signal sent")
+	case result.ProcessWasGone:
+		fmt.Println("  Process: already gone; no signal sent")
+	case result.ProcessLeftAlone:
+		fmt.Println("  Process: left alone; no signal sent")
+	}
+	switch {
+	case result.QuarantinedPath != "":
+		fmt.Printf("  Record quarantined: %s\n", result.QuarantinedPath)
+	case result.RecordLeftAlone:
+		fmt.Println("  Record: left unchanged")
+	}
+	if result.Error != "" {
+		return HandleError("%s", result.Error)
+	}
+	return nil
 }
 
 var doltStatusCmd = &cobra.Command{
@@ -1479,7 +1615,7 @@ func isTimeoutError(err error) bool {
 
 func init() {
 	doltSetCmd.Flags().Bool("update-config", false, "Also write to config.yaml for team-wide defaults")
-	doltStopCmd.Flags().Bool("force", false, "Force stop the server")
+	doltStopCmd.Flags().Bool("force", false, "Force stop (proxied recovery still requires a bd/dolt executable match)")
 	doltPushCmd.Flags().Bool("force", false, "Force push (overwrite remote changes)")
 	doltPushCmd.Flags().String("remote", "", "Push to a specific named remote instead of the default")
 	doltPullCmd.Flags().String("remote", "", "Pull from a specific named remote instead of the default")

--- a/cmd/bd/dolt.go
+++ b/cmd/bd/dolt.go
@@ -599,10 +599,12 @@ var doltStopCmd = &cobra.Command{
 This sends a graceful shutdown signal. The server will restart automatically
 on the next bd command unless auto-start is disabled.
 
-For a managed proxied server, --force can recover an unverifiable or legacy
-process record only after its live process executable is matched to bd or dolt.
-In that recovery path, force still refuses to signal a process whose executable
-identity cannot be matched to bd or dolt.`,
+For a managed proxied server, --force can recover unverifiable or legacy
+process records (both the proxy and its backend) only after each live process
+executable is matched to bd or dolt and its command line ties it to this
+workspace. In that recovery path, force still refuses to signal a process
+whose executable identity cannot be matched to bd or dolt, or whose workspace
+scope cannot be established.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		beadsDir := selectedDoltBeadsDir()
 		if beadsDir == "" {
@@ -654,23 +656,37 @@ identity cannot be matched to bd or dolt.`,
 // action so automation can distinguish a matched executable from a signaled
 // process and a quarantined record from one left in place.
 type doltStopResult struct {
-	Stopped               bool   `json:"stopped"`
-	Force                 bool   `json:"force"`
-	ForcedRecovery        bool   `json:"forced_recovery,omitempty"`
-	Verified              *bool  `json:"verified,omitempty"`
-	VerifiedShutdownError string `json:"verified_shutdown_error,omitempty"`
-	RecordFound           bool   `json:"record_found,omitempty"`
-	RecordPath            string `json:"record_path,omitempty"`
-	RecordLeftAlone       bool   `json:"record_left_alone,omitempty"`
-	LockWasHeld           bool   `json:"lock_was_held,omitempty"`
-	PID                   int    `json:"pid,omitempty"`
-	Executable            string `json:"executable,omitempty"`
-	ExecutableVerified    *bool  `json:"executable_verified,omitempty"`
-	ProcessWasGone        bool   `json:"process_was_gone,omitempty"`
-	SignalSent            bool   `json:"signal_sent,omitempty"`
-	ProcessLeftAlone      bool   `json:"process_left_alone,omitempty"`
-	QuarantinedPath       string `json:"quarantined_path,omitempty"`
-	Error                 string `json:"error,omitempty"`
+	Stopped               bool                  `json:"stopped"`
+	Force                 bool                  `json:"force"`
+	ForcedRecovery        bool                  `json:"forced_recovery,omitempty"`
+	Verified              *bool                 `json:"verified,omitempty"`
+	VerifiedShutdownError string                `json:"verified_shutdown_error,omitempty"`
+	RecordFound           bool                  `json:"record_found,omitempty"`
+	RecordPath            string                `json:"record_path,omitempty"`
+	RecordLeftAlone       bool                  `json:"record_left_alone,omitempty"`
+	LockWasHeld           bool                  `json:"lock_was_held,omitempty"`
+	PID                   int                   `json:"pid,omitempty"`
+	Executable            string                `json:"executable,omitempty"`
+	ExecutableVerified    *bool                 `json:"executable_verified,omitempty"`
+	ProcessWasGone        bool                  `json:"process_was_gone,omitempty"`
+	SignalSent            bool                  `json:"signal_sent,omitempty"`
+	ProcessLeftAlone      bool                  `json:"process_left_alone,omitempty"`
+	QuarantinedPath       string                `json:"quarantined_path,omitempty"`
+	Backend               *doltStopRecordResult `json:"backend,omitempty"`
+	Error                 string                `json:"error,omitempty"`
+}
+
+// doltStopRecordResult mirrors the per-record force-stop fields for the
+// backend (proxy-child) record.
+type doltStopRecordResult struct {
+	RecordFound     bool   `json:"record_found,omitempty"`
+	RecordPath      string `json:"record_path,omitempty"`
+	LockWasHeld     bool   `json:"lock_was_held,omitempty"`
+	PID             int    `json:"pid,omitempty"`
+	Executable      string `json:"executable,omitempty"`
+	ProcessWasGone  bool   `json:"process_was_gone,omitempty"`
+	SignalSent      bool   `json:"signal_sent,omitempty"`
+	QuarantinedPath string `json:"quarantined_path,omitempty"`
 }
 
 func newForcedDoltStopResult(
@@ -702,6 +718,18 @@ func newForcedDoltStopResult(
 		!report.ProcessWasGone &&
 		!report.SignalSent
 	result.RecordLeftAlone = report.RecordFound && report.QuarantinedPath == ""
+	if report.Backend != nil {
+		result.Backend = &doltStopRecordResult{
+			RecordFound:     report.Backend.RecordFound,
+			RecordPath:      report.Backend.RecordPath,
+			LockWasHeld:     report.Backend.LockWasHeld,
+			PID:             report.Backend.PID,
+			Executable:      report.Backend.Executable,
+			ProcessWasGone:  report.Backend.ProcessWasGone,
+			SignalSent:      report.Backend.SignalSent,
+			QuarantinedPath: report.Backend.QuarantinedPath,
+		}
+	}
 	if forceErr != nil {
 		result.Error = forceErr.Error()
 	}
@@ -762,6 +790,25 @@ func renderDoltStopResult(result doltStopResult) error {
 		fmt.Printf("  Record quarantined: %s\n", result.QuarantinedPath)
 	case result.RecordLeftAlone:
 		fmt.Println("  Record: left unchanged")
+	}
+	if backend := result.Backend; backend != nil {
+		fmt.Printf("  Backend record: %s\n", backend.RecordPath)
+		if backend.PID != 0 {
+			fmt.Printf("  Backend PID: %d\n", backend.PID)
+		}
+		switch {
+		case backend.SignalSent:
+			fmt.Println("  Backend process: signal sent")
+		case backend.ProcessWasGone:
+			fmt.Println("  Backend process: already gone; no signal sent")
+		default:
+			fmt.Println("  Backend process: left alone; no signal sent")
+		}
+		if backend.QuarantinedPath != "" {
+			fmt.Printf("  Backend record quarantined: %s\n", backend.QuarantinedPath)
+		} else {
+			fmt.Println("  Backend record: left unchanged")
+		}
 	}
 	if result.Error != "" {
 		return HandleError("%s", result.Error)

--- a/cmd/bd/dolt_stop_test.go
+++ b/cmd/bd/dolt_stop_test.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/storage/dbproxy/proxy"
+)
+
+func TestDoltStopHelpStatesForceExecutableSafety(t *testing.T) {
+	normalizedHelp := strings.Join(strings.Fields(strings.ToLower(doltStopCmd.Long)), " ")
+	for _, want := range []string{
+		"force still refuses to signal",
+		"executable identity cannot be matched to bd or dolt",
+	} {
+		if !strings.Contains(normalizedHelp, want) {
+			t.Errorf("dolt stop long help missing %q:\n%s", want, doltStopCmd.Long)
+		}
+	}
+	flag := doltStopCmd.Flags().Lookup("force")
+	if flag == nil || !strings.Contains(flag.Usage, "bd/dolt executable match") {
+		t.Errorf("dolt stop --force usage does not state executable match: %+v", flag)
+	}
+}
+
+func TestNewForcedDoltStopResultReportsCompletedActions(t *testing.T) {
+	shutdownErr := errors.New("verified shutdown refused")
+	result := newForcedDoltStopResult(shutdownErr, proxy.ForceStopReport{
+		RecordPath:      "/tmp/proxy.pid",
+		PID:             42,
+		Executable:      "bd",
+		RecordFound:     true,
+		LockWasHeld:     true,
+		SignalSent:      true,
+		QuarantinedPath: "/tmp/proxy.pid.stale-1",
+	}, nil)
+
+	if !result.Stopped || !result.Force || !result.ForcedRecovery {
+		t.Fatalf("stop state = %+v, want completed forced recovery", result)
+	}
+	if result.Verified == nil || *result.Verified {
+		t.Fatalf("verified = %v, want explicit false", result.Verified)
+	}
+	if result.ExecutableVerified == nil || !*result.ExecutableVerified {
+		t.Fatalf("executable_verified = %v, want explicit true", result.ExecutableVerified)
+	}
+	if !result.SignalSent || result.ProcessLeftAlone {
+		t.Fatalf("process action = %+v, want signaled and not left alone", result)
+	}
+	if result.RecordLeftAlone || result.QuarantinedPath == "" {
+		t.Fatalf("record action = %+v, want quarantined and not left alone", result)
+	}
+}
+
+func TestNewForcedDoltStopResultReportsRefusalWithoutClaimingActions(t *testing.T) {
+	shutdownErr := errors.New("verified shutdown refused")
+	forceErr := errors.New("executable basename is \"sleep\", want bd or dolt")
+	result := newForcedDoltStopResult(shutdownErr, proxy.ForceStopReport{
+		RecordPath:  "/tmp/proxy.pid",
+		PID:         43,
+		Executable:  "sleep",
+		RecordFound: true,
+	}, forceErr)
+
+	if result.Stopped || result.Error != forceErr.Error() {
+		t.Fatalf("stop state = %+v, want refused with error", result)
+	}
+	if result.ExecutableVerified == nil || *result.ExecutableVerified {
+		t.Fatalf("executable_verified = %v, want explicit false", result.ExecutableVerified)
+	}
+	if result.SignalSent || result.ProcessWasGone || !result.ProcessLeftAlone {
+		t.Fatalf("process action = %+v, want left alone", result)
+	}
+	if !result.RecordLeftAlone || result.QuarantinedPath != "" {
+		t.Fatalf("record action = %+v, want unchanged", result)
+	}
+}

--- a/cmd/bd/proxied_local_identity_lifecycle_linux_test.go
+++ b/cmd/bd/proxied_local_identity_lifecycle_linux_test.go
@@ -1,0 +1,658 @@
+//go:build cgo && linux
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/steveyegge/beads/internal/procid"
+	"github.com/steveyegge/beads/internal/storage/dbproxy/pidfile"
+	"github.com/steveyegge/beads/internal/storage/dbproxy/proxy"
+	"github.com/steveyegge/beads/internal/storage/dbproxy/server"
+	"github.com/steveyegge/beads/internal/storage/dbproxy/util"
+)
+
+const managedLocalIdentityIdleTimeout = 5 * time.Minute
+
+func TestManagedLocalProxiedForeignListenerNotAdopted(t *testing.T) {
+	requireManagedLocalProxiedEnv(t)
+	bd := buildEmbeddedBD(t)
+	p, oldProxy, _ := initStoppedManagedLocal(t, bd, "mlforeign")
+
+	listener := startManagedForeignListener(t, oldProxy.Port)
+	wrongBirth, err := procid.Capture(os.Getpid())
+	if err != nil {
+		t.Fatalf("capture test-process birth token: %v", err)
+	}
+	doctored := *oldProxy
+	doctored.Birth = string(wrongBirth)
+	if err := pidfile.Write(p.proxyRoot, proxy.PIDFileName, doctored); err != nil {
+		t.Fatalf("write doctored proxy record: %v", err)
+	}
+
+	if out, err := bdProxiedRun(t, bd, p.dir, "list", "--json"); err != nil {
+		t.Fatalf("bd list did not self-heal a foreign listener: %v\n%s", err, out)
+	}
+	newProxy, newBackend := waitForManagedProxiedHealthy(t, p)
+	if newProxy.Port == oldProxy.Port {
+		t.Fatalf("replacement proxy reused foreign listener port %d", oldProxy.Port)
+	}
+	assertManagedPidfilesConsistent(t, p, newProxy, newBackend)
+	assertManagedForeignListenerReachable(t, listener)
+	assertManagedQuarantineCount(t, p.proxyRoot, proxy.PIDFileName, 1)
+}
+
+func TestManagedLocalProxiedReusedPidNeverKilled(t *testing.T) {
+	requireManagedLocalProxiedEnv(t)
+	bd := buildEmbeddedBD(t)
+	p, oldProxy, _ := initStoppedManagedLocal(t, bd, "mlreused")
+	helper := startManagedSleepProcess(t)
+
+	doctored := *oldProxy
+	doctored.Pid = helper.cmd.Process.Pid
+	// oldProxy.Birth is a valid token from the same boot, but it cannot
+	// match the newly spawned helper. This models numeric PID reuse without
+	// weakening the record into a syntactically invalid token.
+	if err := pidfile.Write(p.proxyRoot, proxy.PIDFileName, doctored); err != nil {
+		t.Fatalf("write reused-pid proxy record: %v", err)
+	}
+
+	if out, err := bdProxiedRun(t, bd, p.dir, "list", "--json"); err != nil {
+		t.Fatalf("bd list did not self-heal reused PID record: %v\n%s", err, out)
+	}
+	newProxy, newBackend := waitForManagedProxiedHealthy(t, p)
+	assertManagedPidfilesConsistent(t, p, newProxy, newBackend)
+	if !processAlive(helper.cmd.Process.Pid) {
+		t.Fatalf("unrelated helper pid %d was killed", helper.cmd.Process.Pid)
+	}
+	assertManagedQuarantineCount(t, p.proxyRoot, proxy.PIDFileName, 1)
+}
+
+func TestManagedLocalProxiedLegacyRecordFailClosed(t *testing.T) {
+	requireManagedLocalProxiedEnv(t)
+	bd := buildEmbeddedBD(t)
+
+	t.Run("free lock quarantines without signaling", func(t *testing.T) {
+		p, oldProxy, _ := initStoppedManagedLocal(t, bd, "mllegacyfree")
+		helper := startManagedSleepProcess(t)
+		writeManagedLegacyProxyRecord(t, p, helper.cmd.Process.Pid, oldProxy.Port)
+
+		if out, err := bdProxiedRun(t, bd, p.dir, "list", "--json"); err != nil {
+			t.Fatalf("bd list did not replace free-lock legacy record: %v\n%s", err, out)
+		}
+		waitForManagedProxiedHealthy(t, p)
+		if !processAlive(helper.cmd.Process.Pid) {
+			t.Fatalf("legacy-record helper pid %d was killed", helper.cmd.Process.Pid)
+		}
+		assertManagedQuarantineCount(t, p.proxyRoot, proxy.PIDFileName, 1)
+	})
+
+	t.Run("held lock refuses foreign executable", func(t *testing.T) {
+		p, oldProxy, _ := initStoppedManagedLocal(t, bd, "mllegacyforeign")
+		helper := startManagedSleepProcessHoldingLock(t, p)
+		writeManagedLegacyProxyRecord(t, p, helper.cmd.Process.Pid, oldProxy.Port)
+
+		listOut := bdProxiedListFail(t, bd, p)
+		assertManagedActionableLegacyError(t, listOut, p)
+
+		_, stopStderr, stopErr := bdProxiedRunBuffers(t, bd, p.dir, "dolt", "stop")
+		if stopErr == nil {
+			t.Fatalf("bd dolt stop unexpectedly accepted held legacy record:\n%s", stopStderr)
+		}
+		assertManagedActionableLegacyError(t, stopStderr, p)
+
+		forceStdout, forceStderr, forceErr := bdProxiedRunBuffers(
+			t, bd, p.dir, "dolt", "stop", "--force", "--json",
+		)
+		if forceErr == nil {
+			t.Fatalf("bd dolt stop --force signaled a foreign executable:\n%s", forceStdout)
+		}
+		result := decodeManagedDoltStopResult(t, forceStdout)
+		if got := result["process_left_alone"]; got != true {
+			t.Errorf("process_left_alone = %v, want true; result=%v", got, result)
+		}
+		if got := result["record_left_alone"]; got != true {
+			t.Errorf("record_left_alone = %v, want true; result=%v", got, result)
+		}
+		if !strings.Contains(fmt.Sprint(result["error"]), "want bd or dolt") {
+			t.Errorf("force error does not explain executable refusal: %v", result)
+		}
+		if strings.TrimSpace(forceStderr) != "" {
+			t.Errorf("--json force refusal wrote non-JSON stderr:\n%s", forceStderr)
+		}
+		if !processAlive(helper.cmd.Process.Pid) {
+			t.Fatalf("foreign helper pid %d was killed by --force", helper.cmd.Process.Pid)
+		}
+		if _, err := os.Stat(pidfile.Path(p.proxyRoot, proxy.PIDFileName)); err != nil {
+			t.Fatalf("legacy record was not left in place after refusal: %v", err)
+		}
+
+		stopManagedProcess(t, helper)
+		if err := pidfile.Remove(p.proxyRoot, proxy.PIDFileName); err != nil {
+			t.Fatalf("remove negative-case legacy record: %v", err)
+		}
+	})
+
+	t.Run("held lock accepts copied bd executable", func(t *testing.T) {
+		p, oldProxy, _ := initStoppedManagedLocal(t, bd, "mllegacybd")
+		helper := startCopiedBDManagedHelper(t, bd, p)
+		writeManagedLegacyProxyRecord(t, p, helper.cmd.Process.Pid, oldProxy.Port)
+
+		_, stopStderr, stopErr := bdProxiedRunBuffers(t, bd, p.dir, "dolt", "stop")
+		if stopErr == nil {
+			t.Fatalf("bd dolt stop unexpectedly accepted held legacy record:\n%s", stopStderr)
+		}
+		assertManagedActionableLegacyError(t, stopStderr, p)
+
+		forceStdout, forceStderr, forceErr := bdProxiedRunBuffers(
+			t, bd, p.dir, "dolt", "stop", "--force", "--json",
+		)
+		if forceErr != nil {
+			t.Fatalf("bd dolt stop --force rejected copied bd helper: %v\nstdout:\n%s\nstderr:\n%s",
+				forceErr, forceStdout, forceStderr)
+		}
+		result := decodeManagedDoltStopResult(t, forceStdout)
+		for field, want := range map[string]any{
+			"stopped":             true,
+			"force":               true,
+			"executable":          "bd",
+			"executable_verified": true,
+			"signal_sent":         true,
+		} {
+			if got := result[field]; got != want {
+				t.Errorf("%s = %v, want %v; result=%v", field, got, want, result)
+			}
+		}
+		if fmt.Sprint(result["quarantined_path"]) == "" {
+			t.Errorf("force result omitted quarantined_path: %v", result)
+		}
+		if processAlive(helper.cmd.Process.Pid) {
+			t.Fatalf("copied bd helper pid %d survived successful force stop", helper.cmd.Process.Pid)
+		}
+		if _, err := os.Stat(pidfile.Path(p.proxyRoot, proxy.PIDFileName)); !os.IsNotExist(err) {
+			t.Fatalf("legacy record remains after successful force stop: %v", err)
+		}
+		assertManagedQuarantineCount(t, p.proxyRoot, proxy.PIDFileName, 1)
+	})
+}
+
+func TestManagedLocalProxiedOrphanBackendReaped(t *testing.T) {
+	requireManagedLocalProxiedEnv(t)
+	bd := buildEmbeddedBD(t)
+	p := bdManagedLocalInit(t, bd, "mlorphan", managedLocalIdentityIdleTimeout)
+	oldProxy, oldBackend := waitForManagedProxiedHealthy(t, p)
+
+	proc, err := os.FindProcess(oldProxy.Pid)
+	if err != nil {
+		t.Fatalf("find proxy pid %d: %v", oldProxy.Pid, err)
+	}
+	if err := proc.Kill(); err != nil {
+		t.Fatalf("SIGKILL proxy pid %d: %v", oldProxy.Pid, err)
+	}
+	waitForManagedProxied(t, 10*time.Second, "SIGKILLed proxy exit", func() (bool, string) {
+		return !processAlive(oldProxy.Pid), fmt.Sprintf("proxy pid %d alive", oldProxy.Pid)
+	})
+	if !processAlive(oldBackend.Pid) {
+		t.Fatalf("backend pid %d did not survive proxy SIGKILL; test did not create an orphan", oldBackend.Pid)
+	}
+
+	if out, err := bdProxiedRun(t, bd, p.dir, "list", "--json"); err != nil {
+		t.Fatalf("bd list did not recover orphan backend: %v\n%s", err, out)
+	}
+	newProxy, newBackend := waitForManagedProxiedHealthy(t, p)
+	if processAlive(oldBackend.Pid) {
+		t.Fatalf("verified orphan backend pid %d survived recovery", oldBackend.Pid)
+	}
+	if newBackend.Pid == oldBackend.Pid {
+		t.Fatalf("replacement backend reused orphan pid %d", oldBackend.Pid)
+	}
+	assertManagedPidfilesConsistent(t, p, newProxy, newBackend)
+	assertManagedProcessCounts(t, p, 1, 1)
+	assertManagedQuarantineCount(t, p.proxyRoot, server.PIDFileName, 1)
+}
+
+func TestManagedLocalProxiedNProcessColdStartConvergence(t *testing.T) {
+	requireManagedLocalProxiedEnv(t)
+	bd := buildEmbeddedBD(t)
+	p, _, _ := initStoppedManagedLocal(t, bd, "mlconverge")
+
+	const workers = 5
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	start := make(chan struct{})
+	results := make([]managedCommandResult, workers)
+	var wg sync.WaitGroup
+	for i := range workers {
+		wg.Add(1)
+		go func(index int) {
+			defer wg.Done()
+			<-start
+			results[index] = runManagedCommand(ctx, bd, p.dir, "list", "--json")
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+
+	for i, result := range results {
+		if result.err != nil {
+			t.Errorf("worker %d failed: %v\nstdout:\n%s\nstderr:\n%s",
+				i, result.err, result.stdout, result.stderr)
+		}
+	}
+	if t.Failed() {
+		return
+	}
+	proxyPF, backendPF := waitForManagedProxiedHealthy(t, p)
+	assertManagedPidfilesConsistent(t, p, proxyPF, backendPF)
+	waitForManagedProxied(t, 10*time.Second, "losing cold-start processes to exit", func() (bool, string) {
+		proxies, backends := managedProcessPIDs(p)
+		return len(proxies) == 1 && len(backends) == 1,
+			fmt.Sprintf("proxy pids=%v backend pids=%v", proxies, backends)
+	})
+	assertManagedProcessCounts(t, p, 1, 1)
+}
+
+func TestManagedLocalProxiedStopStartInterleave(t *testing.T) {
+	requireManagedLocalProxiedEnv(t)
+	bd := buildEmbeddedBD(t)
+	p, _, _ := initStoppedManagedLocal(t, bd, "mlinterleave")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	start := make(chan struct{})
+	var listResult, stopResult managedCommandResult
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		<-start
+		listResult = runManagedCommand(ctx, bd, p.dir, "list", "--json")
+	}()
+	go func() {
+		defer wg.Done()
+		<-start
+		stopResult = runManagedCommand(ctx, bd, p.dir, "dolt", "stop")
+	}()
+	close(start)
+	wg.Wait()
+
+	if listResult.err != nil && stopResult.err != nil {
+		t.Fatalf("both interleaved operations failed\nlist: %v\n%s\nstop: %v\n%s",
+			listResult.err, listResult.stderr, stopResult.err, stopResult.stderr)
+	}
+
+	// The later successful completion defines the observable winner. When
+	// stop completes last, no process it was responsible for stopping may
+	// survive. When list completes last (or stop refuses), the started
+	// topology must be healthy.
+	wantRunning := listResult.err == nil &&
+		(stopResult.err != nil || listResult.ended.After(stopResult.ended))
+	if wantRunning {
+		proxyPF, backendPF := waitForManagedProxiedHealthy(t, p)
+		assertManagedPidfilesConsistent(t, p, proxyPF, backendPF)
+		assertManagedProcessCounts(t, p, 1, 1)
+		return
+	}
+	if stopResult.err != nil {
+		t.Fatalf("stop was the logical winner but failed: %v\n%s", stopResult.err, stopResult.stderr)
+	}
+	waitForManagedProxied(t, 10*time.Second, "stop-winning interleave to leave no topology", func() (bool, string) {
+		arts := snapshotManagedProxiedArtifacts(p)
+		proxies, backends := managedProcessPIDs(p)
+		done := !arts.ProxyPid && !arts.BackendPid && len(proxies) == 0 && len(backends) == 0
+		return done, fmt.Sprintf("artifacts=%+v proxy pids=%v backend pids=%v", arts, proxies, backends)
+	})
+}
+
+func initStoppedManagedLocal(
+	t *testing.T,
+	bd string,
+	prefix string,
+) (proxiedProject, *pidfile.PidFile, *pidfile.PidFile) {
+	t.Helper()
+	p := bdManagedLocalInit(t, bd, prefix, managedLocalIdentityIdleTimeout)
+	proxyPF, backendPF := waitForManagedProxiedHealthy(t, p)
+	if out, err := bdProxiedRun(t, bd, p.dir, "dolt", "stop"); err != nil {
+		t.Fatalf("bd dolt stop: %v\n%s", err, out)
+	}
+	waitForManagedProxiedShutdown(t, p, proxyPF.Pid, backendPF.Pid, 60*time.Second)
+	return p, proxyPF, backendPF
+}
+
+func waitForManagedProxiedHealthy(
+	t *testing.T,
+	p proxiedProject,
+) (*pidfile.PidFile, *pidfile.PidFile) {
+	t.Helper()
+	var proxyPF, backendPF *pidfile.PidFile
+	waitForManagedProxied(t, 60*time.Second, "healthy managed proxy and backend", func() (bool, string) {
+		proxyPF = readManagedProxyPidFile(t, p)
+		backendPF = readManagedBackendPidFile(t, p)
+		if proxyPF != nil && backendPF != nil &&
+			processAlive(proxyPF.Pid) && processAlive(backendPF.Pid) {
+			return true, ""
+		}
+		return false, fmt.Sprintf("proxy=%+v backend=%+v", proxyPF, backendPF)
+	})
+	return proxyPF, backendPF
+}
+
+func assertManagedPidfilesConsistent(
+	t *testing.T,
+	p proxiedProject,
+	proxyPF *pidfile.PidFile,
+	backendPF *pidfile.PidFile,
+) {
+	t.Helper()
+	if err := proxyPF.ValidateV2(pidfile.KindProxy); err != nil {
+		t.Errorf("proxy pidfile is not valid v2: %+v: %v", proxyPF, err)
+	}
+	if err := backendPF.ValidateV2(pidfile.KindDoltBackend); err != nil {
+		t.Errorf("backend pidfile is not valid v2: %+v: %v", backendPF, err)
+	}
+	if proxyPF.RootID == "" || proxyPF.RootID != backendPF.RootID {
+		t.Errorf("pidfile root identities disagree: proxy=%q backend=%q",
+			proxyPF.RootID, backendPF.RootID)
+	}
+	if proxyPF.ControlPort == 0 {
+		t.Errorf("proxy pidfile has no control port: %+v", proxyPF)
+	}
+	assertExpectedLoopbackListener(t, proxyPF.Pid, proxyPF.Port, "managed proxy")
+	assertExpectedLoopbackListener(t, backendPF.Pid, backendPF.Port, "managed backend")
+	assertManagedConfigLoopback(t, p, backendPF.Port)
+}
+
+func startManagedForeignListener(t *testing.T, port int) net.Listener {
+	t.Helper()
+	listener, err := net.Listen("tcp", net.JoinHostPort("127.0.0.1", strconv.Itoa(port)))
+	if err != nil {
+		t.Fatalf("occupy former proxy port %d: %v", port, err)
+	}
+	t.Cleanup(func() { _ = listener.Close() })
+	go func() {
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				return
+			}
+			_ = conn.Close()
+		}
+	}()
+	return listener
+}
+
+func assertManagedForeignListenerReachable(t *testing.T, listener net.Listener) {
+	t.Helper()
+	conn, err := net.DialTimeout("tcp", listener.Addr().String(), 2*time.Second)
+	if err != nil {
+		t.Fatalf("foreign listener was disturbed: %v", err)
+	}
+	_ = conn.Close()
+}
+
+func writeManagedLegacyProxyRecord(t *testing.T, p proxiedProject, processPID, port int) {
+	t.Helper()
+	if err := pidfile.Write(p.proxyRoot, proxy.PIDFileName, pidfile.PidFile{
+		Pid:  processPID,
+		Port: port,
+	}); err != nil {
+		t.Fatalf("write legacy proxy record: %v", err)
+	}
+}
+
+func assertManagedActionableLegacyError(t *testing.T, output string, p proxiedProject) {
+	t.Helper()
+	for _, want := range []string{
+		"legacy",
+		"old bd binary",
+		pidfile.Path(p.proxyRoot, proxy.PIDFileName),
+		".stale-<unix-timestamp>",
+	} {
+		if !strings.Contains(output, want) {
+			t.Errorf("legacy refusal missing %q:\n%s", want, output)
+		}
+	}
+}
+
+func assertManagedQuarantineCount(t *testing.T, root, name string, want int) {
+	t.Helper()
+	matches, err := filepath.Glob(filepath.Join(root, name+".stale-*"))
+	if err != nil {
+		t.Fatalf("glob quarantines for %s: %v", name, err)
+	}
+	if len(matches) != want {
+		t.Errorf("%s quarantine count = %d, want %d: %v", name, len(matches), want, matches)
+	}
+}
+
+type managedProcess struct {
+	cmd   *exec.Cmd
+	token procid.Token
+	done  <-chan error
+}
+
+func startManagedSleepProcess(t *testing.T) managedProcess {
+	t.Helper()
+	sleep, err := exec.LookPath("sleep")
+	if err != nil {
+		t.Fatalf("find sleep helper: %v", err)
+	}
+	return startManagedProcess(t, exec.Command(sleep, "300"))
+}
+
+func startManagedSleepProcessHoldingLock(t *testing.T, p proxiedProject) managedProcess {
+	t.Helper()
+	sleep, err := exec.LookPath("sleep")
+	if err != nil {
+		t.Fatalf("find sleep helper: %v", err)
+	}
+	return startManagedProcessHoldingProxyLock(t, p, exec.Command(sleep, "300"))
+}
+
+func startManagedProcessHoldingProxyLock(
+	t *testing.T,
+	p proxiedProject,
+	cmd *exec.Cmd,
+) managedProcess {
+	t.Helper()
+	lock, err := util.TryLock(filepath.Join(p.proxyRoot, proxy.LockFileName))
+	if err != nil {
+		t.Fatalf("hold proxy lock: %v", err)
+	}
+	parentFDClosed := false
+	t.Cleanup(func() {
+		if !parentFDClosed {
+			_ = lock.File().Close()
+		}
+	})
+	cmd.ExtraFiles = append(cmd.ExtraFiles, lock.File())
+	helper := startManagedProcess(t, cmd)
+	// Do not call Unlock: the child inherited this open file description and
+	// now owns the flock. Closing only the parent's descriptor makes the lock
+	// release automatically when the helper exits.
+	if err := lock.File().Close(); err != nil {
+		t.Fatalf("close parent proxy-lock descriptor: %v", err)
+	}
+	parentFDClosed = true
+	return helper
+}
+
+func startManagedProcess(t *testing.T, cmd *exec.Cmd) managedProcess {
+	t.Helper()
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start helper %s: %v", cmd.Path, err)
+	}
+	token, err := procid.Capture(cmd.Process.Pid)
+	if err != nil {
+		_ = cmd.Process.Kill()
+		_, _ = cmd.Process.Wait()
+		t.Fatalf("capture helper pid %d: %v", cmd.Process.Pid, err)
+	}
+	done := make(chan error, 1)
+	go func() {
+		done <- cmd.Wait()
+		close(done)
+	}()
+	helper := managedProcess{cmd: cmd, token: token, done: done}
+	t.Cleanup(func() { stopManagedProcess(t, helper) })
+	return helper
+}
+
+func stopManagedProcess(t *testing.T, helper managedProcess) {
+	t.Helper()
+	matched, err := procid.Verify(helper.cmd.Process.Pid, helper.token)
+	if err == nil && matched {
+		handle, openErr := procid.Open(helper.cmd.Process.Pid, helper.token)
+		if openErr == nil {
+			_ = handle.Kill()
+			_ = handle.Close()
+		}
+	}
+	select {
+	case <-helper.done:
+	case <-time.After(5 * time.Second):
+		t.Errorf("helper pid %d did not exit", helper.cmd.Process.Pid)
+	}
+}
+
+func startCopiedBDManagedHelper(t *testing.T, bd string, p proxiedProject) managedProcess {
+	t.Helper()
+	copyPath := filepath.Join(t.TempDir(), "bd")
+	copyExecutable(t, bd, copyPath)
+
+	upstream, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen for copied-bd upstream: %v", err)
+	}
+	t.Cleanup(func() { _ = upstream.Close() })
+	go func() {
+		for {
+			conn, err := upstream.Accept()
+			if err != nil {
+				return
+			}
+			_ = conn.Close()
+		}
+	}()
+	upstreamPort := upstream.Addr().(*net.TCPAddr).Port
+	helperRoot := t.TempDir()
+	cmd := exec.Command(
+		copyPath,
+		"db-proxy-child",
+		"--root", helperRoot,
+		"--port", "0",
+		"--idle-timeout", "-1ns",
+		"--backend", string(proxy.BackendExternal),
+		"--logpath", filepath.Join(helperRoot, "proxy.log"),
+		"--external-host", "127.0.0.1",
+		"--external-port", strconv.Itoa(upstreamPort),
+	)
+	helper := startManagedProcessHoldingProxyLock(t, p, cmd)
+	waitForManagedProxied(t, 10*time.Second, "copied bd helper to publish identity", func() (bool, string) {
+		pf, readErr := pidfile.Read(helperRoot, proxy.PIDFileName)
+		if readErr != nil {
+			return false, readErr.Error()
+		}
+		return pf != nil && pf.Pid == helper.cmd.Process.Pid && processAlive(pf.Pid),
+			fmt.Sprintf("pidfile=%+v helper alive=%v", pf, processAlive(helper.cmd.Process.Pid))
+	})
+	return helper
+}
+
+func copyExecutable(t *testing.T, source, target string) {
+	t.Helper()
+	in, err := os.Open(source) //nolint:gosec // source is the test-selected bd binary
+	if err != nil {
+		t.Fatalf("open helper source %s: %v", source, err)
+	}
+	defer in.Close()
+	out, err := os.OpenFile(target, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o700)
+	if err != nil {
+		t.Fatalf("create helper copy %s: %v", target, err)
+	}
+	if _, err := io.Copy(out, in); err != nil {
+		_ = out.Close()
+		t.Fatalf("copy helper binary: %v", err)
+	}
+	if err := out.Close(); err != nil {
+		t.Fatalf("close helper copy: %v", err)
+	}
+}
+
+func decodeManagedDoltStopResult(t *testing.T, output string) map[string]any {
+	t.Helper()
+	var result map[string]any
+	if err := json.Unmarshal([]byte(strings.TrimSpace(output)), &result); err != nil {
+		t.Fatalf("decode bd dolt stop JSON: %v\n%s", err, output)
+	}
+	return result
+}
+
+type managedCommandResult struct {
+	stdout string
+	stderr string
+	err    error
+	ended  time.Time
+}
+
+func runManagedCommand(ctx context.Context, bd, dir string, args ...string) managedCommandResult {
+	cmd := exec.CommandContext(ctx, bd, args...)
+	cmd.Dir = dir
+	cmd.Env = bdProxiedEnv(dir)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	return managedCommandResult{
+		stdout: stdout.String(),
+		stderr: stderr.String(),
+		err:    err,
+		ended:  time.Now(),
+	}
+}
+
+func managedProcessPIDs(p proxiedProject) (proxyPIDs, backendPIDs []int) {
+	entries, err := os.ReadDir("/proc")
+	if err != nil {
+		return nil, nil
+	}
+	configPath := proxiedServerConfigPath(p.beadsDir)
+	for _, entry := range entries {
+		pid, err := strconv.Atoi(entry.Name())
+		if err != nil {
+			continue
+		}
+		cmdline := procCmdline(pid)
+		switch {
+		case strings.Contains(cmdline, "db-proxy-child") &&
+			strings.Contains(cmdline, p.proxyRoot):
+			proxyPIDs = append(proxyPIDs, pid)
+		case strings.Contains(cmdline, "sql-server") &&
+			strings.Contains(cmdline, configPath):
+			backendPIDs = append(backendPIDs, pid)
+		}
+	}
+	return proxyPIDs, backendPIDs
+}
+
+func assertManagedProcessCounts(t *testing.T, p proxiedProject, wantProxy, wantBackend int) {
+	t.Helper()
+	proxyPIDs, backendPIDs := managedProcessPIDs(p)
+	if len(proxyPIDs) != wantProxy || len(backendPIDs) != wantBackend {
+		t.Errorf("managed process counts: proxy=%d (%v), backend=%d (%v); want %d/%d",
+			len(proxyPIDs), proxyPIDs, len(backendPIDs), backendPIDs, wantProxy, wantBackend)
+	}
+}

--- a/cmd/bd/proxied_local_identity_lifecycle_linux_test.go
+++ b/cmd/bd/proxied_local_identity_lifecycle_linux_test.go
@@ -549,6 +549,10 @@ func startCopiedBDManagedHelper(t *testing.T, bd string, p proxiedProject) manag
 	}()
 	upstreamPort := upstream.Addr().(*net.TCPAddr).Port
 	helperRoot := t.TempDir()
+	// The helper isolates its records under helperRoot, but force-stop only
+	// signals a process whose command line references the target workspace (a
+	// real pre-upgrade proxy carries the workspace in its --root argument);
+	// logging under p.proxyRoot models that scope without record collisions.
 	cmd := exec.Command(
 		copyPath,
 		"db-proxy-child",
@@ -556,7 +560,7 @@ func startCopiedBDManagedHelper(t *testing.T, bd string, p proxiedProject) manag
 		"--port", "0",
 		"--idle-timeout", "-1ns",
 		"--backend", string(proxy.BackendExternal),
-		"--logpath", filepath.Join(helperRoot, "proxy.log"),
+		"--logpath", filepath.Join(p.proxyRoot, "copied-bd-helper.log"),
 		"--external-host", "127.0.0.1",
 		"--external-port", strconv.Itoa(upstreamPort),
 	)

--- a/cmd/bd/proxied_local_lifecycle_linux_test.go
+++ b/cmd/bd/proxied_local_lifecycle_linux_test.go
@@ -19,13 +19,26 @@ package main
 // Run locally with:
 //
 //	BEADS_TEST_PROXIED_LOCAL=1 go test -tags gms_pure_go ./cmd/bd \
-//	    -run TestManagedLocalProxiedLifecycleSmoke -v
+//	    -run '^TestManagedLocalProxied' -v
 //
 // CI additionally runs it inside a network namespace with only loopback up
 // (see .github/workflows/proxied-local-smoke.yml), proving the whole
 // lifecycle needs no outbound network once bd and dolt are installed.
 // When BEADS_TEST_PROXIED_LOCAL=1 is set, missing prerequisites or a Dolt
 // child that fails to launch FAIL the test rather than skipping.
+//
+// Defined, not implemented in this Linux-first stage:
+//
+//   - macOS runs the same identity, legacy-record, orphan, convergence, and
+//     stop/start cases using Darwin birth tokens and process inspection,
+//     replacing procfs listener/process enumeration with native facilities.
+//   - Windows runs the same cases using creation-FILETIME identity and
+//     handle-safe termination, LockFileEx-compatible lock injection, and
+//     native listener/process enumeration.
+//
+// Both future lanes retain the same hermetic workspace, bounded-wait, and
+// executable-match safety assertions; only their OS-specific observation and
+// lock-injection helpers differ.
 
 import (
 	"context"

--- a/internal/procid/procid.go
+++ b/internal/procid/procid.go
@@ -1,0 +1,10 @@
+// Package procid provides process-birth identity for safe reattachment and
+// signaling of managed child processes. Its Token and Verify shape
+// intentionally matches the API requested in gastownhall/beads#4513 for
+// internal/doltserver, so that package can adopt it later. On macOS, where
+// this package has no pidfd equivalent, signaling uses verify, signal, verify
+// and retains a residual PID-reuse race.
+package procid
+
+// Token is an opaque, versioned process-birth identity.
+type Token string

--- a/internal/procid/procid_darwin.go
+++ b/internal/procid/procid_darwin.go
@@ -3,6 +3,7 @@
 package procid
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"syscall"
@@ -76,3 +77,9 @@ func (h *Handle) Signal(sig os.Signal) error {
 func (h *Handle) Kill() error { return h.Signal(syscall.SIGKILL) }
 
 func (h *Handle) Close() error { return nil }
+
+// IsProcessGone reports whether err means the referenced process no longer
+// exists.
+func IsProcessGone(err error) bool {
+	return errors.Is(err, unix.ESRCH)
+}

--- a/internal/procid/procid_darwin.go
+++ b/internal/procid/procid_darwin.go
@@ -7,9 +7,12 @@ import (
 	"fmt"
 	"os"
 	"syscall"
+	"time"
 
 	"golang.org/x/sys/unix"
 )
+
+const fallbackSignalConfirmTimeout = 2 * time.Second
 
 // Handle verifies before and after signaling. macOS has no pidfd equivalent
 // here, so a residual PID-reuse race remains between those operations.
@@ -30,7 +33,7 @@ func Capture(pid int) (Token, error) {
 func Verify(pid int, tok Token) (bool, error) {
 	current, err := Capture(pid)
 	if err != nil {
-		if err == unix.ESRCH {
+		if IsProcessGone(err) {
 			return false, nil
 		}
 		return false, err
@@ -62,7 +65,13 @@ func (h *Handle) Signal(sig os.Signal) error {
 		return fmt.Errorf("procid: unsupported signal %v", sig)
 	}
 	if err := syscall.Kill(h.pid, unixSig); err != nil {
+		if isFatalSignal(unixSig) && errors.Is(err, unix.ESRCH) {
+			return nil
+		}
 		return fmt.Errorf("procid: signal %d: %w", h.pid, err)
+	}
+	if isFatalSignal(unixSig) {
+		return h.confirmFatalSignal()
 	}
 	match, err = Verify(h.pid, h.token)
 	if err != nil {
@@ -74,6 +83,31 @@ func (h *Handle) Signal(sig os.Signal) error {
 	return nil
 }
 
+func (h *Handle) confirmFatalSignal() error {
+	deadline := time.Now().Add(fallbackSignalConfirmTimeout)
+	for {
+		match, err := Verify(h.pid, h.token)
+		if err != nil {
+			return err
+		}
+		if !match {
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf(
+				"procid: process %d still matches token after fatal signal and %s re-check",
+				h.pid,
+				fallbackSignalConfirmTimeout,
+			)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func isFatalSignal(sig syscall.Signal) bool {
+	return sig == syscall.SIGKILL || sig == syscall.SIGTERM
+}
+
 func (h *Handle) Kill() error { return h.Signal(syscall.SIGKILL) }
 
 func (h *Handle) Close() error { return nil }
@@ -81,5 +115,7 @@ func (h *Handle) Close() error { return nil }
 // IsProcessGone reports whether err means the referenced process no longer
 // exists.
 func IsProcessGone(err error) bool {
-	return errors.Is(err, unix.ESRCH)
+	// SysctlKinfoProc returns EIO when kern.proc.pid produces a zero-length
+	// result, which is Darwin's normal missing-pid result.
+	return errors.Is(err, unix.ESRCH) || errors.Is(err, unix.EIO)
 }

--- a/internal/procid/procid_darwin.go
+++ b/internal/procid/procid_darwin.go
@@ -1,0 +1,78 @@
+//go:build darwin
+
+package procid
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+
+	"golang.org/x/sys/unix"
+)
+
+// Handle verifies before and after signaling. macOS has no pidfd equivalent
+// here, so a residual PID-reuse race remains between those operations.
+type Handle struct {
+	pid   int
+	token Token
+}
+
+func Capture(pid int) (Token, error) {
+	proc, err := unix.SysctlKinfoProc("kern.proc.pid", pid)
+	if err != nil {
+		return "", fmt.Errorf("procid: sysctl process %d: %w", pid, err)
+	}
+	started := proc.Proc.P_starttime
+	return Token(fmt.Sprintf("darwin-v1:%d.%d", started.Sec, started.Usec)), nil
+}
+
+func Verify(pid int, tok Token) (bool, error) {
+	current, err := Capture(pid)
+	if err != nil {
+		if err == unix.ESRCH {
+			return false, nil
+		}
+		return false, err
+	}
+	return current == tok, nil
+}
+
+func Open(pid int, tok Token) (*Handle, error) {
+	match, err := Verify(pid, tok)
+	if err != nil {
+		return nil, err
+	}
+	if !match {
+		return nil, fmt.Errorf("procid: process %d does not match token", pid)
+	}
+	return &Handle{pid: pid, token: tok}, nil
+}
+
+func (h *Handle) Signal(sig os.Signal) error {
+	match, err := Verify(h.pid, h.token)
+	if err != nil {
+		return err
+	}
+	if !match {
+		return fmt.Errorf("procid: process %d no longer matches token", h.pid)
+	}
+	unixSig, ok := sig.(syscall.Signal)
+	if !ok {
+		return fmt.Errorf("procid: unsupported signal %v", sig)
+	}
+	if err := syscall.Kill(h.pid, unixSig); err != nil {
+		return fmt.Errorf("procid: signal %d: %w", h.pid, err)
+	}
+	match, err = Verify(h.pid, h.token)
+	if err != nil {
+		return err
+	}
+	if !match {
+		return fmt.Errorf("procid: process %d no longer matches token", h.pid)
+	}
+	return nil
+}
+
+func (h *Handle) Kill() error { return h.Signal(syscall.SIGKILL) }
+
+func (h *Handle) Close() error { return nil }

--- a/internal/procid/procid_linux.go
+++ b/internal/procid/procid_linux.go
@@ -9,8 +9,16 @@ import (
 	"strconv"
 	"strings"
 	"syscall"
+	"time"
 
 	"golang.org/x/sys/unix"
+)
+
+const fallbackSignalConfirmTimeout = 2 * time.Second
+
+var (
+	bootIDPath = "/proc/sys/kernel/random/boot_id"
+	pidfdOpen  = unix.PidfdOpen
 )
 
 // Handle identifies a process through a pidfd when the running kernel supports
@@ -24,9 +32,11 @@ type Handle struct {
 
 // Capture resolves pid's current process-birth token.
 func Capture(pid int) (Token, error) {
-	bootID, err := os.ReadFile("/proc/sys/kernel/random/boot_id")
+	bootID, err := os.ReadFile(bootIDPath)
 	if err != nil {
-		return "", fmt.Errorf("procid: read boot ID: %w", err)
+		// Do not unwrap this environmental failure: a missing or inaccessible
+		// boot_id is not evidence that the requested process is gone.
+		return "", &bootIDReadError{path: bootIDPath, err: err}
 	}
 	startTime, err := processStartTime(pid)
 	if err != nil {
@@ -58,7 +68,7 @@ func Open(pid int, tok Token) (*Handle, error) {
 		return nil, fmt.Errorf("procid: process %d does not match token", pid)
 	}
 
-	fd, err := unix.PidfdOpen(pid, 0)
+	fd, err := pidfdOpen(pid, 0)
 	if err == nil {
 		return &Handle{pid: pid, token: tok, pidfd: fd}, nil
 	}
@@ -115,7 +125,13 @@ func (h *Handle) verifyThenSignal(sig os.Signal) error {
 		return fmt.Errorf("procid: unsupported signal %v", sig)
 	}
 	if err := syscall.Kill(h.pid, unixSig); err != nil {
+		if isFatalSignal(unixSig) && errors.Is(err, unix.ESRCH) {
+			return nil
+		}
 		return fmt.Errorf("procid: signal %d: %w", h.pid, err)
+	}
+	if isFatalSignal(unixSig) {
+		return h.confirmFatalSignal()
 	}
 	match, err = Verify(h.pid, h.token)
 	if err != nil {
@@ -127,10 +143,35 @@ func (h *Handle) verifyThenSignal(sig os.Signal) error {
 	return nil
 }
 
+func (h *Handle) confirmFatalSignal() error {
+	deadline := time.Now().Add(fallbackSignalConfirmTimeout)
+	for {
+		match, err := Verify(h.pid, h.token)
+		if err != nil {
+			return err
+		}
+		if !match {
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf(
+				"procid: process %d still matches token after fatal signal and %s re-check",
+				h.pid,
+				fallbackSignalConfirmTimeout,
+			)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func isFatalSignal(sig syscall.Signal) bool {
+	return sig == syscall.SIGKILL || sig == syscall.SIGTERM
+}
+
 func processStartTime(pid int) (string, error) {
 	data, err := os.ReadFile("/proc/" + strconv.Itoa(pid) + "/stat")
 	if err != nil {
-		return "", fmt.Errorf("procid: read stat for %d: %w", pid, err)
+		return "", &processStatReadError{pid: pid, err: err}
 	}
 	return parseStartTime(string(data))
 }
@@ -146,14 +187,41 @@ func parseStartTime(stat string) (string, error) {
 	if len(fields) < 20 {
 		return "", errors.New("procid: malformed proc stat: missing starttime")
 	}
+	if fields[0] == "Z" || fields[0] == "X" || fields[0] == "x" {
+		return "", fmt.Errorf("procid: process is no longer running: %w", unix.ESRCH)
+	}
 	if _, err := strconv.ParseUint(fields[19], 10, 64); err != nil {
 		return "", fmt.Errorf("procid: malformed proc stat starttime: %w", err)
 	}
 	return fields[19], nil
 }
 
+type bootIDReadError struct {
+	path string
+	err  error
+}
+
+func (e *bootIDReadError) Error() string {
+	return fmt.Sprintf("procid: read boot ID %s: %v", e.path, e.err)
+}
+
+type processStatReadError struct {
+	pid int
+	err error
+}
+
+func (e *processStatReadError) Error() string {
+	return fmt.Sprintf("procid: read stat for %d: %v", e.pid, e.err)
+}
+
+func (e *processStatReadError) Unwrap() error {
+	return e.err
+}
+
 func isGone(err error) bool {
-	return errors.Is(err, os.ErrNotExist) || errors.Is(err, unix.ESRCH)
+	var statErr *processStatReadError
+	return (errors.As(err, &statErr) && errors.Is(statErr.err, os.ErrNotExist)) ||
+		errors.Is(err, unix.ESRCH)
 }
 
 // IsProcessGone reports whether err means the referenced process no longer

--- a/internal/procid/procid_linux.go
+++ b/internal/procid/procid_linux.go
@@ -59,23 +59,39 @@ func Verify(pid int, tok Token) (bool, error) {
 }
 
 // Open verifies pid's token and opens a handle suitable for safe signaling.
+//
+// The pidfd is opened before the token check: a pidfd pins the PID number
+// against reuse, so verifying afterwards proves the fd refers to the process
+// the token describes. Verifying first would leave a window where the
+// verified process exits, the PID is recycled, and the pidfd targets the
+// unrelated replacement.
 func Open(pid int, tok Token) (*Handle, error) {
-	match, err := Verify(pid, tok)
+	fd, err := pidfdOpen(pid, 0)
 	if err != nil {
-		return nil, err
+		if !errors.Is(err, unix.ENOSYS) {
+			return nil, fmt.Errorf("procid: pidfd open %d: %w", pid, err)
+		}
+		// Kernel without pidfds: fall back to verify-then-signal, which
+		// retains the documented small PID-reuse race.
+		match, verifyErr := Verify(pid, tok)
+		if verifyErr != nil {
+			return nil, verifyErr
+		}
+		if !match {
+			return nil, fmt.Errorf("procid: process %d does not match token", pid)
+		}
+		return &Handle{pid: pid, token: tok, pidfd: -1}, nil
+	}
+	match, verifyErr := Verify(pid, tok)
+	if verifyErr != nil {
+		_ = unix.Close(fd)
+		return nil, verifyErr
 	}
 	if !match {
+		_ = unix.Close(fd)
 		return nil, fmt.Errorf("procid: process %d does not match token", pid)
 	}
-
-	fd, err := pidfdOpen(pid, 0)
-	if err == nil {
-		return &Handle{pid: pid, token: tok, pidfd: fd}, nil
-	}
-	if !errors.Is(err, unix.ENOSYS) {
-		return nil, fmt.Errorf("procid: pidfd open %d: %w", pid, err)
-	}
-	return &Handle{pid: pid, token: tok, pidfd: -1}, nil
+	return &Handle{pid: pid, token: tok, pidfd: fd}, nil
 }
 
 // Signal sends sig to the verified process.
@@ -86,6 +102,11 @@ func (h *Handle) Signal(sig os.Signal) error {
 			return fmt.Errorf("procid: unsupported signal %v", sig)
 		}
 		if err := unix.PidfdSendSignal(h.pidfd, unixSig, nil, 0); err != nil {
+			if isFatalSignal(unixSig) && errors.Is(err, unix.ESRCH) {
+				// The target exited on its own after Open; a fatal signal's
+				// goal is already met, matching the fallback path.
+				return nil
+			}
 			return fmt.Errorf("procid: pidfd signal %d: %w", h.pid, err)
 		}
 		return nil

--- a/internal/procid/procid_linux.go
+++ b/internal/procid/procid_linux.go
@@ -1,0 +1,157 @@
+//go:build linux
+
+package procid
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"syscall"
+
+	"golang.org/x/sys/unix"
+)
+
+// Handle identifies a process through a pidfd when the running kernel supports
+// it. On older kernels without pidfds, it falls back to verify, signal, verify;
+// that fallback retains a small PID-reuse race.
+type Handle struct {
+	pid   int
+	token Token
+	pidfd int
+}
+
+// Capture resolves pid's current process-birth token.
+func Capture(pid int) (Token, error) {
+	bootID, err := os.ReadFile("/proc/sys/kernel/random/boot_id")
+	if err != nil {
+		return "", fmt.Errorf("procid: read boot ID: %w", err)
+	}
+	startTime, err := processStartTime(pid)
+	if err != nil {
+		return "", err
+	}
+	return Token("linux-v1:" + strings.TrimSpace(string(bootID)) + ":" + startTime), nil
+}
+
+// Verify reports whether pid still refers to tok. A process which has exited
+// returns false, nil.
+func Verify(pid int, tok Token) (bool, error) {
+	current, err := Capture(pid)
+	if err != nil {
+		if isGone(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return current == tok, nil
+}
+
+// Open verifies pid's token and opens a handle suitable for safe signaling.
+func Open(pid int, tok Token) (*Handle, error) {
+	match, err := Verify(pid, tok)
+	if err != nil {
+		return nil, err
+	}
+	if !match {
+		return nil, fmt.Errorf("procid: process %d does not match token", pid)
+	}
+
+	fd, err := unix.PidfdOpen(pid, 0)
+	if err == nil {
+		return &Handle{pid: pid, token: tok, pidfd: fd}, nil
+	}
+	if !errors.Is(err, unix.ENOSYS) {
+		return nil, fmt.Errorf("procid: pidfd open %d: %w", pid, err)
+	}
+	return &Handle{pid: pid, token: tok, pidfd: -1}, nil
+}
+
+// Signal sends sig to the verified process.
+func (h *Handle) Signal(sig os.Signal) error {
+	if h.pidfd >= 0 {
+		unixSig, ok := sig.(syscall.Signal)
+		if !ok {
+			return fmt.Errorf("procid: unsupported signal %v", sig)
+		}
+		if err := unix.PidfdSendSignal(h.pidfd, unixSig, nil, 0); err != nil {
+			return fmt.Errorf("procid: pidfd signal %d: %w", h.pid, err)
+		}
+		return nil
+	}
+	if err := h.verifyThenSignal(sig); err != nil {
+		return err
+	}
+	return nil
+}
+
+// Kill sends SIGKILL to the verified process.
+func (h *Handle) Kill() error { return h.Signal(syscall.SIGKILL) }
+
+// Close releases the underlying pidfd, if one was opened.
+func (h *Handle) Close() error {
+	if h.pidfd < 0 {
+		return nil
+	}
+	err := unix.Close(h.pidfd)
+	h.pidfd = -1
+	if err != nil {
+		return fmt.Errorf("procid: close pidfd: %w", err)
+	}
+	return nil
+}
+
+func (h *Handle) verifyThenSignal(sig os.Signal) error {
+	match, err := Verify(h.pid, h.token)
+	if err != nil {
+		return err
+	}
+	if !match {
+		return fmt.Errorf("procid: process %d no longer matches token", h.pid)
+	}
+	unixSig, ok := sig.(syscall.Signal)
+	if !ok {
+		return fmt.Errorf("procid: unsupported signal %v", sig)
+	}
+	if err := syscall.Kill(h.pid, unixSig); err != nil {
+		return fmt.Errorf("procid: signal %d: %w", h.pid, err)
+	}
+	match, err = Verify(h.pid, h.token)
+	if err != nil {
+		return err
+	}
+	if !match {
+		return fmt.Errorf("procid: process %d no longer matches token", h.pid)
+	}
+	return nil
+}
+
+func processStartTime(pid int) (string, error) {
+	data, err := os.ReadFile("/proc/" + strconv.Itoa(pid) + "/stat")
+	if err != nil {
+		return "", fmt.Errorf("procid: read stat for %d: %w", pid, err)
+	}
+	return parseStartTime(string(data))
+}
+
+func parseStartTime(stat string) (string, error) {
+	endComm := strings.LastIndex(stat, ")")
+	if endComm == -1 {
+		return "", errors.New("procid: malformed proc stat: missing comm terminator")
+	}
+	fields := strings.Fields(stat[endComm+1:])
+	// The remainder starts with state (field 3), so starttime (field 22) is
+	// its twentieth field.
+	if len(fields) < 20 {
+		return "", errors.New("procid: malformed proc stat: missing starttime")
+	}
+	if _, err := strconv.ParseUint(fields[19], 10, 64); err != nil {
+		return "", fmt.Errorf("procid: malformed proc stat starttime: %w", err)
+	}
+	return fields[19], nil
+}
+
+func isGone(err error) bool {
+	return errors.Is(err, os.ErrNotExist) || errors.Is(err, unix.ESRCH)
+}

--- a/internal/procid/procid_linux.go
+++ b/internal/procid/procid_linux.go
@@ -155,3 +155,10 @@ func parseStartTime(stat string) (string, error) {
 func isGone(err error) bool {
 	return errors.Is(err, os.ErrNotExist) || errors.Is(err, unix.ESRCH)
 }
+
+// IsProcessGone reports whether err means the referenced process no longer
+// exists. Callers use it to distinguish a dead recorded process from a live
+// process whose birth token does not match.
+func IsProcessGone(err error) bool {
+	return isGone(err)
+}

--- a/internal/procid/procid_linux_test.go
+++ b/internal/procid/procid_linux_test.go
@@ -98,6 +98,79 @@ func TestFallbackFatalSignalAcceptsExitedTarget(t *testing.T) {
 	}
 }
 
+func requirePidfdSupport(t *testing.T) {
+	t.Helper()
+	fd, err := pidfdOpen(os.Getpid(), 0)
+	if errors.Is(err, unix.ENOSYS) {
+		t.Skip("kernel has no pidfd support")
+	}
+	if err != nil {
+		t.Fatalf("pidfd open self: %v", err)
+	}
+	_ = unix.Close(fd)
+}
+
+// A fatal signal whose target exited naturally between Open and Signal must
+// count as success on the pidfd path, matching the fallback path: the process
+// is gone, which is the goal.
+func TestPidfdFatalSignalAcceptsExitedTarget(t *testing.T) {
+	requirePidfdSupport(t)
+
+	cmd := exec.Command("sleep", "30")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start child: %v", err)
+	}
+	tok, err := Capture(cmd.Process.Pid)
+	if err != nil {
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+		t.Fatalf("Capture(child): %v", err)
+	}
+	handle, err := Open(cmd.Process.Pid, tok)
+	if err != nil {
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+		t.Fatalf("Open(child): %v", err)
+	}
+	defer func() { _ = handle.Close() }()
+	if handle.pidfd < 0 {
+		t.Fatalf("Open pidfd = %d, want >= 0", handle.pidfd)
+	}
+	if err := cmd.Process.Kill(); err != nil {
+		t.Fatalf("kill child: %v", err)
+	}
+	_ = cmd.Wait() // reap, so the target is fully gone, not a zombie
+	if err := handle.Kill(); err != nil {
+		t.Fatalf("Kill after natural exit = %v, want nil", err)
+	}
+}
+
+// Open must not hand back a handle for an exited process, and the failure has
+// to classify as gone so lifecycle callers quarantine instead of refusing.
+func TestOpenReapedChildReportsGone(t *testing.T) {
+	requirePidfdSupport(t)
+
+	cmd := exec.Command("sleep", "0.05")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start child: %v", err)
+	}
+	tok, err := Capture(cmd.Process.Pid)
+	if err != nil {
+		_ = cmd.Wait()
+		t.Fatalf("Capture(child): %v", err)
+	}
+	if err := cmd.Wait(); err != nil {
+		t.Fatalf("wait child: %v", err)
+	}
+	_, err = Open(cmd.Process.Pid, tok)
+	if err == nil {
+		t.Fatal("Open(reaped child) succeeded, want error")
+	}
+	if !IsProcessGone(err) {
+		t.Fatalf("IsProcessGone(Open(reaped child)) = false for %v", err)
+	}
+}
+
 func TestVerifyZombieChildIsGone(t *testing.T) {
 	cmd := exec.Command("sleep", "0.05")
 	if err := cmd.Start(); err != nil {

--- a/internal/procid/procid_linux_test.go
+++ b/internal/procid/procid_linux_test.go
@@ -1,0 +1,35 @@
+//go:build linux
+
+package procid
+
+import "testing"
+
+func TestParseStartTime(t *testing.T) {
+	tests := []struct {
+		name string
+		stat string
+		want string
+	}{
+		{
+			name: "ordinary command",
+			stat: "123 (sleep) S 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 987654 20",
+			want: "987654",
+		},
+		{
+			name: "spaces and parentheses in command",
+			stat: "123 (a) b) S 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 42 20",
+			want: "42",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseStartTime(tt.stat)
+			if err != nil {
+				t.Fatalf("parseStartTime: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("parseStartTime = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/procid/procid_linux_test.go
+++ b/internal/procid/procid_linux_test.go
@@ -2,7 +2,16 @@
 
 package procid
 
-import "testing"
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"syscall"
+	"testing"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
 
 func TestParseStartTime(t *testing.T) {
 	tests := []struct {
@@ -31,5 +40,94 @@ func TestParseStartTime(t *testing.T) {
 				t.Errorf("parseStartTime = %q, want %q", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestCaptureBootIDFailureIsNotProcessGone(t *testing.T) {
+	previous := bootIDPath
+	bootIDPath = "/definitely-not-a-real-procid-boot-id"
+	t.Cleanup(func() { bootIDPath = previous })
+
+	_, err := Capture(os.Getpid())
+	if err == nil {
+		t.Fatal("Capture succeeded with missing boot_id, want error")
+	}
+	if IsProcessGone(err) {
+		t.Fatalf("IsProcessGone(%v) = true, want false for environmental boot_id failure", err)
+	}
+	if matched, verifyErr := Verify(os.Getpid(), "linux-v1:irrelevant:1"); verifyErr == nil || matched {
+		t.Fatalf("Verify with missing boot_id = (%v, %v), want (false, error)", matched, verifyErr)
+	}
+}
+
+func TestFallbackFatalSignalAcceptsExitedTarget(t *testing.T) {
+	previous := pidfdOpen
+	pidfdOpen = func(int, int) (int, error) { return -1, unix.ENOSYS }
+	t.Cleanup(func() { pidfdOpen = previous })
+
+	cmd := exec.Command("sleep", "30")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start child: %v", err)
+	}
+	waited := make(chan error, 1)
+	go func() { waited <- cmd.Wait() }()
+
+	tok, err := Capture(cmd.Process.Pid)
+	if err != nil {
+		_ = cmd.Process.Kill()
+		<-waited
+		t.Fatalf("Capture(child): %v", err)
+	}
+	handle, err := Open(cmd.Process.Pid, tok)
+	if err != nil {
+		_ = cmd.Process.Kill()
+		<-waited
+		t.Fatalf("Open(child): %v", err)
+	}
+	defer func() { _ = handle.Close() }()
+	if handle.pidfd != -1 {
+		t.Fatalf("Open fallback pidfd = %d, want -1", handle.pidfd)
+	}
+	if err := handle.Kill(); err != nil {
+		t.Fatalf("fallback Kill: %v", err)
+	}
+	select {
+	case <-waited:
+	case <-time.After(5 * time.Second):
+		t.Fatal("fallback-signaled child did not exit")
+	}
+}
+
+func TestVerifyZombieChildIsGone(t *testing.T) {
+	cmd := exec.Command("sleep", "0.05")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start child: %v", err)
+	}
+	tok, err := Capture(cmd.Process.Pid)
+	if err != nil {
+		_ = cmd.Wait()
+		t.Fatalf("Capture(child): %v", err)
+	}
+	defer func() { _ = cmd.Wait() }()
+
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		matched, verifyErr := Verify(cmd.Process.Pid, tok)
+		if verifyErr != nil {
+			t.Fatalf("Verify(zombie child): %v", verifyErr)
+		}
+		if !matched {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("Verify(zombie child) remained true")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	// Signal 0 still sees an unreaped zombie's PID, proving Verify classified
+	// process state rather than relying only on /proc/<pid> disappearing.
+	if err := syscall.Kill(cmd.Process.Pid, 0); err != nil && !errors.Is(err, unix.EPERM) {
+		t.Fatalf("signal 0 to unreaped zombie: %v", err)
 	}
 }

--- a/internal/procid/procid_test.go
+++ b/internal/procid/procid_test.go
@@ -1,0 +1,109 @@
+package procid
+
+import (
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestCaptureAndVerifySelf(t *testing.T) {
+	tok, err := Capture(os.Getpid())
+	if err != nil {
+		t.Fatalf("Capture(self): %v", err)
+	}
+	matched, err := Verify(os.Getpid(), tok)
+	if err != nil {
+		t.Fatalf("Verify(self): %v", err)
+	}
+	if !matched {
+		t.Fatal("Verify(self) = false, want true")
+	}
+	if runtime.GOOS == "linux" {
+		parts := strings.Split(string(tok), ":")
+		if len(parts) != 3 || parts[0] != "linux-v1" {
+			t.Fatalf("linux token = %q, want linux-v1 with three parts", tok)
+		}
+	}
+}
+
+func TestVerifyExitedChild(t *testing.T) {
+	cmd := exec.Command("sleep", "0.05")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start child: %v", err)
+	}
+	tok, err := Capture(cmd.Process.Pid)
+	if err != nil {
+		_ = cmd.Wait()
+		t.Fatalf("Capture(child): %v", err)
+	}
+	if err := cmd.Wait(); err != nil {
+		t.Fatalf("wait child: %v", err)
+	}
+	matched, err := Verify(cmd.Process.Pid, tok)
+	if err != nil {
+		t.Fatalf("Verify(exited child): %v", err)
+	}
+	if matched {
+		t.Fatal("Verify(exited child) = true, want false")
+	}
+}
+
+func TestVerifyWrongToken(t *testing.T) {
+	tok, err := Capture(os.Getpid())
+	if err != nil {
+		t.Fatalf("Capture(self): %v", err)
+	}
+	wrongText := string(tok)
+	last := wrongText[len(wrongText)-1]
+	if last == '0' {
+		last = '1'
+	} else {
+		last = '0'
+	}
+	wrong := Token(wrongText[:len(wrongText)-1] + string(last))
+	matched, err := Verify(os.Getpid(), wrong)
+	if err != nil {
+		t.Fatalf("Verify(wrong token): %v", err)
+	}
+	if matched {
+		t.Fatal("Verify(wrong token) = true, want false")
+	}
+}
+
+func TestOpen(t *testing.T) {
+	tok, err := Capture(os.Getpid())
+	if err != nil {
+		t.Fatalf("Capture(self): %v", err)
+	}
+	h, err := Open(os.Getpid(), tok)
+	if err != nil {
+		t.Fatalf("Open(self): %v", err)
+	}
+	if err := h.Close(); err != nil {
+		t.Fatalf("Close(self): %v", err)
+	}
+
+	cmd := exec.Command("sleep", "0.05")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start child: %v", err)
+	}
+	childToken, err := Capture(cmd.Process.Pid)
+	if err != nil {
+		_ = cmd.Wait()
+		t.Fatalf("Capture(child): %v", err)
+	}
+	if err := cmd.Wait(); err != nil {
+		t.Fatalf("wait child: %v", err)
+	}
+	if _, err := Open(cmd.Process.Pid, childToken); err == nil {
+		t.Fatal("Open(exited child) succeeded, want error")
+	}
+}
+
+func TestCaptureNonexistentProcess(t *testing.T) {
+	if _, err := Capture(1 << 22); err == nil {
+		t.Fatal("Capture(nonexistent process) succeeded, want error")
+	}
+}

--- a/internal/procid/procid_test.go
+++ b/internal/procid/procid_test.go
@@ -100,6 +100,13 @@ func TestOpen(t *testing.T) {
 	if _, err := Open(cmd.Process.Pid, childToken); err == nil {
 		t.Fatal("Open(exited child) succeeded, want error")
 	}
+	_, err = Capture(cmd.Process.Pid)
+	if err == nil {
+		t.Fatal("Capture(exited child) succeeded, want error")
+	}
+	if !IsProcessGone(err) {
+		t.Fatalf("IsProcessGone(Capture(exited child)) = false for %v", err)
+	}
 }
 
 func TestCaptureNonexistentProcess(t *testing.T) {

--- a/internal/procid/procid_test.go
+++ b/internal/procid/procid_test.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package procid
 
 import (
@@ -48,6 +50,8 @@ func TestVerifyExitedChild(t *testing.T) {
 	if matched {
 		t.Fatal("Verify(exited child) = true, want false")
 	}
+	// On Darwin this specifically exercises SysctlKinfoProc's zero-length/EIO
+	// missing-pid result; Linux normally reports ENOENT from /proc/<pid>/stat.
 }
 
 func TestVerifyWrongToken(t *testing.T) {
@@ -107,10 +111,14 @@ func TestOpen(t *testing.T) {
 	if !IsProcessGone(err) {
 		t.Fatalf("IsProcessGone(Capture(exited child)) = false for %v", err)
 	}
+	// The Darwin assertion above covers both wrapped ESRCH and the EIO mapping
+	// used by SysctlKinfoProc for a zero-length missing-pid result.
 }
 
 func TestCaptureNonexistentProcess(t *testing.T) {
 	if _, err := Capture(1 << 22); err == nil {
 		t.Fatal("Capture(nonexistent process) succeeded, want error")
+	} else if !IsProcessGone(err) {
+		t.Fatalf("IsProcessGone(Capture(nonexistent process)) = false for %v", err)
 	}
 }

--- a/internal/procid/procid_windows.go
+++ b/internal/procid/procid_windows.go
@@ -3,6 +3,7 @@
 package procid
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"strconv"
@@ -17,7 +18,7 @@ type Handle struct {
 }
 
 func Capture(pid int) (Token, error) {
-	process, err := openProcess(pid)
+	process, err := openProcess(pid, windows.PROCESS_QUERY_LIMITED_INFORMATION)
 	if err != nil {
 		return "", fmt.Errorf("procid: open process %d: %w", pid, err)
 	}
@@ -26,7 +27,7 @@ func Capture(pid int) (Token, error) {
 }
 
 func Verify(pid int, tok Token) (bool, error) {
-	process, err := openProcess(pid)
+	process, err := openProcess(pid, windows.PROCESS_QUERY_LIMITED_INFORMATION)
 	if err != nil {
 		if err == windows.ERROR_INVALID_PARAMETER {
 			return false, nil
@@ -42,7 +43,7 @@ func Verify(pid int, tok Token) (bool, error) {
 }
 
 func Open(pid int, tok Token) (*Handle, error) {
-	process, err := openProcess(pid)
+	process, err := openProcess(pid, windows.PROCESS_QUERY_LIMITED_INFORMATION|windows.PROCESS_TERMINATE)
 	if err != nil {
 		return nil, fmt.Errorf("procid: open process %d: %w", pid, err)
 	}
@@ -92,8 +93,8 @@ func (h *Handle) verify() error {
 	return nil
 }
 
-func openProcess(pid int) (windows.Handle, error) {
-	return windows.OpenProcess(windows.PROCESS_QUERY_LIMITED_INFORMATION, false, uint32(pid))
+func openProcess(pid int, access uint32) (windows.Handle, error) {
+	return windows.OpenProcess(access, false, uint32(pid))
 }
 
 func tokenForProcess(process windows.Handle) (Token, error) {
@@ -103,4 +104,10 @@ func tokenForProcess(process windows.Handle) (Token, error) {
 	}
 	value := uint64(created.HighDateTime)<<32 | uint64(created.LowDateTime)
 	return Token("windows-v1:" + strconv.FormatUint(value, 10)), nil
+}
+
+// IsProcessGone reports whether err means the referenced process no longer
+// exists.
+func IsProcessGone(err error) bool {
+	return errors.Is(err, windows.ERROR_INVALID_PARAMETER)
 }

--- a/internal/procid/procid_windows.go
+++ b/internal/procid/procid_windows.go
@@ -1,0 +1,106 @@
+//go:build windows
+
+package procid
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+
+	"golang.org/x/sys/windows"
+)
+
+// Handle keeps a Windows process handle open to prevent PID reuse.
+type Handle struct {
+	process windows.Handle
+	token   Token
+}
+
+func Capture(pid int) (Token, error) {
+	process, err := openProcess(pid)
+	if err != nil {
+		return "", fmt.Errorf("procid: open process %d: %w", pid, err)
+	}
+	defer windows.CloseHandle(process)
+	return tokenForProcess(process)
+}
+
+func Verify(pid int, tok Token) (bool, error) {
+	process, err := openProcess(pid)
+	if err != nil {
+		if err == windows.ERROR_INVALID_PARAMETER {
+			return false, nil
+		}
+		return false, fmt.Errorf("procid: open process %d: %w", pid, err)
+	}
+	defer windows.CloseHandle(process)
+	current, err := tokenForProcess(process)
+	if err != nil {
+		return false, err
+	}
+	return current == tok, nil
+}
+
+func Open(pid int, tok Token) (*Handle, error) {
+	process, err := openProcess(pid)
+	if err != nil {
+		return nil, fmt.Errorf("procid: open process %d: %w", pid, err)
+	}
+	current, err := tokenForProcess(process)
+	if err != nil || current != tok {
+		_ = windows.CloseHandle(process)
+		if err != nil {
+			return nil, err
+		}
+		return nil, fmt.Errorf("procid: process %d does not match token", pid)
+	}
+	return &Handle{process: process, token: tok}, nil
+}
+
+func (h *Handle) Signal(os.Signal) error {
+	if err := h.verify(); err != nil {
+		return err
+	}
+	if err := windows.TerminateProcess(h.process, 1); err != nil {
+		return fmt.Errorf("procid: terminate process: %w", err)
+	}
+	return nil
+}
+
+func (h *Handle) Kill() error { return h.Signal(os.Kill) }
+
+func (h *Handle) Close() error {
+	if h.process == 0 {
+		return nil
+	}
+	err := windows.CloseHandle(h.process)
+	h.process = 0
+	if err != nil {
+		return fmt.Errorf("procid: close process handle: %w", err)
+	}
+	return nil
+}
+
+func (h *Handle) verify() error {
+	current, err := tokenForProcess(h.process)
+	if err != nil {
+		return err
+	}
+	if current != h.token {
+		return fmt.Errorf("procid: process no longer matches token")
+	}
+	return nil
+}
+
+func openProcess(pid int) (windows.Handle, error) {
+	return windows.OpenProcess(windows.PROCESS_QUERY_LIMITED_INFORMATION, false, uint32(pid))
+}
+
+func tokenForProcess(process windows.Handle) (Token, error) {
+	var created, exited, kernel, user windows.Filetime
+	if err := windows.GetProcessTimes(process, &created, &exited, &kernel, &user); err != nil {
+		return "", fmt.Errorf("procid: get process times: %w", err)
+	}
+	value := uint64(created.HighDateTime)<<32 | uint64(created.LowDateTime)
+	return Token("windows-v1:" + strconv.FormatUint(value, 10)), nil
+}

--- a/internal/procid/procid_windows.go
+++ b/internal/procid/procid_windows.go
@@ -17,6 +17,16 @@ type Handle struct {
 	token   Token
 }
 
+// errProcessExited marks a process which is terminated but whose PID is still
+// resolvable because some handle (ours or a third party's, such as Task
+// Manager or an antivirus scanner) keeps the process object alive. Treating
+// it as gone keeps the invariant "Verify == true implies running" on Windows.
+var errProcessExited = errors.New("procid: process has exited")
+
+// stillActive is the GetExitCodeProcess sentinel for a running process
+// (STILL_ACTIVE, 259).
+const stillActive = 259
+
 func Capture(pid int) (Token, error) {
 	process, err := openProcess(pid, windows.PROCESS_QUERY_LIMITED_INFORMATION)
 	if err != nil {
@@ -29,7 +39,7 @@ func Capture(pid int) (Token, error) {
 func Verify(pid int, tok Token) (bool, error) {
 	process, err := openProcess(pid, windows.PROCESS_QUERY_LIMITED_INFORMATION)
 	if err != nil {
-		if err == windows.ERROR_INVALID_PARAMETER {
+		if errors.Is(err, windows.ERROR_INVALID_PARAMETER) {
 			return false, nil
 		}
 		return false, fmt.Errorf("procid: open process %d: %w", pid, err)
@@ -37,6 +47,9 @@ func Verify(pid int, tok Token) (bool, error) {
 	defer windows.CloseHandle(process)
 	current, err := tokenForProcess(process)
 	if err != nil {
+		if errors.Is(err, errProcessExited) {
+			return false, nil
+		}
 		return false, err
 	}
 	return current == tok, nil
@@ -60,9 +73,17 @@ func Open(pid int, tok Token) (*Handle, error) {
 
 func (h *Handle) Signal(os.Signal) error {
 	if err := h.verify(); err != nil {
+		if errors.Is(err, errProcessExited) {
+			// The target exited on its own after Open; termination's goal is
+			// already met.
+			return nil
+		}
 		return err
 	}
 	if err := windows.TerminateProcess(h.process, 1); err != nil {
+		if _, exitedErr := tokenForProcess(h.process); errors.Is(exitedErr, errProcessExited) {
+			return nil
+		}
 		return fmt.Errorf("procid: terminate process: %w", err)
 	}
 	return nil
@@ -98,6 +119,16 @@ func openProcess(pid int, access uint32) (windows.Handle, error) {
 }
 
 func tokenForProcess(process windows.Handle) (Token, error) {
+	// An open handle keeps a terminated process's PID resolvable and its
+	// creation time readable, so check liveness explicitly before minting a
+	// token for it.
+	var code uint32
+	if err := windows.GetExitCodeProcess(process, &code); err != nil {
+		return "", fmt.Errorf("procid: get process exit code: %w", err)
+	}
+	if code != stillActive {
+		return "", errProcessExited
+	}
 	var created, exited, kernel, user windows.Filetime
 	if err := windows.GetProcessTimes(process, &created, &exited, &kernel, &user); err != nil {
 		return "", fmt.Errorf("procid: get process times: %w", err)
@@ -109,5 +140,6 @@ func tokenForProcess(process windows.Handle) (Token, error) {
 // IsProcessGone reports whether err means the referenced process no longer
 // exists.
 func IsProcessGone(err error) bool {
-	return errors.Is(err, windows.ERROR_INVALID_PARAMETER)
+	return errors.Is(err, windows.ERROR_INVALID_PARAMETER) ||
+		errors.Is(err, errProcessExited)
 }

--- a/internal/procid/procid_windows_test.go
+++ b/internal/procid/procid_windows_test.go
@@ -1,0 +1,67 @@
+//go:build windows
+
+package procid
+
+import (
+	"os/exec"
+	"testing"
+	"time"
+)
+
+// A terminated process stays PID-resolvable for as long as anyone holds a
+// handle to it (our own os.Process here models Task Manager, antivirus, or a
+// debugger). Verify must still classify it as not matching: the invariant is
+// "Verify == true implies running" on every platform.
+func TestVerifyAfterTerminateWhileHandleHeld(t *testing.T) {
+	cmd := exec.Command("ping", "-n", "30", "127.0.0.1")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start child: %v", err)
+	}
+	// cmd.Process keeps a handle open until Wait, pinning the PID; Wait only
+	// in cleanup so the pin outlives every assertion below.
+	defer func() { _ = cmd.Wait() }()
+	pid := cmd.Process.Pid
+
+	tok, err := Capture(pid)
+	if err != nil {
+		_ = cmd.Process.Kill()
+		t.Fatalf("Capture(child): %v", err)
+	}
+	handle, err := Open(pid, tok)
+	if err != nil {
+		_ = cmd.Process.Kill()
+		t.Fatalf("Open(child): %v", err)
+	}
+	defer func() { _ = handle.Close() }()
+
+	if err := handle.Kill(); err != nil {
+		t.Fatalf("Kill(child): %v", err)
+	}
+
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		matched, verifyErr := Verify(pid, tok)
+		if verifyErr != nil {
+			t.Fatalf("Verify(terminated child): %v", verifyErr)
+		}
+		if !matched {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("Verify kept matching a terminated process whose handle is still held")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	if _, captureErr := Capture(pid); captureErr == nil {
+		t.Fatal("Capture(terminated child) succeeded, want process-gone error")
+	} else if !IsProcessGone(captureErr) {
+		t.Fatalf("IsProcessGone(Capture(terminated child)) = false for %v", captureErr)
+	}
+
+	// A repeat fatal signal against the already-terminated target is a
+	// success, not a shutdown failure.
+	if err := handle.Kill(); err != nil {
+		t.Fatalf("Kill(terminated child) = %v, want nil", err)
+	}
+}

--- a/internal/storage/dbproxy/identity/control.go
+++ b/internal/storage/dbproxy/identity/control.go
@@ -1,0 +1,64 @@
+package identity
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"strconv"
+	"time"
+)
+
+const maxIdentReplyBytes = 4096
+
+// ErrIdentRefused reports that a control listener closed the connection
+// without replying to an identity request.
+var ErrIdentRefused = errors.New("identity: request refused")
+
+// IdentReply is the authenticated identity published by a managed proxy.
+type IdentReply struct {
+	Schema      int    `json:"schema"`
+	Role        string `json:"role"`
+	RootID      string `json:"root_id"`
+	UpstreamID  string `json:"upstream_id"`
+	PID         int    `json:"pid"`
+	Birth       string `json:"birth"`
+	DataPort    int    `json:"data_port"`
+	ControlPort int    `json:"control_port"`
+}
+
+// Identify authenticates to a proxy control listener and returns its identity.
+func Identify(host string, controlPort int, secret string, timeout time.Duration) (*IdentReply, error) {
+	addr := net.JoinHostPort(host, strconv.Itoa(controlPort))
+	conn, err := net.DialTimeout("tcp", addr, timeout)
+	if err != nil {
+		return nil, fmt.Errorf("identity: dial control listener: %w", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	if err := conn.SetDeadline(time.Now().Add(timeout)); err != nil {
+		return nil, fmt.Errorf("identity: set control deadline: %w", err)
+	}
+	if _, err := io.WriteString(conn, "IDENT "+secret+"\n"); err != nil {
+		return nil, fmt.Errorf("identity: write request: %w", err)
+	}
+
+	line, err := bufio.NewReader(io.LimitReader(conn, maxIdentReplyBytes+1)).ReadString('\n')
+	if errors.Is(err, io.EOF) && len(line) == 0 {
+		return nil, ErrIdentRefused
+	}
+	if err != nil {
+		return nil, fmt.Errorf("identity: read reply: %w", err)
+	}
+	if len(line) > maxIdentReplyBytes {
+		return nil, errors.New("identity: oversized reply")
+	}
+
+	var reply IdentReply
+	if err := json.Unmarshal([]byte(line), &reply); err != nil {
+		return nil, fmt.Errorf("identity: decode reply: %w", err)
+	}
+	return &reply, nil
+}

--- a/internal/storage/dbproxy/identity/control.go
+++ b/internal/storage/dbproxy/identity/control.go
@@ -2,6 +2,10 @@ package identity
 
 import (
 	"bufio"
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -11,7 +15,10 @@ import (
 	"time"
 )
 
-const maxIdentReplyBytes = 4096
+const (
+	maxIdentReplyBytes = 4096
+	identNonceBytes    = 16
+)
 
 // ErrIdentRefused reports that a control listener closed the connection
 // without replying to an identity request.
@@ -27,6 +34,7 @@ type IdentReply struct {
 	Birth       string `json:"birth"`
 	DataPort    int    `json:"data_port"`
 	ControlPort int    `json:"control_port"`
+	MAC         string `json:"mac"`
 }
 
 // Identify authenticates to a proxy control listener and returns its identity.
@@ -41,7 +49,12 @@ func Identify(host string, controlPort int, secret string, timeout time.Duration
 	if err := conn.SetDeadline(time.Now().Add(timeout)); err != nil {
 		return nil, fmt.Errorf("identity: set control deadline: %w", err)
 	}
-	if _, err := io.WriteString(conn, "IDENT "+secret+"\n"); err != nil {
+	nonceBytes := make([]byte, identNonceBytes)
+	if _, err := rand.Read(nonceBytes); err != nil {
+		return nil, fmt.Errorf("identity: generate request nonce: %w", err)
+	}
+	nonce := hex.EncodeToString(nonceBytes)
+	if _, err := io.WriteString(conn, "IDENT "+secret+" "+nonce+"\n"); err != nil {
 		return nil, fmt.Errorf("identity: write request: %w", err)
 	}
 
@@ -60,5 +73,78 @@ func Identify(host string, controlPort int, secret string, timeout time.Duration
 	if err := json.Unmarshal([]byte(line), &reply); err != nil {
 		return nil, fmt.Errorf("identity: decode reply: %w", err)
 	}
+	if err := VerifyIdentReply(reply, secret, nonce); err != nil {
+		return nil, err
+	}
 	return &reply, nil
+}
+
+// SignIdentReply authenticates reply for the nonce in an IDENT request.
+// The MAC covers the raw nonce bytes followed by canonical JSON for every
+// reply field except MAC.
+func SignIdentReply(reply IdentReply, secret, nonce string) (IdentReply, error) {
+	nonceBytes, err := decodeIdentNonce(nonce)
+	if err != nil {
+		return IdentReply{}, err
+	}
+	payload, err := canonicalIdentReply(reply)
+	if err != nil {
+		return IdentReply{}, err
+	}
+	mac := hmac.New(sha256.New, []byte(secret))
+	_, _ = mac.Write(nonceBytes)
+	_, _ = mac.Write(payload)
+	reply.MAC = hex.EncodeToString(mac.Sum(nil))
+	return reply, nil
+}
+
+// VerifyIdentReply verifies the authenticated reply for the request nonce.
+func VerifyIdentReply(reply IdentReply, secret, nonce string) error {
+	got, err := hex.DecodeString(reply.MAC)
+	if err != nil {
+		return errors.New("identity: invalid reply MAC")
+	}
+	signed, err := SignIdentReply(reply, secret, nonce)
+	if err != nil {
+		return fmt.Errorf("identity: authenticate reply: %w", err)
+	}
+	want, err := hex.DecodeString(signed.MAC)
+	if err != nil {
+		return fmt.Errorf("identity: decode expected reply MAC: %w", err)
+	}
+	if !hmac.Equal(got, want) {
+		return errors.New("identity: reply authentication failed")
+	}
+	return nil
+}
+
+func decodeIdentNonce(nonce string) ([]byte, error) {
+	raw, err := hex.DecodeString(nonce)
+	if err != nil || len(raw) != identNonceBytes {
+		return nil, errors.New("identity: invalid request nonce")
+	}
+	return raw, nil
+}
+
+func canonicalIdentReply(reply IdentReply) ([]byte, error) {
+	payload := struct {
+		Schema      int    `json:"schema"`
+		Role        string `json:"role"`
+		RootID      string `json:"root_id"`
+		UpstreamID  string `json:"upstream_id"`
+		PID         int    `json:"pid"`
+		Birth       string `json:"birth"`
+		DataPort    int    `json:"data_port"`
+		ControlPort int    `json:"control_port"`
+	}{
+		Schema:      reply.Schema,
+		Role:        reply.Role,
+		RootID:      reply.RootID,
+		UpstreamID:  reply.UpstreamID,
+		PID:         reply.PID,
+		Birth:       reply.Birth,
+		DataPort:    reply.DataPort,
+		ControlPort: reply.ControlPort,
+	}
+	return json.Marshal(payload)
 }

--- a/internal/storage/dbproxy/identity/identity.go
+++ b/internal/storage/dbproxy/identity/identity.go
@@ -1,0 +1,65 @@
+// Package identity provides shared managed dbproxy identity primitives.
+package identity
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/steveyegge/beads/internal/atomicfile"
+)
+
+// SecretFileName is the per-workspace secret used to authenticate control
+// listener requests.
+const SecretFileName = "proxy.secret"
+
+// RootID returns the SHA-256 of rootDir's symlink-resolved absolute path.
+// It identifies the workspace proxy root, not the Dolt data directory;
+// upstream_id continues to identify the backend through DoltServer.ID.
+func RootID(rootDir string) (string, error) {
+	abs, err := filepath.Abs(rootDir)
+	if err != nil {
+		return "", fmt.Errorf("identity: absolute root path: %w", err)
+	}
+	resolved, err := filepath.EvalSymlinks(abs)
+	if err != nil {
+		return "", fmt.Errorf("identity: resolve root path: %w", err)
+	}
+	sum := sha256.Sum256([]byte(resolved))
+	return hex.EncodeToString(sum[:]), nil
+}
+
+// WriteSecret creates and atomically writes a new control-listener secret.
+// Each proxy start intentionally rotates the previous secret.
+func WriteSecret(rootDir string) (string, error) {
+	raw := make([]byte, 32)
+	if _, err := rand.Read(raw); err != nil {
+		return "", fmt.Errorf("identity: generate proxy secret: %w", err)
+	}
+	secret := hex.EncodeToString(raw)
+	if err := atomicfile.WriteFile(filepath.Join(rootDir, SecretFileName), []byte(secret+"\n"), 0o600); err != nil {
+		return "", fmt.Errorf("identity: write proxy secret: %w", err)
+	}
+	return secret, nil
+}
+
+// ReadSecret reads and validates the control-listener secret.
+func ReadSecret(rootDir string) (string, error) {
+	data, err := os.ReadFile(filepath.Join(rootDir, SecretFileName)) // #nosec G304 - rootDir is the workspace proxy root, not user input
+	if err != nil {
+		return "", fmt.Errorf("identity: read proxy secret: %w", err)
+	}
+	secret := strings.TrimSpace(string(data))
+	if len(secret) != 64 {
+		return "", errors.New("identity: invalid proxy secret")
+	}
+	if _, err := hex.DecodeString(secret); err != nil {
+		return "", errors.New("identity: invalid proxy secret")
+	}
+	return secret, nil
+}

--- a/internal/storage/dbproxy/identity/identity.go
+++ b/internal/storage/dbproxy/identity/identity.go
@@ -21,6 +21,9 @@ const SecretFileName = "proxy.secret"
 // RootID returns the SHA-256 of rootDir's symlink-resolved absolute path.
 // It identifies the workspace proxy root, not the Dolt data directory;
 // upstream_id continues to identify the backend through DoltServer.ID.
+// Darwin's default case-insensitive filesystems can resolve the same directory
+// through differently cased path spellings; callers should use a canonical
+// workspace spelling when they need stable IDs across invocations.
 func RootID(rootDir string) (string, error) {
 	abs, err := filepath.Abs(rootDir)
 	if err != nil {

--- a/internal/storage/dbproxy/identity/identity_test.go
+++ b/internal/storage/dbproxy/identity/identity_test.go
@@ -1,10 +1,15 @@
 package identity
 
 import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"net"
 	"os"
 	"path/filepath"
 	"runtime"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -26,6 +31,95 @@ func TestRootID_StableAcrossSymlink(t *testing.T) {
 	linked, err := RootID(link)
 	require.NoError(t, err)
 	assert.Equal(t, first, linked)
+}
+
+func TestIdentReplyMACRejectsTampering(t *testing.T) {
+	reply := IdentReply{
+		Schema:      2,
+		Role:        "proxy",
+		RootID:      "root",
+		UpstreamID:  "upstream",
+		PID:         123,
+		Birth:       "birth",
+		DataPort:    3306,
+		ControlPort: 3307,
+	}
+	secret := "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	nonce := "0123456789abcdef0123456789abcdef"
+	signed, err := SignIdentReply(reply, secret, nonce)
+	require.NoError(t, err)
+	require.NoError(t, VerifyIdentReply(signed, secret, nonce))
+
+	signed.DataPort++
+	require.ErrorContains(t, VerifyIdentReply(signed, secret, nonce), "authentication failed")
+}
+
+func TestIdentifyRejectsUnauthenticatedReply(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer listener.Close()
+	port := listener.Addr().(*net.TCPAddr).Port
+	serverErr := make(chan error, 1)
+	go func() {
+		conn, acceptErr := listener.Accept()
+		if acceptErr != nil {
+			serverErr <- acceptErr
+			return
+		}
+		defer conn.Close()
+		if _, readErr := bufio.NewReader(conn).ReadString('\n'); readErr != nil {
+			serverErr <- readErr
+			return
+		}
+		reply := IdentReply{Schema: 2, Role: "proxy", MAC: "00"}
+		serverErr <- json.NewEncoder(conn).Encode(reply)
+	}()
+
+	secret := "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	_, err = Identify("127.0.0.1", port, secret, time.Second)
+	require.ErrorContains(t, err, "authentication failed")
+	require.NoError(t, <-serverErr)
+}
+
+func TestIdentifyRequestCarriesFreshNonce(t *testing.T) {
+	secret := "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	nonces := make(chan string, 2)
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer listener.Close()
+	port := listener.Addr().(*net.TCPAddr).Port
+
+	for range 2 {
+		go func() {
+			conn, acceptErr := listener.Accept()
+			if acceptErr != nil {
+				return
+			}
+			defer conn.Close()
+			line, readErr := bufio.NewReader(conn).ReadString('\n')
+			if readErr != nil {
+				return
+			}
+			var command, gotSecret, nonce string
+			if _, scanErr := fmt.Sscanf(line, "%s %s %s\n", &command, &gotSecret, &nonce); scanErr != nil {
+				return
+			}
+			nonces <- nonce
+			reply, signErr := SignIdentReply(IdentReply{Schema: 2, Role: "proxy"}, secret, nonce)
+			if signErr == nil {
+				_ = json.NewEncoder(conn).Encode(reply)
+			}
+		}()
+	}
+	for range 2 {
+		_, err := Identify("127.0.0.1", port, secret, time.Second)
+		require.NoError(t, err)
+	}
+	first := <-nonces
+	second := <-nonces
+	assert.Len(t, first, identNonceBytes*2)
+	assert.Len(t, second, identNonceBytes*2)
+	assert.NotEqual(t, first, second)
 }
 
 func TestSecret_WriteReadAndRotate(t *testing.T) {

--- a/internal/storage/dbproxy/identity/identity_test.go
+++ b/internal/storage/dbproxy/identity/identity_test.go
@@ -1,0 +1,69 @@
+package identity
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRootID_StableAcrossSymlink(t *testing.T) {
+	target := t.TempDir()
+	first, err := RootID(target)
+	require.NoError(t, err)
+	second, err := RootID(target)
+	require.NoError(t, err)
+	assert.Equal(t, first, second)
+
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation requires privileges on Windows")
+	}
+	link := filepath.Join(t.TempDir(), "workspace-link")
+	require.NoError(t, os.Symlink(target, link))
+	linked, err := RootID(link)
+	require.NoError(t, err)
+	assert.Equal(t, first, linked)
+}
+
+func TestSecret_WriteReadAndRotate(t *testing.T) {
+	root := t.TempDir()
+	first, err := WriteSecret(root)
+	require.NoError(t, err)
+	got, err := ReadSecret(root)
+	require.NoError(t, err)
+	assert.Equal(t, first, got)
+
+	if runtime.GOOS != "windows" {
+		info, err := os.Stat(filepath.Join(root, SecretFileName))
+		require.NoError(t, err)
+		assert.Equal(t, os.FileMode(0o600), info.Mode().Perm())
+	}
+
+	second, err := WriteSecret(root)
+	require.NoError(t, err)
+	assert.NotEqual(t, first, second)
+	got, err = ReadSecret(root)
+	require.NoError(t, err)
+	assert.Equal(t, second, got)
+}
+
+func TestReadSecret_RejectsInvalidValues(t *testing.T) {
+	cases := []struct {
+		name  string
+		value string
+	}{
+		{name: "short", value: "0123"},
+		{name: "non hex", value: "zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			require.NoError(t, os.WriteFile(filepath.Join(root, SecretFileName), []byte(tc.value), 0o600))
+			_, err := ReadSecret(root)
+			require.Error(t, err)
+		})
+	}
+}

--- a/internal/storage/dbproxy/pidfile/pidfile.go
+++ b/internal/storage/dbproxy/pidfile/pidfile.go
@@ -11,9 +11,49 @@ import (
 )
 
 type PidFile struct {
-	Pid        int    `json:"pid"`
-	Port       int    `json:"port"`
-	UpstreamID string `json:"upstream_id,omitempty"`
+	Pid         int    `json:"pid"`
+	Port        int    `json:"port"`
+	UpstreamID  string `json:"upstream_id,omitempty"`
+	Schema      int    `json:"schema,omitempty"`
+	Kind        string `json:"kind,omitempty"`
+	Birth       string `json:"birth,omitempty"`
+	RootID      string `json:"root_id,omitempty"`
+	ControlPort int    `json:"control_port,omitempty"`
+}
+
+const SchemaV2 = 2
+
+const (
+	KindProxy       = "db-proxy"
+	KindDoltBackend = "dolt-backend"
+)
+
+var (
+	ErrLegacySchema = errors.New("pidfile: legacy schema")
+	ErrBadPid       = errors.New("pidfile: invalid pid")
+	ErrBadPort      = errors.New("pidfile: invalid port")
+	ErrKindMismatch = errors.New("pidfile: kind mismatch")
+	ErrMissingBirth = errors.New("pidfile: missing birth token")
+)
+
+// ValidateV2 validates the fields required for a schema v2 pidfile.
+func (p *PidFile) ValidateV2(wantKind string) error {
+	if p.Schema < SchemaV2 {
+		return ErrLegacySchema
+	}
+	if p.Pid <= 0 {
+		return ErrBadPid
+	}
+	if p.Port < 1 || p.Port > 65535 || (p.ControlPort != 0 && (p.ControlPort < 1 || p.ControlPort > 65535)) {
+		return ErrBadPort
+	}
+	if p.Kind != wantKind {
+		return ErrKindMismatch
+	}
+	if p.Birth == "" {
+		return ErrMissingBirth
+	}
+	return nil
 }
 
 func Path(rootDir, name string) string {

--- a/internal/storage/dbproxy/pidfile/pidfile_test.go
+++ b/internal/storage/dbproxy/pidfile/pidfile_test.go
@@ -1,6 +1,9 @@
 package pidfile
 
 import (
+	"errors"
+	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -19,6 +22,79 @@ func TestPidFileRoundTrip(t *testing.T) {
 	}
 	if *out != in {
 		t.Errorf("round-trip: got %+v, want %+v", *out, in)
+	}
+}
+
+func TestPidFileV1JSONRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "proxy.pid"), []byte(`{"pid":7,"port":8}`), 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	pf, err := Read(dir, "proxy.pid")
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if pf == nil || pf.Schema != 0 || pf.Kind != "" || pf.Birth != "" || pf.RootID != "" || pf.ControlPort != 0 {
+		t.Fatalf("v1 pidfile = %+v, want zero v2 fields", pf)
+	}
+}
+
+func TestPidFileV2RoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	in := PidFile{
+		Pid:         42,
+		Port:        1234,
+		UpstreamID:  "abc123",
+		Schema:      SchemaV2,
+		Kind:        KindProxy,
+		Birth:       "linux-v1:boot:123",
+		RootID:      "root",
+		ControlPort: 4321,
+	}
+	if err := Write(dir, "proxy.pid", in); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	out, err := Read(dir, "proxy.pid")
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if out == nil || *out != in {
+		t.Errorf("round-trip: got %+v, want %+v", out, in)
+	}
+}
+
+func TestValidateV2(t *testing.T) {
+	valid := PidFile{Pid: 1, Port: 1234, Schema: SchemaV2, Kind: KindProxy, Birth: "birth"}
+	tests := []struct {
+		name string
+		pf   PidFile
+		want error
+	}{
+		{name: "valid", pf: valid},
+		{name: "legacy schema", pf: PidFile{Pid: 1, Port: 1234, Kind: KindProxy, Birth: "birth"}, want: ErrLegacySchema},
+		{name: "bad pid", pf: PidFile{Port: 1234, Schema: SchemaV2, Kind: KindProxy, Birth: "birth"}, want: ErrBadPid},
+		{name: "bad port", pf: PidFile{Pid: 1, Schema: SchemaV2, Kind: KindProxy, Birth: "birth"}, want: ErrBadPort},
+		{name: "bad control port", pf: PidFile{Pid: 1, Port: 1234, ControlPort: 65536, Schema: SchemaV2, Kind: KindProxy, Birth: "birth"}, want: ErrBadPort},
+		{name: "wrong kind", pf: PidFile{Pid: 1, Port: 1234, Schema: SchemaV2, Kind: KindDoltBackend, Birth: "birth"}, want: ErrKindMismatch},
+		{name: "missing birth", pf: PidFile{Pid: 1, Port: 1234, Schema: SchemaV2, Kind: KindProxy}, want: ErrMissingBirth},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.pf.ValidateV2(KindProxy)
+			if !errors.Is(err, tt.want) {
+				t.Errorf("ValidateV2() error = %v, want %v", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestReadMalformedJSON(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "proxy.pid"), []byte(`{"pid":`), 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	if _, err := Read(dir, "proxy.pid"); err == nil {
+		t.Fatal("Read(malformed JSON) succeeded, want error")
 	}
 }
 

--- a/internal/storage/dbproxy/proxy/control.go
+++ b/internal/storage/dbproxy/proxy/control.go
@@ -1,0 +1,93 @@
+package proxy
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/steveyegge/beads/internal/storage/dbproxy/identity"
+)
+
+const (
+	maxIdentRequestBytes = 256
+	identDeadline        = 2 * time.Second
+)
+
+type controlServer struct {
+	listener net.Listener
+	secret   string
+	done     chan struct{}
+	once     sync.Once
+	reply    func() identity.IdentReply
+}
+
+func startControl(rootDir string, reply func() identity.IdentReply) (*controlServer, error) {
+	secret, err := identity.ReadSecret(rootDir)
+	if err != nil {
+		return nil, fmt.Errorf("proxy: read control secret: %w", err)
+	}
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return nil, fmt.Errorf("proxy: listen control: %w", err)
+	}
+	s := &controlServer{
+		listener: ln,
+		secret:   secret,
+		done:     make(chan struct{}),
+		reply:    reply,
+	}
+	go s.acceptLoop()
+	return s, nil
+}
+
+func (s *controlServer) Port() int {
+	return s.listener.Addr().(*net.TCPAddr).Port
+}
+
+func (s *controlServer) Close() error {
+	var err error
+	s.once.Do(func() {
+		err = s.listener.Close()
+		<-s.done
+	})
+	return err
+}
+
+func (s *controlServer) acceptLoop() {
+	defer close(s.done)
+	for {
+		conn, err := s.listener.Accept()
+		if err != nil {
+			if errors.Is(err, net.ErrClosed) {
+				return
+			}
+			continue
+		}
+		go s.handle(conn)
+	}
+}
+
+func (s *controlServer) handle(conn net.Conn) {
+	defer func() { _ = conn.Close() }()
+	if err := conn.SetDeadline(time.Now().Add(identDeadline)); err != nil {
+		return
+	}
+	line, err := bufio.NewReader(io.LimitReader(conn, maxIdentRequestBytes+1)).ReadString('\n')
+	if err != nil || len(line) > maxIdentRequestBytes || !strings.HasPrefix(line, "IDENT ") {
+		return
+	}
+	if line != "IDENT "+s.secret+"\n" {
+		return
+	}
+	_ = writeIdentReply(conn, s.reply())
+}
+
+func writeIdentReply(w io.Writer, reply identity.IdentReply) error {
+	return json.NewEncoder(w).Encode(reply)
+}

--- a/internal/storage/dbproxy/proxy/control.go
+++ b/internal/storage/dbproxy/proxy/control.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log"
 	"net"
 	"strings"
 	"sync"
@@ -19,17 +20,17 @@ const (
 	maxIdentRequestBytes       = 256
 	identDeadline              = 2 * time.Second
 	maxConcurrentIdentRequests = 8
-	maxControlAcceptErrors     = 3
 	controlAcceptRetryDelay    = 10 * time.Millisecond
+	controlAcceptRetryMax      = 5 * time.Second
 )
 
 type controlServer struct {
 	listener net.Listener
 	secret   string
 	done     chan struct{}
+	closing  chan struct{}
 	once     sync.Once
 	reply    func() identity.IdentReply
-	errs     chan error
 	slots    chan struct{}
 }
 
@@ -46,8 +47,8 @@ func startControl(rootDir string, reply func() identity.IdentReply) (*controlSer
 		listener: ln,
 		secret:   secret,
 		done:     make(chan struct{}),
+		closing:  make(chan struct{}),
 		reply:    reply,
-		errs:     make(chan error, 1),
 		slots:    make(chan struct{}, maxConcurrentIdentRequests),
 	}
 	go s.acceptLoop()
@@ -58,13 +59,10 @@ func (s *controlServer) Port() int {
 	return s.listener.Addr().(*net.TCPAddr).Port
 }
 
-func (s *controlServer) Errors() <-chan error {
-	return s.errs
-}
-
 func (s *controlServer) Close() error {
 	var err error
 	s.once.Do(func() {
+		close(s.closing)
 		err = s.listener.Close()
 		if errors.Is(err, net.ErrClosed) {
 			err = nil
@@ -74,9 +72,14 @@ func (s *controlServer) Close() error {
 	return err
 }
 
+// acceptLoop retries transient Accept failures (e.g. EMFILE) indefinitely
+// with capped exponential backoff instead of tearing anything down: the data
+// path may still be perfectly healthy, and a proxy that stops answering
+// identity probes merely degrades adoption to the caller's poll/retry path.
 func (s *controlServer) acceptLoop() {
 	defer close(s.done)
 	consecutiveErrors := 0
+	delay := controlAcceptRetryDelay
 	for {
 		conn, err := s.listener.Accept()
 		if err != nil {
@@ -84,19 +87,22 @@ func (s *controlServer) acceptLoop() {
 				return
 			}
 			consecutiveErrors++
-			if consecutiveErrors >= maxControlAcceptErrors {
-				acceptErr := fmt.Errorf("proxy: control accept failed %d times: %w", consecutiveErrors, err)
-				select {
-				case s.errs <- acceptErr:
-				default:
-				}
-				_ = s.listener.Close()
+			log.Printf(
+				"dbproxy: control accept failed %d consecutive time(s), retrying in %s: %v",
+				consecutiveErrors, delay, err,
+			)
+			select {
+			case <-s.closing:
 				return
+			case <-time.After(delay):
 			}
-			time.Sleep(time.Duration(consecutiveErrors) * controlAcceptRetryDelay)
+			if delay *= 2; delay > controlAcceptRetryMax {
+				delay = controlAcceptRetryMax
+			}
 			continue
 		}
 		consecutiveErrors = 0
+		delay = controlAcceptRetryDelay
 		select {
 		case s.slots <- struct{}{}:
 			go func() {

--- a/internal/storage/dbproxy/proxy/control.go
+++ b/internal/storage/dbproxy/proxy/control.go
@@ -2,6 +2,7 @@ package proxy
 
 import (
 	"bufio"
+	"crypto/subtle"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -15,8 +16,11 @@ import (
 )
 
 const (
-	maxIdentRequestBytes = 256
-	identDeadline        = 2 * time.Second
+	maxIdentRequestBytes       = 256
+	identDeadline              = 2 * time.Second
+	maxConcurrentIdentRequests = 8
+	maxControlAcceptErrors     = 3
+	controlAcceptRetryDelay    = 10 * time.Millisecond
 )
 
 type controlServer struct {
@@ -25,6 +29,8 @@ type controlServer struct {
 	done     chan struct{}
 	once     sync.Once
 	reply    func() identity.IdentReply
+	errs     chan error
+	slots    chan struct{}
 }
 
 func startControl(rootDir string, reply func() identity.IdentReply) (*controlServer, error) {
@@ -41,6 +47,8 @@ func startControl(rootDir string, reply func() identity.IdentReply) (*controlSer
 		secret:   secret,
 		done:     make(chan struct{}),
 		reply:    reply,
+		errs:     make(chan error, 1),
+		slots:    make(chan struct{}, maxConcurrentIdentRequests),
 	}
 	go s.acceptLoop()
 	return s, nil
@@ -50,10 +58,17 @@ func (s *controlServer) Port() int {
 	return s.listener.Addr().(*net.TCPAddr).Port
 }
 
+func (s *controlServer) Errors() <-chan error {
+	return s.errs
+}
+
 func (s *controlServer) Close() error {
 	var err error
 	s.once.Do(func() {
 		err = s.listener.Close()
+		if errors.Is(err, net.ErrClosed) {
+			err = nil
+		}
 		<-s.done
 	})
 	return err
@@ -61,15 +76,36 @@ func (s *controlServer) Close() error {
 
 func (s *controlServer) acceptLoop() {
 	defer close(s.done)
+	consecutiveErrors := 0
 	for {
 		conn, err := s.listener.Accept()
 		if err != nil {
 			if errors.Is(err, net.ErrClosed) {
 				return
 			}
+			consecutiveErrors++
+			if consecutiveErrors >= maxControlAcceptErrors {
+				acceptErr := fmt.Errorf("proxy: control accept failed %d times: %w", consecutiveErrors, err)
+				select {
+				case s.errs <- acceptErr:
+				default:
+				}
+				_ = s.listener.Close()
+				return
+			}
+			time.Sleep(time.Duration(consecutiveErrors) * controlAcceptRetryDelay)
 			continue
 		}
-		go s.handle(conn)
+		consecutiveErrors = 0
+		select {
+		case s.slots <- struct{}{}:
+			go func() {
+				defer func() { <-s.slots }()
+				s.handle(conn)
+			}()
+		default:
+			_ = conn.Close()
+		}
 	}
 }
 
@@ -79,13 +115,23 @@ func (s *controlServer) handle(conn net.Conn) {
 		return
 	}
 	line, err := bufio.NewReader(io.LimitReader(conn, maxIdentRequestBytes+1)).ReadString('\n')
-	if err != nil || len(line) > maxIdentRequestBytes || !strings.HasPrefix(line, "IDENT ") {
+	if err != nil || len(line) > maxIdentRequestBytes || !strings.HasSuffix(line, "\n") {
 		return
 	}
-	if line != "IDENT "+s.secret+"\n" {
+	parts := strings.Split(strings.TrimSuffix(line, "\n"), " ")
+	if len(parts) != 3 || parts[0] != "IDENT" {
 		return
 	}
-	_ = writeIdentReply(conn, s.reply())
+	if subtle.ConstantTimeCompare([]byte(parts[1]), []byte(s.secret)) != 1 {
+		return
+	}
+	reply := s.reply()
+	reply.ControlPort = s.Port()
+	signed, err := identity.SignIdentReply(reply, s.secret, parts[2])
+	if err != nil {
+		return
+	}
+	_ = writeIdentReply(conn, signed)
 }
 
 func writeIdentReply(w io.Writer, reply identity.IdentReply) error {

--- a/internal/storage/dbproxy/proxy/control_test.go
+++ b/internal/storage/dbproxy/proxy/control_test.go
@@ -33,7 +33,6 @@ func newControlServer(t *testing.T) (*controlServer, string, identity.IdentReply
 	control, err := startControl(root, func() identity.IdentReply { return want })
 	require.NoError(t, err)
 	want.ControlPort = control.Port()
-	control.reply = func() identity.IdentReply { return want }
 	t.Cleanup(func() { _ = control.Close() })
 	return control, secret, want
 }
@@ -42,6 +41,8 @@ func TestControl_Identify(t *testing.T) {
 	control, secret, want := newControlServer(t)
 	got, err := identity.Identify("127.0.0.1", control.Port(), secret, time.Second)
 	require.NoError(t, err)
+	assert.Len(t, got.MAC, 64)
+	got.MAC = ""
 	assert.Equal(t, &want, got)
 }
 
@@ -77,14 +78,17 @@ func TestControl_RejectsOversizedAndGarbageRequests(t *testing.T) {
 
 func TestControl_ConcurrentIdentify(t *testing.T) {
 	control, secret, want := newControlServer(t)
-	const calls = 16
+	const calls = maxConcurrentIdentRequests
 	errs := make(chan error, calls)
 	var wg sync.WaitGroup
 	for range calls {
 		wg.Go(func() {
 			got, err := identity.Identify("127.0.0.1", control.Port(), secret, time.Second)
-			if err == nil && *got != want {
-				err = errors.New("identity reply mismatch")
+			if err == nil {
+				got.MAC = ""
+				if *got != want {
+					err = errors.New("identity reply mismatch")
+				}
 			}
 			errs <- err
 		})
@@ -94,4 +98,78 @@ func TestControl_ConcurrentIdentify(t *testing.T) {
 	for err := range errs {
 		assert.NoError(t, err)
 	}
+}
+
+func TestControl_CapsConcurrentHandshakes(t *testing.T) {
+	control, _, _ := newControlServer(t)
+	addr := net.JoinHostPort("127.0.0.1", strconv.Itoa(control.Port()))
+	conns := make([]net.Conn, 0, maxConcurrentIdentRequests)
+	t.Cleanup(func() {
+		for _, conn := range conns {
+			_ = conn.Close()
+		}
+	})
+	for range maxConcurrentIdentRequests {
+		conn, err := net.DialTimeout("tcp", addr, time.Second)
+		require.NoError(t, err)
+		conns = append(conns, conn)
+	}
+	require.Eventually(t, func() bool {
+		return len(control.slots) == maxConcurrentIdentRequests
+	}, time.Second, 10*time.Millisecond)
+
+	extra, err := net.DialTimeout("tcp", addr, time.Second)
+	require.NoError(t, err)
+	defer extra.Close()
+	require.NoError(t, extra.SetDeadline(time.Now().Add(time.Second)))
+	_, err = io.WriteString(extra, "IDENT blocked blocked\n")
+	require.NoError(t, err)
+	buf := make([]byte, 1)
+	_, err = extra.Read(buf)
+	require.Error(t, err)
+}
+
+func TestControl_AcceptLoopStopsAfterPersistentErrors(t *testing.T) {
+	listener := &failingListener{err: errors.New("persistent accept failure")}
+	control := &controlServer{
+		listener: listener,
+		done:     make(chan struct{}),
+		errs:     make(chan error, 1),
+		slots:    make(chan struct{}, maxConcurrentIdentRequests),
+	}
+	go control.acceptLoop()
+
+	select {
+	case err := <-control.Errors():
+		require.ErrorContains(t, err, "control accept failed")
+	case <-time.After(time.Second):
+		t.Fatal("control accept loop did not report persistent failure")
+	}
+	select {
+	case <-control.done:
+	case <-time.After(time.Second):
+		t.Fatal("control accept loop did not stop")
+	}
+	assert.Equal(t, maxControlAcceptErrors, listener.accepts)
+	assert.True(t, listener.closed)
+}
+
+type failingListener struct {
+	err     error
+	accepts int
+	closed  bool
+}
+
+func (l *failingListener) Accept() (net.Conn, error) {
+	l.accepts++
+	return nil, l.err
+}
+
+func (l *failingListener) Close() error {
+	l.closed = true
+	return nil
+}
+
+func (l *failingListener) Addr() net.Addr {
+	return &net.TCPAddr{}
 }

--- a/internal/storage/dbproxy/proxy/control_test.go
+++ b/internal/storage/dbproxy/proxy/control_test.go
@@ -1,0 +1,97 @@
+package proxy
+
+import (
+	"errors"
+	"io"
+	"net"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/steveyegge/beads/internal/storage/dbproxy/identity"
+	"github.com/steveyegge/beads/internal/storage/dbproxy/pidfile"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newControlServer(t *testing.T) (*controlServer, string, identity.IdentReply) {
+	t.Helper()
+	root := t.TempDir()
+	secret, err := identity.WriteSecret(root)
+	require.NoError(t, err)
+	want := identity.IdentReply{
+		Schema:     pidfile.SchemaV2,
+		Role:       pidfile.KindProxy,
+		RootID:     "workspace-root",
+		UpstreamID: "dolt-server",
+		PID:        123,
+		Birth:      "linux-v1:boot:1",
+		DataPort:   3306,
+	}
+	control, err := startControl(root, func() identity.IdentReply { return want })
+	require.NoError(t, err)
+	want.ControlPort = control.Port()
+	control.reply = func() identity.IdentReply { return want }
+	t.Cleanup(func() { _ = control.Close() })
+	return control, secret, want
+}
+
+func TestControl_Identify(t *testing.T) {
+	control, secret, want := newControlServer(t)
+	got, err := identity.Identify("127.0.0.1", control.Port(), secret, time.Second)
+	require.NoError(t, err)
+	assert.Equal(t, &want, got)
+}
+
+func TestControl_RejectsWrongSecret(t *testing.T) {
+	control, _, _ := newControlServer(t)
+	_, err := identity.Identify("127.0.0.1", control.Port(), "not-the-secret", time.Second)
+	require.ErrorIs(t, err, identity.ErrIdentRefused)
+}
+
+func TestControl_RejectsOversizedAndGarbageRequests(t *testing.T) {
+	control, _, _ := newControlServer(t)
+	cases := []struct {
+		name    string
+		request string
+	}{
+		{name: "oversized", request: "IDENT " + strings.Repeat("x", maxIdentRequestBytes) + "\n"},
+		{name: "garbage", request: "WHOAMI\n"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			conn, err := net.DialTimeout("tcp", net.JoinHostPort("127.0.0.1", strconv.Itoa(control.Port())), time.Second)
+			require.NoError(t, err)
+			defer conn.Close()
+			require.NoError(t, conn.SetDeadline(time.Now().Add(time.Second)))
+			_, err = io.WriteString(conn, tc.request)
+			require.NoError(t, err)
+			buf := make([]byte, 1)
+			_, err = conn.Read(buf)
+			assert.Error(t, err)
+		})
+	}
+}
+
+func TestControl_ConcurrentIdentify(t *testing.T) {
+	control, secret, want := newControlServer(t)
+	const calls = 16
+	errs := make(chan error, calls)
+	var wg sync.WaitGroup
+	for range calls {
+		wg.Go(func() {
+			got, err := identity.Identify("127.0.0.1", control.Port(), secret, time.Second)
+			if err == nil && *got != want {
+				err = errors.New("identity reply mismatch")
+			}
+			errs <- err
+		})
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		assert.NoError(t, err)
+	}
+}

--- a/internal/storage/dbproxy/proxy/control_test.go
+++ b/internal/storage/dbproxy/proxy/control_test.go
@@ -129,40 +129,42 @@ func TestControl_CapsConcurrentHandshakes(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestControl_AcceptLoopStopsAfterPersistentErrors(t *testing.T) {
-	listener := &failingListener{err: errors.New("persistent accept failure")}
+// Persistent transient Accept failures (e.g. EMFILE) must not tear down the
+// control server: the data path may still be healthy, and losing control only
+// degrades adoption to the caller's poll/retry path.
+func TestControl_AcceptLoopSurvivesPersistentErrors(t *testing.T) {
+	listener := &failingListener{err: errors.New("transient accept failure"), failures: 5}
 	control := &controlServer{
 		listener: listener,
 		done:     make(chan struct{}),
-		errs:     make(chan error, 1),
+		closing:  make(chan struct{}),
 		slots:    make(chan struct{}, maxConcurrentIdentRequests),
 	}
 	go control.acceptLoop()
 
 	select {
-	case err := <-control.Errors():
-		require.ErrorContains(t, err, "control accept failed")
-	case <-time.After(time.Second):
-		t.Fatal("control accept loop did not report persistent failure")
-	}
-	select {
 	case <-control.done:
-	case <-time.After(time.Second):
-		t.Fatal("control accept loop did not stop")
+	case <-time.After(10 * time.Second):
+		t.Fatal("control accept loop did not exit after the listener closed")
 	}
-	assert.Equal(t, maxControlAcceptErrors, listener.accepts)
-	assert.True(t, listener.closed)
+	assert.Equal(t, listener.failures+1, listener.accepts,
+		"loop must retry through every transient failure until the listener reports closed")
+	assert.False(t, listener.closed, "accept failures must not close the control listener")
 }
 
 type failingListener struct {
-	err     error
-	accepts int
-	closed  bool
+	err      error
+	failures int
+	accepts  int
+	closed   bool
 }
 
 func (l *failingListener) Accept() (net.Conn, error) {
 	l.accepts++
-	return nil, l.err
+	if l.accepts <= l.failures {
+		return nil, l.err
+	}
+	return nil, net.ErrClosed
 }
 
 func (l *failingListener) Close() error {

--- a/internal/storage/dbproxy/proxy/endpoint.go
+++ b/internal/storage/dbproxy/proxy/endpoint.go
@@ -83,6 +83,12 @@ const (
 
 var ResolveExecutable = os.Executable
 
+var (
+	verifyProcessIdentity = procid.Verify
+	resolveRootIdentity   = identity.RootID
+	readControlSecret     = identity.ReadSecret
+)
+
 var stopEpochSequence atomic.Uint64
 
 // beforeProxyChildStart is a deterministic test hook for the otherwise tiny
@@ -96,6 +102,7 @@ const (
 	adoptionNoRecord
 	adoptionStaleDead
 	adoptionIdentityMismatch
+	adoptionUnverifiable
 	adoptionLegacy
 	adoptionMalformed
 	adoptionIOErr
@@ -111,6 +118,8 @@ func (s adoptionStatus) String() string {
 		return "stale dead"
 	case adoptionIdentityMismatch:
 		return "identity mismatch"
+	case adoptionUnverifiable:
+		return "identity unverifiable"
 	case adoptionLegacy:
 		return "legacy"
 	case adoptionMalformed:
@@ -221,6 +230,8 @@ func GetCreateDatabaseProxyServerEndpoint(rootDir string, opts OpenOpts) (Endpoi
 			if markerActive {
 				lock.Unlock()
 				lastSpawnErr = nil
+				// This break exits the switch only; the outer discovery loop
+				// continues with its normal bounded poll.
 				break
 			}
 
@@ -235,9 +246,13 @@ func GetCreateDatabaseProxyServerEndpoint(rootDir string, opts OpenOpts) (Endpoi
 		case !lockfile.IsLocked(err):
 			return Endpoint{}, fmt.Errorf("probe proxy lock: %w", err)
 		case discovery.status == adoptionLegacy:
+			recordPath := pidfile.Path(rootDir, PIDFileName)
 			return Endpoint{}, fmt.Errorf(
-				"legacy proxy record %s is protected by held lock %s; stop the pre-upgrade proxy with the old bd binary or wait for its idle exit",
-				pidfile.Path(rootDir, PIDFileName), filepath.Join(rootDir, LockFileName),
+				"legacy proxy record %s is protected by held lock %s; stop the pre-upgrade proxy with the old bd binary or wait for its idle exit, then quarantine the record manually by renaming %s to %s.stale-<unix-timestamp> before retrying",
+				recordPath,
+				filepath.Join(rootDir, LockFileName),
+				recordPath,
+				recordPath,
 			)
 		}
 
@@ -306,6 +321,7 @@ func spawnAndHandoff(
 	if err != nil {
 		return Endpoint{}, fmt.Errorf("fork child: %w", err)
 	}
+	defer func() { _ = clearOwnSpawnMarker(rootDir, child.marker) }()
 	defer func() {
 		if child.handle != nil {
 			_ = child.handle.Close()
@@ -330,7 +346,6 @@ func spawnAndHandoff(
 		}
 		select {
 		case <-child.done:
-			_ = clearOwnSpawnMarker(rootDir, child.marker)
 			if interrupted, ierr := stopEpochChanged(rootDir, stopEpoch); ierr != nil {
 				return Endpoint{}, ierr
 			} else if interrupted {
@@ -341,7 +356,6 @@ func spawnAndHandoff(
 			if err := killSpawnedChild(child); err != nil {
 				return Endpoint{}, fmt.Errorf("hard timeout waiting for proxy on port %d; safe child kill failed: %w", port, err)
 			}
-			_ = clearOwnSpawnMarker(rootDir, child.marker)
 			return Endpoint{}, fmt.Errorf("hard timeout (%s) waiting for proxy on port %d", spawnReadyHardTimeout, port)
 		case <-poll.C:
 		}
@@ -349,7 +363,6 @@ func spawnAndHandoff(
 			if err := killSpawnedChild(child); err != nil {
 				return Endpoint{}, fmt.Errorf("timeout waiting for proxy on port %d; safe child kill failed: %w", port, err)
 			}
-			_ = clearOwnSpawnMarker(rootDir, child.marker)
 			return Endpoint{}, fmt.Errorf("timeout waiting for proxy to become ready on port %d", port)
 		}
 	}
@@ -507,21 +520,29 @@ func readAndDial(rootDir string) adoptionResult {
 		return adoptionResult{status: adoptionMalformed, pidfile: pf, err: err}
 	}
 
-	matched, err := procid.Verify(pf.Pid, procid.Token(pf.Birth))
+	matched, err := verifyProcessIdentity(pf.Pid, procid.Token(pf.Birth))
 	if err != nil {
-		return adoptionResult{status: adoptionIOErr, pidfile: pf, err: fmt.Errorf("verify proxy pid %d: %w", pf.Pid, err)}
+		// Discovery must not turn an identity-probe failure into a fatal
+		// pidfile I/O error. In particular, Windows ERROR_ACCESS_DENIED on a
+		// recycled PID belongs in this non-adopting path; proxy.lock still
+		// gates quarantine and replacement.
+		return adoptionResult{
+			status:  adoptionUnverifiable,
+			pidfile: pf,
+			err:     fmt.Errorf("verify proxy pid %d: %w", pf.Pid, err),
+		}
 	}
 	if !matched {
 		return adoptionResult{status: adoptionStaleDead, pidfile: pf}
 	}
 
-	expectedRootID, err := identity.RootID(rootDir)
+	expectedRootID, err := resolveRootIdentity(rootDir)
 	if err != nil {
-		return adoptionResult{status: adoptionIOErr, pidfile: pf, err: err}
+		return adoptionResult{status: adoptionUnverifiable, pidfile: pf, err: err}
 	}
-	secret, err := identity.ReadSecret(rootDir)
+	secret, err := readControlSecret(rootDir)
 	if err != nil {
-		return adoptionResult{status: adoptionIdentityMismatch, pidfile: pf, err: err}
+		return adoptionResult{status: adoptionUnverifiable, pidfile: pf, err: err}
 	}
 	reply, err := identity.Identify("127.0.0.1", pf.ControlPort, secret, identityProbeTimeout)
 	if err != nil {
@@ -578,6 +599,11 @@ func quarantineForSpawn(rootDir string, discovery adoptionResult) error {
 	case adoptionIdentityMismatch:
 		log.Printf(
 			"dbproxy: refusing proxy identity at %s (%v); quarantining only its record and starting a fresh proxy",
+			pidfile.Path(rootDir, PIDFileName), discovery.err,
+		)
+	case adoptionUnverifiable:
+		log.Printf(
+			"dbproxy: proxy identity at %s could not be verified (%v); quarantining only its record under proxy.lock and starting a fresh proxy",
 			pidfile.Path(rootDir, PIDFileName), discovery.err,
 		)
 	case adoptionLegacy:
@@ -673,13 +699,40 @@ func cleanupOrphanBackend(rootDir string) error {
 	}
 
 	if readErr != nil {
+		if isMalformedPIDFileError(readErr) {
+			return unverifiableProcessError(
+				"backend cleanup",
+				recordPath,
+				0,
+				readErr,
+				unverifiableProcessChecks{},
+			)
+		}
 		return fmt.Errorf("read backend record %s: %w", recordPath, readErr)
 	}
 	if pf == nil {
 		return nil
 	}
 	if err := pf.ValidateV2(pidfile.KindDoltBackend); err != nil {
-		return unverifiableProcessError("backend cleanup", recordPath, pf.Pid, err)
+		dead, live, probeErr := probeUnverifiablePID(pf.Pid)
+		if dead {
+			if _, quarantineErr := quarantineRecord(rootDir, server.PIDFileName, time.Now()); quarantineErr != nil {
+				return fmt.Errorf("quarantine dead unverifiable backend record: %w", quarantineErr)
+			}
+			return nil
+		}
+		if probeErr != nil {
+			err = errors.Join(err, fmt.Errorf("probe recorded pid: %w", probeErr))
+		}
+		return unverifiableProcessError(
+			"backend cleanup",
+			recordPath,
+			pf.Pid,
+			err,
+			unverifiableProcessChecks{
+				LiveEstablished: live,
+			},
+		)
 	}
 	expectedRootID, err := identity.RootID(rootDir)
 	if err != nil {
@@ -691,12 +744,19 @@ func cleanupOrphanBackend(rootDir string) error {
 			recordPath,
 			pf.Pid,
 			fmt.Errorf("root identity mismatch (record has %q, workspace has %q)", pf.RootID, expectedRootID),
+			unverifiableProcessChecks{},
 		)
 	}
 
 	handle, dead, err := openRecordedProcess(pf)
 	if err != nil {
-		return unverifiableProcessError("backend cleanup", recordPath, pf.Pid, err)
+		return unverifiableProcessError(
+			"backend cleanup",
+			recordPath,
+			pf.Pid,
+			err,
+			unverifiableProcessChecks{},
+		)
 	}
 	if dead {
 		if _, err := quarantineRecord(rootDir, server.PIDFileName, time.Now()); err != nil {
@@ -718,11 +778,51 @@ func cleanupOrphanBackend(rootDir string) error {
 	return nil
 }
 
-func unverifiableProcessError(operation, recordPath string, pid int, cause error) error {
+type unverifiableProcessChecks struct {
+	LiveEstablished bool
+	LegacyProxy     bool
+}
+
+func unverifiableProcessError(
+	operation string,
+	recordPath string,
+	pid int,
+	cause error,
+	checks unverifiableProcessChecks,
+) error {
+	liveness := ""
+	if checks.LiveEstablished {
+		liveness = " live"
+	}
+	stopGuidance := "stop the recorded process with the binary that started it"
+	if checks.LegacyProxy && checks.LiveEstablished {
+		stopGuidance = "stop the pre-upgrade proxy with the old bd binary"
+	}
 	return fmt.Errorf(
-		"%s refused for unverifiable live process pid %d recorded at %s: %v; stop that process with the binary that started it, then retry",
-		operation, pid, recordPath, cause,
+		"%s refused for unverifiable%s process pid %d recorded at %s: %v; %s, then quarantine the record manually by renaming %s to %s.stale-<unix-timestamp> before retrying",
+		operation,
+		liveness,
+		pid,
+		recordPath,
+		cause,
+		stopGuidance,
+		recordPath,
+		recordPath,
 	)
+}
+
+func probeUnverifiablePID(pid int) (dead bool, live bool, err error) {
+	if pid <= 0 {
+		return false, false, errors.New("record has no valid pid")
+	}
+	_, err = procid.Capture(pid)
+	if err == nil {
+		return false, true, nil
+	}
+	if procid.IsProcessGone(err) {
+		return true, false, nil
+	}
+	return false, false, err
 }
 
 func openRecordedProcess(pf *pidfile.PidFile) (*procid.Handle, bool, error) {
@@ -742,7 +842,9 @@ func openRecordedProcess(pf *pidfile.PidFile) (*procid.Handle, bool, error) {
 		return nil, false, fmt.Errorf("open process identity: %w (recheck: %v)", err, captureErr)
 	}
 	if current != procid.Token(pf.Birth) {
-		return nil, false, fmt.Errorf("birth token mismatch")
+		// A different birth token proves the recorded process exited, even
+		// when the numeric PID has since been recycled.
+		return nil, true, nil
 	}
 	return nil, false, fmt.Errorf("open verified process handle: %w", err)
 }
@@ -798,14 +900,14 @@ func readStopEpoch(rootDir string) (string, error) {
 	return strings.TrimSpace(string(data)), nil
 }
 
-func advanceStopEpoch(rootDir string) (string, error) {
+func advanceStopEpoch(rootDir string) error {
 	epoch := strconv.FormatInt(time.Now().UnixNano(), 10) +
 		"-" + strconv.Itoa(os.Getpid()) +
 		"-" + strconv.FormatUint(stopEpochSequence.Add(1), 10)
 	if err := atomicfile.WriteFile(filepath.Join(rootDir, stopEpochFileName), []byte(epoch+"\n"), 0o600); err != nil {
-		return "", err
+		return err
 	}
-	return epoch, nil
+	return nil
 }
 
 func stopEpochChanged(rootDir, expected string) (bool, error) {

--- a/internal/storage/dbproxy/proxy/endpoint.go
+++ b/internal/storage/dbproxy/proxy/endpoint.go
@@ -1,17 +1,25 @@
 package proxy
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
+	"io/fs"
+	"log"
 	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strconv"
+	"strings"
+	"sync/atomic"
 	"time"
 
+	"github.com/steveyegge/beads/internal/atomicfile"
 	"github.com/steveyegge/beads/internal/configfile"
 	"github.com/steveyegge/beads/internal/lockfile"
+	"github.com/steveyegge/beads/internal/procid"
+	"github.com/steveyegge/beads/internal/storage/dbproxy/identity"
 	"github.com/steveyegge/beads/internal/storage/dbproxy/pidfile"
 	"github.com/steveyegge/beads/internal/storage/dbproxy/server"
 	"github.com/steveyegge/beads/internal/storage/dbproxy/util"
@@ -63,9 +71,73 @@ const (
 	openDeadline          = 15 * time.Second
 	spawnReadyHardTimeout = 2 * time.Minute
 	openPollInterval      = 100 * time.Millisecond
+	identityProbeTimeout  = 500 * time.Millisecond
+	backendExitTimeout    = 5 * time.Second
+	// quarantineRetention bounds forensic pidfile accumulation; successful
+	// spawns sweep only records older than 30 days.
+	quarantineRetention = 30 * 24 * time.Hour
+
+	spawnMarkerFileName = "proxy.spawn"
+	stopEpochFileName   = "proxy.stop-epoch"
 )
 
 var ResolveExecutable = os.Executable
+
+var stopEpochSequence atomic.Uint64
+
+// beforeProxyChildStart is a deterministic test hook for the otherwise tiny
+// release-lock-before-exec scheduling window. Production leaves it as a no-op.
+var beforeProxyChildStart = func() {}
+
+type adoptionStatus uint8
+
+const (
+	adoptionAdopted adoptionStatus = iota
+	adoptionNoRecord
+	adoptionStaleDead
+	adoptionIdentityMismatch
+	adoptionLegacy
+	adoptionMalformed
+	adoptionIOErr
+)
+
+func (s adoptionStatus) String() string {
+	switch s {
+	case adoptionAdopted:
+		return "adopted"
+	case adoptionNoRecord:
+		return "no record"
+	case adoptionStaleDead:
+		return "stale dead"
+	case adoptionIdentityMismatch:
+		return "identity mismatch"
+	case adoptionLegacy:
+		return "legacy"
+	case adoptionMalformed:
+		return "malformed"
+	case adoptionIOErr:
+		return "I/O error"
+	default:
+		return fmt.Sprintf("unknown adoption status %d", s)
+	}
+}
+
+type adoptionResult struct {
+	status   adoptionStatus
+	endpoint Endpoint
+	pidfile  *pidfile.PidFile
+	err      error
+}
+
+type spawnMarker struct {
+	Schema      int    `json:"schema"`
+	PID         int    `json:"pid"`
+	Birth       string `json:"birth"`
+	StopEpoch   string `json:"stop_epoch"`
+	StartedUnix int64  `json:"started_unix"`
+}
+
+var errStartInterrupted = errors.New("proxy startup interrupted by concurrent shutdown")
 
 func PickFreePort() (int, error) {
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
@@ -103,6 +175,10 @@ func GetCreateDatabaseProxyServerEndpoint(rootDir string, opts OpenOpts) (Endpoi
 			return Endpoint{}, fmt.Errorf("OpenOpts.External: %w", err)
 		}
 	}
+	stopEpoch, err := readStopEpoch(rootDir)
+	if err != nil {
+		return Endpoint{}, fmt.Errorf("read proxy stop epoch: %w", err)
+	}
 	deadline := time.Now().Add(openDeadline)
 
 	timeout := time.NewTimer(openDeadline)
@@ -114,26 +190,55 @@ func GetCreateDatabaseProxyServerEndpoint(rootDir string, opts OpenOpts) (Endpoi
 
 	var lastSpawnErr error
 	for {
-		if ep, pf, ok := readAndDial(rootDir); ok {
-			if want != "" && pf.UpstreamID != "" && pf.UpstreamID != want {
-				return Endpoint{}, &ErrUpstreamMismatch{
-					RootDir: rootDir,
-					Want:    want,
-					Have:    pf.UpstreamID,
-				}
-			}
-			return ep, nil
+		discovery := readAndDial(rootDir)
+		switch discovery.status {
+		case adoptionAdopted:
+			return adoptedEndpoint(rootDir, want, discovery)
+		case adoptionIOErr:
+			return Endpoint{}, fmt.Errorf("discover proxy from %s: %w", pidfile.Path(rootDir, PIDFileName), discovery.err)
 		}
 
 		lock, err := util.TryLock(filepath.Join(rootDir, LockFileName))
 		switch {
 		case err == nil:
+			// Re-read under proxy.lock. Another opener may have replaced the
+			// record after our lock-free discovery.
+			discovery = readAndDial(rootDir)
+			if discovery.status == adoptionAdopted {
+				lock.Unlock()
+				return adoptedEndpoint(rootDir, want, discovery)
+			}
+			if discovery.status == adoptionIOErr {
+				lock.Unlock()
+				return Endpoint{}, fmt.Errorf("discover proxy from %s under lock: %w", pidfile.Path(rootDir, PIDFileName), discovery.err)
+			}
+
+			markerActive, markerErr := inspectSpawnMarkerLocked(rootDir)
+			if markerErr != nil {
+				lock.Unlock()
+				return Endpoint{}, markerErr
+			}
+			if markerActive {
+				lock.Unlock()
+				lastSpawnErr = nil
+				break
+			}
+
 			var ep Endpoint
-			if ep, lastSpawnErr = spawnAndHandoff(rootDir, opts, deadline, lock); lastSpawnErr == nil {
+			ep, lastSpawnErr = spawnAndHandoff(rootDir, opts, deadline, stopEpoch, lock, discovery)
+			if lastSpawnErr == nil {
 				return ep, nil
+			}
+			if errors.Is(lastSpawnErr, errStartInterrupted) {
+				return Endpoint{}, lastSpawnErr
 			}
 		case !lockfile.IsLocked(err):
 			return Endpoint{}, fmt.Errorf("probe proxy lock: %w", err)
+		case discovery.status == adoptionLegacy:
+			return Endpoint{}, fmt.Errorf(
+				"legacy proxy record %s is protected by held lock %s; stop the pre-upgrade proxy with the old bd binary or wait for its idle exit",
+				pidfile.Path(rootDir, PIDFileName), filepath.Join(rootDir, LockFileName),
+			)
 		}
 
 		select {
@@ -147,7 +252,25 @@ func GetCreateDatabaseProxyServerEndpoint(rootDir string, opts OpenOpts) (Endpoi
 	}
 }
 
-func spawnAndHandoff(rootDir string, opts OpenOpts, deadline time.Time, lock *util.Lock) (Endpoint, error) {
+func adoptedEndpoint(rootDir, want string, discovery adoptionResult) (Endpoint, error) {
+	if want != "" && discovery.pidfile.UpstreamID != "" && discovery.pidfile.UpstreamID != want {
+		return Endpoint{}, &ErrUpstreamMismatch{
+			RootDir: rootDir,
+			Want:    want,
+			Have:    discovery.pidfile.UpstreamID,
+		}
+	}
+	return discovery.endpoint, nil
+}
+
+func spawnAndHandoff(
+	rootDir string,
+	opts OpenOpts,
+	deadline time.Time,
+	stopEpoch string,
+	lock *util.Lock,
+	discovery adoptionResult,
+) (Endpoint, error) {
 	handedOff := false
 	defer func() {
 		if !handedOff {
@@ -155,23 +278,19 @@ func spawnAndHandoff(rootDir string, opts OpenOpts, deadline time.Time, lock *ut
 		}
 	}()
 
-	// Stale pidfile from a previous (now-dead) proxy must not mislead racing
-	// readers into dialing a port that nobody is listening on.
-	_ = pidfile.Remove(rootDir, PIDFileName)
+	currentEpoch, err := readStopEpoch(rootDir)
+	if err != nil {
+		return Endpoint{}, fmt.Errorf("read proxy stop epoch under lock: %w", err)
+	}
+	if currentEpoch != stopEpoch {
+		return Endpoint{}, fmt.Errorf("%w for %s", errStartInterrupted, rootDir)
+	}
 
-	// Probe the proxy-child flock: if held, a previous proxy-child is still
-	// alive and has an orphaned dolt sql-server we must kill before
-	// respawning. If we can acquire it, no proxy-child is running — release
-	// immediately so the child we are about to spawn can take it.
-	if l, err := util.TryLock(filepath.Join(rootDir, server.LockFileName)); err == nil {
-		l.Unlock()
-	} else if lockfile.IsLocked(err) {
-		if pf, perr := pidfile.Read(rootDir, server.PIDFileName); perr == nil && pf != nil {
-			if proc, ferr := os.FindProcess(pf.Pid); ferr == nil {
-				_ = proc.Kill()
-			}
-			_ = pidfile.Remove(rootDir, server.PIDFileName)
-		}
+	if err := quarantineForSpawn(rootDir, discovery); err != nil {
+		return Endpoint{}, err
+	}
+	if err := cleanupOrphanBackend(rootDir); err != nil {
+		return Endpoint{}, err
 	}
 
 	port := opts.Port
@@ -183,10 +302,15 @@ func spawnAndHandoff(rootDir string, opts OpenOpts, deadline time.Time, lock *ut
 	}
 
 	handedOff = true
-	cmd, done, err := forkExecChild(rootDir, opts, port, lock)
+	child, err := forkExecChild(rootDir, opts, port, stopEpoch, lock)
 	if err != nil {
 		return Endpoint{}, fmt.Errorf("fork child: %w", err)
 	}
+	defer func() {
+		if child.handle != nil {
+			_ = child.handle.Close()
+		}
+	}()
 
 	hard := time.NewTimer(spawnReadyHardTimeout)
 	defer hard.Stop()
@@ -194,25 +318,51 @@ func spawnAndHandoff(rootDir string, opts OpenOpts, deadline time.Time, lock *ut
 	defer poll.Stop()
 
 	for {
-		if ep, _, ok := readAndDial(rootDir); ok {
-			return ep, nil
+		discovered := readAndDial(rootDir)
+		if discovered.status == adoptionAdopted {
+			if err := sweepOldQuarantines(rootDir, time.Now()); err != nil {
+				log.Printf("dbproxy: could not sweep old quarantined records in %s: %v", rootDir, err)
+			}
+			return discovered.endpoint, nil
+		}
+		if discovered.status == adoptionIOErr {
+			return Endpoint{}, fmt.Errorf("discover spawned proxy: %w", discovered.err)
 		}
 		select {
-		case <-done:
+		case <-child.done:
+			_ = clearOwnSpawnMarker(rootDir, child.marker)
+			if interrupted, ierr := stopEpochChanged(rootDir, stopEpoch); ierr != nil {
+				return Endpoint{}, ierr
+			} else if interrupted {
+				return Endpoint{}, fmt.Errorf("%w for %s", errStartInterrupted, rootDir)
+			}
 			return Endpoint{}, fmt.Errorf("proxy child on port %d exited before becoming ready (likely lost lock race)", port)
 		case <-hard.C:
-			_ = cmd.Process.Kill()
+			if err := killSpawnedChild(child); err != nil {
+				return Endpoint{}, fmt.Errorf("hard timeout waiting for proxy on port %d; safe child kill failed: %w", port, err)
+			}
+			_ = clearOwnSpawnMarker(rootDir, child.marker)
 			return Endpoint{}, fmt.Errorf("hard timeout (%s) waiting for proxy on port %d", spawnReadyHardTimeout, port)
 		case <-poll.C:
 		}
 		if time.Now().After(deadline) {
-			_ = cmd.Process.Kill()
+			if err := killSpawnedChild(child); err != nil {
+				return Endpoint{}, fmt.Errorf("timeout waiting for proxy on port %d; safe child kill failed: %w", port, err)
+			}
+			_ = clearOwnSpawnMarker(rootDir, child.marker)
 			return Endpoint{}, fmt.Errorf("timeout waiting for proxy to become ready on port %d", port)
 		}
 	}
 }
 
-func forkExecChild(rootDir string, opts OpenOpts, port int, lock *util.Lock) (*exec.Cmd, <-chan struct{}, error) {
+type spawnedProxyChild struct {
+	cmd    *exec.Cmd
+	done   <-chan struct{}
+	handle *procid.Handle
+	marker spawnMarker
+}
+
+func forkExecChild(rootDir string, opts OpenOpts, port int, stopEpoch string, lock *util.Lock) (*spawnedProxyChild, error) {
 	released := false
 	defer func() {
 		if !released {
@@ -222,7 +372,7 @@ func forkExecChild(rootDir string, opts OpenOpts, port int, lock *util.Lock) (*e
 
 	self, err := ResolveExecutable()
 	if err != nil {
-		return nil, nil, fmt.Errorf("locate bd executable: %w", err)
+		return nil, fmt.Errorf("locate bd executable: %w", err)
 	}
 
 	idleTimeout := opts.IdleTimeout
@@ -267,7 +417,7 @@ func forkExecChild(rootDir string, opts OpenOpts, port int, lock *util.Lock) (*e
 
 	logFile, err := os.OpenFile(opts.LogFilePath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600) //nolint:gosec // G304: logFilePath is caller-derived (workspace path), not user-request input
 	if err != nil {
-		return nil, nil, fmt.Errorf("open log file %q: %w", opts.LogFilePath, err)
+		return nil, fmt.Errorf("open log file %q: %w", opts.LogFilePath, err)
 	}
 
 	cmd := exec.Command(self, args...)
@@ -276,12 +426,35 @@ func forkExecChild(rootDir string, opts OpenOpts, port int, lock *util.Lock) (*e
 	cmd.Stderr = logFile
 	cmd.SysProcAttr = procAttrDetached()
 
+	birth, err := procid.Capture(os.Getpid())
+	if err != nil {
+		_ = logFile.Close()
+		return nil, fmt.Errorf("capture spawning process identity: %w", err)
+	}
+	marker := spawnMarker{
+		Schema:      1,
+		PID:         os.Getpid(),
+		Birth:       string(birth),
+		StopEpoch:   stopEpoch,
+		StartedUnix: time.Now().Unix(),
+	}
+	if err := writeSpawnMarker(rootDir, marker); err != nil {
+		_ = logFile.Close()
+		return nil, err
+	}
+
+	// The marker is durable before proxy.lock is released. Shutdown treats a
+	// matching live owner as an in-progress start and waits; the child removes
+	// it only after acquiring proxy.lock. This closes the release-before-Start
+	// window without making the child deadlock on the parent's flock.
 	released = true
 	lock.Unlock()
+	beforeProxyChildStart()
 
 	if err := cmd.Start(); err != nil {
 		_ = logFile.Close()
-		return nil, nil, fmt.Errorf("start proxy child: %w", err)
+		_ = clearOwnSpawnMarker(rootDir, marker)
+		return nil, fmt.Errorf("start proxy child: %w", err)
 	}
 
 	done := make(chan struct{})
@@ -291,27 +464,94 @@ func forkExecChild(rootDir string, opts OpenOpts, port int, lock *util.Lock) (*e
 		_ = logFile.Close()
 	}()
 
-	return cmd, done, nil
+	var handle *procid.Handle
+	childBirth, captureErr := procid.Capture(cmd.Process.Pid)
+	if captureErr == nil {
+		handle, captureErr = procid.Open(cmd.Process.Pid, childBirth)
+	}
+	if captureErr != nil && !procid.IsProcessGone(captureErr) {
+		log.Printf("dbproxy: could not open verified handle for newly spawned proxy pid %d: %v", cmd.Process.Pid, captureErr)
+	}
+
+	return &spawnedProxyChild{
+		cmd:    cmd,
+		done:   done,
+		handle: handle,
+		marker: marker,
+	}, nil
 }
 
 func IsRunning(rootDir string) (bool, int) {
-	_, pf, ok := readAndDial(rootDir)
-	if !ok {
+	discovery := readAndDial(rootDir)
+	if discovery.status != adoptionAdopted {
 		return false, 0
 	}
-	return true, pf.Pid
+	return true, discovery.pidfile.Pid
 }
 
-func readAndDial(rootDir string) (Endpoint, *pidfile.PidFile, bool) {
+func readAndDial(rootDir string) adoptionResult {
 	pf, err := pidfile.Read(rootDir, PIDFileName)
-	if err != nil || pf == nil {
-		return Endpoint{}, nil, false
+	if err != nil {
+		if isMalformedPIDFileError(err) {
+			return adoptionResult{status: adoptionMalformed, err: err}
+		}
+		return adoptionResult{status: adoptionIOErr, err: err}
 	}
+	if pf == nil {
+		return adoptionResult{status: adoptionNoRecord}
+	}
+	if err := pf.ValidateV2(pidfile.KindProxy); err != nil {
+		if errors.Is(err, pidfile.ErrLegacySchema) {
+			return adoptionResult{status: adoptionLegacy, pidfile: pf, err: err}
+		}
+		return adoptionResult{status: adoptionMalformed, pidfile: pf, err: err}
+	}
+
+	matched, err := procid.Verify(pf.Pid, procid.Token(pf.Birth))
+	if err != nil {
+		return adoptionResult{status: adoptionIOErr, pidfile: pf, err: fmt.Errorf("verify proxy pid %d: %w", pf.Pid, err)}
+	}
+	if !matched {
+		return adoptionResult{status: adoptionStaleDead, pidfile: pf}
+	}
+
+	expectedRootID, err := identity.RootID(rootDir)
+	if err != nil {
+		return adoptionResult{status: adoptionIOErr, pidfile: pf, err: err}
+	}
+	secret, err := identity.ReadSecret(rootDir)
+	if err != nil {
+		return adoptionResult{status: adoptionIdentityMismatch, pidfile: pf, err: err}
+	}
+	reply, err := identity.Identify("127.0.0.1", pf.ControlPort, secret, identityProbeTimeout)
+	if err != nil {
+		return adoptionResult{status: adoptionIdentityMismatch, pidfile: pf, err: err}
+	}
+	if reply.Schema != pidfile.SchemaV2 ||
+		reply.Role != pidfile.KindProxy ||
+		reply.RootID != expectedRootID ||
+		reply.RootID != pf.RootID ||
+		reply.PID != pf.Pid ||
+		reply.Birth != pf.Birth ||
+		reply.DataPort != pf.Port ||
+		reply.ControlPort != pf.ControlPort ||
+		reply.UpstreamID != pf.UpstreamID {
+		return adoptionResult{
+			status:  adoptionIdentityMismatch,
+			pidfile: pf,
+			err:     errors.New("authenticated proxy identity does not match its pidfile or workspace"),
+		}
+	}
+
 	ep := Endpoint{Host: "127.0.0.1", Port: pf.Port}
-	if !probePort(ep, 500*time.Millisecond) {
-		return Endpoint{}, nil, false
+	if !probePort(ep, identityProbeTimeout) {
+		return adoptionResult{
+			status:  adoptionIdentityMismatch,
+			pidfile: pf,
+			err:     fmt.Errorf("authenticated proxy data port %d is not accepting connections", pf.Port),
+		}
 	}
-	return ep, pf, true
+	return adoptionResult{status: adoptionAdopted, endpoint: ep, pidfile: pf}
 }
 
 func probePort(ep Endpoint, timeout time.Duration) bool {
@@ -321,4 +561,346 @@ func probePort(ep Endpoint, timeout time.Duration) bool {
 	}
 	_ = conn.Close()
 	return true
+}
+
+func isMalformedPIDFileError(err error) bool {
+	var syntaxErr *json.SyntaxError
+	var typeErr *json.UnmarshalTypeError
+	return errors.As(err, &syntaxErr) || errors.As(err, &typeErr)
+}
+
+func quarantineForSpawn(rootDir string, discovery adoptionResult) error {
+	switch discovery.status {
+	case adoptionNoRecord:
+		return nil
+	case adoptionStaleDead:
+		log.Printf("dbproxy: quarantining stale dead proxy record %s before restart", pidfile.Path(rootDir, PIDFileName))
+	case adoptionIdentityMismatch:
+		log.Printf(
+			"dbproxy: refusing proxy identity at %s (%v); quarantining only its record and starting a fresh proxy",
+			pidfile.Path(rootDir, PIDFileName), discovery.err,
+		)
+	case adoptionLegacy:
+		log.Printf(
+			"dbproxy: quarantining legacy proxy record %s; a pre-upgrade proxy may still be running and must be stopped with the old bd binary if it does not idle-exit",
+			pidfile.Path(rootDir, PIDFileName),
+		)
+	case adoptionMalformed:
+		log.Printf("dbproxy: quarantining malformed proxy record %s (%v) before restart", pidfile.Path(rootDir, PIDFileName), discovery.err)
+	default:
+		return fmt.Errorf("cannot spawn from proxy discovery status %s", discovery.status)
+	}
+	target, err := quarantineRecord(rootDir, PIDFileName, time.Now())
+	if err != nil {
+		return fmt.Errorf("quarantine proxy record: %w", err)
+	}
+	log.Printf("dbproxy: preserved proxy record as %s", target)
+	return nil
+}
+
+func quarantineRecord(rootDir, name string, now time.Time) (string, error) {
+	source := pidfile.Path(rootDir, name)
+	for stamp := now.Unix(); ; stamp++ {
+		target := filepath.Join(rootDir, name+".stale-"+strconv.FormatInt(stamp, 10))
+		if _, err := os.Lstat(target); err == nil {
+			continue
+		} else if !errors.Is(err, fs.ErrNotExist) {
+			return "", fmt.Errorf("inspect quarantine target %s: %w", target, err)
+		}
+		if err := os.Rename(source, target); err != nil {
+			return "", fmt.Errorf("rename %s to %s: %w", source, target, err)
+		}
+		return target, nil
+	}
+}
+
+func sweepOldQuarantines(rootDir string, now time.Time) error {
+	entries, err := os.ReadDir(rootDir)
+	if err != nil {
+		return err
+	}
+	cutoff := now.Add(-quarantineRetention).Unix()
+	prefixes := []string{
+		PIDFileName + ".stale-",
+		server.PIDFileName + ".stale-",
+	}
+	var errs []error
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		var stampText string
+		for _, prefix := range prefixes {
+			if strings.HasPrefix(entry.Name(), prefix) {
+				stampText = strings.TrimPrefix(entry.Name(), prefix)
+				break
+			}
+		}
+		if stampText == "" {
+			continue
+		}
+		stamp, err := strconv.ParseInt(stampText, 10, 64)
+		if err != nil || stamp >= cutoff {
+			continue
+		}
+		if err := os.Remove(filepath.Join(rootDir, entry.Name())); err != nil && !errors.Is(err, fs.ErrNotExist) {
+			errs = append(errs, fmt.Errorf("remove expired quarantine %s: %w", entry.Name(), err))
+		}
+	}
+	return errors.Join(errs...)
+}
+
+func cleanupOrphanBackend(rootDir string) error {
+	recordPath := pidfile.Path(rootDir, server.PIDFileName)
+	pf, readErr := pidfile.Read(rootDir, server.PIDFileName)
+
+	childLockPath := filepath.Join(rootDir, server.LockFileName)
+	childLock, lockErr := util.TryLock(childLockPath)
+	switch {
+	case lockErr == nil:
+		childLock.Unlock()
+	case lockfile.IsLocked(lockErr):
+		pid := 0
+		if pf != nil {
+			pid = pf.Pid
+		}
+		return fmt.Errorf(
+			"refusing backend cleanup: %s is held while proxy lock is free (recorded pid %d at %s); stop the process holding the child lock or remove the stale lock owner before retrying",
+			childLockPath, pid, recordPath,
+		)
+	default:
+		return fmt.Errorf("probe backend lock %s: %w", childLockPath, lockErr)
+	}
+
+	if readErr != nil {
+		return fmt.Errorf("read backend record %s: %w", recordPath, readErr)
+	}
+	if pf == nil {
+		return nil
+	}
+	if err := pf.ValidateV2(pidfile.KindDoltBackend); err != nil {
+		return unverifiableProcessError("backend cleanup", recordPath, pf.Pid, err)
+	}
+	expectedRootID, err := identity.RootID(rootDir)
+	if err != nil {
+		return fmt.Errorf("resolve backend root identity: %w", err)
+	}
+	if pf.RootID != expectedRootID {
+		return unverifiableProcessError(
+			"backend cleanup",
+			recordPath,
+			pf.Pid,
+			fmt.Errorf("root identity mismatch (record has %q, workspace has %q)", pf.RootID, expectedRootID),
+		)
+	}
+
+	handle, dead, err := openRecordedProcess(pf)
+	if err != nil {
+		return unverifiableProcessError("backend cleanup", recordPath, pf.Pid, err)
+	}
+	if dead {
+		if _, err := quarantineRecord(rootDir, server.PIDFileName, time.Now()); err != nil {
+			return fmt.Errorf("quarantine dead backend record: %w", err)
+		}
+		return nil
+	}
+	defer func() { _ = handle.Close() }()
+
+	if err := handle.Kill(); err != nil {
+		return fmt.Errorf("kill verified orphan backend pid %d from %s: %w", pf.Pid, recordPath, err)
+	}
+	if err := waitForRecordedProcessExit(pf, backendExitTimeout); err != nil {
+		return fmt.Errorf("wait for verified orphan backend pid %d: %w", pf.Pid, err)
+	}
+	if _, err := quarantineRecord(rootDir, server.PIDFileName, time.Now()); err != nil {
+		return fmt.Errorf("quarantine orphan backend record: %w", err)
+	}
+	return nil
+}
+
+func unverifiableProcessError(operation, recordPath string, pid int, cause error) error {
+	return fmt.Errorf(
+		"%s refused for unverifiable live process pid %d recorded at %s: %v; stop that process with the binary that started it, then retry",
+		operation, pid, recordPath, cause,
+	)
+}
+
+func openRecordedProcess(pf *pidfile.PidFile) (*procid.Handle, bool, error) {
+	handle, err := procid.Open(pf.Pid, procid.Token(pf.Birth))
+	if err == nil {
+		return handle, false, nil
+	}
+	if procid.IsProcessGone(err) {
+		return nil, true, nil
+	}
+
+	current, captureErr := procid.Capture(pf.Pid)
+	if captureErr != nil {
+		if procid.IsProcessGone(captureErr) {
+			return nil, true, nil
+		}
+		return nil, false, fmt.Errorf("open process identity: %w (recheck: %v)", err, captureErr)
+	}
+	if current != procid.Token(pf.Birth) {
+		return nil, false, fmt.Errorf("birth token mismatch")
+	}
+	return nil, false, fmt.Errorf("open verified process handle: %w", err)
+}
+
+func waitForRecordedProcessExit(pf *pidfile.PidFile, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for {
+		matched, err := procid.Verify(pf.Pid, procid.Token(pf.Birth))
+		if err != nil {
+			return err
+		}
+		if !matched {
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("timeout (%s) waiting for process exit", timeout)
+		}
+		time.Sleep(shutdownConfirmPoll)
+	}
+}
+
+func killSpawnedChild(child *spawnedProxyChild) error {
+	select {
+	case <-child.done:
+		return nil
+	default:
+	}
+	if child.handle == nil {
+		return fmt.Errorf("verified process handle for pid %d is unavailable", child.cmd.Process.Pid)
+	}
+	if err := child.handle.Kill(); err != nil {
+		return err
+	}
+	timer := time.NewTimer(shutdownConfirmDeadline)
+	defer timer.Stop()
+	select {
+	case <-child.done:
+		return nil
+	case <-timer.C:
+		return fmt.Errorf("timeout (%s) waiting for pid %d", shutdownConfirmDeadline, child.cmd.Process.Pid)
+	}
+}
+
+func readStopEpoch(rootDir string) (string, error) {
+	path := filepath.Join(rootDir, stopEpochFileName)
+	data, err := os.ReadFile(path) // #nosec G304 - path is a fixed control filename under the workspace proxy root
+	if errors.Is(err, fs.ErrNotExist) {
+		return "", nil
+	}
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(data)), nil
+}
+
+func advanceStopEpoch(rootDir string) (string, error) {
+	epoch := strconv.FormatInt(time.Now().UnixNano(), 10) +
+		"-" + strconv.Itoa(os.Getpid()) +
+		"-" + strconv.FormatUint(stopEpochSequence.Add(1), 10)
+	if err := atomicfile.WriteFile(filepath.Join(rootDir, stopEpochFileName), []byte(epoch+"\n"), 0o600); err != nil {
+		return "", err
+	}
+	return epoch, nil
+}
+
+func stopEpochChanged(rootDir, expected string) (bool, error) {
+	current, err := readStopEpoch(rootDir)
+	if err != nil {
+		return false, fmt.Errorf("read proxy stop epoch: %w", err)
+	}
+	return current != expected, nil
+}
+
+func writeSpawnMarker(rootDir string, marker spawnMarker) error {
+	data, err := json.Marshal(marker)
+	if err != nil {
+		return err
+	}
+	if err := atomicfile.WriteFile(filepath.Join(rootDir, spawnMarkerFileName), data, 0o600); err != nil {
+		return fmt.Errorf("write spawn marker: %w", err)
+	}
+	return nil
+}
+
+func readSpawnMarker(rootDir string) (*spawnMarker, error) {
+	path := filepath.Join(rootDir, spawnMarkerFileName)
+	data, err := os.ReadFile(path) // #nosec G304 - path is a fixed control filename under the workspace proxy root
+	if errors.Is(err, fs.ErrNotExist) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	var marker spawnMarker
+	if err := json.Unmarshal(data, &marker); err != nil {
+		return nil, fmt.Errorf("decode %s: %w", path, err)
+	}
+	if marker.Schema != 1 || marker.PID <= 0 || marker.Birth == "" {
+		return nil, fmt.Errorf("invalid spawn marker %s", path)
+	}
+	return &marker, nil
+}
+
+func inspectSpawnMarkerLocked(rootDir string) (bool, error) {
+	marker, err := readSpawnMarker(rootDir)
+	if err != nil {
+		return false, fmt.Errorf("inspect proxy spawn marker: %w", err)
+	}
+	if marker == nil {
+		return false, nil
+	}
+	matched, err := procid.Verify(marker.PID, procid.Token(marker.Birth))
+	if err != nil {
+		return false, fmt.Errorf("verify proxy spawn owner pid %d: %w", marker.PID, err)
+	}
+	if matched {
+		return true, nil
+	}
+	if err := os.Remove(filepath.Join(rootDir, spawnMarkerFileName)); err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return false, fmt.Errorf("remove dead spawn marker: %w", err)
+	}
+	return false, nil
+}
+
+func clearSpawnMarkerAfterLock(rootDir string) error {
+	err := os.Remove(filepath.Join(rootDir, spawnMarkerFileName))
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return err
+	}
+	return nil
+}
+
+func clearOwnSpawnMarker(rootDir string, own spawnMarker) error {
+	deadline := time.Now().Add(shutdownConfirmDeadline)
+	for {
+		marker, err := readSpawnMarker(rootDir)
+		if err != nil || marker == nil {
+			return err
+		}
+		if *marker != own {
+			return nil
+		}
+
+		lock, err := util.TryLock(filepath.Join(rootDir, LockFileName))
+		if err == nil {
+			current, readErr := readSpawnMarker(rootDir)
+			if readErr == nil && current != nil && *current == own {
+				readErr = clearSpawnMarkerAfterLock(rootDir)
+			}
+			lock.Unlock()
+			return readErr
+		}
+		if !lockfile.IsLocked(err) {
+			return err
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("timeout clearing spawn marker %s", filepath.Join(rootDir, spawnMarkerFileName))
+		}
+		time.Sleep(shutdownConfirmPoll)
+	}
 }

--- a/internal/storage/dbproxy/proxy/endpoint.go
+++ b/internal/storage/dbproxy/proxy/endpoint.go
@@ -495,6 +495,12 @@ func forkExecChild(rootDir string, opts OpenOpts, port int, stopEpoch string, lo
 		_ = logFile.Close()
 	}()
 
+	// Theoretical race: the birth token is captured after Start, so the child
+	// could exit and its PID be recycled before Capture runs, making the
+	// handle describe the unrelated replacement. The window is a few
+	// milliseconds against OS PID-reuse latency, and the OS has no primitive
+	// to atomically capture identity at spawn, so this is accepted and
+	// documented rather than defended.
 	var handle *procid.Handle
 	childBirth, captureErr := procid.Capture(cmd.Process.Pid)
 	if captureErr == nil {
@@ -566,7 +572,9 @@ func readAndDial(rootDir string) adoptionResult {
 	if err != nil {
 		return adoptionResult{status: adoptionIdentityMismatch, pidfile: pf, err: err}
 	}
-	if reply.Schema != pidfile.SchemaV2 ||
+	// Accept schema v2 or newer, matching pidfile.ValidateV2's forward-compat
+	// policy for records.
+	if reply.Schema < pidfile.SchemaV2 ||
 		reply.Role != pidfile.KindProxy ||
 		reply.RootID != expectedRootID ||
 		reply.RootID != pf.RootID ||
@@ -782,10 +790,15 @@ func cleanupOrphanBackend(rootDir string) error {
 		}
 		return nil
 	}
-	defer func() { _ = handle.Close() }()
-
 	if err := handle.Kill(); err != nil {
+		_ = handle.Close()
 		return fmt.Errorf("kill verified orphan backend pid %d from %s: %w", pf.Pid, recordPath, err)
+	}
+	// Close before waiting: an open handle on Windows keeps the dead PID
+	// allocated, so procid.Verify would keep matching it and the exit wait
+	// below would always time out.
+	if err := handle.Close(); err != nil {
+		return fmt.Errorf("close verified backend process handle for pid %d: %w", pf.Pid, err)
 	}
 	if err := waitForRecordedProcessExit(pf, backendExitTimeout); err != nil {
 		return fmt.Errorf("wait for verified orphan backend pid %d: %w", pf.Pid, err)
@@ -891,9 +904,13 @@ func killSpawnedChild(child *spawnedProxyChild) error {
 	default:
 	}
 	if child.handle == nil {
-		return fmt.Errorf("verified process handle for pid %d is unavailable", child.cmd.Process.Pid)
-	}
-	if err := child.handle.Kill(); err != nil {
+		// No verified handle could be opened at spawn time. The child is our
+		// own un-reaped process, so its PID cannot have been recycled and a
+		// direct kill is safe; the alternative is leaking a live proxy child.
+		if err := child.cmd.Process.Kill(); err != nil && !errors.Is(err, os.ErrProcessDone) {
+			return fmt.Errorf("kill spawned proxy child pid %d: %w", child.cmd.Process.Pid, err)
+		}
+	} else if err := child.handle.Kill(); err != nil {
 		return err
 	}
 	timer := time.NewTimer(shutdownConfirmDeadline)

--- a/internal/storage/dbproxy/proxy/endpoint.go
+++ b/internal/storage/dbproxy/proxy/endpoint.go
@@ -89,6 +89,24 @@ var (
 	readControlSecret     = identity.ReadSecret
 )
 
+// ErrUnverifiableProcess marks lifecycle operations that refuse to signal a
+// process because its workspace-scoped identity cannot be verified. Callers
+// may use errors.Is to offer a narrower recovery path without treating
+// unrelated shutdown failures as identity failures.
+var ErrUnverifiableProcess = errors.New("proxy process identity is unverifiable")
+
+type unverifiableLifecycleError struct {
+	message string
+}
+
+func (e *unverifiableLifecycleError) Error() string {
+	return e.message
+}
+
+func (e *unverifiableLifecycleError) Unwrap() error {
+	return ErrUnverifiableProcess
+}
+
 var stopEpochSequence atomic.Uint64
 
 // beforeProxyChildStart is a deterministic test hook for the otherwise tiny
@@ -798,7 +816,7 @@ func unverifiableProcessError(
 	if checks.LegacyProxy && checks.LiveEstablished {
 		stopGuidance = "stop the pre-upgrade proxy with the old bd binary"
 	}
-	return fmt.Errorf(
+	return &unverifiableLifecycleError{message: fmt.Sprintf(
 		"%s refused for unverifiable%s process pid %d recorded at %s: %v; %s, then quarantine the record manually by renaming %s to %s.stale-<unix-timestamp> before retrying",
 		operation,
 		liveness,
@@ -808,7 +826,7 @@ func unverifiableProcessError(
 		stopGuidance,
 		recordPath,
 		recordPath,
-	)
+	)}
 }
 
 func probeUnverifiablePID(pid int) (dead bool, live bool, err error) {

--- a/internal/storage/dbproxy/proxy/endpoint_mismatch_test.go
+++ b/internal/storage/dbproxy/proxy/endpoint_mismatch_test.go
@@ -3,12 +3,14 @@ package proxy_test
 import (
 	"errors"
 	"net"
+	"path/filepath"
 	"testing"
 
 	"github.com/steveyegge/beads/internal/configfile"
 	"github.com/steveyegge/beads/internal/storage/dbproxy/pidfile"
 	"github.com/steveyegge/beads/internal/storage/dbproxy/proxy"
 	"github.com/steveyegge/beads/internal/storage/dbproxy/server"
+	"github.com/steveyegge/beads/internal/storage/dbproxy/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -16,20 +18,22 @@ import (
 func TestGetCreateDatabaseProxyServerEndpoint_RejectsUpstreamMismatch(t *testing.T) {
 	root := t.TempDir()
 
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = ln.Close() })
-	port := ln.Addr().(*net.TCPAddr).Port
-
 	existingCfg := configfile.ExternalDoltConfig{Host: "10.0.0.1", Port: 3306}
-	require.NoError(t, pidfile.Write(root, proxy.PIDFileName, pidfile.PidFile{
-		Pid:        12345,
-		Port:       port,
-		UpstreamID: server.ExternalDoltServerID(existingCfg),
-	}))
+	ts := server.New()
+	ts.ID_ = server.ExternalDoltServerID(existingCfg)
+	h := runProxy(t, proxy.ProxyOpts{
+		RootDir: root,
+		Port:    freeTCPPort(t),
+		Server:  ts,
+	})
+	waitListening(t, root, listenWait)
+	t.Cleanup(func() {
+		h.Cancel()
+		_ = h.waitErr(t, shutdownWait)
+	})
 
 	wantCfg := configfile.ExternalDoltConfig{Host: "10.0.0.2", Port: 3306}
-	_, err = proxy.GetCreateDatabaseProxyServerEndpoint(root, proxy.OpenOpts{
+	_, err := proxy.GetCreateDatabaseProxyServerEndpoint(root, proxy.OpenOpts{
 		Backend:     proxy.BackendExternal,
 		External:    wantCfg,
 		LogFilePath: root + "/server.log",
@@ -47,17 +51,20 @@ func TestGetCreateDatabaseProxyServerEndpoint_RejectsUpstreamMismatch(t *testing
 func TestGetCreateDatabaseProxyServerEndpoint_ReusesMatchingUpstream(t *testing.T) {
 	root := t.TempDir()
 
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = ln.Close() })
-	port := ln.Addr().(*net.TCPAddr).Port
-
 	cfg := configfile.ExternalDoltConfig{Host: "10.0.0.1", Port: 3306}
-	require.NoError(t, pidfile.Write(root, proxy.PIDFileName, pidfile.PidFile{
-		Pid:        12345,
-		Port:       port,
-		UpstreamID: server.ExternalDoltServerID(cfg),
-	}))
+	ts := server.New()
+	ts.ID_ = server.ExternalDoltServerID(cfg)
+	port := freeTCPPort(t)
+	h := runProxy(t, proxy.ProxyOpts{
+		RootDir: root,
+		Port:    port,
+		Server:  ts,
+	})
+	waitListening(t, root, listenWait)
+	t.Cleanup(func() {
+		h.Cancel()
+		_ = h.waitErr(t, shutdownWait)
+	})
 
 	ep, err := proxy.GetCreateDatabaseProxyServerEndpoint(root, proxy.OpenOpts{
 		Backend:     proxy.BackendExternal,
@@ -69,7 +76,7 @@ func TestGetCreateDatabaseProxyServerEndpoint_ReusesMatchingUpstream(t *testing.
 	assert.Equal(t, port, ep.Port)
 }
 
-func TestGetCreateDatabaseProxyServerEndpoint_LegacyPidfileWithoutIDReused(t *testing.T) {
+func TestGetCreateDatabaseProxyServerEndpoint_DoesNotBlindlyAdoptLegacyListener(t *testing.T) {
 	root := t.TempDir()
 
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
@@ -81,14 +88,18 @@ func TestGetCreateDatabaseProxyServerEndpoint_LegacyPidfileWithoutIDReused(t *te
 		Pid:  12345,
 		Port: port,
 	}))
+	lock, err := util.TryLock(filepath.Join(root, proxy.LockFileName))
+	require.NoError(t, err)
+	defer lock.Unlock()
 
-	ep, err := proxy.GetCreateDatabaseProxyServerEndpoint(root, proxy.OpenOpts{
+	_, err = proxy.GetCreateDatabaseProxyServerEndpoint(root, proxy.OpenOpts{
 		Backend:     proxy.BackendExternal,
 		External:    configfile.ExternalDoltConfig{Host: "10.0.0.1", Port: 3306},
 		LogFilePath: root + "/server.log",
 	})
-	require.NoError(t, err)
-	assert.Equal(t, port, ep.Port)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "legacy proxy record")
+	assert.Contains(t, err.Error(), filepath.Join(root, proxy.LockFileName))
 }
 
 func TestErrUpstreamMismatch_Message(t *testing.T) {

--- a/internal/storage/dbproxy/proxy/endpoint_security_test.go
+++ b/internal/storage/dbproxy/proxy/endpoint_security_test.go
@@ -1,0 +1,548 @@
+package proxy
+
+import (
+	"errors"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/steveyegge/beads/internal/configfile"
+	"github.com/steveyegge/beads/internal/procid"
+	"github.com/steveyegge/beads/internal/storage/dbproxy/identity"
+	"github.com/steveyegge/beads/internal/storage/dbproxy/pidfile"
+	"github.com/steveyegge/beads/internal/storage/dbproxy/server"
+	"github.com/steveyegge/beads/internal/storage/dbproxy/util"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type helperProcess struct {
+	cmd   *exec.Cmd
+	token procid.Token
+	done  <-chan error
+}
+
+func startHelperProcess(t *testing.T) helperProcess {
+	t.Helper()
+	cmd := exec.Command("sleep", "30")
+	require.NoError(t, cmd.Start())
+	token, err := procid.Capture(cmd.Process.Pid)
+	require.NoError(t, err)
+	done := make(chan error, 1)
+	go func() {
+		done <- cmd.Wait()
+		close(done)
+	}()
+	t.Cleanup(func() {
+		matched, verifyErr := procid.Verify(cmd.Process.Pid, token)
+		if verifyErr == nil && matched {
+			handle, openErr := procid.Open(cmd.Process.Pid, token)
+			if openErr == nil {
+				_ = handle.Kill()
+				_ = handle.Close()
+			}
+		}
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			t.Errorf("helper pid %d did not exit", cmd.Process.Pid)
+		}
+	})
+	return helperProcess{cmd: cmd, token: token, done: done}
+}
+
+func assertHelperAlive(t *testing.T, helper helperProcess) {
+	t.Helper()
+	matched, err := procid.Verify(helper.cmd.Process.Pid, helper.token)
+	require.NoError(t, err)
+	assert.True(t, matched, "helper pid %d should still be alive", helper.cmd.Process.Pid)
+}
+
+func assertHelperExited(t *testing.T, helper helperProcess) {
+	t.Helper()
+	select {
+	case <-helper.done:
+	case <-time.After(5 * time.Second):
+		t.Fatalf("helper pid %d did not exit", helper.cmd.Process.Pid)
+	}
+	matched, err := procid.Verify(helper.cmd.Process.Pid, helper.token)
+	require.NoError(t, err)
+	assert.False(t, matched)
+}
+
+func v2Record(t *testing.T, root, kind string, helper helperProcess) pidfile.PidFile {
+	t.Helper()
+	rootID, err := identity.RootID(root)
+	require.NoError(t, err)
+	return pidfile.PidFile{
+		Schema: pidfile.SchemaV2,
+		Kind:   kind,
+		Pid:    helper.cmd.Process.Pid,
+		Birth:  string(helper.token),
+		Port:   3307,
+		RootID: rootID,
+	}
+}
+
+func TestReadAndDialClassifiesRecordsWithoutMutation(t *testing.T) {
+	t.Run("no record", func(t *testing.T) {
+		root := t.TempDir()
+		got := readAndDial(root)
+		assert.Equal(t, adoptionNoRecord, got.status)
+	})
+
+	t.Run("malformed JSON", func(t *testing.T) {
+		root := t.TempDir()
+		path := pidfile.Path(root, PIDFileName)
+		require.NoError(t, os.WriteFile(path, []byte(`{"pid":`), 0o600))
+		got := readAndDial(root)
+		assert.Equal(t, adoptionMalformed, got.status)
+		_, err := os.Stat(path)
+		assert.NoError(t, err, "discovery must not mutate the pidfile")
+	})
+
+	t.Run("invalid v2 fields", func(t *testing.T) {
+		root := t.TempDir()
+		require.NoError(t, pidfile.Write(root, PIDFileName, pidfile.PidFile{
+			Schema: pidfile.SchemaV2,
+			Kind:   "foreign-kind",
+			Pid:    os.Getpid(),
+			Birth:  "birth",
+			Port:   3307,
+		}))
+		got := readAndDial(root)
+		assert.Equal(t, adoptionMalformed, got.status)
+		assert.ErrorIs(t, got.err, pidfile.ErrKindMismatch)
+	})
+
+	t.Run("I/O error", func(t *testing.T) {
+		root := t.TempDir()
+		require.NoError(t, os.Mkdir(pidfile.Path(root, PIDFileName), 0o700))
+		got := readAndDial(root)
+		assert.Equal(t, adoptionIOErr, got.status)
+		assert.Error(t, got.err)
+	})
+
+	t.Run("legacy", func(t *testing.T) {
+		root := t.TempDir()
+		require.NoError(t, pidfile.Write(root, PIDFileName, pidfile.PidFile{Pid: os.Getpid(), Port: 3307}))
+		got := readAndDial(root)
+		assert.Equal(t, adoptionLegacy, got.status)
+		_, err := os.Stat(pidfile.Path(root, PIDFileName))
+		assert.NoError(t, err, "discovery must not mutate the pidfile")
+	})
+
+	t.Run("dead process", func(t *testing.T) {
+		root := t.TempDir()
+		helper := startHelperProcess(t)
+		pf := v2Record(t, root, pidfile.KindProxy, helper)
+		handle, err := procid.Open(pf.Pid, procid.Token(pf.Birth))
+		require.NoError(t, err)
+		require.NoError(t, handle.Kill())
+		require.NoError(t, handle.Close())
+		assertHelperExited(t, helper)
+		pf.ControlPort = 3308
+		require.NoError(t, pidfile.Write(root, PIDFileName, pf))
+		got := readAndDial(root)
+		assert.Equal(t, adoptionStaleDead, got.status)
+	})
+
+	t.Run("wrong birth", func(t *testing.T) {
+		root := t.TempDir()
+		helper := startHelperProcess(t)
+		pf := v2Record(t, root, pidfile.KindProxy, helper)
+		pf.Birth += "-wrong"
+		pf.ControlPort = 3308
+		require.NoError(t, pidfile.Write(root, PIDFileName, pf))
+		got := readAndDial(root)
+		assert.Equal(t, adoptionStaleDead, got.status)
+		assertHelperAlive(t, helper)
+	})
+}
+
+func TestReadAndDialForeignListenerWithUnrelatedLiveProcess(t *testing.T) {
+	root := t.TempDir()
+	helper := startHelperProcess(t)
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = ln.Close() })
+	go func() {
+		conn, acceptErr := ln.Accept()
+		if acceptErr == nil {
+			_ = conn.Close()
+		}
+	}()
+
+	pf := v2Record(t, root, pidfile.KindProxy, helper)
+	pf.Port = ln.Addr().(*net.TCPAddr).Port
+	pf.ControlPort = pf.Port
+	require.NoError(t, pidfile.Write(root, PIDFileName, pf))
+	_, err = identity.WriteSecret(root)
+	require.NoError(t, err)
+
+	got := readAndDial(root)
+	assert.Equal(t, adoptionIdentityMismatch, got.status)
+	assertHelperAlive(t, helper)
+}
+
+func TestReadAndDialForeignListenerWithDeadOrWrongProcessIdentity(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = ln.Close() })
+	port := ln.Addr().(*net.TCPAddr).Port
+
+	t.Run("dead pid", func(t *testing.T) {
+		root := t.TempDir()
+		helper := startHelperProcess(t)
+		pf := v2Record(t, root, pidfile.KindProxy, helper)
+		handle, openErr := procid.Open(pf.Pid, procid.Token(pf.Birth))
+		require.NoError(t, openErr)
+		require.NoError(t, handle.Kill())
+		require.NoError(t, handle.Close())
+		assertHelperExited(t, helper)
+		pf.Port = port
+		pf.ControlPort = port
+		require.NoError(t, pidfile.Write(root, PIDFileName, pf))
+		assert.Equal(t, adoptionStaleDead, readAndDial(root).status)
+	})
+
+	t.Run("wrong birth", func(t *testing.T) {
+		root := t.TempDir()
+		helper := startHelperProcess(t)
+		pf := v2Record(t, root, pidfile.KindProxy, helper)
+		pf.Birth += "-wrong"
+		pf.Port = port
+		pf.ControlPort = port
+		require.NoError(t, pidfile.Write(root, PIDFileName, pf))
+		assert.Equal(t, adoptionStaleDead, readAndDial(root).status)
+		assertHelperAlive(t, helper)
+	})
+}
+
+func TestReadAndDialRejectsAuthenticatedRootMismatch(t *testing.T) {
+	rootA := t.TempDir()
+	rootB := t.TempDir()
+	token, err := procid.Capture(os.Getpid())
+	require.NoError(t, err)
+	rootIDA, err := identity.RootID(rootA)
+	require.NoError(t, err)
+
+	dataListener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = dataListener.Close() })
+	dataPort := dataListener.Addr().(*net.TCPAddr).Port
+
+	secret, err := identity.WriteSecret(rootA)
+	require.NoError(t, err)
+	var reply identity.IdentReply
+	var replyMu sync.RWMutex
+	control, err := startControl(rootA, func() identity.IdentReply {
+		replyMu.RLock()
+		defer replyMu.RUnlock()
+		return reply
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = control.Close() })
+	replyMu.Lock()
+	reply = identity.IdentReply{
+		Schema:      pidfile.SchemaV2,
+		Role:        pidfile.KindProxy,
+		RootID:      rootIDA,
+		UpstreamID:  "upstream",
+		PID:         os.Getpid(),
+		Birth:       string(token),
+		DataPort:    dataPort,
+		ControlPort: control.Port(),
+	}
+	replyMu.Unlock()
+	pf := pidfile.PidFile{
+		Schema:      pidfile.SchemaV2,
+		Kind:        pidfile.KindProxy,
+		Pid:         os.Getpid(),
+		Birth:       string(token),
+		Port:        dataPort,
+		ControlPort: control.Port(),
+		RootID:      rootIDA,
+		UpstreamID:  "upstream",
+	}
+	require.NoError(t, pidfile.Write(rootA, PIDFileName, pf))
+	require.NoError(t, pidfile.Write(rootB, PIDFileName, pf))
+	require.NoError(t, os.WriteFile(filepath.Join(rootB, identity.SecretFileName), []byte(secret+"\n"), 0o600))
+
+	got := readAndDial(rootB)
+	assert.Equal(t, adoptionIdentityMismatch, got.status)
+}
+
+func TestLegacyRecordFailClosed(t *testing.T) {
+	t.Run("held lock returns actionable error without kill", func(t *testing.T) {
+		root := t.TempDir()
+		helper := startHelperProcess(t)
+		require.NoError(t, pidfile.Write(root, PIDFileName, pidfile.PidFile{
+			Pid:  helper.cmd.Process.Pid,
+			Port: 3307,
+		}))
+		lock, err := util.TryLock(filepath.Join(root, LockFileName))
+		require.NoError(t, err)
+		defer lock.Unlock()
+
+		_, err = GetCreateDatabaseProxyServerEndpoint(root, externalOpenOpts(root))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), filepath.Join(root, LockFileName))
+		assert.Contains(t, err.Error(), "old bd binary")
+		assertHelperAlive(t, helper)
+		_, err = os.Stat(pidfile.Path(root, PIDFileName))
+		assert.NoError(t, err)
+	})
+
+	t.Run("free lock quarantines and enters spawn path without kill", func(t *testing.T) {
+		root := t.TempDir()
+		helper := startHelperProcess(t)
+		require.NoError(t, pidfile.Write(root, PIDFileName, pidfile.PidFile{
+			Pid:  helper.cmd.Process.Pid,
+			Port: 3307,
+		}))
+		discovery := readAndDial(root)
+		require.Equal(t, adoptionLegacy, discovery.status)
+		lock, err := util.TryLock(filepath.Join(root, LockFileName))
+		require.NoError(t, err)
+
+		previous := ResolveExecutable
+		ResolveExecutable = func() (string, error) { return "", errors.New("spawn reached") }
+		t.Cleanup(func() { ResolveExecutable = previous })
+		_, err = spawnAndHandoff(root, externalOpenOpts(root), time.Now().Add(time.Second), "", lock, discovery)
+		require.ErrorContains(t, err, "spawn reached")
+
+		assertHelperAlive(t, helper)
+		assert.NoFileExists(t, pidfile.Path(root, PIDFileName))
+		assert.Len(t, quarantines(t, root, PIDFileName), 1)
+	})
+}
+
+func TestIdentityMismatchQuarantinesRecordWithoutKillingProcess(t *testing.T) {
+	root := t.TempDir()
+	helper := startHelperProcess(t)
+	pf := v2Record(t, root, pidfile.KindProxy, helper)
+	pf.ControlPort = 3308
+	require.NoError(t, pidfile.Write(root, PIDFileName, pf))
+	lock, err := util.TryLock(filepath.Join(root, LockFileName))
+	require.NoError(t, err)
+
+	previous := ResolveExecutable
+	ResolveExecutable = func() (string, error) { return "", errors.New("spawn reached") }
+	t.Cleanup(func() { ResolveExecutable = previous })
+	_, err = spawnAndHandoff(
+		root,
+		externalOpenOpts(root),
+		time.Now().Add(time.Second),
+		"",
+		lock,
+		adoptionResult{
+			status:  adoptionIdentityMismatch,
+			pidfile: &pf,
+			err:     errors.New("foreign control listener"),
+		},
+	)
+	require.ErrorContains(t, err, "spawn reached")
+	assertHelperAlive(t, helper)
+	assert.NoFileExists(t, pidfile.Path(root, PIDFileName))
+	assert.Len(t, quarantines(t, root, PIDFileName), 1)
+}
+
+func TestMalformedRecordQuarantinesBeforeSpawn(t *testing.T) {
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(pidfile.Path(root, PIDFileName), []byte(`{"pid":`), 0o600))
+	discovery := readAndDial(root)
+	require.Equal(t, adoptionMalformed, discovery.status)
+	lock, err := util.TryLock(filepath.Join(root, LockFileName))
+	require.NoError(t, err)
+
+	previous := ResolveExecutable
+	ResolveExecutable = func() (string, error) { return "", errors.New("spawn reached") }
+	t.Cleanup(func() { ResolveExecutable = previous })
+	_, err = spawnAndHandoff(root, externalOpenOpts(root), time.Now().Add(time.Second), "", lock, discovery)
+	require.ErrorContains(t, err, "spawn reached")
+	assert.NoFileExists(t, pidfile.Path(root, PIDFileName))
+	assert.Len(t, quarantines(t, root, PIDFileName), 1)
+}
+
+func TestGetCreatePropagatesPIDFileIOErrorWithoutSpawning(t *testing.T) {
+	root := t.TempDir()
+	require.NoError(t, os.Mkdir(pidfile.Path(root, PIDFileName), 0o700))
+	_, err := GetCreateDatabaseProxyServerEndpoint(root, externalOpenOpts(root))
+	require.ErrorContains(t, err, "discover proxy")
+	assert.NoFileExists(t, filepath.Join(root, spawnMarkerFileName))
+}
+
+func TestCleanupOrphanBackendRefusesHeldChildLock(t *testing.T) {
+	root := t.TempDir()
+	helper := startHelperProcess(t)
+	require.NoError(t, pidfile.Write(root, server.PIDFileName, v2Record(t, root, pidfile.KindDoltBackend, helper)))
+
+	proxyLock, err := util.TryLock(filepath.Join(root, LockFileName))
+	require.NoError(t, err)
+	defer proxyLock.Unlock()
+	childLock, err := util.TryLock(filepath.Join(root, server.LockFileName))
+	require.NoError(t, err)
+	defer childLock.Unlock()
+
+	err = cleanupOrphanBackend(root)
+	require.ErrorContains(t, err, "refusing backend cleanup")
+	assertHelperAlive(t, helper)
+	assert.FileExists(t, pidfile.Path(root, server.PIDFileName))
+	assert.Empty(t, quarantines(t, root, server.PIDFileName))
+}
+
+func TestCleanupOrphanBackendRefusesRootMismatch(t *testing.T) {
+	root := t.TempDir()
+	helper := startHelperProcess(t)
+	pf := v2Record(t, root, pidfile.KindDoltBackend, helper)
+	pf.RootID = "different-workspace"
+	require.NoError(t, pidfile.Write(root, server.PIDFileName, pf))
+
+	proxyLock, err := util.TryLock(filepath.Join(root, LockFileName))
+	require.NoError(t, err)
+	defer proxyLock.Unlock()
+	err = cleanupOrphanBackend(root)
+	require.ErrorContains(t, err, "root identity mismatch")
+	assertHelperAlive(t, helper)
+	assert.FileExists(t, pidfile.Path(root, server.PIDFileName))
+	assert.Empty(t, quarantines(t, root, server.PIDFileName))
+}
+
+func TestCleanupOrphanBackendKillsVerifiedOrphanAndQuarantines(t *testing.T) {
+	root := t.TempDir()
+	helper := startHelperProcess(t)
+	require.NoError(t, pidfile.Write(root, server.PIDFileName, v2Record(t, root, pidfile.KindDoltBackend, helper)))
+
+	proxyLock, err := util.TryLock(filepath.Join(root, LockFileName))
+	require.NoError(t, err)
+	previous := ResolveExecutable
+	ResolveExecutable = func() (string, error) { return "", errors.New("spawn reached after orphan cleanup") }
+	t.Cleanup(func() { ResolveExecutable = previous })
+	_, err = spawnAndHandoff(
+		root,
+		externalOpenOpts(root),
+		time.Now().Add(time.Second),
+		"",
+		proxyLock,
+		adoptionResult{status: adoptionNoRecord},
+	)
+	require.ErrorContains(t, err, "spawn reached after orphan cleanup")
+
+	assertHelperExited(t, helper)
+	assert.NoFileExists(t, pidfile.Path(root, server.PIDFileName))
+	assert.Len(t, quarantines(t, root, server.PIDFileName), 1)
+}
+
+func TestQuarantineNamingCollisionAndRetentionSweep(t *testing.T) {
+	root := t.TempDir()
+	now := time.Unix(2_000_000_000, 0)
+	currentPath := pidfile.Path(root, PIDFileName)
+	require.NoError(t, os.WriteFile(currentPath, []byte("first"), 0o600))
+	first, err := quarantineRecord(root, PIDFileName, now)
+	require.NoError(t, err)
+	assert.Equal(t, currentPath+".stale-2000000000", first)
+
+	require.NoError(t, os.WriteFile(currentPath, []byte("second"), 0o600))
+	second, err := quarantineRecord(root, PIDFileName, now)
+	require.NoError(t, err)
+	assert.Equal(t, currentPath+".stale-2000000001", second)
+	require.NoError(t, os.WriteFile(currentPath, []byte("current"), 0o600))
+	foreign := filepath.Join(root, "foreign.stale-1")
+	require.NoError(t, os.WriteFile(foreign, []byte("foreign"), 0o600))
+	recent := currentPath + ".stale-" + strconv.FormatInt(now.Add(2*24*time.Hour).Unix(), 10)
+	require.NoError(t, os.WriteFile(recent, []byte("recent"), 0o600))
+
+	require.NoError(t, sweepOldQuarantines(root, now.Add(31*24*time.Hour)))
+	assert.NoFileExists(t, first)
+	assert.NoFileExists(t, second)
+	assert.FileExists(t, currentPath, "current record must never be swept")
+	assert.FileExists(t, foreign, "foreign files must never be swept")
+	assert.FileExists(t, recent, "quarantines younger than 30 days must be retained")
+}
+
+func TestShutdownVerifiedRecordStopsProcess(t *testing.T) {
+	root := t.TempDir()
+	proxyHelper := startHelperProcess(t)
+	backendHelper := startHelperProcess(t)
+	require.NoError(t, pidfile.Write(root, PIDFileName, v2Record(t, root, pidfile.KindProxy, proxyHelper)))
+	require.NoError(t, pidfile.Write(root, server.PIDFileName, v2Record(t, root, pidfile.KindDoltBackend, backendHelper)))
+
+	require.NoError(t, Shutdown(root))
+	assertHelperExited(t, proxyHelper)
+	assertHelperExited(t, backendHelper)
+	assert.NoFileExists(t, pidfile.Path(root, PIDFileName))
+	assert.NoFileExists(t, pidfile.Path(root, server.PIDFileName))
+}
+
+func TestShutdownReportsPartialOutcomeAndRefusesLegacyProcess(t *testing.T) {
+	root := t.TempDir()
+	proxyHelper := startHelperProcess(t)
+	backendHelper := startHelperProcess(t)
+	require.NoError(t, pidfile.Write(root, PIDFileName, pidfile.PidFile{
+		Pid:  proxyHelper.cmd.Process.Pid,
+		Port: 3307,
+	}))
+	require.NoError(t, pidfile.Write(root, server.PIDFileName, v2Record(t, root, pidfile.KindDoltBackend, backendHelper)))
+
+	err := Shutdown(root)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "backend stopped; proxy left running")
+	assert.Contains(t, err.Error(), pidfile.Path(root, PIDFileName))
+	assertHelperAlive(t, proxyHelper)
+	assertHelperExited(t, backendHelper)
+	assert.FileExists(t, pidfile.Path(root, PIDFileName))
+	assert.Empty(t, quarantines(t, root, PIDFileName))
+}
+
+func TestShutdownRefusesBirthMismatchWithoutDeletingRecord(t *testing.T) {
+	root := t.TempDir()
+	helper := startHelperProcess(t)
+	pf := v2Record(t, root, pidfile.KindProxy, helper)
+	pf.Birth += "-wrong"
+	require.NoError(t, pidfile.Write(root, PIDFileName, pf))
+
+	err := Shutdown(root)
+	require.ErrorContains(t, err, "birth token mismatch")
+	assertHelperAlive(t, helper)
+	assert.FileExists(t, pidfile.Path(root, PIDFileName))
+	assert.Empty(t, quarantines(t, root, PIDFileName))
+}
+
+func TestShutdownQuarantinesVerifiedDeadRecord(t *testing.T) {
+	root := t.TempDir()
+	helper := startHelperProcess(t)
+	pf := v2Record(t, root, pidfile.KindProxy, helper)
+	handle, err := procid.Open(pf.Pid, procid.Token(pf.Birth))
+	require.NoError(t, err)
+	require.NoError(t, handle.Kill())
+	require.NoError(t, handle.Close())
+	assertHelperExited(t, helper)
+	require.NoError(t, pidfile.Write(root, PIDFileName, pf))
+
+	require.NoError(t, Shutdown(root))
+	assert.NoFileExists(t, pidfile.Path(root, PIDFileName))
+	assert.Len(t, quarantines(t, root, PIDFileName), 1)
+}
+
+func externalOpenOpts(root string) OpenOpts {
+	return OpenOpts{
+		Backend:     BackendExternal,
+		External:    configfile.ExternalDoltConfig{Host: "127.0.0.1", Port: 3306},
+		LogFilePath: filepath.Join(root, LogFileName),
+		Port:        3307,
+	}
+}
+
+func quarantines(t *testing.T, root, name string) []string {
+	t.Helper()
+	matches, err := filepath.Glob(filepath.Join(root, name+".stale-*"))
+	require.NoError(t, err)
+	return matches
+}

--- a/internal/storage/dbproxy/proxy/endpoint_security_test.go
+++ b/internal/storage/dbproxy/proxy/endpoint_security_test.go
@@ -4,6 +4,7 @@ package proxy
 
 import (
 	"errors"
+	"fmt"
 	"net"
 	"os"
 	"os/exec"
@@ -631,6 +632,8 @@ func TestShutdownReportsPartialOutcomeAndRefusesLegacyProcess(t *testing.T) {
 
 	err := Shutdown(root)
 	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrUnverifiableProcess)
+	assert.True(t, CanForceStopUnverified(err))
 	assert.Contains(t, err.Error(), "backend stopped; proxy left running")
 	assert.Contains(t, err.Error(), pidfile.Path(root, PIDFileName))
 	assert.Contains(t, err.Error(), "old bd binary")
@@ -639,6 +642,27 @@ func TestShutdownReportsPartialOutcomeAndRefusesLegacyProcess(t *testing.T) {
 	assertHelperExited(t, backendHelper)
 	assert.FileExists(t, pidfile.Path(root, PIDFileName))
 	assert.Empty(t, quarantines(t, root, PIDFileName))
+}
+
+func TestCanForceStopUnverifiedRequiresProxyOnlyRefusal(t *testing.T) {
+	unverifiable := fmt.Errorf("%w: legacy record", ErrUnverifiableProcess)
+	other := errors.New("unrelated shutdown failure")
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "proxy only", err: &shutdownError{proxyErr: unverifiable}, want: true},
+		{name: "backend only", err: &shutdownError{backendErr: unverifiable}},
+		{name: "both", err: &shutdownError{proxyErr: unverifiable, backendErr: other}},
+		{name: "unrelated proxy error", err: &shutdownError{proxyErr: other}},
+		{name: "bare sentinel", err: unverifiable},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, CanForceStopUnverified(tc.err))
+		})
+	}
 }
 
 func TestShutdownQuarantinesBirthMismatchWithoutKillingProcess(t *testing.T) {

--- a/internal/storage/dbproxy/proxy/endpoint_security_test.go
+++ b/internal/storage/dbproxy/proxy/endpoint_security_test.go
@@ -330,6 +330,60 @@ func TestReadAndDialRejectsAuthenticatedRootMismatch(t *testing.T) {
 	assert.Equal(t, adoptionIdentityMismatch, got.status)
 }
 
+// The handshake accepts schema v2 or newer, matching pidfile.ValidateV2's
+// forward-compat policy for records: a newer proxy that still answers the v2
+// handshake remains adoptable.
+func TestReadAndDialAcceptsNewerSchemaHandshake(t *testing.T) {
+	root := t.TempDir()
+	token, err := procid.Capture(os.Getpid())
+	require.NoError(t, err)
+	rootID, err := identity.RootID(root)
+	require.NoError(t, err)
+
+	dataListener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = dataListener.Close() })
+	dataPort := dataListener.Addr().(*net.TCPAddr).Port
+
+	_, err = identity.WriteSecret(root)
+	require.NoError(t, err)
+	var reply identity.IdentReply
+	var replyMu sync.RWMutex
+	control, err := startControl(root, func() identity.IdentReply {
+		replyMu.RLock()
+		defer replyMu.RUnlock()
+		return reply
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = control.Close() })
+	replyMu.Lock()
+	reply = identity.IdentReply{
+		Schema:      pidfile.SchemaV2 + 1,
+		Role:        pidfile.KindProxy,
+		RootID:      rootID,
+		UpstreamID:  "upstream",
+		PID:         os.Getpid(),
+		Birth:       string(token),
+		DataPort:    dataPort,
+		ControlPort: control.Port(),
+	}
+	replyMu.Unlock()
+	require.NoError(t, pidfile.Write(root, PIDFileName, pidfile.PidFile{
+		Schema:      pidfile.SchemaV2 + 1,
+		Kind:        pidfile.KindProxy,
+		Pid:         os.Getpid(),
+		Birth:       string(token),
+		Port:        dataPort,
+		ControlPort: control.Port(),
+		RootID:      rootID,
+		UpstreamID:  "upstream",
+	}))
+
+	got := readAndDial(root)
+	assert.Equal(t, adoptionAdopted, got.status)
+	assert.Equal(t, dataPort, got.endpoint.Port)
+}
+
 func TestLegacyRecordFailClosed(t *testing.T) {
 	t.Run("held lock returns actionable error without kill", func(t *testing.T) {
 		root := t.TempDir()
@@ -644,7 +698,7 @@ func TestShutdownReportsPartialOutcomeAndRefusesLegacyProcess(t *testing.T) {
 	assert.Empty(t, quarantines(t, root, PIDFileName))
 }
 
-func TestCanForceStopUnverifiedRequiresProxyOnlyRefusal(t *testing.T) {
+func TestCanForceStopUnverifiedRequiresUnverifiableRefusals(t *testing.T) {
 	unverifiable := fmt.Errorf("%w: legacy record", ErrUnverifiableProcess)
 	other := errors.New("unrelated shutdown failure")
 	tests := []struct {
@@ -653,8 +707,9 @@ func TestCanForceStopUnverifiedRequiresProxyOnlyRefusal(t *testing.T) {
 		want bool
 	}{
 		{name: "proxy only", err: &shutdownError{proxyErr: unverifiable}, want: true},
-		{name: "backend only", err: &shutdownError{backendErr: unverifiable}},
-		{name: "both", err: &shutdownError{proxyErr: unverifiable, backendErr: other}},
+		{name: "backend only", err: &shutdownError{backendErr: unverifiable}, want: true},
+		{name: "paired legacy", err: &shutdownError{proxyErr: unverifiable, backendErr: unverifiable}, want: true},
+		{name: "unverifiable proxy with unrelated backend error", err: &shutdownError{proxyErr: unverifiable, backendErr: other}},
 		{name: "unrelated proxy error", err: &shutdownError{proxyErr: other}},
 		{name: "bare sentinel", err: unverifiable},
 	}

--- a/internal/storage/dbproxy/proxy/endpoint_security_test.go
+++ b/internal/storage/dbproxy/proxy/endpoint_security_test.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package proxy
 
 import (
@@ -163,6 +165,54 @@ func TestReadAndDialClassifiesRecordsWithoutMutation(t *testing.T) {
 		assert.Equal(t, adoptionStaleDead, got.status)
 		assertHelperAlive(t, helper)
 	})
+}
+
+func TestReadAndDialProbeErrorsAreNonFatalDiscovery(t *testing.T) {
+	root := t.TempDir()
+	helper := startHelperProcess(t)
+	pf := v2Record(t, root, pidfile.KindProxy, helper)
+	pf.ControlPort = 3308
+	require.NoError(t, pidfile.Write(root, PIDFileName, pf))
+
+	originalVerify := verifyProcessIdentity
+	originalRootID := resolveRootIdentity
+	originalSecret := readControlSecret
+	t.Cleanup(func() {
+		verifyProcessIdentity = originalVerify
+		resolveRootIdentity = originalRootID
+		readControlSecret = originalSecret
+	})
+
+	t.Run("process verification", func(t *testing.T) {
+		verifyProcessIdentity = func(int, procid.Token) (bool, error) {
+			return false, errors.New("access denied")
+		}
+		got := readAndDial(root)
+		assert.Equal(t, adoptionUnverifiable, got.status)
+		assert.NotEqual(t, adoptionIOErr, got.status)
+		verifyProcessIdentity = originalVerify
+	})
+
+	t.Run("root identity", func(t *testing.T) {
+		resolveRootIdentity = func(string) (string, error) {
+			return "", errors.New("root resolution failed")
+		}
+		got := readAndDial(root)
+		assert.Equal(t, adoptionUnverifiable, got.status)
+		assert.NotEqual(t, adoptionIOErr, got.status)
+		resolveRootIdentity = originalRootID
+	})
+
+	t.Run("secret read", func(t *testing.T) {
+		readControlSecret = func(string) (string, error) {
+			return "", errors.New("secret read failed")
+		}
+		got := readAndDial(root)
+		assert.Equal(t, adoptionUnverifiable, got.status)
+		assert.NotEqual(t, adoptionIOErr, got.status)
+		readControlSecret = originalSecret
+	})
+	assertHelperAlive(t, helper)
 }
 
 func TestReadAndDialForeignListenerWithUnrelatedLiveProcess(t *testing.T) {
@@ -354,6 +404,36 @@ func TestIdentityMismatchQuarantinesRecordWithoutKillingProcess(t *testing.T) {
 	assert.Len(t, quarantines(t, root, PIDFileName), 1)
 }
 
+func TestUnverifiableDiscoveryQuarantinesUnderLockWithoutKillingProcess(t *testing.T) {
+	root := t.TempDir()
+	helper := startHelperProcess(t)
+	pf := v2Record(t, root, pidfile.KindProxy, helper)
+	pf.ControlPort = 3308
+	require.NoError(t, pidfile.Write(root, PIDFileName, pf))
+	lock, err := util.TryLock(filepath.Join(root, LockFileName))
+	require.NoError(t, err)
+
+	previous := ResolveExecutable
+	ResolveExecutable = func() (string, error) { return "", errors.New("spawn reached") }
+	t.Cleanup(func() { ResolveExecutable = previous })
+	_, err = spawnAndHandoff(
+		root,
+		externalOpenOpts(root),
+		time.Now().Add(time.Second),
+		"",
+		lock,
+		adoptionResult{
+			status:  adoptionUnverifiable,
+			pidfile: &pf,
+			err:     errors.New("identity probe denied"),
+		},
+	)
+	require.ErrorContains(t, err, "spawn reached")
+	assertHelperAlive(t, helper)
+	assert.NoFileExists(t, pidfile.Path(root, PIDFileName))
+	assert.Len(t, quarantines(t, root, PIDFileName), 1)
+}
+
 func TestMalformedRecordQuarantinesBeforeSpawn(t *testing.T) {
 	root := t.TempDir()
 	require.NoError(t, os.WriteFile(pidfile.Path(root, PIDFileName), []byte(`{"pid":`), 0o600))
@@ -413,6 +493,64 @@ func TestCleanupOrphanBackendRefusesRootMismatch(t *testing.T) {
 	assertHelperAlive(t, helper)
 	assert.FileExists(t, pidfile.Path(root, server.PIDFileName))
 	assert.Empty(t, quarantines(t, root, server.PIDFileName))
+}
+
+func TestCleanupOrphanBackendLegacyRecords(t *testing.T) {
+	t.Run("dead pid quarantines", func(t *testing.T) {
+		root := t.TempDir()
+		helper := startHelperProcess(t)
+		handle, err := procid.Open(helper.cmd.Process.Pid, helper.token)
+		require.NoError(t, err)
+		require.NoError(t, handle.Kill())
+		require.NoError(t, handle.Close())
+		assertHelperExited(t, helper)
+		require.NoError(t, pidfile.Write(root, server.PIDFileName, pidfile.PidFile{
+			Pid:  helper.cmd.Process.Pid,
+			Port: 3306,
+		}))
+
+		proxyLock, err := util.TryLock(filepath.Join(root, LockFileName))
+		require.NoError(t, err)
+		defer proxyLock.Unlock()
+		require.NoError(t, cleanupOrphanBackend(root))
+		assert.NoFileExists(t, pidfile.Path(root, server.PIDFileName))
+		assert.Len(t, quarantines(t, root, server.PIDFileName), 1)
+	})
+
+	t.Run("live pid refuses", func(t *testing.T) {
+		root := t.TempDir()
+		helper := startHelperProcess(t)
+		require.NoError(t, pidfile.Write(root, server.PIDFileName, pidfile.PidFile{
+			Pid:  helper.cmd.Process.Pid,
+			Port: 3306,
+		}))
+
+		proxyLock, err := util.TryLock(filepath.Join(root, LockFileName))
+		require.NoError(t, err)
+		defer proxyLock.Unlock()
+		err = cleanupOrphanBackend(root)
+		require.ErrorContains(t, err, "unverifiable live process")
+		require.ErrorContains(t, err, pidfile.Path(root, server.PIDFileName)+".stale-<unix-timestamp>")
+		assertHelperAlive(t, helper)
+		assert.FileExists(t, pidfile.Path(root, server.PIDFileName))
+		assert.Empty(t, quarantines(t, root, server.PIDFileName))
+	})
+}
+
+func TestCleanupOrphanBackendBirthMismatchIsDeadRecord(t *testing.T) {
+	root := t.TempDir()
+	helper := startHelperProcess(t)
+	pf := v2Record(t, root, pidfile.KindDoltBackend, helper)
+	pf.Birth += "-recycled"
+	require.NoError(t, pidfile.Write(root, server.PIDFileName, pf))
+
+	proxyLock, err := util.TryLock(filepath.Join(root, LockFileName))
+	require.NoError(t, err)
+	defer proxyLock.Unlock()
+	require.NoError(t, cleanupOrphanBackend(root))
+	assertHelperAlive(t, helper)
+	assert.NoFileExists(t, pidfile.Path(root, server.PIDFileName))
+	assert.Len(t, quarantines(t, root, server.PIDFileName), 1)
 }
 
 func TestCleanupOrphanBackendKillsVerifiedOrphanAndQuarantines(t *testing.T) {
@@ -495,21 +633,37 @@ func TestShutdownReportsPartialOutcomeAndRefusesLegacyProcess(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "backend stopped; proxy left running")
 	assert.Contains(t, err.Error(), pidfile.Path(root, PIDFileName))
+	assert.Contains(t, err.Error(), "old bd binary")
+	assert.Contains(t, err.Error(), pidfile.Path(root, PIDFileName)+".stale-<unix-timestamp>")
 	assertHelperAlive(t, proxyHelper)
 	assertHelperExited(t, backendHelper)
 	assert.FileExists(t, pidfile.Path(root, PIDFileName))
 	assert.Empty(t, quarantines(t, root, PIDFileName))
 }
 
-func TestShutdownRefusesBirthMismatchWithoutDeletingRecord(t *testing.T) {
+func TestShutdownQuarantinesBirthMismatchWithoutKillingProcess(t *testing.T) {
 	root := t.TempDir()
 	helper := startHelperProcess(t)
 	pf := v2Record(t, root, pidfile.KindProxy, helper)
 	pf.Birth += "-wrong"
 	require.NoError(t, pidfile.Write(root, PIDFileName, pf))
 
+	require.NoError(t, Shutdown(root))
+	assertHelperAlive(t, helper)
+	assert.NoFileExists(t, pidfile.Path(root, PIDFileName))
+	assert.Len(t, quarantines(t, root, PIDFileName), 1)
+}
+
+func TestShutdownRefusesForeignRootProxyRecord(t *testing.T) {
+	root := t.TempDir()
+	helper := startHelperProcess(t)
+	pf := v2Record(t, root, pidfile.KindProxy, helper)
+	pf.RootID = "foreign-workspace-root"
+	require.NoError(t, pidfile.Write(root, PIDFileName, pf))
+
 	err := Shutdown(root)
-	require.ErrorContains(t, err, "birth token mismatch")
+	require.ErrorContains(t, err, "root identity mismatch")
+	require.ErrorContains(t, err, pidfile.Path(root, PIDFileName))
 	assertHelperAlive(t, helper)
 	assert.FileExists(t, pidfile.Path(root, PIDFileName))
 	assert.Empty(t, quarantines(t, root, PIDFileName))
@@ -530,6 +684,71 @@ func TestShutdownQuarantinesVerifiedDeadRecord(t *testing.T) {
 	assert.NoFileExists(t, pidfile.Path(root, PIDFileName))
 	assert.Len(t, quarantines(t, root, PIDFileName), 1)
 }
+
+func TestShutdownQuarantinesDeadLegacyAndMalformedRecords(t *testing.T) {
+	tests := []struct {
+		name   string
+		record func(helper helperProcess) pidfile.PidFile
+	}{
+		{
+			name: "legacy",
+			record: func(helper helperProcess) pidfile.PidFile {
+				return pidfile.PidFile{Pid: helper.cmd.Process.Pid, Port: 3307}
+			},
+		},
+		{
+			name: "malformed v2",
+			record: func(helper helperProcess) pidfile.PidFile {
+				return pidfile.PidFile{
+					Schema: pidfile.SchemaV2,
+					Kind:   pidfile.KindProxy,
+					Pid:    helper.cmd.Process.Pid,
+					Port:   3307,
+				}
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			helper := startHelperProcess(t)
+			record := tc.record(helper)
+			handle, err := procid.Open(helper.cmd.Process.Pid, helper.token)
+			require.NoError(t, err)
+			require.NoError(t, handle.Kill())
+			require.NoError(t, handle.Close())
+			assertHelperExited(t, helper)
+			require.NoError(t, pidfile.Write(root, PIDFileName, record))
+
+			require.NoError(t, Shutdown(root))
+			assert.NoFileExists(t, pidfile.Path(root, PIDFileName))
+			assert.Len(t, quarantines(t, root, PIDFileName), 1)
+		})
+	}
+}
+
+func TestControlFilePathsIncludesSecretAndQuarantines(t *testing.T) {
+	root := t.TempDir()
+	proxyStale := pidfile.Path(root, PIDFileName) + ".stale-100"
+	backendStale := pidfile.Path(root, server.PIDFileName) + ".stale-200"
+	require.NoError(t, os.WriteFile(proxyStale, []byte("proxy"), 0o600))
+	require.NoError(t, os.WriteFile(backendStale, []byte("backend"), 0o600))
+	_, err := identity.WriteSecret(root)
+	require.NoError(t, err)
+
+	paths := ControlFilePaths(root)
+	assert.Contains(t, paths, filepath.Join(root, identity.SecretFileName))
+	assert.Contains(t, paths, proxyStale)
+	assert.Contains(t, paths, backendStale)
+
+	assert.Empty(t, PurgeControlFiles(root))
+	assert.NoFileExists(t, filepath.Join(root, identity.SecretFileName))
+	assert.NoFileExists(t, proxyStale)
+	assert.NoFileExists(t, backendStale)
+}
+
+// N-process cold-start convergence remains intentionally deferred to the
+// lifecycle-lane stage; this security suite covers single-spawner invariants.
 
 func externalOpenOpts(root string) OpenOpts {
 	return OpenOpts{

--- a/internal/storage/dbproxy/proxy/endpoint_spawn_stop_unix_test.go
+++ b/internal/storage/dbproxy/proxy/endpoint_spawn_stop_unix_test.go
@@ -1,0 +1,76 @@
+//go:build unix
+
+package proxy
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestShutdownWaitsForStartDelayedBeforeExec(t *testing.T) {
+	root := t.TempDir()
+	childPath := filepath.Join(root, "exit-child.sh")
+	require.NoError(t, os.WriteFile(childPath, []byte("#!/bin/sh\nexit 0\n"), 0o700))
+
+	previousResolve := ResolveExecutable
+	previousHook := beforeProxyChildStart
+	ResolveExecutable = func() (string, error) { return childPath, nil }
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	var once sync.Once
+	beforeProxyChildStart = func() {
+		once.Do(func() {
+			close(entered)
+			<-release
+		})
+	}
+	t.Cleanup(func() {
+		ResolveExecutable = previousResolve
+		beforeProxyChildStart = previousHook
+	})
+
+	startDone := make(chan error, 1)
+	go func() {
+		_, err := GetCreateDatabaseProxyServerEndpoint(root, externalOpenOpts(root))
+		startDone <- err
+	}()
+	select {
+	case <-entered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("start did not reach injected pre-exec delay")
+	}
+
+	stopDone := make(chan error, 1)
+	go func() { stopDone <- Shutdown(root) }()
+	select {
+	case err := <-stopDone:
+		t.Fatalf("Shutdown returned during delayed start: %v", err)
+	case <-time.After(150 * time.Millisecond):
+		// The injected hook, rather than scheduler timing, holds the exact
+		// historical release-lock-before-Start window open.
+	}
+
+	close(release)
+	select {
+	case err := <-startDone:
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, errStartInterrupted), "start error = %v", err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("start did not terminate after concurrent shutdown")
+	}
+	select {
+	case err := <-stopDone:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("Shutdown did not finish after delayed start resolved")
+	}
+
+	assert.NoFileExists(t, filepath.Join(root, spawnMarkerFileName))
+}

--- a/internal/storage/dbproxy/proxy/force_stop.go
+++ b/internal/storage/dbproxy/proxy/force_stop.go
@@ -32,8 +32,9 @@ type ForceStopReport struct {
 	QuarantinedPath string
 }
 
-// ForceStopUnverified is the narrow recovery primitive intended for future
-// wiring to `bd dolt stop --force`. It is not exposed by a CLI in this stage.
+// ForceStopUnverified is the narrow recovery primitive used by
+// `bd dolt stop --force` after an ordinary verified Shutdown refuses an
+// unverifiable proxy record.
 //
 // When proxy.lock is free, the function holds it while inspecting, signaling,
 // and quarantining the unchanged record. When proxy.lock is held (the usual

--- a/internal/storage/dbproxy/proxy/force_stop.go
+++ b/internal/storage/dbproxy/proxy/force_stop.go
@@ -3,7 +3,6 @@ package proxy
 import (
 	"errors"
 	"fmt"
-	"os"
 	"path/filepath"
 	"strings"
 	"time"
@@ -11,6 +10,7 @@ import (
 	"github.com/steveyegge/beads/internal/lockfile"
 	"github.com/steveyegge/beads/internal/storage/dbproxy/identity"
 	"github.com/steveyegge/beads/internal/storage/dbproxy/pidfile"
+	"github.com/steveyegge/beads/internal/storage/dbproxy/server"
 	"github.com/steveyegge/beads/internal/storage/dbproxy/util"
 )
 
@@ -20,7 +20,9 @@ type ForceStopOptions struct {
 }
 
 // ForceStopReport truthfully describes which irreversible force-stop actions
-// completed, including partial progress returned alongside an error.
+// completed, including partial progress returned alongside an error. The
+// top-level fields describe the proxy record; Backend, when non-nil, carries
+// the same fields for the backend (proxy-child) record.
 type ForceStopReport struct {
 	RecordPath      string
 	PID             int
@@ -30,19 +32,26 @@ type ForceStopReport struct {
 	ProcessWasGone  bool
 	SignalSent      bool
 	QuarantinedPath string
+	Backend         *ForceStopReport
 }
 
 // ForceStopUnverified is the narrow recovery primitive used by
 // `bd dolt stop --force` after an ordinary verified Shutdown refuses an
-// unverifiable proxy record.
+// unverifiable proxy or backend record. It applies the same procedure to the
+// proxy record (proxy.pid) and the backend record (proxy-child.pid): a
+// pre-v2 managed-local deployment leaves BOTH as legacy records, so covering
+// only the proxy record would lock the advertised recovery out of the real
+// upgrade topology.
 //
-// When proxy.lock is free, the function holds it while inspecting, signaling,
-// and quarantining the unchanged record. When proxy.lock is held (the usual
-// pre-upgrade-proxy case), it first verifies the live PID's executable basename,
-// signals it, waits for the lock to become free, then quarantines only if the
-// record is unchanged. Both flows accept an already-gone recorded process.
-// An unverified live PID is never signaled unless its executable basename is
-// exactly bd or dolt (with an optional .exe suffix).
+// For each record: when its lock is free, the function holds it while
+// inspecting, signaling, and quarantining the unchanged record. When the lock
+// is held (the usual pre-upgrade-proxy case), it first inspects and signals
+// the live PID, waits for the lock to become free, then quarantines only if
+// the record is unchanged. Both flows accept an already-gone recorded
+// process. An unverified live PID is never signaled unless its executable
+// basename is exactly bd or dolt (with an optional .exe suffix) AND its
+// command line scopes it to this workspace; where the platform cannot
+// establish that scope, force-stop refuses rather than guessing.
 func ForceStopUnverified(rootDir string, opts ...ForceStopOptions) (ForceStopReport, error) {
 	report := ForceStopReport{RecordPath: pidfile.Path(rootDir, PIDFileName)}
 	if len(opts) > 1 {
@@ -59,63 +68,86 @@ func ForceStopUnverified(rootDir string, opts ...ForceStopOptions) (ForceStopRep
 		return report, fmt.Errorf("proxy.ForceStopUnverified: publish stop epoch: %w", err)
 	}
 
+	proxyErr := forceStopRecord(rootDir, LockFileName, PIDFileName, pidfile.KindProxy, timeout, &report)
+
+	backendReport := ForceStopReport{RecordPath: pidfile.Path(rootDir, server.PIDFileName)}
+	backendErr := forceStopRecord(
+		rootDir,
+		server.LockFileName,
+		server.PIDFileName,
+		pidfile.KindDoltBackend,
+		timeout,
+		&backendReport,
+	)
+	if backendReport.RecordFound || backendErr != nil {
+		report.Backend = &backendReport
+	}
+	return report, errors.Join(proxyErr, backendErr)
+}
+
+// forceStopRecord runs the inspect-signal-quarantine procedure for one
+// process record, writing partial progress into report as it goes.
+func forceStopRecord(
+	rootDir string,
+	lockName string,
+	pidName string,
+	wantKind string,
+	timeout time.Duration,
+	report *ForceStopReport,
+) error {
 	deadline := time.Now().Add(timeout)
-	lockPath := filepath.Join(rootDir, LockFileName)
+	lockPath := filepath.Join(rootDir, lockName)
 	lock, err := util.TryLock(lockPath)
 	if err == nil {
 		defer lock.Unlock()
-		return forceStopUnverifiedLocked(rootDir, deadline, report)
+		return forceStopRecordLocked(rootDir, pidName, wantKind, deadline, report)
 	}
 	if !lockfile.IsLocked(err) {
-		return report, fmt.Errorf("proxy.ForceStopUnverified: probe %s: %w", lockPath, err)
+		return fmt.Errorf("proxy.ForceStopUnverified: probe %s: %w", lockPath, err)
 	}
 	report.LockWasHeld = true
 
-	record, err := readForceStopRecord(rootDir, &report)
+	record, err := readForceStopRecord(rootDir, pidName, report)
 	if err != nil || record == nil {
-		return report, err
+		return err
 	}
-	if err := requireUnverifiableProxyRecord(rootDir, record); err != nil {
-		return report, err
+	if err := requireUnverifiableRecord(rootDir, record, wantKind); err != nil {
+		return err
 	}
-	if err := inspectAndStopUnverifiedPID(record.Pid, deadline, &report); err != nil {
-		return report, err
+	if err := inspectAndStopUnverifiedPID(rootDir, record.Pid, deadline, report); err != nil {
+		return err
 	}
 
 	lock, err = acquireForceStopLock(lockPath, deadline)
 	if err != nil {
-		return report, err
+		return err
 	}
 	defer lock.Unlock()
-	if err := quarantineForceStopRecord(rootDir, record, &report); err != nil {
-		return report, err
-	}
-	return report, nil
+	return quarantineForceStopRecord(rootDir, pidName, record, report)
 }
 
-func forceStopUnverifiedLocked(
+func forceStopRecordLocked(
 	rootDir string,
+	pidName string,
+	wantKind string,
 	deadline time.Time,
-	report ForceStopReport,
-) (ForceStopReport, error) {
-	record, err := readForceStopRecord(rootDir, &report)
+	report *ForceStopReport,
+) error {
+	record, err := readForceStopRecord(rootDir, pidName, report)
 	if err != nil || record == nil {
-		return report, err
+		return err
 	}
-	if err := requireUnverifiableProxyRecord(rootDir, record); err != nil {
-		return report, err
+	if err := requireUnverifiableRecord(rootDir, record, wantKind); err != nil {
+		return err
 	}
-	if err := inspectAndStopUnverifiedPID(record.Pid, deadline, &report); err != nil {
-		return report, err
+	if err := inspectAndStopUnverifiedPID(rootDir, record.Pid, deadline, report); err != nil {
+		return err
 	}
-	if err := quarantineForceStopRecord(rootDir, record, &report); err != nil {
-		return report, err
-	}
-	return report, nil
+	return quarantineForceStopRecord(rootDir, pidName, record, report)
 }
 
-func readForceStopRecord(rootDir string, report *ForceStopReport) (*pidfile.PidFile, error) {
-	record, err := pidfile.Read(rootDir, PIDFileName)
+func readForceStopRecord(rootDir, pidName string, report *ForceStopReport) (*pidfile.PidFile, error) {
+	record, err := pidfile.Read(rootDir, pidName)
 	if err != nil {
 		if isMalformedPIDFileError(err) {
 			return nil, unverifiableProcessError(
@@ -136,12 +168,17 @@ func readForceStopRecord(rootDir string, report *ForceStopReport) (*pidfile.PidF
 	return record, nil
 }
 
-func requireUnverifiableProxyRecord(rootDir string, record *pidfile.PidFile) error {
-	if err := record.ValidateV2(pidfile.KindProxy); err != nil {
+func requireUnverifiableRecord(rootDir string, record *pidfile.PidFile, wantKind string) error {
+	if err := record.ValidateV2(wantKind); err != nil {
 		return nil
 	}
 	rootID, err := identity.RootID(rootDir)
-	if err == nil && record.RootID == rootID {
+	if err != nil {
+		// Failing open here would route a possibly-verifiable record into the
+		// destructive force path; surface the identity failure instead.
+		return fmt.Errorf("proxy.ForceStopUnverified: resolve workspace identity: %w", err)
+	}
+	if record.RootID == rootID {
 		return errors.New(
 			"proxy.ForceStopUnverified: record has a verifiable v2 workspace identity; use proxy.Shutdown",
 		)
@@ -149,11 +186,24 @@ func requireUnverifiableProxyRecord(rootDir string, record *pidfile.PidFile) err
 	return nil
 }
 
-func inspectAndStopUnverifiedPID(pid int, deadline time.Time, report *ForceStopReport) error {
+func inspectAndStopUnverifiedPID(rootDir string, pid int, deadline time.Time, report *ForceStopReport) error {
 	if pid <= 0 {
 		return fmt.Errorf("proxy.ForceStopUnverified: record %s has invalid pid %d", report.RecordPath, pid)
 	}
-	executable, gone, err := processExecutableBasename(pid)
+	// One stable handle covers inspection and signaling, so the PID cannot be
+	// recycled between the executable check and the kill on platforms with a
+	// pinning primitive (Linux pidfd, Windows process handle).
+	proc, gone, err := openUnverifiedProcess(pid)
+	if err != nil {
+		return fmt.Errorf("proxy.ForceStopUnverified: open pid %d: %w", pid, err)
+	}
+	if gone {
+		report.ProcessWasGone = true
+		return nil
+	}
+	defer proc.close()
+
+	executable, gone, err := proc.executableBasename()
 	if err != nil {
 		return fmt.Errorf("proxy.ForceStopUnverified: inspect executable for pid %d: %w", pid, err)
 	}
@@ -172,26 +222,52 @@ func inspectAndStopUnverifiedPID(pid int, deadline time.Time, report *ForceStopR
 		)
 	}
 
-	process, err := os.FindProcess(pid)
+	// Basename alone would let a recycled PID now running an unrelated bd or
+	// dolt be killed; require the command line to tie the process to THIS
+	// workspace, and refuse when that scope cannot be established.
+	scoped, gone, err := proc.commandLineContains(rootDir)
 	if err != nil {
-		return fmt.Errorf("proxy.ForceStopUnverified: find pid %d: %w", pid, err)
+		return fmt.Errorf(
+			"proxy.ForceStopUnverified: refusing to signal pid %d from %s: workspace scope could not be established (%v); stop the process manually, then quarantine the record by renaming %s to %s.stale-<unix-timestamp> before retrying",
+			pid,
+			report.RecordPath,
+			err,
+			report.RecordPath,
+			report.RecordPath,
+		)
 	}
-	if err := process.Kill(); err != nil {
-		current, nowGone, inspectErr := processExecutableBasename(pid)
-		if inspectErr == nil && (nowGone || normalizeForceStopExecutable(current) != executable) {
-			report.ProcessWasGone = true
-			return nil
-		}
+	if gone {
+		report.ProcessWasGone = true
+		return nil
+	}
+	if !scoped {
+		return fmt.Errorf(
+			"proxy.ForceStopUnverified: refusing to signal pid %d from %s: its command line does not reference workspace %s, so it may be an unrelated %s process; stop it manually if it is yours, then quarantine the record by renaming %s to %s.stale-<unix-timestamp> before retrying",
+			pid,
+			report.RecordPath,
+			rootDir,
+			executable,
+			report.RecordPath,
+			report.RecordPath,
+		)
+	}
+
+	gone, err = proc.kill()
+	if err != nil {
 		return fmt.Errorf("proxy.ForceStopUnverified: signal pid %d: %w", pid, err)
+	}
+	if gone {
+		report.ProcessWasGone = true
+		return nil
 	}
 	report.SignalSent = true
 
 	for {
-		current, nowGone, inspectErr := processExecutableBasename(pid)
-		if inspectErr != nil {
-			return fmt.Errorf("proxy.ForceStopUnverified: confirm pid %d exit: %w", pid, inspectErr)
+		exited, err := proc.exited()
+		if err != nil {
+			return fmt.Errorf("proxy.ForceStopUnverified: confirm pid %d exit: %w", pid, err)
 		}
-		if nowGone || normalizeForceStopExecutable(current) != executable {
+		if exited {
 			return nil
 		}
 		if time.Now().After(deadline) {
@@ -226,10 +302,11 @@ func acquireForceStopLock(lockPath string, deadline time.Time) (*util.Lock, erro
 
 func quarantineForceStopRecord(
 	rootDir string,
+	pidName string,
 	record *pidfile.PidFile,
 	report *ForceStopReport,
 ) error {
-	current, err := pidfile.Read(rootDir, PIDFileName)
+	current, err := pidfile.Read(rootDir, pidName)
 	if err != nil {
 		return fmt.Errorf("proxy.ForceStopUnverified: re-read %s: %w", report.RecordPath, err)
 	}
@@ -243,7 +320,7 @@ func quarantineForceStopRecord(
 			record.Pid,
 		)
 	}
-	target, err := quarantineRecord(rootDir, PIDFileName, time.Now())
+	target, err := quarantineRecord(rootDir, pidName, time.Now())
 	if err != nil {
 		return fmt.Errorf("proxy.ForceStopUnverified: quarantine %s: %w", report.RecordPath, err)
 	}

--- a/internal/storage/dbproxy/proxy/force_stop.go
+++ b/internal/storage/dbproxy/proxy/force_stop.go
@@ -1,0 +1,251 @@
+package proxy
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/steveyegge/beads/internal/lockfile"
+	"github.com/steveyegge/beads/internal/storage/dbproxy/identity"
+	"github.com/steveyegge/beads/internal/storage/dbproxy/pidfile"
+	"github.com/steveyegge/beads/internal/storage/dbproxy/util"
+)
+
+// ForceStopOptions configures ForceStopUnverified.
+type ForceStopOptions struct {
+	Timeout time.Duration
+}
+
+// ForceStopReport truthfully describes which irreversible force-stop actions
+// completed, including partial progress returned alongside an error.
+type ForceStopReport struct {
+	RecordPath      string
+	PID             int
+	Executable      string
+	RecordFound     bool
+	LockWasHeld     bool
+	ProcessWasGone  bool
+	SignalSent      bool
+	QuarantinedPath string
+}
+
+// ForceStopUnverified is the narrow recovery primitive intended for future
+// wiring to `bd dolt stop --force`. It is not exposed by a CLI in this stage.
+//
+// When proxy.lock is free, the function holds it while inspecting, signaling,
+// and quarantining the unchanged record. When proxy.lock is held (the usual
+// pre-upgrade-proxy case), it first verifies the live PID's executable basename,
+// signals it, waits for the lock to become free, then quarantines only if the
+// record is unchanged. Both flows accept an already-gone recorded process.
+// An unverified live PID is never signaled unless its executable basename is
+// exactly bd or dolt (with an optional .exe suffix).
+func ForceStopUnverified(rootDir string, opts ...ForceStopOptions) (ForceStopReport, error) {
+	report := ForceStopReport{RecordPath: pidfile.Path(rootDir, PIDFileName)}
+	if len(opts) > 1 {
+		return report, errors.New("proxy.ForceStopUnverified: at most one options value is allowed")
+	}
+	timeout := shutdownConfirmDeadline
+	if len(opts) == 1 && opts[0].Timeout != 0 {
+		timeout = opts[0].Timeout
+	}
+	if timeout <= 0 {
+		return report, fmt.Errorf("proxy.ForceStopUnverified: timeout must be positive, got %s", timeout)
+	}
+	if err := advanceStopEpoch(rootDir); err != nil {
+		return report, fmt.Errorf("proxy.ForceStopUnverified: publish stop epoch: %w", err)
+	}
+
+	deadline := time.Now().Add(timeout)
+	lockPath := filepath.Join(rootDir, LockFileName)
+	lock, err := util.TryLock(lockPath)
+	if err == nil {
+		defer lock.Unlock()
+		return forceStopUnverifiedLocked(rootDir, deadline, report)
+	}
+	if !lockfile.IsLocked(err) {
+		return report, fmt.Errorf("proxy.ForceStopUnverified: probe %s: %w", lockPath, err)
+	}
+	report.LockWasHeld = true
+
+	record, err := readForceStopRecord(rootDir, &report)
+	if err != nil || record == nil {
+		return report, err
+	}
+	if err := requireUnverifiableProxyRecord(rootDir, record); err != nil {
+		return report, err
+	}
+	if err := inspectAndStopUnverifiedPID(record.Pid, deadline, &report); err != nil {
+		return report, err
+	}
+
+	lock, err = acquireForceStopLock(lockPath, deadline)
+	if err != nil {
+		return report, err
+	}
+	defer lock.Unlock()
+	if err := quarantineForceStopRecord(rootDir, record, &report); err != nil {
+		return report, err
+	}
+	return report, nil
+}
+
+func forceStopUnverifiedLocked(
+	rootDir string,
+	deadline time.Time,
+	report ForceStopReport,
+) (ForceStopReport, error) {
+	record, err := readForceStopRecord(rootDir, &report)
+	if err != nil || record == nil {
+		return report, err
+	}
+	if err := requireUnverifiableProxyRecord(rootDir, record); err != nil {
+		return report, err
+	}
+	if err := inspectAndStopUnverifiedPID(record.Pid, deadline, &report); err != nil {
+		return report, err
+	}
+	if err := quarantineForceStopRecord(rootDir, record, &report); err != nil {
+		return report, err
+	}
+	return report, nil
+}
+
+func readForceStopRecord(rootDir string, report *ForceStopReport) (*pidfile.PidFile, error) {
+	record, err := pidfile.Read(rootDir, PIDFileName)
+	if err != nil {
+		if isMalformedPIDFileError(err) {
+			return nil, unverifiableProcessError(
+				"force-stop",
+				report.RecordPath,
+				0,
+				err,
+				unverifiableProcessChecks{},
+			)
+		}
+		return nil, fmt.Errorf("proxy.ForceStopUnverified: read %s: %w", report.RecordPath, err)
+	}
+	if record == nil {
+		return nil, nil
+	}
+	report.RecordFound = true
+	report.PID = record.Pid
+	return record, nil
+}
+
+func requireUnverifiableProxyRecord(rootDir string, record *pidfile.PidFile) error {
+	if err := record.ValidateV2(pidfile.KindProxy); err != nil {
+		return nil
+	}
+	rootID, err := identity.RootID(rootDir)
+	if err == nil && record.RootID == rootID {
+		return errors.New(
+			"proxy.ForceStopUnverified: record has a verifiable v2 workspace identity; use proxy.Shutdown",
+		)
+	}
+	return nil
+}
+
+func inspectAndStopUnverifiedPID(pid int, deadline time.Time, report *ForceStopReport) error {
+	if pid <= 0 {
+		return fmt.Errorf("proxy.ForceStopUnverified: record %s has invalid pid %d", report.RecordPath, pid)
+	}
+	executable, gone, err := processExecutableBasename(pid)
+	if err != nil {
+		return fmt.Errorf("proxy.ForceStopUnverified: inspect executable for pid %d: %w", pid, err)
+	}
+	if gone {
+		report.ProcessWasGone = true
+		return nil
+	}
+	executable = normalizeForceStopExecutable(executable)
+	report.Executable = executable
+	if executable != "bd" && executable != "dolt" {
+		return fmt.Errorf(
+			"proxy.ForceStopUnverified: refusing to signal pid %d from %s: executable basename is %q, want bd or dolt",
+			pid,
+			report.RecordPath,
+			executable,
+		)
+	}
+
+	process, err := os.FindProcess(pid)
+	if err != nil {
+		return fmt.Errorf("proxy.ForceStopUnverified: find pid %d: %w", pid, err)
+	}
+	if err := process.Kill(); err != nil {
+		current, nowGone, inspectErr := processExecutableBasename(pid)
+		if inspectErr == nil && (nowGone || normalizeForceStopExecutable(current) != executable) {
+			report.ProcessWasGone = true
+			return nil
+		}
+		return fmt.Errorf("proxy.ForceStopUnverified: signal pid %d: %w", pid, err)
+	}
+	report.SignalSent = true
+
+	for {
+		current, nowGone, inspectErr := processExecutableBasename(pid)
+		if inspectErr != nil {
+			return fmt.Errorf("proxy.ForceStopUnverified: confirm pid %d exit: %w", pid, inspectErr)
+		}
+		if nowGone || normalizeForceStopExecutable(current) != executable {
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("proxy.ForceStopUnverified: timeout waiting for pid %d to exit", pid)
+		}
+		time.Sleep(shutdownConfirmPoll)
+	}
+}
+
+func normalizeForceStopExecutable(name string) string {
+	name = strings.TrimSpace(filepath.Base(name))
+	name = strings.TrimSuffix(name, " (deleted)")
+	name = strings.TrimSuffix(strings.ToLower(name), ".exe")
+	return name
+}
+
+func acquireForceStopLock(lockPath string, deadline time.Time) (*util.Lock, error) {
+	for {
+		lock, err := util.TryLock(lockPath)
+		if err == nil {
+			return lock, nil
+		}
+		if !lockfile.IsLocked(err) {
+			return nil, fmt.Errorf("proxy.ForceStopUnverified: acquire %s: %w", lockPath, err)
+		}
+		if time.Now().After(deadline) {
+			return nil, fmt.Errorf("proxy.ForceStopUnverified: timeout acquiring %s after signaling", lockPath)
+		}
+		time.Sleep(shutdownConfirmPoll)
+	}
+}
+
+func quarantineForceStopRecord(
+	rootDir string,
+	record *pidfile.PidFile,
+	report *ForceStopReport,
+) error {
+	current, err := pidfile.Read(rootDir, PIDFileName)
+	if err != nil {
+		return fmt.Errorf("proxy.ForceStopUnverified: re-read %s: %w", report.RecordPath, err)
+	}
+	if current == nil {
+		return nil
+	}
+	if *current != *record {
+		return fmt.Errorf(
+			"proxy.ForceStopUnverified: record %s changed after pid %d was stopped; refusing to quarantine the replacement",
+			report.RecordPath,
+			record.Pid,
+		)
+	}
+	target, err := quarantineRecord(rootDir, PIDFileName, time.Now())
+	if err != nil {
+		return fmt.Errorf("proxy.ForceStopUnverified: quarantine %s: %w", report.RecordPath, err)
+	}
+	report.QuarantinedPath = target
+	return nil
+}

--- a/internal/storage/dbproxy/proxy/force_stop_linux_test.go
+++ b/internal/storage/dbproxy/proxy/force_stop_linux_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/steveyegge/beads/internal/procid"
 	"github.com/steveyegge/beads/internal/storage/dbproxy/pidfile"
+	"github.com/steveyegge/beads/internal/storage/dbproxy/server"
 	"github.com/steveyegge/beads/internal/storage/dbproxy/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -18,7 +19,7 @@ import (
 
 func TestForceStopUnverifiedFreeLock(t *testing.T) {
 	root := t.TempDir()
-	helper := startNamedForceStopHelper(t, "bd")
+	helper := startNamedForceStopHelper(t, root, "bd")
 	writeLegacyProxyRecord(t, root, helper)
 
 	report, err := ForceStopUnverified(root)
@@ -36,7 +37,7 @@ func TestForceStopUnverifiedFreeLock(t *testing.T) {
 
 func TestForceStopUnverifiedHeldLock(t *testing.T) {
 	root := t.TempDir()
-	helper := startNamedForceStopHelper(t, "dolt")
+	helper := startNamedForceStopHelper(t, root, "dolt")
 	writeLegacyProxyRecord(t, root, helper)
 	held, err := util.TryLock(filepath.Join(root, LockFileName))
 	require.NoError(t, err)
@@ -59,7 +60,7 @@ func TestForceStopUnverifiedHeldLock(t *testing.T) {
 
 func TestForceStopUnverifiedGoneProcess(t *testing.T) {
 	root := t.TempDir()
-	helper := startNamedForceStopHelper(t, "bd")
+	helper := startNamedForceStopHelper(t, root, "bd")
 	writeLegacyProxyRecord(t, root, helper)
 	handle, err := procid.Open(helper.cmd.Process.Pid, helper.token)
 	require.NoError(t, err)
@@ -72,6 +73,41 @@ func TestForceStopUnverifiedGoneProcess(t *testing.T) {
 	assert.True(t, report.ProcessWasGone)
 	assert.False(t, report.SignalSent)
 	assert.NotEmpty(t, report.QuarantinedPath)
+}
+
+// A pre-v2 managed-local deployment leaves BOTH proxy.pid and proxy-child.pid
+// as legacy records, so Shutdown refuses on both sides and the force path must
+// still be offered and recover both records.
+func TestForceStopUnverifiedPairedLegacyRecords(t *testing.T) {
+	root := t.TempDir()
+	proxyHelper := startNamedForceStopHelper(t, root, "bd")
+	backendHelper := startNamedForceStopHelper(t, root, "dolt")
+	writeLegacyProxyRecord(t, root, proxyHelper)
+	require.NoError(t, pidfile.Write(root, server.PIDFileName, pidfile.PidFile{
+		Pid:  backendHelper.cmd.Process.Pid,
+		Port: 3308,
+	}))
+
+	shutdownErr := Shutdown(root)
+	require.Error(t, shutdownErr)
+	assert.ErrorIs(t, shutdownErr, ErrUnverifiableProcess)
+	assert.True(t, CanForceStopUnverified(shutdownErr),
+		"paired legacy records must remain eligible for --force recovery")
+
+	report, err := ForceStopUnverified(root)
+	require.NoError(t, err)
+	assert.True(t, report.SignalSent)
+	assert.NotEmpty(t, report.QuarantinedPath)
+	require.NotNil(t, report.Backend)
+	assert.True(t, report.Backend.RecordFound)
+	assert.Equal(t, backendHelper.cmd.Process.Pid, report.Backend.PID)
+	assert.Equal(t, "dolt", report.Backend.Executable)
+	assert.True(t, report.Backend.SignalSent)
+	assert.NotEmpty(t, report.Backend.QuarantinedPath)
+	assertHelperExited(t, proxyHelper)
+	assertHelperExited(t, backendHelper)
+	assert.NoFileExists(t, pidfile.Path(root, PIDFileName))
+	assert.NoFileExists(t, pidfile.Path(root, server.PIDFileName))
 }
 
 func TestForceStopUnverifiedRejectsForeignExecutable(t *testing.T) {
@@ -87,9 +123,26 @@ func TestForceStopUnverifiedRejectsForeignExecutable(t *testing.T) {
 	assert.FileExists(t, pidfile.Path(root, PIDFileName))
 }
 
+// A recycled PID can point at an unrelated live bd process; a basename match
+// alone must not be a license to SIGKILL it. The command line has to tie the
+// process to this workspace.
+func TestForceStopUnverifiedRejectsForeignWorkspaceProcess(t *testing.T) {
+	root := t.TempDir()
+	helper := startNamedForceStopHelper(t, t.TempDir(), "bd")
+	writeLegacyProxyRecord(t, root, helper)
+
+	report, err := ForceStopUnverified(root)
+	require.ErrorContains(t, err, "does not reference workspace")
+	assert.Equal(t, "bd", report.Executable)
+	assert.False(t, report.SignalSent)
+	assert.Empty(t, report.QuarantinedPath)
+	assertHelperAlive(t, helper)
+	assert.FileExists(t, pidfile.Path(root, PIDFileName))
+}
+
 func TestForceStopUnverifiedRejectsVerifiableV2Record(t *testing.T) {
 	root := t.TempDir()
-	helper := startNamedForceStopHelper(t, "bd")
+	helper := startNamedForceStopHelper(t, root, "bd")
 	record := v2Record(t, root, pidfile.KindProxy, helper)
 	require.NoError(t, pidfile.Write(root, PIDFileName, record))
 
@@ -101,7 +154,11 @@ func TestForceStopUnverifiedRejectsVerifiableV2Record(t *testing.T) {
 	assert.FileExists(t, pidfile.Path(root, PIDFileName))
 }
 
-func startNamedForceStopHelper(t *testing.T, name string) helperProcess {
+// startNamedForceStopHelper starts a long-sleeping process whose executable
+// basename is name and whose command line references dir (the binary lives
+// inside it), matching how a workspace's own bd/dolt processes reference
+// their root path.
+func startNamedForceStopHelper(t *testing.T, dir, name string) helperProcess {
 	t.Helper()
 	sleepPath, err := exec.LookPath("sleep")
 	require.NoError(t, err)
@@ -109,7 +166,7 @@ func startNamedForceStopHelper(t *testing.T, name string) helperProcess {
 	require.NoError(t, err)
 	data, err := os.ReadFile(sleepPath)
 	require.NoError(t, err)
-	executable := filepath.Join(t.TempDir(), name)
+	executable := filepath.Join(dir, name)
 	require.NoError(t, os.WriteFile(executable, data, 0o700))
 
 	cmd := exec.Command(executable, "30")

--- a/internal/storage/dbproxy/proxy/force_stop_linux_test.go
+++ b/internal/storage/dbproxy/proxy/force_stop_linux_test.go
@@ -1,0 +1,149 @@
+//go:build linux
+
+package proxy
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/steveyegge/beads/internal/procid"
+	"github.com/steveyegge/beads/internal/storage/dbproxy/pidfile"
+	"github.com/steveyegge/beads/internal/storage/dbproxy/util"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestForceStopUnverifiedFreeLock(t *testing.T) {
+	root := t.TempDir()
+	helper := startNamedForceStopHelper(t, "bd")
+	writeLegacyProxyRecord(t, root, helper)
+
+	report, err := ForceStopUnverified(root)
+	require.NoError(t, err)
+	assert.True(t, report.RecordFound)
+	assert.False(t, report.LockWasHeld)
+	assert.Equal(t, helper.cmd.Process.Pid, report.PID)
+	assert.Equal(t, "bd", report.Executable)
+	assert.True(t, report.SignalSent)
+	assert.NotEmpty(t, report.QuarantinedPath)
+	assertHelperExited(t, helper)
+	assert.NoFileExists(t, pidfile.Path(root, PIDFileName))
+	assert.FileExists(t, report.QuarantinedPath)
+}
+
+func TestForceStopUnverifiedHeldLock(t *testing.T) {
+	root := t.TempDir()
+	helper := startNamedForceStopHelper(t, "dolt")
+	writeLegacyProxyRecord(t, root, helper)
+	held, err := util.TryLock(filepath.Join(root, LockFileName))
+	require.NoError(t, err)
+	released := make(chan struct{})
+	go func() {
+		<-helper.done
+		held.Unlock()
+		close(released)
+	}()
+
+	report, err := ForceStopUnverified(root, ForceStopOptions{Timeout: 5 * time.Second})
+	require.NoError(t, err)
+	<-released
+	assert.True(t, report.LockWasHeld)
+	assert.Equal(t, "dolt", report.Executable)
+	assert.True(t, report.SignalSent)
+	assert.NotEmpty(t, report.QuarantinedPath)
+	assert.NoFileExists(t, pidfile.Path(root, PIDFileName))
+}
+
+func TestForceStopUnverifiedGoneProcess(t *testing.T) {
+	root := t.TempDir()
+	helper := startNamedForceStopHelper(t, "bd")
+	writeLegacyProxyRecord(t, root, helper)
+	handle, err := procid.Open(helper.cmd.Process.Pid, helper.token)
+	require.NoError(t, err)
+	require.NoError(t, handle.Kill())
+	require.NoError(t, handle.Close())
+	assertHelperExited(t, helper)
+
+	report, err := ForceStopUnverified(root)
+	require.NoError(t, err)
+	assert.True(t, report.ProcessWasGone)
+	assert.False(t, report.SignalSent)
+	assert.NotEmpty(t, report.QuarantinedPath)
+}
+
+func TestForceStopUnverifiedRejectsForeignExecutable(t *testing.T) {
+	root := t.TempDir()
+	helper := startHelperProcess(t)
+	writeLegacyProxyRecord(t, root, helper)
+
+	report, err := ForceStopUnverified(root)
+	require.ErrorContains(t, err, "want bd or dolt")
+	assert.False(t, report.SignalSent)
+	assert.Empty(t, report.QuarantinedPath)
+	assertHelperAlive(t, helper)
+	assert.FileExists(t, pidfile.Path(root, PIDFileName))
+}
+
+func TestForceStopUnverifiedRejectsVerifiableV2Record(t *testing.T) {
+	root := t.TempDir()
+	helper := startNamedForceStopHelper(t, "bd")
+	record := v2Record(t, root, pidfile.KindProxy, helper)
+	require.NoError(t, pidfile.Write(root, PIDFileName, record))
+
+	report, err := ForceStopUnverified(root)
+	require.ErrorContains(t, err, "use proxy.Shutdown")
+	assert.False(t, report.SignalSent)
+	assert.Empty(t, report.QuarantinedPath)
+	assertHelperAlive(t, helper)
+	assert.FileExists(t, pidfile.Path(root, PIDFileName))
+}
+
+func startNamedForceStopHelper(t *testing.T, name string) helperProcess {
+	t.Helper()
+	sleepPath, err := exec.LookPath("sleep")
+	require.NoError(t, err)
+	sleepPath, err = filepath.EvalSymlinks(sleepPath)
+	require.NoError(t, err)
+	data, err := os.ReadFile(sleepPath)
+	require.NoError(t, err)
+	executable := filepath.Join(t.TempDir(), name)
+	require.NoError(t, os.WriteFile(executable, data, 0o700))
+
+	cmd := exec.Command(executable, "30")
+	require.NoError(t, cmd.Start())
+	token, err := procid.Capture(cmd.Process.Pid)
+	require.NoError(t, err)
+	done := make(chan error, 1)
+	go func() {
+		done <- cmd.Wait()
+		close(done)
+	}()
+	helper := helperProcess{cmd: cmd, token: token, done: done}
+	t.Cleanup(func() {
+		matched, verifyErr := procid.Verify(cmd.Process.Pid, token)
+		if verifyErr == nil && matched {
+			handle, openErr := procid.Open(cmd.Process.Pid, token)
+			if openErr == nil {
+				_ = handle.Kill()
+				_ = handle.Close()
+			}
+		}
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			t.Errorf("named helper pid %d did not exit", cmd.Process.Pid)
+		}
+	})
+	return helper
+}
+
+func writeLegacyProxyRecord(t *testing.T, root string, helper helperProcess) {
+	t.Helper()
+	require.NoError(t, pidfile.Write(root, PIDFileName, pidfile.PidFile{
+		Pid:  helper.cmd.Process.Pid,
+		Port: 3307,
+	}))
+}

--- a/internal/storage/dbproxy/proxy/process_executable_darwin.go
+++ b/internal/storage/dbproxy/proxy/process_executable_darwin.go
@@ -1,0 +1,30 @@
+//go:build darwin
+
+package proxy
+
+import (
+	"errors"
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+
+	"golang.org/x/sys/unix"
+)
+
+func processExecutableBasename(pid int) (basename string, gone bool, err error) {
+	output, commandErr := exec.Command("ps", "-p", strconv.Itoa(pid), "-o", "comm=").Output()
+	if commandErr != nil {
+		if killErr := syscall.Kill(pid, 0); errors.Is(killErr, unix.ESRCH) {
+			return "", true, nil
+		}
+		return "", false, commandErr
+	}
+	base := filepath.Base(strings.TrimSpace(string(output)))
+	if base == "." || base == string(filepath.Separator) || base == "" {
+		return "", false, fmt.Errorf("empty executable basename for pid %d", pid)
+	}
+	return base, false, nil
+}

--- a/internal/storage/dbproxy/proxy/process_executable_linux.go
+++ b/internal/storage/dbproxy/proxy/process_executable_linux.go
@@ -1,0 +1,27 @@
+//go:build linux
+
+package proxy
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strconv"
+)
+
+func processExecutableBasename(pid int) (basename string, gone bool, err error) {
+	target, err := os.Readlink("/proc/" + strconv.Itoa(pid) + "/exe")
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return "", true, nil
+		}
+		return "", false, err
+	}
+	base := filepath.Base(target)
+	if base == "." || base == string(filepath.Separator) || base == "" {
+		return "", false, fmt.Errorf("empty executable basename for pid %d", pid)
+	}
+	return base, false, nil
+}

--- a/internal/storage/dbproxy/proxy/process_executable_windows.go
+++ b/internal/storage/dbproxy/proxy/process_executable_windows.go
@@ -1,0 +1,29 @@
+//go:build windows
+
+package proxy
+
+import (
+	"errors"
+	"path/filepath"
+	"syscall"
+
+	"golang.org/x/sys/windows"
+)
+
+func processExecutableBasename(pid int) (basename string, gone bool, err error) {
+	process, err := windows.OpenProcess(windows.PROCESS_QUERY_LIMITED_INFORMATION, false, uint32(pid))
+	if err != nil {
+		if errors.Is(err, windows.ERROR_INVALID_PARAMETER) {
+			return "", true, nil
+		}
+		return "", false, err
+	}
+	defer windows.CloseHandle(process)
+
+	buffer := make([]uint16, 32768)
+	size := uint32(len(buffer))
+	if err := windows.QueryFullProcessImageName(process, 0, &buffer[0], &size); err != nil {
+		return "", false, err
+	}
+	return filepath.Base(syscall.UTF16ToString(buffer[:size])), false, nil
+}

--- a/internal/storage/dbproxy/proxy/server.go
+++ b/internal/storage/dbproxy/proxy/server.go
@@ -104,6 +104,9 @@ func (p *proxyServer) ListenAndServe(parentCtx context.Context) error {
 		return fmt.Errorf("acquire %s: %w", LockFileName, err)
 	}
 	defer lock.Unlock()
+	if err := clearSpawnMarkerAfterLock(p.rootDir); err != nil {
+		return fmt.Errorf("clear proxy spawn marker: %w", err)
+	}
 
 	logPath := filepath.Join(p.rootDir, LogFileName)
 	f, err := os.OpenFile(logPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600) // #nosec G304 -- logPath is derived from operator-supplied config, not untrusted request input

--- a/internal/storage/dbproxy/proxy/server.go
+++ b/internal/storage/dbproxy/proxy/server.go
@@ -19,6 +19,8 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/steveyegge/beads/internal/lockfile"
+	"github.com/steveyegge/beads/internal/procid"
+	"github.com/steveyegge/beads/internal/storage/dbproxy/identity"
 	"github.com/steveyegge/beads/internal/storage/dbproxy/pidfile"
 	"github.com/steveyegge/beads/internal/storage/dbproxy/server"
 	"github.com/steveyegge/beads/internal/storage/dbproxy/util"
@@ -143,6 +145,30 @@ func (p *proxyServer) ListenAndServe(parentCtx context.Context) error {
 	p.listener = ln
 	defer func() { _ = ln.Close() }()
 	p.stats.IncListenAndServe()
+	dataPort, ok := ln.Addr().(*net.TCPAddr)
+	if !ok {
+		return fmt.Errorf("proxy: unexpected data listener address %T", ln.Addr())
+	}
+
+	if _, err := identity.WriteSecret(p.rootDir); err != nil {
+		return fmt.Errorf("write proxy secret: %w", err)
+	}
+
+	var identMu sync.RWMutex
+	identReply := identity.IdentReply{
+		Schema:   pidfile.SchemaV2,
+		Role:     pidfile.KindProxy,
+		DataPort: dataPort.Port,
+	}
+	control, err := startControl(p.rootDir, func() identity.IdentReply {
+		identMu.RLock()
+		defer identMu.RUnlock()
+		return identReply
+	})
+	if err != nil {
+		return fmt.Errorf("start control listener: %w", err)
+	}
+	defer func() { _ = control.Close() }()
 
 	p.stats.IncBackendStart()
 	if err := p.server.Start(ctx); err != nil {
@@ -154,11 +180,35 @@ func (p *proxyServer) ListenAndServe(parentCtx context.Context) error {
 		_ = stopBackendBounded(p.server)
 		return fmt.Errorf("database server not ready: %w", err)
 	}
+	birth, err := procid.Capture(os.Getpid())
+	if err != nil {
+		p.stats.IncBackendStop()
+		_ = stopBackendBounded(p.server)
+		return fmt.Errorf("capture proxy birth identity: %w", err)
+	}
+	rootID, err := identity.RootID(p.rootDir)
+	if err != nil {
+		p.stats.IncBackendStop()
+		_ = stopBackendBounded(p.server)
+		return fmt.Errorf("resolve proxy root identity: %w", err)
+	}
+	identMu.Lock()
+	identReply.RootID = rootID
+	identReply.UpstreamID = p.server.ID(ctx)
+	identReply.PID = os.Getpid()
+	identReply.Birth = string(birth)
+	identReply.ControlPort = control.Port()
+	identMu.Unlock()
 
 	if err := pidfile.Write(p.rootDir, PIDFileName, pidfile.PidFile{
-		Pid:        os.Getpid(),
-		Port:       p.port,
-		UpstreamID: p.server.ID(ctx),
+		Pid:         os.Getpid(),
+		Port:        dataPort.Port,
+		UpstreamID:  p.server.ID(ctx),
+		Schema:      pidfile.SchemaV2,
+		Kind:        pidfile.KindProxy,
+		Birth:       string(birth),
+		RootID:      rootID,
+		ControlPort: control.Port(),
 	}); err != nil {
 		p.stats.IncBackendStop()
 		_ = stopBackendBounded(p.server)
@@ -170,6 +220,7 @@ func (p *proxyServer) ListenAndServe(parentCtx context.Context) error {
 	g.Go(func() error {
 		<-gctx.Done()
 		_ = p.listener.Close()
+		_ = control.Close()
 		return nil
 	})
 	g.Go(func() error { return p.idleWatcher(gctx) })

--- a/internal/storage/dbproxy/proxy/server.go
+++ b/internal/storage/dbproxy/proxy/server.go
@@ -195,9 +195,10 @@ func (p *proxyServer) ListenAndServe(parentCtx context.Context) error {
 		_ = stopBackendBounded(p.server)
 		return fmt.Errorf("resolve proxy root identity: %w", err)
 	}
+	upstreamID := p.server.ID(ctx)
 	identMu.Lock()
 	identReply.RootID = rootID
-	identReply.UpstreamID = p.server.ID(ctx)
+	identReply.UpstreamID = upstreamID
 	identReply.PID = os.Getpid()
 	identReply.Birth = string(birth)
 	identReply.ControlPort = control.Port()
@@ -206,7 +207,7 @@ func (p *proxyServer) ListenAndServe(parentCtx context.Context) error {
 	if err := pidfile.Write(p.rootDir, PIDFileName, pidfile.PidFile{
 		Pid:         os.Getpid(),
 		Port:        dataPort.Port,
-		UpstreamID:  p.server.ID(ctx),
+		UpstreamID:  upstreamID,
 		Schema:      pidfile.SchemaV2,
 		Kind:        pidfile.KindProxy,
 		Birth:       string(birth),
@@ -228,6 +229,14 @@ func (p *proxyServer) ListenAndServe(parentCtx context.Context) error {
 	})
 	g.Go(func() error { return p.idleWatcher(gctx) })
 	g.Go(func() error { return p.acceptLoop(gctx) })
+	g.Go(func() error {
+		select {
+		case <-gctx.Done():
+			return nil
+		case err := <-control.Errors():
+			return err
+		}
+	})
 
 	runErr := g.Wait()
 	_ = p.conns.Wait()

--- a/internal/storage/dbproxy/proxy/server.go
+++ b/internal/storage/dbproxy/proxy/server.go
@@ -229,14 +229,6 @@ func (p *proxyServer) ListenAndServe(parentCtx context.Context) error {
 	})
 	g.Go(func() error { return p.idleWatcher(gctx) })
 	g.Go(func() error { return p.acceptLoop(gctx) })
-	g.Go(func() error {
-		select {
-		case <-gctx.Done():
-			return nil
-		case err := <-control.Errors():
-			return err
-		}
-	})
 
 	runErr := g.Wait()
 	_ = p.conns.Wait()

--- a/internal/storage/dbproxy/proxy/server_test.go
+++ b/internal/storage/dbproxy/proxy/server_test.go
@@ -205,10 +205,11 @@ func TestProxy_PublishesVerifiableIdentity(t *testing.T) {
 	t.Parallel()
 
 	root := t.TempDir()
+	ts := server.New()
 	h := runProxy(t, proxy.ProxyOpts{
 		RootDir: root,
 		Port:    freeTCPPort(t),
-		Server:  server.New(),
+		Server:  ts,
 	})
 	waitListening(t, root, listenWait)
 
@@ -234,6 +235,7 @@ func TestProxy_PublishesVerifiableIdentity(t *testing.T) {
 	assert.Equal(t, pf.RootID, got.RootID)
 	assert.Equal(t, rootID, got.RootID)
 	assert.Equal(t, pf.ControlPort, got.ControlPort)
+	assert.Equal(t, int64(1), ts.Snapshot().IDCalls, "pidfile and control reply must share one captured upstream ID")
 
 	h.Cancel()
 	require.NoError(t, h.waitErr(t, shutdownWait))

--- a/internal/storage/dbproxy/proxy/server_test.go
+++ b/internal/storage/dbproxy/proxy/server_test.go
@@ -14,6 +14,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/steveyegge/beads/internal/procid"
+	"github.com/steveyegge/beads/internal/storage/dbproxy/identity"
 	"github.com/steveyegge/beads/internal/storage/dbproxy/pidfile"
 	"github.com/steveyegge/beads/internal/storage/dbproxy/proxy"
 	"github.com/steveyegge/beads/internal/storage/dbproxy/server"
@@ -197,6 +199,46 @@ func TestProxy_PidFile_WrittenAndRemoved(t *testing.T) {
 	require.NoError(t, h.waitErr(t, shutdownWait))
 
 	assertNoPidFile(t, root)
+}
+
+func TestProxy_PublishesVerifiableIdentity(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	h := runProxy(t, proxy.ProxyOpts{
+		RootDir: root,
+		Port:    freeTCPPort(t),
+		Server:  server.New(),
+	})
+	waitListening(t, root, listenWait)
+
+	pf, err := pidfile.Read(root, proxy.PIDFileName)
+	require.NoError(t, err)
+	require.NotNil(t, pf)
+	require.NoError(t, pf.ValidateV2(pidfile.KindProxy))
+	match, err := procid.Verify(pf.Pid, procid.Token(pf.Birth))
+	require.NoError(t, err)
+	assert.True(t, match)
+
+	secret, err := identity.ReadSecret(root)
+	require.NoError(t, err)
+	got, err := identity.Identify("127.0.0.1", pf.ControlPort, secret, ioTimeout)
+	require.NoError(t, err)
+	rootID, err := identity.RootID(root)
+	require.NoError(t, err)
+	assert.Equal(t, pidfile.SchemaV2, got.Schema)
+	assert.Equal(t, pidfile.KindProxy, got.Role)
+	assert.Equal(t, pf.Pid, got.PID)
+	assert.Equal(t, pf.Birth, got.Birth)
+	assert.Equal(t, pf.Port, got.DataPort)
+	assert.Equal(t, pf.RootID, got.RootID)
+	assert.Equal(t, rootID, got.RootID)
+	assert.Equal(t, pf.ControlPort, got.ControlPort)
+
+	h.Cancel()
+	require.NoError(t, h.waitErr(t, shutdownWait))
+	_, err = net.DialTimeout("tcp", proxyAddr(pf.ControlPort), ioTimeout)
+	assert.Error(t, err)
 }
 
 func TestProxy_ListenError_PortInUse(t *testing.T) {

--- a/internal/storage/dbproxy/proxy/shutdown.go
+++ b/internal/storage/dbproxy/proxy/shutdown.go
@@ -25,6 +25,48 @@ type killRecordChecks struct {
 	CheckSpawnMarker bool
 }
 
+type shutdownError struct {
+	proxyErr   error
+	backendErr error
+}
+
+func (e *shutdownError) Error() string {
+	switch {
+	case e.proxyErr == nil:
+		return fmt.Sprintf("proxy.Shutdown partial: proxy stopped; backend left running: %v", e.backendErr)
+	case e.backendErr == nil:
+		return fmt.Sprintf("proxy.Shutdown partial: backend stopped; proxy left running: %v", e.proxyErr)
+	default:
+		return fmt.Sprintf(
+			"proxy.Shutdown failed: proxy left running: %v; backend left running: %v",
+			e.proxyErr,
+			e.backendErr,
+		)
+	}
+}
+
+func (e *shutdownError) Unwrap() []error {
+	errs := make([]error, 0, 2)
+	if e.proxyErr != nil {
+		errs = append(errs, e.proxyErr)
+	}
+	if e.backendErr != nil {
+		errs = append(errs, e.backendErr)
+	}
+	return errs
+}
+
+// CanForceStopUnverified reports whether err is a Shutdown refusal whose only
+// remaining process is an unverifiable proxy. ForceStopUnverified can recover
+// exactly that partial outcome; it must not be used for backend refusals or
+// unrelated shutdown failures.
+func CanForceStopUnverified(err error) bool {
+	var shutdownErr *shutdownError
+	return errors.As(err, &shutdownErr) &&
+		shutdownErr.backendErr == nil &&
+		errors.Is(shutdownErr.proxyErr, ErrUnverifiableProcess)
+}
+
 // Shutdown stops the verified proxy and backend processes for rootDir.
 //
 // Advancing the stop epoch first makes every start attempt which began before
@@ -66,16 +108,8 @@ func Shutdown(rootDir string) error {
 	switch {
 	case proxyErr == nil && backendErr == nil:
 		return nil
-	case proxyErr == nil:
-		return fmt.Errorf("proxy.Shutdown partial: proxy stopped; backend left running: %w", backendErr)
-	case backendErr == nil:
-		return fmt.Errorf("proxy.Shutdown partial: backend stopped; proxy left running: %w", proxyErr)
 	default:
-		return fmt.Errorf(
-			"proxy.Shutdown failed: proxy left running: %v; backend left running: %w",
-			proxyErr,
-			backendErr,
-		)
+		return &shutdownError{proxyErr: proxyErr, backendErr: backendErr}
 	}
 }
 

--- a/internal/storage/dbproxy/proxy/shutdown.go
+++ b/internal/storage/dbproxy/proxy/shutdown.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/steveyegge/beads/internal/lockfile"
+	"github.com/steveyegge/beads/internal/storage/dbproxy/identity"
 	"github.com/steveyegge/beads/internal/storage/dbproxy/pidfile"
 	"github.com/steveyegge/beads/internal/storage/dbproxy/server"
 	"github.com/steveyegge/beads/internal/storage/dbproxy/util"
@@ -17,22 +18,57 @@ const (
 	shutdownConfirmPoll     = 50 * time.Millisecond
 )
 
-// Shutdown forcibly terminates the proxy and its child dolt sql-server for the
-// given rootDir. Intended for test cleanup: guarantees no proxy or dolt
-// sql-server process is left running against rootDir when this returns nil.
+// Shutdown stops the verified proxy and backend processes for rootDir.
 //
-// For each (lock, pid) pair — proxy-child first, then proxy — it tries to
-// acquire the flock. If the flock is held, it reads the pidfile, sends SIGKILL
-// to the recorded PID, then polls the flock until it can be acquired (the OS
-// releases flocks on process exit). The pidfile is removed on success.
+// Advancing the stop epoch first makes every start attempt which began before
+// this call terminally abort instead of retrying after its child is stopped.
+// The proxy spawn marker covers the smaller release-lock-before-exec window:
+// Shutdown waits for that marked attempt to either acquire proxy.lock or fail,
+// then verifies and stops whatever it published. All waits are bounded by
+// shutdownConfirmDeadline.
 func Shutdown(rootDir string) error {
-	if err := shutdownPair(rootDir, server.LockFileName, server.PIDFileName); err != nil {
-		return fmt.Errorf("proxy.Shutdown: dolt sql-server: %w", err)
+	if _, err := advanceStopEpoch(rootDir); err != nil {
+		return fmt.Errorf("proxy.Shutdown: publish stop epoch: %w", err)
 	}
-	if err := shutdownPair(rootDir, LockFileName, PIDFileName); err != nil {
-		return fmt.Errorf("proxy.Shutdown: proxy: %w", err)
+
+	proxyLock, proxyErr := stopAndAcquire(
+		rootDir,
+		LockFileName,
+		PIDFileName,
+		pidfile.KindProxy,
+		false,
+		true,
+	)
+	if proxyLock != nil {
+		defer proxyLock.Unlock()
 	}
-	return nil
+
+	backendLock, backendErr := stopAndAcquire(
+		rootDir,
+		server.LockFileName,
+		server.PIDFileName,
+		pidfile.KindDoltBackend,
+		true,
+		false,
+	)
+	if backendLock != nil {
+		backendLock.Unlock()
+	}
+
+	switch {
+	case proxyErr == nil && backendErr == nil:
+		return nil
+	case proxyErr == nil:
+		return fmt.Errorf("proxy.Shutdown partial: proxy stopped; backend left running: %w", backendErr)
+	case backendErr == nil:
+		return fmt.Errorf("proxy.Shutdown partial: backend stopped; proxy left running: %w", proxyErr)
+	default:
+		return fmt.Errorf(
+			"proxy.Shutdown failed: proxy left running: %v; backend left running: %w",
+			proxyErr,
+			backendErr,
+		)
+	}
 }
 
 func ControlFilePaths(rootDir string) []string {
@@ -40,6 +76,8 @@ func ControlFilePaths(rootDir string) []string {
 		filepath.Join(rootDir, PIDFileName),
 		filepath.Join(rootDir, LockFileName),
 		filepath.Join(rootDir, LogFileName),
+		filepath.Join(rootDir, spawnMarkerFileName),
+		filepath.Join(rootDir, stopEpochFileName),
 		filepath.Join(rootDir, server.PIDFileName),
 		filepath.Join(rootDir, server.LockFileName),
 	}
@@ -55,37 +93,167 @@ func PurgeControlFiles(rootDir string) []error {
 	return errs
 }
 
-func shutdownPair(rootDir, lockName, pidName string) error {
+// stopAndAcquire returns with lockName held after the recorded process is
+// absent. Holding proxy.lock across backend cleanup prevents a fresh start
+// from slipping between the two shutdown phases.
+func stopAndAcquire(
+	rootDir string,
+	lockName string,
+	pidName string,
+	wantKind string,
+	verifyRoot bool,
+	checkSpawnMarker bool,
+) (*util.Lock, error) {
 	lockPath := filepath.Join(rootDir, lockName)
-
-	if l, err := util.TryLock(lockPath); err == nil {
-		l.Unlock()
-		_ = pidfile.Remove(rootDir, pidName)
-		return nil
-	} else if !lockfile.IsLocked(err) {
-		return fmt.Errorf("probe %s: %w", lockName, err)
-	}
-
-	if pf, err := pidfile.Read(rootDir, pidName); err == nil && pf != nil {
-		if proc, ferr := os.FindProcess(pf.Pid); ferr == nil {
-			_ = proc.Kill()
-		}
-	}
-
+	recordPath := pidfile.Path(rootDir, pidName)
 	deadline := time.Now().Add(shutdownConfirmDeadline)
+	var stopped *pidfile.PidFile
+
 	for {
-		l, err := util.TryLock(lockPath)
-		if err == nil {
-			l.Unlock()
-			_ = pidfile.Remove(rootDir, pidName)
-			return nil
+		lock, err := util.TryLock(lockPath)
+		switch {
+		case err == nil:
+			if checkSpawnMarker {
+				active, markerErr := inspectSpawnMarkerLocked(rootDir)
+				if markerErr != nil {
+					lock.Unlock()
+					return nil, markerErr
+				}
+				if active {
+					lock.Unlock()
+					if time.Now().After(deadline) {
+						return nil, fmt.Errorf(
+							"timeout (%s) waiting for spawn marker %s; wait for the in-progress start to finish, then retry",
+							shutdownConfirmDeadline,
+							filepath.Join(rootDir, spawnMarkerFileName),
+						)
+					}
+					time.Sleep(shutdownConfirmPoll)
+					continue
+				}
+			}
+
+			pf, readErr := pidfile.Read(rootDir, pidName)
+			if readErr != nil {
+				lock.Unlock()
+				return nil, fmt.Errorf("read %s: %w", recordPath, readErr)
+			}
+			if pf == nil {
+				return lock, nil
+			}
+			if stopped != nil && *pf == *stopped {
+				if removeErr := pidfile.Remove(rootDir, pidName); removeErr != nil {
+					lock.Unlock()
+					return nil, fmt.Errorf("remove stopped process record %s: %w", recordPath, removeErr)
+				}
+				return lock, nil
+			}
+			stopped = nil
+
+			if validateErr := validateKillRecord(rootDir, recordPath, pf, wantKind, verifyRoot); validateErr != nil {
+				lock.Unlock()
+				return nil, validateErr
+			}
+			handle, dead, openErr := openRecordedProcess(pf)
+			if openErr != nil {
+				lock.Unlock()
+				return nil, unverifiableProcessError("shutdown", recordPath, pf.Pid, openErr)
+			}
+			if dead {
+				if _, quarantineErr := quarantineRecord(rootDir, pidName, time.Now()); quarantineErr != nil {
+					lock.Unlock()
+					return nil, fmt.Errorf("quarantine dead process record %s: %w", recordPath, quarantineErr)
+				}
+				return lock, nil
+			}
+			if killErr := handle.Kill(); killErr != nil {
+				_ = handle.Close()
+				lock.Unlock()
+				return nil, fmt.Errorf("kill verified pid %d from %s: %w", pf.Pid, recordPath, killErr)
+			}
+			if closeErr := handle.Close(); closeErr != nil {
+				lock.Unlock()
+				return nil, fmt.Errorf("close verified process handle for pid %d: %w", pf.Pid, closeErr)
+			}
+			if waitErr := waitForRecordedProcessExit(pf, time.Until(deadline)); waitErr != nil {
+				lock.Unlock()
+				return nil, fmt.Errorf("confirm verified pid %d stopped: %w", pf.Pid, waitErr)
+			}
+			if removeErr := pidfile.Remove(rootDir, pidName); removeErr != nil {
+				lock.Unlock()
+				return nil, fmt.Errorf("remove stopped process record %s: %w", recordPath, removeErr)
+			}
+			return lock, nil
+
+		case !lockfile.IsLocked(err):
+			return nil, fmt.Errorf("probe %s: %w", lockPath, err)
 		}
-		if !lockfile.IsLocked(err) {
-			return fmt.Errorf("reacquire %s: %w", lockName, err)
+
+		pf, readErr := pidfile.Read(rootDir, pidName)
+		if readErr != nil {
+			return nil, fmt.Errorf("read held-lock record %s: %w", recordPath, readErr)
 		}
+		if pf != nil {
+			if validateErr := validateKillRecord(rootDir, recordPath, pf, wantKind, verifyRoot); validateErr != nil {
+				return nil, validateErr
+			}
+			handle, dead, openErr := openRecordedProcess(pf)
+			if openErr != nil {
+				return nil, unverifiableProcessError("shutdown", recordPath, pf.Pid, openErr)
+			}
+			if !dead {
+				if killErr := handle.Kill(); killErr != nil {
+					_ = handle.Close()
+					return nil, fmt.Errorf("kill verified pid %d from %s: %w", pf.Pid, recordPath, killErr)
+				}
+				if closeErr := handle.Close(); closeErr != nil {
+					return nil, fmt.Errorf("close verified process handle for pid %d: %w", pf.Pid, closeErr)
+				}
+				stopped = pf
+			}
+		}
+
 		if time.Now().After(deadline) {
-			return fmt.Errorf("timeout (%s) confirming death of process holding %s", shutdownConfirmDeadline, lockName)
+			pid := 0
+			if pf != nil {
+				pid = pf.Pid
+			}
+			return nil, fmt.Errorf(
+				"timeout (%s) acquiring %s after inspecting pid %d at %s; stop the lock owner with the binary that started it, then retry",
+				shutdownConfirmDeadline,
+				lockPath,
+				pid,
+				recordPath,
+			)
 		}
 		time.Sleep(shutdownConfirmPoll)
 	}
+}
+
+func validateKillRecord(
+	rootDir string,
+	recordPath string,
+	pf *pidfile.PidFile,
+	wantKind string,
+	verifyRoot bool,
+) error {
+	if err := pf.ValidateV2(wantKind); err != nil {
+		return unverifiableProcessError("shutdown", recordPath, pf.Pid, err)
+	}
+	if !verifyRoot {
+		return nil
+	}
+	rootID, err := identity.RootID(rootDir)
+	if err != nil {
+		return fmt.Errorf("resolve workspace identity for %s: %w", recordPath, err)
+	}
+	if pf.RootID != rootID {
+		return unverifiableProcessError(
+			"shutdown",
+			recordPath,
+			pf.Pid,
+			fmt.Errorf("root identity mismatch (record has %q, workspace has %q)", pf.RootID, rootID),
+		)
+	}
+	return nil
 }

--- a/internal/storage/dbproxy/proxy/shutdown.go
+++ b/internal/storage/dbproxy/proxy/shutdown.go
@@ -56,15 +56,21 @@ func (e *shutdownError) Unwrap() []error {
 	return errs
 }
 
-// CanForceStopUnverified reports whether err is a Shutdown refusal whose only
-// remaining process is an unverifiable proxy. ForceStopUnverified can recover
-// exactly that partial outcome; it must not be used for backend refusals or
-// unrelated shutdown failures.
+// CanForceStopUnverified reports whether err is a Shutdown refusal whose
+// remaining processes are all unverifiable. ForceStopUnverified covers both
+// the proxy and backend records, and a pre-v2 managed-local deployment leaves
+// BOTH as unverifiable legacy records, so either side (or both) may carry the
+// refusal. It must not be used for unrelated shutdown failures.
 func CanForceStopUnverified(err error) bool {
 	var shutdownErr *shutdownError
-	return errors.As(err, &shutdownErr) &&
-		shutdownErr.backendErr == nil &&
+	if !errors.As(err, &shutdownErr) {
+		return false
+	}
+	proxyRecoverable := shutdownErr.proxyErr == nil ||
 		errors.Is(shutdownErr.proxyErr, ErrUnverifiableProcess)
+	backendRecoverable := shutdownErr.backendErr == nil ||
+		errors.Is(shutdownErr.backendErr, ErrUnverifiableProcess)
+	return proxyRecoverable && backendRecoverable
 }
 
 // Shutdown stops the verified proxy and backend processes for rootDir.

--- a/internal/storage/dbproxy/proxy/shutdown.go
+++ b/internal/storage/dbproxy/proxy/shutdown.go
@@ -1,6 +1,7 @@
 package proxy
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -16,7 +17,13 @@ import (
 const (
 	shutdownConfirmDeadline = 5 * time.Second
 	shutdownConfirmPoll     = 50 * time.Millisecond
+	shutdownPostKillMinimum = 2 * time.Second
 )
+
+type killRecordChecks struct {
+	VerifyRoot       bool
+	CheckSpawnMarker bool
+}
 
 // Shutdown stops the verified proxy and backend processes for rootDir.
 //
@@ -27,7 +34,7 @@ const (
 // then verifies and stops whatever it published. All waits are bounded by
 // shutdownConfirmDeadline.
 func Shutdown(rootDir string) error {
-	if _, err := advanceStopEpoch(rootDir); err != nil {
+	if err := advanceStopEpoch(rootDir); err != nil {
 		return fmt.Errorf("proxy.Shutdown: publish stop epoch: %w", err)
 	}
 
@@ -36,8 +43,10 @@ func Shutdown(rootDir string) error {
 		LockFileName,
 		PIDFileName,
 		pidfile.KindProxy,
-		false,
-		true,
+		killRecordChecks{
+			VerifyRoot:       true,
+			CheckSpawnMarker: true,
+		},
 	)
 	if proxyLock != nil {
 		defer proxyLock.Unlock()
@@ -48,8 +57,7 @@ func Shutdown(rootDir string) error {
 		server.LockFileName,
 		server.PIDFileName,
 		pidfile.KindDoltBackend,
-		true,
-		false,
+		killRecordChecks{VerifyRoot: true},
 	)
 	if backendLock != nil {
 		backendLock.Unlock()
@@ -72,15 +80,23 @@ func Shutdown(rootDir string) error {
 }
 
 func ControlFilePaths(rootDir string) []string {
-	return []string{
+	paths := []string{
 		filepath.Join(rootDir, PIDFileName),
 		filepath.Join(rootDir, LockFileName),
 		filepath.Join(rootDir, LogFileName),
+		filepath.Join(rootDir, identity.SecretFileName),
 		filepath.Join(rootDir, spawnMarkerFileName),
 		filepath.Join(rootDir, stopEpochFileName),
 		filepath.Join(rootDir, server.PIDFileName),
 		filepath.Join(rootDir, server.LockFileName),
 	}
+	for _, name := range []string{PIDFileName, server.PIDFileName} {
+		matches, err := filepath.Glob(filepath.Join(rootDir, name+".stale-*"))
+		if err == nil {
+			paths = append(paths, matches...)
+		}
+	}
+	return paths
 }
 
 func PurgeControlFiles(rootDir string) []error {
@@ -101,8 +117,7 @@ func stopAndAcquire(
 	lockName string,
 	pidName string,
 	wantKind string,
-	verifyRoot bool,
-	checkSpawnMarker bool,
+	checks killRecordChecks,
 ) (*util.Lock, error) {
 	lockPath := filepath.Join(rootDir, lockName)
 	recordPath := pidfile.Path(rootDir, pidName)
@@ -113,7 +128,7 @@ func stopAndAcquire(
 		lock, err := util.TryLock(lockPath)
 		switch {
 		case err == nil:
-			if checkSpawnMarker {
+			if checks.CheckSpawnMarker {
 				active, markerErr := inspectSpawnMarkerLocked(rootDir)
 				if markerErr != nil {
 					lock.Unlock()
@@ -136,6 +151,15 @@ func stopAndAcquire(
 			pf, readErr := pidfile.Read(rootDir, pidName)
 			if readErr != nil {
 				lock.Unlock()
+				if isMalformedPIDFileError(readErr) {
+					return nil, unverifiableProcessError(
+						"shutdown",
+						recordPath,
+						0,
+						readErr,
+						unverifiableProcessChecks{},
+					)
+				}
 				return nil, fmt.Errorf("read %s: %w", recordPath, readErr)
 			}
 			if pf == nil {
@@ -150,14 +174,42 @@ func stopAndAcquire(
 			}
 			stopped = nil
 
-			if validateErr := validateKillRecord(rootDir, recordPath, pf, wantKind, verifyRoot); validateErr != nil {
+			if validateErr := validateKillRecord(rootDir, pf, wantKind, checks); validateErr != nil {
+				dead, live, probeErr := classifyInvalidKillRecord(pf, validateErr)
+				if dead {
+					if _, quarantineErr := quarantineRecord(rootDir, pidName, time.Now()); quarantineErr != nil {
+						lock.Unlock()
+						return nil, fmt.Errorf("quarantine dead unverifiable process record %s: %w", recordPath, quarantineErr)
+					}
+					return lock, nil
+				}
+				if probeErr != nil {
+					validateErr = errors.Join(validateErr, fmt.Errorf("probe recorded pid: %w", probeErr))
+				}
 				lock.Unlock()
-				return nil, validateErr
+				return nil, unverifiableProcessError(
+					"shutdown",
+					recordPath,
+					pf.Pid,
+					validateErr,
+					unverifiableProcessChecks{
+						LiveEstablished: live,
+						LegacyProxy: live &&
+							wantKind == pidfile.KindProxy &&
+							errors.Is(validateErr, pidfile.ErrLegacySchema),
+					},
+				)
 			}
 			handle, dead, openErr := openRecordedProcess(pf)
 			if openErr != nil {
 				lock.Unlock()
-				return nil, unverifiableProcessError("shutdown", recordPath, pf.Pid, openErr)
+				return nil, unverifiableProcessError(
+					"shutdown",
+					recordPath,
+					pf.Pid,
+					openErr,
+					unverifiableProcessChecks{},
+				)
 			}
 			if dead {
 				if _, quarantineErr := quarantineRecord(rootDir, pidName, time.Now()); quarantineErr != nil {
@@ -175,7 +227,8 @@ func stopAndAcquire(
 				lock.Unlock()
 				return nil, fmt.Errorf("close verified process handle for pid %d: %w", pf.Pid, closeErr)
 			}
-			if waitErr := waitForRecordedProcessExit(pf, time.Until(deadline)); waitErr != nil {
+			waitBudget := max(time.Until(deadline), shutdownPostKillMinimum)
+			if waitErr := waitForRecordedProcessExit(pf, waitBudget); waitErr != nil {
 				lock.Unlock()
 				return nil, fmt.Errorf("confirm verified pid %d stopped: %w", pf.Pid, waitErr)
 			}
@@ -191,25 +244,62 @@ func stopAndAcquire(
 
 		pf, readErr := pidfile.Read(rootDir, pidName)
 		if readErr != nil {
+			if isMalformedPIDFileError(readErr) {
+				return nil, unverifiableProcessError(
+					"shutdown",
+					recordPath,
+					0,
+					readErr,
+					unverifiableProcessChecks{},
+				)
+			}
 			return nil, fmt.Errorf("read held-lock record %s: %w", recordPath, readErr)
 		}
 		if pf != nil {
-			if validateErr := validateKillRecord(rootDir, recordPath, pf, wantKind, verifyRoot); validateErr != nil {
-				return nil, validateErr
-			}
-			handle, dead, openErr := openRecordedProcess(pf)
-			if openErr != nil {
-				return nil, unverifiableProcessError("shutdown", recordPath, pf.Pid, openErr)
-			}
-			if !dead {
-				if killErr := handle.Kill(); killErr != nil {
-					_ = handle.Close()
-					return nil, fmt.Errorf("kill verified pid %d from %s: %w", pf.Pid, recordPath, killErr)
+			if validateErr := validateKillRecord(rootDir, pf, wantKind, checks); validateErr != nil {
+				dead, live, probeErr := classifyInvalidKillRecord(pf, validateErr)
+				if !dead {
+					if probeErr != nil {
+						validateErr = errors.Join(validateErr, fmt.Errorf("probe recorded pid: %w", probeErr))
+					}
+					return nil, unverifiableProcessError(
+						"shutdown",
+						recordPath,
+						pf.Pid,
+						validateErr,
+						unverifiableProcessChecks{
+							LiveEstablished: live,
+							LegacyProxy: live &&
+								wantKind == pidfile.KindProxy &&
+								errors.Is(validateErr, pidfile.ErrLegacySchema),
+						},
+					)
 				}
-				if closeErr := handle.Close(); closeErr != nil {
-					return nil, fmt.Errorf("close verified process handle for pid %d: %w", pf.Pid, closeErr)
+				// A dead malformed or legacy record can only be quarantined
+				// after the held lock becomes available, so continue polling.
+				pf = nil
+			}
+			if pf != nil {
+				handle, dead, openErr := openRecordedProcess(pf)
+				if openErr != nil {
+					return nil, unverifiableProcessError(
+						"shutdown",
+						recordPath,
+						pf.Pid,
+						openErr,
+						unverifiableProcessChecks{},
+					)
 				}
-				stopped = pf
+				if !dead {
+					if killErr := handle.Kill(); killErr != nil {
+						_ = handle.Close()
+						return nil, fmt.Errorf("kill verified pid %d from %s: %w", pf.Pid, recordPath, killErr)
+					}
+					if closeErr := handle.Close(); closeErr != nil {
+						return nil, fmt.Errorf("close verified process handle for pid %d: %w", pf.Pid, closeErr)
+					}
+					stopped = pf
+				}
 			}
 		}
 
@@ -232,28 +322,37 @@ func stopAndAcquire(
 
 func validateKillRecord(
 	rootDir string,
-	recordPath string,
 	pf *pidfile.PidFile,
 	wantKind string,
-	verifyRoot bool,
+	checks killRecordChecks,
 ) error {
 	if err := pf.ValidateV2(wantKind); err != nil {
-		return unverifiableProcessError("shutdown", recordPath, pf.Pid, err)
+		return err
 	}
-	if !verifyRoot {
+	if !checks.VerifyRoot {
 		return nil
 	}
 	rootID, err := identity.RootID(rootDir)
 	if err != nil {
-		return fmt.Errorf("resolve workspace identity for %s: %w", recordPath, err)
+		return fmt.Errorf("resolve workspace identity: %w", err)
 	}
 	if pf.RootID != rootID {
-		return unverifiableProcessError(
-			"shutdown",
-			recordPath,
-			pf.Pid,
-			fmt.Errorf("root identity mismatch (record has %q, workspace has %q)", pf.RootID, rootID),
-		)
+		return fmt.Errorf("root identity mismatch (record has %q, workspace has %q)", pf.RootID, rootID)
 	}
 	return nil
+}
+
+func classifyInvalidKillRecord(pf *pidfile.PidFile, validationErr error) (dead bool, live bool, err error) {
+	if !isPIDFileValidationError(validationErr) {
+		return false, false, nil
+	}
+	return probeUnverifiablePID(pf.Pid)
+}
+
+func isPIDFileValidationError(err error) bool {
+	return errors.Is(err, pidfile.ErrLegacySchema) ||
+		errors.Is(err, pidfile.ErrBadPid) ||
+		errors.Is(err, pidfile.ErrBadPort) ||
+		errors.Is(err, pidfile.ErrKindMismatch) ||
+		errors.Is(err, pidfile.ErrMissingBirth)
 }

--- a/internal/storage/dbproxy/proxy/unverified_process_darwin.go
+++ b/internal/storage/dbproxy/proxy/unverified_process_darwin.go
@@ -1,0 +1,68 @@
+//go:build darwin
+
+package proxy
+
+import (
+	"errors"
+	"fmt"
+	"os/exec"
+	"strconv"
+	"strings"
+	"syscall"
+
+	"golang.org/x/sys/unix"
+)
+
+// unverifiedProcess identifies a PID whose birth token cannot be verified.
+// Darwin has no pidfd-style primitive, so inspection and signaling keep the
+// historical small PID-reuse race; the workspace-scope check below still
+// narrows what force-stop is willing to signal.
+type unverifiedProcess struct {
+	pid int
+}
+
+// openUnverifiedProcess probes pid. gone reports a PID that no longer exists.
+func openUnverifiedProcess(pid int) (proc *unverifiedProcess, gone bool, err error) {
+	if killErr := syscall.Kill(pid, 0); errors.Is(killErr, unix.ESRCH) {
+		return nil, true, nil
+	}
+	return &unverifiedProcess{pid: pid}, false, nil
+}
+
+func (p *unverifiedProcess) executableBasename() (basename string, gone bool, err error) {
+	return processExecutableBasename(p.pid)
+}
+
+// commandLineContains reports whether the process command line contains
+// needle, read best-effort through ps.
+func (p *unverifiedProcess) commandLineContains(needle string) (matched bool, gone bool, err error) {
+	output, commandErr := exec.Command("ps", "-p", strconv.Itoa(p.pid), "-o", "args=").Output()
+	if commandErr != nil {
+		if killErr := syscall.Kill(p.pid, 0); errors.Is(killErr, unix.ESRCH) {
+			return false, true, nil
+		}
+		return false, false, fmt.Errorf("read command line for pid %d: %w", p.pid, commandErr)
+	}
+	return strings.Contains(strings.TrimSpace(string(output)), needle), false, nil
+}
+
+// kill sends SIGKILL. gone reports a target that had already exited.
+func (p *unverifiedProcess) kill() (gone bool, err error) {
+	if killErr := syscall.Kill(p.pid, syscall.SIGKILL); killErr != nil {
+		if errors.Is(killErr, unix.ESRCH) {
+			return true, nil
+		}
+		return false, fmt.Errorf("signal pid %d: %w", p.pid, killErr)
+	}
+	return false, nil
+}
+
+func (p *unverifiedProcess) exited() (bool, error) {
+	_, gone, err := processExecutableBasename(p.pid)
+	if err != nil {
+		return false, err
+	}
+	return gone, nil
+}
+
+func (p *unverifiedProcess) close() {}

--- a/internal/storage/dbproxy/proxy/unverified_process_linux.go
+++ b/internal/storage/dbproxy/proxy/unverified_process_linux.go
@@ -1,0 +1,102 @@
+//go:build linux
+
+package proxy
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"strconv"
+	"strings"
+	"syscall"
+
+	"golang.org/x/sys/unix"
+)
+
+// unverifiedProcess holds one stable OS reference to a PID whose birth token
+// cannot be verified, so force-stop inspection and signaling act on the same
+// process. A pidfd pins the PID number against reuse for the lifetime of the
+// handle; on kernels without pidfds (pre-5.3) the fallback keeps the
+// historical small PID-reuse race.
+type unverifiedProcess struct {
+	pid   int
+	pidfd int // -1 when the kernel has no pidfd support
+}
+
+// openUnverifiedProcess opens a stable handle for pid. gone reports a PID
+// that no longer exists.
+func openUnverifiedProcess(pid int) (proc *unverifiedProcess, gone bool, err error) {
+	fd, err := unix.PidfdOpen(pid, 0)
+	if err == nil {
+		return &unverifiedProcess{pid: pid, pidfd: fd}, false, nil
+	}
+	if errors.Is(err, unix.ESRCH) {
+		return nil, true, nil
+	}
+	if errors.Is(err, unix.ENOSYS) {
+		return &unverifiedProcess{pid: pid, pidfd: -1}, false, nil
+	}
+	return nil, false, fmt.Errorf("pidfd open %d: %w", pid, err)
+}
+
+func (p *unverifiedProcess) executableBasename() (basename string, gone bool, err error) {
+	return processExecutableBasename(p.pid)
+}
+
+// commandLineContains reports whether the process command line contains
+// needle. The managed proxy child is spawned as "db-proxy-child --root
+// <rootDir>", so a workspace's own processes always match their root path.
+func (p *unverifiedProcess) commandLineContains(needle string) (matched bool, gone bool, err error) {
+	data, err := os.ReadFile("/proc/" + strconv.Itoa(p.pid) + "/cmdline")
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) || errors.Is(err, unix.ESRCH) {
+			return false, true, nil
+		}
+		return false, false, fmt.Errorf("read cmdline for pid %d: %w", p.pid, err)
+	}
+	if len(data) == 0 {
+		// Zombies expose an empty cmdline; the process has effectively exited.
+		return false, true, nil
+	}
+	cmdline := strings.ReplaceAll(strings.TrimRight(string(data), "\x00"), "\x00", " ")
+	return strings.Contains(cmdline, needle), false, nil
+}
+
+// kill sends SIGKILL through the held handle. gone reports a target that had
+// already exited.
+func (p *unverifiedProcess) kill() (gone bool, err error) {
+	if p.pidfd >= 0 {
+		if err := unix.PidfdSendSignal(p.pidfd, unix.SIGKILL, nil, 0); err != nil {
+			if errors.Is(err, unix.ESRCH) {
+				return true, nil
+			}
+			return false, fmt.Errorf("pidfd signal %d: %w", p.pid, err)
+		}
+		return false, nil
+	}
+	if err := syscall.Kill(p.pid, syscall.SIGKILL); err != nil {
+		if errors.Is(err, unix.ESRCH) {
+			return true, nil
+		}
+		return false, fmt.Errorf("signal pid %d: %w", p.pid, err)
+	}
+	return false, nil
+}
+
+// exited reports whether the process is gone (or reduced to a zombie). While
+// the pidfd is held the PID cannot be recycled, so a /proc probe is stable.
+func (p *unverifiedProcess) exited() (bool, error) {
+	_, gone, err := processExecutableBasename(p.pid)
+	if err != nil {
+		return false, err
+	}
+	return gone, nil
+}
+
+func (p *unverifiedProcess) close() {
+	if p.pidfd >= 0 {
+		_ = unix.Close(p.pidfd)
+		p.pidfd = -1
+	}
+}

--- a/internal/storage/dbproxy/proxy/unverified_process_windows.go
+++ b/internal/storage/dbproxy/proxy/unverified_process_windows.go
@@ -1,0 +1,101 @@
+//go:build windows
+
+package proxy
+
+import (
+	"errors"
+	"fmt"
+	"path/filepath"
+	"syscall"
+
+	"golang.org/x/sys/windows"
+)
+
+// windowsStillActive is the GetExitCodeProcess sentinel for a running
+// process (STILL_ACTIVE, 259).
+const windowsStillActive = 259
+
+// unverifiedProcess holds one open process handle so force-stop inspection
+// and signaling act on the same process; an open handle prevents Windows
+// from recycling the PID underneath us.
+type unverifiedProcess struct {
+	pid    int
+	handle windows.Handle
+}
+
+// openUnverifiedProcess opens a stable handle for pid. gone reports a PID
+// that no longer exists or has already terminated.
+func openUnverifiedProcess(pid int) (proc *unverifiedProcess, gone bool, err error) {
+	handle, err := windows.OpenProcess(
+		windows.PROCESS_QUERY_LIMITED_INFORMATION|windows.PROCESS_TERMINATE,
+		false,
+		uint32(pid),
+	)
+	if err != nil {
+		if errors.Is(err, windows.ERROR_INVALID_PARAMETER) {
+			return nil, true, nil
+		}
+		return nil, false, fmt.Errorf("open process %d: %w", pid, err)
+	}
+	exited, err := handleExited(handle)
+	if err != nil {
+		_ = windows.CloseHandle(handle)
+		return nil, false, err
+	}
+	if exited {
+		_ = windows.CloseHandle(handle)
+		return nil, true, nil
+	}
+	return &unverifiedProcess{pid: pid, handle: handle}, false, nil
+}
+
+func (p *unverifiedProcess) executableBasename() (basename string, gone bool, err error) {
+	buffer := make([]uint16, 32768)
+	size := uint32(len(buffer))
+	if err := windows.QueryFullProcessImageName(p.handle, 0, &buffer[0], &size); err != nil {
+		return "", false, fmt.Errorf("query image name for pid %d: %w", p.pid, err)
+	}
+	return filepath.Base(syscall.UTF16ToString(buffer[:size])), false, nil
+}
+
+// commandLineContains cannot establish workspace scope on Windows: another
+// process's command line is only reachable through undocumented PEB reads,
+// so force-stop refuses rather than signaling on basename alone.
+func (p *unverifiedProcess) commandLineContains(string) (matched bool, gone bool, err error) {
+	exited, exitErr := handleExited(p.handle)
+	if exitErr == nil && exited {
+		return false, true, nil
+	}
+	return false, false, errors.New("reading another process's command line is not supported on windows")
+}
+
+// kill terminates the process through the held handle. gone reports a target
+// that had already exited.
+func (p *unverifiedProcess) kill() (gone bool, err error) {
+	if err := windows.TerminateProcess(p.handle, 1); err != nil {
+		if exited, exitErr := handleExited(p.handle); exitErr == nil && exited {
+			return true, nil
+		}
+		return false, fmt.Errorf("terminate pid %d: %w", p.pid, err)
+	}
+	return false, nil
+}
+
+func (p *unverifiedProcess) exited() (bool, error) {
+	return handleExited(p.handle)
+}
+
+func (p *unverifiedProcess) close() {
+	if p.handle != 0 {
+		_ = windows.CloseHandle(p.handle)
+		p.handle = 0
+	}
+}
+
+func handleExited(handle windows.Handle) (bool, error) {
+	var code uint32
+	if err := windows.GetExitCodeProcess(handle, &code); err != nil {
+		return false, fmt.Errorf("get process exit code: %w", err)
+	}
+	return code != windowsStillActive, nil
+}

--- a/internal/storage/dbproxy/server/doltserver.go
+++ b/internal/storage/dbproxy/server/doltserver.go
@@ -22,6 +22,8 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/steveyegge/beads/internal/doltserver"
+	"github.com/steveyegge/beads/internal/procid"
+	"github.com/steveyegge/beads/internal/storage/dbproxy/identity"
 	"github.com/steveyegge/beads/internal/storage/dbproxy/pidfile"
 	"github.com/steveyegge/beads/internal/storage/dbproxy/util"
 	"github.com/steveyegge/beads/internal/storage/versioncontrolops"
@@ -262,10 +264,32 @@ func (s *DoltServer) Start(ctx context.Context) error {
 	}
 
 	s.pid = cmd.Process.Pid
+	birth, err := procid.Capture(s.pid)
+	if err != nil {
+		_ = cmd.Process.Kill()
+		_, _ = cmd.Process.Wait()
+		s.eg, s.egCtx, s.cancel, s.pid = nil, nil, nil, 0
+		cancel()
+		lock.Unlock()
+		return fmt.Errorf("server: DoltServer.Start: capture child birth identity: %w", err)
+	}
+	rootID, err := identity.RootID(s.rootDir)
+	if err != nil {
+		_ = cmd.Process.Kill()
+		_, _ = cmd.Process.Wait()
+		s.eg, s.egCtx, s.cancel, s.pid = nil, nil, nil, 0
+		cancel()
+		lock.Unlock()
+		return fmt.Errorf("server: DoltServer.Start: resolve proxy root identity: %w", err)
+	}
 
 	if err := pidfile.Write(s.rootDir, PIDFileName, pidfile.PidFile{
-		Pid:  s.pid,
-		Port: s.config.Port(),
+		Pid:    s.pid,
+		Port:   s.config.Port(),
+		Schema: pidfile.SchemaV2,
+		Kind:   pidfile.KindDoltBackend,
+		Birth:  string(birth),
+		RootID: rootID,
 	}); err != nil {
 		_ = cmd.Process.Kill()
 		_, _ = cmd.Process.Wait()

--- a/internal/storage/dbproxy/server/doltserver_test.go
+++ b/internal/storage/dbproxy/server/doltserver_test.go
@@ -17,6 +17,8 @@ import (
 
 	mysqldrv "github.com/go-sql-driver/mysql"
 	"github.com/steveyegge/beads/internal/lockfile"
+	"github.com/steveyegge/beads/internal/procid"
+	"github.com/steveyegge/beads/internal/storage/dbproxy/pidfile"
 	"github.com/steveyegge/beads/internal/storage/dbproxy/server"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -157,12 +159,19 @@ func TestDoltServer_DSN(t *testing.T) {
 }
 
 func TestDoltServer_StartStop_HappyPath(t *testing.T) {
-	s, _ := newDoltServer(t)
+	s, rootDir := newDoltServer(t)
 	ctx := context.Background()
 
 	require.NoError(t, s.Start(ctx))
 	t.Cleanup(func() { stopWithTimeout(t, s) })
 	assert.True(t, s.Running(ctx))
+	pf, err := pidfile.Read(rootDir, server.PIDFileName)
+	require.NoError(t, err)
+	require.NotNil(t, pf)
+	require.NoError(t, pf.ValidateV2(pidfile.KindDoltBackend))
+	match, err := procid.Verify(pf.Pid, procid.Token(pf.Birth))
+	require.NoError(t, err)
+	assert.True(t, match)
 
 	db, err := sql.Open("mysql", s.DSN(ctx, "", "root", ""))
 	require.NoError(t, err)


### PR DESCRIPTION
## Why

Managed proxied-server mode currently trusts anything that answers a TCP dial: endpoint
discovery adopts any listener on the pidfile's loopback port with no identity check, stale
cleanup and `bd dolt stop` kill whatever process currently holds a recorded PID, the
pick-then-launch port allocation has a bind race, and a SIGKILLed proxy supervisor leaves an
orphan `dolt sql-server` that cleanup never inspects (its lock was held by the supervisor,
not the child). On a workstation these are wrong-database and kill-the-wrong-process
hazards; they block treating managed-local proxied mode as production-ready
(local-first readiness campaign; related upstream context: #2764).

## What

Five commits, staged to review in order:

1. **`internal/procid`** — versioned process-birth tokens (Linux `boot_id`+starttime,
   Windows creation FILETIME, Darwin `p_starttime`) with TOCTOU-safe signaling handles
   (pidfd on Linux, re-verified process handle on Windows). The `Token`/`Verify` shape
   deliberately matches what #4513 asks `internal/doltserver` to expose, so it can be
   adopted there later; this PR intentionally does not touch doltserver.
2. **Identity publication** — pidfile schema v2 (additive: `schema`, `kind`, `birth`,
   `root_id`, `control_port`), a per-start rotated 0600 `proxy.secret`, and a loopback
   IDENT control listener; a proxy/backend that cannot prove its own identity fails
   startup instead of publishing.
3. **Verified adoption and fail-closed cleanup** — typed adoption statuses (adoption
   requires v2 record + live birth match + authenticated handshake + root/pid/birth/port
   cross-checks), quarantine-by-rename instead of deletion, handle-only kills, orphan
   backend reaping regardless of child-lock state, and a spawn-marker/stop-epoch fix so
   `bd dolt stop` cannot report success while a mid-flight start publishes a listener.
4. **Cross-review hardening** — fixes from two independent adversarial reviews (details
   below), including a fail-open (a `boot_id` read failure classified live processes as
   dead) and restoring self-healing for provably-dead records so fail-closed does not
   become fail-wedged.
5. **`bd dolt stop --force` + end-to-end lane** — a narrowly-scoped operator escape that
   verifies executable identity before signaling and quarantines after, plus six new
   managed-local lifecycle tests (`BEADS_TEST_PROXIED_LOCAL=1`) against a real
   `dolt sql-server`.

## Behavior changes to note

- Records written by older versions (schema v1) are never dial-adopted. Dead-pid legacy
  records self-heal via quarantine; a *live* pre-upgrade proxy is refused with an
  actionable error, and `bd dolt stop --force` is the supported way to retire it.
- `IsRunning`-style discovery now reports false for a running-but-unverifiable proxy;
  the lock probe still backs up migration checks.
- Proxied roots gain two files: `proxy.secret` (rotated each start, purged by
  mode-migration cleanup) and, transiently, `*.stale-*` quarantine records (30-day sweep).

## Testing

- Full `internal/storage/dbproxy/...` + `internal/procid/...` suites, with `-race`, green.
- Managed-local lane against real dolt (all green, Linux): foreign-listener rejection,
  reused-PID never killed, legacy fail-closed (free lock / held-lock refusal of a foreign
  executable / held-lock `--force` of a genuine bd), orphan-backend reaping after
  supervisor SIGKILL, 5-process cold-start convergence, stop/start interleave.
- Darwin/Windows: cross-compile + compile-only test verification; lane equivalents are
  defined in the lane header and staged for follow-up. A macOS test run before merge would
  be welcome — the darwin procid path had two review-caught bugs, now fixed and unit-tested,
  but no macOS CI exists on PRs.

## Review provenance and follow-ups

The branch was adversarially reviewed pre-submission by two independent model reviewers
(structured findings, all fixed in commit 4; write-ups available on request). Known
follow-ups deliberately out of scope: proxy data-listener port-0 allocation and
comprehensive managed listener-host policy (next PR), and dolt-backend port-collision
recovery, which needs a config-ownership contract first (will arrive as an RFC issue).
Relationship to open issues: #4513 (procid is the requested primitive, adoptable by
doltserver later), #4637 (same disease class on the shared-server connect path — not
addressed here; the dbproxy-side handshake pattern may transfer).

_claude-fable-5-high on behalf of maphew_

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WZHiYc3wjcdy1wrUP2JiQi
