### PR TITLE
fix(beads): allow /var/tmp in repo-context safety boundary

### DIFF
--- a/internal/beads/context.go
+++ b/internal/beads/context.go
@@ -315,8 +315,9 @@ func isPathInSafeBoundary(path string) bool {
 	// escapes the boundary must be rejected, not followed into a system
 	// directory — same treatment as the /Users/Shared carve-out below
 	// (be-kghzr SEC-003 hardening).
-	tempDir := strings.TrimSuffix(os.TempDir(), "/")
-	if absPath == tempDir || strings.HasPrefix(absPath, tempDir+"/") {
+	tempDir := filepath.Clean(os.TempDir())
+	physicalTempDir := resolveLongestExistingAncestor(tempDir)
+	if pathWithinTempRoots(absPath, tempDir, physicalTempDir) {
 		return resolvedPathWithinRoot(absPath, tempDir)
 	}
 
@@ -405,6 +406,24 @@ func resolveLongestExistingAncestor(path string) string {
 		remainder = filepath.Join(filepath.Base(cur), remainder)
 		cur = parent
 	}
+}
+
+// pathWithinRoot performs a syntactic, path-boundary-aware containment check.
+// Both paths are cleaned first so sibling prefixes and ".." components cannot
+// make an unrelated path appear to be within root.
+func pathWithinRoot(path, root string) bool {
+	path = filepath.Clean(path)
+	root = filepath.Clean(root)
+	return path == root || strings.HasPrefix(path, root+string(filepath.Separator))
+}
+
+// pathWithinTempRoots gates the OS temp-directory carve-out for both forms seen
+// on macOS: the lexical /var/folders form returned by os.TempDir and the
+// canonical /private/var/folders form produced by symlink resolution. This is
+// only the syntactic gate; resolvedPathWithinRoot makes the final, symlink-safe
+// containment decision.
+func pathWithinTempRoots(path, lexicalRoot, physicalRoot string) bool {
+	return pathWithinRoot(path, lexicalRoot) || pathWithinRoot(path, physicalRoot)
 }
 
 // resolvedPathWithinRoot reports whether absPath, after symlink resolution, still

--- a/internal/beads/context.go
+++ b/internal/beads/context.go
@@ -327,6 +327,18 @@ func isPathInSafeBoundary(path string) bool {
 		return true
 	}
 
+	// Allow /var/tmp as the FHS-standard secondary temp directory (persists across
+	// reboots, unlike /tmp). This is distinct from the os.TempDir() carve-out
+	// above: a machine's build tooling can set GOTMPDIR to redirect Go's own
+	// test/compile temp dirs under /var/tmp even while os.TempDir() itself still
+	// reports /tmp, so t.TempDir() in a test binary can land here without the
+	// os.TempDir() check ever seeing it (be-odye4). Like /Users/Shared, /var/tmp is
+	// world-writable (drwxrwxrwt), so resolve symlinks before admitting (SEC-003):
+	// a symlink planted under it must not be followed into a rejected directory.
+	if absPath == "/var/tmp" || strings.HasPrefix(absPath, "/var/tmp/") {
+		return resolvedPathWithinRoot(absPath, "/var/tmp")
+	}
+
 	for _, prefix := range unsafePrefixes {
 		if strings.HasPrefix(absPath, prefix+"/") || absPath == prefix {
 			return false

--- a/internal/beads/context_test.go
+++ b/internal/beads/context_test.go
@@ -385,6 +385,15 @@ func TestIsPathInSafeBoundary(t *testing.T) {
 		// user's home — it must be accepted (be-vc1 / SEC-003 carve-out).
 		{"macOS shared subdir", "/Users/Shared/portharbour/.beads", true},
 		{"macOS shared root", "/Users/Shared", true},
+
+		// /var/tmp is the FHS-standard secondary temp directory (persists across
+		// reboots, unlike /tmp) and must be accepted despite matching the /var
+		// unsafePrefixes entry above. Go's own test/build tooling can root
+		// GOTMPDIR-influenced temp dirs here even when os.TempDir() itself still
+		// reports /tmp, so the os.TempDir()-based carve-out above doesn't cover it
+		// (be-odye4).
+		{"var/tmp root", "/var/tmp", true},
+		{"var/tmp GOTMPDIR-style subdir", "/var/tmp/gotmp/TestSomething1234/001/.beads", true},
 	}
 
 	for _, tt := range tests {
@@ -476,6 +485,37 @@ func TestIsPathInSafeBoundary_SharedSymlinkEscape(t *testing.T) {
 	// The escaping symlink itself also resolves outside the boundary.
 	if isPathInSafeBoundary(link) {
 		t.Errorf("isPathInSafeBoundary(%q) = true, want false (symlink under /Users/Shared escaping to /etc)", link)
+	}
+}
+
+// TestIsPathInSafeBoundary_VarTmpSymlinkEscape proves the /var/tmp carve-out
+// (be-odye4) applies the same symlink-safe resolution as /Users/Shared: /var/tmp
+// is world-writable (drwxrwxrwt) on Linux/BSD, so a co-located user could plant a
+// symlink under it whose target escapes to a rejected system directory. Skipped
+// when /var/tmp is absent or not writable, so it never fails spuriously.
+func TestIsPathInSafeBoundary_VarTmpSymlinkEscape(t *testing.T) {
+	const varTmp = "/var/tmp"
+	if info, err := os.Stat(varTmp); err != nil || !info.IsDir() {
+		t.Skipf("%s not present as a directory: %v", varTmp, err)
+	}
+
+	link := filepath.Join(varTmp, fmt.Sprintf(".be-odye4-escape-test-%d", os.Getpid()))
+	_ = os.Remove(link)
+	if err := os.Symlink("/etc", link); err != nil {
+		t.Skipf("cannot create symlink in %s (not writable?): %v", varTmp, err)
+	}
+	t.Cleanup(func() { _ = os.Remove(link) })
+
+	// A BEADS_DIR routed *through* the escaping symlink must be rejected: its bytes
+	// resolve into /etc, outside /var/tmp.
+	target := filepath.Join(link, ".beads")
+	if isPathInSafeBoundary(target) {
+		t.Errorf("isPathInSafeBoundary(%q) = true, want false (path through symlink escaping /var/tmp to /etc)", target)
+	}
+
+	// The escaping symlink itself also resolves outside the boundary.
+	if isPathInSafeBoundary(link) {
+		t.Errorf("isPathInSafeBoundary(%q) = true, want false (symlink under /var/tmp escaping to /etc)", link)
 	}
 }
 

--- a/internal/beads/context_test.go
+++ b/internal/beads/context_test.go
@@ -556,6 +556,38 @@ func TestIsPathInSafeBoundary_TempDirSymlinkEscape(t *testing.T) {
 	}
 }
 
+// TestPathWithinTempRoots_PhysicalForm exercises the macOS lexical-to-physical
+// temp-root shape without depending on the host OS. In particular, the path
+// boundary cases ensure a sibling that merely shares a string prefix is not
+// admitted by either side of the gate.
+func TestPathWithinTempRoots_PhysicalForm(t *testing.T) {
+	lexicalRoot := filepath.FromSlash("/var/folders/xy/T")
+	physicalRoot := filepath.FromSlash("/private/var/folders/xy/T")
+
+	tests := []struct {
+		name string
+		path string
+		want bool
+	}{
+		{"lexical root", lexicalRoot, true},
+		{"lexical child", filepath.Join(lexicalRoot, "repo", ".beads"), true},
+		{"physical root", physicalRoot, true},
+		{"physical child", filepath.Join(physicalRoot, "repo", ".beads"), true},
+		{"lexical prefix sibling", lexicalRoot + "-other", false},
+		{"physical prefix sibling", physicalRoot + "-other", false},
+		{"physical parent sibling", filepath.Join(physicalRoot, "..", "other"), false},
+		{"unrelated denied path", filepath.FromSlash("/private/etc/.beads"), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := pathWithinTempRoots(tt.path, lexicalRoot, physicalRoot); got != tt.want {
+				t.Errorf("pathWithinTempRoots(%q, %q, %q) = %v, want %v", tt.path, lexicalRoot, physicalRoot, got, tt.want)
+			}
+		})
+	}
+}
+
 // TestIsPathInSafeBoundary_TempDirPhysicalForm covers the macOS shape where
 // $TMPDIR is itself a symlink (/var/folders/... -> /private/var/...): a
 // caller-supplied path that has already been symlink-resolved arrives in the


### PR DESCRIPTION
## Problem

`isPathInSafeBoundary()` rejected any beads directory located under `/var/tmp`. On systems where Go's build tooling sets `GOTMPDIR=/var/tmp/...` for build-like subcommands, `t.TempDir()` roots test temp dirs under `GOTMPDIR` even though `os.TempDir()` itself still reports `/tmp`. That left the existing `os.TempDir()`-based carve-out unable to match, so any repo context resolved under a fresh `t.TempDir()` on such a system tripped the "unsafe location" check.

## Fix

Add a `/var/tmp` carve-out using the same symlink-safe resolution already used for the existing `/Users/Shared` carve-out, since `/var/tmp` is equally world-writable (`drwxrwxrwt`). This is a general FHS-standard fix (`/var/tmp` is the standard secondary temp directory that persists across reboots), not specific to any one environment.

## Testing

- Two table-test cases cover the `/var/tmp` root and a `GOTMPDIR`-style subdirectory.
- `TestIsPathInSafeBoundary_VarTmpSymlinkEscape` proves the carve-out rejects a symlink planted under `/var/tmp` that escapes to a disallowed directory. It skips gracefully when `/var/tmp` is absent or unwritable.
- `CGO_ENABLED=0 go test -tags gms_pure_go ./internal/beads -count=1`

## Current branch state

#5047 landed the separate macOS physical-temp-root fix on `main`. Merge commit `98051992f` takes that production form and removes the duplicate maintainer helper implementation from this branch. The effective diff against `main` is therefore back to this PR's original approved `/var/tmp` scope, with the contributor commit and tests intact.
