### PR TITLE
fix(beads): make the temp-directory safety-boundary check symlink-safe

### DIFF
--- a/internal/beads/context.go
+++ b/internal/beads/context.go
@@ -309,17 +309,15 @@ func isPathInSafeBoundary(path string) bool {
 		return false
 	}
 
-	// Allow OS-designated temp directories (e.g., /var/folders on macOS)
-	// On macOS, TempDir() returns paths under /var/folders which symlinks to /private/var/folders
-	tempDir := os.TempDir()
-	resolvedTemp, _ := filepath.EvalSymlinks(tempDir)
-	resolvedPath, _ := filepath.EvalSymlinks(absPath)
-	if resolvedTemp != "" && strings.HasPrefix(resolvedPath, resolvedTemp) {
-		return true
-	}
-	// Also check unresolved paths (in case symlink resolution fails)
-	if strings.HasPrefix(absPath, tempDir) {
-		return true
+	// Allow OS-designated temp directories (e.g., /var/folders on macOS, which
+	// symlinks to /private/var/folders). World-writable, so resolve symlinks
+	// before admitting: a symlink planted under the temp dir whose target
+	// escapes the boundary must be rejected, not followed into a system
+	// directory — same treatment as the /Users/Shared carve-out below
+	// (be-kghzr SEC-003 hardening).
+	tempDir := strings.TrimSuffix(os.TempDir(), "/")
+	if absPath == tempDir || strings.HasPrefix(absPath, tempDir+"/") {
+		return resolvedPathWithinRoot(absPath, tempDir)
 	}
 
 	// Allow /var/home as a valid user home directory (Fedora Silverblue, Bluefin, etc.)

--- a/internal/beads/context_test.go
+++ b/internal/beads/context_test.go
@@ -376,6 +376,11 @@ func TestIsPathInSafeBoundary(t *testing.T) {
 		// Safe paths - should be accepted
 		{"user home directory", filepath.Join(homeDir, "projects/.beads"), true},
 		{"temp directory", os.TempDir(), true},
+		// A not-yet-created BEADS_DIR under the temp dir (the common real case --
+		// the directory is created after this check passes) must still validate;
+		// resolveLongestExistingAncestor is what makes this safe despite the
+		// trailing components not existing yet (be-kghzr SEC-003 hardening).
+		{"temp directory not-yet-created subpath", filepath.Join(os.TempDir(), "be-kghzr-nonexistent-subpath", ".beads"), true},
 
 		// Another user's home directory - should be rejected regardless of $HOME
 		{"other user home /home", "/home/some-other-nonexistent-user/.beads", false},
@@ -476,6 +481,38 @@ func TestIsPathInSafeBoundary_SharedSymlinkEscape(t *testing.T) {
 	// The escaping symlink itself also resolves outside the boundary.
 	if isPathInSafeBoundary(link) {
 		t.Errorf("isPathInSafeBoundary(%q) = true, want false (symlink under /Users/Shared escaping to /etc)", link)
+	}
+}
+
+// TestIsPathInSafeBoundary_TempDirSymlinkEscape mirrors
+// TestIsPathInSafeBoundary_SharedSymlinkEscape for the os.TempDir() carve-out
+// (be-kghzr SEC-003 hardening). Unlike /Users/Shared, os.TempDir() is
+// cross-platform and always present, so this test is not OS-gated.
+func TestIsPathInSafeBoundary_TempDirSymlinkEscape(t *testing.T) {
+	tempDir := os.TempDir()
+
+	// Plant a symlink under the world-writable OS temp dir pointing OUTSIDE the
+	// boundary, at /etc (a system dir). Best-effort clear of any stale link from a
+	// crashed run, then register cleanup.
+	link := filepath.Join(tempDir, fmt.Sprintf(".be-kghzr-escape-test-%d", os.Getpid()))
+	_ = os.Remove(link)
+	if err := os.Symlink("/etc", link); err != nil {
+		t.Skipf("cannot create symlink in %s (not writable?): %v", tempDir, err)
+	}
+	t.Cleanup(func() { _ = os.Remove(link) })
+
+	// A BEADS_DIR routed *through* the escaping symlink must be rejected: its bytes
+	// resolve into /etc, outside the temp dir. The trailing ".beads" component does
+	// NOT exist, so a bare filepath.EvalSymlinks(absPath) fails on the full path --
+	// this is the exact shape that tripped the old unresolved-path fallback.
+	target := filepath.Join(link, ".beads")
+	if isPathInSafeBoundary(target) {
+		t.Errorf("isPathInSafeBoundary(%q) = true, want false (path through symlink escaping temp dir to /etc)", target)
+	}
+
+	// The escaping symlink itself also resolves outside the boundary.
+	if isPathInSafeBoundary(link) {
+		t.Errorf("isPathInSafeBoundary(%q) = true, want false (symlink under temp dir escaping to /etc)", link)
 	}
 }
 


### PR DESCRIPTION
## What changed

Hardens the OS temp-directory allowance in the repo-context safety-boundary check (`isPathInSafeBoundary`) so it can no longer be fooled by a symlink.

## Why

The temp directory (`/tmp` and equivalents) is world-writable, so any co-located local user can plant a symlink there. The old check tried to resolve symlinks first, but `filepath.EvalSymlinks` fails outright whenever the last path component doesn't exist yet — which is the normal case for a directory that's about to be created. When resolution failed, the code fell back to a raw prefix check on the *unresolved* path, with no symlink protection at all. A symlink planted under the temp dir pointing somewhere sensitive would sail through that fallback.

This is the same class of gap already closed for the `/Users/Shared` and `/var/tmp` carve-outs elsewhere in this function — the temp-dir check was the one remaining spot still using the weaker pattern.

## What to look at

The two-branch check collapses into a single call to the existing `resolvedPathWithinRoot` helper, which walks up to the longest existing ancestor, resolves symlinks there, and rejoins the non-existent remainder. That's safe for both symlink escapes and the common case of a not-yet-created path.

One thing worth double-checking in review: this returns the helper's result unconditionally once a path syntactically looks like it's under the temp dir, rather than falling through to later checks on a mismatch. That's deliberate — unlike `/Users/Shared` and `/var/tmp`, nothing later in the function covers the temp dir, so falling through on a failed check would silently readmit the escape via the function's fail-open default.

## How we know it works

Added a test that plants a real symlink under the temp dir pointing at `/etc` and confirms both the symlink itself and a not-yet-existent path routed through it are rejected. Also added a table case confirming a legitimate not-yet-created subdirectory under the temp dir still validates correctly. Full existing suite still passes; the only failures present are a pre-existing, unrelated sandbox/environment condition (confirmed identical on `main` before this change).

## Heads up for reviewers

PR #5028 touches this same function (adjacent, non-overlapping carve-out blocks) — no semantic conflict between the two, but landing order may be worth coordinating to avoid a needless textual merge conflict.
