### PR TITLE
ci(dependabot): group version bumps per ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,18 @@ updates:
     labels:
       - "dependencies"
       - "go"
+    # Group minor/patch Go bumps into a single PR. Every gomod bump rewrites
+    # go.sum, which invalidates the nix vendorHash in default.nix; N singleton
+    # PRs mean N vendorHash bot-commits and N '@dependabot recreate' rounds
+    # after each merge (see update-vendor-hash.yml caveat). One grouped PR
+    # gets one bot-computed hash. Majors stay separate so a breaking bump
+    # cannot block the routine group.
+    groups:
+      go-deps:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"
 
   # GitHub Actions
   - package-ecosystem: "github-actions"
@@ -19,6 +31,11 @@ updates:
     labels:
       - "dependencies"
       - "ci"
+    groups:
+      actions:
+        applies-to: version-updates
+        patterns:
+          - "*"
 
   # Python (beads-mcp)
   - package-ecosystem: "uv"
@@ -30,3 +47,8 @@ updates:
       - "dependencies"
       - "python"
       - "mcp"
+    groups:
+      beads-mcp-python:
+        applies-to: version-updates
+        patterns:
+          - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,11 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 5
+    # Headroom above the group count: grouped PRs count as one, but SemVer-major
+    # singles plus the testcontainers group plus a migration window with old
+    # singleton PRs still open must not wedge at the limit (dependabot opens no
+    # new version PR while the limit is saturated).
+    open-pull-requests-limit: 10
     labels:
       - "dependencies"
       - "go"
@@ -13,11 +17,24 @@ updates:
     # go.sum, which invalidates the nix vendorHash in default.nix; N singleton
     # PRs mean N vendorHash bot-commits and N '@dependabot recreate' rounds
     # after each merge (see update-vendor-hash.yml caveat). One grouped PR
-    # gets one bot-computed hash. Majors stay separate so a breaking bump
-    # cannot block the routine group.
+    # gets one bot-computed hash. SemVer-majors stay separate so they cannot
+    # block the routine group (note: pre-1.0 modules ship breaking changes as
+    # "minor" bumps, which do ride in the group — dependabot classifies by
+    # version arithmetic only).
+    #
+    # testcontainers-go and its modules/dolt child must bump in lockstep
+    # (the module requires a matching root), and the project pins 0.x
+    # releases with routine breaking changes — so they get their own group:
+    # always coupled together, never blocking go-deps.
     groups:
+      testcontainers:
+        applies-to: version-updates
+        patterns:
+          - "github.com/testcontainers/testcontainers-go*"
       go-deps:
         applies-to: version-updates
+        exclude-patterns:
+          - "github.com/testcontainers/testcontainers-go*"
         update-types:
           - "minor"
           - "patch"


### PR DESCRIPTION
## Why

Dependabot currently opens one PR per bump. For Go modules that shape is actively expensive here: every gomod bump rewrites `go.sum`, which invalidates the nix `vendorHash` in `default.nix`. The `update-vendor-hash` workflow then pushes a bot commit to each PR, after which dependabot refuses plain rebases ("edited by someone other than Dependabot") — so each merge forces `@dependabot recreate` plus a fresh CI cycle on every remaining single. Yesterday's batch (five gomod PRs: #5017, #5018, #5020, #5021, plus #4702 which has been stuck in this loop since July 10) is the live example.

## What

Add dependabot `groups` per ecosystem:

- **gomod / `go-deps`**: minor + patch version bumps land as one grouped PR — one bot-computed vendorHash, one CI cycle. SemVer-majors stay ungrouped so they can't block the routine group. (Caveat: dependabot classifies by version arithmetic only, so pre-1.0 modules that break in "minor" bumps still ride the group — except the one we know does, below.)
- **gomod / `testcontainers`**: `testcontainers-go` and its `modules/dolt` child must bump in lockstep and routinely break in 0.x minors, so they get their own group — always coupled together, never blocking `go-deps`.
- **gomod limit 5 → 10**: the five open singles exactly saturate the old limit, and dependabot opens no new version PR while the limit is saturated — the grouped PR could be wedged out during migration.
- **github-actions**: all version bumps grouped (low-risk pinned-action bumps like #5015/#5016/#5019).
- **uv (beads-mcp)**: all version bumps grouped (dev deps like #5022/#5023).

Security updates deliberately stay singleton (`applies-to: version-updates` everywhere): urgent, individually reviewable, and not counted against the version-PR limit.

## Migration of the open singles

When this lands, dependabot re-checks the changed ecosystems. Expected outcome is grouped PRs superseding #4702/#5017/#5018/#5020/#5021, but auto-close of existing version singles is not documented as guaranteed — so the plan is: verify the grouped go PRs appear (Insights → Dependency graph → Dependabot → "Check for updates" if needed), then manually close any singles dependabot leaves open. #4702 carries non-dependabot commits and is the most likely to need a manual close. Tracked in the maintainer queue (mybd-ysu1).

## Review

Independently reviewed pre-merge by two model families: claude-opus-tier reviewer (approve, doc nits) and codex gpt-5.6-sol (fix-first). Both fix-first findings — testcontainers isolation and the PR-limit saturation — are incorporated in the second commit.

_claude-fable-5-high on behalf of matt wilkie_
