### PR TITLE
test: fix red main — init-cancel E2E deadline + reclaim JSON assertion

### DIFF
--- a/cmd/bd/init_cancel_e2e_test.go
+++ b/cmd/bd/init_cancel_e2e_test.go
@@ -106,7 +106,11 @@ func TestInitCancel_E2E(t *testing.T) {
 		}
 	case err := <-waitCh:
 		t.Fatalf("bd init exited before prompt: %v\nOutput: %s", err, getOutput())
-	case <-time.After(5 * time.Second):
+	// This deadline guards against a hung init, not startup speed: before the
+	// wizard prints anything, bd init creates the embedded dolt store, which
+	// under the nightly full-suite -race load takes ~5s on CI runners and grew
+	// past the old 5s limit (4.71s -> 4.92s -> 5.02s across 2026-07-23..25).
+	case <-time.After(60 * time.Second):
 		_ = cmd.Process.Kill()
 		err := <-waitCh
 		t.Fatalf("timeout waiting for prompt (exit=%v)\nOutput: %s", err, getOutput())

--- a/cmd/bd/protocol/lease_claim_test.go
+++ b/cmd/bd/protocol/lease_claim_test.go
@@ -12,6 +12,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -388,7 +389,7 @@ func TestProtocol_GrantingReplicaRoundTripsJSONL(t *testing.T) {
 	if err != nil {
 		t.Fatalf("reclaim on laptop: %v\n%s", err, reclaimOut)
 	}
-	if strings.Contains(reclaimOut, leased) {
+	if slices.Contains(reclaimedIDs(t, reclaimOut), leased) {
 		t.Errorf("laptop reclaimed a lease granted by mini:\n%s", reclaimOut)
 	}
 	if after := fresh.showJSON(leased); after["status"] != "in_progress" {
@@ -403,13 +404,41 @@ func TestProtocol_GrantingReplicaRoundTripsJSONL(t *testing.T) {
 	if err != nil {
 		t.Fatalf("reclaim --any-replica on laptop: %v\n%s", err, overrideOut)
 	}
-	if !strings.Contains(overrideOut, leased) {
+	if !slices.Contains(reclaimedIDs(t, overrideOut), leased) {
 		t.Errorf("--any-replica did not reclaim the foreign stale lease:\n%s", overrideOut)
 	}
 	if after := fresh.showJSON(leased); after["status"] != "open" || after["assignee"] != nil {
 		t.Errorf("after --any-replica reclaim: status=%v assignee=%v, want open/unassigned",
 			after["status"], after["assignee"])
 	}
+}
+
+// reclaimedIDs extracts the reclaimed issue ids from a `reclaim --json`
+// invocation captured with CombinedOutput. The replica-guard audit lines on
+// stderr name the skipped issue id too (warnReplica), so a raw
+// strings.Contains on the combined stream reads a correctly-declined reclaim
+// as a reclamation. Only the JSON payload on stdout is the machine truth;
+// decode exactly one JSON value starting at the first brace so audit lines on
+// either side of it are ignored.
+func reclaimedIDs(t *testing.T, out string) []string {
+	t.Helper()
+	start := strings.Index(out, "{")
+	if start < 0 {
+		t.Fatalf("no JSON object in reclaim output:\n%s", out)
+	}
+	var payload struct {
+		Reclaimed []struct {
+			ID string `json:"id"`
+		} `json:"reclaimed"`
+	}
+	if err := json.NewDecoder(strings.NewReader(out[start:])).Decode(&payload); err != nil {
+		t.Fatalf("parse reclaim JSON: %v\n%s", err, out)
+	}
+	ids := make([]string, 0, len(payload.Reclaimed))
+	for _, r := range payload.Reclaimed {
+		ids = append(ids, r.ID)
+	}
+	return ids
 }
 
 // ageLeaseInExport rewrites id's record in a JSONL export so its lease reads as


### PR DESCRIPTION
## Why

This PR is the fix for red CI on `main` — it now carries **two** independent test-only fixes, both for tests that fail while the product behavior is correct.

### 1. Nightly: `TestInitCancel_E2E` deadline exhaustion

Nightly Full Tests went red overnight (run 30141630769, both attempts) on "timeout waiting for prompt" with empty output after exactly 5.02s.

- The test's 5s deadline races `bd init --contributor` startup: the embedded-dolt store is created **before** the wizard prints its first byte, so slow startup looks like "no prompt, no output".
- Nightly timings show margin exhaustion, not a flake or regression: **4.71s** (07-23, pass) → **4.92s** (07-24, pass) → **5.02s** (07-25, killed). The rerun failed identically; in isolation with the same flags the test passes in ~1.2s.
- Fix: widen the deadline to 60s. It guards against a *hung* init, not startup speed; 60s still fails fast against the suite's 30-minute timeout.

### 2. Contract corpus: `TestProtocol_GrantingReplicaRoundTripsJSONL` false positive

This PR's first CI run surfaced a second red: the new wy-jpd3.7 replica-guard test fails deterministically on its first Contract corpus outing — with the guard visibly *working* (`"count": 0`, `"reclaimed": null`, status kept).

- The test asserts non-reclamation via `strings.Contains(reclaimOut, leased)`, but `tryRunEnv` captures **CombinedOutput**, and `warnReplica`'s stderr audit line ("reclaim: skipping `<id>` …") names the very id being asserted absent.
- Fix: parse the reclaimed ids out of the JSON payload (stdout is the machine truth — `warnReplica` deliberately keeps audit lines off stdout) and use the same helper for the `--any-replica` positive assertion, which was passing only incidentally.
- Fails before / passes after: `go test -tags gms_pure_go -run TestProtocol_GrantingReplicaRoundTripsJSONL ./cmd/bd/protocol`

## Validation

Both tests pass locally with their CI flags. Note per-PR CI does not exercise the integration-tagged init test; the authoritative re-check for that half is a `workflow_dispatch` nightly (`full-test`) after merge, which I'll trigger. The Contract corpus job on this PR exercises the second fix directly.

_claude-fable-5-high on behalf of matt wilkie_
