### PR TITLE
fix(test): assert reclaim result from stdout JSON, not combined output

### DIFF
--- a/cmd/bd/protocol/lease_claim_test.go
+++ b/cmd/bd/protocol/lease_claim_test.go
@@ -382,14 +382,28 @@ func TestProtocol_GrantingReplicaRoundTripsJSONL(t *testing.T) {
 	}
 
 	// The laptop's reaper must decline this stale lease: mini granted it, and
-	// the laptop's view of alice's liveness is a full sync interval old.
-	reclaimOut, err := fresh.tryRunEnv([]string{"BEADS_NODE_ID=laptop"},
+	// the laptop's view of alice's liveness is a full sync interval old. The
+	// guard also writes a stderr audit line naming the skipped issue (that is
+	// the whole point of the audit line), so the assertion must read the
+	// --json result from stdout alone rather than combined output, or it
+	// would trip on the very audit line proving the guard worked.
+	reclaimStdout, reclaimStderr, err := fresh.tryRunEnvSplit([]string{"BEADS_NODE_ID=laptop"},
 		"reclaim", "--older-than", "0s", "--json")
 	if err != nil {
-		t.Fatalf("reclaim on laptop: %v\n%s", err, reclaimOut)
+		t.Fatalf("reclaim on laptop: %v\nstdout:\n%s\nstderr:\n%s", err, reclaimStdout, reclaimStderr)
 	}
-	if strings.Contains(reclaimOut, leased) {
-		t.Errorf("laptop reclaimed a lease granted by mini:\n%s", reclaimOut)
+	// reclaimStderr carries the replica guard's audit line naming leased —
+	// expected, and irrelevant to this assertion, which reads stdout only.
+	reclaimResult := parseJSONOutput(t, reclaimStdout)[0]
+	if got := reclaimResult["count"]; got != float64(0) {
+		t.Errorf("laptop reclaimed %v lease(s), want 0:\n%s", got, reclaimStdout)
+	}
+	if reclaimedList, ok := reclaimResult["reclaimed"].([]any); ok {
+		for _, r := range reclaimedList {
+			if row, ok := r.(map[string]any); ok && row["id"] == leased {
+				t.Errorf("laptop reclaimed a lease granted by mini:\n%s", reclaimStdout)
+			}
+		}
 	}
 	if after := fresh.showJSON(leased); after["status"] != "in_progress" {
 		t.Fatalf("issue status = %v after a declined reclaim, want in_progress", after["status"])

--- a/cmd/bd/protocol/wp4_helpers_test.go
+++ b/cmd/bd/protocol/wp4_helpers_test.go
@@ -17,6 +17,7 @@
 package protocol
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"os"
@@ -61,6 +62,22 @@ func (w *workspace) tryRunEnv(extraEnv []string, args ...string) (string, error)
 	cmd := w.command(extraEnv, args...)
 	out, err := cmd.CombinedOutput()
 	return string(out), err
+}
+
+// tryRunEnvSplit runs bd with extra environment appended, like tryRunEnv, but
+// captures stdout and stderr separately instead of folding them into one
+// stream. Some commands (e.g. `reclaim`) write a human-audit line to stderr
+// that legitimately names an issue ID a --json result on stdout correctly
+// omits (the audit line reports *why* the guard skipped it), so an assertion
+// that needs the machine-readable result alone must not use CombinedOutput.
+func (w *workspace) tryRunEnvSplit(extraEnv []string, args ...string) (stdout, stderr string, err error) {
+	w.t.Helper()
+	cmd := w.command(extraEnv, args...)
+	var outBuf, errBuf bytes.Buffer
+	cmd.Stdout = &outBuf
+	cmd.Stderr = &errBuf
+	err = cmd.Run()
+	return outBuf.String(), errBuf.String(), err
 }
 
 // runEnvExpectError runs bd with extra environment appended, expecting a


### PR DESCRIPTION
## Why

`TestProtocol_GrantingReplicaRoundTripsJSONL` landed in c00e4d6a9 via a
direct push, which never ran the pr.yml-only **Contract corpus (golden +
determinism + conformance)** job. Since ~09:30Z 2026-07-25, every fresh PR
against `main` shows this test red, purely from rebasing onto that commit —
not from anything in the PR's own diff.

The test itself has an unpassable assertion, not a product bug. The
replica-guard reclaim path is correct: when a lease was granted by a
different replica, `bd reclaim` on this node declines it (`--json` reports
`count: 0`, the leased issue is absent from `reclaimed`). But the guard also
writes a human-audit line to stderr naming the skipped issue ID
(`reportForeignSkips` in `internal/storage/issueops/lease.go`) — that line
exists so an operator can see *why* a lease wasn't reaped. The test used
`tryRunEnv`'s `CombinedOutput()` and asserted
`!strings.Contains(reclaimOut, leased)`, so it trips on the very audit line
that proves the guard worked correctly.

## Fix (test-only)

- Added `tryRunEnvSplit` in `cmd/bd/protocol/wp4_helpers_test.go`, which
  captures stdout and stderr separately instead of folding them into one
  stream (`tryRunEnv` and all its other callers are unchanged).
- `TestProtocol_GrantingReplicaRoundTripsJSONL` now uses it for the
  cross-replica reclaim call, parses the JSON result from stdout only, and
  asserts `count == 0` and that the leased issue ID is absent from
  `reclaimed` — the same intent as before, expressed against the
  machine-readable result instead of substring-matching combined output.
- No change to `internal/storage/issueops/lease.go` or any other
  non-test file; the guard and its stderr audit line are correct as-is.

## Verification

```
CGO_ENABLED=1 go test -tags gms_pure_go \
  -run TestProtocol_GrantingReplicaRoundTripsJSONL ./cmd/bd/protocol/ -count=1 -v
--- PASS: TestProtocol_GrantingReplicaRoundTripsJSONL (14.55s)
PASS
```

Also ran the package's other lease/reclaim/claim Protocol tests
(`TestProtocol_ErrorClass_AlreadyClaimedNamesHolder`,
`TestProtocol_ErrorClass_NotClaimableNamesState`,
`TestProtocol_ClaimIsUnassignedOnly`,
`TestProtocol_ReadyClaimEmptyFrontIsSuccess`,
`TestProtocol_ReadyClaimComposesWithFilters`,
`TestProtocol_LeaseFieldsExportToJSONL`,
`TestProtocol_LeaseFieldsRoundTripJSONL`,
`TestProtocol_ImportNeverClobbersLiveLocalLease`) — all pass, no collateral
breakage.

_claude-fable-5-high on behalf of maphew_
