### PR TITLE
fix(uow): self-heal fresh-bootstrap debris instead of failing proxied init (#5012)

### DIFF
--- a/internal/storage/domain/db/ddl.go
+++ b/internal/storage/domain/db/ddl.go
@@ -10,6 +10,12 @@ var validIdentifier = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_]*$`)
 
 type DDLSQLRepository interface {
 	CreateDatabaseIfNotExists(ctx context.Context, database string) error
+	// CreateDatabase issues a bare CREATE DATABASE (no IF NOT EXISTS) so the
+	// server arbitrates creation atomically: success proves this call created
+	// the database; an already-exists error (MySQL 1007) proves it did not.
+	// The error is returned unmapped (wrapped with %w) so callers can
+	// classify it against their driver.
+	CreateDatabase(ctx context.Context, database string) error
 	UseDatabase(ctx context.Context, database string) error
 }
 
@@ -30,6 +36,17 @@ func (r *ddlSQLRepository) CreateDatabaseIfNotExists(ctx context.Context, databa
 	}
 	if _, err := r.runner.ExecContext(ctx, "CREATE DATABASE IF NOT EXISTS "+ident); err != nil {
 		return fmt.Errorf("db: CreateDatabaseIfNotExists: %w", err)
+	}
+	return nil
+}
+
+func (r *ddlSQLRepository) CreateDatabase(ctx context.Context, database string) error {
+	ident, err := quoteIdentifier(database)
+	if err != nil {
+		return fmt.Errorf("db: CreateDatabase: %w", err)
+	}
+	if _, err := r.runner.ExecContext(ctx, "CREATE DATABASE "+ident); err != nil {
+		return fmt.Errorf("db: CreateDatabase: %w", err)
 	}
 	return nil
 }

--- a/internal/storage/schema/lock.go
+++ b/internal/storage/schema/lock.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"hash/fnv"
+	"strings"
 	"time"
 )
 
@@ -47,13 +48,39 @@ func MigrationLockName(databaseName string) string {
 	return fmt.Sprintf("%s%016x", migrationLockPrefix, h.Sum64())
 }
 
+// MigrateLockOption configures MigrateUpWithLock.
+type MigrateLockOption func(*migrateLockOptions)
+
+type migrateLockOptions struct {
+	freshBootstrapHeal bool
+}
+
+// WithFreshBootstrapHeal enables the fresh-bootstrap self-heal for the #4566
+// dirty-table guard (gastownhall/beads#5012). Callers must pass it only when
+// they created the database within the current logical operation (it did not
+// exist before this init began), so any working-set dirt the guard reads can
+// only be a previous migration attempt's own half-applied step — a session
+// that died between a migration's SQL and its per-step Dolt commit — never
+// pre-existing user data. When the guard fires under this option, the working
+// set is discarded with DOLT_RESET('--hard') (per-step commits already in
+// history survive) and the migration pass is re-run once, all on the same
+// locked session so no concurrent migrator can be mid-pass.
+func WithFreshBootstrapHeal() MigrateLockOption {
+	return func(o *migrateLockOptions) { o.freshBootstrapHeal = true }
+}
+
 // MigrateUpWithLock serializes schema migrations for a single Dolt sql-server
 // database. conn must be a pinned *sql.Conn because MySQL/Dolt named locks are
 // session-scoped; GET_LOCK, migrations, and RELEASE_LOCK must run on the same
 // server session. Embedded Dolt intentionally uses bare MigrateUp because it
 // relies on the embedded driver's file/concurrency controls instead of
 // sql-server session locks.
-func MigrateUpWithLock(ctx context.Context, conn *sql.Conn, databaseName string) (applied int, err error) {
+func MigrateUpWithLock(ctx context.Context, conn *sql.Conn, databaseName string, opts ...MigrateLockOption) (applied int, err error) {
+	var o migrateLockOptions
+	for _, opt := range opts {
+		opt(&o)
+	}
+
 	lockName := MigrationLockName(databaseName)
 	if err := AcquireMigrationLock(ctx, conn, lockName); err != nil {
 		return 0, err
@@ -64,7 +91,22 @@ func MigrateUpWithLock(ctx context.Context, conn *sql.Conn, databaseName string)
 		}
 	}()
 
-	return MigrateUp(ctx, conn)
+	applied, err = MigrateUp(ctx, conn)
+	var dirtyErr *DirtyTablesError
+	if err != nil && o.freshBootstrapHeal && errors.As(err, &dirtyErr) {
+		// The database was created by this init and we hold its migration
+		// lock: the dirt the guard refused is a previous attempt's own
+		// bootstrap debris (mid-step session death), not user data. Discard
+		// it and re-run the pass instead of failing an init that a plain
+		// retry can never converge (gastownhall/beads#5012).
+		fmt.Fprintf(stderr, "Discarding interrupted-bootstrap working set (%s) and re-running migrations…\n",
+			strings.Join(dirtyErr.Tables, ", "))
+		if _, resetErr := conn.ExecContext(ctx, "CALL DOLT_RESET('--hard')"); resetErr != nil {
+			return applied, errors.Join(err, fmt.Errorf("schema: fresh-bootstrap reset: %w", resetErr))
+		}
+		applied, err = MigrateUp(ctx, conn)
+	}
+	return applied, err
 }
 
 // AcquireMigrationLock acquires the named schema migration lock on the pinned

--- a/internal/storage/schema/lock_test.go
+++ b/internal/storage/schema/lock_test.go
@@ -302,3 +302,124 @@ func expectDoltStatusRows(mock sqlmock.Sqlmock) {
 	mock.ExpectQuery("(?s)SELECT s\\.table_name, s\\.staged\\s+FROM dolt_status s").
 		WillReturnRows(sqlmock.NewRows([]string{"table_name", "staged"}))
 }
+
+// expectDirtyGuardRefusal mocks a MigrateUp invocation that walks up to the
+// #4566 pre-flight guard and gets refused: the cursor is one migration behind,
+// `issues` is dirty in the working set, and the pending (latest) migration
+// touches `issues`. This is the interrupted-fresh-bootstrap shape from
+// gastownhall/beads#5012 — a previous attempt's step debris, read by a retry.
+// It relies on the latest migration touching `issues`; if a future latest
+// migration stops doing so, sqlmock will fail loudly on the unexpected query
+// flow and this helper should dirty a table that migration does touch.
+func expectDirtyGuardRefusal(t *testing.T, mock sqlmock.Sqlmock) {
+	t.Helper()
+
+	latest := LatestVersion()
+
+	expectIgnorePatternSeedNoop(mock)
+	// migrationWorkNeeded: main cursor behind -> work needed (short-circuits).
+	expectScalar(mock, "SELECT COALESCE(MAX(version), 0) FROM schema_migrations", "version", latest-1)
+	// dirtyBeforeAll: `issues` dirty (working set only, not staged).
+	expectDoltStatusDirtyIssues(mock)
+	// Nothing staged -> no unstage exec; seed was a no-op -> no seed commit.
+	// committableDirtyTables re-reads dolt_status (ignored tables excluded).
+	expectDoltStatusDirtyIssues(mock)
+	// auxRekeyResumePending: no local_metadata table, no crashed rekey pass.
+	mock.ExpectQuery(`SELECT COUNT\(\*\) FROM INFORMATION_SCHEMA\.TABLES`).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
+	// pendingMigrationDirtyTables: cursor read, then the pending latest
+	// migration's SQL touches `issues` -> DirtyTablesError.
+	expectScalar(mock, "SELECT COALESCE(MAX(version), 0) FROM schema_migrations", "version", latest-1)
+}
+
+func expectDoltStatusDirtyIssues(mock sqlmock.Sqlmock) {
+	mock.ExpectQuery("(?s)SELECT s\\.table_name, s\\.staged\\s+FROM dolt_status s").
+		WillReturnRows(sqlmock.NewRows([]string{"table_name", "staged"}).AddRow("issues", false))
+}
+
+// TestMigrateUpWithLockDirtyGuardStaysFatalWithoutHeal pins the default
+// behavior: without WithFreshBootstrapHeal, the #4566 guard refusal surfaces
+// as *DirtyTablesError and no DOLT_RESET runs (sqlmock's ordered expectations
+// fail the test on any unexpected reset call).
+func TestMigrateUpWithLockDirtyGuardStaysFatalWithoutHeal(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("create sql mock: %v", err)
+	}
+	defer db.Close()
+
+	ctx := context.Background()
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		t.Fatalf("pin mock connection: %v", err)
+	}
+	defer conn.Close()
+
+	lockName := MigrationLockName("testdb")
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT GET_LOCK(?, ?)")).
+		WithArgs(lockName, migrationLockAcquireTimeoutSeconds).
+		WillReturnRows(sqlmock.NewRows([]string{"locked"}).AddRow(1))
+	expectDirtyGuardRefusal(t, mock)
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT RELEASE_LOCK(?)")).
+		WithArgs(lockName).
+		WillReturnRows(sqlmock.NewRows([]string{"released"}).AddRow(1))
+
+	applied, err := MigrateUpWithLock(ctx, conn, "testdb")
+	if applied != 0 {
+		t.Fatalf("MigrateUpWithLock() applied = %d, want 0", applied)
+	}
+	var dirtyErr *DirtyTablesError
+	if !errors.As(err, &dirtyErr) {
+		t.Fatalf("MigrateUpWithLock() error = %v, want *DirtyTablesError", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet SQL expectations: %v", err)
+	}
+}
+
+// TestMigrateUpWithLockFreshBootstrapHealResetsAndRetries is the unit-level
+// regression for gastownhall/beads#5012: with WithFreshBootstrapHeal (the
+// caller created the database within this init), a #4566 guard refusal is
+// healed under the held migration lock — DOLT_RESET('--hard') discards the
+// interrupted bootstrap's working-set debris and the pass re-runs to
+// completion on the same session.
+func TestMigrateUpWithLockFreshBootstrapHealResetsAndRetries(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("create sql mock: %v", err)
+	}
+	defer db.Close()
+
+	ctx := context.Background()
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		t.Fatalf("pin mock connection: %v", err)
+	}
+	defer conn.Close()
+
+	lockName := MigrationLockName("testdb")
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT GET_LOCK(?, ?)")).
+		WithArgs(lockName, migrationLockAcquireTimeoutSeconds).
+		WillReturnRows(sqlmock.NewRows([]string{"locked"}).AddRow(1))
+	// First MigrateUp: refused by the dirty guard.
+	expectDirtyGuardRefusal(t, mock)
+	// Heal: discard the bootstrap debris on the same locked session.
+	mock.ExpectExec(regexp.QuoteMeta("CALL DOLT_RESET('--hard')")).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	// Second MigrateUp: clean working set, one pending migration applies.
+	expectOnePendingMigration(t, mock)
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT RELEASE_LOCK(?)")).
+		WithArgs(lockName).
+		WillReturnRows(sqlmock.NewRows([]string{"released"}).AddRow(1))
+
+	applied, err := MigrateUpWithLock(ctx, conn, "testdb", WithFreshBootstrapHeal())
+	if err != nil {
+		t.Fatalf("MigrateUpWithLock() error = %v", err)
+	}
+	if applied != 1 {
+		t.Fatalf("MigrateUpWithLock() applied = %d, want 1", applied)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet SQL expectations: %v", err)
+	}
+}

--- a/internal/storage/uow/dolt_sql_provider.go
+++ b/internal/storage/uow/dolt_sql_provider.go
@@ -68,6 +68,18 @@ func (p *doltSQLProvider) initSchema(ctx context.Context, database string) error
 	// full cold-start migration pass (every migration + a Dolt commit each),
 	// not just a transient blip — it grows as migrations accumulate.
 	bo.MaxElapsedTime = 60 * time.Second
+	// Fresh-bootstrap detection for the #4566 guard self-heal
+	// (gastownhall/beads#5012): probed once, before this init's CREATE
+	// DATABASE runs. When the database did not exist before this init, a
+	// retry attempt that finds dirty tables can only be seeing a previous
+	// attempt's own half-applied migration step (a session that died between
+	// a step's SQL and its per-step Dolt commit — the "busy buffer" shape on
+	// a loaded shared server), never pre-existing user data, so the migrate
+	// call may discard that debris and converge instead of failing the init
+	// permanently. The probe is best-effort: on probe error the heal stays
+	// disabled and behavior is unchanged.
+	createdFresh := false
+	probed := false
 	return backoff.Retry(func() error {
 		conn, err := p.db.Conn(ctx)
 		if err != nil {
@@ -78,6 +90,13 @@ func (p *doltSQLProvider) initSchema(ctx context.Context, database string) error
 		}
 		defer conn.Close()
 
+		if !probed {
+			if exists, probeErr := databaseExists(ctx, conn, database); probeErr == nil {
+				createdFresh = !exists
+				probed = true
+			}
+		}
+
 		ddl := db.NewDDLSQLRepository(conn)
 		if err := ddl.CreateDatabaseIfNotExists(ctx, database); err != nil {
 			return backoff.Permanent(fmt.Errorf("uow: creating database: %w", err))
@@ -86,7 +105,11 @@ func (p *doltSQLProvider) initSchema(ctx context.Context, database string) error
 			return backoff.Permanent(fmt.Errorf("uow: switching to database: %w", err))
 		}
 
-		if _, err := schema.MigrateUpWithLock(ctx, conn, database); err != nil {
+		var migrateOpts []schema.MigrateLockOption
+		if createdFresh {
+			migrateOpts = append(migrateOpts, schema.WithFreshBootstrapHeal())
+		}
+		if _, err := schema.MigrateUpWithLock(ctx, conn, database, migrateOpts...); err != nil {
 			if isSerializationError(err) || schema.IsMigrationLockError(err) {
 				return fmt.Errorf("uow: migrate: %w", err)
 			}
@@ -94,6 +117,29 @@ func (p *doltSQLProvider) initSchema(ctx context.Context, database string) error
 		}
 		return nil
 	}, backoff.WithContext(bo, ctx))
+}
+
+// databaseExists reports whether the named database is already present on the
+// server. It iterates SHOW DATABASES rather than filtering
+// information_schema.schemata because Dolt does not push predicates down into
+// information_schema scans.
+func databaseExists(ctx context.Context, conn *sql.Conn, database string) (bool, error) {
+	rows, err := conn.QueryContext(ctx, "SHOW DATABASES")
+	if err != nil {
+		return false, err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return false, err
+		}
+		if name == database {
+			return true, rows.Err()
+		}
+	}
+	return false, rows.Err()
 }
 
 func buildDSN(ep proxy.Endpoint, database, user, password, tlsConfigName string) string {

--- a/internal/storage/uow/dolt_sql_provider.go
+++ b/internal/storage/uow/dolt_sql_provider.go
@@ -68,18 +68,22 @@ func (p *doltSQLProvider) initSchema(ctx context.Context, database string) error
 	// full cold-start migration pass (every migration + a Dolt commit each),
 	// not just a transient blip — it grows as migrations accumulate.
 	bo.MaxElapsedTime = 60 * time.Second
-	// Fresh-bootstrap detection for the #4566 guard self-heal
-	// (gastownhall/beads#5012): probed once, before this init's CREATE
-	// DATABASE runs. When the database did not exist before this init, a
-	// retry attempt that finds dirty tables can only be seeing a previous
-	// attempt's own half-applied migration step (a session that died between
-	// a step's SQL and its per-step Dolt commit — the "busy buffer" shape on
-	// a loaded shared server), never pre-existing user data, so the migrate
-	// call may discard that debris and converge instead of failing the init
-	// permanently. The probe is best-effort: on probe error the heal stays
-	// disabled and behavior is unchanged.
-	createdFresh := false
-	probed := false
+	// Fresh-bootstrap ownership proof for the #4566 guard self-heal
+	// (gastownhall/beads#5012): the first attempt issues a bare CREATE
+	// DATABASE (no IF NOT EXISTS), so the server arbitrates creation
+	// atomically — success proves THIS init created the database, and an
+	// already-exists refusal (1007) proves it did not. Only the proven
+	// creator passes WithFreshBootstrapHeal: on a database this init
+	// created, a retry attempt that finds dirty tables can only be seeing a
+	// previous attempt's own half-applied migration step (a session that
+	// died between a step's SQL and its per-step Dolt commit — the "busy
+	// buffer" shape on a loaded shared server), never pre-existing user
+	// data, so the migrate call may discard that debris and converge instead
+	// of failing the init permanently. A concurrent initializer that loses
+	// the create race keeps the guard's refusal unchanged. `created` is
+	// sticky across retry attempts: it is set exactly when this init's
+	// CREATE succeeded, which no later attempt can re-learn from probing.
+	created := false
 	return backoff.Retry(func() error {
 		conn, err := p.db.Conn(ctx)
 		if err != nil {
@@ -90,23 +94,33 @@ func (p *doltSQLProvider) initSchema(ctx context.Context, database string) error
 		}
 		defer conn.Close()
 
-		if !probed {
-			if exists, probeErr := databaseExists(ctx, conn, database); probeErr == nil {
-				createdFresh = !exists
-				probed = true
-			}
-		}
-
 		ddl := db.NewDDLSQLRepository(conn)
-		if err := ddl.CreateDatabaseIfNotExists(ctx, database); err != nil {
-			return backoff.Permanent(fmt.Errorf("uow: creating database: %w", err))
+		if created {
+			// Re-assert on retries so a database dropped between attempts
+			// (e.g. a concurrent clean-databases) is recreated rather than
+			// failing the USE below.
+			if err := ddl.CreateDatabaseIfNotExists(ctx, database); err != nil {
+				return backoff.Permanent(fmt.Errorf("uow: creating database: %w", err))
+			}
+		} else {
+			switch err := ddl.CreateDatabase(ctx, database); {
+			case err == nil:
+				created = true
+			case isDatabaseExistsError(err):
+				// Pre-existing (or a concurrent initializer won the create
+				// race): not ours, heal stays off.
+			case isSerializationError(err):
+				return fmt.Errorf("uow: creating database: %w", err)
+			default:
+				return backoff.Permanent(fmt.Errorf("uow: creating database: %w", err))
+			}
 		}
 		if err := ddl.UseDatabase(ctx, database); err != nil {
 			return backoff.Permanent(fmt.Errorf("uow: switching to database: %w", err))
 		}
 
 		var migrateOpts []schema.MigrateLockOption
-		if createdFresh {
+		if created {
 			migrateOpts = append(migrateOpts, schema.WithFreshBootstrapHeal())
 		}
 		if _, err := schema.MigrateUpWithLock(ctx, conn, database, migrateOpts...); err != nil {
@@ -117,29 +131,6 @@ func (p *doltSQLProvider) initSchema(ctx context.Context, database string) error
 		}
 		return nil
 	}, backoff.WithContext(bo, ctx))
-}
-
-// databaseExists reports whether the named database is already present on the
-// server. It iterates SHOW DATABASES rather than filtering
-// information_schema.schemata because Dolt does not push predicates down into
-// information_schema scans.
-func databaseExists(ctx context.Context, conn *sql.Conn, database string) (bool, error) {
-	rows, err := conn.QueryContext(ctx, "SHOW DATABASES")
-	if err != nil {
-		return false, err
-	}
-	defer rows.Close()
-
-	for rows.Next() {
-		var name string
-		if err := rows.Scan(&name); err != nil {
-			return false, err
-		}
-		if name == database {
-			return true, rows.Err()
-		}
-	}
-	return false, rows.Err()
 }
 
 func buildDSN(ep proxy.Endpoint, database, user, password, tlsConfigName string) string {

--- a/internal/storage/uow/errors.go
+++ b/internal/storage/uow/errors.go
@@ -2,6 +2,7 @@ package uow
 
 import (
 	"errors"
+	"strings"
 
 	mysql "github.com/go-sql-driver/mysql"
 )
@@ -26,4 +27,22 @@ func isSerializationError(err error) bool {
 		return false
 	}
 	return mysqlErr.Number == 1213 || mysqlErr.Number == 1205
+}
+
+// isDatabaseExistsError reports whether err is the server refusing a bare
+// CREATE DATABASE because the database already exists (MySQL 1007,
+// ER_DB_CREATE_EXISTS). The message fallback matches how the rest of the
+// codebase detects Dolt's variant of this error (see internal/doltserver and
+// internal/storage/dolt), whose text is "can't create database ...; database
+// exists" but whose driver error number has not always been populated.
+func isDatabaseExistsError(err error) bool {
+	var mysqlErr *mysql.MySQLError
+	if errors.As(err, &mysqlErr) && mysqlErr.Number == 1007 {
+		return true
+	}
+	if err == nil {
+		return false
+	}
+	errLower := strings.ToLower(err.Error())
+	return strings.Contains(errLower, "database exists") || strings.Contains(errLower, "1007")
 }

--- a/internal/storage/uow/external_doltserver_provider_test.go
+++ b/internal/storage/uow/external_doltserver_provider_test.go
@@ -2,16 +2,18 @@ package uow
 
 import (
 	"context"
+	"fmt"
 	"path/filepath"
 	"strconv"
 	"sync"
 	"testing"
 	"time"
 
-	_ "github.com/go-sql-driver/mysql"
+	mysql "github.com/go-sql-driver/mysql"
 
 	"github.com/steveyegge/beads/internal/configfile"
 	"github.com/steveyegge/beads/internal/storage/dbproxy/proxy"
+	"github.com/steveyegge/beads/internal/storage/schema"
 	"github.com/steveyegge/beads/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -182,4 +184,108 @@ func TestNewExternalDoltServerUOWProvider_ConcurrentInstantiation(t *testing.T) 
 		assert.NoErrorf(t, r.err, "provider %d", i)
 		assert.NotNilf(t, r.provider, "provider %d", i)
 	}
+}
+
+// TestNewExternalDoltServerUOWProvider_FreshInitSelfHealsAfterMidPassFailure is
+// the regression test for gastownhall/beads#5012: the proxied shard-1 CI flake
+// where a fresh `bd init --proxied-server` fails with
+//
+//	uow: migrate: pending schema migrations alter pre-existing dirty tables: issues
+//
+// The shape of the failure: initSchema's first attempt dies mid-migration-pass
+// on the shared server (transient serialization failure / poisoned session —
+// the "[mysql] busy buffer" breadcrumb), leaving the failed step's SQL applied
+// to the Dolt working set but never Dolt-committed. The backoff retry then
+// re-runs MigrateUp, whose #4566 dirty-table guard reads that debris, decides
+// the pass's own half-applied step is "pre-existing dirty user data", and
+// converts a retryable transient into a permanent init failure — on a database
+// that did not exist seconds earlier.
+//
+// The test reproduces that exact interleaving deterministically: the per-step
+// fault hook fires once after migration 0001 commits, dirties `issues` in the
+// working set the way a mid-step death does (SQL applied, no Dolt commit), and
+// fails the pass with a retryable serialization error. The retry must
+// self-heal (discard the bootstrap debris and finish the pass) instead of
+// reporting DirtyTablesError.
+func TestNewExternalDoltServerUOWProvider_FreshInitSelfHealsAfterMidPassFailure(t *testing.T) {
+	port := testutil.StartIsolatedDoltContainer(t)
+	portInt, err := strconv.Atoi(port)
+	require.NoError(t, err)
+
+	bdBin := buildBDBinary(t)
+	prev := proxy.ResolveExecutable
+	proxy.ResolveExecutable = func() (string, error) { return bdBin, nil }
+	t.Cleanup(func() { proxy.ResolveExecutable = prev })
+
+	t.Setenv("HOME", t.TempDir())
+
+	storeRootDir := t.TempDir()
+	shutdownOnInterrupt(t, storeRootDir)
+	t.Cleanup(func() {
+		if err := proxy.Shutdown(storeRootDir); err != nil {
+			t.Logf("proxy.Shutdown(%s): %v", storeRootDir, err)
+		}
+	})
+	logPath := filepath.Join(t.TempDir(), "server.log")
+
+	// Fire exactly once, right after migration step 1 (create issues) has
+	// committed: dirty `issues` in the working set (schema change applied, no
+	// Dolt commit — indistinguishable from a step whose session died between
+	// its SQL and its per-step commit), then kill the pass with an error the
+	// provider's retry loop classifies as retryable.
+	fired := false
+	restore := schema.SetMigrateStepFaultHookForTest(func(ctx context.Context, db schema.DBConn, version int) error {
+		if version != 1 || fired {
+			return nil
+		}
+		fired = true
+		if _, err := db.ExecContext(ctx, "ALTER TABLE issues ADD COLUMN bd5012_debris INT"); err != nil {
+			return fmt.Errorf("injecting mid-step debris: %w", err)
+		}
+		return &mysql.MySQLError{Number: 1213, Message: "test-injected deadlock (mid-pass session death)"}
+	})
+	t.Cleanup(restore)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	provider, err := NewExternalDoltServerUOWProvider(
+		ctx,
+		storeRootDir,
+		"beads_fresh_heal",
+		logPath,
+		configfile.ExternalDoltConfig{Host: "127.0.0.1", Port: portInt},
+		"root",
+		"",
+		0,
+		0,
+	)
+	require.NoError(t, err, "fresh init must converge after a mid-pass transient failure, not trip the #4566 guard on its own bootstrap debris")
+	require.NotNil(t, provider)
+	t.Cleanup(func() { _ = provider.Close(context.Background()) })
+	require.True(t, fired, "fault hook never fired; test no longer exercises the mid-pass failure path")
+
+	sqlProv, ok := provider.(*doltSQLProvider)
+	require.True(t, ok, "expected *doltSQLProvider, got %T", provider)
+
+	// The injected debris must have been discarded, not committed into history.
+	rows, err := sqlProv.db.QueryContext(ctx, "SHOW COLUMNS FROM issues LIKE 'bd5012_debris'")
+	require.NoError(t, err)
+	defer rows.Close()
+	require.False(t, rows.Next(), "bootstrap debris column survived the self-heal")
+	require.NoError(t, rows.Err())
+
+	// And the migration pass must have completed to the latest version.
+	var version int
+	require.NoError(t, sqlProv.db.QueryRowContext(ctx,
+		"SELECT COALESCE(MAX(version), 0) FROM schema_migrations").Scan(&version))
+	assert.Equal(t, schema.LatestVersion(), version)
+
+	// The working set must not still carry `issues` dirt.
+	statusRows, err := sqlProv.db.QueryContext(ctx,
+		"SELECT table_name FROM dolt_status WHERE table_name = 'issues'")
+	require.NoError(t, err)
+	defer statusRows.Close()
+	assert.False(t, statusRows.Next(), "issues still dirty in dolt_status after init")
+	require.NoError(t, statusRows.Err())
 }

--- a/internal/storage/uow/external_doltserver_provider_test.go
+++ b/internal/storage/uow/external_doltserver_provider_test.go
@@ -2,6 +2,7 @@ package uow
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"path/filepath"
 	"strconv"
@@ -288,4 +289,69 @@ func TestNewExternalDoltServerUOWProvider_FreshInitSelfHealsAfterMidPassFailure(
 	defer statusRows.Close()
 	assert.False(t, statusRows.Next(), "issues still dirty in dolt_status after init")
 	require.NoError(t, statusRows.Err())
+}
+
+// TestNewExternalDoltServerUOWProvider_PreexistingDirtyDatabaseIsNotHealed is
+// the ownership-negative counterpart of the fresh-init self-heal: an
+// initializer that did NOT create the database (its bare CREATE DATABASE loses
+// to an existing one) must keep the #4566 guard's refusal and must not
+// DOLT_RESET the working set — the dirt it sees could be another actor's
+// legitimate uncommitted state, which only the proven creator may discard.
+func TestNewExternalDoltServerUOWProvider_PreexistingDirtyDatabaseIsNotHealed(t *testing.T) {
+	port := testutil.StartIsolatedDoltContainer(t)
+	portInt, err := strconv.Atoi(port)
+	require.NoError(t, err)
+
+	bdBin := buildBDBinary(t)
+	prev := proxy.ResolveExecutable
+	proxy.ResolveExecutable = func() (string, error) { return bdBin, nil }
+	t.Cleanup(func() { proxy.ResolveExecutable = prev })
+
+	t.Setenv("HOME", t.TempDir())
+
+	storeRootDir := t.TempDir()
+	shutdownOnInterrupt(t, storeRootDir)
+	t.Cleanup(func() {
+		if err := proxy.Shutdown(storeRootDir); err != nil {
+			t.Logf("proxy.Shutdown(%s): %v", storeRootDir, err)
+		}
+	})
+	logPath := filepath.Join(t.TempDir(), "server.log")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	// Another actor created the database and left `issues` dirty in the
+	// working set (created, never Dolt-committed) — the state a mid-pass
+	// death leaves behind, indistinguishable from uncommitted user work.
+	admin, err := sql.Open("mysql", fmt.Sprintf("root:@tcp(127.0.0.1:%d)/?parseTime=true", portInt))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = admin.Close() })
+	_, err = admin.ExecContext(ctx, "CREATE DATABASE beads_loser")
+	require.NoError(t, err)
+	_, err = admin.ExecContext(ctx, "CREATE TABLE beads_loser.issues (id INT PRIMARY KEY)")
+	require.NoError(t, err)
+
+	provider, err := NewExternalDoltServerUOWProvider(
+		ctx,
+		storeRootDir,
+		"beads_loser",
+		logPath,
+		configfile.ExternalDoltConfig{Host: "127.0.0.1", Port: portInt},
+		"root",
+		"",
+		0,
+		0,
+	)
+	if provider != nil {
+		t.Cleanup(func() { _ = provider.Close(context.Background()) })
+	}
+	require.Error(t, err, "non-creator init over a dirty database must keep the #4566 refusal")
+	require.Contains(t, err.Error(), "pending schema migrations alter pre-existing dirty tables: issues")
+
+	// The dirt must be untouched: no DOLT_RESET may have fired.
+	var count int
+	require.NoError(t, admin.QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM beads_loser.dolt_status WHERE table_name = 'issues'").Scan(&count))
+	require.Equal(t, 1, count, "issues working-set dirt was discarded by a non-creator init")
 }


### PR DESCRIPTION
# fix(uow): self-heal fresh-bootstrap debris instead of failing proxied init

Fixes the dominant red-main flake tracked in #5012 (`Test (proxied-server cmd 1/15)`).

## Why

A fresh `bd init --proxied-server` can fail permanently with

```
[mysql] connection.go:215 busy buffer
Error: failed to open uow provider: uow: init schema: uow: migrate:
pending schema migrations alter pre-existing dirty tables: issues; run 'bd dolt commit' ... (#4566)
```

on a database that did not exist seconds earlier. The failure needs two moves, and current code supplies both:

1. **A mid-pass transient on the shared server.** Fresh bootstrap runs every migration (59 today) with a Dolt commit per step on one pinned session. Under CI's parallel-test load a step can die between its SQL and its per-step commit: a genuine 1213/1205 rollback, or a poisoned session whose next prepared statement hits the driver's `busy buffer` (that breadcrumb is logged at go-sql-driver `connection.go:215` when `ReleaseMigrationLock`'s `SELECT RELEASE_LOCK(?)` prepare finds unread result data on the connection — its `ErrMigrationLockRelease` is then `errors.Join`ed into the failure and classified retryable). Either way the step's DDL/DML is already applied to the working set but never Dolt-committed.
2. **The #4566 guard reads the debris on retry.** `initSchema`'s backoff re-runs `MigrateUpWithLock`; the pre-flight dirty-table guard sees `issues` dirty with pending migrations touching it, classifies the pass's *own half-applied step* as "pre-existing dirty user data", and returns `DirtyTablesError` — which the retry loop rightly treats as permanent. A retryable transient has been converted into a hard init failure, and no number of retries can converge.

The per-step commit contract (#4566) deliberately leaves this one-step window open, because in general working-set dirt may be user data worth protecting. But on a **fresh bootstrap** — a database created by this very init call — the guard's protection target cannot exist: `bd` hands the database to no writer until init returns. Refusing there is strictly wrong.

This is the same failure chain the external contributor's #4504 diagnosed months ago from the 0040-era symptom (undrained `CALL DOLT_*` result sets → busy buffer → failed version INSERT / lock release). #4504 removes a *poisoning source* (drain proc result sets, make 0040/0041 idempotent); this PR makes the *retry converge* whatever the mid-pass failure mode was (deadlock, kill, network, poisoned buffer). They are complementary, and #4504 remains worth landing on its own merits.

## What

- `internal/storage/uow/dolt_sql_provider.go` — `initSchema` proves database ownership atomically: the first attempt issues a bare `CREATE DATABASE` (no `IF NOT EXISTS`), so the server arbitrates the race — success proves this init created the database (heal eligible, sticky across retries), an already-exists refusal (1007) proves it did not (heal off, guard refusal unchanged). See the review-hardening comment below for why this replaced the earlier existence probe.
- `internal/storage/schema/lock.go` — `MigrateUpWithLock` gains variadic `MigrateLockOption`s (existing callers unchanged). Under `WithFreshBootstrapHeal`, a `*DirtyTablesError` refusal is healed **on the same locked session**: `CALL DOLT_RESET('--hard')` discards the interrupted bootstrap's working set (per-step commits already in history survive), then the pass re-runs once. Holding the migration lock through reset + re-run means no concurrent migrator can be mid-pass when the reset fires.
- Pre-existing databases keep the guard's refusal exactly as before; embedded Dolt (`MigrateUp` without lock) is untouched.

## Reproduction / verification

`TestNewExternalDoltServerUOWProvider_FreshInitSelfHealsAfterMidPassFailure` reproduces the CI interleaving deterministically against a real Dolt container: the per-step fault hook fires once after migration 0001 commits, dirties `issues` in the working set the way a mid-step death does (SQL applied, no Dolt commit), and fails the pass with a retryable 1213.

- On main (4fd05a574) the test fails with the exact shard-1 error string: `uow: init schema: uow: migrate: pending schema migrations alter pre-existing dirty tables: issues; ... (#4566)`.
- With this PR it converges: debris discarded, cursor at `LatestVersion()`, clean `dolt_status`.

sqlmock tests pin both directions: `TestMigrateUpWithLockFreshBootstrapHealResetsAndRetries` (reset + re-run under one lock session) and `TestMigrateUpWithLockDirtyGuardStaysFatalWithoutHeal` (no option → unchanged `*DirtyTablesError`, no reset). `TestNewExternalDoltServerUOWProvider_PreexistingDirtyDatabaseIsNotHealed` (container) pins the ownership-negative path: a non-creator init over a dirty database keeps the #4566 refusal and leaves the working-set dirt untouched.

Preflight run locally: `go build`/`go vet`/`golangci-lint` clean on the touched packages; full `internal/storage/schema` and `internal/storage/uow` suites pass (including the existing 10-way concurrent-instantiation test); 3 serial iterations of the shard-1 test set (`TestProxiedServerConfig*`, `TestProxiedServerDuplicates`, `TestProxiedServerFindDuplicates`) with `BEADS_TEST_PROXIED_SERVER=1` all green.

## Notes for review

- The heal is scoped to the main-source pre-flight guard (`*DirtyTablesError`). The mid-pass ignored-source guard stays fatal; a retry after that failure lands in the healed pre-flight guard anyway.
- `internal/storage/dolt`'s server-mode `initSchemaOnDBWithRetry` has the same theoretical window but its caller doesn't know whether it created the database; left for a follow-up rather than widening this PR.
- Why frequency rose recently (#5012's near-deterministic run): fresh-init cost grows with every added migration (a Dolt commit per step), so the mid-pass window widens monotonically; #4877's 0059 also added a heavy `UPDATE issues` recompute step. #5014's proxied-purge isolation reduced shared-server interference (Main is green since it merged), but the one-transient-from-permanent-failure structure remained.

_claude-fable-5-high on behalf of maphew_
