### PR TITLE
fix(beads): admit the physical temp-root form in the temp-dir carve-out

### DIFF
--- a/internal/beads/context_test.go
+++ b/internal/beads/context_test.go
@@ -516,6 +516,41 @@ func TestIsPathInSafeBoundary_TempDirSymlinkEscape(t *testing.T) {
 	}
 }
 
+// TestIsPathInSafeBoundary_TempDirPhysicalForm covers the macOS shape where
+// $TMPDIR is itself a symlink (/var/folders/... -> /private/var/...): a
+// caller-supplied path that has already been symlink-resolved arrives in the
+// PHYSICAL form, does not share the unresolved os.TempDir() prefix, and must
+// still be admitted by the temp-dir carve-out. On macOS the physical form
+// falls under the denied /private prefix, so without the carve-out this test
+// fails (the exact TestContext* regression from the be-kghzr hardening); on
+// platforms whose physical temp root is not under a denied prefix the
+// assertion is satisfied either way — the macos-latest CI lane is the
+// distinguishing runner.
+func TestIsPathInSafeBoundary_TempDirPhysicalForm(t *testing.T) {
+	base := t.TempDir()
+	phys := filepath.Join(base, "phys")
+	if err := os.MkdirAll(phys, 0o755); err != nil {
+		t.Fatalf("mkdir phys: %v", err)
+	}
+	link := filepath.Join(base, "link")
+	if err := os.Symlink(phys, link); err != nil {
+		t.Skipf("cannot create symlink: %v", err)
+	}
+	t.Setenv("TMPDIR", link)
+
+	// Physical form of a (not-yet-created) subpath of the temp dir: must be safe.
+	target := filepath.Join(phys, "proj", ".beads")
+	if !isPathInSafeBoundary(target) {
+		t.Errorf("isPathInSafeBoundary(%q) = false, want true (physical form of TMPDIR subpath)", target)
+	}
+
+	// The symlinked form keeps working too.
+	linked := filepath.Join(link, "proj", ".beads")
+	if !isPathInSafeBoundary(linked) {
+		t.Errorf("isPathInSafeBoundary(%q) = false, want true (symlinked form of TMPDIR subpath)", linked)
+	}
+}
+
 // TestGetRepoContextForWorkspace_RedirectToUnsafeLocation tests that redirects
 // to unsafe locations are rejected (TS-SEC-003 integration test).
 func TestGetRepoContextForWorkspace_RedirectToUnsafeLocation(t *testing.T) {


### PR DESCRIPTION
## Why

Main is red at 5a88c2b48: `Test (macos-latest)` fails six `TestContext*` tests with `BEADS_DIR points to unsafe location: /private/var/folders/...`. #5030's symlink-safe hardening is correct in `resolvedPathWithinRoot` (both sides resolved), but the temp-dir carve-out **gate** still matches only the unresolved `os.TempDir()` prefix — on macOS that's the `/var/folders/...` symlink form. A caller-supplied path that has already been symlink-resolved arrives in the physical `/private/var/...` form, skips the carve-out, and falls through to the `/private` deny prefix.

## What

The gate now also matches the physical resolution of the temp root (`resolveLongestExistingAncestor(tempDir)`); containment is still decided by `resolvedPathWithinRoot`, so #5030's symlink-escape rejection is fully preserved — this only widens which spellings *enter* the carve-out, not what it admits.

Regression test added. It distinguishes on macOS, where the physical temp root sits under the denied `/private` prefix — i.e. exactly the macos-latest lane that caught the original failure; on other platforms it is satisfied either way and documents the contract.

## Verification

`CGO_ENABLED=0 go build -tags gms_pure_go`, `gofmt`, and the full boundary+context test selection green locally.

Stop-the-line per Base-Branch Health: while main is red this fix is the only mergeable PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

_claude-fable-5-high on behalf of matt wilkie_
