### PR TITLE
fix(beads): actually apply the physical temp-root carve-out (completes #5044)

### DIFF
--- a/internal/beads/context.go
+++ b/internal/beads/context.go
@@ -315,8 +315,16 @@ func isPathInSafeBoundary(path string) bool {
 	// escapes the boundary must be rejected, not followed into a system
 	// directory — same treatment as the /Users/Shared carve-out below
 	// (be-kghzr SEC-003 hardening).
+	// The carve-out must admit both spellings of the temp root: os.TempDir()
+	// itself (on macOS the symlinked /var/folders/... form) and its physical
+	// resolution (/private/var/folders/...). A caller-supplied path that has
+	// already been symlink-resolved arrives in the physical form and would
+	// otherwise skip this branch and be rejected by the /private deny prefix
+	// below.
 	tempDir := strings.TrimSuffix(os.TempDir(), "/")
-	if absPath == tempDir || strings.HasPrefix(absPath, tempDir+"/") {
+	physTempDir := strings.TrimSuffix(resolveLongestExistingAncestor(tempDir), "/")
+	if absPath == tempDir || strings.HasPrefix(absPath, tempDir+"/") ||
+		absPath == physTempDir || strings.HasPrefix(absPath, physTempDir+"/") {
 		return resolvedPathWithinRoot(absPath, tempDir)
 	}
 


### PR DESCRIPTION
## Why

Main is still red on macos-latest (run 30169298748 at d91a57fad) with the same six `TestContext*` "unsafe location: /private/var/..." failures. #5044 was meant to fix this but its squash landed **only the regression test**: a local prove-the-test step checked out `context.go` from `upstream/main` and the restore re-fetched the unfixed base, silently dropping the production hunk before commit. The mistake was invisible in CI because the test is vacuous on Linux (physical `/tmp` isn't under a denied prefix) — the macos-latest lane, which runs only on Main pushes, is the sole distinguishing runner.

## What

Exactly the missing production hunk (verified present this time — `physTempDir` in the committed diff): the temp-dir carve-out gate also matches the physical resolution of `os.TempDir()` (`resolveLongestExistingAncestor(tempDir)`). Containment is still decided by `resolvedPathWithinRoot`, so #5030's symlink-escape rejection is fully preserved. The regression test that #5044 landed becomes meaningful on macos-latest.

## Verification

`CGO_ENABLED=0 go build -tags gms_pure_go`, `gofmt`, boundary+context+repo-context test selection green; `grep physTempDir internal/beads/context.go` in the committed tree returns the two expected occurrences.

Stop-the-line per Base-Branch Health.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

_claude-fable-5-high on behalf of matt wilkie_
