### PR TITLE
test(beads): canonicalize physical temp-root regression fixture

### DIFF
--- a/internal/beads/context_test.go
+++ b/internal/beads/context_test.go
@@ -528,18 +528,20 @@ func TestIsPathInSafeBoundary_TempDirSymlinkEscape(t *testing.T) {
 // distinguishing runner.
 func TestIsPathInSafeBoundary_TempDirPhysicalForm(t *testing.T) {
 	base := t.TempDir()
-	phys := filepath.Join(base, "phys")
-	if err := os.MkdirAll(phys, 0o755); err != nil {
-		t.Fatalf("mkdir phys: %v", err)
+	linkTarget := filepath.Join(base, "phys")
+	if err := os.MkdirAll(linkTarget, 0o755); err != nil {
+		t.Fatalf("mkdir link target: %v", err)
 	}
 	link := filepath.Join(base, "link")
-	if err := os.Symlink(phys, link); err != nil {
+	if err := os.Symlink(linkTarget, link); err != nil {
 		t.Skipf("cannot create symlink: %v", err)
 	}
 	t.Setenv("TMPDIR", link)
 
-	// Physical form of a (not-yet-created) subpath of the temp dir: must be safe.
-	target := filepath.Join(phys, "proj", ".beads")
+	// Canonicalize the link target before appending the not-yet-created tail.
+	// On macOS base still uses the lexical /var/folders spelling, so merely
+	// joining linkTarget would not exercise the physical /private/var form.
+	target := resolveLongestExistingAncestor(filepath.Join(linkTarget, "proj", ".beads"))
 	if !isPathInSafeBoundary(target) {
 		t.Errorf("isPathInSafeBoundary(%q) = false, want true (physical form of TMPDIR subpath)", target)
 	}


### PR DESCRIPTION
## Why

#5047 fixed the real macOS `/var/folders/...` → `/private/var/folders/...` production path: the latest `main` run no longer fails the six `TestContext*` cases. It still fails `TestIsPathInSafeBoundary_TempDirPhysicalForm`, however, because that test labels `filepath.Join(phys, ...)` as physical without canonicalizing it. On macOS, `phys` remains under the lexical `/var/folders/...` spelling, so the fixture never constructs the `/private/var/...` form it claims to test.

## What

- Rename `phys` to `linkTarget` to describe what the directory actually is.
- Canonicalize the longest existing ancestor before re-appending the not-yet-created `proj/.beads` tail.
- Leave production code unchanged.

The assertion remains discriminating on macOS: without #5047's physical-root allowance, the canonical `/private/...` target reaches the denied `/private` prefix and fails.

## Verification

- `CGO_ENABLED=0 go test -tags gms_pure_go ./internal/beads -run '^TestIsPathInSafeBoundary_TempDirPhysicalForm$' -count=1 -v`
- `CGO_ENABLED=0 go test -tags gms_pure_go ./internal/beads -count=1`
- `gofmt`
- `git diff --check`
- Independent high-reasoning review found no issues or test vacuity.

The macOS `Main` lane is the required platform confirmation. While `main` is red, this test-only correction is the only mergeable PR.

_codex-gpt-5.6-sol-high on behalf of maphew_
