### PR TITLE
test(beads): resolve the physical-form probe in TempDirPhysicalForm

### DIFF
--- a/internal/beads/context_test.go
+++ b/internal/beads/context_test.go
@@ -538,8 +538,16 @@ func TestIsPathInSafeBoundary_TempDirPhysicalForm(t *testing.T) {
 	}
 	t.Setenv("TMPDIR", link)
 
-	// Physical form of a (not-yet-created) subpath of the temp dir: must be safe.
-	target := filepath.Join(phys, "proj", ".beads")
+	// Physical form of a (not-yet-created) subpath of the temp dir: must be
+	// safe. On macOS the join base itself sits under the symlinked
+	// /var/folders, so resolve it to the true physical spelling first — the
+	// probe must match what a caller supplies after EvalSymlinks, which is
+	// exactly resolveLongestExistingAncestor(TMPDIR)'s form.
+	physResolved, err := filepath.EvalSymlinks(phys)
+	if err != nil {
+		t.Fatalf("EvalSymlinks(%s): %v", phys, err)
+	}
+	target := filepath.Join(physResolved, "proj", ".beads")
 	if !isPathInSafeBoundary(target) {
 		t.Errorf("isPathInSafeBoundary(%q) = false, want true (physical form of TMPDIR subpath)", target)
 	}


### PR DESCRIPTION
## Why

The #5047 production fix works — the six `TestContext*` macos failures are gone — but Main (run 30171605206) still fails macos-latest on one test: the regression test itself. Its "physical form" probe was built by joining under `t.TempDir()`, which on macOS is the *symlinked* `/var/folders` spelling; the resulting path went through the test's own private link, matched neither carve-out gate spelling, and hit the `/var` deny prefix.

## What

Test-only: resolve the probe through `filepath.EvalSymlinks` so it is genuinely the physical spelling — the same form a caller supplies after symlink resolution, and exactly what the `physTempDir` gate admits. The symlinked-form assertion is unchanged.

## Verification

Boundary test selection green locally; committed diff verified to contain the test file (1 file changed). macos-latest on the subsequent Main run is the decisive check.

Stop-the-line per Base-Branch Health.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

_claude-fable-5-high on behalf of matt wilkie_
