### PR TITLE
test(cmd/bd): skip the testBD build init in helper-process re-execs

### DIFF
--- a/cmd/bd/cli_fast_test.go
+++ b/cmd/bd/cli_fast_test.go
@@ -696,6 +696,15 @@ func TestCLI_Import(t *testing.T) {
 var testBD string
 
 func init() {
+	// Helper-process re-execs (worktree_remove_test.go's
+	// runWorktreeRemoveProcess) run this init in a child whose cwd is a temp
+	// git repo: the repo-root probe below misses and the `go build .`
+	// fallback panics with "cannot find main module" — which is what six
+	// Main integration shards reported at cd25e0919. The helper never uses
+	// testBD, so skip the work entirely in that child.
+	if os.Getenv(worktreeRemoveHelperEnv) != "" {
+		return
+	}
 	// Use existing bd binary from repo root if available, otherwise build once
 	bdBinary := "bd"
 	if runtime.GOOS == "windows" {


### PR DESCRIPTION
## Why

Main is red at cd25e0919: six of eight `Main Linux integration cmd/bd` shards fail on the two new `TestWorktreeRemoveProcess*` tests from #4929. Those tests re-exec the test binary with cwd inside a temp git repo; every package init runs in that child, including `cli_fast_test.go`'s `testBD` builder — whose `../../bd` probe misses from the temp cwd and whose `go build .` fallback panics `go: cannot find main module` (CI trace: `init.140` at `cli_fast_test.go:722`). The parent then reports "failure output did not contain ..." because the child died in init before the helper ran.

## What

One guard: the init returns early when the helper env (`BD_WORKTREE_REMOVE_PROCESS_HELPER`, same-package const) is set — the helper child never uses `testBD`.

## Verification

Committed diff verified to contain the guard (`grep worktreeRemoveHelperEnv` on the committed blob = 1). The failure reproduces only in the Main integration lane's environment — locally the child resolves a prebuilt binary and passes both ways — so the post-merge Main run is the arbiter, exactly as it was for the trace that identified `init.140`.

Stop-the-line per Base-Branch Health.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

_claude-fable-5-high on behalf of matt wilkie_
