### PR TITLE
feat(graph): hint 'body' -> 'description' for unknown graph-plan fields

### DIFF
--- a/cmd/bd/graph_apply.go
+++ b/cmd/bd/graph_apply.go
@@ -177,6 +177,7 @@ var graphFieldHints = map[string]string{
 	"depends":        "use the top-level 'edges' array or per-node 'deps' with type 'blocks'",
 	"children":       "set 'parent_key' or 'parent' on each child instead of listing children on the parent",
 	"acceptance":     "use 'acceptance_criteria' (matching the issue model's JSON field)",
+	"body":           "use 'description' (matching the issue model's JSON field)",
 	"due":            "use 'due_at' with an RFC3339 timestamp",
 	"defer":          "use 'defer_until' with an RFC3339 timestamp",
 	"event_category": "use 'event_kind' (matching the issue model's JSON field)",

--- a/cmd/bd/graph_apply_test.go
+++ b/cmd/bd/graph_apply_test.go
@@ -328,20 +328,23 @@ func TestWarnUnknownGraphFields_HintsForReporterFields(t *testing.T) {
 	// After GH#4064, "parent" is a recognized field. Only "blocks" triggers a hint.
 	var buf bytes.Buffer
 	hinted := warnUnknownGraphFields(&buf, map[string][]string{
-		`node["c1"]`: {"blocks"},
+		`node["c1"]`: {"blocks", "body"},
 	})
 
 	out := buf.String()
-	if !strings.Contains(out, `unknown field(s): [blocks]`) {
+	if !strings.Contains(out, `unknown field(s): [blocks body]`) {
 		t.Errorf("warning missing field list: %q", out)
 	}
 	if !strings.Contains(out, "deps") {
 		t.Errorf("expected 'blocks' hint to mention deps: %q", out)
 	}
+	if !strings.Contains(out, "description") {
+		t.Errorf("expected 'body' hint to mention description: %q", out)
+	}
 
 	got := append([]string(nil), hinted...)
 	sort.Strings(got)
-	want := []string{"blocks"}
+	want := []string{"blocks", "body"}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("hinted fields: got=%v want=%v", got, want)
 	}


### PR DESCRIPTION
## What

Adds one entry to `graphFieldHints`: an unknown `body` field in a `--graph` JSON plan now gets a corrective hint pointing at `description`, plus test coverage in `TestWarnUnknownGraphFields_HintsForReporterFields`.

## Why

`--body` is a real hidden alias for `--description` on the create flags (GitHub CLI convention, `cmd/bd/flags.go`), so `body` in a graph plan is a plausible agent/user mistake — and until now it produced a bare unknown-field warning with no pointer at the schema field.

This is the surviving unique piece of #4439 (kevglynn), absorbed per maintainer policy with `Co-authored-by` attribution. The rest of that PR — content fields on `GraphApplyNode`, the negative-estimate guard, proxied/embedded path symmetry — was independently superseded on `main` by the full-field materializer work (3567866de and follow-ups). #4439 will be closed with a full explanation referencing this PR.

_claude-fable-5-xhigh on behalf of matt wilkie_
