### PR TITLE
fix(test): prebuild bd for subprocess tests; fit cmd/bd inside the package deadline (wy-4mtr0)

### DIFF
--- a/cmd/bd/cli_fast_test.go
+++ b/cmd/bd/cli_fast_test.go
@@ -705,19 +705,20 @@ func init() {
 	if os.Getenv(worktreeRemoveHelperEnv) != "" {
 		return
 	}
-	// Use existing bd binary from repo root if available, otherwise build once
+	// Prebuilt fast path (scripts/test.sh and CI export this), else build
+	// once. No repo-root ./bd reuse: a stale checkout-root binary silently
+	// substitutes itself for the source under test (wy-4mtr0).
+	if prebuilt := os.Getenv("BEADS_TEST_BD_BINARY"); prebuilt != "" {
+		if abs, err := filepath.Abs(prebuilt); err == nil {
+			if _, statErr := os.Stat(abs); statErr == nil {
+				testBD = abs
+				return
+			}
+		}
+	}
 	bdBinary := "bd"
 	if runtime.GOOS == "windows" {
 		bdBinary = "bd.exe"
-	}
-
-	// Check if bd binary exists in repo root (../../bd from cmd/bd/)
-	repoRoot := filepath.Join("..", "..")
-	existingBD := filepath.Join(repoRoot, bdBinary)
-	if _, err := os.Stat(existingBD); err == nil {
-		// Use existing binary
-		testBD, _ = filepath.Abs(existingBD)
-		return
 	}
 
 	// Fall back to building once (for CI or fresh checkouts)

--- a/cmd/bd/context_binding_integration_test.go
+++ b/cmd/bd/context_binding_integration_test.go
@@ -103,17 +103,10 @@ func TestListExplicitDBPathRebindsTargetContext(t *testing.T) {
 		t.Fatalf("create issue: %v", err)
 	}
 
-	binPath := filepath.Join(t.TempDir(), "bd-under-test")
-	packageDir, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("getwd: %v", err)
-	}
-	buildCmd := exec.Command("go", "build", "-o", binPath, ".")
-	buildCmd.Dir = packageDir
-	buildOut, err := buildCmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf("go build failed: %v\n%s", err, buildOut)
-	}
+	// Shared once-per-process binary (honors BEADS_TEST_BD_BINARY) instead of
+	// a per-test go build — the in-test link steps dominated cmd/bd's wall
+	// clock (wy-4mtr0).
+	binPath := buildBDForInitTests(t)
 
 	listCmd := exec.Command(binPath, "list", "--db", filepath.Join(targetBeadsDir, "dolt"), "--json")
 	listCmd.Dir = callerRepo

--- a/cmd/bd/dolt_autostart_lifecycle_integration_test.go
+++ b/cmd/bd/dolt_autostart_lifecycle_integration_test.go
@@ -123,18 +123,10 @@ func TestE2E_AutoStartedRepoLocalServerPersistsAcrossCommands(t *testing.T) {
 
 func buildLifecycleTestBinary(t *testing.T) string {
 	t.Helper()
-	pkgDir, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("getwd: %v", err)
-	}
-	bdBinary := filepath.Join(t.TempDir(), "bd")
-	cmd := exec.Command("go", "build", "-tags", "gms_pure_go", "-o", bdBinary, ".")
-	cmd.Dir = pkgDir
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf("go build failed: %v\n%s", err, out)
-	}
-	return bdBinary
+	// Shared once-per-process binary (honors BEADS_TEST_BD_BINARY) instead of
+	// a per-test go build — the in-test link steps dominated cmd/bd's wall
+	// clock (wy-4mtr0).
+	return buildBDForInitTests(t)
 }
 
 func runBDExecWithBinary(t *testing.T, bdBinary string, dir string, env []string, args ...string) (string, error) {

--- a/cmd/bd/import_prefix_test.go
+++ b/cmd/bd/import_prefix_test.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"testing"
 )
@@ -28,18 +27,10 @@ func TestCLI_Import_ForeignPrefix_E2E(t *testing.T) {
 		t.Skip("skipping: Dolt test container not available")
 	}
 
-	// Step 0: Build the bd binary
+	// Step 0: Locate the bd binary — shared once-per-process build (honors
+	// BEADS_TEST_BD_BINARY) instead of a per-test go build (wy-4mtr0).
 	tmpDir := t.TempDir()
-	bdName := "bd"
-	if runtime.GOOS == "windows" {
-		bdName = "bd.exe"
-	}
-	bdBinary := filepath.Join(tmpDir, bdName)
-
-	buildCmd := exec.Command("go", "build", "-tags", "gms_pure_go", "-o", bdBinary, ".")
-	if out, err := buildCmd.CombinedOutput(); err != nil {
-		t.Fatalf("Failed to build bd: %v\nOutput: %s", err, out)
-	}
+	bdBinary := buildBDForInitTests(t)
 
 	// Step 1: Setup a database with a specific prefix
 	projDir := filepath.Join(tmpDir, "proj")

--- a/cmd/bd/main_test.go
+++ b/cmd/bd/main_test.go
@@ -246,17 +246,10 @@ func TestListUsesRepoBeadsDirWhenDoltDataDirEscapesDotBeads(t *testing.T) {
 	t.Setenv("BEADS_DOLT_SERVER_PORT", "")
 	t.Setenv("BEADS_DOLT_PORT", "")
 
-	binPath := filepath.Join(t.TempDir(), "bd-under-test")
-	packageDir, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("getwd: %v", err)
-	}
-	buildCmd := exec.Command("go", "build", "-tags", "gms_pure_go", "-o", binPath, ".")
-	buildCmd.Dir = packageDir
-	buildOut, err := buildCmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf("go build failed: %v\n%s", err, buildOut)
-	}
+	// Shared once-per-process binary (honors BEADS_TEST_BD_BINARY) instead of
+	// a per-test go build — the in-test link steps dominated cmd/bd's wall
+	// clock (wy-4mtr0).
+	binPath := buildBDForInitTests(t)
 
 	listCmd := exec.Command(binPath, "list", "--json")
 	listCmd.Dir = repoDir

--- a/cmd/bd/scripttest_test.go
+++ b/cmd/bd/scripttest_test.go
@@ -22,11 +22,17 @@ func TestScripts(t *testing.T) {
 		t.Skip("scripttest uses Unix shell commands (sh -c), skipping on Windows")
 	}
 
-	// Build the bd binary
+	// Locate or build the bd binary. Prebuilt fast path (scripts/test.sh and
+	// CI export BEADS_TEST_BD_BINARY, wy-4mtr0); the scripts invoke plain
+	// `bd` via `sh -c`, so the prebuilt is only usable when its basename is
+	// exactly the expected executable name.
 	exeName := "bd"
 	binDir := t.TempDir()
 	exe := filepath.Join(binDir, exeName)
-	if err := exec.Command("go", "build", "-tags", "gms_pure_go", "-o", exe, ".").Run(); err != nil {
+	if prebuilt, err := findPrebuiltBDBinary(); err == nil && prebuilt != "" && filepath.Base(prebuilt) == exeName {
+		exe = prebuilt
+		binDir = filepath.Dir(prebuilt)
+	} else if err := exec.Command("go", "build", "-tags", "gms_pure_go", "-o", exe, ".").Run(); err != nil {
 		t.Fatal(err)
 	}
 

--- a/cmd/bd/test_helpers_pure_test.go
+++ b/cmd/bd/test_helpers_pure_test.go
@@ -282,21 +282,19 @@ func findPrebuiltBDBinary() (string, error) {
 	return "", nil
 }
 
-// isCGOBuild reports whether the binary at path was compiled with CGO enabled.
-// Subprocess init tests require embedded Dolt which is only available in CGO builds.
-// Returns true when the build info cannot be read (assumes CGO capable).
-func isCGOBuild(path string) bool {
-	out, err := exec.Command("go", "version", "-m", path).Output()
-	if err != nil {
-		return true
-	}
-	return !strings.Contains(string(out), "\tbuild\tCGO_ENABLED=0\n")
-}
-
 // buildBDForInitTests builds (or locates) a bd binary suitable for subprocess
 // tests. Uses the gms_pure_go tag so the resulting binary works in either
 // CGO mode. Lives in the pure-Go helpers file so subprocess-style tests can
 // run without the test package itself depending on cgo at compile time.
+//
+// The fast path is BEADS_TEST_BD_BINARY (exported by scripts/test.sh and CI),
+// via findPrebuiltBDBinary. There is deliberately NO repo-root ./bd reuse
+// here anymore: that "optimization" silently ran subprocess tests against
+// whatever stale binary happened to sit in the checkout root — a two-day-old
+// one produced phantom TestCreateDepsAtomicity failures (features the source
+// under test had, the binary didn't). Tests must exercise the checkout's
+// source or an explicitly supplied binary, never an incidental artifact
+// (wy-4mtr0).
 func buildBDForInitTests(t *testing.T) string {
 	t.Helper()
 	initTestBDOnce.Do(func() {
@@ -312,19 +310,6 @@ func buildBDForInitTests(t *testing.T) string {
 		bdBinary := "bd"
 		if runtime.GOOS == windowsOS {
 			bdBinary = "bd.exe"
-		}
-		// Preserve the existing local optimization: if a bd binary exists in
-		// the repository root, init-style subprocess tests can reuse it —
-		// but only if it was compiled with CGO enabled. Embedded Dolt requires
-		// CGO; a CGO_ENABLED=0 binary will fail bd init without --server.
-		existingBD := filepath.Join("..", "..", bdBinary)
-		if _, err := os.Stat(existingBD); err == nil {
-			absPath, _ := filepath.Abs(existingBD)
-			if isCGOBuild(absPath) {
-				initTestBD = absPath
-				return
-			}
-			// Pre-built binary is CGO-disabled — fall through to build fresh.
 		}
 		// Fall back to building.
 		tmpDir, err := testTempDir("bd-init-test-*")

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -28,8 +28,21 @@ build_skip_pattern() {
     echo "$pattern"
 }
 
-# Default values
-TIMEOUT="${TEST_TIMEOUT:-3m}"
+# Default values.
+#
+# TIMEOUT is go test's PER-PACKAGE deadline — a hang backstop, not a
+# performance budget: it costs nothing while packages pass. The floor is set
+# by cmd/bd, the slowest package: measured 2026-07-26 on a busy darwin fleet
+# box (wy-4mtr0), its default suite is ~1090s of test time across ~1490 tests
+# (mostly serial — subprocess tests that spawn bd + embedded Dolt per
+# invocation, largely t.Setenv-bound so they cannot t.Parallel), giving
+# ~18min wall WITH the prebuilt-binary fast path below already removing the
+# in-test `go build` steps. 3m could never fit that, which made every
+# full-suite run FAIL with a package deadline panic naming no failing test.
+# 25m holds the measurement plus fleet-load headroom (the passing full-suite
+# acceptance run clocked cmd/bd at 870s under -p 4 package concurrency).
+# Raise via TEST_TIMEOUT; don't lower it below cmd/bd's measured runtime.
+TIMEOUT="${TEST_TIMEOUT:-25m}"
 GO_TEST_PKG_PARALLEL="${GO_TEST_PKG_PARALLEL:-4}"
 GO_TEST_PARALLEL="${GO_TEST_PARALLEL:-4}"
 SKIP_PATTERN=$(build_skip_pattern)
@@ -74,6 +87,35 @@ done
 # Default to all packages if none specified
 if [[ ${#PACKAGES[@]} -eq 0 ]]; then
     PACKAGES=("./...")
+fi
+
+# Prebuild bd once for subprocess-style tests (wy-4mtr0). cmd/bd has a dozen
+# test helpers that otherwise each `go build` the full bd binary inside the
+# test run — on a busy machine those link steps alone can blow the package
+# deadline, and one helper used to silently fall back to a stale repo-root
+# ./bd. CI already exports BEADS_TEST_BD_BINARY from a prebuilt artifact
+# (.github/workflows/main.yml); this gives the local runner the same fast
+# path. A caller-supplied BEADS_TEST_BD_BINARY always wins; skipped when the
+# requested packages cannot include cmd/bd.
+if [[ -z "${BEADS_TEST_BD_BINARY:-}" ]]; then
+    case " ${PACKAGES[*]} " in
+        # Any recursive pattern (./..., ./cmd/...) can expand to cmd/bd.
+        *"..."* | *"cmd/bd"*)
+            if [[ -n "${BEADS_TEST_ENV_ROOT:-}" ]]; then
+                PREBUILT_BD_DIR="$BEADS_TEST_ENV_ROOT/prebuilt-bd"
+            else
+                PREBUILT_BD_DIR=$(mktemp -d "${TMPDIR:-/tmp}/beads-prebuilt-bd-XXXXXX")
+            fi
+            mkdir -p "$PREBUILT_BD_DIR"
+            echo "Prebuilding bd for subprocess tests..." >&2
+            if go build -o "$PREBUILT_BD_DIR/bd" "$REPO_ROOT/cmd/bd"; then
+                export BEADS_TEST_BD_BINARY="$PREBUILT_BD_DIR/bd"
+                echo "Prebuilt bd: $BEADS_TEST_BD_BINARY" >&2
+            else
+                echo "WARN: bd prebuild failed; tests will build their own binaries" >&2
+            fi
+            ;;
+    esac
 fi
 
 # Optional: start a single shared Dolt test server for all packages.


### PR DESCRIPTION
## Problem (wyvern wy-4mtr0, filed by navi)

`./scripts/test.sh` with no flags could never produce a green full-suite receipt on a busy darwin fleet machine: cmd/bd tripped the 3m per-package go test deadline — `panic: test timed out after 3m0s` with one test running at 0s, i.e. the package alarm, not a hang. Acceptance lines were getting hand-waved because no green receipt was possible.

## Measurements (2026-07-26, the reporting machine class)

- cmd/bd's default suite: **~1090s of test time across ~1486 tests** — mostly serial, since the heavy prime/metrics/init families are `t.Setenv`-bound and cannot `t.Parallel`.
- Wall clock was dominated by **twelve separate in-test `go build` sites**, each linking the full cgo bd binary (top offender `TestClose_UpdatesLastTouched` = 142s of which nearly all was the once-build; `TestCreateDepsAtomicity` dropped 126s → 27s once prebuilt).
- CI never sees this: main.yml prebuilds bd and exports `BEADS_TEST_BD_BINARY` — but only 5 of the 12 builder sites honored it, and the local runner never got the prebuild at all.

## Fix — no naked timeout bump

1. **scripts/test.sh prebuilds bd once** and exports `BEADS_TEST_BD_BINARY` (same fast path as CI). Binary lands in the test-env root so cleanup is inherited; a caller-supplied value always wins; skipped when the requested packages can't include cmd/bd.
2. **All twelve in-test builder sites now honor `BEADS_TEST_BD_BINARY`** (six built unconditionally before). The **repo-root `./bd` reuse is removed** from `buildBDForInitTests` and `cli_fast_test`: it silently ran subprocess tests against whatever stale binary sat in the checkout root — a two-day-old one produced phantom `TestCreateDepsAtomicity` failures during this investigation (`--waits-for-gate` silently ignored by a binary predating the feature). Tests must exercise the checkout's source or an explicitly supplied binary, never an incidental artifact.
3. **Default TIMEOUT 3m → 25m, justified in the comment**: the deadline is a hang backstop, not a performance budget — it costs nothing while packages pass. cmd/bd measured 870s under `-p 4` in the passing acceptance run; 25m holds that plus fleet-load headroom.

## Acceptance (the bead's criterion, verified)

`./scripts/test.sh` with NO extra flags on the busy darwin machine class: **exit 0, 71 packages ok, zero failures** (cmd/bd 870s). One contention flake was chased down and cleared: `TestPrime_MemoriesOnly_WithCustomPrimeMd` has a 30s per-subprocess deadline that fired under deliberate parallel load; it passes 3/3 isolated.

## Follow-up (out of scope, noted on the bead)

The deep runtime cut — sharing the per-test embedded-Dolt bring-up and unwinding the `t.Setenv` serialization of the subprocess families — interacts with wy-s4zdj (leaked test dolt servers on darwin) and remains open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EF8QbCbF6JnTuoCKvu9xiG