### PR TITLE
ci: give conformance explicit timeout budgets

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -19,6 +19,7 @@ env:
 jobs:
   conformance:
     name: Storage backend conformance (embedded Dolt oracle)
+    timeout-minutes: 45
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6

--- a/scripts/conformance.sh
+++ b/scripts/conformance.sh
@@ -40,9 +40,9 @@ echo "==> Tier 1: in-process store conformance + wedge gates"
 # (assert_conformance_passed explains why the skip/pass checks anchor to column-0 lines.)
 embedded_dolt_log="$(mktemp)"
 BEADS_TEST_EMBEDDED_DOLT=1 CGO_ENABLED=1 go test -tags "$TAGS" -v \
-  ./internal/storage/embeddeddolt/ -run TestConformance | tee "$embedded_dolt_log"
+  -timeout 30m ./internal/storage/embeddeddolt/ -run TestConformance | tee "$embedded_dolt_log"
 assert_conformance_passed "$embedded_dolt_log" "embedded-Dolt reference (need BEADS_TEST_EMBEDDED_DOLT=1)"
 echo "==> Tier 2: end-to-end 'bd init' + CLI conformance (reference round-trip)"
-CGO_ENABLED=1 go test -tags "$TAGS e2e" ./test/conformance/
+CGO_ENABLED=1 go test -tags "$TAGS e2e" -timeout 10m ./test/conformance/
 
 echo "==> conformance OK"

--- a/scripts/conformance_script_test.go
+++ b/scripts/conformance_script_test.go
@@ -1,0 +1,166 @@
+package scripts_test
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestConformanceScriptUsesExplicitTimeoutBudgets(t *testing.T) {
+	run := runConformanceScript(t, 0, 0)
+	if run.err != nil {
+		t.Fatalf("conformance.sh failed: %v\n%s", run.err, run.output)
+	}
+
+	want := [][]string{
+		{"test", "-tags", "gms_pure_go", "-v", "-timeout", "30m", "./internal/storage/embeddeddolt/", "-run", "TestConformance"},
+		{"test", "-tags", "gms_pure_go e2e", "-timeout", "10m", "./test/conformance/"},
+	}
+	if !reflect.DeepEqual(run.calls, want) {
+		t.Fatalf("go calls = %#v, want %#v", run.calls, want)
+	}
+}
+
+func TestConformanceScriptPropagatesGoTestFailures(t *testing.T) {
+	tests := []struct {
+		name      string
+		failCall  int
+		exitCode  int
+		wantCalls int
+	}{
+		{name: "tier 1", failCall: 1, exitCode: 41, wantCalls: 1},
+		{name: "tier 2", failCall: 2, exitCode: 42, wantCalls: 2},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			run := runConformanceScript(t, test.failCall, test.exitCode)
+			if got := conformanceExitCode(run.err); got != test.exitCode {
+				t.Fatalf("exit = %d, want %d; error=%v\n%s", got, test.exitCode, run.err, run.output)
+			}
+			if len(run.calls) != test.wantCalls {
+				t.Fatalf("go call count = %d, want %d; calls=%#v", len(run.calls), test.wantCalls, run.calls)
+			}
+		})
+	}
+}
+
+func conformanceExitCode(err error) int {
+	if err == nil {
+		return 0
+	}
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		return exitErr.ExitCode()
+	}
+	return -1
+}
+
+func TestConformanceWorkflowHasOuterTimeoutBudget(t *testing.T) {
+	path := filepath.Join(sourceRepoRoot(t), ".github", "workflows", "conformance.yml")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := strings.ReplaceAll(string(data), "\r\n", "\n")
+	want := "  conformance:\n" +
+		"    name: Storage backend conformance (embedded Dolt oracle)\n" +
+		"    timeout-minutes: 45\n" +
+		"    runs-on: ubuntu-latest\n"
+	if !strings.Contains(text, want) {
+		t.Fatalf("conformance job does not declare the maintained 45-minute outer budget:\n%s", text)
+	}
+}
+
+type conformanceRun struct {
+	output string
+	calls  [][]string
+	err    error
+}
+
+func runConformanceScript(t *testing.T, failCall, failExit int) conformanceRun {
+	t.Helper()
+
+	bash, err := exec.LookPath("bash")
+	if err != nil {
+		t.Skipf("bash is required to test conformance.sh: %v", err)
+	}
+
+	bin := t.TempDir()
+	stateDir := t.TempDir()
+	callLog := filepath.Join(stateDir, "go-calls")
+	if err := os.WriteFile(callLog, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	writeExecutable(t, filepath.Join(bin, "go"), `#!/bin/sh
+set -eu
+count=0
+if [ -s "$GO_CALL_COUNT" ]; then
+  count="$(cat "$GO_CALL_COUNT")"
+fi
+count=$((count + 1))
+printf '%s\n' "$count" >"$GO_CALL_COUNT"
+printf '%s\0' "$#" >>"$GO_CALL_LOG"
+printf '%s\0' "$@" >>"$GO_CALL_LOG"
+if [ "$count" = "$GO_FAIL_CALL" ]; then
+  exit "$GO_FAIL_EXIT"
+fi
+if [ "$count" = 1 ]; then
+  printf '%s\n' '--- PASS: TestConformance (0.01s)'
+fi
+`)
+
+	root := sourceRepoRoot(t)
+	binPath := shellPath(t, bin)
+	statePath := shellPath(t, stateDir)
+	path := binPath + ":" + os.Getenv("PATH") + ":/usr/bin:/bin"
+	if runtime.GOOS == "windows" {
+		path = binPath + ":/usr/bin:/bin"
+	}
+	cmd := exec.Command(bash, "scripts/conformance.sh")
+	cmd.Dir = root
+	cmd.Env = []string{
+		"PATH=" + path,
+		"HOME=" + statePath,
+		"LC_ALL=C",
+		"LANG=C",
+		"BASH_ENV=",
+		"ENV=",
+		"GO_CALL_LOG=" + statePath + "/go-calls",
+		"GO_CALL_COUNT=" + statePath + "/go-call-count",
+		"GO_FAIL_CALL=" + strconv.Itoa(failCall),
+		"GO_FAIL_EXIT=" + strconv.Itoa(failExit),
+	}
+	output, runErr := cmd.CombinedOutput()
+	log, readErr := os.ReadFile(callLog)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	return conformanceRun{output: string(output), calls: parseArgvCalls(t, log), err: runErr}
+}
+
+func parseArgvCalls(t *testing.T, log []byte) [][]string {
+	t.Helper()
+	tokens := strings.Split(string(log), "\x00")
+	if len(tokens) == 0 || tokens[len(tokens)-1] != "" {
+		t.Fatalf("invalid NUL-delimited argv log: %q", log)
+	}
+	tokens = tokens[:len(tokens)-1]
+
+	var calls [][]string
+	for len(tokens) > 0 {
+		count, err := strconv.Atoi(tokens[0])
+		if err != nil || count < 0 || len(tokens) < count+1 {
+			t.Fatalf("invalid NUL-delimited argv log: %q", log)
+		}
+		calls = append(calls, append([]string(nil), tokens[1:count+1]...))
+		tokens = tokens[count+1:]
+	}
+	return calls
+}


### PR DESCRIPTION
# ci: give conformance explicit timeout budgets

Fixes #5070

## What

- Give the embedded-Dolt reference oracle an explicit 30-minute Go test
  timeout.
- Preserve the end-to-end CLI tier's existing ten-minute behavior explicitly.
- Add a 45-minute outer timeout to the standalone Conformance job.
- Add black-box tests for both exact Go argument vectors and for nonzero exit
  propagation from either tier.

## Why

The standalone entrypoint inherited Go's ten-minute default even though the
embedded oracle regularly needs longer and the dedicated conformance jobs
already budget 30 minutes. PR #4979 run `29973997194` timed out at exactly ten
minutes while the same merge commit passed in the explicitly budgeted
conformance lane.

The three deadlines are intentionally nested:

- Tier 1: 30 minutes for the long-running embedded oracle.
- Tier 2: 10 minutes, preserving its prior implicit behavior.
- Workflow: 45 minutes for both tiers plus setup and teardown.

The workflow placement is not a platform claim: these relative timeout and
failure-propagation semantics are host-independent. The exact-head standalone
Conformance result remains the required publication-time execution proof.

## Validation

Exact candidate `131c17fdfcc5f814b198292421a36917e2e811c9` passed:

- black-box, NUL-delimited argv assertions for the exact 30m and 10m Go calls;
- failure-propagation falsifiers for Tier 1 and Tier 2;
- focused, default, and integration Go tests;
- real Go command grammar checks;
- Bash syntax, ShellCheck, actionlint, golangci-lint, `gofmt`, and
  `git diff --check`;
- independent contract-centred review of the exact candidate.

The fresh exact-head `Conformance / Storage backend conformance (embedded Dolt
oracle)` pull-request job remains mandatory after publication.

---

_codex-tui-gpt-5.6-sol-ultra on behalf of Ewen Cuthiell_
