### PR TITLE
ci: lint Windows-tagged Go code

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -13,7 +13,7 @@
 
 ## Tech Stack
 
-- **Language**: Go 1.21+
+- **Language**: exact version from `go.mod` (currently Go 1.26.5)
 - **Storage**: Dolt (version-controlled SQL database)
 - **CLI Framework**: Cobra
 - **Testing**: Go standard testing + table-driven tests
@@ -29,7 +29,8 @@
 - Never create test issues in production DB (use temporary DB)
 
 ### Code Style
-- Run `golangci-lint run ./...` before committing
+- Run `make ci-pr-lint`; direct lint and pre-commit hooks are not equivalent to
+  the repository-owned v2 gate
 - Follow existing patterns in `cmd/bd/` for new commands
 - Add `--json` flag to all commands for programmatic use
 - Update docs when changing behavior

--- a/.github/workflows/ci-measurements.yml
+++ b/.github/workflows/ci-measurements.yml
@@ -76,6 +76,15 @@ jobs:
           dolt config --global --add user.email "ci@beads.test"
 
       - name: Measure commands
+        env:
+          BASH_ENV: ""
+          ENV: ""
+          BEADS_CI_EXPECTED_OUTER_OS: linux
+          BEADS_CI_EXPECTED_TARGET_GOOS: linux
+          BEADS_CI_EXPECTED_TARGET_GOARCH: amd64
+          BEADS_CI_EXPECTED_TARGET_CGO_ENABLED: "1"
+          BEADS_CI_EXPECTED_GOLANGCI_LINT_VERSION: "2.10.1"
+          BEADS_CI_INSTALL_GOLANGCI_LINT: "1"
         run: |
           set -euo pipefail
           mkdir -p artifacts
@@ -83,11 +92,13 @@ jobs:
           source ./.buildflags
 
           ci_time "install gotestsum" -- go install gotest.tools/gotestsum@v1.13.0
-          ci_time "install golangci-lint" -- go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.10.1
           status=0
           ci_time "pr-policy wrapper" -- make ci-pr-policy || status=$?
           ci_time "pr-core gotestsum" -- gotestsum --junitfile artifacts/pr-core-junit.xml --format testdox -- -race -short -skip '^TestEmbedded' ./... || status=$?
-          ci_time "pr-lint wrapper" -- make ci-pr-lint || status=$?
+          ci_time "pr-lint wrapper" -- \
+            env -u MAKE -u MAKEFLAGS -u MFLAGS -u GNUMAKEFLAGS -u MAKEFILES \
+              /usr/bin/make -f Makefile CI_BASH=/usr/bin/bash ci-pr-lint ||
+            status=$?
           exit "$status"
 
       - name: Upload measurement artifacts

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,14 +62,21 @@ jobs:
         with:
           go-version-file: 'go.mod'
 
-      - name: Install golangci-lint
-        run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.10.1
-
       - name: Run policy checks
         run: make ci-pr-policy
 
-      - name: Run lint checks
-        run: make ci-pr-lint
+      - name: Run bound lint checks
+        shell: /usr/bin/bash --noprofile --norc -euo pipefail {0}
+        env:
+          BASH_ENV: ""
+          ENV: ""
+          BEADS_CI_EXPECTED_OUTER_OS: linux
+          BEADS_CI_EXPECTED_TARGET_GOOS: linux
+          BEADS_CI_EXPECTED_TARGET_GOARCH: amd64
+          BEADS_CI_EXPECTED_TARGET_CGO_ENABLED: "1"
+          BEADS_CI_EXPECTED_GOLANGCI_LINT_VERSION: "2.10.1"
+          BEADS_CI_INSTALL_GOLANGCI_LINT: "1"
+        run: env -u MAKE -u MAKEFLAGS -u MFLAGS -u GNUMAKEFLAGS -u MAKEFILES /usr/bin/make -f Makefile CI_BASH=/usr/bin/bash ci-pr-lint
 
       - name: Build reusable Linux artifacts
         run: |
@@ -380,7 +387,8 @@ jobs:
 
   pr-lint-wrapper:
     name: PR Lint (wrapper timing)
-    runs-on: ubuntu-latest
+    runs-on: macos-15
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
 
@@ -389,11 +397,22 @@ jobs:
         with:
           go-version-file: 'go.mod'
 
-      - name: Install golangci-lint
-        run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.10.1
-
-      - name: Run PR lint wrapper
-        run: make ci-pr-lint
+      - name: Run bound PR lint wrapper
+        shell: /bin/bash --noprofile --norc -euo pipefail {0}
+        env:
+          BASH_ENV: ""
+          ENV: ""
+          GOOS: darwin
+          GOARCH: arm64
+          CGO_ENABLED: "1"
+          BEADS_CI_EXPECTED_OUTER_OS: macos
+          BEADS_CI_EXPECTED_TARGET_GOOS: darwin
+          BEADS_CI_EXPECTED_TARGET_GOARCH: arm64
+          BEADS_CI_EXPECTED_TARGET_CGO_ENABLED: "1"
+          BEADS_CI_EXPECTED_MAKE_VERSION: "3.81"
+          BEADS_CI_EXPECTED_GOLANGCI_LINT_VERSION: "2.10.1"
+          BEADS_CI_INSTALL_GOLANGCI_LINT: "1"
+        run: env -u MAKE -u MAKEFLAGS -u MFLAGS -u GNUMAKEFLAGS -u MAKEFILES /usr/bin/make -f Makefile CI_BASH=/bin/bash ci-pr-lint
 
   # Cross-platform test matrix (Linux/macOS only - Windows uses smoke tests)
   test:
@@ -977,9 +996,11 @@ jobs:
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9
+        env:
+          GOWORK: "off"
         with:
-          version: latest
-          args: --timeout=5m --build-tags=gms_pure_go
+          version: v2.10.1
+          args: --config=.golangci.yml --modules-download-mode=readonly --timeout=5m --build-tags=gms_pure_go
 
   test-nix:
     name: Test Nix Flake

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -28,14 +28,21 @@ jobs:
         with:
           go-version-file: 'go.mod'
 
-      - name: Install golangci-lint
-        run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.10.1
-
       - name: Run policy checks
         run: make ci-pr-policy
 
-      - name: Run lint checks
-        run: make ci-pr-lint
+      - name: Run bound lint checks
+        shell: /usr/bin/bash --noprofile --norc -euo pipefail {0}
+        env:
+          BASH_ENV: ""
+          ENV: ""
+          BEADS_CI_EXPECTED_OUTER_OS: linux
+          BEADS_CI_EXPECTED_TARGET_GOOS: linux
+          BEADS_CI_EXPECTED_TARGET_GOARCH: amd64
+          BEADS_CI_EXPECTED_TARGET_CGO_ENABLED: "1"
+          BEADS_CI_EXPECTED_GOLANGCI_LINT_VERSION: "2.10.1"
+          BEADS_CI_INSTALL_GOLANGCI_LINT: "1"
+        run: env -u MAKE -u MAKEFLAGS -u MFLAGS -u GNUMAKEFLAGS -u MAKEFILES /usr/bin/make -f Makefile CI_BASH=/usr/bin/bash ci-pr-lint
 
       - name: Build reusable Linux artifacts
         run: |
@@ -439,7 +446,8 @@ jobs:
 
   pr-lint-wrapper:
     name: PR Lint (wrapper timing)
-    runs-on: ubuntu-latest
+    runs-on: macos-15
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
 
@@ -448,11 +456,386 @@ jobs:
         with:
           go-version-file: 'go.mod'
 
-      - name: Install golangci-lint
-        run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.10.1
+      - name: Refuse conflicting hosted and cleanup authority
+        shell: /bin/bash --noprofile --norc -euo pipefail {0}
+        env:
+          BASH_ENV: ""
+          ENV: ""
+          GOOS: darwin
+          GOARCH: arm64
+          CGO_ENABLED: "1"
+          BEADS_CI_EXPECTED_OUTER_OS: macos
+          BEADS_CI_EXPECTED_TARGET_GOOS: darwin
+          BEADS_CI_EXPECTED_TARGET_GOARCH: arm64
+          BEADS_CI_EXPECTED_TARGET_CGO_ENABLED: "1"
+          BEADS_CI_EXPECTED_MAKE_VERSION: "3.81"
+          BEADS_CI_EXPECTED_GOLANGCI_LINT_VERSION: "2.10.1"
+          BEADS_CI_INSTALL_GOLANGCI_LINT: "1"
+        run: |
+          refusal_count=0
+          public_make=(
+            env
+            -u MAKE
+            -u MAKEFLAGS
+            -u MFLAGS
+            -u GNUMAKEFLAGS
+            -u MAKEFILES
+            /usr/bin/make
+            -f
+            Makefile
+          )
+          assert_refusal() {
+            local name="$1"
+            local expected="$2"
+            shift 2
+            local output="$RUNNER_TEMP/pr-lint-refusal-$name.output"
+            if "$@" >"$output" 2>&1; then
+              printf 'Refusal case %s unexpectedly succeeded\n' "$name" >&2
+              exit 1
+            fi
+            grep -F -- "$expected" "$output" >/dev/null || {
+              printf 'Refusal case %s failed for an unrelated reason\n' "$name" >&2
+              cat "$output" >&2
+              exit 1
+            }
+            refusal_count=$((refusal_count + 1))
+          }
 
-      - name: Run PR lint wrapper
-        run: make ci-pr-lint
+          assert_refusal make-origin \
+            'MAKE origin must be default in GitHub Actions' \
+            "${public_make[@]}" MAKE=/tmp/forged CI_BASH=/bin/bash ci-pr-lint
+          assert_refusal makeflags-origin \
+            'MAKEFLAGS origin must be file in GitHub Actions' \
+            "${public_make[@]}" MAKEFLAGS=-s CI_BASH=/bin/bash ci-pr-lint
+          # Detection occurs after Make parsing; the missing path cannot run
+          # parse-time content and does not claim containment for malicious argv.
+          assert_refusal makefiles-origin \
+            'MAKEFILES must be absent at the public Make boundary' \
+            "${public_make[@]}" MAKEFILES=/definitely-missing-beads-forged.mk \
+              CI_BASH=/bin/bash ci-pr-lint
+          assert_refusal goos \
+            'GOOS conflicts with the protected hosted target' \
+            env GOOS=plan9 "${public_make[@]}" \
+              CI_AMBIENT_GOOS_PRESENT=0 CI_AMBIENT_GOOS=darwin \
+              CI_BASH=/bin/bash ci-pr-lint
+          assert_refusal goarch \
+            'GOARCH conflicts with the protected hosted target' \
+            env GOARCH=386 "${public_make[@]}" \
+              CI_AMBIENT_GOARCH_PRESENT=0 CI_AMBIENT_GOARCH=arm64 \
+              CI_BASH=/bin/bash ci-pr-lint
+          assert_refusal cgo \
+            'CGO_ENABLED conflicts with the protected hosted target' \
+            env CGO_ENABLED=0 "${public_make[@]}" \
+              CI_AMBIENT_CGO_ENABLED_PRESENT=0 CI_AMBIENT_CGO_ENABLED=1 \
+              CI_BASH=/bin/bash ci-pr-lint
+
+          cleanup_target="$RUNNER_TEMP/pr-lint-cleanup-target"
+          cleanup_link="$RUNNER_TEMP/pr-lint-cleanup-link"
+          mkdir "$cleanup_target"
+          ln -s "$cleanup_target" "$cleanup_link"
+          trap 'rm -f "$cleanup_link"; rmdir "$cleanup_target"' EXIT
+          assert_refusal cleanup-root \
+            'RUNNER_TEMP must not be a symbolic link' \
+            env RUNNER_TEMP="$cleanup_link" \
+              "${public_make[@]}" CI_BASH=/bin/bash ci-pr-lint
+
+          cleanup_probe_root="$RUNNER_TEMP/pr-lint-cleanup-probes"
+          cleanup_probe_bin="$cleanup_probe_root/mktemp-bin"
+          mkdir -p "$cleanup_probe_bin"
+          alternate_make="$cleanup_probe_root/alternate-make"
+          ln -s /usr/bin/make "$alternate_make"
+          assert_refusal make-invocation-leaf \
+            'stock macOS GNU Make must be invoked through /usr/bin/make' \
+            env \
+              -u MAKE \
+              -u MAKEFLAGS \
+              -u MFLAGS \
+              -u GNUMAKEFLAGS \
+              -u MAKEFILES \
+              "$alternate_make" \
+              -f \
+              Makefile \
+              CI_BASH=/bin/bash \
+              ci-pr-lint
+          cat >"$cleanup_probe_bin/mktemp" <<'PROBE_MKTEMP'
+          #!/bin/bash
+          set -euo pipefail
+          case "${CLEANUP_PROBE_CASE:?}" in
+            malformed)
+              created="$RUNNER_TEMP/beads-pr-lint-tools.BAD"
+              ;;
+            outside)
+              created="${RUNNER_TEMP%/*}/beads-pr-lint-tools.OUTSIDE1"
+              ;;
+            nested)
+              created="$RUNNER_TEMP/pr-lint-cleanup-probes/nested/beads-pr-lint-tools.NESTED01"
+              ;;
+            *)
+              exit 91
+              ;;
+          esac
+          [[ ! -e "$created" && ! -L "$created" ]]
+          "$PROBE_MKDIR" -p -- "$created"
+          printf '%s\n' "$created" >"$CLEANUP_PROBE_RECEIPT"
+          printf '%s\n' "$created"
+          PROBE_MKTEMP
+          chmod +x "$cleanup_probe_bin/mktemp"
+
+          for cleanup_case in malformed outside nested; do
+            cleanup_receipt="$cleanup_probe_root/$cleanup_case.receipt"
+            assert_refusal "cleanup-$cleanup_case" \
+              'mktemp returned an unauthorized private linter directory' \
+              env \
+                PATH="$cleanup_probe_bin:$PATH" \
+                CLEANUP_PROBE_CASE="$cleanup_case" \
+                CLEANUP_PROBE_RECEIPT="$cleanup_receipt" \
+                PROBE_MKDIR="$(command -v mkdir)" \
+                "${public_make[@]}" CI_BASH=/bin/bash ci-pr-lint
+            retained_path="$(cat "$cleanup_receipt")"
+            [[ -d "$retained_path" && ! -L "$retained_path" ]] || {
+              printf 'Cleanup case %s did not retain %s\n' \
+                "$cleanup_case" "$retained_path" >&2
+              exit 1
+            }
+            rm -rf -- "$retained_path"
+          done
+
+          replace_probe_bin="$cleanup_probe_root/replace-bin"
+          mkdir -p "$replace_probe_bin"
+          real_go="$(command -v go)"
+          real_gofmt="${real_go%/*}/gofmt"
+          [[ -f "$real_gofmt" && -x "$real_gofmt" ]]
+          ln -s "$real_gofmt" "$replace_probe_bin/gofmt"
+          cat >"$replace_probe_bin/go" <<'PROBE_GO'
+          #!/bin/bash
+          set -euo pipefail
+          if [[ "${1:-}" == "tool" &&
+                "${2:-}" == "dist" &&
+                "${3:-}" == "list" &&
+                -f "${0%/*}/dist-list-failure" ]]; then
+            printf 'darwin/arm64\n'
+            exit 88
+          fi
+          if [[ "${1:-}" == "install" ]]; then
+            [[ "${GOENV:-}" == off ]]
+            [[ "${GOWORK:-}" == off ]]
+            [[ -n "${GOFLAGS+x}" && -z "$GOFLAGS" ]]
+            [[ "${GOTOOLCHAIN:-}" == local ]]
+            [[ -n "${GOEXPERIMENT+x}" && -z "$GOEXPERIMENT" ]]
+            [[ "${GOOS:-}" == darwin ]]
+            [[ "${GOARCH:-}" == arm64 ]]
+            [[ "${CGO_ENABLED:-}" == 0 ]]
+            [[ "${GOARM64:-}" == v8.0 ]]
+            [[ -z "${GOAMD64+x}" ]]
+            [[ -z "${GOROOT+x}" ]]
+            [[ -z "${CC+x}" && -z "${CXX+x}" ]]
+            if [[ -f "${0%/*}/partial-install-failure" ]]; then
+              printf 'partial\n' >"$GOBIN/partial-linter"
+              printf '%s\n' "$GOBIN" >"${0%/*}/partial-install.receipt"
+              exit 89
+            fi
+            linter="$GOBIN/golangci-lint"
+            cat >"$linter" <<'PROBE_LINTER'
+          #!/bin/bash
+          set -euo pipefail
+          case "${1:-}" in
+            version)
+              root="${0%/*}"
+              case "${CLEANUP_PROBE_MODE:?}" in
+                replaced)
+                  retained="${root}.retained"
+                  "$PROBE_MV" "$root" "$retained"
+                  "$PROBE_LN" -s "$retained" "$root"
+                  ;;
+                unexpected)
+                  printf 'unexpected\n' >"$root/unexpected-entry"
+                  ;;
+                clean)
+                  ;;
+                ordinary)
+                  printf '%s\n' "$root" >"$CLEANUP_PROBE_RECEIPT"
+                  exit 94
+                  ;;
+                int|term|hup)
+                  printf '%s\n' "$root" >"$CLEANUP_PROBE_RECEIPT"
+                  case "$CLEANUP_PROBE_MODE" in
+                    int) signal=INT ;;
+                    term) signal=TERM ;;
+                    hup) signal=HUP ;;
+                  esac
+                  kill -s "$signal" "$PPID"
+                  read -r -t 1 _ </dev/null || :
+                  ;;
+                *)
+                  exit 93
+                  ;;
+              esac
+              printf '%s\n' "$root" >"$CLEANUP_PROBE_RECEIPT"
+              printf 'golangci-lint has version 2.10.1\n'
+              ;;
+            run)
+              exit 0
+              ;;
+            *)
+              exit 92
+              ;;
+          esac
+          PROBE_LINTER
+            chmod +x "$linter"
+            exit 0
+          fi
+          exec "$PROBE_REAL_GO" "$@"
+          PROBE_GO
+          chmod +x "$replace_probe_bin/go"
+
+          touch "$replace_probe_bin/dist-list-failure"
+          assert_refusal dist-list-producer-failure \
+            'the bound Go executable could not enumerate supported Go targets' \
+            env \
+              PATH="$replace_probe_bin:$PATH" \
+              PROBE_REAL_GO="$real_go" \
+              "${public_make[@]}" CI_BASH=/bin/bash ci-pr-lint
+          rm -f "$replace_probe_bin/dist-list-failure"
+
+          touch "$replace_probe_bin/partial-install-failure"
+          assert_refusal cleanup-partial-install \
+            'refused unsafe private-tool cleanup' \
+            env \
+              PATH="$replace_probe_bin:$PATH" \
+              PROBE_REAL_GO="$real_go" \
+              "${public_make[@]}" CI_BASH=/bin/bash ci-pr-lint
+          rm -f "$replace_probe_bin/partial-install-failure"
+          partial_path="$(cat "$replace_probe_bin/partial-install.receipt")"
+          [[ -d "$partial_path" &&
+             ! -L "$partial_path" &&
+             -f "$partial_path/partial-linter" ]] || {
+            printf 'Partial installation was not retained at %s\n' \
+              "$partial_path" >&2
+            exit 1
+          }
+          rm -rf -- "$partial_path"
+
+          handled_cleanup_count=0
+          assert_handled_cleanup() {
+            local mode="$1"
+            local receipt="$cleanup_probe_root/$mode.receipt"
+            if env \
+                PATH="$replace_probe_bin:$PATH" \
+                CLEANUP_PROBE_MODE="$mode" \
+                CLEANUP_PROBE_RECEIPT="$receipt" \
+                PROBE_LN="$(command -v ln)" \
+                PROBE_MV="$(command -v mv)" \
+                PROBE_REAL_GO="$real_go" \
+                "${public_make[@]}" CI_BASH=/bin/bash ci-pr-lint \
+                >"$cleanup_probe_root/$mode.output" 2>&1; then
+              printf 'Handled cleanup case %s unexpectedly succeeded\n' \
+                "$mode" >&2
+              exit 1
+            fi
+            local cleaned_path
+            cleaned_path="$(cat "$receipt")"
+            [[ ! -e "$cleaned_path" && ! -L "$cleaned_path" ]] || {
+              printf 'Handled cleanup case %s retained %s\n' \
+                "$mode" "$cleaned_path" >&2
+              exit 1
+            }
+            handled_cleanup_count=$((handled_cleanup_count + 1))
+          }
+          for handled_mode in ordinary int term hup; do
+            assert_handled_cleanup "$handled_mode"
+          done
+          [[ "$handled_cleanup_count" -eq 4 ]]
+
+          ambient_receipt="$cleanup_probe_root/ambient-state.receipt"
+          env \
+            PATH="$replace_probe_bin:$PATH" \
+            GOFLAGS='-tags=ambient_install_poison' \
+            GOENV="$cleanup_probe_root/ambient-goenv" \
+            GOWORK="$cleanup_probe_root/ambient-go.work" \
+            GOTOOLCHAIN=auto \
+            GOEXPERIMENT=ambient_poison \
+            CLEANUP_PROBE_MODE=clean \
+            CLEANUP_PROBE_RECEIPT="$ambient_receipt" \
+            PROBE_LN="$(command -v ln)" \
+            PROBE_MV="$(command -v mv)" \
+            PROBE_REAL_GO="$real_go" \
+            "${public_make[@]}" CI_BASH=/bin/bash ci-pr-lint
+          ambient_path="$(cat "$ambient_receipt")"
+          [[ ! -e "$ambient_path" && ! -L "$ambient_path" ]] || {
+            printf 'Curated installation-state case retained %s\n' \
+              "$ambient_path" >&2
+            exit 1
+          }
+
+          replace_receipt="$cleanup_probe_root/replaced.receipt"
+          assert_refusal cleanup-replaced \
+            'refused unsafe private-tool cleanup' \
+            env \
+              PATH="$replace_probe_bin:$PATH" \
+              CLEANUP_PROBE_MODE=replaced \
+              CLEANUP_PROBE_RECEIPT="$replace_receipt" \
+              PROBE_CAT="$(command -v cat)" \
+              PROBE_CHMOD="$(command -v chmod)" \
+              PROBE_LN="$(command -v ln)" \
+              PROBE_MV="$(command -v mv)" \
+              PROBE_REAL_GO="$real_go" \
+              "${public_make[@]}" CI_BASH=/bin/bash ci-pr-lint
+          replaced_path="$(cat "$replace_receipt")"
+          [[ -L "$replaced_path" &&
+             -d "${replaced_path}.retained" &&
+             ! -L "${replaced_path}.retained" ]] || {
+            printf 'Cleanup replacement was not retained at %s\n' \
+              "$replaced_path" >&2
+            exit 1
+          }
+          rm -f -- "$replaced_path"
+          rm -rf -- "${replaced_path}.retained"
+
+          unexpected_receipt="$cleanup_probe_root/unexpected.receipt"
+          assert_refusal cleanup-unexpected \
+            'refused unsafe private-tool cleanup' \
+            env \
+              PATH="$replace_probe_bin:$PATH" \
+              CLEANUP_PROBE_MODE=unexpected \
+              CLEANUP_PROBE_RECEIPT="$unexpected_receipt" \
+              PROBE_CAT="$(command -v cat)" \
+              PROBE_CHMOD="$(command -v chmod)" \
+              PROBE_LN="$(command -v ln)" \
+              PROBE_MV="$(command -v mv)" \
+              PROBE_REAL_GO="$real_go" \
+              "${public_make[@]}" CI_BASH=/bin/bash ci-pr-lint
+          unexpected_path="$(cat "$unexpected_receipt")"
+          [[ -d "$unexpected_path" &&
+             ! -L "$unexpected_path" &&
+             -f "$unexpected_path/golangci-lint" &&
+             -f "$unexpected_path/unexpected-entry" ]] || {
+            printf 'Unexpected-entry cleanup was not retained at %s\n' \
+              "$unexpected_path" >&2
+            exit 1
+          }
+          rm -rf -- "$unexpected_path"
+          rm -rf -- "$cleanup_probe_root"
+
+          [[ "$refusal_count" -eq 15 ]]
+          printf 'PR lint host falsifiers passed (%s refusals; %s handled-cleanup signals/failures; ambient Go state curated)\n' \
+            "$refusal_count" "$handled_cleanup_count"
+
+      - name: Run bound PR lint wrapper
+        shell: /bin/bash --noprofile --norc -euo pipefail {0}
+        env:
+          BASH_ENV: ""
+          ENV: ""
+          GOOS: darwin
+          GOARCH: arm64
+          CGO_ENABLED: "1"
+          BEADS_CI_EXPECTED_OUTER_OS: macos
+          BEADS_CI_EXPECTED_TARGET_GOOS: darwin
+          BEADS_CI_EXPECTED_TARGET_GOARCH: arm64
+          BEADS_CI_EXPECTED_TARGET_CGO_ENABLED: "1"
+          BEADS_CI_EXPECTED_MAKE_VERSION: "3.81"
+          BEADS_CI_EXPECTED_GOLANGCI_LINT_VERSION: "2.10.1"
+          BEADS_CI_INSTALL_GOLANGCI_LINT: "1"
+        run: env -u MAKE -u MAKEFLAGS -u MFLAGS -u GNUMAKEFLAGS -u MAKEFILES /usr/bin/make -f Makefile CI_BASH=/bin/bash ci-pr-lint
 
   # Focused job for the hexagonal storage layer (internal/storage/domain/* and
   # internal/storage/uow). These packages back the proxied-server init path and
@@ -589,13 +972,16 @@ jobs:
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9
+        env:
+          GOWORK: "off"
         with:
-          version: latest
-          args: --timeout=5m --build-tags=gms_pure_go
+          version: v2.10.1
+          args: --config=.golangci.yml --modules-download-mode=readonly --timeout=5m --build-tags=gms_pure_go
 
   windows-make-shell:
     name: Windows Make shell (${{ matrix.host }})
     runs-on: windows-latest
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:
@@ -606,10 +992,74 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
 
-      - name: Install native GNU Make
+      - name: Set up exact native Go
         if: matrix.host == 'native'
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version: '1.26.5'
+
+      - name: Install native GNU Make and MinGW
+        if: matrix.host == 'native'
+        id: native_toolchain
         shell: pwsh
-        run: choco install make --version=4.4.1 --yes --no-progress
+        run: |
+          $ErrorActionPreference = 'Stop'
+          choco install make --version=4.4.1 --yes --no-progress
+          if ($LASTEXITCODE -ne 0) {
+            throw 'Could not install exact GNU Make 4.4.1'
+          }
+          choco install mingw --version=16.1.0 --yes --no-progress
+          if ($LASTEXITCODE -ne 0) {
+            throw 'Could not install exact MinGW 16.1.0'
+          }
+          # Chocolatey updates the machine PATH, but the current job process
+          # retains the hosted image's older C:\mingw64 entry. Bind the exact
+          # package layout instead of relying on a shell refresh or PATH order.
+          $compilerBin = [IO.Path]::GetFullPath(
+            (Join-Path $env:ProgramData 'mingw64\mingw64\bin'))
+          $compilers = @(
+            [pscustomobject]@{
+              Name = 'gcc.exe'
+              Path = Join-Path $compilerBin 'gcc.exe'
+            },
+            [pscustomobject]@{
+              Name = 'g++.exe'
+              Path = Join-Path $compilerBin 'g++.exe'
+            }
+          )
+          foreach ($compiler in $compilers) {
+            if (-not [IO.Path]::IsPathFullyQualified($compiler.Path) -or
+                [IO.Path]::GetFileName($compiler.Path) -ne $compiler.Name -or
+                -not (Test-Path -LiteralPath $compiler.Path -PathType Leaf) -or
+                [IO.Path]::GetFullPath((Split-Path $compiler.Path)) -ne $compilerBin) {
+              throw "The exact Chocolatey MinGW compiler is missing: '$($compiler.Path)'"
+            }
+            $compilerVersion = @(& $compiler.Path --version)
+            $compilerExitCode = $LASTEXITCODE
+            $compilerFirstLine = if ($compilerVersion.Count -gt 0) {
+              $compilerVersion[0].Trim()
+            } else {
+              '<no output>'
+            }
+            if ($compilerExitCode -ne 0 -or
+                $compilerFirstLine -notmatch '(^|\s)16\.1\.0(\s|$)') {
+              throw "Expected MinGW 16.1.0 at '$($compiler.Path)', observed '$compilerFirstLine'"
+            }
+            $compilerMachine = (& $compiler.Path -dumpmachine).Trim()
+            if ($LASTEXITCODE -ne 0 -or
+                $compilerMachine -ne 'x86_64-w64-mingw32') {
+              throw "Expected x86_64-w64-mingw32 at '$($compiler.Path)', observed '$compilerMachine'"
+            }
+          }
+          [string]$outputPayload = (
+            "gcc={0}`ngxx={1}`n" -f
+              $compilers[0].Path,
+              $compilers[1].Path
+          )
+          [IO.File]::AppendAllText(
+            $env:GITHUB_OUTPUT,
+            $outputPayload,
+            [Text.UTF8Encoding]::new($false))
 
       - name: Set up MSYS2 GNU Make
         if: matrix.host == 'msys2'
@@ -630,18 +1080,215 @@ jobs:
       - name: Exercise native Windows Make
         if: matrix.host == 'native'
         shell: pwsh
+        env:
+          BEADS_CI_EXPECTED_OUTER_OS: windows
+          BEADS_CI_EXPECTED_MAKE_VERSION: "4.4.1"
+          BEADS_CI_NATIVE_GCC: ${{ steps.native_toolchain.outputs.gcc }}
+          BEADS_CI_NATIVE_GXX: ${{ steps.native_toolchain.outputs.gxx }}
         run: |
           $ErrorActionPreference = 'Stop'
+          foreach ($makeControl in @(
+            'MAKE',
+            'MAKEFLAGS',
+            'MFLAGS',
+            'GNUMAKEFLAGS',
+            'MAKEFILES'
+          )) {
+            Remove-Item -LiteralPath "Env:$makeControl" -ErrorAction SilentlyContinue
+          }
+          if ($env:BEADS_CI_EXPECTED_OUTER_OS -ne 'windows' -or
+              -not $IsWindows -or
+              -not [System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform(
+                  [System.Runtime.InteropServices.OSPlatform]::Windows)) {
+            throw 'The protected native lane expected and requires actual Windows'
+          }
+          $pwsh = (Get-Process -Id $PID -ErrorAction Stop).Path
+          if (-not [IO.Path]::IsPathFullyQualified($pwsh) -or
+              [IO.Path]::GetFileName($pwsh) -ne 'pwsh.exe' -or
+              $PSVersionTable.PSEdition -ne 'Core' -or
+              $PSVersionTable.PSVersion.Major -lt 7) {
+            throw "Expected an absolute PowerShell 7+ Core host, found '$pwsh'"
+          }
+
           $make = (Get-Command make.exe -ErrorAction Stop).Source
-          $hostOutput = & $make --no-print-directory -f NUL --eval '$(info MAKE_HOST=$(MAKE_HOST))' --eval 'noop:;' noop
+          if (-not [IO.Path]::IsPathFullyQualified($make) -or
+              [IO.Path]::GetFileName($make) -ne 'make.exe') {
+            throw "GNU Make did not resolve to one absolute make.exe: '$make'"
+          }
+          $makeVersion = @(& $make --version)
+          if ($LASTEXITCODE -ne 0 -or
+              $makeVersion.Count -eq 0 -or
+              $makeVersion[0].Trim() -ne "GNU Make $env:BEADS_CI_EXPECTED_MAKE_VERSION") {
+            throw "Expected GNU Make $env:BEADS_CI_EXPECTED_MAKE_VERSION at '$make'"
+          }
+          $hostProbe = @'
+          $(info MAKE_HOST=$(MAKE_HOST))
+          .PHONY: noop
+          noop: ;
+          '@
+          $hostOutput = $hostProbe | & $make --no-print-directory -f - noop
           $makeHost = (($hostOutput | Where-Object { $_ -like 'MAKE_HOST=*' }) -replace '^MAKE_HOST=', '').Trim()
           if ($LASTEXITCODE -ne 0 -or ($makeHost -ne 'Windows32' -and $makeHost -notmatch '-mingw32$')) {
             throw "Expected native Windows GNU Make, found '$makeHost' at '$make'"
           }
+          $makeOnlyDirectory = Join-Path $env:RUNNER_TEMP 'mingw32-make-only'
+          New-Item -ItemType Directory -Force -Path $makeOnlyDirectory | Out-Null
+          $mingwOnlyMake = Join-Path $makeOnlyDirectory 'mingw32-make.exe'
+          Copy-Item -LiteralPath $make -Destination $mingwOnlyMake
+          if (Test-Path -LiteralPath (Join-Path $makeOnlyDirectory 'make.exe')) {
+            throw 'The no-make-alias fixture unexpectedly contains make.exe'
+          }
+          $make = $mingwOnlyMake
+          $copiedMakeVersion = @(& $make --version)
+          if ($LASTEXITCODE -ne 0 -or
+              $copiedMakeVersion.Count -eq 0 -or
+              $copiedMakeVersion[0].Trim() -ne "GNU Make $env:BEADS_CI_EXPECTED_MAKE_VERSION") {
+            throw "The isolated mingw32-make.exe lost GNU Make authority: '$make'"
+          }
 
           $git = (Get-Command git.exe -ErrorAction Stop).Source
+          if (-not [IO.Path]::IsPathFullyQualified($git) -or
+              [IO.Path]::GetFileName($git) -ne 'git.exe') {
+            throw "Git did not resolve to one absolute git.exe: '$git'"
+          }
           if ($git -notmatch ' ') {
-            throw "Expected the hosted Git for Windows path to contain a space, found '$git'"
+            throw "Expected the hosted Windows Git bundle path to contain a space, found '$git'"
+          }
+          Get-ChildItem Env: |
+            Where-Object {
+              $_.Name -like 'GIT_CONFIG_*' -or
+              $_.Name -like 'GIT_TRACE*'
+            } |
+            ForEach-Object {
+              Remove-Item -LiteralPath "Env:$($_.Name)" -ErrorAction Stop
+            }
+          Remove-Item Env:GIT_EXEC_PATH -ErrorAction SilentlyContinue
+          $env:GIT_CONFIG_NOSYSTEM = '1'
+          $env:GIT_CONFIG_GLOBAL = 'NUL'
+          $env:GIT_TERMINAL_PROMPT = '0'
+          $gitVersion = (& $git --version).Trim()
+          if ($LASTEXITCODE -ne 0 -or $gitVersion -notmatch '^git version \S+$') {
+            throw "The bound Windows Git executable did not report a coherent version: '$gitVersion'"
+          }
+          $gitRootProbe = (& $git -c core.hooksPath=NUL -C $env:GITHUB_WORKSPACE rev-parse --show-toplevel).Trim()
+          if ($LASTEXITCODE -ne 0 -or
+              [IO.Path]::GetFullPath($gitRootProbe) -ne
+              [IO.Path]::GetFullPath($env:GITHUB_WORKSPACE)) {
+            throw "The bound Windows Git executable resolved the wrong repository: '$gitRootProbe'"
+          }
+          $gitExecPath = (& $git --exec-path).Trim()
+          if ($LASTEXITCODE -ne 0 -or -not [IO.Path]::IsPathFullyQualified($gitExecPath)) {
+            throw "The bound Windows Git executable returned an invalid exec path: '$gitExecPath'"
+          }
+          $gitRoot = [IO.Path]::GetFullPath((Join-Path $gitExecPath '..\..\..'))
+          $bash = Join-Path $gitRoot 'usr\bin\bash.exe'
+          $cygpath = Join-Path $gitRoot 'usr\bin\cygpath.exe'
+          $allowedGitLeaves = @(
+            (Join-Path $gitRoot 'cmd\git.exe'),
+            (Join-Path $gitRoot 'bin\git.exe'),
+            (Join-Path $gitRoot 'mingw64\bin\git.exe')
+          ) | Where-Object { Test-Path -LiteralPath $_ -PathType Leaf }
+          if (-not (
+            $allowedGitLeaves |
+              Where-Object {
+                [IO.Path]::GetFullPath($_).Equals(
+                  [IO.Path]::GetFullPath($git),
+                  [StringComparison]::OrdinalIgnoreCase)
+              }
+          )) {
+            throw "The bootstrap Git is not an exact executable leaf of '$gitRoot'"
+          }
+          $resolvedGit = Join-Path $gitRoot 'mingw64\bin\git.exe'
+          if (-not [IO.Path]::IsPathFullyQualified($resolvedGit) -or
+              -not (Test-Path -LiteralPath $resolvedGit -PathType Leaf)) {
+            throw "The mixed-PATH Git leaf is missing from '$gitRoot'"
+          }
+          $requiredPosixTools = @(
+            $bash,
+            $cygpath,
+            (Join-Path $gitRoot 'usr\bin\cat.exe'),
+            (Join-Path $gitRoot 'usr\bin\chmod.exe'),
+            (Join-Path $gitRoot 'usr\bin\cp.exe'),
+            (Join-Path $gitRoot 'usr\bin\diff.exe'),
+            (Join-Path $gitRoot 'usr\bin\env.exe'),
+            (Join-Path $gitRoot 'usr\bin\mkdir.exe'),
+            (Join-Path $gitRoot 'usr\bin\mktemp.exe'),
+            (Join-Path $gitRoot 'usr\bin\readlink.exe'),
+            (Join-Path $gitRoot 'usr\bin\rm.exe'),
+            (Join-Path $gitRoot 'usr\bin\rmdir.exe'),
+            (Join-Path $gitRoot 'usr\bin\sed.exe'),
+            (Join-Path $gitRoot 'usr\bin\uname.exe')
+          )
+          foreach ($tool in $requiredPosixTools) {
+            if (-not [IO.Path]::IsPathFullyQualified($tool) -or
+                -not (Test-Path -LiteralPath $tool -PathType Leaf)) {
+              throw "The Windows Git POSIX bundle is missing '$tool'"
+            }
+          }
+          $bashProbe = (& $bash --noprofile --norc -c @'
+          test "$BASH" = /usr/bin/bash
+          case "$OSTYPE" in cygwin*|msys*) ;; *) exit 72;; esac
+          case "$(uname -s)" in MINGW*_NT-*|MSYS*_NT-*|CYGWIN*_NT-*) ;; *) exit 73;; esac
+          printf '%s' 'bound Windows Bash passed'
+          '@).Trim()
+          if ($LASTEXITCODE -ne 0 -or $bashProbe -ne 'bound Windows Bash passed') {
+            throw "The bound Windows Bash failed its family/path probe: '$bashProbe'"
+          }
+
+          $cmd = Join-Path $env:SystemRoot 'System32\cmd.exe'
+          if (-not [IO.Path]::IsPathFullyQualified($cmd) -or
+              -not (Test-Path -LiteralPath $cmd -PathType Leaf)) {
+            throw "Could not bind the Windows command processor: '$cmd'"
+          }
+          $goDirective = @(
+            Get-Content -LiteralPath (Join-Path $env:GITHUB_WORKSPACE 'go.mod') |
+              Where-Object { $_ -match '^go [0-9]+\.[0-9]+\.[0-9]+$' }
+          )
+          if ($goDirective.Count -ne 1) {
+            throw 'go.mod must contain one exact three-component Go version'
+          }
+          $goVersion = ($goDirective[0] -replace '^go ', '').Trim()
+          if ($goVersion -ne '1.26.5') {
+            throw "Expected protected Go 1.26.5, found '$goVersion'"
+          }
+          $go = (Get-Command go.exe -ErrorAction Stop).Source
+          if (-not [IO.Path]::IsPathFullyQualified($go) -or
+              [IO.Path]::GetFileName($go) -ne 'go.exe' -or
+              (& $go version).Trim() -notmatch '^go version go1\.26\.5 windows/amd64$') {
+            throw "Expected exact native Go 1.26.5 windows/amd64 at '$go'"
+          }
+          $expectedCompilerBin = [IO.Path]::GetFullPath(
+            (Join-Path $env:ProgramData 'mingw64\mingw64\bin'))
+          $gcc = $env:BEADS_CI_NATIVE_GCC
+          $gxx = $env:BEADS_CI_NATIVE_GXX
+          foreach ($compiler in @(
+            [pscustomobject]@{ Name = 'gcc.exe'; Path = $gcc },
+            [pscustomobject]@{ Name = 'g++.exe'; Path = $gxx }
+          )) {
+            if (-not [IO.Path]::IsPathFullyQualified($compiler.Path) -or
+                [IO.Path]::GetFileName($compiler.Path) -ne $compiler.Name -or
+                -not (Test-Path -LiteralPath $compiler.Path -PathType Leaf) -or
+                [IO.Path]::GetFullPath((Split-Path $compiler.Path)) -ne
+                  $expectedCompilerBin) {
+              throw "A protected MinGW compiler is not the exact installed leaf: '$($compiler.Path)'"
+            }
+            $compilerVersion = @(& $compiler.Path --version)
+            $compilerExitCode = $LASTEXITCODE
+            $compilerFirstLine = if ($compilerVersion.Count -gt 0) {
+              $compilerVersion[0].Trim()
+            } else {
+              '<no output>'
+            }
+            if ($compilerExitCode -ne 0 -or
+                $compilerFirstLine -notmatch '(^|\s)16\.1\.0(\s|$)') {
+              throw "Expected MinGW 16.1.0 at '$($compiler.Path)', observed '$compilerFirstLine'"
+            }
+          }
+          if ((& $gcc -dumpmachine).Trim() -ne 'x86_64-w64-mingw32') {
+            throw "Expected the x86_64 MinGW compiler at '$gcc'"
+          }
+          if ((& $gxx -dumpmachine).Trim() -ne 'x86_64-w64-mingw32') {
+            throw "Expected the x86_64 MinGW C++ compiler at '$gxx'"
           }
 
           $profile = Join-Path $env:RUNNER_TEMP 'profile with spaces'
@@ -649,63 +1296,258 @@ jobs:
           $poison = Join-Path $profile 'poison bash env.sh'
           Set-Content -LiteralPath $poison -Encoding utf8 -Value 'exit 97'
 
-          $env:USERPROFILE = $profile
           $env:BASH_ENV = $poison
           $env:BASHOPTS = 'failglob'
           $env:SHELLOPTS = 'nounset'
           $env:GIT_EXEC_PATH = Join-Path $profile 'missing git exec path'
-          $env:PATH = "$(Split-Path $git);$env:SystemRoot\System32"
+          # Deliberately resolve Git from mingw64/bin while Make bootstraps from
+          # cmd/git.exe. The host must accept distinct exact leaves of one
+          # bundle and reject any leaf from another root.
+          $env:PATH = @(
+            (Split-Path $make),
+            (Split-Path $go),
+            (Split-Path $gcc),
+            (Split-Path $resolvedGit),
+            (Split-Path $git),
+            (Join-Path $env:SystemRoot 'System32')
+          ) -join ';'
+          if (Get-Command make.exe -ErrorAction SilentlyContinue) {
+            throw 'The full native boundary still has a make.exe alias'
+          }
+          $onlyNamedMake = (Get-Command mingw32-make.exe -ErrorAction Stop).Source
+          if ([IO.Path]::GetFullPath($onlyNamedMake) -ne [IO.Path]::GetFullPath($make)) {
+            throw "The isolated Make name resolved to an unexpected executable: '$onlyNamedMake'"
+          }
 
-          & $make --no-print-directory help | Out-Null
+          $makeAuthority = @(
+            "WINDOWS_CMD_EXE=$cmd",
+            "GIT_WINDOWS_EXE=$git",
+            "CI_GIT=$resolvedGit",
+            "CI_BASH=$($bash.Replace('\', '/'))",
+            "GO_VERSION=$goVersion",
+            "EXPECTED_WINDOWS_BASH=$($bash.Replace('\', '/'))"
+          )
+          & $make -f Makefile @makeAuthority --no-print-directory help | Out-Null
           if ($LASTEXITCODE -ne 0) {
             throw 'Native Make failed while parsing or running help'
           }
 
+          $env:GOOS = 'windows'
+          $env:GOARCH = 'amd64'
+          $env:CGO_ENABLED = '1'
+          $env:BEADS_CI_EXPECTED_TARGET_GOOS = 'windows'
+          $env:BEADS_CI_EXPECTED_TARGET_GOARCH = 'amd64'
+          $env:BEADS_CI_EXPECTED_TARGET_CGO_ENABLED = '1'
+          $env:BEADS_CI_EXPECTED_CC_VERSION = '16.1.0'
+          $env:BEADS_CI_EXPECTED_GOLANGCI_LINT_VERSION = '2.10.1'
+          $env:BEADS_CI_INSTALL_GOLANGCI_LINT = '1'
+          $env:BEADS_CI_INVOKING_WINDOWS_GIT = $git
+          $env:RUNNER_TEMP = [IO.Path]::GetFullPath($env:RUNNER_TEMP)
+
+          $wrongRoot = Join-Path $env:RUNNER_TEMP 'wrong git bundle'
+          $wrongBin = Join-Path $wrongRoot 'bin'
+          New-Item -ItemType Directory -Force -Path $wrongBin | Out-Null
+          $wrongGit = Join-Path $wrongBin 'git'
+          $delegateGit = (& $cygpath -u $resolvedGit).Trim()
+          if ($LASTEXITCODE -ne 0 -or $delegateGit -notmatch '^/') {
+            throw "Could not translate the resolved Git leaf: '$delegateGit'"
+          }
+          $wrongGitScript = "#!/usr/bin/bash`nexec `"$delegateGit`" `"`$@`"`n"
+          [IO.File]::WriteAllText(
+            $wrongGit,
+            $wrongGitScript,
+            [Text.UTF8Encoding]::new($false))
+          $wrongOutput = Join-Path $env:RUNNER_TEMP 'wrong-git-bundle.output'
+          & $make @(
+            '-f',
+            'Makefile',
+            "WINDOWS_CMD_EXE=$cmd",
+            "GIT_WINDOWS_EXE=$git",
+            "CI_GIT=$wrongGit",
+            "CI_BASH=$($bash.Replace('\', '/'))",
+            "GO_VERSION=$goVersion",
+            'ci-pr-lint'
+          ) *> $wrongOutput
+          if ($LASTEXITCODE -eq 0) {
+            throw 'The public lint target accepted a Git executable from the wrong bundle root'
+          }
+          if ((Get-Content -LiteralPath $wrongOutput -Raw) -notmatch
+              'the resolved Git executable is outside the GIT_WINDOWS_EXE bundle') {
+            throw 'The wrong-bundle falsifier failed for an unrelated reason'
+          }
+
+          & $make -f Makefile @makeAuthority ci-pr-lint
+          if ($LASTEXITCODE -ne 0) {
+            throw 'The native Windows public PR lint target failed'
+          }
+          if (Get-ChildItem -LiteralPath $env:RUNNER_TEMP -Directory -Filter 'beads-pr-lint-tools.*') {
+            throw 'The native Windows lint target left a private tool directory behind'
+          }
+
+          # The exact-equal ambient tuple above is accepted. Each conflicting
+          # field must fail through the same public Make target before lint.
+          $targetRefusalCount = 0
+          foreach ($conflict in @(
+            @{ Name = 'GOOS'; Value = 'plan9' },
+            @{ Name = 'GOARCH'; Value = '386' },
+            @{ Name = 'CGO_ENABLED'; Value = '0' }
+          )) {
+            $saved = [Environment]::GetEnvironmentVariable($conflict.Name, 'Process')
+            [Environment]::SetEnvironmentVariable(
+              $conflict.Name,
+              $conflict.Value,
+              'Process')
+            try {
+              $conflictPath = Join-Path (
+                $env:RUNNER_TEMP) "conflict-$($conflict.Name).output"
+              & $make -f Makefile @makeAuthority ci-pr-lint *> $conflictPath
+              if ($LASTEXITCODE -eq 0) {
+                throw "The public lint target accepted conflicting $($conflict.Name)"
+              }
+              $conflictOutput = Get-Content -LiteralPath $conflictPath -Raw
+              if ($conflictOutput -notmatch "$($conflict.Name) conflicts with the protected hosted target") {
+                throw "The $($conflict.Name) falsifier failed for an unrelated reason"
+              }
+              $targetRefusalCount++
+            } finally {
+              [Environment]::SetEnvironmentVariable(
+                $conflict.Name,
+                $saved,
+                'Process')
+            }
+          }
+          if ($targetRefusalCount -ne 3) {
+            throw "Expected three native target refusals, observed $targetRefusalCount"
+          }
+          Write-Output "Native PR lint authority falsifiers passed (3 target; 1 bundle)"
+
+          $env:BEADS_CI_TOOLCHAIN_BOUND = '1'
+          $env:BEADS_CI_EXPECTED_OUTER_OS = 'windows'
+          $env:BEADS_CI_BASH = '/usr/bin/bash'
+          $env:BEADS_CI_ENV = '/usr/bin/env'
+          $env:BEADS_CI_MKDIR = '/usr/bin/mkdir'
+          $env:BEADS_CI_MKTEMP = '/usr/bin/mktemp'
+          $env:BEADS_CI_READLINK = '/usr/bin/readlink'
+          $env:BEADS_CI_RM = '/usr/bin/rm'
+          $env:BEADS_CI_UNAME = '/usr/bin/uname'
+          $env:GO_VERSION = $goVersion
+
+          $smokeMakefile = Join-Path $env:GITHUB_WORKSPACE (
+            '.native-windows-make-smoke.mk')
           @'
           include Makefile
           .RECIPEPREFIX := >
           .PHONY: windows-make-shell-smoke
           windows-make-shell-smoke:
-          >@case "$(SHELL)" in */bin/bash.exe) ;; *) exit 1;; esac
+          >@test "$(MAKEFILE_LIST)" = ".native-windows-make-smoke.mk Makefile"
+          >@test "$(SHELL)" = "$(EXPECTED_WINDOWS_BASH)"
+          >@test "$$BASH" = /usr/bin/bash
           >@test -n "$$BASH_VERSION"
+          >@case "$$OSTYPE" in cygwin*|msys*) ;; *) exit 1;; esac
+          >@case "$$(uname -s)" in MINGW*_NT-*|MSYS*_NT-*|CYGWIN*_NT-*) ;; *) exit 1;; esac
+          >@test "$$(command -v bash)" = /usr/bin/bash
           >@test "$$(command -v sed)" = /usr/bin/sed
           >@test "$$(command -v env)" = /usr/bin/env
+          >@test "$$(command -v mkdir)" = /usr/bin/mkdir
+          >@test "$$(command -v mktemp)" = /usr/bin/mktemp
+          >@test "$$(command -v readlink)" = /usr/bin/readlink
+          >@test "$$(command -v rm)" = /usr/bin/rm
+          >@test "$$(command -v rmdir)" = /usr/bin/rmdir
+          >@test "$$(command -v uname)" = /usr/bin/uname
           >@test -z "$${BASH_ENV+x}"
+          >@test -z "$${ENV+x}"
           >@case "$$-" in *u*) exit 1;; esac
           >@shopt -q failglob && exit 1 || :
           >@test -z "$${GIT_EXEC_PATH+x}"
           >@env printf '%s\n' 'native Windows Make shell smoke passed'
-          '@ | & $make --no-print-directory -f - windows-make-shell-smoke
-          if ($LASTEXITCODE -ne 0) {
-            throw 'Native Make shell smoke failed'
+          '@ | Set-Content -LiteralPath $smokeMakefile -Encoding utf8NoBOM
+          try {
+            & $make @makeAuthority --no-print-directory `
+              -f '.native-windows-make-smoke.mk' windows-make-shell-smoke
+            if ($LASTEXITCODE -ne 0) {
+              throw 'Native Make shell smoke failed'
+            }
+          } finally {
+            Remove-Item -LiteralPath $smokeMakefile -ErrorAction Stop
           }
+          Set-Content -LiteralPath (
+            Join-Path $env:RUNNER_TEMP 'windows-make-shell-native.ok'
+          ) -Encoding ascii -Value 'native'
 
       - name: Exercise MSYS2-hosted Make
         if: matrix.host == 'msys2'
         shell: msys2 {0}
         run: |
           set -euo pipefail
+          export PATH=/usr/bin
+          resolve_tool() {
+            local name="$1"
+            local path=""
+            path="$(type -P -- "$name")"
+            [[ "$path" == /* && -f "$path" && -x "$path" ]] || {
+              printf 'Could not bind MSYS2 tool %s: %s\n' "$name" "$path" >&2
+              exit 1
+            }
+            printf '%s' "$path"
+          }
+          bash_path="$(resolve_tool bash)"
+          cat_path="$(resolve_tool cat)"
+          cygpath_path="$(resolve_tool cygpath)"
+          env_path="$(resolve_tool env)"
+          git_path="$(resolve_tool git)"
+          make_path="$(resolve_tool make)"
+          mkdir_path="$(resolve_tool mkdir)"
+          sed_path="$(resolve_tool sed)"
+          sh_path="$(resolve_tool sh)"
+          uname_path="$(resolve_tool uname)"
+
+          [[ "$BASH" == "$bash_path" ]]
+          case "$("$uname_path" -s)" in
+            MSYS*_NT-*|MINGW*_NT-*) ;;
+            *) printf 'Expected actual MSYS2-on-Windows outer OS\n' >&2; exit 1 ;;
+          esac
+          [[ "$("$git_path" --version)" == "git version "* ]]
+          git_root="$(
+            GIT_CONFIG_NOSYSTEM=1 GIT_CONFIG_GLOBAL=/dev/null \
+              "$git_path" -C "$GITHUB_WORKSPACE" rev-parse --show-toplevel
+          )"
+          [[ "$("$cygpath_path" -aw "$git_root")" == "$("$cygpath_path" -aw "$GITHUB_WORKSPACE")" ]]
+          make_version="$("$make_path" --version)"
+          [[ "${make_version%%$'\n'*}" == "GNU Make "* ]]
           make_host="$(
-            make --no-print-directory -f /dev/null \
-              --eval '$(info $(MAKE_HOST))' \
-              --eval 'noop:;' noop |
-              sed -n '1p'
+            printf '%s\n' \
+              '$(info $(MAKE_HOST))' \
+              '.PHONY: noop' \
+              'noop: ;' |
+              "$make_path" --no-print-directory -f - noop |
+              "$sed_path" -n '1p'
           )"
           case "$make_host" in
             *-msys|*-cygwin) ;;
             *) echo "Expected a POSIX-hosted MSYS2 GNU Make, found '$make_host'" >&2; exit 1 ;;
           esac
 
-          profile="$(cygpath -u "$RUNNER_TEMP")/profile with spaces"
-          mkdir -p "$profile"
+          go_version="$("$sed_path" -n 's/^go //p' go.mod)"
+          go_version="${go_version%$'\r'}"
+          [[ "$go_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]
+          profile="$("$cygpath_path" -u "$RUNNER_TEMP")/profile with spaces"
+          "$mkdir_path" -p "$profile"
           bash_env="$profile/compat bash env.sh"
           printf '%s\n' 'exit 97' > "$bash_env"
+          env_file="$profile/compat env.sh"
+          printf '%s\n' 'exit 96' > "$env_file"
           export BASH_ENV="$bash_env"
+          export ENV="$env_file"
           export GIT_EXEC_PATH="$profile/missing git exec path"
-          export PATH=/usr/bin
 
-          make --no-print-directory help >/dev/null
-          cat > "$profile/smoke.mk" <<'MAKE_EOF'
+          make_authority=(
+            "SHELL=$sh_path"
+            "CI_GIT=$git_path"
+            "CI_SED=$sed_path"
+            "GO_VERSION=$go_version"
+          )
+          "$make_path" "${make_authority[@]}" --no-print-directory help >/dev/null
+          "$cat_path" > "$profile/smoke.mk" <<'MAKE_EOF'
           include Makefile
           .RECIPEPREFIX := >
           .PHONY: windows-make-shell-smoke
@@ -714,12 +1556,15 @@ jobs:
           >@test -n "$$BASH_VERSION"
           >@test "$$(command -v sed)" = /usr/bin/sed
           >@test "$$(command -v env)" = /usr/bin/env
-          >@test -f "$$BASH_ENV"
+          >@test -z "$${BASH_ENV+x}"
+          >@test -z "$${ENV+x}"
           >@test -n "$$GIT_EXEC_PATH"
           >@case "$$PATH" in *';'*) exit 1;; esac
           >@env printf '%s\n' 'MSYS2 Make shell smoke passed'
           MAKE_EOF
-          make --no-print-directory -f "$profile/smoke.mk" windows-make-shell-smoke
+          "$make_path" "${make_authority[@]}" --no-print-directory \
+            -f "$profile/smoke.mk" windows-make-shell-smoke
+          printf '%s\n' msys2 >"$("$cygpath_path" -u "$RUNNER_TEMP")/windows-make-shell-msys2.ok"
 
       - name: Exercise Cygwin-hosted Make
         if: matrix.host == 'cygwin'
@@ -728,32 +1573,105 @@ jobs:
           CYGWIN_ROOT: ${{ steps.cygwin.outputs.root }}
         run: |
           $ErrorActionPreference = 'Stop'
+          if (-not $IsWindows -or
+              -not [System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform(
+                  [System.Runtime.InteropServices.OSPlatform]::Windows)) {
+            throw 'The protected Cygwin lane expected and requires actual Windows'
+          }
           $bash = Join-Path $env:CYGWIN_ROOT 'bin\bash.exe'
+          if (-not [IO.Path]::IsPathFullyQualified($bash) -or
+              -not (Test-Path -LiteralPath $bash -PathType Leaf)) {
+            throw "Could not bind the Cygwin Bash executable: '$bash'"
+          }
           $script = @'
           set -euo pipefail
           export PATH=/usr/bin
-          cd "$(cygpath -u "$GITHUB_WORKSPACE")"
+          resolve_tool() {
+            local name="$1"
+            local path=""
+            path="$(type -P -- "$name")"
+            [[ "$path" == /* && -f "$path" && -x "$path" ]] || {
+              printf 'Could not bind Cygwin tool %s: %s\n' "$name" "$path" >&2
+              exit 1
+            }
+            printf '%s' "$path"
+          }
+          bash_path="$(resolve_tool bash)"
+          cat_path="$(resolve_tool cat)"
+          cygpath_path="$(resolve_tool cygpath)"
+          env_path="$(resolve_tool env)"
+          git_path="$(resolve_tool git)"
+          make_path="$(resolve_tool make)"
+          mktemp_path="$(resolve_tool mktemp)"
+          rm_path="$(resolve_tool rm)"
+          sed_path="$(resolve_tool sed)"
+          sh_path="$(resolve_tool sh)"
+          uname_path="$(resolve_tool uname)"
+
+          [[ "$BASH" == "$bash_path" ]]
+          case "$("$uname_path" -s)" in
+            CYGWIN*_NT-*) ;;
+            *) printf 'Expected actual Cygwin-on-Windows outer OS\n' >&2; exit 1 ;;
+          esac
+          cd "$("$cygpath_path" -u "$GITHUB_WORKSPACE")"
+          profile="$("$mktemp_path" -d)"
+          cleanup() {
+            "$rm_path" -rf -- "$profile"
+          }
+          trap cleanup EXIT
+          # actions/checkout registers the Win32 spelling in Git for Windows'
+          # temporary global config. Cygwin Git sees a distinct canonical
+          # spelling and ownership domain, so give only this script an isolated
+          # protected config containing the exact repository it just entered.
+          git_config="$profile/gitconfig"
+          GIT_CONFIG_NOSYSTEM=1 GIT_CONFIG_GLOBAL=/dev/null \
+            "$git_path" config --file "$git_config" --add safe.directory "$PWD"
+          export GIT_CONFIG_NOSYSTEM=1
+          export GIT_CONFIG_GLOBAL="$git_config"
+          safe_directory="$(
+            "$git_path" config --global --get-all safe.directory
+          )"
+          [[ "$("$cygpath_path" -aw "$safe_directory")" == "$("$cygpath_path" -aw "$PWD")" ]]
+          [[ "$("$git_path" --version)" == "git version "* ]]
+          git_root="$(
+            "$git_path" -C "$PWD" rev-parse --show-toplevel
+          )"
+          [[ "$("$cygpath_path" -aw "$git_root")" == "$("$cygpath_path" -aw "$PWD")" ]]
+          make_version="$("$make_path" --version)"
+          [[ "${make_version%%$'\n'*}" == "GNU Make "* ]]
 
           make_host="$(
-            make --no-print-directory -f /dev/null \
-              --eval '$(info $(MAKE_HOST))' \
-              --eval 'noop:;' noop |
-              sed -n '1p'
+            printf '%s\n' \
+              '$(info $(MAKE_HOST))' \
+              '.PHONY: noop' \
+              'noop: ;' |
+              "$make_path" --no-print-directory -f - noop |
+              "$sed_path" -n '1p'
           )"
           case "$make_host" in
             *-cygwin) ;;
             *) echo "Expected Cygwin GNU Make, found '$make_host'" >&2; exit 1 ;;
           esac
 
-          profile="$(mktemp -d)"
-          trap 'rm -rf -- "$profile"' EXIT
+          go_version="$("$sed_path" -n 's/^go //p' go.mod)"
+          go_version="${go_version%$'\r'}"
+          [[ "$go_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]
           bash_env="$profile/cygwin bash env.sh"
           printf '%s\n' 'exit 97' > "$bash_env"
+          env_file="$profile/cygwin env.sh"
+          printf '%s\n' 'exit 96' > "$env_file"
           export BASH_ENV="$bash_env"
+          export ENV="$env_file"
           export GIT_EXEC_PATH="$profile/missing git exec path"
 
-          make --no-print-directory help >/dev/null
-          cat > "$profile/smoke.mk" <<'MAKE_EOF'
+          make_authority=(
+            "SHELL=$sh_path"
+            "CI_GIT=$git_path"
+            "CI_SED=$sed_path"
+            "GO_VERSION=$go_version"
+          )
+          "$make_path" "${make_authority[@]}" --no-print-directory help >/dev/null
+          "$cat_path" > "$profile/smoke.mk" <<'MAKE_EOF'
           include Makefile
           .RECIPEPREFIX := >
           .PHONY: windows-make-shell-smoke
@@ -762,17 +1680,41 @@ jobs:
           >@test -n "$$BASH_VERSION"
           >@test "$$(command -v sed)" = /usr/bin/sed
           >@test "$$(command -v env)" = /usr/bin/env
-          >@test -f "$$BASH_ENV"
+          >@test -z "$${BASH_ENV+x}"
+          >@test -z "$${ENV+x}"
           >@test -n "$$GIT_EXEC_PATH"
           >@case "$$PATH" in *';'*) exit 1;; esac
           >@env printf '%s\n' 'Cygwin Make shell smoke passed'
           MAKE_EOF
-          make --no-print-directory -f "$profile/smoke.mk" windows-make-shell-smoke
+          "$make_path" "${make_authority[@]}" --no-print-directory \
+            -f "$profile/smoke.mk" windows-make-shell-smoke
+          printf '%s\n' cygwin >"$("$cygpath_path" -u "$RUNNER_TEMP")/windows-make-shell-cygwin.ok"
           '@
           $script = $script.Replace("`r`n", "`n")
           & $bash --noprofile --norc -c $script
           if ($LASTEXITCODE -ne 0) {
             throw 'Cygwin Make shell smoke failed'
+          }
+
+      - name: Require the selected Windows Make lane
+        if: ${{ always() }}
+        shell: pwsh
+        env:
+          EXPECTED_HOST: ${{ matrix.host }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+          if ($env:EXPECTED_HOST -notin @('native', 'msys2', 'cygwin')) {
+            throw "Unsupported Windows Make matrix host '$env:EXPECTED_HOST'"
+          }
+          $marker = Join-Path $env:RUNNER_TEMP (
+            "windows-make-shell-$env:EXPECTED_HOST.ok"
+          )
+          if (-not (Test-Path -LiteralPath $marker -PathType Leaf)) {
+            throw "The $env:EXPECTED_HOST semantic lane did not execute successfully"
+          }
+          $observed = (Get-Content -LiteralPath $marker -Raw).Trim()
+          if ($observed -ne $env:EXPECTED_HOST) {
+            throw "The $env:EXPECTED_HOST marker contained '$observed'"
           }
 
   ci-gate:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -133,7 +133,7 @@ plane"), you MUST complete ALL steps below. Work is NOT complete until
 
 1. **File issues for remaining work** - Create issues for anything that needs follow-up
 2. **Run quality gates** (if code changed):
-   - `golangci-lint run ./...` (or `pre-commit run --all-files` if pre-commit is installed)
+   - `make ci-pr-lint` (authoritative; pre-commit hooks are narrower conveniences)
    - `make test` (and `make test-icu-path` only if you intentionally need the ICU regex path)
    - File a P0 issue if quality gates are broken
 3. **Update issue status** - Close finished work, update in-progress items

--- a/AGENT_INSTRUCTIONS.md
+++ b/AGENT_INSTRUCTIONS.md
@@ -8,8 +8,8 @@ This document contains detailed operational instructions for AI agents working o
 
 ### Code Standards
 
-- **Go version**: see `go.mod` for the required version (currently 1.26+)
-- **Linting**: `golangci-lint run ./...` (baseline warnings documented in [engdocs/LINTING.md](engdocs/LINTING.md))
+- **Go version**: use the exact three-component version in `go.mod` (currently 1.26.5)
+- **Linting**: `make ci-pr-lint` (the authoritative v2 host, target, format, and lint contract documented in [engdocs/LINTING.md](engdocs/LINTING.md))
 - **Testing**: All new features need tests (`make test` for the normal local/CI path, `make test-icu-path` only when intentionally exercising the opt-in ICU regex path)
 - **Documentation**: Update relevant .md files
 
@@ -73,7 +73,7 @@ test runs if `du -sh /tmp/beads-* /tmp/bd-*` shows accumulation. See bd-3q2u.
 
 1. **Run tests**: `make test` (or `./scripts/test.sh`)
    - Only if intentionally exercising the ICU regex path: `make test-icu-path`
-2. **Run linter**: `golangci-lint run ./...` (ignore baseline warnings)
+2. **Run lint gate**: `make ci-pr-lint` (all findings are failures; there is no ignored baseline)
 3. **Update docs**: If you changed behavior, update README.md or other docs
 4. **Commit**: With git hooks installed (`bd hooks install`), Dolt changes are auto-committed
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,10 +6,11 @@ Thank you for your interest in contributing to bd! This document provides guidel
 
 ### Prerequisites
 
-- Go (see `go.mod` for the required version; currently 1.26+)
+- Go at the exact three-component version in `go.mod` (currently 1.26.5)
 - Git
 - A C compiler (CGO is required for the embedded Dolt database)
-- (Optional) golangci-lint for local linting
+- GNU Make and Bash 3.2 or newer for the authoritative lint gate
+- golangci-lint 2.10.1 for local linting
 - ICU headers are **not required** for building -- see [engdocs/ICU-POLICY.md](engdocs/ICU-POLICY.md)
 
 ### Getting Started
@@ -71,19 +72,21 @@ We follow standard Go conventions:
 
 ### Linting
 
-We use golangci-lint for code quality checks:
+Use the repository-owned gate for formatting and lint:
 
 ```bash
-# Install golangci-lint
-brew install golangci-lint  # macOS
-# or
-go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+# Install the exact v2 local linter once.
+go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.10.1
 
-# Run linter
-golangci-lint run ./...
+make ci-pr-lint
 ```
 
-**Note**: The linter currently reports ~100 warnings. These are documented false positives and idiomatic Go patterns (deferred cleanup, Cobra interface requirements, etc.). See [engdocs/LINTING.md](engdocs/LINTING.md) for details. When contributing, focus on avoiding *new* issues rather than the baseline warnings.
+Required CI installs a private golangci-lint 2.10.1 and runs the same public
+target. The target pins the repository configuration, readonly module mode,
+the caller's native target, and the Windows/non-CGO target. A direct
+`golangci-lint run`, the staged-file pre-commit hooks, and the pre-commit
+framework configuration are optional conveniences, not equivalent substitutes.
+The authoritative gate has no tolerated warning baseline.
 
 CI will automatically run linting on all pull requests.
 
@@ -102,7 +105,7 @@ engine, or expand the database schema when issue metadata is sufficient.
 2. Create a feature branch (`git checkout -b feature/my-feature`)
 3. Make your changes
 4. Add tests for new functionality
-5. Run tests and linter locally
+5. Run tests and `make ci-pr-lint` locally
 6. Commit your changes with clear messages
 7. Push to your fork
 8. Open a pull request

--- a/Makefile
+++ b/Makefile
@@ -1,56 +1,85 @@
 # Makefile for beads project
 
-# Native Windows GNU Make needs Git for Windows' bash for the POSIX shell
+# Tool variables are overrideable so required CI can resolve each executable
+# exactly once and pass the absolute identity through every recursive boundary.
+# Interactive use retains the ordinary command-name defaults.
+CI_BASH ?= /bin/bash
+CI_GIT ?= git
+CI_SED ?= sed
+CI_GOFMT ?= gofmt
+override BASH_ENV :=
+override ENV :=
+unexport BASH_ENV
+unexport ENV
+override CI_INVOKING_MAKE := $(if $(or $(findstring /,$(MAKE)),$(findstring \,$(MAKE))),$(MAKE),)
+override CI_INVOKING_MAKE_ORIGIN := $(origin MAKE)
+override CI_INVOKING_MAKEFILE_LIST := $(strip $(MAKEFILE_LIST))
+override CI_INVOKING_MAKEFLAGS_ORIGIN := $(origin MAKEFLAGS)
+override CI_INVOKING_MFLAGS := $(MFLAGS)
+override CI_INVOKING_GNUMAKEFLAGS := $(GNUMAKEFLAGS)
+override CI_INVOKING_MAKEFILES_ORIGIN := $(origin MAKEFILES)
+override CI_INVOKING_MAKEFILES := $(MAKEFILES)
+# Freeze caller-supplied target state before this file applies its normal
+# CGO default. Required CI uses this to reject conflicting ambient state
+# without rejecting exact-equal state inherited from the hosted runner.
+override CI_AMBIENT_GOOS_PRESENT := $(if $(filter environment environment override command line,$(origin GOOS)),1,0)
+override CI_AMBIENT_GOOS := $(GOOS)
+override CI_AMBIENT_GOARCH_PRESENT := $(if $(filter environment environment override command line,$(origin GOARCH)),1,0)
+override CI_AMBIENT_GOARCH := $(GOARCH)
+override CI_AMBIENT_CGO_ENABLED_PRESENT := $(if $(filter environment environment override command line,$(origin CGO_ENABLED)),1,0)
+override CI_AMBIENT_CGO_ENABLED := $(CGO_ENABLED)
+
+# Native Windows GNU Make needs the hosted Windows Git bundle's POSIX shell
 # syntax used throughout this Makefile. MSYS2 and Cygwin Make already provide
-# POSIX shell semantics, despite inheriting OS=Windows_NT, so leave them alone.
+# their own POSIX shell semantics despite inheriting OS=Windows_NT.
 ifeq ($(OS),Windows_NT)
 ifneq ($(filter Windows32 mingw32 %-mingw32,$(MAKE_HOST)),)
-override BASH_ENV :=
-unexport BASH_ENV
+WINDOWS_CMD_EXE ?= cmd.exe
+GIT_WINDOWS_EXE ?= git.exe
 unexport GIT_EXEC_PATH
 unexport BASHOPTS
 unexport SHELLOPTS
-SHELL := cmd.exe
+SHELL := $(WINDOWS_CMD_EXE)
 .SHELLFLAGS := /d /c
-GIT_WINDOWS_EXEC_PATH := $(strip $(shell set "GIT_EXEC_PATH=" && git.exe --exec-path))
+GIT_WINDOWS_EXEC_PATH := $(strip $(shell set "GIT_EXEC_PATH=" && "$(GIT_WINDOWS_EXE)" --exec-path))
 ifeq ($(GIT_WINDOWS_EXEC_PATH),)
-$(error Git for Windows is required to run this Makefile)
+$(error A Windows Git POSIX tool bundle is required to run this Makefile)
 endif
 GIT_WINDOWS_ROOT := $(strip $(shell cd /d "$(GIT_WINDOWS_EXEC_PATH)/../../.." && cd))
 ifeq ($(GIT_WINDOWS_ROOT),)
-$(error Could not resolve the Git for Windows installation from $(GIT_WINDOWS_EXEC_PATH))
+$(error Could not resolve the Windows Git POSIX tool bundle from $(GIT_WINDOWS_EXEC_PATH))
 endif
-GIT_WINDOWS_BASH := $(GIT_WINDOWS_ROOT)/bin/bash.exe
+GIT_WINDOWS_BASH := $(GIT_WINDOWS_ROOT)/usr/bin/bash.exe
 GIT_WINDOWS_SED := $(GIT_WINDOWS_ROOT)/usr/bin/sed.exe
 GIT_WINDOWS_ENV := $(GIT_WINDOWS_ROOT)/usr/bin/env.exe
 ifneq ($(strip $(shell if exist "$(GIT_WINDOWS_BASH)" echo ready)),ready)
-$(error Could not find Git for Windows' bash at $(GIT_WINDOWS_BASH))
+$(error Could not find the Windows Git POSIX bundle's bash at $(GIT_WINDOWS_BASH))
 endif
 ifneq ($(strip $(shell if exist "$(GIT_WINDOWS_SED)" echo ready)),ready)
-$(error Could not find Git for Windows' sed at $(GIT_WINDOWS_SED))
+$(error Could not find the Windows Git POSIX bundle's sed at $(GIT_WINDOWS_SED))
 endif
 ifneq ($(strip $(shell if exist "$(GIT_WINDOWS_ENV)" echo ready)),ready)
-$(error Could not find Git for Windows' env at $(GIT_WINDOWS_ENV))
+$(error Could not find the Windows Git POSIX bundle's env at $(GIT_WINDOWS_ENV))
 endif
 SHELL := $(GIT_WINDOWS_BASH)
 .SHELLFLAGS := -c
 ifneq ($(strip $(shell printf '%s' ready;)),ready)
-$(error Could not start Git for Windows' bash at $(SHELL))
+$(error Could not start the Windows Git POSIX bundle's bash at $(SHELL))
 endif
 # GNU Make may launch simple commands and shebang interpreters directly instead
-# of through SHELL, so expose Git's POSIX tools to those process lookups too.
+# of through SHELL, so expose the bound POSIX tools to those process lookups too.
 export PATH := $(GIT_WINDOWS_ROOT)/usr/bin;$(PATH)
 endif
 endif
 
 .PHONY: all build doctor-build test test-icu-path test-full-cgo test-regression test-upgrade test-cross-version test-migration corpus-regen bench bench-quick clean clean-test-tmp install install-force help check-up-to-date fmt fmt-check check-testing-short
-.PHONY: ci-pr-core ci-pr-policy ci-pr-lint ci-package-mcp ci-package-npm
+.PHONY: ci-pr-core ci-pr-policy ci-pr-lint ci-pr-lint-bound ci-package-mcp ci-package-npm
 
 # Default target
 all: build
 
 BUILD_DIR := .
-GIT_BUILD := $(shell git rev-parse --short HEAD)
+GIT_BUILD = $(shell "$(CI_GIT)" rev-parse --short HEAD)
 ifeq ($(OS),Windows_NT)
 INSTALL_DIR := $(USERPROFILE)/.local/bin
 WINDOWS_MINGW_BIN ?= /c/ProgramData/mingw64/mingw64/bin
@@ -75,7 +104,7 @@ export CGO_ENABLED := 1
 # GOTOOLCHAIN=auto downloads the right compiler but coverage instrumentation
 # may still use the local toolchain's compile tool, causing version mismatch.
 # Force the go.mod version to ensure all tools match.
-GO_VERSION := $(shell sed -n 's/^go //p' go.mod)
+GO_VERSION ?= $(shell "$(CI_SED)" -n 's/^go //p' go.mod)
 ifneq ($(GO_VERSION),)
 export GOTOOLCHAIN := go$(GO_VERSION)
 endif
@@ -187,7 +216,33 @@ ci-pr-policy:
 	@./scripts/ci/pr-policy.sh
 
 ci-pr-lint:
-	@./scripts/ci/pr-lint.sh
+	@unset BASH_ENV ENV; \
+		BEADS_CI_INVOKING_MAKE="$(CI_INVOKING_MAKE)" \
+		BEADS_CI_INVOKING_MAKE_ORIGIN="$(CI_INVOKING_MAKE_ORIGIN)" \
+		BEADS_CI_INVOKING_MAKEFILE_LIST="$(CI_INVOKING_MAKEFILE_LIST)" \
+		BEADS_CI_INVOKING_MAKEFLAGS_ORIGIN="$(CI_INVOKING_MAKEFLAGS_ORIGIN)" \
+		BEADS_CI_INVOKING_MFLAGS="$(CI_INVOKING_MFLAGS)" \
+		BEADS_CI_INVOKING_GNUMAKEFLAGS="$(CI_INVOKING_GNUMAKEFLAGS)" \
+		BEADS_CI_INVOKING_MAKEFILES_ORIGIN="$(CI_INVOKING_MAKEFILES_ORIGIN)" \
+		BEADS_CI_INVOKING_MAKEFILES="$(CI_INVOKING_MAKEFILES)" \
+		BEADS_CI_INVOKING_GIT="$(CI_GIT)" \
+		BEADS_CI_INVOKING_WINDOWS_GIT="$(GIT_WINDOWS_EXE)" \
+		BEADS_CI_AMBIENT_GOOS_PRESENT="$(CI_AMBIENT_GOOS_PRESENT)" \
+		BEADS_CI_AMBIENT_GOOS="$(CI_AMBIENT_GOOS)" \
+		BEADS_CI_AMBIENT_GOARCH_PRESENT="$(CI_AMBIENT_GOARCH_PRESENT)" \
+		BEADS_CI_AMBIENT_GOARCH="$(CI_AMBIENT_GOARCH)" \
+		BEADS_CI_AMBIENT_CGO_ENABLED_PRESENT="$(CI_AMBIENT_CGO_ENABLED_PRESENT)" \
+		BEADS_CI_AMBIENT_CGO_ENABLED="$(CI_AMBIENT_CGO_ENABLED)" \
+		"$(CI_BASH)" --noprofile --norc ./scripts/ci/pr-lint-host.sh
+
+ci-pr-lint-bound:
+	@test "$(BEADS_CI_TOOLCHAIN_BOUND)" = 1 || { \
+		printf '%s\n' \
+			'ci-pr-lint-bound requires BEADS_CI_TOOLCHAIN_BOUND=1' >&2; \
+		exit 1; \
+	}
+	@"$(BEADS_CI_BASH)" --noprofile --norc ./scripts/ci/pr-lint-routing-test.sh
+	@"$(BEADS_CI_BASH)" --noprofile --norc ./scripts/ci/pr-lint.sh
 
 ci-package-mcp:
 	@./scripts/ci/package-mcp.sh
@@ -296,7 +351,12 @@ fmt:
 # Check that all Go files are properly formatted (for CI)
 fmt-check:
 	@echo "Checking Go formatting..."
-	@UNFORMATTED=$$(gofmt -l .); \
+	@UNFORMATTED=$$("$(CI_GOFMT)" -l .); \
+	status=$$?; \
+	if [ "$$status" -ne 0 ]; then \
+		echo "gofmt failed while checking formatting" >&2; \
+		exit "$$status"; \
+	fi; \
 	if [ -n "$$UNFORMATTED" ]; then \
 		echo "The following files are not properly formatted:"; \
 		echo "$$UNFORMATTED"; \

--- a/engdocs/CI_CLEANUP_PLAN.md
+++ b/engdocs/CI_CLEANUP_PLAN.md
@@ -1,6 +1,6 @@
 # CI Cleanup Plan
 
-Last reviewed: 2026-05-29
+Last reviewed: 2026-07-26
 
 Freshness source: `engdocs/CI_TEST_SURFACE_AUDIT.md`, `.github/workflows/*.yml`,
 `.buildflags`, `.golangci.yml`, package test manifests, and maintainer decision
@@ -10,10 +10,16 @@ This document records the agreed target shape for CI cleanup. It is the policy
 and roadmap layer; the current inventory remains in
 [`CI_TEST_SURFACE_AUDIT.md`](CI_TEST_SURFACE_AUDIT.md).
 
+Scoped update (2026-07-26): the goals, tier wording, and `pr-lint` sections were
+reviewed for the current lint-contract candidate. Measurements, non-lint tiers,
+release policy, and the remaining roadmap retain their 2026-05-29 review
+authority.
+
 ## Goals
 
 - Make every important CI tier reproducible through a repository-owned command.
-- Keep PR checks fast, required, and Linux-only unless risk justifies more.
+- Keep broad PR checks Linux-first while retaining narrow real-host required
+  lanes where a host contract cannot be established from Linux.
 - Run expensive platform and integration coverage on `main`, manual dispatch, or
   scheduled background jobs after measuring wall-clock cost.
 - Make release/package checks rerun release-critical validation before
@@ -23,7 +29,9 @@ and roadmap layer; the current inventory remains in
 ## Non-Goals
 
 - Do not make `.test-skip` part of CI. It is a local human optimization file.
-- Do not run macOS or Windows checks on PRs by default.
+- Do not add broad macOS or Windows suites to PRs by default. Narrow required
+  platform-boundary checks remain appropriate when the contract cannot be
+  exercised from Linux alone.
 - Do not make Codecov/upload success block PRs or `main`.
 - Do not broaden `pull_request_target` usage for package validation.
 
@@ -33,26 +41,36 @@ and roadmap layer; the current inventory remains in
 |---|---|---:|---|---|
 | `pr-core` | Every PR and merge queue run | Yes | Linux | Fast baseline Go validation for the shipped default path. |
 | `pr-policy` | Every PR and merge queue run | Yes | Linux | Repository policy checks that should fail before expensive tests matter. |
-| `pr-lint` | Every PR and merge queue run | Yes | Linux | Required `gofmt` and `golangci-lint` gate. |
+| `pr-lint` | Every PR and merge queue run | Yes | Linux amd64 CGO, Darwin arm64 CGO, native Windows amd64 CGO/non-CGO; MSYS2/Cygwin smokes | Required `gofmt`, authority-bound native lint, Windows/non-CGO coverage, public routing, and host/bundle falsifiers. |
 | `pr-risk-*` | PRs matching risky paths or maintainer labels | Yes when applicable | Linux | Descriptive risk checks such as embedded, regression, Nix, packages, and release paths. |
 | `main-*` | Every push to `main` | Yes for branch health | Linux plus selected macOS/Windows | Detect after-merge issues from direct pushes and platform-specific behavior. |
 | `measure-*` | Manual dispatch | No | Per suite | Collect wall-clock and sharding data before promoting suites. |
 | `nightly-*` | Scheduled/manual | No, but failures require triage | Linux unless measured otherwise | Expensive background coverage not ready for every `main` push. |
 | `release-*` | Tags/manual release | Yes before publish | Per artifact | Re-run release-critical checks and publish only after package gates pass. |
 
-`merge_group` means GitHub Merge Queue. Treat it like a PR event: run Linux
-`pr-core`, `pr-policy`, `pr-lint`, and the same risk checks; do not add macOS or
-Windows there.
+`merge_group` means GitHub Merge Queue. Treat it like a PR event: run the Linux
+`pr-core`, `pr-policy`, and `pr-lint` jobs, including the narrow full macOS and
+native Windows lint-host boundaries, and the same risk checks. This does not
+add the broad macOS or Windows test fanout to merge-queue runs.
 
 ## Required PR Checks
 
 Every PR, including docs-only PRs, should run the required Linux baseline:
-`pr-core`, `pr-policy`, and `pr-lint`.
+`pr-core`, `pr-policy`, and `pr-lint`. The latter includes required real
+Darwin/arm64 and native Windows/amd64 host boundaries; MSYS2 and Cygwin remain
+narrow bootstrap smokes.
+
+“Required” in this plan is a repository workflow-policy designation. It does not
+assert current GitHub merge enforcement. As of 2026-07-26, active ruleset
+`15646382` has no required-status-check rule; server-side rollout of the
+aggregate checks remains pending.
 
 ## Wrapper Conventions
 
-Shell scripts under `scripts/ci/` are the source of truth. Make targets should
-be aliases for discoverability, not a second implementation of command policy.
+Shell scripts under `scripts/ci/` own implementation. The public
+`make ci-pr-lint` target is nevertheless part of lint contract v2: it captures
+caller state and exact Make/Bash/Git authority before entering private scripts.
+Direct script or hook invocation is not an equivalent alias.
 
 Wrapper rules:
 
@@ -117,15 +135,18 @@ macOS short, and Windows smoke. Main can tolerate more jobs than PRs, but should
 still avoid rebuilding the same Linux candidate binary in each consumer.
 
 Initial implementation on branch `ci/bd-am3.1-wrapper-commands` adds the
-`Build Artifacts` CI job. It runs `make ci-pr-policy`, `make ci-pr-lint`, builds
+`Build Artifacts` CI job. It runs `make ci-pr-policy`, enters the bound lint
+contract through absolute
+`/usr/bin/make -f Makefile CI_BASH=/usr/bin/bash ci-pr-lint`,
+and builds
 `bd-linux-gms-pure`, writes `SHA256SUMS` and `build-manifest.txt`, then uploads
 the run-scoped `ci-build-artifacts` artifact. The first consumers are
 `PR Core (wrapper timing)`, `Test (ubuntu-latest)`, and
 `Test (storage domain + uow)`, all of which verify `SHA256SUMS`; the Linux test
 consumers pass the binary through `BEADS_TEST_BD_BINARY` for subprocess tests.
-The legacy cross-platform `Test` matrix and Windows smoke job are gated to
-push-to-main only, so PR and merge queue events do not run macOS, Windows, or
-coverage collection.
+The legacy cross-platform `Test` matrix and broad Windows smoke job are gated
+to push-to-main only. PR and merge queue events retain only narrow required
+platform-boundary coverage, not the broad macOS, Windows, or coverage suites.
 
 ### `pr-core`
 
@@ -159,11 +180,91 @@ Additional rules:
 
 ### `pr-lint`
 
-`pr-lint` is required. It should stay separate from policy so lint failures are
-easy to identify and rerun. It includes:
+`pr-lint` is required. It stays separate from policy so lint failures are easy
+to identify and rerun. Local `make ci-pr-lint` and the required workflow host
+driver converge on one bound internal target containing:
 
-- `make fmt-check`.
-- `golangci-lint run --timeout=5m --build-tags=gms_pure_go ./...`.
+- a strict eleven-case black-box regression for target routing, one-query
+  snapshot, target-state change between snapshot and lint, explicit frozen
+  normal-pass values, both linter-pass failures, Make failure propagation, and
+  nonzero execution,
+  plus four fail-closed authority cases for config, workspace, vendor, and
+  public-target substitution, plus a nonzero-gofmt end-to-end refusal;
+- `make fmt-check`;
+- one lint with the validated tuple frozen by a single
+  `go env GOOS GOARCH CGO_ENABLED` call; and
+- unless that tuple is already Windows/non-CGO, one lint with
+  `GOOS=windows`, the frozen `GOARCH`, and `CGO_ENABLED=0`.
+
+Every maintained workflow caller uses `-f Makefile` with an absolute public
+Make target. PR/main `Build Artifacts` provide Linux/amd64/CGO=1 through
+`/usr/bin/make` and
+`/usr/bin/bash`; PR/main `PR Lint (wrapper timing)` provide
+Darwin/arm64/CGO=1 on `macos-15` through stock `/usr/bin/make` 3.81 and
+`/bin/bash`, with a 30-minute job bound; manual measurements retain a Linux
+timing caller. Hosted values
+may be absent or exact-equal to the protected tuple, while wrong GOOS, GOARCH,
+or CGO values fail. Protected callers strip ambient `MAKE`, `MAKEFLAGS`,
+`MFLAGS`, `GNUMAKEFLAGS`, and `MAKEFILES`; the host requires GNU Make's
+unmodified `default` `MAKE` origin and refuses command-line Make/control
+substitution. The fixed workflow argv never supplies `MAKEFILES`; its
+missing-path falsifier verifies the post-parse origin/value check but is not
+containment for a malicious command-line makefile, because Make loads
+`MAKEFILES` before any recipe can run.
+The public boundary also requires `MAKEFILE_LIST` to be exactly `Makefile`.
+Local callers carry one validated tuple through both Make boundaries. Each
+lint explicitly names
+`.golangci.yml`, disables Go workspace discovery, and uses readonly module mode.
+The workflow-required native-Windows row runs the full public route with exact
+Go 1.26.5, GNU Make 4.4.1 under the sole command name
+`mingw32-make.exe`, with no `make.exe` alias, and MinGW 16.1.0 (`gcc` and `g++` both target
+`x86_64-w64-mingw32`), and private golangci-lint 2.10.1 for
+Windows/amd64/CGO=1 and CGO=0. One bootstrap Git derives the bundle root;
+resolved Git and all POSIX leaves must remain in that root. Mixed-PATH,
+wrong-bundle, and wrong-target falsifiers fail closed. MSYS2 and Cygwin rows
+are shell/bootstrap smokes. Static per-row markers make a skipped or unknown
+Windows matrix route fail. The matrix has a 45-minute outer bound for cold
+tool installation plus the full native route.
+
+Private linter cleanup is authority-bearing: only a canonical, non-symlinked
+`RUNNER_TEMP` direct child matching
+`beads-pr-lint-tools.<8 alphanumerics>` can receive deletion authority. The
+same canonical path, directory type, and allowed shape are revalidated
+immediately before deletion; this does not claim portable file identity.
+The contract relies on the trusted private runner temp having one owner and no
+concurrent same-type replacement writer during cleanup. Malformed, nested,
+outside, symlink-replaced, or unexpected paths are retained and fail.
+Production cleanup enters that canonical directory, permits exactly one
+verified regular linter leaf, unlinks only that leaf, and applies
+bound nonrecursive `rmdir` to the now-empty exact directory. Any unexpected
+entry is retained; production never uses recursive deletion. Handled ordinary
+failure and INT, TERM, or HUP run the same cleanup handler; SIGKILL, caller
+loss, and power loss instead depend on runner teardown. A partial installation
+is deliberately retained because no verified linter leaf exists.
+The workflow-required macOS caller black-boxes three hosted-target conflicts, a symlinked cleanup
+root, malformed, outside, nested, replaced, and unexpected-entry private tool
+paths, plus forged command-line `MAKE`, `MAKEFLAGS`, and `MAKEFILES`: exactly
+fifteen refusal cases including an alternate Make invocation leaf, a nonzero
+target-enumerator producer, and partial installation. It separately proves
+cleanup after ordinary failure and INT/TERM/HUP and proves ambient Go build
+state cannot enter private install.
+
+Version authority is deliberately field-specific: Go matches the exact
+three-component `go.mod` directive and golangci-lint is exactly 2.10.1. The
+native Windows lane claims GNU Make 4.4.1 because it installs that exact
+version. Linux binds one GNU Make executable without claiming a mutable package
+version, then exercises every GNU Make capability the full lint gate consumes.
+macOS binds stock GNU Make 3.81 using a stdin makefile probe and no modern
+`.SHELLFLAGS` assumption. Its Apple build may omit `MAKE_HOST`; that fallback
+is restricted to the exact `/usr/bin/make` invocation leaf with exact
+first-line version `GNU Make 3.81` after the outer Darwin host has already been
+proved. The canonical target must be executable; the remaining free-form build
+banner is deliberately not authority. MSYS2 and Cygwin make only their narrower
+shell/bootstrap claims.
+
+The authoritative protected surface and affected-caller list live in
+[`LINTING.md`](LINTING.md); required-check review must include the workflow
+aggregate helper and timing helper as well as the visible wrapper scripts.
 
 Known false positives must be handled in `.golangci.yml` or with targeted
 `//nolint` comments. CI should not use a tolerated failing lint baseline.
@@ -303,6 +404,9 @@ not make final tiering or sharding decisions from one run.
 | `pr-policy` | 91s | 65s | `build bd for docs checks` at 53s |
 | `pr-core` | 593s | 577s | `go test -race -short -skip '^TestEmbedded' ./...` |
 | `pr-lint` | 211s | 143s, plus 54s tool install | `golangci-lint` at 143s |
+
+These historical measurements predate the frozen-target two-pass lint contract.
+Use a fresh measurement before treating them as current capacity evidence.
 
 Same-run job-level observations:
 

--- a/engdocs/CI_REQUIRED_CHECK_TOPOLOGY.md
+++ b/engdocs/CI_REQUIRED_CHECK_TOPOLOGY.md
@@ -1,8 +1,10 @@
 # Required Check Topology
 
-Status: initial aggregate gate jobs implemented on branch
-`ci/bd-am3.1-wrapper-commands`. Do not change branch protection until the new
-checks have appeared and passed on at least one recent commit.
+Status: aggregate gate jobs exist in the repository workflow source, and the
+current lint candidate extends their dependency graph. GitHub server enforcement
+has not been rolled out. As of 2026-07-26, active ruleset
+`Protect main - light (beads and gastown)` (ID `15646382`) contains only
+`deletion` and `non_fast_forward`; it has no required-status-check rule.
 
 ## Problem
 
@@ -32,8 +34,9 @@ Current PR-related workflow names:
 
 - `.github/workflows/pr.yml`: `PR`
   Runs on `pull_request` and `merge_group`. Contains the baseline PR jobs,
-  Linux build artifact stage, policy/lint compatibility jobs, package gates
-  that consume the Linux artifact, focused storage domain/uow coverage, and
+  Linux build artifact stage, Darwin/arm64 and native-Windows lint-host routes,
+  MSYS2/Cygwin smokes, policy/lint compatibility jobs, package gates that
+  consume the Linux artifact, focused storage/domain/contract coverage, and
   the baseline aggregate gate `PR / CI Gate / Required`.
 - `.github/workflows/pr-risk.yml`: `PR Risk`
   Runs on `pull_request` and `merge_group`. Contains embedded Dolt risk
@@ -58,24 +61,21 @@ Current PR-related workflow names:
   Runs on `pull_request_target` for Dependabot Go bumps. It mutates Dependabot
   branches and must not be a required PR check.
 
-As of 2026-05-26, the live `gastownhall/beads` ruleset named
-`Protect main - light (beads and gastown)` enforces deletion and non-fast-forward
-protection on the default branch. It does not currently require status checks.
+## Workflow-Policy Required Check Contract
 
-## Required Check Contract
-
-After the aggregate checks are verified on the branch, branch protection or the
+In this document, “required” describes repository workflow policy and aggregate
+job dependencies. It does not mean GitHub currently blocks merges when a check
+is absent or failing. If server enforcement is enabled, branch protection or the
 default-branch ruleset should require stable aggregate GitHub Actions checks
-from unfiltered workflows. The original single-check proposal assumed all PR
-jobs lived in one workflow; after the workflow split, a single in-workflow
-aggregate can only cover jobs in that same workflow. The implemented first
-rollout uses one aggregate per required workflow. An external status aggregator
-would only be needed if maintainers still want exactly one required check.
+from unfiltered workflows. One in-workflow aggregate can only cover jobs in
+that workflow, so the current topology uses one aggregate per workflow-policy
+required workflow.
 
 - Baseline aggregate candidate: `PR / CI Gate / Required`
 - Risk aggregate candidate: `PR Risk / CI Gate / Required`
 - Source: GitHub Actions
-- Required on: pull requests and merge queue groups targeting `main`
+- Intended server-enforcement scope: pull requests and merge queue groups
+  targeting `main`
 
 Do not require these existing check names directly:
 
@@ -84,16 +84,20 @@ Do not require these existing check names directly:
 - `Check cmd/bd pure-Go tests compile (CGO_ENABLED=0)`
 - `Check version consistency`
 - `Check doc flags freshness`
+- `Check doc freshness (<platform>)`
+- `PR preflight process (<platform>)`
 - `Check for .beads changes`
 - `Test (ubuntu-latest)`
 - `Test (macos-latest)`
 - `Test (storage domain + uow)`
+- `Contract corpus (golden + determinism + conformance)`
 - `Build (Embedded Dolt)`
 - `Test (Embedded Dolt Storage)`
 - `Test (Embedded Dolt Cmd 1/20)` through `Test (Embedded Dolt Cmd 20/20)`
 - `Test (Windows - smoke)`
 - `Check formatting`
 - `Lint`
+- `Windows Make shell (<host>)`
 - `Test Nix Flake`
 - `Differential Regression (v0.49.6 baseline)`
 - `Upgrade smoke (<version> -> candidate)`
@@ -135,23 +139,27 @@ Do not add `paths`, `paths-ignore`, or narrower branch filters to `pr.yml` or
       - build-artifacts
       - check-build-tags
       - check-cmd-bd-puregeo-tests
+      - worktree-remove-windows
       - check-version-consistency
-      - check-no-duplicate-migrations
+      - check-migration-hygiene
       - check-doc-flags
+      - check-doc-freshness-platforms
+      - pr-preflight-platforms
       - check-no-beads-changes
       - detect-package-gates
       - package-mcp
       - package-npm
-      - package-website
       - pr-policy-wrapper
       - pr-core-wrapper
       - pr-lint-wrapper
       - test-domain-uow
+      - contract-corpus
       - fmt-check
       - lint
+      - windows-make-shell
     if: ${{ always() }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
 
       - name: Evaluate CI gate
         env:
@@ -160,37 +168,45 @@ Do not add `paths`, `paths-ignore`, or narrower branch filters to `pr.yml` or
             BUILD_ARTIFACTS
             CHECK_BUILD_TAGS
             CHECK_CMD_BD_PUREGEO_TESTS
+            WORKTREE_REMOVE_WINDOWS
             CHECK_VERSION_CONSISTENCY
-            CHECK_NO_DUPLICATE_MIGRATIONS
+            CHECK_MIGRATION_HYGIENE
             CHECK_DOC_FLAGS
+            CHECK_DOC_FRESHNESS_PLATFORMS
+            PR_PREFLIGHT_PLATFORMS
             CHECK_NO_BEADS_CHANGES
             DETECT_PACKAGE_GATES
             PACKAGE_MCP
             PACKAGE_NPM
-            PACKAGE_WEBSITE
             PR_POLICY_WRAPPER
             PR_CORE_WRAPPER
             PR_LINT_WRAPPER
             TEST_DOMAIN_UOW
+            CONTRACT_CORPUS
             FMT_CHECK
             LINT
+            WINDOWS_MAKE_SHELL
           BUILD_ARTIFACTS: ${{ needs.build-artifacts.result }}
           CHECK_BUILD_TAGS: ${{ needs.check-build-tags.result }}
           CHECK_CMD_BD_PUREGEO_TESTS: ${{ needs.check-cmd-bd-puregeo-tests.result }}
+          WORKTREE_REMOVE_WINDOWS: ${{ needs.worktree-remove-windows.result }}
           CHECK_VERSION_CONSISTENCY: ${{ needs.check-version-consistency.result }}
-          CHECK_NO_DUPLICATE_MIGRATIONS: ${{ needs.check-no-duplicate-migrations.result }}
+          CHECK_MIGRATION_HYGIENE: ${{ needs.check-migration-hygiene.result }}
           CHECK_DOC_FLAGS: ${{ needs.check-doc-flags.result }}
+          CHECK_DOC_FRESHNESS_PLATFORMS: ${{ needs.check-doc-freshness-platforms.result }}
+          PR_PREFLIGHT_PLATFORMS: ${{ needs.pr-preflight-platforms.result }}
           CHECK_NO_BEADS_CHANGES: ${{ needs.check-no-beads-changes.result }}
           DETECT_PACKAGE_GATES: ${{ needs.detect-package-gates.result }}
           PACKAGE_MCP: ${{ needs.package-mcp.result }}
           PACKAGE_NPM: ${{ needs.package-npm.result }}
-          PACKAGE_WEBSITE: ${{ needs.package-website.result }}
           PR_POLICY_WRAPPER: ${{ needs.pr-policy-wrapper.result }}
           PR_CORE_WRAPPER: ${{ needs.pr-core-wrapper.result }}
           PR_LINT_WRAPPER: ${{ needs.pr-lint-wrapper.result }}
           TEST_DOMAIN_UOW: ${{ needs.test-domain-uow.result }}
+          CONTRACT_CORPUS: ${{ needs.contract-corpus.result }}
           FMT_CHECK: ${{ needs.fmt-check.result }}
           LINT: ${{ needs.lint.result }}
+          WINDOWS_MAKE_SHELL: ${{ needs.windows-make-shell.result }}
         run: |
           skipped_ok=""
           if [[ "$GITHUB_EVENT_NAME" == "merge_group" ]]; then
@@ -325,7 +341,8 @@ Policy for `merge_group`:
 
 ## Rollout Steps
 
-1. Add `.github/scripts/ci-gate.sh` and aggregate gate jobs to the required PR
+1. Add `.github/scripts/ci-gate.sh` and aggregate gate jobs to the
+   workflow-policy PR
    workflows. Initial implementation exists on branch
    `ci/bd-am3.1-wrapper-commands`.
 2. Open a PR and verify the new aggregate check names appear exactly as

--- a/engdocs/CI_TEST_SURFACE_AUDIT.md
+++ b/engdocs/CI_TEST_SURFACE_AUDIT.md
@@ -10,6 +10,14 @@ This is an audit snapshot, not the final CI policy. Use it to reason from first
 principles about what the repository can validate, what CI currently validates,
 and what should be cleaned up next.
 
+Scoped update (2026-07-26): only the lint-contract rows and related CI-topology
+descriptions were reviewed against the current lint candidate's `Makefile`,
+`scripts/ci/pr-lint-host.sh`, `scripts/ci/pr-lint.sh`,
+`scripts/ci/pr-lint-routing-test.sh`, `.github/workflows/pr.yml`,
+`.github/workflows/main.yml`, `.github/workflows/ci-measurements.yml`,
+`engdocs/LINTING.md`, and `engdocs/CI_REQUIRED_CHECK_TOPOLOGY.md`. Inventory
+counts and all other findings remain the 2026-05-26 snapshot identified above.
+
 Accepted cleanup decisions and implementation order are tracked in
 [`CI_CLEANUP_PLAN.md`](CI_CLEANUP_PLAN.md).
 
@@ -65,6 +73,7 @@ exists only as an opt-in maintainer path.
 | `make bench` | `go test -bench=. ./internal/storage/dolt/` | Full Dolt benchmark suite. |
 | `make bench-quick` | Shorter benchmark run | Local performance iteration. |
 | `make fmt-check` | `gofmt -l .` | Formatting gate. |
+| `make ci-pr-lint` | Public v2 host contract, eleven routing cases, `fmt-check`, native-target lint, Windows/non-CGO lint | Candidate authoritative local/workflow-policy lint gate. |
 | `make check-docs` | Build no-CGO binary, then `scripts/check-doc-flags.sh` | CLI-doc flag freshness. |
 
 ### Go Test Runner
@@ -154,9 +163,10 @@ These are valuable but are not one unified release gate in CI today.
 The former monolithic `ci.yml` has been split by tier/domain:
 
 - `pr.yml`: pull request and merge queue baseline. It owns the Linux build
-  artifact stage, PR policy/core/lint wrappers, compatibility policy/lint jobs,
-  package gates that consume the Linux artifact, storage domain/uow tests, and
-  the aggregate check `PR / CI Gate / Required`.
+  artifact stage, Darwin/arm64 and native-Windows full lint-host routes,
+  MSYS2/Cygwin smokes, PR policy/core wrappers, compatibility jobs, package
+  gates that consume the Linux artifact, storage domain/uow tests, and the
+  aggregate check `PR / CI Gate / Required`.
 - `pr-risk.yml`: pull request and merge queue risk jobs. It owns embedded Dolt
   risk detection, embedded build/storage/cmd shards, the Nix flake smoke, and
   the aggregate check `PR Risk / CI Gate / Required`.
@@ -166,18 +176,23 @@ The former monolithic `ci.yml` has been split by tier/domain:
 
 Key jobs preserved by display name:
 
-- `Build Artifacts`: runs `make ci-pr-policy`, `make ci-pr-lint`, builds
+- `Build Artifacts`: runs `make ci-pr-policy`, enters lint v2 through absolute
+  `/usr/bin/make -f Makefile CI_BASH=/usr/bin/bash ci-pr-lint`, builds
   `bd-linux-gms-pure`, and uploads checksummed run-scoped artifacts.
 - `Check build-tag policy`: runs `scripts/check-build-tags.sh` and
   `scripts/check-go-install-guidance.sh`.
 - `Check cmd/bd pure-Go tests compile (CGO_ENABLED=0)`: CGO-disabled cmd/bd
   build, test-binary compile, and a focused pure-Go test subset.
-- `Check version consistency`, `Check no duplicate migration versions`,
-  `Check doc flags freshness`, and PR-only `Check for .beads changes`.
-- `PR Policy (wrapper timing)`, `PR Core (wrapper timing)`, and
-  `PR Lint (wrapper timing)`.
-- `Package Gate (MCP)`, `Package Gate (npm)`, and `Package Gate (website)`.
-- `Test (storage domain + uow)`.
+- `Check version consistency`, `Check migration hygiene`,
+  `Check doc flags freshness`, `Check doc freshness (<platform>)`,
+  `PR preflight process (<platform>)`, and PR-only
+  `Check for .beads changes`.
+- `PR Policy (wrapper timing)`, `PR Core (wrapper timing)`, and Darwin/arm64
+  `PR Lint (wrapper timing)` on `macos-15`.
+- `Package Gate (MCP)` and `Package Gate (npm)`.
+- `Worktree remove boundary (Windows)`, `Test (storage domain + uow)`,
+  `Contract corpus (golden + determinism + conformance)`, and
+  `Windows Make shell (<host>)`.
 - `Build (Embedded Dolt)`, `Test (Embedded Dolt Storage)`, and
   `Test (Embedded Dolt Cmd N/20)`.
 - Aggregate required-check candidates: `PR / CI Gate / Required` and
@@ -262,9 +277,12 @@ paths.
 Impact: package-specific regressions can reach release/publish workflows
 without the package's own tests having run.
 
-### P2: Windows Is Smoke-Only
+### P2: Broad Windows Tests Remain Smoke-Only
 
-Windows CI builds and runs `version` and `help`, but it does not run Go tests.
+Windows CI still limits broad product validation to build/version/help smoke,
+but the workflow-policy lint route now runs the real native Windows/amd64/CGO=1 and
+non-CGO analysis through exact Go, Make, MinGW, Git-bundle, and linter
+authority.
 
 Impact: Windows-specific filesystem, path, shell, and CGO behavior depends on
 limited coverage. This may be the right tradeoff, but it should be an explicit
@@ -278,19 +296,18 @@ captures benchmark artifacts or runs labeled performance checks.
 Impact: performance-sensitive changes rely on human/agent discipline rather
 than a repeatable CI path.
 
-### P2: Existing Docs Have Drift
+### P2: Remaining Historical Docs May Drift
 
 Examples:
 
 - `engdocs/TESTING.md` says the wrapper script is consistent with CI, but PR CI
   uses direct `go test`.
-- `engdocs/LINTING.md` says CI may not fail on known lint issues, while the
-  workflow uses the standard `golangci-lint` action without an explicit
-  non-failing issues exit code.
 - Older staged audit docs contain obsolete test counts.
 
-Impact: stale docs undermine the cleanup effort because they hide the actual
-current contract.
+The earlier lint-baseline and direct-entrypoint drift is resolved by lint
+contract v2 and its expanded freshness source set. Remaining historical counts
+still need ordinary inventory review rather than being treated as gate
+authority.
 
 ## Roadmap
 

--- a/engdocs/DOC_INVENTORY.md
+++ b/engdocs/DOC_INVENTORY.md
@@ -1,6 +1,7 @@
 # Documentation Disposition Inventory
 
-Reviewed: 2026-07-07 (paths updated 2026-07-10 for the Mintlify port: user docs now live in the docs/ site tree; this ledger and other internal docs live in engdocs/)
+Reviewed: 2026-07-26 (Mintlify paths remain current; lint-contract authority
+and CI topology entries were re-reviewed against their complete source set.)
 
 CI cleanup entry added: 2026-05-28
 
@@ -34,7 +35,7 @@ freshness source.
 | `reference/json-schema.md` | `Last reviewed:` marker tied to `cmd/bd/output.go`, `cmd/bd/errors.go`, and protocol tests. (Mintlify port: was `JSON_SCHEMA.md`.) |
 | `recovery/init-safety.md` | `Last reviewed:` marker tied to `cmd/bd/init*.go` safety code and tests. (Mintlify port: was `RECOVERY.md`.) |
 | `ERROR_HANDLING.md` | `Last reviewed:` marker tied to current command error exits and JSON error helpers. |
-| `LINTING.md` | `Last reviewed:` marker tied to `.golangci.yml` and current lint output. |
+| `LINTING.md` | `Last reviewed:` marker tied to the v2 Make/host/routing scripts, protected config/module inputs, PR aggregate and host workflows, affected caller workflows, contributor/agent guidance, formula guidance, and freshness checker/tests. |
 | `CI_CLEANUP_PLAN.md` | `Last reviewed:` marker tied to CI audit, workflow files, package manifests, and maintainer decision review. |
 | `design/otel/otel-data-model.md` | `Last reviewed:` marker tied to telemetry, Dolt storage, hooks, and AI call sites. |
 
@@ -89,7 +90,7 @@ Follow-up automation should replace marker-only checks with generated or
 | `INTERNALS.md` | Keep | Internal architecture/runtime deep dive. |
 | `JSON_SCHEMA.md` | Keep with freshness | JSON contract; marker tied to schema constant and tests. |
 | `LABELS.md` | Keep | User-facing label philosophy plus examples; generated CLI handles command reference. |
-| `LINTING.md` | Revise with freshness | Stale fixed-count wording removed; marker tied to current lint output. |
+| `LINTING.md` | Keep with freshness | Authoritative v2 public entrypoint, real-host matrix, target/bundle/cleanup contract, and exact protected/review corpus are tied to the complete freshness source set. |
 | `messaging.md` | Keep | Design doc for messaging issue types. |
 | `METADATA.md` | Keep | Behaviour doc for metadata field semantics. |
 | `MOLECULES.md` | Keep | User-facing workflow concept doc. |

--- a/engdocs/LINTING.md
+++ b/engdocs/LINTING.md
@@ -1,36 +1,214 @@
 # Linting Policy
 
-Last reviewed: 2026-05-29
+Last reviewed: 2026-07-26
 
-Freshness source: `.golangci.yml`, `.github/workflows/pr.yml`,
-`.github/workflows/main.yml`, and
-`golangci-lint run --timeout=5m --build-tags=gms_pure_go ./...` returning zero
-issues.
+Freshness source: `.golangci.yml`, `.buildflags`, `go.mod`, `go.sum`,
+`Makefile`, `scripts/ci/pr-lint-host.sh`, `scripts/ci/pr-lint.sh`,
+`scripts/ci/pr-lint-routing-test.sh`, `scripts/pr_lint_ci_contract_test.go`,
+`scripts/ci/lib/timing.sh`,
+`.github/scripts/ci-gate.sh`, `.github/workflows/pr.yml`,
+`.github/workflows/main.yml`, `.github/workflows/ci-measurements.yml`,
+`CONTRIBUTING.md`, `AGENTS.md`, `AGENT_INSTRUCTIONS.md`,
+`.github/copilot-instructions.md`, `scripts/README.md`,
+`engdocs/CI_CLEANUP_PLAN.md`, `engdocs/CI_TEST_SURFACE_AUDIT.md`,
+`engdocs/CI_REQUIRED_CHECK_TOPOLOGY.md`, `engdocs/TESTING.md`,
+`engdocs/DOC_INVENTORY.md`,
+`examples/formulas/gh-pr-review.formula.toml`,
+`examples/formulas/gh-issue-to-pr.formula.toml`,
+`.pre-commit-config.yaml`, `.githooks/pre-commit`, `cmd/bd/preflight.go`,
+`scripts/check-doc-freshness.sh`, and
+`scripts/check_doc_freshness_test.go`.
 
 This document explains the required Go lint gate for this codebase.
 
 ## Current Status
 
-Lint is a required CI gate. The PR and main workflows run `golangci-lint` with
-the repository configuration and `--build-tags=gms_pure_go`; it is expected to
-pass with zero issues.
+Lint contract v2 is a workflow-policy CI gate. The only public entry point is
+`make ci-pr-lint`; it
+enters `scripts/ci/pr-lint-host.sh`, binds the host and tools, and then runs the
+same internal target as workflow-required CI. The internal target first runs the
+target-routing regression and then the repository-owned wrapper. Every linter
+pass names the exact repository `.golangci.yml`, disables workspace discovery,
+uses readonly module mode, applies `--build-tags=gms_pure_go`, and must return
+zero issues.
 
-Run the same check locally with:
+In this document, “required” means required by repository workflow policy and
+the aggregate job dependency graph. It does not assert server-side merge
+enforcement. As of 2026-07-26, active ruleset `15646382` has no
+required-status-check rule; rollout of aggregate checks as server requirements
+remains pending.
+
+Run the complete required contract locally with:
 
 ```bash
-golangci-lint run --timeout=5m --build-tags=gms_pure_go ./...
+make ci-pr-lint
 ```
 
-Formatting is a separate required gate:
+To exercise the exact Windows/non-CGO skip case from a POSIX shell:
 
 ```bash
-make fmt-check
+GOOS=windows GOARCH=amd64 make CGO_ENABLED=0 ci-pr-lint
 ```
+
+## Target Snapshot and Passes
+
+For local use, the public host makes one `GOENV=off GOWORK=off go env GOOS
+GOARCH CGO_ENABLED` call and narrowly validates that complete caller tuple.
+The outer Make invocation passes it into the host, and the host passes the same
+three values as explicit command-line variables through the internal Make
+boundary. In GitHub Actions, protected expected-target fields instead pin the
+actual Go host tuple. The public Make boundary freezes caller state before the
+Makefile's normal CGO default: ambient `GOOS`, `GOARCH`, or `CGO_ENABLED` may
+be absent or exactly equal to the protected value, while every conflict is
+refused. Those private snapshots use Make `override` assignments, so a caller
+cannot forge the presence or value fields on the command line.
+
+Before either lint starts, `scripts/ci/pr-lint.sh` makes one fail-closed `go env
+GOOS GOARCH CGO_ENABLED` call. It requires an exact match with the host-selected
+tuple, freezes the result, and never re-queries target state. This is the
+end-to-end public-entrypoint guard: dropping or changing a caller value at
+either Make boundary stops before formatting or lint.
+
+Unless the frozen tuple is already exactly `windows` with `CGO_ENABLED=0`, the
+wrapper runs a second lint for `GOOS=windows`, the frozen `GOARCH`, and
+`CGO_ENABLED=0`. This keeps files guarded by `//go:build windows && !cgo` inside
+the required gate without silently changing architecture. A Windows/non-CGO
+caller runs only the normal pass. Failure or malformed output from the one
+target query stops before either linter.
+
+Formatting remains part of the wrapper through `make fmt-check`.
+
+Every linter pass uses the exact regular file
+`$REPO_ROOT/.golangci.yml`, `GOWORK=off`, and
+`--modules-download-mode=readonly`. A sibling `.golangci.yaml`, a `go.work`,
+or a `vendor` directory therefore cannot become an undeclared input. The
+black-box contract includes explicit refusals for a substituted config,
+workspace mode, vendor mode, and a changed public target.
+
+## Host and Tool Authority
+
+Workflow-required Linux callers invoke
+`/usr/bin/make -f Makefile CI_BASH=/usr/bin/bash ci-pr-lint` and declare
+Linux/amd64/CGO=1. Required macOS uses stock `/usr/bin/make` 3.81 plus
+`/bin/bash` on explicit `macos-15` and requires Darwin/arm64/CGO=1. The stdin
+makefile probe works on Make 3.81, and neither POSIX route relies on modern
+`.SHELLFLAGS` behavior. Apple's 3.81 build may emit an empty `MAKE_HOST`; only
+the exact `/usr/bin/make` invocation leaf with exact first-line version
+`GNU Make 3.81` can use that narrow fallback after the outer Darwin host has
+already been proved. Its canonical target must be executable, but the remaining
+free-form build banner is deliberately not authority. Both PR and main macOS
+jobs have a 30-minute outer bound, including cold private installation. The
+host wrapper then:
+
+- requires hosted callers to strip ambient `MAKE`, `MAKEFLAGS`, `MFLAGS`,
+  `GNUMAKEFLAGS`, and `MAKEFILES`, proves `MAKE` retained its GNU Make
+  `default` origin, and rejects command-line Make/control substitution. The
+  fixed workflow argv always supplies `-f Makefile` and never supplies
+  `MAKEFILES`; the missing-path falsifier
+  checks its post-parse origin/value receipt, not containment of a malicious
+  command-line makefile, which Make would load before the recipe;
+- requires `MAKEFILE_LIST` to be exactly `Makefile`, clears `BASH_ENV` and
+  `ENV` before every public recipe, and passes the exact bound Make executable
+  to formatting recursion;
+- confirms the actual Bash, `uname`, and Go host all report the declared
+  Linux or macOS host;
+- resolves Bash, GNU Make, Go, gofmt, Git, sed, env, the C/C++ compilers, and
+  golangci-lint once to absolute executable paths;
+- checks the exact Go version from protected `go.mod`;
+- installs golangci-lint 2.10.1 into a new private runner directory under an
+  empty environment carrying explicit host `GOOS`/`GOARCH`, `CGO_ENABLED=0`,
+  `GOENV=off`, `GOWORK=off`, empty `GOFLAGS`/`GOEXPERIMENT`,
+  `GOTOOLCHAIN=local`, and the applicable baseline architecture level, then
+  checks the invoked binary reports exactly that version;
+- exercises startup isolation, quoting, repository/path resolution, and GNU
+  Make host semantics; and
+- launches the internal Make target through a curated environment that carries
+  those exact identities, the selected target, and no ambient Go configuration.
+
+The version contract is field-specific. Go must match the exact three-component
+version protected by `go.mod`, and every installed or claimed golangci-lint is
+exactly 2.10.1. Linux GNU Make is deliberately version-independent: the host
+binds one GNU Make executable and positively exercises every host/quoting
+capability this gate uses instead of claiming an uninstalled version.
+macOS instead binds the stock paths and exact GNU Make 3.81 expected by its
+protected runner image.
+
+`pr-lint.sh` refuses an unbound toolchain and uses only those absolute paths.
+The same Bash identity starts both scripts, the same Make identity runs
+`fmt-check`, the bound gofmt performs formatting discovery, and temporary
+`GOOS`/`GOARCH`/`CGO_ENABLED` assignments call the bound linter directly rather
+than going through `env` or another `PATH` lookup. The timing helper uses
+Bash's built-in `SECONDS` counter rather than an external clock command.
+When the public target was itself launched through an absolute GNU Make path,
+it hands that identity to the host wrapper; a bare local `make` is resolved once
+by the wrapper like the other tools.
+
+Full Windows `make -f Makefile ci-pr-lint` host semantics are supported through native
+Windows GNU Make only. That required lane separately asserts actual Windows and
+a PowerShell 7+ Core process, resolves and reuses one absolute GNU Make 4.4.1
+and one bootstrap Windows Git executable, and invokes the full public target.
+That target is exact Go 1.26.5 Windows/amd64/CGO=1 using MinGW 16.1.0 with
+both `gcc` and `g++` reporting `x86_64-w64-mingw32`, plus a private
+golangci-lint 2.10.1, followed by Windows/amd64/CGO=0. The full workflow
+boundary exposes GNU Make only as `mingw32-make.exe`, with no `make.exe` alias,
+and proves formatting recursion retains that invoked executable. The bootstrap
+Git exec path derives one common bundle root; resolved Git may be the distinct
+`cmd` or `mingw64/bin` leaf, but Bash, cat, chmod, cp, diff, env, mkdir, mktemp,
+readlink, rm, rmdir, sed, uname, and cygpath must be their exact leaves under
+that same root. A
+mixed-PATH positive case and wrong-root Git falsifier protect this rule.
+MSYS2 and Cygwin packages are
+separate shell/bootstrap compatibility boundaries only; they do not execute or
+claim the full lint-host wrapper. Their mutable package versions are not
+claimed as authority. Those rows bind GNU Make family plus the exact
+family/path/Make/Git smoke they consume. Every matrix row must publish its own
+success marker; an unknown, skipped, or zero-execution row fails an
+unconditional final step. The complete Windows matrix has a 45-minute outer
+bound, including cold Go, Make, MinGW, and private-linter installation.
+
+Private linter installation is also a cleanup contract. `RUNNER_TEMP` is
+canonical and non-symlinked; `mktemp` must return one regular direct child named
+`beads-pr-lint-tools.<8 alphanumerics>`. Cleanup authority is granted only
+after that proof. Immediately before deletion the handler re-proves canonical
+path, directory type, and allowed contents; it does not claim a portable file
+identity. This is safe under the explicit trusted-runner assumption that the
+private temp root has one owner and no concurrent same-type replacement writer.
+An outside, nested, malformed, symlink-replaced, or redirected result is
+retained and fails closed. Cleanup enters the canonical directory, requires
+exactly the one verified regular linter leaf, unlinks only that leaf, and
+removes the now-empty directory with bound `rmdir`; production never uses
+recursive deletion. Unexpected entries and partial installations are retained,
+and successful cleanup requires the exact child to be absent. Ordinary failure
+and handled INT, TERM, and HUP use this same path. SIGKILL, caller loss, and
+power loss cannot run an in-process trap and rely on runner teardown.
+
+The separate action-based `Lint` job is pinned to golangci-lint 2.10.1, but it
+is not authority for the Windows-target claim. That authority belongs to the
+bound wrapper jobs and their required aggregate.
+
+## Workflow Callers and Runtime
+
+Every maintained workflow caller invokes an absolute Make executable and the
+public target, never `pr-lint-host.sh` directly. PR and main `Build Artifacts`
+provide the full Linux route. PR and main `PR Lint (wrapper timing)` provide
+the full Darwin arm64 route. PR `Windows Make shell (native)` provides the
+full native Windows route; its MSYS2/Cygwin siblings remain smokes. The manual
+`ci-measurements` workflow is an optional Linux timing caller. The public Make
+boundary also carries its `CI_GIT` selection explicitly into the host; native
+Windows proves that resolved leaf can differ from the bootstrap
+`GIT_WINDOWS_EXE` leaf while remaining inside the same bundle.
+
+Each full non-Windows route performs its native lint and Windows/non-CGO lint.
+Native Windows performs Windows/CGO and Windows/non-CGO. This is intentional
+independent host coverage rather than duplicate Linux timing.
 
 ## Policy
 
 Treat new lint findings as defects to fix before merge. Do not add a tolerated
 failing baseline, and do not configure CI with `--issues-exit-code=0`.
+The staged-file `.githooks/pre-commit`, `.pre-commit-config.yaml`, and the
+current `cmd/bd` preflight lint are narrower developer conveniences. They do
+not share the v2 host/target/config contract and cannot satisfy this gate.
 
 When a linter reports an intentional or false-positive pattern:
 
@@ -43,20 +221,55 @@ The current configuration already encodes accepted exclusions for intentional
 patterns such as deferred cleanup errors, controlled subprocess execution,
 test-fixture file reads, and documented security false positives.
 
+## Protected Dependency Surface
+
+A review or required-check declaration for this contract must protect the exact
+head plus all semantic routing and aggregation inputs:
+
+- `.github/workflows/pr.yml` and `.github/scripts/ci-gate.sh`;
+- `Makefile`, `.buildflags`, `.golangci.yml`, `go.mod`, and `go.sum`;
+- `scripts/ci/pr-lint-host.sh`, `scripts/ci/pr-lint.sh`,
+  `scripts/ci/pr-lint-routing-test.sh`,
+  `scripts/pr_lint_ci_contract_test.go`, and `scripts/ci/lib/timing.sh`; and
+- this document, `engdocs/CI_CLEANUP_PLAN.md`,
+  `engdocs/CI_TEST_SURFACE_AUDIT.md`,
+  `engdocs/CI_REQUIRED_CHECK_TOPOLOGY.md`, `engdocs/TESTING.md`,
+  `engdocs/DOC_INVENTORY.md`,
+  `scripts/README.md`, `CONTRIBUTING.md`, `AGENTS.md`,
+  `AGENT_INSTRUCTIONS.md`, `.github/copilot-instructions.md`,
+  `examples/formulas/gh-pr-review.formula.toml`,
+  `examples/formulas/gh-issue-to-pr.formula.toml`,
+  `.pre-commit-config.yaml`, `.githooks/pre-commit`,
+  `cmd/bd/preflight.go`,
+  `scripts/check-doc-freshness.sh`, and
+  `scripts/check_doc_freshness_test.go`.
+
+The affected non-PR consumers are `.github/workflows/main.yml` and
+`.github/workflows/ci-measurements.yml`; they use the same bound wrapper and
+belong in the review corpus even though only PR's `CI Gate / Required` controls
+pull-request integration.
+
 ## CI Cleanup Decision
 
-`pr-lint` should stay separate from `pr-policy` and `pr-core` so failures are
+`pr-lint` stays separate from `pr-policy` and `pr-core` so failures are
 easy to identify and rerun. It should include:
 
-- `make fmt-check`
-- `golangci-lint run --timeout=5m --build-tags=gms_pure_go ./...`
+- the strict eleven-case routing, one-query, mutable-state, both linter-pass
+  failures, Make-failure propagation, and nonzero-execution regression, plus
+  four inner authority refusals, a nonzero-gofmt end-to-end refusal, fifteen
+  macOS Make/target/cleanup/producer refusals, four handled cleanup cases,
+  ambient install-state poison, and the native Windows
+  three-target/one-bundle/no-`make.exe` falsifiers;
+- `make fmt-check`;
+- a lint with the frozen caller tuple; and
+- a Windows/non-CGO lint with the same architecture unless it would duplicate
+  the frozen tuple.
 
 See [`CI_CLEANUP_PLAN.md`](CI_CLEANUP_PLAN.md) for the full CI tier policy.
 
 ## Future Work
 
-- Pin the `golangci-lint` version in CI instead of using `version: latest`.
-- Move the final CI shape behind a repository-owned `scripts/ci/pr-lint.sh`
-  wrapper.
 - Periodically audit `.golangci.yml` exclusions and remove entries that are no
   longer needed.
+- Re-measure the two-pass wrapper before changing caller placement or
+  concurrency.

--- a/examples/formulas/gh-issue-to-pr.formula.toml
+++ b/examples/formulas/gh-issue-to-pr.formula.toml
@@ -30,7 +30,8 @@
 #   - Git configured with remotes for upstream and (if fork) push target
 #   - `bd` (beads) installed with molecule/wisp support
 #   - `council` installed (or rubber-duck agent available as fallback)
-#   - `make`, `golangci-lint` available for quality gates
+#   - `make`, Bash, and golangci-lint 2.10.1 available for repository quality
+#     gates
 #   - `make test` may take 3-5 minutes on a full run
 #
 # Pager safety (CRITICAL for non-interactive execution):
@@ -468,11 +469,11 @@ ALL THREE quality gates are MANDATORY — do not skip any without explicit justi
    ```
    make test
    ```
-2. Run the linter:
+2. Run the authoritative lint gate:
    ```
-   golangci-lint run ./...
+   make ci-pr-lint
    ```
-   (Ignore baseline warnings documented in engdocs/LINTING.md — focus on NEW issues)
+   All findings fail; there is no tolerated baseline.
 3. Build the project:
    ```
    make build
@@ -504,7 +505,7 @@ CGO_ENABLED=1 go test -tags gms_pure_go ./cmd/bd/...
 ```
 
 If you need to abort after this step, clean up the worktree first (see worktree-setup)."""
-acceptance = "make test passes (or failures documented as pre-existing/flaky), golangci-lint clean (no new warnings), make build succeeds"
+acceptance = "make test passes (or failures documented as pre-existing/flaky), make ci-pr-lint passes, make build succeeds"
 
 [[steps]]
 id = "council-review"
@@ -632,7 +633,7 @@ WORKING DIRECTORY: This step runs in the worktree.
 
    ## Testing
    - All tests pass (make test)
-   - Linter clean (golangci-lint)
+   - Authoritative lint gate passes (make ci-pr-lint)
    - Build succeeds (make build)
    <If any flaky/pre-existing failures were noted, document them here>
 

--- a/examples/formulas/gh-pr-review.formula.toml
+++ b/examples/formulas/gh-pr-review.formula.toml
@@ -33,7 +33,8 @@
 #     contents:write, pull_requests:write)
 #   - Git configured with remotes for upstream and (if fork) push target
 #   - `bd` (beads) installed with molecule/wisp support
-#   - `make`, `golangci-lint` available for quality gates (fix-merge path)
+#   - `make`, Bash, and golangci-lint 2.10.1 available for repository quality
+#     gates (fix-merge path)
 #
 # Pager safety (CRITICAL for non-interactive execution):
 #   - ALL `gh` commands MUST use: GH_PAGER=cat gh ...
@@ -361,7 +362,7 @@ Based on the classification, fix the identified blockers:
 ### Run quality gates (on the clean-base transplant)
 ```
 make test
-golangci-lint run ./...
+make ci-pr-lint
 make build
 ```
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -5,7 +5,8 @@ Utility scripts for maintaining the beads project.
 ## ci/
 
 Repository-owned CI command wrappers. These scripts are the source of truth for
-the target CI tiers; Make targets are aliases for local discoverability.
+the target CI tiers. `make ci-pr-lint` is the authoritative public v2 lint
+entrypoint; calling its private scripts or hooks directly is not equivalent.
 
 ```bash
 make ci-pr-core
@@ -18,6 +19,29 @@ make ci-package-npm
 Each wrapper auto-detects the repository root, sources `.buildflags` when it
 invokes Go in the default build mode, and records per-command timing through
 `scripts/ci/lib/timing.sh`.
+
+`make ci-pr-lint` first enters `scripts/ci/pr-lint-host.sh` through the exact
+Make and Bash selected by its caller. Workflow-policy callers always invoke
+that public target with `-f Makefile`: Linux uses `/usr/bin/make` with
+`/usr/bin/bash`, macOS uses its stock `/usr/bin/make` 3.81 with `/bin/bash`,
+and native Windows uses GNU Make 4.4.1 under the sole name
+`mingw32-make.exe` with one exact Git-for-Windows bundle. The host resolves
+and checks each executable path, family, and required behavior once, privately installs golangci-lint
+2.10.1 in one validated direct child of `RUNNER_TEMP`, confirms its removal,
+and runs the internal lint target under a curated environment. Local callers
+must provide golangci-lint 2.10.1 on `PATH` and may select one validated Go
+target tuple. Hosted caller values may be absent or exactly equal to the
+protected tuple, while conflicts fail before lint. Every lint names
+`.golangci.yml`, disables workspace discovery, and forces readonly module
+mode. The protected Go and linter versions are exact.
+
+The PR gate keeps three real full-host routes: Linux/amd64/CGO, Darwin
+arm64/CGO on `macos-15`, and native Windows/amd64/CGO with MinGW 16.1.0; each
+also covers Windows/non-CGO where needed. MSYS2 and Cygwin lanes claim only
+their narrower shell/bootstrap smokes. `ci-pr-lint-bound` is private and
+refuses callers that bypass the binding. The staged-file Git hook,
+`.pre-commit-config.yaml`, and `cmd/bd` preflight lint remain useful
+conveniences, but none substitutes for `make ci-pr-lint`.
 
 Broad Go test wrappers also source `scripts/ci/lib/test-env.sh`, which creates a
 temporary HOME/XDG/Dolt root, isolates Git global/system config, clears runtime

--- a/scripts/check-doc-freshness.sh
+++ b/scripts/check-doc-freshness.sh
@@ -25,7 +25,7 @@ DOCS=(
     "docs/reference/json-schema.md|cmd/bd/output.go;cmd/bd/errors.go;cmd/bd/protocol/json_contract_test.go"
     "docs/recovery/init-safety.md|cmd/bd/init.go;cmd/bd/init_safety.go;cmd/bd/init_safety_test.go"
     "engdocs/ERROR_HANDLING.md|cmd/bd/*.go;cmd/bd/errors.go"
-    "engdocs/LINTING.md|.golangci.yml"
+    "engdocs/LINTING.md|.golangci.yml;.buildflags;go.mod;go.sum;Makefile;scripts/ci/pr-lint-host.sh;scripts/ci/pr-lint.sh;scripts/ci/pr-lint-routing-test.sh;scripts/pr_lint_ci_contract_test.go;scripts/ci/lib/timing.sh;.github/scripts/ci-gate.sh;.github/workflows/pr.yml;.github/workflows/main.yml;.github/workflows/ci-measurements.yml;CONTRIBUTING.md;AGENTS.md;AGENT_INSTRUCTIONS.md;.github/copilot-instructions.md;scripts/README.md;engdocs/CI_CLEANUP_PLAN.md;engdocs/CI_TEST_SURFACE_AUDIT.md;engdocs/CI_REQUIRED_CHECK_TOPOLOGY.md;engdocs/TESTING.md;engdocs/DOC_INVENTORY.md;examples/formulas/gh-pr-review.formula.toml;examples/formulas/gh-issue-to-pr.formula.toml;.pre-commit-config.yaml;.githooks/pre-commit;cmd/bd/preflight.go;scripts/check-doc-freshness.sh;scripts/check_doc_freshness_test.go"
     "engdocs/design/otel/otel-data-model.md|internal/telemetry/;internal/storage/dolt/store.go;internal/compact/haiku.go;cmd/bd/find_duplicates.go;internal/hooks/"
 )
 

--- a/scripts/check_doc_freshness_test.go
+++ b/scripts/check_doc_freshness_test.go
@@ -22,7 +22,39 @@ var freshnessDocuments = []struct {
 	{"docs/reference/json-schema.md", []string{"cmd/bd/output.go", "cmd/bd/errors.go", "cmd/bd/protocol/json_contract_test.go"}},
 	{"docs/recovery/init-safety.md", []string{"cmd/bd/init.go", "cmd/bd/init_safety.go", "cmd/bd/init_safety_test.go"}},
 	{"engdocs/ERROR_HANDLING.md", []string{"cmd/bd/*.go", "cmd/bd/errors.go"}},
-	{"engdocs/LINTING.md", []string{".golangci.yml"}},
+	{"engdocs/LINTING.md", []string{
+		".golangci.yml",
+		".buildflags",
+		"go.mod",
+		"go.sum",
+		"Makefile",
+		"scripts/ci/pr-lint-host.sh",
+		"scripts/ci/pr-lint.sh",
+		"scripts/ci/pr-lint-routing-test.sh",
+		"scripts/pr_lint_ci_contract_test.go",
+		"scripts/ci/lib/timing.sh",
+		".github/scripts/ci-gate.sh",
+		".github/workflows/pr.yml",
+		".github/workflows/main.yml",
+		".github/workflows/ci-measurements.yml",
+		"CONTRIBUTING.md",
+		"AGENTS.md",
+		"AGENT_INSTRUCTIONS.md",
+		".github/copilot-instructions.md",
+		"scripts/README.md",
+		"engdocs/CI_CLEANUP_PLAN.md",
+		"engdocs/CI_TEST_SURFACE_AUDIT.md",
+		"engdocs/CI_REQUIRED_CHECK_TOPOLOGY.md",
+		"engdocs/TESTING.md",
+		"engdocs/DOC_INVENTORY.md",
+		"examples/formulas/gh-pr-review.formula.toml",
+		"examples/formulas/gh-issue-to-pr.formula.toml",
+		".pre-commit-config.yaml",
+		".githooks/pre-commit",
+		"cmd/bd/preflight.go",
+		"scripts/check-doc-freshness.sh",
+		"scripts/check_doc_freshness_test.go",
+	}},
 	{"engdocs/design/otel/otel-data-model.md", []string{"internal/telemetry/", "internal/storage/dolt/store.go", "internal/compact/haiku.go", "cmd/bd/find_duplicates.go", "internal/hooks/"}},
 }
 
@@ -454,6 +486,11 @@ func createFreshnessSource(t *testing.T, root, source string) {
 
 	source = strings.ReplaceAll(source, "*", "fixture")
 	source = strings.ReplaceAll(source, "?", "x")
+	if _, err := os.Stat(filepath.Join(root, filepath.FromSlash(source))); err == nil {
+		return
+	} else if !os.IsNotExist(err) {
+		t.Fatalf("inspect existing source %s: %v", source, err)
+	}
 	writeFixtureFile(t, root, source, "")
 }
 

--- a/scripts/ci/lib/timing.sh
+++ b/scripts/ci/lib/timing.sh
@@ -50,7 +50,7 @@ ci_time() {
     esac
 
     printf '==> %s\n' "$label"
-    start="$(date +%s)"
+    start="$SECONDS"
 
     set +e
     "$@"
@@ -61,7 +61,7 @@ ci_time() {
         set +e
     fi
 
-    end="$(date +%s)"
+    end="$SECONDS"
     duration=$((end - start))
 
     if [[ "$status" -eq 0 ]]; then

--- a/scripts/ci/pr-lint-host.sh
+++ b/scripts/ci/pr-lint-host.sh
@@ -1,0 +1,1011 @@
+#!/bin/bash
+# Resolve and bind the complete host/tool contract for the required PR lint gate.
+
+set -euo pipefail
+
+fail() {
+    printf 'pr-lint host contract: %s\n' "$1" >&2
+    exit 1
+}
+
+probe_only=0
+case "$#" in
+    0) ;;
+    1)
+        [[ "$1" == "--probe-only" ]] || fail "unknown argument: $1"
+        [[ "${GITHUB_ACTIONS:-}" != "true" ]] ||
+            fail "--probe-only is forbidden in GitHub Actions"
+        probe_only=1
+        ;;
+    *) fail "expected no arguments or --probe-only" ;;
+esac
+
+script_source="${BASH_SOURCE[0]}"
+case "$script_source" in
+    */*) script_parent="${script_source%/*}" ;;
+    *) script_parent="." ;;
+esac
+SCRIPT_DIR="$(cd -P -- "$script_parent" && pwd)"
+REPO_ROOT="$(cd -P -- "$SCRIPT_DIR/../.." && pwd)"
+
+require_absolute_executable() {
+    local label="$1"
+    local path="$2"
+    [[ "$path" == /* ]] || fail "$label did not resolve to an absolute path: $path"
+    [[ "$path" != *$'\n'* && "$path" != *$'\r'* ]] ||
+        fail "$label path contains a line break"
+    [[ -f "$path" && -x "$path" ]] || fail "$label is not an executable file: $path"
+}
+
+canonicalize_path() {
+    local path="$1"
+    local directory=""
+    local leaf=""
+    local target=""
+    local link_count=0
+
+    [[ "$path" == /* ]] || return 1
+    while :; do
+        directory="${path%/*}"
+        leaf="${path##*/}"
+        [[ -n "$directory" ]] || directory="/"
+        directory="$(cd -P -- "$directory" 2>/dev/null && pwd)" || return 1
+        if [[ "$directory" == "/" ]]; then
+            path="/$leaf"
+        else
+            path="$directory/$leaf"
+        fi
+        if [[ ! -L "$path" ]]; then
+            printf '%s' "$path"
+            return 0
+        fi
+
+        link_count=$((link_count + 1))
+        ((link_count <= 40)) || return 1
+        target="$("$readlink_path" "$path")" || return 1
+        if [[ "$target" == /* ]]; then
+            path="$target"
+        else
+            path="$directory/$target"
+        fi
+    done
+}
+
+windows_path_to_unambiguous_posix() {
+    local path="$1"
+    local drive=""
+    local remainder=""
+
+    [[ "$path" =~ ^[A-Za-z]:[\\/] ]] || return 1
+    [[ "$path" != *$'\n'* && "$path" != *$'\r'* ]] || return 1
+    drive="${path:0:1}"
+    remainder="${path:2}"
+    remainder="${remainder//\\//}"
+    printf '/%s%s' "$drive" "$remainder"
+}
+
+resolve_executable() {
+    local name="$1"
+    local path=""
+    path="$(type -P -- "$name" 2>/dev/null)" ||
+        fail "required executable is unavailable: $name"
+    path="$(canonicalize_path "$path")" ||
+        fail "could not canonicalize required executable: $name"
+    require_absolute_executable "$name" "$path"
+    printf '%s' "$path"
+}
+
+append_path_directory() {
+    local executable="$1"
+    local directory="${executable%/*}"
+    case ":$curated_path:" in
+        *":$directory:"*) ;;
+        *) curated_path="${curated_path:+$curated_path:}$directory" ;;
+    esac
+}
+
+expected_outer_os="${BEADS_CI_EXPECTED_OUTER_OS:-}"
+if [[ -z "$expected_outer_os" ]]; then
+    [[ "${GITHUB_ACTIONS:-}" != "true" ]] ||
+        fail "BEADS_CI_EXPECTED_OUTER_OS is mandatory in GitHub Actions"
+    case "${OSTYPE:-}" in
+        linux*) expected_outer_os="linux" ;;
+        darwin*) expected_outer_os="macos" ;;
+        cygwin*|msys*) expected_outer_os="windows" ;;
+        *) fail "cannot derive a supported local outer OS from OSTYPE=${OSTYPE:-<unset>}" ;;
+    esac
+fi
+case "$expected_outer_os" in
+    linux|macos|windows) ;;
+    *) fail "unsupported expected outer OS: $expected_outer_os" ;;
+esac
+
+readlink_path="$(type -P -- readlink 2>/dev/null)" ||
+    fail "required executable is unavailable: readlink"
+require_absolute_executable "readlink" "$readlink_path"
+readlink_path="$(canonicalize_path "$readlink_path")" ||
+    fail "could not canonicalize readlink"
+require_absolute_executable "canonical readlink" "$readlink_path"
+
+invoked_bash="${BASH:-}"
+if [[ "$expected_outer_os" == "windows" &&
+      "$invoked_bash" =~ ^[A-Za-z]:[\\/] ]]; then
+    invoked_bash_alias="$(type -P -- bash 2>/dev/null)" ||
+        fail "could not resolve a POSIX alias for the current Bash"
+    [[ "$invoked_bash_alias" == /* &&
+       -f "$invoked_bash_alias" &&
+       -x "$invoked_bash_alias" &&
+       "$invoked_bash_alias" -ef "$invoked_bash" ]] ||
+        fail "the POSIX Bash alias does not name the running interpreter"
+    invoked_bash="$invoked_bash_alias"
+fi
+require_absolute_executable "current Bash" "$invoked_bash"
+bash_path="$(canonicalize_path "$invoked_bash")" ||
+    fail "could not canonicalize the current Bash"
+require_absolute_executable "canonical current Bash" "$bash_path"
+[[ "$bash_path" -ef "$invoked_bash" ]] ||
+    fail "canonical Bash identity does not name the running interpreter"
+((BASH_VERSINFO[0] > 3 ||
+   (BASH_VERSINFO[0] == 3 && BASH_VERSINFO[1] >= 2))) ||
+    fail "Bash 3.2 or newer is required"
+
+env_path="$(resolve_executable env)"
+cat_path="$(resolve_executable cat)"
+chmod_path="$(resolve_executable chmod)"
+cp_path="$(resolve_executable cp)"
+diff_path="$(resolve_executable diff)"
+go_path="$(resolve_executable go)"
+mkdir_path="$(resolve_executable mkdir)"
+mktemp_path="$(resolve_executable mktemp)"
+rm_path="$(resolve_executable rm)"
+rmdir_path="$(resolve_executable rmdir)"
+sed_path="$(resolve_executable sed)"
+uname_path="$(resolve_executable uname)"
+cygpath_path=""
+windows_cmd_path=""
+windows_git_path=""
+windows_bundle_root=""
+if [[ "$expected_outer_os" == "windows" ]]; then
+    cygpath_path="$(resolve_executable cygpath)"
+fi
+invoking_git="${BEADS_CI_INVOKING_GIT:-}"
+[[ -n "$invoking_git" ]] ||
+    fail "CI_GIT identity did not cross the public Make boundary"
+if [[ "$expected_outer_os" == "windows" &&
+      "$invoking_git" =~ ^[A-Za-z]:[\\/] ]]; then
+    invoking_git="$(windows_path_to_unambiguous_posix "$invoking_git")" ||
+        fail "could not translate the invoking Git without a mount alias"
+fi
+case "$invoking_git" in
+    /*)
+        git_path="$(canonicalize_path "$invoking_git")" ||
+            fail "could not canonicalize the invoking Git"
+        require_absolute_executable "invoking Git" "$git_path"
+        ;;
+    *) git_path="$(resolve_executable "$invoking_git")" ;;
+esac
+
+make_candidate="${BEADS_CI_INVOKING_MAKE:-}"
+make_invocation_path="$make_candidate"
+make_origin="${BEADS_CI_INVOKING_MAKE_ORIGIN:-}"
+invoking_makefile_list="${BEADS_CI_INVOKING_MAKEFILE_LIST:-}"
+makeflags_origin="${BEADS_CI_INVOKING_MAKEFLAGS_ORIGIN:-}"
+invoking_mflags="${BEADS_CI_INVOKING_MFLAGS:-}"
+invoking_gnumakeflags="${BEADS_CI_INVOKING_GNUMAKEFLAGS:-}"
+makefiles_origin="${BEADS_CI_INVOKING_MAKEFILES_ORIGIN:-}"
+invoking_makefiles="${BEADS_CI_INVOKING_MAKEFILES:-}"
+[[ "$invoking_makefile_list" == "Makefile" ]] ||
+    fail "the public lint boundary must load exactly -f Makefile"
+if [[ "${GITHUB_ACTIONS:-}" == "true" ]]; then
+    [[ "$make_origin" == "default" ]] ||
+        fail "MAKE origin must be default in GitHub Actions, observed: ${make_origin:-<unset>}"
+    [[ -n "$make_candidate" ]] ||
+        fail "the absolute invoking GNU Make did not cross the public boundary"
+    [[ "$makeflags_origin" == "file" ]] ||
+        fail "MAKEFLAGS origin must be file in GitHub Actions, observed: ${makeflags_origin:-<unset>}"
+    [[ -z "$invoking_mflags" ]] ||
+        fail "MFLAGS must be empty at the public Make boundary"
+    [[ -z "$invoking_gnumakeflags" ]] ||
+        fail "GNUMAKEFLAGS must be absent at the public Make boundary"
+    # This post-parse check is diagnostic, not a sandbox for command-line
+    # MAKEFILES: protected workflows guarantee absence through curated
+    # environment and fixed argv before Make starts.
+    # Stock Apple GNU Make 3.81 leaves an absent MAKEFILES undefined; newer
+    # GNU Make exposes the same empty built-in with default origin.
+    [[ ("$makefiles_origin" == "default" ||
+        "$makefiles_origin" == "undefined") &&
+       -z "$invoking_makefiles" ]] ||
+        fail "MAKEFILES must be absent at the public Make boundary"
+fi
+if [[ -n "$make_candidate" ]]; then
+    if [[ "$expected_outer_os" == "windows" &&
+          "$make_candidate" =~ ^[A-Za-z]:[\\/] ]]; then
+        make_candidate="$(windows_path_to_unambiguous_posix "$make_candidate")" ||
+            fail "could not translate invoking GNU Make without a mount alias"
+    fi
+    make_path="$(canonicalize_path "$make_candidate")" ||
+        fail "could not canonicalize the invoking GNU Make"
+    require_absolute_executable "invoking GNU Make" "$make_path"
+else
+    make_path="$(resolve_executable make)"
+fi
+
+uname_system="$("$uname_path" -s)"
+case "$expected_outer_os" in
+    linux)
+        [[ "${OSTYPE:-}" == linux* && "$uname_system" == "Linux" ]] ||
+            fail "expected Linux, observed OSTYPE=${OSTYPE:-<unset>} uname=$uname_system"
+        expected_make_host_pattern="linux"
+        ;;
+    macos)
+        [[ "${OSTYPE:-}" == darwin* && "$uname_system" == "Darwin" ]] ||
+            fail "expected macOS, observed OSTYPE=${OSTYPE:-<unset>} uname=$uname_system"
+        expected_make_host_pattern="darwin"
+        ;;
+    windows)
+        [[ "${OSTYPE:-}" == cygwin* || "${OSTYPE:-}" == msys* ]] ||
+            fail "expected a Windows POSIX Bash, observed OSTYPE=${OSTYPE:-<unset>}"
+        [[ "$uname_system" == MINGW*_NT-* ||
+           "$uname_system" == MSYS*_NT-* ||
+           "$uname_system" == CYGWIN*_NT-* ]] ||
+            fail "expected a Windows POSIX uname, observed $uname_system"
+        expected_make_host_pattern="windows"
+        comspec="${COMSPEC:-${ComSpec:-}}"
+        [[ -n "$comspec" ]] || fail "COMSPEC is required for native Windows Make"
+        windows_cmd_posix="$(windows_path_to_unambiguous_posix "$comspec")" ||
+            fail "could not translate the Windows command processor"
+        windows_cmd_posix="$(canonicalize_path "$windows_cmd_posix")"
+        require_absolute_executable "Windows command processor" "$windows_cmd_posix"
+        windows_cmd_path="$("$cygpath_path" -aw "$windows_cmd_posix")"
+        ;;
+esac
+
+probe_value='spaces * ? [ ] $ " preserved'
+# The single-quoted program is evaluated by the freshly started bound Bash.
+# shellcheck disable=SC2016
+probe_output="$(
+    "$env_path" -i \
+        BEADS_HOST_PROBE="$probe_value" \
+        "$bash_path" --noprofile --norc -c \
+        '[[ -z "${BASH_ENV+x}" && -z "${ENV+x}" &&
+            "$BEADS_HOST_PROBE" == "$1" ]] || exit 71
+         printf "%s" "$BEADS_HOST_PROBE"' \
+        beads-host-probe "$probe_value"
+)" || fail "Bash startup, environment, or quoting probe failed"
+[[ "$probe_output" == "$probe_value" ]] ||
+    fail "Bash quoting probe changed its argument"
+
+go_module_version=""
+while IFS=' ' read -r directive value _; do
+    if [[ "$directive" == "go" ]]; then
+        [[ -z "$go_module_version" ]] || fail "go.mod contains multiple go directives"
+        go_module_version="${value%$'\r'}"
+    fi
+done <"$REPO_ROOT/go.mod"
+[[ "$go_module_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] ||
+    fail "go.mod does not contain one exact three-component Go version"
+
+go_version_output="$(
+    GOENV=off GOWORK=off GOFLAGS='' GOTOOLCHAIN=local GOEXPERIMENT='' \
+        "$go_path" version
+)" || fail "the bound Go executable could not report its version"
+[[ "$go_version_output" == "go version go${go_module_version} "* ]] ||
+    fail "expected Go $go_module_version, observed: $go_version_output"
+if ! go_host_output="$(
+    GOENV=off GOWORK=off GOFLAGS='' GOTOOLCHAIN=local GOEXPERIMENT='' \
+        "$go_path" env GOHOSTOS GOHOSTARCH
+)"; then
+    fail "the bound Go executable could not report its host tuple"
+fi
+go_host_values=()
+while IFS= read -r value; do
+    go_host_values+=("$value")
+done <<<"$go_host_output"
+[[ "${#go_host_values[@]}" -eq 2 ]] ||
+    fail "Go returned an invalid host tuple"
+go_host_os="${go_host_values[0]}"
+go_host_arch="${go_host_values[1]}"
+case "$expected_outer_os" in
+    linux) [[ "$go_host_os" == "linux" ]] || fail "Go host OS is $go_host_os, expected linux" ;;
+    macos) [[ "$go_host_os" == "darwin" ]] || fail "Go host OS is $go_host_os, expected darwin" ;;
+    windows) [[ "$go_host_os" == "windows" ]] || fail "Go host OS is $go_host_os, expected windows" ;;
+esac
+[[ "$go_host_arch" =~ ^[a-z0-9_]+$ ]] ||
+    fail "Go returned an invalid host architecture: $go_host_arch"
+
+target_source="local"
+if [[ "${GITHUB_ACTIONS:-}" == "true" ]]; then
+    target_source="hosted"
+    for variable in \
+        BEADS_CI_EXPECTED_TARGET_GOOS \
+        BEADS_CI_EXPECTED_TARGET_GOARCH \
+        BEADS_CI_EXPECTED_TARGET_CGO_ENABLED; do
+        [[ -n "${!variable:-}" ]] ||
+            fail "$variable is mandatory in GitHub Actions"
+    done
+    target_goos="$BEADS_CI_EXPECTED_TARGET_GOOS"
+    target_goarch="$BEADS_CI_EXPECTED_TARGET_GOARCH"
+    target_cgo_enabled="$BEADS_CI_EXPECTED_TARGET_CGO_ENABLED"
+    for variable in GOOS GOARCH CGO_ENABLED; do
+        case "$variable" in
+            GOOS)
+                expected_value="$target_goos"
+                present="${BEADS_CI_AMBIENT_GOOS_PRESENT:-}"
+                observed="${BEADS_CI_AMBIENT_GOOS:-}"
+                ;;
+            GOARCH)
+                expected_value="$target_goarch"
+                present="${BEADS_CI_AMBIENT_GOARCH_PRESENT:-}"
+                observed="${BEADS_CI_AMBIENT_GOARCH:-}"
+                ;;
+            CGO_ENABLED)
+                expected_value="$target_cgo_enabled"
+                present="${BEADS_CI_AMBIENT_CGO_ENABLED_PRESENT:-}"
+                observed="${BEADS_CI_AMBIENT_CGO_ENABLED:-}"
+                ;;
+        esac
+        [[ "$present" == "0" || "$present" == "1" ]] ||
+            fail "the public Make boundary omitted $variable presence authority"
+        if [[ "$present" == "1" && "$observed" != "$expected_value" ]]; then
+            fail "$variable conflicts with the protected hosted target"
+        fi
+    done
+    [[ "$target_goos" == "$go_host_os" &&
+       "$target_goarch" == "$go_host_arch" ]] ||
+        fail "the protected hosted target must equal the actual Go host"
+else
+    if ! target_output="$(
+        GOENV=off GOWORK=off GOFLAGS='' GOTOOLCHAIN=local GOEXPERIMENT='' \
+            "$go_path" env GOOS GOARCH CGO_ENABLED
+    )"; then
+        fail "the bound Go executable could not report its local target tuple"
+    fi
+    target_values=()
+    while IFS= read -r value; do
+        target_values+=("$value")
+    done <<<"$target_output"
+    [[ "${#target_values[@]}" -eq 3 ]] ||
+        fail "Go returned an invalid local target tuple"
+    target_goos="${target_values[0]}"
+    target_goarch="${target_values[1]}"
+    target_cgo_enabled="${target_values[2]}"
+fi
+[[ "$target_goos" =~ ^[a-z0-9_]+$ &&
+   "$target_goarch" =~ ^[a-z0-9_]+$ &&
+   "$target_cgo_enabled" =~ ^[01]$ ]] ||
+    fail "invalid selected target: $target_goos/$target_goarch cgo=$target_cgo_enabled"
+target_supported=0
+if ! supported_targets_output="$(
+    GOENV=off GOWORK=off GOFLAGS='' GOTOOLCHAIN=local GOEXPERIMENT='' \
+        "$go_path" tool dist list
+)"; then
+    fail "the bound Go executable could not enumerate supported Go targets"
+fi
+while IFS= read -r supported_target; do
+    if [[ "$supported_target" == "$target_goos/$target_goarch" ]]; then
+        target_supported=1
+        break
+    fi
+done <<<"$supported_targets_output"
+[[ "$target_supported" -eq 1 ]] ||
+    fail "unsupported selected Go target: $target_goos/$target_goarch"
+
+sed_go_version="$("$sed_path" -n 's/^go //p' "$REPO_ROOT/go.mod")"
+sed_go_version="${sed_go_version%$'\r'}"
+[[ "$sed_go_version" == "$go_module_version" ]] ||
+    fail "bound sed did not parse the protected Go version"
+
+linter_config_path="$REPO_ROOT/.golangci.yml"
+[[ "$linter_config_path" == /* &&
+   -f "$linter_config_path" &&
+   ! -L "$linter_config_path" ]] ||
+    fail "the protected golangci-lint configuration is not one regular file"
+
+go_directory="${go_path%/*}"
+case "$expected_outer_os" in
+    windows) gofmt_path="$go_directory/gofmt.exe" ;;
+    *) gofmt_path="$go_directory/gofmt" ;;
+esac
+gofmt_path="$(canonicalize_path "$gofmt_path")" ||
+    fail "could not canonicalize gofmt from the bound Go toolchain"
+require_absolute_executable "gofmt from the bound Go toolchain" "$gofmt_path"
+
+make_version_output="$("$make_path" --version)"
+make_version_first_line="${make_version_output%%$'\n'*}"
+make_version_first_line="${make_version_first_line%$'\r'}"
+[[ "$make_version_first_line" =~ ^GNU\ Make\ ([0-9]+\.[0-9]+(\.[0-9]+)?)$ ]] ||
+    fail "expected GNU Make, observed: $make_version_first_line"
+if [[ -n "${BEADS_CI_EXPECTED_MAKE_VERSION:-}" ]]; then
+    [[ "$make_version_first_line" == "GNU Make ${BEADS_CI_EXPECTED_MAKE_VERSION}" ]] ||
+        fail "expected GNU Make ${BEADS_CI_EXPECTED_MAKE_VERSION}, observed: $make_version_first_line"
+fi
+if [[ "${GITHUB_ACTIONS:-}" == "true" &&
+      ("$expected_outer_os" == "macos" ||
+       "$expected_outer_os" == "windows") ]]; then
+    [[ -n "${BEADS_CI_EXPECTED_MAKE_VERSION:-}" ]] ||
+        fail "the exact GNU Make version is mandatory on $expected_outer_os"
+fi
+if [[ "${GITHUB_ACTIONS:-}" == "true" &&
+      "$expected_outer_os" == "macos" ]]; then
+    [[ "$make_invocation_path" == "/usr/bin/make" ]] ||
+        fail "stock macOS GNU Make must be invoked through /usr/bin/make"
+fi
+
+# GNU Make, not this shell, expands MAKE_HOST. Feed the probe as a makefile so
+# this remains valid on the stock GNU Make 3.81 supplied by macOS.
+# shellcheck disable=SC2016
+make_host_output="$(
+    printf '%s\n' \
+        '$(info MAKE_HOST=$(MAKE_HOST))' \
+        '.PHONY: noop' \
+        'noop: ;' |
+        "$make_path" --no-print-directory -f - noop
+)"
+make_host=""
+make_host_line_count=0
+while IFS= read -r line; do
+    if [[ "$line" == MAKE_HOST=* ]]; then
+        make_host_line_count=$((make_host_line_count + 1))
+        [[ "$make_host_line_count" -eq 1 ]] ||
+            fail "GNU Make emitted multiple MAKE_HOST identities"
+        make_host="${line#MAKE_HOST=}"
+        make_host="${make_host%$'\r'}"
+    fi
+done <<<"$make_host_output"
+[[ "$make_host_line_count" -eq 1 ]] || fail "GNU Make did not emit MAKE_HOST"
+case "$expected_make_host_pattern" in
+    linux) [[ "$make_host" == *linux* ]] || fail "GNU Make host is $make_host, expected Linux" ;;
+    darwin)
+        if [[ -n "$make_host" ]]; then
+            [[ "$make_host" == *darwin* ]] ||
+                fail "GNU Make host is $make_host, expected macOS"
+        else
+            # Apple's stock GNU Make 3.81 leaves MAKE_HOST empty. Bind that
+            # exceptional identity to the original immutable system leaf and
+            # exact version after the outer Darwin identity has already been
+            # proved. make_path is the validated canonical target and is kept
+            # only for execution and diagnostics: /usr/bin/make currently
+            # resolves inside Xcode on hosted macOS.
+            # Do not parse the remaining free-form build banner: current hosted
+            # images are allowed to change it without changing either authority.
+            if [[ "$make_version_first_line" != "GNU Make 3.81" ]]; then
+                fail "GNU Make omitted MAKE_HOST outside the stock macOS 3.81 contract: invocation=$make_invocation_path canonical=$make_path version=$make_version_first_line"
+            fi
+        fi
+        ;;
+    windows)
+        [[ "$make_host" == "Windows32" || "$make_host" == "mingw32" ||
+           "$make_host" == *-mingw32 ]] ||
+            fail "GNU Make host is $make_host, expected native Windows"
+        ;;
+esac
+
+git_version_output="$("$git_path" --version)"
+[[ "$git_version_output" == "git version "* ]] ||
+    fail "bound Git did not report a Git version"
+if [[ "$expected_outer_os" == "windows" ]]; then
+    invoking_windows_git="${BEADS_CI_INVOKING_WINDOWS_GIT:-}"
+    [[ -n "$invoking_windows_git" ]] ||
+        fail "GIT_WINDOWS_EXE identity did not cross the public Make boundary"
+    if [[ "$invoking_windows_git" =~ ^[A-Za-z]:[\\/] ]]; then
+        invoking_windows_git="$(
+            windows_path_to_unambiguous_posix "$invoking_windows_git"
+        )" || fail "could not translate GIT_WINDOWS_EXE without a mount alias"
+    fi
+    invoking_windows_git="$(canonicalize_path "$invoking_windows_git")" ||
+        fail "could not canonicalize GIT_WINDOWS_EXE"
+    require_absolute_executable "GIT_WINDOWS_EXE" "$invoking_windows_git"
+
+    git_exec_path="$(
+        GIT_CONFIG_NOSYSTEM=1 \
+        GIT_CONFIG_GLOBAL=/dev/null \
+            "$invoking_windows_git" --exec-path
+    )"
+    if [[ "$git_exec_path" =~ ^[A-Za-z]:[\\/] ]]; then
+        git_exec_path="$(
+            windows_path_to_unambiguous_posix "$git_exec_path"
+        )" || fail "could not translate the bound Git exec path"
+    fi
+    git_exec_path="$(canonicalize_path "$git_exec_path")" ||
+        fail "could not canonicalize the bound Git exec path"
+    windows_bundle_root="$(cd -P -- "$git_exec_path/../../.." && pwd)" ||
+        fail "could not derive the Windows Git bundle root"
+    bundle_path() {
+        local relative="$1"
+        if [[ "$windows_bundle_root" == "/" ]]; then
+            printf '/%s' "$relative"
+        else
+            printf '%s/%s' "$windows_bundle_root" "$relative"
+        fi
+    }
+
+    invoking_git_in_bundle=0
+    resolved_git_in_bundle=0
+    for relative_git in \
+        cmd/git.exe cmd/git \
+        bin/git.exe bin/git \
+        mingw64/bin/git.exe mingw64/bin/git; do
+        candidate="$(bundle_path "$relative_git")"
+        [[ "$invoking_windows_git" == "$candidate" ]] &&
+            invoking_git_in_bundle=1
+        [[ "$git_path" == "$candidate" ]] &&
+            resolved_git_in_bundle=1
+    done
+    [[ "$invoking_git_in_bundle" -eq 1 ]] ||
+        fail "GIT_WINDOWS_EXE is outside its derived Windows Git bundle"
+    [[ "$resolved_git_in_bundle" -eq 1 ]] ||
+        fail "the resolved Git executable is outside the GIT_WINDOWS_EXE bundle"
+    windows_git_path="$("$cygpath_path" -aw "$invoking_windows_git")"
+
+    for binding in \
+        "Bash|$bash_path|$(bundle_path usr/bin/bash.exe)" \
+        "cat|$cat_path|$(bundle_path usr/bin/cat.exe)" \
+        "chmod|$chmod_path|$(bundle_path usr/bin/chmod.exe)" \
+        "cp|$cp_path|$(bundle_path usr/bin/cp.exe)" \
+        "diff|$diff_path|$(bundle_path usr/bin/diff.exe)" \
+        "env|$env_path|$(bundle_path usr/bin/env.exe)" \
+        "mkdir|$mkdir_path|$(bundle_path usr/bin/mkdir.exe)" \
+        "mktemp|$mktemp_path|$(bundle_path usr/bin/mktemp.exe)" \
+        "readlink|$readlink_path|$(bundle_path usr/bin/readlink.exe)" \
+        "rm|$rm_path|$(bundle_path usr/bin/rm.exe)" \
+        "rmdir|$rmdir_path|$(bundle_path usr/bin/rmdir.exe)" \
+        "sed|$sed_path|$(bundle_path usr/bin/sed.exe)" \
+        "uname|$uname_path|$(bundle_path usr/bin/uname.exe)" \
+        "cygpath|$cygpath_path|$(bundle_path usr/bin/cygpath.exe)"; do
+        label="${binding%%|*}"
+        paths="${binding#*|}"
+        observed="${paths%%|*}"
+        expected="${paths#*|}"
+        require_absolute_executable "Windows Git bundle $label" "$expected"
+        expected_alias="${expected%.exe}"
+        observed_windows="$("$cygpath_path" -aw "$observed")" ||
+            fail "could not translate the resolved $label to Windows authority"
+        observed_physical="$(
+            windows_path_to_unambiguous_posix "$observed_windows"
+        )" || fail "could not normalize the resolved $label"
+        [[ "$observed_physical" == "$expected" ||
+           "$observed_physical" == "$expected_alias" ]] ||
+            fail "$label resolved outside the GIT_WINDOWS_EXE bundle"
+    done
+fi
+git_root="$(
+    GIT_CONFIG_NOSYSTEM=1 \
+    GIT_CONFIG_GLOBAL=/dev/null \
+        "$git_path" -C "$REPO_ROOT" rev-parse --show-toplevel
+)"
+expected_git_root="$REPO_ROOT"
+if [[ "$expected_outer_os" == "windows" ]]; then
+    expected_git_root="$(cd -P -- "$REPO_ROOT" && pwd -W)"
+    expected_git_root="${expected_git_root//\\//}"
+fi
+[[ "$git_root" == "$expected_git_root" ]] ||
+    fail "bound Git resolved the wrong repository root: $git_root"
+
+temporary_linter_root=""
+temporary_linter_parent=""
+temporary_linter_binary=""
+cleanup_authorized=0
+cleanup() {
+    local original_status=$?
+    local cleanup_failed=0
+    local observed_parent=""
+    local observed_root=""
+    local basename=""
+    local binary_leaf=""
+
+    # This proves canonical path, type, and shape immediately before mutation;
+    # it does not claim a portable file identity. The hosted runner's private
+    # RUNNER_TEMP is trusted to have one owner and no concurrent same-type
+    # replacement writer while this handler runs.
+    if [[ "$cleanup_authorized" -eq 1 ]]; then
+        basename="${temporary_linter_root##*/}"
+        if [[ "$basename" =~ ^beads-pr-lint-tools\.[A-Za-z0-9]{8}$ &&
+              "${temporary_linter_root%/*}" == "$temporary_linter_parent" &&
+              -d "$temporary_linter_parent" &&
+              ! -L "$temporary_linter_parent" ]]; then
+            observed_parent="$(cd -P -- "$temporary_linter_parent" && pwd)" ||
+                cleanup_failed=1
+            if [[ "$observed_parent" != "$temporary_linter_parent" ]]; then
+                cleanup_failed=1
+            elif [[ ! -e "$temporary_linter_root" &&
+                    ! -L "$temporary_linter_root" ]]; then
+                :
+            elif [[ -d "$temporary_linter_root" &&
+                    ! -L "$temporary_linter_root" ]]; then
+                observed_root="$(cd -P -- "$temporary_linter_root" && pwd)" ||
+                    cleanup_failed=1
+                if [[ "$observed_root" != "$temporary_linter_root" ]]; then
+                    cleanup_failed=1
+                else
+                    binary_leaf="${temporary_linter_binary##*/}"
+                    if ! (
+                        cd -P -- "$temporary_linter_root" || exit 1
+                        [[ "$PWD" == "$temporary_linter_root" ]] || exit 1
+                        shopt -s dotglob nullglob
+                        entries=(./*)
+                        if [[ -n "$temporary_linter_binary" ]]; then
+                            [[ "$binary_leaf" == "golangci-lint" ||
+                               "$binary_leaf" == "golangci-lint.exe" ]] ||
+                                exit 1
+                            [[ "$temporary_linter_binary" == "$temporary_linter_root/$binary_leaf" ]] ||
+                                exit 1
+                            [[ "${#entries[@]}" -eq 1 &&
+                               "${entries[0]}" == "./$binary_leaf" &&
+                               -f "./$binary_leaf" &&
+                               ! -L "./$binary_leaf" ]] ||
+                                exit 1
+                            "$rm_path" -- "./$binary_leaf" || exit 1
+                            [[ ! -e "./$binary_leaf" &&
+                               ! -L "./$binary_leaf" ]] ||
+                                exit 1
+                        else
+                            [[ "${#entries[@]}" -eq 0 ]] || exit 1
+                        fi
+                        remaining_entries=(./*)
+                        [[ "${#remaining_entries[@]}" -eq 0 ]] || exit 1
+                    ); then
+                        cleanup_failed=1
+                    fi
+                    if [[ "$cleanup_failed" -eq 0 ]]; then
+                        observed_parent="$(
+                            cd -P -- "$temporary_linter_parent" && pwd
+                        )" || cleanup_failed=1
+                    fi
+                    if [[ "$cleanup_failed" -eq 0 &&
+                          ("$observed_parent" != "$temporary_linter_parent" ||
+                           ! -d "$temporary_linter_root" ||
+                           -L "$temporary_linter_root") ]]; then
+                        cleanup_failed=1
+                    fi
+                    if [[ "$cleanup_failed" -eq 0 ]] &&
+                       ! "$rmdir_path" -- "$temporary_linter_root"; then
+                        cleanup_failed=1
+                    fi
+                    if [[ "$cleanup_failed" -eq 0 &&
+                          (-e "$temporary_linter_root" ||
+                           -L "$temporary_linter_root") ]]; then
+                        cleanup_failed=1
+                    fi
+                fi
+            else
+                cleanup_failed=1
+            fi
+        else
+            cleanup_failed=1
+        fi
+    fi
+    if [[ "$cleanup_failed" -ne 0 ]]; then
+        printf 'pr-lint host contract: refused unsafe private-tool cleanup: %s\n' \
+            "$temporary_linter_root" >&2
+        original_status=1
+    fi
+    trap - EXIT
+    exit "$original_status"
+}
+trap cleanup EXIT
+
+if [[ "${GITHUB_ACTIONS:-}" == "true" ]]; then
+    [[ -n "${BEADS_CI_EXPECTED_GOLANGCI_LINT_VERSION:-}" ]] ||
+        fail "the expected golangci-lint version is mandatory in GitHub Actions"
+    [[ "${BEADS_CI_INSTALL_GOLANGCI_LINT:-}" == "1" ]] ||
+        fail "GitHub Actions must install a private bound golangci-lint"
+fi
+expected_linter_version="${BEADS_CI_EXPECTED_GOLANGCI_LINT_VERSION:-2.10.1}"
+[[ "$expected_linter_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] ||
+    fail "invalid expected golangci-lint version: $expected_linter_version"
+
+case "${BEADS_CI_INSTALL_GOLANGCI_LINT:-0}" in
+    0|1) ;;
+    *) fail "BEADS_CI_INSTALL_GOLANGCI_LINT must be 0 or 1" ;;
+esac
+if [[ "${BEADS_CI_INSTALL_GOLANGCI_LINT:-0}" == "1" ]]; then
+    runner_temp="${RUNNER_TEMP:-}"
+    if [[ "$expected_outer_os" == "windows" &&
+          "$runner_temp" =~ ^[A-Za-z]:[\\/] ]]; then
+        runner_temp="$(
+            windows_path_to_unambiguous_posix "$runner_temp"
+        )" || fail "could not translate RUNNER_TEMP without a mount alias"
+    fi
+    [[ "$runner_temp" == /* && -d "$runner_temp" ]] ||
+        fail "RUNNER_TEMP must be an existing absolute directory for tool installation"
+    [[ ! -L "$runner_temp" ]] ||
+        fail "RUNNER_TEMP must not be a symbolic link"
+    runner_temp="$(cd -P -- "$runner_temp" && pwd)" ||
+        fail "could not canonicalize RUNNER_TEMP"
+    created_linter_root="$(
+        "$mktemp_path" -d "$runner_temp/beads-pr-lint-tools.XXXXXXXX"
+    )" || fail "could not create the private linter directory"
+    created_basename="${created_linter_root##*/}"
+    created_parent="${created_linter_root%/*}"
+    [[ "$created_basename" =~ ^beads-pr-lint-tools\.[A-Za-z0-9]{8}$ &&
+       "$created_parent" == "$runner_temp" &&
+       -d "$created_linter_root" &&
+       ! -L "$created_linter_root" ]] ||
+        fail "mktemp returned an unauthorized private linter directory"
+    canonical_linter_root="$(cd -P -- "$created_linter_root" && pwd)" ||
+        fail "could not canonicalize the private linter directory"
+    [[ "$canonical_linter_root" == "$runner_temp/$created_basename" ]] ||
+        fail "mktemp returned a nested or redirected private linter directory"
+    temporary_linter_parent="$runner_temp"
+    temporary_linter_root="$canonical_linter_root"
+    cleanup_authorized=1
+
+    install_path="${go_path%/*}:${git_path%/*}:${env_path%/*}"
+    install_environment=(
+        "PATH=$install_path"
+        "HOME=${HOME:-}"
+        "GOBIN=$temporary_linter_root"
+        "GOENV=off"
+        "GOWORK=off"
+        "GOFLAGS="
+        "GOTOOLCHAIN=local"
+        "GOEXPERIMENT="
+        "GOOS=$go_host_os"
+        "GOARCH=$go_host_arch"
+        "CGO_ENABLED=0"
+        "GIT_CONFIG_NOSYSTEM=1"
+        "GIT_CONFIG_GLOBAL=/dev/null"
+        "GIT_TERMINAL_PROMPT=0"
+    )
+    case "$go_host_arch" in
+        amd64) install_environment+=("GOAMD64=v1") ;;
+        arm64) install_environment+=("GOARM64=v8.0") ;;
+        *) fail "unsupported private-linter host architecture: $go_host_arch" ;;
+    esac
+    for name in \
+        APPDATA \
+        LOCALAPPDATA \
+        PROGRAMDATA \
+        SYSTEMROOT \
+        SystemRoot \
+        TEMP \
+        TMP \
+        TMPDIR \
+        USER \
+        USERPROFILE \
+        WINDIR; do
+        if [[ -n "${!name+x}" ]]; then
+            install_environment+=("$name=${!name}")
+        fi
+    done
+    "$env_path" -i \
+        "${install_environment[@]}" \
+        "$go_path" install \
+        "github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v${expected_linter_version}"
+    case "$expected_outer_os" in
+        windows) linter_path="$temporary_linter_root/golangci-lint.exe" ;;
+        *) linter_path="$temporary_linter_root/golangci-lint" ;;
+    esac
+    require_absolute_executable "newly installed golangci-lint" "$linter_path"
+    [[ ! -L "$linter_path" &&
+       "${linter_path%/*}" == "$temporary_linter_root" ]] ||
+        fail "newly installed golangci-lint is not one direct regular file"
+    canonical_linter_binary="$(canonicalize_path "$linter_path")" ||
+        fail "could not canonicalize the newly installed golangci-lint"
+    [[ "$canonical_linter_binary" == "$linter_path" ]] ||
+        fail "newly installed golangci-lint resolved outside its proved direct path"
+    temporary_linter_binary="$canonical_linter_binary"
+else
+    linter_path="$(resolve_executable golangci-lint)"
+fi
+
+linter_version_output="$("$linter_path" version)"
+expected_linter_version_regex="${expected_linter_version//./\\.}"
+[[ "$linter_version_output" =~ (^|[[:space:]])version[[:space:]]${expected_linter_version_regex}([[:space:]]|$) ]] ||
+    fail "expected golangci-lint $expected_linter_version, observed: $linter_version_output"
+
+if ! cc_name="$(
+    GOENV=off GOWORK=off GOFLAGS='' GOTOOLCHAIN=local GOEXPERIMENT='' \
+        "$go_path" env CC
+)"; then
+    fail "the bound Go executable could not report its C compiler"
+fi
+if ! cxx_name="$(
+    GOENV=off GOWORK=off GOFLAGS='' GOTOOLCHAIN=local GOEXPERIMENT='' \
+        "$go_path" env CXX
+)"; then
+    fail "the bound Go executable could not report its C++ compiler"
+fi
+case "$cc_name" in
+    /*)
+        cc_path="$(canonicalize_path "$cc_name")"
+        require_absolute_executable "Go C compiler" "$cc_path"
+        ;;
+    *) cc_path="$(resolve_executable "$cc_name")" ;;
+esac
+case "$cxx_name" in
+    /*)
+        cxx_path="$(canonicalize_path "$cxx_name")"
+        require_absolute_executable "Go C++ compiler" "$cxx_path"
+        ;;
+    *) cxx_path="$(resolve_executable "$cxx_name")" ;;
+esac
+if [[ -n "${BEADS_CI_EXPECTED_CC_VERSION:-}" ]]; then
+    expected_cc_version="$BEADS_CI_EXPECTED_CC_VERSION"
+    [[ "$expected_cc_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] ||
+        fail "invalid expected C compiler version: $expected_cc_version"
+    cc_version_output="$("$cc_path" --version)"
+    cc_version_first_line="${cc_version_output%%$'\n'*}"
+    [[ "$cc_version_first_line" =~ (^|[[:space:]])${expected_cc_version}([[:space:]]|$) ]] ||
+        fail "expected C compiler $expected_cc_version, observed: $cc_version_first_line"
+    cxx_version_output="$("$cxx_path" --version)"
+    cxx_version_first_line="${cxx_version_output%%$'\n'*}"
+    [[ "$cxx_version_first_line" =~ (^|[[:space:]])${expected_cc_version}([[:space:]]|$) ]] ||
+        fail "expected C++ compiler $expected_cc_version, observed: $cxx_version_first_line"
+fi
+if [[ "$expected_outer_os" == "windows" && "$target_cgo_enabled" == "1" ]]; then
+    [[ "${GITHUB_ACTIONS:-}" != "true" ||
+       -n "${BEADS_CI_EXPECTED_CC_VERSION:-}" ]] ||
+        fail "native Windows CGO requires an exact protected compiler version"
+    cc_machine="$("$cc_path" -dumpmachine)"
+    [[ "$cc_machine" == "x86_64-w64-mingw32" ]] ||
+        fail "expected an x86_64 MinGW compiler, observed: $cc_machine"
+    cxx_machine="$("$cxx_path" -dumpmachine)"
+    [[ "$cxx_machine" == "x86_64-w64-mingw32" ]] ||
+        fail "expected an x86_64 MinGW C++ compiler, observed: $cxx_machine"
+fi
+
+curated_path=""
+for executable in \
+    "$linter_path" \
+    "$cat_path" \
+    "$chmod_path" \
+    "$cp_path" \
+    "$diff_path" \
+    "$go_path" \
+    "$gofmt_path" \
+    "$make_path" \
+    "$git_path" \
+    "$cc_path" \
+    "$cxx_path" \
+    "$bash_path" \
+    "$env_path" \
+    "$mkdir_path" \
+    "$mktemp_path" \
+    "$rm_path" \
+    "$rmdir_path" \
+    "$sed_path" \
+    "$uname_path" \
+    "$readlink_path"; do
+    append_path_directory "$executable"
+done
+if [[ -n "$cygpath_path" ]]; then
+    append_path_directory "$cygpath_path"
+fi
+
+fixture_temp_parent="${RUNNER_TEMP:-${TMPDIR:-/tmp}}"
+if [[ "$expected_outer_os" == "windows" &&
+      "$fixture_temp_parent" =~ ^[A-Za-z]:[\\/] ]]; then
+    fixture_temp_parent="$("$cygpath_path" -u "$fixture_temp_parent")"
+fi
+[[ "$fixture_temp_parent" == /* &&
+   -d "$fixture_temp_parent" &&
+   ! -L "$fixture_temp_parent" ]] ||
+    fail "the test-fixture temp parent is not one absolute regular directory"
+fixture_temp_parent="$(cd -P -- "$fixture_temp_parent" && pwd)" ||
+    fail "could not canonicalize the test-fixture temp parent"
+
+printf 'host contract: os=%s uname=%s bash=%s make=%s go=%s lint=%s target=%s/%s,cgo=%s source=%s\n' \
+    "$expected_outer_os" \
+    "$uname_system" \
+    "$bash_path" \
+    "$make_version_first_line" \
+    "go${go_module_version}" \
+    "$expected_linter_version" \
+    "$target_goos" \
+    "$target_goarch" \
+    "$target_cgo_enabled" \
+    "$target_source"
+
+if [[ "$probe_only" -eq 1 ]]; then
+    printf 'pr-lint host capability probe passed\n'
+    exit 0
+fi
+
+child_environment=(
+    "PATH=$curated_path"
+    "HOME=${HOME:-}"
+    "GOENV=off"
+    "GOWORK=off"
+    "GOFLAGS=-mod=readonly"
+    "GOOS=$target_goos"
+    "GOARCH=$target_goarch"
+    "CGO_ENABLED=$target_cgo_enabled"
+    "CC=$cc_path"
+    "CXX=$cxx_path"
+    "GIT_CONFIG_NOSYSTEM=1"
+    "GIT_CONFIG_GLOBAL=/dev/null"
+    "GIT_TERMINAL_PROMPT=0"
+    "BASH_ENV="
+    "ENV="
+    "BEADS_CI_TOOLCHAIN_BOUND=1"
+    "BEADS_CI_EXPECTED_OUTER_OS=$expected_outer_os"
+    "BEADS_CI_BASH=$bash_path"
+    "BEADS_CI_CAT=$cat_path"
+    "BEADS_CI_CHMOD=$chmod_path"
+    "BEADS_CI_CP=$cp_path"
+    "BEADS_CI_DIFF=$diff_path"
+    "BEADS_CI_ENV=$env_path"
+    "BEADS_CI_GIT=$git_path"
+    "BEADS_CI_GO=$go_path"
+    "BEADS_CI_GOFMT=$gofmt_path"
+    "BEADS_CI_GOLANGCI_LINT=$linter_path"
+    "BEADS_CI_GOLANGCI_CONFIG=$linter_config_path"
+    "BEADS_CI_MAKE=$make_path"
+    "BEADS_CI_MKDIR=$mkdir_path"
+    "BEADS_CI_MKTEMP=$mktemp_path"
+    "BEADS_CI_READLINK=$readlink_path"
+    "BEADS_CI_RM=$rm_path"
+    "BEADS_CI_SED=$sed_path"
+    "BEADS_CI_UNAME=$uname_path"
+    "BEADS_CI_EXPECTED_GOLANGCI_LINT_VERSION=$expected_linter_version"
+    "BEADS_CI_TARGET_GOOS=$target_goos"
+    "BEADS_CI_TARGET_GOARCH=$target_goarch"
+    "BEADS_CI_TARGET_CGO_ENABLED=$target_cgo_enabled"
+    "BEADS_CI_FIXTURE_TEMP_PARENT=$fixture_temp_parent"
+)
+if [[ -n "${BEADS_CI_EXPECTED_CC_VERSION:-}" ]]; then
+    child_environment+=(
+        "BEADS_CI_EXPECTED_CC_VERSION=$BEADS_CI_EXPECTED_CC_VERSION"
+    )
+fi
+if [[ "$expected_outer_os" == "windows" ]]; then
+    child_environment+=(
+        "BEADS_CI_CYGPATH=$cygpath_path"
+        "BEADS_CI_WINDOWS_CMD=$windows_cmd_path"
+        "BEADS_CI_WINDOWS_GIT=$windows_git_path"
+        "COMSPEC=$windows_cmd_path"
+    )
+fi
+for name in \
+    APPDATA \
+    CI \
+    GITHUB_ACTIONS \
+    GITHUB_JOB \
+    GITHUB_RUN_ATTEMPT \
+    GITHUB_RUN_ID \
+    GITHUB_STEP_SUMMARY \
+    LOCALAPPDATA \
+    PROGRAMDATA \
+    RUNNER_TEMP \
+    SYSTEMROOT \
+    SystemRoot \
+    TEMP \
+    TMP \
+    TMPDIR \
+    USER \
+    USERPROFILE \
+    WINDIR; do
+    if [[ -n "${!name+x}" ]]; then
+        child_environment+=("$name=${!name}")
+    fi
+done
+
+make_contract=(
+    --no-print-directory
+    -f
+    Makefile
+    "GOOS=$target_goos"
+    "GOARCH=$target_goarch"
+    "CGO_ENABLED=$target_cgo_enabled"
+    "CI_BASH=$bash_path"
+    "CI_GOFMT=$gofmt_path"
+    "CI_SED=$sed_path"
+    "GO_VERSION=$go_module_version"
+)
+if [[ "$expected_outer_os" == "windows" ]]; then
+    make_contract+=(
+        "WINDOWS_CMD_EXE=$windows_cmd_path"
+        "GIT_WINDOWS_EXE=$windows_git_path"
+        "CI_GIT=$windows_git_path"
+    )
+else
+    make_contract+=(
+        "CI_GIT=$git_path"
+    )
+fi
+make_contract+=(ci-pr-lint-bound)
+
+"$env_path" -i \
+    "${child_environment[@]}" \
+    "$make_path" "${make_contract[@]}"

--- a/scripts/ci/pr-lint-routing-test.sh
+++ b/scripts/ci/pr-lint-routing-test.sh
@@ -1,0 +1,728 @@
+#!/bin/bash
+# Black-box routing tests for the required PR lint wrapper.
+
+set -euo pipefail
+
+fail() {
+    printf 'PR lint routing contract: %s\n' "$1" >&2
+    exit 1
+}
+
+script_source="${BASH_SOURCE[0]}"
+case "$script_source" in
+    */*) script_parent="${script_source%/*}" ;;
+    *) script_parent="." ;;
+esac
+SCRIPT_DIR="$(cd -P -- "$script_parent" && pwd)"
+REPO_ROOT="$(cd -P -- "$SCRIPT_DIR/../.." && pwd)"
+PR_LINT="$SCRIPT_DIR/pr-lint.sh"
+
+[[ "${BEADS_CI_TOOLCHAIN_BOUND:-}" == "1" ]] ||
+    fail "the host toolchain was not bound"
+[[ "${BASH:-}" == "${BEADS_CI_BASH:-}" ]] ||
+    fail "routing test did not reuse the bound Bash"
+[[ "$BEADS_CI_BASH" == /* ||
+   "$BEADS_CI_BASH" =~ ^[A-Za-z]:/ ]] ||
+    fail "the bound Bash is not absolute: $BEADS_CI_BASH"
+stub_bash="$BEADS_CI_BASH"
+if [[ "$stub_bash" == *[[:space:]]* ]]; then
+    [[ "$BEADS_CI_EXPECTED_OUTER_OS" == "windows" ]] ||
+        fail "the bound Bash contains whitespace outside Windows"
+    stub_bash="/usr/bin/bash"
+    [[ -f "$stub_bash" && -x "$stub_bash" &&
+       "$stub_bash" -ef "$BEADS_CI_BASH" ]] ||
+        fail "the shebang-safe Bash alias is not the bound Windows Bash"
+fi
+
+require_absolute_executable() {
+    local label="$1"
+    local path="$2"
+    [[ ("$path" == /* || "$path" =~ ^[A-Za-z]:/) &&
+       -f "$path" && -x "$path" ]] ||
+        fail "$label is not an absolute executable: $path"
+}
+
+canonicalize_path() {
+    local path="$1"
+    local directory=""
+    local leaf=""
+    local target=""
+    local link_count=0
+
+    [[ "$path" == /* ]] || return 1
+    while :; do
+        directory="${path%/*}"
+        leaf="${path##*/}"
+        [[ -n "$directory" ]] || directory="/"
+        directory="$(cd -P -- "$directory" 2>/dev/null && pwd)" || return 1
+        if [[ "$directory" == "/" ]]; then
+            path="/$leaf"
+        else
+            path="$directory/$leaf"
+        fi
+        if [[ ! -L "$path" ]]; then
+            printf '%s' "$path"
+            return 0
+        fi
+
+        link_count=$((link_count + 1))
+        ((link_count <= 40)) || return 1
+        target="$("$BEADS_CI_READLINK" "$path")" || return 1
+        if [[ "$target" == /* ]]; then
+            path="$target"
+        else
+            path="$directory/$target"
+        fi
+    done
+}
+
+resolve_executable() {
+    local name="$1"
+    local path=""
+    path="$(type -P -- "$name" 2>/dev/null)" ||
+        fail "required routing-test executable is unavailable: $name"
+    path="$(canonicalize_path "$path")" ||
+        fail "could not canonicalize routing-test executable: $name"
+    require_absolute_executable "$name" "$path"
+    printf '%s' "$path"
+}
+
+for variable in \
+    BEADS_CI_CAT \
+    BEADS_CI_CHMOD \
+    BEADS_CI_CP \
+    BEADS_CI_DIFF \
+    BEADS_CI_ENV \
+    BEADS_CI_MKDIR \
+    BEADS_CI_MKTEMP \
+    BEADS_CI_READLINK \
+    BEADS_CI_RM \
+    BEADS_CI_UNAME; do
+    require_absolute_executable "$variable" "${!variable:-}"
+done
+[[ "${GO_VERSION:-}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] ||
+    fail "GO_VERSION is not one exact protected version"
+
+cat_path="$BEADS_CI_CAT"
+chmod_path="$BEADS_CI_CHMOD"
+cp_path="$BEADS_CI_CP"
+diff_path="$BEADS_CI_DIFF"
+
+fixture_parent="${BEADS_CI_FIXTURE_TEMP_PARENT:-}"
+if [[ "$BEADS_CI_EXPECTED_OUTER_OS" == "windows" &&
+      "$fixture_parent" =~ ^[A-Za-z]:[\\/] ]]; then
+    require_absolute_executable "BEADS_CI_CYGPATH" "${BEADS_CI_CYGPATH:-}"
+    fixture_parent="$("$BEADS_CI_CYGPATH" -u "$fixture_parent")" ||
+        fail "could not translate the routing-test fixture parent"
+fi
+[[ "$fixture_parent" == /* && -d "$fixture_parent" && ! -L "$fixture_parent" ]] ||
+    fail "the routing-test fixture parent is not one absolute regular directory: ${fixture_parent:-<unset>}"
+fixture_parent="$(cd -P -- "$fixture_parent" && pwd)" ||
+    fail "could not canonicalize the routing-test fixture parent"
+tmpdir="$(
+    "$BEADS_CI_MKTEMP" -d "$fixture_parent/beads-pr-lint-routing.XXXXXXXX"
+)" || fail "mktemp could not create the routing-test directory"
+tmp_basename="${tmpdir##*/}"
+tmp_parent="${tmpdir%/*}"
+[[ "$tmp_basename" =~ ^beads-pr-lint-routing\.[A-Za-z0-9]{8}$ &&
+   "$tmp_parent" == "$fixture_parent" &&
+   -d "$tmpdir" &&
+   ! -L "$tmpdir" ]] ||
+    fail "mktemp returned an unauthorized routing-test directory"
+tmpdir="$(cd -P -- "$tmpdir" && pwd)" ||
+    fail "could not canonicalize the routing-test directory"
+[[ "$tmpdir" == "$fixture_parent/$tmp_basename" ]] ||
+    fail "mktemp returned a nested or redirected routing-test directory"
+cleanup() {
+    local original_status=$?
+    local cleanup_failed=0
+    local observed_parent=""
+
+    observed_parent="$(cd -P -- "$fixture_parent" && pwd)" ||
+        cleanup_failed=1
+    if [[ "$cleanup_failed" -eq 0 &&
+          "$observed_parent" == "$fixture_parent" &&
+          "${tmpdir%/*}" == "$fixture_parent" &&
+          "${tmpdir##*/}" =~ ^beads-pr-lint-routing\.[A-Za-z0-9]{8}$ &&
+          -d "$tmpdir" &&
+          ! -L "$tmpdir" ]]; then
+        # This recursively removes only the fully validated private test
+        # fixture. Production private-tool cleanup is deliberately leaf-only.
+        "$BEADS_CI_RM" -rf -- "$tmpdir" || cleanup_failed=1
+        [[ ! -e "$tmpdir" && ! -L "$tmpdir" ]] || cleanup_failed=1
+    else
+        cleanup_failed=1
+    fi
+    if [[ "$cleanup_failed" -ne 0 ]]; then
+        printf 'PR lint routing contract: fixture cleanup failed: %s\n' \
+            "$tmpdir" >&2
+        original_status=1
+    fi
+    trap - EXIT
+    exit "$original_status"
+}
+trap cleanup EXIT
+
+stub_dir="$tmpdir/bin"
+event_log="$tmpdir/ordered-events"
+"$BEADS_CI_MKDIR" -p "$stub_dir"
+
+printf '%s\n' same >"$tmpdir/diff-same-a"
+printf '%s\n' same >"$tmpdir/diff-same-b"
+printf '%s\n' different >"$tmpdir/diff-different"
+"$diff_path" -u "$tmpdir/diff-same-a" "$tmpdir/diff-same-b" >/dev/null ||
+    fail "the bound diff rejected known-identical files"
+if "$diff_path" -u "$tmpdir/diff-same-a" "$tmpdir/diff-different" >/dev/null; then
+    fail "the bound diff accepted known-different files"
+fi
+
+{
+    printf '#!%s\n' "$stub_bash"
+    "$cat_path" <<'EOF'
+set -euo pipefail
+
+expected=(
+    --no-print-directory
+    -f
+    Makefile
+    "CI_BASH=$BEADS_CI_BASH"
+    "CI_GOFMT=$BEADS_CI_GOFMT"
+    "CI_SED=$BEADS_CI_SED"
+    "GO_VERSION=$GO_VERSION"
+)
+if [[ "$BEADS_CI_EXPECTED_OUTER_OS" == "windows" ]]; then
+    expected+=(
+        "WINDOWS_CMD_EXE=$BEADS_CI_WINDOWS_CMD"
+        "GIT_WINDOWS_EXE=$BEADS_CI_WINDOWS_GIT"
+        "CI_GIT=$BEADS_CI_WINDOWS_GIT"
+    )
+else
+    expected+=(
+        "CI_GIT=$BEADS_CI_GIT"
+    )
+fi
+expected+=(fmt-check)
+if [[ "$#" -ne "${#expected[@]}" ]]; then
+    printf 'unexpected make argument count: %s\n' "$#" >&2
+    exit 64
+fi
+for ((index = 0; index < ${#expected[@]}; index++)); do
+    position=$((index + 1))
+    actual="${!position}"
+    if [[ "$actual" != "${expected[$index]}" ]]; then
+        printf 'unexpected make argument %s: %q\n' \
+            "$position" "$actual" >&2
+        exit 64
+    fi
+done
+
+printf 'format\tstate-change\n' >>"$PR_LINT_EVENT_LOG"
+if [[ "${PR_LINT_MAKE_FAIL:-0}" == "1" ]]; then
+    exit 69
+fi
+EOF
+} >"$stub_dir/make"
+
+{
+    printf '#!%s\n' "$stub_bash"
+    "$cat_path" <<'EOF'
+set -euo pipefail
+
+generation=1
+while IFS= read -r event; do
+    if [[ "$event" == format$'\t'* || "$event" == lint$'\t'* ]]; then
+        generation=2
+    fi
+done <"$PR_LINT_EVENT_LOG"
+{
+    printf 'go-env\t%s\t%s' "$generation" "${1:-}"
+    for argument in "${@:2}"; do
+        printf '\t%s' "$argument"
+    done
+    printf '\n'
+} >>"$PR_LINT_EVENT_LOG"
+
+if [[ "${PR_LINT_GO_ENV_FAIL:-0}" == "1" ]]; then
+    exit 68
+fi
+
+if ((generation == 1)); then
+    goos="$PR_LINT_SNAPSHOT_GOOS"
+    goarch="$PR_LINT_SNAPSHOT_GOARCH"
+    cgo_enabled="$PR_LINT_SNAPSHOT_CGO_ENABLED"
+else
+    goos="$PR_LINT_NEXT_GOOS"
+    goarch="$PR_LINT_NEXT_GOARCH"
+    cgo_enabled="$PR_LINT_NEXT_CGO_ENABLED"
+fi
+
+if [[ "$#" -eq 4 &&
+      "$1" == "env" &&
+      "$2" == "GOOS" &&
+      "$3" == "GOARCH" &&
+      "$4" == "CGO_ENABLED" ]]; then
+    if [[ "${PR_LINT_GO_ENV_MALFORMED:-0}" == "1" ]]; then
+        printf '%s\n%s\n' "$goos" "$goarch"
+    else
+        printf '%s\n%s\n%s\n' "$goos" "$goarch" "$cgo_enabled"
+    fi
+    exit 0
+fi
+
+if [[ "$#" -eq 2 && "$1" == "env" ]]; then
+    case "$2" in
+        GOOS) printf '%s\n' "$goos" ;;
+        GOARCH) printf '%s\n' "$goarch" ;;
+        CGO_ENABLED) printf '%s\n' "$cgo_enabled" ;;
+        *)
+            printf 'unexpected go env key: %s\n' "$2" >&2
+            exit 66
+            ;;
+    esac
+    exit 0
+fi
+
+if [[ "$#" -eq 0 ]]; then
+    printf 'unexpected empty go invocation\n' >&2
+else
+    printf 'unexpected go invocation:' >&2
+    printf ' %q' "$@" >&2
+    printf '\n' >&2
+fi
+exit 65
+EOF
+} >"$stub_dir/go"
+
+{
+    printf '#!%s\n' "$stub_bash"
+    "$cat_path" <<'EOF'
+set -euo pipefail
+
+if [[ "$#" -ne 7 ||
+      "$1" != "run" ||
+      "$2" != "--config" ||
+      "$3" != "$PR_LINT_EXPECTED_CONFIG" ||
+      "$4" != "--modules-download-mode=readonly" ||
+      "$5" != "--timeout=5m" ||
+      "$6" != "--build-tags=gms_pure_go" ||
+      "$7" != "./..." ]]; then
+    printf 'unexpected golangci-lint invocation:' >&2
+    printf ' %q' "$@" >&2
+    printf '\n' >&2
+    exit 67
+fi
+[[ "${GOENV:-}" == "off" ]] || exit 67
+[[ "${GOWORK:-}" == "off" ]] || exit 67
+[[ "${GOFLAGS:-}" == "-mod=readonly -tags=gms_pure_go" ]] || exit 67
+
+lint_generation=1
+while IFS= read -r event; do
+    if [[ "$event" == lint$'\t'* ]]; then
+        lint_generation=$((lint_generation + 1))
+    fi
+done <"$PR_LINT_EVENT_LOG"
+printf 'lint\t%s\t%s\t%s\t%s\n' \
+    "$lint_generation" \
+    "${GOOS:-<unset>}" \
+    "${GOARCH:-<unset>}" \
+    "${CGO_ENABLED:-<unset>}" >>"$PR_LINT_EVENT_LOG"
+
+if [[ "${PR_LINT_FAIL_LINT_GENERATION:-0}" == "$lint_generation" ]]; then
+    exit 70
+fi
+EOF
+} >"$stub_dir/golangci-lint"
+
+"$chmod_path" +x "$stub_dir/make" "$stub_dir/go" "$stub_dir/golangci-lint"
+
+assert_event_log() {
+    local name="$1"
+    shift
+
+    local actual="$tmpdir/$name.events.actual"
+    local expected="$tmpdir/$name.events.expected"
+    "$cp_path" "$event_log" "$actual"
+    printf '%s\n' "$@" >"$expected"
+    if ! "$diff_path" -u "$expected" "$actual"; then
+        printf 'PR lint routing case %s observed the wrong event sequence\n' "$name" >&2
+        return 1
+    fi
+
+    local first_event=""
+    local go_env_events=0
+    local format_events=0
+    while IFS= read -r event; do
+        if [[ -z "$first_event" ]]; then
+            first_event="$event"
+        fi
+        if [[ "$event" == go-env$'\t'* ]]; then
+            go_env_events=$((go_env_events + 1))
+        elif [[ "$event" == format$'\t'* ]]; then
+            format_events=$((format_events + 1))
+        fi
+    done <"$event_log"
+
+    [[ "$go_env_events" -eq 1 ]] ||
+        fail "case $name did not use exactly one go env event"
+    [[ "$format_events" -le 1 ]] ||
+        fail "case $name formatted more than once"
+    [[ "$first_event" == go-env$'\t'* ]] ||
+        fail "case $name performed work before freezing target state"
+}
+
+case_count=0
+
+run_case_with_state() {
+    local name="$1"
+    local snapshot_goos="$2"
+    local snapshot_goarch="$3"
+    local snapshot_cgo_enabled="$4"
+    local next_goos="$5"
+    local next_goarch="$6"
+    local next_cgo_enabled="$7"
+    shift 7
+    case_count=$((case_count + 1))
+
+    : >"$event_log"
+
+    if ! "$BEADS_CI_ENV" -i \
+        PATH= \
+        BASH_ENV= \
+        ENV= \
+        HOME="${HOME:-}" \
+        GOENV=off \
+        GOWORK=off \
+        GOFLAGS=-mod=readonly \
+        GOOS=plan9 \
+        GOARCH=386 \
+        CGO_ENABLED=0 \
+        GO_VERSION="$GO_VERSION" \
+        BEADS_CI_TOOLCHAIN_BOUND=1 \
+        BEADS_CI_EXPECTED_OUTER_OS="$BEADS_CI_EXPECTED_OUTER_OS" \
+        BEADS_CI_BASH="$BEADS_CI_BASH" \
+        BEADS_CI_ENV="$BEADS_CI_ENV" \
+        BEADS_CI_GIT="$stub_dir/go" \
+        BEADS_CI_GO="$stub_dir/go" \
+        BEADS_CI_GOFMT="$stub_dir/go" \
+        BEADS_CI_GOLANGCI_LINT="$stub_dir/golangci-lint" \
+        BEADS_CI_GOLANGCI_CONFIG="$REPO_ROOT/.golangci.yml" \
+        BEADS_CI_MAKE="$stub_dir/make" \
+        BEADS_CI_SED="$stub_dir/go" \
+        BEADS_CI_UNAME="$BEADS_CI_UNAME" \
+        BEADS_CI_WINDOWS_CMD='C:\bound\cmd.exe' \
+        BEADS_CI_WINDOWS_GIT='C:\bound\git.exe' \
+        BEADS_CI_TARGET_GOOS="$snapshot_goos" \
+        BEADS_CI_TARGET_GOARCH="$snapshot_goarch" \
+        BEADS_CI_TARGET_CGO_ENABLED="$snapshot_cgo_enabled" \
+        PR_LINT_EXPECTED_CONFIG="$REPO_ROOT/.golangci.yml" \
+        PR_LINT_SNAPSHOT_GOOS="$snapshot_goos" \
+        PR_LINT_SNAPSHOT_GOARCH="$snapshot_goarch" \
+        PR_LINT_SNAPSHOT_CGO_ENABLED="$snapshot_cgo_enabled" \
+        PR_LINT_NEXT_GOOS="$next_goos" \
+        PR_LINT_NEXT_GOARCH="$next_goarch" \
+        PR_LINT_NEXT_CGO_ENABLED="$next_cgo_enabled" \
+        PR_LINT_EVENT_LOG="$event_log" \
+        "$BEADS_CI_BASH" --noprofile --norc "$PR_LINT" \
+        >"$tmpdir/$name.output" 2>&1; then
+        printf 'PR lint routing case %s failed:\n' "$name" >&2
+        "$cat_path" "$tmpdir/$name.output" >&2
+        return 1
+    fi
+
+    assert_event_log "$name" "$@"
+}
+
+run_case() {
+    local name="$1"
+    local goos="$2"
+    local goarch="$3"
+    local cgo_enabled="$4"
+    shift 4
+    run_case_with_state \
+        "$name" \
+        "$goos" "$goarch" "$cgo_enabled" \
+        freebsd arm64 0 \
+        "$@"
+}
+
+run_refusal_case() {
+    local name="$1"
+    local mode="$2"
+    shift 2
+    case_count=$((case_count + 1))
+    : >"$event_log"
+
+    local go_env_fail=0
+    local go_env_malformed=0
+    local lint_failure=0
+    local make_failure=0
+    case "$mode" in
+        go-failure) go_env_fail=1 ;;
+        go-malformed) go_env_malformed=1 ;;
+        lint-failure-1) lint_failure=1 ;;
+        lint-failure-2) lint_failure=2 ;;
+        make-failure) make_failure=1 ;;
+        *) fail "unknown refusal mode: $mode" ;;
+    esac
+
+    if "$BEADS_CI_ENV" -i \
+        PATH= \
+        BASH_ENV= \
+        ENV= \
+        HOME="${HOME:-}" \
+        GOENV=off \
+        GOWORK=off \
+        GOFLAGS=-mod=readonly \
+        GOOS=plan9 \
+        GOARCH=386 \
+        CGO_ENABLED=0 \
+        GO_VERSION="$GO_VERSION" \
+        BEADS_CI_TOOLCHAIN_BOUND=1 \
+        BEADS_CI_EXPECTED_OUTER_OS="$BEADS_CI_EXPECTED_OUTER_OS" \
+        BEADS_CI_BASH="$BEADS_CI_BASH" \
+        BEADS_CI_ENV="$BEADS_CI_ENV" \
+        BEADS_CI_GIT="$stub_dir/go" \
+        BEADS_CI_GO="$stub_dir/go" \
+        BEADS_CI_GOFMT="$stub_dir/go" \
+        BEADS_CI_GOLANGCI_LINT="$stub_dir/golangci-lint" \
+        BEADS_CI_GOLANGCI_CONFIG="$REPO_ROOT/.golangci.yml" \
+        BEADS_CI_MAKE="$stub_dir/make" \
+        BEADS_CI_SED="$stub_dir/go" \
+        BEADS_CI_UNAME="$BEADS_CI_UNAME" \
+        BEADS_CI_WINDOWS_CMD='C:\bound\cmd.exe' \
+        BEADS_CI_WINDOWS_GIT='C:\bound\git.exe' \
+        BEADS_CI_TARGET_GOOS=linux \
+        BEADS_CI_TARGET_GOARCH=amd64 \
+        BEADS_CI_TARGET_CGO_ENABLED=1 \
+        PR_LINT_EXPECTED_CONFIG="$REPO_ROOT/.golangci.yml" \
+        PR_LINT_SNAPSHOT_GOOS=linux \
+        PR_LINT_SNAPSHOT_GOARCH=amd64 \
+        PR_LINT_SNAPSHOT_CGO_ENABLED=1 \
+        PR_LINT_NEXT_GOOS=freebsd \
+        PR_LINT_NEXT_GOARCH=arm64 \
+        PR_LINT_NEXT_CGO_ENABLED=0 \
+        PR_LINT_GO_ENV_FAIL="$go_env_fail" \
+        PR_LINT_GO_ENV_MALFORMED="$go_env_malformed" \
+        PR_LINT_FAIL_LINT_GENERATION="$lint_failure" \
+        PR_LINT_MAKE_FAIL="$make_failure" \
+        PR_LINT_EVENT_LOG="$event_log" \
+        "$BEADS_CI_BASH" --noprofile --norc "$PR_LINT" \
+        >"$tmpdir/$name.output" 2>&1; then
+        fail "$name unexpectedly succeeded"
+    fi
+    assert_event_log "$name" "$@"
+}
+
+run_case required_linux_cgo linux amd64 1 \
+    $'go-env\t1\tenv\tGOOS\tGOARCH\tCGO_ENABLED' \
+    $'format\tstate-change' \
+    $'lint\t1\tlinux\tamd64\t1' \
+    $'lint\t2\twindows\tamd64\t0'
+
+run_case required_macos_arm64_cgo darwin arm64 1 \
+    $'go-env\t1\tenv\tGOOS\tGOARCH\tCGO_ENABLED' \
+    $'format\tstate-change' \
+    $'lint\t1\tdarwin\tarm64\t1' \
+    $'lint\t2\twindows\tarm64\t0'
+
+run_case linux_to_windows_noncgo linux amd64 0 \
+    $'go-env\t1\tenv\tGOOS\tGOARCH\tCGO_ENABLED' \
+    $'format\tstate-change' \
+    $'lint\t1\tlinux\tamd64\t0' \
+    $'lint\t2\twindows\tamd64\t0'
+
+run_case native_windows_noncgo windows amd64 0 \
+    $'go-env\t1\tenv\tGOOS\tGOARCH\tCGO_ENABLED' \
+    $'format\tstate-change' \
+    $'lint\t1\twindows\tamd64\t0'
+
+run_case windows_arm64_cgo_two_pass windows arm64 1 \
+    $'go-env\t1\tenv\tGOOS\tGOARCH\tCGO_ENABLED' \
+    $'format\tstate-change' \
+    $'lint\t1\twindows\tarm64\t1' \
+    $'lint\t2\twindows\tarm64\t0'
+
+run_case_with_state changing_state_explicit_snapshot \
+    linux amd64 1 \
+    freebsd arm64 0 \
+    $'go-env\t1\tenv\tGOOS\tGOARCH\tCGO_ENABLED' \
+    $'format\tstate-change' \
+    $'lint\t1\tlinux\tamd64\t1' \
+    $'lint\t2\twindows\tamd64\t0'
+
+run_refusal_case go_env_failure go-failure \
+    $'go-env\t1\tenv\tGOOS\tGOARCH\tCGO_ENABLED'
+
+run_refusal_case go_env_malformed go-malformed \
+    $'go-env\t1\tenv\tGOOS\tGOARCH\tCGO_ENABLED'
+
+run_refusal_case linter_generation_1_failure_is_fatal lint-failure-1 \
+    $'go-env\t1\tenv\tGOOS\tGOARCH\tCGO_ENABLED' \
+    $'format\tstate-change' \
+    $'lint\t1\tlinux\tamd64\t1'
+
+run_refusal_case linter_generation_2_failure_is_fatal lint-failure-2 \
+    $'go-env\t1\tenv\tGOOS\tGOARCH\tCGO_ENABLED' \
+    $'format\tstate-change' \
+    $'lint\t1\tlinux\tamd64\t1' \
+    $'lint\t2\twindows\tamd64\t0'
+
+run_refusal_case format_make_failure_is_fatal make-failure \
+    $'go-env\t1\tenv\tGOOS\tGOARCH\tCGO_ENABLED' \
+    $'format\tstate-change'
+
+expected_case_count=11
+[[ "$case_count" -eq "$expected_case_count" ]] ||
+    fail "expected $expected_case_count mandatory cases, ran $case_count"
+
+authority_refusal_count=0
+assert_refusal_event_log() {
+    local name="$1"
+    shift
+
+    local actual="$tmpdir/$name.events.actual"
+    local expected="$tmpdir/$name.events.expected"
+    "$cp_path" "$event_log" "$actual"
+    if [[ "$#" -eq 0 ]]; then
+        : >"$expected"
+    else
+        printf '%s\n' "$@" >"$expected"
+    fi
+    if ! "$diff_path" -u "$expected" "$actual"; then
+        printf 'PR lint authority refusal %s observed unexpected work\n' "$name" >&2
+        return 1
+    fi
+}
+
+run_authority_refusal_case() {
+    local name="$1"
+    local mode="$2"
+    authority_refusal_count=$((authority_refusal_count + 1))
+    : >"$event_log"
+
+    local config="$REPO_ROOT/.golangci.yml"
+    local gowork=off
+    local goflags=-mod=readonly
+    local expected_goos=linux
+    local expected_events=()
+    case "$mode" in
+        sibling-config)
+            config="$tmpdir/.golangci.yaml"
+            printf '%s\n' 'version: "2"' >"$config"
+            ;;
+        go-work)
+            gowork="$tmpdir/go.work"
+            printf '%s\n' 'go 1.26.0' >"$gowork"
+            ;;
+        vendor-mode)
+            goflags=-mod=vendor
+            ;;
+        target-mismatch)
+            expected_goos=windows
+            expected_events+=($'go-env\t1\tenv\tGOOS\tGOARCH\tCGO_ENABLED')
+            ;;
+        *) fail "unknown authority refusal mode: $mode" ;;
+    esac
+
+    if "$BEADS_CI_ENV" -i \
+        PATH= \
+        BASH_ENV= \
+        ENV= \
+        HOME="${HOME:-}" \
+        GOENV=off \
+        GOWORK="$gowork" \
+        GOFLAGS="$goflags" \
+        GOOS=linux \
+        GOARCH=amd64 \
+        CGO_ENABLED=1 \
+        GO_VERSION="$GO_VERSION" \
+        BEADS_CI_TOOLCHAIN_BOUND=1 \
+        BEADS_CI_EXPECTED_OUTER_OS="$BEADS_CI_EXPECTED_OUTER_OS" \
+        BEADS_CI_BASH="$BEADS_CI_BASH" \
+        BEADS_CI_ENV="$BEADS_CI_ENV" \
+        BEADS_CI_GIT="$stub_dir/go" \
+        BEADS_CI_GO="$stub_dir/go" \
+        BEADS_CI_GOFMT="$stub_dir/go" \
+        BEADS_CI_GOLANGCI_LINT="$stub_dir/golangci-lint" \
+        BEADS_CI_GOLANGCI_CONFIG="$config" \
+        BEADS_CI_MAKE="$stub_dir/make" \
+        BEADS_CI_SED="$stub_dir/go" \
+        BEADS_CI_UNAME="$BEADS_CI_UNAME" \
+        BEADS_CI_WINDOWS_CMD='C:\bound\cmd.exe' \
+        BEADS_CI_WINDOWS_GIT='C:\bound\git.exe' \
+        BEADS_CI_TARGET_GOOS="$expected_goos" \
+        BEADS_CI_TARGET_GOARCH=amd64 \
+        BEADS_CI_TARGET_CGO_ENABLED=1 \
+        PR_LINT_EXPECTED_CONFIG="$REPO_ROOT/.golangci.yml" \
+        PR_LINT_SNAPSHOT_GOOS=linux \
+        PR_LINT_SNAPSHOT_GOARCH=amd64 \
+        PR_LINT_SNAPSHOT_CGO_ENABLED=1 \
+        PR_LINT_NEXT_GOOS=freebsd \
+        PR_LINT_NEXT_GOARCH=arm64 \
+        PR_LINT_NEXT_CGO_ENABLED=0 \
+        PR_LINT_EVENT_LOG="$event_log" \
+        "$BEADS_CI_BASH" --noprofile --norc "$PR_LINT" \
+        >"$tmpdir/$name.output" 2>&1; then
+        fail "$name unexpectedly accepted ambiguous authority"
+    fi
+    assert_refusal_event_log "$name" "${expected_events[@]}"
+}
+
+run_authority_refusal_case sibling_config_is_ignored_only_by_exact_binding sibling-config
+run_authority_refusal_case go_work_is_forbidden go-work
+run_authority_refusal_case vendor_auto_mode_is_forbidden vendor-mode
+run_authority_refusal_case public_target_mismatch_is_forbidden target-mismatch
+
+expected_authority_refusal_count=4
+[[ "$authority_refusal_count" -eq "$expected_authority_refusal_count" ]] ||
+    fail "expected $expected_authority_refusal_count authority refusals, ran $authority_refusal_count"
+
+{
+    printf '#!%s\n' "$stub_bash"
+    "$cat_path" <<'EOF'
+printf '%s\n' 'gofmt failure stub executed' >"$0.receipt"
+exit 73
+EOF
+} >"$stub_dir/gofmt-failure"
+"$chmod_path" +x "$stub_dir/gofmt-failure"
+false_gofmt_receipt="$stub_dir/gofmt-failure.receipt"
+false_gofmt_output="$tmpdir/false-gofmt.output"
+[[ ! -e "$false_gofmt_receipt" ]] ||
+    fail "the nonzero gofmt execution receipt already exists"
+false_gofmt_arguments=(
+    --no-print-directory
+    -f
+    Makefile
+    "CI_GOFMT=$stub_dir/gofmt-failure"
+)
+if [[ "$BEADS_CI_EXPECTED_OUTER_OS" == "windows" ]]; then
+    false_gofmt_arguments+=(
+        "WINDOWS_CMD_EXE=$BEADS_CI_WINDOWS_CMD"
+        "GIT_WINDOWS_EXE=$BEADS_CI_WINDOWS_GIT"
+        "CI_GIT=$BEADS_CI_WINDOWS_GIT"
+    )
+else
+    false_gofmt_arguments+=("CI_GIT=$BEADS_CI_GIT")
+fi
+false_gofmt_arguments+=(fmt-check)
+if "$BEADS_CI_MAKE" "${false_gofmt_arguments[@]}" \
+    >"$false_gofmt_output" 2>&1; then
+    fail "fmt-check accepted a nonzero gofmt producer"
+fi
+[[ -f "$false_gofmt_receipt" && ! -L "$false_gofmt_receipt" ]] ||
+    fail "fmt-check failed without executing the nonzero gofmt producer"
+IFS= read -r false_gofmt_receipt_value <"$false_gofmt_receipt" ||
+    fail "could not read the nonzero gofmt execution receipt"
+[[ "$false_gofmt_receipt_value" == "gofmt failure stub executed" ]] ||
+    fail "the nonzero gofmt execution receipt was malformed"
+false_gofmt_diagnostic_seen=0
+while IFS= read -r line || [[ -n "$line" ]]; do
+    if [[ "$line" == "gofmt failed while checking formatting" ]]; then
+        false_gofmt_diagnostic_seen=1
+    fi
+done <"$false_gofmt_output"
+[[ "$false_gofmt_diagnostic_seen" -eq 1 ]] ||
+    fail "fmt-check failed for an unrelated reason without the gofmt producer-status diagnostic"
+
+printf 'PR lint target routing tests passed (%s mandatory cases; %s authority refusals; nonzero gofmt refused)\n' \
+    "$case_count" "$authority_refusal_count"

--- a/scripts/ci/pr-lint.sh
+++ b/scripts/ci/pr-lint.sh
@@ -1,18 +1,168 @@
-#!/usr/bin/env bash
+#!/bin/bash
+# shellcheck source-path=SCRIPTDIR
 # Required PR formatting and Go lint contract.
 
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+fail() {
+    printf 'pr-lint contract: %s\n' "$1" >&2
+    exit 1
+}
 
-# shellcheck source=../.buildflags
+script_source="${BASH_SOURCE[0]}"
+case "$script_source" in
+    */*) script_parent="${script_source%/*}" ;;
+    *) script_parent="." ;;
+esac
+SCRIPT_DIR="$(cd -P -- "$script_parent" && pwd)"
+REPO_ROOT="$(cd -P -- "$SCRIPT_DIR/../.." && pwd)"
+
+[[ "${BEADS_CI_TOOLCHAIN_BOUND:-}" == "1" ]] ||
+    fail "the host toolchain was not bound"
+
+require_absolute_executable() {
+    local label="$1"
+    local path="$2"
+    [[ ("$path" == /* || "$path" =~ ^[A-Za-z]:/) &&
+       -f "$path" && -x "$path" ]] ||
+        fail "$label is not an absolute executable: $path"
+}
+
+for variable in \
+    BEADS_CI_BASH \
+    BEADS_CI_GIT \
+    BEADS_CI_GO \
+    BEADS_CI_GOFMT \
+    BEADS_CI_GOLANGCI_LINT \
+    BEADS_CI_MAKE \
+    BEADS_CI_SED \
+    BEADS_CI_UNAME; do
+    value="${!variable:-}"
+    require_absolute_executable "$variable" "$value"
+done
+[[ ("${BEADS_CI_GOLANGCI_CONFIG:-}" == /* ||
+    "${BEADS_CI_GOLANGCI_CONFIG:-}" =~ ^[A-Za-z]:/) &&
+   -f "$BEADS_CI_GOLANGCI_CONFIG" &&
+   ! -L "$BEADS_CI_GOLANGCI_CONFIG" ]] ||
+    fail "BEADS_CI_GOLANGCI_CONFIG is not an absolute regular file"
+[[ "$BEADS_CI_GOLANGCI_CONFIG" -ef "$REPO_ROOT/.golangci.yml" ]] ||
+    fail "the bound golangci-lint configuration is not the repository authority"
+[[ "${BASH:-}" == "$BEADS_CI_BASH" ]] ||
+    fail "wrapper Bash identity changed from $BEADS_CI_BASH to ${BASH:-<unset>}"
+[[ "${GO_VERSION:-}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] ||
+    fail "GO_VERSION is not one exact protected version"
+actual_uname="$("$BEADS_CI_UNAME" -s)"
+case "${BEADS_CI_EXPECTED_OUTER_OS:-}" in
+    linux) [[ "$actual_uname" == "Linux" ]] || fail "outer OS changed to $actual_uname" ;;
+    macos) [[ "$actual_uname" == "Darwin" ]] || fail "outer OS changed to $actual_uname" ;;
+    windows)
+        [[ "$actual_uname" == MINGW*_NT-* ||
+           "$actual_uname" == MSYS*_NT-* ||
+           "$actual_uname" == CYGWIN*_NT-* ]] ||
+            fail "outer OS changed to $actual_uname"
+        ;;
+    *) fail "BEADS_CI_EXPECTED_OUTER_OS is missing or unsupported" ;;
+esac
+if [[ "$BEADS_CI_EXPECTED_OUTER_OS" == "windows" ]]; then
+    [[ "${BEADS_CI_WINDOWS_CMD:-}" =~ ^[A-Za-z]:[\\/] ]] ||
+        fail "BEADS_CI_WINDOWS_CMD is not an absolute Windows path"
+    [[ "${BEADS_CI_WINDOWS_GIT:-}" =~ ^[A-Za-z]:[\\/] ]] ||
+        fail "BEADS_CI_WINDOWS_GIT is not an absolute Windows path"
+fi
+
+# shellcheck source=../../.buildflags
 source "$REPO_ROOT/.buildflags"
 # shellcheck source=lib/timing.sh
 source "$REPO_ROOT/scripts/ci/lib/timing.sh"
+[[ "${GOENV:-}" == "off" ]] ||
+    fail "GOENV must be disabled"
+[[ "${GOWORK:-}" == "off" ]] ||
+    fail "GOWORK must be disabled"
+[[ "${GOFLAGS:-}" == "-mod=readonly -tags=${BEADS_BUILD_TAGS}" ]] ||
+    fail "GOFLAGS does not enforce the protected readonly module contract"
 
 cd "$REPO_ROOT"
 
-ci_time "gofmt check" -- make fmt-check
+go_env_output=""
+if ! go_env_output="$("$BEADS_CI_GO" env GOOS GOARCH CGO_ENABLED)"; then
+    printf 'failed to snapshot GOOS, GOARCH, and CGO_ENABLED with go env\n' >&2
+    exit 1
+fi
+
+frozen_go_env=()
+while IFS= read -r value; do
+    frozen_go_env+=("$value")
+done <<<"$go_env_output"
+if [[ "${#frozen_go_env[@]}" -ne 3 ]]; then
+    printf 'go env returned an invalid target snapshot\n' >&2
+    exit 1
+fi
+
+frozen_goos="${frozen_go_env[0]}"
+frozen_goarch="${frozen_go_env[1]}"
+frozen_cgo_enabled="${frozen_go_env[2]}"
+if [[ ! "$frozen_goos" =~ ^[a-z0-9_]+$ ||
+      ! "$frozen_goarch" =~ ^[a-z0-9_]+$ ||
+      ! "$frozen_cgo_enabled" =~ ^[01]$ ]]; then
+    printf 'go env returned an invalid target tuple\n' >&2
+    exit 1
+fi
+[[ "$frozen_goos" == "${BEADS_CI_TARGET_GOOS:-}" &&
+   "$frozen_goarch" == "${BEADS_CI_TARGET_GOARCH:-}" &&
+   "$frozen_cgo_enabled" == "${BEADS_CI_TARGET_CGO_ENABLED:-}" ]] ||
+    fail "the selected target changed across the public Make boundary"
+
+run_linter() {
+    local goos="$1"
+    local goarch="$2"
+    local cgo_enabled="$3"
+
+    GOOS="$goos" \
+    GOARCH="$goarch" \
+    CGO_ENABLED="$cgo_enabled" \
+        "$BEADS_CI_GOLANGCI_LINT" \
+        run \
+        --config "$BEADS_CI_GOLANGCI_CONFIG" \
+        --modules-download-mode=readonly \
+        --timeout=5m \
+        --build-tags="$BEADS_BUILD_TAGS" \
+        ./...
+}
+
+run_format_check() {
+    local make_arguments=(
+        --no-print-directory
+        -f
+        Makefile
+        "CI_BASH=$BEADS_CI_BASH"
+        "CI_GOFMT=$BEADS_CI_GOFMT"
+        "CI_SED=$BEADS_CI_SED"
+        "GO_VERSION=$GO_VERSION"
+    )
+    if [[ "$BEADS_CI_EXPECTED_OUTER_OS" == "windows" ]]; then
+        make_arguments+=(
+            "WINDOWS_CMD_EXE=$BEADS_CI_WINDOWS_CMD"
+            "GIT_WINDOWS_EXE=$BEADS_CI_WINDOWS_GIT"
+            "CI_GIT=$BEADS_CI_WINDOWS_GIT"
+        )
+    else
+        make_arguments+=(
+            "CI_GIT=$BEADS_CI_GIT"
+        )
+    fi
+    make_arguments+=(fmt-check)
+    "$BEADS_CI_MAKE" "${make_arguments[@]}"
+}
+
+ci_time "gofmt check" -- run_format_check
 ci_time "golangci-lint" -- \
-    golangci-lint run --timeout=5m --build-tags=gms_pure_go ./...
+    run_linter "$frozen_goos" "$frozen_goarch" "$frozen_cgo_enabled"
+
+# Other target tuples may not load files guarded by //go:build windows && !cgo.
+# Cross-lint that non-CGO Windows build as part of the same required wrapper,
+# preserving the frozen architecture and avoiding a duplicate only when the
+# selected target already matches it exactly.
+if [[ "$frozen_goos" != "windows" || "$frozen_cgo_enabled" != "0" ]]; then
+    ci_time "golangci-lint (windows)" -- \
+        run_linter windows "$frozen_goarch" 0
+fi

--- a/scripts/pr_lint_ci_contract_test.go
+++ b/scripts/pr_lint_ci_contract_test.go
@@ -1,0 +1,112 @@
+package scripts_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestPRLintStockMacMakeUsesFixedInvocationLeaf(t *testing.T) {
+	hostScript := readPRLintContractFile(t, "scripts/ci/pr-lint-host.sh")
+	workflow := readPRLintContractFile(t, ".github/workflows/pr.yml")
+	contractDocs := map[string]string{
+		"engdocs/LINTING.md": readPRLintContractFile(t, "engdocs/LINTING.md"),
+		"engdocs/CI_CLEANUP_PLAN.md": readPRLintContractFile(
+			t,
+			"engdocs/CI_CLEANUP_PLAN.md",
+		),
+	}
+	refusalCountContracts := map[string]string{
+		"engdocs/LINTING.md":         "fifteen macOS Make/target/cleanup/producer refusals",
+		"engdocs/CI_CLEANUP_PLAN.md": "fifteen refusal cases",
+	}
+
+	for _, required := range []string{
+		`make_invocation_path="$make_candidate"`,
+		`[[ "$make_invocation_path" == "/usr/bin/make" ]] ||`,
+		`stock macOS GNU Make must be invoked through /usr/bin/make`,
+		`canonical=$make_path`,
+	} {
+		if !strings.Contains(hostScript, required) {
+			t.Fatalf("PR lint host script does not bind the stock macOS Make contract through %q", required)
+		}
+	}
+	for _, forbidden := range []string{
+		`[[ "$make_path" != "/usr/bin/make" ||`,
+		`[[ "$make_invocation_path" != "/usr/bin/make" ||`,
+		"apple-darwin",
+	} {
+		if strings.Contains(hostScript, forbidden) {
+			t.Fatalf("PR lint host script retained obsolete macOS Make authority %q", forbidden)
+		}
+	}
+	if !strings.Contains(workflow, "assert_refusal make-invocation-leaf") {
+		t.Fatal("PR workflow does not falsify an alternate path to the stock macOS Make executable")
+	}
+	for path, content := range contractDocs {
+		normalized := strings.Join(strings.Fields(content), " ")
+		for _, required := range []string{
+			"exact `/usr/bin/make` invocation leaf",
+			"exact first-line version `GNU Make 3.81`",
+			"free-form build banner",
+			refusalCountContracts[path],
+		} {
+			if !strings.Contains(normalized, required) {
+				t.Fatalf("%s does not bind the macOS Make contract through %q", path, required)
+			}
+		}
+		for _, forbidden := range []string{"apple-darwin", "fourteen refusal"} {
+			if strings.Contains(normalized, forbidden) {
+				t.Fatalf("%s retains obsolete macOS Make authority %q", path, forbidden)
+			}
+		}
+	}
+}
+
+func TestNativeToolchainPublishesTypedUTF8Payload(t *testing.T) {
+	workflow := readPRLintContractFile(t, ".github/workflows/pr.yml")
+	step := contractSection(
+		t,
+		workflow,
+		"      - name: Install native GNU Make and MinGW",
+		"      - name: Set up MSYS2 GNU Make",
+	)
+
+	for _, required := range []string{
+		`[string]$outputPayload = (`,
+		`"gcc={0}` + "`n" + `gxx={1}` + "`n" + `" -f`,
+		`[IO.File]::AppendAllText(`,
+		`[Text.UTF8Encoding]::new($false)`,
+	} {
+		if !strings.Contains(step, required) {
+			t.Fatalf("native toolchain step does not publish through %q", required)
+		}
+	}
+	if strings.Contains(step, "[IO.File]::AppendAllLines(") {
+		t.Fatal("native toolchain step retained the object-array AppendAllLines overload")
+	}
+}
+
+func readPRLintContractFile(t *testing.T, relativePath string) string {
+	t.Helper()
+	content, err := os.ReadFile(filepath.Join(sourceRepoRoot(t), filepath.FromSlash(relativePath)))
+	if err != nil {
+		t.Fatalf("read %s: %v", relativePath, err)
+	}
+	return string(content)
+}
+
+func contractSection(t *testing.T, content, startMarker, endMarker string) string {
+	t.Helper()
+	start := strings.Index(content, startMarker)
+	if start < 0 {
+		t.Fatalf("missing contract section start %q", startMarker)
+	}
+	remaining := content[start+len(startMarker):]
+	end := strings.Index(remaining, endMarker)
+	if end < 0 {
+		t.Fatalf("missing contract section end %q", endMarker)
+	}
+	return remaining[:end]
+}


### PR DESCRIPTION
## Summary

Make the public PR lint route select Windows-tagged non-CGO Go files on every host, and make a green required job prove which target, Make boundary, shell/path dialect, and tool identities actually ran.

Closes #4991.

PR #4981 cleared the two pre-existing Windows-only findings and supplied the clean baseline for this gate.

## What changes

- Keep one native-target lint pass, then add a mandatory `GOOS=windows CGO_ENABLED=0` whole-repository pass unless that is already the selected target.
- Route maintained lint callers through one public `make -f Makefile ci-pr-lint` contract.
- Bind Bash, Git, Go/gofmt, GNU Make, compiler, sed, and private `golangci-lint` identities before the lint child starts, and curate inherited Make, Bash, Git, and Go controls.
- Add required capability lanes for Linux, macOS arm64, native Windows, MSYS2-on-Windows, and Cygwin-on-Windows, with mandatory selection markers and CI Gate propagation.
- Install `golangci-lint` 2.10.1 into one private runner-temp directory and clean only its proved direct file/directory shape.
- Propagate a failing `gofmt` producer instead of accepting captured output as success.
- Keep contributor, agent, lint, CI-topology, cleanup, audit, formula, and freshness guidance synchronized with the maintained route.

This changes development and CI validation only; it adds no application runtime dependency.

## Hosted-run repairs

The first published generation failed closed and exposed two defects in the new hosted authority:

- Stock macOS `/usr/bin/make` resolves to an Xcode target. The repaired contract binds the original `/usr/bin/make` invocation leaf, proves the canonical target is executable, requires exact first-line `GNU Make 3.81`, and deliberately does not parse the mutable free-form build banner. A fifteenth refusal case rejects an alternate invocation leaf.
- Native Windows no longer relies on the hosted image's stale MinGW `PATH`. The install step binds the exact Chocolatey 16.1.0 `gcc.exe` and `g++.exe` leaves, checks version and target machine, and publishes their paths as one explicitly typed UTF-8-no-BOM payload. This replaces the failing `AppendAllLines(object[])` overload path.

The repair also gives Cygwin Git a private, process-scoped `safe.directory` configuration for the canonical workspace spelling instead of mutating runner-global state. Permanent Go structural tests reject the obsolete macOS banner authority, fourteen-case refusal count, untyped workflow-output path, and missing protected dependency.

## Why

The existing Ubuntu lint pass can be green without loading `//go:build windows` files. Before #4981, the equivalent Windows-target invocation exposed two unchecked `CloseHandle` findings that the required PR gate did not see.

The routing fix crosses Make, Bash, Go, Git, path-translation, compiler, and hosted-runner boundaries. The protected assertions prevent a green result produced by a different target, startup hook, Makefile, executable, compiler, Git ownership decision, or shell dialect than the workflow declares.

## Exact-head local validation

Candidate `add7951651469412987b9598deb48f59f1e95d53` passed:

- the complete `scripts` Go package in 30.498 seconds;
- the full integration-tagged `scripts` suite in 96.279 seconds;
- the native Windows public `ci-pr-lint` route with Go 1.26.5, GNU Make 4.4.1, MinGW 16.1.0, eleven mandatory routing cases, four authority refusals, and the nonzero-`gofmt` falsifier;
- native Windows/amd64/CGO and Windows/non-CGO golangci-lint passes with zero issues;
- actionlint, ShellCheck with sourced-file analysis, Bash syntax, and `go vet` for the affected scripts package; and
- canonical diff and whitespace hygiene.

An independent exact-head review found no remaining issue and confirmed that the rebuild retains the newer upstream Windows compiler-selection logic without conflicting with the lint authority.

These local results prove the source, native public route, parser, routing, and falsifier contracts available on this workstation. They do not substitute for the macOS, MSYS2, or Cygwin hosted boundaries below.

## Required post-publication proof

Every prior hosted generation belongs to a superseded head and is not reusable. A wholly new exact-`add7951651469412987b9598deb48f59f1e95d53` `pull_request` generation must complete all of these jobs successfully:

- `Build Artifacts` for the bound Linux public lint route;
- `PR Lint (wrapper timing)` for real macOS arm64 and stock GNU Make 3.81 semantics;
- `Windows Make shell (native)` for the exact Chocolatey compiler leaves, typed workflow-output handoff, Git-for-Windows Bash, and full native lint route;
- `Windows Make shell (msys2)` for real MSYS2 Make/shell/path semantics; and
- `Windows Make shell (cygwin)` for real Cygwin Make/shell/path and process-scoped Git ownership semantics.

Missing, skipped, cancelled, stale, wrong-head, failed, or ambiguously associated evidence blocks verification.

---

_codex-tui-gpt-5.6-sol-ultra on behalf of Ewen Cuthiell_
