### PR TITLE
test(docsmint): make missing staging path portable

### DIFF
--- a/tools/docsmint/docsmint_test.go
+++ b/tools/docsmint/docsmint_test.go
@@ -380,8 +380,9 @@ func TestRunFailsLoudlyWithoutStaging(t *testing.T) {
 	if err == nil {
 		t.Fatal("run() succeeded with no staging tree; want loud failure")
 	}
-	if !strings.Contains(err.Error(), "build/cli-docs") {
-		t.Errorf("error should name the missing staging dir: %v", err)
+	staging := filepath.Join(root, "build", "cli-docs")
+	if !strings.Contains(err.Error(), staging) {
+		t.Errorf("error should name the missing staging dir %q: %v", staging, err)
 	}
 }
 


### PR DESCRIPTION
## What

Make `tools/docsmint`'s missing-staging regression assert the exact native
staging path constructed with `filepath.Join`.

Fixes #5072

## Why

`run` correctly reports an absolute `filepath.Join`-derived path. The test
instead searched for the POSIX-only literal `build/cli-docs`, so it failed on
Windows when the valid diagnostic contained `build\cli-docs`.

This changes only the test assertion. Production diagnostics, staging
selection, and filesystem behavior are unchanged.

## Verification

Windows NT 10.0.26200, Go 1.26.5 `windows/amd64`:

```text
go test ./tools/docsmint -run '^TestRunFailsLoudlyWithoutStaging$' -count=1
ok github.com/steveyegge/beads/tools/docsmint

go test ./tools/docsmint -count=1
ok github.com/steveyegge/beads/tools/docsmint

./scripts/test.sh -run '^TestRunFailsLoudlyWithoutStaging$' ./tools/docsmint/...
ok github.com/steveyegge/beads/tools/docsmint

go vet ./tools/docsmint/...
clean
```

Additional local checks:

- `gofmt -d tools/docsmint/docsmint_test.go` produced no diff;
- `git diff --check` passed; and
- `GOOS=linux GOARCH=amd64 go test -c -o <temporary-path>
  ./tools/docsmint` succeeded.

The exact-head `PR Core (wrapper timing)` and `CI Gate / Required` checks
remain mandatory after publication as regression and aggregate gates. They are
not claimed as host-attestation evidence: the patch's portability argument is
the identical `filepath.Join` construction in production and the assertion,
the real Windows execution above, and the successful `linux/amd64`
cross-compilation.

---

_codex-tui-gpt-5.6-sol-ultra on behalf of Ewen Cuthiell_
