### PR TITLE
fix(dolt): recover persisted remotes in the GH#2118 cold-start window (wy-6k7f7)

### DIFF
--- a/cmd/bd/config_apply.go
+++ b/cmd/bd/config_apply.go
@@ -12,6 +12,7 @@ import (
 	"github.com/steveyegge/beads/internal/doltserver"
 	"github.com/steveyegge/beads/internal/git"
 	"github.com/steveyegge/beads/internal/metrics"
+	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/storage/dolt"
 	"github.com/steveyegge/beads/internal/storage/doltutil"
 )
@@ -217,6 +218,40 @@ func applyHooks(drifted bool, dryRun bool) ApplyResult {
 }
 
 // applyRemote ensures the Dolt origin remote matches federation.remote config.
+// originRemoteEvidence is the store surface currentOriginRemoteURL needs:
+// the SQL-visible remotes plus the on-disk persisted enumeration. The
+// concrete *dolt.DoltStore that applyRemote opens satisfies both directly —
+// no decorator peel needed here (unlike cmd paths holding the wired store).
+type originRemoteEvidence interface {
+	ListRemotes(ctx context.Context) ([]storage.RemoteInfo, error)
+	PersistedRemoteInfos() []storage.RemoteInfo
+}
+
+// currentOriginRemoteURL resolves the origin remote's URL from evidence, not
+// from the SQL listing alone: a freshly (auto-)started sql-server can report
+// an empty dolt_remotes while the remote is persisted on disk in
+// .dolt/repo_state.json (GH#2118, wy-6k7f7). Recovering the persisted URL
+// routes `bd config apply` into the same consistent/update legs it would
+// take after the window, instead of blind-adding over an invisible remote.
+// A failed listing returns the error — it is never evidence of "no remote".
+func currentOriginRemoteURL(ctx context.Context, st originRemoteEvidence) (string, error) {
+	remotes, err := st.ListRemotes(ctx)
+	if err != nil {
+		return "", err
+	}
+	for _, r := range remotes {
+		if r.Name == "origin" {
+			return r.URL, nil
+		}
+	}
+	for _, r := range st.PersistedRemoteInfos() {
+		if r.Name == "origin" {
+			return r.URL, nil
+		}
+	}
+	return "", nil
+}
+
 func applyRemote(drifted bool, dryRun bool) ApplyResult {
 	if !drifted {
 		return ApplyResult{
@@ -260,7 +295,7 @@ func applyRemote(drifted bool, dryRun bool) ApplyResult {
 	}
 	defer func() { _ = st.Close() }()
 
-	remotes, err := st.ListRemotes(ctx)
+	currentURL, err := currentOriginRemoteURL(ctx, st)
 	if err != nil {
 		return ApplyResult{
 			Check:   "remote",
@@ -268,13 +303,6 @@ func applyRemote(drifted bool, dryRun bool) ApplyResult {
 			Status:  applyStatusError,
 			Message: "Failed to list Dolt remotes",
 			Error:   err.Error(),
-		}
-	}
-	var currentURL string
-	for _, r := range remotes {
-		if r.Name == "origin" {
-			currentURL = r.URL
-			break
 		}
 	}
 

--- a/cmd/bd/config_apply_test.go
+++ b/cmd/bd/config_apply_test.go
@@ -1,10 +1,14 @@
 package main
 
 import (
+	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/steveyegge/beads/internal/storage"
 )
 
 func TestApplyHooksNoDrift(t *testing.T) {
@@ -344,4 +348,69 @@ func TestPrintApplyResults(t *testing.T) {
 	defer func() { os.Stdout = old }()
 	printApplyResults(results)
 	printApplyResults(nil)
+}
+
+// fakeOriginRemoteEvidence simulates the two evidence sources
+// currentOriginRemoteURL consults: the SQL-visible dolt_remotes listing and
+// the on-disk .dolt/repo_state.json enumeration.
+type fakeOriginRemoteEvidence struct {
+	listed    []storage.RemoteInfo
+	listErr   error
+	persisted []storage.RemoteInfo
+}
+
+func (f *fakeOriginRemoteEvidence) ListRemotes(ctx context.Context) ([]storage.RemoteInfo, error) {
+	return f.listed, f.listErr
+}
+
+func (f *fakeOriginRemoteEvidence) PersistedRemoteInfos() []storage.RemoteInfo {
+	return f.persisted
+}
+
+// TestCurrentOriginRemoteURL pins the wy-6k7f7 evidence rule for
+// `bd config apply`: an empty dolt_remotes listing alone is not proof there
+// is no origin — a cold-started sql-server hides a persisted remote
+// (GH#2118), and blind-adding over it was the defect. The SQL listing wins
+// when populated; the persisted enumeration is the fallback; a failed
+// listing is an error, never evidence.
+func TestCurrentOriginRemoteURL(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("listing_wins_when_populated", func(t *testing.T) {
+		url, err := currentOriginRemoteURL(ctx, &fakeOriginRemoteEvidence{
+			listed:    []storage.RemoteInfo{{Name: "origin", URL: "https://sql.example/repo"}},
+			persisted: []storage.RemoteInfo{{Name: "origin", URL: "https://disk.example/repo"}},
+		})
+		if err != nil || url != "https://sql.example/repo" {
+			t.Fatalf("got (%q, %v), want the SQL-visible URL", url, err)
+		}
+	})
+
+	t.Run("cold_start_recovers_persisted_origin", func(t *testing.T) {
+		url, err := currentOriginRemoteURL(ctx, &fakeOriginRemoteEvidence{
+			persisted: []storage.RemoteInfo{{Name: "origin", URL: "https://disk.example/repo"}},
+		})
+		if err != nil || url != "https://disk.example/repo" {
+			t.Fatalf("got (%q, %v), want the persisted on-disk URL", url, err)
+		}
+	})
+
+	t.Run("no_evidence_means_no_origin", func(t *testing.T) {
+		url, err := currentOriginRemoteURL(ctx, &fakeOriginRemoteEvidence{
+			persisted: []storage.RemoteInfo{{Name: "peer-mini", URL: "https://disk.example/other"}},
+		})
+		if err != nil || url != "" {
+			t.Fatalf("got (%q, %v), want empty with no error", url, err)
+		}
+	})
+
+	t.Run("list_failure_is_an_error_not_evidence", func(t *testing.T) {
+		_, err := currentOriginRemoteURL(ctx, &fakeOriginRemoteEvidence{
+			listErr:   errors.New("connection refused"),
+			persisted: []storage.RemoteInfo{{Name: "origin", URL: "https://disk.example/repo"}},
+		})
+		if err == nil {
+			t.Fatal("a failed listing must surface as an error, not fall through to disk")
+		}
+	})
 }

--- a/cmd/bd/dolt.go
+++ b/cmd/bd/dolt.go
@@ -209,11 +209,13 @@ func hasNoRemoteConfigured(ctx context.Context, st remoteLister) bool {
 // hasConfiguredRemote decides, from evidence, whether a rig has a Dolt remote
 // at all. It is the one decider for the push/sync no-remote question: both
 // hasNoRemoteConfigured (the `bd sync` / `bd dolt push|pull` exit-0 gate) and
-// adoptGitOriginRemoteForPush go through it. It is NOT yet the only reader of
-// that evidence in cmd/bd — `bd config apply`, ensureDoltRemote, and the
-// doctor/drift diagnostics still judge from len(ListRemotes) alone and have
-// the same cold-start hole; converging them is wy-6k7f7. Do not assume a new
-// remote-related decision is covered by this function: route it here.
+// adoptGitOriginRemoteForPush go through it. The MUTATING siblings —
+// `bd config apply`, ensureDoltRemote, and the git-protocol CLI push route —
+// consult the same persisted evidence via PersistedRemoteInfos (wy-6k7f7);
+// the read-only doctor/drift diagnostics still judge from len(ListRemotes)
+// alone and can report a false "no origin remote" during the cold-start
+// window. Do not assume a new remote-related decision is covered by this
+// function: route it here.
 //
 // Two sources of evidence, because dolt_remotes alone is not enough: a
 // server-mode rig whose sql-server has just cold-started can report an EMPTY
@@ -273,6 +275,37 @@ func persistedRemoteProberFor(st remoteLister) (persistedRemoteProber, bool) {
 		inner := u.Unwrap()
 		if inner == nil {
 			return nil, false
+		}
+		st = inner
+	}
+}
+
+// persistedRemoteInfoLister is the recovery-grade sibling of
+// persistedRemoteProber: stores that can enumerate the on-disk remotes
+// (name AND url) rather than only report their existence (server-mode
+// DoltStore). Callers use it in the GH#2118 cold-start window to act on the
+// invisible remote's actual URL instead of merely refusing (wy-6k7f7).
+type persistedRemoteInfoLister interface {
+	PersistedRemoteInfos() []storage.RemoteInfo
+}
+
+// persistedRemoteInfosFor finds the on-disk remote enumeration behind any
+// chain of storage decorators, peeling exactly like persistedRemoteProberFor
+// (a direct implementer is honored before any peeling, so test doubles work).
+// Returns nil when no store in the chain can enumerate persisted remotes —
+// embedded rigs, where GH#2118 cannot occur.
+func persistedRemoteInfosFor(st any) []storage.RemoteInfo {
+	for {
+		if lister, ok := st.(persistedRemoteInfoLister); ok {
+			return lister.PersistedRemoteInfos()
+		}
+		u, ok := st.(storage.Unwrapper)
+		if !ok {
+			return nil
+		}
+		inner := u.Unwrap()
+		if inner == nil {
+			return nil
 		}
 		st = inner
 	}
@@ -1212,6 +1245,17 @@ func ensureDoltRemote(ctx context.Context, st doltRemoteAddStore, name, url stri
 	}
 
 	existingURL := findDoltRemoteURL(remotes, name)
+	existingFromDiskOnly := false
+	if existingURL == "" {
+		// An empty listing is not proof the remote is absent: a freshly
+		// (auto-)started sql-server can report empty dolt_remotes while the
+		// remote is persisted on disk (GH#2118, wy-6k7f7). Recover the
+		// persisted URL so the add gets the same match/confirm treatment it
+		// would after the window, instead of silently writing over an
+		// invisible remote.
+		existingURL = findDoltRemoteURL(persistedRemoteInfosFor(st), name)
+		existingFromDiskOnly = existingURL != ""
+	}
 	if existingURL == "" {
 		if err := st.AddRemote(ctx, name, url); err != nil {
 			return doltRemoteAddResult{}, fmt.Errorf("add remote %s: %w", name, err)
@@ -1227,7 +1271,12 @@ func ensureDoltRemote(ctx context.Context, st doltRemoteAddStore, name, url stri
 		return doltRemoteAddResult{Canceled: true}, nil
 	}
 	if err := st.RemoveRemote(ctx, name); err != nil {
-		return doltRemoteAddResult{}, fmt.Errorf("remove existing remote %s: %w", name, err)
+		// A remote known only from disk may not be removable through a
+		// cold-started server that doesn't see it yet; the confirmed add
+		// below is what establishes the new URL either way.
+		if !existingFromDiskOnly {
+			return doltRemoteAddResult{}, fmt.Errorf("remove existing remote %s: %w", name, err)
+		}
 	}
 	if err := st.AddRemote(ctx, name, url); err != nil {
 		return doltRemoteAddResult{}, fmt.Errorf("add remote %s: %w", name, err)

--- a/cmd/bd/dolt_remote_add_test.go
+++ b/cmd/bd/dolt_remote_add_test.go
@@ -2,7 +2,9 @@ package main
 
 import (
 	"context"
+	"errors"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/steveyegge/beads/internal/storage"
@@ -94,4 +96,114 @@ func TestEnsureDoltRemoteDifferentURLReplacesExisting(t *testing.T) {
 	if !reflect.DeepEqual(store.calls, want) {
 		t.Fatalf("calls = %v, want %v", store.calls, want)
 	}
+}
+
+// fakeDoltRemoteAddStoreWithDisk simulates the GH#2118 cold-start window: the
+// SQL listing (embedded fake) can be empty while remotes are persisted on
+// disk. It implements persistedRemoteInfoLister directly, which
+// persistedRemoteInfosFor honors before any decorator peeling.
+type fakeDoltRemoteAddStoreWithDisk struct {
+	fakeDoltRemoteAddStore
+	persisted []storage.RemoteInfo
+	removeErr error
+}
+
+func (f *fakeDoltRemoteAddStoreWithDisk) PersistedRemoteInfos() []storage.RemoteInfo {
+	f.calls = append(f.calls, "persisted")
+	return append([]storage.RemoteInfo(nil), f.persisted...)
+}
+
+func (f *fakeDoltRemoteAddStoreWithDisk) RemoveRemote(ctx context.Context, name string) error {
+	if f.removeErr != nil {
+		f.calls = append(f.calls, "remove-fail "+name)
+		return f.removeErr
+	}
+	return f.fakeDoltRemoteAddStore.RemoveRemote(ctx, name)
+}
+
+// TestEnsureDoltRemoteColdStartSameURLIsNoop pins the wy-6k7f7 fence: an
+// empty dolt_remotes listing with the same remote persisted on disk (a
+// freshly started sql-server, GH#2118) must be treated as the existing
+// remote it is — an idempotent re-add writes nothing and asks nothing.
+func TestEnsureDoltRemoteColdStartSameURLIsNoop(t *testing.T) {
+	store := &fakeDoltRemoteAddStoreWithDisk{
+		persisted: []storage.RemoteInfo{
+			{Name: "origin", URL: "https://github.com/org/repo.git"},
+		},
+	}
+	prompted := false
+
+	result, err := ensureDoltRemote(context.Background(), store, "origin", "git+https://github.com/org/repo.git", func(surface, name, existingURL, newURL string) bool {
+		prompted = true
+		return true
+	})
+	if err != nil {
+		t.Fatalf("ensureDoltRemote: %v", err)
+	}
+	if result.Canceled || prompted {
+		t.Fatalf("cold-start same-URL re-add should be a silent no-op (canceled=%v prompted=%v)", result.Canceled, prompted)
+	}
+	if want := []string{"list", "persisted"}; !reflect.DeepEqual(store.calls, want) {
+		t.Fatalf("calls = %v, want %v (no write may reach the store)", store.calls, want)
+	}
+}
+
+// TestEnsureDoltRemoteColdStartDifferentURLPrompts pins that the invisible
+// persisted remote gets the SAME overwrite confirmation the visible one
+// would — before wy-6k7f7 an empty listing skipped the confirmation and the
+// add silently clobbered the persisted remote. A declined confirmation
+// writes nothing; a confirmed one proceeds even though the cold server
+// cannot remove a remote it does not see yet.
+func TestEnsureDoltRemoteColdStartDifferentURLPrompts(t *testing.T) {
+	t.Run("declined_writes_nothing", func(t *testing.T) {
+		store := &fakeDoltRemoteAddStoreWithDisk{
+			persisted: []storage.RemoteInfo{
+				{Name: "origin", URL: "git+https://github.com/org/old.git"},
+			},
+		}
+		confirmed := false
+		result, err := ensureDoltRemote(context.Background(), store, "origin", "git+https://github.com/org/new.git", func(surface, name, existingURL, newURL string) bool {
+			confirmed = true
+			if existingURL != "git+https://github.com/org/old.git" {
+				t.Fatalf("confirm existingURL = %q, want the persisted on-disk URL", existingURL)
+			}
+			return false
+		})
+		if err != nil {
+			t.Fatalf("ensureDoltRemote: %v", err)
+		}
+		if !confirmed {
+			t.Fatal("cold-start URL disagreement should prompt for overwrite")
+		}
+		if !result.Canceled {
+			t.Fatal("declined overwrite should cancel")
+		}
+		for _, call := range store.calls {
+			if strings.HasPrefix(call, "add") || strings.HasPrefix(call, "remove") {
+				t.Fatalf("declined overwrite wrote to the store: %v", store.calls)
+			}
+		}
+	})
+
+	t.Run("confirmed_tolerates_unremovable_invisible_remote", func(t *testing.T) {
+		store := &fakeDoltRemoteAddStoreWithDisk{
+			persisted: []storage.RemoteInfo{
+				{Name: "origin", URL: "git+https://github.com/org/old.git"},
+			},
+			removeErr: errors.New("unknown remote: origin"),
+		}
+		result, err := ensureDoltRemote(context.Background(), store, "origin", "git+https://github.com/org/new.git", func(surface, name, existingURL, newURL string) bool {
+			return true
+		})
+		if err != nil {
+			t.Fatalf("ensureDoltRemote: %v", err)
+		}
+		if result.Canceled {
+			t.Fatal("confirmed overwrite should not cancel")
+		}
+		want := []string{"list", "persisted", "remove-fail origin", "add origin git+https://github.com/org/new.git"}
+		if !reflect.DeepEqual(store.calls, want) {
+			t.Fatalf("calls = %v, want %v", store.calls, want)
+		}
+	})
 }

--- a/internal/storage/dolt/federation.go
+++ b/internal/storage/dolt/federation.go
@@ -201,6 +201,23 @@ func (s *DoltStore) hasPersistedCLIRemote() bool {
 // trust an empty dolt_remotes table at cold start: the remote-migrate gate
 // and the push/pull "no remote configured" exit-0 skip (bd-578h9.10).
 func (s *DoltStore) HasPersistedRemote() bool {
+	return len(s.PersistedRemoteInfos()) > 0
+}
+
+// PersistedRemoteInfos returns the remotes persisted on disk in
+// .dolt/repo_state.json — names AND urls — searching the same directories in
+// the same order as HasPersistedRemote: the database CLI directory first,
+// then the dolt server root (GH#2118). The first directory that yields any
+// remotes wins, mirroring HasPersistedRemote's first-hit semantics.
+//
+// Callers in the GH#2118 cold-start window use this to RECOVER the invisible
+// remote rather than merely detect it: a freshly (auto-)started sql-server
+// can report an empty dolt_remotes even though the remote is persisted on
+// disk, so an empty listing is a reporting artifact, not an unconfigured rig
+// (wy-6k7f7). Read/parse failures are logged and skipped, matching the old
+// HasPersistedRemote behavior — callers only consult this after a SUCCESSFUL
+// (empty) ListRemotes, so a read failure here never masquerades as evidence.
+func (s *DoltStore) PersistedRemoteInfos() []storage.RemoteInfo {
 	cliDir := s.CLIDir()
 	dirs := []string{cliDir}
 	if s.dbPath != "" && s.dbPath != cliDir {
@@ -218,10 +235,10 @@ func (s *DoltStore) HasPersistedRemote() bool {
 			continue
 		}
 		if len(remotes) > 0 {
-			return true
+			return remotes
 		}
 	}
-	return false
+	return nil
 }
 
 // RemoveRemote removes a configured remote.

--- a/internal/storage/dolt/remote_routing_test.go
+++ b/internal/storage/dolt/remote_routing_test.go
@@ -6,6 +6,11 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+
+	"github.com/steveyegge/beads/internal/storage/doltutil"
+	"github.com/steveyegge/beads/internal/testutil"
 )
 
 func TestEnsureMatchingCLIRemoteSurfacesValidationErrors(t *testing.T) {
@@ -165,4 +170,93 @@ func TestCLIRoutingFallsBackToSQLWhenNoCLIDir(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestPrepareCLIRouteForGitProtocolColdStartWindow pins the wy-6k7f7 recovery
+// in the GH#2118 cold-start window: a freshly (auto-)started sql-server
+// reports an EMPTY dolt_remotes even though the remote is persisted on disk
+// in .dolt/repo_state.json. The route decider must consult the persisted
+// enumeration instead of treating the empty listing as proof:
+//   - a persisted git-protocol remote routes over the CLI (the push proceeds
+//     — full recovery, the CLI transport never needed the SQL listing);
+//   - a persisted non-git remote would need the SQL route the cold server
+//     refuses, so the decider fails with the cold-start explanation instead
+//     of letting DOLT_PUSH emit a bare "remote not found";
+//   - nothing persisted keeps today's (false, nil) SQL fallback.
+//
+// Needs the dolt binary (real CLI repo for remote materialization checks)
+// plus sqlmock for the empty server-side listing; no test server.
+func TestPrepareCLIRouteForGitProtocolColdStartWindow(t *testing.T) {
+	testutil.RequireDoltBinary(t)
+	ctx := context.Background()
+
+	newColdStore := func(t *testing.T) *DoltStore {
+		t.Helper()
+		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+		if err != nil {
+			t.Fatalf("sqlmock: %v", err)
+		}
+		t.Cleanup(func() { _ = db.Close() })
+		// Every ListRemotes in these scenarios sees the cold server's empty
+		// dolt_remotes.
+		mock.MatchExpectationsInOrder(false)
+		for i := 0; i < 4; i++ {
+			mock.ExpectQuery("SELECT name, url FROM dolt_remotes").
+				WillReturnRows(sqlmock.NewRows([]string{"name", "url"}))
+		}
+		store := &DoltStore{
+			serverMode: true,
+			dbPath:     t.TempDir(),
+			database:   "testdb",
+			remote:     "origin",
+			db:         db,
+		}
+		initLocalDoltRepoForRemote(t, store.CLIDir())
+		return store
+	}
+
+	t.Run("persisted_git_protocol_remote_recovers_cli_route", func(t *testing.T) {
+		store := newColdStore(t)
+		const url = "git+ssh://git@example.com/org/repo.git"
+		if err := doltutil.AddCLIRemote(store.CLIDir(), "origin", url); err != nil {
+			t.Fatalf("AddCLIRemote: %v", err)
+		}
+
+		useCLI, err := store.prepareCLIRouteForGitProtocol(ctx, "origin")
+		if err != nil {
+			t.Fatalf("prepareCLIRouteForGitProtocol: %v", err)
+		}
+		if !useCLI {
+			t.Fatal("persisted git-protocol remote should recover the CLI route in the cold-start window")
+		}
+	})
+
+	t.Run("persisted_non_git_remote_fails_with_cold_start_hint", func(t *testing.T) {
+		store := newColdStore(t)
+		if err := doltutil.AddCLIRemote(store.CLIDir(), "origin", "https://doltremoteapi.dolthub.com/org/repo"); err != nil {
+			t.Fatalf("AddCLIRemote: %v", err)
+		}
+
+		_, err := store.prepareCLIRouteForGitProtocol(ctx, "origin")
+		if err == nil {
+			t.Fatal("persisted non-git remote in the window should fail with the cold-start explanation, not fall to a bare SQL 'remote not found'")
+		}
+		for _, want := range []string{"GH#2118", "persisted on disk"} {
+			if !strings.Contains(err.Error(), want) {
+				t.Fatalf("error %q should contain %q", err.Error(), want)
+			}
+		}
+	})
+
+	t.Run("nothing_persisted_keeps_sql_fallback", func(t *testing.T) {
+		store := newColdStore(t)
+
+		useCLI, err := store.prepareCLIRouteForGitProtocol(ctx, "origin")
+		if err != nil {
+			t.Fatalf("prepareCLIRouteForGitProtocol: %v", err)
+		}
+		if useCLI {
+			t.Fatal("no remote anywhere should keep the SQL fallback, not invent a CLI route")
+		}
+	})
 }

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -2790,6 +2790,25 @@ func (s *DoltStore) prepareCLIRouteForGitProtocol(ctx context.Context, remote st
 			return true, nil
 		}
 	}
+	// Not visible in dolt_remotes — but that is not proof it is absent: a
+	// freshly (auto-)started sql-server can report an empty dolt_remotes
+	// while the remote is persisted on disk (GH#2118, wy-6k7f7). Recover the
+	// persisted truth: a git-protocol remote routes over the CLI anyway, so
+	// the push can proceed; a non-git remote would need the SQL route, which
+	// the cold server would refuse with a bare "remote not found" — fail
+	// with the cold-start explanation instead.
+	for _, r := range s.PersistedRemoteInfos() {
+		if r.Name != remote {
+			continue
+		}
+		if !doltutil.IsGitProtocolURL(r.URL) {
+			return false, fmt.Errorf("remote %q (%s) is persisted on disk but not yet visible to this sql-server (GH#2118 cold start); retry shortly, or restart the dolt sql-server if it persists", remote, r.URL)
+		}
+		if err := s.ensureMatchingCLIRemote(remote, r.URL); err != nil {
+			return false, fmt.Errorf("remote %q uses git protocol and requires CLI routing: %w", remote, err)
+		}
+		return true, nil
+	}
 	return false, nil
 }
 


### PR DESCRIPTION
## Problem (wyvern wy-6k7f7, filed by austen from the wy-82hc5 adversarial pass)

A freshly (auto-)started sql-server can report an **empty `dolt_remotes`** while the remote is persisted on disk in `.dolt/repo_state.json` (GH#2118). wy-xtv17/wy-82hc5 taught the push/sync no-remote gate (`hasConfiguredRemote`) to consult the on-disk probe, but three **mutating** siblings still decided "no remote" from `len(ListRemotes)` alone:

1. `bd config apply` blind-added the federation remote over the invisible one.
2. `bd dolt remote add` (`ensureDoltRemote`): an empty listing made `existingURL == ""`, so the URL-disagreement confirmation was skipped and the add silently clobbered the persisted remote.
3. `prepareCLIRouteForGitProtocol` fell back to SQL `DOLT_PUSH`, which the cold server refuses with a bare `remote origin not found`.

## Fix: recovery, not just detection

The on-disk evidence carries **URLs**, not just existence — so the window is recoverable:

- New `DoltStore.PersistedRemoteInfos()` exposes the persisted name+URL enumeration with `HasPersistedRemote`'s exact directory-search semantics (`HasPersistedRemote` is now derived from it). Embedded rigs return nil — GH#2118 is a sql-server phenomenon.
- New `persistedRemoteInfosFor` peels storage decorators exactly like `persistedRemoteProberFor` (direct implementers honored first, so test doubles work).
- **config apply**: `currentOriginRemoteURL` resolves origin from evidence — SQL listing first, persisted enumeration as fallback, a failed listing stays an error — routing apply into the same consistent/update legs it takes after the window.
- **remote add**: the idempotent re-add of the persisted URL is a no-op; a real disagreement gets the same confirm flow as a visible remote; a confirmed overwrite tolerates the cold server refusing to remove a remote it can't see yet (the add establishes the new URL).
- **push route**: a persisted git-protocol remote recovers the CLI route outright — the CLI transport never needed the SQL listing, so **the push proceeds**; a persisted non-git remote fails with the cold-start explanation instead of the bare `remote not found` (the loud-beats-silent trade from wy-xtv17 kept, with better words — the bead's explicit ask).

Read-only doctor/drift diagnostics still judge from the listing alone (they misreport, they don't mutate) — noted in `hasConfiguredRemote`'s doc comment and tracked as the bead's lower-priority tail.

## Tests

- `TestEnsureDoltRemoteColdStartSameURLIsNoop` / `...DifferentURLPrompts` (declined writes nothing; confirmed tolerates the unremovable invisible remote) — fake store implementing the new lister directly.
- `TestCurrentOriginRemoteURL` — listing wins when populated; cold-start recovers persisted origin; no evidence → no origin; **list failure is an error, never evidence**.
- `TestPrepareCLIRouteForGitProtocolColdStartWindow` — sqlmock empty listing + real CLI repo: git-protocol recovers the route; non-git fails naming GH#2118; nothing persisted keeps the SQL fallback.

## Acceptance (as filed on the bead, verified)

`go build ./...` + `go vet ./...` rc=0; `go test ./internal/storage/dolt/ -count=1` ok; `go test ./cmd/bd/ -count=1 -timeout 40m` **ok in 435s**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EF8QbCbF6JnTuoCKvu9xiG