### PR TITLE
fix(release): regenerate and gate the MCP uv.lock on version bumps

### DIFF
--- a/scripts/check-versions.sh
+++ b/scripts/check-versions.sh
@@ -59,6 +59,34 @@ check_version "npm-package/package.json" \
     "$(jq -r '.version' npm-package/package.json 2>/dev/null)" \
     "npm package.json"
 
+# The release workflow's MCP package gate runs `uv sync --locked`, so a stale
+# lockfile fails the release only in the tag-triggered run — after the tag
+# exists and can no longer be rewritten (this burned the v1.1.1 tag; v1.1.0
+# lost its first run the same way). Gate it here so the release-tag pre-push
+# hook and CI refuse the stale lock before a tag exists. The pinned-version
+# check is dependency-free; the fuller `uv lock --check` runs when uv is
+# available and also catches dependency edits made without a relock.
+#
+# uv.lock records the PEP 440-normalized version (1.1.0-rc.1 → 1.1.0rc1), so
+# normalize the canonical form before comparing.
+LOCK_EXPECTED=$(printf '%s' "$CANONICAL" | sed -E 's/-rc\.?/rc/')
+LOCK_VERSION=$(awk -F '"' '/^name = "beads-mcp"$/ { found=1; next } found && /^version = / { print $2; exit }' integrations/beads-mcp/uv.lock 2>/dev/null)
+if [ "$LOCK_VERSION" != "$LOCK_EXPECTED" ]; then
+    echo -e "${RED}❌ MCP uv.lock (beads-mcp pin): ${LOCK_VERSION:-missing} (expected $LOCK_EXPECTED) — run: uv lock --directory integrations/beads-mcp${NC}"
+    MISMATCH=1
+else
+    echo -e "${GREEN}✓ MCP uv.lock (beads-mcp pin): $LOCK_VERSION${NC}"
+fi
+
+if command -v uv >/dev/null 2>&1; then
+    if uv lock --check --directory integrations/beads-mcp >/dev/null 2>&1; then
+        echo -e "${GREEN}✓ MCP uv.lock: fresh (uv lock --check)${NC}"
+    else
+        echo -e "${RED}❌ MCP uv.lock: stale — run: uv lock --directory integrations/beads-mcp${NC}"
+        MISMATCH=1
+    fi
+fi
+
 # Hook templates are now generated dynamically by cmd/bd/hooks.go using the
 # Version constant from version.go, so no separate file check is needed.
 # (Previously checked cmd/bd/templates/hooks/pre-commit which no longer exists.)

--- a/scripts/update-versions.sh
+++ b/scripts/update-versions.sh
@@ -105,6 +105,25 @@ update_file ".claude-plugin/marketplace.json" "\"version\": \"$CURRENT_VERSION\"
 echo "  • integrations/beads-mcp/*"
 update_file "integrations/beads-mcp/pyproject.toml" "version = \"$CURRENT_VERSION\"" "version = \"$NEW_VERSION\""
 update_file "integrations/beads-mcp/src/beads_mcp/__init__.py" "__version__ = \"$CURRENT_VERSION\"" "__version__ = \"$NEW_VERSION\""
+# The release workflow's MCP package gate runs `uv sync --locked`, so a
+# pyproject bump without a lock refresh fails the release only in the
+# tag-triggered run — after the tag exists and can no longer be rewritten.
+# That cost v1.1.0 and v1.1.2 their first release runs and burned the v1.1.1
+# tag outright. Regenerate the lock as part of the bump. A failure here must
+# not abort the bump half-applied (set -e): warn and let check-versions.sh
+# hold the gate.
+if command -v uv >/dev/null 2>&1; then
+    echo "  • integrations/beads-mcp/uv.lock"
+    if ! uv lock --directory integrations/beads-mcp; then
+        echo -e "${RED}✗ uv lock failed — integrations/beads-mcp/uv.lock NOT refreshed.${NC}"
+        echo "  Fix and rerun before tagging, or check-versions.sh and the release MCP gate will fail:"
+        echo "    uv lock --directory integrations/beads-mcp"
+    fi
+else
+    echo -e "${RED}✗ uv not found — integrations/beads-mcp/uv.lock NOT refreshed.${NC}"
+    echo "  Run this before tagging, or check-versions.sh and the release MCP gate will fail:"
+    echo "    uv lock --directory integrations/beads-mcp"
+fi
 
 # 4. npm package
 echo "  • npm-package/package.json"


### PR DESCRIPTION
## Why

The release workflow's MCP package gate runs `uv sync --locked`, but a version bump via `scripts/update-versions.sh` edits `integrations/beads-mcp/pyproject.toml` without regenerating `uv.lock`, and no pre-tag gate checks the lock at all. A stale lock therefore only surfaces in the tag-triggered release run — after the tag exists and can no longer be rewritten (protected `v*` tags).

This has now cost three release runs:

- v1.1.0's first run failed on it (fixed in-flight by the "refresh MCP lock for v1.1.0" commit, 8e4e59d39).
- v1.1.1's run (30212687110) died on it with nothing published, and because the tag was already up and immutable, the number was burned entirely.
- v1.1.2 shipped only after manually refreshing the lock.

## What

Two-part fix so the failure can neither be created nor reach a tag:

1. **`scripts/update-versions.sh`** runs `uv lock` as part of the MCP bump when `uv` is available. If `uv` is missing or the lock fails, it warns loudly with the exact command and completes the rest of the bump (aborting half-applied under `set -e` would be worse than a warned-stale lock, since the gate below still holds).
2. **`scripts/check-versions.sh`** gains a dependency-free check that the `beads-mcp` version pinned in `uv.lock` matches the canonical version, plus a fuller `uv lock --check` freshness pass when `uv` is available (also catches dependency edits made without a relock). Both the release-tag pre-push hook and the release workflow's `verify-version-consistency` job run this script, so a stale lock is refused before a tag exists.

One wrinkle handled: `uv.lock` stores the PEP 440-normalized version (`1.1.0-rc.1` → `1.1.0rc1`), so the pin comparison normalizes `-rc.N` before comparing — RC releases pass, as they do today with `uv sync --locked`.

## Testing

All on this branch, locally:

- Clean tree: `check-versions.sh` passes (both new checks green).
- Stale pin injected into `uv.lock`: both checks fail, exit 1.
- Stable round-trip (`update-versions.sh 1.1.1`): lock follows to 1.1.1, check passes.
- RC round-trip (`update-versions.sh 1.1.1-rc.1`): lock records `1.1.1rc1`, normalized check passes.
- `uv` absent from PATH: bump completes with the loud warning and all later files still updated; `check-versions.sh` still catches the stale pin dependency-free and exits 1.

Tracking: coordination bead mybd-6vbo (discovered during the v1.1.2 hotfix, see #4380 for the release it shipped in).

_claude-fable-5-xhigh on behalf of maphew_
