### PR TITLE
ci(lint): cross-lint Windows-tagged Go, fix fmt-check exit status, pin golangci-lint (core of #5075)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -977,9 +977,11 @@ jobs:
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9
+        env:
+          GOWORK: "off"
         with:
-          version: latest
-          args: --timeout=5m --build-tags=gms_pure_go
+          version: v2.10.1
+          args: --config=.golangci.yml --modules-download-mode=readonly --timeout=5m --build-tags=gms_pure_go
 
   test-nix:
     name: Test Nix Flake

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -589,9 +589,11 @@ jobs:
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9
+        env:
+          GOWORK: "off"
         with:
-          version: latest
-          args: --timeout=5m --build-tags=gms_pure_go
+          version: v2.10.1
+          args: --config=.golangci.yml --modules-download-mode=readonly --timeout=5m --build-tags=gms_pure_go
 
   windows-make-shell:
     name: Windows Make shell (${{ matrix.host }})

--- a/Makefile
+++ b/Makefile
@@ -268,6 +268,11 @@ fmt:
 fmt-check:
 	@echo "Checking Go formatting..."
 	@UNFORMATTED=$$(gofmt -l .); \
+	status=$$?; \
+	if [ "$$status" -ne 0 ]; then \
+		echo "gofmt failed while checking formatting" >&2; \
+		exit "$$status"; \
+	fi; \
 	if [ -n "$$UNFORMATTED" ]; then \
 		echo "The following files are not properly formatted:"; \
 		echo "$$UNFORMATTED"; \

--- a/scripts/ci/pr-lint.sh
+++ b/scripts/ci/pr-lint.sh
@@ -15,4 +15,17 @@ cd "$REPO_ROOT"
 
 ci_time "gofmt check" -- make fmt-check
 ci_time "golangci-lint" -- \
-    golangci-lint run --timeout=5m --build-tags=gms_pure_go ./...
+    golangci-lint run --config=.golangci.yml --modules-download-mode=readonly \
+        --timeout=5m --build-tags=gms_pure_go ./...
+
+# Other target tuples may not load files guarded by //go:build windows && !cgo.
+# Cross-lint that non-CGO Windows build too, unless the native target above
+# already matches it exactly.
+native_goos="$(go env GOOS)"
+native_cgo_enabled="$(go env CGO_ENABLED)"
+if [[ "$native_goos" != "windows" || "$native_cgo_enabled" != "0" ]]; then
+    ci_time "golangci-lint (windows)" -- \
+        env GOOS=windows GOARCH=amd64 CGO_ENABLED=0 GOWORK=off \
+            golangci-lint run --config=.golangci.yml --modules-download-mode=readonly \
+                --timeout=5m --build-tags=gms_pure_go ./...
+fi


### PR DESCRIPTION
## What

The minimal core of #5075, extracted per its review (split-merge) so the lint gap stops waiting on the larger discussion:

- `scripts/ci/pr-lint.sh`: a second golangci-lint pass under `GOOS=windows GOARCH=amd64 CGO_ENABLED=0 GOWORK=off` (skipped if the native target already matches) — the 15 `go:build windows` files in the tree were previously never linted. Closes #4991.
- `Makefile` `fmt-check`: propagate gofmt's exit status; previously a gofmt parse failure produced an empty file list and a green check. Verified with teeth (syntactically broken file → exit 2).
- Pin `golangci-lint-action` `version: latest` → `v2.10.1` in `pr.yml`/`main.yml` (the `go install` paths were already pinned), and add `--config=.golangci.yml --modules-download-mode=readonly` + `GOWORK=off` to the lint invocations.

## Why

#4991 is real: Windows-tagged Go escaped every lint pass. ecuthiell found the gap and wrote the right fix inside #5075; the review there concluded the fix should land now while the PR's host-identity-binding machinery (~2.7k lines, currently red on two deterministic bugs) is reworked separately. Attribution preserved via `Co-authored-by`; the follow-up gate list for the remainder is tracked maintainer-side.

## Verification

- `GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go build -tags gms_pure_go ./...` clean on main.
- The new windows lint pass run for real locally: `0 issues.`
- `make fmt-check` teeth test: broken file → exit 2; clean tree → exit 0.
- `bash -n` + YAML parse checks on all touched workflows.

_claude-fable-5-medium on behalf of maphew_
