### PR TITLE
fix(lint): check deferred windows.CloseHandle returns (errcheck)

### DIFF
--- a/internal/procid/procid_windows.go
+++ b/internal/procid/procid_windows.go
@@ -32,7 +32,7 @@ func Capture(pid int) (Token, error) {
 	if err != nil {
 		return "", fmt.Errorf("procid: open process %d: %w", pid, err)
 	}
-	defer windows.CloseHandle(process)
+	defer func() { _ = windows.CloseHandle(process) }()
 	return tokenForProcess(process)
 }
 
@@ -44,7 +44,7 @@ func Verify(pid int, tok Token) (bool, error) {
 		}
 		return false, fmt.Errorf("procid: open process %d: %w", pid, err)
 	}
-	defer windows.CloseHandle(process)
+	defer func() { _ = windows.CloseHandle(process) }()
 	current, err := tokenForProcess(process)
 	if err != nil {
 		if errors.Is(err, errProcessExited) {

--- a/internal/storage/dbproxy/proxy/process_executable_windows.go
+++ b/internal/storage/dbproxy/proxy/process_executable_windows.go
@@ -18,7 +18,7 @@ func processExecutableBasename(pid int) (basename string, gone bool, err error) 
 		}
 		return "", false, err
 	}
-	defer windows.CloseHandle(process)
+	defer func() { _ = windows.CloseHandle(process) }()
 
 	buffer := make([]uint16, 32768)
 	size := uint32(len(buffer))


### PR DESCRIPTION
## Why

Main is red at e2dd121f4: the windows lint pass (Build Artifacts / PR Lint) flags `Error return value of windows.CloseHandle is not checked (errcheck)` at three sites in `internal/procid/procid_windows.go` and `internal/storage/dbproxy/proxy/process_executable_windows.go`, introduced with #5013.

## What

Switch the three bare `defer windows.CloseHandle(...)` calls to the convention already used everywhere else in the tree (`doltserver_windows.go`, `synclock_windows.go`, and #5013's own non-deferred sites): `defer func() { _ = windows.CloseHandle(...) }()`.

## Verification

`GOOS=windows go build` of both packages and `golangci-lint run` clean; committed diff verified to contain both files.

Stop-the-line per Base-Branch Health.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

_claude-fable-5-high on behalf of matt wilkie_
