### PR TITLE
feat(dolt): make the shared pool's per-I/O read/write deadlines configurable (bd-vz0y9)

### DIFF
--- a/internal/config/yaml_config.go
+++ b/internal/config/yaml_config.go
@@ -80,9 +80,11 @@ var YamlOnlyKeys = map[string]bool{
 	"import.path": true,
 
 	// Dolt server settings
-	"dolt.shared-server": true, // Shared Dolt server at ~/.beads/shared-server/ (GH#2377)
-	"dolt.max-conns":     true, // Connection pool size override (default 10, GH#3140)
-	"dolt.debug":         true, // Debug-mode dolt sql-server: --loglevel=debug + --prof cpu
+	"dolt.shared-server":      true, // Shared Dolt server at ~/.beads/shared-server/ (GH#2377)
+	"dolt.max-conns":          true, // Connection pool size override (default 10, GH#3140)
+	"dolt.pool-read-timeout":  true, // Pool per-I/O read deadline override (default 10s, bd-vz0y9)
+	"dolt.pool-write-timeout": true, // Pool per-I/O write deadline override (default 10s, bd-vz0y9)
+	"dolt.debug":              true, // Debug-mode dolt sql-server: --loglevel=debug + --prof cpu
 
 	// Secrets: tokens and API keys must NOT be stored in the Dolt database
 	// because that data is pushed to remotes, triggering secret-scanning

--- a/internal/storage/dolt/open.go
+++ b/internal/storage/dolt/open.go
@@ -301,6 +301,23 @@ func applyResolvedConfig(ctx context.Context, beadsDir string, fileCfg *configfi
 		}
 	}
 
+	// Pool per-I/O deadlines: env var > config.yaml > caller override > default
+	// (10s, see buildServerDSN). The default fast-fail is right for healthy
+	// local servers; overloaded shared-server deployments raise it so ordinary
+	// queries stop dying with "i/o timeout" under load (bd-vz0y9).
+	if cfg.PoolReadTimeout == 0 {
+		cfg.PoolReadTimeout = timeoutFromEnv("BEADS_DOLT_POOL_READ_TIMEOUT", 0)
+	}
+	if cfg.PoolReadTimeout == 0 {
+		cfg.PoolReadTimeout = parseTimeout(config.GetString("dolt.pool-read-timeout"), 0)
+	}
+	if cfg.PoolWriteTimeout == 0 {
+		cfg.PoolWriteTimeout = timeoutFromEnv("BEADS_DOLT_POOL_WRITE_TIMEOUT", 0)
+	}
+	if cfg.PoolWriteTimeout == 0 {
+		cfg.PoolWriteTimeout = parseTimeout(config.GetString("dolt.pool-write-timeout"), 0)
+	}
+
 	return nil
 }
 

--- a/internal/storage/dolt/open.go
+++ b/internal/storage/dolt/open.go
@@ -301,7 +301,7 @@ func applyResolvedConfig(ctx context.Context, beadsDir string, fileCfg *configfi
 		}
 	}
 
-	// Pool per-I/O deadlines: env var > config.yaml > caller override > default
+	// Pool per-I/O deadlines: caller override > env var > config.yaml > default
 	// (10s, see buildServerDSN). The default fast-fail is right for healthy
 	// local servers; overloaded shared-server deployments raise it so ordinary
 	// queries stop dying with "i/o timeout" under load (bd-vz0y9).

--- a/internal/storage/dolt/open_test.go
+++ b/internal/storage/dolt/open_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/steveyegge/beads/internal/configfile"
 	"github.com/steveyegge/beads/internal/doltserver"
@@ -368,6 +369,36 @@ func TestApplyResolvedConfig(t *testing.T) {
 		}
 		if cfg.ServerUser != "custom" {
 			t.Fatalf("ServerUser override lost: %q", cfg.ServerUser)
+		}
+	})
+
+	t.Run("pool timeouts populate from env vars (bd-vz0y9)", func(t *testing.T) {
+		t.Setenv("BEADS_DOLT_POOL_READ_TIMEOUT", "90s")
+		t.Setenv("BEADS_DOLT_POOL_WRITE_TIMEOUT", "45")
+		cfg := &Config{}
+
+		if err := applyResolvedConfig(context.Background(), t.TempDir(), &configfile.Config{Backend: configfile.BackendDolt}, cfg); err != nil {
+			t.Fatalf("applyResolvedConfig: %v", err)
+		}
+
+		if cfg.PoolReadTimeout != 90*time.Second {
+			t.Fatalf("PoolReadTimeout = %v, want 90s", cfg.PoolReadTimeout)
+		}
+		if cfg.PoolWriteTimeout != 45*time.Second {
+			t.Fatalf("PoolWriteTimeout = %v, want 45s (bare number = seconds)", cfg.PoolWriteTimeout)
+		}
+	})
+
+	t.Run("caller-set pool timeouts win over env vars", func(t *testing.T) {
+		t.Setenv("BEADS_DOLT_POOL_READ_TIMEOUT", "90s")
+		cfg := &Config{PoolReadTimeout: 2 * time.Minute}
+
+		if err := applyResolvedConfig(context.Background(), t.TempDir(), &configfile.Config{Backend: configfile.BackendDolt}, cfg); err != nil {
+			t.Fatalf("applyResolvedConfig: %v", err)
+		}
+
+		if cfg.PoolReadTimeout != 2*time.Minute {
+			t.Fatalf("PoolReadTimeout = %v, want caller's 2m", cfg.PoolReadTimeout)
 		}
 	})
 }

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -396,6 +396,17 @@ type Config struct {
 	// connection before the server reaps it server-side; otherwise the next
 	// query handed a server-reaped connection fails with "invalid connection".
 	ConnMaxIdleTime time.Duration
+
+	// PoolReadTimeout / PoolWriteTimeout override the per-I/O read/write
+	// deadlines on shared-pool connections (0 = default 10s each; see
+	// buildServerDSN). The default's fast-fail is right for a healthy local
+	// server, but on an overloaded shared server it kills ordinary queries
+	// mid-flight ("client connection went away", wy-b72dj/bd-vz0y9); raising
+	// it is the intended relief valve for such deployments. Known-long
+	// operations should not lean on this — route them through
+	// execWithLongTimeout/openLongTimeoutConn instead.
+	PoolReadTimeout  time.Duration
+	PoolWriteTimeout time.Duration
 }
 
 // Defaults for the *sql.DB connection pool. Exported for tests/callers that
@@ -410,6 +421,14 @@ const (
 	// before the server reaps it; this prevents the next read from picking up a
 	// server-closed connection and failing with "invalid connection".
 	defaultConnMaxIdleTime = 20 * time.Second
+	// defaultPoolReadTimeout / defaultPoolWriteTimeout are the per-I/O
+	// deadlines on shared-pool connections. Overridable via
+	// Config.PoolReadTimeout/PoolWriteTimeout (BEADS_DOLT_POOL_READ_TIMEOUT /
+	// BEADS_DOLT_POOL_WRITE_TIMEOUT, dolt.pool-read-timeout /
+	// dolt.pool-write-timeout); the defaults themselves are deliberately
+	// unchanged (bd-vz0y9).
+	defaultPoolReadTimeout  = 10 * time.Second
+	defaultPoolWriteTimeout = 10 * time.Second
 )
 
 // cliExecTimeout is the default maximum time to wait for dolt CLI
@@ -448,7 +467,14 @@ func withCLIExecTimeout(ctx context.Context) (context.Context, context.CancelFun
 // time.ParseDuration strings (e.g. "2m", "90s") or bare numbers treated as
 // seconds (e.g. "90") are accepted.
 func timeoutFromEnv(env string, fallback time.Duration) time.Duration {
-	raw := strings.TrimSpace(os.Getenv(env))
+	return parseTimeout(os.Getenv(env), fallback)
+}
+
+// parseTimeout parses a duration setting, falling back to fallback when raw is
+// empty, unparsable, or non-positive. Valid time.ParseDuration strings (e.g.
+// "2m", "90s") or bare numbers treated as seconds (e.g. "90") are accepted.
+func parseTimeout(raw string, fallback time.Duration) time.Duration {
+	raw = strings.TrimSpace(raw)
 	if raw == "" {
 		return fallback
 	}
@@ -1733,8 +1759,14 @@ func buildServerDSN(cfg *Config, database string) string {
 	if err != nil {
 		return base.String()
 	}
-	parsed.ReadTimeout = 10 * time.Second
-	parsed.WriteTimeout = 10 * time.Second
+	parsed.ReadTimeout = defaultPoolReadTimeout
+	if cfg.PoolReadTimeout > 0 {
+		parsed.ReadTimeout = cfg.PoolReadTimeout
+	}
+	parsed.WriteTimeout = defaultPoolWriteTimeout
+	if cfg.PoolWriteTimeout > 0 {
+		parsed.WriteTimeout = cfg.PoolWriteTimeout
+	}
 	return parsed.FormatDSN()
 }
 

--- a/internal/storage/dolt/store_unit_test.go
+++ b/internal/storage/dolt/store_unit_test.go
@@ -564,6 +564,72 @@ func TestExecWithLongTimeoutDSNRewrite(t *testing.T) {
 	}
 }
 
+// TestBuildServerDSN_PoolTimeouts verifies the shared pool's per-I/O deadlines:
+// 10s defaults when unset, and Config.PoolReadTimeout/PoolWriteTimeout
+// overrides carried through to the DSN (bd-vz0y9).
+func TestBuildServerDSN_PoolTimeouts(t *testing.T) {
+	tests := []struct {
+		name         string
+		readTimeout  time.Duration
+		writeTimeout time.Duration
+		wantRead     time.Duration
+		wantWrite    time.Duration
+	}{
+		{"defaults when unset", 0, 0, 10 * time.Second, 10 * time.Second},
+		{"read override only", 90 * time.Second, 0, 90 * time.Second, 10 * time.Second},
+		{"write override only", 0, 45 * time.Second, 10 * time.Second, 45 * time.Second},
+		{"both overridden", 2 * time.Minute, 30 * time.Second, 2 * time.Minute, 30 * time.Second},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &Config{
+				ServerUser:       "root",
+				ServerHost:       "127.0.0.1",
+				ServerPort:       3307,
+				Database:         "testdb",
+				PoolReadTimeout:  tt.readTimeout,
+				PoolWriteTimeout: tt.writeTimeout,
+			}
+			parsed, err := mysql.ParseDSN(buildServerDSN(cfg, cfg.Database))
+			if err != nil {
+				t.Fatalf("failed to parse DSN: %v", err)
+			}
+			if parsed.ReadTimeout != tt.wantRead {
+				t.Errorf("expected readTimeout=%v, got %v", tt.wantRead, parsed.ReadTimeout)
+			}
+			if parsed.WriteTimeout != tt.wantWrite {
+				t.Errorf("expected writeTimeout=%v, got %v", tt.wantWrite, parsed.WriteTimeout)
+			}
+		})
+	}
+}
+
+// TestParseTimeout verifies the shared duration-setting parser: ParseDuration
+// strings, bare seconds, and fallback on empty/invalid/non-positive input.
+func TestParseTimeout(t *testing.T) {
+	tests := []struct {
+		raw  string
+		want time.Duration
+	}{
+		{"", 0},
+		{"30s", 30 * time.Second},
+		{"2m", 2 * time.Minute},
+		{"90", 90 * time.Second},
+		{" 45 ", 45 * time.Second},
+		{"bogus", 0},
+		{"-5s", 0},
+		{"0", 0},
+	}
+	for _, tt := range tests {
+		if got := parseTimeout(tt.raw, 0); got != tt.want {
+			t.Errorf("parseTimeout(%q, 0) = %v, want %v", tt.raw, got, tt.want)
+		}
+	}
+	if got := parseTimeout("bogus", 7*time.Second); got != 7*time.Second {
+		t.Errorf("parseTimeout(bogus, 7s) = %v, want fallback 7s", got)
+	}
+}
+
 // TestBuildServerDSN_SpecialCharacterPassword verifies that passwords with
 // characters that collide with DSN delimiters (@ : / ? & < > etc.) are
 // properly escaped by FormatDSN. This was a real bug — passwords from Secret


### PR DESCRIPTION
## Summary

`buildServerDSN` pins the shared pool's `ReadTimeout`/`WriteTimeout` to a hardcoded 10s with no override. On a healthy local server that fast-fail is right; on an overloaded shared sql-server box the ceiling kills **ordinary** queries — link (wyvern fleet) measures ~300 `client connection went away while a query was executing` events/hour in dolt-server.log under load, including plain `bd list` and `bd mail send` — the latter meaning failure alerts for *other* bugs never got out. Today's confirmation: during a host load-avg-81 window, bridge-sync's `bd recompute-blocked` failed 24 consecutive retries on this ceiling (bd-bn8jo).

The known-long procedures are each hand-routed off the pool (`execWithLongTimeout`\* 5m, `openLongTimeoutConn` 5m, `openMigrationDB` uncapped, backup via bd-2o8nv/#5052), but the pool's own ceiling for everything else was invisible and untunable.

## Changes

- `Config.PoolReadTimeout` / `Config.PoolWriteTimeout` (0 = default 10s; **defaults deliberately unchanged** — the bug is that overloaded deployments have no knob, not the default)
- Resolution mirrors the sibling `dolt.max-conns` knob: caller override > `BEADS_DOLT_POOL_READ_TIMEOUT` / `BEADS_DOLT_POOL_WRITE_TIMEOUT` env > `dolt.pool-read-timeout` / `dolt.pool-write-timeout` config.yaml keys > 10s default
- Values accept `time.ParseDuration` strings (`90s`, `2m`) or bare seconds (`90`) via `parseTimeout`, extracted from the existing `timeoutFromEnv`
- Explicit yaml-registry entries for the two keys (the `dolt.` prefix already routed them to config.yaml)

No docs edit: docs describe the v1.1.0 pin; the knob reaches the site at the next release regeneration (same call as #5052).

## Testing

- `TestBuildServerDSN_PoolTimeouts`: defaults when unset; read-only, write-only, and both overrides carried into the DSN
- `TestParseTimeout`: duration strings, bare seconds, fallback on empty/invalid/non-positive
- `TestApplyResolvedConfig` subtests: env vars populate the fields (incl. bare-seconds form); caller-set values win over env
- Full `internal/storage/dolt`, `internal/config`, `internal/configfile` suites green; gofmt/vet/golangci-lint clean on touched packages

Validation offer: link reproduces the query-kill events on demand and offered to test patched builds (bd-vz0y9 / bd-na129).

Closes bd-vz0y9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KspC6Y46KKaU9ZNKupXLwk