### PR TITLE
fix(dolt): run is_blocked recomputes on the long-timeout connection (bd-bn8jo)

### DIFF
--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -3438,7 +3438,18 @@ func (s *DoltStore) recomputeBlockedAfterPull(ctx context.Context, fromCommit st
 // operator resolved by hand — leaves is_blocked stale until this full pass runs.
 // Idempotent: a consistent database corrects nothing.
 func (s *DoltStore) RecomputeAllBlocked(ctx context.Context) (int, error) {
-	tx, err := s.db.BeginTx(ctx, nil)
+	// The full pass's batched UPDATEs carry five correlated EXISTS subqueries
+	// each; on a loaded shared server a single batch can outlive the pool's
+	// per-I/O deadline (default 10s, see buildServerDSN), killing the repair
+	// with "i/o timeout" — and the retry dies the same way, so the owed
+	// recompute never lands (bd-bn8jo). Run it on a dedicated long-timeout
+	// connection like the other known-long maintenance ops.
+	db, err := s.openLongTimeoutConn()
+	if err != nil {
+		return 0, err
+	}
+	defer db.Close()
+	tx, err := db.BeginTx(ctx, nil)
 	if err != nil {
 		return 0, fmt.Errorf("begin is_blocked recompute: %w", err)
 	}
@@ -3470,9 +3481,17 @@ func (s *DoltStore) RecomputeAllBlocked(ctx context.Context) (int, error) {
 }
 
 // recomputeBlockedTx runs the post-merge is_blocked recompute in its own
-// transaction.
+// transaction. Like RecomputeAllBlocked it runs on a long-timeout connection:
+// a heavy merge scopes the recompute over a large diff, and a pool-deadline
+// kill here is what turns into the owed full recompute in the first place
+// (bd-bn8jo).
 func (s *DoltStore) recomputeBlockedTx(ctx context.Context, fromCommit string) error {
-	tx, err := s.db.BeginTx(ctx, nil)
+	db, err := s.openLongTimeoutConn()
+	if err != nil {
+		return err
+	}
+	defer db.Close()
+	tx, err := db.BeginTx(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("begin is_blocked recompute: %w", err)
 	}


### PR DESCRIPTION
## Summary

Both the full `is_blocked` recompute (`bd recompute-blocked` / `bd doctor --fix`) and the scoped post-merge recompute run their batched mark/unmark UPDATEs over the shared pool, whose per-I/O deadline (default 10s, `buildServerDSN`) kills any batch that outlives it. The UPDATEs carry five correlated EXISTS subqueries each, so on a loaded shared server the repair dies with `i/o timeout` / `invalid connection`.

Observed live today: bridge-sync's owed recompute against the wyvern DB failed **24 consecutive retries** during a host load-avg-81 window (wy-b72dj signature), reproduced manually twice. The two paths also compound: a pool-deadline kill of the post-merge recompute is exactly what creates the owed full recompute — which then dies the same way, so the repair never lands.

## Changes

Route both recompute transactions through `openLongTimeoutConn` (5m) — the path every other known-long maintenance op already uses (pull/merge conflict resolution, backup via bd-2o8nv/#5052, migrations):

- `RecomputeAllBlocked` (store.go): dedicated long-timeout connection for the guard + full mark/unmark pass
- `recomputeBlockedTx` (post-merge scoped recompute): same treatment

The trailing `DOLT_ADD`/`DOLT_COMMIT` stays on the pool: it stages a small computed diff, and the pool's ceiling is independently tunable via the bd-vz0y9 knob (#5089 — sibling PR, no code overlap conflict; both touch `store.go` in disjoint regions).

## Risk notes

- No session-state coupling: both recomputes already ran in their own transactions after the outer operation committed; the working set is server-global, and the established pattern (pull on long conn → commit on pool) is unchanged.
- Embedded mode unaffected — `EmbeddedDoltStore` has its own `RecomputeAllBlocked` with no network deadline.

## Testing

- Full `internal/storage/dolt` suite green (includes blocked_consistency, blocked_merge, blocked_recompute_guard tests exercising both changed paths)
- gofmt/build clean
- Field validation before the fix: direct no-timeout SQL probes of the exact mark/unmark predicates confirmed the failing owed recompute was a no-op *that run* (0 stale rows) — but only because local writes had kept flags consistent; a conflicted-pull window would have left `is_blocked` stale with no working repair path.

Closes bd-bn8jo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KspC6Y46KKaU9ZNKupXLwk