### PR TITLE
docs(release): record the v1.1.2 hotfix in CHANGELOG and bd info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -339,6 +339,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `bd.claim_verify_lost_total` and `bd.claim_verify_recovered_total` count
   loud failures and converted outcomes.
 
+## [1.1.2] - 2026-07-26
+
+Hotfix release cut from v1.1.0. (There is no 1.1.1 release: its tag was cut
+but the release pipeline's package gate failed on a stale MCP lockfile before
+publishing anything, and the version number was burned rather than moving the
+tag.) If `bd migrate` on 1.1.0 aborted with
+`rekey aux row ids: <table>: ... invalid hash length` and the database then
+refused to open, this release lets the migration complete.
+
+### Fixed
+
+- **The v53 aux row re-key survives dolt#11131 encoding drift.** On storage
+  affected by the upstream Dolt adaptive-encoding bug, reading the drifted
+  cells panics (`invalid hash length: 19`), which aborted the migration and
+  left the database unopenable under 1.1.0. The re-key now skips such a
+  table with a warning, records it in a clone-local drift record
+  (`aux_row_rekey_drifted` in `local_metadata`), and completes the
+  migration; recorded tables are retried on later migration passes and are
+  exempted from the changed-signature dirty-table guard so the retry cannot
+  re-brick the database
+  ([#4380](https://github.com/gastownhall/beads/issues/4380)).
+
 ## [1.1.0] - 2026-07-04
 
 First stable release of the 1.1.0 line. It consolidates everything from

--- a/cmd/bd/info.go
+++ b/cmd/bd/info.go
@@ -209,6 +209,13 @@ type VersionChange struct {
 // versionChanges contains agent-actionable changes for recent versions
 var versionChanges = []VersionChange{
 	{
+		Version: "1.1.2",
+		Date:    "2026-07-26",
+		Changes: []string{
+			"FIX: the v53 aux row re-key no longer aborts the migration on dolt#11131 encoding drift ('invalid hash length' panic); drifted tables are skipped with a warning, recorded clone-locally, and retried on later passes instead of leaving the database unopenable (#4380).",
+		},
+	},
+	{
 		Version: "1.1.0",
 		Date:    "2026-07-04",
 		Changes: []string{


### PR DESCRIPTION
## Why

v1.1.2 shipped on 2026-07-26, cut from the v1.1.0 tag (branch `hotfix/v1.1.1`) to carry the dolt#11131 aux-rekey encoding-drift fix so bricked 1.1.0 databases regain an upgrade path (#4380). Main never received the release metadata, so `CHANGELOG.md` jumps from `[Unreleased]` to `[1.1.0]` and `bd info --changes` doesn't mention 1.1.2. This is the standard post-hotfix back-merge of that metadata.

## What

- `CHANGELOG.md`: add the `[1.1.2] - 2026-07-26` section (verbatim from the release branch). It also records why there is no 1.1.1: the tag was cut but the release run died at the MCP package gate on a stale `uv.lock` before publishing anything, and the number was burned rather than moving the tag.
- `cmd/bd/info.go`: add the 1.1.2 `versionChanges` entry.

## Deliberately not carried from the hotfix branch

- **The fix itself** — reaches main via #5064, which stays gated on storage-owner review; this PR must not bypass that.
- **Version bumps** (version.go, winres, npm/MCP package manifests) — release-branch concerns; main builds stamp version via ldflags.
- **The Docusaurus versioned-docs snapshot** — main deleted the Docusaurus site in 52aea3f7e (Mintlify migration), so there is nothing to version here anymore.

Docs-only + one data literal; `go build ./cmd/bd` passes, `gofmt` clean.

_claude-fable-5-medium on behalf of matt wilkie_
