### PR TITLE
docs(maintainer): prior-art pass in every review; rebases are maintainer work

### DIFF
--- a/PR_MAINTAINER_GUIDELINES.md
+++ b/PR_MAINTAINER_GUIDELINES.md
@@ -16,7 +16,7 @@ core, metadata, integration, plugin, orchestration layer, or external tool.
 
 ## Contributor Protection
 
-External contributor PRs have priority. Before implementing related work, opening a competing PR, or closing a PR, check whether an existing contributor PR already addresses the same area.
+External contributor PRs have priority. Before implementing related work, opening a competing PR, **reviewing or merging any PR**, or closing a PR, check whether an existing contributor PR already addresses the same area.
 
 - Review contributor work first. Read the PR description, changed files, linked issues, tests, CI status, and latest discussion.
 - Build on the contributor branch by default. If the PR branch allows maintainer edits, push maintainer fix commits directly to that branch instead of opening a replacement PR.
@@ -25,6 +25,39 @@ External contributor PRs have priority. Before implementing related work, openin
 - Never close, supersede, or replace a contributor PR silently. Explain what was preserved, what changed, and why.
 - Open a replacement PR only when in-place maintainer edits are not possible or would create a larger risk, such as when the contributor branch is not writable, the branch history is unusable, or the accepted change must be substantially reimplemented. Document that reason in both PR threads.
 - If a rewrite is unavoidable, credit the contributor's design, tests, bug report, or use case in the replacement commit or PR.
+
+### Prior art is part of the review, not the merge
+
+Every review of a PR — before any verdict, and always before handing it to
+anything that merges on green — includes a prior-art pass over **older open PRs
+and issues**:
+
+```bash
+scripts/pr-preflight.sh --search "<topic keywords>"
+gh search prs --repo gastownhall/beads --state open "<bug keywords>"
+```
+
+The rule at the top of this section always covered implementing, competing, and
+closing; the missing case was *merging*: a newer PR under review can itself be
+the duplicate of an older open contributor PR. Merge automation and per-PR
+preflight run no duplicate scan — the review is the only gate where prior art
+can be caught, so the reviewer owns this check.
+
+When an older open PR covers the same change:
+
+- **Default precedence goes to the older PR.** Merge it (fix-merge if needed)
+  rather than the newer duplicate.
+- If the newer implementation is genuinely superior, resolve the older PR
+  **first**: a personal explanation and credit *before* the newer one merges,
+  never a retire notice after the fact.
+
+Motivating incident (2026-07-26, #4376 vs #4939): a 44-day-old PR whose author
+had complied with a requested rebase in under 24 hours sat merge-ready for 20
+days while a 5-day-old duplicate was reviewed and auto-merged with zero
+comments ever posted on it. The original author learned their work was dead
+from the retire notice. Both the review of the newer PR and the queue
+follow-through on the older one had the information to prevent this; neither
+used it.
 
 ## Triage Groups
 
@@ -101,3 +134,26 @@ These rules apply to everyone who can merge — human maintainers and agents ali
 - Post multi-line PR comments from a real Markdown body file or a shell heredoc, not from strings with escaped `\n` sequences. Run `scripts/gh-body-lint <body-file>` before posting body files; after posting or editing, verify the rendered body with `gh pr view --comments --json comments --jq ...` before moving on.
 - Sign agent-written GitHub comments, reviews, and commits using [engdocs/AGENT_SIGNING.md](engdocs/AGENT_SIGNING.md).
 - Before finishing, re-read the PR, latest comments, review threads, and linked issues; address or explicitly note any unresolved action items.
+
+### Rebases are maintainer work
+
+Do not ask a contributor to rebase when that is the only thing left. If the
+review verdict is "correct once rebased," the verdict is **fix-merge**: check
+out the PR branch, rebase and resolve conflicts ourselves, push back to the
+contributor's branch (maintainer edits), and take it to merge — in the same
+session.
+
+- Ask for a rebase only when bundled with substantive changes that only the
+  contributor can make. When they comply, the PR goes straight to merge, not
+  back into the ambient queue — a contributor who did what we asked must never
+  be the one waiting on us again.
+- Maintainer edits are refused on branches owned by an **organization** fork
+  (GitHub restriction). In that case use the replacement-PR route from
+  Contributor Protection with preserved attribution, and say why on the thread.
+
+Why: a requested rebase multiplies across everything a contributor has open —
+each of their branches must then be rebased independently against different
+lines of our work, so the cost lands heaviest on the most prolific
+contributors. And a rebase we request but then sit on is pure contributor cost:
+on #4376 the author rebased within 24 hours of the request and then waited 20
+days for a maintainer action that never came.


### PR DESCRIPTION
## Why

On 2026-07-26, #4376 — a correct fix whose author had complied with a requested rebase in under 24 hours — was retired after 44 days because #4939, a 5-day-old duplicate, was reviewed twice and auto-merged without anyone discovering or discussing the older PR. The author (rightly) asked: why wasn't the older PR merged first, and why did nothing check for an already-open PR before the newer one landed?

An audit of all 2,973 closed PRs found this was not a one-off: 127 closed-unmerged contributor PRs were redundant closes, and roughly 7 followed the exact #4376 shape — maintainer engaged, author complied, weeks of maintainer silence, then a supersede close.

## What

Two additions to `PR_MAINTAINER_GUIDELINES.md`, matching the failure modes:

1. **Prior art is part of the review, not the merge** (under Contributor Protection). Every review runs a prior-art pass over older open PRs/issues (`scripts/pr-preflight.sh --search` + `gh search prs`) before any verdict or merge handoff. Merge automation runs no duplicate scan, so the reviewer owns this check. Older open PR covering the same change ⇒ it takes precedence by default; if the newer is genuinely superior, the older PR gets a personal explanation *before* the merge, never a retire notice after. Also widened the section's opening rule to cover "reviewing or merging any PR" — the case #4939 slipped through.

2. **Rebases are maintainer work** (under Operating Rules). A "correct once rebased" verdict is a fix-merge maintainers execute themselves via maintainer edits, same session. Rebase requests only ride along with substantive asks; a complied-with request goes straight to merge, never back into the ambient queue. Includes the org-owned-fork caveat where GitHub refuses maintainer edits.

Docs-only change; no code paths touched.

_claude-fable-5-high on behalf of maphew_

**Thank you @sarendipitee for bringing this lapse to my attention in #4376 (comment)](https://github.com/gastownhall/beads/pull/4376#issuecomment-5085212884)**
