### PR TITLE
fix: preserve forced delete dry-runs and payload-blind previews

### DIFF
--- a/cmd/bd/delete.go
+++ b/cmd/bd/delete.go
@@ -133,7 +133,20 @@ Force: Delete and orphan dependents
 		idPattern := `(^|[^A-Za-z0-9_-])(` + regexp.QuoteMeta(issueID) + `)($|[^A-Za-z0-9_-])`
 		re := regexp.MustCompile(idPattern)
 		replacementText := `$1[deleted:` + issueID + `]$3`
-		if !force {
+		if dryRun || !force {
+			var previewResult *types.DeleteIssuesResult
+			if dryRun {
+				previewResult, err = activeStore.DeleteIssues(ctx, []string{issueID}, false, force, true)
+				if err != nil {
+					if previewErr := outputDeletionPreview([]string{issueID}, map[string]*types.Issue{issueID: issue}, false, true, previewResult, err, jsonOutput); previewErr != nil {
+						return previewErr
+					}
+					return HandleError("previewing deletion: %v", err)
+				}
+			}
+			if jsonOutput || isQuiet() {
+				return outputDeletionPreview([]string{issueID}, map[string]*types.Issue{issueID: issue}, false, dryRun, previewResult, nil, jsonOutput)
+			}
 			fmt.Printf("\n%s\n", ui.RenderFail("⚠️  DELETE PREVIEW"))
 			fmt.Printf("\nIssue to delete:\n")
 			fmt.Printf("  %s: %s\n", issueID, issue.Title)
@@ -164,8 +177,17 @@ Force: Delete and orphan dependents
 					fmt.Printf("  (none have text references)\n")
 				}
 			}
-			fmt.Printf("\n%s\n", ui.RenderWarn("This operation cannot be undone!"))
-			fmt.Printf("To proceed, run: %s\n\n", ui.RenderWarn("bd delete "+issueID+" --force"))
+			if dryRun {
+				fmt.Printf("\nWould delete: %d issues\n", previewResult.DeletedCount)
+				fmt.Printf("Would remove: %d dependencies, %d labels, %d events\n", previewResult.DependenciesCount, previewResult.LabelsCount, previewResult.EventsCount)
+				if len(previewResult.OrphanedIssues) > 0 {
+					fmt.Printf("Would orphan: %d issues\n", len(previewResult.OrphanedIssues))
+				}
+				fmt.Printf("\n(Dry-run mode - no changes made)\n")
+			} else {
+				fmt.Printf("\n%s\n", ui.RenderWarn("This operation cannot be undone!"))
+				fmt.Printf("To proceed, run: %s\n\n", ui.RenderWarn("bd delete "+issueID+" --force"))
+			}
 			return nil
 		}
 		updatedIssueCount := 0
@@ -276,21 +298,17 @@ func deleteBatch(_ *cobra.Command, issueIDs []string, force bool, dryRun bool, c
 		batchStore = routedStore
 	}
 	if dryRun || !force {
-		result, err := batchStore.DeleteIssues(ctx, issueIDs, cascade, false, true)
+		result, err := batchStore.DeleteIssues(ctx, issueIDs, cascade, force, true)
 		if err != nil {
-			showDeletionPreview(issueIDs, issues, cascade, err)
+			if previewErr := outputDeletionPreview(issueIDs, issues, cascade, dryRun, result, err, jsonOutput); previewErr != nil {
+				return previewErr
+			}
 			return err
 		}
-		showDeletionPreview(issueIDs, issues, cascade, nil)
-		fmt.Printf("\nWould delete: %d issues\n", result.DeletedCount)
-		fmt.Printf("Would remove: %d dependencies, %d labels, %d events\n",
-			result.DependenciesCount, result.LabelsCount, result.EventsCount)
-		if len(result.OrphanedIssues) > 0 {
-			fmt.Printf("Would orphan: %d issues\n", len(result.OrphanedIssues))
+		if previewErr := outputDeletionPreview(issueIDs, issues, cascade, dryRun, result, nil, jsonOutput); previewErr != nil {
+			return previewErr
 		}
-		if dryRun {
-			fmt.Printf("\n(Dry-run mode - no changes made)\n")
-		} else {
+		if !dryRun && !jsonOutput && !isQuiet() {
 			fmt.Printf("\n%s\n", ui.RenderWarn("This operation cannot be undone!"))
 			if cascade {
 				fmt.Printf("To proceed with cascade deletion, run: %s\n",
@@ -360,8 +378,32 @@ func deleteBatch(_ *cobra.Command, issueIDs []string, force bool, dryRun bool, c
 	return nil
 }
 
-// showDeletionPreview shows what would be deleted
-func showDeletionPreview(issueIDs []string, issues map[string]*types.Issue, cascade bool, depError error) {
+// outputDeletionPreview renders a deletion preview without exposing issue payloads
+// in machine-readable or quiet output.
+func outputDeletionPreview(issueIDs []string, issues map[string]*types.Issue, cascade bool, dryRun bool, result *types.DeleteIssuesResult, depError error, jsonOutput bool) error {
+	if jsonOutput {
+		preview := map[string]interface{}{
+			"preview":   true,
+			"dry_run":   dryRun,
+			"issue_ids": issueIDs,
+			"cascade":   cascade,
+		}
+		if result != nil {
+			preview["would_delete"] = result.DeletedCount
+			preview["would_remove_dependencies"] = result.DependenciesCount
+			preview["would_remove_labels"] = result.LabelsCount
+			preview["would_remove_events"] = result.EventsCount
+			preview["would_orphan"] = len(result.OrphanedIssues)
+		}
+		if depError != nil {
+			preview["error"] = depError.Error()
+		}
+		return outputJSON(preview)
+	}
+	if isQuiet() {
+		return nil
+	}
+
 	fmt.Printf("\n%s\n", ui.RenderFail("⚠️  DELETE PREVIEW"))
 	fmt.Printf("\nIssues to delete (%d):\n", len(issueIDs))
 	for _, id := range issueIDs {
@@ -375,6 +417,18 @@ func showDeletionPreview(issueIDs []string, issues map[string]*types.Issue, casc
 	if depError != nil {
 		fmt.Printf("\n%s\n", ui.RenderFail(depError.Error()))
 	}
+	if result != nil {
+		fmt.Printf("\nWould delete: %d issues\n", result.DeletedCount)
+		fmt.Printf("Would remove: %d dependencies, %d labels, %d events\n",
+			result.DependenciesCount, result.LabelsCount, result.EventsCount)
+		if len(result.OrphanedIssues) > 0 {
+			fmt.Printf("Would orphan: %d issues\n", len(result.OrphanedIssues))
+		}
+		if dryRun {
+			fmt.Printf("\n(Dry-run mode - no changes made)\n")
+		}
+	}
+	return nil
 }
 
 // updateTextReferencesInIssues updates text references to deleted issues in pre-collected connected issues

--- a/cmd/bd/delete.go
+++ b/cmd/bd/delete.go
@@ -90,6 +90,9 @@ Force: Delete and orphan dependents
 
 		if len(issueIDs) > 1 || cascade {
 			if err := deleteBatch(cmd, issueIDs, force, dryRun, cascade, jsonOutput, false); err != nil {
+				if _, ok := exitCodeFromError(err); ok {
+					return err
+				}
 				return HandleError("%v", err)
 			}
 			return nil
@@ -140,6 +143,9 @@ Force: Delete and orphan dependents
 				if err != nil {
 					if previewErr := outputDeletionPreview([]string{issueID}, map[string]*types.Issue{issueID: issue}, false, true, previewResult, err, jsonOutput); previewErr != nil {
 						return previewErr
+					}
+					if jsonOutput {
+						return outputJSONError(err, "")
 					}
 					return HandleError("previewing deletion: %v", err)
 				}
@@ -302,6 +308,9 @@ func deleteBatch(_ *cobra.Command, issueIDs []string, force bool, dryRun bool, c
 		if err != nil {
 			if previewErr := outputDeletionPreview(issueIDs, issues, cascade, dryRun, result, err, jsonOutput); previewErr != nil {
 				return previewErr
+			}
+			if jsonOutput {
+				return outputJSONError(err, "")
 			}
 			return err
 		}

--- a/cmd/bd/delete_embedded_test.go
+++ b/cmd/bd/delete_embedded_test.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"encoding/json"
 	"os"
 	"os/exec"
 	"strings"
@@ -161,6 +162,114 @@ func TestEmbeddedDelete(t *testing.T) {
 	t.Run("delete_nonexistent", func(t *testing.T) {
 		bdDeleteFail(t, bd, dir, "td-nonexistent999", "--force")
 	})
+}
+
+func TestEmbeddedDeleteJSONDependencyErrorContract(t *testing.T) {
+	if os.Getenv("BEADS_TEST_EMBEDDED_DOLT") != "1" {
+		t.Skip("set BEADS_TEST_EMBEDDED_DOLT=1 to run embedded dolt integration tests")
+	}
+	t.Parallel()
+
+	bd := buildEmbeddedBD(t)
+	dir, beadsDir, _ := bdInit(t, bd, "--prefix", "jde")
+
+	for _, tc := range []struct {
+		name  string
+		batch bool
+	}{
+		{name: "single"},
+		{name: "batch", batch: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			titleMarker := "EMBEDDED_JSON_ERROR_TITLE_" + tc.name
+			descriptionMarker := "EMBEDDED_JSON_ERROR_DESCRIPTION_" + tc.name
+			notesMarker := "EMBEDDED_JSON_ERROR_NOTES_" + tc.name
+			metadataMarker := "EMBEDDED_JSON_ERROR_METADATA_" + tc.name
+			parent := bdCreate(t, bd, dir, titleMarker,
+				"--type", "task",
+				"--description", descriptionMarker,
+				"--notes", notesMarker,
+				"--metadata", `{"marker":"`+metadataMarker+`"}`)
+			child := bdCreate(t, bd, dir, "JSON error dependent "+tc.name, "--type", "task")
+			bdDepAdd(t, bd, dir, child.ID, parent.ID)
+
+			issueIDs := []string{parent.ID}
+			if tc.batch {
+				other := bdCreate(t, bd, dir, "JSON error batch companion", "--type", "task")
+				issueIDs = append(issueIDs, other.ID)
+			}
+
+			runDelete := func(flags ...string) (string, string, error) {
+				args := append([]string{"delete"}, issueIDs...)
+				args = append(args, flags...)
+				cmd := exec.Command(bd, args...)
+				cmd.Dir = dir
+				cmd.Env = append(bdEnv(dir), "BD_JSON_ENVELOPE=0")
+				stdout, stderr, err := runCommandBuffers(t, cmd)
+				return stdout.String(), stderr.String(), err
+			}
+
+			stdout, stderr, err := runDelete("--dry-run", "--json")
+			if err == nil {
+				t.Fatalf("unforced dependency-blocked JSON dry-run succeeded\nstdout:\n%s\nstderr:\n%s", stdout, stderr)
+			}
+			var preview map[string]interface{}
+			if err := json.Unmarshal([]byte(stdout), &preview); err != nil {
+				t.Fatalf("unforced preview stdout is not exactly one JSON object: %v\nstdout:\n%s", err, stdout)
+			}
+			if preview["preview"] != true || preview["dry_run"] != true {
+				t.Fatalf("unforced preview missing structural fields: %#v", preview)
+			}
+			if _, ok := preview["error"].(string); !ok {
+				t.Fatalf("unforced preview missing dependency error: %#v", preview)
+			}
+			var jsonErr map[string]interface{}
+			if err := json.Unmarshal([]byte(stderr), &jsonErr); err != nil {
+				t.Fatalf("unforced stderr is not exactly one JSON error object: %v\nstderr:\n%s", err, stderr)
+			}
+			if _, ok := jsonErr["error"].(string); !ok {
+				t.Fatalf("unforced stderr missing error field: %#v", jsonErr)
+			}
+			if strings.Contains(stderr, "Error:") {
+				t.Fatalf("unforced stderr contains plaintext error prefix: %s", stderr)
+			}
+			for _, marker := range []string{titleMarker, descriptionMarker, notesMarker, metadataMarker} {
+				if strings.Contains(stdout+stderr, marker) {
+					t.Fatalf("unforced JSON dry-run leaked %q", marker)
+				}
+			}
+
+			stdout, stderr, err = runDelete("--force", "--dry-run", "--quiet", "--json")
+			if err != nil {
+				t.Fatalf("forced quiet JSON dry-run failed: %v\nstdout:\n%s\nstderr:\n%s", err, stdout, stderr)
+			}
+			if strings.TrimSpace(stderr) != "" {
+				t.Fatalf("forced quiet JSON dry-run wrote stderr: %s", stderr)
+			}
+			var forcedPreview map[string]interface{}
+			if err := json.Unmarshal([]byte(stdout), &forcedPreview); err != nil {
+				t.Fatalf("forced quiet JSON stdout is not exactly one JSON object: %v\nstdout:\n%s", err, stdout)
+			}
+			for _, key := range []string{"preview", "dry_run", "would_delete", "would_orphan"} {
+				if _, ok := forcedPreview[key]; !ok {
+					t.Fatalf("forced quiet JSON preview missing %q: %#v", key, forcedPreview)
+				}
+			}
+			for _, marker := range []string{titleMarker, descriptionMarker, notesMarker, metadataMarker} {
+				if strings.Contains(stdout, marker) {
+					t.Fatalf("forced quiet JSON dry-run leaked %q", marker)
+				}
+			}
+
+			if got := bdShowDetails(t, bd, dir, parent.ID); got["id"] != parent.ID {
+				t.Fatalf("dry-run removed parent: got %v, want %q", got["id"], parent.ID)
+			}
+			if got := bdShowDetails(t, bd, dir, child.ID); got["id"] != child.ID {
+				t.Fatalf("dry-run removed dependent: got %v, want %q", got["id"], child.ID)
+			}
+			assertDepExists(t, beadsDir, "jde", child.ID, parent.ID)
+		})
+	}
 }
 
 func TestEmbeddedGetDependencies(t *testing.T) {

--- a/cmd/bd/delete_embedded_test.go
+++ b/cmd/bd/delete_embedded_test.go
@@ -96,6 +96,43 @@ func TestEmbeddedDelete(t *testing.T) {
 		}
 	})
 
+	t.Run("delete_single_quiet_forced_dry_run_is_payload_blind", func(t *testing.T) {
+		titleMarker := "EMBEDDED_QUIET_TITLE_MARKER"
+		descriptionMarker := "EMBEDDED_QUIET_DESCRIPTION_MARKER"
+		notesMarker := "EMBEDDED_QUIET_NOTES_MARKER"
+		payloadMarker := "EMBEDDED_QUIET_PAYLOAD_MARKER"
+		parent := bdCreate(t, bd, dir, titleMarker,
+			"--type", "task",
+			"--description", descriptionMarker,
+			"--notes", notesMarker,
+			"--metadata", `{"marker":"`+payloadMarker+`"}`)
+		child := bdCreate(t, bd, dir, "Embedded quiet dependent", "--type", "task")
+		bdDepAdd(t, bd, dir, child.ID, parent.ID)
+
+		cmd := exec.Command(bd, "delete", parent.ID, "--force", "--dry-run", "--quiet")
+		cmd.Dir = dir
+		cmd.Env = bdEnv(dir)
+		stdout, stderr, err := runCommandBuffers(t, cmd)
+		if err != nil {
+			t.Fatalf("single forced quiet dry-run failed: %v\nstdout:\n%s\nstderr:\n%s", err, stdout.String(), stderr.String())
+		}
+		if stdout.Len() != 0 {
+			t.Fatalf("quiet dry-run produced stdout: %s", stdout.String())
+		}
+		combined := stdout.String() + stderr.String()
+		for _, marker := range []string{titleMarker, descriptionMarker, notesMarker, payloadMarker} {
+			if strings.Contains(combined, marker) {
+				t.Fatalf("quiet dry-run leaked %q: %s", marker, combined)
+			}
+		}
+		if got := bdShowDetails(t, bd, dir, parent.ID); got["id"] != parent.ID {
+			t.Fatalf("forced dry-run removed parent: got %v, want %q", got["id"], parent.ID)
+		}
+		if got := bdShowDetails(t, bd, dir, child.ID); got["id"] != child.ID {
+			t.Fatalf("forced dry-run removed dependent: got %v, want %q", got["id"], child.ID)
+		}
+	})
+
 	t.Run("delete_force_orphans_dependents", func(t *testing.T) {
 		parent := bdCreate(t, bd, dir, "Force parent", "--type", "task")
 		child := bdCreate(t, bd, dir, "Force child", "--type", "task")

--- a/cmd/bd/delete_proxied_server.go
+++ b/cmd/bd/delete_proxied_server.go
@@ -18,6 +18,7 @@ type deleteInput struct {
 	force      bool
 	dryRun     bool
 	jsonOutput bool
+	quiet      bool
 }
 
 func gatherDeleteInput(cmd *cobra.Command, args []string) (*deleteInput, error) {
@@ -40,6 +41,7 @@ func gatherDeleteInput(cmd *cobra.Command, args []string) (*deleteInput, error) 
 	in.force, _ = cmd.Flags().GetBool("force")
 	in.dryRun, _ = cmd.Flags().GetBool("dry-run")
 	in.jsonOutput = jsonOutput
+	in.quiet = isQuiet()
 	return in, nil
 }
 
@@ -126,8 +128,14 @@ func runDeleteProxiedPreviewTx(ctx context.Context, in *deleteInput) error {
 		return HandleErrorRespectJSON("%v", err)
 	}
 
+	return outputDeleteProxiedPreview(in, result)
+}
+
+// outputDeleteProxiedPreview is the proxied-server preview output boundary.
+// JSON takes precedence over quiet, but neither mode may serialize issue payloads.
+func outputDeleteProxiedPreview(in *deleteInput, result deletePreviewResult) error {
 	if in.jsonOutput {
-		_ = outputJSON(map[string]any{
+		return outputJSON(map[string]any{
 			"would_delete":         result.res.DeletedCount,
 			"dependencies_removed": result.res.DependenciesCount,
 			"labels_removed":       result.res.LabelsCount,
@@ -137,6 +145,8 @@ func runDeleteProxiedPreviewTx(ctx context.Context, in *deleteInput) error {
 			"connected":            sortedKeys(result.preview.ConnectedIssues),
 			"dry_run":              in.dryRun,
 		})
+	}
+	if in.quiet {
 		return nil
 	}
 	renderDeletePreview(in, result.preview, result.res)

--- a/cmd/bd/delete_proxied_server_output_test.go
+++ b/cmd/bd/delete_proxied_server_output_test.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/storage/domain"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+func TestOutputDeleteProxiedPreviewIsPayloadBlind(t *testing.T) {
+	titleMarker := "PROXIED_OUTPUT_TITLE_MARKER"
+	descriptionMarker := "PROXIED_OUTPUT_DESCRIPTION_MARKER"
+	notesMarker := "PROXIED_OUTPUT_NOTES_MARKER"
+	payloadMarker := "PROXIED_OUTPUT_PAYLOAD_MARKER"
+	result := deletePreviewResult{
+		preview: domain.DeletePreview{
+			Issues: map[string]*types.Issue{
+				"test-target": {
+					ID:          "test-target",
+					Title:       titleMarker,
+					Description: descriptionMarker,
+					Notes:       notesMarker,
+					Metadata:    json.RawMessage(`{"marker":"` + payloadMarker + `"}`),
+				},
+			},
+			ConnectedIssues: map[string]*types.Issue{
+				"test-connected": {
+					ID:          "test-connected",
+					Title:       titleMarker,
+					Description: descriptionMarker,
+					Notes:       notesMarker,
+					Metadata:    json.RawMessage(`{"marker":"` + payloadMarker + `"}`),
+				},
+			},
+		},
+		res: domain.DeleteIssuesResult{DeletedCount: 1, DependenciesCount: 2},
+	}
+	markers := []string{titleMarker, descriptionMarker, notesMarker, payloadMarker}
+
+	t.Run("quiet dry-run emits nothing", func(t *testing.T) {
+		in := &deleteInput{ids: []string{"test-target"}, force: true, dryRun: true, quiet: true}
+		out := captureStdout(t, func() error { return outputDeleteProxiedPreview(in, result) })
+		if out != "" {
+			t.Fatalf("proxied quiet preview produced output: %s", out)
+		}
+	})
+
+	t.Run("JSON takes precedence without payload", func(t *testing.T) {
+		in := &deleteInput{ids: []string{"test-target"}, force: true, dryRun: true, quiet: true, jsonOutput: true}
+		out := captureStdout(t, func() error { return outputDeleteProxiedPreview(in, result) })
+		for _, marker := range markers {
+			if strings.Contains(out, marker) {
+				t.Fatalf("proxied JSON preview leaked %q: %s", marker, out)
+			}
+		}
+		start := strings.Index(out, "{")
+		if start < 0 {
+			t.Fatalf("proxied JSON preview produced no JSON: %s", out)
+		}
+		var got map[string]any
+		if err := json.Unmarshal([]byte(out[start:]), &got); err != nil {
+			t.Fatalf("parse proxied JSON preview: %v\nraw: %s", err, out[start:])
+		}
+		if _, ok := got["would_delete"]; !ok {
+			t.Fatalf("proxied JSON preview missing would_delete: %v", got)
+		}
+	})
+}

--- a/cmd/bd/delete_test.go
+++ b/cmd/bd/delete_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/steveyegge/beads/internal/types"
@@ -103,6 +104,84 @@ func TestUniqueStrings(t *testing.T) {
 			t.Errorf("Expected 3 items, got %d", len(result))
 		}
 	})
+}
+
+func TestDeletePreviewJSONIsPayloadBlind(t *testing.T) {
+	ensureCleanGlobalState(t)
+	oldQuiet := quietFlag
+	quietFlag = false
+	t.Cleanup(func() { quietFlag = oldQuiet })
+
+	issues := map[string]*types.Issue{
+		"test-delete-1": {
+			ID:          "test-delete-1",
+			Title:       "sensitive title must not appear",
+			Description: "sensitive payload must not appear",
+		},
+	}
+	result := &types.DeleteIssuesResult{DeletedCount: 1, DependenciesCount: 2}
+
+	out := captureStdout(t, func() error {
+		return outputDeletionPreview([]string{"test-delete-1"}, issues, false, true, result, nil, true)
+	})
+
+	for _, secret := range []string{"sensitive title", "sensitive payload"} {
+		if strings.Contains(out, secret) {
+			t.Fatalf("JSON preview leaked %q: %s", secret, out)
+		}
+	}
+	for _, required := range []string{"\"issue_ids\"", "\"would_delete\"", "\"dry_run\""} {
+		if !strings.Contains(out, required) {
+			t.Errorf("JSON preview missing %s: %s", required, out)
+		}
+	}
+
+	quietFlag = true
+	quietOut := captureStdout(t, func() error {
+		return outputDeletionPreview([]string{"test-delete-1"}, issues, false, true, result, nil, false)
+	})
+	if quietOut != "" {
+		t.Fatalf("quiet preview produced output: %s", quietOut)
+	}
+}
+
+func TestDeleteBatchDryRunHonorsForce(t *testing.T) {
+	tmpDir := t.TempDir()
+	s := newTestStore(t, filepath.Join(tmpDir, ".beads", "beads.db"))
+	ctx := context.Background()
+
+	parent := &types.Issue{Title: "parent", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask}
+	child := &types.Issue{Title: "child", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask}
+	if err := s.CreateIssue(ctx, parent, "test"); err != nil {
+		t.Fatalf("create parent: %v", err)
+	}
+	if err := s.CreateIssue(ctx, child, "test"); err != nil {
+		t.Fatalf("create child: %v", err)
+	}
+	if err := s.AddDependency(ctx, &types.Dependency{IssueID: child.ID, DependsOnID: parent.ID, Type: types.DepBlocks}, "test"); err != nil {
+		t.Fatalf("add dependency: %v", err)
+	}
+
+	oldStore, oldRootCtx, oldJSON, oldQuiet := store, rootCtx, jsonOutput, quietFlag
+	store, rootCtx, jsonOutput, quietFlag = s, ctx, false, true
+	t.Cleanup(func() { store, rootCtx, jsonOutput, quietFlag = oldStore, oldRootCtx, oldJSON, oldQuiet })
+
+	if err := deleteBatch(nil, []string{parent.ID}, true, true, false, false, false); err != nil {
+		t.Fatalf("forced dry-run rejected a dependent issue: %v", err)
+	}
+	if issue, err := s.GetIssue(ctx, parent.ID); err != nil || issue == nil {
+		t.Fatalf("forced dry-run deleted parent: issue=%v err=%v", issue, err)
+	}
+	if issue, err := s.GetIssue(ctx, child.ID); err != nil || issue == nil {
+		t.Fatalf("forced dry-run deleted child: issue=%v err=%v", issue, err)
+	}
+	deps, err := s.GetDependencies(ctx, child.ID)
+	if err != nil {
+		t.Fatalf("get dependencies after dry-run: %v", err)
+	}
+	if len(deps) != 1 {
+		t.Fatalf("forced dry-run changed dependencies: got %d, want 1", len(deps))
+	}
 }
 
 func TestBulkDeleteNoResurrection(t *testing.T) {


### PR DESCRIPTION
## Summary

- Propagate `--force` to single and batch delete dry-run previews without mutating records or dependencies.
- Keep quiet output empty and JSON previews structural-only across embedded and proxied-server output boundaries.
- Add hermetic regressions for quiet/JSON payload blindness and forced dry-run nonmutation.

## Verification

- `BEADS_TEST_EMBEDDED_DOLT=1 CGO_ENABLED=1 go test -tags gms_pure_go ./cmd/bd -run '^TestEmbeddedDelete$' -count=1 -v`\n- `CGO_ENABLED=1 go test -tags 'gms_pure_go integration' ./cmd/bd -run '^(TestDeletePreviewJSONIsPayloadBlind|TestDeleteBatchDryRunHonorsForce|TestOutputDeleteProxiedPreviewIsPayloadBlind|TestEmbeddedDelete)$' -count=1 -v` (payload-output cases passed; storage-backed cases skip when the local Dolt/Docker fixture is unavailable)\n- `CGO_ENABLED=1 go test -tags gms_pure_go ./cmd/bd -run '^$' -count=1` and `CGO_ENABLED=1 go build -tags gms_pure_go ./cmd/bd`\n\n## Release request\n\nPlease include this contribution in the next stable canonical release. Before publishing, verify the release tag commit contains the eventual canonical merge commit for this PR (and, during review, this branch head `4fcfd55f4da416c13f13bbc1723c896bcaafedf4`) with `git merge-base --is-ancestor`. The release should use the existing canonical native `darwin/arm64` path and publish `beads_<version>_darwin_arm64.tar.gz` with its SHA-256 row in `checksums.txt`; install only through the checksum-verifying installer. Preserve the currently installed CLI as a recoverable regular file and record its version/embedded commit/SHA-256 before replacement; roll back by restoring that preserved file and re-verifying it.\n\n## Scope and negative proof\n\nThis PR carries only the five approved delete-path repair files, from a fresh canonical `main` base `dbbf3a9618aacaab20427f7bc1f7b35b6edab3ba`; it does not modify release workflows, version/changelog, credentials, permissions, signing, publishing, packages, or runtime data. It does not create a tag or release.