### PR TITLE
cmd/bd: --db/--database select the proxied-server database per invocation

### DIFF
--- a/cmd/bd/dolt_clean_databases_proxied_server.go
+++ b/cmd/bd/dolt_clean_databases_proxied_server.go
@@ -8,7 +8,7 @@ import (
 )
 
 func runDoltCleanDatabasesProxied(ctx context.Context, beadsDir string, opts cleanDatabasesOptions) error {
-	provider, err := newProxiedServerUOWProvider(ctx, beadsDir)
+	provider, err := newProxiedServerUOWProvider(ctx, beadsDir, "")
 	if err != nil {
 		return HandleError("failed to open uow provider: %v", err)
 	}

--- a/cmd/bd/init.go
+++ b/cmd/bd/init.go
@@ -2049,7 +2049,6 @@ func init() {
 	initCmd.Flags().Int("server-port", 0, "Dolt server port (default: 3307)")
 	initCmd.Flags().String("server-socket", "", "Unix domain socket path (overrides host/port)")
 	initCmd.Flags().String("server-user", "", "Dolt server MySQL user (default: root)")
-	initCmd.Flags().String("database", "", "Use existing server database name (overrides prefix-based naming)")
 	initCmd.Flags().Bool("shared-server", false, "Enable shared Dolt server mode (all projects share one server at ~/.beads/shared-server/)")
 	initCmd.Flags().Bool("external", false, "Server is externally managed (skip server startup); use with --shared-server or --server")
 	initCmd.Flags().Bool("debug", false, "Run the managed Dolt sql-server with --loglevel=debug and CPU profiling (--prof cpu). Persisted to config.yaml as dolt.debug. No effect on externally-managed servers.")

--- a/cmd/bd/init_proxied_server.go
+++ b/cmd/bd/init_proxied_server.go
@@ -148,7 +148,7 @@ func runInitProxiedServer(cmd *cobra.Command, ctx context.Context, in initProxie
 		fmt.Fprintf(os.Stderr, "Warning: failed to initialize version tracking: %v\n", fsResult.LocalVersionErr)
 	}
 
-	initUOWProvider, err := newProxiedServerUOWProvider(ctx, beadsDir)
+	initUOWProvider, err := newProxiedServerUOWProvider(ctx, beadsDir, "")
 	if err != nil {
 		return fmt.Errorf("failed to open uow provider: %v", err)
 	}

--- a/cmd/bd/main.go
+++ b/cmd/bd/main.go
@@ -34,6 +34,7 @@ import (
 	"github.com/steveyegge/beads/internal/routing"
 	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/storage/dolt"
+	dbidentifier "github.com/steveyegge/beads/internal/storage/domain/db"
 	"github.com/steveyegge/beads/internal/storage/schema"
 	"github.com/steveyegge/beads/internal/storage/uow"
 	"github.com/steveyegge/beads/internal/telemetry"
@@ -1366,7 +1367,7 @@ var rootCmd = &cobra.Command{
 			if !proxiedServerMode {
 				return HandleErrorRespectJSON("--database (or a --db value naming a database) is only supported in proxied-server mode")
 			}
-			if err := dolt.ValidateDatabaseName(databaseOverride); err != nil {
+			if err := dbidentifier.ValidateIdentifier(databaseOverride); err != nil {
 				return HandleErrorRespectJSON("%v", err)
 			}
 		}

--- a/cmd/bd/main.go
+++ b/cmd/bd/main.go
@@ -8,7 +8,6 @@ import (
 	"os/exec"
 	"os/signal"
 	"path/filepath"
-	"regexp"
 	"runtime"
 	"runtime/pprof"
 	"runtime/trace"
@@ -96,8 +95,6 @@ var (
 
 	// Dolt auto-commit policy (flag/config). Values: off | on
 	doltAutoCommit string
-
-	databaseIdentifierPattern = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_]*$`)
 
 	// commandDidWrite is set when a command performs a write that should trigger
 	// auto-flush. Used to decide whether to auto-commit Dolt after the command completes.
@@ -886,6 +883,9 @@ var rootCmd = &cobra.Command{
 		var dbNameFromDBFlag string
 		if cmd.Name() != "init" && cmd.Root().PersistentFlags().Changed("db") && dbPath != "" {
 			if _, statErr := os.Stat(dbPath); statErr != nil {
+				if !os.IsNotExist(statErr) {
+					return HandleError("--db %q: %v", dbPath, statErr)
+				}
 				dbNameFromDBFlag = dbPath
 				dbPath = ""
 			}
@@ -1366,8 +1366,8 @@ var rootCmd = &cobra.Command{
 			if !proxiedServerMode {
 				return HandleErrorRespectJSON("--database (or a --db value naming a database) is only supported in proxied-server mode")
 			}
-			if !databaseIdentifierPattern.MatchString(databaseOverride) {
-				return HandleErrorRespectJSON("invalid database name %q", databaseOverride)
+			if err := dolt.ValidateDatabaseName(databaseOverride); err != nil {
+				return HandleErrorRespectJSON("%v", err)
 			}
 		}
 

--- a/cmd/bd/main.go
+++ b/cmd/bd/main.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"os/signal"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"runtime/pprof"
 	"runtime/trace"
@@ -44,12 +45,13 @@ import (
 )
 
 var (
-	changeDir   string
-	dbPath      string
-	actor       string
-	store       storage.DoltStorage
-	uowProvider uow.UnitOfWorkProvider
-	jsonOutput  bool
+	changeDir    string
+	dbPath       string
+	databaseFlag string
+	actor        string
+	store        storage.DoltStorage
+	uowProvider  uow.UnitOfWorkProvider
+	jsonOutput   bool
 
 	// Signal-aware context for graceful cancellation
 	rootCtx    context.Context
@@ -94,6 +96,8 @@ var (
 
 	// Dolt auto-commit policy (flag/config). Values: off | on
 	doltAutoCommit string
+
+	databaseIdentifierPattern = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_]*$`)
 
 	// commandDidWrite is set when a command performs a write that should trigger
 	// auto-flush. Used to decide whether to auto-commit Dolt after the command completes.
@@ -671,7 +675,8 @@ func init() {
 
 	// Register persistent flags
 	rootCmd.PersistentFlags().StringVarP(&changeDir, "directory", "C", "", "Change to this directory before running the command (like git -C)")
-	rootCmd.PersistentFlags().StringVar(&dbPath, "db", "", "Database path (default: auto-discover .beads/*.db)")
+	rootCmd.PersistentFlags().StringVar(&dbPath, "db", "", "Database path (default: auto-discover .beads/*.db). In proxied-server mode, a value that isn't an existing path is treated as a database name override (see --database)")
+	rootCmd.PersistentFlags().StringVar(&databaseFlag, "database", "", "Run against a different server database for this invocation, without changing the project's configured database (proxied-server mode only)")
 	rootCmd.PersistentFlags().StringVar(&actor, "actor", "", "Actor name for audit trail (default: $BEADS_ACTOR, git user.name, $USER)")
 	rootCmd.PersistentFlags().BoolVar(&jsonOutput, "json", false, "Output in JSON format")
 	rootCmd.PersistentFlags().String("format", "", "Output format (json). Alias for --json")
@@ -878,6 +883,14 @@ var rootCmd = &cobra.Command{
 				WasSet bool
 			}{readonlyMode, true}
 		}
+		var dbNameFromDBFlag string
+		if cmd.Name() != "init" && cmd.Root().PersistentFlags().Changed("db") && dbPath != "" {
+			if _, statErr := os.Stat(dbPath); statErr != nil {
+				dbNameFromDBFlag = dbPath
+				dbPath = ""
+			}
+		}
+
 		if !cmd.Root().PersistentFlags().Changed("db") && dbPath == "" &&
 			os.Getenv("BEADS_DB") == "" && os.Getenv("BD_DB") == "" && os.Getenv("BEADS_DIR") == "" {
 			dbPath = config.GetString("db")
@@ -1342,10 +1355,26 @@ var rootCmd = &cobra.Command{
 		// other helper paths stay in lockstep with the main command path.
 		dolt.ApplyCLIAutoStart(beadsDir, doltCfg)
 
+		databaseOverride := databaseFlag
+		if dbNameFromDBFlag != "" {
+			if databaseOverride != "" && databaseOverride != dbNameFromDBFlag {
+				return HandleError("conflicting database selection: --db=%q vs --database=%q", dbNameFromDBFlag, databaseOverride)
+			}
+			databaseOverride = dbNameFromDBFlag
+		}
+		if databaseOverride != "" {
+			if !proxiedServerMode {
+				return HandleErrorRespectJSON("--database (or a --db value naming a database) is only supported in proxied-server mode")
+			}
+			if !databaseIdentifierPattern.MatchString(databaseOverride) {
+				return HandleErrorRespectJSON("invalid database name %q", databaseOverride)
+			}
+		}
+
 		// In proxied mode the CLI short-circuits to the uowProvider path and
 		// dispatches through the *_proxied_server.go duals.
 		if proxiedServerMode {
-			p, err := newProxiedServerUOWProvider(rootCtx, beadsDir)
+			p, err := newProxiedServerUOWProvider(rootCtx, beadsDir, databaseOverride)
 			if err != nil {
 				return HandleError("failed to open uow provider: %v", err)
 			}

--- a/cmd/bd/main.go
+++ b/cmd/bd/main.go
@@ -882,7 +882,8 @@ var rootCmd = &cobra.Command{
 			}{readonlyMode, true}
 		}
 		var dbNameFromDBFlag string
-		if cmd.Name() != "init" && cmd.Root().PersistentFlags().Changed("db") && dbPath != "" {
+		if cmd.Name() != "init" && cmd.Root().PersistentFlags().Changed("db") && dbPath != "" &&
+			dbidentifier.ValidateIdentifier(dbPath) == nil {
 			if _, statErr := os.Stat(dbPath); statErr != nil {
 				if !os.IsNotExist(statErr) {
 					return HandleError("--db %q: %v", dbPath, statErr)

--- a/cmd/bd/sql.go
+++ b/cmd/bd/sql.go
@@ -51,14 +51,9 @@ WARNING: Direct database access bypasses the storage layer. Use with caution.`,
 		}
 		query := args[0]
 		csvOutput, _ := cmd.Flags().GetBool("csv")
-		database, _ := cmd.Flags().GetString("database")
 
 		if usesProxiedServer() {
-			return runSQLProxiedServer(rootCtx, query, csvOutput, database)
-		}
-
-		if database != "" {
-			return HandleErrorRespectJSON("--database is only supported in proxied-server mode")
+			return runSQLProxiedServer(rootCtx, query, csvOutput)
 		}
 
 		if store == nil {
@@ -233,7 +228,6 @@ WARNING: Direct database access bypasses the storage layer. Use with caution.`,
 
 func init() {
 	sqlCmd.Flags().Bool("csv", false, "Output results in CSV format")
-	sqlCmd.Flags().String("database", "", "Run the query against a different server database (proxied-server mode only)")
 
 	// Register as a read-only command for SELECT queries.
 	// Write queries will be caught by CheckReadonly.

--- a/cmd/bd/sql_proxied_server.go
+++ b/cmd/bd/sql_proxied_server.go
@@ -11,7 +11,7 @@ import (
 	"github.com/steveyegge/beads/internal/storage/uow"
 )
 
-func runSQLProxiedServer(ctx context.Context, query string, csvOutput bool, database string) error {
+func runSQLProxiedServer(ctx context.Context, query string, csvOutput bool) error {
 	if uowProvider == nil {
 		return HandleError("proxied-server UOW provider not initialized")
 	}
@@ -20,11 +20,6 @@ func runSQLProxiedServer(ctx context.Context, query string, csvOutput bool, data
 
 	if !multiStatement && sqlQueryIsRead(query) {
 		result, err := uow.RunTxRead(ctx, uowProvider, func(ctx context.Context, uw uow.UnitOfWork) (*domain.RawSQLResult, error) {
-			if database != "" {
-				if err := uw.SwitchDatabase(ctx, database); err != nil {
-					return nil, err
-				}
-			}
 			return uw.RawSQLUseCase().Query(ctx, query)
 		})
 		if err != nil {
@@ -36,11 +31,6 @@ func runSQLProxiedServer(ctx context.Context, query string, csvOutput bool, data
 	CheckReadonly("sql")
 
 	affected, err := uow.RunTxResult(ctx, uowProvider, func(ctx context.Context, uw uow.UnitOfWork) (int64, string, error) {
-		if database != "" {
-			if err := uw.SwitchDatabase(ctx, database); err != nil {
-				return 0, "", err
-			}
-		}
 		affected, err := uw.RawSQLUseCase().Exec(ctx, query)
 		if err != nil {
 			return 0, "", err

--- a/cmd/bd/uow_factory.go
+++ b/cmd/bd/uow_factory.go
@@ -14,7 +14,7 @@ import (
 	"github.com/steveyegge/beads/internal/storage/uow"
 )
 
-func newProxiedServerUOWProvider(ctx context.Context, beadsDir string) (uow.UnitOfWorkProvider, error) {
+func newProxiedServerUOWProvider(ctx context.Context, beadsDir, databaseOverride string) (uow.UnitOfWorkProvider, error) {
 	if beadsDir == "" {
 		return nil, fmt.Errorf("newProxiedServerUOWProvider: beadsDir must be set")
 	}
@@ -23,6 +23,9 @@ func newProxiedServerUOWProvider(ctx context.Context, beadsDir string) (uow.Unit
 	database := configfile.DefaultDoltDatabase
 	if persisted != nil {
 		database = persisted.GetDoltDatabase()
+	}
+	if databaseOverride != "" {
+		database = databaseOverride
 	}
 
 	info, _ := configfile.LoadProxiedServerClientInfo(beadsDir)

--- a/cmd/bd/uow_factory_test.go
+++ b/cmd/bd/uow_factory_test.go
@@ -18,7 +18,7 @@ func TestNewProxiedServerUOWProvider_RoutesExternalConfigToExternalProvider(t *t
 		},
 	}))
 
-	_, err := newProxiedServerUOWProvider(context.Background(), beadsDir)
+	_, err := newProxiedServerUOWProvider(context.Background(), beadsDir, "")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "Host requires Port",
 		"expected external validation error proving the external code path was taken; got: %v", err)
@@ -44,7 +44,7 @@ func TestNewExternalProxiedServerUOWProvider_HonorsCustomRootPath(t *testing.T) 
 		External: &configfile.ExternalDoltConfig{Host: "db.invalid"},
 	}))
 
-	_, err := newProxiedServerUOWProvider(context.Background(), beadsDir)
+	_, err := newProxiedServerUOWProvider(context.Background(), beadsDir, "")
 	require.Error(t, err, "invalid external config must surface a validation error")
 
 	assert.DirExists(t, customRoot, "external provider should create the custom root dir, not the default")
@@ -61,7 +61,7 @@ func TestNewExternalProxiedServerUOWProvider_HonorsCustomLogPath(t *testing.T) {
 		External: &configfile.ExternalDoltConfig{Host: "db.invalid"},
 	}))
 
-	_, err := newProxiedServerUOWProvider(context.Background(), beadsDir)
+	_, err := newProxiedServerUOWProvider(context.Background(), beadsDir, "")
 	require.Error(t, err, "invalid external config must surface a validation error")
 	assert.Contains(t, err.Error(), "Host requires Port",
 		"external code path must be the one reached; got: %v", err)

--- a/internal/storage/domain/db/ddl.go
+++ b/internal/storage/domain/db/ddl.go
@@ -8,6 +8,20 @@ import (
 
 var validIdentifier = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_]*$`)
 
+const maxIdentifierLength = 64
+
+// ValidateIdentifier checks whether name is safe to use, unquoted, as a
+// database or table identifier in this package's DDL statements.
+func ValidateIdentifier(name string) error {
+	if len(name) > maxIdentifierLength {
+		return fmt.Errorf("identifier too long: %q (max %d chars)", name, maxIdentifierLength)
+	}
+	if !validIdentifier.MatchString(name) {
+		return fmt.Errorf("invalid identifier: %q", name)
+	}
+	return nil
+}
+
 type DDLSQLRepository interface {
 	CreateDatabaseIfNotExists(ctx context.Context, database string) error
 	// CreateDatabase issues a bare CREATE DATABASE (no IF NOT EXISTS) so the
@@ -63,8 +77,8 @@ func (r *ddlSQLRepository) UseDatabase(ctx context.Context, database string) err
 }
 
 func quoteIdentifier(name string) (string, error) {
-	if !validIdentifier.MatchString(name) {
-		return "", fmt.Errorf("invalid identifier: %q", name)
+	if err := ValidateIdentifier(name); err != nil {
+		return "", err
 	}
 	return "`" + name + "`", nil
 }


### PR DESCRIPTION
## Summary
- `--database <name>` is now a single global persistent flag (previously duplicated locally on `bd sql` and `bd init`), usable by any command in proxied-server mode to run against a different server database for that invocation only, without touching `config.yaml`/`metadata.json`.
- `--db <value>` now doubles as a database-name selector in proxied-server mode: if the value doesn't resolve to an existing filesystem path, it's treated as a database name (path resolution always wins when the value does exist on disk).
- `bd init` is exempt from the new `--db`-as-name heuristic — there, `--db`/`--database` still name/locate the primary database being provisioned (often a path/name that doesn't exist yet by design).
- `bd sql --database`, which previously implemented this via its own per-transaction `USE`, now gets the same behavior for free from the shared mechanism; its bespoke switching logic was removed.
- Database name overrides are validated against the same identifier pattern Dolt enforces server-side, and rejected outside proxied-server mode or on conflicting `--db`/`--database` values.

## Test plan
- [x] `go build ./...` / `go vet ./...`
- [x] `TestProxiedServerSQLDatabaseFlag`, `TestProxiedServerMultiStatementSQL` (via `BEADS_TEST_PROXIED_SERVER=1`)
- [x] `TestInitDatabaseFlag` validation subtests
- [x] Manual end-to-end: `--database`, `--db` as a name, `--db`/`--database` conflict detection, invalid-identifier rejection, `metadata.json` left untouched after a database switch, `bd init --db <not-yet-existing-path>` still provisions correctly