### PR TITLE
fix(preflight): classify status checks latest-per-name, not raw rollup entries

### DIFF
--- a/scripts/pr-preflight.sh
+++ b/scripts/pr-preflight.sh
@@ -300,9 +300,19 @@ fi
 # GitHub reports CLEAN (observed on gastownhall/beads#5073–5076: 20 stale
 # CANCELLED runs + 1 stale gate FAILURE alongside 80 green checks). Collapse
 # to the most recent entry per check name/context before classifying.
-rollup_latest=$(jq '[.statusCheckRollup[]?]
-  | group_by(.name // .context // "")
-  | map(max_by(.completedAt // .startedAt // .createdAt // ""))' <<<"$json")
+# Group key includes __typename and workflowName: a commit status and a
+# check run sharing a name are independent gates (GitHub requires both),
+# and identically named jobs in different workflows must not collapse into
+# one entry where a green run could mask the other workflow's red one.
+# gh exports absent CheckRun times as the zero time (0001-01-01...), so
+# normalize before comparing or the // fallback never fires; "latest" is
+# the max of completed/started/created so a fresh in-progress rerun beats
+# an old completed failure (and is then reported as pending, not failed).
+rollup_latest=$(jq '
+  def nz: (. // "") | if startswith("0001-") then "" else . end;
+  [.statusCheckRollup[]?]
+  | group_by([(.__typename // ""), (.workflowName // ""), (.name // .context // "")])
+  | map(max_by([(.completedAt | nz), (.startedAt | nz), (.createdAt | nz)] | max))' <<<"$json")
 failed_checks=$(jq '[.[] | select(
   ((.conclusion // "") | test("FAILURE|CANCELLED|TIMED_OUT|ACTION_REQUIRED")) or
   ((.state // "") | test("ERROR|FAILURE"))

--- a/scripts/pr-preflight.sh
+++ b/scripts/pr-preflight.sh
@@ -292,11 +292,22 @@ else
   warn "Could not determine CI health of base branch ${base_ref}; check it manually before merging."
 fi
 
-failed_checks=$(jq '[.statusCheckRollup[]? | select(
+# statusCheckRollup keeps every check run on the head SHA, including runs
+# from cancelled or superseded check suites. A head whose earlier suite was
+# cancelled mid-flight carries stale CANCELLED/FAILURE entries forever, next
+# to the fresh green re-runs of the same checks — GitHub's own mergeability
+# uses latest-per-name, so counting raw entries permanently blocks PRs that
+# GitHub reports CLEAN (observed on gastownhall/beads#5073–5076: 20 stale
+# CANCELLED runs + 1 stale gate FAILURE alongside 80 green checks). Collapse
+# to the most recent entry per check name/context before classifying.
+rollup_latest=$(jq '[.statusCheckRollup[]?]
+  | group_by(.name // .context // "")
+  | map(max_by(.completedAt // .startedAt // .createdAt // ""))' <<<"$json")
+failed_checks=$(jq '[.[] | select(
   ((.conclusion // "") | test("FAILURE|CANCELLED|TIMED_OUT|ACTION_REQUIRED")) or
   ((.state // "") | test("ERROR|FAILURE"))
-)] | length' <<<"$json")
-pending_checks=$(jq '[.statusCheckRollup[]? | select(
+)] | length' <<<"$rollup_latest")
+pending_checks=$(jq '[.[] | select(
   if (.status? // null) != null then
     .status != "COMPLETED"
   elif (.state? // null) != null then
@@ -304,7 +315,7 @@ pending_checks=$(jq '[.statusCheckRollup[]? | select(
   else
     true
   end
-)] | length' <<<"$json")
+)] | length' <<<"$rollup_latest")
 if [[ "$failed_checks" -gt 0 ]]; then
   block "$failed_checks status check(s) failed or require action."
 elif [[ "$pending_checks" -gt 0 ]]; then

--- a/scripts/pr_preflight_test.go
+++ b/scripts/pr_preflight_test.go
@@ -41,7 +41,7 @@ const (
             ;;
         esac
       done
-      printf '%s\n' "{\"number\":${PR_NUMBER},\"title\":\"Compatibility fixture\",\"author\":{\"login\":\"contributor\"},\"url\":\"${PR_URL}\",\"baseRefName\":\"main\",\"headRefName\":\"fix/preflight\",\"headRepositoryOwner\":{\"login\":\"contributor\"},\"isCrossRepository\":true,\"isDraft\":false,\"maintainerCanModify\":true,\"mergeStateStatus\":\"CLEAN\",\"mergeable\":\"MERGEABLE\",\"reviewDecision\":\"APPROVED\",\"changedFiles\":1,\"additions\":1,\"deletions\":0,\"files\":[{\"path\":\"README.md\"}],\"statusCheckRollup\":[],\"latestReviews\":[]}"
+      printf '%s\n' "{\"number\":${PR_NUMBER},\"title\":\"Compatibility fixture\",\"author\":{\"login\":\"contributor\"},\"url\":\"${PR_URL}\",\"baseRefName\":\"main\",\"headRefName\":\"fix/preflight\",\"headRepositoryOwner\":{\"login\":\"contributor\"},\"isCrossRepository\":true,\"isDraft\":false,\"maintainerCanModify\":true,\"mergeStateStatus\":\"CLEAN\",\"mergeable\":\"MERGEABLE\",\"reviewDecision\":\"APPROVED\",\"changedFiles\":1,\"additions\":1,\"deletions\":0,\"files\":[{\"path\":\"README.md\"}],\"statusCheckRollup\":${PR_ROLLUP:-[]},\"latestReviews\":[]}"
       ;;
     "run list")
       printf '[]\n'
@@ -68,6 +68,7 @@ type preflightFixture struct {
 	canonicalURL    string
 	graphQLResponse string
 	graphQLExit     string
+	rollup          string
 }
 
 type preflightRun struct {
@@ -260,6 +261,41 @@ func TestPRPreflightFixtureIgnoresHostShellAndGitHubState(t *testing.T) {
 	}
 }
 
+// A head SHA whose earlier check suites were cancelled or failed keeps those
+// stale entries in statusCheckRollup next to the fresh green re-runs of the
+// same checks. GitHub's mergeability is latest-per-name; preflight must be
+// too, or green PRs stay blocked forever (gastownhall/beads#5073-5076).
+func TestPRPreflightChecksUseLatestRunPerName(t *testing.T) {
+	staleGreenRollup := `[` +
+		`{"name":"CI Gate / Required","status":"COMPLETED","conclusion":"FAILURE","completedAt":"2026-07-27T10:00:00Z"},` +
+		`{"name":"CI Gate / Required","status":"COMPLETED","conclusion":"SUCCESS","completedAt":"2026-07-28T10:00:00Z"},` +
+		`{"name":"Test (Proxied 1/2)","status":"COMPLETED","conclusion":"CANCELLED","completedAt":"2026-07-27T09:00:00Z"},` +
+		`{"name":"Test (Proxied 1/2)","status":"COMPLETED","conclusion":"SUCCESS","completedAt":"2026-07-28T09:00:00Z"},` +
+		`{"name":"Lint","status":"COMPLETED","conclusion":"SUCCESS","completedAt":"2026-07-28T08:00:00Z"}` +
+		`]`
+
+	t.Run("stale failures and cancellations are superseded by newer green runs", func(t *testing.T) {
+		run := runPRPreflightWithFakeGH(t, preflightFixture{rollup: staleGreenRollup})
+		if !strings.Contains(run.output, "No failed or pending status checks reported.") {
+			t.Fatalf("expected stale rollup entries to be superseded:\n%s", run.output)
+		}
+		if strings.Contains(run.output, "failed or require action") {
+			t.Fatalf("stale rollup entries still counted as failures:\n%s", run.output)
+		}
+	})
+
+	t.Run("a genuinely failing latest run still blocks", func(t *testing.T) {
+		freshRedRollup := `[` +
+			`{"name":"CI Gate / Required","status":"COMPLETED","conclusion":"SUCCESS","completedAt":"2026-07-27T10:00:00Z"},` +
+			`{"name":"CI Gate / Required","status":"COMPLETED","conclusion":"FAILURE","completedAt":"2026-07-28T10:00:00Z"}` +
+			`]`
+		run := runPRPreflightWithFakeGH(t, preflightFixture{rollup: freshRedRollup})
+		if !strings.Contains(run.output, "1 status check(s) failed or require action.") {
+			t.Fatalf("expected the latest failing run to block:\n%s", run.output)
+		}
+	})
+}
+
 func runPRPreflightWithFakeGH(t *testing.T, fixture preflightFixture) preflightRun {
 	t.Helper()
 
@@ -277,6 +313,9 @@ func runPRPreflightWithFakeGH(t *testing.T, fixture preflightFixture) preflightR
 	}
 	if fixture.graphQLExit == "" {
 		fixture.graphQLExit = "0"
+	}
+	if fixture.rollup == "" {
+		fixture.rollup = "[]"
 	}
 
 	bash, path := prPreflightProcessTools(t)
@@ -319,6 +358,7 @@ func runPRPreflightWithFakeGH(t *testing.T, fixture preflightFixture) preflightR
 		"GRAPHQL_RESPONSE="+fixture.graphQLResponse,
 		"PR_NUMBER="+fixture.returnedNumber,
 		"PR_URL="+fixture.canonicalURL,
+		"PR_ROLLUP="+fixture.rollup,
 	)
 	out, runErr := cmd.CombinedOutput()
 	logBytes, readErr := os.ReadFile(callLog)

--- a/scripts/pr_preflight_test.go
+++ b/scripts/pr_preflight_test.go
@@ -294,6 +294,42 @@ func TestPRPreflightChecksUseLatestRunPerName(t *testing.T) {
 			t.Fatalf("expected the latest failing run to block:\n%s", run.output)
 		}
 	})
+
+	t.Run("a commit status cannot supersede a same-named check run", func(t *testing.T) {
+		// GitHub treats a check run and a commit status sharing a name as
+		// independent required gates; both must pass.
+		mixedRollup := `[` +
+			`{"__typename":"CheckRun","name":"build","status":"COMPLETED","conclusion":"FAILURE","completedAt":"2026-07-28T10:00:00Z"},` +
+			`{"__typename":"StatusContext","context":"build","state":"SUCCESS","startedAt":"2026-07-28T11:00:00Z"}` +
+			`]`
+		run := runPRPreflightWithFakeGH(t, preflightFixture{rollup: mixedRollup})
+		if !strings.Contains(run.output, "1 status check(s) failed or require action.") {
+			t.Fatalf("expected the failing check run to block despite the same-named commit status:\n%s", run.output)
+		}
+	})
+
+	t.Run("identically named jobs in different workflows stay independent", func(t *testing.T) {
+		crossWorkflowRollup := `[` +
+			`{"__typename":"CheckRun","workflowName":"Main","name":"Test","status":"COMPLETED","conclusion":"FAILURE","completedAt":"2026-07-28T10:00:00Z"},` +
+			`{"__typename":"CheckRun","workflowName":"Nightly","name":"Test","status":"COMPLETED","conclusion":"SUCCESS","completedAt":"2026-07-28T11:00:00Z"}` +
+			`]`
+		run := runPRPreflightWithFakeGH(t, preflightFixture{rollup: crossWorkflowRollup})
+		if !strings.Contains(run.output, "1 status check(s) failed or require action.") {
+			t.Fatalf("expected the other workflow's red job to keep blocking:\n%s", run.output)
+		}
+	})
+
+	t.Run("an in-progress rerun with a zero completion time supersedes an old failure as pending", func(t *testing.T) {
+		// gh exports absent CheckRun times as the Go zero time, not null.
+		rerunRollup := `[` +
+			`{"__typename":"CheckRun","workflowName":"Main","name":"CI","status":"COMPLETED","conclusion":"FAILURE","startedAt":"2026-07-27T09:00:00Z","completedAt":"2026-07-27T10:00:00Z"},` +
+			`{"__typename":"CheckRun","workflowName":"Main","name":"CI","status":"IN_PROGRESS","conclusion":"","startedAt":"2026-07-28T12:00:00Z","completedAt":"0001-01-01T00:00:00Z"}` +
+			`]`
+		run := runPRPreflightWithFakeGH(t, preflightFixture{rollup: rerunRollup})
+		if !strings.Contains(run.output, "1 status check(s) are still pending.") {
+			t.Fatalf("expected the fresh rerun to classify as pending, not stale failure:\n%s", run.output)
+		}
+	})
 }
 
 func runPRPreflightWithFakeGH(t *testing.T, fixture preflightFixture) preflightRun {


### PR DESCRIPTION
## Why

The pr-babysit merge patrol was permanently unable to merge three green, approved PRs (#5073/#5074/#5076): preflight reported "21 status check(s) failed or require action" while GitHub showed `mergeStateStatus: CLEAN` and `gh pr checks` showed 80/80 pass. Each needed a manual in-session merge.

Root cause: `statusCheckRollup` keeps every check run on the head SHA, including runs from cancelled or superseded check suites. Those heads carried 20 stale CANCELLED proxied-test runs plus one stale `CI Gate / Required` FAILURE from an older suite, next to the fresh green re-runs of the same checks. Preflight counted raw rollup entries, so the stale ones blocked forever.

## What

Collapse the rollup to the most recent entry per check name/context (`completedAt`, falling back to `startedAt`/`createdAt`) before classifying failed/pending, mirroring GitHub's own latest-per-name mergeability semantics.

- A genuinely failing or pending *latest* run still blocks — regression-tested both directions.
- The fake-gh test harness now accepts an injectable rollup via `PR_ROLLUP` (defaults to `[]`, existing fixtures unchanged).

## Validation

- `go test -tags integration -run TestPRPreflight ./scripts/` — all pass, including the two new subtests.
- Live run against an open PR with re-run suites reports checks correctly.

_claude-fable-5-high on behalf of maphew_
