### PR TITLE
fix(dep): normalize --type aliases so blocked-by gates bd ready

### DIFF
--- a/cmd/bd/cli_fast_test.go
+++ b/cmd/bd/cli_fast_test.go
@@ -600,6 +600,44 @@ func TestCLI_DepAdd(t *testing.T) {
 	}
 }
 
+// TestCLI_DepAdd_TypeBlockedByAliasGates is the regression test for GH#5069:
+// `bd dep add A B --type blocked-by` used to store the literal custom type
+// "blocked-by" instead of normalizing it to the canonical "blocks" type, so
+// the dependency was displayed everywhere but silently never gated `bd
+// ready`/`bd blocked`. Assert the alias now gates exactly like the default
+// (canonical) type does.
+func TestCLI_DepAdd_TypeBlockedByAliasGates(t *testing.T) {
+	// Note: Not using t.Parallel() because inProcessMutex serializes execution anyway
+	tmpDir := setupCLITestDB(t)
+
+	out1 := runBDInProcess(t, tmpDir, "create", "Blocker", "-p", "1", "--json")
+	out2 := runBDInProcess(t, tmpDir, "create", "Blocked", "-p", "1", "--json")
+
+	var issue1, issue2 map[string]interface{}
+	json.Unmarshal([]byte(out1), &issue1)
+	json.Unmarshal([]byte(out2), &issue2)
+
+	blockerID := issue1["id"].(string)
+	blockedID := issue2["id"].(string)
+
+	// blockedID depends on (is blocked by) blockerID, using the --type
+	// blocked-by alias rather than the default "blocks" type.
+	out := runBDInProcess(t, tmpDir, "dep", "add", blockedID, blockerID, "--type", "blocked-by")
+	if !strings.Contains(out, "Added dependency") {
+		t.Fatalf("Expected 'Added dependency', got: %s", out)
+	}
+
+	blockedOut := runBDInProcess(t, tmpDir, "blocked")
+	if !strings.Contains(blockedOut, "Blocked") {
+		t.Errorf("Expected 'Blocked' issue in `bd blocked` output after --type blocked-by dep, got: %s", blockedOut)
+	}
+
+	readyOut := runBDInProcess(t, tmpDir, "ready")
+	if strings.Contains(readyOut, "Blocked") {
+		t.Errorf("Expected blocked issue to be excluded from `bd ready` after --type blocked-by dep, got: %s", readyOut)
+	}
+}
+
 func TestCLI_DepRemove(t *testing.T) {
 	// Note: Not using t.Parallel() because inProcessMutex serializes execution anyway
 	tmpDir := setupCLITestDB(t)

--- a/cmd/bd/create_deps.go
+++ b/cmd/bd/create_deps.go
@@ -40,26 +40,54 @@ func parseDepSpec(raw string) (domain.DependencySpec, error) {
 	rawType := types.DependencyType(strings.TrimSpace(parts[0]))
 	target := strings.TrimSpace(parts[1])
 
-	spec := domain.DependencySpec{TargetID: target}
-	switch rawType {
-	case "depends-on", "blocked-by":
-		spec.Type = types.DepBlocks
-	case types.DepBlocks:
-		spec.Type = types.DepBlocks
+	spec := domain.DependencySpec{TargetID: target, Type: canonicalDependencyType(rawType)}
+	if rawType == types.DepBlocks {
+		// Explicit "blocks:" (as opposed to the "depends-on"/"blocked-by"
+		// aliases, which keep direction) reverses direction: the target
+		// depends on the issue being created, not the other way around.
 		spec.SwapDirection = true
-	default:
-		spec.Type = rawType
 	}
 
-	if !spec.Type.IsValid() {
-		return domain.DependencySpec{}, fmt.Errorf("invalid dependency type %q (must be non-empty, max 50 chars); valid types: %s",
-			spec.Type, createDepsAcceptedTypeList())
-	}
-	if !spec.Type.IsWellKnown() {
-		return domain.DependencySpec{}, fmt.Errorf("unknown dependency type %q; valid types: %s",
-			spec.Type, createDepsAcceptedTypeList())
+	if err := validateDependencyType(spec.Type); err != nil {
+		return domain.DependencySpec{}, err
 	}
 	return spec, nil
+}
+
+// canonicalDependencyType maps the documented alias spellings "depends-on"
+// and "blocked-by" to the canonical "blocks" storage type that ready/blocked
+// gating checks (types.DependencyType.AffectsReadyWork). Both `bd create
+// --deps` and `bd dep add --type` share this mapping so an alias always
+// gates the same way as the canonical type — see GH#5069, where `bd dep add
+// --type blocked-by` stored the literal string "blocked-by" and silently
+// never gated `bd ready`/`bd blocked`, even though `--help` itself documents
+// "blocked-by" as the flag name. Any other value (including well-known types
+// like "parent-child" and custom types) passes through unchanged.
+func canonicalDependencyType(t types.DependencyType) types.DependencyType {
+	switch t {
+	case "depends-on", "blocked-by":
+		return types.DepBlocks
+	default:
+		return t
+	}
+}
+
+// validateDependencyType enforces that a (post-alias-normalization)
+// dependency type is both structurally valid and one of the well-known
+// built-in types. `bd create --deps` and `bd dep add --type` intentionally
+// reject custom/unknown dependency types (see the comment on
+// WellKnownDependencyTypes) — this is the single shared check so both
+// commands stay in lockstep.
+func validateDependencyType(t types.DependencyType) error {
+	if !t.IsValid() {
+		return fmt.Errorf("invalid dependency type %q (must be non-empty, max 50 chars); valid types: %s",
+			t, createDepsAcceptedTypeList())
+	}
+	if !t.IsWellKnown() {
+		return fmt.Errorf("unknown dependency type %q; valid types: %s",
+			t, createDepsAcceptedTypeList())
+	}
+	return nil
 }
 
 // buildWaitsFor validates and constructs a WaitsForSpec from the --waits-for

--- a/cmd/bd/create_deps_test.go
+++ b/cmd/bd/create_deps_test.go
@@ -107,6 +107,65 @@ func TestParseDepSpecs(t *testing.T) {
 	}
 }
 
+// TestCanonicalDependencyType is a table test for the alias-normalization
+// helper shared by `bd create --deps` (parseDepSpec) and `bd dep add --type`
+// (GH#5069): both "blocked-by" and "depends-on" must map to the canonical
+// "blocks" type that ready/blocked gating checks, and any other value
+// (well-known or custom) must pass through unchanged.
+func TestCanonicalDependencyType(t *testing.T) {
+	tests := []struct {
+		name string
+		in   types.DependencyType
+		want types.DependencyType
+	}{
+		{"blocked-by aliases to blocks", "blocked-by", types.DepBlocks},
+		{"depends-on aliases to blocks", "depends-on", types.DepBlocks},
+		{"blocks passes through unchanged", types.DepBlocks, types.DepBlocks},
+		{"parent-child passes through unchanged", types.DepParentChild, types.DepParentChild},
+		{"discovered-from passes through unchanged", types.DepDiscoveredFrom, types.DepDiscoveredFrom},
+		{"unknown type passes through unchanged", "totally-custom", "totally-custom"},
+		{"empty type passes through unchanged", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := canonicalDependencyType(tt.in); got != tt.want {
+				t.Errorf("canonicalDependencyType(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestValidateDependencyType covers the shared validity/well-known-ness gate
+// used by both `bd create --deps` and `bd dep add --type`. Per the intent
+// documented on types.WellKnownDependencyTypes, both commands reject
+// custom/unknown dependency types identically.
+func TestValidateDependencyType(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      types.DependencyType
+		wantErr bool
+	}{
+		{"canonical blocks accepted", types.DepBlocks, false},
+		{"parent-child accepted", types.DepParentChild, false},
+		{"discovered-from accepted", types.DepDiscoveredFrom, false},
+		{"related accepted", types.DepRelated, false},
+		{"empty type rejected", "", true},
+		{"unknown/custom type rejected", "totally-custom", true},
+		{"unnormalized alias rejected (caller must normalize first)", "blocked-by", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateDependencyType(tt.in)
+			if tt.wantErr && err == nil {
+				t.Fatalf("validateDependencyType(%q) = nil, want error", tt.in)
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("validateDependencyType(%q) unexpected error: %v", tt.in, err)
+			}
+		})
+	}
+}
+
 func TestBuildWaitsFor(t *testing.T) {
 	t.Run("empty spawner without explicit gate returns nil", func(t *testing.T) {
 		got, err := buildWaitsFor("", "", false)

--- a/cmd/bd/dep.go
+++ b/cmd/bd/dep.go
@@ -378,13 +378,13 @@ Examples:
 			}
 		}
 
-		dt := types.DependencyType(depType)
+		dt := canonicalDependencyType(types.DependencyType(depType))
 		if isDisallowedHierarchicalDependency(fromID, toID, dt) {
 			return HandleErrorRespectJSON("cannot add dependency: %s is already a child of %s. Children inherit dependency on parent completion via hierarchy. Adding an explicit dependency would create a deadlock", fromID, toID)
 		}
 
-		if !dt.IsValid() {
-			return HandleErrorRespectJSON("invalid dependency type %q: must be non-empty and at most 50 characters", depType)
+		if err := validateDependencyType(dt); err != nil {
+			return HandleErrorRespectJSON("%v", err)
 		}
 
 		dep := &types.Dependency{
@@ -414,12 +414,12 @@ Examples:
 				"status":        "added",
 				"issue_id":      fromID,
 				"depends_on_id": toID,
-				"type":          depType,
+				"type":          string(dt),
 			})
 		}
 
 		fmt.Printf("%s Added dependency: %s depends on %s (%s)\n",
-			ui.RenderPass("✓"), formatFeedbackIDParen(fromID, lookupTitle(fromID)), formatFeedbackIDParen(toID, lookupTitle(toID)), depType)
+			ui.RenderPass("✓"), formatFeedbackIDParen(fromID, lookupTitle(fromID)), formatFeedbackIDParen(toID, lookupTitle(toID)), dt)
 		return nil
 	},
 }
@@ -608,11 +608,12 @@ func readBulkDepEdges(file string, defaultType string) ([]bulkDepEdge, error) {
 		if to == "" {
 			errs = append(errs, fmt.Sprintf("line %d: missing to", lineNo))
 		}
-		dt := types.DependencyType(depType)
-		if !dt.IsValid() {
-			errs = append(errs, fmt.Sprintf("line %d: invalid dependency type %q: must be non-empty and at most 50 characters", lineNo, depType))
+		dt := canonicalDependencyType(types.DependencyType(depType))
+		typeErr := validateDependencyType(dt)
+		if typeErr != nil {
+			errs = append(errs, fmt.Sprintf("line %d: %v", lineNo, typeErr))
 		}
-		if from == "" || to == "" || !dt.IsValid() {
+		if from == "" || to == "" || typeErr != nil {
 			continue
 		}
 
@@ -1573,7 +1574,7 @@ func init() {
 	depCmd.Flags().StringP("blocks", "b", "", "Issue ID that this issue blocks (shorthand for: bd dep add <blocked> <blocker>)")
 	depCmd.Flags().Bool("no-cycle-check", false, "Skip per-edge cycle checks for speed (bulk wiring); bulk --file adds still run one final whole-graph check before commit")
 
-	depAddCmd.Flags().StringP("type", "t", "blocks", "Dependency type (blocks|tracks|related|parent-child|discovered-from|until|caused-by|validates|relates-to|supersedes)")
+	depAddCmd.Flags().StringP("type", "t", "blocks", "Dependency type (blocks|tracks|related|parent-child|discovered-from|until|caused-by|validates|relates-to|supersedes); 'blocked-by' and 'depends-on' are accepted as aliases for 'blocks'")
 	depAddCmd.Flags().String("blocked-by", "", "Issue ID that blocks the first issue (alternative to positional arg)")
 	depAddCmd.Flags().String("depends-on", "", "Issue ID that the first issue depends on (alias for --blocked-by)")
 	depAddCmd.Flags().String("file", "", "Read dependency edges from JSONL file, or '-' for stdin")

--- a/cmd/bd/dep_proxied_server.go
+++ b/cmd/bd/dep_proxied_server.go
@@ -155,13 +155,13 @@ func runDepAddProxiedServer(cmd *cobra.Command, ctx context.Context, args []stri
 		toID = dependsOnArg
 	}
 
-	dt := types.DependencyType(depType)
+	dt := canonicalDependencyType(types.DependencyType(depType))
 	if isDisallowedHierarchicalDependency(fromID, toID, dt) {
 		return HandleErrorRespectJSON("cannot add dependency: %s is already a child of %s. Children inherit dependency on parent completion via hierarchy. Adding an explicit dependency would create a deadlock", fromID, toID)
 	}
 
-	if !dt.IsValid() {
-		return HandleErrorRespectJSON("invalid dependency type %q: must be non-empty and at most 50 characters", depType)
+	if err := validateDependencyType(dt); err != nil {
+		return HandleErrorRespectJSON("%v", err)
 	}
 
 	if uowProvider == nil {
@@ -201,7 +201,7 @@ func runDepAddProxiedServer(cmd *cobra.Command, ctx context.Context, args []stri
 			"status":        "added",
 			"issue_id":      fromID,
 			"depends_on_id": toID,
-			"type":          depType,
+			"type":          string(dt),
 		})
 		return nil
 	}
@@ -210,7 +210,7 @@ func runDepAddProxiedServer(cmd *cobra.Command, ctx context.Context, args []stri
 		ui.RenderPass("✓"),
 		formatFeedbackIDParen(fromID, res.fromTitle),
 		formatFeedbackIDParen(toID, res.toTitle),
-		depType)
+		dt)
 	return nil
 }
 


### PR DESCRIPTION
## What

`bd dep add A B --type blocked-by` (and `--type depends-on`, via the single-edge, bulk `--file`, and proxied-server code paths) now normalizes to the canonical `blocks` storage type, through shared `canonicalDependencyType()`/`validateDependencyType()` helpers extracted from `bd create --deps`'s existing alias handling. `dep add --type` also now rejects unknown/custom dependency types, matching `create --deps`'s existing behavior, and its output reports the stored canonical type rather than echoing the raw flag value.

## Why

`--type blocked-by` — the exact word `bd dep add --help` itself uses to describe the blocking relationship — silently stored the literal string `blocked-by`. The edge displayed correctly everywhere (`dep list`, `dep tree`, `show`), but never gated `bd ready`/`bd blocked`, which check the canonical type constants. An edge that looks right everywhere you inspect it and enforces nothing is worse than an error; it bit our own coordination tracker twice this week before we traced it.

The `--type` path simply lacked the alias mapping that `create --deps` already had; this consolidates both paths onto one implementation so they cannot drift again. The design intent documented on `types.WellKnownDependencyTypes()` ("accepted by user-facing commands that intentionally reject custom dependency types") already reads as plural — `dep add` was the straggler.

Fixes #5069.

## Verification

- New table tests `TestCanonicalDependencyType` / `TestValidateDependencyType`; existing `TestParseDepSpecs` and dep-suite tests all pass.
- New command-level regression test `TestCLI_DepAdd_TypeBlockedByAliasGates` pins the exact reported repro: after `--type blocked-by`, the issue appears in `bd blocked` and is excluded from `bd ready`. Passes in isolation; the integration suite in our sandbox has pre-existing unrelated testcontainers flakiness (reproduced with unmodified baseline tests).
- `go build` / `go vet` / `gofmt` clean with `CGO_ENABLED=1 -tags gms_pure_go`.

Known adjacent gaps NOT fixed here (same pattern, filed separately so this stays reviewable): `bd link` and `bd batch`'s `dep.add` operation still store `--type` values verbatim.

Note: #4833 touches `cmd/bd/create_deps.go` for a different `--deps` bug (multi-type same-target collision) — functionally independent, textual overlap only; happy to rebase whichever lands second.

_claude-fable-5-high on behalf of maphew_
