### PR TITLE
ci: shard Embedded Dolt Storage into 5 manifest-driven shards

### DIFF
--- a/.github/scripts/embedded-storage-test-shard.sh
+++ b/.github/scripts/embedded-storage-test-shard.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+# embedded-storage-test-shard.sh — run a shard of embedded dolt storage tests.
+#
+# Usage: embedded-storage-test-shard.sh <shard_number> <total_shards>
+#
+# Discovers all top-level Test* functions from
+# internal/storage/embeddeddolt/*_test.go, excluding TestConformance. That
+# suite runs in the dedicated test-embedded-conformance job instead, sharded
+# by sub-test path (core/audit) rather than by top-level function name; this
+# manifest's exact-name matching does not cover it. See
+# engdocs/CI_REQUIRED_CHECK_TOPOLOGY.md for why the two use different
+# sharding mechanisms.
+#
+# Tests listed in embedded-storage-test-shards.txt for the requested shard
+# count use that committed assignment; newly-added tests fall back to
+# hash(name) % total. Runs the matching subset using the pre-built test
+# binary at BEADS_TEST_EMBEDDED_TEST_BINARY (or /tmp/embeddeddolt-test).
+#
+# Every store-open in these tests re-runs the full migration chain, which
+# grows with each migration (bd-lrgn1 pushed a slow runner past the old
+# unsharded job's 20m). The manifest spreads TestEmbeddedMigration* /
+# TestEmbeddedMigrate* tests round-robin across shards (~2-3 each of ~11
+# total) rather than clustering them, so each shard's migration-chain
+# overhead is a fraction of what the unsharded job carried.
+#
+# Environment:
+#   BEADS_TEST_EMBEDDED_DOLT=1              required (tests skip without it)
+#   BEADS_TEST_EMBEDDED_TEST_BINARY=<path>  pre-built storage test binary
+#                                            (default: /tmp/embeddeddolt-test)
+#   BEADS_TEST_SHARD_LIST_ONLY=1            print selected tests without running them
+
+set -euo pipefail
+
+SHARD_NUMBER="${1:?usage: $0 <shard_number> <total_shards>}"
+TOTAL_SHARDS="${2:?usage: $0 <shard_number> <total_shards>}"
+shift 2
+
+if ! [[ "$SHARD_NUMBER" =~ ^[0-9]+$ ]] || ! [[ "$TOTAL_SHARDS" =~ ^[0-9]+$ ]]; then
+  echo "Shard number and total shards must be positive integers" >&2
+  exit 1
+fi
+if (( TOTAL_SHARDS < 1 || SHARD_NUMBER < 1 || SHARD_NUMBER > TOTAL_SHARDS )); then
+  echo "Invalid shard ${SHARD_NUMBER}/${TOTAL_SHARDS}" >&2
+  exit 1
+fi
+
+SHARD_INDEX=$(( SHARD_NUMBER - 1 ))
+MANIFEST="${BEADS_TEST_SHARD_MANIFEST:-.github/scripts/embedded-storage-test-shards.txt}"
+
+# Discover all top-level Test* functions except TestConformance, which is
+# sharded separately (core/audit sub-test partition in the workflow, not this
+# manifest) because it is a single top-level function with sub-tests reached
+# via -test.run path regex, not distinct top-level function names.
+ALL_TESTS=$(grep -rh '^func Test' internal/storage/embeddeddolt/*_test.go \
+  | sed 's/func \(Test[A-Za-z0-9_]*\).*/\1/' \
+  | grep -v '^TestConformance$' \
+  | sort -u)
+
+if [ -z "$ALL_TESTS" ]; then
+  echo "No Test* functions found" >&2
+  exit 1
+fi
+
+declare -A ALL_TEST_SET=()
+while IFS= read -r name; do
+  ALL_TEST_SET["$name"]=1
+done <<< "$ALL_TESTS"
+
+declare -A MANIFEST_SHARDS=()
+if [ -f "$MANIFEST" ]; then
+  while IFS= read -r line || [ -n "$line" ]; do
+    line="${line%%#*}"
+    read -r manifest_total manifest_shard test_name extra <<< "$line"
+    if [ -z "${manifest_total:-}" ]; then
+      continue
+    fi
+    if [ -n "${extra:-}" ] || ! [[ "$manifest_total" =~ ^[0-9]+$ ]] || ! [[ "$manifest_shard" =~ ^[0-9]+$ ]] || ! [[ "$test_name" =~ ^Test[A-Za-z0-9_]+$ ]] || [ "$test_name" = "TestConformance" ]; then
+      echo "Invalid shard manifest line: $line" >&2
+      exit 1
+    fi
+    if (( manifest_total != TOTAL_SHARDS )); then
+      continue
+    fi
+    if (( manifest_shard < 1 || manifest_shard > TOTAL_SHARDS )); then
+      echo "Invalid shard ${manifest_shard}/${manifest_total} for $test_name in $MANIFEST" >&2
+      exit 1
+    fi
+    if [ -n "${MANIFEST_SHARDS[$test_name]:-}" ]; then
+      echo "Duplicate shard manifest entry for $test_name in $MANIFEST" >&2
+      exit 1
+    fi
+    MANIFEST_SHARDS["$test_name"]="$manifest_shard"
+  done < "$MANIFEST"
+fi
+
+for name in "${!MANIFEST_SHARDS[@]}"; do
+  if [ -z "${ALL_TEST_SET[$name]:-}" ]; then
+    echo "Shard manifest entry does not match a discovered test: $name" >&2
+    exit 1
+  fi
+done
+
+SHARD_TESTS=()
+MANIFEST_COUNT=0
+FALLBACK_COUNT=0
+while IFS= read -r name; do
+  assigned_shard="${MANIFEST_SHARDS[$name]:-}"
+  if [ -n "$assigned_shard" ]; then
+    if (( assigned_shard == SHARD_NUMBER )); then
+      SHARD_TESTS+=("$name")
+      MANIFEST_COUNT=$(( MANIFEST_COUNT + 1 ))
+    fi
+    continue
+  fi
+
+  # Use cksum for a portable numeric hash fallback for newly-added tests.
+  hash=$(printf %s "$name" | cksum | cut -d ' ' -f 1)
+  if (( hash % TOTAL_SHARDS == SHARD_INDEX )); then
+    SHARD_TESTS+=("$name")
+    FALLBACK_COUNT=$(( FALLBACK_COUNT + 1 ))
+  fi
+done <<< "$ALL_TESTS"
+
+if [ ${#SHARD_TESTS[@]} -eq 0 ]; then
+  echo "Shard ${SHARD_NUMBER}/${TOTAL_SHARDS}: no tests assigned (all hashed to other shards)"
+  exit 0
+fi
+
+# Build the -run regex: "^(TestA|TestB|TestC)$"
+RUN_REGEX="^($(IFS='|'; echo "${SHARD_TESTS[*]}"))$"
+
+echo "Shard ${SHARD_NUMBER}/${TOTAL_SHARDS}: running ${#SHARD_TESTS[@]} test(s)"
+echo "  manifest: ${MANIFEST_COUNT}, fallback: ${FALLBACK_COUNT}"
+printf "  %s\n" "${SHARD_TESTS[@]}"
+echo ""
+
+# Use pre-built test binary if available, otherwise fall back to go test.
+STORAGE_BINARY="${BEADS_TEST_EMBEDDED_TEST_BINARY:-/tmp/embeddeddolt-test}"
+if [ "${BEADS_TEST_SHARD_LIST_ONLY:-}" = "1" ]; then
+  exit 0
+fi
+
+if [ -x "$STORAGE_BINARY" ]; then
+  exec "$STORAGE_BINARY" -test.v -test.count=1 -test.timeout=15m \
+    -test.run "$RUN_REGEX" \
+    "$@"
+else
+  echo "Warning: pre-built test binary not found at $STORAGE_BINARY, falling back to go test"
+  exec go test -tags=gms_pure_go -v -race -count=1 -timeout 15m \
+    -run "$RUN_REGEX" \
+    "$@" \
+    ./internal/storage/embeddeddolt/
+fi

--- a/.github/scripts/embedded-storage-test-shards.txt
+++ b/.github/scripts/embedded-storage-test-shards.txt
@@ -1,0 +1,101 @@
+# Embedded storage test shard manifest.
+#
+# Format: <total_shards> <shard_number> <top_level_test_name>
+#
+# There is no committed recent per-test duration artifact for these tests
+# (engdocs/CI_CLEANUP_PLAN.md records only whole-job wall clock for the
+# unsharded storage job, and engdocs/CI_TEST_SURFACE_AUDIT.md does not track
+# per-test timing here either). This manifest assigns tests round-robin over
+# the alphabetically sorted discovered-test list for the 5-shard CI matrix,
+# which spreads adjacent same-prefix families (e.g. the seven
+# TestEmbeddedMergeAndSettle* tests, the TestEmbeddedMigration* tests, and the
+# four TestSearchIssues_MaxRows_* tests) across different shards instead of
+# clustering them in one, as a balance heuristic in the absence of timing
+# data. embedded-storage-test-shard.sh continues to hash-distribute
+# newly-added tests that are not listed here. TestConformance is deliberately
+# excluded — it runs in the separate test-embedded-conformance job, which
+# shards by sub-test path (core/audit), not by top-level function name, and
+# is a different mechanism from this manifest.
+5 1 TestActiveDatabaseSizeFailsForMissingEmbeddedDatabase
+5 2 TestActiveDatabaseSizeScopesToActiveEmbeddedDatabase
+5 3 TestAddDependency
+5 4 TestAddLabel
+5 5 TestBuildDSN_NoDatabase
+5 1 TestBuildDSN_SpacesInPath
+5 2 TestBuildDSN_WithDatabase
+5 3 TestCleanGitRemoteCacheGarbage
+5 4 TestCleanGitRemoteCacheGarbage_NoCacheDir
+5 5 TestCleanGitRemoteCacheGarbage_Throttled
+5 1 TestConcurrencyMultiProcess
+5 2 TestConcurrentOpenReturnsCached
+5 3 TestCountsIncludeWispDependencies
+5 4 TestCreateIssue
+5 5 TestCreateIssues
+5 1 TestCreateIssuesRejectStaleUpserts
+5 2 TestCreateRejectsCrossTableIDCollision
+5 3 TestEmbeddedCloseIssueChecked
+5 4 TestEmbeddedCloseIssueCheckedTransitiveBlockedCloses
+5 5 TestEmbeddedCloseIssueCheckedVersionCAS
+5 1 TestEmbeddedConfigCommitStagesConfig
+5 2 TestEmbeddedDirtyTablesGate_BlocksReopenThenWorkingSetReconcileRecovers
+5 3 TestEmbeddedGetMergeBlockersOnAQuietStore
+5 4 TestEmbeddedMergeAndSettleDirtyWorkingSetSurvivesRefusedMerge
+5 5 TestEmbeddedMergeAndSettleFKCascadeRepair
+5 1 TestEmbeddedMergeAndSettleMemoryConfigConflict
+5 2 TestEmbeddedMergeAndSettleMetadataConflict
+5 3 TestEmbeddedMergeAndSettleRefusesUnknownTable
+5 4 TestEmbeddedMergeAndSettleReportsOperatorConflicts
+5 5 TestEmbeddedMergeAndSettleSkipsNonMemoryConfigConflict
+5 1 TestEmbeddedMigrateConvergesUnderConcurrentInterruptedRetries_4566
+5 2 TestEmbeddedMigrateRepairedDependenciesIDColumnCommitsAtomicallyWithVersion53_4690
+5 3 TestEmbeddedMigrateSelfHealsAfterMidPassFault_4566
+5 4 TestEmbeddedMigrateStepCommitLeavesUntouchedUserDirt_4566
+5 5 TestEmbeddedMigration0047DelegatesToSplitTargetRepairAndConvergesThroughIgnoredChain
+5 1 TestEmbeddedMigration0057ConvertsTextEventsColumnsToLongtext
+5 2 TestEmbeddedMigration0058AddsOnlyMissingConstraintInMixedPopulation
+5 3 TestEmbeddedMigration0058CleansOrphanedAndInvalidWispDependenciesRowsBeforeAddingConstraints
+5 4 TestEmbeddedMigration0058HealsAlreadyAffectedDatabase
+5 5 TestEmbeddedOpenForReadOnlyCommand_LenientGate
+5 1 TestEmbeddedOpenReadOnly_FreshDatabaseNoWrites
+5 2 TestEmbeddedOpenReadOnly_SkipsGateAndMigrations
+5 3 TestEmbeddedRecomputeAllBlockedDirtyGraphIsTyped
+5 4 TestEmbeddedRecomputeAllBlockedWiring
+5 5 TestEmbeddedRemoteMigrateGate_BlocksReopen
+5 1 TestEmbeddedSyncCommitsConfigBeforeMerge
+5 2 TestEmbeddedUpdateIssueCheckedFieldGuards
+5 3 TestEmbeddedUpdateIssueCheckedVersionCAS
+5 4 TestEventsSinceEmbedded
+5 5 TestGetDependentRecordsEmbedded
+5 1 TestGetDependentRecordsForIssuesEmbedded
+5 2 TestGetIssue
+5 3 TestGetIssueCommentsPageEmbedded
+5 4 TestGetLabels
+5 5 TestGetNextChildID
+5 1 TestGetReadyWorkIncludeEphemeralAppliesWispFilters
+5 2 TestGetReadyWorkIncludeEphemeralExcludesNonReadyWisps
+5 3 TestGetReadyWorkMoleculeFilter
+5 4 TestHeartbeatRejectsWispEmbedded
+5 5 TestHelperProcess
+5 1 TestHistory_NullTextColumns
+5 2 TestHookFiringStoreCreateIssuesFiresDependencyUpdatesFromEmbeddedStore
+5 3 TestIsBlockedBatchEmbedded
+5 4 TestLeaseLifecycleEmbedded
+5 5 TestListWisps
+5 1 TestOpenAfterCloseCreatesNewStore
+5 2 TestOpenDifferentDirsReturnsDifferentStores
+5 3 TestOpenReturnsCachedStore
+5 4 TestPromoteStillWorksWithCollisionGuard
+5 5 TestReclaimAnyReplicaOverride
+5 1 TestReclaimExpiredLeaseSurvivesRestartEmbedded
+5 2 TestReclaimRefusesForeignReplicaLease
+5 3 TestReopenIssue
+5 4 TestSchemaAfterInit
+5 5 TestSearchIssuesKeysetEmbedded
+5 1 TestSearchIssues_MaxRows_Exceeded_ReturnsErrTooManyRows
+5 2 TestSearchIssues_MaxRows_NotExceeded
+5 3 TestSearchIssues_MaxRows_WithLimit
+5 4 TestSearchIssues_MaxRows_Zero_NoCap
+5 5 TestUnknownProvenanceLeaseStaysReclaimable
+5 1 TestUpdateIssueType
+5 2 TestUpdateMergeOps_DoltEngine
+5 3 TestUpdateMergeOps_DoltEngine_TwoIssues

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -812,10 +812,15 @@ jobs:
           retention-days: 1
 
   test-embedded-storage:
-    name: Test (Embedded Dolt Storage)
+    name: Test (Embedded Dolt Storage ${{ matrix.shard }}/${{ strategy.job-total }})
     needs: [detect-ci-tier, build-embedded]
     if: needs.detect-ci-tier.outputs.full_embedded == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4, 5]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
 
@@ -837,11 +842,12 @@ jobs:
         env:
           BEADS_TEST_EMBEDDED_DOLT: "1"
           BEADS_TEST_EMBEDDED_TEST_BINARY: /tmp/embeddeddolt-test
-        # Conformance runs in the dedicated test-embedded-conformance job
-        # below (mirrors pr-risk.yml); skip it here. The budget must cover
-        # every store-open re-running the full migration chain, which grows
-        # with each migration (bd-lrgn1 pushed a slow runner past 20m).
-        run: /tmp/embeddeddolt-test -test.v -test.count=1 -test.timeout=30m -test.skip '^TestConformance$'
+        # Manifest-driven shard of the storage suite (mirrors test-embedded-cmd
+        # / embedded-test-shard.sh). Conformance runs separately in the
+        # dedicated test-embedded-conformance job below (mirrors pr-risk.yml);
+        # embedded-storage-test-shard.sh excludes TestConformance from
+        # discovery, so it never lands in one of these shards.
+        run: bash .github/scripts/embedded-storage-test-shard.sh ${{ matrix.shard }} 5
 
   test-embedded-conformance:
     name: Test (Embedded Dolt Conformance - ${{ matrix.partition }})

--- a/.github/workflows/pr-risk.yml
+++ b/.github/workflows/pr-risk.yml
@@ -143,10 +143,15 @@ jobs:
           retention-days: 1
 
   test-embedded-storage:
-    name: Test (Embedded Dolt Storage)
+    name: Test (Embedded Dolt Storage ${{ matrix.shard }}/${{ strategy.job-total }})
     needs: [detect-ci-tier, build-embedded]
     if: needs.detect-ci-tier.outputs.full_embedded == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4, 5]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
 
@@ -168,11 +173,12 @@ jobs:
         env:
           BEADS_TEST_EMBEDDED_DOLT: "1"
           BEADS_TEST_EMBEDDED_TEST_BINARY: /tmp/embeddeddolt-test
-        # Conformance runs in the dedicated test-embedded-conformance job; skip
-        # it here. The budget must cover every store-open re-running the full
-        # migration chain, which grows with each migration (bd-lrgn1 pushed a
-        # slow runner past the old 20m).
-        run: /tmp/embeddeddolt-test -test.v -test.count=1 -test.timeout=30m -test.skip '^TestConformance$'
+        # Manifest-driven shard of the storage suite (mirrors test-embedded-cmd
+        # / embedded-test-shard.sh). Conformance runs separately in the
+        # dedicated test-embedded-conformance job; embedded-storage-test-shard.sh
+        # excludes TestConformance from discovery, so it never lands in one of
+        # these shards.
+        run: bash .github/scripts/embedded-storage-test-shard.sh ${{ matrix.shard }} 5
 
   test-embedded-conformance:
     name: Test (Embedded Dolt Conformance - ${{ matrix.partition }})

--- a/engdocs/CI_REQUIRED_CHECK_TOPOLOGY.md
+++ b/engdocs/CI_REQUIRED_CHECK_TOPOLOGY.md
@@ -89,7 +89,7 @@ Do not require these existing check names directly:
 - `Test (macos-latest)`
 - `Test (storage domain + uow)`
 - `Build (Embedded Dolt)`
-- `Test (Embedded Dolt Storage)`
+- `Test (Embedded Dolt Storage 1/5)` through `Test (Embedded Dolt Storage 5/5)`
 - `Test (Embedded Dolt Cmd 1/20)` through `Test (Embedded Dolt Cmd 20/20)`
 - `Test (Windows - smoke)`
 - `Check formatting`

--- a/engdocs/CI_TEST_SURFACE_AUDIT.md
+++ b/engdocs/CI_TEST_SURFACE_AUDIT.md
@@ -110,7 +110,9 @@ Embedded Dolt tests are split out from the PR/core matrix:
   coverage.
 - `build-embedded` prebuilds `/tmp/bd-embedded-test`,
   `/tmp/embeddeddolt-test`, and `/tmp/bd-cmd-test`.
-- `test-embedded-storage` runs the embedded storage test binary with
+- `test-embedded-storage` shards `internal/storage/embeddeddolt` `Test*`
+  (excluding `TestConformance`) across 5 jobs using
+  `.github/scripts/embedded-storage-test-shard.sh`, with
   `BEADS_TEST_EMBEDDED_DOLT=1`.
 - `test-embedded-cmd` shards `cmd/bd` `TestEmbedded*` across 20 jobs using
   `.github/scripts/embedded-test-shard.sh`.
@@ -178,7 +180,7 @@ Key jobs preserved by display name:
   `PR Lint (wrapper timing)`.
 - `Package Gate (MCP)`, `Package Gate (npm)`, and `Package Gate (website)`.
 - `Test (storage domain + uow)`.
-- `Build (Embedded Dolt)`, `Test (Embedded Dolt Storage)`, and
+- `Build (Embedded Dolt)`, `Test (Embedded Dolt Storage N/5)`, and
   `Test (Embedded Dolt Cmd N/20)`.
 - Aggregate required-check candidates: `PR / CI Gate / Required` and
   `PR Risk / CI Gate / Required`.


### PR DESCRIPTION
## What

Shard `Test (Embedded Dolt Storage)` into 5 manifest-driven shards, mirroring the existing `test-embedded-cmd` scheme (`embedded-test-shard.sh` + `embedded-cmd-test-shards.txt`, already 20-way):

- New `.github/scripts/embedded-storage-test-shard.sh` discovers top-level `Test*` functions in `internal/storage/embeddeddolt/*_test.go` (excluding `TestConformance`, which keeps its own dedicated job), consults a committed manifest for balance, and hash-falls-back for newly-added tests.
- New `.github/scripts/embedded-storage-test-shards.txt` assigns the 83 discovered tests round-robin over the alphabetically sorted list for 5 shards (17/17/17/16/16), spreading related families (7 `TestEmbeddedMergeAndSettle*`, ~11 `TestEmbeddedMigrat(e|ion)*`, 4 `TestSearchIssues_MaxRows_*`) across shards instead of clustering them.
- `test-embedded-storage` becomes a 5-way matrix job in both `main.yml` and `pr-risk.yml`, with `timeout-minutes: 15` and `-test.timeout=15m` per shard (half the old 30m budget, scaled to ~1/5 the tests).
- Updated the two required-check-name references (`engdocs/CI_REQUIRED_CHECK_TOPOLOGY.md`, `engdocs/CI_TEST_SURFACE_AUDIT.md`) from `Test (Embedded Dolt Storage)` to the `1/5` .. `5/5` range.

Merge-gate safety: the job id `test-embedded-storage` and env var `TEST_EMBEDDED_STORAGE` are unchanged — `pr-risk.yml`'s `ci-gate` references the job by id, and a matrixed job's `needs.<id>.result` is success only if all legs succeed, so the aggregate gate keeps working unmodified.

Conformance (core/audit split, ~14min each) is deliberately left alone: `TestConformance` shards by sub-test path (`-test.run '^TestConformance$/^Audit$'`), a different mechanism from this manifest's exact top-level function-name matching. It stays tracked separately for subtest-path sharding.

## Why

`Test (Embedded Dolt Storage)` ran ~24.3min unsharded — the longest pole in every Main/PR-Risk run — and timeout-red'd upstream `main` twice on 2026-07-28 at its 30m suite budget. Every added test tightens that ceiling further. Sharding cuts the wall-clock floor toward ~12min, directly weakening the CI-latency bypass incentive: push cadence regularly outruns CI verdict time on this repo, and the longest pole sets the floor.

## Verification

- YAML validity checked for both workflow files; `bash -n` + `shellcheck` clean on the new script (parity: also clean on the pre-existing `embedded-test-shard.sh`).
- Manifest dry-run (`BEADS_TEST_SHARD_LIST_ONLY=1`) confirms all 83 non-conformance tests assigned exactly once across 5 shards (17/17/17/16/16, 0 fallback, none lost or duplicated vs the 84 discovered `Test*` functions).
- No Go source touched; `go vet` clean on the package.
- Balance is a test-count heuristic (no per-test timing data exists in the repo — documented in the manifest header); expect one rebalance pass from real shard timings after this runs on CI a few times.
- GitHub Actions cannot be exercised locally; the split's first live run is this PR's own CI.

_claude-fable-5-high on behalf of maphew_
