### PR TITLE
fix(dolt): arm fresh-bootstrap heal in server-mode init (ports #5042, closes the #5012 family)

### DIFF
--- a/internal/storage/dolt/initschema_fresh_bootstrap_heal_test.go
+++ b/internal/storage/dolt/initschema_fresh_bootstrap_heal_test.go
@@ -1,0 +1,197 @@
+package dolt
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	_ "github.com/go-sql-driver/mysql"
+
+	"github.com/steveyegge/beads/internal/storage/doltutil"
+	"github.com/steveyegge/beads/internal/storage/schema"
+)
+
+// TestFreshBootstrapHealSelfHealsAfterMidPassFailure is the server-mode
+// (internal/storage/dolt) regression test for gastownhall/beads#5012,
+// porting the proxied/uow path's
+// TestNewExternalDoltServerUOWProvider_FreshInitSelfHealsAfterMidPassFailure
+// (merged #5042) to initSchemaOnDBWithRetryAndGateOwnership.
+//
+// The shape of the failure: New's openServerConnection proves this open
+// created the fresh target database (bare CREATE DATABASE succeeds), but the
+// first migration attempt dies mid-pass — simulated here by a per-step fault
+// hook that dirties a table right after migration 0001 commits and then
+// fails with a retryable error, the same shape as a session dying between a
+// step's SQL and its per-step Dolt commit. The outer retry
+// (initSchemaOnDBWithRetryAndGateOwnership) re-runs MigrateUpWithLock; its
+// #4566 dirty-table guard would normally treat that leftover debris as
+// pre-existing dirty user data and fail the open permanently — unless the
+// fresh-bootstrap ownership signal threaded from openServerConnection arms
+// schema.WithFreshBootstrapHeal, in which case the guard discards the debris
+// and the pass converges.
+func TestFreshBootstrapHealSelfHealsAfterMidPassFailure(t *testing.T) {
+	skipIfNoDolt(t)
+	acquireTestSlot()
+	t.Cleanup(releaseTestSlot)
+
+	tmpDir, err := os.MkdirTemp("", "dolt-fresh-heal-*")
+	if err != nil {
+		t.Fatalf("create temp dir: %v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(tmpDir) })
+
+	dbName := uniqueTestDBName(t)
+
+	fired := false
+	restore := schema.SetMigrateStepFaultHookForTest(func(ctx context.Context, db schema.DBConn, version int) error {
+		if version != 1 || fired {
+			return nil
+		}
+		fired = true
+		if _, err := db.ExecContext(ctx, "ALTER TABLE issues ADD COLUMN bd_freshheal_debris INT"); err != nil {
+			return fmt.Errorf("injecting mid-step debris: %w", err)
+		}
+		// Message text must land in isRetryableError's substring
+		// classification (internal/storage/dolt/store.go matches on
+		// err.Error() text, unlike the uow path's mysql-error-code-based
+		// isSerializationError) so the outer retry loop re-attempts instead
+		// of failing this open permanently on the very first attempt.
+		return fmt.Errorf("test-injected session death: lost connection to MySQL server during query")
+	})
+	t.Cleanup(restore)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	cfg := &Config{
+		Path:            tmpDir,
+		CommitterName:   "test",
+		CommitterEmail:  "test@example.com",
+		Database:        dbName,
+		MaxOpenConns:    1,
+		CreateIfMissing: true, // fresh database: this open must win the create race
+	}
+
+	store, err := New(ctx, cfg)
+	if err != nil {
+		t.Fatalf("New must converge after a mid-pass transient failure on a database it created, "+
+			"not trip the #4566 guard on its own bootstrap debris: %v", err)
+	}
+	t.Cleanup(func() { store.Close() })
+
+	if !fired {
+		t.Fatal("fault hook never fired; test no longer exercises the mid-pass failure path")
+	}
+
+	var debrisCols int
+	if err := store.db.QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM information_schema.columns WHERE table_name = 'issues' AND column_name = 'bd_freshheal_debris'",
+	).Scan(&debrisCols); err != nil {
+		t.Fatalf("count debris column: %v", err)
+	}
+	if debrisCols != 0 {
+		t.Fatalf("bootstrap debris column survived the self-heal, count = %d", debrisCols)
+	}
+
+	var version int
+	if err := store.db.QueryRowContext(ctx,
+		"SELECT COALESCE(MAX(version), 0) FROM schema_migrations",
+	).Scan(&version); err != nil {
+		t.Fatalf("read schema version: %v", err)
+	}
+	if version != schema.LatestVersion() {
+		t.Fatalf("schema version = %d, want %d (latest)", version, schema.LatestVersion())
+	}
+
+	var dirtyIssues int
+	if err := store.db.QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM dolt_status WHERE table_name = 'issues'",
+	).Scan(&dirtyIssues); err != nil {
+		t.Fatalf("count dirty issues rows: %v", err)
+	}
+	if dirtyIssues != 0 {
+		t.Fatalf("issues still dirty in dolt_status after init, count = %d", dirtyIssues)
+	}
+}
+
+// TestFreshBootstrapHealNotArmedWhenDatabasePreexists is the
+// ownership-negative counterpart: an open that did NOT create the database
+// (it already existed, so openServerConnection's bare CREATE DATABASE loses
+// the race with "database exists") must keep the #4566 guard's refusal and
+// must not DOLT_RESET the working set — the dirt it sees could be another
+// actor's legitimate uncommitted state, which only the proven creator may
+// discard.
+func TestFreshBootstrapHealNotArmedWhenDatabasePreexists(t *testing.T) {
+	skipIfNoDolt(t)
+	acquireTestSlot()
+	t.Cleanup(releaseTestSlot)
+
+	if testServerPort == 0 {
+		t.Skip("no Dolt test server available")
+	}
+
+	dbName := uniqueTestDBName(t)
+
+	// Pre-create the database directly, outside of New(), so this test's own
+	// open loses openServerConnection's bare-CREATE ownership race:
+	// createdDatabase must come back false, and WithFreshBootstrapHeal must
+	// not be armed.
+	initDSN := doltutil.ServerDSN{Host: "127.0.0.1", Port: testServerPort, User: "root"}.String()
+	initDB, err := sql.Open("mysql", initDSN)
+	if err != nil {
+		t.Fatalf("open init connection: %v", err)
+	}
+	defer initDB.Close()
+	if _, err := initDB.ExecContext(context.Background(), "CREATE DATABASE IF NOT EXISTS `"+dbName+"`"); err != nil {
+		t.Fatalf("pre-create database: %v", err)
+	}
+
+	tmpDir, err := os.MkdirTemp("", "dolt-fresh-heal-negative-*")
+	if err != nil {
+		t.Fatalf("create temp dir: %v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(tmpDir) })
+
+	fired := false
+	restore := schema.SetMigrateStepFaultHookForTest(func(ctx context.Context, db schema.DBConn, version int) error {
+		if version != 1 || fired {
+			return nil
+		}
+		fired = true
+		if _, err := db.ExecContext(ctx, "ALTER TABLE issues ADD COLUMN bd_freshheal_negative_debris INT"); err != nil {
+			return fmt.Errorf("injecting mid-step debris: %w", err)
+		}
+		return fmt.Errorf("test-injected session death: lost connection to MySQL server during query")
+	})
+	t.Cleanup(restore)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	cfg := &Config{
+		Path:            tmpDir,
+		CommitterName:   "test",
+		CommitterEmail:  "test@example.com",
+		Database:        dbName,
+		MaxOpenConns:    1,
+		CreateIfMissing: true,
+	}
+
+	store, err := New(ctx, cfg)
+	if store != nil {
+		store.Close()
+	}
+	if err == nil {
+		t.Fatal("New must not silently heal a database it did not create; expected the #4566 guard's refusal")
+	}
+	if !strings.Contains(err.Error(), "dirty tables") {
+		t.Fatalf("New error = %v, want the #4566 dirty-table guard refusal", err)
+	}
+	if !fired {
+		t.Fatal("fault hook never fired; test no longer exercises the mid-pass failure path")
+	}
+}

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -1548,7 +1548,7 @@ func newServerMode(ctx context.Context, cfg *Config) (*DoltStore, error) {
 	}
 
 	// Server mode: connect via MySQL protocol to dolt sql-server
-	db, connStr, err := openServerConnection(ctx, cfg)
+	db, connStr, createdDatabase, err := openServerConnection(ctx, cfg)
 	if err != nil {
 		return nil, err
 	}
@@ -1604,7 +1604,7 @@ func newServerMode(ctx context.Context, cfg *Config) (*DoltStore, error) {
 	// ReadOnly for schema — the forward-drift guard above still protects a stale client
 	// binary.
 	if !cfg.ReadOnly && !cfg.Gateway {
-		if err := store.initSchema(ctx); err != nil {
+		if err := store.initSchema(ctx, createdDatabase); err != nil {
 			return nil, fmt.Errorf("failed to initialize schema: %w", err)
 		}
 	}
@@ -1894,13 +1894,17 @@ func applyPoolLimits(db *sql.DB, cfg *Config) {
 	db.SetConnMaxIdleTime(idle)
 }
 
-// openServerConnection opens a connection to a dolt sql-server via MySQL protocol
-func openServerConnection(ctx context.Context, cfg *Config) (*sql.DB, string, error) {
+// openServerConnection opens a connection to a dolt sql-server via MySQL
+// protocol. The returned bool reports whether THIS call created the target
+// database (see the bare-CREATE ownership arbitration below) — server-mode's
+// analog of the uow path's `created` signal (#5042), threaded through to
+// initSchema so only the proven creator arms schema.WithFreshBootstrapHeal.
+func openServerConnection(ctx context.Context, cfg *Config) (*sql.DB, string, bool, error) {
 	connStr := buildServerDSN(cfg, cfg.Database)
 
 	db, err := sql.Open("mysql", connStr)
 	if err != nil {
-		return nil, "", fmt.Errorf("failed to open Dolt server connection: %w", err)
+		return nil, "", false, fmt.Errorf("failed to open Dolt server connection: %w", err)
 	}
 
 	// Configure the pool. *sql.DB is safe for concurrent use and manages its
@@ -1925,11 +1929,11 @@ func openServerConnection(ctx context.Context, cfg *Config) (*sql.DB, string, er
 	// above would close the *sql.DB we just handed the caller.
 	if cfg.Gateway {
 		if err := db.PingContext(ctx); err != nil {
-			return nil, "", fmt.Errorf("failed to connect to gateway server %s:%d (database %q): %w",
+			return nil, "", false, fmt.Errorf("failed to connect to gateway server %s:%d (database %q): %w",
 				cfg.ServerHost, cfg.ServerPort, cfg.Database, err)
 		}
 		connReady = true
-		return db, connStr, nil
+		return db, connStr, false, nil
 	}
 
 	// Ensure database exists (may need to create it)
@@ -1937,13 +1941,13 @@ func openServerConnection(ctx context.Context, cfg *Config) (*sql.DB, string, er
 	initConnStr := buildServerDSN(cfg, "")
 	initDB, err := sql.Open("mysql", initConnStr)
 	if err != nil {
-		return nil, "", fmt.Errorf("failed to open init connection: %w", err)
+		return nil, "", false, fmt.Errorf("failed to open init connection: %w", err)
 	}
 	defer func() { _ = initDB.Close() }()
 
 	// Validate database name to prevent SQL injection via backtick escaping
 	if err := ValidateDatabaseName(cfg.Database); err != nil {
-		return nil, "", fmt.Errorf("invalid database name %q: %w", cfg.Database, err)
+		return nil, "", false, fmt.Errorf("invalid database name %q: %w", cfg.Database, err)
 	}
 
 	// FIREWALL: Never create test databases on the production server.
@@ -1952,7 +1956,7 @@ func openServerConnection(ctx context.Context, cfg *Config) (*sql.DB, string, er
 	// Production-port detection generalized via isProductionPort so non-3307
 	// production deployments are covered (AD-01).
 	if isTestDatabaseName(cfg.Database) && isProductionPort(cfg) {
-		return nil, "", fmt.Errorf(
+		return nil, "", false, fmt.Errorf(
 			"REFUSED: will not CREATE DATABASE %q on production port %d — "+
 				"this is a test database name on the production server (see DOLT-WAR-ROOM.md)",
 			cfg.Database, cfg.ServerPort)
@@ -1968,28 +1972,46 @@ func openServerConnection(ctx context.Context, cfg *Config) (*sql.DB, string, er
 	// match unrelated databases with LIKE.
 	dbExists, checkErr := databaseExistsOnServer(ctx, initDB, cfg.Database)
 	if checkErr != nil {
-		return nil, "", fmt.Errorf("failed to check if database %q exists on server %s:%d: %w",
+		return nil, "", false, fmt.Errorf("failed to check if database %q exists on server %s:%d: %w",
 			cfg.Database, cfg.ServerHost, cfg.ServerPort, checkErr)
 	}
 
+	// created reports whether THIS call's CREATE DATABASE won the race and
+	// actually created the database (the #5042 ownership-arbitration signal,
+	// ported from internal/storage/uow/dolt_sql_provider.go's initSchema).
+	// Only the proven creator may later arm schema.WithFreshBootstrapHeal:
+	// on a database this call created, dirty tables a retry sees can only be
+	// this same process's own half-applied migration step (a session that
+	// died between a step's SQL and its per-step Dolt commit), never
+	// pre-existing user data (gastownhall/beads#5012).
+	created := false
 	if !dbExists {
 		if !cfg.CreateIfMissing {
-			return nil, "", databaseNotFoundError(cfg)
+			return nil, "", false, databaseNotFoundError(cfg)
 		}
 
-		_, err = initDB.ExecContext(ctx, fmt.Sprintf("CREATE DATABASE IF NOT EXISTS `%s`", cfg.Database)) //nolint:gosec // G201: cfg.Database validated by ValidateDatabaseName above
-		if err != nil {
-			// Dolt may return error 1007 even with IF NOT EXISTS - ignore if database already exists
+		// Bare CREATE DATABASE (no IF NOT EXISTS): the server arbitrates
+		// creation atomically, so a nil error here proves THIS call created
+		// the database. A concurrent initializer that loses the race gets
+		// the same "database exists" (1007) refusal the old IF NOT EXISTS
+		// form absorbed silently — still tolerated below, just no longer
+		// ambiguous about who created it.
+		_, err = initDB.ExecContext(ctx, fmt.Sprintf("CREATE DATABASE `%s`", cfg.Database)) //nolint:gosec // G201: cfg.Database validated by ValidateDatabaseName above
+		switch {
+		case err == nil:
+			created = true
+		default:
 			errLower := strings.ToLower(err.Error())
 			if !strings.Contains(errLower, "database exists") && !strings.Contains(errLower, "1007") {
 				// Check for connection refused - server likely not running
 				if strings.Contains(errLower, "connection refused") || strings.Contains(errLower, "connect: connection refused") {
-					return nil, "", fmt.Errorf("failed to connect to Dolt server at %s:%d: %w\n\nThe Dolt server may not be running. Try:\n  bd dolt start    # Start a local server\n  gt dolt start    # If using an orchestrator",
+					return nil, "", false, fmt.Errorf("failed to connect to Dolt server at %s:%d: %w\n\nThe Dolt server may not be running. Try:\n  bd dolt start    # Start a local server\n  gt dolt start    # If using an orchestrator",
 						cfg.ServerHost, cfg.ServerPort, err)
 				}
-				return nil, "", fmt.Errorf("failed to create database: %w", err)
+				return nil, "", false, fmt.Errorf("failed to create database: %w", err)
 			}
-			// Database already exists - that's fine, continue
+			// Lost the create race (or a benign TOCTOU with the dbExists
+			// check above): not ours, heal stays off.
 		}
 	}
 
@@ -2011,11 +2033,11 @@ func openServerConnection(ctx context.Context, cfg *Config) (*sql.DB, string, er
 		}
 		return nil
 	}, backoff.WithContext(bo, ctx)); err != nil {
-		return nil, "", fmt.Errorf("database %q not available after CREATE DATABASE: %w", cfg.Database, err)
+		return nil, "", false, fmt.Errorf("database %q not available after CREATE DATABASE: %w", cfg.Database, err)
 	}
 
 	connReady = true
-	return db, connStr, nil
+	return db, connStr, created, nil
 }
 
 // databaseExistsOnServer checks if a database with the exact given name exists
@@ -2044,6 +2066,20 @@ func databaseExistsOnServer(ctx context.Context, db *sql.DB, name string) (bool,
 // applied versions in schema_migrations and backfills legacy config-driven
 // tables. Returns the number of migrations applied.
 func initSchemaOnDB(ctx context.Context, db *sql.DB) (int, error) {
+	return initSchemaOnDBOwnership(ctx, db, false)
+}
+
+// initSchemaOnDBOwnership is initSchemaOnDB with the fresh-bootstrap
+// ownership signal for the #4566 dirty-table guard self-heal
+// (gastownhall/beads#5012), ported from the uow path's initSchema (#5042):
+// createdDatabase must be true only when the caller proved — via the
+// bare-CREATE-DATABASE ownership arbitration in openServerConnection — that
+// THIS process's open created the target database. On a database this init
+// created, dirty tables a retry finds can only be this same process's own
+// half-applied migration step (a session that died between a step's SQL and
+// its per-step Dolt commit), never pre-existing user data, so
+// schema.WithFreshBootstrapHeal is safe to arm.
+func initSchemaOnDBOwnership(ctx context.Context, db *sql.DB, createdDatabase bool) (int, error) {
 	conn, err := db.Conn(ctx)
 	if err != nil {
 		return 0, fmt.Errorf("schema: pin connection: %w", err)
@@ -2055,7 +2091,11 @@ func initSchemaOnDB(ctx context.Context, db *sql.DB) (int, error) {
 		return 0, fmt.Errorf("schema: read database name: %w", err)
 	}
 
-	applied, err := schema.MigrateUpWithLock(ctx, conn, dbName)
+	var opts []schema.MigrateLockOption
+	if createdDatabase {
+		opts = append(opts, schema.WithFreshBootstrapHeal())
+	}
+	applied, err := schema.MigrateUpWithLock(ctx, conn, dbName, opts...)
 	if err != nil {
 		return applied, fmt.Errorf("schema migration: %w", err)
 	}
@@ -2073,6 +2113,17 @@ func initSchemaOnDBWithRetry(ctx context.Context, db *sql.DB) (int, error) {
 // retried with them instead of failing the open fast (bd-6dnrw.30); a
 // *schema.RemoteMigrateGateError refusal stays permanent.
 func initSchemaOnDBWithRetryAndGate(ctx context.Context, db *sql.DB, gate func(context.Context, *sql.DB) error) (int, error) {
+	return initSchemaOnDBWithRetryAndGateOwnership(ctx, db, gate, false)
+}
+
+// initSchemaOnDBWithRetryAndGateOwnership is initSchemaOnDBWithRetryAndGate
+// with the fresh-bootstrap ownership signal (see initSchemaOnDBOwnership)
+// threaded to every retry attempt. createdDatabase is fixed for the whole
+// retry loop: unlike the uow path, where database creation is retried inside
+// the same loop that runs the migration, server mode creates the database
+// exactly once in openServerConnection, before this loop starts — so there is
+// no "re-assert on retry" case to port here.
+func initSchemaOnDBWithRetryAndGateOwnership(ctx context.Context, db *sql.DB, gate func(context.Context, *sql.DB) error, createdDatabase bool) (int, error) {
 	// Schema initialization for server mode is idempotent. Retry transient
 	// Dolt startup/catalog races and contended migration-lock attempts so
 	// concurrent bd processes converge instead of failing one unlucky waiter.
@@ -2092,7 +2143,7 @@ func initSchemaOnDBWithRetryAndGate(ctx context.Context, db *sql.DB, gate func(c
 			}
 		}
 		var schemaErr error
-		applied, schemaErr = initSchemaOnDB(ctx, db)
+		applied, schemaErr = initSchemaOnDBOwnership(ctx, db, createdDatabase)
 		if schemaErr != nil && isRetryableError(schemaErr) {
 			return schemaErr
 		}
@@ -2104,7 +2155,12 @@ func initSchemaOnDBWithRetryAndGate(ctx context.Context, db *sql.DB, gate func(c
 	return applied, err
 }
 
-func (s *DoltStore) initSchema(ctx context.Context) error {
+// initSchema runs pending schema migrations for a freshly opened store.
+// createdDatabase must be true only when this open's openServerConnection
+// call proved (via bare-CREATE ownership arbitration) that it created the
+// target database — see initSchemaOnDBOwnership for why that arms
+// schema.WithFreshBootstrapHeal (gastownhall/beads#5012, #5042).
+func (s *DoltStore) initSchema(ctx context.Context, createdDatabase bool) error {
 	// Schema migrations can run arbitrarily long (e.g. full-table recomputes
 	// such as the is_blocked backfill in migration 0047). The main connection
 	// pool sets a 10s ReadTimeout (see buildServerDSN); a slow migration over
@@ -2155,7 +2211,7 @@ func (s *DoltStore) initSchema(ctx context.Context) error {
 	gate := func(ctx context.Context, db *sql.DB) error {
 		return schema.CheckRemoteMigrateGateForRemoteWithRemoteCheckAndAdopt(ctx, db, s.remote, s.hasPersistedCLIRemote, adopt)
 	}
-	_, err = initSchemaOnDBWithRetryAndGate(ctx, migDB, gate)
+	_, err = initSchemaOnDBWithRetryAndGateOwnership(ctx, migDB, gate, createdDatabase)
 	return err
 }
 


### PR DESCRIPTION
## What

Server-mode's `initSchemaOnDBWithRetry` (`internal/storage/dolt/store.go`) never armed `schema.WithFreshBootstrapHeal` on a database it just created, because `openServerConnection` used `CREATE DATABASE IF NOT EXISTS` and had no way to know whether *this* open won the create race.

`openServerConnection` now issues a bare `CREATE DATABASE` (no `IF NOT EXISTS`) so the server arbitrates creation atomically: success proves this call created the database; an "already exists" (1007) refusal — still tolerated exactly as before — proves it did not. That ownership bool is threaded through `newServerMode` → `DoltStore.initSchema` → new `initSchemaOnDBWithRetryAndGateOwnership`/`initSchemaOnDBOwnership` helpers, which arm `WithFreshBootstrapHeal` only for the proven creator. All existing wrappers (`initSchemaOnDB`, `initSchemaOnDBWithRetry`, `initSchemaOnDBWithRetryAndGate`) are preserved unchanged, forwarding `createdDatabase=false` — zero churn for the ~20 existing call sites.

## Why

This ports the fix from #5042 (merged) — which closed the same hole for the proxied/uow path — to the server-mode path, the remaining half of the #5012 family. Without it, a session dying between a migration step's SQL and its per-step Dolt commit leaves debris that the next retry's `MigrateUp` misclassifies as pre-existing dirty user data (`*DirtyTablesError`), which the retry loop treats as permanent — unconvergeable on a database that didn't exist seconds earlier.

One structural difference is intentionally not ported: uow re-issues `CREATE DATABASE IF NOT EXISTS` on every retry attempt because creation and migration share one retry loop there. Server mode creates the database exactly once, before the migration retry loop starts, so `createdDatabase` is a fixed invariant for the whole retry sequence.

## Verification

- New tests in `internal/storage/dolt/initschema_fresh_bootstrap_heal_test.go`, modeled on #5042's uow tests but using this package's local dolt test-server harness:
  - `TestFreshBootstrapHealSelfHealsAfterMidPassFailure` — a per-step fault hook dirties `issues` right after migration 0001 commits and fails with a retryable error; the retry discards the debris and converges. PASS.
  - `TestFreshBootstrapHealNotArmedWhenDatabasePreexists` — same fault against a pre-existing database (ownership lost); `New()` returns the #4566 guard's permanent refusal, not a heal. PASS.
- Targeted existing suites (`TestSchemaMigration*`, `TestConcurrentInitSchema`, `TestNewDoltStore`, `TestInitSchema*`, `TestGate*`) pass unchanged — except `TestSchemaMigrationRejectsChangedPreExistingDirtyTable`, which we confirmed (via git stash) fails identically on unmodified main; pre-existing, tracked separately on our side.
- `go build` / `go vet` / `gofmt` clean repo-wide with `CGO_ENABLED=1 -tags gms_pure_go`; full `internal/storage/schema` suite green.

_claude-fable-5-high on behalf of maphew_
