### PR TITLE
fix(bootstrap): prefer existing DB over re-clone when sync.remote is set (GH#5037)

### DIFF
--- a/cmd/bd/bootstrap.go
+++ b/cmd/bd/bootstrap.go
@@ -309,6 +309,21 @@ func detectBootstrapAction(beadsDir string, cfg *configfile.Config) BootstrapPla
 	isSharedServer := bootstrapSharedServerMode(beadsDir)
 	isServer := cfg.IsDoltServerMode() || isSharedServer
 
+	// Prefer an existing local database over re-clone (GH#5037). Previously
+	// sync.remote returned Action=sync unconditionally, so a second
+	// `bd bootstrap` on an already-cloned workspace ran DOLT_CLONE into the
+	// existing dir and failed with Error 1007 (database exists) — contradicting
+	// help text ("If database already exists: validates and reports status")
+	// and the multi-clone upgrade guide. If the local beadsDir does not exist
+	// yet, still prefer sync recovery first for Action=="none" so a default
+	// shared-server "beads" DB from another project cannot mask a real clone.
+	if dbAction, ok := existingBootstrapDBPlan(beadsDir, cfg, isServer, isSharedServer); ok {
+		if beadsDirExists || dbAction.Action != "none" {
+			return dbAction
+		}
+		plan = dbAction
+	}
+
 	// Check sync.remote (primary) or sync.git-remote (deprecated fallback)
 	syncRemote := resolveSyncRemote()
 	if syncRemote != "" {
@@ -333,20 +348,6 @@ func detectBootstrapAction(beadsDir string, cfg *configfile.Config) BootstrapPla
 				return plan
 			}
 		}
-	}
-
-	if dbAction, ok := existingBootstrapDBPlan(beadsDir, cfg, isServer, isSharedServer); ok {
-		// If the local beadsDir does not exist yet, prefer recovering via sync
-		// first. This avoids false "nothing to do" results when the default
-		// shared-server database name happens to exist for another project.
-		if beadsDirExists || dbAction.Action != "none" {
-			return dbAction
-		}
-		// For synthesized paths with no local workspace directory yet, defer the
-		// existing-db no-op until we've ruled out all other recovery paths.
-		// This preserves the sync-precedence fix without downgrading the
-		// legitimate "database already exists" case into a fresh init.
-		plan = dbAction
 	}
 
 	// Check for backup JSONL files (must be non-empty to be useful)

--- a/cmd/bd/bootstrap_test.go
+++ b/cmd/bd/bootstrap_test.go
@@ -367,6 +367,62 @@ func TestDetectBootstrapAction_ExplicitSyncRemotePreservesRemotesAPIURL(t *testi
 	}
 }
 
+// TestDetectBootstrapAction_ExistingEmbeddedDBWithSyncRemoteIsNoOp is a
+// regression for GH#5037: when sync.remote is set AND embeddeddolt already
+// exists, plan must be Action=none (validate/report), not Action=sync which
+// would DOLT_CLONE into the existing database and fail with Error 1007.
+func TestDetectBootstrapAction_ExistingEmbeddedDBWithSyncRemoteIsNoOp(t *testing.T) {
+	restore := snapshotBootstrapEnv(t)
+	defer restore()
+	config.ResetForTesting()
+	defer config.ResetForTesting()
+
+	tmpDir := t.TempDir()
+	beadsDir := filepath.Join(tmpDir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	// Non-empty embedded database footprint (what a prior successful bootstrap left).
+	embedded := filepath.Join(beadsDir, "embeddeddolt")
+	if err := os.MkdirAll(filepath.Join(embedded, "mydb"), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(embedded, "mydb", ".keep"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	const syncRemote = "http://myserver:7007/mydb"
+	if err := os.WriteFile(filepath.Join(beadsDir, "config.yaml"), []byte("sync.remote: "+syncRemote+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("BEADS_DIR", beadsDir)
+	t.Setenv("BEADS_TEST_IGNORE_REPO_CONFIG", "1")
+	if err := config.Initialize(); err != nil {
+		t.Fatalf("config.Initialize failed: %v", err)
+	}
+
+	oldWd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chdir(oldWd) }()
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := configfile.DefaultConfig()
+	plan := detectBootstrapAction(beadsDir, cfg)
+
+	if plan.Action != "none" {
+		t.Fatalf("action = %q reason=%q, want none (existing DB must not re-clone when sync.remote set)", plan.Action, plan.Reason)
+	}
+	if !plan.HasExisting {
+		t.Error("HasExisting = false, want true")
+	}
+	if !strings.Contains(plan.Reason, "already exists") {
+		t.Errorf("Reason = %q, want to mention already exists", plan.Reason)
+	}
+}
+
 func TestDetectBootstrapAction_InitWhenOriginHasNoDoltRef(t *testing.T) {
 	t.Setenv("BEADS_DOLT_DATA_DIR", "")
 	t.Setenv("BEADS_DOLT_SERVER_DATABASE", "")


### PR DESCRIPTION
## Summary

Fixes `bd bootstrap` with `sync.remote` set on a workspace that **already has** a local database.

Previously `detectBootstrapAction` returned `Action=sync` whenever `sync.remote` was configured, skipping the existing-DB check. A second bootstrap then ran `DOLT_CLONE` into the existing dir and failed with `Error 1007: can't create database …; database exists` — contradicting help text ("If database already exists: validates and reports status") and the multi-clone upgrade guide.

Existing local DB detection now runs **before** the `sync.remote` early-return. Fresh clones (no local DB) still plan `sync` as before.

Closes #5037

## Test plan

- [x] `go test ./cmd/bd/ -run 'TestDetectBootstrapAction_ExistingEmbeddedDBWithSyncRemoteIsNoOp|TestDetectBootstrapAction_ExplicitSyncRemote' -count=1` (ICU cgo) — pass
- [x] Explicit sync.remote without local DB still plans `sync`
