### PR TITLE
fix(export): stage basename under cmd.Dir to avoid double-root git add (GH#4351)

### DIFF
--- a/cmd/bd/export_auto.go
+++ b/cmd/bd/export_auto.go
@@ -600,9 +600,12 @@ func gitAddFile(path string) error {
 
 	ctx, cancel := context.WithTimeout(context.Background(), gitAddTimeout)
 	defer cancel()
-	// Pass the basename only: cmd.Dir is the parent of path, so a full path
-	// argument would double-root (cd .beads && git add .beads/issues.jsonl →
-	// pathspec looks under .beads/.beads/). See GH#4351.
+	// Pass the basename only, defensively: cmd.Dir is the parent of path, so
+	// a full path argument would double-root (cd .beads && git add
+	// .beads/issues.jsonl → pathspec looks under .beads/.beads/) if a caller
+	// ever passed a relative path here. Both current callers pass absolute
+	// paths, so this guards against a regression rather than fixing a live
+	// failure. See GH#4351.
 	// Keep cmd.Dir = parent so GH#3311 hook worktree staging still resolves
 	// the index path under the repo root (not bare "issues.jsonl" at root).
 	cmd := exec.CommandContext(ctx, "git", "add", "--", filepath.Base(path))

--- a/cmd/bd/export_auto.go
+++ b/cmd/bd/export_auto.go
@@ -600,7 +600,12 @@ func gitAddFile(path string) error {
 
 	ctx, cancel := context.WithTimeout(context.Background(), gitAddTimeout)
 	defer cancel()
-	cmd := exec.CommandContext(ctx, "git", "add", path)
+	// Pass the basename only: cmd.Dir is the parent of path, so a full path
+	// argument would double-root (cd .beads && git add .beads/issues.jsonl →
+	// pathspec looks under .beads/.beads/). See GH#4351.
+	// Keep cmd.Dir = parent so GH#3311 hook worktree staging still resolves
+	// the index path under the repo root (not bare "issues.jsonl" at root).
+	cmd := exec.CommandContext(ctx, "git", "add", "--", filepath.Base(path))
 	cmd.Dir = filepath.Dir(path)
 	cmd.Env = env
 	// Capture combined output so the caller's warning surfaces git's stderr

--- a/cmd/bd/export_auto_test.go
+++ b/cmd/bd/export_auto_test.go
@@ -584,6 +584,77 @@ func TestGitAddFile_NonHookContext_GuardDoesNotFire(t *testing.T) {
 	}
 }
 
+// TestGitAddFile_RelativePathDoesNotDoubleRoot is a regression test for
+// GH#4351: gitAddFile sets cmd.Dir to filepath.Dir(path). When path is
+// relative (e.g. ".beads/issues.jsonl"), passing that full path as the
+// git-add argument becomes `cd .beads && git add .beads/issues.jsonl`,
+// which looks for a non-existent nested path and exits 128. The fix is
+// to pass filepath.Base(path) so the pathspec is relative to cmd.Dir.
+func TestGitAddFile_RelativePathDoesNotDoubleRoot(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+
+	tmpDir, err := os.MkdirTemp("", "bd-gh4351-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(tmpDir) })
+	tmpDir, err = filepath.EvalSymlinks(tmpDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	repo := filepath.Join(tmpDir, "repo")
+	if err := os.MkdirAll(repo, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	runGit := func(args ...string) {
+		t.Helper()
+		c := exec.Command("git", args...)
+		c.Dir = repo
+		if out, err := c.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	runGit("init", "-q")
+	runGit("config", "user.email", "t@t")
+	runGit("config", "user.name", "t")
+	if err := os.WriteFile(filepath.Join(repo, "README.md"), []byte("x\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGit("add", "README.md")
+	runGit("commit", "-qm", "init")
+
+	if err := os.MkdirAll(filepath.Join(repo, ".beads"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, ".beads", "issues.jsonl"), []byte(`{"id":"x"}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.Unsetenv("GIT_DIR"); err != nil {
+		t.Fatal(err)
+	}
+	// Repo-relative path — the double-root trigger. Must stage successfully.
+	t.Chdir(repo)
+	relPath := filepath.Join(".beads", "issues.jsonl")
+	if err := gitAddFile(relPath); err != nil {
+		t.Fatalf("gitAddFile(%q): %v", relPath, err)
+	}
+
+	c := exec.Command("git", "diff", "--cached", "--name-only")
+	c.Dir = repo
+	data, err := c.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git diff --cached: %v\n%s", err, data)
+	}
+	staged := strings.TrimSpace(string(data))
+	if !strings.Contains(staged, ".beads/issues.jsonl") && !strings.Contains(staged, filepath.ToSlash(relPath)) {
+		t.Errorf("expected .beads/issues.jsonl staged, got: %q", staged)
+	}
+}
+
 // TestGitAddFile_CapturesStderrOnFailure verifies that when `git add` fails,
 // the returned error wraps git's stderr text instead of just the bare exit
 // status. Regression guard for the silent "Warning: auto-export: git add


### PR DESCRIPTION
## Summary

Fixes an auto-export `git add` double-rooting path that would fail with exit 128 when the export path was relative (e.g. `.beads/issues.jsonl`).

`gitAddFile` set `cmd.Dir` to the parent of the path but passed the full path as the `git add` argument, so git effectively ran:

```
cd .beads && git add .beads/issues.jsonl
```

which looks for a non-existent nested path. Pass `filepath.Base(path)` (with `--`) so the pathspec is relative to `cmd.Dir`. Preserves `cmd.Dir = parent` so the GH#3311 hook worktree staging path still lands under `.beads/`, not bare `issues.jsonl` at repo root.

Refs #4351

(Corrected 2026-07-29: this was originally `Closes #4351`. It should not close the issue — as @maphew established in review, the regression fixed here is real but is not the reporter's exit-128 path, which looks more likely to be an `isGitRepo()` cwd-vs-`cmd.Dir` mismatch. The original claim was ours and it was wrong.)

## Test plan

- [x] `go test ./cmd/bd/ -run 'TestGitAddFile_' -count=1` (with ICU cgo flags) — all gitAddFile tests pass, including new `TestGitAddFile_RelativePathDoesNotDoubleRoot`
- [x] Existing GH#3311 worktree-hook regression still green

