### PR TITLE
fix(storage): advance child_counters on singular hierarchical create (#4750)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -998,6 +998,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `bd.claim_verify_lost_total` and `bd.claim_verify_recovered_total` count
   loud failures and converted outcomes.
 
+- **Single-issue `bd create --id P.N` no longer leaves `child_counters` stale**
+  (one root cause of [#4750](https://github.com/gastownhall/beads/issues/4750);
+  the issue stays open — three other drift paths remain). `CreateIssueInTxWithResult`
+  only reconciled `child_counters` when the batch path called
+  `ReconcileChildCounters`; an explicit hierarchical `--id` never advanced the
+  parent's `last_child` high-water mark. Once such children were later
+  archived out of `issues`, `GetNextChildIDTx` no longer saw them and could
+  re-mint an already-used suffix — an ID collision with an archived issue.
+  The single-issue path now calls `ReconcileChildCounters` too, and its
+  changed tables are merged into the result so the reconcile actually gets
+  staged for commit.
+
 ## [1.1.2] - 2026-07-26
 
 Hotfix release cut from v1.1.0. (There is no 1.1.1 release: its tag was cut

--- a/backend/conformance/portable.go
+++ b/backend/conformance/portable.go
@@ -677,9 +677,9 @@ func testCreateIssuesWithFullOptions(t *testing.T, f Factory) {
 
 // Batch-creating dotted hierarchical child IDs runs ReconcileChildCounters, which
 // emits `... ON DUPLICATE KEY UPDATE last_child = GREATEST(last_child, ?)` in the
-// child-counter upsert (issueops/create.go). That GREATEST path is reachable only
-// from batch create — the single-issue path never reconciles counters — so it was
-// dead in the rest of the suite, which is how a missing SQLite GREATEST translation
+// child-counter upsert (issueops/create.go). Both the batch and single-issue create
+// paths reach that GREATEST upsert (GH#4750), but this suite historically only
+// exercised it via batch create, which is how a missing SQLite GREATEST translation
 // (child creation aborted with "no such function: GREATEST") shipped green. This
 // scenario mints x-1, x-1.1, x-1.2 through the batch path and asserts every backend
 // both creates the children and reconciles the counter to the max direct child.

--- a/internal/storage/embeddeddolt/child_id_test.go
+++ b/internal/storage/embeddeddolt/child_id_test.go
@@ -108,6 +108,52 @@ func TestGetNextChildID(t *testing.T) {
 		}
 	})
 
+	// GH#4750: singular create with an explicit hierarchical ID must raise
+	// child_counters so subsequent --parent mints do not restart below it.
+	t.Run("explicit_id_create_advances_counter", func(t *testing.T) {
+		te := newTestEnv(t, "ex")
+		ctx := t.Context()
+
+		parent := &types.Issue{
+			ID:        "ex-parent",
+			Title:     "Parent",
+			Status:    types.StatusOpen,
+			Priority:  2,
+			IssueType: types.TypeEpic,
+		}
+		if err := te.store.CreateIssue(ctx, parent, "tester"); err != nil {
+			t.Fatalf("CreateIssue parent: %v", err)
+		}
+
+		// Simulate `bd create --id ex-parent.8` (no prior counter activity).
+		child := &types.Issue{
+			ID:        "ex-parent.8",
+			Title:     "Explicit child 8",
+			Status:    types.StatusOpen,
+			Priority:  2,
+			IssueType: types.TypeTask,
+		}
+		if err := te.store.CreateIssue(ctx, child, "tester"); err != nil {
+			t.Fatalf("CreateIssue explicit child: %v", err)
+		}
+
+		var lastChild int
+		te.queryScalar(t, ctx,
+			"SELECT last_child FROM child_counters WHERE parent_id = ?",
+			[]any{"ex-parent"}, &lastChild)
+		if lastChild != 8 {
+			t.Fatalf("child_counters last_child = %d, want 8 after explicit --id create", lastChild)
+		}
+
+		next, err := te.store.GetNextChildID(ctx, "ex-parent")
+		if err != nil {
+			t.Fatalf("GetNextChildID: %v", err)
+		}
+		if next != "ex-parent.9" {
+			t.Fatalf("GetNextChildID = %q, want ex-parent.9", next)
+		}
+	})
+
 	t.Run("wisp_parent_uses_wisp_counter", func(t *testing.T) {
 		te := newTestEnv(t, "wp")
 		ctx := t.Context()

--- a/internal/storage/issueops/create.go
+++ b/internal/storage/issueops/create.go
@@ -164,6 +164,21 @@ func CreateIssueInTxWithResult(ctx context.Context, tx DBTX, bc *BatchContext, i
 		return result, err
 	}
 	result.ChangedTables = mergeChangedTables(result.ChangedTables, commentResult.ChangedTables)
+
+	// Advance child_counters when a singular create materializes a hierarchical
+	// ID (e.g. bd create --id P.8). The batch path already calls
+	// ReconcileChildCounters after CreateIssuesInTx; without this, explicit --id
+	// creates leave last_child behind the live suffix high-water mark and the
+	// next bd create --parent can recycle lower suffixes (GH#4750).
+	if isNew {
+		if _, childNum, ok := ParseHierarchicalID(issue.ID); ok && childNum > 0 {
+			changedCounters, err := ReconcileChildCounters(ctx, tx, []*types.Issue{issue})
+			if err != nil {
+				return result, err
+			}
+			result.ChangedTables = mergeChangedTables(result.ChangedTables, changedCounters)
+		}
+	}
 	return result, nil
 }
 

--- a/internal/storage/issueops/create.go
+++ b/internal/storage/issueops/create.go
@@ -22,6 +22,15 @@ type BatchContext struct {
 	ConfigPrefix    string
 	AllowedPrefixes string
 	Opts            storage.BatchCreateOptions
+	// SkipChildCounterReconcile tells CreateIssueInTxWithResult to skip its
+	// per-issue ReconcileChildCounters call. CreateIssuesInTxWithResult sets
+	// this because it already runs one slice-wide ReconcileChildCounters over
+	// the whole accepted batch after the per-issue loop, which covers every
+	// issue the per-issue call would have handled; running it again per issue
+	// during a batch import was 3-4 redundant round trips per hierarchical
+	// issue for a result the caller discards. Singular creates leave this
+	// false so they keep reconciling immediately, per-issue.
+	SkipChildCounterReconcile bool
 }
 
 // NewBatchContext reads config from the database and returns a BatchContext.
@@ -170,7 +179,7 @@ func CreateIssueInTxWithResult(ctx context.Context, tx DBTX, bc *BatchContext, i
 	// ReconcileChildCounters after CreateIssuesInTx; without this, explicit --id
 	// creates leave last_child behind the live suffix high-water mark and the
 	// next bd create --parent can recycle lower suffixes (GH#4750).
-	if isNew {
+	if isNew && !bc.SkipChildCounterReconcile {
 		if _, childNum, ok := ParseHierarchicalID(issue.ID); ok && childNum > 0 {
 			changedCounters, err := ReconcileChildCounters(ctx, tx, []*types.Issue{issue})
 			if err != nil {
@@ -247,6 +256,9 @@ func CreateIssuesInTxWithResult(ctx context.Context, tx DBTX, issues []*types.Is
 	if err != nil {
 		return CreateIssuesResult{}, err
 	}
+	// This function already runs a slice-wide ReconcileChildCounters below,
+	// covering every accepted issue; skip the redundant per-issue reconcile.
+	bc.SkipChildCounterReconcile = true
 
 	result := CreateIssuesResult{}
 	accepted := issues[:0:0]


### PR DESCRIPTION
# fix(storage): advance child_counters on singular hierarchical create

**Partial fix for #4750**

## Summary

`child_counters.last_child` is supposed to be a high-water mark for
`bd create --parent`, but only the **batch** create path called
`ReconcileChildCounters`. A singular `bd create --id P.8` left the counter
behind, so a later `--parent P` could mint a lower suffix after explicit IDs
or imports.

## Change

After a successful singular `CreateIssueInTx` of a new hierarchical ID, call
`ReconcileChildCounters` so `last_child` catches up.

## Out of scope (still open on #4750)

- IDs that exist only in archive JSONL (not in `issues`) are still invisible
  to the allocator — needs a separate high-water source from archives.

## Test plan

- [x] `BEADS_TEST_EMBEDDED_DOLT=1 CGO_ENABLED=1 go test ./internal/storage/embeddeddolt/ -run 'TestGetNextChildID/explicit_id_create'`
  — counter = 8 after `CreateIssue` with ID `P.8`; next mint is `P.9`

## Notes

Scope: this closes root cause 1 of #4750 only — the stale `child_counters` row on the single-issue explicit-ID create path. The `isNew` guard means a singular *upsert* of an existing dotted ID still does not raise the counter, and compaction-before-delete, JSONL export/import durability, and the `ON DELETE CASCADE` wipe all remain. #4750 stays open.

*(Corrected 2026-07-29 — the test command above originally read `-tags cgo`. As @maphew pointed out, `child_id_test.go` carries `//go:build cgo`, which is satisfied by `CGO_ENABLED=1` rather than a `-tags` value, and the subtests are additionally gated on `BEADS_TEST_EMBEDDED_DOLT=1`. The command as originally written would not have run the test. CI sets both, so the coverage itself is genuine.)*
