### PR TITLE
docs: caveat --parent label inheritance with size/effort labels (#4562)

### DIFF
--- a/docs/core-concepts/labels.md
+++ b/docs/core-concepts/labels.md
@@ -109,7 +109,7 @@ large     # > 3 days
 ```
 
 **Interaction with label inheritance:** `bd create --parent` copies the parent's
-labels onto the child by default (see #2100). If the epic carries a size marker
+labels onto the child by default (see GH#2100). If the epic carries a size marker
 (e.g. `large` or `sp:13`) and children have their own estimates, every child
 will also inherit the epic's size label — so `bd list -l large` returns the
 whole tree, not just epic-scale work. For per-child size labels, pass
@@ -122,8 +122,7 @@ shared can still be added explicitly).
 bd ready --json | jq '.[] | select(.labels[] == "small")'
 
 # Child keeps its own size label without inheriting the epic's
-bd create "Implement auth endpoints" -p 1 --parent bd-a3f8e9 --no-inherit-labels
-bd label add <child-id> small
+bd create "Implement auth endpoints" -p 1 --parent bd-a3f8e9 --no-inherit-labels -l small
 ```
 
 ### 4. Quality Gates

--- a/docs/core-concepts/labels.md
+++ b/docs/core-concepts/labels.md
@@ -108,10 +108,22 @@ medium    # 1-3 days
 large     # > 3 days
 ```
 
+**Interaction with label inheritance:** `bd create --parent` copies the parent's
+labels onto the child by default (see #2100). If the epic carries a size marker
+(e.g. `large` or `sp:13`) and children have their own estimates, every child
+will also inherit the epic's size label — so `bd list -l large` returns the
+whole tree, not just epic-scale work. For per-child size labels, pass
+`--no-inherit-labels` when creating children (team/domain labels you *do* want
+shared can still be added explicitly).
+
 **Example:**
 ```bash
 # Find small quick wins
 bd ready --json | jq '.[] | select(.labels[] == "small")'
+
+# Child keeps its own size label without inheriting the epic's
+bd create "Implement auth endpoints" -p 1 --parent bd-a3f8e9 --no-inherit-labels
+bd label add <child-id> small
 ```
 
 ### 4. Quality Gates

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -128,11 +128,10 @@ For large features, use hierarchical IDs to organize work:
 bd create "Auth System" -t epic -p 1
 # Returns: bd-a3f8e9
 
-# Create child tasks (use --parent to attach to the epic).
-# --no-inherit-labels keeps epic-level size/effort labels off children (GH#4562).
-bd create "Design login UI" -p 1 --parent bd-a3f8e9 --no-inherit-labels       # bd-a3f8e9.1
-bd create "Backend validation" -p 1 --parent bd-a3f8e9 --no-inherit-labels    # bd-a3f8e9.2
-bd create "Integration tests" -p 1 --parent bd-a3f8e9 --no-inherit-labels     # bd-a3f8e9.3
+# Create child tasks (use --parent to attach to the epic)
+bd create "Design login UI" -p 1 --parent bd-a3f8e9       # bd-a3f8e9.1
+bd create "Backend validation" -p 1 --parent bd-a3f8e9    # bd-a3f8e9.2
+bd create "Integration tests" -p 1 --parent bd-a3f8e9     # bd-a3f8e9.3
 
 # View hierarchy
 bd dep tree bd-a3f8e9
@@ -147,6 +146,8 @@ Dependency tree for bd-a3f8e9:
   > bd-a3f8e9.2: Backend validation [P1] (open)
   > bd-a3f8e9.3: Integration tests [P1] (open)
 ```
+
+Children inherit the epic's labels by default — if the epic carries a size/effort label, see [Labels](/core-concepts/labels) for how to keep it off the children.
 
 ## Add dependencies
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -128,10 +128,11 @@ For large features, use hierarchical IDs to organize work:
 bd create "Auth System" -t epic -p 1
 # Returns: bd-a3f8e9
 
-# Create child tasks (use --parent to attach to the epic)
-bd create "Design login UI" -p 1 --parent bd-a3f8e9       # bd-a3f8e9.1
-bd create "Backend validation" -p 1 --parent bd-a3f8e9    # bd-a3f8e9.2
-bd create "Integration tests" -p 1 --parent bd-a3f8e9     # bd-a3f8e9.3
+# Create child tasks (use --parent to attach to the epic).
+# --no-inherit-labels keeps epic-level size/effort labels off children (GH#4562).
+bd create "Design login UI" -p 1 --parent bd-a3f8e9 --no-inherit-labels       # bd-a3f8e9.1
+bd create "Backend validation" -p 1 --parent bd-a3f8e9 --no-inherit-labels    # bd-a3f8e9.2
+bd create "Integration tests" -p 1 --parent bd-a3f8e9 --no-inherit-labels     # bd-a3f8e9.3
 
 # View hierarchy
 bd dep tree bd-a3f8e9

--- a/docs/multi-agent/coordination.md
+++ b/docs/multi-agent/coordination.md
@@ -77,10 +77,10 @@ bd list --status in_progress --json
 Split work, then merge:
 
 ```bash
-# Fan-out
-bd create "Part A" --parent bd-epic
-bd create "Part B" --parent bd-epic
-bd create "Part C" --parent bd-epic
+# Fan-out (use --no-inherit-labels if epic size labels must not land on children)
+bd create "Part A" --parent bd-epic --no-inherit-labels
+bd create "Part B" --parent bd-epic --no-inherit-labels
+bd create "Part C" --parent bd-epic --no-inherit-labels
 
 bd assign bd-epic.1 agent-a
 bd assign bd-epic.2 agent-b

--- a/docs/multi-agent/coordination.md
+++ b/docs/multi-agent/coordination.md
@@ -77,10 +77,10 @@ bd list --status in_progress --json
 Split work, then merge:
 
 ```bash
-# Fan-out (use --no-inherit-labels if epic size labels must not land on children)
-bd create "Part A" --parent bd-epic --no-inherit-labels
-bd create "Part B" --parent bd-epic --no-inherit-labels
-bd create "Part C" --parent bd-epic --no-inherit-labels
+# Fan-out
+bd create "Part A" --parent bd-epic
+bd create "Part B" --parent bd-epic
+bd create "Part C" --parent bd-epic
 
 bd assign bd-epic.1 agent-a
 bd assign bd-epic.2 agent-b
@@ -91,6 +91,8 @@ bd dep add bd-merge bd-epic.1
 bd dep add bd-merge bd-epic.2
 bd dep add bd-merge bd-epic.3
 ```
+
+If `bd-epic` carries a size/effort label, see [Labels](/core-concepts/labels) for keeping it off the parts.
 
 <Tip>
 For structured epic fan-out, `bd swarm` creates and tracks a swarm molecule

--- a/docs/workflows/molecules.md
+++ b/docs/workflows/molecules.md
@@ -46,9 +46,10 @@ Create the epic and wire the dependencies directly:
 
 ```bash
 bd create "Feature X" -t epic
-bd create "Design" -t task --parent <epic-id>
-bd create "Implement" -t task --parent <epic-id>
-bd create "Test" -t task --parent <epic-id>
+# --no-inherit-labels if the epic has size labels children should not share
+bd create "Design" -t task --parent <epic-id> --no-inherit-labels
+bd create "Implement" -t task --parent <epic-id> --no-inherit-labels
+bd create "Test" -t task --parent <epic-id> --no-inherit-labels
 bd dep add <implement-id> <design-id>   # implement needs design
 bd dep add <test-id> <implement-id>     # test needs implement
 ```

--- a/docs/workflows/molecules.md
+++ b/docs/workflows/molecules.md
@@ -46,13 +46,14 @@ Create the epic and wire the dependencies directly:
 
 ```bash
 bd create "Feature X" -t epic
-# --no-inherit-labels if the epic has size labels children should not share
-bd create "Design" -t task --parent <epic-id> --no-inherit-labels
-bd create "Implement" -t task --parent <epic-id> --no-inherit-labels
-bd create "Test" -t task --parent <epic-id> --no-inherit-labels
+bd create "Design" -t task --parent <epic-id>
+bd create "Implement" -t task --parent <epic-id>
+bd create "Test" -t task --parent <epic-id>
 bd dep add <implement-id> <design-id>   # implement needs design
 bd dep add <test-id> <implement-id>     # test needs implement
 ```
+
+If the epic carries a size/effort label, see [Labels](/core-concepts/labels) for keeping it off the steps.
 
 If an ad-hoc epic turns out to be worth repeating, extract a reusable formula
 from it with `bd mol distill <epic-id> <formula-name>`.

--- a/plugins/beads/skills/beads/commands/epic.md
+++ b/plugins/beads/skills/beads/commands/epic.md
@@ -21,6 +21,9 @@ Manage epics (large features composed of multiple issues).
 1. Create epic: `bd create "Large Feature" -t epic -p 1`
 2. Link subtasks: `bd dep add bd-20 bd-10 --type parent-child` (task bd-20 is child of epic bd-10)
    - Or at creation: `bd create "Subtask title" -t task --parent bd-10`
+   - Children inherit parent labels by default. If the epic uses size/effort
+     labels and children should have their own, add `--no-inherit-labels`
+     (GH#4562).
 3. Track progress: `bd epic status`
 4. Auto-close when done: `bd epic close-eligible`
 

--- a/plugins/beads/skills/beads/resources/INTEGRATION_PATTERNS.md
+++ b/plugins/beads/skills/beads/resources/INTEGRATION_PATTERNS.md
@@ -312,8 +312,8 @@ TESTS: All 12 tests passing (auth, rotation, expiry, error handling)"
    bd dep add validation-2 auth-epic --type parent-child
    bd dep add middleware-3 auth-epic --type parent-child
    bd dep add tests-4 auth-epic --type parent-child
-   # Or use --parent at creation time:
-   # bd create "Update login endpoint" -t task --parent auth-epic
+   # Or use --parent at creation time (--no-inherit-labels if epic has size labels):
+   # bd create "Update login endpoint" -t task --parent auth-epic --no-inherit-labels
 
    # Add ordering
    bd dep add validation-2 login-1  # validation depends on login

--- a/plugins/beads/skills/beads/resources/INTEGRATION_PATTERNS.md
+++ b/plugins/beads/skills/beads/resources/INTEGRATION_PATTERNS.md
@@ -312,8 +312,8 @@ TESTS: All 12 tests passing (auth, rotation, expiry, error handling)"
    bd dep add validation-2 auth-epic --type parent-child
    bd dep add middleware-3 auth-epic --type parent-child
    bd dep add tests-4 auth-epic --type parent-child
-   # Or use --parent at creation time (--no-inherit-labels if epic has size labels):
-   # bd create "Update login endpoint" -t task --parent auth-epic --no-inherit-labels
+   # Or use --parent at creation time:
+   # bd create "Update login endpoint" -t task --parent auth-epic
 
    # Add ordering
    bd dep add validation-2 login-1  # validation depends on login


### PR DESCRIPTION
# docs: caveat --parent label inheritance with size/effort labels

**Closes #4562**

## Summary

`bd create --parent` inherits parent labels by default (#2100). That is right for
team/domain labels, but combined with size/effort labels on epics it silently
double-labels every child and breaks effort queries (`bd list -l large` returns
the whole tree).

Docs/skill examples used bare `--parent` with no mention of this interaction.

## Change

- `docs/core-concepts/labels.md` — Size/Effort section caveat + example with
  `--no-inherit-labels`
- Parent-create examples in quickstart, molecules, multi-agent coordination,
  skill `epic` command, and integration patterns

No behavior change — documentation only.

## Test plan

- [x] Docs read-through for consistency
- [ ] Optional: follow quickstart epic/child steps and confirm children lack epic size labels when flag is used

## Notes
