### PR TITLE
refactor(cli): rename CPU profiling flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,7 +101,7 @@ __pycache__/
 .Python
 .envrc
 
-# Performance profiling files (benchmarks, bd doctor --perf, and bd --profile)
+# Performance profiling files (benchmarks, bd doctor --perf, and bd --cpu-profile)
 *.prof
 *.out
 beads-perf-*.prof

--- a/cmd/bd/cpu_profile_test.go
+++ b/cmd/bd/cpu_profile_test.go
@@ -1,0 +1,19 @@
+package main
+
+import "testing"
+
+func TestCPUProfileFlagRegistered(t *testing.T) {
+	flag := rootCmd.PersistentFlags().Lookup("cpu-profile")
+	if flag == nil {
+		t.Fatal("--cpu-profile persistent flag is not registered")
+	}
+	if got, want := flag.Value.Type(), "bool"; got != want {
+		t.Errorf("--cpu-profile flag type = %q, want %q", got, want)
+	}
+	if got, want := flag.Usage, "Generate CPU profile for performance analysis"; got != want {
+		t.Errorf("--cpu-profile usage = %q, want %q", got, want)
+	}
+	if old := rootCmd.PersistentFlags().Lookup("profile"); old != nil {
+		t.Error("--profile must not remain registered as the CPU profiling flag")
+	}
+}

--- a/cmd/bd/main.go
+++ b/cmd/bd/main.go
@@ -87,7 +87,7 @@ var (
 	storeIsReadOnly   bool               // Track if store was opened read-only (for staleness checks)
 	ignoreSchemaSkew  bool               // Proceed despite forward schema drift
 	lockTimeout       = 30 * time.Second // Dolt open timeout (fixed default)
-	profileEnabled    bool
+	cpuProfileEnabled bool
 	profileFile       *os.File
 	traceFile         *os.File
 	memProfilePath    string
@@ -683,7 +683,7 @@ func init() {
 	rootCmd.PersistentFlags().BoolVar(&readonlyMode, "readonly", false, "Read-only mode: block write operations (for worker sandboxes)")
 	rootCmd.PersistentFlags().BoolVar(&globalFlag, "global", false, "Use the global shared-server database (beads_global)")
 	rootCmd.PersistentFlags().StringVar(&doltAutoCommit, "dolt-auto-commit", "", "Dolt auto-commit policy (off|on|batch). 'on': commit after each write. 'batch': defer commits to bd dolt commit; uncommitted changes persist in the working set until then. SIGTERM/SIGHUP flush pending batch commits. Default: off. Override via config key dolt.auto-commit")
-	rootCmd.PersistentFlags().BoolVar(&profileEnabled, "profile", false, "Generate CPU profile for performance analysis")
+	rootCmd.PersistentFlags().BoolVar(&cpuProfileEnabled, "cpu-profile", false, "Generate CPU profile for performance analysis")
 	rootCmd.PersistentFlags().StringVar(&memProfilePath, "mem-profile", "", "Write heap profile to FILE on exit (also respects BEADS_MEM_PROFILE)")
 	rootCmd.PersistentFlags().BoolVarP(&verboseFlag, "verbose", "v", false, "Enable verbose/debug output")
 	rootCmd.PersistentFlags().BoolVarP(&quietFlag, "quiet", "q", false, "Suppress non-essential output (errors only)")
@@ -1060,7 +1060,7 @@ var rootCmd = &cobra.Command{
 		}
 
 		// Performance profiling setup
-		if profileEnabled {
+		if cpuProfileEnabled {
 			timestamp := time.Now().Format("20060102-150405")
 			if f, _ := os.Create(fmt.Sprintf("bd-profile-%s-%s.prof", cmd.Name(), timestamp)); f != nil {
 				profileFile = f


### PR DESCRIPTION
## What

Rename the global CPU/trace diagnostic switch from `--profile` to
`--cpu-profile` and update its focused regression coverage and in-tree comment.

## Why

`--profile NAME` is the conventional namespace for selecting a named CLI
configuration. The existing boolean diagnostic flag prevents that interface
from being added and is less precise than `--cpu-profile` about what it does.

The profiling implementation and generated filenames are unchanged. This PR
intentionally does not edit the release-pinned generated CLI reference; it will
pick up the new spelling when the documentation pin advances.

## Validation

```text
GOCACHE=/tmp/bd-cpu-profile-gocache CGO_ENABLED=1 go test -tags gms_pure_go ./cmd/bd -run '^TestCPUProfileFlagRegistered$' -count=1
git diff --check
pre-commit golangci-lint: 0 issues
```

_codex-gpt-5.6-terra-high on behalf of CI Bot_
