### PR TITLE
fix(ado): map parent-child deps to hierarchy links (not Related)

### DIFF
--- a/internal/ado/links.go
+++ b/internal/ado/links.go
@@ -51,6 +51,8 @@ const discoveredFromComment = "beads:discovered-from"
 // adoRelToBeadsDep maps an ADO relation type to a beads dependency type.
 // Returns the dep type and whether the from/to should be swapped
 // (true for reverse link types that need direction normalization).
+// Hierarchy links use beads storage vocabulary "parent-child" (types.DepParentChild),
+// not the obsolete "parent" alias (GH#4961).
 func adoRelToBeadsDep(rel string, attributes map[string]interface{}) (depType string, swap bool) {
 	switch rel {
 	case RelDependsOn: // Dependency-Forward: this item is predecessor (blocks target)
@@ -58,9 +60,9 @@ func adoRelToBeadsDep(rel string, attributes map[string]interface{}) (depType st
 	case RelDependencyOf: // Dependency-Reverse: target blocks this item → swap
 		return "blocks", true
 	case RelChild: // Hierarchy-Forward: this item is parent of target
-		return "parent", false
+		return "parent-child", false
 	case RelParent: // Hierarchy-Reverse: target is parent of this item → swap
-		return "parent", true
+		return "parent-child", true
 	case RelRelated:
 		if hasDiscoveredFromAttribute(attributes) {
 			return "discovered-from", false
@@ -89,11 +91,13 @@ func hasDiscoveredFromAttribute(attributes map[string]interface{}) bool {
 }
 
 // beadsDepToADORel maps a beads dependency type to an ADO relation type.
+// Accepts both "parent-child" (canonical storage type) and the obsolete
+// "parent" alias so older in-memory values still map to hierarchy (GH#4961).
 func beadsDepToADORel(depType string) string {
 	switch depType {
 	case "blocks":
 		return RelDependsOn
-	case "parent":
+	case "parent-child", "parent": // "parent" kept as alias only
 		return RelChild
 	case "related":
 		return RelRelated

--- a/internal/ado/links.go
+++ b/internal/ado/links.go
@@ -52,7 +52,8 @@ const discoveredFromComment = "beads:discovered-from"
 // Returns the dep type and whether the from/to should be swapped
 // (true for reverse link types that need direction normalization).
 // Hierarchy links use beads storage vocabulary "parent-child" (types.DepParentChild),
-// not the obsolete "parent" alias (GH#4961).
+// not the legacy "parent" type, which was only ever produced by the pre-fix
+// pull path and is stored backwards (GH#4961, PR #5129).
 //
 // beads stores parent-child deps child → parent: IssueID is the child,
 // DependsOnID is the parent (see types.go ready-item parent computation).
@@ -99,7 +100,7 @@ func hasDiscoveredFromAttribute(attributes map[string]interface{}) bool {
 
 // beadsDepToADORel maps a beads dependency type to an ADO relation type.
 // Accepts both "parent-child" (canonical storage type) and the obsolete
-// "parent" alias so older in-memory values still map to hierarchy (GH#4961).
+// The legacy "parent" type is intentionally not mapped here (GH#4961, PR #5129).
 //
 // A parent-child dep's desired set is built from the child's own outgoing
 // dependency row (IssueID=child, DependsOnID=parent — see
@@ -111,7 +112,14 @@ func beadsDepToADORel(depType string) string {
 	switch depType {
 	case "blocks":
 		return RelDependsOn
-	case "parent-child", "parent": // "parent" kept as alias only
+	// The "parent" alias is deliberately NOT accepted here. Rows of that type were
+	// only ever written by the pre-fix pull path, and both old branches stored them
+	// parent -> child — backwards relative to the convention this file now uses. Mapping
+	// them to RelParent would assert the child is the parent's parent and reparent real
+	// hierarchies (maphew, PR #5129). They fall through to RelRelated, i.e. inert, which
+	// is where they have effectively been all along. Retyping and reversing those legacy
+	// rows needs a migration with its own tests, tracked separately.
+	case "parent-child":
 		return RelParent
 	case "related":
 		return RelRelated

--- a/internal/ado/links.go
+++ b/internal/ado/links.go
@@ -53,16 +53,23 @@ const discoveredFromComment = "beads:discovered-from"
 // (true for reverse link types that need direction normalization).
 // Hierarchy links use beads storage vocabulary "parent-child" (types.DepParentChild),
 // not the obsolete "parent" alias (GH#4961).
+//
+// beads stores parent-child deps child → parent: IssueID is the child,
+// DependsOnID is the parent (see types.go ready-item parent computation).
+// RelChild (Hierarchy-Forward) means "this item is the parent of target," so
+// the resulting dep must point from target (child) to this item (parent) —
+// swap. RelParent (Hierarchy-Reverse) means "target is the parent of this
+// item," so this item is already the child — no swap.
 func adoRelToBeadsDep(rel string, attributes map[string]interface{}) (depType string, swap bool) {
 	switch rel {
 	case RelDependsOn: // Dependency-Forward: this item is predecessor (blocks target)
 		return "blocks", false
 	case RelDependencyOf: // Dependency-Reverse: target blocks this item → swap
 		return "blocks", true
-	case RelChild: // Hierarchy-Forward: this item is parent of target
-		return "parent-child", false
-	case RelParent: // Hierarchy-Reverse: target is parent of this item → swap
+	case RelChild: // Hierarchy-Forward: this item is parent of target → swap so dep is child(target) → parent(this)
 		return "parent-child", true
+	case RelParent: // Hierarchy-Reverse: target is parent of this item; this item is already the child
+		return "parent-child", false
 	case RelRelated:
 		if hasDiscoveredFromAttribute(attributes) {
 			return "discovered-from", false
@@ -93,12 +100,19 @@ func hasDiscoveredFromAttribute(attributes map[string]interface{}) bool {
 // beadsDepToADORel maps a beads dependency type to an ADO relation type.
 // Accepts both "parent-child" (canonical storage type) and the obsolete
 // "parent" alias so older in-memory values still map to hierarchy (GH#4961).
+//
+// A parent-child dep's desired set is built from the child's own outgoing
+// dependency row (IssueID=child, DependsOnID=parent — see
+// GetDependenciesWithMetadata), so PushLinks always runs with workItemID as
+// the child and the target as the parent. RelParent (Hierarchy-Reverse) means
+// "target is parent of this item," which is exactly that relationship;
+// RelChild would instead assert the child is the parent's parent.
 func beadsDepToADORel(depType string) string {
 	switch depType {
 	case "blocks":
 		return RelDependsOn
 	case "parent-child", "parent": // "parent" kept as alias only
-		return RelChild
+		return RelParent
 	case "related":
 		return RelRelated
 	case "discovered-from":
@@ -188,18 +202,22 @@ type adoLinkKey struct {
 	Commented bool // true if the link has a discovered-from comment
 }
 
-// removableRelTypes are the forward-direction ADO relation types beads emits
-// and therefore owns. Only links of these types may be removed during push.
+// removableRelTypes are the ADO relation types beads emits during push and
+// therefore owns. Only links of these types may be removed during push.
 //
-// Reverse-direction link types — Hierarchy-Reverse (parent) and
-// Dependency-Reverse (predecessor/successor) — are deliberately excluded:
-// beads represents those relationships via the forward link on the *other*
-// work item, so they never appear in the desired set and must not be deleted.
-// Likewise, any other relation type (hyperlinks, attachments, custom link
-// types) is left untouched. See GH#4522.
+// Dependency-Forward and Related are the forward-direction types beads emits
+// for "blocks" and "related" deps. Hierarchy-Reverse is the type beads emits
+// for "parent-child" deps: PushLinks runs with workItemID as the child and
+// the target as the parent, so the link beads creates on the child is
+// Hierarchy-Reverse (RelParent), not Hierarchy-Forward (GH#4961). Hierarchy-
+// Forward and Dependency-Reverse are deliberately excluded: beads represents
+// those relationships via the link it owns on the *other* work item, so they
+// never appear in the desired set and must not be deleted. Likewise, any
+// other relation type (hyperlinks, attachments, custom link types) is left
+// untouched. See GH#4522.
 var removableRelTypes = map[string]bool{
 	RelDependsOn: true, // Dependency-Forward
-	RelChild:     true, // Hierarchy-Forward
+	RelParent:    true, // Hierarchy-Reverse
 	RelRelated:   true, // Related
 }
 
@@ -212,9 +230,9 @@ var removableRelTypes = map[string]bool{
 // managedTargets is the set of ADO work item IDs that beads tracks. A current
 // link is only removed when beads owns it: its relation type is one beads emits
 // (see removableRelTypes) AND its target is in managedTargets. This read-merge-
-// write behavior preserves links beads does not manage — reverse-direction
-// links and human-created Related/Predecessor-Successor links to untracked
-// items — instead of clobbering them. See GH#4522.
+// write behavior preserves links beads does not manage — the opposite-direction
+// hierarchy/dependency links and human-created Related/Predecessor-Successor
+// links to untracked items — instead of clobbering them. See GH#4522.
 func (r *LinkResolver) PushLinks(ctx context.Context, workItemID int, currentRelations []WorkItemRelation, desiredDeps []tracker.DependencyInfo, managedTargets map[int]bool) []error {
 	// Build desired link set.
 	desired := make(map[adoLinkKey]tracker.DependencyInfo)
@@ -260,10 +278,11 @@ func (r *LinkResolver) PushLinks(ctx context.Context, workItemID int, currentRel
 	var errs []error
 
 	// Find relations to remove (in current but not desired).
-	// Only remove links beads owns: a forward-direction type it emits, pointing
-	// at a work item beads tracks. Reverse-direction links and links to
-	// untracked items (e.g. human-created Related / Predecessor-Successor links)
-	// are left untouched so the push does not clobber them. See GH#4522.
+	// Only remove links beads owns: a type it emits (see removableRelTypes),
+	// pointing at a work item beads tracks. Links of the opposite hierarchy/
+	// dependency direction and links to untracked items (e.g. human-created
+	// Related / Predecessor-Successor links) are left untouched so the push
+	// does not clobber them. See GH#4522.
 	// Collect indices and remove in reverse order to avoid index shifting.
 	var removeIndices []int
 	for _, cl := range current {

--- a/internal/ado/links_test.go
+++ b/internal/ado/links_test.go
@@ -60,7 +60,7 @@ func TestPullLinks_DirectRelations(t *testing.T) {
 	// Dependency-Forward: 100 blocks 200 (no swap)
 	assertDep(t, deps[0], testWebURL(100), testWebURL(200), "blocks")
 	// Hierarchy-Forward: 100 is parent of 300 (no swap)
-	assertDep(t, deps[1], testWebURL(100), testWebURL(300), "parent")
+	assertDep(t, deps[1], testWebURL(100), testWebURL(300), "parent-child")
 	// Related: 100 related to 400
 	assertDep(t, deps[2], testWebURL(100), testWebURL(400), "related")
 }
@@ -95,7 +95,7 @@ func TestPullLinks_ReverseDirectionNormalization(t *testing.T) {
 	// Dependency-Reverse swapped: 200 blocks 100
 	assertDep(t, deps[0], testWebURL(200), testWebURL(100), "blocks")
 	// Hierarchy-Reverse swapped: 300 is parent of 100
-	assertDep(t, deps[1], testWebURL(300), testWebURL(100), "parent")
+	assertDep(t, deps[1], testWebURL(300), testWebURL(100), "parent-child")
 }
 
 func TestPullLinks_DiscoveredFrom(t *testing.T) {
@@ -188,15 +188,15 @@ func TestAdoRelToBeadsDep(t *testing.T) {
 			wantSwap: true,
 		},
 		{
-			name:     "Child → parent, no swap",
+			name:     "Child → parent-child, no swap",
 			rel:      RelChild,
-			wantType: "parent",
+			wantType: "parent-child",
 			wantSwap: false,
 		},
 		{
-			name:     "Parent → parent, swap",
+			name:     "Parent → parent-child, swap",
 			rel:      RelParent,
-			wantType: "parent",
+			wantType: "parent-child",
 			wantSwap: true,
 		},
 		{
@@ -250,7 +250,8 @@ func TestBeadsDepToADORel(t *testing.T) {
 		wantRel string
 	}{
 		{"blocks", RelDependsOn},
-		{"parent", RelChild},
+		{"parent-child", RelChild}, // canonical beads storage type (GH#4961)
+		{"parent", RelChild},       // obsolete alias still accepted
 		{"related", RelRelated},
 		{"discovered-from", RelRelated},
 		{"unknown", RelRelated}, // default
@@ -385,7 +386,7 @@ func TestPushLinks_AddMissing(t *testing.T) {
 
 	desired := []tracker.DependencyInfo{
 		{FromExternalID: "100", ToExternalID: "200", Type: "blocks"},
-		{FromExternalID: "100", ToExternalID: "300", Type: "parent"},
+		{FromExternalID: "100", ToExternalID: "300", Type: "parent-child"},
 	}
 
 	errs := resolver.PushLinks(context.Background(), 100, nil, desired, nil)

--- a/internal/ado/links_test.go
+++ b/internal/ado/links_test.go
@@ -279,7 +279,10 @@ func TestBeadsDepToADORel(t *testing.T) {
 	}{
 		{"blocks", RelDependsOn},
 		{"parent-child", RelParent}, // canonical beads storage type; desired set is built child -> parent (GH#4961)
-		{"parent", RelParent},       // obsolete alias still accepted
+		// Legacy "parent" rows were written parent -> child by the pre-fix pull path,
+		// so mapping them to RelParent would reparent real hierarchies backwards.
+		// They must stay inert until a migration retypes and reverses them (PR #5129).
+		{"parent", RelRelated},
 		{"related", RelRelated},
 		{"discovered-from", RelRelated},
 		{"unknown", RelRelated}, // default

--- a/internal/ado/links_test.go
+++ b/internal/ado/links_test.go
@@ -57,10 +57,11 @@ func TestPullLinks_DirectRelations(t *testing.T) {
 		return deps[i].ToExternalID < deps[j].ToExternalID
 	})
 
+	// Hierarchy-Forward: 100 is parent of 300 → swapped so the dep points
+	// child(300) -> parent(100), matching beads' child-to-parent storage.
+	assertDep(t, deps[0], testWebURL(300), testWebURL(100), "parent-child")
 	// Dependency-Forward: 100 blocks 200 (no swap)
-	assertDep(t, deps[0], testWebURL(100), testWebURL(200), "blocks")
-	// Hierarchy-Forward: 100 is parent of 300 (no swap)
-	assertDep(t, deps[1], testWebURL(100), testWebURL(300), "parent-child")
+	assertDep(t, deps[1], testWebURL(100), testWebURL(200), "blocks")
 	// Related: 100 related to 400
 	assertDep(t, deps[2], testWebURL(100), testWebURL(400), "related")
 }
@@ -75,7 +76,7 @@ func TestPullLinks_ReverseDirectionNormalization(t *testing.T) {
 				URL: "https://dev.azure.com/org/proj/_apis/wit/workitems/200",
 			},
 			{
-				Rel: RelParent, // Hierarchy-Reverse: target is parent of this → swap
+				Rel: RelParent, // Hierarchy-Reverse: target is parent of this item (self is the child) → no swap
 				URL: "https://dev.azure.com/org/proj/_apis/wit/workitems/300",
 			},
 		},
@@ -92,10 +93,37 @@ func TestPullLinks_ReverseDirectionNormalization(t *testing.T) {
 		return deps[i].FromExternalID < deps[j].FromExternalID
 	})
 
+	// Hierarchy-Reverse, no swap: self(100) is the child, so the dep points
+	// child(100) -> parent(300), matching beads' child-to-parent storage.
+	assertDep(t, deps[0], testWebURL(100), testWebURL(300), "parent-child")
 	// Dependency-Reverse swapped: 200 blocks 100
-	assertDep(t, deps[0], testWebURL(200), testWebURL(100), "blocks")
-	// Hierarchy-Reverse swapped: 300 is parent of 100
-	assertDep(t, deps[1], testWebURL(300), testWebURL(100), "parent-child")
+	assertDep(t, deps[1], testWebURL(200), testWebURL(100), "blocks")
+}
+
+// TestPullLinks_HierarchyChildDirection is a direction-pinning regression
+// test for GH#5129: a work item carrying Hierarchy-Forward (RelChild) is
+// asserting it is the parent of the target, so the resulting dep must be
+// From = the child (target), To = the source (this item) — matching beads'
+// child-to-parent storage convention.
+func TestPullLinks_HierarchyChildDirection(t *testing.T) {
+	wi := &WorkItem{
+		ID:  100,
+		URL: testAPIURL(100),
+		Relations: []WorkItemRelation{
+			{
+				Rel: RelChild,
+				URL: "https://dev.azure.com/org/proj/_apis/wit/workitems/300",
+			},
+		},
+	}
+
+	resolver := NewLinkResolver(NewClient(NewSecretString("pat"), "org", "proj"))
+	deps := resolver.PullLinks(wi)
+
+	if len(deps) != 1 {
+		t.Fatalf("got %d deps, want 1", len(deps))
+	}
+	assertDep(t, deps[0], testWebURL(300), testWebURL(100), "parent-child")
 }
 
 func TestPullLinks_DiscoveredFrom(t *testing.T) {
@@ -188,16 +216,16 @@ func TestAdoRelToBeadsDep(t *testing.T) {
 			wantSwap: true,
 		},
 		{
-			name:     "Child → parent-child, no swap",
+			name:     "Child → parent-child, swap (this item is target's parent; dep must point target(child) -> this(parent))",
 			rel:      RelChild,
 			wantType: "parent-child",
-			wantSwap: false,
+			wantSwap: true,
 		},
 		{
-			name:     "Parent → parent-child, swap",
+			name:     "Parent → parent-child, no swap (this item is already the child)",
 			rel:      RelParent,
 			wantType: "parent-child",
-			wantSwap: true,
+			wantSwap: false,
 		},
 		{
 			name:     "Related → related",
@@ -250,8 +278,8 @@ func TestBeadsDepToADORel(t *testing.T) {
 		wantRel string
 	}{
 		{"blocks", RelDependsOn},
-		{"parent-child", RelChild}, // canonical beads storage type (GH#4961)
-		{"parent", RelChild},       // obsolete alias still accepted
+		{"parent-child", RelParent}, // canonical beads storage type; desired set is built child -> parent (GH#4961)
+		{"parent", RelParent},       // obsolete alias still accepted
 		{"related", RelRelated},
 		{"discovered-from", RelRelated},
 		{"unknown", RelRelated}, // default
@@ -415,6 +443,67 @@ func TestPushLinks_AddMissing(t *testing.T) {
 	}
 }
 
+// TestPushLinks_HierarchyDirection is a direction-pinning regression test for
+// GH#5129: the desired set for a parent-child dep is built from the child's
+// own outgoing dependency row (storage direction: From = child, To =
+// parent). Pushing it must emit Hierarchy-Reverse (RelParent) — asserting
+// "the target is the parent of this item" — not Hierarchy-Forward, which
+// would reparent the target beneath the child.
+func TestPushLinks_HierarchyDirection(t *testing.T) {
+	var mu sync.Mutex
+	var patchCalls []patchCall
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPatch {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		body, _ := io.ReadAll(r.Body)
+		var ops []PatchOperation
+		_ = json.Unmarshal(body, &ops)
+		mu.Lock()
+		patchCalls = append(patchCalls, patchCall{ops: ops})
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	t.Cleanup(ts.Close)
+
+	client, err := NewClient(NewSecretString("pat"), "org", "proj").
+		WithBaseURL(ts.URL)
+	if err != nil {
+		t.Fatalf("WithBaseURL error: %v", err)
+	}
+	client = client.WithHTTPClient(ts.Client())
+	resolver := NewLinkResolver(client)
+
+	// workItemID 100 is the child being pushed; desired points to its
+	// parent, 300 — the storage direction GetDependenciesWithMetadata
+	// produces for a "parent-child" dep.
+	desired := []tracker.DependencyInfo{
+		{FromExternalID: "100", ToExternalID: "300", Type: "parent-child"},
+	}
+
+	errs := resolver.PushLinks(context.Background(), 100, nil, desired, nil)
+	if len(errs) != 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(patchCalls) != 1 {
+		t.Fatalf("got %d PATCH calls, want 1", len(patchCalls))
+	}
+
+	value, ok := patchCalls[0].ops[0].Value.(map[string]interface{})
+	if !ok {
+		t.Fatalf("PATCH op value is not a map: %#v", patchCalls[0].ops[0].Value)
+	}
+	if rel, _ := value["rel"].(string); rel != RelParent {
+		t.Errorf("PATCH rel = %q, want %q (Hierarchy-Reverse)", rel, RelParent)
+	}
+}
+
 func TestPushLinks_RemoveStale(t *testing.T) {
 	var mu sync.Mutex
 	var patchCalls []patchCall
@@ -449,7 +538,7 @@ func TestPushLinks_RemoveStale(t *testing.T) {
 			URL: ts.URL + "/proj/_apis/wit/workitems/200",
 		},
 		{
-			Rel: RelChild,
+			Rel: RelParent, // Hierarchy-Reverse: the type beads emits for parent-child (GH#4961)
 			URL: ts.URL + "/proj/_apis/wit/workitems/300",
 		},
 	}
@@ -483,10 +572,10 @@ func TestPushLinks_RemoveStale(t *testing.T) {
 }
 
 // TestPushLinks_PreservesUnmanagedLinks is the regression test for GH#4522:
-// a push must not delete links beads does not own. That includes
-// reverse-direction links (Dependency-Reverse predecessor/successor and
-// Hierarchy-Reverse parent), which beads represents via the forward link on
-// the other work item, and forward links pointing at items beads does not
+// a push must not delete links beads does not own. That includes links of
+// the opposite direction (Dependency-Reverse predecessor/successor and
+// Hierarchy-Forward), which beads represents via the link it owns on the
+// other work item, and forward links pointing at items beads does not
 // track (e.g. human-created Related links to work items outside the synced
 // set). None of these may be removed even though they are absent from the
 // desired set.
@@ -521,8 +610,9 @@ func TestPushLinks_PreservesUnmanagedLinks(t *testing.T) {
 	currentRelations := []WorkItemRelation{
 		// Reverse-direction predecessor/successor link to a tracked item.
 		{Rel: RelDependencyOf, URL: ts.URL + "/proj/_apis/wit/workitems/200"},
-		// Reverse-direction parent link to a tracked item.
-		{Rel: RelParent, URL: ts.URL + "/proj/_apis/wit/workitems/300"},
+		// Opposite-direction hierarchy link (Hierarchy-Forward) to a tracked
+		// item — beads owns the Hierarchy-Reverse link on the child, not this one.
+		{Rel: RelChild, URL: ts.URL + "/proj/_apis/wit/workitems/300"},
 		// Forward Related link to an UNtracked item (e.g. created by a human).
 		{Rel: RelRelated, URL: ts.URL + "/proj/_apis/wit/workitems/400"},
 	}
@@ -826,7 +916,7 @@ func TestPushLinks_RemoveFailure(t *testing.T) {
 			URL: ts.URL + "/proj/_apis/wit/workitems/200",
 		},
 		{
-			Rel: RelChild,
+			Rel: RelParent, // Hierarchy-Reverse: the type beads emits for parent-child (GH#4961)
 			URL: ts.URL + "/proj/_apis/wit/workitems/300",
 		},
 	}


### PR DESCRIPTION

## Summary

Fixes #4961.

The ADO adapter mapped beads dependency types using the string `"parent"`, but beads stores the hierarchy type as `"parent-child"` (`types.DepParentChild`) — `"parent"` is not a constant that exists anywhere in `internal/types`. As a result, every parent-child dependency was pushed to Azure DevOps as a **Related** link instead of a hierarchy link, and `System.Parent` was never set. The pull direction was broken the same way, writing a `"parent"` dependency type back into beads that no other code recognizes.

`beadsDepToADORel` and `adoRelToBeadsDep` (`internal/ado/links.go`) now match on `"parent-child"` in both directions **and emit the correct hierarchy direction**.

*(Corrected 2026-07-29 — an earlier version of this paragraph said the change "preserves the direction swap the pull side already did." That was wrong on both halves, as @maphew established in review: the push path applies no swap at all (it builds the desired set from storage and simply used the wrong relation constant), and the pull side's swap flags were themselves inverted. Both are fixed in `e00fcfea3`; the original claim was ours and it was incorrect.)*

Because the desired set is built from the child's own outgoing row (`IssueID`=child, `DependsOnID`=parent), `PushLinks` always runs with `workItemID` as the child and the target as the parent, so the push must emit `RelParent` (Hierarchy-Reverse). On pull, the swap flags are flipped so both branches yield beads' child → parent storage direction.

Thanks to Ruben Fonseca for the detailed root-cause trace and live ADO round-trip repro in the issue.

## Test plan

- [x] `go test ./internal/ado/ -count=1 -timeout 25m` (icu4c CGO flags) — pass, verified on a probe branch merged with current main (`3830f0a34`)

