### PR TITLE
fix(bootstrap): skip unreadable peer DBs on shared sql-server

### DIFF
--- a/cmd/bd/doctor/fix/metadata.go
+++ b/cmd/bd/doctor/fix/metadata.go
@@ -471,9 +471,15 @@ func inspectServerMetadataDatabases(beadsDir string, cfg *configfile.Config) ([]
 }
 
 // isExpectedProbeError returns true for errors that indicate the table/row
-// simply doesn't exist — safe to treat as "not present". Permission errors,
-// connection failures, and other unexpected errors should be propagated so
-// that reconciliation doesn't act on an incomplete inventory.
+// simply doesn't exist — or that this user cannot inspect that database —
+// safe to treat as "not present" when enumerating SHOW DATABASES.
+//
+// GH#4931: shared sql-servers often host non-beads databases the beads
+// user cannot read. Access denied on those peers must not abort bootstrap
+// / metadata reconciliation for the configured beads database.
+//
+// Hard connection failures (server down, auth to the catalog itself) still
+// surface via openServerCatalogDB / SHOW DATABASES, not this probe helper.
 func isExpectedProbeError(err error) bool {
 	if err == nil {
 		return true
@@ -490,7 +496,23 @@ func isExpectedProbeError(err error) bool {
 			return true
 		case 1054: // Unknown column
 			return true
+		case 1044: // Access denied for user to database
+			return true
+		case 1142: // Access denied for user to table
+			return true
+		case 1143: // Access denied for user to column
+			return true
+		case 1227: // Access denied (requires privilege)
+			return true
+		case 1105: // HY000 — Dolt often wraps access denied here (GH#4931)
+			if strings.Contains(strings.ToLower(mysqlErr.Message), "access denied") {
+				return true
+			}
 		}
+	}
+	// Driver / wrapper may not expose MySQLError; match the common message.
+	if strings.Contains(strings.ToLower(err.Error()), "access denied") {
+		return true
 	}
 	return false
 }

--- a/cmd/bd/doctor/fix/metadata_test.go
+++ b/cmd/bd/doctor/fix/metadata_test.go
@@ -501,11 +501,14 @@ func TestIsExpectedProbeError(t *testing.T) {
 		{"table not exist (1146)", &mysql.MySQLError{Number: 1146, Message: "Table doesn't exist"}, true},
 		{"unknown database (1049)", &mysql.MySQLError{Number: 1049, Message: "Unknown database"}, true},
 		{"unknown column (1054)", &mysql.MySQLError{Number: 1054, Message: "Unknown column"}, true},
-		{"access denied (1045)", &mysql.MySQLError{Number: 1045, Message: "Access denied"}, false},
-		{"access denied for db (1044)", &mysql.MySQLError{Number: 1044, Message: "Access denied for user"}, false},
+		// GH#4931: unreadable peer DBs on a shared server must not abort bootstrap
+		{"access denied table (1142)", &mysql.MySQLError{Number: 1142, Message: "Access denied for user to table"}, true},
+		{"access denied for db (1044)", &mysql.MySQLError{Number: 1044, Message: "Access denied for user"}, true},
+		{"dolt HY000 access denied (1105)", &mysql.MySQLError{Number: 1105, Message: "Access denied for user 'beads_rw'@'%' to table 'issues'"}, true},
+		{"access denied string", errors.New("Error 1105 (HY000): Access denied for user 'beads_rw'@'%' to table 'issues'"), true},
 		{"generic error", errors.New("connection reset"), false},
 		{"wrapped ErrNoRows", fmt.Errorf("wrapped: %w", sql.ErrNoRows), true},
-		{"wrapped access denied", fmt.Errorf("wrapped: %w", &mysql.MySQLError{Number: 1045}), false},
+		{"wrapped access denied 1044", fmt.Errorf("wrapped: %w", &mysql.MySQLError{Number: 1044, Message: "Access denied"}), true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION

## Summary

Fixes #4931.

`bd bootstrap --yes` aborted entirely when a shared Dolt sql-server hosted databases the beads user's grants don't cover:

```text
Error: failed to reconcile shared-server metadata: probing database "fleet_meta" for schema: Error 1105 (HY000): Access denied for user 'beads_rw'@'%' to table 'issues'
```

Bootstrap enumerates every database on the server and probes each for a bd schema, so one unreadable peer database — unrelated to the configured `dolt_database` — aborted the whole run. `isExpectedProbeError` now treats access-denied (MySQL 1044/1142/1143/1227, and Dolt's 1105 with an access-denied message) as a skip, the same way it already treats a missing table.

Thanks to Soichi Sumi for the clear repro.

## Test plan

- [x] `go test ./cmd/bd/doctor/fix/ -count=1 -timeout 25m` (icu4c CGO flags) — pass, verified on a probe branch merged with current main (`3830f0a34`)
