### PR TITLE
fix(rename-prefix): do not double IDs already on the target prefix

### DIFF
--- a/cmd/bd/rename_prefix.go
+++ b/cmd/bd/rename_prefix.go
@@ -137,46 +137,76 @@ NOTE: This is a rare operation. Most users never need this command.`,
 			return nil
 		}
 
+		// The prefix actually on the rows is the ground truth for ID rewriting,
+		// not the (possibly stale) issue_prefix config cell — see #5135 review.
+		// detectPrefixes already established this is a single, consistent
+		// prefix (the len(prefixes) > 1 case returned above).
+		detected := oldPrefix
+		if len(prefixes) == 1 {
+			for p := range prefixes {
+				detected = p
+			}
+		}
+
+		// detected == newPrefix means every row is already correctly prefixed
+		// and only the config cell is stale (GH#4827 half-migrated database).
+		// Repair the config without touching any IDs.
+		if detected == newPrefix {
+			if dryRun {
+				fmt.Printf("DRY RUN: config prefix disagrees with issue IDs — would repair config only: '%s' -> '%s' (%d issue IDs already correct)\n", oldPrefix, newPrefix, len(issues))
+				return nil
+			}
+			if err := store.SetConfig(ctx, "issue_prefix", newPrefix); err != nil {
+				return HandleError("failed to update prefix: %v", err)
+			}
+			commandDidWrite.Store(true)
+			fmt.Printf("%s Repaired config prefix: '%s' -> '%s' (%d issue IDs already correct, none rewritten)\n", ui.RenderPass("✓"), ui.RenderAccent(oldPrefix), ui.RenderAccent(newPrefix), len(issues))
+			if jsonOutput {
+				result := map[string]interface{}{
+					"old_prefix":      oldPrefix,
+					"new_prefix":      newPrefix,
+					"issues_count":    0,
+					"config_repaired": true,
+				}
+				enc := json.NewEncoder(os.Stdout)
+				enc.SetIndent("", "  ")
+				if eerr := enc.Encode(result); eerr != nil {
+					return eerr
+				}
+			}
+			return nil
+		}
+
 		if dryRun {
-			fmt.Printf("DRY RUN: Would rename issues from config prefix '%s' to '%s'\n\n", oldPrefix, newPrefix)
+			fmt.Printf("DRY RUN: Would rename issues from prefix '%s' to '%s'\n\n", detected, newPrefix)
 			fmt.Printf("Sample changes:\n")
-			unchanged := 0
 			shown := 0
 			for _, issue := range issues {
-				newID := rewriteIssueID(oldPrefix, newPrefix, issue.ID)
-				if newID == issue.ID {
-					unchanged++
-					continue
-				}
+				newID := rewriteIssueID(detected, newPrefix, issue.ID)
 				if shown < 5 {
 					fmt.Printf("  %s -> %s\n", ui.RenderAccent(issue.ID), ui.RenderAccent(newID))
 					shown++
 				}
 			}
-			if shown == 0 {
-				fmt.Printf("  (all %d issue IDs already use prefix %s — would only update config)\n", len(issues), newPrefix)
-			} else if len(issues)-shown-unchanged > 0 {
-				fmt.Printf("... and more\n")
-			}
-			if unchanged > 0 && shown > 0 {
-				fmt.Printf("  (%d IDs already on target prefix — left unchanged)\n", unchanged)
+			if remaining := len(issues) - shown; remaining > 0 {
+				fmt.Printf("... and %d more issues\n", remaining)
 			}
 			return nil
 		}
 
-		fmt.Printf("Renaming issues from config prefix '%s' to '%s'...\n", oldPrefix, newPrefix)
+		fmt.Printf("Renaming issues from prefix '%s' to '%s'...\n", detected, newPrefix)
 
-		if err := renamePrefixInDB(ctx, oldPrefix, newPrefix, issues); err != nil {
+		if err := renamePrefixInDB(ctx, detected, newPrefix, issues); err != nil {
 			return HandleError("failed to rename prefix: %v", err)
 		}
 
 		commandDidWrite.Store(true)
 
-		fmt.Printf("%s Successfully renamed prefix from %s to %s\n", ui.RenderPass("✓"), ui.RenderAccent(oldPrefix), ui.RenderAccent(newPrefix))
+		fmt.Printf("%s Successfully renamed prefix from %s to %s\n", ui.RenderPass("✓"), ui.RenderAccent(detected), ui.RenderAccent(newPrefix))
 
 		if jsonOutput {
 			result := map[string]interface{}{
-				"old_prefix":   oldPrefix,
+				"old_prefix":   detected,
 				"new_prefix":   newPrefix,
 				"issues_count": len(issues),
 			}
@@ -368,16 +398,20 @@ func repairPrefixes(ctx context.Context, st storage.DoltStorage, actorName strin
 	return nil
 }
 
-// rewriteIssueID maps oldID from oldPrefix to newPrefix without doubling when
-// the ID already uses the target prefix (GH#4827 half-migrated config cell).
+// rewriteIssueID maps oldID from oldPrefix to newPrefix. oldPrefix must be
+// the prefix actually detected on the issue rows (see detectPrefixes), not
+// the possibly-stale issue_prefix config cell — see PR #5135 review (maphew,
+// 2026-07-29): using the config cell here made the "already on target
+// prefix" check ambiguous with genuine prefix-shortening renames (e.g.
+// "beads-vscode-" -> "beads-" would leave "beads-vscode-1" unchanged,
+// because it also starts with "beads-"). The GH#4827 half-migrated-config
+// case is now handled by the caller comparing the detected prefix to
+// newPrefix directly and skipping ID rewrites entirely (config-only
+// repair), so this function no longer needs — or has — a newPrefix guard.
 func rewriteIssueID(oldPrefix, newPrefix, oldID string) string {
 	oldP := strings.TrimRight(oldPrefix, "-")
 	newP := strings.TrimRight(newPrefix, "-")
 	if oldP == "" || newP == "" {
-		return oldID
-	}
-	// Already on the destination prefix — leave alone (config may still be stale).
-	if strings.HasPrefix(oldID, newP+"-") {
 		return oldID
 	}
 	if strings.HasPrefix(oldID, oldP+"-") {

--- a/cmd/bd/rename_prefix.go
+++ b/cmd/bd/rename_prefix.go
@@ -138,21 +138,33 @@ NOTE: This is a rare operation. Most users never need this command.`,
 		}
 
 		if dryRun {
-			fmt.Printf("DRY RUN: Would rename %d issues from prefix '%s' to '%s'\n\n", len(issues), oldPrefix, newPrefix)
+			fmt.Printf("DRY RUN: Would rename issues from config prefix '%s' to '%s'\n\n", oldPrefix, newPrefix)
 			fmt.Printf("Sample changes:\n")
-			for i, issue := range issues {
-				if i >= 5 {
-					fmt.Printf("... and %d more issues\n", len(issues)-5)
-					break
+			unchanged := 0
+			shown := 0
+			for _, issue := range issues {
+				newID := rewriteIssueID(oldPrefix, newPrefix, issue.ID)
+				if newID == issue.ID {
+					unchanged++
+					continue
 				}
-				oldID := fmt.Sprintf("%s-%s", oldPrefix, strings.TrimPrefix(issue.ID, oldPrefix+"-"))
-				newID := fmt.Sprintf("%s-%s", newPrefix, strings.TrimPrefix(issue.ID, oldPrefix+"-"))
-				fmt.Printf("  %s -> %s\n", ui.RenderAccent(oldID), ui.RenderAccent(newID))
+				if shown < 5 {
+					fmt.Printf("  %s -> %s\n", ui.RenderAccent(issue.ID), ui.RenderAccent(newID))
+					shown++
+				}
+			}
+			if shown == 0 {
+				fmt.Printf("  (all %d issue IDs already use prefix %s — would only update config)\n", len(issues), newPrefix)
+			} else if len(issues)-shown-unchanged > 0 {
+				fmt.Printf("... and more\n")
+			}
+			if unchanged > 0 && shown > 0 {
+				fmt.Printf("  (%d IDs already on target prefix — left unchanged)\n", unchanged)
 			}
 			return nil
 		}
 
-		fmt.Printf("Renaming %d issues from prefix '%s' to '%s'...\n", len(issues), oldPrefix, newPrefix)
+		fmt.Printf("Renaming issues from config prefix '%s' to '%s'...\n", oldPrefix, newPrefix)
 
 		if err := renamePrefixInDB(ctx, oldPrefix, newPrefix, issues); err != nil {
 			return HandleError("failed to rename prefix: %v", err)
@@ -356,24 +368,41 @@ func repairPrefixes(ctx context.Context, st storage.DoltStorage, actorName strin
 	return nil
 }
 
+// rewriteIssueID maps oldID from oldPrefix to newPrefix without doubling when
+// the ID already uses the target prefix (GH#4827 half-migrated config cell).
+func rewriteIssueID(oldPrefix, newPrefix, oldID string) string {
+	oldP := strings.TrimRight(oldPrefix, "-")
+	newP := strings.TrimRight(newPrefix, "-")
+	if oldP == "" || newP == "" {
+		return oldID
+	}
+	// Already on the destination prefix — leave alone (config may still be stale).
+	if strings.HasPrefix(oldID, newP+"-") {
+		return oldID
+	}
+	if strings.HasPrefix(oldID, oldP+"-") {
+		return newP + "-" + strings.TrimPrefix(oldID, oldP+"-")
+	}
+	return oldID
+}
+
 func renamePrefixInDB(ctx context.Context, oldPrefix, newPrefix string, issues []*types.Issue) error {
 	// NOTE: Each issue is updated in its own transaction. A failure mid-way could leave
 	// the database in a mixed state with some issues renamed and others not.
 	// For production use, consider implementing a single atomic RenamePrefix() method
 	// in the storage layer that wraps all updates in one transaction.
 
-	oldPrefixPattern := regexp.MustCompile(`\b` + regexp.QuoteMeta(oldPrefix) + `-(\d+)\b`)
+	oldP := strings.TrimRight(oldPrefix, "-")
+	newP := strings.TrimRight(newPrefix, "-")
+	oldPrefixPattern := regexp.MustCompile(`\b` + regexp.QuoteMeta(oldP) + `-(\d+)\b`)
 
 	replaceFunc := func(match string) string {
-		return strings.Replace(match, oldPrefix+"-", newPrefix+"-", 1)
+		return strings.Replace(match, oldP+"-", newP+"-", 1)
 	}
 
 	for _, issue := range issues {
 		oldID := issue.ID
-		numPart := strings.TrimPrefix(oldID, oldPrefix+"-")
-		newID := fmt.Sprintf("%s-%s", newPrefix, numPart)
-
-		issue.ID = newID
+		newID := rewriteIssueID(oldP, newP, oldID)
 
 		issue.Title = oldPrefixPattern.ReplaceAllStringFunc(issue.Title, replaceFunc)
 		issue.Description = oldPrefixPattern.ReplaceAllStringFunc(issue.Description, replaceFunc)
@@ -387,12 +416,19 @@ func renamePrefixInDB(ctx context.Context, oldPrefix, newPrefix string, issues [
 			issue.Notes = oldPrefixPattern.ReplaceAllStringFunc(issue.Notes, replaceFunc)
 		}
 
+		// ID already on the target prefix (stale config cell only): skip UpdateIssueID
+		// so we never produce atlas-atlas-* (GH#4827).
+		if newID == oldID {
+			continue
+		}
+
+		issue.ID = newID
 		if err := store.UpdateIssueID(ctx, oldID, newID, issue, actor); err != nil {
 			return fmt.Errorf("failed to update issue %s: %w", oldID, err)
 		}
 	}
 
-	if err := store.SetConfig(ctx, "issue_prefix", newPrefix); err != nil {
+	if err := store.SetConfig(ctx, "issue_prefix", newP); err != nil {
 		return fmt.Errorf("failed to update config: %w", err)
 	}
 

--- a/cmd/bd/rename_prefix_embedded_test.go
+++ b/cmd/bd/rename_prefix_embedded_test.go
@@ -130,6 +130,37 @@ func TestEmbeddedRenamePrefix(t *testing.T) {
 			t.Errorf("expected 'No issues' message: %s", out)
 		}
 	})
+
+	// ===== Prefix Shortening (PR #5135 review blocker B1) =====
+	// Shortening a multi-part prefix to one of its own leading segments
+	// (e.g. "beads-vscode-" -> "beads-") must still rewrite every row —
+	// "beads-vscode-1" starting with "beads-" is not the same thing as it
+	// already being on the target prefix.
+
+	t.Run("rename_prefix_shortening", func(t *testing.T) {
+		dir, _, _ := bdInit(t, bd, "--prefix", "beads-vscode")
+		bdCreate(t, bd, dir, "Shortening test 1", "--type", "task")
+		bdCreate(t, bd, dir, "Shortening test 2", "--type", "task")
+
+		out := bdRenamePrefix(t, bd, dir, "beads")
+		if !strings.Contains(out, "Successfully renamed") {
+			t.Errorf("expected 'Successfully renamed' in output: %s", out)
+		}
+
+		cmd := exec.Command(bd, "list")
+		cmd.Dir = dir
+		cmd.Env = bdEnv(dir)
+		stdout, stderr, err := runCommandBuffers(t, cmd)
+		if err != nil {
+			t.Fatalf("bd list after rename failed: %v\nstdout:\n%s\nstderr:\n%s", err, stdout.String(), stderr.String())
+		}
+		if !strings.Contains(stdout.String(), "beads-1") {
+			t.Errorf("expected shortened 'beads-1' in list output: %s", stdout.String())
+		}
+		if strings.Contains(stdout.String(), "beads-vscode-") {
+			t.Errorf("regression: 'beads-vscode-' IDs were left unrewritten: %s", stdout.String())
+		}
+	})
 }
 
 // TestEmbeddedRenamePrefixConcurrent exercises rename-prefix --dry-run concurrently.

--- a/cmd/bd/rename_prefix_embedded_test.go
+++ b/cmd/bd/rename_prefix_embedded_test.go
@@ -154,8 +154,12 @@ func TestEmbeddedRenamePrefix(t *testing.T) {
 		if err != nil {
 			t.Fatalf("bd list after rename failed: %v\nstdout:\n%s\nstderr:\n%s", err, stdout.String(), stderr.String())
 		}
-		if !strings.Contains(stdout.String(), "beads-1") {
-			t.Errorf("expected shortened 'beads-1' in list output: %s", stdout.String())
+		// bd create mints hash IDs (beads-cyc), never sequential ones, so assert the
+		// rewritten prefix rather than a number — the beads-vscode- check below is what
+		// carries the real weight. Mirrors rename_basic, which asserts "new-" for the
+		// same reason.
+		if !strings.Contains(stdout.String(), "beads-") {
+			t.Errorf("expected shortened 'beads-' prefix in list output: %s", stdout.String())
 		}
 		if strings.Contains(stdout.String(), "beads-vscode-") {
 			t.Errorf("regression: 'beads-vscode-' IDs were left unrewritten: %s", stdout.String())

--- a/cmd/bd/rename_prefix_rewrite_test.go
+++ b/cmd/bd/rename_prefix_rewrite_test.go
@@ -1,0 +1,36 @@
+package main
+
+import "testing"
+
+func TestRewriteIssueID_NoDoublePrefix(t *testing.T) {
+	t.Parallel()
+	// GH#4827: config still "global" but rows already "atlas-*"
+	got := rewriteIssueID("global", "atlas", "atlas-1")
+	if got != "atlas-1" {
+		t.Fatalf("got %q, want atlas-1 (must not double)", got)
+	}
+	got = rewriteIssueID("global-", "atlas-", "atlas-99")
+	if got != "atlas-99" {
+		t.Fatalf("got %q, want atlas-99", got)
+	}
+}
+
+func TestRewriteIssueID_NormalRename(t *testing.T) {
+	t.Parallel()
+	got := rewriteIssueID("global", "atlas", "global-1")
+	if got != "atlas-1" {
+		t.Fatalf("got %q, want atlas-1", got)
+	}
+	got = rewriteIssueID("old-", "new-", "old-abc")
+	if got != "new-abc" {
+		t.Fatalf("got %q, want new-abc", got)
+	}
+}
+
+func TestRewriteIssueID_UnrelatedPrefixUnchanged(t *testing.T) {
+	t.Parallel()
+	got := rewriteIssueID("global", "atlas", "other-1")
+	if got != "other-1" {
+		t.Fatalf("got %q, want other-1", got)
+	}
+}

--- a/cmd/bd/rename_prefix_rewrite_test.go
+++ b/cmd/bd/rename_prefix_rewrite_test.go
@@ -34,3 +34,20 @@ func TestRewriteIssueID_UnrelatedPrefixUnchanged(t *testing.T) {
 		t.Fatalf("got %q, want other-1", got)
 	}
 }
+
+// TestRewriteIssueID_PrefixShortening pins PR #5135 review blocker B1
+// (maphew, 2026-07-29): the "already on target prefix" guard was checked
+// before the old-prefix match, so shortening a multi-part prefix to one of
+// its own leading segments (e.g. "beads-vscode-" -> "beads-") silently
+// skipped every ID, because "beads-vscode-1" also starts with "beads-".
+func TestRewriteIssueID_PrefixShortening(t *testing.T) {
+	t.Parallel()
+	got := rewriteIssueID("beads-vscode", "beads", "beads-vscode-1")
+	if got != "beads-1" {
+		t.Fatalf("got %q, want beads-1 (shortening regression)", got)
+	}
+	got = rewriteIssueID("kw-team", "kw", "kw-team-42")
+	if got != "kw-42" {
+		t.Fatalf("got %q, want kw-42 (shortening regression)", got)
+	}
+}

--- a/cmd/bd/rename_prefix_test.go
+++ b/cmd/bd/rename_prefix_test.go
@@ -221,3 +221,67 @@ func TestRenamePrefixInDB(t *testing.T) {
 		t.Errorf("Expected ID 'new-1', got %q", newIssue.ID)
 	}
 }
+
+// TestRenamePrefixInDB_HalfMigratedConfigNotDoubled pins the actual GH#4827
+// recovery path at the DB layer: config says "global" but the row is
+// already "atlas-1" (a half-migrated database). renamePrefixInDB must leave
+// the row alone — not produce "atlas-atlas-1" — while still repairing the
+// config cell. See PR #5135 review (maphew, 2026-07-29).
+func TestRenamePrefixInDB_HalfMigratedConfigNotDoubled(t *testing.T) {
+	tmpDir := t.TempDir()
+	dbPath := filepath.Join(tmpDir, "test.db")
+
+	testStore, err := dolt.New(context.Background(), &dolt.Config{Path: dbPath})
+	if err != nil {
+		t.Skipf("skipping: Dolt server not available: %v", err)
+	}
+	t.Cleanup(func() {
+		testStore.Close()
+		os.Remove(dbPath)
+	})
+
+	ctx := context.Background()
+	store = testStore
+	actor = "test-actor"
+
+	if err := testStore.SetConfig(ctx, "issue_prefix", "global"); err != nil {
+		t.Fatalf("Failed to set config: %v", err)
+	}
+
+	issue1 := &types.Issue{
+		ID:          "atlas-1",
+		Title:       "Already migrated",
+		Description: "Row is on the target prefix; config cell is stale",
+		Status:      types.StatusOpen,
+		Priority:    1,
+		IssueType:   types.TypeTask,
+	}
+	if err := testStore.CreateIssue(ctx, issue1, "test"); err != nil {
+		t.Fatalf("Failed to create issue: %v", err)
+	}
+
+	issues := []*types.Issue{issue1}
+	if err := renamePrefixInDB(ctx, "global", "atlas", issues); err != nil {
+		t.Fatalf("renamePrefixInDB failed: %v", err)
+	}
+
+	newPrefix, err := testStore.GetConfig(ctx, "issue_prefix")
+	if err != nil {
+		t.Fatalf("Failed to get new prefix: %v", err)
+	}
+	if newPrefix != "atlas" {
+		t.Errorf("Expected config prefix 'atlas', got %q", newPrefix)
+	}
+
+	survivingIssue, err := testStore.GetIssue(ctx, "atlas-1")
+	if err != nil {
+		t.Fatalf("Expected atlas-1 to survive unchanged, got error: %v", err)
+	}
+	if survivingIssue.ID != "atlas-1" {
+		t.Errorf("Expected surviving ID 'atlas-1', got %q", survivingIssue.ID)
+	}
+
+	if doubled, err := testStore.GetIssue(ctx, "atlas-atlas-1"); err == nil && doubled != nil {
+		t.Errorf("regression: found doubled ID 'atlas-atlas-1': %+v", doubled)
+	}
+}


### PR DESCRIPTION

## Summary

Fixes #4827.

In a half-migrated state — `config.issue_prefix` still `global` while the rows are already `atlas-*` — running `bd rename-prefix atlas` doubled the prefix:

```text
numPart = TrimPrefix("atlas-1", "global-")  // → "atlas-1"  (no-op, wrong prefix)
newID   = "atlas-" + numPart                // → "atlas-atlas-1"
```

`rewriteIssueID` now leaves an ID unchanged when it already starts with `newPrefix-`, while still calling `SetConfig(issue_prefix, newPrefix)`. That way the config cell can be repaired without rewriting IDs that are already correct, which is exactly the recovery path a half-migrated database needs.

Scope note: this does not add a separate `config set issue_prefix` route — repairing the config cell still goes through `rename-prefix`. Happy to split that out if you'd prefer it as its own verb.

Heads-up on sequencing: #4175 also edits `cmd/bd/rename_prefix.go`, but only to wrap the `SetConfig` calls in a prefix-mutation guard — it doesn't touch `rewriteIssueID`, so the two changes are complementary rather than competing. They may still conflict textually depending on merge order; happy to rebase on whichever lands first.

## Test plan

- [x] `go test ./cmd/bd/ -count=1 -timeout 25m` on this branch merged with current `main` (`3830f0a34`): `ok github.com/steveyegge/beads/cmd/bd` in 636s, no failures
- [x] `gofmt -l` clean on the touched files
