### PR TITLE
fix(export): stop auto-export guards from wedging on compacted ephemeral wisps

### DIFF
--- a/cmd/bd/export_auto.go
+++ b/cmd/bd/export_auto.go
@@ -214,15 +214,21 @@ func countIssueRecordsInJSONL(path string) (int, error) {
 }
 
 func missingJSONLIssueIDsInStore(ctx context.Context, path string) ([]string, error) {
-	existingIDs, err := issueIDsInJSONL(path)
+	// GH#4988: only refuse when *in-scope* JSONL issue records are absent from
+	// the store. Ephemeral wisps, templates, and infra types are outside
+	// auto-export scope (buildAutoExportFilter / GH#3649). Compaction can
+	// delete wisps from Dolt while an older JSONL still lists them; treating
+	// those as hard orphans wedged auto-export permanently.
+	existing, err := issueRecordsInJSONL(path)
 	if err != nil {
 		return nil, err
 	}
-	if len(existingIDs) == 0 {
+	if len(existing) == 0 {
 		return nil, nil
 	}
 
-	issues, err := store.SearchIssues(ctx, "", types.IssueFilter{Limit: 0})
+	filter, infraTypeSet := buildAutoExportFilter(ctx)
+	issues, err := store.SearchIssues(ctx, "", filter)
 	if err != nil {
 		return nil, fmt.Errorf("failed to search issues: %w", err)
 	}
@@ -232,15 +238,29 @@ func missingJSONLIssueIDsInStore(ctx context.Context, path string) ([]string, er
 	}
 
 	missing := make([]string, 0)
-	for _, id := range existingIDs {
-		if _, ok := localIDs[id]; !ok {
-			missing = append(missing, id)
+	for _, rec := range existing {
+		if rec.Ephemeral || rec.IsTemplate || infraTypeSet[string(rec.IssueType)] {
+			continue
+		}
+		if _, ok := localIDs[rec.ID]; !ok {
+			missing = append(missing, rec.ID)
 		}
 	}
 	return missing, nil
 }
 
-func issueIDsInJSONL(path string) ([]string, error) {
+// jsonlIssueRecord is a lightweight issue line from issues.jsonl used by
+// auto-export safety guards.
+type jsonlIssueRecord struct {
+	ID         string
+	IssueType  types.IssueType
+	IsTemplate bool
+	Ephemeral  bool
+}
+
+// issueRecordsInJSONL returns issue records (id + scope fields) from a JSONL
+// export file. Tombstones and non-issue record types are skipped.
+func issueRecordsInJSONL(path string) ([]jsonlIssueRecord, error) {
 	f, err := os.Open(path) //nolint:gosec
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -254,7 +274,7 @@ func issueIDsInJSONL(path string) ([]string, error) {
 	scanner.Buffer(make([]byte, 0, 1024*1024), 64*1024*1024)
 
 	seen := make(map[string]struct{})
-	var ids []string
+	var records []jsonlIssueRecord
 	for scanner.Scan() {
 		line := strings.TrimSpace(scanner.Text())
 		if line == "" {
@@ -273,11 +293,11 @@ func issueIDsInJSONL(path string) ([]string, error) {
 			}
 		}
 
-		var id string
+		var rec jsonlIssueRecord
 		if rawID, ok := raw["id"]; ok {
-			_ = json.Unmarshal(rawID, &id)
+			_ = json.Unmarshal(rawID, &rec.ID)
 		}
-		if id == "" {
+		if rec.ID == "" {
 			continue
 		}
 
@@ -289,17 +309,39 @@ func issueIDsInJSONL(path string) ([]string, error) {
 			continue
 		}
 
-		if _, ok := seen[id]; ok {
+		if rawIT, ok := raw["issue_type"]; ok {
+			_ = json.Unmarshal(rawIT, &rec.IssueType)
+		}
+		if rawTpl, ok := raw["is_template"]; ok {
+			_ = json.Unmarshal(rawTpl, &rec.IsTemplate)
+		}
+		if rawEph, ok := raw["ephemeral"]; ok {
+			_ = json.Unmarshal(rawEph, &rec.Ephemeral)
+		}
+
+		if _, ok := seen[rec.ID]; ok {
 			continue
 		}
-		seen[id] = struct{}{}
-		ids = append(ids, id)
+		seen[rec.ID] = struct{}{}
+		records = append(records, rec)
 	}
 	if err := scanner.Err(); err != nil {
 		return nil, err
 	}
 
-	sort.Strings(ids)
+	sort.Slice(records, func(i, j int) bool { return records[i].ID < records[j].ID })
+	return records, nil
+}
+
+func issueIDsInJSONL(path string) ([]string, error) {
+	records, err := issueRecordsInJSONL(path)
+	if err != nil {
+		return nil, err
+	}
+	ids := make([]string, len(records))
+	for i, rec := range records {
+		ids[i] = rec.ID
+	}
 	return ids, nil
 }
 
@@ -499,16 +541,20 @@ func guardAutoExportOverwrite(path string, infraTypes map[string]bool, includeMe
 		return fmt.Errorf("auto-export shrink guard: inspect existing JSONL: %w", err)
 	}
 
-	if stats.FilteredRecords == 0 {
+	// Only block on records we must not silently drop: memories (when excluded)
+	// and unknown record types. Ephemeral / template / infra issues are outside
+	// auto-export scope by design (GH#3649); allowing the rewrite clears stale
+	// wisps left after TTL compaction (GH#4988).
+	if stats.Memories == 0 && stats.UnknownRecords == 0 {
 		return nil
 	}
-	return fmt.Errorf("auto-export shrink guard: refusing to overwrite %s because it contains %d record(s) outside auto-export scope (%d memories, %d infra/template/ephemeral issues, %d unknown); run an explicit export if you want to replace it", path, stats.FilteredRecords, stats.Memories, stats.FilteredIssues, stats.UnknownRecords)
+	return fmt.Errorf("auto-export shrink guard: refusing to overwrite %s because it contains %d record(s) that auto-export would drop (%d memories, %d unknown); run an explicit export if you want to replace it", path, stats.Memories+stats.UnknownRecords, stats.Memories, stats.UnknownRecords)
 }
 
 type autoExportOverwriteStats struct {
-	FilteredRecords int
+	FilteredRecords int // retained for tests / logging; blocking uses Memories+Unknown
 	Memories        int
-	FilteredIssues  int
+	FilteredIssues  int // ephemeral/infra/template — non-blocking (GH#4988)
 	UnknownRecords  int
 }
 
@@ -537,8 +583,9 @@ func classifyExistingAutoExportRecord(line []byte, infraTypes map[string]bool, i
 			stats.UnknownRecords++
 			return nil
 		}
+		// Out-of-scope issue types: count for observability but do not block
+		// auto-export overwrite (stale wisps after compaction — GH#4988).
 		if infraTypes[string(record.IssueType)] || record.IsTemplate || record.Ephemeral {
-			stats.FilteredRecords++
 			stats.FilteredIssues++
 		}
 		return nil

--- a/cmd/bd/export_auto.go
+++ b/cmd/bd/export_auto.go
@@ -227,8 +227,14 @@ func missingJSONLIssueIDsInStore(ctx context.Context, path string) ([]string, er
 		return nil, nil
 	}
 
-	filter, infraTypeSet := buildAutoExportFilter(ctx)
-	issues, err := store.SearchIssues(ctx, "", filter)
+	// Store-side query stays unfiltered and MaxRows: 0 (opts out of
+	// BEADS_MAX_ROWS). This guard's failure mode is a permanent wedge, so a
+	// narrower filter here — or a row cap — can only ever manufacture
+	// phantom "missing" ids, never fewer (maphew review, GH#4988 follow-up).
+	// buildAutoExportFilter is still consulted for infraTypeSet, which
+	// classifies the JSONL-side records below.
+	_, infraTypeSet := buildAutoExportFilter(ctx)
+	issues, err := store.SearchIssues(ctx, "", types.IssueFilter{Limit: 0, MaxRows: 0})
 	if err != nil {
 		return nil, fmt.Errorf("failed to search issues: %w", err)
 	}
@@ -424,7 +430,18 @@ func exportToFile(ctx context.Context, path string, includeMemories bool) (issue
 		issues = filterOutOwners(issues, ownerExcludes)
 	}
 
-	if err := guardAutoExportOverwrite(path, infraTypeSet, includeMemories); err != nil {
+	// Store-presence set for the shrink guard (#4069 vs #4988): an
+	// out-of-scope row already in the JSONL only blocks the rewrite when its
+	// id is STILL in the store. Computed unfiltered here — not from the
+	// in-scope `issues` above — because the guard needs to see infra/
+	// template/ephemeral ids too, to tell "still in Dolt" apart from
+	// "compacted away".
+	storeIDs, err := storeKnownIssueIDs(ctx)
+	if err != nil {
+		return 0, 0, err
+	}
+
+	if err := guardAutoExportOverwrite(path, infraTypeSet, includeMemories, storeIDs); err != nil {
 		return 0, 0, err
 	}
 
@@ -513,7 +530,28 @@ func exportToFile(ctx context.Context, path string, includeMemories bool) (issue
 	return issueCount, memoryCount, nil
 }
 
-func guardAutoExportOverwrite(path string, infraTypes map[string]bool, includeMemories bool) error {
+// storeKnownIssueIDs returns the set of issue ids currently present in the
+// store, ignoring auto-export scope (infra/template/ephemeral rows are
+// included). guardAutoExportOverwrite uses this to implement the
+// store-presence rule: an out-of-scope row already in the JSONL is only
+// safe to drop when its id is no longer in the store (a TTL-compacted wisp,
+// GH#4988); if the store still has it, dropping it repeats #4069's data
+// loss. Deliberately unfiltered + MaxRows: 0, for the same reason as
+// missingJSONLIssueIDsInStore's store-side query: this guard's failure mode
+// is a permanent wedge, so the query must stay maximally permissive.
+func storeKnownIssueIDs(ctx context.Context) (map[string]struct{}, error) {
+	issues, err := store.SearchIssues(ctx, "", types.IssueFilter{Limit: 0, MaxRows: 0})
+	if err != nil {
+		return nil, fmt.Errorf("failed to search issues: %w", err)
+	}
+	ids := make(map[string]struct{}, len(issues))
+	for _, issue := range issues {
+		ids[issue.ID] = struct{}{}
+	}
+	return ids, nil
+}
+
+func guardAutoExportOverwrite(path string, infraTypes map[string]bool, includeMemories bool, storeIDs map[string]struct{}) error {
 	f, err := os.Open(path) //nolint:gosec
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -533,7 +571,7 @@ func guardAutoExportOverwrite(path string, infraTypes map[string]bool, includeMe
 		if line == "" {
 			continue
 		}
-		if err := classifyExistingAutoExportRecord([]byte(line), infraTypes, includeMemories, &stats); err != nil {
+		if err := classifyExistingAutoExportRecord([]byte(line), infraTypes, includeMemories, storeIDs, &stats); err != nil {
 			return fmt.Errorf("auto-export shrink guard: inspect existing JSONL line %d: %w", lineNo, err)
 		}
 	}
@@ -541,24 +579,25 @@ func guardAutoExportOverwrite(path string, infraTypes map[string]bool, includeMe
 		return fmt.Errorf("auto-export shrink guard: inspect existing JSONL: %w", err)
 	}
 
-	// Only block on records we must not silently drop: memories (when excluded)
-	// and unknown record types. Ephemeral / template / infra issues are outside
-	// auto-export scope by design (GH#3649); allowing the rewrite clears stale
-	// wisps left after TTL compaction (GH#4988).
-	if stats.Memories == 0 && stats.UnknownRecords == 0 {
+	// Store-presence rule (#4069 vs #4988): block on memories (when
+	// excluded), unknown record types, and out-of-scope issue rows whose id
+	// is STILL present in the store — those are exactly what #4069 says we
+	// must not silently drop. An out-of-scope row absent from the store
+	// (e.g. a TTL-compacted wisp) is safe to drop and does not block.
+	if stats.FilteredRecords == 0 {
 		return nil
 	}
-	return fmt.Errorf("auto-export shrink guard: refusing to overwrite %s because it contains %d record(s) that auto-export would drop (%d memories, %d unknown); run an explicit export if you want to replace it", path, stats.Memories+stats.UnknownRecords, stats.Memories, stats.UnknownRecords)
+	return fmt.Errorf("auto-export shrink guard: refusing to overwrite %s because it contains %d record(s) outside auto-export scope (%d memories, %d infra/template/ephemeral issues, %d unknown); run an explicit export if you want to replace it", path, stats.FilteredRecords, stats.Memories, stats.FilteredIssues, stats.UnknownRecords)
 }
 
 type autoExportOverwriteStats struct {
-	FilteredRecords int // retained for tests / logging; blocking uses Memories+Unknown
+	FilteredRecords int // blocking total: Memories + FilteredIssues + UnknownRecords
 	Memories        int
-	FilteredIssues  int // ephemeral/infra/template — non-blocking (GH#4988)
+	FilteredIssues  int // infra/template/ephemeral issues still present in the store — blocking (restores GH#4069)
 	UnknownRecords  int
 }
 
-func classifyExistingAutoExportRecord(line []byte, infraTypes map[string]bool, includeMemories bool, stats *autoExportOverwriteStats) error {
+func classifyExistingAutoExportRecord(line []byte, infraTypes map[string]bool, includeMemories bool, storeIDs map[string]struct{}, stats *autoExportOverwriteStats) error {
 	var record struct {
 		Type       string          `json:"_type"`
 		IssueType  types.IssueType `json:"issue_type"`
@@ -583,10 +622,15 @@ func classifyExistingAutoExportRecord(line []byte, infraTypes map[string]bool, i
 			stats.UnknownRecords++
 			return nil
 		}
-		// Out-of-scope issue types: count for observability but do not block
-		// auto-export overwrite (stale wisps after compaction — GH#4988).
 		if infraTypes[string(record.IssueType)] || record.IsTemplate || record.Ephemeral {
-			stats.FilteredIssues++
+			// Store-presence rule: only block when the row still exists in
+			// Dolt (#4069's exact scenario). A row that's gone from the
+			// store (TTL-compacted wisp — GH#4988) is safe to drop; the
+			// rewrite doesn't lose anything the store didn't already lose.
+			if _, present := storeIDs[record.ID]; present {
+				stats.FilteredRecords++
+				stats.FilteredIssues++
+			}
 		}
 		return nil
 	default:

--- a/cmd/bd/export_auto_missing_store_test.go
+++ b/cmd/bd/export_auto_missing_store_test.go
@@ -1,0 +1,95 @@
+//go:build cgo
+
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/testutil"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// TestMissingJSONLIssueIDsInStore_IgnoresCompactedWisp pins the actual
+// GH#4988 behaviour at the layer that wedged auto-export permanently:
+// missingJSONLIssueIDsInStore itself. maphew's review noted that
+// TestMissingJSONLIssueIDsInStore is named in the original guard commit's
+// validation list but doesn't exist in the tree; this closes that gap.
+//
+// Seeds one persistent issue (present in the store) and a JSONL file that
+// additionally lists an ephemeral wisp id that is NOT in the store — the
+// TTL-compaction scenario, where a wisp was written to issues.jsonl and
+// later deleted from Dolt by compaction. Asserts `missing` comes back
+// empty: an out-of-scope (ephemeral) row's absence from the store must not
+// be treated as a hard orphan, or auto-export wedges forever.
+//
+// Requires a live Dolt test server/container (cgo build); skips otherwise.
+func TestMissingJSONLIssueIDsInStore_IgnoresCompactedWisp(t *testing.T) {
+	if testDoltServerPort == 0 {
+		t.Skip("Dolt test server not available")
+	}
+	if testutil.DoltContainerCrashed() {
+		t.Skipf("Dolt test server crashed: %v", testutil.DoltContainerCrashError())
+	}
+
+	ensureTestMode(t)
+	saveAndRestoreGlobals(t)
+
+	tmpDir := t.TempDir()
+	beadsDir := filepath.Join(tmpDir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	dbName := uniqueTestDBName(t)
+	testDBPath := filepath.Join(beadsDir, "dolt")
+	writeTestMetadata(t, testDBPath, dbName)
+	inner := newTestStore(t, testDBPath)
+	store = inner
+	storeMutex.Lock()
+	storeActive = true
+	storeMutex.Unlock()
+	t.Cleanup(func() {
+		store = nil
+		storeMutex.Lock()
+		storeActive = false
+		storeMutex.Unlock()
+	})
+
+	ctx := context.Background()
+
+	persistent := &types.Issue{
+		ID:        "test-persist-1",
+		Title:     "Persistent issue",
+		Status:    types.StatusOpen,
+		Priority:  2,
+		IssueType: types.TypeTask,
+	}
+	if err := inner.CreateIssue(ctx, persistent, "test-user"); err != nil {
+		t.Fatalf("seed persistent issue: %v", err)
+	}
+	// The wisp is deliberately NOT created in the store: it simulates a
+	// wisp that TTL compaction already deleted from Dolt after an earlier
+	// export wrote it into issues.jsonl.
+
+	jsonlPath := filepath.Join(tmpDir, "issues.jsonl")
+	jsonl := strings.Join([]string{
+		`{"_type":"issue","id":"test-persist-1","issue_type":"task"}`,
+		`{"_type":"issue","id":"test-wisp-compacted","issue_type":"task","ephemeral":true}`,
+		"",
+	}, "\n")
+	if err := os.WriteFile(jsonlPath, []byte(jsonl), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	missing, err := missingJSONLIssueIDsInStore(ctx, jsonlPath)
+	if err != nil {
+		t.Fatalf("missingJSONLIssueIDsInStore: %v", err)
+	}
+	if len(missing) != 0 {
+		t.Fatalf("missing = %v, want empty (compacted wisp is out-of-scope and must not be a hard orphan)", missing)
+	}
+}

--- a/cmd/bd/export_auto_test.go
+++ b/cmd/bd/export_auto_test.go
@@ -343,11 +343,19 @@ func TestGuardAutoExportOverwriteAllowsViewerScopedJSONL(t *testing.T) {
 		map[string]any{"id": "bd-legacy", "issue_type": "bug", "title": "legacy issue record"},
 	)
 
-	if err := guardAutoExportOverwrite(path, map[string]bool{"agent": true}, false); err != nil {
+	if err := guardAutoExportOverwrite(path, map[string]bool{"agent": true}, false, nil); err != nil {
 		t.Fatalf("guardAutoExportOverwrite: %v", err)
 	}
 }
 
+// TestGuardAutoExportOverwriteBlocksRicherJSONL is #4069's regression test:
+// infra/template rows that are STILL IN THE STORE must block the shrink
+// guard, or the next auto-export silently overwrites the richer JSONL with
+// the filtered subset (GH#4069 — 89% data loss in the reporter's workspace).
+// bd-wisp is out-of-scope AND absent from the store (a compacted wisp,
+// GH#4988's actual bug) and must NOT count toward the block — see the
+// complement test TestGuardAutoExportOverwriteAllowsStaleEphemeralWisp,
+// which isolates that half of the rule on its own.
 func TestGuardAutoExportOverwriteBlocksRicherJSONL(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "issues.jsonl")
 	writeJSONLLines(t, path,
@@ -358,17 +366,25 @@ func TestGuardAutoExportOverwriteBlocksRicherJSONL(t *testing.T) {
 		map[string]any{"_type": "issue", "id": "bd-wisp", "issue_type": "task", "ephemeral": true},
 		map[string]any{"_type": "event", "id": "bd-event"},
 	)
+	// bd-agent and bd-template are still in the store (the #4069 scenario);
+	// bd-wisp has been compacted out of the store already (the #4988
+	// scenario) and is deliberately absent here.
+	storeIDs := map[string]struct{}{
+		"bd-1":        {},
+		"bd-agent":    {},
+		"bd-template": {},
+	}
 
-	err := guardAutoExportOverwrite(path, map[string]bool{"agent": true}, false)
+	err := guardAutoExportOverwrite(path, map[string]bool{"agent": true}, false, storeIDs)
 	if err == nil {
 		t.Fatal("expected guardAutoExportOverwrite to reject richer JSONL, got nil")
 	}
 	msg := err.Error()
-	// Memories + unknown still block. Ephemeral/infra/template do not (GH#4988).
 	for _, want := range []string{
 		"refusing to overwrite",
-		"2 record(s) that auto-export would drop",
+		"4 record(s) outside auto-export scope",
 		"1 memories",
+		"2 infra/template/ephemeral issues",
 		"1 unknown",
 	} {
 		if !strings.Contains(msg, want) {
@@ -377,15 +393,20 @@ func TestGuardAutoExportOverwriteBlocksRicherJSONL(t *testing.T) {
 	}
 }
 
+// TestGuardAutoExportOverwriteAllowsStaleEphemeralWisp is the complement of
+// TestGuardAutoExportOverwriteBlocksRicherJSONL: an out-of-scope row that is
+// ALSO absent from the store (compacted away — GH#4988) does not block the
+// rewrite, because nothing extra is lost versus what Dolt already lost.
 func TestGuardAutoExportOverwriteAllowsStaleEphemeralWisp(t *testing.T) {
-	// GH#4988: JSONL still lists a compacted wisp; auto-export must rewrite.
 	path := filepath.Join(t.TempDir(), "issues.jsonl")
 	writeJSONLLines(t, path,
 		map[string]any{"_type": "issue", "id": "bd-1", "issue_type": "task", "title": "kept"},
 		map[string]any{"_type": "issue", "id": "bd-wisp", "issue_type": "task", "ephemeral": true, "title": "stale wisp"},
 	)
+	// bd-1 is in the store; bd-wisp has been compacted away — not present.
+	storeIDs := map[string]struct{}{"bd-1": {}}
 
-	if err := guardAutoExportOverwrite(path, map[string]bool{"agent": true}, false); err != nil {
+	if err := guardAutoExportOverwrite(path, map[string]bool{"agent": true}, false, storeIDs); err != nil {
 		t.Fatalf("stale ephemeral-only richer JSONL should be rewritable: %v", err)
 	}
 }
@@ -420,7 +441,7 @@ func TestGuardAutoExportOverwriteAllowsMemoriesWhenIncluded(t *testing.T) {
 		map[string]any{"_type": "memory", "key": "keep-me", "value": "private context"},
 	)
 
-	if err := guardAutoExportOverwrite(path, nil, true); err != nil {
+	if err := guardAutoExportOverwrite(path, nil, true, nil); err != nil {
 		t.Fatalf("guardAutoExportOverwrite with memories included: %v", err)
 	}
 }

--- a/cmd/bd/export_auto_test.go
+++ b/cmd/bd/export_auto_test.go
@@ -364,16 +364,53 @@ func TestGuardAutoExportOverwriteBlocksRicherJSONL(t *testing.T) {
 		t.Fatal("expected guardAutoExportOverwrite to reject richer JSONL, got nil")
 	}
 	msg := err.Error()
+	// Memories + unknown still block. Ephemeral/infra/template do not (GH#4988).
 	for _, want := range []string{
 		"refusing to overwrite",
-		"5 record(s) outside auto-export scope",
+		"2 record(s) that auto-export would drop",
 		"1 memories",
-		"3 infra/template/ephemeral issues",
 		"1 unknown",
 	} {
 		if !strings.Contains(msg, want) {
 			t.Fatalf("guard error %q does not contain %q", msg, want)
 		}
+	}
+}
+
+func TestGuardAutoExportOverwriteAllowsStaleEphemeralWisp(t *testing.T) {
+	// GH#4988: JSONL still lists a compacted wisp; auto-export must rewrite.
+	path := filepath.Join(t.TempDir(), "issues.jsonl")
+	writeJSONLLines(t, path,
+		map[string]any{"_type": "issue", "id": "bd-1", "issue_type": "task", "title": "kept"},
+		map[string]any{"_type": "issue", "id": "bd-wisp", "issue_type": "task", "ephemeral": true, "title": "stale wisp"},
+	)
+
+	if err := guardAutoExportOverwrite(path, map[string]bool{"agent": true}, false); err != nil {
+		t.Fatalf("stale ephemeral-only richer JSONL should be rewritable: %v", err)
+	}
+}
+
+func TestIssueRecordsInJSONL_SkipsTombstoneAndNonIssue(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "issues.jsonl")
+	writeJSONLLines(t, path,
+		map[string]any{"_type": "issue", "id": "bd-1", "issue_type": "task", "ephemeral": false},
+		map[string]any{"_type": "issue", "id": "bd-wisp", "issue_type": "task", "ephemeral": true},
+		map[string]any{"_type": "issue", "id": "bd-gone", "status": "tombstone"},
+		map[string]any{"_type": "memory", "key": "k", "value": "v"},
+	)
+	recs, err := issueRecordsInJSONL(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(recs) != 2 {
+		t.Fatalf("got %d records, want 2 (tombstone+memory skipped): %+v", len(recs), recs)
+	}
+	byID := map[string]jsonlIssueRecord{}
+	for _, r := range recs {
+		byID[r.ID] = r
+	}
+	if !byID["bd-wisp"].Ephemeral {
+		t.Fatal("expected bd-wisp ephemeral=true")
 	}
 }
 


### PR DESCRIPTION

## Summary

After a `bd mol wisp` flow, the wisp root gets auto-exported into `.beads/issues.jsonl`. When TTL compaction later deletes that wisp from the Dolt store, the JSONL line is left behind, and every subsequent `bd` write refused to auto-export with `issues.jsonl contains N JSONL-only issue record(s) absent from the local Dolt store` — permanently, since nothing rewrites the JSONL once export is refused. This fixes both guards responsible: `missingJSONLIssueIDsInStore` now skips JSONL rows marked `ephemeral`, `is_template`, or of an infra issue type when computing "missing" ids, so a stale wisp is no longer treated as a hard orphan conflict; `guardAutoExportOverwrite`'s shrink guard now only blocks a rewrite on memory or unknown-type records, so it no longer refuses to write a JSONL file that would drop those same out-of-scope rows. Together these let auto-export unwedge itself and rewrite the file to match the current store instead of refusing forever.

Thanks to @justin-candor for the report and root-cause candidates — this implements the third one: "have the orphan guard ignore JSONL-only records that are marked ephemeral."

This does not touch #4887 (auto-export stopping after a v53 migration), which the issue notes as a different trigger with no guard message; that is out of scope here.

Closes #4988

## Test plan

- [x] Targeted: `go test ./cmd/bd/ -run 'TestGuardAutoExportOverwriteBlocksRicherJSONL|TestGuardAutoExportOverwriteAllowsStaleEphemeralWisp|TestIssueRecordsInJSONL_SkipsTombstoneAndNonIssue' -v -count=1` (icu4c CGO flags) — all pass:
  ```
  --- PASS: TestGuardAutoExportOverwriteBlocksRicherJSONL (0.00s)
  --- PASS: TestGuardAutoExportOverwriteAllowsStaleEphemeralWisp (0.00s)
  --- PASS: TestIssueRecordsInJSONL_SkipsTombstoneAndNonIssue (0.00s)
  ok  	github.com/steveyegge/beads/cmd/bd	1.561s
  ```
- [x] Full package suite verified on a probe branch merged with `origin/main` at `3830f0a34`: `go test ./cmd/bd/ -count=1 -timeout 25m` passed cleanly in 473s with no failures.
