### PR TITLE
fix(doctor): verify project identity before destructive doctor --fix operations

### DIFF
--- a/cmd/bd/doctor/fix/blocked.go
+++ b/cmd/bd/doctor/fix/blocked.go
@@ -17,18 +17,28 @@ import (
 // Mirrors DependencyKeys: opens its own writable store, repairs in a
 // transaction, and stages only the table it touched so an unrelated dirty
 // working set is not swept under this commit.
+//
+// orderDoctorFixes (cmd/bd/doctor_fix.go) pins this fix to run LAST in a
+// `bd doctor --fix` pass, after every graph-mutating fix — so a stale/wrong
+// connection here would land a DOLT_COMMIT into another project's history
+// even when every earlier fix correctly aborted on the same mismatched
+// target (mybd-2qegi). guardFixTarget below is what stops that.
 func RecomputeBlocked(path string) error {
 	beadsDir, err := resolvedWorkspaceBeadsDir(path)
 	if err != nil {
 		return err
 	}
 
-	db, err := openDoltDB(beadsDir)
+	db, cfg, err := openDoltDB(beadsDir)
 	if err != nil {
 		fmt.Printf("  Blocked-state fix skipped (%v)\n", err)
 		return nil
 	}
 	defer db.Close()
+
+	if skip, err := guardFixTarget("Blocked-state fix", db, beadsDir, cfg); skip {
+		return err
+	}
 
 	return repairBlockedState(context.Background(), db)
 }

--- a/cmd/bd/doctor/fix/dep_keys.go
+++ b/cmd/bd/doctor/fix/dep_keys.go
@@ -89,6 +89,10 @@ func DependencyKeys(path string, verbose bool) error {
 	}
 	defer db.Close()
 
+	if err := verifyFixTargetIdentity(db, beadsDir); err != nil {
+		return err
+	}
+
 	return repairDependencyKeys(context.Background(), db, verbose)
 }
 

--- a/cmd/bd/doctor/fix/dep_keys.go
+++ b/cmd/bd/doctor/fix/dep_keys.go
@@ -82,14 +82,14 @@ func DependencyKeys(path string, verbose bool) error {
 		return err
 	}
 
-	db, err := openDoltDB(beadsDir)
+	db, cfg, err := openDoltDB(beadsDir)
 	if err != nil {
 		fmt.Printf("  Dependency key fix skipped (%v)\n", err)
 		return nil
 	}
 	defer db.Close()
 
-	if err := verifyFixTargetIdentity(db, beadsDir); err != nil {
+	if skip, err := guardFixTarget("Dependency key fix", db, beadsDir, cfg); skip {
 		return err
 	}
 

--- a/cmd/bd/doctor/fix/metadata.go
+++ b/cmd/bd/doctor/fix/metadata.go
@@ -217,8 +217,12 @@ func FixMissingDoltDatabase(path string) error {
 		return nil
 	}
 
-	// Connect to the server and probe for the correct database
-	db, err := openDoltDB(beadsDir)
+	// Connect to the server and probe for the correct database. No
+	// verifyFixTargetIdentity guard here: cfg.DoltDatabase is empty at this
+	// point (that's the condition that got us here), so there is no target
+	// database identity to verify yet — this call establishes it by probing
+	// schema across the server, it does not delete or mutate anything.
+	db, _, err := openDoltDB(beadsDir)
 	if err != nil {
 		fmt.Printf("  dolt_database fix skipped (server not reachable: %v)\n", err)
 		return nil

--- a/cmd/bd/doctor/fix/remotes.go
+++ b/cmd/bd/doctor/fix/remotes.go
@@ -3,12 +3,14 @@ package fix
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"time"
 
 	"github.com/steveyegge/beads/internal/configfile"
 	"github.com/steveyegge/beads/internal/doltserver"
 	"github.com/steveyegge/beads/internal/storage/doltutil"
+	"github.com/steveyegge/beads/internal/storage/issueops"
 )
 
 func openFixDB(beadsDir string, cfg *configfile.Config) (*sql.DB, error) {
@@ -29,6 +31,17 @@ func openFixDB(beadsDir string, cfg *configfile.Config) (*sql.DB, error) {
 	return sql.Open("mysql", connStr)
 }
 
+// errUnverifiableFixTarget marks a verifyFixTargetIdentity failure that is
+// not a confirmed identity mismatch — the project_id needed to compare is
+// missing on one side, or couldn't be read. Callers treat this as a soft
+// skip (see guardFixTarget), the same convention already used for "database
+// unreachable" at each destructive fix's call site. It is deliberately not
+// a hard abort: shared-server-mode workspaces, projects that predate the
+// project_id metadata table, and workspaces where a user has declined the
+// interactive "Project Identity" fix are all real, common, and otherwise
+// have no self-service way to unblock every other doctor fix.
+var errUnverifiableFixTarget = errors.New("cannot verify target database identity")
+
 // verifyFixTargetIdentity guards every destructive doctor --fix path against
 // a stale or wrong dolt-server.port file (or the shared-mode default port)
 // silently redirecting DELETE/UPDATE statements at a different project's
@@ -44,43 +57,76 @@ func openFixDB(beadsDir string, cfg *configfile.Config) (*sql.DB, error) {
 // This compares the freshly-dialed connection's `_project_id` (from the
 // dolt-synced metadata table, the same key internal/storage/dolt/store.go's
 // verifyProjectIdentity checks) against the local metadata.json project_id
-// for beadsDir. Unlike verifyProjectIdentity — which treats a missing id on
-// either side as an old-style setup and skips verification — a destructive
-// fix must never proceed on an unverifiable target, so a missing id on
-// either side is also treated as a hard abort here.
-func verifyFixTargetIdentity(db *sql.DB, beadsDir string) error {
-	metaCfg, err := configfile.Load(beadsDir)
-	if err != nil || metaCfg == nil {
-		return fmt.Errorf("refusing destructive fix: cannot load local metadata.json to verify target database identity: %w", err)
+// for beadsDir. cfg may be nil, in which case metadata.json is loaded fresh;
+// callers that already loaded it (e.g. via openDoltDB) should pass it
+// through so the two loads cannot disagree.
+//
+// Returns a non-nil error wrapping errUnverifiableFixTarget when the
+// comparison can't be made (see errUnverifiableFixTarget's doc). Returns a
+// plain (non-wrapped) error only for a confirmed project_id MISMATCH, which
+// callers must always treat as a hard abort.
+func verifyFixTargetIdentity(db *sql.DB, beadsDir string, cfg *configfile.Config) error {
+	metaCfg := cfg
+	if metaCfg == nil {
+		loaded, err := configfile.Load(beadsDir)
+		if err != nil {
+			return fmt.Errorf("%w: failed to load local metadata.json: %v", errUnverifiableFixTarget, err)
+		}
+		metaCfg = loaded
+	}
+	if metaCfg == nil {
+		return fmt.Errorf("%w: no local metadata.json found", errUnverifiableFixTarget)
 	}
 	localID := metaCfg.ProjectID
 	if localID == "" {
-		return fmt.Errorf("refusing destructive fix: local metadata.json has no project_id, cannot verify the dolt server we resolved is the diagnosed database")
+		return fmt.Errorf("%w: local metadata.json has no project_id", errUnverifiableFixTarget)
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	var dbID string
-	err = db.QueryRowContext(ctx, "SELECT value FROM metadata WHERE `key` = '_project_id'").Scan(&dbID)
-	if err != nil && err != sql.ErrNoRows {
-		return fmt.Errorf("refusing destructive fix: failed to read database project_id to verify target identity: %w", err)
+	// GetMetadataInTx returns ("", nil) when the row is absent, so there's no
+	// separate sql.ErrNoRows branch to handle here.
+	dbID, err := issueops.GetMetadataInTx(ctx, db, "_project_id")
+	if err != nil {
+		return fmt.Errorf("%w: failed to read database project_id: %v", errUnverifiableFixTarget, err)
 	}
 	if dbID == "" {
-		return fmt.Errorf("refusing destructive fix: connected database has no project_id in its metadata table, cannot verify it is the diagnosed database (possible stale dolt-server.port or wrong server)")
+		return fmt.Errorf("%w: connected database has no project_id in its metadata table (possible stale dolt-server.port or wrong server)", errUnverifiableFixTarget)
 	}
 
 	if localID != dbID {
 		return fmt.Errorf(
-			"refusing destructive fix — PROJECT IDENTITY MISMATCH\n\n"+
+			"PROJECT IDENTITY MISMATCH — refusing destructive fix\n\n"+
 				"  Local project ID (metadata.json):  %s\n"+
 				"  Connected database project ID:     %s\n\n"+
-				"The resolved dolt server port is serving a DIFFERENT project's database\n"+
-				"than the one doctor diagnosed. This can happen with a stale\n"+
+				"The resolved dolt server connection is serving a DIFFERENT project's\n"+
+				"database than the one doctor diagnosed. This can happen with a stale\n"+
 				"dolt-server.port file or the shared-mode default port pointing at\n"+
 				"another project's server.\n\n"+
 				"To diagnose: bd dolt status",
 			localID, dbID)
 	}
 	return nil
+}
+
+// guardFixTarget wraps verifyFixTargetIdentity with the convention every
+// destructive fix entry point must follow: an unverifiable target is a soft
+// skip (printed, then treated as "nothing to fix" — matching the existing
+// "database unreachable" convention at each call site), while a confirmed
+// PROJECT IDENTITY MISMATCH is a hard abort. Call sites use it as:
+//
+//	if skip, err := guardFixTarget("<Fix Name>", db, beadsDir, cfg); skip {
+//		return err
+//	}
+func guardFixTarget(fixName string, db *sql.DB, beadsDir string, cfg *configfile.Config) (skip bool, err error) {
+	verr := verifyFixTargetIdentity(db, beadsDir, cfg)
+	if verr == nil {
+		return false, nil
+	}
+	if errors.Is(verr, errUnverifiableFixTarget) {
+		fmt.Printf("  %s skipped: cannot verify target database identity (no project_id); run 'bd doctor --fix' to backfill project identity, then re-run\n", fixName)
+		return true, nil
+	}
+	return true, verr
 }

--- a/cmd/bd/doctor/fix/remotes.go
+++ b/cmd/bd/doctor/fix/remotes.go
@@ -1,7 +1,10 @@
 package fix
 
 import (
+	"context"
 	"database/sql"
+	"fmt"
+	"time"
 
 	"github.com/steveyegge/beads/internal/configfile"
 	"github.com/steveyegge/beads/internal/doltserver"
@@ -24,4 +27,60 @@ func openFixDB(beadsDir string, cfg *configfile.Config) (*sql.DB, error) {
 		TLS:      cfg.GetDoltServerTLS(),
 	}.String()
 	return sql.Open("mysql", connStr)
+}
+
+// verifyFixTargetIdentity guards every destructive doctor --fix path against
+// a stale or wrong dolt-server.port file (or the shared-mode default port)
+// silently redirecting DELETE/UPDATE statements at a different project's
+// database than the one doctor diagnosed (mybd-2qegi).
+//
+// openFixDB dials fresh on every fix call, re-resolving the port from
+// doltserver.DefaultConfig(beadsDir) independently of whatever connection
+// doctor's read-only checks used. Two different projects commonly share the
+// same database name ("beads" by default), so a stale port pointing at an
+// unrelated project's server would otherwise connect successfully and
+// destructively mutate the wrong data with no error.
+//
+// This compares the freshly-dialed connection's `_project_id` (from the
+// dolt-synced metadata table, the same key internal/storage/dolt/store.go's
+// verifyProjectIdentity checks) against the local metadata.json project_id
+// for beadsDir. Unlike verifyProjectIdentity — which treats a missing id on
+// either side as an old-style setup and skips verification — a destructive
+// fix must never proceed on an unverifiable target, so a missing id on
+// either side is also treated as a hard abort here.
+func verifyFixTargetIdentity(db *sql.DB, beadsDir string) error {
+	metaCfg, err := configfile.Load(beadsDir)
+	if err != nil || metaCfg == nil {
+		return fmt.Errorf("refusing destructive fix: cannot load local metadata.json to verify target database identity: %w", err)
+	}
+	localID := metaCfg.ProjectID
+	if localID == "" {
+		return fmt.Errorf("refusing destructive fix: local metadata.json has no project_id, cannot verify the dolt server we resolved is the diagnosed database")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	var dbID string
+	err = db.QueryRowContext(ctx, "SELECT value FROM metadata WHERE `key` = '_project_id'").Scan(&dbID)
+	if err != nil && err != sql.ErrNoRows {
+		return fmt.Errorf("refusing destructive fix: failed to read database project_id to verify target identity: %w", err)
+	}
+	if dbID == "" {
+		return fmt.Errorf("refusing destructive fix: connected database has no project_id in its metadata table, cannot verify it is the diagnosed database (possible stale dolt-server.port or wrong server)")
+	}
+
+	if localID != dbID {
+		return fmt.Errorf(
+			"refusing destructive fix — PROJECT IDENTITY MISMATCH\n\n"+
+				"  Local project ID (metadata.json):  %s\n"+
+				"  Connected database project ID:     %s\n\n"+
+				"The resolved dolt server port is serving a DIFFERENT project's database\n"+
+				"than the one doctor diagnosed. This can happen with a stale\n"+
+				"dolt-server.port file or the shared-mode default port pointing at\n"+
+				"another project's server.\n\n"+
+				"To diagnose: bd dolt status",
+			localID, dbID)
+	}
+	return nil
 }

--- a/cmd/bd/doctor/fix/remotes_test.go
+++ b/cmd/bd/doctor/fix/remotes_test.go
@@ -4,6 +4,7 @@ package fix
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -88,8 +89,8 @@ func newIdentityTestStore(t *testing.T, dir, prefix string) (store *dolt.DoltSto
 // have: the connection openDoltDB opens belongs to a database whose stored
 // _project_id does not match the local metadata.json project_id it was
 // diagnosed against. verifyFixTargetIdentity must catch that and abort
-// before any DELETE runs, regardless of *how* the mismatched connection was
-// reached.
+// before any DELETE/UPDATE runs, regardless of *how* the mismatched
+// connection was reached.
 func TestDestructiveFix_AbortsOnProjectIdentityMismatch(t *testing.T) {
 	dir := t.TempDir()
 	store, _, _ := newIdentityTestStore(t, dir, "tst")
@@ -144,11 +145,15 @@ func TestDestructiveFix_AbortsOnProjectIdentityMismatch(t *testing.T) {
 	}
 
 	// Same guard must apply to the other destructive fix entrypoints that
-	// share openDoltDB/openFixDB.
+	// share openDoltDB/openFixDB, including RecomputeBlocked — which
+	// orderDoctorFixes (cmd/bd/doctor_fix.go) runs LAST in a `bd doctor
+	// --fix` pass, after every graph-mutating fix, and which would otherwise
+	// still land a DOLT_COMMIT into the wrong project's history.
 	for name, fn := range map[string]func(string) error{
 		"CrossTableDuplicates":    func(p string) error { return CrossTableDuplicates(p, false) },
 		"OrphanedDependencies":    func(p string) error { return OrphanedDependencies(p, false) },
 		"ChildParentDependencies": func(p string) error { return ChildParentDependencies(p, false) },
+		"RecomputeBlocked":        RecomputeBlocked,
 	} {
 		t.Run(name, func(t *testing.T) {
 			if err := fn(dir); err == nil {
@@ -160,48 +165,112 @@ func TestDestructiveFix_AbortsOnProjectIdentityMismatch(t *testing.T) {
 	}
 }
 
-// TestVerifyFixTargetIdentity covers verifyFixTargetIdentity directly:
-// match passes, mismatch and unverifiable targets (missing project_id on
-// either side) abort.
-func TestVerifyFixTargetIdentity(t *testing.T) {
+// TestDestructiveFix_SkipsOnUnverifiableTarget covers the non-fatal-skip
+// half of the guard: a workspace whose local metadata.json has no
+// project_id (pre-project_id projects, shared-server-mode workspaces that
+// never got backfilled, or a user who declined the interactive "Project
+// Identity" fix) must not be permanently locked out of every other
+// doctor fix — the destructive statements still must not run, but the
+// caller gets nil back, not an error, matching the existing "database
+// unreachable" skip convention at each call site.
+func TestDestructiveFix_SkipsOnUnverifiableTarget(t *testing.T) {
 	dir := t.TempDir()
-	store, beadsDir, _ := newIdentityTestStore(t, dir, "vfi")
+	store, beadsDir, _ := newIdentityTestStore(t, dir, "skp")
 	ctx := context.Background()
-	db := store.UnderlyingDB()
 
+	cfg, err := configfile.Load(beadsDir)
+	if err != nil || cfg == nil {
+		t.Fatalf("load config: %v", err)
+	}
+	cfg.ProjectID = ""
+	if err := cfg.Save(beadsDir); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+
+	const randomID = "bbbbbbbb-cccc-dddd-eeee-ffffffffffff"
+	for _, id := range []string{"skp-1", "skp-2"} {
+		issue := &types.Issue{
+			ID:        id,
+			Title:     "skip guard test " + id,
+			Priority:  2,
+			Status:    types.StatusOpen,
+			IssueType: types.TypeTask,
+		}
+		if err := store.CreateIssue(ctx, issue, "test"); err != nil {
+			t.Fatalf("CreateIssue(%s): %v", id, err)
+		}
+	}
+	db := store.UnderlyingDB()
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO dependencies (id, issue_id, depends_on_issue_id, type, created_at, created_by)
+		VALUES (?, 'skp-1', 'skp-2', 'blocks', NOW(), 'test')`, randomID); err != nil {
+		t.Fatalf("insert randomly-keyed dependency: %v", err)
+	}
+
+	if err := DependencyKeys(dir, false); err != nil {
+		t.Fatalf("DependencyKeys should skip (nil error) on an unverifiable target, got: %v", err)
+	}
+
+	// Still not touched — the skip must be as safe as the abort.
+	var count int
+	if scanErr := db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM dependencies WHERE id = ?`, randomID).Scan(&count); scanErr != nil {
+		t.Fatalf("count dependency row: %v", scanErr)
+	}
+	if count != 1 {
+		t.Errorf("expected the mis-keyed row to survive the skipped fix, found %d matching rows", count)
+	}
+}
+
+// TestVerifyFixTargetIdentity covers verifyFixTargetIdentity directly: match
+// passes; mismatch aborts with a plain (non-errUnverifiableFixTarget) error;
+// unverifiable targets (missing project_id on either side) return an error
+// wrapping errUnverifiableFixTarget. Each case gets its own store so the
+// subtests don't depend on run order.
+func TestVerifyFixTargetIdentity(t *testing.T) {
 	t.Run("matching project ids pass", func(t *testing.T) {
-		if err := verifyFixTargetIdentity(db, beadsDir); err != nil {
+		store, beadsDir, _ := newIdentityTestStore(t, t.TempDir(), "vfi1")
+		if err := verifyFixTargetIdentity(store.UnderlyingDB(), beadsDir, nil); err != nil {
 			t.Errorf("expected no error for matching project ids, got: %v", err)
 		}
 	})
 
-	t.Run("mismatched project ids abort", func(t *testing.T) {
+	t.Run("mismatched project ids abort with a plain error", func(t *testing.T) {
+		store, beadsDir, _ := newIdentityTestStore(t, t.TempDir(), "vfi2")
+		ctx := context.Background()
 		if err := store.SetMetadata(ctx, "_project_id", "some-other-project"); err != nil {
 			t.Fatalf("SetMetadata: %v", err)
 		}
-		err := verifyFixTargetIdentity(db, beadsDir)
+		err := verifyFixTargetIdentity(store.UnderlyingDB(), beadsDir, nil)
 		if err == nil {
 			t.Fatal("expected mismatch error, got nil")
 		}
 		if !strings.Contains(err.Error(), "PROJECT IDENTITY MISMATCH") {
 			t.Errorf("expected PROJECT IDENTITY MISMATCH, got: %v", err)
 		}
+		if errors.Is(err, errUnverifiableFixTarget) {
+			t.Errorf("a confirmed mismatch must not be classified as unverifiable: %v", err)
+		}
 	})
 
-	t.Run("missing database project_id is unverifiable and aborts", func(t *testing.T) {
+	t.Run("missing database project_id is unverifiable", func(t *testing.T) {
+		store, beadsDir, _ := newIdentityTestStore(t, t.TempDir(), "vfi3")
+		ctx := context.Background()
+		db := store.UnderlyingDB()
 		if _, err := db.ExecContext(ctx, "DELETE FROM metadata WHERE `key` = '_project_id'"); err != nil {
 			t.Fatalf("clear _project_id: %v", err)
 		}
-		err := verifyFixTargetIdentity(db, beadsDir)
+		err := verifyFixTargetIdentity(db, beadsDir, nil)
 		if err == nil {
 			t.Fatal("expected unverifiable-target error, got nil")
 		}
-		if !strings.Contains(err.Error(), "no project_id") {
-			t.Errorf("expected an unverifiable-target error, got: %v", err)
+		if !errors.Is(err, errUnverifiableFixTarget) {
+			t.Errorf("expected an errUnverifiableFixTarget error, got: %v", err)
 		}
 	})
 
-	t.Run("missing local project_id is unverifiable and aborts", func(t *testing.T) {
+	t.Run("missing local project_id is unverifiable", func(t *testing.T) {
+		store, beadsDir, _ := newIdentityTestStore(t, t.TempDir(), "vfi4")
 		cfg, err := configfile.Load(beadsDir)
 		if err != nil || cfg == nil {
 			t.Fatalf("load config: %v", err)
@@ -210,8 +279,32 @@ func TestVerifyFixTargetIdentity(t *testing.T) {
 		if err := cfg.Save(beadsDir); err != nil {
 			t.Fatalf("save config: %v", err)
 		}
-		if err := verifyFixTargetIdentity(db, beadsDir); err == nil {
+		verr := verifyFixTargetIdentity(store.UnderlyingDB(), beadsDir, nil)
+		if verr == nil {
 			t.Fatal("expected unverifiable-target error for missing local project_id, got nil")
+		}
+		if !errors.Is(verr, errUnverifiableFixTarget) {
+			t.Errorf("expected an errUnverifiableFixTarget error, got: %v", verr)
+		}
+	})
+
+	t.Run("passed-in cfg is used instead of reloading", func(t *testing.T) {
+		store, beadsDir, projectID := newIdentityTestStore(t, t.TempDir(), "vfi5")
+		// A cfg with a different (wrong) project_id than what's on disk —
+		// if verifyFixTargetIdentity ignored the passed-in cfg and reloaded
+		// from beadsDir instead, this would incorrectly pass.
+		staleCfg := &configfile.Config{ProjectID: "stale-in-memory-id"}
+		err := verifyFixTargetIdentity(store.UnderlyingDB(), beadsDir, staleCfg)
+		if err == nil {
+			t.Fatal("expected mismatch using the passed-in (stale) cfg, got nil")
+		}
+		if !strings.Contains(err.Error(), "PROJECT IDENTITY MISMATCH") {
+			t.Errorf("expected PROJECT IDENTITY MISMATCH, got: %v", err)
+		}
+		// Sanity: the real on-disk project_id still matches the database.
+		onDisk, loadErr := configfile.Load(beadsDir)
+		if loadErr != nil || onDisk == nil || onDisk.ProjectID != projectID {
+			t.Fatalf("on-disk project_id drifted unexpectedly: %+v, err=%v", onDisk, loadErr)
 		}
 	})
 }

--- a/cmd/bd/doctor/fix/remotes_test.go
+++ b/cmd/bd/doctor/fix/remotes_test.go
@@ -1,0 +1,217 @@
+//go:build cgo
+
+package fix
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/configfile"
+	"github.com/steveyegge/beads/internal/storage/dolt"
+	"github.com/steveyegge/beads/internal/testutil"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// newIdentityTestStore is a variant of newFixTestStore that additionally
+// sets CreateIfMissing on the dolt.Config (newFixTestStore's connect-only
+// config depends on the test database already existing, which this Dolt
+// server build does not do implicitly) and seeds a project_id shared by
+// metadata.json and the database, matching what a real `bd init` produces.
+func newIdentityTestStore(t *testing.T, dir, prefix string) (store *dolt.DoltStore, beadsDir, projectID string) {
+	t.Helper()
+	testutil.RequireDoltBinary(t)
+	ctx := context.Background()
+
+	port := fixTestServerPort()
+
+	beadsDir = filepath.Join(dir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0755); err != nil {
+		t.Fatalf("create .beads: %v", err)
+	}
+
+	dbName := "fixident_" + strings.ToLower(t.Name())
+	dbName = strings.NewReplacer("/", "_", " ", "_").Replace(dbName)
+
+	projectID = configfile.GenerateProjectID()
+	cfg := &configfile.Config{
+		Database:       "dolt",
+		DoltMode:       configfile.DoltModeServer,
+		DoltServerHost: "127.0.0.1",
+		DoltServerPort: port,
+		DoltDatabase:   dbName,
+		ProjectID:      projectID,
+	}
+	if err := cfg.Save(beadsDir); err != nil {
+		t.Fatalf("write metadata.json: %v", err)
+	}
+
+	store, err := dolt.New(ctx, &dolt.Config{
+		Path:            filepath.Join(beadsDir, "beads.db"),
+		ServerHost:      "127.0.0.1",
+		ServerPort:      port,
+		Database:        dbName,
+		CreateIfMissing: true,
+		MaxOpenConns:    1,
+	})
+	if err != nil {
+		t.Skipf("skipping: Dolt server not available: %v", err)
+	}
+
+	if err := store.SetConfig(ctx, "issue_prefix", prefix); err != nil {
+		store.Close()
+		t.Fatalf("SetConfig(issue_prefix): %v", err)
+	}
+	if err := store.SetMetadata(ctx, "_project_id", projectID); err != nil {
+		store.Close()
+		t.Fatalf("SetMetadata(_project_id): %v", err)
+	}
+
+	t.Cleanup(func() {
+		store.Close()
+		dropFixTestDatabase(dbName, port)
+	})
+	return store, beadsDir, projectID
+}
+
+// TestDestructiveFix_AbortsOnProjectIdentityMismatch is the mybd-2qegi
+// regression test: destructive doctor --fix paths (remotes.go's openFixDB)
+// dial a fresh connection on every call, re-resolving the dolt server port
+// independently of whatever connection doctor's read-only checks used. A
+// stale .beads/dolt-server.port file (or the shared-mode default port) can
+// aim that fresh connection at a different project's database — one that
+// commonly shares the same default database name ("beads").
+//
+// This models the observable effect a stale/wrong port resolution would
+// have: the connection openDoltDB opens belongs to a database whose stored
+// _project_id does not match the local metadata.json project_id it was
+// diagnosed against. verifyFixTargetIdentity must catch that and abort
+// before any DELETE runs, regardless of *how* the mismatched connection was
+// reached.
+func TestDestructiveFix_AbortsOnProjectIdentityMismatch(t *testing.T) {
+	dir := t.TempDir()
+	store, _, _ := newIdentityTestStore(t, dir, "tst")
+	ctx := context.Background()
+
+	// Simulate the stale-port scenario: the connection openDoltDB resolves
+	// lands on a database belonging to a *different* project than the local
+	// metadata.json describes.
+	if err := store.SetMetadata(ctx, "_project_id", "wrong-project-"+configfile.GenerateProjectID()); err != nil {
+		t.Fatalf("failed to force a project_id mismatch: %v", err)
+	}
+
+	// Plant a mis-keyed dependency row that a real DependencyKeys fix would
+	// re-key/delete if it were allowed to proceed against this connection.
+	for _, id := range []string{"tst-1", "tst-2"} {
+		issue := &types.Issue{
+			ID:        id,
+			Title:     "mismatch guard test " + id,
+			Priority:  2,
+			Status:    types.StatusOpen,
+			IssueType: types.TypeTask,
+		}
+		if err := store.CreateIssue(ctx, issue, "test"); err != nil {
+			t.Fatalf("CreateIssue(%s): %v", id, err)
+		}
+	}
+	const randomID = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+	db := store.UnderlyingDB()
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO dependencies (id, issue_id, depends_on_issue_id, type, created_at, created_by)
+		VALUES (?, 'tst-1', 'tst-2', 'blocks', NOW(), 'test')`, randomID); err != nil {
+		t.Fatalf("insert randomly-keyed dependency: %v", err)
+	}
+
+	// The destructive fix must refuse to touch this connection.
+	err := DependencyKeys(dir, false)
+	if err == nil {
+		t.Fatal("DependencyKeys should have aborted on project identity mismatch, got nil error")
+	}
+	if !strings.Contains(err.Error(), "PROJECT IDENTITY MISMATCH") {
+		t.Errorf("expected a PROJECT IDENTITY MISMATCH error, got: %v", err)
+	}
+
+	// The anomalous row must be untouched — no re-key, no delete.
+	var count int
+	if scanErr := db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM dependencies WHERE id = ?`, randomID).Scan(&count); scanErr != nil {
+		t.Fatalf("count dependency row: %v", scanErr)
+	}
+	if count != 1 {
+		t.Errorf("expected the mis-keyed row to survive the aborted fix, found %d matching rows", count)
+	}
+
+	// Same guard must apply to the other destructive fix entrypoints that
+	// share openDoltDB/openFixDB.
+	for name, fn := range map[string]func(string) error{
+		"CrossTableDuplicates":    func(p string) error { return CrossTableDuplicates(p, false) },
+		"OrphanedDependencies":    func(p string) error { return OrphanedDependencies(p, false) },
+		"ChildParentDependencies": func(p string) error { return ChildParentDependencies(p, false) },
+	} {
+		t.Run(name, func(t *testing.T) {
+			if err := fn(dir); err == nil {
+				t.Fatalf("%s should have aborted on project identity mismatch, got nil error", name)
+			} else if !strings.Contains(err.Error(), "PROJECT IDENTITY MISMATCH") {
+				t.Errorf("%s: expected a PROJECT IDENTITY MISMATCH error, got: %v", name, err)
+			}
+		})
+	}
+}
+
+// TestVerifyFixTargetIdentity covers verifyFixTargetIdentity directly:
+// match passes, mismatch and unverifiable targets (missing project_id on
+// either side) abort.
+func TestVerifyFixTargetIdentity(t *testing.T) {
+	dir := t.TempDir()
+	store, beadsDir, _ := newIdentityTestStore(t, dir, "vfi")
+	ctx := context.Background()
+	db := store.UnderlyingDB()
+
+	t.Run("matching project ids pass", func(t *testing.T) {
+		if err := verifyFixTargetIdentity(db, beadsDir); err != nil {
+			t.Errorf("expected no error for matching project ids, got: %v", err)
+		}
+	})
+
+	t.Run("mismatched project ids abort", func(t *testing.T) {
+		if err := store.SetMetadata(ctx, "_project_id", "some-other-project"); err != nil {
+			t.Fatalf("SetMetadata: %v", err)
+		}
+		err := verifyFixTargetIdentity(db, beadsDir)
+		if err == nil {
+			t.Fatal("expected mismatch error, got nil")
+		}
+		if !strings.Contains(err.Error(), "PROJECT IDENTITY MISMATCH") {
+			t.Errorf("expected PROJECT IDENTITY MISMATCH, got: %v", err)
+		}
+	})
+
+	t.Run("missing database project_id is unverifiable and aborts", func(t *testing.T) {
+		if _, err := db.ExecContext(ctx, "DELETE FROM metadata WHERE `key` = '_project_id'"); err != nil {
+			t.Fatalf("clear _project_id: %v", err)
+		}
+		err := verifyFixTargetIdentity(db, beadsDir)
+		if err == nil {
+			t.Fatal("expected unverifiable-target error, got nil")
+		}
+		if !strings.Contains(err.Error(), "no project_id") {
+			t.Errorf("expected an unverifiable-target error, got: %v", err)
+		}
+	})
+
+	t.Run("missing local project_id is unverifiable and aborts", func(t *testing.T) {
+		cfg, err := configfile.Load(beadsDir)
+		if err != nil || cfg == nil {
+			t.Fatalf("load config: %v", err)
+		}
+		cfg.ProjectID = ""
+		if err := cfg.Save(beadsDir); err != nil {
+			t.Fatalf("save config: %v", err)
+		}
+		if err := verifyFixTargetIdentity(db, beadsDir); err == nil {
+			t.Fatal("expected unverifiable-target error for missing local project_id, got nil")
+		}
+	})
+}

--- a/cmd/bd/doctor/fix/validation.go
+++ b/cmd/bd/doctor/fix/validation.go
@@ -28,14 +28,14 @@ func OrphanedDependencies(path string, verbose bool) error {
 		return err
 	}
 
-	db, err := openDoltDB(beadsDir)
+	db, cfg, err := openDoltDB(beadsDir)
 	if err != nil {
 		fmt.Printf("  Orphaned dependencies fix skipped (%v)\n", err)
 		return nil
 	}
 	defer db.Close()
 
-	if err := verifyFixTargetIdentity(db, beadsDir); err != nil {
+	if skip, err := guardFixTarget("Orphaned dependencies fix", db, beadsDir, cfg); skip {
 		return err
 	}
 
@@ -126,14 +126,14 @@ func ChildParentDependencies(path string, verbose bool) error {
 		return err
 	}
 
-	db, err := openDoltDB(beadsDir)
+	db, cfg, err := openDoltDB(beadsDir)
 	if err != nil {
 		fmt.Printf("  Child-parent dependencies fix skipped (%v)\n", err)
 		return nil
 	}
 	defer db.Close()
 
-	if err := verifyFixTargetIdentity(db, beadsDir); err != nil {
+	if skip, err := guardFixTarget("Child-parent dependencies fix", db, beadsDir, cfg); skip {
 		return err
 	}
 
@@ -225,14 +225,14 @@ func CrossTableDuplicates(path string, verbose bool) error {
 		return err
 	}
 
-	db, err := openDoltDB(beadsDir)
+	db, cfg, err := openDoltDB(beadsDir)
 	if err != nil {
 		fmt.Printf("  Cross-table duplicates fix skipped (%v)\n", err)
 		return nil
 	}
 	defer db.Close()
 
-	if err := verifyFixTargetIdentity(db, beadsDir); err != nil {
+	if skip, err := guardFixTarget("Cross-table duplicates fix", db, beadsDir, cfg); skip {
 		return err
 	}
 
@@ -303,7 +303,7 @@ func CountCrossTableDuplicates(path string) (int, error) {
 		return 0, err
 	}
 
-	db, err := openDoltDB(beadsDir)
+	db, _, err := openDoltDB(beadsDir)
 	if err != nil {
 		return 0, err
 	}
@@ -318,22 +318,25 @@ func CountCrossTableDuplicates(path string) (int, error) {
 
 // openDoltDB opens a Dolt database connection via MySQL protocol.
 // Delegates to openFixDB for DSN construction (timeout + password support).
-func openDoltDB(beadsDir string) (*sql.DB, error) {
+// Also returns the loaded config so callers that need it afterward (e.g. to
+// verify the connection's target identity) don't have to load it a second
+// time and risk it disagreeing with what was actually dialed.
+func openDoltDB(beadsDir string) (*sql.DB, *configfile.Config, error) {
 	cfg, err := configfile.Load(beadsDir)
 	if err != nil || cfg == nil {
-		return nil, fmt.Errorf("no database configuration found")
+		return nil, nil, fmt.Errorf("no database configuration found")
 	}
 
 	db, err := openFixDB(beadsDir, cfg)
 	if err != nil {
-		return nil, fmt.Errorf("dolt server connection failed: %w", err)
+		return nil, nil, fmt.Errorf("dolt server connection failed: %w", err)
 	}
 
 	// Verify the connection actually works
 	if err := db.Ping(); err != nil {
 		_ = db.Close() // Best effort cleanup
-		return nil, fmt.Errorf("dolt server not reachable: %w", err)
+		return nil, nil, fmt.Errorf("dolt server not reachable: %w", err)
 	}
 
-	return db, nil
+	return db, cfg, nil
 }

--- a/cmd/bd/doctor/fix/validation.go
+++ b/cmd/bd/doctor/fix/validation.go
@@ -35,6 +35,10 @@ func OrphanedDependencies(path string, verbose bool) error {
 	}
 	defer db.Close()
 
+	if err := verifyFixTargetIdentity(db, beadsDir); err != nil {
+		return err
+	}
+
 	// Find orphaned dependencies (exclude external: cross-rig tracking refs, #1593)
 	//nolint:gosec // G202: fixDependencyUnionSQL returns a fixed internal SELECT fragment.
 	query := `
@@ -128,6 +132,10 @@ func ChildParentDependencies(path string, verbose bool) error {
 		return nil
 	}
 	defer db.Close()
+
+	if err := verifyFixTargetIdentity(db, beadsDir); err != nil {
+		return err
+	}
 
 	// Find child→parent BLOCKING dependencies where issue_id starts with depends_on_id + "."
 	// Only matches blocking types (blocks, conditional-blocks, waits-for) that cause deadlock.
@@ -223,6 +231,10 @@ func CrossTableDuplicates(path string, verbose bool) error {
 		return nil
 	}
 	defer db.Close()
+
+	if err := verifyFixTargetIdentity(db, beadsDir); err != nil {
+		return err
+	}
 
 	// Find IDs present in both tables — the wisp copy is canonical.
 	rows, err := db.Query(`SELECT id FROM issues WHERE id IN (SELECT id FROM wisps)`)

--- a/cmd/bd/doctor/fix/validation_test.go
+++ b/cmd/bd/doctor/fix/validation_test.go
@@ -46,6 +46,12 @@ func newFixTestStore(t *testing.T, dir string, prefix string) *dolt.DoltStore {
 		t.Fatalf("Failed to create .beads: %v", err)
 	}
 
+	// project_id matched between metadata.json and the database so
+	// verifyFixTargetIdentity (mybd-2qegi) doesn't reject these fix calls as
+	// unverifiable targets. Mismatch/unverifiable-target cases get their own
+	// tests below.
+	projectID := configfile.GenerateProjectID()
+
 	// Write metadata.json so openAnyDB can connect to the same database
 	cfg := &configfile.Config{
 		Database:       "dolt",
@@ -53,6 +59,7 @@ func newFixTestStore(t *testing.T, dir string, prefix string) *dolt.DoltStore {
 		DoltServerHost: "127.0.0.1",
 		DoltServerPort: port,
 		DoltDatabase:   dbName,
+		ProjectID:      projectID,
 	}
 	if err := cfg.Save(beadsDir); err != nil {
 		t.Fatalf("Failed to write metadata.json: %v", err)
@@ -73,6 +80,10 @@ func newFixTestStore(t *testing.T, dir string, prefix string) *dolt.DoltStore {
 	if err := store.SetConfig(ctx, "issue_prefix", prefix); err != nil {
 		store.Close()
 		t.Fatalf("Failed to set issue_prefix: %v", err)
+	}
+	if err := store.SetMetadata(ctx, "_project_id", projectID); err != nil {
+		store.Close()
+		t.Fatalf("Failed to set _project_id metadata: %v", err)
 	}
 
 	t.Cleanup(func() {


### PR DESCRIPTION
## Why

`doctor --fix` can issue its DELETEs against a different database than the one `doctor` diagnosed.

The read-only checks go through `SharedStore`, which opens one already-verified `dolt.DoltStore`. But every destructive fix entry point instead calls `openFixDB`/`openDoltDB` in `cmd/bd/doctor/fix/remotes.go`, which dials a **fresh** connection and re-derives the port from `doltserver.DefaultConfig(beadsDir).Port` — env, then `.beads/dolt-server.port`, then `config.yaml`, then a `metadata.json` fallback. That resolution is completely independent of the store the checks used and is never compared against it. A stale port file, or shared-mode's default 3308, is enough to point a destructive fix somewhere else.

This has been latent for a while. It became load-bearing as destructive fixes accumulated — #4858 adds another DELETE.

## What this does

Adds `verifyFixTargetIdentity`, called immediately after the connection opens and before any query runs, in all five raw-dial destructive fixers: `OrphanedDependencies`, `ChildParentDependencies`, `CrossTableDuplicates`, `DependencyKeys`, and `RecomputeBlocked`. It compares the freshly-dialled connection's `_project_id` against the workspace's `metadata.json`, using the same identity model as `internal/storage/dolt/store.go`'s `verifyProjectIdentity`.

`RecomputeBlocked` matters more than its lack of a DELETE suggests: it runs a whole-table UPDATE followed by `CALL DOLT_ADD` and `DOLT_COMMIT`, so against the wrong database it writes a commit into another project's Dolt history, which then syncs. It is also the fix `orderDoctorFixes` runs **last**, so without a guard it is the one statement that would still execute after every other fix had aborted.

Two outcomes, deliberately different:

- **Confirmed mismatch** — hard error. The user is pointed at `bd dolt status`.
- **Unverifiable** (no `_project_id` on either side, unreadable `metadata` table) — non-fatal skip, matching the convention the surrounding call sites already use for an unreachable database: `<fix> skipped: cannot verify target database identity (no project_id); run 'bd doctor --fix' to backfill project identity, then re-run`.

That second case is not hypothetical politeness. In shared-server mode the data lives in the shared server directory, so `CheckProjectIdentity` short-circuits to `N/A (no database)` when `.beads/dolt` is absent and never offers the project-id backfill — and that is exactly the population this change targets. A hard abort there would have left them with no self-service remedy. The destructive statements still do not run either way; only the exit status and the message differ.

## What this does and does not catch

It prevents cross-**project** misdirection of destructive fixes — the connection landing on a database belonging to a different beads project. That is the reported scenario and it is genuinely closed.

It does **not** prove the fix targets the same database the read-only checks diagnosed. `_project_id` lives in the synced `metadata` table and is copied by clone, so a second clone of the same project on the resolved port, a different Dolt branch, or any other same-project drift all pass the guard. Please don't read this as a general "right target" guarantee.

## The larger fix this defers

The root cause is that `openFixDB` re-derives the port at all, ignoring both `cfg.DoltServerPort` and the store the checks used — while the *check* side of the very same fix already takes `store.UnderlyingDB()` (`cmd/bd/doctor/dep_keys.go:30`). Routing the fixers through `dolt.NewFromConfig(...).UnderlyingDB()`, as `StaleClosedIssues` and `PatrolPollution` already do, would inherit canonical port resolution *and* the existing `verifyProjectIdentity`, and would delete `openFixDB`/`openDoltDB` rather than add a guard beside them. That is a larger refactor of the doctor/fix architecture than this change wants to be, so this is defence-in-depth on top of the duplicated connection path, not a replacement for removing it. Happy to do the refactor as a follow-up if you'd rather have that shape.

Also out of scope: `FixMissingDoltDatabase` is the same raw-dial family and a genuine cross-project vector, but it cannot use this guard — it runs precisely when `dolt_database` is unknown. It is already fronted by `resolveAuthoritativeServerMetadata`.

## Tests

`TestDestructiveFix_AbortsOnProjectIdentityMismatch` calls the real exported fixers and asserts a planted anomalous row **survives**, which is what proves the abort happens before any mutation. `TestDestructiveFix_SkipsOnUnverifiableTarget` proves the skip path returns nil and likewise leaves data untouched. `TestVerifyFixTargetIdentity` covers match, mismatch, and unverifiable-on-either-side, with each subtest building its own store so they are order-independent.

One honest limitation: the tests model the stale-port scenario by making the connection's stored `_project_id` disagree with local `metadata.json` — the observable effect of a fresh dial landing on the wrong project — rather than literally redirecting a port, since the package's tests share one Dolt container. That is called out in the test's doc comment.

```
CGO_ENABLED=1 go build -tags gms_pure_go ./...            # clean
CGO_ENABLED=1 go vet -tags gms_pure_go ./cmd/bd/doctor/...  # clean
CGO_ENABLED=1 go test -tags gms_pure_go ./cmd/bd/doctor/fix/... -count=1
ok  github.com/steveyegge/beads/cmd/bd/doctor/fix  16.248s
```

The broader `./cmd/bd/doctor/...` suite has pre-existing failures on this machine (`TestCheckRepoFingerprint_UsesTargetRepoOutsideCWD`, `TestCheckTestPollution_NoTestIssues_EmptyDB`, and intermittent dolt-connection-loss flakes) — confirmed identical on an unmodified baseline, unrelated to this change.

_claude-opus-5-medium on behalf of maphew_
