### PR TITLE
docs(dolt): document remote-server password/TLS auth in CLI help

### DIFF
--- a/cmd/bd/dolt.go
+++ b/cmd/bd/dolt.go
@@ -63,6 +63,23 @@ Configuration keys for 'bd dolt set':
   user      MySQL user (default: root)
   data-dir  Custom dolt data directory (absolute path; default: .beads/dolt)
 
+Remote server authentication (password + TLS) is NOT stored via 'bd dolt set'
+(keeps secrets out of metadata.json). Configure them with:
+
+  BEADS_DOLT_PASSWORD       Server password (highest priority)
+  BEADS_DOLT_SERVER_TLS     Enable TLS (set to "1" or "true")
+  BEADS_DOLT_SERVER_USER    MySQL user override (else use 'bd dolt set user')
+  BEADS_CREDENTIALS_FILE    Optional path to credentials file
+
+  Default credentials file: ~/.config/beads/credentials (Linux/macOS)
+                            %APPDATA%\\beads\\credentials (Windows)
+  Format (INI, section = host:port of the resolved connection):
+    [127.0.0.1:3307]
+    password = secret
+
+  Password resolution: BEADS_DOLT_PASSWORD → credentials [host:port] → empty.
+  Full reference: docs/architecture/dolt.md (Environment Variables / Credentials).
+
 Flags for 'bd dolt set':
   --update-config  Also write to config.yaml for team-wide defaults
 
@@ -70,6 +87,7 @@ Examples:
   bd dolt set database myproject
   bd dolt set host 192.168.1.100 --update-config
   bd dolt set data-dir /home/user/.beads-dolt/myproject
+  export BEADS_DOLT_PASSWORD=... BEADS_DOLT_SERVER_TLS=1
   bd dolt test`,
 }
 
@@ -97,13 +115,28 @@ Keys:
   user      MySQL user (default: root)
   data-dir  Custom dolt data directory (absolute path; default: .beads/dolt)
 
+There is no 'password' or 'tls' key here on purpose — secrets and TLS must
+not land in metadata.json. Use environment variables or the credentials file:
+
+  BEADS_DOLT_PASSWORD     Server password (highest priority)
+  BEADS_DOLT_SERVER_TLS   Enable TLS ("1" or "true")
+  BEADS_CREDENTIALS_FILE  Optional override path for credentials
+
+  Default credentials file: ~/.config/beads/credentials
+  Format:
+    [host:port]
+    password = secret
+
+  See: bd dolt --help and docs/architecture/dolt.md
+
 Use --update-config to also write to config.yaml for team-wide defaults.
 
 Examples:
   bd dolt set database myproject
   bd dolt set host 192.168.1.100
   bd dolt set port 3307 --update-config
-  bd dolt set data-dir /home/user/.beads-dolt/myproject`,
+  bd dolt set data-dir /home/user/.beads-dolt/myproject
+  export BEADS_DOLT_PASSWORD=... BEADS_DOLT_SERVER_TLS=1`,
 	Args: cobra.ExactArgs(2),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		beadsDir := selectedDoltBeadsDir()

--- a/cmd/bd/dolt.go
+++ b/cmd/bd/dolt.go
@@ -72,7 +72,7 @@ Remote server authentication (password + TLS) is NOT stored via 'bd dolt set'
   BEADS_CREDENTIALS_FILE    Optional path to credentials file
 
   Default credentials file: ~/.config/beads/credentials (Linux/macOS)
-                            %APPDATA%\\beads\\credentials (Windows)
+                            %APPDATA%\beads\credentials (Windows)
   Format (INI, section = host:port of the resolved connection):
     [127.0.0.1:3307]
     password = secret

--- a/cmd/bd/dolt_help_auth_test.go
+++ b/cmd/bd/dolt_help_auth_test.go
@@ -1,5 +1,3 @@
-//go:build !cgo
-
 package main
 
 import (

--- a/cmd/bd/dolt_help_auth_test.go
+++ b/cmd/bd/dolt_help_auth_test.go
@@ -1,0 +1,26 @@
+//go:build !cgo
+
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// GH#5011: remote-server auth must be discoverable from CLI help.
+func TestDoltHelpMentionsRemoteAuth(t *testing.T) {
+	for _, body := range []string{doltCmd.Long, doltSetCmd.Long} {
+		for _, needle := range []string{
+			"BEADS_DOLT_PASSWORD",
+			"BEADS_DOLT_SERVER_TLS",
+			"credentials",
+		} {
+			if !strings.Contains(body, needle) {
+				t.Errorf("dolt help missing %q", needle)
+			}
+		}
+	}
+	if !strings.Contains(doltSetCmd.Long, "metadata.json") {
+		t.Error("dolt set help should explain why password is not a set key")
+	}
+}


### PR DESCRIPTION

## Summary

Closes #5011.

@hexsprite reported that remote Dolt server authentication (password + TLS) is fully supported by `bd` — via `BEADS_DOLT_PASSWORD`, `BEADS_DOLT_SERVER_TLS`, and a `~/.config/beads/credentials` INI file — but was undiscoverable from the CLI: `bd dolt --help` and `bd dolt set --help` mentioned none of it, so a user standing up a password+TLS remote had no way to learn how short of reading `internal/storage/doltutil/dsn.go`.

This adds that documentation to both help texts:

- `bd dolt --help` (`doltCmd.Long`): documents `BEADS_DOLT_PASSWORD`, `BEADS_DOLT_SERVER_TLS`, `BEADS_DOLT_SERVER_USER`, `BEADS_CREDENTIALS_FILE`, the credentials-file default location and `[host:port]` INI format, password resolution order, and points to `docs/architecture/dolt.md` (which already documents this in more depth).
- `bd dolt set --help` (`doltSetCmd.Long`): explains that `password`/`tls` are intentionally not `bd dolt set` keys — so secrets stay out of `metadata.json` — and documents the same env vars/credentials-file path as the alternative.

The issue offered a second option (adding `password`/`tls` as `bd dolt set` keys); this PR takes the documentation-only route the issue itself flagged as the likely reason those keys are env/credentials-file only, and leaves the storage mechanism unchanged.

## Test plan

Env: `GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null` (isolates from this machine's global `beads.role=maintainer` git config, unrelated to this change).

- [x] `go test ./cmd/bd/ -run TestDoltHelpMentionsRemoteAuth -v -count=1` → `--- PASS: TestDoltHelpMentionsRemoteAuth (0.00s)` / `ok  	github.com/steveyegge/beads/cmd/bd	0.981s`. Targeted run under the **default (cgo) build**, asserting both help strings contain `BEADS_DOLT_PASSWORD`, `BEADS_DOLT_SERVER_TLS` and `credentials`, and that the `set` help explains `metadata.json`. Not a full-suite run.
- [x] `CGO_ENABLED=0 go vet ./cmd/bd/` — pure-Go build still clean.

A note on the second commit: the test was initially written with `//go:build !cgo`, while the rest of `cmd/bd`'s test files use `//go:build cgo`. Under the default build it was excluded and never ran, so the constraint is removed in `37e40b2ee` — the run above is under the build that previously skipped it.

Separately, this change plus a merge of the fix branch onto `origin/main` (d1f67a91e) passed a full `go test ./cmd/bd/ -count=1 -timeout 25m` probe run (403s) prior to this rewrite; that full run was not re-executed for this pass.
