### PR TITLE
feat(storage): storage-class plumbing — schema marker, --storage-class flag, per-type config defaults (bd-8rifr)

### DIFF
--- a/cmd/bd/config.go
+++ b/cmd/bd/config.go
@@ -959,9 +959,21 @@ var recognizedConfigPrefixes = []string{
 // set, not discovered broken at create time). The key suffix must name an
 // issue type and the value must be a storage class.
 func validateStorageClassConfig(key, value string) error {
-	issueType := strings.TrimPrefix(key, "storage-class.")
-	if issueType == "" || strings.Contains(issueType, ".") {
+	suffix := strings.TrimPrefix(key, "storage-class.")
+	if suffix == "" || strings.Contains(suffix, ".") {
 		return fmt.Errorf("invalid key %q: expected storage-class.<issue-type> (e.g. storage-class.event)", key)
+	}
+	// The key suffix must be a canonical, known issue type: create-time lookup
+	// keys on the Normalize()d type (resolveStorageClass), so an alias like
+	// storage-class.feat or a typo like storage-class.taks would pass set-time
+	// validation and then silently never match — the C-OQ1 failure mode this
+	// validator exists to prevent.
+	issueType := types.IssueType(suffix)
+	if canonical := issueType.Normalize(); canonical != issueType {
+		return fmt.Errorf("invalid key %q: %q is an alias of %q, and create-time lookup uses the canonical type; set storage-class.%s instead", key, suffix, canonical, canonical)
+	}
+	if !issueType.IsValidWithCustom(loadEmbeddedCustomTypes()) {
+		return fmt.Errorf("invalid key %q: unknown issue type %q (use a built-in type, or add it to types.custom first)", key, suffix)
 	}
 	if _, err := types.ParseStorageClass(value); err != nil {
 		return err

--- a/cmd/bd/config.go
+++ b/cmd/bd/config.go
@@ -140,6 +140,12 @@ var configSetCmd = &cobra.Command{
 			return SilentExit()
 		}
 
+		if strings.HasPrefix(key, "storage-class.") {
+			if err := validateStorageClassConfig(key, value); err != nil {
+				return HandleError("%v", err)
+			}
+		}
+
 		if !isRecognizedConfigKey(key) {
 			suggestion := suggestConfigKey(key)
 			if suggestion != "" {
@@ -825,6 +831,11 @@ Examples:
 					return HandleError("invalid status.custom value: %v", err)
 				}
 			}
+			if strings.HasPrefix(p.key, "storage-class.") {
+				if err := validateStorageClassConfig(p.key, p.value); err != nil {
+					return HandleError("%v", err)
+				}
+			}
 		}
 
 		var yamlPairs, gitPairs, dbPairs []kvPair
@@ -940,7 +951,22 @@ var recognizedConfigPrefixes = []string{
 	"status.", "types.", "doctor.suppress.", "routing.", "sync.", "git.",
 	"directory.", "repos.", "external_projects.", "validation.",
 	"hierarchy.", "ai.", "backup.", "federation.", "metrics.", "agent.",
-	"claim.",
+	"claim.", "storage-class.",
+}
+
+// validateStorageClassConfig validates a storage-class.<type> per-type
+// default at config-set time (Protocol v0.1 C-OQ1: values are validated when
+// set, not discovered broken at create time). The key suffix must name an
+// issue type and the value must be a storage class.
+func validateStorageClassConfig(key, value string) error {
+	issueType := strings.TrimPrefix(key, "storage-class.")
+	if issueType == "" || strings.Contains(issueType, ".") {
+		return fmt.Errorf("invalid key %q: expected storage-class.<issue-type> (e.g. storage-class.event)", key)
+	}
+	if _, err := types.ParseStorageClass(value); err != nil {
+		return err
+	}
+	return nil
 }
 
 // allRecognizedConfigPrefixes returns the static namespaces plus the prefix of

--- a/cmd/bd/create.go
+++ b/cmd/bd/create.go
@@ -193,6 +193,22 @@ var createCmd = &cobra.Command{
 		if wisp && noHistory {
 			return HandleError("--ephemeral and --no-history are mutually exclusive")
 		}
+		storageClassFlag, _ := cmd.Flags().GetString("storage-class")
+		storageClass, err := resolveStorageClass(storageClassFlag, types.IssueType(issueType).Normalize())
+		if err != nil {
+			return HandleError("%v", err)
+		}
+		// --storage-class ephemeral is the spelled-out spelling of --ephemeral
+		// (Protocol v0.1 C1.4: the wisp plane is today's ephemeral-class
+		// implementation). It routes to the wisp path exactly like the flag;
+		// the --no-history mutual exclusion above still applies.
+		if storageClass == types.StorageClassEphemeral {
+			if noHistory {
+				return HandleError("--storage-class ephemeral and --no-history are mutually exclusive")
+			}
+			wisp = true
+			storageClass = "" // wisp-plane rows derive ephemeral class (C1.2); no marker cell needed
+		}
 		molTypeStr, _ := cmd.Flags().GetString("mol-type")
 		var molType types.MolType
 		if molTypeStr != "" {
@@ -350,6 +366,7 @@ var createCmd = &cobra.Command{
 				EstimatedMinutes:   estimatedMinutes,
 				Ephemeral:          wisp,
 				NoHistory:          noHistory,
+				StorageClass:       storageClass,
 				CreatedBy:          getActorWithGit(),
 				Owner:              getOwner(),
 				Labels:             labels,
@@ -513,6 +530,7 @@ var createCmd = &cobra.Command{
 			EstimatedMinutes:   estimatedMinutes,
 			Ephemeral:          wisp,
 			NoHistory:          noHistory,
+			StorageClass:       storageClass,
 			CreatedBy:          getActorWithGit(),
 			Owner:              getOwner(),
 			Labels:             labels,
@@ -609,6 +627,7 @@ type createIssueParams struct {
 	EstimatedMinutes   *int
 	Ephemeral          bool
 	NoHistory          bool
+	StorageClass       types.StorageClass
 	CreatedBy          string
 	Owner              string
 	Labels             []string
@@ -622,6 +641,34 @@ type createIssueParams struct {
 	DueAt              *time.Time
 	DeferUntil         *time.Time
 	Metadata           json.RawMessage
+}
+
+// resolveStorageClass resolves the effective storage class at create time
+// (Protocol v0.1 C1.3): the explicit --storage-class flag wins; otherwise the
+// per-type config default storage-class.<type> applies; otherwise unset.
+// Versioned normalizes to unset — the class marker is omitted when versioned
+// (C2.4), and both spell identical semantics (C1.2). Values are validated
+// wherever they came from: a bad flag is a usage error, a bad config value is
+// a config bug and fails just as loudly.
+func resolveStorageClass(explicit string, issueType types.IssueType) (types.StorageClass, error) {
+	raw := explicit
+	if raw == "" {
+		raw = config.GetString("storage-class." + string(issueType))
+		if raw == "" {
+			return "", nil
+		}
+	}
+	class, err := types.ParseStorageClass(raw)
+	if err != nil {
+		if explicit == "" {
+			return "", fmt.Errorf("config storage-class.%s: %w", issueType, err)
+		}
+		return "", err
+	}
+	if class == types.StorageClassVersioned {
+		return "", nil
+	}
+	return class, nil
 }
 
 func buildCreateIssue(params createIssueParams) *types.Issue {
@@ -653,6 +700,7 @@ func buildCreateIssue(params createIssueParams) *types.Issue {
 		EstimatedMinutes:   params.EstimatedMinutes,
 		Ephemeral:          params.Ephemeral,
 		NoHistory:          params.NoHistory,
+		StorageClass:       params.StorageClass,
 		CreatedBy:          params.CreatedBy,
 		Owner:              params.Owner,
 		Labels:             append([]string(nil), params.Labels...),
@@ -779,6 +827,7 @@ func init() {
 	createCmd.Flags().IntP("estimate", "e", 0, "Time estimate in minutes (e.g., 60 for 1 hour)")
 	createCmd.Flags().Bool("ephemeral", false, "Create as ephemeral (short-lived, subject to TTL compaction)")
 	createCmd.Flags().Bool("no-history", false, "Skip Dolt commit history without making GC-eligible (for permanent agent beads)")
+	createCmd.Flags().String("storage-class", "", "Storage class: versioned, unversioned, or ephemeral (default: storage-class.<type> config, else versioned)")
 	createCmd.Flags().String("mol-type", "", "Molecule type: swarm (multi-agent), patrol (recurring ops), work (default)")
 	createCmd.Flags().String("wisp-type", "", "Wisp type for TTL-based compaction: heartbeat, ping, patrol, gc_report, recovery, error, escalation")
 	createCmd.Flags().Bool("validate", false, "Validate description contains required sections for issue type")

--- a/cmd/bd/create_embedded_test.go
+++ b/cmd/bd/create_embedded_test.go
@@ -590,6 +590,7 @@ func TestEmbeddedCreate(t *testing.T) {
 					"labels": ["x", "y"],
 					"metadata": {"str": "v", "num": 3},
 					"mol_type": "swarm",
+					"storage_class": "unversioned",
 					"pinned": true
 				},
 				{
@@ -653,6 +654,9 @@ func TestEmbeddedCreate(t *testing.T) {
 		}
 		if issue.MolType != types.MolType("swarm") {
 			t.Errorf("mol_type: got %q", issue.MolType)
+		}
+		if issue.StorageClass != types.StorageClassUnversioned {
+			t.Errorf("storage_class: got %q, want unversioned", issue.StorageClass)
 		}
 		if !issue.Pinned {
 			t.Errorf("pinned not set")

--- a/cmd/bd/graph_apply.go
+++ b/cmd/bd/graph_apply.go
@@ -55,8 +55,9 @@ type GraphApplyNode struct {
 	ParentKey          string                     `json:"parent_key,omitempty"`
 	ParentID           string                     `json:"parent_id,omitempty"`
 	Deps               []GraphApplyNodeDep        `json:"deps,omitempty"`
-	Ephemeral          *bool                      `json:"ephemeral,omitempty"`  // overrides --ephemeral for this node
-	NoHistory          *bool                      `json:"no_history,omitempty"` // overrides --no-history for this node
+	Ephemeral          *bool                      `json:"ephemeral,omitempty"`     // overrides --ephemeral for this node
+	NoHistory          *bool                      `json:"no_history,omitempty"`    // overrides --no-history for this node
+	StorageClass       string                     `json:"storage_class,omitempty"` // explicit class (C1.3: wins over storage-class.<type> config); "ephemeral" routes to the wisp plane
 	WispType           string                     `json:"wisp_type,omitempty"`
 	MolType            string                     `json:"mol_type,omitempty"`
 	Pinned             bool                       `json:"pinned,omitempty"`
@@ -685,7 +686,7 @@ func validateGraphApplyNodeFields(node GraphApplyNode, customTypes, customStatus
 // the routing decision for the whole plan.
 func validateGraphApplyStorageClasses(plan *GraphApplyPlan, opts GraphApplyOptions, requireUniform bool) (useWisp bool, err error) {
 	for i, node := range plan.Nodes {
-		ephemeral, noHistory, err := graphApplyNodeStorageClass(node, opts)
+		ephemeral, noHistory, _, err := graphApplyNodeStorageClass(node, opts)
 		if err != nil {
 			return false, err
 		}
@@ -805,7 +806,7 @@ func graphApplyNodeIssue(node GraphApplyNode, opts GraphApplyOptions, createdBy,
 		priority = *node.Priority
 	}
 
-	ephemeral, noHistory, err := graphApplyNodeStorageClass(node, opts)
+	ephemeral, noHistory, storageClass, err := graphApplyNodeStorageClass(node, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -841,6 +842,7 @@ func graphApplyNodeIssue(node GraphApplyNode, opts GraphApplyOptions, createdBy,
 		EstimatedMinutes:   estimatedMinutes,
 		Ephemeral:          ephemeral,
 		NoHistory:          noHistory,
+		StorageClass:       storageClass,
 		CreatedBy:          createdBy,
 		Owner:              owner,
 		Labels:             node.Labels,
@@ -869,8 +871,13 @@ func graphApplyNodeIssue(node GraphApplyNode, opts GraphApplyOptions, createdBy,
 }
 
 // graphApplyNodeStorageClass resolves a node's effective storage class from
-// its per-node overrides and the plan-wide CLI flags.
-func graphApplyNodeStorageClass(node GraphApplyNode, opts GraphApplyOptions) (ephemeral, noHistory bool, err error) {
+// its per-node overrides, the plan-wide CLI flags, and the per-type config
+// default, with single-issue create's precedence (Protocol v0.1 C1.3): the
+// node's explicit storage_class wins, then storage-class.<type> config, else
+// unset. "ephemeral" is the spelled-out spelling of ephemeral: true (C1.4) —
+// it routes the node to the wisp plane and leaves the marker cell empty
+// (wisp-plane rows derive their class, C1.2).
+func graphApplyNodeStorageClass(node GraphApplyNode, opts GraphApplyOptions) (ephemeral, noHistory bool, class types.StorageClass, err error) {
 	ephemeral = opts.Ephemeral
 	if node.Ephemeral != nil {
 		ephemeral = *node.Ephemeral
@@ -880,9 +887,27 @@ func graphApplyNodeStorageClass(node GraphApplyNode, opts GraphApplyOptions) (ep
 		noHistory = *node.NoHistory
 	}
 	if ephemeral && noHistory {
-		return false, false, fmt.Errorf("node %q: ephemeral and no_history are mutually exclusive", node.Key)
+		return false, false, "", fmt.Errorf("node %q: ephemeral and no_history are mutually exclusive", node.Key)
 	}
-	return ephemeral, noHistory, nil
+	issueType := types.IssueType(node.Type)
+	if issueType == "" {
+		issueType = types.TypeTask
+	}
+	class, err = resolveStorageClass(node.StorageClass, issueType.Normalize())
+	if err != nil {
+		return false, false, "", fmt.Errorf("node %q: %w", node.Key, err)
+	}
+	if class == types.StorageClassEphemeral {
+		if noHistory {
+			return false, false, "", fmt.Errorf("node %q: storage_class ephemeral and no_history are mutually exclusive", node.Key)
+		}
+		if node.Ephemeral != nil && !*node.Ephemeral {
+			return false, false, "", fmt.Errorf("node %q: storage_class ephemeral conflicts with ephemeral: false", node.Key)
+		}
+		ephemeral = true
+		class = ""
+	}
+	return ephemeral, noHistory, class, nil
 }
 
 func executeGraphApply(ctx context.Context, plan *GraphApplyPlan, opts GraphApplyOptions) (*GraphApplyResult, error) {

--- a/cmd/bd/storage_class_embedded_test.go
+++ b/cmd/bd/storage_class_embedded_test.go
@@ -1,0 +1,123 @@
+//go:build cgo
+
+package main
+
+import (
+	"database/sql"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/storage/embeddeddolt"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// End-to-end contract for the storage-class plumbing (bd-8rifr,
+// Protocol v0.1 §C): create-time resolution (flag > per-type config >
+// unset), the omitted-when-versioned marker rule (C2.4) down to the DB
+// cell, and the ephemeral spelling routing to the wisp plane (C1.4).
+func TestEmbeddedCreateStorageClass(t *testing.T) {
+	if os.Getenv("BEADS_TEST_EMBEDDED_DOLT") != "1" {
+		t.Skip("set BEADS_TEST_EMBEDDED_DOLT=1 to run embedded dolt create tests")
+	}
+	t.Parallel()
+
+	bd := buildEmbeddedBD(t)
+
+	// storageClassCell reads the raw issues.storage_class cell so the test
+	// pins the at-rest form (NULL vs literal), not just the JSON view.
+	storageClassCell := func(t *testing.T, beadsDir, prefix, id string) sql.NullString {
+		t.Helper()
+		db, cleanup, err := embeddeddolt.OpenSQL(t.Context(), filepath.Join(beadsDir, "embeddeddolt"), prefix, "main")
+		if err != nil {
+			t.Fatalf("OpenSQL: %v", err)
+		}
+		defer cleanup()
+		var got sql.NullString
+		if err := db.QueryRowContext(t.Context(), "SELECT storage_class FROM issues WHERE id = ?", id).Scan(&got); err != nil {
+			t.Fatalf("query storage_class: %v", err)
+		}
+		return got
+	}
+
+	t.Run("explicit_unversioned", func(t *testing.T) {
+		dir, beadsDir, _ := bdInit(t, bd, "--prefix", "su")
+		issue := bdCreate(t, bd, dir, "Unversioned bead", "--storage-class", "unversioned")
+		if issue.StorageClass != types.StorageClassUnversioned {
+			t.Errorf("JSON storage_class: got %q, want unversioned", issue.StorageClass)
+		}
+		cell := storageClassCell(t, beadsDir, "su", issue.ID)
+		if !cell.Valid || cell.String != "unversioned" {
+			t.Errorf("DB cell: got %+v, want 'unversioned'", cell)
+		}
+	})
+
+	t.Run("default_and_explicit_versioned_stay_null", func(t *testing.T) {
+		dir, beadsDir, _ := bdInit(t, bd, "--prefix", "sv")
+		plain := bdCreate(t, bd, dir, "Plain bead")
+		if plain.StorageClass != "" {
+			t.Errorf("plain create: storage_class should be unset, got %q", plain.StorageClass)
+		}
+		if cell := storageClassCell(t, beadsDir, "sv", plain.ID); cell.Valid {
+			t.Errorf("plain create: DB cell should be NULL, got %q", cell.String)
+		}
+		// C2.4: the explicit versioned spelling normalizes to the same NULL.
+		explicit := bdCreate(t, bd, dir, "Versioned bead", "--storage-class", "versioned")
+		if cell := storageClassCell(t, beadsDir, "sv", explicit.ID); cell.Valid {
+			t.Errorf("explicit versioned: DB cell should be NULL, got %q", cell.String)
+		}
+	})
+
+	t.Run("per_type_config_default_and_override", func(t *testing.T) {
+		dir, beadsDir, _ := bdInit(t, bd, "--prefix", "sc")
+		if out, err := bdRunWithFlockRetry(t, bd, dir, "config", "set", "storage-class.task", "unversioned"); err != nil {
+			t.Fatalf("config set: %v\n%s", err, out)
+		}
+		byDefault := bdCreate(t, bd, dir, "Defaulted bead", "-t", "task")
+		if byDefault.StorageClass != types.StorageClassUnversioned {
+			t.Errorf("config default: got %q, want unversioned", byDefault.StorageClass)
+		}
+		// Explicit per-record declaration wins over the per-type default (C1.3).
+		forced := bdCreate(t, bd, dir, "Forced versioned", "-t", "task", "--storage-class", "versioned")
+		if cell := storageClassCell(t, beadsDir, "sc", forced.ID); cell.Valid {
+			t.Errorf("explicit versioned over config default: DB cell should be NULL, got %q", cell.String)
+		}
+		// Other types are untouched by the task default.
+		bug := bdCreate(t, bd, dir, "A bug", "-t", "bug")
+		if bug.StorageClass != "" {
+			t.Errorf("other type: got %q, want unset", bug.StorageClass)
+		}
+	})
+
+	t.Run("ephemeral_spelling_routes_to_wisp_plane", func(t *testing.T) {
+		dir, beadsDir, _ := bdInit(t, bd, "--prefix", "se")
+		issue := bdCreate(t, bd, dir, "Ephemeral bead", "--storage-class", "ephemeral")
+		if !issue.Ephemeral {
+			t.Errorf("--storage-class ephemeral should set the ephemeral flag")
+		}
+		db, cleanup, err := embeddeddolt.OpenSQL(t.Context(), filepath.Join(beadsDir, "embeddeddolt"), "se", "main")
+		if err != nil {
+			t.Fatalf("OpenSQL: %v", err)
+		}
+		defer cleanup()
+		var count int
+		if err := db.QueryRowContext(t.Context(), "SELECT COUNT(*) FROM wisps WHERE id = ?", issue.ID).Scan(&count); err != nil {
+			t.Fatalf("query wisps: %v", err)
+		}
+		if count != 1 {
+			t.Errorf("ephemeral bead should live in wisps, found %d rows", count)
+		}
+	})
+
+	t.Run("config_set_validates_value", func(t *testing.T) {
+		dir, _, _ := bdInit(t, bd, "--prefix", "sx")
+		out, err := bdRunWithFlockRetry(t, bd, dir, "config", "set", "storage-class.task", "permanent")
+		if err == nil {
+			t.Fatalf("config set with bad value should fail, got:\n%s", out)
+		}
+		if !strings.Contains(string(out), "versioned, unversioned, or ephemeral") {
+			t.Errorf("error should enumerate valid values, got:\n%s", out)
+		}
+	})
+}

--- a/cmd/bd/storage_class_pure_test.go
+++ b/cmd/bd/storage_class_pure_test.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// resolveStorageClass: the explicit flag path (config-default resolution
+// rides config.GetString and is exercised by the embedded create tests).
+func TestResolveStorageClassExplicit(t *testing.T) {
+	got, err := resolveStorageClass("unversioned", types.TypeTask)
+	if err != nil || got != types.StorageClassUnversioned {
+		t.Errorf("explicit unversioned: got %q, %v", got, err)
+	}
+
+	// Explicit versioned normalizes to unset (C2.4 omitted-when-versioned)
+	// while still overriding any per-type config default upstream.
+	got, err = resolveStorageClass("versioned", types.TypeTask)
+	if err != nil || got != "" {
+		t.Errorf("explicit versioned should normalize to unset: got %q, %v", got, err)
+	}
+
+	got, err = resolveStorageClass("ephemeral", types.TypeTask)
+	if err != nil || got != types.StorageClassEphemeral {
+		t.Errorf("explicit ephemeral: got %q, %v", got, err)
+	}
+
+	if _, err := resolveStorageClass("bogus", types.TypeTask); err == nil {
+		t.Error("invalid explicit value should error")
+	}
+}
+
+func TestValidateStorageClassConfig(t *testing.T) {
+	if err := validateStorageClassConfig("storage-class.event", "unversioned"); err != nil {
+		t.Errorf("valid key+value rejected: %v", err)
+	}
+	if err := validateStorageClassConfig("storage-class.", "unversioned"); err == nil {
+		t.Error("empty type suffix should be rejected")
+	}
+	if err := validateStorageClassConfig("storage-class.event.extra", "unversioned"); err == nil {
+		t.Error("nested suffix should be rejected")
+	}
+	err := validateStorageClassConfig("storage-class.event", "permanent")
+	if err == nil || !strings.Contains(err.Error(), "versioned, unversioned, or ephemeral") {
+		t.Errorf("bad value should be rejected with the value list, got: %v", err)
+	}
+}

--- a/cmd/bd/storage_class_pure_test.go
+++ b/cmd/bd/storage_class_pure_test.go
@@ -46,4 +46,17 @@ func TestValidateStorageClassConfig(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "versioned, unversioned, or ephemeral") {
 		t.Errorf("bad value should be rejected with the value list, got: %v", err)
 	}
+	// The suffix is validated too: create-time lookup keys on the Normalize()d
+	// type, so an alias or typo would otherwise pass here and silently never
+	// match (lion's #5149 should-fix).
+	err = validateStorageClassConfig("storage-class.feat", "unversioned")
+	if err == nil || !strings.Contains(err.Error(), "storage-class.feature") {
+		t.Errorf("alias suffix should be rejected with the canonical key hint, got: %v", err)
+	}
+	if err := validateStorageClassConfig("storage-class.taks", "unversioned"); err == nil {
+		t.Error("unknown (typo) suffix should be rejected")
+	}
+	if err := validateStorageClassConfig("storage-class.task", "unversioned"); err != nil {
+		t.Errorf("canonical built-in suffix rejected: %v", err)
+	}
 }

--- a/internal/config/yaml_config.go
+++ b/internal/config/yaml_config.go
@@ -107,7 +107,7 @@ func IsYamlOnlyKey(key string) bool {
 	}
 
 	// Check prefix matches for nested keys
-	prefixes := []string{"routing.", "sync.", "git.", "directory.", "repos.", "external_projects.", "validation.", "hierarchy.", "ai.", "backup.", "export.", "dolt.", "federation.", "metrics.", "list.", "audit."}
+	prefixes := []string{"routing.", "sync.", "git.", "directory.", "repos.", "external_projects.", "validation.", "hierarchy.", "ai.", "backup.", "export.", "dolt.", "federation.", "metrics.", "list.", "audit.", "storage-class."}
 	for _, prefix := range prefixes {
 		if strings.HasPrefix(key, prefix) {
 			return true

--- a/internal/storage/domain/db/issue.go
+++ b/internal/storage/domain/db/issue.go
@@ -657,7 +657,7 @@ func insertIssueRow(ctx context.Context, runner Runner, table string, issue *typ
 		issue.EventKind, issue.Actor, issue.Target, issue.Payload,
 		issue.AwaitType, issue.AwaitID, issue.Timeout.Nanoseconds(), formatJSONStringArray(issue.Waiters),
 		issue.DueAt, issue.DeferUntil, jsonMetadata(issue.Metadata),
-		issueops.FreshRowLock(), nullString(string(issue.StorageClass)),
+		issueops.FreshRowLock(), nullString(string(issue.StorageClass.Normalize())),
 	)
 	if err != nil {
 		return fmt.Errorf("db: insert into %s: %w", table, err)

--- a/internal/storage/domain/db/issue.go
+++ b/internal/storage/domain/db/issue.go
@@ -614,7 +614,7 @@ func insertIssueRow(ctx context.Context, runner Runner, table string, issue *typ
 			event_kind, actor, target, payload,
 			await_type, await_id, timeout_ns, waiters,
 			due_at, defer_until, metadata,
-			row_lock
+			row_lock, storage_class
 		) VALUES (
 			?, ?, ?, ?, ?, ?, ?,
 			?, ?, ?, ?, ?,
@@ -625,7 +625,7 @@ func insertIssueRow(ctx context.Context, runner Runner, table string, issue *typ
 			?, ?, ?, ?,
 			?, ?, ?, ?,
 			?, ?, ?,
-			?
+			?, ?
 		)
 		ON DUPLICATE KEY UPDATE
 			content_hash = VALUES(content_hash),
@@ -657,7 +657,7 @@ func insertIssueRow(ctx context.Context, runner Runner, table string, issue *typ
 		issue.EventKind, issue.Actor, issue.Target, issue.Payload,
 		issue.AwaitType, issue.AwaitID, issue.Timeout.Nanoseconds(), formatJSONStringArray(issue.Waiters),
 		issue.DueAt, issue.DeferUntil, jsonMetadata(issue.Metadata),
-		issueops.FreshRowLock(),
+		issueops.FreshRowLock(), nullString(string(issue.StorageClass)),
 	)
 	if err != nil {
 		return fmt.Errorf("db: insert into %s: %w", table, err)

--- a/internal/storage/domain/db/issue_scan_parity_test.go
+++ b/internal/storage/domain/db/issue_scan_parity_test.go
@@ -42,7 +42,7 @@ func TestScanIssue_StringTimestamps(t *testing.T) {
 	for i := range cols {
 		cols[i] = strings.TrimSpace(cols[i])
 	}
-	require.Len(t, cols, 50)
+	require.Len(t, cols, 51)
 
 	row := []driver.Value{
 		"bd-test.1", nil, "title", "desc", "", "", "", // id..notes
@@ -56,9 +56,10 @@ func TestScanIssue_StringTimestamps(t *testing.T) {
 		nil, nil, // due_at, defer_until
 		nil, nil, nil, // work_type, source_system, metadata
 		int64(12345),  // row_lock
+		nil,           // storage_class
 		nil, nil, nil, // lease_expires_at, heartbeat_at, granted_node
 	}
-	require.Len(t, row, 50)
+	require.Len(t, row, 51)
 
 	mock.ExpectQuery("SELECT").WillReturnRows(sqlmock.NewRows(cols).AddRow(row...))
 

--- a/internal/storage/issueops/helpers.go
+++ b/internal/storage/issueops/helpers.go
@@ -120,7 +120,7 @@ func insertIssueIntoTable(ctx context.Context, tx *sql.Tx, table string, issue *
 			event_kind, actor, target, payload,
 			await_type, await_id, timeout_ns, waiters,
 			due_at, defer_until, metadata,
-			row_lock
+			row_lock, storage_class
 		) VALUES (
 			?, ?, ?, ?, ?, ?, ?,
 			?, ?, ?, ?, ?,
@@ -131,7 +131,7 @@ func insertIssueIntoTable(ctx context.Context, tx *sql.Tx, table string, issue *
 			?, ?, ?, ?,
 			?, ?, ?, ?,
 			?, ?, ?,
-			?
+			?, ?
 		)
 		ON DUPLICATE KEY UPDATE
 			%s
@@ -145,7 +145,7 @@ func insertIssueIntoTable(ctx context.Context, tx *sql.Tx, table string, issue *
 		issue.EventKind, issue.Actor, issue.Target, issue.Payload,
 		issue.AwaitType, issue.AwaitID, issue.Timeout.Nanoseconds(), FormatJSONStringArray(issue.Waiters),
 		issue.DueAt, issue.DeferUntil, JSONMetadata(issue.Metadata),
-		freshRowLock(),
+		freshRowLock(), NullString(string(issue.StorageClass)),
 	)
 	if err != nil {
 		return fmt.Errorf("insert issue into %s: %w", table, err)

--- a/internal/storage/issueops/helpers.go
+++ b/internal/storage/issueops/helpers.go
@@ -145,7 +145,7 @@ func insertIssueIntoTable(ctx context.Context, tx *sql.Tx, table string, issue *
 		issue.EventKind, issue.Actor, issue.Target, issue.Payload,
 		issue.AwaitType, issue.AwaitID, issue.Timeout.Nanoseconds(), FormatJSONStringArray(issue.Waiters),
 		issue.DueAt, issue.DeferUntil, JSONMetadata(issue.Metadata),
-		freshRowLock(), NullString(string(issue.StorageClass)),
+		freshRowLock(), NullString(string(issue.StorageClass.Normalize())),
 	)
 	if err != nil {
 		return fmt.Errorf("insert issue into %s: %w", table, err)

--- a/internal/storage/issueops/scan.go
+++ b/internal/storage/issueops/scan.go
@@ -42,7 +42,7 @@ const IssueSelectColumnsLite = `id, content_hash, title,
 	       mol_type,
 	       event_kind, actor, target,
 	       due_at, defer_until,
-	       work_type, source_system, metadata, row_lock,
+	       work_type, source_system, metadata, row_lock, storage_class,
 	       leases.lease_expires_at, leases.heartbeat_at, leases.granted_node`
 
 // HeavyDropList enumerates the columns omitted from IssueSelectColumnsLite.
@@ -89,7 +89,8 @@ func ScanIssueFrom(s IssueScanner, extra ...any) (*types.Issue, error) {
 	var awaitType, awaitID, waiters sql.NullString
 	var ephemeral, noHistory, pinned, isTemplate sql.NullInt64
 	var metadata sql.NullString
-	var rowLock sql.NullInt64 // row_lock column (NOT NULL DEFAULT 0); scanned defensively so NULL maps to 0
+	var rowLock sql.NullInt64       // row_lock column (NOT NULL DEFAULT 0); scanned defensively so NULL maps to 0
+	var storageClass sql.NullString // storage_class column (migration 0060); NULL = unset, resolves per EffectiveStorageClass
 
 	dests := []any{
 		&issue.ID, &contentHash, &issue.Title, &issue.Description, &issue.Design,
@@ -102,7 +103,7 @@ func ScanIssueFrom(s IssueScanner, extra ...any) (*types.Issue, error) {
 		&molType,
 		&eventKind, &actor, &target, &payload,
 		&dueAt, &deferUntil,
-		&workType, &sourceSystem, &metadata, &rowLock,
+		&workType, &sourceSystem, &metadata, &rowLock, &storageClass,
 		&leaseExpiresAt, &heartbeatAt, &leaseGrantedNode,
 	}
 	dests = append(dests, extra...)
@@ -226,6 +227,11 @@ func ScanIssueFrom(s IssueScanner, extra ...any) (*types.Issue, error) {
 	// row_lock surfaced as the opaque RowVersion token. NOT NULL DEFAULT 0, so
 	// this is normally valid; a NULL (defensive) maps to 0.
 	issue.RowVersion = rowLock.Int64
+	// storage_class (migration 0060); NULL = unset (EffectiveStorageClass
+	// resolves the default per Protocol v0.1 C1.2).
+	if storageClass.Valid {
+		issue.StorageClass = types.StorageClass(storageClass.String)
+	}
 	// Lease columns (migration 0054); NULL when no active lease.
 	if leaseExpiresAt.Valid {
 		issue.LeaseExpiresAt = &leaseExpiresAt.Time
@@ -261,7 +267,8 @@ func ScanIssueLiteFrom(s IssueScanner, extra ...any) (*types.Issue, error) {
 	var awaitType, awaitID sql.NullString
 	var ephemeral, noHistory, pinned, isTemplate sql.NullInt64
 	var metadata sql.NullString
-	var rowLock sql.NullInt64 // row_lock column (NOT NULL DEFAULT 0); scanned defensively so NULL maps to 0
+	var rowLock sql.NullInt64       // row_lock column (NOT NULL DEFAULT 0); scanned defensively so NULL maps to 0
+	var storageClass sql.NullString // storage_class column (migration 0060); NULL = unset, resolves per EffectiveStorageClass
 
 	dests := []any{
 		&issue.ID, &contentHash, &issue.Title,
@@ -274,7 +281,7 @@ func ScanIssueLiteFrom(s IssueScanner, extra ...any) (*types.Issue, error) {
 		&molType,
 		&eventKind, &actor, &target,
 		&dueAt, &deferUntil,
-		&workType, &sourceSystem, &metadata, &rowLock,
+		&workType, &sourceSystem, &metadata, &rowLock, &storageClass,
 		&leaseExpiresAt, &heartbeatAt, &leaseGrantedNode,
 	}
 	dests = append(dests, extra...)
@@ -389,6 +396,11 @@ func ScanIssueLiteFrom(s IssueScanner, extra ...any) (*types.Issue, error) {
 	// row_lock surfaced as the opaque RowVersion token. NOT NULL DEFAULT 0, so
 	// this is normally valid; a NULL (defensive) maps to 0.
 	issue.RowVersion = rowLock.Int64
+	// storage_class (migration 0060); NULL = unset (EffectiveStorageClass
+	// resolves the default per Protocol v0.1 C1.2).
+	if storageClass.Valid {
+		issue.StorageClass = types.StorageClass(storageClass.String)
+	}
 	// Lease columns (migration 0054); NULL when no active lease.
 	if leaseExpiresAt.Valid {
 		issue.LeaseExpiresAt = &leaseExpiresAt.Time

--- a/internal/storage/issueops/search_lite_merge_test.go
+++ b/internal/storage/issueops/search_lite_merge_test.go
@@ -25,7 +25,7 @@ func liteColumnNames() []string {
 		"mol_type",
 		"event_kind", "actor", "target",
 		"due_at", "defer_until",
-		"work_type", "source_system", "metadata", "row_lock",
+		"work_type", "source_system", "metadata", "row_lock", "storage_class",
 		"lease_expires_at", "heartbeat_at", "granted_node",
 	}
 }
@@ -45,7 +45,7 @@ func liteMergeRow(id string, createdAt time.Time) []driver.Value {
 		nil,           // mol_type
 		nil, nil, nil, // event_kind, actor, target
 		nil, nil, // due_at, defer_until
-		nil, nil, nil, 0, // work_type, source_system, metadata, row_lock
+		nil, nil, nil, 0, nil, // work_type, source_system, metadata, row_lock, storage_class
 		nil, nil, nil, // lease_expires_at, heartbeat_at, granted_node
 	}
 }

--- a/internal/storage/schema/migrations/0060_add_storage_class.down.sql
+++ b/internal/storage/schema/migrations/0060_add_storage_class.down.sql
@@ -1,0 +1,25 @@
+-- Roll back the storage_class marker column (bd-8rifr). Guarded so an
+-- issues-only or partially-applied workspace rolls back as safely as it
+-- migrated up (0054 precedent).
+
+SET @has_col = (
+    SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = 'issues'
+      AND COLUMN_NAME = 'storage_class'
+);
+SET @sql = IF(@has_col > 0,
+    'ALTER TABLE issues DROP COLUMN storage_class',
+    'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @has_col = (
+    SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = 'wisps'
+      AND COLUMN_NAME = 'storage_class'
+);
+SET @sql = IF(@has_col > 0,
+    'ALTER TABLE wisps DROP COLUMN storage_class',
+    'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;

--- a/internal/storage/schema/migrations/0060_add_storage_class.up.sql
+++ b/internal/storage/schema/migrations/0060_add_storage_class.up.sql
@@ -1,0 +1,48 @@
+-- Storage-class plumbing (Protocol v0.1 §C, bd-7vb13 / bd-8rifr).
+--
+-- storage_class declares a record's history/replication contract:
+-- 'versioned' | 'unversioned' | 'ephemeral'. NULL means unset, which
+-- resolves per C1.2: ephemeral for wisp-plane rows, versioned otherwise
+-- (types.Issue.EffectiveStorageClass). NULL-as-default deliberately avoids
+-- rewriting every existing row's cell (a full prolly-tree churn of exactly
+-- the kind this epic exists to remove) and mirrors the JSONL rule that the
+-- field is omitted when versioned (C2.4).
+--
+-- The column is a class MARKER only: this migration changes no behavior.
+-- ephemeral rows continue to live in the wisps plane; the unversioned
+-- replication leg is bd-1quyq; the events/comments migration is bd-red8u.
+--
+-- Guarded so the migration is idempotent on a schema_migrations row that
+-- regressed without its DDL rolled back (see 0052/0046/0054 precedent).
+
+-- issues.storage_class
+SET @needs_add = (
+    SELECT IF(COUNT(*) = 0, 1, 0)
+    FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = 'issues'
+      AND COLUMN_NAME = 'storage_class'
+);
+SET @sql = IF(@needs_add = 1,
+    'ALTER TABLE issues ADD COLUMN storage_class VARCHAR(16)',
+    'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+-- wisps.storage_class: wisps shares the issues row shape and the shared
+-- scans select the same column list from both tables. Guarded on the wisps
+-- table existing (older workspaces created issues-only; 0054 precedent).
+SET @has_wisps = (
+    SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES
+    WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'wisps'
+);
+
+SET @needs_add = IF(@has_wisps > 0 AND
+    (SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
+        WHERE TABLE_SCHEMA = DATABASE()
+          AND TABLE_NAME = 'wisps'
+          AND COLUMN_NAME = 'storage_class') = 0,
+    1, 0);
+SET @sql = IF(@needs_add = 1,
+    'ALTER TABLE wisps ADD COLUMN storage_class VARCHAR(16)',
+    'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;

--- a/internal/storage/sqlbuild/sqlbuild.go
+++ b/internal/storage/sqlbuild/sqlbuild.go
@@ -44,7 +44,7 @@ const IssueBaseColumns = `id, content_hash, title, description, design, acceptan
 	       mol_type,
 	       event_kind, actor, target, payload,
 	       due_at, defer_until,
-	       work_type, source_system, metadata, row_lock`
+	       work_type, source_system, metadata, row_lock, storage_class`
 
 // LeaseSelectColumns is the lease overlay for full issue hydration. Leases
 // live in the ephemeral leases table (bd-lrgn1), not on the issues row, so

--- a/internal/types/storage_class_test.go
+++ b/internal/types/storage_class_test.go
@@ -1,0 +1,153 @@
+package types
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestStorageClassIsValid(t *testing.T) {
+	valid := []StorageClass{"", StorageClassVersioned, StorageClassUnversioned, StorageClassEphemeral}
+	for _, s := range valid {
+		if !s.IsValid() {
+			t.Errorf("IsValid(%q) = false, want true", s)
+		}
+	}
+	invalid := []StorageClass{"Versioned", "durable", "wisp", "none"}
+	for _, s := range invalid {
+		if s.IsValid() {
+			t.Errorf("IsValid(%q) = true, want false", s)
+		}
+	}
+}
+
+func TestParseStorageClass(t *testing.T) {
+	if _, err := ParseStorageClass(""); err == nil {
+		t.Error("ParseStorageClass(\"\") should reject empty (callers gate unset before parsing)")
+	}
+	if _, err := ParseStorageClass("bogus"); err == nil {
+		t.Error("ParseStorageClass(\"bogus\") should fail")
+	} else if !strings.Contains(err.Error(), "versioned, unversioned, or ephemeral") {
+		t.Errorf("error should enumerate valid values, got: %v", err)
+	}
+	got, err := ParseStorageClass("unversioned")
+	if err != nil || got != StorageClassUnversioned {
+		t.Errorf("ParseStorageClass(unversioned) = %q, %v", got, err)
+	}
+}
+
+func TestStorageClassNormalize(t *testing.T) {
+	if got := StorageClassVersioned.Normalize(); got != "" {
+		t.Errorf("versioned should normalize to unset, got %q", got)
+	}
+	if got := StorageClassUnversioned.Normalize(); got != StorageClassUnversioned {
+		t.Errorf("unversioned should survive normalize, got %q", got)
+	}
+	if got := StorageClass("").Normalize(); got != "" {
+		t.Errorf("unset should stay unset, got %q", got)
+	}
+}
+
+func TestEffectiveStorageClass(t *testing.T) {
+	cases := []struct {
+		name  string
+		issue Issue
+		want  StorageClass
+	}{
+		{"default is versioned", Issue{}, StorageClassVersioned},
+		{"wisp plane is ephemeral", Issue{Ephemeral: true}, StorageClassEphemeral},
+		{"no-history plane is ephemeral", Issue{NoHistory: true}, StorageClassEphemeral},
+		{"explicit wins", Issue{StorageClass: StorageClassUnversioned}, StorageClassUnversioned},
+		{"explicit ephemeral on wisp plane", Issue{Ephemeral: true, StorageClass: StorageClassEphemeral}, StorageClassEphemeral},
+	}
+	for _, tc := range cases {
+		if got := tc.issue.EffectiveStorageClass(); got != tc.want {
+			t.Errorf("%s: EffectiveStorageClass() = %q, want %q", tc.name, got, tc.want)
+		}
+	}
+}
+
+func validBaseIssue() Issue {
+	return Issue{
+		ID:        "bd-sc1",
+		Title:     "t",
+		Status:    StatusOpen,
+		IssueType: TypeTask,
+		Priority:  2,
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+	}
+}
+
+func TestIssueValidateStorageClass(t *testing.T) {
+	// Unknown value rejected.
+	bad := validBaseIssue()
+	bad.StorageClass = "durable"
+	if err := bad.Validate(); err == nil || !strings.Contains(err.Error(), "invalid storage class") {
+		t.Errorf("unknown class: got %v", err)
+	}
+
+	// Durable class on a wisp-plane record rejected.
+	wispDurable := validBaseIssue()
+	wispDurable.Ephemeral = true
+	wispDurable.StorageClass = StorageClassUnversioned
+	if err := wispDurable.Validate(); err == nil || !strings.Contains(err.Error(), "conflicts with ephemeral") {
+		t.Errorf("durable-on-wisp: got %v", err)
+	}
+
+	// Ephemeral class without the wisp plane rejected.
+	looseEphemeral := validBaseIssue()
+	looseEphemeral.StorageClass = StorageClassEphemeral
+	if err := looseEphemeral.Validate(); err == nil || !strings.Contains(err.Error(), "requires the ephemeral flag") {
+		t.Errorf("ephemeral-off-plane: got %v", err)
+	}
+
+	// Coherent combinations accepted.
+	for _, ok := range []Issue{
+		func() Issue { i := validBaseIssue(); i.StorageClass = StorageClassUnversioned; return i }(),
+		func() Issue { i := validBaseIssue(); i.StorageClass = StorageClassVersioned; return i }(),
+		func() Issue {
+			i := validBaseIssue()
+			i.Ephemeral = true
+			i.StorageClass = StorageClassEphemeral
+			return i
+		}(),
+		func() Issue { i := validBaseIssue(); i.Ephemeral = true; return i }(),
+	} {
+		if err := ok.Validate(); err != nil {
+			t.Errorf("coherent issue rejected: %+v: %v", ok.StorageClass, err)
+		}
+	}
+}
+
+// C2.4: storage_class appears in JSONL for non-versioned records and is
+// omitted when versioned (unset).
+func TestStorageClassJSONRoundTrip(t *testing.T) {
+	unversioned := validBaseIssue()
+	unversioned.StorageClass = StorageClassUnversioned
+	data, err := json.Marshal(&unversioned)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), `"storage_class":"unversioned"`) {
+		t.Errorf("unversioned record should carry storage_class, got: %s", data)
+	}
+
+	var back Issue
+	if err := json.Unmarshal(data, &back); err != nil {
+		t.Fatal(err)
+	}
+	if back.StorageClass != StorageClassUnversioned {
+		t.Errorf("round-trip lost storage_class: %q", back.StorageClass)
+	}
+
+	versioned := validBaseIssue()
+	data, err = json.Marshal(&versioned)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(data), "storage_class") {
+		t.Errorf("versioned (unset) record must omit storage_class, got: %s", data)
+	}
+}

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -846,9 +846,10 @@ const (
 	// StorageClassUnversioned is durable and interchanged with no revision-
 	// history promise: only current state is retained and replicated (C2.2).
 	StorageClassUnversioned StorageClass = "unversioned"
-	// StorageClassEphemeral is TTL-bounded operational state: never exported,
-	// never replicated (C2.1). The existing wisp/lease planes have this
-	// character.
+	// StorageClassEphemeral is operational state that is never exported and
+	// never replicated (C2.1) — typically TTL-bounded, though not always:
+	// no-history rows are class-ephemeral yet TTL-exempt. The existing
+	// wisp/lease planes have this character.
 	StorageClassEphemeral StorageClass = "ephemeral"
 )
 

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -122,6 +122,13 @@ type Issue struct {
 	Ephemeral bool     `json:"ephemeral,omitempty"`  // If true, not synced via git
 	NoHistory bool     `json:"no_history,omitempty"` // If true, stored in wisps table but NOT GC-eligible
 	WispType  WispType `json:"wisp_type,omitempty"`  // Classification for TTL-based compaction (gt-9br)
+
+	// StorageClass declares the record's history/replication contract
+	// (Protocol v0.1 §C, bd-7vb13). Empty means unset: effective class is
+	// ephemeral for wisp-plane records (Ephemeral/NoHistory), else versioned
+	// (C1.2) — see EffectiveStorageClass. Omitted from JSONL when versioned
+	// (C2.4). Set at create, immutable except via promotion (C1.3/C4).
+	StorageClass StorageClass `json:"storage_class,omitempty"`
 	// NOTE: RepliesTo, RelatesTo, DuplicateOf, SupersededBy moved to dependencies table
 	// per Decision 004 (Edge Schema Consolidation). Use dependency API instead.
 
@@ -324,6 +331,23 @@ func (i *Issue) ValidateWithCustom(customStatuses, customTypes []string) error {
 	// Ephemeral and NoHistory are mutually exclusive (GH#2619)
 	if i.Ephemeral && i.NoHistory {
 		return fmt.Errorf("ephemeral and no_history are mutually exclusive")
+	}
+	// Storage class must be a known value, and a declared class must agree
+	// with the wisp-plane flags: wisp-plane records are ephemeral-class by
+	// construction, and a durable class on one (or ephemeral class off one)
+	// would silently promise semantics the row's plane doesn't deliver
+	// (Protocol v0.1 §C1.3/C2.1).
+	if !i.StorageClass.IsValid() {
+		return fmt.Errorf("invalid storage class %q (must be %s)", i.StorageClass, ValidStorageClassNames())
+	}
+	if i.StorageClass != "" {
+		wispPlane := i.Ephemeral || i.NoHistory
+		if wispPlane && i.StorageClass != StorageClassEphemeral {
+			return fmt.Errorf("storage class %q conflicts with ephemeral/no_history (wisp-plane records are storage class ephemeral)", i.StorageClass)
+		}
+		if !wispPlane && i.StorageClass == StorageClassEphemeral {
+			return fmt.Errorf("storage class ephemeral requires the ephemeral flag (create with --ephemeral)")
+		}
 	}
 	// Bound the VARCHAR(255) assignment columns up front so callers get a typed
 	// ErrFieldTooLong rejection instead of a raw backend "data too long" error.
@@ -804,6 +828,72 @@ func (w WispType) IsValid() bool {
 // ValidWispTypeNames enumerates the accepted wisp-type values for error messages.
 func ValidWispTypeNames() string {
 	return joinNamesWithOr(validWispTypes)
+}
+
+// StorageClass declares how a record's history and replication are priced
+// (Protocol v0.1 §C, bd-7vb13). The class is a semantic contract, not a table
+// or backend (C1.4): ephemeral happens to live in the dolt_ignore'd wisps
+// plane today, and unversioned's replication leg is tracked separately
+// (bd-1quyq) — the class marker must not imply either mechanism.
+type StorageClass string
+
+const (
+	// StorageClassVersioned is the default (C1.2): durable, replicated with
+	// history, mergeable. Serialized as the empty string — the storage_class
+	// field is omitted when versioned (C2.4), so every pre-v0.1 record is a
+	// valid versioned record unchanged.
+	StorageClassVersioned StorageClass = "versioned"
+	// StorageClassUnversioned is durable and interchanged with no revision-
+	// history promise: only current state is retained and replicated (C2.2).
+	StorageClassUnversioned StorageClass = "unversioned"
+	// StorageClassEphemeral is TTL-bounded operational state: never exported,
+	// never replicated (C2.1). The existing wisp/lease planes have this
+	// character.
+	StorageClassEphemeral StorageClass = "ephemeral"
+)
+
+// validStorageClasses is the canonical value list; IsValid,
+// ParseStorageClass, and ValidStorageClassNames all derive from it.
+var validStorageClasses = []StorageClass{
+	StorageClassVersioned, StorageClassUnversioned, StorageClassEphemeral,
+}
+
+// IsValid reports whether the storage class value is valid. Empty is valid
+// and means "unset": the effective class defaults per C1.2/C1.3.
+func (s StorageClass) IsValid() bool {
+	if s == "" {
+		return true
+	}
+	return slices.Contains(validStorageClasses, s)
+}
+
+// ValidStorageClassNames enumerates the accepted values for error messages.
+func ValidStorageClassNames() string {
+	return joinNamesWithOr(validStorageClasses)
+}
+
+// ParseStorageClass validates a user-supplied storage-class value (flag or
+// config). Empty is rejected here — callers that allow "unset" check for
+// empty before parsing.
+func ParseStorageClass(v string) (StorageClass, error) {
+	s := StorageClass(v)
+	if s == "" || !s.IsValid() {
+		return "", fmt.Errorf("invalid storage class %q (must be %s)", v, ValidStorageClassNames())
+	}
+	return s, nil
+}
+
+// EffectiveStorageClass resolves the record's class per C1.2/C1.3: an
+// explicit declaration wins; otherwise wisp-plane records (Ephemeral or
+// NoHistory) are ephemeral and everything else is versioned.
+func (i *Issue) EffectiveStorageClass() StorageClass {
+	if i.StorageClass != "" {
+		return i.StorageClass
+	}
+	if i.Ephemeral || i.NoHistory {
+		return StorageClassEphemeral
+	}
+	return StorageClassVersioned
 }
 
 // joinNamesWithOr formats a value list as "a, b, or c" for error messages.

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -883,6 +883,17 @@ func ParseStorageClass(v string) (StorageClass, error) {
 	return s, nil
 }
 
+// Normalize maps the explicit versioned spelling to unset: the two are
+// semantically identical (C1.2) and the marker is omitted when versioned
+// (C2.4) — in storage cells and JSONL alike. Both insert stacks call this so
+// the database never persists the literal "versioned".
+func (s StorageClass) Normalize() StorageClass {
+	if s == StorageClassVersioned {
+		return ""
+	}
+	return s
+}
+
 // EffectiveStorageClass resolves the record's class per C1.2/C1.3: an
 // explicit declaration wins; otherwise wisp-plane records (Ephemeral or
 // NoHistory) are ephemeral and everything else is versioned.


### PR DESCRIPTION
First child of the bd-7vb13 storage-classes epic (Protocol v0.1 §C, hopper's ratified addendum v0.2). Plumbing only — no behavior moves yet: the class is a validated, persisted **marker**. The events/comments migration is bd-red8u; the unversioned replication leg is bd-1quyq (deliberately held pending the Team Server evaluation, bd-btj0k).

## What's here

- **types.StorageClass** (`versioned|unversioned|ephemeral`, empty = unset): C1.2 defaulting via `EffectiveStorageClass` (wisp-plane rows resolve ephemeral, everything else versioned), `Normalize` (versioned → unset, so the DB never stores the literal), Validate coherence with the wisp-plane flags in both directions.
- **Migration 0060**: nullable `storage_class VARCHAR(16)` on issues+wisps, guarded/idempotent per the 0054 pattern. NULL-as-default deliberately avoids rewriting every row's cell — a full prolly-tree churn of exactly the kind this epic exists to remove.
- **Column threading**: IssueBaseColumns/Lite, both scans, both insert stacks (classic + domain/db), with the Lite∪HeavyDropList parity and lite-merge fixtures updated.
- **`bd create --storage-class`** (C-OQ1 spelling: spelled out, no `--class`, no sugar): explicit flag > `storage-class.<type>` config default > unset; `ephemeral` routes to the wisp plane as the spelled-out `--ephemeral` (C1.4) and keeps the `--no-history` mutual exclusion.
- **`storage-class.<type>` config keys**: yaml-plane (`dolt.auto-commit` precedent), validated at set time (C-OQ1) in both `config set` and `set-many`.
- **JSONL**: field rides the Issue tags with omit-when-versioned (C2.4); export's existing ephemeral exclusion generalizes unchanged; import validates via Issue.Validate.

## Tests

- Unit: class validation/parse/normalize/effective-class, Validate coherence, JSON round-trip incl. the C2.4 omission rule; resolveStorageClass + config validation.
- Embedded end-to-end contract (`TestEmbeddedCreateStorageClass`, 5 subtests, green locally): flag → JSON + at-rest cell, plain/explicit-versioned → NULL cell, config default + explicit override + other-type isolation, ephemeral → wisps row, config set-time rejection.

## Docs

Deferred to the cli-docs.pin bump per docs policy (docs describe the pinned release; #5052/#5089 precedent). The flag's help text regenerates into the CLI reference at that point; the concept page lands with the pin bump alongside bd-red8u.

Note: `internal/storage/uow` external-doltserver tests fail identically on this branch's base in this environment (external-server setup dependency) — not introduced here; CI is the adjudicator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)