### PR TITLE
feat(storage): content-derived ids for events/comments at insert time (bd-ri8bd)

### DIFF
--- a/internal/storage/dolt/derived_id_insert_test.go
+++ b/internal/storage/dolt/derived_id_insert_test.go
@@ -1,0 +1,227 @@
+package dolt
+
+import (
+	"context"
+	"database/sql"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/storage/issueops"
+	"github.com/steveyegge/beads/internal/storage/rowid"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// derivedIDDigestColumns mirrors the FROZEN digest column lists in
+// internal/storage/schema (auxRekeyTables) and the insert-time derivation in
+// issueops. Deliberately duplicated here: if either side drifts from the
+// frozen lists, the recomputation below stops matching the stored ids and
+// these tests fail.
+var derivedIDDigestColumns = map[string]string{
+	"events":   "issue_id, event_type, actor, old_value, new_value, comment, CAST(created_at AS CHAR)",
+	"comments": "issue_id, author, text, CAST(created_at AS CHAR)",
+}
+
+// assertTableIDsContentDerived scans every row of table, recomputes the
+// content digest from the stored (server-rendered) column values, and asserts
+// the table's id set is exactly the derived ids for ordinals 0..n-1 per
+// digest group — i.e. the ids the schema backfill would have assigned. This
+// is the insert-time/backfill equivalence at the heart of bd-ri8bd: a row
+// minted by the new insert paths must already sit on its convergent id.
+func assertTableIDsContentDerived(ctx context.Context, t *testing.T, db *sql.DB, table string) {
+	t.Helper()
+	columns := derivedIDDigestColumns[table]
+
+	rows, err := db.QueryContext(ctx, "SELECT id, "+columns+" FROM "+table) //nolint:gosec // test-local constant tables
+	if err != nil {
+		t.Fatalf("scan %s: %v", table, err)
+	}
+	defer rows.Close()
+
+	nFields := strings.Count(columns, ",") + 1
+	groups := make(map[string][]string)
+	for rows.Next() {
+		var id string
+		fields := make([]sql.NullString, nFields)
+		dests := make([]any, 0, nFields+1)
+		dests = append(dests, &id)
+		for i := range fields {
+			dests = append(dests, &fields[i])
+		}
+		if err := rows.Scan(dests...); err != nil {
+			t.Fatalf("scan %s row: %v", table, err)
+		}
+		groups[rowid.Digest(fields)] = append(groups[rowid.Digest(fields)], id)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("scan %s: %v", table, err)
+	}
+	if len(groups) == 0 {
+		t.Fatalf("no %s rows to verify", table)
+	}
+
+	for digest, ids := range groups {
+		want := make([]string, len(ids))
+		for i := range ids {
+			want[i] = rowid.New(table, i, digest)
+		}
+		got := append([]string(nil), ids...)
+		sort.Strings(got)
+		sort.Strings(want)
+		for i := range want {
+			if got[i] != want[i] {
+				t.Errorf("%s digest %s: ids = %v, want derived %v", table, digest[:12], got, want)
+				break
+			}
+		}
+	}
+}
+
+// TestInsertTimeIDsMatchBackfillDerivation drives the real store write paths
+// (issue create with labels, update, comment) and verifies every resulting
+// events/comments row landed on its content-derived id — recomputed from the
+// server-rendered stored values, so a drift between the Go-side digest inputs
+// (app-stamped created_at text, NULL-vs-empty encoding) and what the column
+// actually holds fails here, not in a fleet merge.
+func TestInsertTimeIDsMatchBackfillDerivation(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	issue := &types.Issue{
+		Title:       "derived id fixture",
+		Description: "insert-time derivation",
+		Status:      types.StatusOpen,
+		Priority:    2,
+		IssueType:   types.TypeTask,
+		Labels:      []string{"lane-a"},
+	}
+	if err := store.CreateIssue(ctx, issue, "tester"); err != nil {
+		t.Fatalf("CreateIssue: %v", err)
+	}
+	if err := store.UpdateIssue(ctx, issue.ID, map[string]interface{}{"status": "in_progress"}, "tester"); err != nil {
+		t.Fatalf("UpdateIssue: %v", err)
+	}
+	if _, err := store.AddIssueComment(ctx, issue.ID, "tester", "a derived comment"); err != nil {
+		t.Fatalf("AddIssueComment: %v", err)
+	}
+
+	assertTableIDsContentDerived(ctx, t, store.db, "events")
+	assertTableIDsContentDerived(ctx, t, store.db, "comments")
+}
+
+// TestDerivedEventOrdinalsPreserveLocalDuplicates pins the ordinal
+// discipline: the same logical event recorded twice in the same second stays
+// two rows, on ordinals 0 and 1 of the same digest — multiplicity within a
+// database is preserved even though the id is a function of content.
+func TestDerivedEventOrdinalsPreserveLocalDuplicates(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	issue := &types.Issue{
+		Title:     "ordinal fixture",
+		Status:    types.StatusOpen,
+		Priority:  2,
+		IssueType: types.TypeTask,
+	}
+	if err := store.CreateIssue(ctx, issue, "tester"); err != nil {
+		t.Fatalf("CreateIssue: %v", err)
+	}
+
+	evt := issueops.AuxEvent{
+		IssueID:   issue.ID,
+		EventType: types.EventCommented,
+		Actor:     "tester",
+		Comment:   sql.NullString{String: "same twice", Valid: true},
+		CreatedAt: "2026-07-29 10:00:00",
+	}
+	if err := issueops.InsertDerivedEvent(ctx, store.db, "events", evt); err != nil {
+		t.Fatalf("first insert: %v", err)
+	}
+	if err := issueops.InsertDerivedEvent(ctx, store.db, "events", evt); err != nil {
+		t.Fatalf("second insert: %v", err)
+	}
+
+	rows, err := store.db.QueryContext(ctx,
+		"SELECT id FROM events WHERE issue_id = ? AND comment = 'same twice' ORDER BY id", issue.ID)
+	if err != nil {
+		t.Fatalf("read events: %v", err)
+	}
+	defer rows.Close()
+	var got []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		got = append(got, id)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("read events: %v", err)
+	}
+
+	digest := rowid.Digest([]sql.NullString{
+		{String: issue.ID, Valid: true},
+		{String: string(types.EventCommented), Valid: true},
+		{String: "tester", Valid: true},
+		{}, {},
+		{String: "same twice", Valid: true},
+		{String: "2026-07-29 10:00:00", Valid: true},
+	})
+	want := []string{rowid.New("events", 0, digest), rowid.New("events", 1, digest)}
+	sort.Strings(want)
+	if len(got) != 2 || got[0] != want[0] || got[1] != want[1] {
+		t.Errorf("duplicate event ids = %v, want ordinals 0 and 1: %v", got, want)
+	}
+}
+
+// TestDerivedCommentInsertCollapsesDuplicates pins the comment semantics: a
+// second identical comment (same issue, author, text, second) is the same
+// logical comment and collapses onto the existing row, exactly like the
+// import path's historical existence check.
+func TestDerivedCommentInsertCollapsesDuplicates(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	issue := &types.Issue{
+		Title:     "collapse fixture",
+		Status:    types.StatusOpen,
+		Priority:  2,
+		IssueType: types.TypeTask,
+	}
+	if err := store.CreateIssue(ctx, issue, "tester"); err != nil {
+		t.Fatalf("CreateIssue: %v", err)
+	}
+
+	first, existed, err := issueops.InsertDerivedComment(ctx, store.db, "comments", issue.ID, "tester", "dup text", "2026-07-29 10:00:00")
+	if err != nil {
+		t.Fatalf("first insert: %v", err)
+	}
+	if existed {
+		t.Fatal("first insert reported existed=true")
+	}
+	second, existed, err := issueops.InsertDerivedComment(ctx, store.db, "comments", issue.ID, "tester", "dup text", "2026-07-29 10:00:00")
+	if err != nil {
+		t.Fatalf("second insert: %v", err)
+	}
+	if !existed || second != first {
+		t.Errorf("second insert = (%s, existed=%v), want collapse onto %s", second, existed, first)
+	}
+
+	var n int
+	if err := store.db.QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM comments WHERE issue_id = ?", issue.ID).Scan(&n); err != nil {
+		t.Fatalf("count comments: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("comment rows = %d, want 1", n)
+	}
+}

--- a/internal/storage/dolt/ephemeral_routing.go
+++ b/internal/storage/dolt/ephemeral_routing.go
@@ -271,10 +271,7 @@ func (s *DoltStore) demoteToWispInTx(ctx context.Context, tx *sql.Tx, id string,
 		return fmt.Errorf("delete copied comments for demoted issue %s: %w", id, err)
 	}
 
-	if _, err := tx.ExecContext(ctx, `
-		INSERT INTO wisp_events (id, issue_id, event_type, actor, old_value, new_value)
-		VALUES (?, ?, ?, ?, ?, ?)
-	`, issueops.NewEventID(), id, types.EventUpdated, actor, "", "demoted to wisp"); err != nil {
+	if err := issueops.RecordFullEventInTable(ctx, tx, "wisp_events", id, types.EventUpdated, actor, "", "demoted to wisp"); err != nil {
 		return fmt.Errorf("record demotion event for demoted issue %s: %w", id, err)
 	}
 

--- a/internal/storage/dolt/issues.go
+++ b/internal/storage/dolt/issues.go
@@ -799,11 +799,7 @@ func doltBuildSQLInClause(ids []string) (string, []interface{}) {
 // =============================================================================
 
 func recordEvent(ctx context.Context, tx *sql.Tx, issueID string, eventType types.EventType, actor, oldValue, newValue string) error {
-	_, err := tx.ExecContext(ctx, `
-		INSERT INTO events (id, issue_id, event_type, actor, old_value, new_value)
-		VALUES (?, ?, ?, ?, ?, ?)
-	`, issueops.NewEventID(), issueID, eventType, actor, oldValue, newValue)
-	return wrapExecError("record event", err)
+	return wrapExecError("record event", issueops.RecordFullEventInTable(ctx, tx, "events", issueID, eventType, actor, oldValue, newValue))
 }
 
 // seedCounterFromExistingIssuesTx scans existing issues to find the highest numeric suffix

--- a/internal/storage/dolt/transaction.go
+++ b/internal/storage/dolt/transaction.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/storage/domain"
 	"github.com/steveyegge/beads/internal/storage/issueops"
@@ -1071,19 +1070,18 @@ func (t *doltTransaction) ImportIssueComment(ctx context.Context, issueID, autho
 		table = "wisp_comments"
 	}
 
-	createdAt = createdAt.UTC()
-	id := uuid.Must(uuid.NewV7()).String()
-	//nolint:gosec // G201: table is hardcoded
-	_, err = t.txFor(table).ExecContext(ctx, fmt.Sprintf(`
-		INSERT INTO %s (id, issue_id, author, text, created_at)
-		VALUES (?, ?, ?, ?, ?)
-	`, table), id, issueID, author, text, createdAt)
+	createdAtText := issueops.FormatAuxTime(createdAt)
+	id, _, err := issueops.InsertDerivedComment(ctx, t.txFor(table), table, issueID, author, text, createdAtText)
 	if err != nil {
 		return nil, fmt.Errorf("failed to add comment: %w", err)
 	}
 	t.dirty.MarkDirty(table)
 
-	return &types.Comment{ID: id, IssueID: issueID, Author: author, Text: text, CreatedAt: createdAt}, nil
+	stored, err := issueops.ParseAuxTime(createdAtText)
+	if err != nil {
+		return nil, fmt.Errorf("failed to add comment: %w", err)
+	}
+	return &types.Comment{ID: id, IssueID: issueID, Author: author, Text: text, CreatedAt: stored}, nil
 }
 
 func (t *doltTransaction) GetIssueComments(ctx context.Context, issueID string) ([]*types.Comment, error) {
@@ -1121,11 +1119,12 @@ func (t *doltTransaction) AddComment(ctx context.Context, issueID, actor, commen
 		table = "wisp_events"
 	}
 
-	//nolint:gosec // G201: table is hardcoded
-	_, err := t.txFor(table).ExecContext(ctx, fmt.Sprintf(`
-		INSERT INTO %s (id, issue_id, event_type, actor, comment)
-		VALUES (?, ?, ?, ?, ?)
-	`, table), issueops.NewEventID(), issueID, types.EventCommented, actor, comment)
+	err := issueops.InsertDerivedEvent(ctx, t.txFor(table), table, issueops.AuxEvent{
+		IssueID:   issueID,
+		EventType: types.EventCommented,
+		Actor:     actor,
+		Comment:   sql.NullString{String: comment, Valid: true},
+	})
 	if err == nil {
 		t.dirty.MarkDirty(table)
 	}

--- a/internal/storage/dolt/transaction_test.go
+++ b/internal/storage/dolt/transaction_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/storage/issueops"
 	"github.com/steveyegge/beads/internal/types"
@@ -150,7 +151,7 @@ func TestRunInTransactionAlreadyClosedDoesNotCommitUnrelatedEvent(t *testing.T) 
 	const strayComment = "uncommitted stray event"
 	if _, err := store.db.ExecContext(ctx,
 		"INSERT INTO events (id, issue_id, event_type, actor, comment) VALUES (?, ?, ?, ?, ?)",
-		issueops.NewEventID(), issue.ID, types.EventCommented, "tester", strayComment,
+		uuid.Must(uuid.NewV7()).String(), issue.ID, types.EventCommented, "tester", strayComment,
 	); err != nil {
 		t.Fatalf("insert stray event: %v", err)
 	}

--- a/internal/storage/domain/db/comment.go
+++ b/internal/storage/domain/db/comment.go
@@ -4,12 +4,10 @@ import (
 	"context"
 	"fmt"
 	"strings"
-	"time"
-
-	"github.com/google/uuid"
 
 	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/storage/domain"
+	"github.com/steveyegge/beads/internal/storage/issueops"
 	"github.com/steveyegge/beads/internal/types"
 )
 
@@ -130,13 +128,14 @@ func (r *commentSQLRepositoryImpl) Insert(ctx context.Context, issueID, author, 
 		return nil, fmt.Errorf("db: CommentSQLRepository.Insert: issue %s not found", issueID)
 	}
 
-	createdAt := time.Now().UTC()
-	id := uuid.Must(uuid.NewV7()).String()
+	createdAtText := issueops.NowAuxTime()
 	commentTable := pickCommentTable(opts.UseWispsTable)
-	//nolint:gosec // G201: commentTable is one of two hardcoded constants
-	if _, err := r.runner.ExecContext(ctx,
-		fmt.Sprintf("INSERT INTO %s (id, issue_id, author, text, created_at) VALUES (?, ?, ?, ?, ?)", commentTable),
-		id, issueID, author, text, createdAt); err != nil {
+	id, _, err := issueops.InsertDerivedComment(ctx, r.runner, commentTable, issueID, author, text, createdAtText)
+	if err != nil {
+		return nil, fmt.Errorf("db: CommentSQLRepository.Insert: %w", err)
+	}
+	createdAt, err := issueops.ParseAuxTime(createdAtText)
+	if err != nil {
 		return nil, fmt.Errorf("db: CommentSQLRepository.Insert: %w", err)
 	}
 

--- a/internal/storage/domain/db/events.go
+++ b/internal/storage/domain/db/events.go
@@ -25,12 +25,7 @@ func (r *eventsSQLRepositoryImpl) Record(ctx context.Context, evt domain.Event, 
 	if opts.UseWispsTable {
 		table = "wisp_events"
 	}
-	//nolint:gosec // G201: table is one of two hardcoded constants
-	_, err := r.runner.ExecContext(ctx, fmt.Sprintf(`
-		INSERT INTO %s (id, issue_id, event_type, actor, old_value, new_value)
-		VALUES (?, ?, ?, ?, ?, ?)
-	`, table), issueops.NewEventID(), evt.IssueID, string(evt.Type), evt.Actor, evt.OldValue, evt.NewValue)
-	if err != nil {
+	if err := issueops.RecordFullEventInTable(ctx, r.runner, table, evt.IssueID, evt.Type, evt.Actor, evt.OldValue, evt.NewValue); err != nil {
 		return fmt.Errorf("db: record event in %s: %w", table, err)
 	}
 	return nil

--- a/internal/storage/issueops/bulk_ops.go
+++ b/internal/storage/issueops/bulk_ops.go
@@ -253,11 +253,13 @@ func updateIssueIDInTx(ctx context.Context, tx *sql.Tx, oldID, newID string, iss
 		return fmt.Errorf("rename lease row: %w", err)
 	}
 
-	_, err = tx.ExecContext(ctx, `
-		INSERT INTO events (id, issue_id, event_type, actor, old_value, new_value)
-		VALUES (?, ?, 'renamed', ?, ?, ?)
-	`, NewEventID(), newID, actor, oldID, newID)
-	return err
+	return InsertDerivedEvent(ctx, tx, "events", AuxEvent{
+		IssueID:   newID,
+		EventType: "renamed",
+		Actor:     actor,
+		OldValue:  str(oldID),
+		NewValue:  str(newID),
+	})
 }
 
 func updateWispIDInTx(ctx context.Context, tx *sql.Tx, oldID, newID string, issue *types.Issue, actor string) error {
@@ -274,10 +276,13 @@ func updateWispIDInTx(ctx context.Context, tx *sql.Tx, oldID, newID string, issu
 		return fmt.Errorf("wisp not found: %s", oldID)
 	}
 
-	if _, err = tx.ExecContext(ctx, `
-		INSERT INTO wisp_events (id, issue_id, event_type, actor, old_value, new_value)
-		VALUES (?, ?, 'renamed', ?, ?, ?)
-	`, NewEventID(), newID, actor, oldID, newID); err != nil {
+	if err = InsertDerivedEvent(ctx, tx, "wisp_events", AuxEvent{
+		IssueID:   newID,
+		EventType: "renamed",
+		Actor:     actor,
+		OldValue:  str(oldID),
+		NewValue:  str(newID),
+	}); err != nil {
 		return err
 	}
 

--- a/internal/storage/issueops/comments.go
+++ b/internal/storage/issueops/comments.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/types"
 )
@@ -250,12 +249,13 @@ func ImportIssueCommentInTx(ctx context.Context, tx *sql.Tx, issueID, author, te
 		return nil, fmt.Errorf("issue %s not found", issueID)
 	}
 
-	createdAt = createdAt.UTC()
-	id := uuid.Must(uuid.NewV7()).String()
-	if _, err := tx.ExecContext(ctx, fmt.Sprintf(`
-		INSERT INTO %s (id, issue_id, author, text, created_at)
-		VALUES (?, ?, ?, ?, ?)
-	`, commentTable), id, issueID, author, text, createdAt); err != nil {
+	createdAtText := FormatAuxTime(createdAt)
+	id, _, err := InsertDerivedComment(ctx, tx, commentTable, issueID, author, text, createdAtText)
+	if err != nil {
+		return nil, err
+	}
+	stored, err := ParseAuxTime(createdAtText)
+	if err != nil {
 		return nil, fmt.Errorf("add comment to %s: %w", commentTable, err)
 	}
 
@@ -264,7 +264,7 @@ func ImportIssueCommentInTx(ctx context.Context, tx *sql.Tx, issueID, author, te
 		IssueID:   issueID,
 		Author:    author,
 		Text:      text,
-		CreatedAt: createdAt,
+		CreatedAt: stored,
 	}, nil
 }
 
@@ -276,10 +276,12 @@ func AddCommentEventInTx(ctx context.Context, tx DBTX, issueID, actor, comment s
 	isWisp := IsActiveWispInTx(ctx, tx, issueID)
 	_, _, eventTable, _ := WispTableRouting(isWisp)
 
-	if _, err := tx.ExecContext(ctx, fmt.Sprintf(`
-		INSERT INTO %s (id, issue_id, event_type, actor, comment)
-		VALUES (?, ?, ?, ?, ?)
-	`, eventTable), NewEventID(), issueID, types.EventCommented, actor, comment); err != nil {
+	if err := InsertDerivedEvent(ctx, tx, eventTable, AuxEvent{
+		IssueID:   issueID,
+		EventType: types.EventCommented,
+		Actor:     actor,
+		Comment:   str(comment),
+	}); err != nil {
 		return fmt.Errorf("add comment event to %s: %w", eventTable, err)
 	}
 	return nil

--- a/internal/storage/issueops/compaction.go
+++ b/internal/storage/issueops/compaction.go
@@ -121,12 +121,8 @@ func SnapshotIssueInTx(ctx context.Context, tx *sql.Tx, issueID string, tier int
 		return fmt.Errorf("snapshot issue %s: marshal: %w", issueID, err)
 	}
 
-	now := time.Now().UTC()
-	if _, err := tx.ExecContext(ctx,
-		`INSERT INTO compaction_snapshots (id, issue_id, compaction_level, snapshot_json, created_at) VALUES (?, ?, ?, ?, ?)`,
-		NewEventID(), issueID, tier, payload, now,
-	); err != nil {
-		return fmt.Errorf("snapshot issue %s: insert: %w", issueID, err)
+	if err := InsertDerivedCompactionSnapshot(ctx, tx, issueID, tier, payload, ""); err != nil {
+		return fmt.Errorf("snapshot issue %s: %w", issueID, err)
 	}
 	return nil
 }

--- a/internal/storage/issueops/create.go
+++ b/internal/storage/issueops/create.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/storage/depid"
 	"github.com/steveyegge/beads/internal/types"
@@ -669,11 +668,12 @@ func PersistLabels(ctx context.Context, tx *sql.Tx, issue *types.Issue, actor, e
 		}
 		result.markChanged(labelTable)
 		comment := "Added label: " + label
-		//nolint:gosec // G201: eventTable is determined by ephemeral flag
-		if _, err := tx.ExecContext(ctx, fmt.Sprintf(`
-			INSERT INTO %s (id, issue_id, event_type, actor, comment)
-			VALUES (?, ?, ?, ?, ?)
-		`, eventTable), NewEventID(), issue.ID, types.EventLabelAdded, actor, comment); err != nil {
+		if err := InsertDerivedEvent(ctx, tx, eventTable, AuxEvent{
+			IssueID:   issue.ID,
+			EventType: types.EventLabelAdded,
+			Actor:     actor,
+			Comment:   str(comment),
+		}); err != nil {
 			return result, fmt.Errorf("failed to record label event %q for %s: %w", label, issue.ID, err)
 		}
 		result.markChanged(eventTable)
@@ -695,30 +695,38 @@ func PersistComments(ctx context.Context, tx *sql.Tx, issue *types.Issue) (Creat
 		if createdAt.IsZero() {
 			createdAt = time.Now().UTC()
 		}
-		// Check for existing identical comment to prevent duplicates on re-import.
-		// The UUID PK means ON DUPLICATE KEY UPDATE would never fire,
-		// so we do an explicit existence check instead.
+		createdAtText := FormatAuxTime(createdAt)
+		if comment.ID == "" {
+			// No incoming id (fresh comment): content-derived id, collapsing
+			// onto an identical existing row exactly like the import dedup.
+			id, existed, err := InsertDerivedComment(ctx, tx, commentTable, issue.ID, comment.Author, comment.Text, createdAtText)
+			if err != nil {
+				return result, fmt.Errorf("failed to insert comment for %s: %w", issue.ID, err)
+			}
+			comment.ID = id
+			if !existed {
+				result.markChanged(commentTable)
+			}
+			continue
+		}
+		// Incoming id (import/interchange): preserve it, with the historical
+		// existence check preventing duplicates on re-import.
 		var exists int
 		//nolint:gosec // G201: table is determined by ephemeral flag
 		if err := tx.QueryRowContext(ctx, fmt.Sprintf(`
 				SELECT COUNT(*) FROM %s
 				WHERE issue_id = ? AND author = ? AND created_at = ? AND text = ?
-			`, commentTable), issue.ID, comment.Author, createdAt, comment.Text).Scan(&exists); err != nil {
+			`, commentTable), issue.ID, comment.Author, createdAtText, comment.Text).Scan(&exists); err != nil {
 			return result, fmt.Errorf("failed to check comment existence for %s: %w", issue.ID, err)
 		}
 		if exists > 0 {
 			continue
 		}
-		commentID := comment.ID
-		if commentID == "" {
-			commentID = uuid.Must(uuid.NewV7()).String()
-			comment.ID = commentID
-		}
 		//nolint:gosec // G201: table is determined by ephemeral flag
 		_, err := tx.ExecContext(ctx, fmt.Sprintf(`
 			INSERT INTO %s (id, issue_id, author, text, created_at)
 			VALUES (?, ?, ?, ?, ?)
-		`, commentTable), commentID, issue.ID, comment.Author, comment.Text, createdAt)
+		`, commentTable), comment.ID, issue.ID, comment.Author, comment.Text, createdAtText)
 		if err != nil {
 			return result, fmt.Errorf("failed to insert comment for %s: %w", issue.ID, err)
 		}

--- a/internal/storage/issueops/derivedid.go
+++ b/internal/storage/issueops/derivedid.go
@@ -1,0 +1,211 @@
+package issueops
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+
+	"github.com/steveyegge/beads/internal/storage/rowid"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// This file is the insert-time half of the content-derived aux-row ids
+// (bd-ri8bd, Protocol v0.1 C-OQ3). The rekey backfill in
+// internal/storage/schema converged the rows that existed when it shipped;
+// every new events/comments/compaction_snapshots row now mints the same
+// deterministic id at insert, so logically identical rows created
+// independently on two replicas land on the same primary key and converge
+// under merge-free (newest-wins) replication exactly as they do under the
+// versioned union merge.
+//
+// The digest inputs are the FROZEN per-table column lists the backfill
+// established (see auxRekeyTables in internal/storage/schema): deriving from
+// any other column set would fork the id space the backfill converged.
+// created_at participates as the DATETIME(0) text rendering, so insert sites
+// stamp it app-side via NowAuxTime/FormatAuxTime and bind the string itself —
+// what is stored is byte-for-byte what was digested.
+
+// AuxTimeLayout renders a UTC timestamp exactly as Dolt renders
+// CAST(created_at AS CHAR) for a DATETIME(0) column. It is part of the id
+// derivation and frozen with the column lists.
+const AuxTimeLayout = "2006-01-02 15:04:05"
+
+// NowAuxTime returns the current UTC time in AuxTimeLayout.
+func NowAuxTime() string {
+	return time.Now().UTC().Format(AuxTimeLayout)
+}
+
+// FormatAuxTime renders t for digesting and binding as an aux-row created_at.
+func FormatAuxTime(t time.Time) string {
+	return t.UTC().Format(AuxTimeLayout)
+}
+
+// ParseAuxTime is the inverse of FormatAuxTime, for returning the stored
+// timestamp to callers as a time.Time.
+func ParseAuxTime(s string) (time.Time, error) {
+	return time.ParseInLocation(AuxTimeLayout, s, time.UTC)
+}
+
+// AuxEvent is one events-plane row (events or wisp_events) in the frozen
+// digest column order. OldValue/NewValue/Comment distinguish NULL from the
+// empty string — the digest does too, so sites must pass exactly what they
+// previously stored.
+type AuxEvent struct {
+	IssueID   string
+	EventType types.EventType
+	Actor     string
+	OldValue  sql.NullString
+	NewValue  sql.NullString
+	Comment   sql.NullString
+	CreatedAt string // AuxTimeLayout UTC; empty means "stamp now"
+}
+
+func str(s string) sql.NullString {
+	return sql.NullString{String: s, Valid: true}
+}
+
+// firstFreeDerivedID returns the deterministic id for the lowest ordinal not
+// already held by a same-content row. taken may include legacy random ids
+// (rows minted before the derivation shipped, converged later by the rekey
+// pass); those never collide with derived candidates, so the loop terminates
+// within len(taken)+1 probes.
+func firstFreeDerivedID(table, digest string, taken map[string]bool) string {
+	for ordinal := 0; ; ordinal++ {
+		id := rowid.New(table, ordinal, digest)
+		if !taken[id] {
+			return id
+		}
+	}
+}
+
+// InsertDerivedEvent inserts one events-plane row under its content-derived
+// id. Exact-duplicate rows already in table (same digest) push the new row to
+// the next free ordinal, preserving local multiplicity; across replicas an
+// identical (digest, ordinal) pair is the same id, which is what makes
+// independently-created identical rows converge (a deliberate set-union
+// collapse, Protocol v0.1 C2.3).
+//
+// Ordinal selection assumes writes to ONE replica are serialized — true
+// under both current topologies (the shared sql-server and the single-process
+// embedded store). Two truly concurrent same-content transactions on one
+// replica could pick the same free ordinal; the loser fails on the duplicate
+// key rather than silently minting a colliding id, matching the pre-existing
+// behavior of any duplicate primary-key insert. A future multi-writer
+// embedding must revisit this (per the wyvern C-OQ3 review): the
+// cross-replica collapse is by design, a within-replica collision is not.
+//
+//nolint:gosec // G201: table is a hardcoded routing constant at every call site.
+func InsertDerivedEvent(ctx context.Context, tx DBTX, table string, e AuxEvent) error {
+	if e.CreatedAt == "" {
+		e.CreatedAt = NowAuxTime()
+	}
+	digest := rowid.Digest([]sql.NullString{
+		str(e.IssueID), str(string(e.EventType)), str(e.Actor),
+		e.OldValue, e.NewValue, e.Comment, str(e.CreatedAt),
+	})
+	taken := make(map[string]bool)
+	rows, err := tx.QueryContext(ctx, fmt.Sprintf(`
+		SELECT id FROM %s
+		WHERE issue_id = ? AND event_type = ? AND actor = ?
+		  AND old_value <=> ? AND new_value <=> ? AND comment <=> ?
+		  AND created_at = ?`, table),
+		e.IssueID, string(e.EventType), e.Actor, e.OldValue, e.NewValue, e.Comment, e.CreatedAt)
+	if err != nil {
+		return fmt.Errorf("scan same-content events in %s: %w", table, err)
+	}
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			_ = rows.Close()
+			return fmt.Errorf("scan same-content events in %s: %w", table, err)
+		}
+		taken[id] = true
+	}
+	_ = rows.Close()
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("scan same-content events in %s: %w", table, err)
+	}
+
+	if _, err := tx.ExecContext(ctx, fmt.Sprintf(`
+		INSERT INTO %s (id, issue_id, event_type, actor, old_value, new_value, comment, created_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?)`, table),
+		firstFreeDerivedID(table, digest, taken),
+		e.IssueID, string(e.EventType), e.Actor, e.OldValue, e.NewValue, e.Comment, e.CreatedAt); err != nil {
+		return fmt.Errorf("record event in %s: %w", table, err)
+	}
+	return nil
+}
+
+// InsertDerivedComment inserts a comment under its content-derived id, or
+// collapses onto an existing identical comment: a same-content row already in
+// table (any id — it may predate the derivation) is the same logical comment,
+// and the import path has always existence-checked exactly this column set
+// (issue_id, author, text, created_at) rather than insert a duplicate. It
+// returns the surviving row's id and whether it already existed.
+//
+//nolint:gosec // G201: table is a hardcoded routing constant at every call site.
+func InsertDerivedComment(ctx context.Context, tx DBTX, table, issueID, author, text, createdAt string) (id string, existed bool, err error) {
+	err = tx.QueryRowContext(ctx, fmt.Sprintf(`
+		SELECT id FROM %s
+		WHERE issue_id = ? AND author = ? AND text = ? AND created_at = ?
+		ORDER BY id LIMIT 1`, table),
+		issueID, author, text, createdAt).Scan(&id)
+	if err == nil {
+		return id, true, nil
+	}
+	if err != sql.ErrNoRows {
+		return "", false, fmt.Errorf("check comment existence in %s: %w", table, err)
+	}
+	digest := rowid.Digest([]sql.NullString{str(issueID), str(author), str(text), str(createdAt)})
+	id = rowid.New(table, 0, digest)
+	if _, err := tx.ExecContext(ctx, fmt.Sprintf(`
+		INSERT INTO %s (id, issue_id, author, text, created_at)
+		VALUES (?, ?, ?, ?, ?)`, table),
+		id, issueID, author, text, createdAt); err != nil {
+		return "", false, fmt.Errorf("add comment to %s: %w", table, err)
+	}
+	return id, false, nil
+}
+
+// InsertDerivedCompactionSnapshot inserts a compaction_snapshots row under
+// its content-derived id, with the same ordinal discipline as events. Two
+// clones compacting the same issue at the same tier in the same second
+// produce byte-identical snapshots and therefore the same id.
+func InsertDerivedCompactionSnapshot(ctx context.Context, tx DBTX, issueID string, level int, snapshotJSON []byte, createdAt string) error {
+	if createdAt == "" {
+		createdAt = NowAuxTime()
+	}
+	snap := string(snapshotJSON)
+	digest := rowid.Digest([]sql.NullString{
+		str(issueID), str(fmt.Sprintf("%d", level)), str(snap), str(createdAt),
+	})
+	taken := make(map[string]bool)
+	rows, err := tx.QueryContext(ctx, `
+		SELECT id FROM compaction_snapshots
+		WHERE issue_id = ? AND compaction_level = ? AND snapshot_json = ? AND created_at = ?`,
+		issueID, level, snap, createdAt)
+	if err != nil {
+		return fmt.Errorf("scan same-content compaction snapshots: %w", err)
+	}
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			_ = rows.Close()
+			return fmt.Errorf("scan same-content compaction snapshots: %w", err)
+		}
+		taken[id] = true
+	}
+	_ = rows.Close()
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("scan same-content compaction snapshots: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO compaction_snapshots (id, issue_id, compaction_level, snapshot_json, created_at)
+		VALUES (?, ?, ?, ?, ?)`,
+		firstFreeDerivedID("compaction_snapshots", digest, taken),
+		issueID, level, snap, createdAt); err != nil {
+		return fmt.Errorf("insert compaction snapshot: %w", err)
+	}
+	return nil
+}

--- a/internal/storage/issueops/derivedid.go
+++ b/internal/storage/issueops/derivedid.go
@@ -100,6 +100,17 @@ func InsertDerivedEvent(ctx context.Context, tx DBTX, table string, e AuxEvent) 
 	if e.CreatedAt == "" {
 		e.CreatedAt = NowAuxTime()
 	}
+	if table == "wisp_events" {
+		// wisp_events value columns DEFAULT '' (0021) where events defaults
+		// them NULL; the pre-derivation mint sites omitted unset columns and
+		// stored the default. Keep storing "" so the row — and its digest —
+		// matches legacy wisp rows and the rekey pass's re-derivation.
+		for _, p := range []*sql.NullString{&e.OldValue, &e.NewValue, &e.Comment} {
+			if !p.Valid {
+				*p = str("")
+			}
+		}
+	}
 	digest := rowid.Digest([]sql.NullString{
 		str(e.IssueID), str(string(e.EventType)), str(e.Actor),
 		e.OldValue, e.NewValue, e.Comment, str(e.CreatedAt),

--- a/internal/storage/issueops/helpers.go
+++ b/internal/storage/issueops/helpers.go
@@ -14,25 +14,12 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/google/uuid"
 	"github.com/steveyegge/beads/internal/config"
 	"github.com/steveyegge/beads/internal/debug"
 	"github.com/steveyegge/beads/internal/idgen"
 	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/types"
 )
-
-// NewEventID mints the app-side primary key for an events/wisp_events row.
-// Events have no natural identity (the same logical event can legitimately
-// occur twice), so the id is random — but minted app-side, once, at creation.
-// Insert sites must never fall back to the DB-side DEFAULT (UUID()): that is
-// the 0043-era pattern that let bulk/import paths silently mint clone-random
-// keys for logically identical rows, the same failure class as #4259 on
-// dependencies (bd-6dnrw.18). UUIDv7 matches the comments-table convention
-// and keeps ids time-sortable.
-func NewEventID() string {
-	return uuid.Must(uuid.NewV7()).String()
-}
 
 // IsWisp returns true if the issue should be routed to the wisps table.
 // Routes based on flags only — not the ID pattern. The "-wisp-" ID prefix is
@@ -154,17 +141,14 @@ func insertIssueIntoTable(ctx context.Context, tx *sql.Tx, table string, issue *
 }
 
 // RecordEventInTable records an event in the specified events table.
-//
-//nolint:gosec // G201: table is a hardcoded constant ("events" or "wisp_events")
 func RecordEventInTable(ctx context.Context, tx DBTX, table, issueID string, eventType types.EventType, actor, newValue string) error {
-	_, err := tx.ExecContext(ctx, fmt.Sprintf(`
-		INSERT INTO %s (id, issue_id, event_type, actor, old_value, new_value)
-		VALUES (?, ?, ?, ?, ?, ?)
-	`, table), NewEventID(), issueID, eventType, actor, "", newValue)
-	if err != nil {
-		return fmt.Errorf("record event in %s: %w", table, err)
-	}
-	return nil
+	return InsertDerivedEvent(ctx, tx, table, AuxEvent{
+		IssueID:   issueID,
+		EventType: eventType,
+		Actor:     actor,
+		OldValue:  str(""),
+		NewValue:  str(newValue),
+	})
 }
 
 // GenerateIssueIDInTable generates a unique ID, checking for collisions

--- a/internal/storage/issueops/labels.go
+++ b/internal/storage/issueops/labels.go
@@ -153,9 +153,12 @@ func AddLabelInTx(ctx context.Context, tx DBTX, labelTable, eventTable, issueID,
 		return fmt.Errorf("add label: %w", err)
 	}
 	comment := "Added label: " + label
-	//nolint:gosec // G201: eventTable is from WispTableRouting ("events" or "wisp_events")
-	if _, err := tx.ExecContext(ctx, fmt.Sprintf(`INSERT INTO %s (id, issue_id, event_type, actor, comment) VALUES (?, ?, ?, ?, ?)`, eventTable),
-		NewEventID(), issueID, types.EventLabelAdded, actor, comment); err != nil {
+	if err := InsertDerivedEvent(ctx, tx, eventTable, AuxEvent{
+		IssueID:   issueID,
+		EventType: types.EventLabelAdded,
+		Actor:     actor,
+		Comment:   str(comment),
+	}); err != nil {
 		return fmt.Errorf("add label: record event: %w", err)
 	}
 	return nil
@@ -181,8 +184,12 @@ func RemoveLabelInTx(ctx context.Context, tx DBTX, labelTable, eventTable, issue
 		return fmt.Errorf("remove label: %w", err)
 	}
 	comment := "Removed label: " + label
-	if _, err := tx.ExecContext(ctx, fmt.Sprintf(`INSERT INTO %s (id, issue_id, event_type, actor, comment) VALUES (?, ?, ?, ?, ?)`, eventTable),
-		NewEventID(), issueID, types.EventLabelRemoved, actor, comment); err != nil {
+	if err := InsertDerivedEvent(ctx, tx, eventTable, AuxEvent{
+		IssueID:   issueID,
+		EventType: types.EventLabelRemoved,
+		Actor:     actor,
+		Comment:   str(comment),
+	}); err != nil {
 		return fmt.Errorf("remove label: record event: %w", err)
 	}
 	return nil

--- a/internal/storage/issueops/update.go
+++ b/internal/storage/issueops/update.go
@@ -547,15 +547,12 @@ func readIssueAndResolveMergeOps(ctx context.Context, tx DBTX, id string, update
 }
 
 // RecordFullEventInTable records an event with both old and new values.
-//
-//nolint:gosec // G201: table is from WispTableRouting ("events" or "wisp_events")
 func RecordFullEventInTable(ctx context.Context, tx DBTX, table, issueID string, eventType types.EventType, actor, oldValue, newValue string) error {
-	_, err := tx.ExecContext(ctx, fmt.Sprintf(`
-		INSERT INTO %s (id, issue_id, event_type, actor, old_value, new_value)
-		VALUES (?, ?, ?, ?, ?, ?)
-	`, table), NewEventID(), issueID, eventType, actor, oldValue, newValue)
-	if err != nil {
-		return fmt.Errorf("record event in %s: %w", table, err)
-	}
-	return nil
+	return InsertDerivedEvent(ctx, tx, table, AuxEvent{
+		IssueID:   issueID,
+		EventType: eventType,
+		Actor:     actor,
+		OldValue:  str(oldValue),
+		NewValue:  str(newValue),
+	})
 }

--- a/internal/storage/rowid/rowid.go
+++ b/internal/storage/rowid/rowid.go
@@ -19,12 +19,16 @@
 // to indistinguishable rows may permute, but the resulting id set is identical
 // and the rows are interchangeable, so the merged result converges anyway.
 //
-// The derivation is consumed by the one-time upgrade backfill
-// (rekeyAuxRowIDs in internal/storage/schema). Rows inserted after that
-// backfill keep their app-minted random ids (issueops.NewEventID / UUIDv7
-// comment ids; migration 0051 dropped the DB-side DEFAULT): a post-backfill
-// row is created on exactly one clone and reaches the others by merge, so its
-// id is random but consistent everywhere and needs no convergence.
+// The derivation is consumed in two places. The upgrade backfills
+// (rekeyAuxRowIDs in internal/storage/schema) converge rows that predate it:
+// the 0037-randomized legacy rows, and the UUIDv7 rows minted between that
+// first backfill and bd-ri8bd. And since bd-ri8bd, every insert derives the
+// id up front (issueops.InsertDerivedEvent and friends): merge-free
+// newest-wins replication (Protocol v0.1 §C) has no union pass to reconcile
+// independently-created identical rows, so convergence has to be a property
+// of the id itself, on every row, from birth. Migration 0051 dropped the
+// DB-side DEFAULT (UUID()) so an insert that forgets the id fails loudly
+// instead of minting a clone-random key.
 package rowid
 
 import (

--- a/internal/storage/schema/aux_row_id_backfill.go
+++ b/internal/storage/schema/aux_row_id_backfill.go
@@ -10,38 +10,58 @@ import (
 	"github.com/steveyegge/beads/internal/storage/rowid"
 )
 
-// auxRowRekeyMarkerVersion is the ignored (clone-local) migration that records
-// completion of the one-time aux-row-id re-key. The backfill runs only while
-// this version is still pending; ignoredSource.migrate then records it later
-// in the same MigrateUp pass. The cursor table is dolt-ignored, so every clone
-// performs its own convergence pass exactly once.
-const auxRowRekeyMarkerVersion = 9
+// auxRekeyPass names one clone-local convergence pass over the aux tables.
+// Each pass is gated three ways (bd-578h9): markerVersion is the ignored
+// (clone-local) migration that records the pass's completion — the rewrite
+// runs only while it is still pending, and ignoredSource.migrate records it
+// later in the same MigrateUp pass; shippedMainVersion is the main-source
+// schema version that shipped in the same release, distinguishing the
+// lineage's first pass-aware migration from a fresh clone of an
+// already-converged lineage (skip the rewrite, record the marker —
+// bd-578h9.4); sentinelKey is the clone-local in-progress sentinel
+// (local_metadata, dolt-ignored) set before the first UPDATE and cleared
+// after the last table, so a crashed pass resumes on the next MigrateUp even
+// though the main cursor already advanced past shippedMainVersion in the
+// crashed pass (bd-578h9.16).
+type auxRekeyPass struct {
+	markerVersion      int
+	shippedMainVersion int
+	sentinelKey        string
+}
 
-// auxRowRekeyShippedMainVersion is the main-source schema version that shipped
-// in the same release as the re-key pass. A database whose main cursor already
-// reached it BEFORE the current MigrateUp pass was migrated by a rekey-aware
-// binary, so its lineage has already converged — this open is a fresh clone
-// (or a post-pull adoption) whose dolt-ignored marker simply does not exist
-// locally yet. The pass is skipped there: rewriting would churn post-backfill
-// app-minted ids into a mass PK-rewrite commit from every new clone
-// (bd-578h9.4). The marker is still recorded.
-const auxRowRekeyShippedMainVersion = 51
+// auxRekeyPassInitial is the original bd-6dnrw.2 backfill: converge the
+// primary keys that migration 0037 randomized per-clone.
+var auxRekeyPassInitial = auxRekeyPass{
+	markerVersion:      9,
+	shippedMainVersion: 51,
+	sentinelKey:        "aux_row_rekey_in_progress",
+}
 
-// auxRowRekeyInProgressKey is the clone-local sentinel (local_metadata,
-// dolt-ignored) set before the re-key's first UPDATE and cleared after the
-// last table completes. A crashed pass leaves it set, and the next MigrateUp
-// resumes the re-key even though the main cursor already advanced past
-// auxRowRekeyShippedMainVersion in the crashed pass — without it the
-// fresh-clone skip above reads the crashed lineage as already converged and
-// strands the partially re-keyed rows forever (bd-578h9.16).
-const auxRowRekeyInProgressKey = "aux_row_rekey_in_progress"
+// auxRekeyPassDerivedInsert is the bd-ri8bd catch-up: between the initial
+// backfill and the switch to content-derived ids at insert time
+// (issueops.InsertDerivedEvent and friends), new rows minted random UUIDv7
+// keys. Those are minted-once-then-merged (consistent across clones), which
+// was fine under the versioned union merge, but the unversioned newest-wins
+// replication of Protocol v0.1 §C converges only rows whose ids are functions
+// of their content — so this pass re-derives the interim rows once. It reuses
+// the initial pass's rewrite verbatim (the derivation is unchanged and
+// idempotent: rows already holding a derived id keep it).
+var auxRekeyPassDerivedInsert = auxRekeyPass{
+	markerVersion:      18,
+	shippedMainVersion: 61,
+	sentinelKey:        "aux_row_rekey2_in_progress",
+}
 
-// auxRekeyResumePending reports whether a previous re-key pass on this clone
-// recorded the in-progress sentinel and never cleared it. A missing
+// auxRekeyPasses lists every convergence pass, in the order MigrateUp runs
+// them.
+var auxRekeyPasses = []auxRekeyPass{auxRekeyPassInitial, auxRekeyPassDerivedInsert}
+
+// auxRekeyResumePending reports whether a previous run of this re-key pass on
+// this clone recorded the in-progress sentinel and never cleared it. A missing
 // local_metadata table means no sentinel: the table is dolt-ignored and
 // therefore clone-local, so a fresh clone lacks it until something recreates
 // it — setAuxRekeyInProgress creates it on demand.
-func auxRekeyResumePending(ctx context.Context, db DBConn) (bool, error) {
+func auxRekeyResumePending(ctx context.Context, db DBConn, sentinelKey string) (bool, error) {
 	var tableCount int
 	if err := db.QueryRowContext(ctx,
 		`SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES
@@ -55,13 +75,43 @@ func auxRekeyResumePending(ctx context.Context, db DBConn) (bool, error) {
 	var n int
 	if err := db.QueryRowContext(ctx,
 		"SELECT COUNT(*) FROM local_metadata WHERE `key` = ?",
-		auxRowRekeyInProgressKey).Scan(&n); err != nil {
+		sentinelKey).Scan(&n); err != nil {
 		return false, err
 	}
 	return n > 0, nil
 }
 
-func setAuxRekeyInProgress(ctx context.Context, db DBConn) error {
+// anyAuxRekeyResumePending reports whether ANY pass's crash sentinel is still
+// recorded, with one table probe and at most one row query regardless of how
+// many passes exist — it feeds MigrateUp's dirty-table exemption, which only
+// needs to know that some rekey rewrite is about to resume.
+func anyAuxRekeyResumePending(ctx context.Context, db DBConn) (bool, error) {
+	var tableCount int
+	if err := db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES
+		 WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'local_metadata'`,
+	).Scan(&tableCount); err != nil {
+		return false, err
+	}
+	if tableCount == 0 {
+		return false, nil
+	}
+	placeholders := make([]string, len(auxRekeyPasses))
+	keys := make([]any, len(auxRekeyPasses))
+	for i, pass := range auxRekeyPasses {
+		placeholders[i] = "?"
+		keys[i] = pass.sentinelKey
+	}
+	var n int
+	if err := db.QueryRowContext(ctx,
+		fmt.Sprintf("SELECT COUNT(*) FROM local_metadata WHERE `key` IN (%s)", strings.Join(placeholders, ", ")),
+		keys...).Scan(&n); err != nil {
+		return false, err
+	}
+	return n > 0, nil
+}
+
+func setAuxRekeyInProgress(ctx context.Context, db DBConn, sentinelKey string) error {
 	// local_metadata is dolt-ignored, hence clone-local: a fresh clone whose
 	// main cursor is already past 0029 does not have the table (the migration
 	// will not re-run) until EnsureIgnoredTables recreates it. Create it here
@@ -72,14 +122,14 @@ func setAuxRekeyInProgress(ctx context.Context, db DBConn) error {
 	}
 	_, err := db.ExecContext(ctx,
 		"REPLACE INTO local_metadata (`key`, value) VALUES (?, '1')",
-		auxRowRekeyInProgressKey)
+		sentinelKey)
 	return err
 }
 
-func clearAuxRekeyInProgress(ctx context.Context, db DBConn) error {
+func clearAuxRekeyInProgress(ctx context.Context, db DBConn, sentinelKey string) error {
 	_, err := db.ExecContext(ctx,
 		"DELETE FROM local_metadata WHERE `key` = ?",
-		auxRowRekeyInProgressKey)
+		sentinelKey)
 	return err
 }
 
@@ -99,9 +149,11 @@ type auxRekeyTable struct {
 }
 
 // auxRekeyTables covers the four synced tables whose 0037 backfill randomized
-// primary keys across clones. The wisp_ twins (wisp_events, wisp_comments) are
-// deliberately excluded: they are dolt-ignored, never merged, and promotion
-// copies their rows without ids, so their random keys never escape the clone.
+// primary keys across clones. The wisp_ twins (wisp_events, wisp_comments)
+// are deliberately excluded: they are dolt-ignored and never merged, so a
+// wisp row's id only matters once promotion copies the row (id and all) into
+// the synced table — where it is minted-once-then-replicated, i.e. random but
+// consistent everywhere, exactly like any other single-origin row.
 var auxRekeyTables = []auxRekeyTable{
 	{
 		name:    "events",
@@ -139,14 +191,36 @@ var auxRekeyTables = []auxRekeyTable{
 // mainVersionBefore is the main-source cursor as it stood before this pass's
 // migrations ran; at or past auxRowRekeyShippedMainVersion the rewrite is
 // skipped (see that constant).
-func rekeyAuxRowIDs(ctx context.Context, db DBConn, mainVersionBefore int) (bool, error) {
+func rekeyAuxRowIDs(ctx context.Context, db DBConn, mainVersionBefore int, pass auxRekeyPass) (bool, error) {
 	pending, err := ignoredSource.pendingVersions(ctx, db)
 	if err != nil {
 		return false, fmt.Errorf("reading pending ignored migrations: %w", err)
 	}
+	return rekeyAuxRowIDsPending(ctx, db, mainVersionBefore, pass, pending)
+}
+
+// rekeyAuxRowIDsAllPasses runs every convergence pass off a single read of
+// the ignored cursor.
+func rekeyAuxRowIDsAllPasses(ctx context.Context, db DBConn, mainVersionBefore int) (bool, error) {
+	pending, err := ignoredSource.pendingVersions(ctx, db)
+	if err != nil {
+		return false, fmt.Errorf("reading pending ignored migrations: %w", err)
+	}
+	wrote := false
+	for _, pass := range auxRekeyPasses {
+		w, err := rekeyAuxRowIDsPending(ctx, db, mainVersionBefore, pass, pending)
+		wrote = wrote || w
+		if err != nil {
+			return wrote, err
+		}
+	}
+	return wrote, nil
+}
+
+func rekeyAuxRowIDsPending(ctx context.Context, db DBConn, mainVersionBefore int, pass auxRekeyPass, pending []int) (bool, error) {
 	markerPending := false
 	for _, v := range pending {
-		if v == auxRowRekeyMarkerVersion {
+		if v == pass.markerVersion {
 			markerPending = true
 			break
 		}
@@ -154,7 +228,7 @@ func rekeyAuxRowIDs(ctx context.Context, db DBConn, mainVersionBefore int) (bool
 	if !markerPending {
 		return false, nil
 	}
-	resume, err := auxRekeyResumePending(ctx, db)
+	resume, err := auxRekeyResumePending(ctx, db, pass.sentinelKey)
 	if err != nil {
 		return false, fmt.Errorf("reading aux rekey sentinel: %w", err)
 	}
@@ -162,14 +236,14 @@ func rekeyAuxRowIDs(ctx context.Context, db DBConn, mainVersionBefore int) (bool
 	// crashed mid-rekey: that pass already advanced the main cursor past the
 	// shipped version, but its sentinel proves the rewrite never finished
 	// (bd-578h9.16).
-	if mainVersionBefore >= auxRowRekeyShippedMainVersion && !resume {
+	if mainVersionBefore >= pass.shippedMainVersion && !resume {
 		return false, nil
 	}
 
 	// Sentinel before the first UPDATE: a crash anywhere in the rewrite
 	// leaves it set, so the next pass resumes (the rewrite is idempotent)
 	// instead of recording the marker over partially re-keyed rows.
-	if err := setAuxRekeyInProgress(ctx, db); err != nil {
+	if err := setAuxRekeyInProgress(ctx, db, pass.sentinelKey); err != nil {
 		return false, fmt.Errorf("recording aux rekey sentinel: %w", err)
 	}
 
@@ -181,7 +255,7 @@ func rekeyAuxRowIDs(ctx context.Context, db DBConn, mainVersionBefore int) (bool
 			return wrote, fmt.Errorf("%s: %w", t.name, err)
 		}
 	}
-	if err := clearAuxRekeyInProgress(ctx, db); err != nil {
+	if err := clearAuxRekeyInProgress(ctx, db, pass.sentinelKey); err != nil {
 		return wrote, fmt.Errorf("clearing aux rekey sentinel: %w", err)
 	}
 	return wrote, nil

--- a/internal/storage/schema/aux_row_id_backfill_test.go
+++ b/internal/storage/schema/aux_row_id_backfill_test.go
@@ -200,10 +200,10 @@ func TestRekeyAuxRowIDsSkipsWhenMarkerRecorded(t *testing.T) {
 	defer db.Close()
 
 	expectScalar(mock, "SELECT COALESCE(MAX(version), 0) FROM ignored_schema_migrations",
-		"version", auxRowRekeyMarkerVersion)
+		"version", auxRekeyPassInitial.markerVersion)
 	// No further expectations: no table may be probed or scanned.
 
-	wrote, err := rekeyAuxRowIDs(context.Background(), db, auxRowRekeyShippedMainVersion-1)
+	wrote, err := rekeyAuxRowIDs(context.Background(), db, auxRekeyPassInitial.shippedMainVersion-1, auxRekeyPassInitial)
 	if err != nil {
 		t.Fatalf("rekeyAuxRowIDs: %v", err)
 	}
@@ -225,7 +225,7 @@ func TestRekeyAuxRowIDsRunsAllTablesWhenMarkerPending(t *testing.T) {
 	defer db.Close()
 
 	expectScalar(mock, "SELECT COALESCE(MAX(version), 0) FROM ignored_schema_migrations",
-		"version", auxRowRekeyMarkerVersion-1)
+		"version", auxRekeyPassInitial.markerVersion-1)
 	expectAuxRekeySentinel(mock, false)
 	expectSetAuxRekeySentinel(mock)
 	// Each of the four tables is probed; this mocked world has none of them,
@@ -235,7 +235,7 @@ func TestRekeyAuxRowIDsRunsAllTablesWhenMarkerPending(t *testing.T) {
 	}
 	expectClearAuxRekeySentinel(mock)
 
-	wrote, err := rekeyAuxRowIDs(context.Background(), db, auxRowRekeyShippedMainVersion-1)
+	wrote, err := rekeyAuxRowIDs(context.Background(), db, auxRekeyPassInitial.shippedMainVersion-1, auxRekeyPassInitial)
 	if err != nil {
 		t.Fatalf("rekeyAuxRowIDs: %v", err)
 	}
@@ -257,7 +257,7 @@ func expectAuxRekeySentinel(mock sqlmock.Sqlmock, pending bool) {
 		n = 1
 	}
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT COUNT(*) FROM local_metadata WHERE `key` = ?")).
-		WithArgs(auxRowRekeyInProgressKey).
+		WithArgs(auxRekeyPassInitial.sentinelKey).
 		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(n))
 }
 
@@ -267,13 +267,13 @@ func expectSetAuxRekeySentinel(mock sqlmock.Sqlmock) {
 	mock.ExpectExec(`CREATE TABLE IF NOT EXISTS local_metadata`).
 		WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectExec(regexp.QuoteMeta("REPLACE INTO local_metadata (`key`, value) VALUES (?, '1')")).
-		WithArgs(auxRowRekeyInProgressKey).
+		WithArgs(auxRekeyPassInitial.sentinelKey).
 		WillReturnResult(sqlmock.NewResult(0, 1))
 }
 
 func expectClearAuxRekeySentinel(mock sqlmock.Sqlmock) {
 	mock.ExpectExec(regexp.QuoteMeta("DELETE FROM local_metadata WHERE `key` = ?")).
-		WithArgs(auxRowRekeyInProgressKey).
+		WithArgs(auxRekeyPassInitial.sentinelKey).
 		WillReturnResult(sqlmock.NewResult(0, 1))
 }
 
@@ -290,13 +290,13 @@ func TestRekeyAuxRowIDsSkipsConvergedLineage(t *testing.T) {
 	defer db.Close()
 
 	expectScalar(mock, "SELECT COALESCE(MAX(version), 0) FROM ignored_schema_migrations",
-		"version", auxRowRekeyMarkerVersion-1)
+		"version", auxRekeyPassInitial.markerVersion-1)
 	expectAuxRekeySentinel(mock, false)
 	// No further expectations: marker is pending, but the pre-pass main
 	// cursor at the watershed and no crash sentinel means no table may be
 	// probed or scanned.
 
-	wrote, err := rekeyAuxRowIDs(context.Background(), db, auxRowRekeyShippedMainVersion)
+	wrote, err := rekeyAuxRowIDs(context.Background(), db, auxRekeyPassInitial.shippedMainVersion, auxRekeyPassInitial)
 	if err != nil {
 		t.Fatalf("rekeyAuxRowIDs: %v", err)
 	}
@@ -322,7 +322,7 @@ func TestRekeyAuxRowIDsResumesAfterCrash(t *testing.T) {
 	defer db.Close()
 
 	expectScalar(mock, "SELECT COALESCE(MAX(version), 0) FROM ignored_schema_migrations",
-		"version", auxRowRekeyMarkerVersion-1)
+		"version", auxRekeyPassInitial.markerVersion-1)
 	expectAuxRekeySentinel(mock, true)
 	expectSetAuxRekeySentinel(mock)
 	for range auxRekeyTables {
@@ -332,7 +332,7 @@ func TestRekeyAuxRowIDsResumesAfterCrash(t *testing.T) {
 
 	// Pre-pass cursor at the watershed — the crashed pass already migrated
 	// main — yet the rewrite must run because the sentinel is pending.
-	if _, err := rekeyAuxRowIDs(context.Background(), db, auxRowRekeyShippedMainVersion); err != nil {
+	if _, err := rekeyAuxRowIDs(context.Background(), db, auxRekeyPassInitial.shippedMainVersion, auxRekeyPassInitial); err != nil {
 		t.Fatalf("rekeyAuxRowIDs: %v", err)
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
@@ -351,14 +351,14 @@ func TestRekeyAuxRowIDsKeepsSentinelOnFailure(t *testing.T) {
 	defer db.Close()
 
 	expectScalar(mock, "SELECT COALESCE(MAX(version), 0) FROM ignored_schema_migrations",
-		"version", auxRowRekeyMarkerVersion-1)
+		"version", auxRekeyPassInitial.markerVersion-1)
 	expectAuxRekeySentinel(mock, false)
 	expectSetAuxRekeySentinel(mock)
 	// First table probe fails; no DELETE of the sentinel may follow.
 	mock.ExpectQuery(`SELECT COUNT\(\*\) FROM INFORMATION_SCHEMA\.COLUMNS`).
 		WillReturnError(errors.New("boom"))
 
-	if _, err := rekeyAuxRowIDs(context.Background(), db, auxRowRekeyShippedMainVersion-1); err == nil {
+	if _, err := rekeyAuxRowIDs(context.Background(), db, auxRekeyPassInitial.shippedMainVersion-1, auxRekeyPassInitial); err == nil {
 		t.Fatal("expected the table failure to propagate")
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {

--- a/internal/storage/schema/lock_test.go
+++ b/internal/storage/schema/lock_test.go
@@ -320,7 +320,10 @@ func expectDirtyGuardRefusal(t *testing.T, mock sqlmock.Sqlmock) {
 
 	expectIgnorePatternSeedNoop(mock)
 	// migrationWorkNeeded: main cursor behind -> work needed (short-circuits).
-	expectScalar(mock, "SELECT COALESCE(MAX(version), 0) FROM schema_migrations", "version", latest-1)
+	// Two behind, not one: 0061 is a pure version anchor (SELECT 1, touches no
+	// table), so the guard shape needs 0060 — which alters `issues` — among
+	// the pending migrations.
+	expectScalar(mock, "SELECT COALESCE(MAX(version), 0) FROM schema_migrations", "version", latest-2)
 	// dirtyBeforeAll: `issues` dirty (working set only, not staged).
 	expectDoltStatusDirtyIssues(mock)
 	// Nothing staged -> no unstage exec; seed was a no-op -> no seed commit.
@@ -329,9 +332,9 @@ func expectDirtyGuardRefusal(t *testing.T, mock sqlmock.Sqlmock) {
 	// auxRekeyResumePending: no local_metadata table, no crashed rekey pass.
 	mock.ExpectQuery(`SELECT COUNT\(\*\) FROM INFORMATION_SCHEMA\.TABLES`).
 		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
-	// pendingMigrationDirtyTables: cursor read, then the pending latest
-	// migration's SQL touches `issues` -> DirtyTablesError.
-	expectScalar(mock, "SELECT COALESCE(MAX(version), 0) FROM schema_migrations", "version", latest-1)
+	// pendingMigrationDirtyTables: cursor read, then pending 0060's SQL
+	// touches `issues` -> DirtyTablesError.
+	expectScalar(mock, "SELECT COALESCE(MAX(version), 0) FROM schema_migrations", "version", latest-2)
 }
 
 func expectDoltStatusDirtyIssues(mock sqlmock.Sqlmock) {

--- a/internal/storage/schema/migrations/0061_content_derived_aux_ids.up.sql
+++ b/internal/storage/schema/migrations/0061_content_derived_aux_ids.up.sql
@@ -1,0 +1,15 @@
+-- Version anchor for the switch to content-derived aux-row ids at insert
+-- time (bd-ri8bd, Protocol v0.1 C-OQ3). No schema change: the aux tables'
+-- id columns stay CHAR(36) (they now hold RFC-4122 v5 UUIDs derived from row
+-- content — internal/storage/rowid — instead of random UUIDv7s).
+--
+-- The anchor exists for the second re-key pass's fresh-clone gate
+-- (auxRekeyPassDerivedInsert in internal/storage/schema): a lineage whose
+-- main cursor reached this version was migrated by a binary that already
+-- derives ids at insert AND has run the catch-up re-key of the interim
+-- random-id rows, so a fresh clone of it records the clone-local marker
+-- (ignored 0018) without re-running the rewrite. Anchoring to a real main
+-- version — rather than to the neighboring 0060 — matters: a lineage at 0060
+-- may still hold un-converged UUIDv7 rows, and a clone that skipped the pass
+-- there would diverge from its origin's later convergence.
+SELECT 1;

--- a/internal/storage/schema/migrations/ignored/0018_aux_row_id_rekey2_marker.up.sql
+++ b/internal/storage/schema/migrations/ignored/0018_aux_row_id_rekey2_marker.up.sql
@@ -1,0 +1,23 @@
+-- Ignored migration 0018: clone-local marker for the second aux-row-id
+-- re-key pass (bd-ri8bd, Protocol v0.1 C-OQ3).
+--
+-- The initial backfill (ignored 0009) converged the primary keys that
+-- migration 0037 randomized, but rows inserted AFTER that backfill kept
+-- app-minted random UUIDv7 ids — minted once and spread by merge, which was
+-- consistent under the versioned union merge. Unversioned newest-wins
+-- replication (Protocol v0.1 §C) has no merge to union through: only ids that
+-- are functions of row content converge. This release therefore switched the
+-- insert paths to the deterministic content-derived derivation
+-- (issueops.InsertDerivedEvent / InsertDerivedComment /
+-- InsertDerivedCompactionSnapshot), and while this version is still pending,
+-- MigrateUp runs the re-key once more to converge the interim random-id rows.
+-- The rewrite is the same idempotent derivation as 0009's: rows already
+-- holding their content-derived id keep it.
+--
+-- The cursor table is dolt-ignored, so the marker is clone-local — every
+-- clone performs its own convergence pass exactly once, which is safe
+-- precisely because the derivation is deterministic (and therefore does not
+-- need the V2 designated-migrator exclusivity).
+--
+-- The marker itself changes nothing.
+SELECT 1;

--- a/internal/storage/schema/schema.go
+++ b/internal/storage/schema/schema.go
@@ -459,7 +459,7 @@ func MigrateUp(ctx context.Context, db DBConn) (int, error) {
 	// pre-existing user writes: dropping them from dirtyBefore exempts them
 	// from the changed-signature guard (the resumed rekey is about to change
 	// them) and lets stageSchemaTables commit them with the rest of the pass.
-	if resuming, err := auxRekeyResumePending(ctx, db); err != nil {
+	if resuming, err := anyAuxRekeyResumePending(ctx, db); err != nil {
 		return 0, fmt.Errorf("reading aux rekey sentinel: %w", err)
 	} else if resuming {
 		for _, t := range auxRekeyTables {
@@ -514,7 +514,11 @@ func MigrateUp(ctx context.Context, db DBConn) (int, error) {
 	// of churning synced rows on every later migration pass — and on the
 	// pre-pass main cursor, so fresh clones of converged lineages record the
 	// marker without re-running the rewrite (bd-578h9.4).
-	auxRekeyed, err := rekeyAuxRowIDs(ctx, db, mainVersionBefore)
+	// ...and the bd-ri8bd sibling: one more pass over the same tables for the
+	// rows minted with random UUIDv7 ids between the initial backfill and the
+	// switch to content-derived ids at insert time. Same machinery, own
+	// marker/sentinel/shipped-version gates, one shared cursor read.
+	auxRekeyed, err := rekeyAuxRowIDsAllPasses(ctx, db, mainVersionBefore)
 	if err != nil {
 		return applied, fmt.Errorf("rekey aux row ids: %w", err)
 	}


### PR DESCRIPTION
## Summary

Resolves Protocol v0.1 **C-OQ3** (bd-ri8bd): unversioned newest-wins replication has no merge pass to reconcile independently-created identical rows, so convergence must be a property of the primary key itself. This PR makes every `events`/`comments`/`compaction_snapshots` insert derive its id from row content, using the exact derivation the bd-6dnrw.2 aux-row backfill already shipped (`internal/storage/rowid`, frozen digest column lists), and runs one catch-up rekey for the interim UUIDv7 rows.

**Stacked on #5149** (its migration 0060 sits under this PR's 0061 anchor); retarget to `main` after #5149 merges.

Protocol acks: hopper (wyvern side of the v0.2 storage-classes review), mail m-1785313459-1237 — cross-replica collapse anchored to C2.3, second-resolution `created_at` frozen, catch-up-rekey shape endorsed. Design record on bd-ri8bd.

## What changed

- **`issueops/derivedid.go` (new)** — the single derivation point. `InsertDerivedEvent` (smallest-free-ordinal over same-content rows: local multiplicity preserved, cross-replica byte-identical rows deliberately collapse — the C2.3 set-union reading, and byte-for-byte what the versioned automerge union rule already produces), `InsertDerivedComment` (collapses onto an identical existing row, the import path's historical existence-check semantics), `InsertDerivedCompactionSnapshot`. `created_at` is stamped app-side and bound as the digested `DATETIME(0)` string, so the stored cell is byte-for-byte what was digested. The single-writer-per-replica ordinal assumption is documented (hopper's non-blocking flag).
- **All 16 mint sites converted**; `NewEventID` deleted (the "events have no natural identity, random is fine" premise it documented is exactly what C-OQ3 overturns). Import paths still honor incoming comment ids. Wisp-plane and promotion-carried ids stay minted-once by design (clone-local; random-but-consistent).
- **Catch-up rekey** — the backfill machinery generalized over (marker, shipped-version, sentinel) and run a second time: ignored marker `0018`, in-progress sentinel `aux_row_rekey2_in_progress`, anchored on main `0061`. The anchor must be its own version: a 0060-era lineage can still hold unconverged UUIDv7 rows, and a fresh clone skipping the pass there would diverge from its origin's later convergence. Clone-local and deliberately not migrator-exclusive — deterministic derivation is what makes that safe (V2 designated-migrator compatible, same reasoning as the first pass).
- **Tests** — equivalence test recomputes digests from server-rendered stored values and asserts every row minted by the real store paths sits on its backfill-convergent id (catches datetime-format or NULL-encoding drift at test time, not in a fleet merge); ordinal-preservation and comment-collapse contracts; existing rekey suite re-pointed at the generalized pass.

## Notes for review

- Keyset paging keeps its stable-total-order contract; the same-second tie-break becomes hash order (UUIDv7 time-locality loss noted-acceptable in the protocol review).
- Same-id automerge conflicts are now exactly the identical-content case, i.e. always auto-resolvable.
- Docs deferred to the cli-docs.pin bump per policy (#5052/#5089 precedent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)