### PR TITLE
feat(storage): flip the events audit table to the dolt_ignored/unversioned plane (bd-red8u)

### DIFF
--- a/cmd/bd/create_embedded_test.go
+++ b/cmd/bd/create_embedded_test.go
@@ -1003,9 +1003,11 @@ A new feature
 			t.Fatalf("label count = %d, want 2", labelCount)
 		}
 
+		// events is dolt_ignored since 0062 (bd-red8u): audit rows are durable
+		// in the working set, never at HEAD.
 		var labelEventCount int
 		if err := db.QueryRowContext(t.Context(),
-			"SELECT COUNT(*) FROM events AS OF 'HEAD' WHERE issue_id = ? AND event_type = ?",
+			"SELECT COUNT(*) FROM events WHERE issue_id = ? AND event_type = ?",
 			id, types.EventLabelAdded).Scan(&labelEventCount); err != nil {
 			t.Fatalf("count label events: %v", err)
 		}

--- a/cmd/bd/doctor/dolt.go
+++ b/cmd/bd/doctor/dolt.go
@@ -289,7 +289,7 @@ func checkSchemaWithDB(conn *doltConn) DoctorCheck {
 	// Check dolt_ignore'd tables — these only exist in the working set and
 	// must be recreated each server session. (GH#2271)
 	ignoredTables := []string{
-		"leases", "local_metadata", "repo_mtimes",
+		"events", "leases", "local_metadata", "repo_mtimes",
 		"wisps", "wisp_labels", "wisp_dependencies", "wisp_events", "wisp_comments",
 	}
 	var missingIgnoredTables []string
@@ -412,7 +412,7 @@ func CheckDoltIssueCount(path string) DoctorCheck {
 // produces self-fulfilling warnings that can never be cleared.
 func isIgnoredTable(tableName string) bool {
 	switch tableName {
-	case "wisps", "leases", "local_metadata", "repo_mtimes":
+	case "wisps", "leases", "local_metadata", "repo_mtimes", "events":
 		return true
 	}
 	return strings.HasPrefix(tableName, "wisp_")

--- a/internal/storage/dolt/aux_row_id_rekey_test.go
+++ b/internal/storage/dolt/aux_row_id_rekey_test.go
@@ -65,6 +65,14 @@ func seedAuxRekeyFixture(ctx context.Context, t *testing.T, db *sql.DB, clonePre
 		t.Fatalf("regress main cursor: %v", err)
 	}
 
+	// A real pre-rekey lineage predates the 0062 events flip, so its events
+	// rows are committed. The shared test database carries the post-flip
+	// dolt_ignore pattern (with events deliberately materialized at HEAD for
+	// branch inheritance), so '-Am' would silently skip events and leave the
+	// seed dirty — stage it explicitly with '-f' to match the simulated state.
+	if _, err := db.ExecContext(ctx, "CALL DOLT_ADD('-f', 'events')"); err != nil {
+		t.Fatalf("stage events seed: %v", err)
+	}
 	if _, err := db.ExecContext(ctx, "CALL DOLT_COMMIT('-Am', 'seed pre-rekey rows')"); err != nil {
 		t.Fatalf("commit seed: %v", err)
 	}

--- a/internal/storage/dolt/create_issue_commit_test.go
+++ b/internal/storage/dolt/create_issue_commit_test.go
@@ -59,15 +59,23 @@ func TestCreateIssueCommitsInitialRelationalData(t *testing.T) {
 		t.Fatalf("committed comment count = %d, want 1", commentCount)
 	}
 
+	// events is dolt_ignored since migration 0062 (bd-red8u): the audit rows
+	// must be durable in the working set but never part of committed history.
 	var labelEventCount int
 	if err := store.db.QueryRowContext(ctx,
-		"SELECT COUNT(*) FROM events AS OF 'HEAD' WHERE issue_id = ? AND event_type = ?",
+		"SELECT COUNT(*) FROM events WHERE issue_id = ? AND event_type = ?",
 		issue.ID, types.EventLabelAdded,
 	).Scan(&labelEventCount); err != nil {
-		t.Fatalf("count committed label events: %v", err)
+		t.Fatalf("count label events: %v", err)
 	}
 	if labelEventCount != 2 {
-		t.Fatalf("committed label_added event count = %d, want 2", labelEventCount)
+		t.Fatalf("label_added event count = %d, want 2", labelEventCount)
+	}
+	var committedEventCount int
+	if err := store.db.QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM events AS OF 'HEAD'",
+	).Scan(&committedEventCount); err == nil {
+		t.Fatalf("events exists at HEAD with %d rows; want the table absent from committed history (dolt_ignored, 0062)", committedEventCount)
 	}
 
 	var dirtyRelationalTables int

--- a/internal/storage/dolt/create_issue_commit_test.go
+++ b/internal/storage/dolt/create_issue_commit_test.go
@@ -74,14 +74,17 @@ func TestCreateIssueCommitsInitialRelationalData(t *testing.T) {
 	var committedEventCount int
 	if err := store.db.QueryRowContext(ctx,
 		"SELECT COUNT(*) FROM events AS OF 'HEAD'",
-	).Scan(&committedEventCount); err == nil {
-		t.Fatalf("events exists at HEAD with %d rows; want the table absent from committed history (dolt_ignored, 0062)", committedEventCount)
+	).Scan(&committedEventCount); err == nil && committedEventCount != 0 {
+		t.Fatalf("events has %d rows at HEAD; want none in committed history (dolt_ignored, 0062)", committedEventCount)
 	}
 
+	// events is excluded: it is permanently working-set-resident since 0062,
+	// and on the shared branch-per-test database (events materialized at HEAD)
+	// its audit rows legitimately show in dolt_status as a modification.
 	var dirtyRelationalTables int
 	if err := store.db.QueryRowContext(ctx, `
 		SELECT COUNT(*) FROM dolt_status
-		WHERE table_name IN ('labels', 'comments', 'events')
+		WHERE table_name IN ('labels', 'comments')
 	`).Scan(&dirtyRelationalTables); err != nil {
 		t.Fatalf("count dirty relational tables: %v", err)
 	}

--- a/internal/storage/dolt/dependency_events_test.go
+++ b/internal/storage/dolt/dependency_events_test.go
@@ -38,8 +38,8 @@ func newValueOf(t *testing.T, e *types.Event) string {
 // TestDependencyEventEmission ports the SQLite-era dependency_added /
 // dependency_removed event emission onto the Dolt engine: a real add or remove
 // records a descriptive event on the source's event table, an idempotent re-add
-// does not double-emit, and the added event is DOLT_COMMITted (staged), not left
-// dangling in the working set.
+// does not double-emit, and the added event is durable in the working set —
+// events is dolt_ignored since 0062, so audit rows never ride a DOLT_COMMIT.
 func TestDependencyEventEmission(t *testing.T) {
 	store, cleanup := setupTestStore(t)
 	defer cleanup()
@@ -72,7 +72,7 @@ func TestDependencyEventEmission(t *testing.T) {
 		}
 	})
 
-	t.Run("AddCommitsEventRow", func(t *testing.T) {
+	t.Run("AddRecordsEventRowOffTheCommitPlane", func(t *testing.T) {
 		src, tgt := "de-commit-a", "de-commit-b"
 		createPerm(t, ctx, store, src)
 		createPerm(t, ctx, store, tgt)
@@ -82,20 +82,21 @@ func TestDependencyEventEmission(t *testing.T) {
 			t.Fatalf("AddDependency: %v", err)
 		}
 
-		// AS OF 'HEAD' reads the committed tree only: a non-zero count proves the
-		// event row was staged and committed, not merely written to the working set.
-		var committed int
+		// events is dolt_ignored since 0062 (bd-red8u): the audit row is durable
+		// in the working set, never part of committed history.
+		var recorded int
 		if err := store.db.QueryRowContext(ctx,
-			"SELECT COUNT(*) FROM events AS OF 'HEAD' WHERE issue_id = ? AND event_type = ?",
+			"SELECT COUNT(*) FROM events WHERE issue_id = ? AND event_type = ?",
 			src, string(types.EventDependencyAdded),
-		).Scan(&committed); err != nil {
-			t.Fatalf("count committed dependency_added events: %v", err)
+		).Scan(&recorded); err != nil {
+			t.Fatalf("count dependency_added events: %v", err)
 		}
-		if committed != 1 {
-			t.Fatalf("committed dependency_added count = %d, want 1 (events must be staged before DOLT_COMMIT)", committed)
+		if recorded != 1 {
+			t.Fatalf("dependency_added count = %d, want 1", recorded)
 		}
-		// The events table must be clean afterward — the row is in the commit, not
-		// left dirty in the working set where a later DOLT_RESET could drop it.
+		assertEventsNotCommitted(ctx, t, store.db)
+		// The ignored plane suppresses events from dolt_status entirely, so the
+		// commit path never sees it as dirty.
 		var dirtyEvents int
 		if err := store.db.QueryRowContext(ctx,
 			"SELECT COUNT(*) FROM dolt_status WHERE table_name = 'events'",
@@ -103,7 +104,7 @@ func TestDependencyEventEmission(t *testing.T) {
 			t.Fatalf("query dolt_status for events: %v", err)
 		}
 		if dirtyEvents != 0 {
-			t.Fatalf("events table dirty after AddDependency (count=%d); staging is not committing the event", dirtyEvents)
+			t.Fatalf("events table visible in dolt_status (count=%d); the ignored plane must suppress it", dirtyEvents)
 		}
 	})
 
@@ -131,17 +132,8 @@ func TestDependencyEventEmission(t *testing.T) {
 		if got, want := newValueOf(t, removed[0]), "Removed dependency on de-rm-b"; got != want {
 			t.Fatalf("dependency_removed new_value = %q, want %q", got, want)
 		}
-		// The removed event is committed too.
-		var committed int
-		if err := store.db.QueryRowContext(ctx,
-			"SELECT COUNT(*) FROM events AS OF 'HEAD' WHERE issue_id = ? AND event_type = ?",
-			src, string(types.EventDependencyRemoved),
-		).Scan(&committed); err != nil {
-			t.Fatalf("count committed dependency_removed events: %v", err)
-		}
-		if committed != 1 {
-			t.Fatalf("committed dependency_removed count = %d, want 1", committed)
-		}
+		// The removed event is recorded on the same (ignored) plane.
+		assertRecordedEventCount(ctx, t, store.db, src, types.EventDependencyRemoved, 1)
 	})
 
 	t.Run("RemoveMissingEdgeEmitsNothing", func(t *testing.T) {
@@ -184,7 +176,7 @@ func TestDependencyEventEmission(t *testing.T) {
 		if n := len(depEventsOfType(t, ctx, store, src, types.EventDependencyRemoved)); n != 0 {
 			t.Fatalf("structural remove must not emit dependency_removed, got %d", n)
 		}
-		assertCommittedEventCount(ctx, t, store.db, src, types.EventDependencyRemoved, 0)
+		assertRecordedEventCount(ctx, t, store.db, src, types.EventDependencyRemoved, 0)
 	})
 
 	t.Run("IdempotentReAddDoesNotDoubleEmit", func(t *testing.T) {
@@ -259,14 +251,14 @@ func TestRunInTransactionAddRemoveDependencyCommitsEvents(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("RunInTransaction AddDependency: %v", err)
 	}
-	assertCommittedEventCount(ctx, t, store.db, src, types.EventDependencyAdded, 1)
+	assertRecordedEventCount(ctx, t, store.db, src, types.EventDependencyAdded, 1)
 
 	if err := store.RunInTransaction(ctx, "test: tx remove dependency emits event", func(tx storage.Transaction) error {
 		return tx.RemoveDependencyWithOptions(ctx, src, tgt, "remover", storage.DependencyRemoveOptions{EmitEvent: true})
 	}); err != nil {
 		t.Fatalf("RunInTransaction RemoveDependency: %v", err)
 	}
-	assertCommittedEventCount(ctx, t, store.db, src, types.EventDependencyRemoved, 1)
+	assertRecordedEventCount(ctx, t, store.db, src, types.EventDependencyRemoved, 1)
 }
 
 // TestCreateTimeTxAddDependencyDoesNotEmit proves the create-with-deps path —
@@ -306,7 +298,7 @@ func TestCreateTimeTxAddDependencyDoesNotEmit(t *testing.T) {
 	if n := len(depEventsOfType(t, ctx, store, child, types.EventDependencyAdded)); n != 0 {
 		t.Fatalf("create-time parent-child edge must not emit dependency_added, got %d", n)
 	}
-	assertCommittedEventCount(ctx, t, store.db, child, types.EventDependencyAdded, 0)
+	assertRecordedEventCount(ctx, t, store.db, child, types.EventDependencyAdded, 0)
 }
 
 // TestRunInTransactionWispSourceDependencyRoutesToWispEvents proves the tx-path
@@ -389,14 +381,19 @@ func TestNoEventDependencyOpsDoNotSweepDirtyEvents(t *testing.T) {
 	}
 	assertUncommitted := func(t *testing.T, strayID string) {
 		t.Helper()
-		var committed int
+		// events is dolt_ignored since 0062 (bd-red8u): absence of the whole
+		// table from HEAD subsumes the original per-row sweep check — no
+		// dependency op can commit an event row on any path anymore.
+		assertEventsNotCommitted(ctx, t, store.db)
+		// The stray row must still be durable in the working set.
+		var live int
 		if err := store.db.QueryRowContext(ctx,
-			"SELECT COUNT(*) FROM events AS OF 'HEAD' WHERE id = ?", strayID,
-		).Scan(&committed); err != nil {
-			t.Fatalf("count committed stray event: %v", err)
+			"SELECT COUNT(*) FROM events WHERE id = ?", strayID,
+		).Scan(&live); err != nil {
+			t.Fatalf("count stray event: %v", err)
 		}
-		if committed != 0 {
-			t.Fatalf("a no-event dependency op swept an unrelated pending event into its commit (committed=%d, want 0)", committed)
+		if live != 1 {
+			t.Fatalf("stray event row lost from the working set (count=%d, want 1)", live)
 		}
 	}
 

--- a/internal/storage/dolt/dependency_events_test.go
+++ b/internal/storage/dolt/dependency_events_test.go
@@ -95,17 +95,11 @@ func TestDependencyEventEmission(t *testing.T) {
 			t.Fatalf("dependency_added count = %d, want 1", recorded)
 		}
 		assertEventsNotCommitted(ctx, t, store.db)
-		// The ignored plane suppresses events from dolt_status entirely, so the
-		// commit path never sees it as dirty.
-		var dirtyEvents int
-		if err := store.db.QueryRowContext(ctx,
-			"SELECT COUNT(*) FROM dolt_status WHERE table_name = 'events'",
-		).Scan(&dirtyEvents); err != nil {
-			t.Fatalf("query dolt_status for events: %v", err)
-		}
-		if dirtyEvents != 0 {
-			t.Fatalf("events table visible in dolt_status (count=%d); the ignored plane must suppress it", dirtyEvents)
-		}
+		// No dolt_status assertion here: on a production-shaped database the
+		// untracked ignored table never appears in dolt_status (the embedded
+		// contract tests pin that), but the shared branch-per-test database
+		// materializes events at HEAD, so working-set rows legitimately show
+		// as a modification there. Staging respects dolt_ignore either way.
 	})
 
 	t.Run("ExplicitRemoveEmitsDependencyRemoved", func(t *testing.T) {

--- a/internal/storage/dolt/git_remote_test.go
+++ b/internal/storage/dolt/git_remote_test.go
@@ -1060,15 +1060,20 @@ func TestCreateIssueAfterPull(t *testing.T) {
 		t.Fatalf("source Push failed: %v", err)
 	}
 
-	// Simulate a second peer via CLI: clone, add data with UUID
-	// rows (issue + event), commit, and push back to the shared remote.
+	// Simulate a second peer via CLI: clone, add an issue row, commit, and
+	// push back to the shared remote. events is dolt_ignored since 0062
+	// (bd-red8u): the table is not part of committed history, so a fresh
+	// clone arrives without it and audit rows never cross a remote — the
+	// peer's contribution is the issue row alone.
 	cloneDir := filepath.Join(setup.baseDir, "clone-ai")
 	doltClone(t, setup.remoteURL, cloneDir)
+	eventsProbe := exec.Command("dolt", "sql", "-q", "SELECT COUNT(*) FROM events")
+	eventsProbe.Dir = cloneDir
+	if out, err := eventsProbe.CombinedOutput(); err == nil {
+		t.Fatalf("fresh clone materialized the events table from the remote; want it absent (dolt_ignored, 0062)\noutput: %s", out)
+	}
 	sourceInsertIssue(t, cloneDir, "ai-clone-001", "Clone issue generating events")
-	runDoltSQL(t, cloneDir,
-		`INSERT INTO events (id, issue_id, event_type, actor, created_at) `+
-			`VALUES (UUID(), 'ai-clone-001', 'created', 'clone-user', NOW())`)
-	sourceCommitAndPush(t, cloneDir, "Add ai-clone-001 with event")
+	sourceCommitAndPush(t, cloneDir, "Add ai-clone-001")
 
 	// Pull into the source store — this is the code path under test.
 	// With UUID primary keys, there are no counter collisions after pull.
@@ -1094,10 +1099,11 @@ func TestCreateIssueAfterPull(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to count events: %v", err)
 	}
-	// At least 3 events: source created (ai-src-001), clone created (ai-clone-001),
-	// post-pull created (ai-src-002)
-	if eventCount < 3 {
-		t.Errorf("expected at least 3 events, got %d", eventCount)
+	// At least 2 node-local events: source created (ai-src-001) and post-pull
+	// created (ai-src-002). The clone's own audit trail is node-local and
+	// never arrives via pull.
+	if eventCount < 2 {
+		t.Errorf("expected at least 2 events, got %d", eventCount)
 	}
 
 	for _, id := range []string{"ai-src-001", "ai-clone-001", "ai-src-002"} {

--- a/internal/storage/dolt/transaction_test.go
+++ b/internal/storage/dolt/transaction_test.go
@@ -123,7 +123,7 @@ func TestRunInTransactionCloseIssueEmitsEvent(t *testing.T) {
 		t.Fatalf("RunInTransaction CloseIssue: %v", err)
 	}
 
-	assertCommittedEventCount(ctx, t, store.db, issue.ID, types.EventClosed, 1)
+	assertRecordedEventCount(ctx, t, store.db, issue.ID, types.EventClosed, 1)
 }
 
 func TestRunInTransactionAlreadyClosedDoesNotCommitUnrelatedEvent(t *testing.T) {
@@ -162,17 +162,21 @@ func TestRunInTransactionAlreadyClosedDoesNotCommitUnrelatedEvent(t *testing.T) 
 		t.Fatalf("RunInTransaction CloseIssue already closed: %v", err)
 	}
 
+	// events is dolt_ignored since 0062: the stray row can never leak into a
+	// commit because nothing events-shaped is committed at all — but it must
+	// still be durable in the working set alongside the close event.
+	assertEventsNotCommitted(ctx, t, store.db)
 	var got int
 	if err := store.db.QueryRowContext(ctx,
-		"SELECT COUNT(*) FROM events AS OF 'HEAD' WHERE issue_id = ? AND event_type = ? AND comment = ?",
+		"SELECT COUNT(*) FROM events WHERE issue_id = ? AND event_type = ? AND comment = ?",
 		issue.ID, types.EventCommented, strayComment,
 	).Scan(&got); err != nil {
-		t.Fatalf("count committed stray events: %v", err)
+		t.Fatalf("count stray events: %v", err)
 	}
-	if got != 0 {
-		t.Fatalf("committed stray event count = %d, want 0", got)
+	if got != 1 {
+		t.Fatalf("stray event count = %d, want 1", got)
 	}
-	assertCommittedEventCount(ctx, t, store.db, issue.ID, types.EventClosed, 1)
+	assertRecordedEventCount(ctx, t, store.db, issue.ID, types.EventClosed, 1)
 }
 
 func TestRunInTransactionAddLabelEmitsEvent(t *testing.T) {
@@ -200,7 +204,7 @@ func TestRunInTransactionAddLabelEmitsEvent(t *testing.T) {
 		t.Fatalf("RunInTransaction AddLabel: %v", err)
 	}
 
-	assertCommittedEventCount(ctx, t, store.db, issue.ID, types.EventLabelAdded, 1)
+	assertRecordedEventCount(ctx, t, store.db, issue.ID, types.EventLabelAdded, 1)
 }
 
 func TestRunInTransactionRemoveLabelEmitsEvent(t *testing.T) {
@@ -231,21 +235,37 @@ func TestRunInTransactionRemoveLabelEmitsEvent(t *testing.T) {
 		t.Fatalf("RunInTransaction RemoveLabel: %v", err)
 	}
 
-	assertCommittedEventCount(ctx, t, store.db, issue.ID, types.EventLabelRemoved, 1)
+	assertRecordedEventCount(ctx, t, store.db, issue.ID, types.EventLabelRemoved, 1)
 }
 
-func assertCommittedEventCount(ctx context.Context, t *testing.T, db *sql.DB, issueID string, eventType types.EventType, want int) {
+// assertRecordedEventCount counts audit rows in the working-set events table.
+// events is dolt_ignored since migration 0062 (bd-red8u): rows are durable and
+// visible to every client of the store but never part of committed history,
+// so there is no committed variant of this assertion anymore — see
+// assertEventsNotCommitted for the plane check.
+func assertRecordedEventCount(ctx context.Context, t *testing.T, db *sql.DB, issueID string, eventType types.EventType, want int) {
 	t.Helper()
 
 	var got int
 	if err := db.QueryRowContext(ctx,
-		"SELECT COUNT(*) FROM events AS OF 'HEAD' WHERE issue_id = ? AND event_type = ?",
+		"SELECT COUNT(*) FROM events WHERE issue_id = ? AND event_type = ?",
 		issueID, eventType,
 	).Scan(&got); err != nil {
-		t.Fatalf("count committed %s events for %s: %v", eventType, issueID, err)
+		t.Fatalf("count recorded %s events for %s: %v", eventType, issueID, err)
 	}
 	if got != want {
-		t.Fatalf("committed %s event count for %s = %d, want %d", eventType, issueID, got, want)
+		t.Fatalf("recorded %s event count for %s = %d, want %d", eventType, issueID, got, want)
+	}
+}
+
+// assertEventsNotCommitted pins the 0062 plane contract: the events table
+// must not exist in committed history, so the AS OF 'HEAD' probe has to fail.
+func assertEventsNotCommitted(ctx context.Context, t *testing.T, db *sql.DB) {
+	t.Helper()
+
+	var got int
+	if err := db.QueryRowContext(ctx, "SELECT COUNT(*) FROM events AS OF 'HEAD'").Scan(&got); err == nil {
+		t.Fatalf("events exists at HEAD with %d rows; want the table absent from committed history (dolt_ignored, 0062)", got)
 	}
 }
 

--- a/internal/storage/dolt/transaction_test.go
+++ b/internal/storage/dolt/transaction_test.go
@@ -258,14 +258,20 @@ func assertRecordedEventCount(ctx context.Context, t *testing.T, db *sql.DB, iss
 	}
 }
 
-// assertEventsNotCommitted pins the 0062 plane contract: the events table
-// must not exist in committed history, so the AS OF 'HEAD' probe has to fail.
+// assertEventsNotCommitted pins the 0062 plane contract: no events ROW ever
+// reaches committed history. On a production-shaped database the table itself
+// is absent at HEAD (the AS OF probe errors — the embedded contract tests
+// assert that stronger form), but the shared branch-per-test database
+// deliberately materializes an EMPTY events shell at HEAD so branches inherit
+// the schema (testutil.MaterializeLocalTableSchemasForBranchTests), so here
+// the probe may also succeed with zero rows. Any committed row is a
+// regression on both shapes.
 func assertEventsNotCommitted(ctx context.Context, t *testing.T, db *sql.DB) {
 	t.Helper()
 
 	var got int
-	if err := db.QueryRowContext(ctx, "SELECT COUNT(*) FROM events AS OF 'HEAD'").Scan(&got); err == nil {
-		t.Fatalf("events exists at HEAD with %d rows; want the table absent from committed history (dolt_ignored, 0062)", got)
+	if err := db.QueryRowContext(ctx, "SELECT COUNT(*) FROM events AS OF 'HEAD'").Scan(&got); err == nil && got != 0 {
+		t.Fatalf("events has %d rows at HEAD; want none in committed history (dolt_ignored, 0062)", got)
 	}
 }
 

--- a/internal/storage/domain/db/suite_test.go
+++ b/internal/storage/domain/db/suite_test.go
@@ -19,6 +19,7 @@ type testSuite struct {
 	db             *sql.DB
 	dbName         string
 	baselineCommit string
+	eventsDDL      string
 }
 
 func (s *testSuite) SetupSuite() {
@@ -55,6 +56,19 @@ func (s *testSuite) SetupSuite() {
 		db.QueryRowContext(ctx, "SELECT HASHOF('HEAD')").Scan(&s.baselineCommit),
 		"capture baseline commit hash",
 	)
+
+	// events is dolt_ignored since 0062 (bd-red8u): it lives only in the
+	// working set, so the baseline commit above does not contain it and the
+	// per-test DOLT_RESET below swaps out the issues table it references —
+	// after which the surviving untracked table's fk_events_issue silently
+	// stops enforcing (verified on dolt-sql-server 2.2.0). Capture the DDL so
+	// SetupTest can recreate the table fresh against the reset root, which
+	// re-links the FK and clears any audit rows orphaned by the reset.
+	var tbl string
+	s.Require().NoError(
+		db.QueryRowContext(ctx, "SHOW CREATE TABLE events").Scan(&tbl, &s.eventsDDL),
+		"capture events DDL",
+	)
 }
 
 func (s *testSuite) TearDownSuite() {
@@ -79,8 +93,15 @@ func (s *testSuite) TearDownSuite() {
 }
 
 func (s *testSuite) SetupTest() {
-	_, err := s.db.ExecContext(context.Background(), "CALL DOLT_RESET('--hard', ?)", s.baselineCommit)
+	ctx := context.Background()
+	_, err := s.db.ExecContext(ctx, "CALL DOLT_RESET('--hard', ?)", s.baselineCommit)
 	s.Require().NoError(err, "reset to baseline %s", s.baselineCommit)
+	// Recreate the working-set-only events table after the reset — see the
+	// eventsDDL capture in SetupSuite for why.
+	_, err = s.db.ExecContext(ctx, "DROP TABLE IF EXISTS events")
+	s.Require().NoError(err, "drop events after reset")
+	_, err = s.db.ExecContext(ctx, s.eventsDDL)
+	s.Require().NoError(err, "recreate events after reset")
 }
 
 func (s *testSuite) Runner() Runner {

--- a/internal/storage/embeddeddolt/migrate_events_flip_test.go
+++ b/internal/storage/embeddeddolt/migrate_events_flip_test.go
@@ -1,0 +1,200 @@
+//go:build cgo
+
+package embeddeddolt_test
+
+import (
+	"context"
+	"database/sql"
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/storage/schema"
+)
+
+// These tests pin the bd-red8u events-table plane flip (main migration 0062 +
+// ignored migration 0019): the events audit table leaves committed history
+// and lives dolt_ignored in the working set, Protocol v0.1 C2.2's
+// no-per-write-history-cost rule.
+//
+// Like the other frozen-guard tests in this file's siblings, they run the
+// exact frozen migration bytes through a real embedded (cgo) engine — 0062's
+// conditional DOLT_ADD is PREPARE-driven and its DOLT_COMMIT is a real
+// stored-procedure call, neither of which the dolt CLI batch executor
+// exercises faithfully. Both require BEADS_TEST_EMBEDDED_DOLT=1
+// (requireEmbedded, migrate_selfheal_test.go).
+
+// TestEmbeddedMigration0062FlipsEventsToIgnoredPlane drives the full
+// tracked->ignored flip on a database whose events table is genuinely
+// committed with rows, through the production migration path, and then
+// proves the three contract points: the drop is committed out of HEAD, the
+// rows survive in the working set, and subsequent event writes neither dirty
+// dolt_status nor become stageable. A full replay of the frozen bytes (the
+// interrupted-pass retry shape) must converge without error or a second
+// commit.
+func TestEmbeddedMigration0062FlipsEventsToIgnoredPlane(t *testing.T) {
+	requireEmbedded(t)
+	ctx := t.Context()
+
+	dataDir := seedMainSchemaAt(t, ctx, 61)
+	conn, closeConn := openPinnedConn(t, ctx, dataDir)
+	defer closeConn()
+
+	// Seed a committed issue + audit event on the (still versioned) plane.
+	execFrozenGuard(t, ctx, conn, `
+INSERT INTO issues (id, title, description, design, acceptance_criteria, notes, status, priority, issue_type)
+VALUES ('flip-1', 'flip seed', '', '', '', '', 'open', 2, 'task');
+INSERT INTO events (issue_id, event_type, actor, created_at, id)
+VALUES ('flip-1', 'created', 'tester', '2026-07-30 00:00:00', 'evt-seed-1');
+`)
+	mustDrain(t, ctx, conn, "CALL DOLT_ADD('-A')")
+	mustDrain(t, ctx, conn, "CALL DOLT_COMMIT('-m', 'test: seed committed events row')")
+
+	if got := scalarInt(t, ctx, conn, "SELECT COUNT(*) FROM events AS OF 'HEAD'"); got != 1 {
+		t.Fatalf("pre-flip committed events = %d, want 1", got)
+	}
+	headBefore := scalarString(t, ctx, conn, "SELECT commit_hash FROM dolt_log LIMIT 1")
+
+	// The flip, through the production path (execMigrationBody -> DrainCall).
+	if _, err := schema.MigrateUpTo(ctx, conn, 62); err != nil {
+		t.Fatalf("MigrateUpTo(62): %v", err)
+	}
+
+	// 1. The drop is committed: HEAD moved and no longer carries events.
+	headAfter := scalarString(t, ctx, conn, "SELECT commit_hash FROM dolt_log LIMIT 1")
+	if headAfter == headBefore {
+		t.Fatal("flip did not commit the events drop (HEAD unchanged)")
+	}
+	if err := conn.QueryRowContext(ctx, "SELECT COUNT(*) FROM events AS OF 'HEAD'").Scan(new(int)); err == nil {
+		t.Fatal("events still exists at HEAD; want it dropped from committed history")
+	}
+
+	// 2. Rows survive in the working set, and the ignore pattern is present.
+	if got := scalarInt(t, ctx, conn, "SELECT COUNT(*) FROM events"); got != 1 {
+		t.Fatalf("post-flip working-set events = %d, want 1", got)
+	}
+	if got := scalarInt(t, ctx, conn, "SELECT COUNT(*) FROM dolt_ignore WHERE pattern = 'events' AND ignored = 1"); got != 1 {
+		t.Fatalf("dolt_ignore rows for events = %d, want 1", got)
+	}
+
+	// 3. New audit writes are invisible to dolt_status and unstageable: the
+	// runtime's explicit DOLT_ADD('events') (issues.go staging lists) must
+	// silently no-op, minting nothing on a subsequent commit.
+	execFrozenGuard(t, ctx, conn, `
+INSERT INTO events (issue_id, event_type, actor, created_at, id)
+VALUES ('flip-1', 'updated', 'tester', '2026-07-30 00:00:01', 'evt-post-flip');
+`)
+	assertEventsAbsentFromStatus(t, ctx, conn)
+	mustDrain(t, ctx, conn, "CALL DOLT_ADD('events')")
+	if got := scalarInt(t, ctx, conn, "SELECT COUNT(*) FROM dolt_status WHERE table_name = 'events' AND staged = 1"); got != 0 {
+		t.Fatalf("explicit DOLT_ADD staged the ignored events table (%d rows staged)", got)
+	}
+
+	// 4. Replay of the frozen bytes converges: no error, no new commit, both
+	// rows preserved (the temp-copy union keeps the pre-crash copy).
+	flipSQL, err := schema.MigrationSQL("0062_events_dolt_ignore.up.sql")
+	if err != nil {
+		t.Fatalf("read 0062 migration: %v", err)
+	}
+	headBeforeReplay := scalarString(t, ctx, conn, "SELECT commit_hash FROM dolt_log LIMIT 1")
+	if err := schema.DrainCall(ctx, conn, flipSQL); err != nil {
+		t.Fatalf("replaying 0062 frozen bytes: %v", err)
+	}
+	if head := scalarString(t, ctx, conn, "SELECT commit_hash FROM dolt_log LIMIT 1"); head != headBeforeReplay {
+		t.Fatal("0062 replay minted a commit; --skip-empty must make it a no-op")
+	}
+	if got := scalarInt(t, ctx, conn, "SELECT COUNT(*) FROM events"); got != 2 {
+		t.Fatalf("post-replay events rows = %d, want 2", got)
+	}
+	assertEventsAbsentFromStatus(t, ctx, conn)
+}
+
+// TestEmbeddedIgnoredMigration0019CreatesEventsForFreshClones simulates the
+// fresh-clone door: a database whose main cursor is at-latest (0062 recorded
+// in committed history) but which arrived without the working-set-only events
+// table. The full MigrateUp pass must materialize it via ignored/0019, and a
+// replay of 0019's frozen bytes must never touch an existing table.
+func TestEmbeddedIgnoredMigration0019CreatesEventsForFreshClones(t *testing.T) {
+	requireEmbedded(t)
+	ctx := t.Context()
+
+	dataDir := seedMainSchemaAt(t, ctx, schema.LatestVersion())
+	conn, closeConn := openPinnedConn(t, ctx, dataDir)
+	defer closeConn()
+
+	// A clone materializes committed history only; the ignored-plane events
+	// table (recreated by 0062 in the working set) is not part of it.
+	execFrozenGuard(t, ctx, conn, "DROP TABLE IF EXISTS events")
+
+	if _, err := schema.MigrateUp(ctx, conn); err != nil {
+		t.Fatalf("MigrateUp: %v", err)
+	}
+
+	if got := scalarInt(t, ctx, conn, "SELECT COUNT(*) FROM events"); got != 0 {
+		t.Fatalf("fresh events table row count = %d, want 0", got)
+	}
+	assertEventsAbsentFromStatus(t, ctx, conn)
+
+	// Replay branch: with the table present (now holding a row), the frozen
+	// bytes must leave it untouched.
+	execFrozenGuard(t, ctx, conn, `
+INSERT INTO issues (id, title, description, design, acceptance_criteria, notes, status, priority, issue_type)
+VALUES ('clone-1', 'clone seed', '', '', '', '', 'open', 2, 'task');
+INSERT INTO events (issue_id, event_type, actor, created_at, id)
+VALUES ('clone-1', 'created', 'tester', '2026-07-30 00:00:00', 'evt-clone-1');
+`)
+	createSQL, err := schema.IgnoredMigrationSQL("0019_create_events.up.sql")
+	if err != nil {
+		t.Fatalf("read ignored 0019 migration: %v", err)
+	}
+	execFrozenGuard(t, ctx, conn, createSQL)
+	if got := scalarInt(t, ctx, conn, "SELECT COUNT(*) FROM events"); got != 1 {
+		t.Fatalf("events rows after 0019 replay = %d, want 1 (existing table must not be touched)", got)
+	}
+
+	// The FK contract survives the ignored-lane creation: an event for a
+	// missing issue must be refused (fk_events_issue crosses to the
+	// versioned issues table).
+	if _, err := conn.ExecContext(ctx,
+		"INSERT INTO events (issue_id, event_type, actor, created_at, id) VALUES ('no-such-issue', 'created', 'tester', '2026-07-30 00:00:00', 'evt-orphan')",
+	); err == nil {
+		t.Fatal("orphan event insert succeeded; want fk_events_issue to refuse it")
+	}
+}
+
+func mustDrain(t *testing.T, ctx context.Context, conn *sql.Conn, sqlText string) {
+	t.Helper()
+	if err := schema.DrainCall(ctx, conn, sqlText); err != nil {
+		t.Fatalf("drain %q: %v", sqlText, err)
+	}
+}
+
+func scalarInt(t *testing.T, ctx context.Context, conn *sql.Conn, query string) int {
+	t.Helper()
+	var v int
+	if err := conn.QueryRowContext(ctx, query).Scan(&v); err != nil {
+		t.Fatalf("scalar %q: %v", query, err)
+	}
+	return v
+}
+
+func scalarString(t *testing.T, ctx context.Context, conn *sql.Conn, query string) string {
+	t.Helper()
+	var v string
+	if err := conn.QueryRowContext(ctx, query).Scan(&v); err != nil {
+		t.Fatalf("scalar %q: %v", query, err)
+	}
+	return v
+}
+
+func assertEventsAbsentFromStatus(t *testing.T, ctx context.Context, conn *sql.Conn) {
+	t.Helper()
+	tables, err := statusTables(ctx, conn)
+	if err != nil {
+		t.Fatalf("read dolt_status: %v", err)
+	}
+	for _, name := range tables {
+		if strings.EqualFold(name, "events") {
+			t.Fatalf("events present in dolt_status (%v); the ignored plane must suppress it", tables)
+		}
+	}
+}

--- a/internal/storage/schema/lock_test.go
+++ b/internal/storage/schema/lock_test.go
@@ -109,7 +109,7 @@ func TestMigrateUpSeedsIgnorePatternsWhenNoWorkNeeded(t *testing.T) {
 	}
 	defer db.Close()
 
-	expectIgnorePatternSeed(mock)
+	expectIgnorePatternSeed(mock, LatestVersion())
 	// migrationWorkNeeded: both cursors at latest, both content_hash columns
 	// present, no custom backfill pending -> no work, MigrateUp short-circuits.
 	expectScalar(mock, "SELECT COALESCE(MAX(version), 0) FROM schema_migrations", "version", LatestVersion())
@@ -148,7 +148,7 @@ func TestMigrateUpSkipsSeedCommitWhenNothingChanged(t *testing.T) {
 	}
 	defer db.Close()
 
-	expectIgnorePatternSeedNoop(mock)
+	expectIgnorePatternSeedNoop(mock, LatestVersion())
 	// migrationWorkNeeded: no work, MigrateUp short-circuits.
 	expectScalar(mock, "SELECT COALESCE(MAX(version), 0) FROM schema_migrations", "version", LatestVersion())
 	expectScalar(mock, "SELECT COALESCE(MAX(version), 0) FROM ignored_schema_migrations", "version", LatestIgnoredVersion())
@@ -171,22 +171,33 @@ func TestMigrateUpSkipsSeedCommitWhenNothingChanged(t *testing.T) {
 
 // expectIgnorePatternSeed mocks the unconditional dolt_ignore pattern seed
 // MigrateUp runs before anything else, with every pattern actually inserted
-// (RowsAffected=1: an under-seeded database).
-func expectIgnorePatternSeed(mock sqlmock.Sqlmock) {
-	for _, pattern := range doltIgnorePatterns {
-		mock.ExpectExec(regexp.QuoteMeta("INSERT IGNORE INTO dolt_ignore VALUES (?, true)")).
-			WithArgs(pattern).
-			WillReturnResult(sqlmock.NewResult(0, 1))
-	}
+// (RowsAffected=1: an under-seeded database). mainVersion is what the seed's
+// cursor probe reports; version-gated patterns (events, >= 0062) are only
+// expected when it qualifies them.
+func expectIgnorePatternSeed(mock sqlmock.Sqlmock, mainVersion int) {
+	expectIgnorePatternSeedRows(mock, mainVersion, 1)
 }
 
 // expectIgnorePatternSeedNoop mocks the seed on a healthy database: every
 // INSERT IGNORE hits an existing row (RowsAffected=0), nothing changes.
-func expectIgnorePatternSeedNoop(mock sqlmock.Sqlmock) {
+func expectIgnorePatternSeedNoop(mock sqlmock.Sqlmock, mainVersion int) {
+	expectIgnorePatternSeedRows(mock, mainVersion, 0)
+}
+
+func expectIgnorePatternSeedRows(mock sqlmock.Sqlmock, mainVersion int, rowsAffected int64) {
 	for _, pattern := range doltIgnorePatterns {
 		mock.ExpectExec(regexp.QuoteMeta("INSERT IGNORE INTO dolt_ignore VALUES (?, true)")).
 			WithArgs(pattern).
-			WillReturnResult(sqlmock.NewResult(0, 0))
+			WillReturnResult(sqlmock.NewResult(0, rowsAffected))
+	}
+	expectScalar(mock, "SELECT COALESCE(MAX(version), 0) FROM schema_migrations", "version", mainVersion)
+	for _, gated := range versionGatedDoltIgnorePatterns {
+		if mainVersion < gated.minMainVersion {
+			continue
+		}
+		mock.ExpectExec(regexp.QuoteMeta("INSERT IGNORE INTO dolt_ignore VALUES (?, true)")).
+			WithArgs(gated.pattern).
+			WillReturnResult(sqlmock.NewResult(0, rowsAffected))
 	}
 }
 
@@ -196,7 +207,7 @@ func expectOnePendingMigration(t *testing.T, mock sqlmock.Sqlmock) {
 	latest := LatestVersion()
 	latestIgnored := LatestIgnoredVersion()
 
-	expectIgnorePatternSeed(mock)
+	expectIgnorePatternSeed(mock, latest-1)
 	expectScalar(mock, "SELECT COALESCE(MAX(version), 0) FROM schema_migrations", "version", latest-1)
 	expectDoltStatusRows(mock)
 	// The seed changed rows (expectIgnorePatternSeed reports RowsAffected=1),
@@ -234,8 +245,11 @@ func expectOnePendingMigration(t *testing.T, mock sqlmock.Sqlmock) {
 	// Per-step commit (#4566) snapshots the working set before the migration
 	// runs so it can force-stage only the tables this step newly dirties.
 	expectDoltStatusRows(mock)
-	mock.ExpectExec("(?s).*").
-		WillReturnResult(sqlmock.NewResult(0, 0))
+	// The pending (latest) migration is 0062_events_dolt_ignore, whose body
+	// contains a bare CALL DOLT_COMMIT — execMigrationBody routes such bodies
+	// through DrainCall (QueryContext), not ExecContext.
+	mock.ExpectQuery("(?s).*").
+		WillReturnRows(sqlmock.NewRows([]string{"status"}))
 	mock.ExpectExec(regexp.QuoteMeta("INSERT IGNORE INTO schema_migrations (version, content_hash) VALUES (?, ?)")).
 		WithArgs(latest, sqlmock.AnyArg()).
 		WillReturnResult(sqlmock.NewResult(0, 1))
@@ -318,28 +332,28 @@ func expectDirtyGuardRefusal(t *testing.T, mock sqlmock.Sqlmock) {
 
 	latest := LatestVersion()
 
-	expectIgnorePatternSeedNoop(mock)
+	expectIgnorePatternSeedNoop(mock, latest-2)
 	// migrationWorkNeeded: main cursor behind -> work needed (short-circuits).
 	// Two behind, not one: 0061 is a pure version anchor (SELECT 1, touches no
-	// table), so the guard shape needs 0060 — which alters `issues` — among
-	// the pending migrations.
+	// table), so the guard shape needs 0062 — which drops/recreates `events` —
+	// among the pending migrations.
 	expectScalar(mock, "SELECT COALESCE(MAX(version), 0) FROM schema_migrations", "version", latest-2)
-	// dirtyBeforeAll: `issues` dirty (working set only, not staged).
-	expectDoltStatusDirtyIssues(mock)
+	// dirtyBeforeAll: `events` dirty (working set only, not staged).
+	expectDoltStatusDirtyEvents(mock)
 	// Nothing staged -> no unstage exec; seed was a no-op -> no seed commit.
 	// committableDirtyTables re-reads dolt_status (ignored tables excluded).
-	expectDoltStatusDirtyIssues(mock)
+	expectDoltStatusDirtyEvents(mock)
 	// auxRekeyResumePending: no local_metadata table, no crashed rekey pass.
 	mock.ExpectQuery(`SELECT COUNT\(\*\) FROM INFORMATION_SCHEMA\.TABLES`).
 		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
-	// pendingMigrationDirtyTables: cursor read, then pending 0060's SQL
-	// touches `issues` -> DirtyTablesError.
+	// pendingMigrationDirtyTables: cursor read, then pending 0062's SQL
+	// touches `events` -> DirtyTablesError.
 	expectScalar(mock, "SELECT COALESCE(MAX(version), 0) FROM schema_migrations", "version", latest-2)
 }
 
-func expectDoltStatusDirtyIssues(mock sqlmock.Sqlmock) {
+func expectDoltStatusDirtyEvents(mock sqlmock.Sqlmock) {
 	mock.ExpectQuery("(?s)SELECT s\\.table_name, s\\.staged\\s+FROM dolt_status s").
-		WillReturnRows(sqlmock.NewRows([]string{"table_name", "staged"}).AddRow("issues", false))
+		WillReturnRows(sqlmock.NewRows([]string{"table_name", "staged"}).AddRow("events", false))
 }
 
 // TestMigrateUpWithLockDirtyGuardStaysFatalWithoutHeal pins the default

--- a/internal/storage/schema/migrations/0062_events_dolt_ignore.up.sql
+++ b/internal/storage/schema/migrations/0062_events_dolt_ignore.up.sql
@@ -64,7 +64,13 @@ INSERT IGNORE INTO __temp__events_flip (issue_id, event_type, actor, old_value, 
 -- DOLT_ADD is conditional on dolt_status actually showing a pending events
 -- change: on first run the drop of the tracked table is pending; on a replay
 -- the drop of the recreated (never-committed) table leaves no status row, and
--- an unconditional add of a table that exists nowhere would error. The commit
+-- an unconditional add of a table that exists nowhere would error. The add
+-- uses '-f' because plain DOLT_ADD of a dolt_ignore'd table is a silent no-op:
+-- on the normal path 'events' is not in dolt_ignore yet (Phase 3 adds it), but
+-- a database that already carries the pattern while events is still tracked at
+-- HEAD (branch-per-test databases materialize exactly that state; so would any
+-- out-of-band-seeded pattern) needs the force or the drop never commits and
+-- the recreate nets out to a permanently-dirty tracked table. The commit
 -- is a bare statement so the drain path picks it up; --skip-empty makes the
 -- replay a no-op instead of "nothing to commit" (the 0040/0041 lesson).
 --
@@ -81,7 +87,7 @@ INSERT IGNORE INTO __temp__events_flip (issue_id, event_type, actor, old_value, 
 DROP TABLE events;
 COMMIT;
 SET @flip_pending = (SELECT COUNT(*) FROM dolt_status WHERE table_name = 'events');
-SET @sql = IF(@flip_pending > 0, 'CALL DOLT_ADD(''events'')', 'SELECT 1');
+SET @sql = IF(@flip_pending > 0, 'CALL DOLT_ADD(''-f'', ''events'')', 'SELECT 1');
 PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
 CALL DOLT_COMMIT('--skip-empty', '-m', 'schema: drop versioned events table for ignored-plane flip (bd-red8u)');
 

--- a/internal/storage/schema/migrations/0062_events_dolt_ignore.up.sql
+++ b/internal/storage/schema/migrations/0062_events_dolt_ignore.up.sql
@@ -1,0 +1,112 @@
+-- Move the events audit table off the versioned plane (bd-red8u, Protocol
+-- v0.1 C2.2: no per-write history cost for unversioned records).
+--
+-- events is the dominant history churner: every issue op appends audit rows,
+-- so at fleet tempo the table is touched by ~80% of dolt commits and is the
+-- primary driver of unbounded reachable-history growth (bd-7vb13
+-- measurements). Like leases (0055) and repo_mtimes (0028), the rows keep
+-- full SQL durability in the working set; what changes is that they stop
+-- minting versioned history. Unlike those precedents, events is an
+-- already-committed SYNCED table, and dolt_ignore only exempts tables that
+-- have never been committed -- a drop+recreate netting out in one working set
+-- leaves the table tracked-at-HEAD and permanently dirty. The drop must
+-- therefore be committed on its own BEFORE the recreate, which makes this the
+-- first self-committing table-plane migration (0040/0041 are the
+-- self-commit precedent; --skip-empty keeps the replay idempotent).
+--
+-- Replication note (deliberate, per the 2026-07-30 mitigation-first ruling):
+-- dolt_ignored tables do not replicate. Events are single-writer audit rows
+-- with low cross-machine value; the C2.3 newest-wins replication leg
+-- (bd-1quyq) re-adds unversioned sync later. Comments stay versioned until
+-- that leg exists. The pre-flip events history remains in remotes until the
+-- next squash window; only NEW growth stops.
+--
+-- Fresh clones never run this migration (their schema_migrations cursor
+-- arrives at-latest); they materialize the table via ignored migration 0019.
+-- Every step is guarded so a re-run from any intermediate state converges
+-- (verified: full-replay and mid-crash states all land in the final shape).
+
+-- Phase 0: Heal. A replay that crashed after the drop finds no events table;
+-- recreate it empty so the copy below cannot fail. No-op on the normal path.
+CREATE TABLE IF NOT EXISTS events (
+    issue_id VARCHAR(255) NOT NULL,
+    event_type VARCHAR(32) NOT NULL,
+    actor VARCHAR(255) NOT NULL,
+    old_value LONGTEXT,
+    new_value LONGTEXT,
+    comment TEXT,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    id CHAR(36) NOT NULL,
+    PRIMARY KEY (id),
+    INDEX idx_events_created_at (created_at),
+    INDEX idx_events_issue (issue_id),
+    CONSTRAINT fk_events_issue FOREIGN KEY (issue_id) REFERENCES issues (id) ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- Phase 1: Preserve rows in a temp table. IF NOT EXISTS + INSERT IGNORE keep
+-- a copy made by an interrupted earlier run intact (id is the PK, so the
+-- union of the old copy and the current rows converges).
+CREATE TABLE IF NOT EXISTS __temp__events_flip (
+    issue_id VARCHAR(255) NOT NULL,
+    event_type VARCHAR(32) NOT NULL,
+    actor VARCHAR(255) NOT NULL,
+    old_value LONGTEXT,
+    new_value LONGTEXT,
+    comment TEXT,
+    created_at DATETIME NOT NULL,
+    id CHAR(36) NOT NULL,
+    PRIMARY KEY (id)
+);
+INSERT IGNORE INTO __temp__events_flip (issue_id, event_type, actor, old_value, new_value, comment, created_at, id)
+    SELECT issue_id, event_type, actor, old_value, new_value, comment, created_at, id FROM events;
+
+-- Phase 2: Drop the tracked table and commit the drop out of HEAD. The
+-- DOLT_ADD is conditional on dolt_status actually showing a pending events
+-- change: on first run the drop of the tracked table is pending; on a replay
+-- the drop of the recreated (never-committed) table leaves no status row, and
+-- an unconditional add of a table that exists nowhere would error. The commit
+-- is a bare statement so the drain path picks it up; --skip-empty makes the
+-- replay a no-op instead of "nothing to commit" (the 0040/0041 lesson).
+--
+-- The bare COMMIT before the dolt_status read is load-bearing on the
+-- sql-server path: migrations run there on a transaction-pinned connection,
+-- and dolt_status reflects the WORKING SET, which an open SQL transaction has
+-- not updated yet -- without it the probe reads 0, the DOLT_ADD is skipped,
+-- and the drop+recreate nets out to a permanently-dirty tracked table.
+-- Mid-body transaction commits are already this pass's semantics: CALL
+-- DOLT_COMMIT (here and in 0040/0041) implicitly commits the session
+-- transaction too, and every statement in this file is replay-safe from any
+-- intermediate state. On autocommit paths (embedded engine, dolt CLI) the
+-- bare COMMIT is a no-op.
+DROP TABLE events;
+COMMIT;
+SET @flip_pending = (SELECT COUNT(*) FROM dolt_status WHERE table_name = 'events');
+SET @sql = IF(@flip_pending > 0, 'CALL DOLT_ADD(''events'')', 'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+CALL DOLT_COMMIT('--skip-empty', '-m', 'schema: drop versioned events table for ignored-plane flip (bd-red8u)');
+
+-- Phase 3: Register the ignore pattern (committed with the pass, so clones
+-- inherit it) and recreate events in the working set, now dolt-ignored.
+-- MigrateUp's cursor-gated doltIgnorePatterns seeding re-asserts the pattern
+-- for databases materialized out-of-band.
+REPLACE INTO dolt_ignore VALUES ('events', true);
+CREATE TABLE IF NOT EXISTS events (
+    issue_id VARCHAR(255) NOT NULL,
+    event_type VARCHAR(32) NOT NULL,
+    actor VARCHAR(255) NOT NULL,
+    old_value LONGTEXT,
+    new_value LONGTEXT,
+    comment TEXT,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    id CHAR(36) NOT NULL,
+    PRIMARY KEY (id),
+    INDEX idx_events_created_at (created_at),
+    INDEX idx_events_issue (issue_id),
+    CONSTRAINT fk_events_issue FOREIGN KEY (issue_id) REFERENCES issues (id) ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- Phase 4: Restore rows and clean up. __temp__events_flip was never
+-- committed, so dropping it leaves no tracked changes.
+INSERT IGNORE INTO events (issue_id, event_type, actor, old_value, new_value, comment, created_at, id)
+    SELECT issue_id, event_type, actor, old_value, new_value, comment, created_at, id FROM __temp__events_flip;
+DROP TABLE IF EXISTS __temp__events_flip;

--- a/internal/storage/schema/migrations/ignored/0019_create_events.up.sql
+++ b/internal/storage/schema/migrations/ignored/0019_create_events.up.sql
@@ -1,0 +1,34 @@
+-- Materialize the events audit table (bd-red8u) on clones that never ran
+-- main migration 0062. events is dolt_ignored since 0062, so it lives only in
+-- the working set and is never part of committed history: a fresh clone
+-- arrives with the schema_migrations cursor at-latest (0062 already recorded)
+-- but WITHOUT the table, exactly like leases (ignored/0012) and the
+-- wisp/local-state tables (ignored/0001).
+--
+-- NOT the usual __temp__ + RENAME dance: events carries the named constraint
+-- fk_events_issue, and constraint names are database-unique -- creating a
+-- temp twin while events exists errors with "duplicate foreign key constraint
+-- name" (verified on dolt 2.2.2). A PREPAREd conditional CREATE gives the
+-- same create-only-when-absent contract. CREATE TABLE IF NOT EXISTS alone
+-- would also work (a same-name FK short-circuits on the existing table), but
+-- the explicit guard keeps the never-touch-an-existing-table intent readable.
+--
+-- Shape must stay identical to 0062's recreate (the post-0037 converged
+-- column order, id last) -- events/wisp_events twin parity is pinned by
+-- internal/storage/dolt/schema_parity_test.go.
+SET @exists = (SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'events');
+SET @sql = IF(@exists = 0, 'CREATE TABLE events (
+    issue_id VARCHAR(255) NOT NULL,
+    event_type VARCHAR(32) NOT NULL,
+    actor VARCHAR(255) NOT NULL,
+    old_value LONGTEXT,
+    new_value LONGTEXT,
+    comment TEXT,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    id CHAR(36) NOT NULL,
+    PRIMARY KEY (id),
+    INDEX idx_events_created_at (created_at),
+    INDEX idx_events_issue (issue_id),
+    CONSTRAINT fk_events_issue FOREIGN KEY (issue_id) REFERENCES issues (id) ON DELETE CASCADE ON UPDATE CASCADE
+)', 'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;

--- a/internal/storage/schema/schema.go
+++ b/internal/storage/schema/schema.go
@@ -264,6 +264,22 @@ var doltIgnorePatterns = []string{
 	"wisps",
 }
 
+// versionGatedDoltIgnorePatterns are ignore patterns whose table was moved
+// onto the ignored plane by a specific main-lane migration, so re-asserting
+// them is only correct once the main cursor has reached that version. Seeding
+// them unconditionally would strand a pre-flip database whose migration pass
+// is refused (remote-migrate gate, dirty-table gate): the table would still
+// be tracked-and-versioned while the pattern suppressed all staging of it, so
+// its writes would silently stop being committed. The gate matters only for
+// the out-of-band heal path — on a normal upgrade the flip migration itself
+// registers the pattern in the same pass.
+var versionGatedDoltIgnorePatterns = []struct {
+	pattern        string
+	minMainVersion int
+}{
+	{"events", 62}, // 0062_events_dolt_ignore (bd-red8u)
+}
+
 // seedDoltIgnorePatterns idempotently asserts the canonical dolt_ignore
 // patterns and reports whether it actually changed anything. INSERT IGNORE
 // leaves existing rows untouched, so a healthy database sees no working-set
@@ -278,16 +294,38 @@ var doltIgnorePatterns = []string{
 // in one pass instead of riding along inside an unrelated later commit.
 func seedDoltIgnorePatterns(ctx context.Context, db DBConn) (bool, error) {
 	changed := false
-	for _, pattern := range doltIgnorePatterns {
+	seedOne := func(pattern string) error {
 		res, err := db.ExecContext(ctx, "INSERT IGNORE INTO dolt_ignore VALUES (?, true)", pattern)
 		if err != nil {
-			return changed, fmt.Errorf("seeding dolt_ignore pattern %q: %w", pattern, err)
+			return fmt.Errorf("seeding dolt_ignore pattern %q: %w", pattern, err)
 		}
 		// A RowsAffected error degrades to changed=false for that row: the
 		// seed then stays an uncommitted working-set diff swept up by the
 		// next commit, exactly the pre-scoped-commit behavior.
 		if n, raErr := res.RowsAffected(); raErr == nil && n > 0 {
 			changed = true
+		}
+		return nil
+	}
+	for _, pattern := range doltIgnorePatterns {
+		if err := seedOne(pattern); err != nil {
+			return changed, err
+		}
+	}
+	// Version-gated patterns seed only once the main cursor proves the flip
+	// migration applied. The cursor table may not exist yet (first-ever run,
+	// before mainSource.migrate bootstraps it): treat that as version 0 and
+	// skip — the flip migration registers its own pattern when it applies.
+	mainVersion, err := mainSource.currentVersion(ctx, db)
+	if err != nil {
+		mainVersion = 0
+	}
+	for _, gated := range versionGatedDoltIgnorePatterns {
+		if mainVersion < gated.minMainVersion {
+			continue
+		}
+		if err := seedOne(gated.pattern); err != nil {
+			return changed, err
 		}
 	}
 	return changed, nil
@@ -369,6 +407,17 @@ func AllMigrationsSQL() string {
 // hygiene guard (scripts/check-migration-hygiene.sh).
 func MigrationSQL(name string) (string, error) {
 	data, err := mainSource.files.ReadFile(mainSource.dir + "/" + name)
+	if err != nil {
+		return "", err
+	}
+	return string(data), nil
+}
+
+// IgnoredMigrationSQL is MigrationSQL's ignored-lane counterpart: the frozen
+// bytes of an ignored-source migration file (e.g. "0019_create_events.up.sql"),
+// for engine-based frozen-guard tests of clone-local DDL.
+func IgnoredMigrationSQL(name string) (string, error) {
+	data, err := ignoredSource.files.ReadFile(ignoredSource.dir + "/" + name)
 	if err != nil {
 		return "", err
 	}

--- a/internal/storage/schema/schema_test.go
+++ b/internal/storage/schema/schema_test.go
@@ -64,7 +64,7 @@ func TestMigrateUpReturnsDirtyTablesErrorForPreExistingDirtyTable(t *testing.T) 
 	// MigrateUp re-asserts the canonical dolt_ignore patterns before anything
 	// else (GH#4378); the rows changed, so a scoped commit lands before the
 	// pass runs (#4566: the seed must not ride the per-step pass commits).
-	expectIgnorePatternSeed(mock)
+	expectIgnorePatternSeed(mock, 42)
 	// migrationWorkNeeded: mainSource.atLatest reads the current cursor; v42
 	// is behind LatestVersion(), so the || short-circuits before checking
 	// ignoredSource.atLatest or the content-hash/backfill probes.


### PR DESCRIPTION
# feat(storage): flip the events audit table to the dolt_ignored/unversioned plane (bd-red8u)

M1 of the 2026-07-30 mitigation-first ruling (Steve directive via ant; plan of
record: wyvern `brain/dolt-mitigation-plan-2026-07.md`). **Events only** —
comments stay versioned until the C2.3 newest-wins replication leg (bd-1quyq)
exists.

Events is the dominant history churner: every issue op appends audit rows, so
the table rides ~80% of dolt commits and is the primary driver of unbounded
reachable-history growth (bd-7vb13 measurements). After this flip the rows keep
full SQL durability in the working set but stop minting versioned history —
same plane as leases (0055) and repo_mtimes (0028).

## What's different from the leases/wisps precedents

Events is an **already-committed synced table**, and dolt_ignore only exempts
tables that have never been committed. A drop+recreate netting out in one
working set leaves the table tracked-at-HEAD and permanently dirty (verified
empirically on dolt 2.2.2). The drop must therefore be **committed on its own
before the recreate**, making 0062 the first self-committing table-plane
migration (0040/0041 are the self-commit precedent).

## Changes

- **Migration 0062** (`0062_events_dolt_ignore.up.sql`): four-phase,
  replay-safe from any intermediate state — heal-create → copy rows aside →
  drop + conditionally `DOLT_ADD('-f','events')` + `DOLT_COMMIT('--skip-empty')`
  → seed `dolt_ignore` → recreate → restore rows. The add is conditional on
  dolt_status actually showing a pending events change (a replay's drop of the
  never-committed recreation leaves no status row, and adding a table that
  exists nowhere errors). The `-f` matters: plain `DOLT_ADD` of an ignored
  table is a silent no-op, so a database that already carries the pattern while
  events is still tracked at HEAD (branch-per-test databases materialize
  exactly that state) would never commit the drop. On the normal path the
  pattern doesn't exist yet, so `-f` is identical to a plain add.
- **Ignored migration 0019** (`0019_create_events.up.sql`): fresh-clone
  creator on the ignored lane (bd-rotq2 rule). PREPAREd conditional CREATE
  because `fk_events_issue` is database-unique — the usual `__temp__`+RENAME
  idempotent-create recipe collides on the constraint name.
- **Version-gated dolt_ignore seeding** (`schema.go`): `events` seeds into
  `doltIgnorePatterns` only when the main cursor is ≥ 62. Unconditional
  seeding would strand a gate-refused pre-flip DB (tracked table + suppressed
  staging = writes never commit).
- **Doctor**: `events` added to the ignored-table lists in
  `cmd/bd/doctor/dolt.go`.
- **Tests**: two embedded contract tests (flip end-to-end + replay;
  fresh-clone door + FK), retargeted events-at-HEAD assertions across
  `create_issue_commit_test`, `transaction_test`, `dependency_events_test`,
  `git_remote_test`, `cmd/bd/create_embedded_test`, and the aux-rekey fixture
  now force-stages its events seed (a real pre-rekey lineage predates the flip,
  so its events rows were committed; `-Am` now skips the ignored table).
  Shared branch-per-test databases materialize an empty events shell at HEAD
  (`MaterializeLocalTableSchemasForBranchTests`), so the dolt-package
  assertions check "no events ROW at HEAD" — the invariant that holds on both
  shapes — while the embedded contract tests pin the stronger
  production-shape contract (table absent at HEAD, absent from dolt_status).
- **domain/db suite**: `DOLT_RESET('--hard')` swaps the tracked issues
  table's backing object, which silently severs `fk_events_issue`
  enforcement on the untracked events table (verified on dolt-sql-server
  2.2.0 with a minimal probe; labels' FK on the same root keeps enforcing).
  The suite recreates events from captured DDL after each per-test reset,
  re-linking the FK. Production hard-reset sites (flatten/compact squash
  path, mergesettle abort, schema-lock error path) inherit the same
  behavior — consequence is dangling audit rows, the already-accepted
  "harmless audit noise" class; tracked with a dolt-upstream report
  candidate in **bd-7bpkd**.

## Verified dolt semantics the design leans on (scratch DBs, dolt 2.2.2)

- Explicit `DOLT_ADD('events')` and mixed multi-table adds **silently skip**
  ignored tables → bd's runtime staging lists keep working unmodified, and
  **old binaries stay compatible with flipped DBs in place**.
- `DOLT_ADD('-f')` **does** pierce dolt_ignore. The only production force-add
  sites (`stageSchemaTables`, `commitMigrationStep`) draw from ignore-filtered
  sources, so neither can re-track events.
- Drop+recreate in one working set nets to a perma-dirty tracked table — the
  reason the drop is committed before the recreate.

## Review notes for lion

- **Rekey ordering** (your earlier note: rekey catch-up needs versioned
  replication): lane order covers lineages that took the 0061
  content-derived-ids anchor in an earlier pass (the common case — 0061 is on
  deployed main): their rekey work is committed on the versioned plane before
  the flip. For a laggard DB jumping ≤0060→0062 in a **single** pass the
  ordering is the other way around — `mainSource.migrate` applies 0061+0062
  first and `rekeyAuxRowIDsAllPasses` runs in MigrateUp's tail — so that
  lineage rekeys its events rows on the already-unversioned plane. Harmless
  for a different reason: post-flip, events never merges across clones, so
  the cross-clone ID-convergence property the rekey exists for is moot for
  this table (comments/snapshots stay versioned and rekey normally).
- **Rollout easing for wy-7cnbj**: in-place old binaries tolerate flipped DBs
  (see semantics above) — "in place" covers only DBs that flip locally and do
  not merge the flip in from elsewhere. Binary-first ordering is needed for
  **any machine that will fresh-clone OR `bd sync`/pull/merge from a
  post-flip origin**. The merge path delivers the same failure as the clone
  path: 0062 commits the events DROP on the versioned plane, the working-set
  recreate is ignored-plane and never replicates, so an old-binary clone that
  merges the flip either loses its events table outright (bd-rotq2-class
  insert failures, if it had no local events changes since the merge base) or
  hits a drop-vs-modified table conflict (if it did — the normal case at any
  write tempo). Confirmed against 0062 Phase 2 semantics per lion's review.
- **Pre-flip events history stays in remotes** until the next squash window —
  accepted; only new growth stops.
- **Orphaned working-set events**: merge-applied issue deletions do not
  cascade into another clone's working-set events rows. Harmless audit noise;
  sweep candidate for the bd-1quyq era.
- Consumers unchanged: `bd history` / EventsSince / counts read the single
  query plane; merge-code events handling stays (needed for pre-flip DBs
  mid-rollout); events were already absent from jsonl export;
  `commit_pending` batch messages drop events automatically.

## Test results

- `internal/storage/schema`: green (incl. ThroughDoltCLI full-bundle).
- `internal/storage/embeddeddolt` (BEADS_TEST_EMBEDDED_DOLT=1, full suite):
  green, 1131s.
- `internal/storage/dolt` (container path): all 730 tests run in six chunked
  invocations — **zero branch-attributable failures**. Includes
  `TestAuxRowIDRekeyConvergesIndependentClones`, which caught the
  ignored-pattern-pre-exists wedge that motivated the `-f`.
- `cmd/bd` (env -u BEADS_ACTOR): all 2078 tests run in eight chunked
  invocations — **zero branch-attributable failures**.
- `internal/storage/domain/db` (`TestDomainDB`, Docker): green after the
  suite's post-reset events recreation (the one genuine branch interaction
  found outside the dolt package — see above).
- Pre-existing failures on this machine, all verified to fail **identically
  on origin/main** in a clean worktree (none related to this branch):
  doctor role tests (global `git config beads.role` leak) + test-pollution
  EmptyDB; the fresh-DB "table not found: schema_migrations after New()"
  family (`TestDoltNew_*` gates/drift, `TestCheckForwardDrift_EscapeHatch`,
  `TestSchemaRunsInitWhenMissing`); `TestIgnoredMigration0011…` (stale
  delete-latest-cursor mechanism, filed as a bead); an is_blocked/recompute/
  rig-columns cluster of 8; a cmd/bd cluster (init `--contributor` vs
  `--non-interactive` conflict and friends, ~20 tests). A handful of others
  are chunk-order/contention flakes that pass in isolation (heartbeat trio,
  role-prompt trio, `TestDoltStoreComments`, `TestReclaimRevertsExpiredOnly`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

