### PR TITLE
fix(dolt): do not silently retarget an auto-started Dolt server onto a different port/database (#4052)

### DIFF
--- a/internal/doltserver/doltserver.go
+++ b/internal/doltserver/doltserver.go
@@ -517,6 +517,68 @@ func ReadPortFile(beadsDir string) int {
 	return readPortFile(beadsDir)
 }
 
+// PortFileSnapshot captures the exact prior contents of a project's port
+// file, so a caller that speculatively lets EnsureRunningDetailed write a
+// new one can restore the pre-call state exactly if it later decides not to
+// use the new server (GH#4052 fail-closed paths). Existed is false when the
+// file did not exist before the snapshot; in that case Data is nil and
+// RestorePortFile removes the file rather than rewriting it.
+type PortFileSnapshot struct {
+	Data    []byte
+	Existed bool
+}
+
+// SnapshotPortFile captures the current on-disk state of beadsDir's port
+// file (see PortFileSnapshot). Read-only; does not mutate anything.
+func SnapshotPortFile(beadsDir string) (PortFileSnapshot, error) {
+	data, err := os.ReadFile(portPath(beadsDir))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return PortFileSnapshot{}, nil
+		}
+		return PortFileSnapshot{}, err
+	}
+	// Copy: os.ReadFile's backing array should not be retained/mutated by
+	// later callers of the same path.
+	cp := make([]byte, len(data))
+	copy(cp, data)
+	return PortFileSnapshot{Data: cp, Existed: true}, nil
+}
+
+// RestorePortFile restores beadsDir's port file to the state captured by
+// snap: removes the file if it did not exist before, or rewrites it with the
+// exact prior bytes (write-temp-then-rename, matching writePortFile, so a
+// concurrent reader never observes a partially written file). Used on
+// fail-closed auto-start paths (GH#4052) that must leave no port-file trace
+// of a server they decided not to use.
+func RestorePortFile(beadsDir string, snap PortFileSnapshot) error {
+	path := portPath(beadsDir)
+	if !snap.Existed {
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+			return err
+		}
+		return nil
+	}
+	tmp, err := os.CreateTemp(beadsDir, PortFileName+".tmp-*")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	defer os.Remove(tmpName) //nolint:errcheck // no-op after successful rename
+	if _, err := tmp.Write(snap.Data); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Chmod(0o600); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmpName, path)
+}
+
 func configYamlPort(beadsDir string) int {
 	path := filepath.Join(ResolveDoltDir(beadsDir), "config.yaml")
 	if _, err := os.Stat(path); err != nil {

--- a/internal/doltserver/doltserver.go
+++ b/internal/doltserver/doltserver.go
@@ -311,6 +311,14 @@ type Config struct {
 	Port     int        // MySQL protocol port (0 = allocate ephemeral port on Start)
 	Host     string     // Bind address (default: 127.0.0.1)
 	Mode     ServerMode // Server ownership mode (Owned, External, Embedded)
+
+	// PortSource records which step of the precedence chain (see
+	// portSources) resolved Port. PortSourceUnset when Port == 0. Callers
+	// that auto-start a replacement server use this to decide whether
+	// silently retargeting to a different port is safe (GH#4052): safe for
+	// bd's own port-file bookkeeping, not safe for a source where the user
+	// (or config on the user's behalf) explicitly asserted the port.
+	PortSource PortSource
 }
 
 // State holds runtime information about a managed server.
@@ -509,11 +517,56 @@ func configYamlPort(beadsDir string) int {
 	return cfg.Port()
 }
 
+// PortSource identifies which step of the port-resolution precedence chain
+// (see portSources) produced a Config's Port. Callers use it to distinguish
+// a port the user explicitly asserted (authoritative) from bd's own
+// bookkeeping (the gitignored port file), which auto-start is free to
+// replace without confirmation (GH#4052).
+type PortSource string
+
+const (
+	// PortSourceUnset means no source resolved a port (Port == 0); Start()
+	// will allocate an ephemeral port.
+	PortSourceUnset PortSource = ""
+	// PortSourceEnv is the BEADS_DOLT_SERVER_PORT environment variable.
+	PortSourceEnv PortSource = "env"
+	// PortSourcePortFile is the gitignored .beads/dolt-server.port file that
+	// bd itself writes and rewrites as part of normal server bookkeeping.
+	PortSourcePortFile PortSource = "port_file"
+	// PortSourceDoltConfigYaml is the Dolt server's own config.yaml
+	// (listener.port) in the dolt data directory.
+	PortSourceDoltConfigYaml PortSource = "dolt_config_yaml"
+	// PortSourceConfigYaml is Beads' project/global config.yaml (dolt.port).
+	PortSourceConfigYaml PortSource = "config_yaml"
+	// PortSourceGlobalConfig is retained as an alias of PortSourceConfigYaml
+	// for callers that think of it as "global config" (~/.config/bd/config.yaml
+	// resolves through the same config.GetYamlConfig("dolt.port") lookup).
+	PortSourceGlobalConfig = PortSourceConfigYaml
+	// PortSourceMetadataJSON is the deprecated metadata.json dolt_server_port
+	// fallback. Still an explicit user/tooling assertion, not bd bookkeeping.
+	PortSourceMetadataJSON PortSource = "metadata_json"
+)
+
+// IsAuthoritative reports whether this source represents a user (or
+// tooling-on-the-user's-behalf) assertion of where the Dolt server lives, as
+// opposed to bd's own bookkeeping (the port file). Auto-start may freely
+// replace a non-authoritative port; it must not silently replace an
+// authoritative one (GH#4052).
+func (s PortSource) IsAuthoritative() bool {
+	switch s {
+	case PortSourceEnv, PortSourceDoltConfigYaml, PortSourceConfigYaml, PortSourceMetadataJSON:
+		return true
+	default:
+		return false
+	}
+}
+
 // portSource is one step in the port-resolution precedence chain that
 // DefaultConfig walks. resolve reports (port, true) when this source has a
 // usable value; DefaultConfig stops at the first true.
 type portSource struct {
 	label   string
+	source  PortSource
 	resolve func(beadsDir string) (int, bool)
 }
 
@@ -523,7 +576,8 @@ type portSource struct {
 // chain instead of hand-copying it out of sync (GH#4511).
 var portSources = []portSource{
 	{
-		label: "Environment variable (BEADS_DOLT_SERVER_PORT)",
+		label:  "Environment variable (BEADS_DOLT_SERVER_PORT)",
+		source: PortSourceEnv,
 		resolve: func(beadsDir string) (int, bool) {
 			p := os.Getenv("BEADS_DOLT_SERVER_PORT")
 			if p == "" {
@@ -536,14 +590,16 @@ var portSources = []portSource{
 	{
 		// Gitignored, local-only. Elevated above the YAML sources to prevent
 		// git-tracked values from causing cross-project data leakage (GH#2372).
-		label: "Port file (.beads/dolt-server.port; shared-server dir in shared mode)",
+		label:  "Port file (.beads/dolt-server.port; shared-server dir in shared mode)",
+		source: PortSourcePortFile,
 		resolve: func(beadsDir string) (int, bool) {
 			p := readPortFile(beadsDir)
 			return p, p > 0
 		},
 	},
 	{
-		label: "Dolt server config.yaml (listener.port, in the dolt data directory)",
+		label:  "Dolt server config.yaml (listener.port, in the dolt data directory)",
+		source: PortSourceDoltConfigYaml,
 		resolve: func(beadsDir string) (int, bool) {
 			p := configYamlPort(beadsDir)
 			return p, p > 0
@@ -552,7 +608,8 @@ var portSources = []portSource{
 	{
 		// ~/.config/bd/config.yaml or project config.yaml (GH#2073). Git-tracked,
 		// so it ranks below the port file above.
-		label: "Beads config.yaml / global config (dolt.port)",
+		label:  "Beads config.yaml / global config (dolt.port)",
+		source: PortSourceConfigYaml,
 		resolve: func(beadsDir string) (int, bool) {
 			p := config.GetYamlConfig("dolt.port")
 			if p == "" {
@@ -566,7 +623,8 @@ var portSources = []portSource{
 		// Deprecated: git-tracked, propagates to all contributors, causing
 		// cross-project data leakage (GH#2372). Kept as a fallback so existing
 		// setups don't break silently.
-		label: "metadata.json dolt_server_port (deprecated fallback)",
+		label:  "metadata.json dolt_server_port (deprecated fallback)",
+		source: PortSourceMetadataJSON,
 		resolve: func(beadsDir string) (int, bool) {
 			metaCfg, err := configfile.Load(beadsDir)
 			if err != nil || metaCfg == nil || metaCfg.DoltServerPort <= 0 {
@@ -614,6 +672,7 @@ func DefaultConfig(beadsDir string) *Config {
 	for _, src := range portSources {
 		if port, ok := src.resolve(beadsDir); ok {
 			cfg.Port = port
+			cfg.PortSource = src.source
 			break
 		}
 	}

--- a/internal/doltserver/doltserver.go
+++ b/internal/doltserver/doltserver.go
@@ -319,6 +319,18 @@ type Config struct {
 	// bd's own port-file bookkeeping, not safe for a source where the user
 	// (or config on the user's behalf) explicitly asserted the port.
 	PortSource PortSource
+
+	// PortSharedServer records whether Port was resolved in shared-server
+	// mode (BEADS_DOLT_SHARED_SERVER=1): either because port resolution
+	// consulted the shared server directory's sources, or because no source
+	// resolved a port and DefaultConfig fell back to DefaultSharedServerPort.
+	// Orthogonal to PortSource — a shared-mode port can come from any source
+	// (env, port file, config.yaml, ...). Callers use this together with
+	// PortSource.IsAuthoritative() to decide whether auto-starting a
+	// repo-local server on a different port is safe: it never is here,
+	// because the shared server is a different database than whatever
+	// auto-start would create locally (GH#4052).
+	PortSharedServer bool
 }
 
 // State holds runtime information about a managed server.
@@ -657,9 +669,11 @@ func PortSourceLabels() []string {
 // listening port, so already-running-server connections use the right port.
 func DefaultConfig(beadsDir string) *Config {
 	// In shared mode, use the shared server directory for port resolution
+	sharedMode := false
 	if IsSharedServerMode() {
 		if sharedDir, err := SharedServerDir(); err == nil {
 			beadsDir = sharedDir
+			sharedMode = true
 		}
 	}
 
@@ -673,6 +687,7 @@ func DefaultConfig(beadsDir string) *Config {
 		if port, ok := src.resolve(beadsDir); ok {
 			cfg.Port = port
 			cfg.PortSource = src.source
+			cfg.PortSharedServer = sharedMode
 			break
 		}
 	}
@@ -682,6 +697,7 @@ func DefaultConfig(beadsDir string) *Config {
 	// ephemeral port from the OS (GH#2098, GH#2372).
 	if cfg.Port == 0 && IsSharedServerMode() {
 		cfg.Port = DefaultSharedServerPort // 3308 - avoids orchestrator conflict on 3307
+		cfg.PortSharedServer = true
 	}
 
 	return cfg

--- a/internal/doltserver/portsources_test.go
+++ b/internal/doltserver/portsources_test.go
@@ -72,6 +72,85 @@ func TestDefaultConfigPrecedenceChain(t *testing.T) {
 	}
 }
 
+// TestDefaultConfigPortSource asserts that DefaultConfig records which step
+// of the precedence chain resolved Port, layering sources the same way
+// TestDefaultConfigPrecedenceChain does. Auto-start (GH#4052) uses PortSource
+// to decide whether silently retargeting a stale port is safe (bd's own
+// port-file bookkeeping) or not (a source where the user, or config on the
+// user's behalf, explicitly asserted the port).
+func TestDefaultConfigPortSource(t *testing.T) {
+	t.Setenv("BEADS_DOLT_SERVER_PORT", "")
+	t.Setenv("BEADS_DOLT_SHARED_SERVER", "")
+
+	beadsDir := t.TempDir()
+
+	// 1. Nothing configured: unset source, port 0.
+	cfg := DefaultConfig(beadsDir)
+	if cfg.Port != 0 || cfg.PortSource != PortSourceUnset {
+		t.Fatalf("no source configured: port=%d source=%q, want 0/%q", cfg.Port, cfg.PortSource, PortSourceUnset)
+	}
+
+	// 2. metadata.json dolt_server_port (deprecated fallback).
+	writeMetadataPort(t, beadsDir, 5001)
+	cfg = DefaultConfig(beadsDir)
+	if cfg.Port != 5001 || cfg.PortSource != PortSourceMetadataJSON {
+		t.Fatalf("metadata.json only: port=%d source=%q, want 5001/%q", cfg.Port, cfg.PortSource, PortSourceMetadataJSON)
+	}
+
+	// 3. Beads config.yaml (dolt.port) — global/project config source.
+	configDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(configDir, "config.yaml"), []byte("dolt.port: 5002\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("BEADS_DIR", configDir)
+	if err := config.Initialize(); err != nil {
+		t.Fatalf("config.Initialize: %v", err)
+	}
+	t.Cleanup(config.ResetForTesting)
+	cfg = DefaultConfig(beadsDir)
+	if cfg.Port != 5002 || cfg.PortSource != PortSourceConfigYaml {
+		t.Fatalf("beads config.yaml: port=%d source=%q, want 5002/%q", cfg.Port, cfg.PortSource, PortSourceConfigYaml)
+	}
+	if cfg.PortSource != PortSourceGlobalConfig {
+		t.Fatalf("PortSourceGlobalConfig alias diverged from PortSourceConfigYaml: %q vs %q", PortSourceGlobalConfig, PortSourceConfigYaml)
+	}
+
+	// 4. Dolt server's own config.yaml (listener.port).
+	doltDir := filepath.Join(beadsDir, "dolt")
+	if err := os.MkdirAll(doltDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(doltDir, "config.yaml"), []byte("listener:\n  host: 127.0.0.1\n  port: 5003\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg = DefaultConfig(beadsDir)
+	if cfg.Port != 5003 || cfg.PortSource != PortSourceDoltConfigYaml {
+		t.Fatalf("dolt server config.yaml: port=%d source=%q, want 5003/%q", cfg.Port, cfg.PortSource, PortSourceDoltConfigYaml)
+	}
+
+	// 5. Port file — bd's own bookkeeping, not authoritative.
+	if err := writePortFile(beadsDir, 5004); err != nil {
+		t.Fatal(err)
+	}
+	cfg = DefaultConfig(beadsDir)
+	if cfg.Port != 5004 || cfg.PortSource != PortSourcePortFile {
+		t.Fatalf("port file: port=%d source=%q, want 5004/%q", cfg.Port, cfg.PortSource, PortSourcePortFile)
+	}
+	if cfg.PortSource.IsAuthoritative() {
+		t.Fatalf("port file source must not be authoritative (bd's own bookkeeping)")
+	}
+
+	// 6. Env var — highest precedence, authoritative.
+	t.Setenv("BEADS_DOLT_SERVER_PORT", "5005")
+	cfg = DefaultConfig(beadsDir)
+	if cfg.Port != 5005 || cfg.PortSource != PortSourceEnv {
+		t.Fatalf("env var: port=%d source=%q, want 5005/%q", cfg.Port, cfg.PortSource, PortSourceEnv)
+	}
+	if !cfg.PortSource.IsAuthoritative() {
+		t.Fatalf("env var source must be authoritative")
+	}
+}
+
 func writeMetadataPort(t *testing.T, beadsDir string, port int) {
 	t.Helper()
 	data, err := json.Marshal(map[string]any{"dolt_server_port": port})

--- a/internal/doltserver/portsources_test.go
+++ b/internal/doltserver/portsources_test.go
@@ -151,6 +151,60 @@ func TestDefaultConfigPortSource(t *testing.T) {
 	}
 }
 
+// TestDefaultConfigPortSharedServer asserts that DefaultConfig sets
+// PortSharedServer whenever port resolution happened in shared-server mode
+// (BEADS_DOLT_SHARED_SERVER=1) — both when a source resolves a port from the
+// shared server directory, and when no source resolves one and the fixed
+// DefaultSharedServerPort fallback applies — and that it stays false
+// otherwise. newServerMode's auto-start fail-closed check (GH#4052) relies
+// on this: in shared-server mode, retargeting always means auto-start spun
+// up a repo-local server distinct from the shared one, regardless of
+// PortSource.IsAuthoritative().
+func TestDefaultConfigPortSharedServer(t *testing.T) {
+	t.Setenv("BEADS_DOLT_SERVER_PORT", "")
+	t.Setenv("BEADS_DOLT_SHARED_SERVER", "")
+
+	// Per-project mode: never shared, regardless of source.
+	beadsDir := t.TempDir()
+	if cfg := DefaultConfig(beadsDir); cfg.PortSharedServer {
+		t.Fatalf("per-project mode, no port configured: PortSharedServer = true, want false")
+	}
+	writeMetadataPort(t, beadsDir, 6001)
+	if cfg := DefaultConfig(beadsDir); cfg.PortSharedServer {
+		t.Fatalf("per-project mode, metadata.json port: PortSharedServer = true, want false")
+	}
+
+	// Shared-server mode, isolated to a temp shared-server dir so this test
+	// doesn't touch the real ~/.beads/shared-server.
+	sharedDir := t.TempDir()
+	t.Setenv("BEADS_SHARED_SERVER_DIR", sharedDir)
+	t.Setenv("BEADS_DOLT_SHARED_SERVER", "1")
+
+	// No port source resolves in the shared dir: falls back to the fixed
+	// shared server port.
+	cfg := DefaultConfig(t.TempDir())
+	if cfg.Port != DefaultSharedServerPort {
+		t.Fatalf("shared mode fallback: port = %d, want %d", cfg.Port, DefaultSharedServerPort)
+	}
+	if cfg.PortSource != PortSourceUnset {
+		t.Fatalf("shared mode fallback: source = %q, want %q", cfg.PortSource, PortSourceUnset)
+	}
+	if !cfg.PortSharedServer {
+		t.Fatalf("shared mode fallback: PortSharedServer = false, want true")
+	}
+
+	// A source resolves within the shared dir (metadata.json in this case):
+	// still shared, and PortSource still reports the resolving source.
+	writeMetadataPort(t, sharedDir, 6002)
+	cfg = DefaultConfig(t.TempDir())
+	if cfg.Port != 6002 || cfg.PortSource != PortSourceMetadataJSON {
+		t.Fatalf("shared mode, source resolved: port=%d source=%q, want 6002/%q", cfg.Port, cfg.PortSource, PortSourceMetadataJSON)
+	}
+	if !cfg.PortSharedServer {
+		t.Fatalf("shared mode, source resolved: PortSharedServer = false, want true")
+	}
+}
+
 func writeMetadataPort(t *testing.T, beadsDir string, port int) {
 	t.Helper()
 	data, err := json.Marshal(map[string]any{"dolt_server_port": port})

--- a/internal/storage/dolt/port_provenance_test.go
+++ b/internal/storage/dolt/port_provenance_test.go
@@ -2,6 +2,9 @@ package dolt
 
 import (
 	"context"
+	"fmt"
+	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"testing"
@@ -227,6 +230,299 @@ func TestNewServerMode_SharedServerResolvedPort_PortFileSource_FailsClosed(t *te
 	}
 	if cfg.ServerPort != configuredPort {
 		t.Errorf("cfg.ServerPort mutated to %d on fail-closed path, want unchanged %d", cfg.ServerPort, configuredPort)
+	}
+}
+
+// --- Port-file restoration on fail-closed (GH#4052 round 3) ---
+//
+// EnsureRunningDetailed writes serverDir's port file with the actual
+// listening port *before* newServerMode's fail-closed checks run — see
+// doltserver.Start's writePortFile, and the adopt-existing-server path's
+// EnsurePortFile. Left in place, that write survives a fail-closed return:
+// the port file is bd's own bookkeeping and the second-highest-precedence
+// port source (above config.yaml/metadata.json, below only the env var), so
+// a second, otherwise-identical invocation would resolve PortSourcePortFile
+// (non-authoritative) instead of the authoritative source that just failed,
+// silently adopt the server this invocation declined to use, and succeed —
+// disarming the guard after exactly one invocation. newServerMode must
+// restore the port file's pre-call state (including "did not exist before")
+// on every fail-closed return.
+
+// stubEnsureRunningDetailedWithPortFileWrite stubs ensureRunningDetailed to
+// additionally replicate EnsureRunningDetailed's real disk side effect: it
+// writes serverDir's port file with the "new" port before returning, exactly
+// as doltserver.Start/EnsurePortFile do ahead of newServerMode's fail-closed
+// checks. Without this, the plain stubEnsureRunningDetailed helper leaves no
+// on-disk state for the restoration tests below to exercise.
+func stubEnsureRunningDetailedWithPortFileWrite(t *testing.T, port int, startedByUs bool) {
+	t.Helper()
+	orig := ensureRunningDetailed
+	t.Cleanup(func() { ensureRunningDetailed = orig })
+	ensureRunningDetailed = func(beadsDir string) (int, bool, error) {
+		serverDir := doltserver.ResolveServerDir(beadsDir)
+		portFile := filepath.Join(serverDir, doltserver.PortFileName)
+		if err := os.WriteFile(portFile, []byte(strconv.Itoa(port)), 0o600); err != nil {
+			t.Fatalf("simulating production port-file write: %v", err)
+		}
+		return port, startedByUs, nil
+	}
+}
+
+// TestNewServerMode_AuthoritativeSource_FailClosed_RestoresAbsentPortFile is
+// the "did not exist before" half of the restoration regression test: no
+// port file existed prior to the call, so the fail-closed return must leave
+// none behind either.
+func TestNewServerMode_AuthoritativeSource_FailClosed_RestoresAbsentPortFile(t *testing.T) {
+	beadsDir := t.TempDir()
+	const configuredPort = 1
+	const newPort = 54401
+	t.Setenv("BEADS_TEST_MODE", "1")
+	cfg := &Config{
+		Database:         "test_port_provenance_restore_absent",
+		BeadsDir:         beadsDir,
+		Path:             filepath.Join(beadsDir, "dolt"),
+		ServerHost:       "127.0.0.1",
+		ServerPort:       configuredPort,
+		ServerPortSource: doltserver.PortSourceConfigYaml,
+		AutoStart:        true,
+	}
+	stubEnsureRunningDetailedWithPortFileWrite(t, newPort, false)
+
+	if got := doltserver.ReadPortFile(beadsDir); got != 0 {
+		t.Fatalf("precondition: port file unexpectedly present (%d)", got)
+	}
+
+	_, err := newServerMode(context.Background(), cfg)
+	if err == nil {
+		t.Fatal("expected fail-closed error")
+	}
+	if !strings.Contains(err.Error(), "will not silently use") {
+		t.Fatalf("expected fail-closed message, got: %v", err)
+	}
+	if got := doltserver.ReadPortFile(beadsDir); got != 0 {
+		t.Fatalf("port file not restored to absent: got port %d (fail-closed left auto-start's port-file write in place — this re-disarms the guard on a retry)", got)
+	}
+}
+
+// TestNewServerMode_AuthoritativeSource_FailClosed_RestoresPriorPortFileBytes
+// is the "prior bookkeeping existed" half: a stale ephemeral port from a
+// previous run is already recorded; the fail-closed return must restore
+// those exact bytes, not the new port auto-start just wrote.
+func TestNewServerMode_AuthoritativeSource_FailClosed_RestoresPriorPortFileBytes(t *testing.T) {
+	beadsDir := t.TempDir()
+	const configuredPort = 1
+	const priorPort = 9999
+	const newPort = 54402
+	t.Setenv("BEADS_TEST_MODE", "1")
+	portFilePath := filepath.Join(beadsDir, doltserver.PortFileName)
+	priorBytes := []byte(strconv.Itoa(priorPort))
+	if err := os.WriteFile(portFilePath, priorBytes, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &Config{
+		Database:         "test_port_provenance_restore_bytes",
+		BeadsDir:         beadsDir,
+		Path:             filepath.Join(beadsDir, "dolt"),
+		ServerHost:       "127.0.0.1",
+		ServerPort:       configuredPort,
+		ServerPortSource: doltserver.PortSourceConfigYaml,
+		AutoStart:        true,
+	}
+	stubEnsureRunningDetailedWithPortFileWrite(t, newPort, false)
+
+	_, err := newServerMode(context.Background(), cfg)
+	if err == nil {
+		t.Fatal("expected fail-closed error")
+	}
+
+	gotBytes, readErr := os.ReadFile(portFilePath)
+	if readErr != nil {
+		t.Fatalf("port file missing after fail-closed return: %v", readErr)
+	}
+	if string(gotBytes) != string(priorBytes) {
+		t.Fatalf("port file not byte-identical after restore: got %q, want %q", gotBytes, priorBytes)
+	}
+}
+
+// TestNewServerMode_SharedServer_FailClosed_RestoresPortFile is the same
+// byte-identical-restoration assertion for the shared-server-mode fail-closed
+// path (ServerPortSharedServer true).
+func TestNewServerMode_SharedServer_FailClosed_RestoresPortFile(t *testing.T) {
+	beadsDir := t.TempDir()
+	const configuredPort = 1
+	const priorPort = 8888
+	const newPort = 54407
+	t.Setenv("BEADS_TEST_MODE", "1")
+	portFilePath := filepath.Join(beadsDir, doltserver.PortFileName)
+	priorBytes := []byte(strconv.Itoa(priorPort))
+	if err := os.WriteFile(portFilePath, priorBytes, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &Config{
+		Database:               "test_port_provenance_shared_restore",
+		BeadsDir:               beadsDir,
+		Path:                   filepath.Join(beadsDir, "dolt"),
+		ServerHost:             "127.0.0.1",
+		ServerPort:             configuredPort,
+		ServerPortSource:       doltserver.PortSourcePortFile,
+		ServerPortSharedServer: true,
+		AutoStart:              true,
+	}
+	stubEnsureRunningDetailedWithPortFileWrite(t, newPort, false)
+
+	_, err := newServerMode(context.Background(), cfg)
+	if err == nil {
+		t.Fatal("expected fail-closed error")
+	}
+	if !strings.Contains(err.Error(), "Shared Dolt server") {
+		t.Fatalf("expected shared-server fail-closed message, got: %v", err)
+	}
+
+	gotBytes, readErr := os.ReadFile(portFilePath)
+	if readErr != nil {
+		t.Fatalf("port file missing after fail-closed return: %v", readErr)
+	}
+	if string(gotBytes) != string(priorBytes) {
+		t.Fatalf("port file not byte-identical after restore: got %q, want %q", gotBytes, priorBytes)
+	}
+}
+
+// TestNewServerMode_AuthoritativeSource_SecondCallStillFailsClosed is the
+// direct regression test for the user-visible bug: a SECOND, independent
+// invocation with freshly-resolved config (as a retrying user running
+// `bd close` again would produce) must still fail closed. It resolves the
+// port source via the real doltserver.DefaultConfig/config.yaml precedence
+// chain (not a hand-set field) so the port file's on-disk state genuinely
+// participates in resolution, exactly like a real second `bd` invocation
+// would. Before the fix, the first call's stray port-file write flipped the
+// second call's resolved source to PortSourcePortFile (non-authoritative),
+// silently disarming the guard.
+func TestNewServerMode_AuthoritativeSource_SecondCallStillFailsClosed(t *testing.T) {
+	t.Setenv("BEADS_TEST_MODE", "0")
+	t.Setenv("BEADS_DOLT_SERVER_PORT", "")
+	t.Setenv("BEADS_DOLT_SHARED_SERVER", "")
+
+	beadsDir := t.TempDir()
+	doltDir := filepath.Join(beadsDir, "dolt")
+	if err := os.MkdirAll(doltDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	const configuredPort = 1 // unreachable: nothing listens on port 1
+	body := []byte(fmt.Sprintf("listener:\n  host: 127.0.0.1\n  port: %d\n", configuredPort))
+	if err := os.WriteFile(filepath.Join(doltDir, "config.yaml"), body, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	buildCfg := func(t *testing.T, database string) *Config {
+		t.Helper()
+		dc := doltserver.DefaultConfig(beadsDir)
+		if dc.Port != configuredPort {
+			t.Fatalf("precondition: DefaultConfig resolved port %d, want %d (from dolt config.yaml)", dc.Port, configuredPort)
+		}
+		if dc.PortSource != doltserver.PortSourceDoltConfigYaml {
+			t.Fatalf("precondition: DefaultConfig resolved source %q, want %q — the port file left over from a prior call is shadowing the authoritative source", dc.PortSource, doltserver.PortSourceDoltConfigYaml)
+		}
+		return &Config{
+			// Not a test-mode database name: this test deliberately runs
+			// with BEADS_TEST_MODE=0 to exercise the untracked (non-test)
+			// auto-start-stop path in newServerMode/undoRejectedAutoStart.
+			Database:               database,
+			BeadsDir:               beadsDir,
+			Path:                   doltDir,
+			ServerHost:             dc.Host,
+			ServerPort:             dc.Port,
+			ServerPortSource:       dc.PortSource,
+			ServerPortSharedServer: dc.PortSharedServer,
+			AutoStart:              true,
+		}
+	}
+
+	// First invocation: auto-start ends up on a different port; must fail closed.
+	stubEnsureRunningDetailedWithPortFileWrite(t, 54403, true)
+	_, err := newServerMode(context.Background(), buildCfg(t, "prod_second_call_1"))
+	if err == nil {
+		t.Fatal("expected fail-closed error on first invocation")
+	}
+	if !strings.Contains(err.Error(), "will not silently use") {
+		t.Fatalf("expected fail-closed message on first call, got: %v", err)
+	}
+
+	// Second, independent invocation with freshly-resolved config: must
+	// STILL fail closed. This is the actual user-visible regression
+	// (GH#4052 round 3) — the guard must not disarm itself after one call.
+	stubEnsureRunningDetailedWithPortFileWrite(t, 54404, true)
+	_, err = newServerMode(context.Background(), buildCfg(t, "prod_second_call_2"))
+	if err == nil {
+		t.Fatal("expected fail-closed error on second invocation — the port-file restore/stop is missing or broken")
+	}
+	if !strings.Contains(err.Error(), "will not silently use") {
+		t.Fatalf("expected fail-closed message on second call, got: %v", err)
+	}
+}
+
+// --- undoRejectedAutoStart: server-stop behavior ---
+//
+// startedByUs distinguishes "we spawned this server speculatively and are
+// now declining to use it" (must stop it) from "we adopted an
+// already-running server" (must leave it alone — we didn't start it, and
+// something else may still be using it).
+
+// stubStopRejectedAutoStartedServer replaces the package-level
+// stopRejectedAutoStartedServer var with a call-counting stub, so these
+// tests never attempt to signal a real process.
+func stubStopRejectedAutoStartedServer(t *testing.T) *int {
+	t.Helper()
+	calls := new(int)
+	orig := stopRejectedAutoStartedServer
+	t.Cleanup(func() { stopRejectedAutoStartedServer = orig })
+	stopRejectedAutoStartedServer = func(beadsDir string) error {
+		*calls++
+		return nil
+	}
+	return calls
+}
+
+func TestUndoRejectedAutoStart_StartedByUs_StopsServer(t *testing.T) {
+	calls := stubStopRejectedAutoStartedServer(t)
+	serverDir := t.TempDir()
+
+	undoRejectedAutoStart(serverDir, true /* startedByUs */, "" /* autoStartedDir: untracked */, doltserver.PortFileSnapshot{}, nil)
+
+	if *calls != 1 {
+		t.Fatalf("stopRejectedAutoStartedServer called %d times, want 1 (we spawned the server and declined to use it)", *calls)
+	}
+}
+
+func TestUndoRejectedAutoStart_AdoptedServer_NotStopped(t *testing.T) {
+	calls := stubStopRejectedAutoStartedServer(t)
+	serverDir := t.TempDir()
+
+	undoRejectedAutoStart(serverDir, false /* startedByUs: adopted pre-existing */, "", doltserver.PortFileSnapshot{}, nil)
+
+	if *calls != 0 {
+		t.Fatalf("stopRejectedAutoStartedServer called %d times, want 0 (an adopted pre-existing server must not be stopped)", *calls)
+	}
+}
+
+// TestUndoRejectedAutoStart_PortFileSnapshotError_SkipsRestore verifies that
+// a failed snapshot (snapErr != nil) does not trigger a restore attempt — a
+// zero-value snapshot in that case does not mean "file did not exist", so
+// blindly restoring it could wrongly delete a port file that was never
+// actually read.
+func TestUndoRejectedAutoStart_PortFileSnapshotError_SkipsRestore(t *testing.T) {
+	stubStopRejectedAutoStartedServer(t)
+	beadsDir := t.TempDir()
+	portFilePath := filepath.Join(beadsDir, doltserver.PortFileName)
+	if err := os.WriteFile(portFilePath, []byte("54408"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	undoRejectedAutoStart(beadsDir, true, "", doltserver.PortFileSnapshot{}, fmt.Errorf("simulated snapshot read failure"))
+
+	if _, err := os.Stat(portFilePath); err != nil {
+		t.Fatalf("port file should have been left alone after a snapshot error, stat err = %v", err)
 	}
 }
 

--- a/internal/storage/dolt/port_provenance_test.go
+++ b/internal/storage/dolt/port_provenance_test.go
@@ -1,0 +1,176 @@
+package dolt
+
+import (
+	"context"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/doltserver"
+)
+
+// These tests cover the auto-start port-provenance fail-closed behavior
+// (GH#4052): when the configured Dolt server port is unreachable and
+// auto-start ends up on a different port, bd must fail closed instead of
+// silently retargeting when the configured port came from an authoritative
+// source (env var, project/global config.yaml, metadata.json). Retargeting
+// stays unchanged when the source is bd's own port-file bookkeeping, or when
+// no port was ever configured (ServerPort == 0).
+//
+// stubEnsureRunningDetailed replaces the package-level ensureRunningDetailed
+// var so these tests never spawn a real dolt sql-server process.
+func stubEnsureRunningDetailed(t *testing.T, port int, startedByUs bool, err error) {
+	t.Helper()
+	orig := ensureRunningDetailed
+	t.Cleanup(func() { ensureRunningDetailed = orig })
+	ensureRunningDetailed = func(beadsDir string) (int, bool, error) {
+		return port, startedByUs, err
+	}
+}
+
+// baseAutoStartCfg returns a Config that will reach the auto-start branch of
+// newServerMode: the initial dial to ServerPort fails (nothing listens on
+// port 1), auto-start is permitted, and BEADS_TEST_MODE disables the real
+// circuit breaker so no state files are touched.
+func baseAutoStartCfg(t *testing.T, database string, serverPort int, source doltserver.PortSource) *Config {
+	t.Helper()
+	t.Setenv("BEADS_TEST_MODE", "1")
+	return &Config{
+		Database:         database,
+		Path:             t.TempDir(),
+		ServerHost:       "127.0.0.1",
+		ServerPort:       serverPort,
+		ServerPortSource: source,
+		AutoStart:        true,
+		DisableAutoStart: false,
+	}
+}
+
+// TestNewServerMode_AuthoritativePortSource_RetargetedPort_FailsClosed is the
+// regression test: an authoritative port source (env var here) plus a
+// changed auto-start port must fail closed with an explanatory error, not
+// silently retarget. Verified to genuinely discriminate: reverting the
+// store.go fail-closed check makes this test fail (see session report).
+func TestNewServerMode_AuthoritativePortSource_RetargetedPort_FailsClosed(t *testing.T) {
+	const configuredPort = 1 // unreachable: nothing listens on port 1
+	const newPort = 54321
+	cfg := baseAutoStartCfg(t, "test_port_provenance_env", configuredPort, doltserver.PortSourceEnv)
+	stubEnsureRunningDetailed(t, newPort, false, nil)
+
+	_, err := newServerMode(context.Background(), cfg)
+	if err == nil {
+		t.Fatal("expected fail-closed error when an authoritative port source disagrees with auto-start's port")
+	}
+	msg := err.Error()
+	for _, want := range []string{
+		strconv.Itoa(configuredPort),
+		strconv.Itoa(newPort),
+		"will not silently use",
+		"bd dolt start",
+	} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("error message missing %q: %s", want, msg)
+		}
+	}
+	if cfg.ServerPort != configuredPort {
+		t.Errorf("cfg.ServerPort mutated to %d on fail-closed path, want unchanged %d", cfg.ServerPort, configuredPort)
+	}
+}
+
+// TestNewServerMode_AllAuthoritativeSources_FailClosed exercises each
+// authoritative PortSource, not just env, to guard against a future source
+// being added to the authoritative set without updating IsAuthoritative (or
+// vice versa).
+func TestNewServerMode_AllAuthoritativeSources_FailClosed(t *testing.T) {
+	sources := []doltserver.PortSource{
+		doltserver.PortSourceEnv,
+		doltserver.PortSourceDoltConfigYaml,
+		doltserver.PortSourceConfigYaml,
+		doltserver.PortSourceMetadataJSON,
+	}
+	for _, src := range sources {
+		src := src
+		t.Run(string(src), func(t *testing.T) {
+			cfg := baseAutoStartCfg(t, "test_port_provenance_"+string(src), 1, src)
+			stubEnsureRunningDetailed(t, 54322, false, nil)
+
+			_, err := newServerMode(context.Background(), cfg)
+			if err == nil {
+				t.Fatalf("expected fail-closed error for authoritative source %q", src)
+			}
+			if !strings.Contains(err.Error(), "will not silently use") {
+				t.Errorf("source %q: expected fail-closed message, got: %v", src, err)
+			}
+		})
+	}
+}
+
+// TestNewServerMode_PortFileSource_RetargetedPort_StillRetargets guards
+// against the UX regression: bd's own port-file bookkeeping must keep
+// today's silent-retarget-with-warning behavior. Since the retargeted port
+// (54323) is not a real server either, the open still ultimately fails, but
+// via the old "auto-started but still unreachable" path, not the new
+// fail-closed error — proving cfg.ServerPort was updated and a connection
+// was attempted on the new port.
+func TestNewServerMode_PortFileSource_RetargetedPort_StillRetargets(t *testing.T) {
+	const configuredPort = 1
+	const newPort = 54323
+	cfg := baseAutoStartCfg(t, "test_port_provenance_portfile", configuredPort, doltserver.PortSourcePortFile)
+	stubEnsureRunningDetailed(t, newPort, false, nil)
+
+	_, err := newServerMode(context.Background(), cfg)
+	if err == nil {
+		t.Fatal("expected a connection error (no real server listening on the retargeted port)")
+	}
+	if strings.Contains(err.Error(), "will not silently use") {
+		t.Fatalf("port-file source must not trigger the fail-closed path, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "auto-started but still unreachable") {
+		t.Fatalf("expected the existing auto-start-unreachable error, got: %v", err)
+	}
+	if cfg.ServerPort != newPort {
+		t.Errorf("cfg.ServerPort = %d, want retargeted to %d", cfg.ServerPort, newPort)
+	}
+}
+
+// TestNewServerMode_UnsetPortSource_RetargetedPort_StillRetargets guards the
+// same UX-preservation case for a Config built without ServerPortSource set
+// at all (zero value == PortSourceUnset), matching any caller that
+// constructs Config directly rather than through applyConfigDefaults.
+func TestNewServerMode_UnsetPortSource_RetargetedPort_StillRetargets(t *testing.T) {
+	const configuredPort = 1
+	const newPort = 54324
+	cfg := baseAutoStartCfg(t, "test_port_provenance_unset", configuredPort, doltserver.PortSourceUnset)
+	stubEnsureRunningDetailed(t, newPort, false, nil)
+
+	_, err := newServerMode(context.Background(), cfg)
+	if err == nil {
+		t.Fatal("expected a connection error (no real server listening on the retargeted port)")
+	}
+	if strings.Contains(err.Error(), "will not silently use") {
+		t.Fatalf("unset port source must not trigger the fail-closed path, got: %v", err)
+	}
+	if cfg.ServerPort != newPort {
+		t.Errorf("cfg.ServerPort = %d, want retargeted to %d", cfg.ServerPort, newPort)
+	}
+}
+
+// TestNewServerMode_ZeroServerPort_Unaffected verifies cfg.ServerPort == 0
+// (never resolved) is unaffected by the provenance check regardless of
+// source: auto-start always adopts the ephemeral port it allocated.
+func TestNewServerMode_ZeroServerPort_Unaffected(t *testing.T) {
+	const newPort = 54325
+	cfg := baseAutoStartCfg(t, "test_port_provenance_zero", 0, doltserver.PortSourceEnv)
+	stubEnsureRunningDetailed(t, newPort, false, nil)
+
+	_, err := newServerMode(context.Background(), cfg)
+	if err == nil {
+		t.Fatal("expected a connection error (no real server listening on the allocated port)")
+	}
+	if strings.Contains(err.Error(), "will not silently use") {
+		t.Fatalf("cfg.ServerPort == 0 must never trigger the fail-closed path, got: %v", err)
+	}
+	if cfg.ServerPort != newPort {
+		t.Errorf("cfg.ServerPort = %d, want adopted ephemeral port %d", cfg.ServerPort, newPort)
+	}
+}

--- a/internal/storage/dolt/port_provenance_test.go
+++ b/internal/storage/dolt/port_provenance_test.go
@@ -174,3 +174,80 @@ func TestNewServerMode_ZeroServerPort_Unaffected(t *testing.T) {
 		t.Errorf("cfg.ServerPort = %d, want adopted ephemeral port %d", cfg.ServerPort, newPort)
 	}
 }
+
+// --- Shared-server mode (GH#4052 primary scenario) ---
+//
+// In shared-server mode, DefaultConfig resolves the port from the *shared*
+// server directory's port sources (or falls back to DefaultSharedServerPort
+// when none resolve one), but EnsureRunningDetailed(resolvedBeadsDir) in
+// newServerMode's auto-start branch always starts a *repo-local* server.
+// That is a different database than the shared one, so a port change here
+// must fail closed regardless of ServerPortSource — including
+// PortSourcePortFile, which is authoritative-false and would otherwise
+// silently retarget (this is exactly the scenario the title of GH#4052
+// describes: "write commands report success when Dolt is unreachable").
+
+// baseAutoStartCfgShared is baseAutoStartCfg plus ServerPortSharedServer set,
+// modeling a Config built by applyConfigDefaults in shared-server mode.
+func baseAutoStartCfgShared(t *testing.T, database string, serverPort int, source doltserver.PortSource) *Config {
+	t.Helper()
+	cfg := baseAutoStartCfg(t, database, serverPort, source)
+	cfg.ServerPortSharedServer = true
+	return cfg
+}
+
+// TestNewServerMode_SharedServerResolvedPort_PortFileSource_FailsClosed is
+// the regression test for the gap identified in review: a shared-server-mode
+// port sourced from the (shared) port file — non-authoritative by
+// PortSource.IsAuthoritative() alone — must still fail closed, because
+// auto-start would create a repo-local server, not reconnect to the shared
+// one. Reverting the ServerPortSharedServer half of the condition in
+// newServerMode makes this test fail (confirmed; see session report).
+func TestNewServerMode_SharedServerResolvedPort_PortFileSource_FailsClosed(t *testing.T) {
+	const configuredPort = 1
+	const newPort = 54326
+	cfg := baseAutoStartCfgShared(t, "test_port_provenance_shared_portfile", configuredPort, doltserver.PortSourcePortFile)
+	stubEnsureRunningDetailed(t, newPort, false, nil)
+
+	_, err := newServerMode(context.Background(), cfg)
+	if err == nil {
+		t.Fatal("expected fail-closed error when a shared-server-resolved port disagrees with auto-start's port")
+	}
+	msg := err.Error()
+	for _, want := range []string{
+		strconv.Itoa(configuredPort),
+		strconv.Itoa(newPort),
+		"Shared Dolt server",
+		"different database",
+		"bd dolt start",
+	} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("error message missing %q: %s", want, msg)
+		}
+	}
+	if cfg.ServerPort != configuredPort {
+		t.Errorf("cfg.ServerPort mutated to %d on fail-closed path, want unchanged %d", cfg.ServerPort, configuredPort)
+	}
+}
+
+// TestNewServerMode_SharedServerFixedPortFallback_FailsClosed covers the
+// second shared-mode branch in doltserver.DefaultConfig: no port source
+// resolved a value, so it fell back to DefaultSharedServerPort
+// (PortSourceUnset, ServerPortSharedServer true). That must also fail closed.
+func TestNewServerMode_SharedServerFixedPortFallback_FailsClosed(t *testing.T) {
+	const configuredPort = 1
+	const newPort = 54327
+	cfg := baseAutoStartCfgShared(t, "test_port_provenance_shared_fallback", configuredPort, doltserver.PortSourceUnset)
+	stubEnsureRunningDetailed(t, newPort, false, nil)
+
+	_, err := newServerMode(context.Background(), cfg)
+	if err == nil {
+		t.Fatal("expected fail-closed error for the shared-mode fixed-port fallback case")
+	}
+	if !strings.Contains(err.Error(), "Shared Dolt server") {
+		t.Errorf("expected shared-server fail-closed message, got: %v", err)
+	}
+	if cfg.ServerPort != configuredPort {
+		t.Errorf("cfg.ServerPort mutated to %d on fail-closed path, want unchanged %d", cfg.ServerPort, configuredPort)
+	}
+}

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -230,6 +230,56 @@ func autoStartRelease(serverDir string) error {
 	return nil
 }
 
+// undoRejectedAutoStart cleans up the side effects of a speculative
+// auto-start that newServerMode's fail-closed checks (GH#4052) decided not
+// to use.
+//
+// It restores the port file to the pre-call snapshot: EnsureRunningDetailed
+// writes serverDir's port file with the new server's actual port before
+// either fail-closed check runs (Start()'s writePortFile, or the
+// adopt-existing-server path's EnsurePortFile), and that port file is the
+// second-highest-precedence port source. Left in place, it would let a
+// second, identical invocation resolve the port file instead of the
+// authoritative source that just failed, adopt the server we declined to
+// use, and silently succeed — permanently disarming the guard after exactly
+// one invocation.
+//
+// When we spawned the server ourselves (startedByUs), it also stops it: we
+// have decided not to use it, so leaving a stray dolt process running is an
+// unrequested side effect. When autoStartedDir is set, the server is
+// refcount-tracked (the test/test-database path via autoStartAcquire); that
+// path already stops the server once the refcount reaches zero, so
+// autoStartRelease is used instead of a direct Stop to avoid pulling the rug
+// out from under another store instance sharing the same auto-started
+// server. An adopted pre-existing server (startedByUs == false) is left
+// running — we didn't start it, so we don't stop it, but its port file
+// write must still be undone.
+//
+// Best-effort throughout: cleanup failures are reported on stderr but never
+// returned, so they cannot mask the caller's fail-closed error, which is the
+// one that matters.
+func undoRejectedAutoStart(serverDir string, startedByUs bool, autoStartedDir string, snap doltserver.PortFileSnapshot, snapErr error) {
+	if startedByUs {
+		if autoStartedDir != "" {
+			if err := autoStartRelease(autoStartedDir); err != nil {
+				fmt.Fprintf(os.Stderr, "Warning: failed to stop rejected auto-started dolt server: %v\n", err)
+			}
+		} else if err := doltserver.IgnoreNotRunning(stopRejectedAutoStartedServer(serverDir)); err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: failed to stop rejected auto-started dolt server: %v\n", err)
+		}
+	}
+	if snapErr != nil {
+		// The pre-call snapshot itself failed (e.g. a permissions error
+		// reading an existing file) — restoring a zero-value snapshot here
+		// could wrongly delete a port file we never actually read. Leave the
+		// port file alone rather than guess.
+		return
+	}
+	if err := doltserver.RestorePortFile(serverDir, snap); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: failed to restore port file after rejected auto-start: %v\n", err)
+	}
+}
+
 // shouldStopAutoStartedServerOnClose reports whether an auto-started server
 // should be treated as test-owned cleanup state instead of a normal repo-local
 // server. In real repos, auto-start should behave like a persistent helper
@@ -1460,6 +1510,13 @@ func resolveSocketTransport(socket, host string, port int, timeout time.Duration
 // real dolt sql-server process.
 var ensureRunningDetailed = doltserver.EnsureRunningDetailed
 
+// stopRejectedAutoStartedServer stops a repo-local dolt sql-server that
+// newServerMode's fail-closed checks (GH#4052) decided not to use. Declared
+// as a var (matching ensureRunningDetailed above) so unit tests can stub it
+// and assert whether it was invoked, without spawning or killing a real
+// dolt sql-server process.
+var stopRejectedAutoStartedServer = doltserver.Stop
+
 // newServerMode creates a DoltStore connected to a running dolt sql-server.
 // This path is pure Go and does not require CGO.
 func newServerMode(ctx context.Context, cfg *Config) (*DoltStore, error) {
@@ -1506,6 +1563,23 @@ func newServerMode(ctx context.Context, cfg *Config) (*DoltStore, error) {
 		// to manage their own server lifecycle.
 		canAutoStart := serverOpenCanAutoStart(cfg)
 		if canAutoStart {
+			// Snapshot the port file's exact pre-call state before letting
+			// EnsureRunningDetailed write to it. Start() (and the
+			// adopt-existing-server path) write serverDir's port file with
+			// the actual listening port *inside* EnsureRunningDetailed —
+			// before either fail-closed check below runs. Left in place, a
+			// fail-closed return here still leaves that new port findable
+			// via the port-file source (PortSourcePortFile, non-authoritative),
+			// so a second, identical invocation would resolve the port file
+			// instead of the authoritative source, adopt the server we just
+			// declined to use, and silently succeed — permanently disarming
+			// the guard after exactly one invocation (GH#4052 round 3). The
+			// fail-closed branches below restore this snapshot before
+			// returning so a retry re-triggers the same check.
+			portFileSnap, snapErr := doltserver.SnapshotPortFile(serverDir)
+			if snapErr != nil {
+				fmt.Fprintf(os.Stderr, "Warning: could not snapshot port file before auto-start: %v\n", snapErr)
+			}
 			port, startedByUs, startErr := ensureRunningDetailed(resolvedBeadsDir)
 			if startErr != nil {
 				return nil, fmt.Errorf("Dolt server unreachable at %s and auto-start failed: %w\n\n"+
@@ -1544,9 +1618,7 @@ func newServerMode(ctx context.Context, cfg *Config) (*DoltStore, error) {
 					// write commands report success when Dolt is
 					// unreachable").
 					if cfg.ServerPortSharedServer {
-						if autoStartedDir != "" {
-							_ = autoStartRelease(autoStartedDir)
-						}
+						undoRejectedAutoStart(serverDir, startedByUs, autoStartedDir, portFileSnap, snapErr)
 						if breaker != nil {
 							breaker.RecordFailure()
 						}
@@ -1562,9 +1634,7 @@ func newServerMode(ctx context.Context, cfg *Config) (*DoltStore, error) {
 							cfg.ServerPort, cfg.ServerPortSource, port, port, cfg.ServerPort)
 					}
 					if cfg.ServerPortSource.IsAuthoritative() {
-						if autoStartedDir != "" {
-							_ = autoStartRelease(autoStartedDir)
-						}
+						undoRejectedAutoStart(serverDir, startedByUs, autoStartedDir, portFileSnap, snapErr)
 						if breaker != nil {
 							breaker.RecordFailure()
 						}

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -337,6 +337,16 @@ type Config struct {
 	// safe (GH#4052).
 	ServerPortSource doltserver.PortSource
 
+	// ServerPortSharedServer mirrors doltserver.Config.PortSharedServer:
+	// true when ServerPort was resolved via shared-server mode
+	// (BEADS_DOLT_SHARED_SERVER=1). In shared-server mode, auto-start's
+	// EnsureRunningDetailed(resolvedBeadsDir) always spins up a repo-local
+	// server (a different database than the shared one), so a port change
+	// here is never a benign refresh regardless of ServerPortSource —
+	// consulted by newServerMode's auto-start path alongside
+	// ServerPortSource.IsAuthoritative() (GH#4052).
+	ServerPortSharedServer bool
+
 	// Remote auth for Hosted Dolt push/pull (optional)
 	// When set, Push/Pull use the --user flag and set DOLT_REMOTE_PASSWORD env var.
 	RemoteUser     string // Hosted Dolt remote user (set via DOLT_REMOTE_USER env var)
@@ -1252,6 +1262,7 @@ func applyConfigDefaults(cfg *Config) {
 			if resolved := doltserver.DefaultConfig(resolveDir); resolved.Port > 0 {
 				cfg.ServerPort = resolved.Port
 				cfg.ServerPortSource = resolved.PortSource
+				cfg.ServerPortSharedServer = resolved.PortSharedServer
 			}
 		}
 	}
@@ -1520,6 +1531,36 @@ func newServerMode(ctx context.Context, cfg *Config) (*DoltStore, error) {
 					// (e.g. a shared-server host serving multiple repos);
 					// only bd's own bookkeeping is safe to replace without
 					// confirmation.
+					//
+					// Shared-server mode is a second, orthogonal reason to
+					// fail closed regardless of ServerPortSource: the
+					// configured port resolved from the *shared* server
+					// directory, but EnsureRunningDetailed(resolvedBeadsDir)
+					// above always auto-starts a *repo-local* server — a
+					// different database than the shared one. Retargeting
+					// there is never a benign port refresh; it means the
+					// shared server is down and bd just silently wrote
+					// somewhere else instead (GH#4052, "Shared-server mode:
+					// write commands report success when Dolt is
+					// unreachable").
+					if cfg.ServerPortSharedServer {
+						if autoStartedDir != "" {
+							_ = autoStartRelease(autoStartedDir)
+						}
+						if breaker != nil {
+							breaker.RecordFailure()
+						}
+						return nil, fmt.Errorf(
+							"Shared Dolt server configured at port %d (source: %s) is unreachable; "+
+								"auto-start started a repo-local server on port %d instead, but bd will "+
+								"not silently write to it\n\n"+
+								"A repo-local server is a different database than the shared one, so "+
+								"using port %d here would silently write to the wrong database.\n\n"+
+								"To proceed:\n"+
+								"  - Restart the shared Dolt server: bd dolt start\n"+
+								"  - Or check why it stopped responding on port %d before retrying",
+							cfg.ServerPort, cfg.ServerPortSource, port, port, cfg.ServerPort)
+					}
 					if cfg.ServerPortSource.IsAuthoritative() {
 						if autoStartedDir != "" {
 							_ = autoStartRelease(autoStartedDir)

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -328,6 +328,15 @@ type Config struct {
 	ServerPassword string // MySQL password (default: empty, can be set via BEADS_DOLT_PASSWORD)
 	ServerTLS      bool   // Enable TLS for server connections (required for Hosted Dolt)
 
+	// ServerPortSource records which step of doltserver's port-resolution
+	// chain (or the env-var read in applyConfigDefaults) produced ServerPort.
+	// Zero value (doltserver.PortSourceUnset) when ServerPort was never
+	// resolved from a source (e.g. left 0, or set directly by a caller that
+	// bypassed applyConfigDefaults). Consulted by newServerMode's auto-start
+	// path to decide whether silently retargeting to a different port is
+	// safe (GH#4052).
+	ServerPortSource doltserver.PortSource
+
 	// Remote auth for Hosted Dolt push/pull (optional)
 	// When set, Push/Pull use the --user flag and set DOLT_REMOTE_PASSWORD env var.
 	RemoteUser     string // Hosted Dolt remote user (set via DOLT_REMOTE_USER env var)
@@ -1222,6 +1231,11 @@ func applyConfigDefaults(cfg *Config) {
 	if envPort != "" {
 		if p, err := strconv.Atoi(envPort); err == nil && p > 0 {
 			cfg.ServerPort = p
+			// This env read happens before doltserver.DefaultConfig is
+			// consulted below, but it is the same authoritative source
+			// (BEADS_DOLT_SERVER_PORT / legacy BEADS_DOLT_PORT) — record it
+			// so the auto-start fail-closed check in newServerMode sees it.
+			cfg.ServerPortSource = doltserver.PortSourceEnv
 		}
 	}
 	// If env var didn't provide a port, consult the full resolution chain:
@@ -1237,6 +1251,7 @@ func applyConfigDefaults(cfg *Config) {
 		if resolveDir != "" {
 			if resolved := doltserver.DefaultConfig(resolveDir); resolved.Port > 0 {
 				cfg.ServerPort = resolved.Port
+				cfg.ServerPortSource = resolved.PortSource
 			}
 		}
 	}
@@ -1428,6 +1443,12 @@ func resolveSocketTransport(socket, host string, port int, timeout time.Duration
 	return socket // both down (or no TCP port) — keep socket for the error path
 }
 
+// ensureRunningDetailed starts (or reuses) the repo-local auto-started dolt
+// sql-server. Declared as a var (not a plain call) so unit tests can stub
+// auto-start outcomes — including a retargeted port — without spawning a
+// real dolt sql-server process.
+var ensureRunningDetailed = doltserver.EnsureRunningDetailed
+
 // newServerMode creates a DoltStore connected to a running dolt sql-server.
 // This path is pure Go and does not require CGO.
 func newServerMode(ctx context.Context, cfg *Config) (*DoltStore, error) {
@@ -1474,7 +1495,7 @@ func newServerMode(ctx context.Context, cfg *Config) (*DoltStore, error) {
 		// to manage their own server lifecycle.
 		canAutoStart := serverOpenCanAutoStart(cfg)
 		if canAutoStart {
-			port, startedByUs, startErr := doltserver.EnsureRunningDetailed(resolvedBeadsDir)
+			port, startedByUs, startErr := ensureRunningDetailed(resolvedBeadsDir)
 			if startErr != nil {
 				return nil, fmt.Errorf("Dolt server unreachable at %s and auto-start failed: %w\n\n"+
 					"To start manually: bd dolt start\n"+
@@ -1491,6 +1512,34 @@ func newServerMode(ctx context.Context, cfg *Config) (*DoltStore, error) {
 			// Update port — EnsureRunning allocates an ephemeral port
 			if port != cfg.ServerPort {
 				if cfg.ServerPort > 0 {
+					// A configured port is either an authoritative user
+					// assertion (env var, project/global config.yaml,
+					// metadata.json) or bd's own port-file bookkeeping
+					// (GH#4052). Silently retargeting an authoritative port
+					// can land the write on the wrong project's database
+					// (e.g. a shared-server host serving multiple repos);
+					// only bd's own bookkeeping is safe to replace without
+					// confirmation.
+					if cfg.ServerPortSource.IsAuthoritative() {
+						if autoStartedDir != "" {
+							_ = autoStartRelease(autoStartedDir)
+						}
+						if breaker != nil {
+							breaker.RecordFailure()
+						}
+						return nil, fmt.Errorf(
+							"Dolt server configured at port %d (source: %s) is unreachable; "+
+								"auto-start started a new server on port %d, but bd will not "+
+								"silently use a different port than the one you configured\n\n"+
+								"The configured port may be pointing at a shared-server host "+
+								"serving a different project's database; using port %d instead "+
+								"could silently write to the wrong database.\n\n"+
+								"To proceed:\n"+
+								"  - Start the configured server manually: bd dolt start\n"+
+								"  - Or remove/change the pinned port (env var, .beads/config.yaml "+
+								"dolt.port, or global config) if port %d is stale",
+							cfg.ServerPort, cfg.ServerPortSource, port, port, cfg.ServerPort)
+					}
 					fmt.Fprintf(os.Stderr, "Warning: Dolt server endpoint changed: port %d → %d (auto-start)\n", cfg.ServerPort, port)
 					fmt.Fprintf(os.Stderr, "  Previous port was unreachable. If other tools expect port %d, they may see stale data.\n", cfg.ServerPort)
 					fmt.Fprintf(os.Stderr, "  To pin a port: set dolt.port in .beads/config.yaml\n")


### PR DESCRIPTION
Fixes the silent-wrong-database write in #4052, "Shared-server mode: write commands report success when Dolt is unreachable; status change never lands."

## Why the obvious fix is wrong

When the configured Dolt server is unreachable, `newServerMode` auto-starts a new server, which lands on an **ephemeral port**. Today the mismatch is announced on stderr only, `cfg.ServerPort` is overwritten, and the command proceeds — so the write goes to whatever database that new server serves, with exit 0 and a success message.

Simply refusing to retarget would be a bad regression: in the common single-repo case the recorded port is just a stale ephemeral leftover, and silently picking a fresh one is exactly what users want. So the fix has to distinguish the two situations, and it turns out **two** independent things make a retarget unsafe:

**1. Provenance.** A port the *user* asserted — env var, `config.yaml` `dolt.port`, global config, `metadata.json` — is a statement about where the server is. Silently substituting a different one contradicts it. A port bd itself recorded in the gitignored `.beads/dolt-server.port` is our own bookkeeping and may be replaced freely.

That information was being discarded: `DefaultConfig` collapsed a five-source precedence chain into a bare `int`. It already evaluated each source as a separate branch, so recording a `PortSource` alongside the port is nearly free.

**2. Which server directory the port belongs to.** This is the case the issue title is actually about, and provenance alone does not catch it. In shared-server mode `DefaultConfig` resolves the port from the **shared** server directory, so its source is the port file — "non-authoritative" by rule 1. But auto-start calls `EnsureRunningDetailed(resolvedBeadsDir)` with the **repo's** `.beads`. Shared server goes down → bd starts a repo-local server → **different database** → silent write. So a port that resolves from a different server directory than the one auto-start would create is never a benign refresh, whatever its provenance.

Hence `PortSharedServer` as a separate flag rather than another `PortSource` constant — it is orthogonal, since a shared-mode port can come from any source.

## The non-obvious part: the guard has to undo the auto-start

`doltserver.Start()` writes the port file **inside** `EnsureRunningDetailed`, before either check runs. The port file outranks `config.yaml` in the resolution chain, so without cleanup:

1. Configured port down → auto-start on ephemeral `Q` → port file now says `Q` → guard fires → error. Correct.
2. User retries. The port now resolves to `Q` **from the port file** — non-authoritative — the server on `Q` is up, the dial succeeds, the auto-start branch is never entered, and bd silently writes to the wrong database.

The guard would fire exactly once and then permanently disarm itself, which is worse than not guarding: the user sees an error, retries, it "works", and concludes the first error was transient.

So both fail-closed paths now restore the port file to its pre-call state (bytes, or absence) and, when `startedByUs`, stop the server we spawned and declined to use. An *adopted* pre-existing server is left running. Cleanup is best-effort and never masks the original error. If the pre-call snapshot itself failed, the port file is left alone rather than guessed at.

## Behavior change worth calling out explicitly

`config.yaml` and `metadata.json` are **git-tracked by default** — the project's own `.beads/.gitignore` template ignores only `dolt-server.pid/.log/.lock/.port/.activity`.

So a fresh clone that inherited a collaborator's pinned `dolt.port`, with no local server running, now gets a hard error where today it silently auto-starts and retargets. That is a deliberate choice, not an oversight: the asymmetry favors an actionable error over silent data divergence, and a git-tracked port pointing at whatever happens to be listening locally is the cross-project-leakage hazard that made the port file outrank `config.yaml` in the first place.

If you would rather keep that case working, the narrower policy is "env var and shared-server mode only" — a one-line change to `IsAuthoritative()`. I would rather you make that call than discover it from a support report.

## Scope, stated honestly

Does **not** fix a *poisoned* port file — bd writing a port that points at an unintended server in the first place. That is a separate defect and stays open after this.

Unaffected: `cfg.ServerPort == 0` (never resolved), port-file-sourced ports in non-shared mode, and remote hosts, which already fail closed because `serverOpenCanAutoStart` requires `isLocalHost`.

## Tests

- authoritative source + retarget → fails closed; one subtest per authoritative source
- **shared-server-resolved port with a `PortSourcePortFile` source** + retarget → fails closed (the case rule 1 alone misses)
- shared mode falling back to the fixed shared port → fails closed
- port-file source in non-shared mode → still retargets (guards the UX regression)
- `cfg.ServerPort == 0` → unaffected
- port file restored byte-identically, and restored to *absent* when it did not exist
- a **second** `newServerMode` call, resolving through the real `DefaultConfig` precedence chain, still fails closed — the self-disarming case above
- `startedByUs` stops the spawned server; an adopted server is left alone
- `DefaultConfig` unit tests pinning `PortSource` per branch and `PortSharedServer`

Each regression test was negative-controlled: with the corresponding half of the fix reverted, it fails. One caveat — the "second call" test is not a pure discriminator for the port-file restore alone, because `Stop()`'s own cleanup also removes the port file when `startedByUs`; the three byte-identical/absent-restore tests cover that path directly.

`go build ./...`, `go vet`, and the full `./internal/doltserver/` package pass, as do the targeted `internal/storage/dolt` tests. The full `./internal/storage/dolt/` suite is running in our local verification queue; I will report if anything falls out.

_claude-opus-5-medium on behalf of maphew_
