### PR TITLE
test(cmd/bd): de-flake comment ordering test — distinct seconds per comment (bd-vuulx)

### DIFF
--- a/cmd/bd/comment_proxied_integration_test.go
+++ b/cmd/bd/comment_proxied_integration_test.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/steveyegge/beads/internal/types"
 )
@@ -110,8 +111,13 @@ func TestProxiedServerComment(t *testing.T) {
 		p := newSharedProxiedProject(t, bd, "mo")
 		issue := bdProxiedCreate(t, bd, p.dir, "Multi comment")
 
+		// created_at is second-resolution and ids are content digests, so
+		// same-second comments have no defined relative order (bd-vuulx);
+		// give each comment its own second to keep the assertion meaningful.
 		bdProxiedComment(t, bd, p.dir, issue.ID, "one")
+		time.Sleep(1100 * time.Millisecond)
 		bdProxiedComment(t, bd, p.dir, issue.ID, "two")
+		time.Sleep(1100 * time.Millisecond)
 		bdProxiedComment(t, bd, p.dir, issue.ID, "three")
 
 		comments := bdProxiedCommentsJSON(t, bd, p.dir, issue.ID)


### PR DESCRIPTION
## What

Two-line test fix: stagger the three comments in `TestProxiedServerComment/multiple_comments_ordered` across distinct wall-clock seconds (1.1s sleeps), plus the `time` import.

## Why

Since bd-ri8bd (423afdcb2, merged 7/29), comment ids are content digests (`InsertDerivedComment`, ordinal always 0) and `created_at` is stamped app-side at second resolution. Comment listing orders by `(created_at ASC, id ASC)`, so three comments landing in the same second tie on `created_at` and tiebreak on digest ids — arbitrary relative order, a 1-in-6 chance of passing. On CI runners the three CLI invocations reliably land in the same second: PR #5162's run failed this subtest twice in a row with two different wrong permutations (`three,two,one`, then `one,three,two`), turning Proxied Dolt Cmd 14/15 into a repo-wide CI blocker.

The stagger keeps the insertion-order assertion meaningful (each comment gets a distinct `created_at`) rather than weakening it to a set comparison.

## What this does NOT fix

The underlying user-visible behavior — same-second comments on one issue display in arbitrary order at agent tempo — is real and tracked in **bd-vuulx** (fix direction: persist the derivation ordinal and order by `(created_at, ordinal, id)`, updating the keyset-page cursor contract). This PR only makes the test deterministic so CI reflects reality again.

## Test

`go build ./cmd/bd/` + `go vet` clean. The subtest is proxied-only (no embedded sibling asserts insertion order — grepped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)