### PR TITLE
fix(comments): keep same-second comments in write order after content-derived ids

### DIFF
--- a/internal/storage/conformance/portable.go
+++ b/internal/storage/conformance/portable.go
@@ -38,6 +38,7 @@ func RunPortableMethods(t *testing.T, factory Factory) {
 	t.Run("FindWispDependentsRecursive", func(t *testing.T) { testFindWispDependentsRecursive(t, factory) })
 	t.Run("AddComment", func(t *testing.T) { testAddComment(t, factory) })
 	t.Run("ImportIssueComment", func(t *testing.T) { testImportIssueComment(t, factory) })
+	t.Run("AddIssueCommentBurstOrder", func(t *testing.T) { testAddIssueCommentBurstOrder(t, factory) })
 	t.Run("PromoteFromEphemeral", func(t *testing.T) { testPromoteFromEphemeral(t, factory) })
 	t.Run("UpdateIssueID", func(t *testing.T) { testUpdateIssueID(t, factory) })
 	t.Run("DeleteIssuesBySourceRepo", func(t *testing.T) { testDeleteIssuesBySourceRepo(t, factory) })
@@ -480,6 +481,58 @@ func testImportIssueComment(t *testing.T, f Factory) {
 	ordered, _ := s.GetIssueComments(c, "test-ic2")
 	if len(ordered) != 2 || ordered[0].Text != "first" || ordered[1].Text != "second" {
 		t.Errorf("comment order = %v, want [first second] by created_at ASC", commentTexts(ordered))
+	}
+}
+
+// testAddIssueCommentBurstOrder pins the ordering contract that content-derived
+// aux ids (bd-ri8bd) broke: comments read back in (created_at ASC, id ASC)
+// order, created_at holds whole seconds, and the id is now a content digest
+// rather than a time-ordered UUIDv7 — so without help, comments written
+// back-to-back inside one second come back in hash order. AddIssueComment fixes
+// that by advancing its stamp past the issue's newest comment
+// (issueops.NextLiveCommentTime); this test is the backend-visible contract.
+func testAddIssueCommentBurstOrder(t *testing.T, f Factory) {
+	s := f(t)
+	c := ctx()
+	must(t, s.CreateIssue(c, withDefaults(&types.Issue{ID: "test-order", Title: "T"}), "a"))
+
+	// A burst: fast enough to share a wall-clock second on any runner.
+	want := []string{"one", "two", "three", "four", "five"}
+	for _, text := range want {
+		if _, err := s.AddIssueComment(c, "test-order", "alice", text); err != nil {
+			t.Fatalf("AddIssueComment(%q): %v", text, err)
+		}
+	}
+	got, err := s.GetIssueComments(c, "test-order")
+	must(t, err)
+	if !slices.Equal(commentTexts(got), want) {
+		t.Errorf("burst comment order = %v, want %v", commentTexts(got), want)
+	}
+	// The stamps are what carry the order, so they must be strictly increasing.
+	for i := 1; i < len(got); i++ {
+		if !got[i].CreatedAt.After(got[i-1].CreatedAt) {
+			t.Errorf("comment %d created_at %v not after %v — same-second tie is back",
+				i, got[i].CreatedAt, got[i-1].CreatedAt)
+		}
+	}
+
+	// Timing-independent proof of the advance: seed a comment ahead of the
+	// clock, then a live add must land exactly one second past it rather than
+	// sorting in front of it.
+	ahead := time.Now().UTC().Truncate(time.Second).Add(time.Hour)
+	must(t, s.CreateIssue(c, withDefaults(&types.Issue{ID: "test-order2", Title: "T2"}), "a"))
+	if _, err := s.ImportIssueComment(c, "test-order2", "a", "seeded", ahead); err != nil {
+		t.Fatal(err)
+	}
+	added, err := s.AddIssueComment(c, "test-order2", "a", "live")
+	must(t, err)
+	if !added.CreatedAt.Equal(ahead.Add(time.Second)) {
+		t.Errorf("live comment created_at = %v, want %v (one second past the newest comment)",
+			added.CreatedAt, ahead.Add(time.Second))
+	}
+	after, _ := s.GetIssueComments(c, "test-order2")
+	if got := commentTexts(after); !slices.Equal(got, []string{"seeded", "live"}) {
+		t.Errorf("comment order = %v, want [seeded live]", got)
 	}
 }
 

--- a/internal/storage/dolt/events.go
+++ b/internal/storage/dolt/events.go
@@ -68,19 +68,34 @@ func (s *DoltStore) EventsSince(ctx context.Context, cursor storage.EventCursor,
 	return result, err
 }
 
-// AddIssueComment adds a comment to an issue (structured comment)
+// AddIssueComment adds a comment to an issue (structured comment).
+//
+// Unlike ImportIssueComment it stamps created_at through
+// issueops.AddIssueCommentInTx, which advances past the issue's newest existing
+// comment so a burst of comments still reads back in the order it was written
+// (see issueops.NextLiveCommentTime).
 func (s *DoltStore) AddIssueComment(ctx context.Context, issueID, author, text string) (*types.Comment, error) {
-	return s.ImportIssueComment(ctx, issueID, author, text, time.Now().UTC())
+	return s.addOrImportComment(ctx, issueID, func(tx *sql.Tx) (*types.Comment, error) {
+		return issueops.AddIssueCommentInTx(ctx, tx, issueID, author, text)
+	})
 }
 
 // ImportIssueComment adds a comment during import, preserving the original timestamp.
 // This prevents comment timestamp drift across import/export cycles.
 func (s *DoltStore) ImportIssueComment(ctx context.Context, issueID, author, text string, createdAt time.Time) (*types.Comment, error) {
+	return s.addOrImportComment(ctx, issueID, func(tx *sql.Tx) (*types.Comment, error) {
+		return issueops.ImportIssueCommentInTx(ctx, tx, issueID, author, text, createdAt)
+	})
+}
+
+// addOrImportComment is the shared wisp-routing / retry / dolt-commit tail
+// around either comment insert; insert does the write inside the transaction.
+func (s *DoltStore) addOrImportComment(ctx context.Context, issueID string, insert func(*sql.Tx) (*types.Comment, error)) (*types.Comment, error) {
 	isWisp := s.isActiveWisp(ctx, issueID)
 	var result *types.Comment
 	err := s.withRetryTx(ctx, func(tx *sql.Tx) error {
 		var err error
-		result, err = issueops.ImportIssueCommentInTx(ctx, tx, issueID, author, text, createdAt)
+		result, err = insert(tx)
 		return err
 	})
 	if err != nil {

--- a/internal/storage/domain/db/comment.go
+++ b/internal/storage/domain/db/comment.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/storage/domain"
@@ -128,8 +129,14 @@ func (r *commentSQLRepositoryImpl) Insert(ctx context.Context, issueID, author, 
 		return nil, fmt.Errorf("db: CommentSQLRepository.Insert: issue %s not found", issueID)
 	}
 
-	createdAtText := issueops.NowAuxTime()
 	commentTable := pickCommentTable(opts.UseWispsTable)
+	// Live add: advance past the issue's newest comment so a burst inside one
+	// second still reads back in write order (issueops.NextLiveCommentTime).
+	stamp, err := issueops.NextLiveCommentTime(ctx, r.runner, commentTable, issueID, time.Now())
+	if err != nil {
+		return nil, fmt.Errorf("db: CommentSQLRepository.Insert: %w", err)
+	}
+	createdAtText := issueops.FormatAuxTime(stamp)
 	id, _, err := issueops.InsertDerivedComment(ctx, r.runner, commentTable, issueID, author, text, createdAtText)
 	if err != nil {
 		return nil, fmt.Errorf("db: CommentSQLRepository.Insert: %w", err)

--- a/internal/storage/issueops/comments.go
+++ b/internal/storage/issueops/comments.go
@@ -223,15 +223,23 @@ func GetCommentCountsInTx(ctx context.Context, tx *sql.Tx, issueIDs []string) (m
 // GetIssueCommentsPage cursor: an un-truncated sub-second CreatedAt would sort
 // after same-second rows stored at the truncated second and skip them on resume.
 //
+// It is also advanced past the issue's newest existing comment when that
+// truncation would otherwise collide — see nextLiveCommentTime.
+//
 //nolint:gosec // G201: table names come from hardcoded constants
 func AddIssueCommentInTx(ctx context.Context, tx *sql.Tx, issueID, author, text string) (*types.Comment, error) {
-	return ImportIssueCommentInTx(ctx, tx, issueID, author, text, time.Now().UTC().Truncate(time.Second))
+	return addIssueCommentInTx(ctx, tx, issueID, author, text, time.Now().UTC().Truncate(time.Second), true)
 }
 
 // ImportIssueCommentInTx adds a comment preserving the original timestamp.
 //
 //nolint:gosec // G201: table names come from hardcoded constants
 func ImportIssueCommentInTx(ctx context.Context, tx *sql.Tx, issueID, author, text string, createdAt time.Time) (*types.Comment, error) {
+	return addIssueCommentInTx(ctx, tx, issueID, author, text, createdAt, false)
+}
+
+//nolint:gosec // G201: table names come from hardcoded constants
+func addIssueCommentInTx(ctx context.Context, tx *sql.Tx, issueID, author, text string, createdAt time.Time, live bool) (*types.Comment, error) {
 	isWisp := IsActiveWispInTx(ctx, tx, issueID)
 	issueTable, _, _, _ := WispTableRouting(isWisp)
 	commentTable := "comments"
@@ -247,6 +255,14 @@ func ImportIssueCommentInTx(ctx context.Context, tx *sql.Tx, issueID, author, te
 	}
 	if !exists {
 		return nil, fmt.Errorf("issue %s not found", issueID)
+	}
+
+	if live {
+		advanced, err := NextLiveCommentTime(ctx, tx, commentTable, issueID, createdAt)
+		if err != nil {
+			return nil, err
+		}
+		createdAt = advanced
 	}
 
 	createdAtText := FormatAuxTime(createdAt)

--- a/internal/storage/issueops/create.go
+++ b/internal/storage/issueops/create.go
@@ -693,7 +693,16 @@ func PersistComments(ctx context.Context, tx *sql.Tx, issue *types.Issue) (Creat
 	for _, comment := range issue.Comments {
 		createdAt := comment.CreatedAt
 		if createdAt.IsZero() {
-			createdAt = time.Now().UTC()
+			// No supplied timestamp: this is a live comment, so stamp it the
+			// same way AddIssueComment does — one second past the issue's
+			// newest comment when the clock second would collide. Otherwise
+			// several such comments in one create share a second and read back
+			// in content-digest order rather than the order they were listed.
+			stamped, err := NextLiveCommentTime(ctx, tx, commentTable, issue.ID, time.Now())
+			if err != nil {
+				return result, fmt.Errorf("failed to insert comment for %s: %w", issue.ID, err)
+			}
+			createdAt = stamped
 		}
 		createdAtText := FormatAuxTime(createdAt)
 		if comment.ID == "" {

--- a/internal/storage/issueops/derivedid.go
+++ b/internal/storage/issueops/derivedid.go
@@ -148,6 +148,50 @@ func InsertDerivedEvent(ctx context.Context, tx DBTX, table string, e AuxEvent) 
 	return nil
 }
 
+// NextLiveCommentTime returns the created_at to stamp on a comment being added
+// live (as opposed to imported), given the wall-clock instant the caller
+// observed. The result is always truncated to whole seconds — the created_at
+// column's DATETIME(0) precision — and is advanced to one second past the
+// issue's newest existing comment when that comment is at or after `now`.
+//
+// Why: comments read back in (created_at ASC, id ASC) order, created_at holds
+// whole seconds, and since bd-ri8bd a comment's id is a content digest rather
+// than a time-ordered UUIDv7. Two comments added to one issue inside the same
+// wall-clock second therefore tie on the primary sort key and then order by
+// hash — arbitrarily with respect to the order they were written. Keeping
+// (issue_id, created_at) unique on the live path is what restores insertion
+// order for the reader without putting ordering information into the id, which
+// content-derivation cannot carry.
+//
+// This deliberately does NOT apply to the import path: an import carries the
+// original timestamps and must not invent new ones. Same-second groups
+// therefore still occur (imports, seeded/legacy rows, independently created
+// rows on another replica), and the (created_at, id) keyset walk in
+// GetIssueCommentsPageInTx remains the mechanism that keeps those groups
+// consistent between paged and full reads.
+//
+// The cost is a bounded forward skew: a burst of N comments on one issue inside
+// one second reads back spanning N seconds. That is a smaller distortion than N
+// identical stamps in scrambled order, and it drains as wall-clock advances.
+//
+//nolint:gosec // G201: table is a hardcoded routing constant at every call site.
+func NextLiveCommentTime(ctx context.Context, tx DBTX, table, issueID string, now time.Time) (time.Time, error) {
+	now = now.UTC().Truncate(time.Second)
+	var latest sql.NullTime
+	if err := tx.QueryRowContext(ctx, fmt.Sprintf(
+		`SELECT MAX(created_at) FROM %s WHERE issue_id = ?`, table), issueID).Scan(&latest); err != nil {
+		return time.Time{}, fmt.Errorf("read newest comment time from %s: %w", table, err)
+	}
+	if !latest.Valid {
+		return now, nil
+	}
+	newest := latest.Time.UTC().Truncate(time.Second)
+	if newest.Before(now) {
+		return now, nil
+	}
+	return newest.Add(time.Second), nil
+}
+
 // InsertDerivedComment inserts a comment under its content-derived id, or
 // collapses onto an existing identical comment: a same-content row already in
 // table (any id — it may predate the derivation) is the same logical comment,


### PR DESCRIPTION
Fixes #5165. `main` is red on this at `423afdcb2`, and the same failure is hitting PR Risk shard 14 on unrelated PRs (#5163, #5162).

## Why

#5150 made a comment's primary key a content digest instead of a time-ordered UUIDv7. Comments are read with `ORDER BY created_at ASC, id ASC` and `created_at` is a `DATETIME` with no fractional precision, so two comments added to one issue inside the same wall-clock second tie on the primary sort key and then order by hash — arbitrarily with respect to the order they were written.

That is user-visible, not just a test artifact: any burst of comments (agent/scripted use, or a person pasting two quickly) displays in an arbitrary permutation.

Content-derivation cannot carry insertion order by construction — two replicas that independently create the same comment must mint the same id, so the id cannot encode which one was written first locally. With `created_at` at one-second resolution and no other sortable column, that order is not recoverable from what is stored.

## What

Keep the live-add path from creating same-second groups in the first place.

`issueops.NextLiveCommentTime` stamps `created_at` one second past the issue's newest existing comment when the observed clock second would collide, restoring insertion order through the column that already sorts. Nothing about the derivation, the frozen digest column lists, or the schema changes.

Applied at every live entry point:

| path | backend |
|---|---|
| `issueops.AddIssueCommentInTx` | embedded |
| `DoltStore.AddIssueComment` | server / proxied |
| `db.commentSQLRepositoryImpl.Insert` | domain repository |
| `issueops.PersistComments` | comments supplied on create with no timestamp |

The **import path is deliberately untouched** — an import carries the original timestamps and must not invent new ones. Same-second groups therefore still occur (imports, seeded/legacy rows, rows created on another replica), and the `(created_at, id)` keyset walk in `GetIssueCommentsPageInTx` remains what keeps those groups consistent between paged and full reads. `TestGetIssueCommentsPageWalkEqualsFullRead` still exercises exactly that.

`DoltStore.AddIssueComment` previously delegated to `ImportIssueComment`; it now shares only the wisp-routing/retry/dolt-commit tail (`addOrImportComment`) so the two stamping policies are distinct. That also fixes it passing an un-truncated `time.Now()` where the embedded path already truncated.

## Trade-off

A burst of N comments on one issue inside one second reads back spanning N seconds of stamps. That is a smaller distortion than N identical stamps in scrambled order, and it drains as the wall clock advances.

The durable alternative is an explicit monotonic sequence column on `comments`/`wisp_comments` ordered ahead of `id`. That is a schema migration plus a change to the `(created_at, id)` keyset cursor and its sargability guard — a bigger change than seemed proportionate with `main` red, and a call for you to make on your own design. Happy to redo it that way.

## Tests

New portable conformance case `AddIssueCommentBurstOrder`, which is timing-independent (it also seeds a comment ahead of the clock and asserts a live add lands exactly one second past it, rather than in front of it). It fails on `main` today on **both** backends:

```
embedded: burst comment order = [one four five three two], want [one two three four five]
server:   burst comment order = [three five four two one], want [one two three four five]
```

Verified locally with each half of the fix stashed in turn, so both the `issueops` and the `DoltStore` change are load-bearing.

Green locally:

- `internal/storage/embeddeddolt` full suite incl. conformance (`BEADS_TEST_EMBEDDED_DOLT=1`), 464s
- `internal/storage/dolt` conformance suite against a real Dolt server (the full package suite is still running locally at the time of writing; CI covers it)
- `internal/storage/issueops`, `internal/storage/domain/...`, `internal/storage/rowid`, `internal/storage/schema`
- `cmd/bd` `TestProxiedServerComment` (`BEADS_TEST_PROXIED_SERVER=1`) — the shard that is red in CI
- `go build ./...`, `go vet`, `golangci-lint` clean

---

_claude-opus-5-high on behalf of maphew_
