### PR TITLE
fix(import): error on redirected stdin without an explicit source (bd-axluy)

### DIFF
--- a/cmd/bd/import.go
+++ b/cmd/bd/import.go
@@ -24,7 +24,9 @@ var importCmd = &cobra.Command{
 	Long: `Import issues from a JSONL file (newline-delimited JSON) into the database.
 
 If no file is specified, imports from the configured import.path under .beads/
-(default: issues.jsonl). Use "-" to read from stdin. This is the incremental counterpart to
+(default: issues.jsonl). Use "-" to read from stdin; redirecting stdin without
+"-" or a file argument is an error, so a typo'd 'bd import < file' cannot
+silently import the default file instead. This is the incremental counterpart to
 'bd export': new issues are created and existing issues are updated (upsert
 semantics).
 
@@ -153,6 +155,15 @@ func runImportInner(args []string) error {
 	} else if len(args) > 0 {
 		jsonlPath = args[0]
 	} else {
+		// bd-axluy: `bd import < file` (or `... | bd import`) without "-"
+		// used to silently ignore stdin and import the default JSONL — a
+		// mutating command diverging from what the user piped. Demand an
+		// explicit source instead. /dev/null (the stdin subprocesses get by
+		// default) is a character device, so scripted bare `bd import` with
+		// no redirection still works.
+		if fi, statErr := os.Stdin.Stat(); statErr == nil && fi.Mode()&os.ModeCharDevice == 0 {
+			return fmt.Errorf("stdin is redirected, but without \"-\" bd import ignores it and imports the default JSONL instead; use 'bd import -' to import what you piped, or name a file explicitly")
+		}
 		beadsDir := beads.FindBeadsDir()
 		if beadsDir == "" {
 			return fmt.Errorf("%s — %s", activeWorkspaceNotFoundError(), diagHint())

--- a/cmd/bd/import_shared_unit_test.go
+++ b/cmd/bd/import_shared_unit_test.go
@@ -2,6 +2,9 @@ package main
 
 import (
 	"context"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -542,4 +545,88 @@ func TestImportIssuesCoreArmsTransactionalStaleGuard(t *testing.T) {
 	if len(store.createOpts) != 1 || store.createOpts[0].RejectStaleUpserts {
 		t.Fatalf("createOpts = %#v, want RejectStaleUpserts disarmed under --allow-stale", store.createOpts)
 	}
+}
+
+// bd-axluy: redirected stdin without "-" (or a file argument) must be an
+// error, not a silent import of the default JSONL. The guard fires before any
+// store access, so these cases need no database; the pass-through cases are
+// asserted by seeing a later error than the guard's.
+func TestRunImportInnerRejectsRedirectedStdinWithoutSource(t *testing.T) {
+	t.Chdir(t.TempDir())
+	origStdin, origStore := os.Stdin, store
+	store = nil
+	t.Cleanup(func() {
+		os.Stdin = origStdin
+		store = origStore
+		importInput = ""
+	})
+
+	pipeStdin := func(t *testing.T) {
+		t.Helper()
+		r, w, err := os.Pipe()
+		if err != nil {
+			t.Fatalf("os.Pipe: %v", err)
+		}
+		w.Close() // immediate EOF: nothing should ever read this pipe anyway
+		t.Cleanup(func() { r.Close() })
+		os.Stdin = r
+	}
+
+	t.Run("piped stdin, no args", func(t *testing.T) {
+		pipeStdin(t)
+		err := runImportInner(nil)
+		if err == nil || !strings.Contains(err.Error(), "stdin is redirected") {
+			t.Fatalf("err = %v, want redirected-stdin guard error", err)
+		}
+	})
+
+	t.Run("regular-file stdin, no args", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "in.jsonl")
+		if err := os.WriteFile(path, []byte("{}\n"), 0o644); err != nil {
+			t.Fatalf("WriteFile: %v", err)
+		}
+		f, err := os.Open(path)
+		if err != nil {
+			t.Fatalf("Open: %v", err)
+		}
+		t.Cleanup(func() { f.Close() })
+		os.Stdin = f
+		err = runImportInner(nil)
+		if err == nil || !strings.Contains(err.Error(), "stdin is redirected") {
+			t.Fatalf("err = %v, want redirected-stdin guard error", err)
+		}
+	})
+
+	t.Run("piped stdin with explicit dash passes the guard", func(t *testing.T) {
+		pipeStdin(t)
+		err := runImportInner([]string{"-"})
+		if err == nil || strings.Contains(err.Error(), "stdin is redirected") {
+			t.Fatalf("err = %v, want a non-guard error (nil store)", err)
+		}
+	})
+
+	t.Run("piped stdin with explicit file passes the guard", func(t *testing.T) {
+		pipeStdin(t)
+		path := filepath.Join(t.TempDir(), "explicit.jsonl")
+		if err := os.WriteFile(path, []byte("{}\n"), 0o644); err != nil {
+			t.Fatalf("WriteFile: %v", err)
+		}
+		err := runImportInner([]string{path})
+		if err == nil || strings.Contains(err.Error(), "stdin is redirected") {
+			t.Fatalf("err = %v, want a non-guard error (nil store)", err)
+		}
+	})
+
+	t.Run("character-device stdin, no args passes the guard", func(t *testing.T) {
+		devNull, err := os.Open(os.DevNull)
+		if err != nil {
+			t.Skipf("open %s: %v", os.DevNull, err)
+		}
+		t.Cleanup(func() { devNull.Close() })
+		os.Stdin = devNull
+		err = runImportInner(nil)
+		if err == nil || strings.Contains(err.Error(), "stdin is redirected") {
+			t.Fatalf("err = %v, want a non-guard error (no workspace here)", err)
+		}
+	})
 }


### PR DESCRIPTION
## Summary

`bd import < file` (or `... | bd import`) without `-` silently ignored stdin and imported the configured default JSONL instead. For a mutating command, silent divergence between what the user piped and what actually got imported is a data-plane trap: during the wy-98eh5 VM recovery a stale 5,743-issue default file was accidentally imported against the shared DB, and was a no-op only because the stale file happened to be older than every local row (upsert timestamp-safety held).

Per bd-axluy, this takes option (a): when no file argument and no `--input` are given and stdin is not a character device (i.e. it was redirected from a file or pipe), `bd import` now errors and names both fixes (`bd import -` to import what was piped, or an explicit file path).

## Why this doesn't break scripted callers

- `/dev/null` — the stdin subprocesses get by default, including `exec.Command` (the git-hook import path in `cmd/bd/hooks.go` shells out this way, and passes an explicit file argument anyway) — is a character device, so bare scripted `bd import` with no redirection is unaffected.
- Explicit sources (`-`, a positional file, `--input`) bypass the guard entirely; only the ambiguous "stdin redirected but default file about to be read" case errors.
- Same `os.ModeCharDevice` detection already used by `bd audit record` (`cmd/bd/audit.go`).

## Testing

- New `TestRunImportInnerRejectsRedirectedStdinWithoutSource` (cmd/bd, no DB needed — the guard fires before store access): piped stdin and regular-file stdin without a source both error; `-`, an explicit file, and char-device stdin all pass the guard.
- `go test ./cmd/bd/ -run 'TestImport|TestFilterStale|TestClassifyDryRun|TestRunImport'` green; `go vet` clean; `golangci-lint run ./cmd/bd/` shows only the two pre-existing annotated gosec items in `main.go`.

Closes bd-axluy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)