### PR TITLE
fix(doctor): recognize path-fallback fingerprint mismatches as the synced-clone case (bd-46vla)

### DIFF
--- a/cmd/bd/doctor/integrity.go
+++ b/cmd/bd/doctor/integrity.go
@@ -613,7 +613,7 @@ func checkRepoFingerprintWithStore(store *dolt.DoltStore, path string) DoctorChe
 		}
 	}
 
-	currentRepoID, err := beads.ComputeRepoIDForPath(path)
+	currentRepoID, currentSource, err := beads.ComputeRepoIDForPathWithSource(path)
 	if err != nil {
 		if strings.Contains(err.Error(), "not a git repository") {
 			return DoctorCheck{
@@ -630,7 +630,30 @@ func checkRepoFingerprintWithStore(store *dolt.DoltStore, path string) DoctorChe
 		}
 	}
 
+	return classifyRepoFingerprint(storedRepoID, currentRepoID, currentSource)
+}
+
+// classifyRepoFingerprint turns a stored-vs-current fingerprint comparison into
+// a doctor check. Pure so the mismatch branches are unit-testable without a
+// store.
+func classifyRepoFingerprint(storedRepoID, currentRepoID string, currentSource beads.RepoIDSource) DoctorCheck {
 	if storedRepoID != currentRepoID {
+		// bd-46vla: with no origin remote here, the local fingerprint is a
+		// path hash that can never match a remote-derived stored id — the
+		// signature of a synced clone on a host without the canonical remote.
+		// The stored id is the shared value; repo_id lives in the VERSIONED
+		// metadata table, so 'bd migrate --update-repo-id' would stamp this
+		// host's path hash into shared state and propagate it to every clone
+		// on the next sync (the GH#4361 class).
+		if currentSource == beads.RepoIDSourcePath {
+			return DoctorCheck{
+				Name:    "Repo Fingerprint",
+				Status:  StatusWarning,
+				Message: "Fingerprint differs, but this checkout has no origin remote",
+				Detail:  fmt.Sprintf("stored: %s, current (path hash): %s — on a synced clone the stored id is the canonical shared value and this mismatch is cosmetic", truncateID(storedRepoID), truncateID(currentRepoID)),
+				Fix:     "On a synced clone, leave it (or add the canonical origin remote). Only run 'bd migrate --update-repo-id' if this checkout is the canonical repository — the new id propagates to every clone on the next sync",
+			}
+		}
 		return DoctorCheck{
 			Name:    "Repo Fingerprint",
 			Status:  StatusError,

--- a/cmd/bd/doctor/integrity_test.go
+++ b/cmd/bd/doctor/integrity_test.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/steveyegge/beads/internal/beads"
 )
 
 // TestIntegrityChecks_NoBeadsDir verifies all integrity check functions handle
@@ -195,4 +197,41 @@ func TestCheckDependencyCycles_NoDatabase(t *testing.T) {
 	if check.Status != StatusOK {
 		t.Errorf("Status = %q, want %q", check.Status, StatusOK)
 	}
+}
+
+// bd-46vla: a fingerprint mismatch where the current id is a path-fallback
+// hash (no origin remote on this host) is the synced-clone signature — the
+// stored id is the canonical shared value, and stamping the local one via
+// 'bd migrate --update-repo-id' would propagate it to every clone. That case
+// must warn-and-advise-leaving-it, not present as "wrong database".
+func TestClassifyRepoFingerprint(t *testing.T) {
+	t.Run("match is OK regardless of source", func(t *testing.T) {
+		check := classifyRepoFingerprint("aaaa1111bbbb2222", "aaaa1111bbbb2222", beads.RepoIDSourcePath)
+		if check.Status != StatusOK {
+			t.Fatalf("Status = %q, want %q (message=%q)", check.Status, StatusOK, check.Message)
+		}
+	})
+
+	t.Run("mismatch with remote-derived current id is an error", func(t *testing.T) {
+		check := classifyRepoFingerprint("aaaa1111bbbb2222", "cccc3333dddd4444", beads.RepoIDSourceRemote)
+		if check.Status != StatusError {
+			t.Fatalf("Status = %q, want %q (message=%q)", check.Status, StatusError, check.Message)
+		}
+		if !strings.Contains(check.Fix, "bd migrate --update-repo-id") {
+			t.Fatalf("Fix = %q, want the update-repo-id repair offered", check.Fix)
+		}
+	})
+
+	t.Run("mismatch with path-fallback current id warns and advises leaving it", func(t *testing.T) {
+		check := classifyRepoFingerprint("aaaa1111bbbb2222", "cccc3333dddd4444", beads.RepoIDSourcePath)
+		if check.Status != StatusWarning {
+			t.Fatalf("Status = %q, want %q (message=%q)", check.Status, StatusWarning, check.Message)
+		}
+		if !strings.Contains(check.Message, "no origin remote") {
+			t.Fatalf("Message = %q, want the no-origin-remote framing", check.Message)
+		}
+		if !strings.Contains(check.Fix, "propagates to every clone") {
+			t.Fatalf("Fix = %q, want the propagation named", check.Fix)
+		}
+	})
 }

--- a/cmd/bd/migrate.go
+++ b/cmd/bd/migrate.go
@@ -319,7 +319,7 @@ func handleUpdateRepoID(dryRun bool, autoYes bool) error {
 	// not the process cwd. Otherwise `bd -C <dir> migrate --update-repo-id`
 	// stamps the target DB with the caller repo's fingerprint and the bad
 	// value propagates to every clone on the next sync (GH#4361).
-	newRepoID, err := beads.ComputeRepoIDForPath(beadsDir)
+	newRepoID, newRepoIDSource, err := beads.ComputeRepoIDForPathWithSource(beadsDir)
 	if err != nil {
 		if jsonOutput {
 			if jerr := outputJSON(map[string]interface{}{
@@ -374,7 +374,17 @@ func handleUpdateRepoID(dryRun bool, autoYes bool) error {
 	}
 
 	if oldRepoID != "" && oldRepoID != newRepoID && !autoYes && !jsonOutput {
-		fmt.Printf("WARNING: Changing repository ID can break sync if other clones exist.\n\n")
+		fmt.Printf("WARNING: Changing repository ID can break sync if other clones exist.\n")
+		// bd-46vla: repo_id lives in the versioned metadata table, so the new
+		// value propagates to every clone on the next sync. A path-fallback id
+		// (no origin remote here) is host-local — stamping it into shared
+		// state is almost never right on a synced clone.
+		if newRepoIDSource == beads.RepoIDSourcePath {
+			fmt.Printf("The new ID is a path hash (this checkout has no origin remote); it is\n")
+			fmt.Printf("local to this host but will propagate to every clone on the next sync.\n")
+			fmt.Printf("On a synced clone, keep the stored ID instead (see 'bd doctor').\n")
+		}
+		fmt.Printf("\n")
 		fmt.Printf("Current repo ID: %s\n", oldDisplay)
 		fmt.Printf("New repo ID:     %s\n\n", truncateID(newRepoID, 8))
 		fmt.Printf("Continue? [y/N] ")

--- a/internal/beads/fingerprint.go
+++ b/internal/beads/fingerprint.go
@@ -11,6 +11,19 @@ import (
 	"strings"
 )
 
+// RepoIDSource identifies how a repo fingerprint was derived.
+type RepoIDSource string
+
+const (
+	// RepoIDSourceRemote means the fingerprint hashes the canonicalized
+	// remote.origin.url — the same value on every host that clones the repo.
+	RepoIDSourceRemote RepoIDSource = "remote"
+	// RepoIDSourcePath means no origin remote was configured and the
+	// fingerprint hashes the local repo root path — a host-local value that
+	// can never match a remote-derived fingerprint stored by another host.
+	RepoIDSourcePath RepoIDSource = "path"
+)
+
 // ComputeRepoID generates a unique identifier for this git repository
 func ComputeRepoID() (string, error) {
 	return ComputeRepoIDForPath("")
@@ -18,13 +31,24 @@ func ComputeRepoID() (string, error) {
 
 // ComputeRepoIDForPath generates a unique identifier for the git repository
 // rooted at or containing repoPath. An empty repoPath uses the current cwd.
+func ComputeRepoIDForPath(repoPath string) (string, error) {
+	id, _, err := ComputeRepoIDForPathWithSource(repoPath)
+	return id, err
+}
+
+// ComputeRepoIDForPathWithSource is ComputeRepoIDForPath plus which derivation
+// produced the fingerprint, so callers (bd doctor, bd migrate --update-repo-id)
+// can tell a canonical remote-derived fingerprint from the path fallback
+// (bd-46vla: on a synced clone without the canonical origin remote, a
+// path-fallback mismatch against the stored id is cosmetic, and stamping the
+// local value into the versioned metadata table propagates it to every clone).
 //
 // GH#2867: When running from a git worktree, the path-based fallback (no remote)
 // uses the main repository root instead of the worktree root. This ensures all
 // worktrees sharing a database produce the same fingerprint. Without this,
 // worktree operations would compute a different repo_id and bd doctor would
 // report a fingerprint mismatch.
-func ComputeRepoIDForPath(repoPath string) (string, error) {
+func ComputeRepoIDForPathWithSource(repoPath string) (string, RepoIDSource, error) {
 	output, err := runGitInRepo(repoPath, "config", "--get", "remote.origin.url")
 	if err != nil {
 		// No remote configured — fall back to path-based fingerprint.
@@ -32,22 +56,22 @@ func ComputeRepoIDForPath(repoPath string) (string, error) {
 		// worktrees produce the same fingerprint as the main checkout.
 		repoRoot, rootErr := mainRepoRootForPath(repoPath)
 		if rootErr != nil {
-			return "", fmt.Errorf("not a git repository")
+			return "", "", fmt.Errorf("not a git repository")
 		}
 
 		normalized := normalizedRepoPath(repoRoot)
 		hash := sha256.Sum256([]byte(normalized))
-		return hex.EncodeToString(hash[:16]), nil
+		return hex.EncodeToString(hash[:16]), RepoIDSourcePath, nil
 	}
 
 	repoURL := strings.TrimSpace(string(output))
 	canonical, err := canonicalizeGitURL(repoURL)
 	if err != nil {
-		return "", fmt.Errorf("failed to canonicalize URL: %w", err)
+		return "", "", fmt.Errorf("failed to canonicalize URL: %w", err)
 	}
 
 	hash := sha256.Sum256([]byte(canonical))
-	return hex.EncodeToString(hash[:16]), nil
+	return hex.EncodeToString(hash[:16]), RepoIDSourceRemote, nil
 }
 
 func canonicalizeGitURL(rawURL string) (string, error) {

--- a/internal/beads/fingerprint_test.go
+++ b/internal/beads/fingerprint_test.go
@@ -475,3 +475,38 @@ func TestGetCloneIDForPath_UsesTargetRepoOutsideCWD(t *testing.T) {
 		t.Errorf("GetCloneIDForPath(%q) = %q, want %q", repoB, got, want)
 	}
 }
+
+// bd-46vla: callers need to distinguish the canonical remote-derived
+// fingerprint from the host-local path fallback (bd doctor downgrades a
+// path-fallback mismatch; bd migrate --update-repo-id names the propagation).
+func TestComputeRepoIDForPathWithSource(t *testing.T) {
+	t.Run("with remote", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		initFingerprintGitRepo(t, tmpDir, "https://github.com/testuser/testrepo.git")
+		id, source, err := ComputeRepoIDForPathWithSource(tmpDir)
+		if err != nil {
+			t.Fatalf("ComputeRepoIDForPathWithSource: %v", err)
+		}
+		if source != RepoIDSourceRemote {
+			t.Fatalf("source = %q, want %q", source, RepoIDSourceRemote)
+		}
+		if plain, _ := ComputeRepoIDForPath(tmpDir); plain != id {
+			t.Fatalf("ComputeRepoIDForPath = %q, want %q (must agree with WithSource)", plain, id)
+		}
+	})
+
+	t.Run("without remote falls back to path", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		initFingerprintGitRepo(t, tmpDir, "")
+		id, source, err := ComputeRepoIDForPathWithSource(tmpDir)
+		if err != nil {
+			t.Fatalf("ComputeRepoIDForPathWithSource: %v", err)
+		}
+		if source != RepoIDSourcePath {
+			t.Fatalf("source = %q, want %q", source, RepoIDSourcePath)
+		}
+		if id == "" {
+			t.Fatal("empty id")
+		}
+	})
+}


### PR DESCRIPTION
## Summary

From crow's wy-98eh5 question: on a bridge-synced clone (e.g. the claude-code-vm), `bd doctor` flags `stored repo_id != current fingerprint` and its advice — `bd migrate --update-repo-id` — is a trap. On a host without the canonical origin remote, the current fingerprint is the **path fallback** (`fingerprint.go` hashes the repo root path), which can never match the remote-derived stored id. And `repo_id` lives in the **versioned** metadata table, so following the advice stamps the clone's host-local path hash into shared state and propagates it to every clone on the next sync (the GH#4361 class, already called out in `migrate.go`). On such clones the mismatch is cosmetic and the stored (canonical) id is the correct shared value.

## Changes

- `internal/beads/fingerprint.go`: `ComputeRepoIDForPathWithSource` returns which derivation produced the fingerprint (`remote` = canonicalized origin URL, `path` = repo-root path hash). `ComputeRepoIDForPath` delegates; no behavior change for existing callers.
- `cmd/bd/doctor/integrity.go`: the mismatch classification is extracted into pure `classifyRepoFingerprint`. When the current id is the path fallback, the check downgrades from Error ("Database belongs to different repository") to a Warning that says the checkout has no origin remote, names the stored id as the canonical shared value, and advises leaving it (or adding the canonical remote) — running `--update-repo-id` only if this checkout is the canonical repository, with the propagation named. The remote-derived mismatch keeps the existing Error + repair advice.
- `cmd/bd/migrate.go`: the existing `--update-repo-id` y/N confirm gate additionally names the propagation when the new id is a path hash ("local to this host but will propagate to every clone on the next sync").

Agent-mode doctor output (`doctor/agent.go`) derives severity from check status, so it downgrades along with the check.

## Testing

- New `TestClassifyRepoFingerprint` (pure, no store): match → OK; remote-derived mismatch → Error with the update-repo-id repair; path-fallback mismatch → Warning with the no-origin-remote framing and the propagation named.
- New `TestComputeRepoIDForPathWithSource`: remote → `remote` source and agreement with `ComputeRepoIDForPath`; no remote → `path` source.
- `go test ./internal/beads/ ./cmd/bd/doctor/` and the cmd/bd migrate/doctor test slices green; `go vet` clean; `golangci-lint` shows only the two pre-existing annotated gosec items in `main.go`.

Closes bd-46vla.

🤖 Generated with [Claude Code](https://claude.com/claude-code)