### PR TITLE
test(doctor/fix): un-dark the DB-backed cgo suite + fix doctor's fresh-clone create path (bd-nxt5e, bd-kjfsq)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -545,6 +545,16 @@ jobs:
           BEADS_TEST_BD_BINARY: ${{ github.workspace }}/ci-build-artifacts/bd-linux-gms-pure
         run: go test -tags gms_pure_go -race -count=1 -v ./internal/storage/domain/... ./internal/storage/uow/... ./internal/tracker/...
 
+      # The doctor/fix DB-backed suite spins its own Dolt container in
+      # TestMain. BEADS_FIX_REQUIRE_DOLT=1 turns a missing container into a
+      # hard failure so the suite can never silently skip in CI again
+      # (bd-nxt5e: it was dark for months); this job pulls the image above.
+      - name: Test doctor/fix (Dolt-backed, hard-require container)
+        env:
+          BEADS_TEST_BD_BINARY: ${{ github.workspace }}/ci-build-artifacts/bd-linux-gms-pure
+          BEADS_FIX_REQUIRE_DOLT: "1"
+        run: go test -tags gms_pure_go -race -count=1 -v ./cmd/bd/doctor/fix/
+
   main-linux-integration-packages:
     name: Main Linux integration packages (${{ matrix.shard }}/6)
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -508,6 +508,16 @@ jobs:
           BEADS_TEST_BD_BINARY: ${{ github.workspace }}/ci-build-artifacts/bd-linux-gms-pure
         run: go test -tags gms_pure_go -race -count=1 -v ./internal/storage/domain/... ./internal/storage/uow/... ./internal/tracker/...
 
+      # The doctor/fix DB-backed suite spins its own Dolt container in
+      # TestMain. BEADS_FIX_REQUIRE_DOLT=1 turns a missing container into a
+      # hard failure so the suite can never silently skip in CI again
+      # (bd-nxt5e: it was dark for months); this job pulls the image above.
+      - name: Test doctor/fix (Dolt-backed, hard-require container)
+        env:
+          BEADS_TEST_BD_BINARY: ${{ github.workspace }}/ci-build-artifacts/bd-linux-gms-pure
+          BEADS_FIX_REQUIRE_DOLT: "1"
+        run: go test -tags gms_pure_go -race -count=1 -v ./cmd/bd/doctor/fix/
+
   # Producer-side guard for the Beads<->consumer CLI contract. Runs the whole
   # cmd/bd/protocol package: the golden corpus (regenerated from this branch's
   # bd and byte-compared to the committed testdata/corpus/, so an unreviewed

--- a/cmd/bd/doctor/fix/dep_keys_test.go
+++ b/cmd/bd/doctor/fix/dep_keys_test.go
@@ -53,7 +53,7 @@ func TestDependencyKeys_RekeysAndRemovesLeftovers(t *testing.T) {
 		MaxOpenConns:    1,
 	})
 	if err != nil {
-		t.Skipf("skipping: Dolt server not available: %v", err)
+		t.Fatalf("dolt.New: %v", err)
 	}
 	defer func() { _ = store.Close() }()
 

--- a/cmd/bd/doctor/fix/maintenance_cgo_test.go
+++ b/cmd/bd/doctor/fix/maintenance_cgo_test.go
@@ -18,10 +18,8 @@ import (
 )
 
 func TestPatrolPollution_DeletesFromDoltWithoutJSONL(t *testing.T) {
+	requireFixDoltContainer(t)
 	port := fixTestServerPort()
-	if port == 0 {
-		t.Skip("Dolt test server not available, skipping")
-	}
 
 	tmpDir := t.TempDir()
 	beadsDir := filepath.Join(tmpDir, ".beads")
@@ -41,9 +39,9 @@ func TestPatrolPollution_DeletesFromDoltWithoutJSONL(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	store, err := dolt.NewFromConfig(ctx, beadsDir)
+	store, err := dolt.NewFromConfigWithOptions(ctx, beadsDir, &dolt.Config{CreateIfMissing: true})
 	if err != nil {
-		t.Skipf("skipping: Dolt server not available: %v", err)
+		t.Fatalf("dolt.NewFromConfigWithOptions against running test container: %v", err)
 	}
 	if err := store.SetConfig(ctx, "issue_prefix", "bd"); err != nil {
 		_ = store.Close()
@@ -96,7 +94,7 @@ func TestPatrolPollution_DeletesFromDoltWithoutJSONL(t *testing.T) {
 
 	verifyStore, err := dolt.NewFromConfig(ctx, beadsDir)
 	if err != nil {
-		t.Skipf("skipping: Dolt server not available: %v", err)
+		t.Fatalf("failed to reopen store for verification: %v", err)
 	}
 	defer func() { _ = verifyStore.Close() }()
 

--- a/cmd/bd/doctor/fix/metadata_dolt_test.go
+++ b/cmd/bd/doctor/fix/metadata_dolt_test.go
@@ -52,11 +52,12 @@ func setupDoltWorkspace(t *testing.T) string {
 	ctx := context.Background()
 	doltPath := filepath.Join(beadsDir, "dolt")
 	store, err := dolt.New(ctx, &dolt.Config{
-		Path:     doltPath,
-		Database: "beads",
+		Path:            doltPath,
+		Database:        "beads",
+		CreateIfMissing: true,
 	})
 	if err != nil {
-		t.Skipf("skipping: Dolt server not available: %v", err)
+		t.Fatalf("dolt.New: %v", err)
 	}
 	if err := store.Close(); err != nil {
 		t.Fatalf("failed to close Dolt store: %v", err)

--- a/cmd/bd/doctor/fix/migrate.go
+++ b/cmd/bd/doctor/fix/migrate.go
@@ -50,10 +50,13 @@ func DatabaseVersionWithBdVersion(path string, bdVersion string) error {
 	ctx := context.Background()
 
 	if _, err := os.Stat(dbPath); os.IsNotExist(err) {
-		// No database - create a new Dolt store
+		// No database - create a new Dolt store. Creation is this branch's
+		// explicit purpose, so opt out of the dolt.New create-guard
+		// (bd-kjfsq: without CreateIfMissing the guard fails the fix with
+		// "database not found" on exactly the fresh clones it exists for).
 		fmt.Println("  → No database found, creating Dolt store...")
 
-		store, err := dolt.NewFromConfig(ctx, beadsDir)
+		store, err := dolt.NewFromConfigWithOptions(ctx, beadsDir, &dolt.Config{CreateIfMissing: true})
 		if err != nil {
 			return fmt.Errorf("failed to create database: %w", err)
 		}

--- a/cmd/bd/doctor/fix/migrate_import_test.go
+++ b/cmd/bd/doctor/fix/migrate_import_test.go
@@ -33,6 +33,7 @@ func setupTestBeadsDir(t *testing.T, tmpDir string) string {
 		t.Fatal(err)
 	}
 
+	requireFixDoltContainer(t)
 	port := fixTestServerPort()
 	dbName := uniqueDBName(t)
 
@@ -74,10 +75,12 @@ func TestImportJSONLIntoStore(t *testing.T) {
 	tmpDir := t.TempDir()
 	beadsDir := setupTestBeadsDir(t, tmpDir)
 
-	// Create Dolt store
-	store, err := dolt.NewFromConfig(ctx, beadsDir)
+	// Create Dolt store. CreateIfMissing: the per-test database does not
+	// exist yet and the dolt.New create-guard refuses to create it
+	// implicitly (bd-nxt5e).
+	store, err := dolt.NewFromConfigWithOptions(ctx, beadsDir, &dolt.Config{CreateIfMissing: true})
 	if err != nil {
-		t.Skipf("skipping: Dolt not available: %v", err)
+		t.Fatalf("dolt.NewFromConfigWithOptions against running test container: %v", err)
 	}
 	defer func() { _ = store.Close() }()
 
@@ -123,9 +126,9 @@ func TestImportJSONLIntoStore_EmptyFile(t *testing.T) {
 	tmpDir := t.TempDir()
 	beadsDir := setupTestBeadsDir(t, tmpDir)
 
-	store, err := dolt.NewFromConfig(ctx, beadsDir)
+	store, err := dolt.NewFromConfigWithOptions(ctx, beadsDir, &dolt.Config{CreateIfMissing: true})
 	if err != nil {
-		t.Skipf("skipping: Dolt not available: %v", err)
+		t.Fatalf("dolt.NewFromConfigWithOptions against running test container: %v", err)
 	}
 	defer func() { _ = store.Close() }()
 
@@ -161,6 +164,7 @@ func TestDatabaseVersionWithBdVersion_ImportsJSONL(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	requireFixDoltContainer(t)
 	port := fixTestServerPort()
 	dbName := uniqueDBName(t)
 
@@ -175,13 +179,10 @@ func TestDatabaseVersionWithBdVersion_ImportsJSONL(t *testing.T) {
 	if err := cfg.Save(beadsDir); err != nil {
 		t.Fatal(err)
 	}
-
-	// Pre-flight: verify Dolt server is reachable (skip in CI without server)
-	probe, probeErr := dolt.NewFromConfig(ctx, beadsDir)
-	if probeErr != nil {
-		t.Skipf("skipping: Dolt not available: %v", probeErr)
-	}
-	_ = probe.Close()
+	// No connect probe here: the database must not exist yet (creating it is
+	// the behavior under test), and the port guard above already covers the
+	// no-server case. A probe via dolt.NewFromConfig would always fail on
+	// the missing database and silently skip the test (bd-nxt5e).
 
 	// Write JSONL with issues
 	issues := []types.Issue{

--- a/cmd/bd/doctor/fix/remotes_test.go
+++ b/cmd/bd/doctor/fix/remotes_test.go
@@ -4,11 +4,15 @@ package fix
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/steveyegge/beads/internal/configfile"
 	"github.com/steveyegge/beads/internal/storage/dolt"
@@ -16,16 +20,15 @@ import (
 	"github.com/steveyegge/beads/internal/types"
 )
 
-// newIdentityTestStore is a variant of newFixTestStore that additionally
-// sets CreateIfMissing on the dolt.Config (newFixTestStore's connect-only
-// config depends on the test database already existing, which this Dolt
-// server build does not do implicitly) and seeds a project_id shared by
-// metadata.json and the database, matching what a real `bd init` produces.
+// newIdentityTestStore is a variant of newFixTestStore that seeds a
+// project_id shared by metadata.json and the database, matching what a real
+// `bd init` produces.
 func newIdentityTestStore(t *testing.T, dir, prefix string) (store *dolt.DoltStore, beadsDir, projectID string) {
 	t.Helper()
 	testutil.RequireDoltBinary(t)
 	ctx := context.Background()
 
+	requireFixDoltContainer(t)
 	port := fixTestServerPort()
 
 	beadsDir = filepath.Join(dir, ".beads")
@@ -33,8 +36,10 @@ func newIdentityTestStore(t *testing.T, dir, prefix string) (store *dolt.DoltSto
 		t.Fatalf("create .beads: %v", err)
 	}
 
-	dbName := "fixident_" + strings.ToLower(t.Name())
-	dbName = strings.NewReplacer("/", "_", " ", "_").Replace(dbName)
+	// Hash the test name: subtest names blow past Dolt's database-name
+	// length limit if used verbatim (bd-nxt5e).
+	h := sha256.Sum256([]byte(t.Name() + fmt.Sprintf("%d", time.Now().UnixNano())))
+	dbName := "fixident_" + hex.EncodeToString(h[:6])
 
 	projectID = configfile.GenerateProjectID()
 	cfg := &configfile.Config{
@@ -58,7 +63,7 @@ func newIdentityTestStore(t *testing.T, dir, prefix string) (store *dolt.DoltSto
 		MaxOpenConns:    1,
 	})
 	if err != nil {
-		t.Skipf("skipping: Dolt server not available: %v", err)
+		t.Fatalf("dolt.New against running test container: %v", err)
 	}
 
 	if err := store.SetConfig(ctx, "issue_prefix", prefix); err != nil {

--- a/cmd/bd/doctor/fix/validation_test.go
+++ b/cmd/bd/doctor/fix/validation_test.go
@@ -27,13 +27,32 @@ func fixTestServerPort() int {
 	return testutil.DoltContainerPortInt()
 }
 
+// requireFixDoltContainer enforces the Dolt test container precondition for
+// the DB-backed fix tests. Locally a missing container skips, so contributors
+// without Docker stay green. A CI job that sets BEADS_FIX_REQUIRE_DOLT=1
+// (after pulling the Dolt image) turns the missing container into a hard
+// failure instead — the guard that keeps this suite from silently going dark
+// again (bd-nxt5e: every DB-backed test here skipped for months, locally and
+// in CI, with nothing noticing). Once the container IS up, dolt.New failures
+// must be t.Fatal, never t.Skip.
+func requireFixDoltContainer(t *testing.T) {
+	t.Helper()
+	if fixTestServerPort() != 0 {
+		return
+	}
+	if os.Getenv("BEADS_FIX_REQUIRE_DOLT") == "1" {
+		t.Fatal("Dolt test container unavailable but BEADS_FIX_REQUIRE_DOLT=1; the fix-package DB suite must not silently skip")
+	}
+	t.Skip("skipping: Dolt test container not available")
+}
+
 // newFixTestStore creates a DoltStore for fix package tests with proper
 // .beads directory structure so openAnyDB can connect for end-to-end testing.
 func newFixTestStore(t *testing.T, dir string, prefix string) *dolt.DoltStore {
 	t.Helper()
 	ctx := context.Background()
 
-	// Determine server port
+	requireFixDoltContainer(t)
 	port := fixTestServerPort()
 
 	// Generate unique database name for test isolation
@@ -65,16 +84,20 @@ func newFixTestStore(t *testing.T, dir string, prefix string) *dolt.DoltStore {
 		t.Fatalf("Failed to write metadata.json: %v", err)
 	}
 
-	// Create store connected to the same database
+	// Create store connected to the same database. CreateIfMissing is
+	// required: the per-test database does not exist yet, and dolt.New's
+	// create-guard refuses to create it implicitly (bd-nxt5e — its absence
+	// made every test using this helper skip).
 	dbPath := filepath.Join(beadsDir, "beads.db")
 	store, err := dolt.New(ctx, &dolt.Config{
-		Path:       dbPath,
-		ServerHost: "127.0.0.1",
-		ServerPort: port,
-		Database:   dbName,
+		Path:            dbPath,
+		ServerHost:      "127.0.0.1",
+		ServerPort:      port,
+		Database:        dbName,
+		CreateIfMissing: true,
 	})
 	if err != nil {
-		t.Skipf("skipping: Dolt not available: %v", err)
+		t.Fatalf("dolt.New against running test container: %v", err)
 	}
 
 	if err := store.SetConfig(ctx, "issue_prefix", prefix); err != nil {


### PR DESCRIPTION
## Summary

The whole `cmd/bd/doctor/fix` DB-backed cgo suite was **silently skipping — locally and in CI**: `newFixTestStore` predates the `dolt.New` create-guard and never passed `CreateIfMissing`, so every test using it hit the `t.Skipf` path (bd-nxt5e, found while writing the PR #5173 heal test).

Re-enabling it surfaced what the darkness was hiding:

- **`newIdentityTestStore` built DB names from full subtest names**, blowing past Dolt's database-name length limit — 4 of 5 `TestVerifyFixTargetIdentity` subtests were failing. Names are now hashed like `newFixTestStore`'s.
- The **same missing-`CreateIfMissing` bug** in `maintenance_cgo_test.go`, `migrate_import_test.go`, and `metadata_dolt_test.go` setups.
- A **real product bug (bd-kjfsq)**: `DatabaseVersionWithBdVersion`'s fresh-clone branch — whose explicit purpose is creating the store (incl. the JSONL import that closes the doctor-then-init chicken-and-egg gap) — calls `dolt.NewFromConfig` without `CreateIfMissing`, so `bd doctor --fix` has failed with `database ... not found` on exactly the fresh clones the branch exists for, ever since the create-guard landed. Caught by `TestDatabaseVersionWithBdVersion_ImportsJSONL` the moment its silent skip fell. Its pre-flight connect probe (which could only ever fail post-guard, since the DB must not exist yet) is removed; the container-port guard covers the no-server case.

## Ran-not-skipped guard

`requireFixDoltContainer` centralizes the no-container skip and honors **`BEADS_FIX_REQUIRE_DOLT=1`** (mirror of the protocol package's `BEADS_PROTOCOL_REQUIRE_DOLT` pattern): set in the `test-domain-uow` CI job — which already pulls the Dolt image — so a missing container there is a hard failure, never a silent skip. And once the container **is** up, `dolt.New` failures are `t.Fatal`, not `t.Skip`.

## Verification

Full package suite vs the real Dolt container (OrbStack), with `BEADS_FIX_REQUIRE_DOLT=1`:
**92 passed, 0 failed**; remaining skips are bd-binary E2E tests and removed-feature stubs (`UntrackedJSONL*`, bd-9ni.2). `go vet` + `golangci-lint` clean.

Beads: bd-nxt5e (suite dark), bd-kjfsq (doctor fresh-clone create path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L5Z2ovQDzoMFDxyRe87vD5