### PR TITLE
fix(migrate): print path-hash propagation notice under --yes/--json (bd-ek28z)

### DIFF
--- a/cmd/bd/migrate.go
+++ b/cmd/bd/migrate.go
@@ -300,6 +300,18 @@ func loadOrCreateConfig(beadsDir string) (*configfile.Config, error) {
 	return cfg, nil
 }
 
+// pathHashRepoIDStampNotice returns the propagation warning for replacing an
+// existing repository ID with a path-derived one, or "" when none applies
+// (no stored id, no change, or a remote-derived new id).
+func pathHashRepoIDStampNotice(oldRepoID, newRepoID string, source beads.RepoIDSource) string {
+	if oldRepoID == "" || oldRepoID == newRepoID || source != beads.RepoIDSourcePath {
+		return ""
+	}
+	return "Warning: stamping a path-hash repository ID (this checkout has no origin remote).\n" +
+		"It is local to this host but will propagate to every clone on the next sync.\n" +
+		"On a synced clone, keep the stored ID instead (see 'bd doctor').\n"
+}
+
 func handleUpdateRepoID(dryRun bool, autoYes bool) error {
 	beadsDir := beads.FindBeadsDir()
 	if beadsDir == "" {
@@ -396,6 +408,15 @@ func handleUpdateRepoID(dryRun bool, autoYes bool) error {
 		}
 	}
 
+	// bd-ek28z: --yes and --json skip the confirm block above, so scripted
+	// callers stamped a host-local path hash with no warning at all — the
+	// GH#4361 recurrence hole. Print the notice (not the prompt) on those
+	// paths too.
+	pathHashNotice := pathHashRepoIDStampNotice(oldRepoID, newRepoID, newRepoIDSource)
+	if pathHashNotice != "" && (autoYes || jsonOutput) {
+		fmt.Fprint(os.Stderr, pathHashNotice)
+	}
+
 	if err := store.SetMetadata(ctx, "repo_id", newRepoID); err != nil {
 		if jsonOutput {
 			if jerr := outputJSON(map[string]interface{}{
@@ -412,11 +433,16 @@ func handleUpdateRepoID(dryRun bool, autoYes bool) error {
 	commandDidWrite.Store(true)
 
 	if jsonOutput {
-		return outputJSON(map[string]interface{}{
-			"status":      "success",
-			"old_repo_id": oldDisplay,
-			"new_repo_id": truncateID(newRepoID, 8),
-		})
+		payload := map[string]interface{}{
+			"status":         "success",
+			"old_repo_id":    oldDisplay,
+			"new_repo_id":    truncateID(newRepoID, 8),
+			"repo_id_source": string(newRepoIDSource),
+		}
+		if pathHashNotice != "" {
+			payload["warning"] = "new repository ID is a path hash (no origin remote); it will propagate to every clone on the next sync"
+		}
+		return outputJSON(payload)
 	}
 	fmt.Printf("%s\n\n", ui.RenderPass("✓ Repository ID updated"))
 	fmt.Printf("  Old: %s\n", oldDisplay)

--- a/cmd/bd/migrate_repo_id_notice_test.go
+++ b/cmd/bd/migrate_repo_id_notice_test.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/steveyegge/beads/internal/beads"
+)
+
+// bd-ek28z: the path-hash propagation notice must fire exactly when an
+// existing repository ID would be replaced by a different, path-derived one —
+// the case --yes/--json used to stamp silently (GH#4361 recurrence hole).
+func TestPathHashRepoIDStampNotice(t *testing.T) {
+	tests := []struct {
+		name       string
+		oldRepoID  string
+		newRepoID  string
+		source     beads.RepoIDSource
+		wantNotice bool
+	}{
+		{"path hash replacing different id", "aaaa1111", "bbbb2222", beads.RepoIDSourcePath, true},
+		{"no stored id (bootstrap)", "", "bbbb2222", beads.RepoIDSourcePath, false},
+		{"unchanged id", "aaaa1111", "aaaa1111", beads.RepoIDSourcePath, false},
+		{"remote-derived new id", "aaaa1111", "bbbb2222", beads.RepoIDSourceRemote, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := pathHashRepoIDStampNotice(tt.oldRepoID, tt.newRepoID, tt.source)
+			if (got != "") != tt.wantNotice {
+				t.Errorf("pathHashRepoIDStampNotice(%q, %q, %q) = %q, want notice=%v",
+					tt.oldRepoID, tt.newRepoID, tt.source, got, tt.wantNotice)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Follow-up from lion's #5172 review (bd-ek28z). The path-hash propagation warning added in #5172 (b1694a50a) prints inside `migrate --update-repo-id`'s interactive confirm block, so scripted callers using `--yes` or `--json` skipped it entirely: they still stamped a host-local path hash into the versioned metadata table silently — the GH#4361 recurrence hole.

## Changes

- Extract the gating into `pathHashRepoIDStampNotice(old, new, source)`: notice applies only when an existing, different repo id would be replaced by a path-derived one.
- Print the notice (not the prompt) to stderr on the `--yes`/`--json` stamp paths.
- JSON success payload gains `repo_id_source` and, when the notice applies, a `warning` field so machine callers reading stdout see it too.
- Unit test covering all four gating cases.

## Testing

- `go build ./cmd/bd/` clean, `go vet` clean, gofmt clean
- `go test ./cmd/bd/ -run TestPathHashRepoIDStampNotice` — 4/4 pass

Bead: bd-ek28z

🤖 Generated with [Claude Code](https://claude.com/claude-code)