### PR TITLE
feat(cmd/bd): support bd import in proxied-server mode

### DIFF
--- a/cmd/bd/import.go
+++ b/cmd/bd/import.go
@@ -117,9 +117,6 @@ func init() {
 }
 
 func runImport(cmd *cobra.Command, args []string) error {
-	if usesProxiedServer() {
-		return HandleErrorRespectJSON("import is not supported in proxied-server mode")
-	}
 	evt := metrics.NewCommandEvent("import")
 	defer func() {
 		if c := metrics.Global(); c != nil {
@@ -212,16 +209,13 @@ type importResultJSON struct {
 	DryRun              bool           `json:"dry_run,omitempty"`
 }
 
-func runImportFromReader(ctx context.Context, r io.Reader, source string) error {
-	if store == nil {
-		return fmt.Errorf("no database — run 'bd init' or 'bd bootstrap' first")
-	}
-
+// parseImportJSONL reads the import JSONL stream into issues and memory
+// records. Extracted from runImportFromReader so the proxied-server path
+// consumes exactly the same wire semantics (header skip, memory records,
+// tombstone drop, wisp alias, SetDefaults) rather than reimplementing them.
+func parseImportJSONL(r io.Reader) (issues []*types.Issue, memories []memoryRecord, err error) {
 	scanner := bufio.NewScanner(r)
 	scanner.Buffer(make([]byte, 0, 1024*1024), 64*1024*1024)
-
-	var issues []*types.Issue
-	var memories []memoryRecord
 
 	for scanner.Scan() {
 		line := scanner.Text()
@@ -231,7 +225,7 @@ func runImportFromReader(ctx context.Context, r io.Reader, source string) error 
 
 		var peek map[string]json.RawMessage
 		if err := json.Unmarshal([]byte(line), &peek); err != nil {
-			return fmt.Errorf("failed to parse JSONL line: %w", err)
+			return nil, nil, fmt.Errorf("failed to parse JSONL line: %w", err)
 		}
 
 		// Skip the optional beads-jsonl header record (§J1.3). A canonical
@@ -251,7 +245,7 @@ func runImportFromReader(ctx context.Context, r io.Reader, source string) error 
 			if err := json.Unmarshal(rawType, &typeStr); err == nil && typeStr == "memory" {
 				var mem memoryRecord
 				if err := json.Unmarshal([]byte(line), &mem); err != nil {
-					return fmt.Errorf("failed to parse memory record: %w", err)
+					return nil, nil, fmt.Errorf("failed to parse memory record: %w", err)
 				}
 				if mem.Key != "" && mem.Value != "" {
 					memories = append(memories, mem)
@@ -262,7 +256,7 @@ func runImportFromReader(ctx context.Context, r io.Reader, source string) error 
 
 		var issue types.Issue
 		if err := json.Unmarshal([]byte(line), &issue); err != nil {
-			return fmt.Errorf("failed to parse issue from JSONL: %w", err)
+			return nil, nil, fmt.Errorf("failed to parse issue from JSONL: %w", err)
 		}
 		if issue.Status == "tombstone" {
 			continue
@@ -277,7 +271,23 @@ func runImportFromReader(ctx context.Context, r io.Reader, source string) error 
 		issues = append(issues, &issue)
 	}
 	if err := scanner.Err(); err != nil {
-		return fmt.Errorf("failed to scan JSONL: %w", err)
+		return nil, nil, fmt.Errorf("failed to scan JSONL: %w", err)
+	}
+
+	return issues, memories, nil
+}
+
+func runImportFromReader(ctx context.Context, r io.Reader, source string) error {
+	if usesProxiedServer() {
+		return runImportProxiedServer(ctx, r, source)
+	}
+	if store == nil {
+		return fmt.Errorf("no database — run 'bd init' or 'bd bootstrap' first")
+	}
+
+	issues, memories, err := parseImportJSONL(r)
+	if err != nil {
+		return err
 	}
 
 	// Dedup: skip issues whose title matches an existing open issue

--- a/cmd/bd/import_proxied_integration_test.go
+++ b/cmd/bd/import_proxied_integration_test.go
@@ -1,0 +1,176 @@
+//go:build cgo
+
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func bdProxiedImport(t *testing.T, bd, dir string, args ...string) string {
+	t.Helper()
+	fullArgs := append([]string{"import"}, args...)
+	stdout, stderr, err := bdProxiedRunBuffers(t, bd, dir, fullArgs...)
+	if err != nil {
+		t.Fatalf("bd import %s failed: %v\nstdout:\n%s\nstderr:\n%s",
+			strings.Join(args, " "), err, stdout, stderr)
+	}
+	// import reports on stderr and emits JSON on stdout.
+	return stdout + stderr
+}
+
+func writeImportFixture(t *testing.T, name string, lines ...string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), name)
+	if err := os.WriteFile(path, []byte(strings.Join(lines, "\n")+"\n"), 0o600); err != nil {
+		t.Fatalf("write fixture %s: %v", name, err)
+	}
+	return path
+}
+
+type importJSONReport struct {
+	Created         int      `json:"created"`
+	Updated         int      `json:"updated"`
+	Unchanged       int      `json:"unchanged"`
+	Skipped         int      `json:"skipped"`
+	Memories        int      `json:"memories"`
+	StaleSkippedIDs []string `json:"stale_skipped_ids"`
+}
+
+func bdProxiedImportJSON(t *testing.T, bd, dir string, args ...string) importJSONReport {
+	t.Helper()
+	fullArgs := append([]string{"import", "--json"}, args...)
+	stdout, stderr, err := bdProxiedRunBuffers(t, bd, dir, fullArgs...)
+	if err != nil {
+		t.Fatalf("bd import --json %s failed: %v\nstdout:\n%s\nstderr:\n%s",
+			strings.Join(args, " "), err, stdout, stderr)
+	}
+	var report importJSONReport
+	if uerr := json.Unmarshal([]byte(stdout), &report); uerr != nil {
+		t.Fatalf("parse import --json output: %v\nstdout:\n%s", uerr, stdout)
+	}
+	return report
+}
+
+// TestProxiedServerImport covers `bd import` on the proxied-server route.
+//
+// Federation is unavailable in this mode too (#5081), so with `import`
+// refusing there was no bulk path for seeding a database opened here from
+// another workspace's export. Ordinary server mode has neither refusal; these
+// cases pin the proxied route to the same import semantics.
+func TestProxiedServerImport(t *testing.T) {
+	requireSharedProxiedServer(t)
+	t.Parallel()
+
+	bd := buildEmbeddedBD(t)
+
+	t.Run("creates_rows_preserving_ids_and_timestamps", func(t *testing.T) {
+		t.Parallel()
+		p := newSharedProxiedProject(t, bd, "im")
+		fixture := writeImportFixture(t, "seed.jsonl",
+			`{"id":"im-seed1","title":"Imported epic","issue_type":"epic","priority":1,"status":"open","labels":["imported"],"created_at":"2026-07-01T10:00:00Z","updated_at":"2026-07-01T10:00:00Z"}`,
+			`{"id":"im-seed2","title":"Imported task","priority":2,"status":"open","created_at":"2026-07-02T11:00:00Z","updated_at":"2026-07-02T11:00:00Z","dependencies":[{"issue_id":"im-seed2","depends_on_id":"im-seed1","type":"blocks"}]}`,
+			`{"_type":"memory","key":"im-note","value":"imported memory"}`,
+		)
+
+		report := bdProxiedImportJSON(t, bd, p.dir, fixture)
+		if report.Created != 2 {
+			t.Errorf("created = %d, want 2", report.Created)
+		}
+		if report.Memories != 1 {
+			t.Errorf("memories = %d, want 1", report.Memories)
+		}
+
+		// The IDs from the JSONL must survive rather than being re-minted:
+		// this is what makes an export from another workspace round-trip.
+		show := bdProxiedList(t, bd, p)
+		for _, want := range []string{"im-seed1", "im-seed2"} {
+			if !strings.Contains(show, want) {
+				t.Errorf("bd list output missing %s:\n%s", want, show)
+			}
+		}
+	})
+
+	t.Run("reimport_of_identical_snapshot_is_a_no_op", func(t *testing.T) {
+		t.Parallel()
+		p := newSharedProxiedProject(t, bd, "iq")
+		fixture := writeImportFixture(t, "converge.jsonl",
+			`{"id":"iq-one","title":"Converge","priority":2,"status":"open","created_at":"2026-07-01T10:00:00Z","updated_at":"2026-07-01T10:00:00Z"}`,
+		)
+
+		first := bdProxiedImportJSON(t, bd, p.dir, fixture)
+		if first.Created != 1 {
+			t.Fatalf("first import created = %d, want 1", first.Created)
+		}
+
+		// Re-importing the same snapshot must converge: nothing created,
+		// nothing updated. Reporting these as created is the bug this locks
+		// down — the stale guard only lists content changes, so absence from
+		// its change plan must not be read as "new".
+		second := bdProxiedImportJSON(t, bd, p.dir, fixture)
+		if second.Created != 0 {
+			t.Errorf("second import created = %d, want 0", second.Created)
+		}
+		if second.Updated != 0 {
+			t.Errorf("second import updated = %d, want 0", second.Updated)
+		}
+		if second.Unchanged != 1 {
+			t.Errorf("second import unchanged = %d, want 1", second.Unchanged)
+		}
+	})
+
+	t.Run("older_rows_are_stale_skipped_unless_allow_stale", func(t *testing.T) {
+		t.Parallel()
+		p := newSharedProxiedProject(t, bd, "is")
+		newer := writeImportFixture(t, "newer.jsonl",
+			`{"id":"is-row","title":"Newer title","priority":0,"status":"open","created_at":"2026-07-01T10:00:00Z","updated_at":"2026-07-20T10:00:00Z"}`,
+		)
+		older := writeImportFixture(t, "older.jsonl",
+			`{"id":"is-row","title":"Older title","priority":3,"status":"open","created_at":"2026-07-01T10:00:00Z","updated_at":"2026-07-01T10:00:00Z"}`,
+		)
+
+		if got := bdProxiedImportJSON(t, bd, p.dir, newer); got.Created != 1 {
+			t.Fatalf("seed import created = %d, want 1", got.Created)
+		}
+
+		// Default: the older row loses and is reported, not silently applied.
+		stale := bdProxiedImportJSON(t, bd, p.dir, older)
+		if stale.Updated != 0 {
+			t.Errorf("stale import updated = %d, want 0", stale.Updated)
+		}
+		if len(stale.StaleSkippedIDs) != 1 || stale.StaleSkippedIDs[0] != "is-row" {
+			t.Errorf("stale_skipped_ids = %v, want [is-row]", stale.StaleSkippedIDs)
+		}
+		if out := bdProxiedList(t, bd, p); !strings.Contains(out, "Newer title") {
+			t.Errorf("stale import must not overwrite the newer row:\n%s", out)
+		}
+
+		// --allow-stale is the documented restore-an-older-snapshot path.
+		restored := bdProxiedImportJSON(t, bd, p.dir, "--allow-stale", older)
+		if restored.Updated != 1 {
+			t.Errorf("--allow-stale updated = %d, want 1", restored.Updated)
+		}
+		if out := bdProxiedList(t, bd, p); !strings.Contains(out, "Older title") {
+			t.Errorf("--allow-stale should restore the older row:\n%s", out)
+		}
+	})
+
+	t.Run("dry_run_writes_nothing", func(t *testing.T) {
+		t.Parallel()
+		p := newSharedProxiedProject(t, bd, "id")
+		fixture := writeImportFixture(t, "dry.jsonl",
+			`{"id":"id-ghost","title":"Never written","priority":2,"status":"open","created_at":"2026-07-01T10:00:00Z","updated_at":"2026-07-01T10:00:00Z"}`,
+		)
+
+		report := bdProxiedImportJSON(t, bd, p.dir, "--dry-run", fixture)
+		if report.Created != 1 {
+			t.Errorf("dry-run created = %d, want 1 (the would-create count)", report.Created)
+		}
+		if out := bdProxiedList(t, bd, p); strings.Contains(out, "id-ghost") {
+			t.Errorf("dry-run must not write rows:\n%s", out)
+		}
+	})
+}

--- a/cmd/bd/import_proxied_server.go
+++ b/cmd/bd/import_proxied_server.go
@@ -1,0 +1,384 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/steveyegge/beads/internal/storage/domain"
+	"github.com/steveyegge/beads/internal/storage/uow"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// runImportProxiedServer imports a JSONL stream through the proxied-server
+// unit-of-work stack.
+//
+// Refusing import here left no bulk way to seed a database opened in this
+// mode from another workspace's export, since federation is unavailable in
+// proxied-server mode too (#5081). Ordinary server mode has neither refusal,
+// so this closes a gap specific to this mode rather than adding a new
+// capability. That JSONL is an interchange surface and not canonical storage
+// (#4225) is exactly why this is an explicit operator-run command and not an
+// auto-import path.
+//
+// The wire parse, the stale/tie guard, and the memory-record handling are the
+// same code the store-backed path runs (parseImportJSONL,
+// filterStaleImportIssues, classifyDryRunImport), so the two modes cannot
+// drift on import semantics. What differs is the write: the unit of work has
+// no batch upsert, so rows are partitioned into creates and updates and
+// applied through IssueUseCase, all inside one transaction that commits once.
+func runImportProxiedServer(ctx context.Context, r io.Reader, source string) error {
+	if uowProvider == nil {
+		return HandleError("proxied-server UOW provider not initialized")
+	}
+
+	issues, memories, err := parseImportJSONL(r)
+	if err != nil {
+		return HandleError("%v", err)
+	}
+
+	result := importResultJSON{Source: source, DryRun: importDryRun}
+
+	if importDryRun {
+		classification, cerr := uow.RunTxRead(ctx, uowProvider, func(ctx context.Context, uw uow.UnitOfWork) (*ImportResult, error) {
+			return classifyDryRunImport(ctx, uw.IssueUseCase(), issues, importAllowStale)
+		})
+		if cerr != nil {
+			return HandleError("dry-run: %v", cerr)
+		}
+		result.Memories = len(memories)
+		result.Created = classification.Created
+		result.Updated = classification.Updated
+		result.Unchanged = classification.Unchanged
+		result.Skipped = classification.Skipped
+		result.IDs = classification.ImportedIDs
+		result.StaleSkippedIDs = classification.StaleSkippedIDs
+		result.UpdatedIssues = classification.UpdatedIssues
+		result.TieKeptLocalIDs = classification.TieKeptLocalIDs
+
+		if jsonOutput {
+			return outputJSON(result)
+		}
+		considered := result.Created + result.Updated + result.Unchanged
+		fmt.Fprintf(os.Stderr, "Would import %d issues (%d new, %d updated, %d unchanged) and %d memories from %s",
+			considered, result.Created, result.Updated, result.Unchanged, len(memories), source)
+		if len(result.StaleSkippedIDs) > 0 {
+			fmt.Fprintf(os.Stderr, " (%d stale skipped)", len(result.StaleSkippedIDs))
+		}
+		fmt.Fprintln(os.Stderr)
+		return nil
+	}
+
+	applied, err := uow.RunTxResult(ctx, uowProvider, func(ctx context.Context, uw uow.UnitOfWork) (*ImportResult, string, error) {
+		res, aerr := applyProxiedImport(ctx, uw, issues, memories, importAllowStale)
+		if aerr != nil {
+			return nil, "", aerr
+		}
+		msg := fmt.Sprintf("bd import: %d issues", res.Created)
+		if res.Updated > 0 {
+			msg += fmt.Sprintf(", %d updated", res.Updated)
+		}
+		if len(memories) > 0 {
+			msg += fmt.Sprintf(", %d memories", len(memories))
+		}
+		return res, msg + " from " + source, nil
+	})
+	if err != nil {
+		return HandleError("import failed: %v", err)
+	}
+
+	result.Created = applied.Created
+	result.Updated = applied.Updated
+	result.Unchanged = applied.Unchanged
+	result.Skipped = applied.Skipped
+	result.Memories = len(memories)
+	result.IDs = applied.ImportedIDs
+	result.UpdatedIssues = applied.UpdatedIssues
+	result.TieKeptLocalIDs = applied.TieKeptLocalIDs
+	result.StaleSkippedIDs = applied.StaleSkippedIDs
+
+	if jsonOutput {
+		return outputJSON(result)
+	}
+
+	fmt.Fprintf(os.Stderr, "Imported %d issues", result.Created)
+	if result.Updated > 0 {
+		fmt.Fprintf(os.Stderr, ", updated %d", result.Updated)
+	}
+	if result.Unchanged > 0 {
+		fmt.Fprintf(os.Stderr, ", %d unchanged", result.Unchanged)
+	}
+	if result.Memories > 0 {
+		fmt.Fprintf(os.Stderr, " and %d memories", result.Memories)
+	}
+	fmt.Fprintf(os.Stderr, " from %s", source)
+	if len(result.StaleSkippedIDs) > 0 {
+		fmt.Fprintf(os.Stderr, " (%d stale skipped; use --allow-stale to restore older rows)", len(result.StaleSkippedIDs))
+	}
+	fmt.Fprintln(os.Stderr)
+	if len(result.TieKeptLocalIDs) > 0 {
+		fmt.Fprintf(os.Stderr, "Kept local state for %d issue(s) with the same updated_at but different content (use --allow-stale to overwrite): %s\n",
+			len(result.TieKeptLocalIDs), strings.Join(result.TieKeptLocalIDs, ", "))
+	}
+	return nil
+}
+
+// applyProxiedImport writes one import batch inside an open unit of work.
+//
+// Ordering matters: every create runs before any dependency edge is added, so
+// a batch whose rows reference each other does not depend on JSONL line order.
+// Dependency targets missing from both the batch and the database are reported
+// as skipped rather than failing the import, matching the store-backed path's
+// SkipDependencyValidationErrors behavior.
+func applyProxiedImport(ctx context.Context, uw uow.UnitOfWork, issues []*types.Issue, memories []memoryRecord, allowStale bool) (*ImportResult, error) {
+	res := &ImportResult{}
+
+	for _, mem := range memories {
+		if err := uw.ConfigUseCase().SetConfig(ctx, kvPrefix+memoryPrefix+mem.Key, mem.Value); err != nil {
+			return nil, fmt.Errorf("import memory %q: %w", mem.Key, err)
+		}
+	}
+
+	if len(issues) == 0 {
+		return res, nil
+	}
+
+	// Stale/tie guard, shared with the store-backed path. Without
+	// --allow-stale, rows older than the stored copy are dropped here and
+	// reported; equal-timestamp rows keep local columns (bd-hj85c).
+	plan := importChangePlan{}
+	if !allowStale {
+		filtered, staleSkipped, p, err := filterStaleImportIssues(ctx, uw.IssueUseCase(), issues)
+		if err != nil {
+			return nil, err
+		}
+		issues = filtered
+		res.StaleSkippedIDs = staleSkipped
+		res.Skipped = len(staleSkipped)
+		res.TieKeptLocalIDs = p.TieKeptLocal
+		plan = p
+		if len(issues) == 0 {
+			return res, nil
+		}
+	}
+
+	// Create-vs-update must be decided by existence, not by plan.Updates.
+	// filterStaleImportIssues only records a row in Updates when its content
+	// actually differs, so an identical re-import leaves surviving rows absent
+	// from Updates — treating that absence as "new" would re-create every row
+	// (and, on a store that upserts, silently report a fresh import as
+	// created). Ask the database which IDs it already has.
+	existing, err := existingImportIDs(ctx, uw.IssueUseCase(), issues)
+	if err != nil {
+		return nil, err
+	}
+
+	// Rows whose content is unchanged are neither created nor updated; they
+	// are reported as unchanged so a converged re-import reads as a no-op.
+	// --allow-stale deliberately skips the guard that computes the change
+	// list, so in that mode every existing row is rewritten unconditionally —
+	// that is the point of restoring a snapshot over newer local state.
+	changedByID := make(map[string]struct{}, len(plan.Updates))
+	if allowStale {
+		for id := range existing {
+			changedByID[id] = struct{}{}
+		}
+	}
+	for _, change := range plan.Updates {
+		changedByID[change.ID] = struct{}{}
+	}
+	tieKept := make(map[string]struct{}, len(res.TieKeptLocalIDs))
+	for _, id := range res.TieKeptLocalIDs {
+		tieKept[id] = struct{}{}
+	}
+
+	actor := getActorWithGit()
+	inBatch := make(map[string]struct{}, len(issues))
+	for _, issue := range issues {
+		if issue != nil && issue.ID != "" {
+			inBatch[issue.ID] = struct{}{}
+		}
+	}
+
+	// Pass 1: rows only. Dependencies come after every row exists.
+	for _, issue := range issues {
+		if issue == nil {
+			continue
+		}
+		if _, exists := existing[issue.ID]; exists {
+			// A tie keeps every stored column by contract (bd-hj85c), and an
+			// unchanged row has nothing to write: both are no-ops on the row
+			// itself, but their aux data still merges in later passes.
+			if _, tied := tieKept[issue.ID]; tied {
+				res.Unchanged++
+				continue
+			}
+			if _, changed := changedByID[issue.ID]; !changed {
+				res.Unchanged++
+				continue
+			}
+			if err := applyProxiedImportUpdate(ctx, uw, issue, actor); err != nil {
+				return nil, fmt.Errorf("update %s: %w", issue.ID, err)
+			}
+			res.Updated++
+			continue
+		}
+		params := domain.CreateIssueParams{
+			Issue:                issue,
+			ExplicitID:           issue.ID,
+			Labels:               issue.Labels,
+			ForcePrefix:          true,
+			DiscoveredFromParent: "",
+		}
+		if _, err := uw.IssueUseCase().CreateIssue(ctx, params, actor); err != nil {
+			return nil, fmt.Errorf("create %s: %w", issue.ID, err)
+		}
+		res.Created++
+		res.ImportedIDs = append(res.ImportedIDs, issue.ID)
+	}
+
+	// Pass 2: dependency edges, now that every row in the batch exists.
+	for _, issue := range issues {
+		if issue == nil || len(issue.Dependencies) == 0 {
+			continue
+		}
+		for _, dep := range issue.Dependencies {
+			target := dep.DependsOnID
+			if target == "" {
+				continue
+			}
+			if _, batched := inBatch[target]; !batched {
+				if _, err := uw.IssueUseCase().GetIssue(ctx, target); err != nil {
+					res.SkippedDependencies = append(res.SkippedDependencies,
+						fmt.Sprintf("%s -> %s: target not found", issue.ID, target))
+					continue
+				}
+			}
+			depType := dep.Type
+			if depType == "" {
+				depType = types.DepBlocks
+			}
+			edge := &types.Dependency{IssueID: issue.ID, DependsOnID: target, Type: depType}
+			if err := uw.DependencyUseCase().AddDependency(ctx, edge, actor); err != nil {
+				// An edge that already exists is not an import failure:
+				// re-importing a snapshot must converge, not error.
+				if isAlreadyExistsError(err) {
+					continue
+				}
+				return nil, fmt.Errorf("dependency %s -> %s: %w", issue.ID, target, err)
+			}
+		}
+	}
+
+	// Pass 3: comments, after rows exist so authorship attaches to a real issue.
+	for _, issue := range issues {
+		if issue == nil || len(issue.Comments) == 0 {
+			continue
+		}
+		for _, c := range issue.Comments {
+			if c.Text == "" {
+				continue
+			}
+			author := c.Author
+			if author == "" {
+				author = actor
+			}
+			if _, err := uw.CommentUseCase().AddCommentToIssue(ctx, issue.ID, author, c.Text); err != nil {
+				return nil, fmt.Errorf("comment on %s: %w", issue.ID, err)
+			}
+		}
+	}
+
+	res.UpdatedIssues = plan.Updates
+	return res, nil
+}
+
+// existingImportIDs returns the subset of the batch's IDs that already exist,
+// so create-vs-update is decided by the database rather than inferred from the
+// stale guard's change list.
+func existingImportIDs(ctx context.Context, reader issuesByIDReader, issues []*types.Issue) (map[string]struct{}, error) {
+	ids := make([]string, 0, len(issues))
+	seen := make(map[string]struct{}, len(issues))
+	for _, issue := range issues {
+		if issue == nil || issue.ID == "" {
+			continue
+		}
+		if _, ok := seen[issue.ID]; ok {
+			continue
+		}
+		seen[issue.ID] = struct{}{}
+		ids = append(ids, issue.ID)
+	}
+	existing := make(map[string]struct{}, len(ids))
+	if len(ids) == 0 {
+		return existing, nil
+	}
+	local, err := reader.GetIssuesByIDs(ctx, ids)
+	if err != nil {
+		return nil, fmt.Errorf("check existing issues before import: %w", err)
+	}
+	for _, issue := range local {
+		if issue != nil && issue.ID != "" {
+			existing[issue.ID] = struct{}{}
+		}
+	}
+	return existing, nil
+}
+
+// applyProxiedImportUpdate rewrites an existing row from an incoming JSONL
+// issue. The guard upstream of this call already decided the row should be
+// rewritten; this maps the wire fields onto an UpdateSpec.
+func applyProxiedImportUpdate(ctx context.Context, uw uow.UnitOfWork, issue *types.Issue, actor string) error {
+	fields := map[string]any{
+		"title":       issue.Title,
+		"description": issue.Description,
+		"status":      string(issue.Status),
+		"priority":    issue.Priority,
+		"issue_type":  string(issue.IssueType),
+	}
+	if issue.Design != "" {
+		fields["design"] = issue.Design
+	}
+	if issue.AcceptanceCriteria != "" {
+		fields["acceptance_criteria"] = issue.AcceptanceCriteria
+	}
+	if issue.Notes != "" {
+		fields["notes"] = issue.Notes
+	}
+	if issue.Assignee != "" {
+		fields["assignee"] = issue.Assignee
+	}
+	if issue.Owner != "" {
+		fields["owner"] = issue.Owner
+	}
+	// updated_at is deliberately NOT set: the domain update path force-stamps
+	// it to now (db.Update appends its own SET updated_at) and its allow-list
+	// rejects the column outright. So a row rewritten by import here carries a
+	// fresh updated_at rather than the JSONL value, which differs from the
+	// store-backed batch upsert. The divergence is confined to the rewrite
+	// path — creates preserve created_at/updated_at exactly, which is what the
+	// bootstrap-an-empty-database case relies on — and it is convergent: the
+	// next import of the same snapshot classifies the row as stale-skipped
+	// rather than silently reapplying it. Preserving the incoming timestamp
+	// would mean writing the column outside the domain layer.
+
+	spec := domain.UpdateSpec{Fields: fields}
+	if len(issue.Labels) > 0 {
+		labels := issue.Labels
+		spec.SetLabels = &labels
+	}
+	_, err := uw.IssueUseCase().ApplyUpdate(ctx, issue.ID, spec, actor)
+	return err
+}
+
+// isAlreadyExistsError reports whether err is a benign "row/edge is already
+// there" result, which makes a repeated import converge instead of failing.
+func isAlreadyExistsError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "already exists") || strings.Contains(msg, "duplicate")
+}

--- a/cmd/bd/import_proxied_server_test.go
+++ b/cmd/bd/import_proxied_server_test.go
@@ -1,0 +1,212 @@
+package main
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// fakeIssuesByIDReader answers GetIssuesByIDs from a fixed set, which is the
+// only capability the import classification path needs.
+type fakeIssuesByIDReader struct {
+	stored map[string]*types.Issue
+	calls  int
+}
+
+func (f *fakeIssuesByIDReader) GetIssuesByIDs(_ context.Context, ids []string) ([]*types.Issue, error) {
+	f.calls++
+	out := make([]*types.Issue, 0, len(ids))
+	for _, id := range ids {
+		if issue, ok := f.stored[id]; ok {
+			out = append(out, issue)
+		}
+	}
+	return out, nil
+}
+
+func ts(s string) time.Time {
+	t, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		panic(err)
+	}
+	return t
+}
+
+// TestExistingImportIDs_DecidesCreateVsUpdateByExistence locks in the fix for
+// the create/update misclassification: filterStaleImportIssues only records a
+// row in its change plan when the content differs, so an identical re-import
+// leaves surviving rows absent from Updates. Inferring "new" from that absence
+// reported every row of a converged re-import as created. Existence must come
+// from the database.
+func TestExistingImportIDs_DecidesCreateVsUpdateByExistence(t *testing.T) {
+	reader := &fakeIssuesByIDReader{stored: map[string]*types.Issue{
+		"bd-exists": {ID: "bd-exists", Title: "stored", UpdatedAt: ts("2026-07-01T10:00:00Z")},
+	}}
+
+	incoming := []*types.Issue{
+		{ID: "bd-exists", Title: "stored", UpdatedAt: ts("2026-07-01T10:00:00Z")},
+		{ID: "bd-new", Title: "fresh", UpdatedAt: ts("2026-07-01T10:00:00Z")},
+	}
+
+	existing, err := existingImportIDs(context.Background(), reader, incoming)
+	if err != nil {
+		t.Fatalf("existingImportIDs: %v", err)
+	}
+	if _, ok := existing["bd-exists"]; !ok {
+		t.Error("bd-exists should be reported as already present")
+	}
+	if _, ok := existing["bd-new"]; ok {
+		t.Error("bd-new must not be reported as present")
+	}
+	if len(existing) != 1 {
+		t.Errorf("existing = %d entries, want 1", len(existing))
+	}
+}
+
+// TestExistingImportIDs_DedupesAndSkipsBlankIDs guards the lookup against a
+// JSONL batch that repeats an ID or carries title-only rows: neither should
+// produce duplicate lookup keys or a query for the empty string.
+func TestExistingImportIDs_DedupesAndSkipsBlankIDs(t *testing.T) {
+	reader := &fakeIssuesByIDReader{stored: map[string]*types.Issue{}}
+	incoming := []*types.Issue{
+		{ID: "bd-dup", Title: "one"},
+		{ID: "bd-dup", Title: "one again"},
+		{ID: "", Title: "no id at all"},
+		nil,
+	}
+
+	existing, err := existingImportIDs(context.Background(), reader, incoming)
+	if err != nil {
+		t.Fatalf("existingImportIDs: %v", err)
+	}
+	if len(existing) != 0 {
+		t.Errorf("existing = %d, want 0 (store is empty)", len(existing))
+	}
+	if reader.calls != 1 {
+		t.Errorf("GetIssuesByIDs called %d times, want 1", reader.calls)
+	}
+}
+
+// TestExistingImportIDs_EmptyBatchSkipsTheQuery keeps a no-op import from
+// issuing a pointless lookup.
+func TestExistingImportIDs_EmptyBatchSkipsTheQuery(t *testing.T) {
+	reader := &fakeIssuesByIDReader{stored: map[string]*types.Issue{}}
+	existing, err := existingImportIDs(context.Background(), reader, nil)
+	if err != nil {
+		t.Fatalf("existingImportIDs: %v", err)
+	}
+	if len(existing) != 0 {
+		t.Errorf("existing = %d, want 0", len(existing))
+	}
+	if reader.calls != 0 {
+		t.Errorf("GetIssuesByIDs called %d times for an empty batch, want 0", reader.calls)
+	}
+}
+
+// TestFilterStaleImportIssues_ThroughNarrowedReader is the regression guard for
+// narrowing filterStaleImportIssues from storage.DoltStorage to
+// issuesByIDReader: the proxied-server path reuses this guard through its unit
+// of work, so the stale/tie semantics must hold when driven by a reader that is
+// not a full store.
+func TestFilterStaleImportIssues_ThroughNarrowedReader(t *testing.T) {
+	local := ts("2026-07-10T10:00:00Z")
+	reader := &fakeIssuesByIDReader{stored: map[string]*types.Issue{
+		"bd-older":   {ID: "bd-older", Title: "stored", Priority: 1, UpdatedAt: local},
+		"bd-newer":   {ID: "bd-newer", Title: "stored", Priority: 1, UpdatedAt: local},
+		"bd-tie":     {ID: "bd-tie", Title: "stored", Priority: 1, UpdatedAt: local},
+		"bd-samerow": {ID: "bd-samerow", Title: "identical", Priority: 1, UpdatedAt: local},
+	}}
+
+	incoming := []*types.Issue{
+		// older than stored: dropped and reported stale
+		{ID: "bd-older", Title: "incoming", Priority: 2, UpdatedAt: local.Add(-time.Hour)},
+		// strictly newer with different content: an update
+		{ID: "bd-newer", Title: "incoming", Priority: 2, UpdatedAt: local.Add(time.Hour)},
+		// equal timestamp, different content: local wins the tie
+		{ID: "bd-tie", Title: "incoming", Priority: 2, UpdatedAt: local},
+		// equal timestamp, identical content: neither update nor tie
+		{ID: "bd-samerow", Title: "identical", Priority: 1, UpdatedAt: local},
+	}
+
+	filtered, staleSkipped, plan, err := filterStaleImportIssues(context.Background(), reader, incoming)
+	if err != nil {
+		t.Fatalf("filterStaleImportIssues: %v", err)
+	}
+
+	if len(staleSkipped) != 1 || staleSkipped[0] != "bd-older" {
+		t.Errorf("staleSkipped = %v, want [bd-older]", staleSkipped)
+	}
+	for _, issue := range filtered {
+		if issue.ID == "bd-older" {
+			t.Error("bd-older must not survive the filter")
+		}
+	}
+	if len(plan.Updates) != 1 || plan.Updates[0].ID != "bd-newer" {
+		t.Errorf("plan.Updates = %+v, want one entry for bd-newer", plan.Updates)
+	}
+	if len(plan.TieKeptLocal) != 1 || plan.TieKeptLocal[0] != "bd-tie" {
+		t.Errorf("plan.TieKeptLocal = %v, want [bd-tie]", plan.TieKeptLocal)
+	}
+	// The identical row is in neither list: it is the "unchanged" case the
+	// proxied path reports separately from created and updated.
+	for _, change := range plan.Updates {
+		if change.ID == "bd-samerow" {
+			t.Error("an identical row must not be classified as an update")
+		}
+	}
+}
+
+// TestParseImportJSONL_SharedWireSemantics locks in the extraction of the
+// parser: the proxied path must consume exactly the semantics the store-backed
+// path always had — provenance header skipped, memory records split out,
+// tombstones dropped, the legacy wisp alias honored.
+func TestParseImportJSONL_SharedWireSemantics(t *testing.T) {
+	in := strings.Join([]string{
+		`{"_schema":"beads-jsonl/1","_dolt_branch":"main","_sort":"stable-v1"}`,
+		`{"_type":"memory","key":"note","value":"remembered"}`,
+		`{"id":"bd-1","title":"kept"}`,
+		`{"id":"bd-dead","title":"gone","status":"tombstone"}`,
+		`{"id":"bd-wisp","title":"legacy wisp","wisp":true}`,
+		``,
+	}, "\n")
+
+	issues, memories, err := parseImportJSONL(strings.NewReader(in))
+	if err != nil {
+		t.Fatalf("parseImportJSONL: %v", err)
+	}
+
+	if len(memories) != 1 || memories[0].Key != "note" || memories[0].Value != "remembered" {
+		t.Errorf("memories = %+v, want one note/remembered record", memories)
+	}
+	if len(issues) != 2 {
+		t.Fatalf("issues = %d, want 2 (header, tombstone excluded)", len(issues))
+	}
+	byID := map[string]*types.Issue{}
+	for _, issue := range issues {
+		byID[issue.ID] = issue
+	}
+	if _, ok := byID["bd-dead"]; ok {
+		t.Error("tombstone row must be dropped")
+	}
+	if got, ok := byID["bd-wisp"]; !ok || !got.Ephemeral {
+		t.Errorf(`legacy "wisp":true must set Ephemeral, got %+v`, got)
+	}
+	if _, ok := byID["bd-1"]; !ok {
+		t.Error("bd-1 should be parsed")
+	}
+}
+
+// TestParseImportJSONL_RejectsMalformedLines keeps the parser loud: a corrupt
+// line must fail the import rather than silently importing a partial batch.
+func TestParseImportJSONL_RejectsMalformedLines(t *testing.T) {
+	_, _, err := parseImportJSONL(strings.NewReader("{not json}\n"))
+	if err == nil {
+		t.Fatal("expected an error for a malformed JSONL line")
+	}
+	if !strings.Contains(err.Error(), "failed to parse JSONL line") {
+		t.Errorf("error = %v, want a JSONL parse failure", err)
+	}
+}

--- a/cmd/bd/import_shared.go
+++ b/cmd/bd/import_shared.go
@@ -655,7 +655,16 @@ type importChangePlan struct {
 	NewCount int
 }
 
-func filterStaleImportIssues(ctx context.Context, store storage.DoltStorage, issues []*types.Issue) ([]*types.Issue, []string, importChangePlan, error) {
+// issuesByIDReader is the only storage capability filterStaleImportIssues
+// needs. Narrowing it from storage.DoltStorage lets the proxied-server import
+// path reuse this stale/tie guard through its unit-of-work, so both paths
+// share one implementation of the bd-pkim8/bd-hj85c semantics instead of
+// growing a second copy that can drift.
+type issuesByIDReader interface {
+	GetIssuesByIDs(ctx context.Context, ids []string) ([]*types.Issue, error)
+}
+
+func filterStaleImportIssues(ctx context.Context, store issuesByIDReader, issues []*types.Issue) ([]*types.Issue, []string, importChangePlan, error) {
 	var plan importChangePlan
 	ids := make([]string, 0, len(issues))
 	seen := make(map[string]struct{}, len(issues))
@@ -775,7 +784,7 @@ func filterStaleImportIssues(ctx context.Context, store storage.DoltStorage, iss
 // --allow-stale write) imports every row regardless of timestamp ordering,
 // so no row is ever stale-skipped or tie-kept — existence is the only
 // question.
-func classifyImportIssuesExistence(ctx context.Context, store storage.DoltStorage, issues []*types.Issue) (importChangePlan, error) {
+func classifyImportIssuesExistence(ctx context.Context, store issuesByIDReader, issues []*types.Issue) (importChangePlan, error) {
 	var plan importChangePlan
 	ids := make([]string, 0, len(issues))
 	seen := make(map[string]struct{}, len(issues))
@@ -831,7 +840,7 @@ func classifyImportIssuesExistence(ctx context.Context, store storage.DoltStorag
 // classifyDryRunImport runs the same id lookup as a real import, without
 // writing anything, so --dry-run can report create/update/skip counts
 // instead of treating every row as a create (GH#4901).
-func classifyDryRunImport(ctx context.Context, store storage.DoltStorage, issues []*types.Issue, allowStale bool) (*ImportResult, error) {
+func classifyDryRunImport(ctx context.Context, store issuesByIDReader, issues []*types.Issue, allowStale bool) (*ImportResult, error) {
 	if len(issues) == 0 {
 		return &ImportResult{}, nil
 	}


### PR DESCRIPTION
## Why read this

`bd import` is refused in proxied-server mode, and so is `bd federation` (#5081), which leaves no supported way to load an existing JSONL snapshot into a database opened that way. Each refusal is individually reasonable; together they close the bulk transfer paths into such a database.

The tell is that `bd create` works fine through the proxy while `bd import` refuses — the write path is available, only the bulk entry point is closed.

## Why take the change

The same operations all work in ordinary **server mode** against an external dolt sql-server — `import`, `export`, and `remember` have no equivalent guards, and server mode carries TLS too (`dolt_server_tls`, wired to `TLSConfig` in `internal/storage/doltutil/dsn.go`). So this is a gap in the newer mode rather than a blocker: a user who reaches for proxied-server first simply has no way to discover the capability exists one mode over. Correcting my own earlier framing on #5180 — I had wrongly believed proxied-server was the only TLS-capable mode.

This PR closes the gap on the same rails the mode's other proxied companions already use (51 `*_proxied_server.go` files), without a second copy of the import semantics: the wire parse and the stale/tie guard are *shared* with the store-backed path rather than reimplemented, so the two modes cannot drift on what an import means. If proxied-server usage grows, that shared-semantics property is what keeps the two paths from diverging.

The net new logic is small. Most of the diff is an extraction and three interface narrowings that let existing, already-tested code run under the unit of work.

## What

Ports `import` following the established pattern (#4799, #4797, #4794, #4433, #4446, #4997): a `*_proxied_server.go` companion driving `IssueUseCase` through the UOW, in one transaction that commits once.

- **`parseImportJSONL`** extracted from `runImportFromReader` — header skip, memory records, tombstone drop, legacy `wisp` alias, `SetDefaults`. No behavior change to the existing path.
- **`filterStaleImportIssues`, `classifyImportIssuesExistence`, `classifyDryRunImport`** narrowed from `storage.DoltStorage` to a one-method `issuesByIDReader` — the only capability they actually use — so the UOW can drive them. This is what keeps bd-pkim8/bd-hj85c stale and tie semantics identical in both modes.
- **Create-vs-update decided by existence**, via a `GetIssuesByIDs` lookup. The guard's change list only records rows whose *content* differs, so an identical re-import leaves surviving rows absent from it; inferring "new" from that absence reported a converged re-import as `created: 3`. Caught because `--dry-run` said `unchanged: 3` while the write path disagreed. There is a regression test for exactly this.
- Rows are written before dependency edges, so a batch whose rows reference each other does not depend on JSONL line order. Missing dependency targets are reported as skipped rather than failing the import, matching `SkipDependencyValidationErrors`.

## Known divergence (deliberate, documented in the code)

The domain update path force-stamps `updated_at` and its allow-list rejects the column, so rows **rewritten** by a proxied import carry a fresh `updated_at` rather than the JSONL value. **Creates preserve `created_at`/`updated_at` exactly**, which is what seeding an empty database needs. The behavior is convergent: the next import of the same snapshot classifies the row as stale-skipped instead of reapplying it. Preserving it on rewrite would mean writing the column outside the domain layer, which seemed worse than the divergence — happy to revisit if you'd prefer that trade.

## Verification

`CGO_ENABLED=1`, `-tags=gms_pure_go` (per `.buildflags`), dolt 2.2.2, macOS arm64.

6 unit tests + a 4-case proxied integration test:

```sh
BEADS_TEST_PROXIED_SERVER=1 go test ./cmd/bd/ \
  -run 'TestExistingImportIDs|TestFilterStaleImportIssues_ThroughNarrowedReader|TestParseImportJSONL|TestProxiedServerImport' -count=1
# ok  github.com/steveyegge/beads/cmd/bd  25.5s

go test ./cmd/bd/ -run 'Import|import' -count=1     # ok — existing import tests unchanged
```

Also green: full `TestProxiedServerLabel` suite (19 subtests, confirms the shared-helper narrowing doesn't disturb neighboring proxied commands), `make ci-pr-policy`, `go vet`, `gofmt`.

`make ci-pr-lint` reports 2 pre-existing gosec findings in `internal/config/permissions_open_nonlinux.go` and `internal/utils/path_case_darwin.go` — both reproduce on a pristine tree and are untouched by this branch.

Manual end-to-end against dolt 2.2.2 with an `arcaven_rw` account holding **no global CREATE**: fresh import created 3 issues + 1 memory with IDs, original timestamps, labels, a `blocks` edge, and comment authorship all preserved; identical re-run reported 0 created / 3 unchanged; an older snapshot was stale-skipped, then restored by `--allow-stale`; `--dry-run` wrote nothing.

## Collision check

`scripts/pr-preflight.sh --search "import proxied-server"` surfaced 8 open PRs; none touch `cmd/bd/import*.go` or the storage-mode seam. Closest by area is #4844 (`bd dolt rebase`) — no shared files. Independent of #5086/#5087/#5085; this branch is based on plain `upstream/main` (`b1694a50a`) so it can land in any order.

Filed alongside #5179 (`bd migrate issues` panics in this mode), which I did not fix here to keep this PR focused.

Fixes #5180.

_claude-opus-5-xhigh on behalf of skippy_


