### PR TITLE
fix(doltserver): stop detached children inheriting the caller's fds (#4634)

### DIFF
--- a/internal/doltserver/doltserver.go
+++ b/internal/doltserver/doltserver.go
@@ -36,6 +36,7 @@ import (
 	"github.com/steveyegge/beads/internal/config"
 	"github.com/steveyegge/beads/internal/configfile"
 	"github.com/steveyegge/beads/internal/debug"
+	"github.com/steveyegge/beads/internal/fdhygiene"
 	"github.com/steveyegge/beads/internal/lockfile"
 	"github.com/steveyegge/beads/internal/storage/doltutil"
 )
@@ -1163,6 +1164,12 @@ func Start(beadsDir string) (*State, error) {
 			cmd.SysProcAttr = procAttrDetached()
 			cmd.Env = os.Environ()
 
+			// GH#4634: the server outlives the caller, so any descriptor the
+			// caller left non-CLOEXEC (a shell `exec 9>lock`, a CI harness, an
+			// editor terminal) would be pinned by the server until it is
+			// restarted. os/exec does not close those; mark them first.
+			sanitizeInheritedFDs()
+
 			if startErr := cmd.Start(); startErr != nil {
 				lastErr = startErr
 				if !explicitPort {
@@ -1414,6 +1421,16 @@ func StopWithForce(beadsDir string, force bool) error {
 	}
 
 	return cleanupStateFiles(beadsDir)
+}
+
+// sanitizeInheritedFDs marks descriptors bd inherited but did not open
+// close-on-exec, so the detached sql-server does not pin them for its whole
+// lifetime (GH#4634). It is a free function rather than an inline call because
+// the spawn path shadows the debug package with a local `debug bool`.
+func sanitizeInheritedFDs() {
+	if leaked := fdhygiene.MarkInheritedCloexec(); len(leaked) > 0 {
+		debug.Logf("marked %d inherited fd(s) close-on-exec before starting dolt sql-server: %v", len(leaked), leaked)
+	}
 }
 
 // cleanupStateFiles removes all server state files (PID and port).

--- a/internal/doltserver/fdleak_integration_test.go
+++ b/internal/doltserver/fdleak_integration_test.go
@@ -1,0 +1,81 @@
+//go:build integration && linux
+
+package doltserver_test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"golang.org/x/sys/unix"
+
+	"github.com/steveyegge/beads/internal/doltserver"
+	"github.com/steveyegge/beads/internal/testutil/integration"
+)
+
+// TestStart_ServerDoesNotInheritCallerFDs is the end-to-end regression test for
+// GH#4634: a caller that holds a descriptor without FD_CLOEXEC and cold-starts
+// the sql-server used to have that descriptor pinned by the server for its
+// whole lifetime, which outlives the caller. The reported symptom was a sync
+// script's flock on fd 9 reading as permanently held.
+//
+// Linux-only because it reads the child's fd table from /proc/<pid>/fd. The
+// mechanism itself is unix-wide and is unit-tested per-platform in
+// internal/fdhygiene.
+func TestStart_ServerDoesNotInheritCallerFDs(t *testing.T) {
+	beadsDir := setupLifecycleTestDir(t)
+	reg := integration.NewProcessRegistry(t)
+	diag := integration.NewDiagnostics(t, beadsDir)
+	diag.CaptureOnFailure()
+
+	// Stand in for the caller's leaked descriptor: opened without O_CLOEXEC,
+	// exactly as a shell's `exec 9>lockfile` leaves it.
+	leakPath := filepath.Join(t.TempDir(), "caller.lock")
+	if err := os.WriteFile(leakPath, []byte("x"), 0o600); err != nil {
+		t.Fatalf("seeding %s: %v", leakPath, err)
+	}
+	leakFD, err := unix.Open(leakPath, unix.O_RDONLY, 0)
+	if err != nil {
+		t.Fatalf("open %s without O_CLOEXEC: %v", leakPath, err)
+	}
+	defer func() { _ = unix.Close(leakFD) }()
+
+	flags, err := unix.FcntlInt(uintptr(leakFD), unix.F_GETFD, 0)
+	if err != nil {
+		t.Fatalf("F_GETFD on fd %d: %v", leakFD, err)
+	}
+	if flags&unix.FD_CLOEXEC != 0 {
+		t.Fatalf("fixture fd %d is already close-on-exec; the test would pass vacuously", leakFD)
+	}
+
+	state, err := doltserver.Start(beadsDir)
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if p, findErr := os.FindProcess(state.PID); findErr == nil {
+		reg.Register(p)
+	}
+	t.Cleanup(func() { _ = doltserver.Stop(beadsDir) })
+
+	target, err := os.Readlink(fmt.Sprintf("/proc/self/fd/%d", leakFD))
+	if err != nil {
+		t.Fatalf("resolving own fd %d: %v", leakFD, err)
+	}
+
+	entries, err := os.ReadDir(fmt.Sprintf("/proc/%d/fd", state.PID))
+	if err != nil {
+		t.Fatalf("reading fd table of server pid %d: %v", state.PID, err)
+	}
+	for _, e := range entries {
+		link, rlErr := os.Readlink(fmt.Sprintf("/proc/%d/fd/%s", state.PID, e.Name()))
+		if rlErr != nil {
+			continue // races with the server closing an fd are expected
+		}
+		if strings.HasSuffix(link, target) {
+			t.Errorf("sql-server pid %d inherited the caller's descriptor: fd %s -> %s",
+				state.PID, e.Name(), link)
+		}
+	}
+}

--- a/internal/fdhygiene/fdhygiene.go
+++ b/internal/fdhygiene/fdhygiene.go
@@ -1,0 +1,48 @@
+// Package fdhygiene keeps descriptors that bd did not open from leaking into
+// the long-lived children bd spawns (the managed dolt sql-server and the
+// dbproxy child).
+//
+// Go's os/exec wires only fds 0/1/2 plus Cmd.ExtraFiles into a child, and the
+// Go runtime sets FD_CLOEXEC on everything it opens itself. It does not close
+// inherited fds above 2 that lack FD_CLOEXEC — those pass straight through to
+// the child. A caller holding such an fd (a shell `exec 9>lock`, a systemd
+// unit, a CI harness, an editor terminal) therefore pins it for the entire
+// lifetime of a detached server bd starts, which outlives the caller. See
+// GH#4634: an flock held on fd 9 by a sync script was inherited by a
+// cold-started sql-server and read as "held" by every subsequent run until the
+// server was restarted.
+//
+// Go gives no hook between fork and exec, so the descriptors have to be marked
+// in the parent. See MarkInheritedCloexec for why that is safe here.
+package fdhygiene
+
+// MarkInheritedCloexec sets FD_CLOEXEC on every open descriptor above 2 that
+// does not already have it, so the next exec from this process does not hand
+// them to the child. It returns the descriptors it changed, in ascending
+// order, for logging; a nil return means nothing needed marking. Errors are
+// not reported: this is best-effort hardening on a spawn path that must still
+// start the server if the fd table cannot be enumerated.
+//
+// On Windows this is a no-op — handles are non-inheritable unless explicitly
+// passed, so there is nothing to sanitize.
+//
+// Why marking in the parent is safe, given that another goroutine may open or
+// close descriptors concurrently:
+//
+//   - The operation is monotonic. It only ever *adds* FD_CLOEXEC; it never
+//     clears it. If fd N is recycled between the scan and the fcntl, the fd
+//     that gets marked is a Go-opened one, which the runtime already opened
+//     CLOEXEC — so the write is a no-op rather than a leak. Restoring the
+//     original flags after the spawn would invert this and could clear
+//     FD_CLOEXEC on a recycled Go descriptor, so the flags are deliberately
+//     left set.
+//   - Nothing is missed. Descriptors inherited from bd's own parent — the only
+//     ones that can lack FD_CLOEXEC — exist from process start and are
+//     therefore visible to any scan. Descriptors opened concurrently by Go
+//     already carry the flag.
+//   - bd never passes descriptors to a child on purpose. There is no fd-passing
+//     feature whose contract this could break, and Cmd.ExtraFiles is unaffected
+//     (os/exec dups those in the child after exec-time flags are applied).
+func MarkInheritedCloexec() []int {
+	return markInheritedCloexec()
+}

--- a/internal/fdhygiene/fdhygiene_unix.go
+++ b/internal/fdhygiene/fdhygiene_unix.go
@@ -11,8 +11,11 @@ import (
 )
 
 // fdDirCandidates are the per-process fd directories, in preference order.
-// Linux exposes /proc/self/fd; darwin and the BSDs expose /dev/fd (on Linux
-// /dev/fd is a symlink to the same place, so listing it twice is harmless).
+// Linux exposes /proc/self/fd; darwin exposes /dev/fd (on Linux /dev/fd is a
+// symlink to the same place, so listing it twice is harmless). BSDs without
+// fdescfs mounted list only 0-2 under /dev/fd, which would make the scan a
+// silent no-op there — acceptable, since bd's supported platforms are
+// linux/darwin/windows.
 var fdDirCandidates = []string{"/proc/self/fd", "/dev/fd"}
 
 // maxScanFD bounds the brute-force fallback used when no fd directory is

--- a/internal/fdhygiene/fdhygiene_unix.go
+++ b/internal/fdhygiene/fdhygiene_unix.go
@@ -1,0 +1,77 @@
+//go:build unix
+
+package fdhygiene
+
+import (
+	"os"
+	"sort"
+	"strconv"
+
+	"golang.org/x/sys/unix"
+)
+
+// fdDirCandidates are the per-process fd directories, in preference order.
+// Linux exposes /proc/self/fd; darwin and the BSDs expose /dev/fd (on Linux
+// /dev/fd is a symlink to the same place, so listing it twice is harmless).
+var fdDirCandidates = []string{"/proc/self/fd", "/dev/fd"}
+
+// maxScanFD bounds the brute-force fallback used when no fd directory is
+// readable. RLIMIT_NOFILE is commonly 1<<20 or higher, and probing every slot
+// would cost more than the leak it prevents; descriptors inherited from a
+// caller in practice sit in the low hundreds.
+const maxScanFD = 4096
+
+func markInheritedCloexec() []int {
+	var marked []int
+	for fd := range openFDs() {
+		if fd <= 2 {
+			// Leaving stdio alone is deliberate: os/exec rewires 0/1/2 for the
+			// child from Cmd.Stdin/Stdout/Stderr, and marking bd's own stdio
+			// CLOEXEC would affect every other exec bd makes.
+			continue
+		}
+		flags, err := unix.FcntlInt(uintptr(fd), unix.F_GETFD, 0)
+		if err != nil || flags&unix.FD_CLOEXEC != 0 {
+			continue
+		}
+		if _, err := unix.FcntlInt(uintptr(fd), unix.F_SETFD, flags|unix.FD_CLOEXEC); err != nil {
+			continue
+		}
+		marked = append(marked, fd)
+	}
+	sort.Ints(marked)
+	return marked
+}
+
+// openFDs returns the set of descriptors that appear open in this process.
+// The set may include the descriptor used to read the fd directory itself;
+// that one is Go-opened and therefore already CLOEXEC, so the caller skips it.
+func openFDs() map[int]struct{} {
+	for _, dir := range fdDirCandidates {
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			continue
+		}
+		fds := make(map[int]struct{}, len(entries))
+		for _, e := range entries {
+			if fd, err := strconv.Atoi(e.Name()); err == nil {
+				fds[fd] = struct{}{}
+			}
+		}
+		return fds
+	}
+
+	// No fd directory (a minimal container without /proc, say). Probe the
+	// bounded low range instead; F_GETFD on a closed slot just returns EBADF
+	// and the caller skips it.
+	limit := maxScanFD
+	var rlim unix.Rlimit
+	if err := unix.Getrlimit(unix.RLIMIT_NOFILE, &rlim); err == nil && rlim.Cur > 0 && int(rlim.Cur) < limit {
+		limit = int(rlim.Cur)
+	}
+	fds := make(map[int]struct{}, limit)
+	for fd := 0; fd < limit; fd++ {
+		fds[fd] = struct{}{}
+	}
+	return fds
+}

--- a/internal/fdhygiene/fdhygiene_unix_test.go
+++ b/internal/fdhygiene/fdhygiene_unix_test.go
@@ -1,0 +1,148 @@
+//go:build unix
+
+package fdhygiene
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+// openLeakedFD opens a file the way a caller outside Go would leave one: no
+// O_CLOEXEC, so it survives an exec. Returns the raw descriptor.
+func openLeakedFD(t *testing.T) int {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "leak.lock")
+	if err := os.WriteFile(path, []byte("x"), 0o600); err != nil {
+		t.Fatalf("seeding %s: %v", path, err)
+	}
+	fd, err := unix.Open(path, unix.O_RDONLY, 0)
+	if err != nil {
+		t.Fatalf("open %s without O_CLOEXEC: %v", path, err)
+	}
+	t.Cleanup(func() { _ = unix.Close(fd) })
+
+	flags, err := unix.FcntlInt(uintptr(fd), unix.F_GETFD, 0)
+	if err != nil {
+		t.Fatalf("F_GETFD on fd %d: %v", fd, err)
+	}
+	if flags&unix.FD_CLOEXEC != 0 {
+		t.Fatalf("fd %d unexpectedly opened close-on-exec; the fixture proves nothing", fd)
+	}
+	return fd
+}
+
+func TestMarkInheritedCloexec_MarksLeakedFD(t *testing.T) {
+	fd := openLeakedFD(t)
+
+	marked := MarkInheritedCloexec()
+
+	var found bool
+	for _, m := range marked {
+		if m == fd {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("fd %d not reported as marked; got %v", fd, marked)
+	}
+
+	flags, err := unix.FcntlInt(uintptr(fd), unix.F_GETFD, 0)
+	if err != nil {
+		t.Fatalf("F_GETFD on fd %d: %v", fd, err)
+	}
+	if flags&unix.FD_CLOEXEC == 0 {
+		t.Errorf("fd %d still lacks FD_CLOEXEC after marking", fd)
+	}
+}
+
+// TestMarkInheritedCloexec_LeavesStdioAlone guards the carve-out: os/exec
+// rewires 0/1/2 per-child, so marking bd's own stdio would change unrelated
+// spawns.
+func TestMarkInheritedCloexec_LeavesStdioAlone(t *testing.T) {
+	before := make([]int, 3)
+	for fd := range before {
+		flags, err := unix.FcntlInt(uintptr(fd), unix.F_GETFD, 0)
+		if err != nil {
+			t.Skipf("stdio fd %d not open under this test runner: %v", fd, err)
+		}
+		before[fd] = flags
+	}
+
+	for _, fd := range MarkInheritedCloexec() {
+		if fd <= 2 {
+			t.Errorf("MarkInheritedCloexec reported stdio fd %d as marked", fd)
+		}
+	}
+
+	for fd, want := range before {
+		got, err := unix.FcntlInt(uintptr(fd), unix.F_GETFD, 0)
+		if err != nil {
+			t.Fatalf("F_GETFD on stdio fd %d: %v", fd, err)
+		}
+		if got != want {
+			t.Errorf("stdio fd %d flags changed: %d -> %d", fd, want, got)
+		}
+	}
+}
+
+// TestMarkInheritedCloexec_Idempotent checks the second call is a no-op, which
+// is what makes calling it on every spawn cheap and safe.
+func TestMarkInheritedCloexec_Idempotent(t *testing.T) {
+	openLeakedFD(t)
+
+	if first := MarkInheritedCloexec(); len(first) == 0 {
+		t.Fatal("first call marked nothing; fixture fd was not seen")
+	}
+	if second := MarkInheritedCloexec(); len(second) != 0 {
+		t.Errorf("second call marked %v, want nothing left to mark", second)
+	}
+}
+
+// TestMarkInheritedCloexec_ChildDoesNotInherit is the regression test for
+// GH#4634 proper: it execs a real child and asserts the descriptor is absent
+// from the child's fd table. Without the fix the same child sees it.
+func TestMarkInheritedCloexec_ChildDoesNotInherit(t *testing.T) {
+	sh, err := exec.LookPath("sh")
+	if err != nil {
+		t.Skipf("no sh on PATH: %v", err)
+	}
+
+	fd := openLeakedFD(t)
+
+	// Baseline: the child inherits it today. This is the bug, asserted first so
+	// a future runtime that closes fds itself makes the test fail loudly rather
+	// than pass vacuously.
+	if !childSeesFD(t, sh, fd) {
+		t.Skipf("fd %d does not reach an unsanitized child on this platform; nothing to regress", fd)
+	}
+
+	MarkInheritedCloexec()
+
+	if childSeesFD(t, sh, fd) {
+		t.Errorf("fd %d still present in the child's fd table after marking", fd)
+	}
+}
+
+// childSeesFD execs a child that lists its own open descriptors and reports
+// whether fd appears. /dev/fd is the portable spelling: a real fdescfs on
+// darwin and the BSDs, a symlink to /proc/self/fd on Linux.
+func childSeesFD(t *testing.T, sh string, fd int) bool {
+	t.Helper()
+	out, err := exec.Command(sh, "-c", "ls /dev/fd").Output() //nolint:gosec // G204: sh is PATH-resolved in-test, args are constant
+	if err != nil {
+		t.Fatalf("listing child fds: %v", err)
+	}
+	want := strconv.Itoa(fd)
+	for _, f := range strings.Fields(string(out)) {
+		if f == want {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/fdhygiene/fdhygiene_windows.go
+++ b/internal/fdhygiene/fdhygiene_windows.go
@@ -1,0 +1,12 @@
+//go:build windows
+
+package fdhygiene
+
+// markInheritedCloexec is a no-op on Windows. Handles are not inheritable
+// unless a spawn explicitly marks them so and passes them in the STARTUPINFO,
+// which os/exec does only for Stdin/Stdout/Stderr and Cmd.ExtraFiles, so a
+// caller's unrelated handles cannot reach the detached child in the first
+// place.
+func markInheritedCloexec() []int {
+	return nil
+}

--- a/internal/storage/dbproxy/proxy/endpoint.go
+++ b/internal/storage/dbproxy/proxy/endpoint.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/steveyegge/beads/internal/atomicfile"
 	"github.com/steveyegge/beads/internal/configfile"
+	"github.com/steveyegge/beads/internal/fdhygiene"
 	"github.com/steveyegge/beads/internal/lockfile"
 	"github.com/steveyegge/beads/internal/procid"
 	"github.com/steveyegge/beads/internal/storage/dbproxy/identity"
@@ -509,6 +510,14 @@ func forkExecChild(rootDir string, opts OpenOpts, port int, stopEpoch string, lo
 	released = true
 	lock.Unlock()
 	beforeProxyChildStart()
+
+	// GH#4634: same hazard as the direct sql-server spawn, one hop further
+	// out. The proxy child is detached and long-lived, and it starts the
+	// sql-server itself, so a caller's non-CLOEXEC descriptor would otherwise
+	// be inherited twice over and pinned for the proxy's whole lifetime.
+	if leaked := fdhygiene.MarkInheritedCloexec(); len(leaked) > 0 {
+		log.Printf("dbproxy: marked %d inherited fd(s) close-on-exec before starting proxy child: %v", len(leaked), leaked)
+	}
 
 	if err := cmd.Start(); err != nil {
 		_ = logFile.Close()

--- a/internal/storage/dbproxy/proxy/endpoint.go
+++ b/internal/storage/dbproxy/proxy/endpoint.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/steveyegge/beads/internal/atomicfile"
 	"github.com/steveyegge/beads/internal/configfile"
+	"github.com/steveyegge/beads/internal/debug"
 	"github.com/steveyegge/beads/internal/fdhygiene"
 	"github.com/steveyegge/beads/internal/lockfile"
 	"github.com/steveyegge/beads/internal/procid"
@@ -516,7 +517,10 @@ func forkExecChild(rootDir string, opts OpenOpts, port int, stopEpoch string, lo
 	// sql-server itself, so a caller's non-CLOEXEC descriptor would otherwise
 	// be inherited twice over and pinned for the proxy's whole lifetime.
 	if leaked := fdhygiene.MarkInheritedCloexec(); len(leaked) > 0 {
-		log.Printf("dbproxy: marked %d inherited fd(s) close-on-exec before starting proxy child: %v", len(leaked), leaked)
+		// debug.Logf, not log.Printf: this fires in normal operation whenever
+		// the caller's environment leaves any fd open, and the parent's stderr
+		// may be parsed script output.
+		debug.Logf("dbproxy: marked %d inherited fd(s) close-on-exec before starting proxy child: %v", len(leaked), leaked)
 	}
 
 	if err := cmd.Start(); err != nil {


### PR DESCRIPTION
Fixes #4634.

## Why

The managed `dolt sql-server` outlives the process that starts it. Any descriptor the caller left without `FD_CLOEXEC` was therefore pinned by the server until the server was restarted — not until the caller exited.

`os/exec` wires only fds 0/1/2 plus `Cmd.ExtraFiles` into a child, and the Go runtime sets `FD_CLOEXEC` on everything it opens itself. It does **not** close inherited fds above 2 that lack the flag; those pass straight through to the child. `procAttrDetached()` is `Setpgid`/`Setsid` only, so nothing on the spawn path was closing them.

The reporter's real-world hit: a single-instance sync script held an flock on fd 9 (`exec 9>lockfile`) and called `bd dolt pull`. That run cold-started the server, the server inherited fd 9, and every later run saw the lock as held and silently skipped — ambient sync stalled machine-wide until the next server restart.

## What

Go gives no hook between fork and exec, so the descriptors are marked in the parent immediately before `Start`. New `internal/fdhygiene` carries the rationale for why that is safe against a concurrent goroutine opening or closing fds:

- **Monotonic.** It only ever *adds* `FD_CLOEXEC`, never clears it. If fd N is recycled between the scan and the `fcntl`, the fd that gets marked is a Go-opened one that the runtime already opened `CLOEXEC` — the write is a no-op rather than a leak. Restoring the previous flags after the spawn would invert this and could clear `FD_CLOEXEC` on a recycled Go descriptor, so the flags are deliberately left set.
- **Nothing is missed.** Descriptors inherited from bd's own parent — the only ones that can lack the flag — exist from process start and are visible to any scan.
- **stdio is left alone**, since `os/exec` rewires 0/1/2 per child from `Cmd.Stdin/Stdout/Stderr`.

Enumeration is `/proc/self/fd`, falling back to `/dev/fd` (a real fdescfs on darwin and the BSDs) and then to a bounded probe of the low range if neither is readable. Windows is a documented no-op: handles are non-inheritable unless a spawn explicitly passes them.

**Both detached spawn paths are covered**, which is slightly wider than the issue as filed. Patching only `doltserver` would leave proxied mode leaking: the dbproxy child is itself long-lived and detached and starts the sql-server, so a caller's descriptor would be inherited twice over and pinned for the proxy's whole lifetime. Happy to split that hunk out if you'd rather land the reported path alone.

## Tests

- `internal/fdhygiene` unit tests (unix): a fixture fd opened without `O_CLOEXEC` is marked; stdio flags are asserted unchanged; the call is idempotent; and a real `exec`'d child is checked to confirm the descriptor leaves its fd table. Each test asserts the pre-state is non-`CLOEXEC` first, so a future runtime change makes them fail loudly rather than pass vacuously.
- `internal/doltserver/fdleak_integration_test.go` (`integration && linux`): starts a real sql-server via `doltserver.Start` and reads `/proc/<pid>/fd`.

The integration test **fails on `main` at `8bb0d36be`** and passes with this change — verified locally, not inferred:

```
--- FAIL: TestStart_ServerDoesNotInheritCallerFDs (5.56s)   # main, unpatched
--- PASS: TestStart_ServerDoesNotInheritCallerFDs (6.06s)   # this branch
```

`golangci-lint`: 0 issues on the three touched packages. Unit suites for `internal/fdhygiene`, `internal/doltserver`, and `internal/storage/dbproxy/...` pass.

## Scope note

The issue asks whether this is worth doing given a server-mode reimplementation on the horizon. It is self-contained hardening on the existing spawn path and does not constrain that work: the helper is one call, and a rewritten lifecycle either keeps it or drops it wholesale.

_claude-opus-5-medium on behalf of maphew_
