### PR TITLE
test(doctor/fix): guard the last two DB-backed entry points on the Dolt container — fixes red main

### DIFF
--- a/cmd/bd/doctor/fix/dep_keys_test.go
+++ b/cmd/bd/doctor/fix/dep_keys_test.go
@@ -24,6 +24,11 @@ import (
 // removed.
 func TestDependencyKeys_RekeysAndRemovesLeftovers(t *testing.T) {
 	testutil.RequireDoltBinary(t)
+	// The dolt binary being installed does not mean a server is listening:
+	// dolt.New below reaches the container via BEADS_DOLT_PORT, which
+	// TestMain only sets when it actually started one. Without this guard
+	// the test t.Fatals on 127.0.0.1:1 wherever Docker is unavailable.
+	requireFixDoltContainer(t)
 
 	dir := t.TempDir()
 	beadsDir := filepath.Join(dir, ".beads")

--- a/cmd/bd/doctor/fix/metadata_dolt_test.go
+++ b/cmd/bd/doctor/fix/metadata_dolt_test.go
@@ -20,6 +20,9 @@ import (
 func setupDoltWorkspace(t *testing.T) string {
 	t.Helper()
 	testutil.RequireDoltBinary(t)
+	// Binary present != server listening; see dep_keys_test.go. dolt.New
+	// below needs the container port TestMain publishes via BEADS_DOLT_PORT.
+	requireFixDoltContainer(t)
 
 	dir := t.TempDir()
 	beadsDir := filepath.Join(dir, ".beads")


### PR DESCRIPTION
## Why

`main` has been red since 8bb0d36be — [run 30595404594](https://github.com/gastownhall/beads/actions/runs/30595404594), 4 failures in `cmd/bd/doctor/fix` on both ubuntu and macOS. Merge lanes are parked behind it (`PR_PREFLIGHT_BLOCK_RED_BASE=1`), so per **Base-Branch Health** this is the only thing that should land until it is green.

## Root cause

#5174 un-darkened the fix-package DB-backed suite (its `newFixTestStore` predated the `dolt.New` create-guard, so everything using it silently skipped) and centralized the container precondition in `requireFixDoltContainer(t)`: skip when no container is up, hard-fail only when `BEADS_FIX_REQUIRE_DOLT=1`.

Five files were converted to that guard. Two were missed and still guard with only `testutil.RequireDoltBinary(t)` — which checks that the **dolt binary is on PATH**, not that a **server is listening**:

- `cmd/bd/doctor/fix/dep_keys_test.go`
- `cmd/bd/doctor/fix/metadata_dolt_test.go` (`setupDoltWorkspace`)

The Main workflow's `Test` job installs the dolt binary but starts no container. So `TestMain`'s `EnsureDoltContainerForTestMain` fails, `BEADS_DOLT_PORT` is never set, `dolt.New` resolves `127.0.0.1:1`, and these `t.Fatal` on `connection refused` instead of skipping:

```
=== FAIL: cmd/bd/doctor/fix TestDependencyKeys_RekeysAndRemovesLeftovers (0.00s)
    dep_keys_test.go:56: dolt.New: Dolt server unreachable at 127.0.0.1:1: dial tcp 127.0.0.1:1: connect: connection refused
=== FAIL: cmd/bd/doctor/fix TestFixMissingMetadata_DoltRepair (0.01s)
=== FAIL: cmd/bd/doctor/fix TestFixMissingMetadata_DoltIdempotent (0.02s)
=== FAIL: cmd/bd/doctor/fix TestFixMissingMetadata_DoltPartialRepair (0.01s)
DONE 11814 tests, 1432 skipped, 4 failures in 435.955s
```

## What this does

Adds `requireFixDoltContainer(t)` to those two entry points — the same treatment the other five files got in #5174. Nothing else changes.

`RequireDoltBinary` is kept alongside it deliberately: it carries the `BEADS_TEST_SKIP=dolt` opt-out and the "dolt binary missing under `GITHUB_ACTIONS`" assertion, neither of which the container guard covers.

This does not weaken #5174's anti-darkness guarantee. `requireFixDoltContainer` still `t.Fatal`s under `BEADS_FIX_REQUIRE_DOLT=1`, which the `test-domain-uow` job sets after pulling the Dolt image — so these four tests remain a hard requirement exactly where a container is guaranteed.

## Verification

Ran both halves locally (`CGO_ENABLED=1 -tags gms_pure_go`):

| condition | before | after |
|---|---|---|
| container up | 5 passed | 5 passed (unchanged) |
| container down (`DOCKER_HOST` pointed at a dead port) | 4 FAIL | 4 clean SKIP, package `ok` |

The container-down run reproduces the CI failure exactly and shows it resolved:

```
WARN: Docker not available, skipping Dolt tests
    dep_keys_test.go:31: skipping: Dolt test container not available
--- SKIP: TestDependencyKeys_RekeysAndRemovesLeftovers (0.00s)
    metadata_dolt_test.go:76: skipping: Dolt test container not available
--- SKIP: TestFixMissingMetadata_DoltRepair (0.00s)
--- SKIP: TestFixMissingMetadata_DoltIdempotent (0.00s)
--- SKIP: TestFixMissingMetadata_DoltPartialRepair (0.00s)
ok  	github.com/steveyegge/beads/cmd/bd/doctor/fix	0.112s
```

I also swept the rest of the package for the same latent shape: `clone_local_fks_cgo_test.go` is the only other `dolt.New` caller without the central guard, and it already carries its own explicit skip, so it is not affected.

_claude-opus-5-medium on behalf of maphew_
