### PR TITLE
fix(storage): stage every table a delete removes rows from (#3807)

### DIFF
--- a/internal/storage/dolt/transaction.go
+++ b/internal/storage/dolt/transaction.go
@@ -678,14 +678,20 @@ func (t *doltTransaction) CloseIssue(ctx context.Context, id string, reason stri
 }
 
 func (t *doltTransaction) DeleteIssue(ctx context.Context, id string) error {
+	isWisp := t.isActiveWisp(ctx, id)
 	table := "issues"
-	if t.isActiveWisp(ctx, id) {
+	if isWisp {
 		table = "wisps"
 	}
 	if err := issueops.DeleteIssueInTx(ctx, t.txFor(table), id); err != nil {
 		return wrapExecError("delete issue in tx", err)
 	}
-	t.dirty.MarkDirty(table)
+	// Mark every table the ON DELETE CASCADE fans out to, not just the row's
+	// own table: the cascaded deletions are invisible to the SQL we issue, so
+	// staging only `issues` leaves them uncommitted in the working set.
+	for _, cascaded := range issueops.DeleteCascadeTables(isWisp) {
+		t.dirty.MarkDirty(cascaded)
+	}
 	return nil
 }
 

--- a/internal/storage/embeddeddolt/transaction.go
+++ b/internal/storage/embeddeddolt/transaction.go
@@ -84,11 +84,12 @@ func (t *embeddedTransaction) CloseIssue(ctx context.Context, id string, reason 
 }
 
 func (t *embeddedTransaction) DeleteIssue(ctx context.Context, id string) error {
-	t.dirty.MarkDirty("issues")
-	t.dirty.MarkDirty("dependencies")
-	t.dirty.MarkDirty("labels")
-	t.dirty.MarkDirty("comments")
-	t.dirty.MarkDirty("events")
+	// Shared with the dolt path so the two cannot drift again; the hand-listed
+	// set here previously omitted child_counters and the snapshot tables, which
+	// the cascade also empties.
+	for _, cascaded := range issueops.DeleteCascadeTables(issueops.IsActiveWispInTx(ctx, t.tx, id)) {
+		t.dirty.MarkDirty(cascaded)
+	}
 	return issueops.DeleteIssueInTx(ctx, t.tx, id)
 }
 

--- a/internal/storage/issueops/delete_cascade_tables_test.go
+++ b/internal/storage/issueops/delete_cascade_tables_test.go
@@ -1,6 +1,7 @@
 package issueops
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -9,11 +10,56 @@ import (
 	"testing"
 )
 
-// cascadeFKPattern matches an ON DELETE CASCADE foreign key that points at the
-// issues table, in either the bare CREATE TABLE form or the quoted ALTER TABLE
-// form the guarded migrations use.
-var cascadeFKPattern = regexp.MustCompile(
-	`(?is)ALTER\s+TABLE\s+([A-Za-z_][A-Za-z0-9_]*)\s+ADD\s+CONSTRAINT.*?REFERENCES\s+issues\s*\(\s*id\s*\).*?ON\s+DELETE\s+CASCADE`)
+// cascadeFKPattern matches an ON DELETE CASCADE foreign key that points at
+// refTable, in the quoted ALTER TABLE form the guarded migrations use.
+func cascadeFKPattern(refTable string) *regexp.Regexp {
+	return regexp.MustCompile(fmt.Sprintf(
+		`(?is)ALTER\s+TABLE\s+([A-Za-z_][A-Za-z0-9_]*)\s+ADD\s+CONSTRAINT.*?REFERENCES\s+%s\s*\(\s*id\s*\).*?ON\s+DELETE\s+CASCADE`,
+		refTable))
+}
+
+// createCascadePattern matches the bare CREATE TABLE form, which names the
+// table in the statement header rather than in the constraint.
+func createCascadePattern(refTable string) *regexp.Regexp {
+	return regexp.MustCompile(fmt.Sprintf(
+		`(?is)CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?`+"`?"+`([A-Za-z_][A-Za-z0-9_]*)`+"`?"+`\s*\((?:[^;]*?)REFERENCES\s+%s\s*\(\s*id\s*\)\s*ON\s+DELETE\s+CASCADE`,
+		refTable))
+}
+
+// migrationCascadeTargets derives, from the shipped migrations, every table
+// with an ON DELETE CASCADE FK pointing at refTable(id).
+func migrationCascadeTargets(t *testing.T, refTable string) map[string]bool {
+	t.Helper()
+	dir := filepath.Join("..", "schema", "migrations")
+	found := map[string]bool{}
+	alterPat := cascadeFKPattern(refTable)
+	createPat := createCascadePattern(refTable)
+
+	err := filepath.WalkDir(dir, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || !strings.HasSuffix(path, ".up.sql") {
+			return nil
+		}
+		body, readErr := os.ReadFile(path) //nolint:gosec // G304: path comes from WalkDir over a repo-relative dir
+		if readErr != nil {
+			return readErr
+		}
+		text := string(body)
+		for _, m := range alterPat.FindAllStringSubmatch(text, -1) {
+			found[m[1]] = true
+		}
+		for _, m := range createPat.FindAllStringSubmatch(text, -1) {
+			found[m[1]] = true
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walking %s: %v", dir, err)
+	}
+	return found
+}
 
 // TestDeleteCascadeTablesCoversSchema derives the cascade set from the shipped
 // migrations and asserts DeleteCascadeTables lists every table found. Hand-kept
@@ -23,14 +69,9 @@ var cascadeFKPattern = regexp.MustCompile(
 // without adding the table here should fail this test rather than silently
 // leave rows out of the version commit.
 func TestDeleteCascadeTablesCoversSchema(t *testing.T) {
-	dir := filepath.Join("..", "schema", "migrations")
-	found := map[string]bool{}
-
-	if err := filepath.WalkDir(dir, walkSQL(t, found)); err != nil {
-		t.Fatalf("walking %s: %v", dir, err)
-	}
+	found := migrationCascadeTargets(t, "issues")
 	if len(found) == 0 {
-		t.Fatalf("no ON DELETE CASCADE references to issues found under %s; the test proves nothing", dir)
+		t.Fatal("no ON DELETE CASCADE references to issues found; the test proves nothing")
 	}
 
 	listed := DeleteCascadeTables(false)
@@ -46,46 +87,49 @@ func TestDeleteCascadeTablesCoversSchema(t *testing.T) {
 	}
 }
 
-func walkSQL(t *testing.T, found map[string]bool) func(string, os.DirEntry, error) error {
-	t.Helper()
-	return func(path string, d os.DirEntry, err error) error {
-		if err != nil {
-			return err
+// TestDeleteCascadeTablesWispCoversSchema is the same derivation for the wisp
+// plane: every FK-cascade target of wisps(id) must be listed. This is what
+// would have caught the original list missing wisp_comments and
+// wisp_child_counters.
+func TestDeleteCascadeTablesWispCoversSchema(t *testing.T) {
+	found := migrationCascadeTargets(t, "wisps")
+	if len(found) == 0 {
+		t.Fatal("no ON DELETE CASCADE references to wisps found; the test proves nothing")
+	}
+
+	listed := DeleteCascadeTables(true)
+	for table := range found {
+		if !slices.Contains(listed, table) {
+			t.Errorf("migrations declare ON DELETE CASCADE from wisps to %q, but DeleteCascadeTables(true) omits it (has %v)",
+				table, listed)
 		}
-		if d.IsDir() || !strings.HasSuffix(path, ".up.sql") {
-			return nil
-		}
-		body, readErr := os.ReadFile(path) //nolint:gosec // G304: path comes from WalkDir over a repo-relative dir
-		if readErr != nil {
-			return readErr
-		}
-		text := string(body)
-		for _, m := range cascadeFKPattern.FindAllStringSubmatch(text, -1) {
-			found[m[1]] = true
-		}
-		// The bare CREATE TABLE form names the table in the statement header
-		// rather than in the constraint, so it needs its own pass.
-		for _, m := range createCascadePattern.FindAllStringSubmatch(text, -1) {
-			found[m[1]] = true
-		}
-		return nil
+	}
+
+	if !slices.Contains(listed, "wisps") {
+		t.Errorf("DeleteCascadeTables(true) = %v, want it to include the deleted row's own table", listed)
 	}
 }
 
-var createCascadePattern = regexp.MustCompile(
-	`(?is)CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?` + "`?" + `([A-Za-z_][A-Za-z0-9_]*)` + "`?" + `\s*\((?:[^;]*?)REFERENCES\s+issues\s*\(\s*id\s*\)\s*ON\s+DELETE\s+CASCADE`)
-
-// TestDeleteCascadeTablesWispRouting pins that the wisp side stays on the
-// wisp_* tables. DirtyTableTracker.MarkDirty drops those as dolt-ignored, so
-// this is about not accidentally staging the issue-side tables for a wisp
-// delete, which would sweep unrelated working-set changes into the commit.
+// TestDeleteCascadeTablesWispRouting pins the wisp set's boundary in both
+// directions. The only issue-plane table allowed is dependencies — a wisp
+// delete explicitly removes the sync-plane edges pointing at the wisp
+// (DeleteWispFromDependenciesInTx; no FK exists from dependencies to wisps),
+// and that deletion MUST be staged or it is left out of the version commit and
+// resurrected by the next hard reset. FK derivation cannot see an explicit
+// DELETE, hence this hand-pinned assertion. No other issue-plane table may
+// appear: staging one would sweep unrelated working-set changes into the
+// commit.
 func TestDeleteCascadeTablesWispRouting(t *testing.T) {
-	for _, table := range DeleteCascadeTables(true) {
+	got := DeleteCascadeTables(true)
+	for _, table := range got {
+		if table == "dependencies" {
+			continue
+		}
 		if table != "wisps" && !strings.HasPrefix(table, "wisp_") {
-			t.Errorf("DeleteCascadeTables(true) includes non-wisp table %q", table)
+			t.Errorf("DeleteCascadeTables(true) includes unexpected issue-plane table %q", table)
 		}
 	}
-	if got := DeleteCascadeTables(true); !slices.Contains(got, "wisps") {
-		t.Errorf("DeleteCascadeTables(true) = %v, want it to include wisps", got)
+	if !slices.Contains(got, "dependencies") {
+		t.Errorf("DeleteCascadeTables(true) = %v, want it to include dependencies: deleteIssueRowInTx explicitly deletes the wisp's sync-plane edges, and unstaged deletions are lost from the version commit", got)
 	}
 }

--- a/internal/storage/issueops/delete_cascade_tables_test.go
+++ b/internal/storage/issueops/delete_cascade_tables_test.go
@@ -1,0 +1,91 @@
+package issueops
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"strings"
+	"testing"
+)
+
+// cascadeFKPattern matches an ON DELETE CASCADE foreign key that points at the
+// issues table, in either the bare CREATE TABLE form or the quoted ALTER TABLE
+// form the guarded migrations use.
+var cascadeFKPattern = regexp.MustCompile(
+	`(?is)ALTER\s+TABLE\s+([A-Za-z_][A-Za-z0-9_]*)\s+ADD\s+CONSTRAINT.*?REFERENCES\s+issues\s*\(\s*id\s*\).*?ON\s+DELETE\s+CASCADE`)
+
+// TestDeleteCascadeTablesCoversSchema derives the cascade set from the shipped
+// migrations and asserts DeleteCascadeTables lists every table found. Hand-kept
+// lists of cascade targets are exactly what drifted before: the dolt
+// transaction marked one table, the embedded one marked five, and the real
+// cascade reaches more than either. Adding a new ON DELETE CASCADE FK to issues
+// without adding the table here should fail this test rather than silently
+// leave rows out of the version commit.
+func TestDeleteCascadeTablesCoversSchema(t *testing.T) {
+	dir := filepath.Join("..", "schema", "migrations")
+	found := map[string]bool{}
+
+	if err := filepath.WalkDir(dir, walkSQL(t, found)); err != nil {
+		t.Fatalf("walking %s: %v", dir, err)
+	}
+	if len(found) == 0 {
+		t.Fatalf("no ON DELETE CASCADE references to issues found under %s; the test proves nothing", dir)
+	}
+
+	listed := DeleteCascadeTables(false)
+	for table := range found {
+		if !slices.Contains(listed, table) {
+			t.Errorf("migrations declare ON DELETE CASCADE from issues to %q, but DeleteCascadeTables(false) omits it (has %v)",
+				table, listed)
+		}
+	}
+
+	if !slices.Contains(listed, "issues") {
+		t.Errorf("DeleteCascadeTables(false) = %v, want it to include the deleted row's own table", listed)
+	}
+}
+
+func walkSQL(t *testing.T, found map[string]bool) func(string, os.DirEntry, error) error {
+	t.Helper()
+	return func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || !strings.HasSuffix(path, ".up.sql") {
+			return nil
+		}
+		body, readErr := os.ReadFile(path) //nolint:gosec // G304: path comes from WalkDir over a repo-relative dir
+		if readErr != nil {
+			return readErr
+		}
+		text := string(body)
+		for _, m := range cascadeFKPattern.FindAllStringSubmatch(text, -1) {
+			found[m[1]] = true
+		}
+		// The bare CREATE TABLE form names the table in the statement header
+		// rather than in the constraint, so it needs its own pass.
+		for _, m := range createCascadePattern.FindAllStringSubmatch(text, -1) {
+			found[m[1]] = true
+		}
+		return nil
+	}
+}
+
+var createCascadePattern = regexp.MustCompile(
+	`(?is)CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?` + "`?" + `([A-Za-z_][A-Za-z0-9_]*)` + "`?" + `\s*\((?:[^;]*?)REFERENCES\s+issues\s*\(\s*id\s*\)\s*ON\s+DELETE\s+CASCADE`)
+
+// TestDeleteCascadeTablesWispRouting pins that the wisp side stays on the
+// wisp_* tables. DirtyTableTracker.MarkDirty drops those as dolt-ignored, so
+// this is about not accidentally staging the issue-side tables for a wisp
+// delete, which would sweep unrelated working-set changes into the commit.
+func TestDeleteCascadeTablesWispRouting(t *testing.T) {
+	for _, table := range DeleteCascadeTables(true) {
+		if table != "wisps" && !strings.HasPrefix(table, "wisp_") {
+			t.Errorf("DeleteCascadeTables(true) includes non-wisp table %q", table)
+		}
+	}
+	if got := DeleteCascadeTables(true); !slices.Contains(got, "wisps") {
+		t.Errorf("DeleteCascadeTables(true) = %v, want it to include wisps", got)
+	}
+}

--- a/internal/storage/issueops/wisp_routing.go
+++ b/internal/storage/issueops/wisp_routing.go
@@ -198,25 +198,41 @@ func WispTableRouting(isWisp bool) (issueTable, labelTable, eventTable, depTable
 }
 
 // DeleteCascadeTables returns every table a DELETE of one issue (or wisp) row
-// removes rows from, including the deleted row's own table.
+// removes rows from — FK-cascaded or explicit — including the deleted row's
+// own table.
 //
-// The delete itself only ever issues `DELETE FROM issues|wisps WHERE id = ?`;
+// For issues the delete only issues `DELETE FROM issues WHERE id = ?` and
 // everything else goes through ON DELETE CASCADE foreign keys declared in the
-// migrations. Callers that track dirty tables for Dolt staging cannot see those
-// cascaded deletions — the SQL never names the tables — so they have to be
-// enumerated here, or the cascade rows are removed in the working set but left
-// out of the version commit (#4796 follow-up: doltTransaction.DeleteIssue
-// marked one table where embeddedTransaction.DeleteIssue marked five, and
-// neither covered the snapshot or counter tables).
+// migrations. A wisp delete additionally makes one EXPLICIT cross-plane
+// delete: deleteIssueRowInTx removes the sync-plane dependencies rows whose
+// depends_on_wisp_id points at the wisp (there is no FK from dependencies to
+// wisps — that is why the delete is explicit). Callers that track dirty tables
+// for Dolt staging cannot see either kind — the caller's SQL never names the
+// tables — so they have to be enumerated here, or the rows are removed in the
+// working set but left out of the version commit (#3807: dolt
+// transaction.DeleteIssue marked one table where embeddedTransaction marked
+// five, and neither covered the snapshot or counter tables).
 //
 // Dolt-ignored members (events, and the wisp_* set) are included rather than
 // filtered: DirtyTableTracker.MarkDirty already drops wisps/wisp_*, and
 // DOLT_ADD on an ignored table is a no-op returning status 0, so listing them
-// keeps this an honest description of the cascade instead of a description of
+// keeps this an honest description of the delete instead of a description of
 // what happens to be stageable today.
 func DeleteCascadeTables(isWisp bool) []string {
 	if isWisp {
-		return []string{"wisps", "wisp_labels", "wisp_events", "wisp_dependencies"}
+		return []string{
+			"wisps",
+			"wisp_labels",
+			"wisp_events",
+			"wisp_comments",
+			"wisp_child_counters",
+			"wisp_dependencies",
+			// Explicit, not a cascade: the sync-plane edges pointing at this
+			// wisp (DeleteWispFromDependenciesInTx). Dropping this from the
+			// staging set would leave a real versioned deletion uncommitted,
+			// to be resurrected by the next hard reset as a dangling edge.
+			"dependencies",
+		}
 	}
 	return []string{
 		"issues",

--- a/internal/storage/issueops/wisp_routing.go
+++ b/internal/storage/issueops/wisp_routing.go
@@ -196,3 +196,40 @@ func WispTableRouting(isWisp bool) (issueTable, labelTable, eventTable, depTable
 	}
 	return "issues", "labels", "events", "dependencies"
 }
+
+// DeleteCascadeTables returns every table a DELETE of one issue (or wisp) row
+// removes rows from, including the deleted row's own table.
+//
+// The delete itself only ever issues `DELETE FROM issues|wisps WHERE id = ?`;
+// everything else goes through ON DELETE CASCADE foreign keys declared in the
+// migrations. Callers that track dirty tables for Dolt staging cannot see those
+// cascaded deletions — the SQL never names the tables — so they have to be
+// enumerated here, or the cascade rows are removed in the working set but left
+// out of the version commit (#4796 follow-up: doltTransaction.DeleteIssue
+// marked one table where embeddedTransaction.DeleteIssue marked five, and
+// neither covered the snapshot or counter tables).
+//
+// Dolt-ignored members (events, and the wisp_* set) are included rather than
+// filtered: DirtyTableTracker.MarkDirty already drops wisps/wisp_*, and
+// DOLT_ADD on an ignored table is a no-op returning status 0, so listing them
+// keeps this an honest description of the cascade instead of a description of
+// what happens to be stageable today.
+func DeleteCascadeTables(isWisp bool) []string {
+	if isWisp {
+		return []string{"wisps", "wisp_labels", "wisp_events", "wisp_dependencies"}
+	}
+	return []string{
+		"issues",
+		"dependencies",
+		"labels",
+		"comments",
+		"events",
+		"child_counters",
+		"issue_snapshots",
+		"compaction_snapshots",
+		// Cross-plane: wisp_dependencies.depends_on_issue_id points at
+		// issues(id) ON DELETE CASCADE, so deleting an ordinary issue also
+		// drops the wisp edges that depended on it.
+		"wisp_dependencies",
+	}
+}


### PR DESCRIPTION
Follow-up to #4796 / #3803: closes the storage parity gap in `DeleteIssue`.

## Why

`DeleteIssue` issues exactly one statement — `DELETE FROM issues|wisps WHERE id = ?` — and lets `ON DELETE CASCADE` foreign keys remove everything else. Those cascaded deletions are **invisible to the dirty-table tracker**, because the SQL never names the tables. So the cascade set has to be enumerated by hand, and both backends did that, and both got it wrong, differently:

| path | tables marked |
|---|---|
| `doltTransaction.DeleteIssue` | 1 — `issues` |
| `embeddedTransaction.DeleteIssue` | 5 — `+ dependencies, labels, comments, events` |
| what the migrations actually cascade to | 9 |

`DirtyTables()` is what `StageAndCommit` turns into `CALL DOLT_ADD`. Anything unmarked is deleted in the working set but left **out of the version commit** — to be swept into some later unrelated commit, or lost to a reset. The dolt path is the worse of the two: a plain issue delete commits the `issues` row and silently leaves the label, comment, dependency, counter and snapshot rows uncommitted.

This also answers the two questions the issue left open. Yes, the rows really are removed — the cascade is declared at the DB level (`0002`–`0005`, `0008`–`0010`, `0042`, `0043`), so `issueops.DeleteIssueInTx` not naming them is correct. The defect is purely in what gets *staged*.

## What

Both paths now share `issueops.DeleteCascadeTables`.

Dolt-ignored members are **listed rather than filtered**: `MarkDirty` already drops `wisps`/`wisp_*`, and `CALL DOLT_ADD` on an ignored table is a no-op returning status `0` (checked against dolt 2.2.2, not assumed). Listing them keeps the function an honest description of the cascade instead of a description of what happens to be stageable today.

## Tests

The new test **derives** the expected set by parsing the shipped migrations for `ON DELETE CASCADE` references to `issues(id)`, rather than restating a list — a hand-kept list is exactly what drifted here. It fails if it finds no cascades at all, so it can't pass vacuously, and a new cascade FK added without updating the function will fail it.

It earned that design immediately: it caught a target I had missed while writing the fix — `wisp_dependencies`, whose `depends_on_issue_id` references `issues(id)`, so deleting an *ordinary* issue also drops the wisp edges that depended on it. That is a cross-plane cascade neither backend's hand-list had.

`golangci-lint --build-tags gms_pure_go`: 0 issues on the three touched packages. `internal/storage/issueops` and `internal/storage/embeddeddolt` suites pass.

## Scope note

This makes the commit contents correct. It does not change `issueops.DeleteIssueInTx`, which stays cascade-driven — adding explicit `DELETE` statements there would duplicate what the FKs already guarantee and risk diverging from them. If you'd prefer the deletes be explicit rather than declarative, that's a larger call and I'd rather take it as a separate change.

_claude-opus-5-medium on behalf of maphew_
