### PR TITLE
fix(dolt): require consent before adopting a Dolt remote derived from git origin (#5068)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -141,6 +141,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`bd dolt push` and `bd sync` no longer adopt a Dolt remote derived from
+  git origin without consent** (#5068). On a rig with no Dolt remote
+  configured, both commands silently derived one from `git remote get-url
+  origin`, added it, persisted `sync.remote` into `.beads/config.yaml`,
+  committed that config change under the user's git identity, and uploaded the
+  full issue history — no prompt, no flag, no opt-out. A public git origin
+  therefore published the whole issue database on a command the user believed
+  targeted an already-configured remote.
+
+  Adoption is now a consent decision and fails closed. Interactively, bd shows
+  the derived URL and every side effect that follows a yes (including the
+  config commit made under your git identity) and defaults to **no**.
+  Non-interactively it refuses and exits non-zero, naming the URL it would have
+  adopted and the explicit opt-in. `--yes`/`-y` consents ahead of time for
+  scripted use; `--no-adopt` or `BD_NO_REMOTE_ADOPT=1` disables adoption
+  entirely and wins over `--yes`. Rigs with a remote already configured are
+  unaffected — that path was and remains a no-op.
+
+  Workspace resolution also moved below the gate: it calls
+  `prepareSelectedNoDBContext`, which mutates workspace state, and nothing may
+  mutate before consent is established.
+
 - **Proxied-server CI shard 1 flake: `TestProxiedServerCleanDatabases` ran a
   server-global destructive command against the shared test container**
   (p1-9lf, hazard tracked in p1-8dz). The test used the shared external Dolt

--- a/cmd/bd/dolt.go
+++ b/cmd/bd/dolt.go
@@ -413,7 +413,7 @@ func printNoRemoteGuidance() {
 // decideRemoteAdoption in dolt_remote_adopt.go and applied here, after the URL
 // is known and before anything is written: nothing below this point is
 // reachable without either --yes or an interactive confirmation.
-func adoptGitOriginRemoteForPush(ctx context.Context, st storage.DoltStorage, policy adoptPolicy) (bool, error) {
+func adoptGitOriginRemoteForPush(ctx context.Context, st storage.DoltStorage, policy adoptPolicy, optIn adoptOptIn) (bool, error) {
 	configured, err := hasConfiguredRemote(ctx, st)
 	if err != nil || configured {
 		return false, err
@@ -428,7 +428,7 @@ func adoptGitOriginRemoteForPush(ctx context.Context, st storage.DoltStorage, po
 	}
 	remoteURL := normalizeRemoteURL(originURL)
 
-	if proceed, err := applyAdoptionConsent(remoteURL, policy); err != nil || !proceed {
+	if proceed, err := applyAdoptionConsent(remoteURL, policy, optIn); err != nil || !proceed {
 		return false, err
 	}
 
@@ -481,7 +481,10 @@ var doltPushCmd = &cobra.Command{
 	Short:         "Push commits to Dolt remote",
 	Long: `Push local Dolt commits to the configured remote.
 
-Requires a Dolt remote to be configured in the database directory.
+Requires a Dolt remote to be configured in the database directory. With no
+remote configured, bd can adopt one derived from git origin — only with
+consent: interactively, or via --yes; --no-adopt or BD_NO_REMOTE_ADOPT=1
+disables adoption entirely.
 For Hosted Dolt, set DOLT_REMOTE_USER and DOLT_REMOTE_PASSWORD environment
 variables for authentication.
 
@@ -534,8 +537,8 @@ The remote must already exist (see 'bd dolt remote add').`,
 		}
 		assumeYes, _ := cmd.Flags().GetBool("yes")
 		noAdopt, _ := cmd.Flags().GetBool("no-adopt")
-		policy := currentAdoptPolicy(assumeYes, noAdopt, stdinIsTerminal())
-		if adopted, err := adoptGitOriginRemoteForPush(ctx, st, policy); err != nil {
+		policy := currentAdoptPolicy(assumeYes, noAdopt, stdinIsTerminal(), jsonOutput)
+		if adopted, err := adoptGitOriginRemoteForPush(ctx, st, policy, pushAdoptOptIn); err != nil {
 			return HandleError("%v", err)
 		} else if adopted {
 			fmt.Println("Configured Dolt remote origin from git origin.")

--- a/cmd/bd/dolt.go
+++ b/cmd/bd/dolt.go
@@ -408,20 +408,35 @@ func printNoRemoteGuidance() {
 // when the persisted remote and the git origin disagree — a Dolt remote
 // deliberately pointed elsewhere, or a renamed/redirected origin — the rig
 // starts pushing somewhere else on the strength of a stale listing (wy-82hc5).
-func adoptGitOriginRemoteForPush(ctx context.Context, st storage.DoltStorage) (bool, error) {
+//
+// Adoption requires consent (#5068). The policy is decided by
+// decideRemoteAdoption in dolt_remote_adopt.go and applied here, after the URL
+// is known and before anything is written: nothing below this point is
+// reachable without either --yes or an interactive confirmation.
+func adoptGitOriginRemoteForPush(ctx context.Context, st storage.DoltStorage, policy adoptPolicy) (bool, error) {
 	configured, err := hasConfiguredRemote(ctx, st)
 	if err != nil || configured {
 		return false, err
 	}
-	beadsDir := selectedDoltBeadsDir()
-	if beadsDir == "" {
-		return false, fmt.Errorf("no active beads workspace")
-	}
+	// Deriving the URL comes first and is read-only (`git remote get-url`).
+	// Workspace resolution is deliberately NOT done yet: selectedDoltBeadsDir
+	// calls prepareSelectedNoDBContext, which mutates process and on-disk
+	// workspace state, and nothing may mutate before consent is established.
 	originURL, err := gitOriginGetURLForActiveRepo(ctx)
 	if err != nil || originURL == "" {
 		return false, nil
 	}
 	remoteURL := normalizeRemoteURL(originURL)
+
+	if proceed, err := applyAdoptionConsent(remoteURL, policy); err != nil || !proceed {
+		return false, err
+	}
+
+	beadsDir := selectedDoltBeadsDir()
+	if beadsDir == "" {
+		return false, fmt.Errorf("no active beads workspace")
+	}
+
 	if err := st.AddRemote(ctx, "origin", remoteURL); err != nil {
 		return false, err
 	}
@@ -429,6 +444,7 @@ func adoptGitOriginRemoteForPush(ctx context.Context, st storage.DoltStorage) (b
 	if err := config.SetYamlConfigInDir(beadsDir, "sync.remote", remoteURL); err != nil {
 		return false, fmt.Errorf("failed to persist sync.remote to config.yaml: %w", err)
 	}
+	fmt.Fprintln(os.Stderr, "Committing .beads/config.yaml (sync.remote) under your git identity.")
 	commitBeadsConfigForActiveRepo(ctx, "bd: update sync.remote")
 	return true, nil
 }
@@ -516,8 +532,11 @@ The remote must already exist (see 'bd dolt remote add').`,
 			fmt.Println("Push complete.")
 			return nil
 		}
-		if adopted, err := adoptGitOriginRemoteForPush(ctx, st); err != nil {
-			return HandleError("failed to adopt git origin as Dolt remote: %v", err)
+		assumeYes, _ := cmd.Flags().GetBool("yes")
+		noAdopt, _ := cmd.Flags().GetBool("no-adopt")
+		policy := currentAdoptPolicy(assumeYes, noAdopt, stdinIsTerminal())
+		if adopted, err := adoptGitOriginRemoteForPush(ctx, st, policy); err != nil {
+			return HandleError("%v", err)
 		} else if adopted {
 			fmt.Println("Configured Dolt remote origin from git origin.")
 		}
@@ -1714,6 +1733,8 @@ func init() {
 	doltStopCmd.Flags().Bool("force", false, "Force stop (proxied recovery still requires a bd/dolt executable match)")
 	doltPushCmd.Flags().Bool("force", false, "Force push (overwrite remote changes)")
 	doltPushCmd.Flags().String("remote", "", "Push to a specific named remote instead of the default")
+	doltPushCmd.Flags().BoolP("yes", "y", false, "Consent to adopting a Dolt remote derived from git origin when none is configured")
+	doltPushCmd.Flags().Bool("no-adopt", false, "Never derive a Dolt remote from git origin (also BD_NO_REMOTE_ADOPT=1)")
 	doltPullCmd.Flags().String("remote", "", "Pull from a specific named remote instead of the default")
 	doltPullCmd.Flags().String("strategy", "", "Conflict resolution strategy for conflicts the auto-resolver declines: 'ours' or 'theirs' (embedded storage only, #4992)")
 	doltCommitCmd.Flags().StringP("message", "m", "", "Commit message (default: auto-generated)")

--- a/cmd/bd/dolt_remote_adopt.go
+++ b/cmd/bd/dolt_remote_adopt.go
@@ -23,6 +23,22 @@ import (
 // right default for "proceed with the thing you asked for" and the wrong one
 // for this, which is why adoption does not reuse it.
 
+// adoptOptIn is the caller's identity for adoption messages: the command that
+// re-runs this operation with consent, and the verb the interactive question
+// uses. The sync path shares the whole adoption flow with push
+// (syncAdoptGitOrigin), and a refusal that steers a sync user into
+// `bd dolt push --yes` would trade their pull away — the opt-in must name the
+// command they actually ran.
+type adoptOptIn struct {
+	rerun  string // e.g. "bd dolt push --yes"
+	action string // completes "Adopt this remote and <action>?"
+}
+
+var (
+	pushAdoptOptIn = adoptOptIn{rerun: "bd dolt push --yes", action: "push"}
+	syncAdoptOptIn = adoptOptIn{rerun: "bd sync --yes", action: "sync"}
+)
+
 // adoptPolicy carries the caller's consent inputs for git-origin adoption.
 // It is a value, not global state, so the decision is testable without a TTY,
 // a store, or a repo to mutate.
@@ -80,11 +96,14 @@ func decideRemoteAdoption(p adoptPolicy) (adoptDecision, adoptRefusal) {
 
 // currentAdoptPolicy builds the policy from flags plus BD_NO_REMOTE_ADOPT.
 // stdinIsTerminal is injected so tests do not depend on how they were invoked.
-func currentAdoptPolicy(assumeYes, noAdopt, stdinIsTerminal bool) adoptPolicy {
+// jsonMode forces non-interactive even on a TTY: --json is a machine contract,
+// and a consent prompt inside it hangs whatever is parsing the stream (same
+// rule as validateHookMigrationApplyConsent — JSON callers opt in with --yes).
+func currentAdoptPolicy(assumeYes, noAdopt, stdinIsTerminal, jsonMode bool) adoptPolicy {
 	return adoptPolicy{
 		AssumeYes:   assumeYes,
 		Disabled:    noAdopt || envNoRemoteAdopt(),
-		Interactive: stdinIsTerminal,
+		Interactive: stdinIsTerminal && !jsonMode,
 	}
 }
 
@@ -101,7 +120,7 @@ func stdinIsTerminal() bool {
 // names the URL that would have been adopted, because "a remote was derived"
 // is useless without knowing which one — the reporter's whole complaint was
 // not knowing where the upload was going.
-func adoptionRefusedError(remoteURL string) error {
+func adoptionRefusedError(remoteURL string, optIn adoptOptIn) error {
 	return fmt.Errorf(`no Dolt remote is configured, and bd will not adopt one without consent.
 
   Derived from git origin: %s
@@ -109,10 +128,10 @@ func adoptionRefusedError(remoteURL string) error {
 This would publish your entire issue history to that remote. If it is what you
 want, opt in explicitly:
 
-  bd dolt push --yes                     # adopt the derived remote and push
+  %-38s # adopt the derived remote and %s
   bd dolt remote add origin <url>        # or name the remote yourself first
 
-To never adopt implicitly, pass --no-adopt or set BD_NO_REMOTE_ADOPT=1.`, remoteURL)
+To never adopt implicitly, pass --no-adopt or set BD_NO_REMOTE_ADOPT=1.`, remoteURL, optIn.rerun, optIn.action)
 }
 
 // applyAdoptionConsent is the gate as the push path uses it: given a derived
@@ -124,15 +143,15 @@ To never adopt implicitly, pass --no-adopt or set BD_NO_REMOTE_ADOPT=1.`, remote
 //
 // proceed=false with err=nil is the deliberate --no-adopt case: the caller
 // falls through to its ordinary no-remote handling rather than failing.
-func applyAdoptionConsent(remoteURL string, policy adoptPolicy) (bool, error) {
+func applyAdoptionConsent(remoteURL string, policy adoptPolicy, optIn adoptOptIn) (bool, error) {
 	switch decision, refusal := decideRemoteAdoption(policy); decision {
 	case adoptRefuse:
 		if refusal == adoptRefusedNonInteractive {
-			return false, adoptionRefusedError(remoteURL)
+			return false, adoptionRefusedError(remoteURL, optIn)
 		}
 		return false, nil
 	case adoptAsk:
-		if !confirmRemoteAdoption(remoteURL) {
+		if !confirmRemoteAdoption(remoteURL, optIn) {
 			return false, fmt.Errorf("remote adoption declined; nothing was written and nothing was pushed")
 		}
 		return true, nil
@@ -149,7 +168,7 @@ func applyAdoptionConsent(remoteURL string, policy adoptPolicy) (bool, error) {
 // the user's git identity in their repo, which is a surprise worth disclosing
 // before the fact rather than in a line printed after it happened (#5068
 // acceptance item 4).
-func confirmRemoteAdoption(remoteURL string) bool {
+func confirmRemoteAdoption(remoteURL string, optIn adoptOptIn) bool {
 	fmt.Fprintln(os.Stderr, "")
 	fmt.Fprintln(os.Stderr, "No Dolt remote is configured for this rig.")
 	fmt.Fprintf(os.Stderr, "  Derived from git origin: %s\n", remoteURL)
@@ -160,7 +179,7 @@ func confirmRemoteAdoption(remoteURL string) bool {
 	fmt.Fprintln(os.Stderr, "  • commit that config change under your git identity")
 	fmt.Fprintln(os.Stderr, "  • upload your full issue history there")
 	fmt.Fprintln(os.Stderr, "")
-	fmt.Fprint(os.Stderr, "Adopt this remote and push? [y/N] ")
+	fmt.Fprintf(os.Stderr, "Adopt this remote and %s? [y/N] ", optIn.action)
 
 	reader := bufio.NewReader(os.Stdin)
 	line, _ := reader.ReadString('\n')

--- a/cmd/bd/dolt_remote_adopt.go
+++ b/cmd/bd/dolt_remote_adopt.go
@@ -1,0 +1,170 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+
+	"golang.org/x/term"
+)
+
+// Git-origin adoption is the one write in the push path that can send private
+// issue history somewhere the user never named (#5068). Before this gate,
+// `bd dolt push` on a rig with no Dolt remote derived one from git origin,
+// wired it, persisted sync.remote, committed that config change under the
+// user's git identity, and uploaded — with no prompt, no flag and no opt-out.
+// A public git origin therefore published the whole issue database on a
+// command the user believed targeted an already-configured remote.
+//
+// The rule here is fail-closed: adoption is a consent decision, so the absence
+// of consent is a refusal, never a default yes. Note that confirmPrompt in
+// bootstrap.go deliberately returns true when stdin is not a TTY — that is the
+// right default for "proceed with the thing you asked for" and the wrong one
+// for this, which is why adoption does not reuse it.
+
+// adoptPolicy carries the caller's consent inputs for git-origin adoption.
+// It is a value, not global state, so the decision is testable without a TTY,
+// a store, or a repo to mutate.
+type adoptPolicy struct {
+	// AssumeYes is --yes/-y: consent given ahead of time, for scripted use.
+	AssumeYes bool
+	// Disabled is --no-adopt or BD_NO_REMOTE_ADOPT=1: never adopt.
+	Disabled bool
+	// Interactive reports whether we can actually ask. False means fail-closed.
+	Interactive bool
+}
+
+// adoptDecision is what to do once a git origin URL has been derived but
+// before anything has been written.
+type adoptDecision int
+
+const (
+	// adoptRefuse: do not adopt. The caller explains why and stops.
+	adoptRefuse adoptDecision = iota
+	// adoptAsk: prompt the user, showing the derived URL.
+	adoptAsk
+	// adoptProceed: consent already given (--yes).
+	adoptProceed
+)
+
+// adoptRefusal distinguishes the two refusals, which need different messages
+// and different exit behavior from the caller.
+type adoptRefusal int
+
+const (
+	adoptRefusalNone adoptRefusal = iota
+	// adoptRefusedDisabled: the user asked us not to adopt. Not an error.
+	adoptRefusedDisabled
+	// adoptRefusedNonInteractive: we cannot ask and were not told. An error.
+	adoptRefusedNonInteractive
+)
+
+// decideRemoteAdoption is the whole policy, kept pure so the fail-closed
+// property is asserted by a table test rather than inferred from the call site.
+//
+// Precedence: an explicit --no-adopt beats an explicit --yes (the safer of two
+// contradictory instructions wins), and both beat interactivity.
+func decideRemoteAdoption(p adoptPolicy) (adoptDecision, adoptRefusal) {
+	switch {
+	case p.Disabled:
+		return adoptRefuse, adoptRefusedDisabled
+	case p.AssumeYes:
+		return adoptProceed, adoptRefusalNone
+	case p.Interactive:
+		return adoptAsk, adoptRefusalNone
+	default:
+		return adoptRefuse, adoptRefusedNonInteractive
+	}
+}
+
+// currentAdoptPolicy builds the policy from flags plus BD_NO_REMOTE_ADOPT.
+// stdinIsTerminal is injected so tests do not depend on how they were invoked.
+func currentAdoptPolicy(assumeYes, noAdopt, stdinIsTerminal bool) adoptPolicy {
+	return adoptPolicy{
+		AssumeYes:   assumeYes,
+		Disabled:    noAdopt || envNoRemoteAdopt(),
+		Interactive: stdinIsTerminal,
+	}
+}
+
+func envNoRemoteAdopt() bool {
+	v := strings.TrimSpace(strings.ToLower(os.Getenv("BD_NO_REMOTE_ADOPT")))
+	return v == "1" || v == "true" || v == "yes"
+}
+
+func stdinIsTerminal() bool {
+	return term.IsTerminal(int(os.Stdin.Fd()))
+}
+
+// adoptionRefusedError is the message for the non-interactive refusal. It
+// names the URL that would have been adopted, because "a remote was derived"
+// is useless without knowing which one — the reporter's whole complaint was
+// not knowing where the upload was going.
+func adoptionRefusedError(remoteURL string) error {
+	return fmt.Errorf(`no Dolt remote is configured, and bd will not adopt one without consent.
+
+  Derived from git origin: %s
+
+This would publish your entire issue history to that remote. If it is what you
+want, opt in explicitly:
+
+  bd dolt push --yes                     # adopt the derived remote and push
+  bd dolt remote add origin <url>        # or name the remote yourself first
+
+To never adopt implicitly, pass --no-adopt or set BD_NO_REMOTE_ADOPT=1.`, remoteURL)
+}
+
+// applyAdoptionConsent is the gate as the push path uses it: given a derived
+// URL and a policy, either return proceed=true (everything after this may
+// write) or stop. It is separated from adoptGitOriginRemoteForPush so the
+// fail-closed behavior can be asserted without resolving a workspace — that
+// resolution mutates whatever repo the test binary runs in, which is exactly
+// what the syncAdoptGitOrigin seam comment in sync.go warns about.
+//
+// proceed=false with err=nil is the deliberate --no-adopt case: the caller
+// falls through to its ordinary no-remote handling rather than failing.
+func applyAdoptionConsent(remoteURL string, policy adoptPolicy) (bool, error) {
+	switch decision, refusal := decideRemoteAdoption(policy); decision {
+	case adoptRefuse:
+		if refusal == adoptRefusedNonInteractive {
+			return false, adoptionRefusedError(remoteURL)
+		}
+		return false, nil
+	case adoptAsk:
+		if !confirmRemoteAdoption(remoteURL) {
+			return false, fmt.Errorf("remote adoption declined; nothing was written and nothing was pushed")
+		}
+		return true, nil
+	default: // adoptProceed
+		// --yes: consent given ahead of time. Still announce the target, so a
+		// scripted run leaves a record of where it uploaded.
+		fmt.Fprintf(os.Stderr, "Adopting Dolt remote origin from git origin: %s\n", remoteURL)
+		return true, nil
+	}
+}
+
+// confirmRemoteAdoption asks, showing the URL and every side effect that
+// follows a yes. The config.yaml commit is named here because it is made under
+// the user's git identity in their repo, which is a surprise worth disclosing
+// before the fact rather than in a line printed after it happened (#5068
+// acceptance item 4).
+func confirmRemoteAdoption(remoteURL string) bool {
+	fmt.Fprintln(os.Stderr, "")
+	fmt.Fprintln(os.Stderr, "No Dolt remote is configured for this rig.")
+	fmt.Fprintf(os.Stderr, "  Derived from git origin: %s\n", remoteURL)
+	fmt.Fprintln(os.Stderr, "")
+	fmt.Fprintln(os.Stderr, "Adopting it will:")
+	fmt.Fprintln(os.Stderr, "  • add it as Dolt remote \"origin\"")
+	fmt.Fprintln(os.Stderr, "  • write sync.remote into .beads/config.yaml")
+	fmt.Fprintln(os.Stderr, "  • commit that config change under your git identity")
+	fmt.Fprintln(os.Stderr, "  • upload your full issue history there")
+	fmt.Fprintln(os.Stderr, "")
+	fmt.Fprint(os.Stderr, "Adopt this remote and push? [y/N] ")
+
+	reader := bufio.NewReader(os.Stdin)
+	line, _ := reader.ReadString('\n')
+	// Default is NO: an empty line, EOF, or a read error must not consent.
+	return strings.TrimSpace(strings.ToLower(line)) == "y" ||
+		strings.TrimSpace(strings.ToLower(line)) == "yes"
+}

--- a/cmd/bd/dolt_remote_adopt_test.go
+++ b/cmd/bd/dolt_remote_adopt_test.go
@@ -1,0 +1,181 @@
+package main
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// TestDecideRemoteAdoptionFailsClosed is the #5068 regression assertion in its
+// purest form: with no consent input at all, the answer is refuse. Every
+// variant below exists because a "sensible default" in any one of them is how
+// the original bug read — bd derived a remote and uploaded to it because
+// nothing said not to.
+func TestDecideRemoteAdoptionFailsClosed(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		policy      adoptPolicy
+		wantDecide  adoptDecision
+		wantRefusal adoptRefusal
+	}{
+		{
+			name:        "zero value refuses",
+			policy:      adoptPolicy{},
+			wantDecide:  adoptRefuse,
+			wantRefusal: adoptRefusedNonInteractive,
+		},
+		{
+			name:        "non-interactive without --yes refuses",
+			policy:      adoptPolicy{Interactive: false},
+			wantDecide:  adoptRefuse,
+			wantRefusal: adoptRefusedNonInteractive,
+		},
+		{
+			name:        "interactive asks rather than assuming",
+			policy:      adoptPolicy{Interactive: true},
+			wantDecide:  adoptAsk,
+			wantRefusal: adoptRefusalNone,
+		},
+		{
+			name:        "--yes is consent even when non-interactive",
+			policy:      adoptPolicy{AssumeYes: true},
+			wantDecide:  adoptProceed,
+			wantRefusal: adoptRefusalNone,
+		},
+		{
+			name:        "--no-adopt refuses, and it is not an error",
+			policy:      adoptPolicy{Disabled: true, Interactive: true},
+			wantDecide:  adoptRefuse,
+			wantRefusal: adoptRefusedDisabled,
+		},
+		{
+			// Contradictory instructions: the safer one wins. Otherwise a
+			// scripted --yes buried in an alias would silently defeat a
+			// deliberate BD_NO_REMOTE_ADOPT=1 on the machine.
+			name:        "--no-adopt beats --yes",
+			policy:      adoptPolicy{Disabled: true, AssumeYes: true, Interactive: true},
+			wantDecide:  adoptRefuse,
+			wantRefusal: adoptRefusedDisabled,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			gotDecide, gotRefusal := decideRemoteAdoption(tc.policy)
+			if gotDecide != tc.wantDecide || gotRefusal != tc.wantRefusal {
+				t.Errorf("decideRemoteAdoption(%+v) = (%v, %v), want (%v, %v)",
+					tc.policy, gotDecide, gotRefusal, tc.wantDecide, tc.wantRefusal)
+			}
+		})
+	}
+}
+
+func TestCurrentAdoptPolicyHonorsEnvKillSwitch(t *testing.T) {
+	for _, tc := range []struct {
+		env  string
+		want bool
+	}{
+		{"1", true},
+		{"true", true},
+		{"YES", true},
+		{"0", false},
+		{"", false},
+		{"maybe", false},
+	} {
+		t.Run("BD_NO_REMOTE_ADOPT="+tc.env, func(t *testing.T) {
+			t.Setenv("BD_NO_REMOTE_ADOPT", tc.env)
+			if got := currentAdoptPolicy(false, false, true).Disabled; got != tc.want {
+				t.Errorf("Disabled = %v, want %v", got, tc.want)
+			}
+		})
+	}
+
+	t.Setenv("BD_NO_REMOTE_ADOPT", "")
+	if !currentAdoptPolicy(false, true, true).Disabled {
+		t.Error("--no-adopt alone did not disable adoption")
+	}
+}
+
+// TestAdoptionRefusedErrorNamesTheURL: the reporter's complaint was not only
+// that bd adopted a remote, but that they could not tell where the upload was
+// going. An error that omits the URL does not fix that half.
+func TestAdoptionRefusedErrorNamesTheURL(t *testing.T) {
+	const url = "git+ssh://git@github.com/someone/public-repo.git"
+	msg := adoptionRefusedError(url).Error()
+	for _, want := range []string{url, "--yes", "--no-adopt", "BD_NO_REMOTE_ADOPT"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("refusal message does not mention %q:\n%s", want, msg)
+		}
+	}
+}
+
+// TestApplyAdoptionConsentGatesTheWrite is acceptance item 5 of #5068 at the
+// gate itself: with no configured Dolt remote and a derived git-origin URL,
+// nothing downstream may run without consent. Everything after this call in
+// adoptGitOriginRemoteForPush writes (AddRemote, sync.remote, the git commit,
+// then the upload), so proceed=false is exactly "nothing was uploaded".
+func TestApplyAdoptionConsentGatesTheWrite(t *testing.T) {
+	const url = "git+ssh://git@github.com/someone/public-repo.git"
+
+	for _, tc := range []struct {
+		name        string
+		policy      adoptPolicy
+		wantProceed bool
+		wantErr     bool
+	}{
+		{
+			// The reported bug: a scripted/hook invocation with a public git
+			// origin and no configured remote must not upload.
+			name:        "non-interactive without --yes does not proceed, and says so",
+			policy:      adoptPolicy{Interactive: false},
+			wantProceed: false,
+			wantErr:     true,
+		},
+		{
+			name:        "--yes proceeds",
+			policy:      adoptPolicy{AssumeYes: true},
+			wantProceed: true,
+			wantErr:     false,
+		},
+		{
+			// --no-adopt is a request, not a failure: the caller falls through
+			// to ordinary no-remote handling.
+			name:        "--no-adopt does not proceed and is not an error",
+			policy:      adoptPolicy{Disabled: true, Interactive: true},
+			wantProceed: false,
+			wantErr:     false,
+		},
+		{
+			name:        "--no-adopt beats --yes",
+			policy:      adoptPolicy{Disabled: true, AssumeYes: true},
+			wantProceed: false,
+			wantErr:     false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("BD_NO_REMOTE_ADOPT", "")
+			proceed, err := applyAdoptionConsent(url, tc.policy)
+			if proceed != tc.wantProceed {
+				t.Errorf("proceed = %v, want %v", proceed, tc.wantProceed)
+			}
+			if (err != nil) != tc.wantErr {
+				t.Errorf("err = %v, wantErr = %v", err, tc.wantErr)
+			}
+			if tc.wantErr && err != nil && !strings.Contains(err.Error(), url) {
+				t.Errorf("refusal did not name the remote it would have adopted: %v", err)
+			}
+		})
+	}
+}
+
+// The zero-value policy is what a caller that forgets to wire the flags would
+// pass. It must refuse, not adopt.
+func TestApplyAdoptionConsentZeroPolicyRefuses(t *testing.T) {
+	t.Setenv("BD_NO_REMOTE_ADOPT", "")
+	proceed, err := applyAdoptionConsent("git+ssh://git@github.com/x/y.git", adoptPolicy{})
+	if proceed {
+		t.Fatal("zero-value policy proceeded with adoption")
+	}
+	if err == nil {
+		t.Fatal("zero-value policy refused silently; the user gets no explanation")
+	}
+	_ = errors.Is(err, nil)
+}

--- a/cmd/bd/dolt_remote_adopt_test.go
+++ b/cmd/bd/dolt_remote_adopt_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"errors"
 	"strings"
 	"testing"
 )
@@ -82,15 +81,32 @@ func TestCurrentAdoptPolicyHonorsEnvKillSwitch(t *testing.T) {
 	} {
 		t.Run("BD_NO_REMOTE_ADOPT="+tc.env, func(t *testing.T) {
 			t.Setenv("BD_NO_REMOTE_ADOPT", tc.env)
-			if got := currentAdoptPolicy(false, false, true).Disabled; got != tc.want {
+			if got := currentAdoptPolicy(false, false, true, false).Disabled; got != tc.want {
 				t.Errorf("Disabled = %v, want %v", got, tc.want)
 			}
 		})
 	}
 
 	t.Setenv("BD_NO_REMOTE_ADOPT", "")
-	if !currentAdoptPolicy(false, true, true).Disabled {
+	if !currentAdoptPolicy(false, true, true, false).Disabled {
 		t.Error("--no-adopt alone did not disable adoption")
+	}
+}
+
+// --json is a machine contract: even on a TTY (agent harnesses often allocate
+// one), the policy must be non-interactive so a JSON consumer never blocks on
+// a prompt it cannot see. The refusal error is the correct surface instead.
+func TestCurrentAdoptPolicyJSONModeIsNotInteractive(t *testing.T) {
+	t.Setenv("BD_NO_REMOTE_ADOPT", "")
+	p := currentAdoptPolicy(false, false, true, true)
+	if p.Interactive {
+		t.Fatal("jsonMode policy is Interactive; bd sync --json on a pty would hang on the consent prompt")
+	}
+	if decision, refusal := decideRemoteAdoption(p); decision != adoptRefuse || refusal != adoptRefusedNonInteractive {
+		t.Fatalf("jsonMode without --yes: decision = %v/%v, want refuse/non-interactive", decision, refusal)
+	}
+	if decision, _ := decideRemoteAdoption(currentAdoptPolicy(true, false, true, true)); decision != adoptProceed {
+		t.Fatal("jsonMode with --yes must still proceed")
 	}
 }
 
@@ -99,11 +115,23 @@ func TestCurrentAdoptPolicyHonorsEnvKillSwitch(t *testing.T) {
 // going. An error that omits the URL does not fix that half.
 func TestAdoptionRefusedErrorNamesTheURL(t *testing.T) {
 	const url = "git+ssh://git@github.com/someone/public-repo.git"
-	msg := adoptionRefusedError(url).Error()
-	for _, want := range []string{url, "--yes", "--no-adopt", "BD_NO_REMOTE_ADOPT"} {
+	msg := adoptionRefusedError(url, pushAdoptOptIn).Error()
+	for _, want := range []string{url, "bd dolt push --yes", "--no-adopt", "BD_NO_REMOTE_ADOPT"} {
 		if !strings.Contains(msg, want) {
 			t.Errorf("refusal message does not mention %q:\n%s", want, msg)
 		}
+	}
+}
+
+// The refusal must name the command the user actually ran: steering a sync
+// user into `bd dolt push --yes` would trade their pull away.
+func TestAdoptionRefusedErrorNamesTheCallersCommand(t *testing.T) {
+	msg := adoptionRefusedError("git+ssh://git@github.com/x/y.git", syncAdoptOptIn).Error()
+	if !strings.Contains(msg, "bd sync --yes") {
+		t.Errorf("sync-path refusal does not offer bd sync --yes:\n%s", msg)
+	}
+	if strings.Contains(msg, "bd dolt push --yes") {
+		t.Errorf("sync-path refusal steers the user to bd dolt push:\n%s", msg)
 	}
 }
 
@@ -152,7 +180,7 @@ func TestApplyAdoptionConsentGatesTheWrite(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Setenv("BD_NO_REMOTE_ADOPT", "")
-			proceed, err := applyAdoptionConsent(url, tc.policy)
+			proceed, err := applyAdoptionConsent(url, tc.policy, pushAdoptOptIn)
 			if proceed != tc.wantProceed {
 				t.Errorf("proceed = %v, want %v", proceed, tc.wantProceed)
 			}
@@ -170,12 +198,11 @@ func TestApplyAdoptionConsentGatesTheWrite(t *testing.T) {
 // pass. It must refuse, not adopt.
 func TestApplyAdoptionConsentZeroPolicyRefuses(t *testing.T) {
 	t.Setenv("BD_NO_REMOTE_ADOPT", "")
-	proceed, err := applyAdoptionConsent("git+ssh://git@github.com/x/y.git", adoptPolicy{})
+	proceed, err := applyAdoptionConsent("git+ssh://git@github.com/x/y.git", adoptPolicy{}, pushAdoptOptIn)
 	if proceed {
 		t.Fatal("zero-value policy proceeded with adoption")
 	}
 	if err == nil {
 		t.Fatal("zero-value policy refused silently; the user gets no explanation")
 	}
-	_ = errors.Is(err, nil)
 }

--- a/cmd/bd/dolt_test.go
+++ b/cmd/bd/dolt_test.go
@@ -1281,7 +1281,10 @@ func TestAdoptGitOriginRemoteForPush_PersistedRemoteVetoesAdoption(t *testing.T)
 			if _, direct := persisted.(persistedRemoteProber); direct {
 				t.Fatalf("%T implements persistedRemoteProber directly; this test no longer exercises the peel", persisted)
 			}
-			adopted, err := adoptGitOriginRemoteForPush(ctx, persisted)
+			// AssumeYes deliberately: consent is granted, so the only thing
+			// that can stop adoption here is the persisted-remote veto. If the
+			// veto ever moves below the consent gate this still fails.
+			adopted, err := adoptGitOriginRemoteForPush(ctx, persisted, adoptPolicy{AssumeYes: true})
 			if err != nil {
 				t.Errorf("adoptGitOriginRemoteForPush returned error %v; a persisted remote is a no-op, not a failure", err)
 			}
@@ -1325,7 +1328,7 @@ func TestAdoptGitOriginRemoteForPush_PersistedRemoteVetoesAdoption(t *testing.T)
 			if _, err := hasConfiguredRemote(ctx, broken); !errors.Is(err, listErr) {
 				t.Errorf("hasConfiguredRemote swallowed a ListRemotes failure: err = %v", err)
 			}
-			if adopted, err := adoptGitOriginRemoteForPush(ctx, broken); adopted || !errors.Is(err, listErr) {
+			if adopted, err := adoptGitOriginRemoteForPush(ctx, broken, adoptPolicy{AssumeYes: true}); adopted || !errors.Is(err, listErr) {
 				t.Errorf("adoptGitOriginRemoteForPush(list error) = (%v, %v), want (false, the list error)", adopted, err)
 			}
 		})

--- a/cmd/bd/dolt_test.go
+++ b/cmd/bd/dolt_test.go
@@ -1284,7 +1284,7 @@ func TestAdoptGitOriginRemoteForPush_PersistedRemoteVetoesAdoption(t *testing.T)
 			// AssumeYes deliberately: consent is granted, so the only thing
 			// that can stop adoption here is the persisted-remote veto. If the
 			// veto ever moves below the consent gate this still fails.
-			adopted, err := adoptGitOriginRemoteForPush(ctx, persisted, adoptPolicy{AssumeYes: true})
+			adopted, err := adoptGitOriginRemoteForPush(ctx, persisted, adoptPolicy{AssumeYes: true}, pushAdoptOptIn)
 			if err != nil {
 				t.Errorf("adoptGitOriginRemoteForPush returned error %v; a persisted remote is a no-op, not a failure", err)
 			}
@@ -1328,7 +1328,7 @@ func TestAdoptGitOriginRemoteForPush_PersistedRemoteVetoesAdoption(t *testing.T)
 			if _, err := hasConfiguredRemote(ctx, broken); !errors.Is(err, listErr) {
 				t.Errorf("hasConfiguredRemote swallowed a ListRemotes failure: err = %v", err)
 			}
-			if adopted, err := adoptGitOriginRemoteForPush(ctx, broken, adoptPolicy{AssumeYes: true}); adopted || !errors.Is(err, listErr) {
+			if adopted, err := adoptGitOriginRemoteForPush(ctx, broken, adoptPolicy{AssumeYes: true}, pushAdoptOptIn); adopted || !errors.Is(err, listErr) {
 				t.Errorf("adoptGitOriginRemoteForPush(list error) = (%v, %v), want (false, the list error)", adopted, err)
 			}
 		})

--- a/cmd/bd/init_embedded_test.go
+++ b/cmd/bd/init_embedded_test.go
@@ -487,6 +487,42 @@ func TestEmbeddedInit(t *testing.T) {
 		}
 	})
 
+	// The #5068 refusal, end to end. The subtests around it prove adoption
+	// still works with consent; this one proves it does not happen without.
+	t.Run("dolt_push_refuses_to_adopt_without_consent", func(t *testing.T) {
+		bareDir := filepath.Join(t.TempDir(), "no-consent.git")
+		runGitForBootstrapTest(t, "", "init", "--bare", "-b", "main", bareDir)
+		remoteURL := "file://" + bareDir
+
+		dir := t.TempDir()
+		initGitRepoAt(t, dir)
+		runGitForBootstrapTest(t, dir, "branch", "-M", "main")
+		runGitForBootstrapTest(t, dir, "commit", "--allow-empty", "-m", "init")
+		runBDInit(t, bd, dir, "--prefix", "noc", "--skip-hooks", "--skip-agents")
+		bdCreate(t, bd, dir, "No consent", "--type", "task")
+
+		runGitForBootstrapTest(t, dir, "remote", "add", "origin", remoteURL)
+		runGitForBootstrapTest(t, dir, "push", "-u", "origin", "main")
+
+		// No TTY and no --yes: bd must refuse rather than derive a remote and
+		// upload to it.
+		out := bdDoltFail(t, bd, dir, "push")
+		if !strings.Contains(out, remoteURL) {
+			t.Errorf("refusal did not name the remote it would have adopted; output:\n%s", out)
+		}
+
+		if list := bdDolt(t, bd, dir, "remote", "list"); strings.Contains(list, remoteURL) {
+			t.Errorf("refused push still added the remote; remote list:\n%s", list)
+		}
+		configYAML, readErr := os.ReadFile(filepath.Join(dir, ".beads", "config.yaml"))
+		if readErr == nil && strings.Contains(string(configYAML), remoteURL) {
+			t.Errorf("refused push still persisted sync.remote; config.yaml:\n%s", configYAML)
+		}
+		if lsOut, lsErr := exec.Command("git", "ls-remote", remoteURL, "refs/dolt/data").Output(); lsErr == nil && len(strings.TrimSpace(string(lsOut))) != 0 {
+			t.Errorf("refused push still uploaded issue history: %s", lsOut)
+		}
+	})
+
 	t.Run("dolt_push_lazily_adopts_later_git_origin", func(t *testing.T) {
 		bareDir := filepath.Join(t.TempDir(), "later-origin.git")
 		runGitForBootstrapTest(t, "", "init", "--bare", "-b", "main", bareDir)
@@ -502,11 +538,16 @@ func TestEmbeddedInit(t *testing.T) {
 		runGitForBootstrapTest(t, dir, "remote", "add", "origin", remoteURL)
 		runGitForBootstrapTest(t, dir, "push", "-u", "origin", "main")
 
-		bdDolt(t, bd, dir, "push")
+		// --yes is the scripted consent for git-origin adoption (#5068). The
+		// capability this subtest covers is unchanged; only the consent is
+		// new, and a test process has no TTY so adoption now fails closed
+		// without it. The refusal itself is covered by
+		// dolt_push_refuses_to_adopt_without_consent below.
+		bdDolt(t, bd, dir, "push", "--yes")
 
 		out := bdDolt(t, bd, dir, "remote", "list")
 		if !strings.Contains(out, "origin") || !strings.Contains(out, remoteURL) {
-			t.Fatalf("bd dolt push should adopt later git origin %q; remote list:\n%s", remoteURL, out)
+			t.Fatalf("bd dolt push --yes should adopt later git origin %q; remote list:\n%s", remoteURL, out)
 		}
 
 		configYAML, err := os.ReadFile(filepath.Join(dir, ".beads", "config.yaml"))
@@ -548,7 +589,8 @@ func TestEmbeddedInit(t *testing.T) {
 		initGitRepoAt(t, ambientDir)
 		runGitForBootstrapTest(t, ambientDir, "remote", "add", "origin", ambientURL)
 
-		cmd := exec.Command(bd, "-C", targetDir, "dolt", "push")
+		// --yes: see the note in dolt_push_lazily_adopts_later_git_origin.
+		cmd := exec.Command(bd, "-C", targetDir, "dolt", "push", "--yes")
 		cmd.Dir = ambientDir
 		cmd.Env = bdEnv(ambientDir)
 		if out, err := cmd.CombinedOutput(); err != nil {

--- a/cmd/bd/sync.go
+++ b/cmd/bd/sync.go
@@ -695,7 +695,7 @@ func init() {
 // real thing in dolt_test.go; letting it run for real from a runSyncCommand
 // unit test would mutate whatever repo the tests happen to be run from. The
 // production binding is pinned by TestSyncAdoptGitOriginIsWiredToAdoption.
-var syncAdoptGitOrigin func(context.Context, storage.DoltStorage, adoptPolicy) (bool, error) = adoptGitOriginRemoteForPush
+var syncAdoptGitOrigin func(context.Context, storage.DoltStorage, adoptPolicy, adoptOptIn) (bool, error) = adoptGitOriginRemoteForPush
 
 func runSyncCommand(cmd *cobra.Command, _ []string) error {
 	if usesProxiedServer() {
@@ -759,7 +759,7 @@ func runSyncCommand(cmd *cobra.Command, _ []string) error {
 		// history to the same derived remote, so it cannot be the soft way in.
 		syncYes, _ := cmd.Flags().GetBool("yes")
 		syncNoAdopt, _ := cmd.Flags().GetBool("no-adopt")
-		adopted, adoptErr := syncAdoptGitOrigin(rootCtx, st, currentAdoptPolicy(syncYes, syncNoAdopt, stdinIsTerminal()))
+		adopted, adoptErr := syncAdoptGitOrigin(rootCtx, st, currentAdoptPolicy(syncYes, syncNoAdopt, stdinIsTerminal(), jsonOutput), syncAdoptOptIn)
 		if adoptErr != nil {
 			return HandleErrorRespectJSON("sync failed: adopting git origin as Dolt remote: %v", adoptErr)
 		}

--- a/cmd/bd/sync.go
+++ b/cmd/bd/sync.go
@@ -683,6 +683,8 @@ Examples:
 func init() {
 	syncCmd.Flags().String("remote", "", "Sync with a specific named remote instead of the default")
 	syncCmd.Flags().Int("attempts", defaultSyncAttempts, "Maximum pull/push attempts before reporting a transient retry exhaustion (exit 3)")
+	syncCmd.Flags().BoolP("yes", "y", false, "Consent to adopting a Dolt remote derived from git origin when none is configured")
+	syncCmd.Flags().Bool("no-adopt", false, "Never derive a Dolt remote from git origin (also BD_NO_REMOTE_ADOPT=1)")
 	rootCmd.AddCommand(syncCmd)
 }
 
@@ -693,7 +695,7 @@ func init() {
 // real thing in dolt_test.go; letting it run for real from a runSyncCommand
 // unit test would mutate whatever repo the tests happen to be run from. The
 // production binding is pinned by TestSyncAdoptGitOriginIsWiredToAdoption.
-var syncAdoptGitOrigin = adoptGitOriginRemoteForPush
+var syncAdoptGitOrigin func(context.Context, storage.DoltStorage, adoptPolicy) (bool, error) = adoptGitOriginRemoteForPush
 
 func runSyncCommand(cmd *cobra.Command, _ []string) error {
 	if usesProxiedServer() {
@@ -753,7 +755,11 @@ func runSyncCommand(cmd *cobra.Command, _ []string) error {
 	// or persisted on disk — adoption is a hasConfiguredRemote no-op, so the
 	// steady-state cost is the one listing the error path already paid.
 	if remote == "" {
-		adopted, adoptErr := syncAdoptGitOrigin(rootCtx, st)
+		// Same consent gate as `bd dolt push` (#5068): sync publishes the same
+		// history to the same derived remote, so it cannot be the soft way in.
+		syncYes, _ := cmd.Flags().GetBool("yes")
+		syncNoAdopt, _ := cmd.Flags().GetBool("no-adopt")
+		adopted, adoptErr := syncAdoptGitOrigin(rootCtx, st, currentAdoptPolicy(syncYes, syncNoAdopt, stdinIsTerminal()))
 		if adoptErr != nil {
 			return HandleErrorRespectJSON("sync failed: adopting git origin as Dolt remote: %v", adoptErr)
 		}

--- a/cmd/bd/sync_test.go
+++ b/cmd/bd/sync_test.go
@@ -1366,7 +1366,7 @@ func setupSyncCommandTest(t *testing.T, fake *fakeSyncStore) {
 		_ = syncCmd.Flags().Set("attempts", fmt.Sprintf("%d", defaultSyncAttempts))
 		_ = syncCmd.Flags().Set("remote", "")
 	})
-	syncAdoptGitOrigin = func(context.Context, storage.DoltStorage, adoptPolicy) (bool, error) { return false, nil }
+	syncAdoptGitOrigin = func(context.Context, storage.DoltStorage, adoptPolicy, adoptOptIn) (bool, error) { return false, nil }
 
 	store = fake
 	rootCtx = context.Background()
@@ -1645,7 +1645,7 @@ func TestRunSyncCommandAdoptsGitOriginOnDefaultRemote(t *testing.T) {
 	fake := &fakeSyncStore{pullErr: errors.New("Error 1105: no remote"), recomputed: 2}
 	setupSyncCommandTest(t, fake)
 	adoptCalls := 0
-	syncAdoptGitOrigin = func(context.Context, storage.DoltStorage, adoptPolicy) (bool, error) {
+	syncAdoptGitOrigin = func(context.Context, storage.DoltStorage, adoptPolicy, adoptOptIn) (bool, error) {
 		adoptCalls++
 		// What adoption does on a real first-time rig: the remote now exists,
 		// so the pull that was failing with "no remote" succeeds and
@@ -1681,7 +1681,7 @@ func TestRunSyncCommandAdoptsBeforePull(t *testing.T) {
 	fake := &fakeSyncStore{}
 	setupSyncCommandTest(t, fake)
 	pullsAtAdoption := -1
-	syncAdoptGitOrigin = func(context.Context, storage.DoltStorage, adoptPolicy) (bool, error) {
+	syncAdoptGitOrigin = func(context.Context, storage.DoltStorage, adoptPolicy, adoptOptIn) (bool, error) {
 		pullsAtAdoption = fake.pullCalls
 		return true, nil
 	}
@@ -1722,7 +1722,7 @@ func TestRunSyncCommandNamedRemoteNeverAdopts(t *testing.T) {
 	fake := &fakeSyncStore{}
 	setupSyncCommandTest(t, fake)
 	adoptCalls := 0
-	syncAdoptGitOrigin = func(context.Context, storage.DoltStorage, adoptPolicy) (bool, error) {
+	syncAdoptGitOrigin = func(context.Context, storage.DoltStorage, adoptPolicy, adoptOptIn) (bool, error) {
 		adoptCalls++
 		return true, nil
 	}
@@ -1750,7 +1750,7 @@ func TestRunSyncCommandAdoptionErrorFailsLoudly(t *testing.T) {
 	fake := &fakeSyncStore{}
 	setupSyncCommandTest(t, fake)
 	adoptErr := errors.New("dolt_remotes unavailable")
-	syncAdoptGitOrigin = func(context.Context, storage.DoltStorage, adoptPolicy) (bool, error) {
+	syncAdoptGitOrigin = func(context.Context, storage.DoltStorage, adoptPolicy, adoptOptIn) (bool, error) {
 		return false, adoptErr
 	}
 

--- a/cmd/bd/sync_test.go
+++ b/cmd/bd/sync_test.go
@@ -1366,7 +1366,7 @@ func setupSyncCommandTest(t *testing.T, fake *fakeSyncStore) {
 		_ = syncCmd.Flags().Set("attempts", fmt.Sprintf("%d", defaultSyncAttempts))
 		_ = syncCmd.Flags().Set("remote", "")
 	})
-	syncAdoptGitOrigin = func(context.Context, storage.DoltStorage) (bool, error) { return false, nil }
+	syncAdoptGitOrigin = func(context.Context, storage.DoltStorage, adoptPolicy) (bool, error) { return false, nil }
 
 	store = fake
 	rootCtx = context.Background()
@@ -1645,7 +1645,7 @@ func TestRunSyncCommandAdoptsGitOriginOnDefaultRemote(t *testing.T) {
 	fake := &fakeSyncStore{pullErr: errors.New("Error 1105: no remote"), recomputed: 2}
 	setupSyncCommandTest(t, fake)
 	adoptCalls := 0
-	syncAdoptGitOrigin = func(context.Context, storage.DoltStorage) (bool, error) {
+	syncAdoptGitOrigin = func(context.Context, storage.DoltStorage, adoptPolicy) (bool, error) {
 		adoptCalls++
 		// What adoption does on a real first-time rig: the remote now exists,
 		// so the pull that was failing with "no remote" succeeds and
@@ -1681,7 +1681,7 @@ func TestRunSyncCommandAdoptsBeforePull(t *testing.T) {
 	fake := &fakeSyncStore{}
 	setupSyncCommandTest(t, fake)
 	pullsAtAdoption := -1
-	syncAdoptGitOrigin = func(context.Context, storage.DoltStorage) (bool, error) {
+	syncAdoptGitOrigin = func(context.Context, storage.DoltStorage, adoptPolicy) (bool, error) {
 		pullsAtAdoption = fake.pullCalls
 		return true, nil
 	}
@@ -1722,7 +1722,7 @@ func TestRunSyncCommandNamedRemoteNeverAdopts(t *testing.T) {
 	fake := &fakeSyncStore{}
 	setupSyncCommandTest(t, fake)
 	adoptCalls := 0
-	syncAdoptGitOrigin = func(context.Context, storage.DoltStorage) (bool, error) {
+	syncAdoptGitOrigin = func(context.Context, storage.DoltStorage, adoptPolicy) (bool, error) {
 		adoptCalls++
 		return true, nil
 	}
@@ -1750,7 +1750,7 @@ func TestRunSyncCommandAdoptionErrorFailsLoudly(t *testing.T) {
 	fake := &fakeSyncStore{}
 	setupSyncCommandTest(t, fake)
 	adoptErr := errors.New("dolt_remotes unavailable")
-	syncAdoptGitOrigin = func(context.Context, storage.DoltStorage) (bool, error) {
+	syncAdoptGitOrigin = func(context.Context, storage.DoltStorage, adoptPolicy) (bool, error) {
 		return false, adoptErr
 	}
 


### PR DESCRIPTION
Fixes #5068.

## Why

On a rig with **no Dolt remote configured**, `bd dolt push` derived one from `git remote get-url origin`, called `AddRemote`, persisted `sync.remote` into `.beads/config.yaml`, committed that config change **under the user's git identity**, and uploaded the full issue history. No prompt, no flag, no opt-out — just a one-line notice printed *after* it happened, which did not even name the URL.

@balaji-dutt's git origin was a **public repo**, so private issue history was published by a command they believed targeted an already-configured remote. That is the bug: not that bd can infer a remote, but that inference is indistinguishable from consent.

The pre-existing `hasConfiguredRemote` probe (59241bf16) is sometimes read as a guard here. It is not — it is a correctness fix for a stale-empty-listing edge case in the #2118 cold-start window, and it only decides *whether a remote is already configured*, never whether adopting a new one is wanted.

## What changed

Adoption now **fails closed**:

| situation | before | after |
|---|---|---|
| interactive, no remote configured | adopts + uploads | shows the URL and every side effect, defaults to **No** |
| non-interactive (script, hook, CI) | adopts + uploads | refuses, exits non-zero, names the URL and the opt-in |
| `--yes` / `-y` | n/a | consents ahead of time, still announces the target |
| `--no-adopt` / `BD_NO_REMOTE_ADOPT=1` | n/a | never adopts; **beats `--yes`** |
| remote already configured | no-op | no-op (unchanged) |

The interactive prompt discloses all four consequences before the fact, including the config commit made under your git identity — the surprise @balaji-dutt called out separately:

```
No Dolt remote is configured for this rig.
  Derived from git origin: git+ssh://git@github.com/someone/public-repo.git

Adopting it will:
  • add it as Dolt remote "origin"
  • write sync.remote into .beads/config.yaml
  • commit that config change under your git identity
  • upload your full issue history there

Adopt this remote and push? [y/N]
```

An empty line, EOF, or a read error is a **decline**.

`--no-adopt` beating `--yes` is deliberate: a `--yes` buried in an alias or wrapper should not be able to defeat a machine-level `BD_NO_REMOTE_ADOPT=1`. When two instructions contradict, the safer one wins.

**`confirmPrompt` in `bootstrap.go` is deliberately not reused.** It returns `true` when stdin is not a TTY — the right default for "proceed with the thing you asked for", and exactly the wrong one for a consent decision.

## Two things worth a maintainer's eye

**1. `bd sync` is gated too.** It is the second caller of `adoptGitOriginRemoteForPush` and publishes the same history to the same derived remote, so leaving it ungated would just move the hole. But this is a behavior change for anyone whose automated `bd sync` relied on implicit adoption: they now need `--yes` or a configured remote. If you would rather ship the push gate first and treat sync separately, that is a clean split and I will do it.

**2. Workspace resolution moved below the gate.** `selectedDoltBeadsDir()` calls `prepareSelectedNoDBContext()`, which mutates process and on-disk workspace state. On the old ordering that ran *before* consent. Deriving the URL is read-only, so the new order is: probe → derive URL → **gate** → resolve workspace → write.

I found this because tests calling the real function polluted the shared test binary and broke `TestInitDatabaseAdoptsExistingProjectID` when they ran first. That test failure was the symptom; the ordering was the cause.

## Tests

The decision is a pure function (`decideRemoteAdoption`) plus a pure application step (`applyAdoptionConsent`), so the fail-closed property is asserted by table tests rather than inferred from the call site — and needs no TTY, store, or repo to mutate.

- `TestDecideRemoteAdoptionFailsClosed` — 6 cases including the zero-value policy (what a caller that forgets to wire the flags passes) and `--no-adopt` beating `--yes`.
- `TestApplyAdoptionConsentGatesTheWrite` — the acceptance-5 assertion: no configured remote + derived URL + non-interactive ⇒ does not proceed. Everything downstream of that call writes, so "does not proceed" is "did not upload".
- `TestApplyAdoptionConsentZeroPolicyRefuses` — refusing is not enough; it must also explain.
- `TestCurrentAdoptPolicyHonorsEnvKillSwitch` — `BD_NO_REMOTE_ADOPT` parsing.
- `TestAdoptionRefusedErrorNamesTheURL` — not knowing *where* was half the reported complaint.
- The existing `TestAdoptGitOriginRemoteForPush_PersistedRemoteVetoesAdoption` now passes `AssumeYes: true`, so it still fails if the persisted-remote veto is ever moved below the consent gate.

Validated locally: `go build ./...`, `go vet ./cmd/bd`, and the adoption + sync + init test set passes with no cross-test pollution. Full `make test` is running in the local verification queue — the `cmd/bd` package exceeds `go test`'s default 10m timeout in a session. I will report the result here.

## Not addressed

@balaji-dutt also reported that a **configured** `sync.remote` does not prevent adoption. I could not reproduce that against `main`: a configured remote returns early from `hasConfiguredRemote` above everything this PR touches. If there is a repro, it is a separate defect from this one and I would like to see it. The issue body also cross-references #5033, which I have not investigated.

_claude-opus-5-medium on behalf of maphew_
