### PR TITLE
fix(init): re-init inherits the workspace's connection mode instead of silently rewriting it (#3885)

### DIFF
--- a/cmd/bd/init.go
+++ b/cmd/bd/init.go
@@ -552,8 +552,11 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 		// explicit --server/--shared-server/--proxied-server, the BEADS_DOLT_*
 		// env vars, and a global dolt.mode all still win.
 		if !initServerMode && !initModeExplicitlyRequested(cmd) {
-			switch existingWorkspaceDoltMode() {
-			case configfile.DoltModeServer:
+			inheritServer, inheritErr := inheritWorkspaceDoltMode()
+			if inheritErr != nil {
+				return inheritErr
+			}
+			if inheritServer {
 				initServerMode = true
 				serverMode = true
 				if cmdCtx != nil {
@@ -561,14 +564,6 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 				}
 				if !quiet {
 					fmt.Fprintln(os.Stderr, "Preserving server mode from the existing .beads/metadata.json.")
-				}
-			case configfile.DoltModeProxiedServer:
-				proxiedServerMode = true
-				if cmdCtx != nil {
-					cmdCtx.ProxiedServerMode = true
-				}
-				if !quiet {
-					fmt.Fprintln(os.Stderr, "Preserving proxied-server mode from the existing .beads/metadata.json.")
 				}
 			}
 		}
@@ -2570,6 +2565,29 @@ func existingWorkspaceDoltMode() string {
 	// Matched case-insensitively by callers, mirroring configfile's own
 	// IsServerMode/IsProxiedServerMode comparisons.
 	return strings.ToLower(strings.TrimSpace(cfg.DoltMode))
+}
+
+// inheritWorkspaceDoltMode is the decision half of #3885's fix: what a bare
+// re-init adopts from the workspace it is re-initializing. It returns
+// inheritServer=true when the workspace records server mode.
+//
+// Proxied-server is deliberately an error, not an inheritance: the dedicated
+// proxied init path (runInitProxiedServer) dispatches on the explicit flag
+// BEFORE the inheritance point in RunE, so inheriting by mutating only the
+// process-mode globals would build the database embedded while metadata.json
+// kept claiming proxied-server — the exact silent mismatch inheritance exists
+// to prevent. The mode is experimental and dark-launched; a re-init of such a
+// workspace must name it explicitly so it routes through the real init path.
+func inheritWorkspaceDoltMode() (bool, error) {
+	switch existingWorkspaceDoltMode() {
+	case configfile.DoltModeServer:
+		return true, nil
+	case configfile.DoltModeProxiedServer:
+		return false, fmt.Errorf("this workspace is recorded as proxied-server in .beads/metadata.json; " +
+			"re-run with --proxied-server to keep it, or name another mode explicitly to change it")
+	default:
+		return false, nil
+	}
 }
 
 // initModeExplicitlyRequested reports whether this invocation names a

--- a/cmd/bd/init.go
+++ b/cmd/bd/init.go
@@ -538,6 +538,41 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 			// Non-fatal - continue with defaults
 		}
 
+		// Re-init inherits the existing workspace's connection mode (#3885).
+		//
+		// This must be seeded HERE, with the other mode sources, not patched
+		// onto cfg.DoltMode where it is persisted further down: everything
+		// between the two points — which engine init opens, which database
+		// name rules apply, where the data lands — reads the process mode. A
+		// late fixup would write "server" into metadata.json describing a
+		// database that init had just built embedded, trading a silent
+		// downgrade for a silent mismatch.
+		//
+		// Only applies when this invocation names no mode of its own, so an
+		// explicit --server/--shared-server/--proxied-server, the BEADS_DOLT_*
+		// env vars, and a global dolt.mode all still win.
+		if !initServerMode && !initModeExplicitlyRequested(cmd) {
+			switch existingWorkspaceDoltMode() {
+			case configfile.DoltModeServer:
+				initServerMode = true
+				serverMode = true
+				if cmdCtx != nil {
+					cmdCtx.ServerMode = true
+				}
+				if !quiet {
+					fmt.Fprintln(os.Stderr, "Preserving server mode from the existing .beads/metadata.json.")
+				}
+			case configfile.DoltModeProxiedServer:
+				proxiedServerMode = true
+				if cmdCtx != nil {
+					cmdCtx.ProxiedServerMode = true
+				}
+				if !quiet {
+					fmt.Fprintln(os.Stderr, "Preserving proxied-server mode from the existing .beads/metadata.json.")
+				}
+			}
+		}
+
 		// config.yaml fallback for dolt.mode: if --server wasn't passed and
 		// env var didn't set it, check config.yaml for dolt.mode: server.
 		if !initServerMode {
@@ -1444,6 +1479,10 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 				}
 
 				// Persist the connection mode matching this build.
+				priorMode := ""
+				if existingCfg != nil {
+					priorMode = strings.ToLower(strings.TrimSpace(existingCfg.DoltMode))
+				}
 				switch {
 				case usesProxiedServer():
 					cfg.DoltMode = configfile.DoltModeProxiedServer
@@ -1451,6 +1490,17 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 					cfg.DoltMode = configfile.DoltModeServer
 				default:
 					cfg.DoltMode = configfile.DoltModeEmbedded
+				}
+				// A mode change on an existing workspace is never silent
+				// (#3885). By this point the inheritance above has already
+				// preserved the old mode unless something explicitly asked to
+				// change it, so reaching here with a different mode means the
+				// user asked — but they still get told, because the change
+				// rewrites where this project's data lives.
+				if priorMode != "" && priorMode != cfg.DoltMode && !quiet {
+					fmt.Fprintf(os.Stderr,
+						"Connection mode changed: %s -> %s (recorded in .beads/metadata.json).\n",
+						priorMode, cfg.DoltMode)
 				}
 
 				if !usesProxiedServer() {
@@ -2499,6 +2549,56 @@ func existingWorkspaceDBName() string {
 		return ""
 	}
 	return cfg.DoltDatabase
+}
+
+// existingWorkspaceDoltMode returns the connection mode recorded in the
+// already-initialized workspace's metadata.json, or "" if there is none.
+//
+// Like existingWorkspaceDBName it reads the raw field rather than a getter: a
+// getter that defaults to embedded would make "no recorded mode" and
+// "deliberately embedded" indistinguishable, and this value is used to decide
+// whether a re-init is about to change modes.
+func existingWorkspaceDoltMode() string {
+	beadsDir := resolveInitBeadsDir()
+	if beadsDir == "" {
+		return ""
+	}
+	cfg, err := configfile.Load(beadsDir)
+	if err != nil || cfg == nil {
+		return ""
+	}
+	// Matched case-insensitively by callers, mirroring configfile's own
+	// IsServerMode/IsProxiedServerMode comparisons.
+	return strings.ToLower(strings.TrimSpace(cfg.DoltMode))
+}
+
+// initModeExplicitlyRequested reports whether this invocation names a
+// connection mode of its own, as opposed to falling back to the build default.
+//
+// Only an explicit request may change an existing workspace's mode. Without
+// this distinction a bare `bd init --from-jsonl --reinit-local` on a
+// server-mode project runs embedded and rewrites dolt_mode to embedded, which
+// is #3885: the project comes back half-configured and the user is told
+// nothing.
+func initModeExplicitlyRequested(cmd *cobra.Command) bool {
+	for _, name := range []string{"server", "shared-server", "proxied-server"} {
+		if f := cmd.Flags().Lookup(name); f != nil && f.Changed {
+			return true
+		}
+	}
+	for _, env := range []string{
+		"BEADS_DOLT_SERVER_MODE",
+		"BEADS_DOLT_SHARED_SERVER",
+		"BEADS_DOLT_PROXIED_SERVER",
+	} {
+		if os.Getenv(env) != "" {
+			return true
+		}
+	}
+	// A global config.yaml `dolt.mode` is a deliberate statement about this
+	// machine, so it counts as explicit too — the seeding block above already
+	// treats it like --server.
+	return config.GetYamlConfig("dolt.mode") != ""
 }
 
 func checkExistingBeadsData(prefix string) error {

--- a/cmd/bd/init_mode_inherit_test.go
+++ b/cmd/bd/init_mode_inherit_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/spf13/cobra"
@@ -135,4 +136,53 @@ func TestInitModeExplicitlyRequested(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestInheritWorkspaceDoltMode covers the decision the RunE inheritance block
+// applies — the composition a helper-only test suite would miss (#3885 review).
+// The proxied-server case is the load-bearing one: the proxied init path
+// dispatches on the explicit flag before the inheritance point, so "inherit"
+// there would build embedded data under proxied-server metadata. It must
+// refuse instead.
+func TestInheritWorkspaceDoltMode(t *testing.T) {
+	t.Run("server mode is inherited", func(t *testing.T) {
+		writeWorkspaceMode(t, configfile.DoltModeServer)
+		inheritServer, err := inheritWorkspaceDoltMode()
+		if err != nil {
+			t.Fatalf("inheritWorkspaceDoltMode() error: %v", err)
+		}
+		if !inheritServer {
+			t.Error("server-mode workspace was not inherited")
+		}
+	})
+
+	t.Run("embedded mode inherits nothing", func(t *testing.T) {
+		writeWorkspaceMode(t, configfile.DoltModeEmbedded)
+		inheritServer, err := inheritWorkspaceDoltMode()
+		if err != nil || inheritServer {
+			t.Errorf("embedded workspace: got (%v, %v), want (false, nil)", inheritServer, err)
+		}
+	})
+
+	t.Run("missing workspace inherits nothing", func(t *testing.T) {
+		t.Setenv("BEADS_DIR", filepath.Join(t.TempDir(), "nope", ".beads"))
+		inheritServer, err := inheritWorkspaceDoltMode()
+		if err != nil || inheritServer {
+			t.Errorf("missing workspace: got (%v, %v), want (false, nil)", inheritServer, err)
+		}
+	})
+
+	t.Run("proxied-server refuses rather than silently building embedded", func(t *testing.T) {
+		writeWorkspaceMode(t, configfile.DoltModeProxiedServer)
+		inheritServer, err := inheritWorkspaceDoltMode()
+		if inheritServer {
+			t.Fatal("proxied-server workspace was inherited as server mode")
+		}
+		if err == nil {
+			t.Fatal("proxied-server workspace did not refuse; a bare re-init would build embedded data under proxied-server metadata")
+		}
+		if !strings.Contains(err.Error(), "--proxied-server") {
+			t.Errorf("refusal does not tell the user how to proceed: %v", err)
+		}
+	})
 }

--- a/cmd/bd/init_mode_inherit_test.go
+++ b/cmd/bd/init_mode_inherit_test.go
@@ -1,0 +1,138 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/steveyegge/beads/internal/configfile"
+)
+
+// writeWorkspaceMode lays down a .beads/metadata.json recording mode and
+// points BEADS_DIR at it, which is what resolveInitBeadsDir consults first.
+func writeWorkspaceMode(t *testing.T, mode string) string {
+	t.Helper()
+	beadsDir := filepath.Join(t.TempDir(), ".beads")
+	if err := os.MkdirAll(beadsDir, 0o755); err != nil {
+		t.Fatalf("mkdir .beads: %v", err)
+	}
+	body := map[string]string{"dolt_mode": mode, "dolt_database": "proj"}
+	blob, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("marshal metadata: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(beadsDir, "metadata.json"), blob, 0o644); err != nil {
+		t.Fatalf("write metadata.json: %v", err)
+	}
+	t.Setenv("BEADS_DIR", beadsDir)
+	return beadsDir
+}
+
+// TestExistingWorkspaceDoltModeReadsRawField is the input half of #3885: the
+// re-init path could not see the existing mode at all, because nothing read it.
+func TestExistingWorkspaceDoltModeReadsRawField(t *testing.T) {
+	for _, tc := range []struct {
+		written string
+		want    string
+	}{
+		{configfile.DoltModeServer, configfile.DoltModeServer},
+		{configfile.DoltModeProxiedServer, configfile.DoltModeProxiedServer},
+		{configfile.DoltModeEmbedded, configfile.DoltModeEmbedded},
+		// Case and whitespace are normalized, matching configfile's own
+		// IsServerMode comparison.
+		{"  SERVER  ", configfile.DoltModeServer},
+		// Unset must stay distinguishable from "deliberately embedded";
+		// defaulting here would make every fresh init look like a mode change.
+		{"", ""},
+	} {
+		t.Run("mode="+tc.written, func(t *testing.T) {
+			writeWorkspaceMode(t, tc.written)
+			if got := existingWorkspaceDoltMode(); got != tc.want {
+				t.Errorf("existingWorkspaceDoltMode() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestExistingWorkspaceDoltModeMissingWorkspace(t *testing.T) {
+	t.Setenv("BEADS_DIR", filepath.Join(t.TempDir(), "nope", ".beads"))
+	if got := existingWorkspaceDoltMode(); got != "" {
+		t.Errorf("existingWorkspaceDoltMode() = %q on a missing workspace, want \"\"", got)
+	}
+}
+
+// newModeFlagCmd mirrors the mode-bearing flags init registers.
+func newModeFlagCmd() *cobra.Command {
+	c := &cobra.Command{Use: "init"}
+	c.Flags().Bool("server", false, "")
+	c.Flags().Bool("shared-server", false, "")
+	c.Flags().Bool("proxied-server", false, "")
+	return c
+}
+
+// TestInitModeExplicitlyRequested is the decision half: only an explicit
+// request may change an existing workspace's mode. Get this wrong in the
+// permissive direction and #3885 comes straight back — a bare re-init would
+// once again count as "the user asked for embedded".
+func TestInitModeExplicitlyRequested(t *testing.T) {
+	// Neutralize ambient signals; these tests are about the flags.
+	clearModeEnv := func(t *testing.T) {
+		t.Helper()
+		for _, e := range []string{
+			"BEADS_DOLT_SERVER_MODE",
+			"BEADS_DOLT_SHARED_SERVER",
+			"BEADS_DOLT_PROXIED_SERVER",
+		} {
+			t.Setenv(e, "")
+		}
+	}
+
+	t.Run("bare invocation is not explicit", func(t *testing.T) {
+		clearModeEnv(t)
+		if initModeExplicitlyRequested(newModeFlagCmd()) {
+			t.Error("a bare `bd init` counted as an explicit mode request; a re-init would silently rewrite the mode")
+		}
+	})
+
+	for _, flag := range []string{"server", "shared-server", "proxied-server"} {
+		t.Run("--"+flag+" is explicit", func(t *testing.T) {
+			clearModeEnv(t)
+			c := newModeFlagCmd()
+			if err := c.Flags().Set(flag, "true"); err != nil {
+				t.Fatalf("set --%s: %v", flag, err)
+			}
+			if !initModeExplicitlyRequested(c) {
+				t.Errorf("--%s was not treated as an explicit mode request", flag)
+			}
+		})
+	}
+
+	// A flag set to its default value still counts: the user typed it.
+	t.Run("--server=false is still explicit", func(t *testing.T) {
+		clearModeEnv(t)
+		c := newModeFlagCmd()
+		if err := c.Flags().Set("server", "false"); err != nil {
+			t.Fatalf("set --server=false: %v", err)
+		}
+		if !initModeExplicitlyRequested(c) {
+			t.Error("--server=false was ignored; an explicit downgrade request must not be overridden by inheritance")
+		}
+	})
+
+	for _, env := range []string{
+		"BEADS_DOLT_SERVER_MODE",
+		"BEADS_DOLT_SHARED_SERVER",
+		"BEADS_DOLT_PROXIED_SERVER",
+	} {
+		t.Run(env+" is explicit", func(t *testing.T) {
+			clearModeEnv(t)
+			t.Setenv(env, "1")
+			if !initModeExplicitlyRequested(newModeFlagCmd()) {
+				t.Errorf("%s was not treated as an explicit mode request", env)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #3885.

## Why

`bd init --from-jsonl --reinit-local` (and `--force`, its deprecated alias) on a server-mode project brings it back as **embedded**, silently. @vbtcl reported this in May with a concrete repro; the issue's timeline is empty and nothing has touched it since.

The mechanism, at `cmd/bd/init.go`:

```go
// Persist the connection mode matching this build.
switch {
case usesProxiedServer(): cfg.DoltMode = configfile.DoltModeProxiedServer
case usesSQLServer():     cfg.DoltMode = configfile.DoltModeServer
default:                  cfg.DoltMode = configfile.DoltModeEmbedded
}
```

This runs *after* the existing `metadata.json` has been loaded into `cfg`, and unconditionally overwrites the mode. The globals behind `usesSQLServer()` / `usesProxiedServer()` are seeded only from `--server`, the `BEADS_DOLT_*` env vars, or the **global** `config.yaml` `dolt.mode` key — never from `existingCfg.DoltMode`. Grepping every `DoltMode` occurrence in `init.go` finds writes plus that one YAML lookup and no read of the existing workspace value.

So re-running init without re-passing `--server` writes `dolt_mode: embedded` over a server config. The user is told nothing, and the project comes back half-configured.

(The narrower `--shared-server` propagation fix noted at `init.go:471-473` for #2946 does not cover this case.)

## The fix, and why it goes where it does

The mode is now inherited from the existing workspace **at the seeding block, alongside the other mode sources** — not patched onto `cfg.DoltMode` at the persistence point.

That placement is the whole point. Everything between the two — which engine init opens, which database-name rules apply (`init.go:552-558`), where the data actually lands — reads the *process* mode. Patching only the persisted value would write `server` into `metadata.json` describing a database init had just built embedded: a silent downgrade traded for a silent mismatch, where the next open fails instead.

Inheritance applies **only when the invocation names no mode of its own**, so everything explicit still wins:

| signal | wins over inheritance? |
|---|---|
| `--server`, `--shared-server`, `--proxied-server` | yes |
| `BEADS_DOLT_SERVER_MODE`, `BEADS_DOLT_SHARED_SERVER`, `BEADS_DOLT_PROXIED_SERVER` | yes |
| global `config.yaml` `dolt.mode` | yes (the seeding block already treats it like `--server`) |
| nothing named | **inherit the workspace's recorded mode** |

A flag set explicitly to its default counts as explicit too — `--server=false` is the user typing a downgrade, and `f.Changed` catches it. There is no `--embedded` flag today, so this is currently the only way to state one; if you would like a real `--embedded`, say so and I will add it here or in a follow-up.

Any actual mode change on an existing workspace is now announced on stderr naming both modes, since it moves where the project's data lives.

Two helpers, both mirroring the established shape of `existingWorkspaceDBName()` right beside them:

- `existingWorkspaceDoltMode()` reads the **raw** `DoltMode` field (normalized for case/whitespace like `configfile`'s own `IsServerMode`). Unset stays distinguishable from "deliberately embedded" — defaulting here would make every fresh init look like a mode change.
- `initModeExplicitlyRequested(cmd)` is the flag/env/config decision, kept pure enough to table-test.

## Tests

`cmd/bd/init_mode_inherit_test.go`:

- `TestExistingWorkspaceDoltModeReadsRawField` — server / proxied-server / embedded / case-and-space normalization / unset-stays-unset.
- `TestExistingWorkspaceDoltModeMissingWorkspace` — no workspace ⇒ `""`, not a phantom default.
- `TestInitModeExplicitlyRequested` — each flag, each env var, `--server=false`, and the case that matters most: **a bare invocation is not an explicit request**. Get that one wrong in the permissive direction and #3885 comes straight back, because a bare re-init would again count as "the user asked for embedded".

## A note on local validation

The pre-existing `cmd/bd` init suite cannot be meaningfully run from a worktree nested under another beads workspace: those tests resolve the ambient `.beads` and fail with `Found existing Dolt database: .../.beads/embeddeddolt/...`. I checked that baseline on **unmodified `upstream/main`** in the same layout and got the identical failure set before concluding this change is clean. `go build ./...`, `go vet ./cmd/bd`, and the new tests all pass; full `make test` is in my local verification queue and I will report the result here.

This is worth knowing independently of this PR — it makes the init suite effectively CI-only for anyone whose checkout sits inside another beads project.

## Scope

This is the config half of the re-init problem. The data half — that JSONL is a deliberate subset (wisps, events/history, memories unless `--all`) while the destructive prompt only says "this will destroy the existing database" — is #3884 and is deliberately not in this PR.

_claude-opus-5-medium on behalf of maphew_
