### PR TITLE
fix(schema): stop believing an ignored-migration cursor the schema contradicts (#5033)

### DIFF
--- a/internal/storage/schema/aux_row_id_backfill_test.go
+++ b/internal/storage/schema/aux_row_id_backfill_test.go
@@ -201,6 +201,7 @@ func TestRekeyAuxRowIDsSkipsWhenMarkerRecorded(t *testing.T) {
 
 	expectScalar(mock, "SELECT COALESCE(MAX(version), 0) FROM ignored_schema_migrations",
 		"version", auxRekeyPassInitial.markerVersion)
+	expectIgnoredSentinelProbes(mock, true)
 	// No further expectations: no table may be probed or scanned.
 
 	wrote, err := rekeyAuxRowIDs(context.Background(), db, auxRekeyPassInitial.shippedMainVersion-1, auxRekeyPassInitial)
@@ -226,6 +227,7 @@ func TestRekeyAuxRowIDsRunsAllTablesWhenMarkerPending(t *testing.T) {
 
 	expectScalar(mock, "SELECT COALESCE(MAX(version), 0) FROM ignored_schema_migrations",
 		"version", auxRekeyPassInitial.markerVersion-1)
+	expectIgnoredSentinelProbes(mock, true)
 	expectAuxRekeySentinel(mock, false)
 	expectSetAuxRekeySentinel(mock)
 	// Each of the four tables is probed; this mocked world has none of them,
@@ -291,6 +293,7 @@ func TestRekeyAuxRowIDsSkipsConvergedLineage(t *testing.T) {
 
 	expectScalar(mock, "SELECT COALESCE(MAX(version), 0) FROM ignored_schema_migrations",
 		"version", auxRekeyPassInitial.markerVersion-1)
+	expectIgnoredSentinelProbes(mock, true)
 	expectAuxRekeySentinel(mock, false)
 	// No further expectations: marker is pending, but the pre-pass main
 	// cursor at the watershed and no crash sentinel means no table may be
@@ -323,6 +326,7 @@ func TestRekeyAuxRowIDsResumesAfterCrash(t *testing.T) {
 
 	expectScalar(mock, "SELECT COALESCE(MAX(version), 0) FROM ignored_schema_migrations",
 		"version", auxRekeyPassInitial.markerVersion-1)
+	expectIgnoredSentinelProbes(mock, true)
 	expectAuxRekeySentinel(mock, true)
 	expectSetAuxRekeySentinel(mock)
 	for range auxRekeyTables {
@@ -352,6 +356,7 @@ func TestRekeyAuxRowIDsKeepsSentinelOnFailure(t *testing.T) {
 
 	expectScalar(mock, "SELECT COALESCE(MAX(version), 0) FROM ignored_schema_migrations",
 		"version", auxRekeyPassInitial.markerVersion-1)
+	expectIgnoredSentinelProbes(mock, true)
 	expectAuxRekeySentinel(mock, false)
 	expectSetAuxRekeySentinel(mock)
 	// First table probe fails; no DELETE of the sentinel may follow.

--- a/internal/storage/schema/content_hash_test.go
+++ b/internal/storage/schema/content_hash_test.go
@@ -111,6 +111,7 @@ func TestMigrationWorkNeededAddsContentHashColumnOnUpToDateDB(t *testing.T) {
 	// Both sources are already at their latest version...
 	expectScalar(mock, "SELECT COALESCE(MAX(version), 0) FROM schema_migrations", "version", LatestVersion())
 	expectScalar(mock, "SELECT COALESCE(MAX(version), 0) FROM ignored_schema_migrations", "version", LatestIgnoredVersion())
+	expectIgnoredSentinelProbes(mock, true)
 	// ...but schema_migrations predates the content_hash column.
 	mock.ExpectQuery(`SHOW COLUMNS FROM schema_migrations LIKE 'content_hash'`).
 		WillReturnRows(showColumnsRows())
@@ -140,6 +141,7 @@ func TestMigrationWorkNotNeededWhenContentHashColumnsPresent(t *testing.T) {
 
 	expectScalar(mock, "SELECT COALESCE(MAX(version), 0) FROM schema_migrations", "version", LatestVersion())
 	expectScalar(mock, "SELECT COALESCE(MAX(version), 0) FROM ignored_schema_migrations", "version", LatestIgnoredVersion())
+	expectIgnoredSentinelProbes(mock, true)
 	mock.ExpectQuery(`SHOW COLUMNS FROM schema_migrations LIKE 'content_hash'`).
 		WillReturnRows(showColumnsRows("content_hash"))
 	mock.ExpectQuery(`SHOW COLUMNS FROM ignored_schema_migrations LIKE 'content_hash'`).

--- a/internal/storage/schema/cursor_reality_test.go
+++ b/internal/storage/schema/cursor_reality_test.go
@@ -1,0 +1,180 @@
+package schema
+
+import (
+	"context"
+	"errors"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+)
+
+// stubSentinelTables replaces the INFORMATION_SCHEMA probe with a fixed answer
+// for the duration of a test, following the issueRowCounter seam convention in
+// this package. The DBConn is never touched, so these run with no database.
+func stubSentinelTables(t *testing.T, present map[string]bool, probeErr error) *[]string {
+	t.Helper()
+	var probed []string
+	orig := sentinelTableExists
+	t.Cleanup(func() { sentinelTableExists = orig })
+	sentinelTableExists = func(_ context.Context, _ DBConn, table string) (bool, error) {
+		probed = append(probed, table)
+		if probeErr != nil {
+			return false, probeErr
+		}
+		return present[table], nil
+	}
+	return &probed
+}
+
+// TestCursorContradictedBySchema is the gh 5033 / gh 4356 regression: the
+// cursor is a claim about the schema, and a claim the schema contradicts must
+// not be believed. Before this, a database whose clone-local wisp tables were
+// absent but whose (also clone-local) cursor rows survived reported at-latest,
+// migrationWorkNeeded() short-circuited, the ignored series never re-ran, and
+// the damage surfaced much later as "table not found: wisp_dependencies".
+func TestCursorContradictedBySchema(t *testing.T) {
+	ctx := context.Background()
+
+	for _, tc := range []struct {
+		name    string
+		present map[string]bool
+		want    bool
+	}{
+		{
+			name:    "no wisp tables at all",
+			present: map[string]bool{},
+			want:    true,
+		},
+		{
+			// Partial materialization must count as contradicted; checking
+			// only the first sentinel would miss exactly gh 5033's shape,
+			// where wisp_dependencies is the missing one.
+			name:    "wisps present, wisp_dependencies absent",
+			present: map[string]bool{"wisps": true},
+			want:    true,
+		},
+		{
+			name:    "wisp_dependencies present, wisps absent",
+			present: map[string]bool{"wisp_dependencies": true},
+			want:    true,
+		},
+		{
+			name:    "schema corroborates the cursor",
+			present: map[string]bool{"wisps": true, "wisp_dependencies": true},
+			want:    false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			stubSentinelTables(t, tc.present, nil)
+			got, err := ignoredSource.cursorContradictedBySchema(ctx, nil)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("cursorContradictedBySchema = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// A probe failure must not be laundered into "contradicted" — that would
+// re-run the whole series on a database whose state could not be read.
+func TestCursorProbeErrorIsNotTreatedAsContradicted(t *testing.T) {
+	boom := errors.New("information_schema unavailable")
+	stubSentinelTables(t, nil, boom)
+
+	got, err := ignoredSource.cursorContradictedBySchema(context.Background(), nil)
+	if !errors.Is(err, boom) {
+		t.Errorf("probe error was swallowed: err = %v", err)
+	}
+	if got {
+		t.Error("an unreadable probe reported the cursor as contradicted")
+	}
+}
+
+// The main series is deliberately unguarded: its tables are not clone-local,
+// so it cannot reach the contradicted state, and probing would add queries to
+// every store open for nothing. cursorContradictedBySchema must be a no-op for
+// it — including never probing.
+func TestMainSourceIsNotProbed(t *testing.T) {
+	probed := stubSentinelTables(t, map[string]bool{}, nil)
+
+	got, err := mainSource.cursorContradictedBySchema(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got {
+		t.Error("mainSource reported contradicted; it has no sentinels and must never be")
+	}
+	if len(*probed) != 0 {
+		t.Errorf("mainSource probed %v; it was deliberately left unguarded", *probed)
+	}
+	if len(ignoredSource.sentinelTables) == 0 {
+		t.Error("ignoredSource has no sentinel tables; the gh 5033 guard is inert")
+	}
+}
+
+// TestSentinelTablesAreCreatedByTheSeries keeps the sentinel list honest. A
+// sentinel this series does not create could never be repaired by re-running
+// it, so the cursor would be rejected on every single open — turning a silent
+// wrong answer into a permanent re-migration loop.
+func TestSentinelTablesAreCreatedByTheSeries(t *testing.T) {
+	entries, err := ignoredSource.files.ReadDir(ignoredSource.dir)
+	if err != nil {
+		t.Fatalf("read %s: %v", ignoredSource.dir, err)
+	}
+	var all strings.Builder
+	for _, e := range entries {
+		blob, err := ignoredSource.files.ReadFile(ignoredSource.dir + "/" + e.Name())
+		if err != nil {
+			t.Fatalf("read %s: %v", e.Name(), err)
+		}
+		all.Write(blob)
+	}
+	body := all.String()
+
+	for _, table := range ignoredSource.sentinelTables {
+		// ignored/0001 builds each table as __temp__<name> and renames it into
+		// place only when <name> is absent, which is also why re-running the
+		// series repairs rather than clobbers.
+		if !strings.Contains(body, "__temp__"+table) {
+			t.Errorf("sentinel %q is never created by the %s series; re-running it could not repair that table",
+				table, ignoredSource.dir)
+		}
+	}
+}
+
+// TestMigrationWorkNeededWhenWispTablesAbsent is gh 5033 end to end, through
+// the real short-circuit that caused it. Both cursors read at-latest, so
+// before this change migrationWorkNeeded returned false, MigrateUp did
+// nothing, and the missing wisp tables were never recreated — the user met the
+// bug much later as "table not found: wisp_dependencies" on `bd close`.
+//
+// The first sentinel probe returning 0 is enough to decide, so exactly one
+// probe is expected: proving the check short-circuits is part of the contract,
+// since it runs on every store open.
+func TestMigrationWorkNeededWhenWispTablesAbsent(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	expectScalar(mock, "SELECT COALESCE(MAX(version), 0) FROM schema_migrations", "version", LatestVersion())
+	expectScalar(mock, "SELECT COALESCE(MAX(version), 0) FROM ignored_schema_migrations", "version", LatestIgnoredVersion())
+	mock.ExpectQuery(regexp.QuoteMeta("FROM INFORMATION_SCHEMA.TABLES")).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
+
+	needed, err := migrationWorkNeeded(context.Background(), db)
+	if err != nil {
+		t.Fatalf("migrationWorkNeeded: %v", err)
+	}
+	if !needed {
+		t.Fatal("migrationWorkNeeded = false with an at-latest cursor and no wisp tables; the ignored series would never re-run (gh 5033)")
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}

--- a/internal/storage/schema/cursor_reality_test.go
+++ b/internal/storage/schema/cursor_reality_test.go
@@ -178,3 +178,53 @@ func TestMigrationWorkNeededWhenWispTablesAbsent(t *testing.T) {
 		t.Fatalf("unmet expectations: %v", err)
 	}
 }
+
+// TestMigrateAppliesUnderContradictedCursor closes the loop the work-needed
+// test cannot: deciding "work needed" is worthless if the applier then
+// re-reads the cursor raw, believes it, and applies nothing — MigrateUp would
+// run its whole pass preamble on every store open, heal nothing, and repeat
+// forever. The applier must read through the same guarded currentVersion.
+//
+// The mock walks migrate() up to the first statement of ignored/0001 and fails
+// it with a distinctive error: reaching that statement at all proves the
+// contradicted cursor was disbelieved by the APPLIER (an at-latest raw read
+// would have returned "nothing to do" without touching migration SQL), and the
+// ordered expectations prove it happened via the sentinel probe.
+func TestMigrateAppliesUnderContradictedCursor(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	// migrate() preamble: cursor-table bootstrap, content_hash presence check.
+	mock.ExpectExec(regexp.QuoteMeta("CREATE TABLE IF NOT EXISTS ignored_schema_migrations")).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectQuery(regexp.QuoteMeta("SHOW COLUMNS FROM ignored_schema_migrations LIKE 'content_hash'")).
+		WillReturnRows(sqlmock.NewRows([]string{"Field", "Type", "Null", "Key", "Default", "Extra"}).
+			AddRow("content_hash", "char(64)", "YES", "", nil, ""))
+
+	// The guarded read: cursor claims at-latest, sentinel probe contradicts it.
+	expectScalar(mock, "SELECT COALESCE(MAX(version), 0) FROM ignored_schema_migrations", "version", LatestIgnoredVersion())
+	mock.ExpectQuery(regexp.QuoteMeta("FROM INFORMATION_SCHEMA.TABLES")).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
+
+	// The proof: the applier reaches ignored/0001's SQL. Fail it distinctively
+	// rather than mocking the whole series.
+	boom := errors.New("stop here: the applier disbelieved the cursor")
+	mock.ExpectExec(".*").WillReturnError(boom)
+
+	_, _, err = ignoredSource.migrate(context.Background(), db, 0)
+	if err == nil {
+		t.Fatal("migrate returned nil with a contradicted at-latest cursor; the applier believed the raw cursor and healed nothing (gh 5033)")
+	}
+	if !errors.Is(err, boom) {
+		t.Fatalf("migrate failed for another reason before applying: %v", err)
+	}
+	if !strings.Contains(err.Error(), "0001") {
+		t.Errorf("failure not attributed to the first ignored migration: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}

--- a/internal/storage/schema/lock_test.go
+++ b/internal/storage/schema/lock_test.go
@@ -278,7 +278,11 @@ func expectOnePendingMigration(t *testing.T, mock sqlmock.Sqlmock) {
 	mock.ExpectExec("(?s)^CREATE TABLE IF NOT EXISTS ignored_schema_migrations").
 		WillReturnResult(sqlmock.NewResult(0, 0))
 	expectContentHashColumnExists(mock)
+	// The applier reads the ignored cursor through the guarded currentVersion
+	// (gh 5033), so a non-zero cursor is followed by the sentinel probes here
+	// too, not just in migrationWorkNeeded.
 	expectScalar(mock, "SELECT COALESCE(MAX(version), 0) FROM ignored_schema_migrations", "version", latestIgnored)
+	expectIgnoredSentinelProbes(mock, true)
 	expectDoltStatusRows(mock)
 	expectDoltStatusRows(mock)
 	mock.ExpectQuery("(?s)SELECT t\\.TABLE_NAME\\s+FROM INFORMATION_SCHEMA\\.TABLES t").

--- a/internal/storage/schema/lock_test.go
+++ b/internal/storage/schema/lock_test.go
@@ -114,6 +114,7 @@ func TestMigrateUpSeedsIgnorePatternsWhenNoWorkNeeded(t *testing.T) {
 	// present, no custom backfill pending -> no work, MigrateUp short-circuits.
 	expectScalar(mock, "SELECT COALESCE(MAX(version), 0) FROM schema_migrations", "version", LatestVersion())
 	expectScalar(mock, "SELECT COALESCE(MAX(version), 0) FROM ignored_schema_migrations", "version", LatestIgnoredVersion())
+	expectIgnoredSentinelProbes(mock, true)
 	expectContentHashColumnExists(mock)
 	expectContentHashColumnExists(mock)
 	expectScalar(mock, "SELECT COUNT(*) FROM custom_types", "count", 1)
@@ -152,6 +153,7 @@ func TestMigrateUpSkipsSeedCommitWhenNothingChanged(t *testing.T) {
 	// migrationWorkNeeded: no work, MigrateUp short-circuits.
 	expectScalar(mock, "SELECT COALESCE(MAX(version), 0) FROM schema_migrations", "version", LatestVersion())
 	expectScalar(mock, "SELECT COALESCE(MAX(version), 0) FROM ignored_schema_migrations", "version", LatestIgnoredVersion())
+	expectIgnoredSentinelProbes(mock, true)
 	expectContentHashColumnExists(mock)
 	expectContentHashColumnExists(mock)
 	expectScalar(mock, "SELECT COUNT(*) FROM custom_types", "count", 1)
@@ -272,6 +274,7 @@ func expectOnePendingMigration(t *testing.T, mock sqlmock.Sqlmock) {
 	// rekeyAuxRowIDs reads the ignored cursor to see whether its clone-local
 	// marker is pending; at latest it is not, so the re-key no-ops.
 	expectScalar(mock, "SELECT COALESCE(MAX(version), 0) FROM ignored_schema_migrations", "version", latestIgnored)
+	expectIgnoredSentinelProbes(mock, true)
 	mock.ExpectExec("(?s)^CREATE TABLE IF NOT EXISTS ignored_schema_migrations").
 		WillReturnResult(sqlmock.NewResult(0, 0))
 	expectContentHashColumnExists(mock)
@@ -440,5 +443,20 @@ func TestMigrateUpWithLockFreshBootstrapHealResetsAndRetries(t *testing.T) {
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("unmet SQL expectations: %v", err)
+	}
+}
+
+// expectIgnoredSentinelProbes mocks the INFORMATION_SCHEMA lookups
+// currentVersion issues to confirm a non-zero ignored cursor against the
+// schema it claims (gh 5033). They fire only for a non-zero cursor, in
+// ignoredSource.sentinelTables order.
+func expectIgnoredSentinelProbes(mock sqlmock.Sqlmock, present bool) {
+	count := 0
+	if present {
+		count = 1
+	}
+	for range ignoredSource.sentinelTables {
+		mock.ExpectQuery(regexp.QuoteMeta("FROM INFORMATION_SCHEMA.TABLES")).
+			WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(count))
 	}
 }

--- a/internal/storage/schema/schema.go
+++ b/internal/storage/schema/schema.go
@@ -225,6 +225,11 @@ type migrationSource struct {
 	files       embed.FS
 	dir         string
 	cursorTable string
+	// sentinelTables are tables this series is responsible for creating. A
+	// non-zero cursor is only believed while they all exist: the cursor is a
+	// claim about the schema, and a claim contradicted by the schema is worth
+	// less than no claim at all. See cursorContradictedBySchema.
+	sentinelTables []string
 }
 
 var (
@@ -237,6 +242,11 @@ var (
 		files:       upIgnoredMigrations,
 		dir:         "migrations/ignored",
 		cursorTable: "ignored_schema_migrations",
+		// Created by ignored 0001 (the series' foundation) and required by
+		// the wisp write path. wisp_dependencies is the one gh 5033 reports
+		// missing; wisps is checked too so a partially materialized database
+		// is caught by whichever is absent.
+		sentinelTables: []string{"wisps", "wisp_dependencies"},
 	}
 )
 
@@ -1091,13 +1101,70 @@ func (m migrationSource) atLatest(ctx context.Context, db DBConn) bool {
 func (m migrationSource) currentVersion(ctx context.Context, db DBConn) (int, error) {
 	var current int
 	err := db.QueryRowContext(ctx, "SELECT COALESCE(MAX(version), 0) FROM "+m.cursorTable).Scan(&current)
-	if err == nil || err == sql.ErrNoRows {
-		return current, nil
+	if err != nil && err != sql.ErrNoRows {
+		if dberrors.IsTableNotExist(err) {
+			return 0, nil
+		}
+		return 0, fmt.Errorf("reading %s version: %w", m.cursorTable, err)
 	}
-	if dberrors.IsTableNotExist(err) {
+	if current == 0 {
 		return 0, nil
 	}
-	return 0, fmt.Errorf("reading %s version: %w", m.cursorTable, err)
+	// A missing cursor TABLE already meant "nothing applied". A cursor whose
+	// tables are absent means the same thing and was previously believed
+	// (gh 5033, gh 4356): ignored_schema_migrations is itself dolt-ignored and
+	// clone-local, so a database materialized out of band — table-by-table
+	// copy, dump restore, or a clone that picked up the cursor rows without
+	// the clone-local tables they describe — arrives claiming at-latest with
+	// no wisps tables. atLatest() then short-circuits migrationWorkNeeded()
+	// and the series never re-runs, surfacing much later and much further away
+	// as "table not found: wisp_dependencies" on `bd close`.
+	contradicted, cerr := m.cursorContradictedBySchema(ctx, db)
+	if cerr != nil {
+		return 0, cerr
+	}
+	if contradicted {
+		return 0, nil
+	}
+	return current, nil
+}
+
+// cursorContradictedBySchema reports whether this series' cursor claims work
+// that the schema does not corroborate.
+//
+// Returning "cursor is 0" rather than an error is deliberate: the series is
+// written to be re-runnable against a database that already has some of it.
+// migrations/ignored/0001 builds each table as __temp__<name> and then
+// `RENAME TABLE __temp__x TO x` only when x does not already exist, DROPping
+// the temp otherwise; later migrations gate their ALTERs on
+// INFORMATION_SCHEMA lookups. So re-running the series repairs the missing
+// tables and leaves existing data untouched — which is why this can heal
+// rather than merely diagnose.
+func (m migrationSource) cursorContradictedBySchema(ctx context.Context, db DBConn) (bool, error) {
+	for _, table := range m.sentinelTables {
+		present, err := sentinelTableExists(ctx, db, table)
+		if err != nil {
+			return false, fmt.Errorf("checking %s sentinel table %s: %w", m.cursorTable, table, err)
+		}
+		if !present {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// sentinelTableExists is a function variable for the same reason
+// issueRowCounter is: it lets the cursor-reality tests exercise the real
+// decision without a live database.
+var sentinelTableExists = func(ctx context.Context, db DBConn, table string) (bool, error) {
+	var n int
+	if err := db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES
+		 WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ?`,
+		table).Scan(&n); err != nil {
+		return false, err
+	}
+	return n > 0, nil
 }
 
 func (m migrationSource) pendingVersions(ctx context.Context, db DBConn) ([]int, error) {

--- a/internal/storage/schema/schema.go
+++ b/internal/storage/schema/schema.go
@@ -229,6 +229,13 @@ type migrationSource struct {
 	// non-zero cursor is only believed while they all exist: the cursor is a
 	// claim about the schema, and a claim contradicted by the schema is worth
 	// less than no claim at all. See cursorContradictedBySchema.
+	//
+	// INVARIANT: no future migration in this series may DROP or RENAME a
+	// sentinel. Older binaries in the field check their own sentinel list
+	// against the live schema, so removing one would make every healthy newer
+	// database read as "contradicted" to them and re-run their whole series.
+	// TestSentinelTablesAreCreatedByTheSeries enforces the creating side only;
+	// the dropping side is this comment.
 	sentinelTables []string
 }
 
@@ -1328,9 +1335,15 @@ func (m migrationSource) migrate(ctx context.Context, db DBConn, upTo int) (int,
 		target = upTo
 	}
 
-	var current int
-	if err := db.QueryRowContext(ctx, "SELECT COALESCE(MAX(version), 0) FROM "+m.cursorTable).Scan(&current); err != nil && err != sql.ErrNoRows {
-		return 0, columnAdded, fmt.Errorf("reading %s version: %w", m.cursorTable, err)
+	// The cursor is read through currentVersion, never raw: that is where the
+	// cursor-reality check lives (gh 5033). A raw read here would believe the
+	// contradicted cursor that migrationWorkNeeded just disbelieved — MigrateUp
+	// would decide "work needed" on every open, run the whole pass, and then
+	// apply nothing, leaving the missing tables missing and the pass to repeat
+	// forever. The heal only happens if the applier disbelieves the cursor too.
+	current, err := m.currentVersion(ctx, db)
+	if err != nil {
+		return 0, columnAdded, err
 	}
 
 	if current >= target {

--- a/internal/storage/schema/schema_test.go
+++ b/internal/storage/schema/schema_test.go
@@ -123,6 +123,7 @@ func TestIgnoredPendingMigrationDirtyTablesDetectsWispDependencies(t *testing.T)
 
 	mock.ExpectQuery(`SELECT COALESCE\(MAX\(version\), 0\) FROM ignored_schema_migrations`).
 		WillReturnRows(sqlmock.NewRows([]string{"version"}).AddRow(2))
+	expectIgnoredSentinelProbes(mock, true)
 
 	touched, err := ignoredSource.pendingMigrationDirtyTables(context.Background(), db, map[string]dirtyTableState{
 		"wisp_dependencies": {},


### PR DESCRIPTION
Fixes #5033. Same root cause as #4356.

## Why

`currentVersion()` already special-cases a **missing cursor table** as "nothing applied":

```go
if dberrors.IsTableNotExist(err) {
    return 0, nil
}
```

but it believed a cursor whose **tables** do not exist. `ignored_schema_migrations` is itself in `doltIgnorePatterns` — it is dolt-ignored and therefore clone-local, exactly like the wisp tables it tracks. So a database materialized out of band (table-by-table copy, dump restore, or a clone that picked up the cursor rows without the clone-local tables they describe) arrives claiming **at-latest with no wisps tables**.

From there:

`atLatest()` → true → `migrationWorkNeeded()` short-circuits → the ignored series never re-runs → the user meets it much later and much further away as **`table not found: wisp_dependencies`** on `bd close`. That is #5033 exactly. #4356 is the same root cause seen from the dirty-working-set side.

The cursor is a *claim about the schema*. A claim the schema contradicts is worth less than no claim at all.

## Why re-running repairs rather than clobbers

This is the part that makes healing possible instead of merely diagnosing, so it is worth stating explicitly: **the ignored series is written to be re-runnable.**

`migrations/ignored/0001_create_local_state_tables.up.sql` builds every table as `__temp__<name>`, then:

```sql
SET @sql = IF(@exists = 0, 'RENAME TABLE __temp__wisps TO wisps', 'DROP TABLE __temp__wisps');
```

— it renames into place only when the real table is absent, and drops its temp otherwise. Later migrations gate their `ALTER`s on `INFORMATION_SCHEMA` lookups (e.g. `0003`, `0006`). So a re-run recreates what is missing and leaves existing data untouched.

`TestSentinelTablesAreCreatedByTheSeries` pins this: a sentinel the series cannot create would reject the cursor on *every* open forever, turning a silent wrong answer into a permanent re-migration loop.

## Scope, deliberately narrow

| decision | why |
|---|---|
| only the **ignored** series is guarded (`wisps`, `wisp_dependencies`) | the main series' tables are not clone-local and cannot reach this state; probing it would add two queries to every store open for nothing. `TestMainSourceIsNotProbed` pins that it is never probed. |
| probe skipped entirely for a **zero cursor** | no added cost on databases with nothing applied |
| **both** sentinels checked, not just the first | #5033's actual shape is `wisp_dependencies` missing while `wisps` exists |
| a probe **error** propagates, never becomes "contradicted" | re-running the series on a database whose state could not be read is the one outcome worse than the bug |

The `INFORMATION_SCHEMA` lookup sits behind the `sentinelTableExists` function variable, following this package's existing `issueRowCounter` seam convention, so the decision is testable without a live database.

## Tests

New `internal/storage/schema/cursor_reality_test.go`:

- `TestCursorContradictedBySchema` — no tables / `wisps` only / `wisp_dependencies` only / both present.
- `TestCursorProbeErrorIsNotTreatedAsContradicted` — an unreadable probe must not trigger a re-migration.
- `TestMainSourceIsNotProbed` — the main series is never probed, and the ignored guard is not inert.
- `TestSentinelTablesAreCreatedByTheSeries` — the sentinel list stays repairable-by-re-run.
- `TestMigrationWorkNeededWhenWispTablesAbsent` — **the end-to-end assertion**: both cursors read at-latest, no wisp tables, `migrationWorkNeeded` must now return `true`. This is the exact short-circuit that produced #5033. It also asserts only one probe is issued, since the check runs on every store open.

Several existing sqlmock tests assert exact query ordering, so the ones whose flow now issues sentinel probes gained an `expectIgnoredSentinelProbes()` expectation (new helper beside `expectScalar` in `lock_test.go`). **No existing assertion was weakened or removed** — the additions are purely the two new queries.

`go build ./...`, `go vet ./internal/storage/schema`, and the full `./internal/storage/schema` package are green. I confirmed the package was green on unmodified `upstream/main` first, so that baseline is real rather than assumed. Full `make test` is in my local verification queue and I will report the result here.

## Not addressed

The bead this came from also notes there is **no self-heal for the mirror-image state** — a cursor that is missing rows for migrations that *were* applied — and no `DOLT_RM`-based reassertion anywhere. This PR only fixes the direction that causes #5033 and #4356. Whether the cursor should be reconciled against the schema in both directions is a larger question I have deliberately left alone.

_claude-opus-5-medium on behalf of maphew_
