### PR TITLE
fix(comments): preserve unquoted multi-word text

### DIFF
--- a/cmd/bd/comment_proxied_integration_test.go
+++ b/cmd/bd/comment_proxied_integration_test.go
@@ -193,7 +193,7 @@ func TestProxiedServerComment(t *testing.T) {
 		p := newSharedProxiedProject(t, bd, "aj")
 		issue := bdProxiedCreate(t, bd, p.dir, "Add JSON")
 
-		stdout, stderr, err := bdProxiedRunBuffers(t, bd, p.dir, "comments", "add", issue.ID, "add json body", "--json")
+		stdout, stderr, err := bdProxiedRunBuffers(t, bd, p.dir, "comments", "add", issue.ID, "add", "json", "body", "--json")
 		if err != nil {
 			t.Fatalf("comments add --json failed: %v\nstderr:\n%s", err, stderr)
 		}

--- a/cmd/bd/comments.go
+++ b/cmd/bd/comments.go
@@ -164,7 +164,7 @@ See: bd comments --help`)
 }
 
 var commentsAddCmd = &cobra.Command{
-	Use:   "add [issue-id] [text]",
+	Use:   "add [issue-id] [text...]",
 	Short: "Add a comment to an issue",
 	Long: `Add a comment to an issue.
 
@@ -203,7 +203,7 @@ Examples:
 		} else if len(args) < 2 {
 			return HandleErrorRespectJSON("comment text required (use -f to read from file)")
 		} else {
-			commentText = args[1]
+			commentText = strings.Join(args[1:], " ")
 		}
 
 		if strings.TrimSpace(commentText) == "" {

--- a/cmd/bd/comments_cli_embedded_test.go
+++ b/cmd/bd/comments_cli_embedded_test.go
@@ -48,7 +48,7 @@ func TestEmbeddedCommentsCLI(t *testing.T) {
 
 	t.Run("comments_add_json", func(t *testing.T) {
 		issue := bdCreate(t, bd, dir, "JSON comment", "--type", "task")
-		cmd := exec.Command(bd, "comments", "add", issue.ID, "JSON comment text", "--json")
+		cmd := exec.Command(bd, "comments", "add", issue.ID, "JSON", "comment", "text", "--json")
 		cmd.Dir = dir
 		cmd.Env = bdEnv(dir)
 		stdout, stderr, err := runCommandBuffers(t, cmd)

--- a/cmd/bd/comments_proxied_server.go
+++ b/cmd/bd/comments_proxied_server.go
@@ -127,7 +127,7 @@ func runCommentsAddProxiedServer(cmd *cobra.Command, ctx context.Context, args [
 	} else if len(args) < 2 {
 		return HandleErrorRespectJSON("comment text required (use -f to read from file)")
 	} else {
-		commentText = args[1]
+		commentText = strings.Join(args[1:], " ")
 	}
 
 	if strings.TrimSpace(commentText) == "" {


### PR DESCRIPTION
## What

Preserve every positional word passed to `bd comments add` in both direct and proxied-server modes. The command usage now documents the variadic text argument as `[text...]`.

## Why

The command accepted multiple text arguments but persisted only `args[1]`. An invocation such as `bd comments add bd-123 Working on this now` therefore stored only `Working` and still exited successfully. This change matches the existing behavior of the `bd comment` shorthand.

## Impact

Unquoted multi-word comments now round-trip without truncation. Quoted text and `--file` input keep their existing behavior.

## Verification

- `BEADS_TEST_EMBEDDED_DOLT=1 CGO_ENABLED=1 go test -tags gms_pure_go ./cmd/bd -run '^TestEmbeddedCommentsCLI$/^comments_add_json$' -count=1`
- `BEADS_TEST_PROXIED_SERVER=1 CGO_ENABLED=1 go test -tags gms_pure_go ./cmd/bd -run '^TestProxiedServerComment$/^comments_add_json$' -count=1`
- `make test`
- `golangci-lint run --config=.golangci.yml --modules-download-mode=readonly --timeout=5m --build-tags=gms_pure_go ./cmd/bd`
- `GOOS=windows GOARCH=amd64 CGO_ENABLED=0 GOWORK=off golangci-lint run --config=.golangci.yml --modules-download-mode=readonly --timeout=5m --build-tags=gms_pure_go ./cmd/bd`
