### PR TITLE
feat(dolt): bd dolt remote reset-data — replace a remote's data plane after a history squash

### DIFF
--- a/cmd/bd/dolt.go
+++ b/cmd/bd/dolt.go
@@ -1561,9 +1561,10 @@ var doltRemoteCmd = &cobra.Command{
 	Long: `Manage Dolt remotes for push/pull replication.
 
 Subcommands:
-  add <name> <url>   Add a new remote
-  list               List all configured remotes
-  remove <name>      Remove a remote`,
+  add <name> <url>     Add a new remote
+  list                 List all configured remotes
+  remove <name>        Remove a remote
+  reset-data <name>    Replace a remote's data plane after a history squash`,
 }
 
 var doltRemoteAddCmd = &cobra.Command{
@@ -1777,9 +1778,11 @@ func init() {
 	doltCleanDatabasesCmd.Flags().Bool("dry-run", false, "Show what would be dropped without dropping")
 	doltCleanDatabasesCmd.Flags().Bool("purge-dropped", false, "After dropping, also run CALL DOLT_PURGE_DROPPED_DATABASES() — server-global and irreversible, see --help")
 	doltRemoteAddCmd.Flags().Bool("allow-git-origin", false, "Allow adding a Dolt remote whose URL matches the git origin (proceed with a warning instead of aborting)")
+	doltRemoteResetDataCmd.Flags().BoolVarP(&doltRemoteResetDataYes, "yes", "y", false, "Skip the confirmation prompt (required in non-interactive use)")
 	doltRemoteCmd.AddCommand(doltRemoteAddCmd)
 	doltRemoteCmd.AddCommand(doltRemoteListCmd)
 	doltRemoteCmd.AddCommand(doltRemoteRemoveCmd)
+	doltRemoteCmd.AddCommand(doltRemoteResetDataCmd)
 	doltCmd.AddCommand(doltShowCmd)
 	doltCmd.AddCommand(doltSetCmd)
 	doltCmd.AddCommand(doltTestCmd)

--- a/cmd/bd/dolt_remote_reset_data.go
+++ b/cmd/bd/dolt_remote_reset_data.go
@@ -1,0 +1,355 @@
+package main
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+	"golang.org/x/term"
+
+	"github.com/steveyegge/beads/internal/githooksenv"
+	"github.com/steveyegge/beads/internal/storage"
+	"github.com/steveyegge/beads/internal/storage/doltutil"
+)
+
+// Ref names anchoring a git-backed Dolt remote's data plane, as published by
+// dolt's git blobstore (store/blobstore/git_refs.go: DoltDataRef and
+// DefaultInfoBranch). Pinned locally so the binary does not import that
+// package; TestResetDataRefNamesMatchDolt keeps the pin honest.
+const (
+	gitDoltDataRef = "refs/dolt/data"
+	gitDoltInfoRef = "refs/heads/__dolt_remote_info__"
+)
+
+// resetDataKind classifies how reset-data can replace the data plane behind
+// a remote URL.
+type resetDataKind int
+
+const (
+	// resetDataGitBacked: delete the Dolt data refs on the git remote, then
+	// force-push to rebuild a fresh store holding only live chunks.
+	resetDataGitBacked resetDataKind = iota
+	// resetDataFileStore: clear the native Dolt file-store directory, then
+	// force-push to rebuild it.
+	resetDataFileStore
+	// resetDataFileAbsent: the file target is missing or empty — nothing
+	// anchors old data; force-push alone rebuilds it.
+	resetDataFileAbsent
+	// resetDataUnsupported: a cloud or hosted store whose contents bd cannot
+	// safely clear — replace the remote with a fresh URL/prefix instead.
+	resetDataUnsupported
+)
+
+// classifyResetDataRemote decides which reset-data mechanism applies to url.
+// File URLs are classified by what is actually on disk, because a file://
+// remote can be either a bare git repository (Dolt normalizes those to
+// git+file:// at push time) or a native Dolt file store: a bare git repo
+// takes the git-backed path, a directory with an nbs manifest is a file
+// store, and a missing or empty target has nothing to reset. A non-empty
+// target that is neither is an error — reset-data must not clear a
+// directory it cannot identify.
+func classifyResetDataRemote(url string) (resetDataKind, error) {
+	if doltutil.IsGitProtocolURL(url) {
+		return resetDataGitBacked, nil
+	}
+	path, isFile := resetDataFilePath(url)
+	if !isFile {
+		return resetDataUnsupported, nil
+	}
+	entries, err := os.ReadDir(path)
+	if os.IsNotExist(err) {
+		return resetDataFileAbsent, nil
+	}
+	if err != nil {
+		return 0, fmt.Errorf("inspecting remote target %s: %w", path, err)
+	}
+	if len(entries) == 0 {
+		return resetDataFileAbsent, nil
+	}
+	if isBareGitRepoDir(path) {
+		return resetDataGitBacked, nil
+	}
+	if _, err := os.Stat(filepath.Join(path, "manifest")); err == nil {
+		return resetDataFileStore, nil
+	}
+	return 0, fmt.Errorf("remote target %s is non-empty but is neither a bare git repository nor a Dolt file store (no manifest); refusing to clear it", path)
+}
+
+// resetDataFilePath extracts the local filesystem path from a file:// URL or
+// a bare absolute path, reporting whether url is file-backed at all.
+func resetDataFilePath(url string) (string, bool) {
+	if strings.HasPrefix(url, "file://") {
+		return strings.TrimPrefix(url, "file://"), true
+	}
+	if filepath.IsAbs(url) {
+		return url, true
+	}
+	return "", false
+}
+
+// isBareGitRepoDir reports whether dir looks like a bare git repository
+// (HEAD file plus an objects directory).
+func isBareGitRepoDir(dir string) bool {
+	if fi, err := os.Stat(filepath.Join(dir, "HEAD")); err != nil || fi.IsDir() {
+		return false
+	}
+	fi, err := os.Stat(filepath.Join(dir, "objects"))
+	return err == nil && fi.IsDir()
+}
+
+// resetDataGitURL converts a Dolt git-protocol remote URL to the form the
+// git CLI accepts (strip the git+ prefix; file paths gain file://).
+func resetDataGitURL(url string) string {
+	if trimmed := strings.TrimPrefix(url, "git+"); trimmed != url {
+		return trimmed
+	}
+	if path, isFile := resetDataFilePath(url); isFile && !strings.HasPrefix(url, "file://") {
+		return "file://" + path
+	}
+	return url
+}
+
+// lsRemoteDoltDataRefs returns which of the Dolt data-plane refs currently
+// exist on the git remote at gitURL.
+func lsRemoteDoltDataRefs(ctx context.Context, gitURL string) ([]string, error) {
+	ctx, cancel := context.WithTimeout(ctx, 60*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "git", "ls-remote", gitURL, gitDoltDataRef, gitDoltInfoRef) // #nosec G204 -- URL from configured remote
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return nil, fmt.Errorf("git ls-remote %s failed: %s: %w", gitURL, strings.TrimSpace(string(out)), err)
+	}
+	var refs []string
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) == 2 {
+			refs = append(refs, fields[1])
+		}
+	}
+	return refs, nil
+}
+
+// deleteGitDoltDataRefs deletes refs on the git remote at gitURL. Git
+// client-side hooks are disabled for the push, same as bd's other internal
+// git invocations (GH#3724 class: a user's templated pre-push hook must not
+// break — or observe — bd's data-plane plumbing).
+func deleteGitDoltDataRefs(ctx context.Context, gitURL string, refs []string) error {
+	args := []string{"push", gitURL}
+	for _, ref := range refs {
+		args = append(args, ":"+ref)
+	}
+	cmd := exec.CommandContext(ctx, "git", args...) // #nosec G204 -- URL from configured remote, fixed refspecs
+	cmd.Env = envWithNoGitHooks()
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("git push (delete %s) failed: %s: %w", strings.Join(refs, ", "), strings.TrimSpace(string(out)), err)
+	}
+	return nil
+}
+
+// envWithNoGitHooks returns the current environment with git client-side
+// hooks disabled via GIT_CONFIG_PARAMETERS, preserving any parameters the
+// caller already set (mirrors applyNoGitHooksToCmd in internal/storage/dolt).
+func envWithNoGitHooks() []string {
+	base := os.Environ()
+	merged := githooksenv.AppendParameter(githooksenv.Extract(base), githooksenv.NoHooksParam)
+	env := make([]string, 0, len(base)+1)
+	prefix := githooksenv.ParametersEnv + "="
+	for _, e := range base {
+		if !strings.HasPrefix(e, prefix) {
+			env = append(env, e)
+		}
+	}
+	return append(env, prefix+merged)
+}
+
+// clearDoltFileStore removes the contents of a native Dolt file-store
+// directory, keeping the directory itself so the follow-up push can rebuild
+// the store in place. The caller has already verified a manifest is present.
+func clearDoltFileStore(dir string) error {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return fmt.Errorf("reading remote store %s: %w", dir, err)
+	}
+	for _, entry := range entries {
+		if err := os.RemoveAll(filepath.Join(dir, entry.Name())); err != nil {
+			return fmt.Errorf("clearing remote store %s: %w", dir, err)
+		}
+	}
+	return nil
+}
+
+var doltRemoteResetDataYes bool
+
+var doltRemoteResetDataCmd = &cobra.Command{
+	Use:   "reset-data <name>",
+	Short: "Replace a remote's data plane in place after a history squash",
+	Long: `Replace a Dolt remote's stored data with a fresh copy of local HEAD.
+
+After a history squash (see the History Bloat recovery runbook), a plain
+'bd dolt push --force' re-points the remote's refs but deletes nothing:
+Dolt remotes accumulate chunks monotonically, so the remote keeps the full
+pre-squash store. This command rebuilds the remote's data plane so it holds
+only live chunks:
+
+  - Git-backed remotes (issue data riding a git remote under refs/dolt/data):
+    deletes the Dolt data refs on the git remote, then force-pushes to
+    rebuild a fresh store. Code branches are untouched.
+  - Native file remotes (file:// paths): clears the store directory, then
+    force-pushes to rebuild it.
+  - Cloud/hosted remotes (aws://, gs://, dolthub://, ...): bd cannot clear
+    the stored data safely — replace the remote with a fresh URL or prefix:
+      bd dolt remote remove <name>
+      bd dolt remote add <name> <fresh-url>
+      bd dolt push --force
+
+This rewrites the remote's data plane. Every other clone must re-clone from
+the reset remote (that is already true after the squash itself). Refuses to
+run with uncommitted working-set changes: the rebuilt remote holds exactly
+HEAD, and anything uncommitted would not be part of it.
+
+Examples:
+  bd dolt remote reset-data origin          # prompts for confirmation
+  bd dolt remote reset-data origin --yes    # no prompt (scripts, agents)`,
+	SilenceUsage:  true,
+	SilenceErrors: true,
+	Args:          cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		CheckReadonly("dolt remote reset-data")
+		name := args[0]
+
+		if usesProxiedServer() {
+			return HandleErrorRespectJSON("bd dolt remote reset-data is not supported over a proxied bd server; run it from the workspace that hosts the Dolt database")
+		}
+		if isDoltLocalOnly() {
+			fmt.Fprintln(os.Stderr, "Error: cannot reset remote data: remote sync is disabled (dolt.local-only=true).")
+			fmt.Fprintln(os.Stderr, "To re-enable remote sync: bd config unset dolt.local-only")
+			return SilentExit()
+		}
+
+		ctx := rootCtx
+		st := getStore()
+		if st == nil {
+			return HandleError("no store available")
+		}
+
+		remotes, err := st.ListRemotes(ctx)
+		if err != nil {
+			return HandleError("listing remotes: %v", err)
+		}
+		var url string
+		for _, r := range remotes {
+			if r.Name == name {
+				url = r.URL
+				break
+			}
+		}
+		if url == "" {
+			return HandleErrorWithHint(
+				fmt.Sprintf("remote %q is not configured", name),
+				"Use 'bd dolt remote list' to see configured remotes.")
+		}
+
+		// The rebuilt remote holds exactly HEAD; refuse while anything
+		// uncommitted would be silently left out of it.
+		if det, ok := storage.UnwrapStore(st).(storage.PendingChangeDetector); ok {
+			dirty, derr := det.HasCommittablePending(ctx)
+			if derr != nil {
+				return HandleError("checking working set: %v", derr)
+			}
+			if dirty {
+				return HandleErrorWithHint(
+					"working set has uncommitted changes; refusing to reset remote data",
+					"Run 'bd dolt commit' first — the rebuilt remote holds exactly HEAD.")
+			}
+		}
+
+		kind, err := classifyResetDataRemote(url)
+		if err != nil {
+			return HandleError("%v", err)
+		}
+		if kind == resetDataUnsupported {
+			return HandleErrorWithHint(
+				fmt.Sprintf("cannot clear stored data on remote %q (%s)", name, url),
+				fmt.Sprintf("Replace the remote with a fresh URL or prefix instead:\n"+
+					"  bd dolt remote remove %s\n"+
+					"  bd dolt remote add %s <fresh-url>\n"+
+					"  bd dolt push --force", name, name))
+		}
+
+		if !doltRemoteResetDataYes {
+			if !term.IsTerminal(int(os.Stdin.Fd())) {
+				return HandleErrorWithHint(
+					fmt.Sprintf("reset-data replaces all Dolt data stored on remote %q (%s)", name, url),
+					"Re-run with --yes to confirm.")
+			}
+			fmt.Printf("This replaces all Dolt data stored on remote %q:\n", name)
+			fmt.Printf("  %s\n", url)
+			fmt.Println("The remote is rebuilt from local HEAD; other clones must re-clone.")
+			fmt.Print("Proceed? (y/N): ")
+			reader := bufio.NewReader(os.Stdin)
+			response, rerr := reader.ReadString('\n')
+			if rerr != nil {
+				return HandleError("reading confirmation: %v", rerr)
+			}
+			response = strings.TrimSpace(strings.ToLower(response))
+			if response != "y" && response != "yes" {
+				fmt.Println("Canceled.")
+				return nil
+			}
+		}
+
+		var deletedRefs []string
+		var clearedStore bool
+		switch kind {
+		case resetDataGitBacked:
+			gitURL := resetDataGitURL(url)
+			refs, lerr := lsRemoteDoltDataRefs(ctx, gitURL)
+			if lerr != nil {
+				return HandleError("%v", lerr)
+			}
+			if len(refs) == 0 {
+				fmt.Println("No Dolt data refs found on the remote (already reset?); pushing fresh store.")
+			} else {
+				if derr := deleteGitDoltDataRefs(ctx, gitURL, refs); derr != nil {
+					return HandleError("%v", derr)
+				}
+				deletedRefs = refs
+				fmt.Printf("Deleted %s on %s\n", strings.Join(refs, ", "), gitURL)
+			}
+		case resetDataFileStore:
+			path, _ := resetDataFilePath(url)
+			if cerr := clearDoltFileStore(path); cerr != nil {
+				return HandleError("%v", cerr)
+			}
+			clearedStore = true
+			fmt.Printf("Cleared remote store %s\n", path)
+		case resetDataFileAbsent:
+			fmt.Println("Remote store is empty or absent; pushing fresh store.")
+		}
+
+		fmt.Printf("Force-pushing to remote %q...\n", name)
+		if perr := st.PushRemote(ctx, name, true); perr != nil {
+			return HandleError("push after reset failed (the remote's data refs were already removed — re-run 'bd dolt push --force --remote %s' once the cause is fixed): %v", name, perr)
+		}
+
+		if jsonOutput {
+			return outputJSON(map[string]interface{}{
+				"remote":        name,
+				"url":           url,
+				"deleted_refs":  deletedRefs,
+				"cleared_store": clearedStore,
+				"pushed":        true,
+			})
+		}
+		fmt.Printf("✓ Remote %q data plane reset; store rebuilt from HEAD.\n", name)
+		fmt.Println("  Other clones of this database must re-clone from the remote.")
+		return nil
+	},
+}

--- a/cmd/bd/dolt_remote_reset_data_embedded_test.go
+++ b/cmd/bd/dolt_remote_reset_data_embedded_test.go
@@ -1,0 +1,151 @@
+//go:build cgo
+
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Integration tests for bd-fs6k3: bd dolt remote reset-data — replace a
+// remote's data plane in place after a history squash. Run with
+// BEADS_TEST_EMBEDDED_DOLT=1.
+
+// resetDataRunGit runs a git command in dir, fatal on failure.
+func resetDataRunGit(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s failed in %s: %v\n%s", strings.Join(args, " "), dir, err, out)
+	}
+	return string(out)
+}
+
+// setupBareGitRemote creates a bare git repo seeded with an initial commit
+// on main (Dolt's git blobstore requires an existing branch) and returns
+// its path.
+func setupBareGitRemote(t *testing.T) string {
+	t.Helper()
+	base := t.TempDir()
+	remoteDir := filepath.Join(base, "remote.git")
+	resetDataRunGit(t, base, "init", "--bare", "-b", "main", remoteDir)
+
+	seedDir := filepath.Join(base, "seed")
+	if err := os.MkdirAll(seedDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	resetDataRunGit(t, seedDir, "init", "-b", "main")
+	resetDataRunGit(t, seedDir, "-c", "user.name=bd-test", "-c", "user.email=bd-test@example.com",
+		"commit", "--allow-empty", "-m", "init")
+	resetDataRunGit(t, seedDir, "push", remoteDir, "main")
+	return remoteDir
+}
+
+// lsRemoteRef returns the hash the bare repo has for ref, or "" if absent.
+func lsRemoteRef(t *testing.T, remoteDir, ref string) string {
+	t.Helper()
+	out := resetDataRunGit(t, remoteDir, "ls-remote", remoteDir, ref)
+	fields := strings.Fields(strings.TrimSpace(out))
+	if len(fields) == 0 {
+		return ""
+	}
+	return fields[0]
+}
+
+func TestDoltRemoteResetData_GitBacked(t *testing.T) {
+	if os.Getenv("BEADS_TEST_EMBEDDED_DOLT") != "1" {
+		t.Skip("set BEADS_TEST_EMBEDDED_DOLT=1 to run embedded integration tests")
+	}
+	t.Parallel()
+	bd := buildEmbeddedBD(t)
+	dir, _, _ := bdInit(t, bd, "--prefix", "rd")
+
+	remoteDir := setupBareGitRemote(t)
+	remoteURL := "git+file://" + remoteDir
+
+	if _, stderr, err := bdDoltSeparate(t, bd, dir, "remote", "add", "origin", remoteURL); err != nil {
+		t.Fatalf("bd dolt remote add failed: %v\nstderr:\n%s", err, stderr)
+	}
+	bdCreate(t, bd, dir, "seed issue", "--type", "task")
+	if stdout, stderr, err := bdDoltSeparate(t, bd, dir, "push"); err != nil {
+		t.Fatalf("bd dolt push failed: %v\nstdout:\n%s\nstderr:\n%s", err, stdout, stderr)
+	}
+
+	dataBefore := lsRemoteRef(t, remoteDir, "refs/dolt/data")
+	if dataBefore == "" {
+		t.Fatal("push did not create refs/dolt/data on the git remote")
+	}
+
+	// Non-interactive without --yes: refuse, mention --yes, touch nothing.
+	if _, stderr, err := bdDoltSeparate(t, bd, dir, "remote", "reset-data", "origin"); err == nil {
+		t.Fatalf("expected reset-data without --yes to exit non-zero\nstderr:\n%s", stderr)
+	} else if !strings.Contains(stderr, "--yes") {
+		t.Errorf("refusal should mention --yes, got:\n%s", stderr)
+	}
+	if got := lsRemoteRef(t, remoteDir, "refs/dolt/data"); got != dataBefore {
+		t.Fatalf("refused reset-data still changed refs/dolt/data: %q -> %q", dataBefore, got)
+	}
+
+	// With --yes: delete the data refs and rebuild the store via force-push.
+	stdout, stderr, err := bdDoltSeparate(t, bd, dir, "remote", "reset-data", "origin", "--yes")
+	if err != nil {
+		t.Fatalf("bd dolt remote reset-data --yes failed: %v\nstdout:\n%s\nstderr:\n%s", err, stdout, stderr)
+	}
+	if !strings.Contains(stdout, "refs/dolt/data") {
+		t.Errorf("expected deleted-refs report in output, got:\n%s", stdout)
+	}
+	if got := lsRemoteRef(t, remoteDir, "refs/dolt/data"); got == "" {
+		t.Error("refs/dolt/data missing after reset-data; force-push should have rebuilt it")
+	}
+	// Code branches are untouched.
+	if got := lsRemoteRef(t, remoteDir, "refs/heads/main"); got == "" {
+		t.Error("refs/heads/main disappeared from the git remote")
+	}
+
+	// Re-run is idempotent: refs exist again, so they are deleted and rebuilt.
+	if stdout, stderr, err := bdDoltSeparate(t, bd, dir, "remote", "reset-data", "origin", "--yes"); err != nil {
+		t.Fatalf("second reset-data failed: %v\nstdout:\n%s\nstderr:\n%s", err, stdout, stderr)
+	}
+}
+
+func TestDoltRemoteResetData_UnknownRemote(t *testing.T) {
+	if os.Getenv("BEADS_TEST_EMBEDDED_DOLT") != "1" {
+		t.Skip("set BEADS_TEST_EMBEDDED_DOLT=1 to run embedded integration tests")
+	}
+	t.Parallel()
+	bd := buildEmbeddedBD(t)
+	dir, _, _ := bdInit(t, bd, "--prefix", "rd")
+
+	_, stderr, err := bdDoltSeparate(t, bd, dir, "remote", "reset-data", "nosuch", "--yes")
+	if err == nil {
+		t.Fatalf("expected reset-data on unknown remote to exit non-zero\nstderr:\n%s", stderr)
+	}
+	if !strings.Contains(stderr, "not configured") {
+		t.Errorf("expected 'not configured' in stderr, got:\n%s", stderr)
+	}
+}
+
+func TestDoltRemoteResetData_CloudRemoteRefused(t *testing.T) {
+	if os.Getenv("BEADS_TEST_EMBEDDED_DOLT") != "1" {
+		t.Skip("set BEADS_TEST_EMBEDDED_DOLT=1 to run embedded integration tests")
+	}
+	t.Parallel()
+	bd := buildEmbeddedBD(t)
+	dir, _, _ := bdInit(t, bd, "--prefix", "rd")
+
+	if _, stderr, err := bdDoltSeparate(t, bd, dir, "remote", "add", "cloud", "gs://bucket/db"); err != nil {
+		t.Fatalf("bd dolt remote add failed: %v\nstderr:\n%s", err, stderr)
+	}
+	_, stderr, err := bdDoltSeparate(t, bd, dir, "remote", "reset-data", "cloud", "--yes")
+	if err == nil {
+		t.Fatalf("expected reset-data on gs:// remote to exit non-zero\nstderr:\n%s", stderr)
+	}
+	if !strings.Contains(stderr, "fresh URL") {
+		t.Errorf("expected replace-the-remote guidance in stderr, got:\n%s", stderr)
+	}
+}

--- a/cmd/bd/dolt_remote_reset_data_test.go
+++ b/cmd/bd/dolt_remote_reset_data_test.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/dolthub/dolt/go/store/blobstore"
+)
+
+// TestResetDataRefNamesMatchDolt keeps the locally pinned data-plane ref
+// names in sync with the constants dolt's git blobstore actually publishes
+// (store/blobstore/git_refs.go). If a dolt bump renames either ref, this
+// fails instead of reset-data silently deleting the wrong refs.
+func TestResetDataRefNamesMatchDolt(t *testing.T) {
+	if gitDoltDataRef != blobstore.DoltDataRef {
+		t.Errorf("gitDoltDataRef = %q, dolt publishes %q", gitDoltDataRef, blobstore.DoltDataRef)
+	}
+	if want := "refs/heads/" + blobstore.DefaultInfoBranch; gitDoltInfoRef != want {
+		t.Errorf("gitDoltInfoRef = %q, dolt publishes %q", gitDoltInfoRef, want)
+	}
+}
+
+func TestClassifyResetDataRemote(t *testing.T) {
+	makeBareGitRepo := func(t *testing.T) string {
+		dir := t.TempDir()
+		if err := os.WriteFile(filepath.Join(dir, "HEAD"), []byte("ref: refs/heads/main\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.MkdirAll(filepath.Join(dir, "objects"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		return dir
+	}
+	makeDoltFileStore := func(t *testing.T) string {
+		dir := t.TempDir()
+		if err := os.WriteFile(filepath.Join(dir, "manifest"), []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		return dir
+	}
+
+	bareRepo := makeBareGitRepo(t)
+	fileStore := makeDoltFileStore(t)
+	emptyDir := t.TempDir()
+	strangeDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(strangeDir, "notes.txt"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name    string
+		url     string
+		want    resetDataKind
+		wantErr bool
+	}{
+		{"git+https", "git+https://github.com/org/repo.git", resetDataGitBacked, false},
+		{"git+ssh", "git+ssh://git@github.com/org/repo.git", resetDataGitBacked, false},
+		{"scp-style", "git@github.com:org/repo.git", resetDataGitBacked, false},
+		{"git+file", "git+file://" + bareRepo, resetDataGitBacked, false},
+		{"file url to bare git repo", "file://" + bareRepo, resetDataGitBacked, false},
+		{"bare path to bare git repo", bareRepo, resetDataGitBacked, false},
+		{"file url to dolt store", "file://" + fileStore, resetDataFileStore, false},
+		{"bare path to dolt store", fileStore, resetDataFileStore, false},
+		{"file url to missing dir", "file://" + filepath.Join(emptyDir, "nope"), resetDataFileAbsent, false},
+		{"file url to empty dir", "file://" + emptyDir, resetDataFileAbsent, false},
+		{"file url to unrecognized dir", "file://" + strangeDir, 0, true},
+		{"aws", "aws://[table:bucket]/db", resetDataUnsupported, false},
+		{"gs", "gs://bucket/db", resetDataUnsupported, false},
+		{"dolthub", "dolthub://org/db", resetDataUnsupported, false},
+		{"https hosted", "https://doltremoteapi.dolthub.com/org/db", resetDataUnsupported, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := classifyResetDataRemote(tt.url)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("classifyResetDataRemote(%q) = %v, want error", tt.url, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("classifyResetDataRemote(%q): %v", tt.url, err)
+			}
+			if got != tt.want {
+				t.Errorf("classifyResetDataRemote(%q) = %v, want %v", tt.url, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResetDataGitURL(t *testing.T) {
+	tests := []struct {
+		url  string
+		want string
+	}{
+		{"git+https://github.com/org/repo.git", "https://github.com/org/repo.git"},
+		{"git+ssh://git@github.com/org/repo.git", "ssh://git@github.com/org/repo.git"},
+		{"git+file:///tmp/remote.git", "file:///tmp/remote.git"},
+		{"git@github.com:org/repo.git", "git@github.com:org/repo.git"},
+		{"file:///tmp/remote.git", "file:///tmp/remote.git"},
+		{"/tmp/remote.git", "file:///tmp/remote.git"},
+	}
+	for _, tt := range tests {
+		if got := resetDataGitURL(tt.url); got != tt.want {
+			t.Errorf("resetDataGitURL(%q) = %q, want %q", tt.url, got, tt.want)
+		}
+	}
+}

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -2919,16 +2919,10 @@ func (s *DoltStore) doltAddAndCommit(ctx context.Context, tables []string, commi
 	return nil
 }
 
-// CommitPending creates a single Dolt commit for all uncommitted changes in the working set.
-// Returns (true, nil) if changes were committed, (false, nil) if there was nothing to commit,
-// or (false, err) on failure. The commit message summarizes the accumulated changes by
-// querying dolt_diff to count issue-level operations.
-//
-// This is the primary commit mechanism for batch mode, where multiple bd commands
-// accumulate changes in the working set before committing at a logical boundary.
-func (s *DoltStore) CommitPending(ctx context.Context, actor string) (bool, error) {
-	// Check if there are any committable changes (excluding dolt_ignore'd tables
-	// like wisp tables, which appear in dolt_status but can't be staged).
+// HasCommittablePending reports whether the working set holds committable
+// changes, excluding dolt_ignore'd tables (wisp and lease tables appear in
+// dolt_status but can't be staged). Implements storage.PendingChangeDetector.
+func (s *DoltStore) HasCommittablePending(ctx context.Context) (bool, error) {
 	var count int
 	err := s.db.QueryRowContext(ctx, `
 		SELECT COUNT(*) FROM dolt_status s
@@ -2940,7 +2934,22 @@ func (s *DoltStore) CommitPending(ctx context.Context, actor string) (bool, erro
 	if err != nil {
 		return false, fmt.Errorf("failed to check status: %w", err)
 	}
-	if count == 0 {
+	return count > 0, nil
+}
+
+// CommitPending creates a single Dolt commit for all uncommitted changes in the working set.
+// Returns (true, nil) if changes were committed, (false, nil) if there was nothing to commit,
+// or (false, err) on failure. The commit message summarizes the accumulated changes by
+// querying dolt_diff to count issue-level operations.
+//
+// This is the primary commit mechanism for batch mode, where multiple bd commands
+// accumulate changes in the working set before committing at a logical boundary.
+func (s *DoltStore) CommitPending(ctx context.Context, actor string) (bool, error) {
+	dirty, err := s.HasCommittablePending(ctx)
+	if err != nil {
+		return false, err
+	}
+	if !dirty {
 		return false, nil // Nothing to commit
 	}
 

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -496,6 +496,16 @@ type PendingCommitter interface {
 	CommitPending(ctx context.Context, actor string) (bool, error)
 }
 
+// PendingChangeDetector reports whether the working set holds changes a
+// commit would capture. Unlike VersionControl.Status, this excludes
+// dolt_ignore'd tables (wisp and lease tables appear in dolt_status but
+// cannot be staged), so it answers "would CommitPending mint a commit?"
+// without committing. Callers that must refuse to act on a dirty working
+// set (bd dolt remote reset-data) should type-assert to this interface.
+type PendingChangeDetector interface {
+	HasCommittablePending(ctx context.Context) (bool, error)
+}
+
 // BackupStore provides Dolt backup operations (CALL DOLT_BACKUP) for
 // disaster recovery.
 // Callers that need backup functionality should type-assert to this interface.


### PR DESCRIPTION
## What

`bd dolt remote reset-data <name>` — replace a remote's data plane in place after a history squash (bd-fs6k3, split from bd-gpgdy).

## Why

The History Bloat runbook's Step 4 hand-rolls git plumbing for git-backed remotes: a Dolt remote accumulates chunks monotonically, so after a squash `bd dolt push --force` re-points refs but the remote keeps the full pre-squash store. On a git-backed remote the manifest lists every historical table file as current, so the only way to reclaim the published side is to delete `refs/dolt/data` + `refs/heads/__dolt_remote_info__` on the git remote and force-push a fresh store. Production numbers from the 7/29 squash window: 587M→57.8M and 274M→2.6M reachable. The next squash window shouldn't hand-roll that.

## How

- **Git-backed remotes** (git+*, ssh, scp-style, and file URLs that point at a bare git repo): probe with `git ls-remote`, delete whichever data-plane refs exist (client-side git hooks disabled, same GH#3724 class as bd's other internal git invocations), then `PushRemote(force)` rebuilds a store holding only live chunks. Code branches untouched.
- **Native Dolt file remotes** (file URL with an nbs `manifest`): clear the store directory in place, then force-push. A non-empty directory that is neither a bare git repo nor a Dolt store is refused, never cleared.
- **Cloud/hosted remotes** (`aws://`, `gs://`, `dolthub://`, https): refused with the runbook's replace-the-remote guidance (`remote remove` + `remote add <fresh-url>` + `push --force`) — bd cannot safely clear those stores.
- **Gates**: confirmation prompt on a TTY, `--yes` required non-interactively; refuses while the working set has committable changes (the rebuilt remote holds exactly HEAD). The dirty check is a new `storage.PendingChangeDetector` capability — `HasCommittablePending` extracted verbatim from `CommitPending`, so it excludes `dolt_ignore`'d wisp/lease tables that appear in `dolt_status` but can't be staged. Refused over a proxied bd server and under `dolt.local-only`.

Ref names are pinned locally (no blobstore import in the binary) and `TestResetDataRefNamesMatchDolt` asserts them against dolt's actual `store/blobstore` constants, so a dolt bump that renames either ref fails the build instead of deleting the wrong refs.

## Testing

- `TestClassifyResetDataRemote` / `TestResetDataGitURL` / `TestResetDataRefNamesMatchDolt` (unit)
- `TestDoltRemoteResetData_GitBacked` — end-to-end against a bare git repo via `git+file://`: push seeds `refs/dolt/data`, non-interactive run without `--yes` refuses and provably touches nothing, `--yes` deletes + rebuilds the refs, `refs/heads/main` survives, re-run is idempotent
- `TestDoltRemoteResetData_UnknownRemote`, `TestDoltRemoteResetData_CloudRemoteRefused`
- Full `./cmd/bd` and `./internal/storage/...` suites green locally (separate invocations); golangci-lint clean on changed files

## Docs

`docs/recovery/history-squash.md` deliberately does NOT reference the verb yet: the docs corpus describes the pinned release (`docs/cli-docs.pin`), not main. Fold the runbook reference in at the next pin bump; the CLI reference page flows from the Cobra strings automatically at that point. Noted on bd-fs6k3.

Closes bd-fs6k3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
