### PR TITLE
fix(doctor,hooks): diagnose a dangling core.hooksPath and clear beads.role on uninstall (#4440)

### DIFF
--- a/cmd/bd/doctor.go
+++ b/cmd/bd/doctor.go
@@ -448,6 +448,11 @@ func runDiagnostics(path string) doctorResult {
 	legacyCheck := convertWithCategory(doctor.CheckStaleLegacyHooks(), doctor.CategoryGit)
 	result.Checks = append(result.Checks, legacyCheck)
 
+	// Check for a dangling core.hooksPath pointing at a missing directory (GH#4440)
+	hooksPathCheck := convertWithCategory(doctor.CheckHooksPath(), doctor.CategoryGit)
+	result.Checks = append(result.Checks, hooksPathCheck)
+	// Warning-class check — don't fail overall check, matching the neighboring hooks checks.
+
 	// Check git hooks Dolt compatibility (hooks without Dolt check cause errors)
 	doltHooksCheck := convertWithCategory(doctor.CheckGitHooksDoltCompatibility(path), doctor.CategoryGit)
 	result.Checks = append(result.Checks, doltHooksCheck)

--- a/cmd/bd/doctor/git.go
+++ b/cmd/bd/doctor/git.go
@@ -596,6 +596,128 @@ func staleFilePaths(hooksDir string, names []string) []string {
 	return paths
 }
 
+// CheckHooksPath detects a dangling core.hooksPath: a git config value that
+// still points at a hooks directory which no longer exists. This happens
+// when a user manually deletes .beads/ (e.g. `rm -rf .beads/`) without
+// running `bd hooks uninstall` first — git keeps looking for the missing
+// directory, and beads' post-checkout import can recreate a stray .beads/
+// workspace as a side effect (GH#4440).
+func CheckHooksPath() DoctorCheck {
+	const name = "Hooks Path"
+
+	repoRoot, _ := git.GetMainRepoRoot()
+	if repoRoot == "" {
+		repoRoot = git.GetRepoRoot()
+	}
+	if repoRoot == "" {
+		return DoctorCheck{
+			Name:    name,
+			Status:  StatusOK,
+			Message: "N/A (not a git repository)",
+		}
+	}
+
+	hooksPath, ok := getConfiguredHooksPath(repoRoot)
+	if !ok || hooksPath == "" {
+		return DoctorCheck{
+			Name:    name,
+			Status:  StatusOK,
+			Message: "core.hooksPath is not set",
+		}
+	}
+
+	resolved := expandHookPathTilde(hooksPath)
+	if !filepath.IsAbs(resolved) {
+		resolved = filepath.Join(repoRoot, resolved)
+	}
+
+	if fileExists(resolved) {
+		return DoctorCheck{
+			Name:    name,
+			Status:  StatusOK,
+			Message: fmt.Sprintf("core.hooksPath is set to %s", hooksPath),
+		}
+	}
+
+	managed := isBeadsManagedHooksPath(repoRoot, hooksPath)
+	var fix string
+	if managed {
+		fix = "Run 'bd doctor --fix' to unset core.hooksPath, or: git config --unset core.hooksPath"
+	} else {
+		fix = "core.hooksPath is not beads-managed; bd will not change it. Restore the missing directory, or unset it yourself: git config --unset core.hooksPath"
+	}
+
+	return DoctorCheck{
+		Name:    name,
+		Status:  StatusWarning,
+		Message: "core.hooksPath points at a missing directory",
+		Detail:  fmt.Sprintf("core.hooksPath=%s (resolved: %s)", hooksPath, resolved),
+		Fix:     fix,
+	}
+}
+
+// FixHooksPath unsets core.hooksPath ONLY when it is beads-managed and its
+// target is missing. It re-reads the current value and re-checks both
+// conditions immediately before acting, so it never mutates a third-party
+// hooksPath (e.g. husky) even if the check that triggered the fix pass is
+// stale.
+func FixHooksPath() error {
+	repoRoot, _ := git.GetMainRepoRoot()
+	if repoRoot == "" {
+		repoRoot = git.GetRepoRoot()
+	}
+	if repoRoot == "" {
+		return nil // not in a git repo
+	}
+
+	hooksPath, ok := getConfiguredHooksPath(repoRoot)
+	if !ok || hooksPath == "" {
+		return nil // nothing set
+	}
+
+	if !isBeadsManagedHooksPath(repoRoot, hooksPath) {
+		return nil // never touch a third-party hooksPath
+	}
+
+	resolved := expandHookPathTilde(hooksPath)
+	if !filepath.IsAbs(resolved) {
+		resolved = filepath.Join(repoRoot, resolved)
+	}
+	if fileExists(resolved) {
+		return nil // target exists — nothing dangling to fix
+	}
+
+	cmd := exec.Command("git", "config", "--unset", "core.hooksPath")
+	cmd.Dir = repoRoot
+	if output, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("git config --unset core.hooksPath failed: %w (output: %s)", err, strings.TrimSpace(string(output)))
+	}
+	return nil
+}
+
+// getConfiguredHooksPath reads the raw core.hooksPath value from repoRoot.
+// The bool return is false when core.hooksPath is not set at all.
+func getConfiguredHooksPath(repoRoot string) (string, bool) {
+	cmd := exec.Command("git", "config", "--get", "core.hooksPath")
+	cmd.Dir = repoRoot
+	out, err := cmd.Output()
+	if err != nil {
+		return "", false
+	}
+	return strings.TrimSpace(string(out)), true
+}
+
+// isBeadsManagedHooksPath reports whether hooksPath is one of the values bd
+// itself writes to core.hooksPath (.beads/hooks or .beads-hooks, relative or
+// absolute under repoRoot). Mirrors the matching in
+// resetHooksPathIfBeadsManaged (cmd/bd/hooks.go) — keep the two in sync.
+func isBeadsManagedHooksPath(repoRoot, hooksPath string) bool {
+	absBeadsHooks := filepath.Join(repoRoot, ".beads", "hooks")
+	absSharedHooks := filepath.Join(repoRoot, ".beads-hooks")
+	return hooksPath == ".beads/hooks" || hooksPath == ".beads-hooks" ||
+		hooksPath == absBeadsHooks || hooksPath == absSharedHooks
+}
+
 // CheckGitHooksDoltCompatibility checks if installed git hooks are compatible with Dolt backend.
 // Hooks installed before Dolt support was added don't have the backend check and will
 // fail with confusing errors on git pull/commit.

--- a/cmd/bd/doctor/hooks_path_test.go
+++ b/cmd/bd/doctor/hooks_path_test.go
@@ -1,0 +1,203 @@
+package doctor
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// setGitConfig sets a git config value in dir, failing the test on error.
+func setGitConfig(t *testing.T, dir, key, value string) {
+	t.Helper()
+	cmd := exec.Command("git", "config", key, value)
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git config %s %s failed: %v (%s)", key, value, err, strings.TrimSpace(string(out)))
+	}
+}
+
+// unsetGitConfig unsets a git config value in dir. Ignores "not set" errors
+// since the goal is just to make sure the key is absent.
+func unsetGitConfig(t *testing.T, dir, key string) {
+	t.Helper()
+	cmd := exec.Command("git", "config", "--unset", key)
+	cmd.Dir = dir
+	_ = cmd.Run()
+}
+
+// getGitConfig reads a git config value in dir. Returns "" if unset.
+func getGitConfig(t *testing.T, dir, key string) string {
+	t.Helper()
+	cmd := exec.Command("git", "config", "--get", key)
+	cmd.Dir = dir
+	out, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}
+
+func TestCheckHooksPath_NotInGitRepo(t *testing.T) {
+	dir := t.TempDir()
+	runInDir(t, dir, func() {
+		check := CheckHooksPath()
+		if check.Status != StatusOK {
+			t.Errorf("expected StatusOK, got %q: %s", check.Status, check.Message)
+		}
+		if !strings.Contains(check.Message, "N/A") {
+			t.Errorf("expected N/A message, got %q", check.Message)
+		}
+	})
+}
+
+func TestCheckHooksPath_Unset(t *testing.T) {
+	dir := t.TempDir()
+	setupGitRepoInDir(t, dir)
+	// setupGitRepoInDir sets core.hooksPath=.git/hooks for isolation; clear it
+	// so we exercise the genuinely-unset case.
+	unsetGitConfig(t, dir, "core.hooksPath")
+
+	runInDir(t, dir, func() {
+		check := CheckHooksPath()
+		if check.Status != StatusOK {
+			t.Errorf("expected StatusOK, got %q: %s", check.Status, check.Message)
+		}
+		if !strings.Contains(check.Message, "not set") {
+			t.Errorf("expected message to mention core.hooksPath is not set, got %q", check.Message)
+		}
+	})
+}
+
+func TestCheckHooksPath_SetToExistingDir(t *testing.T) {
+	dir := t.TempDir()
+	setupGitRepoInDir(t, dir)
+	// setupGitRepoInDir already points core.hooksPath at .git/hooks, which
+	// always exists after git init.
+
+	runInDir(t, dir, func() {
+		check := CheckHooksPath()
+		if check.Status != StatusOK {
+			t.Errorf("expected StatusOK, got %q: %s", check.Status, check.Message)
+		}
+	})
+}
+
+func TestCheckHooksPath_MissingBeadsManagedPath(t *testing.T) {
+	tests := []struct {
+		name        string
+		hooksPath   func(dir string) string
+		wantAbsHint bool
+	}{
+		{
+			name:      "relative .beads/hooks",
+			hooksPath: func(dir string) string { return ".beads/hooks" },
+		},
+		{
+			name:      "relative .beads-hooks",
+			hooksPath: func(dir string) string { return ".beads-hooks" },
+		},
+		{
+			name:        "absolute .beads/hooks",
+			hooksPath:   func(dir string) string { return filepath.Join(dir, ".beads", "hooks") },
+			wantAbsHint: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			setupGitRepoInDir(t, dir)
+			hooksPath := tt.hooksPath(dir)
+			setGitConfig(t, dir, "core.hooksPath", hooksPath)
+
+			runInDir(t, dir, func() {
+				check := CheckHooksPath()
+				if check.Status != StatusWarning {
+					t.Fatalf("expected StatusWarning, got %q: %s", check.Status, check.Message)
+				}
+				if !strings.Contains(check.Fix, "bd doctor --fix") {
+					t.Errorf("expected beads-managed fix hint, got %q", check.Fix)
+				}
+				if !strings.Contains(check.Detail, hooksPath) {
+					t.Errorf("expected detail to mention configured value %q, got %q", hooksPath, check.Detail)
+				}
+
+				if err := FixHooksPath(); err != nil {
+					t.Fatalf("FixHooksPath failed: %v", err)
+				}
+			})
+
+			if got := getGitConfig(t, dir, "core.hooksPath"); got != "" {
+				t.Errorf("expected core.hooksPath to be unset after FixHooksPath, got %q", got)
+			}
+		})
+	}
+}
+
+func TestCheckHooksPath_MissingNonBeadsPath(t *testing.T) {
+	dir := t.TempDir()
+	setupGitRepoInDir(t, dir)
+	setGitConfig(t, dir, "core.hooksPath", ".husky/_")
+
+	runInDir(t, dir, func() {
+		check := CheckHooksPath()
+		if check.Status != StatusWarning {
+			t.Fatalf("expected StatusWarning, got %q: %s", check.Status, check.Message)
+		}
+		if strings.Contains(check.Fix, "bd doctor --fix") {
+			t.Errorf("did not expect bd auto-fix to be offered for a non-beads-managed path, got %q", check.Fix)
+		}
+		if !strings.Contains(check.Fix, "not beads-managed") {
+			t.Errorf("expected fix text to say the path is not beads-managed, got %q", check.Fix)
+		}
+
+		// The important guard: FixHooksPath must be a no-op for a third-party
+		// (e.g. husky) hooksPath, even though its target is also missing.
+		if err := FixHooksPath(); err != nil {
+			t.Fatalf("FixHooksPath returned error: %v", err)
+		}
+	})
+
+	if got := getGitConfig(t, dir, "core.hooksPath"); got != ".husky/_" {
+		t.Errorf("expected core.hooksPath to remain %q after FixHooksPath, got %q", ".husky/_", got)
+	}
+}
+
+func TestCheckHooksPath_ExistingNonBeadsPath(t *testing.T) {
+	dir := t.TempDir()
+	setupGitRepoInDir(t, dir)
+	huskyDir := filepath.Join(dir, ".husky", "_")
+	if err := os.MkdirAll(huskyDir, 0755); err != nil {
+		t.Fatalf("failed to create husky dir: %v", err)
+	}
+	setGitConfig(t, dir, "core.hooksPath", ".husky/_")
+
+	runInDir(t, dir, func() {
+		check := CheckHooksPath()
+		if check.Status != StatusOK {
+			t.Errorf("expected StatusOK for an existing third-party hooksPath, got %q: %s", check.Status, check.Message)
+		}
+	})
+}
+
+func TestFixHooksPath_NoOpWhenTargetExists(t *testing.T) {
+	dir := t.TempDir()
+	setupGitRepoInDir(t, dir)
+	beadsHooksDir := filepath.Join(dir, ".beads", "hooks")
+	if err := os.MkdirAll(beadsHooksDir, 0755); err != nil {
+		t.Fatalf("failed to create .beads/hooks: %v", err)
+	}
+	setGitConfig(t, dir, "core.hooksPath", ".beads/hooks")
+
+	runInDir(t, dir, func() {
+		if err := FixHooksPath(); err != nil {
+			t.Fatalf("FixHooksPath failed: %v", err)
+		}
+	})
+
+	if got := getGitConfig(t, dir, "core.hooksPath"); got != ".beads/hooks" {
+		t.Errorf("expected core.hooksPath to remain %q when target exists, got %q", ".beads/hooks", got)
+	}
+}

--- a/cmd/bd/doctor_fix.go
+++ b/cmd/bd/doctor_fix.go
@@ -290,6 +290,8 @@ func applyFixList(path string, fixes []doctorCheck) {
 			err = doctor.FixTrackedRuntimeFiles(path)
 		case "Git Hooks":
 			err = fix.GitHooks(path)
+		case "Hooks Path":
+			err = doctor.FixHooksPath()
 		case "Sync Divergence":
 			fmt.Printf("  ⚠ Sync divergence fix removed (Dolt-native sync)\n")
 			continue

--- a/cmd/bd/hooks.go
+++ b/cmd/bd/hooks.go
@@ -1257,16 +1257,24 @@ func uninstallHooks() error {
 		// Not a bd hook at all — leave it alone
 	}
 
-	// Reset core.hooksPath if it was set to a beads-managed directory
+	// Reset beads-managed git config (core.hooksPath, beads.role) now that the
+	// hook files themselves are removed. A failure here must not be a
+	// scrolling stderr warning — bd hooks uninstall must not report success
+	// while beads-managed config is still left behind (GH#4440).
 	if err := resetHooksPathIfBeadsManaged(); err != nil {
-		fmt.Fprintf(os.Stderr, "Warning: failed to reset core.hooksPath: %v\n", err)
+		return fmt.Errorf("hook files removed, but failed to reset beads-managed git config: %w", err)
 	}
 
 	return nil
 }
 
 // resetHooksPathIfBeadsManaged unsets core.hooksPath if it points to a
-// beads-managed hooks directory (.beads/hooks or .beads-hooks).
+// beads-managed hooks directory (.beads/hooks or .beads-hooks), and unsets
+// beads.role. beads.role marks a repo as beads-managed independent of
+// core.hooksPath, so it is cleared unconditionally here rather than gated on
+// the hooksPath match — otherwise an uninstall that runs after core.hooksPath
+// was already cleared (e.g. by `bd doctor --fix`) would leave a stale
+// beads.role behind. A key that is already absent is not an error.
 func resetHooksPathIfBeadsManaged() error {
 	repoRoot, _ := git.GetMainRepoRoot()
 	if repoRoot == "" {
@@ -1276,24 +1284,44 @@ func resetHooksPathIfBeadsManaged() error {
 		return nil // not in a git repo
 	}
 
+	var failures []string
+
 	cmd := exec.Command("git", "config", "--get", "core.hooksPath")
 	cmd.Dir = repoRoot
-	out, err := cmd.Output()
-	if err != nil {
-		return nil // core.hooksPath not set — nothing to reset
+	if out, err := cmd.Output(); err == nil {
+		hooksPath := strings.TrimSpace(string(out))
+		// Match both relative (legacy) and absolute (GH#2414) beads hooks paths
+		absBeadsHooks := filepath.Join(repoRoot, ".beads", "hooks")
+		absSharedHooks := filepath.Join(repoRoot, ".beads-hooks")
+		if hooksPath == ".beads/hooks" || hooksPath == ".beads-hooks" ||
+			hooksPath == absBeadsHooks || hooksPath == absSharedHooks {
+			unsetCmd := exec.Command("git", "config", "--unset", "core.hooksPath")
+			unsetCmd.Dir = repoRoot
+			if output, err := unsetCmd.CombinedOutput(); err != nil {
+				failures = append(failures, fmt.Sprintf("core.hooksPath: %v (output: %s)", err, strings.TrimSpace(string(output))))
+			}
+		}
+	}
+	// core.hooksPath not set at all — nothing to reset there; still fall
+	// through to beads.role below.
+
+	// Read before unsetting rather than treating git's exit 5 as "already
+	// absent". Exit 5 also means "the key has multiple values, refusing an
+	// ambiguous unset" — a repo with a duplicated beads.role (bad merge, hand
+	// edit) would then report a clean uninstall while leaving the key set,
+	// which is the exact failure this is supposed to stop.
+	getRoleCmd := exec.Command("git", "config", "--get", "beads.role")
+	getRoleCmd.Dir = repoRoot
+	if _, err := getRoleCmd.Output(); err == nil {
+		roleCmd := exec.Command("git", "config", "--unset", "beads.role")
+		roleCmd.Dir = repoRoot
+		if output, err := roleCmd.CombinedOutput(); err != nil {
+			failures = append(failures, fmt.Sprintf("beads.role: %v (output: %s)", err, strings.TrimSpace(string(output))))
+		}
 	}
 
-	hooksPath := strings.TrimSpace(string(out))
-	// Match both relative (legacy) and absolute (GH#2414) beads hooks paths
-	absBeadsHooks := filepath.Join(repoRoot, ".beads", "hooks")
-	absSharedHooks := filepath.Join(repoRoot, ".beads-hooks")
-	if hooksPath == ".beads/hooks" || hooksPath == ".beads-hooks" ||
-		hooksPath == absBeadsHooks || hooksPath == absSharedHooks {
-		cmd = exec.Command("git", "config", "--unset", "core.hooksPath")
-		cmd.Dir = repoRoot
-		if output, err := cmd.CombinedOutput(); err != nil {
-			return fmt.Errorf("git config --unset core.hooksPath failed: %w (output: %s)", err, string(output))
-		}
+	if len(failures) > 0 {
+		return fmt.Errorf("%s", strings.Join(failures, "; "))
 	}
 
 	return nil

--- a/cmd/bd/uninstall_config_test.go
+++ b/cmd/bd/uninstall_config_test.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestUninstallHooksUnsetsBeadsRole verifies AC2: bd hooks uninstall clears
+// beads.role in addition to core.hooksPath, so a manual `rm -rf .beads/`
+// followed by a proper uninstall doesn't leave stale beads-managed git
+// config behind (GH#4440).
+func TestUninstallHooksUnsetsBeadsRole(t *testing.T) {
+	tmpDir := newGitRepo(t)
+	runInDir(t, tmpDir, func() {
+		cmd := exec.Command("git", "config", "beads.role", "primary")
+		cmd.Dir = tmpDir
+		if err := cmd.Run(); err != nil {
+			t.Fatalf("failed to set beads.role: %v", err)
+		}
+
+		if err := uninstallHooks(); err != nil {
+			t.Fatalf("uninstallHooks() failed: %v", err)
+		}
+
+		getCmd := exec.Command("git", "config", "--get", "beads.role")
+		getCmd.Dir = tmpDir
+		out, err := getCmd.Output()
+		if err == nil {
+			t.Errorf("expected beads.role to be unset after uninstallHooks(), got %q", strings.TrimSpace(string(out)))
+		}
+	})
+}
+
+// TestUninstallHooksNoBeadsRoleIsNotAnError verifies that an already-absent
+// beads.role is treated as success, not surfaced as a failure.
+func TestUninstallHooksNoBeadsRoleIsNotAnError(t *testing.T) {
+	tmpDir := newGitRepo(t)
+	runInDir(t, tmpDir, func() {
+		if err := uninstallHooks(); err != nil {
+			t.Fatalf("uninstallHooks() failed when beads.role was never set: %v", err)
+		}
+	})
+}
+
+// A duplicated beads.role makes git refuse the unset as ambiguous — and it
+// exits 5 to say so, the same code it uses for "key not set". Reading the key
+// before unsetting is what keeps the two apart; treating exit 5 as success
+// would report a clean uninstall with the key still set, which is precisely
+// the failure AC2 exists to prevent.
+func TestUninstallHooksReportsAmbiguousBeadsRole(t *testing.T) {
+	tmpDir := newGitRepo(t)
+	runInDir(t, tmpDir, func() {
+		for _, value := range []string{"primary", "secondary"} {
+			cmd := exec.Command("git", "config", "--add", "beads.role", value)
+			cmd.Dir = tmpDir
+			if err := cmd.Run(); err != nil {
+				t.Fatalf("failed to add beads.role=%s: %v", value, err)
+			}
+		}
+
+		err := uninstallHooks()
+		if err == nil {
+			t.Fatal("uninstallHooks() = nil, want an error: git cannot unset a multi-valued beads.role")
+		}
+		if !strings.Contains(err.Error(), "beads.role") {
+			t.Errorf("error %q does not name beads.role", err)
+		}
+
+		// And the key really is still set — the error was not spurious.
+		getCmd := exec.Command("git", "config", "--get-all", "beads.role")
+		getCmd.Dir = tmpDir
+		out, getErr := getCmd.Output()
+		if getErr != nil {
+			t.Fatalf("expected beads.role to still be set, --get-all failed: %v", getErr)
+		}
+		if len(strings.Fields(string(out))) != 2 {
+			t.Errorf("beads.role values = %q, want both still present", strings.TrimSpace(string(out)))
+		}
+	})
+}
+
+// TestResetHooksPathIfBeadsManagedReportsFailureLoudly verifies AC2: when
+// the underlying git config command genuinely fails, resetHooksPathIfBeadsManaged
+// returns a non-nil error (and thus uninstallHooks propagates it) instead of
+// silently printing a scrolling stderr warning and reporting success.
+func TestResetHooksPathIfBeadsManagedReportsFailureLoudly(t *testing.T) {
+	tmpDir := newGitRepo(t)
+	runInDir(t, tmpDir, func() {
+		gitDir := filepath.Join(tmpDir, ".git")
+		info, err := os.Stat(gitDir)
+		if err != nil {
+			t.Fatalf("failed to stat .git: %v", err)
+		}
+		orig := info.Mode()
+
+		// There has to be something to unset, or there is no git invocation to
+		// fail: the reset reads beads.role first and only unsets it when it is
+		// actually present.
+		setCmd := exec.Command("git", "config", "beads.role", "primary")
+		setCmd.Dir = tmpDir
+		if err := setCmd.Run(); err != nil {
+			t.Fatalf("failed to set beads.role: %v", err)
+		}
+
+		// Make .git/ read+execute only (no write), so `git rev-parse` (used to
+		// resolve repoRoot) and `git config --get` still succeed but
+		// `git config --unset` cannot create its lockfile — a genuine failure,
+		// which resetHooksPathIfBeadsManaged must not swallow.
+		if err := os.Chmod(gitDir, 0555); err != nil {
+			t.Fatalf("failed to chmod .git: %v", err)
+		}
+		t.Cleanup(func() {
+			_ = os.Chmod(gitDir, orig)
+		})
+
+		err = resetHooksPathIfBeadsManaged()
+		if err == nil {
+			t.Fatal("expected resetHooksPathIfBeadsManaged to return an error when the config lockfile cannot be created")
+		}
+		if !strings.Contains(err.Error(), "beads.role") {
+			t.Errorf("error %q does not name the key it failed to unset", err)
+		}
+	})
+}

--- a/docs/recovery/uninstalling.md
+++ b/docs/recovery/uninstalling.md
@@ -89,9 +89,21 @@ If beads-specific git config remains, remove it:
 
 ```bash
 git config --unset beads.role 2>/dev/null || true
+git config --unset core.hooksPath 2>/dev/null || true
 git config --unset merge.beads.driver 2>/dev/null || true
 git config --unset merge.beads.name 2>/dev/null || true
 ```
+
+Do not skip `core.hooksPath`: if it is left set, git keeps looking for a
+hooks directory that no longer exists, and beads' post-checkout import can
+recreate a `.beads/` workspace under the old prefix.
+
+Check the value first, though — `core.hooksPath` is not beads-only. If
+`git config --get core.hooksPath` reports a directory that belongs to another
+hook manager (husky's `.husky/_`, for example) rather than `.beads/hooks` or
+`.beads-hooks`, leave it alone; unsetting it would disable that tool's hooks
+too. `bd doctor` applies the same rule and will not touch a hooks path it did
+not set.
 
 ## Remove the `bd` Binary
 


### PR DESCRIPTION
## Why

Reported in #4440: the user uninstalled beads by hand (`rm -rf .beads/`) and was left with `core.hooksPath` still pointing at the directory they had just deleted, plus a stale `beads.role`. Nothing told them so, and `.beads/` reappearing on checkout made it look like beads was reinstalling itself.

Two things worth correcting from the report before the fix makes sense.

**It is not regeneration.** `runPostCheckoutHook` runs the chained hooks and then `importJSONLForSync("post-checkout")`. `.beads/` reappears as a side effect of that import initialising an embedded-dolt workspace under the old prefix — which is also why the reporter then sees "issue_prefix config is missing". There is no regeneration code to find, and a fixer looking for some will waste an afternoon.

**One of the three suggested fixes already exists and does not help.** `uninstallHooks()` has called `resetHooksPathIfBeadsManaged()` since before this issue was filed. It is irrelevant here because the reporter did a *manual* uninstall and never ran the command; by the time they noticed, `.beads/` was already gone. The other two suggestions were genuinely unimplemented, and are what this PR does.

## What

**A "Hooks Path" doctor check.** None of the three registered hooks checks tests whether the configured hooks path still exists — `hooks_migration.go` reads `core.hooksPath`, resolves it, and assigns it without ever calling `os.Stat`. The new check warns when it resolves to a missing directory, naming both the configured value and the resolved path.

`bd doctor --fix` unsets it, but **only when it is one of the values bd itself writes** (`.beads/hooks`, `.beads-hooks`, relative or absolute). `core.hooksPath` is not a beads-only key — husky and friends use it too, and unsetting someone else's would disable their hooks. `FixHooksPath` re-reads and re-checks both conditions immediately before acting, so a stale check result cannot cause it to touch third-party config. That guard has its own test asserting the value is *still there* afterwards.

**`bd hooks uninstall` also clears `beads.role`, and fails loudly.** `beads.role` was previously only unset by an explicit `bd config unset`, so the reporter's leftover was expected behaviour. Uninstall also swallowed a failed config reset as a scrolling stderr warning and still returned success; it now returns an error naming what it could not unset. Hook-file removal errors keep returning immediately, as before.

`beads.role` is *read* before it is unset rather than treating git's exit 5 as "already absent". Exit 5 also means "refusing an ambiguous unset" on a multi-valued key, so conflating the two would report a clean uninstall with the key still set — the exact failure this change exists to prevent. `TestUninstallHooksReportsAmbiguousBeadsRole` sets the key twice and asserts both the error and that the values survived.

**Docs.** `docs/recovery/uninstalling.md` walks users through precisely the manual path in this report and never mentions `core.hooksPath` — grep the file, it is not there. Manual Cleanup now includes it, with the reason and the not-beads-only caveat.

## Known gap, stated plainly

**The new doctor check does not reach the users most likely to hit this.** Bare `bd doctor` is gated off in embedded mode by deliberate policy (#3794): *"embedded support is enabled one subcommand at a time, each human-vetted — do not lift this gate wholesale."* Embedded is the default, and it is the reporter's mode.

The gate's stated reason is that checks reach into the database layer. This one does not — it shells out to git and stats a directory. So it looks like a candidate for the same per-subcommand vetting that already admitted `--check=artifacts`, `--check=conventions` and `--check=pollution`. But that is a maintainer call the policy comment explicitly reserves, and I have not made it here. Filed separately.

The uninstall and documentation changes in this PR are mode-independent and do help embedded users today.

## Verification

- New tests: `cmd/bd/doctor/hooks_path_test.go` (unset, existing dir, missing beads-managed in relative/`.beads-hooks`/absolute forms, missing non-beads `.husky/_` no-touch guard, existing non-beads, fix-is-no-op-when-target-exists) and `cmd/bd/uninstall_config_test.go` (unsets `beads.role`, absent key is not an error, ambiguous key is a loud error, genuine unset failure is surfaced).
- `go test ./cmd/bd/doctor/... -run 'HooksPath|Hooks'` — `ok`
- `go test ./cmd/bd/ -run 'Hook|Uninstall|ResetHooksPath'` — `ok`
- `go vet ./cmd/bd/...`, `gofmt -l` — clean.
- Full `make test` is queued in the local verifier; I will report the result here.

Confirmed by hand that `bd doctor --fix` leaves a `.husky/_` value untouched.

## Note on CI

`main` is currently red on an unrelated failure (11 migrate-mode tests failing with `workspacegate: acquiring .beads.gate.lock: context canceled`, since `d223edcb6`). Expect that to show on this PR too; it is not from these changes.

_claude-opus-5-high on behalf of maphew_
