### PR TITLE
test(init): stop requiring that a concurrent-init racer lost the race (#4914)

### DIFF
--- a/cmd/bd/init_embedded_test.go
+++ b/cmd/bd/init_embedded_test.go
@@ -1920,8 +1920,26 @@ func TestEmbeddedInit(t *testing.T) {
 // before the embedded Dolt flock is ever attempted, so contention here
 // normally surfaces as gate-busy output rather than a flock error; either is
 // classified by isEmbeddedLockOutput as the same "another process holds the
-// lock" outcome. At least one process must succeed and at least one must
-// see a lock/gate-busy outcome; unexpected errors still fail the test.
+// lock" outcome. At least one process must succeed; unexpected errors still
+// fail the test.
+//
+// It deliberately does NOT require that any racer *observed* contention.
+// Whether a waiter blocks and then succeeds or gives up and reports the gate
+// busy depends on how long the winner holds the gate versus the waiter's wait
+// budget — a property of the machine, not of the lock. On a runner fast enough
+// that all ten inits serialize inside that budget, zero lock errors is the
+// correct outcome: it means serialization worked and nobody had to give up.
+// Requiring one made this test fail on exactly the hardware where the gate was
+// working best (GH#4914), and the EXCLUSIVE gate added in #5093 — acquired
+// before the embedded flock is ever attempted — makes the serialize-and-succeed
+// outcome more likely, not less. Every other concurrency test in this package
+// already treats contention as tolerated rather than required; this one was the
+// outlier.
+//
+// The contention path itself is not left uncovered:
+// TestInitGateBusyClassifiedAsLockContention (added alongside the gate in
+// #5093) exercises it deterministically by holding the gate in-process, which
+// is what this test was approximating by racing.
 func TestEmbeddedInitConcurrent(t *testing.T) {
 	if os.Getenv("BEADS_TEST_EMBEDDED_DOLT") != "1" {
 		t.Skip("set BEADS_TEST_EMBEDDED_DOLT=1 to run embedded dolt init tests")
@@ -1980,9 +1998,7 @@ func TestEmbeddedInitConcurrent(t *testing.T) {
 	if successes < 1 {
 		t.Errorf("expected at least 1 success, got %d", successes)
 	}
-	if lockErrors < 1 {
-		t.Errorf("expected at least 1 lock error, got %d", lockErrors)
-	}
+	// No assertion on lockErrors: see the doc comment. 0 is a valid outcome.
 	// timeoutKills > 2 (i.e. > N/5) indicates a systemic runner problem, not normal load variance.
 	if timeoutKills > 2 {
 		t.Errorf("too many timeout-killed processes: %d/%d (cap is 2)", timeoutKills, N)


### PR DESCRIPTION
## Why

`TestEmbeddedInitConcurrent` asserted that at least one of ten concurrent `bd init` processes came back reporting contention:

```go
if lockErrors < 1 {
    t.Errorf("expected at least 1 lock error, got %d", lockErrors)
}
```

That is an assertion about timing, not about the lock. Whether a waiter blocks and then succeeds, or gives up and reports the gate busy, depends on how long the winner holds the gate versus the waiter's wait budget — a property of the machine. On a runner fast enough that all ten inits serialize inside that budget, **zero lock errors is the correct outcome**: it means serialization worked and nobody had to give up.

So the test fails on exactly the hardware where the gate is working best. The EXCLUSIVE workspace gate added in #5093 makes that more likely, not less, because it is acquired before the embedded Dolt flock is ever attempted.

Reproduced on `main` @ `9973e9628` with no other changes:

```
init_embedded_test.go:1984: expected at least 1 lock error, got 0
init_embedded_test.go:1994: 10/10 succeeded, 0/10 got lock error, 0/10 timed out
--- FAIL: TestEmbeddedInitConcurrent (11.10s)
```

With this branch, same host: `--- PASS: TestEmbeddedInitConcurrent (11.99s)`, logging the same `10/10 succeeded, 0/10 got lock error`.

## What

One assertion removed, plus the doc comment explaining why it should not come back.

Everything else is kept: at least one success, the timeout-kill cap, the outcome-total invariant, and the post-conditions that are the actual safety property — one coherent database, clean working set, the `schema: apply migrations` commit present, correct prefix and backend. Those are what "the gate prevents concurrent writers" means. An observed lock error is not; it is evidence about how the race happened to resolve.

This also brings the test in line with the rest of the package. `config_embedded_test.go`, `reopen_embedded_test.go`, `defer_embedded_test.go`, `diff_embedded_test.go` and others all treat `"one writer at a time"` as a tolerated outcome and log "flock contention expected" without requiring it. `TestEmbeddedInitConcurrent` was the outlier.

## No coverage gap

The contention path stays covered, deterministically. #5093 added `TestInitGateBusyClassifiedAsLockContention`, which holds the gate in-process and asserts a loser's output is classified as lock contention — which is precisely what this test was approximating by racing subprocesses against a wall clock. Its own doc comment says so:

> Deterministic and fast: it holds the gate in-process instead of racing subprocesses against a wall-clock deadline, so unlike `TestEmbeddedInitConcurrent` it does not depend on the winner's init being slow enough to exhaust another process's wait budget.

That test arrived with the gate; removing the racy assertion is the other half of the same change. I wrote a second lock-holding test before finding it, then deleted mine as redundant.

## Verification

```
$ BEADS_TEST_EMBEDDED_DOLT=1 go test -tags gms_pure_go ./cmd/bd/ \
    -run 'TestEmbeddedInitConcurrent|TestInitGateBusyClassifiedAsLockContention' -count=1 -v
--- PASS: TestInitGateBusyClassifiedAsLockContention (0.01s)
    init_embedded_test.go:2010: 10/10 succeeded, 0/10 got lock error, 0/10 timed out
--- PASS: TestEmbeddedInitConcurrent (11.99s)
ok      github.com/steveyegge/beads/cmd/bd      12.125s
```

`gofmt -l` and `go vet ./cmd/bd/` clean. Host: Linux, dolt 2.2.3.

## Note on CI

`main` is currently red on an unrelated failure (11 migrate-mode tests, `workspacegate: acquiring .beads.gate.lock: context canceled`, since `d223edcb6`). Expect it here too; it is not from this change.

_claude-opus-5-high on behalf of maphew_
