### PR TITLE
feat(update): enforce close policy when a status update crosses into done

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Breaking: `bd update --status <done-status>` now enforces close policy.**
+  Moving an issue into `closed` (or any configured done-category status) via
+  `bd update`, `bd batch update`, or the issueops facade now refuses when the
+  issue has open children or a live direct blocker — matching `bd close`.
+  Override with `bd update --force`, which now means: allow `-a/--assignee` to
+  overwrite another actor's live in_progress claim, AND allow a status change
+  into done despite open children or a live blocker (same as
+  `bd close --force`). `bd update --force` without `-a` was previously a
+  validation error on the direct path; it is now valid. In `bd batch`, spell the
+  override `update <id> status=closed force=true`; an unforced refusal rolls
+  back the entire batch. Facade consumers: set `UpdateRequest.ForceClosePolicy`.
+  Tracker sync-pull always forces (remote state is authoritative).
+  `bd batch close` remains unchecked, as before.
+
 - **`beads.BulkIssueStore.ReclaimExpiredLeases` gained a `types.ReclaimFilter`
   parameter** (wy-jpd3.3), threaded through the domain use-case/repository
   interfaces and every backend. Callers that reclaim globally pass the zero

--- a/cmd/bd/batch.go
+++ b/cmd/bd/batch.go
@@ -53,8 +53,15 @@ Grammar (one command per line):
   dep remove <from-id> <to-id>
   #comment  (blank lines and '# ...' comments are ignored)
 
-Supported 'update' keys: status, priority, title, assignee
+Supported 'update' keys: status, priority, title, assignee, force
 Supported dependency types: see 'bd dep add --help' (default: blocks)
+
+'force' is not a field. An update whose status moves the issue into closed
+(or a configured done status) is refused when it still has open children or
+a live blocker, the same as 'bd close'; 'force=true' overrides that refusal.
+Because the batch is one transaction, an unforced refusal rolls back EVERY
+operation in the batch, not just the offending line. Note the asymmetry with
+'close <id>', which does not apply that policy at all.
 
 Tokens are whitespace-separated. Double-quoted strings ("like this") may
 contain spaces; use \" to embed a quote and \\ for a backslash.

--- a/cmd/bd/batch.go
+++ b/cmd/bd/batch.go
@@ -13,6 +13,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/steveyegge/beads/internal/metrics"
 	"github.com/steveyegge/beads/internal/storage"
+	"github.com/steveyegge/beads/internal/storage/issueops"
 	"github.com/steveyegge/beads/internal/types"
 )
 
@@ -475,8 +476,17 @@ func parseUpdateKVs(kvs []string) (map[string]interface{}, error) {
 			updates["title"] = value
 		case "assignee":
 			updates["assignee"] = value
+		case "force":
+			// Not a field: the override for close policy on a status that
+			// crosses into done, spelled as a token because a batch script has
+			// no flags. The write funnel pops it before validating fields.
+			force, err := strconv.ParseBool(value)
+			if err != nil {
+				return nil, fmt.Errorf("update: invalid force %q: %w", value, err)
+			}
+			updates[issueops.OpForceClosePolicy] = force
 		default:
-			return nil, fmt.Errorf("update: unsupported key %q (allowed: status, priority, title, assignee)", key)
+			return nil, fmt.Errorf("update: unsupported key %q (allowed: status, priority, title, assignee, force)", key)
 		}
 	}
 	return updates, nil

--- a/cmd/bd/update.go
+++ b/cmd/bd/update.go
@@ -907,8 +907,8 @@ func init() {
 	updateCmd.Flags().StringSlice("set-labels", nil, "Set labels, replacing all existing (repeatable)")
 	updateCmd.Flags().String("parent", "", "New parent issue ID (reparents the issue, use empty string to remove parent)")
 	updateCmd.Flags().Bool("claim", false, "Atomically claim the issue (sets assignee to you, status to in_progress; idempotent if already claimed by you; issues assigned to a pool alias listed in the claim.pools config are claimable too)")
-	// Live-claim reassign fence override (bd-98s5c)
-	updateCmd.Flags().Bool("force", false, "Allow -a/--assignee to overwrite another actor's live in_progress claim (use only for abandoned claims — crashed agent, expired lease; prefer bd reclaim)")
+	// Overrides the live-claim reassign fence (bd-98s5c) and close policy.
+	updateCmd.Flags().Bool("force", false, "Override two refusals: let -a/--assignee overwrite another actor's live in_progress claim (use only for abandoned claims — crashed agent, expired lease; prefer bd reclaim), and let -s/--status move the issue into closed (or a configured done status) despite open children or a live blocker (same as bd close --force)")
 	// Conditional (compare-and-set) update guards (bd-wsqvw)
 	updateCmd.Flags().String("if-assignee", "", "Apply the update only if the current assignee equals this value (--if-assignee '' requires unassigned); a mismatch writes nothing and exits 13 (vs 1 for other failures). Requires a field update; cannot combine with --claim")
 	updateCmd.Flags().String("if-status", "", "Apply the update only if the current status equals this value; a mismatch writes nothing and exits 13 (vs 1 for other failures). Requires a field update; cannot combine with --claim")

--- a/cmd/bd/update.go
+++ b/cmd/bd/update.go
@@ -467,12 +467,18 @@ pointless).`,
 			// Guards ride the operation itself: a stale assignee/status refuses
 			// atomically with a typed mismatch error and MUST surface as a
 			// non-zero exit — never collapse it to success (finding #10).
+			// One --force, two overrides. The assignee half only applies to an
+			// assignee edit — asserting it without one is an invalid request,
+			// which is why it is conditioned here rather than passed straight
+			// through: `--force -s closed` is now a legitimate way to ask for
+			// the close-policy half alone.
 			updateResult, updateErr := ops.Update(opsCtx, issueops.UpdateRequest{
 				Actor:                 actor,
 				IssueID:               result.ResolvedID,
 				Patch:                 patch,
 				Claim:                 claimFlag,
-				ForceAssigneeTransfer: forceFlag,
+				ForceAssigneeTransfer: forceFlag && patch.Assignee.Set,
+				ForceClosePolicy:      forceFlag,
 				ExpectedAssignee:      ifAssignee,
 				ExpectedStatus:        expectedStatus,
 			})

--- a/cmd/bd/update_close_policy_test.go
+++ b/cmd/bd/update_close_policy_test.go
@@ -1,0 +1,172 @@
+//go:build cgo
+
+package main
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// Close policy on the generic status update. `bd close` refuses an issue that
+// still has open parent-child children or a live direct blocker; the cases
+// below pin what `bd update --status closed` does at that same boundary, on
+// each surface that can reach a write funnel carrying a status of its own.
+//
+// These start as characterizations of today's permissive behavior. They are
+// inverted in the commit that moves the policy into the funnels, so the
+// behavior change reads as an explicit diff rather than a new file appearing
+// beside untouched old assertions.
+
+// seedClosePolicyFixture creates a parent with one open child and a target with
+// one live direct blocker, and returns the two IDs a status update is aimed at.
+func seedClosePolicyFixture(t *testing.T, env *parityEnv, prefix string) (parentID, blockedID string) {
+	t.Helper()
+	parentID = prefix + "-parent"
+	childID := prefix + "-child"
+	blockerID := prefix + "-blocker"
+	blockedID = prefix + "-blocked"
+	for _, id := range []string{parentID, childID, blockerID, blockedID} {
+		env.seed(id, id, nil)
+	}
+	for _, dep := range []*types.Dependency{
+		{IssueID: childID, DependsOnID: parentID, Type: types.DepParentChild},
+		{IssueID: blockedID, DependsOnID: blockerID, Type: types.DepBlocks},
+	} {
+		if err := env.store.inner.AddDependency(rootCtx, dep, "parity-seed"); err != nil {
+			t.Fatalf("seed dependency %s -> %s: %v", dep.IssueID, dep.DependsOnID, err)
+		}
+	}
+	if blocked, _, err := env.store.inner.IsBlocked(rootCtx, blockedID); err != nil || !blocked {
+		t.Fatalf("%s should be blocked (blocked=%v err=%v)", blockedID, blocked, err)
+	}
+	env.store.reset()
+	return parentID, blockedID
+}
+
+// TestUpdateClosePolicyDirectCrossesIntoDone drives the direct (non-proxied)
+// `bd update` path, which reaches the embedded write funnel through the
+// issue-operations facade.
+func TestUpdateClosePolicyDirectCrossesIntoDone(t *testing.T) {
+	env := newParityEnv(t)
+	parentID, blockedID := seedClosePolicyFixture(t, env, "test-ucp")
+
+	// CHARACTERIZATION: an open child does not stop the crossing.
+	env.setFlags(updateCmd, map[string]string{"status": "closed"})
+	res := env.run(updateCmd, parentID)
+	if res.exitCode != 0 {
+		t.Fatalf("update %s into done: exit = %d, want 0\nstderr:\n%s", parentID, res.exitCode, res.stderr)
+	}
+	if got := env.get(parentID).Status; got != types.StatusClosed {
+		t.Errorf("%s status = %q, want closed", parentID, got)
+	}
+
+	// CHARACTERIZATION: neither does a live direct blocker.
+	res = env.run(updateCmd, blockedID)
+	if res.exitCode != 0 {
+		t.Fatalf("update %s into done: exit = %d, want 0\nstderr:\n%s", blockedID, res.exitCode, res.stderr)
+	}
+	if got := env.get(blockedID).Status; got != types.StatusClosed {
+		t.Errorf("%s status = %q, want closed", blockedID, got)
+	}
+
+	// A done-to-done restatement is filtered out as a no-op before any policy
+	// could observe it.
+	res = env.run(updateCmd, parentID)
+	if res.exitCode != 0 {
+		t.Fatalf("restate %s as done: exit = %d, want 0\nstderr:\n%s", parentID, res.exitCode, res.stderr)
+	}
+}
+
+// TestUpdateClosePolicyDirectForceWithoutAssignee pins how the direct path
+// treats a bare `--force`. The flag's only meaning today is the assignee
+// fence, and the CLI hands it to the facade unconditionally, so a `--force`
+// with no `-a` to authorize is rejected as an invalid request.
+func TestUpdateClosePolicyDirectForceWithoutAssignee(t *testing.T) {
+	env := newParityEnv(t)
+	env.seed("test-ucpf", "Force without assignee", nil)
+
+	env.setFlags(updateCmd, map[string]string{"status": "closed", "force": "true"})
+	res := env.run(updateCmd, "test-ucpf")
+	// CHARACTERIZATION: rejected, and the status never lands.
+	if res.exitCode != 1 {
+		t.Fatalf("exit = %d, want 1\nstderr:\n%s", res.exitCode, res.stderr)
+	}
+	if !strings.Contains(res.stderr, "invalid forced assignee transfer") {
+		t.Errorf("stderr lacks the assignee-fence validation refusal:\n%s", res.stderr)
+	}
+	if got := env.get("test-ucpf").Status; got != types.StatusOpen {
+		t.Errorf("status = %q after a rejected request, want open", got)
+	}
+}
+
+// TestUpdateClosePolicyBatchCrossesIntoDone drives `bd batch update`, whose
+// transaction reaches the same embedded write funnel without going through the
+// facade at all.
+func TestUpdateClosePolicyBatchCrossesIntoDone(t *testing.T) {
+	tmpDir := t.TempDir()
+	st := newTestStoreWithPrefix(t, filepath.Join(tmpDir, ".beads", "beads.db"), "tbc")
+	ctx := context.Background()
+
+	seedBatchTestIssues(t, ctx, st, "tbc-parent", "tbc-child", "tbc-blocker", "tbc-blocked")
+	for _, dep := range []*types.Dependency{
+		{IssueID: "tbc-child", DependsOnID: "tbc-parent", Type: types.DepParentChild},
+		{IssueID: "tbc-blocked", DependsOnID: "tbc-blocker", Type: types.DepBlocks},
+	} {
+		if err := st.AddDependency(ctx, dep, "test"); err != nil {
+			t.Fatalf("seed dependency %s -> %s: %v", dep.IssueID, dep.DependsOnID, err)
+		}
+	}
+
+	// CHARACTERIZATION: the batch grammar crosses both boundaries unimpeded.
+	script := "update tbc-parent status=closed\nupdate tbc-blocked status=closed\n"
+	if err := runBatchScriptInTx(t, ctx, st, script); err != nil {
+		t.Fatalf("batch update into done: %v", err)
+	}
+	for _, id := range []string{"tbc-parent", "tbc-blocked"} {
+		got, err := st.GetIssue(ctx, id)
+		if err != nil {
+			t.Fatalf("GetIssue %s: %v", id, err)
+		}
+		if got.Status != types.StatusClosed {
+			t.Errorf("%s status = %q, want closed", id, got.Status)
+		}
+	}
+}
+
+// TestUpdateClosePolicyBatchGrammarRejectsForce pins the batch update
+// grammar's allowlist. It is the surface that keeps a reserved update-map key
+// from being client-reachable, so it must reject anything it does not name.
+func TestUpdateClosePolicyBatchGrammarRejectsForce(t *testing.T) {
+	// CHARACTERIZATION: force is not part of the grammar.
+	if _, err := parseUpdateKVs([]string{"status=closed", "force=true"}); err == nil {
+		t.Fatal("parseUpdateKVs accepted force=true; the grammar has no override token yet")
+	}
+	if _, err := parseUpdateKVs([]string{"_force_close_policy=true"}); err == nil {
+		t.Fatal("parseUpdateKVs accepted a reserved update-map key as a client token")
+	}
+}
+
+// TestUpdateClosePolicyProxiedSpecCarriesNoForce pins the proxied path's
+// translation of `--force`. This is the exact shape of the mapping that was
+// reverted in 11382270b: the proxied caller built a spec that never carried
+// the override, so a shared policy check would refuse it with no way to say
+// otherwise.
+func TestUpdateClosePolicyProxiedSpecCarriesNoForce(t *testing.T) {
+	current := &types.Issue{ID: "test-ucpp", Status: types.StatusOpen}
+	in := &updateInput{fields: map[string]any{"status": string(types.StatusClosed)}, force: true}
+
+	spec := buildUpdateSpecForIssue(current, in)
+
+	// CHARACTERIZATION: --force reaches no further than the reassign fence.
+	// Spelled as a literal because no override key exists yet.
+	if _, ok := spec.Fields["_force_close_policy"]; ok {
+		t.Error("spec.Fields carries a close-policy override; the proxied path has none yet")
+	}
+	if got := spec.Fields["status"]; got != string(types.StatusClosed) {
+		t.Errorf("spec.Fields[status] = %v, want closed", got)
+	}
+}

--- a/cmd/bd/update_close_policy_test.go
+++ b/cmd/bd/update_close_policy_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/steveyegge/beads/internal/storage/issueops"
 	"github.com/steveyegge/beads/internal/types"
 )
 
@@ -82,24 +83,53 @@ func TestUpdateClosePolicyDirectCrossesIntoDone(t *testing.T) {
 }
 
 // TestUpdateClosePolicyDirectForceWithoutAssignee pins how the direct path
-// treats a bare `--force`. The flag's only meaning today is the assignee
-// fence, and the CLI hands it to the facade unconditionally, so a `--force`
-// with no `-a` to authorize is rejected as an invalid request.
+// treats a bare `--force`. The flag now carries a second override that stands
+// on its own, so `--force` with no `-a` is a legitimate request: the assignee
+// half is simply not asserted, and the update applies.
 func TestUpdateClosePolicyDirectForceWithoutAssignee(t *testing.T) {
 	env := newParityEnv(t)
 	env.seed("test-ucpf", "Force without assignee", nil)
 
 	env.setFlags(updateCmd, map[string]string{"status": "closed", "force": "true"})
 	res := env.run(updateCmd, "test-ucpf")
-	// CHARACTERIZATION: rejected, and the status never lands.
-	if res.exitCode != 1 {
-		t.Fatalf("exit = %d, want 1\nstderr:\n%s", res.exitCode, res.stderr)
+	if res.exitCode != 0 {
+		t.Fatalf("exit = %d, want 0\nstderr:\n%s", res.exitCode, res.stderr)
 	}
-	if !strings.Contains(res.stderr, "invalid forced assignee transfer") {
-		t.Errorf("stderr lacks the assignee-fence validation refusal:\n%s", res.stderr)
+	if strings.Contains(res.stderr, "invalid forced assignee transfer") {
+		t.Errorf("--force without -a still asserts the assignee fence:\n%s", res.stderr)
 	}
-	if got := env.get("test-ucpf").Status; got != types.StatusOpen {
-		t.Errorf("status = %q after a rejected request, want open", got)
+	if got := env.get("test-ucpf").Status; got != types.StatusClosed {
+		t.Errorf("status = %q, want closed", got)
+	}
+}
+
+// TestUpdateClosePolicyDirectForceStillFencesAssigneeTransfer keeps the other
+// half of `--force` intact. Conditioning it on an assignee edit must not turn
+// it off when there IS one: a transfer away from a live foreign claim is still
+// exactly what the flag authorizes.
+func TestUpdateClosePolicyDirectForceStillFencesAssigneeTransfer(t *testing.T) {
+	env := newParityEnv(t)
+	env.seed("test-ucpa", "Held by another actor", func(i *types.Issue) {
+		i.Assignee = "someone-else"
+		i.Status = types.StatusInProgress
+	})
+
+	// Without --force the fence holds.
+	env.setFlags(updateCmd, map[string]string{"assignee": "thief"})
+	if res := env.run(updateCmd, "test-ucpa"); res.exitCode == 0 {
+		t.Fatalf("unforced transfer succeeded; the fence is gone\nstderr:\n%s", res.stderr)
+	}
+	if got := env.get("test-ucpa").Assignee; got != "someone-else" {
+		t.Fatalf("assignee = %q after a refused transfer, want someone-else", got)
+	}
+
+	// With it, the transfer is authorized.
+	env.setFlags(updateCmd, map[string]string{"assignee": "thief", "force": "true"})
+	if res := env.run(updateCmd, "test-ucpa"); res.exitCode != 0 {
+		t.Fatalf("forced transfer exit = %d, want 0\nstderr:\n%s", res.exitCode, res.stderr)
+	}
+	if got := env.get("test-ucpa").Assignee; got != "thief" {
+		t.Errorf("assignee = %q, want thief", got)
 	}
 }
 
@@ -137,36 +167,64 @@ func TestUpdateClosePolicyBatchCrossesIntoDone(t *testing.T) {
 	}
 }
 
-// TestUpdateClosePolicyBatchGrammarRejectsForce pins the batch update
-// grammar's allowlist. It is the surface that keeps a reserved update-map key
-// from being client-reachable, so it must reject anything it does not name.
-func TestUpdateClosePolicyBatchGrammarRejectsForce(t *testing.T) {
-	// CHARACTERIZATION: force is not part of the grammar.
-	if _, err := parseUpdateKVs([]string{"status=closed", "force=true"}); err == nil {
-		t.Fatal("parseUpdateKVs accepted force=true; the grammar has no override token yet")
+// TestUpdateClosePolicyBatchGrammarForceToken pins the batch update grammar's
+// spelling of the override, and — the part that matters — pins the allowlist
+// that keeps the reserved update-map key from being client-reachable. A script
+// asks for force by the grammar's own token; it can never name the transport
+// key itself, which is what stops the key from becoming a policy bypass.
+func TestUpdateClosePolicyBatchGrammarForceToken(t *testing.T) {
+	updates, err := parseUpdateKVs([]string{"status=closed", "force=true"})
+	if err != nil {
+		t.Fatalf("parseUpdateKVs(force=true): %v", err)
+	}
+	if got := updates[issueops.OpForceClosePolicy]; got != true {
+		t.Errorf("updates[%q] = %v, want true", issueops.OpForceClosePolicy, got)
+	}
+	if updates["status"] != "closed" {
+		t.Errorf("updates[status] = %v, want closed", updates["status"])
+	}
+
+	unforced, err := parseUpdateKVs([]string{"status=closed", "force=false"})
+	if err != nil {
+		t.Fatalf("parseUpdateKVs(force=false): %v", err)
+	}
+	if got := unforced[issueops.OpForceClosePolicy]; got != false {
+		t.Errorf("updates[%q] = %v, want false", issueops.OpForceClosePolicy, got)
+	}
+
+	if _, err := parseUpdateKVs([]string{"force=perhaps"}); err == nil {
+		t.Error("parseUpdateKVs accepted a non-boolean force value")
 	}
 	if _, err := parseUpdateKVs([]string{"_force_close_policy=true"}); err == nil {
-		t.Fatal("parseUpdateKVs accepted a reserved update-map key as a client token")
+		t.Error("parseUpdateKVs accepted the reserved update-map key as a client token")
+	}
+	if _, err := parseUpdateKVs([]string{"description=foo"}); err == nil {
+		t.Error("parseUpdateKVs stopped rejecting keys outside its allowlist")
 	}
 }
 
-// TestUpdateClosePolicyProxiedSpecCarriesNoForce pins the proxied path's
-// translation of `--force`. This is the exact shape of the mapping that was
+// TestUpdateClosePolicyProxiedSpecCarriesForce pins the proxied path's
+// translation of `--force`. This is the exact mapping whose absence was
 // reverted in 11382270b: the proxied caller built a spec that never carried
-// the override, so a shared policy check would refuse it with no way to say
-// otherwise.
-func TestUpdateClosePolicyProxiedSpecCarriesNoForce(t *testing.T) {
+// the override, so a shared policy check refused it with no way to say
+// otherwise. The spec must carry it, and must not invent it.
+func TestUpdateClosePolicyProxiedSpecCarriesForce(t *testing.T) {
 	current := &types.Issue{ID: "test-ucpp", Status: types.StatusOpen}
-	in := &updateInput{fields: map[string]any{"status": string(types.StatusClosed)}, force: true}
 
-	spec := buildUpdateSpecForIssue(current, in)
-
-	// CHARACTERIZATION: --force reaches no further than the reassign fence.
-	// Spelled as a literal because no override key exists yet.
-	if _, ok := spec.Fields["_force_close_policy"]; ok {
-		t.Error("spec.Fields carries a close-policy override; the proxied path has none yet")
+	forced := buildUpdateSpecForIssue(current, &updateInput{
+		fields: map[string]any{"status": string(types.StatusClosed)}, force: true,
+	})
+	if got := forced.Fields[issueops.OpForceClosePolicy]; got != true {
+		t.Errorf("spec.Fields[%q] = %v, want true", issueops.OpForceClosePolicy, got)
 	}
-	if got := spec.Fields["status"]; got != string(types.StatusClosed) {
+	if got := forced.Fields["status"]; got != string(types.StatusClosed) {
 		t.Errorf("spec.Fields[status] = %v, want closed", got)
+	}
+
+	unforced := buildUpdateSpecForIssue(current, &updateInput{
+		fields: map[string]any{"status": string(types.StatusClosed)},
+	})
+	if _, ok := unforced.Fields[issueops.OpForceClosePolicy]; ok {
+		t.Errorf("spec.Fields carries %q without --force", issueops.OpForceClosePolicy)
 	}
 }

--- a/cmd/bd/update_close_policy_test.go
+++ b/cmd/bd/update_close_policy_test.go
@@ -4,10 +4,12 @@ package main
 
 import (
 	"context"
+	"errors"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/storage/issueops"
 	"github.com/steveyegge/beads/internal/types"
 )
@@ -55,30 +57,103 @@ func TestUpdateClosePolicyDirectCrossesIntoDone(t *testing.T) {
 	env := newParityEnv(t)
 	parentID, blockedID := seedClosePolicyFixture(t, env, "test-ucp")
 
-	// CHARACTERIZATION: an open child does not stop the crossing.
+	// An open child refuses, names the count, and writes nothing.
 	env.setFlags(updateCmd, map[string]string{"status": "closed"})
 	res := env.run(updateCmd, parentID)
-	if res.exitCode != 0 {
-		t.Fatalf("update %s into done: exit = %d, want 0\nstderr:\n%s", parentID, res.exitCode, res.stderr)
+	if res.exitCode != 1 {
+		t.Fatalf("update %s into done: exit = %d, want 1\nstderr:\n%s", parentID, res.exitCode, res.stderr)
 	}
-	if got := env.get(parentID).Status; got != types.StatusClosed {
-		t.Errorf("%s status = %q, want closed", parentID, got)
+	if !strings.Contains(res.stderr, "1 open child issue(s)") {
+		t.Errorf("stderr lacks the open-children refusal:\n%s", res.stderr)
+	}
+	if got := env.get(parentID).Status; got != types.StatusOpen {
+		t.Errorf("%s status = %q after a refusal, want open", parentID, got)
 	}
 
-	// CHARACTERIZATION: neither does a live direct blocker.
+	// A live direct blocker refuses too.
 	res = env.run(updateCmd, blockedID)
-	if res.exitCode != 0 {
-		t.Fatalf("update %s into done: exit = %d, want 0\nstderr:\n%s", blockedID, res.exitCode, res.stderr)
+	if res.exitCode != 1 {
+		t.Fatalf("update %s into done: exit = %d, want 1\nstderr:\n%s", blockedID, res.exitCode, res.stderr)
 	}
-	if got := env.get(blockedID).Status; got != types.StatusClosed {
-		t.Errorf("%s status = %q, want closed", blockedID, got)
+	if !strings.Contains(res.stderr, "blocked by") {
+		t.Errorf("stderr lacks the blocker refusal:\n%s", res.stderr)
+	}
+	if got := env.get(blockedID).Status; got != types.StatusOpen {
+		t.Errorf("%s status = %q after a refusal, want open", blockedID, got)
+	}
+
+	// --force overrides both.
+	env.setFlags(updateCmd, map[string]string{"status": "closed", "force": "true"})
+	for _, id := range []string{parentID, blockedID} {
+		if res := env.run(updateCmd, id); res.exitCode != 0 {
+			t.Fatalf("forced update %s into done: exit = %d\nstderr:\n%s", id, res.exitCode, res.stderr)
+		}
+		if got := env.get(id).Status; got != types.StatusClosed {
+			t.Errorf("%s status = %q after --force, want closed", id, got)
+		}
 	}
 
 	// A done-to-done restatement is filtered out as a no-op before any policy
-	// could observe it.
-	res = env.run(updateCmd, parentID)
-	if res.exitCode != 0 {
+	// could observe it, so it needs no force despite the still-open child.
+	env.setFlags(updateCmd, map[string]string{"status": "closed"})
+	if res := env.run(updateCmd, parentID); res.exitCode != 0 {
 		t.Fatalf("restate %s as done: exit = %d, want 0\nstderr:\n%s", parentID, res.exitCode, res.stderr)
+	}
+}
+
+// TestUpdateClosePolicyDirectRefusalIsInert pins what a refusal costs. Nothing
+// about the issue may move — not the row, not its event stream, not a claim
+// riding the same request — and no hook may fire, because the parity harness
+// counts one facade mutation per hook production would run.
+func TestUpdateClosePolicyDirectRefusalIsInert(t *testing.T) {
+	env := newParityEnv(t)
+	parentID, _ := seedClosePolicyFixture(t, env, "test-ucpi")
+
+	beforeEvents := len(env.eventTypes(parentID))
+	before := env.get(parentID)
+
+	// The claim rides the same request, so a refusal must take it down too.
+	env.setFlags(updateCmd, map[string]string{"status": "closed", "claim": "true"})
+	res := env.run(updateCmd, parentID)
+	if res.exitCode != 1 {
+		t.Fatalf("exit = %d, want 1\nstderr:\n%s", res.exitCode, res.stderr)
+	}
+
+	after := env.get(parentID)
+	if after.Status != before.Status || after.Assignee != before.Assignee || after.RowVersion != before.RowVersion {
+		t.Errorf("refusal moved the row: %+v -> %+v", before, after)
+	}
+	if after.ClosedAt != nil {
+		t.Error("refusal stamped closed_at")
+	}
+	if got := len(env.eventTypes(parentID)); got != beforeEvents {
+		t.Errorf("refusal wrote %d events, want 0", got-beforeEvents)
+	}
+	if got := env.store.mutations(); len(got) != 0 {
+		t.Errorf("refusal made %v store mutations, want none (each would fire a hook)", got)
+	}
+}
+
+// TestUpdateClosePolicyDirectForcedCrossingStaysAnUpdate keeps the change
+// scoped to policy. A forced crossing is still an update, not a close: it
+// records the status-change event stream an update records, and never the
+// close verb's own.
+func TestUpdateClosePolicyDirectForcedCrossingStaysAnUpdate(t *testing.T) {
+	env := newParityEnv(t)
+	parentID, _ := seedClosePolicyFixture(t, env, "test-ucpu")
+	before := len(env.eventTypes(parentID))
+
+	env.setFlags(updateCmd, map[string]string{"status": "closed", "force": "true"})
+	if res := env.run(updateCmd, parentID); res.exitCode != 0 {
+		t.Fatalf("forced crossing: exit = %d\nstderr:\n%s", res.exitCode, res.stderr)
+	}
+
+	if got := env.store.mutations(); len(got) != 1 || got[0] != "Update" {
+		t.Errorf("store mutations = %v, want exactly one Update (never a Close)", got)
+	}
+	added := env.eventTypes(parentID)[before:]
+	if len(added) != 1 {
+		t.Fatalf("forced crossing wrote %v, want one event", added)
 	}
 }
 
@@ -151,10 +226,33 @@ func TestUpdateClosePolicyBatchCrossesIntoDone(t *testing.T) {
 		}
 	}
 
-	// CHARACTERIZATION: the batch grammar crosses both boundaries unimpeded.
-	script := "update tbc-parent status=closed\nupdate tbc-blocked status=closed\n"
-	if err := runBatchScriptInTx(t, ctx, st, script); err != nil {
-		t.Fatalf("batch update into done: %v", err)
+	// An unforced crossing refuses — and because the batch is one transaction,
+	// it takes the WHOLE batch down, including the priority edit on a line that
+	// had nothing to do with the refusal. That is the documented contract.
+	script := "update tbc-blocker priority=0\nupdate tbc-parent status=closed\n"
+	err := runBatchScriptInTx(t, ctx, st, script)
+	if err == nil {
+		t.Fatal("batch update into done with an open child succeeded, want a refusal")
+	}
+	if !errors.Is(err, storage.ErrCloseOpenChildren) {
+		t.Errorf("batch error = %v, want ErrCloseOpenChildren", err)
+	}
+	rolledBack, getErr := st.GetIssue(ctx, "tbc-blocker")
+	if getErr != nil {
+		t.Fatalf("GetIssue tbc-blocker: %v", getErr)
+	}
+	if rolledBack.Priority != 2 {
+		t.Errorf("tbc-blocker priority = %d; an unforced refusal must roll back the whole batch", rolledBack.Priority)
+	}
+
+	if err := runBatchScriptInTx(t, ctx, st, "update tbc-blocked status=closed\n"); !errors.Is(err, storage.ErrCloseBlocked) {
+		t.Errorf("batch error = %v, want ErrCloseBlocked", err)
+	}
+
+	// force=true overrides both, in the same one transaction.
+	forced := "update tbc-parent status=closed force=true\nupdate tbc-blocked status=closed force=true\n"
+	if err := runBatchScriptInTx(t, ctx, st, forced); err != nil {
+		t.Fatalf("forced batch update into done: %v", err)
 	}
 	for _, id := range []string{"tbc-parent", "tbc-blocked"} {
 		got, err := st.GetIssue(ctx, id)

--- a/cmd/bd/update_close_policy_test.go
+++ b/cmd/bd/update_close_policy_test.go
@@ -302,10 +302,10 @@ func TestUpdateClosePolicyBatchGrammarForceToken(t *testing.T) {
 }
 
 // TestUpdateClosePolicyProxiedSpecCarriesForce pins the proxied path's
-// translation of `--force`. This is the exact mapping whose absence was
-// reverted in 11382270b: the proxied caller built a spec that never carried
-// the override, so a shared policy check refused it with no way to say
-// otherwise. The spec must carry it, and must not invent it.
+// translation of `--force`. An earlier attempt was reverted for exactly this
+// missing mapping: the proxied caller built a spec that never carried the
+// override, so a shared policy check refused the close with no way for the
+// user to say otherwise. The spec must carry it, and must not invent it.
 func TestUpdateClosePolicyProxiedSpecCarriesForce(t *testing.T) {
 	current := &types.Issue{ID: "test-ucpp", Status: types.StatusOpen}
 

--- a/cmd/bd/update_proxied_server.go
+++ b/cmd/bd/update_proxied_server.go
@@ -189,6 +189,18 @@ func applyUpdateProxiedAttempt(ctx context.Context, id string, in *updateInput) 
 			fmt.Fprintf(os.Stderr, "Error claiming %s: %v\n", id, err)
 			return nil, &updateIDFailure{ID: id, Error: fmt.Sprintf("claiming issue: %v", err)}, false, nil
 		}
+		// Close policy refused the status change. Same copy the proxied close
+		// prints for the same two refusals, so the boundary reads identically
+		// whichever verb a script reached it through. A policy refusal is a
+		// terminal per-issue failure — exit 1, never GuardMismatch/13.
+		if errors.Is(err, storage.ErrCloseOpenChildren) {
+			fmt.Fprintf(os.Stderr, "%v\n", err)
+			return nil, &updateIDFailure{ID: id, Error: err.Error()}, false, nil
+		}
+		if errors.Is(err, storage.ErrCloseBlocked) {
+			fmt.Fprintf(os.Stderr, "%v (use --force to override)\n", err)
+			return nil, &updateIDFailure{ID: id, Error: fmt.Sprintf("%v (use --force to override)", err)}, false, nil
+		}
 		if isGuardMismatch(err) {
 			// bd-wsqvw guard verdict: the precondition no longer holds, nothing
 			// was written. Loud and non-zero, never collapsed to success —
@@ -297,6 +309,12 @@ func buildUpdateSpecForIssue(current *types.Issue, in *updateInput) domain.Updat
 	}
 	if len(in.unsetMetadata) > 0 {
 		fields[issueops.OpUnsetMetadata] = in.unsetMetadata
+	}
+	// --force means both of its halves here too. The assignee half is applied
+	// above by validateIssueReassignable; this is the close-policy half, which
+	// the repository pops before it validates fields.
+	if in.force {
+		fields[issueops.OpForceClosePolicy] = true
 	}
 
 	return domain.UpdateSpec{

--- a/internal/storage/conformance/issue_operations_contract.go
+++ b/internal/storage/conformance/issue_operations_contract.go
@@ -206,10 +206,10 @@ func RunIssueOperationsUpdateFoldsMetadataIntoOneEvent(t *testing.T, ctx context
 }
 
 // RunIssueOperationsUpdateClosePolicy pins what a generic status update does
-// when it crosses from a non-done status into the done category. `bd close`
-// refuses an issue that still has open parent-child children or a live direct
-// blocker; this case records whether the generic update path applies the same
-// policy. Until now the contract had no boundary-crossing case at all, and that
+// when it crosses from a non-done status into the done category: it answers to
+// the same policy `bd close` does — the open-children refusal and the
+// live-direct-blocker refusal — and ForceClosePolicy is how a caller overrides
+// them. Until now the contract had no boundary-crossing case at all, and that
 // gap is exactly how two earlier attempts at a shared policy check reached a
 // backend that could not satisfy them without any test noticing.
 func RunIssueOperationsUpdateClosePolicy(t *testing.T, ctx context.Context, fixture IssueOperationsStagingFixture) {
@@ -226,43 +226,88 @@ func RunIssueOperationsUpdateClosePolicy(t *testing.T, ctx context.Context, fixt
 		Dependencies: []publicops.CreateDependency{{TargetID: blockerID, Type: types.DepBlocks}},
 	})
 
-	// CHARACTERIZATION: today a generic status update carries the close EFFECTS
-	// (closed_at, the closed event) but none of the close POLICY, so both
-	// refusals that `bd close` raises are silently skipped here.
-	openChildren, err := fixture.Operations.Update(ctx, closePolicyStatusRequest(parentID))
-	if err != nil {
-		t.Fatalf("update %s into done with an open child: %v", parentID, err)
+	// An open child refuses, with the typed error and its count, and writes
+	// nothing — not the row, not an event.
+	events := newIssueOperationsEventCounter(t, ctx, fixture, parentID)
+	var openChildrenErr *publicops.CloseOpenChildrenError
+	_, err := fixture.Operations.Update(ctx, closePolicyStatusRequest(parentID, false))
+	if !errors.As(err, &openChildrenErr) {
+		t.Fatalf("update %s into done with an open child: err = %v, want CloseOpenChildrenError", parentID, err)
 	}
-	if !openChildren.Changed || openChildren.Issue.Status != types.StatusClosed {
-		t.Fatalf("update %s into done = %#v, want a committed close", parentID, openChildren)
+	if openChildrenErr.OpenChildren != 1 {
+		t.Errorf("refusal reported %d open children, want 1", openChildrenErr.OpenChildren)
 	}
+	assertClosePolicyStatus(t, ctx, fixture, parentID, types.StatusOpen)
+	events.assert(t, "refused crossing", 0, nil)
 
-	liveBlocker, err := fixture.Operations.Update(ctx, closePolicyStatusRequest(blockedID))
-	if err != nil {
-		t.Fatalf("update %s into done with a live blocker: %v", blockedID, err)
+	// A live direct blocker refuses too.
+	_, err = fixture.Operations.Update(ctx, closePolicyStatusRequest(blockedID, false))
+	if !errors.Is(err, publicops.ErrCloseBlocked) {
+		t.Fatalf("update %s into done with a live blocker: err = %v, want ErrCloseBlocked", blockedID, err)
 	}
-	if !liveBlocker.Changed || liveBlocker.Issue.Status != types.StatusClosed {
-		t.Fatalf("update %s into done = %#v, want a committed close", blockedID, liveBlocker)
+	assertClosePolicyStatus(t, ctx, fixture, blockedID, types.StatusOpen)
+
+	// Force bypasses close policy and nothing else. A stale ExpectedVersion is
+	// an orthogonal precondition, checked ahead of the policy and never waived
+	// by it — the same ordering a checked close applies.
+	stale := int64(-1)
+	staleRequest := closePolicyStatusRequest(parentID, true)
+	staleRequest.ExpectedVersion = &stale
+	if _, err := fixture.Operations.Update(ctx, staleRequest); !errors.Is(err, publicops.ErrVersionMismatch) {
+		t.Fatalf("forced crossing with a stale version: err = %v, want ErrVersionMismatch", err)
+	}
+	assertClosePolicyStatus(t, ctx, fixture, parentID, types.StatusOpen)
+
+	// ForceClosePolicy bypasses both, and only those.
+	for _, id := range []string{parentID, blockedID} {
+		forced, err := fixture.Operations.Update(ctx, closePolicyStatusRequest(id, true))
+		if err != nil {
+			t.Fatalf("forced update %s into done: %v", id, err)
+		}
+		if !forced.Changed || forced.Issue.Status != types.StatusClosed {
+			t.Fatalf("forced update %s into done = %#v, want a committed close", id, forced)
+		}
 	}
 
 	// A done-to-done restatement is filtered out as a no-op before any policy
-	// could observe it, so it stays free of both refusals either way.
-	reclose, err := fixture.Operations.Update(ctx, closePolicyStatusRequest(parentID))
+	// could observe it, so it needs no force even though the child is still open.
+	reclose, err := fixture.Operations.Update(ctx, closePolicyStatusRequest(parentID, false))
 	if err != nil {
 		t.Fatalf("restate %s as done: %v", parentID, err)
 	}
 	if reclose.Changed {
 		t.Errorf("restating %s as done reported Changed = true, want a no-op", parentID)
 	}
+
+	// A status change that does not reach the done category is untouched by any
+	// of this, open child or not.
+	nonCrossing := closePolicyStatusRequest(parentID, false)
+	nonCrossing.Patch.Status.Value = types.StatusInProgress
+	if _, err := fixture.Operations.Update(ctx, nonCrossing); err != nil {
+		t.Fatalf("non-crossing status update on %s: %v", parentID, err)
+	}
+	assertClosePolicyStatus(t, ctx, fixture, parentID, types.StatusInProgress)
 }
 
 // closePolicyStatusRequest builds the generic status update that crosses into
 // the done category — the operation whose policy this case pins.
-func closePolicyStatusRequest(id string) publicops.UpdateRequest {
+func closePolicyStatusRequest(id string, force bool) publicops.UpdateRequest {
 	return publicops.UpdateRequest{
-		Actor:   "writer",
-		IssueID: id,
-		Patch:   publicops.IssuePatch{Status: publicops.Field[publicops.Status]{Set: true, Value: types.StatusClosed}},
+		Actor:            "writer",
+		IssueID:          id,
+		ForceClosePolicy: force,
+		Patch:            publicops.IssuePatch{Status: publicops.Field[publicops.Status]{Set: true, Value: types.StatusClosed}},
+	}
+}
+
+func assertClosePolicyStatus(t *testing.T, ctx context.Context, fixture IssueOperationsStagingFixture, id string, want types.Status) {
+	t.Helper()
+	var got string
+	if err := fixture.QueryScalar(ctx, "SELECT status FROM issues WHERE id = ?", []any{id}, &got); err != nil {
+		t.Fatalf("read status for %s: %v", id, err)
+	}
+	if types.Status(got) != want {
+		t.Errorf("%s status = %q, want %q", id, got, want)
 	}
 }
 

--- a/internal/storage/conformance/issue_operations_contract.go
+++ b/internal/storage/conformance/issue_operations_contract.go
@@ -205,6 +205,81 @@ func RunIssueOperationsUpdateFoldsMetadataIntoOneEvent(t *testing.T, ctx context
 	events.assert(t, "no-op metadata update", 0, nil)
 }
 
+// RunIssueOperationsUpdateClosePolicy pins what a generic status update does
+// when it crosses from a non-done status into the done category. `bd close`
+// refuses an issue that still has open parent-child children or a live direct
+// blocker; this case records whether the generic update path applies the same
+// policy. Until now the contract had no boundary-crossing case at all, and that
+// gap is exactly how two earlier attempts at a shared policy check reached a
+// backend that could not satisfy them without any test noticing.
+func RunIssueOperationsUpdateClosePolicy(t *testing.T, ctx context.Context, fixture IssueOperationsStagingFixture) {
+	t.Helper()
+
+	parentID := fixture.IssuePrefix + "-closepolicy-parent"
+	seedClosePolicyIssue(t, ctx, fixture, parentID, publicops.CreateRequest{})
+	seedClosePolicyIssue(t, ctx, fixture, fixture.IssuePrefix+"-closepolicy-child", publicops.CreateRequest{ParentID: parentID})
+
+	blockerID := fixture.IssuePrefix + "-closepolicy-blocker"
+	blockedID := fixture.IssuePrefix + "-closepolicy-blocked"
+	seedClosePolicyIssue(t, ctx, fixture, blockerID, publicops.CreateRequest{})
+	seedClosePolicyIssue(t, ctx, fixture, blockedID, publicops.CreateRequest{
+		Dependencies: []publicops.CreateDependency{{TargetID: blockerID, Type: types.DepBlocks}},
+	})
+
+	// CHARACTERIZATION: today a generic status update carries the close EFFECTS
+	// (closed_at, the closed event) but none of the close POLICY, so both
+	// refusals that `bd close` raises are silently skipped here.
+	openChildren, err := fixture.Operations.Update(ctx, closePolicyStatusRequest(parentID))
+	if err != nil {
+		t.Fatalf("update %s into done with an open child: %v", parentID, err)
+	}
+	if !openChildren.Changed || openChildren.Issue.Status != types.StatusClosed {
+		t.Fatalf("update %s into done = %#v, want a committed close", parentID, openChildren)
+	}
+
+	liveBlocker, err := fixture.Operations.Update(ctx, closePolicyStatusRequest(blockedID))
+	if err != nil {
+		t.Fatalf("update %s into done with a live blocker: %v", blockedID, err)
+	}
+	if !liveBlocker.Changed || liveBlocker.Issue.Status != types.StatusClosed {
+		t.Fatalf("update %s into done = %#v, want a committed close", blockedID, liveBlocker)
+	}
+
+	// A done-to-done restatement is filtered out as a no-op before any policy
+	// could observe it, so it stays free of both refusals either way.
+	reclose, err := fixture.Operations.Update(ctx, closePolicyStatusRequest(parentID))
+	if err != nil {
+		t.Fatalf("restate %s as done: %v", parentID, err)
+	}
+	if reclose.Changed {
+		t.Errorf("restating %s as done reported Changed = true, want a no-op", parentID)
+	}
+}
+
+// closePolicyStatusRequest builds the generic status update that crosses into
+// the done category — the operation whose policy this case pins.
+func closePolicyStatusRequest(id string) publicops.UpdateRequest {
+	return publicops.UpdateRequest{
+		Actor:   "writer",
+		IssueID: id,
+		Patch:   publicops.IssuePatch{Status: publicops.Field[publicops.Status]{Set: true, Value: types.StatusClosed}},
+	}
+}
+
+// seedClosePolicyIssue creates one open task at an explicit ID, carrying any
+// relationships the close-policy case needs. It goes through Create rather than
+// the fixture's raw seed hook so the edges recompute is_blocked exactly as a
+// real create would.
+func seedClosePolicyIssue(t *testing.T, ctx context.Context, fixture IssueOperationsStagingFixture, id string, request publicops.CreateRequest) {
+	t.Helper()
+	request.Actor = "seed"
+	request.ForceIDPrefix = true
+	request.Issue = &types.Issue{ID: id, Title: id, Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask}
+	if _, err := fixture.Operations.Create(ctx, request); err != nil {
+		t.Fatalf("seed %s: %v", id, err)
+	}
+}
+
 func assertIssueOperationsRowCount(t *testing.T, ctx context.Context, fixture IssueOperationsStagingFixture, table, id string, want int) {
 	t.Helper()
 	var got int

--- a/internal/storage/dolt/close_policy_gate_test.go
+++ b/internal/storage/dolt/close_policy_gate_test.go
@@ -1,0 +1,232 @@
+package dolt
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/storage"
+	"github.com/steveyegge/beads/internal/storage/issueops"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// closePolicyVerdict classifies what a close-policy evaluation decided, so the
+// standalone gate and the checked close can be compared without depending on
+// the wording of either refusal.
+type closePolicyVerdict string
+
+const (
+	verdictAllowed      closePolicyVerdict = "allowed"
+	verdictOpenChildren closePolicyVerdict = "open children"
+	verdictBlocked      closePolicyVerdict = "blocked"
+)
+
+func classifyClosePolicy(err error) closePolicyVerdict {
+	var openChildren *storage.CloseOpenChildrenError
+	switch {
+	case err == nil:
+		return verdictAllowed
+	case errors.As(err, &openChildren):
+		return verdictOpenChildren
+	case errors.Is(err, storage.ErrCloseBlocked):
+		return verdictBlocked
+	}
+	return closePolicyVerdict("unexpected: " + err.Error())
+}
+
+// inRolledBackTx runs body in its own transaction and always rolls it back, so
+// a fixture survives being evaluated by both policy entry points in turn.
+func inRolledBackTx(t *testing.T, ctx context.Context, store *DoltStore, body func(tx *sql.Tx) error) error {
+	t.Helper()
+	tx, err := store.db.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatalf("BeginTx: %v", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	return body(tx)
+}
+
+// TestEnforceClosePolicyInTxMatchesCheckedClose proves the extracted gate is
+// the same policy the checked close applies, not a second implementation of it.
+// Both entry points are run against identical fixtures in throwaway
+// transactions and must reach the same verdict every time — that equivalence is
+// the whole justification for letting a generic status update reuse the gate.
+func TestEnforceClosePolicyInTxMatchesCheckedClose(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	mkParentWithOpenChild := func(prefix string) string {
+		parent, child := prefix+"-parent", prefix+"-child"
+		createPerm(t, ctx, store, parent)
+		createPerm(t, ctx, store, child)
+		if err := store.AddDependency(ctx, &types.Dependency{
+			IssueID: child, DependsOnID: parent, Type: types.DepParentChild,
+		}, "tester"); err != nil {
+			t.Fatalf("AddDependency: %v", err)
+		}
+		return parent
+	}
+	mkBlocked := func(prefix string) string {
+		blocker, target := prefix+"-blocker", prefix+"-target"
+		createPerm(t, ctx, store, blocker)
+		createPerm(t, ctx, store, target)
+		if err := store.AddDependency(ctx, &types.Dependency{
+			IssueID: target, DependsOnID: blocker, Type: types.DepBlocks,
+		}, "tester"); err != nil {
+			t.Fatalf("AddDependency: %v", err)
+		}
+		if !getIsBlocked(t, ctx, store, "issues", target) {
+			t.Fatalf("%s should be is_blocked = 1", target)
+		}
+		return target
+	}
+
+	// An already-closed target whose blocker is still open. Closing recomputes
+	// is_blocked to 0, so the column is put back by hand: that is the stale
+	// column a re-close actually meets, and it makes the case discriminating —
+	// the blocker list is live, so a gate that ran the blocker check here would
+	// refuse.
+	closedBlocked := mkBlocked("gpc-closed")
+	if _, err := store.CloseIssueChecked(ctx, closedBlocked, "tester", storage.CloseIssueOptions{Reason: "done", Force: true}); err != nil {
+		t.Fatalf("force close %s: %v", closedBlocked, err)
+	}
+	if _, err := store.db.ExecContext(ctx, "UPDATE issues SET is_blocked = 1 WHERE id = ?", closedBlocked); err != nil {
+		t.Fatalf("restore is_blocked on %s: %v", closedBlocked, err)
+	}
+	if !getIsBlocked(t, ctx, store, "issues", closedBlocked) {
+		t.Fatalf("%s should carry is_blocked = 1 for this case", closedBlocked)
+	}
+
+	for _, tc := range []struct {
+		name  string
+		id    string
+		force bool
+		want  closePolicyVerdict
+	}{
+		{"open children refuse", mkParentWithOpenChild("gpc-oc"), false, verdictOpenChildren},
+		{"open children forced", mkParentWithOpenChild("gpc-ocf"), true, verdictAllowed},
+		{"live blocker refuses", mkBlocked("gpc-lb"), false, verdictBlocked},
+		{"live blocker forced", mkBlocked("gpc-lbf"), true, verdictAllowed},
+		{"already closed skips the blocker check", closedBlocked, false, verdictAllowed},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			gate := classifyClosePolicy(inRolledBackTx(t, ctx, store, func(tx *sql.Tx) error {
+				_, err := issueops.EnforceClosePolicyInTx(ctx, tx, tc.id, tc.force)
+				return err
+			}))
+			checked := classifyClosePolicy(inRolledBackTx(t, ctx, store, func(tx *sql.Tx) error {
+				_, err := issueops.CloseIssueCheckedInTx(ctx, tx, tc.id, "done", "tester", "", tc.force, nil)
+				return err
+			}))
+			if gate != tc.want {
+				t.Errorf("EnforceClosePolicyInTx verdict = %q, want %q", gate, tc.want)
+			}
+			if gate != checked {
+				t.Errorf("gate verdict %q != checked-close verdict %q; the extraction changed policy", gate, checked)
+			}
+		})
+	}
+}
+
+// TestEnforceClosePolicyInTxRoutesDualResidentToDurableRow pins the gate's
+// table routing to the checked close's. An ID present in BOTH issues and wisps
+// must have its children counted against the durable row; deriving the target
+// from an is-wisp flag instead would silently count zero and wave the refusal
+// through on exactly the ambiguous IDs that need it most.
+func TestEnforceClosePolicyInTxRoutesDualResidentToDurableRow(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	const parent, child = "gpd-parent", "gpd-child"
+	createPerm(t, ctx, store, parent)
+	createPerm(t, ctx, store, child)
+	if err := store.AddDependency(ctx, &types.Dependency{
+		IssueID: child, DependsOnID: parent, Type: types.DepParentChild,
+	}, "tester"); err != nil {
+		t.Fatalf("AddDependency: %v", err)
+	}
+
+	// Reproduce the post-promotion state where one ID holds a row in both
+	// tables. Only the durable row carries the parent-child edge.
+	tx, err := store.db.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatalf("BeginTx: %v", err)
+	}
+	if err := issueops.InsertIssueStrictInTx(ctx, tx, "wisps", &types.Issue{
+		ID: parent, Title: "wisp twin", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask, Ephemeral: true,
+	}); err != nil {
+		_ = tx.Rollback()
+		t.Fatalf("seed wisp twin: %v", err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("commit wisp twin: %v", err)
+	}
+
+	gate := classifyClosePolicy(inRolledBackTx(t, ctx, store, func(tx *sql.Tx) error {
+		_, err := issueops.EnforceClosePolicyInTx(ctx, tx, parent, false)
+		return err
+	}))
+	checked := classifyClosePolicy(inRolledBackTx(t, ctx, store, func(tx *sql.Tx) error {
+		_, err := issueops.CloseIssueCheckedInTx(ctx, tx, parent, "done", "tester", "", false, nil)
+		return err
+	}))
+	if gate != verdictOpenChildren {
+		t.Errorf("dual-resident gate verdict = %q, want %q (durable row's open child)", gate, verdictOpenChildren)
+	}
+	if gate != checked {
+		t.Errorf("dual-resident gate verdict %q != checked-close verdict %q; routing diverged", gate, checked)
+	}
+}
+
+// TestCrossesIntoDoneCategoryInTx pins the trigger for the gate. It fires on a
+// move INTO the done category from outside it — for a configured done status
+// exactly as for the built-in closed — and on nothing else.
+func TestCrossesIntoDoneCategoryInTx(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	if err := store.SetConfig(ctx, "status.custom", "review:wip,archived:done"); err != nil {
+		t.Fatalf("SetConfig(status.custom): %v", err)
+	}
+
+	for _, tc := range []struct {
+		name    string
+		old     types.Status
+		updates map[string]interface{}
+		want    bool
+	}{
+		{"open to built-in closed", types.StatusOpen, map[string]interface{}{"status": "closed"}, true},
+		{"open to configured done", types.StatusOpen, map[string]interface{}{"status": "archived"}, true},
+		{"typed status value", types.StatusOpen, map[string]interface{}{"status": types.StatusClosed}, true},
+		{"wip to done", types.StatusInProgress, map[string]interface{}{"status": "closed"}, true},
+		{"configured wip is not done", types.StatusOpen, map[string]interface{}{"status": "review"}, false},
+		{"open to open", types.StatusOpen, map[string]interface{}{"status": "in_progress"}, false},
+		{"done to done", types.StatusClosed, map[string]interface{}{"status": "closed"}, false},
+		{"closed to configured done", types.StatusClosed, map[string]interface{}{"status": "archived"}, false},
+		{"configured done to closed", types.Status("archived"), map[string]interface{}{"status": "closed"}, false},
+		{"no status update", types.StatusOpen, map[string]interface{}{"priority": 1}, false},
+		{"non-string status value", types.StatusOpen, map[string]interface{}{"status": 7}, false},
+		{"unknown status is unspecified", types.StatusOpen, map[string]interface{}{"status": "not-configured"}, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var got bool
+			if err := inRolledBackTx(t, ctx, store, func(tx *sql.Tx) error {
+				var err error
+				got, err = issueops.CrossesIntoDoneCategoryInTx(ctx, tx, tc.old, tc.updates)
+				return err
+			}); err != nil {
+				t.Fatalf("CrossesIntoDoneCategoryInTx: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("CrossesIntoDoneCategoryInTx(%q, %v) = %v, want %v", tc.old, tc.updates, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/storage/dolt/close_policy_gate_test.go
+++ b/internal/storage/dolt/close_policy_gate_test.go
@@ -236,7 +236,9 @@ func getClosePolicyStatus(t *testing.T, ctx context.Context, store *DoltStore, i
 
 // TestCrossesIntoDoneCategoryInTx pins the trigger for the gate. It fires on a
 // move INTO the done category from outside it — for a configured done status
-// exactly as for the built-in closed — and on nothing else.
+// exactly as for the built-in closed — and on nothing else. A status value it
+// cannot read is the one case that is neither: it refuses, because a false
+// there would wave the update past the gate.
 func TestCrossesIntoDoneCategoryInTx(t *testing.T) {
 	store, cleanup := setupTestStore(t)
 	defer cleanup()
@@ -252,27 +254,37 @@ func TestCrossesIntoDoneCategoryInTx(t *testing.T) {
 		old     types.Status
 		updates map[string]interface{}
 		want    bool
+		wantErr bool
 	}{
-		{"open to built-in closed", types.StatusOpen, map[string]interface{}{"status": "closed"}, true},
-		{"open to configured done", types.StatusOpen, map[string]interface{}{"status": "archived"}, true},
-		{"typed status value", types.StatusOpen, map[string]interface{}{"status": types.StatusClosed}, true},
-		{"wip to done", types.StatusInProgress, map[string]interface{}{"status": "closed"}, true},
-		{"configured wip is not done", types.StatusOpen, map[string]interface{}{"status": "review"}, false},
-		{"open to open", types.StatusOpen, map[string]interface{}{"status": "in_progress"}, false},
-		{"done to done", types.StatusClosed, map[string]interface{}{"status": "closed"}, false},
-		{"closed to configured done", types.StatusClosed, map[string]interface{}{"status": "archived"}, false},
-		{"configured done to closed", types.Status("archived"), map[string]interface{}{"status": "closed"}, false},
-		{"no status update", types.StatusOpen, map[string]interface{}{"priority": 1}, false},
-		{"non-string status value", types.StatusOpen, map[string]interface{}{"status": 7}, false},
-		{"unknown status is unspecified", types.StatusOpen, map[string]interface{}{"status": "not-configured"}, false},
+		{name: "open to built-in closed", old: types.StatusOpen, updates: map[string]interface{}{"status": "closed"}, want: true},
+		{name: "open to configured done", old: types.StatusOpen, updates: map[string]interface{}{"status": "archived"}, want: true},
+		{name: "typed status value", old: types.StatusOpen, updates: map[string]interface{}{"status": types.StatusClosed}, want: true},
+		{name: "wip to done", old: types.StatusInProgress, updates: map[string]interface{}{"status": "closed"}, want: true},
+		{name: "configured wip is not done", old: types.StatusOpen, updates: map[string]interface{}{"status": "review"}},
+		{name: "open to open", old: types.StatusOpen, updates: map[string]interface{}{"status": "in_progress"}},
+		{name: "done to done", old: types.StatusClosed, updates: map[string]interface{}{"status": "closed"}},
+		{name: "closed to configured done", old: types.StatusClosed, updates: map[string]interface{}{"status": "archived"}},
+		{name: "configured done to closed", old: types.Status("archived"), updates: map[string]interface{}{"status": "closed"}},
+		{name: "no status update", old: types.StatusOpen, updates: map[string]interface{}{"priority": 1}},
+		{name: "unknown status is unspecified", old: types.StatusOpen, updates: map[string]interface{}{"status": "not-configured"}},
+		{name: "unreadable status value refuses", old: types.StatusOpen, updates: map[string]interface{}{"status": 7}, wantErr: true},
+		{name: "byte-slice status value refuses", old: types.StatusOpen, updates: map[string]interface{}{"status": []byte("closed")}, wantErr: true},
+		{name: "nil status value refuses", old: types.StatusOpen, updates: map[string]interface{}{"status": nil}, wantErr: true},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			var got bool
-			if err := inRolledBackTx(t, ctx, store, func(tx *sql.Tx) error {
+			err := inRolledBackTx(t, ctx, store, func(tx *sql.Tx) error {
 				var err error
 				got, err = issueops.CrossesIntoDoneCategoryInTx(ctx, tx, tc.old, tc.updates)
 				return err
-			}); err != nil {
+			})
+			if tc.wantErr {
+				if !errors.Is(err, storage.ErrValidation) {
+					t.Fatalf("CrossesIntoDoneCategoryInTx(%q, %v) error = %v, want storage.ErrValidation", tc.old, tc.updates, err)
+				}
+				return
+			}
+			if err != nil {
 				t.Fatalf("CrossesIntoDoneCategoryInTx: %v", err)
 			}
 			if got != tc.want {

--- a/internal/storage/dolt/close_policy_gate_test.go
+++ b/internal/storage/dolt/close_policy_gate_test.go
@@ -183,6 +183,57 @@ func TestEnforceClosePolicyInTxRoutesDualResidentToDurableRow(t *testing.T) {
 	}
 }
 
+// TestUpdateIssueEnforcesClosePolicyForConfiguredDoneStatus proves the gate
+// really is category-driven end to end, not a check for the literal string
+// "closed". A project that configures its own done status gets the same
+// refusal, and the same override, on the way into it.
+func TestUpdateIssueEnforcesClosePolicyForConfiguredDoneStatus(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	if err := store.SetConfig(ctx, "status.custom", "archived:done"); err != nil {
+		t.Fatalf("SetConfig(status.custom): %v", err)
+	}
+
+	const parent, child = "cds-parent", "cds-child"
+	createPerm(t, ctx, store, parent)
+	createPerm(t, ctx, store, child)
+	if err := store.AddDependency(ctx, &types.Dependency{
+		IssueID: child, DependsOnID: parent, Type: types.DepParentChild,
+	}, "tester"); err != nil {
+		t.Fatalf("AddDependency: %v", err)
+	}
+
+	err := store.UpdateIssue(ctx, parent, map[string]interface{}{"status": "archived"}, "tester")
+	if !errors.Is(err, storage.ErrCloseOpenChildren) {
+		t.Fatalf("update into a configured done status: err = %v, want ErrCloseOpenChildren", err)
+	}
+	if got := getClosePolicyStatus(t, ctx, store, parent); got != types.StatusOpen {
+		t.Errorf("%s status = %q after a refusal, want open", parent, got)
+	}
+
+	if err := store.UpdateIssue(ctx, parent, map[string]interface{}{
+		"status":                    "archived",
+		issueops.OpForceClosePolicy: true,
+	}, "tester"); err != nil {
+		t.Fatalf("forced update into a configured done status: %v", err)
+	}
+	if got := getClosePolicyStatus(t, ctx, store, parent); got != types.Status("archived") {
+		t.Errorf("%s status = %q, want archived", parent, got)
+	}
+}
+
+func getClosePolicyStatus(t *testing.T, ctx context.Context, store *DoltStore, id string) types.Status {
+	t.Helper()
+	issue, err := store.GetIssue(ctx, id)
+	if err != nil {
+		t.Fatalf("GetIssue(%s): %v", id, err)
+	}
+	return issue.Status
+}
+
 // TestCrossesIntoDoneCategoryInTx pins the trigger for the gate. It fires on a
 // move INTO the done category from outside it — for a configured done status
 // exactly as for the built-in closed — and on nothing else.

--- a/internal/storage/dolt/issue_operations_contract_test.go
+++ b/internal/storage/dolt/issue_operations_contract_test.go
@@ -25,6 +25,12 @@ func TestIssueOperationsUpdateFoldsMetadataIntoOneEvent(t *testing.T) {
 	conformance.RunIssueOperationsUpdateFoldsMetadataIntoOneEvent(t, ctx, fixture)
 }
 
+func TestIssueOperationsUpdateClosePolicy(t *testing.T) {
+	fixture, ctx, cleanup := newDoltIssueOperationsFixture(t)
+	defer cleanup()
+	conformance.RunIssueOperationsUpdateClosePolicy(t, ctx, fixture)
+}
+
 func newDoltIssueOperationsFixture(t *testing.T) (conformance.IssueOperationsStagingFixture, context.Context, func()) {
 	t.Helper()
 	store, storeCleanup := setupTestStore(t)

--- a/internal/storage/dolt/update_force_close_policy_test.go
+++ b/internal/storage/dolt/update_force_close_policy_test.go
@@ -1,9 +1,11 @@
 package dolt
 
 import (
+	"errors"
 	"strings"
 	"testing"
 
+	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/storage/issueops"
 	"github.com/steveyegge/beads/internal/types"
 )
@@ -57,5 +59,46 @@ func TestUpdateIssueRefusesUnpoppedClosePolicyOverride(t *testing.T) {
 	}
 	if issue.Status != types.StatusOpen {
 		t.Errorf("status = %q, want open", issue.Status)
+	}
+}
+
+// TestUpdateIssueRefusesUnreadableStatusInsteadOfSkippingClosePolicy is the
+// embedded funnel's proof that the gate cannot be stepped around by getting the
+// status transport wrong. An in-process embedder can hand this map any Go value
+// it likes; a []byte reaches SQL as the string 'closed' just fine, so a status
+// the gate cannot read used to mean the close landed with the policy check
+// never run — on a parent with an open child, which the gate exists to refuse.
+// The update is now refused up front and the row is untouched.
+func TestUpdateIssueRefusesUnreadableStatusInsteadOfSkippingClosePolicy(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	const parent, child = "urs-parent", "urs-child"
+	createPerm(t, ctx, store, parent)
+	createPerm(t, ctx, store, child)
+	if err := store.AddDependency(ctx, &types.Dependency{
+		IssueID: child, DependsOnID: parent, Type: types.DepParentChild,
+	}, "tester"); err != nil {
+		t.Fatalf("AddDependency: %v", err)
+	}
+
+	err := store.UpdateIssue(ctx, parent, map[string]interface{}{"status": []byte("closed")}, "tester")
+	if !errors.Is(err, storage.ErrValidation) {
+		t.Fatalf("UpdateIssue error = %v, want storage.ErrValidation", err)
+	}
+	if got := getClosePolicyStatus(t, ctx, store, parent); got != types.StatusOpen {
+		t.Errorf("status = %q after a refused update, want open", got)
+	}
+
+	// The refusal is about the transport, not about closing: the same close
+	// spelled with a string reaches the gate and is refused on the open child.
+	err = store.UpdateIssue(ctx, parent, map[string]interface{}{"status": string(types.StatusClosed)}, "tester")
+	if err == nil {
+		t.Fatal("UpdateIssue closed a parent with an open child")
+	}
+	if errors.Is(err, storage.ErrValidation) {
+		t.Fatalf("error = %v, want a close-policy refusal, not a validation error", err)
 	}
 }

--- a/internal/storage/dolt/update_force_close_policy_test.go
+++ b/internal/storage/dolt/update_force_close_policy_test.go
@@ -1,0 +1,61 @@
+package dolt
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/storage/issueops"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// TestUpdateIssueRefusesUnpoppedClosePolicyOverride pins the fail-loud half of
+// the reserved-key transport on the embedded write funnel. A well-formed
+// override is popped and leaves no trace; a malformed one survives the pop and
+// is refused by name, so a caller that spells the override wrong learns about
+// it instead of silently running unforced.
+func TestUpdateIssueRefusesUnpoppedClosePolicyOverride(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	const id = "ufc-target"
+	createPerm(t, ctx, store, id)
+
+	err := store.UpdateIssue(ctx, id, map[string]interface{}{
+		"priority":                  1,
+		issueops.OpForceClosePolicy: "yes",
+	}, "tester")
+	if err == nil {
+		t.Fatal("UpdateIssue accepted a malformed close-policy override")
+	}
+	if !strings.Contains(err.Error(), "invalid field for update") || !strings.Contains(err.Error(), issueops.OpForceClosePolicy) {
+		t.Fatalf("error = %v, want an \"invalid field for update\" refusal naming %q", err, issueops.OpForceClosePolicy)
+	}
+	issue, getErr := store.GetIssue(ctx, id)
+	if getErr != nil {
+		t.Fatalf("GetIssue: %v", getErr)
+	}
+	if issue.Priority != 2 {
+		t.Errorf("priority = %d after a refused update, want the seeded 2", issue.Priority)
+	}
+
+	// A well-formed override is transport, not a column: it is popped, the rest
+	// of the update applies, and nothing about it reaches the row.
+	if err := store.UpdateIssue(ctx, id, map[string]interface{}{
+		"priority":                  1,
+		issueops.OpForceClosePolicy: true,
+	}, "tester"); err != nil {
+		t.Fatalf("UpdateIssue with a well-formed override: %v", err)
+	}
+	issue, getErr = store.GetIssue(ctx, id)
+	if getErr != nil {
+		t.Fatalf("GetIssue: %v", getErr)
+	}
+	if issue.Priority != 1 {
+		t.Errorf("priority = %d, want 1", issue.Priority)
+	}
+	if issue.Status != types.StatusOpen {
+		t.Errorf("status = %q, want open", issue.Status)
+	}
+}

--- a/internal/storage/domain/db/issue.go
+++ b/internal/storage/domain/db/issue.go
@@ -118,6 +118,11 @@ func (r *issueSQLRepositoryImpl) Update(ctx context.Context, id string, updates 
 		return nil
 	}
 	updates = cloneUpdateFields(updates)
+	// Pop the close-policy override before anything reads the map as a set of
+	// columns, mirroring issueops.updateIssueInTx. The no-op filter below keeps
+	// unrecognized keys, so a surviving override would reach the field
+	// allowlist and be refused by name.
+	_ = issueops.PopForceClosePolicy(updates)
 
 	// Bound the VARCHAR(255) assignment columns before touching SQL, mirroring
 	// issueops.updateIssueInTx: an over-length assignee/owner aborts with a typed

--- a/internal/storage/domain/db/issue.go
+++ b/internal/storage/domain/db/issue.go
@@ -122,7 +122,7 @@ func (r *issueSQLRepositoryImpl) Update(ctx context.Context, id string, updates 
 	// columns, mirroring issueops.updateIssueInTx. The no-op filter below keeps
 	// unrecognized keys, so a surviving override would reach the field
 	// allowlist and be refused by name.
-	_ = issueops.PopForceClosePolicy(updates)
+	forceClosePolicy := issueops.PopForceClosePolicy(updates)
 
 	// Bound the VARCHAR(255) assignment columns before touching SQL, mirroring
 	// issueops.updateIssueInTx: an over-length assignee/owner aborts with a typed
@@ -181,6 +181,23 @@ func (r *issueSQLRepositoryImpl) Update(ctx context.Context, id string, updates 
 	// A status that matched the row was already dropped as a no-op, so the
 	// lifecycle side effects below only fire on a real transition.
 	_, statusChanging := updates["status"]
+
+	// Close-policy parity with issueops.updateIssueInTx: a status that crosses
+	// into the done category is a close by another name and answers to close
+	// policy. A refusal returns before any write and aborts the caller's unit of
+	// work. The wrap keeps the sentinels matchable, so a caller distinguishes
+	// these refusals here exactly as it does on the close path.
+	if statusChanging {
+		crossing, err := issueops.CrossesIntoDoneCategoryInTx(ctx, r.runner, oldIssue.Status, updates)
+		if err != nil {
+			return fmt.Errorf("db: Update %s: %w", id, err)
+		}
+		if crossing {
+			if _, err := issueops.EnforceClosePolicyInTx(ctx, r.runner, id, forceClosePolicy); err != nil {
+				return fmt.Errorf("db: Update %s: %w", id, err)
+			}
+		}
+	}
 
 	setClauses := make([]string, 0, len(updates)+3)
 	args := make([]any, 0, len(updates)+4)

--- a/internal/storage/domain/db/issue_force_close_policy_test.go
+++ b/internal/storage/domain/db/issue_force_close_policy_test.go
@@ -1,0 +1,46 @@
+package db
+
+import (
+	"github.com/steveyegge/beads/internal/storage/domain"
+	"github.com/steveyegge/beads/internal/storage/issueops"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// TestUpdateRefusesUnpoppedClosePolicyOverride is the proxied funnel's half of
+// the reserved-key transport pin. This repository's field allowlist is a
+// separate map from the embedded funnel's, so it gets its own proof that the
+// override is not a column here either: a malformed one survives the pop and is
+// refused by name, a well-formed one is popped and leaves no trace.
+func (s *testSuite) TestUpdateRefusesUnpoppedClosePolicyOverride() {
+	created, err := s.issueUseCase().CreateIssue(s.Ctx(), domain.CreateIssueParams{
+		Issue: &types.Issue{
+			ID:        "bd-domain-unpopped-override",
+			Title:     "override transport",
+			IssueType: types.TypeTask,
+			Priority:  2,
+		},
+	}, "tester")
+	s.Require().NoError(err)
+	id := created.Issue.ID
+
+	err = NewIssueSQLRepository(s.Runner()).Update(s.Ctx(), id, map[string]any{
+		"priority":                  1,
+		issueops.OpForceClosePolicy: "yes",
+	}, "tester", domain.IssueTableOpts{})
+	s.Require().Error(err, "Update accepted a malformed close-policy override")
+	s.Contains(err.Error(), "is not allowed")
+	s.Contains(err.Error(), issueops.OpForceClosePolicy)
+
+	unchanged, err := s.issueUseCase().GetIssue(s.Ctx(), id)
+	s.Require().NoError(err)
+	s.Equal(2, unchanged.Priority, "a refused update must write nothing")
+
+	s.Require().NoError(NewIssueSQLRepository(s.Runner()).Update(s.Ctx(), id, map[string]any{
+		"priority":                  1,
+		issueops.OpForceClosePolicy: true,
+	}, "tester", domain.IssueTableOpts{}))
+	applied, err := s.issueUseCase().GetIssue(s.Ctx(), id)
+	s.Require().NoError(err)
+	s.Equal(1, applied.Priority)
+	s.Equal(types.StatusOpen, applied.Status)
+}

--- a/internal/storage/domain/db/issue_force_close_policy_test.go
+++ b/internal/storage/domain/db/issue_force_close_policy_test.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/storage/domain"
 	"github.com/steveyegge/beads/internal/storage/issueops"
 	"github.com/steveyegge/beads/internal/types"
@@ -43,4 +44,36 @@ func (s *testSuite) TestUpdateRefusesUnpoppedClosePolicyOverride() {
 	s.Require().NoError(err)
 	s.Equal(1, applied.Priority)
 	s.Equal(types.StatusOpen, applied.Status)
+}
+
+// TestUpdateRefusesUnreadableStatusInsteadOfSkippingClosePolicy is the proxied
+// funnel's half of the same pin. This repository asks the shared crossing check
+// the same question the embedded funnel does, so a status value the check
+// cannot read must refuse here too: a false would send a close straight past
+// the gate and into SQL, where a []byte lands as 'closed' like any string.
+func (s *testSuite) TestUpdateRefusesUnreadableStatusInsteadOfSkippingClosePolicy() {
+	const parent, child = "bd-domain-unreadable-parent", "bd-domain-unreadable-child"
+	for _, id := range []string{parent, child} {
+		_, err := s.issueUseCase().CreateIssue(s.Ctx(), domain.CreateIssueParams{
+			Issue: &types.Issue{ID: id, Title: "unreadable status", IssueType: types.TypeTask, Priority: 2},
+		}, "tester")
+		s.Require().NoError(err)
+	}
+	s.Require().NoError(domain.NewDependencyUseCase(NewDependencySQLRepository(s.Runner())).AddDependency(s.Ctx(),
+		&types.Dependency{IssueID: child, DependsOnID: parent, Type: types.DepParentChild}, "tester"))
+
+	err := NewIssueSQLRepository(s.Runner()).Update(s.Ctx(), parent,
+		map[string]any{"status": []byte("closed")}, "tester", domain.IssueTableOpts{})
+	s.Require().ErrorIs(err, storage.ErrValidation, "an unreadable status must refuse, not skip the gate")
+
+	untouched, err := s.issueUseCase().GetIssue(s.Ctx(), parent)
+	s.Require().NoError(err)
+	s.Equal(types.StatusOpen, untouched.Status, "a refused update must write nothing")
+
+	// The refusal is about the transport: spelled as a string, the same close
+	// reaches the gate and is refused on the open child instead.
+	err = NewIssueSQLRepository(s.Runner()).Update(s.Ctx(), parent,
+		map[string]any{"status": string(types.StatusClosed)}, "tester", domain.IssueTableOpts{})
+	s.Require().Error(err, "Update closed a parent with an open child")
+	s.Require().NotErrorIs(err, storage.ErrValidation, "want a close-policy refusal, not a validation error")
 }

--- a/internal/storage/embeddeddolt/issue_operations_contract_test.go
+++ b/internal/storage/embeddeddolt/issue_operations_contract_test.go
@@ -31,6 +31,13 @@ func TestEmbeddedIssueOperationsUpdateFoldsMetadataIntoOneEvent(t *testing.T) {
 	conformance.RunIssueOperationsUpdateFoldsMetadataIntoOneEvent(t, ctx, newEmbeddedIssueOperationsFixture(t, ctx, te, "metaevent"))
 }
 
+func TestEmbeddedIssueOperationsUpdateClosePolicy(t *testing.T) {
+	skipUnlessEmbeddedDolt(t)
+	te := newTestEnv(t, "closepol")
+	ctx := t.Context()
+	conformance.RunIssueOperationsUpdateClosePolicy(t, ctx, newEmbeddedIssueOperationsFixture(t, ctx, te, "closepol"))
+}
+
 func newEmbeddedIssueOperationsFixture(t *testing.T, ctx context.Context, te *testEnv, prefix string) conformance.IssueOperationsStagingFixture {
 	t.Helper()
 	operations, err := embeddeddolt.NewIssueOperations(te.store)

--- a/internal/storage/issueops/close.go
+++ b/internal/storage/issueops/close.go
@@ -115,28 +115,9 @@ func closeCheckedSavepointEligible(tx DBTX) bool {
 }
 
 func closeIssueCheckedAfterSavepoint(ctx context.Context, tx DBTX, id, reason, actor, session string, force, closed bool, targetColumn string) (*CloseResult, error) {
-	// This write precedes every child-count policy branch, including Force and
-	// idempotent closes. A concurrent new parent-child edge writes its own tier
-	// cell, while a close writes both tiers, so Dolt cannot merge a stale count
-	// with a new edge.
-	if err := touchDependencyCoordinationInTx(ctx, tx, id); err != nil {
-		return nil, err
-	}
-	openChildren, err := countOpenChildrenForTargetInTx(ctx, tx, id, targetColumn)
+	openChildren, err := enforceClosePolicyForTargetInTx(ctx, tx, id, targetColumn, force, closed)
 	if err != nil {
 		return nil, err
-	}
-	if !force && openChildren > 0 {
-		return nil, &storage.CloseOpenChildrenError{IssueID: id, OpenChildren: openChildren}
-	}
-	if !force && !closed {
-		blocked, blockers, err := IsBlockedInTx(ctx, tx, id)
-		if err != nil {
-			return nil, err
-		}
-		if blocked && len(blockers) > 0 {
-			return nil, fmt.Errorf("%w: %s is blocked by %v", storage.ErrCloseBlocked, id, blockers)
-		}
 	}
 	result, err := CloseIssueInTx(ctx, tx, id, reason, actor, session)
 	if err != nil {
@@ -144,6 +125,61 @@ func closeIssueCheckedAfterSavepoint(ctx context.Context, tx DBTX, id, reason, a
 	}
 	result.OpenChildren = openChildren
 	return result, nil
+}
+
+// enforceClosePolicyForTargetInTx applies the close policy — the open-children
+// refusal and the live-direct-blocker refusal — to an already-routed target,
+// and reports the open-child count it observed. It is the whole policy half of
+// a checked close, split out so a status change that reaches done through
+// another route can run the identical gate rather than a second copy of it.
+//
+// closed is the target's pre-write closed state and targetColumn its dependency
+// routing, both read by the caller from the same transaction.
+func enforceClosePolicyForTargetInTx(ctx context.Context, tx DBTX, id, targetColumn string, force, closed bool) (int, error) {
+	// This write precedes every child-count policy branch, including Force and
+	// idempotent closes. A concurrent new parent-child edge writes its own tier
+	// cell, while a close writes both tiers, so Dolt cannot merge a stale count
+	// with a new edge.
+	if err := touchDependencyCoordinationInTx(ctx, tx, id); err != nil {
+		return 0, err
+	}
+	openChildren, err := countOpenChildrenForTargetInTx(ctx, tx, id, targetColumn)
+	if err != nil {
+		return 0, err
+	}
+	if !force && openChildren > 0 {
+		return 0, &storage.CloseOpenChildrenError{IssueID: id, OpenChildren: openChildren}
+	}
+	if !force && !closed {
+		blocked, blockers, err := IsBlockedInTx(ctx, tx, id)
+		if err != nil {
+			return 0, err
+		}
+		if blocked && len(blockers) > 0 {
+			return 0, fmt.Errorf("%w: %s is blocked by %v", storage.ErrCloseBlocked, id, blockers)
+		}
+	}
+	return openChildren, nil
+}
+
+// EnforceClosePolicyInTx applies the close policy to id without closing it, for
+// a caller that reaches a done status by some other write. It routes the target
+// exactly as a checked close does — probing issues then wisps by ID, preferring
+// the durable row when both hold it — rather than deriving the table from an
+// is-wisp flag, so a dual-resident ID counts children against the same row the
+// close guard would.
+//
+// It returns the observed open-child count. force bypasses both refusals and
+// nothing else; the coordination-cell touch happens either way.
+func EnforceClosePolicyInTx(ctx context.Context, tx DBTX, id string, force bool) (int, error) {
+	closed, targetColumn, found, err := isClosedInTx(ctx, tx, id)
+	if err != nil {
+		return 0, err
+	}
+	if !found {
+		return 0, fmt.Errorf("%w: issue %s", storage.ErrNotFound, id)
+	}
+	return enforceClosePolicyForTargetInTx(ctx, tx, id, targetColumn, force, closed)
 }
 
 func countOpenChildrenInTx(ctx context.Context, tx DBTX, id string) (int, error) {

--- a/internal/storage/issueops/execution.go
+++ b/internal/storage/issueops/execution.go
@@ -166,6 +166,12 @@ func ExecuteUpdate(ctx context.Context, tx *sql.Tx, request publicops.UpdateRequ
 	if metadataChanged {
 		updates["metadata"] = metadata
 	}
+	// The override only means anything alongside a status change, so it is spelled
+	// only then: an update that carries it with no status would be handing the
+	// funnel a key it has no question to answer.
+	if attempt.ForceClosePolicy && attempt.Patch.Status.Set {
+		updates[OpForceClosePolicy] = true
+	}
 	if len(updates) > 0 {
 		updated, err := UpdateIssueInTx(ctx, tx, attempt.IssueID, updates, attempt.Actor)
 		if err != nil {

--- a/internal/storage/issueops/update.go
+++ b/internal/storage/issueops/update.go
@@ -176,9 +176,17 @@ func DetermineEventType(oldIssue *types.Issue, updates map[string]interface{}) t
 // transaction that will perform the write, so a custom status configured as
 // done counts exactly as the built-in closed status does.
 //
-// It is false without a status update, for a value whose Go type cannot carry a
-// status, and for a move that starts in the done category — a done-to-done
-// restatement is not a crossing, and reopening is the operation that leaves.
+// It is false without a status update, and for a move that starts in the done
+// category — a done-to-done restatement is not a crossing, and reopening is the
+// operation that leaves.
+//
+// A status value whose Go type cannot carry a status is a validation error, not
+// a false. Both write funnels ask this question to decide whether close policy
+// applies, so answering "no crossing" for a value nobody can read would let an
+// in-process caller that got the transport wrong land status='closed' with the
+// policy gate skipped — on an issue with open children, no less. Refusing here
+// gives a mis-typed status the same fail-loud handling the mis-typed override
+// key already gets (see PopForceClosePolicy).
 func CrossesIntoDoneCategoryInTx(ctx context.Context, tx DBTX, oldStatus types.Status, updates map[string]interface{}) (bool, error) {
 	rawStatus, hasStatus := updates["status"]
 	if !hasStatus {
@@ -191,7 +199,7 @@ func CrossesIntoDoneCategoryInTx(ctx context.Context, tx DBTX, oldStatus types.S
 	case types.Status:
 		newStatus = value
 	default:
-		return false, nil
+		return false, fmt.Errorf("%w: status value of type %T is neither a string nor a types.Status", storage.ErrValidation, rawStatus)
 	}
 
 	newCategory, err := ReopenCategoryInTx(ctx, tx, newStatus)

--- a/internal/storage/issueops/update.go
+++ b/internal/storage/issueops/update.go
@@ -239,7 +239,7 @@ func updateIssueInTx(ctx context.Context, tx DBTX, id string, updates map[string
 	// has to come out ahead of the no-op filter too: the filter keeps every key
 	// it does not recognize, so a surviving override would reach the field
 	// allowlist and be refused by name.
-	_ = PopForceClosePolicy(updates)
+	forceClosePolicy := PopForceClosePolicy(updates)
 
 	// Route to correct table.
 	isWisp := IsActiveWispInTx(ctx, tx, id)
@@ -265,6 +265,23 @@ func updateIssueInTx(ctx context.Context, tx DBTX, id string, updates map[string
 	}
 	if len(updates) == 0 {
 		return &UpdateResult{OldIssue: oldIssue, IsWisp: isWisp, Changed: false}, nil
+	}
+
+	// A status update that crosses into the done category is a close by another
+	// name, so it answers to close policy. Running after the no-op filter keeps
+	// a done-to-done restatement policy-free, and running after the callers'
+	// version and assignee preconditions keeps force away from those: it
+	// bypasses the two close refusals and nothing else, exactly as it does for
+	// `bd close`. A refusal returns here, before any write, and aborts the
+	// caller's transaction.
+	crossing, err := CrossesIntoDoneCategoryInTx(ctx, tx, oldIssue.Status, updates)
+	if err != nil {
+		return nil, err
+	}
+	if crossing {
+		if _, err := EnforceClosePolicyInTx(ctx, tx, id, forceClosePolicy); err != nil {
+			return nil, err
+		}
 	}
 
 	if err := ValidateScalarUpdates(ctx, tx, updates); err != nil {

--- a/internal/storage/issueops/update.go
+++ b/internal/storage/issueops/update.go
@@ -171,6 +171,43 @@ func DetermineEventType(oldIssue *types.Issue, updates map[string]interface{}) t
 	return types.EventStatusChanged
 }
 
+// CrossesIntoDoneCategoryInTx reports whether updates move oldStatus from
+// outside the done category into it. The categories are resolved from the same
+// transaction that will perform the write, so a custom status configured as
+// done counts exactly as the built-in closed status does.
+//
+// It is false without a status update, for a value whose Go type cannot carry a
+// status, and for a move that starts in the done category — a done-to-done
+// restatement is not a crossing, and reopening is the operation that leaves.
+func CrossesIntoDoneCategoryInTx(ctx context.Context, tx DBTX, oldStatus types.Status, updates map[string]interface{}) (bool, error) {
+	rawStatus, hasStatus := updates["status"]
+	if !hasStatus {
+		return false, nil
+	}
+	var newStatus types.Status
+	switch value := rawStatus.(type) {
+	case string:
+		newStatus = types.Status(value)
+	case types.Status:
+		newStatus = value
+	default:
+		return false, nil
+	}
+
+	newCategory, err := ReopenCategoryInTx(ctx, tx, newStatus)
+	if err != nil {
+		return false, err
+	}
+	if newCategory != types.CategoryDone {
+		return false, nil
+	}
+	oldCategory, err := ReopenCategoryInTx(ctx, tx, oldStatus)
+	if err != nil {
+		return false, err
+	}
+	return oldCategory != types.CategoryDone, nil
+}
+
 // UpdateResult holds the result of an UpdateIssueInTx call.
 type UpdateResult struct {
 	OldIssue         *types.Issue

--- a/internal/storage/issueops/update.go
+++ b/internal/storage/issueops/update.go
@@ -235,6 +235,11 @@ func UpdateIssueWithoutEventInTx(ctx context.Context, tx DBTX, id string, update
 
 func updateIssueInTx(ctx context.Context, tx DBTX, id string, updates map[string]interface{}, actor string, recordEvent bool) (*UpdateResult, error) {
 	updates = cloneUpdateFields(updates)
+	// Pop the override before anything reads the map as a set of columns. It
+	// has to come out ahead of the no-op filter too: the filter keeps every key
+	// it does not recognize, so a surviving override would reach the field
+	// allowlist and be refused by name.
+	_ = PopForceClosePolicy(updates)
 
 	// Route to correct table.
 	isWisp := IsActiveWispInTx(ctx, tx, id)
@@ -414,6 +419,36 @@ const (
 	// (bd update --append-notes). Value: string.
 	OpAppendNotes = "append_notes"
 )
+
+// OpForceClosePolicy carries a close-policy override into a generic update
+// (bd update --force). Value: bool. It is not a merge operation and not a
+// column — the write funnels pop it before validating fields, so it never
+// reaches SQL.
+//
+// It rides the update map, like the merge operations, so adding the override
+// breaks no interface. That choice has a deliberate failure mode: the field
+// allowlists do not name this key, so an occurrence that reaches field
+// validation unpopped is refused by name. A caller that misspells the override,
+// or a write path that forgets to pop it, fails loudly instead of quietly
+// running the update with force read as off.
+const OpForceClosePolicy = "_force_close_policy"
+
+// PopForceClosePolicy removes the close-policy override from updates and
+// reports whether it asked for force. A value that is not a bool is left in
+// place on purpose: it cannot be read as an intent, and leaving it lets the
+// field allowlist refuse it by name.
+func PopForceClosePolicy(updates map[string]interface{}) bool {
+	raw, present := updates[OpForceClosePolicy]
+	if !present {
+		return false
+	}
+	force, isBool := raw.(bool)
+	if !isBool {
+		return false
+	}
+	delete(updates, OpForceClosePolicy)
+	return force
+}
 
 // HasMergeOps reports whether the update map carries any read-merge-write
 // operation key. Updates with merge ops must resolve those ops against the row

--- a/internal/storage/issueops/update_force_close_policy_test.go
+++ b/internal/storage/issueops/update_force_close_policy_test.go
@@ -1,0 +1,64 @@
+package issueops
+
+import (
+	"testing"
+
+	publicops "github.com/steveyegge/beads/issueops"
+)
+
+func TestPopForceClosePolicy(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name      string
+		updates   map[string]interface{}
+		want      bool
+		wantAfter bool // whether the key survives the pop
+	}{
+		{"absent", map[string]interface{}{"status": "closed"}, false, false},
+		{"true", map[string]interface{}{"status": "closed", OpForceClosePolicy: true}, true, false},
+		{"false", map[string]interface{}{"status": "closed", OpForceClosePolicy: false}, false, false},
+		{"non-bool survives", map[string]interface{}{"status": "closed", OpForceClosePolicy: "yes"}, false, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := PopForceClosePolicy(tc.updates)
+			if got != tc.want {
+				t.Errorf("PopForceClosePolicy() = %v, want %v", got, tc.want)
+			}
+			if _, present := tc.updates[OpForceClosePolicy]; present != tc.wantAfter {
+				t.Errorf("key present after pop = %v, want %v", present, tc.wantAfter)
+			}
+			if tc.updates["status"] != "closed" {
+				t.Errorf("pop disturbed the rest of the map: %v", tc.updates)
+			}
+		})
+	}
+}
+
+// TestForceClosePolicyKeyIsNotAnUpdateField pins the fail-loud half of the
+// reserved-key transport. Neither write funnel names the override as a column,
+// so an occurrence that survives to field validation is refused instead of
+// being written or quietly dropped. That is what makes a caller which forgets
+// to plumb force break visibly rather than run unforced.
+func TestForceClosePolicyKeyIsNotAnUpdateField(t *testing.T) {
+	t.Parallel()
+	if IsAllowedUpdateField(OpForceClosePolicy) {
+		t.Fatalf("%q is an allowed update field; an unpopped override would be written as a column", OpForceClosePolicy)
+	}
+}
+
+// TestCloneUpdateRequestCarriesForceClosePolicy keeps the override inside the
+// snapshot every transaction attempt is cloned from. A clone that rebuilt the
+// request field by field and missed this one would drop force silently on
+// retry — the shape of failure this whole transport exists to prevent.
+func TestCloneUpdateRequestCarriesForceClosePolicy(t *testing.T) {
+	t.Parallel()
+	request := publicops.UpdateRequest{Actor: "actor", IssueID: "bd-clone", ForceClosePolicy: true}
+	if !CloneUpdateRequest(request).ForceClosePolicy {
+		t.Fatal("CloneUpdateRequest() dropped ForceClosePolicy")
+	}
+	if CloneUpdateRequest(publicops.UpdateRequest{Actor: "actor", IssueID: "bd-clone"}).ForceClosePolicy {
+		t.Fatal("CloneUpdateRequest() invented ForceClosePolicy")
+	}
+}

--- a/internal/storage/uow/issue_operations.go
+++ b/internal/storage/uow/issue_operations.go
@@ -273,6 +273,11 @@ func updateSpec(request publicops.UpdateRequest) (domain.UpdateSpec, error) {
 			fields[storageissueops.OpUnsetMetadata] = patch.Metadata.Unset
 		}
 	}
+	// Spelled only alongside a status change, matching the embedded backend:
+	// without one the funnel has no crossing to judge.
+	if request.ForceClosePolicy && patch.Status.Set {
+		fields[storageissueops.OpForceClosePolicy] = true
+	}
 	var persistence *types.PersistenceMode
 	if patch.Persistence.Set {
 		value := patch.Persistence.Value

--- a/internal/storage/uow/issue_operations_contract_test.go
+++ b/internal/storage/uow/issue_operations_contract_test.go
@@ -26,6 +26,11 @@ func TestIssueOperationsUpdateFoldsMetadataIntoOneEvent(t *testing.T) {
 	conformance.RunIssueOperationsUpdateFoldsMetadataIntoOneEvent(t, ctx, newUOWIssueOperationsFixture(t, ctx))
 }
 
+func TestIssueOperationsUpdateClosePolicy(t *testing.T) {
+	ctx := context.Background()
+	conformance.RunIssueOperationsUpdateClosePolicy(t, ctx, newUOWIssueOperationsFixture(t, ctx))
+}
+
 func newUOWIssueOperationsFixture(t *testing.T, ctx context.Context) conformance.IssueOperationsStagingFixture {
 	t.Helper()
 	operations, provider := newRealIssueOperationsWithProvider(t, ctx)

--- a/internal/storage/uow/issue_operations_force_close_policy_test.go
+++ b/internal/storage/uow/issue_operations_force_close_policy_test.go
@@ -1,0 +1,60 @@
+package uow
+
+import (
+	"testing"
+
+	storageissueops "github.com/steveyegge/beads/internal/storage/issueops"
+	"github.com/steveyegge/beads/internal/types"
+	publicops "github.com/steveyegge/beads/issueops"
+)
+
+// TestUpdateSpecCarriesForceClosePolicy pins the unit-of-work backend's
+// translation of the typed override into the update map. This backend reaches
+// storage by a path the other two do not, and a mapping dropped exactly here is
+// what 11382270b reverted: the request carried the override, the spec did not,
+// and the caller's force was lost without a sound.
+func TestUpdateSpecCarriesForceClosePolicy(t *testing.T) {
+	t.Parallel()
+
+	statusPatch := publicops.IssuePatch{Status: publicops.Field[publicops.Status]{Set: true, Value: types.StatusClosed}}
+	for _, tc := range []struct {
+		name    string
+		request publicops.UpdateRequest
+		want    bool
+		present bool
+	}{
+		{
+			name:    "forced status change",
+			request: publicops.UpdateRequest{Actor: "a", IssueID: "bd-1", ForceClosePolicy: true, Patch: statusPatch},
+			want:    true,
+			present: true,
+		},
+		{
+			name:    "unforced status change",
+			request: publicops.UpdateRequest{Actor: "a", IssueID: "bd-1", Patch: statusPatch},
+			present: false,
+		},
+		{
+			name: "forced without a status change",
+			request: publicops.UpdateRequest{Actor: "a", IssueID: "bd-1", ForceClosePolicy: true, Patch: publicops.IssuePatch{
+				Priority: publicops.Field[int]{Set: true, Value: 1},
+			}},
+			present: false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			spec, err := updateSpec(tc.request)
+			if err != nil {
+				t.Fatalf("updateSpec: %v", err)
+			}
+			got, present := spec.Fields[storageissueops.OpForceClosePolicy]
+			if present != tc.present {
+				t.Fatalf("spec.Fields[%q] present = %v, want %v", storageissueops.OpForceClosePolicy, present, tc.present)
+			}
+			if present && got != tc.want {
+				t.Errorf("spec.Fields[%q] = %v, want %v", storageissueops.OpForceClosePolicy, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/storage/uow/issue_operations_force_close_policy_test.go
+++ b/internal/storage/uow/issue_operations_force_close_policy_test.go
@@ -10,9 +10,9 @@ import (
 
 // TestUpdateSpecCarriesForceClosePolicy pins the unit-of-work backend's
 // translation of the typed override into the update map. This backend reaches
-// storage by a path the other two do not, and a mapping dropped exactly here is
-// what 11382270b reverted: the request carried the override, the spec did not,
-// and the caller's force was lost without a sound.
+// storage by a path the other two do not, and an earlier attempt was reverted
+// for exactly this: the request carried the override, the spec did not, and the
+// caller's force was lost silently.
 func TestUpdateSpecCarriesForceClosePolicy(t *testing.T) {
 	t.Parallel()
 

--- a/internal/tracker/engine.go
+++ b/internal/tracker/engine.go
@@ -15,6 +15,7 @@ import (
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/steveyegge/beads/internal/storage"
+	"github.com/steveyegge/beads/internal/storage/issueops"
 	"github.com/steveyegge/beads/internal/types"
 	"github.com/steveyegge/beads/internal/ui"
 )
@@ -566,7 +567,15 @@ func applyPullIssueUpdate(ctx context.Context, tx storage.IssueLifecycleTransact
 
 // applyPullIssueFields applies a pulled issue's fields while preserving the
 // caller's control over related collections such as labels.
+//
+// A pull always forces close policy. The remote tracker is authoritative for
+// the status it reports, and it knows nothing about local-only children or
+// local-only blockers — refusing an upstream close because of them would wedge
+// sync on state the remote cannot see and the operator did not create. Both the
+// pull and the conflict reimport route through here, so this is the one place
+// that decision lives.
 func applyPullIssueFields(ctx context.Context, tx storage.IssueLifecycleTransaction, id string, updates map[string]interface{}, actor string) error {
+	updates[issueops.OpForceClosePolicy] = true
 	return tx.UpdateIssue(ctx, id, updates, actor)
 }
 

--- a/internal/tracker/engine_close_policy_test.go
+++ b/internal/tracker/engine_close_policy_test.go
@@ -1,0 +1,46 @@
+package tracker
+
+import (
+	"context"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/storage"
+	"github.com/steveyegge/beads/internal/storage/issueops"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// recordingLifecycleTx captures the update map a pull hands to the funnel.
+type recordingLifecycleTx struct {
+	storage.IssueLifecycleTransaction
+	updates map[string]interface{}
+}
+
+func (t *recordingLifecycleTx) UpdateIssue(_ context.Context, _ string, updates map[string]interface{}, _ string) error {
+	t.updates = updates
+	return nil
+}
+
+// TestApplyPullIssueFieldsAlwaysForcesClosePolicy pins the sync-pull decision.
+// The remote tracker is authoritative for the status it reports and cannot see
+// local-only children or blockers, so a pull must never be refused by close
+// policy — a single upstream close would otherwise wedge every later sync. Both
+// the pull and the conflict reimport route through this one function, so the
+// key has to be unconditional here rather than argued about per caller.
+func TestApplyPullIssueFieldsAlwaysForcesClosePolicy(t *testing.T) {
+	for _, updates := range []map[string]interface{}{
+		{"title": "from remote", "status": string(types.StatusClosed)},
+		{"title": "from remote", "status": string(types.StatusOpen)},
+		{"title": "from remote"},
+	} {
+		tx := &recordingLifecycleTx{}
+		if err := applyPullIssueFields(context.Background(), tx, "bd-pull", updates, "sync"); err != nil {
+			t.Fatalf("applyPullIssueFields: %v", err)
+		}
+		if got := tx.updates[issueops.OpForceClosePolicy]; got != true {
+			t.Errorf("updates[%q] = %v for %v, want true", issueops.OpForceClosePolicy, got, updates)
+		}
+		if tx.updates["title"] != "from remote" {
+			t.Errorf("the pulled fields did not survive: %v", tx.updates)
+		}
+	}
+}

--- a/issueops/issueops.go
+++ b/issueops/issueops.go
@@ -200,6 +200,14 @@ type UpdateRequest struct {
 	// no effect with Claim or an omitted Patch.Assignee and must be false with
 	// ExpectedAssignee. It never bypasses other guards.
 	ForceAssigneeTransfer bool
+	// ForceClosePolicy bypasses only close policy — the open-children refusal
+	// and the live-direct-blocker refusal — for a Patch.Status that crosses into
+	// the done category. The zero value enforces the policy. It has no effect
+	// without such a status change, and never bypasses validation,
+	// ExpectedVersion, ExpectedAssignee, ExpectedStatus, or the assignee fence.
+	// It is the update-side spelling of CloseRequest.Force; a command adapter
+	// that maps one flag to both spells both.
+	ForceClosePolicy bool
 	// ExpectedVersion requires the current row version to match before the claim
 	// and patch. It is an independent precondition and may be combined with Claim.
 	ExpectedVersion *int64

--- a/issueops/issueops.go
+++ b/issueops/issueops.go
@@ -94,9 +94,13 @@ type IssuePatch struct {
 	AppendNotes Field[string]
 	SpecID      Field[string]
 	AwaitID     Field[string]
-	// Status sets the issue's status, including across the configured
-	// done/non-done category boundary. Close and Reopen remain the operations
-	// that carry the full lifecycle policy.
+	// Status sets the issue's status. A status that crosses from outside the
+	// configured done category into it answers to close policy: the update
+	// refuses with CloseOpenChildrenError or ErrCloseBlocked unless
+	// UpdateRequest.ForceClosePolicy is set. A done-to-done change and a move
+	// out of the done category are unaffected. Close and Reopen remain the
+	// operations that carry the full lifecycle policy — a crossing update
+	// applies the close policy, not the close semantics.
 	Status           Field[Status]
 	Priority         Field[int]
 	IssueType        Field[IssueType]
@@ -198,7 +202,11 @@ type UpdateRequest struct {
 	// idempotent and needs no force. Assignees configured as claim.pools aliases
 	// are transferable without force. The zero value enforces the fence. It has
 	// no effect with Claim or an omitted Patch.Assignee and must be false with
-	// ExpectedAssignee. It never bypasses other guards.
+	// ExpectedAssignee. It never bypasses other guards — in particular it is
+	// independent of ForceClosePolicy, and a request that sets it without
+	// Patch.Assignee is invalid. A command adapter with a single --force flag
+	// therefore maps that flag to both fields, conditioning this one on an
+	// assignee edit.
 	ForceAssigneeTransfer bool
 	// ForceClosePolicy bypasses only close policy — the open-children refusal
 	// and the live-direct-blocker refusal — for a Patch.Status that crosses into
@@ -313,7 +321,12 @@ type Lifecycle interface {
 	// validation error also leaves no partial persistent state.
 	Create(context.Context, CreateRequest) (CreateResult, error)
 	// Update validates guards and commits the complete request as one atomic
-	// mutation. A refusal or validation error leaves persistent state unchanged.
+	// mutation. A Patch.Status that crosses from outside the configured done
+	// category into it answers to close policy: an unforced crossing with open
+	// children returns CloseOpenChildrenError and one with a live direct blocker
+	// returns ErrCloseBlocked, both without mutation. ForceClosePolicy bypasses
+	// those two refusals and nothing else. A refusal or validation error leaves
+	// persistent state unchanged.
 	Update(context.Context, UpdateRequest) (UpdateResult, error)
 	// Close validates guards and commits the complete request as one atomic
 	// mutation. It moves the issue to literal StatusClosed, including from a


### PR DESCRIPTION
## What

A generic status update that crosses from a non-done status into a done-category status (`closed`, or a configured custom done status) now enforces close policy — the open-children refusal and the live-direct-blocker refusal — instead of bypassing it. `bd update --force` gains a second meaning: it overrides close policy in addition to the existing assignee-transfer fence.

What changes for users, before → after:

- **Direct and proxied `bd update -s closed`** on an issue with open children or a live direct blocker: before, succeeded silently; after, refuses with the same message `bd close` prints, and `--force` overrides.
- **`bd update --force` without `-a/--assignee`**: before, a validation error on the direct path; after, valid — it means "override close policy" when no assignee transfer is requested.
- **`bd batch`**: the update grammar gains a force token (`update <id> status=closed force=true`); an unforced refusal fails the script and rolls back the whole batch, since batches run in one transaction.
- **Tracker sync-pull**: before, wrote remote closes through the unchecked generic path; after, the pull path always sets the override — remote state is authoritative, so observable sync behavior is unchanged, now explicitly rather than accidentally.
- **`bd batch close`**: unchanged — still an unchecked close. The asymmetry is documented in the batch help text.

Breaking for scripts that relied on `bd update -s closed` to bypass the checks `bd close` applies. CHANGELOG entry under [Unreleased] > Changed. Facade consumers set `UpdateRequest.ForceClosePolicy`.

## Why

`bd close` refuses to close an issue with open children or a live blocker, but `bd update -s closed` — the same transition by another name — skipped both checks on every path (CLI direct, proxied, batch, in-process embedder APIs). This closes that hole.

Enforcement lives at the two storage-layer update funnels (the issueops update transaction and the domain repository `Update`) rather than at call sites: every status-capable update path in the tree converges on one of those two implementations, so new callers are covered by default. The force override travels as a reserved update-map key that each funnel pops before field validation. A caller that fails to plumb it hits the field allowlist and is refused loudly by name, never silently stripped. That property is deliberate: earlier attempts at enforcing this at a shared boundary were reverted because some callers (proxied, batch) either could not satisfy the check or silently dropped the override; the loud-failure transport plus per-caller tests pin against both failure shapes.

The commit series is staged so no commit enforces policy on a caller that cannot yet override: characterization pins first, then a pure extraction of the existing `bd close` gate (byte-identical policy body), then inert transport, then caller plumbing, then a single flip commit with docs.

## Verification

Note: the embedded-backend package skips silently without `BEADS_TEST_EMBEDDED_DOLT=1 CGO_ENABLED=1` — `go test` still prints `ok` with zero tests run, so count RUN/PASS lines rather than trusting `ok`.

```
go vet ./...                                   # clean; golangci-lint run: 0 issues
go test ./internal/storage/issueops/ -v        # 338 pass, 0 fail
go test ./internal/storage/domain/db/ -v       # 799 pass, 0 fail
go test ./internal/storage/uow/ -v             # 135 pass, 0 fail (includes conformance close-policy case)
go test ./internal/storage/dolt/ -run 'ClosePolicy|IssueOperations' -v         # live Dolt
BEADS_TEST_EMBEDDED_DOLT=1 CGO_ENABLED=1 \
  go test ./internal/storage/embeddeddolt/ -run 'ClosePolicy|IssueOperations' -v
go test ./cmd/bd/ -run TestUpdateClosePolicy -v   # 8 pass, 0 fail
go test ./internal/tracker/ -run ClosePolicy -v   # 1 pass
```

The two backend filters must show PASS lines (0 FAIL) for `TestEnforceClosePolicyInTxMatchesCheckedClose`, `TestEnforceClosePolicyInTxRoutesDualResidentToDurableRow`, `TestCrossesIntoDoneCategoryInTx`, `TestUpdateIssueEnforcesClosePolicyForConfiguredDoneStatus`, and the `IssueOperationsUpdateClosePolicy` conformance entry, which also runs on the uow backend — so the same contract is exercised on all three backends. The step-0 characterization pins were run against pre-change code and passed with the old permissive assertions before being inverted in the commits that changed each behavior.

Limitations, honestly stated:

- The proxied CLI refusal branches (stderr copy and exit-code shaping in `cmd/bd/update_proxied_server.go`) are not exercised end-to-end. The enforcement behind them is covered by the uow conformance run, and the spec mapping that carries `--force` is pinned by a unit test, but no test drives a proxied `bd update -s closed` into a refusal and asserts the printed output and exit code.
- Tracker always-force is pinned at the unit level (the pull path injects the override, asserted against a recording fake), not by an end-to-end pull over a real store.
- `bd batch close` remaining unchecked is documented but not pinned by a characterization test.
- `go test ./cmd/bd/` run whole-package has 34 pre-existing failures (init/config/doctor/completion), verified test-for-test identical on an origin/main worktree — unrelated to this change; use the `-run` filter above.