### PR TITLE
fix(doctor,hooks): symlink-resolve absolute core.hooksPath before matching (fixes red macOS main)

### DIFF
--- a/cmd/bd/doctor/git.go
+++ b/cmd/bd/doctor/git.go
@@ -639,7 +639,7 @@ func CheckHooksPath() DoctorCheck {
 		}
 	}
 
-	managed := isBeadsManagedHooksPath(repoRoot, hooksPath)
+	managed := IsBeadsManagedHooksPath(repoRoot, hooksPath)
 	var fix string
 	if managed {
 		fix = "Run 'bd doctor --fix' to unset core.hooksPath, or: git config --unset core.hooksPath"
@@ -675,7 +675,7 @@ func FixHooksPath() error {
 		return nil // nothing set
 	}
 
-	if !isBeadsManagedHooksPath(repoRoot, hooksPath) {
+	if !IsBeadsManagedHooksPath(repoRoot, hooksPath) {
 		return nil // never touch a third-party hooksPath
 	}
 
@@ -707,15 +707,61 @@ func getConfiguredHooksPath(repoRoot string) (string, bool) {
 	return strings.TrimSpace(string(out)), true
 }
 
-// isBeadsManagedHooksPath reports whether hooksPath is one of the values bd
+// IsBeadsManagedHooksPath reports whether hooksPath is one of the values bd
 // itself writes to core.hooksPath (.beads/hooks or .beads-hooks, relative or
-// absolute under repoRoot). Mirrors the matching in
-// resetHooksPathIfBeadsManaged (cmd/bd/hooks.go) — keep the two in sync.
-func isBeadsManagedHooksPath(repoRoot, hooksPath string) bool {
-	absBeadsHooks := filepath.Join(repoRoot, ".beads", "hooks")
-	absSharedHooks := filepath.Join(repoRoot, ".beads-hooks")
-	return hooksPath == ".beads/hooks" || hooksPath == ".beads-hooks" ||
-		hooksPath == absBeadsHooks || hooksPath == absSharedHooks
+// absolute under repoRoot). It is the single matcher for that question;
+// resetHooksPathIfBeadsManaged (cmd/bd/hooks.go) calls it too, so the two
+// paths cannot drift apart.
+//
+// Absolute values are compared after symlink resolution. repoRoot comes from
+// git.GetMainRepoRoot, which canonicalizes the path, while the configured
+// core.hooksPath is whatever string the user or an older bd wrote. A raw
+// string compare therefore misses a genuinely beads-managed path any time the
+// repo is reached through a symlink — on macOS every repo under /var (which
+// is a symlink to /private/var, including all of t.TempDir()) hits this. The
+// false negative is not cosmetic: CheckHooksPath then reports the dangling
+// path as third-party and FixHooksPath deliberately refuses to unset it.
+func IsBeadsManagedHooksPath(repoRoot, hooksPath string) bool {
+	if hooksPath == ".beads/hooks" || hooksPath == ".beads-hooks" {
+		return true
+	}
+	if !filepath.IsAbs(hooksPath) {
+		return false
+	}
+	root := resolveExistingPrefix(repoRoot)
+	candidate := resolveExistingPrefix(hooksPath)
+	return candidate == filepath.Join(root, ".beads", "hooks") ||
+		candidate == filepath.Join(root, ".beads-hooks")
+}
+
+// resolveExistingPrefix returns path with its longest existing ancestor
+// replaced by that ancestor's symlink-resolved form, leaving any missing
+// trailing components untouched.
+//
+// filepath.EvalSymlinks alone is not enough here: the whole point of the
+// dangling-hooksPath check is that the leaf does not exist, so EvalSymlinks
+// on the full path fails and returns nothing usable. Walking up to the
+// deepest component that does exist still canonicalizes the symlinked prefix
+// (/var -> /private/var), which is where the divergence lives.
+func resolveExistingPrefix(path string) string {
+	if path == "" || !filepath.IsAbs(path) {
+		return path
+	}
+	current := filepath.Clean(path)
+	var trailing string
+	for {
+		if resolved, err := filepath.EvalSymlinks(current); err == nil {
+			return filepath.Join(resolved, trailing)
+		}
+		parent := filepath.Dir(current)
+		if parent == current {
+			// Reached the filesystem root without finding an existing
+			// component; nothing to canonicalize against.
+			return filepath.Clean(path)
+		}
+		trailing = filepath.Join(filepath.Base(current), trailing)
+		current = parent
+	}
 }
 
 // CheckGitHooksDoltCompatibility checks if installed git hooks are compatible with Dolt backend.

--- a/cmd/bd/doctor/hooks_path_test.go
+++ b/cmd/bd/doctor/hooks_path_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -199,5 +200,85 @@ func TestFixHooksPath_NoOpWhenTargetExists(t *testing.T) {
 
 	if got := getGitConfig(t, dir, "core.hooksPath"); got != ".beads/hooks" {
 		t.Errorf("expected core.hooksPath to remain %q when target exists, got %q", ".beads/hooks", got)
+	}
+}
+
+// TestCheckHooksPath_SymlinkedRepoRoot pins the fix for the macOS-red build at
+// 868dd077a: git canonicalizes the repo root it reports, but the configured
+// core.hooksPath is whatever string was written, so an absolute beads-managed
+// path reached through a symlink used to string-compare unequal and be
+// misreported as third-party — leaving FixHooksPath refusing to unset it.
+//
+// macOS hits this on every temp dir (/var is a symlink to /private/var), which
+// is how CI caught it, but nothing about it is macOS-specific: an explicit
+// symlink reproduces it anywhere git resolves the root.
+func TestCheckHooksPath_SymlinkedRepoRoot(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("creating symlinks requires elevated privileges on Windows")
+	}
+
+	base := t.TempDir()
+	realDir := filepath.Join(base, "real")
+	if err := os.MkdirAll(realDir, 0755); err != nil {
+		t.Fatalf("failed to create real repo dir: %v", err)
+	}
+	linkDir := filepath.Join(base, "link")
+	if err := os.Symlink(realDir, linkDir); err != nil {
+		t.Fatalf("failed to symlink %s -> %s: %v", linkDir, realDir, err)
+	}
+	setupGitRepoInDir(t, realDir)
+
+	// The value a user (or an older bd) wrote: absolute, and carrying the
+	// unresolved symlink prefix. Its target does not exist, so it is dangling.
+	hooksPath := filepath.Join(linkDir, ".beads", "hooks")
+	setGitConfig(t, realDir, "core.hooksPath", hooksPath)
+
+	runInDir(t, realDir, func() {
+		check := CheckHooksPath()
+		if check.Status != StatusWarning {
+			t.Fatalf("expected StatusWarning, got %q: %s", check.Status, check.Message)
+		}
+		if !strings.Contains(check.Fix, "bd doctor --fix") {
+			t.Errorf("expected beads-managed fix hint for a symlinked repo root, got %q", check.Fix)
+		}
+		if err := FixHooksPath(); err != nil {
+			t.Fatalf("FixHooksPath failed: %v", err)
+		}
+	})
+
+	if got := getGitConfig(t, realDir, "core.hooksPath"); got != "" {
+		t.Errorf("expected core.hooksPath to be unset after FixHooksPath, got %q", got)
+	}
+}
+
+// TestIsBeadsManagedHooksPath_LeavesThirdPartyAlone guards the widened
+// symlink-resolving match against over-reach: resolving paths must not make
+// an unrelated hooks directory look beads-managed, since a false positive here
+// means bd unsets a hooksPath it does not own (husky, lefthook).
+func TestIsBeadsManagedHooksPath_LeavesThirdPartyAlone(t *testing.T) {
+	root := t.TempDir()
+	cases := []struct {
+		name      string
+		hooksPath string
+		want      bool
+	}{
+		{"relative beads hooks", ".beads/hooks", true},
+		{"relative shared beads hooks", ".beads-hooks", true},
+		{"absolute beads hooks", filepath.Join(root, ".beads", "hooks"), true},
+		{"absolute shared beads hooks", filepath.Join(root, ".beads-hooks"), true},
+		{"relative husky", ".husky/_", false},
+		{"relative githooks", ".githooks", false},
+		{"absolute husky", filepath.Join(root, ".husky", "_"), false},
+		{"beads hooks under a different repo", filepath.Join(t.TempDir(), ".beads", "hooks"), false},
+		{"deeper path below beads hooks", filepath.Join(root, ".beads", "hooks", "pre-commit"), false},
+		{"empty", "", false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IsBeadsManagedHooksPath(root, tc.hooksPath); got != tc.want {
+				t.Errorf("IsBeadsManagedHooksPath(%q, %q) = %v, want %v", root, tc.hooksPath, got, tc.want)
+			}
+		})
 	}
 }

--- a/cmd/bd/hooks.go
+++ b/cmd/bd/hooks.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+	"github.com/steveyegge/beads/cmd/bd/doctor"
 	"github.com/steveyegge/beads/internal/beads"
 	"github.com/steveyegge/beads/internal/config"
 	"github.com/steveyegge/beads/internal/debug"
@@ -1290,11 +1291,11 @@ func resetHooksPathIfBeadsManaged() error {
 	cmd.Dir = repoRoot
 	if out, err := cmd.Output(); err == nil {
 		hooksPath := strings.TrimSpace(string(out))
-		// Match both relative (legacy) and absolute (GH#2414) beads hooks paths
-		absBeadsHooks := filepath.Join(repoRoot, ".beads", "hooks")
-		absSharedHooks := filepath.Join(repoRoot, ".beads-hooks")
-		if hooksPath == ".beads/hooks" || hooksPath == ".beads-hooks" ||
-			hooksPath == absBeadsHooks || hooksPath == absSharedHooks {
+		// Matches both relative (legacy) and absolute (GH#2414) beads hooks
+		// paths, symlink-resolving the absolute forms. Shared with
+		// doctor.CheckHooksPath/FixHooksPath so uninstall and `bd doctor --fix`
+		// cannot disagree about what "beads-managed" means.
+		if doctor.IsBeadsManagedHooksPath(repoRoot, hooksPath) {
 			unsetCmd := exec.Command("git", "config", "--unset", "core.hooksPath")
 			unsetCmd.Dir = repoRoot
 			if output, err := unsetCmd.CombinedOutput(); err != nil {


### PR DESCRIPTION
## Why

`main` is red. `Test (macos-latest)` in the **Main** workflow has failed on every push since 868dd077a (#5203), with one failing test:

```
--- FAIL: TestCheckHooksPath_MissingBeadsManagedPath/absolute_.beads/hooks
    hooks_path_test.go:121: expected beads-managed fix hint, got "core.hooksPath is not beads-managed; bd will not change it. ..."
    hooks_path_test.go:133: expected core.hooksPath to be unset after FixHooksPath, got "/var/folders/.../001/.beads/hooks"
```

This is stop-the-line: it is the fix for the base branch.

## What was actually wrong

`isBeadsManagedHooksPath` compared the raw configured `core.hooksPath` string against `filepath.Join(repoRoot, ".beads", "hooks")`.

`repoRoot` comes from `git.GetMainRepoRoot`, which canonicalizes and **symlink-resolves** the path. The configured `core.hooksPath` is whatever string the user (or an older `bd`) wrote, unresolved. So any repo reached through a symlink fails the compare, and a genuinely beads-managed dangling hooksPath gets reported as third-party — at which point `FixHooksPath` *deliberately* refuses to touch it. `bd doctor --fix` therefore cannot repair the exact state the check was added to catch (#4440).

macOS makes it unmissable, because `/var` is a symlink to `/private/var` and so every `t.TempDir()` trips it. **But this is not a macOS quirk and not a test artifact.** `git rev-parse --show-toplevel` resolves symlinks on every platform:

```
$ ln -s "$base/real" "$base/link"; git init -q "$base/link"
configured (via symlink): .../symtest/link
toplevel:                 .../symtest/real
```

Any user whose repo path crosses a symlink — `/var`, a symlinked home, a bind-mounted checkout — gets the same false negative on Linux.

## Change

- Absolute candidates are compared after symlink resolution. `filepath.EvalSymlinks` on the full path is not usable here: in the dangling case the leaf is missing by definition, so it just errors. `resolveExistingPrefix` walks up to the deepest component that *does* exist and canonicalizes there, which is where the divergence lives; missing trailing components are preserved.
- `resetHooksPathIfBeadsManaged` (`cmd/bd/hooks.go`) carried a duplicate of the same matching — and so the same bug — under a `keep the two in sync` comment. It now calls the exported `doctor.IsBeadsManagedHooksPath`, so `bd hooks uninstall` and `bd doctor --fix` cannot disagree about what "beads-managed" means.

Relative matching (`.beads/hooks`, `.beads-hooks`) is unchanged, and a relative non-beads value still returns false exactly as before.

## Tests

- `TestCheckHooksPath_SymlinkedRepoRoot` — reproduces the CI failure **on Linux** via an explicit symlink. Verified failing on the parent commit with the same two assertion messages the macOS runner printed, and passing with the fix. Skipped on Windows (symlink creation needs elevation).
- `TestIsBeadsManagedHooksPath_LeavesThirdPartyAlone` — guards the widened match against over-reach. A false positive here means `bd` unsets a `core.hooksPath` it does not own (husky, lefthook), so the negative cases are pinned explicitly: husky, `.githooks`, a beads path under a *different* repo root, and a path *below* `.beads/hooks`.

Local validation (`CGO_ENABLED=1 -tags gms_pure_go`): the previously-failing subtest passes; `go vet` and `gofmt` clean; `go test -run 'Hook|hook' ./cmd/bd/` passes. Full `./cmd/bd/doctor/...` shows an **identical** failure set before and after this change (`TestCheckRepoFingerprint_UsesTargetRepoOutsideCWD`, `TestCheckTestPollution_NoTestIssues_EmptyDB`) — both pre-existing here and green in CI, so this change introduces no new failures. `make test` is queued in the local verification lane.

Refs #4440
