### PR TITLE
fix(create): route infra types to wisps on the proxied single-create path

### DIFF
--- a/cmd/bd/create_proxied_integration_test.go
+++ b/cmd/bd/create_proxied_integration_test.go
@@ -694,3 +694,68 @@ A new feature
 		}
 	})
 }
+
+// TestProxiedServerCreateInfraTypeRoutesToWisps pins end-to-end that a
+// configured infra type lands in the wisps tables against a real proxied
+// server, matching the embedded path. Before ga-2kkue the proxied path routed
+// on the --ephemeral/--no-history flags alone, so `bd create -t message` wrote
+// a durable row into issues.
+func TestProxiedServerCreateInfraTypeRoutesToWisps(t *testing.T) {
+	requireSharedProxiedServer(t)
+	t.Parallel()
+
+	bd := buildEmbeddedBD(t)
+
+	// countRows reports how many rows the given table holds for an ID. Issues
+	// and wisps share one ID space, so both sides must be asserted: a routing
+	// bug shows up as the row existing in the wrong table, not as a missing row.
+	countRows := func(t *testing.T, p proxiedProject, table, id string) int {
+		t.Helper()
+		db := openProxiedDB(t, p)
+		var count int
+		query := fmt.Sprintf("SELECT COUNT(*) FROM %s WHERE id = ?", table)
+		if err := db.QueryRowContext(context.Background(), query, id).Scan(&count); err != nil {
+			t.Fatalf("query %s: %v", table, err)
+		}
+		return count
+	}
+
+	t.Run("infra type routes to wisps", func(t *testing.T) {
+		t.Parallel()
+		p := newSharedProxiedProject(t, bd, "iw")
+		issue := bdProxiedCreate(t, bd, p.dir, "Infra message", "-t", "message")
+		if !issue.Ephemeral {
+			t.Errorf("Ephemeral = false, want true for an infra type")
+		}
+		if got := countRows(t, p, "wisps", issue.ID); got != 1 {
+			t.Errorf("wisps rows for %s = %d, want 1", issue.ID, got)
+		}
+		if got := countRows(t, p, "issues", issue.ID); got != 0 {
+			t.Errorf("issues rows for %s = %d, want 0", issue.ID, got)
+		}
+	})
+
+	t.Run("non-infra type stays durable", func(t *testing.T) {
+		t.Parallel()
+		p := newSharedProxiedProject(t, bd, "id")
+		issue := bdProxiedCreate(t, bd, p.dir, "Plain task", "-t", "task")
+		if got := countRows(t, p, "issues", issue.ID); got != 1 {
+			t.Errorf("issues rows for %s = %d, want 1", issue.ID, got)
+		}
+		if got := countRows(t, p, "wisps", issue.ID); got != 0 {
+			t.Errorf("wisps rows for %s = %d, want 0 — infra routing must not wisp everything", issue.ID, got)
+		}
+	})
+
+	t.Run("no-history infra type keeps its retention mode", func(t *testing.T) {
+		t.Parallel()
+		p := newSharedProxiedProject(t, bd, "ih")
+		issue := bdProxiedCreate(t, bd, p.dir, "Infra message", "-t", "message", "--no-history")
+		if issue.Ephemeral {
+			t.Errorf("Ephemeral = true, want false — --no-history keeps its own retention mode")
+		}
+		if got := countRows(t, p, "wisps", issue.ID); got != 1 {
+			t.Errorf("wisps rows for %s = %d, want 1", issue.ID, got)
+		}
+	})
+}

--- a/cmd/bd/create_proxied_server.go
+++ b/cmd/bd/create_proxied_server.go
@@ -123,6 +123,16 @@ func runCreateProxiedSingle(_ *cobra.Command, ctx context.Context, in createInpu
 			}
 		}
 
+		// Configured infra types live in the wisp tables, the same routing the
+		// embedded path applies (cmd/bd/create_atomic.go, DoltStore.CreateIssue)
+		// and the uow facade applies in uow.issueOperations.Create. Mark the
+		// issue before params reads it so ID minting and table routing agree on
+		// the destination. A no-history create keeps its own retention mode and
+		// already routes to wisps.
+		if !issue.Ephemeral && !issue.NoHistory && cctx.InfraTypes[string(issue.IssueType)] {
+			issue.Ephemeral = true
+		}
+
 		params := domain.CreateIssueParams{
 			Issue:                   issue,
 			ExplicitID:              in.explicitID,

--- a/cmd/bd/create_proxied_server_test.go
+++ b/cmd/bd/create_proxied_server_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -11,6 +12,7 @@ import (
 
 	"github.com/steveyegge/beads/internal/config"
 	"github.com/steveyegge/beads/internal/storage/domain"
+	"github.com/steveyegge/beads/internal/storage/uow"
 	"github.com/steveyegge/beads/internal/types"
 )
 
@@ -518,4 +520,110 @@ func withTestYAMLCustomTypes(t *testing.T, customCSV string) func() {
 		t.Fatalf("config.Initialize: %v", err)
 	}
 	return func() { config.ResetForTesting() }
+}
+
+// --- fakes for the proxied single-create routing tests ---
+
+type fakeCreateConfigUC struct {
+	domain.ConfigUseCase // unimplemented methods panic; the create path must not call them
+	cctx                 domain.CreateContext
+}
+
+func (f *fakeCreateConfigUC) LoadCreateContext(ctx context.Context) (domain.CreateContext, error) {
+	return f.cctx, nil
+}
+
+type fakeCreateIssueUC struct {
+	domain.IssueUseCase // unimplemented methods panic; the create path must not call them
+	wispCalls           int
+	issueCalls          int
+	lastIssue           *types.Issue
+}
+
+func (f *fakeCreateIssueUC) CreateWisp(ctx context.Context, params domain.CreateIssueParams, actor string) (domain.CreateIssueResult, error) {
+	f.wispCalls++
+	f.lastIssue = params.Issue
+	return domain.CreateIssueResult{Issue: params.Issue}, nil
+}
+
+func (f *fakeCreateIssueUC) CreateIssue(ctx context.Context, params domain.CreateIssueParams, actor string) (domain.CreateIssueResult, error) {
+	f.issueCalls++
+	f.lastIssue = params.Issue
+	return domain.CreateIssueResult{Issue: params.Issue}, nil
+}
+
+type fakeCreateUOW struct {
+	uow.UnitOfWork // unimplemented methods panic
+	configUC       domain.ConfigUseCase
+	issueUC        domain.IssueUseCase
+}
+
+func (f *fakeCreateUOW) Close(ctx context.Context)                        {}
+func (f *fakeCreateUOW) Commit(ctx context.Context, message string) error { return nil }
+func (f *fakeCreateUOW) ConfigUseCase() domain.ConfigUseCase              { return f.configUC }
+func (f *fakeCreateUOW) IssueUseCase() domain.IssueUseCase                { return f.issueUC }
+
+type fakeCreateUOWProvider struct {
+	configUC domain.ConfigUseCase
+	issueUC  domain.IssueUseCase
+}
+
+func (p *fakeCreateUOWProvider) NewUOW(ctx context.Context) (uow.UnitOfWork, error) {
+	return &fakeCreateUOW{configUC: p.configUC, issueUC: p.issueUC}, nil
+}
+
+func (p *fakeCreateUOWProvider) Close(ctx context.Context) error { return nil }
+
+// TestRunCreateProxiedSingleInfraTypeRoutesToCreateWisp pins the proxied
+// single-create table routing against the configured infra-type set, the same
+// routing the embedded path applies (cmd/bd/create_atomic.go,
+// DoltStore.CreateIssue) and the uow facade applies. The proxied path used to
+// route on the --ephemeral/--no-history flags alone, so `bd create -t message`
+// landed in issues against a server and in wisps embedded (ga-2kkue).
+func TestRunCreateProxiedSingleInfraTypeRoutesToCreateWisp(t *testing.T) {
+	run := func(t *testing.T, in createInput) *fakeCreateIssueUC {
+		t.Helper()
+		issueUC := &fakeCreateIssueUC{}
+		oldProvider := uowProvider
+		uowProvider = &fakeCreateUOWProvider{
+			configUC: &fakeCreateConfigUC{cctx: domain.CreateContext{
+				IssuePrefix: "bd",
+				InfraTypes:  map[string]bool{"message": true},
+			}},
+			issueUC: issueUC,
+		}
+		t.Cleanup(func() { uowProvider = oldProvider })
+
+		captureStdout(t, func() error {
+			return runCreateProxiedSingle(nil, context.Background(), in)
+		})
+		return issueUC
+	}
+
+	t.Run("infra type routes to wisps", func(t *testing.T) {
+		got := run(t, createInput{title: "Infra message", issueType: "message", priority: 2, silent: true})
+		if got.wispCalls != 1 || got.issueCalls != 0 {
+			t.Errorf("CreateWisp/CreateIssue calls = %d/%d, want 1/0", got.wispCalls, got.issueCalls)
+		}
+		if got.lastIssue == nil || !got.lastIssue.Ephemeral {
+			t.Errorf("Ephemeral = %v, want true so ID minting and table routing agree", got.lastIssue)
+		}
+	})
+
+	t.Run("non-infra type stays durable", func(t *testing.T) {
+		got := run(t, createInput{title: "Plain task", issueType: "task", priority: 2, silent: true})
+		if got.issueCalls != 1 || got.wispCalls != 0 {
+			t.Errorf("CreateIssue/CreateWisp calls = %d/%d, want 1/0", got.issueCalls, got.wispCalls)
+		}
+	})
+
+	t.Run("no-history infra type keeps its retention mode", func(t *testing.T) {
+		got := run(t, createInput{title: "Infra message", issueType: "message", priority: 2, noHistory: true, silent: true})
+		if got.wispCalls != 1 || got.issueCalls != 0 {
+			t.Errorf("CreateWisp/CreateIssue calls = %d/%d, want 1/0", got.wispCalls, got.issueCalls)
+		}
+		if got.lastIssue == nil || got.lastIssue.Ephemeral {
+			t.Errorf("Ephemeral = %v, want false — --no-history keeps its own retention mode", got.lastIssue)
+		}
+	})
 }


### PR DESCRIPTION
## What

The proxied single-create path now consults the configured infra-type set when choosing between the `issues` and `wisps` tables, matching every other create surface.

## Why

`runCreateProxiedSingle` picked its destination table from the `--ephemeral` / `--no-history` flags alone. `buildCreateIssueFromInput` sets `Ephemeral` from the flag, so `bd create -t message` against a proxied server wrote a durable row into `issues`, while the identical command on the embedded path landed in `wisps`.

Every other create surface that claims parity already resolves this:

| Surface | Where |
| --- | --- |
| embedded CLI | `cmd/bd/create_atomic.go:53` |
| direct store | `DoltStore.CreateIssue` (`internal/storage/dolt/issues.go:31`) |
| facade engine | `issueops.ExecuteCreate` (`internal/storage/issueops/execution.go:37`) |
| uow backend | `uow.issueOperations.Create` (`internal/storage/uow/issue_operations.go:82`) |

`LoadCreateContext` already returns the resolved `InfraTypes` set on this path, so the routing costs no extra round trip — it just was not read. The guard is byte-for-byte the one the other surfaces use, `!Ephemeral && !NoHistory && InfraTypes[type]`, including the `!NoHistory` term, so a no-history infra create keeps its own retention mode instead of being silently converted to ephemeral. It is placed before `domain.CreateIssueParams` is built so ID minting and table routing agree on the destination.

Same defect class as the facade bug fixed in `2d93fad7e`.

## Scope

Deliberately limited to the single-create surface. The markdown-batch (`CreateWisps` vs `CreateIssues` for a whole batch) and graph-plan proxied paths also route on flags only — but so do their embedded counterparts, so those two are at parity with each other. A mixed-type batch cannot be expressed by one boolean at all, so correcting them belongs to a per-item routing design rather than to this fix.

One reviewer-visible consequence, filed as a follow-up rather than fixed here: `bd create -t message --dry-run` still previews `ephemeral:false` on both the proxied and the embedded path, because both build the preview from flags alone. Before this change the proxied preview and proxied behavior agreed by both being wrong; now the preview is wrong in isolation. It needs fixing on both paths together.

## Verification

```
go build ./...                                                       # clean
go vet ./cmd/bd/                                                     # clean
gofmt -l internal cmd . | grep -v vendor                             # empty
go test -v -count=1 -run TestRunCreateProxiedSingleInfraTypeRoutesToCreateWisp ./cmd/bd/   # 4 PASS
go test -v -count=1 -run TestParity ./cmd/bd/                        # 40 PASS, 0 FAIL
```

`TestParity` matches the protected baseline of 40 exactly, and no assertion in `cmd/bd/write_verbs_parity_test.go` was touched.

Mutation-checked, not just asserted: removing the three-line production hunk makes `TestRunCreateProxiedSingleInfraTypeRoutesToCreateWisp/infra_type_routes_to_wisps` fail, and restoring it leaves `git diff` empty. The test is non-vacuous.

Two layers of coverage were added:

- `TestRunCreateProxiedSingleInfraTypeRoutesToCreateWisp` (`cmd/bd/create_proxied_server_test.go`) — fakes the UOW and asserts `CreateWisp` vs `CreateIssue` dispatch plus the `Ephemeral` flag the params carry.
- `TestProxiedServerCreateInfraTypeRoutesToWisps` (`cmd/bd/create_proxied_integration_test.go`) — end-to-end against a real proxied server, counting rows in **both** `wisps` and `issues`. Issues and wisps share one ID space, so a routing bug shows up as the row being in the wrong table, not as a missing row; asserting only one side would not catch it.

Both cover the infra case, the non-infra case (routing must not wisp everything), and the `--no-history` case.
