### PR TITLE
fix(close): honor the pinned boolean, not just the pinned status

### DIFF
--- a/cmd/bd/show_unit_helpers_test.go
+++ b/cmd/bd/show_unit_helpers_test.go
@@ -36,6 +36,16 @@ func TestValidateIssueClosable(t *testing.T) {
 		t.Fatalf("expected pinned close to succeed with force, got %v", err)
 	}
 
+	// ga-z3vht: pinned=true protects the bead independently of status, so
+	// `bd close` refuses it without --force on both the direct and proxied path.
+	booleanPinned := &types.Issue{Status: types.StatusOpen, Pinned: true}
+	if err := validateIssueClosable("bd-6", booleanPinned, "alice", false); err == nil {
+		t.Fatalf("expected boolean-pinned close error")
+	}
+	if err := validateIssueClosable("bd-6", booleanPinned, "alice", true); err != nil {
+		t.Fatalf("expected boolean-pinned close to succeed with force, got %v", err)
+	}
+
 	// be-035: actor != assignee must be refused without --force.
 	mismatched := &types.Issue{Assignee: "bob"}
 	if err := validateIssueClosable("bd-3", mismatched, "alice", false); err == nil {

--- a/internal/validation/issue.go
+++ b/internal/validation/issue.go
@@ -48,14 +48,22 @@ func NotTemplate() IssueValidator {
 	}
 }
 
-// NotPinned validates that an issue is not pinned.
-// Returns an error if the issue is pinned, unless force is true.
+// NotPinned validates that an issue is not pinned, by either of the two ways
+// bd expresses a pin: the Pinned boolean column or the pinned status. Returns
+// an error if either trigger fires, unless force is true.
+//
+// Both triggers are load-bearing because consumers disagree on which one they
+// write and read (ga-z3vht). Gas Town pins by status — it enumerates pins with
+// List(ListOptions{Status: StatusPinned}) across 21 sites (hook_check.go,
+// prime_output.go, molecule_step.go, up.go) — while Gas City reads the boolean
+// (compute_awake_set.go). Checking only one strips the other consumer's
+// protection outright, so do not "simplify" either clause away.
 func NotPinned(force bool) IssueValidator {
 	return func(id string, issue *types.Issue) error {
 		if issue == nil {
 			return nil // Let Exists() handle nil check if needed
 		}
-		if !force && issue.Status == types.StatusPinned {
+		if !force && (issue.Pinned || issue.Status == types.StatusPinned) {
 			return fmt.Errorf("cannot modify pinned issue %s (use --force to override)", id)
 		}
 		return nil

--- a/internal/validation/issue_test.go
+++ b/internal/validation/issue_test.go
@@ -99,6 +99,20 @@ func TestNotPinned(t *testing.T) {
 			force:   true,
 			wantErr: false,
 		},
+		// ga-z3vht: the pinned boolean is a second, independent trigger — an
+		// issue carrying pinned=true is protected whatever its status.
+		{
+			name:    "boolean-pinned issue without force fails",
+			issue:   &types.Issue{ID: "bd-test", Status: types.StatusOpen, Pinned: true},
+			force:   false,
+			wantErr: true,
+		},
+		{
+			name:    "boolean-pinned issue with force passes",
+			issue:   &types.Issue{ID: "bd-test", Status: types.StatusOpen, Pinned: true},
+			force:   true,
+			wantErr: false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -594,6 +608,14 @@ func TestForClose(t *testing.T) {
 			issue:   &types.Issue{ID: "bd-test", Status: types.StatusPinned},
 			force:   true,
 			wantErr: false,
+		},
+		// ga-z3vht: the chain inherits both pinned triggers, so a boolean-pinned
+		// issue is refused even though its status is open.
+		{
+			name:    "boolean-pinned without force fails",
+			issue:   &types.Issue{ID: "bd-test", Status: types.StatusOpen, Pinned: true},
+			force:   false,
+			wantErr: true,
 		},
 		{
 			name:    "regular open issue passes",


### PR DESCRIPTION
## What

`bd close` now refuses a pinned issue when **either** the `Pinned` boolean column is set **or** the status is `pinned`. `--force` still overrides, as before.

## Why

`validation.NotPinned` checked only `issue.Status == types.StatusPinned`, so it never read the `Pinned` boolean column. An issue carrying `pinned=true` with any other status — `open`, `in_progress` — closed without `--force`, silently losing the protection its pin was supposed to buy.

Both triggers are checked because bd's two consumers disagree about which one they use:

- **Gas Town pins by status.** It enumerates pins with `List(ListOptions{Status: StatusPinned})` at 21 sites (`hook_check.go`, `prime_output.go`, `molecule_step.go`, `up.go`).
- **Gas City reads the boolean** (`compute_awake_set.go:443,467`).

So a boolean-only check — the obvious reading of "the bug is that it checks status instead of the boolean" — would have *stripped* Gas Town's existing protection. That audit is why the guard is `Pinned || Status == pinned` rather than a swap, and the doc comment says so, because this is precisely the kind of clause a later reader would try to simplify away.

The change is strictly additive. No existing assertion in `TestNotPinned`, `TestForClose`, or `TestValidateIssueClosable` changes outcome, since every pre-existing case exercises the status trigger.

## Scope

This stays at the validation layer deliberately. Both live callers — the direct path (`cmd/bd/close.go`) and the proxied path (`cmd/bd/close_proxied_server.go`) — reach it through `validateIssueClosable`, both plumb `--force`, and both fail loudly. No caller inherits a policy it cannot override.

Pushing the guard down into `issueops.Close` was considered and rejected for this PR: `bd batch` close bypasses all close validation and has **no force lever at all**, so a shared-layer guard would reproduce this repo's twice-burned pattern of a policy check reaching a caller that cannot satisfy it. That gap is real and is filed separately, along with the fact that `issueops/close.go` has no pinned check of either kind today — which means linked-library consumers reaching `store.IssueLifecycle().Close()` are currently unprotected.

Three other adjacent gaps were found during review and filed rather than folded in, because each needs an owner ruling:

1. A forced close leaves `pinned=true` residue (`closeIssueInTx` never clears the column), and the new boolean trigger then refuses the *idempotent re-close* that used to exit 0. Fix is either clearing pinned on close or exempting `status == closed` — the latter narrows the ruling, so it is not mine to pick.
2. `bd update --status closed` bypasses the pinned refusal entirely and then auto-clears the pin (`issueops/update.go:338`). Possibly by design, since update *is* the pin/unpin verb.
3. `forClose`/`forUpdate`/`forDelete`/`forReopen` are production-dead — `validateIssueClosable` hand-rolls the same chains. This PR keeps `forClose` in sync via a new case rather than deleting it, but the family should be wired or removed.

## Verification

```
go build ./...                                                # clean
go vet ./internal/validation/ ./cmd/bd/                        # clean
gofmt -l internal cmd . | grep -v vendor                      # empty
go test -v -count=1 ./internal/validation/                    # 218 PASS
go test -count=1 -run 'TestValidateIssueClosable|TestCloseCommand' ./cmd/bd/   # ok
go test -v -count=1 -run TestParity ./cmd/bd/                 # 40 PASS, 0 FAIL
```

`TestParity` matches the protected baseline of 40 exactly, and no assertion in `cmd/bd/write_verbs_parity_test.go` was touched.

Mutation-checked, not just asserted: reverting the guard to `issue.Status == types.StatusPinned` makes both `TestNotPinned/boolean-pinned_issue_without_force_fails` and `TestForClose/boolean-pinned_without_force_fails` fail, and restoring it leaves `git diff` empty. The new cases are non-vacuous.

Coverage added at all three levels the guard is reachable from: `TestNotPinned` (the validator itself, with and without `--force`), `TestForClose` (the chain inherits both triggers), and `TestValidateIssueClosable` (the live `cmd/bd` entry point, with and without `--force`).
