### PR TITLE
fix(uow): enforce the assignee-transfer fence at the facade layer

### DIFF
--- a/internal/storage/conformance/issue_operations_contract.go
+++ b/internal/storage/conformance/issue_operations_contract.go
@@ -289,6 +289,146 @@ func RunIssueOperationsUpdateClosePolicy(t *testing.T, ctx context.Context, fixt
 	assertClosePolicyStatus(t, ctx, fixture, parentID, types.StatusInProgress)
 }
 
+// RunIssueOperationsUpdateAssigneeTransferFence pins what an assignee edit does
+// when it takes an issue away from a live foreign holder: it is refused with
+// ErrAlreadyClaimed, and ForceAssigneeTransfer, an ExpectedAssignee
+// compare-and-set, or a configured claim.pools alias are the only ways past it.
+// The contract had no assignee-transfer case at all, and that gap is exactly how
+// one backend came to permit a transfer the other two refuse.
+func RunIssueOperationsUpdateAssigneeTransferFence(t *testing.T, ctx context.Context, fixture IssueOperationsStagingFixture) {
+	t.Helper()
+
+	heldID := fixture.IssuePrefix + "-xferfence-held"
+	seedClosePolicyIssue(t, ctx, fixture, heldID, publicops.CreateRequest{})
+	claimed, err := fixture.Operations.Update(ctx, publicops.UpdateRequest{Actor: "holder", IssueID: heldID, Claim: true})
+	if err != nil {
+		t.Fatalf("claim %s for holder: %v", heldID, err)
+	}
+	if !claimed.Changed {
+		t.Fatalf("claiming %s reported Changed = false, want a committed claim", heldID)
+	}
+	assertLiveAssignee(t, ctx, fixture, heldID, "holder")
+
+	// The fence itself: an unforced transfer away from the live holder is
+	// refused, and the refusal writes nothing — not the row, not an event.
+	events := newIssueOperationsEventCounter(t, ctx, fixture, heldID)
+	if _, err := fixture.Operations.Update(ctx, assigneeTransferRequest(heldID, "rival", "rival")); !errors.Is(err, publicops.ErrAlreadyClaimed) {
+		t.Fatalf("unforced transfer of %s away from its holder: err = %v, want ErrAlreadyClaimed", heldID, err)
+	}
+	assertLiveAssignee(t, ctx, fixture, heldID, "holder")
+	events.assert(t, "refused transfer", 0, nil)
+
+	// A stale precondition is orthogonal to the fence and is checked ahead of
+	// it, so a request that fails both reports the precondition — the same
+	// ordering a forced close-policy crossing gets.
+	staleVersion := int64(-1)
+	staleVersionRequest := assigneeTransferRequest(heldID, "rival", "rival")
+	staleVersionRequest.ExpectedVersion = &staleVersion
+	if _, err := fixture.Operations.Update(ctx, staleVersionRequest); !errors.Is(err, publicops.ErrVersionMismatch) {
+		t.Fatalf("fenced transfer of %s with a stale version: err = %v, want ErrVersionMismatch", heldID, err)
+	}
+	staleStatus := types.StatusOpen
+	staleStatusRequest := assigneeTransferRequest(heldID, "rival", "rival")
+	staleStatusRequest.ExpectedStatus = &staleStatus
+	if _, err := fixture.Operations.Update(ctx, staleStatusRequest); !errors.Is(err, publicops.ErrStatusMismatch) {
+		t.Fatalf("fenced transfer of %s with a stale status: err = %v, want ErrStatusMismatch", heldID, err)
+	}
+	assertLiveAssignee(t, ctx, fixture, heldID, "holder")
+
+	// Restating the holder's own name is not a transfer, so a third party may
+	// do it unforced — and it changes nothing.
+	reassert, err := fixture.Operations.Update(ctx, assigneeTransferRequest(heldID, "bystander", "holder"))
+	if err != nil {
+		t.Fatalf("reassert %s's current assignee: %v", heldID, err)
+	}
+	if reassert.Changed {
+		t.Errorf("reasserting %s's current assignee reported Changed = true, want a no-op", heldID)
+	}
+
+	// An ExpectedAssignee compare-and-set naming the holder replaces the fence:
+	// the caller proved its view of the claim is current.
+	casRequest := assigneeTransferRequest(heldID, "rival", "rival")
+	holder := "holder"
+	casRequest.ExpectedAssignee = &holder
+	cas, err := fixture.Operations.Update(ctx, casRequest)
+	if err != nil {
+		t.Fatalf("compare-and-set transfer of %s: %v", heldID, err)
+	}
+	if !cas.Changed || cas.Issue.Assignee != "rival" {
+		t.Fatalf("compare-and-set transfer of %s = %#v, want a committed transfer to rival", heldID, cas.Issue)
+	}
+	assertLiveAssignee(t, ctx, fixture, heldID, "rival")
+
+	// ForceAssigneeTransfer is the unconditional override.
+	forcedRequest := assigneeTransferRequest(heldID, "usurper", "usurper")
+	forcedRequest.ForceAssigneeTransfer = true
+	forced, err := fixture.Operations.Update(ctx, forcedRequest)
+	if err != nil {
+		t.Fatalf("forced transfer of %s: %v", heldID, err)
+	}
+	if !forced.Changed || forced.Issue.Assignee != "usurper" {
+		t.Fatalf("forced transfer of %s = %#v, want a committed transfer to usurper", heldID, forced.Issue)
+	}
+	assertLiveAssignee(t, ctx, fixture, heldID, "usurper")
+
+	// A holder that is a configured claim.pools alias is a group placeholder,
+	// not an owner, so taking work from the pool needs no force.
+	if err := fixture.SetConfig(ctx, "claim.pools", "pool-crew"); err != nil {
+		t.Fatalf("SetConfig(claim.pools): %v", err)
+	}
+	pooledID := fixture.IssuePrefix + "-xferfence-pooled"
+	seedClosePolicyIssue(t, ctx, fixture, pooledID, publicops.CreateRequest{})
+	pooledRequest := assigneeTransferRequest(pooledID, "seed", "pool-crew")
+	pooledRequest.Claim = true
+	if _, err := fixture.Operations.Update(ctx, pooledRequest); err != nil {
+		t.Fatalf("assign %s to the pool: %v", pooledID, err)
+	}
+	assertLiveAssignee(t, ctx, fixture, pooledID, "pool-crew")
+	taken, err := fixture.Operations.Update(ctx, assigneeTransferRequest(pooledID, "member", "member"))
+	if err != nil {
+		t.Fatalf("unforced transfer of pooled %s: %v", pooledID, err)
+	}
+	if !taken.Changed || taken.Issue.Assignee != "member" {
+		t.Fatalf("unforced transfer of pooled %s = %#v, want a committed transfer to member", pooledID, taken.Issue)
+	}
+	assertLiveAssignee(t, ctx, fixture, pooledID, "member")
+
+	// The alias set is the only carve-out: a real holder is still fenced while
+	// pools are configured.
+	if _, err := fixture.Operations.Update(ctx, assigneeTransferRequest(pooledID, "rival", "rival")); !errors.Is(err, publicops.ErrAlreadyClaimed) {
+		t.Fatalf("unforced transfer of %s away from a non-pool holder: err = %v, want ErrAlreadyClaimed", pooledID, err)
+	}
+	assertLiveAssignee(t, ctx, fixture, pooledID, "member")
+}
+
+// assigneeTransferRequest builds the bare assignee edit whose fencing this case
+// pins: actor asks for the issue to be assigned to newAssignee.
+func assigneeTransferRequest(id, actor, newAssignee string) publicops.UpdateRequest {
+	return publicops.UpdateRequest{
+		Actor:   actor,
+		IssueID: id,
+		Patch:   publicops.IssuePatch{Assignee: publicops.Field[string]{Set: true, Value: newAssignee}},
+	}
+}
+
+// assertLiveAssignee checks the stored holder of an in-progress issue. Every
+// state this case asserts is a live claim — the fence only speaks over one — so
+// the expected status is fixed, and reading it back proves an assignee edit
+// leaves the claim's status alone.
+func assertLiveAssignee(t *testing.T, ctx context.Context, fixture IssueOperationsStagingFixture, id, wantAssignee string) {
+	t.Helper()
+	var assignee, status string
+	if err := fixture.QueryScalar(ctx, "SELECT assignee, status FROM issues WHERE id = ?", []any{id}, &assignee, &status); err != nil {
+		t.Fatalf("read assignee and status for %s: %v", id, err)
+	}
+	if assignee != wantAssignee {
+		t.Errorf("%s assignee = %q, want %q", id, assignee, wantAssignee)
+	}
+	if types.Status(status) != types.StatusInProgress {
+		t.Errorf("%s status = %q, want %q", id, status, types.StatusInProgress)
+	}
+}
+
 // closePolicyStatusRequest builds the generic status update that crosses into
 // the done category — the operation whose policy this case pins.
 func closePolicyStatusRequest(id string, force bool) publicops.UpdateRequest {

--- a/internal/storage/dolt/issue_operations_contract_test.go
+++ b/internal/storage/dolt/issue_operations_contract_test.go
@@ -31,6 +31,12 @@ func TestIssueOperationsUpdateClosePolicy(t *testing.T) {
 	conformance.RunIssueOperationsUpdateClosePolicy(t, ctx, fixture)
 }
 
+func TestIssueOperationsUpdateAssigneeTransferFence(t *testing.T) {
+	fixture, ctx, cleanup := newDoltIssueOperationsFixture(t)
+	defer cleanup()
+	conformance.RunIssueOperationsUpdateAssigneeTransferFence(t, ctx, fixture)
+}
+
 func newDoltIssueOperationsFixture(t *testing.T) (conformance.IssueOperationsStagingFixture, context.Context, func()) {
 	t.Helper()
 	store, storeCleanup := setupTestStore(t)

--- a/internal/storage/embeddeddolt/issue_operations_contract_test.go
+++ b/internal/storage/embeddeddolt/issue_operations_contract_test.go
@@ -38,6 +38,13 @@ func TestEmbeddedIssueOperationsUpdateClosePolicy(t *testing.T) {
 	conformance.RunIssueOperationsUpdateClosePolicy(t, ctx, newEmbeddedIssueOperationsFixture(t, ctx, te, "closepol"))
 }
 
+func TestEmbeddedIssueOperationsUpdateAssigneeTransferFence(t *testing.T) {
+	skipUnlessEmbeddedDolt(t)
+	te := newTestEnv(t, "xferfence")
+	ctx := t.Context()
+	conformance.RunIssueOperationsUpdateAssigneeTransferFence(t, ctx, newEmbeddedIssueOperationsFixture(t, ctx, te, "xferfence"))
+}
+
 func newEmbeddedIssueOperationsFixture(t *testing.T, ctx context.Context, te *testEnv, prefix string) conformance.IssueOperationsStagingFixture {
 	t.Helper()
 	operations, err := embeddeddolt.NewIssueOperations(te.store)

--- a/internal/storage/issueops/aggregate.go
+++ b/internal/storage/issueops/aggregate.go
@@ -138,14 +138,19 @@ func ValidateScalarUpdates(ctx context.Context, tx DBTX, updates map[string]inte
 	return nil
 }
 
-// AuthorizeAssigneeTransfer protects an active assignment from unguarded transfer.
-func AuthorizeAssigneeTransfer(ctx context.Context, tx DBTX, before *types.Issue, request publicops.UpdateRequest) error {
+// AuthorizeAssigneeTransferWithPools is the assignee-transfer fence itself,
+// with the pool aliases supplied rather than read. It is the single source of
+// the predicate: the DBTX path below and the unit-of-work backend, which
+// reaches config through a use case rather than a transaction, both evaluate
+// it, so the two cannot drift into disagreeing about which transfers are
+// fenced.
+//
+// Passing nil pools answers every question except pool membership, so a caller
+// that wants the config read only when it matters calls with nil first and
+// re-evaluates with the loaded aliases on refusal.
+func AuthorizeAssigneeTransferWithPools(before *types.Issue, request publicops.UpdateRequest, pools []string) error {
 	if !request.Patch.Assignee.Set || request.Patch.Assignee.Value == before.Assignee || request.ExpectedAssignee != nil || request.ForceAssigneeTransfer || before.Status != types.StatusInProgress || before.Assignee == "" || before.Assignee == request.Actor {
 		return nil
-	}
-	pools, err := ClaimPoolAliasesInTx(ctx, tx)
-	if err != nil {
-		return err
 	}
 	for _, pool := range pools {
 		if pool == before.Assignee {
@@ -153,6 +158,18 @@ func AuthorizeAssigneeTransfer(ctx context.Context, tx DBTX, before *types.Issue
 		}
 	}
 	return fmt.Errorf("%w: issue %s is assigned to %q", storage.ErrAlreadyClaimed, before.ID, before.Assignee)
+}
+
+// AuthorizeAssigneeTransfer protects an active assignment from unguarded transfer.
+func AuthorizeAssigneeTransfer(ctx context.Context, tx DBTX, before *types.Issue, request publicops.UpdateRequest) error {
+	if err := AuthorizeAssigneeTransferWithPools(before, request, nil); err == nil {
+		return nil
+	}
+	pools, err := ClaimPoolAliasesInTx(ctx, tx)
+	if err != nil {
+		return err
+	}
+	return AuthorizeAssigneeTransferWithPools(before, request, pools)
 }
 
 // ApplyMetadataPatch returns the canonical metadata value and whether it changes.

--- a/internal/storage/issueops/aggregate_authorize_transfer_test.go
+++ b/internal/storage/issueops/aggregate_authorize_transfer_test.go
@@ -1,0 +1,121 @@
+package issueops
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/storage"
+	"github.com/steveyegge/beads/internal/types"
+	publicops "github.com/steveyegge/beads/issueops"
+)
+
+// TestAuthorizeAssigneeTransferWithPools pins every branch of the fence
+// predicate. Both backends that enforce the fence evaluate this one function,
+// so its branch semantics are the whole policy — the DBTX wrapper adds only
+// the config read.
+func TestAuthorizeAssigneeTransferWithPools(t *testing.T) {
+	held := func() *types.Issue {
+		return &types.Issue{ID: "bd-1", Status: types.StatusInProgress, Assignee: "holder"}
+	}
+	transfer := func(mutate func(*publicops.UpdateRequest)) publicops.UpdateRequest {
+		request := publicops.UpdateRequest{
+			Actor:   "rival",
+			IssueID: "bd-1",
+			Patch:   publicops.IssuePatch{Assignee: publicops.Field[string]{Set: true, Value: "rival"}},
+		}
+		if mutate != nil {
+			mutate(&request)
+		}
+		return request
+	}
+	holder := "holder"
+
+	cases := []struct {
+		name    string
+		before  *types.Issue
+		request publicops.UpdateRequest
+		pools   []string
+		refuse  bool
+	}{
+		{
+			name:    "unset assignee patch",
+			before:  held(),
+			request: transfer(func(r *publicops.UpdateRequest) { r.Patch.Assignee = publicops.Field[string]{} }),
+		},
+		{
+			name:    "reasserts the current assignee",
+			before:  held(),
+			request: transfer(func(r *publicops.UpdateRequest) { r.Patch.Assignee.Value = "holder" }),
+		},
+		{
+			name:    "expected assignee compare-and-set",
+			before:  held(),
+			request: transfer(func(r *publicops.UpdateRequest) { r.ExpectedAssignee = &holder }),
+		},
+		{
+			name:    "forced transfer",
+			before:  held(),
+			request: transfer(func(r *publicops.UpdateRequest) { r.ForceAssigneeTransfer = true }),
+		},
+		{
+			name:    "holder is not in progress",
+			before:  &types.Issue{ID: "bd-1", Status: types.StatusOpen, Assignee: "holder"},
+			request: transfer(nil),
+		},
+		{
+			name:    "unassigned",
+			before:  &types.Issue{ID: "bd-1", Status: types.StatusInProgress},
+			request: transfer(nil),
+		},
+		{
+			name:    "actor already holds it",
+			before:  held(),
+			request: transfer(func(r *publicops.UpdateRequest) { r.Actor = "holder" }),
+		},
+		{
+			name:    "holder is a configured pool alias",
+			before:  &types.Issue{ID: "bd-1", Status: types.StatusInProgress, Assignee: "crew"},
+			request: transfer(nil),
+			pools:   []string{"other", "crew"},
+		},
+		{
+			name:    "unassigning a foreign live holder",
+			before:  held(),
+			request: transfer(func(r *publicops.UpdateRequest) { r.Patch.Assignee.Value = "" }),
+			refuse:  true,
+		},
+		{
+			name:    "foreign live holder with no pools",
+			before:  held(),
+			request: transfer(nil),
+			refuse:  true,
+		},
+		{
+			name:    "foreign live holder outside the pools",
+			before:  held(),
+			request: transfer(nil),
+			pools:   []string{"crew"},
+			refuse:  true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := AuthorizeAssigneeTransferWithPools(tc.before, tc.request, tc.pools)
+			if !tc.refuse {
+				if err != nil {
+					t.Fatalf("AuthorizeAssigneeTransferWithPools = %v, want nil", err)
+				}
+				return
+			}
+			if !errors.Is(err, storage.ErrAlreadyClaimed) {
+				t.Fatalf("AuthorizeAssigneeTransferWithPools = %v, want ErrAlreadyClaimed", err)
+			}
+			// The refusal names the holder so a caller can report who has it.
+			if !strings.Contains(err.Error(), tc.before.Assignee) || !strings.Contains(err.Error(), tc.before.ID) {
+				t.Errorf("refusal %q omits issue %s or holder %q", err, tc.before.ID, tc.before.Assignee)
+			}
+		})
+	}
+}

--- a/internal/storage/uow/issue_operations.go
+++ b/internal/storage/uow/issue_operations.go
@@ -209,6 +209,18 @@ func (o *issueOperations) Update(ctx context.Context, request publicops.UpdateRe
 		if err != nil {
 			return publicops.UpdateResult{}, "", err
 		}
+		// The assignee fence belongs here, over the same-transaction row the
+		// update is about to mutate, and not in ApplyUpdate: callers build their
+		// own UpdateSpec, which carries no override, so a fence down there
+		// silently ignores a caller's --force. A stale compare-and-set
+		// precondition outranks the fence on the other backends, which check
+		// version and status before authorizing, so when one is stale the fence
+		// stands down and ApplyUpdate reports the mismatch instead.
+		if updatePreconditionsHold(attempt, before) {
+			if err := authorizeAssigneeTransfer(ctx, uw, before, attempt); err != nil {
+				return publicops.UpdateResult{}, "", err
+			}
+		}
 		claimChanged := attempt.Claim && (before.Status != types.StatusInProgress || before.Assignee != attempt.Actor)
 		updated, err := uw.IssueUseCase().ApplyUpdate(ctx, attempt.IssueID, spec, attempt.Actor)
 		if err != nil {
@@ -220,6 +232,41 @@ func (o *issueOperations) Update(ctx context.Context, request publicops.UpdateRe
 		}
 		return publicops.UpdateResult{Issue: issue, Changed: claimChanged || !semanticIssueEqual(before, issue)}, "update issue", nil
 	})
+}
+
+// updatePreconditionsHold reports whether request's compare-and-set
+// preconditions match before — that is, whether ApplyUpdate would get past its
+// own guards, leaving the assignee fence as the operative refusal.
+// ExpectedAssignee needs no entry here: the fence already stands down whenever
+// a caller supplies one.
+func updatePreconditionsHold(request publicops.UpdateRequest, before *types.Issue) bool {
+	if request.ExpectedVersion != nil && *request.ExpectedVersion != before.RowVersion {
+		return false
+	}
+	if request.ExpectedStatus != nil && *request.ExpectedStatus != before.Status {
+		return false
+	}
+	return true
+}
+
+// authorizeAssigneeTransfer applies the shared assignee-transfer fence to an
+// update running in this unit of work. It is the sibling of the
+// issueops.AuthorizeAssigneeTransfer call in ExecuteUpdate — the same predicate
+// and the same refusal — reached through the config use case because a unit of
+// work has no transaction handle to read claim.pools from. The read only
+// happens once the transfer is otherwise fenced, and its failure propagates
+// rather than being read as "no pools configured": treating an unreadable
+// config as an empty alias set would refuse pool work the fence was never meant
+// to touch.
+func authorizeAssigneeTransfer(ctx context.Context, uw UnitOfWork, before *types.Issue, request publicops.UpdateRequest) error {
+	if err := storageissueops.AuthorizeAssigneeTransferWithPools(before, request, nil); err == nil {
+		return nil
+	}
+	raw, err := uw.ConfigUseCase().GetConfig(ctx, "claim.pools")
+	if err != nil {
+		return fmt.Errorf("authorize assignee transfer %s: read claim pools: %w", request.IssueID, err)
+	}
+	return storageissueops.AuthorizeAssigneeTransferWithPools(before, request, storageissueops.ParseClaimPools(raw))
 }
 
 func updateSpec(request publicops.UpdateRequest) (domain.UpdateSpec, error) {

--- a/internal/storage/uow/issue_operations_contract_test.go
+++ b/internal/storage/uow/issue_operations_contract_test.go
@@ -31,6 +31,11 @@ func TestIssueOperationsUpdateClosePolicy(t *testing.T) {
 	conformance.RunIssueOperationsUpdateClosePolicy(t, ctx, newUOWIssueOperationsFixture(t, ctx))
 }
 
+func TestIssueOperationsUpdateAssigneeTransferFence(t *testing.T) {
+	ctx := context.Background()
+	conformance.RunIssueOperationsUpdateAssigneeTransferFence(t, ctx, newUOWIssueOperationsFixture(t, ctx))
+}
+
 func newUOWIssueOperationsFixture(t *testing.T, ctx context.Context) conformance.IssueOperationsStagingFixture {
 	t.Helper()
 	operations, provider := newRealIssueOperationsWithProvider(t, ctx)


### PR DESCRIPTION
## What

The unit-of-work `issueops.Lifecycle` backend enforces the foreign-assignee transfer fence again, and the cross-backend conformance contract grows the assignee-transfer case it never had.

## Why

`internal/storage/uow/issue_operations.go` implements `issueops.Lifecycle` by delegating to `domain.ApplyUpdate`, and relied on a fence that lived there. That fence was removed in `11382270b` — correctly — because it was mis-layered: it read a domain `UpdateSpec` field the proxied caller never populated, so `bd update --force` was silently refused on that path.

The consequence was a backend divergence. dolt and embeddeddolt refuse an unforced foreign transfer via `issueops.AuthorizeAssigneeTransfer` (`aggregate.go:142`, reached from `execution.go:133`); the uow backend permitted it.

Bounding the urgency honestly: this is **not** a regression from `main` — the uow `Lifecycle` backend does not exist there — and it has **no production caller today**, because `cmd/bd` reaches the uow provider only through `uw.IssueUseCase()`, never `provider.IssueLifecycle()`. It becomes live when the proxied path is rewired onto the facade.

**The missing conformance case is the real point of this PR.** The contract had no assignee-transfer case at all, which is exactly how one backend came to permit what the other two refuse. Fixing the fence without closing that gap would leave the mechanism that produced the bug intact.

## How

The fence goes in `uow.issueOperations.Update` — the facade layer, alongside its `ExecuteUpdate` sibling — **not** back into `domain.ApplyUpdate`. Callers build their own `UpdateSpec`, which carries no override, so a fence down there silently ignores `--force`. That is the same mis-layering that caused the original removal; putting it back there would repeat the incident verbatim.

To keep the two backends from drifting into disagreeing about *which* transfers are fenced, the predicate is extracted rather than copied: `AuthorizeAssigneeTransferWithPools(before, request, pools)` is now the single source of truth, pure and pools-injected. The DBTX path reads `claim.pools` from the transaction; the uow path reads it through the config use case, because a unit of work has no transaction handle. Both evaluate the same function.

Two details worth a reviewer's attention:

- **Precondition ordering.** `updatePreconditionsHold` stands the fence down when a stale `ExpectedVersion`/`ExpectedStatus` is present, so a request failing both reports the precondition — matching the other backends, which check version and status before authorizing.
- **The config read fails closed.** An unreadable `claim.pools` propagates rather than being read as "no pools configured". Treating it as an empty alias set would refuse pool work the fence was never meant to touch.

The pools read only happens once a transfer is otherwise fenced, so the common path costs nothing.

## Verification

```
gofmt -l internal cmd . | grep -v vendor                                    # empty
go vet ./internal/storage/...                                               # clean
go test -v -count=1 ./internal/storage/uow/                                 # 136 PASS, 0 FAIL  (baseline 135)
go test -v -count=1 ./internal/storage/issueops/                            # 350 PASS, 0 FAIL  (baseline 338)
go test -v -count=1 -run TestIssueOperations ./internal/storage/dolt/       #  74 PASS, 0 FAIL  (baseline  73)
BEADS_TEST_EMBEDDED_DOLT=1 CGO_ENABLED=1 \
  go test -v -count=1 -run TestEmbeddedIssueOperationsUpdateAssigneeTransferFence ./internal/storage/embeddeddolt/   # PASS
```

Every delta above is the new test count, not a changed outcome.

The new case is registered and **runs** (not SKIPs) on all three backends — `dolt/issue_operations_contract_test.go:34`, `uow/issue_operations_contract_test.go:34`, `embeddeddolt/issue_operations_contract_test.go:41`.

**Mutation-checked, and it discriminates between backends.** Removing the fence call from `uow.issueOperations.Update` makes the uow conformance case fail with `unforced transfer of bd-xferfence-held away from its holder: err = <nil>, want ErrAlreadyClaimed`, while the dolt case still passes — which is precisely the divergence this contract exists to catch. Restoring left `git diff` empty.

`RunIssueOperationsUpdateAssigneeTransferFence` pins the refusal, that the refusal writes nothing (no row change, no event), stale-precondition ordering, self-reassert as a no-op, `ExpectedAssignee` compare-and-set, `ForceAssigneeTransfer`, the `claim.pools` alias carve-out, and that a real holder is still fenced while pools are configured.

## Follow-up

Filed rather than folded in: the new case seeds only the `issues` table, so wisp foreign-assignee transfers remain uncovered by any cross-backend test. A wisp-specific fast path added on one backend would reopen this exact divergence class on the other table.
