### PR TITLE
fix(config): apply BEADS_TEST_IGNORE_REPO_CONFIG to the BEADS_DIR source

### DIFF
--- a/cmd/bd/config_isolation_regression_test.go
+++ b/cmd/bd/config_isolation_regression_test.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/config"
+)
+
+// leakFixturePrefix is the issue-prefix written into the fixture workspace below.
+// It is deliberately not a plausible real prefix, so a failure message naming it
+// is unambiguous evidence that the fixture config was imported.
+const leakFixturePrefix = "zzleak"
+
+// newLeakFixtureRepo builds a self-contained fake module root holding a .beads
+// workspace whose config.yaml sets leakFixturePrefix, chdirs into it, and returns
+// the .beads path.
+//
+// It must not depend on the real beads checkout: that checkout's .beads/config.yaml
+// is untracked developer state (it happens to carry `issue-prefix: bd` on the machine
+// where ga-e6h6i was found), so a test reading it would behave differently on CI and
+// on a developer box.
+func newLeakFixtureRepo(t *testing.T) string {
+	t.Helper()
+
+	root := t.TempDir()
+	beadsDir := filepath.Join(root, ".beads")
+	if err := os.MkdirAll(beadsDir, 0o700); err != nil {
+		t.Fatalf("create .beads: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "go.mod"), []byte("module example.com/leakfixture\n\ngo 1.24.0\n"), 0o600); err != nil {
+		t.Fatalf("write go.mod: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(beadsDir, "config.yaml"), []byte("issue-prefix: "+leakFixturePrefix+"\n"), 0o600); err != nil {
+		t.Fatalf("write config.yaml: %v", err)
+	}
+	t.Chdir(root)
+
+	return beadsDir
+}
+
+// ga-e6h6i: a prior test in this binary that dispatches a real CLI command leaves
+// BEADS_DIR pointing at a checkout's .beads via a raw os.Setenv with no restore
+// (prepareSelectedCommandContext). initConfigForTest pins that leaked value, so its
+// config.Initialize used to re-import the repo config — including issue-prefix, which
+// surfaced as "prefix mismatch: database uses bd-" in an unrelated --id test.
+//
+// The raw os.Setenv here is deliberate: t.Setenv would restore the value on cleanup
+// and therefore would not reproduce the unrestored leak this test exists to catch.
+func TestInitConfigForTestNeutralizesLeakedRepoBeadsDir(t *testing.T) {
+	beadsDir := newLeakFixtureRepo(t)
+
+	prev, had := os.LookupEnv("BEADS_DIR")
+	if err := os.Setenv("BEADS_DIR", beadsDir); err != nil {
+		t.Fatalf("setenv BEADS_DIR: %v", err)
+	}
+	t.Cleanup(func() {
+		if had {
+			_ = os.Setenv("BEADS_DIR", prev)
+			return
+		}
+		_ = os.Unsetenv("BEADS_DIR")
+	})
+
+	initConfigForTest(t)
+
+	if got := config.GetString("issue-prefix"); got != "" {
+		t.Fatalf("config.GetString(issue-prefix) = %q after initConfigForTest, want empty: "+
+			"a leaked BEADS_DIR still imports the repo config", got)
+	}
+}
+
+// The other half of ga-e6h6i: running real command dispatch must not leave the
+// package-global viper holding the dispatched workspace's issue-prefix for every
+// later test that does not call initConfigForTest.
+func TestDispatchDoesNotPolluteViperIssuePrefix(t *testing.T) {
+	ensureCleanGlobalState(t)
+	t.Setenv("BEADS_TEST_IGNORE_REPO_CONFIG", "1")
+
+	beadsDir := newLeakFixtureRepo(t)
+	// Dispatch only selects a workspace that FindBeadsDir accepts.
+	if err := os.WriteFile(filepath.Join(beadsDir, "metadata.json"), []byte(`{"database":"beads","backend":"dolt"}`+"\n"), 0o600); err != nil {
+		t.Fatalf("write metadata.json: %v", err)
+	}
+
+	config.ResetForTesting()
+	t.Cleanup(config.ResetForTesting)
+	t.Cleanup(resetCommandContext)
+
+	// --version is a skipsStoreInit command: it reaches dispatch (and its BEADS_DIR
+	// side effect) without needing a live store.
+	runVersionDispatch(t)
+
+	if got := config.GetString("issue-prefix"); got != "" {
+		t.Fatalf("config.GetString(issue-prefix) = %q after command dispatch, want empty: "+
+			"dispatch leaked the workspace config into the global viper", got)
+	}
+}
+
+// runVersionDispatch executes `bd --version` through the shared root command with
+// stdout discarded. Cobra's command tree and os.Stdout are process-global, so this
+// holds stdioMutex per the policy documented on that mutex.
+func runVersionDispatch(t *testing.T) {
+	t.Helper()
+
+	stdioMutex.Lock()
+	defer stdioMutex.Unlock()
+
+	devNull, err := os.OpenFile(os.DevNull, os.O_WRONLY, 0)
+	if err != nil {
+		t.Fatalf("open %s: %v", os.DevNull, err)
+	}
+	defer func() { _ = devNull.Close() }()
+
+	oldStdout := os.Stdout
+	os.Stdout = devNull
+	defer func() { os.Stdout = oldStdout }()
+
+	rootCmd.SetArgs([]string{"--version"})
+	defer rootCmd.SetArgs(nil)
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("rootCmd.Execute(--version): %v", err)
+	}
+}

--- a/cmd/bd/test_helpers_pure_test.go
+++ b/cmd/bd/test_helpers_pure_test.go
@@ -90,10 +90,12 @@ func generateUniqueTestID(t *testing.T, prefix string, index int) string {
 // BEADS_TEST_IGNORE_REPO_CONFIG; tests that want the repo config must override
 // before calling this helper.
 //
-// BEADS_DIR bypasses BEADS_TEST_IGNORE_REPO_CONFIG entirely (config.Initialize
-// treats it as the highest-priority source), so pin it via t.Setenv here too:
-// otherwise a test earlier in the binary that resolves a real BEADS_DIR via
-// raw os.Setenv (e.g. running actual CLI command dispatch) leaks it forward.
+// BEADS_DIR is pinned via t.Setenv here so that a test earlier in the binary which
+// resolved a real BEADS_DIR via raw os.Setenv (e.g. running actual CLI command
+// dispatch) doesn't leak it forward past this test. config.Initialize honors
+// BEADS_TEST_IGNORE_REPO_CONFIG on the BEADS_DIR source too, so such a leaked value
+// can no longer re-import the repo's own config (ga-e6h6i); tests that want the repo
+// config must unset the flag before calling this helper.
 func initConfigForTest(t *testing.T) {
 	t.Helper()
 	t.Setenv("BEADS_DIR", os.Getenv("BEADS_DIR"))

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -81,17 +81,27 @@ func Initialize() error {
 	if beadsDirEnv != "" {
 		beadsEnvConfigPath = filepath.Clean(filepath.Join(beadsDirEnv, "config.yaml"))
 	}
+	// A beads checkout usually has its own `.beads/config.yaml` (untracked developer
+	// state) that sets non-default values. In `go test` — especially for `cmd/bd` —
+	// we want to avoid unintentionally picking up that repo-local config, while still
+	// allowing tests to load config.yaml from temp repos.
+	//
+	// If BEADS_TEST_IGNORE_REPO_CONFIG is set, we ignore the config at
+	// <module-root>/.beads/config.yaml (where module-root is the nearest parent
+	// containing go.mod) and at the worktree fallback location.
+	//
+	// The ignore set applies to every source that can name those paths, including
+	// BEADS_DIR below. BEADS_DIR used to bypass the flag, and because in-process CLI
+	// dispatch sets BEADS_DIR at the checkout's own .beads via a raw os.Setenv with no
+	// restore, that bypass re-imported the repo config into every later Initialize in
+	// the same test binary (ga-e6h6i). A test that genuinely wants the repo config
+	// unsets the flag.
+	ignoreRepoConfig := os.Getenv("BEADS_TEST_IGNORE_REPO_CONFIG") != ""
+	ignoredRepoConfigPaths := map[string]bool{}
+
 	cwd, err := os.Getwd()
 	if err == nil {
-		// In the beads repo, `.beads/config.yaml` is tracked and may set non-default config values.
-		// In `go test` (especially for `cmd/bd`), we want to avoid unintentionally picking up
-		// the repo-local config, while still allowing tests to load config.yaml from temp repos.
-		//
-		// If BEADS_TEST_IGNORE_REPO_CONFIG is set, we will ignore the config at
-		// <module-root>/.beads/config.yaml (where module-root is the nearest parent containing go.mod).
-		ignoreRepoConfig := os.Getenv("BEADS_TEST_IGNORE_REPO_CONFIG") != ""
 		var moduleRoot string
-		ignoredRepoConfigPaths := map[string]bool{}
 		if ignoreRepoConfig {
 			// Find module root by walking up to go.mod.
 			for dir := cwd; dir != filepath.Dir(dir); dir = filepath.Dir(dir) {
@@ -157,7 +167,13 @@ func Initialize() error {
 	// 0. BEADS_DIR: highest priority
 	if beadsDir := os.Getenv("BEADS_DIR"); beadsDir != "" {
 		p := filepath.Join(beadsDir, "config.yaml")
-		if _, err := os.Stat(p); err == nil {
+		// Honor the test ignore set here too, and skip primaryConfigPath along with
+		// the merge so ConfigFileUsed does not name the ignored repo config. This
+		// fences the read and merge path only: SaveConfigValue falls back to the
+		// caller-supplied beadsDir when ConfigFileUsed is empty, so where a write
+		// lands is still the caller's choice, not this flag's.
+		ignored := ignoreRepoConfig && ignoredRepoConfigPaths[filepath.Clean(p)]
+		if _, err := os.Stat(p); err == nil && !ignored {
 			// Avoid duplicate if BEADS_DIR points to same config as CWD walk
 			if primaryConfigPath == "" || filepath.Clean(p) != filepath.Clean(primaryConfigPath) {
 				configPaths = append(configPaths, p)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1855,3 +1855,147 @@ func TestViperIssuePrefixKeysAreDistinct(t *testing.T) {
 		t.Fatalf("GetString(issue_prefix) = %q, want %q", got, "legacy_underscore")
 	}
 }
+
+// newIgnoredRepoConfigFixture builds a fake module root (go.mod + .beads/config.yaml)
+// with HOME/XDG redirected into the same temp tree, so Initialize sees exactly one
+// candidate project config. It returns the .beads directory.
+//
+// The fixture must be self-contained: the real beads checkout carries an untracked
+// .beads/config.yaml with `issue-prefix: bd`, and a test that depended on it would
+// pass or fail based on the developer's machine.
+func newIgnoredRepoConfigFixture(t *testing.T, body string) string {
+	t.Helper()
+
+	tmpDir := t.TempDir()
+	homeDir := filepath.Join(tmpDir, "home")
+	configDir := filepath.Join(tmpDir, "xdg-config")
+	repoDir := filepath.Join(tmpDir, "repo")
+	beadsDir := filepath.Join(repoDir, ".beads")
+
+	for _, dir := range []string{homeDir, configDir, beadsDir} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("failed to create %s: %v", dir, err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(repoDir, "go.mod"), []byte("module example.com/test\n\ngo 1.24.0\n"), 0o644); err != nil {
+		t.Fatalf("failed to write go.mod: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(beadsDir, "config.yaml"), []byte(body), 0o644); err != nil {
+		t.Fatalf("failed to write config.yaml: %v", err)
+	}
+
+	t.Setenv("HOME", homeDir)
+	t.Setenv("XDG_CONFIG_HOME", configDir)
+	t.Chdir(repoDir)
+
+	return beadsDir
+}
+
+// BEADS_DIR is the highest-priority config source, and it used to bypass
+// BEADS_TEST_IGNORE_REPO_CONFIG entirely. That was the leak behind ga-e6h6i:
+// in-process CLI dispatch raw-os.Setenv's BEADS_DIR at the checkout's own .beads
+// and never restores it, so every later Initialize re-imported the repo config —
+// including `issue-prefix: bd`, which broke unrelated --id tests.
+func TestInitialize_IgnoreRepoConfigAppliesToBeadsDirEnv(t *testing.T) {
+	restore := envSnapshot(t)
+	defer restore()
+
+	beadsDir := newIgnoredRepoConfigFixture(t, "json: true\nactor: repo-user\nissue-prefix: zzleak\n")
+
+	t.Setenv("BEADS_TEST_IGNORE_REPO_CONFIG", "1")
+	t.Setenv("BEADS_DIR", beadsDir)
+
+	ResetForTesting()
+	defer ResetForTesting()
+
+	if err := Initialize(); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+
+	if got := GetBool("json"); got {
+		t.Errorf("GetBool(json) = %v, want false when repo config is ignored via BEADS_DIR", got)
+	}
+	if got := GetString("actor"); got != "" {
+		t.Errorf("GetString(actor) = %q, want empty when repo config is ignored via BEADS_DIR", got)
+	}
+	if got := GetString("issue-prefix"); got != "" {
+		t.Errorf("GetString(issue-prefix) = %q, want empty when repo config is ignored via BEADS_DIR", got)
+	}
+	// primaryConfigPath must be suppressed too: otherwise SaveConfigValue would
+	// still write into the repo config the flag exists to protect.
+	if got := ConfigFileUsed(); got != "" {
+		t.Errorf("ConfigFileUsed() = %q, want empty when repo config is ignored via BEADS_DIR", got)
+	}
+}
+
+// Guard against over-ignoring: without the flag, BEADS_DIR must still load the
+// module-root config exactly as before.
+func TestInitialize_BeadsDirEnvLoadsRepoConfigWithoutFlag(t *testing.T) {
+	restore := envSnapshot(t)
+	defer restore()
+
+	beadsDir := newIgnoredRepoConfigFixture(t, "json: true\nactor: repo-user\nissue-prefix: zzleak\n")
+
+	t.Setenv("BEADS_DIR", beadsDir)
+
+	ResetForTesting()
+	defer ResetForTesting()
+
+	if err := Initialize(); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+
+	if got := GetBool("json"); !got {
+		t.Errorf("GetBool(json) = %v, want true when the flag is unset", got)
+	}
+	if got := GetString("actor"); got != "repo-user" {
+		t.Errorf("GetString(actor) = %q, want %q when the flag is unset", got, "repo-user")
+	}
+	if got := GetString("issue-prefix"); got != "zzleak" {
+		t.Errorf("GetString(issue-prefix) = %q, want %q when the flag is unset", got, "zzleak")
+	}
+}
+
+// The ignore set is scoped to the repo under test. Tests that point BEADS_DIR at
+// their own temp workspace (setupServerDriftTest, config-apply, backup-status,
+// auto-export) must keep loading it even with the flag set.
+func TestInitialize_IgnoreRepoConfigStillHonorsTempBeadsDir(t *testing.T) {
+	restore := envSnapshot(t)
+	defer restore()
+
+	// Establish the ignored module root, then point BEADS_DIR somewhere else.
+	newIgnoredRepoConfigFixture(t, "json: true\nactor: repo-user\n")
+
+	workspace := filepath.Join(t.TempDir(), ".beads")
+	if err := os.MkdirAll(workspace, 0o755); err != nil {
+		t.Fatalf("failed to create workspace: %v", err)
+	}
+	workspaceConfig := filepath.Join(workspace, "config.yaml")
+	if err := os.WriteFile(workspaceConfig, []byte("actor: workspace-user\nissue-prefix: wksp\n"), 0o644); err != nil {
+		t.Fatalf("failed to write workspace config.yaml: %v", err)
+	}
+
+	t.Setenv("BEADS_TEST_IGNORE_REPO_CONFIG", "1")
+	t.Setenv("BEADS_DIR", workspace)
+
+	ResetForTesting()
+	defer ResetForTesting()
+
+	if err := Initialize(); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+
+	if got := GetString("actor"); got != "workspace-user" {
+		t.Errorf("GetString(actor) = %q, want %q from the temp BEADS_DIR workspace", got, "workspace-user")
+	}
+	if got := GetString("issue-prefix"); got != "wksp" {
+		t.Errorf("GetString(issue-prefix) = %q, want %q from the temp BEADS_DIR workspace", got, "wksp")
+	}
+	if got := ConfigFileUsed(); filepath.Clean(got) != filepath.Clean(workspaceConfig) {
+		t.Errorf("ConfigFileUsed() = %q, want %q", got, workspaceConfig)
+	}
+	// The ignored repo config must not have merged underneath.
+	if got := GetBool("json"); got {
+		t.Errorf("GetBool(json) = %v, want false — the ignored repo config leaked underneath", got)
+	}
+}


### PR DESCRIPTION
## What

`BEADS_DIR` — the highest-priority config source — now consults the `BEADS_TEST_IGNORE_REPO_CONFIG` ignore set like every other source does.

## Why

Running the `cmd/bd` package as a whole leaked `issue-prefix='bd'` between tests, surviving `initConfigForTest`. It surfaced as `prefix mismatch: database uses bd-` in an unrelated `--id` test during the write-verb parity work; that suite pinned its own config as a workaround, and the underlying leak stayed.

`BEADS_DIR` was the one source that bypassed the ignore flag. In-process CLI dispatch (`prepareSelectedCommandContext`) sets `BEADS_DIR` at the checkout's own `.beads` via a raw `os.Setenv` with no restore, and then re-runs `config.Initialize`. So once *any* test in a binary dispatched a command, every later `Initialize` re-imported the repo's own `config.yaml` through that bypass.

**The original report described the mechanism the other way round, and it is worth correcting in the record:** nothing is cached and nothing survives a reset. `config.ResetForTesting` nils the package viper and `Initialize` builds a fresh one. The value is not stale state — it is re-read from disk on every `Initialize`, because the leaked environment variable still points at the repo. `initConfigForTest` pins the currently-leaked `BEADS_DIR`, which is why the value appeared to "survive" it. That distinction matters: a fix aimed at cache invalidation would not have worked.

## Scope and blast radius

Production behavior is unchanged — the flag is only ever set by tests and by `scripts/ci/lib/test-env.sh`.

Callers that point `BEADS_DIR` at their own temp workspace (`setupServerDriftTest` and friends) keep loading it, because the ignore set only ever contains the module-root and worktree-fallback paths. That is pinned by `TestInitialize_IgnoreRepoConfigStillHonorsTempBeadsDir` rather than left to inspection, since over-ignoring temp workspaces is the obvious way this change could go wrong.

`primaryConfigPath` is skipped alongside the merge so `ConfigFileUsed` does not name the ignored repo config. To be precise about what that does and does not buy: it fences the **read and merge** path only. `SaveConfigValue` falls back to the caller-supplied `beadsDir` when `ConfigFileUsed` is empty, so where a write lands remains the caller's choice, not this flag's. The comment says exactly that rather than claiming a write-path fence this change does not provide.

## Verification

```
gofmt -l internal cmd . | grep -v vendor                     # empty
go vet ./internal/config/ ./cmd/bd/                          # clean
go test -v -count=1 ./internal/config/                       # 297 PASS, 0 FAIL
go test -v -count=1 -run 'TestApply|TestRunApply|TestRemote' ./cmd/bd/    # 94 PASS, 0 FAIL
go test -v -count=1 \
  -run 'TestInitConfigForTestNeutralizesLeakedRepoBeadsDir|TestDispatchDoesNotPolluteViperIssuePrefix' ./cmd/bd/   # 2 PASS
```

The `cmd/bd` run above is the caller-table evidence: `TestApply*` / `TestRunApply*` / `TestRemote*` are the real names of the `setupServerDriftTest` callers — the tests that would break if the ignore set over-ignored a temp `BEADS_DIR` workspace.

**Mutation-checked.** Forcing `ignored` to `false` (kept compiling, so this is a behavioral mutant and not a build break) fails all three new tests — `TestInitConfigForTestNeutralizesLeakedRepoBeadsDir`, `TestDispatchDoesNotPolluteViperIssuePrefix`, and `TestInitialize_IgnoreRepoConfigAppliesToBeadsDirEnv`. Restoring left `git diff` empty.

`TestDispatchDoesNotPolluteViperIssuePrefix` reproduces the actual reported failure path — dispatch a command in-process, then assert a later `Initialize` does not carry the repo's `issue-prefix` — so the regression is pinned at the mechanism, not at a symptom.
