### PR TITLE
fix(config,test): the two remaining macOS-only failures keeping main red

### DIFF
--- a/cmd/bd/uow_factory_server_mode_test.go
+++ b/cmd/bd/uow_factory_server_mode_test.go
@@ -18,6 +18,36 @@ import (
 	"github.com/steveyegge/beads/internal/storage/dbproxy/proxy"
 )
 
+// sunPathLimit is the shortest sockaddr_un.sun_path any runner here imposes:
+// Linux allows 108 bytes including the NUL, macOS 104. Tests bind against the
+// smaller number so a path that works locally works on every runner.
+const sunPathLimit = 104
+
+// shortTempDir returns a temp directory whose name does not carry the test's
+// name, for paths that live under a hard length limit.
+//
+// t.TempDir() spends its budget on the test name, and on macOS $TMPDIR is
+// already ~48 bytes of /var/folders/<hash>/T before anything else, so a
+// descriptive test name alone can push a socket path past sun_path and turn
+// bind(2) into a bare "invalid argument". That is exactly how
+// TestResolveServerModeUOWTopology_KeepsALiveSocket failed on macOS and only
+// macOS, at 120 bytes (Main run 30686406361).
+func shortTempDir(t *testing.T) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("", "bd")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	return dir
+}
+
+// Pin the property that matters: reverting shortTempDir to t.TempDir() would
+// reintroduce the macOS failure, and no Linux runner would notice.
+func TestShortTempDirOmitsTheTestName(t *testing.T) {
+	dir := shortTempDir(t)
+	require.NotContains(t, dir, t.Name(),
+		"shortTempDir must not spend sun_path budget on the test name")
+}
+
 // serverModeBeadsDir writes a server-mode metadata.json into a fresh beads dir
 // and returns it. Nothing here starts a server: every assertion below is about
 // the topology resolution, which happens before anything is dialed.
@@ -139,7 +169,13 @@ func TestResolveServerModeUOWTopology_FallsBackToTCPWhenTheSocketIsDead(t *testi
 // TCP. Without this the previous test could be satisfied by deleting socket
 // support outright.
 func TestResolveServerModeUOWTopology_KeepsALiveSocket(t *testing.T) {
-	socket := filepath.Join(t.TempDir(), "dolt.sock")
+	socket := filepath.Join(shortTempDir(t), "dolt.sock")
+	// Belt and braces: shortTempDir keeps us well inside the limit on every
+	// runner we have, but a caller with an unusually deep $TMPDIR should read a
+	// skip rather than a bare "bind: invalid argument".
+	if len(socket) >= sunPathLimit {
+		t.Skipf("socket path too long (%d bytes): %s", len(socket), socket)
+	}
 	ln, err := net.Listen("unix", socket)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = ln.Close() })

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -19,6 +19,38 @@ var v *viper.Viper
 // GetValueSource can distinguish them from Viper defaults.
 var overriddenKeys = map[string]bool{}
 
+// ignoredConfigKey normalizes a config path into the single form the
+// BEADS_TEST_IGNORE_REPO_CONFIG ignore set is keyed by, so that membership does
+// not depend on which alias of a directory the caller happened to hold.
+//
+// The set is built from os.Getwd(), which honors $PWD and therefore reports the
+// path the process was given rather than the one the kernel resolved. The
+// BEADS_DIR that is tested against it is written by the CLI's own dispatch from
+// beads.FindBeadsDir, which runs utils.CanonicalizePath (filepath.EvalSymlinks).
+// Comparing those two strings directly misses whenever the workspace is reached
+// through a symlink, the ignore is not applied, and the repo config is merged
+// after all — which is exactly what the flag exists to prevent.
+//
+// On macOS that is not an edge case, it is every temp workspace: $TMPDIR is
+// /var/folders/... and /var is a symlink to /private/var, so every t.TempDir()
+// has two names and the two sides pick different ones.
+//
+// Symlinks are resolved on the directory, not the file: callers pass candidate
+// config paths that may not exist, and EvalSymlinks fails on a missing leaf.
+// When the directory cannot be resolved either, fall back to a lexical clean —
+// applied identically on both insert and lookup, so the two still agree.
+func ignoredConfigKey(path string) string {
+	if path == "" {
+		return ""
+	}
+	dir, base := filepath.Split(filepath.Clean(path))
+	resolvedDir, err := filepath.EvalSymlinks(filepath.Clean(dir))
+	if err != nil {
+		return filepath.Clean(path)
+	}
+	return filepath.Clean(filepath.Join(resolvedDir, base))
+}
+
 // Initialize sets up the viper configuration singleton
 // Should be called once at application startup
 func Initialize() error {
@@ -111,10 +143,10 @@ func Initialize() error {
 				}
 			}
 			if moduleRoot != "" {
-				ignoredRepoConfigPaths[filepath.Clean(filepath.Join(moduleRoot, ".beads", "config.yaml"))] = true
+				ignoredRepoConfigPaths[ignoredConfigKey(filepath.Join(moduleRoot, ".beads", "config.yaml"))] = true
 			}
 			if fallbackPath := worktreeFallbackConfigPath(cwd); fallbackPath != "" {
-				ignoredRepoConfigPaths[filepath.Clean(fallbackPath)] = true
+				ignoredRepoConfigPaths[ignoredConfigKey(fallbackPath)] = true
 			}
 		}
 
@@ -125,7 +157,7 @@ func Initialize() error {
 			if _, err := os.Stat(path); err != nil {
 				return false
 			}
-			if ignoreRepoConfig && ignoredRepoConfigPaths[filepath.Clean(path)] {
+			if ignoreRepoConfig && ignoredRepoConfigPaths[ignoredConfigKey(path)] {
 				return false
 			}
 			configPaths = append(configPaths, path)
@@ -172,7 +204,7 @@ func Initialize() error {
 		// fences the read and merge path only: SaveConfigValue falls back to the
 		// caller-supplied beadsDir when ConfigFileUsed is empty, so where a write
 		// lands is still the caller's choice, not this flag's.
-		ignored := ignoreRepoConfig && ignoredRepoConfigPaths[filepath.Clean(p)]
+		ignored := ignoreRepoConfig && ignoredRepoConfigPaths[ignoredConfigKey(p)]
 		if _, err := os.Stat(p); err == nil && !ignored {
 			// Avoid duplicate if BEADS_DIR points to same config as CWD walk
 			if primaryConfigPath == "" || filepath.Clean(p) != filepath.Clean(primaryConfigPath) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -1925,6 +1926,120 @@ func TestInitialize_IgnoreRepoConfigAppliesToBeadsDirEnv(t *testing.T) {
 	// still write into the repo config the flag exists to protect.
 	if got := ConfigFileUsed(); got != "" {
 		t.Errorf("ConfigFileUsed() = %q, want empty when repo config is ignored via BEADS_DIR", got)
+	}
+}
+
+// The two sides of the ignore-set comparison are produced by different code with
+// different opinions about symlinks, and they have to agree anyway.
+//
+// The set is keyed off os.Getwd(), which honors $PWD and so reports the name the
+// process was handed. The BEADS_DIR checked against it is written by the CLI's own
+// dispatch from beads.FindBeadsDir, which canonicalizes through
+// filepath.EvalSymlinks. Compare those as raw strings and the lookup misses for any
+// workspace reached through a symlink: the ignore silently does not apply and the
+// repo config is merged after all.
+//
+// This is not hypothetical on macOS — it is unconditional there. $TMPDIR is
+// /var/folders/... and /var is a symlink to /private/var, so every t.TempDir() has
+// two names and the two sides pick different ones. It took the Main workflow's
+// macos-latest job red on cmd/bd TestDispatchDoesNotPolluteViperIssuePrefix.
+//
+// Constructing the symlink explicitly reproduces it on every platform rather than
+// only where $TMPDIR happens to be one.
+func TestInitialize_IgnoreRepoConfigMatchesThroughASymlinkedRoot(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation requires elevation on Windows")
+	}
+	restore := envSnapshot(t)
+	defer restore()
+
+	beadsDir := newIgnoredRepoConfigFixture(t, "json: true\nactor: repo-user\nissue-prefix: zzleak\n")
+	repoDir := filepath.Dir(beadsDir)
+
+	// An alias for the same repo root. Chdir through it so $PWD — and therefore
+	// os.Getwd, and therefore the ignore set — holds the unresolved name.
+	linkedRepo := filepath.Join(t.TempDir(), "linked-repo")
+	if err := os.Symlink(repoDir, linkedRepo); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	t.Chdir(linkedRepo)
+
+	// Stand in for FindBeadsDir, which hands dispatch a canonicalized path.
+	resolvedBeadsDir, err := filepath.EvalSymlinks(beadsDir)
+	if err != nil {
+		t.Fatalf("EvalSymlinks(%s): %v", beadsDir, err)
+	}
+	if resolvedBeadsDir == filepath.Join(linkedRepo, ".beads") {
+		t.Fatalf("fixture did not produce two distinct names for the same .beads dir: %s", resolvedBeadsDir)
+	}
+
+	t.Setenv("BEADS_TEST_IGNORE_REPO_CONFIG", "1")
+	t.Setenv("BEADS_DIR", resolvedBeadsDir)
+
+	ResetForTesting()
+	defer ResetForTesting()
+
+	if err := Initialize(); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+
+	if got := GetString("issue-prefix"); got != "" {
+		t.Errorf("GetString(issue-prefix) = %q, want empty: the ignore set missed the symlink-resolved BEADS_DIR", got)
+	}
+	if got := GetString("actor"); got != "" {
+		t.Errorf("GetString(actor) = %q, want empty: the ignore set missed the symlink-resolved BEADS_DIR", got)
+	}
+	if got := GetBool("json"); got {
+		t.Errorf("GetBool(json) = %v, want false: the ignore set missed the symlink-resolved BEADS_DIR", got)
+	}
+	if got := ConfigFileUsed(); got != "" {
+		t.Errorf("ConfigFileUsed() = %q, want empty when the repo config is ignored", got)
+	}
+}
+
+// The mirror of the case above: the alias must not become a way to over-ignore.
+// A genuinely different temp workspace still loads even when it is reached
+// through a symlink, so the normalization cannot be collapsing distinct paths.
+func TestInitialize_IgnoreRepoConfigStillHonorsSymlinkedTempBeadsDir(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation requires elevation on Windows")
+	}
+	restore := envSnapshot(t)
+	defer restore()
+
+	newIgnoredRepoConfigFixture(t, "json: true\nactor: repo-user\n")
+
+	workspace := filepath.Join(t.TempDir(), ".beads")
+	if err := os.MkdirAll(workspace, 0o755); err != nil {
+		t.Fatalf("failed to create workspace: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(workspace, "config.yaml"), []byte("actor: workspace-user\nissue-prefix: wksp\n"), 0o644); err != nil {
+		t.Fatalf("failed to write workspace config.yaml: %v", err)
+	}
+
+	linkedWorkspace := filepath.Join(t.TempDir(), "linked-beads")
+	if err := os.Symlink(workspace, linkedWorkspace); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	t.Setenv("BEADS_TEST_IGNORE_REPO_CONFIG", "1")
+	t.Setenv("BEADS_DIR", linkedWorkspace)
+
+	ResetForTesting()
+	defer ResetForTesting()
+
+	if err := Initialize(); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+
+	if got := GetString("actor"); got != "workspace-user" {
+		t.Errorf("GetString(actor) = %q, want %q from the symlinked temp workspace", got, "workspace-user")
+	}
+	if got := GetString("issue-prefix"); got != "wksp" {
+		t.Errorf("GetString(issue-prefix) = %q, want %q from the symlinked temp workspace", got, "wksp")
+	}
+	if got := GetBool("json"); got {
+		t.Errorf("GetBool(json) = %v, want false — the ignored repo config leaked underneath", got)
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2114,3 +2114,50 @@ func TestInitialize_IgnoreRepoConfigStillHonorsTempBeadsDir(t *testing.T) {
 		t.Errorf("GetBool(json) = %v, want false — the ignored repo config leaked underneath", got)
 	}
 }
+
+// The same asymmetry with the sides swapped: cwd resolved, BEADS_DIR reached
+// through the alias. macOS produces the other order, so only that one is
+// load-bearing today — but a normalization applied to one side and not the
+// other would pass the test above and still leak here, and nothing in the code
+// makes the direction obvious. Pin the symmetry rather than the instance.
+func TestInitialize_IgnoreRepoConfigMatchesASymlinkedBeadsDir(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation requires elevation on Windows")
+	}
+	restore := envSnapshot(t)
+	defer restore()
+
+	beadsDir := newIgnoredRepoConfigFixture(t, "json: true\nactor: repo-user\nissue-prefix: zzleak\n")
+	repoDir := filepath.Dir(beadsDir)
+
+	linkedRepo := filepath.Join(t.TempDir(), "linked-repo")
+	if err := os.Symlink(repoDir, linkedRepo); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	// newIgnoredRepoConfigFixture already chdir'd into repoDir; make sure the
+	// name os.Getwd reports is the resolved one, so the alias is on the
+	// BEADS_DIR side only.
+	resolvedRepoDir, err := filepath.EvalSymlinks(repoDir)
+	if err != nil {
+		t.Fatalf("EvalSymlinks(%s): %v", repoDir, err)
+	}
+	t.Chdir(resolvedRepoDir)
+
+	t.Setenv("BEADS_TEST_IGNORE_REPO_CONFIG", "1")
+	t.Setenv("BEADS_DIR", filepath.Join(linkedRepo, ".beads"))
+
+	ResetForTesting()
+	defer ResetForTesting()
+
+	if err := Initialize(); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+
+	if got := GetString("issue-prefix"); got != "" {
+		t.Errorf("GetString(issue-prefix) = %q, want empty: the ignore set missed the aliased BEADS_DIR", got)
+	}
+	if got := ConfigFileUsed(); got != "" {
+		t.Errorf("ConfigFileUsed() = %q, want empty when the repo config is ignored", got)
+	}
+}


### PR DESCRIPTION
## Why

`main` has been red on the `Test (macos-latest)` job since 2026-07-31, and only there. Three tests fail. #5210 fixes one of them (`doctor.isBeadsManagedHooksPath`). This is the other two.

Both have the same cause underneath: macOS `$TMPDIR` is `/var/folders/<hash>/T`, which is (a) a symlink to `/private/var/folders/...` and (b) already ~48 bytes deep before a test has spent anything. Neither property holds on the Linux runners, so both tests passed everywhere except the one place nobody can see before merge.

## What was broken

**1. `TestDispatchDoesNotPolluteViperIssuePrefix`** — new in ed8526721 (#5218).

`config.Initialize` builds the `BEADS_TEST_IGNORE_REPO_CONFIG` ignore set by walking up from `os.Getwd()`, which honors `$PWD` and so reports the name the process was handed. The `BEADS_DIR` checked against that set is written by the CLI's own dispatch from `beads.FindBeadsDir`, which canonicalizes through `filepath.EvalSymlinks`. Resolved on one side, unresolved on the other, compared as raw strings: the lookup misses, the ignore does not apply, and the repo config is merged after all — exactly what the flag exists to prevent. The fixture's `issue-prefix: zzleak` ends up in the global viper.

**2. `TestResolveServerModeUOWTopology_KeepsALiveSocket`** — added by 6510641c3.

Binds a unix socket at `filepath.Join(t.TempDir(), "dolt.sock")`. `t.TempDir()` spends its budget on the test name, and this test has a long one: 120 bytes against a 104-byte `sockaddr_un.sun_path`, so `bind(2)` returns `EINVAL` and the runner reports a bare `bind: invalid argument`. It has never passed on macOS.

## What changed

- `ignoredConfigKey` is the one normalizer both insert and lookup go through, so the set cannot be keyed by a form its own lookups do not produce. It resolves the *directory* rather than the file, because callers pass candidate config paths that need not exist and `EvalSymlinks` fails on a missing leaf; when the directory does not resolve either it falls back to a lexical clean, applied identically on both sides so the two still agree.
- `shortTempDir` allocates via `os.MkdirTemp("", "bd")`, keeping the socket path near 70 bytes on the same runner. The length check at the call site follows the convention already in `internal/storage/dbproxy/server`: a legible skip for a pathological `$TMPDIR`, not the fix.

`BEADS_TEST_IGNORE_REPO_CONFIG` is set only by tests and by `scripts/ci/lib/test-env.sh`, so production config resolution is untouched.

## Verification

The symlinks are constructed explicitly rather than inherited from `$TMPDIR`, so the tests fail on every platform without the fix instead of only where `$TMPDIR` happens to be one. Against the parent commit, on Linux:

```
--- FAIL: TestInitialize_IgnoreRepoConfigMatchesThroughASymlinkedRoot
    GetString(issue-prefix) = "zzleak", want empty
--- FAIL: TestInitialize_IgnoreRepoConfigMatchesASymlinkedBeadsDir
    GetString(issue-prefix) = "zzleak", want empty
```

byte-identical to what the macOS runner reported. Three properties are pinned, not one: the failure itself; its mirror (`...MatchesASymlinkedBeadsDir`, sides swapped — a normalizer applied to one side only would pass the first test and still leak); and the over-ignore guard (`...StillHonorsSymlinkedTempBeadsDir`, a genuinely different workspace reached through a symlink must still load, so the normalization is not collapsing distinct paths).

`./internal/config` and the affected `./cmd/bd` tests are green under `CGO_ENABLED=1 -tags gms_pure_go`; `CGO_ENABLED=0` vet passes for the pure-Go gate. Full `make test` is queued on this head.

## One thing worth flagging

`.github/workflows/main.yml` triggers on `push: branches: [main]` only, so the `macos-latest` Test job never runs on a PR. **This PR cannot demonstrate its own fix**, and neither could the PRs that introduced these failures — the breakage is undetectable pre-merge by construction, and it lands as a red base that then reads as "pre-existing failures" for everything opened behind it.

There is a second-order cost: the local zero-token bisect lane cannot diagnose these either. It ran against this red base and returned `unreproducible` — correctly, since its oracle runs on Linux while the failing job is macOS.

`TestShortTempDirOmitsTheTestName` is a partial substitute for one of the two: it makes reverting the helper fail on Linux rather than silently on the next push to main. The general gap is a CI-spend question for a maintainer, not something this PR should decide.
