### PR TITLE
fix(reset): decide hook deletion from provenance, not the word "beads"

### DIFF
--- a/cmd/bd/reset.go
+++ b/cmd/bd/reset.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"bufio"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -84,13 +83,13 @@ func runReset(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	items := collectResetItems(gitCommonDir, beadsDir)
+	items, preserved := collectResetItems(gitCommonDir, beadsDir)
 
 	if !force {
-		return showResetPreview(items)
+		return showResetPreview(items, preserved)
 	}
 
-	return performReset(items, gitCommonDir, beadsDir)
+	return performReset(items, preserved, gitCommonDir, beadsDir)
 }
 
 type resetItem struct {
@@ -99,23 +98,35 @@ type resetItem struct {
 	Description string `json:"description"`
 }
 
-func collectResetItems(gitCommonDir, beadsDir string) []resetItem {
-	var items []resetItem
-
+// collectResetItems returns what reset will remove, and separately what it
+// found but will leave alone. The second list is not cosmetic: a hook bd only
+// injected a section into is the user's file, and saying nothing about it is
+// how a reset looks like it did less than it did — or, before ownership was
+// checked properly, more.
+func collectResetItems(gitCommonDir, beadsDir string) (items, preserved []resetItem) {
 	// Check for git hooks (hooks are in common git dir, shared across worktrees)
 	hookNames := []string{"pre-commit", "post-merge", "pre-push", "post-checkout"}
 	hooksDir := filepath.Join(gitCommonDir, "hooks")
 	for _, hookName := range hookNames {
 		hookPath := filepath.Join(hooksDir, hookName)
-		if _, err := os.Stat(hookPath); err == nil {
-			// Check if it's a beads hook by looking for version marker
-			if isBdHook(hookPath) {
-				items = append(items, resetItem{
-					Type:        "hook",
-					Path:        hookPath,
-					Description: fmt.Sprintf("Remove git hook: %s", hookName),
-				})
-			}
+		if _, err := os.Stat(hookPath); err != nil {
+			continue
+		}
+		switch classifyResetHook(hookPath) {
+		case hookBdOwned:
+			items = append(items, resetItem{
+				Type:        "hook",
+				Path:        hookPath,
+				Description: fmt.Sprintf("Remove git hook: %s", hookName),
+			})
+		case hookUserOwnedWithBdSection:
+			preserved = append(preserved, resetItem{
+				Type:        "hook",
+				Path:        hookPath,
+				Description: fmt.Sprintf("Keep git hook %s: it is your file with a beads section in it (remove the section with 'bd hooks uninstall')", hookName),
+			})
+		case hookNotOurs:
+			// No bd marker at all. Not ours to mention, let alone remove.
 		}
 	}
 
@@ -136,35 +147,74 @@ func collectResetItems(gitCommonDir, beadsDir string) []resetItem {
 		Description: "Remove .beads directory (database, JSONL, config)",
 	})
 
-	return items
+	return items, preserved
 }
 
-func isBdHook(hookPath string) bool {
+// hookOwnership says how much of a git hook file bd is responsible for, which
+// is the only question that licenses `bd admin reset` to delete it.
+type hookOwnership int
+
+const (
+	// hookNotOurs: no bd provenance marker. bd did not write this file and
+	// must not remove it.
+	hookNotOurs hookOwnership = iota
+	// hookBdOwned: bd wrote the whole file. Removing it restores exactly the
+	// state before bd touched the repo, so reset removes it.
+	hookBdOwned
+	// hookUserOwnedWithBdSection: the user's own hook, with bd's block injected
+	// between section markers (the v0.49+ model). The file is theirs; deleting
+	// it would take their content with it, and reset has no backup to restore
+	// because it never displaced anything here.
+	hookUserOwnedWithBdSection
+)
+
+// classifyResetHook decides ownership from the file's content, using the same
+// markers bd writes when it installs and the same rules preservePreexistingHooks
+// applies (GH#3536), rather than a heuristic of its own.
+//
+// It used to ask whether any of the first ten lines contained the substring
+// "beads", anywhere, in any context. That matched a comment, a path, or a call
+// to any other tool that happens to spell the word — including this project's
+// own hand-composed, git-tracked .githooks/pre-commit, which chains
+// `bd hooks run` alongside guards bd knows nothing about. Such a hook was
+// deleted as if bd had installed it, and performReset's restore path does not
+// help: it renames <hook>.backup back into place, and a backup exists only for
+// hooks bd itself displaced. A hand-written hook went with no way back.
+func classifyResetHook(hookPath string) hookOwnership {
 	// #nosec G304 -- hook path is constructed from git dir, not user input
-	file, err := os.Open(hookPath)
+	data, err := os.ReadFile(hookPath)
 	if err != nil {
-		return false
+		return hookNotOurs
 	}
-	defer file.Close()
+	content := string(data)
 
-	scanner := bufio.NewScanner(file)
-	lineCount := 0
-	for scanner.Scan() && lineCount < 10 {
-		line := scanner.Text()
-		if strings.Contains(line, "bd-hooks-version:") || strings.Contains(line, "beads") {
-			return true
+	// Order matters, and matches shouldPreserveHookContent: a sectioned file is
+	// user-owned unless stripping bd's block leaves nothing but a shebang, in
+	// which case bd effectively wrote all of it.
+	if strings.Contains(content, hookSectionBeginPrefix) {
+		if stripped, _ := removeHookSection(content); isOnlyShebangOrEmpty(stripped) {
+			return hookBdOwned
 		}
-		lineCount++
+		return hookUserOwnedWithBdSection
 	}
-	return false
+	if strings.Contains(content, inlineHookMarker) ||
+		strings.Contains(content, hookVersionPrefix) ||
+		strings.Contains(content, shimVersionPrefix) {
+		return hookBdOwned
+	}
+	return hookNotOurs
 }
 
-func showResetPreview(items []resetItem) error {
+func showResetPreview(items, preserved []resetItem) error {
 	if jsonOutput {
-		return outputJSON(map[string]interface{}{
+		result := map[string]interface{}{
 			"dry_run": true,
 			"items":   items,
-		})
+		}
+		if len(preserved) > 0 {
+			result["preserved"] = preserved
+		}
+		return outputJSON(result)
 	}
 
 	fmt.Println(ui.RenderWarn("Reset preview (dry-run mode)"))
@@ -179,6 +229,8 @@ func showResetPreview(items []resetItem) error {
 		}
 	}
 
+	printPreservedHooks(preserved)
+
 	fmt.Println()
 	fmt.Println(ui.RenderFail("⚠ This operation cannot be undone!"))
 	fmt.Println()
@@ -186,7 +238,23 @@ func showResetPreview(items []resetItem) error {
 	return nil
 }
 
-func performReset(items []resetItem, _, _ string) error {
+// printPreservedHooks reports the hooks reset deliberately did not touch.
+// Silence here is the failure mode worth avoiding: the user asked for a reset
+// and needs to know a beads section is still live in a hook of theirs.
+func printPreservedHooks(preserved []resetItem) {
+	if len(preserved) == 0 {
+		return
+	}
+	fmt.Println()
+	fmt.Println("Left in place (not installed by bd):")
+	fmt.Println()
+	for _, item := range preserved {
+		fmt.Printf("  %s %s\n", ui.RenderPass("•"), item.Description)
+		fmt.Printf("    %s\n", item.Path)
+	}
+}
+
+func performReset(items, preserved []resetItem, _, _ string) error {
 
 	var errors []string
 
@@ -230,8 +298,13 @@ func performReset(items []resetItem, _, _ string) error {
 		if len(errors) > 0 {
 			result["errors"] = errors
 		}
+		if len(preserved) > 0 {
+			result["preserved"] = preserved
+		}
 		return outputJSON(result)
 	}
+
+	printPreservedHooks(preserved)
 
 	fmt.Println()
 	if len(errors) > 0 {

--- a/cmd/bd/reset_hook_ownership_test.go
+++ b/cmd/bd/reset_hook_ownership_test.go
@@ -1,0 +1,180 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// A hand-composed hook that bd never installed, which mentions beads because it
+// chains to bd among other guards. This is the shape the old heuristic deleted:
+// it asked whether any of the first ten lines contained the substring "beads",
+// which this does, on a file bd has no claim to at all.
+const composedForeignHook = `#!/usr/bin/env bash
+# pre-commit — repo guard.
+#
+# Composition: this is the umbrella pre-commit hook. It chains to the
+# project's own config guard, then runs the beads hook, then applies the
+# worktree check. bd did not write this file and must not remove it.
+set -euo pipefail
+
+./scripts/check-config
+bd hooks run pre-commit "$@"
+./scripts/worktree-guard
+`
+
+func writeHook(t *testing.T, dir, name, content string) string {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", dir, err)
+	}
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(content), 0o755); err != nil { // #nosec G306 -- hooks are executable
+		t.Fatalf("write %s: %v", path, err)
+	}
+	return path
+}
+
+func TestClassifyResetHook(t *testing.T) {
+	section := generateHookSection("pre-commit")
+
+	tests := []struct {
+		name    string
+		content string
+		want    hookOwnership
+	}{
+		{
+			name:    "inline hook written by bd init",
+			content: "#!/bin/sh\n# bd-hooks-version: 0.40.0\n# bd (beads) pre-commit hook\nbd sync --flush-only\n",
+			want:    hookBdOwned,
+		},
+		{
+			name:    "legacy shim written by bd",
+			content: "#!/usr/bin/env sh\n# bd-shim v2\n# bd-hooks-version: 0.56.1\nexec bd hooks run pre-commit \"$@\"\n",
+			want:    hookBdOwned,
+		},
+		{
+			name:    "section-only file: bd wrote everything but the shebang",
+			content: "#!/bin/sh\n" + section,
+			want:    hookBdOwned,
+		},
+		{
+			name:    "user hook with bd's section injected",
+			content: "#!/bin/sh\nset -e\n./scripts/lint\n\n" + section,
+			want:    hookUserOwnedWithBdSection,
+		},
+		{
+			// The regression. No bd marker anywhere; "beads" appears only in a
+			// comment and in a call to bd, both of which the old first-ten-lines
+			// substring match treated as bd's signature.
+			name:    "hand-composed hook that merely mentions beads",
+			content: composedForeignHook,
+			want:    hookNotOurs,
+		},
+		{
+			name:    "unrelated hook",
+			content: "#!/bin/sh\n. \"$(dirname -- \"$0\")/_/husky.sh\"\nnpm test\n",
+			want:    hookNotOurs,
+		},
+		{
+			// "beads" past the tenth line was invisible to the old scan, so the
+			// old code was wrong in both directions on the same input class.
+			name:    "mentions beads only far down the file",
+			content: "#!/bin/sh\n#\n#\n#\n#\n#\n#\n#\n#\n#\n#\n# runs beads later\nexit 0\n",
+			want:    hookNotOurs,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := writeHook(t, t.TempDir(), "pre-commit", tt.content)
+			if got := classifyResetHook(path); got != tt.want {
+				t.Errorf("classifyResetHook() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestClassifyResetHook_MissingFileIsNotOurs(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "pre-commit")
+	if got := classifyResetHook(path); got != hookNotOurs {
+		t.Errorf("classifyResetHook(missing) = %v, want hookNotOurs", got)
+	}
+}
+
+// Two functions decide, separately, whether a hook file holds anything of the
+// user's: shouldPreserveHookContent when bd migrates hooks into .beads/hooks,
+// and classifyResetHook when bd is about to delete them. They have to give the
+// same answer. If preservation would carry content forward, that content is the
+// user's and reset must not remove the file; if preservation discards the file
+// as wholly bd-managed, reset may.
+//
+// Drift between them is not a tidiness problem — it is deletion without a
+// restore path, since performReset only renames <hook>.backup back into place
+// and a backup exists only for hooks bd itself displaced.
+//
+// This runs over the repository's own tracked .githooks rather than fixtures,
+// so the inputs are hooks a person actually composed. It asserts the agreement,
+// not a hardcoded verdict per file, so editing those hooks cannot make it lie.
+func TestClassifyResetHook_AgreesWithHookPreservation(t *testing.T) {
+	for _, name := range managedHookNames {
+		path := filepath.Join("..", "..", ".githooks", name)
+		content, err := os.ReadFile(path) // #nosec G304 -- fixed repo-relative path
+		if err != nil {
+			t.Skipf("%s not present in this checkout: %v", path, err)
+		}
+		t.Run(name, func(t *testing.T) {
+			_, wouldPreserve := shouldPreserveHookContent(string(content), false)
+			got := classifyResetHook(path)
+
+			if wouldPreserve && got == hookBdOwned {
+				t.Errorf("classifyResetHook(%s) = hookBdOwned, but shouldPreserveHookContent keeps this file: "+
+					"reset would delete content bd itself considers the user's, with no backup to restore", path)
+			}
+			if !wouldPreserve && got != hookBdOwned {
+				t.Errorf("classifyResetHook(%s) = %v, but shouldPreserveHookContent discards this file as wholly "+
+					"bd-managed: reset would leave behind a hook bd wrote", path, got)
+			}
+		})
+	}
+}
+
+func TestCollectResetItems_OnlyRemovesHooksBdOwns(t *testing.T) {
+	gitCommonDir := t.TempDir()
+	beadsDir := filepath.Join(t.TempDir(), ".beads")
+	hooksDir := filepath.Join(gitCommonDir, "hooks")
+
+	bdOwned := writeHook(t, hooksDir, "post-merge", "#!/bin/sh\n# bd-hooks-version: 0.40.0\n# bd (beads) post-merge hook\nbd import\n")
+	sectioned := writeHook(t, hooksDir, "pre-commit", "#!/bin/sh\nset -e\n./scripts/lint\n\n"+generateHookSection("pre-commit"))
+	foreign := writeHook(t, hooksDir, "pre-push", composedForeignHook)
+
+	items, preserved := collectResetItems(gitCommonDir, beadsDir)
+
+	inItems := map[string]bool{}
+	for _, it := range items {
+		inItems[it.Path] = true
+	}
+	inPreserved := map[string]bool{}
+	for _, it := range preserved {
+		inPreserved[it.Path] = true
+	}
+
+	if !inItems[bdOwned] {
+		t.Errorf("bd-owned hook %s missing from removal list", bdOwned)
+	}
+	if inItems[sectioned] {
+		t.Errorf("hook %s is the user's file with a bd section in it; removing it takes their content too", sectioned)
+	}
+	if !inPreserved[sectioned] {
+		t.Errorf("hook %s should be reported as left in place, not silently ignored", sectioned)
+	}
+	if inItems[foreign] || inPreserved[foreign] {
+		t.Errorf("hook %s carries no bd marker; it is neither ours to remove nor ours to mention", foreign)
+	}
+
+	// The .beads directory is always in the removal list — that is the point of
+	// the command, and this pins that the hook change did not disturb it.
+	if !inItems[beadsDir] {
+		t.Errorf("beads dir %s missing from removal list", beadsDir)
+	}
+}

--- a/docs/recovery/uninstalling.md
+++ b/docs/recovery/uninstalling.md
@@ -44,8 +44,13 @@ bd admin reset --force
 This removes beads-managed repository data such as:
 
 - the `.beads/` directory
-- beads-managed git hook sections
+- git hooks that beads installed in full
 - legacy beads sync worktrees under `.git/beads-worktrees/`
+
+Reset works on whole hook files, not on sections. A hook of your own that
+beads injected a section into is left in place and reported, because deleting
+the file would take your content with it. Remove the section from those with
+`bd hooks uninstall`.
 
 ## Remove Hooks Only
 
@@ -68,6 +73,13 @@ the repository.
 bd dolt stop 2>/dev/null || true
 
 # Remove beads-managed hooks when bd hooks uninstall is unavailable.
+#
+# Check each file before deleting it. These are the standard git hook names,
+# not names beads reserves, so any of them may be a hook you wrote. Delete
+# only the ones whose entire content beads generated — they carry a
+# "# bd-hooks-version:", "# bd-shim", or "# bd (beads)" line. A hook of yours
+# with a "# --- BEGIN BEADS INTEGRATION ... ---" block in it should be edited,
+# removing the block between the BEGIN and END markers and keeping the rest.
 rm -f .git/hooks/pre-commit
 rm -f .git/hooks/prepare-commit-msg
 rm -f .git/hooks/post-merge


### PR DESCRIPTION
## Why

`bd admin reset --force` deletes git hooks it believes bd installed. `isBdHook` decided that by scanning the first ten lines for the substring `"beads"` — anywhere, in any context. A comment, a path, or a call to another tool was enough to make a hook bd's to delete.

**This repository's own tracked `.githooks/pre-commit` is such a file.** It is composed by hand, carries guards bd knows nothing about, and line 9 reads:

```
# the beads section at the bottom must run for non-Go commits too.
```

The old scan matched that comment. Nothing brings the file back afterwards: `performReset`'s restore path renames `<hook>.backup` into place, and a backup exists only for hooks bd itself displaced — so a hook bd never installed is deleted with no restore.

The same scan was wrong in the other direction too (a marker past the tenth line was invisible), but that failure is merely untidy. This one loses work.

## The case the old boolean could not express

A `"beads"` match in the first ten lines is *guaranteed* for any marker-managed hook whose section lands near the top, because the generated section's second line is `# This section is managed by beads.` — so a user's own hook, with bd's block injected into it, was deleted **whole**, taking their content with it. That is the shape every marker-managed install has produced since v0.49.

## What changed

Provenance is not something reset has to guess at. bd writes markers when it installs (`hookVersionPrefix`, `shimVersionPrefix`, `inlineHookMarker`) and wraps injected blocks in section markers, and `preservePreexistingHooks` already has a worked-out model of what those mean (#3536). `classifyResetHook` uses the same markers and the same rules, and returns three states rather than a boolean, because "bd installed this" and "bd may delete this" are different questions:

| state | meaning | reset |
|---|---|---|
| `hookBdOwned` | bd wrote the whole file | removes it |
| `hookUserOwnedWithBdSection` | the user's hook, bd's block injected | reports it, leaves it |
| `hookNotOurs` | no marker at all | neither removes nor mentions |

Preserved hooks are reported in the preview, in the `--force` path, and in `--json` under a new `preserved` key. Saying nothing would leave the user believing a reset removed a beads integration that is in fact still live in one of their hooks.

## Verification

`TestClassifyResetHook` covers each state, both directions of the old ten-line window, and the missing-file case. `TestCollectResetItems_OnlyRemovesHooksBdOwns` checks the three classes end to end and pins that `.beads` itself is still removed.

`TestClassifyResetHook_AgreesWithHookPreservation` is the one worth a look. Two functions decide independently whether a hook holds anything of the user's — `shouldPreserveHookContent` when bd migrates hooks into `.beads/hooks`, and `classifyResetHook` when bd is about to delete them — and drift between them is not a tidiness problem, it is deletion without a restore path. The test asserts they agree, running over this repo's own tracked `.githooks` so the inputs are hooks a person actually composed. It asserts the *agreement*, not a hardcoded verdict per file, so editing those hooks cannot make it lie.

Full `make test` is queued on this head; `./cmd/bd` hook and reset tests pass under `CGO_ENABLED=1 -tags gms_pure_go`, and `CGO_ENABLED=0` vet passes for the pure-Go gate.

## Deliberately not in scope

`collectResetItems` scans four hook names; `managedHookNames` lists five (`prepare-commit-msg` is missing from reset's list). Widening it would make reset delete *more*, which wants its own change and its own justification, not a quiet ride on a fix that exists to make it delete less.

Beads: `mybd-n7j2z`.
