### PR TITLE
fix(proxied): stop reporting backend failures as not-found, plus bd serve v0 docs

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -213,12 +213,20 @@ linters:
       - path: '^cmd/bd/list_show_filter_modes\.go$'
         linters:
           - forbidigo
-      # `bd ready` hands its filter to --claim, --gated, --explain and --mol,
-      # and readyInput carries it as a field for them. Routing only the plain
-      # listing through the role would fork the command in two, so the filter
-      # stays nameable here. `bd ready` is on the shared BUILDER and, on the
-      # proxied route, the shared EPILOGUE; it is not on the role, and this
-      # rule does not pretend otherwise.
+      # `bd ready` hands its filter to the plain listing and to --claim, and
+      # readyInput carries it as a field for them. Routing only the listing
+      # through the role would fork the command in two, so the filter stays
+      # nameable here. The other modes take no filter from readyInput: --gated
+      # and --mol answer a different question and short-circuit before the
+      # flags are gathered, and so does --explain, which is a whole-graph
+      # diagnostic and therefore builds its own fixed request through the same
+      # builder (readyExplainFilter, which names the type it returns) rather
+      # than inlining a third copy of the default - bd-3fs.3. The blocked-issue
+      # views in these files name the type directly for an empty filter or one
+      # carrying only a --parent id, which is the absence of a filter rather
+      # than one this command built. `bd ready` is on the shared BUILDER and,
+      # on the proxied route, the shared EPILOGUE; it is not on the role, and
+      # this rule does not pretend otherwise.
       - path: '^cmd/bd/ready(_input|_proxied_server)?\.go$'
         linters:
           - forbidigo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,71 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`bd serve` — the beads work surface over HTTP** (bd-serve v0). Automation
+  clients and orchestrators that fork a `bd` subprocess per call can now hold
+  one connection instead. `bd serve` binds loopback and answers six
+  OpenAPI-specified operations: `GET /healthz`, `GET /v0/beads/context`,
+  `GET /v0/beads/ready`, `GET /v0/beads/issues`, `GET /v0/beads/issues/{id}`,
+  and the one write, `POST /v0/beads/issues/{id}:claim`. The wire contract is
+  `internal/httpapi/spec/openapi.v0.yaml`; types are generated from it and
+  `make api-check` fails a change that edits one without the other.
+  `GET /v0/beads/context` reports which operations the running build actually
+  implements, derived from the registered handlers, so a release cut mid-slice
+  cannot advertise one that does not work.
+
+  The reads run on `issueops.Reader`, the same role `bd show --json` reaches, so
+  filter construction, workspace config, default limits and the wisp fallback
+  happen *inside* the role rather than being re-performed per front door. The
+  exact scope of that property — what is shared, what is machine-enforced and by
+  which lint rule, and what is not enforced — is stated in full in
+  `issueops.Reader`'s doc comment and in
+  [engdocs/design/bd-serve-v0.md](engdocs/design/bd-serve-v0.md); it is narrower
+  than "the CLI and the API cannot disagree", and the difference is written
+  down.
+
+  **Errors are typed.** Every non-2xx is an RFC 9457 `problem+json` document
+  with a machine-readable `code` (`invalid_argument`, `invalid_cursor`,
+  `not_found`, `already_claimed`, `not_claimable`, `busy`, `db_unavailable`,
+  `internal`), one frozen HTTP status per code, and `Retry-After` on the
+  retryable ones. A client that classified claim conflicts by substring-matching
+  error text should switch to the typed 409: `assignee` and `issue_status` come
+  from a read inside the losing transaction, never from parsing the sentinel's
+  prose. A 5xx `detail` is a fixed string per code — driver errors embed the DSN
+  — and the body's `request_id` correlates to the one log line that carries the
+  real error.
+
+  **Paging is an opaque keyset cursor** on `GET /v0/beads/issues`
+  (`GET /v0/beads/ready` has none: its sort policies admit no keyset predicate).
+  The token holds a position and a private encoding version and nothing else, so
+  it does not expire, survives a restart, and has exactly one failure recovery —
+  restart paging without it. It also carries no filters, so a cursor reused under
+  changed filters is **not** refused and silently resumes from the old position;
+  repeat every filter verbatim for a traversal.
+
+  **Deliberate omissions, stated as contract rather than gaps.** No
+  authentication and no TLS — the trust model is the loopback boundary the
+  database already relies on, and `--allow-non-loopback` is an operator decision
+  that additionally refuses unlimited (`limit=0`) reads. A DNS-rebinding `Host`
+  allowlist with no off switch. Hooks do not fire on an HTTP claim (a
+  user-controlled subprocess per mutation is an unbounded latency multiplier and
+  an orphaned child at shutdown). The per-command auto-commit machinery does not
+  run: durability is per request, and an idempotent re-claim by the current
+  holder writes no commit at all, so a polling client cannot mint empty storage
+  commits. An HTTP `actor` is caller-asserted provenance for the audit trail,
+  not authenticated identity — the same thing `--actor` has always been.
+
+  Embedded-Dolt workspaces are refused permanently: that backend commits outside
+  the SQL transaction, so the per-request atomicity this contract states could
+  not hold there.
+
+  Operators: pass an explicit port. The default `--addr 127.0.0.1:0` takes an
+  ephemeral one and carries **no** mutual exclusion — N servers run side by side
+  on different ports. Probe readiness with `GET /v0/beads/ready?limit=1`;
+  `/healthz` is liveness only and stays green while the database is unreachable.
+  Deployment, the connection budget for a shared `dolt sql-server`, the
+  request-log format and the ambiguous-shutdown re-claim recovery are in
+  [engdocs/SERVE_RUNBOOK.md](engdocs/SERVE_RUNBOOK.md).
+
 - **Replica-aware leases: `bd reclaim` no longer reverts a lease another
   replica granted** (wy-jpd3.7). A lease is only meaningful on the replica that
   granted it — the other machine's liveness view is stale by up to one sync

--- a/cmd/bd/close_proxied_server.go
+++ b/cmd/bd/close_proxied_server.go
@@ -16,6 +16,7 @@ import (
 	"github.com/steveyegge/beads/internal/storage/uow"
 	"github.com/steveyegge/beads/internal/types"
 	"github.com/steveyegge/beads/internal/ui"
+	"github.com/steveyegge/beads/internal/workapi"
 )
 
 type closeProxiedInput struct {
@@ -203,9 +204,13 @@ func gatherCloseProxiedInput(cmd *cobra.Command) closeProxiedInput {
 }
 
 func closeProxiedOne(ctx context.Context, uw uow.UnitOfWork, id, reason string, in closeProxiedInput, errs *[]string) (closeProxiedOutcome, bool) {
-	current, isWisp := proxiedResolveIssueOrWisp(ctx, uw, id)
-	if current == nil {
+	current, isWisp, err := workapi.GetIssueOrWisp(ctx, workapi.NewUOWDetailSource(uw), id)
+	if errors.Is(err, storage.ErrNotFound) {
 		*errs = append(*errs, fmt.Sprintf("Issue %s not found", id))
+		return closeProxiedOutcome{}, false
+	}
+	if err != nil {
+		*errs = append(*errs, fmt.Sprintf("Error resolving %s: %v", id, err))
 		return closeProxiedOutcome{}, false
 	}
 
@@ -216,13 +221,13 @@ func closeProxiedOne(ctx context.Context, uw uow.UnitOfWork, id, reason string, 
 
 	if !in.force && current.IssueType == types.TypeEpic {
 		var openChildren int
-		var err error
+		var cerr error
 		if isWisp {
-			openChildren, err = uw.IssueUseCase().CountOpenWispChildren(ctx, id)
+			openChildren, cerr = uw.IssueUseCase().CountOpenWispChildren(ctx, id)
 		} else {
-			openChildren, err = uw.IssueUseCase().CountOpenChildren(ctx, id)
+			openChildren, cerr = uw.IssueUseCase().CountOpenChildren(ctx, id)
 		}
-		if err == nil && openChildren > 0 {
+		if cerr == nil && openChildren > 0 {
 			*errs = append(*errs, fmt.Sprintf("cannot close epic %s: %d open child issue(s); close children first or use --force to override", id, openChildren))
 			return closeProxiedOutcome{}, false
 		}
@@ -236,10 +241,7 @@ func closeProxiedOne(ctx context.Context, uw uow.UnitOfWork, id, reason string, 
 	}
 
 	params := domain.CloseIssueParams{Reason: reason, Session: in.session}
-	var (
-		res domain.CloseIssueResult
-		err error
-	)
+	var res domain.CloseIssueResult
 	// The is_blocked guard lives in the library's checked close, so the embedded
 	// and proxied paths converge on storage.ErrCloseBlocked and its message. The
 	// guard and the close share this unit-of-work transaction.
@@ -285,18 +287,6 @@ func closeProxiedCommitMessage(outcomes []closeProxiedOutcome, claimed *types.Is
 		msg += "; claim " + claimed.ID
 	}
 	return msg
-}
-
-func proxiedResolveIssueOrWisp(ctx context.Context, uw uow.UnitOfWork, id string) (*types.Issue, bool) {
-	issue, err := uw.IssueUseCase().GetIssue(ctx, id)
-	if err == nil && issue != nil {
-		return issue, false
-	}
-	wisp, err := uw.IssueUseCase().GetWisp(ctx, id)
-	if err == nil && wisp != nil {
-		return wisp, true
-	}
-	return nil, false
 }
 
 func fireProxiedCloseHooks(ctx context.Context, before, after *types.Issue) error {

--- a/cmd/bd/comments_proxied_server.go
+++ b/cmd/bd/comments_proxied_server.go
@@ -164,9 +164,12 @@ func addCommentProxied(ctx context.Context, id, author, text string) (*types.Com
 		return nil, nil, HandleError("proxied-server UOW provider not initialized")
 	}
 	res, err := uow.RunTxResult(ctx, uowProvider, func(ctx context.Context, uw uow.UnitOfWork) (addCommentProxiedResult, string, error) {
-		issue, isWisp := proxiedResolveIssueOrWisp(ctx, uw, id)
-		if issue == nil {
+		issue, isWisp, rerr := workapi.GetIssueOrWisp(ctx, workapi.NewUOWDetailSource(uw), id)
+		if errors.Is(rerr, storage.ErrNotFound) {
 			return addCommentProxiedResult{}, "", fmt.Errorf("issue %s not found", id)
+		}
+		if rerr != nil {
+			return addCommentProxiedResult{}, "", fmt.Errorf("resolving %s: %w", id, rerr)
 		}
 		if err := validateIssueUpdatable(id, issue); err != nil {
 			return addCommentProxiedResult{}, "", err

--- a/cmd/bd/defer_proxied_server.go
+++ b/cmd/bd/defer_proxied_server.go
@@ -2,13 +2,16 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"time"
 
+	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/storage/uow"
 	"github.com/steveyegge/beads/internal/types"
 	"github.com/steveyegge/beads/internal/ui"
+	"github.com/steveyegge/beads/internal/workapi"
 )
 
 type deferProxiedResult struct {
@@ -40,9 +43,13 @@ func runDeferProxiedServer(ctx context.Context, args []string, deferUntil *time.
 	res, err := uow.RunTxResult(ctx, uowProvider, func(ctx context.Context, uw uow.UnitOfWork) (deferProxiedResult, string, error) {
 		var r deferProxiedResult
 		for _, id := range args {
-			issue, isWisp := proxiedResolveIssueOrWisp(ctx, uw, id)
-			if issue == nil {
+			issue, isWisp, rerr := workapi.GetIssueOrWisp(ctx, workapi.NewUOWDetailSource(uw), id)
+			if errors.Is(rerr, storage.ErrNotFound) {
 				r.errs = append(r.errs, fmt.Sprintf("Error resolving %s: not found", id))
+				continue
+			}
+			if rerr != nil {
+				r.errs = append(r.errs, fmt.Sprintf("Error resolving %s: %v", id, rerr))
 				continue
 			}
 			fullID := issue.ID
@@ -108,9 +115,13 @@ func runUndeferProxiedServer(ctx context.Context, args []string) error {
 	res, err := uow.RunTxResult(ctx, uowProvider, func(ctx context.Context, uw uow.UnitOfWork) (deferProxiedResult, string, error) {
 		var r deferProxiedResult
 		for _, id := range args {
-			issue, isWisp := proxiedResolveIssueOrWisp(ctx, uw, id)
-			if issue == nil {
+			issue, isWisp, rerr := workapi.GetIssueOrWisp(ctx, workapi.NewUOWDetailSource(uw), id)
+			if errors.Is(rerr, storage.ErrNotFound) {
 				r.errs = append(r.errs, fmt.Sprintf("Error getting %s: not found", id))
+				continue
+			}
+			if rerr != nil {
+				r.errs = append(r.errs, fmt.Sprintf("Error getting %s: %v", id, rerr))
 				continue
 			}
 			fullID := issue.ID

--- a/cmd/bd/label_proxied_server.go
+++ b/cmd/bd/label_proxied_server.go
@@ -45,9 +45,12 @@ func labelMutateProxied(ctx context.Context, args []string, operation string) er
 	err := uow.RunTx(ctx, uowProvider, func(ctx context.Context, uw uow.UnitOfWork) (string, error) {
 		resolvedIDs = resolvedIDs[:0]
 		for _, inputID := range issueIDs {
-			issue, isWisp := proxiedResolveIssueOrWisp(ctx, uw, inputID)
-			if issue == nil {
+			issue, isWisp, rerr := workapi.GetIssueOrWisp(ctx, workapi.NewUOWDetailSource(uw), inputID)
+			if errors.Is(rerr, storage.ErrNotFound) {
 				return "", fmt.Errorf("resolving issue ID %q: not found", inputID)
+			}
+			if rerr != nil {
+				return "", fmt.Errorf("resolving issue ID %q: %w", inputID, rerr)
 			}
 			for _, label := range labels {
 				var e error
@@ -247,9 +250,12 @@ func runLabelPropagateProxiedServer(ctx context.Context, args []string) error {
 		parentID string
 	)
 	err := uow.RunTx(ctx, uowProvider, func(ctx context.Context, uw uow.UnitOfWork) (string, error) {
-		parent, _ := proxiedResolveIssueOrWisp(ctx, uw, args[0])
-		if parent == nil {
+		parent, _, rerr := workapi.GetIssueOrWisp(ctx, workapi.NewUOWDetailSource(uw), args[0])
+		if errors.Is(rerr, storage.ErrNotFound) {
 			return "", fmt.Errorf("resolving parent %q: not found", args[0])
+		}
+		if rerr != nil {
+			return "", fmt.Errorf("resolving parent %q: %w", args[0], rerr)
 		}
 		parentID = parent.ID
 

--- a/cmd/bd/mol_port.go
+++ b/cmd/bd/mol_port.go
@@ -11,6 +11,7 @@ import (
 	"github.com/steveyegge/beads/internal/storage/domain"
 	"github.com/steveyegge/beads/internal/storage/uow"
 	"github.com/steveyegge/beads/internal/types"
+	"github.com/steveyegge/beads/internal/workapi"
 )
 
 type molReader interface {
@@ -114,9 +115,12 @@ type uowMolReader struct {
 }
 
 func (r uowMolReader) GetIssue(ctx context.Context, id string) (*types.Issue, error) {
-	issue, isWisp := proxiedResolveIssueOrWisp(ctx, r.uw, id)
-	if issue == nil {
+	issue, isWisp, rerr := workapi.GetIssueOrWisp(ctx, workapi.NewUOWDetailSource(r.uw), id)
+	if errors.Is(rerr, storage.ErrNotFound) {
 		return nil, fmt.Errorf("issue %s not found", id)
+	}
+	if rerr != nil {
+		return nil, fmt.Errorf("resolving %s: %w", id, rerr)
 	}
 	var labels []string
 	var err error

--- a/cmd/bd/mutate_proxied_server.go
+++ b/cmd/bd/mutate_proxied_server.go
@@ -2,12 +2,15 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
+	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/storage/uow"
 	"github.com/steveyegge/beads/internal/types"
 	"github.com/steveyegge/beads/internal/ui"
 	"github.com/steveyegge/beads/internal/validation"
+	"github.com/steveyegge/beads/internal/workapi"
 )
 
 func proxiedMutateIssue(ctx context.Context, id, commitMsg string, mutate func(ctx context.Context, uw uow.UnitOfWork, issue *types.Issue, isWisp bool) error) (*types.Issue, error) {
@@ -16,9 +19,12 @@ func proxiedMutateIssue(ctx context.Context, id, commitMsg string, mutate func(c
 	}
 	var updated *types.Issue
 	err := uow.RunTx(ctx, uowProvider, func(ctx context.Context, uw uow.UnitOfWork) (string, error) {
-		issue, isWisp := proxiedResolveIssueOrWisp(ctx, uw, id)
-		if issue == nil {
+		issue, isWisp, rerr := workapi.GetIssueOrWisp(ctx, workapi.NewUOWDetailSource(uw), id)
+		if errors.Is(rerr, storage.ErrNotFound) {
 			return "", fmt.Errorf("issue %s not found", id)
+		}
+		if rerr != nil {
+			return "", fmt.Errorf("resolving %s: %w", id, rerr)
 		}
 		if err := validateIssueUpdatable(id, issue); err != nil {
 			return "", err

--- a/cmd/bd/proxied_lookup_failure_test.go
+++ b/cmd/bd/proxied_lookup_failure_test.go
@@ -69,12 +69,15 @@ func (p lookupOnlyProvider) Close(context.Context) error { return nil }
 // otherwise with the domain seam's wrapped sql.ErrNoRows.
 func withStubbedProxiedLookup(t *testing.T, hardErr error) {
 	t.Helper()
-	oldProvider, oldJSON := uowProvider, jsonOutput
+	oldProvider, oldJSON, oldWrote := uowProvider, jsonOutput, commandDidWrite.Load()
 	uowProvider = lookupOnlyProvider{issues: stubLookupIssueUC{hardErr: hardErr}}
 	jsonOutput = false
 	t.Cleanup(func() {
 		uowProvider = oldProvider
 		jsonOutput = oldJSON
+		// The mutating commands set commandDidWrite before they know whether
+		// anything resolved, and it drives the deferred Dolt commit in main.
+		commandDidWrite.Store(oldWrote)
 	})
 }
 
@@ -93,6 +96,27 @@ func showViewCmd(view string) *cobra.Command {
 	return cmd
 }
 
+// cmdWithStringFlag registers one string flag so the command under test does
+// not fall back to an environment lookup for it - `bd comment add` shells out
+// to git for the author when --author is empty, which has nothing to do with
+// what is being tested here.
+func cmdWithStringFlag(name, value string) *cobra.Command {
+	cmd := &cobra.Command{}
+	cmd.Flags().String(name, value, "")
+	return cmd
+}
+
+// closeReasonCmd registers the reason flags `bd close` reads before it resolves
+// anything. collectCloseReasonFlags returns an error for an unregistered one,
+// which would abort the command ahead of the lookup under test.
+func closeReasonCmd() *cobra.Command {
+	cmd := &cobra.Command{}
+	for _, name := range []string{"resolution", "message", "comment"} {
+		cmd.Flags().String(name, "", "")
+	}
+	return cmd
+}
+
 // proxiedLookupCommands is every proxied-server call site that resolves an id
 // through workapi.GetIssueOrWisp, driven at its real entry point with an id
 // that cannot resolve. Each names the exact stderr line for the two ways that
@@ -106,12 +130,16 @@ var proxiedLookupCommands = []struct {
 	// rows in result set", except gate list, which said "not found" for every
 	// failure including a dead backend.
 	wantNotFound string
-	// wantHardErr is stderr when the lookup fails for any other reason.
+	// wantHardErr is stderr when the lookup fails for any other reason. This is
+	// the half that used to be unreachable: gate list and every mutating
+	// command below it said "not found" for a dropped connection, a stale
+	// schema, anything at all.
 	wantHardErr string
-	// exitsZero marks the views that report per id and keep going. --refs and
-	// --children print the failure and move to the next id, so one bad id out
-	// of one still leaves the command at exit 0. That predates this slice; the
-	// branch under test is what they print, not what they return.
+	// exitsZero marks the commands that report per id and keep going. --refs,
+	// --children, defer, undefer and todo done print the failure and move to
+	// the next id, so one bad id out of one still leaves the command at exit 0.
+	// That predates these slices; the branch under test is what they print, not
+	// what they return.
 	exitsZero bool
 }{
 	{
@@ -190,13 +218,111 @@ var proxiedLookupCommands = []struct {
 		wantNotFound: "Error: message bd-missing not found",
 		wantHardErr:  "Error: fetching message bd-missing: connection reset by peer",
 	},
+	// The mutating commands below reached the same seam through
+	// proxiedResolveIssueOrWisp, which returned a bare (nil, false) and so
+	// could only ever be read as "not found" (bd-3fs.2). Their wantNotFound
+	// lines are the ones they have always shipped; only wantHardErr is new.
+	{
+		name: "close",
+		run: func(ctx context.Context) error {
+			return runCloseProxiedServer(closeReasonCmd(), ctx, []string{stubMissingID})
+		},
+		wantNotFound: "Issue bd-missing not found",
+		wantHardErr:  "Error resolving bd-missing: connection reset by peer",
+	},
+	{
+		name: "reopen",
+		run: func(ctx context.Context) error {
+			return runReopenProxiedServer(&cobra.Command{}, ctx, []string{stubMissingID})
+		},
+		wantNotFound: "Issue bd-missing not found",
+		wantHardErr:  "Error resolving bd-missing: connection reset by peer",
+	},
+	{
+		name: "unclaim",
+		run: func(ctx context.Context) error {
+			return runUnclaimProxiedServer(ctx, []string{stubMissingID}, "", false)
+		},
+		wantNotFound: "Error resolving bd-missing: not found",
+		wantHardErr:  "Error resolving bd-missing: connection reset by peer",
+	},
+	{
+		name: "defer",
+		run: func(ctx context.Context) error {
+			return runDeferProxiedServer(ctx, []string{stubMissingID}, nil, "")
+		},
+		wantNotFound: "Error resolving bd-missing: not found",
+		wantHardErr:  "Error resolving bd-missing: connection reset by peer",
+		exitsZero:    true,
+	},
+	{
+		name: "undefer",
+		run: func(ctx context.Context) error {
+			return runUndeferProxiedServer(ctx, []string{stubMissingID})
+		},
+		wantNotFound: "Error getting bd-missing: not found",
+		wantHardErr:  "Error getting bd-missing: connection reset by peer",
+		exitsZero:    true,
+	},
+	{
+		name: "label add",
+		run: func(ctx context.Context) error {
+			return runLabelAddProxiedServer(ctx, []string{stubMissingID, "urgent"})
+		},
+		wantNotFound: `Error: label added: resolving issue ID "bd-missing": not found`,
+		wantHardErr:  `Error: label added: resolving issue ID "bd-missing": connection reset by peer`,
+	},
+	{
+		name: "label propagate",
+		run: func(ctx context.Context) error {
+			return runLabelPropagateProxiedServer(ctx, []string{stubMissingID, "urgent"})
+		},
+		wantNotFound: `Error: label propagate: resolving parent "bd-missing": not found`,
+		wantHardErr:  `Error: label propagate: resolving parent "bd-missing": connection reset by peer`,
+	},
+	{
+		name: "set state",
+		run: func(ctx context.Context) error {
+			return runSetStateProxiedServer(ctx, stubMissingID, "phase", "done", "")
+		},
+		wantNotFound: "Error: issue bd-missing not found",
+		wantHardErr:  "Error: resolving bd-missing: connection reset by peer",
+	},
+	{
+		name: "todo done",
+		run: func(ctx context.Context) error {
+			return runTodoDoneProxiedServer(&cobra.Command{}, ctx, []string{stubMissingID})
+		},
+		wantNotFound: "Error: failed to close bd-missing: issue bd-missing not found",
+		wantHardErr:  "Error: failed to close bd-missing: resolving bd-missing: connection reset by peer",
+		exitsZero:    true,
+	},
+	{
+		name: "assign",
+		run: func(ctx context.Context) error {
+			return runAssignProxiedServer(ctx, []string{stubMissingID, "someone"}, false)
+		},
+		wantNotFound: "Error: assign bd-missing: issue bd-missing not found",
+		wantHardErr:  "Error: assign bd-missing: resolving bd-missing: connection reset by peer",
+	},
+	{
+		name: "comment add",
+		run: func(ctx context.Context) error {
+			return runCommentsAddProxiedServer(cmdWithStringFlag("author", "tester"), ctx, []string{stubMissingID, "hello"})
+		},
+		wantNotFound: "Error: issue bd-missing not found",
+		wantHardErr:  "Error: resolving bd-missing: connection reset by peer",
+	},
 }
 
 // TestProxiedLookupReportsMissingIssue covers the errors.Is(storage.ErrNotFound)
-// branch bd-hc1 added at every proxied call site. All but one used to hand the
-// user db.issueSQLRepositoryImpl.Get's raw sql.ErrNoRows for a typo'd id; gate
-// list is the exception, and its own regression is in
-// TestProxiedLookupReportsBackendFailure.
+// branch at every proxied call site. Of the read commands bd-hc1 migrated, all
+// but one used to hand the user db.issueSQLRepositoryImpl.Get's raw
+// sql.ErrNoRows for a typo'd id. The exceptions are gate list and the mutating
+// commands, which already printed "not found" - for a miss and for a dead
+// backend alike, which is what TestProxiedLookupReportsBackendFailure guards.
+// Their lines here are unchanged, and that is the point: normalizing the
+// sentinel must not move the message a user sees for a typo.
 func TestProxiedLookupReportsMissingIssue(t *testing.T) {
 	for _, tc := range proxiedLookupCommands {
 		t.Run(tc.name, func(t *testing.T) {
@@ -220,8 +346,11 @@ func TestProxiedLookupReportsMissingIssue(t *testing.T) {
 
 // TestProxiedLookupReportsBackendFailure covers the other side of the same
 // branch: a lookup that failed for a reason other than absence must say so.
-// gate list is the regression this one guards - it answered "issue not found"
-// for a dropped connection, a stale schema, anything at all.
+// gate list is the regression bd-hc1 fixed here; every mutating command in the
+// table is bd-3fs.2's. Those went through proxiedResolveIssueOrWisp, which
+// returned a bare (nil, false) with the reason discarded, so "issue not found"
+// was the only thing a caller could print - for a dropped connection, a stale
+// schema, anything at all. Reverting any of those call sites fails this test.
 func TestProxiedLookupReportsBackendFailure(t *testing.T) {
 	for _, tc := range proxiedLookupCommands {
 		t.Run(tc.name, func(t *testing.T) {
@@ -261,6 +390,34 @@ func TestReportIssueLookupFailure(t *testing.T) {
 		})
 		if got, want := strings.TrimSpace(stderr), "Error resolving bd-gone: i/o timeout"; got != want {
 			t.Errorf("stderr = %q, want %q", got, want)
+		}
+	})
+}
+
+// TestUOWMolReaderLookupFailure covers the twelfth caller of the deleted
+// proxiedResolveIssueOrWisp. uowMolReader is a molReader adapter rather than a
+// command, so it is driven directly: the molecule commands wrap whatever it
+// returns, and what they must not be handed is "step not found" for a backend
+// that never answered.
+func TestUOWMolReaderLookupFailure(t *testing.T) {
+	newReader := func(hardErr error) uowMolReader {
+		return uowMolReader{uw: lookupOnlyUOW{issues: stubLookupIssueUC{hardErr: hardErr}}}
+	}
+
+	t.Run("absent id is not found", func(t *testing.T) {
+		_, err := newReader(nil).GetIssue(context.Background(), stubMissingID)
+		if got, want := fmt.Sprint(err), "issue bd-missing not found"; got != want {
+			t.Errorf("err = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("backend failure keeps the reason", func(t *testing.T) {
+		_, err := newReader(errors.New(stubBackendError)).GetIssue(context.Background(), stubMissingID)
+		if got, want := fmt.Sprint(err), "resolving bd-missing: "+stubBackendError; got != want {
+			t.Errorf("err = %q, want %q", got, want)
+		}
+		if strings.Contains(strings.ToLower(fmt.Sprint(err)), "not found") {
+			t.Errorf("backend failure reported as a missing issue: %v", err)
 		}
 	})
 }

--- a/cmd/bd/ready.go
+++ b/cmd/bd/ready.go
@@ -14,6 +14,7 @@ import (
 	"github.com/steveyegge/beads/internal/ui"
 	"github.com/steveyegge/beads/internal/utils"
 	"github.com/steveyegge/beads/internal/workapi"
+	"github.com/steveyegge/beads/issueops"
 )
 
 var readyCmd = &cobra.Command{
@@ -442,14 +443,30 @@ func buildReadyIssueOutput(ctx context.Context, s storage.DoltStorage, issues []
 	return issuesWithCounts
 }
 
+// readyExplainFilter is the filter both --explain routes run, derived from the
+// same builder the listing uses so the set `bd ready --explain` explains cannot
+// drift from the set `bd ready` shows (bd-3fs.3).
+//
+// --explain takes no listing flags: it is a whole-graph diagnostic, and the
+// direct route reaches it before the flags are even gathered. The limit is
+// therefore pinned to unlimited rather than left to workapi.DefaultReadyLimit,
+// which would silently truncate the explanation at 100 rows.
+func readyExplainFilter() (types.WorkFilter, error) {
+	unlimited := 0
+	return workapi.BuildReadyFilter(issueops.ReadyRequest{
+		Sort:  string(types.SortPolicyPriority),
+		Limit: &unlimited,
+	})
+}
+
 func runReadyExplain(_ *cobra.Command) error {
 	ctx := rootCtx
 
 	activeStore := store
 
-	filter := types.WorkFilter{
-		Status:     types.StatusOpen,
-		SortPolicy: types.SortPolicyPriority,
+	filter, err := readyExplainFilter()
+	if err != nil {
+		return HandleErrorRespectJSON("%v", err)
 	}
 	readyIssues, err := activeStore.GetReadyWork(ctx, filter)
 	if err != nil {

--- a/cmd/bd/ready_input_test.go
+++ b/cmd/bd/ready_input_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"reflect"
 	"slices"
 	"strconv"
 	"strings"
@@ -14,6 +15,9 @@ import (
 	"github.com/spf13/pflag"
 
 	"github.com/steveyegge/beads/internal/config"
+	"github.com/steveyegge/beads/internal/types"
+	"github.com/steveyegge/beads/internal/workapi"
+	"github.com/steveyegge/beads/issueops"
 )
 
 // newReadyFlagsCommand clones readyCmd's flag definitions onto a fresh command
@@ -376,5 +380,36 @@ func TestGatherReadyInputDirectoryLabelDefaultsOnlyWhenNoLabelsGiven(t *testing.
 				}
 			}
 		})
+	}
+}
+
+// TestReadyExplainFilterDerivesTheReadyDefault pins the third copy of the ready
+// default out of existence (bd-3fs.3). Both --explain routes used to inline
+// WorkFilter{Status: StatusOpen, SortPolicy: SortPolicyPriority} beside the two
+// builders bd-ehi had already collapsed into workapi.BuildReadyFilter, so a
+// change to what "ready" means would have moved the listing and left the
+// diagnostic explaining a different set.
+//
+// The limit is the one field --explain sets for itself, and it is asserted
+// rather than derived: the listing takes workapi.DefaultReadyLimit, and an
+// --explain that inherited it would explain the first 100 ready issues of a
+// larger graph while reading as though it had explained the whole thing.
+func TestReadyExplainFilterDerivesTheReadyDefault(t *testing.T) {
+	got, err := readyExplainFilter()
+	if err != nil {
+		t.Fatalf("readyExplainFilter: %v", err)
+	}
+
+	want, err := workapi.BuildReadyFilter(issueops.ReadyRequest{Sort: string(types.SortPolicyPriority)})
+	if err != nil {
+		t.Fatalf("BuildReadyFilter: %v", err)
+	}
+	if want.Limit != workapi.DefaultReadyLimit {
+		t.Fatalf("listing default limit = %d, want workapi.DefaultReadyLimit (%d): this test is measuring against the wrong baseline", want.Limit, workapi.DefaultReadyLimit)
+	}
+	want.Limit = 0
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("explain filter = %+v\nwant the listing default, unlimited = %+v", got, want)
 	}
 }

--- a/cmd/bd/ready_proxied_server.go
+++ b/cmd/bd/ready_proxied_server.go
@@ -241,9 +241,9 @@ func runReadyProxiedClaim(ctx context.Context, _ uow.UnitOfWork, in readyInput) 
 }
 
 func runReadyProxiedExplain(ctx context.Context, uw uow.UnitOfWork, _ readyInput) error {
-	filter := types.WorkFilter{
-		Status:     types.StatusOpen,
-		SortPolicy: types.SortPolicyPriority,
+	filter, err := readyExplainFilter()
+	if err != nil {
+		return HandleErrorRespectJSON("%v", err)
 	}
 	readyPage, err := uw.IssueUseCase().GetReadyWork(ctx, filter)
 	if err != nil {

--- a/cmd/bd/reopen_proxied_server.go
+++ b/cmd/bd/reopen_proxied_server.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -10,10 +11,12 @@ import (
 
 	"github.com/steveyegge/beads/internal/audit"
 	"github.com/steveyegge/beads/internal/hooks"
+	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/storage/domain"
 	"github.com/steveyegge/beads/internal/storage/uow"
 	"github.com/steveyegge/beads/internal/types"
 	"github.com/steveyegge/beads/internal/ui"
+	"github.com/steveyegge/beads/internal/workapi"
 )
 
 type reopenProxiedOutcome struct {
@@ -100,14 +103,18 @@ func runReopenProxiedServer(cmd *cobra.Command, ctx context.Context, args []stri
 	return nil
 }
 
-func reopenProxiedOne(ctx context.Context, uw uow.UnitOfWork, id, reason string, errors *[]string) (reopenProxiedOutcome, bool) {
-	current, isWisp := proxiedResolveIssueOrWisp(ctx, uw, id)
-	if current == nil {
-		*errors = append(*errors, fmt.Sprintf("Issue %s not found", id))
+func reopenProxiedOne(ctx context.Context, uw uow.UnitOfWork, id, reason string, errs *[]string) (reopenProxiedOutcome, bool) {
+	current, isWisp, rerr := workapi.GetIssueOrWisp(ctx, workapi.NewUOWDetailSource(uw), id)
+	if errors.Is(rerr, storage.ErrNotFound) {
+		*errs = append(*errs, fmt.Sprintf("Issue %s not found", id))
+		return reopenProxiedOutcome{}, false
+	}
+	if rerr != nil {
+		*errs = append(*errs, fmt.Sprintf("Error resolving %s: %v", id, rerr))
 		return reopenProxiedOutcome{}, false
 	}
 	if current.Status != types.StatusClosed {
-		*errors = append(*errors, fmt.Sprintf("%s is already %s", id, current.Status))
+		*errs = append(*errs, fmt.Sprintf("%s is already %s", id, current.Status))
 		return reopenProxiedOutcome{id: id, before: current, after: current, reopened: false}, true
 	}
 
@@ -122,7 +129,7 @@ func reopenProxiedOne(ctx context.Context, uw uow.UnitOfWork, id, reason string,
 		res, err = uw.IssueUseCase().ReopenIssue(ctx, id, params, actor)
 	}
 	if err != nil {
-		*errors = append(*errors, fmt.Sprintf("Error reopening %s: %v", id, err))
+		*errs = append(*errs, fmt.Sprintf("Error reopening %s: %v", id, err))
 		return reopenProxiedOutcome{}, false
 	}
 

--- a/cmd/bd/state_proxied_server.go
+++ b/cmd/bd/state_proxied_server.go
@@ -91,9 +91,12 @@ func runSetStateProxiedServer(ctx context.Context, issueID, dimension, newValue,
 	newLabel := dimension + ":" + newValue
 
 	res, err := uow.RunTxResult(ctx, uowProvider, func(ctx context.Context, uw uow.UnitOfWork) (setStateResult, string, error) {
-		issue, isWisp := proxiedResolveIssueOrWisp(ctx, uw, issueID)
-		if issue == nil {
+		issue, isWisp, rerr := workapi.GetIssueOrWisp(ctx, workapi.NewUOWDetailSource(uw), issueID)
+		if errors.Is(rerr, storage.ErrNotFound) {
 			return setStateResult{}, "", fmt.Errorf("issue %s not found", issueID)
+		}
+		if rerr != nil {
+			return setStateResult{}, "", fmt.Errorf("resolving %s: %w", issueID, rerr)
 		}
 		fullID := issue.ID
 

--- a/cmd/bd/todo_proxied_server.go
+++ b/cmd/bd/todo_proxied_server.go
@@ -3,16 +3,19 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
 
+	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/storage/domain"
 	"github.com/steveyegge/beads/internal/storage/uow"
 	"github.com/steveyegge/beads/internal/types"
 	"github.com/steveyegge/beads/internal/ui"
+	"github.com/steveyegge/beads/internal/workapi"
 )
 
 func todoListProxied(ctx context.Context, filter types.IssueFilter) ([]*types.Issue, error) {
@@ -87,9 +90,12 @@ func runTodoDoneProxiedServer(cmd *cobra.Command, ctx context.Context, args []st
 	var closedIDs []string
 	for _, issueID := range args {
 		_, err := uow.RunTxResult(ctx, uowProvider, func(ctx context.Context, uw uow.UnitOfWork) (struct{}, string, error) {
-			issue, isWisp := proxiedResolveIssueOrWisp(ctx, uw, issueID)
-			if issue == nil {
+			issue, isWisp, rerr := workapi.GetIssueOrWisp(ctx, workapi.NewUOWDetailSource(uw), issueID)
+			if errors.Is(rerr, storage.ErrNotFound) {
 				return struct{}{}, "", fmt.Errorf("issue %s not found", issueID)
+			}
+			if rerr != nil {
+				return struct{}{}, "", fmt.Errorf("resolving %s: %w", issueID, rerr)
 			}
 			params := domain.CloseIssueParams{Reason: reason}
 			var e error

--- a/cmd/bd/unclaim_proxied_server.go
+++ b/cmd/bd/unclaim_proxied_server.go
@@ -2,14 +2,17 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
 	"time"
 
+	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/storage/uow"
 	"github.com/steveyegge/beads/internal/types"
 	"github.com/steveyegge/beads/internal/ui"
+	"github.com/steveyegge/beads/internal/workapi"
 )
 
 type unclaimProxiedResult struct {
@@ -26,9 +29,13 @@ func runUnclaimProxiedServer(ctx context.Context, args []string, reason string, 
 	res, err := uow.RunTxResult(ctx, uowProvider, func(ctx context.Context, uw uow.UnitOfWork) (unclaimProxiedResult, string, error) {
 		var r unclaimProxiedResult
 		for _, id := range args {
-			issue, _ := proxiedResolveIssueOrWisp(ctx, uw, id)
-			if issue == nil {
+			issue, _, rerr := workapi.GetIssueOrWisp(ctx, workapi.NewUOWDetailSource(uw), id)
+			if errors.Is(rerr, storage.ErrNotFound) {
 				r.errs = append(r.errs, fmt.Sprintf("Error resolving %s: not found", id))
+				continue
+			}
+			if rerr != nil {
+				r.errs = append(r.errs, fmt.Sprintf("Error resolving %s: %v", id, rerr))
 				continue
 			}
 			fullID := issue.ID

--- a/engdocs/DOC_INVENTORY.md
+++ b/engdocs/DOC_INVENTORY.md
@@ -19,7 +19,7 @@ freshness source.
 | Architecture | `ARCHITECTURE.md`, `INTERNALS.md`, `DOLT.md`, `adr/`, `design/` | Durable structure, package boundaries, storage model, and invariants live here. |
 | Behaviour/reference | `CLI_REFERENCE.md`, `CONFIG.md`, `SETUP.md`, `JSON_SCHEMA.md`, `RECOVERY.md`, `ERROR_HANDLING.md`, `TROUBLESHOOTING.md` | CLI/config/runtime contracts live here and need generation or freshness review. |
 | User-facing workflow | `INSTALLING.md`, `QUICKSTART.md`, `FAQ.md`, `SYNC_SETUP.md`, integration guides, `WORKTREES.md`, `UNINSTALLING.md` | Task-oriented user docs live here; avoid duplicating implementation tables unless linked to reference docs. |
-| Maintainer/operator | root `RELEASING.md`, `RELEASE-STABILITY-GATE.md`, `LINTING.md`, `SECURITY-DEPENDENCY-EXCEPTIONS.md`, `PERFORMANCE_TESTING.md`, `CI_TEST_SURFACE_AUDIT.md`, `CI_CLEANUP_PLAN.md` | Maintainer process docs stay active only when tied to current scripts/checks. |
+| Maintainer/operator | root `RELEASING.md`, `RELEASE-STABILITY-GATE.md`, `LINTING.md`, `SECURITY-DEPENDENCY-EXCEPTIONS.md`, `PERFORMANCE_TESTING.md`, `CI_TEST_SURFACE_AUDIT.md`, `CI_CLEANUP_PLAN.md`, `SERVE_RUNBOOK.md` | Maintainer process docs stay active only when tied to current scripts/checks. |
 | Historical/staged | `staged-for-removal/` | Resolved audits, stale duplicates, and unsupported snapshots are preserved here until deleted or rescued. |
 
 ## Reference Freshness
@@ -35,6 +35,7 @@ freshness source.
 | `recovery/init-safety.md` | `Last reviewed:` marker tied to `cmd/bd/init*.go` safety code and tests. (Mintlify port: was `RECOVERY.md`.) |
 | `ERROR_HANDLING.md` | `Last reviewed:` marker tied to current command error exits and JSON error helpers. |
 | `LINTING.md` | `Last reviewed:` marker tied to `.golangci.yml` and current lint output. |
+| `SERVE_RUNBOOK.md` | `Last reviewed:` marker tied to the operating-envelope constants in `internal/httpapi/server.go` and the log fields in its `event`/`request` emitters. |
 | `CI_CLEANUP_PLAN.md` | `Last reviewed:` marker tied to CI audit, workflow files, package manifests, and maintainer decision review. |
 | `design/otel/otel-data-model.md` | `Last reviewed:` marker tied to telemetry, Dolt storage, hooks, and AI call sites. |
 
@@ -70,6 +71,7 @@ Follow-up automation should replace marker-only checks with generated or
 | `COPILOT_CLI_INTEGRATION.md` | Keep | Design doc for GitHub Copilot CLI integration; paired with `COPILOT_INTEGRATION.md` (VS Code + MCP). |
 | `COPILOT_INTEGRATION.md` | Keep | User-facing integration guide. |
 | `DEPENDENCIES.md` | Keep | Behaviour doc for graph semantics. |
+| `design/bd-serve-v0.md` | Keep | `bd serve` v0 contract and the decisions behind it; defers to `internal/httpapi/spec/openapi.v0.yaml`, `internal/httpapi/doc.go` and `issueops/reader.go` as sources of truth. |
 | `design/dolt-concurrency.md` | Keep | Design note for Dolt concurrency. |
 | `design/kv-store.md` | Keep | Draft design note; retain as design seam, not user reference. |
 | `design/otel/otel-architecture.md` | Keep | Architecture/design doc for telemetry; reference tables should defer to data model. |
@@ -110,6 +112,7 @@ Follow-up automation should replace marker-only checks with generated or
 | `ROUTING.md` | Keep | Multi-repo auto-routing design. |
 | `RULES_AUDIT_DESIGN.md` | Keep | Design doc for rules audit. |
 | `SECURITY-DEPENDENCY-EXCEPTIONS.md` | Keep with freshness | Existing freshness-marker exemplar. |
+| `SERVE_RUNBOOK.md` | Keep with freshness | Operator runbook for `bd serve`; the operating envelope it tabulates is constants in `internal/httpapi/server.go` and must be re-checked when they move. |
 | `SETUP.md` | Keep with freshness | Setup reference; marker tied to setup commands and recipes. |
 | `staged-for-removal/MANIFEST.md` | Keep | Staged removal process and per-file rationale. |
 | `superpowers/plans/2026-05-03-unclaim-command.md` | Removed | PR-passenger planning artifact from a contributor's personal multi-agent rig, same class as the artifacts removed in commit 187ba85f3 (#4632); no readers in this repo, content stays in git history. |

--- a/engdocs/SERVE_RUNBOOK.md
+++ b/engdocs/SERVE_RUNBOOK.md
@@ -1,0 +1,251 @@
+# `bd serve` operator runbook
+
+Last reviewed: 2026-08-01 (freshness sources: the operating-envelope constants
+in `internal/httpapi/server.go`, and the fields its `event` emitters write)
+
+Running the v0 HTTP surface. For the contract it serves — the operations, the
+error vocabulary, the cursor, the loopback posture — see
+[design/bd-serve-v0.md](design/bd-serve-v0.md).
+
+Every number below is a constant in `internal/httpapi/server.go` unless stated
+otherwise. They are not flags yet; when they become flags the wire contract does
+not change.
+
+## Deployment
+
+### Pass an explicit port
+
+```
+bd serve --addr 127.0.0.1:7777
+```
+
+The default is `--addr 127.0.0.1:0`, which takes an ephemeral port. That is
+right for ad-hoc and test use, where the bound address printed on stdout is read
+immediately — and it carries **no mutual exclusion**.
+
+Be precise about this, because the tempting shorthand is wrong. "The TCP bind is
+the singleton" holds only for an *explicit* port: two serves against one
+workspace on `:0` bind two different ephemeral ports and run side by side, with
+no way to enumerate them and nothing that fails. On a fixed port the second
+process fails to bind, which is the intended behavior and the only mutual
+exclusion this command has.
+
+Concurrent serves are data-safe either way — claims are arbitrated in the SQL
+server, not in the HTTP process. What you lose without a fixed port is the
+ability to know how many servers you are running, and clients' ability to find
+the one you meant.
+
+There is no lock file, pid file or discovery file. `bd serve` is
+operator-invoked, and on a fixed port the TCP bind *is* the mutual exclusion: a
+second instance fails at bind with the operating system's own address-in-use
+error. Clients are configured with the address; they do not discover it.
+
+The host in `--addr` must be a numeric IP literal; a DNS name is refused.
+
+### Streams
+
+stdout gets exactly one line, at bind time, and nothing else:
+
+```
+bd serve: listening on http://127.0.0.1:7777
+```
+
+That is how a caller who asked for an ephemeral port discovers it — read one
+line from stdout and stop. Everything else, including the request log, goes to
+stderr, so the two can be redirected separately.
+
+### Run it under a supervisor
+
+`bd serve` runs in the foreground and shuts down gracefully on **SIGHUP** as
+well as SIGINT and SIGTERM. SIGHUP is in that set on purpose: closing the
+terminal of a foreground `bd serve` stops it, rather than leaving an orphan
+holding a port and a pool of database connections. A supervisor that
+double-forks and expects the child to survive its controlling terminal must
+either detach the process from the terminal itself or keep it in the
+foreground under the supervisor.
+
+### Binding beyond loopback
+
+`--allow-non-loopback` prints a warning and changes nothing else. There is no
+authentication and no TLS: every peer that can reach the address can read every
+issue and claim work as any actor. Put an authenticating reverse proxy in front
+of it, or do not use the flag.
+
+One behavioral difference follows the flag: `limit=0` (unlimited) is refused on
+both list operations with 400 `invalid_argument`. Clients must page.
+
+## Probes
+
+| Probe | Route | What green means |
+|---|---|---|
+| Liveness | `GET /healthz` | The process is running. |
+| Readiness | `GET /v0/beads/ready?limit=1` | The process is running **and** the database answered. |
+
+`/healthz` answers from the process and never touches the database. It stays
+green while the database is unreachable, wedged, or idle-stopped — which is what
+makes it a correct liveness probe and a useless readiness probe. Do not wire it
+to a load balancer's readiness check.
+
+`GET /v0/beads/ready?limit=1` is a real query with a one-row bound. 200 means
+ready; 503 means live but not ready, and its `code` says which kind:
+`db_unavailable` for a connectivity failure, `busy` for contention or slot
+saturation. Both carry `Retry-After`; a probe should treat either as not-ready
+and retry, not as a hard failure.
+
+Suggested probe settings: the readiness probe inherits the server's 60s
+whole-request deadline as its worst case, so give it a timeout well under that
+(2–5s) and let the probe's own failure threshold do the smoothing.
+
+## Detecting a wedge
+
+The failure mode to plan for is a database that stops answering while the
+process stays healthy. `/healthz` cannot see it. Three signals can:
+
+- **`event=semaphore_saturated`** — a request waited a second or more for a
+  database slot. This is the wedge-detection signal: with no traffic there are no
+  saturation events, so a stream of them distinguishes "wedged" from "quiet".
+  `outcome=acquired` got its slot in the end; `outcome=abandoned` means the
+  client hung up or the request deadline expired while queued, which is the same
+  wedge seen from a request that did not live long enough to be shed.
+- **`event=semaphore_timeout`** — a request waited the full 10s and was shed as
+  503 `busy`.
+- **`event=conn_cap_saturated`** — accepted connections reached the 64
+  connection cap. Logged once per crossing.
+
+Alert on the readiness probe, and use these to tell a wedged database from a
+slow client.
+
+## Connection budget
+
+Size a shared external `dolt sql-server` before pointing several `bd serve`
+processes at it. Every `bd serve` process claims, at steady state:
+
+| Consumer | Connections |
+|---|---|
+| Handler pool, max open (`maxInflight + 4`) | 20 |
+| Root command's `DoltStore`, in server / external-server / shared-server mode | 1–2 idle |
+| **Per-process worst case** | **~22** |
+
+The shape behind those numbers:
+
+- `maxInflight = 16` bounds handlers that touch the database. Each unit of work
+  pins one SQL connection, so that is also the steady-state connection count
+  under load.
+- The pool is sized `maxInflight + 4 = 20` open, 16 idle, because the semaphore
+  bounds *handlers*, not *connections*. A connection poisoned by a failed
+  ROLLBACK is replaced, each retry attempt of a committing transaction opens a
+  fresh unit of work on a fresh pinned connection, and any semaphore-exempt
+  handler that later touches the database escapes the semaphore entirely. The
+  four spare slots absorb that.
+- In server, external-server and shared-server modes the root command has
+  already opened a `DoltStore` that `bd serve` never uses. It stays open for the
+  life of the process and holds an idle connection or two against the very
+  server this process is about to pool twenty more on. Opening and closing it is
+  the root command's business, not one command's — but it is not free, and it
+  belongs in the arithmetic.
+
+So `max_connections` on a shared server must cover roughly `22 × (number of bd
+serve processes)` plus every other `bd` process pointed at the same server,
+each of which claims its own. Idle connections are reclaimed after 5 minutes and
+recycled after an hour, so a bursty deployment settles below the worst case —
+but size for the worst case.
+
+Those pool limits are applied only if the unit-of-work provider exposes the
+knob. If it does not, `bd serve` says so at startup with
+`event=pool_limits_unavailable` and runs with an **unbounded** pool rather than
+silently pretending. Check for that line before trusting the arithmetic above.
+
+`maxConns = 64` bounds *accepted TCP connections*, which is a client-side limit
+and not part of the database budget. It exists because the semaphore does not
+bound connections: Go spawns a goroutine per connection, and one parked on a
+full semaphore still holds its goroutine, file descriptor and buffers. Excess
+connections wait in the kernel accept backlog instead of in Go memory.
+
+## Shutdown, and the ambiguous claim
+
+On SIGINT, SIGTERM or SIGHUP the server stops accepting and drains for up to
+**20 seconds**. The drain deliberately does *not* cancel in-flight handler
+contexts: the budget covers a claim inside its serialization-retry budget plus
+its commit, because killing such a connection early would leave the client
+unable to tell whether its write landed.
+
+If the drain budget is exceeded, remaining connections are closed and
+`event=shutdown_forced` is logged with the count. That is the ambiguous case,
+and it is a client-visible one: a claim killed mid-commit may or may not have
+landed, and the client saw a dropped connection rather than a response.
+
+**Recovery is a re-claim, and it is safe by construction.** A claim is a
+compare-and-set, and a re-claim by the same actor is idempotent: if the first
+attempt landed, the second finds the actor already holds it, returns 200 and
+writes no commit. If the first did not land, the second claims normally. If a
+different actor won in between, the second gets a typed 409 `already_claimed`
+carrying that actor in `assignee` — which is the true answer, not an error to
+retry through.
+
+So the recovery for an ambiguous shutdown is: re-issue the claim with the same
+actor and read the result. Never infer the outcome from the dropped connection,
+and never fall back to reading the issue and guessing.
+
+The same reasoning covers a client that times out, hangs up, or is restarted
+mid-claim. A client hanging up is not counted as a server fault:
+`event=request` records `code=client_closed` and no `request_error` is emitted,
+so an impatient caller does not spike the signal an operator alerts on.
+
+## Request log
+
+One structured line per request on **stderr**, prefixed `bd serve: ` and a UTC
+timestamp from the standard logger:
+
+```
+bd serve: 2026/08/01 05:17:42 event=request request_id=8f3a1c07-000042 op=listReadyWork method=GET path=/v0/beads/ready status=200 code="" duration_ms=12.480 sem_wait_ms=0.031 uow_ms=11.902 conns=1 remote_addr=127.0.0.1:54321
+```
+
+Fields, in order:
+
+| Field | Meaning |
+|---|---|
+| `request_id` | Correlation id, `<per-process random prefix>-<sequence>`. Echoed in the `request_id` member of any problem body. |
+| `op` | The spec's `operationId`. |
+| `method`, `path`, `status` | As sent and answered. |
+| `code` | The problem `code`, or `""` on success. |
+| `duration_ms` | Whole request, milliseconds with three decimals. |
+| `sem_wait_ms` | Time spent waiting for a database slot. |
+| `uow_ms` | Time spent holding the unit of work. |
+| `conns` | Live accepted connections at that moment — watch this climb toward 64. |
+| `remote_addr` | Which client; on loopback the port identifies the local process. |
+| `refused` | Present only when the request was refused for a specific value: the offending value. |
+
+The per-process random prefix means ids from two servers, or two runs of one
+server, never collide in a shared log.
+
+Values are quoted whenever they contain a space, `"`, `=` or any control
+character, and an empty value renders as `""`. That is not cosmetic: without it
+a caller-supplied value — a `Host` header, a rejected parameter, an error
+message — could forge fields or whole lines, and an unquoted C1 control such as
+U+009B is a CSI introducer that would drive the operator's terminal.
+
+Other events on the same stream:
+
+| Event | When |
+|---|---|
+| `startup` | Bound address, mode, workspace, database, host allowlist, capabilities. |
+| `limits` | The operating envelope this build compiled in. Log it, then compare against this page. |
+| `request_error` | Accompanies a ≥500, carrying the real error the body withholds. Join on `request_id`. Not emitted when the client hung up (see above). |
+| `pool_limits_unavailable` | The unit-of-work provider does not expose the pool knob, so the limits below are *not* applied and the pool is unbounded. Worth alerting on; it changes the connection budget. |
+| `panic` | A panicking handler: the value, the stack, and the same `request_id`. |
+| `semaphore_saturated`, `semaphore_timeout`, `conn_cap_saturated` | See [Detecting a wedge](#detecting-a-wedge). |
+| `shutdown_start`, `shutdown_complete`, `shutdown_forced` | The drain. |
+
+A 5xx body carries a fixed static detail by design, so `request_id` is the
+client's only handle on the one line that has the real error. When a user
+reports a 500, ask for the `request_id` and grep for it — the `request` line
+gives the shape, the `request_error` line gives the cause.
+
+## Refusals to expect at startup
+
+| Message | Cause |
+|---|---|
+| `bd serve requires a Dolt SQL server; this workspace uses embedded Dolt` | Permanent. There is no unit-of-work provider for the embedded backend and there will not be one. |
+| `host must be a numeric IP literal, not a name — use 127.0.0.1 rather than localhost` | `--addr` was given a DNS name. |
+| `binds beyond loopback; bd serve has no authentication, so this requires --allow-non-loopback` | A non-loopback `--addr` without the flag. |
+| `address already in use` | The fixed-port mutual exclusion working as intended: a second server is already on that port. |

--- a/engdocs/design/bd-serve-v0.md
+++ b/engdocs/design/bd-serve-v0.md
@@ -1,0 +1,312 @@
+# `bd serve` — the v0 HTTP surface
+
+`bd serve` answers the same work surface the CLI answers, over HTTP, for
+automation clients and orchestrators that would otherwise fork a `bd`
+subprocess per call. It exists because the subprocess-per-call shape has two
+costs a long-running client cannot pay down: process startup on every read, and
+a contract made of stdout text that clients end up parsing.
+
+This page describes the contract and the decisions behind it. For running one,
+see [SERVE_RUNBOOK.md](../SERVE_RUNBOOK.md).
+
+Source of truth, in order:
+
+- `internal/httpapi/spec/openapi.v0.yaml` — the wire contract. Types are
+  generated from it (`make api-gen`); `make api-check` fails a change that
+  edits one without the other.
+- `internal/httpapi/doc.go` — what is live in this build and how the anti-drift
+  properties are enforced.
+- `issueops/reader.go` — the read role both front doors reach.
+
+Nothing here may contradict those three. Where this page summarizes, it says
+so.
+
+## The surface
+
+Six operations, all under `/v0` except liveness.
+
+| Operation | Route | What it answers |
+|---|---|---|
+| `health` | `GET /healthz` | Process liveness. Never touches the database. |
+| `getContext` | `GET /v0/beads/context` | Workspace and API identity, from a startup snapshot. |
+| `listReadyWork` | `GET /v0/beads/ready` | Unblocked open work, in the requested sort order. |
+| `listIssues` | `GET /v0/beads/issues` | A page of issues under the request's filters. |
+| `getIssue` | `GET /v0/beads/issues/{id}` | One issue's detail view. |
+| `claimIssue` | `POST /v0/beads/issues/{id}:claim` | Compare-and-set claim for a caller-named actor. |
+
+`GET /v0/beads/context` reports which operations this build actually
+implements, in `capabilities`. That list is derived from the registered
+handlers rather than hand-maintained, so a release cut mid-slice cannot
+advertise an operation that does not work. Clients probe `capabilities` for
+operation-level support and a 400 `invalid_argument` /
+`reason: "unknown_parameter"` for per-parameter support; there is no
+finer-grained capability document, and there is deliberately no field
+advertising the bind mode.
+
+Response bodies marshal `internal/types` values directly. There is no wire
+struct, so the CLI's `--json` output and these bodies are one compatibility
+domain — which cuts both ways: a serialized field on `types.Issue` cannot be
+renamed or removed without breaking the HTTP contract, not just the CLI's.
+
+### What the reads share with the CLI
+
+The reads hold no query logic of their own. Each decodes its parameters and
+hands the whole request to `issueops.Reader` — the same role, reached the same
+way, that `bd show --json` reaches on a store. Filter construction, the
+workspace config it depends on, the default limits and the wisp fallback all
+live inside that role, so a handler cannot half-perform that construction and
+answer the same question a different way.
+
+The exact scope of that property, and its limits, are stated in
+[The claim](#the-claim) below. It is a narrower property than "the CLI and the
+API cannot disagree", and the difference matters.
+
+## The error-code vocabulary
+
+Every non-2xx byte is an RFC 9457 `application/problem+json` document. There is
+one error shape. The mapping from sentinel error to status and code lives
+entirely in `internal/httpapi/problem.go` and is matched exclusively with
+`errors.Is`/`errors.As` — never `err != nil -> status`.
+
+`code` is the machine-readable member and the only member a client may dispatch
+on.
+
+| Code | Status | Meaning | Recovery |
+|---|---|---|---|
+| `invalid_argument` | 400 | Request validation refused it. Carries `param` and `reason`. | Send something different. Never retry. |
+| `invalid_cursor` | 400 | A cursor this server did not issue, cannot decode, or issued under a different encoding version. | Restart paging with no `cursor`. |
+| `not_found` | 404 | No issue or wisp with that id. | — |
+| `already_claimed` | 409 | Another actor holds the claim. Carries `assignee`. | — |
+| `not_claimable` | 409 | The issue is not in a claimable state. Carries `issue_status`. | — |
+| `busy` | 503 | Retryable contention: the transaction retry budget was spent, or the in-flight limit was saturated. Carries `Retry-After`. | Retry after the header's delay. |
+| `db_unavailable` | 503 | Retryable connectivity failure reaching the database. Carries `Retry-After`. | Retry after the header's delay. |
+| `internal` | 500 | Anything else. | — |
+
+`reason` splits the two client postures behind a 400 `invalid_argument`, so
+telling them apart never requires parsing `detail`:
+
+- `unknown_parameter` — this server does not know that parameter. Version skew;
+  the client degrades or falls back.
+- `invalid_value` — the server will not act on that value: malformed, outside
+  the vocabulary, or legal-but-refused in this server's configuration.
+
+The vocabulary is a one-way door. Renaming or removing a documented
+status+code pair breaks the wire; adding one does not, which is why clients are
+told to default-branch on unknown codes within a status class.
+`TestSpecStatusCodesMatchHandlerTable` asserts set-equality in both directions
+between the handler table and the spec, so an undocumented emission and an
+unemittable documented status both fail CI.
+
+Two rules govern what a problem body may say. A 5xx `detail` is a fixed string
+per code, whatever the underlying error was: driver and dial errors routinely
+embed the DSN, and query errors can carry SQL fragments, so a verbose 5xx
+detail becomes an information-disclosure channel the moment the server is bound
+with `--allow-non-loopback`. A 4xx `detail` stays specific, because it reflects
+the caller's own input back rather than server state. The real error goes to
+the server log, correlated by the `request_id` the 5xx body carries — that id
+is the client's only handle on the one log line that has it.
+
+### Why typed conflicts matter for adopting clients
+
+A client that classified claim conflicts by substring-matching error text
+("already assigned to", "claimed by") should switch to the typed 409 code. The
+`assignee` and `issue_status` extension members come from a read inside the
+losing transaction, never from parsing fragments out of the sentinel's message.
+That substring classification is exactly what an adopting client gets to
+delete, and it can only delete it because the server never does it either.
+
+## The cursor contract
+
+`GET /v0/beads/issues` pages with an opaque keyset cursor.
+`GET /v0/beads/ready` does not: the ready sort policies admit no keyset
+predicate, and the intended usage there is snapshot-and-requery.
+
+Four properties, all normative:
+
+**Opaque.** Clients must not construct, parse or mutate a cursor. The encoding
+is server-private and version-prefixed. It is base64 of a small JSON object,
+which is legible enough that someone will read it — so the contract is enforced
+by the version prefix rather than by obscurity. A client that mints its own
+token gets `invalid_cursor` the moment the encoding moves.
+
+**No lifetime.** The token carries a position and a private encoding version,
+and nothing else. The server keeps no state for it, so it does not expire, does
+not become invalid across a restart, and is not tied to the connection that
+issued it. The only thing that invalidates one is an encoding change.
+
+**One recovery.** Every failure mode — wrong version, undecodable base64,
+malformed JSON, an empty position — is the same answer, because it is the same
+client situation: restart paging with no `cursor`. Re-sending the value cannot
+succeed.
+
+**Misuse is not detectable.** Because the token carries no filters, a page
+fetched with a cursor minted under different filters is *not* refused. The
+server applies the current request's filters from the old request's position,
+silently skipping every row the new filter set would have placed before it.
+Repeat every filter verbatim for the whole traversal, and start a new traversal
+when they change.
+
+That last property is a deliberate trade. Embedding the filters would make the
+token a second, opaque copy of the request that can disagree with the request
+itself; keeping it a bare position makes the failure mode a documented client
+obligation instead of a hidden server-side reconciliation.
+
+## The loopback posture
+
+v0 has no authentication and no TLS. The trust model is the loopback boundary
+— the same boundary the database behind it already relies on.
+
+`--addr` defaults to `127.0.0.1:0`. The host must be a numeric IP literal.
+`--allow-non-loopback` is the operator decision to bind beyond loopback; it is
+never taken by default, it prints a warning naming what it exposes, and nothing
+else about the server changes. Every peer that can reach the address gets full
+read and claim access.
+
+Three things bound the posture regardless of bind mode:
+
+**The Host allowlist**, which has no off switch. An unauthenticated service on
+loopback is reachable from any browser on the host, and a page that re-resolves
+its own name to `127.0.0.1` issues requests the browser treats as same-origin,
+so no CORS rule stops them. What the browser does preserve is the attacker's
+hostname in `Host`, which is what this rejects. Every bind answers to the
+loopback spellings and to the bound address itself. A *wildcard* bind (`0.0.0.0`,
+`::`) has no single configured address, so it answers to any numeric IP literal
+and still refuses foreign DNS names — a rebound page cannot produce an
+IP-literal `Host`, because the browser sends the hostname from the attacker's
+URL. Matching is on parsed addresses, so every spelling of an allowed address
+is allowed.
+
+**The JSON-only content type on the claim**, which is a CSRF control rather
+than pedantry: a JSON content type is not CORS-"simple", so a cross-origin
+claim always triggers a preflight this server never approves. Accepting
+`text/plain` or a form encoding would let a page skip the preflight and drive
+the one write on this surface from any browser on the host.
+
+**The mode-dependent refusal of an unlimited read.** `limit=0` means unlimited
+on both list operations, exactly as `bd list --limit 0` does — except under
+`--allow-non-loopback`, where it is refused with 400 `invalid_argument`,
+`param: "limit"`, `reason: "invalid_value"`. An unlimited read buffers the
+whole active set and its JSON encoding inside one shared process, which must
+not be reachable by arbitrary network peers. The bind mode is deliberately not
+advertised in `ContextResponse`: a client that wants an unlimited read asks for
+one and, on that 400, re-issues with an explicit limit and pages with `cursor`.
+It is a client-side fix, never a retry.
+
+An `actor` on an HTTP request is caller-asserted provenance for the audit
+trail, not authenticated identity — the same thing it has always been on the
+CLI, where any local process can pass any `--actor`. The claim's
+compare-and-set is therefore a correctness fence against *concurrent* claims,
+not an authorization boundary: it guarantees that two racing claimants cannot
+both win, and guarantees nothing about who either of them really is.
+
+## No hooks
+
+Hooks do not fire on an HTTP claim. A CLI claim runs `on_update`; this does
+not.
+
+A hook is a user-controlled subprocess per mutation. In a concurrent server
+that is an unbounded latency multiplier and an orphaned child at shutdown, and
+the working-directory-derived hook lookup that finds them is meaningless in a
+server process that does not share the client's working directory.
+
+This is a contract statement, not a gap to be closed later. A client that needs
+hook side effects on a claim runs the claim through the CLI.
+
+## No auto-commit
+
+The per-command auto-commit, export and push maintenance that wraps a CLI
+invocation does not run here. Durability is per request: a successful claim
+commits inside its own transaction, exactly as a proxied CLI claim does today.
+
+Two consequences worth stating for an adopting client:
+
+- There is no end-of-process flush. Anything the server did is already durable
+  when the response is written, or it is not going to be.
+- An idempotent re-claim by the current holder writes no commit. The
+  compare-and-set matched no row because there was nothing to change, and an
+  empty commit message tells the transaction runner to skip the commit — so a
+  polling client cannot mint an empty storage commit per call.
+
+## Claim throughput
+
+The claim is the only mutation in v0, and its cost is a storage commit. Sizing
+follows from that, not from HTTP:
+
+- **A claim that changes something commits.** Its throughput ceiling is the
+  store's write path, which serializes commits, and not the request pipeline in
+  front of it. HTTP concurrency does not raise that ceiling.
+- **Contention surfaces as a retryable 503, not as a stall.** The transaction
+  runner spends a serialization-retry budget internally; exhausting it produces
+  `busy` with `Retry-After: 5`. That delay is deliberately not one second: the
+  budget already spans many seconds of observed write contention, and a
+  one-second comeback invites a convoy of retries that each hold a database
+  slot while they wait, starving reads exactly when the server is busiest.
+- **Saturation surfaces as the same code with a shorter delay.** A request that
+  cannot get a database slot within the bounded wait is also `busy`, with
+  `Retry-After: 1`, because slot pressure clears quickly. Shedding load
+  introduces no new status vocabulary — one code, two delays, and the header is
+  the thing to obey.
+- **An idempotent re-claim costs no commit** (above), so a client polling to
+  confirm it still holds a claim does not consume write throughput.
+- **Reads are bounded by slots, not by commits.** Every database-touching
+  handler holds one of a fixed number of in-flight slots, and each slot pins one
+  SQL connection. The arithmetic is in
+  [SERVE_RUNBOOK.md](../SERVE_RUNBOOK.md#connection-budget).
+
+Wisps are not claimable over v0. The claim dispatches to the issues table only,
+so a wisp id answers 404.
+
+## The claim
+
+Carried across from `internal/httpapi/doc.go` and `issueops/reader.go`, which
+are the source of truth for it. Stated once and in full so it can be checked
+sentence by sentence, and deliberately not strengthened here.
+
+**SHARED.** All three issue reads on this surface go through `issueops.Reader`,
+and so does `bd show --json`'s detail view on both its routes. `bd list` and
+`bd ready` are *not* on the role and share instead the request types, the two
+builders in `internal/workapi` that their golden files pin, and
+`workapi.FinishPage` — `bd list` on both routes in every mode but the
+hierarchical `--parent` tree, `bd ready` on its proxied route only.
+
+**ENFORCED, and by what.** depguard (`httpapi-transport-boundary`) denies
+`internal/workapi` from every non-test file of `internal/httpapi`, so no builder
+is callable there; a forbidigo rule denies naming `types.IssueFilter` or
+`types.WorkFilter` there at all, so no filter is writable there either. Both
+are directory-scoped with no per-file exception, so a file added to that package
+tomorrow is covered the moment it exists. That same forbidigo rule covers
+`cmd/bd` deny-by-default with 64 named exceptions, so the files implementing
+`bd list` and `bd show` cannot write a filter, and neither can a file they are
+split or renamed into unless the new name lands on that list.
+
+**NOT ENFORCED.** The rule forbids *naming* those types, not holding a value,
+so the property is "no filter is written there", not "every filter there came
+from a builder". Test files are exempt from both rules, because the oracles hold
+filters in order to inspect them. `bd ready`'s files are among the 64, since its
+listing and `--claim` are handed the filter itself and the blocked-issue views in
+those files name one directly, so it is guarded by the builder and the golden
+files and not by the linter. `GET /healthz` and
+`GET /v0/beads/context` are not issue queries and are on no role. `bd ready`'s
+direct route and `bd list`'s hierarchical tree run epilogues of their own. And
+none of this is a merge gate: the rules run in `make ci-pr-lint` on every pull
+request and aggregate into the `ci-gate` job, but main carries no branch
+protection beyond deletion and non-fast-forward, so no check is GitHub-required
+and a red gate binds by convention.
+
+Closing the rest needs more roles — a claim role, an explain role — not more
+methods on the read one.
+
+## Workspace modes
+
+`bd serve` refuses exactly one workspace mode, permanently: embedded Dolt.
+There is no unit-of-work provider for that backend and there will not be one.
+Its commit protocol runs outside the SQL transaction on a separate connection,
+so the per-request atomicity this contract states would be a lie there even if
+a provider were written. The refusal names the workspace and what serve needs,
+and promises nothing further.
+
+Every mode with a SQL server behind it is served: proxied (managed or
+external), and server, external-server and shared-server. In the latter three
+the root command has already opened a `DoltStore` that serve never uses; serve
+builds its own unit-of-work provider from the same connection settings. That
+idle store matters only for the connection budget — see the runbook.

--- a/issueops/reader.go
+++ b/issueops/reader.go
@@ -302,8 +302,9 @@ type IssuePage struct {
 // value, so the property is "no filter is written there", not "every filter
 // there came from a builder"; test files are exempt from both rules, because
 // the oracles hold filters in order to inspect them; `bd ready`'s files are
-// among the 64, since its four flag-driven modes are handed the filter itself,
-// so it is guarded by the builder and the golden files and not by the linter;
+// among the 64, since its listing and --claim are handed the filter itself and
+// the blocked-issue views in those files name one directly, so it is guarded by
+// the builder and the golden files and not by the linter;
 // GET /healthz and GET /v0/beads/context are not issue queries and are on no
 // role; `bd ready`'s direct route and `bd list`'s hierarchical tree run
 // epilogues of their own; and none of this is a merge gate — the rules run in


### PR DESCRIPTION
Follow-ups deliberately left behind by #5208 (`bd serve` v0). Three beads, one branch.

## bd-3fs.2 (P1 bug) — a backend failure was reported as "issue not found"

`proxiedResolveIssueOrWisp` discarded the lookup error entirely and returned `(nil, false)`, so a
missing issue and a dropped connection were indistinguishable to every caller. This is the same bug
class #5208 was written to kill — the viewer's `if err != nil || issue == nil` → 404, and its mirror
image, missing-issue-500 — surviving in one helper that the earlier extraction did not reach.

The helper is now gone: **0 references remain**. It reached further than the original estimate —
`close`, `comments`, `defer`, `label`, `mutate`, `reopen`, `state`, `todo` and `unclaim` proxied
servers all had to move onto the normalizing seam.

The seam asymmetry is respected rather than papered over: the store path already falls back from
issues to wisps itself and returns a wrapped `storage.ErrNotFound`, so only the domain path needs
normalizing. Over-normalizing the store side would be its own bug.

## bd-3fs.3 — the third copy of the ready default

`runReadyExplain` and `runReadyProxiedExplain` each inlined
`WorkFilter{Status: StatusOpen, SortPolicy: SortPolicyPriority}` rather than deriving it. Both now
derive from `workapi`, so the ready default has one definition. Low stakes on its own — the explain
paths are diagnostic, so drift there misleads rather than breaks — but it was the last inline copy.

## bd-bzw — docs

`engdocs/design/bd-serve-v0.md` and `engdocs/SERVE_RUNBOOK.md`, plus a `DOC_INVENTORY` entry.

The runbook carries the operational facts the design committed to and which are easy to get wrong:
with the default `--addr 127.0.0.1:0` there is **no** mutual exclusion — N servers run in parallel on
different ephemeral ports, so "the TCP bind is the singleton" holds only for an explicit fixed port.
`/healthz` is liveness-only; `GET /v0/beads/ready?limit=1` is the readiness probe. Plus the
SIGHUP/supervisor note, ambiguous-shutdown re-claim recovery, connection-budget arithmetic for a
shared external Dolt server, and the request-log format.

The design page carries the claim paragraph from `internal/httpapi/doc.go` and `issueops/reader.go`
unchanged — SHARED / ENFORCED-and-by-what / NOT-ENFORCED. It is deliberately not strengthened: the
guard forbids *writing* a filter in the guarded trees, which is not the same as proving every filter
came from a builder, and `bd ready`/`bd list` are still not on the Reader role.

Written vendor-neutrally: generic automation clients, no product or downstream names, every decision
motivated from the API contract itself.

## Verification

Build, vet and lint clean (golangci-lint v2.10.1 under `GOTOOLCHAIN=go1.26.5`, 0 issues). Protocol
corpus unchanged structurally and verified behaviourally — `TestCorpusGolden` with
`BEADS_PROTOCOL_REQUIRE_DOLT=1` so a missing container hard-fails rather than skipping.

One caveat stated plainly: a full local `./cmd/bd` run fails 22 tests on this machine — and fails the
**same 22 on pristine `origin/main`**, verified in a detached worktree. They are init/config/doctor
tests this branch does not touch, and they appear to be environmental to a loaded host rather than
main breakage, since #5208's CI was fully green. Local full-package runs are therefore not a usable
signal here; CI is the gate.
