### PR TITLE
ci: retry transient Dolt image pull failures

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -525,7 +525,7 @@ jobs:
       - name: Pull Dolt sql-server image
         # Keep tag in sync with internal/testutil/testdoltcommon.go:DoltDockerImage.
         # Without this, RequireDoltContainer reports doltNoImage and TestDomainDB skips.
-        run: docker pull dolthub/dolt-sql-server:2.2.0
+        run: ./scripts/ci/pull-dolt-image.sh
 
       - name: Download build artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
@@ -774,7 +774,7 @@ jobs:
         # The shared proxied harness requires the image cached locally
         # (isDoltImageCached); without it every proxied test self-skips. Keep the
         # tag in sync with internal/testutil/testdoltcommon.go:DoltDockerImage.
-        run: docker pull dolthub/dolt-sql-server:2.2.0
+        run: ./scripts/ci/pull-dolt-image.sh
 
       - name: Test proxied-server cmd shard
         env:

--- a/.github/workflows/pr-risk.yml
+++ b/.github/workflows/pr-risk.yml
@@ -80,7 +80,7 @@ jobs:
         # The shared proxied harness requires the image cached locally
         # (isDoltImageCached); without it every proxied test self-skips. Keep the
         # tag in sync with internal/testutil/testdoltcommon.go:DoltDockerImage.
-        run: docker pull dolthub/dolt-sql-server:2.2.0
+        run: ./scripts/ci/pull-dolt-image.sh
 
       - name: Test proxied-server cmd shard
         env:
@@ -259,7 +259,7 @@ jobs:
         # Presence of this image flips isDoltImageCached() true, so the suite
         # exercises server Dolt instead of self-skipping. Keep the tag in sync
         # with internal/testutil/testdoltcommon.go:DoltDockerImage.
-        run: docker pull dolthub/dolt-sql-server:2.2.0
+        run: ./scripts/ci/pull-dolt-image.sh
 
       - name: Test
         # Server twin of test-embedded-conformance: same conformance.RunAll, but

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -488,7 +488,7 @@ jobs:
       - name: Pull Dolt sql-server image
         # Keep tag in sync with internal/testutil/testdoltcommon.go:DoltDockerImage.
         # Without this, RequireDoltContainer reports doltNoImage and TestDomainDB skips.
-        run: docker pull dolthub/dolt-sql-server:2.2.0
+        run: ./scripts/ci/pull-dolt-image.sh
 
       - name: Download build artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
@@ -558,7 +558,7 @@ jobs:
 
       - name: Pull Dolt sql-server image
         # Keep tag in sync with internal/testutil/testdoltcommon.go:DoltDockerImage.
-        run: docker pull dolthub/dolt-sql-server:2.2.0
+        run: ./scripts/ci/pull-dolt-image.sh
 
       - name: Protocol conformance + corpus golden + determinism
         # Require a live Dolt store here: this is the gate that must exercise the

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -109,7 +109,7 @@ jobs:
         # has a known cleanup race (see beads issue: TestCreateWithParentFlag
         # TempDir RemoveAll "directory not empty" flake). Keep the tag in sync
         # with internal/testutil/testdoltcommon.go:DoltDockerImage.
-        run: docker pull dolthub/dolt-sql-server:2.2.0
+        run: ./scripts/ci/pull-dolt-image.sh
 
       - name: Cache baseline binary
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v5

--- a/scripts/ci/pull-dolt-image.sh
+++ b/scripts/ci/pull-dolt-image.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Keep this tag in sync with internal/testutil/testdoltcommon.go:DoltDockerImage.
+readonly image="dolthub/dolt-sql-server:2.2.0"
+readonly max_attempts=3
+readonly retry_delay_seconds=5
+
+for ((attempt = 1; attempt <= max_attempts; attempt++)); do
+  if docker pull "$image"; then
+    exit 0
+  else
+    status=$?
+  fi
+
+  if ((attempt == max_attempts)); then
+    printf 'Failed to pull %s after %d attempts.\n' "$image" "$max_attempts" >&2
+    exit "$status"
+  fi
+
+  printf 'Failed to pull %s (attempt %d/%d); retrying in %d seconds.\n' \
+    "$image" "$attempt" "$max_attempts" "$retry_delay_seconds" >&2
+  sleep "$retry_delay_seconds"
+done

--- a/scripts/pull_dolt_image_test.go
+++ b/scripts/pull_dolt_image_test.go
@@ -1,0 +1,196 @@
+package scripts_test
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+const doltSQLServerImage = "dolthub/dolt-sql-server:2.2.0"
+
+func TestPullDoltImageRetriesTransientFailures(t *testing.T) {
+	tests := []struct {
+		name       string
+		failures   int
+		wantExit   int
+		wantPulls  int
+		wantSleeps int
+	}{
+		{name: "immediate success", failures: 0, wantExit: 0, wantPulls: 1, wantSleeps: 0},
+		{name: "eventual success", failures: 2, wantExit: 0, wantPulls: 3, wantSleeps: 2},
+		{name: "exhausted retries", failures: 3, wantExit: 42, wantPulls: 3, wantSleeps: 2},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			run := runPullDoltImage(t, test.failures)
+			if got := pullDoltExitCode(run.err); got != test.wantExit {
+				t.Fatalf("exit = %d, want %d; error=%v\n%s", got, test.wantExit, run.err, run.output)
+			}
+			if len(run.dockerCalls) != test.wantPulls {
+				t.Fatalf("docker pull count = %d, want %d; calls=%q\n%s", len(run.dockerCalls), test.wantPulls, run.dockerCalls, run.output)
+			}
+			for _, call := range run.dockerCalls {
+				if call != "pull "+doltSQLServerImage {
+					t.Fatalf("docker call = %q, want %q", call, "pull "+doltSQLServerImage)
+				}
+			}
+			if len(run.sleepCalls) != test.wantSleeps {
+				t.Fatalf("sleep count = %d, want %d; calls=%q\n%s", len(run.sleepCalls), test.wantSleeps, run.sleepCalls, run.output)
+			}
+			for _, call := range run.sleepCalls {
+				if call != "5" {
+					t.Fatalf("sleep call = %q, want 5", call)
+				}
+			}
+		})
+	}
+}
+
+func TestDoltImagePullWorkflowsUseRetryHelper(t *testing.T) {
+	wantCalls := map[string]int{
+		"main.yml":       2,
+		"pr.yml":         2,
+		"pr-risk.yml":    2,
+		"regression.yml": 1,
+	}
+
+	workflowsDir := filepath.Join(sourceRepoRoot(t), ".github", "workflows")
+	for name, want := range wantCalls {
+		data, err := os.ReadFile(filepath.Join(workflowsDir, name))
+		if err != nil {
+			t.Fatal(err)
+		}
+		text := string(data)
+		if got := strings.Count(text, "run: ./scripts/ci/pull-dolt-image.sh"); got != want {
+			t.Errorf("%s retry-helper calls = %d, want %d", name, got, want)
+		}
+	}
+
+	workflowPaths, err := filepath.Glob(filepath.Join(workflowsDir, "*.y*ml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, path := range workflowPaths {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if strings.Contains(string(data), "docker pull "+doltSQLServerImage) {
+			t.Errorf("%s still pulls the Dolt image without retries", filepath.Base(path))
+		}
+	}
+}
+
+func TestPullDoltImageHelperIsExecutable(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows does not preserve Unix executable bits")
+	}
+
+	path := filepath.Join(sourceRepoRoot(t), "scripts", "ci", "pull-dolt-image.sh")
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm()&0o111 == 0 {
+		t.Fatalf("%s is not executable", path)
+	}
+}
+
+type pullDoltRun struct {
+	output      string
+	dockerCalls []string
+	sleepCalls  []string
+	err         error
+}
+
+func runPullDoltImage(t *testing.T, failures int) pullDoltRun {
+	t.Helper()
+
+	bash, err := exec.LookPath("bash")
+	if err != nil {
+		t.Skipf("bash is required to test pull-dolt-image.sh: %v", err)
+	}
+
+	bin := t.TempDir()
+	stateDir := t.TempDir()
+	dockerLog := filepath.Join(stateDir, "docker-calls")
+	sleepLog := filepath.Join(stateDir, "sleep-calls")
+	for _, path := range []string{dockerLog, sleepLog} {
+		if err := os.WriteFile(path, nil, 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	writeExecutable(t, filepath.Join(bin, "docker"), `#!/bin/sh
+set -eu
+count=0
+if [ -s "$DOLT_PULL_CALL_COUNT" ]; then
+  IFS= read -r count <"$DOLT_PULL_CALL_COUNT"
+fi
+count=$((count + 1))
+printf '%s\n' "$count" >"$DOLT_PULL_CALL_COUNT"
+printf '%s\n' "$*" >>"$DOLT_PULL_DOCKER_LOG"
+if [ "$count" -le "$DOLT_PULL_FAILURES" ]; then
+  exit 42
+fi
+`)
+	writeExecutable(t, filepath.Join(bin, "sleep"), `#!/bin/sh
+set -eu
+printf '%s\n' "$*" >>"$DOLT_PULL_SLEEP_LOG"
+`)
+
+	binPath := shellPath(t, bin)
+	statePath := shellPath(t, stateDir)
+	path := binPath + ":" + os.Getenv("PATH") + ":/usr/bin:/bin"
+	if runtime.GOOS == "windows" {
+		path = binPath + ":/usr/bin:/bin"
+	}
+	cmd := exec.Command(bash, "scripts/ci/pull-dolt-image.sh")
+	cmd.Dir = sourceRepoRoot(t)
+	cmd.Env = []string{
+		"PATH=" + path,
+		"LC_ALL=C",
+		"LANG=C",
+		"BASH_ENV=",
+		"ENV=",
+		"DOLT_PULL_CALL_COUNT=" + statePath + "/docker-call-count",
+		"DOLT_PULL_DOCKER_LOG=" + statePath + "/docker-calls",
+		"DOLT_PULL_SLEEP_LOG=" + statePath + "/sleep-calls",
+		"DOLT_PULL_FAILURES=" + strconv.Itoa(failures),
+	}
+	output, runErr := cmd.CombinedOutput()
+
+	dockerCalls := readCallLines(t, dockerLog)
+	sleepCalls := readCallLines(t, sleepLog)
+	return pullDoltRun{output: string(output), dockerCalls: dockerCalls, sleepCalls: sleepCalls, err: runErr}
+}
+
+func readCallLines(t *testing.T, path string) []string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := strings.TrimSpace(string(data))
+	if text == "" {
+		return nil
+	}
+	return strings.Split(text, "\n")
+}
+
+func pullDoltExitCode(err error) int {
+	if err == nil {
+		return 0
+	}
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		return exitErr.ExitCode()
+	}
+	return -1
+}


### PR DESCRIPTION
## What

Add a shared CI helper that retries the pinned Dolt SQL-server image pull up to three times, preserving the final `docker pull` exit status. Route all seven pull steps in the Main, PR, PR Risk, and Regression workflows through it.

The helper has automated coverage for immediate success, transient failures followed by success, exhausted retries, the executable bit, and complete workflow wiring.

## Why

Two historical proxied-server shards failed solely because Docker Hub timed out while serving `dolthub/dolt-sql-server:2.2.0`. A one-shot pull turns that transient registry failure into a red test shard even though the repository code is healthy.

The retry is bounded to three attempts with five-second gaps. It does not change the image version, job matrix, or which tests run.

Tracked by `bd-m0o1z` as part of the `origin/main` CI audit (`bd-qouky`).

## Verification

- `make test`
- `make ci-pr-policy`
- `make ci-pr-lint`
- `go test ./scripts -run 'Test(PullDoltImage|DoltImagePullWorkflows)' -count=1`
- `shellcheck scripts/ci/pull-dolt-image.sh`
- `actionlint .github/workflows/main.yml .github/workflows/pr.yml .github/workflows/pr-risk.yml .github/workflows/regression.yml`

_codex-unknown-model-unknown-reasoning on behalf of CI Bot_
