### PR TITLE
refactor(test): replace state-label store fixtures with pure projections

### DIFF
--- a/cmd/bd/state.go
+++ b/cmd/bd/state.go
@@ -64,14 +64,7 @@ Examples:
 			return HandleErrorRespectJSON("%v", err)
 		}
 
-		prefix := dimension + ":"
-		var value string
-		for _, label := range labels {
-			if strings.HasPrefix(label, prefix) {
-				value = strings.TrimPrefix(label, prefix)
-				break
-			}
-		}
+		value, _ := findStateLabel(labels, dimension)
 
 		if jsonOutput {
 			result := map[string]interface{}{
@@ -160,15 +153,10 @@ The --reason flag provides context for the event bead (recommended).`,
 			return HandleErrorRespectJSON("%v", err)
 		}
 
-		prefix := dimension + ":"
-		var oldLabel string
-		var oldValue string
-		for _, label := range labels {
-			if strings.HasPrefix(label, prefix) {
-				oldLabel = label
-				oldValue = strings.TrimPrefix(label, prefix)
-				break
-			}
+		oldValue, found := findStateLabel(labels, dimension)
+		oldLabel := ""
+		if found {
+			oldLabel = dimension + ":" + oldValue
 		}
 
 		newLabel := dimension + ":" + newValue
@@ -308,14 +296,7 @@ Example:
 			return HandleErrorRespectJSON("%v", err)
 		}
 
-		states := make(map[string]string)
-		for _, label := range labels {
-			if idx := strings.Index(label, ":"); idx > 0 {
-				dimension := label[:idx]
-				value := label[idx+1:]
-				states[dimension] = value
-			}
-		}
+		states := collectStateLabels(labels)
 
 		if jsonOutput {
 			return outputJSON(map[string]interface{}{
@@ -351,3 +332,23 @@ func init() {
 
 // Ensure ctx is available
 var _ context.Context = rootCtx
+
+func findStateLabel(labels []string, dimension string) (string, bool) {
+	prefix := dimension + ":"
+	for _, label := range labels {
+		if strings.HasPrefix(label, prefix) {
+			return strings.TrimPrefix(label, prefix), true
+		}
+	}
+	return "", false
+}
+
+func collectStateLabels(labels []string) map[string]string {
+	states := make(map[string]string)
+	for _, label := range labels {
+		if index := strings.Index(label, ":"); index > 0 {
+			states[label[:index]] = label[index+1:]
+		}
+	}
+	return states
+}

--- a/cmd/bd/state_test.go
+++ b/cmd/bd/state_test.go
@@ -1,265 +1,112 @@
-//go:build cgo
-
 package main
 
-import (
-	"context"
-	"os"
-	"path/filepath"
-	"strings"
-	"testing"
+import "testing"
 
-	"github.com/steveyegge/beads/internal/storage/dolt"
-	"github.com/steveyegge/beads/internal/types"
-)
+func TestFindStateLabel(t *testing.T) {
+	t.Parallel()
 
-type stateTestHelper struct {
-	s   *dolt.DoltStore
-	ctx context.Context
-	t   *testing.T
-}
-
-func (h *stateTestHelper) createIssue(title string, issueType types.IssueType, priority int) *types.Issue {
-	issue := &types.Issue{
-		Title:     title,
-		Priority:  priority,
-		IssueType: issueType,
-		Status:    types.StatusOpen,
+	tests := []struct {
+		name      string
+		labels    []string
+		dimension string
+		wantValue string
+		wantFound bool
+	}{
+		{
+			name:      "first exact dimension match wins",
+			labels:    []string{"mode:normal", "mode:degraded"},
+			dimension: "mode",
+			wantValue: "normal",
+			wantFound: true,
+		},
+		{
+			name:      "retains colons in value",
+			labels:    []string{"error:code:500"},
+			dimension: "error",
+			wantValue: "code:500",
+			wantFound: true,
+		},
+		{
+			name:      "empty value is found",
+			labels:    []string{"mode:"},
+			dimension: "mode",
+			wantValue: "",
+			wantFound: true,
+		},
+		{
+			name:      "does not match dimension prefix without colon",
+			labels:    []string{"mode-extra:degraded"},
+			dimension: "mode",
+			wantValue: "",
+			wantFound: false,
+		},
+		{
+			name:      "missing dimension",
+			labels:    []string{"mode:normal"},
+			dimension: "health",
+			wantValue: "",
+			wantFound: false,
+		},
 	}
-	if err := h.s.CreateIssue(h.ctx, issue, "test-user"); err != nil {
-		h.t.Fatalf("Failed to create issue: %v", err)
-	}
-	return issue
-}
 
-func (h *stateTestHelper) addLabel(issueID, label string) {
-	if err := h.s.AddLabel(h.ctx, issueID, label, "test-user"); err != nil {
-		h.t.Fatalf("Failed to add label '%s': %v", label, err)
-	}
-}
-
-func (h *stateTestHelper) removeLabel(issueID, label string) {
-	if err := h.s.RemoveLabel(h.ctx, issueID, label, "test-user"); err != nil {
-		h.t.Fatalf("Failed to remove label '%s': %v", label, err)
-	}
-}
-
-func (h *stateTestHelper) getLabels(issueID string) []string {
-	labels, err := h.s.GetLabels(h.ctx, issueID)
-	if err != nil {
-		h.t.Fatalf("Failed to get labels: %v", err)
-	}
-	return labels
-}
-
-// getStateValue extracts the value for a dimension from labels
-func (h *stateTestHelper) getStateValue(issueID, dimension string) string {
-	labels := h.getLabels(issueID)
-	prefix := dimension + ":"
-	for _, label := range labels {
-		if strings.HasPrefix(label, prefix) {
-			return strings.TrimPrefix(label, prefix)
-		}
-	}
-	return ""
-}
-
-// getStates extracts all dimension:value labels as a map
-func (h *stateTestHelper) getStates(issueID string) map[string]string {
-	labels := h.getLabels(issueID)
-	states := make(map[string]string)
-	for _, label := range labels {
-		if idx := strings.Index(label, ":"); idx > 0 {
-			dimension := label[:idx]
-			value := label[idx+1:]
-			states[dimension] = value
-		}
-	}
-	return states
-}
-
-func (h *stateTestHelper) assertStateValue(issueID, dimension, expected string) {
-	actual := h.getStateValue(issueID, dimension)
-	if actual != expected {
-		h.t.Errorf("Expected %s=%s, got %s=%s", dimension, expected, dimension, actual)
-	}
-}
-
-func (h *stateTestHelper) assertNoState(issueID, dimension string) {
-	value := h.getStateValue(issueID, dimension)
-	if value != "" {
-		h.t.Errorf("Expected no %s state, got %s", dimension, value)
-	}
-}
-
-func (h *stateTestHelper) assertStateCount(issueID string, expected int) {
-	states := h.getStates(issueID)
-	if len(states) != expected {
-		h.t.Errorf("Expected %d states, got %d: %v", expected, len(states), states)
-	}
-}
-
-func TestStateQueries(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "bd-test-state-*")
-	if err != nil {
-		t.Fatalf("Failed to create temp dir: %v", err)
-	}
-	defer os.RemoveAll(tmpDir)
-
-	testDB := filepath.Join(tmpDir, "test.db")
-	s := newTestStore(t, testDB)
-	defer s.Close()
-
-	ctx := context.Background()
-	h := &stateTestHelper{s: s, ctx: ctx, t: t}
-
-	t.Run("query state from label", func(t *testing.T) {
-		issue := h.createIssue("Role Test", types.TypeTask, 1)
-		h.addLabel(issue.ID, "patrol:active")
-		h.assertStateValue(issue.ID, "patrol", "active")
-	})
-
-	t.Run("query multiple states", func(t *testing.T) {
-		issue := h.createIssue("Multi State Test", types.TypeTask, 1)
-		h.addLabel(issue.ID, "patrol:active")
-		h.addLabel(issue.ID, "mode:normal")
-		h.addLabel(issue.ID, "health:healthy")
-		h.assertStateValue(issue.ID, "patrol", "active")
-		h.assertStateValue(issue.ID, "mode", "normal")
-		h.assertStateValue(issue.ID, "health", "healthy")
-		h.assertStateCount(issue.ID, 3)
-	})
-
-	t.Run("query missing state returns empty", func(t *testing.T) {
-		issue := h.createIssue("No State Test", types.TypeTask, 1)
-		h.assertNoState(issue.ID, "patrol")
-	})
-
-	t.Run("state labels mixed with regular labels", func(t *testing.T) {
-		issue := h.createIssue("Mixed Labels Test", types.TypeTask, 1)
-		h.addLabel(issue.ID, "patrol:active")
-		h.addLabel(issue.ID, "backend") // Not a state label
-		h.addLabel(issue.ID, "mode:normal")
-		h.addLabel(issue.ID, "urgent") // Not a state label
-		h.assertStateValue(issue.ID, "patrol", "active")
-		h.assertStateValue(issue.ID, "mode", "normal")
-		h.assertStateCount(issue.ID, 2)
-	})
-
-	t.Run("state with colon in value", func(t *testing.T) {
-		issue := h.createIssue("Colon Value Test", types.TypeTask, 1)
-		h.addLabel(issue.ID, "error:code:500")
-		value := h.getStateValue(issue.ID, "error")
-		if value != "code:500" {
-			t.Errorf("Expected 'code:500', got '%s'", value)
-		}
-	})
-}
-
-func TestStateTransitions(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "bd-test-state-transition-*")
-	if err != nil {
-		t.Fatalf("Failed to create temp dir: %v", err)
-	}
-	defer os.RemoveAll(tmpDir)
-
-	testDB := filepath.Join(tmpDir, "test.db")
-	s := newTestStore(t, testDB)
-	defer s.Close()
-
-	ctx := context.Background()
-	h := &stateTestHelper{s: s, ctx: ctx, t: t}
-
-	t.Run("change state value", func(t *testing.T) {
-		issue := h.createIssue("Transition Test", types.TypeTask, 1)
-
-		// Initial state
-		h.addLabel(issue.ID, "patrol:active")
-		h.assertStateValue(issue.ID, "patrol", "active")
-
-		// Transition to muted (remove old, add new)
-		h.removeLabel(issue.ID, "patrol:active")
-		h.addLabel(issue.ID, "patrol:muted")
-		h.assertStateValue(issue.ID, "patrol", "muted")
-	})
-
-	t.Run("prevent duplicate dimension values", func(t *testing.T) {
-		issue := h.createIssue("Duplicate Prevention Test", types.TypeTask, 1)
-
-		// Add initial state
-		h.addLabel(issue.ID, "patrol:active")
-
-		// If we add another value without removing, we'd have both
-		// This is what the set-state command prevents
-		h.addLabel(issue.ID, "patrol:muted")
-
-		// Now we have both - this is the anti-pattern
-		labels := h.getLabels(issue.ID)
-		count := 0
-		for _, l := range labels {
-			if strings.HasPrefix(l, "patrol:") {
-				count++
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			value, found := findStateLabel(tt.labels, tt.dimension)
+			if value != tt.wantValue || found != tt.wantFound {
+				t.Fatalf("findStateLabel(%q, %q) = (%q, %t), want (%q, %t)", tt.labels, tt.dimension, value, found, tt.wantValue, tt.wantFound)
 			}
-		}
-		if count != 2 {
-			t.Errorf("Expected 2 patrol labels (anti-pattern), got %d", count)
-		}
-
-		// The getStateValue only returns the first one found
-		// This demonstrates why proper transitions (remove then add) are needed
-	})
+		})
+	}
 }
 
-func TestStatePatterns(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "bd-test-state-patterns-*")
-	if err != nil {
-		t.Fatalf("Failed to create temp dir: %v", err)
+func TestCollectStateLabels(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		labels []string
+		want   map[string]string
+	}{
+		{
+			name: "nil labels returns nonnil empty map",
+			want: map[string]string{},
+		},
+		{
+			name:   "empty labels returns nonnil empty map",
+			labels: []string{},
+			want:   map[string]string{},
+		},
+		{
+			name:   "ignores labels without a nonempty dimension",
+			labels: []string{"backend", ":value"},
+			want:   map[string]string{},
+		},
+		{
+			name:   "retains empty and colon values",
+			labels: []string{"mode:", "error:code:500"},
+			want:   map[string]string{"mode": "", "error": "code:500"},
+		},
+		{
+			name:   "last duplicate wins",
+			labels: []string{"mode:normal", "mode:degraded"},
+			want:   map[string]string{"mode": "degraded"},
+		},
 	}
-	defer os.RemoveAll(tmpDir)
 
-	testDB := filepath.Join(tmpDir, "test.db")
-	s := newTestStore(t, testDB)
-	defer s.Close()
-
-	ctx := context.Background()
-	h := &stateTestHelper{s: s, ctx: ctx, t: t}
-
-	t.Run("common operational dimensions", func(t *testing.T) {
-		issue := h.createIssue("Operations Role", types.TypeTask, 1)
-
-		// Set up typical operational state
-		h.addLabel(issue.ID, "patrol:active")
-		h.addLabel(issue.ID, "mode:normal")
-		h.addLabel(issue.ID, "health:healthy")
-		h.addLabel(issue.ID, "sync:current")
-
-		states := h.getStates(issue.ID)
-		expected := map[string]string{
-			"patrol": "active",
-			"mode":   "normal",
-			"health": "healthy",
-			"sync":   "current",
-		}
-
-		for dim, val := range expected {
-			if states[dim] != val {
-				t.Errorf("Expected %s=%s, got %s=%s", dim, val, dim, states[dim])
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := collectStateLabels(tt.labels)
+			if got == nil {
+				t.Fatal("collectStateLabels returned a nil map")
 			}
-		}
-	})
-
-	t.Run("degraded mode example", func(t *testing.T) {
-		issue := h.createIssue("Degraded Role", types.TypeTask, 1)
-
-		// Start healthy
-		h.addLabel(issue.ID, "health:healthy")
-		h.addLabel(issue.ID, "mode:normal")
-
-		// Degrade
-		h.removeLabel(issue.ID, "mode:normal")
-		h.addLabel(issue.ID, "mode:degraded")
-
-		h.assertStateValue(issue.ID, "mode", "degraded")
-		h.assertStateValue(issue.ID, "health", "healthy") // Health unchanged
-	})
+			if len(got) != len(tt.want) {
+				t.Fatalf("collectStateLabels(%q) has %d values, want %d: %v", tt.labels, len(got), len(tt.want), got)
+			}
+			for dimension, wantValue := range tt.want {
+				if gotValue, ok := got[dimension]; !ok || gotValue != wantValue {
+					t.Errorf("collectStateLabels(%q)[%q] = (%q, %t), want (%q, true)", tt.labels, dimension, gotValue, ok, wantValue)
+				}
+			}
+		})
+	}
 }


### PR DESCRIPTION
## What

Extract the direct `state` command's existing label projections into two private helpers and exercise those production helpers with untagged table tests.

This replaces three Dolt-backed test fixtures while retaining the embedded command, concurrent update, and proxied-server tests as boundary proofs.

## Why

The removed tests created real stores but never called the production command logic. Their test helper independently reimplemented the same label parsing, adding setup cost without protecting the command from a parsing regression.

The new tests run at the lowest useful seam and cover the observable parsing contract directly.

## Behavior preserved

- Scalar lookup matches the exact dimension prefix and remains first-match-wins.
- Values containing additional colons remain intact.
- Empty values remain distinguishable from a missing label inside the projection.
- State-list projection ignores labels without a non-empty dimension and remains last-match-wins for duplicates.
- Human and JSON output, event creation, label writes, partial-ID resolution, and proxied behavior are unchanged.

## Efficiency evidence

- Direct Dolt fixtures in `state_test.go`: 3 → 0.
- Fixture operations removed: 9 issue creates, 20 label adds, 2 label removes, and 16 label reads.
- Focused test-body time on this host: approximately 0.91s → below Go's 0.01s reporting resolution.
- Focused CGO-disabled red/green loop after compilation: 4.395s.
- Net code change: 126 insertions, 278 deletions.

## Verification

- Focused TDD proof: failed first with undefined projection helpers, then passed.
- `CGO_ENABLED=0 go test -count=1 -tags gms_pure_go ./cmd/bd`
- `make test` — passed in 503.29s; `cmd/bd` passed in 454.447s.
- `golangci-lint run ./...` — 0 issues.
- Two independent Sol reviews reported no blocker or major findings.

Bead: `bd-e5ch3`
