### PR TITLE
refactor(test): consolidate status presentation coverage

### DIFF
--- a/cmd/bd/status_embedded_test.go
+++ b/cmd/bd/status_embedded_test.go
@@ -12,43 +12,6 @@ import (
 	"testing"
 )
 
-// bdStatus runs "bd status" with the given args and returns raw stdout.
-func bdStatus(t *testing.T, bd, dir string, args ...string) string {
-	t.Helper()
-	fullArgs := append([]string{"status"}, args...)
-	cmd := exec.Command(bd, fullArgs...)
-	cmd.Dir = dir
-	cmd.Env = bdEnv(dir)
-	stdout, stderr, err := runCommandBuffers(t, cmd)
-	if err != nil {
-		t.Fatalf("bd status %s failed: %v\nstdout:\n%s\nstderr:\n%s", strings.Join(args, " "), err, stdout.String(), stderr.String())
-	}
-	return stdout.String()
-}
-
-// bdStatusJSON runs "bd status --json" and parses the result.
-func bdStatusJSON(t *testing.T, bd, dir string, args ...string) map[string]interface{} {
-	t.Helper()
-	fullArgs := append([]string{"status", "--json"}, args...)
-	cmd := exec.Command(bd, fullArgs...)
-	cmd.Dir = dir
-	cmd.Env = bdEnv(dir)
-	stdout, stderr, err := runCommandBuffers(t, cmd)
-	if err != nil {
-		t.Fatalf("bd status --json %s failed: %v\nstdout:\n%s\nstderr:\n%s", strings.Join(args, " "), err, stdout.String(), stderr.String())
-	}
-	s := strings.TrimSpace(stdout.String())
-	start := strings.Index(s, "{")
-	if start < 0 {
-		t.Fatalf("no JSON object in status output: %s", s)
-	}
-	var m map[string]interface{}
-	if err := json.Unmarshal([]byte(s[start:]), &m); err != nil {
-		t.Fatalf("parse status JSON: %v\n%s", err, s)
-	}
-	return m
-}
-
 func TestEmbeddedStatus(t *testing.T) {
 	if os.Getenv("BEADS_TEST_EMBEDDED_DOLT") != "1" {
 		t.Skip("set BEADS_TEST_EMBEDDED_DOLT=1 to run embedded dolt integration tests")
@@ -58,7 +21,6 @@ func TestEmbeddedStatus(t *testing.T) {
 	bd := buildEmbeddedBD(t)
 	dir, _, _ := bdInit(t, bd, "--prefix", "ss")
 
-	// Create a known set of issues with specific statuses.
 	bdCreate(t, bd, dir, "Status open 1", "--type", "task")
 	bdCreate(t, bd, dir, "Status open 2", "--type", "bug")
 	ip := bdCreate(t, bd, dir, "Status in_progress", "--type", "task", "--assignee", "alice")
@@ -67,144 +29,77 @@ func TestEmbeddedStatus(t *testing.T) {
 	bdClose(t, bd, dir, closed.ID)
 	bdCreate(t, bd, dir, "Status assigned bob", "--type", "task", "--assignee", "bob")
 
-	// ===== Default statistics output =====
-
-	t.Run("default_output", func(t *testing.T) {
-		out := bdStatus(t, bd, dir)
-		if !strings.Contains(out, "Issue Database Status") {
-			t.Errorf("expected 'Issue Database Status' header: %s", out)
+	runStatus := func(t *testing.T, env []string, actor string, args ...string) []byte {
+		t.Helper()
+		commandArgs := append([]string{"status"}, args...)
+		if actor != "" {
+			commandArgs = append([]string{"--actor", actor}, commandArgs...)
 		}
-		if !strings.Contains(out, "Total Issues:") {
-			t.Errorf("expected 'Total Issues:' in output: %s", out)
-		}
-		if !strings.Contains(out, "Open:") {
-			t.Errorf("expected 'Open:' in output: %s", out)
-		}
-	})
-
-	// ===== --json output =====
-
-	t.Run("json_output_structure", func(t *testing.T) {
-		m := bdStatusJSON(t, bd, dir)
-		summary, ok := m["summary"].(map[string]interface{})
-		if !ok {
-			t.Fatal("expected 'summary' object in JSON output")
-		}
-		for _, key := range []string{"total_issues", "open_issues", "in_progress_issues", "closed_issues"} {
-			if _, ok := summary[key]; !ok {
-				t.Errorf("expected '%s' key in summary", key)
-			}
-		}
-	})
-
-	t.Run("json_counts_match", func(t *testing.T) {
-		m := bdStatusJSON(t, bd, dir)
-		summary := m["summary"].(map[string]interface{})
-		total := int(summary["total_issues"].(float64))
-		if total < 5 {
-			t.Errorf("expected at least 5 total issues, got %d", total)
-		}
-		open := int(summary["open_issues"].(float64))
-		if open < 3 {
-			t.Errorf("expected at least 3 open issues, got %d", open)
-		}
-		inProgress := int(summary["in_progress_issues"].(float64))
-		if inProgress < 1 {
-			t.Errorf("expected at least 1 in_progress issue, got %d", inProgress)
-		}
-		closedCount := int(summary["closed_issues"].(float64))
-		if closedCount < 1 {
-			t.Errorf("expected at least 1 closed issue, got %d", closedCount)
-		}
-	})
-
-	// ===== --assigned =====
-
-	t.Run("assigned_filter", func(t *testing.T) {
-		// Set up env with a known git user
-		env := bdEnv(dir)
-		env = append(env, "GIT_AUTHOR_EMAIL=alice@test.com")
-
-		args := []string{"status", "--json", "--assigned"}
-		cmd := exec.Command(bd, args...)
+		cmd := exec.Command(bd, commandArgs...)
 		cmd.Dir = dir
 		cmd.Env = env
 		stdout, stderr, err := runCommandBuffers(t, cmd)
 		if err != nil {
-			t.Fatalf("bd status --assigned --json failed: %v\nstdout:\n%s\nstderr:\n%s", err, stdout.String(), stderr.String())
+			t.Fatalf("bd status %s failed: %v\nstdout:\n%s\nstderr:\n%s", strings.Join(args, " "), err, stdout.String(), stderr.String())
 		}
+		return stdout.Bytes()
+	}
+	assertCount := func(t *testing.T, name string, got, want int) {
+		t.Helper()
+		if got != want {
+			t.Errorf("%s = %d, want %d", name, got, want)
+		}
+	}
+	assertPointerCount := func(t *testing.T, name string, got *int, want int) {
+		t.Helper()
+		if got == nil {
+			t.Errorf("%s = nil, want %d", name, want)
+			return
+		}
+		assertCount(t, name, *got, want)
+	}
 
-		s := strings.TrimSpace(stdout.String())
-		start := strings.Index(s, "{")
-		if start < 0 {
-			t.Fatalf("no JSON: %s", s)
+	t.Run("known_counts_without_activity", func(t *testing.T) {
+		out := runStatus(t, bdEnv(dir), "", "--json", "--no-activity")
+		var got StatusOutput
+		if err := json.Unmarshal(out, &got); err != nil {
+			t.Fatalf("unmarshal status: %v\n%s", err, out)
 		}
-		var m map[string]interface{}
-		if err := json.Unmarshal([]byte(s[start:]), &m); err != nil {
-			t.Fatalf("parse: %v", err)
+		if got.Summary == nil {
+			t.Fatalf("status summary is nil: %s", out)
 		}
-		summary := m["summary"].(map[string]interface{})
-		total := int(summary["total_issues"].(float64))
-		// alice has 1 issue assigned
-		if total > 5 {
-			t.Errorf("assigned should filter to fewer issues, got total=%d", total)
+		assertCount(t, "total issues", got.Summary.TotalIssues, 5)
+		assertCount(t, "open issues", got.Summary.OpenIssues, 3)
+		assertCount(t, "in-progress issues", got.Summary.InProgressIssues, 1)
+		assertCount(t, "closed issues", got.Summary.ClosedIssues, 1)
+		assertCount(t, "deferred issues", got.Summary.DeferredIssues, 0)
+		assertPointerCount(t, "blocked issues", got.Summary.BlockedIssues, 0)
+		assertPointerCount(t, "ready issues", got.Summary.ReadyIssues, 3)
+		var envelope map[string]json.RawMessage
+		if err := json.Unmarshal(out, &envelope); err != nil {
+			t.Fatalf("unmarshal status envelope: %v", err)
+		}
+		if _, ok := envelope["recent_activity"]; ok {
+			t.Errorf("recent_activity present with --no-activity: %s", out)
 		}
 	})
 
-	// ===== --no-activity =====
-
-	t.Run("no_activity_flag", func(t *testing.T) {
-		m := bdStatusJSON(t, bd, dir, "--no-activity")
-		// Should still have summary, just no recent_activity
-		if _, ok := m["summary"]; !ok {
-			t.Error("expected 'summary' even with --no-activity")
+	t.Run("assigned_counts_without_activity", func(t *testing.T) {
+		out := runStatus(t, bdEnv(dir), "alice", "--assigned", "--json", "--no-activity")
+		var got StatusOutput
+		if err := json.Unmarshal(out, &got); err != nil {
+			t.Fatalf("unmarshal assigned status: %v\n%s", err, out)
 		}
-		// recent_activity should be null/absent
-		if activity, ok := m["recent_activity"]; ok && activity != nil {
-			t.Error("expected no recent_activity with --no-activity")
+		if got.Summary == nil {
+			t.Fatalf("assigned status summary is nil: %s", out)
 		}
-	})
-
-	// ===== Empty database =====
-
-	t.Run("empty_database", func(t *testing.T) {
-		emptyDir, _, _ := bdInit(t, bd, "--prefix", "ss2")
-		m := bdStatusJSON(t, bd, emptyDir)
-		summary := m["summary"].(map[string]interface{})
-		total := int(summary["total_issues"].(float64))
-		if total != 0 {
-			t.Errorf("expected 0 total issues in empty db, got %d", total)
-		}
-	})
-
-	// ===== stats alias =====
-
-	t.Run("stats_alias", func(t *testing.T) {
-		cmd := exec.Command(bd, "stats", "--json")
-		cmd.Dir = dir
-		cmd.Env = bdEnv(dir)
-		stdout, stderr, err := runCommandBuffers(t, cmd)
-		if err != nil {
-			t.Fatalf("bd stats alias failed: %v\nstdout:\n%s\nstderr:\n%s", err, stdout.String(), stderr.String())
-		}
-		if !strings.Contains(stdout.String(), "summary") {
-			t.Errorf("expected 'summary' in stats alias output: %s", stdout.String())
-		}
-	})
-
-	// ===== Human-readable sections =====
-
-	t.Run("human_readable_sections", func(t *testing.T) {
-		out := bdStatus(t, bd, dir)
-		if !strings.Contains(out, "Summary:") {
-			t.Errorf("expected 'Summary:' section: %s", out)
-		}
-		if !strings.Contains(out, "In Progress:") {
-			t.Errorf("expected 'In Progress:' line: %s", out)
-		}
-		if !strings.Contains(out, "Ready to Work:") {
-			t.Errorf("expected 'Ready to Work:' line: %s", out)
-		}
+		assertCount(t, "assigned total issues", got.Summary.TotalIssues, 1)
+		assertCount(t, "assigned open issues", got.Summary.OpenIssues, 0)
+		assertCount(t, "assigned in-progress issues", got.Summary.InProgressIssues, 1)
+		assertCount(t, "assigned closed issues", got.Summary.ClosedIssues, 0)
+		assertCount(t, "assigned deferred issues", got.Summary.DeferredIssues, 0)
+		assertPointerCount(t, "assigned blocked issues", got.Summary.BlockedIssues, 0)
+		assertPointerCount(t, "assigned ready issues", got.Summary.ReadyIssues, 1)
 	})
 }
 

--- a/cmd/bd/status_test.go
+++ b/cmd/bd/status_test.go
@@ -1,420 +1,176 @@
-//go:build cgo
-
 package main
 
 import (
-	"context"
 	"encoding/json"
-	"os"
-	"path/filepath"
 	"strings"
 	"testing"
-	"time"
 
-	"github.com/steveyegge/beads/internal/storage/dolt"
 	"github.com/steveyegge/beads/internal/types"
 )
 
-// Helper function to create a time pointer
-func timePtr(t time.Time) *time.Time {
-	return &t
-}
-
-func TestStatusCommand(t *testing.T) {
-	// Create a temporary directory for the test database
-	tempDir := t.TempDir()
-	dbPath := filepath.Join(tempDir, ".beads", "test.db")
-
-	// Create .beads directory
-	if err := os.MkdirAll(filepath.Dir(dbPath), 0755); err != nil {
-		t.Fatalf("Failed to create .beads directory: %v", err)
-	}
-
-	// Initialize the database
-	store, err := dolt.New(context.Background(), &dolt.Config{Path: dbPath})
-	if err != nil {
-		t.Skipf("skipping: Dolt server not available: %v", err)
-	}
-	defer store.Close()
-
-	ctx := context.Background()
-
-	// Set issue prefix
-	if err := store.SetConfig(ctx, "issue_prefix", "test"); err != nil {
-		t.Fatalf("Failed to set issue prefix: %v", err)
-	}
-
-	// Create some test issues with different statuses
-	testIssues := []*types.Issue{
+func TestBuildAssignedStats(t *testing.T) {
+	tests := []struct {
+		name       string
+		issues     []*types.Issue
+		ready      int
+		total      int
+		open       int
+		inProgress int
+		blocked    int
+		deferred   int
+		closed     int
+	}{
 		{
-			Title:     "Open issue 1",
-			Status:    types.StatusOpen,
-			Priority:  1,
-			IssueType: types.TypeTask,
-			Assignee:  "alice",
+			name: "counts every status and ready work",
+			issues: []*types.Issue{
+				{Status: types.StatusOpen},
+				{Status: types.StatusInProgress},
+				{Status: types.StatusBlocked},
+				{Status: types.StatusDeferred},
+				{Status: types.StatusClosed},
+			},
+			ready: 2, total: 5, open: 1, inProgress: 1, blocked: 1, deferred: 1, closed: 1,
 		},
 		{
-			Title:     "Open issue 2",
-			Status:    types.StatusOpen,
-			Priority:  2,
-			IssueType: types.TypeBug,
-			Assignee:  "bob",
-		},
-		{
-			Title:     "In progress issue",
-			Status:    types.StatusInProgress,
-			Priority:  1,
-			IssueType: types.TypeFeature,
-			Assignee:  "alice",
-		},
-		{
-			Title:     "Blocked issue",
-			Status:    types.StatusBlocked,
-			Priority:  0,
-			IssueType: types.TypeBug,
-			Assignee:  "alice",
-		},
-		{
-			Title:     "Closed issue",
-			Status:    types.StatusClosed,
-			Priority:  3,
-			IssueType: types.TypeTask,
-			Assignee:  "bob",
-			ClosedAt:  timePtr(time.Now()),
+			name:  "empty input retains explicit zero counts",
+			ready: 0,
 		},
 	}
 
-	for _, issue := range testIssues {
-		if err := store.CreateIssue(ctx, issue, "test"); err != nil {
-			t.Fatalf("Failed to create test issue: %v", err)
-		}
-	}
-
-	// Test GetStatistics
-	stats, err := store.GetStatistics(ctx)
-	if err != nil {
-		t.Fatalf("GetStatistics failed: %v", err)
-	}
-
-	// Verify counts
-	if stats.TotalIssues != 5 {
-		t.Errorf("Expected 5 total issues, got %d", stats.TotalIssues)
-	}
-	if stats.OpenIssues != 2 {
-		t.Errorf("Expected 2 open issues, got %d", stats.OpenIssues)
-	}
-	if stats.InProgressIssues != 1 {
-		t.Errorf("Expected 1 in-progress issue, got %d", stats.InProgressIssues)
-	}
-	if stats.BlockedIssues != nil && *stats.BlockedIssues != 0 {
-		// Note: BlockedIssues counts issues that are blocked by dependencies
-		// Our test issue with status=blocked doesn't have dependencies, so count is 0
-		t.Logf("BlockedIssues: %d (expected 0, status=blocked without deps)", *stats.BlockedIssues)
-	}
-	if stats.ClosedIssues != 1 {
-		t.Errorf("Expected 1 closed issue, got %d", stats.ClosedIssues)
-	}
-
-	// Test JSON marshaling with full Statistics
-	output := &StatusOutput{
-		Summary: stats,
-	}
-
-	jsonBytes, err := json.MarshalIndent(output, "", "  ")
-	if err != nil {
-		t.Fatalf("Failed to marshal JSON: %v", err)
-	}
-
-	t.Logf("Status output:\n%s", string(jsonBytes))
-
-	// Verify JSON structure
-	var decoded StatusOutput
-	if err := json.Unmarshal(jsonBytes, &decoded); err != nil {
-		t.Fatalf("Failed to unmarshal JSON: %v", err)
-	}
-
-	if decoded.Summary.TotalIssues != 5 {
-		t.Errorf("Decoded total issues: expected 5, got %d", decoded.Summary.TotalIssues)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildAssignedStats(tt.issues, tt.ready)
+			if got.TotalIssues != tt.total || got.OpenIssues != tt.open || got.InProgressIssues != tt.inProgress || got.DeferredIssues != tt.deferred || got.ClosedIssues != tt.closed {
+				t.Errorf("buildAssignedStats() = %+v, want total=%d open=%d in_progress=%d deferred=%d closed=%d", got, tt.total, tt.open, tt.inProgress, tt.deferred, tt.closed)
+			}
+			if got.BlockedIssues == nil || *got.BlockedIssues != tt.blocked {
+				t.Errorf("blocked issues = %v, want %d", got.BlockedIssues, tt.blocked)
+			}
+			if got.ReadyIssues == nil || *got.ReadyIssues != tt.ready {
+				t.Errorf("ready issues = %v, want %d", got.ReadyIssues, tt.ready)
+			}
+		})
 	}
 }
 
-func TestGetGitActivity(t *testing.T) {
-	// Test getGitActivity - it may return nil if not in a git repo
-	// or if there's no recent activity
-	activity := getGitActivity(24)
+func TestRenderStatusJSON(t *testing.T) {
+	t.Setenv("BD_JSON_ENVELOPE", "0")
 
-	// If we're in a git repo with activity, verify the structure
-	if activity != nil {
-		if activity.HoursTracked != 24 {
-			t.Errorf("Expected 24 hours tracked, got %d", activity.HoursTracked)
-		}
-
-		// Should have non-negative values
-		if activity.CommitCount < 0 {
-			t.Errorf("Negative commit count: %d", activity.CommitCount)
-		}
-		if activity.IssuesCreated < 0 {
-			t.Errorf("Negative issues created: %d", activity.IssuesCreated)
-		}
-		if activity.IssuesClosed < 0 {
-			t.Errorf("Negative issues closed: %d", activity.IssuesClosed)
-		}
-		if activity.IssuesUpdated < 0 {
-			t.Errorf("Negative issues updated: %d", activity.IssuesUpdated)
-		}
-
-		t.Logf("Git activity: commits=%d, created=%d, closed=%d, updated=%d, total=%d",
-			activity.CommitCount, activity.IssuesCreated, activity.IssuesClosed,
-			activity.IssuesUpdated, activity.TotalChanges)
-	} else {
-		t.Log("No git activity found (not in a git repo or no recent commits)")
-	}
-}
-
-func TestGetAssignedStatistics(t *testing.T) {
-	// Create a temporary directory for the test database
-	tempDir := t.TempDir()
-	dbPath := filepath.Join(tempDir, ".beads", "test.db")
-
-	// Create .beads directory
-	if err := os.MkdirAll(filepath.Dir(dbPath), 0755); err != nil {
-		t.Fatalf("Failed to create .beads directory: %v", err)
-	}
-
-	// Initialize the database
-	testStore, err := dolt.New(context.Background(), &dolt.Config{Path: dbPath})
-	if err != nil {
-		t.Skipf("skipping: Dolt server not available: %v", err)
-	}
-	defer testStore.Close()
-
-	ctx := context.Background()
-
-	// Set issue prefix
-	if err := testStore.SetConfig(ctx, "issue_prefix", "test"); err != nil {
-		t.Fatalf("Failed to set issue prefix: %v", err)
-	}
-
-	// Set global store and rootCtx for getAssignedStatistics
-	oldRootCtx := rootCtx
-	rootCtx = ctx
-	defer func() { rootCtx = oldRootCtx }()
-	store = testStore
-
-	// Create test issues with different assignees
-	testIssues := []*types.Issue{
+	count := func(n int) *int { return &n }
+	tests := []struct {
+		name    string
+		stats   *types.Statistics
+		skipped bool
+		blocked *int
+		ready   *int
+	}{
 		{
-			Title:     "Alice's issue 1",
-			Status:    types.StatusOpen,
-			Priority:  1,
-			IssueType: types.TypeTask,
-			Assignee:  "alice",
+			name:    "includes computed counts",
+			stats:   &types.Statistics{TotalIssues: 3, OpenIssues: 1, BlockedIssues: count(1), ReadyIssues: count(1)},
+			blocked: count(1), ready: count(1),
 		},
 		{
-			Title:     "Alice's issue 2",
-			Status:    types.StatusInProgress,
-			Priority:  1,
-			IssueType: types.TypeTask,
-			Assignee:  "alice",
-		},
-		{
-			Title:     "Bob's issue",
-			Status:    types.StatusOpen,
-			Priority:  1,
-			IssueType: types.TypeTask,
-			Assignee:  "bob",
+			name:    "preserves skipped counts as null",
+			stats:   &types.Statistics{TotalIssues: 3, OpenIssues: 2, ClosedIssues: 1},
+			skipped: true,
 		},
 	}
 
-	for _, issue := range testIssues {
-		if err := testStore.CreateIssue(ctx, issue, "test"); err != nil {
-			t.Fatalf("Failed to create test issue: %v", err)
-		}
-	}
-
-	// Test getAssignedStatistics for Alice
-	stats := getAssignedStatistics("alice")
-	if stats == nil {
-		t.Fatal("getAssignedStatistics returned nil")
-	}
-
-	if stats.TotalIssues != 2 {
-		t.Errorf("Expected 2 issues for alice, got %d", stats.TotalIssues)
-	}
-	if stats.OpenIssues != 1 {
-		t.Errorf("Expected 1 open issue for alice, got %d", stats.OpenIssues)
-	}
-	if stats.InProgressIssues != 1 {
-		t.Errorf("Expected 1 in-progress issue for alice, got %d", stats.InProgressIssues)
-	}
-
-	// Test for Bob
-	bobStats := getAssignedStatistics("bob")
-	if bobStats == nil {
-		t.Fatal("getAssignedStatistics returned nil for bob")
-	}
-
-	if bobStats.TotalIssues != 1 {
-		t.Errorf("Expected 1 issue for bob, got %d", bobStats.TotalIssues)
-	}
-}
-
-// TestRenderStatus_SkipJSONEmitsNullNotZero verifies that when BlockedIssues/
-// ReadyIssues are nil (the --no-blocked shape), the JSON envelope reports
-// blocked_count_skipped:true and emits literal `null` for both fields rather
-// than a fake 0 that a CI consumer could misread as "nothing blocked / ready".
-func TestRenderStatus_SkipJSONEmitsNullNotZero(t *testing.T) {
 	oldJSON := jsonOutput
 	jsonOutput = true
 	defer func() { jsonOutput = oldJSON }()
 
-	stats := &types.Statistics{
-		TotalIssues:   3,
-		OpenIssues:    2,
-		ClosedIssues:  1,
-		BlockedIssues: nil,
-		ReadyIssues:   nil,
-	}
-
-	out := captureStdout(t, func() error {
-		return renderStatus(stats, nil)
-	})
-
-	var decoded struct {
-		BlockedCountSkipped bool `json:"blocked_count_skipped"`
-		Summary             struct {
-			BlockedIssues *int `json:"blocked_issues"`
-			ReadyIssues   *int `json:"ready_issues"`
-		} `json:"summary"`
-	}
-	if err := json.Unmarshal([]byte(out), &decoded); err != nil {
-		t.Fatalf("failed to unmarshal renderStatus JSON output: %v\nraw: %s", err, out)
-	}
-
-	if !decoded.BlockedCountSkipped {
-		t.Errorf("expected blocked_count_skipped: true, got false\nraw: %s", out)
-	}
-	if decoded.Summary.BlockedIssues != nil {
-		t.Errorf("expected summary.blocked_issues: null, got %d\nraw: %s", *decoded.Summary.BlockedIssues, out)
-	}
-	if decoded.Summary.ReadyIssues != nil {
-		t.Errorf("expected summary.ready_issues: null, got %d\nraw: %s", *decoded.Summary.ReadyIssues, out)
-	}
-
-	// Literal "null" must actually be present in the raw bytes -- a stray
-	// custom MarshalJSON or a non-pointer regression would silently coerce
-	// this back to 0 without failing the struct-decode assertions above.
-	if !strings.Contains(out, `"blocked_issues": null`) {
-		t.Errorf("expected literal \"blocked_issues\": null in raw JSON, got:\n%s", out)
-	}
-	if !strings.Contains(out, `"ready_issues": null`) {
-		t.Errorf("expected literal \"ready_issues\": null in raw JSON, got:\n%s", out)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out := captureStdout(t, func() error { return renderStatus(tt.stats, nil) })
+			var got StatusOutput
+			if err := json.Unmarshal([]byte(out), &got); err != nil {
+				t.Fatalf("unmarshal status JSON: %v\n%s", err, out)
+			}
+			if got.Summary == nil || got.Summary.TotalIssues != tt.stats.TotalIssues {
+				t.Errorf("summary = %+v, want %+v", got.Summary, tt.stats)
+			}
+			if got.BlockedCountSkipped != tt.skipped {
+				t.Errorf("blocked_count_skipped = %t, want %t", got.BlockedCountSkipped, tt.skipped)
+			}
+			if (got.Summary.BlockedIssues == nil) != (tt.blocked == nil) || (got.Summary.BlockedIssues != nil && *got.Summary.BlockedIssues != *tt.blocked) {
+				t.Errorf("blocked_issues = %v, want %v", got.Summary.BlockedIssues, tt.blocked)
+			}
+			if (got.Summary.ReadyIssues == nil) != (tt.ready == nil) || (got.Summary.ReadyIssues != nil && *got.Summary.ReadyIssues != *tt.ready) {
+				t.Errorf("ready_issues = %v, want %v", got.Summary.ReadyIssues, tt.ready)
+			}
+			if got.RecentActivity != nil {
+				t.Errorf("recent activity = %+v, want nil", got.RecentActivity)
+			}
+			if tt.skipped && (!strings.Contains(out, `"blocked_issues": null`) || !strings.Contains(out, `"ready_issues": null`)) {
+				t.Errorf("skipped counts must be encoded as null:\n%s", out)
+			}
+		})
 	}
 }
 
-// TestRenderStatus_SkipHumanRendersSkippedNotZero verifies the human-readable
-// branch renders "(skipped)" for Blocked and Ready to Work when their stats
-// fields are nil, derived from the data (nil pointers) rather than a
-// separately-tracked flag -- so it stays correct even when a caller (like
-// --assigned) recomputes fully-populated stats.
-func TestRenderStatus_SkipHumanRendersSkippedNotZero(t *testing.T) {
+func TestRenderStatusHuman(t *testing.T) {
+	count := func(n int) *int { return &n }
+	tests := []struct {
+		name     string
+		stats    *types.Statistics
+		activity *RecentActivitySummary
+		contains []string
+		absent   []string
+	}{
+		{
+			name:     "normal counts",
+			stats:    &types.Statistics{TotalIssues: 3, OpenIssues: 1, InProgressIssues: 1, ClosedIssues: 1, BlockedIssues: count(1), ReadyIssues: count(2)},
+			contains: []string{"Issue Database Status", "Total Issues:           3", "Blocked:                1", "Ready to Work:          2"},
+			absent:   []string{"(skipped)"},
+		},
+		{
+			name:     "skipped counts",
+			stats:    &types.Statistics{TotalIssues: 1},
+			contains: []string{"Blocked:                (skipped)", "Ready to Work:          (skipped)"},
+		},
+		{
+			name:     "extended statistics",
+			stats:    &types.Statistics{BlockedIssues: count(0), ReadyIssues: count(0), PinnedIssues: 2, EpicsEligibleForClosure: 3, AverageLeadTime: 4.5},
+			contains: []string{"Extended:", "Pinned:                 2", "Epics Ready to Close:   3", "Avg Lead Time:          4.5 hours"},
+		},
+		{
+			name:     "recent activity",
+			stats:    &types.Statistics{BlockedIssues: count(0), ReadyIssues: count(0)},
+			activity: &RecentActivitySummary{HoursTracked: 24, CommitCount: 1, TotalChanges: 2, IssuesCreated: 3, IssuesClosed: 4, IssuesReopened: 5, IssuesUpdated: 6},
+			contains: []string{"Recent Activity (last 24 hours):", "Commits:                1", "Total Changes:          2", "Issues Created:         3", "Issues Closed:          4", "Issues Reopened:        5", "Issues Updated:         6"},
+		},
+	}
+
 	oldJSON := jsonOutput
 	jsonOutput = false
 	defer func() { jsonOutput = oldJSON }()
 
-	stats := &types.Statistics{
-		TotalIssues:   3,
-		OpenIssues:    2,
-		ClosedIssues:  1,
-		BlockedIssues: nil,
-		ReadyIssues:   nil,
-	}
-
-	out := captureStdout(t, func() error {
-		return renderStatus(stats, nil)
-	})
-
-	if n := strings.Count(out, "(skipped)"); n != 2 {
-		t.Errorf("expected \"(skipped)\" to render twice (Blocked + Ready to Work), got %d times:\n%s", n, out)
-	}
-}
-
-// TestRenderStatus_AssignedIgnoresSkipEvenWithNoBlockedFlag guards the
-// data-derived skip-state fix directly: fully-populated stats (as
-// getAssignedStatistics/buildAssignedStats always produce) must never render
-// "(skipped)", regardless of what --no-blocked was passed on the command
-// line -- renderStatus no longer takes a noBlocked flag at all.
-func TestRenderStatus_AssignedIgnoresSkipEvenWithNoBlockedFlag(t *testing.T) {
-	oldJSON := jsonOutput
-	jsonOutput = false
-	defer func() { jsonOutput = oldJSON }()
-
-	stats := buildAssignedStats([]*types.Issue{
-		{Status: types.StatusOpen},
-		{Status: types.StatusBlocked},
-	}, 1)
-	if stats.BlockedIssues == nil || stats.ReadyIssues == nil {
-		t.Fatalf("buildAssignedStats should always populate BlockedIssues/ReadyIssues; got %+v", stats)
-	}
-
-	out := captureStdout(t, func() error {
-		return renderStatus(stats, nil)
-	})
-
-	if strings.Contains(out, "(skipped)") {
-		t.Errorf("expected no \"(skipped)\" rendering for fully-populated assigned stats, got:\n%s", out)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out := captureStdout(t, func() error { return renderStatus(tt.stats, tt.activity) })
+			for _, want := range tt.contains {
+				if !strings.Contains(out, want) {
+					t.Errorf("output does not contain %q:\n%s", want, out)
+				}
+			}
+			for _, unwanted := range tt.absent {
+				if strings.Contains(out, unwanted) {
+					t.Errorf("output unexpectedly contains %q:\n%s", unwanted, out)
+				}
+			}
+		})
 	}
 }
 
-// TestGetStatisticsNoBlocked verifies the --no-blocked fast path leaves
-// BlockedIssues and ReadyIssues nil, while the same store's full GetStatistics
-// call populates both -- guarding the *int fake-zero regression this PR fixes.
-func TestGetStatisticsNoBlocked(t *testing.T) {
-	tempDir := t.TempDir()
-	dbPath := filepath.Join(tempDir, ".beads", "test.db")
-	if err := os.MkdirAll(filepath.Dir(dbPath), 0755); err != nil {
-		t.Fatalf("Failed to create .beads directory: %v", err)
+func TestGetGitActivityReturnsNil(t *testing.T) {
+	if got := getGitActivity(24); got != nil {
+		t.Errorf("getGitActivity(24) = %+v, want nil", got)
 	}
+}
 
-	testStore, err := dolt.New(context.Background(), &dolt.Config{Path: dbPath})
-	if err != nil {
-		t.Skipf("skipping: Dolt server not available: %v", err)
-	}
-	defer testStore.Close()
-
-	ctx := context.Background()
-	if err := testStore.SetConfig(ctx, "issue_prefix", "test"); err != nil {
-		t.Fatalf("Failed to set issue prefix: %v", err)
-	}
-
-	if err := testStore.CreateIssue(ctx, &types.Issue{
-		Title:     "Open issue",
-		Status:    types.StatusOpen,
-		Priority:  1,
-		IssueType: types.TypeTask,
-	}, "test"); err != nil {
-		t.Fatalf("Failed to create test issue: %v", err)
-	}
-
-	noBlocked, err := testStore.GetStatisticsNoBlocked(ctx)
-	if err != nil {
-		t.Fatalf("GetStatisticsNoBlocked failed: %v", err)
-	}
-	if noBlocked.BlockedIssues != nil {
-		t.Errorf("expected BlockedIssues nil under --no-blocked, got %d", *noBlocked.BlockedIssues)
-	}
-	if noBlocked.ReadyIssues != nil {
-		t.Errorf("expected ReadyIssues nil under --no-blocked, got %d", *noBlocked.ReadyIssues)
-	}
-
-	full, err := testStore.GetStatistics(ctx)
-	if err != nil {
-		t.Fatalf("GetStatistics failed: %v", err)
-	}
-	if full.BlockedIssues == nil {
-		t.Fatal("expected BlockedIssues populated by full GetStatistics, got nil")
-	}
-	if full.ReadyIssues == nil {
-		t.Fatal("expected ReadyIssues populated by full GetStatistics, got nil")
+func TestStatusCommandAliases(t *testing.T) {
+	if len(statusCmd.Aliases) != 1 || statusCmd.Aliases[0] != "stats" {
+		t.Errorf("status aliases = %q, want [stats]", statusCmd.Aliases)
 	}
 }


### PR DESCRIPTION
## What

Replace three false-green direct Dolt status fixtures with untagged pure tests of the existing `buildAssignedStats` and `renderStatus` seams.

Consolidate `TestEmbeddedStatus` to two distinct installed-binary proofs in one initialized project: exact normal status counts and exact assigned counts. The concurrent embedded and proxied status suites remain unchanged.

## Why

The removed direct-store tests attempted to open databases that were never created. Even with the Dolt test environment enabled, all three skipped after starting the shared container, so their cost bought no coverage.

The embedded test separately repeated presentation, JSON-shape, alias, empty-state, and no-activity scenarios that can be proven directly at the pure renderer seam. Keeping only distinct command-wiring risks makes the suite faster and failures more precise without weakening storage or process coverage.

## Behavior preserved

- Status aggregation still counts open, in-progress, blocked, deferred, and closed issues and always populates assigned blocked/ready counts.
- Human output still renders normal, skipped, extended, and recent-activity sections.
- JSON still preserves skipped blocked/ready counts as literal `null` and reports `blocked_count_skipped`.
- `stats` remains the `status` alias.
- Direct `status --json --no-activity` and `status --assigned --json --no-activity` wiring are proven with exact seeded counts.
- Storage statistics semantics remain covered by `internal/storage/dolt/queries_test.go`, including empty stores, status counts, blocked/ready counts, and the no-blocked nil contract.
- `TestEmbeddedStatusConcurrent` and `TestProxiedServerStatus` are unchanged.

## Efficiency evidence

- Nominal direct Dolt fixtures in `status_test.go`: 3 → 0. Before removal, a focused Dolt-enabled package run took 22.019s and all three tests skipped.
- `TestEmbeddedStatus` initialized projects: 2 → 1.
- `TestEmbeddedStatus` status subprocesses: 8 → 2.
- Focused embedded test body: 24.84s → 19.52s, saving 5.32s (21%).
- Focused embedded package time: 29.360s → 23.949s.
- Focused embedded wall time: 36.33s → 30.91s, saving 5.42s.
- Pure status test bodies run below Go's 0.01s reporting resolution and now run with `CGO_ENABLED=0`.
- Net change: 190 insertions, 539 deletions across two test files; no production code changes.

## Verification

- Focused pure tests with `CGO_ENABLED=0` and `gms_pure_go` — passed.
- Focused `TestEmbeddedStatus` with embedded Dolt enabled — passed.
- `./scripts/test.sh ./cmd/bd/...` — passed in 478.09s; `cmd/bd` passed in 452.192s.
- `make test` — passed in 504.70s; `cmd/bd` passed in 455.846s.
- `golangci-lint run ./...` — 0 issues in 16.64s.
- Two independent Sol reviews initially found deterministic-actor and JSON-envelope isolation defects. Both were fixed, and both reviewers cleared the final diff with no blocker or major remaining.

Bead: `bd-gwzj8`
