### PR TITLE
refactor(test): isolate tips metadata behavior

### DIFF
--- a/cmd/bd/tips.go
+++ b/cmd/bd/tips.go
@@ -13,9 +13,20 @@ import (
 	"strings"
 	"sync"
 	"time"
-
-	"github.com/steveyegge/beads/internal/storage"
 )
+
+type tipMetadataReader interface {
+	GetLocalMetadata(context.Context, string) (string, error)
+}
+
+type tipMetadataWriter interface {
+	SetLocalMetadata(context.Context, string, string) error
+}
+
+type tipMetadataStore interface {
+	tipMetadataReader
+	tipMetadataWriter
+}
 
 // Tip represents a contextual hint that can be shown to users after successful commands
 type Tip struct {
@@ -60,7 +71,7 @@ func initTipRand() {
 
 // maybeShowTip selects and displays an eligible tip based on priority and probability
 // Respects --json and --quiet flags
-func maybeShowTip(store storage.DoltStorage) {
+func maybeShowTip(store tipMetadataStore) {
 	// Skip tips in JSON output mode or quiet mode
 	if jsonOutput || quietFlag {
 		return
@@ -84,7 +95,7 @@ func maybeShowTip(store storage.DoltStorage) {
 
 // selectNextTip finds the next tip to show based on conditions, frequency, priority, and probability
 // Returns nil if no tip should be shown
-func selectNextTip(store storage.DoltStorage) *Tip {
+func selectNextTip(store tipMetadataReader) *Tip {
 	if store == nil {
 		return nil
 	}
@@ -134,7 +145,7 @@ func selectNextTip(store storage.DoltStorage) *Tip {
 
 // getLastShown retrieves the timestamp when a tip was last shown
 // Returns zero time if never shown
-func getLastShown(store storage.DoltStorage, tipID string) time.Time {
+func getLastShown(store tipMetadataReader, tipID string) time.Time {
 	key := fmt.Sprintf("tip_%s_last_shown", tipID)
 	value, err := store.GetLocalMetadata(context.Background(), key)
 	if err != nil || value == "" {
@@ -151,7 +162,7 @@ func getLastShown(store storage.DoltStorage, tipID string) time.Time {
 }
 
 // recordTipShown records the timestamp when a tip was shown
-func recordTipShown(store storage.DoltStorage, tipID string) {
+func recordTipShown(store tipMetadataWriter, tipID string) {
 	if store == nil || tipID == "" {
 		return
 	}

--- a/cmd/bd/tips_test.go
+++ b/cmd/bd/tips_test.go
@@ -1,37 +1,95 @@
-//go:build cgo
-
 package main
 
 import (
 	"context"
+	"errors"
+	"math/rand"
 	"os"
-	"path/filepath"
 	"sync"
 	"testing"
 	"time"
 )
 
-func TestTipSelection(t *testing.T) {
-	// Reset doltAutoCommit to prevent test interference (prior tests may set it to "on"
-	// via rootCmd.Execute, causing recordTipShown to defer writes instead of persisting)
-	oldDoltAutoCommit := doltAutoCommit
-	doltAutoCommit = ""
-	t.Cleanup(func() { doltAutoCommit = oldDoltAutoCommit })
+type tipMetadataWrite struct {
+	key   string
+	value string
+}
 
-	// Set deterministic seed for testing
-	os.Setenv("BEADS_TIP_SEED", "12345")
-	defer os.Unsetenv("BEADS_TIP_SEED")
+// tipMetadataRecorder is a scripted recording double. It deliberately does
+// not apply writes to reads; storage owns that persistence behavior.
+type tipMetadataRecorder struct {
+	values   map[string]string
+	readErr  error
+	writeErr error
+	readKeys []string
+	writes   []tipMetadataWrite
+}
 
-	// Reset RNG
-	tipRandOnce = sync.Once{}
-	initTipRand()
+func (r *tipMetadataRecorder) GetLocalMetadata(_ context.Context, key string) (string, error) {
+	r.readKeys = append(r.readKeys, key)
+	if r.readErr != nil {
+		return "", r.readErr
+	}
+	return r.values[key], nil
+}
 
-	// Reset tip registry for testing
+func (r *tipMetadataRecorder) SetLocalMetadata(_ context.Context, key, value string) error {
+	r.writes = append(r.writes, tipMetadataWrite{key: key, value: value})
+	return r.writeErr
+}
+
+func resetTipTestState(t *testing.T) {
+	t.Helper()
 	tipsMutex.Lock()
-	tips = []Tip{}
+	originalTips := append([]Tip(nil), tips...)
+	tips = nil
 	tipsMutex.Unlock()
 
-	store := newTestStoreWithPrefix(t, filepath.Join(t.TempDir(), "test.db"), "test")
+	originalRand := tipRand
+	originalRandWasInitialized := originalRand != nil
+	tipRand = nil
+	tipRandOnce = sync.Once{}
+	originalJSONOutput := jsonOutput
+	jsonOutput = false
+	originalQuietFlag := quietFlag
+	quietFlag = false
+	originalDoltAutoCommit := doltAutoCommit
+	doltAutoCommit = ""
+	originalDidWrite := commandDidWriteTipMetadata
+	commandDidWriteTipMetadata = false
+	originalTipIDsWereNil := commandTipIDsShown == nil
+	originalTipIDs := make(map[string]struct{}, len(commandTipIDsShown))
+	for id := range commandTipIDsShown {
+		originalTipIDs[id] = struct{}{}
+	}
+	commandTipIDsShown = nil
+
+	t.Cleanup(func() {
+		tipsMutex.Lock()
+		tips = originalTips
+		tipsMutex.Unlock()
+		tipRand = originalRand
+		tipRandOnce = sync.Once{}
+		if originalRandWasInitialized {
+			tipRandOnce.Do(func() {})
+		}
+		jsonOutput = originalJSONOutput
+		quietFlag = originalQuietFlag
+		doltAutoCommit = originalDoltAutoCommit
+		commandDidWriteTipMetadata = originalDidWrite
+		if originalTipIDsWereNil {
+			commandTipIDsShown = nil
+		} else {
+			commandTipIDsShown = originalTipIDs
+		}
+	})
+}
+
+func TestTipSelection(t *testing.T) {
+	resetTipTestState(t)
+	t.Setenv("BEADS_TIP_SEED", "12345")
+	initTipRand()
+	store := &tipMetadataRecorder{values: map[string]string{}}
 
 	// Test 1: No tips registered
 	tip := selectNextTip(store)
@@ -60,7 +118,7 @@ func TestTipSelection(t *testing.T) {
 	}
 
 	// Test 3: Frequency limit - should not show again immediately
-	recordTipShown(store, "test_tip_1")
+	store.values["tip_test_tip_1_last_shown"] = time.Now().Format(time.RFC3339)
 	tip = selectNextTip(store)
 	if tip != nil {
 		t.Errorf("Expected nil due to frequency limit, got %v", tip)
@@ -114,15 +172,44 @@ func TestTipSelection(t *testing.T) {
 	if tip != nil {
 		t.Errorf("Expected nil due to condition=false, got %v", tip)
 	}
+
+	for _, test := range []struct {
+		name string
+		tips []Tip
+		want string
+	}{
+		{
+			name: "lower priority wins after higher probability misses",
+			tips: []Tip{
+				{ID: "low", Condition: func() bool { return true }, Priority: 10, Probability: 1},
+				{ID: "high", Condition: func() bool { return true }, Priority: 100, Probability: 0},
+			},
+			want: "low",
+		},
+		{
+			name: "second equal priority tip wins after first probability misses",
+			tips: []Tip{
+				{ID: "first", Condition: func() bool { return true }, Priority: 50, Probability: 0},
+				{ID: "second", Condition: func() bool { return true }, Priority: 50, Probability: 1},
+			},
+			want: "second",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			tipsMutex.Lock()
+			tips = test.tips
+			tipsMutex.Unlock()
+			got := selectNextTip(store)
+			if got == nil || got.ID != test.want {
+				t.Fatalf("selectNextTip() = %#v, want ID %q", got, test.want)
+			}
+		})
+	}
 }
 
 func TestTipProbability(t *testing.T) {
-	// Set deterministic seed
-	os.Setenv("BEADS_TIP_SEED", "99999")
-	defer os.Unsetenv("BEADS_TIP_SEED")
-
-	// Reset RNG by creating a new Once
-	tipRandOnce = sync.Once{}
+	resetTipTestState(t)
+	t.Setenv("BEADS_TIP_SEED", "99999")
 	initTipRand()
 
 	tipsMutex.Lock()
@@ -138,81 +225,116 @@ func TestTipProbability(t *testing.T) {
 	}
 	tipsMutex.Unlock()
 
-	store := newTestStoreWithPrefix(t, filepath.Join(t.TempDir(), "test.db"), "test")
+	store := &tipMetadataRecorder{values: map[string]string{}}
 
 	// Run selection multiple times
 	shownCount := 0
 	for i := 0; i < 100; i++ {
-		// Clear last shown timestamp to make tip eligible
-		_ = store.SetMetadata(context.Background(), "tip_rare_tip_last_shown", "")
-
 		tip := selectNextTip(store)
 		if tip != nil {
 			shownCount++
 		}
 	}
 
-	// With 1% probability, we expect ~1 show out of 100
-	// Allow some variance (0-10 is reasonable for low probability)
-	if shownCount > 10 {
-		t.Errorf("Expected ~1 tip shown with 1%% probability, got %d", shownCount)
+	if shownCount != 1 {
+		t.Errorf("shown count = %d, want 1 for seed 99999", shownCount)
 	}
 }
 
 func TestGetLastShown(t *testing.T) {
-	store := newTestStoreWithPrefix(t, filepath.Join(t.TempDir(), "test.db"), "test")
-
-	// Test 1: Never shown
-	lastShown := getLastShown(store, "never_shown")
-	if !lastShown.IsZero() {
-		t.Errorf("Expected zero time for never shown tip, got %v", lastShown)
-	}
-
-	// Test 2: Recently shown
-	now := time.Now()
-	_ = store.SetMetadata(context.Background(), "tip_test_last_shown", now.Format(time.RFC3339))
-
-	lastShown = getLastShown(store, "test")
-	if lastShown.IsZero() {
-		t.Error("Expected non-zero time for shown tip")
-	}
-
-	// Should be within 1 second (accounting for rounding)
-	diff := now.Sub(lastShown)
-	if diff < 0 {
-		diff = -diff
-	}
-	if diff > time.Second {
-		t.Errorf("Expected last shown time to be close to now, got diff %v", diff)
+	resetTipTestState(t)
+	shown := time.Date(2026, time.August, 1, 12, 0, 0, 0, time.UTC)
+	for _, test := range []struct {
+		name  string
+		value string
+		err   error
+		want  time.Time
+	}{
+		{name: "missing"},
+		{name: "valid", value: shown.Format(time.RFC3339), want: shown},
+		{name: "malformed", value: "not-a-time"},
+		{name: "read failure", err: errors.New("read failed")},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			store := &tipMetadataRecorder{values: map[string]string{"tip_test_last_shown": test.value}, readErr: test.err}
+			if got := getLastShown(store, "test"); !got.Equal(test.want) {
+				t.Fatalf("getLastShown() = %v, want %v", got, test.want)
+			}
+			if len(store.readKeys) != 1 || store.readKeys[0] != "tip_test_last_shown" {
+				t.Fatalf("read keys = %v, want [tip_test_last_shown]", store.readKeys)
+			}
+		})
 	}
 }
 
 func TestRecordTipShown(t *testing.T) {
-	// Reset doltAutoCommit to prevent test interference
-	oldDoltAutoCommit := doltAutoCommit
-	doltAutoCommit = ""
-	t.Cleanup(func() { doltAutoCommit = oldDoltAutoCommit })
-
-	store := newTestStoreWithPrefix(t, filepath.Join(t.TempDir(), "test.db"), "test")
-
-	recordTipShown(store, "test_tip")
-
-	// Verify it was recorded
-	lastShown := getLastShown(store, "test_tip")
-	if lastShown.IsZero() {
-		t.Error("Expected tip to be recorded as shown")
+	resetTipTestState(t)
+	for _, test := range []struct {
+		name string
+		mode string
+	}{
+		{name: "unset", mode: ""},
+		{name: "off", mode: "off"},
+		{name: "batch", mode: "batch"},
+		{name: "invalid", mode: "invalid"},
+	} {
+		t.Run("immediate write with auto commit "+test.name, func(t *testing.T) {
+			commandDidWriteTipMetadata = false
+			commandTipIDsShown = nil
+			doltAutoCommit = test.mode
+			store := &tipMetadataRecorder{}
+			callStarted := time.Now().Truncate(time.Second)
+			recordTipShown(store, "test_tip")
+			callFinished := time.Now().Truncate(time.Second)
+			if len(store.writes) != 1 || store.writes[0].key != "tip_test_tip_last_shown" {
+				t.Fatalf("writes = %#v", store.writes)
+			}
+			writtenAt, err := time.Parse(time.RFC3339, store.writes[0].value)
+			if err != nil {
+				t.Fatalf("written timestamp %q: %v", store.writes[0].value, err)
+			}
+			if writtenAt.Before(callStarted) || writtenAt.After(callFinished) {
+				t.Fatalf("written timestamp %v outside call window [%v, %v]", writtenAt, callStarted, callFinished)
+			}
+			_, tracked := commandTipIDsShown["test_tip"]
+			if !commandDidWriteTipMetadata || len(commandTipIDsShown) != 1 || !tracked {
+				t.Fatalf("tip write tracking = %t, %#v", commandDidWriteTipMetadata, commandTipIDsShown)
+			}
+		})
 	}
-
-	// Should be very recent
-	if time.Since(lastShown) > time.Second {
-		t.Errorf("Expected recent timestamp, got %v", lastShown)
-	}
+	t.Run("write failure is not tracked", func(t *testing.T) {
+		commandDidWriteTipMetadata = false
+		commandTipIDsShown = nil
+		store := &tipMetadataRecorder{writeErr: errors.New("write failed")}
+		recordTipShown(store, "test_tip")
+		if len(store.writes) != 1 || commandDidWriteTipMetadata || commandTipIDsShown != nil {
+			t.Fatalf("writes = %#v, tracking = %t, %#v", store.writes, commandDidWriteTipMetadata, commandTipIDsShown)
+		}
+	})
+	t.Run("nil and empty IDs do not write", func(t *testing.T) {
+		recordTipShown(nil, "test_tip")
+		store := &tipMetadataRecorder{}
+		recordTipShown(store, "")
+		if len(store.writes) != 0 {
+			t.Fatalf("writes = %#v", store.writes)
+		}
+	})
+	t.Run("auto commit defers write", func(t *testing.T) {
+		commandDidWriteTipMetadata = false
+		commandTipIDsShown = nil
+		doltAutoCommit = "on"
+		store := &tipMetadataRecorder{}
+		recordTipShown(store, "test_tip")
+		_, tracked := commandTipIDsShown["test_tip"]
+		if len(store.writes) != 0 || !commandDidWriteTipMetadata || len(commandTipIDsShown) != 1 || !tracked {
+			t.Fatalf("writes = %#v, tracking = %t, %#v", store.writes, commandDidWriteTipMetadata, commandTipIDsShown)
+		}
+	})
 }
 
 func TestMaybeShowTip_RespectsFlags(t *testing.T) {
-	// Set deterministic seed
-	os.Setenv("BEADS_TIP_SEED", "54321")
-	defer os.Unsetenv("BEADS_TIP_SEED")
+	resetTipTestState(t)
+	t.Setenv("BEADS_TIP_SEED", "54321")
 
 	tipsMutex.Lock()
 	tips = []Tip{
@@ -227,29 +349,34 @@ func TestMaybeShowTip_RespectsFlags(t *testing.T) {
 	}
 	tipsMutex.Unlock()
 
-	store := newTestStoreWithPrefix(t, filepath.Join(t.TempDir(), "test.db"), "test")
+	store := &tipMetadataRecorder{values: map[string]string{}}
 
 	// Test 1: Should not show in JSON mode
 	jsonOutput = true
-	maybeShowTip(store) // Should not panic or show output
+	output := captureStdout(t, func() error { maybeShowTip(store); return nil })
+	if output != "" || tipRand != nil || len(store.readKeys) != 0 || len(store.writes) != 0 {
+		t.Fatalf("JSON mode output=%q rand=%v reads=%v writes=%v", output, tipRand, store.readKeys, store.writes)
+	}
 	jsonOutput = false
 
 	// Test 2: Should not show in quiet mode
 	quietFlag = true
-	maybeShowTip(store) // Should not panic or show output
+	output = captureStdout(t, func() error { maybeShowTip(store); return nil })
+	if output != "" || tipRand != nil || len(store.readKeys) != 0 || len(store.writes) != 0 {
+		t.Fatalf("quiet mode output=%q rand=%v reads=%v writes=%v", output, tipRand, store.readKeys, store.writes)
+	}
 	quietFlag = false
 
-	// Test 3: Should show in normal mode (no assertions, just testing it doesn't panic)
-	maybeShowTip(store)
+	output = captureStdout(t, func() error { maybeShowTip(store); return nil })
+	if output != "\n💡 Tip: Always show tip\n" || tipRand == nil || len(store.readKeys) != 1 || len(store.writes) != 1 {
+		t.Fatalf("normal mode output=%q rand=%v reads=%v writes=%v", output, tipRand, store.readKeys, store.writes)
+	}
 }
 
 func TestTipFrequency(t *testing.T) {
-	// Reset doltAutoCommit to prevent test interference
-	oldDoltAutoCommit := doltAutoCommit
-	doltAutoCommit = ""
-	t.Cleanup(func() { doltAutoCommit = oldDoltAutoCommit })
-
-	store := newTestStoreWithPrefix(t, filepath.Join(t.TempDir(), "test.db"), "test")
+	resetTipTestState(t)
+	tipRand = rand.New(rand.NewSource(1))
+	store := &tipMetadataRecorder{values: map[string]string{}}
 
 	tipsMutex.Lock()
 	tips = []Tip{
@@ -270,8 +397,8 @@ func TestTipFrequency(t *testing.T) {
 		t.Fatal("Expected tip to be selected")
 	}
 
-	// Record it as shown
-	recordTipShown(store, tip.ID)
+	// A recorder does not apply writes to reads, so script the persisted value.
+	store.values["tip_frequent_tip_last_shown"] = time.Now().Format(time.RFC3339)
 
 	// Should not show again immediately (within frequency window)
 	tip = selectNextTip(store)
@@ -281,7 +408,7 @@ func TestTipFrequency(t *testing.T) {
 
 	// Manually set last shown to past (simulate time passing)
 	past := time.Now().Add(-10 * time.Second)
-	_ = store.SetMetadata(context.Background(), "tip_frequent_tip_last_shown", past.Format(time.RFC3339))
+	store.values["tip_frequent_tip_last_shown"] = past.Format(time.RFC3339)
 
 	// Should show again now
 	tip = selectNextTip(store)
@@ -291,17 +418,11 @@ func TestTipFrequency(t *testing.T) {
 }
 
 func TestInjectTip(t *testing.T) {
-	// Reset tip registry for testing
-	tipsMutex.Lock()
-	tips = []Tip{}
-	tipsMutex.Unlock()
-
-	store := newTestStoreWithPrefix(t, filepath.Join(t.TempDir(), "test.db"), "test")
+	resetTipTestState(t)
+	store := &tipMetadataRecorder{values: map[string]string{}}
 
 	// Set deterministic seed for testing
-	os.Setenv("BEADS_TIP_SEED", "11111")
-	defer os.Unsetenv("BEADS_TIP_SEED")
-	tipRandOnce = sync.Once{}
+	t.Setenv("BEADS_TIP_SEED", "11111")
 	initTipRand()
 
 	// Test 1: Inject a new tip
@@ -406,6 +527,7 @@ func TestInjectTip(t *testing.T) {
 }
 
 func TestRemoveTip(t *testing.T) {
+	resetTipTestState(t)
 	// Reset tip registry for testing
 	tipsMutex.Lock()
 	tips = []Tip{}
@@ -470,6 +592,7 @@ func TestRemoveTip(t *testing.T) {
 }
 
 func TestInjectTipConcurrency(t *testing.T) {
+	resetTipTestState(t)
 	// Reset tip registry for testing
 	tipsMutex.Lock()
 	tips = []Tip{}
@@ -602,6 +725,7 @@ func TestIsClaudeSetupComplete(t *testing.T) {
 }
 
 func TestClaudeSetupTipRegistered(t *testing.T) {
+	resetTipTestState(t)
 	// Reset tip registry with fresh default tips
 	tipsMutex.Lock()
 	tips = []Tip{}
@@ -636,9 +760,9 @@ func TestClaudeSetupTipRegistered(t *testing.T) {
 }
 
 func TestClaudeSetupTipCondition(t *testing.T) {
-	// Save original env vars
-	origClaudeCode := os.Getenv("CLAUDE_CODE")
-	defer os.Setenv("CLAUDE_CODE", origClaudeCode)
+	resetTipTestState(t)
+	t.Setenv("CLAUDE_CODE", "")
+	t.Setenv("ANTHROPIC_CLI", "")
 
 	// Reset tip registry with fresh default tips
 	tipsMutex.Lock()


### PR DESCRIPTION
## What

Replace the tips subsystem's broad `storage.DoltStorage` dependency with private, consumer-owned metadata reader and writer roles. Convert seven tips tests from real Dolt fixtures to a non-mutating scripted recorder, and admit them to CGO-disabled test runs.

## Why

Tips only read and write local metadata, but their tests paid for full Dolt stores. Under the normal local runner all seven tests skipped; with Dolt enabled, `TestGetLastShown` and `TestTipFrequency` failed because they seeded generic metadata while production reads local metadata.

The narrower seam makes those behaviors fast and explicit while leaving real local-metadata persistence semantics in the existing server and embedded storage conformance suites.

## Behavior and coverage

- No user-visible behavior changes.
- Preserve priority, equal-priority and lower-priority probability fallthrough, frequency, conditions, exact output, and JSON/quiet short-circuiting.
- Cover missing, malformed, valid, and failed metadata reads directly.
- Cover immediate, failed, deferred, nil, and empty-ID writes, including exact RFC3339 recency and tracking IDs.
- Restore all touched process globals, including RNG initialization state, flags, auto-commit mode, environment variables, and nil-vs-populated tracking maps.
- Keep the recorder non-mutating; production backend round trips remain covered by shared conformance tests.

## Measured result

The before/after timing uses the same Dolt-enabled focused command. The before run exposed the two stale tests and exited nonzero; the after run is green.

| Metric | Before | After |
|---|---:|---:|
| Real Dolt fixtures | 7 | 0 |
| Ineffective generic metadata writes | 102 | 0 |
| Seven test bodies | 0.60s | <0.01s |
| Focused `cmd/bd` package | 13.659s | 11.651s |
| Focused wall time | 33.61s | 31.29s |
| CGO-disabled admission | Tests excluded | Tests pass |

The package and wall totals still include unrelated shared container startup; the eliminated work is concentrated in the test bodies and fixtures.

## Verification

```text
CGO_ENABLED=0 go test -count=1 -tags gms_pure_go -v \
  -run '^(TestTipSelection|TestTipProbability|TestGetLastShown|TestRecordTipShown|TestMaybeShowTip_RespectsFlags|TestTipFrequency|TestInjectTip|TestClaudeSetupTipCondition)$' ./cmd/bd
# pass; every target body reports 0.00s

./scripts/test.sh ./cmd/bd
# pass; cmd/bd 447.586s, 472.99s wall

make test
# pass; cmd/bd 446.602s, 39.0% aggregate coverage, 495.00s wall

golangci-lint run ./...
# 0 issues
```

Two independent Sol council reviews cleared the final diff after required fixes; no blocker or major finding remains.

Bead: `bd-875lg`
