### PR TITLE
fix(close): restore idempotent re-close by ordering, not by clearing the pin

### DIFF
--- a/cmd/bd/close.go
+++ b/cmd/bd/close.go
@@ -122,9 +122,25 @@ the flags appear in the command line.`,
 			// Get issue for checks (nil issue is handled by validateIssueClosable)
 			issue := result.Issue
 
-			if err := validateIssueClosable(id, issue, actor, force); err != nil {
-				fmt.Fprintf(os.Stderr, "%s\n", err)
-				continue
+			// Close validation guards a state change; a row already at literal
+			// StatusClosed has none to guard, so skip it and let the re-close reach
+			// the engine as the idempotent no-op it has always been (ga-ktn9pe.4.8).
+			// Without this, a forced close of a boolean-pinned bead leaves
+			// pinned=true (closeIssueInTx never touches the column — deliberately,
+			// it is the deletion-protection flag bd gc/purge/cleanup honor) and the
+			// plain retry hits NotPinned and exits nonzero, which strands the
+			// molecule auto-close re-drive documented on the !res.Changed branch
+			// below. Only a literal closed status qualifies: reaching a configured
+			// done status is still a real close, mirroring the engine's isClosedInTx.
+			// The snapshot only decides whether validation runs, never what is
+			// written — the engine's in-transaction `status != closed` guard remains
+			// the authority on whether the close is a no-op, so a concurrent close
+			// still converges. Mirrored in closeProxiedOne.
+			if issue == nil || issue.Status != types.StatusClosed {
+				if err := validateIssueClosable(id, issue, actor, force); err != nil {
+					fmt.Fprintf(os.Stderr, "%s\n", err)
+					continue
+				}
 			}
 
 			// Open-children close guard: prevent closing any issue with open

--- a/cmd/bd/close_embedded_test.go
+++ b/cmd/bd/close_embedded_test.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/steveyegge/beads/internal/configfile"
 	"github.com/steveyegge/beads/internal/storage/embeddeddolt"
@@ -386,6 +387,50 @@ func TestEmbeddedClose(t *testing.T) {
 		got := bdShow(t, bd, dir, issue.ID)
 		if got.Status != types.StatusClosed {
 			t.Errorf("expected closed with --force, got %s", got.Status)
+		}
+	})
+
+	// ga-ktn9pe.4.8: a forced close of a boolean-pinned bead leaves the pin set —
+	// the close write never touches the column, deliberately, because Pinned is
+	// the deletion-protection flag bd gc, bd purge and bd cleanup honor. The plain
+	// retry must therefore still exit 0 as an idempotent already-closed no-op:
+	// that branch is the only thing that re-drives a stranded molecule auto-close.
+	t.Run("close_boolean_pinned_reclose_is_idempotent", func(t *testing.T) {
+		plan := `{"nodes": [{"key": "p", "title": "Boolean pinned", "type": "task", "pinned": true}]}`
+		planFile := filepath.Join(dir, "boolean-pinned-plan.json")
+		if err := os.WriteFile(planFile, []byte(plan), 0644); err != nil {
+			t.Fatal(err)
+		}
+		id := bdCreateGraph(t, bd, dir, planFile).IDs["p"]
+		if id == "" {
+			t.Fatal("graph create returned no ID for key p")
+		}
+		if seeded := bdShow(t, bd, dir, id); !seeded.Pinned {
+			t.Fatalf("precondition: expected pinned=true on the seeded bead, got %+v", seeded)
+		}
+
+		bdClose(t, bd, dir, id, "--force")
+		// The retry carries no --force. Pre-fix it exited nonzero with the pinned
+		// refusal, so bdClose's t.Fatalf is the red assertion.
+		bdClose(t, bd, dir, id)
+
+		got := bdShow(t, bd, dir, id)
+		if got.Status != types.StatusClosed {
+			t.Errorf("status: got %q, want closed", got.Status)
+		}
+		if !got.Pinned {
+			t.Error("expected the pin to survive the close: it is what protects the row from bd gc/purge/cleanup")
+		}
+
+		// The protection the ruling turns on: a pinned closed row is still skipped
+		// by the filter all six destructive call sites run.
+		cutoff := time.Now().UTC().Add(24 * time.Hour)
+		candidates, stats := filterClosedDeletionCandidates([]*types.Issue{got}, &cutoff)
+		if len(candidates) != 0 {
+			t.Errorf("expected the pinned closed row to be excluded from deletion candidates, got %d", len(candidates))
+		}
+		if stats.PinnedSkipped != 1 {
+			t.Errorf("PinnedSkipped: got %d, want 1", stats.PinnedSkipped)
 		}
 	})
 

--- a/cmd/bd/close_embedded_test.go
+++ b/cmd/bd/close_embedded_test.go
@@ -471,6 +471,37 @@ func TestEmbeddedClose(t *testing.T) {
 		}
 	})
 
+	// ga-ktn9pe.4.8 collateral, owner-accepted 2026-08-01. Skipping close
+	// validation on an already-closed row skips the whole chain, not just the
+	// pinned guard, so a foreign actor's re-close now exits 0 where it used to
+	// refuse. Nothing is written either way — the engine's `status != closed`
+	// guard makes a re-close a pure no-op — so the be-035 authority check has no
+	// state change left to protect. The guard itself is untouched:
+	// close_assignee_mismatch_refuses_without_force above still pins the refusal
+	// on an OPEN bead, which is the case be-035 was filed for.
+	//
+	// The chain's third validator, NotTemplate, has no equivalent case here
+	// because a closed template is unreachable from the CLI: both
+	// validateIssueClosable and validateIssueUpdatable refuse templates, so
+	// neither `bd close` nor `bd update --status closed` can produce one.
+	t.Run("reclose_by_foreign_actor_is_idempotent", func(t *testing.T) {
+		issue := bdCreate(t, bd, dir, "Foreign reclose", "--type", "task")
+		bdUpdate(t, bd, dir, issue.ID, "--actor", "bob", "--claim")
+		bdClose(t, bd, dir, issue.ID, "--actor", "bob")
+
+		// Alice re-closes a bead she never held. bdClose t.Fatalf's on a nonzero
+		// exit, so this line is the assertion.
+		bdClose(t, bd, dir, issue.ID, "--actor", "alice")
+
+		got := bdShow(t, bd, dir, issue.ID)
+		if got.Status != types.StatusClosed {
+			t.Errorf("status: got %q, want closed", got.Status)
+		}
+		if got.Assignee != "bob" {
+			t.Errorf("assignee: got %q, want bob — a re-close must not rewrite the holder", got.Assignee)
+		}
+	})
+
 	t.Run("close_same_actor_succeeds", func(t *testing.T) {
 		issue := bdCreate(t, bd, dir, "Same actor", "--type", "task")
 		bdUpdate(t, bd, dir, issue.ID, "--actor", "alice", "--claim")

--- a/cmd/bd/close_proxied_integration_test.go
+++ b/cmd/bd/close_proxied_integration_test.go
@@ -386,6 +386,47 @@ func TestProxiedServerClose(t *testing.T) {
 		}
 	})
 
+	// ga-ktn9pe.4.8: twin of TestEmbeddedClose/close_boolean_pinned_reclose_is_idempotent.
+	// Both close paths must agree — a fix on one only is the divergence class #5217
+	// just closed.
+	t.Run("close_boolean_pinned_reclose_is_idempotent", func(t *testing.T) {
+		t.Parallel()
+		p := newSharedProxiedProject(t, bd, "cbpr")
+		plan := `{"nodes": [{"key": "p", "title": "Boolean pinned", "type": "task", "pinned": true}]}`
+		planFile := filepath.Join(p.dir, "boolean-pinned-plan.json")
+		if err := os.WriteFile(planFile, []byte(plan), 0644); err != nil {
+			t.Fatal(err)
+		}
+		out, err := bdProxiedRun(t, bd, p.dir, "create", "--graph", planFile, "--json")
+		if err != nil {
+			t.Fatalf("bd create --graph failed: %v\n%s", err, out)
+		}
+		var created GraphApplyResult
+		if err := json.Unmarshal(out, &created); err != nil {
+			t.Fatalf("parse graph result: %v\nstdout:\n%s", err, out)
+		}
+		id := created.IDs["p"]
+		if id == "" {
+			t.Fatalf("expected an ID for key p, got %#v", created.IDs)
+		}
+		if seeded := bdProxiedShow(t, bd, p.dir, id); !seeded.Pinned {
+			t.Fatalf("precondition: expected pinned=true on the seeded bead, got %+v", seeded)
+		}
+
+		bdProxiedClose(t, bd, p.dir, id, "--force")
+		// No --force on the retry. Pre-fix this exited nonzero with the pinned
+		// refusal, so bdProxiedClose's t.Fatalf is the red assertion.
+		bdProxiedClose(t, bd, p.dir, id)
+
+		got := bdProxiedShow(t, bd, p.dir, id)
+		if got.Status != types.StatusClosed {
+			t.Errorf("status: got %q, want closed", got.Status)
+		}
+		if !got.Pinned {
+			t.Error("expected the pin to survive the close: it is what protects the row from bd gc/purge/cleanup")
+		}
+	})
+
 	t.Run("close_epic_open_children_refuses", func(t *testing.T) {
 		t.Parallel()
 		p := newSharedProxiedProject(t, bd, "ceor")

--- a/cmd/bd/close_proxied_server.go
+++ b/cmd/bd/close_proxied_server.go
@@ -209,9 +209,16 @@ func closeProxiedOne(ctx context.Context, uw uow.UnitOfWork, id, reason string, 
 		return closeProxiedOutcome{}, false
 	}
 
-	if err := validateIssueClosable(id, current, actor, in.force); err != nil {
-		*errs = append(*errs, err.Error())
-		return closeProxiedOutcome{}, false
+	// Mirrors the ordering in cmd/bd/close.go (ga-ktn9pe.4.8): a row already at
+	// literal StatusClosed has no state change for close validation to guard, so
+	// the re-close skips it and reaches the engine as the idempotent no-op it has
+	// always been. Both close paths must agree here — diverging is the defect
+	// class #5217 closed.
+	if current.Status != types.StatusClosed {
+		if err := validateIssueClosable(id, current, actor, in.force); err != nil {
+			*errs = append(*errs, err.Error())
+			return closeProxiedOutcome{}, false
+		}
 	}
 
 	if !in.force && current.IssueType == types.TypeEpic {

--- a/cmd/bd/show_unit_helpers_test.go
+++ b/cmd/bd/show_unit_helpers_test.go
@@ -46,6 +46,21 @@ func TestValidateIssueClosable(t *testing.T) {
 		t.Fatalf("expected boolean-pinned close to succeed with force, got %v", err)
 	}
 
+	// ga-ktn9pe.4.8: a closed row carrying pinned=true is the residue left by a
+	// forced close, and this guard still refuses it — closed status earns no
+	// exemption from the boolean trigger. Idempotent re-close was restored by
+	// ORDERING instead: cmd/bd/close.go and close_proxied_server.go skip close
+	// validation entirely for a row already closed at resolve time, so this guard
+	// is never reached on the no-op retry. Do not "simplify" it by exempting
+	// closed here — that would also disarm the guard on live status transitions.
+	closedPinnedResidue := &types.Issue{Status: types.StatusClosed, Pinned: true}
+	if err := validateIssueClosable("bd-7", closedPinnedResidue, "alice", false); err == nil {
+		t.Fatalf("expected closed+pinned residue to refuse a plain close")
+	}
+	if err := validateIssueClosable("bd-7", closedPinnedResidue, "alice", true); err != nil {
+		t.Fatalf("expected closed+pinned residue close to succeed with force, got %v", err)
+	}
+
 	// be-035: actor != assignee must be refused without --force.
 	mismatched := &types.Issue{Assignee: "bob"}
 	if err := validateIssueClosable("bd-3", mismatched, "alice", false); err == nil {

--- a/internal/validation/issue_test.go
+++ b/internal/validation/issue_test.go
@@ -113,6 +113,25 @@ func TestNotPinned(t *testing.T) {
 			force:   true,
 			wantErr: false,
 		},
+		// ga-ktn9pe.4.8: closed status is deliberately NOT exempted from the
+		// boolean trigger — this guard stays strict on closed rows. Idempotent
+		// re-close (and the stranded-molecule auto-close re-drive it carries) was
+		// restored one layer up instead: the close commands short-circuit before
+		// calling this guard when the row is already closed at resolve time.
+		// Anyone adding a closed exemption HERE is simplifying the wrong layer,
+		// and must change these two cases deliberately rather than silently.
+		{
+			name:    "boolean-pinned closed issue without force fails",
+			issue:   &types.Issue{ID: "bd-test", Status: types.StatusClosed, Pinned: true},
+			force:   false,
+			wantErr: true,
+		},
+		{
+			name:    "boolean-pinned closed issue with force passes",
+			issue:   &types.Issue{ID: "bd-test", Status: types.StatusClosed, Pinned: true},
+			force:   true,
+			wantErr: false,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## What

`bd close` on an already-closed issue is an exit-0 no-op again. Close validation is skipped for a row already at literal `StatusClosed`, on both the direct and the proxied path.

The branch name says `close-clears-pin`. It does not clear the pin — see below.

## Why

#5212 made `NotPinned` refuse on `issue.Pinned` **or** `status == pinned`. It changed no ordering, and in both close paths validation runs on the resolve-time snapshot *before* the engine call — `cmd/bd/close.go:125` precedes `ops.Close` at `:162`, whose `!res.Changed` branch (`:179-207`) is the idempotent exit-0 path.

`closeIssueInTx` writes only status / closed_at / updated_at / close_reason / closed_by_session / row_lock, so `bd close --force` on a boolean-pinned bead leaves `{pinned: true, status: closed}`. The retry's snapshot is closed-and-pinned, `NotPinned` fires, and it exits nonzero via `SilentExit()` where it used to exit 0.

That regression is load-bearing: per the comment at `close.go:189-200`, the idempotent re-close is the **only** mechanism that re-drives a stranded molecule auto-close. A crashed auto-close of a boolean-pinned final step stays stranded.

## Why not clear the pin instead

That was the first instinct and it is wrong. `issue.Pinned` is the deletion-protection flag at six destructive call sites — `bd gc` (`gc.go:97`, `gc_proxied_server.go:72`), `bd purge` (`purge.go:279`, `purge_proxied_server.go:90`) and `bd cleanup` (`cleanup.go:107`, which prints "Skipping %d pinned issue(s) (protected from cleanup)"). In `filterClosedDeletionCandidates` the pinned check sits immediately *before* the `Status == StatusClosed` check, so on that path `Pinned` is consulted **only on closed rows**: it is exclusively a deletion-protection flag there. `PinnedSkipped` is deliberately excluded from `SafetySkipped()` and reported separately, so the protection is intentional and user-visible.

Clearing the pin on close would make a pinned closed bead impossible, retiring that guarantee and turning all six branches into dead code. The comments in the diff say so, because this is precisely the "simplification" a later reader would reach for.

Ruling 10 comes out un-narrowed. The guard is not exempted for closed rows — it is simply never reached, because closing an already-closed issue has no state change to guard.

## Is a re-close actually a no-op? Verified yes, with two caveats that shape the fix

The close UPDATE is guarded `WHERE id = ? AND status != ?`. On an already-closed row `RowsAffected == 0` and `closeIssueInTx` returns `AlreadyClosed: true` **before** the lease delete, the event record and the is-blocked recompute. So `--reason` and `--session` are already silently discarded on a re-close today — pre-existing engine behavior, not introduced here. `res.Changed` is exactly `!AlreadyClosed`, and the domain twin converges on the same `CloseIssueCheckedInTx`, so direct and proxied agree. The CLI never sets `ExpectedVersion`. **No write is dropped by skipping validation.**

Two caveats, and both are why the short-circuit skips *only* the CLI validation and still calls the engine:

1. The engine performs one non-user-visible write on the already-closed path — `touchDependencyCoordinationInTx`, whose comment says it precedes every child-count branch "including Force and idempotent closes". Still called, unchanged.
2. The engine can still **refuse** an already-closed target: `!force && openChildren > 0` fires for closed targets by design. Re-close idempotency is intentionally not unconditional at the engine layer, and skipping the engine call would have silently disarmed that policy.

## Details worth a reviewer's eye

- **Literal `StatusClosed` only**, mirroring the engine's `isClosedInTx`. Reaching a configured *done* status is a real close, so validation still runs for it.
- **The snapshot is reused, not re-read** — `result.Issue` on the direct path, `current` on the proxied path.
- **Concurrency is unchanged.** The snapshot decides only whether validation runs, never what is written; the engine's in-transaction `status != 'closed'` guard remains the authority, so two simultaneous closes still converge.
- **Owner-accepted collateral:** skipping the chain also skips `NotTemplate` and `AssigneeMatches`, so a foreign actor's re-close of a closed bead now exits 0 instead of refusing. Nothing is written either way, so the be-035 authority check has no state change left to protect; the refusal on an *open* bead is untouched. Scoping the skip to `NotPinned` alone was rejected — a per-validator carve-out is the guard-narrowing shape this fix exists to avoid. A closed template is unreachable from the CLI (both `bd close` and `bd update --status closed` refuse templates), so that third validator has no reachable case.

## Verification

```
go test -v -count=1 -run TestParity ./cmd/bd/                            #  40 PASS  (baseline 40)
go test -v -count=1 ./internal/validation/                              # 220 PASS  (baseline 218, +2 new)
go test -v -count=1 ./internal/storage/issueops/                        # 350 PASS  (unchanged; engine untouched)
go test -v -count=1 -run TestIssueOperations ./internal/storage/dolt/   #  74 PASS  (unchanged)
go test -v -count=1 ./internal/storage/uow/                             # 144 PASS  (unchanged)
BASE_SHA=origin/main bash scripts/check-migration-hygiene.sh            # OK
gofmt / go vet / golangci-lint --new-from-rev=origin/main               # clean, 0 issues
```

Full `./cmd/bd/` sweep: 23 top-level failures on this branch and 23 on pristine `origin/main`, compared **by name** — the sorted failing-name lists diff empty. Those are the known pre-existing init/config/doctor/completion failures.

**Mutation-checked per path.** Reverting `cmd/bd/close.go` alone (mutant compiles) fails only `TestEmbeddedClose/close_boolean_pinned_reclose_is_idempotent`; reverting `cmd/bd/close_proxied_server.go` alone fails only `TestProxiedServerClose/close_boolean_pinned_reclose_is_idempotent`. Each hunk is load-bearing for exactly its own path, and the twin tests pin both paths independently. Reverting `close.go` also fails the new `reclose_by_foreign_actor_is_idempotent` case. All files restored byte-identical afterwards.

Tests added:

- `TestEmbeddedClose/close_boolean_pinned_reclose_is_idempotent` — seeds `pinned: true`, asserts the pin as a precondition, force-closes, plain re-closes (exit 0 is the assertion), then asserts `Pinned == true` **and** feeds the row through `filterClosedDeletionCandidates` asserting 0 candidates and `PinnedSkipped == 1`. That last part is the guarantee the whole approach turns on, and nothing pinned it before.
- `TestProxiedServerClose/close_boolean_pinned_reclose_is_idempotent` — the proxied twin.
- `TestEmbeddedClose/reclose_by_foreign_actor_is_idempotent` — pins the accepted collateral, asserting the assignee is unrewritten as evidence nothing was written.
- `TestNotPinned` and `TestValidateIssueClosable` gain `{Status: closed, Pinned: true}` cases asserting closed status earns **no** exemption inside the guard — the ratchet against fixing this by weakening the check instead of the ordering.
