### PR TITLE
feat(httpapi): ratify Tier 1 of the canonical Beads API

### DIFF
--- a/internal/httpapi/apigen/types.gen.go
+++ b/internal/httpapi/apigen/types.gen.go
@@ -133,7 +133,7 @@ type IssuesPage struct {
 	NextCursor *string `json:"next_cursor,omitempty"`
 }
 
-// Problem RFC 9457 problem detail. This is the only error shape on this surface. `type` is omitted throughout, so `about:blank` is implied.
+// Problem RFC 9457 problem detail. This is the only error shape on this surface. The core declares `type`; this server never emits it, so `about:blank` is implied throughout.
 type Problem struct {
 	// Assignee With `already_claimed`: the actor currently holding the issue.
 	Assignee *string `json:"assignee,omitempty"`
@@ -153,14 +153,17 @@ type Problem struct {
 	// Reason With `invalid_argument`: `unknown_parameter` (this server does not know that parameter — version skew; degrade or fall back) or `invalid_value` (the value is not one this server will act on: malformed, out of vocabulary, or — for `limit=0` under `--allow-non-loopback` — legal but refused in this server's configuration; `detail` says which). Either way `invalid_value` means send something different, never retry the same request. The set may grow; default-branch on unknown values.
 	Reason *string `json:"reason,omitempty"`
 
-	// RequestId Correlation id for this request, echoed in the server's request log line. Present on every problem response from every route, including the ones the middleware answers before a handler runs. Opaque and per-process: it identifies a log line, nothing else, so it is never a retry key and never survives a restart. Quote it in a bug report and the operator can find the one line that explains the failure.
-	RequestId *string `json:"request_id,omitempty"`
+	// RequestId Opaque correlation id for this request, echoed in the server's request log line. Never a dispatch key and never a retry key. (This server mints per-process ids that do not survive a restart; a deployment may substitute any identifier with the same log-correlation property, such as an edge trace id.)
+	RequestId string `json:"request_id"`
 
 	// Status The HTTP status code, repeated in the body.
 	Status int `json:"status"`
 
 	// Title The status phrase. Human-facing; never dispatch on it.
 	Title string `json:"title"`
+
+	// Type RFC 9457 problem type. This server never emits it, so `about:blank` is implied. A deployment that hosts problem documentation MAY supply it: one stable URI per status+code pair, dereferencing to documentation for that pair. It restates identity that `code` already carries, so a client MUST NOT dispatch on it and a server MUST NOT use it to subdivide a code.
+	Type *string `json:"type,omitempty"`
 }
 
 // ReadyPage defines model for ReadyPage.
@@ -175,16 +178,16 @@ type ReadyPage struct {
 // IssueID defines model for IssueID.
 type IssueID = string
 
-// InternalError RFC 9457 problem detail. This is the only error shape on this surface. `type` is omitted throughout, so `about:blank` is implied.
+// InternalError RFC 9457 problem detail. This is the only error shape on this surface. The core declares `type`; this server never emits it, so `about:blank` is implied throughout.
 type InternalError = Problem
 
-// InvalidArgument RFC 9457 problem detail. This is the only error shape on this surface. `type` is omitted throughout, so `about:blank` is implied.
+// InvalidArgument RFC 9457 problem detail. This is the only error shape on this surface. The core declares `type`; this server never emits it, so `about:blank` is implied throughout.
 type InvalidArgument = Problem
 
-// NotFound RFC 9457 problem detail. This is the only error shape on this surface. `type` is omitted throughout, so `about:blank` is implied.
+// NotFound RFC 9457 problem detail. This is the only error shape on this surface. The core declares `type`; this server never emits it, so `about:blank` is implied throughout.
 type NotFound = Problem
 
-// Unavailable RFC 9457 problem detail. This is the only error shape on this surface. `type` is omitted throughout, so `about:blank` is implied.
+// Unavailable RFC 9457 problem detail. This is the only error shape on this surface. The core declares `type`; this server never emits it, so `about:blank` is implied throughout.
 type Unavailable = Problem
 
 // ListIssuesParams defines parameters for ListIssues.

--- a/internal/httpapi/problem.go
+++ b/internal/httpapi/problem.go
@@ -204,15 +204,15 @@ func (r Result) WithIssueStatus(status string) Result {
 	return r
 }
 
-// WithRequestID attaches the `request_id` extension member, the correlation id
-// echoed in the request log line. It is what makes a 5xx actionable: the body
-// carries a fixed static detail by design, so the id is the client's only
-// handle on the one log line that has the real error.
+// WithRequestID sets the `request_id` member, the correlation id echoed in the
+// request log line. It is what makes a 5xx actionable: the body carries a fixed
+// static detail by design, so the id is the client's only handle on the one log
+// line that has the real error. The document requires it on every problem
+// response, which is why this sets it unconditionally — an id this server
+// failed to mint travels as an empty string rather than as a missing required
+// member.
 func (r Result) WithRequestID(id string) Result {
-	if id == "" {
-		return r
-	}
-	r.Problem.RequestId = &id
+	r.Problem.RequestId = id
 	return r
 }
 

--- a/internal/httpapi/spec/openapi.v0.yaml
+++ b/internal/httpapi/spec/openapi.v0.yaml
@@ -105,6 +105,53 @@ info:
     two-way JSON-tag bijection test, covering all seven, fails CI otherwise. A
     breaking change to those shapes requires cutting `/v1`, not editing `/v0`.
 
+
+    A member that is absent is not set. When reading a RESPONSE, clients MUST
+    treat an explicit `null` member identically to an absent member. Producers
+    on this surface omit absent members; a profile MAY instead emit `null` for
+    members it declares always-present. Explicit `null` in a REQUEST body is
+    NOT covered by this rule; its meaning is defined per operation.
+
+
+    ## Profiles
+
+
+    A PROFILE is a separate document that re-publishes part of this contract as
+    its own surface. Conformance to this core is a checkable relation over
+    wire-observable JSON — the profile's value model is subsumed by this one,
+    plus the deviations the profile DECLARES — not a claim of shared
+    vocabulary. Four rules make it checkable.
+
+
+    * **Verbatim or absent.** A property emitted under a core name carries the
+      core type, format and semantics, and its value is the canonical value
+      verbatim or is wholly absent. Nothing is transformed in place: a
+      re-spelling, a coercion to another JSON type, or a truncation, published
+      under a core name, is non-conformant — and omitting the member is always
+      the conformant alternative.
+
+    * **Tightening is bounds-only.** A profile MAY omit optional properties, and
+      MAY tighten `maxLength`, `maxItems` and `maxProperties` or close an open
+      vocabulary, provided every instance it emits is still valid against this
+      document once explicit `null` is read as absence. Widening a bound,
+      re-typing a member, or extending a vocabulary this document closes is not
+      tightening.
+
+    * **Required members are retained.** A profile keeps the required members of
+      every top-level resource. Dropping a required member of an EMBEDDED
+      relation — a nested edge or summary carried inside another resource — is
+      legal only where the profile DECLARES that omission and its reason. A
+      silent omission never is.
+
+    * **Extensions are declared, and their names ratchet.** A profile MAY add
+      members of its own, provided each is marked as an extension in the
+      profile's own document and its name is not one this document already
+      defines. Because `/v0` grows by ADDING optional members, a later revision
+      of this document may define a name a profile is already using: that
+      collision is reconciled — the core member adopted, or the extension
+      renamed — as part of adopting the revision, never left to resolve by
+      itself.
+
 paths:
 
   /healthz:

--- a/internal/httpapi/spec/openapi.v0.yaml
+++ b/internal/httpapi/spec/openapi.v0.yaml
@@ -1465,9 +1465,20 @@ components:
       type: object
       description: >-
         RFC 9457 problem detail. This is the only error shape on this surface.
-        `type` is omitted throughout, so `about:blank` is implied.
-      required: [status, title, code]
+        The core declares `type`; this server never emits it, so `about:blank`
+        is implied throughout.
+      required: [status, title, code, request_id]
       properties:
+        type:
+          type: string
+          format: uri
+          description: >-
+            RFC 9457 problem type. This server never emits it, so `about:blank`
+            is implied. A deployment that hosts problem documentation MAY supply
+            it: one stable URI per status+code pair, dereferencing to
+            documentation for that pair. It restates identity that `code`
+            already carries, so a client MUST NOT dispatch on it and a server
+            MUST NOT use it to subdivide a code.
         status:
           type: integer
           description: The HTTP status code, repeated in the body.
@@ -1524,9 +1535,8 @@ components:
         request_id:
           type: string
           description: >-
-            Correlation id for this request, echoed in the server's request log
-            line. Present on every problem response from every route, including
-            the ones the middleware answers before a handler runs. Opaque and
-            per-process: it identifies a log line, nothing else, so it is never
-            a retry key and never survives a restart. Quote it in a bug report
-            and the operator can find the one line that explains the failure.
+            Opaque correlation id for this request, echoed in the server's
+            request log line. Never a dispatch key and never a retry key.
+            (This server mints per-process ids that do not survive a restart;
+            a deployment may substitute any identifier with the same
+            log-correlation property, such as an edge trace id.)


### PR DESCRIPTION
Lands Tier 1 of the canonical Beads API ratification. `internal/httpapi/spec/openapi.v0.yaml` is now
the canonical Beads API; a downstream consumer submits fragments in canonical shape and this repo
decides the canonical form. Four changes land here; the rest of the ratification lands downstream.

## `Problem.request_id` becomes required

`required: [status, title, code]` → `[status, title, code, request_id]`.

This is a downstream proposal **adopted**, and it corrects a spec bug rather than adding a feature.
The server already emits `request_id` on every problem response — every non-2xx flows through
`s.fail`, which unconditionally applies `WithRequestID(rec.id)`, with the id minted by the outermost
middleware including the panic path. And 5xx `detail` is a fixed static string by design, so
`request_id` is the *only* actionable member of a 5xx. The schema was the one place not saying so.

Regen consequence, taken rather than worked around: `apigen.Problem.RequestId` goes from
`*string`/`omitempty` to a plain `string`, and `WithRequestID` loses both its pointer assignment and
its empty-string guard. The description is split into contract vs implementation note so a
multi-instance deployment can satisfy it with an edge trace id instead of this server's per-process id.

## RFC 9457 `type` declared, not required

The downstream consumer requires `type`. Requiring it in core is **rejected**; the use case is served.
`type` is declared first in RFC member order, optional, `format: uri`, and the description carries both
prohibitions: a client MUST NOT dispatch on it and a server MUST NOT use it to subdivide a `code`,
because it restates identity `code` already carries. This server never emits it, so `about:blank` is
implied. A profile requiring it is a legal tightening.

`instance` stays undeclared — `request_id` is the occurrence identifier.

## Null-equivalence, scoped to responses

An absent member is not set; when reading a **response**, clients MUST treat explicit `null`
identically to absent. Producers here omit; a profile MAY emit `null` for members it declares
always-present.

The response-only scoping is deliberate and load-bearing: it blesses a required-nullable downstream
style with zero edits *and* reserves request-body `null` for a future PATCH clear-field semantic.

## Profiles — the conformance relation

Conformance is stated as a checkable relation, not shared-vocabulary aspiration: value-model
subsumption plus declared deviations. Four rules — verbatim-or-absent fidelity, bounds-only tightening,
required-retention with declared-only embedded omissions, and declared extensions with a
name-collision ratchet.

This is what lets two well-argued and opposed positions coexist: this spec pins `Issue` to the
canonical Go struct so CLI `--json` and HTTP bodies are one compatibility domain, while a public,
multi-tenant deployment needs a closed DTO with a bound on response size. Sharing names, types and
semantics is the contract; sharing the field set is not.

Written vendor-neutrally, as the document's own header requires: it names no product, no deployment
and no downstream consumer.

## Verification

`make api-check` clean with regenerated types committed. The two description-only changes produce a
**byte-identical** regen — independently reproduced in a detached worktree, same blob hash — which is
their proof. The four existing `request_id` presence tests stay green, including the panic-path and
log-correlation ones.

Note the bijection test is *not* evidence here: it covers only the seven pinned schemas and `Problem`
is not one of them. The regen-diff gate is what proves the generated type matches the spec.

`openapi: 3.0.3` is unchanged. The dialect was ratified as toolchain-facing rather than part of the
wire contract, and the `oapi-codegen` `allOf`/`x-go-type` trap that shapes the pinned schemas was
verified only against 3.0.3 — a 3.1 move needs its own re-verification pass.
