### PR TITLE
docs(httpapi): close the re-spell and value-narrowing gaps in the Profiles relation

### DIFF
--- a/internal/httpapi/spec/openapi.v0.yaml
+++ b/internal/httpapi/spec/openapi.v0.yaml
@@ -120,7 +120,7 @@ info:
     its own surface. Conformance to this core is a checkable relation over
     wire-observable JSON — the profile's value model is subsumed by this one,
     plus the deviations the profile DECLARES — not a claim of shared
-    vocabulary. Four rules make it checkable.
+    vocabulary. Five rules make it checkable.
 
 
     * **Verbatim or absent.** A property emitted under a core name carries the
@@ -130,12 +130,36 @@ info:
       under a core name, is non-conformant — and omitting the member is always
       the conformant alternative.
 
-    * **Tightening is bounds-only.** A profile MAY omit optional properties, and
-      MAY tighten `maxLength`, `maxItems` and `maxProperties` or close an open
-      vocabulary, provided every instance it emits is still valid against this
-      document once explicit `null` is read as absence. Widening a bound,
-      re-typing a member, or extending a vocabulary this document closes is not
-      tightening.
+    * **An omission is not a licence to re-spell.** A profile that omits a core
+      member MUST NOT publish that member's value under any other name.
+      Omission means the value is not on the wire; an extension that carries
+      it is a re-spelling of a core member, and is non-conformant however
+      carefully the extension itself is declared.
+
+    * **Tightening is bounds-only.** A profile MAY omit optional properties,
+      and MAY tighten `maxLength`, `maxItems` and `maxProperties` or close an
+      open vocabulary, provided every instance it emits is still valid against
+      this document once explicit `null` is read as absence. That list is
+      exhaustive and the proviso is a floor, not a grant: a change the list
+      does not name is not made a tightening by the fact that its instances
+      still validate. Widening a bound, re-typing a member, or extending a
+      vocabulary this document closes is not tightening.
+
+      **A narrowed value schema is a declared deviation.** Constraining what a
+      member's VALUES may be — admitting only short strings, say, where this
+      document admits any JSON value — is a third thing, and it is how a
+      profile caps the size of a response without transforming anything: not
+      one of the bounds above, and not the re-typing this rule excludes,
+      because every value that does go on the wire is still the canonical
+      value. It is a DEVIATION, conformant only where the profile DECLARES it,
+      by the same machinery that declares an embedded-relation omission, and
+      only on these terms. A value that does not satisfy the narrower schema is
+      OMITTED ENTIRELY rather than coerced to fit; stringifying a typed value
+      in place is a transformation, and "verbatim or absent" already forbids
+      it. And the declaration states that the member MAY BE INCOMPLETE, because
+      a consumer of the profile cannot distinguish an entry dropped for failing
+      the narrower schema from one that was never set: that consequence must be
+      visible in the declaration, not left to be discovered.
 
     * **Required members are retained.** A profile keeps the required members of
       every top-level resource. Dropping a required member of an EMBEDDED
@@ -889,7 +913,10 @@ components:
             typed values enter through the explicit JSON metadata path and
             persist in older rows. Clients MUST NOT decode this into a
             string-to-string map; a strict decode fails on the first typed
-            value and takes the whole response with it.
+            value and takes the whole response with it. That prohibition is on
+            assuming a narrower type when reading THIS document: a profile MAY
+            declare a narrower value schema under the rules in **Profiles**,
+            and a client of that profile may rely on the profile's declaration.
 
 
             The object-at-top-level shape is the contract every producer and


### PR DESCRIPTION
Two composition gaps in the `## Profiles` conformance relation landed in #5237, found by running a
live profile against the four rules rather than reasoning about them abstractly. Both are
description-only; the regen is byte-identical.

## An omission is not a licence to re-spell

The rules composed into a hole. Rule 1 scopes non-conformance to a re-spelling *"published under a
core name"*. Rule 2 permits omitting optional properties. Rule 4 permits declared extensions whose
names this document does not define. So a profile could omit an optional core member and republish the
same value under an extension name — the exact re-spelling rule 1 exists to forbid, reached by three
individually legal steps.

That was not hypothetical. `issue_type` is optional (`Issue.required` is `[id, title, priority,
created_at, updated_at]`), so a profile omitting it and publishing the value elsewhere read as
conformant. **Tier 1's ruling that `issue_type` is the canonical name therefore bound nobody** — the
relation permitted precisely the outcome the ruling rejected.

New fifth rule, placed next to "Verbatim or absent" because that is the flank it closes: a profile that
omits a core member MUST NOT publish that member's value under any other name. The test is on the
*value's provenance*, not the spelling, so it fires the same for a freshly minted extension name as for
one this document happens to define elsewhere.

## A narrowed value schema is a declared deviation

Rule 2 contradicted itself on the case the relation most needs to answer. Its enumerated tightenings
are `maxLength`/`maxItems`/`maxProperties` and closing an open vocabulary, and it excludes "re-typing a
member" — but its proviso tests *instances*: "every instance it emits is still valid against this
document". Narrowing a free-form object to short strings is schema-level re-typing (forbidden) and
instance-level valid (permitted). Both readings were available from the text.

Ruled as a third category rather than forcing it into either. Narrowing a value schema is **legal**,
because it is how a profile caps response size without transforming anything — but it is a **declared
deviation**, not a bounds-only tightening, conformant only where:

- values failing the narrower schema are **omitted entirely rather than coerced** — stringifying a
  typed value in place is a transformation, which "verbatim or absent" already forbids; and
- the declaration states the member **may be incomplete**, because a consumer cannot distinguish an
  entry dropped for failing the narrower schema from one that was never set.

Rule 2's enumeration is now explicitly exhaustive, with the proviso stated as a floor rather than a
grant: a change the list does not name is not made a tightening by the fact that its instances still
validate.

## Core and the relation stop talking past each other

`Issue.metadata` warns that values may be any JSON type and that clients MUST NOT decode it into a
string-to-string map — while the relation now blesses a profile that declares exactly that narrowing.
One sentence scopes the prohibition to readers of *this* document; a client of a profile may rely on
the profile's declaration. The core warning itself is unchanged: core clients still must not assume.

## Verification

`make api-check` clean, run twice. `internal/httpapi/apigen/types.gen.go` hashes
`dd0f41b2a8d3c6671fc2f851c9aca86f04bb757a` before regeneration, after regeneration, and after the
commit — description-only, proven rather than asserted. Diff is one file, 35 insertions, 8 deletions.
Vendor-neutrality grep over the added lines finds no product, deployment or consumer name; the prose
names only "a profile", "a consumer of the profile", "this document".

The motivating composition was re-run against the amended text and is now non-conformant at step 4,
with both escape clauses shut individually.
