### PR TITLE
ci(pr): run the macOS test leg on PRs — macOS-only breakage currently lands undetected

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -518,6 +518,57 @@ jobs:
           BEADS_FIX_REQUIRE_DOLT: "1"
         run: go test -tags gms_pure_go -race -count=1 -v ./cmd/bd/doctor/fix/
 
+  # macOS-only regressions were landing on main undetected: main.yml's Test
+  # (macos-latest) leg only runs `if: github.event_name == 'push' &&
+  # github.ref == 'refs/heads/main'`, so no PR ever exercises it. On
+  # 2026-08-01 that leg went red from three separately-merged PRs in a single
+  # day, all $TMPDIR=/var/folders symlink/path-depth consequences that only
+  # reproduce on macOS - none of the three could have seen the failure
+  # pre-merge, and the local bisect lane can't diagnose it either (Linux
+  # host, macOS-only failure). This job mirrors that leg's steps on every PR
+  # so the same class of regression fails here instead of on main. It is
+  # self-contained (no build-artifacts dependency): the macOS leg in main.yml
+  # never downloads or verifies the Linux build-artifacts bundle, it just
+  # builds and tests directly.
+  #
+  # Deliberately NOT continue-on-error: unlike the advisory legs elsewhere in
+  # this file that tolerate infrastructure flakiness, a red macOS test here is
+  # a real regression, and blocking the merge lane on it is the entire point.
+  #
+  # Deliberately NOT yet added to ci-gate's `needs`/`CI_GATE_REQUIRED`:
+  # promoting a new job to required-for-merge, once it has run clean for a
+  # while, is a separate maintainer call - same pattern as other jobs in this
+  # file that run on every PR without yet gating the merge.
+  test-macos:
+    name: Test (macos-latest)
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: 'go.mod'
+
+      - name: Install Dolt (Linux/macOS)
+        run: curl -fsSL https://github.com/dolthub/dolt/releases/latest/download/install.sh | sudo bash
+
+      - name: Verify dolt on PATH
+        run: dolt version
+
+      - name: Configure Git and Dolt identity
+        run: |
+          git config --global user.name "CI Bot"
+          git config --global user.email "ci@beads.test"
+          dolt config --global --add user.name "CI Bot"
+          dolt config --global --add user.email "ci@beads.test"
+
+      - name: Build
+        run: go build -v -tags gms_pure_go ./cmd/bd
+
+      - name: Test
+        run: go test -tags gms_pure_go -v -race -short -skip '^TestEmbedded' ./...
+
   # Producer-side guard for the Beads<->consumer CLI contract. Runs the whole
   # cmd/bd/protocol package: the golden corpus (regenerated from this branch's
   # bd and byte-compared to the committed testdata/corpus/, so an unreviewed


### PR DESCRIPTION
## Why

macOS-only breakage is currently undetectable pre-merge. The `Test (macos-latest)` matrix leg lives only in `main.yml`, which triggers on push to `main` — so no PR ever runs the macOS suite, and every macOS-only regression lands first and is discovered afterwards as a red base.

That is not hypothetical: on 2026-08-01 main went red on `Test (macos-latest)` with three failures introduced by three separately-merged PRs, none of which could have seen the failure on its own checks (all three were macOS-specific consequences of `$TMPDIR` being a `/var/folders` symlink rather than `/tmp`). A red base then stalls every armed merge lane behind it, and the local zero-token bisect lane cannot diagnose it either — the bisect oracle runs on a Linux host, so it correctly reports `unreproducible` and burns a cycle producing no signal.

## What

Adds a standalone `test-macos` job to `pr.yml` mirroring exactly what `main.yml`'s macOS matrix leg executes: same pinned actions, same Dolt install, same build (`go build -v -tags gms_pure_go ./cmd/bd`) and same test invocation (`go test -tags gms_pure_go -v -race -short -skip '^TestEmbedded' ./...`, no coverage). The Linux-only steps (artifact download, gotestsum, coverage/Codecov) are conditionally skipped in `main.yml` for macOS and are correspondingly absent here.

Two deliberate postures, both documented in a comment on the job:

- **Not `continue-on-error`.** Unlike the advisory examples-build job, a red macOS test is a real regression; blocking the merge lane on it is the point of the job.
- **Not in `ci-gate`'s required list.** Promoting it to a required check is a separate maintainer call (macOS runner concurrency on public repos is limited; a queue-stalled runner should not hard-block the gate on day one). The raw check still surfaces red on the PR either way.

Runtime on recent main pushes: ~12 minutes, comparable to the existing heavier PR jobs.

## Validation

- YAML parses (`yaml.safe_load`); `ci-gate.needs` verified unchanged.
- Job steps diffed side-by-side against `main.yml`'s macOS leg (flags byte-identical).
- Cross-vendor review (codex `gpt-5.6-sol`) of the diff: no actionable defects; review log recorded at the head SHA.

Tracking: bd `mybd-5eacq`.

_claude-opus-5-high on behalf of maphew_
