### PR TITLE
fix(dbproxy): abort the proxy readiness wait when a concurrent stop advances the epoch

### DIFF
--- a/internal/storage/dbproxy/proxy/server.go
+++ b/internal/storage/dbproxy/proxy/server.go
@@ -189,9 +189,33 @@ func (p *proxyServer) ListenAndServe(parentCtx context.Context) error {
 		return fmt.Errorf("start database server: %w", err)
 	}
 
-	if err := waitForServerReady(ctx, p.server, serverReadyTimeout); err != nil {
+	// Re-check the stop epoch on every readiness probe, not only after the
+	// wait. A concurrent `bd dolt stop` waits at most shutdownConfirmDeadline
+	// (5s) for proxy.lock — 6x shorter than serverReadyTimeout — and this
+	// process holds the lock with neither a spawn marker nor a pidfile
+	// published, so a stop that lands mid-startup would otherwise time out
+	// against a lock we keep holding for up to 30s. Checking inside the retry
+	// loop bounds the abort latency to about one backoff interval
+	// (readyMaxBackoff). A transient epoch-file read error must not kill an
+	// otherwise healthy startup, so it is treated as "no change" here; the
+	// post-wait fence below re-reads the epoch and surfaces a persistent read
+	// error before anything is published.
+	epochInterrupted := func() error {
+		changed, err := stopEpochChanged(p.rootDir, p.stopEpoch)
+		if err != nil || !changed {
+			return nil
+		}
+		return fmt.Errorf("%w for %s: stop epoch advanced during startup", errStartInterrupted, p.rootDir)
+	}
+	if err := waitForServerReady(ctx, p.server, serverReadyTimeout, epochInterrupted); err != nil {
 		p.stats.IncBackendStop()
 		_ = stopBackendBounded(p.server)
+		if errors.Is(err, errStartInterrupted) {
+			// Not a readiness failure: keep the same wording as the
+			// post-wait fence so logs and errors.Is callers see one shape
+			// for "a concurrent stop won".
+			return err
+		}
 		return fmt.Errorf("database server not ready: %w", err)
 	}
 	birth, err := procid.Capture(os.Getpid())
@@ -401,13 +425,23 @@ func (p *proxyServer) handleConn(ctx context.Context, client net.Conn) error {
 	return g.Wait()
 }
 
-func waitForServerReady(ctx context.Context, s server.DatabaseServer, timeout time.Duration) error {
+// waitForServerReady polls s until a dial succeeds or timeout elapses.
+// interrupted, when non-nil, is consulted before every probe: a non-nil
+// return aborts the wait immediately (no further retries) with that error.
+// ListenAndServe uses it to notice a concurrent stop mid-wait, whose 5s
+// lock deadline is far shorter than this wait's 30s budget.
+func waitForServerReady(ctx context.Context, s server.DatabaseServer, timeout time.Duration, interrupted func() error) error {
 	bo := backoff.NewExponentialBackOff()
 	bo.InitialInterval = readyInitialBackoff
 	bo.MaxInterval = readyMaxBackoff
 	bo.MaxElapsedTime = timeout
 
 	return backoff.Retry(func() error {
+		if interrupted != nil {
+			if err := interrupted(); err != nil {
+				return backoff.Permanent(err)
+			}
+		}
 		if !s.Running(ctx) {
 			return errors.New("database server not running")
 		}

--- a/internal/storage/dbproxy/proxy/server.go
+++ b/internal/storage/dbproxy/proxy/server.go
@@ -194,15 +194,21 @@ func (p *proxyServer) ListenAndServe(parentCtx context.Context) error {
 	// (5s) for proxy.lock — 6x shorter than serverReadyTimeout — and this
 	// process holds the lock with neither a spawn marker nor a pidfile
 	// published, so a stop that lands mid-startup would otherwise time out
-	// against a lock we keep holding for up to 30s. Checking inside the retry
-	// loop bounds the abort latency to about one backoff interval
-	// (readyMaxBackoff). A transient epoch-file read error must not kill an
-	// otherwise healthy startup, so it is treated as "no change" here; the
-	// post-wait fence below re-reads the epoch and surfaces a persistent read
-	// error before anything is published.
+	// against a lock we keep holding for up to 30s. The check runs before
+	// each probe, so an epoch advance landing just after a check is not
+	// observed until the in-flight dial finishes (up to readyDialTimeout,
+	// 2s) plus the next backoff (up to readyMaxBackoff, 1s): worst case
+	// about 3s, still well inside the stop side's 5s deadline. A transient
+	// epoch-file read error must not kill an otherwise healthy startup, so
+	// it is treated as "no change" here; the post-wait fence below re-reads
+	// the epoch and surfaces a persistent read error before anything is
+	// published.
 	epochInterrupted := func() error {
-		changed, err := stopEpochChanged(p.rootDir, p.stopEpoch)
-		if err != nil || !changed {
+		changed, _ := stopEpochChanged(p.rootDir, p.stopEpoch)
+		if !changed {
+			// stopEpochChanged returns (false, err) on a read failure, so
+			// this also covers the error case: treat it as "no change" and
+			// let the post-wait fence surface a persistent read error.
 			return nil
 		}
 		return fmt.Errorf("%w for %s: stop epoch advanced during startup", errStartInterrupted, p.rootDir)

--- a/internal/storage/dbproxy/proxy/server_epoch_internal_test.go
+++ b/internal/storage/dbproxy/proxy/server_epoch_internal_test.go
@@ -2,6 +2,11 @@ package proxy
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"net"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -64,4 +69,102 @@ func TestListenAndServe_StopEpochAdvanceDuringStartupAbortsPublish(t *testing.T)
 	counters := ts.Snapshot()
 	assert.Equal(t, int64(1), counters.StartCalls)
 	assert.Equal(t, int64(1), counters.StopCalls, "aborting the publish must still stop the backend")
+}
+
+// TestWaitForServerReady_InterruptAbortsWait asserts the readiness wait
+// honors its interrupted seam promptly: a never-ready backend must not pin
+// the wait for the full timeout once the seam reports a concurrent stop.
+// This is the latency half of the F4 fix — `bd dolt stop` gives up on
+// proxy.lock after 5s, so an abort bounded only by serverReadyTimeout (30s)
+// fails the stop side even though the child eventually cleans up.
+func TestWaitForServerReady_InterruptAbortsWait(t *testing.T) {
+	t.Parallel()
+
+	ts := server.New()
+	ts.DialErr = errors.New("backend still starting")
+	require.NoError(t, ts.Start(context.Background()))
+
+	// Report the interruption only on the third probe so the test exercises
+	// the per-iteration re-check, not just a pre-wait fast path.
+	var calls atomic.Int64
+	interrupted := func() error {
+		if calls.Add(1) < 3 {
+			return nil
+		}
+		return fmt.Errorf("%w for test-root: stop epoch advanced during startup", errStartInterrupted)
+	}
+
+	start := time.Now()
+	err := waitForServerReady(context.Background(), ts, serverReadyTimeout, interrupted)
+	elapsed := time.Since(start)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, errStartInterrupted)
+	// Three probes are separated by at most two max-length backoff intervals
+	// (2 * readyMaxBackoff = 2s); 10s leaves slack for slow CI while still
+	// proving the wait did not run out its 30s budget.
+	assert.Less(t, elapsed, 10*time.Second,
+		"readiness wait must abort within ~one backoff interval of the interrupt, not run out serverReadyTimeout")
+	assert.GreaterOrEqual(t, calls.Load(), int64(3))
+}
+
+// epochAdvanceOnDialServer advances the stop epoch from the first readiness
+// dial and never becomes dialable, simulating `bd dolt stop` landing while
+// the backend is still starting. Deterministic: probe 1 fails after
+// advancing the epoch, so probe 2's epoch re-check must abort the wait.
+type epochAdvanceOnDialServer struct {
+	*server.TestDatabaseServerImpl
+	rootDir string
+	t       *testing.T
+	once    sync.Once
+}
+
+func (s *epochAdvanceOnDialServer) Dial(_ context.Context) (net.Conn, error) {
+	s.once.Do(func() { require.NoError(s.t, advanceStopEpoch(s.rootDir)) })
+	return nil, errors.New("backend still starting")
+}
+
+// TestListenAndServe_StopEpochAdvanceDuringReadinessWaitAbortsPromptly is the
+// mid-wait sibling of the post-wait test above: the epoch advances while the
+// child sits inside waitForServerReady against a backend that never becomes
+// ready. The abort must come from inside the retry loop — well before the
+// 30s readiness budget — release proxy.lock, and stop the backend without
+// ever publishing proxy.pid.
+func TestListenAndServe_StopEpochAdvanceDuringReadinessWaitAbortsPromptly(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	baseline, err := readStopEpoch(root)
+	require.NoError(t, err)
+
+	ts := server.New()
+	backend := &epochAdvanceOnDialServer{TestDatabaseServerImpl: ts, rootDir: root, t: t}
+
+	p := NewProxyServer(ProxyOpts{
+		RootDir:   root,
+		Port:      0,
+		Server:    backend,
+		StopEpoch: baseline,
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	start := time.Now()
+	err = p.ListenAndServe(ctx)
+	elapsed := time.Since(start)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, errStartInterrupted)
+	// Without the in-loop check this scenario burns the full 30s readiness
+	// budget and then fails as "database server not ready" instead.
+	assert.Less(t, elapsed, 15*time.Second,
+		"stop during readiness wait must abort within ~one backoff interval, not exhaust serverReadyTimeout")
+
+	pf, readErr := pidfile.Read(root, PIDFileName)
+	require.NoError(t, readErr)
+	assert.Nil(t, pf, "proxy.pid must not be published after the stop epoch advanced")
+
+	counters := ts.Snapshot()
+	assert.Equal(t, int64(1), counters.StartCalls)
+	assert.Equal(t, int64(1), counters.StopCalls, "aborting the readiness wait must still stop the backend")
 }

--- a/internal/storage/dbproxy/proxy/server_epoch_internal_test.go
+++ b/internal/storage/dbproxy/proxy/server_epoch_internal_test.go
@@ -100,11 +100,14 @@ func TestWaitForServerReady_InterruptAbortsWait(t *testing.T) {
 
 	require.Error(t, err)
 	assert.ErrorIs(t, err, errStartInterrupted)
-	// Three probes are separated by at most two max-length backoff intervals
-	// (2 * readyMaxBackoff = 2s); 10s leaves slack for slow CI while still
-	// proving the wait did not run out its 30s budget.
+	// This fake Dial fails instantly, so the three probes here are separated
+	// only by backoff, not an in-flight dial (production also has up to
+	// readyDialTimeout, 2s, on top — see the epochInterrupted comment in
+	// server.go for the real worst case, ~3s). Two max-length backoff
+	// intervals (2 * readyMaxBackoff = 2s); 10s leaves slack for slow CI
+	// while still proving the wait did not run out its 30s budget.
 	assert.Less(t, elapsed, 10*time.Second,
-		"readiness wait must abort within ~one backoff interval of the interrupt, not run out serverReadyTimeout")
+		"readiness wait must abort within a couple of backoff intervals of the interrupt, not run out serverReadyTimeout")
 	assert.GreaterOrEqual(t, calls.Load(), int64(3))
 }
 
@@ -120,7 +123,16 @@ type epochAdvanceOnDialServer struct {
 }
 
 func (s *epochAdvanceOnDialServer) Dial(_ context.Context) (net.Conn, error) {
-	s.once.Do(func() { require.NoError(s.t, advanceStopEpoch(s.rootDir)) })
+	// Dial runs on the same goroutine as the test today (via ListenAndServe's
+	// synchronous retry loop), but that is an implementation detail of the
+	// call path, not a guarantee. require.NoError's FailNow/Goexit is only
+	// legal on the test goroutine, so use t.Errorf here instead — it is
+	// documented safe to call from any goroutine.
+	s.once.Do(func() {
+		if err := advanceStopEpoch(s.rootDir); err != nil {
+			s.t.Errorf("advance stop epoch: %v", err)
+		}
+	})
 	return nil, errors.New("backend still starting")
 }
 
@@ -155,10 +167,20 @@ func TestListenAndServe_StopEpochAdvanceDuringReadinessWaitAbortsPromptly(t *tes
 
 	require.Error(t, err)
 	assert.ErrorIs(t, err, errStartInterrupted)
+	// The interrupted branch in ListenAndServe returns the raw errStartInterrupted-
+	// wrapped error, not the "database server not ready: %w" wrapper used for
+	// ordinary readiness failures — assert that distinction has teeth so a
+	// mutation dropping the errors.Is(err, errStartInterrupted) branch fails
+	// this test instead of leaving the package green.
+	assert.NotContains(t, err.Error(), "database server not ready:",
+		"an aborted-by-stop error must not carry the ordinary readiness-failure prefix")
 	// Without the in-loop check this scenario burns the full 30s readiness
-	// budget and then fails as "database server not ready" instead.
+	// budget and then fails as "database server not ready" instead. The
+	// real worst case here is bounded by the in-flight dial (this fake Dial
+	// returns immediately, so it doesn't apply) plus one backoff interval —
+	// see the epochInterrupted comment in server.go for the ~3s general bound.
 	assert.Less(t, elapsed, 15*time.Second,
-		"stop during readiness wait must abort within ~one backoff interval, not exhaust serverReadyTimeout")
+		"stop during readiness wait must abort promptly, not exhaust serverReadyTimeout")
 
 	pf, readErr := pidfile.Read(root, PIDFileName)
 	require.NoError(t, readErr)


### PR DESCRIPTION
## Why

`TestManagedLocalProxiedStopStartInterleave` can fail BOTH sides of a stop/start interleave and leave a half-torn-down proxy topology. Two prior diagnosis passes (bd `mybd-e1b3f`) established the mechanism precisely:

- The child proxy clears the spawn marker as its **first** act after taking `proxy.lock`, but publishes its pidfile only at the **end** of startup — after `net.Listen`, `startControl`, backend `Start`, and a readiness wait bounded by `serverReadyTimeout` = 30s. In that window a concurrent `bd dolt stop` finds no record at all ("pid 0") and then times out acquiring `proxy.lock` at `shutdownConfirmDeadline` = 5s — six times shorter than the lock-holder's wait.
- The child's existing stop-epoch re-check fires only **once, after** the readiness wait, so the abort path the code already has cannot release the lock inside stop's patience.

## What

The minimal fix from that diagnosis: `waitForServerReady` now consults an `interrupted` seam before each probe; `ListenAndServe` passes a closure that re-checks the stop epoch. A stop that lands mid-startup aborts the child within one dial-plus-backoff interval — worst case ~3s (in-flight dial 2s + backoff up to 1s), inside stop's 5s deadline — instead of after up to 30s. The existing post-wait fence is retained (it still covers the procid/RootID window); no timeouts changed; the spawn-marker clear is untouched.

Epoch-file read errors inside the loop are treated as no-change: a transient blip must not kill a healthy startup, and the retained post-wait fence still surfaces persistent read errors before publish.

Deliberately **not** in this PR (recorded as follow-up options on the bead if the failure ever recurs): moving the spawn-marker clear after pidfile publication (D-a) and reconciling the 5s/30s timeout mismatch (D-b). This change alone closes the observed CI failure pair with the smallest blast radius.

## Validation

- New unit tests: a direct seam test (never-ready backend, interrupt observed promptly) and a deterministic mid-wait abort scenario asserting `errStartInterrupted`, no pidfile published, backend stopped exactly once, and prompt return.
- **Negative verification**: with the in-loop check disabled, the mid-wait test fails at 29.5s vs 0.06s with it — the seam is load-bearing.
- Real interleave test run 3 iterations under `BEADS_TEST_PROXIED_LOCAL=1`: all pass; zero orphaned `dolt sql-server` processes left (verified by ps before/after).
- Full `./internal/storage/dbproxy/proxy/` package green; `go vet` clean; `make test` enqueued in the local verify queue at this head.
- Adversarial same-vendor review (verdict approve-with-nits) and cross-vendor review (codex `gpt-5.6-sol`, no actionable findings) both run on the final head; all review findings applied in the second commit.

Tracking: bd `mybd-e1b3f`.

_claude-opus-5-high on behalf of maphew_
