### PR TITLE
fix(embeddeddolt): tolerate nothing-to-commit — bd bootstrap dies on a pristine store (#3886)

### DIFF
--- a/cmd/bd/dolt.go
+++ b/cmd/bd/dolt.go
@@ -732,6 +732,7 @@ For more options (--stdin, custom messages), see: bd vc commit`,
 		if msg == "" {
 			msg = fmt.Sprintf("bd: dolt commit (auto-commit) by %s", getActor())
 		}
+		beforeHash, beforeErr := st.GetCurrentCommit(ctx)
 		if err := st.Commit(ctx, msg); err != nil {
 			if isDoltNothingToCommit(err) {
 				fmt.Println("Nothing to commit.")
@@ -740,6 +741,16 @@ For more options (--stdin, custom messages), see: bd vc commit`,
 			return HandleError("%v", err)
 		}
 		commandDidExplicitDoltCommit = true
+
+		// A store whose Commit tolerates nothing-to-commit (e.g. the embedded
+		// store) returns a nil error even when HEAD did not move. Detect that
+		// case here instead of relying on the error, so both backends report
+		// the same "nothing to commit" outcome.
+		if afterHash, afterErr := st.GetCurrentCommit(ctx); beforeErr == nil && afterErr == nil && afterHash == beforeHash {
+			fmt.Println("Nothing to commit.")
+			return nil
+		}
+
 		fmt.Println("Committed.")
 		return nil
 	},

--- a/cmd/bd/dolt_embedded_test.go
+++ b/cmd/bd/dolt_embedded_test.go
@@ -125,6 +125,20 @@ func TestEmbeddedDolt(t *testing.T) {
 		_ = out
 	})
 
+	t.Run("commit_clean_reports_nothing", func(t *testing.T) {
+		// bd init leaves the working set clean (bootstrap's own commit
+		// tolerates nothing-to-commit, GH#3886). A second, truly no-op
+		// "bd dolt commit" here must print "Nothing to commit.", not
+		// "Committed." — this is the case EmbeddedDoltStore.Commit's new
+		// nothing-to-commit tolerance made possible to reach with a nil
+		// error.
+		cleanDir, _, _ := bdInit(t, bd, "--prefix", "tdcln")
+		out := bdDolt(t, bd, cleanDir, "commit")
+		if !strings.Contains(out, "Nothing to commit.") {
+			t.Errorf("expected 'Nothing to commit.' on a clean working set, got: %s", out)
+		}
+	})
+
 	// ===== Remote management =====
 
 	t.Run("remote_list_empty", func(t *testing.T) {

--- a/cmd/bd/main.go
+++ b/cmd/bd/main.go
@@ -1886,13 +1886,23 @@ func flushBatchCommitOnShutdown() {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
+	beforeHash, beforeErr := st.GetCurrentCommit(ctx)
+
 	if err := st.Commit(ctx, "bd: flush pending changes on shutdown"); err != nil {
 		if !isDoltNothingToCommit(err) {
 			fmt.Fprintf(os.Stderr, "\nWarning: failed to flush batch commit on shutdown: %v\n", err)
 		}
-	} else {
-		fmt.Fprintf(os.Stderr, "\nFlushed pending batch commit on shutdown\n")
+		return
 	}
+
+	// A store whose Commit tolerates nothing-to-commit (e.g. the embedded
+	// store) returns a nil error even when HEAD did not move; only report
+	// the flush when HEAD actually advanced, so a clean shutdown stays quiet.
+	if afterHash, afterErr := st.GetCurrentCommit(ctx); beforeErr == nil && afterErr == nil && afterHash == beforeHash {
+		return
+	}
+
+	fmt.Fprintf(os.Stderr, "\nFlushed pending batch commit on shutdown\n")
 }
 
 // validateWorkspaceIdentity checks that the project identity from metadata.json

--- a/cmd/bd/main.go
+++ b/cmd/bd/main.go
@@ -1886,19 +1886,18 @@ func flushBatchCommitOnShutdown() {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	beforeHash, beforeErr := st.GetCurrentCommit(ctx)
-
-	if err := st.Commit(ctx, "bd: flush pending changes on shutdown"); err != nil {
+	// CommitPending reports atomically whether a commit actually landed, so a
+	// clean shutdown stays quiet without spending the 5s flush budget on
+	// HEAD-reporting probes before the commit itself (and without racing a
+	// concurrent writer's HEAD movement the way a before/after compare would).
+	committed, err := st.CommitPending(ctx, getActorWithGit())
+	if err != nil {
 		if !isDoltNothingToCommit(err) {
 			fmt.Fprintf(os.Stderr, "\nWarning: failed to flush batch commit on shutdown: %v\n", err)
 		}
 		return
 	}
-
-	// A store whose Commit tolerates nothing-to-commit (e.g. the embedded
-	// store) returns a nil error even when HEAD did not move; only report
-	// the flush when HEAD actually advanced, so a clean shutdown stays quiet.
-	if afterHash, afterErr := st.GetCurrentCommit(ctx); beforeErr == nil && afterErr == nil && afterHash == beforeHash {
+	if !committed {
 		return
 	}
 

--- a/cmd/bd/vc.go
+++ b/cmd/bd/vc.go
@@ -227,7 +227,11 @@ Examples:
 		// A store whose Commit tolerates nothing-to-commit (e.g. the embedded
 		// store) returns a nil error even when HEAD did not move. Detect that
 		// case here instead of relying on the error, so both backends report
-		// the same "nothing to commit" outcome.
+		// the same "nothing to commit" outcome. Known limitation: a concurrent
+		// writer advancing HEAD between the two reads is misattributed to this
+		// command — pre-existing for server mode, and fixing it means threading
+		// an atomic committed-bool through the VersionControl interface
+		// (tracked as bd mybd-z9h7j; CommitPending already has the shape).
 		if beforeErr == nil && err == nil && hash == beforeHash {
 			if jsonOutput {
 				return outputJSON(map[string]interface{}{"committed": false, "message": "nothing to commit"})

--- a/cmd/bd/vc.go
+++ b/cmd/bd/vc.go
@@ -205,6 +205,8 @@ Examples:
 			return HandleErrorRespectJSON("commit message is required (use -m, --message, or --stdin)")
 		}
 
+		beforeHash, beforeErr := store.GetCurrentCommit(ctx)
+
 		commandDidExplicitDoltCommit = true
 		if err := store.Commit(ctx, vcCommitMessage); err != nil {
 			if isDoltNothingToCommit(err) {
@@ -220,6 +222,18 @@ Examples:
 		hash, err := store.GetCurrentCommit(ctx)
 		if err != nil {
 			hash = "(unknown)"
+		}
+
+		// A store whose Commit tolerates nothing-to-commit (e.g. the embedded
+		// store) returns a nil error even when HEAD did not move. Detect that
+		// case here instead of relying on the error, so both backends report
+		// the same "nothing to commit" outcome.
+		if beforeErr == nil && err == nil && hash == beforeHash {
+			if jsonOutput {
+				return outputJSON(map[string]interface{}{"committed": false, "message": "nothing to commit"})
+			}
+			fmt.Println("Nothing to commit")
+			return nil
 		}
 
 		if jsonOutput {

--- a/cmd/bd/vc_embedded_test.go
+++ b/cmd/bd/vc_embedded_test.go
@@ -88,6 +88,31 @@ func TestEmbeddedVC(t *testing.T) {
 		}
 	})
 
+	t.Run("commit_clean_reports_nothing", func(t *testing.T) {
+		// bd init leaves the working set clean (bootstrap's own commit
+		// tolerates nothing-to-commit, GH#3886). A second, truly no-op
+		// commit here must be reported as "nothing to commit", not
+		// silently treated as a fresh commit — this is the case
+		// EmbeddedDoltStore.Commit's new nothing-to-commit tolerance made
+		// possible to reach with a nil error.
+		dir, _, _ := bdInit(t, bd, "--prefix", "vccln")
+
+		cmd := exec.Command(bd, "vc", "commit", "-m", "clean working set", "--json")
+		cmd.Dir = dir
+		cmd.Env = bdEnv(dir)
+		stdout, stderr, err := runCommandBuffers(t, cmd)
+		if err != nil {
+			t.Fatalf("bd vc commit --json failed unexpectedly: %v\nstdout:\n%s\nstderr:\n%s", err, stdout.String(), stderr.String())
+		}
+		var result map[string]interface{}
+		if jsonErr := json.Unmarshal(stdout.Bytes(), &result); jsonErr != nil {
+			t.Fatalf("failed to parse JSON: %v\n%s", jsonErr, stdout.String())
+		}
+		if committed, _ := result["committed"].(bool); committed {
+			t.Errorf("expected committed=false on a clean working set, got: %s", stdout.String())
+		}
+	})
+
 	t.Run("commit_json", func(t *testing.T) {
 		dir, _, _ := bdInit(t, bd, "--prefix", "vccj")
 		// bd create auto-commits, so vc commit may see "nothing to commit".

--- a/internal/storage/embeddeddolt/commit_nothing_to_commit_test.go
+++ b/internal/storage/embeddeddolt/commit_nothing_to_commit_test.go
@@ -1,0 +1,37 @@
+//go:build cgo
+
+package embeddeddolt_test
+
+import (
+	"testing"
+)
+
+// TestEmbeddedCommitToleratesNothingToCommit is the GH#3886 regression test:
+// `bd bootstrap` always builds an embedded store (no ServerMode) and, on a
+// pristine store, calls SetConfig followed by CommitWithConfig with an
+// otherwise-clean working set. Before this fix, EmbeddedDoltStore.Commit
+// wrapped ANY DOLT_COMMIT error — including Dolt's benign "nothing to
+// commit" — as a hard failure, so bootstrap died even though the server
+// store (DoltStore) has always tolerated the identical case. Both entry
+// points that alias to Commit (Commit itself and CommitWithConfig) must
+// succeed here with no working-set changes at all.
+func TestEmbeddedCommitToleratesNothingToCommit(t *testing.T) {
+	skipUnlessEmbeddedDolt(t)
+	ctx := t.Context()
+
+	t.Run("Commit", func(t *testing.T) {
+		te := newTestEnv(t, "cnt1")
+		// newTestEnv already committed the seed config, so the working set is
+		// clean here: this Commit call has nothing new to stage.
+		if err := te.store.Commit(ctx, "test: nothing to commit"); err != nil {
+			t.Fatalf("Commit on clean working set: %v", err)
+		}
+	})
+
+	t.Run("CommitWithConfig", func(t *testing.T) {
+		te := newTestEnv(t, "cnt2")
+		if err := te.store.CommitWithConfig(ctx, "test: nothing to commit"); err != nil {
+			t.Fatalf("CommitWithConfig on clean working set: %v", err)
+		}
+	})
+}

--- a/internal/storage/embeddeddolt/federation.go
+++ b/internal/storage/embeddeddolt/federation.go
@@ -247,7 +247,13 @@ func (s *EmbeddedDoltStore) Sync(ctx context.Context, peer string, strategy stri
 		}
 		result.ConflictsResolved = true
 
-		if err := s.Commit(ctx, fmt.Sprintf("Resolve conflicts from %s using %s strategy", peer, strategy)); err != nil {
+		// CommitMergeResolution, not Commit: Commit's GH#3886 nothing-to-commit
+		// tolerance would swallow the --ours case (resolution dirties nothing)
+		// as a silent no-op here, leaving dolt_merge_status.is_merging true while
+		// this function reports result.Merged = true and pushes — the exact
+		// re-wedge CommitMergeResolution's doc comment describes. See the
+		// server-mode twin, dolt/federation.go's Sync.
+		if err := s.CommitMergeResolution(ctx, fmt.Sprintf("Resolve conflicts from %s using %s strategy", peer, strategy)); err != nil {
 			result.Error = fmt.Errorf("commit conflict resolution: %w", err)
 			return result, result.Error
 		}

--- a/internal/storage/embeddeddolt/store.go
+++ b/internal/storage/embeddeddolt/store.go
@@ -781,15 +781,25 @@ func (s *EmbeddedDoltStore) ActiveDatabaseSize(ctx context.Context) (int64, erro
 // Branch, Checkout, CurrentBranch, DeleteBranch, ListBranches are
 // implemented in version_control.go via versioncontrolops.
 
+// CommitPending commits all working set changes and reports whether a commit
+// actually landed. It compares HEAD before and after rather than inspecting
+// Commit's error: as of GH#3886, Commit itself tolerates Dolt's "nothing to
+// commit" response (matching the server store) and returns nil for it, so an
+// error-based check here would report every clean-store call as "committed".
 func (s *EmbeddedDoltStore) CommitPending(ctx context.Context, actor string) (bool, error) {
+	before, err := s.GetCurrentCommit(ctx)
+	if err != nil {
+		return false, fmt.Errorf("commit pending: get current commit: %w", err)
+	}
 	msg := fmt.Sprintf("bd: commit pending changes by %s", actor)
 	if err := s.Commit(ctx, msg); err != nil {
-		if issueops.IsNothingToCommitError(err) {
-			return false, nil
-		}
 		return false, err
 	}
-	return true, nil
+	after, err := s.GetCurrentCommit(ctx)
+	if err != nil {
+		return false, fmt.Errorf("commit pending: get current commit: %w", err)
+	}
+	return before != after, nil
 }
 
 // CommitExists is implemented in version_control.go via versioncontrolops.

--- a/internal/storage/embeddeddolt/store.go
+++ b/internal/storage/embeddeddolt/store.go
@@ -782,24 +782,16 @@ func (s *EmbeddedDoltStore) ActiveDatabaseSize(ctx context.Context) (int64, erro
 // implemented in version_control.go via versioncontrolops.
 
 // CommitPending commits all working set changes and reports whether a commit
-// actually landed. It compares HEAD before and after rather than inspecting
-// Commit's error: as of GH#3886, Commit itself tolerates Dolt's "nothing to
-// commit" response (matching the server store) and returns nil for it, so an
-// error-based check here would report every clean-store call as "committed".
+// actually landed. It gets that from commitAll's returned bool rather than
+// inspecting Commit's error or reading HEAD before and after: as of GH#3886,
+// Commit itself tolerates Dolt's "nothing to commit" response (matching the
+// server store) and returns nil for it, so an error-based check here would
+// report every clean-store call as "committed", and a HEAD-before/HEAD-after
+// comparison would cost two extra engine opens on every call (this runs on
+// every embedded pull/sync) and race against any concurrent HEAD movement.
 func (s *EmbeddedDoltStore) CommitPending(ctx context.Context, actor string) (bool, error) {
-	before, err := s.GetCurrentCommit(ctx)
-	if err != nil {
-		return false, fmt.Errorf("commit pending: get current commit: %w", err)
-	}
 	msg := fmt.Sprintf("bd: commit pending changes by %s", actor)
-	if err := s.Commit(ctx, msg); err != nil {
-		return false, err
-	}
-	after, err := s.GetCurrentCommit(ctx)
-	if err != nil {
-		return false, fmt.Errorf("commit pending: get current commit: %w", err)
-	}
-	return before != after, nil
+	return s.commitAll(ctx, msg, true)
 }
 
 // CommitExists is implemented in version_control.go via versioncontrolops.

--- a/internal/storage/embeddeddolt/version_control.go
+++ b/internal/storage/embeddeddolt/version_control.go
@@ -98,6 +98,33 @@ func (s *EmbeddedDoltStore) withMutatingPinnedDBConn(ctx context.Context, fn fun
 	return s.withPinnedDBConn(ctx, fn)
 }
 
+// commitAll runs the single embedded commit statement, DOLT_COMMIT('-Am'),
+// on one connection (via withConn) and reports whether a commit actually
+// landed. When tolerateEmpty is true, Dolt's "nothing to commit" response is
+// treated as a no-op (committed=false, err=nil) instead of an error — the
+// GH#3886 parity behavior Commit relies on. When tolerateEmpty is false, that
+// same response is returned as an error instead, which CommitMergeResolution
+// relies on (see its doc comment).
+//
+// Callers that need to know whether a commit landed (CommitPending) get it
+// from the returned bool instead of reading HEAD before and after: HEAD reads
+// are extra engine opens and are subject to a HEAD-moved-between-reads race
+// if anything else writes concurrently.
+func (s *EmbeddedDoltStore) commitAll(ctx context.Context, message string, tolerateEmpty bool) (committed bool, err error) {
+	err = s.withConn(ctx, true, func(tx *sql.Tx) error {
+		if _, execErr := tx.ExecContext(ctx, "CALL DOLT_COMMIT('-Am', ?)", message); execErr != nil {
+			if tolerateEmpty && issueops.IsNothingToCommitError(execErr) {
+				committed = false
+				return nil
+			}
+			return fmt.Errorf("dolt commit: %w", execErr)
+		}
+		committed = true
+		return nil
+	})
+	return committed, err
+}
+
 // Commit stages and commits the full working set. A clean working set is not
 // an error here: the server store (DoltStore.Commit et al., via
 // isDoltNothingToCommit) has always tolerated Dolt's "nothing to commit"
@@ -106,15 +133,8 @@ func (s *EmbeddedDoltStore) withMutatingPinnedDBConn(ctx context.Context, fn fun
 // CommitWithConfig (below) right after SetConfig on a pristine, otherwise-clean
 // store, died on it (GH#3886). Tolerating it here brings embedded to parity.
 func (s *EmbeddedDoltStore) Commit(ctx context.Context, message string) error {
-	return s.withConn(ctx, true, func(tx *sql.Tx) error {
-		if _, err := tx.ExecContext(ctx, "CALL DOLT_COMMIT('-Am', ?)", message); err != nil {
-			if issueops.IsNothingToCommitError(err) {
-				return nil
-			}
-			return fmt.Errorf("dolt commit: %w", err)
-		}
-		return nil
-	})
+	_, err := s.commitAll(ctx, message, true)
+	return err
 }
 
 // CommitWithConfig commits all working set changes including config.
@@ -134,24 +154,19 @@ func (s *EmbeddedDoltStore) CommitWithConfig(ctx context.Context, message string
 // resolving the conflict dirtied nothing — DoltStore.CommitMergeResolution
 // handles exactly this by explicitly concluding the open merge instead of
 // treating the empty diff as a no-op (concludeOpenMerge, wy-36ilm F12; see
-// versioncontrolops.mergeInProgress / GetMergeBlockers, whose doc comment notes
-// this same gap already surfaces as "a raw dolt error from
-// CommitMergeResolution" for embedded). Swallowing the error here without also
-// concluding the merge would leave dolt_merge_status.is_merging true while
-// reporting success, silently re-wedging the next pull/sync — worse than
-// today's explicit failure. Whether embedded DOLT_COMMIT('-Am') already
-// concludes an open merge on a clean working set (unlike the server-mode
-// stored-procedure path, which requires the explicit conclude step) was not
-// established here, so this keeps the pre-existing non-tolerant behavior
-// rather than guess (GH#3886 scope: fix bootstrap's plain-Commit path, not
-// merge conclusion semantics).
+// versioncontrolops.GetMergeBlockers, which documents the same class of gap:
+// merge state that a plain commit-error check cannot see). Swallowing the
+// error here without also concluding the merge would leave
+// dolt_merge_status.is_merging true while reporting success, silently
+// re-wedging the next pull/sync — worse than today's explicit failure.
+// Whether embedded DOLT_COMMIT('-Am') already concludes an open merge on a
+// clean working set (unlike the server-mode stored-procedure path, which
+// requires the explicit conclude step) was not established here, so this
+// keeps the pre-existing non-tolerant behavior rather than guess (GH#3886
+// scope: fix bootstrap's plain-Commit path, not merge conclusion semantics).
 func (s *EmbeddedDoltStore) CommitMergeResolution(ctx context.Context, message string) error {
-	return s.withConn(ctx, true, func(tx *sql.Tx) error {
-		if _, err := tx.ExecContext(ctx, "CALL DOLT_COMMIT('-Am', ?)", message); err != nil {
-			return fmt.Errorf("dolt commit: %w", err)
-		}
-		return nil
-	})
+	_, err := s.commitAll(ctx, message, false)
+	return err
 }
 
 func (s *EmbeddedDoltStore) AddRemote(ctx context.Context, name, url string) error {

--- a/internal/storage/embeddeddolt/version_control.go
+++ b/internal/storage/embeddeddolt/version_control.go
@@ -98,9 +98,19 @@ func (s *EmbeddedDoltStore) withMutatingPinnedDBConn(ctx context.Context, fn fun
 	return s.withPinnedDBConn(ctx, fn)
 }
 
+// Commit stages and commits the full working set. A clean working set is not
+// an error here: the server store (DoltStore.Commit et al., via
+// isDoltNothingToCommit) has always tolerated Dolt's "nothing to commit"
+// response, but this embedded path wrapped it as a hard failure — so `bd
+// bootstrap`, which builds an embedded store unconditionally and calls
+// CommitWithConfig (below) right after SetConfig on a pristine, otherwise-clean
+// store, died on it (GH#3886). Tolerating it here brings embedded to parity.
 func (s *EmbeddedDoltStore) Commit(ctx context.Context, message string) error {
 	return s.withConn(ctx, true, func(tx *sql.Tx) error {
 		if _, err := tx.ExecContext(ctx, "CALL DOLT_COMMIT('-Am', ?)", message); err != nil {
+			if issueops.IsNothingToCommitError(err) {
+				return nil
+			}
 			return fmt.Errorf("dolt commit: %w", err)
 		}
 		return nil
@@ -116,10 +126,32 @@ func (s *EmbeddedDoltStore) CommitWithConfig(ctx context.Context, message string
 // CommitMergeResolution concludes an operator --strategy merge resolution with
 // config included. Embedded Commit already stages everything via DOLT_COMMIT
 // ('-Am'), so config is never dropped here the way server-mode Commit drops it
-// (GH#2455); this alias satisfies the VersionControl interface so cmd/bd can
-// conclude bd vc merge --strategy uniformly across both stores.
+// (GH#2455).
+//
+// Unlike Commit/CommitWithConfig, this does NOT alias Commit and does NOT
+// tolerate a "nothing to commit" response: a merge resolution that leaves the
+// working set clean is the --ours case, where our values already stood and
+// resolving the conflict dirtied nothing — DoltStore.CommitMergeResolution
+// handles exactly this by explicitly concluding the open merge instead of
+// treating the empty diff as a no-op (concludeOpenMerge, wy-36ilm F12; see
+// versioncontrolops.mergeInProgress / GetMergeBlockers, whose doc comment notes
+// this same gap already surfaces as "a raw dolt error from
+// CommitMergeResolution" for embedded). Swallowing the error here without also
+// concluding the merge would leave dolt_merge_status.is_merging true while
+// reporting success, silently re-wedging the next pull/sync — worse than
+// today's explicit failure. Whether embedded DOLT_COMMIT('-Am') already
+// concludes an open merge on a clean working set (unlike the server-mode
+// stored-procedure path, which requires the explicit conclude step) was not
+// established here, so this keeps the pre-existing non-tolerant behavior
+// rather than guess (GH#3886 scope: fix bootstrap's plain-Commit path, not
+// merge conclusion semantics).
 func (s *EmbeddedDoltStore) CommitMergeResolution(ctx context.Context, message string) error {
-	return s.Commit(ctx, message)
+	return s.withConn(ctx, true, func(tx *sql.Tx) error {
+		if _, err := tx.ExecContext(ctx, "CALL DOLT_COMMIT('-Am', ?)", message); err != nil {
+			return fmt.Errorf("dolt commit: %w", err)
+		}
+		return nil
+	})
 }
 
 func (s *EmbeddedDoltStore) AddRemote(ctx context.Context, name, url string) error {


### PR DESCRIPTION
## Why

`bd bootstrap` dies with `commit init: dolt commit: Error 1105: nothing to commit` on a pristine store (#3886). Root cause, verified byte-for-byte through the error chain: bootstrap always constructs the **embedded** store (its `dolt.Config` never sets `ServerMode`), and the embedded store's `Commit` has no nothing-to-commit tolerance — while the server store has tolerated exactly this case in all three of its commit modes since long before v1.0.2. A clean `SetConfig` + `CommitWithConfig` during bootstrap therefore fails only on the embedded path, which is the default path.

## What

- `EmbeddedDoltStore`: commits now flow through one internal `commitAll(ctx, msg, tolerateEmpty) (committed bool, err error)`; `Commit`/`CommitWithConfig` tolerate Dolt's nothing-to-commit response (parity with the server store), `CommitMergeResolution` deliberately does **not** — a clean merge resolution is the `--ours` case and must still conclude the merge, so swallowing it there would re-wedge the next pull (wy-36ilm). `Sync`'s conflict-resolution conclude was moved onto `CommitMergeResolution` for the same reason, mirroring the server-mode twin.
- `CommitPending` returns `commitAll`'s bool instead of comparing HEAD around the commit — one engine open instead of three on every embedded pull/sync, and no TOCTOU.
- CLI reporting made honest for **both** backends: `bd vc commit` / `bd dolt commit` on a clean working set report "Nothing to commit" (JSON `committed:false`) via a HEAD compare instead of keying off the error — server mode has misreported this case all along. The shutdown batch-flush uses `CommitPending` so a no-op stays quiet without spending the 5s flush budget on reporting probes.
- Regression tests: clean-working-set commit via `Commit`/`CommitWithConfig` (the #3886 shape), and clean-commit no-op reporting for `bd vc commit` and `bd dolt commit` on the embedded store.

Known limitation, documented in-code: the interactive vc/dolt HEAD compare can misattribute a concurrent writer's commit (pre-existing behavior for server mode); the clean fix is threading `CommitPending`'s atomic committed-bool shape through the `VersionControl` interface — tracked as bd `mybd-z9h7j`.

## Validation

- Full `./internal/storage/embeddeddolt/` package green; embedded-gated `TestEmbeddedVC`/`TestEmbeddedDolt` green including the new no-op subtests; `go vet` + full-repo build clean; `make test` enqueued in the local verify queue at this head.
- Adversarial same-vendor review (caught the `Sync` conclude-path gap before it shipped) and two cross-vendor codex reviews; all findings applied or filed (`mybd-z9h7j`, review logs recorded at each reviewed head).

Fixes #3886. Tracking: bd `mybd-p9a1o` (root-caused from `mybd-ghh34`).

_claude-opus-5-high on behalf of maphew_
