### PR TITLE
test: collapse removed-backend admin command matrix

### DIFF
--- a/cmd/bd/store_selection_removed_backend_test.go
+++ b/cmd/bd/store_selection_removed_backend_test.go
@@ -226,41 +226,37 @@ func TestDoltAdministrativeCommandsRejectRemovedBackends(t *testing.T) {
 		{name: "clean-databases", args: []string{"dolt", "clean-databases", "--dry-run"}},
 	}
 
-	for _, backend := range []string{configfile.BackendPostgres, configfile.BackendMySQL, configfile.BackendSQLite} {
-		t.Run(backend, func(t *testing.T) {
-			root := t.TempDir()
-			beadsDir := filepath.Join(root, ".beads")
-			if err := os.MkdirAll(beadsDir, 0o755); err != nil {
-				t.Fatalf("create beads dir: %v", err)
+	root := t.TempDir()
+	beadsDir := filepath.Join(root, ".beads")
+	if err := os.MkdirAll(beadsDir, 0o755); err != nil {
+		t.Fatalf("create beads dir: %v", err)
+	}
+	if err := (&configfile.Config{Backend: configfile.BackendSQLite}).Save(beadsDir); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+
+	for _, command := range commands {
+		t.Run(command.name, func(t *testing.T) {
+			cmd := exec.Command(bd, command.args...)
+			cmd.Dir = root
+			cmd.Env = append(removedBackendTestEnv(beadsDir), "BD_DISABLE_METRICS=1")
+			out, err := cmd.CombinedOutput()
+			if err == nil {
+				t.Fatalf("%q unexpectedly succeeded for removed backend %s: %s", strings.Join(command.args, " "), configfile.BackendSQLite, out)
 			}
-			if err := (&configfile.Config{Backend: backend}).Save(beadsDir); err != nil {
-				t.Fatalf("save config: %v", err)
+
+			message := strings.ToLower(string(out))
+			for _, want := range removedBackendWantSubstrings(configfile.BackendSQLite) {
+				if !strings.Contains(message, want) {
+					t.Errorf("%q error for %s missing %q: %s", strings.Join(command.args, " "), configfile.BackendSQLite, want, message)
+				}
 			}
 
-			for _, command := range commands {
-				t.Run(command.name, func(t *testing.T) {
-					cmd := exec.Command(bd, command.args...)
-					cmd.Dir = root
-					cmd.Env = append(removedBackendTestEnv(beadsDir), "BD_DISABLE_METRICS=1")
-					out, err := cmd.CombinedOutput()
-					if err == nil {
-						t.Fatalf("%q unexpectedly succeeded for removed backend %s: %s", strings.Join(command.args, " "), backend, out)
-					}
-
-					message := strings.ToLower(string(out))
-					for _, want := range removedBackendWantSubstrings(backend) {
-						if !strings.Contains(message, want) {
-							t.Errorf("%q error for %s missing %q: %s", strings.Join(command.args, " "), backend, want, message)
-						}
-					}
-
-					for _, name := range []string{"embeddeddolt", "dolt", "beads.db", ".local_version"} {
-						path := filepath.Join(beadsDir, name)
-						if _, statErr := os.Stat(path); !os.IsNotExist(statErr) {
-							t.Fatalf("%q created local state for removed backend %s at %s (stat error: %v)", strings.Join(command.args, " "), backend, path, statErr)
-						}
-					}
-				})
+			for _, name := range []string{"embeddeddolt", "dolt", "beads.db", ".local_version"} {
+				path := filepath.Join(beadsDir, name)
+				if _, statErr := os.Stat(path); !os.IsNotExist(statErr) {
+					t.Fatalf("%q created local state for removed backend %s at %s (stat error: %v)", strings.Join(command.args, " "), configfile.BackendSQLite, path, statErr)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
## What

Reduce `TestDoltAdministrativeCommandsRejectRemovedBackends` from a 3-backend × 8-command Cartesian matrix to one SQLite workspace exercising all eight real command entry points.

This removes 16 redundant `bd` subprocesses while retaining, for every command:

- a nonzero exit;
- every expected removed-backend guidance marker; and
- proof that no `embeddeddolt`, `dolt`, `beads.db`, or `.local_version` artifact was created.

## Why

The three removed backends do not interact with command-specific behavior:

- `dolt show` and `dolt status` load configuration and call `validateConfiguredBackend` directly.
- The other six commands call `loadDoltBackendConfig` → `requireDoltBackend` → `validateConfiguredBackend`.

All three backends converge on the same validation switch and `RemovedBackendError` before command-specific work. SQLite is the strongest representative here because it also exercises the unique `single engine` guidance branch.

Backend-specific PostgreSQL, MySQL, and SQLite coverage remains in the ordinary-command startup/no-write test, legacy `init` guidance, bootstrap dry-run and execute tests, both storage factories, `TestRequireDoltBackend`, and config/registry recognition tests.

No production code or behavior changes.

## Performance

| Focused test metric | Before | After | Change |
| --- | ---: | ---: | ---: |
| Real subprocess cases | 24 | 8 | −66.7% |
| Go test-body time | 2.30s | 0.79s | −65.7% |

## Verification

- Focused test: passed with exactly eight command subtests.
- Affected package: `./scripts/test.sh ./cmd/bd` passed in 446.873s (473.33s wall).
- Final baseline: `make test` passed in 496.52s with 39.0% aggregate coverage.
- Lint: `golangci-lint run ./...` reported zero issues.
- Two independent Sol blocker/major reviews passed with no findings.

Bead: `bd-skwi4`
