### PR TITLE
fix(metrics): skip the detached flusher spawn under BEADS_TEST_MODE

### DIFF
--- a/internal/metrics/spawn.go
+++ b/internal/metrics/spawn.go
@@ -28,11 +28,14 @@ func inTestMode() bool {
 	return os.Getenv(EnvTestMode) == "1"
 }
 
+// shouldSpawnFlusher is the whole spawn gate, extracted so tests can assert
+// the decision without forking a real detached child.
+func shouldSpawnFlusher() bool {
+	return os.Getenv(EnvIsFlusher) != "1" && Enabled() && !flushDisabledByEnv() && !inTestMode()
+}
+
 func MaybeSpawnFlusher() {
-	if os.Getenv(EnvIsFlusher) == "1" {
-		return
-	}
-	if !Enabled() || flushDisabledByEnv() || inTestMode() {
+	if !shouldSpawnFlusher() {
 		return
 	}
 	self, err := os.Executable()

--- a/internal/metrics/spawn.go
+++ b/internal/metrics/spawn.go
@@ -15,11 +15,24 @@ const SendMetricsSubcommand = "send-metrics"
 // before control returns to main()'s spawn tail.
 const EnvIsFlusher = "BD_IS_FLUSHER"
 
+// EnvTestMode is the same test-run flag the storage layer already checks
+// (e.g. internal/storage/dolt/open.go, store.go): `os.Getenv(EnvTestMode) ==
+// "1"`. MaybeSpawnFlusher honors it too so test suites no longer need to
+// hand-set BD_DISABLE_EVENT_FLUSH=1 just to stop the detached send-metrics
+// child from racing t.TempDir's RemoveAll (gastownhall/beads#5032).
+const EnvTestMode = "BEADS_TEST_MODE"
+
+// inTestMode reports whether the process is running under a beads test
+// suite, using the same idiom as the rest of the codebase.
+func inTestMode() bool {
+	return os.Getenv(EnvTestMode) == "1"
+}
+
 func MaybeSpawnFlusher() {
 	if os.Getenv(EnvIsFlusher) == "1" {
 		return
 	}
-	if !Enabled() || flushDisabledByEnv() {
+	if !Enabled() || flushDisabledByEnv() || inTestMode() {
 		return
 	}
 	self, err := os.Executable()

--- a/internal/metrics/spawn_test.go
+++ b/internal/metrics/spawn_test.go
@@ -1,0 +1,55 @@
+package metrics
+
+import "testing"
+
+// TestInTestModeDetectsEnv exercises the extracted boolean decision directly:
+// inTestMode must match on BEADS_TEST_MODE=1 exactly, the same idiom the
+// storage layer uses, and treat anything else (unset, empty, "0", "true") as
+// not-test-mode.
+func TestInTestModeDetectsEnv(t *testing.T) {
+	cases := []struct {
+		name string
+		val  string
+		set  bool
+		want bool
+	}{
+		{name: "unset", set: false, want: false},
+		{name: "empty", val: "", set: true, want: false},
+		{name: "one", val: "1", set: true, want: true},
+		{name: "true-word", val: "true", set: true, want: false},
+		{name: "zero", val: "0", set: true, want: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.set {
+				t.Setenv(EnvTestMode, tc.val)
+			}
+			if got := inTestMode(); got != tc.want {
+				t.Errorf("inTestMode() = %v, want %v (val=%q set=%v)", got, tc.want, tc.val, tc.set)
+			}
+		})
+	}
+}
+
+// TestMaybeSpawnFlusherNoOpInTestMode guards the source-level test-mode guard:
+// with BEADS_TEST_MODE=1 set, MaybeSpawnFlusher must skip spawning the
+// detached send-metrics child even though metrics are otherwise enabled and
+// BD_DISABLE_EVENT_FLUSH is unset. If the guard regresses this would fork a
+// real child process during `go test`.
+func TestMaybeSpawnFlusherNoOpInTestMode(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv(EnvTestMode, "1")
+
+	if _, err := Init("0.0.0-test", true, ""); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	if !Enabled() {
+		t.Fatalf("Enabled() = false, want true")
+	}
+	if flushDisabledByEnv() {
+		t.Fatalf("flushDisabledByEnv() = true, want false (BD_DISABLE_EVENT_FLUSH unset)")
+	}
+
+	// The only thing preventing a spawn here is the BEADS_TEST_MODE guard.
+	MaybeSpawnFlusher()
+}

--- a/internal/metrics/spawn_test.go
+++ b/internal/metrics/spawn_test.go
@@ -1,6 +1,9 @@
 package metrics
 
-import "testing"
+import (
+	"os"
+	"testing"
+)
 
 // TestInTestModeDetectsEnv exercises the extracted boolean decision directly:
 // inTestMode must match on BEADS_TEST_MODE=1 exactly, the same idiom the
@@ -23,6 +26,14 @@ func TestInTestModeDetectsEnv(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			if tc.set {
 				t.Setenv(EnvTestMode, tc.val)
+			} else {
+				// Hermetic unset: the repo's own runner exports
+				// BEADS_TEST_MODE=1 (scripts/test.sh), so relying on the
+				// ambient environment would fail under a supported test
+				// mode. t.Setenv registers the restore; Unsetenv then
+				// clears it for this subtest.
+				t.Setenv(EnvTestMode, "")
+				os.Unsetenv(EnvTestMode)
 			}
 			if got := inTestMode(); got != tc.want {
 				t.Errorf("inTestMode() = %v, want %v (val=%q set=%v)", got, tc.want, tc.val, tc.set)
@@ -50,6 +61,27 @@ func TestMaybeSpawnFlusherNoOpInTestMode(t *testing.T) {
 		t.Fatalf("flushDisabledByEnv() = true, want false (BD_DISABLE_EVENT_FLUSH unset)")
 	}
 
-	// The only thing preventing a spawn here is the BEADS_TEST_MODE guard.
+	// The only thing preventing a spawn here is the BEADS_TEST_MODE guard —
+	// assert the extracted decision directly, so a regression fails the test
+	// instead of silently forking a real child.
+	if shouldSpawnFlusher() {
+		t.Fatalf("shouldSpawnFlusher() = true under BEADS_TEST_MODE=1, want false")
+	}
+
+	// Positive control: with test mode hermetically cleared (and every other
+	// gate still open), the spawn decision must flip to true — proving the
+	// assertion above is gated on BEADS_TEST_MODE and not on some other
+	// condition that happens to hold in this environment.
+	t.Setenv(EnvTestMode, "")
+	os.Unsetenv(EnvTestMode)
+	t.Setenv(EnvDisableEventFlush, "")
+	os.Unsetenv(EnvDisableEventFlush)
+	if !shouldSpawnFlusher() {
+		t.Fatalf("shouldSpawnFlusher() = false with BEADS_TEST_MODE cleared, want true")
+	}
+
+	// And the exported entry point still returns without spawning under the
+	// guard (smoke path).
+	t.Setenv(EnvTestMode, "1")
 	MaybeSpawnFlusher()
 }

--- a/internal/metrics/spawn_test.go
+++ b/internal/metrics/spawn_test.go
@@ -50,6 +50,11 @@ func TestInTestModeDetectsEnv(t *testing.T) {
 func TestMaybeSpawnFlusherNoOpInTestMode(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	t.Setenv(EnvTestMode, "1")
+	// CI exports BD_DISABLE_EVENT_FLUSH=1 workflow-wide (main.yml/pr.yml env
+	// blocks), which would trip the flushDisabledByEnv precondition below
+	// before the test-mode gate is ever exercised. Clear it hermetically.
+	t.Setenv(EnvDisableEventFlush, "")
+	os.Unsetenv(EnvDisableEventFlush)
 
 	if _, err := Init("0.0.0-test", true, ""); err != nil {
 		t.Fatalf("Init: %v", err)


### PR DESCRIPTION
## Why

Ten-plus test files hand-set `BD_DISABLE_EVENT_FLUSH=1` to stop the detached `bd send-metrics` child (spawned by `internal/metrics.MaybeSpawnFlusher`) from racing `t.TempDir`'s `RemoveAll` — see #5032 and 08881217b. Every new Dolt-backed test file has to remember that line or inherit the race. A source-level guard removes the whole class: the spawn decision now also honors `BEADS_TEST_MODE=1`, the same test-run flag the storage layer already checks.

Credit where due: rjc123 suggested exactly this guard during the #5031/#5032 work; this implements that suggestion.

## What

- `internal/metrics/spawn.go`: `shouldSpawnFlusher()` extracts the whole spawn gate (`BD_IS_FLUSHER` re-entry marker, `Enabled()`, `BD_DISABLE_EVENT_FLUSH`, and now `BEADS_TEST_MODE==1` via `inTestMode()`), and `MaybeSpawnFlusher` early-returns on it. `BD_DISABLE_EVENT_FLUSH` keeps working unchanged.
- `internal/metrics/spawn_test.go`: table test for `inTestMode` (exact-match on `"1"`, hermetic unset case — the repo's own `scripts/test.sh` exports `BEADS_TEST_MODE=1`, so the unset case clears it explicitly), plus a gate test asserting `shouldSpawnFlusher()` flips on `BEADS_TEST_MODE` with every other gate held open (both env vars cleared hermetically; CI exports `BD_DISABLE_EVENT_FLUSH=1` workflow-wide).

The existing `BD_DISABLE_EVENT_FLUSH=1` lines in test files are deliberately left in place; dropping them is a mechanical follow-up once this lands.

## Validation

- `go test -tags gms_pure_go ./internal/metrics/ -count=1` green in three environments: bare, `BEADS_TEST_MODE=1`, and `BD_DISABLE_EVENT_FLUSH=1 BEADS_TEST_MODE=1` (the CI shape).
- `go build -tags gms_pure_go ./...` clean; `gofmt` clean.
- Cross-vendor review pass done (Claude reviewer + codex gpt-5.6 via `pr-open`); both rounds' findings (vacuous spawn assertion, non-hermetic unset case, CI's workflow-wide `BD_DISABLE_EVENT_FLUSH` tripping the precondition) are fixed in the follow-up commits.

Tracked in mybd tracker as mybd-syou (from the rjc123 sweep follow-ups).

_claude-fable-5-high on behalf of maphew_
