### PR TITLE
refactor(test): isolate show --current selection

### DIFF
--- a/cmd/bd/list_show_filter_modes.go
+++ b/cmd/bd/list_show_filter_modes.go
@@ -272,44 +272,38 @@ func gatherProxiedHierarchical(ctx context.Context, uw uow.UnitOfWork, parentID 
 	return out, nil
 }
 
+type currentIssueSearcher interface {
+	SearchIssues(context.Context, string, types.IssueFilter) ([]*types.Issue, error)
+}
+
 // resolveCurrentIssueID determines the current active issue for the agent.
 // Priority: in-progress assigned to actor > hooked > last touched.
 func resolveCurrentIssueID(ctx context.Context) string {
-	if store == nil {
-		// No store — fall back to last touched
-		return GetLastTouchedID()
+	return resolveCurrentIssueIDFrom(ctx, store, getActorWithGit, GetLastTouchedID)
+}
+
+func resolveCurrentIssueIDFrom(ctx context.Context, searcher currentIssueSearcher, currentActor func() string, fallback func() string) string {
+	if searcher == nil {
+		return fallback()
+	}
+	actor := currentActor()
+	if actor == "" {
+		return fallback()
 	}
 
-	currentActor := getActorWithGit()
-
-	// 1. In-progress issues assigned to current actor
-	if currentActor != "" {
-		status := types.StatusInProgress
+	for _, status := range []types.Status{types.StatusInProgress, types.StatusHooked} {
+		status := status
 		filter := types.IssueFilter{
 			Status:   &status,
-			Assignee: &currentActor,
+			Assignee: &actor,
 		}
-		issues, err := store.SearchIssues(ctx, "", filter)
+		issues, err := searcher.SearchIssues(ctx, "", filter)
 		if err == nil && len(issues) > 0 {
 			return issues[0].ID
 		}
 	}
 
-	// 2. Hooked issues assigned to current actor
-	if currentActor != "" {
-		status := types.StatusHooked
-		filter := types.IssueFilter{
-			Status:   &status,
-			Assignee: &currentActor,
-		}
-		issues, err := store.SearchIssues(ctx, "", filter)
-		if err == nil && len(issues) > 0 {
-			return issues[0].ID
-		}
-	}
-
-	// 3. Last touched issue (fallback)
-	return GetLastTouchedID()
+	return fallback()
 }
 
 func resolveCurrentIssueIDProxied(ctx context.Context, uw uow.UnitOfWork) string {

--- a/cmd/bd/show_current_test.go
+++ b/cmd/bd/show_current_test.go
@@ -1,174 +1,142 @@
-//go:build cgo
-
 package main
 
 import (
 	"context"
-	"os"
-	"path/filepath"
+	"errors"
+	"reflect"
 	"testing"
 
 	"github.com/steveyegge/beads/internal/types"
 )
 
-func TestResolveCurrentIssueID_InProgress(t *testing.T) {
-	ctx := context.Background()
-	st := newTestStoreWithPrefix(t, filepath.Join(t.TempDir(), "test.db"), "test")
+type currentIssueSearchCall struct {
+	query  string
+	filter types.IssueFilter
+}
 
-	// Create an in-progress issue assigned to "tester"
-	issue := &types.Issue{
-		Title:     "In-progress task",
-		Status:    types.StatusInProgress,
-		Priority:  2,
-		IssueType: types.TypeTask,
-		Assignee:  "tester",
+type currentIssueSearchResponse struct {
+	issues []*types.Issue
+	err    error
+}
+
+type currentIssueSearchRecorder struct {
+	responses []currentIssueSearchResponse
+	calls     []currentIssueSearchCall
+}
+
+func (r *currentIssueSearchRecorder) SearchIssues(_ context.Context, query string, filter types.IssueFilter) ([]*types.Issue, error) {
+	r.calls = append(r.calls, currentIssueSearchCall{query: query, filter: filter})
+	response := r.responses[len(r.calls)-1]
+	return response.issues, response.err
+}
+
+func TestResolveCurrentIssueIDFromInProgressShortCircuits(t *testing.T) {
+	searcher := &currentIssueSearchRecorder{
+		responses: []currentIssueSearchResponse{{
+			issues: []*types.Issue{{ID: "in-progress-first"}, {ID: "in-progress-second"}},
+		}},
 	}
-	if err := st.CreateIssue(ctx, issue, "tester"); err != nil {
-		t.Fatalf("CreateIssue: %v", err)
+	actorCalls := 0
+
+	got := resolveCurrentIssueIDFrom(context.Background(), searcher, func() string {
+		actorCalls++
+		return "tester"
+	}, func() string {
+		t.Fatal("fallback called after in-progress result")
+		return ""
+	})
+
+	if got != "in-progress-first" {
+		t.Fatalf("resolveCurrentIssueIDFrom() = %q, want %q", got, "in-progress-first")
+	}
+	if actorCalls != 1 {
+		t.Fatalf("actor calls = %d, want 1", actorCalls)
+	}
+	assertCurrentIssueSearchCalls(t, searcher.calls, "tester", types.StatusInProgress)
+}
+
+func TestResolveCurrentIssueIDFromFindsHookedAfterInProgressMiss(t *testing.T) {
+	searcher := &currentIssueSearchRecorder{
+		responses: []currentIssueSearchResponse{
+			{err: errors.New("in-progress search failed")},
+			{issues: []*types.Issue{{ID: "hooked"}}},
+		},
 	}
 
-	// Set globals for the test
-	oldStore := store
-	oldActor := actor
-	store = st
-	actor = "tester"
-	defer func() {
-		store = oldStore
-		actor = oldActor
-	}()
+	got := resolveCurrentIssueIDFrom(context.Background(), searcher, func() string {
+		return "tester"
+	}, func() string {
+		t.Fatal("fallback called after hooked result")
+		return ""
+	})
 
-	got := resolveCurrentIssueID(ctx)
-	if got != issue.ID {
-		t.Errorf("resolveCurrentIssueID() = %q, want %q", got, issue.ID)
+	if got != "hooked" {
+		t.Fatalf("resolveCurrentIssueIDFrom() = %q, want %q", got, "hooked")
+	}
+	assertCurrentIssueSearchCalls(t, searcher.calls, "tester", types.StatusInProgress, types.StatusHooked)
+}
+
+func TestResolveCurrentIssueIDFromFallsBackAfterTwoMisses(t *testing.T) {
+	searcher := &currentIssueSearchRecorder{
+		responses: []currentIssueSearchResponse{{}, {}},
+	}
+	fallbackCalls := 0
+
+	got := resolveCurrentIssueIDFrom(context.Background(), searcher, func() string {
+		return "tester"
+	}, func() string {
+		fallbackCalls++
+		return "last-touched"
+	})
+
+	if got != "last-touched" {
+		t.Fatalf("resolveCurrentIssueIDFrom() = %q, want %q", got, "last-touched")
+	}
+	if fallbackCalls != 1 {
+		t.Fatalf("fallback calls = %d, want 1", fallbackCalls)
+	}
+	assertCurrentIssueSearchCalls(t, searcher.calls, "tester", types.StatusInProgress, types.StatusHooked)
+}
+
+func TestResolveCurrentIssueIDFromNilSearcherUsesFallback(t *testing.T) {
+	actorCalls := 0
+	fallbackCalls := 0
+
+	got := resolveCurrentIssueIDFrom(context.Background(), nil, func() string {
+		actorCalls++
+		return "tester"
+	}, func() string {
+		fallbackCalls++
+		return "last-touched"
+	})
+
+	if got != "last-touched" {
+		t.Fatalf("resolveCurrentIssueIDFrom() = %q, want %q", got, "last-touched")
+	}
+	if actorCalls != 0 {
+		t.Fatalf("actor calls = %d, want 0", actorCalls)
+	}
+	if fallbackCalls != 1 {
+		t.Fatalf("fallback calls = %d, want 1", fallbackCalls)
 	}
 }
 
-func TestResolveCurrentIssueID_Hooked(t *testing.T) {
-	ctx := context.Background()
-	st := newTestStoreWithPrefix(t, filepath.Join(t.TempDir(), "test.db"), "test")
+func assertCurrentIssueSearchCalls(t *testing.T, got []currentIssueSearchCall, actor string, statuses ...types.Status) {
+	t.Helper()
 
-	// Create a hooked issue assigned to "tester"
-	issue := &types.Issue{
-		Title:     "Hooked task",
-		Status:    types.StatusHooked,
-		Priority:  2,
-		IssueType: types.TypeTask,
-		Assignee:  "tester",
-	}
-	if err := st.CreateIssue(ctx, issue, "tester"); err != nil {
-		t.Fatalf("CreateIssue: %v", err)
-	}
-
-	oldStore := store
-	oldActor := actor
-	store = st
-	actor = "tester"
-	defer func() {
-		store = oldStore
-		actor = oldActor
-	}()
-
-	got := resolveCurrentIssueID(ctx)
-	if got != issue.ID {
-		t.Errorf("resolveCurrentIssueID() = %q, want %q", got, issue.ID)
-	}
-}
-
-func TestResolveCurrentIssueID_FallsBackToLastTouched(t *testing.T) {
-	ctx := context.Background()
-	st := newTestStoreWithPrefix(t, filepath.Join(t.TempDir(), "test.db"), "test")
-
-	// No in-progress or hooked issues — should fall back to last touched
-	oldStore := store
-	oldActor := actor
-	store = st
-	actor = "tester"
-	defer func() {
-		store = oldStore
-		actor = oldActor
-	}()
-
-	// Point BEADS_DIR at a temp dir so GetLastTouchedID doesn't find the real file.
-	// Create metadata.json so FindBeadsDir accepts this as a valid beads dir.
-	tmpBeads := filepath.Join(t.TempDir(), ".beads")
-	if err := os.MkdirAll(tmpBeads, 0750); err != nil {
-		t.Fatalf("mkdir: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(tmpBeads, "metadata.json"), []byte("{}"), 0600); err != nil {
-		t.Fatalf("write metadata.json: %v", err)
-	}
-	t.Setenv("BEADS_DIR", tmpBeads)
-
-	// With no last-touched file, should return empty
-	got := resolveCurrentIssueID(ctx)
-	if got != "" {
-		t.Errorf("resolveCurrentIssueID() = %q, want empty string", got)
-	}
-}
-
-func TestResolveCurrentIssueID_InProgressBeforeHooked(t *testing.T) {
-	ctx := context.Background()
-	st := newTestStoreWithPrefix(t, filepath.Join(t.TempDir(), "test.db"), "test")
-
-	// Create both hooked and in-progress issues
-	hooked := &types.Issue{
-		Title:     "Hooked task",
-		Status:    types.StatusHooked,
-		Priority:  2,
-		IssueType: types.TypeTask,
-		Assignee:  "tester",
-	}
-	if err := st.CreateIssue(ctx, hooked, "tester"); err != nil {
-		t.Fatalf("CreateIssue(hooked): %v", err)
+	want := make([]currentIssueSearchCall, 0, len(statuses))
+	for _, status := range statuses {
+		status := status
+		want = append(want, currentIssueSearchCall{
+			query: "",
+			filter: types.IssueFilter{
+				Status:   &status,
+				Assignee: &actor,
+			},
+		})
 	}
 
-	inProgress := &types.Issue{
-		Title:     "In-progress task",
-		Status:    types.StatusInProgress,
-		Priority:  2,
-		IssueType: types.TypeTask,
-		Assignee:  "tester",
-	}
-	if err := st.CreateIssue(ctx, inProgress, "tester"); err != nil {
-		t.Fatalf("CreateIssue(in_progress): %v", err)
-	}
-
-	oldStore := store
-	oldActor := actor
-	store = st
-	actor = "tester"
-	defer func() {
-		store = oldStore
-		actor = oldActor
-	}()
-
-	// Should prefer in-progress over hooked
-	got := resolveCurrentIssueID(ctx)
-	if got != inProgress.ID {
-		t.Errorf("resolveCurrentIssueID() = %q, want %q (in-progress should take priority)", got, inProgress.ID)
-	}
-}
-
-func TestResolveCurrentIssueID_NilStore(t *testing.T) {
-	// When store is nil, should fall back to last-touched
-	oldStore := store
-	store = nil
-	defer func() { store = oldStore }()
-
-	// Point BEADS_DIR at a temp dir so GetLastTouchedID doesn't find the real file.
-	// Create metadata.json so FindBeadsDir accepts this as a valid beads dir.
-	tmpBeads := filepath.Join(t.TempDir(), ".beads")
-	if err := os.MkdirAll(tmpBeads, 0750); err != nil {
-		t.Fatalf("mkdir: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(tmpBeads, "metadata.json"), []byte("{}"), 0600); err != nil {
-		t.Fatalf("write metadata.json: %v", err)
-	}
-	t.Setenv("BEADS_DIR", tmpBeads)
-
-	// With no last-touched file, last-touched returns ""
-	got := resolveCurrentIssueID(context.Background())
-	if got != "" {
-		t.Errorf("resolveCurrentIssueID() with nil store = %q, want empty", got)
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("SearchIssues calls = %#v, want %#v", got, want)
 	}
 }


### PR DESCRIPTION
## What

Extract the direct `show --current` selection policy behind a private, one-method search role with injected actor and last-touched functions.

This replaces four real Dolt store fixtures plus global actor/store and filesystem choreography with four pure-Go recorder scenarios. It also removes the test file's CGO build constraint, so the policy now runs in default and `CGO_ENABLED=0` lanes.

The production adapter remains a one-line binding to `store`, `getActorWithGit`, and `GetLastTouchedID`. The separate proxied resolver is unchanged.

## Behavior preserved

- Nil store falls back without resolving the actor.
- Empty actor falls back without searching.
- In-progress work wins over hooked work.
- Searches keep the empty query and bare `Status`/`Assignee` filters.
- The first result wins; search errors continue to fall through.
- Last-touched fallback runs once after two misses.

No user-visible behavior changes.

## Performance and policy

| Focused workload metric | Before | After | Change |
| --- | ---: | ---: | ---: |
| Real Dolt stores | 4 | 0 | -100% |
| CGO-only test file | Yes | No | Pure-Go admitted |
| Package elapsed | 18.124s | 14.548s | -19.7% |
| Wall time | 43.19s | 22.37s | -48.2% |

The timing uses the same uncached `go test -count=1 -json -run '^TestResolveCurrentIssueID' ./cmd/bd` workload. Wall time includes build/package overhead and is therefore secondary to the structural gain: the policy no longer provisions a persistence engine.

## Verification

- TDD RED: the test-first change failed with the expected undefined/incompatible helper signature errors.
- Focused pure-Go and normal tests passed after implementation and after the council fix.
- Affected `cmd/bd` passed in 463.344s (494.38s wall).
- Final `make test` passed in 520.84s with 39.0% aggregate coverage; `cmd/bd` passed in 466.227s.
- `golangci-lint run ./...` reported zero issues; the pre-commit hook also passed.
- Two independent Sol blocker/major reviewers passed the final diff. One adapter-wiring major was fixed before commit and explicitly cleared on re-review.

Bead: `bd-s9p99`
