### PR TITLE
fix(pr-preflight): warn when a PR-gate workflow is red for every PR while the base shows green

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -66,6 +66,16 @@ signals such as `.beads/` changes or missing tests, and the required
 contributor-protection next steps. It does not replace code review or local
 validation.
 
+Base-branch health is supplemented by a warn-only PR-gate sample: the last 60
+completed `pull_request`-event runs, grouped per workflow. A single workflow
+whose decisive runs (>= 5, across >= 3 distinct head branches) are all
+failure-class is reported as a broken PR gate — the case where a job that
+exists only in the PR workflow is red for every PR while the base branch shows
+green. This detector never blocks (deliberately: automation classifies
+unrecognized `[block]` lines as genuine merge blockers and would park merge
+lanes on a false positive); it is skipped entirely while the base branch is
+red.
+
 ## gh-body-lint
 
 Lint Markdown files before posting them with `gh ... --body-file`.

--- a/scripts/pr-preflight.sh
+++ b/scripts/pr-preflight.sh
@@ -292,6 +292,29 @@ else
   warn "Could not determine CI health of base branch ${base_ref}; check it manually before merging."
 fi
 
+# PR-gate health sample. The base-branch check above cannot see a job that
+# exists only in the PR workflow (pr.yml) - such a job never runs on the base
+# branch, so the check above can report green while every fresh PR is red in
+# that job. Sample recent completed pull_request-event runs across PRs and
+# look for a gate that is uniformly failing regardless of branch. This is a
+# supplemental detector: it only ever adds a warn/block, and stays silent
+# (including on an empty or unreadable sample) rather than asserting health.
+pr_gate_runs=$(gh run list --repo "$repo" --event pull_request --status completed \
+  --limit 12 --json conclusion,headBranch,workflowName,createdAt,url 2>/dev/null) || pr_gate_runs=""
+pr_gate_decisive=$(jq '[.[] | select((.conclusion // "") == "success" or ((.conclusion // "") | test("^(failure|timed_out|action_required)$")))]' <<<"${pr_gate_runs:-[]}")
+pr_gate_decisive_count=$(jq 'length' <<<"$pr_gate_decisive")
+pr_gate_distinct_heads=$(jq '[.[].headBranch] | unique | length' <<<"$pr_gate_decisive")
+pr_gate_red_count=$(jq '[.[] | select((.conclusion // "") | test("^(failure|timed_out|action_required)$"))] | length' <<<"$pr_gate_decisive")
+if [[ "$pr_gate_decisive_count" -ge 6 && "$pr_gate_distinct_heads" -ge 3 && "$pr_gate_red_count" -eq "$pr_gate_decisive_count" ]]; then
+  pr_gate_newest=$(jq -r 'sort_by(.createdAt) | last | "\(.workflowName) at \(.createdAt) \(.url)"' <<<"$pr_gate_decisive")
+  pr_gate_msg="PR gate appears broken: last ${pr_gate_decisive_count} completed pull_request runs across ${pr_gate_distinct_heads} distinct branches all failed (newest: ${pr_gate_newest}). A job that exists only in the PR workflow may be red for every PR while the base branch shows green. Investigate the PR workflow before trusting per-PR check verdicts."
+  if [[ "${PR_PREFLIGHT_BLOCK_RED_BASE:-0}" == "1" ]]; then
+    block "$pr_gate_msg"
+  else
+    warn "$pr_gate_msg"
+  fi
+fi
+
 # statusCheckRollup keeps every check run on the head SHA, including runs
 # from cancelled or superseded check suites. A head whose earlier suite was
 # cancelled mid-flight carries stale CANCELLED/FAILURE entries forever, next

--- a/scripts/pr-preflight.sh
+++ b/scripts/pr-preflight.sh
@@ -317,12 +317,18 @@ if [[ "$base_red_count" -eq 0 && "$base_green_count" -gt 0 ]]; then
   # undetermined base the "while the base branch shows green" explanation
   # would contradict the warn printed just above.
   pr_gate_runs=$(gh run list --repo "$repo" --event pull_request --status completed \
-    --limit 60 --json conclusion,headBranch,workflowName,createdAt,url 2>/dev/null) || pr_gate_runs=""
+    --limit 60 --json conclusion,headBranch,workflowName,workflowDatabaseId,createdAt,url 2>/dev/null) || pr_gate_runs=""
   # gh can exit 0 with non-JSON (or empty) output; treat anything that is not
   # a JSON array the same as an empty sample rather than let jq abort under -e.
   jq -e 'type == "array"' >/dev/null 2>&1 <<<"${pr_gate_runs:-}" || pr_gate_runs='[]'
+  # Grouped by workflowDatabaseId (stable identity), not display name: two
+  # workflow files may share a legal name:, and org/ruleset runs can have no
+  # name at all. Known limitation, accepted for a warn-only supplemental
+  # detector: the sample is repo-wide, so runs from PRs targeting other base
+  # branches are mixed in — resolving each run's PR to filter by base would
+  # cost one API call per run.
   pr_gate_broken=$(jq '
-    [group_by(.workflowName)[]
+    [group_by(.workflowDatabaseId)[]
      | { workflow: (.[0].workflowName // "unknown"),
          decisive: [.[] | select(
            (.conclusion // "") == "success" or

--- a/scripts/pr-preflight.sh
+++ b/scripts/pr-preflight.sh
@@ -311,7 +311,11 @@ fi
 # already red - that already explains per-PR redness, and avoids reporting
 # "the base branch shows green" right after a red-base line above - and stay
 # silent on an empty, unreadable, or mixed-health sample.
-if [[ "$base_red_count" -eq 0 ]]; then
+if [[ "$base_red_count" -eq 0 && "$base_green_count" -gt 0 ]]; then
+  # Only diagnose the PR gate against a base branch known to be green: on a red
+  # base the red-base message already explains PR redness, and on an
+  # undetermined base the "while the base branch shows green" explanation
+  # would contradict the warn printed just above.
   pr_gate_runs=$(gh run list --repo "$repo" --event pull_request --status completed \
     --limit 60 --json conclusion,headBranch,workflowName,createdAt,url 2>/dev/null) || pr_gate_runs=""
   # gh can exit 0 with non-JSON (or empty) output; treat anything that is not

--- a/scripts/pr-preflight.sh
+++ b/scripts/pr-preflight.sh
@@ -23,6 +23,8 @@ What this checks:
   - draft, review, mergeability, and check status
   - CI health of the base branch (red base makes "failures are pre-existing"
     reasoning unsafe; set PR_PREFLIGHT_BLOCK_RED_BASE=1 to block instead of warn)
+  - a supplemental, warn-only sample for a PR-gate workflow (e.g. pr.yml) that
+    is red for every PR while the base branch itself looks green
   - risky diff signals: .beads data, missing tests for code changes, large diffs
   - contributor-protection next steps and attribution reminders
 
@@ -292,26 +294,46 @@ else
   warn "Could not determine CI health of base branch ${base_ref}; check it manually before merging."
 fi
 
-# PR-gate health sample. The base-branch check above cannot see a job that
-# exists only in the PR workflow (pr.yml) - such a job never runs on the base
-# branch, so the check above can report green while every fresh PR is red in
-# that job. Sample recent completed pull_request-event runs across PRs and
-# look for a gate that is uniformly failing regardless of branch. This is a
-# supplemental detector: it only ever adds a warn/block, and stays silent
-# (including on an empty or unreadable sample) rather than asserting health.
-pr_gate_runs=$(gh run list --repo "$repo" --event pull_request --status completed \
-  --limit 12 --json conclusion,headBranch,workflowName,createdAt,url 2>/dev/null) || pr_gate_runs=""
-pr_gate_decisive=$(jq '[.[] | select((.conclusion // "") == "success" or ((.conclusion // "") | test("^(failure|timed_out|action_required)$")))]' <<<"${pr_gate_runs:-[]}")
-pr_gate_decisive_count=$(jq 'length' <<<"$pr_gate_decisive")
-pr_gate_distinct_heads=$(jq '[.[].headBranch] | unique | length' <<<"$pr_gate_decisive")
-pr_gate_red_count=$(jq '[.[] | select((.conclusion // "") | test("^(failure|timed_out|action_required)$"))] | length' <<<"$pr_gate_decisive")
-if [[ "$pr_gate_decisive_count" -ge 6 && "$pr_gate_distinct_heads" -ge 3 && "$pr_gate_red_count" -eq "$pr_gate_decisive_count" ]]; then
-  pr_gate_newest=$(jq -r 'sort_by(.createdAt) | last | "\(.workflowName) at \(.createdAt) \(.url)"' <<<"$pr_gate_decisive")
-  pr_gate_msg="PR gate appears broken: last ${pr_gate_decisive_count} completed pull_request runs across ${pr_gate_distinct_heads} distinct branches all failed (newest: ${pr_gate_newest}). A job that exists only in the PR workflow may be red for every PR while the base branch shows green. Investigate the PR workflow before trusting per-PR check verdicts."
-  if [[ "${PR_PREFLIGHT_BLOCK_RED_BASE:-0}" == "1" ]]; then
-    block "$pr_gate_msg"
-  else
-    warn "$pr_gate_msg"
+# PR-gate health sample. The base-branch check above reads runs on the base
+# branch itself, so it cannot see a job that exists only in the PR workflow
+# (pr.yml) - such a job never runs on the base branch, and one broken job
+# there is diluted to invisibility by every other green PR workflow if runs
+# are judged in aggregate. Sample recent completed pull_request-event runs
+# across PRs, group by workflow, and flag any single workflow whose decisive
+# runs are uniformly failing across several distinct branches.
+#
+# This is a supplemental, warn-only detector, deliberately never coupled to
+# PR_PREFLIGHT_BLOCK_RED_BASE: a [block] line here matches neither the
+# red-base nor the transient-block patterns pr-babysit's patrol looks for,
+# so blocking would park every merge lane and silently revoke the red-base
+# merge exception. (Wiring this signal into the patrol is a separate,
+# coordinated change.) Skip the sample entirely when the base branch is
+# already red - that already explains per-PR redness, and avoids reporting
+# "the base branch shows green" right after a red-base line above - and stay
+# silent on an empty, unreadable, or mixed-health sample.
+if [[ "$base_red_count" -eq 0 ]]; then
+  pr_gate_runs=$(gh run list --repo "$repo" --event pull_request --status completed \
+    --limit 60 --json conclusion,headBranch,workflowName,createdAt,url 2>/dev/null) || pr_gate_runs=""
+  # gh can exit 0 with non-JSON (or empty) output; treat anything that is not
+  # a JSON array the same as an empty sample rather than let jq abort under -e.
+  jq -e 'type == "array"' >/dev/null 2>&1 <<<"${pr_gate_runs:-}" || pr_gate_runs='[]'
+  pr_gate_broken=$(jq '
+    [group_by(.workflowName)[]
+     | { workflow: (.[0].workflowName // "unknown"),
+         decisive: [.[] | select(
+           (.conclusion // "") == "success" or
+           ((.conclusion // "") | test("^(failure|timed_out|action_required|startup_failure)$"))
+         )] }
+     | select((.decisive | length) >= 5)
+     | select((.decisive | map(.headBranch) | unique | length) >= 3)
+     | select(all(.decisive[]; (.conclusion // "") | test("^(failure|timed_out|action_required|startup_failure)$")))
+    ] | .[0] // empty' <<<"$pr_gate_runs")
+  if [[ -n "$pr_gate_broken" ]]; then
+    pr_gate_workflow=$(jq -r '.workflow' <<<"$pr_gate_broken")
+    pr_gate_count=$(jq -r '.decisive | length' <<<"$pr_gate_broken")
+    pr_gate_heads=$(jq -r '.decisive | map(.headBranch) | unique | length' <<<"$pr_gate_broken")
+    pr_gate_newest=$(jq -r '.decisive | sort_by(.createdAt) | last | "\(.createdAt) \(.url)"' <<<"$pr_gate_broken")
+    warn "PR gate workflow '${pr_gate_workflow}' appears broken: all ${pr_gate_count} of its recent completed pull_request runs across ${pr_gate_heads} branches failed (newest: ${pr_gate_newest}). A job that exists only in that workflow may be red for every PR while the base branch shows green. Investigate before trusting per-PR check verdicts."
   fi
 fi
 

--- a/scripts/pr-preflight.sh
+++ b/scripts/pr-preflight.sh
@@ -327,7 +327,7 @@ if [[ "$base_red_count" -eq 0 ]]; then
      | select((.decisive | length) >= 5)
      | select((.decisive | map(.headBranch) | unique | length) >= 3)
      | select(all(.decisive[]; (.conclusion // "") | test("^(failure|timed_out|action_required|startup_failure)$")))
-    ] | .[0] // empty' <<<"$pr_gate_runs")
+    ] | .[0] // empty' <<<"$pr_gate_runs") || pr_gate_broken=""
   if [[ -n "$pr_gate_broken" ]]; then
     pr_gate_workflow=$(jq -r '.workflow' <<<"$pr_gate_broken")
     pr_gate_count=$(jq -r '.decisive | length' <<<"$pr_gate_broken")

--- a/scripts/pr_preflight_test.go
+++ b/scripts/pr_preflight_test.go
@@ -359,12 +359,12 @@ func TestPRPreflightPRGateHealthSample(t *testing.T) {
 	// case that exercises it therefore supplies a green base sample.
 	greenBase := `[{"conclusion":"success","workflowName":"CI","createdAt":"2026-07-28T12:00:00Z","url":"https://github.com/o/r/actions/base-0"}]`
 	sixRunsThreeHeadsAllFailed := `[` +
-		`{"conclusion":"failure","headBranch":"branch-a","workflowName":"PR CI","createdAt":"2026-07-28T10:00:00Z","url":"https://github.com/o/r/actions/runs/1"},` +
-		`{"conclusion":"failure","headBranch":"branch-a","workflowName":"PR CI","createdAt":"2026-07-28T09:00:00Z","url":"https://github.com/o/r/actions/runs/2"},` +
-		`{"conclusion":"failure","headBranch":"branch-b","workflowName":"PR CI","createdAt":"2026-07-28T08:00:00Z","url":"https://github.com/o/r/actions/runs/3"},` +
-		`{"conclusion":"failure","headBranch":"branch-b","workflowName":"PR CI","createdAt":"2026-07-28T07:00:00Z","url":"https://github.com/o/r/actions/runs/4"},` +
-		`{"conclusion":"failure","headBranch":"branch-c","workflowName":"PR CI","createdAt":"2026-07-28T06:00:00Z","url":"https://github.com/o/r/actions/runs/5"},` +
-		`{"conclusion":"failure","headBranch":"branch-c","workflowName":"PR CI","createdAt":"2026-07-28T05:00:00Z","url":"https://github.com/o/r/actions/runs/6"}` +
+		`{"conclusion":"failure","headBranch":"branch-a","workflowName":"PR CI","workflowDatabaseId":101,"createdAt":"2026-07-28T10:00:00Z","url":"https://github.com/o/r/actions/runs/1"},` +
+		`{"conclusion":"failure","headBranch":"branch-a","workflowName":"PR CI","workflowDatabaseId":101,"createdAt":"2026-07-28T09:00:00Z","url":"https://github.com/o/r/actions/runs/2"},` +
+		`{"conclusion":"failure","headBranch":"branch-b","workflowName":"PR CI","workflowDatabaseId":101,"createdAt":"2026-07-28T08:00:00Z","url":"https://github.com/o/r/actions/runs/3"},` +
+		`{"conclusion":"failure","headBranch":"branch-b","workflowName":"PR CI","workflowDatabaseId":101,"createdAt":"2026-07-28T07:00:00Z","url":"https://github.com/o/r/actions/runs/4"},` +
+		`{"conclusion":"failure","headBranch":"branch-c","workflowName":"PR CI","workflowDatabaseId":101,"createdAt":"2026-07-28T06:00:00Z","url":"https://github.com/o/r/actions/runs/5"},` +
+		`{"conclusion":"failure","headBranch":"branch-c","workflowName":"PR CI","workflowDatabaseId":101,"createdAt":"2026-07-28T05:00:00Z","url":"https://github.com/o/r/actions/runs/6"}` +
 		`]`
 
 	t.Run("all failed across 3+ heads with 5+ decisive runs warns and names the workflow", func(t *testing.T) {
@@ -398,7 +398,7 @@ func TestPRPreflightPRGateHealthSample(t *testing.T) {
 	})
 
 	t.Run("one success in the workflow's sample stays silent", func(t *testing.T) {
-		mostlyFailedOneSuccess := strings.Replace(sixRunsThreeHeadsAllFailed, `"conclusion":"failure","headBranch":"branch-c","workflowName":"PR CI","createdAt":"2026-07-28T05:00:00Z"`, `"conclusion":"success","headBranch":"branch-c","workflowName":"PR CI","createdAt":"2026-07-28T05:00:00Z"`, 1)
+		mostlyFailedOneSuccess := strings.Replace(sixRunsThreeHeadsAllFailed, `"conclusion":"failure","headBranch":"branch-c","workflowName":"PR CI","workflowDatabaseId":101,"createdAt":"2026-07-28T05:00:00Z"`, `"conclusion":"success","headBranch":"branch-c","workflowName":"PR CI","workflowDatabaseId":101,"createdAt":"2026-07-28T05:00:00Z"`, 1)
 		run := runPRPreflightWithFakeGH(t, preflightFixture{baseRunList: greenBase, prGateRunList: mostlyFailedOneSuccess})
 		if run.err != nil {
 			t.Fatalf("expected exit 0, got error: %v\n%s", run.err, run.output)
@@ -410,12 +410,12 @@ func TestPRPreflightPRGateHealthSample(t *testing.T) {
 
 	t.Run("all failed but only 2 distinct heads stays silent", func(t *testing.T) {
 		twoHeadsAllFailed := `[` +
-			`{"conclusion":"failure","headBranch":"branch-a","workflowName":"PR CI","createdAt":"2026-07-28T10:00:00Z","url":"https://github.com/o/r/actions/runs/1"},` +
-			`{"conclusion":"failure","headBranch":"branch-a","workflowName":"PR CI","createdAt":"2026-07-28T09:00:00Z","url":"https://github.com/o/r/actions/runs/2"},` +
-			`{"conclusion":"failure","headBranch":"branch-a","workflowName":"PR CI","createdAt":"2026-07-28T08:00:00Z","url":"https://github.com/o/r/actions/runs/3"},` +
-			`{"conclusion":"failure","headBranch":"branch-b","workflowName":"PR CI","createdAt":"2026-07-28T07:00:00Z","url":"https://github.com/o/r/actions/runs/4"},` +
-			`{"conclusion":"failure","headBranch":"branch-b","workflowName":"PR CI","createdAt":"2026-07-28T06:00:00Z","url":"https://github.com/o/r/actions/runs/5"},` +
-			`{"conclusion":"failure","headBranch":"branch-b","workflowName":"PR CI","createdAt":"2026-07-28T05:00:00Z","url":"https://github.com/o/r/actions/runs/6"}` +
+			`{"conclusion":"failure","headBranch":"branch-a","workflowName":"PR CI","workflowDatabaseId":101,"createdAt":"2026-07-28T10:00:00Z","url":"https://github.com/o/r/actions/runs/1"},` +
+			`{"conclusion":"failure","headBranch":"branch-a","workflowName":"PR CI","workflowDatabaseId":101,"createdAt":"2026-07-28T09:00:00Z","url":"https://github.com/o/r/actions/runs/2"},` +
+			`{"conclusion":"failure","headBranch":"branch-a","workflowName":"PR CI","workflowDatabaseId":101,"createdAt":"2026-07-28T08:00:00Z","url":"https://github.com/o/r/actions/runs/3"},` +
+			`{"conclusion":"failure","headBranch":"branch-b","workflowName":"PR CI","workflowDatabaseId":101,"createdAt":"2026-07-28T07:00:00Z","url":"https://github.com/o/r/actions/runs/4"},` +
+			`{"conclusion":"failure","headBranch":"branch-b","workflowName":"PR CI","workflowDatabaseId":101,"createdAt":"2026-07-28T06:00:00Z","url":"https://github.com/o/r/actions/runs/5"},` +
+			`{"conclusion":"failure","headBranch":"branch-b","workflowName":"PR CI","workflowDatabaseId":101,"createdAt":"2026-07-28T05:00:00Z","url":"https://github.com/o/r/actions/runs/6"}` +
 			`]`
 		run := runPRPreflightWithFakeGH(t, preflightFixture{baseRunList: greenBase, prGateRunList: twoHeadsAllFailed})
 		if run.err != nil {
@@ -438,13 +438,13 @@ func TestPRPreflightPRGateHealthSample(t *testing.T) {
 
 	t.Run("mixed workflows: only the all-red workflow fires, and it is named", func(t *testing.T) {
 		mixedWorkflows := `[` +
-			`{"conclusion":"success","headBranch":"branch-a","workflowName":"PR CI","createdAt":"2026-07-28T12:00:00Z","url":"https://github.com/o/r/actions/runs/201"},` +
-			`{"conclusion":"success","headBranch":"branch-b","workflowName":"PR CI","createdAt":"2026-07-28T11:30:00Z","url":"https://github.com/o/r/actions/runs/202"},` +
-			`{"conclusion":"failure","headBranch":"branch-a","workflowName":"Contract corpus","createdAt":"2026-07-28T10:00:00Z","url":"https://github.com/o/r/actions/runs/101"},` +
-			`{"conclusion":"failure","headBranch":"branch-a","workflowName":"Contract corpus","createdAt":"2026-07-28T09:00:00Z","url":"https://github.com/o/r/actions/runs/102"},` +
-			`{"conclusion":"failure","headBranch":"branch-b","workflowName":"Contract corpus","createdAt":"2026-07-28T08:00:00Z","url":"https://github.com/o/r/actions/runs/103"},` +
-			`{"conclusion":"failure","headBranch":"branch-b","workflowName":"Contract corpus","createdAt":"2026-07-28T07:00:00Z","url":"https://github.com/o/r/actions/runs/104"},` +
-			`{"conclusion":"failure","headBranch":"branch-c","workflowName":"Contract corpus","createdAt":"2026-07-28T06:00:00Z","url":"https://github.com/o/r/actions/runs/105"}` +
+			`{"conclusion":"success","headBranch":"branch-a","workflowName":"PR CI","workflowDatabaseId":101,"createdAt":"2026-07-28T12:00:00Z","url":"https://github.com/o/r/actions/runs/201"},` +
+			`{"conclusion":"success","headBranch":"branch-b","workflowName":"PR CI","workflowDatabaseId":101,"createdAt":"2026-07-28T11:30:00Z","url":"https://github.com/o/r/actions/runs/202"},` +
+			`{"conclusion":"failure","headBranch":"branch-a","workflowName":"Contract corpus","workflowDatabaseId":202,"createdAt":"2026-07-28T10:00:00Z","url":"https://github.com/o/r/actions/runs/101"},` +
+			`{"conclusion":"failure","headBranch":"branch-a","workflowName":"Contract corpus","workflowDatabaseId":202,"createdAt":"2026-07-28T09:00:00Z","url":"https://github.com/o/r/actions/runs/102"},` +
+			`{"conclusion":"failure","headBranch":"branch-b","workflowName":"Contract corpus","workflowDatabaseId":202,"createdAt":"2026-07-28T08:00:00Z","url":"https://github.com/o/r/actions/runs/103"},` +
+			`{"conclusion":"failure","headBranch":"branch-b","workflowName":"Contract corpus","workflowDatabaseId":202,"createdAt":"2026-07-28T07:00:00Z","url":"https://github.com/o/r/actions/runs/104"},` +
+			`{"conclusion":"failure","headBranch":"branch-c","workflowName":"Contract corpus","workflowDatabaseId":202,"createdAt":"2026-07-28T06:00:00Z","url":"https://github.com/o/r/actions/runs/105"}` +
 			`]`
 		run := runPRPreflightWithFakeGH(t, preflightFixture{baseRunList: greenBase, prGateRunList: mixedWorkflows})
 		if run.err != nil {

--- a/scripts/pr_preflight_test.go
+++ b/scripts/pr_preflight_test.go
@@ -375,6 +375,25 @@ func TestPRPreflightPRGateHealthSample(t *testing.T) {
 		}
 	})
 
+	t.Run("stays warn-only even under PR_PREFLIGHT_BLOCK_RED_BASE=1", func(t *testing.T) {
+		// The warn-only property is the load-bearing one: mybd's pr-babysit
+		// classifies any unrecognized [block] line as a genuine merge blocker
+		// and parks merge lanes on it, and it withholds the base-fix
+		// exception whenever a non-red-base block is present. This detector
+		// must therefore never escalate to a block, regardless of the
+		// red-base escalation env var.
+		run := runPRPreflightWithFakeGH(t, preflightFixture{prGateRunList: sixRunsThreeHeadsAllFailed, blockRedBase: "1"})
+		if run.err != nil {
+			t.Fatalf("expected warn-only exit even with PR_PREFLIGHT_BLOCK_RED_BASE=1, got error: %v\n%s", run.err, run.output)
+		}
+		if !strings.Contains(run.output, "[warn] PR gate workflow 'PR CI' appears broken") {
+			t.Fatalf("expected the broken-PR-gate warn to still fire:\n%s", run.output)
+		}
+		if strings.Contains(run.output, "[block] PR gate") {
+			t.Fatalf("PR-gate detector must never emit a [block] line:\n%s", run.output)
+		}
+	})
+
 	t.Run("one success in the workflow's sample stays silent", func(t *testing.T) {
 		mostlyFailedOneSuccess := strings.Replace(sixRunsThreeHeadsAllFailed, `"conclusion":"failure","headBranch":"branch-c","workflowName":"PR CI","createdAt":"2026-07-28T05:00:00Z"`, `"conclusion":"success","headBranch":"branch-c","workflowName":"PR CI","createdAt":"2026-07-28T05:00:00Z"`, 1)
 		run := runPRPreflightWithFakeGH(t, preflightFixture{prGateRunList: mostlyFailedOneSuccess})

--- a/scripts/pr_preflight_test.go
+++ b/scripts/pr_preflight_test.go
@@ -44,7 +44,17 @@ const (
       printf '%s\n' "{\"number\":${PR_NUMBER},\"title\":\"Compatibility fixture\",\"author\":{\"login\":\"contributor\"},\"url\":\"${PR_URL}\",\"baseRefName\":\"main\",\"headRefName\":\"fix/preflight\",\"headRepositoryOwner\":{\"login\":\"contributor\"},\"isCrossRepository\":true,\"isDraft\":false,\"maintainerCanModify\":true,\"mergeStateStatus\":\"CLEAN\",\"mergeable\":\"MERGEABLE\",\"reviewDecision\":\"APPROVED\",\"changedFiles\":1,\"additions\":1,\"deletions\":0,\"files\":[{\"path\":\"README.md\"}],\"statusCheckRollup\":${PR_ROLLUP:-[]},\"latestReviews\":[]}"
       ;;
     "run list")
-      printf '[]\n'
+      is_base_call=0
+      for arg in "$@"; do
+        case "$arg" in
+          --branch) is_base_call=1 ;;
+        esac
+      done
+      if [ "$is_base_call" = 1 ]; then
+        printf '%s\n' "${BASE_RUN_LIST:-[]}"
+      else
+        printf '%s\n' "${PR_GATE_RUN_LIST:-[]}"
+      fi
       ;;
     "api graphql")
       if [ "$GRAPHQL_EXIT" != 0 ]; then
@@ -69,6 +79,9 @@ type preflightFixture struct {
 	graphQLResponse string
 	graphQLExit     string
 	rollup          string
+	baseRunList     string
+	prGateRunList   string
+	blockRedBase    string
 }
 
 type preflightRun struct {
@@ -332,6 +345,85 @@ func TestPRPreflightChecksUseLatestRunPerName(t *testing.T) {
 	})
 }
 
+// The base-branch health check above reads gh run list --branch <base>, which
+// only sees workflows that actually run on the base branch. A job that exists
+// only in the PR workflow (pr.yml) never runs there, so that check alone
+// reported "green" while every fresh PR was red in that job. This supplemental
+// sample reads recent completed pull_request-event runs across PRs looking
+// for a gate that is uniformly failing regardless of branch.
+func TestPRPreflightPRGateHealthSample(t *testing.T) {
+	sixRunsThreeHeadsAllFailed := `[` +
+		`{"conclusion":"failure","headBranch":"branch-a","workflowName":"PR CI","createdAt":"2026-07-28T10:00:00Z","url":"https://github.com/o/r/actions/runs/1"},` +
+		`{"conclusion":"failure","headBranch":"branch-a","workflowName":"PR CI","createdAt":"2026-07-28T09:00:00Z","url":"https://github.com/o/r/actions/runs/2"},` +
+		`{"conclusion":"failure","headBranch":"branch-b","workflowName":"PR CI","createdAt":"2026-07-28T08:00:00Z","url":"https://github.com/o/r/actions/runs/3"},` +
+		`{"conclusion":"failure","headBranch":"branch-b","workflowName":"PR CI","createdAt":"2026-07-28T07:00:00Z","url":"https://github.com/o/r/actions/runs/4"},` +
+		`{"conclusion":"failure","headBranch":"branch-c","workflowName":"PR CI","createdAt":"2026-07-28T06:00:00Z","url":"https://github.com/o/r/actions/runs/5"},` +
+		`{"conclusion":"failure","headBranch":"branch-c","workflowName":"PR CI","createdAt":"2026-07-28T05:00:00Z","url":"https://github.com/o/r/actions/runs/6"}` +
+		`]`
+
+	t.Run("all failed across 3+ heads with 6+ decisive runs warns", func(t *testing.T) {
+		run := runPRPreflightWithFakeGH(t, preflightFixture{prGateRunList: sixRunsThreeHeadsAllFailed})
+		if run.err != nil {
+			t.Fatalf("expected warn-only exit, got error: %v\n%s", run.err, run.output)
+		}
+		if !strings.Contains(run.output, "[warn] PR gate appears broken: last 6 completed pull_request runs across 3 distinct branches all failed") {
+			t.Fatalf("expected broken-PR-gate warning:\n%s", run.output)
+		}
+	})
+
+	t.Run("PR_PREFLIGHT_BLOCK_RED_BASE=1 turns the same sample into a block", func(t *testing.T) {
+		run := runPRPreflightWithFakeGH(t, preflightFixture{
+			prGateRunList: sixRunsThreeHeadsAllFailed,
+			blockRedBase:  "1",
+		})
+		if exitCode(run.err) != 1 {
+			t.Fatalf("exit = %d, want 1; error=%v\n%s", exitCode(run.err), run.err, run.output)
+		}
+		if !strings.Contains(run.output, "[block] PR gate appears broken: last 6 completed pull_request runs across 3 distinct branches all failed") {
+			t.Fatalf("expected broken-PR-gate block:\n%s", run.output)
+		}
+	})
+
+	t.Run("one success in the sample stays silent", func(t *testing.T) {
+		mostlyFailedOneSuccess := strings.Replace(sixRunsThreeHeadsAllFailed, `"conclusion":"failure","headBranch":"branch-c","workflowName":"PR CI","createdAt":"2026-07-28T05:00:00Z"`, `"conclusion":"success","headBranch":"branch-c","workflowName":"PR CI","createdAt":"2026-07-28T05:00:00Z"`, 1)
+		run := runPRPreflightWithFakeGH(t, preflightFixture{prGateRunList: mostlyFailedOneSuccess})
+		if run.err != nil {
+			t.Fatalf("expected exit 0, got error: %v\n%s", run.err, run.output)
+		}
+		if strings.Contains(run.output, "PR gate appears broken") {
+			t.Fatalf("a sample with a success should stay silent:\n%s", run.output)
+		}
+	})
+
+	t.Run("all failed but only 2 distinct heads stays silent", func(t *testing.T) {
+		twoHeadsAllFailed := `[` +
+			`{"conclusion":"failure","headBranch":"branch-a","workflowName":"PR CI","createdAt":"2026-07-28T10:00:00Z","url":"https://github.com/o/r/actions/runs/1"},` +
+			`{"conclusion":"failure","headBranch":"branch-a","workflowName":"PR CI","createdAt":"2026-07-28T09:00:00Z","url":"https://github.com/o/r/actions/runs/2"},` +
+			`{"conclusion":"failure","headBranch":"branch-a","workflowName":"PR CI","createdAt":"2026-07-28T08:00:00Z","url":"https://github.com/o/r/actions/runs/3"},` +
+			`{"conclusion":"failure","headBranch":"branch-b","workflowName":"PR CI","createdAt":"2026-07-28T07:00:00Z","url":"https://github.com/o/r/actions/runs/4"},` +
+			`{"conclusion":"failure","headBranch":"branch-b","workflowName":"PR CI","createdAt":"2026-07-28T06:00:00Z","url":"https://github.com/o/r/actions/runs/5"},` +
+			`{"conclusion":"failure","headBranch":"branch-b","workflowName":"PR CI","createdAt":"2026-07-28T05:00:00Z","url":"https://github.com/o/r/actions/runs/6"}` +
+			`]`
+		run := runPRPreflightWithFakeGH(t, preflightFixture{prGateRunList: twoHeadsAllFailed})
+		if run.err != nil {
+			t.Fatalf("expected exit 0, got error: %v\n%s", run.err, run.output)
+		}
+		if strings.Contains(run.output, "PR gate appears broken") {
+			t.Fatalf("only 2 distinct heads should stay silent:\n%s", run.output)
+		}
+	})
+
+	t.Run("empty sample stays silent", func(t *testing.T) {
+		run := runPRPreflightWithFakeGH(t, preflightFixture{prGateRunList: "[]"})
+		if run.err != nil {
+			t.Fatalf("expected exit 0, got error: %v\n%s", run.err, run.output)
+		}
+		if strings.Contains(run.output, "PR gate appears broken") {
+			t.Fatalf("empty sample should stay silent:\n%s", run.output)
+		}
+	})
+}
+
 func runPRPreflightWithFakeGH(t *testing.T, fixture preflightFixture) preflightRun {
 	t.Helper()
 
@@ -352,6 +444,15 @@ func runPRPreflightWithFakeGH(t *testing.T, fixture preflightFixture) preflightR
 	}
 	if fixture.rollup == "" {
 		fixture.rollup = "[]"
+	}
+	if fixture.baseRunList == "" {
+		fixture.baseRunList = "[]"
+	}
+	if fixture.prGateRunList == "" {
+		fixture.prGateRunList = "[]"
+	}
+	if fixture.blockRedBase == "" {
+		fixture.blockRedBase = "0"
 	}
 
 	bash, path := prPreflightProcessTools(t)
@@ -395,6 +496,9 @@ func runPRPreflightWithFakeGH(t *testing.T, fixture preflightFixture) preflightR
 		"PR_NUMBER="+fixture.returnedNumber,
 		"PR_URL="+fixture.canonicalURL,
 		"PR_ROLLUP="+fixture.rollup,
+		"BASE_RUN_LIST="+fixture.baseRunList,
+		"PR_GATE_RUN_LIST="+fixture.prGateRunList,
+		"PR_PREFLIGHT_BLOCK_RED_BASE="+fixture.blockRedBase,
 	)
 	out, runErr := cmd.CombinedOutput()
 	logBytes, readErr := os.ReadFile(callLog)

--- a/scripts/pr_preflight_test.go
+++ b/scripts/pr_preflight_test.go
@@ -44,16 +44,18 @@ const (
       printf '%s\n' "{\"number\":${PR_NUMBER},\"title\":\"Compatibility fixture\",\"author\":{\"login\":\"contributor\"},\"url\":\"${PR_URL}\",\"baseRefName\":\"main\",\"headRefName\":\"fix/preflight\",\"headRepositoryOwner\":{\"login\":\"contributor\"},\"isCrossRepository\":true,\"isDraft\":false,\"maintainerCanModify\":true,\"mergeStateStatus\":\"CLEAN\",\"mergeable\":\"MERGEABLE\",\"reviewDecision\":\"APPROVED\",\"changedFiles\":1,\"additions\":1,\"deletions\":0,\"files\":[{\"path\":\"README.md\"}],\"statusCheckRollup\":${PR_ROLLUP:-[]},\"latestReviews\":[]}"
       ;;
     "run list")
-      is_base_call=0
+      is_pr_gate_call=0
+      prev=""
       for arg in "$@"; do
-        case "$arg" in
-          --branch) is_base_call=1 ;;
-        esac
+        if [ "$prev" = "--event" ] && [ "$arg" = "pull_request" ]; then
+          is_pr_gate_call=1
+        fi
+        prev="$arg"
       done
-      if [ "$is_base_call" = 1 ]; then
-        printf '%s\n' "${BASE_RUN_LIST:-[]}"
-      else
+      if [ "$is_pr_gate_call" = 1 ]; then
         printf '%s\n' "${PR_GATE_RUN_LIST:-[]}"
+      else
+        printf '%s\n' "${BASE_RUN_LIST:-[]}"
       fi
       ;;
     "api graphql")
@@ -347,10 +349,11 @@ func TestPRPreflightChecksUseLatestRunPerName(t *testing.T) {
 
 // The base-branch health check above reads gh run list --branch <base>, which
 // only sees workflows that actually run on the base branch. A job that exists
-// only in the PR workflow (pr.yml) never runs there, so that check alone
-// reported "green" while every fresh PR was red in that job. This supplemental
-// sample reads recent completed pull_request-event runs across PRs looking
-// for a gate that is uniformly failing regardless of branch.
+// only in the PR workflow (pr.yml) never runs there, and even sampling
+// pull_request-event runs in aggregate would dilute one broken workflow's
+// signal against every other green PR workflow. This supplemental, warn-only
+// detector groups the sample by workflow and flags any single workflow that
+// is uniformly failing across several distinct branches.
 func TestPRPreflightPRGateHealthSample(t *testing.T) {
 	sixRunsThreeHeadsAllFailed := `[` +
 		`{"conclusion":"failure","headBranch":"branch-a","workflowName":"PR CI","createdAt":"2026-07-28T10:00:00Z","url":"https://github.com/o/r/actions/runs/1"},` +
@@ -361,37 +364,25 @@ func TestPRPreflightPRGateHealthSample(t *testing.T) {
 		`{"conclusion":"failure","headBranch":"branch-c","workflowName":"PR CI","createdAt":"2026-07-28T05:00:00Z","url":"https://github.com/o/r/actions/runs/6"}` +
 		`]`
 
-	t.Run("all failed across 3+ heads with 6+ decisive runs warns", func(t *testing.T) {
+	t.Run("all failed across 3+ heads with 5+ decisive runs warns and names the workflow", func(t *testing.T) {
 		run := runPRPreflightWithFakeGH(t, preflightFixture{prGateRunList: sixRunsThreeHeadsAllFailed})
 		if run.err != nil {
 			t.Fatalf("expected warn-only exit, got error: %v\n%s", run.err, run.output)
 		}
-		if !strings.Contains(run.output, "[warn] PR gate appears broken: last 6 completed pull_request runs across 3 distinct branches all failed") {
-			t.Fatalf("expected broken-PR-gate warning:\n%s", run.output)
+		want := "[warn] PR gate workflow 'PR CI' appears broken: all 6 of its recent completed pull_request runs across 3 branches failed (newest: 2026-07-28T10:00:00Z https://github.com/o/r/actions/runs/1)."
+		if !strings.Contains(run.output, want) {
+			t.Fatalf("expected broken-PR-gate warning naming the workflow and newest run:\nwant substring: %s\ngot:\n%s", want, run.output)
 		}
 	})
 
-	t.Run("PR_PREFLIGHT_BLOCK_RED_BASE=1 turns the same sample into a block", func(t *testing.T) {
-		run := runPRPreflightWithFakeGH(t, preflightFixture{
-			prGateRunList: sixRunsThreeHeadsAllFailed,
-			blockRedBase:  "1",
-		})
-		if exitCode(run.err) != 1 {
-			t.Fatalf("exit = %d, want 1; error=%v\n%s", exitCode(run.err), run.err, run.output)
-		}
-		if !strings.Contains(run.output, "[block] PR gate appears broken: last 6 completed pull_request runs across 3 distinct branches all failed") {
-			t.Fatalf("expected broken-PR-gate block:\n%s", run.output)
-		}
-	})
-
-	t.Run("one success in the sample stays silent", func(t *testing.T) {
+	t.Run("one success in the workflow's sample stays silent", func(t *testing.T) {
 		mostlyFailedOneSuccess := strings.Replace(sixRunsThreeHeadsAllFailed, `"conclusion":"failure","headBranch":"branch-c","workflowName":"PR CI","createdAt":"2026-07-28T05:00:00Z"`, `"conclusion":"success","headBranch":"branch-c","workflowName":"PR CI","createdAt":"2026-07-28T05:00:00Z"`, 1)
 		run := runPRPreflightWithFakeGH(t, preflightFixture{prGateRunList: mostlyFailedOneSuccess})
 		if run.err != nil {
 			t.Fatalf("expected exit 0, got error: %v\n%s", run.err, run.output)
 		}
-		if strings.Contains(run.output, "PR gate appears broken") {
-			t.Fatalf("a sample with a success should stay silent:\n%s", run.output)
+		if strings.Contains(run.output, "PR gate workflow") {
+			t.Fatalf("a workflow sample with a success should stay silent:\n%s", run.output)
 		}
 	})
 
@@ -408,7 +399,7 @@ func TestPRPreflightPRGateHealthSample(t *testing.T) {
 		if run.err != nil {
 			t.Fatalf("expected exit 0, got error: %v\n%s", run.err, run.output)
 		}
-		if strings.Contains(run.output, "PR gate appears broken") {
+		if strings.Contains(run.output, "PR gate workflow") {
 			t.Fatalf("only 2 distinct heads should stay silent:\n%s", run.output)
 		}
 	})
@@ -418,8 +409,72 @@ func TestPRPreflightPRGateHealthSample(t *testing.T) {
 		if run.err != nil {
 			t.Fatalf("expected exit 0, got error: %v\n%s", run.err, run.output)
 		}
-		if strings.Contains(run.output, "PR gate appears broken") {
+		if strings.Contains(run.output, "PR gate workflow") {
 			t.Fatalf("empty sample should stay silent:\n%s", run.output)
+		}
+	})
+
+	t.Run("mixed workflows: only the all-red workflow fires, and it is named", func(t *testing.T) {
+		mixedWorkflows := `[` +
+			`{"conclusion":"success","headBranch":"branch-a","workflowName":"PR CI","createdAt":"2026-07-28T12:00:00Z","url":"https://github.com/o/r/actions/runs/201"},` +
+			`{"conclusion":"success","headBranch":"branch-b","workflowName":"PR CI","createdAt":"2026-07-28T11:30:00Z","url":"https://github.com/o/r/actions/runs/202"},` +
+			`{"conclusion":"failure","headBranch":"branch-a","workflowName":"Contract corpus","createdAt":"2026-07-28T10:00:00Z","url":"https://github.com/o/r/actions/runs/101"},` +
+			`{"conclusion":"failure","headBranch":"branch-a","workflowName":"Contract corpus","createdAt":"2026-07-28T09:00:00Z","url":"https://github.com/o/r/actions/runs/102"},` +
+			`{"conclusion":"failure","headBranch":"branch-b","workflowName":"Contract corpus","createdAt":"2026-07-28T08:00:00Z","url":"https://github.com/o/r/actions/runs/103"},` +
+			`{"conclusion":"failure","headBranch":"branch-b","workflowName":"Contract corpus","createdAt":"2026-07-28T07:00:00Z","url":"https://github.com/o/r/actions/runs/104"},` +
+			`{"conclusion":"failure","headBranch":"branch-c","workflowName":"Contract corpus","createdAt":"2026-07-28T06:00:00Z","url":"https://github.com/o/r/actions/runs/105"}` +
+			`]`
+		run := runPRPreflightWithFakeGH(t, preflightFixture{prGateRunList: mixedWorkflows})
+		if run.err != nil {
+			t.Fatalf("expected exit 0, got error: %v\n%s", run.err, run.output)
+		}
+		want := "[warn] PR gate workflow 'Contract corpus' appears broken: all 5 of its recent completed pull_request runs across 3 branches failed (newest: 2026-07-28T10:00:00Z https://github.com/o/r/actions/runs/101)."
+		if !strings.Contains(run.output, want) {
+			t.Fatalf("expected the all-red workflow to be named despite a healthy sibling workflow:\nwant substring: %s\ngot:\n%s", want, run.output)
+		}
+		if strings.Contains(run.output, "'PR CI'") {
+			t.Fatalf("the healthy workflow must not be named as broken:\n%s", run.output)
+		}
+	})
+
+	t.Run("red base skips the sample even when a workflow would otherwise fire", func(t *testing.T) {
+		redBaseRunList := `[{"conclusion":"failure","workflowName":"CI","createdAt":"2026-07-28T09:00:00Z","url":"https://github.com/o/r/actions/base-1"}]`
+		run := runPRPreflightWithFakeGH(t, preflightFixture{
+			baseRunList:   redBaseRunList,
+			prGateRunList: sixRunsThreeHeadsAllFailed,
+		})
+		if run.err != nil {
+			t.Fatalf("expected exit 0 (warn-only), got error: %v\n%s", run.err, run.output)
+		}
+		if !strings.Contains(run.output, "Base branch main CI is RED") {
+			t.Fatalf("expected the existing red-base warning to still fire:\n%s", run.output)
+		}
+		if strings.Contains(run.output, "PR gate workflow") {
+			t.Fatalf("the PR-gate sample must be skipped while the base is red:\n%s", run.output)
+		}
+	})
+
+	t.Run("unreadable/non-JSON sample stays silent", func(t *testing.T) {
+		run := runPRPreflightWithFakeGH(t, preflightFixture{prGateRunList: "gh: rate limit exceeded"})
+		if run.err != nil {
+			t.Fatalf("expected exit 0, got error: %v\n%s", run.err, run.output)
+		}
+		if strings.Contains(run.output, "PR gate workflow") {
+			t.Fatalf("an unreadable sample should stay silent, not error:\n%s", run.output)
+		}
+	})
+
+	t.Run("BASE_RUN_LIST positively drives the base-branch dispatch, not the PR-gate one", func(t *testing.T) {
+		greenBaseRunList := `[{"conclusion":"success","workflowName":"CI","createdAt":"2026-07-28T12:00:00Z","url":"https://github.com/o/r/actions/base-2"}]`
+		run := runPRPreflightWithFakeGH(t, preflightFixture{baseRunList: greenBaseRunList})
+		if run.err != nil {
+			t.Fatalf("expected exit 0, got error: %v\n%s", run.err, run.output)
+		}
+		if !strings.Contains(run.output, "[pass] Base branch main CI is green (latest completed run of each of 1 workflow(s) succeeded).") {
+			t.Fatalf("expected BASE_RUN_LIST to reach the base-branch call, not the PR-gate one:\n%s", run.output)
+		}
+		if strings.Contains(run.output, "PR gate workflow") {
+			t.Fatalf("default empty PR-gate sample should stay silent:\n%s", run.output)
 		}
 	})
 }

--- a/scripts/pr_preflight_test.go
+++ b/scripts/pr_preflight_test.go
@@ -355,6 +355,9 @@ func TestPRPreflightChecksUseLatestRunPerName(t *testing.T) {
 // detector groups the sample by workflow and flags any single workflow that
 // is uniformly failing across several distinct branches.
 func TestPRPreflightPRGateHealthSample(t *testing.T) {
+	// The detector only speaks against a base branch known to be green; every
+	// case that exercises it therefore supplies a green base sample.
+	greenBase := `[{"conclusion":"success","workflowName":"CI","createdAt":"2026-07-28T12:00:00Z","url":"https://github.com/o/r/actions/base-0"}]`
 	sixRunsThreeHeadsAllFailed := `[` +
 		`{"conclusion":"failure","headBranch":"branch-a","workflowName":"PR CI","createdAt":"2026-07-28T10:00:00Z","url":"https://github.com/o/r/actions/runs/1"},` +
 		`{"conclusion":"failure","headBranch":"branch-a","workflowName":"PR CI","createdAt":"2026-07-28T09:00:00Z","url":"https://github.com/o/r/actions/runs/2"},` +
@@ -365,7 +368,7 @@ func TestPRPreflightPRGateHealthSample(t *testing.T) {
 		`]`
 
 	t.Run("all failed across 3+ heads with 5+ decisive runs warns and names the workflow", func(t *testing.T) {
-		run := runPRPreflightWithFakeGH(t, preflightFixture{prGateRunList: sixRunsThreeHeadsAllFailed})
+		run := runPRPreflightWithFakeGH(t, preflightFixture{baseRunList: greenBase, prGateRunList: sixRunsThreeHeadsAllFailed})
 		if run.err != nil {
 			t.Fatalf("expected warn-only exit, got error: %v\n%s", run.err, run.output)
 		}
@@ -382,7 +385,7 @@ func TestPRPreflightPRGateHealthSample(t *testing.T) {
 		// exception whenever a non-red-base block is present. This detector
 		// must therefore never escalate to a block, regardless of the
 		// red-base escalation env var.
-		run := runPRPreflightWithFakeGH(t, preflightFixture{prGateRunList: sixRunsThreeHeadsAllFailed, blockRedBase: "1"})
+		run := runPRPreflightWithFakeGH(t, preflightFixture{baseRunList: greenBase, prGateRunList: sixRunsThreeHeadsAllFailed, blockRedBase: "1"})
 		if run.err != nil {
 			t.Fatalf("expected warn-only exit even with PR_PREFLIGHT_BLOCK_RED_BASE=1, got error: %v\n%s", run.err, run.output)
 		}
@@ -396,7 +399,7 @@ func TestPRPreflightPRGateHealthSample(t *testing.T) {
 
 	t.Run("one success in the workflow's sample stays silent", func(t *testing.T) {
 		mostlyFailedOneSuccess := strings.Replace(sixRunsThreeHeadsAllFailed, `"conclusion":"failure","headBranch":"branch-c","workflowName":"PR CI","createdAt":"2026-07-28T05:00:00Z"`, `"conclusion":"success","headBranch":"branch-c","workflowName":"PR CI","createdAt":"2026-07-28T05:00:00Z"`, 1)
-		run := runPRPreflightWithFakeGH(t, preflightFixture{prGateRunList: mostlyFailedOneSuccess})
+		run := runPRPreflightWithFakeGH(t, preflightFixture{baseRunList: greenBase, prGateRunList: mostlyFailedOneSuccess})
 		if run.err != nil {
 			t.Fatalf("expected exit 0, got error: %v\n%s", run.err, run.output)
 		}
@@ -414,7 +417,7 @@ func TestPRPreflightPRGateHealthSample(t *testing.T) {
 			`{"conclusion":"failure","headBranch":"branch-b","workflowName":"PR CI","createdAt":"2026-07-28T06:00:00Z","url":"https://github.com/o/r/actions/runs/5"},` +
 			`{"conclusion":"failure","headBranch":"branch-b","workflowName":"PR CI","createdAt":"2026-07-28T05:00:00Z","url":"https://github.com/o/r/actions/runs/6"}` +
 			`]`
-		run := runPRPreflightWithFakeGH(t, preflightFixture{prGateRunList: twoHeadsAllFailed})
+		run := runPRPreflightWithFakeGH(t, preflightFixture{baseRunList: greenBase, prGateRunList: twoHeadsAllFailed})
 		if run.err != nil {
 			t.Fatalf("expected exit 0, got error: %v\n%s", run.err, run.output)
 		}
@@ -424,7 +427,7 @@ func TestPRPreflightPRGateHealthSample(t *testing.T) {
 	})
 
 	t.Run("empty sample stays silent", func(t *testing.T) {
-		run := runPRPreflightWithFakeGH(t, preflightFixture{prGateRunList: "[]"})
+		run := runPRPreflightWithFakeGH(t, preflightFixture{baseRunList: greenBase, prGateRunList: "[]"})
 		if run.err != nil {
 			t.Fatalf("expected exit 0, got error: %v\n%s", run.err, run.output)
 		}
@@ -443,7 +446,7 @@ func TestPRPreflightPRGateHealthSample(t *testing.T) {
 			`{"conclusion":"failure","headBranch":"branch-b","workflowName":"Contract corpus","createdAt":"2026-07-28T07:00:00Z","url":"https://github.com/o/r/actions/runs/104"},` +
 			`{"conclusion":"failure","headBranch":"branch-c","workflowName":"Contract corpus","createdAt":"2026-07-28T06:00:00Z","url":"https://github.com/o/r/actions/runs/105"}` +
 			`]`
-		run := runPRPreflightWithFakeGH(t, preflightFixture{prGateRunList: mixedWorkflows})
+		run := runPRPreflightWithFakeGH(t, preflightFixture{baseRunList: greenBase, prGateRunList: mixedWorkflows})
 		if run.err != nil {
 			t.Fatalf("expected exit 0, got error: %v\n%s", run.err, run.output)
 		}
@@ -453,6 +456,19 @@ func TestPRPreflightPRGateHealthSample(t *testing.T) {
 		}
 		if strings.Contains(run.output, "'PR CI'") {
 			t.Fatalf("the healthy workflow must not be named as broken:\n%s", run.output)
+		}
+	})
+
+	t.Run("undetermined base health skips the sample", func(t *testing.T) {
+		// With no decisive base runs at all, preflight has just warned that it
+		// could not determine base health; diagnosing "red for every PR while
+		// the base branch shows green" would contradict that line.
+		run := runPRPreflightWithFakeGH(t, preflightFixture{baseRunList: "[]", prGateRunList: sixRunsThreeHeadsAllFailed})
+		if run.err != nil {
+			t.Fatalf("expected exit 0, got error: %v\n%s", run.err, run.output)
+		}
+		if strings.Contains(run.output, "PR gate workflow") {
+			t.Fatalf("the PR-gate sample must be skipped when base health is undetermined:\n%s", run.output)
 		}
 	})
 
@@ -474,7 +490,7 @@ func TestPRPreflightPRGateHealthSample(t *testing.T) {
 	})
 
 	t.Run("unreadable/non-JSON sample stays silent", func(t *testing.T) {
-		run := runPRPreflightWithFakeGH(t, preflightFixture{prGateRunList: "gh: rate limit exceeded"})
+		run := runPRPreflightWithFakeGH(t, preflightFixture{baseRunList: greenBase, prGateRunList: "gh: rate limit exceeded"})
 		if run.err != nil {
 			t.Fatalf("expected exit 0, got error: %v\n%s", run.err, run.output)
 		}


### PR DESCRIPTION
## Why

`scripts/pr-preflight.sh`'s base-health check reads the base branch's own workflow runs, so a job that exists only in the PR workflow (e.g. the Contract corpus job in pr.yml) is invisible to it: preflight reported "Base branch main CI is green" across five PRs while every fresh PR was red in that job. Downstream automation that mirrors preflight's verdict inherits the blind spot by construction.

## What

A supplemental, deliberately **warn-only** PR-gate sample after the base-health block:

- Samples the last 60 completed `pull_request`-event runs, groups them by `workflowDatabaseId` (stable identity — display names are not unique and org/ruleset runs may lack one), and warns when any single workflow has >= 5 decisive runs, spanning >= 3 distinct head branches, all failure-class (`failure|timed_out|action_required|startup_failure`). The warning names the workflow and its newest failing run.
- It only speaks against a base branch known green: skipped when the base is red (the red-base message already explains PR redness) or undetermined (the "while the base branch shows green" explanation would contradict the warn printed just above).
- It never blocks, regardless of `PR_PREFLIGHT_BLOCK_RED_BASE`. That is load-bearing, not an oversight: automation that consumes preflight output classifies unrecognized `[block]` lines as genuine merge blockers and would park merge lanes — including a base-fix PR — on a false positive. A regression test pins the warn-only contract.
- Malformed-but-exit-0 `gh` output is treated as an empty sample rather than aborting the report under `set -euo pipefail`.

Tests: the fake-`gh` fixture now dispatches `run list` calls on the presence of `--event pull_request`, and `TestPRPreflightPRGateHealthSample` covers firing, naming amid healthy sibling workflows, one-success silence, insufficient-head silence, empty/unreadable samples, red-base and undetermined-base skips, and the warn-only contract under `PR_PREFLIGHT_BLOCK_RED_BASE=1`.

## Review

Cross-vendor reviewed (Claude reviewer, 2 rounds + codex gpt-5.6, 3 rounds). Adopted: per-workflow grouping (the original aggregate rule could never fire for a single broken workflow amid green siblings), warn-only contract, known-green gating, `workflowDatabaseId` identity, jq abort guards. Declined with reasons:

- *Filter the sample to runs whose PR targets this base*: requires one API call per sampled run; accepted as a documented limitation for a warn-only supplemental detector in a repo whose PRs overwhelmingly target `main`.
- *Treat `startup_failure` as red in the base-health check itself*: that classification predates this PR; extending the base check is out of scope here (the new detector does count `startup_failure` as failure-class).

Tracked in the mybd tracker as mybd-msll (from the rjc123 sweep follow-ups).

_claude-fable-5-high on behalf of maphew_
