### PR TITLE
fix(formula): validate provided-empty and enum/pattern var values in pour/wisp/bond, not just cook

### DIFF
--- a/cmd/bd/cook.go
+++ b/cmd/bd/cook.go
@@ -698,6 +698,20 @@ func resolveAndCookFormulaWithVars(formulaName string, searchPaths []string, con
 		return nil, fmt.Errorf("resolving formula %q: %w", formulaName, err)
 	}
 
+	// Validate any caller-provided variable values against enum/pattern/
+	// required-empty constraints. This is deliberately presence-agnostic:
+	// a var missing entirely is left to the caller's own UX (e.g. bd mol
+	// pour/wisp's missing-var hint), but a var explicitly provided with a
+	// value that violates its constraints must error here so it reaches
+	// every caller of this shared path (cook, pour, wisp, mol bond, mol
+	// seed) — previously only `bd cook --mode=runtime` enforced these
+	// (mybd-u2r6).
+	if conditionVars != nil {
+		if err := formula.ValidateProvidedVars(resolved, conditionVars); err != nil {
+			return nil, fmt.Errorf("formula %q: %w", formulaName, err)
+		}
+	}
+
 	// Apply control flow operators - loops, branches, gates
 	controlFlowSteps, err := formula.ApplyControlFlow(resolved.Steps, resolved.Compose)
 	if err != nil {

--- a/cmd/bd/cook.go
+++ b/cmd/bd/cook.go
@@ -703,9 +703,10 @@ func resolveAndCookFormulaWithVars(formulaName string, searchPaths []string, con
 	// a var missing entirely is left to the caller's own UX (e.g. bd mol
 	// pour/wisp's missing-var hint), but a var explicitly provided with a
 	// value that violates its constraints must error here so it reaches
-	// every caller of this shared path (cook, pour, wisp, mol bond, mol
-	// seed) — previously only `bd cook --mode=runtime` enforced these
-	// (mybd-u2r6).
+	// every caller of this shared path (pour, wisp, mol bond, mol seed) —
+	// runCook does not go through this helper; it validates separately via
+	// its own formula.ValidateVars call under --mode=runtime. Previously
+	// only that `bd cook --mode=runtime` path enforced these (mybd-u2r6).
 	if conditionVars != nil {
 		if err := formula.ValidateProvidedVars(resolved, conditionVars); err != nil {
 			return nil, fmt.Errorf("formula %q: %w", formulaName, err)

--- a/cmd/bd/mol_bond.go
+++ b/cmd/bd/mol_bond.go
@@ -110,11 +110,11 @@ func runMolBond(cmd *cobra.Command, args []string) error {
 	}
 
 	if in.dryRun {
-		issueA, formulaA, err := resolveOrDescribe(ctx, store, in.argA)
+		issueA, formulaA, err := resolveOrDescribe(ctx, store, in.argA, in.vars)
 		if err != nil {
 			return HandleErrorRespectJSON("%v", err)
 		}
-		issueB, formulaB, err := resolveOrDescribe(ctx, store, in.argB)
+		issueB, formulaB, err := resolveOrDescribe(ctx, store, in.argB, in.vars)
 		if err != nil {
 			return HandleErrorRespectJSON("%v", err)
 		}
@@ -606,7 +606,7 @@ func minPriority(a, b int) int {
 // resolveOrDescribe checks if an operand is an issue or formula without cooking.
 // Used for dry-run mode. Returns (issue, formulaName, error).
 // If it's an issue, issue is set. If it's a formula, formulaName is set.
-func resolveOrDescribe(ctx context.Context, s molReader, operand string) (*types.Issue, string, error) {
+func resolveOrDescribe(ctx context.Context, s molReader, operand string, vars map[string]string) (*types.Issue, string, error) {
 	// First, try to resolve as an existing issue
 	id, err := utils.ResolvePartialID(ctx, s, operand)
 	if err == nil {
@@ -624,6 +624,13 @@ func resolveOrDescribe(ctx context.Context, s molReader, operand string) (*types
 	f, err := parser.LoadByName(operand)
 	if err != nil {
 		return nil, "", fmt.Errorf("'%s' not found as issue or formula: %w", operand, err)
+	}
+
+	// A dry-run must fail the same way the real bond would: an enum/pattern/
+	// provided-empty violation in --var values fails resolveOrCookToSubgraph,
+	// so reporting "will be cooked" here would be a false preview.
+	if err := formula.ValidateProvidedVars(f, vars); err != nil {
+		return nil, "", err
 	}
 
 	return nil, f.Formula, nil

--- a/cmd/bd/mol_bond.go
+++ b/cmd/bd/mol_bond.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -662,6 +663,12 @@ func resolveOrCookToSubgraph(ctx context.Context, s molReader, operand string, v
 	// condition filtering (bd-7zka.1).
 	subgraph, err := resolveAndCookFormulaWithVars(operand, nil, vars)
 	if err != nil {
+		if errors.Is(err, formula.ErrVarValidation) {
+			// Don't double-wrap: operand IS a formula, and the --var values
+			// it was given fail enum/pattern/required-empty constraints,
+			// which is a distinct condition from "not found".
+			return nil, false, err
+		}
 		return nil, false, fmt.Errorf("'%s' not found as issue or formula: %w", operand, err)
 	}
 

--- a/cmd/bd/mol_proxied_server.go
+++ b/cmd/bd/mol_proxied_server.go
@@ -381,11 +381,11 @@ func runMolBondProxiedServer(ctx context.Context, in molBondInput) error {
 		defer uw.Close(ctx)
 		r := uowMolReader{uw: uw}
 
-		issueA, formulaA, err := resolveOrDescribe(ctx, r, in.argA)
+		issueA, formulaA, err := resolveOrDescribe(ctx, r, in.argA, in.vars)
 		if err != nil {
 			return HandleErrorRespectJSON("%v", err)
 		}
-		issueB, formulaB, err := resolveOrDescribe(ctx, r, in.argB)
+		issueB, formulaB, err := resolveOrDescribe(ctx, r, in.argB, in.vars)
 		if err != nil {
 			return HandleErrorRespectJSON("%v", err)
 		}

--- a/cmd/bd/mol_proxied_server.go
+++ b/cmd/bd/mol_proxied_server.go
@@ -2,10 +2,12 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"time"
 
+	"github.com/steveyegge/beads/internal/formula"
 	"github.com/steveyegge/beads/internal/storage/domain"
 	"github.com/steveyegge/beads/internal/storage/uow"
 	"github.com/steveyegge/beads/internal/types"
@@ -39,6 +41,12 @@ func runPourProxiedServer(ctx context.Context, in pourInput) error {
 		if sg.Phase == "vapor" {
 			warnPourVaporFormula(in.protoArg, in.varFlags)
 		}
+	} else if errors.Is(err, formula.ErrVarValidation) {
+		// in.protoArg IS a formula; the --var values it was given fail
+		// enum/pattern/required-empty constraints. Report that directly
+		// instead of falling through to the proto-ID lookup below, which
+		// would otherwise mask this as "not found as formula or proto ID".
+		return HandleError("%v", err)
 	}
 
 	res, err := uow.RunTxResult(ctx, uowProvider, func(ctx context.Context, uw uow.UnitOfWork) (pourProxiedResult, string, error) {

--- a/cmd/bd/mol_seed.go
+++ b/cmd/bd/mol_seed.go
@@ -1,11 +1,13 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
 	"github.com/spf13/cobra"
 
+	"github.com/steveyegge/beads/internal/formula"
 	"github.com/steveyegge/beads/internal/metrics"
 )
 
@@ -76,6 +78,12 @@ func verifyFormula(formulaName string, vars map[string]string) error {
 	// 4. Formula can be cooked to subgraph
 	_, err := resolveAndCookFormulaWithVars(formulaName, nil, vars)
 	if err != nil {
+		if errors.Is(err, formula.ErrVarValidation) {
+			// Don't double-wrap: the --var values fail enum/pattern/
+			// required-empty constraints, which is a distinct condition
+			// from the formula itself being inaccessible.
+			return err
+		}
 		return fmt.Errorf("formula %q not accessible: %w", formulaName, err)
 	}
 	return nil

--- a/cmd/bd/mol_wisp_proxied_var_validation_test.go
+++ b/cmd/bd/mol_wisp_proxied_var_validation_test.go
@@ -1,0 +1,79 @@
+//go:build cgo
+
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/formula"
+)
+
+// Regression coverage for mybd-u2r6 on the proxied-server pour/wisp paths
+// (runPourProxiedServer / runWispCreateProxiedServer). The non-proxied
+// runPour/runWispCreate paths already distinguish "arg IS a formula but the
+// --var values violate an enum/pattern/required-empty constraint" (report
+// formula.ErrVarValidation directly) from "arg is not a formula at all" (fall
+// through to proto-ID resolution) — see pour_wisp_var_validation_test.go. The
+// proxied-server variants swallowed that same error and fell through
+// regardless, producing a misleading "not found as formula or proto ID"/"not
+// found as formula or proto" message instead of the validation error.
+
+func varValidationFixtureFormula(name string) *formula.Formula {
+	return &formula.Formula{
+		Formula: name,
+		Version: 1,
+		Type:    formula.TypeWorkflow,
+		Vars: map[string]*formula.VarDef{
+			"policy": {
+				Required: true,
+				Enum:     []string{"merge-completes", "tracking-only"},
+			},
+		},
+		Steps: []*formula.Step{
+			{ID: "publish", Title: "Publish with {{policy}}", Type: "task"},
+		},
+	}
+}
+
+func TestProxiedServerPourRejectsEnumViolatingVar(t *testing.T) {
+	requireSharedProxiedServer(t)
+	t.Parallel()
+	bd := buildEmbeddedBD(t)
+
+	p := newSharedProxiedProject(t, bd, "ppvv")
+	writeFormulaFixture(t, p, varValidationFixtureFormula("proxied-pour-var-validation-test"))
+
+	stdout, stderr, err := bdProxiedRunBuffers(t, bd, p.dir, "mol", "pour", "proxied-pour-var-validation-test", "--var", "policy=bogus")
+	if err == nil {
+		t.Fatalf("expected an enum-violation error, got stdout:%s stderr:%s", stdout, stderr)
+	}
+	combined := stdout + stderr
+	if !strings.Contains(combined, "not in allowed values") {
+		t.Errorf("expected an enum-violation message, got: %s", combined)
+	}
+	if strings.Contains(combined, "not found as formula or proto ID") {
+		t.Errorf("validation error was masked by the proto-ID fallback message: %s", combined)
+	}
+}
+
+func TestProxiedServerWispCreateRejectsEnumViolatingVar(t *testing.T) {
+	requireSharedProxiedServer(t)
+	t.Parallel()
+	bd := buildEmbeddedBD(t)
+
+	p := newSharedProxiedProject(t, bd, "pwvv")
+	writeFormulaFixture(t, p, varValidationFixtureFormula("proxied-wisp-var-validation-test"))
+
+	stdout, stderr, err := bdProxiedRunBuffers(t, bd, p.dir, "mol", "wisp", "create", "proxied-wisp-var-validation-test", "--var", "policy=bogus")
+	if err == nil {
+		t.Fatalf("expected an enum-violation error, got stdout:%s stderr:%s", stdout, stderr)
+	}
+	combined := stdout + stderr
+	if !strings.Contains(combined, "not in allowed values") {
+		t.Errorf("expected an enum-violation message, got: %s", combined)
+	}
+	if strings.Contains(combined, "not found as formula or proto") {
+		t.Errorf("validation error was masked by the proto-ID fallback message: %s", combined)
+	}
+}

--- a/cmd/bd/pour.go
+++ b/cmd/bd/pour.go
@@ -1,11 +1,13 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
+	"github.com/steveyegge/beads/internal/formula"
 	"github.com/steveyegge/beads/internal/metrics"
 	"github.com/steveyegge/beads/internal/types"
 	"github.com/steveyegge/beads/internal/ui"
@@ -121,6 +123,12 @@ func runPour(cmd *cobra.Command, args []string) error {
 		if sg.Phase == "vapor" {
 			warnPourVaporFormula(in.protoArg, in.varFlags)
 		}
+	} else if errors.Is(err, formula.ErrVarValidation) {
+		// in.protoArg IS a formula; the --var values it was given fail
+		// enum/pattern/required-empty constraints. Report that directly
+		// instead of falling through to the proto-ID lookup below, which
+		// would otherwise mask this as "not found as formula or proto ID".
+		return HandleError("%v", err)
 	}
 
 	if subgraph == nil {

--- a/cmd/bd/pour_wisp_var_validation_test.go
+++ b/cmd/bd/pour_wisp_var_validation_test.go
@@ -133,6 +133,29 @@ func TestPourMissingVarHintUnchanged(t *testing.T) {
 	}
 }
 
+// TestPourRejectsExplicitlyEmptyRequiredVar covers the bead's headline repro:
+// an unset shell variable interpolated into --var (e.g. --var
+// policy=$UNSET_SHELL_VAR) arrives as an explicitly-*provided*, empty-string
+// value rather than an absent flag, so it must hit ValidateProvidedVars'
+// required-and-empty check rather than the missing-var hint path.
+func TestPourRejectsExplicitlyEmptyRequiredVar(t *testing.T) {
+	writeVarValidationFormula(t)
+	s := newTestStoreWithPrefix(t, filepath.Join(t.TempDir(), "test.db"), "test")
+	withWispTestGlobals(t, s, context.Background())
+
+	var runErr error
+	stderr := captureStderr(t, func() {
+		runErr = runPour(makePourVarTestCmd([]string{"policy=", "slug=abc"}), []string{"pour-wisp-var-validation-test"})
+	})
+
+	if runErr == nil {
+		t.Fatal("runPour accepted an explicitly-empty value for a required variable")
+	}
+	if !strings.Contains(stderr, "is required and cannot be empty") {
+		t.Fatalf("runPour stderr = %q, want the required-and-empty message", stderr)
+	}
+}
+
 func TestWispRejectsEnumViolatingVar(t *testing.T) {
 	writeVarValidationFormula(t)
 	s := newTestStoreWithPrefix(t, filepath.Join(t.TempDir(), "test.db"), "test")

--- a/cmd/bd/pour_wisp_var_validation_test.go
+++ b/cmd/bd/pour_wisp_var_validation_test.go
@@ -1,0 +1,193 @@
+//go:build cgo
+
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// Regression coverage for mybd-u2r6: bd mol pour/wisp previously validated
+// only variable *presence* (extractRequiredVariables), never the enum/pattern
+// constraints cook enforces. Once resolveAndCookFormulaWithVars started
+// calling formula.ValidateProvidedVars (mybd-u2r6 fix), pour/wisp needed to
+// distinguish "the arg isn't a formula at all" (fall through to legacy
+// proto-ID resolution) from "it IS a formula, but the given --var values
+// violate a constraint" (report directly) without disturbing the missing-var
+// hint path, which has its own better UX and must keep working unchanged.
+
+const varValidationFormulaTOML = `formula = "pour-wisp-var-validation-test"
+version = 1
+type = "workflow"
+
+[vars.policy]
+required = true
+enum = ["merge-completes", "tracking-only"]
+
+[vars.slug]
+pattern = "^[a-z]+$"
+
+[[steps]]
+id = "publish"
+title = "Publish with {{policy}} / {{slug}}"
+`
+
+// writeVarValidationFormula writes the shared fixture under a temp GT_ROOT so
+// pour/wisp's DefaultSearchPaths() resolution (which always passes a nil
+// search-path list) discovers it by name without perturbing the real
+// project's formula registry.
+func writeVarValidationFormula(t *testing.T) {
+	t.Helper()
+	gtRoot := t.TempDir()
+	formulaDir := filepath.Join(gtRoot, ".beads", "formulas")
+	if err := os.MkdirAll(formulaDir, 0o755); err != nil {
+		t.Fatalf("mkdir formula dir: %v", err)
+	}
+	formulaPath := filepath.Join(formulaDir, "pour-wisp-var-validation-test.formula.toml")
+	if err := os.WriteFile(formulaPath, []byte(varValidationFormulaTOML), 0o600); err != nil {
+		t.Fatalf("write formula fixture: %v", err)
+	}
+	t.Setenv("GT_ROOT", gtRoot)
+}
+
+func makePourVarTestCmd(varFlags []string) *cobra.Command {
+	c := &cobra.Command{Use: "pour"}
+	c.Flags().Bool("dry-run", true, "")
+	c.Flags().StringArray("var", varFlags, "")
+	c.Flags().String("assignee", "", "")
+	c.Flags().StringSlice("attach", []string{}, "")
+	c.Flags().String("attach-type", "", "")
+	return c
+}
+
+func makeWispVarTestCmd(varFlags []string) *cobra.Command {
+	c := &cobra.Command{Use: "wisp"}
+	c.Flags().StringArray("var", varFlags, "")
+	c.Flags().Bool("dry-run", true, "")
+	c.Flags().Bool("root-only", false, "")
+	return c
+}
+
+func TestPourRejectsEnumViolatingVar(t *testing.T) {
+	writeVarValidationFormula(t)
+	s := newTestStoreWithPrefix(t, filepath.Join(t.TempDir(), "test.db"), "test")
+	withWispTestGlobals(t, s, context.Background())
+
+	var runErr error
+	stderr := captureStderr(t, func() {
+		runErr = runPour(makePourVarTestCmd([]string{"policy=bogus", "slug=abc"}), []string{"pour-wisp-var-validation-test"})
+	})
+
+	if runErr == nil {
+		t.Fatal("runPour accepted a value outside the declared enum")
+	}
+	if !strings.Contains(stderr, `not in allowed values`) {
+		t.Fatalf("runPour stderr = %q, want an enum-violation message", stderr)
+	}
+}
+
+func TestPourRejectsPatternViolatingVar(t *testing.T) {
+	writeVarValidationFormula(t)
+	s := newTestStoreWithPrefix(t, filepath.Join(t.TempDir(), "test.db"), "test")
+	withWispTestGlobals(t, s, context.Background())
+
+	var runErr error
+	stderr := captureStderr(t, func() {
+		runErr = runPour(makePourVarTestCmd([]string{"policy=merge-completes", "slug=NOT-LOWERCASE"}), []string{"pour-wisp-var-validation-test"})
+	})
+
+	if runErr == nil {
+		t.Fatal("runPour accepted a value violating the declared pattern")
+	}
+	if !strings.Contains(stderr, `does not match pattern`) {
+		t.Fatalf("runPour stderr = %q, want a pattern-violation message", stderr)
+	}
+}
+
+// TestPourMissingVarHintUnchanged asserts that a genuinely absent required
+// var still surfaces through checkPourVars/missingVarHint's existing
+// HandleErrorWithHint path, not the new enum/pattern validation error path.
+func TestPourMissingVarHintUnchanged(t *testing.T) {
+	writeVarValidationFormula(t)
+	s := newTestStoreWithPrefix(t, filepath.Join(t.TempDir(), "test.db"), "test")
+	withWispTestGlobals(t, s, context.Background())
+
+	var runErr error
+	stderr := captureStderr(t, func() {
+		runErr = runPour(makePourVarTestCmd([]string{}), []string{"pour-wisp-var-validation-test"})
+	})
+
+	if runErr == nil {
+		t.Fatal("runPour accepted a formula with a missing required variable")
+	}
+	if !strings.Contains(stderr, "missing required variables") {
+		t.Fatalf("runPour stderr = %q, want the missing-required-variables message", stderr)
+	}
+	if !strings.Contains(stderr, "Hint: Provide them with: --var policy=") {
+		t.Fatalf("runPour stderr = %q, want the pour-specific --var hint text", stderr)
+	}
+}
+
+func TestWispRejectsEnumViolatingVar(t *testing.T) {
+	writeVarValidationFormula(t)
+	s := newTestStoreWithPrefix(t, filepath.Join(t.TempDir(), "test.db"), "test")
+	withWispTestGlobals(t, s, context.Background())
+
+	var runErr error
+	stderr := captureStderr(t, func() {
+		runErr = runWispCreate(makeWispVarTestCmd([]string{"policy=bogus", "slug=abc"}), []string{"pour-wisp-var-validation-test"})
+	})
+
+	if runErr == nil {
+		t.Fatal("runWispCreate accepted a value outside the declared enum")
+	}
+	if !strings.Contains(stderr, `not in allowed values`) {
+		t.Fatalf("runWispCreate stderr = %q, want an enum-violation message", stderr)
+	}
+}
+
+func TestWispRejectsPatternViolatingVar(t *testing.T) {
+	writeVarValidationFormula(t)
+	s := newTestStoreWithPrefix(t, filepath.Join(t.TempDir(), "test.db"), "test")
+	withWispTestGlobals(t, s, context.Background())
+
+	var runErr error
+	stderr := captureStderr(t, func() {
+		runErr = runWispCreate(makeWispVarTestCmd([]string{"policy=merge-completes", "slug=NOT-LOWERCASE"}), []string{"pour-wisp-var-validation-test"})
+	})
+
+	if runErr == nil {
+		t.Fatal("runWispCreate accepted a value violating the declared pattern")
+	}
+	if !strings.Contains(stderr, `does not match pattern`) {
+		t.Fatalf("runWispCreate stderr = %q, want a pattern-violation message", stderr)
+	}
+}
+
+// TestWispMissingVarHintUnchanged mirrors TestPourMissingVarHintUnchanged for
+// wisp's own checkRequiredVars/firstMissingVar hint path.
+func TestWispMissingVarHintUnchanged(t *testing.T) {
+	writeVarValidationFormula(t)
+	s := newTestStoreWithPrefix(t, filepath.Join(t.TempDir(), "test.db"), "test")
+	withWispTestGlobals(t, s, context.Background())
+
+	var runErr error
+	stderr := captureStderr(t, func() {
+		runErr = runWispCreate(makeWispVarTestCmd([]string{}), []string{"pour-wisp-var-validation-test"})
+	})
+
+	if runErr == nil {
+		t.Fatal("runWispCreate accepted a formula with a missing required variable")
+	}
+	if !strings.Contains(stderr, "missing required variables") {
+		t.Fatalf("runWispCreate stderr = %q, want the missing-required-variables message", stderr)
+	}
+	if !strings.Contains(stderr, "Hint: Provide them with: --var policy=") {
+		t.Fatalf("runWispCreate stderr = %q, want the wisp-specific --var hint text", stderr)
+	}
+}

--- a/cmd/bd/wisp.go
+++ b/cmd/bd/wisp.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+	"github.com/steveyegge/beads/internal/formula"
 	"github.com/steveyegge/beads/internal/metrics"
 	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/types"
@@ -209,6 +210,12 @@ func runWispCreateCore(cmd *cobra.Command, args []string) error {
 	if err == nil {
 		subgraph = sg
 		protoID = sg.Root.ID
+	} else if errors.Is(err, formula.ErrVarValidation) {
+		// args[0] IS a formula; the --var values it was given fail
+		// enum/pattern/required-empty constraints. Report that directly
+		// instead of falling through to the legacy proto-ID lookup below,
+		// which would otherwise mask this as "not found as formula or proto".
+		return HandleError("%v", err)
 	}
 
 	if subgraph == nil {

--- a/cmd/bd/wisp_proxied_server.go
+++ b/cmd/bd/wisp_proxied_server.go
@@ -2,11 +2,13 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
 	"time"
 
+	"github.com/steveyegge/beads/internal/formula"
 	"github.com/steveyegge/beads/internal/storage/domain"
 	"github.com/steveyegge/beads/internal/storage/uow"
 	"github.com/steveyegge/beads/internal/types"
@@ -29,6 +31,12 @@ func runWispCreateProxiedServer(ctx context.Context, in wispCreateInput) error {
 	if sg, err := resolveAndCookFormulaWithVars(in.protoArg, nil, vars); err == nil {
 		formulaSubgraph = sg
 		formulaProtoID = sg.Root.ID
+	} else if errors.Is(err, formula.ErrVarValidation) {
+		// in.protoArg IS a formula; the --var values it was given fail
+		// enum/pattern/required-empty constraints. Report that directly
+		// instead of falling through to the proto-ID lookup below, which
+		// would otherwise mask this as "not found as formula or proto".
+		return HandleError("%v", err)
 	}
 
 	if formulaSubgraph == nil {

--- a/internal/formula/parser.go
+++ b/internal/formula/parser.go
@@ -442,14 +442,21 @@ func ValidateVars(formula *Formula, values map[string]string) error {
 			errs = append(errs, fmt.Sprintf("variable %q is required", name))
 			continue
 		}
+		if def.Required && provided && val == "" {
+			errs = append(errs, fmt.Sprintf("variable %q is required and cannot be empty", name))
+			continue
+		}
 
 		// Use default if not provided
 		if !provided && def.Default != nil {
 			val = *def.Default
 		}
 
-		// Skip further validation if no value
-		if val == "" {
+		// Skip further validation only when the var was genuinely not
+		// provided (absent from the map). A value that was explicitly
+		// provided as "" must still be checked against enum/pattern
+		// constraints rather than silently passing.
+		if !provided && val == "" {
 			continue
 		}
 

--- a/internal/formula/parser.go
+++ b/internal/formula/parser.go
@@ -2,6 +2,7 @@ package formula
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -12,6 +13,13 @@ import (
 	"github.com/steveyegge/beads/internal/beads"
 	"github.com/steveyegge/beads/internal/git"
 )
+
+// ErrVarValidation wraps a variable validation failure so callers with a
+// fallback resolution path (e.g. "is this actually a proto/issue ID rather
+// than a formula name?") can distinguish "not a formula" from "is a formula,
+// but the provided variables are invalid" and surface the latter directly
+// with errors.Is, instead of silently falling through to a worse error.
+var ErrVarValidation = errors.New("variable validation failed")
 
 // Formula file extensions. TOML is preferred, JSON is legacy fallback.
 const (
@@ -442,54 +450,94 @@ func ValidateVars(formula *Formula, values map[string]string) error {
 			errs = append(errs, fmt.Sprintf("variable %q is required", name))
 			continue
 		}
-		if def.Required && provided && val == "" {
-			errs = append(errs, fmt.Sprintf("variable %q is required and cannot be empty", name))
-			continue
-		}
 
-		// Use default if not provided
-		if !provided && def.Default != nil {
-			val = *def.Default
-		}
-
-		// Skip further validation only when the var was genuinely not
-		// provided (absent from the map). A value that was explicitly
-		// provided as "" must still be checked against enum/pattern
-		// constraints rather than silently passing.
-		if !provided && val == "" {
-			continue
-		}
-
-		// Check enum constraint
-		if len(def.Enum) > 0 {
-			found := false
-			for _, allowed := range def.Enum {
-				if val == allowed {
-					found = true
-					break
-				}
-			}
-			if !found {
-				errs = append(errs, fmt.Sprintf("variable %q: value %q not in allowed values %v", name, val, def.Enum))
-			}
-		}
-
-		// Check pattern constraint
-		if def.Pattern != "" {
-			re, err := regexp.Compile(def.Pattern)
-			if err != nil {
-				errs = append(errs, fmt.Sprintf("variable %q: invalid pattern %q: %v", name, def.Pattern, err))
-			} else if !re.MatchString(val) {
-				errs = append(errs, fmt.Sprintf("variable %q: value %q does not match pattern %q", name, val, def.Pattern))
-			}
-		}
+		errs = append(errs, validateVarValue(name, def, val, provided)...)
 	}
 
 	if len(errs) > 0 {
-		return fmt.Errorf("variable validation failed:\n  - %s", strings.Join(errs, "\n  - "))
+		return fmt.Errorf("%w:\n  - %s", ErrVarValidation, strings.Join(errs, "\n  - "))
 	}
 
 	return nil
+}
+
+// ValidateProvidedVars checks enum/pattern/required-empty constraints only
+// for variables that are present in values; it does not flag variables that
+// are entirely absent. Callers that already surface a more specific
+// missing-variable message (e.g. bd mol pour/wisp's hint path) should keep
+// using that path for absent vars — this exists so those same callers still
+// catch malformed *provided* values, which a presence-only check misses
+// (mybd-u2r6).
+func ValidateProvidedVars(formula *Formula, values map[string]string) error {
+	var errs []string
+
+	for name, def := range formula.Vars {
+		val, provided := values[name]
+		if !provided {
+			continue
+		}
+
+		errs = append(errs, validateVarValue(name, def, val, provided)...)
+	}
+
+	if len(errs) > 0 {
+		return fmt.Errorf("%w:\n  - %s", ErrVarValidation, strings.Join(errs, "\n  - "))
+	}
+
+	return nil
+}
+
+// validateVarValue applies the required-empty, enum, and pattern checks for
+// a single variable given its (possibly defaulted) value. It assumes any
+// "required and not provided at all" check has already been handled by the
+// caller, since that case is presented differently by ValidateVars vs.
+// ValidateProvidedVars.
+func validateVarValue(name string, def *VarDef, val string, provided bool) []string {
+	var errs []string
+
+	if def.Required && provided && val == "" {
+		errs = append(errs, fmt.Sprintf("variable %q is required and cannot be empty", name))
+		return errs
+	}
+
+	// Use default if not provided
+	if !provided && def.Default != nil {
+		val = *def.Default
+	}
+
+	// Skip further validation only when the var was genuinely not
+	// provided (absent from the map). A value that was explicitly
+	// provided as "" must still be checked against enum/pattern
+	// constraints rather than silently passing.
+	if !provided && val == "" {
+		return errs
+	}
+
+	// Check enum constraint
+	if len(def.Enum) > 0 {
+		found := false
+		for _, allowed := range def.Enum {
+			if val == allowed {
+				found = true
+				break
+			}
+		}
+		if !found {
+			errs = append(errs, fmt.Sprintf("variable %q: value %q not in allowed values %v", name, val, def.Enum))
+		}
+	}
+
+	// Check pattern constraint
+	if def.Pattern != "" {
+		re, err := regexp.Compile(def.Pattern)
+		if err != nil {
+			errs = append(errs, fmt.Sprintf("variable %q: invalid pattern %q: %v", name, def.Pattern, err))
+		} else if !re.MatchString(val) {
+			errs = append(errs, fmt.Sprintf("variable %q: value %q does not match pattern %q", name, val, def.Pattern))
+		}
+	}
+
+	return errs
 }
 
 // ApplyDefaults returns a new map with default values filled in.

--- a/internal/formula/parser.go
+++ b/internal/formula/parser.go
@@ -495,7 +495,10 @@ func ValidateProvidedVars(formula *Formula, values map[string]string) error {
 func validateVarValue(name string, def *VarDef, val string, provided bool) []string {
 	var errs []string
 
-	if def.Required && provided && val == "" {
+	// A variable with no default is effectively required: the command paths
+	// (extractRequiredVariables) demand a value for it, so a provided-but-empty
+	// value is the same unset-shell-variable trap as for required=true.
+	if (def.Required || def.Default == nil) && provided && val == "" {
 		errs = append(errs, fmt.Sprintf("variable %q is required and cannot be empty", name))
 		return errs
 	}

--- a/internal/formula/parser_test.go
+++ b/internal/formula/parser_test.go
@@ -653,12 +653,15 @@ func TestValidateVars(t *testing.T) {
 }
 
 func TestValidateProvidedVars(t *testing.T) {
+	fallback := "fallback"
 	formula := &Formula{
 		Formula: "mol-vars-provided",
 		Vars: map[string]*VarDef{
-			"required_var": {Required: true},
-			"enum_var":     {Enum: []string{"a", "b", "c"}},
-			"pattern_var":  {Pattern: `^[a-z]+$`},
+			"required_var":  {Required: true},
+			"enum_var":      {Enum: []string{"a", "b", "c"}},
+			"pattern_var":   {Pattern: `^[a-z]+$`},
+			"no_default":    {},
+			"defaulted_var": {Default: &fallback},
 		},
 	}
 
@@ -700,6 +703,21 @@ func TestValidateProvidedVars(t *testing.T) {
 		{
 			name:    "all provided and valid",
 			values:  map[string]string{"required_var": "x", "enum_var": "a", "pattern_var": "abc"},
+			wantErr: false,
+		},
+		{
+			// No default means the command paths treat the var as required, so
+			// a provided-empty value is the same unset-shell-variable trap.
+			name:    "no-default var provided empty is flagged",
+			values:  map[string]string{"no_default": ""},
+			wantErr: true,
+		},
+		{
+			// A defaulted, unconstrained var provided explicitly empty is a
+			// deliberate choice the formula tolerates; only enum/pattern
+			// constraints could reject it.
+			name:    "defaulted var provided empty is tolerated",
+			values:  map[string]string{"defaulted_var": ""},
 			wantErr: false,
 		},
 	}

--- a/internal/formula/parser_test.go
+++ b/internal/formula/parser_test.go
@@ -620,6 +620,26 @@ func TestValidateVars(t *testing.T) {
 			values:  map[string]string{"required_var": "x", "pattern_var": "123"},
 			wantErr: true,
 		},
+		{
+			name:    "required var provided empty",
+			values:  map[string]string{"required_var": ""},
+			wantErr: true,
+		},
+		{
+			name:    "enum var provided empty",
+			values:  map[string]string{"required_var": "x", "enum_var": ""},
+			wantErr: true,
+		},
+		{
+			name:    "pattern var provided empty",
+			values:  map[string]string{"required_var": "x", "pattern_var": ""},
+			wantErr: true,
+		},
+		{
+			name:    "optional var genuinely absent still ok",
+			values:  map[string]string{"required_var": "x"},
+			wantErr: false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/formula/parser_test.go
+++ b/internal/formula/parser_test.go
@@ -652,6 +652,68 @@ func TestValidateVars(t *testing.T) {
 	}
 }
 
+func TestValidateProvidedVars(t *testing.T) {
+	formula := &Formula{
+		Formula: "mol-vars-provided",
+		Vars: map[string]*VarDef{
+			"required_var": {Required: true},
+			"enum_var":     {Enum: []string{"a", "b", "c"}},
+			"pattern_var":  {Pattern: `^[a-z]+$`},
+		},
+	}
+
+	tests := []struct {
+		name    string
+		values  map[string]string
+		wantErr bool
+	}{
+		{
+			name:    "required var entirely absent is not flagged",
+			values:  map[string]string{},
+			wantErr: false,
+		},
+		{
+			name:    "required var provided empty is flagged",
+			values:  map[string]string{"required_var": ""},
+			wantErr: true,
+		},
+		{
+			name:    "enum var absent is not flagged",
+			values:  map[string]string{},
+			wantErr: false,
+		},
+		{
+			name:    "enum var provided invalid is flagged",
+			values:  map[string]string{"enum_var": "invalid"},
+			wantErr: true,
+		},
+		{
+			name:    "enum var provided empty is flagged",
+			values:  map[string]string{"enum_var": ""},
+			wantErr: true,
+		},
+		{
+			name:    "pattern var provided invalid is flagged",
+			values:  map[string]string{"pattern_var": "123"},
+			wantErr: true,
+		},
+		{
+			name:    "all provided and valid",
+			values:  map[string]string{"required_var": "x", "enum_var": "a", "pattern_var": "abc"},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateProvidedVars(formula, tt.values)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateProvidedVars() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
 func TestApplyDefaults(t *testing.T) {
 	formula := &Formula{
 		Formula: "mol-defaults",


### PR DESCRIPTION
## Why

Two validation gaps found while reviewing #5045 (which added enum/pattern enforcement for `bd cook`):

1. **Explicitly-empty `--var` values bypass all validation** (`internal/formula/parser.go` `ValidateVars` skipped everything on `val == ""`, conflating "not provided" with "provided empty"). Repro: a formula with `[vars.policy] required=true enum=[a,b]` accepts `bd cook --mode=runtime --var policy=` and substitutes the empty string. The likeliest real-world trigger is `--var policy=$UNSET_SHELL_VAR`.
2. **`bd mol pour` / `bd mol wisp` never validate enum/pattern at all** — they check variable presence only, while cook's help steers users to them as the preferred commands. So the most-used paths ignore the constraints #5045 enforced for cook.

## What

- `ValidateVars`: only genuinely-absent vars skip validation; provided-empty values are checked (required → error; enum/pattern → validated against `""`). A var with **no default** is treated as required for the provided-empty check, matching what the command paths (`extractRequiredVariables`) already demand.
- New `ValidateProvidedVars` runs in `resolveAndCookFormulaWithVars`, covering pour, wisp, `mol bond`, and `mol seed` in one place — deliberately *after* the existing presence checks so pour/wisp's better `HandleErrorWithHint` missing-var message is preserved (pinned by test).
- Proxied-server pour/wisp paths and both `mol bond --dry-run` paths (local and proxied) surface `ErrVarValidation` instead of masking it as "not found as formula" or falsely previewing success; `mol seed`/`mol bond` no longer double-wrap it.
- Tests: table cases for provided-empty/enum/pattern/no-default in `internal/formula`, end-to-end pour/wisp violation cases including the headline `--var policy=` repro, and hermetic Docker-backed proxied-server cases.

## Review

Cross-vendor reviewed (Claude reviewer + codex gpt-5.6, 3 rounds); adopted fixes include the proxied-path error handling, dry-run consistency, and no-default-is-required. Two remaining codex suggestions are deliberately deferred as follow-ups rather than grown into this PR:

- validating *authored defaults* against their own enum/pattern at pour/wisp time (an invalid default is a formula-authoring bug that cook's `ValidateVars` already reports; pour/wisp validated nothing at all before this PR);
- resolving `extends` inheritance before validating in `bd mol bond --dry-run` (the real command still rejects; only the preview of an inherited-constraint violation is optimistic).

Both are tracked in the mybd tracker (follow-up filed under mybd-s8vb/mybd-u2r6, this PR's beads).

_claude-fable-5-high on behalf of maphew_
