### PR TITLE
fix(hooks): clone the issue handed to the async hook runner on update/close completion

### DIFF
--- a/internal/storage/hook_decorator.go
+++ b/internal/storage/hook_decorator.go
@@ -305,15 +305,17 @@ func (h *HookFiringStore) CompleteIssueOperationCreate(ctx context.Context, issu
 }
 
 // CompleteIssueOperationUpdate fires the update hook for a committed guarded
-// operation.
+// operation. The issue is cloned because the hook runner marshals it on its
+// own goroutine while callers (cmd/bd close/update/reopen) go on to mutate
+// the result they handed in.
 func (h *HookFiringStore) CompleteIssueOperationUpdate(issue *types.Issue) {
-	h.fireHook(hooks.EventUpdate, issue)
+	h.fireHook(hooks.EventUpdate, cloneIssueForHook(issue))
 }
 
 // CompleteIssueOperationClose fires the close hook for a committed guarded
-// close.
+// close. Cloned for the same reason as CompleteIssueOperationUpdate.
 func (h *HookFiringStore) CompleteIssueOperationClose(issue *types.Issue) {
-	h.fireHook(hooks.EventClose, issue)
+	h.fireHook(hooks.EventClose, cloneIssueForHook(issue))
 }
 
 func (h *HookFiringStore) fireHookByID(ctx context.Context, event, id string) {

--- a/internal/storage/hook_issue_operations_test.go
+++ b/internal/storage/hook_issue_operations_test.go
@@ -115,6 +115,36 @@ func TestHookFiringStoreCompleteIssueOperationsFireOncePerCall(t *testing.T) {
 	}
 }
 
+// TestHookFiringStoreCompleteIssueOperationsSnapshotIssue pins the clone at the
+// completion entry points: the real hook runner marshals the issue on its own
+// goroutine, and the CLI mutates the result object it handed in right after
+// completing (cmd/bd close/update/reopen nil out .Dependencies), so handing
+// the runner the caller's pointer is a data race with a nondeterministic
+// payload (bd-9wgv3).
+func TestHookFiringStoreCompleteIssueOperationsSnapshotIssue(t *testing.T) {
+	runner := &recordingHookRunner{}
+	store := &HookFiringStore{runner: runner}
+	issue := &types.Issue{ID: "hook-issue", Dependencies: []*types.Dependency{
+		{IssueID: "hook-issue", DependsOnID: "dep", Type: types.DepBlocks},
+	}}
+
+	store.CompleteIssueOperationUpdate(issue)
+	store.CompleteIssueOperationClose(issue)
+	issue.Dependencies = nil
+
+	if len(runner.issues) != 2 {
+		t.Fatalf("recorded issues = %d, want 2", len(runner.issues))
+	}
+	for i, got := range runner.issues {
+		if got == issue {
+			t.Fatalf("event %d received the caller's issue pointer; completion must hand the runner a clone", i)
+		}
+		if len(got.Dependencies) != 1 || got.Dependencies[0].DependsOnID != "dep" {
+			t.Fatalf("event %d dependencies = %#v, want the snapshot taken before the caller mutated the issue", i, got.Dependencies)
+		}
+	}
+}
+
 func TestHookFiringStoreCompleteIssueOperationCreateFiresReverseDependencyUpdate(t *testing.T) {
 	runner := &recordingHookRunner{}
 	reverse := &types.Dependency{IssueID: "existing-source", DependsOnID: "created", Type: types.DepRelatesTo, Metadata: `{"key":"value"}`, ThreadID: "thread"}


### PR DESCRIPTION
## Why

Regression from #5191, found during the bd-tveyi post-merge review (bd-9wgv3, P2). `CompleteIssueOperationUpdate`/`CompleteIssueOperationClose` (internal/storage/hook_decorator.go) pass `result.Issue` **by pointer** into `hooks.Runner.Run`, which `json.Marshal`s it on a spawned goroutine (internal/hooks/hooks_unix.go) — while the CLI mutates the very same object on the main goroutine right afterwards (`Dependencies = nil` at cmd/bd/close.go:255, update.go:548, reopen.go:103, before their own JSON output). That is a genuine unsynchronized write-while-read (the race detector flags it), observable as a nondeterministic hook stdin payload: the `dependencies` array is present or absent depending on goroutine scheduling.

The legacy paths were immune: `fireHookByID` re-fetches a private copy, and the create path already clones via `cloneIssueForHook` — so only Update/Close/Reopen (which funnels through `CompleteIssueOperationUpdate`) were exposed.

## What

Clone at the two completion entry points with the existing `cloneIssueForHook`. This fixes the race for every exposed verb on every backend (all three funnel through these two methods) and makes the payload deterministic as a side effect: hook scripts now always see the hydrated dependency snapshot taken at completion time — which subsumes the payload-shape drift vs pre-#5191 noted on the bead (old payloads came from an unhydrated `GetIssue`; the hydrated shape is the intended one going forward).

## Validation

- New regression test `TestHookFiringStoreCompleteIssueOperationsSnapshotIssue` pins both properties: the runner never receives the caller's pointer, and the recorded payload survives the caller's post-completion mutation.
- `go test -tags gms_pure_go -race -run 'TestHookFiringStore' ./internal/storage/` green (the new test fails on the pre-fix tree); full `./internal/storage/` suite green; `go vet` and `gofmt` clean.

Closes bd-9wgv3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

_claude-code-claude-fable-5-unknown-reasoning on behalf of Steve Yegge_