### PR TITLE
fix(issueops): make a done-crossing generic update close like bd close

### DIFF
--- a/cmd/bd/write_verbs_parity_test.go
+++ b/cmd/bd/write_verbs_parity_test.go
@@ -47,6 +47,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"sync"
 	"testing"
@@ -1854,6 +1855,140 @@ func TestParityReopenNonDoneStatusReportsNothingToDo(t *testing.T) {
 	// The status is still what it was.
 	if got := env.get("test-rop6").Status; got != types.StatusInProgress {
 		t.Errorf("status = %q, want in_progress (the engine no-ops)", got)
+	}
+}
+
+// ===== bd update crossing into closed vs bd close =====
+
+// closeRowParityExclusions lists the types.Issue fields a row-for-row
+// comparison of `bd update -s closed` against `bd close` must skip, and why.
+// Everything else has to match: the two verbs reach the same done state, so any
+// other divergence is the update funnel failing to close the way close closes.
+var closeRowParityExclusions = map[string]string{
+	"ID":          "the two verbs act on two different issues",
+	"Title":       "the two verbs act on two different issues",
+	"ContentHash": "derives from ID and Title",
+	"CreatedAt":   "wall-clock stamp from two different seeds",
+	"UpdatedAt":   "wall-clock stamp from two different writes",
+	"ClosedAt":    "wall-clock stamp; asserted non-nil on both instead",
+	"RowVersion":  "freshRowLock() is regenerated per write by design",
+	"CloseReason": "cmd/bd/close.go resolveCloseReasons defaults `bd close`'s " +
+		"reason to \"Closed\" at the CLI layer, and `bd update` has no reason " +
+		"flag; the funnel-level default is asserted separately below",
+	// ga-ktn9pe.4.14 owns pin behavior in the update funnels — issueops
+	// auto-clears `pinned` on a status change and domain/db does not. Comparing
+	// it here would either bless that divergence or drag its fix into ga-kjkv1.
+	"Pinned": "ga-ktn9pe.4.14 owns pin behavior in the update funnels",
+}
+
+// TestParityUpdateToClosedMatchesCloseRow pins ga-kjkv1's shape: a generic
+// update whose status crosses into closed must land the same row `bd close`
+// lands. close writes close_reason and closed_by_session on every close
+// (issueops/close.go closeIssueInTx), including the empty values a caller that
+// named neither produces; the funnels used to write them only when the caller
+// passed the key, so the columns kept whatever the last close left.
+func TestParityUpdateToClosedMatchesCloseRow(t *testing.T) {
+	env := newParityEnv(t)
+	env.seed("test-updcls1", "Update into closed", nil)
+	env.seed("test-updcls2", "Close verb", nil)
+
+	env.setFlags(updateCmd, map[string]string{"status": "closed"})
+	if res := env.run(updateCmd, "test-updcls1"); res.exitCode != 0 {
+		t.Fatalf("update into closed: exit=%d err=%v stderr=%s", res.exitCode, res.err, res.stderr)
+	}
+	env.setFlags(closeCmd, nil)
+	if res := env.run(closeCmd, "test-updcls2"); res.exitCode != 0 {
+		t.Fatalf("close: exit=%d err=%v stderr=%s", res.exitCode, res.err, res.stderr)
+	}
+
+	updated, closed := env.get("test-updcls1"), env.get("test-updcls2")
+	if updated.ClosedAt == nil || closed.ClosedAt == nil {
+		t.Fatalf("closed_at: update = %v, close = %v; both verbs must stamp it", updated.ClosedAt, closed.ClosedAt)
+	}
+
+	updatedValue, closedValue := reflect.ValueOf(*updated), reflect.ValueOf(*closed)
+	for i := 0; i < updatedValue.NumField(); i++ {
+		field := updatedValue.Type().Field(i)
+		if why, skip := closeRowParityExclusions[field.Name]; skip {
+			t.Logf("skipping %s: %s", field.Name, why)
+			continue
+		}
+		got, want := updatedValue.Field(i).Interface(), closedValue.Field(i).Interface()
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("%s after `bd update -s closed` = %#v, want %#v (the value `bd close` writes)", field.Name, got, want)
+		}
+	}
+
+	// And the funnel default itself: no session flag, no session recorded.
+	if updated.ClosedBySession != "" {
+		t.Errorf("closed_by_session after a sessionless `bd update -s closed` = %q, want empty", updated.ClosedBySession)
+	}
+	if updated.CloseReason != "" {
+		t.Errorf("close_reason after a reasonless `bd update -s closed` = %q, want empty", updated.CloseReason)
+	}
+}
+
+// TestParityUpdateToClosedClearsPriorCloseAttribution pins the misattribution
+// ga-kjkv1 fixes. The generic reopen branch never cleared closed_by_session, so
+// a re-close through the funnel inherited the PREVIOUS close's session and
+// `bd show` rendered the new close as that old session's work.
+func TestParityUpdateToClosedClearsPriorCloseAttribution(t *testing.T) {
+	env := newParityEnv(t)
+	env.seed("test-updcls3", "Reclose attribution", nil)
+
+	env.setFlags(closeCmd, map[string]string{"reason": "first pass", "session": "session-one"})
+	if res := env.run(closeCmd, "test-updcls3"); res.exitCode != 0 {
+		t.Fatalf("first close: exit=%d err=%v stderr=%s", res.exitCode, res.err, res.stderr)
+	}
+	if got := env.get("test-updcls3"); got.ClosedBySession != "session-one" || got.CloseReason != "first pass" {
+		t.Fatalf("first close recorded reason=%q session=%q, want %q/%q", got.CloseReason, got.ClosedBySession, "first pass", "session-one")
+	}
+
+	// Reopen through the generic funnel, not the reopen verb — this is the path
+	// that used to leave the close attribution behind.
+	env.setFlags(updateCmd, map[string]string{"status": "open"})
+	if res := env.run(updateCmd, "test-updcls3"); res.exitCode != 0 {
+		t.Fatalf("generic reopen: exit=%d err=%v stderr=%s", res.exitCode, res.err, res.stderr)
+	}
+	reopened := env.get("test-updcls3")
+	if reopened.ClosedBySession != "" {
+		t.Errorf("closed_by_session after a generic reopen = %q, want empty", reopened.ClosedBySession)
+	}
+	if reopened.CloseReason != "" {
+		t.Errorf("close_reason after a generic reopen = %q, want empty", reopened.CloseReason)
+	}
+	if reopened.ClosedAt != nil {
+		t.Errorf("closed_at after a generic reopen = %v, want nil", reopened.ClosedAt)
+	}
+
+	// The re-close must attribute itself, not the first close.
+	env.setFlags(updateCmd, map[string]string{"status": "closed"})
+	if res := env.run(updateCmd, "test-updcls3"); res.exitCode != 0 {
+		t.Fatalf("generic re-close: exit=%d err=%v stderr=%s", res.exitCode, res.err, res.stderr)
+	}
+	reclosed := env.get("test-updcls3")
+	if reclosed.ClosedBySession != "" {
+		t.Errorf("closed_by_session after a sessionless generic re-close = %q, want empty (not the first close's session)", reclosed.ClosedBySession)
+	}
+	if reclosed.CloseReason != "" {
+		t.Errorf("close_reason after a reasonless generic re-close = %q, want empty (not the first close's reason)", reclosed.CloseReason)
+	}
+}
+
+// TestParityUpdateToClosedKeepsExplicitSession pins that the defaults above
+// yield to an explicit key: `bd update -s closed --session` still attributes the
+// close, so the CLI's own closed_by_session pass-through (cmd/bd/update.go:133,
+// cmd/bd/update_input.go:58) keeps working and must stay in place.
+func TestParityUpdateToClosedKeepsExplicitSession(t *testing.T) {
+	env := newParityEnv(t)
+	env.seed("test-updcls4", "Explicit session", nil)
+
+	env.setFlags(updateCmd, map[string]string{"status": "closed", "session": "session-two"})
+	if res := env.run(updateCmd, "test-updcls4"); res.exitCode != 0 {
+		t.Fatalf("update into closed with a session: exit=%d err=%v stderr=%s", res.exitCode, res.err, res.stderr)
+	}
+	if got := env.get("test-updcls4").ClosedBySession; got != "session-two" {
+		t.Errorf("closed_by_session = %q, want %q (the explicit key beats the default)", got, "session-two")
 	}
 }
 

--- a/internal/storage/conformance/issue_operations_contract.go
+++ b/internal/storage/conformance/issue_operations_contract.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/steveyegge/beads/internal/types"
 	publicops "github.com/steveyegge/beads/issueops"
@@ -318,6 +319,146 @@ func RunIssueOperationsUpdateClosePolicy(t *testing.T, ctx context.Context, fixt
 		t.Fatalf("non-crossing status update on %s: %v", parentID, err)
 	}
 	assertClosePolicyStatus(t, ctx, fixture, parentID, types.StatusInProgress)
+}
+
+// RunIssueOperationsUpdateClosedFieldsMatchClose pins the close-lifecycle
+// columns a generic update leaves behind (ga-kjkv1). A status update that
+// crosses into closed is a close by another name, so it must land the row a
+// close lands: close_reason and closed_by_session written, not inherited from
+// whatever the previous close left. It also pins the closed_at coherence guard,
+// which is reachable only through the raw column map an external-sync or
+// backfill caller uses — the typed patch carries no closed_at.
+//
+// A shared helper alone does not keep the two funnels honest: both already call
+// ManageClosedAt, and the pin auto-clear that sits three lines away from it
+// exists in issueops and is absent from domain/db. Only a case that asserts the
+// stored row on every backend catches that shape of divergence.
+func RunIssueOperationsUpdateClosedFieldsMatchClose(t *testing.T, ctx context.Context, fixture IssueOperationsStagingFixture) {
+	t.Helper()
+
+	// A generic close on a row a previous close stamped must not inherit that
+	// close's reason or session. This is the misattribution ga-kjkv1 fixes:
+	// `bd show` renders a stale closed_by_session as "Closed by session".
+	recloseID := fixture.IssuePrefix + "-closedfields-reclose"
+	seedClosePolicyIssue(t, ctx, fixture, recloseID, publicops.CreateRequest{})
+	if _, err := fixture.Operations.Close(ctx, publicops.CloseRequest{
+		Actor: "writer", IssueID: recloseID, Reason: "first pass", Session: "session-one",
+	}); err != nil {
+		t.Fatalf("close %s: %v", recloseID, err)
+	}
+	assertClosedFields(t, ctx, fixture, recloseID, "after close", "first pass", "session-one", true)
+
+	// Reopen through the generic funnel, not the reopen verb: this is the path
+	// that used to leave close_reason and closed_by_session in place.
+	if err := fixture.UpdateRaw(ctx, recloseID, map[string]any{"status": string(types.StatusOpen)}, "writer"); err != nil {
+		t.Fatalf("generic reopen of %s: %v", recloseID, err)
+	}
+	assertClosedFields(t, ctx, fixture, recloseID, "after generic reopen", "", "", false)
+
+	if err := fixture.UpdateRaw(ctx, recloseID, map[string]any{"status": string(types.StatusClosed)}, "writer"); err != nil {
+		t.Fatalf("generic re-close of %s: %v", recloseID, err)
+	}
+	assertClosedFields(t, ctx, fixture, recloseID, "after generic re-close", "", "", true)
+
+	// An explicit key still wins over its default, so the CLI's own
+	// closed_by_session pass-through keeps working.
+	explicitID := fixture.IssuePrefix + "-closedfields-explicit"
+	seedClosePolicyIssue(t, ctx, fixture, explicitID, publicops.CreateRequest{})
+	if err := fixture.UpdateRaw(ctx, explicitID, map[string]any{
+		"status": string(types.StatusClosed), "closed_by_session": "session-two", "close_reason": "handled",
+	}, "writer"); err != nil {
+		t.Fatalf("generic close of %s with explicit close fields: %v", explicitID, err)
+	}
+	assertClosedFields(t, ctx, fixture, explicitID, "explicit close fields", "handled", "session-two", true)
+
+	// The coherence guard. Stamping closed_at on a row that stays open is
+	// refused by name, typed as a validation error, and writes nothing.
+	guardID := fixture.IssuePrefix + "-closedfields-guard"
+	seedClosePolicyIssue(t, ctx, fixture, guardID, publicops.CreateRequest{})
+	stamp := time.Date(2026, 3, 4, 5, 6, 7, 0, time.UTC)
+	events := newIssueOperationsEventCounter(t, ctx, fixture, guardID)
+	err := fixture.UpdateRaw(ctx, guardID, map[string]any{"closed_at": stamp}, "writer")
+	assertClosedAtRefusal(t, err, "stamping closed_at on an open row", guardID)
+	assertClosePolicyStatus(t, ctx, fixture, guardID, types.StatusOpen)
+	assertClosedFields(t, ctx, fixture, guardID, "after refused closed_at stamp", "", "", false)
+	events.assert(t, "refused closed_at stamp", 0, nil)
+
+	// So is a stamp riding a status that does not land closed.
+	err = fixture.UpdateRaw(ctx, guardID, map[string]any{"status": string(types.StatusInProgress), "closed_at": stamp}, "writer")
+	assertClosedAtRefusal(t, err, "stamping closed_at on a non-closed transition", guardID)
+	assertClosePolicyStatus(t, ctx, fixture, guardID, types.StatusOpen)
+
+	// Landing status and closed_at together is the coherent write, so it is
+	// allowed — an external-sync or backfill caller depends on it.
+	if err := fixture.UpdateRaw(ctx, guardID, map[string]any{
+		"status": string(types.StatusClosed), "closed_at": stamp,
+	}, "writer"); err != nil {
+		t.Fatalf("landing status and closed_at together on %s: %v", guardID, err)
+	}
+	assertClosePolicyStatus(t, ctx, fixture, guardID, types.StatusClosed)
+	assertClosedFields(t, ctx, fixture, guardID, "coherent close with explicit closed_at", "", "", true)
+
+	// Restamping closed_at on a row that is already closed is the repair path
+	// for rows a pre-invariant close left blank; it stays open.
+	repaired := stamp.Add(time.Hour)
+	if err := fixture.UpdateRaw(ctx, guardID, map[string]any{"closed_at": repaired}, "writer"); err != nil {
+		t.Fatalf("repairing closed_at on closed %s: %v", guardID, err)
+	}
+
+	// Clearing closed_at while the status stays closed is the other incoherent
+	// half, and it is refused too.
+	err = fixture.UpdateRaw(ctx, guardID, map[string]any{"closed_at": nil}, "writer")
+	assertClosedAtRefusal(t, err, "clearing closed_at on a closed row", guardID)
+	assertClosePolicyStatus(t, ctx, fixture, guardID, types.StatusClosed)
+	assertClosedFields(t, ctx, fixture, guardID, "after refused closed_at clear", "", "", true)
+
+	// Clearing it as part of a reopen is coherent, so it is allowed.
+	if err := fixture.UpdateRaw(ctx, guardID, map[string]any{
+		"status": string(types.StatusOpen), "closed_at": nil,
+	}, "writer"); err != nil {
+		t.Fatalf("reopening %s with an explicit closed_at clear: %v", guardID, err)
+	}
+	assertClosedFields(t, ctx, fixture, guardID, "reopen with explicit closed_at clear", "", "", false)
+}
+
+// assertClosedAtRefusal checks that a coherence refusal is typed as a
+// validation error and names both the column and the issue, so a raw-map caller
+// with no override can tell exactly which write was rejected.
+func assertClosedAtRefusal(t *testing.T, err error, label, id string) {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("%s: err = nil, want a refusal", label)
+	}
+	if !errors.Is(err, publicops.ErrValidation) {
+		t.Fatalf("%s: err = %v, want ErrValidation", label, err)
+	}
+	for _, want := range []string{"closed_at", id} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("%s: refusal %q does not mention %q", label, err.Error(), want)
+		}
+	}
+}
+
+// assertClosedFields reads the close-lifecycle columns back from storage. The
+// stored empty string and SQL NULL are the same "nothing recorded" state to
+// every reader, so both collapse to "" here.
+func assertClosedFields(t *testing.T, ctx context.Context, fixture IssueOperationsStagingFixture, id, label, wantReason, wantSession string, wantClosedAt bool) {
+	t.Helper()
+	var reason, session, closedAt string
+	if err := fixture.QueryScalar(ctx,
+		"SELECT COALESCE(close_reason, ''), COALESCE(closed_by_session, ''), COALESCE(CAST(closed_at AS CHAR), '') FROM issues WHERE id = ?",
+		[]any{id}, &reason, &session, &closedAt); err != nil {
+		t.Fatalf("read close fields for %s (%s): %v", id, label, err)
+	}
+	if reason != wantReason {
+		t.Errorf("%s %s close_reason = %q, want %q", id, label, reason, wantReason)
+	}
+	if session != wantSession {
+		t.Errorf("%s %s closed_by_session = %q, want %q", id, label, session, wantSession)
+	}
+	if gotClosedAt := closedAt != ""; gotClosedAt != wantClosedAt {
+		t.Errorf("%s %s closed_at = %q, want set = %v", id, label, closedAt, wantClosedAt)
+	}
 }
 
 // RunIssueOperationsUpdateAssigneeTransferFence pins what an assignee edit does

--- a/internal/storage/conformance/issue_operations_contract.go
+++ b/internal/storage/conformance/issue_operations_contract.go
@@ -371,6 +371,27 @@ func RunIssueOperationsUpdateClosedFieldsMatchClose(t *testing.T, ctx context.Co
 	}
 	assertClosedFields(t, ctx, fixture, explicitID, "explicit close fields", "handled", "session-two", true)
 
+	// The close-crossing defaults have to be observable on a row that carries
+	// stale attribution at the moment it closes. A freshly created row already
+	// has both columns empty, and the re-close above routes through a generic
+	// reopen that blanks them first, so neither case can tell a funnel that
+	// writes the columns from one that merely inherits them. Seeding the stale
+	// values onto an OPEN row does: the columns are allowlisted by name, and
+	// with no closed_at in the map the coherence guard has nothing to refuse.
+	staleID := fixture.IssuePrefix + "-closedfields-stale"
+	seedClosePolicyIssue(t, ctx, fixture, staleID, publicops.CreateRequest{})
+	if err := fixture.UpdateRaw(ctx, staleID, map[string]any{
+		"close_reason": "stale", "closed_by_session": "stale-sess",
+	}, "writer"); err != nil {
+		t.Fatalf("seed stale close attribution on open %s: %v", staleID, err)
+	}
+	assertClosedFields(t, ctx, fixture, staleID, "stale attribution staged while open", "stale", "stale-sess", false)
+
+	if err := fixture.UpdateRaw(ctx, staleID, map[string]any{"status": string(types.StatusClosed)}, "writer"); err != nil {
+		t.Fatalf("generic close of %s over stale attribution: %v", staleID, err)
+	}
+	assertClosedFields(t, ctx, fixture, staleID, "generic close over stale attribution", "", "", true)
+
 	// The coherence guard. Stamping closed_at on a row that stays open is
 	// refused by name, typed as a validation error, and writes nothing.
 	guardID := fixture.IssuePrefix + "-closedfields-guard"
@@ -411,6 +432,20 @@ func RunIssueOperationsUpdateClosedFieldsMatchClose(t *testing.T, ctx context.Co
 	assertClosedAtRefusal(t, err, "clearing closed_at on a closed row", guardID)
 	assertClosePolicyStatus(t, ctx, fixture, guardID, types.StatusClosed)
 	assertClosedFields(t, ctx, fixture, guardID, "after refused closed_at clear", "", "", true)
+
+	// The same refusal must hold when the explicit closed_at happens to equal
+	// the value already stored. That is a no-op by VALUE and an incoherent
+	// write by INTENT — the caller is asking to reopen the row and keep its
+	// closed_at — so the guard has to see the key before the no-op filter can
+	// drop it. Otherwise this write and the identical one carrying a stamp one
+	// nanosecond off get opposite answers, and the reopen silently clears the
+	// column the caller explicitly asked to keep.
+	err = fixture.UpdateRaw(ctx, guardID, map[string]any{
+		"status": string(types.StatusOpen), "closed_at": repaired,
+	}, "writer")
+	assertClosedAtRefusal(t, err, "reopening while restating the row's own closed_at", guardID)
+	assertClosePolicyStatus(t, ctx, fixture, guardID, types.StatusClosed)
+	assertClosedFields(t, ctx, fixture, guardID, "after refused no-op-valued closed_at reopen", "", "", true)
 
 	// Clearing it as part of a reopen is coherent, so it is allowed.
 	if err := fixture.UpdateRaw(ctx, guardID, map[string]any{

--- a/internal/storage/conformance/issue_operations_staging.go
+++ b/internal/storage/conformance/issue_operations_staging.go
@@ -21,6 +21,11 @@ type IssueOperationsStagingFixture struct {
 	Commit        func(context.Context, string) error
 	Exec          func(context.Context, string, ...any) error
 	QueryScalar   func(context.Context, string, []any, ...any) error
+	// UpdateRaw drives the backend's generic update funnel with an untyped
+	// column map, the way an external-sync or backfill caller does. The typed
+	// patch behind Operations.Update carries no closed_at, so this is the only
+	// route to the columns the close-lifecycle assertions cover.
+	UpdateRaw func(context.Context, string, map[string]any, string) error
 }
 
 // RunIssueOperationsCreateReverseNonBlockingStagesConcreteTables proves that a

--- a/internal/storage/dolt/issue_operations_contract_test.go
+++ b/internal/storage/dolt/issue_operations_contract_test.go
@@ -37,6 +37,12 @@ func TestIssueOperationsUpdateAssigneeTransferFence(t *testing.T) {
 	conformance.RunIssueOperationsUpdateAssigneeTransferFence(t, ctx, fixture)
 }
 
+func TestIssueOperationsUpdateClosedFieldsMatchClose(t *testing.T) {
+	fixture, ctx, cleanup := newDoltIssueOperationsFixture(t)
+	defer cleanup()
+	conformance.RunIssueOperationsUpdateClosedFieldsMatchClose(t, ctx, fixture)
+}
+
 func newDoltIssueOperationsFixture(t *testing.T) (conformance.IssueOperationsStagingFixture, context.Context, func()) {
 	t.Helper()
 	store, storeCleanup := setupTestStore(t)
@@ -52,6 +58,7 @@ func newDoltIssueOperationsFixture(t *testing.T) (conformance.IssueOperationsSta
 		Operations:  operations,
 		CreateIssue: store.CreateIssue,
 		SetConfig:   store.SetConfig,
+		UpdateRaw:   store.UpdateIssue,
 		QueryScalar: func(ctx context.Context, query string, args []any, dest ...any) error {
 			return store.db.QueryRowContext(ctx, query, args...).Scan(dest...)
 		},

--- a/internal/storage/domain/db/issue.go
+++ b/internal/storage/domain/db/issue.go
@@ -182,6 +182,14 @@ func (r *issueSQLRepositoryImpl) Update(ctx context.Context, id string, updates 
 	// lifecycle side effects below only fire on a real transition.
 	_, statusChanging := updates["status"]
 
+	// closed_at coherence parity with issueops.updateIssueInTx: an explicit
+	// closed_at must agree with the status this update lands, checked against
+	// the row this unit of work already read and ahead of the close-policy gate
+	// so a refusal writes nothing at all.
+	if err := issueops.ValidateClosedAtCoherence(oldIssue, updates); err != nil {
+		return fmt.Errorf("db: Update %s: %w", id, err)
+	}
+
 	// Close-policy parity with issueops.updateIssueInTx: a status that crosses
 	// into the done category is a close by another name and answers to close
 	// policy. A refusal returns before any write and aborts the caller's unit of

--- a/internal/storage/domain/db/issue.go
+++ b/internal/storage/domain/db/issue.go
@@ -170,6 +170,17 @@ func (r *issueSQLRepositoryImpl) Update(ctx context.Context, id string, updates 
 		updates = resolved
 	}
 
+	// closed_at coherence parity with issueops.updateIssueInTx: an explicit
+	// closed_at must agree with the status this update lands, checked against
+	// the row this unit of work already read and ahead of the close-policy gate
+	// so a refusal writes nothing at all. It runs on the merge-resolved map
+	// BEFORE the no-op filter for the same reason it does there — the guard
+	// reads the caller's intent, and a closed_at equal to the stored value is
+	// still a request to keep the column, not an absent key.
+	if err := issueops.ValidateClosedAtCoherence(oldIssue, updates); err != nil {
+		return fmt.Errorf("db: Update %s: %w", id, err)
+	}
+
 	filteredUpdates, err := issueops.DiscardNoopIssueUpdates(oldIssue, updates)
 	if err != nil {
 		return fmt.Errorf("db: Update %s: compare updates: %w", id, err)
@@ -181,14 +192,6 @@ func (r *issueSQLRepositoryImpl) Update(ctx context.Context, id string, updates 
 	// A status that matched the row was already dropped as a no-op, so the
 	// lifecycle side effects below only fire on a real transition.
 	_, statusChanging := updates["status"]
-
-	// closed_at coherence parity with issueops.updateIssueInTx: an explicit
-	// closed_at must agree with the status this update lands, checked against
-	// the row this unit of work already read and ahead of the close-policy gate
-	// so a refusal writes nothing at all.
-	if err := issueops.ValidateClosedAtCoherence(oldIssue, updates); err != nil {
-		return fmt.Errorf("db: Update %s: %w", id, err)
-	}
 
 	// Close-policy parity with issueops.updateIssueInTx: a status that crosses
 	// into the done category is a close by another name and answers to close

--- a/internal/storage/embeddeddolt/issue_operations_contract_test.go
+++ b/internal/storage/embeddeddolt/issue_operations_contract_test.go
@@ -45,6 +45,13 @@ func TestEmbeddedIssueOperationsUpdateAssigneeTransferFence(t *testing.T) {
 	conformance.RunIssueOperationsUpdateAssigneeTransferFence(t, ctx, newEmbeddedIssueOperationsFixture(t, ctx, te, "xferfence"))
 }
 
+func TestEmbeddedIssueOperationsUpdateClosedFieldsMatchClose(t *testing.T) {
+	skipUnlessEmbeddedDolt(t)
+	te := newTestEnv(t, "closedfields")
+	ctx := t.Context()
+	conformance.RunIssueOperationsUpdateClosedFieldsMatchClose(t, ctx, newEmbeddedIssueOperationsFixture(t, ctx, te, "closedfields"))
+}
+
 func newEmbeddedIssueOperationsFixture(t *testing.T, ctx context.Context, te *testEnv, prefix string) conformance.IssueOperationsStagingFixture {
 	t.Helper()
 	operations, err := embeddeddolt.NewIssueOperations(te.store)
@@ -56,6 +63,7 @@ func newEmbeddedIssueOperationsFixture(t *testing.T, ctx context.Context, te *te
 		Operations:  operations,
 		CreateIssue: te.store.CreateIssue,
 		SetConfig:   te.store.SetConfig,
+		UpdateRaw:   te.store.UpdateIssue,
 		QueryScalar: func(ctx context.Context, query string, args []any, dest ...any) error {
 			te.queryScalar(t, ctx, query, args, dest...)
 			return nil

--- a/internal/storage/issueops/update.go
+++ b/internal/storage/issueops/update.go
@@ -31,11 +31,25 @@ func IsAllowedUpdateField(key string) bool {
 	return allowed[key]
 }
 
-// ManageClosedAt auto-sets closed_at when closing or clears it when reopening.
+// ManageClosedAt brings the close-lifecycle columns along with a status
+// transition, so a generic update that crosses into closed lands the same row
+// `bd close` would and a reopen leaves nothing of the old close behind.
+//
+// closeIssueInTx writes closed_at, close_reason and closed_by_session on EVERY
+// close, including the empty reason and session a caller that supplied neither
+// produces. The update funnels write a column only when the caller names its
+// key, so without these defaults a generic close inherits whatever the previous
+// close left: a re-close after a generic reopen keeps the old session and
+// `bd show` reports the new close as the old session's work (ga-kjkv1). Each
+// default is suppressed by its own explicit key, so a caller that names the
+// column still wins — the CLI's own closed_by_session pass-through included.
+//
+// The reopen branch clears all three, mirroring ReopenIssueInTx. Both branches
+// stay keyed on the LITERAL closed status; category-aware reopen keying is
+// ga-ktn9pe.4.15.
 func ManageClosedAt(oldIssue *types.Issue, updates map[string]interface{}, setClauses []string, args []interface{}) ([]string, []interface{}) {
 	statusVal, hasStatus := updates["status"]
-	_, hasExplicitClosedAt := updates["closed_at"]
-	if hasExplicitClosedAt || !hasStatus {
+	if !hasStatus {
 		return setClauses, args
 	}
 
@@ -49,16 +63,93 @@ func ManageClosedAt(oldIssue *types.Issue, updates map[string]interface{}, setCl
 		return setClauses, args
 	}
 
+	// Defaults are SET-clause appends, never inserts into updates: the map
+	// drives no-op detection, the event payload, lease management and the
+	// blocked recompute, none of which should see a column the caller did not
+	// ask for.
+	appendDefault := func(column string, value interface{}) {
+		if _, explicit := updates[column]; explicit {
+			return
+		}
+		setClauses = append(setClauses, column+" = ?")
+		args = append(args, value)
+	}
+
 	if newStatus == string(types.StatusClosed) {
-		now := time.Now().UTC()
-		setClauses = append(setClauses, "closed_at = ?")
-		args = append(args, now)
+		appendDefault("closed_at", time.Now().UTC())
+		appendDefault("close_reason", "")
+		appendDefault("closed_by_session", "")
 	} else if oldIssue.Status == types.StatusClosed {
-		setClauses = append(setClauses, "closed_at = ?", "close_reason = ?")
-		args = append(args, nil, "")
+		appendDefault("closed_at", nil)
+		appendDefault("close_reason", "")
+		appendDefault("closed_by_session", "")
 	}
 
 	return setClauses, args
+}
+
+// ValidateClosedAtCoherence refuses an explicit closed_at write that would
+// leave the row violating the closed-iff-closed_at invariant
+// types.Issue.Validate enforces: a closed issue has a closed_at, a non-closed
+// issue has none. It reads the status the update actually lands — the update's
+// own status when it carries one, otherwise the row's current status, which
+// both funnels read inside the mutation transaction.
+//
+// The key stays allowlisted, so every coherent standalone write still works:
+// stamping closed_at on a row that is already closed is the repair path for
+// rows a pre-invariant close left blank, an external-sync or backfill caller
+// can land status and closed_at together, and clearing closed_at on a row that
+// is or becomes non-closed is the reverse repair. What is refused is the half
+// that mints a row no reader can trust — stamping closed_at on a row that stays
+// open, or clearing it from a row that stays closed.
+//
+// This is a coherence invariant rather than close policy, so the force override
+// that waives the open-children and blocker refusals does not waive it, exactly
+// as force never waives the version CAS.
+func ValidateClosedAtCoherence(oldIssue *types.Issue, updates map[string]interface{}) error {
+	rawClosedAt, hasClosedAt := updates["closed_at"]
+	if !hasClosedAt {
+		return nil
+	}
+
+	landedStatus := oldIssue.Status
+	if rawStatus, hasStatus := updates["status"]; hasStatus {
+		switch value := rawStatus.(type) {
+		case string:
+			landedStatus = types.Status(value)
+		case types.Status:
+			landedStatus = value
+		default:
+			// A status Go type nobody can read is already CrossesIntoDoneCategoryInTx's
+			// refusal in both funnels; leave that the single message for it.
+			return nil
+		}
+	}
+
+	clearing := clearsClosedAt(rawClosedAt)
+	switch {
+	case landedStatus == types.StatusClosed && clearing:
+		return fmt.Errorf("%w: refusing to clear closed_at on %s: its status stays %q, and a closed issue must keep a closed_at; reopen it with a status update instead",
+			storage.ErrValidation, oldIssue.ID, landedStatus)
+	case landedStatus != types.StatusClosed && !clearing:
+		return fmt.Errorf("%w: refusing to set closed_at on %s: its status stays %q, and only a closed issue may carry a closed_at; set status=closed in the same update to close it",
+			storage.ErrValidation, oldIssue.ID, landedStatus)
+	}
+	return nil
+}
+
+// clearsClosedAt reports whether an allowlisted closed_at value blanks the
+// column. It accepts the same nil shapes matchesTimePointer treats as empty, so
+// the guard and the no-op filter agree on what "no closed_at" means.
+func clearsClosedAt(value interface{}) bool {
+	switch typed := value.(type) {
+	case nil:
+		return true
+	case *time.Time:
+		return typed == nil
+	default:
+		return false
+	}
 }
 
 // ManageStartedAt auto-sets started_at when transitioning to in_progress.
@@ -273,6 +364,14 @@ func updateIssueInTx(ctx context.Context, tx DBTX, id string, updates map[string
 	}
 	if len(updates) == 0 {
 		return &UpdateResult{OldIssue: oldIssue, IsWisp: isWisp, Changed: false}, nil
+	}
+
+	// An explicit closed_at must agree with the status the update lands. This
+	// runs ahead of the close-policy gate so a refused write never even touches
+	// the dependency coordination cell, and it reads the row the same
+	// transaction just read, so no concurrent status change can slip between.
+	if err := ValidateClosedAtCoherence(oldIssue, updates); err != nil {
+		return nil, err
 	}
 
 	// A status update that crosses into the done category is a close by another

--- a/internal/storage/issueops/update.go
+++ b/internal/storage/issueops/update.go
@@ -106,6 +106,12 @@ func ManageClosedAt(oldIssue *types.Issue, updates map[string]interface{}, setCl
 // This is a coherence invariant rather than close policy, so the force override
 // that waives the open-children and blocker refusals does not waive it, exactly
 // as force never waives the version CAS.
+//
+// Both funnels must call this BEFORE DiscardNoopIssueUpdates. The guard judges
+// the caller's intent, and a closed_at equal to the stored value is still a
+// request to keep the column; the no-op filter drops it as an unchanged value,
+// which would hide exactly the incoherent halves this refuses and let
+// ManageClosedAt's reopen branch clear the column instead.
 func ValidateClosedAtCoherence(oldIssue *types.Issue, updates map[string]interface{}) error {
 	rawClosedAt, hasClosedAt := updates["closed_at"]
 	if !hasClosedAt {
@@ -358,20 +364,29 @@ func updateIssueInTx(ctx context.Context, tx DBTX, id string, updates map[string
 	if err != nil {
 		return nil, err
 	}
+
+	// An explicit closed_at must agree with the status the update lands. The
+	// guard reads the caller's INTENT, so it runs on the merge-resolved map
+	// BEFORE the no-op filter: a closed_at that happens to equal the stored
+	// value is still a request to keep the column, and letting the filter drop
+	// it first would send that request down ManageClosedAt's reopen branch —
+	// clearing the column instead of refusing the write, and answering two
+	// identical intents differently over a nanosecond of stamp. Merge-op
+	// resolution only ever writes metadata and notes, so the key the guard sees
+	// is always one the caller supplied. It also runs ahead of the close-policy
+	// gate so a refused write never even touches the dependency coordination
+	// cell, and it reads the row the same transaction just read, so no
+	// concurrent status change can slip between.
+	if err := ValidateClosedAtCoherence(oldIssue, updates); err != nil {
+		return nil, err
+	}
+
 	updates, err = DiscardNoopIssueUpdates(oldIssue, updates)
 	if err != nil {
 		return nil, err
 	}
 	if len(updates) == 0 {
 		return &UpdateResult{OldIssue: oldIssue, IsWisp: isWisp, Changed: false}, nil
-	}
-
-	// An explicit closed_at must agree with the status the update lands. This
-	// runs ahead of the close-policy gate so a refused write never even touches
-	// the dependency coordination cell, and it reads the row the same
-	// transaction just read, so no concurrent status change can slip between.
-	if err := ValidateClosedAtCoherence(oldIssue, updates); err != nil {
-		return nil, err
 	}
 
 	// A status update that crosses into the done category is a close by another

--- a/internal/storage/issueops/update_closed_fields_test.go
+++ b/internal/storage/issueops/update_closed_fields_test.go
@@ -1,0 +1,240 @@
+package issueops
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/steveyegge/beads/internal/storage"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// clauseValues pairs the SET clauses ManageClosedAt appended with their args so
+// a test can assert on the column a clause writes rather than on ordering.
+func clauseValues(t *testing.T, clauses []string, args []interface{}) map[string]interface{} {
+	t.Helper()
+	if len(clauses) != len(args) {
+		t.Fatalf("clauses (%d) and args (%d) are out of step: %v / %v", len(clauses), len(args), clauses, args)
+	}
+	out := make(map[string]interface{}, len(clauses))
+	for i, clause := range clauses {
+		column := strings.TrimSpace(strings.TrimSuffix(clause, "= ?"))
+		column = strings.Trim(column, "` ")
+		if _, dup := out[column]; dup {
+			t.Fatalf("column %q written twice by %v", column, clauses)
+		}
+		out[column] = args[i]
+	}
+	return out
+}
+
+// TestManageClosedAtMatchesCloseSemantics pins the close-crossing defaults
+// (ga-kjkv1): closeIssueInTx always writes close_reason and closed_by_session,
+// including the empty values a caller supplying neither produces, so a generic
+// update that crosses into closed must write them too. Without this a re-close
+// after a generic reopen keeps the PREVIOUS close's session and `bd show`
+// misattributes it. Each default is suppressed by its own explicit key.
+func TestManageClosedAtMatchesCloseSemantics(t *testing.T) {
+	openIssue := &types.Issue{ID: "bd-1", Status: types.StatusOpen}
+	closedAt := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	closedIssue := &types.Issue{ID: "bd-1", Status: types.StatusClosed, ClosedAt: &closedAt}
+
+	tests := []struct {
+		name     string
+		oldIssue *types.Issue
+		updates  map[string]interface{}
+		want     map[string]interface{}
+		// wantClosedAtNow marks the closed_at default as a fresh timestamp the
+		// test cannot predict; want must omit the key when this is set.
+		wantClosedAtNow bool
+	}{
+		{
+			name:            "crossing into closed defaults reason and session to empty",
+			oldIssue:        openIssue,
+			updates:         map[string]interface{}{"status": "closed"},
+			want:            map[string]interface{}{"close_reason": "", "closed_by_session": ""},
+			wantClosedAtNow: true,
+		},
+		{
+			name:            "typed status crosses the same way",
+			oldIssue:        openIssue,
+			updates:         map[string]interface{}{"status": types.StatusClosed},
+			want:            map[string]interface{}{"close_reason": "", "closed_by_session": ""},
+			wantClosedAtNow: true,
+		},
+		{
+			name:            "explicit close_reason wins over its default",
+			oldIssue:        openIssue,
+			updates:         map[string]interface{}{"status": "closed", "close_reason": "shipped"},
+			want:            map[string]interface{}{"closed_by_session": ""},
+			wantClosedAtNow: true,
+		},
+		{
+			name:            "explicit closed_by_session wins over its default",
+			oldIssue:        openIssue,
+			updates:         map[string]interface{}{"status": "closed", "closed_by_session": "sess-9"},
+			want:            map[string]interface{}{"close_reason": ""},
+			wantClosedAtNow: true,
+		},
+		{
+			name:     "explicit closed_at suppresses only the closed_at default",
+			oldIssue: openIssue,
+			updates:  map[string]interface{}{"status": "closed", "closed_at": closedAt},
+			want:     map[string]interface{}{"close_reason": "", "closed_by_session": ""},
+		},
+		{
+			name:     "reopen clears closed_at, reason and session",
+			oldIssue: closedIssue,
+			updates:  map[string]interface{}{"status": "open"},
+			want:     map[string]interface{}{"closed_at": nil, "close_reason": "", "closed_by_session": ""},
+		},
+		{
+			name:     "no status update writes nothing",
+			oldIssue: closedIssue,
+			updates:  map[string]interface{}{"priority": 1},
+			want:     map[string]interface{}{},
+		},
+		{
+			name:     "non-closed transition on an open row writes nothing",
+			oldIssue: openIssue,
+			updates:  map[string]interface{}{"status": "in_progress"},
+			want:     map[string]interface{}{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			before := time.Now().UTC()
+			clauses, args := ManageClosedAt(tt.oldIssue, tt.updates, nil, nil)
+			got := clauseValues(t, clauses, args)
+
+			if tt.wantClosedAtNow {
+				stamp, ok := got["closed_at"].(time.Time)
+				if !ok {
+					t.Fatalf("closed_at = %#v, want a fresh time.Time", got["closed_at"])
+				}
+				if stamp.Before(before) {
+					t.Errorf("closed_at = %v, want at or after %v", stamp, before)
+				}
+				delete(got, "closed_at")
+			}
+			if len(got) != len(tt.want) {
+				t.Fatalf("columns = %#v, want %#v", got, tt.want)
+			}
+			for column, want := range tt.want {
+				if got[column] != want {
+					t.Errorf("%s = %#v, want %#v", column, got[column], want)
+				}
+			}
+		})
+	}
+}
+
+// TestValidateClosedAtCoherence pins ruling 2's matrix (ga-kjkv1): an explicit
+// closed_at write is allowed only when it leaves the row satisfying the
+// closed-iff-closed_at invariant types.Issue.Validate enforces. The repair path
+// — stamping closed_at on a row that is or becomes closed — stays open.
+func TestValidateClosedAtCoherence(t *testing.T) {
+	stamp := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	openIssue := &types.Issue{ID: "bd-open", Status: types.StatusOpen}
+	closedIssue := &types.Issue{ID: "bd-closed", Status: types.StatusClosed, ClosedAt: &stamp}
+
+	tests := []struct {
+		name       string
+		oldIssue   *types.Issue
+		updates    map[string]interface{}
+		wantRefuse bool
+	}{
+		{
+			name:     "closed row repairs its closed_at",
+			oldIssue: closedIssue,
+			updates:  map[string]interface{}{"closed_at": stamp},
+		},
+		{
+			name:     "row becoming closed carries its closed_at",
+			oldIssue: openIssue,
+			updates:  map[string]interface{}{"status": "closed", "closed_at": stamp},
+		},
+		{
+			name:     "row becoming closed via typed status carries its closed_at",
+			oldIssue: openIssue,
+			updates:  map[string]interface{}{"status": types.StatusClosed, "closed_at": &stamp},
+		},
+		{
+			name:     "reopen clears closed_at",
+			oldIssue: closedIssue,
+			updates:  map[string]interface{}{"status": "open", "closed_at": nil},
+		},
+		{
+			name:     "open row clears closed_at",
+			oldIssue: openIssue,
+			updates:  map[string]interface{}{"closed_at": nil},
+		},
+		{
+			name:       "open row cannot stamp closed_at",
+			oldIssue:   openIssue,
+			updates:    map[string]interface{}{"closed_at": stamp},
+			wantRefuse: true,
+		},
+		{
+			name:       "non-closed transition cannot stamp closed_at",
+			oldIssue:   openIssue,
+			updates:    map[string]interface{}{"status": "in_progress", "closed_at": stamp},
+			wantRefuse: true,
+		},
+		{
+			name:       "closed row cannot clear closed_at",
+			oldIssue:   closedIssue,
+			updates:    map[string]interface{}{"closed_at": nil},
+			wantRefuse: true,
+		},
+		{
+			name:       "closed row cannot clear closed_at through a nil pointer",
+			oldIssue:   closedIssue,
+			updates:    map[string]interface{}{"closed_at": (*time.Time)(nil)},
+			wantRefuse: true,
+		},
+		{
+			name:       "restating closed cannot clear closed_at",
+			oldIssue:   closedIssue,
+			updates:    map[string]interface{}{"status": "closed", "closed_at": nil},
+			wantRefuse: true,
+		},
+		{
+			name:     "no closed_at key is never refused",
+			oldIssue: openIssue,
+			updates:  map[string]interface{}{"status": "closed"},
+		},
+		{
+			name:     "a mis-typed status defers to the crossing check",
+			oldIssue: openIssue,
+			updates:  map[string]interface{}{"status": 7, "closed_at": stamp},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateClosedAtCoherence(tt.oldIssue, tt.updates)
+			if !tt.wantRefuse {
+				if err != nil {
+					t.Fatalf("ValidateClosedAtCoherence = %v, want nil", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatal("ValidateClosedAtCoherence = nil, want a refusal")
+			}
+			if !errors.Is(err, storage.ErrValidation) {
+				t.Errorf("refusal %v is not storage.ErrValidation", err)
+			}
+			// The refusal must name the column and the issue, so a raw-map
+			// caller can tell WHICH write was rejected and why.
+			for _, want := range []string{"closed_at", tt.oldIssue.ID} {
+				if !strings.Contains(err.Error(), want) {
+					t.Errorf("refusal %q does not mention %q", err.Error(), want)
+				}
+			}
+		})
+	}
+}

--- a/internal/storage/uow/issue_operations_contract_test.go
+++ b/internal/storage/uow/issue_operations_contract_test.go
@@ -36,6 +36,11 @@ func TestIssueOperationsUpdateAssigneeTransferFence(t *testing.T) {
 	conformance.RunIssueOperationsUpdateAssigneeTransferFence(t, ctx, newUOWIssueOperationsFixture(t, ctx))
 }
 
+func TestIssueOperationsUpdateClosedFieldsMatchClose(t *testing.T) {
+	ctx := context.Background()
+	conformance.RunIssueOperationsUpdateClosedFieldsMatchClose(t, ctx, newUOWIssueOperationsFixture(t, ctx))
+}
+
 func newUOWIssueOperationsFixture(t *testing.T, ctx context.Context) conformance.IssueOperationsStagingFixture {
 	t.Helper()
 	operations, provider := newRealIssueOperationsWithProvider(t, ctx)
@@ -56,6 +61,11 @@ func newUOWIssueOperationsFixture(t *testing.T, ctx context.Context) conformance
 		SetConfig: func(ctx context.Context, key, value string) error {
 			return RunTx(ctx, provider, func(ctx context.Context, uw UnitOfWork) (string, error) {
 				return "set " + key, uw.ConfigUseCase().SetConfig(ctx, key, value)
+			})
+		},
+		UpdateRaw: func(ctx context.Context, id string, updates map[string]any, actor string) error {
+			return RunTx(ctx, provider, func(ctx context.Context, uw UnitOfWork) (string, error) {
+				return "raw update " + id, uw.IssueUseCase().UpdateIssue(ctx, id, updates, actor)
 			})
 		},
 		QueryScalar: func(ctx context.Context, query string, args []any, dest ...any) error {


### PR DESCRIPTION
## What

When a generic update's status change crosses into close, both write funnels now apply the same field effects `Lifecycle.Close` applies — and an explicit `closed_at` that contradicts the status the update lands is refused.

## Why

`bd close` always writes `close_reason` and `closed_by_session`, even when empty. The update funnels wrote them only if the caller passed the key. Two consequences:

- A non-CLI caller closing through a generic update leaves both columns empty.
- Worse, it leaves them **stale**. The funnel reopen branch never cleared `closed_by_session`, so a re-close after a generic reopen misattributes the close to the *previous* session — and `bd show` renders it as "Closed by session".

Separately, neither funnel enforced the invariant `types.Issue.Validate` already declares at `internal/types/types.go:346-350`: `Status == StatusClosed ⇔ ClosedAt != nil`. It is enforced on create and on import, but `ValidateScalarUpdates` checks only issue_type/assignee/owner, so a generic update could mint a row the type's own validator calls invalid.

Note what this is **not**: a metadata-only write moves no status, so the row never crosses into done and the #5206 close-policy gate has nothing to catch. The issue stays open and ready. This was filed as a policy bypass; it is an integrity defect.

## The three owner rulings this implements

1. The keys stay allowlisted. Rather than removing them, the funnels grow close's semantics on a close crossing.
2. An explicit `closed_at` is judged against the row's status: settable only on a row that is or is becoming closed; clearable only on an open row. The repair path — fixing a wrong `closed_at` on an already-closed row — is deliberately preserved.
3. The reopen mirror is limited to clearing `closed_by_session`. Category-aware reopen keying, `defer_until` and reopen comment events are deferred.

## How

`ManageClosedAt` — already shared by both funnels — appends `close_reason=''` and `closed_by_session=''` on a literal close crossing, each independently suppressed by an explicit key, mirroring the existing explicit-`closed_at` suppression. The reopen branch additionally clears `closed_by_session`.

**These are SET-clause appends, never inserts into the `updates` map.** That map feeds `DiscardNoopIssueUpdates`, `DetermineEventType`'s `newData` payload, `ManageLeaseOnUpdate` and the blocked-recompute trigger. Inserting keys would silently change event payloads and no-op detection while passing the obvious tests. As clause appends, the change is invisible to all four.

`ValidateClosedAtCoherence` is a pure function over the `oldIssue` both funnels already read inside their mutation transaction — transaction-local, no extra read. Keeping it literal-closed keyed makes it provably the *same* biconditional `types.Validate` enforces rather than a second, differently-keyed rule.

## Why this is not the shared-layer trap

This adds validation to two shared write funnels, which is the shape that broke this repo twice. The caller table says it does not land the same way:

| Caller | Can it reach the guard? |
| --- | --- |
| `bd update`, direct and proxied | **No** — the typed `IssuePatch` has no `ClosedAt` field |
| `bd batch update` | **No** — `parseUpdateKVs` hard-allowlists status/priority/title/assignee/force |
| `bd close`/`reopen`/`--claim` | **No** — dedicated verbs with their own SQL |
| tracker sync, compactor, merge slots, `DemoteToWisp`, metadata helpers | **No** — none carry `closed_at` |
| `internal/linear.BuildLinearToLocalUpdates` | Yes in principle — but it is dead code with test-only callers, and it always sets `status` in the same map |
| raw-map in-process/SDK callers | **Yes** — the intended audience |

The proxied server and `bd batch` are exactly the callers the closed-boundary guard and the assignee fence each broke. Neither can reach this one. The refusal is a `storage.ErrValidation` naming the column, the issue and the landed status; there is no override, by design — this is a coherence invariant, so `ForceClosePolicy` does not waive it, mirroring how force never waives the version CAS.

## Two behavior changes worth a reviewer's eye

- **`{status: closed, closed_at: nil}` on an open row is now refused.** Previously the nil matched the stored NULL, was filtered as a no-op, and `ManageClosedAt` silently stamped `now()`. This cell is an *inference* from the ruling's matrix rather than a quoted row of it, and it is flagged as such. It is consistent — an explicit nil means "clear it", and "close this and clear its closed_at" is contradictory — and a caller wanting the system to stamp simply omits the key. No in-tree caller sends this shape.
- **A raw-map `{status: <custom done-category status>, closed_at: T}` is refused**, because the guard is literal-closed keyed. No in-repo caller does this and `types.Validate` would reject the resulting row anyway. The guard was deliberately not widened to the done *category*, since the blocking model and `types.Validate` are coherently literal-keyed today.

Also accepted deliberately: defaulting `close_reason=''` on a done crossing overwrites a `close_reason` a caller staged on an open row in an earlier update. Obscure, and exactly what `bd close` does.

## Verification

Counts are RUN/PASS, all FAIL=0, against baselines captured from `origin/main` before the first edit:

```
cmd/bd -run TestParity                        43  (baseline 40, +3 new parity cases)
internal/storage/issueops                    372  (baseline 350, +22 new subtests)
domain/db -run TestDomainDB                  800  (unchanged)
internal/storage/uow                         145  (baseline 144, +1 conformance case)
dolt -run TestIssueOperations                 75  (baseline 74, +1) — 0 SKIP
embeddeddolt -run TestEmbeddedIssueOperations 58  (baseline 57, +1) — 0 SKIP
```

Full `./cmd/bd/` sweep: 21 top-level failures, failing set compared **by name** against baseline — `diff` reports no difference. All are the known pre-existing init/config/doctor/completion failures. `gofmt`, `go vet`, and golangci-lint `--new-from-rev=origin/main` all clean.

**Mutation-checked, including the two that matter for funnel divergence.** Dropping only the `issueops` call site fails dolt conformance while uow passes; dropping only the `domain/db` call site fails uow while dolt passes. The two funnels are proven independently covered — which a shared helper alone demonstrably does not guarantee, since both funnels already call `ManageClosedAt` yet the pin auto-clear block exists in `issueops` only. Reverting the guard's ordering in one funnel likewise fails only that funnel's backends. All files restored and checksum-verified.

Two review findings were fixed before this PR opened, both caught by mutation rather than by reading:

1. The guard originally ran *after* `DiscardNoopIssueUpdates`, so an explicit `closed_at` equal to the stored value had its key dropped as a no-op and bypassed the refusal entirely — the same request with `T+1ns` was refused. It now runs on the merge-op-resolved map before the filter, in both funnels, and the doc comment states that ordering as a caller contract so a refactor cannot quietly restore the bypass.
2. The close-crossing defaults had no surviving end-to-end coverage: a mutant removing only the two close-branch `appendDefault` lines passed dolt conformance, uow conformance and all three parity tests, because every integration scenario routed through a reopen that blanked the columns first. The conformance case now seeds stale attribution directly onto an **open** row via the allowlisted keys, then closes it — and that mutant fails on all three backends.

Coverage added: 8 clause-level cases for the defaults and their per-key suppression, 12 for the coherence matrix, one cross-backend conformance case wired into all three contract entry points, and three `cmd/bd` parity cases (additions only; `pinned` is excluded from the field-by-field comparison with an explicit `ga-ktn9pe.4.14` citation, and `close_reason` because `bd close` defaults it to "Closed" at the CLI layer while `bd update` has no reason flag).
