### PR TITLE
refactor(test): test benchmark env at command boundary

### DIFF
--- a/scripts/repro-dolt-prod-timeouts/main.go
+++ b/scripts/repro-dolt-prod-timeouts/main.go
@@ -1014,9 +1014,7 @@ func runJob(ctx context.Context, cfg config, ws *workspace, j job) opResult {
 func runBD(ctx context.Context, cfg config, ws *workspace, j job) opResult {
 	opCtx, cancel := context.WithTimeout(ctx, cfg.Timeout)
 	defer cancel()
-	cmd := exec.CommandContext(opCtx, cfg.BDPath, j.Argv...)
-	cmd.Dir = ws.Dir
-	cmd.Env = subprocessEnv(append([]string{"BD_NON_INTERACTIVE=1"}, j.Env...)...)
+	cmd := newBDCommand(opCtx, cfg, ws, j)
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
 	start := time.Now()
@@ -1039,9 +1037,7 @@ func runBD(ctx context.Context, cfg config, ws *workspace, j job) opResult {
 func runShell(ctx context.Context, cfg config, ws *workspace, j job) opResult {
 	opCtx, cancel := context.WithTimeout(ctx, cfg.Timeout)
 	defer cancel()
-	cmd := exec.CommandContext(opCtx, "sh", "-c", j.Sh)
-	cmd.Dir = ws.Dir
-	cmd.Env = subprocessEnv(append([]string{"BD_NON_INTERACTIVE=1", "BD_BIN=" + cfg.BDPath}, j.Env...)...)
+	cmd := newShellCommand(opCtx, cfg, ws, j)
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
 	start := time.Now()
@@ -1056,6 +1052,20 @@ func runShell(ctx context.Context, cfg config, ws *workspace, j job) opResult {
 	}
 	res.StderrTail = tail(stderr.String(), 300)
 	return res
+}
+
+func newBDCommand(ctx context.Context, cfg config, ws *workspace, j job) *exec.Cmd {
+	cmd := exec.CommandContext(ctx, cfg.BDPath, j.Argv...)
+	cmd.Dir = ws.Dir
+	cmd.Env = subprocessEnv(append([]string{"BD_NON_INTERACTIVE=1"}, j.Env...)...)
+	return cmd
+}
+
+func newShellCommand(ctx context.Context, cfg config, ws *workspace, j job) *exec.Cmd {
+	cmd := exec.CommandContext(ctx, "sh", "-c", j.Sh)
+	cmd.Dir = ws.Dir
+	cmd.Env = subprocessEnv(append([]string{"BD_NON_INTERACTIVE=1", "BD_BIN=" + cfg.BDPath}, j.Env...)...)
+	return cmd
 }
 
 func compactShell(s string) string {

--- a/scripts/repro-dolt-prod-timeouts/main_test.go
+++ b/scripts/repro-dolt-prod-timeouts/main_test.go
@@ -12,7 +12,6 @@ import (
 	"regexp"
 	"runtime"
 	"slices"
-	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -23,47 +22,6 @@ import (
 	"github.com/steveyegge/beads/internal/storage/schema"
 	"github.com/steveyegge/beads/internal/testutil"
 )
-
-const (
-	fakeBDModeEnv      = "BEADS_REPRO_TIMEOUTS_TEST_BD_MODE"
-	fakeBDParentPIDEnv = "BEADS_REPRO_TIMEOUTS_TEST_BD_PARENT_PID"
-	fakeBDSuccess      = "BEADS_REPRO_TIMEOUTS_TEST_BD_OK"
-)
-
-// init handles the self-reexec fixture before the generated test runner parses
-// the production-style bd arguments appended by runBD. Both executable name
-// and live parent identity keep an ambient environment value from turning the
-// ordinary test runner into a successful helper process.
-func init() {
-	mode := os.Getenv(fakeBDModeEnv)
-	if mode == "" || filepath.Base(os.Args[0]) != nativeBDExecutableName() {
-		return
-	}
-	if os.Getenv(fakeBDParentPIDEnv) != strconv.Itoa(os.Getppid()) {
-		fmt.Fprintln(os.Stderr, "fake bd parent identity mismatch")
-		os.Exit(95)
-	}
-	os.Exit(runFakeBDTestProcess(mode))
-}
-
-func runFakeBDTestProcess(mode string) int {
-	if mode != "assert-no-dolt-overrides" {
-		fmt.Fprintf(os.Stderr, "unknown fake bd mode %q\n", mode)
-		return 97
-	}
-	if !slices.Equal(os.Args[1:], []string{"status"}) {
-		fmt.Fprintf(os.Stderr, "fake bd args = %q, want [status]\n", os.Args[1:])
-		return 96
-	}
-	for _, key := range subprocessEnvDenylist {
-		if value := os.Getenv(key); value != "" {
-			fmt.Fprintf(os.Stderr, "%s inherited: %s\n", key, value)
-			return 42
-		}
-	}
-	fmt.Fprintln(os.Stderr, fakeBDSuccess)
-	return 0
-}
 
 func TestIsDriverReadTimeout(t *testing.T) {
 	result := opResult{
@@ -150,56 +108,83 @@ func TestParseFlagsPreservesExplicitExistingWorkspaceSeedMode(t *testing.T) {
 	}
 }
 
-func TestBenchmarkSubprocessesStripDoltEnvOverrides(t *testing.T) {
+func TestBenchmarkCommandBuildersStripDoltEnvOverrides(t *testing.T) {
 	for _, key := range subprocessEnvDenylist {
-		t.Setenv(key, "caller-"+strings.ToLower(key))
+		t.Setenv(key, "ambient-"+strings.ToLower(key))
 	}
+	const allowedAmbient = "BEADS_REPRO_TIMEOUTS_ALLOWED_AMBIENT=present"
+	allowedKey, allowedValue, _ := strings.Cut(allowedAmbient, "=")
+	t.Setenv(allowedKey, allowedValue)
 
-	tmp := t.TempDir()
-	bd := writeNativeBDTestExecutable(t, tmp)
-
-	cfg := config{BDPath: bd, Timeout: 5 * time.Second}
-	ws := &workspace{Dir: tmp}
-	fakeEnv := []string{
-		fakeBDModeEnv + "=assert-no-dolt-overrides",
-		fakeBDParentPIDEnv + "=" + strconv.Itoa(os.Getpid()),
-	}
-	got := runBD(context.Background(), cfg, ws, job{
+	cfg := config{BDPath: filepath.Join(t.TempDir(), "bd")}
+	ws := &workspace{Dir: t.TempDir()}
+	j := job{
 		Kind: "env",
 		Argv: []string{"status"},
-		Env:  fakeEnv,
-	})
-	if got.Err != "" {
-		t.Fatalf("runBD inherited denied env: err=%q stderr=%q", got.Err, got.StderrTail)
+		Env: []string{
+			"BEADS_REPRO_TIMEOUTS_CONTROLLED=one",
+			"BEADS_REPRO_TIMEOUTS_CONTROLLED_SECOND=two",
+		},
+		Sh: "printf test",
 	}
-	if got.StderrTail != fakeBDSuccess {
-		t.Fatalf("runBD fake receipt = %q, want %q", got.StderrTail, fakeBDSuccess)
+	shellPath, err := exec.LookPath("sh")
+	if err != nil {
+		t.Fatalf("find shell: %v", err)
 	}
-	if got := runShell(context.Background(), cfg, ws, job{Kind: "env", Sh: noDoltOverrideEnvScript()}); got.Err != "" {
-		t.Fatalf("runShell inherited denied env: err=%q stderr=%q", got.Err, got.StderrTail)
-	}
-}
 
-func TestNativeBDHelperRejectsWrongParent(t *testing.T) {
-	bd := writeNativeBDTestExecutable(t, t.TempDir())
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-	cmd := exec.CommandContext(ctx, bd, "-test.run=^$")
-	cmd.WaitDelay = time.Second
-	cmd.Env = subprocessEnv(
-		fakeBDModeEnv+"=assert-no-dolt-overrides",
-		fakeBDParentPIDEnv+"=0",
-	)
+	tests := []struct {
+		name       string
+		build      func(context.Context, config, *workspace, job) *exec.Cmd
+		wantPath   string
+		wantArgs   []string
+		wantSuffix []string
+	}{
+		{
+			name:       "bd",
+			build:      newBDCommand,
+			wantPath:   cfg.BDPath,
+			wantArgs:   []string{cfg.BDPath, "status"},
+			wantSuffix: append([]string{"BD_NON_INTERACTIVE=1"}, j.Env...),
+		},
+		{
+			name:     "shell",
+			build:    newShellCommand,
+			wantPath: shellPath,
+			wantArgs: []string{"sh", "-c", j.Sh},
+			wantSuffix: append([]string{
+				"BD_NON_INTERACTIVE=1",
+				"BD_BIN=" + cfg.BDPath,
+			}, j.Env...),
+		},
+	}
 
-	output, err := cmd.CombinedOutput()
-	if ctx.Err() != nil {
-		t.Fatalf("wrong-parent fake bd did not terminate promptly: %v", ctx.Err())
-	}
-	if err == nil {
-		t.Fatalf("wrong-parent fake bd succeeded: %s", output)
-	}
-	if !strings.Contains(string(output), "fake bd parent identity mismatch") {
-		t.Fatalf("wrong-parent output = %q", output)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := tt.build(context.Background(), cfg, ws, j)
+			if cmd.Path != tt.wantPath {
+				t.Fatalf("Path = %q, want %q", cmd.Path, tt.wantPath)
+			}
+			if !slices.Equal(cmd.Args, tt.wantArgs) {
+				t.Fatalf("Args = %q, want %q", cmd.Args, tt.wantArgs)
+			}
+			if cmd.Dir != ws.Dir {
+				t.Fatalf("Dir = %q, want %q", cmd.Dir, ws.Dir)
+			}
+			if len(cmd.Env) < len(tt.wantSuffix) || !slices.Equal(cmd.Env[len(cmd.Env)-len(tt.wantSuffix):], tt.wantSuffix) {
+				t.Fatalf("Env suffix = %q, want %q", cmd.Env, tt.wantSuffix)
+			}
+			if !slices.Contains(cmd.Env, allowedAmbient) {
+				t.Fatalf("Env dropped allowed ambient variable %q", allowedAmbient)
+			}
+			for _, key := range subprocessEnvDenylist {
+				for _, entry := range cmd.Env {
+					gotKey, _, _ := strings.Cut(entry, "=")
+					if gotKey == key {
+						t.Fatalf("Env retained ambient denied override %q", entry)
+					}
+				}
+			}
+		})
 	}
 }
 
@@ -255,25 +240,6 @@ func nativeBDExecutableName() string {
 		return "bd.exe"
 	}
 	return "bd"
-}
-
-func noDoltOverrideEnvScript() string {
-	var b strings.Builder
-	b.WriteString("for key in")
-	for _, key := range subprocessEnvDenylist {
-		b.WriteByte(' ')
-		b.WriteString(key)
-	}
-	b.WriteString(`; do
-	eval "value=\${$key:-}"
-	if [ -n "$value" ]; then
-		echo "$key inherited: $value" >&2
-		exit 42
-	fi
-done
-exit 0
-`)
-	return b.String()
 }
 
 func TestScenarioNamesAllIncludesEveryAdvertisedScenario(t *testing.T) {


### PR DESCRIPTION
## What

- extract the exact `runBD` and `runShell` command construction into two private builders
- test both builders' executable, arguments, working directory, and environment directly
- remove the self-reexec fixture, its parent-identity protocol, and two contention-sensitive child processes

The builders remain on the production execution path. `runBD` and `runShell` still own the same timeout, process execution, latency measurement, stderr capture, and result classification.

## Why

`TestBenchmarkSubprocessesStripDoltEnvOverrides` launched two children only to observe the `exec.Cmd.Env` values that this package had just constructed. Under a full-suite load, one child exceeded the test-only five-second command timeout and was killed even though the environment-denylist behavior was correct.

The owned contract exists at the command-construction handoff. Testing it there removes the scheduler/process-startup failure mode without increasing a timeout or weakening the assertion.

## Preserved contract

For both benchmark subprocess paths, the test now proves:

- every ambient key in `subprocessEnvDenylist` is absent
- an allowed ambient variable survives
- `BD_NON_INTERACTIVE=1` remains
- controlled `job.Env` entries survive in their original order
- shell jobs retain `BD_BIN=<cfg.BDPath>`
- executable, arguments, and working directory remain unchanged

Production benchmark defaults and execution behavior are unchanged.

## Evidence

- test body: 4.42s and two child processes -> below Go's 0.01s timer resolution and zero child processes
- focused stress: 100 repetitions passed in 4.394s package time
- affected package: passed in 8.719s
- canonical `make test`: passed; `cmd/bd` 572.267s, changed package 8.708s
- `golangci-lint run ./...`: 0 issues
- `git diff --check`: clean
- two independent Sol reviews: final PASS / PASS

The test-architecture review found one major before final approval: allowed ambient variables were not asserted. The test now includes an allowed sentinel, and a temporary mutation that discarded ambient variables failed both builder cases before production code was restored.

Bead: `bd-l7i27`

_codex-unknown-model-unknown-reasoning on behalf of CI Bot_
