### PR TITLE
test(doltutil): make close timeout test event-driven

### DIFF
--- a/internal/storage/doltutil/close.go
+++ b/internal/storage/doltutil/close.go
@@ -14,6 +14,13 @@ const CloseTimeout = 5 * time.Second
 // CloseWithTimeout runs a close function with a timeout to prevent indefinite hangs.
 // Returns an error if the close times out or if the close function returns an error.
 func CloseWithTimeout(name string, closeFn func() error) error {
+	timer := time.NewTimer(CloseTimeout)
+	defer timer.Stop()
+
+	return closeWithDeadline(name, closeFn, timer.C)
+}
+
+func closeWithDeadline(name string, closeFn func() error, deadline <-chan time.Time) error {
 	done := make(chan error, 1)
 	go func() {
 		done <- closeFn()
@@ -22,7 +29,7 @@ func CloseWithTimeout(name string, closeFn func() error) error {
 	select {
 	case err := <-done:
 		return err
-	case <-time.After(CloseTimeout):
+	case <-deadline:
 		// Close is hanging - log and continue rather than blocking forever
 		return fmt.Errorf("%s close timed out after %v", name, CloseTimeout)
 	}

--- a/internal/storage/doltutil/close_test.go
+++ b/internal/storage/doltutil/close_test.go
@@ -2,7 +2,7 @@ package doltutil
 
 import (
 	"errors"
-	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -27,18 +27,38 @@ func TestCloseWithTimeout_Error(t *testing.T) {
 }
 
 func TestCloseWithTimeout_Timeout(t *testing.T) {
-	err := CloseWithTimeout("slow-db", func() error {
-		time.Sleep(CloseTimeout + time.Second)
-		return nil
+	deadline := make(chan time.Time)
+	releaseClose := make(chan struct{})
+	closeExited := make(chan struct{})
+	closeStarted := make(chan struct{})
+	var closeCalls atomic.Int32
+
+	result := make(chan error, 1)
+	go func() {
+		result <- closeWithDeadline("slow-db", func() error {
+			closeCalls.Add(1)
+			close(closeStarted)
+			<-releaseClose
+			close(closeExited)
+			return nil
+		}, deadline)
+	}()
+
+	<-closeStarted
+	t.Cleanup(func() {
+		close(releaseClose)
+		<-closeExited
 	})
+	deadline <- time.Now()
+	err := <-result
 	if err == nil {
 		t.Fatal("CloseWithTimeout() should return error on timeout")
 	}
-	if !strings.Contains(err.Error(), "timed out") {
-		t.Errorf("error should mention timeout, got: %v", err)
+	if got, want := err.Error(), "slow-db close timed out after 5s"; got != want {
+		t.Errorf("CloseWithTimeout() error = %q, want %q", got, want)
 	}
-	if !strings.Contains(err.Error(), "slow-db") {
-		t.Errorf("error should mention resource name, got: %v", err)
+	if got, want := closeCalls.Load(), int32(1); got != want {
+		t.Errorf("close function calls = %d, want %d", got, want)
 	}
 }
 


### PR DESCRIPTION
## What

Keep `CloseWithTimeout` on its real five-second production timer, but move the
two-event race into a private helper that accepts the timer's receive channel.
The timeout test can now drive that event directly and cleanly release the
intentionally blocked close goroutine.

## Why

`TestCloseWithTimeout_Timeout` previously paid the full production timeout on
every run by sleeping for six seconds. Persistence, wall-clock accuracy, and
process behavior are not part of this package-level contract; the observable
contract is which of the close result or deadline event wins.

This is tracked by `bd-c3qkw` and follows the edge-selection policy in
`engdocs/TESTING.md`.

## Behavior preserved

- `CloseWithTimeout(name, closeFn)` remains the exported entry point.
- `CloseTimeout` remains exactly five seconds.
- Production still uses a real timer and keeps the original buffered-result
  channel and `select` behavior.
- Close errors retain their identity.
- Timeout errors retain the resource name and fixed timeout budget.
- Production still returns on timeout without waiting for or cancelling the
  close function.

## Measurement

| Forced-uncached workload | Before | After |
| --- | ---: | ---: |
| `^TestCloseWithTimeout` package time | 5.013s | 0.009s |

That removes about 99.8% of the package test execution time for this workload.
The full affected package now reports 0.023s. The focused test also passed 100
normal repetitions and 1,000 race-enabled repetitions.

## Verification

- TDD RED: timeout test failed to compile with `undefined: closeWithDeadline`
- Focused and full `internal/storage/doltutil` tests
- Race-enabled repeated timeout test
- One final `make test` (all packages pass; 39.1% total coverage)
- Repository pre-commit lint: `0 issues`
- `go vet ./internal/storage/doltutil`
- `git diff --check`

Two independent Sol reviewers evaluated blocker/major issues. One found that
the initial test cleanup could be skipped by `t.Fatal`; cleanup was moved to
`t.Cleanup`, and both reviewers passed the final byte-identical diff with no
remaining blocker or major.

No `engdocs/TESTING.md` change is included: the current canonical guide already
requires event-driven tests for incidental timing and permits real time only
when time itself is the contract.
