### PR TITLE
refactor(dbproxy): inject accept retry timer seam for tests

### DIFF
--- a/internal/storage/dbproxy/proxy/control.go
+++ b/internal/storage/dbproxy/proxy/control.go
@@ -77,6 +77,10 @@ func (s *controlServer) Close() error {
 // path may still be perfectly healthy, and a proxy that stops answering
 // identity probes merely degrades adoption to the caller's poll/retry path.
 func (s *controlServer) acceptLoop() {
+	s.acceptLoopWithAfter(time.After)
+}
+
+func (s *controlServer) acceptLoopWithAfter(after func(time.Duration) <-chan time.Time) {
 	defer close(s.done)
 	consecutiveErrors := 0
 	delay := controlAcceptRetryDelay
@@ -94,7 +98,7 @@ func (s *controlServer) acceptLoop() {
 			select {
 			case <-s.closing:
 				return
-			case <-time.After(delay):
+			case <-after(delay):
 			}
 			if delay *= 2; delay > controlAcceptRetryMax {
 				delay = controlAcceptRetryMax

--- a/internal/storage/dbproxy/proxy/control_test.go
+++ b/internal/storage/dbproxy/proxy/control_test.go
@@ -133,29 +133,57 @@ func TestControl_CapsConcurrentHandshakes(t *testing.T) {
 // control server: the data path may still be healthy, and losing control only
 // degrades adoption to the caller's poll/retry path.
 func TestControl_AcceptLoopSurvivesPersistentErrors(t *testing.T) {
-	listener := &failingListener{err: errors.New("transient accept failure"), failures: 5}
+	listener := &failingListener{err: errors.New("transient accept failure"), failures: 11}
 	control := &controlServer{
 		listener: listener,
 		done:     make(chan struct{}),
 		closing:  make(chan struct{}),
 		slots:    make(chan struct{}, maxConcurrentIdentRequests),
 	}
-	go control.acceptLoop()
+	immediately := make(chan time.Time)
+	close(immediately)
+	recorder := &acceptRetryRecorder{afterResult: immediately}
+	go control.acceptLoopWithAfter(recorder.after)
 
 	select {
 	case <-control.done:
-	case <-time.After(10 * time.Second):
+	case <-time.After(time.Second):
 		t.Fatal("control accept loop did not exit after the listener closed")
 	}
 	assert.Equal(t, listener.failures+1, listener.accepts,
 		"loop must retry through every transient failure until the listener reports closed")
+	assert.ErrorIs(t, listener.finalErr, net.ErrClosed)
 	assert.False(t, listener.closed, "accept failures must not close the control listener")
+	assert.Equal(t, []time.Duration{
+		10 * time.Millisecond,
+		20 * time.Millisecond,
+		40 * time.Millisecond,
+		80 * time.Millisecond,
+		160 * time.Millisecond,
+		320 * time.Millisecond,
+		640 * time.Millisecond,
+		1280 * time.Millisecond,
+		2560 * time.Millisecond,
+		5 * time.Second,
+		5 * time.Second,
+	}, recorder.delays)
+}
+
+type acceptRetryRecorder struct {
+	afterResult <-chan time.Time
+	delays      []time.Duration
+}
+
+func (r *acceptRetryRecorder) after(delay time.Duration) <-chan time.Time {
+	r.delays = append(r.delays, delay)
+	return r.afterResult
 }
 
 type failingListener struct {
 	err      error
 	failures int
 	accepts  int
+	finalErr error
 	closed   bool
 }
 
@@ -164,7 +192,8 @@ func (l *failingListener) Accept() (net.Conn, error) {
 	if l.accepts <= l.failures {
 		return nil, l.err
 	}
-	return nil, net.ErrClosed
+	l.finalErr = net.ErrClosed
+	return nil, l.finalErr
 }
 
 func (l *failingListener) Close() error {


### PR DESCRIPTION
## What

Keep `controlServer.acceptLoop` as the production entry point, but delegate its
existing loop to a private helper that accepts the `time.After` function. The
persistent-error test supplies a pre-closed timer channel and records the full
capped retry schedule instead of waiting for wall-clock time.

This is a two-file, private refactor. It adds no public API or configuration.

## Why

`TestControl_AcceptLoopSurvivesPersistentErrors` previously paid five real
backoff delays—10 + 20 + 40 + 80 + 160 ms—on every run. Wall-clock passage was
not the contract; the requested retry schedule and loop behavior were.

The revised test checks eleven delays, including the transition to and repeated
use of the 5-second cap. It also retains the proofs that transient accept errors
do not close the listener and that `net.ErrClosed` terminates the loop.

Bead: `bd-pccmh`

## Behavior preserved

- Production still calls `time.After`.
- Retry constants, exponential growth, and the 5-second cap are unchanged.
- Error logging, successful-accept reset behavior, and close/done semantics are unchanged.
- Existing real-listener identity, authentication, malformed-request, concurrency,
  and shutdown tests still exercise the production wrapper.

## Measured impact

| Workload | Before | After |
|---|---:|---:|
| Focused test, five uncached repetitions | 0.31 s each | 0.00 s each |
| Focused test, 100 repetitions | — | 0.039 s total |
| Focused test under race, 100 repetitions | — | 1.151 s total |

The focused reduction is greater than 96.8% and at least 31× at Go's 0.01-second
JSON reporting bound. Whole-package timing is dominated by unrelated lifecycle
tests, so the repeated focused measurement is the performance acceptance signal.

## Verification

- Focused RED: compile failure on the intentionally missing private helper
- Focused GREEN: pass
- Five-run uncached timing: pass, all reported `0.00 s`
- Focused `-count=100`: pass
- Focused `-race -count=100`: pass
- `./scripts/test.sh -count=1 ./internal/storage/dbproxy/proxy`: pass
- `go vet ./internal/storage/dbproxy/proxy`: pass
- `golangci-lint run ./internal/storage/dbproxy/proxy/...`: pass, 0 issues
- `git diff --check`: pass
- `make test`: pass, 39.1% aggregate coverage
- Two independent Sol blocker/major reviews: PASS / PASS

## Prior art

The exact `accept loop retry` preflight found no open PR. A broader search
matched #5207, but that PR changes only `internal/storage/embeddeddolt` peer-auth
files and has no code or behavior overlap with this dbproxy timer seam.

_codex-unknown-model-unknown-reasoning on behalf of CI Bot_
