### PR TITLE
ci: release artifacts before policy and lint checks

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,15 +62,6 @@ jobs:
         with:
           go-version-file: 'go.mod'
 
-      - name: Install golangci-lint
-        run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.10.1
-
-      - name: Run policy checks
-        run: make ci-pr-policy
-
-      - name: Run lint checks
-        run: make ci-pr-lint
-
       - name: Build reusable Linux artifacts
         run: |
           set -euo pipefail

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -28,15 +28,6 @@ jobs:
         with:
           go-version-file: 'go.mod'
 
-      - name: Install golangci-lint
-        run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.10.1
-
-      - name: Run policy checks
-        run: make ci-pr-policy
-
-      - name: Run lint checks
-        run: make ci-pr-lint
-
       - name: Build reusable Linux artifacts
         run: |
           set -euo pipefail

--- a/scripts/ci_workflow_test.go
+++ b/scripts/ci_workflow_test.go
@@ -1,0 +1,155 @@
+package scripts_test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestCIWorkflowArtifactOwnership(t *testing.T) {
+	for _, workflowName := range []string{"pr.yml", "main.yml"} {
+		t.Run(workflowName, func(t *testing.T) {
+			workflow := readCIWorkflow(t, workflowName)
+
+			for _, forbidden := range []string{
+				"golangci-lint",
+				"make ci-pr-policy",
+				"make ci-pr-lint",
+			} {
+				for _, step := range workflow.job(t, "build-artifacts").Steps {
+					if strings.Contains(step.Run, forbidden) {
+						t.Errorf("build-artifacts runs %q in step %q", forbidden, step.Name)
+					}
+				}
+			}
+
+			assertJobRunsExactly(t, workflow.job(t, "pr-policy-wrapper"), "make ci-pr-policy")
+			assertJobRunsExactly(t, workflow.job(t, "pr-lint-wrapper"), "make ci-pr-lint")
+		})
+	}
+}
+
+func TestPRCIGateRequiresPolicyAndLintWrappers(t *testing.T) {
+	gate := readCIWorkflow(t, "pr.yml").job(t, "ci-gate")
+	gateEnv := gate.step(t, "Evaluate CI gate").Env
+
+	for _, job := range []string{"pr-policy-wrapper", "pr-lint-wrapper"} {
+		if !contains(gate.Needs, job) {
+			t.Errorf("ci-gate needs %q: %v", job, gate.Needs)
+		}
+	}
+
+	for key, want := range map[string]string{
+		"PR_POLICY_WRAPPER": "${{ needs.pr-policy-wrapper.result }}",
+		"PR_LINT_WRAPPER":   "${{ needs.pr-lint-wrapper.result }}",
+	} {
+		if got := gateEnv[key]; got != want {
+			t.Errorf("ci-gate env %s = %q, want %q", key, got, want)
+		}
+	}
+
+	for _, required := range []string{"PR_POLICY_WRAPPER", "PR_LINT_WRAPPER"} {
+		if !strings.Contains(gateEnv["CI_GATE_REQUIRED"], required) {
+			t.Errorf("ci-gate CI_GATE_REQUIRED does not include %q", required)
+		}
+	}
+}
+
+type ciWorkflow struct {
+	Jobs map[string]ciWorkflowJob `yaml:"jobs"`
+}
+
+type ciWorkflowJob struct {
+	Needs ciWorkflowStringList `yaml:"needs"`
+	Steps []ciWorkflowStep     `yaml:"steps"`
+}
+
+type ciWorkflowStep struct {
+	Name string            `yaml:"name"`
+	Run  string            `yaml:"run"`
+	Env  map[string]string `yaml:"env"`
+}
+
+type ciWorkflowStringList []string
+
+func (items *ciWorkflowStringList) UnmarshalYAML(node *yaml.Node) error {
+	switch node.Kind {
+	case yaml.ScalarNode:
+		*items = []string{node.Value}
+		return nil
+	case yaml.SequenceNode:
+		values := make([]string, 0, len(node.Content))
+		for _, item := range node.Content {
+			if item.Kind != yaml.ScalarNode {
+				return fmt.Errorf("needs item must be scalar, got YAML kind %d", item.Kind)
+			}
+			values = append(values, item.Value)
+		}
+		*items = values
+		return nil
+	default:
+		return fmt.Errorf("needs must be scalar or sequence, got YAML kind %d", node.Kind)
+	}
+}
+
+func readCIWorkflow(t *testing.T, name string) ciWorkflow {
+	t.Helper()
+
+	path := filepath.Join(sourceRepoRoot(t), ".github", "workflows", name)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var workflow ciWorkflow
+	if err := yaml.Unmarshal(data, &workflow); err != nil {
+		t.Fatalf("parse %s: %v", path, err)
+	}
+	return workflow
+}
+
+func (workflow ciWorkflow) job(t *testing.T, name string) ciWorkflowJob {
+	t.Helper()
+
+	job, ok := workflow.Jobs[name]
+	if !ok {
+		t.Fatalf("workflow has no %q job", name)
+	}
+	return job
+}
+
+func (job ciWorkflowJob) step(t *testing.T, name string) ciWorkflowStep {
+	t.Helper()
+
+	for _, step := range job.Steps {
+		if step.Name == name {
+			return step
+		}
+	}
+	t.Fatalf("job has no %q step", name)
+	return ciWorkflowStep{}
+}
+
+func assertJobRunsExactly(t *testing.T, job ciWorkflowJob, want string) {
+	t.Helper()
+
+	for _, step := range job.Steps {
+		if strings.TrimSpace(step.Run) == want {
+			return
+		}
+	}
+	t.Errorf("job has no step that runs exactly %q", want)
+}
+
+func contains(items []string, want string) bool {
+	for _, item := range items {
+		if item == want {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## What

Make the PR and Main `build-artifacts` jobs build, checksum, and upload reusable binaries immediately. Policy and lint remain unchanged in their dedicated wrapper jobs, and the required PR aggregate gate still owns both results.

Add a structured workflow contract test so artifact production cannot silently reacquire policy/lint work and so the dedicated owners cannot disappear from the PR gate.

## Why

Artifact production currently serializes behind duplicate copies of checks that already run in parallel as required jobs. Every artifact consumer—including PR Core—waits for that duplicated work before it can start.

Three recent successful PR runs establish the old baseline:

| Run | Build Artifacts | Duplicate lint install + policy + lint | Final warmed binary build |
|---|---:|---:|---:|
| 30728109499 | 312s | 276s | 12s |
| 30726135971 | 400s | 360s | 14s |
| 30723660897 | 407s | 369s | 15s |

The first live run of this PR completed `Build Artifacts` in 192s. The now-cold binary build took 170s, so some of the projected saving was cache warming rather than removable work. The empirical critical-path improvement is still 120–215s (2.0–3.6 minutes) against those baselines, while 5–6 runner-minutes of duplicate execution are removed. Tracked as `bd-4b1dt`.

## Coverage ownership

- `pr-policy-wrapper` still runs `make ci-pr-policy` in both workflows.
- `pr-lint-wrapper` still runs `make ci-pr-lint` in both workflows.
- PR `ci-gate` still needs both jobs, exports both results, and lists both in `CI_GATE_REQUIRED`, including merge-queue runs.
- Artifact build commands, contents, checksums, manifest, upload name, and consumer dependencies are unchanged.

## Verification

- Red proof against the previous topology: `GOTOOLCHAIN=go1.26.5 ./scripts/test.sh -run '^TestCIWorkflowArtifactOwnership$' ./scripts` failed on all three forbidden actions in both artifact producers.
- `GOTOOLCHAIN=go1.26.5 ./scripts/test.sh -run '^(TestCIWorkflowArtifactOwnership|TestPRCIGateRequiresPolicyAndLintWrappers)$' ./scripts`
- `GOTOOLCHAIN=go1.26.5 ./scripts/test.sh ./scripts`
- `GOTOOLCHAIN=go1.26.5 go vet ./scripts`
- `actionlint .github/workflows/pr.yml .github/workflows/main.yml`
- Pre-commit golangci-lint: `0 issues`
- Two independent Sol reviews: no blocker or major findings.
- `make test`: every Go package passed; final coverage summarization encountered the pre-existing shared `/tmp/beads.coverage.out` writer collision, now tracked as `bd-qg9qc`. The malformed profile was outside this diff (`cmd/bd/worktree_cmd.go`), after `cmd/bd` and all other packages had passed.
- Live PR run 30731012441: `Build Artifacts` passed in 192s; dedicated policy and lint owners continued running independently.

_codex-unknown-model-unknown-reasoning on behalf of CI Bot_
