### PR TITLE
fix(doctor): one filter for both uncommitted-changes checks (#5260)

### DIFF
--- a/cmd/bd/doctor/dolt.go
+++ b/cmd/bd/doctor/dolt.go
@@ -418,10 +418,68 @@ func isIgnoredTable(tableName string) bool {
 	return strings.HasPrefix(tableName, "wisp_")
 }
 
-// isWispTable returns true if the table name refers to a wisp (ephemeral) table.
-// Deprecated: use isIgnoredTable for broader coverage.
-func isWispTable(tableName string) bool {
-	return tableName == "wisps" || strings.HasPrefix(tableName, "wisp_")
+// doltStatusRow is one row of the dolt_status system table.
+type doltStatusRow struct {
+	table  string
+	staged bool
+	status string
+}
+
+// scanDoltStatus reads a `SELECT table_name, staged, status FROM dolt_status`
+// result set. Rows that fail to scan are skipped rather than aborting the
+// health check: a doctor check reporting what it could read beats one that
+// reports nothing.
+func scanDoltStatus(rows *sql.Rows) ([]doltStatusRow, error) {
+	var out []doltStatusRow
+	for rows.Next() {
+		var r doltStatusRow
+		if err := rows.Scan(&r.table, &r.staged, &r.status); err != nil {
+			continue
+		}
+		out = append(out, r)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// describeUncommittedTables drops dolt_ignore'd tables from a dolt_status scan
+// and renders the rest as human-readable "table: status (staged)" strings.
+//
+// Every uncommitted-changes check in doctor must funnel through this function.
+// Two of them previously kept private skip-lists that drifted apart — "Dolt
+// Locks" excluded only wisp tables while "Dolt Status" excluded the full
+// ignored set — so the same clean store was clean by one check and dirty by
+// the other, permanently. One filter, one source of truth.
+//
+// The filter is a static name list rather than a read of the store's own
+// dolt_ignore rows, which is worth explaining because the reverse looks
+// obvious. dolt_ignore does not mean "do not report changes to this table".
+// Per doltdb.ShouldIgnoreDelta, "only newly added or dropped tables are
+// matched against the patterns. Changes to already tracked tables are always
+// included." Every table listed here is tracked, so Dolt reports it dirty
+// forever by design and dolt_ignore has no say in it. Deriving the skip-set
+// from that table would therefore borrow a mechanism that answers a different
+// question, and would additionally require reimplementing Dolt's pattern
+// syntax — doltdb.compilePattern treats '*' and '?' and '%' as wildcards, '_'
+// as a literal, and matches case-sensitively, none of which is SQL LIKE.
+//
+// Silencing these tables is a beads decision about which tables are
+// bookkeeping, so it belongs in beads code. See isIgnoredTable.
+func describeUncommittedTables(rows []doltStatusRow) []string {
+	var changes []string
+	for _, r := range rows {
+		if isIgnoredTable(r.table) {
+			continue
+		}
+		mark := ""
+		if r.staged {
+			mark = " (staged)"
+		}
+		changes = append(changes, fmt.Sprintf("%s: %s%s", r.table, r.status, mark))
+	}
+	return changes
 }
 
 // checkStatusWithDB reports uncommitted changes in Dolt using an existing connection.
@@ -442,26 +500,8 @@ func checkStatusWithDB(conn *doltConn) DoctorCheck {
 	}
 	defer rows.Close()
 
-	var changes []string
-	for rows.Next() {
-		var tableName string
-		var staged bool
-		var status string
-		if err := rows.Scan(&tableName, &staged, &status); err != nil {
-			continue
-		}
-		// Skip dolt_ignore'd tables — they are ephemeral and expected to have
-		// uncommitted changes.
-		if isIgnoredTable(tableName) {
-			continue
-		}
-		stageMark := ""
-		if staged {
-			stageMark = "(staged)"
-		}
-		changes = append(changes, fmt.Sprintf("%s: %s %s", tableName, status, stageMark))
-	}
-	if err := rows.Err(); err != nil {
+	scanned, err := scanDoltStatus(rows)
+	if err != nil {
 		return DoctorCheck{
 			Name:     "Dolt Status",
 			Status:   StatusWarning,
@@ -470,6 +510,7 @@ func checkStatusWithDB(conn *doltConn) DoctorCheck {
 			Category: CategoryData,
 		}
 	}
+	changes := describeUncommittedTables(scanned)
 
 	if len(changes) > 0 {
 		return DoctorCheck{

--- a/cmd/bd/doctor/dolt_test.go
+++ b/cmd/bd/doctor/dolt_test.go
@@ -152,7 +152,7 @@ func TestServerMode_NoLockAcquired(t *testing.T) {
 
 }
 
-func TestIsWispTable(t *testing.T) {
+func TestIsIgnoredTable(t *testing.T) {
 	tests := []struct {
 		name     string
 		table    string
@@ -163,8 +163,11 @@ func TestIsWispTable(t *testing.T) {
 		{"wisp_labels", "wisp_labels", true},
 		{"wisp_dependencies", "wisp_dependencies", true},
 		{"wisp_comments", "wisp_comments", true},
+		{"leases", "leases", true},
+		{"local_metadata", "local_metadata", true},
+		{"repo_mtimes", "repo_mtimes", true},
+		{"events", "events", true},
 		{"issues table", "issues", false},
-		{"events table", "events", false},
 		{"labels table", "labels", false},
 		{"dependencies table", "dependencies", false},
 		{"config table", "config", false},
@@ -174,9 +177,73 @@ func TestIsWispTable(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := isWispTable(tt.table); got != tt.expected {
-				t.Errorf("isWispTable(%q) = %v, want %v", tt.table, got, tt.expected)
+			if got := isIgnoredTable(tt.table); got != tt.expected {
+				t.Errorf("isIgnoredTable(%q) = %v, want %v", tt.table, got, tt.expected)
 			}
 		})
+	}
+}
+
+// TestDescribeUncommittedTables_FiltersIgnored is the regression test for the
+// skip-list drift (#5260). Both uncommitted-changes checks — "Dolt Status" and
+// "Dolt Locks" — now share this one filter, so a table that is benign for one
+// cannot be a permanent warning on the other.
+func TestDescribeUncommittedTables_FiltersIgnored(t *testing.T) {
+	rows := []doltStatusRow{
+		{table: "wisps", status: "modified"},
+		{table: "wisp_events", status: "modified"},
+		{table: "leases", status: "modified"},
+		{table: "local_metadata", status: "modified"},
+		{table: "repo_mtimes", status: "modified"},
+		{table: "events", status: "modified"},
+		{table: "issues", status: "modified", staged: true},
+		{table: "labels", status: "modified"},
+	}
+
+	got := describeUncommittedTables(rows)
+
+	want := []string{"issues: modified (staged)", "labels: modified"}
+	if len(got) != len(want) {
+		t.Fatalf("describeUncommittedTables() = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("describeUncommittedTables()[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+// TestDescribeUncommittedTables_AllIgnoredIsClean pins the property the bug
+// report turned on: a store whose only dirty tables are dolt_ignore'd must read
+// as clean, not as a warning that can never be cleared.
+func TestDescribeUncommittedTables_AllIgnoredIsClean(t *testing.T) {
+	rows := []doltStatusRow{
+		{table: "wisps", status: "modified"},
+		{table: "wisp_dependencies", status: "new table"},
+		{table: "leases", status: "modified"},
+		{table: "events", status: "modified"},
+	}
+
+	if got := describeUncommittedTables(rows); len(got) != 0 {
+		t.Errorf("describeUncommittedTables() = %v, want empty (all tables are dolt_ignore'd)", got)
+	}
+}
+
+// TestDoltLocksAndDoltStatusShareOneFilter is the anti-drift guard. The two
+// checks previously kept independent skip-lists that diverged; if a future
+// change reintroduces a second private filter, the shared helper stops being
+// the only path and this test is the place that should start failing.
+func TestDoltLocksAndDoltStatusShareOneFilter(t *testing.T) {
+	// Tables that were reported dirty by "Dolt Locks" but not by "Dolt Status"
+	// before #5260, because checkDoltLocks skipped only wisp tables.
+	previouslyDivergent := []string{"leases", "local_metadata", "repo_mtimes", "events"}
+
+	for _, table := range previouslyDivergent {
+		if !isIgnoredTable(table) {
+			t.Errorf("isIgnoredTable(%q) = false; the shared filter must cover every table both checks ignore", table)
+		}
+		if got := describeUncommittedTables([]doltStatusRow{{table: table, status: "modified"}}); len(got) != 0 {
+			t.Errorf("describeUncommittedTables(%q) = %v, want empty", table, got)
+		}
 	}
 }

--- a/cmd/bd/doctor/migration_validation.go
+++ b/cmd/bd/doctor/migration_validation.go
@@ -497,28 +497,12 @@ func checkDoltLocks(beadsDir string) (bool, string, error) {
 	}
 	defer rows.Close()
 
-	var changes []string
-	for rows.Next() {
-		var tableName string
-		var staged bool
-		var status string
-		if err := rows.Scan(&tableName, &staged, &status); err != nil {
-			continue
-		}
-		// Skip wisp tables — they are ephemeral and expected to have
-		// uncommitted changes (covered by dolt_ignore).
-		if isWispTable(tableName) {
-			continue
-		}
-		mark := ""
-		if staged {
-			mark = " (staged)"
-		}
-		changes = append(changes, fmt.Sprintf("%s: %s%s", tableName, status, mark))
-	}
-	if err := rows.Err(); err != nil {
+	// Same filter as the "Dolt Status" check — see describeUncommittedTables.
+	scanned, err := scanDoltStatus(rows)
+	if err != nil {
 		return false, "", fmt.Errorf("row iteration error: %w", err)
 	}
+	changes := describeUncommittedTables(scanned)
 
 	if len(changes) > 0 {
 		return true, strings.Join(changes, ", "), nil


### PR DESCRIPTION
Fixes #5260 (the drift half — see Scope below).

## Why

`bd doctor` has two checks that scan `dolt_status` for uncommitted tables, and each kept its own skip-list:

| check | source | skipped |
|---|---|---|
| **Dolt Status** | `dolt.go` `checkStatusWithDB` | `isIgnoredTable` |
| **Dolt Locks** | `migration_validation.go` `checkDoltLocks` | `isWispTable` |

`isWispTable` is a strict subset — it misses `leases`, `local_metadata`, `repo_mtimes` and `events`. It has been carrying the doc comment *"Deprecated: use `isIgnoredTable` for broader coverage"* for some time; its last caller was simply never moved.

On a healthy store those tables are legitimately dirty, so the same store is **clean by one check and permanently dirty by the other**. The warning is self-fulfilling: it can never clear, on every store, forever. Neither the name "Locks" (it is a working-set-dirty check, not a lock check) nor the suggested fix (`bd vc commit`) helps, because committing them is not what stops them being dirty.

## What

Both checks now go through one scan (`scanDoltStatus`) and one filter (`describeUncommittedTables`), so there is a single skip-set instead of two that can diverge again. `isWispTable` had no other callers and is removed; its test is repointed at `isIgnoredTable`.

Tests: the filter's behaviour is pinned directly (previously it was only reachable through a live Dolt connection), including an explicit anti-drift guard naming the four tables that diverged.

## Why the filter is still a static name list

The report suggests deriving the skip-set from the store's own `dolt_ignore` patterns. That was implemented first and then backed out, because `dolt_ignore` answers a different question:

> `doltdb.ShouldIgnoreDelta`: *"Only newly added or dropped tables are matched against the patterns. Changes to already tracked tables are always included."*

Every table in the skip-set is **tracked**, so `dolt_ignore` has no opinion about it — Dolt reports those tables dirty forever by design. `dolt_ignore` means "don't auto-add this *new* table", not "don't report changes to it".

It would also mean reimplementing `doltdb.compilePattern`, which is not SQL LIKE: `*`, `?` and `%` are wildcards, `_` is a **literal**, and matching is **case-sensitive**. Reaching for a LIKE matcher (as I did) is wrong in three separate ways and silently over-suppresses — it makes `wisp_%` match `wispXfoo`.

Which tables are benign bookkeeping is a beads decision, so it stays in beads code. The reasoning is a comment on `describeUncommittedTables` so it does not get re-litigated.

## Scope

This fixes the drift and the false positive it caused. The report also asks whether the remaining bookkeeping tables (`child_counters`, `labels`, `metadata`, `schema_migrations`, …) should be silenced here or committed by the store instead — that is a durability question (are those tables meant to be versioned?) and is deliberately **not** decided here. With this change, whatever the answer, both checks agree.

Behaviour note: detail formatting is now shared, so "Dolt Status" renders `table: status (staged)` with the single space "Dolt Locks" already used, instead of leaving a trailing space when a table is unstaged.

## Validation

- `go build ./cmd/...` and `go vet ./cmd/bd/doctor/` clean (`CGO_ENABLED=1 -tags gms_pure_go`).
- New and existing filter tests pass.
- Full `./cmd/bd/doctor/` suite: two failures, `TestCheckRepoFingerprint_UsesTargetRepoOutsideCWD` and `TestCheckTestPollution_NoTestIssues_EmptyDB`. **Both reproduce identically on an unmodified checkout of `upstream/main` @ db966433e**, so they are pre-existing and local to this machine (they pass in CI). Tracked locally; flagging in case they are known.
- Cross-vendor review pass (Codex `gpt-5.6-sol`, high reasoning) on the final commit: no findings. Two earlier rounds on earlier revisions produced four findings, all confirmed against the vendored Dolt source and all resolved — three of them by the revert described above.

_claude-opus-5-high on behalf of maphew_
