### PR TITLE
test: replace embedded list process storm

### DIFF
--- a/cmd/bd/list_embedded_test.go
+++ b/cmd/bd/list_embedded_test.go
@@ -3,13 +3,12 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
-	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
-	"sync"
 	"testing"
 	"time"
 
@@ -903,8 +902,8 @@ func seedTestData(t *testing.T, bd, dir string) testSeedData {
 	return s
 }
 
-// TestEmbeddedListConcurrent verifies that 20 concurrent workers can each
-// run 10 creates and 10 lists without data loss, corruption, or errors.
+// TestEmbeddedListConcurrent verifies one simultaneous embedded-Dolt writer
+// and reader complete without corrupting the list snapshot or durable state.
 func TestEmbeddedListConcurrent(t *testing.T) {
 	if os.Getenv("BEADS_TEST_EMBEDDED_DOLT") != "1" {
 		t.Skip("set BEADS_TEST_EMBEDDED_DOLT=1 to run embedded dolt integration tests")
@@ -913,136 +912,82 @@ func TestEmbeddedListConcurrent(t *testing.T) {
 
 	bd := buildEmbeddedBD(t)
 	dir, _, _ := bdInit(t, bd, "--prefix", "cl")
+	seedID := bdCreateSilent(t, bd, dir, "seed")
 
-	const (
-		numWorkers      = 20
-		issuesPerWorker = 10
-	)
+	createCmd := exec.Command(bd, "create", "--silent", "concurrent")
+	createCmd.Dir = dir
+	createCmd.Env = bdEnv(dir)
+	var createStdout, createStderr bytes.Buffer
+	createCmd.Stdout = &createStdout
+	createCmd.Stderr = &createStderr
 
-	type workerResult struct {
-		worker     int
-		createIDs  []string
-		listCounts []int // number of issues returned by each list call
-		err        error
+	listCmd := exec.Command(bd, "list", "--json", "--limit", "0")
+	listCmd.Dir = dir
+	listCmd.Env = bdEnv(dir)
+	var listStdout, listStderr bytes.Buffer
+	listCmd.Stdout = &listStdout
+	listCmd.Stderr = &listStderr
+
+	if err := createCmd.Start(); err != nil {
+		t.Fatalf("start concurrent create: %v", err)
+	}
+	if err := listCmd.Start(); err != nil {
+		_ = createCmd.Wait()
+		t.Fatalf("start concurrent list: %v", err)
+	}
+	createErr := createCmd.Wait()
+	listErr := listCmd.Wait()
+	if createErr != nil {
+		t.Fatalf("concurrent create failed: %v\nstdout:\n%s\nstderr:\n%s", createErr, createStdout.String(), createStderr.String())
+	}
+	if listErr != nil {
+		t.Fatalf("concurrent list failed: %v\nstdout:\n%s\nstderr:\n%s", listErr, listStdout.String(), listStderr.String())
 	}
 
-	results := make([]workerResult, numWorkers)
-	var wg sync.WaitGroup
-	wg.Add(numWorkers)
-
-	for w := 0; w < numWorkers; w++ {
-		go func(worker int) {
-			defer wg.Done()
-			r := workerResult{worker: worker}
-
-			// Interleave creates and lists: create one, list once, repeat.
-			for i := 0; i < issuesPerWorker; i++ {
-				// Create
-				title := fmt.Sprintf("w%d-issue-%d", worker, i)
-				out, err := bdRunWithFlockRetry(t, bd, dir, "create", "--silent", title)
-				if err != nil {
-					r.err = fmt.Errorf("create %d: %v\n%s", i, err, out)
-					results[worker] = r
-					return
-				}
-				id := strings.TrimSpace(string(out))
-				if id == "" {
-					r.err = fmt.Errorf("create %d: empty ID", i)
-					results[worker] = r
-					return
-				}
-				r.createIDs = append(r.createIDs, id)
-
-				// List (JSON for easy parsing)
-				listCmd := exec.Command(bd, "list", "--json", "--limit", "0")
-				listCmd.Dir = dir
-				listCmd.Env = bdEnv(dir)
-				listStdout, listStderr, err := runCommandBuffers(t, listCmd)
-				if err != nil {
-					r.err = fmt.Errorf("list after create %d: %v\nstdout:\n%s\nstderr:\n%s", i, err, listStdout.String(), listStderr.String())
-					results[worker] = r
-					return
-				}
-				// Parse JSON array to count issues
-				s := listStdout.String()
-				start := strings.Index(s, "[")
-				if start < 0 {
-					r.listCounts = append(r.listCounts, 0)
-					continue
-				}
-				var issues []json.RawMessage
-				if jsonErr := json.Unmarshal([]byte(s[start:]), &issues); jsonErr != nil {
-					r.err = fmt.Errorf("list parse after create %d: %v\nstdout:\n%s\nstderr:\n%s", i, jsonErr, s, listStderr.String())
-					results[worker] = r
-					return
-				}
-				r.listCounts = append(r.listCounts, len(issues))
-			}
-
-			results[worker] = r
-		}(w)
+	createdID := strings.TrimSpace(createStdout.String())
+	if createdID == "" {
+		t.Fatalf("concurrent create returned an empty ID\nstderr:\n%s", createStderr.String())
 	}
-	wg.Wait()
 
-	// Collect all created IDs and check for errors.
-	allIDs := make(map[string]bool)
-	var successes int
-	for _, r := range results {
-		if r.err != nil {
-			if !strings.Contains(r.err.Error(), "one writer at a time") {
-				t.Errorf("worker %d failed: %v", r.worker, r.err)
-			}
-			continue
+	listOutput := listStdout.String()
+	start := strings.Index(listOutput, "[")
+	if start < 0 {
+		t.Fatalf("concurrent list returned no JSON array:\n%s", listOutput)
+	}
+	var concurrentIssues []*types.IssueWithCounts
+	if err := json.Unmarshal([]byte(listOutput[start:]), &concurrentIssues); err != nil {
+		t.Fatalf("decode concurrent list JSON: %v\nstdout:\n%s\nstderr:\n%s", err, listOutput, listStderr.String())
+	}
+
+	concurrentIDs := make(map[string]struct{}, len(concurrentIssues))
+	for _, issue := range concurrentIssues {
+		if _, duplicate := concurrentIDs[issue.ID]; duplicate {
+			t.Fatalf("concurrent list returned duplicate ID %q", issue.ID)
 		}
-		successes++
-		for _, id := range r.createIDs {
-			if allIDs[id] {
-				t.Errorf("duplicate ID %q from worker %d", id, r.worker)
-			}
-			allIDs[id] = true
-		}
+		concurrentIDs[issue.ID] = struct{}{}
+	}
+	if _, found := concurrentIDs[seedID]; !found {
+		t.Fatalf("concurrent list did not contain seed ID %q", seedID)
 	}
 
-	if successes == 0 {
-		t.Fatal("all workers failed — expected at least 1 success")
-	}
-	expectedIDs := successes * issuesPerWorker
-	if len(allIDs) != expectedIDs {
-		t.Errorf("expected %d unique IDs from %d successful workers, got %d", expectedIDs, successes, len(allIDs))
-	}
-
-	// Verify list counts were monotonically non-decreasing within each worker
-	// (each worker creates then lists, so count should never decrease).
-	for _, r := range results {
-		if r.err != nil {
-			continue
-		}
-		for i := 1; i < len(r.listCounts); i++ {
-			if r.listCounts[i] < r.listCounts[i-1] {
-				t.Errorf("worker %d: list count decreased from %d to %d between iterations %d and %d",
-					r.worker, r.listCounts[i-1], r.listCounts[i], i-1, i)
-			}
-		}
-	}
-
-	// Final verification: one authoritative list should see all created issues.
 	finalIssues := bdListJSON(t, bd, dir, "--limit", "0")
-	finalIDSet := make(map[string]bool, len(finalIssues))
+	finalIDCounts := make(map[string]int, len(finalIssues))
 	for _, issue := range finalIssues {
-		finalIDSet[issue.ID] = true
+		finalIDCounts[issue.ID]++
 	}
-	var missing int
-	for id := range allIDs {
-		if !finalIDSet[id] {
-			t.Errorf("created ID %s not found in final list", id)
-			missing++
+	for id, count := range finalIDCounts {
+		if count != 1 {
+			t.Fatalf("authoritative list returned ID %q %d times", id, count)
 		}
 	}
-	if missing > 0 {
-		t.Errorf("%d/%d created issues missing from final list (%d total in list)",
-			missing, len(allIDs), len(finalIssues))
+	for _, id := range []string{seedID, createdID} {
+		if finalIDCounts[id] != 1 {
+			t.Fatalf("authoritative list returned ID %q %d times, want once", id, finalIDCounts[id])
+		}
 	}
-
-	t.Logf("concurrency test: %d/%d workers succeeded, %d IDs created, %d in final list",
-		successes, numWorkers, len(allIDs), len(finalIssues))
+	for id := range concurrentIDs {
+		if finalIDCounts[id] == 0 {
+			t.Fatalf("authoritative list omitted concurrent snapshot ID %q", id)
+		}
+	}
 }


### PR DESCRIPTION
## What

Replace TestEmbeddedListConcurrent's 20×10 create/list process storm with one representative real CLI composition test:

1. Initialize and commit a seed issue.
2. Start one create process and one JSON list process before waiting for either.
3. Require both processes to succeed without retries or tolerated lock failures.
4. Validate the concurrent snapshot, then prove the final durable state is unique and complete.

No production code or test double is introduced.

## Why

The old test launched 401 race-instrumented action processes and had a 423.43s median across eight runs. It was also weaker than its size suggested: 19 of 20 workers could fail, writer-lock failures were tolerated, and missing JSON arrays could count as empty results.

Broad multi-process transaction contention is already owned by TestConcurrencyMultiProcess. This test now owns only the distinct CLI writer/reader composition edge.

Refs bd-rg90p.

## Test ownership

| Concern | Owner after this change |
|---|---|
| CLI list filters and JSON wiring | TestEmbeddedList |
| Storage search semantics | Storage conformance |
| Broad multi-process contention | TestConcurrencyMultiProcess |
| Real CLI writer/reader composition | TestEmbeddedListConcurrent |

## Measurements

| Measurement | Before | After |
|---|---:|---:|
| Action processes | 401 | 4 |
| Test wall time | 460.58s observed | 24.03s median |
| Three replacement runs | — | 18.50s, 24.03s, 28.30s |

The measured test work falls by about 7m17s. Based on the observed shard floor, the expected shard-wall saving is roughly 4m51s–5m11s.

## Verification

- Targeted race run: PASS; package 13.862s, wall 64.19s including compile/link.
- Three independent prebuilt-binary runs: PASS; 24.03s median wall.
- Independent Sol review reran the focused race test: PASS in 27.656s.
- go vet -tags=gms_pure_go ./cmd/bd
- Pre-commit golangci-lint: 0 issues.
- Independent review verdict: APPROVE, no blockers or majors.

_Agent: codex-unknown-model-unknown-reasoning on behalf of CI Bot_
