### PR TITLE
test: reuse pristine embedded Dolt fixtures

### DIFF
--- a/internal/storage/embeddeddolt/conformance_test.go
+++ b/internal/storage/embeddeddolt/conformance_test.go
@@ -3,175 +3,17 @@
 package embeddeddolt_test
 
 import (
-	"crypto/sha256"
-	"errors"
-	"fmt"
-	"io"
 	"os"
-	"path/filepath"
 	"testing"
 
 	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/storage/conformance"
-	"github.com/steveyegge/beads/internal/storage/embeddeddolt"
-	"github.com/steveyegge/beads/internal/types"
 )
-
-type pristineConformanceTemplate struct {
-	beadsDir string
-}
 
 func requireEmbeddedDolt(t *testing.T) {
 	t.Helper()
 	if os.Getenv("BEADS_TEST_EMBEDDED_DOLT") != "1" {
 		t.Skip("set BEADS_TEST_EMBEDDED_DOLT=1 to run embedded dolt tests")
-	}
-}
-
-func newPristineConformanceTemplate(t *testing.T) pristineConformanceTemplate {
-	t.Helper()
-	ctx := t.Context()
-	beadsDir := filepath.Join(t.TempDir(), ".beads")
-	store, err := embeddeddolt.Open(ctx, beadsDir, "test", "main")
-	if err != nil {
-		t.Fatalf("open pristine conformance template: %v", err)
-	}
-	if err := store.SetConfig(ctx, "issue_prefix", "test"); err != nil {
-		t.Fatalf("configure pristine conformance template: %v", err)
-	}
-	if err := store.Commit(ctx, "bd init"); err != nil {
-		t.Fatalf("commit pristine conformance template: %v", err)
-	}
-	closeEmbeddedDoltStore(t, store)
-	return pristineConformanceTemplate{beadsDir: beadsDir}
-}
-
-func clonePristineConformanceTemplate(template pristineConformanceTemplate, destination string) error {
-	if err := os.Mkdir(destination, 0o700); err != nil {
-		return fmt.Errorf("reserve clone destination %q: %w", destination, err)
-	}
-	if err := os.CopyFS(destination, os.DirFS(template.beadsDir)); err != nil {
-		return fmt.Errorf("copy pristine conformance template to %q: %w", destination, err)
-	}
-	return nil
-}
-
-func openPristineConformanceClone(t *testing.T, beadsDir string) *embeddeddolt.EmbeddedDoltStore {
-	t.Helper()
-	store, err := embeddeddolt.Open(t.Context(), beadsDir, "test", "main")
-	if err != nil {
-		t.Fatalf("open pristine conformance clone %q: %v", beadsDir, err)
-	}
-	return store
-}
-
-func closeEmbeddedDoltStore(t *testing.T, store *embeddeddolt.EmbeddedDoltStore) {
-	t.Helper()
-	if err := store.Close(); err != nil {
-		t.Fatalf("close embedded Dolt store: %v", err)
-	}
-}
-
-func directoryDigest(t *testing.T, root string) string {
-	t.Helper()
-	digest := sha256.New()
-	err := filepath.WalkDir(root, func(path string, entry os.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
-		relative, err := filepath.Rel(root, path)
-		if err != nil {
-			return err
-		}
-		if _, err := io.WriteString(digest, relative+"\\x00"); err != nil {
-			return err
-		}
-		if entry.IsDir() {
-			return nil
-		}
-		contents, err := os.ReadFile(path)
-		if err != nil {
-			return err
-		}
-		if _, err := digest.Write(contents); err != nil {
-			return err
-		}
-		return nil
-	})
-	if err != nil {
-		t.Fatalf("digest %q: %v", root, err)
-	}
-	return fmt.Sprintf("%x", digest.Sum(nil))
-}
-
-func TestPristineConformanceTemplateClonesAreIndependent(t *testing.T) {
-	requireEmbeddedDolt(t)
-
-	template := newPristineConformanceTemplate(t)
-	before := directoryDigest(t, template.beadsDir)
-
-	cloneAPath := filepath.Join(t.TempDir(), ".beads")
-	if err := clonePristineConformanceTemplate(template, cloneAPath); err != nil {
-		t.Fatalf("clone A: %v", err)
-	}
-	cloneBPath := filepath.Join(t.TempDir(), ".beads")
-	if err := clonePristineConformanceTemplate(template, cloneBPath); err != nil {
-		t.Fatalf("clone B: %v", err)
-	}
-	if err := clonePristineConformanceTemplate(template, cloneAPath); err == nil {
-		t.Fatal("clone into an existing destination succeeded")
-	}
-
-	cloneA := openPristineConformanceClone(t, cloneAPath)
-	if err := cloneA.CreateIssue(t.Context(), &types.Issue{
-		ID:        "test-1",
-		Title:     "only clone A has this issue",
-		Status:    types.StatusOpen,
-		IssueType: types.TypeTask,
-	}, "test"); err != nil {
-		t.Fatalf("create in clone A: %v", err)
-	}
-	if err := cloneA.Commit(t.Context(), "mutate clone A"); err != nil {
-		t.Fatalf("commit clone A: %v", err)
-	}
-	closeEmbeddedDoltStore(t, cloneA)
-
-	if got := directoryDigest(t, template.beadsDir); got != before {
-		t.Fatalf("template digest changed after clone A mutation: got %s, want %s", got, before)
-	}
-
-	cloneB := openPristineConformanceClone(t, cloneBPath)
-	assertEmptyPristineConformanceStore(t, cloneB, "clone B")
-	closeEmbeddedDoltStore(t, cloneB)
-
-	templateStore := openPristineConformanceClone(t, template.beadsDir)
-	assertEmptyPristineConformanceStore(t, templateStore, "template")
-	closeEmbeddedDoltStore(t, templateStore)
-	if got := directoryDigest(t, template.beadsDir); got != before {
-		t.Fatalf("template digest changed after reopen: got %s, want %s", got, before)
-	}
-
-	cloneA = openPristineConformanceClone(t, cloneAPath)
-	if _, err := cloneA.GetIssue(t.Context(), "test-1"); err != nil {
-		t.Fatalf("reopened clone A GetIssue(test-1): %v", err)
-	}
-	closeEmbeddedDoltStore(t, cloneA)
-
-	cloneB = openPristineConformanceClone(t, cloneBPath)
-	if _, err := cloneB.GetIssue(t.Context(), "test-1"); !errors.Is(err, storage.ErrNotFound) {
-		t.Fatalf("reopened clone B GetIssue(test-1) error = %v, want ErrNotFound", err)
-	}
-	closeEmbeddedDoltStore(t, cloneB)
-}
-
-func assertEmptyPristineConformanceStore(t *testing.T, store storage.DoltStorage, name string) {
-	t.Helper()
-	count, err := store.CountIssues(t.Context(), "", types.IssueFilter{})
-	if err != nil {
-		t.Fatalf("count issues in %s: %v", name, err)
-	}
-	if count != 0 {
-		t.Fatalf("%s has %d issues, want empty store", name, count)
 	}
 }
 
@@ -181,15 +23,9 @@ func assertEmptyPristineConformanceStore(t *testing.T, store storage.DoltStorage
 // asserted. The factory returns a fresh, empty in-process store per sub-test.
 func TestConformance(t *testing.T) {
 	requireEmbeddedDolt(t)
-	template := newPristineConformanceTemplate(t)
-
 	conformance.RunAll(t, func(t *testing.T) storage.DoltStorage {
-		beadsDir := filepath.Join(t.TempDir(), ".beads")
-		if err := clonePristineConformanceTemplate(template, beadsDir); err != nil {
-			t.Fatalf("clone pristine conformance template: %v", err)
-		}
-		store := openPristineConformanceClone(t, beadsDir)
-		t.Cleanup(func() { closeEmbeddedDoltStore(t, store) })
-		return store
+		fixture := newPristineEmbeddedDoltFixture(t, pristineEmbeddedDoltDatabase)
+		t.Cleanup(func() { closeEmbeddedDoltStore(t, fixture.store) })
+		return fixture.store
 	})
 }

--- a/internal/storage/embeddeddolt/create_issue_test.go
+++ b/internal/storage/embeddeddolt/create_issue_test.go
@@ -31,24 +31,12 @@ type testEnv struct {
 // sets the issue_prefix config, and returns a testEnv with raw SQL access.
 func newTestEnv(t *testing.T, prefix string) *testEnv {
 	t.Helper()
-	ctx := t.Context()
-	beadsDir := filepath.Join(t.TempDir(), ".beads")
-	store, err := embeddeddolt.Open(ctx, beadsDir, prefix, "main")
-	if err != nil {
-		t.Fatalf("Open: %v", err)
-	}
-	t.Cleanup(func() { store.Close() })
-
-	if err := store.SetConfig(ctx, "issue_prefix", prefix); err != nil {
-		t.Fatalf("SetConfig(issue_prefix): %v", err)
-	}
-	if err := store.Commit(ctx, "bd init"); err != nil {
-		t.Fatalf("Commit: %v", err)
-	}
+	fixture := newPristineEmbeddedDoltFixture(t, prefix)
+	t.Cleanup(func() { closeEmbeddedDoltStore(t, fixture.store) })
 	return &testEnv{
-		store:    store,
-		dataDir:  filepath.Join(beadsDir, "embeddeddolt"),
-		database: prefix,
+		store:    fixture.store,
+		dataDir:  fixture.dataDir,
+		database: fixture.database,
 	}
 }
 

--- a/internal/storage/embeddeddolt/test_fixture_test.go
+++ b/internal/storage/embeddeddolt/test_fixture_test.go
@@ -1,0 +1,282 @@
+//go:build cgo
+
+package embeddeddolt_test
+
+import (
+	"context"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/storage"
+	"github.com/steveyegge/beads/internal/storage/embeddeddolt"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+var embeddedDoltFixtureRoot string
+
+const pristineEmbeddedDoltDatabase = "test"
+
+var (
+	pristineEmbeddedDoltTemplateOnce  sync.Once
+	pristineEmbeddedDoltTemplateValue pristineEmbeddedDoltTemplate
+	pristineEmbeddedDoltTemplateErr   error
+)
+
+type pristineEmbeddedDoltTemplate struct {
+	beadsDir string
+	dataDir  string
+}
+
+type pristineEmbeddedDoltFixture struct {
+	store    *embeddeddolt.EmbeddedDoltStore
+	beadsDir string
+	dataDir  string
+	database string
+}
+
+func TestMain(m *testing.M) {
+	root, err := os.MkdirTemp("", "embeddeddolt-test-fixtures-")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "create embedded Dolt test fixture root:", err)
+		os.Exit(1)
+	}
+	embeddedDoltFixtureRoot = root
+
+	code := m.Run()
+	if err := os.RemoveAll(root); err != nil && code == 0 {
+		fmt.Fprintln(os.Stderr, "remove embedded Dolt test fixture root:", err)
+		code = 1
+	}
+	os.Exit(code)
+}
+
+func pristineEmbeddedDoltTemplateForTest(t *testing.T) pristineEmbeddedDoltTemplate {
+	t.Helper()
+	pristineEmbeddedDoltTemplateOnce.Do(func() {
+		beadsDir := filepath.Join(embeddedDoltFixtureRoot, ".beads")
+		store, err := embeddeddolt.Open(context.Background(), beadsDir, pristineEmbeddedDoltDatabase, "main")
+		if err != nil {
+			pristineEmbeddedDoltTemplateErr = fmt.Errorf("open pristine embedded Dolt template: %w", err)
+			return
+		}
+		if err := store.SetConfig(context.Background(), "issue_prefix", pristineEmbeddedDoltDatabase); err != nil {
+			if closeErr := store.Close(); closeErr != nil {
+				pristineEmbeddedDoltTemplateErr = fmt.Errorf("configure pristine embedded Dolt template: %w", errors.Join(err, closeErr))
+				return
+			}
+			pristineEmbeddedDoltTemplateErr = fmt.Errorf("configure pristine embedded Dolt template: %w", err)
+			return
+		}
+		if err := store.Commit(context.Background(), "bd init"); err != nil {
+			if closeErr := store.Close(); closeErr != nil {
+				pristineEmbeddedDoltTemplateErr = fmt.Errorf("commit pristine embedded Dolt template: %w", errors.Join(err, closeErr))
+				return
+			}
+			pristineEmbeddedDoltTemplateErr = fmt.Errorf("commit pristine embedded Dolt template: %w", err)
+			return
+		}
+		if err := store.Close(); err != nil {
+			pristineEmbeddedDoltTemplateErr = fmt.Errorf("close pristine embedded Dolt template: %w", err)
+			return
+		}
+		pristineEmbeddedDoltTemplateValue = pristineEmbeddedDoltTemplate{
+			beadsDir: beadsDir,
+			dataDir:  filepath.Join(beadsDir, "embeddeddolt"),
+		}
+	})
+	if pristineEmbeddedDoltTemplateErr != nil {
+		t.Fatal(pristineEmbeddedDoltTemplateErr)
+	}
+	return pristineEmbeddedDoltTemplateValue
+}
+
+func clonePristineEmbeddedDoltTemplate(template pristineEmbeddedDoltTemplate, destination string) error {
+	if err := os.Mkdir(destination, 0o700); err != nil {
+		return fmt.Errorf("reserve clone destination %q: %w", destination, err)
+	}
+	if err := os.CopyFS(destination, os.DirFS(template.beadsDir)); err != nil {
+		return fmt.Errorf("copy pristine embedded Dolt template to %q: %w", destination, err)
+	}
+	return nil
+}
+
+func newPristineEmbeddedDoltFixture(t *testing.T, database string) *pristineEmbeddedDoltFixture {
+	t.Helper()
+	template := pristineEmbeddedDoltTemplateForTest(t)
+	beadsDir := filepath.Join(t.TempDir(), ".beads")
+	if err := clonePristineEmbeddedDoltTemplate(template, beadsDir); err != nil {
+		t.Fatalf("clone pristine embedded Dolt template: %v", err)
+	}
+	fixture := &pristineEmbeddedDoltFixture{
+		beadsDir: beadsDir,
+		dataDir:  filepath.Join(beadsDir, "embeddeddolt"),
+		database: database,
+	}
+	if database != pristineEmbeddedDoltDatabase {
+		if err := relocatePristineEmbeddedDoltDatabase(fixture.dataDir, database); err != nil {
+			t.Fatalf("relocate pristine embedded Dolt database to %q: %v", database, err)
+		}
+	}
+	store, err := embeddeddolt.Open(t.Context(), fixture.beadsDir, database, "main")
+	if err != nil {
+		t.Fatalf("open pristine embedded Dolt clone: %v", err)
+	}
+	fixture.store = store
+	if database != pristineEmbeddedDoltDatabase {
+		if err := store.SetConfig(t.Context(), "issue_prefix", database); err != nil {
+			if closeErr := store.Close(); closeErr != nil {
+				t.Fatalf("configure relocated embedded Dolt clone: %v; close: %v", err, closeErr)
+			}
+			t.Fatalf("configure relocated embedded Dolt clone: %v", err)
+		}
+		if err := store.Commit(t.Context(), "bd init"); err != nil {
+			if closeErr := store.Close(); closeErr != nil {
+				t.Fatalf("commit relocated embedded Dolt clone: %v; close: %v", err, closeErr)
+			}
+			t.Fatalf("commit relocated embedded Dolt clone: %v", err)
+		}
+	}
+	return fixture
+}
+
+func relocatePristineEmbeddedDoltDatabase(dataDir, database string) error {
+	if filepath.Base(database) != database || database == "." || database == ".." {
+		return fmt.Errorf("database name %q is not a single path element", database)
+	}
+	source := filepath.Join(dataDir, pristineEmbeddedDoltDatabase)
+	destination := filepath.Join(dataDir, database)
+	if err := os.Rename(source, destination); err != nil {
+		return fmt.Errorf("rename %q to %q: %w", source, destination, err)
+	}
+	return nil
+}
+
+func closeEmbeddedDoltStore(t *testing.T, store *embeddeddolt.EmbeddedDoltStore) {
+	t.Helper()
+	if err := store.Close(); err != nil {
+		t.Fatalf("close embedded Dolt store: %v", err)
+	}
+}
+
+func directoryDigest(t *testing.T, root string) string {
+	t.Helper()
+	digest := sha256.New()
+	err := filepath.WalkDir(root, func(path string, entry os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		relative, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		if _, err := io.WriteString(digest, relative+"\\x00"); err != nil {
+			return err
+		}
+		if entry.IsDir() {
+			return nil
+		}
+		contents, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		if _, err := digest.Write(contents); err != nil {
+			return err
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("digest %q: %v", root, err)
+	}
+	return fmt.Sprintf("%x", digest.Sum(nil))
+}
+
+func TestPristineEmbeddedDoltFixtureRelocatesPrefixes(t *testing.T) {
+	template := pristineEmbeddedDoltTemplateForTest(t)
+	templateDigest := directoryDigest(t, template.beadsDir)
+
+	fast := newPristineEmbeddedDoltFixture(t, "test")
+	if got := directoryDigest(t, fast.beadsDir); got != templateDigest {
+		t.Fatalf("test-prefix clone digest = %s, want pristine template %s", got, templateDigest)
+	}
+	closeEmbeddedDoltStore(t, fast.store)
+
+	alpha := newPristineEmbeddedDoltFixture(t, "alpha")
+	beta := newPristineEmbeddedDoltFixture(t, "beta")
+	for _, fixture := range []*pristineEmbeddedDoltFixture{alpha, beta} {
+		if _, err := os.Stat(filepath.Join(fixture.dataDir, fixture.database)); err != nil {
+			t.Fatalf("%s physical database directory: %v", fixture.database, err)
+		}
+		if _, err := os.Stat(filepath.Join(fixture.dataDir, pristineEmbeddedDoltDatabase)); !errors.Is(err, os.ErrNotExist) {
+			t.Fatalf("%s clone still contains baseline database directory: %v", fixture.database, err)
+		}
+		prefix, err := fixture.store.GetConfig(t.Context(), "issue_prefix")
+		if err != nil || prefix != fixture.database {
+			t.Fatalf("%s issue_prefix = %q, %v; want %q", fixture.database, prefix, err, fixture.database)
+		}
+		db, cleanup, err := embeddeddolt.OpenSQL(t.Context(), fixture.dataDir, fixture.database, "main")
+		if err != nil {
+			t.Fatalf("open raw SQL for %s: %v", fixture.database, err)
+		}
+		var rawPrefix string
+		err = db.QueryRowContext(t.Context(), "SELECT value FROM config WHERE `key` = ?", "issue_prefix").Scan(&rawPrefix)
+		if cleanupErr := cleanup(); cleanupErr != nil && err == nil {
+			err = cleanupErr
+		}
+		if err != nil || rawPrefix != fixture.database {
+			t.Fatalf("raw issue_prefix for %s = %q, %v; want %q", fixture.database, rawPrefix, err, fixture.database)
+		}
+	}
+
+	issue := &types.Issue{Title: "only alpha has this", Status: types.StatusOpen, IssueType: types.TypeTask}
+	if err := alpha.store.CreateIssue(t.Context(), issue, "test"); err != nil {
+		t.Fatalf("create alpha issue: %v", err)
+	}
+	if !strings.HasPrefix(issue.ID, "alpha-") {
+		t.Fatalf("generated alpha issue ID = %q, want alpha prefix", issue.ID)
+	}
+	if err := alpha.store.Commit(t.Context(), "commit alpha issue"); err != nil {
+		t.Fatalf("commit alpha issue: %v", err)
+	}
+	if _, err := beta.store.GetIssue(t.Context(), issue.ID); !errors.Is(err, storage.ErrNotFound) {
+		t.Fatalf("beta GetIssue(%q) error = %v, want ErrNotFound", issue.ID, err)
+	}
+	closeEmbeddedDoltStore(t, alpha.store)
+	closeEmbeddedDoltStore(t, beta.store)
+
+	alphaReopened, err := embeddeddolt.Open(context.Background(), alpha.beadsDir, "alpha", "main")
+	if err != nil {
+		t.Fatalf("reopen alpha: %v", err)
+	}
+	if _, err := alphaReopened.GetIssue(t.Context(), issue.ID); err != nil {
+		t.Fatalf("reopened alpha GetIssue(%q): %v", issue.ID, err)
+	}
+	closeEmbeddedDoltStore(t, alphaReopened)
+
+	betaReopened, err := embeddeddolt.Open(context.Background(), beta.beadsDir, "beta", "main")
+	if err != nil {
+		t.Fatalf("reopen beta: %v", err)
+	}
+	if _, err := betaReopened.GetIssue(t.Context(), issue.ID); !errors.Is(err, storage.ErrNotFound) {
+		t.Fatalf("reopened beta GetIssue(%q) error = %v, want ErrNotFound", issue.ID, err)
+	}
+	closeEmbeddedDoltStore(t, betaReopened)
+
+	if got := directoryDigest(t, template.beadsDir); got != templateDigest {
+		t.Fatalf("template digest changed after relocated clone mutations: got %s, want %s", got, templateDigest)
+	}
+
+	reusedDestination := filepath.Join(t.TempDir(), ".beads")
+	if err := clonePristineEmbeddedDoltTemplate(template, reusedDestination); err != nil {
+		t.Fatalf("first clone into reusable destination: %v", err)
+	}
+	if err := clonePristineEmbeddedDoltTemplate(template, reusedDestination); err == nil {
+		t.Fatal("clone into an existing destination succeeded")
+	}
+}


### PR DESCRIPTION
## What

Replace repeated fresh embedded-Dolt initialization in `newTestEnv` with isolated clones of one package-owned, closed pristine template.

Each caller still gets a unique data directory, store, and branch state. Non-default test prefixes are physically relocated, configured, and committed before use. Production code, migrations, storage APIs, test assertions, and direct fresh-init/migration/recovery tests are unchanged.

## Why

The fixture has 165 call sites. Reopening unique copies of closed initialized bytes removes migrations from semantic-test setup without sharing mutable stores or weakening persistence coverage.

| Representative race package | Before | This PR | Saved |
|---|---:|---:|---:|
| Local | 163.270s | 54.508s | 108.762s (66.6%, 3.0x) |
| Hosted PR Core | 229.412s | 71.023s | 158.389s (69.0%, 3.23x) |

The fixture contract proves:

- package-owned lifetime independent of the first test's context or temp directory;
- commit and close before cloning;
- unique mutable clones and cache keys;
- physical database relocation and raw-SQL/store identity;
- prefix-generated IDs, cross-clone isolation, and reopen durability;
- unchanged template bytes and rejection of destination reuse.

The existing conformance inventory remains intact: 78 core leaves and 85 audit leaves, all against real isolated embedded-Dolt stores.

Prior-art check: #4284 changes bounded production open behavior and `open_test.go`; it does not overlap this test-fixture ownership change or these files.

Tracked by `bd-7q32v`.

## Verification

- `GOTOOLCHAIN=go1.26.5 BEADS_TEST_EMBEDDED_DOLT=1 go test -tags=gms_pure_go -race -count=1 -run '^TestPristineEmbeddedDoltFixtureRelocatesPrefixes$' ./internal/storage/embeddeddolt` — pass, 18.391s
- `GOTOOLCHAIN=go1.26.5 ./scripts/test.sh -tags=gms_pure_go -race -count=1 ./internal/storage/embeddeddolt` — pass, 54.508s
- `GOTOOLCHAIN=go1.26.5 go vet -tags=gms_pure_go ./internal/storage/embeddeddolt` — pass
- Core conformance — pass, 78 leaves, 166.48s
- Audit conformance — pass, 85 leaves, 123.80s
- `GOTOOLCHAIN=go1.26.5 make test` — pass (`cmd/bd`: 541.751s)
- Live hosted PR Core — pass (`internal/storage/embeddeddolt`: 71.023s)
- `gofmt -d` and `git diff --check` — clean

An automated Sol correctness council found no blockers or majors. Repository policy still requires substantive human review before merge.

_codex-unknown-model-unknown-reasoning on behalf of CI Bot_
