### PR TITLE
ci: give Go caches explicit ownership

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,11 +58,35 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Go
+        id: setup-go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: 'go.mod'
+          cache: false
+
+      - name: Restore Go module cache
+        id: restore-go-module-cache
+        uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
+        with:
+          path: ~/go/pkg/mod
+          key: beads-go-mod-v2-${{ runner.os }}-${{ runner.arch }}-go-${{ steps.setup-go.outputs.go-version }}-${{ hashFiles('go.mod', 'go.sum') }}
+          restore-keys: beads-go-mod-v2-${{ runner.os }}-${{ runner.arch }}-go-${{ steps.setup-go.outputs.go-version }}-
+
+      # Per `go help cache`, Go's content-addressed build cache includes
+      # compiler options, so this base-tag directory can serve builds with
+      # additional tags. Race builds stay separate; Windows native/cgo
+      # non-race builds share theirs.
+      - name: Restore non-race Go build cache
+        id: restore-non-race-go-build-cache
+        uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
+        with:
+          path: ${{ runner.temp }}/go-cache/non-race
+          key: beads-go-build-v2-${{ runner.os }}-${{ runner.arch }}-go-${{ steps.setup-go.outputs.go-version }}-base-gms_pure_go-non-race-${{ github.sha }}
+          restore-keys: beads-go-build-v2-${{ runner.os }}-${{ runner.arch }}-go-${{ steps.setup-go.outputs.go-version }}-base-gms_pure_go-non-race-
 
       - name: Build reusable Linux artifacts
+        env:
+          GOCACHE: ${{ runner.temp }}/go-cache/non-race
         run: |
           set -euo pipefail
           mkdir -p artifacts
@@ -92,6 +116,20 @@ jobs:
           retention-days: 1
           if-no-files-found: error
 
+      - name: Save Go module cache
+        if: steps.restore-go-module-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
+        with:
+          path: ~/go/pkg/mod
+          key: beads-go-mod-v2-${{ runner.os }}-${{ runner.arch }}-go-${{ steps.setup-go.outputs.go-version }}-${{ hashFiles('go.mod', 'go.sum') }}
+
+      - name: Save non-race Go build cache
+        if: steps.restore-non-race-go-build-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
+        with:
+          path: ${{ runner.temp }}/go-cache/non-race
+          key: beads-go-build-v2-${{ runner.os }}-${{ runner.arch }}-go-${{ steps.setup-go.outputs.go-version }}-base-gms_pure_go-non-race-${{ github.sha }}
+
   # Fast check: every `go build|test|run|generate|install` invocation in
   # tracked scripts/hooks/CI carries -tags=gms_pure_go. Prevents ICU-linkage
   # regressions from re-entering the build (see engdocs/ICU-POLICY.md).
@@ -120,6 +158,7 @@ jobs:
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: 'go.mod'
+          cache: false
 
       - name: Build cmd/bd (CGO_ENABLED=0, gms_pure_go)
         env:
@@ -192,6 +231,7 @@ jobs:
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: 'go.mod'
+          cache: false
 
       - name: Build bd
         run: CGO_ENABLED=0 go build -tags gms_pure_go -o bd ./cmd/bd/
@@ -325,6 +365,7 @@ jobs:
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: 'go.mod'
+          cache: false
 
       - name: Run PR policy wrapper
         run: make ci-pr-policy
@@ -337,9 +378,27 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
 
       - name: Set up Go
+        id: setup-go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: 'go.mod'
+          cache: false
+
+      - name: Restore Go module cache
+        id: restore-go-module-cache
+        uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
+        with:
+          path: ~/go/pkg/mod
+          key: beads-go-mod-v2-${{ runner.os }}-${{ runner.arch }}-go-${{ steps.setup-go.outputs.go-version }}-${{ hashFiles('go.mod', 'go.sum') }}
+          restore-keys: beads-go-mod-v2-${{ runner.os }}-${{ runner.arch }}-go-${{ steps.setup-go.outputs.go-version }}-
+
+      - name: Restore race Go build cache
+        id: restore-race-go-build-cache
+        uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
+        with:
+          path: ${{ runner.temp }}/go-cache/race
+          key: beads-go-build-v2-${{ runner.os }}-${{ runner.arch }}-go-${{ steps.setup-go.outputs.go-version }}-base-gms_pure_go-race-${{ github.sha }}
+          restore-keys: beads-go-build-v2-${{ runner.os }}-${{ runner.arch }}-go-${{ steps.setup-go.outputs.go-version }}-base-gms_pure_go-race-
 
       - name: Install Dolt
         run: curl -fsSL https://github.com/dolthub/dolt/releases/latest/download/install.sh | sudo bash
@@ -367,6 +426,7 @@ jobs:
       - name: Run PR core wrapper
         env:
           BEADS_TEST_BD_BINARY: ${{ github.workspace }}/ci-build-artifacts/bd-linux-gms-pure
+          GOCACHE: ${{ runner.temp }}/go-cache/race
         run: make ci-pr-core
 
   pr-lint-wrapper:
@@ -379,6 +439,7 @@ jobs:
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: 'go.mod'
+          cache: false
 
       - name: Install golangci-lint
         run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.10.1
@@ -409,9 +470,36 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
 
       - name: Set up Go
+        id: setup-go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: 'go.mod'
+          cache: false
+
+      - name: Restore Go module cache
+        id: restore-go-module-cache
+        uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
+        with:
+          path: ~/go/pkg/mod
+          key: beads-go-mod-v2-${{ runner.os }}-${{ runner.arch }}-go-${{ steps.setup-go.outputs.go-version }}-${{ hashFiles('go.mod', 'go.sum') }}
+          restore-keys: beads-go-mod-v2-${{ runner.os }}-${{ runner.arch }}-go-${{ steps.setup-go.outputs.go-version }}-
+
+      - name: Restore non-race Go build cache
+        id: restore-non-race-go-build-cache
+        if: matrix.os == 'macos-latest'
+        uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
+        with:
+          path: ${{ runner.temp }}/go-cache/non-race
+          key: beads-go-build-v2-${{ runner.os }}-${{ runner.arch }}-go-${{ steps.setup-go.outputs.go-version }}-base-gms_pure_go-non-race-${{ github.sha }}
+          restore-keys: beads-go-build-v2-${{ runner.os }}-${{ runner.arch }}-go-${{ steps.setup-go.outputs.go-version }}-base-gms_pure_go-non-race-
+
+      - name: Restore race Go build cache
+        id: restore-race-go-build-cache
+        uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
+        with:
+          path: ${{ runner.temp }}/go-cache/race
+          key: beads-go-build-v2-${{ runner.os }}-${{ runner.arch }}-go-${{ steps.setup-go.outputs.go-version }}-base-gms_pure_go-race-${{ github.sha }}
+          restore-keys: beads-go-build-v2-${{ runner.os }}-${{ runner.arch }}-go-${{ steps.setup-go.outputs.go-version }}-base-gms_pure_go-race-
 
       - name: Install Dolt (Linux/macOS)
         run: curl -fsSL https://github.com/dolthub/dolt/releases/latest/download/install.sh | sudo bash
@@ -447,12 +535,15 @@ jobs:
 
       - name: Build
         if: matrix.os != 'ubuntu-latest'
+        env:
+          GOCACHE: ${{ runner.temp }}/go-cache/non-race
         run: go build -v -tags gms_pure_go ./cmd/bd
 
       - name: Test (with coverage + JUnit XML)
         if: matrix.coverage
         env:
           BEADS_TEST_BD_BINARY: ${{ github.workspace }}/ci-build-artifacts/bd-linux-gms-pure
+          GOCACHE: ${{ runner.temp }}/go-cache/race
         run: |
           gotestsum \
             --junitfile junit.xml \
@@ -461,6 +552,8 @@ jobs:
 
       - name: Test
         if: ${{ !matrix.coverage }}
+        env:
+          GOCACHE: ${{ runner.temp }}/go-cache/race
         run: go test -tags gms_pure_go ${{ matrix.test-flags }} -skip '^TestEmbedded' ./...
 
       - name: Upload coverage to Codecov
@@ -482,6 +575,29 @@ jobs:
           report_type: test_results
           fail_ci_if_error: false
 
+      # Only the macOS leg owns macOS generations. The Linux leg restores the
+      # Linux writers above and must never become a second cache publisher.
+      - name: Save Go module cache
+        if: matrix.os == 'macos-latest' && steps.restore-go-module-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
+        with:
+          path: ~/go/pkg/mod
+          key: beads-go-mod-v2-${{ runner.os }}-${{ runner.arch }}-go-${{ steps.setup-go.outputs.go-version }}-${{ hashFiles('go.mod', 'go.sum') }}
+
+      - name: Save non-race Go build cache
+        if: matrix.os == 'macos-latest' && steps.restore-non-race-go-build-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
+        with:
+          path: ${{ runner.temp }}/go-cache/non-race
+          key: beads-go-build-v2-${{ runner.os }}-${{ runner.arch }}-go-${{ steps.setup-go.outputs.go-version }}-base-gms_pure_go-non-race-${{ github.sha }}
+
+      - name: Save race Go build cache
+        if: matrix.os == 'macos-latest' && steps.restore-race-go-build-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
+        with:
+          path: ${{ runner.temp }}/go-cache/race
+          key: beads-go-build-v2-${{ runner.os }}-${{ runner.arch }}-go-${{ steps.setup-go.outputs.go-version }}-base-gms_pure_go-race-${{ github.sha }}
+
   # Focused job for the hexagonal storage layer (internal/storage/domain/* and
   # internal/storage/uow). These packages back the proxied-server init path and
   # also live behind the existing ./... matrix, but TestDomainDB requires the
@@ -499,6 +615,7 @@ jobs:
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: 'go.mod'
+          cache: false
 
       - name: Install Dolt CLI
         run: curl -fsSL https://github.com/dolthub/dolt/releases/latest/download/install.sh | sudo bash
@@ -563,6 +680,7 @@ jobs:
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: 'go.mod'
+          cache: false
 
       - name: Download build artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
@@ -646,6 +764,7 @@ jobs:
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: 'go.mod'
+          cache: false
 
       - name: Download build artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
@@ -789,17 +908,41 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
 
       - name: Set up Go
+        id: setup-go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: 'go.mod'
+          cache: false
+
+      - name: Restore Go module cache
+        id: restore-go-module-cache
+        uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
+        with:
+          path: ~/go/pkg/mod
+          key: beads-go-mod-v2-${{ runner.os }}-${{ runner.arch }}-go-${{ steps.setup-go.outputs.go-version }}-${{ hashFiles('go.mod', 'go.sum') }}
+          restore-keys: beads-go-mod-v2-${{ runner.os }}-${{ runner.arch }}-go-${{ steps.setup-go.outputs.go-version }}-
+
+      - name: Restore race Go build cache
+        id: restore-race-go-build-cache
+        uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
+        with:
+          path: ${{ runner.temp }}/go-cache/race
+          key: beads-go-build-v2-${{ runner.os }}-${{ runner.arch }}-go-${{ steps.setup-go.outputs.go-version }}-base-gms_pure_go-race-${{ github.sha }}
+          restore-keys: beads-go-build-v2-${{ runner.os }}-${{ runner.arch }}-go-${{ steps.setup-go.outputs.go-version }}-base-gms_pure_go-race-
 
       - name: Build embedded bd binary
+        env:
+          GOCACHE: ${{ runner.temp }}/go-cache/race
         run: go build -tags gms_pure_go -race -o /tmp/bd-embedded-test ./cmd/bd/
 
       - name: Build embedded storage test binary
+        env:
+          GOCACHE: ${{ runner.temp }}/go-cache/race
         run: go test -tags gms_pure_go -race -c -o /tmp/embeddeddolt-test ./internal/storage/embeddeddolt/
 
       - name: Build embedded cmd test binary
+        env:
+          GOCACHE: ${{ runner.temp }}/go-cache/race
         run: go test -tags gms_pure_go -race -c -o /tmp/bd-cmd-test ./cmd/bd/
 
       - name: Upload binaries
@@ -811,6 +954,13 @@ jobs:
             /tmp/embeddeddolt-test
             /tmp/bd-cmd-test
           retention-days: 1
+
+      - name: Save race Go build cache
+        if: steps.restore-race-go-build-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
+        with:
+          path: ${{ runner.temp }}/go-cache/race
+          key: beads-go-build-v2-${{ runner.os }}-${{ runner.arch }}-go-${{ steps.setup-go.outputs.go-version }}-base-gms_pure_go-race-${{ github.sha }}
 
   test-embedded-storage:
     name: Test (Embedded Dolt Storage ${{ matrix.shard }}/${{ strategy.job-total }})
@@ -939,9 +1089,27 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
 
       - name: Set up Go
+        id: setup-go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: 'go.mod'
+          cache: false
+
+      - name: Restore Go module cache
+        id: restore-go-module-cache
+        uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
+        with:
+          path: ~/go/pkg/mod
+          key: beads-go-mod-v2-${{ runner.os }}-${{ runner.arch }}-go-${{ steps.setup-go.outputs.go-version }}-${{ hashFiles('go.mod', 'go.sum') }}
+          restore-keys: beads-go-mod-v2-${{ runner.os }}-${{ runner.arch }}-go-${{ steps.setup-go.outputs.go-version }}-
+
+      - name: Restore non-race Go build cache
+        id: restore-non-race-go-build-cache
+        uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
+        with:
+          path: ${{ runner.temp }}/go-cache/non-race
+          key: beads-go-build-v2-${{ runner.os }}-${{ runner.arch }}-go-${{ steps.setup-go.outputs.go-version }}-base-gms_pure_go-non-race-${{ github.sha }}
+          restore-keys: beads-go-build-v2-${{ runner.os }}-${{ runner.arch }}-go-${{ steps.setup-go.outputs.go-version }}-base-gms_pure_go-non-race-
 
       - name: Configure Git
         run: |
@@ -949,6 +1117,8 @@ jobs:
           git config --global user.email "ci@beads.test"
 
       - name: Build (pure Go regex)
+        env:
+          GOCACHE: ${{ runner.temp }}/go-cache/non-race
         run: go build -v -tags gms_pure_go -o bd.exe ./cmd/bd
 
       - name: Smoke test - version
@@ -956,6 +1126,20 @@ jobs:
 
       - name: Smoke test - help
         run: ./bd.exe help
+
+      - name: Save Go module cache
+        if: steps.restore-go-module-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
+        with:
+          path: ~/go/pkg/mod
+          key: beads-go-mod-v2-${{ runner.os }}-${{ runner.arch }}-go-${{ steps.setup-go.outputs.go-version }}-${{ hashFiles('go.mod', 'go.sum') }}
+
+      - name: Save non-race Go build cache
+        if: steps.restore-non-race-go-build-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
+        with:
+          path: ${{ runner.temp }}/go-cache/non-race
+          key: beads-go-build-v2-${{ runner.os }}-${{ runner.arch }}-go-${{ steps.setup-go.outputs.go-version }}-base-gms_pure_go-non-race-${{ github.sha }}
 
   fmt-check:
     name: Check formatting
@@ -967,6 +1151,7 @@ jobs:
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: 'go.mod'
+          cache: false
 
       - name: Check gofmt
         run: make fmt-check
@@ -981,6 +1166,7 @@ jobs:
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: 'go.mod'
+          cache: false
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9

--- a/.github/workflows/pr-risk.yml
+++ b/.github/workflows/pr-risk.yml
@@ -104,23 +104,54 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
 
       - name: Set up Go
+        id: setup-go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: 'go.mod'
+          cache: false
+
+      - name: Restore Go module cache
+        uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
+        with:
+          path: ~/go/pkg/mod
+          key: beads-go-mod-v2-${{ runner.os }}-${{ runner.arch }}-go-${{ steps.setup-go.outputs.go-version }}-${{ hashFiles('go.mod', 'go.sum') }}
+          restore-keys: beads-go-mod-v2-${{ runner.os }}-${{ runner.arch }}-go-${{ steps.setup-go.outputs.go-version }}-
+
+      - name: Restore race Go build cache
+        uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
+        with:
+          path: ${{ runner.temp }}/go-cache/race
+          key: beads-go-build-v2-${{ runner.os }}-${{ runner.arch }}-go-${{ steps.setup-go.outputs.go-version }}-base-gms_pure_go-race-${{ github.sha }}
+          restore-keys: beads-go-build-v2-${{ runner.os }}-${{ runner.arch }}-go-${{ steps.setup-go.outputs.go-version }}-base-gms_pure_go-race-
+
+      - name: Restore non-race Go build cache
+        uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
+        with:
+          path: ${{ runner.temp }}/go-cache/non-race
+          key: beads-go-build-v2-${{ runner.os }}-${{ runner.arch }}-go-${{ steps.setup-go.outputs.go-version }}-base-gms_pure_go-non-race-${{ github.sha }}
+          restore-keys: beads-go-build-v2-${{ runner.os }}-${{ runner.arch }}-go-${{ steps.setup-go.outputs.go-version }}-base-gms_pure_go-non-race-
 
       - name: Build embedded bd binary
+        env:
+          GOCACHE: ${{ runner.temp }}/go-cache/race
         run: go build -tags gms_pure_go -race -o /tmp/bd-embedded-test ./cmd/bd/
 
       - name: Build embedded storage test binary
+        env:
+          GOCACHE: ${{ runner.temp }}/go-cache/race
         run: go test -tags gms_pure_go -race -c -o /tmp/embeddeddolt-test ./internal/storage/embeddeddolt/
 
       - name: Build embedded cmd test binary
+        env:
+          GOCACHE: ${{ runner.temp }}/go-cache/race
         run: go test -tags gms_pure_go -race -c -o /tmp/bd-cmd-test ./cmd/bd/
 
       # Non-race bd used as the proxied-server test subprocess. The proxied
       # tests spawn bd many times per sub-test; a -race subprocess would slow
       # every invocation, so build a plain binary for BEADS_TEST_BD_BINARY.
       - name: Build proxied bd subprocess binary
+        env:
+          GOCACHE: ${{ runner.temp }}/go-cache/non-race
         run: go build -tags gms_pure_go -o /tmp/bd-proxied ./cmd/bd/
 
       # Server-Dolt conformance binary. No -race: the Dolt server runs
@@ -128,6 +159,8 @@ jobs:
       # job's timeout. The dolt package self-skips without the docker image, so
       # the binary is harmless if its job is gated off.
       - name: Build server Dolt conformance test binary
+        env:
+          GOCACHE: ${{ runner.temp }}/go-cache/non-race
         run: go test -tags=integration,gms_pure_go -c -o /tmp/dolt-conformance-test ./internal/storage/dolt/
 
       - name: Upload binaries

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -24,11 +24,29 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Go
+        id: setup-go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: 'go.mod'
+          cache: false
+
+      - name: Restore Go module cache
+        uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
+        with:
+          path: ~/go/pkg/mod
+          key: beads-go-mod-v2-${{ runner.os }}-${{ runner.arch }}-go-${{ steps.setup-go.outputs.go-version }}-${{ hashFiles('go.mod', 'go.sum') }}
+          restore-keys: beads-go-mod-v2-${{ runner.os }}-${{ runner.arch }}-go-${{ steps.setup-go.outputs.go-version }}-
+
+      - name: Restore non-race Go build cache
+        uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
+        with:
+          path: ${{ runner.temp }}/go-cache/non-race
+          key: beads-go-build-v2-${{ runner.os }}-${{ runner.arch }}-go-${{ steps.setup-go.outputs.go-version }}-base-gms_pure_go-non-race-${{ github.sha }}
+          restore-keys: beads-go-build-v2-${{ runner.os }}-${{ runner.arch }}-go-${{ steps.setup-go.outputs.go-version }}-base-gms_pure_go-non-race-
 
       - name: Build reusable Linux artifacts
+        env:
+          GOCACHE: ${{ runner.temp }}/go-cache/non-race
         run: |
           set -euo pipefail
           mkdir -p artifacts
@@ -84,6 +102,7 @@ jobs:
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: 'go.mod'
+          cache: false
 
       - name: Build cmd/bd (CGO_ENABLED=0, gms_pure_go)
         env:
@@ -119,13 +138,30 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
 
       - name: Set up Go
+        id: setup-go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: 'go.mod'
+          cache: false
+
+      - name: Restore Go module cache
+        uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
+        with:
+          path: ~/go/pkg/mod
+          key: beads-go-mod-v2-${{ runner.os }}-${{ runner.arch }}-go-${{ steps.setup-go.outputs.go-version }}-${{ hashFiles('go.mod', 'go.sum') }}
+          restore-keys: beads-go-mod-v2-${{ runner.os }}-${{ runner.arch }}-go-${{ steps.setup-go.outputs.go-version }}-
+
+      - name: Restore non-race Go build cache
+        uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
+        with:
+          path: ${{ runner.temp }}/go-cache/non-race
+          key: beads-go-build-v2-${{ runner.os }}-${{ runner.arch }}-go-${{ steps.setup-go.outputs.go-version }}-base-gms_pure_go-non-race-${{ github.sha }}
+          restore-keys: beads-go-build-v2-${{ runner.os }}-${{ runner.arch }}-go-${{ steps.setup-go.outputs.go-version }}-base-gms_pure_go-non-race-
 
       - name: Run native Windows worktree removal boundary tests
         env:
           CGO_ENABLED: "0"
+          GOCACHE: ${{ runner.temp }}/go-cache/non-race
         run: go test -tags gms_pure_go -count=1 -run '^TestWorktreeRemove' ./cmd/bd
 
   # Fast check to ensure all version files are in sync
@@ -171,6 +207,7 @@ jobs:
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: 'go.mod'
+          cache: false
 
       - name: Build bd
         run: CGO_ENABLED=0 go build -tags gms_pure_go -o bd ./cmd/bd/
@@ -207,9 +244,18 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
 
       - name: Set up Go
+        id: setup-go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: 'go.mod'
+          cache: false
+
+      - name: Restore Go module cache
+        uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
+        with:
+          path: ~/go/pkg/mod
+          key: beads-go-mod-v2-${{ runner.os }}-${{ runner.arch }}-go-${{ steps.setup-go.outputs.go-version }}-${{ hashFiles('go.mod', 'go.sum') }}
+          restore-keys: beads-go-mod-v2-${{ runner.os }}-${{ runner.arch }}-go-${{ steps.setup-go.outputs.go-version }}-
 
       - name: Exercise native date and Bash process boundary
         run: go test '-tags=integration,gms_pure_go' -count=1 -run '^TestDocFreshness' ./scripts
@@ -226,9 +272,18 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
 
       - name: Set up Go
+        id: setup-go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: 'go.mod'
+          cache: false
+
+      - name: Restore Go module cache
+        uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
+        with:
+          path: ~/go/pkg/mod
+          key: beads-go-mod-v2-${{ runner.os }}-${{ runner.arch }}-go-${{ steps.setup-go.outputs.go-version }}-${{ hashFiles('go.mod', 'go.sum') }}
+          restore-keys: beads-go-mod-v2-${{ runner.os }}-${{ runner.arch }}-go-${{ steps.setup-go.outputs.go-version }}-
 
       - name: Exercise the real Bash process boundary
         shell: bash
@@ -384,6 +439,7 @@ jobs:
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: 'go.mod'
+          cache: false
 
       - name: Run PR policy wrapper
         run: make ci-pr-policy
@@ -396,9 +452,25 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
 
       - name: Set up Go
+        id: setup-go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: 'go.mod'
+          cache: false
+
+      - name: Restore Go module cache
+        uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
+        with:
+          path: ~/go/pkg/mod
+          key: beads-go-mod-v2-${{ runner.os }}-${{ runner.arch }}-go-${{ steps.setup-go.outputs.go-version }}-${{ hashFiles('go.mod', 'go.sum') }}
+          restore-keys: beads-go-mod-v2-${{ runner.os }}-${{ runner.arch }}-go-${{ steps.setup-go.outputs.go-version }}-
+
+      - name: Restore race Go build cache
+        uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
+        with:
+          path: ${{ runner.temp }}/go-cache/race
+          key: beads-go-build-v2-${{ runner.os }}-${{ runner.arch }}-go-${{ steps.setup-go.outputs.go-version }}-base-gms_pure_go-race-${{ github.sha }}
+          restore-keys: beads-go-build-v2-${{ runner.os }}-${{ runner.arch }}-go-${{ steps.setup-go.outputs.go-version }}-base-gms_pure_go-race-
 
       - name: Install Dolt
         run: curl -fsSL https://github.com/dolthub/dolt/releases/latest/download/install.sh | sudo bash
@@ -426,6 +498,7 @@ jobs:
       - name: Run PR core wrapper
         env:
           BEADS_TEST_BD_BINARY: ${{ github.workspace }}/ci-build-artifacts/bd-linux-gms-pure
+          GOCACHE: ${{ runner.temp }}/go-cache/race
         run: make ci-pr-core
 
   pr-lint-wrapper:
@@ -438,6 +511,7 @@ jobs:
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: 'go.mod'
+          cache: false
 
       - name: Install golangci-lint
         run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.10.1
@@ -462,6 +536,7 @@ jobs:
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: 'go.mod'
+          cache: false
 
       - name: Install Dolt CLI
         run: curl -fsSL https://github.com/dolthub/dolt/releases/latest/download/install.sh | sudo bash
@@ -537,9 +612,32 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
 
       - name: Set up Go
+        id: setup-go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: 'go.mod'
+          cache: false
+
+      - name: Restore Go module cache
+        uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
+        with:
+          path: ~/go/pkg/mod
+          key: beads-go-mod-v2-${{ runner.os }}-${{ runner.arch }}-go-${{ steps.setup-go.outputs.go-version }}-${{ hashFiles('go.mod', 'go.sum') }}
+          restore-keys: beads-go-mod-v2-${{ runner.os }}-${{ runner.arch }}-go-${{ steps.setup-go.outputs.go-version }}-
+
+      - name: Restore non-race Go build cache
+        uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
+        with:
+          path: ${{ runner.temp }}/go-cache/non-race
+          key: beads-go-build-v2-${{ runner.os }}-${{ runner.arch }}-go-${{ steps.setup-go.outputs.go-version }}-base-gms_pure_go-non-race-${{ github.sha }}
+          restore-keys: beads-go-build-v2-${{ runner.os }}-${{ runner.arch }}-go-${{ steps.setup-go.outputs.go-version }}-base-gms_pure_go-non-race-
+
+      - name: Restore race Go build cache
+        uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
+        with:
+          path: ${{ runner.temp }}/go-cache/race
+          key: beads-go-build-v2-${{ runner.os }}-${{ runner.arch }}-go-${{ steps.setup-go.outputs.go-version }}-base-gms_pure_go-race-${{ github.sha }}
+          restore-keys: beads-go-build-v2-${{ runner.os }}-${{ runner.arch }}-go-${{ steps.setup-go.outputs.go-version }}-base-gms_pure_go-race-
 
       - name: Install Dolt (Linux/macOS)
         run: curl -fsSL https://github.com/dolthub/dolt/releases/latest/download/install.sh | sudo bash
@@ -555,9 +653,13 @@ jobs:
           dolt config --global --add user.email "ci@beads.test"
 
       - name: Build
+        env:
+          GOCACHE: ${{ runner.temp }}/go-cache/non-race
         run: go build -v -tags gms_pure_go ./cmd/bd
 
       - name: Test
+        env:
+          GOCACHE: ${{ runner.temp }}/go-cache/race
         run: go test -tags gms_pure_go -v -race -short -skip '^TestEmbedded' ./...
 
   # Producer-side guard for the Beads<->consumer CLI contract. Runs the whole
@@ -587,6 +689,7 @@ jobs:
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: 'go.mod'
+          cache: false
 
       - name: Install Dolt CLI
         run: curl -fsSL https://github.com/dolthub/dolt/releases/latest/download/install.sh | sudo bash
@@ -624,6 +727,7 @@ jobs:
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: 'go.mod'
+          cache: false
 
       - name: Check gofmt
         run: make fmt-check
@@ -638,6 +742,7 @@ jobs:
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: 'go.mod'
+          cache: false
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9

--- a/scripts/ci_workflow_test.go
+++ b/scripts/ci_workflow_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -59,19 +60,472 @@ func TestPRCIGateRequiresPolicyAndLintWrappers(t *testing.T) {
 	}
 }
 
+func TestGoCacheOwnershipTopology(t *testing.T) {
+	workflows := map[string]ciWorkflow{
+		"main.yml":    readCIWorkflow(t, "main.yml"),
+		"pr.yml":      readCIWorkflow(t, "pr.yml"),
+		"pr-risk.yml": readCIWorkflow(t, "pr-risk.yml"),
+	}
+
+	for workflowName, workflow := range workflows {
+		assertPinnedGoCacheActions(t, workflowName, workflow)
+	}
+	t.Run("monolithic cache action is forbidden", func(t *testing.T) {
+		if !isGoCacheActionFamily(cacheMonolithicActionFamily) || !isForbiddenGoCacheActionFamily(cacheMonolithicActionFamily) {
+			t.Fatal("actions/cache must be recognized as a forbidden cache action family")
+		}
+	})
+
+	assertGoCacheInventory(t, workflows["main.yml"].job(t, "build-artifacts"), []goCacheStep{
+		mainRestoreModuleCache(), mainRestoreBuildCache("non-race"), saveModuleCache(), saveBuildCache("non-race"),
+	})
+	assertGoCacheInventory(t, workflows["main.yml"].job(t, "build-embedded"), []goCacheStep{
+		mainRestoreModuleCache(), mainRestoreBuildCache("race"), saveBuildCache("race"),
+	})
+	assertGoCacheInventory(t, workflows["main.yml"].job(t, "pr-core-wrapper"), []goCacheStep{
+		mainRestoreModuleCache(), mainRestoreBuildCache("race"),
+	})
+	assertGoCacheInventory(t, workflows["main.yml"].job(t, "test"), []goCacheStep{
+		mainRestoreModuleCache(), mainRestoreBuildCacheIf("non-race", macOSMatrixCondition), mainRestoreBuildCache("race"),
+		saveModuleCacheIf(macOSMatrixCondition), saveBuildCacheIf("non-race", macOSMatrixCondition), saveBuildCacheIf("race", macOSMatrixCondition),
+	})
+	assertGoCacheInventory(t, workflows["main.yml"].job(t, "test-windows"), []goCacheStep{
+		mainRestoreModuleCache(), mainRestoreBuildCache("non-race"), saveModuleCache(), saveBuildCache("non-race"),
+	})
+	assertConditionalCacheWritersHaveMatrixMember(t, workflows["main.yml"].job(t, "test"), macOSRunner)
+
+	assertGoCacheInventory(t, workflows["pr.yml"].job(t, "build-artifacts"), []goCacheStep{
+		restoreModuleCache(), restoreBuildCache("non-race"),
+	})
+	assertGoCacheInventory(t, workflows["pr.yml"].job(t, "pr-core-wrapper"), []goCacheStep{
+		restoreModuleCache(), restoreBuildCache("race"),
+	})
+	assertGoCacheInventory(t, workflows["pr.yml"].job(t, "test-macos"), []goCacheStep{
+		restoreModuleCache(), restoreBuildCache("non-race"), restoreBuildCache("race"),
+	})
+	assertGoCacheInventory(t, workflows["pr.yml"].job(t, "worktree-remove-windows"), []goCacheStep{
+		restoreModuleCache(), restoreBuildCache("non-race"),
+	})
+	for _, jobName := range []string{"check-doc-freshness-platforms", "pr-preflight-platforms"} {
+		assertGoCacheInventory(t, workflows["pr.yml"].job(t, jobName), []goCacheStep{restoreModuleCache()})
+	}
+	assertGoCacheInventory(t, workflows["pr-risk.yml"].job(t, "build-embedded"), []goCacheStep{
+		restoreModuleCache(), restoreBuildCache("race"), restoreBuildCache("non-race"),
+	})
+	assertNoUnmanagedGoCacheSteps(t, workflows, map[string]map[string]bool{
+		"main.yml": {
+			"build-artifacts": true, "build-embedded": true, "pr-core-wrapper": true, "test": true, "test-windows": true,
+		},
+		"pr.yml": {
+			"build-artifacts": true, "pr-core-wrapper": true, "test-macos": true, "worktree-remove-windows": true,
+			"check-doc-freshness-platforms": true, "pr-preflight-platforms": true,
+		},
+		"pr-risk.yml": {"build-embedded": true},
+	})
+
+	mainArtifacts := workflows["main.yml"].job(t, "build-artifacts")
+	assertStepsBefore(t, mainArtifacts, []string{"Restore Go module cache", "Restore non-race Go build cache"}, []string{"Build reusable Linux artifacts"})
+	assertStepsBefore(t, mainArtifacts, []string{"Build reusable Linux artifacts", "Upload build artifacts"}, []string{"Save Go module cache", "Save non-race Go build cache"})
+
+	mainEmbedded := workflows["main.yml"].job(t, "build-embedded")
+	embeddedRaceBuilds := []string{"Build embedded bd binary", "Build embedded storage test binary", "Build embedded cmd test binary"}
+	assertStepsBefore(t, mainEmbedded, []string{"Restore Go module cache", "Restore race Go build cache"}, embeddedRaceBuilds)
+	assertStepsBefore(t, mainEmbedded, append(embeddedRaceBuilds, "Upload binaries"), []string{"Save race Go build cache"})
+
+	assertStepsBefore(t, workflows["main.yml"].job(t, "pr-core-wrapper"),
+		[]string{"Restore Go module cache", "Restore race Go build cache"}, []string{"Run PR core wrapper"})
+	mainTest := workflows["main.yml"].job(t, "test")
+	assertStepsBefore(t, mainTest, []string{"Restore Go module cache"}, []string{"Install gotestsum", "Build", "Test (with coverage + JUnit XML)", "Test"})
+	assertStepsBefore(t, mainTest, []string{"Restore non-race Go build cache"}, []string{"Build"})
+	assertStepsBefore(t, mainTest, []string{"Restore race Go build cache"}, []string{"Test (with coverage + JUnit XML)", "Test"})
+	assertStepsBefore(t, mainTest, []string{"Build", "Test"}, []string{"Save Go module cache"})
+	assertStepsBefore(t, mainTest, []string{"Build"}, []string{"Save non-race Go build cache"})
+	assertStepsBefore(t, mainTest, []string{"Test"}, []string{"Save race Go build cache"})
+
+	mainWindows := workflows["main.yml"].job(t, "test-windows")
+	assertStepsBefore(t, mainWindows, []string{"Restore Go module cache", "Restore non-race Go build cache"}, []string{"Build (pure Go regex)"})
+	assertStepsBefore(t, mainWindows, []string{"Build (pure Go regex)", "Smoke test - version", "Smoke test - help"}, []string{"Save Go module cache", "Save non-race Go build cache"})
+
+	assertStepsBefore(t, workflows["pr.yml"].job(t, "build-artifacts"),
+		[]string{"Restore Go module cache", "Restore non-race Go build cache"}, []string{"Build reusable Linux artifacts"})
+	assertStepsBefore(t, workflows["pr.yml"].job(t, "pr-core-wrapper"),
+		[]string{"Restore Go module cache", "Restore race Go build cache"}, []string{"Run PR core wrapper"})
+	prMacOS := workflows["pr.yml"].job(t, "test-macos")
+	assertStepsBefore(t, prMacOS, []string{"Restore Go module cache"}, []string{"Build", "Test"})
+	assertStepsBefore(t, prMacOS, []string{"Restore non-race Go build cache"}, []string{"Build"})
+	assertStepsBefore(t, prMacOS, []string{"Restore race Go build cache"}, []string{"Test"})
+	assertStepsBefore(t, workflows["pr.yml"].job(t, "worktree-remove-windows"),
+		[]string{"Restore Go module cache", "Restore non-race Go build cache"}, []string{"Run native Windows worktree removal boundary tests"})
+	assertStepsBefore(t, workflows["pr.yml"].job(t, "check-doc-freshness-platforms"),
+		[]string{"Restore Go module cache"}, []string{"Exercise native date and Bash process boundary"})
+	assertStepsBefore(t, workflows["pr.yml"].job(t, "pr-preflight-platforms"),
+		[]string{"Restore Go module cache"}, []string{"Exercise the real Bash process boundary"})
+
+	prRiskEmbedded := workflows["pr-risk.yml"].job(t, "build-embedded")
+	prRiskNonRaceBuilds := []string{"Build proxied bd subprocess binary", "Build server Dolt conformance test binary"}
+	assertStepsBefore(t, prRiskEmbedded, []string{"Restore Go module cache"}, append(append([]string{}, embeddedRaceBuilds...), prRiskNonRaceBuilds...))
+	assertStepsBefore(t, prRiskEmbedded, []string{"Restore race Go build cache"}, embeddedRaceBuilds)
+	assertStepsBefore(t, prRiskEmbedded, []string{"Restore non-race Go build cache"}, prRiskNonRaceBuilds)
+
+	assertGoCacheEnv(t, workflows["main.yml"].job(t, "build-artifacts"), "Build reusable Linux artifacts", "non-race")
+	for _, stepName := range []string{"Build embedded bd binary", "Build embedded storage test binary", "Build embedded cmd test binary"} {
+		assertGoCacheEnv(t, workflows["main.yml"].job(t, "build-embedded"), stepName, "race")
+	}
+	assertGoCacheEnv(t, workflows["main.yml"].job(t, "test"), "Build", "non-race")
+	assertGoCacheEnv(t, workflows["main.yml"].job(t, "test"), "Test (with coverage + JUnit XML)", "race")
+	assertGoCacheEnv(t, workflows["main.yml"].job(t, "test"), "Test", "race")
+	assertGoCacheEnv(t, workflows["main.yml"].job(t, "test-windows"), "Build (pure Go regex)", "non-race")
+	assertGoCacheEnv(t, workflows["pr.yml"].job(t, "build-artifacts"), "Build reusable Linux artifacts", "non-race")
+	assertGoCacheEnv(t, workflows["pr.yml"].job(t, "pr-core-wrapper"), "Run PR core wrapper", "race")
+	assertGoCacheEnv(t, workflows["pr.yml"].job(t, "test-macos"), "Build", "non-race")
+	assertGoCacheEnv(t, workflows["pr.yml"].job(t, "test-macos"), "Test", "race")
+	assertGoCacheEnv(t, workflows["pr.yml"].job(t, "worktree-remove-windows"), "Run native Windows worktree removal boundary tests", "non-race")
+	for _, stepName := range []string{"Build embedded bd binary", "Build embedded storage test binary", "Build embedded cmd test binary"} {
+		assertGoCacheEnv(t, workflows["pr-risk.yml"].job(t, "build-embedded"), stepName, "race")
+	}
+	for _, stepName := range []string{"Build proxied bd subprocess binary", "Build server Dolt conformance test binary"} {
+		assertGoCacheEnv(t, workflows["pr-risk.yml"].job(t, "build-embedded"), stepName, "non-race")
+	}
+	for _, workflowName := range []string{"pr.yml", "pr-risk.yml"} {
+		for jobName, job := range workflows[workflowName].Jobs {
+			for _, step := range job.Steps {
+				family := actionFamily(step.Uses)
+				if family == cacheSaveActionFamily || isForbiddenGoCacheActionFamily(family) {
+					t.Errorf("%s job %q may not save cache in PR workflow", workflowName, jobName)
+				}
+			}
+		}
+	}
+
+	assertGoCacheWriter(t, workflows["main.yml"], "build-artifacts", "ubuntu-latest", "Save Go module cache", cacheMissCondition(goModuleCacheRestoreID))
+	assertGoCacheWriter(t, workflows["main.yml"], "build-artifacts", "ubuntu-latest", "Save non-race Go build cache", cacheMissCondition(goBuildCacheRestoreID("non-race")))
+	assertGoCacheWriter(t, workflows["main.yml"], "build-embedded", "ubuntu-latest", "Save race Go build cache", cacheMissCondition(goBuildCacheRestoreID("race")))
+	assertGoCacheWriter(t, workflows["main.yml"], "test", "${{ matrix.os }}", "Save Go module cache", combineConditions(macOSMatrixCondition, cacheMissCondition(goModuleCacheRestoreID)))
+	assertGoCacheWriter(t, workflows["main.yml"], "test", "${{ matrix.os }}", "Save non-race Go build cache", combineConditions(macOSMatrixCondition, cacheMissCondition(goBuildCacheRestoreID("non-race"))))
+	assertGoCacheWriter(t, workflows["main.yml"], "test", "${{ matrix.os }}", "Save race Go build cache", combineConditions(macOSMatrixCondition, cacheMissCondition(goBuildCacheRestoreID("race"))))
+	assertGoCacheWriter(t, workflows["main.yml"], "test-windows", "windows-latest", "Save Go module cache", cacheMissCondition(goModuleCacheRestoreID))
+	assertGoCacheWriter(t, workflows["main.yml"], "test-windows", "windows-latest", "Save non-race Go build cache", cacheMissCondition(goBuildCacheRestoreID("non-race")))
+	for _, target := range []struct{ workflow, job string }{
+		{"main.yml", "build-artifacts"},
+		{"main.yml", "build-embedded"},
+		{"main.yml", "pr-core-wrapper"},
+		{"main.yml", "test"},
+		{"main.yml", "test-windows"},
+		{"pr.yml", "build-artifacts"},
+		{"pr.yml", "pr-core-wrapper"},
+		{"pr.yml", "test-macos"},
+		{"pr.yml", "worktree-remove-windows"},
+		{"pr.yml", "check-doc-freshness-platforms"},
+		{"pr.yml", "pr-preflight-platforms"},
+		{"pr-risk.yml", "build-embedded"},
+	} {
+		if got := workflows[target.workflow].job(t, target.job).step(t, "Set up Go").ID; got != "setup-go" {
+			t.Errorf("%s job %q setup-go id = %q, want setup-go", target.workflow, target.job, got)
+		}
+	}
+}
+
+func assertNoUnmanagedGoCacheSteps(t *testing.T, workflows map[string]ciWorkflow, managed map[string]map[string]bool) {
+	t.Helper()
+
+	for workflowName, workflow := range workflows {
+		for jobName, job := range workflow.Jobs {
+			for _, step := range job.Steps {
+				family := actionFamily(step.Uses)
+				if isForbiddenGoCacheActionFamily(family) {
+					t.Errorf("%s job %q has forbidden monolithic cache step %q", workflowName, jobName, step.Name)
+					continue
+				}
+				if isGoCacheActionFamily(family) && !managed[workflowName][jobName] {
+					t.Errorf("%s job %q has unmanaged cache step %q", workflowName, jobName, step.Name)
+				}
+			}
+		}
+	}
+}
+
+const (
+	setupGoActionFamily         = "actions/setup-go"
+	cacheMonolithicActionFamily = "actions/cache"
+	cacheRestoreActionFamily    = "actions/cache/restore"
+	cacheSaveActionFamily       = "actions/cache/save"
+	setupGoSHA                  = "b7ad1dad31e06c5925ef5d2fc7ad053ef454303e"
+	cacheSHA                    = "caa296126883cff596d87d8935842f9db880ef25"
+	goCacheSchema               = "v2"
+	goBaseTag                   = "gms_pure_go"
+	goModuleCachePath           = "~/go/pkg/mod"
+	goModuleCacheRestoreID      = "restore-go-module-cache"
+	macOSRunner                 = "macos-latest"
+	macOSMatrixCondition        = "matrix.os == '" + macOSRunner + "'"
+)
+
+type goCacheStep struct {
+	name        string
+	id          string
+	family      string
+	key         string
+	restoreKeys string
+	path        string
+	ifCondition string
+}
+
+func goModuleCacheKey() string {
+	return "beads-go-mod-" + goCacheSchema + "-${{ runner.os }}-${{ runner.arch }}-go-${{ steps.setup-go.outputs.go-version }}-${{ hashFiles('go.mod', 'go.sum') }}"
+}
+
+func goModuleCacheRestoreKeys() string {
+	return "beads-go-mod-" + goCacheSchema + "-${{ runner.os }}-${{ runner.arch }}-go-${{ steps.setup-go.outputs.go-version }}-"
+}
+
+func goBuildCachePrefix(profile string) string {
+	// The base tag identifies the cache topology. Go's content-addressed
+	// cache includes compiler options, so extra tags can safely share it.
+	return "beads-go-build-" + goCacheSchema + "-${{ runner.os }}-${{ runner.arch }}-go-${{ steps.setup-go.outputs.go-version }}-base-" + goBaseTag + "-" + profile + "-"
+}
+
+func goBuildCacheKey(profile string) string {
+	return goBuildCachePrefix(profile) + "${{ github.sha }}"
+}
+
+func goBuildCachePath(profile string) string { return "${{ runner.temp }}/go-cache/" + profile }
+
+func goBuildCacheRestoreID(profile string) string {
+	return "restore-" + profile + "-go-build-cache"
+}
+
+func cacheMissCondition(restoreID string) string {
+	return "steps." + restoreID + ".outputs.cache-hit != 'true'"
+}
+
+func combineConditions(conditions ...string) string {
+	var nonEmpty []string
+	for _, condition := range conditions {
+		if condition != "" {
+			nonEmpty = append(nonEmpty, condition)
+		}
+	}
+	return strings.Join(nonEmpty, " && ")
+}
+
+func restoreModuleCache() goCacheStep {
+	return goCacheStep{name: "Restore Go module cache", family: cacheRestoreActionFamily, key: goModuleCacheKey(), restoreKeys: goModuleCacheRestoreKeys(), path: goModuleCachePath}
+}
+
+func mainRestoreModuleCache() goCacheStep {
+	step := restoreModuleCache()
+	step.id = goModuleCacheRestoreID
+	return step
+}
+
+func saveModuleCache() goCacheStep { return saveModuleCacheIf("") }
+
+func saveModuleCacheIf(condition string) goCacheStep {
+	return goCacheStep{name: "Save Go module cache", family: cacheSaveActionFamily, key: goModuleCacheKey(), path: goModuleCachePath, ifCondition: combineConditions(condition, cacheMissCondition(goModuleCacheRestoreID))}
+}
+
+func restoreBuildCache(profile string) goCacheStep {
+	return restoreBuildCacheIf(profile, "")
+}
+
+func restoreBuildCacheIf(profile, condition string) goCacheStep {
+	return goCacheStep{name: "Restore " + profile + " Go build cache", family: cacheRestoreActionFamily, key: goBuildCacheKey(profile), restoreKeys: goBuildCachePrefix(profile), path: goBuildCachePath(profile), ifCondition: condition}
+}
+
+func mainRestoreBuildCache(profile string) goCacheStep {
+	return mainRestoreBuildCacheIf(profile, "")
+}
+
+func mainRestoreBuildCacheIf(profile, condition string) goCacheStep {
+	step := restoreBuildCacheIf(profile, condition)
+	step.id = goBuildCacheRestoreID(profile)
+	return step
+}
+
+func saveBuildCache(profile string) goCacheStep { return saveBuildCacheIf(profile, "") }
+
+func saveBuildCacheIf(profile, condition string) goCacheStep {
+	return goCacheStep{name: "Save " + profile + " Go build cache", family: cacheSaveActionFamily, key: goBuildCacheKey(profile), path: goBuildCachePath(profile), ifCondition: combineConditions(condition, cacheMissCondition(goBuildCacheRestoreID(profile)))}
+}
+
+func assertGoCacheInventory(t *testing.T, job ciWorkflowJob, want []goCacheStep) {
+	t.Helper()
+
+	var got []ciWorkflowStep
+	for _, step := range job.Steps {
+		if isGoCacheActionFamily(actionFamily(step.Uses)) {
+			got = append(got, step)
+		}
+	}
+	if len(got) != len(want) {
+		t.Fatalf("cache steps = %d, want %d; got %+v", len(got), len(want), got)
+	}
+	for i, expected := range want {
+		step := got[i]
+		if step.Name != expected.name || step.ID != expected.id || actionFamily(step.Uses) != expected.family || step.With["key"] != expected.key || step.With["restore-keys"] != expected.restoreKeys || step.With["path"] != expected.path || step.If != expected.ifCondition {
+			t.Errorf("cache step %d = {name:%q id:%q family:%q key:%q restore-keys:%q path:%q if:%q}, want {name:%q id:%q family:%q key:%q restore-keys:%q path:%q if:%q}", i, step.Name, step.ID, actionFamily(step.Uses), step.With["key"], step.With["restore-keys"], step.With["path"], step.If, expected.name, expected.id, expected.family, expected.key, expected.restoreKeys, expected.path, expected.ifCondition)
+		}
+	}
+}
+
+func assertConditionalCacheWritersHaveMatrixMember(t *testing.T, job ciWorkflowJob, wantMember string) {
+	t.Helper()
+
+	memberCount := 0
+	for _, member := range job.Strategy.Matrix.OS {
+		if member == wantMember {
+			memberCount++
+		}
+	}
+	if memberCount != 1 {
+		t.Errorf("strategy matrix os has %d concrete %q members, want exactly 1: %v", memberCount, wantMember, job.Strategy.Matrix.OS)
+	}
+
+	conditionalWriters := 0
+	for _, step := range job.Steps {
+		if actionFamily(step.Uses) != cacheSaveActionFamily {
+			continue
+		}
+		remainder, found := strings.CutPrefix(step.If, "matrix.os == '")
+		if !found {
+			continue
+		}
+		member, _, found := strings.Cut(remainder, "'")
+		if !found {
+			t.Errorf("cache writer %q has malformed matrix.os condition %q", step.Name, step.If)
+			continue
+		}
+		conditionalWriters++
+		if member != wantMember {
+			t.Errorf("cache writer %q targets matrix member %q, want %q", step.Name, member, wantMember)
+		}
+	}
+	if conditionalWriters == 0 {
+		t.Fatal("job has no conditional matrix cache writers")
+	}
+}
+
+func assertStepsBefore(t *testing.T, job ciWorkflowJob, before, after []string) {
+	t.Helper()
+
+	for _, beforeName := range before {
+		beforeIndex := job.stepIndex(t, beforeName)
+		for _, afterName := range after {
+			afterIndex := job.stepIndex(t, afterName)
+			if beforeIndex >= afterIndex {
+				t.Errorf("step %q index %d must precede %q index %d", beforeName, beforeIndex, afterName, afterIndex)
+			}
+		}
+	}
+}
+
+func assertGoCacheEnv(t *testing.T, job ciWorkflowJob, stepName, profile string) {
+	t.Helper()
+	if got := job.step(t, stepName).Env["GOCACHE"]; got != goBuildCachePath(profile) {
+		t.Errorf("step %q GOCACHE = %q, want %q", stepName, got, goBuildCachePath(profile))
+	}
+}
+
+func assertGoCacheWriter(t *testing.T, workflow ciWorkflow, wantJob, wantRunner, wantStep, wantCondition string) {
+	t.Helper()
+
+	var writers []string
+	for jobName, job := range workflow.Jobs {
+		for _, step := range job.Steps {
+			if job.RunsOn == wantRunner && actionFamily(step.Uses) == cacheSaveActionFamily && step.Name == wantStep && step.If == wantCondition {
+				writers = append(writers, jobName+"/"+step.Name)
+			}
+		}
+	}
+	want := wantJob + "/" + wantStep
+	if len(writers) != 1 || writers[0] != want {
+		t.Errorf("cache writer %q with if %q = %v, want exactly [%s]", wantStep, wantCondition, writers, want)
+	}
+}
+
+var actionPin = regexp.MustCompile(`^[0-9a-f]{40}$`)
+
+func actionFamily(uses string) string {
+	family, _, found := strings.Cut(uses, "@")
+	if !found {
+		return uses
+	}
+	return family
+}
+
+func isGoCacheActionFamily(family string) bool {
+	return family == cacheMonolithicActionFamily || family == cacheRestoreActionFamily || family == cacheSaveActionFamily
+}
+
+func isForbiddenGoCacheActionFamily(family string) bool {
+	return family == cacheMonolithicActionFamily
+}
+
+func assertPinnedGoCacheActions(t *testing.T, workflowName string, workflow ciWorkflow) {
+	t.Helper()
+
+	allowed := map[string]string{
+		setupGoActionFamily:      setupGoSHA,
+		cacheRestoreActionFamily: cacheSHA,
+		cacheSaveActionFamily:    cacheSHA,
+	}
+	for jobName, job := range workflow.Jobs {
+		for _, step := range job.Steps {
+			family := actionFamily(step.Uses)
+			wantSHA, managed := allowed[family]
+			if isForbiddenGoCacheActionFamily(family) {
+				managed = true
+			}
+			if !managed {
+				continue
+			}
+			_, sha, found := strings.Cut(step.Uses, "@")
+			if !found || !actionPin.MatchString(sha) {
+				t.Errorf("%s job %q step %q action %q is not pinned to exactly 40 lowercase hex characters", workflowName, jobName, step.Name, step.Uses)
+			}
+			if isForbiddenGoCacheActionFamily(family) {
+				t.Errorf("%s job %q step %q uses forbidden monolithic action %q", workflowName, jobName, step.Name, family)
+				continue
+			}
+			if !found || !actionPin.MatchString(sha) {
+				continue
+			}
+			if sha != wantSHA {
+				t.Errorf("%s job %q step %q action %q has SHA %q, want released SHA %q", workflowName, jobName, step.Name, family, sha, wantSHA)
+			}
+			if family == setupGoActionFamily && step.With["cache"] != "false" {
+				t.Errorf("%s job %q setup-go cache = %q, want false", workflowName, jobName, step.With["cache"])
+			}
+		}
+	}
+}
+
 type ciWorkflow struct {
 	Jobs map[string]ciWorkflowJob `yaml:"jobs"`
 }
 
 type ciWorkflowJob struct {
-	Needs ciWorkflowStringList `yaml:"needs"`
-	Steps []ciWorkflowStep     `yaml:"steps"`
+	Needs    ciWorkflowStringList `yaml:"needs"`
+	Steps    []ciWorkflowStep     `yaml:"steps"`
+	RunsOn   string               `yaml:"runs-on"`
+	Strategy ciWorkflowStrategy   `yaml:"strategy"`
+}
+
+type ciWorkflowStrategy struct {
+	Matrix ciWorkflowMatrix `yaml:"matrix"`
+}
+
+type ciWorkflowMatrix struct {
+	OS []string `yaml:"os"`
 }
 
 type ciWorkflowStep struct {
 	Name string            `yaml:"name"`
+	ID   string            `yaml:"id"`
+	If   string            `yaml:"if"`
+	Uses string            `yaml:"uses"`
 	Run  string            `yaml:"run"`
 	Env  map[string]string `yaml:"env"`
+	With map[string]string `yaml:"with"`
 }
 
 type ciWorkflowStringList []string
@@ -132,6 +586,25 @@ func (job ciWorkflowJob) step(t *testing.T, name string) ciWorkflowStep {
 	}
 	t.Fatalf("job has no %q step", name)
 	return ciWorkflowStep{}
+}
+
+func (job ciWorkflowJob) stepIndex(t *testing.T, name string) int {
+	t.Helper()
+
+	index := -1
+	for i, step := range job.Steps {
+		if step.Name != name {
+			continue
+		}
+		if index >= 0 {
+			t.Fatalf("job has more than one %q step", name)
+		}
+		index = i
+	}
+	if index < 0 {
+		t.Fatalf("job has no %q step", name)
+	}
+	return index
 }
 
 func assertJobRunsExactly(t *testing.T, job ciWorkflowJob, want string) {


### PR DESCRIPTION
## What

- replace implicit `setup-go` cache ownership with explicit v2 module and build caches
- let designated heavy jobs on `main` publish Linux, macOS, and Windows caches
- keep pull-request and PR Risk jobs restore-only
- separate race and non-race build objects while allowing safe generation fallback
- skip immutable cache saves after exact hits and lock the topology with workflow contract tests

## Why

The current Linux cache was only 7,688 bytes because a lightweight job won the immutable cache key. Required jobs then reported a cache hit while downloading dependencies and compiling from scratch, and could not replace the poisoned entry. Comparable caches were about 1.21 GB on macOS and 725 MB on Windows.

Observed cold work included roughly 492 seconds in a PR Risk producer and 189 plus 624 seconds across required PR producer/core jobs. Warm caches are expected to save about 2–4 minutes. Exact before/after timing must be measured after `main` seeds the new v2 keys; this PR does not claim an unmeasured realized speedup.

## Design

- module and build caches have separate keys and paths
- build keys include OS, architecture, exact Go version, profile, race mode, schema generation, and commit SHA
- prefix fallback restores the newest compatible generation
- only successful designated `main` jobs save caches
- exact hits do not recompress or attempt to republish immutable archives
- additive compiler tags share the compatible base build cache because Go includes compiler options in cache identities; an integration-only cache with no writer would stay cold

## Verification

- `./scripts/test.sh -tags=gms_pure_go -count=1 -run '^TestGoCacheOwnershipTopology$' ./scripts`
- `./scripts/test.sh -tags=gms_pure_go -count=1 ./scripts`
- `go vet -tags=gms_pure_go ./scripts`
- `actionlint .github/workflows/main.yml .github/workflows/pr.yml .github/workflows/pr-risk.yml`
- `git diff --check`
- two independent adversarial Sol reviews found no remaining blocker or major issue

## Follow-up measurement

After merge and one successful `main` seed run, compare three warm PR runs against the recorded baseline. Report cache sizes, exact/fallback hit behavior, and median required-check wall time on `bd-712nf`.

Issue: `bd-712nf`
