### PR TITLE
test(protocol): make corpus determinism pure

### DIFF
--- a/cmd/bd/protocol/canonicalize_test.go
+++ b/cmd/bd/protocol/canonicalize_test.go
@@ -3,6 +3,9 @@ package protocol
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
+	"fmt"
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -147,15 +150,23 @@ func TestCanonicalizeDropsProvenance(t *testing.T) {
 	})
 }
 
-// TestCorpusDoubleRunByteIdentical generates the corpus twice, in two fresh
-// stores, and asserts every blob is byte-identical. This is the determinism
-// backstop: if any nondeterministic field survives canonicalization, it fails
-// here at PR time rather than as flaky corpus drift later.
+// TestCorpusDoubleRunByteIdentical proves the generator normalizes two raw
+// corpus runs that vary in the ways live bd output can vary. It deliberately
+// stays pure: the golden test owns the expensive live-store boundary.
 func TestCorpusDoubleRunByteIdentical(t *testing.T) {
-	requireDoltStore(t, "corpus double-run test")
 	for _, envelope := range []bool{false, true} {
-		first := generateCorpus(t, envelope)
-		second := generateCorpus(t, envelope)
+		firstRaw, firstCalls, firstRunner := scriptedCorpusRunner(t, 1)
+		secondRaw, secondCalls, secondRunner := scriptedCorpusRunner(t, 2)
+		first, err := generateCorpus(envelope, firstRunner)
+		if err != nil {
+			t.Fatalf("first corpus (envelope=%v): %v", envelope, err)
+		}
+		second, err := generateCorpus(envelope, secondRunner)
+		if err != nil {
+			t.Fatalf("second corpus (envelope=%v): %v", envelope, err)
+		}
+		assertCaptureCalls(t, *firstCalls, envelope)
+		assertCaptureCalls(t, *secondCalls, envelope)
 		if len(first) != len(second) {
 			t.Fatalf("envelope=%v: blob count differs: %d vs %d", envelope, len(first), len(second))
 		}
@@ -167,6 +178,151 @@ func TestCorpusDoubleRunByteIdentical(t *testing.T) {
 			if !bytes.Equal(a, b) {
 				t.Fatalf("envelope=%v: %q is nondeterministic across runs:\n--- run 1 ---\n%s\n--- run 2 ---\n%s", envelope, name, a, b)
 			}
+			if bytes.Equal((*firstRaw)[name], (*secondRaw)[name]) {
+				t.Fatalf("envelope=%v: %q raw fixture unexpectedly identical", envelope, name)
+			}
+		}
+	}
+}
+
+func TestGenerateCorpusRejectsInvalidCaptures(t *testing.T) {
+	tests := []struct {
+		name     string
+		envelope bool
+		result   func(Capture) captureResult
+		want     string
+	}{
+		{
+			name:   "successful capture exits non-zero",
+			result: func(Capture) captureResult { return captureResult{stdout: []byte(`{"ok":true}`), exitCode: 1} },
+			want:   "capture \"create_root\"",
+		},
+		{
+			name: "error capture exits zero",
+			result: func(c Capture) captureResult {
+				if c.Name == errorCaptureName {
+					return captureResult{stdout: []byte(`{"error":"missing"}`), exitCode: 0}
+				}
+				return captureResult{stdout: []byte(`{"ok":true}`)}
+			},
+			want: "error capture exit code = 0",
+		},
+		{
+			name: "error capture exits wrong code",
+			result: func(c Capture) captureResult {
+				if c.Name == errorCaptureName {
+					return captureResult{stdout: []byte(`{"error":"missing"}`), exitCode: 2}
+				}
+				return captureResult{stdout: []byte(`{"ok":true}`)}
+			},
+			want: "error capture exit code = 2",
+		},
+		{
+			name:   "execution failure",
+			result: func(Capture) captureResult { return captureResult{execErr: errors.New("binary missing")} },
+			want:   "execution failed",
+		},
+		{
+			name:   "malformed JSON",
+			result: func(Capture) captureResult { return captureResult{stdout: []byte(`{`)} },
+			want:   "canonicalize create_root",
+		},
+		{
+			name:   "trailing JSON text",
+			result: func(Capture) captureResult { return captureResult{stdout: []byte("{\"ok\":true} warning")} },
+			want:   "canonicalize create_root",
+		},
+		{
+			name:   "unexpected flat error envelope",
+			result: func(Capture) captureResult { return captureResult{stdout: []byte(`{"error":"unexpected"}`)} },
+			want:   "produced an error envelope",
+		},
+		{
+			name:     "unexpected nested envelope error",
+			envelope: true,
+			result:   func(Capture) captureResult { return captureResult{stdout: []byte(`{"data":{"error":"unexpected"}}`)} },
+			want:     "produced an error envelope",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := generateCorpus(tc.envelope, func(_ bool, c Capture) captureResult {
+				return tc.result(c)
+			})
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("generateCorpus() error = %v, want containing %q", err, tc.want)
+			}
+		})
+	}
+}
+
+type scriptedCall struct {
+	envelope bool
+	capture  Capture
+	result   captureResult
+}
+
+func scriptedCorpusRunner(t *testing.T, variant int) (*map[string][]byte, *[]scriptedCall, captureRunner) {
+	t.Helper()
+	raw := make(map[string][]byte)
+	var calls []scriptedCall
+	return &raw, &calls, func(envelope bool, capture Capture) captureResult {
+		stdout := scriptedCaptureJSON(capture.Name, envelope, variant)
+		raw[capture.Name] = stdout
+		result := captureResult{stdout: stdout}
+		if capture.Name == errorCaptureName {
+			result.exitCode = errorCaptureExitCode
+		}
+		calls = append(calls, scriptedCall{envelope: envelope, capture: capture, result: result})
+		return result
+	}
+}
+
+func scriptedCaptureJSON(name string, envelope bool, variant int) []byte {
+	timestamp := fmt.Sprintf("2026-08-02T00:00:0%dZ", variant)
+	var payload string
+	switch name {
+	case "list":
+		if variant == 1 {
+			payload = fmt.Sprintf(`[{"id":"b","created_at":%q},{"id":"a","created_at":%q}]`, timestamp, timestamp)
+		} else {
+			payload = fmt.Sprintf(`[{"id":"a","created_at":%q},{"id":"b","created_at":%q}]`, timestamp, timestamp)
+		}
+	case "version":
+		payload = fmt.Sprintf(`{"version":"v%d","branch":"branch-%d","build":"build-%d","commit":"commit-%d","schema_version":1}`, variant, variant, variant, variant)
+	case errorCaptureName:
+		payload = fmt.Sprintf(`{"error":"missing","at":%q,"schema_version":1}`, timestamp)
+	default:
+		payload = fmt.Sprintf(`{"name":%q,"created_at":%q,"schema_version":1}`, name, timestamp)
+	}
+	if !envelope {
+		return []byte(payload)
+	}
+	return []byte(fmt.Sprintf(`{"data":%s,"schema_version":1}`, payload))
+}
+
+func assertCaptureCalls(t *testing.T, got []scriptedCall, envelope bool) {
+	t.Helper()
+	want := CorpusPlan()
+	if len(got) != len(want) {
+		t.Fatalf("runner calls = %d, want %d", len(got), len(want))
+	}
+	for i, call := range got {
+		if call.envelope != envelope {
+			t.Errorf("call %d envelope = %v, want %v", i, call.envelope, envelope)
+		}
+		if !reflect.DeepEqual(call.capture, want[i]) {
+			t.Errorf("call %d capture = %#v, want %#v", i, call.capture, want[i])
+		}
+		wantExitCode := 0
+		if call.capture.Name == errorCaptureName {
+			wantExitCode = errorCaptureExitCode
+		}
+		if call.result.exitCode != wantExitCode {
+			t.Errorf("call %d (%s) exit code = %d, want %d", i, call.capture.Name, call.result.exitCode, wantExitCode)
+		}
+		if call.result.execErr != nil {
+			t.Errorf("call %d (%s) execution error = %v, want nil", i, call.capture.Name, call.result.execErr)
 		}
 	}
 }

--- a/cmd/bd/protocol/corpus_test.go
+++ b/cmd/bd/protocol/corpus_test.go
@@ -19,15 +19,21 @@ var updateCorpus = flag.Bool("corpus.update", false, "regenerate the committed g
 
 const corpusGeneratedBy = "cmd/bd/protocol TestCorpusGolden"
 
-// generateCorpus runs the PLAN in a FRESH workspace for one envelope mode and
-// returns name -> canonicalized blob bytes. Each mode (and each call) gets its
-// own isolated store because the create/dep steps are stateful and cannot
-// repeat in a single database.
-func generateCorpus(t *testing.T, envelope bool) map[string][]byte {
+type captureResult struct {
+	stdout   []byte
+	exitCode int
+	execErr  error
+}
+
+type captureRunner func(envelope bool, capture Capture) captureResult
+
+// newLiveCaptureRunner adapts one fresh subprocess workspace to captureRunner.
+// The corpus PLAN is stateful, so a runner owns exactly one workspace and a
+// separate runner is required for every independent corpus generation.
+func newLiveCaptureRunner(t *testing.T) captureRunner {
 	t.Helper()
 	w := newWorkspace(t)
-	out := make(map[string][]byte)
-	for _, c := range CorpusPlan() {
+	return func(envelope bool, c Capture) captureResult {
 		env := w.env()
 		if envelope {
 			env = append(env, "BD_JSON_ENVELOPE=1")
@@ -37,30 +43,41 @@ func generateCorpus(t *testing.T, envelope bool) map[string][]byte {
 		cmd.Env = env
 		var stdout bytes.Buffer
 		cmd.Stdout = &stdout // stdout only: bd writes human error banners to stderr
-		runErr := cmd.Run()  // keep the exit status: it is itself part of the pinned contract
+		runErr := cmd.Run()
+		result := captureResult{stdout: stdout.Bytes()}
+		if runErr == nil {
+			return result
+		}
+		var exitErr *exec.ExitError
+		if errors.As(runErr, &exitErr) {
+			result.exitCode = exitErr.ExitCode()
+			return result
+		}
+		result.execErr = runErr
+		return result
+	}
+}
 
-		// Validate the exit status BEFORE canonicalizing: every capture but the
-		// error capture must succeed, and the error capture must fail with bd's
-		// not-found exit code. Discarding this let a "successful" command exit
-		// non-zero (or the error capture stop failing) slip through, leaving the
-		// exit-codes-and-errors contract the error blob claims (CATALOG.md)
-		// unpinned even though its stdout still looked right.
-		if err := checkCaptureExit(c.Name, runErr); err != nil {
-			t.Fatalf("capture %q (envelope=%v): %v", c.Name, envelope, err)
+// generateCorpus runs the exact corpus PLAN through runner for one envelope
+// mode and returns name -> canonicalized blob bytes.
+func generateCorpus(envelope bool, runner captureRunner) (map[string][]byte, error) {
+	out := make(map[string][]byte)
+	for _, c := range CorpusPlan() {
+		result := runner(envelope, c)
+		if err := checkCaptureExit(c.Name, result); err != nil {
+			return nil, fmt.Errorf("capture %q (envelope=%v): %w", c.Name, envelope, err)
 		}
 
-		canon, err := CanonicalizeJSON(stdout.Bytes())
+		canon, err := CanonicalizeJSON(result.stdout)
 		if err != nil {
-			t.Fatalf("canonicalize %s (envelope=%v): %v\nraw stdout:\n%s", c.Name, envelope, err, stdout.Bytes())
+			return nil, fmt.Errorf("canonicalize %s (envelope=%v): %w\nraw stdout:\n%s", c.Name, envelope, err, result.stdout)
 		}
-		// Guard against silently baking a failure into the corpus: only the
-		// dedicated error capture may be an error envelope.
 		if c.Name != errorCaptureName && isErrorEnvelope(canon, envelope) {
-			t.Fatalf("capture %q (envelope=%v) produced an error envelope, not real output:\n%s\n(check the bd command in CorpusPlan)", c.Name, envelope, canon)
+			return nil, fmt.Errorf("capture %q (envelope=%v) produced an error envelope, not real output:\n%s\n(check the bd command in CorpusPlan)", c.Name, envelope, canon)
 		}
 		out[c.Name] = canon
 	}
-	return out
+	return out, nil
 }
 
 // isErrorEnvelope reports whether a canonicalized blob is bd's {error, ...}
@@ -94,70 +111,51 @@ func isErrorEnvelope(blob []byte, envelope bool) bool {
 // a downstream consumer's error classifier keys off of.
 const errorCaptureExitCode = 1
 
-// checkCaptureExit validates a capture's subprocess exit status against the
+// checkCaptureExit validates a capture result's exit status against the
 // corpus contract, so the exit-codes-and-errors coverage CATALOG.md claims is
-// actually enforced instead of silently discarded. runErr is cmd.Run()'s
-// result. Every capture except errorCaptureName must exit 0 (success); the error
-// capture must exit non-zero with errorCaptureExitCode (bd's not-found path). It
-// returns a descriptive error instead of failing the test directly, so the rule
-// is unit-testable without a live bd (TestCheckCaptureExit) and lives in one
-// place the generation loop runs for every capture — a new capture cannot bypass
-// exit-status validation.
-func checkCaptureExit(name string, runErr error) error {
+// actually enforced instead of silently discarded. Every capture except
+// errorCaptureName must exit 0; the error capture must exit with
+// errorCaptureExitCode. It returns a descriptive error instead of failing the
+// test directly, so the rule is unit-testable without a live bd and every PLAN
+// capture passes through the same validation.
+func checkCaptureExit(name string, result captureResult) error {
+	if result.execErr != nil {
+		return fmt.Errorf("capture execution failed: %w", result.execErr)
+	}
 	if name == errorCaptureName {
-		var exitErr *exec.ExitError
-		if !errors.As(runErr, &exitErr) {
-			return fmt.Errorf("error capture must exit non-zero via *exec.ExitError, got %T: %v", runErr, runErr)
-		}
-		if got := exitErr.ExitCode(); got != errorCaptureExitCode {
+		if got := result.exitCode; got != errorCaptureExitCode {
 			return fmt.Errorf("error capture exit code = %d, want %d (bd not-found contract)", got, errorCaptureExitCode)
 		}
 		return nil
 	}
-	if runErr != nil {
-		return fmt.Errorf("capture must exit 0 (success), but the command failed: %v", runErr)
+	if result.exitCode != 0 {
+		return fmt.Errorf("capture exit code = %d, want 0 (success)", result.exitCode)
 	}
 	return nil
 }
 
 func TestCheckCaptureExit(t *testing.T) {
-	// Genuine *exec.ExitError values can only come from a real process (their
-	// fields are unexported). CI is ubuntu-latest and the protocol harness already
-	// shells out to git/go, so a POSIX shell is present; skip if it somehow is not
-	// rather than fail spuriously.
-	if _, err := exec.LookPath("sh"); err != nil {
-		t.Skipf("sh not available: %v", err)
-	}
-	exitErr := func(code int) error {
-		err := exec.Command("sh", "-c", fmt.Sprintf("exit %d", code)).Run()
-		var ee *exec.ExitError
-		if !errors.As(err, &ee) {
-			t.Fatalf("sh -c 'exit %d': want *exec.ExitError, got %T: %v", code, err, err)
-		}
-		return err
-	}
-
 	tests := []struct {
 		desc    string
 		capture string
-		runErr  error
+		result  captureResult
 		wantErr bool
 	}{
-		{"success capture, exit 0", "show", nil, false},
-		{"success capture, non-zero exit", "show", exitErr(1), true},
-		{"error capture, expected exit code", errorCaptureName, exitErr(errorCaptureExitCode), false},
-		{"error capture, exit 0", errorCaptureName, nil, true},
-		{"error capture, wrong non-zero code", errorCaptureName, exitErr(errorCaptureExitCode + 1), true},
-		{"error capture, never started (not an ExitError)", errorCaptureName, errors.New("exec: not started"), true},
+		{"success capture, exit 0", "show", captureResult{}, false},
+		{"success capture, non-zero exit", "show", captureResult{exitCode: 1}, true},
+		{"error capture, expected exit code", errorCaptureName, captureResult{exitCode: errorCaptureExitCode}, false},
+		{"error capture, exit 0", errorCaptureName, captureResult{}, true},
+		{"error capture, wrong non-zero code", errorCaptureName, captureResult{exitCode: errorCaptureExitCode + 1}, true},
+		{"execution failed", "show", captureResult{execErr: errors.New("exec: not started")}, true},
 	}
 	for _, tc := range tests {
 		t.Run(tc.desc, func(t *testing.T) {
-			err := checkCaptureExit(tc.capture, tc.runErr)
+			err := checkCaptureExit(tc.capture, tc.result)
 			if tc.wantErr && err == nil {
-				t.Fatalf("checkCaptureExit(%q, %v) = nil, want error", tc.capture, tc.runErr)
+				t.Fatalf("checkCaptureExit(%q, %#v) = nil, want error", tc.capture, tc.result)
 			}
 			if !tc.wantErr && err != nil {
-				t.Fatalf("checkCaptureExit(%q, %v) = %v, want nil", tc.capture, tc.runErr, err)
+				t.Fatalf("checkCaptureExit(%q, %#v) = %v, want nil", tc.capture, tc.result, err)
 			}
 		})
 	}
@@ -176,7 +174,12 @@ func TestCorpusGolden(t *testing.T) {
 
 	blobs := make(map[string]map[string][]byte, len(modes))
 	for _, m := range modes {
-		blobs[m.name] = generateCorpus(t, m.envelope)
+		runner := newLiveCaptureRunner(t)
+		generated, err := generateCorpus(m.envelope, runner)
+		if err != nil {
+			t.Fatalf("generate %s corpus: %v", m.name, err)
+		}
+		blobs[m.name] = generated
 	}
 
 	dir := filepath.Join("testdata", "corpus")


### PR DESCRIPTION
## Summary

- Keep `TestCorpusGolden` fully live against real Dolt for all 17 commands in flat and envelope modes (34 subprocess captures total).
- Replace only the duplicate determinism backstop: four fresh workspaces and 68 additional `bd` captures become two scripted raw-result passes.
- Normalize subprocess outcomes at a test-only adapter so exit policy, canonicalization, and error-envelope guards are pure and directly testable.

## Why this is safe

The ownership boundary is unchanged:

- `TestCorpusGolden` still owns the candidate binary, real storage/process wiring, actual exit codes, all committed blobs, manifest/schema validation, regeneration, and stale-file detection.
- `TestCorpusDoubleRunByteIdentical` owns only whether known timestamp, object-order, and build-provenance variation canonicalizes to identical bytes.
- Pure generator tests now prove every exit, execution, malformed-output, trailing-output, and unexpected-error-envelope guard.

No corpus plan, golden blob, manifest, production file, workflow, or storage behavior changes.

## Hosted performance evidence

| Measurement | Before median | After median | Median change |
|---|---:|---:|---:|
| Required Contract corpus job | 386s | 359s | **-27s (-7.0%)** |
| `cmd/bd/protocol` package | 344.360s | 319.645s | **-24.715s (-7.2%)** |

Before samples:

- Job wall: 371s, 386s, 411s.
- Package: 324.999s, 344.360s, 362.066s.

After samples from workflow run `30747629093` and its two reruns:

- Job wall: 314s, 359s, 387s.
- Package: 266.565s, 319.645s, 335.239s.

This is a material reduction in infrastructure work and improves failure locality, but it does **not** meet the original 120-second target. The PR deliberately makes no minute-scale claim.

## Verification

- `./scripts/test.sh -run '^(TestCanonicalize.*|TestCheckCaptureExit|TestCorpusDoubleRunByteIdentical|TestGenerateCorpusRejectsInvalidCaptures)$' ./cmd/bd/protocol/...`
- `BEADS_TEST_ENV_RUN_DOLT=1 BEADS_PROTOCOL_REQUIRE_DOLT=1 ./scripts/test.sh -run '^TestCorpusGolden$' ./cmd/bd/protocol`
- `GOTOOLCHAIN=go1.26.5 go vet -tags=gms_pure_go ./cmd/bd/protocol`
- `git diff --check`
- Three hosted Contract corpus runs passed.
- Two independent Sol reviews approved the final diff with no blocker or major findings.

## Scope

This PR changes only `cmd/bd/protocol/corpus_test.go` and `cmd/bd/protocol/canonicalize_test.go`.

_codex-unknown-model-unknown-reasoning on behalf of CI Bot_
