### PR TITLE
test: batch embedded Swarm DAG fixture

### DIFF
--- a/cmd/bd/swarm_embedded_test.go
+++ b/cmd/bd/swarm_embedded_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
@@ -70,16 +71,37 @@ func bdSwarmJSON(t *testing.T, bd, dir string, args ...string) map[string]interf
 // createSwarmableEpic creates an epic with 3 children forming a DAG suitable for swarming.
 func createSwarmableEpic(t *testing.T, bd, dir, prefix string) (epicID string, childIDs []string) {
 	t.Helper()
-	epic := bdCreate(t, bd, dir, prefix+" epic", "--type", "epic")
-	c1 := bdCreate(t, bd, dir, prefix+" child 1", "--type", "task")
-	c2 := bdCreate(t, bd, dir, prefix+" child 2", "--type", "task")
-	c3 := bdCreate(t, bd, dir, prefix+" child 3", "--type", "task")
-	bdDep(t, bd, dir, "add", c1.ID, epic.ID, "--type", "parent-child")
-	bdDep(t, bd, dir, "add", c2.ID, epic.ID, "--type", "parent-child")
-	bdDep(t, bd, dir, "add", c3.ID, epic.ID, "--type", "parent-child")
-	// c3 depends on c1 (serial constraint)
-	bdDep(t, bd, dir, "add", c3.ID, c1.ID)
-	return epic.ID, []string{c1.ID, c2.ID, c3.ID}
+	plan := fmt.Sprintf(`{
+		"nodes": [
+			{"key": "epic", "title": %q, "type": "epic"},
+			{"key": "child1", "title": %q, "type": "task", "parent_key": "epic"},
+			{"key": "child2", "title": %q, "type": "task", "parent_key": "epic"},
+			{"key": "child3", "title": %q, "type": "task", "parent_key": "epic"}
+		],
+		"edges": [
+			{"from_key": "child3", "to_key": "child1", "type": "blocks"}
+		]
+	}`, prefix+" epic", prefix+" child 1", prefix+" child 2", prefix+" child 3")
+	planFile := filepath.Join(dir, "swarm-graph-plan.json")
+	if err := os.WriteFile(planFile, []byte(plan), 0o600); err != nil {
+		t.Fatalf("write swarm graph plan: %v", err)
+	}
+
+	result := bdCreateGraph(t, bd, dir, planFile)
+	epicID = result.IDs["epic"]
+	childIDs = []string{result.IDs["child1"], result.IDs["child2"], result.IDs["child3"]}
+	allIDs := append([]string{epicID}, childIDs...)
+	for i, id := range allIDs {
+		if id == "" {
+			t.Fatalf("graph create returned an empty ID at index %d: %#v", i, result.IDs)
+		}
+		for j := 0; j < i; j++ {
+			if id == allIDs[j] {
+				t.Fatalf("graph create returned duplicate IDs at indexes %d and %d: %#v", j, i, result.IDs)
+			}
+		}
+	}
+	return epicID, childIDs
 }
 
 func TestEmbeddedSwarm(t *testing.T) {


### PR DESCRIPTION
## What

Build each embedded Swarm test DAG with one existing `bd create --graph` call instead of four `bd create` calls followed by four `bd dep add` calls.

The fixture still creates:

- one epic;
- three task children linked to that epic;
- one blocking edge from child 3 to child 1.

Every Swarm command subtest and assertion is unchanged. No production code changes.

## Why

Comparable hosted PR Risk measurements:

| Signal | Before | After | Change |
|---|---:|---:|---:|
| `TestEmbeddedSwarm` | 287.61s | 102.21s | -185.40s (-64.5%) |
| shard-11 job | 328s | 269s | -59s |
| `TestEmbeddedSwarmConcurrent` | 135.34s | 55.21s | -80.13s (-59.2%) |
| shard-12 job | 272s | 244s | -28s |

Eight fixtures in `TestEmbeddedSwarm` repeatedly paid for eight setup subprocesses. Batching the same graph atomically removes 56 launches from shard 11. Four additional fixtures in `TestEmbeddedSwarmConcurrent` remove another 28 launches on its separate shard.

The Swarm leaf beat its 150-second target and moved below Close, making Close the new shard-11 tail. Shard 11 now completes in 4m29s, below the five-minute goal. The distinction matters: batching removed 185.40 seconds from the Swarm leaf, while parallel same-shard work limited the job-wall saving to 59 seconds.

## Correctness

- Prefix-derived titles, node types, topology, and returned child order are preserved.
- All four graph-created IDs must be nonempty and pairwise distinct.
- `TestEmbeddedSwarm` and `TestEmbeddedSwarmConcurrent` bodies are byte-unchanged.
- Two independent Sol reviewers approved diff hash `52a770de73375f2f8c7a465dc68dce8860976e1140c9f52dfeff250bda443440` with no blocker or major findings.

## Measurement and verification

- Hosted PR Risk run `30752305646`: shard 11 and shard 12 PASS with the timings above.
- Before: local focused Swarm package 59.556s.
- After: explicit opt-in Swarm plus concurrent package 34.144s.
- Race-enabled focused Swarm: PASS in 149.542s under local fleet contention.
- `make test`: PASS; `cmd/bd` 522.125s.
- `golangci-lint run ./cmd/bd/...`: 0 issues.
- Pre-commit hook: PASS with Go 1.26.5.
- Post-rebase diff hash: unchanged from the reviewed bytes.

Tracks `bd-1rh.2` under test-performance epic `bd-1rh`.
