### PR TITLE
test: trim redundant embedded Create journeys

### DIFF
--- a/cmd/bd/create_embedded_test.go
+++ b/cmd/bd/create_embedded_test.go
@@ -188,729 +188,322 @@ func TestEmbeddedCreate(t *testing.T) {
 
 	bd := buildEmbeddedBD(t)
 
-	t.Run("basic", func(t *testing.T) {
-		dir, _, _ := bdInit(t, bd, "--prefix", "bc")
-		issue := bdCreate(t, bd, dir, "Basic issue")
-		if issue.ID == "" {
-			t.Fatal("expected issue ID")
-		}
-		if issue.Title != "Basic issue" {
-			t.Errorf("title: got %q, want %q", issue.Title, "Basic issue")
-		}
-		if issue.Status != types.StatusOpen {
-			t.Errorf("status: got %q, want %q", issue.Status, types.StatusOpen)
-		}
-		if issue.Priority != 2 {
-			t.Errorf("priority: got %d, want 2 (default)", issue.Priority)
-		}
-		if issue.IssueType != types.TypeTask {
-			t.Errorf("type: got %q, want %q", issue.IssueType, types.TypeTask)
-		}
-		if !strings.HasPrefix(issue.ID, "bc-") {
-			t.Errorf("ID should have prefix bc-, got %q", issue.ID)
-		}
-	})
-
-	t.Run("title_flag", func(t *testing.T) {
-		dir, _, _ := bdInit(t, bd, "--prefix", "tf")
-		issue := bdCreate(t, bd, dir, "--title", "Title via flag")
-		if issue.Title != "Title via flag" {
-			t.Errorf("title: got %q, want %q", issue.Title, "Title via flag")
-		}
-	})
-
-	t.Run("silent", func(t *testing.T) {
-		dir, _, _ := bdInit(t, bd, "--prefix", "sl")
-		id := bdCreateSilent(t, bd, dir, "Silent issue")
-		if id == "" {
-			t.Fatal("expected issue ID from --silent")
-		}
-		if !strings.HasPrefix(id, "sl-") {
-			t.Errorf("ID should have prefix sl-, got %q", id)
-		}
-	})
-
-	t.Run("priority", func(t *testing.T) {
-		dir, _, _ := bdInit(t, bd, "--prefix", "pr")
-		for _, tc := range []struct {
-			flag string
-			want int
-		}{
-			{"0", 0},
-			{"1", 1},
-			{"P3", 3},
-			{"4", 4},
-		} {
-			t.Run("P"+tc.flag, func(t *testing.T) {
-				issue := bdCreate(t, bd, dir, fmt.Sprintf("Priority %s", tc.flag), "-p", tc.flag)
-				if issue.Priority != tc.want {
-					t.Errorf("priority: got %d, want %d", issue.Priority, tc.want)
-				}
-			})
-		}
-	})
-
-	t.Run("issue_types", func(t *testing.T) {
-		dir, _, _ := bdInit(t, bd, "--prefix", "it")
-		for _, issueType := range []string{"bug", "feature", "task", "epic", "chore", "decision"} {
-			t.Run(issueType, func(t *testing.T) {
-				issue := bdCreate(t, bd, dir, fmt.Sprintf("Type %s", issueType), "-t", issueType)
-				normalized := types.IssueType(issueType).Normalize()
-				if issue.IssueType != normalized {
-					t.Errorf("type: got %q, want %q", issue.IssueType, normalized)
-				}
-			})
-		}
-	})
-
-	t.Run("description", func(t *testing.T) {
-		dir, _, _ := bdInit(t, bd, "--prefix", "ds")
-		issue := bdCreate(t, bd, dir, "Desc issue", "-d", "This is the description")
-		if issue.Description != "This is the description" {
-			t.Errorf("description: got %q, want %q", issue.Description, "This is the description")
-		}
-	})
-
-	t.Run("design_and_acceptance", func(t *testing.T) {
-		dir, _, _ := bdInit(t, bd, "--prefix", "da")
-		issue := bdCreate(t, bd, dir, "Design issue",
-			"--design", "Use MVC pattern",
-			"--acceptance", "All tests pass")
-		if issue.Design != "Use MVC pattern" {
-			t.Errorf("design: got %q, want %q", issue.Design, "Use MVC pattern")
-		}
-		if issue.AcceptanceCriteria != "All tests pass" {
-			t.Errorf("acceptance: got %q, want %q", issue.AcceptanceCriteria, "All tests pass")
-		}
-	})
-
-	t.Run("assignee", func(t *testing.T) {
-		dir, _, _ := bdInit(t, bd, "--prefix", "as")
-		issue := bdCreate(t, bd, dir, "Assigned issue", "-a", "alice")
-		if issue.Assignee != "alice" {
-			t.Errorf("assignee: got %q, want %q", issue.Assignee, "alice")
-		}
-	})
-
-	t.Run("labels", func(t *testing.T) {
-		dir, beadsDir, _ := bdInit(t, bd, "--prefix", "lb")
-		issue := bdCreate(t, bd, dir, "Labeled issue", "-l", "bug,critical")
-
-		store := openStore(t, beadsDir, "lb")
-		labels, err := store.GetLabels(t.Context(), issue.ID)
-		if err != nil {
-			t.Fatalf("GetLabels: %v", err)
-		}
-		labelMap := make(map[string]bool)
-		for _, l := range labels {
-			labelMap[l] = true
-		}
-		if !labelMap["bug"] || !labelMap["critical"] {
-			t.Errorf("expected labels bug and critical, got %v", labels)
-		}
-	})
-
-	t.Run("explicit_id", func(t *testing.T) {
-		dir, _, _ := bdInit(t, bd, "--prefix", "ei")
-		issue := bdCreate(t, bd, dir, "Explicit ID", "--id", "ei-custom42")
-		if issue.ID != "ei-custom42" {
-			t.Errorf("ID: got %q, want %q", issue.ID, "ei-custom42")
-		}
-	})
-
-	t.Run("dependencies", func(t *testing.T) {
-		dir, beadsDir, _ := bdInit(t, bd, "--prefix", "dp")
-		parent := bdCreate(t, bd, dir, "Parent issue")
-		child := bdCreate(t, bd, dir, "Child issue", "--deps", "blocks:"+parent.ID)
-
-		// "blocks:X" reverses direction: X depends on new issue (parent.ID -> child.ID)
-		assertDepExists(t, beadsDir, "dp", parent.ID, child.ID)
-	})
-
-	t.Run("blocked_by_alias", func(t *testing.T) {
-		dir, beadsDir, _ := bdInit(t, bd, "--prefix", "bb")
-		blocker := bdCreate(t, bd, dir, "Blocker issue")
-		blocked := bdCreate(t, bd, dir, "Blocked issue", "--deps", "blocked-by:"+blocker.ID)
-
-		assertDepExistsWithType(t, beadsDir, "bb", blocked.ID, blocker.ID, "blocks")
-	})
-
-	t.Run("depends_on_alias", func(t *testing.T) {
-		dir, beadsDir, _ := bdInit(t, bd, "--prefix", "do")
-		prereq := bdCreate(t, bd, dir, "Prerequisite")
-		dependent := bdCreate(t, bd, dir, "Dependent issue", "--deps", "depends-on:"+prereq.ID)
-
-		assertDepExistsWithType(t, beadsDir, "do", dependent.ID, prereq.ID, "blocks")
-	})
-
-	t.Run("unknown_dep_type_rejected", func(t *testing.T) {
-		dir, _, _ := bdInit(t, bd, "--prefix", "ud")
-		blocker := bdCreate(t, bd, dir, "Blocker")
-		out := bdCreateFail(t, bd, dir, "Bad dep type", "--deps", "bogus-type:"+blocker.ID)
-		if !strings.Contains(out, "unknown dependency type") {
-			t.Errorf("expected 'unknown dependency type' error, got:\n%s", out)
-		}
-		if !strings.Contains(out, "blocked-by") || !strings.Contains(out, "depends-on") {
-			t.Errorf("expected accepted dependency aliases in error, got:\n%s", out)
-		}
-	})
-
-	t.Run("multiple_dependencies", func(t *testing.T) {
-		dir, beadsDir, _ := bdInit(t, bd, "--prefix", "md")
-		dep1 := bdCreate(t, bd, dir, "Dep 1")
-		dep2 := bdCreate(t, bd, dir, "Dep 2")
-		child := bdCreate(t, bd, dir, "Multi dep issue",
-			"--deps", fmt.Sprintf("blocks:%s,related:%s", dep1.ID, dep2.ID))
-
-		// blocks reverses direction; related keeps original direction
-		assertDepExists(t, beadsDir, "md", dep1.ID, child.ID)
-		assertDepExists(t, beadsDir, "md", child.ID, dep2.ID)
-	})
-
-	t.Run("parent_child", func(t *testing.T) {
-		dir, beadsDir, _ := bdInit(t, bd, "--prefix", "pc")
-		parent := bdCreate(t, bd, dir, "Parent epic", "-t", "epic")
-		child := bdCreate(t, bd, dir, "Child task", "--parent", parent.ID)
-
-		if !strings.HasPrefix(child.ID, parent.ID+".") {
-			t.Errorf("child ID %q should start with %q.", child.ID, parent.ID)
-		}
-
-		assertDepExists(t, beadsDir, "pc", child.ID, parent.ID)
-	})
-
-	t.Run("parent_label_inheritance", func(t *testing.T) {
-		dir, beadsDir, _ := bdInit(t, bd, "--prefix", "pi")
-		parent := bdCreate(t, bd, dir, "Parent with labels", "-t", "epic", "-l", "team-a,priority:high")
-		child := bdCreate(t, bd, dir, "Child inherits", "--parent", parent.ID)
-
-		store := openStore(t, beadsDir, "pi")
-		childLabels, err := store.GetLabels(t.Context(), child.ID)
-		if err != nil {
-			t.Fatalf("GetLabels: %v", err)
-		}
-		labelMap := make(map[string]bool)
-		for _, l := range childLabels {
-			labelMap[l] = true
-		}
-		if !labelMap["team-a"] || !labelMap["priority:high"] {
-			t.Errorf("expected inherited labels team-a and priority:high, got %v", childLabels)
-		}
-	})
-
-	t.Run("parent_no_inherit_labels", func(t *testing.T) {
-		dir, beadsDir, _ := bdInit(t, bd, "--prefix", "ni")
-		parent := bdCreate(t, bd, dir, "Parent", "-t", "epic", "-l", "inherited-label")
-		child := bdCreate(t, bd, dir, "Child no inherit", "--parent", parent.ID, "--no-inherit-labels", "-l", "own-label")
-
-		store := openStore(t, beadsDir, "ni")
-		childLabels, err := store.GetLabels(t.Context(), child.ID)
-		if err != nil {
-			t.Fatalf("GetLabels: %v", err)
-		}
-		labelMap := make(map[string]bool)
-		for _, l := range childLabels {
-			labelMap[l] = true
-		}
-		if !labelMap["own-label"] {
-			t.Error("expected own-label on child")
-		}
-		if labelMap["inherited-label"] {
-			t.Error("did not expect inherited-label on child with --no-inherit-labels")
-		}
-	})
-
-	t.Run("due_date", func(t *testing.T) {
-		dir, _, _ := bdInit(t, bd, "--prefix", "dd")
-		issue := bdCreate(t, bd, dir, "Due issue", "--due", "+24h")
-		if issue.DueAt == nil {
-			t.Fatal("expected DueAt to be set")
-		}
-		expected := time.Now().Add(24 * time.Hour)
-		diff := issue.DueAt.Sub(expected)
-		if diff < -5*time.Minute || diff > 5*time.Minute {
-			t.Errorf("DueAt off by too much: got %v, expected ~%v", issue.DueAt, expected)
-		}
-	})
-
-	t.Run("defer_until", func(t *testing.T) {
-		dir, _, _ := bdInit(t, bd, "--prefix", "df")
-		issue := bdCreate(t, bd, dir, "Deferred issue", "--defer", "+2h")
-		if issue.DeferUntil == nil {
-			t.Fatal("expected DeferUntil to be set")
-		}
-		expected := time.Now().Add(2 * time.Hour)
-		diff := issue.DeferUntil.Sub(expected)
-		if diff < -5*time.Minute || diff > 5*time.Minute {
-			t.Errorf("DeferUntil off by too much: got %v, expected ~%v", issue.DeferUntil, expected)
-		}
-	})
-
-	t.Run("initial_status_builtin", func(t *testing.T) {
-		dir, _, _ := bdInit(t, bd, "--prefix", "sb")
-		issue := bdCreate(t, bd, dir, "Blocked issue", "--status", "blocked")
-		if issue.Status != types.StatusBlocked {
-			t.Errorf("status: got %q, want %q", issue.Status, types.StatusBlocked)
-		}
-	})
-
-	t.Run("initial_status_custom", func(t *testing.T) {
+	t.Run("scalar_create_journey", func(t *testing.T) {
 		dir, _, _ := bdInit(t, bd, "--prefix", "sc")
+
+		basic := bdCreate(t, bd, dir, "Basic JSON issue")
+		if basic.ID == "" || basic.Title != "Basic JSON issue" || basic.Status != types.StatusOpen || basic.Priority != 2 || basic.IssueType != types.TypeTask {
+			t.Fatalf("default JSON create = %+v", basic)
+		}
+		if issue := bdCreate(t, bd, dir, "--title", "Title via flag"); issue.Title != "Title via flag" {
+			t.Fatalf("title flag = %q", issue.Title)
+		}
+		if id := bdCreateSilent(t, bd, dir, "Silent issue"); id == "" || strings.Contains(id, "\n") {
+			t.Fatalf("silent output = %q, want exactly one ID", id)
+		}
+
+		full := bdCreate(t, bd, dir, "Full fields",
+			"--id", "sc-full", "-p", "1", "-t", "bug", "-d", "description", "--design", "design",
+			"--acceptance", "acceptance", "-a", "worker", "-l", "portfolio-scalar-a,portfolio-scalar-b",
+			"--due", "+24h", "--defer", "+2h", "-e", "60", "--notes", "notes", "--spec-id", "sc-spec",
+			"--external-ref", "gh-123", "--metadata", `{"key":"value"}`, "--skills", "Go,SQL", "--context", "embedded create")
+		if full.ID != "sc-full" || full.Priority != 1 || full.IssueType != types.TypeBug || full.Design != "design" || full.AcceptanceCriteria != "acceptance" || full.Assignee != "worker" || full.Notes != "notes" || full.SpecID != "sc-spec" || full.ExternalRef == nil || *full.ExternalRef != "gh-123" || full.EstimatedMinutes == nil || *full.EstimatedMinutes != 60 || full.DueAt == nil || full.DeferUntil == nil {
+			t.Fatalf("full-field create lost values: %+v", full)
+		}
+		for _, want := range []string{"description", "## Required Skills\nGo,SQL", "## Context\nembedded create"} {
+			if !strings.Contains(full.Description, want) {
+				t.Fatalf("full-field description = %q, missing %q", full.Description, want)
+			}
+		}
+		if delta := full.DueAt.Sub(time.Now().Add(24 * time.Hour)); delta < -5*time.Minute || delta > 5*time.Minute {
+			t.Fatalf("full-field due date = %v, want approximately +24h", full.DueAt)
+		}
+		var metadata map[string]any
+		if err := json.Unmarshal(full.Metadata, &metadata); err != nil || metadata["key"] != "value" {
+			t.Fatalf("full-field metadata = %q, err = %v", full.Metadata, err)
+		}
+
+		if issue := bdCreate(t, bd, dir, "Built-in status", "--status", "blocked"); issue.Status != types.StatusBlocked {
+			t.Fatalf("built-in status = %q, want %q", issue.Status, types.StatusBlocked)
+		}
 		bdConfig(t, bd, dir, "set", "status.custom", "review:wip")
-		issue := bdCreate(t, bd, dir, "Review issue", "--status", "review")
-		if issue.Status != types.Status("review") {
-			t.Errorf("status: got %q, want review", issue.Status)
+		if issue := bdCreate(t, bd, dir, "Custom status", "--status", "review"); issue.Status != types.Status("review") {
+			t.Fatalf("custom status = %q, want review", issue.Status)
+		}
+		if out := bdCreateFail(t, bd, dir, "Invalid status", "--status", "not_a_status"); !strings.Contains(out, `invalid status "not_a_status"`) {
+			t.Fatalf("invalid status output = %s", out)
+		}
+		if issue := bdCreate(t, bd, dir, "Status wins", "--status", "blocked", "--defer", "+2h"); issue.Status != types.StatusBlocked || issue.DeferUntil == nil {
+			t.Fatalf("status-over-defer = %+v", issue)
+		}
+		if out := bdCreateFail(t, bd, dir); !strings.Contains(out, "title") {
+			t.Fatalf("missing title output = %s", out)
 		}
 	})
 
-	t.Run("initial_status_invalid", func(t *testing.T) {
-		dir, _, _ := bdInit(t, bd, "--prefix", "si")
-		out := bdCreateFail(t, bd, dir, "Invalid status issue", "--status", "not_a_status")
-		if !strings.Contains(out, `invalid status "not_a_status"`) {
-			t.Fatalf("expected invalid status error, got:\n%s", out)
-		}
-	})
+	t.Run("relationships_and_parent_journey", func(t *testing.T) {
+		dir, beadsDir, _ := bdInit(t, bd, "--prefix", "rp")
+		blocker := bdCreate(t, bd, dir, "Blocker")
+		dependent := bdCreate(t, bd, dir, "Dependent", "--deps", "blocks:"+blocker.ID)
+		assertDepExists(t, beadsDir, "rp", blocker.ID, dependent.ID)
 
-	t.Run("initial_status_wins_over_defer", func(t *testing.T) {
-		dir, _, _ := bdInit(t, bd, "--prefix", "sd")
-		issue := bdCreate(t, bd, dir, "Deferred but blocked issue", "--status", "blocked", "--defer", "+2h")
-		if issue.Status != types.StatusBlocked {
-			t.Errorf("status: got %q, want %q", issue.Status, types.StatusBlocked)
-		}
-		if issue.DeferUntil == nil {
-			t.Fatal("expected DeferUntil to be set")
-		}
-	})
-
-	t.Run("ephemeral", func(t *testing.T) {
-		dir, beadsDir, _ := bdInit(t, bd, "--prefix", "ep")
-		issue := bdCreate(t, bd, dir, "Ephemeral issue", "--ephemeral")
-
-		// Verify it went to wisps table
-		dataDir := filepath.Join(beadsDir, "embeddeddolt")
-		db, cleanup, err := embeddeddolt.OpenSQL(t.Context(), dataDir, "ep", "main")
-		if err != nil {
-			t.Fatalf("OpenSQL: %v", err)
-		}
-		defer cleanup()
-
-		var count int
-		if err := db.QueryRowContext(t.Context(), "SELECT COUNT(*) FROM wisps WHERE id = ?", issue.ID).Scan(&count); err != nil {
-			t.Fatalf("query wisps: %v", err)
-		}
-		if count != 1 {
-			t.Errorf("expected issue in wisps table, found %d rows", count)
-		}
-	})
-
-	t.Run("no_history", func(t *testing.T) {
-		dir, _, _ := bdInit(t, bd, "--prefix", "nh")
-		issue := bdCreate(t, bd, dir, "No history issue", "--no-history")
-		if issue.ID == "" {
-			t.Fatal("expected issue ID")
-		}
-	})
-
-	t.Run("graph_ephemeral", func(t *testing.T) {
-		dir, beadsDir, _ := bdInit(t, bd, "--prefix", "ge")
-		planFile := writeGraphCreatePlan(t, dir)
-		result := bdCreateGraph(t, bd, dir, planFile, "--ephemeral")
-		rootID := result.IDs["root"]
-		childID := result.IDs["child"]
-		if rootID == "" || childID == "" {
-			t.Fatalf("expected root and child IDs, got %#v", result.IDs)
-		}
-
-		dataDir := filepath.Join(beadsDir, "embeddeddolt")
-		db, cleanup, err := embeddeddolt.OpenSQL(t.Context(), dataDir, "ge", "main")
-		if err != nil {
-			t.Fatalf("OpenSQL: %v", err)
-		}
-		defer cleanup()
-
-		for _, id := range []string{rootID, childID} {
-			var ephemeral, noHistory int
-			if err := db.QueryRowContext(t.Context(), "SELECT ephemeral, no_history FROM wisps WHERE id = ?", id).Scan(&ephemeral, &noHistory); err != nil {
-				t.Fatalf("query graph ephemeral bead %s: %v", id, err)
-			}
-			if ephemeral != 1 || noHistory != 0 {
-				t.Fatalf("graph ephemeral bead %s flags = ephemeral:%d no_history:%d, want 1/0", id, ephemeral, noHistory)
-			}
-		}
-	})
-
-	t.Run("graph_no_history", func(t *testing.T) {
-		dir, beadsDir, _ := bdInit(t, bd, "--prefix", "gn")
-		planFile := writeGraphCreatePlan(t, dir)
-		result := bdCreateGraph(t, bd, dir, planFile, "--no-history")
-		rootID := result.IDs["root"]
-		childID := result.IDs["child"]
-		if rootID == "" || childID == "" {
-			t.Fatalf("expected root and child IDs, got %#v", result.IDs)
-		}
-
-		dataDir := filepath.Join(beadsDir, "embeddeddolt")
-		db, cleanup, err := embeddeddolt.OpenSQL(t.Context(), dataDir, "gn", "main")
-		if err != nil {
-			t.Fatalf("OpenSQL: %v", err)
-		}
-		defer cleanup()
-
-		for _, id := range []string{rootID, childID} {
-			var ephemeral, noHistory int
-			if err := db.QueryRowContext(t.Context(), "SELECT ephemeral, no_history FROM wisps WHERE id = ?", id).Scan(&ephemeral, &noHistory); err != nil {
-				t.Fatalf("query graph no-history bead %s: %v", id, err)
-			}
-			if ephemeral != 0 || noHistory != 1 {
-				t.Fatalf("graph no-history bead %s flags = ephemeral:%d no_history:%d, want 0/1", id, ephemeral, noHistory)
-			}
-		}
-	})
-
-	t.Run("graph_full_fields", func(t *testing.T) {
-		dir, _, _ := bdInit(t, bd, "--prefix", "gff")
-		plan := `{
-			"nodes": [
-				{
-					"key": "main",
-					"id": "gff-a1b2c3",
-					"title": "Full-field node",
-					"type": "task",
-					"status": "in_progress",
-					"description": "desc",
-					"design": "the design",
-					"acceptance_criteria": "the criteria",
-					"notes": "the notes",
-					"spec_id": "gff-spec1",
-					"external_ref": "gh-42",
-					"assignee": "worker",
-					"owner": "owner@example.com",
-					"priority": 1,
-					"estimated_minutes": 45,
-					"due_at": "2030-01-02T15:04:05Z",
-					"labels": ["x", "y"],
-					"metadata": {"str": "v", "num": 3},
-					"mol_type": "swarm",
-					"storage_class": "unversioned",
-					"pinned": true
-				},
-				{
-					"key": "deferred",
-					"title": "Deferred node",
-					"defer_until": "2030-01-01T00:00:00Z"
-				},
-				{
-					"key": "done",
-					"title": "Closed node",
-					"status": "closed"
-				},
-				{
-					"key": "evt",
-					"title": "Event node",
-					"type": "event",
-					"event_kind": "agent.started",
-					"actor": "agent://a",
-					"target": "bead://b",
-					"payload": "{\"k\":1}"
-				}
-			]
-		}`
-		planFile := filepath.Join(dir, "full-fields-plan.json")
-		if err := os.WriteFile(planFile, []byte(plan), 0o600); err != nil {
-			t.Fatalf("write graph plan: %v", err)
-		}
-		result := bdCreateGraph(t, bd, dir, planFile)
-
-		if result.IDs["main"] != "gff-a1b2c3" {
-			t.Errorf("explicit id: got %q, want gff-a1b2c3", result.IDs["main"])
-		}
-
-		issue := bdShow(t, bd, dir, result.IDs["main"])
-		if issue.Status != types.StatusInProgress {
-			t.Errorf("status: got %q, want in_progress", issue.Status)
-		}
-		if issue.Description != "desc" || issue.Design != "the design" || issue.AcceptanceCriteria != "the criteria" || issue.Notes != "the notes" {
-			t.Errorf("content fields lost: %+v", issue)
-		}
-		if issue.SpecID != "gff-spec1" {
-			t.Errorf("spec_id: got %q", issue.SpecID)
-		}
-		if issue.ExternalRef == nil || *issue.ExternalRef != "gh-42" {
-			t.Errorf("external_ref: got %v", issue.ExternalRef)
-		}
-		if issue.Assignee != "worker" {
-			t.Errorf("assignee: got %q", issue.Assignee)
-		}
-		if issue.Owner != "owner@example.com" {
-			t.Errorf("owner: got %q", issue.Owner)
-		}
-		if issue.Priority != 1 {
-			t.Errorf("priority: got %d, want 1", issue.Priority)
-		}
-		if issue.EstimatedMinutes == nil || *issue.EstimatedMinutes != 45 {
-			t.Errorf("estimated_minutes: got %v, want 45", issue.EstimatedMinutes)
-		}
-		if issue.DueAt == nil || issue.DueAt.Format("2006-01-02") != "2030-01-02" {
-			t.Errorf("due_at: got %v", issue.DueAt)
-		}
-		if issue.MolType != types.MolType("swarm") {
-			t.Errorf("mol_type: got %q", issue.MolType)
-		}
-		if issue.StorageClass != types.StorageClassUnversioned {
-			t.Errorf("storage_class: got %q, want unversioned", issue.StorageClass)
-		}
-		if !issue.Pinned {
-			t.Errorf("pinned not set")
-		}
-		var meta map[string]any
-		if err := json.Unmarshal(issue.Metadata, &meta); err != nil {
-			t.Fatalf("metadata not valid JSON: %v", err)
-		}
-		if meta["str"] != "v" || meta["num"] != float64(3) {
-			t.Errorf("metadata round-trip wrong (non-string values must survive): %v", meta)
-		}
-
-		deferred := bdShow(t, bd, dir, result.IDs["deferred"])
-		if deferred.Status != types.StatusDeferred {
-			t.Errorf("deferred status: got %q, want deferred", deferred.Status)
-		}
-		if deferred.DeferUntil == nil {
-			t.Errorf("defer_until lost")
-		}
-
-		done := bdShow(t, bd, dir, result.IDs["done"])
-		if done.Status != types.StatusClosed {
-			t.Errorf("closed status: got %q, want closed", done.Status)
-		}
-		if done.ClosedAt == nil {
-			t.Errorf("closed node missing auto-filled closed_at")
-		}
-
-		evt := bdShow(t, bd, dir, result.IDs["evt"])
-		if evt.EventKind != "agent.started" || evt.Actor != "agent://a" || evt.Target != "bead://b" || evt.Payload != `{"k":1}` {
-			t.Errorf("event fields lost: kind=%q actor=%q target=%q payload=%q", evt.EventKind, evt.Actor, evt.Target, evt.Payload)
-		}
-	})
-
-	t.Run("graph_waits_for_gate", func(t *testing.T) {
-		dir, beadsDir, _ := bdInit(t, bd, "--prefix", "gw")
-		plan := `{
-			"nodes": [
-				{"key": "gate", "title": "Fanout gate"},
-				{"key": "spawner", "title": "Spawner step"}
-			],
-			"edges": [
-				{"from_key": "gate", "to_key": "spawner", "type": "waits-for", "gate": "any-children", "spawner_key": "spawner"}
-			]
-		}`
-		planFile := filepath.Join(dir, "gate-plan.json")
-		if err := os.WriteFile(planFile, []byte(plan), 0o600); err != nil {
-			t.Fatalf("write graph plan: %v", err)
-		}
-		result := bdCreateGraph(t, bd, dir, planFile)
-		gateID := result.IDs["gate"]
-		spawnerID := result.IDs["spawner"]
-
-		dataDir := filepath.Join(beadsDir, "embeddeddolt")
-		db, cleanup, err := embeddeddolt.OpenSQL(t.Context(), dataDir, "gw", "main")
-		if err != nil {
-			t.Fatalf("OpenSQL: %v", err)
-		}
-		defer cleanup()
-
-		var metadata string
-		err = db.QueryRowContext(t.Context(),
-			"SELECT COALESCE(metadata, '') FROM dependencies WHERE issue_id = ? AND COALESCE(depends_on_issue_id, depends_on_wisp_id, depends_on_external) = ? AND type = 'waits-for'",
-			gateID, spawnerID).Scan(&metadata)
-		if err != nil {
-			t.Fatalf("query waits-for dep: %v", err)
-		}
-		var meta types.WaitsForMeta
-		if err := json.Unmarshal([]byte(metadata), &meta); err != nil {
-			t.Fatalf("dep metadata not WaitsForMeta JSON (%q): %v", metadata, err)
-		}
-		if meta.Gate != types.WaitsForAnyChildren {
-			t.Errorf("gate: got %q, want any-children", meta.Gate)
-		}
-		if meta.SpawnerID != spawnerID {
-			t.Errorf("spawner: got %q, want resolved key %q", meta.SpawnerID, spawnerID)
-		}
-	})
-
-	t.Run("graph_per_node_storage_class", func(t *testing.T) {
-		dir, beadsDir, _ := bdInit(t, bd, "--prefix", "gs")
-		plan := `{
-			"nodes": [
-				{"key": "durable", "title": "Durable node"},
-				{"key": "wisp", "title": "Wisp node", "ephemeral": true}
-			]
-		}`
-		planFile := filepath.Join(dir, "storage-plan.json")
-		if err := os.WriteFile(planFile, []byte(plan), 0o600); err != nil {
-			t.Fatalf("write graph plan: %v", err)
-		}
-		result := bdCreateGraph(t, bd, dir, planFile)
-
-		dataDir := filepath.Join(beadsDir, "embeddeddolt")
-		db, cleanup, err := embeddeddolt.OpenSQL(t.Context(), dataDir, "gs", "main")
-		if err != nil {
-			t.Fatalf("OpenSQL: %v", err)
-		}
-		defer cleanup()
-
-		var count int
-		if err := db.QueryRowContext(t.Context(), "SELECT COUNT(*) FROM issues WHERE id = ?", result.IDs["durable"]).Scan(&count); err != nil {
-			t.Fatalf("query issues: %v", err)
-		}
-		if count != 1 {
-			t.Errorf("durable node not in issues table")
-		}
-		if err := db.QueryRowContext(t.Context(), "SELECT COUNT(*) FROM wisps WHERE id = ?", result.IDs["wisp"]).Scan(&count); err != nil {
-			t.Fatalf("query wisps: %v", err)
-		}
-		if count != 1 {
-			t.Errorf("per-node ephemeral override not routed to wisps table")
-		}
-	})
-
-	t.Run("estimate", func(t *testing.T) {
-		dir, _, _ := bdInit(t, bd, "--prefix", "es")
-		issue := bdCreate(t, bd, dir, "Estimated issue", "-e", "60")
-		if issue.EstimatedMinutes == nil || *issue.EstimatedMinutes != 60 {
-			t.Errorf("estimate: got %v, want 60", issue.EstimatedMinutes)
-		}
-	})
-
-	t.Run("notes", func(t *testing.T) {
-		dir, _, _ := bdInit(t, bd, "--prefix", "nt")
-		issue := bdCreate(t, bd, dir, "Notes issue", "--notes", "Some notes here")
-		if issue.Notes != "Some notes here" {
-			t.Errorf("notes: got %q, want %q", issue.Notes, "Some notes here")
-		}
-	})
-
-	t.Run("spec_id", func(t *testing.T) {
-		dir, _, _ := bdInit(t, bd, "--prefix", "sp")
-		issue := bdCreate(t, bd, dir, "Spec issue", "--spec-id", "sp-spec1")
-		if issue.SpecID != "sp-spec1" {
-			t.Errorf("spec_id: got %q, want %q", issue.SpecID, "sp-spec1")
-		}
-	})
-
-	t.Run("external_ref", func(t *testing.T) {
-		dir, _, _ := bdInit(t, bd, "--prefix", "er")
-		issue := bdCreate(t, bd, dir, "External ref issue", "--external-ref", "gh-123")
-		if issue.ExternalRef == nil || *issue.ExternalRef != "gh-123" {
-			t.Errorf("external_ref: got %v, want %q", issue.ExternalRef, "gh-123")
-		}
-	})
-
-	t.Run("linear_external_ref", func(t *testing.T) {
-		dir, _, _ := bdInit(t, bd, "--prefix", "ler")
-		ref := "https://linear.app/team/issue/TEAM-123/fix-login"
-		issue := bdCreate(t, bd, dir, "Pre-linked Linear issue", "--external-ref", ref)
-		if issue.ExternalRef == nil || *issue.ExternalRef != ref {
-			t.Errorf("external_ref: got %v, want %q", issue.ExternalRef, ref)
-		}
-	})
-
-	t.Run("metadata", func(t *testing.T) {
-		dir, _, _ := bdInit(t, bd, "--prefix", "mt")
-		issue := bdCreate(t, bd, dir, "Metadata issue", "--metadata", `{"key":"value"}`)
-		if issue.Metadata == nil {
-			t.Fatal("expected metadata to be set")
-		}
-		var m map[string]interface{}
-		if err := json.Unmarshal(issue.Metadata, &m); err != nil {
-			t.Fatalf("failed to parse metadata: %v", err)
-		}
-		if v, ok := m["key"]; !ok || v != "value" {
-			t.Errorf("metadata: got %v, want key=value", m)
-		}
-	})
-
-	t.Run("dry_run", func(t *testing.T) {
-		dir, _, _ := bdInit(t, bd, "--prefix", "dr")
-
-		cmd := exec.Command(bd, "create", "--dry-run", "Dry run issue", "--json")
-		cmd.Dir = dir
-		cmd.Env = bdEnv(dir)
-		stdout, stderr, err := runCommandBuffers(t, cmd)
-		if err != nil {
-			t.Fatalf("bd create --dry-run failed: %v\nstdout:\n%s\nstderr:\n%s", err, stdout.String(), stderr.String())
-		}
-
-		// Dry run should not persist anything. Create a real issue and verify
-		// the dry-run issue doesn't exist.
-		if strings.Contains(stdout.String(), "error") {
-			t.Errorf("dry-run produced error output: %s", stdout.String())
-		}
-	})
-
-	t.Run("dry_run_parent_label_inheritance", func(t *testing.T) {
-		dir, _, _ := bdInit(t, bd, "--prefix", "dp")
-		parent := bdCreate(t, bd, dir, "Parent with labels", "-t", "epic", "-l", "team-a,shared")
-
-		cmd := exec.Command(bd, "create", "--dry-run", "Preview child", "--json",
-			"--parent", parent.ID, "-l", "child,shared")
-		cmd.Dir = dir
-		cmd.Env = bdEnv(dir)
-		stdout, stderr, err := runCommandBuffers(t, cmd)
-		if err != nil {
-			t.Fatalf("bd create --dry-run --parent failed: %v\nstdout:\n%s\nstderr:\n%s", err, stdout.String(), stderr.String())
-		}
-
-		preview := parseIssueJSON(t, stdout.Bytes())
-		labelMap := make(map[string]bool)
-		for _, label := range preview.Labels {
-			labelMap[label] = true
-		}
-		for _, want := range []string{"team-a", "shared", "child"} {
-			if !labelMap[want] {
-				t.Fatalf("dry-run labels = %v, want %q", preview.Labels, want)
-			}
-		}
-		if len(preview.Labels) != 3 {
-			t.Fatalf("dry-run labels = %v, want 3 deduped labels", preview.Labels)
-		}
-
-		child := bdCreate(t, bd, dir, "Real child after dry-run", "--parent", parent.ID)
+		parent := bdCreate(t, bd, dir, "Parent", "-t", "epic", "-l", "portfolio-parent,portfolio-shared")
+		child := bdCreate(t, bd, dir, "Child", "--parent", parent.ID, "-l", "portfolio-child,portfolio-shared")
 		if child.ID != parent.ID+".1" {
-			t.Fatalf("child ID after dry-run = %q, want %q", child.ID, parent.ID+".1")
+			t.Fatalf("child ID = %q, want %q", child.ID, parent.ID+".1")
+		}
+		assertDepExists(t, beadsDir, "rp", child.ID, parent.ID)
+
+		noInherit := bdCreate(t, bd, dir, "No inherited labels", "--parent", parent.ID, "--no-inherit-labels", "-l", "portfolio-own")
+		grandchild := bdCreate(t, bd, dir, "Grandchild", "--parent", child.ID)
+		if grandchild.ID != child.ID+".1" {
+			t.Fatalf("hierarchical child counter = %q, want %q", grandchild.ID, child.ID+".1")
+		}
+
+		store := openStore(t, beadsDir, "rp")
+		labels, err := store.GetLabels(t.Context(), child.ID)
+		if err != nil {
+			t.Fatalf("get child labels: %v", err)
+		}
+		wantLabels := map[string]bool{"portfolio-parent": true, "portfolio-shared": true, "portfolio-child": true}
+		if len(labels) != len(wantLabels) {
+			t.Fatalf("merged labels = %v, want three deduplicated labels", labels)
+		}
+		for _, label := range labels {
+			delete(wantLabels, label)
+		}
+		if len(wantLabels) != 0 {
+			t.Fatalf("missing merged labels: %v", wantLabels)
+		}
+
+		labels, err = store.GetLabels(t.Context(), noInherit.ID)
+		if err != nil {
+			t.Fatalf("get no-inherit labels: %v", err)
+		}
+		if len(labels) != 1 || labels[0] != "portfolio-own" {
+			t.Fatalf("no-inherit labels = %v, want [portfolio-own]", labels)
+		}
+
+		sourceParent := &types.Issue{
+			Title:      "Source repository parent",
+			Priority:   1,
+			Status:     types.StatusOpen,
+			IssueType:  types.TypeTask,
+			SourceRepo: "/path/to/repo",
+		}
+		if err := store.CreateIssue(t.Context(), sourceParent, "test"); err != nil {
+			t.Fatalf("create source repository parent: %v", err)
+		}
+		if err := store.Commit(t.Context(), "create source repository parent"); err != nil {
+			t.Fatalf("commit source repository parent: %v", err)
+		}
+		store.Close()
+
+		discovered := bdCreate(t, bd, dir, "Discovered work", "--deps", "discovered-from:"+sourceParent.ID)
+		db, cleanup, err := embeddeddolt.OpenSQL(t.Context(), filepath.Join(beadsDir, "embeddeddolt"), "rp", "main")
+		if err != nil {
+			t.Fatalf("OpenSQL: %v", err)
+		}
+		defer cleanup()
+		var sourceRepo string
+		if err := db.QueryRowContext(t.Context(), "SELECT COALESCE(source_repo, '') FROM issues WHERE id = ?", discovered.ID).Scan(&sourceRepo); err != nil {
+			t.Fatalf("query discovered source_repo: %v", err)
+		}
+		if sourceRepo != sourceParent.SourceRepo {
+			t.Fatalf("discovered source_repo = %q, want %q", sourceRepo, sourceParent.SourceRepo)
 		}
 	})
 
-	t.Run("skills_and_context", func(t *testing.T) {
-		dir, _, _ := bdInit(t, bd, "--prefix", "sc")
-		issue := bdCreate(t, bd, dir, "Skills issue",
-			"--skills", "Go, SQL",
-			"--context", "Working on embedded storage")
-		if !strings.Contains(issue.Description, "Go, SQL") {
-			t.Errorf("expected skills in description, got %q", issue.Description)
+	t.Run("storage_plane_journey", func(t *testing.T) {
+		dir, beadsDir, _ := bdInit(t, bd, "--prefix", "sp")
+		ephemeral := bdCreate(t, bd, dir, "Ephemeral", "--ephemeral")
+		noHistory := bdCreate(t, bd, dir, "No history", "--no-history")
+		db, cleanup, err := embeddeddolt.OpenSQL(t.Context(), filepath.Join(beadsDir, "embeddeddolt"), "sp", "main")
+		if err != nil {
+			t.Fatalf("OpenSQL: %v", err)
 		}
-		if !strings.Contains(issue.Description, "Working on embedded storage") {
-			t.Errorf("expected context in description, got %q", issue.Description)
+		defer cleanup()
+		for _, check := range []struct {
+			id                   string
+			ephemeral, noHistory int
+		}{{ephemeral.ID, 1, 0}, {noHistory.ID, 0, 1}} {
+			var gotEphemeral, gotNoHistory int
+			if err := db.QueryRowContext(t.Context(), "SELECT ephemeral, no_history FROM wisps WHERE id = ?", check.id).Scan(&gotEphemeral, &gotNoHistory); err != nil {
+				t.Fatalf("query wisp %s: %v", check.id, err)
+			}
+			if gotEphemeral != check.ephemeral || gotNoHistory != check.noHistory {
+				t.Fatalf("wisp %s flags = %d/%d, want %d/%d", check.id, gotEphemeral, gotNoHistory, check.ephemeral, check.noHistory)
+			}
 		}
 	})
 
-	t.Run("discovered_from_dep", func(t *testing.T) {
-		dir, beadsDir, _ := bdInit(t, bd, "--prefix", "di")
-
-		parent := bdCreate(t, bd, dir, "Parent work")
-		child := bdCreate(t, bd, dir, "Discovered bug",
-			"--deps", "discovered-from:"+parent.ID)
-
-		if child.ID == "" {
-			t.Fatal("expected child issue ID")
+	t.Run("graph_create_journey", func(t *testing.T) {
+		dir, beadsDir, _ := bdInit(t, bd, "--prefix", "gr")
+		plan := `{
+			"nodes": [
+				{"key":"main","id":"gr-a1b2c3","title":"Full-field node","type":"task","status":"in_progress","description":"desc","design":"the design","acceptance_criteria":"the criteria","notes":"the notes","spec_id":"gr-spec1","external_ref":"gh-42","assignee":"worker","owner":"owner@example.com","priority":1,"estimated_minutes":45,"due_at":"2030-01-02T15:04:05Z","labels":["portfolio-graph-a","portfolio-graph-b"],"metadata":{"str":"v","num":3},"mol_type":"swarm","storage_class":"unversioned","pinned":true},
+				{"key":"deferred","title":"Deferred node","defer_until":"2030-01-01T00:00:00Z"},
+				{"key":"done","title":"Closed node","status":"closed"},
+				{"key":"evt","title":"Event node","type":"event","event_kind":"agent.started","actor":"agent://a","target":"bead://b","payload":"{\"k\":1}"},
+				{"key":"wisp","title":"Wisp node","ephemeral":true},
+				{"key":"gate","title":"Fanout gate"},
+				{"key":"spawner","title":"Spawner step"}
+			],
+			"edges": [{"from_key":"gate","to_key":"spawner","type":"waits-for","gate":"any-children","spawner_key":"spawner"}]
+		}`
+		planFile := filepath.Join(dir, "compound-plan.json")
+		if err := os.WriteFile(planFile, []byte(plan), 0o600); err != nil {
+			t.Fatalf("write compound graph plan: %v", err)
 		}
-		// Verify discovered-from dependency was created (keeps original direction)
-		assertDepExists(t, beadsDir, "di", child.ID, parent.ID)
+		result := bdCreateGraph(t, bd, dir, planFile)
+		if result.IDs["main"] != "gr-a1b2c3" || result.IDs["deferred"] == "" || result.IDs["done"] == "" || result.IDs["evt"] == "" || result.IDs["wisp"] == "" || result.IDs["gate"] == "" || result.IDs["spawner"] == "" {
+			t.Fatalf("compound graph IDs = %#v", result.IDs)
+		}
+		issue := bdShow(t, bd, dir, result.IDs["main"])
+		if issue.Status != types.StatusInProgress || issue.Description != "desc" || issue.Design != "the design" || issue.AcceptanceCriteria != "the criteria" || issue.Notes != "the notes" || issue.SpecID != "gr-spec1" || issue.ExternalRef == nil || *issue.ExternalRef != "gh-42" || issue.Assignee != "worker" || issue.Owner != "owner@example.com" || issue.Priority != 1 || issue.EstimatedMinutes == nil || *issue.EstimatedMinutes != 45 || issue.MolType != types.MolType("swarm") || issue.StorageClass != types.StorageClassUnversioned || !issue.Pinned {
+			t.Fatalf("compound graph full-field issue = %+v", issue)
+		}
+		if issue.DueAt == nil || issue.DueAt.UTC().Format(time.RFC3339) != "2030-01-02T15:04:05Z" {
+			t.Fatalf("compound graph due_at = %v, want 2030-01-02T15:04:05Z", issue.DueAt)
+		}
+		var metadata map[string]any
+		if err := json.Unmarshal(issue.Metadata, &metadata); err != nil || metadata["str"] != "v" || metadata["num"] != float64(3) {
+			t.Fatalf("compound graph metadata = %q, err = %v", issue.Metadata, err)
+		}
+		deferred := bdShow(t, bd, dir, result.IDs["deferred"])
+		if deferred.Status != types.StatusDeferred || deferred.DeferUntil == nil || deferred.DeferUntil.UTC().Format(time.RFC3339) != "2030-01-01T00:00:00Z" {
+			t.Fatalf("compound graph deferred node = %+v", deferred)
+		}
+		done := bdShow(t, bd, dir, result.IDs["done"])
+		if done.Status != types.StatusClosed || done.ClosedAt == nil {
+			t.Fatalf("compound graph closed node = %+v", done)
+		}
+		event := bdShow(t, bd, dir, result.IDs["evt"])
+		if event.EventKind != "agent.started" || event.Actor != "agent://a" || event.Target != "bead://b" || event.Payload != `{"k":1}` {
+			t.Fatalf("compound graph event fields: kind=%q actor=%q target=%q payload=%q", event.EventKind, event.Actor, event.Target, event.Payload)
+		}
+		planWide := make([]struct {
+			ids                          []string
+			wantEphemeral, wantNoHistory int
+		}, 0, 2)
+		for _, check := range []struct {
+			args                         []string
+			wantEphemeral, wantNoHistory int
+		}{{[]string{"--ephemeral"}, 1, 0}, {[]string{"--no-history"}, 0, 1}} {
+			planFile := writeGraphCreatePlan(t, dir)
+			journey := bdCreateGraph(t, bd, dir, planFile, check.args...)
+			planWide = append(planWide, struct {
+				ids                          []string
+				wantEphemeral, wantNoHistory int
+			}{[]string{journey.IDs["root"], journey.IDs["child"]}, check.wantEphemeral, check.wantNoHistory})
+		}
+
+		db, cleanup, err := embeddeddolt.OpenSQL(t.Context(), filepath.Join(beadsDir, "embeddeddolt"), "gr", "main")
+		if err != nil {
+			t.Fatalf("OpenSQL: %v", err)
+		}
+		defer cleanup()
+		var count int
+		if err := db.QueryRowContext(t.Context(), "SELECT COUNT(*) FROM issues WHERE id = ?", result.IDs["main"]).Scan(&count); err != nil || count != 1 {
+			t.Fatalf("durable graph node count = %d, err = %v", count, err)
+		}
+		if err := db.QueryRowContext(t.Context(), "SELECT COUNT(*) FROM wisps WHERE id = ?", result.IDs["wisp"]).Scan(&count); err != nil || count != 1 {
+			t.Fatalf("wisp graph node count = %d, err = %v", count, err)
+		}
+		var depMetadata string
+		if err := db.QueryRowContext(t.Context(), "SELECT COALESCE(metadata, '') FROM dependencies WHERE issue_id = ? AND COALESCE(depends_on_issue_id, depends_on_wisp_id, depends_on_external) = ? AND type = 'waits-for'", result.IDs["gate"], result.IDs["spawner"]).Scan(&depMetadata); err != nil {
+			t.Fatalf("query waits-for dependency: %v", err)
+		}
+		var waitsFor types.WaitsForMeta
+		if err := json.Unmarshal([]byte(depMetadata), &waitsFor); err != nil || waitsFor.Gate != types.WaitsForAnyChildren || waitsFor.SpawnerID != result.IDs["spawner"] {
+			t.Fatalf("waits-for metadata = %+v, raw = %q, err = %v", waitsFor, depMetadata, err)
+		}
+		if err := db.QueryRowContext(t.Context(), "SELECT COUNT(*) FROM labels AS OF 'HEAD' WHERE issue_id = ?", result.IDs["main"]).Scan(&count); err != nil || count != 2 {
+			t.Fatalf("graph label count = %d, err = %v", count, err)
+		}
+		if err := db.QueryRowContext(t.Context(), "SELECT COUNT(*) FROM events WHERE issue_id = ? AND event_type = ?", result.IDs["main"], types.EventLabelAdded).Scan(&count); err != nil || count != 2 {
+			t.Fatalf("graph label_added event count = %d, err = %v", count, err)
+		}
+
+		for _, check := range planWide {
+			for _, id := range check.ids {
+				var gotEphemeral, gotNoHistory int
+				if err := db.QueryRowContext(t.Context(), "SELECT ephemeral, no_history FROM wisps WHERE id = ?", id).Scan(&gotEphemeral, &gotNoHistory); err != nil {
+					t.Fatalf("query plan-wide graph wisp %s: %v", id, err)
+				}
+				if gotEphemeral != check.wantEphemeral || gotNoHistory != check.wantNoHistory {
+					t.Fatalf("plan-wide graph wisp %s flags = %d/%d, want %d/%d", id, gotEphemeral, gotNoHistory, check.wantEphemeral, check.wantNoHistory)
+				}
+			}
+		}
 	})
 
-	t.Run("markdown_bulk_create", func(t *testing.T) {
+	t.Run("dry_run_journey", func(t *testing.T) {
+		dir, beadsDir, _ := bdInit(t, bd, "--prefix", "dr")
+		parent := bdCreate(t, bd, dir, "Parent", "-t", "epic", "-l", "portfolio-preview-parent,portfolio-preview-shared")
+		type dryRunSnapshot struct {
+			head                                        string
+			issues, wisps, labels, dependencies, events int
+		}
+		readSnapshot := func() dryRunSnapshot {
+			db, cleanup, err := embeddeddolt.OpenSQL(t.Context(), filepath.Join(beadsDir, "embeddeddolt"), "dr", "main")
+			if err != nil {
+				t.Fatalf("OpenSQL: %v", err)
+			}
+			defer func() {
+				if err := cleanup(); err != nil {
+					t.Errorf("cleanup dry-run snapshot: %v", err)
+				}
+			}()
+			var got dryRunSnapshot
+			if err := db.QueryRowContext(t.Context(), "SELECT HASHOF('HEAD')").Scan(&got.head); err != nil {
+				t.Fatalf("read dry-run HEAD: %v", err)
+			}
+			for _, query := range []struct {
+				table string
+				count *int
+			}{
+				{"issues", &got.issues},
+				{"wisps", &got.wisps},
+				{"labels", &got.labels},
+				{"dependencies", &got.dependencies},
+				{"events", &got.events},
+			} {
+				if err := db.QueryRowContext(t.Context(), "SELECT COUNT(*) FROM "+query.table).Scan(query.count); err != nil {
+					t.Fatalf("count dry-run %s: %v", query.table, err)
+				}
+			}
+			return got
+		}
+		before := readSnapshot()
+		cmd := exec.Command(bd, "create", "--dry-run", "Preview child", "--json", "--parent", parent.ID, "-l", "portfolio-preview-child,portfolio-preview-shared")
+		cmd.Dir = dir
+		cmd.Env = bdEnv(dir)
+		stdout, stderr, err := runCommandBuffers(t, cmd)
+		if err != nil {
+			t.Fatalf("dry-run create: %v\nstdout:\n%s\nstderr:\n%s", err, stdout.String(), stderr.String())
+		}
+		preview := parseIssueJSON(t, stdout.Bytes())
+		wantLabels := map[string]bool{"portfolio-preview-parent": true, "portfolio-preview-shared": true, "portfolio-preview-child": true}
+		for _, label := range preview.Labels {
+			delete(wantLabels, label)
+		}
+		if len(preview.Labels) != 3 || len(wantLabels) != 0 {
+			t.Fatalf("dry-run labels = %v, want three deduplicated labels", preview.Labels)
+		}
+		after := readSnapshot()
+		if after != before {
+			t.Fatalf("dry-run mutated embedded state: before=%+v after=%+v", before, after)
+		}
+		child := bdCreate(t, bd, dir, "Real child", "--parent", parent.ID)
+		if child.ID != parent.ID+".1" {
+			t.Fatalf("dry-run consumed child counter: got %q, want %q", child.ID, parent.ID+".1")
+		}
+	})
+
+	t.Run("markdown_bulk_journey", func(t *testing.T) {
 		dir, beadsDir, _ := bdInit(t, bd, "--prefix", "mk")
-
-		mdContent := `## First issue
+		markdown := `## First issue
 
 ### Priority
 1
@@ -922,7 +515,7 @@ bug
 First bug description
 
 ### Labels
-urgent, backend
+portfolio-markdown-a, portfolio-markdown-b
 
 ## Second issue
 
@@ -935,185 +528,21 @@ feature
 ### Description
 A new feature
 `
-		mdFile := filepath.Join(dir, "issues.md")
-		if err := os.WriteFile(mdFile, []byte(mdContent), 0644); err != nil {
+		path := filepath.Join(dir, "issues.md")
+		if err := os.WriteFile(path, []byte(markdown), 0o600); err != nil {
 			t.Fatal(err)
 		}
-
-		cmd := exec.Command(bd, "create", "-f", mdFile, "--json")
+		cmd := exec.Command(bd, "create", "-f", path, "--json")
 		cmd.Dir = dir
 		cmd.Env = bdEnv(dir)
 		stdout, stderr, err := runCommandBuffers(t, cmd)
 		if err != nil {
-			t.Fatalf("bd create -f failed: %v\nstdout:\n%s\nstderr:\n%s", err, stdout.String(), stderr.String())
+			t.Fatalf("markdown bulk create: %v\nstdout:\n%s\nstderr:\n%s", err, stdout.String(), stderr.String())
 		}
-
-		// Verify both issues were created
 		store := openStore(t, beadsDir, "mk")
 		stats, err := store.GetStatistics(t.Context())
-		if err != nil {
-			t.Fatalf("GetStatistics: %v", err)
-		}
-		if stats.TotalIssues < 2 {
-			t.Errorf("expected at least 2 issues from markdown, got %d", stats.TotalIssues)
-		}
-	})
-
-	t.Run("graph_initial_labels_not_duplicated", func(t *testing.T) {
-		dir, beadsDir, _ := bdInit(t, bd, "--prefix", "gl")
-		plan := `{
-  "nodes": [
-    {"key": "root", "title": "Graph root", "type": "task", "labels": ["team-a", "shared"]}
-  ]
-}`
-		planFile := filepath.Join(dir, "graph-labels.json")
-		if err := os.WriteFile(planFile, []byte(plan), 0644); err != nil {
-			t.Fatal(err)
-		}
-
-		cmd := exec.Command(bd, "create", "--graph", planFile, "--json")
-		cmd.Dir = dir
-		cmd.Env = bdEnv(dir)
-		stdout, stderr, err := runCommandBuffers(t, cmd)
-		if err != nil {
-			t.Fatalf("bd create --graph failed: %v\nstdout:\n%s\nstderr:\n%s", err, stdout.String(), stderr.String())
-		}
-
-		var result GraphApplyResult
-		if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
-			t.Fatalf("parse graph result: %v\nstdout:\n%s", err, stdout.String())
-		}
-		id := result.IDs["root"]
-		if id == "" {
-			t.Fatalf("graph result missing root ID: %#v", result.IDs)
-		}
-
-		dataDir := filepath.Join(beadsDir, "embeddeddolt")
-		db, cleanup, err := embeddeddolt.OpenSQL(t.Context(), dataDir, "gl", "main")
-		if err != nil {
-			t.Fatalf("OpenSQL: %v", err)
-		}
-		defer cleanup()
-
-		var labelCount int
-		if err := db.QueryRowContext(t.Context(),
-			"SELECT COUNT(*) FROM labels AS OF 'HEAD' WHERE issue_id = ?", id).Scan(&labelCount); err != nil {
-			t.Fatalf("count labels: %v", err)
-		}
-		if labelCount != 2 {
-			t.Fatalf("label count = %d, want 2", labelCount)
-		}
-
-		// events is dolt_ignored since 0062 (bd-red8u): audit rows are durable
-		// in the working set, never at HEAD.
-		var labelEventCount int
-		if err := db.QueryRowContext(t.Context(),
-			"SELECT COUNT(*) FROM events WHERE issue_id = ? AND event_type = ?",
-			id, types.EventLabelAdded).Scan(&labelEventCount); err != nil {
-			t.Fatalf("count label events: %v", err)
-		}
-		if labelEventCount != 2 {
-			t.Fatalf("label_added event count = %d, want 2", labelEventCount)
-		}
-	})
-
-	t.Run("both_due_and_defer", func(t *testing.T) {
-		dir, _, _ := bdInit(t, bd, "--prefix", "bd2")
-		issue := bdCreate(t, bd, dir, "Both due and defer", "--due", "+48h", "--defer", "+24h")
-		if issue.DueAt == nil {
-			t.Fatal("expected DueAt to be set")
-		}
-		if issue.DeferUntil == nil {
-			t.Fatal("expected DeferUntil to be set")
-		}
-	})
-
-	t.Run("parent_label_inheritance_merge", func(t *testing.T) {
-		dir, beadsDir, _ := bdInit(t, bd, "--prefix", "pm")
-		parent := bdCreate(t, bd, dir, "Parent with a,b", "-t", "epic", "-l", "a,b")
-		// Child with explicit label "c" and "a" (overlaps parent)
-		child := bdCreate(t, bd, dir, "Child with c,a", "--parent", parent.ID, "-l", "c,a")
-
-		store := openStore(t, beadsDir, "pm")
-		childLabels, err := store.GetLabels(t.Context(), child.ID)
-		if err != nil {
-			t.Fatalf("GetLabels: %v", err)
-		}
-		labelMap := make(map[string]bool)
-		for _, l := range childLabels {
-			labelMap[l] = true
-		}
-		// Should have a, b (inherited), c (explicit) — deduped
-		for _, want := range []string{"a", "b", "c"} {
-			if !labelMap[want] {
-				t.Errorf("expected label %q, got %v", want, childLabels)
-			}
-		}
-		if len(childLabels) != 3 {
-			t.Errorf("expected 3 labels, got %d: %v", len(childLabels), childLabels)
-		}
-	})
-
-	t.Run("parent_no_labels", func(t *testing.T) {
-		dir, beadsDir, _ := bdInit(t, bd, "--prefix", "pn")
-		parent := bdCreate(t, bd, dir, "Labelless parent", "-t", "epic")
-		child := bdCreate(t, bd, dir, "Child of labelless", "--parent", parent.ID)
-
-		store := openStore(t, beadsDir, "pn")
-		childLabels, err := store.GetLabels(t.Context(), child.ID)
-		if err != nil {
-			t.Fatalf("GetLabels: %v", err)
-		}
-		if len(childLabels) != 0 {
-			t.Errorf("expected 0 labels, got %d: %v", len(childLabels), childLabels)
-		}
-	})
-
-	t.Run("discovered_from_inherits_source_repo", func(t *testing.T) {
-		dir, beadsDir, _ := bdInit(t, bd, "--prefix", "sr")
-
-		// Create parent with source_repo set via store API
-		store := openStore(t, beadsDir, "sr")
-		parent := &types.Issue{
-			Title:      "Parent with source repo",
-			Priority:   1,
-			Status:     types.StatusOpen,
-			IssueType:  types.TypeTask,
-			SourceRepo: "/path/to/repo",
-		}
-		if err := store.CreateIssue(t.Context(), parent, "test"); err != nil {
-			t.Fatalf("CreateIssue: %v", err)
-		}
-		if err := store.Commit(t.Context(), "create parent"); err != nil {
-			t.Fatalf("Commit: %v", err)
-		}
-		store.Close()
-
-		child := bdCreate(t, bd, dir, "Discovered bug", "--deps", "discovered-from:"+parent.ID)
-
-		// Verify via raw SQL since the JSON output may not include source_repo
-		dataDir := filepath.Join(beadsDir, "embeddeddolt")
-		db, cleanup, err := embeddeddolt.OpenSQL(t.Context(), dataDir, "sr", "main")
-		if err != nil {
-			t.Fatalf("OpenSQL: %v", err)
-		}
-		defer cleanup()
-		var sourceRepo string
-		err = db.QueryRowContext(t.Context(),
-			"SELECT COALESCE(source_repo, '') FROM issues WHERE id = ?", child.ID).Scan(&sourceRepo)
-		if err != nil {
-			t.Fatalf("query source_repo: %v", err)
-		}
-		if sourceRepo != "/path/to/repo" {
-			t.Errorf("source_repo: got %q, want %q", sourceRepo, "/path/to/repo")
-		}
-	})
-
-	t.Run("no_title_fails", func(t *testing.T) {
-		dir, _, _ := bdInit(t, bd, "--prefix", "nt2")
-		out := bdCreateFail(t, bd, dir)
-		if !strings.Contains(out, "title") {
-			t.Errorf("expected title-related error, got: %s", out)
+		if err != nil || stats.TotalIssues < 2 {
+			t.Fatalf("markdown bulk statistics = %+v, err = %v", stats, err)
 		}
 	})
 }


### PR DESCRIPTION
## What

Consolidate `TestEmbeddedCreate` from 48 separately initialized cases into six boundary-focused journeys. This is a one-file, test-only change; production behavior and CI selection are unchanged.

## Why

The hosted baseline from #5290 put `TestEmbeddedCreate` at **773.02s** and Embedded Cmd shard 7 at **15m12s**. Most of that matrix repeated parser, validation, and projection semantics already owned by lower tests while paying for a fresh real-Dolt workspace each time.

The retained portfolio keeps the risks that only the real process/store boundary can prove:

| Journey | Distinct boundary risk retained |
| --- | --- |
| Scalar create | CLI-to-JSON defaults, full-field projection, status/config wiring, and errors |
| Relationships and parent | Dependency direction, hierarchical IDs, label inheritance/deduplication, no-inherit behavior, and `source_repo` inheritance |
| Storage plane | Ephemeral and no-history routing at rest |
| Graph create | Full-field persistence, durable/wisp mixing, deferred/closed/event values, waits-for metadata, labels, and label events |
| Dry run | Parent-label preview without changes to HEAD, issues, wisps, labels, dependencies, events, or the child counter |
| Markdown bulk | File parser through the real CLI/process/store boundary |

All separate embedded tests below `TestEmbeddedCreate` remain byte-identical, including migration, cross-repository, commit, remote, and concurrency coverage. Removed combinatorial cases retain lower-owner coverage in the create input/builders, dependency parsing, label merge, graph validation/execution, write-verb parity, and Markdown parser tests.

Beads work item: `bd-okxx4`.

## Performance evidence

The exact reviewed diff produced three normal full leaf measurements before commit: **36.20s**, **39.75s**, and **44.158s**. A post-rebase run on current `main` completed in **41.556s**. The first two measured package durations were 40.615s and 44.204s, with external wall times of 60.56s and 63.78s.

One earlier run took 435.403s under host contention. It did not reproduce: isolated profiling put the six journeys at 40.18s total, with each journey between 4.31s and 9.58s. Hosted PR Risk remains the authoritative shard comparison because local and hosted hardware differ.

## Contributor protection

- #4738 also touches this test file, but its `status.default` implementation and four new tests are not on `main`; this PR neither copies nor supersedes them.
- #5122 retains ownership of the explicit hierarchical child-counter fix and conformance coverage; this portfolio only preserves the ordinary hierarchy observation already on `main`.
- #5164, #4757, and #5243 remain independent. This branch does not use #5182 as a base.

## Verification

- `BEADS_TEST_EMBEDDED_DOLT=1 ./scripts/test.sh -run '^TestEmbeddedCreate$' ./cmd/bd/...`
- Focused lower-owner Create, dependency, label, graph, parity, and Markdown tests
- `make test` — all packages passed; total coverage 39.2%
- `golangci-lint run ./cmd/bd/...` — 0 issues
- `gofmt -d cmd/bd/create_embedded_test.go`
- `git diff --check`
- Two independent delegated Sol reviews: APPROVE, no blocker/major findings

This nontrivial test change still requires substantive human review before merge.

_codex-unknown-model-unknown-reasoning on behalf of CI Bot_
