### PR TITLE
ci: let macOS caches bootstrap after test failure

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -578,21 +578,21 @@ jobs:
       # Only the macOS leg owns macOS generations. The Linux leg restores the
       # Linux writers above and must never become a second cache publisher.
       - name: Save Go module cache
-        if: matrix.os == 'macos-latest' && steps.restore-go-module-cache.outputs.cache-hit != 'true'
+        if: ${{ !cancelled() && matrix.os == 'macos-latest' && steps.restore-go-module-cache.outputs.cache-hit != 'true' }}
         uses: actions/cache/save@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           path: ~/go/pkg/mod
           key: beads-go-mod-v2-${{ runner.os }}-${{ runner.arch }}-go-${{ steps.setup-go.outputs.go-version }}-${{ hashFiles('go.mod', 'go.sum') }}
 
       - name: Save non-race Go build cache
-        if: matrix.os == 'macos-latest' && steps.restore-non-race-go-build-cache.outputs.cache-hit != 'true'
+        if: ${{ !cancelled() && matrix.os == 'macos-latest' && steps.restore-non-race-go-build-cache.outputs.cache-hit != 'true' }}
         uses: actions/cache/save@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           path: ${{ runner.temp }}/go-cache/non-race
           key: beads-go-build-v2-${{ runner.os }}-${{ runner.arch }}-go-${{ steps.setup-go.outputs.go-version }}-base-gms_pure_go-non-race-${{ github.sha }}
 
       - name: Save race Go build cache
-        if: matrix.os == 'macos-latest' && steps.restore-race-go-build-cache.outputs.cache-hit != 'true'
+        if: ${{ !cancelled() && matrix.os == 'macos-latest' && steps.restore-race-go-build-cache.outputs.cache-hit != 'true' }}
         uses: actions/cache/save@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           path: ${{ runner.temp }}/go-cache/race

--- a/scripts/ci_workflow_test.go
+++ b/scripts/ci_workflow_test.go
@@ -87,7 +87,7 @@ func TestGoCacheOwnershipTopology(t *testing.T) {
 	})
 	assertGoCacheInventory(t, workflows["main.yml"].job(t, "test"), []goCacheStep{
 		mainRestoreModuleCache(), mainRestoreBuildCacheIf("non-race", macOSMatrixCondition), mainRestoreBuildCache("race"),
-		saveModuleCacheIf(macOSMatrixCondition), saveBuildCacheIf("non-race", macOSMatrixCondition), saveBuildCacheIf("race", macOSMatrixCondition),
+		saveModuleCacheAfterFailureOnMacOS(), saveBuildCacheAfterFailureOnMacOS("non-race"), saveBuildCacheAfterFailureOnMacOS("race"),
 	})
 	assertGoCacheInventory(t, workflows["main.yml"].job(t, "test-windows"), []goCacheStep{
 		mainRestoreModuleCache(), mainRestoreBuildCache("non-race"), saveModuleCache(), saveBuildCache("non-race"),
@@ -200,9 +200,9 @@ func TestGoCacheOwnershipTopology(t *testing.T) {
 	assertGoCacheWriter(t, workflows["main.yml"], "build-artifacts", "ubuntu-latest", "Save Go module cache", cacheMissCondition(goModuleCacheRestoreID))
 	assertGoCacheWriter(t, workflows["main.yml"], "build-artifacts", "ubuntu-latest", "Save non-race Go build cache", cacheMissCondition(goBuildCacheRestoreID("non-race")))
 	assertGoCacheWriter(t, workflows["main.yml"], "build-embedded", "ubuntu-latest", "Save race Go build cache", cacheMissCondition(goBuildCacheRestoreID("race")))
-	assertGoCacheWriter(t, workflows["main.yml"], "test", "${{ matrix.os }}", "Save Go module cache", combineConditions(macOSMatrixCondition, cacheMissCondition(goModuleCacheRestoreID)))
-	assertGoCacheWriter(t, workflows["main.yml"], "test", "${{ matrix.os }}", "Save non-race Go build cache", combineConditions(macOSMatrixCondition, cacheMissCondition(goBuildCacheRestoreID("non-race"))))
-	assertGoCacheWriter(t, workflows["main.yml"], "test", "${{ matrix.os }}", "Save race Go build cache", combineConditions(macOSMatrixCondition, cacheMissCondition(goBuildCacheRestoreID("race"))))
+	assertGoCacheWriter(t, workflows["main.yml"], "test", "${{ matrix.os }}", "Save Go module cache", failureSurvivingCacheSaveCondition(macOSMatrixCondition, cacheMissCondition(goModuleCacheRestoreID)))
+	assertGoCacheWriter(t, workflows["main.yml"], "test", "${{ matrix.os }}", "Save non-race Go build cache", failureSurvivingCacheSaveCondition(macOSMatrixCondition, cacheMissCondition(goBuildCacheRestoreID("non-race"))))
+	assertGoCacheWriter(t, workflows["main.yml"], "test", "${{ matrix.os }}", "Save race Go build cache", failureSurvivingCacheSaveCondition(macOSMatrixCondition, cacheMissCondition(goBuildCacheRestoreID("race"))))
 	assertGoCacheWriter(t, workflows["main.yml"], "test-windows", "windows-latest", "Save Go module cache", cacheMissCondition(goModuleCacheRestoreID))
 	assertGoCacheWriter(t, workflows["main.yml"], "test-windows", "windows-latest", "Save non-race Go build cache", cacheMissCondition(goBuildCacheRestoreID("non-race")))
 	for _, target := range []struct{ workflow, job string }{
@@ -307,6 +307,10 @@ func combineConditions(conditions ...string) string {
 	return strings.Join(nonEmpty, " && ")
 }
 
+func failureSurvivingCacheSaveCondition(conditions ...string) string {
+	return "${{ !cancelled() && " + combineConditions(conditions...) + " }}"
+}
+
 func restoreModuleCache() goCacheStep {
 	return goCacheStep{name: "Restore Go module cache", family: cacheRestoreActionFamily, key: goModuleCacheKey(), restoreKeys: goModuleCacheRestoreKeys(), path: goModuleCachePath}
 }
@@ -321,6 +325,12 @@ func saveModuleCache() goCacheStep { return saveModuleCacheIf("") }
 
 func saveModuleCacheIf(condition string) goCacheStep {
 	return goCacheStep{name: "Save Go module cache", family: cacheSaveActionFamily, key: goModuleCacheKey(), path: goModuleCachePath, ifCondition: combineConditions(condition, cacheMissCondition(goModuleCacheRestoreID))}
+}
+
+func saveModuleCacheAfterFailureOnMacOS() goCacheStep {
+	step := saveModuleCache()
+	step.ifCondition = failureSurvivingCacheSaveCondition(macOSMatrixCondition, cacheMissCondition(goModuleCacheRestoreID))
+	return step
 }
 
 func restoreBuildCache(profile string) goCacheStep {
@@ -345,6 +355,12 @@ func saveBuildCache(profile string) goCacheStep { return saveBuildCacheIf(profil
 
 func saveBuildCacheIf(profile, condition string) goCacheStep {
 	return goCacheStep{name: "Save " + profile + " Go build cache", family: cacheSaveActionFamily, key: goBuildCacheKey(profile), path: goBuildCachePath(profile), ifCondition: combineConditions(condition, cacheMissCondition(goBuildCacheRestoreID(profile)))}
+}
+
+func saveBuildCacheAfterFailureOnMacOS(profile string) goCacheStep {
+	step := saveBuildCache(profile)
+	step.ifCondition = failureSurvivingCacheSaveCondition(macOSMatrixCondition, cacheMissCondition(goBuildCacheRestoreID(profile)))
+	return step
 }
 
 func assertGoCacheInventory(t *testing.T, job ciWorkflowJob, want []goCacheStep) {
@@ -381,23 +397,16 @@ func assertConditionalCacheWritersHaveMatrixMember(t *testing.T, job ciWorkflowJ
 	}
 
 	conditionalWriters := 0
+	wantCondition := "matrix.os == '" + wantMember + "'"
 	for _, step := range job.Steps {
 		if actionFamily(step.Uses) != cacheSaveActionFamily {
 			continue
 		}
-		remainder, found := strings.CutPrefix(step.If, "matrix.os == '")
-		if !found {
-			continue
-		}
-		member, _, found := strings.Cut(remainder, "'")
-		if !found {
-			t.Errorf("cache writer %q has malformed matrix.os condition %q", step.Name, step.If)
+		if !strings.Contains(step.If, wantCondition) {
+			t.Errorf("cache writer %q condition %q does not target matrix member %q", step.Name, step.If, wantMember)
 			continue
 		}
 		conditionalWriters++
-		if member != wantMember {
-			t.Errorf("cache writer %q targets matrix member %q, want %q", step.Name, member, wantMember)
-		}
 	}
 	if conditionalWriters == 0 {
 		t.Fatal("job has no conditional matrix cache writers")


### PR DESCRIPTION
## What

Allow the three trusted-main macOS Go cache writers to save after an ordinary build or test failure, while continuing to skip saves when the workflow is cancelled or the matching cache was restored.

The workflow contract now requires that exact condition for the module, non-race build, and race build caches. PR and PR Risk workflows remain restore-only.

## Why

#5278 moved CI to explicit v2 caches, but the macOS writers remained implicitly success-gated. A cold macOS test timeout therefore skipped every save, leaving the next run cold and capable of repeating the same timeout.

Main has since recovered on a failed-job rerun and seeded the caches, so this is a recurrence guard rather than a claim that main is still red. The seeded cache sizes support the diagnosis:

- module cache: 455,786,893 bytes
- non-race build cache: 303,286,479 bytes
- race build cache: 755,221,506 bytes

This does not change test selection, commands, timeouts, matrices, artifacts, or required gates. Go's build cache is content-addressed, and only trusted pushes to `main` can publish these entries.

Tracks `bd-712nf`.

## Verification

- `./scripts/test.sh -count=1 -run '^TestGoCacheOwnershipTopology$' ./scripts`
- `./scripts/test.sh ./scripts`
- `go vet ./scripts`
- `actionlint .github/workflows/main.yml .github/workflows/pr.yml .github/workflows/pr-risk.yml`
- `make test`
- `git diff --check`
- Two independent blocker/major-only architecture and contract reviews: approved with no findings

Hosted evidence: main run [30756940756](https://github.com/gastownhall/beads/actions/runs/30756940756) passed on rerun and published all three v2 macOS caches.

_codex-unknown-model-unknown-reasoning on behalf of CI Bot_
