### PR TITLE
test: consolidate embedded Migrate journeys

### DIFF
--- a/cmd/bd/migrate_embedded_test.go
+++ b/cmd/bd/migrate_embedded_test.go
@@ -31,6 +31,21 @@ func bdMigrate(t *testing.T, bd, dir string, args ...string) string {
 	return stdout.String()
 }
 
+// bdMigrateJSON runs "bd --json migrate" so PersistentPreRunE observes the
+// explicit root flag even though migrate subcommands also register local flags.
+func bdMigrateJSON(t *testing.T, bd, dir string, args ...string) string {
+	t.Helper()
+	fullArgs := append([]string{"--json", "migrate"}, args...)
+	cmd := exec.Command(bd, fullArgs...)
+	cmd.Dir = dir
+	cmd.Env = bdEnv(dir)
+	stdout, stderr, err := runCommandBuffers(t, cmd)
+	if err != nil {
+		t.Fatalf("bd --json migrate %s failed: %v\nstdout:\n%s\nstderr:\n%s", strings.Join(args, " "), err, stdout.String(), stderr.String())
+	}
+	return stdout.String()
+}
+
 // extractNewRepoID pulls the fingerprint from the "  New: <hash>" line of
 // `bd migrate --update-repo-id --dry-run` output.
 func extractNewRepoID(t *testing.T, out string) string {
@@ -66,6 +81,13 @@ func withEmbeddedMigrateSQL(t *testing.T, beadsDir, database string, operation f
 	}
 }
 
+func setMigrateJSONConfigFalse(t *testing.T, beadsDir string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(beadsDir, "config.yaml"), []byte("json: false\n"), 0o600); err != nil {
+		t.Fatalf("write explicit false JSON config: %v", err)
+	}
+}
+
 func TestEmbeddedMigrate(t *testing.T) {
 	if os.Getenv("BEADS_TEST_EMBEDDED_DOLT") != "1" {
 		t.Skip("set BEADS_TEST_EMBEDDED_DOLT=1 to run embedded dolt integration tests")
@@ -76,6 +98,7 @@ func TestEmbeddedMigrate(t *testing.T) {
 
 	t.Run("migrate_metadata_preview_and_inspection", func(t *testing.T) {
 		dir, beadsDir, _ := bdInit(t, bd, "--prefix", "mg")
+		setMigrateJSONConfigFalse(t, beadsDir)
 		bdCreate(t, bd, dir, "Inspect test issue", "--type", "task")
 		const staleVersion = "0.0.0"
 		setVersion := func(version string) {
@@ -106,7 +129,7 @@ func TestEmbeddedMigrate(t *testing.T) {
 
 		inspect := func() map[string]interface{} {
 			t.Helper()
-			out := bdMigrate(t, bd, dir, "--inspect", "--json")
+			out := bdMigrateJSON(t, bd, dir, "--inspect")
 			var result map[string]interface{}
 			if err := json.Unmarshal([]byte(out), &result); err != nil {
 				t.Fatalf("migrate --inspect --json returned invalid JSON: %v\n%s", err, out)
@@ -135,7 +158,7 @@ func TestEmbeddedMigrate(t *testing.T) {
 		}
 
 		before := inspect()
-		out := bdMigrate(t, bd, dir, "--dry-run", "--json")
+		out := bdMigrateJSON(t, bd, dir, "--dry-run")
 		var preview map[string]interface{}
 		if err := json.Unmarshal([]byte(out), &preview); err != nil {
 			t.Fatalf("migrate --dry-run --json returned invalid JSON: %v\n%s", err, out)
@@ -174,6 +197,7 @@ func TestEmbeddedMigrate(t *testing.T) {
 	t.Run("migrate_update_repo_id_honors_C", func(t *testing.T) {
 		dirA, _, _ := bdInit(t, bd, "--prefix", "ca")
 		dirB, beadsDirB, _ := bdInit(t, bd, "--prefix", "cb")
+		setMigrateJSONConfigFalse(t, beadsDirB)
 
 		runDryRun := func(cwd, target, home string) string {
 			cmd := exec.Command(bd, "-C", target, "migrate", "--update-repo-id", "--dry-run")
@@ -221,7 +245,7 @@ func TestEmbeddedMigrate(t *testing.T) {
 			return nil
 		})
 
-		cmd := exec.Command(bd, "-C", dirB, "migrate", "--update-repo-id", "--yes", "--json")
+		cmd := exec.Command(bd, "-C", dirB, "--json", "migrate", "--update-repo-id", "--yes")
 		cmd.Dir = dirA
 		cmd.Env = bdEnv(dirB)
 		stdout, stderr, err := runCommandBuffers(t, cmd)
@@ -252,10 +276,11 @@ func TestEmbeddedMigrate(t *testing.T) {
 	})
 
 	t.Run("migrate_schema_json_is_idempotent", func(t *testing.T) {
-		dir, _, _ := bdInit(t, bd, "--prefix", "sc")
+		dir, beadsDir, _ := bdInit(t, bd, "--prefix", "sc")
+		setMigrateJSONConfigFalse(t, beadsDir)
 		run := func() map[string]interface{} {
 			t.Helper()
-			out := bdMigrate(t, bd, dir, "schema", "--json")
+			out := bdMigrateJSON(t, bd, dir, "schema")
 			var result map[string]interface{}
 			if err := json.Unmarshal([]byte(out), &result); err != nil {
 				t.Fatalf("migrate schema --json returned invalid JSON: %v\n%s", err, out)
@@ -288,11 +313,12 @@ func TestEmbeddedMigrate(t *testing.T) {
 	})
 
 	t.Run("migrate_sync_persists_and_noops", func(t *testing.T) {
-		dir, _, _ := bdInit(t, bd, "--prefix", "ms")
+		dir, beadsDir, _ := bdInit(t, bd, "--prefix", "ms")
+		setMigrateJSONConfigFalse(t, beadsDir)
 		const branch = "beads-sync"
 		decode := func(args ...string) map[string]interface{} {
 			t.Helper()
-			out := bdMigrate(t, bd, dir, args...)
+			out := bdMigrateJSON(t, bd, dir, args...)
 			var result map[string]interface{}
 			if err := json.Unmarshal([]byte(out), &result); err != nil {
 				t.Fatalf("migrate %s returned invalid JSON: %v\n%s", strings.Join(args, " "), err, out)
@@ -300,7 +326,7 @@ func TestEmbeddedMigrate(t *testing.T) {
 			return result
 		}
 
-		dryRun := decode("sync", branch, "--dry-run", "--json")
+		dryRun := decode("sync", branch, "--dry-run")
 		if got, ok := dryRun["dry_run"].(bool); !ok || !got {
 			t.Errorf("migrate sync dry_run = %#v, want true", dryRun["dry_run"])
 		}
@@ -311,7 +337,7 @@ func TestEmbeddedMigrate(t *testing.T) {
 			t.Errorf("migrate sync dry-run changed = %#v, want true", dryRun["changed"])
 		}
 
-		applied := decode("sync", branch, "--json")
+		applied := decode("sync", branch)
 		if got, ok := applied["status"].(string); !ok || got != "success" {
 			t.Errorf("migrate sync status = %#v, want success", applied["status"])
 		}
@@ -330,7 +356,7 @@ func TestEmbeddedMigrate(t *testing.T) {
 			t.Errorf("reopened sync.branch = %q, want %q", got, branch)
 		}
 
-		noop := decode("sync", branch, "--json")
+		noop := decode("sync", branch)
 		if got, ok := noop["status"].(string); !ok || got != "noop" {
 			t.Errorf("same-value migrate sync status = %#v, want noop", noop["status"])
 		}

--- a/cmd/bd/migrate_embedded_test.go
+++ b/cmd/bd/migrate_embedded_test.go
@@ -31,17 +31,17 @@ func bdMigrate(t *testing.T, bd, dir string, args ...string) string {
 	return stdout.String()
 }
 
-// bdMigrateJSON runs "bd --json migrate" so PersistentPreRunE observes the
-// explicit root flag even though migrate subcommands also register local flags.
+// bdMigrateJSON runs "bd --format=json migrate" so PersistentPreRunE observes
+// the unique root flag without migrate's duplicate local --json shadowing it.
 func bdMigrateJSON(t *testing.T, bd, dir string, args ...string) string {
 	t.Helper()
-	fullArgs := append([]string{"--json", "migrate"}, args...)
+	fullArgs := append([]string{"--format=json", "migrate"}, args...)
 	cmd := exec.Command(bd, fullArgs...)
 	cmd.Dir = dir
 	cmd.Env = bdEnv(dir)
 	stdout, stderr, err := runCommandBuffers(t, cmd)
 	if err != nil {
-		t.Fatalf("bd --json migrate %s failed: %v\nstdout:\n%s\nstderr:\n%s", strings.Join(args, " "), err, stdout.String(), stderr.String())
+		t.Fatalf("bd --format=json migrate %s failed: %v\nstdout:\n%s\nstderr:\n%s", strings.Join(args, " "), err, stdout.String(), stderr.String())
 	}
 	return stdout.String()
 }
@@ -132,7 +132,7 @@ func TestEmbeddedMigrate(t *testing.T) {
 			out := bdMigrateJSON(t, bd, dir, "--inspect")
 			var result map[string]interface{}
 			if err := json.Unmarshal([]byte(out), &result); err != nil {
-				t.Fatalf("migrate --inspect --json returned invalid JSON: %v\n%s", err, out)
+				t.Fatalf("bd --format=json migrate --inspect returned invalid JSON: %v\n%s", err, out)
 			}
 			for _, key := range []string{"registered_migrations", "current_state", "warnings", "invariants_to_check"} {
 				if _, ok := result[key]; !ok {
@@ -161,7 +161,7 @@ func TestEmbeddedMigrate(t *testing.T) {
 		out := bdMigrateJSON(t, bd, dir, "--dry-run")
 		var preview map[string]interface{}
 		if err := json.Unmarshal([]byte(out), &preview); err != nil {
-			t.Fatalf("migrate --dry-run --json returned invalid JSON: %v\n%s", err, out)
+			t.Fatalf("bd --format=json migrate --dry-run returned invalid JSON: %v\n%s", err, out)
 		}
 		if got, ok := preview["dry_run"].(bool); !ok || !got {
 			t.Errorf("migrate metadata dry_run = %#v, want true", preview["dry_run"])
@@ -245,16 +245,16 @@ func TestEmbeddedMigrate(t *testing.T) {
 			return nil
 		})
 
-		cmd := exec.Command(bd, "-C", dirB, "--json", "migrate", "--update-repo-id", "--yes")
+		cmd := exec.Command(bd, "-C", dirB, "--format=json", "migrate", "--update-repo-id", "--yes")
 		cmd.Dir = dirA
 		cmd.Env = bdEnv(dirB)
 		stdout, stderr, err := runCommandBuffers(t, cmd)
 		if err != nil {
-			t.Fatalf("bd -C %s migrate --update-repo-id --yes --json (cwd=%s) failed: %v\nstdout:\n%s\nstderr:\n%s", dirB, dirA, err, stdout.String(), stderr.String())
+			t.Fatalf("bd -C %s --format=json migrate --update-repo-id --yes (cwd=%s) failed: %v\nstdout:\n%s\nstderr:\n%s", dirB, dirA, err, stdout.String(), stderr.String())
 		}
 		var applied map[string]interface{}
 		if err := json.Unmarshal(stdout.Bytes(), &applied); err != nil {
-			t.Fatalf("migrate --update-repo-id --json returned invalid JSON: %v\n%s", err, stdout.String())
+			t.Fatalf("bd -C %s --format=json migrate --update-repo-id returned invalid JSON: %v\n%s", dirB, err, stdout.String())
 		}
 		if got, ok := applied["status"].(string); !ok || got != "success" {
 			t.Errorf("migrate --update-repo-id status = %#v, want success", applied["status"])
@@ -283,7 +283,7 @@ func TestEmbeddedMigrate(t *testing.T) {
 			out := bdMigrateJSON(t, bd, dir, "schema")
 			var result map[string]interface{}
 			if err := json.Unmarshal([]byte(out), &result); err != nil {
-				t.Fatalf("migrate schema --json returned invalid JSON: %v\n%s", err, out)
+				t.Fatalf("bd --format=json migrate schema returned invalid JSON: %v\n%s", err, out)
 			}
 			for _, key := range []string{"status", "applied", "latest_version"} {
 				if _, ok := result[key]; !ok {
@@ -345,17 +345,7 @@ func TestEmbeddedMigrate(t *testing.T) {
 			t.Errorf("migrate sync branch = %#v, want %q", applied["branch"], branch)
 		}
 
-		cmd := exec.Command(bd, "config", "get", "sync.branch")
-		cmd.Dir = dir
-		cmd.Env = bdEnv(dir)
-		stdout, stderr, err := runCommandBuffers(t, cmd)
-		if err != nil {
-			t.Fatalf("bd config get sync.branch failed: %v\nstdout:\n%s\nstderr:\n%s", err, stdout.String(), stderr.String())
-		}
-		if got := strings.TrimSpace(stdout.String()); got != branch {
-			t.Errorf("reopened sync.branch = %q, want %q", got, branch)
-		}
-
+		// decode launches a fresh process, so noop proves the store value persisted across reopen.
 		noop := decode("sync", branch)
 		if got, ok := noop["status"].(string); !ok || got != "noop" {
 			t.Errorf("same-value migrate sync status = %#v, want noop", noop["status"])

--- a/cmd/bd/migrate_embedded_test.go
+++ b/cmd/bd/migrate_embedded_test.go
@@ -3,13 +3,18 @@
 package main
 
 import (
+	"database/sql"
 	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
+	"reflect"
 	"strings"
 	"sync"
 	"testing"
+
+	"github.com/steveyegge/beads/internal/storage/embeddeddolt"
 )
 
 // bdMigrate runs "bd migrate" with the given args and returns stdout.
@@ -40,18 +45,25 @@ func extractNewRepoID(t *testing.T, out string) string {
 	return ""
 }
 
-// bdMigrateFail runs "bd migrate" expecting failure.
-func bdMigrateFail(t *testing.T, bd, dir string, args ...string) string {
+// withEmbeddedMigrateSQL runs a direct fixture operation and verifies that the
+// embedded SQL connection closes cleanly even when the operation fails.
+func withEmbeddedMigrateSQL(t *testing.T, beadsDir, database string, operation func(*sql.DB) error) {
 	t.Helper()
-	fullArgs := append([]string{"migrate"}, args...)
-	cmd := exec.Command(bd, fullArgs...)
-	cmd.Dir = dir
-	cmd.Env = bdEnv(dir)
-	out, err := cmd.CombinedOutput()
-	if err == nil {
-		t.Fatalf("expected bd migrate %s to fail, but succeeded:\n%s", strings.Join(args, " "), out)
+	db, cleanup, err := embeddeddolt.OpenSQL(t.Context(), filepath.Join(beadsDir, "embeddeddolt"), database, "main")
+	if err != nil {
+		t.Fatalf("open embedded database: %v", err)
 	}
-	return string(out)
+	opErr := operation(db)
+	cleanupErr := cleanup()
+	if opErr != nil && cleanupErr != nil {
+		t.Fatalf("embedded database operation failed: %v; cleanup failed: %v", opErr, cleanupErr)
+	}
+	if opErr != nil {
+		t.Fatalf("embedded database operation failed: %v", opErr)
+	}
+	if cleanupErr != nil {
+		t.Fatalf("close embedded database: %v", cleanupErr)
+	}
 }
 
 func TestEmbeddedMigrate(t *testing.T) {
@@ -62,68 +74,96 @@ func TestEmbeddedMigrate(t *testing.T) {
 
 	bd := buildEmbeddedBD(t)
 
-	// ===== Default (metadata update) =====
-
-	t.Run("migrate_default", func(t *testing.T) {
-		dir, _, _ := bdInit(t, bd, "--prefix", "mg")
-		out := bdMigrate(t, bd, dir)
-		if !strings.Contains(out, "Dolt database") {
-			t.Errorf("expected 'Dolt database' in output: %s", out)
-		}
-	})
-
-	// ===== --dry-run =====
-
-	t.Run("migrate_dry_run", func(t *testing.T) {
-		dir, _, _ := bdInit(t, bd, "--prefix", "md")
-		out := bdMigrate(t, bd, dir, "--dry-run")
-		// Should show what would be done without making changes
-		if len(strings.TrimSpace(out)) == 0 {
-			t.Error("expected non-empty --dry-run output")
-		}
-	})
-
-	// ===== --inspect =====
-
-	t.Run("migrate_inspect", func(t *testing.T) {
-		dir, _, _ := bdInit(t, bd, "--prefix", "mi")
+	t.Run("migrate_metadata_preview_and_inspection", func(t *testing.T) {
+		dir, beadsDir, _ := bdInit(t, bd, "--prefix", "mg")
 		bdCreate(t, bd, dir, "Inspect test issue", "--type", "task")
-		out := bdMigrate(t, bd, dir, "--inspect")
-		if !strings.Contains(out, "Migration") || !strings.Contains(out, "Inspection") {
-			t.Errorf("expected migration inspection output: %s", out)
+		const staleVersion = "0.0.0"
+		setVersion := func(version string) {
+			t.Helper()
+			withEmbeddedMigrateSQL(t, beadsDir, "mg", func(db *sql.DB) error {
+				result, err := db.ExecContext(t.Context(), "UPDATE local_metadata SET value = ? WHERE `key` = ?", version, "bd_version")
+				if err != nil {
+					return fmt.Errorf("set fixture bd_version: %w", err)
+				}
+				if rows, err := result.RowsAffected(); err != nil || rows != 1 {
+					return fmt.Errorf("set fixture bd_version affected %d rows, %v; want 1", rows, err)
+				}
+				return nil
+			})
 		}
-	})
+		getVersion := func() string {
+			t.Helper()
+			var version string
+			withEmbeddedMigrateSQL(t, beadsDir, "mg", func(db *sql.DB) error {
+				if err := db.QueryRowContext(t.Context(), "SELECT value FROM local_metadata WHERE `key` = ?", "bd_version").Scan(&version); err != nil {
+					return fmt.Errorf("read fixture bd_version: %w", err)
+				}
+				return nil
+			})
+			return version
+		}
+		setVersion(staleVersion)
 
-	t.Run("migrate_inspect_json", func(t *testing.T) {
-		dir, _, _ := bdInit(t, bd, "--prefix", "mj")
-		out := bdMigrate(t, bd, dir, "--inspect", "--json")
-		s := strings.TrimSpace(out)
-		start := strings.Index(s, "{")
-		if start >= 0 {
-			var m map[string]interface{}
-			if err := json.Unmarshal([]byte(s[start:]), &m); err != nil {
-				t.Errorf("invalid JSON: %v\n%s", err, s)
+		inspect := func() map[string]interface{} {
+			t.Helper()
+			out := bdMigrate(t, bd, dir, "--inspect", "--json")
+			var result map[string]interface{}
+			if err := json.Unmarshal([]byte(out), &result); err != nil {
+				t.Fatalf("migrate --inspect --json returned invalid JSON: %v\n%s", err, out)
 			}
+			for _, key := range []string{"registered_migrations", "current_state", "warnings", "invariants_to_check"} {
+				if _, ok := result[key]; !ok {
+					t.Errorf("migrate inspection JSON missing %q: %v", key, result)
+				}
+			}
+			state, ok := result["current_state"].(map[string]interface{})
+			if !ok {
+				t.Fatalf("migrate inspection current_state = %#v, want object", result["current_state"])
+			}
+			for _, key := range []string{"schema_version", "issue_count", "config", "missing_config", "db_exists"} {
+				if _, ok := state[key]; !ok {
+					t.Errorf("migrate inspection current_state missing %q: %v", key, state)
+				}
+			}
+			if got, ok := state["db_exists"].(bool); !ok || !got {
+				t.Errorf("migrate inspection db_exists = %#v, want true", state["db_exists"])
+			}
+			if got, ok := state["issue_count"].(float64); !ok || got != 1 {
+				t.Errorf("migrate inspection issue_count = %#v, want 1", state["issue_count"])
+			}
+			return result
 		}
-		// --json flag may not produce JSON due to flag shadowing;
-		// verify command at least succeeds.
-	})
 
-	// ===== --update-repo-id =====
-
-	t.Run("migrate_update_repo_id_dry_run", func(t *testing.T) {
-		dir, _, _ := bdInit(t, bd, "--prefix", "mr")
-		out := bdMigrate(t, bd, dir, "--update-repo-id", "--dry-run")
-		if len(strings.TrimSpace(out)) == 0 {
-			t.Error("expected non-empty --update-repo-id --dry-run output")
+		before := inspect()
+		out := bdMigrate(t, bd, dir, "--dry-run", "--json")
+		var preview map[string]interface{}
+		if err := json.Unmarshal([]byte(out), &preview); err != nil {
+			t.Fatalf("migrate --dry-run --json returned invalid JSON: %v\n%s", err, out)
 		}
-	})
+		if got, ok := preview["dry_run"].(bool); !ok || !got {
+			t.Errorf("migrate metadata dry_run = %#v, want true", preview["dry_run"])
+		}
+		if got, ok := preview["needs_version_update"].(bool); !ok || !got {
+			t.Errorf("migrate metadata needs_version_update = %#v, want true", preview["needs_version_update"])
+		}
+		if got, ok := preview["current_version"].(string); !ok || got != staleVersion {
+			t.Errorf("migrate metadata current_version = %#v, want %q", preview["current_version"], staleVersion)
+		}
+		if got, ok := preview["target_version"].(string); !ok || got != Version {
+			t.Errorf("migrate metadata target_version = %#v, want %q", preview["target_version"], Version)
+		}
+		if got := getVersion(); got != staleVersion {
+			t.Errorf("migrate --dry-run changed persisted bd_version to %q, want %q", got, staleVersion)
+		}
+		after := inspect()
+		if !reflect.DeepEqual(before["current_state"], after["current_state"]) {
+			t.Errorf("migrate --dry-run changed inspection state:\nbefore: %#v\nafter:  %#v", before["current_state"], after["current_state"])
+		}
 
-	t.Run("migrate_update_repo_id", func(t *testing.T) {
-		dir, _, _ := bdInit(t, bd, "--prefix", "mu")
-		out := bdMigrate(t, bd, dir, "--update-repo-id", "--yes")
-		if !strings.Contains(out, "Repository ID") && !strings.Contains(out, "repo_id") {
-			t.Errorf("expected repo ID update message: %s", out)
+		setVersion(Version)
+		out = bdMigrate(t, bd, dir)
+		if !strings.Contains(out, "Dolt database version") || !strings.Contains(out, "All metadata fields present") {
+			t.Errorf("migrate output = %q, want current metadata summary", out)
 		}
 	})
 
@@ -133,7 +173,7 @@ func TestEmbeddedMigrate(t *testing.T) {
 	// which then propagates to every clone via the synced metadata table.
 	t.Run("migrate_update_repo_id_honors_C", func(t *testing.T) {
 		dirA, _, _ := bdInit(t, bd, "--prefix", "ca")
-		dirB, _, _ := bdInit(t, bd, "--prefix", "cb")
+		dirB, beadsDirB, _ := bdInit(t, bd, "--prefix", "cb")
 
 		runDryRun := func(cwd, target, home string) string {
 			cmd := exec.Command(bd, "-C", target, "migrate", "--update-repo-id", "--dry-run")
@@ -162,110 +202,141 @@ func TestEmbeddedMigrate(t *testing.T) {
 		if got != wantB {
 			t.Errorf("bd -C <B> migrate --update-repo-id from cwd A reported %q, want B's fingerprint %q", got, wantB)
 		}
-	})
 
-	// ===== --schema =====
-
-	t.Run("migrate_schema", func(t *testing.T) {
-		dir, _, _ := bdInit(t, bd, "--prefix", "sa")
-		out := bdMigrate(t, bd, dir, "schema")
-		if !strings.Contains(out, "Schema") {
-			t.Errorf("expected 'Schema' in 'migrate schema' output: %s", out)
-		}
-	})
-
-	t.Run("migrate_schema_idempotent", func(t *testing.T) {
-		dir, _, _ := bdInit(t, bd, "--prefix", "si")
-		// First run: bd init already migrated to latest; this is the
-		// idempotent re-check. Should report current, not error.
-		first := bdMigrate(t, bd, dir, "schema")
-		// Second run: must also succeed and report current.
-		second := bdMigrate(t, bd, dir, "schema")
-		if !strings.Contains(first, "Schema") || !strings.Contains(second, "Schema") {
-			t.Errorf("expected 'Schema' in both runs:\nfirst:%s\nsecond:%s", first, second)
-		}
-	})
-
-	t.Run("migrate_schema_json", func(t *testing.T) {
-		dir, _, _ := bdInit(t, bd, "--prefix", "sj")
-		out := bdMigrate(t, bd, dir, "schema", "--json")
-		s := strings.TrimSpace(out)
-		start := strings.Index(s, "{")
-		if start < 0 {
-			// --json flag may be shadowed by other migrate flags; tolerate
-			// non-JSON output so long as the command succeeded.
-			return
-		}
-		var m map[string]interface{}
-		if err := json.Unmarshal([]byte(s[start:]), &m); err != nil {
-			t.Fatalf("invalid JSON: %v\n%s", err, s)
-		}
-		for _, key := range []string{"status", "applied", "latest_version"} {
-			if _, ok := m[key]; !ok {
-				t.Errorf("missing key %q in JSON output: %v", key, m)
+		var expectedRepoID string
+		withEmbeddedMigrateSQL(t, beadsDirB, "cb", func(db *sql.DB) error {
+			if err := db.QueryRowContext(t.Context(), "SELECT value FROM metadata WHERE `key` = ?", "repo_id").Scan(&expectedRepoID); err != nil {
+				return fmt.Errorf("read B repo_id before apply: %w", err)
 			}
+			if len(expectedRepoID) < 8 {
+				return fmt.Errorf("B repo_id %q is shorter than the CLI fingerprint", expectedRepoID)
+			}
+			if expectedRepoID[:8] != wantB {
+				return fmt.Errorf("B repo_id %q does not match dry-run fingerprint %q", expectedRepoID, wantB)
+			}
+			_, err := db.ExecContext(t.Context(), "UPDATE metadata SET value = ? WHERE `key` = ?", "stale-repo-id", "repo_id")
+			if err != nil {
+				return fmt.Errorf("seed B stale repo_id: %w", err)
+			}
+			return nil
+		})
+
+		cmd := exec.Command(bd, "-C", dirB, "migrate", "--update-repo-id", "--yes", "--json")
+		cmd.Dir = dirA
+		cmd.Env = bdEnv(dirB)
+		stdout, stderr, err := runCommandBuffers(t, cmd)
+		if err != nil {
+			t.Fatalf("bd -C %s migrate --update-repo-id --yes --json (cwd=%s) failed: %v\nstdout:\n%s\nstderr:\n%s", dirB, dirA, err, stdout.String(), stderr.String())
 		}
-		if status, _ := m["status"].(string); status != "current" && status != "applied" {
-			t.Errorf("unexpected status %q in JSON output: %v", status, m)
+		var applied map[string]interface{}
+		if err := json.Unmarshal(stdout.Bytes(), &applied); err != nil {
+			t.Fatalf("migrate --update-repo-id --json returned invalid JSON: %v\n%s", err, stdout.String())
+		}
+		if got, ok := applied["status"].(string); !ok || got != "success" {
+			t.Errorf("migrate --update-repo-id status = %#v, want success", applied["status"])
+		}
+		if got, ok := applied["new_repo_id"].(string); !ok || got != wantB {
+			t.Errorf("migrate --update-repo-id new_repo_id = %#v, want B fingerprint %q", applied["new_repo_id"], wantB)
+		}
+
+		var persistedRepoID string
+		withEmbeddedMigrateSQL(t, beadsDirB, "cb", func(db *sql.DB) error {
+			if err := db.QueryRowContext(t.Context(), "SELECT value FROM metadata WHERE `key` = ?", "repo_id").Scan(&persistedRepoID); err != nil {
+				return fmt.Errorf("read B repo_id after apply: %w", err)
+			}
+			return nil
+		})
+		if persistedRepoID != expectedRepoID {
+			t.Errorf("persisted B repo_id = %q, want %q", persistedRepoID, expectedRepoID)
 		}
 	})
 
-	t.Run("migrate_schema_rejects_inspect", func(t *testing.T) {
-		dir, _, _ := bdInit(t, bd, "--prefix", "sx")
-		// --inspect lives on the parent migrate command, not on the schema
-		// subcommand. Passing it should error rather than silently apply.
-		out := bdMigrateFail(t, bd, dir, "schema", "--inspect")
-		if !strings.Contains(out, "unknown flag") && !strings.Contains(out, "inspect") {
-			t.Errorf("expected error about --inspect on 'migrate schema': %s", out)
+	t.Run("migrate_schema_json_is_idempotent", func(t *testing.T) {
+		dir, _, _ := bdInit(t, bd, "--prefix", "sc")
+		run := func() map[string]interface{} {
+			t.Helper()
+			out := bdMigrate(t, bd, dir, "schema", "--json")
+			var result map[string]interface{}
+			if err := json.Unmarshal([]byte(out), &result); err != nil {
+				t.Fatalf("migrate schema --json returned invalid JSON: %v\n%s", err, out)
+			}
+			for _, key := range []string{"status", "applied", "latest_version"} {
+				if _, ok := result[key]; !ok {
+					t.Errorf("migrate schema JSON missing %q: %v", key, result)
+				}
+			}
+			return result
+		}
+
+		first := run()
+		second := run()
+		if got, ok := first["status"].(string); !ok || got != "current" {
+			t.Errorf("first migrate schema status = %#v, want current", first["status"])
+		}
+		if got, ok := second["status"].(string); !ok || got != "current" {
+			t.Errorf("second migrate schema status = %#v, want current", second["status"])
+		}
+		if got, ok := first["applied"].(float64); !ok || got != 0 {
+			t.Errorf("first migrate schema applied = %#v, want 0", first["applied"])
+		}
+		if got, ok := second["applied"].(float64); !ok || got != 0 {
+			t.Errorf("second migrate schema applied = %#v, want 0", second["applied"])
+		}
+		if !reflect.DeepEqual(first["latest_version"], second["latest_version"]) {
+			t.Errorf("migrate schema latest_version changed between idempotent runs: first %#v, second %#v", first["latest_version"], second["latest_version"])
 		}
 	})
 
-	t.Run("migrate_schema_rejects_dry_run", func(t *testing.T) {
-		dir, _, _ := bdInit(t, bd, "--prefix", "sd")
-		out := bdMigrateFail(t, bd, dir, "schema", "--dry-run")
-		if !strings.Contains(out, "unknown flag") && !strings.Contains(out, "dry-run") {
-			t.Errorf("expected error about --dry-run on 'migrate schema': %s", out)
-		}
-	})
-
-	// ===== migrate sync =====
-
-	t.Run("migrate_sync_dry_run", func(t *testing.T) {
+	t.Run("migrate_sync_persists_and_noops", func(t *testing.T) {
 		dir, _, _ := bdInit(t, bd, "--prefix", "ms")
-		out := bdMigrate(t, bd, dir, "sync", "test-branch", "--dry-run")
-		if !strings.Contains(out, "test-branch") {
-			t.Errorf("expected branch name in dry-run output: %s", out)
-		}
-	})
-
-	t.Run("migrate_sync", func(t *testing.T) {
-		dir, _, _ := bdInit(t, bd, "--prefix", "mc")
-		out := bdMigrate(t, bd, dir, "sync", "beads-sync")
-		if !strings.Contains(out, "beads-sync") {
-			t.Errorf("expected 'beads-sync' in sync output: %s", out)
-		}
-	})
-
-	t.Run("migrate_sync_json", func(t *testing.T) {
-		dir, _, _ := bdInit(t, bd, "--prefix", "mz")
-		out := bdMigrate(t, bd, dir, "sync", "json-branch", "--json")
-		s := strings.TrimSpace(out)
-		start := strings.Index(s, "{")
-		if start >= 0 {
-			if !json.Valid([]byte(s[start:])) {
-				t.Errorf("invalid JSON: %s", s)
+		const branch = "beads-sync"
+		decode := func(args ...string) map[string]interface{} {
+			t.Helper()
+			out := bdMigrate(t, bd, dir, args...)
+			var result map[string]interface{}
+			if err := json.Unmarshal([]byte(out), &result); err != nil {
+				t.Fatalf("migrate %s returned invalid JSON: %v\n%s", strings.Join(args, " "), err, out)
 			}
+			return result
 		}
-		// --json flag may not produce JSON due to flag shadowing;
-		// verify command at least succeeds.
-	})
 
-	// ===== migrate hooks =====
+		dryRun := decode("sync", branch, "--dry-run", "--json")
+		if got, ok := dryRun["dry_run"].(bool); !ok || !got {
+			t.Errorf("migrate sync dry_run = %#v, want true", dryRun["dry_run"])
+		}
+		if got, ok := dryRun["branch"].(string); !ok || got != branch {
+			t.Errorf("migrate sync dry-run branch = %#v, want %q", dryRun["branch"], branch)
+		}
+		if got, ok := dryRun["changed"].(bool); !ok || !got {
+			t.Errorf("migrate sync dry-run changed = %#v, want true", dryRun["changed"])
+		}
 
-	t.Run("migrate_hooks_dry_run", func(t *testing.T) {
-		dir, _, _ := bdInit(t, bd, "--prefix", "mh")
-		out := bdMigrate(t, bd, dir, "hooks", "--dry-run")
-		_ = out // Should succeed without crashing
+		applied := decode("sync", branch, "--json")
+		if got, ok := applied["status"].(string); !ok || got != "success" {
+			t.Errorf("migrate sync status = %#v, want success", applied["status"])
+		}
+		if got, ok := applied["branch"].(string); !ok || got != branch {
+			t.Errorf("migrate sync branch = %#v, want %q", applied["branch"], branch)
+		}
+
+		cmd := exec.Command(bd, "config", "get", "sync.branch")
+		cmd.Dir = dir
+		cmd.Env = bdEnv(dir)
+		stdout, stderr, err := runCommandBuffers(t, cmd)
+		if err != nil {
+			t.Fatalf("bd config get sync.branch failed: %v\nstdout:\n%s\nstderr:\n%s", err, stdout.String(), stderr.String())
+		}
+		if got := strings.TrimSpace(stdout.String()); got != branch {
+			t.Errorf("reopened sync.branch = %q, want %q", got, branch)
+		}
+
+		noop := decode("sync", branch, "--json")
+		if got, ok := noop["status"].(string); !ok || got != "noop" {
+			t.Errorf("same-value migrate sync status = %#v, want noop", noop["status"])
+		}
+		if got, ok := noop["branch"].(string); !ok || got != branch {
+			t.Errorf("same-value migrate sync branch = %#v, want %q", noop["branch"], branch)
+		}
 	})
 }
 

--- a/cmd/bd/migrate_test.go
+++ b/cmd/bd/migrate_test.go
@@ -17,9 +17,9 @@ import (
 // TestFormatDBList removed: formatDBList and dbInfo types were removed.
 
 func TestMigrateSchemaFlagBoundaries(t *testing.T) {
-	// Registration only: strict subprocess tests use the root persistent
-	// --json flag because local registration does not prove PersistentPreRunE
-	// will observe the flag as explicitly set.
+	// Registration only: strict subprocess tests use the unique root persistent
+	// --format=json alias because duplicate local --json registration can shadow
+	// whether PersistentPreRunE sees the root flag as explicitly set.
 	for _, name := range []string{"inspect", "dry-run"} {
 		if flag := migrateSchemaCmd.Flags().Lookup(name); flag != nil {
 			t.Errorf("migrate schema unexpectedly registers local --%s", name)
@@ -32,6 +32,9 @@ func TestMigrateSchemaFlagBoundaries(t *testing.T) {
 	}
 	if flag := rootCmd.PersistentFlags().Lookup("json"); flag == nil {
 		t.Error("root command must register persistent --json")
+	}
+	if flag := rootCmd.PersistentFlags().Lookup("format"); flag == nil {
+		t.Error("root command must register persistent --format")
 	}
 }
 

--- a/cmd/bd/migrate_test.go
+++ b/cmd/bd/migrate_test.go
@@ -16,6 +16,19 @@ import (
 
 // TestFormatDBList removed: formatDBList and dbInfo types were removed.
 
+func TestMigrateSchemaFlagBoundaries(t *testing.T) {
+	for _, name := range []string{"inspect", "dry-run"} {
+		if flag := migrateSchemaCmd.Flags().Lookup(name); flag != nil {
+			t.Errorf("migrate schema unexpectedly owns --%s", name)
+		}
+	}
+	for _, name := range []string{"json", "force"} {
+		if flag := migrateSchemaCmd.Flags().Lookup(name); flag == nil {
+			t.Errorf("migrate schema must own --%s", name)
+		}
+	}
+}
+
 func TestMigrateRespectsConfigJSON(t *testing.T) {
 	t.Skip("SQLite-specific: Dolt backend always uses 'dolt' directory, not custom database filenames")
 	// Test that migrate respects custom database name from metadata.json

--- a/cmd/bd/migrate_test.go
+++ b/cmd/bd/migrate_test.go
@@ -17,15 +17,21 @@ import (
 // TestFormatDBList removed: formatDBList and dbInfo types were removed.
 
 func TestMigrateSchemaFlagBoundaries(t *testing.T) {
+	// Registration only: strict subprocess tests use the root persistent
+	// --json flag because local registration does not prove PersistentPreRunE
+	// will observe the flag as explicitly set.
 	for _, name := range []string{"inspect", "dry-run"} {
 		if flag := migrateSchemaCmd.Flags().Lookup(name); flag != nil {
-			t.Errorf("migrate schema unexpectedly owns --%s", name)
+			t.Errorf("migrate schema unexpectedly registers local --%s", name)
 		}
 	}
 	for _, name := range []string{"json", "force"} {
 		if flag := migrateSchemaCmd.Flags().Lookup(name); flag == nil {
-			t.Errorf("migrate schema must own --%s", name)
+			t.Errorf("migrate schema must register local --%s", name)
 		}
+	}
+	if flag := rootCmd.PersistentFlags().Lookup("json"); flag == nil {
+		t.Error("root command must register persistent --json")
 	}
 }
 


### PR DESCRIPTION
## What

Consolidate `TestEmbeddedMigrate` from 16 separately initialized scenarios
(17 full `bd init` calls) into four behavior-rich journeys using five
initializations. Add one store-free Cobra contract for the schema subcommand
flag boundary.

This changes tests only. Production behavior, build tags, shard manifests,
timeouts, and skips are unchanged. `TestEmbeddedMigrateConcurrent` remains
byte-for-byte unchanged.

## Why

Hosted PR Risk run
[30763436058](https://github.com/gastownhall/beads/actions/runs/30763436058)
measured `TestEmbeddedMigrate` at 251 seconds and Embedded Cmd shard 7 at 395
seconds. The old matrix repeatedly paid full Git and embedded-Dolt bootstrap
cost for assertions that were sometimes only nonempty output or tolerant of
missing JSON.

## Hosted result

Final green run:
[30767314134](https://github.com/gastownhall/beads/actions/runs/30767314134)

| Metric | Baseline | Final green | Improvement |
| --- | ---: | ---: | ---: |
| Full embedded initializations | 17 | 5 | 12 fewer (71%) |
| `TestEmbeddedMigrate` | 251.00s | 114.43s | 136.57s saved (54%) |
| Embedded Cmd shard 7 | 395s | 284s | 111s saved (28%) |

Shard 7 now completes in **4m44s**, below the five-minute goal. The green leaf
was 4.43 seconds above the provisional 110-second target, so this description
records the measured result instead of tuning assertions to benchmark noise.

## Confidence retained

The real process/store boundary remains only where it owns a distinct risk:

| Risk | Retained owner |
| --- | --- |
| Pending metadata preview and inspection | Strict JSON plus raw persisted-version nonmutation |
| `-C` target versus caller CWD | Two-repository fingerprint check plus real apply/readback |
| Schema observability and idempotence | Two strict `bd --format=json migrate schema` runs |
| Sync persistence | Dry-run, apply, then a fresh process proving persisted state through strict `noop` readback |
| Schema-only flag grammar | Direct Cobra registration contract; no database or subprocess |
| Writer contention | Existing `TestEmbeddedMigrateConcurrent`, byte-for-byte unchanged |

Hook planning/apply remains owned by `migrate_hooks_test.go` and
`migrate_hooks_apply_test.go`; missing-identity metadata mutation remains owned
by `TestE2E_MigrateDoltMetadata`.

## Product findings kept out of scope

- Strict output assertions exposed
  [#5147](https://github.com/gastownhall/beads/issues/5147): duplicate
  migrate-local `--json` flags can shadow explicit root JSON selection. The
  harness uses the existing unique root alias `--format=json`; production is
  unchanged.
- Validation also exposed `bd-p6xzp`: `migrate sync` writes `sync.branch` to
  the Dolt config table while `config get` routes `sync.*` to YAML. The test
  now uses the migrate command's own fresh-process readback; the product-plane
  decision is tracked separately.

## Verification

- `GOTOOLCHAIN=go1.26.5 ./scripts/test.sh -run '^TestMigrateSchemaFlagBoundaries$' ./cmd/bd/...`
- `GOTOOLCHAIN=go1.26.5 BEADS_TEST_EMBEDDED_DOLT=1 ./scripts/test.sh -count=1 -run '^TestEmbeddedMigrate$' ./cmd/bd/...`
- Initial final baseline: `make test` passed; `cmd/bd` 307.17s; total coverage 39.8%
- Active pre-commit hook: golangci-lint reported `0 issues`
- Two independent Sol blocker/major-only reviews approved final repair diff
  `b02115e5...b0b6747d`
- Final GitHub status: 84 successful checks, 3 intentional skips, zero failures

## Contributor overlap

Preflight found no open PR touching either changed file. Related open work is
independent: #4804 changes internal schema locking, #5284 changes hook write
guards, and #4415 adds the flat-file backend without modifying this embedded
Migrate portfolio. This PR does not replace or supersede contributor work.

Tracks `bd-1rh.5` under the test-performance epic `bd-1rh`.

_codex-unknown-model-unknown-reasoning on behalf of CI Bot_
