### PR TITLE
fix: store dependency timestamps in UTC

### DIFF
--- a/internal/storage/dolt/dependencies_extended_test.go
+++ b/internal/storage/dolt/dependencies_extended_test.go
@@ -4,9 +4,57 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/steveyegge/beads/internal/types"
 )
+
+func TestAddDependencyCreatedAtUsesUTC(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	if _, err := store.db.ExecContext(ctx, "SET @@session.time_zone = '-06:00'"); err != nil {
+		t.Fatalf("set session time zone: %v", err)
+	}
+
+	for _, issue := range []*types.Issue{
+		{ID: "dep-utc-source", Title: "Source", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask},
+		{ID: "dep-utc-target", Title: "Target", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask},
+	} {
+		if err := store.CreateIssue(ctx, issue, "tester"); err != nil {
+			t.Fatalf("create issue %s: %v", issue.ID, err)
+		}
+	}
+
+	var utcBefore time.Time
+	if err := store.db.QueryRowContext(ctx, "SELECT UTC_TIMESTAMP()").Scan(&utcBefore); err != nil {
+		t.Fatalf("read UTC time before dependency creation: %v", err)
+	}
+
+	dep := &types.Dependency{IssueID: "dep-utc-source", DependsOnID: "dep-utc-target", Type: types.DepBlocks}
+	if err := store.AddDependency(ctx, dep, "tester"); err != nil {
+		t.Fatalf("add dependency: %v", err)
+	}
+
+	var createdAt, sessionNow, utcAfter time.Time
+	if err := store.db.QueryRowContext(ctx, `
+		SELECT created_at, NOW(), UTC_TIMESTAMP()
+		FROM dependencies
+		WHERE issue_id = ? AND depends_on_issue_id = ?
+	`, dep.IssueID, dep.DependsOnID).Scan(&createdAt, &sessionNow, &utcAfter); err != nil {
+		t.Fatalf("read dependency timestamp: %v", err)
+	}
+
+	if offset := utcAfter.Sub(sessionNow); offset != 6*time.Hour {
+		t.Fatalf("session time zone offset = %v, want 6h", offset)
+	}
+	if createdAt.Before(utcBefore) || createdAt.After(utcAfter) {
+		t.Errorf("dependency created_at = %v, want UTC time between %v and %v", createdAt, utcBefore, utcAfter)
+	}
+}
 
 // =============================================================================
 // GetDependenciesWithMetadata Tests

--- a/internal/storage/dolt/dependencies_extended_test.go
+++ b/internal/storage/dolt/dependencies_extended_test.go
@@ -48,11 +48,15 @@ func TestAddDependencyCreatedAtUsesUTC(t *testing.T) {
 		t.Fatalf("read dependency timestamp: %v", err)
 	}
 
-	if offset := utcAfter.Sub(sessionNow); offset != 6*time.Hour {
+	if offset := utcAfter.Truncate(time.Second).Sub(sessionNow); offset != 6*time.Hour {
 		t.Fatalf("session time zone offset = %v, want 6h", offset)
 	}
-	if createdAt.Before(utcBefore) || createdAt.After(utcAfter) {
-		t.Errorf("dependency created_at = %v, want UTC time between %v and %v", createdAt, utcBefore, utcAfter)
+	// created_at is stored in a second-precision DATETIME column, so the
+	// stored value may round to the nearest second of the true insert time.
+	// Allow a one-second slack on each side of the observed window while
+	// still failing if the value lands near session-local time (the bug).
+	if createdAt.Before(utcBefore.Add(-time.Second)) || createdAt.After(utcAfter.Add(time.Second)) {
+		t.Errorf("dependency created_at = %v, want UTC time near %v between %v and %v", createdAt, utcBefore, utcBefore, utcAfter)
 	}
 }
 

--- a/internal/storage/issueops/dependencies.go
+++ b/internal/storage/issueops/dependencies.go
@@ -290,7 +290,7 @@ func addDependencyInTx(ctx context.Context, tx *sql.Tx, dep *types.Dependency, a
 	//nolint:gosec // G201: writeTable from WispTableRouting; targetCol from DepTargetKind.Column()
 	if _, err := tx.ExecContext(ctx, fmt.Sprintf(`
 		INSERT INTO %s (id, issue_id, %s, type, created_at, created_by, metadata, thread_id)
-		VALUES (?, ?, ?, ?, NOW(), ?, ?, ?)
+		VALUES (?, ?, ?, ?, UTC_TIMESTAMP(), ?, ?, ?)
 	`, writeTable, targetCol), depid.New(dep.IssueID, dep.DependsOnID), dep.IssueID, dep.DependsOnID, dep.Type, actor, metadata, dep.ThreadID); err != nil {
 		return false, fmt.Errorf("failed to add dependency: %w", err)
 	}


### PR DESCRIPTION
- generate new dependency `created_at` values with `UTC_TIMESTAMP()` instead of session-local `NOW()`
- cover a UTC-6 Dolt session and assert persisted timestamps are bounded by database UTC time

Dependency records created through the shared issueops insertion path currently inherit the database session timezone, but are later serialized as UTC. This affects both durable and wisp dependency tables.

This is PR 2 of 2 for #5233 and depends on #5295; once #5295 lands, the GitHub diff against `main` will collapse to these two files

## testing

- `./scripts/test.sh -run '^TestAddDependency$/basic_blocks' ./internal/storage/embeddeddolt/...`
- `./scripts/test.sh ./internal/storage/issueops/...`
- `make test`
- `golangci-lint run ./internal/storage/issueops/... ./internal/storage/dolt/...`
- manual embedded-Dolt reproduction under `TZ=America/Denver`; persisted `created_at` matched `UTC_TIMESTAMP()` rather than `NOW()`

Closes #5233