### PR TITLE
test: consolidate proxied delete contract journey

### DIFF
--- a/cmd/bd/delete_input_test.go
+++ b/cmd/bd/delete_input_test.go
@@ -1,0 +1,136 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestReadIssueIDsFromFile(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	t.Run("read valid IDs from file", func(t *testing.T) {
+		testFile := filepath.Join(tmpDir, "ids.txt")
+		content := "bd-1\nbd-2\nbd-3\n"
+		if err := os.WriteFile(testFile, []byte(content), 0o644); err != nil {
+			t.Fatalf("Failed to write test file: %v", err)
+		}
+
+		ids, err := readIssueIDsFromFile(testFile)
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+
+		if !reflect.DeepEqual(ids, []string{"bd-1", "bd-2", "bd-3"}) {
+			t.Errorf("IDs: got %v, want [bd-1 bd-2 bd-3]", ids)
+		}
+	})
+
+	t.Run("skip empty lines and comments", func(t *testing.T) {
+		testFile := filepath.Join(tmpDir, "ids_with_comments.txt")
+		content := "bd-1\n\n# This is a comment\nbd-2\n  \nbd-3\n"
+		if err := os.WriteFile(testFile, []byte(content), 0o644); err != nil {
+			t.Fatalf("Failed to write test file: %v", err)
+		}
+
+		ids, err := readIssueIDsFromFile(testFile)
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+
+		if !reflect.DeepEqual(ids, []string{"bd-1", "bd-2", "bd-3"}) {
+			t.Errorf("IDs: got %v, want [bd-1 bd-2 bd-3]", ids)
+		}
+	})
+
+	t.Run("handle non-existent file", func(t *testing.T) {
+		_, err := readIssueIDsFromFile(filepath.Join(tmpDir, "nonexistent.txt"))
+		if err == nil {
+			t.Error("Expected error for non-existent file")
+		}
+	})
+}
+
+func TestUniqueStrings(t *testing.T) {
+	t.Run("remove duplicates while preserving the first occurrence order", func(t *testing.T) {
+		got := uniqueStrings([]string{"a", "b", "a", "c", "b", "d"})
+		want := []string{"a", "b", "c", "d"}
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("uniqueStrings(): got %v, want %v", got, want)
+		}
+	})
+
+	t.Run("handle empty input", func(t *testing.T) {
+		if got := uniqueStrings([]string{}); len(got) != 0 {
+			t.Errorf("Expected empty result, got %d items", len(got))
+		}
+	})
+
+	t.Run("handle all unique", func(t *testing.T) {
+		got := uniqueStrings([]string{"a", "b", "c"})
+		want := []string{"a", "b", "c"}
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("uniqueStrings(): got %v, want %v", got, want)
+		}
+	})
+}
+
+func TestGatherDeleteInput(t *testing.T) {
+	oldJSONOutput, oldQuiet := jsonOutput, quietFlag
+	t.Cleanup(func() { jsonOutput, quietFlag = oldJSONOutput, oldQuiet })
+
+	newCommand := func(t *testing.T) *cobra.Command {
+		t.Helper()
+		cmd := &cobra.Command{}
+		cmd.Flags().String("from-file", "", "")
+		cmd.Flags().Bool("force", false, "")
+		cmd.Flags().Bool("dry-run", false, "")
+		cmd.Flags().Bool("cascade", false, "")
+		return cmd
+	}
+
+	t.Run("merges positional and file IDs with stable deduplication and projects flags", func(t *testing.T) {
+		idsPath := filepath.Join(t.TempDir(), "ids.txt")
+		if err := os.WriteFile(idsPath, []byte(strings.Join([]string{"bd-file", "bd-shared", "bd-file"}, "\n")), 0o600); err != nil {
+			t.Fatalf("write IDs file: %v", err)
+		}
+		cmd := newCommand(t)
+		for name, value := range map[string]string{"from-file": idsPath, "force": "true", "dry-run": "true"} {
+			if err := cmd.Flags().Set(name, value); err != nil {
+				t.Fatalf("set %s: %v", name, err)
+			}
+		}
+		jsonOutput, quietFlag = true, true
+
+		got, err := gatherDeleteInput(cmd, []string{"bd-arg", "bd-shared", "bd-arg"})
+		if err != nil {
+			t.Fatalf("gatherDeleteInput: %v", err)
+		}
+		want := &deleteInput{
+			ids:        []string{"bd-arg", "bd-shared", "bd-file"},
+			force:      true,
+			dryRun:     true,
+			jsonOutput: true,
+			quiet:      true,
+		}
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("gatherDeleteInput(): got %#v, want %#v", got, want)
+		}
+	})
+
+	t.Run("rejects cascade without accessing a store", func(t *testing.T) {
+		cmd := newCommand(t)
+		if err := cmd.Flags().Set("cascade", "true"); err != nil {
+			t.Fatalf("set cascade: %v", err)
+		}
+
+		_, err := gatherDeleteInput(cmd, []string{"bd-target"})
+		if err == nil || !strings.Contains(err.Error(), "--cascade") {
+			t.Fatalf("gatherDeleteInput() error = %v, want --cascade rejection", err)
+		}
+	})
+}

--- a/cmd/bd/delete_proxied_integration_test.go
+++ b/cmd/bd/delete_proxied_integration_test.go
@@ -6,8 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os"
-	"path/filepath"
+	"reflect"
 	"strings"
 	"sync"
 	"testing"
@@ -17,469 +16,106 @@ func TestProxiedServerDelete(t *testing.T) {
 	requireSharedProxiedServer(t)
 	t.Parallel()
 	bd := buildEmbeddedBD(t)
+	p := newSharedProxiedProject(t, bd, "delete")
 
-	t.Run("delete_single_issue", func(t *testing.T) {
-		t.Parallel()
-		p := newSharedProxiedProject(t, bd, "dsi")
-		issue := bdProxiedCreate(t, bd, p.dir, "Delete me", "-t", "task")
-		bdProxiedDelete(t, bd, p.dir, issue.ID, "--force")
-		db := openProxiedDB(t, p)
-		assertRowAbsent(t, db, "issues", issue.ID)
-	})
+	survivor := bdProxiedCreate(t, bd, p.dir, "Survivor", "--type", "task")
+	target := bdProxiedCreate(t, bd, p.dir, "Target", "--type", "task", "--label", "alpha", "--deps", "depends-on:"+survivor.ID)
+	dependent := bdProxiedCreate(t, bd, p.dir, "Dependent", "--type", "task", "--deps", "depends-on:"+target.ID)
+	descendant := bdProxiedCreate(t, bd, p.dir, "Descendant", "--type", "task", "--parent", dependent.ID)
+	bdProxiedUpdateOne(t, bd, p.dir, survivor.ID, "--description", "see "+target.ID+" for context")
 
-	t.Run("delete_without_force_shows_preview", func(t *testing.T) {
-		t.Parallel()
-		p := newSharedProxiedProject(t, bd, "dwf")
-		issue := bdProxiedCreate(t, bd, p.dir, "Preview only", "-t", "task")
+	db := openProxiedDB(t, p)
+	ctx := context.Background()
+	var headBefore string
+	if err := db.QueryRowContext(ctx, "SELECT HASHOF('HEAD')").Scan(&headBefore); err != nil {
+		t.Fatalf("read HEAD before preview: %v", err)
+	}
 
-		out := bdProxiedDelete(t, bd, p.dir, issue.ID)
-		if !strings.Contains(out, "PREVIEW") && !strings.Contains(out, "preview") {
-			t.Errorf("expected preview prose, got: %s", out)
-		}
+	preview := bdProxiedDeleteJSON(t, bd, p.dir, "--json", target.ID)
+	previewWant := map[string]any{
+		"schema_version":       float64(1),
+		"would_delete":         float64(3),
+		"dependencies_removed": float64(3),
+		"labels_removed":       float64(1),
+		"events_removed":       float64(4),
+		"ids":                  []any{target.ID},
+		"not_found":            nil,
+		"connected":            []any{survivor.ID},
+		"dry_run":              false,
+	}
+	if !deleteJSONEqual(preview, previewWant) {
+		t.Errorf("preview JSON: got %#v, want %#v", preview, previewWant)
+	}
+	for _, id := range []string{survivor.ID, target.ID, dependent.ID, descendant.ID} {
+		assertRowExists(t, db, "issues", id)
+	}
+	var headAfterPreview string
+	if err := db.QueryRowContext(ctx, "SELECT HASHOF('HEAD')").Scan(&headAfterPreview); err != nil {
+		t.Fatalf("read HEAD after preview: %v", err)
+	}
+	if headAfterPreview != headBefore {
+		t.Errorf("preview advanced HEAD: before=%s after=%s", headBefore, headAfterPreview)
+	}
 
-		db := openProxiedDB(t, p)
-		assertRowExists(t, db, "issues", issue.ID)
-	})
+	deleted := bdProxiedDeleteJSON(t, bd, p.dir, "--json", target.ID, "--force")
+	deletedWant := map[string]any{
+		"schema_version":       float64(1),
+		"deleted":              []any{target.ID},
+		"deleted_count":        float64(3),
+		"dependencies_removed": float64(3),
+		"labels_removed":       float64(1),
+		"events_removed":       float64(4),
+		"references_updated":   float64(1),
+	}
+	if !deleteJSONEqual(deleted, deletedWant) {
+		t.Errorf("delete JSON: got %#v, want %#v", deleted, deletedWant)
+	}
 
-	t.Run("delete_clears_aux_tables", func(t *testing.T) {
-		t.Parallel()
-		p := newSharedProxiedProject(t, bd, "dcat")
-		neighbor := bdProxiedCreate(t, bd, p.dir, "Neighbor", "-t", "task")
-		issue := bdProxiedCreate(t, bd, p.dir, "Aux cleanup", "-t", "task",
-			"--label", "alpha",
-			"--deps", "depends-on:"+neighbor.ID)
-
-		bdProxiedDelete(t, bd, p.dir, issue.ID, "--force")
-
-		db := openProxiedDB(t, p)
-		ctx := context.Background()
-		assertRowAbsent(t, db, "issues", issue.ID)
-
-		for _, q := range []struct {
-			table, where string
-		}{
+	for _, id := range []string{target.ID, dependent.ID, descendant.ID} {
+		assertRowAbsent(t, db, "issues", id)
+		for _, q := range []struct{ table, where string }{
 			{"labels", "issue_id = ?"},
 			{"events", "issue_id = ?"},
 			{"dependencies", "issue_id = ? OR depends_on_issue_id = ?"},
 		} {
 			var count int
-			args := []any{issue.ID}
+			args := []any{id}
 			if strings.Count(q.where, "?") == 2 {
-				args = append(args, issue.ID)
+				args = append(args, id)
 			}
-			query := fmt.Sprintf("SELECT COUNT(*) FROM %s WHERE %s", q.table, q.where)
-			if err := db.QueryRowContext(ctx, query, args...).Scan(&count); err != nil {
-				t.Fatalf("count %s for %s: %v", q.table, issue.ID, err)
+			if err := db.QueryRowContext(ctx, "SELECT COUNT(*) FROM "+q.table+" WHERE "+q.where, args...).Scan(&count); err != nil {
+				t.Fatalf("count %s rows for %s: %v", q.table, id, err)
 			}
 			if count != 0 {
-				t.Errorf("%s rows for deleted %s: got %d, want 0", q.table, issue.ID, count)
+				t.Errorf("%s rows for deleted %s: got %d, want 0", q.table, id, count)
 			}
 		}
-	})
+	}
+	assertRowExists(t, db, "issues", survivor.ID)
+	var description string
+	if err := db.QueryRowContext(ctx, "SELECT description FROM issues WHERE id = ?", survivor.ID).Scan(&description); err != nil {
+		t.Fatalf("read survivor description: %v", err)
+	}
+	if !strings.Contains(description, "[deleted:"+target.ID+"]") {
+		t.Errorf("survivor description: got %q, want rewritten target reference", description)
+	}
+	var headAfterDelete string
+	if err := db.QueryRowContext(ctx, "SELECT HASHOF('HEAD')").Scan(&headAfterDelete); err != nil {
+		t.Fatalf("read HEAD after delete: %v", err)
+	}
+	if headAfterDelete == headBefore {
+		t.Errorf("HEAD did not advance: before=%s after=%s", headBefore, headAfterDelete)
+	}
 
-	t.Run("delete_json_returns_result_shape", func(t *testing.T) {
-		t.Parallel()
-		p := newSharedProxiedProject(t, bd, "djs")
-		issue := bdProxiedCreate(t, bd, p.dir, "JSON shape", "-t", "task")
+	missing := "delete-missing-id"
+	missingOut := bdProxiedDeleteFail(t, bd, p.dir, missing, "--force")
+	if !strings.Contains(strings.ToLower(missingOut), "not found") || !strings.Contains(missingOut, missing) {
+		t.Errorf("missing-ID error: got %q, want not-found translation naming %q", missingOut, missing)
+	}
+}
 
-		got := bdProxiedDeleteJSON(t, bd, p.dir, "--json", issue.ID, "--force")
-		for _, key := range []string{
-			"deleted", "deleted_count", "dependencies_removed",
-			"labels_removed", "events_removed", "references_updated",
-		} {
-			if _, ok := got[key]; !ok {
-				t.Errorf("delete JSON output missing key %q; got keys: %v", key, mapKeys(got))
-			}
-		}
-
-		deleted, ok := got["deleted"].([]any)
-		if !ok {
-			t.Fatalf("`deleted` is not a slice; got %T: %v", got["deleted"], got["deleted"])
-		}
-		if len(deleted) != 1 || deleted[0] != issue.ID {
-			t.Errorf("`deleted`: got %v, want [%s]", deleted, issue.ID)
-		}
-	})
-
-	t.Run("delete_leaf_clears_outbound_dep_rows", func(t *testing.T) {
-		t.Parallel()
-		p := newSharedProxiedProject(t, bd, "dlc")
-		a := bdProxiedCreate(t, bd, p.dir, "Survivor A", "-t", "task")
-		b := bdProxiedCreate(t, bd, p.dir, "Will be deleted", "-t", "task",
-			"--deps", "depends-on:"+a.ID)
-
-		bdProxiedDelete(t, bd, p.dir, b.ID, "--force")
-
-		db := openProxiedDB(t, p)
-		assertRowAbsent(t, db, "issues", b.ID)
-		assertRowExists(t, db, "issues", a.ID)
-
-		var refs int
-		if err := db.QueryRowContext(context.Background(),
-			"SELECT COUNT(*) FROM dependencies WHERE issue_id = ? OR depends_on_issue_id = ?",
-			b.ID, b.ID).Scan(&refs); err != nil {
-			t.Fatalf("count dep rows referencing %s: %v", b.ID, err)
-		}
-		if refs != 0 {
-			t.Errorf("dependencies referencing deleted %s: got %d rows, want 0", b.ID, refs)
-		}
-	})
-
-	t.Run("delete_creates_dolt_commit", func(t *testing.T) {
-		t.Parallel()
-		p := newSharedProxiedProject(t, bd, "ddc")
-		issue := bdProxiedCreate(t, bd, p.dir, "Dolt commit test", "-t", "task")
-
-		db := openProxiedDB(t, p)
-		var before string
-		if err := db.QueryRowContext(context.Background(),
-			"SELECT HASHOF('HEAD')").Scan(&before); err != nil {
-			t.Fatalf("read HEAD before: %v", err)
-		}
-
-		bdProxiedDelete(t, bd, p.dir, issue.ID, "--force")
-
-		var after string
-		if err := db.QueryRowContext(context.Background(),
-			"SELECT HASHOF('HEAD')").Scan(&after); err != nil {
-			t.Fatalf("read HEAD after: %v", err)
-		}
-		if after == before {
-			t.Errorf("HEAD did not advance: before=%s after=%s (uw.Commit should produce a Dolt commit)",
-				before, after)
-		}
-	})
-
-	t.Run("delete_bulk_no_resurrection", func(t *testing.T) {
-		t.Parallel()
-		p := newSharedProxiedProject(t, bd, "dbr")
-
-		const total = 20
-		const toDelete = 10
-		ids := make([]string, 0, total)
-		for i := 0; i < total; i++ {
-			issue := bdProxiedCreate(t, bd, p.dir,
-				fmt.Sprintf("Bulk %d", i), "-t", "task")
-			ids = append(ids, issue.ID)
-		}
-
-		deleteArgs := append([]string{}, ids[:toDelete]...)
-		deleteArgs = append(deleteArgs, "--force")
-		bdProxiedDelete(t, bd, p.dir, deleteArgs...)
-
-		db := openProxiedDB(t, p)
-		var count int
-		if err := db.QueryRowContext(context.Background(),
-			"SELECT COUNT(*) FROM issues").Scan(&count); err != nil {
-			t.Fatalf("count issues: %v", err)
-		}
-		if count != total-toDelete {
-			t.Errorf("issues count after bulk delete: got %d, want %d", count, total-toDelete)
-		}
-		for _, id := range ids[:toDelete] {
-			assertRowAbsent(t, db, "issues", id)
-		}
-		for _, id := range ids[toDelete:] {
-			assertRowExists(t, db, "issues", id)
-		}
-	})
-
-	t.Run("delete_nonexistent", func(t *testing.T) {
-		t.Parallel()
-		p := newSharedProxiedProject(t, bd, "dne")
-		out := bdProxiedDeleteFail(t, bd, p.dir, "dne-doesnotexist", "--force")
-		if !strings.Contains(strings.ToLower(out), "not found") &&
-			!strings.Contains(strings.ToLower(out), "error") {
-			t.Errorf("expected not-found / error message, got: %s", out)
-		}
-	})
-
-	t.Run("delete_batch", func(t *testing.T) {
-		t.Parallel()
-		p := newSharedProxiedProject(t, bd, "dbt")
-		a := bdProxiedCreate(t, bd, p.dir, "Batch 1", "-t", "task")
-		b := bdProxiedCreate(t, bd, p.dir, "Batch 2", "-t", "task")
-		c := bdProxiedCreate(t, bd, p.dir, "Batch 3", "-t", "task")
-
-		bdProxiedDelete(t, bd, p.dir, a.ID, b.ID, c.ID, "--force")
-
-		db := openProxiedDB(t, p)
-		for _, id := range []string{a.ID, b.ID, c.ID} {
-			assertRowAbsent(t, db, "issues", id)
-		}
-	})
-
-	t.Run("delete_force_cascades_dependents", func(t *testing.T) {
-		t.Parallel()
-		p := newSharedProxiedProject(t, bd, "dfc")
-		parent := bdProxiedCreate(t, bd, p.dir, "Force parent", "-t", "task")
-		child := bdProxiedCreate(t, bd, p.dir, "Force child", "-t", "task",
-			"--deps", "depends-on:"+parent.ID)
-
-		bdProxiedDelete(t, bd, p.dir, parent.ID, "--force")
-
-		db := openProxiedDB(t, p)
-		assertRowAbsent(t, db, "issues", parent.ID)
-		assertRowAbsent(t, db, "issues", child.ID)
-	})
-
-	t.Run("delete_cleans_up_dependencies", func(t *testing.T) {
-		t.Parallel()
-		p := newSharedProxiedProject(t, bd, "dcd")
-		parent := bdProxiedCreate(t, bd, p.dir, "Parent", "-t", "task")
-		child := bdProxiedCreate(t, bd, p.dir, "Child", "-t", "task",
-			"--deps", "depends-on:"+parent.ID)
-
-		bdProxiedDelete(t, bd, p.dir, child.ID, "--force")
-
-		db := openProxiedDB(t, p)
-		assertRowAbsent(t, db, "issues", child.ID)
-		assertRowExists(t, db, "issues", parent.ID)
-
-		var status string
-		if err := db.QueryRowContext(context.Background(),
-			"SELECT status FROM issues WHERE id = ?", parent.ID).Scan(&status); err != nil {
-			t.Fatalf("read parent status: %v", err)
-		}
-		if status == "closed" {
-			t.Errorf("parent status after deleting child: got %q, want non-closed", status)
-		}
-	})
-
-	t.Run("delete_always_cascades_dependents", func(t *testing.T) {
-		t.Parallel()
-		p := newSharedProxiedProject(t, bd, "dac")
-		parent := bdProxiedCreate(t, bd, p.dir, "Parent", "-t", "epic")
-		child := bdProxiedCreate(t, bd, p.dir, "Child", "-t", "task",
-			"--parent", parent.ID)
-
-		bdProxiedDelete(t, bd, p.dir, parent.ID, "--force")
-
-		db := openProxiedDB(t, p)
-		assertRowAbsent(t, db, "issues", parent.ID)
-		assertRowAbsent(t, db, "issues", child.ID)
-	})
-
-	t.Run("delete_cascade_spans_all_dep_types", func(t *testing.T) {
-		t.Parallel()
-		p := newSharedProxiedProject(t, bd, "dcs")
-		a := bdProxiedCreate(t, bd, p.dir, "A", "-t", "task")
-		b := bdProxiedCreate(t, bd, p.dir, "B", "-t", "task",
-			"--deps", "depends-on:"+a.ID)
-		c := bdProxiedCreate(t, bd, p.dir, "C", "-t", "task",
-			"--parent", b.ID)
-
-		bdProxiedDelete(t, bd, p.dir, a.ID, "--force")
-
-		db := openProxiedDB(t, p)
-		for _, id := range []string{a.ID, b.ID, c.ID} {
-			assertRowAbsent(t, db, "issues", id)
-		}
-	})
-
-	t.Run("delete_json_counts_match_cascade", func(t *testing.T) {
-		t.Parallel()
-		p := newSharedProxiedProject(t, bd, "djc")
-		a := bdProxiedCreate(t, bd, p.dir, "Chain A", "-t", "task")
-		b := bdProxiedCreate(t, bd, p.dir, "Chain B", "-t", "task",
-			"--deps", "depends-on:"+a.ID)
-		c := bdProxiedCreate(t, bd, p.dir, "Chain C", "-t", "task",
-			"--deps", "depends-on:"+b.ID)
-
-		got := bdProxiedDeleteJSON(t, bd, p.dir, "--json", a.ID, "--force")
-
-		count, ok := got["deleted_count"].(float64)
-		if !ok {
-			t.Fatalf("deleted_count not a number: %T %v", got["deleted_count"], got["deleted_count"])
-		}
-		if int(count) != 3 {
-			t.Errorf("deleted_count: got %v, want 3 (A,B,C cascade)", count)
-		}
-
-		db := openProxiedDB(t, p)
-		for _, id := range []string{a.ID, b.ID, c.ID} {
-			assertRowAbsent(t, db, "issues", id)
-		}
-	})
-
-	t.Run("delete_dry_run_does_not_mutate", func(t *testing.T) {
-		t.Parallel()
-		p := newSharedProxiedProject(t, bd, "ddr")
-		issue := bdProxiedCreate(t, bd, p.dir, "Dry run target", "-t", "task")
-
-		got := bdProxiedDeleteJSON(t, bd, p.dir, "--json", issue.ID, "--dry-run")
-		if _, ok := got["would_delete"]; !ok {
-			t.Errorf("dry-run JSON missing `would_delete`; got keys: %v", mapKeys(got))
-		}
-
-		db := openProxiedDB(t, p)
-		assertRowExists(t, db, "issues", issue.ID)
-	})
-
-	t.Run("delete_preview_lists_not_found", func(t *testing.T) {
-		t.Parallel()
-		p := newSharedProxiedProject(t, bd, "dpn")
-		issue := bdProxiedCreate(t, bd, p.dir, "Preview NotFound", "-t", "task")
-
-		out := bdProxiedDeleteFail(t, bd, p.dir, issue.ID, "dpn-bogus")
-		if !strings.Contains(strings.ToLower(out), "not found") {
-			t.Errorf("expected `not found` in preview error, got: %s", out)
-		}
-		if !strings.Contains(out, "dpn-bogus") {
-			t.Errorf("expected bogus id in preview error, got: %s", out)
-		}
-
-		db := openProxiedDB(t, p)
-		assertRowExists(t, db, "issues", issue.ID)
-	})
-
-	t.Run("delete_preview_lists_connected", func(t *testing.T) {
-		t.Parallel()
-		p := newSharedProxiedProject(t, bd, "dpc")
-		neighbor := bdProxiedCreate(t, bd, p.dir, "Preview neighbor", "-t", "task")
-		target := bdProxiedCreate(t, bd, p.dir, "Preview target", "-t", "task",
-			"--deps", "depends-on:"+neighbor.ID)
-
-		got := bdProxiedDeleteJSON(t, bd, p.dir, "--json", target.ID)
-
-		connectedRaw, ok := got["connected"]
-		if !ok {
-			t.Fatalf("preview JSON missing `connected` key; got keys: %v", mapKeys(got))
-		}
-		connected, ok := connectedRaw.([]any)
-		if !ok {
-			t.Fatalf("`connected` is not a slice; got %T", connectedRaw)
-		}
-		var found bool
-		for _, v := range connected {
-			if s, ok := v.(string); ok && s == neighbor.ID {
-				found = true
-				break
-			}
-		}
-		if !found {
-			t.Errorf("connected does not contain neighbor %q: %v", neighbor.ID, connected)
-		}
-	})
-
-	t.Run("delete_rewrites_text_references", func(t *testing.T) {
-		t.Parallel()
-		p := newSharedProxiedProject(t, bd, "drt")
-		neighbor := bdProxiedCreate(t, bd, p.dir, "Rewrite neighbor", "-t", "task")
-		target := bdProxiedCreate(t, bd, p.dir, "Rewrite target", "-t", "task",
-			"--deps", "depends-on:"+neighbor.ID)
-		bdProxiedUpdateOne(t, bd, p.dir, neighbor.ID, "--description", "see "+target.ID+" for context")
-
-		bdProxiedDelete(t, bd, p.dir, target.ID, "--force")
-
-		db := openProxiedDB(t, p)
-		assertRowAbsent(t, db, "issues", target.ID)
-		assertRowExists(t, db, "issues", neighbor.ID)
-
-		var desc string
-		if err := db.QueryRowContext(context.Background(),
-			"SELECT description FROM issues WHERE id = ?", neighbor.ID).Scan(&desc); err != nil {
-			t.Fatalf("read neighbor description: %v", err)
-		}
-		want := "[deleted:" + target.ID + "]"
-		if !strings.Contains(desc, want) {
-			t.Errorf("neighbor description: got %q, want substring %q", desc, want)
-		}
-	})
-
-	t.Run("delete_references_updated_count_reported", func(t *testing.T) {
-		t.Parallel()
-		p := newSharedProxiedProject(t, bd, "dru")
-		neighbor := bdProxiedCreate(t, bd, p.dir, "Refs neighbor", "-t", "task")
-		target := bdProxiedCreate(t, bd, p.dir, "Refs target", "-t", "task",
-			"--deps", "depends-on:"+neighbor.ID)
-		bdProxiedUpdateOne(t, bd, p.dir, neighbor.ID, "--description", "see "+target.ID)
-
-		got := bdProxiedDeleteJSON(t, bd, p.dir, "--json", target.ID, "--force")
-		refs, ok := got["references_updated"].(float64)
-		if !ok {
-			t.Fatalf("references_updated not a number: %T %v",
-				got["references_updated"], got["references_updated"])
-		}
-		if int(refs) < 1 {
-			t.Errorf("references_updated: got %v, want >= 1", refs)
-		}
-	})
-
-	t.Run("delete_zero_aux_rows_after", func(t *testing.T) {
-		t.Parallel()
-		p := newSharedProxiedProject(t, bd, "dza")
-		outbound := bdProxiedCreate(t, bd, p.dir, "Outbound dependee", "-t", "task")
-		issue := bdProxiedCreate(t, bd, p.dir, "Zero aux target", "-t", "task",
-			"--label", "alpha",
-			"--deps", "depends-on:"+outbound.ID)
-		_ = bdProxiedCreate(t, bd, p.dir, "Inbound depender", "-t", "task",
-			"--deps", "depends-on:"+issue.ID)
-		bdProxiedUpdateOne(t, bd, p.dir, issue.ID, "--add-label", "beta")
-		bdProxiedUpdateOne(t, bd, p.dir, issue.ID, "-s", "in_progress")
-
-		bdProxiedDelete(t, bd, p.dir, issue.ID, "--force")
-
-		db := openProxiedDB(t, p)
-		ctx := context.Background()
-		assertRowAbsent(t, db, "issues", issue.ID)
-
-		for _, q := range []struct {
-			table, where string
-		}{
-			{"labels", "issue_id = ?"},
-			{"events", "issue_id = ?"},
-			{"dependencies", "issue_id = ? OR depends_on_issue_id = ?"},
-		} {
-			var count int
-			args := []any{issue.ID}
-			if strings.Count(q.where, "?") == 2 {
-				args = append(args, issue.ID)
-			}
-			query := fmt.Sprintf("SELECT COUNT(*) FROM %s WHERE %s", q.table, q.where)
-			if err := db.QueryRowContext(ctx, query, args...).Scan(&count); err != nil {
-				t.Fatalf("count %s for %s: %v", q.table, issue.ID, err)
-			}
-			if count != 0 {
-				t.Errorf("%s rows for deleted %s: got %d, want 0", q.table, issue.ID, count)
-			}
-		}
-	})
-
-	t.Run("delete_from_file", func(t *testing.T) {
-		t.Parallel()
-		p := newSharedProxiedProject(t, bd, "dff")
-		a := bdProxiedCreate(t, bd, p.dir, "From-file 1", "-t", "task")
-		b := bdProxiedCreate(t, bd, p.dir, "From-file 2", "-t", "task")
-		c := bdProxiedCreate(t, bd, p.dir, "From-file 3", "-t", "task")
-
-		idsPath := filepath.Join(p.dir, "ids.txt")
-		body := strings.Join([]string{a.ID, b.ID, c.ID}, "\n") + "\n"
-		if err := os.WriteFile(idsPath, []byte(body), 0o600); err != nil {
-			t.Fatalf("write ids file: %v", err)
-		}
-
-		bdProxiedDelete(t, bd, p.dir, "--from-file", idsPath, "--force")
-
-		db := openProxiedDB(t, p)
-		for _, id := range []string{a.ID, b.ID, c.ID} {
-			assertRowAbsent(t, db, "issues", id)
-		}
-	})
-
-	t.Run("delete_cascade_flag_is_error", func(t *testing.T) {
-		t.Parallel()
-		p := newSharedProxiedProject(t, bd, "dcn")
-		issue := bdProxiedCreate(t, bd, p.dir, "Cascade flag", "-t", "task")
-
-		out := bdProxiedDeleteFail(t, bd, p.dir, issue.ID, "--force", "--cascade")
-		if !strings.Contains(out, "--cascade") {
-			t.Errorf("expected error mentioning --cascade, got: %s", out)
-		}
-
-		db := openProxiedDB(t, p)
-		assertRowExists(t, db, "issues", issue.ID)
-	})
+func deleteJSONEqual(got, want map[string]any) bool {
+	return reflect.DeepEqual(got, want)
 }
 
 func TestProxiedServerDeleteWisp(t *testing.T) {

--- a/cmd/bd/delete_proxied_server_output_test.go
+++ b/cmd/bd/delete_proxied_server_output_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -65,6 +66,104 @@ func TestOutputDeleteProxiedPreviewIsPayloadBlind(t *testing.T) {
 		}
 		if _, ok := got["would_delete"]; !ok {
 			t.Fatalf("proxied JSON preview missing would_delete: %v", got)
+		}
+	})
+}
+
+func TestOutputDeleteProxiedPreviewExactContracts(t *testing.T) {
+	result := deletePreviewResult{
+		preview: domain.DeletePreview{
+			Issues: map[string]*types.Issue{
+				"bd-target": {ID: "bd-target", Title: "Target"},
+			},
+			ConnectedIssues: map[string]*types.Issue{
+				"bd-zulu":  {ID: "bd-zulu", Title: "Zulu"},
+				"bd-alpha": {ID: "bd-alpha", Title: "Alpha"},
+			},
+		},
+		res: domain.DeleteIssuesResult{DeletedCount: 3, DependenciesCount: 4, LabelsCount: 2, EventsCount: 5},
+	}
+
+	t.Run("JSON includes the complete preview contract with sorted connections and takes precedence over quiet", func(t *testing.T) {
+		in := &deleteInput{ids: []string{"bd-target"}, force: true, dryRun: true, quiet: true, jsonOutput: true}
+		out := captureStdout(t, func() error { return outputDeleteProxiedPreview(in, result) })
+		var got map[string]any
+		if err := json.Unmarshal([]byte(out), &got); err != nil {
+			t.Fatalf("parse preview JSON: %v\nraw: %s", err, out)
+		}
+		want := map[string]any{
+			"schema_version":       float64(1),
+			"would_delete":         float64(3),
+			"dependencies_removed": float64(4),
+			"labels_removed":       float64(2),
+			"events_removed":       float64(5),
+			"ids":                  []any{"bd-target"},
+			"not_found":            nil,
+			"connected":            []any{"bd-alpha", "bd-zulu"},
+			"dry_run":              true,
+		}
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("preview JSON: got %#v, want %#v", got, want)
+		}
+	})
+
+	t.Run("prose renders preview counts, sorted reference candidates, and dry-run marker", func(t *testing.T) {
+		in := &deleteInput{ids: []string{"bd-target"}, dryRun: true}
+		out := captureStdout(t, func() error { return outputDeleteProxiedPreview(in, result) })
+		for _, required := range []string{
+			"Issues to delete (1):", "bd-target: Target", "3 issue(s) total", "4 dependency link(s)",
+			"2 label(s)", "5 event(s)", "Connected issues (text references may be rewritten):",
+			"bd-alpha: Alpha", "bd-zulu: Zulu", "(Dry-run mode - no changes made)",
+		} {
+			if !strings.Contains(out, required) {
+				t.Errorf("prose preview missing %q:\n%s", required, out)
+			}
+		}
+		if strings.Index(out, "bd-alpha: Alpha") > strings.Index(out, "bd-zulu: Zulu") {
+			t.Errorf("prose connected issue order is not sorted:\n%s", out)
+		}
+	})
+}
+
+func TestRenderDeleteProxiedResultExactContracts(t *testing.T) {
+	res := domain.DeleteIssuesResult{DeletedCount: 3, DependenciesCount: 4, LabelsCount: 2, EventsCount: 5, ReferencesUpdated: 1}
+
+	t.Run("JSON includes the complete final aggregate", func(t *testing.T) {
+		in := &deleteInput{ids: []string{"bd-target", "bd-dependent"}, jsonOutput: true}
+		out := captureStdout(t, func() error {
+			renderDeleteProxiedResult(in, res)
+			return nil
+		})
+		var got map[string]any
+		if err := json.Unmarshal([]byte(out), &got); err != nil {
+			t.Fatalf("parse final JSON: %v\nraw: %s", err, out)
+		}
+		want := map[string]any{
+			"schema_version":       float64(1),
+			"deleted":              []any{"bd-target", "bd-dependent"},
+			"deleted_count":        float64(3),
+			"dependencies_removed": float64(4),
+			"labels_removed":       float64(2),
+			"events_removed":       float64(5),
+			"references_updated":   float64(1),
+		}
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("final JSON: got %#v, want %#v", got, want)
+		}
+	})
+
+	t.Run("prose includes all aggregate counts and reference updates", func(t *testing.T) {
+		out := captureStdout(t, func() error {
+			renderDeleteProxiedResult(&deleteInput{}, res)
+			return nil
+		})
+		for _, required := range []string{
+			"Deleted 3 issue(s)", "Removed 4 dependency link(s)", "Removed 2 label(s)",
+			"Removed 5 event(s)", "Updated text references in 1 issue(s)",
+		} {
+			if !strings.Contains(out, required) {
+				t.Errorf("final prose missing %q:\n%s", required, out)
+			}
 		}
 	})
 }

--- a/cmd/bd/delete_test.go
+++ b/cmd/bd/delete_test.go
@@ -5,7 +5,6 @@ package main
 
 import (
 	"context"
-	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -13,98 +12,6 @@ import (
 
 	"github.com/steveyegge/beads/internal/types"
 )
-
-func TestReadIssueIDsFromFile(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "bd-test-delete-*")
-	if err != nil {
-		t.Fatalf("Failed to create temp dir: %v", err)
-	}
-	defer os.RemoveAll(tmpDir)
-
-	t.Run("read valid IDs from file", func(t *testing.T) {
-		testFile := filepath.Join(tmpDir, "ids.txt")
-		content := "bd-1\nbd-2\nbd-3\n"
-		if err := os.WriteFile(testFile, []byte(content), 0644); err != nil {
-			t.Fatalf("Failed to write test file: %v", err)
-		}
-
-		ids, err := readIssueIDsFromFile(testFile)
-		if err != nil {
-			t.Fatalf("Unexpected error: %v", err)
-		}
-
-		if len(ids) != 3 {
-			t.Errorf("Expected 3 IDs, got %d", len(ids))
-		}
-
-		expected := []string{"bd-1", "bd-2", "bd-3"}
-		for i, id := range ids {
-			if id != expected[i] {
-				t.Errorf("Expected ID %s at position %d, got %s", expected[i], i, id)
-			}
-		}
-	})
-
-	t.Run("skip empty lines and comments", func(t *testing.T) {
-		testFile := filepath.Join(tmpDir, "ids_with_comments.txt")
-		content := "bd-1\n\n# This is a comment\nbd-2\n  \nbd-3\n"
-		if err := os.WriteFile(testFile, []byte(content), 0644); err != nil {
-			t.Fatalf("Failed to write test file: %v", err)
-		}
-
-		ids, err := readIssueIDsFromFile(testFile)
-		if err != nil {
-			t.Fatalf("Unexpected error: %v", err)
-		}
-
-		if len(ids) != 3 {
-			t.Errorf("Expected 3 IDs (skipping comments/empty), got %d", len(ids))
-		}
-	})
-
-	t.Run("handle non-existent file", func(t *testing.T) {
-		_, err := readIssueIDsFromFile(filepath.Join(tmpDir, "nonexistent.txt"))
-		if err == nil {
-			t.Error("Expected error for non-existent file")
-		}
-	})
-}
-
-func TestUniqueStrings(t *testing.T) {
-	t.Run("remove duplicates", func(t *testing.T) {
-		input := []string{"a", "b", "a", "c", "b", "d"}
-		result := uniqueStrings(input)
-
-		if len(result) != 4 {
-			t.Errorf("Expected 4 unique strings, got %d", len(result))
-		}
-
-		// Verify all unique values are present
-		seen := make(map[string]bool)
-		for _, s := range result {
-			if seen[s] {
-				t.Errorf("Duplicate found in result: %s", s)
-			}
-			seen[s] = true
-		}
-	})
-
-	t.Run("handle empty input", func(t *testing.T) {
-		result := uniqueStrings([]string{})
-		if len(result) != 0 {
-			t.Errorf("Expected empty result, got %d items", len(result))
-		}
-	})
-
-	t.Run("handle all unique", func(t *testing.T) {
-		input := []string{"a", "b", "c"}
-		result := uniqueStrings(input)
-
-		if len(result) != 3 {
-			t.Errorf("Expected 3 items, got %d", len(result))
-		}
-	})
-}
 
 func TestDeletePreviewJSONIsPayloadBlind(t *testing.T) {
 	ensureCleanGlobalState(t)


### PR DESCRIPTION
## What

Consolidates `TestProxiedServerDelete` from 22 isolated proxied databases and 87 logical CLI subprocesses into one behavior-rich, nine-subprocess contract journey.

Moves pure input behavior and exact preview/final rendering contracts into direct, untagged tests. `TestProxiedServerDeleteWisp` and `TestProxiedServerDeleteConcurrent` remain byte-for-byte unchanged because they own distinct routing and contention risks.

| Portfolio | Before | After |
| --- | ---: | ---: |
| Proxied databases | 22 | 1 |
| Logical CLI subprocesses | 87 | 9 |
| Direct input/rendering owners | Partial / integration-tagged | Untagged and exact |

## Why

Five recent successful PR Risk runs put the effective delete leaf at a 352.23s median and Proxied Dolt Cmd shard 1/15 at 387s. Most of that time repeatedly proved domain and persistence semantics already owned below the process boundary.

The retained real journey still proves the risks that require a real CLI/UOW/Dolt boundary: preview non-mutation, transitive cascade across dependency types, auxiliary cleanup, reference rewriting, exact aggregate output, not-found translation, durable readback, and `HEAD` advancement.

This is test-only and behavior-neutral. It does not modify delete production code, schemas, workflows, timeouts, or skips. It also does not supersede #4742: that contributor PR changes fresh-UOW retry behavior; this PR only makes the existing boundary portfolio focused and faster.

Tracks `bd-1rh.7`.

## Performance gate

Hosted PR Risk will measure the real integration boundary. Acceptance requires:

- Effective `TestProxiedServerDelete` leaf at or below 100s.
- Proxied Dolt Cmd shard 1/15 at or below 285s.
- At least 60s median shard saving versus the 387s baseline.

## Verification

- `GOTOOLCHAIN=go1.26.5 make test` — passed; `cmd/bd` completed in 304.064s.
- Focused untagged input and exact rendering tests — passed.
- Integration-tagged `cmd/bd` compile/focused run — passed.
- Two independent delegated reviews approved exact diff SHA-256 `6156a0b29143032816a3b7c079175fc3e5193024eb3ab94d52bf45199a89561a` after correcting their blocker/major findings.
- `git diff --check` — passed.

_codex-unknown-model-unknown-reasoning on behalf of CI Bot_
