### PR TITLE
fix: report proxied delete preview candidates

### DIFF
--- a/internal/storage/domain/db/issue_usecase_delete_test.go
+++ b/internal/storage/domain/db/issue_usecase_delete_test.go
@@ -122,21 +122,58 @@ func (s *testSuite) iucDeleteIssuesEmpty() {
 func (s *testSuite) iucDeleteIssuesDryRun() {
 	s.seedOpenIssue("bd-iuc-dry-a")
 	s.seedOpenIssue("bd-iuc-dry-b")
+	s.seedOpenWisp("bd-iuc-dry-c")
 	s.Require().NoError(s.depRepo().Insert(s.Ctx(),
-		newDep("bd-iuc-dry-a", "bd-iuc-dry-b", types.DepBlocks), "tester", domain.DepInsertOpts{}))
+		newDep("bd-iuc-dry-b", "bd-iuc-dry-a", types.DepBlocks), "tester", domain.DepInsertOpts{}))
+	s.Require().NoError(s.depRepo().Insert(s.Ctx(),
+		newDep("bd-iuc-dry-c", "bd-iuc-dry-b", types.DepParentChild), "tester",
+		domain.DepInsertOpts{UseWispsTable: true}))
+	s.Require().NoError(s.labelRepo().Insert(s.Ctx(),
+		"bd-iuc-dry-a", "dry-run-label", "tester", domain.LabelOpts{}))
+	s.Require().NoError(s.labelRepo().Insert(s.Ctx(),
+		"bd-iuc-dry-c", "dry-run-wisp-label", "tester", domain.LabelOpts{UseWispsTable: true}))
 
 	res, err := s.issueUseCase().DeleteIssues(s.Ctx(), domain.DeleteIssuesParams{
-		IDs:    []string{"bd-iuc-dry-a"},
-		DryRun: true,
+		IDs:     []string{"bd-iuc-dry-a"},
+		Cascade: true,
+		DryRun:  true,
 	}, "tester")
 	s.Require().NoError(err)
-	s.Equal(0, res.DeletedCount, "DryRun must not actually delete")
-	s.Equal(1, res.DependenciesCount)
+	s.Equal(3, res.DeletedCount, "DryRun must report the cascade candidate count")
+	s.Equal(2, res.DependenciesCount)
+	s.Equal(2, res.LabelsCount)
+	s.Equal(5, res.EventsCount)
 
-	var rows int
-	s.Require().NoError(s.Runner().QueryRowContext(s.Ctx(),
-		"SELECT COUNT(*) FROM issues WHERE id = ?", "bd-iuc-dry-a").Scan(&rows))
-	s.Equal(1, rows, "row must still exist after DryRun")
+	for _, table := range []struct {
+		name  string
+		where string
+		args  []any
+		want  int
+	}{
+		{name: "issues", where: "id IN (?, ?)", args: []any{"bd-iuc-dry-a", "bd-iuc-dry-b"}, want: 2},
+		{name: "wisps", where: "id = ?", args: []any{"bd-iuc-dry-c"}, want: 1},
+		{
+			name:  "dependencies",
+			where: "issue_id = ? AND depends_on_issue_id = ?",
+			args:  []any{"bd-iuc-dry-b", "bd-iuc-dry-a"},
+			want:  1,
+		},
+		{
+			name:  "wisp_dependencies",
+			where: "issue_id = ? AND depends_on_issue_id = ?",
+			args:  []any{"bd-iuc-dry-c", "bd-iuc-dry-b"},
+			want:  1,
+		},
+		{name: "labels", where: "issue_id = ?", args: []any{"bd-iuc-dry-a"}, want: 1},
+		{name: "wisp_labels", where: "issue_id = ?", args: []any{"bd-iuc-dry-c"}, want: 1},
+		{name: "events", where: "issue_id IN (?, ?)", args: []any{"bd-iuc-dry-a", "bd-iuc-dry-b"}, want: 3},
+		{name: "wisp_events", where: "issue_id = ?", args: []any{"bd-iuc-dry-c"}, want: 2},
+	} {
+		var rows int
+		s.Require().NoError(s.Runner().QueryRowContext(s.Ctx(),
+			"SELECT COUNT(*) FROM "+table.name+" WHERE "+table.where, table.args...).Scan(&rows))
+		s.Equal(table.want, rows, "%s rows must remain after DryRun", table.name)
+	}
 }
 
 func (s *testSuite) iucDeleteCleansAuxiliaryTables() {

--- a/internal/storage/domain/issue_delete.go
+++ b/internal/storage/domain/issue_delete.go
@@ -102,6 +102,7 @@ func (u *issueUseCaseImpl) deleteMany(ctx context.Context, params DeleteIssuesPa
 	result.EventsCount = evIssue + evWisp
 
 	if params.DryRun {
+		result.DeletedCount = len(regularIDs) + len(wispIDs)
 		return result, nil
 	}
 


### PR DESCRIPTION
## What

Populate `DeleteIssuesResult.DeletedCount` from the expanded regular-and-wisp candidate set before a proxied dry-run returns. The direct regression now uses a three-member cascade that crosses `issues` and `wisps`, and proves that all issue, dependency, label, and event rows remain unchanged.

## Why

Hosted validation for #5303 exposed a contract mismatch: proxied `bd delete --json` previewed a real three-member cascade as `"would_delete": 0`, while the eventual forced delete reported `"deleted_count": 3`. The proxied use case returned before assigning `DeletedCount`; embedded mode already reports candidate cardinality during a dry-run.

This is a focused correctness prerequisite for #5303. It does not weaken the optimized test or fold production behavior into that test-only PR.

Bead: `bd-fofny`

## Verification

- RED before the production fix: the focused domain test failed with expected `3`, actual `0`.
- Mutation check: counting regular candidates only failed with expected `3`, actual `2`, proving the regression exercises the wisp branch.
- `BEADS_TEST_ENV_RUN_DOLT=1 ./scripts/test.sh -v -run '^TestDomainDB/TestIssueUseCase_Delete/DeleteIssues/DryRunCountsButDoesNotDelete$' ./internal/storage/domain/db`
- `BEADS_TEST_ENV_RUN_DOLT=1 ./scripts/test.sh -v -run '^TestDomainDB/TestIssueUseCase_Delete$' ./internal/storage/domain/db`
- `make test`
- `golangci-lint run ./...` — 0 issues
- Two independent Sol blocker/major reviews approved the final diff hash `b8d0b8f34022dc779ffe5aec2e961d2414e7250522f5cbfb421c1c679787596d`.

## Scope

No change to actual delete selection, cascade expansion, reference rewriting, transaction commit behavior, CLI fields, schemas, migrations, workflows, skips, or timeouts.

_codex-unknown-model-unknown-reasoning on behalf of CI Bot_
