### PR TITLE
refactor: extract Init clone and host policy seams

### DIFF
--- a/cmd/bd/init.go
+++ b/cmd/bd/init.go
@@ -611,22 +611,15 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 			configPort := config.GetYamlConfig("dolt.port")
 			envPort := os.Getenv("BEADS_DOLT_SERVER_PORT")
 
-			effectiveHost := configHost
-			hostSource := "config.yaml"
-			if envHost != "" {
-				effectiveHost = envHost
-				hostSource = "environment"
-			}
-
-			if effectiveHost != "" && !isLocalHost(effectiveHost) {
-				detail := fmt.Sprintf("dolt.host (%s) is", effectiveHost)
-				if configPort != "" || envPort != "" {
-					detail = fmt.Sprintf("dolt.host (%s) and dolt.port are", effectiveHost)
+			if conflict := detectInitRemoteHostConflict(configHost, envHost, configPort, envPort); conflict != nil {
+				detail := fmt.Sprintf("dolt.host (%s) is", conflict.host)
+				if conflict.includesPort {
+					detail = fmt.Sprintf("dolt.host (%s) and dolt.port are", conflict.host)
 				}
 				return fmt.Errorf("%s set via %s but server mode is not enabled.\n"+
 					"  Embedded mode has no host/port — these settings require server mode.\n"+
 					"  Set dolt.mode: server in %s or pass --server to bd init.",
-					detail, hostSource, config.UserConfigYamlPath())
+					detail, conflict.source, config.UserConfigYamlPath())
 			}
 		}
 
@@ -1162,20 +1155,20 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 			}
 		}
 		if syncFromRemote {
-			var err error
 			cloneCfg := initTimeCloneConfig(initServerMode, serverHost, serverPort, serverSocket, serverUser, dbName)
-			err = cloneFromRemoteWithMode(ctx, beadsDir, syncURL, dbName, cloneCfg, initRemoteCloneMode(initServerMode, externalServer))
+			disposition, err := runInitRemoteClone(syncURL, func(remoteURL string) error {
+				return cloneFromRemoteWithMode(ctx, beadsDir, remoteURL, dbName, cloneCfg, initRemoteCloneMode(initServerMode, externalServer))
+			})
 			if err != nil {
-				if isEmptyRemoteCloneError(err) {
-					if !quiet {
-						fmt.Printf("  %s Remote has no Dolt data yet; initialized a fresh local database\n", ui.RenderWarn("!"))
-					}
-					syncFromRemote = false
-				} else {
-					fmt.Fprintf(os.Stderr, "Error: failed to clone remote %q: %v\n", syncURL, err)
-					fmt.Fprintf(os.Stderr, "Hint: verify the URL is reachable and any credentials are valid, or omit --remote to initialize a fresh local database.\n")
-					return &exitError{Code: 1}
+				fmt.Fprintf(os.Stderr, "Error: failed to clone remote %q: %v\n", syncURL, err)
+				fmt.Fprintf(os.Stderr, "Hint: verify the URL is reachable and any credentials are valid, or omit --remote to initialize a fresh local database.\n")
+				return &exitError{Code: 1}
+			}
+			if disposition == initRemoteCloneFresh {
+				if !quiet {
+					fmt.Printf("  %s Remote has no Dolt data yet; initialized a fresh local database\n", ui.RenderWarn("!"))
 				}
+				syncFromRemote = false
 			} else {
 				bootstrappedFromRemote = true
 				if !quiet {

--- a/cmd/bd/init_policy.go
+++ b/cmd/bd/init_policy.go
@@ -1,0 +1,54 @@
+package main
+
+// initRemoteCloneDisposition describes how init continues after a remote clone
+// attempt. It deliberately owns only the clone result policy; callers retain
+// all output, state, and remote-safety decisions.
+type initRemoteCloneDisposition uint8
+
+const (
+	initRemoteCloneFailed initRemoteCloneDisposition = iota
+	initRemoteCloneBootstrapped
+	initRemoteCloneFresh
+)
+
+// runInitRemoteClone runs one remote clone attempt and classifies the result
+// for Init. Empty remotes initialize locally; every other clone error is
+// returned unchanged.
+func runInitRemoteClone(remoteURL string, clone func(string) error) (initRemoteCloneDisposition, error) {
+	if err := clone(remoteURL); err != nil {
+		if isEmptyRemoteCloneError(err) {
+			return initRemoteCloneFresh, nil
+		}
+		return initRemoteCloneFailed, err
+	}
+	return initRemoteCloneBootstrapped, nil
+}
+
+// initRemoteHostConflict contains the effective remote host configuration
+// that embedded Init rejects when server mode is not enabled.
+type initRemoteHostConflict struct {
+	host         string
+	source       string
+	includesPort bool
+}
+
+// detectInitRemoteHostConflict applies Init's host-precedence rule. An
+// environment host overrides config, and ports are only explanatory once a
+// remote effective host has made the configuration incompatible with embedded
+// mode.
+func detectInitRemoteHostConflict(configHost, envHost, configPort, envPort string) *initRemoteHostConflict {
+	effectiveHost := configHost
+	hostSource := "config.yaml"
+	if envHost != "" {
+		effectiveHost = envHost
+		hostSource = "environment"
+	}
+	if effectiveHost == "" || isLocalHost(effectiveHost) {
+		return nil
+	}
+	return &initRemoteHostConflict{
+		host:         effectiveHost,
+		source:       hostSource,
+		includesPort: configPort != "" || envPort != "",
+	}
+}

--- a/cmd/bd/init_policy_test.go
+++ b/cmd/bd/init_policy_test.go
@@ -1,0 +1,194 @@
+package main
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/config"
+)
+
+func TestRunInitRemoteClone(t *testing.T) {
+	t.Run("passes explicit HTTP URL through unchanged", func(t *testing.T) {
+		const remoteURL = "http://127.0.0.1:1/no-such-db"
+		var gotURL string
+		resolvedURL, source := resolveInitConfiguredSyncRemote(remoteURL, true, func() string {
+			t.Fatal("explicit remote must not resolve a configured fallback")
+			return ""
+		})
+		if resolvedURL != remoteURL {
+			t.Fatalf("resolved URL = %q, want %q", resolvedURL, remoteURL)
+		}
+		if source != initSyncRemoteExplicit {
+			t.Fatalf("source = %v, want explicit", source)
+		}
+
+		disposition, err := runInitRemoteClone(resolvedURL, func(url string) error {
+			gotURL = url
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("runInitRemoteClone: %v", err)
+		}
+		if gotURL != remoteURL {
+			t.Fatalf("clone URL = %q, want %q", gotURL, remoteURL)
+		}
+		if disposition != initRemoteCloneBootstrapped {
+			t.Fatalf("disposition = %v, want bootstrapped", disposition)
+		}
+	})
+
+	t.Run("empty remote selects fresh initialization", func(t *testing.T) {
+		const remoteURL = "file:///empty"
+		resolvedURL, source := resolveInitConfiguredSyncRemote(remoteURL, true, func() string {
+			t.Fatal("explicit remote must not resolve a configured fallback")
+			return ""
+		})
+		if resolvedURL != remoteURL || source != initSyncRemoteExplicit {
+			t.Fatalf("resolved remote = (%q, %v), want (%q, explicit)", resolvedURL, source, remoteURL)
+		}
+		syncURLFromConfig := resolvedURL != "" && source != initSyncRemoteNone
+		called := false
+		disposition, err := runInitRemoteClone(resolvedURL, func(string) error {
+			called = true
+			return errors.New("remote contains no Dolt data")
+		})
+		if err != nil {
+			t.Fatalf("runInitRemoteClone: %v", err)
+		}
+		if !called {
+			t.Fatal("clone callback was not called")
+		}
+		if disposition != initRemoteCloneFresh {
+			t.Fatalf("disposition = %v, want fresh", disposition)
+		}
+
+		// The production call site clears syncFromRemote after this fresh
+		// fallback, but the explicit source remains a durable remote-wiring
+		// intent for both the Dolt remote and config.yaml.
+		if !shouldWireInitRemote(resolvedURL, false, syncURLFromConfig, false) {
+			t.Fatal("fresh fallback lost explicit remote wiring")
+		}
+		if !shouldWriteInitDoltRemote(false, resolvedURL, false, syncURLFromConfig, false, false) {
+			t.Fatal("fresh fallback lost explicit Dolt remote wiring")
+		}
+
+		beadsDir := filepath.Join(t.TempDir(), ".beads")
+		if err := os.MkdirAll(beadsDir, 0o750); err != nil {
+			t.Fatalf("mkdir beads dir: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(beadsDir, "config.yaml"), []byte("# Beads Config\n"), 0o600); err != nil {
+			t.Fatalf("write config.yaml: %v", err)
+		}
+		if err := persistInitSyncRemote(beadsDir, remoteURL, resolvedURL, false, syncURLFromConfig, false); err != nil {
+			t.Fatalf("persistInitSyncRemote: %v", err)
+		}
+		configBytes, err := os.ReadFile(filepath.Join(beadsDir, "config.yaml"))
+		if err != nil {
+			t.Fatalf("read config.yaml: %v", err)
+		}
+		if !strings.Contains(string(configBytes), remoteURL) {
+			t.Fatalf("config.yaml does not contain explicit remote %q:\n%s", remoteURL, configBytes)
+		}
+	})
+
+	t.Run("preserves non-empty clone failure", func(t *testing.T) {
+		want := errors.New("permission denied")
+		disposition, err := runInitRemoteClone("https://example.invalid/beads", func(string) error {
+			return want
+		})
+		if !errors.Is(err, want) {
+			t.Fatalf("error = %v, want %v", err, want)
+		}
+		if disposition != initRemoteCloneFailed {
+			t.Fatalf("disposition = %v, want failed", disposition)
+		}
+	})
+}
+
+func TestDetectInitRemoteHostConflict(t *testing.T) {
+	for _, tt := range []struct {
+		name                string
+		configHost, envHost string
+		configPort, envPort string
+		want                *initRemoteHostConflict
+	}{
+		{name: "port only", configPort: "3306"},
+		{
+			name:       "remote config host",
+			configHost: "100.111.197.110",
+			want:       &initRemoteHostConflict{host: "100.111.197.110", source: "config.yaml"},
+		},
+		{name: "localhost environment overrides remote config", configHost: "100.111.197.110", envHost: "localhost"},
+		{name: "loopback environment overrides remote config", configHost: "100.111.197.110", envHost: "127.0.0.1"},
+		{
+			name:       "remote environment takes precedence",
+			configHost: "127.0.0.1",
+			envHost:    "100.111.197.110",
+			envPort:    "3307",
+			want:       &initRemoteHostConflict{host: "100.111.197.110", source: "environment", includesPort: true},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			got := detectInitRemoteHostConflict(tt.configHost, tt.envHost, tt.configPort, tt.envPort)
+			if got == nil || tt.want == nil {
+				if got != tt.want {
+					t.Fatalf("detectInitRemoteHostConflict() = %#v, want %#v", got, tt.want)
+				}
+				return
+			}
+			if *got != *tt.want {
+				t.Fatalf("detectInitRemoteHostConflict() = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestConfiguredImportJSONLPath(t *testing.T) {
+	t.Setenv("BEADS_TEST_IGNORE_REPO_CONFIG", "1")
+	config.ResetForTesting()
+	if err := config.Initialize(); err != nil {
+		t.Fatalf("config.Initialize: %v", err)
+	}
+	t.Cleanup(config.ResetForTesting)
+
+	const beadsDir = "/workspace/.beads"
+	for _, tt := range []struct {
+		name string
+		path string
+		want string
+	}{
+		{name: "default", want: filepath.Join(beadsDir, "issues.jsonl")},
+		{name: "configured", path: "beads.jsonl", want: filepath.Join(beadsDir, "beads.jsonl")},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			config.Set("import.path", tt.path)
+			if got := configuredImportJSONLPath(beadsDir); got != tt.want {
+				t.Errorf("configuredImportJSONLPath(%q) = %q, want %q", beadsDir, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNormalizeIssuePrefixAndDatabaseName(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{name: "dotted directory", raw: "MyPkg.jl", want: "MyPkg_jl"},
+		{name: "leading dot", raw: ".claude", want: "claude"},
+		{name: "trailing hyphen", raw: "project-", want: "project"},
+		{name: "numeric start", raw: "001", want: "bd_001"},
+		{name: "database hyphen", raw: "my-prefix", want: "my_prefix"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			got := dbNameFromPrefix(normalizeIssuePrefix(tt.raw))
+			if got != tt.want {
+				t.Errorf("dbNameFromPrefix(normalizeIssuePrefix(%q)) = %q, want %q", tt.raw, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

Extract two package-private Init policy seams without changing behavior:

- `runInitRemoteClone` classifies one injected clone attempt as bootstrapped, fresh-empty, or failed while passing the exact remote URL.
- `detectInitRemoteHostConflict` owns Init's existing environment-over-config host precedence and keeps ports explanatory rather than mode-selecting.

All existing process journeys remain in place. This is the independently reviewable prerequisite for the later test-only performance change in `bd-1rh.8`.

## Why

Six `TestEmbeddedInit` journeys cost 87.04s on the successful PR Risk baseline, but the first test-only reduction exposed three Init-specific contracts without crisp lower owners: empty-remote fallback, explicit HTTP URL preservation, and Init's ambient host/port policy.

Landing these seams first lets hosted CI exercise the refactored code while every old process assertion still exists. The next PR can then remove only the redundant journeys with a mechanically auditable diff.

Bead: `bd-1rh.9`

## Contract ownership

| Contract | Fast owner added here | Existing process proof retained |
| --- | --- | --- |
| Explicit `http://` reaches clone unchanged | Recording clone callback after explicit remote resolution | `remote_http_url_preserved_verbatim` |
| Empty clone falls back fresh and keeps remote wiring | Clone disposition + config/Dolt wiring assertions | `remote_empty_initializes_fresh_and_wires_origin` |
| Fatal clone errors remain fatal | Sentinel error preservation | `remote_clone_failure_emits_url_and_hint` |
| Port alone does not imply server mode | Pure host-conflict table | `port_only_without_server_mode_succeeds` |
| Local environment host outranks remote config host | Pure precedence table | `local_env_host_overrides_remote_config_host` |
| Configured import path and dotted prefix normalization | Direct path/prefix tests | Both current Init journeys remain |

## Behavior-neutral evidence

- Two Sol reviewers approved frozen diff hash `856d8d2e2d00875064a8167253929f4fd1d900ed995056fef5f1b4f6bef8d309` with no blocker or major findings.
- All six downstream process journeys passed unchanged through the new seams in 39.608s.
- `TestCheckRemoteSafety_GuardMatrix` passed; safety decisions remain before the clone seam.
- Four temporary mutations each failed the intended direct test: URL normalization, empty-as-fatal, port-as-conflict, and config-over-environment precedence.
- `cmd/bd/init_embedded_test.go` is byte-identical to `main`.

## Contributor overlap

- #4415: no backend decision or embedded test is changed; its flat-file routing and future Dolt pins remain intact.
- #5136: its remote probe and safety decision region stays upstream of this clone seam.
- #5178: its explicit server-flag promotion continues to feed the environment values consumed here.
- #5285: its Git-ignore block is disjoint.

This PR does not replace or supersede any of those contributions.

## Verification

```text
focused direct policy tests                         PASS (4.790s)
six retained TestEmbeddedInit journeys             PASS (39.608s)
TestCheckRemoteSafety_GuardMatrix                   PASS
GOTOOLCHAIN=go1.26.5 make test                     PASS
  cmd/bd                                            343.132s
GOTOOLCHAIN=go1.26.5 golangci-lint run ./...       PASS (0 issues)
git diff --check                                    PASS
```

No test, timeout, skip, shard manifest, workflow, schema, migration, flag, CLI output, or storage interface is removed or changed.
