### PR TITLE
fix(uow): serialize database bootstrap with migration (bd-zog57)

### DIFF
--- a/internal/storage/schema/lock.go
+++ b/internal/storage/schema/lock.go
@@ -54,12 +54,23 @@ type MigrateLockOption func(*migrateLockOptions)
 
 type migrateLockOptions struct {
 	freshBootstrapHeal *freshBootstrapHealRequest
+	lockedPreparation  *lockedPreparationRequest
 }
 
 type freshBootstrapHealRequest struct {
 	capability *FreshBootstrapHealCapability
 	endpoint   string
 }
+
+type lockedPreparationRequest struct {
+	endpoint string
+	fn       LockedPreparation
+}
+
+// LockedPreparation performs bootstrap work under MigrateUpWithLock's pinned
+// connection and database-scoped migration lock. It may return a fresh
+// bootstrap heal capability to enable the existing guarded recovery path.
+type LockedPreparation func(context.Context, *sql.Conn) (*FreshBootstrapHealCapability, error)
 
 // FreshBootstrapHealCapability is a one-shot authorization to discard an
 // interrupted bootstrap working set. It is bound to the exact endpoint,
@@ -149,6 +160,15 @@ func WithFreshBootstrapHeal(capability *FreshBootstrapHealCapability, endpoint s
 	}
 }
 
+// WithLockedPreparation configures bootstrap work that must execute after the
+// migration lock is acquired and before migrations run. A non-nil capability
+// returned by fn enables the existing fresh-bootstrap recovery path.
+func WithLockedPreparation(endpoint string, fn LockedPreparation) MigrateLockOption {
+	return func(o *migrateLockOptions) {
+		o.lockedPreparation = &lockedPreparationRequest{endpoint: endpoint, fn: fn}
+	}
+}
+
 // MigrateUpWithLock serializes schema migrations for a single Dolt sql-server
 // database. conn must be a pinned *sql.Conn because MySQL/Dolt named locks are
 // session-scoped; GET_LOCK, migrations, and RELEASE_LOCK must run on the same
@@ -170,6 +190,18 @@ func MigrateUpWithLock(ctx context.Context, conn *sql.Conn, databaseName string,
 			err = errors.Join(err, releaseErr)
 		}
 	}()
+	if o.lockedPreparation != nil && o.lockedPreparation.fn != nil {
+		capability, preparationErr := o.lockedPreparation.fn(ctx, conn)
+		if preparationErr != nil {
+			return 0, preparationErr
+		}
+		if capability != nil {
+			o.freshBootstrapHeal = &freshBootstrapHealRequest{
+				capability: capability,
+				endpoint:   o.lockedPreparation.endpoint,
+			}
+		}
+	}
 
 	applied, err = MigrateUp(ctx, conn)
 	var dirtyErr *DirtyTablesError

--- a/internal/storage/schema/lock_test.go
+++ b/internal/storage/schema/lock_test.go
@@ -2,6 +2,7 @@ package schema
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"regexp"
 	"strings"
@@ -89,6 +90,51 @@ func TestMigrateUpWithLockUsesDatabaseScopedLockOnly(t *testing.T) {
 	}
 	if applied != 1 {
 		t.Fatalf("MigrateUpWithLock() applied = %d, want 1", applied)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet SQL expectations: %v", err)
+	}
+}
+
+func TestMigrateUpWithLockPreparationErrorReleasesAndJoinsReleaseFailure(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("create sql mock: %v", err)
+	}
+	defer db.Close()
+
+	ctx := context.Background()
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		t.Fatalf("pin mock connection: %v", err)
+	}
+	defer conn.Close()
+
+	lockName := MigrationLockName("testdb")
+	preparationErr := errors.New("bootstrap preparation failed")
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT GET_LOCK(?, ?)")).
+		WithArgs(lockName, migrationLockAcquireTimeoutSeconds).
+		WillReturnRows(sqlmock.NewRows([]string{"locked"}).AddRow(1))
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT RELEASE_LOCK(?)")).
+		WithArgs(lockName).
+		WillReturnError(errors.New("release failed"))
+
+	called := 0
+	applied, err := MigrateUpWithLock(ctx, conn, "testdb", WithLockedPreparation("tcp:test", func(context.Context, *sql.Conn) (*FreshBootstrapHealCapability, error) {
+		called++
+		return nil, preparationErr
+	}))
+	if applied != 0 {
+		t.Fatalf("MigrateUpWithLock() applied = %d, want 0", applied)
+	}
+	if called != 1 {
+		t.Fatalf("locked preparation calls = %d, want 1", called)
+	}
+	if !errors.Is(err, preparationErr) {
+		t.Fatalf("MigrateUpWithLock() error = %v, want preparation error", err)
+	}
+	if !errors.Is(err, ErrMigrationLockRelease) || !IsMigrationLockError(err) {
+		t.Fatalf("MigrateUpWithLock() error = %v, want classifiable release failure", err)
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("unmet SQL expectations: %v", err)

--- a/internal/storage/uow/dolt_sql_provider.go
+++ b/internal/storage/uow/dolt_sql_provider.go
@@ -42,6 +42,33 @@ type doltSQLProvider struct {
 	preview bool
 }
 
+type bootstrapPreparationError struct {
+	err       error
+	retryable bool
+}
+
+func (e *bootstrapPreparationError) Error() string {
+	return e.err.Error()
+}
+
+func (e *bootstrapPreparationError) Unwrap() error {
+	return e.err
+}
+
+func classifyInitSchemaError(err error) error {
+	var preparationErr *bootstrapPreparationError
+	if errors.As(err, &preparationErr) {
+		if preparationErr.retryable {
+			return fmt.Errorf("uow: bootstrap preparation: %w", err)
+		}
+		return backoff.Permanent(err)
+	}
+	if isSerializationError(err) || schema.IsMigrationLockError(err) {
+		return fmt.Errorf("uow: migrate: %w", err)
+	}
+	return backoff.Permanent(fmt.Errorf("uow: migrate: %w", err))
+}
+
 // ProviderOption tunes how a SQL-server unit-of-work provider opens. Options
 // are variadic so the existing constructor call sites — every one of which
 // wants the ordinary mutating open — stay unchanged.
@@ -137,6 +164,55 @@ func (p *doltSQLProvider) initSchema(ctx context.Context, database string) error
 	// never inferred again from probing or CREATE IF NOT EXISTS.
 	created := false
 	var bootstrapHeal *schema.FreshBootstrapHealCapability
+	prepareBootstrap := func(ctx context.Context, conn *sql.Conn) (*schema.FreshBootstrapHealCapability, error) {
+		ddl := db.NewDDLSQLRepository(conn)
+		justCreated := false
+		if created {
+			// Re-assert on retries so a database dropped between attempts
+			// (e.g. a concurrent clean-databases) is recreated rather than
+			// failing the USE below.
+			if err := ddl.CreateDatabaseIfNotExists(ctx, database); err != nil {
+				return nil, &bootstrapPreparationError{err: fmt.Errorf("uow: creating database: %w", err)}
+			}
+		} else {
+			switch err := ddl.CreateDatabase(ctx, database); {
+			case err == nil:
+				created = true
+				justCreated = true
+			case isDatabaseExistsError(err):
+				// Pre-existing (or a concurrent initializer won the create
+				// race): not ours, heal stays off.
+			case isSerializationError(err):
+				// Only the initial bare CREATE preserves its historical
+				// serialization retry classification. The later sticky CREATE,
+				// USE, and identity capture remain permanent regardless of
+				// their nested driver error.
+				return nil, &bootstrapPreparationError{
+					err:       fmt.Errorf("uow: creating database: %w", err),
+					retryable: true,
+				}
+			default:
+				return nil, &bootstrapPreparationError{err: fmt.Errorf("uow: creating database: %w", err)}
+			}
+		}
+		if err := ddl.UseDatabase(ctx, database); err != nil {
+			return nil, &bootstrapPreparationError{err: fmt.Errorf("uow: switching to database: %w", err)}
+		}
+		if justCreated {
+			// Capture authority only in the same attempt that won the exact bare
+			// CREATE. A later retry may re-create a missing database for
+			// availability, but it must never infer ownership of a replacement
+			// incarnation from CREATE IF NOT EXISTS.
+			var err error
+			bootstrapHeal, err = schema.CaptureFreshBootstrapHealCapability(
+				ctx, conn, p.serverEndpoint, database,
+			)
+			if err != nil {
+				return nil, &bootstrapPreparationError{err: fmt.Errorf("uow: capture fresh database identity: %w", err)}
+			}
+		}
+		return bootstrapHeal, nil
+	}
 	return backoff.Retry(func() error {
 		conn, err := p.db.Conn(ctx)
 		if err != nil {
@@ -188,53 +264,9 @@ func (p *doltSQLProvider) initSchema(ctx context.Context, database string) error
 			}
 			return nil
 		}
-		justCreated := false
-		if created {
-			// Re-assert on retries so a database dropped between attempts
-			// (e.g. a concurrent clean-databases) is recreated rather than
-			// failing the USE below.
-			if err := ddl.CreateDatabaseIfNotExists(ctx, database); err != nil {
-				return backoff.Permanent(fmt.Errorf("uow: creating database: %w", err))
-			}
-		} else {
-			switch err := ddl.CreateDatabase(ctx, database); {
-			case err == nil:
-				created = true
-				justCreated = true
-			case isDatabaseExistsError(err):
-				// Pre-existing (or a concurrent initializer won the create
-				// race): not ours, heal stays off.
-			case isSerializationError(err):
-				return fmt.Errorf("uow: creating database: %w", err)
-			default:
-				return backoff.Permanent(fmt.Errorf("uow: creating database: %w", err))
-			}
-		}
-		if err := ddl.UseDatabase(ctx, database); err != nil {
-			return backoff.Permanent(fmt.Errorf("uow: switching to database: %w", err))
-		}
-		if justCreated {
-			// Capture authority only in the same attempt that won the exact bare
-			// CREATE. A later retry may re-create a missing database for
-			// availability, but it must never infer ownership of a replacement
-			// incarnation from CREATE IF NOT EXISTS.
-			bootstrapHeal, err = schema.CaptureFreshBootstrapHealCapability(
-				ctx, conn, p.serverEndpoint, database,
-			)
-			if err != nil {
-				return backoff.Permanent(fmt.Errorf("uow: capture fresh database identity: %w", err))
-			}
-		}
-
-		var migrateOpts []schema.MigrateLockOption
-		if bootstrapHeal != nil {
-			migrateOpts = append(migrateOpts, schema.WithFreshBootstrapHeal(bootstrapHeal, p.serverEndpoint))
-		}
-		if _, err := schema.MigrateUpWithLock(ctx, conn, database, migrateOpts...); err != nil {
-			if isSerializationError(err) || schema.IsMigrationLockError(err) {
-				return fmt.Errorf("uow: migrate: %w", err)
-			}
-			return backoff.Permanent(fmt.Errorf("uow: migrate: %w", err))
+		if _, err := schema.MigrateUpWithLock(ctx, conn, database,
+			schema.WithLockedPreparation(p.serverEndpoint, prepareBootstrap)); err != nil {
+			return classifyInitSchemaError(err)
 		}
 		return nil
 	}, backoff.WithContext(bo, ctx))

--- a/internal/storage/uow/dolt_sql_provider_lock_test.go
+++ b/internal/storage/uow/dolt_sql_provider_lock_test.go
@@ -1,0 +1,103 @@
+package uow
+
+import (
+	"context"
+	"errors"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/cenkalti/backoff/v4"
+	mysql "github.com/go-sql-driver/mysql"
+	"github.com/steveyegge/beads/internal/storage/schema"
+)
+
+func TestClassifyInitSchemaErrorKeepsBootstrapPreparationErrorsDistinct(t *testing.T) {
+	t.Run("permanent preparation remains permanent when cleanup fails", func(t *testing.T) {
+		preparationErr := errors.New("create database failed")
+		err := classifyInitSchemaError(errors.Join(
+			&bootstrapPreparationError{err: preparationErr},
+			schema.ErrMigrationLockRelease,
+		))
+
+		var permanentErr *backoff.PermanentError
+		if !errors.As(err, &permanentErr) {
+			t.Fatalf("classifyInitSchemaError() error = %T %v, want permanent", err, err)
+		}
+		if !errors.Is(err, preparationErr) || !errors.Is(err, schema.ErrMigrationLockRelease) {
+			t.Fatalf("classifyInitSchemaError() error = %v, want preparation and release errors", err)
+		}
+	})
+
+	for _, tt := range []struct {
+		name      string
+		retryable bool
+		permanent bool
+	}{
+		{name: "initial bare create serialization retries", retryable: true},
+		{name: "use serialization remains permanent", permanent: true},
+		{name: "capture serialization remains permanent", permanent: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			serializationErr := &mysql.MySQLError{Number: 1213}
+			err := classifyInitSchemaError(&bootstrapPreparationError{
+				err:       serializationErr,
+				retryable: tt.retryable,
+			})
+
+			var permanentErr *backoff.PermanentError
+			if got := errors.As(err, &permanentErr); got != tt.permanent {
+				t.Fatalf("classifyInitSchemaError() permanent = %t, want %t (error = %v)", got, tt.permanent, err)
+			}
+			if !errors.Is(err, serializationErr) {
+				t.Fatalf("classifyInitSchemaError() error = %v, want serialization error", err)
+			}
+			if !tt.permanent && (!strings.Contains(err.Error(), "bootstrap preparation") || strings.Contains(err.Error(), "uow: migrate:")) {
+				t.Fatalf("classifyInitSchemaError() error = %v, want retryable bootstrap preparation error", err)
+			}
+		})
+	}
+}
+
+func TestInitSchemaAcquiresMigrationLockBeforeBootstrapDDL(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("create sql mock: %v", err)
+	}
+	defer db.Close()
+
+	lockName := schema.MigrationLockName("beads")
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT GET_LOCK(?, ?)")).
+		WithArgs(lockName, 5).
+		WillReturnRows(sqlmock.NewRows([]string{"locked"}).AddRow(1))
+	mock.ExpectExec(regexp.QuoteMeta("CREATE DATABASE `beads`")).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec(regexp.QuoteMeta("USE `beads`")).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT DATABASE(), @@server_uuid, DOLT_HASHOF('HEAD')")).
+		WillReturnRows(sqlmock.NewRows([]string{"database", "server_uuid", "head"}).AddRow("beads", "server-uuid", "initial-head"))
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT COUNT(*) FROM dolt_log")).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT COUNT(*) FROM dolt_status")).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
+	mock.ExpectExec(regexp.QuoteMeta("INSERT IGNORE INTO dolt_ignore VALUES (?, true)")).
+		WithArgs(sqlmock.AnyArg()).
+		WillReturnError(errors.New("first migration statement failed"))
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT RELEASE_LOCK(?)")).
+		WithArgs(lockName).
+		WillReturnRows(sqlmock.NewRows([]string{"released"}).AddRow(1))
+
+	p := &doltSQLProvider{
+		defaultBranch:  defaultBranch,
+		db:             db,
+		serverEndpoint: "tcp:127.0.0.1:3306",
+	}
+	err = p.initSchema(context.Background(), "beads")
+	if err == nil || !strings.Contains(err.Error(), "first migration statement failed") {
+		t.Fatalf("initSchema() error = %v, want first migration sentinel", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ordered bootstrap SQL expectations: %v", err)
+	}
+}


### PR DESCRIPTION
## What

Serialize ordinary Dolt SQL-server database bootstrap and schema migration under one database-scoped named lock on one pinned connection:

`GET_LOCK` → exact `CREATE` / `USE` → creator-only identity capture → migrate or guarded heal → `RELEASE_LOCK`.

The schema lock API gains a narrow locked-preparation callback so the UOW provider can perform bootstrap DDL and capture fresh-bootstrap authority inside the existing migration critical section.

## Why

Concurrent cold opens could let a losing initializer begin schema DDL after the winner created the database but before the winner captured its pristine identity. The winner then observed a dirty Dolt working set and failed permanently, intermittently breaking the race-enabled storage gate.

This keeps the existing fail-closed recovery rules: only the exact bare-`CREATE DATABASE` winner can capture reset authority, and authority remains bound to the endpoint, server, database, initial commit, and clean working set. Only serialization failure from that initial bare create retains its historical retry classification; `CREATE IF NOT EXISTS`, `USE`, and identity capture remain permanent failures.

Tracks `bd-zog57`.

## Contributor prior art

PR #5124 by @vishnujayvel identified concurrent provider cold-open contention and added useful test-side reliability work. This production repair credits that diagnosis, but addresses the newer create/capture/migrate ordering race. It does not replace, supersede, or close #5124.

## Verification

TDD RED was demonstrated first: `TestInitSchemaAcquiresMigrationLockBeforeBootstrapDDL` failed against `main` because `CREATE DATABASE` occurred before the expected `GET_LOCK`.

Passed after the fix:

```text
GOTOOLCHAIN=go1.26.5 ./scripts/test.sh ./internal/storage/schema/... ./internal/storage/uow/...
GOTOOLCHAIN=go1.26.5 make test
golangci-lint run ./internal/storage/schema/... ./internal/storage/uow/...
```

Final baseline evidence:

- `make test`: exit 0
- `cmd/bd`: 302.605s
- `internal/storage/schema`: 4.442s
- `internal/storage/uow`: 4.871s
- total coverage: 40.0%
- final staged diff: `a8162e89fea26f39eba72c5f762fd3010ce43c602f93edc1b64c81ad239c8e7b`

Two independent Sol reviews covered correctness, cleanup/error joining, architecture, and retry semantics. One major finding about over-broad preparation retries was fixed; the final composite was re-reviewed with no blocker or major findings.

## Risk and scope

- Changes the protected schema/bootstrap ordering, but does not change migrations or schema contents.
- Preserves lock release and joined cleanup errors when preparation fails.
- Leaves preview and team-server initialization paths unchanged.
- Adds deterministic ordered-SQL and preparation-failure regression tests; no sleeps or weakened concurrency assertions.

This is a nontrivial storage/schema-path change and requires substantive human maintainer review. The author will not self-merge it.

_codex-unknown-model-unknown-reasoning on behalf of CI Bot_
