### PR TITLE
ci: reuse built bd in macOS test lanes (bd-vygvv)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -553,6 +553,7 @@ jobs:
       - name: Test
         if: ${{ !matrix.coverage }}
         env:
+          BEADS_TEST_BD_BINARY: ${{ github.workspace }}/bd
           GOCACHE: ${{ runner.temp }}/go-cache/race
         run: go test -tags gms_pure_go ${{ matrix.test-flags }} -skip '^TestEmbedded' ./...
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -659,6 +659,7 @@ jobs:
 
       - name: Test
         env:
+          BEADS_TEST_BD_BINARY: ${{ github.workspace }}/bd
           GOCACHE: ${{ runner.temp }}/go-cache/race
         run: go test -tags gms_pure_go -v -race -short -skip '^TestEmbedded' ./...
 

--- a/scripts/ci_workflow_test.go
+++ b/scripts/ci_workflow_test.go
@@ -60,6 +60,61 @@ func TestPRCIGateRequiresPolicyAndLintWrappers(t *testing.T) {
 	}
 }
 
+func TestMacOSTestJobsReuseWorkspaceBDBinary(t *testing.T) {
+	const (
+		workspaceBDBinary = "${{ github.workspace }}/bd"
+		buildCommand      = "go build -v -tags gms_pure_go ./cmd/bd"
+		prTestCommand     = "go test -tags gms_pure_go -v -race -short -skip '^TestEmbedded' ./..."
+		mainTestCommand   = "go test -tags gms_pure_go ${{ matrix.test-flags }} -skip '^TestEmbedded' ./..."
+	)
+
+	workflows := map[string]ciWorkflow{
+		"main.yml": readCIWorkflow(t, "main.yml"),
+		"pr.yml":   readCIWorkflow(t, "pr.yml"),
+	}
+
+	prMacOS := workflows["pr.yml"].job(t, "test-macos")
+	if prMacOS.RunsOn != macOSRunner {
+		t.Errorf("pr macOS test runner = %q, want %q", prMacOS.RunsOn, macOSRunner)
+	}
+	assertStepRunsExactly(t, prMacOS, "Build", buildCommand)
+	assertStepRunsExactly(t, prMacOS, "Test", prTestCommand)
+	assertStepsBefore(t, prMacOS, []string{"Build"}, []string{"Test"})
+	assertStepEnvValue(t, prMacOS, "Test", "BEADS_TEST_BD_BINARY", workspaceBDBinary)
+
+	mainTest := workflows["main.yml"].job(t, "test")
+	assertStepRunsExactly(t, mainTest, "Build", buildCommand)
+	assertStepRunsExactly(t, mainTest, "Test", mainTestCommand)
+	assertStepsBefore(t, mainTest, []string{"Build"}, []string{"Test"})
+	if got := mainTest.step(t, "Build").If; got != "matrix.os != 'ubuntu-latest'" {
+		t.Errorf("main build condition = %q, want macOS-only condition", got)
+	}
+	if got := mainTest.step(t, "Test").If; got != "${{ !matrix.coverage }}" {
+		t.Errorf("main test condition = %q, want non-coverage condition", got)
+	}
+	if got := mainTest.Strategy.Matrix.OS; !equalStrings(got, []string{"ubuntu-latest", macOSRunner}) {
+		t.Errorf("main test matrix os = %v, want [ubuntu-latest %s]", got, macOSRunner)
+	}
+	if got := mainTest.Strategy.Matrix.Include; len(got) != 2 ||
+		got[0].OS != "ubuntu-latest" || !got[0].Coverage ||
+		got[1].OS != macOSRunner || got[1].Coverage || got[1].TestFlags != "-v -race -short" {
+		t.Errorf("main test matrix include = %+v, want macOS non-coverage entry with -v -race -short", got)
+	}
+	assertStepEnvValue(t, mainTest, "Test", "BEADS_TEST_BD_BINARY", workspaceBDBinary)
+
+	for workflowName, workflow := range workflows {
+		for jobName, job := range workflow.Jobs {
+			for _, step := range job.Steps {
+				if step.Env["BEADS_TEST_BD_BINARY"] == workspaceBDBinary &&
+					!(workflowName == "pr.yml" && jobName == "test-macos" && step.Name == "Test") &&
+					!(workflowName == "main.yml" && jobName == "test" && step.Name == "Test") {
+					t.Errorf("%s job %q step %q has unexpected workspace bd binary override", workflowName, jobName, step.Name)
+				}
+			}
+		}
+	}
+}
+
 func TestGoCacheOwnershipTopology(t *testing.T) {
 	workflows := map[string]ciWorkflow{
 		"main.yml":    readCIWorkflow(t, "main.yml"),
@@ -434,6 +489,32 @@ func assertGoCacheEnv(t *testing.T, job ciWorkflowJob, stepName, profile string)
 	}
 }
 
+func assertStepRunsExactly(t *testing.T, job ciWorkflowJob, stepName, want string) {
+	t.Helper()
+	if got := job.step(t, stepName).Run; got != want {
+		t.Errorf("step %q run = %q, want %q", stepName, got, want)
+	}
+}
+
+func assertStepEnvValue(t *testing.T, job ciWorkflowJob, stepName, key, want string) {
+	t.Helper()
+	if got := job.step(t, stepName).Env[key]; got != want {
+		t.Errorf("step %q env %s = %q, want %q", stepName, key, got, want)
+	}
+}
+
+func equalStrings(got, want []string) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			return false
+		}
+	}
+	return true
+}
+
 func assertGoCacheWriter(t *testing.T, workflow ciWorkflow, wantJob, wantRunner, wantStep, wantCondition string) {
 	t.Helper()
 
@@ -524,7 +605,14 @@ type ciWorkflowStrategy struct {
 }
 
 type ciWorkflowMatrix struct {
-	OS []string `yaml:"os"`
+	OS      []string                  `yaml:"os"`
+	Include []ciWorkflowMatrixInclude `yaml:"include"`
+}
+
+type ciWorkflowMatrixInclude struct {
+	OS        string `yaml:"os"`
+	Coverage  bool   `yaml:"coverage"`
+	TestFlags string `yaml:"test-flags"`
 }
 
 type ciWorkflowStep struct {


### PR DESCRIPTION
## What

Reuse the current-checkout `./bd` binary that the two macOS jobs already build:

- PR workflow: `test-macos` → `Test`
- Main workflow: `test` → non-coverage macOS `Test`

The workflow contract test pins the build provenance, build-before-test ordering,
exact test commands, and macOS-only placement of the override.

## Why

Several `cmd/bd` subprocess helpers otherwise relink the same current-checkout
binary during the test step. Both jobs already run
`go build -v -tags gms_pure_go ./cmd/bd` immediately before testing, so the
test helpers can reuse that output without changing what is built or tested.

## Safety boundaries

- No test scenarios, flags, skips, assertions, or timeouts changed.
- The suite remains race-enabled; only its subprocess binary uses the existing
  non-race build, matching prior helper behavior.
- The main-workflow override remains limited to the non-coverage macOS matrix
  entry.
- No production code changed.

## Verification

- TDD RED: `TestMacOSTestJobsReuseWorkspaceBDBinary` failed on the missing
  override.
- `./scripts/test.sh ./scripts` — pass (`5.103s`).
- `make ci-pr-policy` — pass.
- `golangci-lint run ./...` — `0 issues`.
- `make test` — pass; `cmd/bd` `307.763s`, total coverage `40.0%`.
- Two independent Sol reviews approved frozen diff SHA-256
  `704b53b2b34c595459d706cb7ed448eb57546047b236cab76c38892b701fc839`
  with no blocker/major findings.
- Hosted CI passed on the first attempt: 84 successes, three intentional skips,
  and zero failures.

## Hosted result

The first hosted run confirms that the intended reuse path works, but it does
not support the original minute-scale forecast:

| Metric | Comparable #5307 | This PR #5311 | Observed change |
|---|---:|---:|---:|
| `cmd/bd` package | 306.294s | 284.191s | -22.103s |
| macOS test step | 361s | 322s | -39s |
| whole macOS job | 463s | 458s | -5s |

Representative rebuild-blocked tests improved sharply
(`TestBootstrapRejectsRemovedBackendsBeforeWorkspaceWrites` 44.13s → 0.91s;
`TestInitRepairsPermissiveBeadsDir` 19.99s → 2.95s), proving the override is
used. The prior estimate incorrectly added waits that overlap because tests run
in parallel behind package-wide `sync.Once` builds. The two PR runs also were
not a controlled same-commit A/B: unrelated package work and runner/cache
variance differed materially.

The package is now below five minutes in this run, but the issue's 246.294s
target was not reached. This PR therefore claims only removal of redundant work
and the measured first-run result above, not a guaranteed minute-scale saving.

Tracks `bd-vygvv`.
