### PR TITLE
test: collapse proxied DeleteWisp portfolio (bd-1rh.11)

### DIFF
--- a/cmd/bd/delete_proxied_integration_test.go
+++ b/cmd/bd/delete_proxied_integration_test.go
@@ -5,7 +5,6 @@ package main
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"reflect"
 	"strings"
 	"sync"
@@ -120,201 +119,55 @@ func deleteJSONEqual(got, want map[string]any) bool {
 
 func TestProxiedServerDeleteWisp(t *testing.T) {
 	requireSharedProxiedServer(t)
-	t.Parallel()
 	bd := buildEmbeddedBD(t)
+	p := newSharedProxiedProject(t, bd, "dwr")
+	wisp := bdProxiedCreate(t, bd, p.dir, "Wisp delete routing", "--ephemeral")
+	db := openProxiedDB(t, p)
+	assertRowExists(t, db, "wisps", wisp.ID)
 
-	t.Run("delete_mixed_wisp_and_issue_partition", func(t *testing.T) {
-		t.Parallel()
-		p := newSharedProxiedProject(t, bd, "dmp")
-		issue := bdProxiedCreate(t, bd, p.dir, "Regular target", "-t", "task")
-		wisp := bdProxiedCreate(t, bd, p.dir, "Wisp target", "--ephemeral")
+	if _, err := db.ExecContext(context.Background(),
+		"INSERT INTO issues (id, title, description, design, acceptance_criteria, notes) VALUES (?, ?, '', '', '', '')",
+		wisp.ID, "shadow row"); err != nil {
+		t.Fatalf("seed shadow issues row: %v", err)
+	}
+	assertRowExists(t, db, "issues", wisp.ID)
+	if _, err := db.ExecContext(context.Background(), "CALL DOLT_COMMIT('-Am', 'seed shadow issue')"); err != nil {
+		t.Fatalf("commit shadow issues row: %v", err)
+	}
 
-		db := openProxiedDB(t, p)
-		assertRowExists(t, db, "issues", issue.ID)
-		assertRowExists(t, db, "wisps", wisp.ID)
+	var headBefore string
+	if err := db.QueryRowContext(context.Background(), "SELECT HASHOF('HEAD')").Scan(&headBefore); err != nil {
+		t.Fatalf("read HEAD before: %v", err)
+	}
 
-		bdProxiedDelete(t, bd, p.dir, issue.ID, wisp.ID, "--force")
+	out := bdProxiedDelete(t, bd, p.dir, "--json", wisp.ID, "--force")
+	start := strings.Index(out, "{")
+	if start < 0 {
+		t.Fatalf("no JSON object in delete output:\n%s", out)
+	}
+	var result struct {
+		SchemaVersion int      `json:"schema_version"`
+		Deleted       []string `json:"deleted"`
+		DeletedCount  int      `json:"deleted_count"`
+	}
+	if err := json.Unmarshal([]byte(out[start:]), &result); err != nil {
+		t.Fatalf("parse delete JSON: %v\nraw: %s", err, out[start:])
+	}
+	if result.SchemaVersion != JSONSchemaVersion || !reflect.DeepEqual(result.Deleted, []string{wisp.ID}) || result.DeletedCount != 1 {
+		t.Errorf("delete JSON: got %+v, want schema_version=%d deleted=[%s] deleted_count=1",
+			result, JSONSchemaVersion, wisp.ID)
+	}
 
-		assertRowAbsent(t, db, "issues", issue.ID)
-		assertRowAbsent(t, db, "wisps", wisp.ID)
-	})
+	assertRowAbsent(t, db, "wisps", wisp.ID)
+	assertRowExists(t, db, "issues", wisp.ID)
 
-	t.Run("delete_wisp_clears_wisp_aux_tables", func(t *testing.T) {
-		t.Parallel()
-		p := newSharedProxiedProject(t, bd, "dwc")
-		a := bdProxiedCreate(t, bd, p.dir, "Wisp aux A", "--ephemeral")
-		_ = bdProxiedCreate(t, bd, p.dir, "Wisp aux B", "--ephemeral",
-			"--deps", "depends-on:"+a.ID)
-		bdProxiedUpdateOne(t, bd, p.dir, a.ID, "--add-label", "alpha")
-
-		bdProxiedDelete(t, bd, p.dir, a.ID, "--force")
-
-		db := openProxiedDB(t, p)
-		ctx := context.Background()
-		assertRowAbsent(t, db, "wisps", a.ID)
-
-		for _, q := range []struct {
-			table, where string
-		}{
-			{"wisp_labels", "issue_id = ?"},
-			{"wisp_events", "issue_id = ?"},
-			{"wisp_dependencies", "issue_id = ? OR depends_on_wisp_id = ?"},
-		} {
-			var count int
-			args := []any{a.ID}
-			if strings.Count(q.where, "?") == 2 {
-				args = append(args, a.ID)
-			}
-			query := fmt.Sprintf("SELECT COUNT(*) FROM %s WHERE %s", q.table, q.where)
-			if err := db.QueryRowContext(ctx, query, args...).Scan(&count); err != nil {
-				t.Fatalf("count %s for %s: %v", q.table, a.ID, err)
-			}
-			if count != 0 {
-				t.Errorf("%s rows for deleted wisp %s: got %d, want 0", q.table, a.ID, count)
-			}
-		}
-	})
-
-	t.Run("delete_wisp_routes_to_wisps_table", func(t *testing.T) {
-		t.Parallel()
-		p := newSharedProxiedProject(t, bd, "dwr")
-		wisp := bdProxiedCreate(t, bd, p.dir, "Wisp delete routing", "--ephemeral")
-
-		db := openProxiedDB(t, p)
-		assertRowExists(t, db, "wisps", wisp.ID)
-		assertRowAbsent(t, db, "issues", wisp.ID)
-
-		if _, err := db.ExecContext(context.Background(),
-			"INSERT INTO issues (id, title, description, design, acceptance_criteria, notes) VALUES (?, ?, '', '', '', '')",
-			wisp.ID, "shadow row"); err != nil {
-			t.Fatalf("seed shadow issues row: %v", err)
-		}
-		assertRowExists(t, db, "issues", wisp.ID)
-
-		bdProxiedDelete(t, bd, p.dir, wisp.ID, "--force")
-
-		assertRowAbsent(t, db, "wisps", wisp.ID)
-		assertRowExists(t, db, "issues", wisp.ID)
-	})
-
-	t.Run("delete_wisp_batch", func(t *testing.T) {
-		t.Parallel()
-		p := newSharedProxiedProject(t, bd, "dwb")
-		a := bdProxiedCreate(t, bd, p.dir, "Wisp batch 1", "--ephemeral")
-		b := bdProxiedCreate(t, bd, p.dir, "Wisp batch 2", "--ephemeral")
-		c := bdProxiedCreate(t, bd, p.dir, "Wisp batch 3", "--ephemeral")
-
-		bdProxiedDelete(t, bd, p.dir, a.ID, b.ID, c.ID, "--force")
-
-		db := openProxiedDB(t, p)
-		for _, id := range []string{a.ID, b.ID, c.ID} {
-			assertRowAbsent(t, db, "wisps", id)
-		}
-	})
-
-	t.Run("delete_wisp_cascades_dependents", func(t *testing.T) {
-		t.Parallel()
-		p := newSharedProxiedProject(t, bd, "dwc")
-		parent := bdProxiedCreate(t, bd, p.dir, "Wisp parent", "--ephemeral")
-		child := bdProxiedCreate(t, bd, p.dir, "Wisp child", "--ephemeral",
-			"--deps", "depends-on:"+parent.ID)
-
-		bdProxiedDelete(t, bd, p.dir, parent.ID, "--force")
-
-		db := openProxiedDB(t, p)
-		assertRowAbsent(t, db, "wisps", parent.ID)
-		assertRowAbsent(t, db, "wisps", child.ID)
-	})
-
-	t.Run("delete_wisp_cascade_spans_all_dep_types", func(t *testing.T) {
-		t.Parallel()
-		p := newSharedProxiedProject(t, bd, "dws")
-		a := bdProxiedCreate(t, bd, p.dir, "Wisp A", "--ephemeral")
-		b := bdProxiedCreate(t, bd, p.dir, "Wisp B", "--ephemeral",
-			"--deps", "depends-on:"+a.ID)
-		c := bdProxiedCreate(t, bd, p.dir, "Wisp C", "--ephemeral",
-			"--parent", b.ID)
-
-		bdProxiedDelete(t, bd, p.dir, a.ID, "--force")
-
-		db := openProxiedDB(t, p)
-		for _, id := range []string{a.ID, b.ID, c.ID} {
-			assertRowAbsent(t, db, "wisps", id)
-		}
-	})
-
-	t.Run("delete_wisp_skips_dolt_commit", func(t *testing.T) {
-		t.Parallel()
-		p := newSharedProxiedProject(t, bd, "dwdc")
-		wisp := bdProxiedCreate(t, bd, p.dir, "Wisp commit skip", "--ephemeral")
-
-		db := openProxiedDB(t, p)
-		var before string
-		if err := db.QueryRowContext(context.Background(),
-			"SELECT HASHOF('HEAD')").Scan(&before); err != nil {
-			t.Fatalf("read HEAD before: %v", err)
-		}
-
-		bdProxiedDelete(t, bd, p.dir, wisp.ID, "--force")
-
-		var after string
-		if err := db.QueryRowContext(context.Background(),
-			"SELECT HASHOF('HEAD')").Scan(&after); err != nil {
-			t.Fatalf("read HEAD after: %v", err)
-		}
-		if after != before {
-			t.Errorf("HEAD advanced for a wisp-only delete (wisps are dolt_ignored): before=%s after=%s",
-				before, after)
-		}
-	})
-
-	t.Run("delete_wisp_dry_run_does_not_mutate", func(t *testing.T) {
-		t.Parallel()
-		p := newSharedProxiedProject(t, bd, "dwdr")
-		wisp := bdProxiedCreate(t, bd, p.dir, "Wisp dry-run target", "--ephemeral")
-
-		got := bdProxiedDeleteJSON(t, bd, p.dir, "--json", wisp.ID, "--dry-run")
-		if _, ok := got["would_delete"]; !ok {
-			t.Errorf("dry-run JSON missing `would_delete`; got keys: %v", mapKeys(got))
-		}
-
-		db := openProxiedDB(t, p)
-		assertRowExists(t, db, "wisps", wisp.ID)
-	})
-
-	t.Run("delete_wisp_rewrites_text_references", func(t *testing.T) {
-		t.Parallel()
-		p := newSharedProxiedProject(t, bd, "dwrt")
-		neighbor := bdProxiedCreate(t, bd, p.dir, "Wisp neighbor", "--ephemeral")
-		target := bdProxiedCreate(t, bd, p.dir, "Wisp target", "--ephemeral",
-			"--deps", "depends-on:"+neighbor.ID)
-		bdProxiedUpdateOne(t, bd, p.dir, neighbor.ID, "--description", "see "+target.ID+" for context")
-
-		bdProxiedDelete(t, bd, p.dir, target.ID, "--force")
-
-		db := openProxiedDB(t, p)
-		assertRowAbsent(t, db, "wisps", target.ID)
-		assertRowExists(t, db, "wisps", neighbor.ID)
-
-		var desc string
-		if err := db.QueryRowContext(context.Background(),
-			"SELECT description FROM wisps WHERE id = ?", neighbor.ID).Scan(&desc); err != nil {
-			t.Fatalf("read wisp neighbor description: %v", err)
-		}
-		want := "[deleted:" + target.ID + "]"
-		if !strings.Contains(desc, want) {
-			t.Errorf("wisp neighbor description: got %q, want substring %q", desc, want)
-		}
-	})
-
-	t.Run("delete_wisp_nonexistent", func(t *testing.T) {
-		t.Parallel()
-		p := newSharedProxiedProject(t, bd, "dwn")
-		out := bdProxiedDeleteFail(t, bd, p.dir, "dwn-doesnotexist", "--force")
-		if !strings.Contains(strings.ToLower(out), "not found") {
-			t.Errorf("expected `not found` error for bogus wisp id, got: %s", out)
-		}
-	})
+	var headAfter string
+	if err := db.QueryRowContext(context.Background(), "SELECT HASHOF('HEAD')").Scan(&headAfter); err != nil {
+		t.Fatalf("read HEAD after: %v", err)
+	}
+	if headAfter != headBefore {
+		t.Errorf("HEAD advanced for a wisp-only delete (wisps are dolt_ignored): before=%s after=%s", headBefore, headAfter)
+	}
 }
 
 func TestProxiedServerDeleteConcurrent(t *testing.T) {
@@ -398,14 +251,6 @@ func bdProxiedDeleteJSON(t *testing.T, bd, dir string, args ...string) map[strin
 		t.Fatalf("parse delete JSON: %v\nraw: %s", err, out[start:])
 	}
 	return got
-}
-
-func mapKeys(m map[string]any) []string {
-	out := make([]string, 0, len(m))
-	for k := range m {
-		out = append(out, k)
-	}
-	return out
 }
 
 func bdProxiedDeleteRaw(t *testing.T, bd, dir string, args ...string) (string, string, error) {

--- a/internal/storage/domain/db/issue_usecase_delete_test.go
+++ b/internal/storage/domain/db/issue_usecase_delete_test.go
@@ -19,10 +19,13 @@ func (s *testSuite) TestIssueUseCase_Delete() {
 		s.Run("EmptyIDsIsNoop", s.iucDeleteIssuesEmpty)
 		s.Run("DryRunCountsButDoesNotDelete", s.iucDeleteIssuesDryRun)
 		s.Run("CleansLabelsAndEvents", s.iucDeleteCleansAuxiliaryTables)
+		s.Run("MixedIssueAndWispMutatesCorrectTables", s.iucDeleteIssuesMixedIssueAndWispMutatesCorrectTables)
 		s.Run("UpdateTextReferencesFalseLeavesRefs", s.iucDeleteSkipsRefsWhenFlagOff)
 	})
 	s.Run("DeleteWisp", func() {
 		s.Run("DispatchesToWispsTable", s.iucDeleteWispDispatches)
+		s.Run("CleansAuxiliaryTablesAndCascadesAcrossDependencyTypes", s.iucDeleteWispCleansAuxiliaryTablesAndCascadesAcrossDependencyTypes)
+		s.Run("RewritesTextReferencesInWisps", s.iucDeleteWispRewritesTextReferencesInWisps)
 	})
 	s.Run("PreviewDelete", func() {
 		s.Run("EmptyInputReturnsEmpty", s.iucPreviewEmpty)
@@ -200,6 +203,31 @@ func (s *testSuite) iucDeleteCleansAuxiliaryTables() {
 	s.Equal(0, rows)
 }
 
+func (s *testSuite) iucDeleteIssuesMixedIssueAndWispMutatesCorrectTables() {
+	s.seedOpenIssue("bd-iuc-mixed-issue")
+	s.seedOpenWisp("bd-iuc-mixed-wisp")
+	s.seedOpenIssue("bd-iuc-mixed-wisp")
+
+	res, err := s.issueUseCase().DeleteIssues(s.Ctx(), domain.DeleteIssuesParams{
+		IDs:                  []string{"bd-iuc-mixed-issue", "bd-iuc-mixed-wisp"},
+		Cascade:              true,
+		UpdateTextReferences: true,
+	}, "tester")
+	s.Require().NoError(err)
+	s.Equal(2, res.DeletedCount)
+
+	var issueRows, wispRows, shadowIssueRows int
+	s.Require().NoError(s.Runner().QueryRowContext(s.Ctx(),
+		"SELECT COUNT(*) FROM issues WHERE id = ?", "bd-iuc-mixed-issue").Scan(&issueRows))
+	s.Equal(0, issueRows)
+	s.Require().NoError(s.Runner().QueryRowContext(s.Ctx(),
+		"SELECT COUNT(*) FROM wisps WHERE id = ?", "bd-iuc-mixed-wisp").Scan(&wispRows))
+	s.Equal(0, wispRows)
+	s.Require().NoError(s.Runner().QueryRowContext(s.Ctx(),
+		"SELECT COUNT(*) FROM issues WHERE id = ?", "bd-iuc-mixed-wisp").Scan(&shadowIssueRows))
+	s.Equal(1, shadowIssueRows, "durable row shadowing the wisp ID must remain")
+}
+
 func (s *testSuite) iucDeleteSkipsRefsWhenFlagOff() {
 	s.seedOpenIssue("bd-iuc-noref-target")
 	s.seedOpenIssue("bd-iuc-noref-neighbor")
@@ -238,6 +266,66 @@ func (s *testSuite) iucDeleteWispDispatches() {
 	s.Require().NoError(s.Runner().QueryRowContext(s.Ctx(),
 		"SELECT COUNT(*) FROM issues WHERE id = ?", "bd-iuc-delw-1").Scan(&issueRows))
 	s.Equal(1, issueRows, "issues row with shadowed ID must remain")
+}
+
+func (s *testSuite) iucDeleteWispCleansAuxiliaryTablesAndCascadesAcrossDependencyTypes() {
+	root := "bd-iuc-wisp-cascade-root"
+	mid := "bd-iuc-wisp-cascade-mid"
+	leaf := "bd-iuc-wisp-cascade-leaf"
+	for _, id := range []string{root, mid, leaf} {
+		s.seedOpenWisp(id)
+	}
+	s.Require().NoError(s.depRepo().Insert(s.Ctx(),
+		newDep(mid, root, types.DepBlocks), "tester", domain.DepInsertOpts{UseWispsTable: true}))
+	s.Require().NoError(s.depRepo().Insert(s.Ctx(),
+		newDep(leaf, mid, types.DepParentChild), "tester", domain.DepInsertOpts{UseWispsTable: true}))
+	s.Require().NoError(s.labelRepo().Insert(s.Ctx(),
+		root, "delete-me", "tester", domain.LabelOpts{UseWispsTable: true}))
+	s.Require().NoError(s.eventsRepo().Record(s.Ctx(),
+		domain.Event{IssueID: root, Type: types.EventCreated, Actor: "tester"},
+		domain.RecordEventOpts{UseWispsTable: true}))
+
+	res, err := s.issueUseCase().DeleteWisp(s.Ctx(), root, "tester")
+	s.Require().NoError(err)
+	s.Equal(3, res.DeletedCount, "root plus both transitive dependents")
+
+	for _, id := range []string{root, mid, leaf} {
+		var wispRows, labelRows, eventRows, dependencyRows int
+		s.Require().NoError(s.Runner().QueryRowContext(s.Ctx(),
+			"SELECT COUNT(*) FROM wisps WHERE id = ?", id).Scan(&wispRows))
+		s.Equal(0, wispRows, "%s should be deleted", id)
+		s.Require().NoError(s.Runner().QueryRowContext(s.Ctx(),
+			"SELECT COUNT(*) FROM wisp_labels WHERE issue_id = ?", id).Scan(&labelRows))
+		s.Equal(0, labelRows, "%s labels should be deleted", id)
+		s.Require().NoError(s.Runner().QueryRowContext(s.Ctx(),
+			"SELECT COUNT(*) FROM wisp_events WHERE issue_id = ?", id).Scan(&eventRows))
+		s.Equal(0, eventRows, "%s events should be deleted", id)
+		s.Require().NoError(s.Runner().QueryRowContext(s.Ctx(),
+			"SELECT COUNT(*) FROM wisp_dependencies WHERE issue_id = ? OR depends_on_issue_id = ? OR depends_on_wisp_id = ?",
+			id, id, id).Scan(&dependencyRows))
+		s.Equal(0, dependencyRows, "%s dependencies should be deleted", id)
+	}
+}
+
+func (s *testSuite) iucDeleteWispRewritesTextReferencesInWisps() {
+	target := "bd-iuc-wisp-ref-target"
+	neighbor := "bd-iuc-wisp-ref-neighbor"
+	s.seedOpenWisp(target)
+	s.seedOpenWisp(neighbor)
+	s.Require().NoError(s.issueRepo().Update(s.Ctx(), neighbor,
+		map[string]any{"description": "see " + target + " for context"},
+		"seeder", domain.IssueTableOpts{UseWispsTable: true}))
+	s.Require().NoError(s.depRepo().Insert(s.Ctx(),
+		newDep(target, neighbor, types.DepRelated), "tester", domain.DepInsertOpts{UseWispsTable: true}))
+
+	res, err := s.issueUseCase().DeleteWisp(s.Ctx(), target, "tester")
+	s.Require().NoError(err)
+	s.Equal(1, res.DeletedCount)
+	s.GreaterOrEqual(res.ReferencesUpdated, 1)
+
+	updated, err := s.issueRepo().Get(s.Ctx(), neighbor, domain.IssueTableOpts{UseWispsTable: true})
+	s.Require().NoError(err)
+	s.Contains(updated.Description, "[deleted:"+target+"]")
 }
 
 func (s *testSuite) iucPreviewEmpty() {


### PR DESCRIPTION
## What

Replace ten fresh-project `TestProxiedServerDeleteWisp` scenarios with:

- three typed `domain.IssueUseCase` characterization tests for the semantic matrix; and
- one real proxied CLI journey for the distinct process, routing, JSON, ignored-table, and Dolt-history boundary.

The retained journey creates a real wisp, commits a durable issue row with the same ID, deletes the wisp through the proxied CLI, and proves the typed JSON result, table routing, durable-shadow survival, and unchanged `HEAD`.

## Why

PR Risk proxied-command shard 11 has a stable seven-run median of **452s** (`452, 451, 439, 456, 455, 453, 452`). This test family creates ten independent projects for behavior that the typed domain seam can prove more directly. In the representative timing trace, the family contributed **691.27s of child work** under the four-way scheduler and owned **145.77s of exclusive shard tail**.

This change removes nine project initializations and dozens of subprocess journeys while retaining one representative end-to-end boundary.

## Coverage ownership

| Behavior | Owner after this change |
|---|---|
| Mixed issue/wisp partition and batch mutation | New typed domain mixed-delete contract |
| Wisp auxiliary cleanup and transitive cascade across dependency types | New typed domain cascade contract |
| Wisp text-reference rewriting | New typed domain reference contract |
| Wisp-table routing | Existing domain routing test plus retained proxied journey |
| Dry-run semantics | Existing domain dry-run and output-contract tests |
| Missing-ID error | Existing generic proxied delete/not-found coverage |
| Real proxy/process path, JSON wire, ignored-table mutation, durable-shadow survival, unchanged Dolt `HEAD` | Retained proxied journey |

PR #4674's `issueops` cascade regression and PR #4742's fresh-UOW retry coverage remain intact and are not claimed as replaced here.

## Safety boundaries

- Test-only change: no production or workflow files.
- No shard, skip, timeout, race, fixture-harness, or blanket-parallelism changes.
- Exactly one nonparallel proxied journey remains.
- The lower tests use the existing typed domain seam; no new fake, mock, or production abstraction.

## Verification

- Real opt-in domain run (twice): all new tests explicitly `RUN/PASS`; **7.74–7.92s** package time.
- Real opt-in proxied run (twice): retained test explicitly `RUN/PASS`; **8.51–8.80s** test time.
- `./scripts/test.sh ./cmd/bd ./internal/storage/domain/db` — pass (`cmd/bd` **309.334s**, domain package **4.526s**).
- `make test` — pass; **362.89s** wall, `cmd/bd` **312.848s**, total coverage **40.0%**.
- `golangci-lint run ./cmd/bd ./internal/storage/domain/db` — `0 issues`.
- Active pre-commit hook — pass with the repository's Go 1.26.5 toolchain; the hook launcher's default toolchain-selection defect is tracked separately as `bd-1rh.12`.
- Two independent Sol blocker/major reviews approved frozen diff SHA-256 `723d6f732b31325f595739aadd5eee273664ca164b39b02cb9549bf64a67086e`.

Focused commands:

```bash
BEADS_TEST_ENV_RUN_DOLT=1 ./scripts/test.sh -v \
  -run '^TestDomainDB/TestIssueUseCase_Delete/' \
  ./internal/storage/domain/db

BEADS_TEST_ENV_RUN_DOLT=1 BEADS_TEST_PROXIED_SERVER=1 ./scripts/test.sh -v \
  -run '^TestProxiedServerDeleteWisp$' \
  ./cmd/bd
```

## Hosted acceptance

The measured hosted baseline is **452s whole-job median** and **423s test-step median** across seven successful shard-11 runs. Acceptance is seven successful post-change runs with whole-job median **≤332s**.

The first hosted datapoint is green:

| Metric | Seven-run baseline median | #5312 first run | Observed change |
|---|---:|---:|---:|
| Whole shard job | 452s | 214s | -238s (-52.7%) |
| Test step | 423s | 182s | -241s (-57.0%) |

This is [PR Risk run 30786697585, job 91602120838](https://github.com/gastownhall/beads/actions/runs/30786697585/job/91602120838) on `ubuntu-24.04`. It used the same workflow, shard script, manifest, and seven assigned tests as the baseline; the nearest baseline checkout has the same tree as this PR's base. The full PR suite completed with 84 successes and zero failures.

Acceptance is therefore **1/7**, not a post-change median. The jobs use distinct ephemeral runners and varied regions, so every successful sample—including slow ones—will remain in the result. The 306–326s design forecast was conservative; this PR claims the measured first-run result only.

Local package timings in the verification section are separate validation evidence and are not mixed into this hosted comparison.

Tracks `bd-1rh.11`.
