### PR TITLE
test: collapse proxied Ready2 portfolio (bd-1rh.13)

### DIFF
--- a/cmd/bd/ready_input_test.go
+++ b/cmd/bd/ready_input_test.go
@@ -209,6 +209,9 @@ func TestGatherReadyInputResolvesCapWhereTheDirectBuilderDid(t *testing.T) {
 		}{
 			{"mol_type", []string{"--max-rows", "-1", "--mol-type", "bogus"}, "invalid mol-type"},
 			{"claim_assignee", []string{"--max-rows", "-1", "--claim", "--assignee", "alice"}, "--claim cannot be combined with --assignee"},
+			{"claim_gated", []string{"--max-rows", "-1", "--claim", "--gated"}, "--claim cannot be combined with --gated"},
+			{"claim_mol", []string{"--max-rows", "-1", "--claim", "--mol", "bd-mol"}, "--claim cannot be combined with --mol"},
+			{"claim_explain", []string{"--max-rows", "-1", "--claim", "--explain"}, "--claim cannot be combined with --explain"},
 		}
 		for _, c := range cases {
 			t.Run(c.name, func(t *testing.T) {
@@ -252,6 +255,141 @@ func TestGatherReadyInputResolvesCapWhereTheDirectBuilderDid(t *testing.T) {
 			t.Errorf("no resolver should mean no cap output, got:\n%s", got.stderr)
 		}
 	})
+}
+
+// TestGatherReadyInputMapsReadyPassThroughFlags keeps the CLI parsing boundary
+// covered for filters whose result semantics live at the domain seam. The
+// workapi golden starts from ReadyRequest, so it cannot prove that these flags
+// reached that request and its resulting WorkFilter.
+func TestGatherReadyInputMapsReadyPassThroughFlags(t *testing.T) {
+	tests := []struct {
+		name  string
+		args  []string
+		check func(*testing.T, types.WorkFilter)
+	}{
+		{
+			name: "priority_zero_preserves_explicit_pointer",
+			args: []string{"--priority", "0"},
+			check: func(t *testing.T, filter types.WorkFilter) {
+				t.Helper()
+				if filter.Priority == nil || *filter.Priority != 0 {
+					t.Errorf("filter.Priority = %v, want non-nil pointer to 0", filter.Priority)
+				}
+			},
+		},
+		{
+			name: "assignee",
+			args: []string{"--assignee", "alice"},
+			check: func(t *testing.T, filter types.WorkFilter) {
+				t.Helper()
+				if filter.Assignee == nil || *filter.Assignee != "alice" {
+					t.Errorf("filter.Assignee = %v, want non-nil pointer to alice", filter.Assignee)
+				}
+			},
+		},
+		{
+			name: "unassigned",
+			args: []string{"--unassigned"},
+			check: func(t *testing.T, filter types.WorkFilter) {
+				t.Helper()
+				if !filter.Unassigned {
+					t.Error("filter.Unassigned = false, want true")
+				}
+			},
+		},
+		{
+			name: "type",
+			args: []string{"--type", "bug"},
+			check: func(t *testing.T, filter types.WorkFilter) {
+				t.Helper()
+				if filter.Type != "bug" {
+					t.Errorf("filter.Type = %q, want bug", filter.Type)
+				}
+			},
+		},
+		{
+			name: "parent",
+			args: []string{"--parent", "bd-parent"},
+			check: func(t *testing.T, filter types.WorkFilter) {
+				t.Helper()
+				if filter.ParentID == nil || *filter.ParentID != "bd-parent" {
+					t.Errorf("filter.ParentID = %v, want non-nil pointer to bd-parent", filter.ParentID)
+				}
+			},
+		},
+		{
+			name: "metadata_equality",
+			args: []string{"--metadata-field", "team=platform"},
+			check: func(t *testing.T, filter types.WorkFilter) {
+				t.Helper()
+				if !reflect.DeepEqual(filter.MetadataFields, map[string]string{"team": "platform"}) {
+					t.Errorf("filter.MetadataFields = %#v, want map[team:platform]", filter.MetadataFields)
+				}
+			},
+		},
+		{
+			name: "metadata_key_presence",
+			args: []string{"--has-metadata-key", "team"},
+			check: func(t *testing.T, filter types.WorkFilter) {
+				t.Helper()
+				if filter.HasMetadataKey != "team" {
+					t.Errorf("filter.HasMetadataKey = %q, want team", filter.HasMetadataKey)
+				}
+			},
+		},
+		{
+			name: "include_deferred",
+			args: []string{"--include-deferred"},
+			check: func(t *testing.T, filter types.WorkFilter) {
+				t.Helper()
+				if !filter.IncludeDeferred {
+					t.Error("filter.IncludeDeferred = false, want true")
+				}
+			},
+		},
+		{
+			name: "include_ephemeral",
+			args: []string{"--include-ephemeral"},
+			check: func(t *testing.T, filter types.WorkFilter) {
+				t.Helper()
+				if !filter.IncludeEphemeral {
+					t.Error("filter.IncludeEphemeral = false, want true")
+				}
+			},
+		},
+		{
+			name: "exclude_type_csv",
+			args: []string{"--exclude-type", "bug,epic"},
+			check: func(t *testing.T, filter types.WorkFilter) {
+				t.Helper()
+				want := []types.IssueType{types.TypeBug, types.TypeEpic}
+				if !slices.Equal(filter.ExcludeTypes, want) {
+					t.Errorf("filter.ExcludeTypes = %q, want %q", filter.ExcludeTypes, want)
+				}
+			},
+		},
+		{
+			name: "exclude_type_repeated",
+			args: []string{"--exclude-type", "bug", "--exclude-type", "epic"},
+			check: func(t *testing.T, filter types.WorkFilter) {
+				t.Helper()
+				want := []types.IssueType{types.TypeBug, types.TypeEpic}
+				if !slices.Equal(filter.ExcludeTypes, want) {
+					t.Errorf("filter.ExcludeTypes = %q, want %q", filter.ExcludeTypes, want)
+				}
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := runGatherReadyInput(t, newReadyFlagsCommand(t, tc.args...), nil)
+			if got.err != nil {
+				t.Fatalf("gatherReadyInput(%v): %v", tc.args, got.err)
+			}
+			tc.check(t, got.in.filter)
+		})
+	}
 }
 
 // TestGatherReadyInputUsageErrorsRespectJSON pins the one behavior change in

--- a/cmd/bd/ready_proxied_integration_test.go
+++ b/cmd/bd/ready_proxied_integration_test.go
@@ -594,192 +594,22 @@ func TestProxiedServerReady2(t *testing.T) {
 		}
 	})
 
-	t.Run("empty_state_no_open_issues", func(t *testing.T) {
+	t.Run("empty_state_messages", func(t *testing.T) {
 		t.Parallel()
-		p := newSharedProxiedProject(t, bd, "rdei")
+		p := newSharedProxiedProject(t, bd, "rde")
 		stdout, _ := bdProxiedReadyCapture(t, bd, p)
 		if !strings.Contains(stdout, "No open issues") {
 			t.Errorf("expected 'No open issues', got: %s", stdout)
 		}
-	})
 
-	t.Run("empty_state_no_ready_with_blockers", func(t *testing.T) {
-		t.Parallel()
-		p := newSharedProxiedProject(t, bd, "rdeb")
-		blocker := bdProxiedCreate(t, bd, p.dir, "Self-blocker")
-		bdProxiedCreate(t, bd, p.dir, "Only issue, blocked", "--deps", "blocks:"+blocker.ID)
-		if _, err := bdProxiedRun(t, bd, p.dir, "ready", "--claim", "--json"); err == nil {
-		}
-		if _, err := bdProxiedRun(t, bd, p.dir, "update", blocker.ID, "--claim"); err != nil {
-			t.Fatalf("update --claim blocker: %v", err)
-		}
-		stdout, _ := bdProxiedReadyCapture(t, bd, p, "--label", "no-such-label")
-		if !strings.Contains(stdout, "No ready work found") && !strings.Contains(stdout, "No open issues") {
-			t.Errorf("expected empty-state hint, got: %s", stdout)
-		}
-	})
-
-	t.Run("filter_priority_pass_through", func(t *testing.T) {
-		t.Parallel()
-		p := newSharedProxiedProject(t, bd, "rfp")
-		hi := bdProxiedCreate(t, bd, p.dir, "Hi pri", "-p", "0")
-		lo := bdProxiedCreate(t, bd, p.dir, "Lo pri", "-p", "3")
-		ready := bdProxiedReadyJSON(t, bd, p, "-p", "0")
-		ids := map[string]bool{}
-		for _, r := range ready {
-			ids[r.ID] = true
-		}
-		if !ids[hi.ID] {
-			t.Errorf("expected %s in priority=0 filter result", hi.ID)
-		}
-		if ids[lo.ID] {
-			t.Errorf("did not expect %s in priority=0 result", lo.ID)
-		}
-	})
-
-	t.Run("filter_assignee_pass_through", func(t *testing.T) {
-		t.Parallel()
-		p := newSharedProxiedProject(t, bd, "rfa")
-		mine := bdProxiedCreate(t, bd, p.dir, "Alice work", "--assignee", "alice")
-		bdProxiedCreate(t, bd, p.dir, "Bob work", "--assignee", "bob")
-		ready := bdProxiedReadyJSON(t, bd, p, "--assignee", "alice")
-		ids := map[string]bool{}
-		for _, r := range ready {
-			ids[r.ID] = true
-		}
-		if !ids[mine.ID] {
-			t.Errorf("expected %s for assignee=alice", mine.ID)
-		}
-		for _, r := range ready {
-			if r.Assignee != "alice" {
-				t.Errorf("got non-alice assignee %q for %s", r.Assignee, r.ID)
-			}
-		}
-	})
-
-	t.Run("filter_unassigned_pass_through", func(t *testing.T) {
-		t.Parallel()
-		p := newSharedProxiedProject(t, bd, "rfu")
-		un := bdProxiedCreate(t, bd, p.dir, "Free agent")
-		bdProxiedCreate(t, bd, p.dir, "Taken", "--assignee", "alice")
-		ready := bdProxiedReadyJSON(t, bd, p, "--unassigned")
-		ids := map[string]bool{}
-		for _, r := range ready {
-			ids[r.ID] = true
-		}
-		if !ids[un.ID] {
-			t.Errorf("expected %s in --unassigned result", un.ID)
-		}
-		for _, r := range ready {
-			if r.Assignee != "" {
-				t.Errorf("got assignee %q for %s under --unassigned", r.Assignee, r.ID)
-			}
-		}
-	})
-
-	t.Run("filter_type_pass_through", func(t *testing.T) {
-		t.Parallel()
-		p := newSharedProxiedProject(t, bd, "rft")
-		bug := bdProxiedCreate(t, bd, p.dir, "A bug", "--type", "bug")
-		bdProxiedCreate(t, bd, p.dir, "A task", "--type", "task")
-		ready := bdProxiedReadyJSON(t, bd, p, "--type", "bug")
-		ids := map[string]bool{}
-		for _, r := range ready {
-			ids[r.ID] = true
-		}
-		if !ids[bug.ID] {
-			t.Errorf("expected %s for --type=bug", bug.ID)
-		}
-		for _, r := range ready {
-			if r.IssueType != types.TypeBug {
-				t.Errorf("got type %s for %s under --type=bug", r.IssueType, r.ID)
-			}
-		}
-	})
-
-	t.Run("filter_parent_pass_through", func(t *testing.T) {
-		t.Parallel()
-		p := newSharedProxiedProject(t, bd, "rfpar")
-		epic := bdProxiedCreate(t, bd, p.dir, "Epic", "--type", "epic")
-		child := bdProxiedCreate(t, bd, p.dir, "Inside", "--parent", epic.ID)
-		outside := bdProxiedCreate(t, bd, p.dir, "Outside")
-		ready := bdProxiedReadyJSON(t, bd, p, "--parent", epic.ID)
-		ids := map[string]bool{}
-		for _, r := range ready {
-			ids[r.ID] = true
-		}
-		if !ids[child.ID] {
-			t.Errorf("expected %s under --parent=%s", child.ID, epic.ID)
-		}
-		if ids[outside.ID] {
-			t.Errorf("outside-of-parent issue %s leaked into --parent result", outside.ID)
-		}
-	})
-
-	t.Run("metadata_field_match", func(t *testing.T) {
-		t.Parallel()
-		p := newSharedProxiedProject(t, bd, "rmd1")
-		match := bdProxiedCreate(t, bd, p.dir, "Has team", "--metadata", `{"team":"platform"}`)
-		bdProxiedCreate(t, bd, p.dir, "Other team", "--metadata", `{"team":"frontend"}`)
-		ready := bdProxiedReadyJSON(t, bd, p, "--metadata-field", "team=platform")
-		ids := map[string]bool{}
-		for _, r := range ready {
-			ids[r.ID] = true
-		}
-		if !ids[match.ID] {
-			t.Errorf("expected %s for team=platform filter", match.ID)
-		}
-	})
-
-	t.Run("metadata_has_key", func(t *testing.T) {
-		t.Parallel()
-		p := newSharedProxiedProject(t, bd, "rmd2")
-		withMeta := bdProxiedCreate(t, bd, p.dir, "With meta", "--metadata", `{"team":"x"}`)
-		bdProxiedCreate(t, bd, p.dir, "No meta")
-		ready := bdProxiedReadyJSON(t, bd, p, "--has-metadata-key", "team")
-		ids := map[string]bool{}
-		for _, r := range ready {
-			ids[r.ID] = true
-		}
-		if !ids[withMeta.ID] {
-			t.Errorf("expected %s in --has-metadata-key=team result", withMeta.ID)
-		}
-	})
-
-	t.Run("metadata_field_invalid_key_errors", func(t *testing.T) {
-		t.Parallel()
-		p := newSharedProxiedProject(t, bd, "rmd3")
-		out := bdProxiedReadyFail(t, bd, p, "--metadata-field", "bad$key=x")
-		if !strings.Contains(out, "metadata-field") {
-			t.Errorf("expected validation error about metadata-field, got: %s", out)
-		}
-	})
-
-	t.Run("include_deferred_toggle", func(t *testing.T) {
-		t.Parallel()
-		p := newSharedProxiedProject(t, bd, "rdd")
-		issue := bdProxiedCreate(t, bd, p.dir, "Will defer")
+		blocked := bdProxiedCreate(t, bd, p.dir, "Blocked open issue")
 		db := openProxiedDB(t, p)
-		if _, err := db.ExecContext(context.Background(),
-			"UPDATE issues SET defer_until = DATE_ADD(UTC_TIMESTAMP(), INTERVAL 1 DAY) WHERE id = ?", issue.ID); err != nil {
-			t.Fatalf("plant defer_until: %v", err)
+		if _, err := db.ExecContext(context.Background(), "UPDATE issues SET is_blocked = 1 WHERE id = ?", blocked.ID); err != nil {
+			t.Fatalf("mark issue blocked: %v", err)
 		}
-		ready := bdProxiedReadyJSON(t, bd, p)
-		for _, r := range ready {
-			if r.ID == issue.ID {
-				t.Errorf("future-deferred issue %s should be hidden by default", issue.ID)
-			}
-		}
-		ready2 := bdProxiedReadyJSON(t, bd, p, "--include-deferred")
-		found := false
-		for _, r := range ready2 {
-			if r.ID == issue.ID {
-				found = true
-				break
-			}
-		}
-		if !found {
-			t.Errorf("expected deferred %s under --include-deferred", issue.ID)
+		stdout, _ = bdProxiedReadyCapture(t, bd, p)
+		if !strings.Contains(stdout, "No ready work found") {
+			t.Errorf("expected 'No ready work found', got: %s", stdout)
 		}
 	})
 
@@ -809,104 +639,34 @@ func TestProxiedServerReady2(t *testing.T) {
 		}
 	})
 
-	t.Run("mol_type_validation_rejects_invalid", func(t *testing.T) {
-		t.Parallel()
-		p := newSharedProxiedProject(t, bd, "rmtv")
-		out := bdProxiedReadyFail(t, bd, p, "--mol-type", "garbage")
-		if !strings.Contains(out, "invalid mol-type") {
-			t.Errorf("expected 'invalid mol-type' error, got: %s", out)
-		}
-	})
-
-	// Since bd-ehi both routes share one flag gatherer, and it reports usage
-	// errors the way the direct route always has: as a JSON error object on
-	// stdout when the caller asked for --json. This route used to print
-	// "Error: ..." to stderr for these three, so a script that parses proxied
-	// `bd ready --json` failures sees the change - which is why it is pinned
-	// end to end here as well as at the gatherer
-	// (TestGatherReadyInputUsageErrorsRespectJSON).
-	t.Run("json_usage_errors_are_json_on_stdout", func(t *testing.T) {
-		t.Parallel()
-		p := newSharedProxiedProject(t, bd, "rdjue")
-		cases := []struct {
-			name string
-			args []string
-			want string
-		}{
-			{"sort_policy", []string{"--sort", "bogus"}, "invalid sort policy"},
-			{"mol_type", []string{"--mol-type", "garbage"}, "invalid mol-type"},
-			{"metadata_field", []string{"--metadata-field", "bad$key=x"}, "invalid --metadata-field key"},
-		}
-		for _, c := range cases {
-			t.Run(c.name, func(t *testing.T) {
-				args := append([]string{"ready", "--json"}, c.args...)
-				stdout, stderr, err := bdProxiedRunBuffers(t, bd, p.dir, args...)
-				if err == nil {
-					t.Fatalf("bd ready --json %s should have failed; stdout:\n%s", strings.Join(c.args, " "), stdout)
-				}
-				var payload map[string]any
-				if jsonErr := json.Unmarshal([]byte(strings.TrimSpace(stdout)), &payload); jsonErr != nil {
-					t.Fatalf("stdout is not a JSON error object: %v\nstdout:\n%s\nstderr:\n%s", jsonErr, stdout, stderr)
-				}
-				if data, ok := payload["data"].(map[string]any); ok {
-					payload = data
-				}
-				msg, _ := payload["error"].(string)
-				if !strings.Contains(msg, c.want) {
-					t.Errorf("JSON error = %q, want it to contain %q", msg, c.want)
-				}
-				if strings.Contains(stderr, "Error:") {
-					t.Errorf("under --json the error must not also go to stderr, got:\n%s", stderr)
-				}
-			})
-		}
-	})
-
-	t.Run("claim_combo_guards", func(t *testing.T) {
-		t.Parallel()
-		p := newSharedProxiedProject(t, bd, "rcc")
-		bdProxiedCreate(t, bd, p.dir, "Seed")
-		cases := []struct {
-			name string
-			args []string
-		}{
-			{"claim_gated", []string{"--claim", "--gated"}},
-			{"claim_mol", []string{"--claim", "--mol", "x"}},
-			{"claim_explain", []string{"--claim", "--explain"}},
-			{"claim_assignee", []string{"--claim", "--assignee", "alice"}},
-		}
-		for _, c := range cases {
-			t.Run(c.name, func(t *testing.T) {
-				out := bdProxiedReadyFail(t, bd, p, c.args...)
-				if !strings.Contains(out, "--claim cannot be combined") {
-					t.Errorf("expected '--claim cannot be combined' error, got: %s", out)
-				}
-			})
-		}
-	})
-
-	// be-x42v.4 round-3 follow-up: rejectMaxRowsUnderProxiedServer must not
-	// block `bd ready --claim` under proxied mode. --claim always delivers
-	// exactly one row (same reasoning as the direct-path fix in
-	// issueops/claim.go), so a rig-wide cap sized for bulk reads must not
-	// hard-fail it. Bulk (non-claim) `bd ready` under proxied mode with an
-	// active cap must still reject, same as `bd list` (see
-	// list_proxied_integration_test.go's reject_max_rows_flag/_env).
-	t.Run("claim_succeeds_under_env_max_rows_cap", func(t *testing.T) {
+	t.Run("max_rows_claim_policy_and_transaction", func(t *testing.T) {
 		t.Parallel()
 		p := newSharedProxiedProject(t, bd, "rcmr")
-		// Ready pool (3) exceeds the cap (1) — exactly the scenario a
-		// rig-wide BEADS_MAX_ROWS is meant to guard bulk reads against,
-		// while claim (which only ever returns one row) must still work.
 		for i := 0; i < 3; i++ {
 			bdProxiedCreate(t, bd, p.dir, fmt.Sprintf("Claim under cap %d", i), "--label", "rcmr-claim")
 		}
+
+		out := bdProxiedReadyFail(t, bd, p, "--claim", "--max-rows", "-1")
+		if !strings.Contains(out, "must be non-negative") {
+			t.Errorf("expected --max-rows usage-error rejection, got: %s", out)
+		}
+		out = bdProxiedReadyFail(t, bd, p, "--max-rows", "1")
+		if !strings.Contains(out, "not supported in proxied-server mode") {
+			t.Errorf("expected --max-rows proxied-server rejection for bulk ready, got: %s", out)
+		}
 		stdout, stderr, err := bdProxiedRunBuffersWithEnv(t, bd, p.dir,
-			[]string{"BEADS_MAX_ROWS=1"},
-			"ready", "--claim", "--json", "--label", "rcmr-claim")
+			[]string{"BEADS_MAX_ROWS=1"}, "ready")
+		if err == nil {
+			t.Fatalf("expected BEADS_MAX_ROWS under proxied bulk ready to fail, but it succeeded:\nstdout:\n%s\nstderr:\n%s", stdout, stderr)
+		}
+		if out := stdout + stderr; !strings.Contains(out, "not supported in proxied-server mode") {
+			t.Errorf("expected BEADS_MAX_ROWS proxied-server rejection for bulk ready, got: %s", out)
+		}
+
+		stdout, stderr, err = bdProxiedRunBuffersWithEnv(t, bd, p.dir,
+			[]string{"BEADS_MAX_ROWS=1"}, "ready", "--claim", "--json", "--label", "rcmr-claim")
 		if err != nil {
-			t.Fatalf("bd ready --claim --json under BEADS_MAX_ROWS=1 with a larger ready pool should succeed: %v\nstdout:\n%s\nstderr:\n%s",
-				err, stdout, stderr)
+			t.Fatalf("bd ready --claim --json under BEADS_MAX_ROWS=1 should succeed: %v\nstdout:\n%s\nstderr:\n%s", err, stdout, stderr)
 		}
 		var claimed []types.IssueWithCounts
 		s := strings.TrimSpace(stdout)
@@ -923,81 +683,9 @@ func TestProxiedServerReady2(t *testing.T) {
 		if claimed[0].Status != types.StatusInProgress {
 			t.Errorf("Status = %s, want %s", claimed[0].Status, types.StatusInProgress)
 		}
-	})
-
-	// be-x42v.4 round-4 follow-up (codex P2): the claim-exempt branch above
-	// must still validate --max-rows via resolveMaxRows even though it
-	// ignores the resolved (positive) cap — otherwise a malformed value
-	// like -1 is silently accepted under proxied `ready --claim`, unlike
-	// every other command (direct or proxied).
-	t.Run("claim_rejects_invalid_max_rows_flag", func(t *testing.T) {
-		t.Parallel()
-		p := newSharedProxiedProject(t, bd, "rcim")
-		bdProxiedCreate(t, bd, p.dir, "Claim invalid max-rows seed")
-		out := bdProxiedReadyFail(t, bd, p, "--claim", "--max-rows", "-1")
-		if !strings.Contains(out, "must be non-negative") {
-			t.Errorf("expected --max-rows usage-error rejection, got: %s", out)
-		}
-	})
-
-	t.Run("reject_bulk_ready_under_max_rows_flag", func(t *testing.T) {
-		t.Parallel()
-		p := newSharedProxiedProject(t, bd, "rbmf")
-		bdProxiedCreate(t, bd, p.dir, "Bulk ready seed")
-		out := bdProxiedReadyFail(t, bd, p, "--max-rows", "1")
-		if !strings.Contains(out, "not supported in proxied-server mode") {
-			t.Errorf("expected --max-rows proxied-server rejection for bulk (non-claim) ready, got: %s", out)
-		}
-	})
-
-	t.Run("reject_bulk_ready_under_max_rows_env", func(t *testing.T) {
-		t.Parallel()
-		p := newSharedProxiedProject(t, bd, "rbme")
-		bdProxiedCreate(t, bd, p.dir, "Bulk ready env seed")
-		stdout, stderr, err := bdProxiedRunBuffersWithEnv(t, bd, p.dir,
-			[]string{"BEADS_MAX_ROWS=1"}, "ready")
-		if err == nil {
-			t.Fatalf("expected BEADS_MAX_ROWS under proxied bulk ready to fail, but it succeeded:\nstdout:\n%s\nstderr:\n%s", stdout, stderr)
-		}
-		out := stdout + stderr
-		if !strings.Contains(out, "not supported in proxied-server mode") {
-			t.Errorf("expected BEADS_MAX_ROWS proxied-server rejection for bulk (non-claim) ready, got: %s", out)
-		}
-	})
-
-	t.Run("exclude_type_csv_and_repeated", func(t *testing.T) {
-		t.Parallel()
-		p := newSharedProxiedProject(t, bd, "rxt")
-		task := bdProxiedCreate(t, bd, p.dir, "Task work", "--type", "task")
-		bdProxiedCreate(t, bd, p.dir, "Bug work", "--type", "bug")
-		bdProxiedCreate(t, bd, p.dir, "Epic work", "--type", "epic")
-
-		csv := bdProxiedReadyJSON(t, bd, p, "--exclude-type", "bug,epic")
-		csvIDs := map[string]bool{}
-		for _, r := range csv {
-			csvIDs[r.ID] = true
-		}
-		if !csvIDs[task.ID] {
-			t.Errorf("expected task %s in CSV result", task.ID)
-		}
-		for _, r := range csv {
-			if r.IssueType == types.TypeBug || r.IssueType == types.TypeEpic {
-				t.Errorf("excluded type %s leaked: %s", r.IssueType, r.ID)
-			}
-		}
-
-		rep := bdProxiedReadyJSON(t, bd, p, "--exclude-type", "bug", "--exclude-type", "epic")
-		repIDs := map[string]bool{}
-		for _, r := range rep {
-			repIDs[r.ID] = true
-		}
-		if !repIDs[task.ID] {
-			t.Errorf("expected task %s in repeated-flag result", task.ID)
-		}
-		for _, r := range rep {
-			if r.IssueType == types.TypeBug || r.IssueType == types.TypeEpic {
-				t.Errorf("excluded type %s leaked under repeated flag: %s", r.IssueType, r.ID)
-			}
+		persisted := bdProxiedShow(t, bd, p.dir, claimed[0].ID)
+		if persisted.Status != types.StatusInProgress || persisted.Assignee == "" {
+			t.Errorf("persisted claim = %+v, want in_progress with assignee", persisted)
 		}
 	})
 }

--- a/internal/storage/domain/db/ready_work_test.go
+++ b/internal/storage/domain/db/ready_work_test.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
@@ -18,6 +19,11 @@ func (s *testSuite) TestIssueGetReadyWork() {
 	s.Run("ExcludesDefaultTypes", s.readyExcludesDefaultTypes)
 	s.Run("FilterByPriority", s.readyFilterByPriority)
 	s.Run("FilterByAssignee", s.readyFilterByAssignee)
+	s.Run("FilterByType", s.readyFilterByType)
+	s.Run("FilterByParent", s.readyFilterByParent)
+	s.Run("FilterByMetadataEquality", s.readyFilterByMetadataEquality)
+	s.Run("FilterByMetadataKeyPresence", s.readyFilterByMetadataKeyPresence)
+	s.Run("ExcludesRequestedTypes", s.readyExcludesRequestedTypes)
 	s.Run("Unassigned", s.readyUnassigned)
 	s.Run("ExcludesDeferred", s.readyExcludesDeferred)
 	s.Run("IncludeDeferred", s.readyIncludeDeferred)
@@ -158,6 +164,92 @@ func (s *testSuite) readyFilterByAssignee() {
 	got := issueIDsFrom(out)
 	s.Contains(got, "bd-rdy-as-mine")
 	s.NotContains(got, "bd-rdy-as-theirs")
+}
+
+func (s *testSuite) readyFilterByType() {
+	r := s.issueRepo()
+	bug := newTestIssue("bd-rdy-typ-bug", "bug")
+	bug.IssueType = types.TypeBug
+	s.Require().NoError(r.Insert(s.Ctx(), bug, "tester", domain.InsertIssueOpts{}))
+	task := newTestIssue("bd-rdy-typ-task", "task")
+	s.Require().NoError(r.Insert(s.Ctx(), task, "tester", domain.InsertIssueOpts{}))
+
+	out, err := r.GetReadyWork(s.Ctx(), types.WorkFilter{Type: string(types.TypeBug)})
+	s.Require().NoError(err)
+	got := issueIDsFrom(out)
+	s.Contains(got, bug.ID)
+	s.NotContains(got, task.ID)
+}
+
+func (s *testSuite) readyFilterByParent() {
+	r := s.issueRepo()
+	parent := newTestIssue("bd-rdy-par-root", "parent")
+	parent.IssueType = types.TypeEpic
+	s.Require().NoError(r.Insert(s.Ctx(), parent, "tester", domain.InsertIssueOpts{}))
+	child := newTestIssue("bd-rdy-par-child", "child")
+	s.Require().NoError(r.Insert(s.Ctx(), child, "tester", domain.InsertIssueOpts{}))
+	outside := newTestIssue("bd-rdy-par-outside", "outside")
+	s.Require().NoError(r.Insert(s.Ctx(), outside, "tester", domain.InsertIssueOpts{}))
+	s.Require().NoError(s.depRepo().Insert(s.Ctx(),
+		newDep(child.ID, parent.ID, types.DepParentChild), "tester", domain.DepInsertOpts{}))
+
+	parentID := parent.ID
+	out, err := r.GetReadyWork(s.Ctx(), types.WorkFilter{ParentID: &parentID})
+	s.Require().NoError(err)
+	got := issueIDsFrom(out)
+	s.Contains(got, child.ID)
+	s.NotContains(got, outside.ID)
+}
+
+func (s *testSuite) readyFilterByMetadataEquality() {
+	r := s.issueRepo()
+	match := newTestIssue("bd-rdy-meta-match", "matches metadata")
+	match.Metadata = json.RawMessage(`{"team":"platform"}`)
+	s.Require().NoError(r.Insert(s.Ctx(), match, "tester", domain.InsertIssueOpts{}))
+	other := newTestIssue("bd-rdy-meta-other", "other metadata")
+	other.Metadata = json.RawMessage(`{"team":"frontend"}`)
+	s.Require().NoError(r.Insert(s.Ctx(), other, "tester", domain.InsertIssueOpts{}))
+
+	out, err := r.GetReadyWork(s.Ctx(), types.WorkFilter{MetadataFields: map[string]string{"team": "platform"}})
+	s.Require().NoError(err)
+	got := issueIDsFrom(out)
+	s.Contains(got, match.ID)
+	s.NotContains(got, other.ID)
+}
+
+func (s *testSuite) readyFilterByMetadataKeyPresence() {
+	r := s.issueRepo()
+	withKey := newTestIssue("bd-rdy-metakey-yes", "has metadata key")
+	withKey.Metadata = json.RawMessage(`{"team":"platform"}`)
+	s.Require().NoError(r.Insert(s.Ctx(), withKey, "tester", domain.InsertIssueOpts{}))
+	withoutKey := newTestIssue("bd-rdy-metakey-no", "missing metadata key")
+	withoutKey.Metadata = json.RawMessage(`{"area":"cli"}`)
+	s.Require().NoError(r.Insert(s.Ctx(), withoutKey, "tester", domain.InsertIssueOpts{}))
+
+	out, err := r.GetReadyWork(s.Ctx(), types.WorkFilter{HasMetadataKey: "team"})
+	s.Require().NoError(err)
+	got := issueIDsFrom(out)
+	s.Contains(got, withKey.ID)
+	s.NotContains(got, withoutKey.ID)
+}
+
+func (s *testSuite) readyExcludesRequestedTypes() {
+	r := s.issueRepo()
+	task := newTestIssue("bd-rdy-excl-task", "task")
+	s.Require().NoError(r.Insert(s.Ctx(), task, "tester", domain.InsertIssueOpts{}))
+	bug := newTestIssue("bd-rdy-excl-bug", "bug")
+	bug.IssueType = types.TypeBug
+	s.Require().NoError(r.Insert(s.Ctx(), bug, "tester", domain.InsertIssueOpts{}))
+	epic := newTestIssue("bd-rdy-excl-epic", "epic")
+	epic.IssueType = types.TypeEpic
+	s.Require().NoError(r.Insert(s.Ctx(), epic, "tester", domain.InsertIssueOpts{}))
+
+	out, err := r.GetReadyWork(s.Ctx(), types.WorkFilter{ExcludeTypes: []types.IssueType{types.TypeBug, types.TypeEpic}})
+	s.Require().NoError(err)
+	got := issueIDsFrom(out)
+	s.Contains(got, task.ID)
+	s.NotContains(got, bug.ID)
+	s.NotContains(got, epic.ID)
 }
 
 func (s *testSuite) readyUnassigned() {


### PR DESCRIPTION
## What

Reduce `TestProxiedServerReady2` from 22 fresh proxied projects to five representative real-boundary projects, while moving the removed matrix to:

- typed `WorkFilter` result contracts at the domain repository seam; and
- a cheap Cobra-to-`gatherReadyInput` mapping contract for the actual CLI flags.

The five retained projects cover gated JSON, molecule text/JSON, both human empty states, durable+wisp routing, and the combined max-row/transactional-claim boundary.

## Why

PR Risk proxied-command shard 6 has a stable seven-run whole-job median of **402s** (`406, 404, 416, 394, 398, 393, 402`). `TestProxiedServerReady2` spans 187–311s across those runs (median **298s**) and creates 22 independent projects for many behaviors that lower typed seams can prove more directly.

The removed cases account for about **595 runner-slot-seconds**, or roughly **149s of saturated four-way shard capacity**. In run `30783099201`, Ready2 held scheduler capacity for more than four minutes after the other ordinary top-level families finished, so this is exclusive-tail evidence rather than merely summed child time.

## Coverage ownership

| Behavior | Owner after this change |
|---|---|
| Type, parent, metadata equality/key, and excluded-type result semantics | New typed domain `WorkFilter` contracts |
| Priority zero, assignee, unassigned, type, parent, metadata, deferred, ephemeral, and exclude-type flag mapping | New Cobra-to-`gatherReadyInput` table |
| Invalid sort/molecule/metadata JSON error placement | Existing `TestGatherReadyInputUsageErrorsRespectJSON` |
| Claim combination guards | Existing cheap guard table, extended for gated/molecule/explain |
| Priority, assignee, unassigned, blocking, deferred, ephemeral, labels, limits, and sorting semantics | Existing typed domain tests |
| Human empty-state rendering | Retained real proxied project |
| Gated and molecule output modes | Retained real proxied projects |
| Mixed durable/wisp proxy routing | Retained include-ephemeral project |
| Proxied max-row policy and persisted transactional claim | Retained combined project |
| Concurrency, retry, and metadata-index behavior | Existing untouched regressions |

PR #5293's ready-role contracts, PR #4742's fresh-UOW retry coverage, and PR #4289's metadata-index coverage remain intact and are not claimed as replaced.

## Safety boundaries

- Test-only change in exactly three files.
- No production, workflow, shard-manifest, documentation, skip, timeout, race, or fixture-harness changes.
- Exactly five real projects remain in `TestProxiedServerReady2`.
- `TestProxiedServerReady`, `TestProxiedServerReadyConcurrent`, and `TestProxiedServerReadyClaimConcurrent` are untouched.
- No new fake, mock, or production abstraction.

## Verification

- Real opt-in domain selector: all five new cases explicitly `RUN/PASS`; `TestIssueGetReadyWork` **1.54s**, package **13.371s**.
- Cobra/input selector: all mapping and claim-guard cases explicitly `RUN/PASS`; package **4.890s**.
- Real opt-in proxied selector: all five retained projects explicitly `RUN/PASS`; package **26.542s**.
- `./scripts/test.sh ./cmd/bd ./internal/storage/domain/db` — pass (`cmd/bd` **312.903s**, domain **4.202s**, **357.51s** wall).
- `make test` — pass; **364.72s** wall, `cmd/bd` **313.895s**, total coverage **40.1%**.
- `golangci-lint run ./cmd/bd ./internal/storage/domain/db` — `0 issues`.
- Active pre-commit hook — pass with the repository's Go 1.26.5 toolchain; the default launcher defect remains tracked separately as `bd-1rh.12`.
- Two independent Sol blocker/major reviews approved frozen diff SHA-256 `7f519a94a8de878372ddc713275dd2c5393b62fcad41a6c75f8d5ddb5e17c885`. The first review caught the missing CLI flag-mapping owner; the mapping contract above closed it before final approval.

Focused commands:

```bash
BEADS_TEST_ENV_RUN_DOLT=1 ./scripts/test.sh -v \
  -run '^TestDomainDB/TestIssueGetReadyWork/' \
  ./internal/storage/domain/db

./scripts/test.sh -v -run '^TestGatherReadyInput' ./cmd/bd

BEADS_TEST_ENV_RUN_DOLT=1 BEADS_TEST_PROXIED_SERVER=1 ./scripts/test.sh -v \
  -run '^TestProxiedServerReady2$' \
  ./cmd/bd
```

## Hosted result

All seven successful Ubuntu PR Risk shard-6 samples were retained:

| Sample | Whole job | Test step |
|---:|---:|---:|
| 1 | 153s | 129s |
| 2 | 144s | 106s |
| 3 | 149s | 129s |
| 4 | 168s | 133s |
| 5 | 178s | 144s |
| 6 | 155s | 129s |
| 7 | 152s | 122s |

The whole-job median is **153s**, versus the **402s** seven-run baseline:
**249s faster at the median (61.9%)**. The test-step median is **129s**. Every
sample is below the predeclared **≤280s** acceptance threshold; no slow result
was discarded. The full hosted PR matrix is CLEAN with 84 successes, three
intentional skips, and zero failures.

Tracks `bd-1rh.13`.