### PR TITLE
docs(lint): align contributor guidance with CI (saa-90w)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -29,7 +29,7 @@
 - Never create test issues in production DB (use temporary DB)
 
 ### Code Style
-- Run `golangci-lint run ./...` before committing
+- Run `make ci-pr-lint` before committing changes to Go or lint-controlled files
 - Follow existing patterns in `cmd/bd/` for new commands
 - Add `--json` flag to all commands for programmatic use
 - Update docs when changing behavior

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,7 +127,7 @@ plane"), you MUST complete ALL steps below. Work is NOT complete until
 
 1. **File issues for remaining work** - Create issues for anything that needs follow-up
 2. **Run quality gates** (if code changed):
-   - `golangci-lint run ./...` (or `pre-commit run --all-files` if pre-commit is installed)
+   - `make ci-pr-lint` (required zero-finding formatting and lint wrapper)
    - `make test` (and `make test-icu-path` only if you intentionally need the ICU regex path)
    - File a P0 issue if quality gates are broken
 3. **Update issue status** - Close finished work, update in-progress items

--- a/AGENT_INSTRUCTIONS.md
+++ b/AGENT_INSTRUCTIONS.md
@@ -9,7 +9,8 @@ This document contains detailed operational instructions for AI agents working o
 ### Code Standards
 
 - **Go version**: see `go.mod` for the required version (currently 1.26+)
-- **Linting**: `golangci-lint run ./...` (baseline warnings documented in [engdocs/LINTING.md](engdocs/LINTING.md))
+- **Linting**: `make ci-pr-lint` must pass with zero issues; see
+  [engdocs/LINTING.md](engdocs/LINTING.md)
 - **Testing**: All new features need tests; use [engdocs/TESTING.md](engdocs/TESTING.md) for command selection, test design, and PR readiness.
 - **Documentation**: Update relevant .md files
 
@@ -83,8 +84,8 @@ test runs if `du -sh /tmp/beads-* /tmp/bd-*` shows accumulation. See bd-3q2u.
 ### Before Committing
 
 1. **Run tests**: follow [engdocs/TESTING.md](engdocs/TESTING.md).
-2. **Run linter when its code surface changed**: `golangci-lint run ./...`
-   (ignore baseline warnings)
+2. **Run the required lint contract when its code surface changed**:
+   `make ci-pr-lint`
 3. **Update docs**: If you changed behavior, update README.md or other docs
 4. **Commit**: With git hooks installed (`bd hooks install`), Dolt changes are auto-committed
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ Thank you for your interest in contributing to bd! This document provides guidel
 - Go (see `go.mod` for the required version; currently 1.26+)
 - Git
 - A C compiler (CGO is required for the embedded Dolt database)
-- (Optional) golangci-lint for local linting
+- golangci-lint v2.10.1 for the required local lint gate
 - ICU headers are **not required** for building -- see [engdocs/ICU-POLICY.md](engdocs/ICU-POLICY.md)
 
 ### Getting Started
@@ -61,21 +61,23 @@ We follow standard Go conventions:
 
 ### Linting
 
-We use golangci-lint for code quality checks:
+Use the same pinned golangci-lint version and repository-owned wrapper as CI:
 
 ```bash
-# Install golangci-lint
-brew install golangci-lint  # macOS
-# or
-go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+# Install the version pinned by CI
+go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.10.1
 
-# Run linter
-golangci-lint run ./...
+# Run the required formatting and lint contract
+make ci-pr-lint
 ```
 
-**Note**: The linter currently reports ~100 warnings. These are documented false positives and idiomatic Go patterns (deferred cleanup, Cobra interface requirements, etc.). See [engdocs/LINTING.md](engdocs/LINTING.md) for details. When contributing, focus on avoiding *new* issues rather than the baseline warnings.
+`make ci-pr-lint` must pass with zero issues. It checks formatting, lints the
+repository's normal `gms_pure_go` build, and cross-lints Windows-only non-CGO
+code. Accepted intentional patterns are encoded narrowly in `.golangci.yml`;
+do not ignore a failing baseline. See [engdocs/LINTING.md](engdocs/LINTING.md)
+for the full policy.
 
-CI will automatically run linting on all pull requests.
+CI runs the same required wrapper on all pull requests.
 
 ## Making Changes
 

--- a/engdocs/CI_CLEANUP_PLAN.md
+++ b/engdocs/CI_CLEANUP_PLAN.md
@@ -1,10 +1,10 @@
 # CI Cleanup Plan
 
-Last reviewed: 2026-05-29
+Last reviewed: 2026-08-02
 
 Freshness source: `engdocs/CI_TEST_SURFACE_AUDIT.md`, `.github/workflows/*.yml`,
-`.buildflags`, `.golangci.yml`, package test manifests, and maintainer decision
-review on 2026-05-28.
+`.buildflags`, `.golangci.yml`, `scripts/ci/pr-lint.sh`, `Makefile`, package test
+manifests, and maintainer decision review.
 
 This document records the agreed target shape for CI cleanup. It is the policy
 and roadmap layer; the current inventory remains in
@@ -163,7 +163,10 @@ Additional rules:
 easy to identify and rerun. It includes:
 
 - `make fmt-check`.
-- `golangci-lint run --timeout=5m --build-tags=gms_pure_go ./...`.
+- A zero-finding golangci-lint pass using `.golangci.yml`, readonly module
+  downloads, a five-minute timeout, and the `gms_pure_go` build tag.
+- A second non-CGO Windows cross-lint pass when the native target does not
+  already cover that build tuple.
 
 Known false positives must be handled in `.golangci.yml` or with targeted
 `//nolint` comments. CI should not use a tolerated failing lint baseline.

--- a/engdocs/DOC_INVENTORY.md
+++ b/engdocs/DOC_INVENTORY.md
@@ -34,9 +34,9 @@ freshness source.
 | `reference/json-schema.md` | `Last reviewed:` marker tied to `cmd/bd/output.go`, `cmd/bd/errors.go`, and protocol tests. (Mintlify port: was `JSON_SCHEMA.md`.) |
 | `recovery/init-safety.md` | `Last reviewed:` marker tied to `cmd/bd/init*.go` safety code and tests. (Mintlify port: was `RECOVERY.md`.) |
 | `ERROR_HANDLING.md` | `Last reviewed:` marker tied to current command error exits and JSON error helpers. |
-| `LINTING.md` | `Last reviewed:` marker tied to `.golangci.yml` and current lint output. |
+| `LINTING.md` | `Last reviewed:` marker tied to `.golangci.yml`, `scripts/ci/pr-lint.sh`, the `Makefile` wrapper, and CI workflow wiring. |
 | `SERVE_RUNBOOK.md` | `Last reviewed:` marker tied to the operating-envelope constants in `internal/httpapi/server.go` and the log fields in its `event`/`request` emitters. |
-| `CI_CLEANUP_PLAN.md` | `Last reviewed:` marker tied to CI audit, workflow files, package manifests, and maintainer decision review. |
+| `CI_CLEANUP_PLAN.md` | `Last reviewed:` marker tied to the CI audit, workflow files, wrapper scripts, `Makefile`, package manifests, and maintainer decision review. |
 | `design/otel/otel-data-model.md` | `Last reviewed:` marker tied to telemetry, Dolt storage, hooks, and AI call sites. |
 
 Follow-up automation should replace marker-only checks with generated or
@@ -91,7 +91,7 @@ Follow-up automation should replace marker-only checks with generated or
 | `INTERNALS.md` | Keep | Internal architecture/runtime deep dive. |
 | `JSON_SCHEMA.md` | Keep with freshness | JSON contract; marker tied to schema constant and tests. |
 | `LABELS.md` | Keep | User-facing label philosophy plus examples; generated CLI handles command reference. |
-| `LINTING.md` | Revise with freshness | Stale fixed-count wording removed; marker tied to current lint output. |
+| `LINTING.md` | Revise with freshness | Zero-issue wrapper contract and CI pin reviewed; marker tied to lint configuration, wrapper, and workflow wiring. |
 | `messaging.md` | Keep | Design doc for messaging issue types. |
 | `METADATA.md` | Keep | Behaviour doc for metadata field semantics. |
 | `MOLECULES.md` | Keep | User-facing workflow concept doc. |

--- a/engdocs/LINTING.md
+++ b/engdocs/LINTING.md
@@ -1,31 +1,31 @@
 # Linting Policy
 
-Last reviewed: 2026-05-29
+Last reviewed: 2026-08-02
 
-Freshness source: `.golangci.yml`, `.github/workflows/pr.yml`,
-`.github/workflows/main.yml`, and
-`golangci-lint run --timeout=5m --build-tags=gms_pure_go ./...` returning zero
-issues.
+Freshness source: `.golangci.yml`, `scripts/ci/pr-lint.sh`, `Makefile`,
+`.github/workflows/pr.yml`, and `.github/workflows/main.yml`.
 
 This document explains the required Go lint gate for this codebase.
 
 ## Current Status
 
-Lint is a required CI gate. The PR and main workflows run `golangci-lint` with
-the repository configuration and `--build-tags=gms_pure_go`; it is expected to
-pass with zero issues.
+Lint is a required CI gate. The PR and main workflows install the pinned
+golangci-lint v2.10.1 release and invoke the repository-owned `ci-pr-lint`
+wrapper, which must pass with zero issues.
 
-Run the same check locally with:
-
-```bash
-golangci-lint run --timeout=5m --build-tags=gms_pure_go ./...
-```
-
-Formatting is a separate required gate:
+Run the same required contract locally with:
 
 ```bash
-make fmt-check
+make ci-pr-lint
 ```
+
+The wrapper runs:
+
+- `make fmt-check`;
+- golangci-lint with `.golangci.yml`, readonly module downloads, a five-minute
+  timeout, and the `gms_pure_go` build tag; and
+- a second non-CGO Windows cross-lint pass when the native host does not already
+  cover that target.
 
 ## Policy
 
@@ -45,18 +45,13 @@ test-fixture file reads, and documented security false positives.
 
 ## CI Cleanup Decision
 
-`pr-lint` should stay separate from `pr-policy` and `pr-core` so failures are
-easy to identify and rerun. It should include:
-
-- `make fmt-check`
-- `golangci-lint run --timeout=5m --build-tags=gms_pure_go ./...`
+`pr-lint` stays separate from `pr-policy` and `pr-core` so failures are easy to
+identify and rerun. Its repository-owned wrapper is
+`scripts/ci/pr-lint.sh`, exposed as `make ci-pr-lint`.
 
 See [`CI_CLEANUP_PLAN.md`](CI_CLEANUP_PLAN.md) for the full CI tier policy.
 
 ## Future Work
 
-- Pin the `golangci-lint` version in CI instead of using `version: latest`.
-- Move the final CI shape behind a repository-owned `scripts/ci/pr-lint.sh`
-  wrapper.
 - Periodically audit `.golangci.yml` exclusions and remove entries that are no
   longer needed.

--- a/examples/formulas/gh-issue-to-pr.formula.toml
+++ b/examples/formulas/gh-issue-to-pr.formula.toml
@@ -30,7 +30,8 @@
 #   - Git configured with remotes for upstream and (if fork) push target
 #   - `bd` (beads) installed with molecule/wisp support
 #   - `council` installed (or rubber-duck agent available as fallback)
-#   - `make`, `golangci-lint` available for quality gates
+#   - The target repository's documented quality-gate tools are available
+#     (`make` and the CI-pinned `golangci-lint` for Beads)
 #   - `make test` may take 3-5 minutes on a full run
 #
 # Pager safety (CRITICAL for non-interactive execution):
@@ -468,11 +469,12 @@ ALL THREE quality gates are MANDATORY — do not skip any without explicit justi
    ```
    make test
    ```
-2. Run the linter:
+2. Run the required lint gate. For Beads:
    ```
-   golangci-lint run ./...
+   make ci-pr-lint
    ```
-   (Ignore baseline warnings documented in engdocs/LINTING.md — focus on NEW issues)
+   The wrapper must pass with zero issues. For a non-Beads repository, use its
+   documented required lint gate instead and require a clean pass.
 3. Build the project:
    ```
    make build
@@ -504,7 +506,7 @@ CGO_ENABLED=1 go test -tags gms_pure_go ./cmd/bd/...
 ```
 
 If you need to abort after this step, clean up the worktree first (see worktree-setup)."""
-acceptance = "make test passes (or failures documented as pre-existing/flaky), golangci-lint clean (no new warnings), make build succeeds"
+acceptance = "make test passes (or failures documented as pre-existing/flaky), required lint gate passes with zero issues (make ci-pr-lint for Beads), make build succeeds"
 
 [[steps]]
 id = "council-review"
@@ -632,7 +634,7 @@ WORKING DIRECTORY: This step runs in the worktree.
 
    ## Testing
    - All tests pass (make test)
-   - Linter clean (golangci-lint)
+   - Required lint gate passes with zero issues (make ci-pr-lint for Beads)
    - Build succeeds (make build)
    <If any flaky/pre-existing failures were noted, document them here>
 

--- a/examples/formulas/gh-pr-review.formula.toml
+++ b/examples/formulas/gh-pr-review.formula.toml
@@ -33,7 +33,8 @@
 #     contents:write, pull_requests:write)
 #   - Git configured with remotes for upstream and (if fork) push target
 #   - `bd` (beads) installed with molecule/wisp support
-#   - `make`, `golangci-lint` available for quality gates (fix-merge path)
+#   - The target repository's documented quality-gate tools are available
+#     (`make` and the CI-pinned `golangci-lint` for Beads' fix-merge path)
 #
 # Pager safety (CRITICAL for non-interactive execution):
 #   - ALL `gh` commands MUST use: GH_PAGER=cat gh ...
@@ -359,11 +360,14 @@ Based on the classification, fix the identified blockers:
 - Keep changes minimal — fix the blocker, don't refactor
 
 ### Run quality gates (on the clean-base transplant)
+Use the target repository's documented required gates. For Beads:
 ```
 make test
-golangci-lint run ./...
+make ci-pr-lint
 make build
 ```
+The Beads lint wrapper must pass with zero issues. For a non-Beads repository,
+use its documented lint gate instead and require a clean pass.
 
 ### Commit with attribution
 ```

--- a/scripts/check-doc-freshness.sh
+++ b/scripts/check-doc-freshness.sh
@@ -25,7 +25,8 @@ DOCS=(
     "docs/reference/json-schema.md|cmd/bd/output.go;cmd/bd/errors.go;cmd/bd/protocol/json_contract_test.go"
     "docs/recovery/init-safety.md|cmd/bd/init.go;cmd/bd/init_safety.go;cmd/bd/init_safety_test.go"
     "engdocs/ERROR_HANDLING.md|cmd/bd/*.go;cmd/bd/errors.go"
-    "engdocs/LINTING.md|.golangci.yml"
+    "engdocs/LINTING.md|.golangci.yml;scripts/ci/pr-lint.sh;Makefile;.github/workflows/pr.yml;.github/workflows/main.yml"
+    "engdocs/CI_CLEANUP_PLAN.md|engdocs/CI_TEST_SURFACE_AUDIT.md;.github/workflows/*.yml;.buildflags;.golangci.yml;scripts/ci/pr-lint.sh;Makefile"
     "engdocs/design/otel/otel-data-model.md|internal/telemetry/;internal/storage/dolt/store.go;internal/compact/haiku.go;cmd/bd/find_duplicates.go;internal/hooks/"
 )
 

--- a/scripts/check_doc_freshness_test.go
+++ b/scripts/check_doc_freshness_test.go
@@ -22,7 +22,8 @@ var freshnessDocuments = []struct {
 	{"docs/reference/json-schema.md", []string{"cmd/bd/output.go", "cmd/bd/errors.go", "cmd/bd/protocol/json_contract_test.go"}},
 	{"docs/recovery/init-safety.md", []string{"cmd/bd/init.go", "cmd/bd/init_safety.go", "cmd/bd/init_safety_test.go"}},
 	{"engdocs/ERROR_HANDLING.md", []string{"cmd/bd/*.go", "cmd/bd/errors.go"}},
-	{"engdocs/LINTING.md", []string{".golangci.yml"}},
+	{"engdocs/LINTING.md", []string{".golangci.yml", "scripts/ci/pr-lint.sh", "Makefile", ".github/workflows/pr.yml", ".github/workflows/main.yml"}},
+	{"engdocs/CI_CLEANUP_PLAN.md", []string{"engdocs/CI_TEST_SURFACE_AUDIT.md", ".github/workflows/*.yml", ".buildflags", ".golangci.yml", "scripts/ci/pr-lint.sh", "Makefile"}},
 	{"engdocs/design/otel/otel-data-model.md", []string{"internal/telemetry/", "internal/storage/dolt/store.go", "internal/compact/haiku.go", "cmd/bd/find_duplicates.go", "internal/hooks/"}},
 }
 


### PR DESCRIPTION
## What

Align the active contributor, agent, maintainer, and shipped-formula lint guidance with the repository-owned `make ci-pr-lint` contract.

This change:

- removes the obsolete tolerated-warning baseline and raw Beads-repository lint advice from contributor-facing documentation and formulas;
- leaves the lower-level `bd preflight` checklist and `bd preflight --check` runtime contract to #5300;
- documents the CI-pinned golangci-lint v2.10.1 installation path and zero-finding policy;
- describes the formatting, normal `gms_pure_go`, and Windows non-CGO cross-lint passes owned by the wrapper;
- keeps non-Beads formula workflows routed to each target repository's documented lint gate; and
- expands documentation freshness ownership to the wrapper, Make target, configuration, and workflow wiring.

## Why

Fixes #5299.

The old guidance could send contributors through a materially weaker command than required CI. The separate `bd preflight` checklist and `bd preflight --check` runtime still own a lower-level lint path; #5300 tracks their generic-project and cross-platform process contract rather than mixing that behavior change into this guidance patch.

## Verification

- `scripts/check-doc-freshness.sh` with deterministic date: pass
- integration `TestDocFreshness` suite: pass
- `go test -tags=gms_pure_go -count=1 ./test/docsync`: pass
- both edited formula TOMLs parsed exactly and `./internal/formula` tests passed
- exact-head direct normal and Windows non-CGO golangci-lint passes: zero issues
- `git diff --check` and stale-guidance searches: pass

An earlier exact candidate with the same stable patch ID passed the full wrapper after cache population (1s formatting, 5s normal lint, 16s Windows cross-lint). On the refreshed LF-clean native-Windows lane, the wrapper layer is independently blocked by the recursive-Make defect in #5302; the repository-wide EOL policy gap remains separately scoped to #5301. Do not merge unless the hosted `PR Lint` job passes at the published head.

_codex-gpt-5-unknown-reasoning on behalf of Ewen Cuthiell_
