### PR TITLE
test: cut proxied Create projects from 20 to 2 (bd-1rh.14)

### DIFF
--- a/cmd/bd/create_deps_test.go
+++ b/cmd/bd/create_deps_test.go
@@ -13,10 +13,11 @@ import (
 
 func TestParseDepSpecs(t *testing.T) {
 	tests := []struct {
-		name    string
-		in      []string
-		want    []domain.DependencySpec
-		wantErr bool
+		name              string
+		in                []string
+		want              []domain.DependencySpec
+		wantErr           bool
+		wantErrSubstrings []string
 	}{
 		{
 			name: "empty input",
@@ -80,9 +81,10 @@ func TestParseDepSpecs(t *testing.T) {
 			},
 		},
 		{
-			name:    "unknown type rejected",
-			in:      []string{"nonsense:bd-1"},
-			wantErr: true,
+			name:              "unknown type rejected",
+			in:                []string{"nonsense:bd-1"},
+			wantErr:           true,
+			wantErrSubstrings: []string{"unknown dependency type", "blocked-by", "depends-on"},
 		},
 		{
 			name:    "empty type rejected",
@@ -125,6 +127,11 @@ func TestParseDepSpecs(t *testing.T) {
 			if tt.wantErr {
 				if err == nil {
 					t.Fatalf("parseDepSpecs(%v) = %v, want error", tt.in, got)
+				}
+				for _, want := range tt.wantErrSubstrings {
+					if !strings.Contains(err.Error(), want) {
+						t.Errorf("parseDepSpecs(%v) error = %q, want to contain %q", tt.in, err, want)
+					}
 				}
 				return
 			}

--- a/cmd/bd/create_input_test.go
+++ b/cmd/bd/create_input_test.go
@@ -3,10 +3,13 @@ package main
 import (
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 func TestCreateCommandRejectsExtraPositionalArguments(t *testing.T) {
@@ -54,4 +57,153 @@ func TestGatherCreateInputRejectsEmptyBodyFile(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected create input gathering to reject an empty body file")
 	}
+}
+
+func TestGatherCreateInputMapsSingleIssueFlags(t *testing.T) {
+	cmd := newCreateFlagsCommand(t,
+		"--title", "Title from flag",
+		"--description", "Description",
+		"--design", "Design",
+		"--acceptance", "Acceptance",
+		"--notes", "Notes",
+		"--append-notes", "Append notes",
+		"--spec-id", "spec-1",
+		"--priority", "P1",
+		"--type", "event",
+		"--status", "blocked",
+		"--assignee", "alice",
+		"--external-ref", "gh-9",
+		"--labels", "team-a,shared",
+		"--label", "alias",
+		"--deps", "blocks:bd-target,related:bd-other",
+		"--waits-for", "bd-spawner",
+		"--waits-for-gate", "any-children",
+		"--silent",
+		"--dry-run",
+		"--force",
+		"--validate",
+		"--ephemeral",
+		"--mol-type", "work",
+		"--wisp-type", "heartbeat",
+		"--event-category", "patrol.muted",
+		"--event-actor", "agent:alice",
+		"--event-target", "bd-target",
+		"--event-payload", `{"reason":"test"}`,
+		"--due", "+48h",
+		"--defer", "+24h",
+		"--metadata", `{"key":"value"}`,
+		"--estimate", "90",
+		"--repo", "https://example.test/issues",
+	)
+
+	beforeGather := time.Now()
+	in, err := gatherCreateInput(cmd, nil)
+	afterGather := time.Now()
+	if err != nil {
+		t.Fatalf("gatherCreateInput: %v", err)
+	}
+
+	if in.title != "Title from flag" || in.description != "Description" || in.design != "Design" || in.acceptanceCriteria != "Acceptance" {
+		t.Errorf("content fields = %#v", in)
+	}
+	if in.notes != "Notes" || in.appendNotes != "Append notes" || in.specID != "spec-1" {
+		t.Errorf("planning fields = %#v", in)
+	}
+	if in.priority != 1 || in.issueType != "event" || in.status != "blocked" || in.assignee != "alice" || in.externalRef != "gh-9" {
+		t.Errorf("issue fields = %#v", in)
+	}
+	if got, want := strings.Join(in.labels, ","), "team-a,shared,alias"; got != want {
+		t.Errorf("labels = %q, want %q", got, want)
+	}
+	if got, want := strings.Join(in.deps, ","), "blocks:bd-target,related:bd-other"; got != want {
+		t.Errorf("deps = %q, want %q", got, want)
+	}
+	if in.waitsFor != "bd-spawner" || in.waitsForGate != "any-children" || !in.waitsForGateSet {
+		t.Errorf("waits-for fields = %#v", in)
+	}
+	if !in.silent || !in.dryRun || !in.force || !in.validate || !in.ephemeral || in.noHistory {
+		t.Errorf("boolean fields = %#v", in)
+	}
+	if in.molType != "work" || in.wispType != "heartbeat" {
+		t.Errorf("wisp fields = %#v", in)
+	}
+	if in.eventCategory != "patrol.muted" || in.eventActor != "agent:alice" || in.eventTarget != "bd-target" || in.eventPayload != `{"reason":"test"}` {
+		t.Errorf("event fields = %#v", in)
+	}
+	if in.dueAt == nil || in.deferUntil == nil {
+		t.Errorf("due/defer fields = %#v", in)
+	} else {
+		if in.dueAt.Before(beforeGather.Add(48*time.Hour)) || in.dueAt.After(afterGather.Add(48*time.Hour)) {
+			t.Errorf("DueAt = %v, want between %v and %v", in.dueAt, beforeGather.Add(48*time.Hour), afterGather.Add(48*time.Hour))
+		}
+		if in.deferUntil.Before(beforeGather.Add(24*time.Hour)) || in.deferUntil.After(afterGather.Add(24*time.Hour)) {
+			t.Errorf("DeferUntil = %v, want between %v and %v", in.deferUntil, beforeGather.Add(24*time.Hour), afterGather.Add(24*time.Hour))
+		}
+	}
+	if string(in.metadata) != `{"key":"value"}` || !in.metadataSet {
+		t.Errorf("metadata = %q, set = %t", in.metadata, in.metadataSet)
+	}
+	if in.estimatedMinutes == nil || *in.estimatedMinutes != 90 {
+		t.Errorf("estimate = %v", in.estimatedMinutes)
+	}
+	if in.repoOverride != "https://example.test/issues" || !in.repoOverrideSet {
+		t.Errorf("repo override = %q, set = %t", in.repoOverride, in.repoOverrideSet)
+	}
+
+	t.Run("explicit ID", func(t *testing.T) {
+		in, err := gatherCreateInput(newCreateFlagsCommand(t, "--id", "bd-explicit"), []string{"Explicit ID"})
+		if err != nil {
+			t.Fatalf("gatherCreateInput: %v", err)
+		}
+		if in.explicitID != "bd-explicit" || in.parentID != "" {
+			t.Errorf("ID fields = %#v", in)
+		}
+	})
+
+	t.Run("parent and label inheritance controls", func(t *testing.T) {
+		in, err := gatherCreateInput(newCreateFlagsCommand(t,
+			"--parent", "bd-parent",
+			"--no-inherit-labels",
+			"--labels", "own-label",
+		), []string{"Child"})
+		if err != nil {
+			t.Fatalf("gatherCreateInput: %v", err)
+		}
+		if in.parentID != "bd-parent" || !in.noInheritLabels || strings.Join(in.labels, ",") != "own-label" {
+			t.Errorf("parent fields = %#v", in)
+		}
+	})
+}
+
+// newCreateFlagsCommand clones createCmd's flag definitions onto a fresh
+// command. This keeps gatherCreateInput's flag-level tests on the real CLI
+// surface without allowing state from one case to leak into another.
+func newCreateFlagsCommand(t *testing.T, args ...string) *cobra.Command {
+	t.Helper()
+	cmd := &cobra.Command{Use: "create [title]"}
+	createCmd.Flags().VisitAll(func(f *pflag.Flag) {
+		switch f.Value.Type() {
+		case "bool":
+			cmd.Flags().Bool(f.Name, f.DefValue == "true", f.Usage)
+		case "int":
+			n, err := strconv.Atoi(f.DefValue)
+			if err != nil {
+				t.Fatalf("--%s has non-integer default %q: %v", f.Name, f.DefValue, err)
+			}
+			cmd.Flags().Int(f.Name, n, f.Usage)
+		case "string":
+			cmd.Flags().String(f.Name, f.DefValue, f.Usage)
+		case "stringSlice":
+			if f.DefValue != "[]" {
+				t.Fatalf("--%s has a non-empty slice default %q, which this clone does not reproduce", f.Name, f.DefValue)
+			}
+			cmd.Flags().StringSlice(f.Name, nil, f.Usage)
+		default:
+			t.Fatalf("--%s has unhandled flag type %q", f.Name, f.Value.Type())
+		}
+	})
+	if err := cmd.ParseFlags(args); err != nil {
+		t.Fatalf("parse %v: %v", args, err)
+	}
+	return cmd
 }

--- a/cmd/bd/create_proxied_integration_test.go
+++ b/cmd/bd/create_proxied_integration_test.go
@@ -10,7 +10,6 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/steveyegge/beads/internal/types"
 )
@@ -21,274 +20,75 @@ func TestProxiedServerCreate(t *testing.T) {
 
 	bd := buildEmbeddedBD(t)
 
-	t.Run("basic", func(t *testing.T) {
+	t.Run("scalar_and_output_boundary", func(t *testing.T) {
 		t.Parallel()
-		p := newSharedProxiedProject(t, bd, "bc")
-		issue := bdProxiedCreate(t, bd, p.dir, "Basic issue")
-		if issue.ID == "" {
-			t.Fatal("expected issue ID")
+		p := newSharedProxiedProject(t, bd, "sc")
+		issue := bdProxiedCreate(t, bd, p.dir, "Scalar issue")
+		if !strings.HasPrefix(issue.ID, "sc-") {
+			t.Fatalf("ID should have prefix sc-, got %q", issue.ID)
 		}
-		if issue.Title != "Basic issue" {
-			t.Errorf("title: got %q, want %q", issue.Title, "Basic issue")
+		if issue.Title != "Scalar issue" || issue.Status != types.StatusOpen || issue.Priority != 2 || issue.IssueType != types.TypeTask {
+			t.Errorf("create result = %+v, want scalar defaults", issue)
 		}
-		if issue.Status != types.StatusOpen {
-			t.Errorf("status: got %q, want %q", issue.Status, types.StatusOpen)
-		}
-		if issue.Priority != 2 {
-			t.Errorf("priority: got %d, want 2 (default)", issue.Priority)
-		}
-		if issue.IssueType != types.TypeTask {
-			t.Errorf("type: got %q, want %q", issue.IssueType, types.TypeTask)
-		}
-		if !strings.HasPrefix(issue.ID, "bc-") {
-			t.Errorf("ID should have prefix bc-, got %q", issue.ID)
-		}
-	})
-
-	t.Run("title_flag", func(t *testing.T) {
-		t.Parallel()
-		p := newSharedProxiedProject(t, bd, "tf")
-		issue := bdProxiedCreate(t, bd, p.dir, "--title", "Title via flag")
-		if issue.Title != "Title via flag" {
-			t.Errorf("title: got %q, want %q", issue.Title, "Title via flag")
-		}
-	})
-
-	t.Run("silent", func(t *testing.T) {
-		t.Parallel()
-		p := newSharedProxiedProject(t, bd, "sl")
-		id := bdProxiedCreateSilent(t, bd, p.dir, "Silent issue")
-		if id == "" {
-			t.Fatal("expected issue ID from --silent")
-		}
-		if !strings.HasPrefix(id, "sl-") {
-			t.Errorf("ID should have prefix sl-, got %q", id)
-		}
-	})
-
-	t.Run("priority", func(t *testing.T) {
-		t.Parallel()
-		p := newSharedProxiedProject(t, bd, "pr")
-		for _, tc := range []struct {
-			flag string
-			want int
-		}{
-			{"0", 0}, {"1", 1}, {"P3", 3}, {"4", 4},
-		} {
-			t.Run("P"+tc.flag, func(t *testing.T) {
-				issue := bdProxiedCreate(t, bd, p.dir, fmt.Sprintf("Priority %s", tc.flag), "-p", tc.flag)
-				if issue.Priority != tc.want {
-					t.Errorf("priority: got %d, want %d", issue.Priority, tc.want)
-				}
-			})
-		}
-	})
-
-	t.Run("issue_types", func(t *testing.T) {
-		t.Parallel()
-		p := newSharedProxiedProject(t, bd, "it")
-		for _, issueType := range []string{"bug", "feature", "task", "epic", "chore", "decision"} {
-			t.Run(issueType, func(t *testing.T) {
-				issue := bdProxiedCreate(t, bd, p.dir, fmt.Sprintf("Type %s", issueType), "-t", issueType)
-				normalized := types.IssueType(issueType).Normalize()
-				if issue.IssueType != normalized {
-					t.Errorf("type: got %q, want %q", issue.IssueType, normalized)
-				}
-			})
-		}
-	})
-
-	t.Run("description", func(t *testing.T) {
-		t.Parallel()
-		p := newSharedProxiedProject(t, bd, "ds")
-		issue := bdProxiedCreate(t, bd, p.dir, "Desc issue", "-d", "This is the description")
-		if issue.Description != "This is the description" {
-			t.Errorf("description: got %q, want %q", issue.Description, "This is the description")
-		}
-	})
-
-	t.Run("design_and_acceptance", func(t *testing.T) {
-		t.Parallel()
-		p := newSharedProxiedProject(t, bd, "da")
-		issue := bdProxiedCreate(t, bd, p.dir, "Design issue",
-			"--design", "Use MVC pattern",
-			"--acceptance", "All tests pass")
-		if issue.Design != "Use MVC pattern" {
-			t.Errorf("design: got %q, want %q", issue.Design, "Use MVC pattern")
-		}
-		if issue.AcceptanceCriteria != "All tests pass" {
-			t.Errorf("acceptance: got %q, want %q", issue.AcceptanceCriteria, "All tests pass")
-		}
-	})
-
-	t.Run("assignee", func(t *testing.T) {
-		t.Parallel()
-		p := newSharedProxiedProject(t, bd, "as")
-		issue := bdProxiedCreate(t, bd, p.dir, "Assigned issue", "-a", "alice")
-		if issue.Assignee != "alice" {
-			t.Errorf("assignee: got %q, want %q", issue.Assignee, "alice")
-		}
-	})
-
-	t.Run("labels", func(t *testing.T) {
-		t.Parallel()
-		p := newSharedProxiedProject(t, bd, "lb")
-		issue := bdProxiedCreate(t, bd, p.dir, "Labeled issue", "-l", "bug,critical")
 
 		db := openProxiedDB(t, p)
-		labels := getProxiedLabels(t, db, issue.ID)
-		labelMap := make(map[string]bool)
-		for _, l := range labels {
-			labelMap[l] = true
+		var title, status, issueType string
+		var priority int
+		if err := db.QueryRowContext(context.Background(), "SELECT title, status, priority, issue_type FROM issues WHERE id = ?", issue.ID).Scan(&title, &status, &priority, &issueType); err != nil {
+			t.Fatalf("query persisted scalar issue: %v", err)
 		}
-		if !labelMap["bug"] || !labelMap["critical"] {
-			t.Errorf("expected labels bug and critical, got %v", labels)
+		if title != "Scalar issue" || status != string(types.StatusOpen) || priority != 2 || issueType != string(types.TypeTask) {
+			t.Errorf("persisted scalar issue = title=%q status=%q priority=%d type=%q", title, status, priority, issueType)
 		}
-	})
 
-	t.Run("explicit_id", func(t *testing.T) {
-		t.Parallel()
-		p := newSharedProxiedProject(t, bd, "ei")
-		issue := bdProxiedCreate(t, bd, p.dir, "Explicit ID", "--id", "ei-custom42")
-		if issue.ID != "ei-custom42" {
-			t.Errorf("ID: got %q, want %q", issue.ID, "ei-custom42")
+		out, err := bdProxiedRun(t, bd, p.dir, "create", "--silent", "Silent issue")
+		if err != nil {
+			t.Fatalf("bd create --silent: %v\n%s", err, out)
 		}
-	})
-
-	t.Run("dependencies", func(t *testing.T) {
-		t.Parallel()
-		p := newSharedProxiedProject(t, bd, "dp")
-		parent := bdProxiedCreate(t, bd, p.dir, "Parent issue")
-		child := bdProxiedCreate(t, bd, p.dir, "Child issue", "--deps", "blocks:"+parent.ID)
-
-		db := openProxiedDB(t, p)
-		assertProxiedDepExists(t, db, parent.ID, child.ID)
-	})
-
-	t.Run("blocked_by_alias", func(t *testing.T) {
-		t.Parallel()
-		p := newSharedProxiedProject(t, bd, "bb")
-		blocker := bdProxiedCreate(t, bd, p.dir, "Blocker issue")
-		blocked := bdProxiedCreate(t, bd, p.dir, "Blocked issue", "--deps", "blocked-by:"+blocker.ID)
-
-		db := openProxiedDB(t, p)
-		assertProxiedDepExistsWithType(t, db, blocked.ID, blocker.ID, "blocks")
-	})
-
-	t.Run("depends_on_alias", func(t *testing.T) {
-		t.Parallel()
-		p := newSharedProxiedProject(t, bd, "do")
-		prereq := bdProxiedCreate(t, bd, p.dir, "Prerequisite")
-		dependent := bdProxiedCreate(t, bd, p.dir, "Dependent issue", "--deps", "depends-on:"+prereq.ID)
-
-		db := openProxiedDB(t, p)
-		assertProxiedDepExistsWithType(t, db, dependent.ID, prereq.ID, "blocks")
-	})
-
-	t.Run("unknown_dep_type_rejected", func(t *testing.T) {
-		t.Parallel()
-		p := newSharedProxiedProject(t, bd, "ud")
-		blocker := bdProxiedCreate(t, bd, p.dir, "Blocker")
-		out := bdProxiedCreateFail(t, bd, p.dir, "Bad dep type", "--deps", "bogus-type:"+blocker.ID)
-		if !strings.Contains(out, "unknown dependency type") {
-			t.Errorf("expected 'unknown dependency type' error, got:\n%s", out)
+		silentID := strings.TrimSpace(string(out))
+		if !strings.HasPrefix(silentID, "sc-") || string(out) != silentID+"\n" {
+			t.Errorf("silent stdout = %q, want exactly the created ID plus newline", out)
 		}
-		if !strings.Contains(out, "blocked-by") || !strings.Contains(out, "depends-on") {
-			t.Errorf("expected accepted dependency aliases in error, got:\n%s", out)
+		if err := db.QueryRowContext(context.Background(), "SELECT title FROM issues WHERE id = ?", silentID).Scan(&title); err != nil {
+			t.Fatalf("query persisted silent issue: %v", err)
+		}
+		if title != "Silent issue" {
+			t.Errorf("silent issue title = %q, want Silent issue", title)
 		}
 	})
 
-	t.Run("multiple_dependencies", func(t *testing.T) {
+	t.Run("aggregate_transaction_boundary", func(t *testing.T) {
 		t.Parallel()
-		p := newSharedProxiedProject(t, bd, "md")
-		dep1 := bdProxiedCreate(t, bd, p.dir, "Dep 1")
-		dep2 := bdProxiedCreate(t, bd, p.dir, "Dep 2")
-		child := bdProxiedCreate(t, bd, p.dir, "Multi dep issue",
-			"--deps", fmt.Sprintf("blocks:%s,related:%s", dep1.ID, dep2.ID))
-
-		db := openProxiedDB(t, p)
-		assertProxiedDepExists(t, db, dep1.ID, child.ID)
-		assertProxiedDepExists(t, db, child.ID, dep2.ID)
-	})
-
-	t.Run("parent_child", func(t *testing.T) {
-		t.Parallel()
-		p := newSharedProxiedProject(t, bd, "pc")
-		parent := bdProxiedCreate(t, bd, p.dir, "Parent epic", "-t", "epic")
-		child := bdProxiedCreate(t, bd, p.dir, "Child task", "--parent", parent.ID)
-
+		p := newSharedProxiedProject(t, bd, "ag")
+		parent := bdProxiedCreate(t, bd, p.dir, "Parent", "-t", "epic", "-l", "parent-label,shared")
+		target := bdProxiedCreate(t, bd, p.dir, "Dependency target")
+		child := bdProxiedCreate(t, bd, p.dir, "Child", "--parent", parent.ID, "-l", "own-label", "--deps", "blocks:"+target.ID)
 		if !strings.HasPrefix(child.ID, parent.ID+".") {
 			t.Errorf("child ID %q should start with %q.", child.ID, parent.ID)
 		}
-		db := openProxiedDB(t, p)
-		assertProxiedDepExists(t, db, child.ID, parent.ID)
-	})
-
-	t.Run("parent_label_inheritance", func(t *testing.T) {
-		t.Parallel()
-		p := newSharedProxiedProject(t, bd, "pi")
-		parent := bdProxiedCreate(t, bd, p.dir, "Parent with labels", "-t", "epic", "-l", "team-a,priority:high")
-		child := bdProxiedCreate(t, bd, p.dir, "Child inherits", "--parent", parent.ID)
 
 		db := openProxiedDB(t, p)
+		var persistedTitle string
+		if err := db.QueryRowContext(context.Background(), "SELECT title FROM issues WHERE id = ?", child.ID).Scan(&persistedTitle); err != nil {
+			t.Fatalf("query persisted child: %v", err)
+		}
+		if persistedTitle != "Child" {
+			t.Errorf("persisted child title = %q, want Child", persistedTitle)
+		}
+		assertProxiedDepExistsWithType(t, db, child.ID, parent.ID, "parent-child")
+		assertProxiedDepExistsWithType(t, db, target.ID, child.ID, "blocks")
+
 		labels := getProxiedLabels(t, db, child.ID)
-		labelMap := make(map[string]bool)
-		for _, l := range labels {
-			labelMap[l] = true
+		labelSet := make(map[string]bool, len(labels))
+		for _, label := range labels {
+			labelSet[label] = true
 		}
-		if !labelMap["team-a"] || !labelMap["priority:high"] {
-			t.Errorf("expected inherited labels team-a and priority:high, got %v", labels)
-		}
-	})
-
-	t.Run("parent_no_inherit_labels", func(t *testing.T) {
-		t.Parallel()
-		p := newSharedProxiedProject(t, bd, "ni")
-		parent := bdProxiedCreate(t, bd, p.dir, "Parent", "-t", "epic", "-l", "inherited-label")
-		child := bdProxiedCreate(t, bd, p.dir, "Child no inherit", "--parent", parent.ID, "--no-inherit-labels", "-l", "own-label")
-
-		db := openProxiedDB(t, p)
-		labels := getProxiedLabels(t, db, child.ID)
-		labelMap := make(map[string]bool)
-		for _, l := range labels {
-			labelMap[l] = true
-		}
-		if !labelMap["own-label"] {
-			t.Error("expected own-label on child")
-		}
-		if labelMap["inherited-label"] {
-			t.Error("did not expect inherited-label on child with --no-inherit-labels")
+		for _, want := range []string{"parent-label", "shared", "own-label"} {
+			if !labelSet[want] {
+				t.Errorf("child labels = %v, missing %q", labels, want)
+			}
 		}
 	})
-
-	t.Run("due_date", func(t *testing.T) {
-		t.Parallel()
-		p := newSharedProxiedProject(t, bd, "dd")
-		issue := bdProxiedCreate(t, bd, p.dir, "Due issue", "--due", "+24h")
-		if issue.DueAt == nil {
-			t.Fatal("expected DueAt to be set")
-		}
-		expected := time.Now().Add(24 * time.Hour)
-		diff := issue.DueAt.Sub(expected)
-		if diff < -5*time.Minute || diff > 5*time.Minute {
-			t.Errorf("DueAt off by too much: got %v, expected ~%v", issue.DueAt, expected)
-		}
-	})
-
-	t.Run("defer_until", func(t *testing.T) {
-		t.Parallel()
-		p := newSharedProxiedProject(t, bd, "df")
-		issue := bdProxiedCreate(t, bd, p.dir, "Deferred issue", "--defer", "+2h")
-		if issue.DeferUntil == nil {
-			t.Fatal("expected DeferUntil to be set")
-		}
-		expected := time.Now().Add(2 * time.Hour)
-		diff := issue.DeferUntil.Sub(expected)
-		if diff < -5*time.Minute || diff > 5*time.Minute {
-			t.Errorf("DeferUntil off by too much: got %v, expected ~%v", issue.DeferUntil, expected)
-		}
-	})
-
 }
 
 func TestProxiedServerCreate2(t *testing.T) {

--- a/cmd/bd/create_proxied_server_test.go
+++ b/cmd/bd/create_proxied_server_test.go
@@ -58,11 +58,17 @@ func TestBuildCreateIssueFromInput_PopulatesAllFields(t *testing.T) {
 	if got.Title != "Title" {
 		t.Errorf("Title = %q", got.Title)
 	}
+	if got.Description != "Desc" || got.Design != "Design" || got.AcceptanceCriteria != "Accept" || got.Notes != "Notes" || got.SpecID != "spec-1" {
+		t.Errorf("content fields = %+v", got)
+	}
 	if got.IssueType != types.TypeFeature {
 		t.Errorf("IssueType = %q, want feature (normalized from feat)", got.IssueType)
 	}
 	if got.Priority != 1 {
 		t.Errorf("Priority = %d", got.Priority)
+	}
+	if got.Assignee != "alice" {
+		t.Errorf("Assignee = %q, want alice", got.Assignee)
 	}
 	if got.Status != types.StatusDeferred {
 		t.Errorf("Status = %q, want %q", got.Status, types.StatusDeferred)
@@ -73,8 +79,8 @@ func TestBuildCreateIssueFromInput_PopulatesAllFields(t *testing.T) {
 	if got.EstimatedMinutes == nil || *got.EstimatedMinutes != 90 {
 		t.Errorf("EstimatedMinutes = %v, want 90", got.EstimatedMinutes)
 	}
-	if !got.Ephemeral {
-		t.Errorf("Ephemeral = false, want true")
+	if !got.Ephemeral || got.NoHistory {
+		t.Errorf("storage flags = ephemeral:%t no_history:%t, want true:false", got.Ephemeral, got.NoHistory)
 	}
 	if got.CreatedBy != "tester" || got.Owner != "tester@example.com" {
 		t.Errorf("identity fields wrong: %q / %q", got.CreatedBy, got.Owner)


### PR DESCRIPTION
## What

Replace 20 independent real proxied-Create project setups with two representative boundary journeys, while moving removed permutations to their typed lower-level owners.

- `scalar_and_output_boundary` keeps real subprocess, proxy routing, JSON/default-field persistence, and exact `--silent` output coverage.
- `aggregate_transaction_boundary` keeps real hierarchical ID, issue, parent-child edge, reverse dependency, and inherited-plus-own label persistence coverage.
- Typed input, builder, parser, priority, and issue-type tests own the scalar permutations that do not require a process or persistence boundary.
- No production code, workflow, shard manifest, skip, timeout, retry, or parallelism setting changes.

| Removed proxied permutations | Authoritative owner |
| --- | --- |
| Basic JSON result and silent output | `scalar_and_output_boundary` |
| Parent, dependency direction, and label inheritance | `aggregate_transaction_boundary` |
| Title flag, due/defer mapping, explicit ID, and inheritance controls | `TestGatherCreateInputMapsSingleIssueFlags` |
| Description, design, acceptance, assignee, and materialized fields | `TestBuildCreateIssueFromInput_PopulatesAllFields` |
| Priority and issue-type normalization | Existing validation/type unit tests |
| Dependency aliases, multiple specs, and unknown-type guidance | `TestParseDepSpecs` |

## Why

Ubuntu PR Risk shard 8 is a current PR-latency ceiling. Its seven-success baseline is `412, 395, 404, 373, 405, 389, 395s` (median `395s`). `TestProxiedServerCreate` created 20 fresh real projects and was the sole final 213–266 second tail in four of those seven runs.

The removed cases mostly proved flag parsing and object construction by repeatedly paying for a real store and process boundary. This keeps the distinct end-to-end risks while making field permutations fast and failure-local.

This does not supersede contributor work in #4738 or #4742. Their default-status and fresh-UOW-retry behavior remains outside this test-only change.

Tracked by `bd-1rh.14`.

## Measurement

- Current-checkout local shard 8, using prebuilt race test and non-race subprocess binaries: **80.44s**, PASS.
- Both retained Create children explicitly ran and passed; neither skipped.
- Hosted acceptance after opening: retain the next seven successful shard-8 samples and require every sample to be at most 300 seconds.

The local and hosted environments are not directly comparable, so the 80.44-second local result is a correctness/smoke measurement rather than the claimed hosted speedup.

## Verification

```text
./scripts/test.sh -v -run '^(TestGatherCreateInputMapsSingleIssueFlags|TestParseDepSpecs)$' ./cmd/bd
BEADS_TEST_PROXIED_SERVER=1 BEADS_TEST_BD_BINARY=/tmp/bd-1rh14-proxied BEADS_TEST_CMD_BINARY=/tmp/bd-1rh14-cmd-test bash .github/scripts/proxied-test-shard.sh 8 15
make test
go vet ./...
golangci-lint run ./cmd/bd/...
git diff --check
```

Two independent Sol blocker/major reviews approved the final frozen diff after their two findings were moved to the lower test seams. The configured pre-commit hook also passed under Go 1.26.5.

This nontrivial PR should receive substantive human review and be merged by a different maintainer; it will not be self-merged.

_codex-unknown-model-unknown-reasoning on behalf of CI Bot_
