### PR TITLE
fix(ci): remove recursive Make from lint formatting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -337,21 +337,7 @@ fmt:
 
 # Check that all Go files are properly formatted (for CI)
 fmt-check:
-	@echo "Checking Go formatting..."
-	@UNFORMATTED=$$(gofmt -l .); \
-	status=$$?; \
-	if [ "$$status" -ne 0 ]; then \
-		echo "gofmt failed while checking formatting" >&2; \
-		exit "$$status"; \
-	fi; \
-	if [ -n "$$UNFORMATTED" ]; then \
-		echo "The following files are not properly formatted:"; \
-		echo "$$UNFORMATTED"; \
-		echo ""; \
-		echo "Run 'make fmt' to fix formatting"; \
-		exit 1; \
-	fi
-	@echo "All Go files are properly formatted"
+	@./scripts/ci/fmt-check.sh
 
 # Validate documentation references against actual CLI flags
 check-docs:

--- a/scripts/ci/fmt-check.sh
+++ b/scripts/ci/fmt-check.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Shared Go formatting check for Make and PR lint wrappers.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+cd "$REPO_ROOT"
+
+printf 'Checking Go formatting...\n'
+if UNFORMATTED="$(gofmt -l .)"; then
+    :
+else
+    status=$?
+    printf 'gofmt failed while checking formatting\n' >&2
+    exit "$status"
+fi
+
+if [[ -n "$UNFORMATTED" ]]; then
+    printf 'The following files are not properly formatted:\n'
+    printf '%s\n' "$UNFORMATTED"
+    printf '\n'
+    printf "Run 'make fmt' to fix formatting\n"
+    exit 1
+fi
+
+printf 'All Go files are properly formatted\n'

--- a/scripts/ci/pr-lint.sh
+++ b/scripts/ci/pr-lint.sh
@@ -21,7 +21,7 @@ if [[ -n "${BD_LINT_NEW_FROM_MERGE_BASE:-}" ]]; then
     lint_scope=(--new-from-merge-base="$BD_LINT_NEW_FROM_MERGE_BASE")
 fi
 
-ci_time "gofmt check" -- make fmt-check
+ci_time "gofmt check" -- ./scripts/ci/fmt-check.sh
 ci_time "golangci-lint" -- \
     golangci-lint run --config=.golangci.yml --modules-download-mode=readonly \
         --timeout=5m --build-tags=gms_pure_go \

--- a/scripts/prlintmake/prlintmake_test.go
+++ b/scripts/prlintmake/prlintmake_test.go
@@ -1,0 +1,176 @@
+package prlintmake
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestFmtCheckClean(t *testing.T) {
+	output, err := runFmtCheck(t, "exit 0\n")
+	if err != nil {
+		t.Fatalf("fmt-check failed: %v\n%s", err, output)
+	}
+	want := "Checking Go formatting...\nAll Go files are properly formatted\n"
+	if output != want {
+		t.Fatalf("output = %q, want %q", output, want)
+	}
+}
+
+func TestFmtCheckReportsUnformattedFiles(t *testing.T) {
+	output, err := runFmtCheck(t, "printf '%s\\n' cmd/bd/main.go internal/config/config.go\n")
+	if got := processExitCode(err); got != 1 {
+		t.Fatalf("exit = %d, want 1; error=%v\n%s", got, err, output)
+	}
+	want := "Checking Go formatting...\n" +
+		"The following files are not properly formatted:\n" +
+		"cmd/bd/main.go\n" +
+		"internal/config/config.go\n\n" +
+		"Run 'make fmt' to fix formatting\n"
+	if output != want {
+		t.Fatalf("output = %q, want %q", output, want)
+	}
+}
+
+func TestFmtCheckPreservesGofmtFailure(t *testing.T) {
+	output, err := runFmtCheck(t, "printf 'synthetic gofmt failure\\n' >&2\nexit 42\n")
+	if got := processExitCode(err); got != 42 {
+		t.Fatalf("exit = %d, want 42; error=%v\n%s", got, err, output)
+	}
+	for _, want := range []string{
+		"Checking Go formatting...",
+		"synthetic gofmt failure",
+		"gofmt failed while checking formatting",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("missing %q in output:\n%s", want, output)
+		}
+	}
+}
+
+func runFmtCheck(t *testing.T, gofmtBody string) (string, error) {
+	t.Helper()
+	bash := testBash(t)
+	testRoot := t.TempDir()
+	shimDir := filepath.Join(testRoot, "fmt shims")
+	if err := os.MkdirAll(shimDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeShellExecutable(t, bash, filepath.Join(shimDir, "gofmt"), "#!/usr/bin/env bash\nset -euo pipefail\n"+gofmtBody)
+
+	path := shimDir + string(os.PathListSeparator) + os.Getenv("PATH")
+	if runtime.GOOS == "windows" {
+		path = msysPath(shimDir) + ":/usr/bin:/bin"
+	}
+	cmd := exec.Command(
+		bash,
+		"--noprofile",
+		"--norc",
+		"--",
+		shellVisiblePath(filepath.Join(sourceRepoRoot(), "scripts", "ci", "fmt-check.sh")),
+	)
+	cmd.Dir = sourceRepoRoot()
+	cmd.Env = environment(map[string]string{
+		"BASH_ENV":  "",
+		"BASHOPTS":  "",
+		"ENV":       "",
+		"LANG":      "C",
+		"LC_ALL":    "C",
+		"PATH":      path,
+		"SHELLOPTS": "",
+	})
+	output, err := cmd.CombinedOutput()
+	return normalizeNewlines(string(output)), err
+}
+
+func writeShellExecutable(t *testing.T, bash, path, body string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(strings.ReplaceAll(body, "\r\n", "\n")), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if runtime.GOOS != "windows" {
+		if err := os.Chmod(path, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		return
+	}
+	cmd := exec.Command(bash, "--noprofile", "--norc", "-c", `/usr/bin/chmod +x "$1"`, "--", msysPath(path))
+	cmd.Env = environment(map[string]string{
+		"BASH_ENV":  "",
+		"BASHOPTS":  "",
+		"ENV":       "",
+		"SHELLOPTS": "",
+	})
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("make %s executable: %v\n%s", path, err, output)
+	}
+}
+
+func testBash(t *testing.T) string {
+	t.Helper()
+	path, err := exec.LookPath("bash")
+	if err != nil {
+		t.Fatalf("bash is required: %v", err)
+	}
+	return path
+}
+
+func environment(overrides map[string]string) []string {
+	overridden := make(map[string]struct{}, len(overrides))
+	for key := range overrides {
+		overridden[strings.ToUpper(key)] = struct{}{}
+	}
+	env := make([]string, 0, len(os.Environ())+len(overrides))
+	for _, entry := range os.Environ() {
+		key, _, _ := strings.Cut(entry, "=")
+		if _, ok := overridden[strings.ToUpper(key)]; !ok {
+			env = append(env, entry)
+		}
+	}
+	for key, value := range overrides {
+		env = append(env, key+"="+value)
+	}
+	return env
+}
+
+func processExitCode(err error) int {
+	if err == nil {
+		return 0
+	}
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		return exitErr.ExitCode()
+	}
+	return -1
+}
+
+func sourceRepoRoot() string {
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		panic("runtime.Caller failed")
+	}
+	return filepath.Dir(filepath.Dir(filepath.Dir(file)))
+}
+
+func shellVisiblePath(path string) string {
+	if runtime.GOOS == "windows" {
+		return msysPath(path)
+	}
+	return path
+}
+
+func msysPath(path string) string {
+	path = filepath.ToSlash(filepath.Clean(path))
+	if len(path) >= 3 && path[1] == ':' && path[2] == '/' {
+		return "/" + strings.ToLower(path[:1]) + path[2:]
+	}
+	return path
+}
+
+func normalizeNewlines(value string) string {
+	return strings.ReplaceAll(value, "\r\n", "\n")
+}


### PR DESCRIPTION
## Summary

- move the formatting check into one repository-owned shell script;
- have both `make fmt-check` and `scripts/ci/pr-lint.sh` call that script
  directly; and
- cover its clean, unformatted-file, and underlying-`gofmt` failure behavior.

## Why

The supported native-Windows entrypoint is `mingw32-make.exe`. The lint wrapper
previously entered through that executable and then launched a nested literal
`make fmt-check`. A normal UCRT64 installation provides `mingw32-make.exe`, not
a `make.exe` alias, so the wrapper failed during recursive Make discovery
before it reached formatting.

Both entrypoints now delegate to `scripts/ci/fmt-check.sh`. The implementation
there preserves the prior output contract and returns the underlying `gofmt`
failure status, while eliminating the second Make lookup entirely.

`scripts/ci/pr-lint.sh` remains a directly runnable public entrypoint; it does
not require a Make-exported sentinel or a privileged-shell relaunch.

## Scope decision

This reduced change intentionally excludes the broader Make, shell, host, and
workflow-authority hardening previously carried on this branch. Those design
questions remain separate under #5451 and #5463.

The former `.gitattributes` hunk is now absent; merged PR #5319 supplies the
repository-wide LF policy.

## Validation

- the three focused `TestFmtCheck*` tests on the rebased head;
- Bash syntax and ShellCheck for the new shared script;
- native `mingw32-make fmt-check` from a fresh Windows checkout; and
- exact four-file diff and whitespace hygiene checks.

Fresh hosted results are required for this rebased head.

Fixes #5302

_codex-gpt-5-unknown-reasoning on behalf of Ewen Cuthiell_
