### PR TITLE
ci: shadow PR Risk capability ownership

### DIFF
--- a/.github/scripts/ci-capability-selector.sh
+++ b/.github/scripts/ci-capability-selector.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+# Report candidate PR Risk capabilities without changing the current gates.
+
+set -euo pipefail
+
+embedded_cli=false
+proxied_cli=false
+embedded_storage=false
+embedded_conformance=false
+server_conformance=false
+full=false
+reason=""
+diff_file=""
+
+cleanup() {
+	if [[ -n "$diff_file" ]]; then
+		rm -f "$diff_file"
+	fi
+}
+trap cleanup EXIT
+
+set_full() {
+	embedded_cli=true
+	proxied_cli=true
+	embedded_storage=true
+	embedded_conformance=true
+	server_conformance=true
+	full=true
+	reason="$1"
+}
+
+emit() {
+	local lines=(
+		"embedded_cli=$embedded_cli"
+		"proxied_cli=$proxied_cli"
+		"embedded_storage=$embedded_storage"
+		"embedded_conformance=$embedded_conformance"
+		"server_conformance=$server_conformance"
+		"full=$full"
+		"reason=$reason"
+	)
+	printf '%s\n' "${lines[@]}"
+	if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+		printf '%s\n' "${lines[@]}" >> "$GITHUB_OUTPUT"
+	fi
+}
+
+event_name="${GITHUB_EVENT_NAME:-}"
+base_sha="${PR_BASE_SHA:-}"
+head_sha="${PR_HEAD_SHA:-}"
+case "$event_name" in
+	pull_request) ;;
+	push) set_full "push"; emit; exit 0 ;;
+	merge_group) set_full "merge_group"; emit; exit 0 ;;
+	*) set_full "unsupported_event"; emit; exit 0 ;;
+esac
+
+if [[ -z "$base_sha" || -z "$head_sha" ]]; then
+	set_full "missing_bounds"
+	emit
+	exit 0
+fi
+
+diff_file=$(mktemp)
+if ! git diff --no-ext-diff --find-renames --name-status -z "$base_sha" "$head_sha" -- > "$diff_file"; then
+	set_full "diff_failed"
+	emit
+	exit 0
+fi
+
+saw_path=false
+saw_cmd=false
+saw_embedded=false
+saw_server=false
+saw_conformance=false
+
+while :; do
+	status=""
+	if ! IFS= read -r -d '' status <&3; then
+		if [[ -n "$status" ]]; then
+			set_full "malformed_record"
+		fi
+		break
+	fi
+	if [[ "$status" != "A" && "$status" != "M" ]]; then
+		set_full "unsafe_status"
+		break
+	fi
+	path=""
+	if ! IFS= read -r -d '' path <&3; then
+		set_full "malformed_record"
+		break
+	fi
+	saw_path=true
+	if [[ -z "$path" || "$path" == /* || "/$path/" == *"/../"* || "$path" == . || "$path" == .. || "$path" == ./* ]]; then
+		set_full "unsafe_path"
+		break
+	fi
+	case "$path" in
+		.github/workflows/*|.github/scripts/*)
+			set_full "unsafe_control"
+			break
+			;;
+		.buildflags|go.mod|go.sum|Makefile|default.nix|flake.nix|flake.lock|overlay.nix|packages.nix)
+			set_full "build_input"
+			break
+			;;
+		cmd/bd/*)
+			embedded_cli=true
+			proxied_cli=true
+			saw_cmd=true
+			;;
+		internal/storage/embeddeddolt/*)
+			embedded_cli=true
+			embedded_storage=true
+			embedded_conformance=true
+			saw_embedded=true
+			;;
+		internal/storage/dolt/*)
+			proxied_cli=true
+			server_conformance=true
+			saw_server=true
+			;;
+		backend/conformance/*|test/conformance/*)
+			embedded_conformance=true
+			server_conformance=true
+			saw_conformance=true
+			;;
+		internal/storage/*|backend/*|schema/*)
+			set_full "cross_cutting_storage"
+			break
+			;;
+		docs/*.md|docs/*.mdx|docs/*.png|docs/*.jpg|docs/*.jpeg|docs/*.gif|docs/*.svg|docs/*.webp|docs/*.avif|engdocs/*.md|engdocs/*.mdx|engdocs/*.png|engdocs/*.jpg|engdocs/*.jpeg|engdocs/*.gif|engdocs/*.svg|engdocs/*.webp|engdocs/*.avif|README.md|CHANGELOG.md|ARTICLES.md|BENCHMARKS.md|NEWSLETTER.md)
+			;;
+		*)
+			set_full "unowned_path"
+			break
+			;;
+	esac
+done 3< "$diff_file"
+
+if [[ "$full" != true ]]; then
+	if [[ "$embedded_cli" == true && "$proxied_cli" == true && "$embedded_storage" == true && "$embedded_conformance" == true && "$server_conformance" == true ]]; then
+		full=true
+		reason="full"
+	elif [[ "$saw_path" != true ]]; then
+		reason="empty_diff"
+	elif [[ "$saw_cmd" == true && "$saw_embedded" != true && "$saw_server" != true && "$saw_conformance" != true ]]; then
+		reason="cmd_bd"
+	elif [[ "$saw_embedded" == true && "$saw_cmd" != true && "$saw_server" != true && "$saw_conformance" != true ]]; then
+		reason="embedded_storage"
+	elif [[ "$saw_server" == true && "$saw_cmd" != true && "$saw_embedded" != true && "$saw_conformance" != true ]]; then
+		reason="server_storage"
+	elif [[ "$saw_conformance" == true && "$saw_cmd" != true && "$saw_embedded" != true && "$saw_server" != true ]]; then
+		reason="shared_conformance"
+	elif [[ "$saw_cmd" == false && "$saw_embedded" == false && "$saw_server" == false && "$saw_conformance" == false ]]; then
+		reason="docs_only"
+	else
+		reason="mixed"
+	fi
+fi
+
+emit

--- a/.github/workflows/pr-risk.yml
+++ b/.github/workflows/pr-risk.yml
@@ -20,6 +20,13 @@ jobs:
     outputs:
       full_embedded: ${{ steps.tier.outputs.full_embedded }}
       reason: ${{ steps.tier.outputs.reason }}
+      shadow_embedded_cli: ${{ steps.shadow-selector.outputs.embedded_cli }}
+      shadow_proxied_cli: ${{ steps.shadow-selector.outputs.proxied_cli }}
+      shadow_embedded_storage: ${{ steps.shadow-selector.outputs.embedded_storage }}
+      shadow_embedded_conformance: ${{ steps.shadow-selector.outputs.embedded_conformance }}
+      shadow_server_conformance: ${{ steps.shadow-selector.outputs.server_conformance }}
+      shadow_full: ${{ steps.shadow-selector.outputs.full }}
+      shadow_reason: ${{ steps.shadow-selector.outputs.reason }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
         with:
@@ -31,6 +38,22 @@ jobs:
           PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
           PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: bash .github/scripts/ci-embedded-tier.sh
+
+      - name: Shadow CI capability selector
+        id: shadow-selector
+        continue-on-error: true
+        env:
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -o pipefail
+          selection="$(bash .github/scripts/ci-capability-selector.sh)"
+          printf '%s\n' "$selection"
+          {
+            echo '### Shadow CI capability selector'
+            printf '%s\n' "$selection" | sed 's/^/- `/' | sed 's/$/`/'
+          } >> "$GITHUB_STEP_SUMMARY"
 
   # End-to-end coverage for proxied-server CLI subcommands, sharded across the
   # CI matrix. Each sub-test drives the bd CLI subprocess against a real dolt

--- a/scripts/ci_capability_selector_test.go
+++ b/scripts/ci_capability_selector_test.go
@@ -1,0 +1,275 @@
+package scripts_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+var selectorKeys = []string{
+	"embedded_cli", "proxied_cli", "embedded_storage", "embedded_conformance", "server_conformance", "full", "reason",
+}
+
+func TestCICapabilitySelectorClassifiesOwnedPaths(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		records []string
+		want    map[string]string
+	}{
+		{"docs", []string{"A", "docs/guide.md"}, decisions(false, false, false, false, false, "docs_only")},
+		{"command", []string{"M", "cmd/bd/create.go"}, decisions(true, true, false, false, false, "cmd_bd")},
+		{"embedded", []string{"M", "internal/storage/embeddeddolt/store.go"}, decisions(true, false, true, true, false, "embedded_storage")},
+		{"server", []string{"M", "internal/storage/dolt/store.go"}, decisions(false, true, false, false, true, "server_storage")},
+		{"shared conformance", []string{"M", "backend/conformance/portable.go"}, decisions(false, false, false, true, true, "shared_conformance")},
+		{"mixed union", []string{"M", "cmd/bd/create.go", "M", "internal/storage/embeddeddolt/store.go"}, decisions(true, true, true, true, false, "mixed")},
+		{"all leaves normalize full", []string{"M", "cmd/bd/create.go", "M", "internal/storage/embeddeddolt/store.go", "M", "internal/storage/dolt/store.go"}, decisions(true, true, true, true, true, "full")},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			got, _ := runCICapabilitySelector(t, tt.records, "pull_request", true, false)
+			assertSelectorOutputs(t, got, tt.want)
+		})
+	}
+}
+
+func TestCICapabilitySelectorFailsClosed(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		event   string
+		records []string
+		bounds  bool
+		gitFail bool
+		reason  string
+	}{
+		{"push", "push", nil, true, false, "push"},
+		{"merge group", "merge_group", nil, true, false, "merge_group"},
+		{"unsupported event", "schedule", nil, true, false, "unsupported_event"},
+		{"missing bounds", "pull_request", nil, false, false, "missing_bounds"},
+		{"diff failure", "pull_request", nil, true, true, "diff_failed"},
+		{"delete", "pull_request", []string{"D", "docs/guide.md"}, true, false, "unsafe_status"},
+		{"rename", "pull_request", []string{"R100", "docs/old.md", "docs/new.md"}, true, false, "unsafe_status"},
+		{"copy", "pull_request", []string{"C100", "docs/old.md", "docs/new.md"}, true, false, "unsafe_status"},
+		{"type change", "pull_request", []string{"T", "docs/guide.md"}, true, false, "unsafe_status"},
+		{"unmerged", "pull_request", []string{"U", "docs/guide.md"}, true, false, "unsafe_status"},
+		{"unknown status", "pull_request", []string{"X", "docs/guide.md"}, true, false, "unsafe_status"},
+		{"broken pair", "pull_request", []string{"B", "docs/guide.md"}, true, false, "unsafe_status"},
+		{"malformed", "pull_request", []string{"A"}, true, false, "malformed_record"},
+		{"absolute", "pull_request", []string{"A", "/tmp/unsafe"}, true, false, "unsafe_path"},
+		{"traversal", "pull_request", []string{"A", "docs/../unsafe.md"}, true, false, "unsafe_path"},
+		{"workflow", "pull_request", []string{"M", ".github/workflows/pr-risk.yml"}, true, false, "unsafe_control"},
+		{"selector", "pull_request", []string{"M", ".github/scripts/ci-capability-selector.sh"}, true, false, "unsafe_control"},
+		{"build input", "pull_request", []string{"M", "go.mod"}, true, false, "build_input"},
+		{"cross cutting storage", "pull_request", []string{"M", "internal/storage/schema/migrations/1.sql"}, true, false, "cross_cutting_storage"},
+		{"unowned", "pull_request", []string{"M", "internal/other/change.go"}, true, false, "unowned_path"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			got, _ := runCICapabilitySelector(t, tt.records, tt.event, tt.bounds, tt.gitFail)
+			assertSelectorOutputs(t, got, decisions(true, true, true, true, true, tt.reason))
+		})
+	}
+}
+
+func TestCICapabilitySelectorNeverInjectsFilenamesIntoOutputs(t *testing.T) {
+	got, raw := runCICapabilitySelector(t, []string{"A", "docs/new\nname\t%=.md"}, "pull_request", true, false)
+	assertSelectorOutputs(t, got, decisions(false, false, false, false, false, "docs_only"))
+	if strings.Contains(raw, "new\nname") || strings.Contains(raw, "\t%=") {
+		t.Fatalf("filename leaked into selector output: %q", raw)
+	}
+
+	got, raw = runCICapabilitySelector(t, []string{"A", "unowned/new\nname\t%=.txt"}, "pull_request", true, false)
+	assertSelectorOutputs(t, got, decisions(true, true, true, true, true, "unowned_path"))
+	if strings.Contains(raw, "new\nname") || strings.Contains(raw, "\t%=") {
+		t.Fatalf("untrusted filename leaked into selector output: %q", raw)
+	}
+}
+
+func TestCICapabilitySelectorWorkflowPreservesExistingAuthority(t *testing.T) {
+	data, err := os.ReadFile(filepath.Join(sourceRepoRoot(t), ".github", "workflows", "pr-risk.yml"))
+	if err != nil {
+		t.Fatalf("read workflow: %v", err)
+	}
+	var workflow capabilitySelectorWorkflow
+	if err := yaml.Unmarshal(data, &workflow); err != nil {
+		t.Fatalf("parse workflow: %v", err)
+	}
+	wantJobs := map[string]bool{"detect-ci-tier": true, "build-embedded": true, "test-embedded-storage": true, "test-embedded-conformance": true, "test-server-storage": true, "test-embedded-cmd": true, "test-proxied-cmd": true, "test-nix": true, "ci-gate": true}
+	if len(workflow.Jobs) != len(wantJobs) {
+		t.Errorf("job count = %d, want %d", len(workflow.Jobs), len(wantJobs))
+	}
+	for name := range workflow.Jobs {
+		if !wantJobs[name] {
+			t.Errorf("unexpected job %q", name)
+		}
+	}
+	for name := range wantJobs {
+		if _, ok := workflow.Jobs[name]; !ok {
+			t.Errorf("missing job %q", name)
+		}
+	}
+	detector := workflow.Jobs["detect-ci-tier"]
+	if detector.Outputs["full_embedded"] != "${{ steps.tier.outputs.full_embedded }}" {
+		t.Errorf("full_embedded output = %q", detector.Outputs["full_embedded"])
+	}
+	tier, shadow := detector.step(t, "Decide embedded Dolt coverage"), detector.step(t, "Shadow CI capability selector")
+	if tier.ID != "tier" || shadow.ID != "shadow-selector" || !shadow.ContinueOnError || detector.stepIndex(t, shadow.Name) != detector.stepIndex(t, tier.Name)+1 {
+		t.Errorf("shadow step is not immediately after tier: tier=%+v shadow=%+v", tier, shadow)
+	}
+	for _, name := range []string{"build-embedded", "test-embedded-storage", "test-embedded-conformance", "test-server-storage", "test-embedded-cmd", "test-proxied-cmd"} {
+		if got := workflow.Jobs[name].If; got != "needs.detect-ci-tier.outputs.full_embedded == 'true'" {
+			t.Errorf("%s if = %q", name, got)
+		}
+	}
+	if workflow.Jobs["test-nix"].If != "" {
+		t.Errorf("test-nix if = %q, want ungated", workflow.Jobs["test-nix"].If)
+	}
+	gate := workflow.Jobs["ci-gate"]
+	wantNeeds := []string{"detect-ci-tier", "build-embedded", "test-embedded-storage", "test-embedded-conformance", "test-server-storage", "test-embedded-cmd", "test-proxied-cmd", "test-nix"}
+	gateStep := gate.step(t, "Evaluate CI gate")
+	if gate.If != "${{ always() }}" || strings.Join(gate.Needs, ",") != strings.Join(wantNeeds, ",") || gateStep.Env["FULL_EMBEDDED"] != "${{ needs.detect-ci-tier.outputs.full_embedded }}" || gateStep.Env["CI_GATE_REQUIRED"] != "DETECT_CI_TIER BUILD_EMBEDDED TEST_EMBEDDED_STORAGE TEST_EMBEDDED_CONFORMANCE TEST_SERVER_STORAGE TEST_EMBEDDED_CMD TEST_PROXIED_CMD TEST_NIX" || !strings.Contains(gateStep.Run, "skipped_ok=\"BUILD_EMBEDDED TEST_EMBEDDED_STORAGE TEST_EMBEDDED_CONFORMANCE TEST_SERVER_STORAGE TEST_EMBEDDED_CMD TEST_PROXIED_CMD\"") {
+		t.Errorf("ci-gate authority changed: needs=%v env=%v", gate.Needs, gateStep.Env)
+	}
+	for name, job := range workflow.Jobs {
+		if strings.Contains(job.If, "shadow_") {
+			t.Errorf("job %q shadow condition = %q", name, job.If)
+		}
+		for _, step := range job.Steps {
+			if strings.Contains(step.If, "shadow_") {
+				t.Errorf("step %q shadow condition = %q", step.Name, step.If)
+			}
+			for key, value := range step.Env {
+				if strings.Contains(value, "shadow_") {
+					t.Errorf("step %q env %s consumes shadow output", step.Name, key)
+				}
+			}
+		}
+	}
+}
+
+type capabilitySelectorWorkflow struct {
+	Jobs map[string]capabilitySelectorJob `yaml:"jobs"`
+}
+
+type capabilitySelectorJob struct {
+	Needs   ciWorkflowStringList             `yaml:"needs"`
+	If      string                           `yaml:"if"`
+	Outputs map[string]string                `yaml:"outputs"`
+	Steps   []capabilitySelectorWorkflowStep `yaml:"steps"`
+}
+
+type capabilitySelectorWorkflowStep struct {
+	Name            string            `yaml:"name"`
+	ID              string            `yaml:"id"`
+	If              string            `yaml:"if"`
+	ContinueOnError bool              `yaml:"continue-on-error"`
+	Run             string            `yaml:"run"`
+	Env             map[string]string `yaml:"env"`
+}
+
+func (job capabilitySelectorJob) step(t *testing.T, name string) capabilitySelectorWorkflowStep {
+	t.Helper()
+	for _, step := range job.Steps {
+		if step.Name == name {
+			return step
+		}
+	}
+	t.Fatalf("job has no %q step", name)
+	return capabilitySelectorWorkflowStep{}
+}
+
+func (job capabilitySelectorJob) stepIndex(t *testing.T, name string) int {
+	t.Helper()
+	for index, step := range job.Steps {
+		if step.Name == name {
+			return index
+		}
+	}
+	t.Fatalf("job has no %q step", name)
+	return -1
+}
+
+func decisions(embeddedCLI, proxiedCLI, embeddedStorage, embeddedConformance, serverConformance bool, reason string) map[string]string {
+	full := embeddedCLI && proxiedCLI && embeddedStorage && embeddedConformance && serverConformance
+	return map[string]string{
+		"embedded_cli":         boolString(embeddedCLI),
+		"proxied_cli":          boolString(proxiedCLI),
+		"embedded_storage":     boolString(embeddedStorage),
+		"embedded_conformance": boolString(embeddedConformance),
+		"server_conformance":   boolString(serverConformance),
+		"full":                 boolString(full),
+		"reason":               reason,
+	}
+}
+
+func boolString(value bool) string {
+	if value {
+		return "true"
+	}
+	return "false"
+}
+
+func runCICapabilitySelector(t *testing.T, records []string, event string, bounds, gitFail bool) (map[string]string, string) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("selector is a Bash boundary")
+	}
+	dir := t.TempDir()
+	fixture := filepath.Join(dir, "diff")
+	if err := os.WriteFile(fixture, append([]byte(strings.Join(records, "\x00")), 0), 0600); err != nil {
+		t.Fatalf("write NUL fixture: %v", err)
+	}
+	fakeGit := filepath.Join(dir, "git")
+	if err := os.WriteFile(fakeGit, []byte("#!/bin/sh\n[ \"${FAKE_GIT_FAIL:-}\" = 1 ] && exit 1\ncat \"$FAKE_GIT_FIXTURE\"\n"), 0700); err != nil {
+		t.Fatalf("write fake git: %v", err)
+	}
+	output := filepath.Join(dir, "github-output")
+	cmd := exec.Command("bash", filepath.Join("..", ".github", "scripts", "ci-capability-selector.sh"))
+	cmd.Env = append(os.Environ(), "PATH="+dir+string(os.PathListSeparator)+os.Getenv("PATH"), "GITHUB_EVENT_NAME="+event, "FAKE_GIT_FIXTURE="+fixture, "GITHUB_OUTPUT="+output)
+	if bounds {
+		cmd.Env = append(cmd.Env, "PR_BASE_SHA=base", "PR_HEAD_SHA=head")
+	}
+	if gitFail {
+		cmd.Env = append(cmd.Env, "FAKE_GIT_FAIL=1")
+	}
+	raw, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("selector failed: %v", err)
+	}
+	outputBytes, err := os.ReadFile(output)
+	if err != nil {
+		t.Fatalf("read GITHUB_OUTPUT: %v", err)
+	}
+	if string(raw) != string(outputBytes) {
+		t.Fatalf("stdout and GITHUB_OUTPUT differ:\nstdout=%q\noutput=%q", raw, outputBytes)
+	}
+	return parseSelectorOutputs(t, string(raw)), string(raw)
+}
+
+func parseSelectorOutputs(t *testing.T, raw string) map[string]string {
+	t.Helper()
+	lines := strings.Split(strings.TrimSuffix(raw, "\n"), "\n")
+	if len(lines) != len(selectorKeys) {
+		t.Fatalf("selector output has %d lines, want %d: %q", len(lines), len(selectorKeys), raw)
+	}
+	got := make(map[string]string, len(lines))
+	for index, line := range lines {
+		key, value, ok := strings.Cut(line, "=")
+		if !ok || key != selectorKeys[index] {
+			t.Fatalf("selector output line %d = %q, want %q=...", index, line, selectorKeys[index])
+		}
+		got[key] = value
+	}
+	return got
+}
+
+func assertSelectorOutputs(t *testing.T, got, want map[string]string) {
+	t.Helper()
+	for _, key := range selectorKeys {
+		if got[key] != want[key] {
+			t.Errorf("%s = %q, want %q", key, got[key], want[key])
+		}
+	}
+}


### PR DESCRIPTION
## What

Add a fail-closed capability classifier for the five expensive PR Risk test
families and publish its decision in shadow mode.

The classifier reports candidate ownership for:

- embedded CLI
- proxied CLI
- embedded storage
- embedded conformance
- server conformance

It parses NUL-delimited `git diff --name-status` output, accumulates capability
ownership across the whole diff, and selects full coverage for unknown paths,
renames, deletes, malformed records, missing diff bounds, CI-control changes,
and other ambiguous inputs.

## Why

Recent queue-free PR Risk runs take about 24 minutes, and runner contention has
pushed observed wall time near an hour. Most command-only changes do not need
both complete storage-conformance families, but we need evidence that path
ownership is sound before any lane can be skipped.

This is the first slice of `bd-8yjq8`: establish a deterministic selector and
collect shadow decisions. It intentionally provides no immediate CI speedup.

## Safety

This PR does not change test admission.

- The existing `full_embedded` detector remains the sole authority for all six
  existing build/test jobs.
- The aggregate gate still uses `needs.detect-ci-tier.outputs.full_embedded`
  and retains `if: ${{ always() }}` plus its existing skip policy.
- The shadow step is `continue-on-error`; a selector defect cannot skip or fail
  existing coverage.
- Structural tests pin the current job set, job conditions, aggregate inputs,
  step ordering, and fail-closed reason contract.

The selector remains observational until historical replay is complete and
required checks/reviews are enforced for `main`.

## Verification

- `./scripts/test.sh -v -run '^TestCICapabilitySelector' ./scripts`
- `make ci-pr-policy`
- `make test`
- `golangci-lint run --allow-parallel-runners --build-tags=gms_pure_go ./scripts/...`
- `shellcheck .github/scripts/ci-capability-selector.sh`
- `actionlint .github/workflows/pr-risk.yml`
- `git diff --check`

Two independent Sol reviews approved the final frozen diff after three major
test-ratchet findings were fixed.

Bead: `bd-8yjq8.1`

_codex-unknown-model-unknown-reasoning on behalf of CI Bot_
