### PR TITLE
perf(doltserver): snapshot Unix Dolt processes once

### DIFF
--- a/internal/doltserver/doltserver_unix.go
+++ b/internal/doltserver/doltserver_unix.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"syscall"
 	"time"
+	"unicode"
 )
 
 // portConflictHint is the platform-specific command to diagnose port conflicts.
@@ -44,49 +45,59 @@ func findPIDOnPort(port int) int {
 // listDoltProcessPIDs returns PIDs of all running dolt sql-server processes.
 // Excludes zombies and defunct processes. Callers derive count (len) and
 // membership (linear scan) from the returned slice.
-//
-// The pgrep pattern uses `dolt.*sql-server` rather than the literal
-// `dolt sql-server` so it still matches when top-level dolt flags appear
-// between the binary name and the subcommand — e.g. debug mode launches
-// the server as `dolt --prof cpu --prof-path /…/dolt-pprof sql-server …`,
-// in which `dolt sql-server` no longer appears as a contiguous substring.
-// Without this, IsRunning's isDoltProcess check would reject the PID as
-// "not a dolt process" and wipe the PID/port files of a healthy server,
-// breaking `bd dolt status` and auto-start reattachment. The per-PID
-// substring check below still requires both "dolt" and "sql-server" in
-// the cmdline, so this only widens the first-stage filter; it does not
-// loosen identity validation.
 func listDoltProcessPIDs() []int {
-	out, err := exec.Command("pgrep", "-f", "dolt.*sql-server").Output()
+	out, err := exec.Command("ps", "-axo", "pid=,state=,command=").Output()
 	if err != nil {
 		return nil
 	}
+	return parseDoltProcessPIDs(out)
+}
+
+// parseDoltProcessPIDs returns matching, non-defunct Dolt server PIDs from a
+// `ps -axo pid=,state=,command=` snapshot. It preserves the source row order.
+func parseDoltProcessPIDs(snapshot []byte) []int {
 	var pids []int
-	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
-		pid, err := strconv.Atoi(strings.TrimSpace(line))
+	for _, line := range strings.Split(string(snapshot), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+
+		pidText, rest, ok := splitPSField(line)
+		if !ok {
+			continue
+		}
+		state, command, ok := splitPSField(rest)
+		if !ok {
+			continue
+		}
+
+		pid, err := strconv.Atoi(pidText)
 		if err != nil || pid <= 0 {
 			continue
 		}
-		// Exclude zombies: ps -o state= returns Z for zombie, X for dead
-		stateOut, err := exec.Command("ps", "-p", strconv.Itoa(pid), "-o", "state=").Output()
-		if err != nil {
+		if state[0] == 'Z' || state[0] == 'X' {
 			continue
 		}
-		state := strings.TrimSpace(string(stateOut))
-		if len(state) > 0 && (state[0] == 'Z' || state[0] == 'X') {
-			continue
-		}
-		// Verify command line contains both "dolt" and "sql-server"
-		cmdOut, err := exec.Command("ps", "-p", strconv.Itoa(pid), "-o", "command=").Output()
-		if err != nil {
-			continue
-		}
-		cmdline := strings.TrimSpace(string(cmdOut))
-		if strings.Contains(cmdline, "dolt") && strings.Contains(cmdline, "sql-server") {
+
+		doltIndex := strings.Index(command, "dolt")
+		if doltIndex >= 0 && strings.Contains(command[doltIndex+len("dolt"):], "sql-server") {
 			pids = append(pids, pid)
 		}
 	}
 	return pids
+}
+
+// splitPSField separates the next whitespace-delimited ps field from the
+// remaining text, retaining whitespace within the final command column.
+func splitPSField(line string) (field, rest string, ok bool) {
+	fieldEnd := strings.IndexFunc(line, unicode.IsSpace)
+	if fieldEnd == -1 {
+		return "", "", false
+	}
+	field = line[:fieldEnd]
+	rest = strings.TrimLeftFunc(line[fieldEnd:], unicode.IsSpace)
+	return field, rest, rest != ""
 }
 
 // isProcessInDir checks if a process's working directory matches the given path.

--- a/internal/doltserver/doltserver_unix_test.go
+++ b/internal/doltserver/doltserver_unix_test.go
@@ -1,0 +1,73 @@
+//go:build !windows
+
+package doltserver
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseDoltProcessPIDs(t *testing.T) {
+	tests := []struct {
+		name     string
+		snapshot string
+		want     []int
+	}{
+		{
+			name:     "ordinary command",
+			snapshot: "  101 S /usr/local/bin/dolt sql-server --port 3306\n",
+			want:     []int{101},
+		},
+		{
+			name:     "profiled command",
+			snapshot: "102 Sl dolt --prof cpu --prof-path /tmp/dolt-pprof sql-server\n",
+			want:     []int{102},
+		},
+		{
+			name:     "ordered loose false positive",
+			snapshot: "103 S some-tool says dolt then sql-server\n",
+			want:     []int{103},
+		},
+		{
+			name:     "sql server before dolt is rejected",
+			snapshot: "104 S sql-server then dolt\n",
+		},
+		{
+			name:     "case sensitive command matching",
+			snapshot: "105 S Dolt sql-server\n106 S dolt SQL-SERVER\n",
+		},
+		{
+			name:     "zombie and dead states including modifiers are rejected",
+			snapshot: "107 Z dolt sql-server\n108 Z+ dolt sql-server\n109 X dolt sql-server\n110 X< dolt sql-server\n",
+		},
+		{
+			name:     "valid state prefix with modifier is accepted",
+			snapshot: "111 S+ dolt sql-server\n",
+			want:     []int{111},
+		},
+		{
+			name: "malformed and invalid rows are rejected",
+			snapshot: "\n" +
+				"not-a-pid S dolt sql-server\n" +
+				"0 S dolt sql-server\n" +
+				"-1 S dolt sql-server\n" +
+				"112\n" +
+				"113 S\n" +
+				"114\tdolt sql-server\n" +
+				"115 S \n",
+		},
+		{
+			name:     "preserves source order",
+			snapshot: "202 S dolt sql-server\n201 S dolt sql-server\n203 R dolt sql-server\n",
+			want:     []int{202, 201, 203},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := parseDoltProcessPIDs([]byte(tt.snapshot)); !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("parseDoltProcessPIDs() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

Replace Unix Dolt process discovery's `pgrep` plus two `ps` calls per candidate with one `ps -axo pid=,state=,command=` snapshot. Add a pure parser contract for the existing positive-PID, live-state, ordered case-sensitive `dolt … sql-server` membership semantics.

## Why

On a dense shared executor, 57 matching processes turned one discovery into 115 subprocesses. Five affected tests spent 292.2 seconds enumerating processes even though their own assertions were small.

The one-snapshot adapter removes that N+1 cost and the race between separate PID, state, and command probes without weakening the historical match contract. On the same host, those five tests now take 5.446 seconds, a 286.8-second reduction.

Tracks `bd-1rh.15`.

## Verification

- TDD red: the parser contract initially failed to compile because `parseDoltProcessPIDs` did not exist.
- Focused five-test workload: 292.2s before → 5.446s after.
- `./scripts/test.sh ./internal/doltserver` — pass, 11.712s.
- `go vet ./internal/doltserver` — pass.
- `golangci-lint run ./...` — pass, zero issues.
- Darwin amd64 and arm64 compile-only checks — pass.
- Cache-cleared `make test` — pass, 325.86s wall; `cmd/bd` remains the critical path at 275.702s.
- Two independent read-only review passes found no blocker or major issue in behavior preservation, portability, or test scope.

## Scope

- Unix adapter only; Windows behavior is unchanged.
- Matching intentionally retains the prior loose ordered substring behavior.
- This does not overlap the files or MySQL probe behavior in contributor PR #5277.
