### PR TITLE
perf(label): count list-all labels from hydrated SearchIssues result

### DIFF
--- a/cmd/bd/label.go
+++ b/cmd/bd/label.go
@@ -242,6 +242,29 @@ var labelListCmd = &cobra.Command{
 		return nil
 	},
 }
+
+// labelListAllSearcher is the whole storage surface `bd label list-all`
+// needs. SearchIssues already hydrates Issue.Labels in bulk; omitting
+// GetLabels here keeps the per-issue lookup — one extra connection and
+// transaction per issue in embedded mode — unreachable (GH#5325).
+type labelListAllSearcher interface {
+	SearchIssues(ctx context.Context, query string, filter types.IssueFilter) ([]*types.Issue, error)
+}
+
+func countLabelsAcrossIssues(ctx context.Context, s labelListAllSearcher) (map[string]int, error) {
+	issues, err := s.SearchIssues(ctx, "", types.IssueFilter{})
+	if err != nil {
+		return nil, err
+	}
+	labelCounts := make(map[string]int)
+	for _, issue := range issues {
+		for _, label := range issue.Labels {
+			labelCounts[label]++
+		}
+	}
+	return labelCounts, nil
+}
+
 var labelListAllCmd = &cobra.Command{
 	Use:           "list-all",
 	Short:         "List all unique labels in the database",
@@ -259,22 +282,9 @@ var labelListAllCmd = &cobra.Command{
 			return runLabelListAllProxiedServer(rootCtx)
 		}
 
-		ctx := rootCtx
-		var issues []*types.Issue
-		var err error
-		issues, err = store.SearchIssues(ctx, "", types.IssueFilter{})
+		labelCounts, err := countLabelsAcrossIssues(rootCtx, store)
 		if err != nil {
 			return HandleErrorRespectJSON("%v", err)
-		}
-		labelCounts := make(map[string]int)
-		for _, issue := range issues {
-			labels, err := store.GetLabels(ctx, issue.ID)
-			if err != nil {
-				return HandleErrorRespectJSON("getting labels for %s: %v", issue.ID, err)
-			}
-			for _, label := range labels {
-				labelCounts[label]++
-			}
 		}
 		type labelInfo struct {
 			Label string `json:"label"`

--- a/cmd/bd/label_list_all_test.go
+++ b/cmd/bd/label_list_all_test.go
@@ -1,0 +1,131 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// searchOnlyStore records the SearchIssues calls countLabelsAcrossIssues
+// makes and returns issues whose Labels are already hydrated, the way
+// issueops.SearchIssuesInTx hydrates them for a real store.
+type searchOnlyStore struct {
+	issues []*types.Issue
+	err    error
+
+	calls   int
+	filters []types.IssueFilter
+	queries []string
+}
+
+func (s *searchOnlyStore) SearchIssues(_ context.Context, query string, filter types.IssueFilter) ([]*types.Issue, error) {
+	s.calls++
+	s.queries = append(s.queries, query)
+	s.filters = append(s.filters, filter)
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.issues, nil
+}
+
+func TestCountLabelsAcrossIssues(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		issues []*types.Issue
+		want   map[string]int
+	}{
+		{
+			name: "counts every hydrated label once per issue",
+			issues: []*types.Issue{
+				{ID: "be-1", Labels: []string{"backend", "urgent"}},
+				{ID: "be-2", Labels: []string{"backend"}},
+				{ID: "be-3", Labels: []string{"urgent", "docs"}},
+			},
+			want: map[string]int{"backend": 2, "urgent": 2, "docs": 1},
+		},
+		{
+			name:   "issues without labels contribute nothing",
+			issues: []*types.Issue{{ID: "be-1"}, {ID: "be-2", Labels: []string{}}},
+			want:   map[string]int{},
+		},
+		{
+			name:   "no issues",
+			issues: nil,
+			want:   map[string]int{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			store := &searchOnlyStore{issues: tt.issues}
+			got, err := countLabelsAcrossIssues(context.Background(), store)
+			if err != nil {
+				t.Fatalf("countLabelsAcrossIssues: %v", err)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("counts = %v, want %v", got, tt.want)
+			}
+			if store.calls != 1 {
+				t.Errorf("SearchIssues called %d times, want exactly 1", store.calls)
+			}
+		})
+	}
+}
+
+// TestCountLabelsAcrossIssues_SearchFilter locks the search contract the
+// command depends on: an empty query and a zero IssueFilter, which means
+// full-database scope, bulk label hydration (SkipLabels stays false), and
+// the CONTRIBUTING.md MaxRows opt-out (this is not a --max-rows-wired
+// command, so the cap must never abort it).
+func TestCountLabelsAcrossIssues_SearchFilter(t *testing.T) {
+	t.Parallel()
+
+	store := &searchOnlyStore{issues: []*types.Issue{{ID: "be-1", Labels: []string{"x"}}}}
+	if _, err := countLabelsAcrossIssues(context.Background(), store); err != nil {
+		t.Fatalf("countLabelsAcrossIssues: %v", err)
+	}
+	if len(store.filters) != 1 {
+		t.Fatalf("SearchIssues called %d times, want exactly 1", len(store.filters))
+	}
+	if store.queries[0] != "" {
+		t.Errorf("query = %q, want empty (whole database)", store.queries[0])
+	}
+	if got := store.filters[0]; !reflect.DeepEqual(got, types.IssueFilter{}) {
+		t.Errorf("filter = %+v, want the zero IssueFilter", got)
+	}
+}
+
+func TestCountLabelsAcrossIssues_SearchError(t *testing.T) {
+	t.Parallel()
+
+	want := errors.New("boom")
+	store := &searchOnlyStore{err: want}
+	if _, err := countLabelsAcrossIssues(context.Background(), store); !errors.Is(err, want) {
+		t.Fatalf("err = %v, want %v", err, want)
+	}
+}
+
+// TestLabelListAllSearcherExposesNoPerIssueLookup is the regression gate for
+// GH#5325. bd label list-all used to call store.GetLabels once per issue on
+// top of a SearchIssues result that already carried hydrated labels; in
+// embedded Dolt mode that is a fresh connector plus transaction per issue.
+// Keeping the command's storage surface to SearchIssues alone makes that
+// N+1 unreachable at compile time — widening this interface would silently
+// re-open it, so the method set is asserted directly.
+func TestLabelListAllSearcherExposesNoPerIssueLookup(t *testing.T) {
+	t.Parallel()
+
+	iface := reflect.TypeOf((*labelListAllSearcher)(nil)).Elem()
+	for i := 0; i < iface.NumMethod(); i++ {
+		if name := iface.Method(i).Name; name != "SearchIssues" {
+			t.Errorf("labelListAllSearcher exposes %q; bd label list-all must read labels only from the bulk-hydrated SearchIssues result (GH#5325)", name)
+		}
+	}
+}

--- a/internal/storage/embeddeddolt/label_list_all_benchmark_test.go
+++ b/internal/storage/embeddeddolt/label_list_all_benchmark_test.go
@@ -1,0 +1,121 @@
+//go:build cgo
+
+package embeddeddolt_test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/storage/embeddeddolt"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// BenchmarkLabelListAllLabelCounting measures the two ways `bd label list-all`
+// can total every label in the database against a real embedded Dolt store.
+//
+//   - bulk_hydrated is what the command does now: one SearchIssues call, then
+//     count from the Issue.Labels that issueops.SearchIssuesInTx already
+//     hydrated in bulk.
+//   - per_issue_getlabels is what it did before GH#5325: the same SearchIssues
+//     call, then Store.GetLabels once per issue. In embedded mode each of
+//     those opens a short-lived connector, starts a transaction, runs a wisp
+//     probe plus the label SELECT, and closes.
+//
+// Workload: BEADS_BENCH_ISSUES issues (default 200), each carrying two labels
+// drawn from a small shared vocabulary, so both arms return identical counts.
+// Set BEADS_TEST_EMBEDDED_DOLT=1 to run.
+func BenchmarkLabelListAllLabelCounting(b *testing.B) {
+	if os.Getenv("BEADS_TEST_EMBEDDED_DOLT") != "1" {
+		b.Skip("set BEADS_TEST_EMBEDDED_DOLT=1 to run embedded dolt benchmarks")
+	}
+
+	issueCount := 200
+	if raw := os.Getenv("BEADS_BENCH_ISSUES"); raw != "" {
+		parsed, err := strconv.Atoi(raw)
+		if err != nil || parsed <= 0 {
+			b.Fatalf("BEADS_BENCH_ISSUES=%q: want a positive integer", raw)
+		}
+		issueCount = parsed
+	}
+
+	ctx := b.Context()
+	beadsDir := filepath.Join(b.TempDir(), ".beads")
+	store, err := embeddeddolt.Open(ctx, beadsDir, "bench", "main")
+	if err != nil {
+		b.Fatalf("open embedded Dolt store: %v", err)
+	}
+	b.Cleanup(func() {
+		if err := store.Close(); err != nil {
+			b.Errorf("close embedded Dolt store: %v", err)
+		}
+	})
+	if err := store.SetConfig(ctx, "issue_prefix", "bench"); err != nil {
+		b.Fatalf("set issue_prefix: %v", err)
+	}
+
+	for i := range issueCount {
+		issue := &types.Issue{
+			ID:        fmt.Sprintf("bench-%04d", i),
+			Title:     fmt.Sprintf("Bench issue %d", i),
+			Status:    types.StatusOpen,
+			Priority:  2,
+			IssueType: types.TypeTask,
+		}
+		if err := store.CreateIssue(ctx, issue, "bench"); err != nil {
+			b.Fatalf("CreateIssue %s: %v", issue.ID, err)
+		}
+		for _, label := range []string{fmt.Sprintf("area-%d", i%7), fmt.Sprintf("tier-%d", i%3)} {
+			if err := store.AddLabel(ctx, issue.ID, label, "bench"); err != nil {
+				b.Fatalf("AddLabel %s/%s: %v", issue.ID, label, err)
+			}
+		}
+	}
+	if err := store.Commit(ctx, "bench seed"); err != nil {
+		b.Fatalf("commit seed: %v", err)
+	}
+
+	wantLabels := min(issueCount, 7) + min(issueCount, 3)
+
+	b.Run("bulk_hydrated", func(b *testing.B) {
+		for b.Loop() {
+			issues, err := store.SearchIssues(ctx, "", types.IssueFilter{})
+			if err != nil {
+				b.Fatalf("SearchIssues: %v", err)
+			}
+			counts := make(map[string]int)
+			for _, issue := range issues {
+				for _, label := range issue.Labels {
+					counts[label]++
+				}
+			}
+			if len(counts) != wantLabels {
+				b.Fatalf("unique labels = %d, want %d", len(counts), wantLabels)
+			}
+		}
+	})
+
+	b.Run("per_issue_getlabels", func(b *testing.B) {
+		for b.Loop() {
+			issues, err := store.SearchIssues(ctx, "", types.IssueFilter{})
+			if err != nil {
+				b.Fatalf("SearchIssues: %v", err)
+			}
+			counts := make(map[string]int)
+			for _, issue := range issues {
+				labels, err := store.GetLabels(ctx, issue.ID)
+				if err != nil {
+					b.Fatalf("GetLabels %s: %v", issue.ID, err)
+				}
+				for _, label := range labels {
+					counts[label]++
+				}
+			}
+			if len(counts) != wantLabels {
+				b.Fatalf("unique labels = %d, want %d", len(counts), wantLabels)
+			}
+		}
+	})
+}


### PR DESCRIPTION
## What

`bd label list-all` now totals labels from the `Issue.Labels` that
`SearchIssues` already hydrated, instead of calling `store.GetLabels` once per
issue on top of that result.

Application layer only: one file of production code (`cmd/bd/label.go`), no
storage interface change, no behavior change. Same unique labels, same counts,
same sort order, same JSON shape.

## Why

Fixes #5325.

`issueops.SearchIssuesInTx` hydrates labels for the whole result set via
`hydrateIssueLabelsAndDeps` → `GetLabelsForIssuesFromTableInTx` unless
`filter.SkipLabels` is set. `label list-all` passed the zero `IssueFilter`, so
every issue it got back already carried its labels — and then it discarded them
and re-read each issue's labels individually.

In embedded Dolt mode each `store.GetLabels` enters `withConn`, opens a
short-lived `OpenSQL` connector, starts a transaction, runs a wisp-routing
probe plus the label `SELECT`, and closes. That is 2N extra round trips for
data already in memory.

On a live 455-issue embedded database this made `bd label list-all --json` take
33.75s against 10.17s for `bd list --all --limit 0 --json`, which walks the same
rows and hydrates the same labels; one run was still going at 104.31s when it
was killed with `context canceled while getting labels for mr-qji`, the error
string from exactly this loop. `OpenSQL` showed 10.95s cumulative in the CPU
profile of a command that should open the database once. Full data in #5325.

This is the same defect #1583 / merged PR #1586 removed from the RPC
`handleList` path, in a command that sweep missed. The proxied-server path
(`runLabelListAllProxiedServer`) was already doing the bulk thing.

## Changes

- `cmd/bd/label.go` — extract `countLabelsAcrossIssues`, counting from
  `issue.Labels`; drop the per-issue `GetLabels` loop. The helper takes a
  `labelListAllSearcher` interface that exposes only `SearchIssues`, so the
  N+1 is not reachable from this command without widening the interface.
- `cmd/bd/label_list_all_test.go` (new) — counting behavior, the search
  contract (empty query, zero `IssueFilter`, which keeps `SkipLabels` false
  and preserves the `MaxRows` opt-out required by CONTRIBUTING.md for
  commands not wired to `--max-rows`), error propagation, and a gate
  asserting `labelListAllSearcher` exposes nothing but `SearchIssues`.
- `internal/storage/embeddeddolt/label_list_all_benchmark_test.go` (new) —
  benchmark comparing the two label-counting strategies against a real
  embedded Dolt store. Test-only; no production code outside `cmd/bd`.

## Benchmark

`BenchmarkLabelListAllLabelCounting` seeds an embedded Dolt store with
`BEADS_BENCH_ISSUES` issues (default 200), two labels each, then times both
strategies over the same store. `bulk_hydrated` is this PR; `per_issue_getlabels`
is the code being removed.

```
BEADS_TEST_EMBEDDED_DOLT=1 ./scripts/test.sh -run '^$' \
  -bench BenchmarkLabelListAllLabelCounting -benchtime 5x -timeout 40m \
  ./internal/storage/embeddeddolt/
```

goos: linux, goarch: amd64, cpu: Intel(R) Xeon(R) CPU E5-2690 v4 @ 2.60GHz

| Issues | before (`per_issue_getlabels`) | after (`bulk_hydrated`) | speedup |
|---|---|---|---|
| 200 (default, `-benchtime 5x`) | 5,960,321,599 ns/op | 64,347,066 ns/op | 92.6x |
| 20 (`BEADS_BENCH_ISSUES=20`, `-benchtime 3x`) | 478,715,030 ns/op | 27,281,546 ns/op | 17.5x |

Both arms assert the same unique-label count, so the fast arm is not winning by
doing less work. The gap scales with issue count, as expected for an N+1.

## Verification

Output equivalence, disposable workspace, `make build` binary, 10 issues with
overlapping labels: `bd label list-all --json` and `bd label list-all` match the
label totals derived from `bd list --all --limit 0 --json` exactly (5 unique
labels, identical counts).

Red/green on the regression gate:

- Re-adding `GetLabels` to `labelListAllSearcher` **and** the per-issue loop
  fails the package build (`*searchOnlyStore does not implement
  labelListAllSearcher`).
- Widening the interface alone fails
  `TestLabelListAllSearcherExposesNoPerIssueLookup` at runtime:
  `labelListAllSearcher exposes "GetLabels"`.

Commands run:

```
./scripts/test.sh -run 'TestCountLabelsAcrossIssues|TestLabelListAllSearcher' ./cmd/bd/...   # ok
./scripts/test.sh ./cmd/bd/...                                                               # ok, 330s (all 5 packages)
make ci-pr-lint                                                                              # gofmt + golangci-lint (linux + windows): 0 issues
make test                                                                                    # one pre-existing unrelated failure, see below
```

`make test` reports exactly one failure,
`TestForceStopUnverifiedPairedLegacyRecords` in
`internal/storage/dbproxy/proxy`. It is not related to this change (that
package does not touch `cmd/bd`), it is not in `.test-skip`, and it reproduces
deterministically on `main` at 67f812a23 in a clean detached worktree. Filed as
#5327 rather than skipped. Every other package is green.

`make test` skips Dolt by default, so the benchmark and the embedded-store
timings above were run explicitly with `BEADS_TEST_EMBEDDED_DOLT=1`.

---

_claude-code-claude-opus-5-unknown-reasoning on behalf of mwotton_
