### PR TITLE
test: share Prime binary fixtures

### DIFF
--- a/cmd/bd/prime_gemini_hook_test.go
+++ b/cmd/bd/prime_gemini_hook_test.go
@@ -86,41 +86,93 @@ func parseEnvelope(t *testing.T, raw []byte) primeEnvelope {
 	return env
 }
 
-// TestPrime_HookJSON_DefaultPath: with --hook-json and no PRIME.md
-// override, output is the JSON envelope wrapping the generated workflow
-// context.
-func TestPrime_HookJSON_DefaultPath(t *testing.T) {
+func writePrimeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write PRIME.md: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+			t.Errorf("remove PRIME.md: %v", err)
+		}
+	})
+}
+
+// TestPrimeBinaryPortfolio runs the binary-level Prime scenarios sequentially
+// against shared workspaces. The scenarios retain their individual names as
+// subtests because each remains an independently observable CLI contract.
+func TestPrimeBinaryPortfolio(t *testing.T) {
 	binPath := buildBDUnderTest(t)
-	workDir := t.TempDir()
-	initBeadsWorkspace(t, binPath, workDir)
+	localWorkDir := t.TempDir()
+	initBeadsWorkspace(t, binPath, localWorkDir)
+	redirectedRoot := t.TempDir()
+	initBeadsWorkspace(t, binPath, redirectedRoot)
+	redirectedBeads := filepath.Join(redirectedRoot, ".beads")
+	noWorkspaceWorkDir := t.TempDir()
 
-	stdout, _ := runPrimeBinary(t, binPath, workDir, "--hook-json")
-	env := parseEnvelope(t, stdout)
+	t.Run("TestPrime_HookJSON_DefaultPath", func(t *testing.T) {
+		stdout, _ := runPrimeBinary(t, binPath, localWorkDir, "--hook-json")
+		env := parseEnvelope(t, stdout)
 
-	if env.HookSpecificOutput.AdditionalContext == "" {
-		t.Fatal("expected non-empty additionalContext for default path")
-	}
-	// Sanity-check that the generated content actually flowed through.
-	// The CLI/MCP variants both lead with one of these phrases.
-	ctx := env.HookSpecificOutput.AdditionalContext
-	if !strings.Contains(ctx, "Beads") {
-		t.Errorf("additionalContext should contain generated bd prime markdown, got: %q", firstN(ctx, 200))
-	}
+		if env.HookSpecificOutput.AdditionalContext == "" {
+			t.Fatal("expected non-empty additionalContext for default path")
+		}
+		// Sanity-check that the generated content actually flowed through.
+		// The CLI/MCP variants both lead with one of these phrases.
+		ctx := env.HookSpecificOutput.AdditionalContext
+		if !strings.Contains(ctx, "Beads") {
+			t.Errorf("additionalContext should contain generated bd prime markdown, got: %q", firstN(ctx, 200))
+		}
+	})
+
+	t.Run("TestPrime_HookJSON_LocalPrimeOverride", func(t *testing.T) {
+		primeScenarioHookJSONLocalPrimeOverride(t, binPath, localWorkDir)
+	})
+	t.Run("TestPrime_HookJSON_NotJSON_WithoutFlag", func(t *testing.T) {
+		primeScenarioHookJSONNotJSONWithoutFlag(t, binPath, localWorkDir)
+	})
+	t.Run("TestPrime_HookJSON_StealthCompose", func(t *testing.T) {
+		primeScenarioHookJSONStealthCompose(t, binPath, localWorkDir)
+	})
+	t.Run("TestPrime_HookJSON_GlobalPrimeOverride", func(t *testing.T) {
+		primeScenarioHookJSONGlobalPrimeOverride(t, binPath, localWorkDir)
+	})
+	t.Run("TestPrime_HookJSON_RedirectedPrimeOverride", func(t *testing.T) {
+		primeScenarioHookJSONRedirectedPrimeOverride(t, binPath, noWorkspaceWorkDir, redirectedBeads)
+	})
+	t.Run("TestPrime_HookJSON_NoBeadsWorkspace", func(t *testing.T) {
+		primeScenarioHookJSONNoBeadsWorkspace(t, binPath, noWorkspaceWorkDir)
+	})
+	t.Run("TestPrime_NoTelemetryInIsolatedHome", func(t *testing.T) {
+		primeScenarioNoTelemetryInIsolatedHome(t, binPath, localWorkDir)
+	})
+
+	rememberInWorkspace(t, binPath, localWorkDir, "prime-mem-key", "remember this insight")
+
+	t.Run("TestPrime_CustomPrimeMd_AppendsMemories", func(t *testing.T) {
+		primeScenarioCustomPrimeMdAppendsMemories(t, binPath, localWorkDir)
+	})
+	t.Run("TestPrime_MemoriesOnly_WithCustomPrimeMd", func(t *testing.T) {
+		primeScenarioMemoriesOnlyWithCustomPrimeMd(t, binPath, localWorkDir)
+	})
+	t.Run("TestPrime_NoMemories_DefaultPath", func(t *testing.T) {
+		primeScenarioNoMemoriesDefaultPath(t, binPath, localWorkDir)
+	})
+	t.Run("TestPrime_NoMemories_CustomPrimeMd", func(t *testing.T) {
+		primeScenarioNoMemoriesCustomPrimeMd(t, binPath, localWorkDir)
+	})
+	t.Run("TestPrime_NoMemories_MemoriesOnlyWins", func(t *testing.T) {
+		primeScenarioNoMemoriesMemoriesOnlyWins(t, binPath, localWorkDir)
+	})
 }
 
 // TestPrime_HookJSON_LocalPrimeOverride: with --hook-json and a
 // .beads/PRIME.md file present, output is the JSON envelope with that file's
 // contents in additionalContext (verbatim).
-func TestPrime_HookJSON_LocalPrimeOverride(t *testing.T) {
-	binPath := buildBDUnderTest(t)
-	workDir := t.TempDir()
-	initBeadsWorkspace(t, binPath, workDir)
-
+func primeScenarioHookJSONLocalPrimeOverride(t *testing.T, binPath, workDir string) {
 	const custom = "# Custom local PRIME.md override\nBe excellent.\n"
 	primePath := filepath.Join(workDir, ".beads", "PRIME.md")
-	if err := os.WriteFile(primePath, []byte(custom), 0o644); err != nil {
-		t.Fatalf("write PRIME.md: %v", err)
-	}
+	writePrimeFile(t, primePath, custom)
 
 	stdout, _ := runPrimeBinary(t, binPath, workDir, "--hook-json")
 	env := parseEnvelope(t, stdout)
@@ -134,11 +186,7 @@ func TestPrime_HookJSON_LocalPrimeOverride(t *testing.T) {
 // --hook-json, prime output is raw markdown — NOT a JSON envelope.
 // This is the binary-level companion to the in-process unit test in
 // prime_test.go and protects the existing Claude/CLI contract.
-func TestPrime_HookJSON_NotJSON_WithoutFlag(t *testing.T) {
-	binPath := buildBDUnderTest(t)
-	workDir := t.TempDir()
-	initBeadsWorkspace(t, binPath, workDir)
-
+func primeScenarioHookJSONNotJSONWithoutFlag(t *testing.T, binPath, workDir string) {
 	stdout, _ := runPrimeBinary(t, binPath, workDir)
 	out := strings.TrimSpace(string(stdout))
 	if strings.HasPrefix(out, "{") {
@@ -153,11 +201,7 @@ func TestPrime_HookJSON_NotJSON_WithoutFlag(t *testing.T) {
 // TestPrime_HookJSON_StealthCompose: --hook-json composed with --stealth
 // emits the JSON envelope, and additionalContext is in stealth mode (no raw
 // `git push` instructions in the close protocol).
-func TestPrime_HookJSON_StealthCompose(t *testing.T) {
-	binPath := buildBDUnderTest(t)
-	workDir := t.TempDir()
-	initBeadsWorkspace(t, binPath, workDir)
-
+func primeScenarioHookJSONStealthCompose(t *testing.T, binPath, workDir string) {
 	stdout, _ := runPrimeBinary(t, binPath, workDir, "--hook-json", "--stealth")
 	env := parseEnvelope(t, stdout)
 
@@ -181,11 +225,7 @@ func TestPrime_HookJSON_StealthCompose(t *testing.T) {
 // ~/.config/beads/PRIME.md file present (XDG path), output is the JSON
 // envelope wrapping that file's contents. This exercises the third
 // custom-PRIME.md path through the wrapper.
-func TestPrime_HookJSON_GlobalPrimeOverride(t *testing.T) {
-	binPath := buildBDUnderTest(t)
-	workDir := t.TempDir()
-	initBeadsWorkspace(t, binPath, workDir)
-
+func primeScenarioHookJSONGlobalPrimeOverride(t *testing.T, binPath, workDir string) {
 	const custom = "# Global PRIME override\nGreetings from XDG.\n"
 
 	// resolveGlobalPrimePath uses os.UserConfigDir, which on Linux honors
@@ -199,17 +239,13 @@ func TestPrime_HookJSON_GlobalPrimeOverride(t *testing.T) {
 	if err := os.MkdirAll(xdgBeadsDir, 0o755); err != nil {
 		t.Fatalf("mkdir xdg beads dir: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(xdgBeadsDir, "PRIME.md"), []byte(custom), 0o644); err != nil {
-		t.Fatalf("write xdg PRIME.md: %v", err)
-	}
+	writePrimeFile(t, filepath.Join(xdgBeadsDir, "PRIME.md"), custom)
 	// Cross-platform staging for macOS UserConfigDir.
 	macConfigDir := filepath.Join(home, "Library", "Application Support", "beads")
 	if err := os.MkdirAll(macConfigDir, 0o755); err != nil {
 		t.Fatalf("mkdir mac config dir: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(macConfigDir, "PRIME.md"), []byte(custom), 0o644); err != nil {
-		t.Fatalf("write mac PRIME.md: %v", err)
-	}
+	writePrimeFile(t, filepath.Join(macConfigDir, "PRIME.md"), custom)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
@@ -242,24 +278,9 @@ func TestPrime_HookJSON_GlobalPrimeOverride(t *testing.T) {
 // envelope wrapping that file's contents. This exercises the redirected
 // path independently from the local path so DoD #2 ("ALL FOUR output paths
 // wrap correctly") is fully covered end-to-end.
-func TestPrime_HookJSON_RedirectedPrimeOverride(t *testing.T) {
-	binPath := buildBDUnderTest(t)
-
-	// CWD has no .beads/ at all — the local override can't fire.
-	workDir := t.TempDir()
-
-	// Stage the relocated beads dir at a sibling path. We can't `bd init`
-	// straight into it (init resolves to ./.beads), so we init in a separate
-	// dir and copy the .beads/ into our target. That gives FindBeadsDir
-	// what it needs to validate the dir.
-	relocatedRoot := t.TempDir()
-	initBeadsWorkspace(t, binPath, relocatedRoot)
-	relocatedBeads := filepath.Join(relocatedRoot, ".beads")
-
+func primeScenarioHookJSONRedirectedPrimeOverride(t *testing.T, binPath, workDir, relocatedBeads string) {
 	const custom = "# Redirected PRIME override\nFrom a relocated beadsDir.\n"
-	if err := os.WriteFile(filepath.Join(relocatedBeads, "PRIME.md"), []byte(custom), 0o644); err != nil {
-		t.Fatalf("write redirected PRIME.md: %v", err)
-	}
+	writePrimeFile(t, filepath.Join(relocatedBeads, "PRIME.md"), custom)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
@@ -289,11 +310,9 @@ func TestPrime_HookJSON_RedirectedPrimeOverride(t *testing.T) {
 // TestPrime_HookJSON_NoBeadsWorkspace: when bd prime would otherwise emit
 // nothing (no beads workspace resolved), --hook-json still emits the empty
 // JSON envelope so Gemini's strict stdout-must-be-JSON contract is honored.
-func TestPrime_HookJSON_NoBeadsWorkspace(t *testing.T) {
-	binPath := buildBDUnderTest(t)
-	// Use a freshly created tmpdir with NO beads workspace and HOME isolated
-	// so FindBeadsDir cannot walk up into the test repo.
-	workDir := t.TempDir()
+func primeScenarioHookJSONNoBeadsWorkspace(t *testing.T, binPath, workDir string) {
+	// workDir is a freshly created tmpdir with NO beads workspace, so
+	// FindBeadsDir cannot walk up into the test repo.
 	home := t.TempDir()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
@@ -347,17 +366,10 @@ func rememberInWorkspace(t *testing.T, binPath, workDir, key, content string) {
 // TestPrime_CustomPrimeMd_AppendsMemories: a custom .beads/PRIME.md replaces the
 // default workflow text, but persistent memories must still be appended so
 // `bd remember` keeps working under a custom template (GH#3941).
-func TestPrime_CustomPrimeMd_AppendsMemories(t *testing.T) {
-	binPath := buildBDUnderTest(t)
-	workDir := t.TempDir()
-	initBeadsWorkspace(t, binPath, workDir)
-	rememberInWorkspace(t, binPath, workDir, "prime-mem-key", "remember this insight")
-
+func primeScenarioCustomPrimeMdAppendsMemories(t *testing.T, binPath, workDir string) {
 	const custom = "# Custom local PRIME.md override\nBe excellent.\n"
 	primePath := filepath.Join(workDir, ".beads", "PRIME.md")
-	if err := os.WriteFile(primePath, []byte(custom), 0o644); err != nil {
-		t.Fatalf("write PRIME.md: %v", err)
-	}
+	writePrimeFile(t, primePath, custom)
 
 	stdout, _ := runPrimeBinary(t, binPath, workDir)
 	out := string(stdout)
@@ -377,17 +389,10 @@ func TestPrime_CustomPrimeMd_AppendsMemories(t *testing.T) {
 // memories section even when a custom PRIME.md exists; the PRIME.md content must
 // NOT leak into the output (GH#3941). This is the primary memory-injection path
 // for PreCompact hooks, which a custom PRIME.md previously broke.
-func TestPrime_MemoriesOnly_WithCustomPrimeMd(t *testing.T) {
-	binPath := buildBDUnderTest(t)
-	workDir := t.TempDir()
-	initBeadsWorkspace(t, binPath, workDir)
-	rememberInWorkspace(t, binPath, workDir, "prime-mem-key", "remember this insight")
-
+func primeScenarioMemoriesOnlyWithCustomPrimeMd(t *testing.T, binPath, workDir string) {
 	const custom = "# Custom local PRIME.md override\nBe excellent.\n"
 	primePath := filepath.Join(workDir, ".beads", "PRIME.md")
-	if err := os.WriteFile(primePath, []byte(custom), 0o644); err != nil {
-		t.Fatalf("write PRIME.md: %v", err)
-	}
+	writePrimeFile(t, primePath, custom)
 
 	stdout, _ := runPrimeBinary(t, binPath, workDir, "--memories-only")
 	out := string(stdout)
@@ -403,12 +408,7 @@ func TestPrime_MemoriesOnly_WithCustomPrimeMd(t *testing.T) {
 // TestPrime_NoMemories_DefaultPath: --no-memories omits the persistent memories
 // section from the default (generated) prime output. A control run without the
 // flag confirms the memory is otherwise present, so the assertion has signal.
-func TestPrime_NoMemories_DefaultPath(t *testing.T) {
-	binPath := buildBDUnderTest(t)
-	workDir := t.TempDir()
-	initBeadsWorkspace(t, binPath, workDir)
-	rememberInWorkspace(t, binPath, workDir, "prime-mem-key", "remember this insight")
-
+func primeScenarioNoMemoriesDefaultPath(t *testing.T, binPath, workDir string) {
 	// Control: without --no-memories, the memory is injected.
 	ctrl, _ := runPrimeBinary(t, binPath, workDir, "--full")
 	if !strings.Contains(string(ctrl), "remember this insight") {
@@ -432,16 +432,9 @@ func TestPrime_NoMemories_DefaultPath(t *testing.T) {
 
 // TestPrime_NoMemories_CustomPrimeMd: --no-memories suppresses the memories that
 // GH#3941 appends under a custom PRIME.md; the custom content itself is unaffected.
-func TestPrime_NoMemories_CustomPrimeMd(t *testing.T) {
-	binPath := buildBDUnderTest(t)
-	workDir := t.TempDir()
-	initBeadsWorkspace(t, binPath, workDir)
-	rememberInWorkspace(t, binPath, workDir, "prime-mem-key", "remember this insight")
-
+func primeScenarioNoMemoriesCustomPrimeMd(t *testing.T, binPath, workDir string) {
 	const custom = "# Custom local PRIME.md override\nBe excellent.\n"
-	if err := os.WriteFile(filepath.Join(workDir, ".beads", "PRIME.md"), []byte(custom), 0o644); err != nil {
-		t.Fatalf("write PRIME.md: %v", err)
-	}
+	writePrimeFile(t, filepath.Join(workDir, ".beads", "PRIME.md"), custom)
 
 	stdout, _ := runPrimeBinary(t, binPath, workDir, "--no-memories")
 	out := string(stdout)
@@ -455,12 +448,7 @@ func TestPrime_NoMemories_CustomPrimeMd(t *testing.T) {
 
 // TestPrime_NoMemories_MemoriesOnlyWins: when both --memories-only and
 // --no-memories are set, --memories-only wins and memories are still returned.
-func TestPrime_NoMemories_MemoriesOnlyWins(t *testing.T) {
-	binPath := buildBDUnderTest(t)
-	workDir := t.TempDir()
-	initBeadsWorkspace(t, binPath, workDir)
-	rememberInWorkspace(t, binPath, workDir, "prime-mem-key", "remember this insight")
-
+func primeScenarioNoMemoriesMemoriesOnlyWins(t *testing.T, binPath, workDir string) {
 	stdout, _ := runPrimeBinary(t, binPath, workDir, "--memories-only", "--no-memories")
 	out := string(stdout)
 	if !strings.Contains(out, "remember this insight") {
@@ -484,11 +472,7 @@ func TestPrime_NoMemories_MemoriesOnlyWins(t *testing.T) {
 // metrics.Init creates the eventsData dir eagerly (and synchronously, in the
 // parent) whenever metrics are enabled, so its absence proves the flusher was
 // never armed.
-func TestPrime_NoTelemetryInIsolatedHome(t *testing.T) {
-	binPath := buildBDUnderTest(t)
-	workDir := t.TempDir()
-	initBeadsWorkspace(t, binPath, workDir)
-
+func primeScenarioNoTelemetryInIsolatedHome(t *testing.T, binPath, workDir string) {
 	home := t.TempDir()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)


### PR DESCRIPTION
## What

Consolidate the 13 binary-level Prime scenarios into one sequential portfolio.
The portfolio still runs every real `bd prime` subprocess and assertion, but it
reuses one local workspace, one redirected workspace, and one remembered row.

## Why

The scenarios spent most of their time repeating `bd init` and `bd remember`,
not exercising Prime. The 13 scenarios consumed 52.30 seconds of serial
`cmd/bd` package time even though their Prime work takes about 10 seconds.

This is a test-only fixture refactor. It does not change Prime behavior,
production code, timeouts, skips, or parallelism.

## Coverage preserved

- All 13 original test names remain as independently reported subtests.
- Default JSON, local/global/redirected overrides, raw Markdown, stealth, and
  no-workspace behavior still cross the real binary boundary.
- Telemetry still runs with an isolated HOME against an empty workspace.
- All five memory scenarios run after one real `bd remember` operation.
- Each temporary `PRIME.md` is removed at subtest cleanup.

## Measurements

| Workload | Before | After | Savings |
|---|---:|---:|---:|
| Prime scenario family | 52.30s | 10.91s | 41.39s |
| Cache-cleared `make test` | 325.86s | 290.79s | 35.07s |

The full local baseline is now **4m50.79s**, clearing the five-minute target by
9.21 seconds with total coverage unchanged at 40.2%.

## Verification

- Focused portfolio: pass; all 13 named subtests ran.
- `./scripts/test.sh -skip '^TestInitMetricsEmittedPerDoltMode$' ./cmd/bd`: pass.
  The excluded file is owned by open contributor PR #4828; normal PR CI still
  runs the repository-required matrix.
- Cache-cleared `make test`: pass in 290.79s.
- `go vet ./cmd/bd`: pass.
- `golangci-lint run ./cmd/bd`: pass with zero issues.
- Active pre-commit hook: pass using the tracked Go 1.26.5 workaround for
  `bd-1rh.12`; lint was not bypassed.
- `git diff --check`: pass.

Two independent Sol blocker/major reviews found one ordering issue: the
telemetry scenario initially followed the memory mutation. It was moved back
to the empty-workspace phase, the focused suite was rerun, and both reviewers
approved the corrected diff.

## Scope

- Changes only `cmd/bd/prime_gemini_hook_test.go`.
- Refreshed contributor preflight found no overlapping open PR.
- Does not touch the Prime files owned by #5139 or #4806.

Tracks `bd-1rh.16`.
