### PR TITLE
Let httpapi.Config take the issue roles as a database source

### DIFF
--- a/cmd/bd/serve.go
+++ b/cmd/bd/serve.go
@@ -180,11 +180,20 @@ func runServe() error {
 
 // serveModeGate refuses the one workspace mode bd serve cannot answer for.
 //
-// Embedded is permanent, and the message is written to promise nothing: there
-// is no unit-of-work provider for that backend, and there will not be one. Its
+// Embedded is permanent, and the message is written to promise nothing: its
 // commit protocol runs outside the SQL transaction on a separate connection, so
-// the per-request atomicity this server's contract states would be a lie there
-// even if a provider were written.
+// the per-request atomicity this server's contract states would be a lie there.
+// That is a property of the backend rather than of what has been built so far,
+// which is also why no unit-of-work provider for it exists or will.
+//
+// THIS IS THE ENFORCEMENT POINT, and it is now the only one. It used to be
+// redundant: httpapi.Listen took a unit-of-work provider or nothing, so deleting
+// this gate would still have left an embedded-backed server unbuildable.
+// httpapi.Config now also accepts the two issue roles as a database source and
+// the embedded store publishes both accessors, so it is buildable — and nothing
+// downstream will catch a bypass here, because internal/httpapi cannot see the
+// backend behind a role. That is also why runServe builds a provider and never
+// hands Listen roles, which TestServeBuildsOnlyAProviderBackedServer pins.
 //
 // Every mode that does have a SQL server behind it is served: proxied (managed
 // or external), and — since bd-emv — server, external-server and shared-server,
@@ -201,9 +210,10 @@ func serveModeGate() error {
 	return nil
 }
 
-// errServeEmbedded is the PERMANENT refusal. There is no unit-of-work provider
-// for the embedded backend and there will not be one: the message says what the
-// workspace is and what serve needs, and promises nothing further.
+// errServeEmbedded is the PERMANENT refusal. The message says what the
+// workspace is and what serve needs, and promises nothing further: the reason
+// is the embedded backend's commit protocol (see serveModeGate), which no
+// amount of provider or role plumbing changes.
 func errServeEmbedded() error {
 	return fmt.Errorf("%w: bd serve requires a Dolt SQL server; this workspace uses embedded Dolt",
 		&storage.ErrUnsupported{Op: "serve", Backend: "embedded-dolt"})

--- a/cmd/bd/serve_test.go
+++ b/cmd/bd/serve_test.go
@@ -2,6 +2,12 @@ package main
 
 import (
 	"errors"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"runtime"
 	"slices"
 	"sort"
 	"strings"
@@ -193,4 +199,97 @@ func useStorageModeGlobals(t *testing.T) {
 		serverMode, proxiedServerMode = oldServerMode, oldProxied
 		cmdCtx, testModeUseGlobals = oldCmdCtx, oldUseGlobals
 	})
+}
+
+// TestServeBuildsOnlyAProviderBackedServer is the source-level half of the
+// embedded refusal, and it exists because the other half stopped being
+// structural.
+//
+// httpapi.Listen once took a unit-of-work provider or nothing, and there is no
+// provider for the embedded backend, so an embedded-backed server could not be
+// built even with serveModeGate deleted. httpapi.Config now also accepts the
+// two issue roles as a database source, and the embedded store publishes both
+// accessors — so the shortest edit from here to a server whose per-request
+// atomicity claim is false is handing Listen the roles off the store the root
+// command already opened. internal/httpapi will not catch it: a role is an
+// interface, and nothing about one says which backend is behind it.
+//
+// So the claim this pins is narrow and checkable: bd names exactly one database
+// source, and it is the provider serveModeGate has already vouched for. An edit
+// that reaches for the roles instead fails here and has to read that gate.
+func TestServeBuildsOnlyAProviderBackedServer(t *testing.T) {
+	dir := packageDir(t)
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read %s: %v", dir, err)
+	}
+
+	fset := token.NewFileSet()
+	configs, provided := 0, 0
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		file, err := parser.ParseFile(fset, filepath.Join(dir, name), nil, 0)
+		if err != nil {
+			t.Fatalf("parse %s: %v", name, err)
+		}
+		ast.Inspect(file, func(n ast.Node) bool {
+			lit, ok := n.(*ast.CompositeLit)
+			if !ok {
+				return true
+			}
+			sel, ok := lit.Type.(*ast.SelectorExpr)
+			if !ok || sel.Sel.Name != "Config" {
+				return true
+			}
+			if pkg, ok := sel.X.(*ast.Ident); !ok || pkg.Name != "httpapi" {
+				return true
+			}
+			configs++
+			for _, elt := range lit.Elts {
+				kv, ok := elt.(*ast.KeyValueExpr)
+				if !ok {
+					continue
+				}
+				key, ok := kv.Key.(*ast.Ident)
+				if !ok {
+					continue
+				}
+				switch key.Name {
+				case "Reader", "Claimer":
+					t.Errorf("%s: bd serve sets httpapi.Config.%s. The roles source bypasses the unit-of-work "+
+						"provider serveModeGate vouched for, and internal/httpapi cannot tell an embedded-backed "+
+						"role from any other — read serveModeGate before changing this",
+						fset.Position(kv.Pos()), key.Name)
+				case "Provider":
+					provided++
+				}
+			}
+			return true
+		})
+	}
+
+	// Both counts, so the test cannot pass because the literal moved, was
+	// renamed, or stopped naming a source at all.
+	if configs == 0 {
+		t.Fatal("no httpapi.Config literal in cmd/bd: this test no longer looks at the code that builds the server")
+	}
+	if provided != configs {
+		t.Errorf("%d of %d httpapi.Config literals set Provider; every server bd builds is provider-backed", provided, configs)
+	}
+}
+
+// packageDir is this test file's own directory, resolved from the compiled-in
+// source path rather than from the working directory: tests in this package
+// chdir into temporary workspaces, and a relative path would read whichever one
+// happened to be current.
+func packageDir(t *testing.T) string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("cannot resolve this test's source path")
+	}
+	return filepath.Dir(file)
 }

--- a/engdocs/SERVE_RUNBOOK.md
+++ b/engdocs/SERVE_RUNBOOK.md
@@ -245,7 +245,7 @@ gives the shape, the `request_error` line gives the cause.
 
 | Message | Cause |
 |---|---|
-| `bd serve requires a Dolt SQL server; this workspace uses embedded Dolt` | Permanent. There is no unit-of-work provider for the embedded backend and there will not be one. |
+| `bd serve requires a Dolt SQL server; this workspace uses embedded Dolt` | Permanent. The embedded backend commits outside the SQL transaction on a separate connection, so this server's per-request atomicity would be a lie there. Refused by `serveModeGate`, which is the only thing refusing it — see "Workspace modes" in the design doc. |
 | `host must be a numeric IP literal, not a name — use 127.0.0.1 rather than localhost` | `--addr` was given a DNS name. |
 | `binds beyond loopback; bd serve has no authentication, so this requires --allow-non-loopback` | A non-loopback `--addr` without the flag. |
 | `address already in use` | The fixed-port mutual exclusion working as intended: a second server is already on that port. |

--- a/engdocs/design/bd-serve-v0.md
+++ b/engdocs/design/bd-serve-v0.md
@@ -298,12 +298,36 @@ methods on the read one.
 
 ## Workspace modes
 
-`bd serve` refuses exactly one workspace mode, permanently: embedded Dolt.
-There is no unit-of-work provider for that backend and there will not be one.
-Its commit protocol runs outside the SQL transaction on a separate connection,
-so the per-request atomicity this contract states would be a lie there even if
-a provider were written. The refusal names the workspace and what serve needs,
-and promises nothing further.
+`bd serve` refuses exactly one workspace mode, permanently: embedded Dolt. Its
+commit protocol runs outside the SQL transaction on a separate connection, so
+the per-request atomicity this contract states would be a lie there. That is a
+property of the backend rather than of what has been built so far, which is what
+makes the refusal permanent — and it is also why there is no unit-of-work
+provider for it and will not be one. The refusal names the workspace and what
+serve needs, and promises nothing further.
+
+**WHERE IT IS ENFORCED**, stated exactly, because it used to be enforced by
+construction and no longer is. `httpapi.Listen` once took a unit-of-work
+provider or nothing at all, so an embedded-backed server was not *constructible*
+— the absence of a provider was itself the refusal. `httpapi.Config` now also
+takes the two issue roles as a database source, and the embedded store publishes
+both accessors, so one is. The gate is `serveModeGate` in `cmd/bd/serve.go`: it
+runs before serve resolves anything else about the workspace, and
+`TestServeRefusalsPromiseNothing` pins both that it refuses and that its message
+promises nothing. `bd serve` also builds provider-backed servers and only those,
+which `TestServeBuildsOnlyAProviderBackedServer` pins against the source of
+`cmd/bd` — so a change that routed serve through store roles fails a test rather
+than quietly reaching the embedded backend by a path this gate never sees.
+
+**NOT ENFORCED.** `internal/httpapi` does not refuse an embedded-backed server
+and cannot. A role is an interface, and no inspection of one reveals the commit
+protocol of the backend behind it; every check available at that layer is a
+self-declaration by the same caller-supplied code being checked, which is the
+trust it would be replacing rather than a replacement for it. The precondition
+is therefore stated on `Config.Reader`/`Config.Claimer` — each call commits on
+its own, atomically and durably — and a caller outside `bd` that hands the
+server embedded-backed roles gets a server whose per-request atomicity claim is
+false, with nothing in this repository to stop it.
 
 Every mode with a SQL server behind it is served: proxied (managed or
 external), and server, external-server and shared-server. In the latter three

--- a/internal/httpapi/roles.go
+++ b/internal/httpapi/roles.go
@@ -1,0 +1,82 @@
+package httpapi
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/steveyegge/beads/issueops"
+)
+
+// The role seam, and the one guarantee this package cannot get by asking for
+// it.
+//
+// Two handlers hold a POINTER that a role returned and dereference it the
+// moment the error is nil: handleGetIssue writes *details, handleClaim writes
+// *result.Issue. Until roles became configuration those dereferences were safe
+// BY CONSTRUCTION — s.reader() could only return uow.NewIssueReader(...),
+// whose Get routes through workapi.GetIssueOrWisp, and that function exists
+// precisely so that no caller can be handed a nil issue with a nil error. A
+// role reached through Config is ordinary caller-supplied code, and the same
+// dereference is a nil pointer panic on a live server.
+//
+// So the fold happens here instead, on EVERY role this server hands a handler,
+// from either database source. Unconditionally, and that is the point: the
+// dereferences above are safe because there is no other way to reach them, not
+// because the provider path is separately known to be well behaved. The
+// provider path pays one wrapper allocation per request for the privilege of
+// making that a single sentence.
+//
+// The vocabulary is the one ClassifyError already documents: the shared read
+// path folds "a nil issue with a nil error" into ErrNotFound, so a reader that
+// answers with nothing answers the documented miss. A claim has no such
+// reading — a claim that reports success has written a row, or it has not
+// succeeded — so it falls to the generic 500, which is where an unrecognized
+// error goes.
+
+// checkedReader is the reader every read handler is handed.
+//
+// Ready and List need nothing from it: both return a VALUE, and wireItems
+// already drops a nil element out of a page. Get is the whole reason the type
+// exists.
+type checkedReader struct{ inner issueops.Reader }
+
+// Ready passes the request through unchanged.
+func (c checkedReader) Ready(ctx context.Context, req issueops.ReadyRequest) (issueops.IssuePage, error) {
+	return c.inner.Ready(ctx, req)
+}
+
+// List passes the request through unchanged.
+func (c checkedReader) List(ctx context.Context, req issueops.ListRequest) (issueops.IssuePage, error) {
+	return c.inner.List(ctx, req)
+}
+
+// Get folds a detail view that is absent without being an error into the miss
+// the document already describes, so the client gets the same 404 an absent
+// issue produces rather than a panic recovered into a generic 500.
+func (c checkedReader) Get(ctx context.Context, req issueops.GetRequest) (*issueops.IssueDetails, error) {
+	details, err := c.inner.Get(ctx, req)
+	if err == nil && details == nil {
+		return nil, fmt.Errorf("get %q: %w", req.ID, issueops.ErrNotFound)
+	}
+	return details, err
+}
+
+// checkedClaimer is the claimer the claim handler is handed.
+type checkedClaimer struct{ inner issueops.Claimer }
+
+// Claim refuses a result that reports success without the row the response
+// body is built from.
+//
+// There is no wire code for it and there must not be one: `already_claimed`
+// says a claim landed earlier and the response still carries the row, and a
+// 404 would tell a client the issue does not exist when nothing here knows
+// that. It is a broken implementation, so it is the generic 500 — with the
+// fault in the log as an error and a request_error line beside it, which is
+// what the panic it replaces did not produce.
+func (c checkedClaimer) Claim(ctx context.Context, req issueops.ClaimRequest) (issueops.ClaimResult, error) {
+	result, err := c.inner.Claim(ctx, req)
+	if err == nil && result.Issue == nil {
+		return issueops.ClaimResult{}, fmt.Errorf("claim %q: the claimer reported success without an issue", req.IssueID)
+	}
+	return result, err
+}

--- a/internal/httpapi/roles_test.go
+++ b/internal/httpapi/roles_test.go
@@ -1,0 +1,446 @@
+package httpapi
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/storage"
+	"github.com/steveyegge/beads/internal/storage/uow"
+	"github.com/steveyegge/beads/internal/types"
+	"github.com/steveyegge/beads/issueops"
+)
+
+// These tests cover the OTHER database source: a backend whose facade is a
+// store rather than a unit-of-work provider, served by handing Listen the two
+// issue roles directly.
+//
+// The fakes below implement issueops.Reader and issueops.Claimer and NOTHING
+// else — deliberately not uow.UnitOfWorkProvider, because "a backend that
+// cannot produce a unit of work is still servable" is the property this whole
+// seam exists for. If either of them ever grows a NewUOW method these tests
+// stop proving it.
+
+type roleReader struct {
+	page    issueops.IssuePage
+	details *issueops.IssueDetails
+	err     error
+
+	mu    sync.Mutex
+	ready []issueops.ReadyRequest
+	list  []issueops.ListRequest
+	get   []issueops.GetRequest
+}
+
+func (r *roleReader) Ready(_ context.Context, req issueops.ReadyRequest) (issueops.IssuePage, error) {
+	r.mu.Lock()
+	r.ready = append(r.ready, req)
+	r.mu.Unlock()
+	if r.err != nil {
+		return issueops.IssuePage{}, r.err
+	}
+	return r.page, nil
+}
+
+func (r *roleReader) List(_ context.Context, req issueops.ListRequest) (issueops.IssuePage, error) {
+	r.mu.Lock()
+	r.list = append(r.list, req)
+	r.mu.Unlock()
+	if r.err != nil {
+		return issueops.IssuePage{}, r.err
+	}
+	return r.page, nil
+}
+
+func (r *roleReader) Get(_ context.Context, req issueops.GetRequest) (*issueops.IssueDetails, error) {
+	r.mu.Lock()
+	r.get = append(r.get, req)
+	r.mu.Unlock()
+	if r.err != nil {
+		return nil, r.err
+	}
+	return r.details, nil
+}
+
+func (r *roleReader) readyRequests() []issueops.ReadyRequest {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]issueops.ReadyRequest(nil), r.ready...)
+}
+
+func (r *roleReader) getRequests() []issueops.GetRequest {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]issueops.GetRequest(nil), r.get...)
+}
+
+type roleClaimer struct {
+	result issueops.ClaimResult
+	err    error
+
+	mu     sync.Mutex
+	claims []issueops.ClaimRequest
+}
+
+func (c *roleClaimer) Claim(_ context.Context, req issueops.ClaimRequest) (issueops.ClaimResult, error) {
+	c.mu.Lock()
+	c.claims = append(c.claims, req)
+	c.mu.Unlock()
+	if c.err != nil {
+		return issueops.ClaimResult{}, c.err
+	}
+	return c.result, nil
+}
+
+func (c *roleClaimer) claimRequests() []issueops.ClaimRequest {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]issueops.ClaimRequest(nil), c.claims...)
+}
+
+// countedPage is the fixture both database sources answer with, so a body
+// difference between them can only come from the construction.
+func countedPage() []*types.IssueWithCounts {
+	return []*types.IssueWithCounts{
+		{Issue: seededIssue("bd-1", "alice", types.StatusOpen), DependencyCount: 1, DependentCount: 2, CommentCount: 3},
+		{Issue: seededIssue("bd-2", "", types.StatusOpen)},
+	}
+}
+
+// TestListenRequiresExactlyOneDatabaseSource pins the precondition that
+// replaced the old nil-provider check.
+//
+// The two refusals are different mistakes and must stay distinguishable. A
+// HALF-SET pair is the dangerous one: a Config carrying a reader and no claimer
+// would bind, answer every read, and fail the one write on this surface with a
+// nil dereference — at claim time, in a handler, on a live server.
+func TestListenRequiresExactlyOneDatabaseSource(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		cfg     Config
+		wantErr string
+	}{
+		{
+			name:    "neither source",
+			cfg:     Config{},
+			wantErr: "no database source",
+		},
+		{
+			name: "a provider alone is a complete source",
+			cfg:  Config{Provider: &fakeProvider{}},
+		},
+		{
+			name: "both roles together are a complete source",
+			cfg:  Config{Reader: &roleReader{}, Claimer: &roleClaimer{}},
+		},
+		{
+			name:    "a reader without a claimer",
+			cfg:     Config{Reader: &roleReader{}},
+			wantErr: "no database source",
+		},
+		{
+			name:    "a claimer without a reader",
+			cfg:     Config{Claimer: &roleClaimer{}},
+			wantErr: "no database source",
+		},
+		{
+			name:    "a provider and a reader",
+			cfg:     Config{Provider: &fakeProvider{}, Reader: &roleReader{}},
+			wantErr: "exactly one database source",
+		},
+		{
+			name:    "a provider and a claimer",
+			cfg:     Config{Provider: &fakeProvider{}, Claimer: &roleClaimer{}},
+			wantErr: "exactly one database source",
+		},
+		{
+			name:    "a provider and both roles",
+			cfg:     Config{Provider: &fakeProvider{}, Reader: &roleReader{}, Claimer: &roleClaimer{}},
+			wantErr: "exactly one database source",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := tc.cfg
+			cfg.Addr = "127.0.0.1:0"
+			cfg.Stdout = io.Discard
+			cfg.Stderr = io.Discard
+
+			srv, err := Listen(cfg)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("Listen: %v, want a bound server", err)
+				}
+				t.Cleanup(func() { _ = srv.http.Close() })
+				return
+			}
+			if err == nil {
+				t.Fatalf("Listen bound a server for %s; want a refusal mentioning %q", tc.name, tc.wantErr)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Errorf("error %q does not mention %q", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+// TestConfiguredRolesServeTheSameReadyBytesAsAProvider is the "construction
+// only" proof: two servers built from the two database sources, over fakes that
+// answer with the same page, produce the same response byte for byte.
+func TestConfiguredRolesServeTheSameReadyBytesAsAProvider(t *testing.T) {
+	items := countedPage()
+
+	viaProvider := newTestServer(t, Config{Provider: &fakeProvider{
+		issues:     &fakeIssues{},
+		readIssues: &recordingIssues{items: items},
+		readConfig: emptyConfig{},
+	}})
+	viaRoles := newTestServer(t, Config{
+		Reader:  &roleReader{page: issueops.IssuePage{Items: items}},
+		Claimer: &roleClaimer{},
+	})
+
+	for _, path := range []string{"/v0/beads/ready", "/v0/beads/issues"} {
+		fromProvider := viaProvider.get(t, path)
+		fromRoles := viaRoles.get(t, path)
+
+		if fromProvider.StatusCode != http.StatusOK || fromRoles.StatusCode != http.StatusOK {
+			t.Fatalf("GET %s: provider status %d, roles status %d, want 200 from both",
+				path, fromProvider.StatusCode, fromRoles.StatusCode)
+		}
+		if got, want := fromRoles.Header.Get("Content-Type"), fromProvider.Header.Get("Content-Type"); got != want {
+			t.Errorf("GET %s: roles Content-Type %q, provider %q", path, got, want)
+		}
+		if got, want := readAll(t, fromRoles), readAll(t, fromProvider); got != want {
+			t.Errorf("GET %s: the two database sources answer differently\nroles:    %s\nprovider: %s", path, got, want)
+		}
+	}
+}
+
+// TestConfiguredRolesAnswerEveryDatabaseRoute drives all four
+// database-touching operations against a store-shaped source, which is the
+// whole point: none of them can reach a unit of work here, because there is no
+// provider to open one.
+func TestConfiguredRolesAnswerEveryDatabaseRoute(t *testing.T) {
+	details := &issueops.IssueDetails{Issue: *seededIssue("bd-1", "alice", types.StatusOpen)}
+	reader := &roleReader{page: issueops.IssuePage{Items: countedPage(), HasMore: true}, details: details}
+	claimer := &roleClaimer{result: issueops.ClaimResult{
+		Issue:   seededIssue("bd-1", "alice", types.StatusInProgress),
+		Changed: true,
+	}}
+	ts := newTestServer(t, Config{Reader: reader, Claimer: claimer})
+
+	t.Run("ready", func(t *testing.T) {
+		resp := ts.get(t, "/v0/beads/ready?sort=oldest")
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("status = %d, want 200: %s", resp.StatusCode, readAll(t, resp))
+		}
+		body := decodeBody(t, resp)
+		if body["has_more"] != true {
+			t.Errorf("has_more = %v, want the value the role reported", body["has_more"])
+		}
+		if got, ok := body["items"].([]any); !ok || len(got) != 2 {
+			t.Errorf("items = %v, want the role's two rows", body["items"])
+		}
+		// The role is handed the request the wire named, not a rewritten one.
+		reqs := reader.readyRequests()
+		if len(reqs) != 1 || reqs[0].Sort != "oldest" {
+			t.Errorf("ready requests = %+v, want one carrying sort=oldest", reqs)
+		}
+	})
+
+	t.Run("list", func(t *testing.T) {
+		resp := ts.get(t, "/v0/beads/issues")
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("status = %d, want 200: %s", resp.StatusCode, readAll(t, resp))
+		}
+		body := decodeBody(t, resp)
+		// has_more and next_cursor are a biconditional on this surface, and the
+		// cursor is minted from the page the role returned.
+		if body["has_more"] != true {
+			t.Errorf("has_more = %v, want true", body["has_more"])
+		}
+		if cursor, _ := body["next_cursor"].(string); cursor == "" {
+			t.Errorf("no next_cursor beside has_more: %v", body)
+		}
+	})
+
+	t.Run("get", func(t *testing.T) {
+		resp := ts.get(t, "/v0/beads/issues/bd-1")
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("status = %d, want 200: %s", resp.StatusCode, readAll(t, resp))
+		}
+		if body := decodeBody(t, resp); body["id"] != "bd-1" {
+			t.Errorf("body = %v, want the detail view the role returned", body)
+		}
+		if reqs := reader.getRequests(); len(reqs) != 1 || reqs[0].ID != "bd-1" {
+			t.Errorf("get requests = %+v, want one for bd-1", reqs)
+		}
+	})
+
+	t.Run("claim", func(t *testing.T) {
+		resp := ts.claim(t, claimPath, `{"actor":"alice"}`)
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("status = %d, want 200: %s", resp.StatusCode, readAll(t, resp))
+		}
+		body := decodeBody(t, resp)
+		if body["already_claimed"] != false {
+			t.Errorf("already_claimed = %v, want false for a claim that changed the row", body["already_claimed"])
+		}
+		issue, _ := body["issue"].(map[string]any)
+		if issue["id"] != "bd-1" || issue["status"] != string(types.StatusInProgress) {
+			t.Errorf("issue = %v, want the row the role reported", body["issue"])
+		}
+		if reqs := claimer.claimRequests(); len(reqs) != 1 || reqs[0] != (issueops.ClaimRequest{IssueID: "bd-1", Actor: "alice"}) {
+			t.Errorf("claim requests = %+v, want one for bd-1 by alice", reqs)
+		}
+	})
+}
+
+// TestConfiguredRolesKeepTheDocumentedRefusals: the error vocabulary belongs to
+// the handlers, so it cannot depend on which database source produced the role.
+// Every case here is the roles-path twin of a provider-path test in this
+// package.
+func TestConfiguredRolesKeepTheDocumentedRefusals(t *testing.T) {
+	t.Run("a missing issue is 404", func(t *testing.T) {
+		ts := newTestServer(t, Config{
+			Reader:  &roleReader{err: fmt.Errorf("get bd-404: %w", storage.ErrNotFound)},
+			Claimer: &roleClaimer{},
+		})
+		resp := ts.get(t, "/v0/beads/issues/bd-404")
+		if resp.StatusCode != http.StatusNotFound {
+			t.Fatalf("status = %d, want 404: %s", resp.StatusCode, readAll(t, resp))
+		}
+		if body := decodeBody(t, resp); body["code"] != string(CodeNotFound) {
+			t.Errorf("code = %v, want %s", body["code"], CodeNotFound)
+		}
+	})
+
+	t.Run("a filter refusal is the documented 400", func(t *testing.T) {
+		// The builders run INSIDE the role on this path, so their refusal
+		// arrives at the handler exactly as it does from a unit-of-work reader —
+		// and must still be mapped to its parameter rather than to a 500.
+		ts := newTestServer(t, Config{
+			Reader:  &roleReader{err: errors.New("invalid status bogus")},
+			Claimer: &roleClaimer{},
+		})
+		resp := ts.get(t, "/v0/beads/issues?status=bogus")
+		if resp.StatusCode != http.StatusBadRequest {
+			t.Fatalf("status = %d, want 400: %s", resp.StatusCode, readAll(t, resp))
+		}
+		body := decodeBody(t, resp)
+		if body["code"] != string(CodeInvalidArgument) || body["param"] != "status" {
+			t.Errorf("body = %v, want invalid_argument on param status", body)
+		}
+	})
+
+	t.Run("a foreign holder is 409 with its state", func(t *testing.T) {
+		ts := newTestServer(t, Config{
+			Reader: &roleReader{},
+			Claimer: &roleClaimer{err: &issueops.ClaimConflictError{
+				IssueID:  "bd-1",
+				Assignee: "bob",
+				Status:   types.StatusInProgress,
+				Err:      fmt.Errorf("claim bd-1: %w", storage.ErrAlreadyClaimed),
+			}},
+		})
+		resp := ts.claim(t, claimPath, `{"actor":"alice"}`)
+		if resp.StatusCode != http.StatusConflict {
+			t.Fatalf("status = %d, want 409: %s", resp.StatusCode, readAll(t, resp))
+		}
+		body := decodeBody(t, resp)
+		if body["code"] != string(CodeAlreadyClaimed) {
+			t.Errorf("code = %v, want %s", body["code"], CodeAlreadyClaimed)
+		}
+		if body["assignee"] != "bob" || body["issue_status"] != string(types.StatusInProgress) {
+			t.Errorf("body = %v, want the holder and status the role reported", body)
+		}
+	})
+
+	t.Run("a role failure is the generic 500", func(t *testing.T) {
+		ts := newTestServer(t, Config{
+			Reader:  &roleReader{err: errors.New("backend is unreachable")},
+			Claimer: &roleClaimer{},
+		})
+		resp := ts.get(t, "/v0/beads/ready")
+		if resp.StatusCode != http.StatusInternalServerError {
+			t.Fatalf("status = %d, want 500: %s", resp.StatusCode, readAll(t, resp))
+		}
+		if body := readAll(t, resp); strings.Contains(body, "backend is unreachable") {
+			t.Errorf("the 5xx body republished the backend's error text: %s", body)
+		}
+	})
+}
+
+// TestStartupNamesTheDatabaseSource: uow_ms is 0.000 for every request a
+// roles-backed server answers, because it opens no units of work. That is the
+// true value, and the startup line is what makes it attributable instead of
+// looking like lost instrumentation.
+func TestStartupNamesTheDatabaseSource(t *testing.T) {
+	t.Run("provider", func(t *testing.T) {
+		ts := newTestServer(t, Config{Provider: &tunableProvider{}})
+		startup := findLogLine(t, ts.stderr.String(), "event=startup")
+		if !strings.Contains(startup, "db=provider") {
+			t.Errorf("startup line does not name the database source:\n%s", startup)
+		}
+		limits := findLogLine(t, ts.stderr.String(), "event=limits")
+		if !strings.Contains(limits, "pool_max_open=") {
+			t.Errorf("limits line omits the pool bounds a provider-backed server applies:\n%s", limits)
+		}
+	})
+
+	t.Run("roles", func(t *testing.T) {
+		ts := newTestServer(t, Config{Reader: &roleReader{}, Claimer: &roleClaimer{}})
+		startup := findLogLine(t, ts.stderr.String(), "event=startup")
+		if !strings.Contains(startup, "db=roles") {
+			t.Errorf("startup line does not name the database source:\n%s", startup)
+		}
+		// The pool belongs to whatever the backend is; this server neither owns
+		// it nor tuned it, so publishing bounds it did not set would be a lie.
+		limits := findLogLine(t, ts.stderr.String(), "event=limits")
+		if strings.Contains(limits, "pool_") {
+			t.Errorf("limits line publishes pool bounds this server never applied:\n%s", limits)
+		}
+		if strings.Contains(ts.stderr.String(), "event=pool_limits_unavailable") {
+			t.Errorf("a roles-backed server announced a missing provider knob:\n%s", ts.stderr.String())
+		}
+	})
+}
+
+// TestARolesRequestReportsNoUnitOfWorkTime states the other half out loud: the
+// number really is zero, and it is zero because nothing on this path opens a
+// unit of work — not because the timing wrapper was dropped.
+func TestARolesRequestReportsNoUnitOfWorkTime(t *testing.T) {
+	ts := newTestServer(t, Config{Reader: &roleReader{}, Claimer: &roleClaimer{}})
+
+	if resp := ts.get(t, "/v0/beads/ready"); resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	line := findLogLine(t, ts.stderr.String(), "op="+OpListReadyWork)
+	if !strings.Contains(line, "uow_ms=0.000") {
+		t.Errorf("a roles-backed request reported unit-of-work time it cannot have spent:\n%s", line)
+	}
+}
+
+// TestWithUOWRefusesWithoutAProvider: the helper's whole job is to open a unit
+// of work, and a roles-backed server has nothing to open one from. An error is
+// the answer; a nil dereference inside a handler is not.
+func TestWithUOWRefusesWithoutAProvider(t *testing.T) {
+	ts := newTestServer(t, Config{Reader: &roleReader{}, Claimer: &roleClaimer{}})
+
+	ran := false
+	err := ts.WithUOW(context.Background(), &reqInfo{}, func(uow.UnitOfWork) error {
+		ran = true
+		return nil
+	})
+	if err == nil {
+		t.Fatal("WithUOW succeeded on a server with no unit-of-work provider")
+	}
+	if ran {
+		t.Error("the callback ran without a unit of work")
+	}
+}

--- a/internal/httpapi/roles_test.go
+++ b/internal/httpapi/roles_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"reflect"
 	"strings"
 	"sync"
 	"testing"
@@ -443,4 +444,145 @@ func TestWithUOWRefusesWithoutAProvider(t *testing.T) {
 	if ran {
 		t.Error("the callback ran without a unit of work")
 	}
+}
+
+// TestARoleThatAnswersWithNothingIsNotDereferenced covers the one guarantee a
+// configured role cannot be asked for: that a call which reports no error
+// carries the value the handler is about to dereference.
+//
+// It used to hold BY CONSTRUCTION. s.reader() could only return
+// uow.NewIssueReader(...), whose Get routes through workapi.GetIssueOrWisp —
+// a function whose whole reason to exist is folding both miss shapes into
+// ErrNotFound so that no caller can write `if err != nil || issue == nil` and
+// report a dropped connection as "not found". A caller-supplied role is
+// ordinary code and carries no such guarantee, and both handlers that hold a
+// pointer from a role dereference it unconditionally.
+func TestARoleThatAnswersWithNothingIsNotDereferenced(t *testing.T) {
+	// The answer is the SAME 404 a real miss produces, byte for byte: the
+	// document states one not-found body, and a client must not be able to
+	// tell a broken role from an absent issue.
+	t.Run("a reader with no detail view is the documented miss", func(t *testing.T) {
+		silent := newTestServer(t, Config{Reader: &roleReader{}, Claimer: &roleClaimer{}})
+		missed := newTestServer(t, Config{
+			Reader:  &roleReader{err: fmt.Errorf("get bd-1: %w", storage.ErrNotFound)},
+			Claimer: &roleClaimer{},
+		})
+
+		got := silent.get(t, "/v0/beads/issues/bd-1")
+		want := missed.get(t, "/v0/beads/issues/bd-1")
+		if got.StatusCode != http.StatusNotFound {
+			t.Fatalf("status = %d, want 404: %s", got.StatusCode, readAll(t, got))
+		}
+		gotBody, wantBody := decodeBody(t, got), decodeBody(t, want)
+		// request_id is per request and is the only member that may differ.
+		delete(gotBody, "request_id")
+		delete(wantBody, "request_id")
+		if !reflect.DeepEqual(gotBody, wantBody) {
+			t.Errorf("body = %v, want the body a real miss produces: %v", gotBody, wantBody)
+		}
+		assertNoPanic(t, silent)
+	})
+
+	// A claim that reports success without a row is not a documented outcome —
+	// there is no wire code for it — so it is the generic 500. What it must not
+	// be is a panic: the response is recovered into the same status, but the
+	// fault reaches the log as a stack trace instead of as an error, and the
+	// panic path writes no request_error line for an operator to alert on.
+	t.Run("a claimer with no issue is the generic failure", func(t *testing.T) {
+		ts := newTestServer(t, Config{
+			Reader:  &roleReader{},
+			Claimer: &roleClaimer{result: issueops.ClaimResult{Changed: true}},
+		})
+
+		resp := ts.claim(t, claimPath, `{"actor":"alice"}`)
+		if resp.StatusCode != http.StatusInternalServerError {
+			t.Fatalf("status = %d, want 500: %s", resp.StatusCode, readAll(t, resp))
+		}
+		if body := decodeBody(t, resp); body["code"] != string(CodeInternal) {
+			t.Errorf("code = %v, want %s", body["code"], CodeInternal)
+		}
+		assertNoPanic(t, ts)
+		if line := findLogLine(t, ts.stderr.String(), "event=request_error"); !strings.Contains(line, "claim") {
+			t.Errorf("the 500 is logged without naming the operation that produced it:\n%s", line)
+		}
+	})
+}
+
+// assertNoPanic fails when the server recovered a panic. Every case in this
+// file is one a handler could reach by trusting a role's return value, so the
+// status alone does not distinguish a refusal from a recovered dereference.
+func assertNoPanic(t *testing.T, ts *testServer) {
+	t.Helper()
+	if log := ts.stderr.String(); strings.Contains(log, "event=panic") {
+		t.Errorf("a handler dereferenced what the role did not return:\n%s", log)
+	}
+}
+
+// hookableStore is the smallest thing storage.NewHookFiringStore will decorate:
+// the DoltStorage surface is embedded nil because IssueClaimer is the only
+// method this test ever reaches through it.
+type hookableStore struct {
+	storage.DoltStorage
+	claimer issueops.Claimer
+}
+
+func (s hookableStore) IssueClaimer() (issueops.Claimer, error) { return s.claimer, nil }
+
+// TestListenRefusesARoleThatFiresTheWorkspaceHooks.
+//
+// `bd serve` documents that hooks do not fire, and until roles became
+// configuration nothing could make them: the provider seam builds its claimer
+// from a unit of work, which carries no hook layer at all. A store is the
+// opposite — its accessors hand out its decorators, deliberately, so that a CLI
+// claim keeps its on_update — and bd's own chain is
+// caller -> HookFiringStore -> InstrumentedStorage -> raw. So the one line a
+// caller with a store would obviously write, store.IssueClaimer(), returns
+// exactly the claimer this server may not serve.
+//
+// The refusal is at Listen because the alternative is silent: a server built
+// that way answers every request correctly and runs a user's subprocess per
+// landed claim for as long as it is up.
+func TestListenRefusesARoleThatFiresTheWorkspaceHooks(t *testing.T) {
+	// A nil runner, which is what a HookFiringStore built without one carries.
+	// The refusal must not depend on that: the type's job is to fire hooks, and
+	// a server that admitted this one would be a config change away from
+	// breaking its own contract.
+	hooked := storage.NewHookFiringStore(hookableStore{claimer: &roleClaimer{}}, nil)
+
+	fromTheStore, err := hooked.IssueClaimer()
+	if err != nil {
+		t.Fatalf("IssueClaimer: %v", err)
+	}
+	if !storage.RoleFiresHooks(fromTheStore) {
+		t.Fatal("the store's own accessor no longer returns a hook-firing claimer; this test proves nothing")
+	}
+
+	listen := func(cl issueops.Claimer) (*Server, error) {
+		return Listen(Config{
+			Addr:    "127.0.0.1:0",
+			Stdout:  io.Discard,
+			Stderr:  io.Discard,
+			Reader:  &roleReader{},
+			Claimer: cl,
+		})
+	}
+
+	if _, err := listen(fromTheStore); err == nil {
+		t.Error("Listen bound a server whose claim route runs the workspace's hook scripts")
+	} else if !strings.Contains(err.Error(), "hooks") {
+		t.Errorf("refusal %q does not say what is wrong with the role", err)
+	}
+
+	// And the store BENEATH the decorator is the value the doc sends a caller
+	// to, so it has to be servable. Without this the guard could be a blanket
+	// refusal of every store-backed claimer and still pass.
+	fromBeneath, err := hooked.Unwrap().IssueClaimer()
+	if err != nil {
+		t.Fatalf("IssueClaimer on the undecorated store: %v", err)
+	}
+	srv, err := listen(fromBeneath)
+	if err != nil {
+		t.Fatalf("Listen: %v, want a bound server for the claimer beneath the hook layer", err)
+	}
+	t.Cleanup(func() { _ = srv.http.Close() })
 }

--- a/internal/httpapi/server.go
+++ b/internal/httpapi/server.go
@@ -119,6 +119,29 @@ type Config struct {
 	// Provider is where every database-touching handler opens its one unit of
 	// work per request.
 	Provider uow.UnitOfWorkProvider
+	// Reader and Claimer are the issue roles this server answers from, for a
+	// backend whose facade is a STORE rather than a unit-of-work provider.
+	//
+	// Set both together, and only when Provider is nil: they are the other
+	// complete database source, not an override of one. Listen refuses every
+	// other combination, including a half-set pair — a reader without a claimer
+	// would bind, answer every read, and fail the one write on this surface with
+	// a nil dereference inside a handler.
+	//
+	// A caller with a store passes what the store's own accessors return:
+	//
+	//	rd, err := store.IssueReader()
+	//	cl, err := store.IssueClaimer()
+	//	httpapi.Listen(httpapi.Config{Reader: rd, Claimer: cl, ...})
+	//
+	// Unlike the provider path these are built ONCE, before Listen, rather than
+	// per request. The provider path rebuilds its roles per request for exactly
+	// one reason — so the units of work they open land in that request's uow_ms
+	// (see Server.reader) — and a role reached this way opens none through this
+	// server, so a rebuild would buy nothing. Every decorator a store carries is
+	// already on the value its accessor returned.
+	Reader  issueops.Reader
+	Claimer issueops.Claimer
 	// Workspace is the startup snapshot GET /v0/beads/context answers from.
 	// Only the allowlisted fields are ever serialized — see contextResponse,
 	// which names the whole set and the reasons for the exclusions.
@@ -141,6 +164,13 @@ type Config struct {
 type Server struct {
 	cfg      Config
 	provider uow.UnitOfWorkProvider
+
+	// issueReader and issueClaimer are the configured roles, set exactly when
+	// provider is nil. They are what reader() and claimer() hand back on the
+	// store-shaped source; the names differ from those methods because a struct
+	// cannot carry both.
+	issueReader  issueops.Reader
+	issueClaimer issueops.Claimer
 
 	listener net.Listener
 	http     *http.Server
@@ -215,8 +245,8 @@ func ValidateBindAddr(addr string, allowNonLoopback bool) (net.IP, error) {
 // exist — N instances simply run on N ports — which is why fixed ports are the
 // deployment recommendation.)
 func Listen(cfg Config) (*Server, error) {
-	if cfg.Provider == nil {
-		return nil, errors.New("httpapi: no unit-of-work provider")
+	if err := checkDatabaseSource(cfg); err != nil {
+		return nil, err
 	}
 	ip, err := ValidateBindAddr(cfg.Addr, cfg.AllowNonLoopback)
 	if err != nil {
@@ -235,8 +265,11 @@ func Listen(cfg Config) (*Server, error) {
 	}
 
 	s := &Server{
-		cfg:        cfg,
-		provider:   cfg.Provider,
+		cfg:          cfg,
+		provider:     cfg.Provider,
+		issueReader:  cfg.Reader,
+		issueClaimer: cfg.Claimer,
+
 		sem:        make(chan struct{}, maxInflight),
 		semTimeout: semAcquireTimeout,
 		semWarn:    saturationWarn,
@@ -268,15 +301,45 @@ func Listen(cfg Config) (*Server, error) {
 	// Bound what a burst of requests can open on the database. The knob is
 	// optional on the interface, so say so out loud when a provider does not
 	// carry it rather than silently running unbounded.
-	if tuner, ok := cfg.Provider.(uow.PoolTuner); ok {
-		tuner.SetPoolLimits(servePoolLimits)
-	} else {
-		s.event("pool_limits_unavailable", "provider", fmt.Sprintf("%T", cfg.Provider))
+	//
+	// Nothing to bound on the roles source: the pool belongs to whatever the
+	// backend is, and this server neither owns it nor can reach it. Saying the
+	// knob is "unavailable" there would report a missing capability for a
+	// provider that was never asked for.
+	if cfg.Provider != nil {
+		if tuner, ok := cfg.Provider.(uow.PoolTuner); ok {
+			tuner.SetPoolLimits(servePoolLimits)
+		} else {
+			s.event("pool_limits_unavailable", "provider", fmt.Sprintf("%T", cfg.Provider))
+		}
 	}
 
 	fmt.Fprintf(s.stdout, "bd serve: listening on http://%s\n", s.Addr())
 	s.logStartup()
 	return s, nil
+}
+
+// checkDatabaseSource enforces exactly one complete database source.
+//
+// There are two, and a Config carries one or the other: a unit-of-work
+// provider, or the two issue roles. A HALF-SET pair is refused with the same
+// message as none at all, because it is the same mistake and the failure it
+// would otherwise produce is the worst shape available — a reader without a
+// claimer binds, answers every read, and fails the one write on this surface
+// with a nil dereference in a handler on a live server.
+//
+// Both together is refused rather than resolved by precedence: a caller that
+// set both holds two different opinions about where this server reads from, and
+// silently honoring one of them leaves the other as configuration that looks
+// live and is not.
+func checkDatabaseSource(cfg Config) error {
+	switch {
+	case cfg.Provider != nil && (cfg.Reader != nil || cfg.Claimer != nil):
+		return errors.New("httpapi: both a unit-of-work provider and issue roles were set; pass exactly one database source")
+	case cfg.Provider == nil && (cfg.Reader == nil || cfg.Claimer == nil):
+		return errors.New("httpapi: no database source: set Provider, or Reader and Claimer together")
+	}
+	return nil
 }
 
 // Addr is the bound address, which is the only way to discover the port under
@@ -347,32 +410,40 @@ func (s *Server) connState(_ net.Conn, state http.ConnState) {
 	}
 }
 
-// reader returns the issue-query surface for one request, obtained from the
-// provider's own capability accessor.
+// reader returns the issue-query surface for one request.
 //
-// It is built per request rather than once at startup so that the units of
-// work it opens are timed into THIS request's log line. That is the only
-// reason: the role itself is stateless, and the accessor is the API on this
-// seam exactly as it is on a store.
+// On the ROLES source it is the configured role, handed back unchanged. There
+// is nothing to build and nothing to wrap: a store's accessor already answered
+// for its whole decorator chain when the caller called it, and this server
+// opens no units of work on that path.
+//
+// On the PROVIDER source it is built per request rather than once at startup so
+// that the units of work it opens are timed into THIS request's log line. That
+// is the only reason: the role itself is stateless, and the accessor is the API
+// on this seam exactly as it is on a store.
 //
 // The source is held by INTERFACE, not by the concrete wrapper. That is what
 // makes uow.IssueReaderSource load-bearing rather than decorative: this call
 // site type-checks against the accessor the provider seam publishes, so
 // renaming or dropping it is a compile error here.
 func (s *Server) reader(r *http.Request) (issueops.Reader, error) {
+	if s.provider == nil {
+		return s.issueReader, nil
+	}
 	var src uow.IssueReaderSource = timedProvider{inner: s.provider, rec: requestInfo(r.Context())}
 	return src.IssueReader()
 }
 
-// claimer returns the guarded atomic-claim surface for one request, obtained
-// from the provider's own capability accessor.
+// claimer returns the guarded atomic-claim surface for one request.
 //
-// It is the write-side twin of reader above, for all the same reasons: built
-// per request so its units of work are timed into THIS request's log line, and
-// held by INTERFACE so uow.IssueClaimerSource is load-bearing rather than
-// decorative. Config keeps holding a provider rather than a role — a claimer
-// on Config could not be bound to the request's own timing wrapper.
+// It is the write-side twin of reader above, for all the same reasons: the
+// configured role on the roles source, and on the provider source one built per
+// request so its units of work are timed into THIS request's log line, held by
+// INTERFACE so uow.IssueClaimerSource is load-bearing rather than decorative.
 func (s *Server) claimer(r *http.Request) (issueops.Claimer, error) {
+	if s.provider == nil {
+		return s.issueClaimer, nil
+	}
 	var src uow.IssueClaimerSource = timedProvider{inner: s.provider, rec: requestInfo(r.Context())}
 	return src.IssueClaimer()
 }
@@ -387,7 +458,14 @@ func (s *Server) claimer(r *http.Request) (issueops.Claimer, error) {
 // closing with the request's own canceled context would fail the ROLLBACK
 // immediately and burn one pinned session on every client disconnect. Reads
 // never commit.
+//
+// It is provider-only, and says so rather than dereferencing nil: a
+// roles-backed server has no unit of work to open, and the roles it does hold
+// own their own transactions.
 func (s *Server) WithUOW(ctx context.Context, rec *reqInfo, fn func(uow.UnitOfWork) error) error {
+	if s.provider == nil {
+		return errors.New("httpapi: this server has no unit-of-work provider; it answers from configured issue roles")
+	}
 	start := time.Now()
 	uw, err := s.provider.NewUOW(ctx)
 	if rec != nil {
@@ -869,22 +947,47 @@ func (s *Server) logStartup() {
 	s.event("startup",
 		"addr", s.Addr(),
 		"mode", s.cfg.Mode,
+		"db", s.dbSource(),
 		"workspace", s.cfg.Workspace.RepoRoot,
 		"beads_dir", s.cfg.Workspace.BeadsDir,
 		"database", s.cfg.Workspace.Database,
 		"host_allowlist", s.hosts.label(),
 		"capabilities", strings.Join(s.ctxBody.Capabilities, ","),
 	)
-	s.event("limits",
+
+	limits := []any{
 		"max_inflight", maxInflight,
 		"max_conns", maxConns,
 		"sem_wait", semAcquireTimeout.String(),
 		"deadline", requestDeadline.String(),
-		"pool_max_open", servePoolLimits.MaxOpenConns,
-		"pool_max_idle", servePoolLimits.MaxIdleConns,
-		"pool_idle_time", servePoolLimits.ConnMaxIdleTime.String(),
-		"pool_lifetime", servePoolLimits.ConnMaxLifetime.String(),
-	)
+	}
+	// The pool bounds are this server's, applied to the provider above. On the
+	// roles source there is no pool here to bound, and printing the numbers
+	// anyway would report limits nothing enforces.
+	if s.provider != nil {
+		limits = append(limits,
+			"pool_max_open", servePoolLimits.MaxOpenConns,
+			"pool_max_idle", servePoolLimits.MaxIdleConns,
+			"pool_idle_time", servePoolLimits.ConnMaxIdleTime.String(),
+			"pool_lifetime", servePoolLimits.ConnMaxLifetime.String(),
+		)
+	}
+	s.event("limits", limits...)
+}
+
+// dbSource names which database source this server was built from, for the
+// startup line.
+//
+// It is there so uow_ms is attributable. That field means "how long this
+// request spent OBTAINING units of work", and a roles-backed server obtains
+// none — so every one of its request lines reads uow_ms=0.000, which is the
+// true value and is indistinguishable, on its own, from instrumentation that
+// broke. This is the line that tells them apart.
+func (s *Server) dbSource() string {
+	if s.provider != nil {
+		return "provider"
+	}
+	return "roles"
 }
 
 // event writes one structured stderr line. Values are quoted when they are not

--- a/internal/httpapi/server.go
+++ b/internal/httpapi/server.go
@@ -24,6 +24,7 @@ import (
 	"golang.org/x/net/netutil"
 
 	"github.com/steveyegge/beads/internal/httpapi/apigen"
+	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/storage/domain"
 	"github.com/steveyegge/beads/internal/storage/uow"
 	"github.com/steveyegge/beads/issueops"
@@ -128,18 +129,40 @@ type Config struct {
 	// would bind, answer every read, and fail the one write on this surface with
 	// a nil dereference inside a handler.
 	//
-	// A caller with a store passes what the store's own accessors return:
+	// A caller with a store takes them off the store's own accessors, and WHICH
+	// store value it takes them off is the whole question. Every decorator a
+	// store wears is on the value its accessor returns — that is what the
+	// accessors are for — and bd's chain is
+	// HookFiringStore -> InstrumentedStorage -> raw, so `store.IssueClaimer()`
+	// there returns a claimer that runs the workspace's on_update hook script
+	// for every claim it lands. That is precisely what this server documents it
+	// does not do (cmd/bd/serve.go). Take the roles from BENEATH the hook layer:
 	//
-	//	rd, err := store.IssueReader()
-	//	cl, err := store.IssueClaimer()
+	//	src := store
+	//	if hooked, ok := src.(*storage.HookFiringStore); ok {
+	//		src = hooked.Unwrap() // keeps the telemetry layer, drops the hooks
+	//	}
+	//	rd, err := src.IssueReader()
+	//	cl, err := src.IssueClaimer()
 	//	httpapi.Listen(httpapi.Config{Reader: rd, Claimer: cl, ...})
+	//
+	// Listen refuses a hook-firing role rather than trusting the paragraph
+	// above — see checkDatabaseSource.
+	//
+	// WHAT LISTEN CANNOT CHECK, and the caller therefore owns: each call must
+	// commit ON ITS OWN, atomically and durably. That is what this server's
+	// contract states per request, and nothing here can observe the commit
+	// protocol of the backend behind an interface — every check available would
+	// be a self-declaration by the same caller-supplied code being checked.
+	// Embedded Dolt is the backend that does not qualify (its commit runs
+	// outside the SQL transaction on a separate connection) and it is refused
+	// where the workspace is actually known: serveModeGate in cmd/bd/serve.go.
 	//
 	// Unlike the provider path these are built ONCE, before Listen, rather than
 	// per request. The provider path rebuilds its roles per request for exactly
 	// one reason — so the units of work they open land in that request's uow_ms
 	// (see Server.reader) — and a role reached this way opens none through this
-	// server, so a rebuild would buy nothing. Every decorator a store carries is
-	// already on the value its accessor returned.
+	// server, so a rebuild would buy nothing.
 	Reader  issueops.Reader
 	Claimer issueops.Claimer
 	// Workspace is the startup snapshot GET /v0/beads/context answers from.
@@ -332,12 +355,26 @@ func Listen(cfg Config) (*Server, error) {
 // set both holds two different opinions about where this server reads from, and
 // silently honoring one of them leaves the other as configuration that looks
 // live and is not.
+//
+// The last refusal is the one a caller does not see coming. A store wears
+// decorators and its accessors hand them out — that is what the accessors are
+// FOR — so the obvious `store.IssueClaimer()` on bd's own storage chain returns
+// a claimer that fires the workspace's on_update hook for every claim it lands.
+// This server's contract says hooks do not fire (cmd/bd/serve.go), and a
+// contract broken by the caller's most natural line is not a contract. Refusing
+// at Listen is the difference between a startup error naming the store to take
+// roles from and a server that has been quietly running a user's subprocess per
+// claim since it booted.
 func checkDatabaseSource(cfg Config) error {
 	switch {
 	case cfg.Provider != nil && (cfg.Reader != nil || cfg.Claimer != nil):
 		return errors.New("httpapi: both a unit-of-work provider and issue roles were set; pass exactly one database source")
 	case cfg.Provider == nil && (cfg.Reader == nil || cfg.Claimer == nil):
 		return errors.New("httpapi: no database source: set Provider, or Reader and Claimer together")
+	case storage.RoleFiresHooks(cfg.Reader) || storage.RoleFiresHooks(cfg.Claimer):
+		return errors.New("httpapi: a configured role fires this workspace's hooks; " +
+			"this server does not run hooks, so take the roles from the store beneath the hook decorator " +
+			"((*storage.HookFiringStore).Unwrap)")
 	}
 	return nil
 }
@@ -412,10 +449,9 @@ func (s *Server) connState(_ net.Conn, state http.ConnState) {
 
 // reader returns the issue-query surface for one request.
 //
-// On the ROLES source it is the configured role, handed back unchanged. There
-// is nothing to build and nothing to wrap: a store's accessor already answered
-// for its whole decorator chain when the caller called it, and this server
-// opens no units of work on that path.
+// On the ROLES source it is the configured role. There is nothing to build: a
+// store's accessor already answered for its whole decorator chain when the
+// caller called it, and this server opens no units of work on that path.
 //
 // On the PROVIDER source it is built per request rather than once at startup so
 // that the units of work it opens are timed into THIS request's log line. That
@@ -426,12 +462,20 @@ func (s *Server) connState(_ net.Conn, state http.ConnState) {
 // makes uow.IssueReaderSource load-bearing rather than decorative: this call
 // site type-checks against the accessor the provider seam publishes, so
 // renaming or dropping it is a compile error here.
+//
+// EITHER WAY it goes out through checkedReader, which is what makes
+// handleGetIssue's dereference of the detail view safe by construction again —
+// see roles.go.
 func (s *Server) reader(r *http.Request) (issueops.Reader, error) {
 	if s.provider == nil {
-		return s.issueReader, nil
+		return checkedReader{inner: s.issueReader}, nil
 	}
 	var src uow.IssueReaderSource = timedProvider{inner: s.provider, rec: requestInfo(r.Context())}
-	return src.IssueReader()
+	rd, err := src.IssueReader()
+	if err != nil {
+		return nil, err
+	}
+	return checkedReader{inner: rd}, nil
 }
 
 // claimer returns the guarded atomic-claim surface for one request.
@@ -439,13 +483,18 @@ func (s *Server) reader(r *http.Request) (issueops.Reader, error) {
 // It is the write-side twin of reader above, for all the same reasons: the
 // configured role on the roles source, and on the provider source one built per
 // request so its units of work are timed into THIS request's log line, held by
-// INTERFACE so uow.IssueClaimerSource is load-bearing rather than decorative.
+// INTERFACE so uow.IssueClaimerSource is load-bearing rather than decorative —
+// and, from either source, wrapped in checkedClaimer.
 func (s *Server) claimer(r *http.Request) (issueops.Claimer, error) {
 	if s.provider == nil {
-		return s.issueClaimer, nil
+		return checkedClaimer{inner: s.issueClaimer}, nil
 	}
 	var src uow.IssueClaimerSource = timedProvider{inner: s.provider, rec: requestInfo(r.Context())}
-	return src.IssueClaimer()
+	cl, err := src.IssueClaimer()
+	if err != nil {
+		return nil, err
+	}
+	return checkedClaimer{inner: cl}, nil
 }
 
 // WithUOW runs fn inside one unit of work and guarantees the rollback.

--- a/internal/httpapi/server_test.go
+++ b/internal/httpapi/server_test.go
@@ -175,7 +175,10 @@ func newTestServer(t *testing.T, cfg Config) *testServer {
 	if cfg.Addr == "" {
 		cfg.Addr = "127.0.0.1:0"
 	}
-	if cfg.Provider == nil {
+	// The default source, for the tests that care about something else. A
+	// config that already names a source — either one — keeps it: defaulting a
+	// provider onto a roles-backed config would serve the wrong one and pass.
+	if cfg.Provider == nil && cfg.Reader == nil && cfg.Claimer == nil {
 		cfg.Provider = &fakeProvider{}
 	}
 	cfg.Stdout = stdout

--- a/internal/storage/hook_decorator.go
+++ b/internal/storage/hook_decorator.go
@@ -60,6 +60,36 @@ type Unwrapper interface {
 // Unwrap returns the underlying store, satisfying Unwrapper.
 func (h *HookFiringStore) Unwrap() DoltStorage { return h.inner }
 
+// RoleFiresHooks reports whether an issue role taken off a store carries this
+// decorator's hook layer — that is, whether a landed write through it runs the
+// workspace's user hook scripts.
+//
+// It is the question a caller cannot answer from the role's own type, and the
+// one a NETWORK server has to answer before it serves anything: `bd serve`
+// documents that hooks do not fire (a user-controlled subprocess per mutation
+// is an unbounded latency multiplier and an orphaned child at shutdown), and
+// the accessors on a decorated store return decorated roles by design —
+// IssueClaimer recurses precisely so a CLI claim keeps its on_update. So the
+// exact value the obvious `store.IssueClaimer()` produces on bd's own storage
+// chain is the one value that server must refuse, and this is what lets it.
+//
+// A decorator built with a nil runner still answers true. Whether hooks fire
+// on this instant's configuration is not the property: the type's contract is
+// to fire them, and a server that admitted it would be one config change away
+// from breaking its own.
+//
+// NOT ENFORCED, because the assertion is on the type: a role this decorator
+// produced and something else then wrapped is invisible here, and so is a
+// future decorator elsewhere that fires hooks of its own. Every case that
+// exists today is in the switch, and a new one belongs there too.
+func RoleFiresHooks(role any) bool {
+	switch role.(type) {
+	case *hookIssueClaimer:
+		return true
+	}
+	return false
+}
+
 // UnwrapStore peels back any chain of Unwrapper decorators and returns
 // the innermost store. Use this before type-asserting to optional
 // interfaces (StoreLocator, BackupStore, Flattener, RawDBAccessor, etc.)


### PR DESCRIPTION
`httpapi.Config.Provider` was the only database field, so the roles the handlers use were always
*constructed from* a unit-of-work provider. A backend whose facade is a store rather than a provider
therefore could not be served at all — there was no field to pass it through. This adds
`Config.Reader` and `Config.Claimer` beside `Provider`.

## Why two bare role fields rather than one "role source" interface

A source interface (`IssueReader() (issueops.Reader, error); IssueClaimer() (...)`) is structurally
satisfied by **both** `storage.Storage` and `*doltSQLProvider`. A caller could pass the uow provider
through the source field, compile clean, and log `uow_ms=0.000` on every request forever — the exact
silent-timing loss that `TestAReadRouteTimesTheUnitsOfWorkItsReaderOpens` and its claim twin exist to
catch. With bare role fields that mistake is a type error.

It also matches the repo's own convention — a new capability gets a new role and its own accessor,
never an appended method — so a future role is a new Config field rather than a breaking change to an
interface backends implement.

## Instrumentation

The provider path is untouched byte-for-byte: when `Provider` is set, roles are still built per
request over `timedProvider`, and both timing tests still run against it. On the roles path there is
nothing to time at this seam — `uow_ms` is defined as time spent *obtaining* units of work, and a
store-backed role opens none — so `0.000` is the true value, not a lost measurement. To keep that
attributable rather than silent, the startup event gains `db=provider|roles`, and the `pool_*` fields
are emitted only in provider mode, where they aren't lies.

## Guardrails — three structural guarantees the export would otherwise have dissolved

A review council found that exporting the roles moved guarantees previously enforced *by construction*
into prose contracts on caller-supplied code. Each was resolved by asking whether the API layer can
actually see the property.

**Visible in the value → made structural.** `handleGetIssue`'s `writeJSON(w, *details)` was previously
unreachable with a nil `details`, because the only possible reader routed through a function documented
to never return `(nil, nil)`. Roles are now wrapped in `checkedReader`/`checkedClaimer` **from both
sources** — deliberately unconditional, so "there is no other way to reach the dereference" is the
reason the deref is safe. `(nil, nil)` folds to the documented 404 instead of a panic. The claim path
had the identical shape and is fixed too.

**Visible in the type → made structural.** The obvious wiring, `store.IssueClaimer()`, returns the
**hook-firing** claimer on bd's own chain (`caller → HookFiringStore → InstrumentedStorage → DoltStore`),
which would silently void `bd serve`'s documented "Hooks do not fire" contract. `Listen` now refuses a
hook-firing role via a new `storage.RoleFiresHooks`, and the doc example names the safe value instead.
The test asserts `Listen` **accepts** the unwrapped claimer, so the guard can't degrade into a blanket
refusal of store-backed roles.

**Visible in neither → docs corrected, enforcement point pinned.** `bd-serve-v0.md` grounded the
*permanence* of the embedded-Dolt refusal in "there is no unit-of-work provider and there will not be
one" — a guarantee that was structural only while `Listen` took a provider or nothing. A role is an
interface; nothing about one reveals the commit protocol behind it. Two candidate API-layer refusals
were prototyped and rejected on evidence: keying on `Workspace.DoltMode` produces false refusals,
because `doltserver.ResolveServerMode` deliberately checks shared-server intent *before* metadata.json
so a stale `dolt_mode=embedded` cannot override active intent; and a capability marker is
self-declaration by the code being checked. So the refusal stays in `serveModeGate`, the docs now say
plainly that `internal/httpapi` does not and cannot refuse it, and `TestServeBuildsOnlyAProviderBackedServer`
is an AST guard proving no `httpapi.Config` literal in `cmd/bd` ever carries the role fields.

Known asymmetry, recorded rather than hidden: an opt-out marker on the embedded claimer would be
partly symmetric with the hook guard. It isn't done here because `internal/storage` cannot import
`embeddeddolt` (cycle) and `internal/httpapi` imports no concrete backend today; a marker would also
catch only the one in-repo backend, unlike the hook wrapper, which is detectable on any chain.

## Verification

    internal/httpapi              202 PASS  0 FAIL   (173 on origin/main)
    issueops + storage/issueops   399 PASS  0 FAIL
    internal/storage/uow          167 PASS  0 FAIL
    go build ./... / go vet ./... / gofmt   clean
    zero diff under internal/httpapi/spec/ and internal/httpapi/apigen/

`cmd/bd` carries 40 pre-existing failures, byte-identical by name on both sides.

Two measurement notes for anyone re-running this: `cmd/bd` emits un-newline-terminated stdout that
glues onto `--- PASS:` lines, so a `^ *--- PASS` anchor undercounts nondeterministically; and
`internal/storage/uow` must be run alone, since it contends with `cmd/bd` for the external dolt server.

Every guard was mutation-checked with mutants that compile, and independently re-verified — including
by building an embedded-backed server through the roles seam to confirm the corrected docs describe
what actually happens.

Agent-Signature: claude-opus-5